### PR TITLE
[bugfix] Fix SetInformationRequest LastWriteTime and Reserved wire sizes (#302)

### DIFF
--- a/network/smb/smb_v10/message/commands/SetInformationRequest.go
+++ b/network/smb/smb_v10/message/commands/SetInformationRequest.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"encoding/binary"
 	"fmt"
 
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/andx"
@@ -22,11 +23,13 @@ type SetInformationRequest struct {
 	// SMB_FILE_ATTRIBUTES (section 2.2.4.10.1)
 	FileAttributes types.SMB_FILE_ATTRIBUTES
 
-	// LastWriteTime (4 bytes): The time of the last write to the file.
-	LastWriteTime types.FILETIME
+	// LastWriteTime (4 bytes): The time of the last write to the file, encoded as a
+	// 4-byte UTIME (number of seconds since January 1, 1970 00:00:00.0).
+	LastWriteTime types.ULONG
 
-	// Reserved (5 bytes): This field MUST be 0x0000000000000000.
-	Reserved [5]types.UCHAR
+	// Reserved (10 bytes): This field is reserved, and all bytes MUST be set to 0x00
+	// (USHORT Reserved[5]).
+	Reserved [10]types.UCHAR
 
 	// Data
 
@@ -45,8 +48,8 @@ func NewSetInformationRequest() *SetInformationRequest {
 	c := &SetInformationRequest{
 		// Parameters
 		FileAttributes: types.SMB_FILE_ATTRIBUTES{},
-		LastWriteTime:  types.FILETIME{},
-		Reserved:       [5]types.UCHAR{0, 0, 0, 0, 0},
+		LastWriteTime:  types.ULONG(0),
+		Reserved:       [10]types.UCHAR{0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 
 		// Data
 		FileName: types.SMB_STRING{},
@@ -109,14 +112,12 @@ func (c *SetInformationRequest) Marshal() ([]byte, error) {
 	}
 	rawParametersContent = append(rawParametersContent, bytesStream...)
 
-	// Marshalling parameter LastWriteTime
-	bytesStream, err = c.LastWriteTime.Marshal()
-	if err != nil {
-		return nil, err
-	}
-	rawParametersContent = append(rawParametersContent, bytesStream...)
+	// Marshalling parameter LastWriteTime (4-byte UTIME, little-endian)
+	buf4 := make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf4, uint32(c.LastWriteTime))
+	rawParametersContent = append(rawParametersContent, buf4...)
 
-	// Marshalling parameter Reserved
+	// Marshalling parameter Reserved (10 bytes)
 	rawParametersContent = append(rawParametersContent, c.Reserved[:]...)
 
 	// Marshalling parameters
@@ -176,15 +177,12 @@ func (c *SetInformationRequest) Unmarshal(data []byte) (int, error) {
 	}
 	offset += bytesRead
 
-	// Unmarshalling parameter LastWriteTime
-	if len(rawParametersContent) < offset+8 {
+	// Unmarshalling parameter LastWriteTime (4-byte UTIME, little-endian)
+	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for LastWriteTime")
 	}
-	bytesRead, err = c.LastWriteTime.Unmarshal(rawParametersContent[offset:])
-	if err != nil {
-		return offset, err
-	}
-	offset += bytesRead
+	c.LastWriteTime = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
+	offset += 4
 
 	// Unmarshalling parameter Reserved
 	if len(rawParametersContent) < offset+10 {


### PR DESCRIPTION
### Linked Issue
Closes #302

### Root Cause
The `SetInformationRequest` struct was generated using the 8-byte MS-DTYP `FILETIME` type for `LastWriteTime`, but MS-CIFS SMB_COM_SET_INFORMATION specifies a 4-byte `UTIME`. Additionally `Reserved` was declared as `[5]UCHAR` (5 bytes) instead of the documented `USHORT Reserved[5]` (10 bytes). The result was a 15-byte Words block instead of the required 16 (WordCount 0x08), with `LastWriteTime` over-running by 4 bytes and `Reserved` under-sized by 5, corrupting the wire layout. The `Unmarshal` path was also internally inconsistent: it consumed 8 bytes for `LastWriteTime` and `copy`-truncated 10 source bytes into a 5-byte array.

### Fix Description
- `LastWriteTime` is now `types.ULONG` and marshalled/unmarshalled as a 4-byte little-endian UTIME, matching the existing `CloseRequest` convention for UTIME fields.
- `Reserved` is now `[10]types.UCHAR`, emitting and consuming the documented 10 bytes.
- Words block is now 2 + 4 + 10 = 16 bytes, yielding WordCount 0x08 as the spec requires.

Spec: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/76577ee1-eb2d-4db7-9bed-65c74a952741

### How Verified
- **Static:** the marshalled parameter block now totals 16 bytes (FileAttributes 2 + LastWriteTime 4 + Reserved 10); Unmarshal reads the same field sizes, preserving Marshal/Unmarshal symmetry.
- **Tests:** `go build ./...` and `go test ./network/smb/smb_v10/...` both pass.

### Test Coverage
**Existing:** the `network/smb/smb_v10/message/commands` round-trip tests pass against the corrected field sizes.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/SetInformationRequest.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local to a single command structure; safe to merge. Any caller setting `LastWriteTime` should now use a UTIME (seconds since 1970) rather than a FILETIME value.