### PR TITLE
[bugfix] Fix NtTransactSecondaryRequest parameters little-endian marshalling (#194)

### DIFF
--- a/network/smb/smb_v10/message/commands/NtTransactSecondaryRequest.go
+++ b/network/smb/smb_v10/message/commands/NtTransactSecondaryRequest.go
@@ -182,42 +182,42 @@ func (c *NtTransactSecondaryRequest) Marshal() ([]byte, error) {
 
 	// Marshalling parameter TotalParameterCount
 	buf4 := make([]byte, 4)
-	binary.BigEndian.PutUint32(buf4, uint32(c.TotalParameterCount))
+	binary.LittleEndian.PutUint32(buf4, uint32(c.TotalParameterCount))
 	rawParametersContent = append(rawParametersContent, buf4...)
 
 	// Marshalling parameter TotalDataCount
 	buf4 = make([]byte, 4)
-	binary.BigEndian.PutUint32(buf4, uint32(c.TotalDataCount))
+	binary.LittleEndian.PutUint32(buf4, uint32(c.TotalDataCount))
 	rawParametersContent = append(rawParametersContent, buf4...)
 
 	// Marshalling parameter ParameterCount
 	buf4 = make([]byte, 4)
-	binary.BigEndian.PutUint32(buf4, uint32(c.ParameterCount))
+	binary.LittleEndian.PutUint32(buf4, uint32(c.ParameterCount))
 	rawParametersContent = append(rawParametersContent, buf4...)
 
 	// Marshalling parameter ParameterOffset
 	buf4 = make([]byte, 4)
-	binary.BigEndian.PutUint32(buf4, uint32(c.ParameterOffset))
+	binary.LittleEndian.PutUint32(buf4, uint32(c.ParameterOffset))
 	rawParametersContent = append(rawParametersContent, buf4...)
 
 	// Marshalling parameter ParameterDisplacement
 	buf4 = make([]byte, 4)
-	binary.BigEndian.PutUint32(buf4, uint32(c.ParameterDisplacement))
+	binary.LittleEndian.PutUint32(buf4, uint32(c.ParameterDisplacement))
 	rawParametersContent = append(rawParametersContent, buf4...)
 
 	// Marshalling parameter DataCount
 	buf4 = make([]byte, 4)
-	binary.BigEndian.PutUint32(buf4, uint32(c.DataCount))
+	binary.LittleEndian.PutUint32(buf4, uint32(c.DataCount))
 	rawParametersContent = append(rawParametersContent, buf4...)
 
 	// Marshalling parameter DataOffset
 	buf4 = make([]byte, 4)
-	binary.BigEndian.PutUint32(buf4, uint32(c.DataOffset))
+	binary.LittleEndian.PutUint32(buf4, uint32(c.DataOffset))
 	rawParametersContent = append(rawParametersContent, buf4...)
 
 	// Marshalling parameter DataDisplacement
 	buf4 = make([]byte, 4)
-	binary.BigEndian.PutUint32(buf4, uint32(c.DataDisplacement))
+	binary.LittleEndian.PutUint32(buf4, uint32(c.DataDisplacement))
 	rawParametersContent = append(rawParametersContent, buf4...)
 
 	// Marshalling parameter Reserved2
@@ -277,56 +277,56 @@ func (c *NtTransactSecondaryRequest) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for TotalParameterCount")
 	}
-	c.TotalParameterCount = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	c.TotalParameterCount = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
 	offset += 4
 
 	// Unmarshalling parameter TotalDataCount
 	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for TotalDataCount")
 	}
-	c.TotalDataCount = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	c.TotalDataCount = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
 	offset += 4
 
 	// Unmarshalling parameter ParameterCount
 	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for ParameterCount")
 	}
-	c.ParameterCount = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	c.ParameterCount = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
 	offset += 4
 
 	// Unmarshalling parameter ParameterOffset
 	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for ParameterOffset")
 	}
-	c.ParameterOffset = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	c.ParameterOffset = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
 	offset += 4
 
 	// Unmarshalling parameter ParameterDisplacement
 	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for ParameterDisplacement")
 	}
-	c.ParameterDisplacement = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	c.ParameterDisplacement = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
 	offset += 4
 
 	// Unmarshalling parameter DataCount
 	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for DataCount")
 	}
-	c.DataCount = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	c.DataCount = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
 	offset += 4
 
 	// Unmarshalling parameter DataOffset
 	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for DataOffset")
 	}
-	c.DataOffset = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	c.DataOffset = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
 	offset += 4
 
 	// Unmarshalling parameter DataDisplacement
 	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for DataDisplacement")
 	}
-	c.DataDisplacement = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	c.DataDisplacement = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
 	offset += 4
 
 	// Unmarshalling parameter Reserved2


### PR DESCRIPTION
### Linked Issue
`Closes #194`

### Root Cause
The command struct was generated with `binary.BigEndian` for all 32-bit parameter fields. The `parameters` layer is byte-preserving (it re-emits words in the same byte order the struct supplied), so the big-endian bytes were transmitted verbatim, contrary to the little-endian wire format mandated by MS-CIFS. Round-trip unit tests never caught it because `Unmarshal` used `binary.BigEndian` symmetrically.

### Fix Description
Replaced every `binary.BigEndian` with `binary.LittleEndian` in both `Marshal()` and `Unmarshal()` (16 call sites) so the eight ULONG parameter fields are encoded and decoded little-endian as the spec requires. Marshal/Unmarshal symmetry is preserved.

### How Verified
- Static: all 16 integer conversions in the file now use `binary.LittleEndian`; `grep -c binary.BigEndian` returns 0.
- Tests: `go test ./network/smb/smb_v10/message/commands/` passes; `go build ./network/smb/smb_v10/...` succeeds.

### Test Coverage
**Existing:** existing round-trip tests in the commands package continue to pass after the change.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/NtTransactSecondaryRequest.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local to one command's wire encoding; safe to merge.

### Notes
This file has two further confirmed defects tracked separately: a missing 3-byte `Reserved1` field (#206) and incorrect `Pad1`/`Pad2` offset handling in `Unmarshal` (#209). Those PRs touch overlapping regions of this file and will need a rebase after this merges. Part of tracking issue #134.
