### PR TITLE
[bugfix] Fix WriteAndxRequest.Unmarshal out-of-bounds panic on DataLength (#238)

### DIFF
--- a/network/smb/smb_v10/message/commands/WriteAndxRequest.go
+++ b/network/smb/smb_v10/message/commands/WriteAndxRequest.go
@@ -325,7 +325,11 @@ func (c *WriteAndxRequest) Unmarshal(data []byte) (int, error) {
 	offset++
 
 	// Unmarshalling data Data
+	if len(rawDataContent) < offset+int(c.DataLength) {
+		return offset, fmt.Errorf("rawDataContent too short for Data")
+	}
 	c.Data = rawDataContent[offset : offset+int(c.DataLength)]
+	offset += int(c.DataLength)
 
 	return offset, nil
 }


### PR DESCRIPTION
### Linked Issue
Closes #238

### Root Cause
`WriteAndxRequest.Unmarshal` parsed the trailing variable-length `Data` field by slicing the data buffer with the wire-supplied `DataLength`: `c.Data = rawDataContent[offset : offset+int(c.DataLength)]`. Unlike every other field in the function, this slice had no length guard. `DataLength` is read directly off the wire and is independent of the actual length of `rawDataContent`, so a request whose declared `DataLength` exceeded the available data bytes triggered a runtime index-out-of-range panic instead of a returned error.

### Fix Description
Added a bounds check that returns an error when `offset+int(c.DataLength)` exceeds `len(rawDataContent)`, matching the guard pattern used by all preceding fields. Also advanced `offset` by `DataLength` after the slice so the returned byte count reflects the data consumed. The fix preserves Marshal/Unmarshal symmetry and changes no wire format.

### How Verified
- **Static:** the new guard at the `Data` read mirrors the existing `Pad` guard; `offset` now accounts for the consumed data bytes.
- **Tests:** `go test ./network/smb/smb_v10/message/commands/` passes.
- **Build:** `go build ./network/smb/smb_v10/message/commands/` succeeds.

### Test Coverage
**Existing:** existing command package tests pass after the fix. The change is a defensive bounds guard on malformed input; no new malformed-input test was added in this focused PR.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/WriteAndxRequest.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local and additive — adds an error return on malformed input and corrects the returned offset. Safe to merge without staged rollout.