### PR TITLE
[bugfix] Fix WritePrintFileRequest FID big-endian marshalling (#300)

### DIFF
--- a/network/smb/smb_v10/message/commands/WritePrintFileRequest.go
+++ b/network/smb/smb_v10/message/commands/WritePrintFileRequest.go
@@ -96,7 +96,7 @@ func (c *WritePrintFileRequest) Marshal() ([]byte, error) {
 
 	// Marshalling parameter FID
 	buf2 := make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.FID))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.FID))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameters
@@ -153,7 +153,7 @@ func (c *WritePrintFileRequest) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for FID")
 	}
-	c.FID = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.FID = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Then unmarshal the data


### PR DESCRIPTION
### Linked Issue
Closes #300

### Root Cause
The command file was generated with a big-endian default for its parameter word. The `parameters` layer is byte-preserving: `AddWordsFromBytesStream` packs raw bytes `[hi, lo]` into a word and `Parameters.Marshal` re-emits them with `binary.BigEndian.PutUint16`, so the bytes the command struct produces are exactly what is transmitted. Because `Marshal`/`Unmarshal` are symmetric, round-trip unit tests passed and the wire-order defect went unnoticed; only a live server or a golden-byte comparison exposes it. MS-CIFS specifies the `USHORT FID` word of SMB_COM_WRITE_PRINT_FILE as little-endian, like all SMB integers.

### Fix Description
Changed the FID encoding in `Marshal()` from `binary.BigEndian.PutUint16` to `binary.LittleEndian.PutUint16`, and the decoding in `Unmarshal()` from `binary.BigEndian.Uint16` to `binary.LittleEndian.Uint16`. This matches the spec and the hand-corrected sibling commands (`CloseRequest.go`, `ReadAndxRequest.go`, `WriteAndxRequest.go`). Marshal/Unmarshal symmetry is preserved.

### How Verified
- Static: the FID word is now emitted little-endian, so a multi-byte FID (e.g. 0x1234) reaches the wire as `34 12`, matching the MS-CIFS little-endian USHORT.
- Tests: `go test ./network/smb/smb_v10/message/commands/...` passes.
- Build: `go build ./...` succeeds.

### Test Coverage
**Existing:** the existing round-trip tests in the commands package continue to pass after the fix. No new test added; the package has no golden-byte harness, and the round-trip tests are symmetric so they cannot assert wire endianness.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/WritePrintFileRequest.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local, single-field change confined to one command's FID encoding; safe to merge directly.