### PR TITLE
[bugfix] Fix QueryInformation2Response little-endian ULONG marshalling (#184)

### DIFF
--- a/network/smb/smb_v10/message/commands/QueryInformation2Response.go
+++ b/network/smb/smb_v10/message/commands/QueryInformation2Response.go
@@ -154,12 +154,12 @@ func (c *QueryInformation2Response) Marshal() ([]byte, error) {
 
 	// Marshalling parameter FileDataSize
 	buf4 := make([]byte, 4)
-	binary.BigEndian.PutUint32(buf4, uint32(c.FileDataSize))
+	binary.LittleEndian.PutUint32(buf4, uint32(c.FileDataSize))
 	rawParametersContent = append(rawParametersContent, buf4...)
 
 	// Marshalling parameter FileAllocationSize
 	buf4 = make([]byte, 4)
-	binary.BigEndian.PutUint32(buf4, uint32(c.FileAllocationSize))
+	binary.LittleEndian.PutUint32(buf4, uint32(c.FileAllocationSize))
 	rawParametersContent = append(rawParametersContent, buf4...)
 
 	// Marshalling parameter FileAttributes
@@ -263,14 +263,14 @@ func (c *QueryInformation2Response) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for FileDataSize")
 	}
-	c.FileDataSize = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	c.FileDataSize = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
 	offset += 4
 
 	// Unmarshalling parameter FileAllocationSize
 	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for FileAllocationSize")
 	}
-	c.FileAllocationSize = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	c.FileAllocationSize = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
 	offset += 4
 
 	// Unmarshalling parameter FileAttributes


### PR DESCRIPTION
### Linked Issue
Closes #184

### Root Cause
The `QueryInformation2Response` command file was generated with a big-endian default for its `ULONG` parameter fields. The `parameters` layer is byte-preserving, so whatever endianness the struct uses reaches the wire verbatim; SMB/CIFS integers are little-endian. Round-trip unit tests did not catch this because `Marshal` and `Unmarshal` are symmetric.

### Fix Description
Switched the `FileDataSize` and `FileAllocationSize` encode/decode from `binary.BigEndian` to `binary.LittleEndian` in both `Marshal()` and `Unmarshal()`. This matches the MS-CIFS SMB_COM_QUERY_INFORMATION2 Response layout and the sibling `SMB_DATE`/`SMB_TIME`/`SMB_FILE_ATTRIBUTES` types, which already marshal little-endian.

### How Verified
- Static: the four changed lines (Marshal L157/L162, Unmarshal L266/L273) now use `binary.LittleEndian`, producing little-endian bytes on the wire and decoding them correctly.
- Tests: `go build ./network/smb/smb_v10/...` and `go test ./network/smb/smb_v10/message/commands/` both pass.

### Test Coverage
**Existing:** the package's existing round-trip tests cover the marshalling path and continue to pass; the fix preserves Marshal<->Unmarshal symmetry.

### Scope of Change
- **Files changed:** network/smb/smb_v10/message/commands/QueryInformation2Response.go
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Notes
Part of the systemic big-endian defect class tracked in #134. Spec: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/eed3d7c3-759e-470a-8731-10583931426f