### PR TITLE
[bugfix] Fix Flags.String misleading QR/OP labels (#103)

### DIFF
--- a/network/llmnr/message/header/flags.go
+++ b/network/llmnr/message/header/flags.go
@@ -64,13 +64,14 @@ func (f *Flags) Unmarshal(data []byte) (int, error) {
 }
 
 // String returns a string representation of the flags.
+//
+// The QR label is emitted only when the QR bit is set (response), matching the
+// convention used in DNS trace output. Query messages (QR=0) produce no QR
+// label. OPCODE is a separate 4-bit field and is not derived from the QR bit.
 func (f Flags) String() string {
 	flags := []string{}
-	if f.IsQuery() {
-		flags = append(flags, "QR")
-	}
 	if f.IsResponse() {
-		flags = append(flags, "OP")
+		flags = append(flags, "QR")
 	}
 	if f.IsConflict() {
 		flags = append(flags, "C")

--- a/network/llmnr/message/header/flags_test.go
+++ b/network/llmnr/message/header/flags_test.go
@@ -111,14 +111,18 @@ func TestFlagsString(t *testing.T) {
 		flags    header.Flags
 		expected string
 	}{
-		{0, "QR"},
-		{header.FlagQR, "OP"},
-		{header.FlagC, "QR|C"},
-		{header.FlagTC, "QR|TC"},
-		{header.FlagT, "QR|T"},
-		{header.FlagQR | header.FlagC, "OP|C"},
-		{header.FlagQR | header.FlagTC | header.FlagT, "OP|TC|T"},
-		{header.FlagQR | header.FlagOP | header.FlagC | header.FlagTC | header.FlagT, "OP|C|TC|T"},
+		// Query messages (QR bit clear) must not emit "QR".
+		{0, ""},
+		{header.FlagC, "C"},
+		{header.FlagTC, "TC"},
+		{header.FlagT, "T"},
+		// Response messages (QR bit set) emit "QR".
+		{header.FlagQR, "QR"},
+		{header.FlagQR | header.FlagC, "QR|C"},
+		{header.FlagQR | header.FlagTC | header.FlagT, "QR|TC|T"},
+		// FlagOP is not rendered as a label by String(); OPCODE is a 4-bit field,
+		// not a single-bit flag, and is deliberately not surfaced here.
+		{header.FlagQR | header.FlagOP | header.FlagC | header.FlagTC | header.FlagT, "QR|C|TC|T"},
 	}
 	for _, tt := range tests {
 		got := tt.flags.String()


### PR DESCRIPTION
### Linked Issue
Closes #103

### Root Cause
`Flags.String()` emitted `"QR"` for query messages (QR bit *clear*) and `"OP"` for response messages (QR bit *set*). This inverted the meaning of `QR` relative to DNS convention — in DNS trace output, `QR` denotes the QR bit being set — and conflated the QR bit with OPCODE, which is a separate 4-bit field. The per-bit helpers `IsQuery()` and `IsResponse()` were implemented correctly; only the string rendering was wrong.

### Fix Description
`String()` now emits `"QR"` only when the QR bit is set (response), and no longer emits `"OP"` based on the QR bit. `OP` is not a single-bit label — OPCODE is a separate 4-bit subfield — so rendering it as a boolean flag here would be a continuing source of confusion. If opcode rendering is wanted in the future it should be a separate, distinct string.

`TestFlagsString` was asserting the buggy behaviour and is updated to assert the corrected mapping:

- Query flags render without any `QR` prefix (e.g., `FlagC` → `"C"`, `0` → `""`).
- Response flags render with a `QR` prefix (e.g., `FlagQR` → `"QR"`, `FlagQR|FlagC` → `"QR|C"`).

### How Verified
- **Tests:** `TestFlagsString` (updated) and the unchanged `TestIsQueryAndIsResponse` / `TestFlagsMarshalUnmarshal` all pass.
- `go test ./network/llmnr/...` passes.

### Test Coverage
**Existing:** `network/llmnr/message/header/flags_test.go::TestFlagsString` is updated to assert the corrected behaviour across query/response combinations and to document why `FlagOP` is not rendered.

### Scope of Change
- **Files changed:** `network/llmnr/message/header/flags.go`, `network/llmnr/message/header/flags_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Affects human-readable rendering via `Describe()` and any log consumer that formats `Flags`. No on-wire behaviour change.

### Notes
Any downstream consumer that grepped for `OP` in logs to mean "response" should instead match on `QR`. That was already the DNS convention and is what the fix now produces.