### PR TITLE
[bugfix] Fix GetRootDSE panic on empty search result (#82)

### DIFF
--- a/network/ldap/ldap.go
+++ b/network/ldap/ldap.go
@@ -66,5 +66,9 @@ func (ldapSession *Session) GetRootDSE() (*Entry, error) {
 		return nil, fmt.Errorf("error searching LDAP: %w", err)
 	}
 
+	if len(searchResult.Entries) == 0 {
+		return nil, fmt.Errorf("rootDSE search returned no entries")
+	}
+
 	return searchResult.Entries[0], nil
 }


### PR DESCRIPTION
### Linked Issue
Closes #82

### Root Cause
`searchResult.Entries` from `go-ldap/ldap/v3` is a `[]*ldap.Entry` that can legitimately be empty on a successful Search — e.g. when the server returns success-with-zero-entries or when filters eliminate everything. The function indexed `Entries[0]` with no length check, so an empty result caused `panic: runtime error: index out of range [0] with length 0` instead of a returned error.

### Fix Description
Add `len(searchResult.Entries) == 0` guard after the error check and return a typed error. Three lines.

### How Verified
- **Static:** the panicking index is now preceded by a length check; the error path is exercised on any empty result.
- **Build / vet:** clean.

### Test Coverage
**None added.** Triggering the bug requires a live LDAP server that returns zero entries for a base-scope rootDSE search — an environment-level concern. The fix is small and the risk is localized to callers that previously relied on a panic.

### Scope of Change
- **Files changed:** `network/ldap/ldap.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none