### PR TITLE
[bugfix] Fix Message.Validate skips Authority and Additional names (#105)

### DIFF
--- a/network/llmnr/message/message.go
+++ b/network/llmnr/message/message.go
@@ -270,6 +270,18 @@ func (m *Message) Validate() error {
 		}
 	}
 
+	for _, rr := range m.Authority {
+		if err := rr.Name.Validate(); err != nil {
+			return err
+		}
+	}
+
+	for _, rr := range m.Additional {
+		if err := rr.Name.Validate(); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/network/llmnr/message/message_test.go
+++ b/network/llmnr/message/message_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/TheManticoreProject/Manticore/network/llmnr/class"
+	"github.com/TheManticoreProject/Manticore/network/llmnr/domain_name"
 	"github.com/TheManticoreProject/Manticore/network/llmnr/errors"
 	"github.com/TheManticoreProject/Manticore/network/llmnr/llmnr_type"
 	"github.com/TheManticoreProject/Manticore/network/llmnr/message"
@@ -279,5 +280,37 @@ func TestValidate(t *testing.T) {
 	err = msg.Validate()
 	if err != errors.ErrInvalidMessage {
 		t.Errorf("Validate() error = %v, want %v", err, errors.ErrInvalidMessage)
+	}
+}
+
+func TestValidateChecksAuthorityAndAdditional(t *testing.T) {
+	// Label of 64 'a' chars — exceeds MaxLabelLength (63).
+	tooLongLabel := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+	mkRR := func(name string) resourcerecord.ResourceRecord {
+		return resourcerecord.ResourceRecord{
+			Name:     domain_name.DomainName(name),
+			Type:     llmnr_type.TypeA,
+			Class:    class.ClassIN,
+			TTL:      30,
+			RDLength: 4,
+			RData:    []byte{127, 0, 0, 1},
+		}
+	}
+
+	// Invalid name in Authority section.
+	msgAuth := message.NewMessage()
+	msgAuth.Authority = append(msgAuth.Authority, mkRR(tooLongLabel))
+	msgAuth.Header.NSCount = 1
+	if err := msgAuth.Validate(); err != errors.ErrLabelTooLong {
+		t.Errorf("Validate() returned %v for invalid Authority name, want %v", err, errors.ErrLabelTooLong)
+	}
+
+	// Invalid name in Additional section.
+	msgAdd := message.NewMessage()
+	msgAdd.Additional = append(msgAdd.Additional, mkRR(tooLongLabel))
+	msgAdd.Header.ARCount = 1
+	if err := msgAdd.Validate(); err != errors.ErrLabelTooLong {
+		t.Errorf("Validate() returned %v for invalid Additional name, want %v", err, errors.ErrLabelTooLong)
 	}
 }


### PR DESCRIPTION
### Linked Issue
Closes #105

### Root Cause
`Message.Validate()` checked record counts against the header counts for all four sections (Questions, Answers, Authority, Additional), but iterated only Questions and Answers to validate domain names. Authority and Additional records with invalid names (e.g., a label longer than `MaxLabelLength`) passed validation. The omission was a maintenance gap: the two extra sections exist on the struct and are correctly counted but were never added to the validation loop.

### Fix Description
`Validate()` now iterates all four record slices and calls `rr.Name.Validate()` on each entry. The behaviour for previously-checked sections (Questions, Answers) is unchanged; the change only adds coverage for Authority and Additional. The method's documented contract of "ensuring the integrity of the LLMNR message" now matches its implementation.

### How Verified
- **Tests:** new `TestValidateChecksAuthorityAndAdditional` builds a message carrying a 64-character label (one over `MaxLabelLength`) in the Authority section, then in the Additional section, and asserts `Validate()` returns `errors.ErrLabelTooLong` in both cases. Pre-fix the test fails (validate returns nil); post-fix it passes.
- Existing `TestValidate` still passes.
- `go test ./network/llmnr/...` passes.

### Test Coverage
**Added:** `network/llmnr/message/message_test.go::TestValidateChecksAuthorityAndAdditional` covers the two previously-unvalidated sections.

### Scope of Change
- **Files changed:** `network/llmnr/message/message.go`, `network/llmnr/message/message_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Tightens a validation check; does not change on-wire behaviour. Callers that previously passed `Validate()` with invalid Authority/Additional names will now correctly receive an error — this is the intended contract.