### PR TITLE
[bugfix] Fix NtTransactSecondaryRequest missing 3-byte Reserved1 field (#206)

### DIFF
--- a/network/smb/smb_v10/message/commands/NtTransactSecondaryRequest.go
+++ b/network/smb/smb_v10/message/commands/NtTransactSecondaryRequest.go
@@ -19,6 +19,11 @@ type NtTransactSecondaryRequest struct {
 
 	// Parameters
 
+	// Reserved1 (3 bytes): Reserved. Used to align the following fields to a 32-bit
+	// boundary. This field MUST contain null padding bytes in the server response. The
+	// client MUST ignore the contents of this field.
+	Reserved1 [3]types.UCHAR
+
 	// TotalParameterCount (4 bytes): The total number of transaction parameter bytes
 	// to be sent to the server over the course of this transaction. This value MAY be
 	// less than or equal to the TotalParameterCount in preceding request messages that
@@ -109,6 +114,7 @@ type NtTransactSecondaryRequest struct {
 func NewNtTransactSecondaryRequest() *NtTransactSecondaryRequest {
 	c := &NtTransactSecondaryRequest{
 		// Parameters
+		Reserved1:             [3]types.UCHAR{0, 0, 0},
 		TotalParameterCount:   types.ULONG(0),
 		TotalDataCount:        types.ULONG(0),
 		ParameterCount:        types.ULONG(0),
@@ -179,6 +185,11 @@ func (c *NtTransactSecondaryRequest) Marshal() ([]byte, error) {
 
 	// Then marshal the parameters
 	rawParametersContent := []byte{}
+
+	// Marshalling parameter Reserved1 (3 bytes)
+	for _, b := range c.Reserved1 {
+		rawParametersContent = append(rawParametersContent, types.UCHAR(b))
+	}
 
 	// Marshalling parameter TotalParameterCount
 	buf4 := make([]byte, 4)
@@ -272,6 +283,13 @@ func (c *NtTransactSecondaryRequest) Unmarshal(data []byte) (int, error) {
 
 	// First unmarshal the parameters
 	offset = 0
+
+	// Unmarshalling parameter Reserved1 (3 bytes)
+	if len(rawParametersContent) < offset+3 {
+		return offset, fmt.Errorf("rawParametersContent too short for Reserved1")
+	}
+	copy(c.Reserved1[:], rawParametersContent[offset:offset+3])
+	offset += 3
 
 	// Unmarshalling parameter TotalParameterCount
 	if len(rawParametersContent) < offset+4 {


### PR DESCRIPTION
### Linked Issue
`Closes #206`

### Root Cause
The 3-byte `Reserved1` alignment field defined first in the MS-CIFS SMB_Parameters Words layout was dropped when the command struct was generated. MS-CIFS specifies the Words block as `UCHAR Reserved1[3]; ULONG TotalParameterCount; ...` (36 bytes, WordCount MUST be 0x12). Without it the struct emitted only 33 parameter bytes, the `parameters` layer derived WordCount 0x11, and every field was 3 bytes earlier than the spec mandates.

### Fix Description
Added the `Reserved1 [3]types.UCHAR` field to the struct (immediately before `TotalParameterCount`, matching spec order), initialized it to zero in the constructor, wrote its 3 bytes at the start of the parameter block in `Marshal()`, and read 3 bytes for it at the start of the parameter parse in `Unmarshal()`. This restores the 36-byte Words block, WordCount 0x12, and correct field offsets. Marshal/Unmarshal symmetry is preserved.

### How Verified
- Static: spec field order now matches (`Reserved1[3]` then the eight ULONGs then `Reserved2`).
- Runtime: a temporary test confirmed `Marshal()` now emits `WordCount == 0x12` (was 0x11) and a 39-byte command (1 WordCount + 36 Words + 2 ByteCount).
- Tests: `go test ./network/smb/smb_v10/message/commands/` passes; `go build ./network/smb/smb_v10/...` succeeds.

### Test Coverage
**Existing:** existing round-trip tests pass with the added field; manual WordCount assertion confirmed the corrected value (test not retained to keep the diff to the source file).

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/NtTransactSecondaryRequest.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local to one command's parameter layout; safe to merge.

### Notes
This file has two other confirmed defects tracked separately: big-endian parameter marshalling (#194, PR #237) and incorrect `Pad1`/`Pad2` offset handling in `Unmarshal` (#209). Those PRs touch overlapping regions of this file; whichever merges second will need a trivial rebase.
