### PR TITLE
[bugfix] Fix SearchResponse Count little-endian marshalling (#278)

### DIFF
--- a/network/smb/smb_v10/message/commands/SearchResponse.go
+++ b/network/smb/smb_v10/message/commands/SearchResponse.go
@@ -102,7 +102,7 @@ func (c *SearchResponse) Marshal() ([]byte, error) {
 
 	// Marshalling parameter Count
 	buf2 := make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.Count))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.Count))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameters
@@ -159,7 +159,7 @@ func (c *SearchResponse) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for Count")
 	}
-	c.Count = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.Count = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Then unmarshal the data


### PR DESCRIPTION
### Linked Issue
`Closes #278`

### Root Cause
`SearchResponse.Marshal`/`Unmarshal` encoded the `Count` parameter word with `binary.BigEndian`. The `parameters` layer is byte-preserving (`AddWordsFromBytesStream` packs `b[i]<<8 | b[i+1]` and `Parameters.Marshal` re-emits each word via `binary.BigEndian.PutUint16`), so the bytes written into `rawParametersContent` are exactly what reaches the wire. Per [MS-CIFS 2.2.4.58.2](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/12a609ad-8709-4492-9b95-4a402589cf56) the `Count` USHORT is little-endian, so the prior code transmitted a byte-swapped value. The generated command file defaulted to big-endian and was never corrected.

### Fix Description
Switch the `Count` field to `binary.LittleEndian.PutUint16` in `Marshal` (L105) and `binary.LittleEndian.Uint16` in `Unmarshal` (L162). Marshal/Unmarshal remain symmetric. No other fields change: the Data section (`SMB_Directory_Information` as an SMB_STRING variable block, BufferFormat 0x05 + USHORT length) already uses little-endian and matches the spec.

### How Verified
- **Static:** the only integer parameter field is `Count`; after the change both directions use little-endian, matching the MS-CIFS USHORT wire encoding.
- **Tests:** `go test ./network/smb/smb_v10/message/commands/` passes; `go build ./network/smb/smb_v10/...` succeeds.

### Test Coverage
**Existing:** the package's round-trip tests cover Marshal/Unmarshal symmetry and continue to pass. No new test added because round-trip tests are endianness-symmetric and cannot assert on-wire byte order; the fix is a one-to-one endianness correction validated against the spec.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/SearchResponse.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Notes
Instance of the systemic big-endian defect tracked in #134.
