### PR TITLE
[bugfix] Fix OpenAndxResponse parameter block wiring and endianness (#188)

### DIFF
--- a/network/smb/smb_v10/message/commands/OpenAndxResponse.go
+++ b/network/smb/smb_v10/message/commands/OpenAndxResponse.go
@@ -26,9 +26,9 @@ type OpenAndxResponse struct {
 	// the attribute bytes is set, the file attributes refer to a regular file.
 	FileAttrs types.SMB_FILE_ATTRIBUTES
 
-	// LastWriteTime (4 bytes): A 32-bit integer time value of the last modification to
-	// the file.
-	LastWriteTime types.FILETIME
+	// LastWriteTime (4 bytes): A 32-bit integer time value (UTIME) of the last
+	// modification to the file.
+	LastWriteTime types.ULONG
 
 	// FileDataSize (4 bytes): The number of bytes in the file. This field is advisory
 	// and MAY be used.
@@ -61,7 +61,7 @@ func NewOpenAndxResponse() *OpenAndxResponse {
 		// Parameters
 		FID:           types.USHORT(0),
 		FileAttrs:     types.SMB_FILE_ATTRIBUTES{},
-		LastWriteTime: types.FILETIME{},
+		LastWriteTime: types.ULONG(0),
 		FileDataSize:  types.ULONG(0),
 		AccessRights:  types.USHORT(0),
 		ResourceType:  types.USHORT(0),
@@ -119,7 +119,7 @@ func (c *OpenAndxResponse) Marshal() ([]byte, error) {
 
 	// Marshalling parameter FID
 	buf2 := make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.FID))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.FID))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter FileAttrs
@@ -129,34 +129,44 @@ func (c *OpenAndxResponse) Marshal() ([]byte, error) {
 	}
 	rawParametersContent = append(rawParametersContent, bytesStream...)
 
-	// Marshalling parameter LastWriteTime
-	bytesStream, err = c.LastWriteTime.Marshal()
+	// Marshalling parameter LastWriteTime (4-byte UTIME, little-endian)
+	buf4 := make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf4, uint32(c.LastWriteTime))
+	rawParametersContent = append(rawParametersContent, buf4...)
+
+	// Marshalling parameter FileDataSize
+	buf4 = make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf4, uint32(c.FileDataSize))
+	rawParametersContent = append(rawParametersContent, buf4...)
+
+	// Marshalling parameter AccessRights
+	buf2 = make([]byte, 2)
+	binary.LittleEndian.PutUint16(buf2, uint16(c.AccessRights))
+	rawParametersContent = append(rawParametersContent, buf2...)
+
+	// Marshalling parameter ResourceType
+	buf2 = make([]byte, 2)
+	binary.LittleEndian.PutUint16(buf2, uint16(c.ResourceType))
+	rawParametersContent = append(rawParametersContent, buf2...)
+
+	// Marshalling parameter NMPipeStatus
+	bytesStream, err = c.NMPipeStatus.Marshal()
 	if err != nil {
 		return nil, err
 	}
 	rawParametersContent = append(rawParametersContent, bytesStream...)
 
-	// Marshalling parameter FileDataSize
-	buf4 := make([]byte, 4)
-	binary.BigEndian.PutUint32(buf4, uint32(c.FileDataSize))
-	rawParametersContent = append(rawParametersContent, buf4...)
-
-	// Marshalling parameter AccessRights
-	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.AccessRights))
-	rawParametersContent = append(rawParametersContent, buf2...)
-
-	// Marshalling parameter ResourceType
-	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.ResourceType))
-	rawParametersContent = append(rawParametersContent, buf2...)
-
-	// Marshalling parameter NMPipeStatus
-
 	// Marshalling parameter OpenResults
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.OpenResults))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.OpenResults))
 	rawParametersContent = append(rawParametersContent, buf2...)
+
+	// Marshalling parameter Reserved (3 USHORTs, 6 bytes, little-endian)
+	for i := 0; i < 3; i++ {
+		buf2 = make([]byte, 2)
+		binary.LittleEndian.PutUint16(buf2, uint16(c.Reserved[i]))
+		rawParametersContent = append(rawParametersContent, buf2...)
+	}
 
 	// Marshalling parameters
 	c.GetParameters().AddWordsFromBytesStream(rawParametersContent)
@@ -215,7 +225,7 @@ func (c *OpenAndxResponse) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for FID")
 	}
-	c.FID = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.FID = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter FileAttrs
@@ -228,45 +238,59 @@ func (c *OpenAndxResponse) Unmarshal(data []byte) (int, error) {
 	}
 	offset += bytesRead
 
-	// Unmarshalling parameter LastWriteTime
-	if len(rawParametersContent) < offset+8 {
+	// Unmarshalling parameter LastWriteTime (4-byte UTIME, little-endian)
+	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for LastWriteTime")
 	}
-	bytesRead, err = c.LastWriteTime.Unmarshal(rawParametersContent[offset:])
-	if err != nil {
-		return offset, err
-	}
-	offset += bytesRead
+	c.LastWriteTime = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
+	offset += 4
 
 	// Unmarshalling parameter FileDataSize
 	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for FileDataSize")
 	}
-	c.FileDataSize = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	c.FileDataSize = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
 	offset += 4
 
 	// Unmarshalling parameter AccessRights
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for AccessRights")
 	}
-	c.AccessRights = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.AccessRights = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter ResourceType
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for ResourceType")
 	}
-	c.ResourceType = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.ResourceType = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter NMPipeStatus
+	if len(rawParametersContent) < offset+2 {
+		return offset, fmt.Errorf("rawParametersContent too short for NMPipeStatus")
+	}
+	bytesRead, err = c.NMPipeStatus.Unmarshal(rawParametersContent[offset:])
+	if err != nil {
+		return offset, err
+	}
+	offset += bytesRead
 
 	// Unmarshalling parameter OpenResults
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for OpenResults")
 	}
-	c.OpenResults = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.OpenResults = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
+
+	// Unmarshalling parameter Reserved (3 USHORTs, 6 bytes, little-endian)
+	for i := 0; i < 3; i++ {
+		if len(rawParametersContent) < offset+2 {
+			return offset, fmt.Errorf("rawParametersContent too short for Reserved[%d]", i)
+		}
+		c.Reserved[i] = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
+		offset += 2
+	}
 
 	// Then unmarshal the data
 	offset = 0


### PR DESCRIPTION
### Linked Issue
Closes #188

### Root Cause
The `OpenAndxResponse` parameter block was generated/hand-edited incorrectly and never exercised on the wire. Four defects compounded:

1. All integer parameters (`FID`, `FileDataSize`, `AccessRights`, `ResourceType`, `OpenResults`) were marshalled and unmarshalled with `binary.BigEndian`. The `parameters` layer is byte-preserving, so big-endian struct bytes are transmitted verbatim, violating the little-endian wire format that MS-CIFS mandates for all SMB integer fields.
2. `LastWriteTime` was typed as `types.FILETIME`, whose `Marshal`/`Unmarshal` emit/consume 8 bytes, but the spec (section 2.2.4.41.2) defines `LastWriteTime` as a 4-byte `UTIME`. The extra 4 bytes shifted every subsequent field and changed the word count.
3. `NMPipeStatus` (2 bytes) was declared in the struct but never marshalled or unmarshalled — the marshal/unmarshal code had only an empty comment placeholder.
4. `Reserved[3]` (6 bytes) was likewise never marshalled or unmarshalled.

Together these produced a 26-byte parameter block (13 words) instead of the spec-required 30-byte block (`WordCount = 0x0F`, 15 words), with the wrong byte order — a fully malformed `SMB_COM_OPEN_ANDX` response. Round-trip unit tests passed because `Marshal`/`Unmarshal` were symmetrically wrong.

### Fix Description
- Changed `LastWriteTime` from `types.FILETIME` to `types.ULONG` and marshal/unmarshal it as a 4-byte little-endian UTIME, matching the repo idiom already used for the UTIME field in `CloseRequest`.
- Switched all integer parameter fields to `binary.LittleEndian` in both `Marshal` and `Unmarshal`.
- Added marshalling and unmarshalling of `NMPipeStatus` (via its 2-byte `Marshal`/`Unmarshal`) and the `Reserved[3]` array (3 little-endian USHORTs).
- Unmarshal length guards use `>= N` and the field order now matches the spec: FID, FileAttrs, LastWriteTime, FileDataSize, AccessRights, ResourceType, NMPipeStatus, OpenResults, Reserved[3].

The resulting parameter block is 4 (AndX) + 26 = 30 bytes = 15 words (`WordCount = 0x0F`), as required by MS-CIFS 2.2.4.41.2.

### How Verified
- **Static:** Walked the corrected `Marshal` byte accumulation: 2+2+4+4+2+2+2+2+6 = 26 parameter bytes after the 4-byte AndX header, yielding the spec's 30-byte / 15-word block, all little-endian.
- **Tests:** `go build ./...` and `go test ./network/smb/smb_v10/...` both pass (existing round-trip tests in `network/smb/smb_v10/message/commands` remain green).

### Test Coverage
**Existing:** Existing round-trip tests in the `commands` package exercise marshal/unmarshal symmetry and continue to pass after the fix.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/OpenAndxResponse.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local to a single command struct. The wire format was previously incorrect and unused on the wire; correcting it aligns the implementation with MS-CIFS. Safe to merge directly.
