### PR TITLE
[bugfix] Fix NtCreateAndx FileName to be a raw null-terminated string (#126)

### DIFF
--- a/network/smb/smb_v10/message/commands/NtCreateAndxRequest.go
+++ b/network/smb/smb_v10/message/commands/NtCreateAndxRequest.go
@@ -159,13 +159,13 @@ func (c *NtCreateAndxRequest) Marshal() ([]byte, error) {
 	// the data will be stored in the parameters
 	rawDataContent := []byte{}
 
-	// Marshalling data FileName
-	c.FileName.SetBufferFormat(types.SMB_STRING_BUFFER_FORMAT_NULL_TERMINATED_ASCII_STRING)
-	bytesStream, err := c.FileName.Marshal()
-	if err != nil {
-		return nil, err
-	}
-	rawDataContent = append(rawDataContent, bytesStream...)
+	// Marshalling data FileName.
+	// For SMB_COM_NT_CREATE_ANDX the FileName is a raw null-terminated string and MUST
+	// NOT be prefixed with an SMB_STRING buffer-format byte. Marshalling it through
+	// SMB_STRING (ASCII) would prepend a spurious 0x04 byte, which servers reject with
+	// STATUS_OBJECT_NAME_INVALID.
+	rawDataContent = append(rawDataContent, []byte(c.FileName.Buffer)...)
+	rawDataContent = append(rawDataContent, 0x00)
 
 	// Then marshal the parameters
 	rawParametersContent := []byte{}
@@ -366,12 +366,19 @@ func (c *NtCreateAndxRequest) Unmarshal(data []byte) (int, error) {
 	// Then unmarshal the data
 	offset = 0
 
-	// Unmarshalling data FileName
-	bytesRead, err = c.FileName.Unmarshal(rawDataContent[offset:])
-	if err != nil {
-		return offset, err
+	// Unmarshalling data FileName: a raw null-terminated string with no SMB_STRING
+	// buffer-format byte (mirrors Marshal above).
+	nameBytes := []byte{}
+	for offset < len(rawDataContent) && rawDataContent[offset] != 0x00 {
+		nameBytes = append(nameBytes, rawDataContent[offset])
+		offset++
 	}
-	offset += bytesRead
+	c.FileName.Buffer = []types.UCHAR(nameBytes)
+	c.FileName.Length = types.USHORT(len(nameBytes))
+	if offset < len(rawDataContent) {
+		// Consume the null terminator.
+		offset++
+	}
 
 	return offset, nil
 }


### PR DESCRIPTION
### Linked Issue
Closes #126

### Root Cause
`NtCreateAndxRequest.Marshal` reused `SMB_STRING` (null-terminated ASCII) to encode the `FileName`. `SMB_STRING.Marshal` prepends a buffer-format byte (`0x04`) to the string, which is correct for fields that are defined as `SMB_STRING` with a format prefix, but `SMB_COM_NT_CREATE_ANDX` defines `FileName` as a raw null-terminated OEM/Unicode string with no prefix byte. The spurious `0x04` corrupts the path.

### Fix Description
The `FileName` is now marshalled as its raw buffer bytes followed by a single `0x00` terminator, and unmarshalled by reading up to the null terminator. No buffer-format byte is written. `Unmarshal` is updated symmetrically so the round-trip is preserved.

### How Verified
- **Runtime:** Against a live Samba server, the marshalled data block changed from `0b 00 04 5c 66 69 6c 65 2e 74 78 74 00` (with the bogus `0x04`) to the raw `\file.txt\0`, and `NtCreateAndx` now returns `STATUS_SUCCESS` with a valid FID instead of `STATUS_OBJECT_NAME_INVALID` (0xC0000033).
- **Spec:** MS-CIFS states FileName "MUST be a null-terminated array of extended ASCII (OEM) characters"; `ByteCount` minimum is `0x0002` (one char + terminator) for the non-Unicode case — no format byte.
- **Tests:** `go test ./network/smb/smb_v10/message/commands/` passes.

### Test Coverage
**Existing:** package round-trip tests pass. Wire correctness is confirmed by the runtime verification above.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/NtCreateAndxRequest.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Notes
This change is in a different region of `NtCreateAndxRequest.go` than the little-endian fix in #124/#125, so the two do not overlap. The ASCII (non-Unicode) path is addressed here, matching the client's current behaviour of not setting `SMB_FLAGS2_UNICODE` for this request.
