### PR TITLE
[bugfix] Fix CreateResponse FID marshalling to little-endian (#142)

### DIFF
--- a/network/smb/smb_v10/message/commands/CreateResponse.go
+++ b/network/smb/smb_v10/message/commands/CreateResponse.go
@@ -77,7 +77,7 @@ func (c *CreateResponse) Marshal() ([]byte, error) {
 
 	// Marshalling parameter FID
 	buf2 := make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.FID))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.FID))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameters
@@ -134,7 +134,7 @@ func (c *CreateResponse) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for FID")
 	}
-	c.FID = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.FID = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Then unmarshal the data


### PR DESCRIPTION
### Linked Issue
`Closes #142`

### Root Cause
`CreateResponse.go` was generated with `binary.BigEndian` for its 2-byte `FID` parameter and was never exercised against a live server. SMB/CIFS encodes all integer fields little-endian on the wire, and the package's `parameters` layer is byte-preserving, so the byte order the struct writes is exactly what is transmitted. The big-endian encoding therefore swapped the FID bytes on the wire.

### Fix Description
Switched both the marshal and unmarshal of the `FID` field from `binary.BigEndian` to `binary.LittleEndian`, matching the MS-CIFS SMB_COM_CREATE Response wire format and the hand-corrected sibling commands (`TreeConnectAndxRequest`, `SessionSetupAndxRequest`). Marshal/Unmarshal remain symmetric.

### How Verified
- **Static:** Cross-checked against [MS-CIFS SMB_COM_CREATE Response](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/c11c97ae-e5ea-48c0-aeec-2d3012b440e2): `SMB_Parameters { UCHAR WordCount=0x01; Words { USHORT FID } }`, `SMB_Data { USHORT ByteCount=0x0000 }`. A FID such as 0x0102 now emits little-endian bytes `02 01` instead of `01 02`.
- **Build/Test:** `go build ./...` and `go test ./network/smb/smb_v10/message/commands/` both pass.

### Test Coverage
**Existing:** Existing round-trip tests in the commands package continue to pass. They are symmetric and do not assert wire byte order, so they neither caught nor regress with this change; correctness is established against the spec.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/CreateResponse.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local, two-line change to a single command's wire encoding. Safe to merge without staged rollout.

### Notes
Part of tracking issue #134 (SMB command parameters marshalled big-endian across remaining command files).
