### PR TITLE
[enhancement] Add SMBv1 client file I/O and tree-ID tracking (#132)

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,6 +17,10 @@ var (
 	// Network settings
 	target string
 
+	// Share / file under test
+	shareName string
+	filePath  string
+
 	// Authentication details
 	authDomain   string
 	authUsername string
@@ -38,6 +42,8 @@ func parseArgs() {
 		fmt.Printf("[error] Error creating ArgumentGroup: %s\n", err)
 	} else {
 		subparser_list_group_network.NewStringArgument(&target, "", "--target", "", false, "IP Address of the target host.")
+		subparser_list_group_network.NewStringArgument(&shareName, "", "--share", "share", false, "Name of the share to connect to.")
+		subparser_list_group_network.NewStringArgument(&filePath, "", "--file", "file.txt", false, "Path of the file to read at the share root.")
 	}
 	// Authentication
 	subparser_list_group_auth, err := ap.NewArgumentGroup("Authentication")
@@ -64,6 +70,8 @@ func parseArgs() {
 
 func main() {
 	parseArgs()
+
+	client.FileIODebug = debug
 
 	creds, err := credentials.NewCredentials(authDomain, authUsername, authPassword, authHashes)
 	if err != nil {
@@ -113,11 +121,39 @@ func main() {
 		return
 	}
 
-	err = c.TreeConnect("IPC$")
+	err = c.TreeConnect(shareName)
 	if err != nil {
-		fmt.Printf("[error] Error connecting to IPC$ share: %s\n", err)
+		fmt.Printf("[error] Error connecting to share %q: %s\n", shareName, err)
 		return
 	}
+	fmt.Printf("[info] Connected to share [%s] (TID 0x%04x)\n", shareName, c.Session.TreeID)
 
-	fmt.Printf("[info] Connected to IPC$ share\n")
+	// Open the file at the root of the share for reading.
+	fid, err := c.OpenFile(
+		filePath,
+		client.GENERIC_READ,
+		client.FILE_SHARE_READ|client.FILE_SHARE_WRITE,
+		client.FILE_OPEN,
+		client.FILE_NON_DIRECTORY_FILE,
+	)
+	if err != nil {
+		fmt.Printf("[error] Error opening file %q: %s\n", filePath, err)
+		return
+	}
+	fmt.Printf("[info] Opened file [%s] (FID 0x%04x)\n", filePath, uint16(fid))
+
+	// Read up to 1 MiB from the file.
+	contents, err := c.ReadFile(fid, 0, 1024*1024)
+	if err != nil {
+		fmt.Printf("[error] Error reading file %q: %s\n", filePath, err)
+		_ = c.CloseFile(fid)
+		return
+	}
+	fmt.Printf("[info] Read %d bytes from [%s]\n", len(contents), filePath)
+
+	if err = c.CloseFile(fid); err != nil {
+		fmt.Printf("[warn] Error closing file %q: %s\n", filePath, err)
+	}
+
+	fmt.Printf("----- %s -----\n%s\n----- end -----\n", filePath, string(contents))
 }

--- a/network/smb/smb_v10/client/file.go
+++ b/network/smb/smb_v10/client/file.go
@@ -1,0 +1,254 @@
+package client
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/codes"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header/flags"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header/flags2"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+)
+
+// FID is an opaque file handle returned by the server for an open file or directory.
+type FID uint16
+
+// NT access mask values (subset) used by OpenFile.
+const (
+	GENERIC_READ  uint32 = 0x80000000
+	GENERIC_WRITE uint32 = 0x40000000
+)
+
+// FILE_SHARE_* values for the shareAccess argument of OpenFile.
+const (
+	FILE_SHARE_NONE   uint32 = 0x00000000
+	FILE_SHARE_READ   uint32 = 0x00000001
+	FILE_SHARE_WRITE  uint32 = 0x00000002
+	FILE_SHARE_DELETE uint32 = 0x00000004
+)
+
+// CreateDisposition values for the createDisp argument of OpenFile.
+const (
+	FILE_SUPERSEDE    uint32 = 0x00000000
+	FILE_OPEN         uint32 = 0x00000001
+	FILE_CREATE       uint32 = 0x00000002
+	FILE_OPEN_IF      uint32 = 0x00000003
+	FILE_OVERWRITE    uint32 = 0x00000004
+	FILE_OVERWRITE_IF uint32 = 0x00000005
+)
+
+// CreateOptions values for the createOptions argument of OpenFile.
+const (
+	FILE_DIRECTORY_FILE     uint32 = 0x00000001
+	FILE_NON_DIRECTORY_FILE uint32 = 0x00000040
+)
+
+// FileIODebug, when true, dumps the raw bytes of file-I/O requests and responses
+// to stdout. It is a coarse diagnostic aid until a structured logger is wired in.
+var FileIODebug bool
+
+func fileIODump(label string, data []byte) {
+	if FileIODebug {
+		fmt.Printf("[debug] %s (%d bytes)\n%s\n", label, len(data), hex.Dump(data))
+	}
+}
+
+// newFileIOMessage builds a message pre-populated with the header fields common to
+// every file-I/O command issued on the currently selected tree/session.
+func (c *Client) newFileIOMessage(command codes.CommandCode) *message.Message {
+	msg := message.NewMessage()
+	msg.Header.Command = command
+	msg.Header.Flags = flags.Flags(flags.FLAGS_CANONICALIZED_PATHS | flags.FLAGS_CASE_INSENSITIVE)
+	msg.Header.Flags2 = flags2.Flags2(flags2.FLAGS2_NT_STATUS_ERROR_CODES | flags2.FLAGS2_LONG_NAMES_ALLOWED)
+	msg.Header.SetPID(msg.Header.GetPID())
+	msg.Header.MID = c.Connection.MaxMpxCount
+	msg.Header.TID = c.Session.TreeID
+	msg.Header.UID = c.Session.SessionUID
+	return msg
+}
+
+// sendReceive marshals msg, sends it on the transport, and returns both the parsed
+// response message and the raw response bytes (the raw bytes are needed by callers
+// that index into the message by an absolute offset, e.g. ReadAndx DataOffset).
+func (c *Client) sendReceive(msg *message.Message, label string) (*message.Message, []byte, error) {
+	marshalled, err := msg.Marshal()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to marshal %s: %v", label, err)
+	}
+	fileIODump(label+" request", marshalled)
+
+	if _, err = c.Transport.Send(marshalled); err != nil {
+		return nil, nil, fmt.Errorf("failed to send %s: %v", label, err)
+	}
+
+	raw, err := c.Transport.Receive()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to receive %s response: %v", label, err)
+	}
+	fileIODump(label+" response", raw)
+
+	response := message.NewMessage()
+	if err = response.Unmarshal(raw); err != nil {
+		return nil, nil, fmt.Errorf("failed to unmarshal %s response: %v", label, err)
+	}
+
+	return response, raw, nil
+}
+
+// OpenFile opens (or creates) a file on the currently connected tree and returns
+// the server-assigned FID.
+//
+// Wire: NtCreateAndxRequest / NtCreateAndxResponse.
+func (c *Client) OpenFile(path string, desiredAccess, shareAccess, createDisp, createOptions uint32) (FID, error) {
+	if c.Session == nil {
+		return 0, fmt.Errorf("no session established")
+	}
+
+	// NtCreate FileName is relative to the share root (the TID) and uses backslash separators.
+	smbPath := path
+	if len(smbPath) == 0 || smbPath[0] != '\\' {
+		smbPath = "\\" + smbPath
+	}
+
+	msg := c.newFileIOMessage(codes.SMB_COM_NT_CREATE_ANDX)
+
+	cmd := commands.NewNtCreateAndxRequest()
+	cmd.DesiredAccess = types.ULONG(desiredAccess)
+	cmd.ShareAccess = types.ULONG(shareAccess)
+	cmd.CreateDisposition = types.ULONG(createDisp)
+	cmd.CreateOptions = types.ULONG(createOptions)
+	// SEC_IMPERSONATE (2): give the server a static snapshot of the client's security context.
+	cmd.ImpersonationLevel = types.ULONG(0x00000002)
+	// FILE_ATTRIBUTE_NORMAL
+	cmd.ExtFileAttributes = types.SMB_EXT_FILE_ATTR(0x00000080)
+	if err := cmd.FileName.SetString(smbPath); err != nil {
+		return 0, fmt.Errorf("failed to set file name: %v", err)
+	}
+	cmd.NameLength = types.USHORT(len(smbPath))
+
+	msg.AddCommand(cmd)
+
+	response, _, err := c.sendReceive(msg, "NtCreateAndx")
+	if err != nil {
+		return 0, err
+	}
+
+	if response.Header.Status != 0x00000000 {
+		return 0, fmt.Errorf("NtCreateAndx failed: 0x%08x", response.Header.Status)
+	}
+
+	createResponse, ok := response.Command.(*commands.NtCreateAndxResponse)
+	if !ok {
+		return 0, fmt.Errorf("unexpected response command: 0x%02x", response.Header.Command)
+	}
+
+	return FID(createResponse.FID), nil
+}
+
+// CloseFile releases an open FID on the server.
+//
+// Wire: CloseRequest / CloseResponse.
+func (c *Client) CloseFile(fid FID) error {
+	if c.Session == nil {
+		return fmt.Errorf("no session established")
+	}
+
+	msg := c.newFileIOMessage(codes.SMB_COM_CLOSE)
+
+	cmd := commands.NewCloseRequest()
+	cmd.FID = types.USHORT(fid)
+	// LastTimeModified left at zero: the server uses its own default and does not
+	// apply an explicit modification time on close.
+
+	msg.AddCommand(cmd)
+
+	response, _, err := c.sendReceive(msg, "Close")
+	if err != nil {
+		return err
+	}
+
+	if response.Header.Status != 0x00000000 {
+		return fmt.Errorf("Close failed: 0x%08x", response.Header.Status)
+	}
+
+	return nil
+}
+
+// ReadFile reads up to maxLen bytes starting at offset from the file referenced by
+// fid. It issues as many ReadAndx requests as required, stopping at maxLen or at the
+// first short read (end of file).
+//
+// Wire: ReadAndxRequest / ReadAndxResponse.
+func (c *Client) ReadFile(fid FID, offset uint64, maxLen uint32) ([]byte, error) {
+	if c.Session == nil {
+		return nil, fmt.Errorf("no session established")
+	}
+
+	// Bound each read by what the server will accept in a single response. Leave room
+	// for the SMB header and the ReadAndx parameter/data framing.
+	chunkSize := uint32(0xFF00)
+	if c.Connection.Server != nil && c.Connection.Server.MaxBufferSize > 0 {
+		if budget := c.Connection.Server.MaxBufferSize; budget < chunkSize+512 {
+			if budget <= 512 {
+				return nil, fmt.Errorf("negotiated MaxBufferSize (%d) too small to read", budget)
+			}
+			chunkSize = budget - 512
+		}
+	}
+
+	result := make([]byte, 0, maxLen)
+
+	for uint32(len(result)) < maxLen {
+		want := maxLen - uint32(len(result))
+		if want > chunkSize {
+			want = chunkSize
+		}
+
+		msg := c.newFileIOMessage(codes.SMB_COM_READ_ANDX)
+
+		cmd := commands.NewReadAndxRequest()
+		cmd.FID = types.USHORT(fid)
+		cmd.Offset = types.ULONG(uint32(offset + uint64(len(result))))
+		cmd.MaxCountOfBytesToReturn = types.USHORT(want)
+		cmd.MinCountOfBytesToReturn = types.USHORT(0)
+		cmd.Timeout = types.ULONG(0)
+		cmd.Remaining = types.USHORT(0)
+
+		msg.AddCommand(cmd)
+
+		response, raw, err := c.sendReceive(msg, "ReadAndx")
+		if err != nil {
+			return result, err
+		}
+
+		if response.Header.Status != 0x00000000 {
+			return result, fmt.Errorf("ReadAndx failed: 0x%08x", response.Header.Status)
+		}
+
+		readResponse, ok := response.Command.(*commands.ReadAndxResponse)
+		if !ok {
+			return result, fmt.Errorf("unexpected response command: 0x%02x", response.Header.Command)
+		}
+
+		dataLen := int(readResponse.DataLength)
+		dataOff := int(readResponse.DataOffset)
+		if dataLen == 0 {
+			// End of file reached.
+			break
+		}
+		if dataOff < 0 || dataOff+dataLen > len(raw) {
+			return result, fmt.Errorf("ReadAndx data window [%d:%d] out of bounds (response is %d bytes)", dataOff, dataOff+dataLen, len(raw))
+		}
+
+		result = append(result, raw[dataOff:dataOff+dataLen]...)
+
+		// A short read means we have reached the end of the file.
+		if uint32(dataLen) < want {
+			break
+		}
+	}
+
+	return result, nil
+}

--- a/network/smb/smb_v10/client/session.go
+++ b/network/smb/smb_v10/client/session.go
@@ -29,6 +29,10 @@ type Session struct {
 	// The 2-byte UID for this session
 	SessionUID uint16
 
+	// TreeID is the TID of the tree connect currently selected for outbound
+	// commands (file I/O, etc.). It is populated by Client.TreeConnect.
+	TreeID uint16
+
 	// The credentials for this session
 	Credentials *credentials.Credentials
 }

--- a/network/smb/smb_v10/client/tree.go
+++ b/network/smb/smb_v10/client/tree.go
@@ -79,5 +79,10 @@ func (c *Client) TreeConnect(shareName string) error {
 	}
 	c.Connection.TreeConnectTable[response_msg.Header.TID] = tree_connect_response_cmd
 
+	// Select this tree as the current one for subsequent commands (file I/O, etc.).
+	if c.Session != nil {
+		c.Session.TreeID = response_msg.Header.TID
+	}
+
 	return nil
 }


### PR DESCRIPTION
### Linked Issue
Closes #132

### Motivation
The SMBv1 client could negotiate, authenticate, and tree-connect but could not open or read a file, blocking every byte-moving shell command. This adds the P0 file-I/O glue from `prereqs.md`.

### What Changed
- **New `network/smb/smb_v10/client/file.go`:**
  - `type FID uint16`.
  - `OpenFile(path, desiredAccess, shareAccess, createDisp, createOptions)` builds an `NtCreateAndx`, sends it on the selected tree, and returns the server FID.
  - `ReadFile(fid, offset, maxLen)` issues `ReadAndx` requests in a loop bounded by the negotiated `MaxBufferSize`, reassembling data sliced by the response `DataOffset`, and stops at `maxLen` or the first short read (EOF).
  - `CloseFile(fid)` sends `Close`.
  - Helper `newFileIOMessage` (shared header setup), `sendReceive` (marshal/send/receive/parse, returning raw bytes for offset indexing), and a `FileIODebug` hex-dump switch.
  - Exported `GENERIC_READ/WRITE`, `FILE_SHARE_*`, `FILE_OPEN`/disposition, and `FILE_*_FILE` create-option constants.
- **`session.go`:** new `Session.TreeID` field (the currently selected tree's TID).
- **`tree.go`:** `TreeConnect` now records the assigned TID on the session.
- **`main.go`:** demonstrates connect -> tree-connect a named share -> open/read/close a file -> print contents; adds `--share` and `--file` flags and wires `--debug` to `FileIODebug`.

### Design Notes
- "Current tree" is a single TID on the session, matching `plan.md` (the shell holds one tree at a time); per-call TID routing is intentionally not introduced yet.
- `ReadFile` indexes file data by the response `DataOffset` against the raw message bytes rather than trusting the parsed data block, which avoids any inter-field padding.
- The request uses OEM (non-Unicode) paths, consistent with the existing `TreeConnect` behaviour.

### Acceptance Criteria Check
- `OpenFile`/`ReadFile`/`CloseFile` exist and compile — `file.go`.
- `TreeConnect` records the TID and file-I/O sends it — `tree.go` (`Session.TreeID = ...`), `file.go` (`newFileIOMessage` sets `Header.TID`).
- Live read of a file at the share root, closed cleanly — verified (see below).
- `go build ./...` and `go test ./network/smb/smb_v10/...` pass.

### How Verified
- **Runtime:** With the wire-format fixes (#124, #126, #128, #130) applied, run against a live Samba server reads the full contents of `file.txt` at the share root and closes the handle with no error.
- **Tests:** `go build ./...`, `go vet ./network/smb/smb_v10/client/`, and `go test ./network/smb/smb_v10/...` all pass.

### Test Coverage
**None (glue + demo):** this PR is high-level client glue plus a `main.go` demonstrator; behaviour is exercised end-to-end against a real server. Unit coverage with a fake transport is a sensible follow-up but is out of scope here.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/client/file.go` (new), `network/smb/smb_v10/client/session.go`, `network/smb/smb_v10/client/tree.go`, `main.go`
- **Submodule pointer updated:** no
- **Public API changes:** additive — new `Client` methods, `FID`, constants, and `Session.TreeID`. No breaking changes.
- **Behavioral changes outside the stated enhancement:** none

### Notes
End-to-end success depends on #124/#126/#128/#130 being merged; this branch compiles independently and contains none of those fixes.
