### PR TITLE
[bugfix] Fix TreeConnectRequest.Unmarshal nil pointer panic on Parameters/Data (#312)

### DIFF
--- a/network/smb/smb_v10/message/commands/TreeConnectRequest.go
+++ b/network/smb/smb_v10/message/commands/TreeConnectRequest.go
@@ -139,20 +139,29 @@ func (c *TreeConnectRequest) Marshal() ([]byte, error) {
 // Unmarshal unmarshals a byte array into the command structure
 //
 // Parameters:
-// - data: The byte array to unmarshal
+// - rawData: The byte array to unmarshal
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *TreeConnectRequest) Unmarshal(data []byte) (int, error) {
+func (c *TreeConnectRequest) Unmarshal(rawData []byte) (int, error) {
 	offset := 0
 
+	// Create the Parameters structure if it is nil
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Create the Data structure if it is nil
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
+
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	_ = c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/TreeConnectRequest_test.go
+++ b/network/smb/smb_v10/message/commands/TreeConnectRequest_test.go
@@ -1,0 +1,30 @@
+package commands_test
+
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+)
+
+// TestTreeConnectRequestUnmarshalInitializesStructures verifies that Unmarshal
+// does not panic on a freshly constructed TreeConnectRequest. NewTreeConnectRequest
+// leaves the embedded Parameters/Data nil, and Unmarshal must initialize them
+// before use (mirroring Marshal) rather than dereferencing a nil *Parameters.
+func TestTreeConnectRequestUnmarshalInitializesStructures(t *testing.T) {
+	out := commands.NewTreeConnectRequest()
+	out.Path = *types.NewOEM_STRINGFromString(`\\server\share`)
+	out.Password = *types.NewOEM_STRINGFromString("secret")
+	out.Service = *types.NewOEM_STRINGFromString("A:")
+
+	marshalled, err := out.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	// A fresh request has nil Parameters/Data; Unmarshal must not panic.
+	in := commands.NewTreeConnectRequest()
+	if _, err := in.Unmarshal(marshalled); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+}


### PR DESCRIPTION
Linked Issue
Closes #312

Root Cause
NewTreeConnectRequest does not call Command.Init() and does not set the embedded Parameters/Data structures, so both remain nil. command_interface.GetParameters()/GetData() return those fields directly with no lazy initialization. TreeConnectRequest.Unmarshal called c.GetParameters().Unmarshal(rawData) on the nil *Parameters receiver, which panicked when writing p.WordCount inside parameters.Unmarshal. Marshal already guarded against this by creating the structures when nil; Unmarshal had no equivalent guard.

Fix Description
Add the same nil guards to Unmarshal that Marshal already uses: create Parameters/Data via SetParameters(parameters.NewParameters()) / SetData(data.NewData()) when nil, before they are dereferenced. The Unmarshal parameter was renamed from data to rawData to avoid shadowing the imported data package now referenced inside the function. Field decoding logic is unchanged.

How Verified
- go build ./... passes.
- go test ./network/smb/smb_v10/message/commands/ passes.
- Added regression test TestTreeConnectRequestUnmarshalInitializesStructures: with the fix reverted it panics with a nil pointer dereference; with the fix it passes.

Test Coverage
Added: network/smb/smb_v10/message/commands/TreeConnectRequest_test.go:TestTreeConnectRequestUnmarshalInitializesStructures, which marshals a request and unmarshals it into a freshly constructed (nil Parameters/Data) TreeConnectRequest, asserting no panic and no error.

Scope of Change
- Files changed: network/smb/smb_v10/message/commands/TreeConnectRequest.go, network/smb/smb_v10/message/commands/TreeConnectRequest_test.go
- Submodule pointer updated: no
- Behavioral changes outside the bug fix: none

Risk and Rollout
Local and low risk: the guard only creates structures when they are nil, matching Marshal behavior. Safe to merge without staged rollout.