### PR TITLE
[enhancement] Add SMBv1 client WriteFile (file write path) (#137)

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,8 +18,9 @@ var (
 	target string
 
 	// Share / file under test
-	shareName string
-	filePath  string
+	shareName    string
+	filePath     string
+	writeContent string
 
 	// Authentication details
 	authDomain   string
@@ -44,6 +45,7 @@ func parseArgs() {
 		subparser_list_group_network.NewStringArgument(&target, "", "--target", "", false, "IP Address of the target host.")
 		subparser_list_group_network.NewStringArgument(&shareName, "", "--share", "share", false, "Name of the share to connect to.")
 		subparser_list_group_network.NewStringArgument(&filePath, "", "--file", "file.txt", false, "Path of the file to read at the share root.")
+		subparser_list_group_network.NewStringArgument(&writeContent, "", "--write", "", false, "If set, write this content to --file (create/overwrite) before reading it back.")
 	}
 	// Authentication
 	subparser_list_group_auth, err := ap.NewArgumentGroup("Authentication")
@@ -127,6 +129,31 @@ func main() {
 		return
 	}
 	fmt.Printf("[info] Connected to share [%s] (TID 0x%04x)\n", shareName, c.Session.TreeID)
+
+	// Optionally write content to the file first (creating or overwriting it).
+	if writeContent != "" {
+		wfid, err := c.OpenFile(
+			filePath,
+			client.GENERIC_READ|client.GENERIC_WRITE,
+			client.FILE_SHARE_READ|client.FILE_SHARE_WRITE,
+			client.FILE_OVERWRITE_IF,
+			client.FILE_NON_DIRECTORY_FILE,
+		)
+		if err != nil {
+			fmt.Printf("[error] Error opening file %q for write: %s\n", filePath, err)
+			return
+		}
+		n, err := c.WriteFile(wfid, 0, []byte(writeContent))
+		if err != nil {
+			fmt.Printf("[error] Error writing file %q: %s\n", filePath, err)
+			_ = c.CloseFile(wfid)
+			return
+		}
+		fmt.Printf("[info] Wrote %d bytes to [%s]\n", n, filePath)
+		if err = c.CloseFile(wfid); err != nil {
+			fmt.Printf("[warn] Error closing file %q after write: %s\n", filePath, err)
+		}
+	}
 
 	// Open the file at the root of the share for reading.
 	fid, err := c.OpenFile(

--- a/network/smb/smb_v10/client/file.go
+++ b/network/smb/smb_v10/client/file.go
@@ -7,9 +7,23 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/codes"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header/flags"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header/flags2"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+)
+
+const (
+	// writeAndxWordsSize is the size in bytes of the WriteAndx request Words block
+	// for the 32-bit-offset form (WordCount 0x0C, no OffsetHigh): AndX(4) + FID(2) +
+	// Offset(4) + Timeout(4) + WriteMode(2) + Remaining(2) + Reserved(2) + DataLength(2)
+	// + DataOffset(2).
+	writeAndxWordsSize = 24
+
+	// writeAndxDataOffset is the byte offset, measured from the start of the SMB
+	// header, at which the Data block begins in our single (non-chained) WriteAndx
+	// request: SMB header + WordCount(1) + Words + ByteCount(2) + Pad(1).
+	writeAndxDataOffset = header.SMB_HEADER_SIZE + 1 + writeAndxWordsSize + 2 + 1
 )
 
 // FID is an opaque file handle returned by the server for an open file or directory.
@@ -251,4 +265,80 @@ func (c *Client) ReadFile(fid FID, offset uint64, maxLen uint32) ([]byte, error)
 	}
 
 	return result, nil
+}
+
+// WriteFile writes data to the file referenced by fid starting at offset and
+// returns the total number of bytes written. It issues as many WriteAndx requests
+// as required, bounding each one so the request message stays within the negotiated
+// MaxBufferSize.
+//
+// Wire: WriteAndxRequest / WriteAndxResponse.
+func (c *Client) WriteFile(fid FID, offset uint64, data []byte) (int, error) {
+	if c.Session == nil {
+		return 0, fmt.Errorf("no session established")
+	}
+
+	// Each request carries: SMB header + WriteAndx parameters + Pad + Data. Keep the
+	// whole message within the negotiated buffer by reserving the fixed overhead.
+	chunkSize := 0xFF00
+	if c.Connection.Server != nil && c.Connection.Server.MaxBufferSize > 0 {
+		budget := int(c.Connection.Server.MaxBufferSize) - writeAndxDataOffset
+		if budget <= 0 {
+			return 0, fmt.Errorf("negotiated MaxBufferSize (%d) too small to write", c.Connection.Server.MaxBufferSize)
+		}
+		if budget < chunkSize {
+			chunkSize = budget
+		}
+	}
+
+	written := 0
+	for written < len(data) {
+		end := written + chunkSize
+		if end > len(data) {
+			end = len(data)
+		}
+		chunk := data[written:end]
+
+		msg := c.newFileIOMessage(codes.SMB_COM_WRITE_ANDX)
+
+		cmd := commands.NewWriteAndxRequest()
+		cmd.FID = types.USHORT(fid)
+		cmd.Offset = types.ULONG(uint32(offset + uint64(written)))
+		cmd.Timeout = types.ULONG(0)
+		cmd.WriteMode = types.USHORT(0)
+		cmd.Remaining = types.USHORT(0)
+		cmd.Reserved = types.USHORT(0)
+		cmd.DataLength = types.USHORT(len(chunk))
+		// DataOffset is measured from the start of the SMB header (not from the AndX
+		// command's position), so it is a fixed value for our single-command layout.
+		cmd.DataOffset = types.USHORT(writeAndxDataOffset)
+		cmd.OffsetHigh = types.ULONG(0)
+		cmd.Pad = types.UCHAR(0)
+		cmd.Data = []types.UCHAR(chunk)
+
+		msg.AddCommand(cmd)
+
+		response, _, err := c.sendReceive(msg, "WriteAndx")
+		if err != nil {
+			return written, err
+		}
+
+		if response.Header.Status != 0x00000000 {
+			return written, fmt.Errorf("WriteAndx failed: 0x%08x", response.Header.Status)
+		}
+
+		writeResponse, ok := response.Command.(*commands.WriteAndxResponse)
+		if !ok {
+			return written, fmt.Errorf("unexpected response command: 0x%02x", response.Header.Command)
+		}
+
+		n := int(writeResponse.Count)
+		if n <= 0 {
+			return written, fmt.Errorf("server accepted 0 bytes of a %d-byte write", len(chunk))
+		}
+
+		written += n
+	}
+
+	return written, nil
 }


### PR DESCRIPTION
### Linked Issue
Closes #137

### Motivation
Completes the P0 file-I/O surface by adding the write primitive. With `OpenFile`/`ReadFile`/`CloseFile` already present (#133), `WriteFile` unblocks `put`-style operations.

### What Changed
- **`network/smb/smb_v10/client/file.go`:** new `Client.WriteFile(fid FID, offset uint64, data []byte) (int, error)`. It loops over `data`, sending one `WriteAndx` per chunk, bounding each chunk by `MaxBufferSize` minus the fixed request overhead, reads the bytes-written `Count` from each response, and advances by what the server accepted. Two named constants (`writeAndxWordsSize`, `writeAndxDataOffset`) document the request layout.
- **`main.go`:** new `--write <content>` flag. When set, the demo opens `--file` with `GENERIC_READ|GENERIC_WRITE` + `FILE_OVERWRITE_IF`, writes the content, closes, then reads it back. Defaults off, so normal runs remain read-only.

### Design Notes
- `WriteAndx.DataOffset` is the offset of the payload **from the start of the SMB header** (per MS-CIFS), independent of any AndX chaining. For our single-command request that is a fixed `header(32) + WordCount(1) + Words(24) + ByteCount(2) + Pad(1) = 60`, expressed as a constant rather than a magic number.
- Uses the 32-bit-offset (`WordCount 0x0C`) form, so writes target offsets below 4 GiB — same limitation as `ReadFile`; the 64-bit `OffsetHigh`/`0x0E` form is a later addition.

### Acceptance Criteria Check
- `Client.WriteFile` exists and compiles — `file.go`.
- Write + read-back returns identical bytes for single- and multi-request writes — verified (below).
- `go build ./...` and `go test ./network/smb/smb_v10/...` pass.

### How Verified
- **Runtime (live Samba):** `--write` of a 39-byte string → "Wrote 39 bytes" → read-back identical. A 9003-byte write (> the 4356-byte `MaxBufferSize`, ~3 `WriteAndx` requests) → "Wrote 9003 bytes" → read-back 9003 bytes intact.
- **Build/tests:** `go build ./...`, `go vet ./network/smb/smb_v10/client/`, `go test ./network/smb/smb_v10/...` all pass.

### Test Coverage
**None (glue + demo):** high-level client glue plus a `main.go` demonstrator, exercised end-to-end against a real server. Fake-transport unit coverage is a sensible follow-up, out of scope here.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/client/file.go`, `main.go`
- **Submodule pointer updated:** no
- **Public API changes:** additive — new `Client.WriteFile` method. No breaking changes.
- **Behavioral changes outside the stated enhancement:** none

### Risk and Rollout
Additive client method plus an opt-in demo flag. Low risk.

### Notes
The file-I/O glue this builds on (#133) is already merged to `main`, so this PR targets `main` directly. End-to-end writes also require the WriteAndx little-endian fix in #135/#136 (open).