### PR TITLE
[bugfix] Fix WriteMpxResponse ResponseMask to use little-endian (#242)

### DIFF
--- a/network/smb/smb_v10/message/commands/WriteMpxResponse.go
+++ b/network/smb/smb_v10/message/commands/WriteMpxResponse.go
@@ -82,7 +82,7 @@ func (c *WriteMpxResponse) Marshal() ([]byte, error) {
 
 	// Marshalling parameter ResponseMask
 	buf4 := make([]byte, 4)
-	binary.BigEndian.PutUint32(buf4, uint32(c.ResponseMask))
+	binary.LittleEndian.PutUint32(buf4, uint32(c.ResponseMask))
 	rawParametersContent = append(rawParametersContent, buf4...)
 
 	// Marshalling parameters
@@ -139,7 +139,7 @@ func (c *WriteMpxResponse) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for ResponseMask")
 	}
-	c.ResponseMask = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	c.ResponseMask = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
 	offset += 4
 
 	// Then unmarshal the data


### PR DESCRIPTION
### Linked Issue
Closes #242

### Root Cause
The `SMB_COM_WRITE_MPX` response struct was generated with a big-endian default for its single parameter, `ResponseMask`. The `parameters` layer in `smb_v10` is byte-preserving, so the endianness the command struct uses to build its raw parameter bytes is exactly what is transmitted on the wire. CIFS/SMB mandates little-endian for all integer fields, so `ResponseMask` was being mis-encoded and mis-decoded on the wire.

### Fix Description
Changed the 4-byte `ResponseMask` field in both `Marshal` and `Unmarshal` from `binary.BigEndian` to `binary.LittleEndian`, matching the MS-CIFS specification (https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/25efbb00-5ad0-42a2-8861-99a79c4d63fe) and the convention already used by the hand-corrected commands. Marshal/Unmarshal symmetry is preserved.

### How Verified
- **Static:** `ResponseMask` is a `ULONG` (4 bytes); spec defines WordCount=0x02 and ByteCount=0x0000, both produced by the byte-preserving parameters/data layers unchanged. Marshal L85 and Unmarshal L142 now use `binary.LittleEndian`.
- **Build/Tests:** `go build ./network/smb/smb_v10/message/commands/` succeeds; `go test ./network/smb/smb_v10/message/commands/` passes.

### Test Coverage
**Existing:** existing round-trip tests in the package pass. Round-trip tests are symmetric and do not assert wire byte order; the fix is verified against the spec's documented little-endian encoding.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/WriteMpxResponse.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Notes
Part of tracking issue #134 (big-endian parameter marshalling across remaining command files).