### PR TITLE
[bugfix] Fix OpenAndxRequest parameters to little-endian (#195)

### DIFF
--- a/network/smb/smb_v10/message/commands/OpenAndxRequest.go
+++ b/network/smb/smb_v10/message/commands/OpenAndxRequest.go
@@ -140,12 +140,12 @@ func (c *OpenAndxRequest) Marshal() ([]byte, error) {
 
 	// Marshalling parameter Flags
 	buf2 := make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.Flags))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.Flags))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter AccessMode
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.AccessMode))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.AccessMode))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter SearchAttrs
@@ -171,23 +171,23 @@ func (c *OpenAndxRequest) Marshal() ([]byte, error) {
 
 	// Marshalling parameter OpenMode
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.OpenMode))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.OpenMode))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter AllocationSize
 	buf4 := make([]byte, 4)
-	binary.BigEndian.PutUint32(buf4, uint32(c.AllocationSize))
+	binary.LittleEndian.PutUint32(buf4, uint32(c.AllocationSize))
 	rawParametersContent = append(rawParametersContent, buf4...)
 
 	// Marshalling parameter Timeout
 	buf4 = make([]byte, 4)
-	binary.BigEndian.PutUint32(buf4, uint32(c.Timeout))
+	binary.LittleEndian.PutUint32(buf4, uint32(c.Timeout))
 	rawParametersContent = append(rawParametersContent, buf4...)
 
 	// Marshalling parameter Reserved
 	buf2 = make([]byte, 2)
 	for i := range c.Reserved {
-		binary.BigEndian.PutUint16(buf2, uint16(c.Reserved[i]))
+		binary.LittleEndian.PutUint16(buf2, uint16(c.Reserved[i]))
 		rawParametersContent = append(rawParametersContent, buf2...)
 	}
 
@@ -248,14 +248,14 @@ func (c *OpenAndxRequest) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for Flags")
 	}
-	c.Flags = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.Flags = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter AccessMode
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for AccessMode")
 	}
-	c.AccessMode = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.AccessMode = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter SearchAttrs
@@ -286,21 +286,21 @@ func (c *OpenAndxRequest) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for OpenMode")
 	}
-	c.OpenMode = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.OpenMode = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter AllocationSize
 	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for AllocationSize")
 	}
-	c.AllocationSize = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	c.AllocationSize = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
 	offset += 4
 
 	// Unmarshalling parameter Timeout
 	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for Timeout")
 	}
-	c.Timeout = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	c.Timeout = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
 	offset += 4
 
 	// Unmarshalling parameter Reserved
@@ -308,7 +308,7 @@ func (c *OpenAndxRequest) Unmarshal(data []byte) (int, error) {
 		return offset, fmt.Errorf("rawParametersContent too short for Reserved")
 	}
 	for i := range c.Reserved {
-		c.Reserved[i] = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+		c.Reserved[i] = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 		offset += 2
 	}
 


### PR DESCRIPTION
### Linked Issue
Closes #195

### Root Cause
The generated `OpenAndxRequest` command file encoded and decoded all integer parameter fields with `binary.BigEndian`. SMB/CIFS wire integers are little-endian, and the `parameters` layer is byte-preserving, so the endianness used by the struct is exactly what is transmitted. Because `Marshal()` and `Unmarshal()` were symmetric, round-trip unit tests passed while the bytes on the wire were byte-reversed.

### Fix Description
Replaced every `binary.BigEndian` call with `binary.LittleEndian` for the integer parameter fields: Flags, AccessMode, OpenMode, AllocationSize, Timeout, and Reserved (both Marshal and Unmarshal). Field order, sizes, and length guards are unchanged. The CreationTime size fix is handled separately in #185 / PR #268 and is not touched here.

### How Verified
- **Static:** all 12 integer encode/decode sites in `OpenAndxRequest.go` now use `binary.LittleEndian`; none remain big-endian (`grep -c binary.BigEndian` = 0).
- **Tests:** `go test ./network/smb/smb_v10/message/commands/...` passes; `go build ./network/smb/smb_v10/...` succeeds.

### Test Coverage
**Existing:** the package round-trip tests in `network/smb/smb_v10/message/commands` pass after the change. (Round-trip tests cannot detect wire-endianness by themselves; correctness is established against the [MS-CIFS] spec.)

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/OpenAndxRequest.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local to one command struct; changes only the byte order of already-present fields. Safe to merge.