### PR TITLE
[bugfix] Fix ReadResponse missing 8-byte Reserved parameter field (#222)

### DIFF
--- a/network/smb/smb_v10/message/commands/ReadResponse.go
+++ b/network/smb/smb_v10/message/commands/ReadResponse.go
@@ -25,8 +25,8 @@ type ReadResponse struct {
 	// at or beyond the end of file.
 	CountOfBytesReturned types.USHORT
 
-	// Reserved (4 bytes): Reserved. MUST be 0x00000000.
-	Reserved types.USHORT
+	// Reserved (8 bytes): Reserved. All bytes MUST be 0x00.
+	Reserved [4]types.USHORT
 
 	// Data
 
@@ -45,6 +45,7 @@ func NewReadResponse() *ReadResponse {
 	c := &ReadResponse{
 		// Parameters
 		CountOfBytesReturned: types.USHORT(0),
+		Reserved:             [4]types.USHORT{},
 
 		// Data
 		Bytes: types.SMB_STRING{},
@@ -104,6 +105,13 @@ func (c *ReadResponse) Marshal() ([]byte, error) {
 	binary.BigEndian.PutUint16(buf2, uint16(c.CountOfBytesReturned))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
+	// Marshalling parameter Reserved (4 USHORT = 8 bytes, all MUST be 0x00)
+	for _, reservedWord := range c.Reserved {
+		bufReserved := make([]byte, 2)
+		binary.LittleEndian.PutUint16(bufReserved, uint16(reservedWord))
+		rawParametersContent = append(rawParametersContent, bufReserved...)
+	}
+
 	// Marshalling parameters
 	c.GetParameters().AddWordsFromBytesStream(rawParametersContent)
 	marshalledParameters, err := c.GetParameters().Marshal()
@@ -160,6 +168,15 @@ func (c *ReadResponse) Unmarshal(data []byte) (int, error) {
 	}
 	c.CountOfBytesReturned = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
+
+	// Unmarshalling parameter Reserved (4 USHORT = 8 bytes)
+	for i := range c.Reserved {
+		if len(rawParametersContent) < offset+2 {
+			return offset, fmt.Errorf("rawParametersContent too short for Reserved")
+		}
+		c.Reserved[i] = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
+		offset += 2
+	}
 
 	// Then unmarshal the data
 	offset = 0


### PR DESCRIPTION
Closes #222

### Root Cause
Per [MS-CIFS SMB_COM_READ Response](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/bc54fec8-3e8a-4c05-bbe9-11ed116d1d67) the parameter block is `WordCount = 0x05` (10 bytes of Words): `USHORT CountOfBytesReturned` followed by `USHORT Reserved[4]` (8 bytes, all 0x00). The struct declared `Reserved` as a single `types.USHORT` (2 bytes) and never marshalled or unmarshalled it. As a result `Marshal` emitted only the 2-byte CountOfBytesReturned word, producing `WordCount = 0x01` instead of the required `0x05` and corrupting the entire parameter block on the wire.

### Fix Description
- Changed `Reserved` from `types.USHORT` to `[4]types.USHORT` to match the documented 8-byte `Reserved[4]` field.
- `Marshal` now writes all four reserved words (little-endian, value 0x0000) immediately after `CountOfBytesReturned`, yielding the spec-required 10-byte Words block (WordCount 0x05).
- `Unmarshal` now consumes the four reserved words with `len >= offset+2` guards before parsing the data block, preserving Marshal/Unmarshal symmetry.

### How Verified
- **Static:** `Marshal` now appends 4 x 2 bytes after the 2-byte CountOfBytesReturned, producing exactly 10 bytes of Words (WordCount 0x05) per the spec table. `Unmarshal` reads them back symmetrically.
- **Tests:** `go test ./network/smb/smb_v10/message/commands/...` passes.

### Test Coverage
**Existing:** existing command round-trip tests in `network/smb/smb_v10/message/commands` exercise this path and pass after the fix.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/ReadResponse.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Notes
The little-endian encoding of `CountOfBytesReturned` (issue #211) is addressed separately in PR #277; this PR edits non-overlapping regions and only fixes the missing Reserved field.