### PR TITLE
[bugfix] Fix WriteAndCloseResponse CountOfBytesWritten to little-endian (#233)

### DIFF
--- a/network/smb/smb_v10/message/commands/WriteAndCloseResponse.go
+++ b/network/smb/smb_v10/message/commands/WriteAndCloseResponse.go
@@ -81,7 +81,7 @@ func (c *WriteAndCloseResponse) Marshal() ([]byte, error) {
 
 	// Marshalling parameter CountOfBytesWritten
 	buf2 := make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.CountOfBytesWritten))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.CountOfBytesWritten))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameters
@@ -138,7 +138,7 @@ func (c *WriteAndCloseResponse) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for CountOfBytesWritten")
 	}
-	c.CountOfBytesWritten = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.CountOfBytesWritten = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Then unmarshal the data


### PR DESCRIPTION
### Linked Issue
Closes #233

### Root Cause
`WriteAndCloseResponse` was generated with a big-endian default for its single parameter word. SMB/CIFS encodes all integer fields little-endian, and the package's `parameters` layer is byte-preserving, so the big-endian `PutUint16`/`Uint16` calls placed a byte-swapped `CountOfBytesWritten` on the wire. Round-trip unit tests did not catch it because `Marshal`/`Unmarshal` were symmetrically wrong.

### Fix Description
Changed both the `Marshal` encode (L84) and the `Unmarshal` decode (L141) of `CountOfBytesWritten` from `binary.BigEndian` to `binary.LittleEndian`, matching the [MS-CIFS] SMB_COM_WRITE_AND_CLOSE Response definition (WordCount = 0x01, `USHORT CountOfBytesWritten`, ByteCount = 0x0000).

### How Verified
- `go build ./network/smb/smb_v10/...` succeeds.
- `go test ./network/smb/smb_v10/message/commands/` passes.
- Static review: `CountOfBytesWritten` now emits/reads little-endian bytes per the spec.

### Test Coverage
**Existing:** the package's round-trip tests for this command continue to pass and now exercise the spec-correct little-endian encoding.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/WriteAndCloseResponse.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local, two-line endianness correction to a single command. Safe to merge without staged rollout.