### PR TITLE
[bugfix] Fix EndsWithNullTerminator panic on short input (#84)

### DIFF
--- a/utils/strings.go
+++ b/utils/strings.go
@@ -98,6 +98,9 @@ func SizeInBytes(size uint64) string {
 // Returns:
 // - A boolean indicating if the input string ends with a null terminator.
 func EndsWithNullTerminator(input string) bool {
+	if len(input) < 1 {
+		return false
+	}
 	return input[len(input)-1] == 0x00
 }
 
@@ -109,6 +112,9 @@ func EndsWithNullTerminator(input string) bool {
 // Returns:
 // - A boolean indicating if the input string ends with a null terminator.
 func EndsWithNullTerminatorUTF16(input []byte) bool {
+	if len(input) < 2 {
+		return false
+	}
 	return input[len(input)-2] == 0x00 && input[len(input)-1] == 0x00
 }
 

--- a/utils/strings_test.go
+++ b/utils/strings_test.go
@@ -60,6 +60,7 @@ func TestEndsWithNullTerminator(t *testing.T) {
 	}{
 		{"hello\x00", true},
 		{"world", false},
+		{"", false},
 	}
 
 	for _, tt := range tests {
@@ -82,6 +83,8 @@ func TestEndsWithNullTerminatorUTF16(t *testing.T) {
 		{"UTF16-LE hello without null terminator", []byte("h\x00e\x00l\x00l\x00o\x00"), false},
 		{"UTF16-LE world with null terminator", []byte("\x00w\x00o\x00r\x00l\x00d\x00\x00"), true},
 		{"UTF16-LE world without null terminator", []byte("\x00w\x00o\x00r\x00l\x00d"), false},
+		{"empty input", []byte{}, false},
+		{"single byte input", []byte{0x00}, false},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
### Linked Issue
Closes #84

### Root Cause
Both `EndsWithNullTerminator` and `EndsWithNullTerminatorUTF16` accessed `input[len(input)-N]` with no check that `len(input) >= N`. Empty strings and single-byte slices produce a runtime panic via negative indexing.

### Fix Description
Add `if len(input) < N { return false }` guards at the top of each function. A string that is too short to contain the terminator trivially does not end with one, so `false` is the correct result.

### How Verified
- **Tests:** extended the existing table-driven tests with `""` for `TestEndsWithNullTerminator` and with `[]byte{}` and `[]byte{0x00}` for `TestEndsWithNullTerminatorUTF16`. All cases pass after the fix and would panic on the previous code.
- **Build / vet:** clean.

### Test Coverage
**Added:** new table rows in `utils/strings_test.go::TestEndsWithNullTerminator` and `TestEndsWithNullTerminatorUTF16` covering the short-input edge cases.

### Scope of Change
- **Files changed:** `utils/strings.go`, `utils/strings_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none