### PR TITLE
[bugfix] Fix CreateRequest CreationTime to use 4-byte UTIME instead of 8-byte FILETIME (#145)

### DIFF
--- a/network/smb/smb_v10/message/commands/CreateRequest.go
+++ b/network/smb/smb_v10/message/commands/CreateRequest.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"encoding/binary"
 	"fmt"
 
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/andx"
@@ -21,8 +22,8 @@ type CreateRequest struct {
 	// A 16-bit field of 1-bit flags that represent the file attributes to assign to the file if it is created successfully.
 	FileAttributes types.SMB_FILE_ATTRIBUTES
 
-	// The time that the file was created on the client, represented as the number of seconds since Jan 1, 1970, 00:00:00.0.
-	CreationTime types.FILETIME
+	// The time that the file was created on the client, represented as the number of seconds since Jan 1, 1970, 00:00:00.0 (a 4-byte UTIME).
+	CreationTime types.ULONG
 
 	// Data
 
@@ -38,7 +39,7 @@ func NewCreateRequest() *CreateRequest {
 	c := &CreateRequest{
 		// Parameters
 		FileAttributes: types.SMB_FILE_ATTRIBUTES{},
-		CreationTime:   types.FILETIME{},
+		CreationTime:   types.ULONG(0),
 
 		// Data
 		FileName: types.SMB_STRING{},
@@ -101,12 +102,10 @@ func (c *CreateRequest) Marshal() ([]byte, error) {
 	}
 	rawParametersContent = append(rawParametersContent, bytesStream...)
 
-	// Marshalling parameter CreationTime
-	bytesStream, err = c.CreationTime.Marshal()
-	if err != nil {
-		return nil, err
-	}
-	rawParametersContent = append(rawParametersContent, bytesStream...)
+	// Marshalling parameter CreationTime (4-byte UTIME, little-endian)
+	buf4 := make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf4, uint32(c.CreationTime))
+	rawParametersContent = append(rawParametersContent, buf4...)
 
 	// Marshalling parameters
 	c.GetParameters().AddWordsFromBytesStream(rawParametersContent)
@@ -165,15 +164,12 @@ func (c *CreateRequest) Unmarshal(data []byte) (int, error) {
 	}
 	offset += bytesRead
 
-	// Unmarshalling parameter CreationTime
-	if len(rawParametersContent) < offset+8 {
+	// Unmarshalling parameter CreationTime (4-byte UTIME, little-endian)
+	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for CreationTime")
 	}
-	bytesRead, err = c.CreationTime.Unmarshal(rawParametersContent[offset:])
-	if err != nil {
-		return offset, err
-	}
-	offset += bytesRead
+	c.CreationTime = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
+	offset += 4
 
 	// Then unmarshal the data
 	offset = 0


### PR DESCRIPTION
### Linked Issue
Closes #145

### Root Cause
The `CreationTime` field of `SMB_COM_CREATE` was typed as `types.FILETIME`, an 8-byte (two `uint32`) Windows 100-nanosecond time value. The MS-CIFS specification defines this field as a `UTIME` — a 4-byte count of seconds since 1970-01-01. Because the field marshalled to 8 bytes, the Words block was 8 bytes instead of 6, and the resulting `WordCount` became `0x04` instead of the spec-mandated `0x03`. Round-trip unit tests did not catch this because Marshal/Unmarshal were mutually symmetric.

### Fix Description
Retype `CreationTime` from `types.FILETIME` to `types.ULONG` and marshal/unmarshal it explicitly as a single 4-byte little-endian value (`binary.LittleEndian.PutUint32` / `binary.LittleEndian.Uint32`). The `Unmarshal` length guard is updated from `offset+8` to `offset+4`. This mirrors the previously merged fix for `CloseRequest.LastTimeModified` (#130). The Words block is now 6 bytes, producing the correct WordCount of `0x03`. The `FileName` data field (BufferFormat `0x04` + null-terminated ASCII) was already spec-compliant and is unchanged.

### How Verified
- **Static:** the parameter block now emits FileAttributes (2 bytes) + CreationTime (4 bytes) = 6 bytes, matching the spec's `Words (6 bytes)` and `WordCount 0x03`. Unmarshal reads exactly 4 bytes for CreationTime with a `>= offset+4` guard (CreateRequest.go L164-L171).
- **Build/Test:** `go build ./network/smb/...` succeeds; `go test ./network/smb/smb_v10/message/commands/` passes.

### Test Coverage
**Existing:** the package's existing CreateRequest round-trip tests pass against the corrected 4-byte field.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/CreateRequest.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local to the SMB_COM_CREATE request encoding; changes the on-wire parameter size to match the spec. Safe to merge.