### PR TITLE
[bugfix] Fix SearchRequest MaxCount little-endian (#199)

### DIFF
--- a/network/smb/smb_v10/message/commands/SearchRequest.go
+++ b/network/smb/smb_v10/message/commands/SearchRequest.go
@@ -132,7 +132,7 @@ func (c *SearchRequest) Marshal() ([]byte, error) {
 
 	// Marshalling parameter MaxCount
 	buf2 := make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.MaxCount))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.MaxCount))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter SearchAttributes
@@ -196,7 +196,7 @@ func (c *SearchRequest) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for MaxCount")
 	}
-	c.MaxCount = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.MaxCount = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter SearchAttributes


### PR DESCRIPTION
### Linked Issue
Closes #199

### Root Cause
`SearchRequest` (SMB_COM_SEARCH) is a generated command file that defaulted to `binary.BigEndian` for its `MaxCount` parameter word. SMB/CIFS encodes all integer fields little-endian, and the `parameters` layer is byte-preserving, so the big-endian bytes were transmitted verbatim on the wire. Because `Marshal` and `Unmarshal` used the same (wrong) byte order, symmetric round-trip unit tests passed and never exposed the defect.

### Fix Description
Switch the `MaxCount` 2-byte USHORT to `binary.LittleEndian` in both `Marshal()` (L135) and `Unmarshal()` (L199), matching the MS-CIFS SMB_COM_SEARCH Request specification (https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/239b0def-8370-4dc7-8391-ee60952901b1). Symmetry between Marshal and Unmarshal is preserved.

### How Verified
- **Static:** L135 now emits the little-endian 2-byte encoding of `MaxCount`; L199 decodes it little-endian. Field order, size (2 bytes), and WordCount (0x02) are unchanged.
- **Tests:** `go test ./network/smb/smb_v10/message/commands/` passes.
- **Build:** `go build ./...` succeeds.

### Test Coverage
**Existing:** existing round-trip tests for the commands package pass after the fix. No new test added — the existing tests are symmetric and do not assert on-wire byte order; the change is a one-for-one endianness correction verified against the spec.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/SearchRequest.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Notes
Part of the systemic big-endian defect class tracked in #134. The sibling `SearchAttributes` field in the same struct is mis-encoded via the shared `SMB_FILE_ATTRIBUTES` type and is tracked separately in #157; it is intentionally left out of this PR to keep the change scoped to a single file/defect.