### PR TITLE
[bugfix] Fix SMB_NMPIPE_STATUS.Unmarshal to accept trailing bytes (#128)

### DIFF
--- a/network/smb/smb_v10/types/SMB_NMPIPE_STATUS.go
+++ b/network/smb/smb_v10/types/SMB_NMPIPE_STATUS.go
@@ -123,8 +123,8 @@ func (s SMB_NMPIPE_STATUS) Marshal() ([]byte, error) {
 // Returns:
 // - The number of bytes unmarshalled
 func (s *SMB_NMPIPE_STATUS) Unmarshal(data []byte) (int, error) {
-	if len(data) != 2 {
-		return 0, fmt.Errorf("data must be 2 bytes long")
+	if len(data) < 2 {
+		return 0, fmt.Errorf("data must be at least 2 bytes long")
 	}
 
 	s.ICount = data[0]

--- a/network/smb/smb_v10/types/SMB_NMPIPE_STATUS_test.go
+++ b/network/smb/smb_v10/types/SMB_NMPIPE_STATUS_test.go
@@ -181,11 +181,13 @@ func TestSMB_NMPIPE_STATUS_Unmarshal(t *testing.T) {
 			expectError: true,
 		},
 		{
-			name:        "Invalid data length (too long)",
+			// A buffer longer than 2 bytes is valid: the field is fixed-size, so only
+			// the first 2 bytes are consumed and the remainder belongs to the caller.
+			name:        "Trailing data after the field",
 			data:        []byte{5, 0x81, 0x00},
-			expected:    types.SMB_NMPIPE_STATUS{},
-			expectedLen: 0,
-			expectError: true,
+			expected:    types.SMB_NMPIPE_STATUS{ICount: 5, Flags: 0x81},
+			expectedLen: 2,
+			expectError: false,
 		},
 	}
 


### PR DESCRIPTION
### Linked Issue
Closes #128

### Root Cause
`SMB_NMPIPE_STATUS.Unmarshal` guarded its input with `len(data) != 2`. The structure is a fixed 2-byte field that is virtually always decoded from the middle of a larger parameter stream (for example, inside `NtCreateAndxResponse`, where it is followed by the `Directory` byte). Treating the field as if it owned the entire buffer made every realistic call fail.

### Fix Description
The guard is changed to `len(data) < 2` (with an updated message): `Unmarshal` now consumes exactly the first 2 bytes and returns `2`, leaving any trailing bytes for the caller to continue parsing. The "too short" case (fewer than 2 bytes) still errors.

### How Verified
- **Runtime:** Parsing a real `NtCreateAndxResponse` (which passes 3 remaining bytes) previously failed with `"data must be 2 bytes long"`; it now parses successfully.
- **Tests:** `go test ./network/smb/smb_v10/types/` passes. The "too long" unit test case is updated to assert the corrected contract (valid, consumes 2 bytes, parses the first two).

### Test Coverage
**Existing (updated):** `TestSMB_NMPIPE_STATUS_Unmarshal` — the former "Invalid data length (too long)" case is replaced with "Trailing data after the field", asserting no error, `expectedLen = 2`, and correct field values. The "too short" error case is retained.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/types/SMB_NMPIPE_STATUS.go`, `network/smb/smb_v10/types/SMB_NMPIPE_STATUS_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none
