### PR TITLE
[bugfix] Fix WriteAndCloseResponse CountOfBytesWritten little-endian marshalling (#297)

### DIFF
--- a/network/smb/smb_v10/message/commands/WriteAndCloseResponse.go
+++ b/network/smb/smb_v10/message/commands/WriteAndCloseResponse.go
@@ -81,7 +81,7 @@ func (c *WriteAndCloseResponse) Marshal() ([]byte, error) {
 
 	// Marshalling parameter CountOfBytesWritten
 	buf2 := make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.CountOfBytesWritten))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.CountOfBytesWritten))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameters
@@ -138,7 +138,7 @@ func (c *WriteAndCloseResponse) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for CountOfBytesWritten")
 	}
-	c.CountOfBytesWritten = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.CountOfBytesWritten = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Then unmarshal the data


### PR DESCRIPTION
### Linked Issue
`Closes #297`

### Root Cause
The `WriteAndCloseResponse` command file was generated with a big-endian default for serializing its parameter word. SMB/CIFS transmits all integer fields little-endian, and the `parameters` layer is byte-preserving, so the big-endian bytes produced by the struct reached the wire unchanged. The command was never exercised against a live peer, and symmetric `Marshal`/`Unmarshal` round-trip tests cannot detect an endianness defect because both sides use the same (wrong) order.

### Fix Description
Switch `CountOfBytesWritten` to little-endian in both directions: `binary.LittleEndian.PutUint16` in `Marshal()` and `binary.LittleEndian.Uint16` in `Unmarshal()`. This matches the MS-CIFS definition of the field as a little-endian `USHORT`. Marshal/Unmarshal symmetry is preserved.

### How Verified
- **Static:** Confirmed against [MS-CIFS SMB_COM_WRITE_AND_CLOSE Response](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/fcf13ef6-ce16-4143-a926-e7cafabaeea3): `WordCount` MUST be 0x01, the single word is `CountOfBytesWritten` (2-byte `USHORT`), `ByteCount` MUST be 0x0000. Only the endianness of the word was wrong.
- **Tests:** `go build ./network/smb/smb_v10/...` and `go test ./network/smb/smb_v10/message/commands/...` both pass.

### Test Coverage
- **Existing:** Existing round-trip tests in the `commands` package continue to pass. No new test added, as the package has no golden-byte harness to assert on-wire endianness; the change is a one-token endianness correction mirrored on both sides.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/WriteAndCloseResponse.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local, single-field change; safe to merge. Same defect class as #249, #261, #278, #286.