### PR TITLE
[bugfix] Fix CreateTemporaryResponse FID marshalled big-endian (#150)

### DIFF
--- a/network/smb/smb_v10/message/commands/CreateTemporaryResponse.go
+++ b/network/smb/smb_v10/message/commands/CreateTemporaryResponse.go
@@ -94,7 +94,7 @@ func (c *CreateTemporaryResponse) Marshal() ([]byte, error) {
 
 	// Marshalling parameter FID
 	buf2 := make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.FID))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.FID))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameters
@@ -151,7 +151,7 @@ func (c *CreateTemporaryResponse) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for FID")
 	}
-	c.FID = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.FID = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Then unmarshal the data


### PR DESCRIPTION
### Linked Issue
`Closes #150`

### Root Cause
`CreateTemporaryResponse` was generated with a big-endian default for its integer parameter, so `Marshal`/`Unmarshal` used `binary.BigEndian` for the 2-byte `FID`. The `parameters` layer is byte-preserving, so the big-endian bytes reach the wire directly. MS-CIFS specifies all SMB integer fields as little-endian, so the FID's two bytes were swapped relative to what a real server expects.

### Fix Description
Switched the `FID` field to `binary.LittleEndian` in both `Marshal()` (L97) and `Unmarshal()` (L154), matching the SMB header and the previously hand-corrected commands (e.g. `CloseRequest`, fixed in #124). No other fields changed; `Marshal`/`Unmarshal` remain symmetric.

### How Verified
- Static: the only integer parameter is `FID` (`WordCount = 0x01`, single `USHORT`); both sites now use little-endian per MS-CIFS SMB_COM_CREATE_TEMPORARY Response (https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/763af5c5-74bf-43c6-b410-e48c79b08f57).
- Build: `go build ./network/smb/smb_v10/...` succeeds.
- Tests: `go test ./network/smb/smb_v10/message/commands/` passes.

### Test Coverage
**Existing:** existing round-trip tests in the commands package pass. (Round-trip tests are symmetric and cannot detect endianness on their own; correctness is established against the spec, which fixes the absolute byte order.)

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/CreateTemporaryResponse.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Notes
Part of the systemic big-endian defect tracked in #134. The `TemporaryFileName` data block is emitted via `SMB_STRING` with a `0x04` buffer-format prefix byte, whereas the spec's data block is a raw null-terminated string (`UCHAR TemporaryFileName[ByteCount]`); that concern lives in the shared `SMB_STRING` type and is out of scope for this single-field fix.