### PR TITLE
[bugfix] Fix OpenAndxRequest CreationTime to a 4-byte UTIME (#185)

### DIFF
--- a/network/smb/smb_v10/message/commands/OpenAndxRequest.go
+++ b/network/smb/smb_v10/message/commands/OpenAndxRequest.go
@@ -37,9 +37,9 @@ type OpenAndxRequest struct {
 	// MUST refer to a regular file.
 	FileAttrs types.SMB_FILE_ATTRIBUTES
 
-	// CreationTime (4 bytes): A 32-bit integer time value to be assigned to the file
-	// as the time of creation if the file is created.
-	CreationTime types.FILETIME
+	// CreationTime (4 bytes): A 32-bit integer time value (UTIME) to be assigned to the
+	// file as the time of creation if the file is created.
+	CreationTime types.ULONG
 
 	// OpenMode (2 bytes): A 16-bit field that controls the way a file SHOULD be
 	// treated when it is opened for use by certain extended SMB requests.
@@ -74,7 +74,7 @@ func NewOpenAndxRequest() *OpenAndxRequest {
 		AccessMode:     types.USHORT(0),
 		SearchAttrs:    types.SMB_FILE_ATTRIBUTES{},
 		FileAttrs:      types.SMB_FILE_ATTRIBUTES{},
-		CreationTime:   types.FILETIME{},
+		CreationTime:   types.ULONG(0),
 		OpenMode:       types.USHORT(0),
 		AllocationSize: types.ULONG(0),
 		Timeout:        types.ULONG(0),
@@ -162,12 +162,10 @@ func (c *OpenAndxRequest) Marshal() ([]byte, error) {
 	}
 	rawParametersContent = append(rawParametersContent, bytesStream...)
 
-	// Marshalling parameter CreationTime
-	bytesStream, err = c.CreationTime.Marshal()
-	if err != nil {
-		return nil, err
-	}
-	rawParametersContent = append(rawParametersContent, bytesStream...)
+	// Marshalling parameter CreationTime (4-byte UTIME)
+	bufCreationTime := make([]byte, 4)
+	binary.BigEndian.PutUint32(bufCreationTime, uint32(c.CreationTime))
+	rawParametersContent = append(rawParametersContent, bufCreationTime...)
 
 	// Marshalling parameter OpenMode
 	buf2 = make([]byte, 2)
@@ -272,15 +270,12 @@ func (c *OpenAndxRequest) Unmarshal(data []byte) (int, error) {
 	}
 	offset += bytesRead
 
-	// Unmarshalling parameter CreationTime
-	if len(rawParametersContent) < offset+8 {
+	// Unmarshalling parameter CreationTime (4-byte UTIME)
+	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for CreationTime")
 	}
-	bytesRead, err = c.CreationTime.Unmarshal(rawParametersContent[offset:])
-	if err != nil {
-		return offset, err
-	}
-	offset += bytesRead
+	c.CreationTime = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	offset += 4
 
 	// Unmarshalling parameter OpenMode
 	if len(rawParametersContent) < offset+2 {


### PR DESCRIPTION
### Linked Issue
Closes #185

### Root Cause
The generated `OpenAndxRequest` struct mapped the spec field `UTIME CreationTime` to the Go type `types.FILETIME`, whose `Marshal()` emits 8 bytes (and `Unmarshal()` consumes 8). [MS-CIFS] (https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/3a760987-f60d-4012-930b-fe90328775cc) defines `CreationTime` as a 4-byte UTIME and requires `WordCount` = 0x0F (15 words = 30 bytes of Words). With CreationTime taking 8 bytes the Words block was 34 bytes, corrupting WordCount and every field that follows it on the wire.

### Fix Description
Changed `CreationTime` from `types.FILETIME` to `types.ULONG` (a 4-byte unsigned 32-bit value, matching UTIME), updated the constructor default, and replaced the 8-byte `FILETIME.Marshal()`/`Unmarshal()` calls with explicit 4-byte encode/decode and a `>= offset+4` length guard. This mirrors the same fix already applied to CreateRequest (#145), CreateNewRequest (#144), and CreateTemporaryRequest (#146). Endianness of the integer fields is addressed separately (#195) and left unchanged here.

### How Verified
- **Static:** CreationTime now contributes exactly 4 bytes, making the Words block 30 bytes (WordCount 0x0F) as required by the spec.
- **Tests:** `go test ./network/smb/smb_v10/message/commands/...` passes; `go build ./network/smb/smb_v10/...` succeeds.

### Test Coverage
**Existing:** the package round-trip tests in `network/smb/smb_v10/message/commands` exercise marshal/unmarshal symmetry and pass after the change.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/OpenAndxRequest.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local to one command struct; safe to merge. The field type is now a 32-bit integer instead of a FILETIME wrapper, which is the correct UTIME representation.