### PR TITLE
[bugfix] Fix OpenPrintFileRequest little-endian parameter marshalling (#162)

### DIFF
--- a/network/smb/smb_v10/message/commands/OpenPrintFileRequest.go
+++ b/network/smb/smb_v10/message/commands/OpenPrintFileRequest.go
@@ -103,12 +103,12 @@ func (c *OpenPrintFileRequest) Marshal() ([]byte, error) {
 
 	// Marshalling parameter SetupLength
 	buf2 := make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.SetupLength))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.SetupLength))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter Mode
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.Mode))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.Mode))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameters
@@ -165,14 +165,14 @@ func (c *OpenPrintFileRequest) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for SetupLength")
 	}
-	c.SetupLength = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.SetupLength = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter Mode
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for Mode")
 	}
-	c.Mode = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.Mode = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Then unmarshal the data


### PR DESCRIPTION
### Linked Issue
Closes #162

### Root Cause
The generated `OpenPrintFileRequest` command defaulted to `binary.BigEndian` for its two USHORT parameter words (`SetupLength`, `Mode`) and was never exercised against a live SMB server. SMB/CIFS transmits all integer fields little-endian, and the `parameters` layer is byte-preserving, so the big-endian bytes the struct built were sent verbatim. Symmetric Marshal/Unmarshal meant round-trip unit tests passed despite the wire format being wrong.

### Fix Description
Switch the `SetupLength` and `Mode` encode/decode from `binary.BigEndian` to `binary.LittleEndian` in both `Marshal` and `Unmarshal`, matching the [MS-CIFS] SMB_COM_OPEN_PRINT_FILE Request definition (USHORT word fields, little-endian on the wire). No other behavior is changed; Marshal/Unmarshal remain symmetric.

### How Verified
- Static: the four edited lines (Marshal L106/L111, Unmarshal L168/L175) now use `binary.LittleEndian`, matching the spec's USHORT fields.
- `go build ./...` succeeds.
- `go test ./network/smb/smb_v10/message/commands/...` passes.

### Test Coverage
- **Existing:** existing round-trip tests in the commands package continue to pass. (Round-trip tests are endianness-symmetric and do not assert wire bytes; this fix aligns the wire format with the spec.)

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/OpenPrintFileRequest.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local, single-file change limited to the SMB_COM_OPEN_PRINT_FILE parameter encoding. Safe to merge directly.
