### PR TITLE
[bugfix] Fix NtRenameRequest little-endian parameter marshalling (#164)

### DIFF
--- a/network/smb/smb_v10/message/commands/NtRenameRequest.go
+++ b/network/smb/smb_v10/message/commands/NtRenameRequest.go
@@ -123,12 +123,12 @@ func (c *NtRenameRequest) Marshal() ([]byte, error) {
 
 	// Marshalling parameter InformationLevel
 	buf2 := make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.InformationLevel))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.InformationLevel))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter Reserved
 	buf4 := make([]byte, 4)
-	binary.BigEndian.PutUint32(buf4, uint32(c.Reserved))
+	binary.LittleEndian.PutUint32(buf4, uint32(c.Reserved))
 	rawParametersContent = append(rawParametersContent, buf4...)
 
 	// Marshalling parameters
@@ -195,14 +195,14 @@ func (c *NtRenameRequest) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for InformationLevel")
 	}
-	c.InformationLevel = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.InformationLevel = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter Reserved
 	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for Reserved")
 	}
-	c.Reserved = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	c.Reserved = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
 	offset += 4
 
 	// Then unmarshal the data


### PR DESCRIPTION
### Linked Issue
Closes #164

### Root Cause
The `NtRenameRequest` command file was generated with a big-endian default for its integer parameter fields. SMB/CIFS wire fields are little-endian, and the `parameters` layer in `network/smb/smb_v10/message/parameters` is byte-preserving, so the endianness the struct uses is exactly what is transmitted. Because `Marshal`/`Unmarshal` are symmetric, round-trip unit tests passed and the defect was never exercised against a live server.

### Fix Description
Switched `InformationLevel` (USHORT, 2 bytes) and `Reserved` (ULONG, 4 bytes) from `binary.BigEndian` to `binary.LittleEndian` in both `Marshal()` and `Unmarshal()`, matching MS-CIFS 2.2.4.66.1 (SMB_COM_NT_RENAME Request). `SearchAttributes` is marshalled by its own type and was not affected. The Data block (BufferFormat1 + OldFileName + BufferFormat2 + NewFileName) already matches the spec and was left unchanged.

### How Verified
- **Static:** the four call sites (L126, L131 in `Marshal`; L198, L205 in `Unmarshal`) now use `binary.LittleEndian`, so a 0x0104 InformationLevel is emitted as `04 01` rather than `01 04`.
- **Tests:** `go test ./network/smb/smb_v10/message/commands/...` passes; `go build ./...` succeeds.

### Test Coverage
**Existing:** existing round-trip tests in the commands package cover the path and remain green (they are endianness-symmetric, so they validate structure but not the wire byte order; the spec citation establishes correctness).

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/NtRenameRequest.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local to NtRenameRequest serialization; safe to merge. Any consumer relying on the previous (incorrect) big-endian bytes would itself have been non-spec-compliant.