### PR TITLE
[bugfix] Fix SMB_FILE_ATTRIBUTES to marshal SearchAttributes little-endian (#157)

### DIFF
--- a/network/smb/smb_v10/types/SMB_FILE_ATTRIBUTES.go
+++ b/network/smb/smb_v10/types/SMB_FILE_ATTRIBUTES.go
@@ -31,7 +31,7 @@ func (s *SMB_FILE_ATTRIBUTES) SetAttributes(attributes uint16) {
 // - An error if the marshaling fails
 func (s *SMB_FILE_ATTRIBUTES) Marshal() ([]byte, error) {
 	buf := make([]byte, 2)
-	binary.BigEndian.PutUint16(buf, s.Attributes)
+	binary.LittleEndian.PutUint16(buf, s.Attributes)
 	return buf, nil
 }
 
@@ -43,6 +43,6 @@ func (s *SMB_FILE_ATTRIBUTES) Marshal() ([]byte, error) {
 // Returns:
 // - The number of bytes unmarshalled
 func (s *SMB_FILE_ATTRIBUTES) Unmarshal(data []byte) (int, error) {
-	s.Attributes = binary.BigEndian.Uint16(data)
+	s.Attributes = binary.LittleEndian.Uint16(data)
 	return 2, nil
 }

--- a/network/smb/smb_v10/types/SMB_FILE_ATTRIBUTES_test.go
+++ b/network/smb/smb_v10/types/SMB_FILE_ATTRIBUTES_test.go
@@ -104,12 +104,12 @@ func TestSMB_FILE_ATTRIBUTES_Marshal(t *testing.T) {
 		{
 			name:           "Read-only attribute",
 			attributes:     0x0001,
-			expectedOutput: []byte{0x00, 0x01},
+			expectedOutput: []byte{0x01, 0x00},
 		},
 		{
 			name:           "Multiple attributes",
 			attributes:     0x0037, // Read-only, Hidden, System, Directory, Archive
-			expectedOutput: []byte{0x00, 0x37},
+			expectedOutput: []byte{0x37, 0x00},
 		},
 	}
 
@@ -146,13 +146,13 @@ func TestSMB_FILE_ATTRIBUTES_Unmarshal(t *testing.T) {
 		},
 		{
 			name:              "Read-only attribute",
-			input:             []byte{0x00, 0x01},
+			input:             []byte{0x01, 0x00},
 			expectedAttr:      0x0001,
 			expectedBytesRead: 2,
 		},
 		{
 			name:              "Multiple attributes",
-			input:             []byte{0x00, 0x37, 0xFF}, // Extra byte should be ignored
+			input:             []byte{0x37, 0x00, 0xFF}, // Extra byte should be ignored
 			expectedAttr:      0x0037,
 			expectedBytesRead: 2,
 		},


### PR DESCRIPTION
### Linked Issue
Closes #157

### Root Cause
SMB/CIFS encodes all integer fields in little-endian byte order, but `SMB_FILE_ATTRIBUTES.Marshal`/`Unmarshal` used `binary.BigEndian`. Because the `parameters` layer of `smb_v10` is byte-preserving, the big-endian bytes produced by this type reached the wire unchanged, so every command that carries a `SMB_FILE_ATTRIBUTES` parameter (e.g. `SMB_COM_DELETE` `SearchAttributes`) transmitted the attribute word with its bytes swapped. The defect was masked because `Marshal`/`Unmarshal` are symmetric, so round-trip unit tests passed; the existing test even asserted the swapped byte order.

### Fix Description
Switched both `Marshal` and `Unmarshal` to `binary.LittleEndian`, matching the [MS-CIFS] wire format, and corrected the `SMB_FILE_ATTRIBUTES_test.go` Marshal/Unmarshal byte expectations to the little-endian representation (e.g. 0x0001 -> {0x01, 0x00}).

### How Verified
- Static: `Marshal` now emits `binary.LittleEndian.PutUint16` and `Unmarshal` reads `binary.LittleEndian.Uint16`, matching [MS-CIFS] SMB_COM_DELETE Request where SearchAttributes is a 2-byte little-endian field.
- Tests: ran `go test ./network/smb/smb_v10/...` — all pass, including the corrected `TestSMB_FILE_ATTRIBUTES_Marshal` and `TestSMB_FILE_ATTRIBUTES_Unmarshal`.
- Build: `go build ./...` succeeds.

### Test Coverage
**Existing:** `TestSMB_FILE_ATTRIBUTES_Marshal` and `TestSMB_FILE_ATTRIBUTES_Unmarshal` cover the corrected byte order after the fix.

### Scope of Change
- **Files changed:** network/smb/smb_v10/types/SMB_FILE_ATTRIBUTES.go, network/smb/smb_v10/types/SMB_FILE_ATTRIBUTES_test.go
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Blast radius is every SMB1 command using SMB_FILE_ATTRIBUTES (16 command files). The change corrects on-wire bytes to match the spec; safe to merge without staged rollout.
