### PR TITLE
[bugfix] Fix QueryInformationDiskResponse parameters to use little-endian (#171)

### DIFF
--- a/network/smb/smb_v10/message/commands/QueryInformationDiskResponse.go
+++ b/network/smb/smb_v10/message/commands/QueryInformationDiskResponse.go
@@ -99,27 +99,27 @@ func (c *QueryInformationDiskResponse) Marshal() ([]byte, error) {
 
 	// Marshalling parameter TotalUnits
 	buf2 := make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.TotalUnits))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.TotalUnits))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter BlocksPerUnit
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.BlocksPerUnit))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.BlocksPerUnit))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter BlockSize
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.BlockSize))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.BlockSize))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter FreeUnits
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.FreeUnits))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.FreeUnits))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter Reserved
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.Reserved))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.Reserved))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameters
@@ -176,35 +176,35 @@ func (c *QueryInformationDiskResponse) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for TotalUnits")
 	}
-	c.TotalUnits = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.TotalUnits = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter BlocksPerUnit
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for BlocksPerUnit")
 	}
-	c.BlocksPerUnit = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.BlocksPerUnit = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter BlockSize
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for BlockSize")
 	}
-	c.BlockSize = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.BlockSize = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter FreeUnits
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for FreeUnits")
 	}
-	c.FreeUnits = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.FreeUnits = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter Reserved
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for Reserved")
 	}
-	c.Reserved = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.Reserved = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Then unmarshal the data


### PR DESCRIPTION
A bug fix for QueryInformationDiskResponse.

### Linked Issue
Closes #171

### Root Cause
The command file was generated with `binary.BigEndian` for its SMB_Parameters Words and never exercised on the wire. Because the `parameters` layer is byte-preserving, the byte order chosen in the struct is exactly what is transmitted, so the five 16-bit fields went out byte-swapped relative to the little-endian SMB/CIFS wire format. Round-trip unit tests did not catch it because Marshal and Unmarshal were symmetrically wrong.

### Fix Description
Changed all `binary.BigEndian` references to `binary.LittleEndian` in both `Marshal()` and `Unmarshal()` for TotalUnits, BlocksPerUnit, BlockSize, FreeUnits, and Reserved. This matches [MS-CIFS] SMB_COM_QUERY_INFORMATION_DISK Response (https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/3d5291fd-33f5-4899-b3ad-949b0d4d7f93), where the Words block is five 16-bit unsigned fields, transmitted little-endian.

### How Verified
- `go build ./network/smb/smb_v10/...` succeeds.
- `go test ./network/smb/smb_v10/message/commands/...` passes.
- Static review: all ten BigEndian call sites (five in Marshal, five in Unmarshal) now use LittleEndian; field order and sizes already matched the spec.

### Test Coverage
**Existing:** existing round-trip tests in the commands package continue to pass; they verify Marshal/Unmarshal symmetry, which holds after the fix.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/QueryInformationDiskResponse.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local, single-file change limited to byte order of one command response. Safe to merge.