### PR TITLE
[bugfix] Fix CreateTemporaryRequest CreationTime to 4-byte UTIME (#146)

### DIFF
--- a/network/smb/smb_v10/message/commands/CreateTemporaryRequest.go
+++ b/network/smb/smb_v10/message/commands/CreateTemporaryRequest.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"encoding/binary"
 	"fmt"
 
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/andx"
@@ -21,8 +22,8 @@ type CreateTemporaryRequest struct {
 	// This field SHOULD be ignored by the server.
 	FileAttributes types.SMB_FILE_ATTRIBUTES
 
-	// The time that the file was created, represented as the number of seconds since Jan 1, 1970, 00:00:00.0.
-	CreationTime types.FILETIME
+	// The time that the file was created, represented as the number of seconds since Jan 1, 1970, 00:00:00.0 (a 4-byte UTIME).
+	CreationTime types.ULONG
 
 	// Data
 
@@ -38,7 +39,7 @@ func NewCreateTemporaryRequest() *CreateTemporaryRequest {
 	c := &CreateTemporaryRequest{
 		// Parameters
 		FileAttributes: types.SMB_FILE_ATTRIBUTES{},
-		CreationTime:   types.FILETIME{},
+		CreationTime:   types.ULONG(0),
 
 		// Data
 		DirectoryName: types.SMB_STRING{},
@@ -101,12 +102,10 @@ func (c *CreateTemporaryRequest) Marshal() ([]byte, error) {
 	}
 	rawParametersContent = append(rawParametersContent, bytesStream...)
 
-	// Marshalling parameter CreationTime
-	bytesStream, err = c.CreationTime.Marshal()
-	if err != nil {
-		return nil, err
-	}
-	rawParametersContent = append(rawParametersContent, bytesStream...)
+	// Marshalling parameter CreationTime (4-byte UTIME, little-endian)
+	buf4 := make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf4, uint32(c.CreationTime))
+	rawParametersContent = append(rawParametersContent, buf4...)
 
 	// Marshalling parameters
 	c.GetParameters().AddWordsFromBytesStream(rawParametersContent)
@@ -165,15 +164,12 @@ func (c *CreateTemporaryRequest) Unmarshal(data []byte) (int, error) {
 	}
 	offset += bytesRead
 
-	// Unmarshalling parameter CreationTime
-	if len(rawParametersContent) < offset+8 {
+	// Unmarshalling parameter CreationTime (4-byte UTIME, little-endian)
+	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for CreationTime")
 	}
-	bytesRead, err = c.CreationTime.Unmarshal(rawParametersContent[offset:])
-	if err != nil {
-		return offset, err
-	}
-	offset += bytesRead
+	c.CreationTime = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
+	offset += 4
 
 	// Then unmarshal the data
 	offset = 0


### PR DESCRIPTION
### Linked Issue
Closes #146

### Root Cause
`CreateTemporaryRequest.CreationTime` was modeled with `types.FILETIME`, whose `Marshal()` emits two little-endian Uint32s (8 bytes). MS-CIFS specifies the field as a 4-byte `UTIME` (seconds since Jan 1, 1970). Because the SMB `parameters` layer is byte-preserving, the struct put 8 bytes on the wire for a field the spec sizes at 4, so the Words block was 10 bytes (FileAttributes 2 + CreationTime 8) and WordCount serialized as 0x05 instead of the required 0x03 — corrupting the entire parameter block. Symmetric round-trip tests did not catch this because both sides used the same wrong size.

### Fix Description
Model `CreationTime` as `types.ULONG` and marshal/unmarshal it as a 4-byte little-endian value, mirroring the existing UTIME handling in `CloseRequest` (`LastTimeModified`). The `Unmarshal` length guard is corrected from `>= offset+8` to `>= offset+4`. Words now total 6 bytes (WordCount 0x03), matching the spec.

### How Verified
- **Static:** Per [MS-CIFS 3dae394e](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/3dae394e-5c48-46fc-82ea-4031995f903c), WordCount MUST be 0x03 and Words is 6 bytes: `SMB_FILE_ATTRIBUTES FileAttributes` (2) + `UTIME CreationTime` (4). The patched `Marshal()` now appends exactly 4 bytes for CreationTime, producing 6 Words bytes.
- **Build/Tests:** `go build ./network/smb/smb_v10/...` and `go test ./network/smb/smb_v10/message/commands/...` both pass.

### Test Coverage
**Existing:** the package round-trip tests for commands exercise Marshal/Unmarshal symmetry and pass after the change; the field size now also matches the spec's WordCount.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/CreateTemporaryRequest.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local to a single command struct; safe to merge directly. Any caller that set `CreationTime` as a `FILETIME` value must now assign a `ULONG` (UTIME seconds), which is the correct on-wire representation.