### PR TITLE
[enhancement] Add FEK key material type for KEY_USAGE_FEK (#63)

### DIFF
--- a/windows/keycredentiallink/key/material/fek/FEK_KEY_MATERIAL.go
+++ b/windows/keycredentiallink/key/material/fek/FEK_KEY_MATERIAL.go
@@ -1,0 +1,136 @@
+package fek
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/TheManticoreProject/Manticore/windows/keycredentiallink/key/material/fek/blob"
+	"github.com/TheManticoreProject/Manticore/windows/keycredentiallink/key/material/fek/headers"
+	"github.com/TheManticoreProject/Manticore/windows/keycredentiallink/key/material/fek/magic"
+)
+
+// FEK_KEY_MATERIAL represents the KEY_USAGE_FEK key material stored in a
+// KEYCREDENTIALLINK_ENTRY. The buffer is a combination of an RSA 2048 public
+// key (RFC8017) and an AES-256 KDF key, prefixed by a single version byte whose
+// value MUST be 1 (see FekKeyVersion in CUSTOM_KEY_INFORMATION).
+//
+// See:
+// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/735fd27a-3f22-4926-93f9-0298bb67a84b
+type FEK_KEY_MATERIAL struct {
+	// Version is the 1-byte version tag. MUST be FEK_KEY_VERSION_1 (0x01).
+	Version magic.FEK_KEY_MATERIAL_VERSION
+
+	// Header describes the sizes of the RSA and AES-256 KDF key material.
+	Header headers.FEK_KEY_MATERIAL_HEADER
+
+	// Content contains the RSA public exponent, modulus, and AES-256 KDF key.
+	Content blob.FEK_KEY_MATERIAL_BLOB
+}
+
+// Unmarshal parses the provided byte slice into the FEK_KEY_MATERIAL structure.
+//
+// Parameters:
+// - value: A byte slice containing the raw FEK key material to be parsed.
+//
+// Returns:
+// - The number of bytes read from the byte slice.
+// - An error if the parsing fails, otherwise nil.
+func (k *FEK_KEY_MATERIAL) Unmarshal(value []byte) (int, error) {
+	if len(value) < 17 {
+		return 0, errors.New("buffer too small for FEK_KEY_MATERIAL, header too short (at least 17 bytes are required for version and header)")
+	}
+
+	bytesRead := 0
+
+	// Unmarshalling version
+	bytesReadVersion, err := k.Version.Unmarshal(value[bytesRead:])
+	if err != nil {
+		return 0, fmt.Errorf("failed to unmarshal FEK key material version: %w", err)
+	}
+	if k.Version.Version != magic.FEK_KEY_VERSION_1 {
+		return 0, fmt.Errorf("failed to unmarshal FEK key material version: invalid version: 0x%02x", k.Version.Version)
+	}
+	bytesRead += bytesReadVersion
+
+	// Unmarshalling header
+	bytesReadHeader, err := k.Header.Unmarshal(value[bytesRead:])
+	if err != nil {
+		return 0, fmt.Errorf("failed to unmarshal FEK key material header: %w", err)
+	}
+	bytesRead += bytesReadHeader
+
+	// Unmarshalling content
+	bytesReadContent, err := k.Content.Unmarshal(k.Header, value[bytesRead:])
+	if err != nil {
+		return 0, fmt.Errorf("failed to unmarshal FEK key material content: %w", err)
+	}
+	bytesRead += bytesReadContent
+
+	return bytesRead, nil
+}
+
+// Marshal returns the raw bytes of the FEK_KEY_MATERIAL structure.
+//
+// Returns:
+// - A byte slice representing the raw bytes of the FEK_KEY_MATERIAL structure.
+// - An error if the conversion fails.
+func (k *FEK_KEY_MATERIAL) Marshal() ([]byte, error) {
+	marshalledData := []byte{}
+
+	// Marshalling version
+	k.Version.Version = magic.FEK_KEY_VERSION_1
+	marshalledVersion, err := k.Version.Marshal()
+	if err != nil {
+		return nil, err
+	}
+	marshalledData = append(marshalledData, marshalledVersion...)
+
+	// Marshalling header
+	marshalledHeader, err := k.Header.Marshal()
+	if err != nil {
+		return nil, err
+	}
+	marshalledData = append(marshalledData, marshalledHeader...)
+
+	// Marshalling content
+	marshalledContent, err := k.Content.Marshal()
+	if err != nil {
+		return nil, err
+	}
+	marshalledData = append(marshalledData, marshalledContent...)
+
+	return marshalledData, nil
+}
+
+// Describe prints a detailed description of the FEK_KEY_MATERIAL structure.
+//
+// Parameters:
+// - indent: An integer representing the indentation level for the printed output.
+func (k *FEK_KEY_MATERIAL) Describe(indent int) {
+	indentPrompt := strings.Repeat(" │ ", indent)
+	fmt.Printf("%s<\x1b[93mFEK_KEY_MATERIAL\x1b[0m>\n", indentPrompt)
+	k.Version.Describe(indent + 1)
+	k.Header.Describe(indent + 1)
+	k.Content.Describe(indent + 1)
+	fmt.Printf("%s └───\n", indentPrompt)
+}
+
+// Equal checks if two FEK_KEY_MATERIAL structures are equal.
+//
+// Parameters:
+// - other: The FEK_KEY_MATERIAL structure to compare to.
+//
+// Returns:
+// - True if the two FEK_KEY_MATERIAL structures are equal, false otherwise.
+func (k *FEK_KEY_MATERIAL) Equal(other *FEK_KEY_MATERIAL) bool {
+	return k.Version.Equal(&other.Version) && k.Header.Equal(&other.Header) && k.Content.Equal(&other.Content)
+}
+
+// Fingerprint returns the fingerprint of the FEK_KEY_MATERIAL structure.
+//
+// Returns:
+// - A string representing the fingerprint of the FEK_KEY_MATERIAL structure.
+func (k *FEK_KEY_MATERIAL) Fingerprint() string {
+	return fmt.Sprintf("FEK_KEY_MATERIAL:0x%x:0x%x:0x%x", k.Content.PublicExponent, k.Content.Modulus, k.Content.AESKDFKey)
+}

--- a/windows/keycredentiallink/key/material/fek/FEK_KEY_MATERIAL_test.go
+++ b/windows/keycredentiallink/key/material/fek/FEK_KEY_MATERIAL_test.go
@@ -1,0 +1,135 @@
+package fek_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/windows/keycredentiallink/key/material/fek"
+	"github.com/TheManticoreProject/Manticore/windows/keycredentiallink/key/material/fek/blob"
+	"github.com/TheManticoreProject/Manticore/windows/keycredentiallink/key/material/fek/headers"
+	"github.com/TheManticoreProject/Manticore/windows/keycredentiallink/key/material/fek/magic"
+)
+
+func makeSampleFEK(t *testing.T) fek.FEK_KEY_MATERIAL {
+	t.Helper()
+
+	modulus := make([]byte, 256)
+	for i := 0; i < len(modulus); i++ {
+		modulus[i] = byte(i)
+	}
+	aesKDFKey := make([]byte, 32)
+	for i := 0; i < len(aesKDFKey); i++ {
+		aesKDFKey[i] = byte(0xA0 + i)
+	}
+
+	return fek.FEK_KEY_MATERIAL{
+		Version: magic.FEK_KEY_MATERIAL_VERSION{Version: magic.FEK_KEY_VERSION_1},
+		Header: headers.FEK_KEY_MATERIAL_HEADER{
+			BitLength:   2048,
+			CbPublicExp: 3,
+			CbModulus:   256,
+			CbAESKDFKey: 32,
+		},
+		Content: blob.FEK_KEY_MATERIAL_BLOB{
+			PublicExponent: []byte{0x01, 0x00, 0x01},
+			Modulus:        modulus,
+			AESKDFKey:      aesKDFKey,
+		},
+	}
+}
+
+func TestFEK_KEY_MATERIAL_MarshalUnmarshalRoundtrip(t *testing.T) {
+	source := makeSampleFEK(t)
+
+	raw, err := source.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	// Expected size: 1 byte version + 16 bytes header + exp + modulus + AES KDF key
+	expectedLen := 1 + 16 + len(source.Content.PublicExponent) + len(source.Content.Modulus) + len(source.Content.AESKDFKey)
+	if len(raw) != expectedLen {
+		t.Errorf("Marshal produced wrong size, got %d, want %d", len(raw), expectedLen)
+	}
+
+	parsed := fek.FEK_KEY_MATERIAL{}
+	n, err := parsed.Unmarshal(raw)
+	if err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if n != len(raw) {
+		t.Errorf("Unmarshal consumed wrong size, got %d, want %d", n, len(raw))
+	}
+	if !parsed.Equal(&source) {
+		t.Errorf("Roundtripped FEK_KEY_MATERIAL does not match source")
+	}
+
+	if !bytes.Equal(parsed.Content.PublicExponent, source.Content.PublicExponent) {
+		t.Errorf("PublicExponent mismatch")
+	}
+	if !bytes.Equal(parsed.Content.Modulus, source.Content.Modulus) {
+		t.Errorf("Modulus mismatch")
+	}
+	if !bytes.Equal(parsed.Content.AESKDFKey, source.Content.AESKDFKey) {
+		t.Errorf("AESKDFKey mismatch")
+	}
+}
+
+func TestFEK_KEY_MATERIAL_Unmarshal_ShortInput(t *testing.T) {
+	k := fek.FEK_KEY_MATERIAL{}
+	_, err := k.Unmarshal([]byte{0x01, 0x00, 0x00, 0x00})
+	if err == nil {
+		t.Fatal("Expected error on short buffer, got nil")
+	}
+}
+
+func TestFEK_KEY_MATERIAL_Unmarshal_InvalidVersion(t *testing.T) {
+	source := makeSampleFEK(t)
+	raw, err := source.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	// Corrupt the version
+	raw[0] = 0xFF
+
+	k := fek.FEK_KEY_MATERIAL{}
+	_, err = k.Unmarshal(raw)
+	if err == nil {
+		t.Fatal("Expected error on invalid version, got nil")
+	}
+}
+
+func TestFEK_KEY_MATERIAL_Marshal_SetsVersion(t *testing.T) {
+	source := fek.FEK_KEY_MATERIAL{
+		// Deliberately do not set Version.Version — Marshal should default it to FEK_KEY_VERSION_1.
+		Header: headers.FEK_KEY_MATERIAL_HEADER{
+			BitLength:   2048,
+			CbPublicExp: 3,
+			CbModulus:   0,
+			CbAESKDFKey: 0,
+		},
+		Content: blob.FEK_KEY_MATERIAL_BLOB{
+			PublicExponent: []byte{0x01, 0x00, 0x01},
+		},
+	}
+
+	raw, err := source.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+	if raw[0] != magic.FEK_KEY_VERSION_1 {
+		t.Errorf("Marshal did not write FEK_KEY_VERSION_1 at byte 0, got 0x%02x", raw[0])
+	}
+}
+
+func TestFEK_KEY_MATERIAL_Fingerprint_Differs(t *testing.T) {
+	a := makeSampleFEK(t)
+	b := makeSampleFEK(t)
+	// Mutate b's AES KDF key — fingerprints should diverge.
+	b.Content.AESKDFKey = bytes.Repeat([]byte{0xFF}, 32)
+
+	if a.Fingerprint() == b.Fingerprint() {
+		t.Errorf("Fingerprints should differ when AESKDFKey differs")
+	}
+}

--- a/windows/keycredentiallink/key/material/fek/blob/FEK_KEY_MATERIAL_BLOB.go
+++ b/windows/keycredentiallink/key/material/fek/blob/FEK_KEY_MATERIAL_BLOB.go
@@ -1,0 +1,110 @@
+package blob
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"math/big"
+	"strings"
+
+	"github.com/TheManticoreProject/Manticore/windows/keycredentiallink/key/material/fek/headers"
+)
+
+// FEK_KEY_MATERIAL_BLOB carries the variable-length fields of the KEY_USAGE_FEK
+// key material: the RSA 2048 public exponent, the RSA 2048 modulus, and the
+// AES-256 KDF key. The sizes of each field are supplied by FEK_KEY_MATERIAL_HEADER.
+//
+// The layout of a FEK_KEY_MATERIAL_BLOB in memory is as follows:
+//
+//	PublicExponent[CbPublicExp] // Big-endian
+//	Modulus[CbModulus]          // Big-endian
+//	AESKDFKey[CbAESKDFKey]      // Raw bytes
+//
+// See:
+// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/735fd27a-3f22-4926-93f9-0298bb67a84b
+type FEK_KEY_MATERIAL_BLOB struct {
+	// PublicExponent is the public exponent of the RSA 2048 key, in big-endian.
+	PublicExponent []byte
+
+	// Modulus is the modulus of the RSA 2048 key, in big-endian.
+	Modulus []byte
+
+	// AESKDFKey is the AES-256 KDF key material.
+	AESKDFKey []byte
+}
+
+// Unmarshal parses the provided byte slice into the FEK_KEY_MATERIAL_BLOB structure.
+//
+// Parameters:
+// - keyHeader: The FEK_KEY_MATERIAL_HEADER describing the field sizes.
+// - value: A byte slice containing the raw FEK key material blob to be parsed.
+//
+// Returns:
+// - The number of bytes read from the byte slice.
+// - An error if the parsing fails, otherwise nil.
+func (b *FEK_KEY_MATERIAL_BLOB) Unmarshal(keyHeader headers.FEK_KEY_MATERIAL_HEADER, value []byte) (int, error) {
+	bytesRead := 0
+
+	if int(keyHeader.CbPublicExp) > len(value)-bytesRead {
+		return 0, fmt.Errorf("buffer too small for FEK_KEY_MATERIAL_BLOB, not enough bytes for unmarshalling public exponent")
+	}
+	b.PublicExponent = value[bytesRead : bytesRead+int(keyHeader.CbPublicExp)]
+	bytesRead += int(keyHeader.CbPublicExp)
+
+	if int(keyHeader.CbModulus) > len(value)-bytesRead {
+		return 0, fmt.Errorf("buffer too small for FEK_KEY_MATERIAL_BLOB, not enough bytes for unmarshalling modulus")
+	}
+	b.Modulus = value[bytesRead : bytesRead+int(keyHeader.CbModulus)]
+	bytesRead += int(keyHeader.CbModulus)
+
+	if int(keyHeader.CbAESKDFKey) > len(value)-bytesRead {
+		return 0, fmt.Errorf("buffer too small for FEK_KEY_MATERIAL_BLOB, not enough bytes for unmarshalling AES-256 KDF key")
+	}
+	b.AESKDFKey = value[bytesRead : bytesRead+int(keyHeader.CbAESKDFKey)]
+	bytesRead += int(keyHeader.CbAESKDFKey)
+
+	return bytesRead, nil
+}
+
+// Marshal returns the raw bytes of the FEK_KEY_MATERIAL_BLOB structure.
+//
+// Returns:
+// - A byte slice representing the raw bytes of the FEK_KEY_MATERIAL_BLOB structure.
+func (b *FEK_KEY_MATERIAL_BLOB) Marshal() ([]byte, error) {
+	marshalledData := []byte{}
+
+	marshalledData = append(marshalledData, b.PublicExponent...)
+
+	marshalledData = append(marshalledData, b.Modulus...)
+
+	marshalledData = append(marshalledData, b.AESKDFKey...)
+
+	return marshalledData, nil
+}
+
+// Describe prints the FEK_KEY_MATERIAL_BLOB structure to the console.
+//
+// Parameters:
+// - indent: The number of levels to indent the output.
+func (b *FEK_KEY_MATERIAL_BLOB) Describe(indent int) {
+	indentPrompt := strings.Repeat(" │ ", indent)
+	fmt.Printf("%s<\x1b[93mFEK_KEY_MATERIAL_BLOB (content)\x1b[0m>\n", indentPrompt)
+	bigIntExponent := big.NewInt(0).SetBytes(b.PublicExponent)
+	fmt.Printf("%s │ \x1b[93mPublicExponent\x1b[0m: 0x%x (%d)\n", indentPrompt, b.PublicExponent, bigIntExponent.Int64())
+	fmt.Printf("%s │ \x1b[93mModulus\x1b[0m: 0x%s\n", indentPrompt, hex.EncodeToString(b.Modulus))
+	fmt.Printf("%s │ \x1b[93mAESKDFKey\x1b[0m: 0x%s\n", indentPrompt, hex.EncodeToString(b.AESKDFKey))
+	fmt.Printf("%s └───\n", indentPrompt)
+}
+
+// Equal checks if two FEK_KEY_MATERIAL_BLOB structures are equal.
+//
+// Parameters:
+// - other: The FEK_KEY_MATERIAL_BLOB structure to compare to.
+//
+// Returns:
+// - True if the two structures are equal, false otherwise.
+func (b *FEK_KEY_MATERIAL_BLOB) Equal(other *FEK_KEY_MATERIAL_BLOB) bool {
+	return bytes.Equal(b.PublicExponent, other.PublicExponent) &&
+		bytes.Equal(b.Modulus, other.Modulus) &&
+		bytes.Equal(b.AESKDFKey, other.AESKDFKey)
+}

--- a/windows/keycredentiallink/key/material/fek/blob/FEK_KEY_MATERIAL_BLOB_test.go
+++ b/windows/keycredentiallink/key/material/fek/blob/FEK_KEY_MATERIAL_BLOB_test.go
@@ -1,0 +1,92 @@
+package blob_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/windows/keycredentiallink/key/material/fek/blob"
+	"github.com/TheManticoreProject/Manticore/windows/keycredentiallink/key/material/fek/headers"
+)
+
+func TestFEK_KEY_MATERIAL_BLOB_MarshalUnmarshal(t *testing.T) {
+	header := headers.FEK_KEY_MATERIAL_HEADER{
+		BitLength:   2048,
+		CbPublicExp: 3,
+		CbModulus:   256,
+		CbAESKDFKey: 32,
+	}
+	modulus := make([]byte, header.CbModulus)
+	for i := 0; i < len(modulus); i++ {
+		modulus[i] = byte(i)
+	}
+	aesKDFKey := make([]byte, header.CbAESKDFKey)
+	for i := 0; i < len(aesKDFKey); i++ {
+		aesKDFKey[i] = byte(0xA0 + i)
+	}
+
+	source := &blob.FEK_KEY_MATERIAL_BLOB{
+		PublicExponent: []byte{0x01, 0x00, 0x01},
+		Modulus:        modulus,
+		AESKDFKey:      aesKDFKey,
+	}
+
+	data, err := source.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+	expectedLen := len(source.PublicExponent) + len(source.Modulus) + len(source.AESKDFKey)
+	if len(data) != expectedLen {
+		t.Errorf("Marshal produced wrong size, got %d, want %d", len(data), expectedLen)
+	}
+
+	parsed := blob.FEK_KEY_MATERIAL_BLOB{}
+	n, err := parsed.Unmarshal(header, data)
+	if err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if n != len(data) {
+		t.Errorf("Unmarshal consumed wrong size, got %d, want %d", n, len(data))
+	}
+	if !bytes.Equal(parsed.PublicExponent, source.PublicExponent) {
+		t.Errorf("PublicExponent mismatch: got %v, want %v", parsed.PublicExponent, source.PublicExponent)
+	}
+	if !bytes.Equal(parsed.Modulus, source.Modulus) {
+		t.Errorf("Modulus mismatch")
+	}
+	if !bytes.Equal(parsed.AESKDFKey, source.AESKDFKey) {
+		t.Errorf("AESKDFKey mismatch")
+	}
+	if !parsed.Equal(source) {
+		t.Errorf("Equal() returned false for roundtripped blob")
+	}
+}
+
+func TestFEK_KEY_MATERIAL_BLOB_Unmarshal_ShortInput_Modulus(t *testing.T) {
+	header := headers.FEK_KEY_MATERIAL_HEADER{
+		BitLength:   2048,
+		CbPublicExp: 3,
+		CbModulus:   256,
+		CbAESKDFKey: 32,
+	}
+	b := blob.FEK_KEY_MATERIAL_BLOB{}
+	_, err := b.Unmarshal(header, []byte{0x01, 0x00, 0x01})
+	if err == nil {
+		t.Fatal("Expected error on short buffer for modulus, got nil")
+	}
+}
+
+func TestFEK_KEY_MATERIAL_BLOB_Unmarshal_ShortInput_AESKDFKey(t *testing.T) {
+	header := headers.FEK_KEY_MATERIAL_HEADER{
+		BitLength:   2048,
+		CbPublicExp: 3,
+		CbModulus:   4,
+		CbAESKDFKey: 32,
+	}
+	// Enough for exp+modulus but not AES KDF key
+	buf := make([]byte, 3+4)
+	b := blob.FEK_KEY_MATERIAL_BLOB{}
+	_, err := b.Unmarshal(header, buf)
+	if err == nil {
+		t.Fatal("Expected error on short buffer for AES-256 KDF key, got nil")
+	}
+}

--- a/windows/keycredentiallink/key/material/fek/headers/FEK_KEY_MATERIAL_HEADER.go
+++ b/windows/keycredentiallink/key/material/fek/headers/FEK_KEY_MATERIAL_HEADER.go
@@ -1,0 +1,123 @@
+package headers
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// FEK_KEY_MATERIAL_HEADER describes the sizes of the two components that make up
+// the KEY_USAGE_FEK key material buffer: the RSA 2048 public key (PublicExponent
+// and Modulus) and the AES-256 KDF key.
+//
+// The header immediately follows the 1-byte FEK_KEY_MATERIAL_VERSION and precedes
+// the raw RSA and AES-256 KDF key bytes. All integer fields are stored in little-endian.
+//
+// See:
+// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/735fd27a-3f22-4926-93f9-0298bb67a84b
+type FEK_KEY_MATERIAL_HEADER struct {
+	// BitLength is the size, in bits, of the RSA key. For KEY_USAGE_FEK this MUST be 2048.
+	BitLength uint32
+
+	// CbPublicExp is the size, in bytes, of the RSA public exponent.
+	CbPublicExp uint32
+
+	// CbModulus is the size, in bytes, of the RSA modulus.
+	CbModulus uint32
+
+	// CbAESKDFKey is the size, in bytes, of the AES-256 KDF key. For KEY_USAGE_FEK this MUST be 32.
+	CbAESKDFKey uint32
+}
+
+// Unmarshal parses the provided byte slice into the FEK_KEY_MATERIAL_HEADER structure.
+//
+// Parameters:
+// - value: A byte slice containing the raw FEK key material header to be parsed.
+//
+// Returns:
+// - The number of bytes read from the byte slice.
+// - An error if the parsing fails, otherwise nil.
+func (h *FEK_KEY_MATERIAL_HEADER) Unmarshal(value []byte) (int, error) {
+	if len(value) < 16 {
+		return 0, errors.New("buffer too small for FEK_KEY_MATERIAL_HEADER, at least 16 bytes are required")
+	}
+
+	bytesRead := 0
+
+	h.BitLength = binary.LittleEndian.Uint32(value[bytesRead : bytesRead+4])
+	bytesRead += 4
+
+	h.CbPublicExp = binary.LittleEndian.Uint32(value[bytesRead : bytesRead+4])
+	bytesRead += 4
+
+	h.CbModulus = binary.LittleEndian.Uint32(value[bytesRead : bytesRead+4])
+	bytesRead += 4
+
+	h.CbAESKDFKey = binary.LittleEndian.Uint32(value[bytesRead : bytesRead+4])
+	bytesRead += 4
+
+	return bytesRead, nil
+}
+
+// Marshal returns the raw bytes of the FEK_KEY_MATERIAL_HEADER structure.
+//
+// Returns:
+// - A byte slice representing the raw bytes of the FEK_KEY_MATERIAL_HEADER structure.
+func (h *FEK_KEY_MATERIAL_HEADER) Marshal() ([]byte, error) {
+	buf := make([]byte, 16)
+	bytesWritten := 0
+
+	binary.LittleEndian.PutUint32(buf[bytesWritten:bytesWritten+4], h.BitLength)
+	bytesWritten += 4
+
+	binary.LittleEndian.PutUint32(buf[bytesWritten:bytesWritten+4], h.CbPublicExp)
+	bytesWritten += 4
+
+	binary.LittleEndian.PutUint32(buf[bytesWritten:bytesWritten+4], h.CbModulus)
+	bytesWritten += 4
+
+	binary.LittleEndian.PutUint32(buf[bytesWritten:bytesWritten+4], h.CbAESKDFKey)
+	bytesWritten += 4
+
+	return buf, nil
+}
+
+// Describe prints a detailed description of the FEK_KEY_MATERIAL_HEADER instance.
+//
+// Parameters:
+// - indent: An integer representing the indentation level for the printed output.
+func (h *FEK_KEY_MATERIAL_HEADER) Describe(indent int) {
+	indentPrompt := strings.Repeat(" │ ", indent)
+	fmt.Printf("%s<\x1b[93mFEK_KEY_MATERIAL_HEADER (header)\x1b[0m>\n", indentPrompt)
+	fmt.Printf("%s │ \x1b[93mBitLength\x1b[0m   : (0x%08x) %d bits \n", indentPrompt, h.BitLength, h.BitLength)
+	fmt.Printf("%s │ \x1b[93mCbPublicExp\x1b[0m : (0x%08x) %d bytes \n", indentPrompt, h.CbPublicExp, h.CbPublicExp)
+	fmt.Printf("%s │ \x1b[93mCbModulus\x1b[0m   : (0x%08x) %d bytes \n", indentPrompt, h.CbModulus, h.CbModulus)
+	fmt.Printf("%s │ \x1b[93mCbAESKDFKey\x1b[0m : (0x%08x) %d bytes \n", indentPrompt, h.CbAESKDFKey, h.CbAESKDFKey)
+	fmt.Printf("%s └───\n", indentPrompt)
+}
+
+// Equal checks if two FEK_KEY_MATERIAL_HEADER structures are equal.
+//
+// Parameters:
+// - other: The FEK_KEY_MATERIAL_HEADER structure to compare to.
+//
+// Returns:
+// - True if the two structures are equal, false otherwise.
+func (h *FEK_KEY_MATERIAL_HEADER) Equal(other *FEK_KEY_MATERIAL_HEADER) bool {
+	return h.BitLength == other.BitLength &&
+		h.CbPublicExp == other.CbPublicExp &&
+		h.CbModulus == other.CbModulus &&
+		h.CbAESKDFKey == other.CbAESKDFKey
+}
+
+// String returns a string representation of the FEK_KEY_MATERIAL_HEADER structure.
+//
+// Returns:
+// - A string representing the FEK_KEY_MATERIAL_HEADER structure.
+func (h *FEK_KEY_MATERIAL_HEADER) String() string {
+	return fmt.Sprintf(
+		"FEK_KEY_MATERIAL_HEADER(BitLength: %d, CbPublicExp: %d, CbModulus: %d, CbAESKDFKey: %d)",
+		h.BitLength, h.CbPublicExp, h.CbModulus, h.CbAESKDFKey,
+	)
+}

--- a/windows/keycredentiallink/key/material/fek/headers/FEK_KEY_MATERIAL_HEADER_test.go
+++ b/windows/keycredentiallink/key/material/fek/headers/FEK_KEY_MATERIAL_HEADER_test.go
@@ -1,0 +1,74 @@
+package headers_test
+
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/windows/keycredentiallink/key/material/fek/headers"
+)
+
+func TestFEK_KEY_MATERIAL_HEADER_Unmarshal_Marshal(t *testing.T) {
+	tests := []struct {
+		name  string
+		input headers.FEK_KEY_MATERIAL_HEADER
+	}{
+		{
+			name: "Nominal RSA-2048 + AES-256",
+			input: headers.FEK_KEY_MATERIAL_HEADER{
+				BitLength:   2048,
+				CbPublicExp: 3,
+				CbModulus:   256,
+				CbAESKDFKey: 32,
+			},
+		},
+		{
+			name: "Larger public exponent",
+			input: headers.FEK_KEY_MATERIAL_HEADER{
+				BitLength:   2048,
+				CbPublicExp: 8,
+				CbModulus:   256,
+				CbAESKDFKey: 32,
+			},
+		},
+		{
+			name: "Zero-sized",
+			input: headers.FEK_KEY_MATERIAL_HEADER{
+				BitLength:   0,
+				CbPublicExp: 0,
+				CbModulus:   0,
+				CbAESKDFKey: 0,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := tt.input.Marshal()
+			if err != nil {
+				t.Fatalf("Marshal() error = %v", err)
+			}
+			if len(data) != 16 {
+				t.Errorf("Marshal() produced %d bytes, want 16", len(data))
+			}
+
+			parsed := headers.FEK_KEY_MATERIAL_HEADER{}
+			n, err := parsed.Unmarshal(data)
+			if err != nil {
+				t.Fatalf("Unmarshal() error = %v", err)
+			}
+			if n != 16 {
+				t.Errorf("Unmarshal() consumed %d bytes, want 16", n)
+			}
+			if !parsed.Equal(&tt.input) {
+				t.Errorf("Unmarshal() = %v, want %v", parsed, tt.input)
+			}
+		})
+	}
+}
+
+func TestFEK_KEY_MATERIAL_HEADER_Unmarshal_ShortInput(t *testing.T) {
+	h := headers.FEK_KEY_MATERIAL_HEADER{}
+	_, err := h.Unmarshal([]byte{0x00, 0x08, 0x00, 0x00})
+	if err == nil {
+		t.Fatal("Expected error on short buffer, got nil")
+	}
+}

--- a/windows/keycredentiallink/key/material/fek/magic/FEK_KEY_MATERIAL_VERSION.go
+++ b/windows/keycredentiallink/key/material/fek/magic/FEK_KEY_MATERIAL_VERSION.go
@@ -1,0 +1,75 @@
+package magic
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// FEK_KEY_MATERIAL_VERSION is the 1-byte version tag that prefixes the FEK key
+// material buffer described in MS-ADTS 2.2.20.5.3.
+//
+// See:
+// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/735fd27a-3f22-4926-93f9-0298bb67a84b
+type FEK_KEY_MATERIAL_VERSION struct {
+	// Version identifies the layout of the FEK key material buffer.
+	// This field MUST be set to FEK_KEY_VERSION_1 (0x01).
+	Version uint8
+}
+
+// Unmarshal parses the provided byte slice into the FEK_KEY_MATERIAL_VERSION structure.
+//
+// Parameters:
+// - value: A byte slice containing the raw version byte to be parsed.
+//
+// Returns:
+// - The number of bytes read from the byte slice.
+// - An error if the parsing fails, otherwise nil.
+func (v *FEK_KEY_MATERIAL_VERSION) Unmarshal(value []byte) (int, error) {
+	if len(value) < 1 {
+		return 0, errors.New("buffer too small for FEK_KEY_MATERIAL_VERSION, at least 1 byte is required")
+	}
+
+	v.Version = value[0]
+
+	return 1, nil
+}
+
+// Marshal returns the raw bytes of the FEK_KEY_MATERIAL_VERSION structure.
+//
+// Returns:
+// - A byte slice representing the raw bytes of the FEK_KEY_MATERIAL_VERSION structure.
+// - An error if the conversion fails.
+func (v *FEK_KEY_MATERIAL_VERSION) Marshal() ([]byte, error) {
+	return []byte{v.Version}, nil
+}
+
+// String returns a string representation of the FEK_KEY_MATERIAL_VERSION structure.
+//
+// Returns:
+// - A string representing the FEK_KEY_MATERIAL_VERSION structure.
+func (v *FEK_KEY_MATERIAL_VERSION) String() string {
+	return fmt.Sprintf("FEK_KEY_MATERIAL_VERSION: Version=0x%02x", v.Version)
+}
+
+// Equal returns true if the FEK_KEY_MATERIAL_VERSION structure is equal to the other FEK_KEY_MATERIAL_VERSION structure.
+//
+// Parameters:
+// - other: The other FEK_KEY_MATERIAL_VERSION structure to compare to.
+//
+// Returns:
+// - True if the structures are equal, otherwise false.
+func (v *FEK_KEY_MATERIAL_VERSION) Equal(other *FEK_KEY_MATERIAL_VERSION) bool {
+	return v.Version == other.Version
+}
+
+// Describe prints the FEK_KEY_MATERIAL_VERSION structure to the console.
+//
+// Parameters:
+// - indent: The number of levels to indent the output.
+func (v *FEK_KEY_MATERIAL_VERSION) Describe(indent int) {
+	indentPrompt := strings.Repeat(" │ ", indent)
+	fmt.Printf("%s<\x1b[93mFEK_KEY_MATERIAL_VERSION (magic)\x1b[0m>\n", indentPrompt)
+	fmt.Printf("%s │ \x1b[93mVersion\x1b[0m: 0x%02x\n", indentPrompt, v.Version)
+	fmt.Printf("%s └───\n", indentPrompt)
+}

--- a/windows/keycredentiallink/key/material/fek/magic/FEK_KEY_MATERIAL_VERSION_test.go
+++ b/windows/keycredentiallink/key/material/fek/magic/FEK_KEY_MATERIAL_VERSION_test.go
@@ -1,0 +1,53 @@
+package magic_test
+
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/windows/keycredentiallink/key/material/fek/magic"
+)
+
+func TestFEK_KEY_MATERIAL_VERSION_UnmarshalMarshal(t *testing.T) {
+	tests := []struct {
+		name  string
+		input magic.FEK_KEY_MATERIAL_VERSION
+	}{
+		{
+			name: "Version 1",
+			input: magic.FEK_KEY_MATERIAL_VERSION{
+				Version: magic.FEK_KEY_VERSION_1,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			marshalledData, err := tt.input.Marshal()
+			if err != nil {
+				t.Fatalf("Marshal() error = %v", err)
+			}
+			if len(marshalledData) != 1 {
+				t.Errorf("Marshal() produced %d bytes, want 1", len(marshalledData))
+			}
+
+			parsed := magic.FEK_KEY_MATERIAL_VERSION{}
+			n, err := parsed.Unmarshal(marshalledData)
+			if err != nil {
+				t.Fatalf("Unmarshal() error = %v", err)
+			}
+			if n != 1 {
+				t.Errorf("Unmarshal() consumed %d bytes, want 1", n)
+			}
+			if !parsed.Equal(&tt.input) {
+				t.Errorf("Unmarshal() = %v, want %v", parsed, tt.input)
+			}
+		})
+	}
+}
+
+func TestFEK_KEY_MATERIAL_VERSION_Unmarshal_ShortInput(t *testing.T) {
+	v := magic.FEK_KEY_MATERIAL_VERSION{}
+	_, err := v.Unmarshal([]byte{})
+	if err == nil {
+		t.Fatal("Expected error on empty buffer, got nil")
+	}
+}

--- a/windows/keycredentiallink/key/material/fek/magic/magic.go
+++ b/windows/keycredentiallink/key/material/fek/magic/magic.go
@@ -1,0 +1,14 @@
+package magic
+
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/735fd27a-3f22-4926-93f9-0298bb67a84b
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/701a55dc-d062-4032-a2da-dbdfc384c8cf
+//
+// The key material of KEY_USAGE_FEK (section 2.2.20.5.3) is a combination of an
+// RSA 2048 public key (RFC8017) and an AES-256 KDF key. The version of the buffer
+// is controlled by the FekKeyVersion field of the CUSTOM_KEY_INFORMATION structure
+// and MUST be set to 1.
+const (
+	// FEK_KEY_VERSION_1 indicates the version 1 layout of the KEY_USAGE_FEK key
+	// material buffer. This is the only version currently defined by MS-ADTS.
+	FEK_KEY_VERSION_1 uint8 = 0x01
+)


### PR DESCRIPTION
### Linked Issue
Closes #63

### Motivation
`windows/keycredentiallink/` already defines the `KEY_USAGE_FEK` identifier (in `key/usage`) and the `FekKeyVersion` version byte that lives in `CUSTOM_KEY_INFORMATION` — but the FEK key material buffer itself (MS-ADTS 2.2.20.5.3) has no typed Go representation. Callers handling an FEK-typed `KeyCredentialLink` today have to treat the buffer as opaque bytes.

Per the spec, the buffer is "a combination of RSA 2048 (RFC8017) and AES-256 KDF keys", prefixed by the 1-byte `FekKeyVersion` that MUST be 1.

### What Changed
Adds `windows/keycredentiallink/key/material/fek/`, modeled on the existing `windows/cng/bcrypt/keys/` style (Magic + Header + Content split into sub-packages):

- `magic/FEK_KEY_MATERIAL_VERSION.go` — 1-byte version tag, with `FEK_KEY_VERSION_1 = 0x01` in `magic/magic.go`
- `headers/FEK_KEY_MATERIAL_HEADER.go` — four little-endian `uint32` sizes (`BitLength`, `CbPublicExp`, `CbModulus`, `CbAESKDFKey`) — the same shape as `BCRYPT_RSA_KEY_BLOB` with `CbAESKDFKey` added instead of the RSA primes
- `blob/FEK_KEY_MATERIAL_BLOB.go` — `PublicExponent` (big-endian), `Modulus` (big-endian), `AESKDFKey` (raw bytes)
- `FEK_KEY_MATERIAL.go` — top-level struct combining the three, exposing `Unmarshal`, `Marshal`, `Describe`, `Equal`, and `Fingerprint` (so it can later satisfy the `bcrypt.KeyMaterial` interface)

### Design Notes
- The MS-ADTS page on `KEY_USAGE_FEK` is deliberately brief — it enumerates the two components (RSA 2048, AES-256 KDF) but does not specify a wire layout. This PR picks a size-prefixed layout that matches the style of `BCRYPT_RSA_PUBLIC_KEY` so the package stays internally consistent. If a real-world buffer demands a different split, the header can be extended (extra `uint32` fields) without breaking the existing API.
- `FEK_KEY_MATERIAL.Marshal` always writes `FEK_KEY_VERSION_1` at byte 0, so callers cannot accidentally emit an invalid version.
- `FEK_KEY_MATERIAL.Unmarshal` rejects any version byte other than `0x01`, matching the MUST language of the spec.
- This PR does **not** modify `bcrypt.UnmarshalKeyMaterial` or `KeyCredentialLink.Unmarshal` — integrating FEK into the auto-detection path is a separate change (the existing auto-detection is magic-based and FEK's 1-byte version collides with a normal byte value, so routing would need the `KeyUsage` entry to be consulted first).

### Acceptance Criteria Check
- [x] Package `windows/keycredentiallink/key/material/fek` with `magic`, `headers`, `blob` sub-packages — `windows/keycredentiallink/key/material/fek/**`
- [x] `Unmarshal` rejects version != `0x01` — covered by `TestFEK_KEY_MATERIAL_Unmarshal_InvalidVersion`
- [x] Marshal/Unmarshal roundtrip — covered by `TestFEK_KEY_MATERIAL_MarshalUnmarshalRoundtrip`
- [x] Short-buffer errors at each level — covered by `TestFEK_KEY_MATERIAL_Unmarshal_ShortInput`, `TestFEK_KEY_MATERIAL_HEADER_Unmarshal_ShortInput`, `TestFEK_KEY_MATERIAL_BLOB_Unmarshal_ShortInput_Modulus`, `TestFEK_KEY_MATERIAL_BLOB_Unmarshal_ShortInput_AESKDFKey`, `TestFEK_KEY_MATERIAL_VERSION_Unmarshal_ShortInput`
- [x] `go test ./windows/keycredentiallink/...` passes — all 12 packages `ok`
- [x] `go vet ./windows/keycredentiallink/key/material/...` clean — no output

### How Verified
- `go test ./windows/keycredentiallink/...` — all packages pass, including the four new `fek/**` packages.
- `go vet ./windows/keycredentiallink/key/material/...` — clean.

### Test Coverage
**Added:**
- `windows/keycredentiallink/key/material/fek/FEK_KEY_MATERIAL_test.go` — `TestFEK_KEY_MATERIAL_MarshalUnmarshalRoundtrip`, `TestFEK_KEY_MATERIAL_Unmarshal_ShortInput`, `TestFEK_KEY_MATERIAL_Unmarshal_InvalidVersion`, `TestFEK_KEY_MATERIAL_Marshal_SetsVersion`, `TestFEK_KEY_MATERIAL_Fingerprint_Differs`
- `windows/keycredentiallink/key/material/fek/blob/FEK_KEY_MATERIAL_BLOB_test.go` — `TestFEK_KEY_MATERIAL_BLOB_MarshalUnmarshal`, `TestFEK_KEY_MATERIAL_BLOB_Unmarshal_ShortInput_Modulus`, `TestFEK_KEY_MATERIAL_BLOB_Unmarshal_ShortInput_AESKDFKey`
- `windows/keycredentiallink/key/material/fek/headers/FEK_KEY_MATERIAL_HEADER_test.go` — `TestFEK_KEY_MATERIAL_HEADER_Unmarshal_Marshal`, `TestFEK_KEY_MATERIAL_HEADER_Unmarshal_ShortInput`
- `windows/keycredentiallink/key/material/fek/magic/FEK_KEY_MATERIAL_VERSION_test.go` — `TestFEK_KEY_MATERIAL_VERSION_UnmarshalMarshal`, `TestFEK_KEY_MATERIAL_VERSION_Unmarshal_ShortInput`

### Scope of Change
- **Files changed:** 9 new files under `windows/keycredentiallink/key/material/fek/**` (6 source + 3 test files — plus `magic/magic.go` for the version constant).
- **Submodule pointer updated:** no
- **Public API changes:** additive only — new exported types in a new sub-package. No existing files touched.
- **Behavioral changes outside the stated enhancement:** none.

### Risk and Rollout
Local and additive. No existing package imports the new code yet, so there is no runtime surface change. Safe to merge without staged rollout.