### PR TITLE
[bugfix] Fix WritePrintFileRequest FID big-endian marshalling (#286)

### DIFF
--- a/network/smb/smb_v10/message/commands/WritePrintFileRequest.go
+++ b/network/smb/smb_v10/message/commands/WritePrintFileRequest.go
@@ -96,7 +96,7 @@ func (c *WritePrintFileRequest) Marshal() ([]byte, error) {
 
 	// Marshalling parameter FID
 	buf2 := make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.FID))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.FID))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameters
@@ -153,7 +153,7 @@ func (c *WritePrintFileRequest) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for FID")
 	}
-	c.FID = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.FID = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Then unmarshal the data


### PR DESCRIPTION
### Linked Issue
Closes #286

### Root Cause
`WritePrintFileRequest` was generated with a big-endian default for its `FID` parameter. SMB/CIFS integer fields are little-endian, and the `parameters` layer is byte-preserving, so the big-endian bytes were transmitted verbatim — sending a byte-swapped FID on the wire. Round-trip unit tests never caught it because `Marshal`/`Unmarshal` were symmetrically wrong.

### Fix Description
Switch the `FID` USHORT to `binary.LittleEndian` in both `Marshal()` (L99) and `Unmarshal()` (L156), matching the MS-CIFS SMB_COM_WRITE_PRINT_FILE Request wire format (WordCount = 0x01, USHORT FID). Marshal/Unmarshal symmetry is preserved. The data block (BufferFormat 0x01 + little-endian DataLength + Data) was already correct via `SMB_STRING` with `SMB_STRING_BUFFER_FORMAT_VARIABLE_BLOCK_16BIT` and was left unchanged.

### How Verified
- **Static:** FID at L99/L156 now uses little-endian, the only integer parameter; matches the spec table.
- **Tests:** `go build ./network/smb/smb_v10/...` succeeds; `go test ./network/smb/smb_v10/message/commands/` passes.

### Test Coverage
**Existing:** existing command round-trip tests cover the package and pass after the fix. No new test added — the existing symmetric tests pass regardless of endianness, and there is no golden-byte fixture harness for this command in the repo.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/WritePrintFileRequest.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local, two-line change to one command's wire encoding. Safe to merge directly; corrects previously-invalid wire output.