### PR TITLE
[bugfix] Fix SeekRequest little-endian parameter marshalling (#202)

### DIFF
--- a/network/smb/smb_v10/message/commands/SeekRequest.go
+++ b/network/smb/smb_v10/message/commands/SeekRequest.go
@@ -88,17 +88,17 @@ func (c *SeekRequest) Marshal() ([]byte, error) {
 
 	// Marshalling parameter FID
 	buf2 := make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.FID))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.FID))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter Mode
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.Mode))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.Mode))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter Offset
 	buf4 := make([]byte, 4)
-	binary.BigEndian.PutUint32(buf4, uint32(c.Offset))
+	binary.LittleEndian.PutUint32(buf4, uint32(c.Offset))
 	rawParametersContent = append(rawParametersContent, buf4...)
 
 	// Marshalling parameters
@@ -155,21 +155,21 @@ func (c *SeekRequest) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for FID")
 	}
-	c.FID = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.FID = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter Mode
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for Mode")
 	}
-	c.Mode = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.Mode = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter Offset
 	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for Offset")
 	}
-	c.Offset = types.LONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	c.Offset = types.LONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
 	offset += 4
 
 	// Then unmarshal the data


### PR DESCRIPTION
### Linked Issue
Closes #202

### Root Cause
`SeekRequest.Marshal` and `SeekRequest.Unmarshal` were generated using `binary.BigEndian` for the `FID`, `Mode`, and `Offset` parameter fields. SMB/CIFS encodes all integer fields little-endian, and the `parameters` layer is byte-preserving, so whatever endianness the command struct builds is exactly what reaches the wire. The big-endian encoding byte-swapped all three fields. Round-trip unit tests passed because Marshal and Unmarshal shared the same incorrect endianness.

### Fix Description
Switch FID, Mode, and Offset to `binary.LittleEndian` in both `Marshal` (L91, L96, L101) and `Unmarshal` (L158, L165, L172). This matches MS-CIFS SMB_COM_SEEK Request (WordCount=0x0004: USHORT FID, USHORT Mode, LONG Offset), https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/e9dd996c-ba2b-474b-ae5d-5f65c3be1251.

### How Verified
- Static: all six encode/decode sites now use `binary.LittleEndian`; no `binary.BigEndian` references remain in the file.
- `go build ./network/smb/smb_v10/...` succeeds.
- `go test ./network/smb/smb_v10/message/commands/...` passes.

### Test Coverage
**Existing:** existing round-trip tests in the commands package continue to pass. They remain symmetric and do not assert wire bytes, but the change is a one-to-one endianness swap consistent with the already-merged little-endian fixes for sibling commands.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/SeekRequest.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local to one command's wire encoding; safe to merge. Corrects the bytes sent/parsed for SMB_COM_SEEK to match the spec.

### Notes
Part of tracking issue #134.