### PR TITLE
[bugfix] Fix OpenAndxRequest wire format: little-endian parameters and 4-byte UTIME CreationTime (#195, #301)

### DIFF
--- a/network/smb/smb_v10/message/commands/OpenAndxRequest.go
+++ b/network/smb/smb_v10/message/commands/OpenAndxRequest.go
@@ -37,9 +37,9 @@ type OpenAndxRequest struct {
 	// MUST refer to a regular file.
 	FileAttrs types.SMB_FILE_ATTRIBUTES
 
-	// CreationTime (4 bytes): A 32-bit integer time value to be assigned to the file
-	// as the time of creation if the file is created.
-	CreationTime types.FILETIME
+	// CreationTime (4 bytes): A 32-bit integer time value (UTIME) to be assigned to the
+	// file as the time of creation if the file is created.
+	CreationTime types.ULONG
 
 	// OpenMode (2 bytes): A 16-bit field that controls the way a file SHOULD be
 	// treated when it is opened for use by certain extended SMB requests.
@@ -74,7 +74,7 @@ func NewOpenAndxRequest() *OpenAndxRequest {
 		AccessMode:     types.USHORT(0),
 		SearchAttrs:    types.SMB_FILE_ATTRIBUTES{},
 		FileAttrs:      types.SMB_FILE_ATTRIBUTES{},
-		CreationTime:   types.FILETIME{},
+		CreationTime:   types.ULONG(0),
 		OpenMode:       types.USHORT(0),
 		AllocationSize: types.ULONG(0),
 		Timeout:        types.ULONG(0),
@@ -140,12 +140,12 @@ func (c *OpenAndxRequest) Marshal() ([]byte, error) {
 
 	// Marshalling parameter Flags
 	buf2 := make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.Flags))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.Flags))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter AccessMode
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.AccessMode))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.AccessMode))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter SearchAttrs
@@ -162,32 +162,30 @@ func (c *OpenAndxRequest) Marshal() ([]byte, error) {
 	}
 	rawParametersContent = append(rawParametersContent, bytesStream...)
 
-	// Marshalling parameter CreationTime
-	bytesStream, err = c.CreationTime.Marshal()
-	if err != nil {
-		return nil, err
-	}
-	rawParametersContent = append(rawParametersContent, bytesStream...)
+	// Marshalling parameter CreationTime (4-byte UTIME, little-endian)
+	buf4 := make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf4, uint32(c.CreationTime))
+	rawParametersContent = append(rawParametersContent, buf4...)
 
 	// Marshalling parameter OpenMode
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.OpenMode))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.OpenMode))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter AllocationSize
-	buf4 := make([]byte, 4)
-	binary.BigEndian.PutUint32(buf4, uint32(c.AllocationSize))
+	buf4 = make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf4, uint32(c.AllocationSize))
 	rawParametersContent = append(rawParametersContent, buf4...)
 
 	// Marshalling parameter Timeout
 	buf4 = make([]byte, 4)
-	binary.BigEndian.PutUint32(buf4, uint32(c.Timeout))
+	binary.LittleEndian.PutUint32(buf4, uint32(c.Timeout))
 	rawParametersContent = append(rawParametersContent, buf4...)
 
 	// Marshalling parameter Reserved
 	buf2 = make([]byte, 2)
 	for i := range c.Reserved {
-		binary.BigEndian.PutUint16(buf2, uint16(c.Reserved[i]))
+		binary.LittleEndian.PutUint16(buf2, uint16(c.Reserved[i]))
 		rawParametersContent = append(rawParametersContent, buf2...)
 	}
 
@@ -248,14 +246,14 @@ func (c *OpenAndxRequest) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for Flags")
 	}
-	c.Flags = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.Flags = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter AccessMode
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for AccessMode")
 	}
-	c.AccessMode = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.AccessMode = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter SearchAttrs
@@ -272,35 +270,32 @@ func (c *OpenAndxRequest) Unmarshal(data []byte) (int, error) {
 	}
 	offset += bytesRead
 
-	// Unmarshalling parameter CreationTime
-	if len(rawParametersContent) < offset+8 {
+	// Unmarshalling parameter CreationTime (4-byte UTIME, little-endian)
+	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for CreationTime")
 	}
-	bytesRead, err = c.CreationTime.Unmarshal(rawParametersContent[offset:])
-	if err != nil {
-		return offset, err
-	}
-	offset += bytesRead
+	c.CreationTime = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
+	offset += 4
 
 	// Unmarshalling parameter OpenMode
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for OpenMode")
 	}
-	c.OpenMode = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.OpenMode = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter AllocationSize
 	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for AllocationSize")
 	}
-	c.AllocationSize = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	c.AllocationSize = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
 	offset += 4
 
 	// Unmarshalling parameter Timeout
 	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for Timeout")
 	}
-	c.Timeout = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	c.Timeout = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
 	offset += 4
 
 	// Unmarshalling parameter Reserved
@@ -308,7 +303,7 @@ func (c *OpenAndxRequest) Unmarshal(data []byte) (int, error) {
 		return offset, fmt.Errorf("rawParametersContent too short for Reserved")
 	}
 	for i := range c.Reserved {
-		c.Reserved[i] = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+		c.Reserved[i] = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 		offset += 2
 	}
 


### PR DESCRIPTION
### Linked Issue
Closes #195
Closes #301

### Root Cause
`OpenAndxRequest` is a generated command file that was never exercised on the wire, so two wire-format defects went unnoticed (round-trip unit tests pass because Marshal/Unmarshal are symmetric):

1. **Endianness (#195):** all integer parameter fields were encoded/decoded with `binary.BigEndian`, but SMB/CIFS integers are little-endian. The `parameters` layer is byte-preserving, so the byte-reversed values reached the wire.
2. **CreationTime size (#301):** `CreationTime` was typed as `types.FILETIME` (8 bytes) and marshalled as 8 bytes, but [MS-CIFS] defines it as a 4-byte `UTIME`. This made the Words block 34 bytes (WordCount 0x11) instead of the required 30 bytes (WordCount 0x0F) and shifted every subsequent field by 4 bytes.

These two defects share the same overlapping Marshal/Unmarshal parameter region; the CreationTime size change shifts the exact bytes the endianness fix touches, so they cannot be split into non-overlapping PRs and are fixed together to produce a single spec-correct wire layout.

### Fix Description
- Changed `CreationTime` from `types.FILETIME` to `types.ULONG` and marshal/unmarshal it as a 4-byte little-endian UTIME (matching the sibling `CloseRequest.LastTimeModified` pattern).
- Switched Flags, AccessMode, OpenMode, AllocationSize, Timeout, and Reserved to `binary.LittleEndian` in both `Marshal()` and `Unmarshal()`.
- Updated the CreationTime `Unmarshal` length guard from `>= offset+8` to `>= offset+4`.
- Updated the struct/constructor doc and field type accordingly.

`SearchAttrs`/`FileAttrs` (`SMB_FILE_ATTRIBUTES`) and `FileName` (`SMB_STRING`) are shared types and out of scope for this file; note that `SMB_FILE_ATTRIBUTES.Marshal` itself still uses big-endian (a separate shared-type defect, not edited here).

### How Verified
- `go build ./...` and `go test ./network/smb/smb_v10/message/commands/` pass.
- Golden-byte test (temporary, not committed) confirmed the marshalled output: WordCount = 0x0F, Flags emitted as `02 01` (little-endian), CreationTime emitted as 4 little-endian bytes `0C 0B 0A 09`, and the full frame layout matches the [MS-CIFS] SMB_COM_OPEN_ANDX Request structure.

### Test Coverage
- **Existing:** the package's existing round-trip tests pass with the corrected types.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/OpenAndxRequest.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Notes
The big-endian marshalling in the shared `SMB_FILE_ATTRIBUTES` type (used by `SearchAttrs`/`FileAttrs` here and by many sibling commands) is a separate defect class that should be tracked and fixed in the type itself; it was intentionally left untouched to keep this PR scoped to `OpenAndxRequest.go`.