### PR TITLE
[bugfix] Fix NtTransactSecondaryRequest.Unmarshal Pad1/Pad2 length derivation (#209)

### DIFF
--- a/network/smb/smb_v10/message/commands/NtTransactSecondaryRequest.go
+++ b/network/smb/smb_v10/message/commands/NtTransactSecondaryRequest.go
@@ -337,35 +337,58 @@ func (c *NtTransactSecondaryRequest) Unmarshal(data []byte) (int, error) {
 	offset++
 
 	// Then unmarshal the data
+	//
+	// rawDataContent is the SMB_Data.Bytes block, laid out as:
+	//   Pad1[] | NT_Trans_Parameters[ParameterCount] | Pad2[] | NT_Trans_Data[DataCount]
+	// ParameterOffset and DataOffset are absolute offsets measured from the start of
+	// the SMB_Header, not lengths within this block, so they cannot be used directly as
+	// slice lengths. The block shares a single header-relative base with both offsets,
+	// so the inter-block gaps are recovered as differences:
+	//   len(Pad2) = DataOffset - (ParameterOffset + ParameterCount)
+	//   len(Pad1) = len(rawDataContent) - ParameterCount - len(Pad2) - DataCount
 	offset = 0
 
-	// Unmarshalling data Pad1
-	if len(rawDataContent) < offset+int(c.ParameterOffset) {
-		return offset, fmt.Errorf("rawDataContent too short for Pad1")
+	parameterCount := int(c.ParameterCount)
+	dataCount := int(c.DataCount)
+
+	// Length of Pad2 is the gap between the end of the parameter block and the start of
+	// the data block, both expressed relative to the same header-relative base.
+	pad2Length := int(c.DataOffset) - (int(c.ParameterOffset) + parameterCount)
+	if pad2Length < 0 {
+		return offset, fmt.Errorf("invalid offsets: DataOffset precedes end of NT_Trans_Parameters")
 	}
-	c.Pad1 = rawDataContent[offset : offset+int(c.ParameterOffset)]
-	offset += int(c.ParameterOffset)
+
+	// Length of Pad1 is whatever leading padding remains once the fixed-size parameter
+	// block, Pad2, and data block are accounted for within rawDataContent.
+	pad1Length := len(rawDataContent) - parameterCount - pad2Length - dataCount
+	if pad1Length < 0 {
+		return offset, fmt.Errorf("rawDataContent too short for NT_Trans_Secondary data block")
+	}
+
+	// Unmarshalling data Pad1
+	c.Pad1 = rawDataContent[offset : offset+pad1Length]
+	offset += pad1Length
 
 	// Unmarshalling data NT_Trans_Parameters
-	if len(rawDataContent) < offset+int(c.ParameterCount) {
+	if len(rawDataContent) < offset+parameterCount {
 		return offset, fmt.Errorf("rawDataContent too short for NT_Trans_Parameters")
 	}
-	c.NT_Trans_Parameters = rawDataContent[offset : offset+int(c.ParameterCount)]
-	offset += int(c.ParameterCount)
+	c.NT_Trans_Parameters = rawDataContent[offset : offset+parameterCount]
+	offset += parameterCount
 
 	// Unmarshalling data Pad2
-	if len(rawDataContent) < offset+int(c.DataOffset) {
+	if len(rawDataContent) < offset+pad2Length {
 		return offset, fmt.Errorf("rawDataContent too short for Pad2")
 	}
-	c.Pad2 = rawDataContent[offset : offset+int(c.DataOffset)]
-	offset += int(c.DataOffset)
+	c.Pad2 = rawDataContent[offset : offset+pad2Length]
+	offset += pad2Length
 
 	// Unmarshalling data NT_Trans_Data
-	if len(rawDataContent) < offset+int(c.DataCount) {
+	if len(rawDataContent) < offset+dataCount {
 		return offset, fmt.Errorf("rawDataContent too short for NT_Trans_Data")
 	}
-	c.NT_Trans_Data = rawDataContent[offset : offset+int(c.DataCount)]
-	offset += int(c.DataCount)
+	c.NT_Trans_Data = rawDataContent[offset : offset+dataCount]
+	offset += dataCount
 
 	return offset, nil
 }


### PR DESCRIPTION
### Linked Issue
Closes #209

### Root Cause
`NtTransactSecondaryRequest.Unmarshal` treated the `ParameterOffset` and `DataOffset` parameter fields as in-block lengths for the `Pad1` and `Pad2` padding arrays. Per MS-CIFS (https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/4173c449-a6e1-4fa9-b980-708a229fdb3a), those fields are absolute offsets measured from the start of the SMB_Header (typically >= 32), not lengths within the SMB_Data.Bytes block. Slicing `rawDataContent[offset : offset+ParameterOffset]` for `Pad1` (and the analogous `DataOffset` for `Pad2`) therefore over-ran the data block, so the length guard returned a "too short" error in the common case, or sliced unrelated bytes otherwise. `Marshal` simply concatenates `Pad1 | NT_Trans_Parameters | Pad2 | NT_Trans_Data` and never derives the offsets, so `Marshal` and `Unmarshal` were asymmetric.

### Fix Description
`Unmarshal` now derives the padding lengths from the block geometry instead of misusing the absolute offsets:
- `len(Pad2) = DataOffset - (ParameterOffset + ParameterCount)` — the gap between the end of the parameter block and the start of the data block. Both offsets share the same header-relative base, so the difference is base-independent and correct. A negative result is rejected.
- `len(Pad1) = len(rawDataContent) - ParameterCount - len(Pad2) - DataCount` — the leading padding that remains once the fixed-size parameter block, `Pad2`, and the data block are accounted for. A negative result is rejected.

The parameter and data blocks are then read by their documented `ParameterCount` / `DataCount` lengths. This restores `Marshal` <-> `Unmarshal` symmetry and reads exactly the documented `NT_Trans_Parameters` and `NT_Trans_Data` bytes.

### How Verified
- **Static:** the new logic reads `Pad1` (length `pad1Length`), then `ParameterCount` parameter bytes, then `Pad2` (length `pad2Length`), then `DataCount` data bytes, with `>=` length guards on each slice — exactly the layout `Marshal` emits, so a marshalled-then-unmarshalled request round-trips.
- **Tests:** `go test ./network/smb/smb_v10/message/commands/` passes.
- **Build:** `go build ./...` succeeds.

### Test Coverage
**Existing:** the package's existing round-trip tests for the commands package pass with the corrected logic. No bug-specific test existed previously; the fix makes the existing marshal/unmarshal path consistent.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/NtTransactSecondaryRequest.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Notes
This `Unmarshal` Pad-length defect class also exists in sibling secondary-transaction files (e.g. `TransactionSecondaryRequest`, `Transaction2SecondaryRequest`); those are out of scope for this PR and tracked separately.