### PR TITLE
[bugfix] Fix CloseRequest LastTimeModified to a 4-byte UTIME (#130)

### DIFF
--- a/network/smb/smb_v10/message/commands/CloseRequest.go
+++ b/network/smb/smb_v10/message/commands/CloseRequest.go
@@ -22,10 +22,10 @@ type CloseRequest struct {
 	// The FID of the object to be closed.
 	FID types.USHORT
 
-	// A time value encoded as the number of seconds since January 1, 1970 00:00:00.0. The client can request that the last
-	// modification time for the file be updated to this time value. A value of 0x00000000 or 0xFFFFFFFF results in the server
-	// not updating the last modification time.
-	LastTimeModified types.FILETIME
+	// A time value encoded as the number of seconds since January 1, 1970 00:00:00.0 (a 4-byte UTIME). The client can request
+	// that the last modification time for the file be updated to this time value. A value of 0x00000000 or 0xFFFFFFFF results in
+	// the server not updating the last modification time.
+	LastTimeModified types.ULONG
 }
 
 // NewCloseRequest creates a new CloseRequest structure
@@ -36,7 +36,7 @@ func NewCloseRequest() *CloseRequest {
 	c := &CloseRequest{
 		// Parameters
 		FID:              types.USHORT(0),
-		LastTimeModified: types.FILETIME{},
+		LastTimeModified: types.ULONG(0),
 	}
 
 	c.Command.SetCommandCode(codes.SMB_COM_CLOSE)
@@ -86,12 +86,10 @@ func (c *CloseRequest) Marshal() ([]byte, error) {
 	binary.BigEndian.PutUint16(buf2, uint16(c.FID))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
-	// Marshalling parameter LastTimeModified
-	bytesStream, err := c.LastTimeModified.Marshal()
-	if err != nil {
-		return nil, err
-	}
-	rawParametersContent = append(rawParametersContent, bytesStream...)
+	// Marshalling parameter LastTimeModified (4-byte UTIME, little-endian)
+	buf4 := make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf4, uint32(c.LastTimeModified))
+	rawParametersContent = append(rawParametersContent, buf4...)
 
 	// Marshalling parameters
 	c.GetParameters().AddWordsFromBytesStream(rawParametersContent)
@@ -150,15 +148,12 @@ func (c *CloseRequest) Unmarshal(data []byte) (int, error) {
 	c.FID = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
-	// Unmarshalling parameter LastTimeModified
-	if len(rawParametersContent) < offset+8 {
+	// Unmarshalling parameter LastTimeModified (4-byte UTIME, little-endian)
+	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for LastTimeModified")
 	}
-	bytesRead, err = c.LastTimeModified.Unmarshal(rawParametersContent[offset:])
-	if err != nil {
-		return offset, err
-	}
-	offset += bytesRead
+	c.LastTimeModified = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
+	offset += 4
 
 	// Then unmarshal the data
 	offset = 0


### PR DESCRIPTION
### Linked Issue
Closes #130

### Root Cause
`CloseRequest.LastTimeModified` was modelled with the 8-byte `FILETIME` type, but `SMB_COM_CLOSE` defines the field as a 4-byte `UTIME` (seconds since 1970-01-01). The oversized field produced a `WordCount` of 5 instead of the required 3, making the whole Close request malformed.

### Fix Description
`LastTimeModified` is retyped from `types.FILETIME` to `types.ULONG` (a 4-byte value), and the constructor, `Marshal()`, and `Unmarshal()` are updated to write/read 4 little-endian bytes. The resulting request has the correct `WordCount = 3` (FID + UTIME).

### How Verified
- **Runtime:** Against a live Samba server, the Close request changed from a `WordCount = 5` (FID + 8-byte FILETIME) form, which the server rejected with an `ERRSRV` DOS error (`0x00010002`), to the spec `WordCount = 3` form, which the server accepts.
- **Spec:** MS-CIFS SMB_COM_CLOSE Request: `WordCount MUST be 0x03`, `Words { USHORT FID; UTIME LastTimeModified; }`, with `LastTimeModified` documented as 4 bytes.
- **Tests:** `go test ./network/smb/smb_v10/message/commands/` passes.

### Test Coverage
**Existing:** package round-trip tests pass with the corrected 4-byte field. Wire correctness confirmed by the runtime verification above.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/CloseRequest.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Notes
The new `LastTimeModified` (de)serialization uses little-endian, which is the correct on-the-wire order. The `FID` field on this branch still uses big-endian; that is the separate concern of #124/#125, whose edits touch a different region of this file, so the two changes do not overlap.
