### PR TITLE
[bugfix] Fix WriteRawInterim Available marshalling to little-endian (#247)

### DIFF
--- a/network/smb/smb_v10/message/commands/WriteRawInterim.go
+++ b/network/smb/smb_v10/message/commands/WriteRawInterim.go
@@ -80,7 +80,7 @@ func (c *WriteRawInterim) Marshal() ([]byte, error) {
 
 	// Marshalling parameter Available
 	buf2 := make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.Available))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.Available))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameters
@@ -137,7 +137,7 @@ func (c *WriteRawInterim) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for Available")
 	}
-	c.Available = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.Available = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Then unmarshal the data


### PR DESCRIPTION
### Linked Issue
Closes #247

### Root Cause
The command file was generated with `binary.BigEndian` as the default integer encoding and was never corrected to little-endian. SMB/CIFS encodes all integer fields little-endian, and the `parameters` layer is byte-preserving, so the big-endian bytes produced by the struct were transmitted verbatim on the wire.

### Fix Description
Changed the `Available` field encoding in both directions to little-endian:
- `Marshal()`: `binary.BigEndian.PutUint16` -> `binary.LittleEndian.PutUint16`.
- `Unmarshal()`: `binary.BigEndian.Uint16` -> `binary.LittleEndian.Uint16`.

This matches MS-CIFS 2.2.4.25.4 Interim Server Response, where `SMB_Parameters` is `WordCount = 0x01` followed by a single 2-byte little-endian `USHORT Available`, and `ByteCount = 0x0000`. Marshal/Unmarshal remain symmetric.

### How Verified
- **Static:** The two encode/decode sites (L83 and L140 of `WriteRawInterim.go`) now use `binary.LittleEndian`, so the 16-bit `Available` value is placed on and read from the wire least-significant-byte first, as the spec requires.
- **Tests:** `go test ./network/smb/smb_v10/message/commands/...` passes; `go build ./...` succeeds.

### Test Coverage
**Existing:** Existing round-trip tests in the commands package cover Marshal/Unmarshal symmetry and continue to pass. (Round-trip tests are endianness-symmetric, so the spec citation is the authority for the wire format here.)

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/WriteRawInterim.go`
- **Submodule pointer updated:** no
- **Public API changes:** none
- **Behavioral changes outside the stated fix:** none

### Risk and Rollout
Local, single-field change. Blast radius limited to the `Available` field wire encoding of SMB_COM_WRITE_RAW interim responses. Safe to merge directly.
