### PR TITLE
[bugfix] Fix OpenRequest FileName BufferFormat 0x04 emission (#198)

### DIFF
--- a/network/smb/smb_v10/message/commands/OpenRequest.go
+++ b/network/smb/smb_v10/message/commands/OpenRequest.go
@@ -90,6 +90,10 @@ func (c *OpenRequest) Marshal() ([]byte, error) {
 	rawDataContent := []byte{}
 
 	// Marshalling data FileName
+	// Per MS-CIFS, the SMB_COM_OPEN data block starts with a BufferFormat byte that MUST be 0x04
+	// (a null-terminated ASCII string follows). The SMB_STRING marshaller emits this byte from its
+	// BufferFormat field, so it must be set before marshalling.
+	c.FileName.SetBufferFormat(types.SMB_STRING_BUFFER_FORMAT_NULL_TERMINATED_ASCII_STRING)
 	bytesStream, err := c.FileName.Marshal()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### Linked Issue
Closes #198

### Root Cause
The MS-CIFS SMB_COM_OPEN Request data block is `UCHAR BufferFormat` (MUST be 0x04) followed by the `SMB_STRING FileName`. In this codebase the BufferFormat byte is emitted by `SMB_STRING.Marshal` from its `BufferFormat` field. `OpenRequest.Marshal` marshalled `FileName` without first setting that field, leaving it at its zero value `0x00`, which is not a valid format and causes `SMB_STRING.Marshal` to return `invalid buffer format: 0`. The mandatory 0x04 prefix was therefore never emitted and the request could not be marshalled. Sibling commands (`DeleteRequest`, `CreateDirectoryRequest`) already set the format before marshalling; OpenRequest omitted that call.

### Fix Description
Set `c.FileName.SetBufferFormat(types.SMB_STRING_BUFFER_FORMAT_NULL_TERMINATED_ASCII_STRING)` (0x04) immediately before `c.FileName.Marshal()`, matching the spec (https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/ab9bb872-1967-4088-b444-6a35d0af305e) and the established sibling-command pattern. The data block now emits `0x04` + null-terminated FileName, so ByteCount is >= 0x0002 as required.

### How Verified
- Static: FileName marshalling now sets format 0x04, so `SMB_STRING.Marshal` takes the NULL_TERMINATED_ASCII_STRING branch and prepends the 0x04 BufferFormat byte followed by the null-terminated name.
- Tests: `go test ./network/smb/smb_v10/message/commands/` passes.
- Build: `go build ./network/smb/smb_v10/...` passes.

### Test Coverage
**Existing:** package round-trip tests pass; Unmarshal already reads the BufferFormat byte via `SMB_STRING.Unmarshal`, so the corrected Marshal is symmetric with it.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/OpenRequest.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local, single-statement change in the Marshal data path; safe to merge directly.