### PR TITLE
[bugfix] Fix QueryInformationRequest omits required BufferFormat 0x04 byte (#183)

### DIFF
--- a/network/smb/smb_v10/message/commands/QueryInformationRequest.go
+++ b/network/smb/smb_v10/message/commands/QueryInformationRequest.go
@@ -73,6 +73,7 @@ func (c *QueryInformationRequest) Marshal() ([]byte, error) {
 	rawDataContent := []byte{}
 
 	// Marshalling data FileName
+	c.FileName.SetBufferFormat(types.SMB_STRING_BUFFER_FORMAT_NULL_TERMINATED_ASCII_STRING)
 	bytesStream, err := c.FileName.Marshal()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### Linked Issue
Closes #183

### Root Cause
`NewQueryInformationRequest()` constructs `FileName` as a zero-value `types.SMB_STRING`, leaving its `BufferFormat` at `0x00`. `Marshal()` then called `c.FileName.Marshal()` without first selecting a buffer format. `SMB_STRING.Marshal()` switches on `BufferFormat`, and `0x00` matches no case, so it falls through to the `default` branch and returns `invalid buffer format: 0`. The required leading `0x04` byte was therefore never set, and marshalling failed outright.

### Fix Description
Set the FileName buffer format to `SMB_STRING_BUFFER_FORMAT_NULL_TERMINATED_ASCII_STRING` (0x04) immediately before marshalling, matching the pattern already used by the structurally identical `CheckDirectoryRequest.Marshal()`. Per MS-CIFS SMB_COM_QUERY_INFORMATION Request, the Bytes block is `BufferFormat (1 byte)` which MUST be `0x04`, followed by the null-terminated `SMB_STRING FileName`.

### How Verified
- Static: with the fix, `FileName.BufferFormat` is `0x04` at marshal time, so `SMB_STRING.Marshal()` takes the null-terminated ASCII case and emits `0x04` + name + `0x00`, satisfying the spec's `ByteCount >= 0x0002` requirement.
- `go build ./network/smb/smb_v10/...` succeeds.
- `go test ./network/smb/smb_v10/message/commands/...` passes.

### Test Coverage
**None:** the package has no test file for QueryInformationRequest; the fix mirrors the established and tested CheckDirectoryRequest pattern. Existing command/type tests continue to pass.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/QueryInformationRequest.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local and minimal: a single added line in `Marshal()`. Safe to merge directly.

### Spec
https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/fc708fd3-b133-415c-9659-b0acf5f596c7