### PR TITLE
[bugfix] Fix little-endian marshalling of WriteAndx command parameters (#135)

### DIFF
--- a/network/smb/smb_v10/message/commands/WriteAndxRequest.go
+++ b/network/smb/smb_v10/message/commands/WriteAndxRequest.go
@@ -151,48 +151,48 @@ func (c *WriteAndxRequest) Marshal() ([]byte, error) {
 
 	// Marshalling parameter FID
 	buf2 := make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.FID))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.FID))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter Offset
 	buf4 := make([]byte, 4)
-	binary.BigEndian.PutUint32(buf4, uint32(c.Offset))
+	binary.LittleEndian.PutUint32(buf4, uint32(c.Offset))
 	rawParametersContent = append(rawParametersContent, buf4...)
 
 	// Marshalling parameter Timeout
 	buf4 = make([]byte, 4)
-	binary.BigEndian.PutUint32(buf4, uint32(c.Timeout))
+	binary.LittleEndian.PutUint32(buf4, uint32(c.Timeout))
 	rawParametersContent = append(rawParametersContent, buf4...)
 
 	// Marshalling parameter WriteMode
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.WriteMode))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.WriteMode))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter Remaining
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.Remaining))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.Remaining))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter Reserved
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.Reserved))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.Reserved))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter DataLength
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.DataLength))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.DataLength))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter DataOffset
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.DataOffset))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.DataOffset))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter OffsetHigh
 	if c.OffsetHigh != 0 {
 		buf4 = make([]byte, 4)
-		binary.BigEndian.PutUint32(buf4, uint32(c.OffsetHigh))
+		binary.LittleEndian.PutUint32(buf4, uint32(c.OffsetHigh))
 		rawParametersContent = append(rawParametersContent, buf4...)
 	}
 
@@ -253,56 +253,56 @@ func (c *WriteAndxRequest) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for FID")
 	}
-	c.FID = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.FID = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter Offset
 	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for Offset")
 	}
-	c.Offset = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	c.Offset = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
 	offset += 4
 
 	// Unmarshalling parameter Timeout
 	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for Timeout")
 	}
-	c.Timeout = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	c.Timeout = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
 	offset += 4
 
 	// Unmarshalling parameter WriteMode
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for WriteMode")
 	}
-	c.WriteMode = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.WriteMode = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter Remaining
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for Remaining")
 	}
-	c.Remaining = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.Remaining = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter Reserved
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for Reserved")
 	}
-	c.Reserved = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.Reserved = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter DataLength
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for DataLength")
 	}
-	c.DataLength = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.DataLength = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter DataOffset
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for DataOffset")
 	}
-	c.DataOffset = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.DataOffset = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter OffsetHigh
@@ -310,7 +310,7 @@ func (c *WriteAndxRequest) Unmarshal(data []byte) (int, error) {
 		if len(rawParametersContent) < offset+4 {
 			return offset, fmt.Errorf("rawParametersContent too short for OffsetHigh")
 		}
-		c.OffsetHigh = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+		c.OffsetHigh = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
 		offset += 4
 	}
 

--- a/network/smb/smb_v10/message/commands/WriteAndxResponse.go
+++ b/network/smb/smb_v10/message/commands/WriteAndxResponse.go
@@ -93,17 +93,17 @@ func (c *WriteAndxResponse) Marshal() ([]byte, error) {
 
 	// Marshalling parameter Count
 	buf2 := make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.Count))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.Count))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter Available
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.Available))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.Available))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter Reserved
 	buf4 := make([]byte, 4)
-	binary.BigEndian.PutUint32(buf4, uint32(c.Reserved))
+	binary.LittleEndian.PutUint32(buf4, uint32(c.Reserved))
 	rawParametersContent = append(rawParametersContent, buf4...)
 
 	// Marshalling parameters
@@ -163,21 +163,21 @@ func (c *WriteAndxResponse) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for Count")
 	}
-	c.Count = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.Count = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter Available
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for Available")
 	}
-	c.Available = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.Available = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter Reserved
 	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for Reserved")
 	}
-	c.Reserved = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	c.Reserved = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
 	offset += 4
 
 	// Then unmarshal the data


### PR DESCRIPTION
### Linked Issue
Closes #135

### Root Cause
`WriteAndxRequest` and `WriteAndxResponse` were generated with a big-endian default for their multi-byte integer parameter fields. SMB/CIFS is little-endian, and the `parameters` layer is byte-preserving, so the endianness the struct uses to build its raw parameter bytes is exactly what is transmitted. The write commands therefore put big-endian FID/Offset/DataLength/DataOffset (and parse a big-endian bytes-written `Count`) on the wire.

### Fix Description
Switched every `binary.BigEndian` call in the parameter `Marshal()`/`Unmarshal()` paths of `WriteAndxRequest.go` and `WriteAndxResponse.go` to `binary.LittleEndian`. This mirrors the fix already applied to the read/open/close path in #124. No field order, sizes, or `WordCount`/`ByteCount` logic changed.

### How Verified
- **Runtime:** Against a live Samba server (`NT LM 0.12`), a `WriteAndx` write followed by a read-back returns byte-identical content — both a small single-request write and a multi-request write of 9003 bytes (larger than the negotiated `MaxBufferSize` of 4356), which exercises chunking.
- **Spec:** MS-CIFS SMB_COM_WRITE_ANDX Request/Response — all integer fields are little-endian.
- **Tests:** `go test ./network/smb/smb_v10/...` passes (round-trips remain symmetric).

### Test Coverage
**Existing:** package marshal/unmarshal round-trip tests continue to pass. Byte-order correctness is exercised by the runtime write+read-back verification above.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/WriteAndxRequest.go`, `network/smb/smb_v10/message/commands/WriteAndxResponse.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Low blast radius: byte order of the two write commands only. Safe to merge directly.

### Notes
One runtime-verified instance of the systemic big-endian defect tracked in #134; same fix shape as #124. The `WriteFile` client method that exercises these commands is submitted separately as an enhancement.
