### PR TITLE
[bugfix] Fix LockAndReadResponse CountOfBytesReturned little-endian marshalling (#167)

### DIFF
--- a/network/smb/smb_v10/message/commands/LockAndReadResponse.go
+++ b/network/smb/smb_v10/message/commands/LockAndReadResponse.go
@@ -99,7 +99,7 @@ func (c *LockAndReadResponse) Marshal() ([]byte, error) {
 
 	// Marshalling parameter CountOfBytesReturned
 	buf2 := make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.CountOfBytesReturned))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.CountOfBytesReturned))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameters
@@ -156,7 +156,7 @@ func (c *LockAndReadResponse) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for CountOfBytesReturned")
 	}
-	c.CountOfBytesReturned = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.CountOfBytesReturned = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Then unmarshal the data


### PR DESCRIPTION
Closes #167

### Root Cause
`LockAndReadResponse.Marshal`/`Unmarshal` used `binary.BigEndian` for the `CountOfBytesReturned` USHORT parameter. SMB/CIFS integer fields are little-endian, and the `parameters` layer is byte-preserving, so the big-endian bytes were transmitted on the wire. Symmetric Marshal/Unmarshal round-trip tests did not catch this.

### Fix Description
Switched the two `CountOfBytesReturned` conversions to `binary.LittleEndian` (`PutUint16` in `Marshal`, `Uint16` in `Unmarshal`), matching the MS-CIFS Response spec for SMB_COM_LOCK_AND_READ.

### How Verified
- Static: the only `CountOfBytesReturned` byte conversions now use `binary.LittleEndian`; logic is otherwise unchanged and remains symmetric.
- Tests: `go test ./network/smb/smb_v10/message/commands/...` passes; `go build ./...` succeeds.

### Test Coverage
- **Existing:** existing round-trip tests in the `commands` package continue to pass after the fix.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/LockAndReadResponse.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Notes
Spec: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/ac41df92-de51-4d2d-935a-7eae93ae9bcc
Part of the systemic big-endian parameter defect tracked in #134. A separate PR addresses the missing 8-byte Reserved field (#174).