### PR TITLE
[bugfix] Fix panic on 1-byte input in SMB Data.Unmarshal (#96)

### DIFF
--- a/network/smb/smb_v10/message/data/data.go
+++ b/network/smb/smb_v10/message/data/data.go
@@ -78,8 +78,8 @@ func (d *Data) Marshal() ([]byte, error) {
 func (d *Data) Unmarshal(data []byte) (int, error) {
 	bytesRead := 0
 
-	if len(data) == 0 {
-		return bytesRead, fmt.Errorf("data is empty")
+	if len(data) < 2 {
+		return bytesRead, fmt.Errorf("data too short to unmarshal SMB data byte count")
 	}
 
 	d.ByteCount = binary.LittleEndian.Uint16(data[:2])

--- a/network/smb/smb_v10/message/data/data_test.go
+++ b/network/smb/smb_v10/message/data/data_test.go
@@ -110,3 +110,20 @@ func Test_DataUnmarshalEmptyData(t *testing.T) {
 		t.Errorf("Expected Bytes to be empty, got length: %d", len(data.Bytes))
 	}
 }
+
+// Test_DataUnmarshalOneByteDoesNotPanic verifies that a 1-byte input (too
+// short to contain the 2-byte ByteCount) returns an error rather than
+// panicking on the binary.LittleEndian.Uint16(data[:2]) read.
+func Test_DataUnmarshalOneByteDoesNotPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Data.Unmarshal panicked on 1-byte input: %v", r)
+		}
+	}()
+
+	d := data.NewData()
+	_, err := d.Unmarshal([]byte{0x01})
+	if err == nil {
+		t.Fatal("Expected error when unmarshalling 1-byte data, got nil")
+	}
+}


### PR DESCRIPTION
### Linked Issue
Closes #96

### Root Cause
`(*Data).Unmarshal` guarded against an empty input (`len(data) == 0`) but not against a 1-byte input. The next line, `binary.LittleEndian.Uint16(data[:2])`, requires at least 2 bytes. A 1-byte input slips past the guard and panics with `runtime error: slice bounds out of range`. The sibling `Parameters.Unmarshal` uses a 1-byte length guard because its header is 1 byte; `Data`'s header (`ByteCount`) is 2 bytes, so the guard was off by one when it was copied over.

### Fix Description
Change the guard to `len(data) < 2` and update the error message to describe what's missing. No behavioural change for inputs of 2 bytes or more.

### How Verified
- **Tests:** new `Test_DataUnmarshalOneByteDoesNotPanic` feeds a 1-byte buffer and asserts `Unmarshal` returns an error; a deferred `recover()` fails the test if a panic escapes. Without the fix, the test panics.
- **Static:** the new check runs before `data[:2]`, so the short-input path cannot reach the panicking slice.

### Test Coverage
**Added:** `network/smb/smb_v10/message/data/data_test.go::Test_DataUnmarshalOneByteDoesNotPanic`.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/data/data.go`, `network/smb/smb_v10/message/data/data_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Strictly additive length check. Inputs of 2 bytes or more continue to decode unchanged. Safe to merge without a staged rollout.