### PR TITLE
[bugfix] Fix OpenPrintFileResponse FID little-endian marshalling (#163)

### DIFF
--- a/network/smb/smb_v10/message/commands/OpenPrintFileResponse.go
+++ b/network/smb/smb_v10/message/commands/OpenPrintFileResponse.go
@@ -79,7 +79,7 @@ func (c *OpenPrintFileResponse) Marshal() ([]byte, error) {
 
 	// Marshalling parameter FID
 	buf2 := make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.FID))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.FID))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameters
@@ -136,7 +136,7 @@ func (c *OpenPrintFileResponse) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for FID")
 	}
-	c.FID = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.FID = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Then unmarshal the data


### PR DESCRIPTION
### Linked Issue
Closes #163

### Root Cause
`OpenPrintFileResponse` is a generated SMB command file that defaulted to `binary.BigEndian` for its `FID` parameter in both `Marshal` and `Unmarshal`. SMB/CIFS encodes all integer fields little-endian, and the `parameters` layer in `smb_v10` is byte-preserving (it re-emits whatever bytes the command struct produced), so the big-endian FID was transmitted on the wire with its two bytes swapped. Because `Marshal`/`Unmarshal` are symmetric, the round-trip unit tests passed despite the wire defect.

### Fix Description
Switch the FID encoding in `Marshal()` (L82) from `binary.BigEndian.PutUint16` to `binary.LittleEndian.PutUint16`, and the decoding in `Unmarshal()` (L139) from `binary.BigEndian.Uint16` to `binary.LittleEndian.Uint16`. This matches the MS-CIFS SMB_COM_OPEN_PRINT_FILE Response (WordCount = 0x01, a single little-endian USHORT FID): https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/fb4c1ba4-4269-47ff-8e43-02f3577190db

### How Verified
- **Static:** the patched code path now writes/reads the FID as a little-endian USHORT at L82 and L139, matching the spec field order/size/endianness. Marshal<->Unmarshal symmetry is preserved.
- **Build:** `go build ./network/smb/smb_v10/...` succeeds.

### Test Coverage
**Existing:** existing round-trip tests for the command continue to pass (they are endianness-symmetric and validate structural correctness). No new test added because the defect is a pure wire-encoding swap not observable through the symmetric round-trip harness; it is verified against the spec.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/OpenPrintFileResponse.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local, two-line change confined to one command's FID encoding. Safe to merge; corrects an on-wire byte order that no other code depended on.