### PR TITLE
[bugfix] Fix SeekResponse Offset marshalling to little-endian (#197)

### DIFF
--- a/network/smb/smb_v10/message/commands/SeekResponse.go
+++ b/network/smb/smb_v10/message/commands/SeekResponse.go
@@ -80,7 +80,7 @@ func (c *SeekResponse) Marshal() ([]byte, error) {
 
 	// Marshalling parameter Offset
 	buf4 := make([]byte, 4)
-	binary.BigEndian.PutUint32(buf4, uint32(c.Offset))
+	binary.LittleEndian.PutUint32(buf4, uint32(c.Offset))
 	rawParametersContent = append(rawParametersContent, buf4...)
 
 	// Marshalling parameters
@@ -137,7 +137,7 @@ func (c *SeekResponse) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for Offset")
 	}
-	c.Offset = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	c.Offset = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
 	offset += 4
 
 	// Then unmarshal the data


### PR DESCRIPTION
### Linked Issue
Closes #197

### Root Cause
The generated `SeekResponse` command marshalled and unmarshalled its `Offset` parameter with `binary.BigEndian`. SMB/CIFS integer fields are little-endian on the wire, and the `parameters` layer in `network/smb/smb_v10` is byte-preserving, so the endianness chosen by the struct is exactly what is transmitted. The defect was never caught because Marshal/Unmarshal are symmetric, so round-trip unit tests pass regardless of byte order.

### Fix Description
Changed both the `Marshal` and `Unmarshal` paths of `Offset` to use `binary.LittleEndian`, matching the [MS-CIFS SMB_COM_SEEK Response](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/089b214b-8501-4bcb-a9bd-9b2aa80b0042) specification (Words block: a single 4-byte `ULONG Offset`). Marshal/Unmarshal symmetry is preserved.

### How Verified
- Static: per MS-CIFS the response Words block is a single `ULONG Offset` (4 bytes) and all SMB/CIFS integers are little-endian; the patched L83/L140 now emit/consume little-endian bytes.
- Tests: `go build ./network/smb/smb_v10/message/commands/...` and `go test ./network/smb/smb_v10/message/commands/` both pass on a clean checkout of this branch.

### Test Coverage
**Existing:** the package's existing round-trip tests cover the Marshal/Unmarshal path and pass. They are symmetric and do not assert byte order; correctness against the wire format is established by the spec citation above.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/SeekResponse.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local change to a single command's byte order; blast radius limited to SMB_COM_SEEK response serialization. Safe to merge.

### Notes
Part of tracking issue #134 (systemic big-endian parameter marshalling across SMB command files).