### PR TITLE
[bugfix] Fix QueryInformation2Request FID marshalled big-endian instead of little-endian (#169)

### DIFF
--- a/network/smb/smb_v10/message/commands/QueryInformation2Request.go
+++ b/network/smb/smb_v10/message/commands/QueryInformation2Request.go
@@ -79,7 +79,7 @@ func (c *QueryInformation2Request) Marshal() ([]byte, error) {
 
 	// Marshalling parameter FID
 	buf2 := make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.FID))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.FID))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameters
@@ -136,7 +136,7 @@ func (c *QueryInformation2Request) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for FID")
 	}
-	c.FID = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.FID = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Then unmarshal the data


### PR DESCRIPTION
### Linked Issue
Closes #169

### Root Cause
The generated `QueryInformation2Request` command encoded its single `FID` parameter with `binary.BigEndian` in both `Marshal` and `Unmarshal`. SMB/CIFS transmits all integer fields little-endian, and the `parameters` layer in `smb_v10` is byte-preserving, so the big-endian bytes the struct produced were sent verbatim on the wire with the two FID bytes reversed. The defect was never caught because `Marshal`/`Unmarshal` are symmetric, so round-trip unit tests pass regardless of endianness.

### Fix Description
Switch the `FID` field to `binary.LittleEndian` in both `Marshal` (L82) and `Unmarshal` (L139), matching the little-endian convention used by the hand-corrected commands (e.g. `TreeConnectAndxRequest`). This is verified against [MS-CIFS SMB_COM_QUERY_INFORMATION2 Request](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/7b86f799-9dbb-4078-93c5-f9041c7f9f47), which specifies `WordCount = 0x01`, a single `USHORT FID` (2 bytes), and `ByteCount = 0x0000`.

### How Verified
- **Static:** the corrected `Marshal` now emits the FID low byte first; `Unmarshal` reads it back with the matching little-endian decode (L82, L139).
- **Tests:** `go test ./network/smb/smb_v10/message/commands/` passes; `go build ./network/smb/smb_v10/...` succeeds.

### Test Coverage
**Existing:** the package round-trip tests exercise `Marshal`/`Unmarshal` and continue to pass; they are symmetric so they do not assert on-wire byte order. No new test added because the existing suite has no golden-byte fixtures for this command and the change mirrors the established fix pattern used across the sibling files in tracking issue #134.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/QueryInformation2Request.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Notes
Part of tracking issue #134 (SMB command parameters marshalled big-endian across remaining command files).