### PR TITLE
[bugfix] Fix TransactionSecondaryRequest little-endian parameter marshalling (#228)

### DIFF
--- a/network/smb/smb_v10/message/commands/TransactionSecondaryRequest.go
+++ b/network/smb/smb_v10/message/commands/TransactionSecondaryRequest.go
@@ -180,42 +180,42 @@ func (c *TransactionSecondaryRequest) Marshal() ([]byte, error) {
 
 	// Marshalling parameter TotalParameterCount
 	buf2 := make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.TotalParameterCount))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.TotalParameterCount))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter TotalDataCount
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.TotalDataCount))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.TotalDataCount))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter ParameterCount
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.ParameterCount))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.ParameterCount))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter ParameterOffset
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.ParameterOffset))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.ParameterOffset))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter ParameterDisplacement
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.ParameterDisplacement))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.ParameterDisplacement))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter DataCount
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.DataCount))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.DataCount))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter DataOffset
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.DataOffset))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.DataOffset))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter DataDisplacement
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.DataDisplacement))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.DataDisplacement))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameters
@@ -272,56 +272,56 @@ func (c *TransactionSecondaryRequest) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for TotalParameterCount")
 	}
-	c.TotalParameterCount = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.TotalParameterCount = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter TotalDataCount
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for TotalDataCount")
 	}
-	c.TotalDataCount = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.TotalDataCount = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter ParameterCount
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for ParameterCount")
 	}
-	c.ParameterCount = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.ParameterCount = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter ParameterOffset
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for ParameterOffset")
 	}
-	c.ParameterOffset = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.ParameterOffset = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter ParameterDisplacement
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for ParameterDisplacement")
 	}
-	c.ParameterDisplacement = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.ParameterDisplacement = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter DataCount
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for DataCount")
 	}
-	c.DataCount = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.DataCount = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter DataOffset
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for DataOffset")
 	}
-	c.DataOffset = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.DataOffset = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter DataDisplacement
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for DataDisplacement")
 	}
-	c.DataDisplacement = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.DataDisplacement = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Then unmarshal the data


### PR DESCRIPTION
### Linked Issue
`Closes #228`

### Root Cause
The `TransactionSecondaryRequest` parameter words were generated with a big-endian default (`binary.BigEndian`), like the ~62 other command files tracked in #134. The SMB `parameters` layer is byte-preserving, so whatever endianness the struct uses to build its raw parameter bytes is exactly what is transmitted. MS-CIFS specifies all SMB integer fields as little-endian, so this struct emitted byte-swapped `TotalParameterCount`, `TotalDataCount`, `ParameterCount`, `ParameterOffset`, `ParameterDisplacement`, `DataCount`, `DataOffset`, and `DataDisplacement` words. The symmetric Marshal/Unmarshal meant round-trip unit tests never caught it.

### Fix Description
Switched all eight USHORT parameter fields from `binary.BigEndian` to `binary.LittleEndian` in both `Marshal()` and `Unmarshal()` (16 call sites). The data block (Pad1/Trans2_Parameters/Pad2/Trans2_Data) is a raw byte array and was already endian-agnostic, so it is unchanged. Field order, sizes, and the WordCount (0x08 / 16 bytes) all already match MS-CIFS section 2.2.4.34.

### How Verified
- Static: confirmed every parameter field now uses `binary.LittleEndian`, matching the byte order MS-CIFS (https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/79ece32a-139d-46b0-ba28-055f822a8c05) requires and the SMB header / `TreeConnectAndxRequest` already use. `grep -c binary.BigEndian` on the file now returns 0.
- Build/tests: `go build ./...` clean; `go test ./network/smb/smb_v10/message/commands/` passes.

### Test Coverage
- **Existing:** existing round-trip tests in the commands package pass. They are symmetric and cannot assert wire byte order; a golden-byte/live-server test for the whole big-endian class is tracked under #134.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/TransactionSecondaryRequest.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Notes
Part of the systemic big-endian defect tracked in #134. The Unmarshal Pad1/Pad2 slicing in the Transaction-secondary family uses ParameterOffset/DataOffset as in-data lengths rather than SMB-header-relative offsets; this is a shared pattern across the Transaction family and out of scope for this endianness fix.