### PR TITLE
[bugfix] Fix WriteRawRequest parameters to use little-endian encoding (#261)

### DIFF
--- a/network/smb/smb_v10/message/commands/WriteRawRequest.go
+++ b/network/smb/smb_v10/message/commands/WriteRawRequest.go
@@ -154,53 +154,53 @@ func (c *WriteRawRequest) Marshal() ([]byte, error) {
 
 	// Marshalling parameter FID
 	buf2 := make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.FID))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.FID))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter CountOfBytes
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.CountOfBytes))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.CountOfBytes))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter Reserved1
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.Reserved1))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.Reserved1))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter Offset
 	buf4 := make([]byte, 4)
-	binary.BigEndian.PutUint32(buf4, uint32(c.Offset))
+	binary.LittleEndian.PutUint32(buf4, uint32(c.Offset))
 	rawParametersContent = append(rawParametersContent, buf4...)
 
 	// Marshalling parameter Timeout
 	buf4 = make([]byte, 4)
-	binary.BigEndian.PutUint32(buf4, uint32(c.Timeout))
+	binary.LittleEndian.PutUint32(buf4, uint32(c.Timeout))
 	rawParametersContent = append(rawParametersContent, buf4...)
 
 	// Marshalling parameter WriteMode
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.WriteMode))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.WriteMode))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter Reserved2
 	buf4 = make([]byte, 4)
-	binary.BigEndian.PutUint32(buf4, uint32(c.Reserved2))
+	binary.LittleEndian.PutUint32(buf4, uint32(c.Reserved2))
 	rawParametersContent = append(rawParametersContent, buf4...)
 
 	// Marshalling parameter DataLength
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.DataLength))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.DataLength))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter DataOffset
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.DataOffset))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.DataOffset))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter OffsetHigh
 	if c.OffsetHigh != 0x00000000 {
 		buf4 = make([]byte, 4)
-		binary.BigEndian.PutUint32(buf4, uint32(c.OffsetHigh))
+		binary.LittleEndian.PutUint32(buf4, uint32(c.OffsetHigh))
 		rawParametersContent = append(rawParametersContent, buf4...)
 	}
 
@@ -258,63 +258,63 @@ func (c *WriteRawRequest) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for FID")
 	}
-	c.FID = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.FID = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter CountOfBytes
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for CountOfBytes")
 	}
-	c.CountOfBytes = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.CountOfBytes = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter Reserved1
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for Reserved1")
 	}
-	c.Reserved1 = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.Reserved1 = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter Offset
 	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for Offset")
 	}
-	c.Offset = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	c.Offset = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
 	offset += 4
 
 	// Unmarshalling parameter Timeout
 	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for Timeout")
 	}
-	c.Timeout = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	c.Timeout = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
 	offset += 4
 
 	// Unmarshalling parameter WriteMode
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for WriteMode")
 	}
-	c.WriteMode = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.WriteMode = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter Reserved2
 	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for Reserved2")
 	}
-	c.Reserved2 = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	c.Reserved2 = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
 	offset += 4
 
 	// Unmarshalling parameter DataLength
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for DataLength")
 	}
-	c.DataLength = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.DataLength = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter DataOffset
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for DataOffset")
 	}
-	c.DataOffset = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.DataOffset = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter OffsetHigh
@@ -322,7 +322,7 @@ func (c *WriteRawRequest) Unmarshal(data []byte) (int, error) {
 		if len(rawParametersContent) < offset+4 {
 			return offset, fmt.Errorf("rawParametersContent too short for OffsetHigh")
 		}
-		c.OffsetHigh = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+		c.OffsetHigh = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
 		offset += 4
 	}
 


### PR DESCRIPTION
### Linked Issue
Closes #261

### Root Cause
`WriteRawRequest` was generated with `binary.BigEndian` for every integer field in both `Marshal()` and `Unmarshal()`. SMB/CIFS wire fields are little-endian, and the `parameters` layer is byte-preserving, so the endianness chosen by the struct reaches the wire verbatim. Because `Marshal`/`Unmarshal` are symmetric, round-trip unit tests passed while the on-wire bytes were reversed; the defect was never exercised against a live peer.

### Fix Description
Replaced all 20 `binary.BigEndian` calls with `binary.LittleEndian` across the parameter fields (FID, CountOfBytes, Reserved1, Offset, Timeout, WriteMode, Reserved2, DataLength, DataOffset, OffsetHigh) in both `Marshal()` and `Unmarshal()`. This matches MS-CIFS (https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/1ff2a25f-efe2-470c-a780-b06ef46c4089) and the hand-corrected commands such as `TreeConnectAndxRequest`. Field order, sizes, and types were already correct and are unchanged.

### How Verified
- **Static:** Confirmed all integer fields now use `binary.LittleEndian`; field order/sizes match the MS-CIFS Words table (WordCount 0x0C/0x0E, OffsetHigh optional on 0x0E).
- **Tests:** `go build ./...` succeeds; `go test ./network/smb/smb_v10/message/commands/...` passes.

### Test Coverage
**Existing:** The existing round-trip tests in the `commands` package continue to pass after the fix. No new test added — the round-trip tests are endianness-symmetric and cannot distinguish wire byte order; the correctness is established against the MS-CIFS spec.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/WriteRawRequest.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local to a single command's wire encoding; corrects bytes that were previously wrong on the wire. Safe to merge.