### PR TITLE
[bugfix] Fix TreeConnectAndxResponse to marshal OptionalSupport little-endian (#216)

### DIFF
--- a/network/smb/smb_v10/message/commands/TreeConnectAndxResponse.go
+++ b/network/smb/smb_v10/message/commands/TreeConnectAndxResponse.go
@@ -111,7 +111,7 @@ func (c *TreeConnectAndxResponse) Marshal() ([]byte, error) {
 
 	// Marshalling parameter OptionalSupport
 	buf2 := make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.OptionalSupport))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.OptionalSupport))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameters
@@ -171,7 +171,7 @@ func (c *TreeConnectAndxResponse) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for OptionalSupport")
 	}
-	c.OptionalSupport = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.OptionalSupport = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Then unmarshal the data


### PR DESCRIPTION
### Linked Issue
Closes #216

### Root Cause
The generated `TreeConnectAndxResponse` command defaulted to `binary.BigEndian` for its 2-byte `OptionalSupport` parameter field. SMB/CIFS wire fields are little-endian, and the `parameters` layer in this package is byte-preserving, so whatever endianness the struct uses is exactly what is transmitted. The field was therefore byte-swapped on the wire. Round-trip unit tests did not catch this because `Marshal`/`Unmarshal` are symmetric.

### Fix Description
Switched both the `Marshal` and `Unmarshal` paths for `OptionalSupport` from `binary.BigEndian` to `binary.LittleEndian`, matching the [MS-CIFS] SMB_COM_TREE_CONNECT_ANDX Response specification and the hand-corrected AndX commands (`TreeConnectAndxRequest`, `SessionSetupAndxRequest`). Marshal/Unmarshal symmetry is preserved.

### How Verified
- `go build ./...` succeeds.
- `go test ./network/smb/smb_v10/message/commands/...` passes.
- Static review against the spec: `OptionalSupport` is a USHORT; the only two valid flag values (SMB_SUPPORT_SEARCH_BITS 0x0001, SMB_SHARE_IS_IN_DFS 0x0002) now serialize with the low-order byte first, as required.

### Test Coverage
**Existing:** the package's existing round-trip tests for this command continue to pass; they exercise the corrected Marshal/Unmarshal path. No new test added because the existing symmetric tests cover the code path and a golden-byte fixture is out of scope for this focused fix.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/TreeConnectAndxResponse.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local, two-line change confined to one field's byte order. Safe to merge without staged rollout.