### PR TITLE
[bugfix] Fix TreeConnectAndxRequest.Unmarshal nil-pointer panic on fresh request (#265)

### DIFF
--- a/network/smb/smb_v10/message/commands/TreeConnectAndxRequest.go
+++ b/network/smb/smb_v10/message/commands/TreeConnectAndxRequest.go
@@ -198,20 +198,29 @@ func (c *TreeConnectAndxRequest) Marshal() ([]byte, error) {
 // Unmarshal unmarshals a byte array into the command structure
 //
 // Parameters:
-// - data: The byte array to unmarshal
+// - marshalledData: The byte array to unmarshal
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *TreeConnectAndxRequest) Unmarshal(data []byte) (int, error) {
+func (c *TreeConnectAndxRequest) Unmarshal(marshalledData []byte) (int, error) {
 	offset := 0
 
+	// Create the Parameters structure if it is nil
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Create the Data structure if it is nil
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
+
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(marshalledData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(marshalledData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/TreeConnectAndxRequest_test.go
+++ b/network/smb/smb_v10/message/commands/TreeConnectAndxRequest_test.go
@@ -1,0 +1,32 @@
+package commands_test
+
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+)
+
+// TestTreeConnectAndxRequestUnmarshalFreshNoPanic verifies that calling
+// Unmarshal on a request constructed with NewTreeConnectAndxRequest does not
+// panic with a nil-pointer dereference. The constructor does not initialize the
+// Parameters/Data structures, so Unmarshal must create them when nil (mirroring
+// Marshal) before using them.
+func TestTreeConnectAndxRequestUnmarshalFreshNoPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Unmarshal panicked on a freshly constructed request: %v", r)
+		}
+	}()
+
+	c := commands.NewTreeConnectAndxRequest()
+
+	// A minimal SMB_Parameters/SMB_Data byte stream: WordCount=0 then ByteCount=0.
+	// The exact decoding is irrelevant here; the point is that Unmarshal must not
+	// panic on the nil Parameters/Data structures of a fresh request.
+	input := []byte{0x00, 0x00, 0x00}
+
+	if _, err := c.Unmarshal(input); err != nil {
+		// An error is acceptable for this minimal input; a panic is not.
+		t.Logf("Unmarshal returned an error (acceptable, no panic): %v", err)
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #265`

### Root Cause
`NewTreeConnectAndxRequest` initializes only the scalar parameter/data fields and never calls `SetParameters`/`SetData`, so `GetParameters()` and `GetData()` return `nil` on a freshly constructed request. `Unmarshal` dereferenced those accessors directly (`c.GetParameters().Unmarshal(...)`, `c.GetData().Unmarshal(...)`) with no nil guard, while `Marshal` already guarded against the same condition. Calling `Unmarshal` on a fresh request therefore panicked with a nil-pointer dereference.

### Fix Description
`Unmarshal` now creates the `Parameters` and `Data` structures when they are nil, mirroring the guard already present in `Marshal`. The `Unmarshal` parameter was renamed from `data` to `marshalledData` so that the `data.NewData()` package reference resolves (the previous parameter name shadowed the imported `data` package); this matches the existing convention in `NegotiateResponse.Unmarshal`.

### How Verified
- `go build ./...` passes.
- `go test ./network/smb/smb_v10/message/commands/...` passes.
- Added regression test `TestTreeConnectAndxRequestUnmarshalFreshNoPanic` constructs a request via `NewTreeConnectAndxRequest()` and calls `Unmarshal`; before the fix this panicked, after the fix it returns without panicking.

### Test Coverage
**Added:** `network/smb/smb_v10/message/commands/TreeConnectAndxRequest_test.go` — `TestTreeConnectAndxRequestUnmarshalFreshNoPanic`.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/TreeConnectAndxRequest.go`, `network/smb/smb_v10/message/commands/TreeConnectAndxRequest_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none
