### PR TITLE
[bugfix] Fix Kerberos v5 import paths after directory move (#109)

### DIFF
--- a/network/kerberos/v5/asreproast.go
+++ b/network/kerberos/v5/asreproast.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/TheManticoreProject/Manticore/network/kerberos/messages"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/messages"
 )
 
 // ASREPRoastResult contains the raw fields extracted from an AS-REP response for an

--- a/network/kerberos/v5/client.go
+++ b/network/kerberos/v5/client.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"time"
 
-	kerbcrypto "github.com/TheManticoreProject/Manticore/network/kerberos/crypto"
-	"github.com/TheManticoreProject/Manticore/network/kerberos/messages"
+	kerbcrypto "github.com/TheManticoreProject/Manticore/network/kerberos/v5/crypto"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/messages"
 )
 
 // KerberosClient manages Kerberos authentication against an Active Directory KDC.

--- a/network/kerberos/v5/crypto/crypto.go
+++ b/network/kerberos/v5/crypto/crypto.go
@@ -2,7 +2,7 @@
 // string-to-key derivation, encryption, and decryption for RC4-HMAC and
 // AES-CTS-HMAC-SHA1-96 encryption types.
 //
-// Import path: github.com/TheManticoreProject/Manticore/network/kerberos/crypto
+// Import path: github.com/TheManticoreProject/Manticore/network/kerberos/v5/crypto
 package kerbcrypto
 
 import (
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/TheManticoreProject/Manticore/network/kerberos/messages"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/messages"
 )
 
 // Key usage constants per RFC 4120 Section 7.5.1.

--- a/network/kerberos/v5/crypto/crypto_test.go
+++ b/network/kerberos/v5/crypto/crypto_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/TheManticoreProject/Manticore/crypto/nt"
-	"github.com/TheManticoreProject/Manticore/network/kerberos/messages"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/messages"
 )
 
 // ---------------------------------------------------------------------------

--- a/network/ldap/session.go
+++ b/network/ldap/session.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/TheManticoreProject/Manticore/windows/credentials"
 
-	"github.com/TheManticoreProject/Manticore/network/kerberos"
+	kerberos "github.com/TheManticoreProject/Manticore/network/kerberos/v5"
 	"github.com/go-ldap/ldap/v3"
 	"github.com/go-ldap/ldap/v3/gssapi"
 	krb5client "github.com/jcmturner/gokrb5/v8/client"


### PR DESCRIPTION
### Linked Issue
Closes #109

### Root Cause
Commit 3d7eaf1 (\"Moved kerberos to v5\") used `git mv` to move `network/kerberos/*` into `network/kerberos/v5/` but did not update any of the import paths inside the moved files, nor the single out-of-tree consumer in `network/ldap/session.go`. Go's module system resolves imports by the literal string in the source, so after the move every import pointing at the old location became unresolvable and the repo stopped compiling on `main`.

### Fix Description
Update each affected import to the new location:

- `network/kerberos/v5/client.go` — retarget `.../kerberos/crypto` and `.../kerberos/messages` at `.../kerberos/v5/crypto` and `.../kerberos/v5/messages`.
- `network/kerberos/v5/asreproast.go` — same for `.../kerberos/messages`.
- `network/kerberos/v5/crypto/crypto.go` — same for `.../kerberos/messages`, plus update the corresponding path in the file-level doc comment.
- `network/kerberos/v5/crypto/crypto_test.go` — same for `.../kerberos/messages`.
- `network/ldap/session.go` — retarget the top-level `.../kerberos` import at `.../kerberos/v5`. Added an import alias `kerberos` so the existing call sites (`kerberos.KerberosInit(...)`) continue to compile unchanged.

No behavioural changes; this is a pure path-correction fix required for the tree to build at all.

### How Verified
Runtime:

```
$ go build ./...
(no errors)

$ go test ./network/kerberos/v5/...
?       github.com/TheManticoreProject/Manticore/network/kerberos/v5   [no test files]
ok      github.com/TheManticoreProject/Manticore/network/kerberos/v5/crypto    0.005s
?       github.com/TheManticoreProject/Manticore/network/kerberos/v5/messages  [no test files]
```

Compared against the pre-fix state (three unresolved-import errors) to confirm this exact set of changes fixes the build.

### Test Coverage
**Existing:** the `crypto` package already has roundtrip and known-vector tests (`crypto/crypto_test.go`) that exercise both the code under the fixed import and the fixed test file's own import path. All pass after the change.

### Scope of Change
- **Files changed:** `network/kerberos/v5/asreproast.go`, `network/kerberos/v5/client.go`, `network/kerberos/v5/crypto/crypto.go`, `network/kerberos/v5/crypto/crypto_test.go`, `network/ldap/session.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Trivial and local. Only the import strings change; no symbol, signature, or runtime path changes. Safe to merge immediately — the alternative is that `main` cannot be built.