### PR TITLE
[bugfix] Fix LLMNR Message.Unmarshal cumulative offset tracking (#80)

### DIFF
--- a/network/llmnr/message/message.go
+++ b/network/llmnr/message/message.go
@@ -381,40 +381,44 @@ func (m *Message) Unmarshal(data []byte) (int, error) {
 	// Decode questions
 	for i := uint16(0); i < m.Header.QDCount; i++ {
 		q := question.Question{}
-		bytesRead, err = q.Unmarshal(data[bytesRead:])
+		n, err := q.Unmarshal(data[bytesRead:])
 		if err != nil {
 			return 0, fmt.Errorf("error unmarshalling question: %w", err)
 		}
+		bytesRead += n
 		m.Questions = append(m.Questions, q)
 	}
 
 	// Decode answers
 	for i := uint16(0); i < m.Header.ANCount; i++ {
 		rr := resourcerecord.ResourceRecord{}
-		bytesRead, err = rr.Unmarshal(data[bytesRead:])
+		n, err := rr.Unmarshal(data[bytesRead:])
 		if err != nil {
 			return 0, fmt.Errorf("error unmarshalling answer: %w", err)
 		}
+		bytesRead += n
 		m.Answers = append(m.Answers, rr)
 	}
 
 	// Decode authority
 	for i := uint16(0); i < m.Header.NSCount; i++ {
 		rr := resourcerecord.ResourceRecord{}
-		bytesRead, err = rr.Unmarshal(data[bytesRead:])
+		n, err := rr.Unmarshal(data[bytesRead:])
 		if err != nil {
 			return 0, fmt.Errorf("error unmarshalling authority: %w", err)
 		}
+		bytesRead += n
 		m.Authority = append(m.Authority, rr)
 	}
 
 	// Decode additional
 	for i := uint16(0); i < m.Header.ARCount; i++ {
 		rr := resourcerecord.ResourceRecord{}
-		bytesRead, err = rr.Unmarshal(data[bytesRead:])
+		n, err := rr.Unmarshal(data[bytesRead:])
 		if err != nil {
 			return 0, fmt.Errorf("error unmarshalling additional: %w", err)
 		}
+		bytesRead += n
 		m.Additional = append(m.Additional, rr)
 	}
 

--- a/network/llmnr/message/message_test.go
+++ b/network/llmnr/message/message_test.go
@@ -188,6 +188,65 @@ func TestAddAnswer(t *testing.T) {
 	}
 }
 
+// TestUnmarshalMultipleRecords exercises the Marshal -> Unmarshal round trip
+// with more than one question and at least one answer. The prior
+// implementation of Message.Unmarshal overwrote its cumulative offset on
+// every nested Unmarshal, so the second question's bytes were parsed from
+// the wrong position and later sections got corrupted. This test fails on
+// the broken code and passes once bytesRead accumulates correctly.
+func TestUnmarshalMultipleRecords(t *testing.T) {
+	orig := message.NewMessage()
+	orig.Header.Identifier = 0x1234
+	orig.Header.Flags = 0x0100
+
+	if err := orig.AddQuestion("host.local", llmnr_type.TypeA, class.ClassIN); err != nil {
+		t.Fatalf("AddQuestion 1 failed: %v", err)
+	}
+	if err := orig.AddQuestion("other.local", llmnr_type.TypeAAAA, class.ClassIN); err != nil {
+		t.Fatalf("AddQuestion 2 failed: %v", err)
+	}
+	if err := orig.AddAnswer(resourcerecord.ResourceRecord{
+		Name:     "host.local",
+		Type:     llmnr_type.TypeA,
+		Class:    class.ClassIN,
+		TTL:      300,
+		RDLength: 4,
+		RData:    []byte{192, 168, 1, 1},
+	}); err != nil {
+		t.Fatalf("AddAnswer failed: %v", err)
+	}
+
+	wire, err := orig.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	parsed := message.NewMessage()
+	n, err := parsed.Unmarshal(wire)
+	if err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if n != len(wire) {
+		t.Errorf("Unmarshal returned %d bytes read, want %d", n, len(wire))
+	}
+
+	if len(parsed.Questions) != 2 {
+		t.Fatalf("expected 2 questions, got %d", len(parsed.Questions))
+	}
+	if parsed.Questions[0].Name != "host.local" {
+		t.Errorf("question 0 name mismatch: got %q", parsed.Questions[0].Name)
+	}
+	if parsed.Questions[1].Name != "other.local" {
+		t.Errorf("question 1 name mismatch: got %q", parsed.Questions[1].Name)
+	}
+	if len(parsed.Answers) != 1 {
+		t.Fatalf("expected 1 answer, got %d", len(parsed.Answers))
+	}
+	if parsed.Answers[0].Name != "host.local" {
+		t.Errorf("answer name mismatch: got %q", parsed.Answers[0].Name)
+	}
+}
+
 func TestValidate(t *testing.T) {
 	msg := message.NewMessage()
 


### PR DESCRIPTION
### Linked Issue
Closes #80

### Root Cause
`Message.Unmarshal` calls each nested `Unmarshal` on `data[bytesRead:]`, which returns an offset *relative to that sub-slice*. The existing loops assigned the return value directly back to `bytesRead` instead of adding it, so after the first question, every subsequent read used a bytesRead value that no longer reflected the cumulative offset from the start of the buffer. Multi-record messages got parsed from wrong positions.

The header case (L375–L379) already got this right — it uses `bytesRead += bytesReadHeader`. The four record loops did not.

### Fix Description
Change each record loop to `n, err := ...; bytesRead += n`, matching the header pattern. Single-line change per loop; no other behavior altered.

### How Verified
- **Tests:** added `TestUnmarshalMultipleRecords` in `network/llmnr/message/message_test.go`. It builds a message with two questions and one answer, round-trips through `Marshal` and `Unmarshal`, and asserts each record survives. On the prior code the second question is parsed from a bogus offset and the test fails; with the fix it passes.
- **Build / vet:** `go build ./...`, `go vet ./...`, and `go test ./network/llmnr/...` all clean.

### Test Coverage
**Added:** `network/llmnr/message/message_test.go::TestUnmarshalMultipleRecords` — Marshal → Unmarshal round trip with 2 questions + 1 answer.

### Scope of Change
- **Files changed:** `network/llmnr/message/message.go`, `network/llmnr/message/message_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none