### PR TITLE
[bugfix] Fix NegotiateResponse data block discriminator and Marshal/Unmarshal layout (#168)

### DIFF
--- a/network/smb/smb_v10/message/commands/NegotiateResponse.go
+++ b/network/smb/smb_v10/message/commands/NegotiateResponse.go
@@ -205,17 +205,21 @@ func (c *NegotiateResponse) Marshal() ([]byte, error) {
 	// This is because some parameters are dependent on the data, for example the size of some fields within
 	// the data will be stored in the parameters
 	rawDataContent := []byte{}
-	if c.SecurityMode.SupportsChallengeResponseAuth() {
+	// The SMB_Data layout is selected by the CAP_EXTENDED_SECURITY capability bit, as
+	// specified in [MS-SMB] section 2.2.4.5.2.1 (Extended Security Response). When it is
+	// set, the data block carries ServerGUID + SecurityBlob; otherwise it carries the
+	// [MS-CIFS] section 2.2.4.52.2 layout of Challenge + DomainName.
+	if c.Capabilities.HasCapability(capabilities.CAP_EXTENDED_SECURITY) {
+		// Marshalling data ServerGUID
+		rawDataContent = append(rawDataContent, c.ServerGUID.ToBytes()...)
+		// Marshalling data SecurityBlob
+		rawDataContent = append(rawDataContent, c.SecurityBlob...)
+	} else {
 		// Marshalling data Challenge
 		c.ChallengeLength = types.UCHAR(len(c.Challenge))
 		rawDataContent = append(rawDataContent, c.Challenge...)
 		// Marshalling data DomainName
 		rawDataContent = append(rawDataContent, c.DomainName...)
-	} else {
-		// Marshalling data ServerGUID
-		rawDataContent = append(rawDataContent, c.ServerGUID.ToBytes()...)
-		// Marshalling data SecurityBlob
-		rawDataContent = append(rawDataContent, c.SecurityBlob...)
 	}
 
 	// Then marshal the parameters
@@ -391,8 +395,12 @@ func (c *NegotiateResponse) Unmarshal(marshalledData []byte) (int, error) {
 	offset++
 
 	// Then unmarshal the data
+	// The SMB_Data layout is selected by the CAP_EXTENDED_SECURITY capability bit, as
+	// specified in [MS-SMB] section 2.2.4.5.2.1 (Extended Security Response). When it is
+	// set, the data block carries ServerGUID + SecurityBlob; otherwise it carries the
+	// [MS-CIFS] section 2.2.4.52.2 layout of Challenge + DomainName.
 	offset = 0
-	if c.SecurityMode.SupportsChallengeResponseAuth() {
+	if c.Capabilities.HasCapability(capabilities.CAP_EXTENDED_SECURITY) {
 		// Unmarshalling data ServerGUID
 		if len(rawDataContent) < offset+16 {
 			return offset, fmt.Errorf("rawDataContent too short for ServerGUID")

--- a/network/smb/smb_v10/message/commands/NegotiateResponse_test.go
+++ b/network/smb/smb_v10/message/commands/NegotiateResponse_test.go
@@ -4,8 +4,8 @@ import (
 	"encoding/binary"
 	"testing"
 
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/capabilities"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
-	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/securitymode"
 )
 
 // buildNegotiateResponseParameters constructs the marshalled parameters section
@@ -20,13 +20,15 @@ import (
 //	DialectIndex(2) + SecurityMode(1) + MaxMpxCount(2) + MaxNumberVcs(2) +
 //	MaxBufferSize(4) + MaxRawSize(4) + SessionKey(4) + Capabilities(4) +
 //	SystemTime(8) + ServerTimeZone(2) + ChallengeLength(1) = 34 bytes
-func buildNegotiateResponseParameters(secMode securitymode.SecurityMode) []byte {
+func buildNegotiateResponseParameters(caps capabilities.Capabilities) []byte {
 	// Raw little-endian parameter bytes.
 	params := make([]byte, 34)
 	// DialectIndex = 0
 	binary.LittleEndian.PutUint16(params[0:2], 0)
-	// SecurityMode (1 byte)
-	params[2] = byte(secMode)
+	// SecurityMode (1 byte) left as zero.
+	// Capabilities (4 bytes) at offset 19 selects the SMB_Data layout: when
+	// CAP_EXTENDED_SECURITY is set the data block carries ServerGUID + SecurityBlob.
+	binary.LittleEndian.PutUint32(params[19:23], uint32(caps))
 	// Remaining fields left as zero; ChallengeLength at offset 33 is 0.
 
 	// Repack as 17 big-endian uint16 words so that Parameters.Unmarshal
@@ -47,7 +49,7 @@ func buildNegotiateResponseParameters(secMode securitymode.SecurityMode) []byte 
 // shorter than 16 bytes) returns an error instead of panicking on an
 // out-of-range slice access.
 func Test_NegotiateResponse_Unmarshal_ShortExtendedSecurityDataDoesNotPanic(t *testing.T) {
-	paramsSection := buildNegotiateResponseParameters(securitymode.NEGOTIATE_ENCRYPT_PASSWORDS)
+	paramsSection := buildNegotiateResponseParameters(capabilities.CAP_EXTENDED_SECURITY)
 
 	// Data section: ByteCount = 4 (less than the 16 bytes required for ServerGUID)
 	dataSection := []byte{0x04, 0x00, 0xAA, 0xBB, 0xCC, 0xDD}


### PR DESCRIPTION
### Linked Issue
Closes #168

### Root Cause
The `SMB_COM_NEGOTIATE` response carries one of two mutually exclusive `SMB_Data` layouts: the non-extended-security layout (`Challenge` + `DomainName`, per [MS-CIFS] 2.2.4.52.2) or the extended-security layout (`ServerGUID` + `SecurityBlob`, per [MS-SMB] 2.2.4.5.2.1 "Extended Security Response"). The spec selects between them by whether `CAP_EXTENDED_SECURITY` (0x80000000) is negotiated in `Capabilities`.

The implementation instead discriminated on `c.SecurityMode.SupportsChallengeResponseAuth()` — the `NEGOTIATE_ENCRYPT_PASSWORDS` bit of `SecurityMode`, which governs plaintext-vs-challenge/response password authentication, an orthogonal field. On top of that, `Marshal` and `Unmarshal` used the same boolean to select *opposite* layouts: `Marshal`'s `true` branch wrote `Challenge`+`DomainName` while `Unmarshal`'s `true` branch read `ServerGUID`+`SecurityBlob`. The two were mirror-inverted, so a marshalled response could not be round-tripped back.

### Fix Description
Both `Marshal` and `Unmarshal` now select the data-block layout with `c.Capabilities.HasCapability(capabilities.CAP_EXTENDED_SECURITY)`, and both place the extended-security layout (`ServerGUID` + `SecurityBlob`) in the `true` branch and the non-extended layout (`Challenge` + `DomainName`) in the `false` branch. This makes the two routines symmetric and matches the spec's discriminator. The parameters block was already correct and is untouched.

### How Verified
- Static: the corrected `Marshal` (L208-L223) and `Unmarshal` (L395-L408) now use the same condition and the same branch ordering, so `Unmarshal(Marshal(x))` reconstructs `x`; the discriminator matches [MS-SMB] 2.2.4.5.2.1.
- Tests: `go test ./network/smb/smb_v10/message/commands/` passes, including `Test_NegotiateResponse_Unmarshal_ShortExtendedSecurityDataDoesNotPanic`.
- `go build ./...` passes.

### Test Coverage
**Existing:** `Test_NegotiateResponse_Unmarshal_ShortExtendedSecurityDataDoesNotPanic` was updated to select the extended-security path through the corrected discriminator (`CAP_EXTENDED_SECURITY` capability bit) rather than the old `NEGOTIATE_ENCRYPT_PASSWORDS` security-mode bit, and continues to assert the truncated-data path returns an error instead of panicking.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/NegotiateResponse.go`, `network/smb/smb_v10/message/commands/NegotiateResponse_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Notes
While confirming the fix, the non-extended path's `DomainName`/`ServerName` parsing via `utils.GetNullTerminatedUnicodeString` was observed to read past the buffer and return an over-long offset when the data lacks a UTF-16 null terminator (an out-of-range slice on `rawDataContent[offset:]`). That is a separate latent defect in the utils helper and is not addressed here.
