### PR TITLE
[bugfix] Fix RC4-HMAC usageMsgType to use little-endian uint32 encoding (#115)

### DIFF
--- a/network/kerberos/v5/crypto/crypto_test.go
+++ b/network/kerberos/v5/crypto/crypto_test.go
@@ -254,3 +254,37 @@ func TestUnsupportedEType(t *testing.T) {
 		t.Error("Decrypt: expected error for unsupported etype")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// RC4-HMAC usageMsgType encoding
+// ---------------------------------------------------------------------------
+
+// TestRC4HMACUsageMsgTypeEncoding verifies that usageMsgType produces the
+// fixed 4-byte little-endian uint32 encoding required by MS-KILE / RFC 4757
+// (matching impacket's pack('<I', msusage) and gokrb5's
+// binary.LittleEndian.PutUint32), for both small and >=128 values.
+//
+// The regression target is values >= 128: the previous implementation used
+// binary.PutUvarint, which for 128 emits 0x80 0x01 in the first two bytes
+// instead of 0x80 0x00 0x00 0x00.
+func TestRC4HMACUsageMsgTypeEncoding(t *testing.T) {
+	cases := []struct {
+		usage int
+		want  []byte
+	}{
+		{1, []byte{0x01, 0x00, 0x00, 0x00}},
+		{3, []byte{0x08, 0x00, 0x00, 0x00}},     // remapped to 8
+		{23, []byte{0x0d, 0x00, 0x00, 0x00}},    // remapped to 13
+		{127, []byte{0x7f, 0x00, 0x00, 0x00}},   // boundary: still 1-byte varint
+		{128, []byte{0x80, 0x00, 0x00, 0x00}},   // first value where varint and LE-uint32 diverge
+		{255, []byte{0xff, 0x00, 0x00, 0x00}},
+		{256, []byte{0x00, 0x01, 0x00, 0x00}},
+		{65536, []byte{0x00, 0x00, 0x01, 0x00}},
+	}
+	for _, tc := range cases {
+		got := usageMsgType(tc.usage)
+		if !bytes.Equal(got, tc.want) {
+			t.Errorf("usageMsgType(%d) = %x, want %x", tc.usage, got, tc.want)
+		}
+	}
+}

--- a/network/kerberos/v5/crypto/rc4hmac.go
+++ b/network/kerberos/v5/crypto/rc4hmac.go
@@ -27,12 +27,13 @@ func mapRC4HMACUsage(usage int) uint32 {
 	return uint32(usage)
 }
 
-// usageMsgType encodes a mapped usage as a 4-byte little-endian slice.
-// binary.PutUvarint is used for consistency with MS/gokrb5 reference behaviour.
+// usageMsgType encodes a mapped usage as a 4-byte little-endian uint32,
+// matching MS-KILE Section 3.1.5.7 and RFC 4757 Section 4 (impacket's
+// pack('<I', msusage), jcmturner/gokrb5's binary.LittleEndian.PutUint32).
 func usageMsgType(usage int) []byte {
 	mapped := mapRC4HMACUsage(usage)
 	tb := make([]byte, 4)
-	binary.PutUvarint(tb, uint64(mapped))
+	binary.LittleEndian.PutUint32(tb, mapped)
 	return tb
 }
 


### PR DESCRIPTION
### Linked Issue
Closes #115

### Root Cause
`usageMsgType` called `binary.PutUvarint(tb, uint64(mapped))` on a 4-byte buffer. `binary.PutUvarint` is Go's variable-length varint encoding (7 bits per byte, continuation bit on the high bit), not a fixed little-endian `uint32`. The two encodings happen to coincide for values 0..127 because the pre-zeroed buffer supplies the trailing zero bytes, which is why every current Kerberos key usage — and every remapped value (8, 13) — has been producing the \"right\" bytes by accident. At 128 they diverge (`0x80 0x01` vs `0x80 0x00 0x00 0x00`), so the moment any mapped usage crosses that boundary, `HMAC-MD5(key, usageMsgType(usage))` derives a key from the wrong bytes on both the encrypt and decrypt paths and RC4-HMAC silently breaks. The existing comment also misdescribed the encoding as matching MS/gokrb5, the opposite of what MS and gokrb5 actually do.

### Fix Description
Replace `binary.PutUvarint` with `binary.LittleEndian.PutUint32`, which is a fixed 4-byte little-endian encoding, matching impacket's `pack('<I', msusage)` (`impacket/krb5/crypto.py::_RC4.usage_str`) and `jcmturner/gokrb5`'s usage serialization. Update the comment to spell out the correct spec references (MS-KILE 3.1.5.7, RFC 4757 §4) and the reference implementations. No other signature or call-site changes are needed — the function returns bytes of the same length as before.

### How Verified
**Static:** traced the encoding into `rc4HMACEncrypt` (`rc4hmac.go:69`) and `rc4HMACDecrypt` (`rc4hmac.go:122`). With the fix, the bytes fed to `HMAC-MD5` now match `pack('<I', msusage)` for every 32-bit-representable input. Cross-checked against impacket's `_RC4.usage_str` and gokrb5's `binary.LittleEndian.PutUint32(b, uint32(mapped))`.

**Tests:** added `TestRC4HMACUsageMsgTypeEncoding` that spot-checks the encoding at the <128 safe range (1, 3, 23, 127), at the divergence boundary (128), and at multi-byte values (255, 256, 65536). Under the previous `binary.PutUvarint` implementation, the 128 and 65536 cases fail (`usageMsgType(128)` previously yielded `80 01 00 00`); under the fix they pass:

```
=== RUN   TestRC4HMACUsageMsgTypeEncoding
--- PASS: TestRC4HMACUsageMsgTypeEncoding (0.00s)
PASS
ok  	github.com/TheManticoreProject/Manticore/network/kerberos/v5/crypto
```

All pre-existing RC4-HMAC roundtrip tests (`TestRC4HMACRoundtrip`, `TestRC4HMACDecryptTamperedMAC`) also continue to pass — expected, because those use usages < 128 where the two encodings coincided.

### Test Coverage
**Added:** `TestRC4HMACUsageMsgTypeEncoding` in `network/kerberos/v5/crypto/crypto_test.go`. Covers both the previously-correct-by-accident range and the divergence boundary, so the varint regression can never silently reappear.

### Scope of Change
- **Files changed:** `network/kerberos/v5/crypto/rc4hmac.go`, `network/kerberos/v5/crypto/crypto_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Very low risk. For every mapped usage actually reachable today (1, 3, 7, 8, 11, 13), the new encoding produces byte-identical output to the old one, so no user-visible RC4-HMAC ciphertext changes for current call sites. The fix only affects behaviour for mapped usages >= 128, which the current client never produces but where the previous code would have silently broken.