### PR TITLE
[bugfix] Fix EchoResponse SequenceNumber little-endian marshalling (#143)

### DIFF
--- a/network/smb/smb_v10/message/commands/EchoResponse.go
+++ b/network/smb/smb_v10/message/commands/EchoResponse.go
@@ -88,7 +88,7 @@ func (c *EchoResponse) Marshal() ([]byte, error) {
 
 	// Marshalling parameter SequenceNumber
 	buf2 := make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.SequenceNumber))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.SequenceNumber))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameters
@@ -145,7 +145,7 @@ func (c *EchoResponse) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for SequenceNumber")
 	}
-	c.SequenceNumber = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.SequenceNumber = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Then unmarshal the data


### PR DESCRIPTION
### Linked Issue
Closes #143

### Root Cause
SMB/CIFS encodes all integer fields little-endian, and the `parameters` layer in this package is byte-preserving, so the endianness a command struct uses to build its raw parameter bytes is exactly what is transmitted on the wire. The generated `EchoResponse` used `binary.BigEndian` for the `SequenceNumber` USHORT, so it emitted (and parsed) the two bytes reversed relative to the spec. Because `Marshal` and `Unmarshal` are symmetric, the existing round-trip unit tests passed and never surfaced the wire defect.

### Fix Description
Switch the `SequenceNumber` USHORT to `binary.LittleEndian` in both `Marshal` (L91) and `Unmarshal` (L148), matching MS-CIFS 2.2.4.39.2 (SMB_COM_ECHO Server Response: `Words { USHORT SequenceNumber; }`). Symmetry between marshal and unmarshal is preserved.

### How Verified
- **Static:** Confirmed against the MS-CIFS Response spec (https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/36242467-7c62-4041-b60f-939683cacdf2): WordCount MUST be 0x01 with a single `USHORT SequenceNumber`; SMB/CIFS integers are little-endian. The patched code at L91/L148 now writes/reads the field little-endian.
- **Tests:** `go test ./network/smb/smb_v10/message/commands/` passes; `go build ./network/smb/smb_v10/message/commands/` succeeds.

### Test Coverage
**Existing:** existing round-trip tests in the commands package cover marshal/unmarshal of `EchoResponse`; they remain green after the fix. (Round-trip tests are symmetric and cannot detect the wire endianness directly; correctness is established by the spec citation above.)

### Scope of Change
- **Files changed:** network/smb/smb_v10/message/commands/EchoResponse.go
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local two-line change to a single command's parameter encoding; blast radius limited to SMB_COM_ECHO responses. Safe to merge without staged rollout.

### Notes
Part of the big-endian defect class tracked in #134.