### PR TITLE
[bugfix] Fix ReadMpxRequest little-endian parameter marshalling (#170)

### DIFF
--- a/network/smb/smb_v10/message/commands/ReadMpxRequest.go
+++ b/network/smb/smb_v10/message/commands/ReadMpxRequest.go
@@ -104,32 +104,32 @@ func (c *ReadMpxRequest) Marshal() ([]byte, error) {
 
 	// Marshalling parameter FID
 	buf2 := make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.FID))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.FID))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter Offset
 	buf4 := make([]byte, 4)
-	binary.BigEndian.PutUint32(buf4, uint32(c.Offset))
+	binary.LittleEndian.PutUint32(buf4, uint32(c.Offset))
 	rawParametersContent = append(rawParametersContent, buf4...)
 
 	// Marshalling parameter MaxCountOfBytesToReturn
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.MaxCountOfBytesToReturn))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.MaxCountOfBytesToReturn))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter MinCountOfBytesToReturn
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.MinCountOfBytesToReturn))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.MinCountOfBytesToReturn))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter Timeout
 	buf4 = make([]byte, 4)
-	binary.BigEndian.PutUint32(buf4, uint32(c.Timeout))
+	binary.LittleEndian.PutUint32(buf4, uint32(c.Timeout))
 	rawParametersContent = append(rawParametersContent, buf4...)
 
 	// Marshalling parameter Reserved
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.Reserved))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.Reserved))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameters
@@ -186,42 +186,42 @@ func (c *ReadMpxRequest) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for FID")
 	}
-	c.FID = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.FID = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter Offset
 	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for Offset")
 	}
-	c.Offset = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	c.Offset = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
 	offset += 4
 
 	// Unmarshalling parameter MaxCountOfBytesToReturn
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for MaxCountOfBytesToReturn")
 	}
-	c.MaxCountOfBytesToReturn = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.MaxCountOfBytesToReturn = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter MinCountOfBytesToReturn
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for MinCountOfBytesToReturn")
 	}
-	c.MinCountOfBytesToReturn = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.MinCountOfBytesToReturn = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter Timeout
 	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for Timeout")
 	}
-	c.Timeout = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	c.Timeout = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
 	offset += 4
 
 	// Unmarshalling parameter Reserved
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for Reserved")
 	}
-	c.Reserved = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.Reserved = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Then unmarshal the data


### PR DESCRIPTION
### Linked Issue
Closes #170

### Root Cause
The SMB_COM_READ_MPX request was generated with `binary.BigEndian` for all parameter fields. SMB/CIFS transmits integer fields little-endian, and the `parameters` layer is byte-preserving, so the big-endian bytes reached the wire byte-reversed. Symmetric Marshal/Unmarshal meant round-trip unit tests never exposed the defect.

### Fix Description
Changed all `binary.BigEndian` reads/writes to `binary.LittleEndian` in `Marshal()` and `Unmarshal()` for FID, Offset, MaxCountOfBytesToReturn, MinCountOfBytesToReturn, Timeout, and Reserved. Field order, sizes (matching WordCount 0x08 / 16 bytes of words), and the empty SMB_Data (ByteCount 0x0000) already matched MS-CIFS and are unchanged.

### How Verified
- **Static:** Each field now encodes/decodes little-endian per MS-CIFS SMB_COM_READ_MPX Request (https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/3e066ba0-9fce-43c7-85fd-756e4721f7ee).
- **Tests:** `go build ./...` and `go test ./network/smb/smb_v10/message/commands/...` pass.

### Test Coverage
**Existing:** existing round-trip tests in the commands package continue to pass (they are endianness-symmetric and cover marshalling structure).

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/ReadMpxRequest.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local to one command; corrects on-wire byte order. Safe to merge.

### Notes
Part of tracking issue #134.