### PR TITLE
[bugfix] Fix WriteRequest parameters little-endian marshalling (#249)

### DIFF
--- a/network/smb/smb_v10/message/commands/WriteRequest.go
+++ b/network/smb/smb_v10/message/commands/WriteRequest.go
@@ -117,22 +117,22 @@ func (c *WriteRequest) Marshal() ([]byte, error) {
 
 	// Marshalling parameter FID
 	buf2 := make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.FID))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.FID))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter CountOfBytesToWrite
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.CountOfBytesToWrite))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.CountOfBytesToWrite))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter WriteOffsetInBytes
 	buf4 := make([]byte, 4)
-	binary.BigEndian.PutUint32(buf4, uint32(c.WriteOffsetInBytes))
+	binary.LittleEndian.PutUint32(buf4, uint32(c.WriteOffsetInBytes))
 	rawParametersContent = append(rawParametersContent, buf4...)
 
 	// Marshalling parameter EstimateOfRemainingBytesToBeWritten
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.EstimateOfRemainingBytesToBeWritten))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.EstimateOfRemainingBytesToBeWritten))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameters
@@ -189,28 +189,28 @@ func (c *WriteRequest) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for FID")
 	}
-	c.FID = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.FID = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter CountOfBytesToWrite
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for CountOfBytesToWrite")
 	}
-	c.CountOfBytesToWrite = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.CountOfBytesToWrite = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter WriteOffsetInBytes
 	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for WriteOffsetInBytes")
 	}
-	c.WriteOffsetInBytes = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	c.WriteOffsetInBytes = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
 	offset += 4
 
 	// Unmarshalling parameter EstimateOfRemainingBytesToBeWritten
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for EstimateOfRemainingBytesToBeWritten")
 	}
-	c.EstimateOfRemainingBytesToBeWritten = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.EstimateOfRemainingBytesToBeWritten = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Then unmarshal the data


### PR DESCRIPTION
### Linked Issue
Closes #249

### Root Cause
`WriteRequest.go` is a generated command file that defaulted to `binary.BigEndian` for its SMB_Parameters words and was never exercised against a live server. Because the `parameters` layer in `smb_v10` is byte-preserving, the endianness chosen in the struct is exactly what reaches the wire. SMB/CIFS integer fields are little-endian (per MS-CIFS), so every SMB_COM_WRITE request transmitted FID, CountOfBytesToWrite, WriteOffsetInBytes, and EstimateOfRemainingBytesToBeWritten with swapped bytes. Symmetric round-trip unit tests pass regardless and never surfaced the defect.

### Fix Description
Switched the four SMB_Parameters integer fields from `binary.BigEndian` to `binary.LittleEndian` in both `Marshal()` and `Unmarshal()`:
- `FID` (USHORT, 2 bytes)
- `CountOfBytesToWrite` (USHORT, 2 bytes)
- `WriteOffsetInBytes` (ULONG, 4 bytes)
- `EstimateOfRemainingBytesToBeWritten` (USHORT, 2 bytes)

The SMB_Data section is unchanged: it already uses `SMB_STRING` format `0x01` (VARIABLE_BLOCK_16BIT), which emits BufferFormat=0x01 + a little-endian 2-byte DataLength + raw Data, matching MS-CIFS 2.2.4.29.1.

### How Verified
Static: per [MS-CIFS Request 2.2.4.29.1](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/861c96cf-d6b1-4fb9-b6e3-1783220813ad), WordCount=0x05 and the Words block is USHORT/ULONG fields, all little-endian. The patched Marshal/Unmarshal now use `binary.LittleEndian` for all four fields, in the spec field order with the spec sizes.
Tests: `go build ./network/smb/smb_v10/...` succeeds; `go test ./network/smb/smb_v10/message/commands/...` passes.

### Test Coverage
Existing: the package's round-trip tests in `network/smb/smb_v10/message/commands` continue to pass (they are endianness-symmetric and exercise Marshal/Unmarshal). No new test added because the existing suite is symmetric and cannot assert wire endianness; the spec citation is the authoritative check.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/WriteRequest.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Low blast radius, local to WriteRequest marshalling. Safe to merge directly; corrects on-wire bytes for SMB_COM_WRITE requests.