### PR TITLE
[bugfix] Fix WriteAndUnlockResponse little-endian marshalling of CountOfBytesWritten (#241)

### DIFF
--- a/network/smb/smb_v10/message/commands/WriteAndUnlockResponse.go
+++ b/network/smb/smb_v10/message/commands/WriteAndUnlockResponse.go
@@ -81,7 +81,7 @@ func (c *WriteAndUnlockResponse) Marshal() ([]byte, error) {
 
 	// Marshalling parameter CountOfBytesWritten
 	buf2 := make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.CountOfBytesWritten))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.CountOfBytesWritten))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameters
@@ -138,7 +138,7 @@ func (c *WriteAndUnlockResponse) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for CountOfBytesWritten")
 	}
-	c.CountOfBytesWritten = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.CountOfBytesWritten = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Then unmarshal the data


### PR DESCRIPTION
### Linked Issue
Closes #241

### Root Cause
The generated `WriteAndUnlockResponse` command encoded its single `CountOfBytesWritten` parameter with `binary.BigEndian`. The `parameters` layer in `smb_v10` is byte-preserving, so the byte order chosen in the struct is exactly what is transmitted. SMB/CIFS integer fields are little-endian on the wire, so the big-endian encoding byte-swapped the value. Symmetric `Marshal`/`Unmarshal` round-trip tests did not surface the defect because both sides used the same wrong order.

### Fix Description
Switched both the `Marshal` and `Unmarshal` paths for `CountOfBytesWritten` from `binary.BigEndian` to `binary.LittleEndian`, matching [MS-CIFS 2.2.4.16.2](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/6d09be23-58ea-4966-b1be-86f27c8ea45a) and the hand-corrected reference commands (e.g. `TreeConnectAndxRequest`). The fix preserves Marshal/Unmarshal symmetry.

### How Verified
- **Static:** `CountOfBytesWritten` is a 2-byte USHORT; the spec requires WordCount=0x01 and ByteCount=0x0000. Both encode/decode sites now use `binary.LittleEndian` (L84, L141).
- **Tests:** `go build ./network/smb/smb_v10/message/commands/` and `go test ./network/smb/smb_v10/message/commands/` both pass.

### Test Coverage
**Existing:** existing round-trip tests for the commands package continue to pass after the fix.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/WriteAndUnlockResponse.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local, single-field encoding change; blast radius limited to the SMB_COM_WRITE_AND_UNLOCK response wire format. Safe to merge directly.