### PR TITLE
[bugfix] Fix placeholder passwords being sent in plaintext SMB1 auth path (#93)

### DIFF
--- a/network/smb/smb_v10/client/session.go
+++ b/network/smb/smb_v10/client/session.go
@@ -147,16 +147,21 @@ func (s *Session) SessionSetup() error {
 			session_setup_cmd.VcNumber = types.USHORT(0x0000)
 			session_setup_cmd.SessionKey = s.Client.Connection.Server.SessionKey
 
+			if s.Credentials == nil {
+				return fmt.Errorf("plaintext authentication requires credentials but none were provided")
+			}
+			password := s.Credentials.Password
+
 			// Check if Unicode is supported
-			if s.Client.Connection.Server.Capabilities&0x00000004 != 0 { // CAP_UNICODE
+			if s.Client.Connection.Server.Capabilities&capabilities.CAP_UNICODE == capabilities.CAP_UNICODE {
 				// Send password in Unicode
-				session_setup_cmd.UnicodePassword = []types.UCHAR(utf16.EncodeUTF16LE("UnicodePassword"))
+				session_setup_cmd.UnicodePassword = []types.UCHAR(utf16.EncodeUTF16LE(password))
 				session_setup_cmd.UnicodePasswordLen = types.USHORT(len(session_setup_cmd.UnicodePassword))
 				session_setup_cmd.OEMPasswordLen = types.USHORT(0x0000)
 				session_setup_cmd.OEMPassword = []types.UCHAR{}
 			} else {
 				// Send password in OEM format
-				session_setup_cmd.OEMPassword = []types.UCHAR("OEMPassword")
+				session_setup_cmd.OEMPassword = []types.UCHAR(password)
 				session_setup_cmd.OEMPasswordLen = types.USHORT(len(session_setup_cmd.OEMPassword))
 				session_setup_cmd.UnicodePasswordLen = types.USHORT(0x0000)
 				session_setup_cmd.UnicodePassword = []types.UCHAR{}


### PR DESCRIPTION
### Linked Issue
Closes #93

### Root Cause
`(*Session).SessionSetup` had a fallback branch for servers that do not advertise challenge/response authentication. That branch ignored `s.Credentials.Password` entirely and put the Go string literals `"UnicodePassword"` or `"OEMPassword"` into `session_setup_cmd.UnicodePassword` / `OEMPassword`. The placeholder was presumably left over from development and was never wired up to use the caller-supplied credentials, so every plaintext SessionSetup transmitted a hardcoded string on the wire instead of the user's password.

### Fix Description
Replace the two placeholder literals with `s.Credentials.Password`, encoding UTF-16LE when `CAP_UNICODE` is negotiated and OEM otherwise. Return an explicit `plaintext authentication requires credentials but none were provided` error if the plaintext path is reached with `s.Credentials == nil`, to avoid dereferencing nil. Replace the raw `0x00000004` capability constant with the `capabilities.CAP_UNICODE` symbol that the sibling challenge-response branch already uses.

### How Verified
- **Static:** both branches now reference `password := s.Credentials.Password` (after the nil guard); no remaining reference to the `"UnicodePassword"`/`"OEMPassword"` string literals. `go build ./...` and `go test ./...` pass.
- **Tests:** the existing unit tests cover Marshal/Unmarshal of `SessionSetupAndxRequest`; there are no tests for the live authentication handshake, so behavior is verified by code reading.

### Test Coverage
**None:** this is a handshake path that requires a live peer to exercise; the repo has no mock SMB server. A unit test at this layer would either repeat the existing Marshal-level tests or duplicate the code under test. No dedicated regression test was feasible without adding a significant test harness outside the scope of the fix.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/client/session.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
This branch is only reached against servers that do not advertise `NEGOTIATE_ENCRYPT_PASSWORDS`, which in practice means very old or misconfigured servers. Previously this path authenticated as the literal user `"UnicodePassword"`/`"OEMPassword"` — i.e. it never worked for any real deployment. The new behavior sends the caller's actual password and, if no credentials were supplied, fails fast with a descriptive error. Safe to merge.