### PR TITLE
[bugfix] Fix LockAndReadResponse missing 8-byte Reserved parameter field (#174)

### DIFF
--- a/network/smb/smb_v10/message/commands/LockAndReadResponse.go
+++ b/network/smb/smb_v10/message/commands/LockAndReadResponse.go
@@ -102,6 +102,13 @@ func (c *LockAndReadResponse) Marshal() ([]byte, error) {
 	binary.BigEndian.PutUint16(buf2, uint16(c.CountOfBytesReturned))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
+	// Marshalling parameter Reserved (4 USHORT = 8 bytes, all MUST be 0x00)
+	for _, reservedWord := range c.Reserved {
+		bufReserved := make([]byte, 2)
+		binary.BigEndian.PutUint16(bufReserved, uint16(reservedWord))
+		rawParametersContent = append(rawParametersContent, bufReserved...)
+	}
+
 	// Marshalling parameters
 	c.GetParameters().AddWordsFromBytesStream(rawParametersContent)
 	marshalledParameters, err := c.GetParameters().Marshal()
@@ -158,6 +165,15 @@ func (c *LockAndReadResponse) Unmarshal(data []byte) (int, error) {
 	}
 	c.CountOfBytesReturned = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
+
+	// Unmarshalling parameter Reserved (4 USHORT = 8 bytes)
+	for i := range c.Reserved {
+		if len(rawParametersContent) < offset+2 {
+			return offset, fmt.Errorf("rawParametersContent too short for Reserved")
+		}
+		c.Reserved[i] = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+		offset += 2
+	}
 
 	// Then unmarshal the data
 	offset = 0


### PR DESCRIPTION
Closes #174

### Root Cause
The `LockAndReadResponse` struct declared `Reserved [4]types.USHORT` (8 bytes) per the MS-CIFS spec, but the `Marshal` and `Unmarshal` methods never serialized or parsed it. Because the `parameters` layer derives WordCount from the bytes actually added, only the 2-byte `CountOfBytesReturned` was emitted, producing WordCount 0x01 instead of the required 0x05 and truncating the parameter block by 8 bytes.

### Fix Description
`Marshal` now appends the 8-byte `Reserved` field (4 USHORTs) immediately after `CountOfBytesReturned`, and `Unmarshal` now parses those 8 bytes into `c.Reserved` with a length guard. This yields a 10-byte Words block (WordCount 0x05) matching the spec. Insertions are placed in regions distinct from the endianness fix (#167 / PR #204) so the two PRs do not conflict.

### How Verified
- Static: `Marshal` emits CountOfBytesReturned (2 bytes) + Reserved (8 bytes) = 10 bytes; `Unmarshal` consumes the matching 10 bytes; the loop guard uses `>= offset+2`.
- Tests: `go test ./network/smb/smb_v10/message/commands/...` passes; `go build ./...` succeeds.

### Test Coverage
- **Existing:** existing round-trip tests in the `commands` package continue to pass after the fix.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/LockAndReadResponse.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Notes
Spec: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/ac41df92-de51-4d2d-935a-7eae93ae9bcc
The Reserved bytes are all zero, so endianness is immaterial for this field; the companion PR #204 corrects the endianness of CountOfBytesReturned.