### PR TITLE
[bugfix] Fix SetInformation2Request FID big-endian marshalling (#245)

### DIFF
--- a/network/smb/smb_v10/message/commands/SetInformation2Request.go
+++ b/network/smb/smb_v10/message/commands/SetInformation2Request.go
@@ -105,7 +105,7 @@ func (c *SetInformation2Request) Marshal() ([]byte, error) {
 
 	// Marshalling parameter FID
 	buf2 := make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.FID))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.FID))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter CreateDate
@@ -207,7 +207,7 @@ func (c *SetInformation2Request) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for FID")
 	}
-	c.FID = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.FID = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter CreateDate


### PR DESCRIPTION
### Linked Issue
Closes #245

### Root Cause
The generated `SetInformation2Request` command defaulted to `binary.BigEndian` for the `FID` parameter. SMB/CIFS integer fields are little-endian (MS-CIFS 2.2.4.30.1, `USHORT FID`). Because the `parameters` layer is byte-preserving, the big-endian bytes were transmitted verbatim, placing the FID on the wire byte-swapped. Round-trip unit tests passed because `Marshal`/`Unmarshal` are symmetric.

### Fix Description
Switch the `FID` field to little-endian in both directions:
- `Marshal()`: `binary.BigEndian.PutUint16` -> `binary.LittleEndian.PutUint16`
- `Unmarshal()`: `binary.BigEndian.Uint16` -> `binary.LittleEndian.Uint16`

### How Verified
- Static: the patched `Marshal()`/`Unmarshal()` now use `binary.LittleEndian` for the 2-byte FID, matching MS-CIFS little-endian integer encoding.
- Tests: `go build ./network/smb/smb_v10/...` succeeds; `go test ./network/smb/smb_v10/message/commands/...` passes.

### Test Coverage
- **Existing:** existing round-trip tests in the commands package cover Marshal/Unmarshal symmetry and continue to pass after the fix.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/SetInformation2Request.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local, two-line endianness change confined to the FID field; safe to merge.