### PR TITLE
[bugfix] Fix EchoRequest EchoCount marshalled big-endian instead of little-endian (#141)

### DIFF
--- a/network/smb/smb_v10/message/commands/EchoRequest.go
+++ b/network/smb/smb_v10/message/commands/EchoRequest.go
@@ -88,7 +88,7 @@ func (c *EchoRequest) Marshal() ([]byte, error) {
 
 	// Marshalling parameter EchoCount
 	buf2 := make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.EchoCount))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.EchoCount))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameters
@@ -145,7 +145,7 @@ func (c *EchoRequest) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for EchoCount")
 	}
-	c.EchoCount = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.EchoCount = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Then unmarshal the data


### PR DESCRIPTION
### Linked Issue
Closes #141

### Root Cause
The generated `EchoRequest` command serialized its `EchoCount` USHORT with `binary.BigEndian`. SMB/CIFS wire integers are little-endian, and the `parameters` layer is byte-preserving, so the big-endian bytes were transmitted unchanged. The defect was masked because `Marshal`/`Unmarshal` are symmetric, so round-trip unit tests pass regardless of endianness. This is one instance of the systemic big-endian defect class tracked in #134.

### Fix Description
Switched both the marshalling (L91) and unmarshalling (L148) of `EchoCount` from `binary.BigEndian` to `binary.LittleEndian`, matching the [MS-CIFS SMB_COM_ECHO Request](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/5dd916b2-9c38-4f0c-ba55-a2c86dd5de10) wire format. WordCount, ByteCount, field order, and the raw `Data` byte handling were already correct and are unchanged.

### How Verified
- Static: `EchoCount` now emits/reads little-endian, conforming to the spec; symmetry preserved.
- Tests: `go test ./network/smb/smb_v10/message/commands/` passes.
- `go vet` clean for the package.

### Test Coverage
**Existing:** the package's existing round-trip tests for `EchoRequest` continue to pass after the fix.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/EchoRequest.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local, two-line endianness correction confined to one command. Safe to merge.