### PR TITLE
[bugfix] Fix GetNtSecurityDescriptorOf panic on empty search result (#83)

### DIFF
--- a/network/ldap/security_descriptors.go
+++ b/network/ldap/security_descriptors.go
@@ -84,6 +84,10 @@ func (s *Session) GetNtSecurityDescriptorOf(distinguishedName string) (string, e
 		return "", fmt.Errorf("error searching for nTSecurityDescriptor: %w", err)
 	}
 
+	if len(searchResult.Entries) == 0 {
+		return "", fmt.Errorf("no entry returned for %q; access may be denied", distinguishedName)
+	}
+
 	ntsd := searchResult.Entries[0].GetEqualFoldRawAttributeValue("nTSecurityDescriptor")
 
 	return string(ntsd), nil


### PR DESCRIPTION
### Linked Issue
Closes #83

### Root Cause
On Active Directory, when the bound principal lacks `RIGHT_DS_READ_CONTROL` (or more generally read permission on `nTSecurityDescriptor`), the server answers the base-scope Search with success and zero entries rather than an access-denied error. The function indexed `Entries[0]` unconditionally, panicking in that common authorization outcome.

### Fix Description
Check `len(searchResult.Entries) == 0` after the error check and return a descriptive error that mentions access-denial as the likely cause (matching the `GetRootDSE` treatment in PR #89).

### How Verified
- **Static:** the panicking index is now preceded by a length check.
- **Build / vet:** clean.

### Test Coverage
**None added.** Reproducing the empty-entries path requires a live directory where the bound principal is filtered from reading the descriptor — environment-level, not unit-testable without mocks that would not meaningfully exercise the real server behavior.

### Scope of Change
- **Files changed:** `network/ldap/security_descriptors.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none