### PR TITLE
[bugfix] Fix OpenRequest AccessMode little-endian marshalling (#187)

### DIFF
--- a/network/smb/smb_v10/message/commands/OpenRequest.go
+++ b/network/smb/smb_v10/message/commands/OpenRequest.go
@@ -101,7 +101,7 @@ func (c *OpenRequest) Marshal() ([]byte, error) {
 
 	// Marshalling parameter AccessMode
 	buf2 := make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.AccessMode))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.AccessMode))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter SearchAttributes
@@ -165,7 +165,7 @@ func (c *OpenRequest) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for AccessMode")
 	}
-	c.AccessMode = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.AccessMode = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter SearchAttributes


### PR DESCRIPTION
### Linked Issue
Closes #187

### Root Cause
The generated `OpenRequest` command marshalled and unmarshalled the 2-byte `AccessMode` parameter with `binary.BigEndian`. SMB/CIFS integer fields are little-endian, and the `network/smb/smb_v10/message/parameters` layer is byte-preserving, so the big-endian bytes reached the wire unchanged. Because Marshal and Unmarshal were symmetric, round-trip unit tests passed and the defect went unnoticed.

### Fix Description
Switched both `binary.BigEndian.PutUint16` (Marshal) and `binary.BigEndian.Uint16` (Unmarshal) for `AccessMode` to `binary.LittleEndian`, matching the MS-CIFS SMB_COM_OPEN Request specification (https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/ab9bb872-1967-4088-b444-6a35d0af305e). `SearchAttributes` is marshalled via its own type and is out of scope here.

### How Verified
- Static: AccessMode now emits/reads bytes least-significant-first, matching the spec's USHORT little-endian convention.
- Tests: `go test ./network/smb/smb_v10/message/commands/...` passes.
- Build: `go build ./network/smb/smb_v10/...` passes.

### Test Coverage
**Existing:** existing command round-trip tests in the package pass after the fix; they exercise the symmetric Marshal/Unmarshal path.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/OpenRequest.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local, single-field change; safe to merge directly.