### PR TITLE
[enhancement] Fix IsIPv6 always returns true for IPv4 addresses (#101)

### DIFF
--- a/network/llmnr/server/server.go
+++ b/network/llmnr/server/server.go
@@ -253,8 +253,10 @@ func (s *Server) IsIPv4() bool {
 // Returns:
 // - A boolean value: true if the server's address is an IPv6 address, false otherwise.
 //
-// The function uses the net.IP.To16 method to determine if the IP address is an IPv6 address.
-// If the IP address is not an IPv6 address, the method will return nil, and the function will return false.
+// An address is considered IPv6 when it has a valid 16-byte representation and
+// cannot be represented as an IPv4 address (net.IP.To4 returns nil). Checking
+// only To16() would incorrectly classify IPv4 addresses as IPv6, because
+// net.IP.To16() also returns a non-nil 16-byte representation for IPv4.
 //
 // Example usage:
 // server, err := llmnr.NewIPv6Server()
@@ -269,7 +271,7 @@ func (s *Server) IsIPv4() bool {
 //	    fmt.Println("The server is not using an IPv6 address.")
 //	}
 func (s *Server) IsIPv6() bool {
-	return s.Address.IP.To16() != nil
+	return s.Address.IP.To16() != nil && s.Address.IP.To4() == nil
 }
 
 // SetDebug enables or disables debug mode for the LLMNR server.

--- a/network/llmnr/server/server_test.go
+++ b/network/llmnr/server/server_test.go
@@ -164,3 +164,31 @@ func TestIPv6ServerStartAndStop(t *testing.T) {
 		t.Error("Expected server to close within 1 second, but it did not")
 	}
 }
+
+func TestIsIPv4AndIsIPv6AreMutuallyExclusive(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping test on Windows")
+	}
+
+	ipv4Server, err := server.NewIPv4Server()
+	if err != nil {
+		t.Fatalf("Failed to create IPv4 server: %v", err)
+	}
+	if !ipv4Server.IsIPv4() {
+		t.Errorf("Expected IPv4 server IsIPv4()=true, got false")
+	}
+	if ipv4Server.IsIPv6() {
+		t.Errorf("Expected IPv4 server IsIPv6()=false, got true (IPv4 address reports as IPv6)")
+	}
+
+	ipv6Server, err := server.NewIPv6Server()
+	if err != nil {
+		t.Fatalf("Failed to create IPv6 server: %v", err)
+	}
+	if !ipv6Server.IsIPv6() {
+		t.Errorf("Expected IPv6 server IsIPv6()=true, got false")
+	}
+	if ipv6Server.IsIPv4() {
+		t.Errorf("Expected IPv6 server IsIPv4()=false, got true")
+	}
+}


### PR DESCRIPTION
### Linked Issue
Closes #101

### Root Cause
`Server.IsIPv6()` tested `s.Address.IP.To16() != nil` to decide whether the address was IPv6. `net.IP.To16()` returns a non-nil 16-byte slice for any valid IP, including IPv4 addresses (Go represents IPv4 internally as the v4-in-v6 mapping `::ffff:a.b.c.d`). Only a zero-length `net.IP` yields nil from `To16()`. As a result the helper classified every valid address — including the IPv4 LLMNR multicast address `224.0.0.252` — as IPv6.

### Fix Description
`IsIPv6()` now returns true only when the address has a 16-byte representation **and** cannot be represented as IPv4 (`To4() == nil`). This is the standard Go idiom for distinguishing genuine IPv6 addresses from IPv4 addresses that happen to sit in 16-byte storage. `IsIPv4()` is unchanged; the two helpers are now mutually exclusive on valid addresses, as their documentation implies.

### How Verified
- **Runtime:** `net.ParseIP("224.0.0.252").To16() != nil` is `true` and `.To4() != nil` is `true`, confirming the misclassification. With the fix, `IsIPv6()` on an IPv4 server returns false.
- **Tests:** `TestIsIPv4AndIsIPv6AreMutuallyExclusive` asserts that an IPv4 server reports `IsIPv4()=true, IsIPv6()=false` and an IPv6 server reports the opposite.
- `go test ./network/llmnr/...` passes.

### Test Coverage
**Added:** `network/llmnr/server/server_test.go::TestIsIPv4AndIsIPv6AreMutuallyExclusive` exercises both `NewIPv4Server` and `NewIPv6Server` and asserts the mutual-exclusion property. The test skips on Windows to match the existing IPv6 test skip for the same `setsockopt` limitation.

### Scope of Change
- **Files changed:** `network/llmnr/server/server.go`, `network/llmnr/server/server_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local, read-only helper change. No on-wire behaviour change. Any caller that relied on `IsIPv6()` returning true for an IPv4 server was relying on buggy behaviour.