### PR TITLE
[bugfix] Fix QueryInformationResponse FileSize little-endian encoding (#213)

### DIFF
--- a/network/smb/smb_v10/message/commands/QueryInformationResponse.go
+++ b/network/smb/smb_v10/message/commands/QueryInformationResponse.go
@@ -107,7 +107,7 @@ func (c *QueryInformationResponse) Marshal() ([]byte, error) {
 
 	// Marshalling parameter FileSize
 	buf4 := make([]byte, 4)
-	binary.BigEndian.PutUint32(buf4, uint32(c.FileSize))
+	binary.LittleEndian.PutUint32(buf4, uint32(c.FileSize))
 	rawParametersContent = append(rawParametersContent, buf4...)
 
 	// Marshalling parameters
@@ -184,7 +184,7 @@ func (c *QueryInformationResponse) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for FileSize")
 	}
-	c.FileSize = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	c.FileSize = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
 	offset += 4
 
 	// Then unmarshal the data


### PR DESCRIPTION
### Linked Issue
Closes #213

### Root Cause
The generated `QueryInformationResponse` code encoded and decoded the 4-byte `FileSize` field with `binary.BigEndian`. SMB/CIFS transmits all integer fields little-endian, and the `parameters` layer is byte-preserving, so the big-endian bytes reached the wire byte-swapped. Round-trip unit tests did not catch this because Marshal and Unmarshal were symmetrically wrong.

### Fix Description
Changed `binary.BigEndian.PutUint32` to `binary.LittleEndian.PutUint32` in `Marshal` and `binary.BigEndian.Uint32` to `binary.LittleEndian.Uint32` in `Unmarshal` for the `FileSize` field, matching the little-endian encoding used by sibling fields such as `FileAttributes` and the [MS-CIFS] specification.

### How Verified
- Static: the two edited lines now use `binary.LittleEndian`, consistent with `FileAttributes` (`SMB_FILE_ATTRIBUTES.Marshal`) and [MS-CIFS] SMB_COM_QUERY_INFORMATION Response (https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/847573c9-cbe6-4dcb-a0db-9b5af815759b).
- `go build ./network/smb/smb_v10/message/commands/` succeeds.
- `go test ./network/smb/smb_v10/message/commands/` passes.

### Test Coverage
**Existing:** existing round-trip tests in the commands package continue to pass; they exercise the Marshal/Unmarshal path for this command.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/QueryInformationResponse.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local, low blast radius: changes only the wire endianness of `FileSize` for this one command. Safe to merge directly.
