### PR TITLE
[bugfix] Fix FindRequest MaxCount little-endian marshalling (#154)

### DIFF
--- a/network/smb/smb_v10/message/commands/FindRequest.go
+++ b/network/smb/smb_v10/message/commands/FindRequest.go
@@ -122,7 +122,7 @@ func (c *FindRequest) Marshal() ([]byte, error) {
 
 	// Marshalling parameter MaxCount
 	buf2 := make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.MaxCount))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.MaxCount))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter SearchAttributes
@@ -186,7 +186,7 @@ func (c *FindRequest) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for MaxCount")
 	}
-	c.MaxCount = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.MaxCount = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter SearchAttributes


### PR DESCRIPTION
### Linked Issue
Closes #154

### Root Cause
`FindRequest` was generated with a big-endian default for its integer parameter. The `parameters` layer in `network/smb/smb_v10/message/parameters` is byte-preserving (it reads the struct's raw bytes into 16-bit words and re-emits them unchanged), so the big-endian bytes produced by `Marshal()` reached the wire verbatim. MS-CIFS defines all SMB integer fields as little-endian, so the transmitted `MaxCount` was byte-swapped. The defect was invisible to unit tests because `Marshal`/`Unmarshal` are symmetric.

### Fix Description
Changed `MaxCount` to use `binary.LittleEndian` in both `Marshal()` (L125) and `Unmarshal()` (L189), matching the MS-CIFS SMB_COM_FIND Request definition of `MaxCount` as a 2-byte little-endian `USHORT`. The `SearchAttributes`, `FileName` (BufferFormat 0x04), and `ResumeKey` (BufferFormat 0x05) fields are encoded by their own types and were not changed by this PR.

### How Verified
- Static: the two patched lines now serialize/parse `MaxCount` little-endian; the byte-preserving `parameters` layer transmits those bytes unchanged, so `MaxCount = 0x0001` is now emitted as `01 00` per spec.
- `go build ./...` succeeds.
- `go test ./network/smb/smb_v10/message/commands/...` passes.

### Test Coverage
- **Existing:** existing round-trip tests in the `commands` package continue to pass; they exercise the symmetric `Marshal`/`Unmarshal` path.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/FindRequest.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Notes
Part of the systemic big-endian defect class tracked in #134. The shared `SMB_FILE_ATTRIBUTES` type (`SearchAttributes`) also marshals big-endian, but it is shared infrastructure used by many commands and is out of scope for this single-file fix.