### PR TITLE
[enhancement] Refactor KDC options into per-message builders and add AD-client flags (#119)

### DIFF
--- a/network/kerberos/v5/asreproast.go
+++ b/network/kerberos/v5/asreproast.go
@@ -45,7 +45,7 @@ func ASREPRoast(username, realm, kdcHost string) (*ASREPRoastResult, error) {
 		MsgType: messages.MsgTypeASReq,
 		// No PAData — absence of pre-auth is what makes the account vulnerable.
 		ReqBody: messages.KDCReqBody{
-			KDCOptions: kdcOptionsForwardable(),
+			KDCOptions: kdcOptionsForASReq(),
 			CName: messages.PrincipalName{
 				NameType:   messages.NameTypePrincipal,
 				NameString: []string{username},

--- a/network/kerberos/v5/client.go
+++ b/network/kerberos/v5/client.go
@@ -152,7 +152,7 @@ func (c *KerberosClient) GetTGS(spn string, includePAC bool) (messages.Ticket, [
 			{PADataType: messages.PAPACRequest, PADataValue: []byte{0x30, 0x05, 0xa0, 0x03, 0x01, 0x01, pacBool}},
 		},
 		ReqBody: messages.KDCReqBody{
-			KDCOptions: kdcOptionsForwardable(),
+			KDCOptions: kdcOptionsForTGSReq(),
 			Realm:      c.realm,
 			SName:      sname,
 			Till:       time.Now().UTC().Add(24 * time.Hour),
@@ -234,7 +234,7 @@ func (c *KerberosClient) sendASReq(pa_data []messages.PAData) ([]byte, error) {
 		MsgType: messages.MsgTypeASReq,
 		PAData:  pa_data,
 		ReqBody: messages.KDCReqBody{
-			KDCOptions: kdcOptionsForwardable(),
+			KDCOptions: kdcOptionsForASReq(),
 			CName: messages.PrincipalName{
 				NameType:   messages.NameTypePrincipal,
 				NameString: []string{c.username},
@@ -447,15 +447,45 @@ func (c *KerberosClient) buildAPReq() ([]byte, error) {
 	return ap_req.Marshal()
 }
 
-// kdcOptionsForwardable returns a KDCOptions BitString with the forwardable flag set.
-// Bit positions follow RFC 4120 Section 5.4.1 (bit 0 = MSB).
-func kdcOptionsForwardable() asn1.BitString {
-	// Forwardable = bit 1 (RFC 4120), renewable-ok = bit 27.
-	// Encoded as a 32-bit big-endian bit string: bit 1 → 0x40 in first byte.
-	return asn1.BitString{
-		Bytes:     []byte{0x40, 0x00, 0x00, 0x00},
-		BitLength: 32,
+// Bit positions for KDCOptions (RFC 4120 Section 5.4.1, RFC 6806 for canonicalize).
+// Bit 0 is the MSB; bit N sits in byte N/8 at position 7-(N%8).
+const (
+	kdcOptionForwardable  = 1  // byte 0, 0x40
+	kdcOptionProxiable    = 3  // byte 0, 0x10
+	kdcOptionRenewable    = 8  // byte 1, 0x80
+	kdcOptionCanonicalize = 15 // byte 1, 0x01 (RFC 6806)
+	kdcOptionRenewableOK  = 27 // byte 3, 0x10
+)
+
+// encodeKDCOptions packs a list of bit positions into a 32-bit BitString
+// suitable for use as the KDCOptions field of an AS-REQ or TGS-REQ.
+func encodeKDCOptions(bits ...int) asn1.BitString {
+	b := make([]byte, 4)
+	for _, pos := range bits {
+		b[pos/8] |= 1 << (7 - (pos % 8))
 	}
+	return asn1.BitString{Bytes: b, BitLength: 32}
+}
+
+// kdcOptionsForASReq returns the KDCOptions BitString for an AS-REQ, matching
+// the flags a real Active Directory client sends (forwardable + proxiable +
+// renewable).
+func kdcOptionsForASReq() asn1.BitString {
+	return encodeKDCOptions(kdcOptionForwardable, kdcOptionProxiable, kdcOptionRenewable)
+}
+
+// kdcOptionsForTGSReq returns the KDCOptions BitString for a TGS-REQ. Adds
+// canonicalize (RFC 6806) so the KDC canonicalizes the requested SPN — AD
+// KDCs can otherwise respond with S_PRINCIPAL_UNKNOWN for non-canonical SPN
+// forms — and renewable-ok so the issued service ticket carries the same
+// renewable window as the TGT it was derived from.
+func kdcOptionsForTGSReq() asn1.BitString {
+	return encodeKDCOptions(
+		kdcOptionForwardable,
+		kdcOptionRenewable,
+		kdcOptionCanonicalize,
+		kdcOptionRenewableOK,
+	)
 }
 
 // parseSPN splits a service principal name into a PrincipalName.

--- a/network/kerberos/v5/kdcoptions_test.go
+++ b/network/kerberos/v5/kdcoptions_test.go
@@ -1,0 +1,65 @@
+package kerberos
+
+import (
+	"bytes"
+	"testing"
+)
+
+// TestEncodeKDCOptionsBitLayout verifies the bit-position-to-byte mapping
+// used by encodeKDCOptions against RFC 4120 §5.2.8 / §5.4.1. Bit 0 is the
+// MSB; bit N sits in byte N/8 at position 7-(N%8).
+func TestEncodeKDCOptionsBitLayout(t *testing.T) {
+	cases := []struct {
+		name string
+		bits []int
+		want []byte
+	}{
+		{"empty", nil, []byte{0x00, 0x00, 0x00, 0x00}},
+		{"forwardable only (bit 1)", []int{kdcOptionForwardable}, []byte{0x40, 0x00, 0x00, 0x00}},
+		{"proxiable only (bit 3)", []int{kdcOptionProxiable}, []byte{0x10, 0x00, 0x00, 0x00}},
+		{"renewable only (bit 8)", []int{kdcOptionRenewable}, []byte{0x00, 0x80, 0x00, 0x00}},
+		{"canonicalize only (bit 15)", []int{kdcOptionCanonicalize}, []byte{0x00, 0x01, 0x00, 0x00}},
+		{"renewable-ok only (bit 27)", []int{kdcOptionRenewableOK}, []byte{0x00, 0x00, 0x00, 0x10}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := encodeKDCOptions(tc.bits...)
+			if got.BitLength != 32 {
+				t.Errorf("BitLength: got %d, want 32", got.BitLength)
+			}
+			if !bytes.Equal(got.Bytes, tc.want) {
+				t.Errorf("Bytes: got %x, want %x", got.Bytes, tc.want)
+			}
+		})
+	}
+}
+
+// TestKDCOptionsForASReq verifies the exact wire-format bits an AS-REQ
+// should carry: forwardable + proxiable + renewable.
+func TestKDCOptionsForASReq(t *testing.T) {
+	// forwardable (bit 1 → byte 0 0x40) + proxiable (bit 3 → byte 0 0x10)
+	// + renewable (bit 8 → byte 1 0x80)
+	want := []byte{0x50, 0x80, 0x00, 0x00}
+	got := kdcOptionsForASReq()
+	if got.BitLength != 32 {
+		t.Errorf("BitLength: got %d, want 32", got.BitLength)
+	}
+	if !bytes.Equal(got.Bytes, want) {
+		t.Errorf("Bytes: got %x, want %x", got.Bytes, want)
+	}
+}
+
+// TestKDCOptionsForTGSReq verifies the exact wire-format bits a TGS-REQ
+// should carry: forwardable + renewable + canonicalize + renewable-ok.
+func TestKDCOptionsForTGSReq(t *testing.T) {
+	// forwardable (bit 1 → byte 0 0x40) + renewable (bit 8 → byte 1 0x80)
+	// + canonicalize (bit 15 → byte 1 0x01) + renewable-ok (bit 27 → byte 3 0x10)
+	want := []byte{0x40, 0x81, 0x00, 0x10}
+	got := kdcOptionsForTGSReq()
+	if got.BitLength != 32 {
+		t.Errorf("BitLength: got %d, want 32", got.BitLength)
+	}
+	if !bytes.Equal(got.Bytes, want) {
+		t.Errorf("Bytes: got %x, want %x", got.Bytes, want)
+	}
+}


### PR DESCRIPTION
### Linked Issue
Closes #119

### Motivation
Every Kerberos request built by `KerberosClient` was going out with only the `forwardable` bit set in its `KDCOptions` field — correct for an AS-REQ but wrong in two ways for TGS-REQ:

1. no `canonicalize` bit (RFC 6806), so an AD KDC may return `S_PRINCIPAL_UNKNOWN` when the client's SPN differs from the canonical registered form (e.g. short-name vs FQDN host component);
2. no `renewable-ok`, so the issued service ticket can end up with a shorter renewable window than the TGT it was derived from.

On top of that, the helper's doc comment claimed `renewable-ok = bit 27` was set even though the encoded bytes only had `forwardable` — reviewers couldn't rely on the comment to reason about the bit layout.

### What Changed
- Added a small set of named bit-position constants (`kdcOptionForwardable`, `kdcOptionProxiable`, `kdcOptionRenewable`, `kdcOptionCanonicalize`, `kdcOptionRenewableOK`) rather than hard-coded literal bytes.
- Added a generic packer `encodeKDCOptions(bits ...int) asn1.BitString` that does the bit-position → byte mapping in one place.
- Replaced the single `kdcOptionsForwardable()` helper with two message-specific builders:
  - `kdcOptionsForASReq()` → `forwardable + proxiable + renewable` (matches impacket's `kerberosv5.py:145–148`).
  - `kdcOptionsForTGSReq()` → `forwardable + renewable + canonicalize + renewable-ok` (matches impacket's `kerberosv5.py:429–435`).
- Updated the three call sites (`client.go:sendASReq`, `client.go:GetTGS`, `asreproast.go:ASREPRoast`) to use the appropriate builder. ASREPRoast is also an AS-REQ, so it uses `kdcOptionsForASReq()` — an incidental but sensible alignment (impacket's `GetNPUsers.py` sends the same AD flags).
- Removed the stale \"renewable-ok = bit 27\" comment that described bits the old implementation didn't actually set.

### Design Notes
- Encoding is byte-indexed and always produces a 32-bit BitString, matching RFC 4120 §5.2.8 semantics and the wire shape AD KDCs parse.
- The new helpers are package-private; no public API surface changes.

### Acceptance Criteria Check
- [x] **AS-REQ's KDCOptions has forwardable (1), proxiable (3), renewable (8) set.** Verified by `TestKDCOptionsForASReq`, which asserts `Bytes = {0x50, 0x80, 0x00, 0x00}`.
- [x] **TGS-REQ's KDCOptions has forwardable (1), renewable (8), canonicalize (15), renewable-ok (27) set.** Verified by `TestKDCOptionsForTGSReq`, which asserts `Bytes = {0x40, 0x81, 0x00, 0x10}`.
- [x] **A unit test asserts the exact encoded bytes so the bit layout can't silently drift.** `TestEncodeKDCOptionsBitLayout` additionally spot-checks each constant in isolation.
- [x] **No function is annotated with a comment describing bits that aren't set.** The misleading comment on the old `kdcOptionsForwardable` is removed along with the helper itself.

### How Verified
**Tests:**

```
$ go test ./network/kerberos/v5/...
ok  	github.com/TheManticoreProject/Manticore/network/kerberos/v5
ok  	github.com/TheManticoreProject/Manticore/network/kerberos/v5/crypto
ok  	github.com/TheManticoreProject/Manticore/network/kerberos/v5/messages
```

Three new tests (`TestEncodeKDCOptionsBitLayout`, `TestKDCOptionsForASReq`, `TestKDCOptionsForTGSReq`) pin down the encoded bytes, and the full suite continues to pass.

**Static:** traced the three old call sites to confirm each is switched to the right builder (AS-REQ paths → `kdcOptionsForASReq`, TGS-REQ → `kdcOptionsForTGSReq`). `git grep kdcOptionsForwardable` now returns nothing.

### Test Coverage
**Added:** `network/kerberos/v5/kdcoptions_test.go` with `TestEncodeKDCOptionsBitLayout`, `TestKDCOptionsForASReq`, `TestKDCOptionsForTGSReq`.

### Scope of Change
- **Files changed:** `network/kerberos/v5/client.go`, `network/kerberos/v5/asreproast.go`, `network/kerberos/v5/kdcoptions_test.go` (new)
- **Submodule pointer updated:** no
- **Public API changes:** none (all helpers are package-private)
- **Behavioral changes outside the stated enhancement:** none

### Risk and Rollout
Low risk. The AS-REQ flags gain `proxiable` and `renewable` — both are advisory requests to the KDC, and the KDC is free to ignore or honour them without breaking the exchange. The TGS-REQ gains `renewable`, `canonicalize`, and `renewable-ok`, which is exactly what a Windows client sends; if this caused interop breakage anywhere, Windows clients would be broken too.