### PR TITLE
[bugfix] Fix LockAndReadRequest parameters to marshal little-endian (#152)

### DIFF
--- a/network/smb/smb_v10/message/commands/LockAndReadRequest.go
+++ b/network/smb/smb_v10/message/commands/LockAndReadRequest.go
@@ -93,22 +93,22 @@ func (c *LockAndReadRequest) Marshal() ([]byte, error) {
 
 	// Marshalling parameter FID
 	buf2 := make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.FID))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.FID))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter CountOfBytesToRead
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.CountOfBytesToRead))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.CountOfBytesToRead))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter ReadOffsetInBytes
 	buf4 := make([]byte, 4)
-	binary.BigEndian.PutUint32(buf4, uint32(c.ReadOffsetInBytes))
+	binary.LittleEndian.PutUint32(buf4, uint32(c.ReadOffsetInBytes))
 	rawParametersContent = append(rawParametersContent, buf4...)
 
 	// Marshalling parameter EstimateOfRemainingBytesToBeRead
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.EstimateOfRemainingBytesToBeRead))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.EstimateOfRemainingBytesToBeRead))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameters
@@ -165,28 +165,28 @@ func (c *LockAndReadRequest) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for FID")
 	}
-	c.FID = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.FID = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter CountOfBytesToRead
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for CountOfBytesToRead")
 	}
-	c.CountOfBytesToRead = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.CountOfBytesToRead = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter ReadOffsetInBytes
 	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for ReadOffsetInBytes")
 	}
-	c.ReadOffsetInBytes = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	c.ReadOffsetInBytes = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
 	offset += 4
 
 	// Unmarshalling parameter EstimateOfRemainingBytesToBeRead
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for EstimateOfRemainingBytesToBeRead")
 	}
-	c.EstimateOfRemainingBytesToBeRead = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.EstimateOfRemainingBytesToBeRead = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Then unmarshal the data


### PR DESCRIPTION
### Linked Issue
Closes #152

### Root Cause
The `LockAndReadRequest` command file was generated with `binary.BigEndian` for all of its integer parameters and was never exercised against a live SMB server. SMB/CIFS encodes all integer fields little-endian on the wire, and the `parameters` layer in this package is byte-preserving, so the endianness chosen in the struct is exactly what is transmitted. The big-endian encoding therefore swapped the bytes of every parameter on the wire.

### Fix Description
Changed all four parameter fields in both `Marshal()` and `Unmarshal()` from `binary.BigEndian` to `binary.LittleEndian`:
- `FID` (USHORT, 2 bytes)
- `CountOfBytesToRead` (USHORT, 2 bytes)
- `ReadOffsetInBytes` (ULONG, 4 bytes)
- `EstimateOfRemainingBytesToBeRead` (USHORT, 2 bytes)

Field order, sizes, WordCount (0x05), and the empty SMB_Data (ByteCount 0x0000) already matched [MS-CIFS SMB_COM_LOCK_AND_READ Request](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/4652d923-dc4e-4611-b17e-9215d8c66f2e); only the byte order was wrong. Marshal/Unmarshal remain symmetric.

### How Verified
- `go build ./network/smb/...` passes.
- `go test ./network/smb/smb_v10/message/commands/` passes.
- Static review against the MS-CIFS spec confirms each field is now emitted/parsed little-endian, matching the documented wire format.

### Test Coverage
**Existing:** existing round-trip tests in the commands package still pass. Round-trip tests are symmetric and do not assert wire byte order, so no new symmetric test would meaningfully guard this; the fix is verified against the spec's documented little-endian encoding.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/LockAndReadRequest.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local to one command's wire encoding. Safe to merge; it corrects bytes that no compliant server could previously interpret.