### PR TITLE
[bugfix] Fix WriteResponse CountOfBytesWritten little-endian marshalling (#250)

### DIFF
--- a/network/smb/smb_v10/message/commands/WriteResponse.go
+++ b/network/smb/smb_v10/message/commands/WriteResponse.go
@@ -82,7 +82,7 @@ func (c *WriteResponse) Marshal() ([]byte, error) {
 
 	// Marshalling parameter CountOfBytesWritten
 	buf2 := make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.CountOfBytesWritten))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.CountOfBytesWritten))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameters
@@ -139,7 +139,7 @@ func (c *WriteResponse) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for CountOfBytesWritten")
 	}
-	c.CountOfBytesWritten = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.CountOfBytesWritten = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Then unmarshal the data


### PR DESCRIPTION
### Linked Issue
Closes #250

### Root Cause
The generated `WriteResponse` command file defaulted to `binary.BigEndian` for the single `CountOfBytesWritten` parameter and was never exercised against a live SMB peer. SMB/CIFS multi-byte integer fields are little-endian, and the package's `parameters` layer is byte-preserving, so the endianness chosen in the struct is exactly what reaches the wire. The big-endian default therefore byte-reversed the count on the wire.

### Fix Description
Switch both the marshal and unmarshal of `CountOfBytesWritten` from `binary.BigEndian` to `binary.LittleEndian`, matching the MS-CIFS SMB_COM_WRITE Response definition (`Words { USHORT CountOfBytesWritten; }`). Marshal/Unmarshal stay symmetric.

### How Verified
- Static: per [MS-CIFS SMB_COM_WRITE Response](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/3f68a73c-e6d6-4383-b81a-d49c2eb4234b), `CountOfBytesWritten` is a 2-byte little-endian USHORT. After the fix a value of 256 (`0x0100`) emits wire bytes `00 01` instead of the previous `01 00`.
- `go build ./network/smb/smb_v10/...` succeeds.
- `go test ./network/smb/smb_v10/message/commands/...` passes.

### Test Coverage
**Existing:** existing round-trip tests in the `commands` package continue to pass. They are symmetric and do not assert wire byte order, but the correctness is established by the spec citation above.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/WriteResponse.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local, two-line change confined to one command's wire encoding. Safe to merge directly.

### Notes
Part of tracking issue #134 (big-endian parameter marshalling across remaining command files).
