### PR TITLE
[bugfix] Fix LockingAndxRequest parameter little-endian marshalling (#160)

### DIFF
--- a/network/smb/smb_v10/message/commands/LockingAndxRequest.go
+++ b/network/smb/smb_v10/message/commands/LockingAndxRequest.go
@@ -158,7 +158,7 @@ func (c *LockingAndxRequest) Marshal() ([]byte, error) {
 
 	// Marshalling parameter FID
 	buf2 := make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.FID))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.FID))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter TypeOfLock
@@ -169,17 +169,17 @@ func (c *LockingAndxRequest) Marshal() ([]byte, error) {
 
 	// Marshalling parameter Timeout
 	buf4 := make([]byte, 4)
-	binary.BigEndian.PutUint32(buf4, uint32(c.Timeout))
+	binary.LittleEndian.PutUint32(buf4, uint32(c.Timeout))
 	rawParametersContent = append(rawParametersContent, buf4...)
 
 	// Marshalling parameter NumberOfRequestedUnlocks
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.NumberOfRequestedUnlocks))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.NumberOfRequestedUnlocks))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter NumberOfRequestedLocks
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.NumberOfRequestedLocks))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.NumberOfRequestedLocks))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameters
@@ -239,7 +239,7 @@ func (c *LockingAndxRequest) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for FID")
 	}
-	c.FID = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.FID = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter TypeOfLock
@@ -260,21 +260,21 @@ func (c *LockingAndxRequest) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for Timeout")
 	}
-	c.Timeout = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	c.Timeout = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
 	offset += 4
 
 	// Unmarshalling parameter NumberOfRequestedUnlocks
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for NumberOfRequestedUnlocks")
 	}
-	c.NumberOfRequestedUnlocks = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.NumberOfRequestedUnlocks = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter NumberOfRequestedLocks
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for NumberOfRequestedLocks")
 	}
-	c.NumberOfRequestedLocks = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.NumberOfRequestedLocks = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Then unmarshal the data


### PR DESCRIPTION
### Linked Issue
Closes #160

### Root Cause
`LockingAndxRequest` was generated with `binary.BigEndian` for its multi-byte parameter fields. SMB/CIFS wire integers are little-endian, and the `parameters` layer in `smb_v10` is byte-preserving, so the big-endian bytes reach the wire verbatim. Because `Marshal`/`Unmarshal` are symmetric, the existing round-trip tests pass despite the wrong on-the-wire byte order, so the defect went unnoticed.

### Fix Description
Switch the FID, Timeout, NumberOfRequestedUnlocks, and NumberOfRequestedLocks fields from `binary.BigEndian` to `binary.LittleEndian` in both `Marshal()` and `Unmarshal()`, matching [MS-CIFS 2.2.4.32 SMB_COM_LOCKING_ANDX Request](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/b5c6eae7-976b-4444-b52e-c76c68c861ad) and the hand-corrected sibling commands (e.g. `TreeConnectAndxRequest`). The single-byte fields (TypeOfLock, NewOpLockLevel) are endianness-independent and unchanged; the `LOCKING_ANDX_RANGE64` data entries were already little-endian and are untouched.

### How Verified
- **Static:** Confirmed against the MS-CIFS structure: WordCount 0x08 / 16 Words bytes, with FID (2), TypeOfLock (1), NewOpLockLevel (1), Timeout (4), NumberOfRequestedUnlocks (2), NumberOfRequestedLocks (2). All integer fields are little-endian per the CIFS wire format.
- **Tests:** `go test ./network/smb/smb_v10/message/commands/` passes.
- **Build:** `go build ./network/smb/...` succeeds.

### Test Coverage
**Existing:** the package's existing `LockingAndxRequest` round-trip tests continue to pass. They are symmetric and do not assert byte order, so no behavioral regression is introduced; the byte-order correctness is verified statically against the spec.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/LockingAndxRequest.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Low blast radius: confined to the byte order of four parameter fields in one command. Safe to merge directly.