### PR TITLE
[bugfix] Fix ReadResponse CountOfBytesReturned little-endian marshalling (#211)

### DIFF
--- a/network/smb/smb_v10/message/commands/ReadResponse.go
+++ b/network/smb/smb_v10/message/commands/ReadResponse.go
@@ -101,7 +101,7 @@ func (c *ReadResponse) Marshal() ([]byte, error) {
 
 	// Marshalling parameter CountOfBytesReturned
 	buf2 := make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.CountOfBytesReturned))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.CountOfBytesReturned))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameters
@@ -158,7 +158,7 @@ func (c *ReadResponse) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for CountOfBytesReturned")
 	}
-	c.CountOfBytesReturned = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.CountOfBytesReturned = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Then unmarshal the data


### PR DESCRIPTION
### Linked Issue
Closes #211

### Root Cause
`ReadResponse` (SMB_COM_READ response) was generated with big-endian serialization for its `CountOfBytesReturned` parameter. All SMB/CIFS multi-byte integer fields are little-endian on the wire ([MS-CIFS SMB_COM_READ Response](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/bc54fec8-3e8a-4c05-bbe9-11ed116d1d67)). The `parameters` layer is byte-preserving, so the struct's endianness is exactly what is transmitted. Round-trip unit tests did not catch this because Marshal/Unmarshal are symmetric.

### Fix Description
Switch `CountOfBytesReturned` to `binary.LittleEndian` in both `Marshal()` and `Unmarshal()`. No other behavior changes.

### How Verified
- Static: the two patched lines now use `binary.LittleEndian` for the 2-byte `CountOfBytesReturned`, matching the MS-CIFS little-endian wire format.
- Build/tests: `go build ./network/smb/smb_v10/message/commands/` and `go test ./network/smb/smb_v10/message/commands/` both pass (verified in an isolated worktree).

### Test Coverage
**Existing:** existing round-trip tests for the commands package continue to pass. No new test added; the existing symmetric tests pass for both endianness and the change is a one-to-one swap of byte order matching the spec.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/ReadResponse.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local, two-line change confined to one command's parameter serialization. Safe to merge.