### PR TITLE
[bugfix] Fix KEYCREDENTIALLINK_ENTRY.Unmarshal bounds checks (#85)

### DIFF
--- a/windows/keycredentiallink/KEYCREDENTIALLINK_ENTRY.go
+++ b/windows/keycredentiallink/KEYCREDENTIALLINK_ENTRY.go
@@ -40,15 +40,24 @@ type KEYCREDENTIALLINK_ENTRY struct {
 func (e *KEYCREDENTIALLINK_ENTRY) Unmarshal(data []byte) (int, error) {
 	bytesRead := 0
 
-	e.Length = binary.LittleEndian.Uint16(data[bytesRead:2])
+	if len(data) < bytesRead+2 {
+		return bytesRead, fmt.Errorf("data too short to read KEYCREDENTIALLINK_ENTRY Length: got %d bytes, need at least 2", len(data))
+	}
+	e.Length = binary.LittleEndian.Uint16(data[bytesRead : bytesRead+2])
 	bytesRead += 2
 
+	if len(data) < bytesRead+1 {
+		return bytesRead, fmt.Errorf("data too short to read KEYCREDENTIALLINK_ENTRY Identifier: got %d bytes, need at least %d", len(data), bytesRead+1)
+	}
 	identifierBytesRead, err := e.Identifier.Unmarshal(data[bytesRead : bytesRead+1])
 	if err != nil {
 		return bytesRead, err
 	}
 	bytesRead += identifierBytesRead
 
+	if len(data) < bytesRead+int(e.Length) {
+		return bytesRead, fmt.Errorf("data too short to read KEYCREDENTIALLINK_ENTRY Value: got %d bytes, need at least %d", len(data), bytesRead+int(e.Length))
+	}
 	e.Value = data[bytesRead : bytesRead+int(e.Length)]
 	bytesRead += int(e.Length)
 

--- a/windows/keycredentiallink/KEYCREDENTIALLINK_ENTRY_test.go
+++ b/windows/keycredentiallink/KEYCREDENTIALLINK_ENTRY_test.go
@@ -1,1 +1,79 @@
 package keycredentiallink_test
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/windows/keycredentiallink"
+)
+
+// TestKEYCREDENTIALLINK_ENTRY_Unmarshal_BoundsChecks verifies that Unmarshal
+// returns an error instead of panicking when fed truncated input at each of
+// the three sensitive positions: Length field, Identifier field, and Value
+// slice. This mirrors the contract established in #34 for the outer
+// KeyCredential type.
+func TestKEYCREDENTIALLINK_ENTRY_Unmarshal_BoundsChecks(t *testing.T) {
+	cases := []struct {
+		name string
+		data []byte
+	}{
+		{name: "empty", data: []byte{}},
+		{name: "length-only-1-byte", data: []byte{0x00}},
+		{name: "missing-identifier", data: []byte{0x01, 0x00}}, // Length=1, no identifier
+		{
+			name: "value-too-short",
+			data: func() []byte {
+				// Length=0xFFFF, identifier=0x00, zero bytes of value
+				b := make([]byte, 3)
+				binary.LittleEndian.PutUint16(b[0:2], 0xFFFF)
+				b[2] = 0x00
+				return b
+			}(),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("Unmarshal panicked on %q input: %v", tc.name, r)
+				}
+			}()
+			entry := &keycredentiallink.KEYCREDENTIALLINK_ENTRY{}
+			_, err := entry.Unmarshal(tc.data)
+			if err == nil {
+				t.Errorf("Unmarshal(%q) returned nil error; wanted a bounds-check error", tc.name)
+			}
+		})
+	}
+}
+
+// TestKEYCREDENTIALLINK_ENTRY_Unmarshal_RoundTrip exercises the happy path:
+// a well-formed entry round-trips through Marshal + Unmarshal.
+func TestKEYCREDENTIALLINK_ENTRY_Unmarshal_RoundTrip(t *testing.T) {
+	original := &keycredentiallink.KEYCREDENTIALLINK_ENTRY{
+		Length:     4,
+		Identifier: keycredentiallink.KEYCREDENTIALLINK_ENTRY_IDENTIFIER_KeyID,
+		Value:      []byte{0xde, 0xad, 0xbe, 0xef},
+	}
+
+	data, err := original.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal returned error: %v", err)
+	}
+
+	decoded := &keycredentiallink.KEYCREDENTIALLINK_ENTRY{}
+	n, err := decoded.Unmarshal(data)
+	if err != nil {
+		t.Fatalf("Unmarshal returned error: %v", err)
+	}
+	if n != len(data) {
+		t.Errorf("Unmarshal read %d bytes, wanted %d", n, len(data))
+	}
+	if decoded.Length != original.Length {
+		t.Errorf("Length mismatch: got %d, want %d", decoded.Length, original.Length)
+	}
+	if string(decoded.Value) != string(original.Value) {
+		t.Errorf("Value mismatch: got %x, want %x", decoded.Value, original.Value)
+	}
+}


### PR DESCRIPTION
### Linked Issue
Closes #85

### Root Cause
`KEYCREDENTIALLINK_ENTRY.Unmarshal` performed three unchecked slice operations:
1. `binary.LittleEndian.Uint16(data[bytesRead:2])` — panics if `len(data) < 2`.
2. `e.Identifier.Unmarshal(data[bytesRead : bytesRead+1])` — panics if `len(data) < 3`.
3. `e.Value = data[bytesRead : bytesRead+int(e.Length)]` — panics on any `Length` that overruns the buffer, which is the attacker-controlled case.

Because `KEYCREDENTIALLINK_ENTRY` values come from the directory, a malformed `msDS-KeyCredentialLink` attribute could take down a goroutine with a slice-bounds panic instead of a returned error — the exact contract issue #34 closed for the outer `KeyCredential` type.

### Fix Description
Add explicit `if len(data) < bytesRead+N { return bytesRead, fmt.Errorf(...) }` checks before each of the three reads. Also use `data[bytesRead : bytesRead+2]` (instead of the misleading `data[bytesRead:2]`) for symmetry with the other two reads.

### How Verified
- **Tests:** added `TestKEYCREDENTIALLINK_ENTRY_Unmarshal_BoundsChecks` (empty, single-byte, missing identifier, oversized Length) and `TestKEYCREDENTIALLINK_ENTRY_Unmarshal_RoundTrip` (positive case). All pass.
- **Build / vet:** clean.

### Test Coverage
**Added:** `windows/keycredentiallink/KEYCREDENTIALLINK_ENTRY_test.go` — both a bounds-checks table test (4 truncation shapes) and a Marshal↔Unmarshal round-trip.

### Scope of Change
- **Files changed:** `windows/keycredentiallink/KEYCREDENTIALLINK_ENTRY.go`, `windows/keycredentiallink/KEYCREDENTIALLINK_ENTRY_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Notes
Related: #34 established that `KeyCredential.Unmarshal` must return errors rather than panic. This brings the adjacent `KEYCREDENTIALLINK_ENTRY.Unmarshal` to the same bar.