### PR TITLE
[bugfix] Fix FindUniqueRequest MaxCount little-endian marshalling (#308)

### DIFF
--- a/network/smb/smb_v10/message/commands/FindUniqueRequest.go
+++ b/network/smb/smb_v10/message/commands/FindUniqueRequest.go
@@ -113,7 +113,7 @@ func (c *FindUniqueRequest) Marshal() ([]byte, error) {
 
 	// Marshalling parameter MaxCount
 	buf2 := make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.MaxCount))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.MaxCount))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter SearchAttributes
@@ -177,7 +177,7 @@ func (c *FindUniqueRequest) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for MaxCount")
 	}
-	c.MaxCount = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.MaxCount = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter SearchAttributes


### PR DESCRIPTION
### Linked Issue
Closes #308

### Root Cause
The generated `FindUniqueRequest` command file marshalled and unmarshalled its inline `MaxCount` USHORT parameter with `binary.BigEndian`. SMB/CIFS integer fields are little-endian, and the `parameters` layer is byte-preserving, so the big-endian bytes were transmitted verbatim, byte-swapping the value on the wire. Round-trip unit tests did not catch this because Marshal and Unmarshal were symmetrically wrong.

### Fix Description
Changed the two `MaxCount` conversions to use `binary.LittleEndian`: `PutUint16` in `Marshal()` and `Uint16` in `Unmarshal()`. This matches the SMB_COM_FIND_UNIQUE Request parameter block in MS-CIFS, where MaxCount is a little-endian USHORT.

### How Verified
- **Static:** The patched `Marshal()` now emits MaxCount as little-endian bytes and `Unmarshal()` reads them back little-endian, matching the spec wire layout.
- **Tests:** `go test ./network/smb/smb_v10/message/commands/...` passes; `go build ./...` succeeds.

### Test Coverage
- **Existing:** existing round-trip tests in the commands package cover the symmetric Marshal/Unmarshal path and continue to pass.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/FindUniqueRequest.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Notes
Part of the systemic big-endian parameter defect class (see #249, #261, #278). Two related observations were noted during the cross-check but are out of scope for this file-local fix: the shared `SMB_FILE_ATTRIBUTES` type also marshals big-endian, and the shared `SMB_RESUME_KEY` type always emits a 21-byte body whereas SMB_COM_FIND_UNIQUE requires ResumeKeyLength=0x0000 with no ResumeKey body.