### PR TITLE
[bugfix] Fix FindUniqueResponse data block framing and Count endianness (#161)

### DIFF
--- a/network/smb/smb_v10/message/commands/FindUniqueResponse.go
+++ b/network/smb/smb_v10/message/commands/FindUniqueResponse.go
@@ -24,6 +24,12 @@ type FindUniqueResponse struct {
 	Count types.USHORT
 
 	// Data
+
+	// BufferFormat (1 byte): This field MUST be 0x05, which indicates that a variable-size block is to follow.
+	// DataLength (2 bytes): The size, in bytes, of the DirectoryInformationData array, which follows. This field MUST
+	// be equal to 43 times the value of SMB_Parameters.Words.Count.
+	// DirectoryInformationData (variable): An array of zero or more SMB_Directory_Information records. Note that the
+	// SMB_Directory_Information record structure is a fixed 43 bytes in length.
 	DirectoryInformationData []types.SMB_DIRECTORY_INFORMATION
 }
 
@@ -79,21 +85,34 @@ func (c *FindUniqueResponse) Marshal() ([]byte, error) {
 	// the data will be stored in the parameters
 	rawDataContent := []byte{}
 
-	// Marshalling data DirectoryInformationData
+	// Marshalling the directory information records first so we can compute DataLength
+	directoryRecords := []byte{}
 	for _, directoryInformationData := range c.DirectoryInformationData {
 		bytesStream, err := directoryInformationData.Marshal()
 		if err != nil {
 			return nil, err
 		}
-		rawDataContent = append(rawDataContent, bytesStream...)
+		directoryRecords = append(directoryRecords, bytesStream...)
 	}
+
+	// BufferFormat (1 byte): MUST be 0x05, indicating that a variable-size block follows
+	rawDataContent = append(rawDataContent, 0x05)
+
+	// DataLength (2 bytes, little-endian): size in bytes of the DirectoryInformationData array,
+	// which MUST equal 43 times the number of directory entries
+	dataLengthBuf := make([]byte, 2)
+	binary.LittleEndian.PutUint16(dataLengthBuf, uint16(len(directoryRecords)))
+	rawDataContent = append(rawDataContent, dataLengthBuf...)
+
+	// DirectoryInformationData (variable)
+	rawDataContent = append(rawDataContent, directoryRecords...)
 
 	// Then marshal the parameters
 	rawParametersContent := []byte{}
 
 	// Marshalling parameter Count
 	buf2 := make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.Count))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.Count))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameters
@@ -150,7 +169,7 @@ func (c *FindUniqueResponse) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for Count")
 	}
-	c.Count = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.Count = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Then unmarshal the data
@@ -159,6 +178,18 @@ func (c *FindUniqueResponse) Unmarshal(data []byte) (int, error) {
 	// Unmarshalling data DirectoryInformationData
 	// Clear any existing entries
 	c.DirectoryInformationData = []types.SMB_DIRECTORY_INFORMATION{}
+
+	// BufferFormat (1 byte): MUST be 0x05
+	if len(rawDataContent) < offset+1 {
+		return offset, fmt.Errorf("rawDataContent too short for BufferFormat")
+	}
+	offset++
+
+	// DataLength (2 bytes, little-endian): size in bytes of the DirectoryInformationData array
+	if len(rawDataContent) < offset+2 {
+		return offset, fmt.Errorf("rawDataContent too short for DataLength")
+	}
+	offset += 2
 
 	// Each directory information entry is 43 bytes fixed size
 	const entrySize = 43


### PR DESCRIPTION
### Linked Issue
Closes #161

### Root Cause
The `FindUniqueResponse` data block was assembled and parsed as a bare array of 43-byte `SMB_Directory_Information` records. MS-CIFS ([Response](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/eb2614e0-ce33-4a7f-847b-bcddb97c00a6)) requires the data block to begin with a 1-byte `BufferFormat` (0x05) and a 2-byte `DataLength` (= 43 × Count) before the records. These framing fields were documented only in comments and never marshalled or unmarshalled, so emitted responses were missing 3 leading bytes and parsing of spec-compliant peers read the first record 3 bytes too early. Separately, the `Count` parameter was (un)marshalled big-endian, but SMB/CIFS integer fields are little-endian (same systemic defect class as tracking issue #134).

### Fix Description
- `Marshal`: build the directory records, then prepend `BufferFormat = 0x05` and a little-endian `DataLength` equal to the record bytes, then append the records.
- `Unmarshal`: consume the `BufferFormat` byte and the 2-byte `DataLength` before iterating the fixed-size 43-byte records.
- Switch `Count` to `binary.LittleEndian` on both marshal and unmarshal.
- The `Unmarshal` length guards use `>=`/`<` checks (never `==`), consistent with parsing fixed sub-fields from a larger stream.

### How Verified
- Static: corrected `Marshal`/`Unmarshal` now match the spec field order (BufferFormat, DataLength, records) and little-endian encoding; the two functions remain symmetric.
- `go build ./network/smb/smb_v10/message/commands/` — passes.
- `go test ./network/smb/smb_v10/message/commands/` — passes.

### Test Coverage
**None:** there is no existing `FindUniqueResponse_test.go`, and round-trip tests would not catch the original wire defect (Marshal/Unmarshal were mutually consistent). The fix is verified against the spec field layout and by building/testing the package.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/FindUniqueResponse.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Notes
The sibling `FindResponse.go` (SMB_COM_FIND) has the identical missing-BufferFormat/DataLength defect and the same big-endian `Count`; it is intentionally out of scope here and should be fixed separately. The `Count` little-endian change is part of the systemic class tracked by #134.