### PR TITLE
[bugfix] Fix FindUniqueRequest MaxCount little-endian marshalling (#181)

### DIFF
--- a/network/smb/smb_v10/message/commands/FindUniqueRequest.go
+++ b/network/smb/smb_v10/message/commands/FindUniqueRequest.go
@@ -113,7 +113,7 @@ func (c *FindUniqueRequest) Marshal() ([]byte, error) {
 
 	// Marshalling parameter MaxCount
 	buf2 := make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.MaxCount))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.MaxCount))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter SearchAttributes
@@ -177,7 +177,7 @@ func (c *FindUniqueRequest) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for MaxCount")
 	}
-	c.MaxCount = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.MaxCount = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter SearchAttributes


### PR DESCRIPTION
### Linked Issue
Closes #181

### Root Cause
`FindUniqueRequest` was generated with a big-endian default for its `MaxCount` parameter. MS-CIFS defines all SMB integer fields as little-endian, and the `parameters` layer is byte-preserving, so the big-endian bytes the struct produced reached the wire unchanged. Symmetric round-trip unit tests could not detect the swap.

### Fix Description
Changed `MaxCount` serialization in `Marshal()` from `binary.BigEndian.PutUint16` to `binary.LittleEndian.PutUint16`, and the matching parse in `Unmarshal()` from `binary.BigEndian.Uint16` to `binary.LittleEndian.Uint16`. No other fields touched.

### How Verified
- Static: per MS-CIFS SMB_COM_FIND_UNIQUE Request, `MaxCount (2 bytes)` is a little-endian `USHORT`; the two edited lines now emit/consume little-endian bytes.
- `go build ./network/smb/smb_v10/message/commands/` passes.
- `go test ./network/smb/smb_v10/message/commands/` passes.

### Test Coverage
**None:** no dedicated FindUniqueRequest round-trip test exists; existing symmetric tests cannot distinguish endianness. The fix is a direct byte-order correction verified against the spec.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/FindUniqueRequest.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local two-line byte-order correction; safe to merge. Part of the systemic big-endian defect class tracked in #134.