### PR TITLE
[bugfix] Fix CreateNewRequest CreationTime to be a 4-byte UTIME (#144)

### DIFF
--- a/network/smb/smb_v10/message/commands/CreateNewRequest.go
+++ b/network/smb/smb_v10/message/commands/CreateNewRequest.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"encoding/binary"
 	"fmt"
 
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/andx"
@@ -21,8 +22,8 @@ type CreateNewRequest struct {
 	// A 16-bit field of 1-bit flags that represent the file attributes to assign to the file if it is created successfully.
 	FileAttributes types.SMB_FILE_ATTRIBUTES
 
-	// The time that the file was created on the client, represented as the number of seconds since Jan 1, 1970, 00:00:00.0.
-	CreationTime types.FILETIME
+	// The time that the file was created on the client, represented as the number of seconds since Jan 1, 1970, 00:00:00.0 (a 4-byte UTIME).
+	CreationTime types.ULONG
 
 	// Data
 
@@ -38,7 +39,7 @@ func NewCreateNewRequest() *CreateNewRequest {
 	c := &CreateNewRequest{
 		// Parameters
 		FileAttributes: types.SMB_FILE_ATTRIBUTES{},
-		CreationTime:   types.FILETIME{},
+		CreationTime:   types.ULONG(0),
 
 		// Data
 		FileName: types.SMB_STRING{},
@@ -101,12 +102,10 @@ func (c *CreateNewRequest) Marshal() ([]byte, error) {
 	}
 	rawParametersContent = append(rawParametersContent, bytesStream...)
 
-	// Marshalling parameter CreationTime
-	bytesStream, err = c.CreationTime.Marshal()
-	if err != nil {
-		return nil, err
-	}
-	rawParametersContent = append(rawParametersContent, bytesStream...)
+	// Marshalling parameter CreationTime (4-byte UTIME, little-endian)
+	buf4 := make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf4, uint32(c.CreationTime))
+	rawParametersContent = append(rawParametersContent, buf4...)
 
 	// Marshalling parameters
 	c.GetParameters().AddWordsFromBytesStream(rawParametersContent)
@@ -165,15 +164,12 @@ func (c *CreateNewRequest) Unmarshal(data []byte) (int, error) {
 	}
 	offset += bytesRead
 
-	// Unmarshalling parameter CreationTime
-	if len(rawParametersContent) < offset+8 {
+	// Unmarshalling parameter CreationTime (4-byte UTIME, little-endian)
+	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for CreationTime")
 	}
-	bytesRead, err = c.CreationTime.Unmarshal(rawParametersContent[offset:])
-	if err != nil {
-		return offset, err
-	}
-	offset += bytesRead
+	c.CreationTime = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
+	offset += 4
 
 	// Then unmarshal the data
 	offset = 0


### PR DESCRIPTION
### Linked Issue
Closes #144

### Root Cause
The `CreationTime` field of `CreateNewRequest` was generated with the 8-byte `FILETIME` type instead of the 4-byte `UTIME` type the [MS-CIFS] SMB_COM_CREATE_NEW Request specification mandates. `FILETIME.Marshal()`/`Unmarshal()` always handle 8 bytes, so the parameter `Words` section was emitted as 10 bytes (FileAttributes 2 + CreationTime 8) instead of the required 6 bytes. This drove `WordCount` to `0x05` rather than the spec-mandated `0x03`, producing a malformed request that a compliant server would reject or misparse. Because `Marshal`/`Unmarshal` were symmetric, round-trip unit tests did not surface the defect.

### Fix Description
`CreationTime` is now a `types.ULONG` and is marshalled/unmarshalled as a 4-byte little-endian UTIME, matching the spec and the convention already used for the equivalent UTIME field (`LastTimeModified`) in `CloseRequest.go`. The `Unmarshal` length guard was corrected from `offset+8` to `offset+4` accordingly. This yields a 6-byte `Words` section and `WordCount = 0x03`. The `FileName` SMB_STRING handling already emits the mandatory `0x04` BufferFormat byte via `SMB_STRING.Marshal()` and was left unchanged.

### How Verified
- **Static:** `Marshal()` now appends exactly 2 (FileAttributes) + 4 (CreationTime) = 6 parameter bytes -> WordCount 0x03, per spec. `Unmarshal()` reads 4 bytes for CreationTime with a `>= offset+4` guard.
- **Tests:** `go test ./network/smb/smb_v10/message/commands/` passes.
- **Build:** `go build ./network/smb/smb_v10/message/commands/` succeeds.

### Test Coverage
- **Existing:** existing command round-trip tests in the package pass after the fix. No new test added; the defect is a fixed-size wire-layout correction validated against the spec field sizes.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/CreateNewRequest.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local to a single command structure. Changes the on-wire size of CreateNewRequest CreationTime from 8 to 4 bytes, which is the intended spec-conformant behavior; safe to merge.