### PR TITLE
[bugfix] Fix QueryInformationResponse LastWriteTime to 4-byte UTIME (#212)

### DIFF
--- a/network/smb/smb_v10/message/commands/QueryInformationResponse.go
+++ b/network/smb/smb_v10/message/commands/QueryInformationResponse.go
@@ -23,8 +23,9 @@ type QueryInformationResponse struct {
 	// SMB_FILE_ATTRIBUTES (see section 2.2.1.2.4).
 	FileAttributes types.SMB_FILE_ATTRIBUTES
 
-	// LastWriteTime (4 bytes): The time of the last write to the file.
-	LastWriteTime types.FILETIME
+	// LastWriteTime (4 bytes): The time of the last write to the file, encoded as a
+	// UTIME (the number of seconds since Jan 1, 1970, 00:00:00.0).
+	LastWriteTime types.ULONG
 
 	// FileSize (4 bytes): This field contains the size of the file, in bytes. Because
 	// this size is limited to 32 bits, this command is inappropriate for files whose
@@ -44,7 +45,7 @@ func NewQueryInformationResponse() *QueryInformationResponse {
 		// Parameters
 
 		FileAttributes: types.SMB_FILE_ATTRIBUTES{},
-		LastWriteTime:  types.FILETIME{},
+		LastWriteTime:  types.ULONG(0),
 		FileSize:       types.ULONG(0),
 		Reserved:       [5]types.USHORT{},
 	}
@@ -98,12 +99,10 @@ func (c *QueryInformationResponse) Marshal() ([]byte, error) {
 	}
 	rawParametersContent = append(rawParametersContent, byteStream...)
 
-	// Marshalling parameter LastWriteTime
-	bytesStream, err := c.LastWriteTime.Marshal()
-	if err != nil {
-		return nil, err
-	}
-	rawParametersContent = append(rawParametersContent, bytesStream...)
+	// Marshalling parameter LastWriteTime (UTIME, 4 bytes, little-endian)
+	bufLastWriteTime := make([]byte, 4)
+	binary.LittleEndian.PutUint32(bufLastWriteTime, uint32(c.LastWriteTime))
+	rawParametersContent = append(rawParametersContent, bufLastWriteTime...)
 
 	// Marshalling parameter FileSize
 	buf4 := make([]byte, 4)
@@ -170,15 +169,12 @@ func (c *QueryInformationResponse) Unmarshal(data []byte) (int, error) {
 	}
 	offset += bytesRead
 
-	// Unmarshalling parameter LastWriteTime
-	if len(rawParametersContent) < offset+8 {
+	// Unmarshalling parameter LastWriteTime (UTIME, 4 bytes, little-endian)
+	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for LastWriteTime")
 	}
-	bytesRead, err = c.LastWriteTime.Unmarshal(rawParametersContent[offset : offset+8])
-	if err != nil {
-		return 0, err
-	}
-	offset += bytesRead
+	c.LastWriteTime = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
+	offset += 4
 
 	// Unmarshalling parameter FileSize
 	if len(rawParametersContent) < offset+4 {


### PR DESCRIPTION
### Linked Issue
Closes #212

### Root Cause
The generated `QueryInformationResponse` mapped the spec's 4-byte `UTIME LastWriteTime` field onto the Go `types.FILETIME` type, whose `Marshal`/`Unmarshal` handle 8 bytes. As a result the Words block was 24 bytes (WordCount 0x0C) instead of the required 20 bytes (WordCount 0x0A), and the following `FileSize` and `Reserved` fields landed at the wrong wire offsets. Symmetric round-trip tests did not catch this because both directions used the same 8-byte type.

### Fix Description
Changed `LastWriteTime` from `types.FILETIME` to `types.ULONG`, the 4-byte little-endian representation of a UTIME (seconds since 1970-01-01). Updated the constructor initializer, and the `Marshal`/`Unmarshal` paths to write/read exactly 4 little-endian bytes (and the length guard to `offset+4`). This yields the spec-mandated 20-byte Words block / WordCount 0x0A and restores the correct offsets of `FileSize` and `Reserved`. The big-endian `FileSize` defect is intentionally left to a separate PR (#213) to keep changes isolated.

### How Verified
- Static: `LastWriteTime` now occupies 4 bytes; total Words = FileAttributes(2) + LastWriteTime(4) + FileSize(4) + Reserved(10) = 20 bytes, matching [MS-CIFS] SMB_COM_QUERY_INFORMATION Response (https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/847573c9-cbe6-4dcb-a0db-9b5af815759b), which mandates WordCount 0x0A.
- `go build ./network/smb/smb_v10/message/commands/` succeeds.
- `go test ./network/smb/smb_v10/message/commands/` passes.

### Test Coverage
**Existing:** existing round-trip tests in the commands package continue to pass. No test referenced `LastWriteTime` as a FILETIME, so no caller breaks.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/QueryInformationResponse.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local, low blast radius: the field type changes from `FILETIME` to `ULONG` for one command only. No external callers reference the field. Safe to merge directly.

### Notes
A sibling file, `network/smb/smb_v10/message/commands/SetInformationRequest.go`, exhibits the same UTIME-as-FILETIME defect class for its `LastWriteTime` field; out of scope here and not modified.
