### PR TITLE
[bugfix] Fix ReadRawRequest parameter marshalling to little-endian (#191)

### DIFF
--- a/network/smb/smb_v10/message/commands/ReadRawRequest.go
+++ b/network/smb/smb_v10/message/commands/ReadRawRequest.go
@@ -114,38 +114,38 @@ func (c *ReadRawRequest) Marshal() ([]byte, error) {
 
 	// Marshalling parameter FID
 	buf2 := make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.FID))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.FID))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter Offset
 	buf4 := make([]byte, 4)
-	binary.BigEndian.PutUint32(buf4, uint32(c.Offset))
+	binary.LittleEndian.PutUint32(buf4, uint32(c.Offset))
 	rawParametersContent = append(rawParametersContent, buf4...)
 
 	// Marshalling parameter MaxCountOfBytesToReturn
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.MaxCountOfBytesToReturn))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.MaxCountOfBytesToReturn))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter MinCountOfBytesToReturn
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.MinCountOfBytesToReturn))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.MinCountOfBytesToReturn))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter Timeout
 	buf4 = make([]byte, 4)
-	binary.BigEndian.PutUint32(buf4, uint32(c.Timeout))
+	binary.LittleEndian.PutUint32(buf4, uint32(c.Timeout))
 	rawParametersContent = append(rawParametersContent, buf4...)
 
 	// Marshalling parameter Reserved
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.Reserved))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.Reserved))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter OffsetHigh
 	if c.GetParameters().WordCount == 0x0A {
 		buf4 = make([]byte, 4)
-		binary.BigEndian.PutUint32(buf4, uint32(c.OffsetHigh))
+		binary.LittleEndian.PutUint32(buf4, uint32(c.OffsetHigh))
 		rawParametersContent = append(rawParametersContent, buf4...)
 	}
 
@@ -203,42 +203,42 @@ func (c *ReadRawRequest) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for FID")
 	}
-	c.FID = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.FID = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter Offset
 	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for Offset")
 	}
-	c.Offset = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	c.Offset = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
 	offset += 4
 
 	// Unmarshalling parameter MaxCountOfBytesToReturn
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for MaxCountOfBytesToReturn")
 	}
-	c.MaxCountOfBytesToReturn = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.MaxCountOfBytesToReturn = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter MinCountOfBytesToReturn
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for MinCountOfBytesToReturn")
 	}
-	c.MinCountOfBytesToReturn = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.MinCountOfBytesToReturn = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter Timeout
 	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for Timeout")
 	}
-	c.Timeout = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	c.Timeout = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
 	offset += 4
 
 	// Unmarshalling parameter Reserved
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for Reserved")
 	}
-	c.Reserved = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.Reserved = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter OffsetHigh
@@ -246,7 +246,7 @@ func (c *ReadRawRequest) Unmarshal(data []byte) (int, error) {
 		if len(rawParametersContent) < offset+4 {
 			return offset, fmt.Errorf("rawParametersContent too short for OffsetHigh")
 		}
-		c.OffsetHigh = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+		c.OffsetHigh = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
 		offset += 4
 	}
 


### PR DESCRIPTION
Part of #134.

### Linked Issue
Closes #191

### Root Cause
SMB/CIFS encodes all integer wire fields in little-endian byte order. `ReadRawRequest` was generated with `binary.BigEndian` for every parameter field in both `Marshal()` and `Unmarshal()`. Because the `parameters` layer is byte-preserving, those big-endian bytes were transmitted verbatim, byte-swapping every field on the wire. The defect was invisible to unit tests because `Marshal`/`Unmarshal` are symmetric and round-trip cleanly.

### Fix Description
Replaced all 14 `binary.BigEndian` references with `binary.LittleEndian` in `Marshal()` and `Unmarshal()`, covering FID, Offset, MaxCountOfBytesToReturn, MinCountOfBytesToReturn, Timeout, Reserved, and the optional OffsetHigh field. Field order, sizes, and the WordCount 0x08/0x0A optional-OffsetHigh logic already matched [MS-CIFS SMB_COM_READ_RAW Request](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/1458b62a-18ed-4fb2-b8a9-ceabffb2c3b7) and are unchanged.

### How Verified
- **Static:** Every parameter field now encodes/decodes little-endian, matching the MS-CIFS spec; the emitted parameter bytes are now correct on the wire.
- **Tests:** `go build ./network/smb/smb_v10/...` succeeds and `go test ./network/smb/smb_v10/message/commands/...` passes.

### Test Coverage
**Existing:** existing command round-trip tests cover the package and pass; they are endianness-symmetric so they validated structure but not wire byte order (the bug class). No new test added because the package has no golden-byte harness; the fix is a direct spec-conformance correction verified against the MS-CIFS field sizes.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/ReadRawRequest.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local to ReadRawRequest serialization; safe to merge. Any code that previously relied on the (incorrect) big-endian output would itself have been non-interoperable with real SMB peers.