### PR TITLE
[bugfix] Fix RC4-HMAC usage 9 remap violating RFC 4757 errata (#113)

### DIFF
--- a/network/kerberos/v5/crypto/crypto_test.go
+++ b/network/kerberos/v5/crypto/crypto_test.go
@@ -254,3 +254,31 @@ func TestUnsupportedEType(t *testing.T) {
 		t.Error("Decrypt: expected error for unsupported etype")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// RC4-HMAC usage remapping (RFC 4757 errata)
+// ---------------------------------------------------------------------------
+
+// TestRC4HMACUsageMapping enforces the RFC 4757 errata:
+// only usages 3 and 23 are remapped (to 8 and 13); every other usage,
+// including 9, passes through unchanged.
+func TestRC4HMACUsageMapping(t *testing.T) {
+	cases := []struct {
+		usage int
+		want  uint32
+	}{
+		{1, 1},   // PA-ENC-TIMESTAMP — unchanged
+		{3, 8},   // AS-REP enc-part — remapped
+		{7, 7},   // TGS-REQ authenticator — unchanged
+		{8, 8},   // TGS-REP enc-part (session key) — unchanged
+		{9, 9},   // TGS-REP enc-part (sub-session key) — MUST NOT remap to 8
+		{11, 11}, // AP-REQ authenticator — unchanged
+		{23, 13}, // AD-KDC-ISSUED checksum — remapped
+	}
+	for _, tc := range cases {
+		got := mapRC4HMACUsage(tc.usage)
+		if got != tc.want {
+			t.Errorf("mapRC4HMACUsage(%d) = %d, want %d", tc.usage, got, tc.want)
+		}
+	}
+}

--- a/network/kerberos/v5/crypto/rc4hmac.go
+++ b/network/kerberos/v5/crypto/rc4hmac.go
@@ -11,10 +11,14 @@ import (
 
 // rc4HMACUsageMap translates RFC 4120 key usage numbers to the Microsoft
 // message-type values used in RC4-HMAC key derivation, per RFC 4757 Section 4
-// and MS-KILE Section 3.1.5.7.
+// (as corrected by the errata) and MS-KILE Section 3.1.5.7.
+//
+// Per the RFC 4757 errata, usage 9 is NOT remapped to 8 — only usages 3 and
+// 23 are remapped. Keeping the pre-errata mapping of 9 → 8 breaks
+// interoperability with any KDC that correctly uses usage 9 for TGS-REP
+// enc-part encrypted under a client-supplied sub-session key.
 var rc4HMACUsageMap = map[int]uint32{
 	3:  8,  // AS-REP enc-part
-	9:  8,  // TGS-REP enc-part (sub-session key)
 	23: 13, // AD-KDC-ISSUED checksum
 }
 


### PR DESCRIPTION
### Linked Issue
Closes #113

### Root Cause
`rc4HMACUsageMap` encoded the *original* RFC 4757 Section 4 instruction that RFC 4120 key usage `9` be remapped to Microsoft message-type `8`. That mapping was later withdrawn by the RFC 4757 errata — only usages `3` and `23` are remapped, everything else passes through — and every modern Kerberos implementation (MIT, Heimdal, impacket) follows the errata. Leaving the pre-errata `9 → 8` entry in the map meant that any RC4-HMAC TGS-REP whose enc-part the KDC encrypted with usage `9` (the case where the client supplied a sub-session key in its Authenticator) would derive `K2` from `HMAC-MD5(key, usage_str(8))` on this side, disagree with the KDC, and fail MAC verification.

### Fix Description
Drop the `9: 8` entry from `rc4HMACUsageMap` so usage `9` now passes through unchanged. Expand the comment on the map to spell out the errata so the decision is discoverable next time someone is tempted to \"re-add\" the missing entry based on the pre-errata RFC text. No other code changes are needed — `mapRC4HMACUsage` already returns the input unchanged when the map has no entry.

I considered also adding impacket's defensive fallback (on usage-9 MAC failure, retry with usage 8 in case a buggy peer still does the pre-errata mapping). That is a behavioural addition beyond the minimal fix and there is no evidence of such a peer in AD today, so it's intentionally out of scope for this PR and can be filed as a separate enhancement if a real interop case appears.

### How Verified
**Static:** traced the map through `mapRC4HMACUsage` (rc4hmac.go:23) → `usageMsgType` (rc4hmac.go:32) → `K2 = HMAC-MD5(key, usageMsgType(usage))` in both `rc4HMACEncrypt` (L69) and `rc4HMACDecrypt` (L122). With `9` absent from the map, `K2` is now derived from the correct 4-byte little-endian representation of `9`, matching what the KDC uses.

**Tests:** added `TestRC4HMACUsageMapping` that enumerates the standard Kerberos usages and checks `mapRC4HMACUsage` against the errata-correct mapping. Most importantly, `{9, 9}` asserts usage `9` is not remapped. Run against the fix:

```
=== RUN   TestRC4HMACUsageMapping
--- PASS: TestRC4HMACUsageMapping (0.00s)
PASS
ok  	github.com/TheManticoreProject/Manticore/network/kerberos/v5/crypto
```

The same test fails on pre-fix code with `mapRC4HMACUsage(9) = 8, want 9`, which is the exact symptom.

### Test Coverage
**Added:** `TestRC4HMACUsageMapping` in `network/kerberos/v5/crypto/crypto_test.go`. It covers remapped usages (3→8, 23→13), and five non-remapped usages including the regressing `9 → 9` case.

### Scope of Change
- **Files changed:** `network/kerberos/v5/crypto/rc4hmac.go`, `network/kerberos/v5/crypto/crypto_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Very low risk. The only behavioural change is that RC4-HMAC encrypt/decrypt with usage `9` now uses the correct derived key. Callers that never pass usage `9` — which includes every path in the current `KerberosClient` — see no change. Callers that do pass usage `9` were previously broken and will now work against any compliant KDC. Existing `TestRC4HMACRoundtrip` cases don't use usage `9`, so they continue to pass unchanged.