### PR TITLE
[bugfix] Fix Transaction2Request parameter marshalling to little-endian (#221)

### DIFF
--- a/network/smb/smb_v10/message/commands/Transaction2Request.go
+++ b/network/smb/smb_v10/message/commands/Transaction2Request.go
@@ -237,22 +237,22 @@ func (c *Transaction2Request) Marshal() ([]byte, error) {
 
 	// Marshalling parameter TotalParameterCount
 	buf2 := make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.TotalParameterCount))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.TotalParameterCount))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter TotalDataCount
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.TotalDataCount))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.TotalDataCount))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter MaxParameterCount
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.MaxParameterCount))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.MaxParameterCount))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter MaxDataCount
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.MaxDataCount))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.MaxDataCount))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter MaxSetupCount
@@ -263,37 +263,37 @@ func (c *Transaction2Request) Marshal() ([]byte, error) {
 
 	// Marshalling parameter Flags
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.Flags))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.Flags))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter Timeout
 	buf4 := make([]byte, 4)
-	binary.BigEndian.PutUint32(buf4, uint32(c.Timeout))
+	binary.LittleEndian.PutUint32(buf4, uint32(c.Timeout))
 	rawParametersContent = append(rawParametersContent, buf4...)
 
 	// Marshalling parameter Reserved2
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.Reserved2))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.Reserved2))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter ParameterCount
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.ParameterCount))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.ParameterCount))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter ParameterOffset
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.ParameterOffset))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.ParameterOffset))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter DataCount
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.DataCount))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.DataCount))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter DataOffset
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.DataOffset))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.DataOffset))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter SetupCount
@@ -356,28 +356,28 @@ func (c *Transaction2Request) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for TotalParameterCount")
 	}
-	c.TotalParameterCount = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.TotalParameterCount = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter TotalDataCount
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for TotalDataCount")
 	}
-	c.TotalDataCount = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.TotalDataCount = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter MaxParameterCount
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for MaxParameterCount")
 	}
-	c.MaxParameterCount = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.MaxParameterCount = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter MaxDataCount
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for MaxDataCount")
 	}
-	c.MaxDataCount = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.MaxDataCount = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter MaxSetupCount
@@ -398,49 +398,49 @@ func (c *Transaction2Request) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for Flags")
 	}
-	c.Flags = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.Flags = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter Timeout
 	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for Timeout")
 	}
-	c.Timeout = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	c.Timeout = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
 	offset += 4
 
 	// Unmarshalling parameter Reserved2
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for Reserved2")
 	}
-	c.Reserved2 = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.Reserved2 = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter ParameterCount
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for ParameterCount")
 	}
-	c.ParameterCount = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.ParameterCount = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter ParameterOffset
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for ParameterOffset")
 	}
-	c.ParameterOffset = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.ParameterOffset = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter DataCount
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for DataCount")
 	}
-	c.DataCount = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.DataCount = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter DataOffset
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for DataOffset")
 	}
-	c.DataOffset = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.DataOffset = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter SetupCount


### PR DESCRIPTION
### Linked Issue
Closes #221

### Root Cause
`Transaction2Request.go` was generated with a big-endian default for its SMB_Parameters integer fields. The `parameters` layer is byte-preserving, so the big-endian bytes were transmitted verbatim on the wire. SMB/CIFS integers are little-endian, so every multi-byte parameter (counts, offsets, flags, timeout) was byte-swapped. Symmetric `Marshal`/`Unmarshal` round-trip unit tests passed regardless, hiding the defect.

### Fix Description
Changed all `binary.BigEndian` reads and writes for the SMB_Parameters fields to `binary.LittleEndian` in both `Marshal()` and `Unmarshal()` (TotalParameterCount, TotalDataCount, MaxParameterCount, MaxDataCount, Flags, Timeout, Reserved2, ParameterCount, ParameterOffset, DataCount, DataOffset). The single-byte fields (MaxSetupCount, Reserved1, SetupCount, Reserved3, Name) are unaffected. Field order and sizes already match [MS-CIFS 2.2.4.46.1](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/f7d148cd-e3d5-49ae-8b37-9633822bfeac).

### How Verified
- Static: every `binary.BigEndian` occurrence (22 total: 11 in Marshal, 11 in Unmarshal) now reads `binary.LittleEndian`; Marshal/Unmarshal remain symmetric.
- `go build ./network/smb/smb_v10/message/commands/` succeeds.
- `go test ./network/smb/smb_v10/message/commands/ -run Transaction2` passes.

### Test Coverage
**Existing:** existing round-trip tests in the commands package continue to pass; they remain symmetric so they validate structure but not endianness (the wire-format correctness is established against the MS-CIFS spec).

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/Transaction2Request.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Low blast radius; the change is local to one command struct and aligns it with the documented CIFS little-endian wire format. Safe to merge.