### PR TITLE
[bugfix] NameQuery in NBTNS protocol

### DIFF
--- a/network/netbios/nbtns/challenge.go
+++ b/network/netbios/nbtns/challenge.go
@@ -1,6 +1,7 @@
 package nbtns
 
 import (
+	"encoding/binary"
 	"fmt"
 	"net"
 	"time"
@@ -126,14 +127,18 @@ func (c *NameChallenger) DefendName(packet *NBTNSPacket, response *NBTNSPacket) 
 		}
 
 		// Add resource records for all owners
-		for _, owner := range owners {
+		for _, ip := range owners {
+			owner := ADDR_ENTRY{
+				Address: binary.BigEndian.Uint32(ip.To4()),
+				Flags:   0x0000,
+			}
 			rr := NBTNSResourceRecord{
 				Name:     q.Name,
 				Type:     q.Type,
 				Class:    q.Class,
 				TTL:      uint32(24 * time.Hour.Seconds()),
-				RDLength: uint16(len(owner)),
-				RData:    owner,
+				RDLength: uint16(owner.Length()),
+				RData:    owner.Marshal(),
 			}
 			response.Answers = append(response.Answers, rr)
 		}

--- a/network/netbios/nbtns/handlers.go
+++ b/network/netbios/nbtns/handlers.go
@@ -1,6 +1,7 @@
 package nbtns
 
 import (
+	"encoding/binary"
 	"net"
 	"time"
 )
@@ -27,18 +28,23 @@ func (h *PacketHandler) handleNameQuery(request *NBTNSPacket, response *NBTNSPac
 		}
 
 		// Create resource record for each owner
-		for _, owner := range owners {
+		for _, ip := range owners {
+			owner := ADDR_ENTRY{
+				Address: binary.BigEndian.Uint32(ip.To4()),
+				Flags:   0x0000,
+			}
 			rr := NBTNSResourceRecord{
 				Name:     q.Name,
 				Type:     q.Type,
 				Class:    q.Class,
 				TTL:      uint32(24 * time.Hour.Seconds()), // 24 hour TTL
-				RDLength: uint16(len(owner)),
-				RData:    owner,
+				RDLength: uint16(owner.Length()),
+				RData:    owner.Marshal(),
 			}
 			response.Answers = append(response.Answers, rr)
 		}
 
+		response.Header.Flags |= FlagRecursion
 		response.Header.Answers = uint16(len(response.Answers))
 
 		// Set group bit if this is a group name

--- a/network/netbios/nbtns/name.go
+++ b/network/netbios/nbtns/name.go
@@ -2,6 +2,7 @@ package nbtns
 
 import (
 	"bytes"
+	"encoding/binary"
 	"fmt"
 	"net"
 	"strings"
@@ -40,6 +41,12 @@ type NameRecord struct {
 type NetBIOSName struct {
 	Name    string
 	ScopeID string
+}
+
+// POSITIVE NAME QUERY RESPONSE
+type ADDR_ENTRY struct {
+	Flags   uint16
+	Address uint32
 }
 
 // Constants for name encoding
@@ -165,4 +172,17 @@ func isValidDomainName(name string) bool {
 	}
 
 	return true
+}
+
+// Marshals ADDR_ENTRY to buffer
+func (n *ADDR_ENTRY) Marshal() []byte {
+	buf := make([]byte, 6)
+	binary.BigEndian.PutUint16(buf[0:2], n.Flags)
+	binary.BigEndian.PutUint32(buf[2:6], n.Address)
+	return buf
+}
+
+// returns static 6 bytes number
+func (n *ADDR_ENTRY) Length() uint16 {
+	return 6
 }

--- a/network/netbios/nbtns/nbtns.go
+++ b/network/netbios/nbtns/nbtns.go
@@ -3,6 +3,7 @@ package nbtns
 import (
 	"fmt"
 	"net"
+	"strings"
 	"sync"
 	"time"
 )
@@ -66,7 +67,7 @@ func (n *NetBIOSNameServer) QueryName(name string) ([]net.IP, NameType, error) {
 	n.mu.RLock()
 	defer n.mu.RUnlock()
 
-	record, exists := n.names[name]
+	record, exists := n.names[strings.TrimRight(name, "\x00")]
 	if !exists || record.Status != Active {
 		return nil, Unique, fmt.Errorf("name not found: %s", name)
 	}

--- a/network/netbios/nbtns/packet.go
+++ b/network/netbios/nbtns/packet.go
@@ -33,6 +33,13 @@ const (
 	FlagTruncated     uint16 = 0x0200
 	FlagRecursion     uint16 = 0x0100
 	FlagBroadcast     uint16 = 0x0010
+
+	// Question Type
+	QuestionTypeNB     uint16 = 0x0020
+	QuestionTypeNBSTAT uint16 = 0x0021
+
+	// Question Class
+	QuestionClassIn uint16 = 0x0001 // Internet class
 )
 
 // NBTNSHeader represents the header of a NetBIOS name service packet

--- a/network/netbios/nbtns/packet.go
+++ b/network/netbios/nbtns/packet.go
@@ -110,6 +110,7 @@ func (p *NBTNSPacket) Marshal() ([]byte, error) {
 			// Add name length and name
 			buf = append(buf, byte(len(encoded)))
 			buf = append(buf, []byte(encoded)...)
+			buf = append(buf, byte(0x00))
 
 			// Add type, class, TTL, and RDATA length
 			buf = binary.BigEndian.AppendUint16(buf, rr.Type)
@@ -158,7 +159,7 @@ func (p *NBTNSPacket) Unmarshal(data []byte) (int, error) {
 		if err != nil {
 			return 0, fmt.Errorf("failed to decode name: %v", err)
 		}
-		offset += nameLen
+		offset += nameLen + 1 // null terminator
 
 		if offset+4 > len(data) {
 			return 0, fmt.Errorf("truncated question")

--- a/network/netbios/nbtns/server.go
+++ b/network/netbios/nbtns/server.go
@@ -1,6 +1,7 @@
 package nbtns
 
 import (
+	"encoding/binary"
 	"fmt"
 	"log"
 	"net"
@@ -158,14 +159,18 @@ func (s *Server) handleNameQuery(request *NBTNSPacket, response *NBTNSPacket) {
 		}
 
 		// Create resource record for each owner
-		for _, owner := range owners {
+		for _, ip := range owners {
+			owner := ADDR_ENTRY{
+				Address: binary.BigEndian.Uint32(ip.To4()),
+				Flags:   0x0000,
+			}
 			rr := NBTNSResourceRecord{
 				Name:     q.Name,
 				Type:     q.Type,
 				Class:    q.Class,
 				TTL:      uint32(24 * time.Hour.Seconds()), // 24 hour TTL
-				RDLength: uint16(len(owner)),
-				RData:    owner,
+				RDLength: uint16(owner.Length()),
+				RData:    owner.Marshal(),
 			}
 			response.Answers = append(response.Answers, rr)
 		}

--- a/network/netbios/nbtns/udp_server.go
+++ b/network/netbios/nbtns/udp_server.go
@@ -116,7 +116,7 @@ func (s *UDPServer) handlePacket(data []byte, remoteAddr *net.UDPAddr) {
 		Header: NBTNSHeader{
 			TransactionID: packet.Header.TransactionID,
 			Flags:         FlagResponse | FlagAuthoritative,
-			Questions:     packet.Header.Questions,
+			Questions:     0,
 		},
 	}
 


### PR DESCRIPTION
This PR fixes **NameQuery** functionality with the following fixes:

1. There is a null-terminator in all names. we should consider that while searching, marshaling and unmarshalling.
2. Implement `ADDR_ENTRY `structure for `NameQuery()`.

Create `main.go` to test:

```go
package main

import (
	"log"
	"net"
	"os"
	"strconv"
	"time"

	"github.com/TheManticoreProject/Manticore/network/netbios/nbtns"
)

func main() {
	addres := "0.0.0.0:" + strconv.Itoa(nbtns.DefaultNBTNSPort)

	nbtnss := nbtns.NewNetBIOSNameServer(true)
	udpServer, err := nbtns.NewUDPServer(addres, nbtnss)
	if err != nil {
		log.Fatalf("Failed to create UDP server: %v", err)
	}

	if err := udpServer.Start(); err != nil {
		log.Fatalf("Failed to start UDP server: %v", err)
	}
	defer udpServer.Stop()

	name := "WIN-CE17E5VG17Q"
	ip := net.ParseIP("172.16.31.84")
	err = nbtnss.RegisterName(name, nbtns.Unique, ip, 24*time.Hour)
	if err != nil {
		log.Fatalf("Failed to register name: %v", err)
	}

	for {
		time.Sleep(time.Second * 1)
	}
}
```