### PR TITLE
[bugfix] Fix LockByteRangeRequest parameters to little-endian (#156)

### DIFF
--- a/network/smb/smb_v10/message/commands/LockByteRangeRequest.go
+++ b/network/smb/smb_v10/message/commands/LockByteRangeRequest.go
@@ -86,17 +86,17 @@ func (c *LockByteRangeRequest) Marshal() ([]byte, error) {
 
 	// Marshalling parameter FID
 	buf2 := make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.FID))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.FID))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter CountOfBytesToLock
 	buf4 := make([]byte, 4)
-	binary.BigEndian.PutUint32(buf4, uint32(c.CountOfBytesToLock))
+	binary.LittleEndian.PutUint32(buf4, uint32(c.CountOfBytesToLock))
 	rawParametersContent = append(rawParametersContent, buf4...)
 
 	// Marshalling parameter LockOffsetInBytes
 	buf4 = make([]byte, 4)
-	binary.BigEndian.PutUint32(buf4, uint32(c.LockOffsetInBytes))
+	binary.LittleEndian.PutUint32(buf4, uint32(c.LockOffsetInBytes))
 	rawParametersContent = append(rawParametersContent, buf4...)
 
 	// Marshalling parameters
@@ -153,21 +153,21 @@ func (c *LockByteRangeRequest) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for FID")
 	}
-	c.FID = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.FID = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter CountOfBytesToLock
 	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for CountOfBytesToLock")
 	}
-	c.CountOfBytesToLock = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	c.CountOfBytesToLock = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
 	offset += 4
 
 	// Unmarshalling parameter LockOffsetInBytes
 	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for LockOffsetInBytes")
 	}
-	c.LockOffsetInBytes = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	c.LockOffsetInBytes = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
 	offset += 4
 
 	// Then unmarshal the data


### PR DESCRIPTION
### Linked Issue
Closes #156

### Root Cause
The generated `LockByteRangeRequest` command file used `binary.BigEndian` to marshal and unmarshal its three integer parameters. SMB/CIFS encodes all integer fields little-endian on the wire, and the `parameters` layer in this package is byte-preserving, so the endianness used by the struct is exactly what is transmitted. The file was never exercised against a live server, so the swapped byte order went unnoticed (round-trip unit tests pass because Marshal/Unmarshal are symmetric).

### Fix Description
Switched all six `binary.BigEndian` calls to `binary.LittleEndian` in `Marshal()` and `Unmarshal()` for `FID` (USHORT, 2 bytes), `CountOfBytesToLock` (ULONG, 4 bytes), and `LockOffsetInBytes` (ULONG, 4 bytes). This matches the [MS-CIFS SMB_COM_LOCK_BYTE_RANGE Request](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/08282636-0876-4ded-82b1-973edd255f87) layout (WordCount 0x05, 10 parameter bytes, ByteCount 0x0000) and the convention used by the hand-corrected sibling commands.

### How Verified
- Static: all integer fields now use `binary.LittleEndian`; field order and sizes already matched the spec table.
- `go build ./network/smb/...` succeeds.
- `go test ./network/smb/smb_v10/message/commands/` passes.

### Test Coverage
**Existing:** the package's existing round-trip tests cover Marshal/Unmarshal of this command and continue to pass after the fix.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/LockByteRangeRequest.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local, single-file change limited to byte order of one command's parameters; safe to merge directly.

### Notes
Part of tracking issue #134.