### PR TITLE
[bugfix] Fix UnlockByteRangeRequest little-endian parameter marshalling (#225)

### DIFF
--- a/network/smb/smb_v10/message/commands/UnlockByteRangeRequest.go
+++ b/network/smb/smb_v10/message/commands/UnlockByteRangeRequest.go
@@ -90,17 +90,17 @@ func (c *UnlockByteRangeRequest) Marshal() ([]byte, error) {
 
 	// Marshalling parameter FID
 	buf2 := make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.FID))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.FID))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter CountOfBytesToUnlock
 	buf4 := make([]byte, 4)
-	binary.BigEndian.PutUint32(buf4, uint32(c.CountOfBytesToUnlock))
+	binary.LittleEndian.PutUint32(buf4, uint32(c.CountOfBytesToUnlock))
 	rawParametersContent = append(rawParametersContent, buf4...)
 
 	// Marshalling parameter UnlockOffsetInBytes
 	buf4 = make([]byte, 4)
-	binary.BigEndian.PutUint32(buf4, uint32(c.UnlockOffsetInBytes))
+	binary.LittleEndian.PutUint32(buf4, uint32(c.UnlockOffsetInBytes))
 	rawParametersContent = append(rawParametersContent, buf4...)
 
 	// Marshalling parameters
@@ -157,21 +157,21 @@ func (c *UnlockByteRangeRequest) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for FID")
 	}
-	c.FID = types.SHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.FID = types.SHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter CountOfBytesToUnlock
 	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for CountOfBytesToUnlock")
 	}
-	c.CountOfBytesToUnlock = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	c.CountOfBytesToUnlock = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
 	offset += 4
 
 	// Unmarshalling parameter UnlockOffsetInBytes
 	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for UnlockOffsetInBytes")
 	}
-	c.UnlockOffsetInBytes = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	c.UnlockOffsetInBytes = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
 	offset += 4
 
 	// Then unmarshal the data


### PR DESCRIPTION
### Linked Issue
Closes #225

### Root Cause
The generated `UnlockByteRangeRequest` command file encoded and decoded its parameter words with `binary.BigEndian`. SMB/CIFS wire integers are little-endian, and the `parameters` layer is byte-preserving, so the big-endian bytes were transmitted unchanged. Because Marshal and Unmarshal were symmetric, round-trip unit tests passed and the defect was never exercised against a real server.

### Fix Description
Switch FID, CountOfBytesToUnlock, and UnlockOffsetInBytes to `binary.LittleEndian` in both `Marshal` and `Unmarshal`, matching [MS-CIFS 2.2.4.29.1](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/7d3d2faf-8421-4acc-885c-805162028764) (Words: `SHORT FID; ULONG CountOfBytesToUnlock; ULONG UnlockOffsetInBytes`, WordCount 0x05, ByteCount 0x0000).

### How Verified
- **Static:** All three parameter fields now use little-endian read/write at L93/L98/L103 (Marshal) and L160/L167/L174 (Unmarshal); field order, sizes (2/4/4) and WordCount are unchanged.
- **Tests:** `go test ./network/smb/smb_v10/message/commands/` passes; `go build ./...` clean.

### Test Coverage
**Existing:** existing round-trip tests in the commands package cover marshalling/unmarshalling symmetry after the fix.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/UnlockByteRangeRequest.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local change to a single command's byte order; safe to merge. The previous big-endian output was incorrect on the wire, so no correct consumer depended on it.