### PR TITLE
[bugfix] Fix resource leak and silenced errors in GetDomainDNSServers (#81)

### DIFF
--- a/network/ldap/domain_controllers.go
+++ b/network/ldap/domain_controllers.go
@@ -20,49 +20,45 @@ func (ldapSession *Session) GetDomainDNSServers() ([]string, error) {
 	dnsServers := []string{}
 	var errList []string
 
+	probe := func(hostname string) {
+		conn, err := net.Dial("tcp", hostname+":53")
+		if err != nil {
+			errList = append(errList, fmt.Sprintf("Error connecting to %s: %s", hostname, err))
+			return
+		}
+		defer conn.Close()
+
+		// Get remote address which contains the IP of the connected DNS server.
+		// Use net.SplitHostPort so IPv6 addresses ("[::1]:53") are handled correctly.
+		host, _, splitErr := net.SplitHostPort(conn.RemoteAddr().String())
+		if splitErr != nil {
+			errList = append(errList, fmt.Sprintf("Error parsing remote address for %s: %s", hostname, splitErr))
+			return
+		}
+		dnsServers = append(dnsServers, host)
+	}
+
 	// Check in domain controllers
 	domainControllersMap, err := ldapSession.GetAllDomainControllers()
 	if err != nil {
-		return dnsServers, nil
+		return dnsServers, fmt.Errorf("failed to list domain controllers: %w", err)
 	}
 
 	for distinguishedName := range domainControllersMap {
 		for _, hostname := range domainControllersMap[distinguishedName] {
-			// Try to connect to
-			conn, err := net.Dial("tcp", hostname+":53")
-			if err == nil {
-				// Get remote address which contains the IP of the connected DNS server
-				remoteAddr := conn.RemoteAddr().String()
-				remoteIP := strings.Split(remoteAddr, ":")[0]
-
-				dnsServers = append(dnsServers, remoteIP)
-				defer conn.Close()
-			} else {
-				errList = append(errList, fmt.Sprintf("Error connecting to %s: %s", hostname, err))
-			}
+			probe(hostname)
 		}
 	}
 
 	// Check in read only domain controllers
 	readOnlyDomainControllersMap, err := ldapSession.GetAllReadOnlyDomainControllers()
 	if err != nil {
-		return dnsServers, nil
+		return dnsServers, fmt.Errorf("failed to list read-only domain controllers: %w", err)
 	}
 
 	for distinguishedName := range readOnlyDomainControllersMap {
 		for _, hostname := range readOnlyDomainControllersMap[distinguishedName] {
-			// Try to connect to
-			conn, err := net.Dial("tcp", hostname+":53")
-			if err == nil {
-				// Get remote address which contains the IP of the connected DNS server
-				remoteAddr := conn.RemoteAddr().String()
-				remoteIP := strings.Split(remoteAddr, ":")[0]
-
-				dnsServers = append(dnsServers, remoteIP)
-				defer conn.Close()
-			} else {
-				errList = append(errList, fmt.Sprintf("Error connecting to %s: %s", hostname, err))
-			}
+			probe(hostname)
 		}
 	}
 


### PR DESCRIPTION
### Linked Issue
Closes #81

### Root Cause
Two defects in the same function:

1. `defer conn.Close()` was placed inside nested `for … for …` loops. Go defers run at function return, not at loop-iteration end, so every successful dial in both loops kept its TCP socket open until `GetDomainDNSServers` itself returned. A directory with N DCs held N sockets open for the lifetime of the call even though each was finished with after the `RemoteAddr()` read.
2. Errors from `GetAllDomainControllers` / `GetAllReadOnlyDomainControllers` were swallowed by `return dnsServers, nil`. LDAP failures disappeared into a success-looking response.

### Fix Description
Extract the per-host probe into an inner closure. The closure's `defer conn.Close()` runs on closure return (i.e. per host), so at most one connection is open at a time.

Return the LDAP-query errors wrapped with `%w` so callers can distinguish "DC enumeration failed" from "probing hosts produced per-host errors."

Replace `strings.Split(remoteAddr, ":")[0]` with `net.SplitHostPort` so IPv6 remote addresses (returned as `"[::1]:53"`) are parsed correctly instead of yielding `"["`.

### How Verified
- **Static:** `defer` now lives inside the closure scope, so each deferred Close fires at closure exit (one per host). LDAP-query errors are propagated with `fmt.Errorf("... %w", err)`.
- **Build / vet:** `go build ./...` and `go vet ./...` are clean.

### Test Coverage
**None added.** The helper reaches out over the network to port 53 on every returned DC hostname and cannot be exercised without either real DNS-capable hosts or a substantial rework to inject a dialer. The fix is small and local; the existing test suite still passes.

### Scope of Change
- **Files changed:** `network/ldap/domain_controllers.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** the function now returns non-nil errors from the two `GetAll*DomainControllers` calls (previously dropped). Callers that relied on those errors being swallowed will begin to see them; this is the intended behavior change.

### Risk and Rollout
Low. The connection-leak fix is an unambiguous improvement; the error-propagation change is technically observable but restores the function's documented return contract.