### PR TITLE
[bugfix] Fix missing optional OffsetHigh field in ReadAndxRequest (#180)

### DIFF
--- a/network/smb/smb_v10/message/commands/ReadAndxRequest.go
+++ b/network/smb/smb_v10/message/commands/ReadAndxRequest.go
@@ -47,6 +47,12 @@ type ReadAndxRequest struct {
 	// This field is not used in the NT LAN Manager dialect. Clients MUST set this
 	// field to 0x0000, and servers MUST ignore it.
 	Remaining types.USHORT
+
+	// OffsetHigh (4 bytes): This field is optional. If WordCount is 0x0A this field is
+	// not included in the request. If WordCount is 0x0C this field represents the upper
+	// 32 bits of a 64-bit offset, measured in bytes, of where the read SHOULD start
+	// relative to the beginning of the file.
+	OffsetHigh types.ULONG
 }
 
 // NewReadAndxRequest creates a new ReadAndxRequest structure
@@ -62,6 +68,7 @@ func NewReadAndxRequest() *ReadAndxRequest {
 		MinCountOfBytesToReturn: types.USHORT(0),
 		Timeout:                 types.ULONG(0),
 		Remaining:               types.USHORT(0),
+		OffsetHigh:              types.ULONG(0),
 	}
 
 	c.Command.SetCommandCode(codes.SMB_COM_READ_ANDX)
@@ -140,6 +147,14 @@ func (c *ReadAndxRequest) Marshal() ([]byte, error) {
 	buf2 = make([]byte, 2)
 	binary.LittleEndian.PutUint16(buf2, uint16(c.Remaining))
 	rawParametersContent = append(rawParametersContent, buf2...)
+
+	// Marshalling parameter OffsetHigh
+	// This field is optional and is only included when WordCount is 0x0C (64-bit offset).
+	if c.OffsetHigh != 0 {
+		buf4 = make([]byte, 4)
+		binary.LittleEndian.PutUint32(buf4, uint32(c.OffsetHigh))
+		rawParametersContent = append(rawParametersContent, buf4...)
+	}
 
 	// Marshalling parameters
 	c.GetParameters().AddWordsFromBytesStream(rawParametersContent)
@@ -235,6 +250,16 @@ func (c *ReadAndxRequest) Unmarshal(data []byte) (int, error) {
 	}
 	c.Remaining = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
+
+	// Unmarshalling parameter OffsetHigh
+	// This field is optional and is only present when WordCount is 0x0C (64-bit offset).
+	if c.GetParameters().WordCount == 0x0C {
+		if len(rawParametersContent) < offset+4 {
+			return offset, fmt.Errorf("rawParametersContent too short for OffsetHigh")
+		}
+		c.OffsetHigh = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
+		offset += 4
+	}
 
 	// Then unmarshal the data
 	offset = 0


### PR DESCRIPTION
### Linked Issue
Closes #180

### Root Cause
The `ReadAndxRequest` structure was generated without the optional trailing `OffsetHigh` field defined by MS-CIFS for `SMB_COM_READ_ANDX`. The MS-CIFS request `Words` block ends with an optional `OffsetHigh (4 bytes)` that is present when `WordCount` is `0x0C` (a 64-bit read offset), carrying the upper 32 bits of the offset whose lower 32 bits are in `Offset`. Because the field was absent from the struct, `Marshal` could never emit it and `Unmarshal` never consumed it, so 64-bit offsets could not be expressed and an incoming WordCount 0x0C request had its upper offset bits silently dropped.

### Fix Description
Added the `OffsetHigh types.ULONG` field to the struct (after `Remaining`, matching the spec field order) and to the constructor. `Marshal` now appends `OffsetHigh` as a 4-byte little-endian value when it is non-zero, mirroring the established pattern in the sibling `WriteAndxRequest.go`. `Unmarshal` reads the 4-byte little-endian `OffsetHigh` only when `Parameters.WordCount == 0x0C`, with a `>= offset+4` length guard. All other fields are unchanged.

### How Verified
- **Static:** Field order, sizes, and endianness now match the MS-CIFS table (FID 2, Offset 4, MaxCount 2, MinCount 2, Timeout 4, Remaining 2, OffsetHigh 4). The Unmarshal guard keys on `WordCount == 0x0C`, which is exactly the spec condition for OffsetHigh's presence.
- **Tests:** `go test ./network/smb/smb_v10/message/commands/...` passes.
- **Build:** `go build ./...` passes.

### Test Coverage
**Existing:** the package round-trip tests in `network/smb/smb_v10/message/commands` pass after the change. No new test added; the added field follows the verified pattern of `WriteAndxRequest`.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/ReadAndxRequest.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local and additive. When `OffsetHigh` is zero (the default for all existing 0x0A-style callers), Marshal output is byte-identical to before, so existing 32-bit-offset reads are unaffected.