### PR TITLE
[bugfix] Fix TransactionRequest little-endian parameter marshalling (#219)

### DIFF
--- a/network/smb/smb_v10/message/commands/TransactionRequest.go
+++ b/network/smb/smb_v10/message/commands/TransactionRequest.go
@@ -283,22 +283,22 @@ func (c *TransactionRequest) Marshal() ([]byte, error) {
 
 	// Marshalling parameter TotalParameterCount
 	buf2 := make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.TotalParameterCount))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.TotalParameterCount))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter TotalDataCount
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.TotalDataCount))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.TotalDataCount))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter MaxParameterCount
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.MaxParameterCount))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.MaxParameterCount))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter MaxDataCount
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.MaxDataCount))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.MaxDataCount))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter MaxSetupCount
@@ -309,37 +309,37 @@ func (c *TransactionRequest) Marshal() ([]byte, error) {
 
 	// Marshalling parameter Flags
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.Flags))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.Flags))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter Timeout
 	buf4 := make([]byte, 4)
-	binary.BigEndian.PutUint32(buf4, uint32(c.Timeout))
+	binary.LittleEndian.PutUint32(buf4, uint32(c.Timeout))
 	rawParametersContent = append(rawParametersContent, buf4...)
 
 	// Marshalling parameter Reserved2
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.Reserved2))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.Reserved2))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter ParameterCount
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.ParameterCount))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.ParameterCount))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter ParameterOffset
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.ParameterOffset))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.ParameterOffset))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter DataCount
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.DataCount))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.DataCount))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter DataOffset
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.DataOffset))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.DataOffset))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter SetupCount
@@ -351,7 +351,7 @@ func (c *TransactionRequest) Marshal() ([]byte, error) {
 	// Marshalling parameter Setup
 	for _, setup := range c.Setup {
 		buf2 = make([]byte, 2)
-		binary.BigEndian.PutUint16(buf2, uint16(setup))
+		binary.LittleEndian.PutUint16(buf2, uint16(setup))
 		rawParametersContent = append(rawParametersContent, buf2...)
 	}
 
@@ -409,28 +409,28 @@ func (c *TransactionRequest) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for TotalParameterCount")
 	}
-	c.TotalParameterCount = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.TotalParameterCount = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter TotalDataCount
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for TotalDataCount")
 	}
-	c.TotalDataCount = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.TotalDataCount = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter MaxParameterCount
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for MaxParameterCount")
 	}
-	c.MaxParameterCount = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.MaxParameterCount = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter MaxDataCount
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for MaxDataCount")
 	}
-	c.MaxDataCount = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.MaxDataCount = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter MaxSetupCount
@@ -451,49 +451,49 @@ func (c *TransactionRequest) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for Flags")
 	}
-	c.Flags = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.Flags = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter Timeout
 	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for Timeout")
 	}
-	c.Timeout = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	c.Timeout = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
 	offset += 4
 
 	// Unmarshalling parameter Reserved2
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for Reserved2")
 	}
-	c.Reserved2 = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.Reserved2 = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter ParameterCount
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for ParameterCount")
 	}
-	c.ParameterCount = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.ParameterCount = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter ParameterOffset
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for ParameterOffset")
 	}
-	c.ParameterOffset = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.ParameterOffset = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter DataCount
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for DataCount")
 	}
-	c.DataCount = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.DataCount = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter DataOffset
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for DataOffset")
 	}
-	c.DataOffset = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.DataOffset = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter SetupCount
@@ -516,7 +516,7 @@ func (c *TransactionRequest) Unmarshal(data []byte) (int, error) {
 	}
 	c.Setup = make([]types.USHORT, c.SetupCount)
 	for i := 0; i < int(c.SetupCount); i++ {
-		c.Setup[i] = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+		c.Setup[i] = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 		offset += 2
 	}
 


### PR DESCRIPTION
### Linked Issue
Closes #219

### Root Cause
`TransactionRequest.Marshal`/`Unmarshal` were generated using `binary.BigEndian` for all integer parameter fields. SMB/CIFS transmits all integers little-endian, and the `parameters` layer is byte-preserving, so the big-endian bytes reached the wire unchanged and produced a malformed `SMB_COM_TRANSACTION` request. The defect was masked because Marshal and Unmarshal are symmetric, so round-trip unit tests passed.

### Fix Description
Switched every `binary.BigEndian` reference to `binary.LittleEndian` in both `Marshal` and `Unmarshal` (TotalParameterCount, TotalDataCount, MaxParameterCount, MaxDataCount, Flags, Timeout, Reserved2, ParameterCount, ParameterOffset, DataCount, DataOffset, and each Setup word). Field order, sizes, and Marshal/Unmarshal symmetry are unchanged; only the byte order is corrected to match [MS-CIFS] 2.2.4.33.1.

### How Verified
- `go build ./...` succeeds.
- `go test ./network/smb/smb_v10/message/commands/` passes.
- Static review: the corrected encoders now match the little-endian convention used by the hand-corrected `TreeConnectAndxRequest`/`SessionSetupAndxRequest`.

### Test Coverage
**Existing:** the package's round-trip tests for the commands package continue to pass after the fix; they exercise Marshal/Unmarshal symmetry.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/TransactionRequest.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Low blast radius, local to one command. Changes the on-wire byte order to the correct little-endian form; any code that previously round-tripped through this struct remains correct since both directions changed symmetrically.

### Notes
The same big-endian defect class exists in the sibling `Transaction2Request.go` (and other transaction-family files); those are tracked/handled separately and are out of scope for this PR.