### PR TITLE
[bugfix] Fix FindUniqueRequest data block format and resume-key encoding (#271)

### DIFF
--- a/network/smb/smb_v10/message/commands/FindUniqueRequest.go
+++ b/network/smb/smb_v10/message/commands/FindUniqueRequest.go
@@ -37,7 +37,9 @@ type FindUniqueRequest struct {
 	// BufferFormat2 (1 byte): This field MUST be 0x05, which indicates that a variable block is to follow.
 	// ResumeKeyLength (2 bytes): This field MUST be 0x0000. No Resume Key is permitted in the SMB_COM_FIND_UNIQUE request.
 	// If the server receives an SMB_COM_FIND_UNIQUE request with a nonzero ResumeKeyLength, it MUST ignore this field.
-	ResumeKey types.SMB_RESUME_KEY
+	// No Resume Key is permitted, so this is encoded as the BufferFormat2 byte (0x05) followed by a
+	// ResumeKeyLength of 0x0000 and no resume-key body, i.e. an empty variable-block SMB_STRING.
+	ResumeKey types.SMB_STRING
 }
 
 // NewFindUniqueRequest creates a new FindUniqueRequest structure
@@ -52,7 +54,7 @@ func NewFindUniqueRequest() *FindUniqueRequest {
 
 		// Data
 		FileName:  types.SMB_STRING{},
-		ResumeKey: types.SMB_RESUME_KEY{},
+		ResumeKey: types.SMB_STRING{},
 	}
 
 	c.Command.SetCommandCode(codes.SMB_COM_FIND_UNIQUE)
@@ -95,6 +97,8 @@ func (c *FindUniqueRequest) Marshal() ([]byte, error) {
 	rawDataContent := []byte{}
 
 	// Marshalling data FileName
+	// BufferFormat1 (1 byte) MUST be 0x04, indicating a null-terminated ASCII string follows.
+	c.FileName.SetBufferFormat(types.SMB_STRING_BUFFER_FORMAT_NULL_TERMINATED_ASCII_STRING)
 	bytesStream, err := c.FileName.Marshal()
 	if err != nil {
 		return nil, err
@@ -102,6 +106,9 @@ func (c *FindUniqueRequest) Marshal() ([]byte, error) {
 	rawDataContent = append(rawDataContent, bytesStream...)
 
 	// Marshalling data ResumeKey
+	// BufferFormat2 (1 byte) MUST be 0x05; with no resume key permitted, this emits a
+	// ResumeKeyLength of 0x0000 and no resume-key body.
+	c.ResumeKey.SetBufferFormat(types.SMB_STRING_BUFFER_FORMAT_VARIABLE_BLOCK)
 	bytesStream, err = c.ResumeKey.Marshal()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### Linked Issue
Closes #271

### Root Cause
Two defects in the SMB_COM_FIND_UNIQUE data block. (1) `NewFindUniqueRequest()` left `FileName.BufferFormat = 0x00` and `Marshal()` never set it, so `SMB_STRING.Marshal()` hit its default case and returned `"invalid buffer format: 0"` — the request could never be serialized. (2) `ResumeKey` was typed `types.SMB_RESUME_KEY`, whose `Marshal()` always emits a 21-byte resume-key body with `ResumeKeyLength = 0x0015`, but MS-CIFS requires `ResumeKeyLength = 0x0000` with no resume key in a FIND_UNIQUE request.

### Fix Description
Following the established `FindRequest.go` pattern: set `FileName` BufferFormat to `0x04` (null-terminated ASCII) before marshalling, change the `ResumeKey` field type from `SMB_RESUME_KEY` to `SMB_STRING`, and set its BufferFormat to `0x05` (variable block). An empty variable-block SMB_STRING marshals to `0x05` + `0x0000`, satisfying the BufferFormat2 + ResumeKeyLength=0x0000 requirement with no resume-key body.

### How Verified
- Static: per MS-CIFS SMB_COM_FIND_UNIQUE Request the data block is `BufferFormat1=0x04`, FileName, `BufferFormat2=0x05`, `ResumeKeyLength=0x0000`.
- Runtime: `NewFindUniqueRequest(); c.FileName.SetString("a"); c.Marshal()` now succeeds (previously returned `invalid buffer format: 0`) and the data block bytes are `04 61 00 05 00 00` (BufferFormat1=0x04, "a"+NUL, BufferFormat2=0x05, ResumeKeyLength=0x0000), ByteCount=6.
- `go build ./network/smb/smb_v10/...` passes; `go test ./network/smb/smb_v10/message/commands/` passes.

### Test Coverage
**None:** no dedicated FindUniqueRequest test exists in the suite. Behavior was verified with a temporary probe (removed) confirming Marshal succeeds and emits the spec-correct data block.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/FindUniqueRequest.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Localized to FindUniqueRequest marshalling; brings it in line with the sibling FindRequest. The `MaxCount` little-endian fix is handled separately in #181 / PR #260 on a non-overlapping region.