### PR TITLE
[bugfix] Fix FlushRequest FID little-endian marshalling (#149)

### DIFF
--- a/network/smb/smb_v10/message/commands/FlushRequest.go
+++ b/network/smb/smb_v10/message/commands/FlushRequest.go
@@ -78,7 +78,7 @@ func (c *FlushRequest) Marshal() ([]byte, error) {
 
 	// Marshalling parameter FID
 	buf2 := make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.FID))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.FID))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameters
@@ -135,7 +135,7 @@ func (c *FlushRequest) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for FID")
 	}
-	c.FID = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.FID = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Then unmarshal the data


### PR DESCRIPTION
### Linked Issue
`Closes #149`

### Root Cause
The generated `FlushRequest` command file defaulted to `binary.BigEndian` for its single `FID` parameter and was never exercised against a live SMB server. SMB/CIFS encodes all integer fields little-endian on the wire, and the package`s `parameters` layer is byte-preserving, so the endianness the struct uses is exactly what is transmitted. Marshal/Unmarshal were symmetric, so round-trip unit tests passed despite the wrong wire byte order.

### Fix Description
Switch the 2-byte `FID` field in `Marshal()` (L81) and `Unmarshal()` (L138) from `binary.BigEndian` to `binary.LittleEndian`, matching the [MS-CIFS SMB_COM_FLUSH Request](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/e5e1e00c-5ec2-4a5c-b825-f8cf2f4cda79) wire format and the hand-corrected sibling commands (`TreeConnectAndxRequest`, `SessionSetupAndxRequest`).

### How Verified
- **Static:** The spec defines `SMB_Parameters { UCHAR WordCount=0x01; Words { USHORT FID } }`, `ByteCount=0x0000`. After the change the FID is emitted/parsed little-endian, matching the documented order. Marshal/Unmarshal remain symmetric.
- **Build/Test:** `go build ./...` succeeds; `go test ./network/smb/smb_v10/message/commands/...` passes.

### Test Coverage
**Existing:** Existing round-trip tests in the commands package continue to pass. No new test added because the existing symmetric round-trip cannot distinguish endianness; correctness is established against the MS-CIFS spec.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/FlushRequest.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local, two-line change to a single command. Blast radius limited to SMB_COM_FLUSH wire encoding, which was previously incorrect; safe to merge.