### PR TITLE
[bugfix] Fix SetInformation2Request SMB_TIME fields to 2-byte DOS time (#255)

### DIFF
--- a/network/smb/smb_v10/message/commands/SetInformation2Request.go
+++ b/network/smb/smb_v10/message/commands/SetInformation2Request.go
@@ -27,14 +27,14 @@ type SetInformation2Request struct {
 	CreateDate types.SMB_DATE
 
 	// CreateTime (2 bytes): This is the time on CreateDate when the file was created.
-	CreationTime types.SMB_TIME
+	CreationTime types.SMB_TIME_DOS
 
 	// LastAccessDate (2 bytes): This is the date when the file was last accessed.
 	LastAccessDate types.SMB_DATE
 
 	// LastAccessTime (2 bytes): This is the time on LastAccessDate when the file was
 	// last accessed.
-	LastAccessTime types.SMB_TIME
+	LastAccessTime types.SMB_TIME_DOS
 
 	// LastWriteDate (2 bytes): This is the date when data was last written to the
 	// file.
@@ -42,7 +42,7 @@ type SetInformation2Request struct {
 
 	// LastWriteTime (2 bytes): This is the time on LastWriteDate when data was last
 	// written to the file.
-	LastWriteTime types.SMB_TIME
+	LastWriteTime types.SMB_TIME_DOS
 }
 
 // NewSetInformation2Request creates a new SetInformation2Request structure
@@ -54,11 +54,11 @@ func NewSetInformation2Request() *SetInformation2Request {
 		// Parameters
 		FID:            types.USHORT(0),
 		CreateDate:     types.SMB_DATE{},
-		CreationTime:   types.SMB_TIME{},
+		CreationTime:   types.SMB_TIME_DOS{},
 		LastAccessDate: types.SMB_DATE{},
-		LastAccessTime: types.SMB_TIME{},
+		LastAccessTime: types.SMB_TIME_DOS{},
 		LastWriteDate:  types.SMB_DATE{},
-		LastWriteTime:  types.SMB_TIME{},
+		LastWriteTime:  types.SMB_TIME_DOS{},
 	}
 
 	c.Command.SetCommandCode(codes.SMB_COM_SET_INFORMATION2)

--- a/network/smb/smb_v10/types/SMB_TIME_DOS.go
+++ b/network/smb/smb_v10/types/SMB_TIME_DOS.go
@@ -1,0 +1,96 @@
+package types
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+// SMB_TIME_DOS is the 2-byte MS-DOS time representation used by legacy SMB
+// commands (e.g. SMB_COM_SET_INFORMATION2). It packs the time of day into a
+// little-endian 16-bit value, analogous to the 2-byte SMB_DATE type.
+//
+// The 8-byte FILETIME-backed types.SMB_TIME alias is unsuitable for these
+// fields because the wire format mandates exactly 2 bytes per SMB_TIME.
+//
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/3e6f3a13-6a40-4f76-af70-bb514554ea5b
+type SMB_TIME_DOS struct {
+	// Hours: bits 11-15 (0xF800) - Values 0-23
+	Hours uint8
+	// Minutes: bits 5-10 (0x07E0) - Values 0-59
+	Minutes uint8
+	// TwoSeconds: bits 0-4 (0x001F) - Values 0-29, each unit is 2 seconds
+	TwoSeconds uint8
+}
+
+// NewSMB_TIME_DOS creates a new SMB_TIME_DOS structure
+//
+// Returns:
+// - A pointer to the new SMB_TIME_DOS structure
+func NewSMB_TIME_DOS() *SMB_TIME_DOS {
+	return &SMB_TIME_DOS{}
+}
+
+// NewSMB_TIME_DOSFromTime creates a new SMB_TIME_DOS structure from a time of day
+//
+// Parameters:
+// - hours: The hours of the time (0-23)
+// - minutes: The minutes of the time (0-59)
+// - seconds: The seconds of the time (0-59); stored with 2-second resolution
+//
+// Returns:
+// - The new SMB_TIME_DOS structure
+func NewSMB_TIME_DOSFromTime(hours int, minutes int, seconds int) *SMB_TIME_DOS {
+	return &SMB_TIME_DOS{
+		Hours:      uint8(hours),
+		Minutes:    uint8(minutes),
+		TwoSeconds: uint8(seconds / 2),
+	}
+}
+
+// Marshal marshals the SMB_TIME_DOS structure
+//
+// Returns:
+// - A byte array representing the SMB_TIME_DOS structure
+// - An error if the marshaling fails
+func (t *SMB_TIME_DOS) Marshal() ([]byte, error) {
+	marshalledData := [2]byte{}
+
+	// Encode the time according to the SMB_TIME format:
+	// - Hours: bits 11-15 (0xF800)
+	// - Minutes: bits 5-10 (0x07E0)
+	// - TwoSeconds: bits 0-4 (0x001F)
+	valueHours := uint16(t.Hours) << 11
+	valueMinutes := uint16(t.Minutes) << 5
+	valueTwoSeconds := uint16(t.TwoSeconds)
+
+	value := valueHours | valueMinutes | valueTwoSeconds
+
+	// Convert to little-endian byte order
+	binary.LittleEndian.PutUint16(marshalledData[:], value)
+
+	return marshalledData[:], nil
+}
+
+// Unmarshal unmarshals the SMB_TIME_DOS structure
+//
+// Returns:
+// - The number of bytes unmarshalled
+// - An error if the unmarshaling fails
+func (t *SMB_TIME_DOS) Unmarshal(data []byte) (int, error) {
+	if len(data) < 2 {
+		return 0, fmt.Errorf("data too short for SMB_TIME_DOS")
+	}
+
+	value := binary.LittleEndian.Uint16(data[:2])
+
+	// Extract the hours value (bits 11-15)
+	t.Hours = uint8((value & 0xF800) >> 11)
+
+	// Extract the minutes value (bits 5-10)
+	t.Minutes = uint8((value & 0x07E0) >> 5)
+
+	// Extract the two-seconds value (bits 0-4)
+	t.TwoSeconds = uint8(value & 0x001F)
+
+	return 2, nil
+}

--- a/network/smb/smb_v10/types/SMB_TIME_DOS_test.go
+++ b/network/smb/smb_v10/types/SMB_TIME_DOS_test.go
@@ -1,0 +1,52 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+)
+
+func TestSMB_TIME_DOSMarshalSize(t *testing.T) {
+	v := types.NewSMB_TIME_DOSFromTime(13, 30, 14)
+	b, err := v.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal returned error: %v", err)
+	}
+	if len(b) != 2 {
+		t.Fatalf("expected 2 bytes, got %d", len(b))
+	}
+}
+
+func TestSMB_TIME_DOSRoundTrip(t *testing.T) {
+	orig := types.NewSMB_TIME_DOSFromTime(13, 30, 14) // 14s -> 7 two-second units
+	b, err := orig.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal returned error: %v", err)
+	}
+
+	// Expected little-endian 16-bit value: hours<<11 | minutes<<5 | twoSeconds
+	expected := uint16(13)<<11 | uint16(30)<<5 | uint16(7)
+	got := uint16(b[0]) | uint16(b[1])<<8
+	if got != expected {
+		t.Fatalf("expected packed value 0x%04x, got 0x%04x", expected, got)
+	}
+
+	var dec types.SMB_TIME_DOS
+	n, err := dec.Unmarshal(b)
+	if err != nil {
+		t.Fatalf("Unmarshal returned error: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("expected 2 bytes read, got %d", n)
+	}
+	if dec.Hours != 13 || dec.Minutes != 30 || dec.TwoSeconds != 7 {
+		t.Fatalf("round-trip mismatch: %+v", dec)
+	}
+}
+
+func TestSMB_TIME_DOSUnmarshalShort(t *testing.T) {
+	var dec types.SMB_TIME_DOS
+	if _, err := dec.Unmarshal([]byte{0x00}); err == nil {
+		t.Fatalf("expected error for short input")
+	}
+}


### PR DESCRIPTION
### Linked Issue
Closes #255

### Root Cause
The three time fields (`CreationTime`, `LastAccessTime`, `LastWriteTime`) in `SetInformation2Request` were typed as `types.SMB_TIME`, which is an alias for the 8-byte `FILETIME` structure. MS-CIFS SMB_COM_SET_INFORMATION2 Request (de521278-f800-4a57-b524-4811fe9edd8f) mandates `WordCount` = 0x07 with a 14-byte Words block in which each `SMB_TIME` is exactly 2 bytes (MS-CIFS SMB_INFO_STANDARD, 3e6f3a13-...). With FILETIME emitting 8 bytes per field, the Words block was 32 bytes and WordCount was 0x10, corrupting every request so no server could parse it.

### Fix Description
Introduce a dedicated 2-byte MS-DOS time type `types.SMB_TIME_DOS`, analogous to the existing 2-byte `types.SMB_DATE`, that packs Hours (bits 11-15), Minutes (bits 5-10), and TwoSeconds (bits 0-4) into a little-endian 16-bit value. The three time fields in `SetInformation2Request` now use `SMB_TIME_DOS`. The `Marshal`/`Unmarshal` bodies are unchanged because they call the field's `Marshal()`/`Unmarshal()` methods, which the new type implements with identical signatures.

The shared `types.SMB_TIME = FILETIME` alias is intentionally left untouched: it is used by sibling structures (`QueryInformation2Response`, `SMB_INFO_STANDARD`, `SMB_DIRECTORY_INFORMATION`, etc.) and is tracked separately. This PR is scoped strictly to `SetInformation2Request`.

### How Verified
- Static: with the new type, the parameter block is `FID` (2) + 3x`SMB_DATE` (6) + 3x`SMB_TIME_DOS` (6) = 14 bytes, yielding WordCount 0x07.
- Tests: a temporary check confirmed `Marshal()` now emits a 17-byte message (1 WordCount + 14 Words + 2 ByteCount) with the first byte 0x07. `go build ./...` and `go test ./network/smb/smb_v10/...` pass.

### Test Coverage
- **Added:** `network/smb/smb_v10/types/SMB_TIME_DOS_test.go` — `TestSMB_TIME_DOSMarshalSize` (asserts 2-byte output), `TestSMB_TIME_DOSRoundTrip` (asserts little-endian bit packing and round-trip), `TestSMB_TIME_DOSUnmarshalShort` (asserts short-input error).

### Scope of Change
- **Files changed:** `network/smb/smb_v10/types/SMB_TIME_DOS.go` (new), `network/smb/smb_v10/types/SMB_TIME_DOS_test.go` (new), `network/smb/smb_v10/message/commands/SetInformation2Request.go`
- **Submodule pointer updated:** no
- **Public API changes:** additive only (new `SMB_TIME_DOS` type); no existing type altered
- **Behavioral changes outside the stated enhancement:** none

### Risk and Rollout
Additive new type plus a field-type swap confined to one command; the shared SMB_TIME alias is unchanged, so sibling structures are unaffected. Safe to merge.