### PR TITLE
[bugfix] Fix little-endian marshalling of SMB1 file-I/O command parameters (#124)

### DIFF
--- a/network/smb/smb_v10/message/commands/CloseRequest.go
+++ b/network/smb/smb_v10/message/commands/CloseRequest.go
@@ -83,7 +83,7 @@ func (c *CloseRequest) Marshal() ([]byte, error) {
 
 	// Marshalling parameter FID
 	buf2 := make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.FID))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.FID))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter LastTimeModified
@@ -147,7 +147,7 @@ func (c *CloseRequest) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for FID")
 	}
-	c.FID = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.FID = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter LastTimeModified

--- a/network/smb/smb_v10/message/commands/NtCreateAndxRequest.go
+++ b/network/smb/smb_v10/message/commands/NtCreateAndxRequest.go
@@ -175,52 +175,52 @@ func (c *NtCreateAndxRequest) Marshal() ([]byte, error) {
 
 	// Marshalling parameter NameLength
 	buf2 := make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.NameLength))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.NameLength))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter Flags
 	buf4 := make([]byte, 4)
-	binary.BigEndian.PutUint32(buf4, uint32(c.Flags))
+	binary.LittleEndian.PutUint32(buf4, uint32(c.Flags))
 	rawParametersContent = append(rawParametersContent, buf4...)
 
 	// Marshalling parameter RootDirectoryFID
 	buf4 = make([]byte, 4)
-	binary.BigEndian.PutUint32(buf4, uint32(c.RootDirectoryFID))
+	binary.LittleEndian.PutUint32(buf4, uint32(c.RootDirectoryFID))
 	rawParametersContent = append(rawParametersContent, buf4...)
 
 	// Marshalling parameter DesiredAccess
 	buf4 = make([]byte, 4)
-	binary.BigEndian.PutUint32(buf4, uint32(c.DesiredAccess))
+	binary.LittleEndian.PutUint32(buf4, uint32(c.DesiredAccess))
 	rawParametersContent = append(rawParametersContent, buf4...)
 
 	// Marshalling parameter AllocationSize
 	buf8 := make([]byte, 8)
-	binary.BigEndian.PutUint64(buf8, uint64(c.AllocationSize.QuadPart))
+	binary.LittleEndian.PutUint64(buf8, uint64(c.AllocationSize.QuadPart))
 	rawParametersContent = append(rawParametersContent, buf8...)
 
 	// Marshalling parameter ExtFileAttributes
 	buf4 = make([]byte, 4)
-	binary.BigEndian.PutUint32(buf4, uint32(c.ExtFileAttributes))
+	binary.LittleEndian.PutUint32(buf4, uint32(c.ExtFileAttributes))
 	rawParametersContent = append(rawParametersContent, buf4...)
 
 	// Marshalling parameter ShareAccess
 	buf4 = make([]byte, 4)
-	binary.BigEndian.PutUint32(buf4, uint32(c.ShareAccess))
+	binary.LittleEndian.PutUint32(buf4, uint32(c.ShareAccess))
 	rawParametersContent = append(rawParametersContent, buf4...)
 
 	// Marshalling parameter CreateDisposition
 	buf4 = make([]byte, 4)
-	binary.BigEndian.PutUint32(buf4, uint32(c.CreateDisposition))
+	binary.LittleEndian.PutUint32(buf4, uint32(c.CreateDisposition))
 	rawParametersContent = append(rawParametersContent, buf4...)
 
 	// Marshalling parameter CreateOptions
 	buf4 = make([]byte, 4)
-	binary.BigEndian.PutUint32(buf4, uint32(c.CreateOptions))
+	binary.LittleEndian.PutUint32(buf4, uint32(c.CreateOptions))
 	rawParametersContent = append(rawParametersContent, buf4...)
 
 	// Marshalling parameter ImpersonationLevel
 	buf4 = make([]byte, 4)
-	binary.BigEndian.PutUint32(buf4, uint32(c.ImpersonationLevel))
+	binary.LittleEndian.PutUint32(buf4, uint32(c.ImpersonationLevel))
 	rawParametersContent = append(rawParametersContent, buf4...)
 
 	// Marshalling parameter SecurityFlags
@@ -290,70 +290,70 @@ func (c *NtCreateAndxRequest) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for NameLength")
 	}
-	c.NameLength = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.NameLength = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter Flags
 	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for Flags")
 	}
-	c.Flags = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	c.Flags = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
 	offset += 4
 
 	// Unmarshalling parameter RootDirectoryFID
 	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for RootDirectoryFID")
 	}
-	c.RootDirectoryFID = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	c.RootDirectoryFID = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
 	offset += 4
 
 	// Unmarshalling parameter DesiredAccess
 	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for DesiredAccess")
 	}
-	c.DesiredAccess = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	c.DesiredAccess = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
 	offset += 4
 
 	// Unmarshalling parameter AllocationSize
 	if len(rawParametersContent) < offset+8 {
 		return offset, fmt.Errorf("rawParametersContent too short for AllocationSize")
 	}
-	c.AllocationSize.QuadPart = uint64(binary.BigEndian.Uint64(rawParametersContent[offset : offset+8]))
+	c.AllocationSize.QuadPart = uint64(binary.LittleEndian.Uint64(rawParametersContent[offset : offset+8]))
 	offset += 8
 
 	// Unmarshalling parameter ExtFileAttributes
 	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for ExtFileAttributes")
 	}
-	c.ExtFileAttributes = types.SMB_EXT_FILE_ATTR(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	c.ExtFileAttributes = types.SMB_EXT_FILE_ATTR(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
 	offset += 4
 
 	// Unmarshalling parameter ShareAccess
 	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for ShareAccess")
 	}
-	c.ShareAccess = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	c.ShareAccess = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
 	offset += 4
 
 	// Unmarshalling parameter CreateDisposition
 	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for CreateDisposition")
 	}
-	c.CreateDisposition = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	c.CreateDisposition = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
 	offset += 4
 
 	// Unmarshalling parameter CreateOptions
 	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for CreateOptions")
 	}
-	c.CreateOptions = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	c.CreateOptions = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
 	offset += 4
 
 	// Unmarshalling parameter ImpersonationLevel
 	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for ImpersonationLevel")
 	}
-	c.ImpersonationLevel = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	c.ImpersonationLevel = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
 	offset += 4
 
 	// Unmarshalling parameter SecurityFlags

--- a/network/smb/smb_v10/message/commands/NtCreateAndxResponse.go
+++ b/network/smb/smb_v10/message/commands/NtCreateAndxResponse.go
@@ -141,12 +141,12 @@ func (c *NtCreateAndxResponse) Marshal() ([]byte, error) {
 
 	// Marshalling parameter FID
 	buf2 := make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.FID))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.FID))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter CreateDisposition
 	buf4 := make([]byte, 4)
-	binary.BigEndian.PutUint32(buf4, uint32(c.CreateDisposition))
+	binary.LittleEndian.PutUint32(buf4, uint32(c.CreateDisposition))
 	rawParametersContent = append(rawParametersContent, buf4...)
 
 	// Marshalling parameter CreateTime
@@ -179,22 +179,22 @@ func (c *NtCreateAndxResponse) Marshal() ([]byte, error) {
 
 	// Marshalling parameter ExtFileAttributes
 	buf4 = make([]byte, 4)
-	binary.BigEndian.PutUint32(buf4, uint32(c.ExtFileAttributes))
+	binary.LittleEndian.PutUint32(buf4, uint32(c.ExtFileAttributes))
 	rawParametersContent = append(rawParametersContent, buf4...)
 
 	// Marshalling parameter AllocationSize
 	buf8 := make([]byte, 8)
-	binary.BigEndian.PutUint64(buf8, uint64(c.AllocationSize.QuadPart))
+	binary.LittleEndian.PutUint64(buf8, uint64(c.AllocationSize.QuadPart))
 	rawParametersContent = append(rawParametersContent, buf8...)
 
 	// Marshalling parameter EndOfFile
 	buf8 = make([]byte, 8)
-	binary.BigEndian.PutUint64(buf8, uint64(c.EndOfFile.QuadPart))
+	binary.LittleEndian.PutUint64(buf8, uint64(c.EndOfFile.QuadPart))
 	rawParametersContent = append(rawParametersContent, buf8...)
 
 	// Marshalling parameter ResourceType
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.ResourceType))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.ResourceType))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter NMPipeStatus
@@ -271,14 +271,14 @@ func (c *NtCreateAndxResponse) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for FID")
 	}
-	c.FID = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.FID = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter CreateDisposition
 	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for CreateDisposition")
 	}
-	c.CreateDisposition = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	c.CreateDisposition = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
 	offset += 4
 
 	// Unmarshalling parameter CreateTime
@@ -325,28 +325,28 @@ func (c *NtCreateAndxResponse) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for ExtFileAttributes")
 	}
-	c.ExtFileAttributes = types.SMB_EXT_FILE_ATTR(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	c.ExtFileAttributes = types.SMB_EXT_FILE_ATTR(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
 	offset += 4
 
 	// Unmarshalling parameter AllocationSize
 	if len(rawParametersContent) < offset+8 {
 		return offset, fmt.Errorf("rawParametersContent too short for AllocationSize")
 	}
-	c.AllocationSize.QuadPart = uint64(binary.BigEndian.Uint64(rawParametersContent[offset : offset+8]))
+	c.AllocationSize.QuadPart = uint64(binary.LittleEndian.Uint64(rawParametersContent[offset : offset+8]))
 	offset += 8
 
 	// Unmarshalling parameter EndOfFile
 	if len(rawParametersContent) < offset+8 {
 		return offset, fmt.Errorf("rawParametersContent too short for EndOfFile")
 	}
-	c.EndOfFile.QuadPart = uint64(binary.BigEndian.Uint64(rawParametersContent[offset : offset+8]))
+	c.EndOfFile.QuadPart = uint64(binary.LittleEndian.Uint64(rawParametersContent[offset : offset+8]))
 	offset += 8
 
 	// Unmarshalling parameter ResourceType
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for ResourceType")
 	}
-	c.ResourceType = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.ResourceType = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter NMPipeStatus

--- a/network/smb/smb_v10/message/commands/ReadAndxRequest.go
+++ b/network/smb/smb_v10/message/commands/ReadAndxRequest.go
@@ -113,32 +113,32 @@ func (c *ReadAndxRequest) Marshal() ([]byte, error) {
 
 	// Marshalling parameter FID
 	buf2 := make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.FID))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.FID))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter Offset
 	buf4 := make([]byte, 4)
-	binary.BigEndian.PutUint32(buf4, uint32(c.Offset))
+	binary.LittleEndian.PutUint32(buf4, uint32(c.Offset))
 	rawParametersContent = append(rawParametersContent, buf4...)
 
 	// Marshalling parameter MaxCountOfBytesToReturn
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.MaxCountOfBytesToReturn))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.MaxCountOfBytesToReturn))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter MinCountOfBytesToReturn
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.MinCountOfBytesToReturn))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.MinCountOfBytesToReturn))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter Timeout
 	buf4 = make([]byte, 4)
-	binary.BigEndian.PutUint32(buf4, uint32(c.Timeout))
+	binary.LittleEndian.PutUint32(buf4, uint32(c.Timeout))
 	rawParametersContent = append(rawParametersContent, buf4...)
 
 	// Marshalling parameter Remaining
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.Remaining))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.Remaining))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameters
@@ -198,42 +198,42 @@ func (c *ReadAndxRequest) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for FID")
 	}
-	c.FID = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.FID = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter Offset
 	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for Offset")
 	}
-	c.Offset = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	c.Offset = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
 	offset += 4
 
 	// Unmarshalling parameter MaxCountOfBytesToReturn
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for MaxCountOfBytesToReturn")
 	}
-	c.MaxCountOfBytesToReturn = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.MaxCountOfBytesToReturn = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter MinCountOfBytesToReturn
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for MinCountOfBytesToReturn")
 	}
-	c.MinCountOfBytesToReturn = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.MinCountOfBytesToReturn = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter Timeout
 	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for Timeout")
 	}
-	c.Timeout = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	c.Timeout = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
 	offset += 4
 
 	// Unmarshalling parameter Remaining
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for Remaining")
 	}
-	c.Remaining = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.Remaining = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Then unmarshal the data

--- a/network/smb/smb_v10/message/commands/ReadAndxResponse.go
+++ b/network/smb/smb_v10/message/commands/ReadAndxResponse.go
@@ -104,27 +104,27 @@ func (c *ReadAndxResponse) Marshal() ([]byte, error) {
 
 	// Marshalling parameter Available
 	buf2 := make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.Available))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.Available))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter DataCompactionMode
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.DataCompactionMode))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.DataCompactionMode))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter Reserved1
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.Reserved1))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.Reserved1))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter DataLength
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.DataLength))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.DataLength))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter DataOffset
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.DataOffset))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.DataOffset))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameters
@@ -184,35 +184,35 @@ func (c *ReadAndxResponse) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for Available")
 	}
-	c.Available = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.Available = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter DataCompactionMode
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for DataCompactionMode")
 	}
-	c.DataCompactionMode = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.DataCompactionMode = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter Reserved1
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for Reserved1")
 	}
-	c.Reserved1 = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.Reserved1 = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter DataLength
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for DataLength")
 	}
-	c.DataLength = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.DataLength = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter DataOffset
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for DataOffset")
 	}
-	c.DataOffset = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.DataOffset = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Then unmarshal the data


### PR DESCRIPTION
### Linked Issue
Closes #124

### Root Cause
The file-I/O command structures were generated with a big-endian default for their multi-byte integer parameter fields. SMB/CIFS is a little-endian protocol: the SMB header and the already-working `TreeConnectAndxRequest`/`SessionSetupAndxRequest` use `binary.LittleEndian`. Because the `parameters` layer is byte-preserving (it reads big-endian into words and re-emits big-endian on the wire), whatever endianness a command struct uses to build its raw parameter bytes is exactly what is transmitted. These commands therefore put big-endian integers on the wire and parse responses as big-endian.

### Fix Description
Switched every `binary.BigEndian` call in the parameter `Marshal()`/`Unmarshal()` paths of the read/open/close commands to `binary.LittleEndian`:
- `NtCreateAndxRequest.go`, `NtCreateAndxResponse.go`
- `ReadAndxRequest.go`, `ReadAndxResponse.go`
- `CloseRequest.go` (FID field)

Scope is limited to the open/read/close path that has been runtime-verified. The `data` block (`ByteCount`) and the SMB header were already little-endian and are untouched.

### How Verified
- **Runtime:** Against a live Samba server (`NT LM 0.12`), the sequence `Negotiate -> SessionSetup -> TreeConnect -> NtCreateAndx -> ReadAndx -> Close` now succeeds and returns correct file contents. With big-endian encoding the create/read parameters (FID, offset, access mask, lengths) were byte-swapped and the server rejected or misread them.
- **Spec:** MS-CIFS defines all SMB integer fields as little-endian.
- **Tests:** `go test ./network/smb/smb_v10/...` passes (marshal/unmarshal round-trips remain symmetric).

### Test Coverage
**Existing:** the package's marshal/unmarshal round-trip tests continue to pass. End-to-end byte-order correctness is exercised by the runtime verification above; a dedicated golden-bytes test is out of scope for this minimal fix.

### Scope of Change
- **Files changed:** `NtCreateAndxRequest.go`, `NtCreateAndxResponse.go`, `ReadAndxRequest.go`, `ReadAndxResponse.go`, `CloseRequest.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Low blast radius: byte order of these five commands only. Safe to merge directly.

### Notes
The same big-endian pattern is latent in ~57 other command files; a separate tracking issue covers them. This PR touches code adjacent to two other fixes (FileName format byte in `NtCreateAndxRequest.go`, `LastTimeModified` size in `CloseRequest.go`) filed as their own issues/PRs; the edits are in non-overlapping regions.
