### PR TITLE
[bugfix] Fix TreeConnectResponse little-endian parameter marshalling (#215)

### DIFF
--- a/network/smb/smb_v10/message/commands/TreeConnectResponse.go
+++ b/network/smb/smb_v10/message/commands/TreeConnectResponse.go
@@ -89,12 +89,12 @@ func (c *TreeConnectResponse) Marshal() ([]byte, error) {
 
 	// Marshalling parameter MaxBufferSize
 	buf2 := make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.MaxBufferSize))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.MaxBufferSize))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter TID
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.TID))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.TID))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameters
@@ -151,14 +151,14 @@ func (c *TreeConnectResponse) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for MaxBufferSize")
 	}
-	c.MaxBufferSize = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.MaxBufferSize = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter TID
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for TID")
 	}
-	c.TID = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.TID = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Then unmarshal the data


### PR DESCRIPTION
### Linked Issue
Closes #215

### Root Cause
The generated `TreeConnectResponse` command file defaulted to `binary.BigEndian` for its 16-bit parameter fields. The `parameters` layer in `smb_v10` is byte-preserving, so the big-endian bytes were emitted verbatim onto the wire. Because `Marshal` and `Unmarshal` used the same (wrong) endianness, round-trip unit tests passed and the defect was never caught.

### Fix Description
Switched both `MaxBufferSize` and `TID` to `binary.LittleEndian` in `Marshal()` (L92, L97) and `Unmarshal()` (L154, L161), matching the MS-CIFS SMB_COM_TREE_CONNECT Response specification, which defines both as little-endian USHORT values. Marshal/Unmarshal symmetry is preserved.

### How Verified
- **Static:** The four field accesses now use `binary.LittleEndian.PutUint16` / `binary.LittleEndian.Uint16`, so a non-zero `TID` (e.g. 0x0001) serializes as `01 00` per spec instead of `00 01`.
- **Tests:** `go test ./network/smb/smb_v10/message/commands/...` passes.
- **Build:** `go build ./network/smb/smb_v10/...` succeeds.

### Test Coverage
**Existing:** existing round-trip tests in the commands package cover serialization symmetry and continue to pass after the fix.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/TreeConnectResponse.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local and low-risk: only the byte order of two parameter fields in one command changes, correcting wire output to match the spec. Safe to merge directly.

### Notes
Part of the systemic big-endian defect class tracked in #134.