### PR TITLE
[bugfix] Fix SMB_COM_READ_ANDX Response missing Reserved2[5] field (#182)

### DIFF
--- a/network/smb/smb_v10/message/commands/ReadAndxResponse.go
+++ b/network/smb/smb_v10/message/commands/ReadAndxResponse.go
@@ -38,6 +38,11 @@ type ReadAndxResponse struct {
 
 	// DataOffset (2 bytes): The offset in bytes from the header of the read data.
 	DataOffset types.USHORT
+
+	// Reserved2 (10 bytes): Reserved. All entries MUST be 0x0000. The last 5 words are
+	// reserved in order to make the SMB_COM_READ_ANDX Response the same size as the
+	// SMB_COM_WRITE_ANDX Response.
+	Reserved2 [5]types.USHORT
 }
 
 // NewReadAndxResponse creates a new ReadAndxResponse structure
@@ -127,6 +132,13 @@ func (c *ReadAndxResponse) Marshal() ([]byte, error) {
 	binary.LittleEndian.PutUint16(buf2, uint16(c.DataOffset))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
+	// Marshalling parameter Reserved2
+	for _, reserved := range c.Reserved2 {
+		buf2 = make([]byte, 2)
+		binary.LittleEndian.PutUint16(buf2, uint16(reserved))
+		rawParametersContent = append(rawParametersContent, buf2...)
+	}
+
 	// Marshalling parameters
 	c.GetParameters().AddWordsFromBytesStream(rawParametersContent)
 	marshalledParameters, err := c.GetParameters().Marshal()
@@ -214,6 +226,15 @@ func (c *ReadAndxResponse) Unmarshal(data []byte) (int, error) {
 	}
 	c.DataOffset = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
+
+	// Unmarshalling parameter Reserved2
+	for i := range c.Reserved2 {
+		if len(rawParametersContent) < offset+2 {
+			return offset, fmt.Errorf("rawParametersContent too short for Reserved2")
+		}
+		c.Reserved2[i] = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
+		offset += 2
+	}
 
 	// Then unmarshal the data
 	offset = 0


### PR DESCRIPTION
Closes #182

### Root Cause
The generated `ReadAndxResponse` struct dropped the trailing `Reserved2[5]` array defined by [MS-CIFS 2.2.4.42.2](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/89d6b552-5406-445c-85d5-54c80b94a20f). That field exists to make the SMB_COM_READ_ANDX Response the same size as the SMB_COM_WRITE_ANDX Response, and its absence reduced the emitted Words block from the mandated 24 bytes (WordCount 0x0C / 12 words) down to 14 bytes (7 words).

### Fix Description
Added the `Reserved2 [5]types.USHORT` field after `DataOffset`, and the corresponding little-endian marshal/unmarshal loops. The Words block now serializes the full 24 bytes required for WordCount 0x0C. Endianness matches the rest of the structure (little-endian) and the parameters layer is byte-preserving, so the correct bytes now reach the wire. Marshal and Unmarshal remain symmetric, and the Unmarshal length guards use `>= offset+2` per array entry.

### How Verified
- **Static:** Words block now emits 4 (AndX) + 2 (Available) + 2 (DataCompactionMode) + 2 (Reserved1) + 2 (DataLength) + 2 (DataOffset) + 10 (Reserved2[5]) = 24 bytes, matching the spec WordCount of 0x0C.
- **Tests:** `go test ./network/smb/smb_v10/message/commands/` passes; `go build ./network/smb/smb_v10/message/commands/` succeeds (verified in a clean worktree at the commit).

### Test Coverage
**Existing:** existing round-trip tests for the package pass against the corrected structure. (Round-trip tests are symmetric and would not, by themselves, have caught the missing-field wire defect; the fix is justified directly against the spec.)

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/ReadAndxResponse.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Low blast radius: the change adds a previously-missing reserved field that defaults to zero, bringing the wire format into spec compliance. Safe to merge.