### PR TITLE
[bugfix] Fix NegotiateResponse extended-security discriminator and inverted data layouts (#168)

### DIFF
--- a/network/smb/smb_v10/message/commands/NegotiateResponse.go
+++ b/network/smb/smb_v10/message/commands/NegotiateResponse.go
@@ -205,17 +205,21 @@ func (c *NegotiateResponse) Marshal() ([]byte, error) {
 	// This is because some parameters are dependent on the data, for example the size of some fields within
 	// the data will be stored in the parameters
 	rawDataContent := []byte{}
-	if c.SecurityMode.SupportsChallengeResponseAuth() {
+	if c.Capabilities.HasCapability(capabilities.CAP_EXTENDED_SECURITY) {
+		// Extended Security Response: SMB_Data.Bytes = ServerGUID + SecurityBlob
+		// When CAP_EXTENDED_SECURITY is set, ChallengeLength MUST be zero.
+		c.ChallengeLength = types.UCHAR(0)
+		// Marshalling data ServerGUID
+		rawDataContent = append(rawDataContent, c.ServerGUID.ToBytes()...)
+		// Marshalling data SecurityBlob
+		rawDataContent = append(rawDataContent, c.SecurityBlob...)
+	} else {
+		// Non-Extended Security Response: SMB_Data.Bytes = Challenge + DomainName
 		// Marshalling data Challenge
 		c.ChallengeLength = types.UCHAR(len(c.Challenge))
 		rawDataContent = append(rawDataContent, c.Challenge...)
 		// Marshalling data DomainName
 		rawDataContent = append(rawDataContent, c.DomainName...)
-	} else {
-		// Marshalling data ServerGUID
-		rawDataContent = append(rawDataContent, c.ServerGUID.ToBytes()...)
-		// Marshalling data SecurityBlob
-		rawDataContent = append(rawDataContent, c.SecurityBlob...)
 	}
 
 	// Then marshal the parameters
@@ -392,7 +396,8 @@ func (c *NegotiateResponse) Unmarshal(marshalledData []byte) (int, error) {
 
 	// Then unmarshal the data
 	offset = 0
-	if c.SecurityMode.SupportsChallengeResponseAuth() {
+	if c.Capabilities.HasCapability(capabilities.CAP_EXTENDED_SECURITY) {
+		// Extended Security Response: SMB_Data.Bytes = ServerGUID + SecurityBlob
 		// Unmarshalling data ServerGUID
 		if len(rawDataContent) < offset+16 {
 			return offset, fmt.Errorf("rawDataContent too short for ServerGUID")

--- a/network/smb/smb_v10/message/commands/NegotiateResponse_test.go
+++ b/network/smb/smb_v10/message/commands/NegotiateResponse_test.go
@@ -1,11 +1,12 @@
 package commands_test
 
 import (
+	"bytes"
 	"encoding/binary"
 	"testing"
 
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/capabilities"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
-	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/securitymode"
 )
 
 // buildNegotiateResponseParameters constructs the marshalled parameters section
@@ -20,13 +21,15 @@ import (
 //	DialectIndex(2) + SecurityMode(1) + MaxMpxCount(2) + MaxNumberVcs(2) +
 //	MaxBufferSize(4) + MaxRawSize(4) + SessionKey(4) + Capabilities(4) +
 //	SystemTime(8) + ServerTimeZone(2) + ChallengeLength(1) = 34 bytes
-func buildNegotiateResponseParameters(secMode securitymode.SecurityMode) []byte {
+func buildNegotiateResponseParameters(caps capabilities.Capabilities) []byte {
 	// Raw little-endian parameter bytes.
 	params := make([]byte, 34)
 	// DialectIndex = 0
 	binary.LittleEndian.PutUint16(params[0:2], 0)
-	// SecurityMode (1 byte)
-	params[2] = byte(secMode)
+	// Capabilities (4 bytes) at offset 19: DialectIndex(2)+SecurityMode(1)+
+	// MaxMpxCount(2)+MaxNumberVcs(2)+MaxBufferSize(4)+MaxRawSize(4)+SessionKey(4).
+	// The data-block layout is selected by the CAP_EXTENDED_SECURITY bit.
+	binary.LittleEndian.PutUint32(params[19:23], uint32(caps))
 	// Remaining fields left as zero; ChallengeLength at offset 33 is 0.
 
 	// Repack as 17 big-endian uint16 words so that Parameters.Unmarshal
@@ -47,7 +50,7 @@ func buildNegotiateResponseParameters(secMode securitymode.SecurityMode) []byte 
 // shorter than 16 bytes) returns an error instead of panicking on an
 // out-of-range slice access.
 func Test_NegotiateResponse_Unmarshal_ShortExtendedSecurityDataDoesNotPanic(t *testing.T) {
-	paramsSection := buildNegotiateResponseParameters(securitymode.NEGOTIATE_ENCRYPT_PASSWORDS)
+	paramsSection := buildNegotiateResponseParameters(capabilities.CAP_EXTENDED_SECURITY)
 
 	// Data section: ByteCount = 4 (less than the 16 bytes required for ServerGUID)
 	dataSection := []byte{0x04, 0x00, 0xAA, 0xBB, 0xCC, 0xDD}
@@ -66,5 +69,70 @@ func Test_NegotiateResponse_Unmarshal_ShortExtendedSecurityDataDoesNotPanic(t *t
 	_, err := resp.Unmarshal(marshalled)
 	if err == nil {
 		t.Fatal("expected error from NegotiateResponse.Unmarshal on truncated data, got nil")
+	}
+}
+
+// Test_NegotiateResponse_RoundTrip_ExtendedSecurity verifies that an
+// extended-security response (CAP_EXTENDED_SECURITY set) marshals the
+// ServerGUID + SecurityBlob data layout and unmarshals it back to the same
+// values. This guards against the Marshal/Unmarshal data branches being
+// inverted or keyed off the wrong discriminator.
+func Test_NegotiateResponse_RoundTrip_ExtendedSecurity(t *testing.T) {
+	resp := commands.NewNegotiateResponse()
+	resp.Capabilities = capabilities.CAP_EXTENDED_SECURITY
+
+	guidBytes := []byte{
+		0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
+		0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF,
+	}
+	resp.ServerGUID.FromRawBytes(guidBytes)
+	resp.SecurityBlob = []byte{0xDE, 0xAD, 0xBE, 0xEF}
+
+	marshalled, err := resp.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	parsed := commands.NewNegotiateResponse()
+	if _, err := parsed.Unmarshal(marshalled); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+
+	if !bytes.Equal(parsed.ServerGUID.ToBytes(), guidBytes) {
+		t.Errorf("ServerGUID mismatch: got %x, want %x", parsed.ServerGUID.ToBytes(), guidBytes)
+	}
+	if !bytes.Equal(parsed.SecurityBlob, resp.SecurityBlob) {
+		t.Errorf("SecurityBlob mismatch: got %x, want %x", parsed.SecurityBlob, resp.SecurityBlob)
+	}
+	if parsed.ChallengeLength != 0 {
+		t.Errorf("ChallengeLength must be 0 for extended security, got %d", parsed.ChallengeLength)
+	}
+}
+
+// Test_NegotiateResponse_RoundTrip_NonExtendedSecurity verifies that a
+// non-extended-security response (CAP_EXTENDED_SECURITY clear) marshals the
+// Challenge + DomainName data layout and unmarshals the Challenge back.
+func Test_NegotiateResponse_RoundTrip_NonExtendedSecurity(t *testing.T) {
+	resp := commands.NewNegotiateResponse()
+	resp.Capabilities = 0
+	resp.Challenge = []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+	// DomainName as a null-terminated UTF-16LE string "WG".
+	resp.DomainName = []byte{0x57, 0x00, 0x47, 0x00, 0x00, 0x00}
+
+	marshalled, err := resp.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	parsed := commands.NewNegotiateResponse()
+	if _, err := parsed.Unmarshal(marshalled); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+
+	if parsed.ChallengeLength != 8 {
+		t.Errorf("ChallengeLength: got %d, want 8", parsed.ChallengeLength)
+	}
+	if !bytes.Equal(parsed.Challenge, resp.Challenge) {
+		t.Errorf("Challenge mismatch: got %x, want %x", parsed.Challenge, resp.Challenge)
 	}
 }


### PR DESCRIPTION
### Linked Issue
Closes #168

### Root Cause
`NegotiateResponse` selected its `SMB_Data` layout with `c.SecurityMode.SupportsChallengeResponseAuth()`, which tests the `NEGOTIATE_ENCRYPT_PASSWORDS` (0x02) bit of `SecurityMode`. That bit governs plaintext-vs-challenge/response password authentication, which is orthogonal to whether the response carries the extended-security data block. Per MS-SMB "Extended Security Response", the extended layout (`ServerGUID` + `SecurityBlob`) is used when `CAP_EXTENDED_SECURITY` (0x80000000) is negotiated in `Capabilities`; per MS-CIFS 2.2.4.52.2 the non-extended layout is `Challenge` + `DomainName`. In addition, for the same boolean condition the `Marshal` `true` branch wrote the non-extended layout while the `Unmarshal` `true` branch read the extended layout, so the two were mirror-inverted and `Unmarshal(Marshal(x))` could not reconstruct `x`.

### Fix Description
Both `Marshal` and `Unmarshal` now discriminate on `c.Capabilities.HasCapability(capabilities.CAP_EXTENDED_SECURITY)`, and both place the extended-security layout (`ServerGUID` + `SecurityBlob`) in the `true` branch and the non-extended layout (`Challenge` + `DomainName`) in the `false` branch, so the two are symmetric. When `CAP_EXTENDED_SECURITY` is set, `ChallengeLength` is forced to 0 on marshal, as required by MS-SMB.

### How Verified
- `go build ./...` succeeds.
- `go test ./...` passes for the whole module.
- Added round-trip tests asserting that an extended-security response marshals and unmarshals `ServerGUID`/`SecurityBlob` (with `ChallengeLength == 0`), and that a non-extended response round-trips `Challenge`/`ChallengeLength`. These fail against the previous inverted/mis-keyed logic.
- Updated the existing short-data regression test (from #95) to select the extended-security branch via `CAP_EXTENDED_SECURITY` rather than the old `SecurityMode` discriminator, preserving its original intent.

### Test Coverage
- **Added:** `Test_NegotiateResponse_RoundTrip_ExtendedSecurity`, `Test_NegotiateResponse_RoundTrip_NonExtendedSecurity` in `network/smb/smb_v10/message/commands/NegotiateResponse_test.go`.
- **Existing (updated):** `Test_NegotiateResponse_Unmarshal_ShortExtendedSecurityDataDoesNotPanic` retargeted to the corrected discriminator.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/NegotiateResponse.go`, `network/smb/smb_v10/message/commands/NegotiateResponse_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local to `NegotiateResponse`. `SMB_COM_NEGOTIATE` is the first message of every SMB session, so the corrected discriminator/symmetry is a prerequisite for correct negotiation; safe to merge directly.

### Notes
The `else` (non-extended) `Unmarshal` path can still mis-handle a `DomainName`/`ServerName` that lacks a UTF-16LE null terminator (a quirk in `utils.GetNullTerminatedUnicodeString` returning `len+2` with no terminator). That is a separate latent defect outside the scope of #168 and is not addressed here.
