### PR TITLE
[bugfix] Fix Transaction2SecondaryRequest little-endian parameter marshalling (#210)

### DIFF
--- a/network/smb/smb_v10/message/commands/Transaction2SecondaryRequest.go
+++ b/network/smb/smb_v10/message/commands/Transaction2SecondaryRequest.go
@@ -186,47 +186,47 @@ func (c *Transaction2SecondaryRequest) Marshal() ([]byte, error) {
 
 	// Marshalling parameter TotalParameterCount
 	buf2 := make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.TotalParameterCount))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.TotalParameterCount))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter TotalDataCount
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.TotalDataCount))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.TotalDataCount))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter ParameterCount
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.ParameterCount))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.ParameterCount))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter ParameterOffset
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.ParameterOffset))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.ParameterOffset))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter ParameterDisplacement
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.ParameterDisplacement))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.ParameterDisplacement))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter DataCount
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.DataCount))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.DataCount))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter DataOffset
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.DataOffset))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.DataOffset))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter DataDisplacement
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.DataDisplacement))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.DataDisplacement))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter FID
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.FID))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.FID))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameters
@@ -283,63 +283,63 @@ func (c *Transaction2SecondaryRequest) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for TotalParameterCount")
 	}
-	c.TotalParameterCount = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.TotalParameterCount = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter TotalDataCount
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for TotalDataCount")
 	}
-	c.TotalDataCount = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.TotalDataCount = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter ParameterCount
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for ParameterCount")
 	}
-	c.ParameterCount = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.ParameterCount = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter ParameterOffset
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for ParameterOffset")
 	}
-	c.ParameterOffset = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.ParameterOffset = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter ParameterDisplacement
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for ParameterDisplacement")
 	}
-	c.ParameterDisplacement = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.ParameterDisplacement = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter DataCount
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for DataCount")
 	}
-	c.DataCount = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.DataCount = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter DataOffset
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for DataOffset")
 	}
-	c.DataOffset = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.DataOffset = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter DataDisplacement
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for DataDisplacement")
 	}
-	c.DataDisplacement = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.DataDisplacement = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter FID
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for FID")
 	}
-	c.FID = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.FID = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Then unmarshal the data


### PR DESCRIPTION
### Linked Issue
Closes #210

### Root Cause
The generated `Transaction2SecondaryRequest` command file encoded and decoded its nine `SMB_Parameters.Words` fields using `binary.BigEndian`. SMB/CIFS integers are little-endian on the wire, and the `parameters` layer is byte-preserving, so the big-endian bytes were transmitted unchanged. The file was never exercised against a live server, and the symmetric Marshal/Unmarshal kept round-trip unit tests green, hiding the defect.

### Fix Description
Replaced every `binary.BigEndian` with `binary.LittleEndian` in `Marshal()` and `Unmarshal()` for all nine USHORT parameter words (TotalParameterCount, TotalDataCount, ParameterCount, ParameterOffset, ParameterDisplacement, DataCount, DataOffset, DataDisplacement, FID). This matches the [MS-CIFS SMB_COM_TRANSACTION2_SECONDARY Request](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/da6bf4b0-3a71-4f1f-9c04-8426cf82b892) wire format, where WordCount is 0x09 and all Words are little-endian USHORTs.

### How Verified
- `go build ./network/smb/...` succeeds.
- `go test ./network/smb/smb_v10/message/commands/` passes.
- Static review: 18 conversions (9 in Marshal, 9 in Unmarshal); zero `binary.BigEndian` remain in the file.

### Test Coverage
**Existing:** the existing round-trip tests in the `commands` package continue to pass; they remain symmetric so they validate field order and sizing after the endianness correction.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/Transaction2SecondaryRequest.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Low blast radius, single file, local change confined to byte order of one command's parameter words. Safe to merge without staged rollout.