### PR TITLE
[bugfix] Fix WriteMpxResponse ResponseMask endianness (#296)

### DIFF
--- a/network/smb/smb_v10/message/commands/WriteMpxResponse.go
+++ b/network/smb/smb_v10/message/commands/WriteMpxResponse.go
@@ -82,7 +82,7 @@ func (c *WriteMpxResponse) Marshal() ([]byte, error) {
 
 	// Marshalling parameter ResponseMask
 	buf4 := make([]byte, 4)
-	binary.BigEndian.PutUint32(buf4, uint32(c.ResponseMask))
+	binary.LittleEndian.PutUint32(buf4, uint32(c.ResponseMask))
 	rawParametersContent = append(rawParametersContent, buf4...)
 
 	// Marshalling parameters
@@ -139,7 +139,7 @@ func (c *WriteMpxResponse) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for ResponseMask")
 	}
-	c.ResponseMask = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	c.ResponseMask = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
 	offset += 4
 
 	// Then unmarshal the data


### PR DESCRIPTION
### Linked Issue
Closes #296

### Root Cause
`WriteMpxResponse` was generated with big-endian integer encoding for its `ResponseMask` parameter. SMB/CIFS encodes all integer fields little-endian, and the package's `parameters` layer is byte-preserving, so the big-endian bytes were transmitted verbatim on the wire. Because `Marshal` and `Unmarshal` both used big-endian, they were symmetric and round-trip unit tests passed, masking the wire defect.

### Fix Description
Changed the `ResponseMask` (4-byte `ULONG`) encode/decode from `binary.BigEndian` to `binary.LittleEndian` in both `Marshal()` and `Unmarshal()`, matching MS-CIFS section 2.2.4.27. Field order, size, WordCount (0x02), and the empty `ByteCount`/data already match the spec and are unchanged.

### How Verified
- **Static:** MS-CIFS spec (https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/25efbb00-5ad0-42a2-8861-99a79c4d63fe) defines `ResponseMask` as a 4-byte ULONG; SMB integers are little-endian. Sibling types (e.g. `LOCKING_ANDX_RANGE32`) already use `binary.LittleEndian` for ULONG fields.
- **Tests:** `go build ./...` and `go test ./network/smb/smb_v10/message/commands/...` both pass.

### Test Coverage
**Existing:** the commands package round-trip tests pass after the fix. They are symmetric so they do not assert the on-wire byte order; correctness is established against the spec.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/WriteMpxResponse.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local change to a single command's parameter encoding; safe to merge directly.