### PR TITLE
[bugfix] Fix NtTransactResponse to implement the standard response format (#178)

### DIFF
--- a/network/smb/smb_v10/message/commands/NtTransactResponse.go
+++ b/network/smb/smb_v10/message/commands/NtTransactResponse.go
@@ -1,17 +1,120 @@
 package commands
 
 import (
+	"encoding/binary"
+	"fmt"
+
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/andx"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/codes"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/command_interface"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/data"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/parameters"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
 )
 
 // NtTransactResponse
 // Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/dd00c842-2398-412f-b21d-bf5074a9a1c4
 type NtTransactResponse struct {
 	command_interface.Command
+
+	// Parameters
+
+	// Reserved1 (3 bytes): Reserved. This field MUST be 0x000000 in the server
+	// response. The client MUST ignore the contents of this field.
+	Reserved1 [3]types.UCHAR
+
+	// TotalParameterCount (4 bytes): The total number of SMB_COM_NT_TRANSACT parameter
+	// bytes to be sent in this transaction response. This value MAY be reduced in any
+	// or all subsequent SMB_COM_NT_TRANSACT responses that are part of the same
+	// transaction. This value represents transaction parameter bytes, not SMB
+	// parameter words. Transaction parameter bytes are carried within the SMB_Data
+	// block.
+	TotalParameterCount types.ULONG
+
+	// TotalDataCount (4 bytes): The total number of SMB_COM_NT_TRANSACT data bytes to
+	// be sent in this transaction response. This value MAY be reduced in any or all
+	// subsequent SMB_COM_NT_TRANSACT responses that are part of the same transaction.
+	// This value represents transaction data bytes, not SMB data bytes.
+	TotalDataCount types.ULONG
+
+	// ParameterCount (4 bytes): The number of transaction parameter bytes being sent
+	// in this SMB message. If the transaction fits within a single SMB_COM_NT_TRANSACT
+	// response, then this value MUST be equal to TotalParameterCount. Otherwise, the
+	// sum of the ParameterCount values in the transaction response messages MUST be
+	// equal to the smallest TotalParameterCount value reported by the server.
+	ParameterCount types.ULONG
+
+	// ParameterOffset (4 bytes): The offset, in bytes, from the start of the
+	// SMB_Header to the transaction parameter bytes. This MUST be the number of bytes
+	// from the start of the SMB message to the start of the
+	// SMB_Data.Bytes.Parameters field. Server implementations MUST use this value to
+	// locate the transaction parameter block within the SMB message. If
+	// ParameterCount is zero, the client/server MAY set this field to zero.
+	ParameterOffset types.ULONG
+
+	// ParameterDisplacement (4 bytes): The offset, relative to all of the transaction
+	// parameter bytes in this transaction response, at which this block of parameter
+	// bytes MUST be placed. This value can be used by the client to correctly
+	// reassemble the transaction parameters even if the SMB response messages are
+	// received out of order.
+	ParameterDisplacement types.ULONG
+
+	// DataCount (4 bytes): The number of transaction data bytes being sent in this SMB
+	// message. If the transaction fits within a single SMB_COM_NT_TRANSACT response,
+	// then this value MUST be equal to TotalDataCount. Otherwise, the sum of the
+	// DataCount values in the transaction response messages MUST be equal to the
+	// smallest TotalDataCount value reported by the server.
+	DataCount types.ULONG
+
+	// DataOffset (4 bytes): The offset, in bytes, from the start of the SMB_Header to
+	// the transaction data bytes. This MUST be the number of bytes from the start of
+	// the SMB message to the start of the SMB_Data.Bytes.Data field. Server
+	// implementations MUST use this value to locate the transaction data block within
+	// the SMB message. If DataCount is zero, the client/server MAY set this field to
+	// zero.
+	DataOffset types.ULONG
+
+	// DataDisplacement (4 bytes): The offset, relative to all of the transaction data
+	// bytes in this transaction response, at which this block of data bytes MUST be
+	// placed. This value can be used by the client to correctly reassemble the
+	// transaction data even if the SMB response messages are received out of order.
+	DataDisplacement types.ULONG
+
+	// SetupCount (1 byte): The number of Setup words that are included in the
+	// transaction response.
+	SetupCount types.UCHAR
+
+	// Setup (variable): An array of two-byte words that provides transaction results
+	// from the server. The size and content of the array are specific to individual
+	// subcommand.
+	Setup []types.USHORT
+
+	// Data
+
+	// Pad1 (variable): This field SHOULD be used as an array of padding bytes to align
+	// the following field to a 4-byte boundary relative to the start of the SMB
+	// Header. This constraint can cause this field to be a zero-length field. This
+	// field SHOULD be set to zero by the client/server and MUST be ignored by the
+	// server/client.
+	Pad1 []types.UCHAR
+
+	// Parameters (variable): Transaction parameter bytes. See the individual
+	// SMB_COM_NT_TRANSACT subcommand descriptions for information on parameters
+	// returned by the server for each subcommand.
+	Parameters []types.UCHAR
+
+	// Pad2 (variable): This field SHOULD be used as an array of padding bytes to align
+	// the following field to a 4-byte boundary relative to the start of the SMB
+	// Header. This constraint can cause this field to be a zero-length field. This
+	// field SHOULD be set to zero by the client/server and MUST be ignored by the
+	// server/client.
+	Pad2 []types.UCHAR
+
+	// Data (variable): Transaction data bytes. See the individual SMB_COM_NT_TRANSACT
+	// subcommand descriptions for information on data returned by the server for each
+	// subcommand.
+	Data []types.UCHAR
 }
 
 // NewNtTransactResponse creates a new NtTransactResponse structure
@@ -19,7 +122,26 @@ type NtTransactResponse struct {
 // Returns:
 // - A pointer to the new NtTransactResponse structure
 func NewNtTransactResponse() *NtTransactResponse {
-	c := &NtTransactResponse{}
+	c := &NtTransactResponse{
+		// Parameters
+		Reserved1:             [3]types.UCHAR{0, 0, 0},
+		TotalParameterCount:   types.ULONG(0),
+		TotalDataCount:        types.ULONG(0),
+		ParameterCount:        types.ULONG(0),
+		ParameterOffset:       types.ULONG(0),
+		ParameterDisplacement: types.ULONG(0),
+		DataCount:             types.ULONG(0),
+		DataOffset:            types.ULONG(0),
+		DataDisplacement:      types.ULONG(0),
+		SetupCount:            types.UCHAR(0),
+		Setup:                 []types.USHORT{},
+
+		// Data
+		Pad1:       []types.UCHAR{},
+		Parameters: []types.UCHAR{},
+		Pad2:       []types.UCHAR{},
+		Data:       []types.UCHAR{},
+	}
 
 	c.Command.SetCommandCode(codes.SMB_COM_NT_TRANSACT)
 
@@ -60,8 +182,73 @@ func (c *NtTransactResponse) Marshal() ([]byte, error) {
 	// the data will be stored in the parameters
 	rawDataContent := []byte{}
 
+	// Marshalling data Pad1
+	rawDataContent = append(rawDataContent, c.Pad1...)
+
+	// Marshalling data Parameters
+	rawDataContent = append(rawDataContent, c.Parameters...)
+
+	// Marshalling data Pad2
+	rawDataContent = append(rawDataContent, c.Pad2...)
+
+	// Marshalling data Data
+	rawDataContent = append(rawDataContent, c.Data...)
+
 	// Then marshal the parameters
 	rawParametersContent := []byte{}
+
+	// Marshalling parameter Reserved1
+	rawParametersContent = append(rawParametersContent, c.Reserved1[0], c.Reserved1[1], c.Reserved1[2])
+
+	// Marshalling parameter TotalParameterCount
+	buf4 := make([]byte, 4)
+	binary.BigEndian.PutUint32(buf4, uint32(c.TotalParameterCount))
+	rawParametersContent = append(rawParametersContent, buf4...)
+
+	// Marshalling parameter TotalDataCount
+	buf4 = make([]byte, 4)
+	binary.BigEndian.PutUint32(buf4, uint32(c.TotalDataCount))
+	rawParametersContent = append(rawParametersContent, buf4...)
+
+	// Marshalling parameter ParameterCount
+	buf4 = make([]byte, 4)
+	binary.BigEndian.PutUint32(buf4, uint32(c.ParameterCount))
+	rawParametersContent = append(rawParametersContent, buf4...)
+
+	// Marshalling parameter ParameterOffset
+	buf4 = make([]byte, 4)
+	binary.BigEndian.PutUint32(buf4, uint32(c.ParameterOffset))
+	rawParametersContent = append(rawParametersContent, buf4...)
+
+	// Marshalling parameter ParameterDisplacement
+	buf4 = make([]byte, 4)
+	binary.BigEndian.PutUint32(buf4, uint32(c.ParameterDisplacement))
+	rawParametersContent = append(rawParametersContent, buf4...)
+
+	// Marshalling parameter DataCount
+	buf4 = make([]byte, 4)
+	binary.BigEndian.PutUint32(buf4, uint32(c.DataCount))
+	rawParametersContent = append(rawParametersContent, buf4...)
+
+	// Marshalling parameter DataOffset
+	buf4 = make([]byte, 4)
+	binary.BigEndian.PutUint32(buf4, uint32(c.DataOffset))
+	rawParametersContent = append(rawParametersContent, buf4...)
+
+	// Marshalling parameter DataDisplacement
+	buf4 = make([]byte, 4)
+	binary.BigEndian.PutUint32(buf4, uint32(c.DataDisplacement))
+	rawParametersContent = append(rawParametersContent, buf4...)
+
+	// Marshalling parameter SetupCount
+	rawParametersContent = append(rawParametersContent, types.UCHAR(c.SetupCount))
+
+	// Marshalling parameter Setup
+	for _, setupWord := range c.Setup {
+		buf2 := make([]byte, 2)
+		binary.BigEndian.PutUint16(buf2, uint16(setupWord))
+		rawParametersContent = append(rawParametersContent, buf2...)
+	}
 
 	// Marshalling parameters
 	c.GetParameters().AddWordsFromBytesStream(rawParametersContent)
@@ -89,28 +276,172 @@ func (c *NtTransactResponse) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *NtTransactResponse) Unmarshal(data []byte) (int, error) {
+func (c *NtTransactResponse) Unmarshal(rawData []byte) (int, error) {
 	offset := 0
 
+	// Create the Parameters structure if it is nil
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Create the Data structure if it is nil
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
+
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
-	_ = c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	rawParametersContent := c.GetParameters().GetBytes()
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}
-	_ = c.GetData().GetBytes()
+	rawDataContent := c.GetData().GetBytes()
+
+	// If the parameters and data are empty, this is the interim server response or a
+	// response carrying an error code in the SMB Header Status field. Both have empty
+	// Parameter and Data sections (WordCount and ByteCount are zero).
+	if len(rawParametersContent) == 0 && len(rawDataContent) == 0 {
+		return 0, nil
+	}
 
 	// First unmarshal the parameters
 	offset = 0
-	// No parameters are sent in this message
+
+	// Unmarshalling parameter Reserved1
+	if len(rawParametersContent) < offset+3 {
+		return offset, fmt.Errorf("rawParametersContent too short for Reserved1")
+	}
+	c.Reserved1 = [3]types.UCHAR{
+		types.UCHAR(rawParametersContent[offset]),
+		types.UCHAR(rawParametersContent[offset+1]),
+		types.UCHAR(rawParametersContent[offset+2]),
+	}
+	offset += 3
+
+	// Unmarshalling parameter TotalParameterCount
+	if len(rawParametersContent) < offset+4 {
+		return offset, fmt.Errorf("rawParametersContent too short for TotalParameterCount")
+	}
+	c.TotalParameterCount = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	offset += 4
+
+	// Unmarshalling parameter TotalDataCount
+	if len(rawParametersContent) < offset+4 {
+		return offset, fmt.Errorf("rawParametersContent too short for TotalDataCount")
+	}
+	c.TotalDataCount = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	offset += 4
+
+	// Unmarshalling parameter ParameterCount
+	if len(rawParametersContent) < offset+4 {
+		return offset, fmt.Errorf("rawParametersContent too short for ParameterCount")
+	}
+	c.ParameterCount = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	offset += 4
+
+	// Unmarshalling parameter ParameterOffset
+	if len(rawParametersContent) < offset+4 {
+		return offset, fmt.Errorf("rawParametersContent too short for ParameterOffset")
+	}
+	c.ParameterOffset = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	offset += 4
+
+	// Unmarshalling parameter ParameterDisplacement
+	if len(rawParametersContent) < offset+4 {
+		return offset, fmt.Errorf("rawParametersContent too short for ParameterDisplacement")
+	}
+	c.ParameterDisplacement = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	offset += 4
+
+	// Unmarshalling parameter DataCount
+	if len(rawParametersContent) < offset+4 {
+		return offset, fmt.Errorf("rawParametersContent too short for DataCount")
+	}
+	c.DataCount = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	offset += 4
+
+	// Unmarshalling parameter DataOffset
+	if len(rawParametersContent) < offset+4 {
+		return offset, fmt.Errorf("rawParametersContent too short for DataOffset")
+	}
+	c.DataOffset = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	offset += 4
+
+	// Unmarshalling parameter DataDisplacement
+	if len(rawParametersContent) < offset+4 {
+		return offset, fmt.Errorf("rawParametersContent too short for DataDisplacement")
+	}
+	c.DataDisplacement = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	offset += 4
+
+	// Unmarshalling parameter SetupCount
+	if len(rawParametersContent) < offset+1 {
+		return offset, fmt.Errorf("rawParametersContent too short for SetupCount")
+	}
+	c.SetupCount = types.UCHAR(rawParametersContent[offset])
+	offset++
+
+	// Unmarshalling parameter Setup
+	if len(rawParametersContent) < offset+int(c.SetupCount)*2 {
+		return offset, fmt.Errorf("rawParametersContent too short for Setup")
+	}
+	c.Setup = make([]types.USHORT, c.SetupCount)
+	for i := 0; i < int(c.SetupCount); i++ {
+		c.Setup[i] = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+		offset += 2
+	}
 
 	// Then unmarshal the data
+	// The Parameters and Data blocks are located within the SMB_Data.Bytes block.
+	// ParameterOffset and DataOffset are measured from the start of the SMB Header, so
+	// their position relative to the start of the SMB_Data.Bytes block is derived by
+	// subtracting the bytes that precede it: the fixed SMB header, the marshalled
+	// SMB_Parameters block (WordCount byte + parameter words, == bytesRead), and the
+	// 2-byte ByteCount field of the SMB_Data block.
+	dataBlockStart := header.SMB_HEADER_SIZE + bytesRead + 2
+
 	offset = 0
-	// No data is sent in this message
+
+	// Unmarshalling data Pad1 (gap between the start of the data block and Parameters)
+	pad1Len := 0
+	if c.ParameterCount > 0 {
+		paramRel := int(c.ParameterOffset) - dataBlockStart
+		if paramRel < offset || len(rawDataContent) < paramRel {
+			return offset, fmt.Errorf("invalid ParameterOffset for Pad1")
+		}
+		pad1Len = paramRel - offset
+	}
+	c.Pad1 = rawDataContent[offset : offset+pad1Len]
+	offset += pad1Len
+
+	// Unmarshalling data Parameters
+	if len(rawDataContent) < offset+int(c.ParameterCount) {
+		return offset, fmt.Errorf("rawDataContent too short for Parameters")
+	}
+	c.Parameters = rawDataContent[offset : offset+int(c.ParameterCount)]
+	offset += int(c.ParameterCount)
+
+	// Unmarshalling data Pad2 (gap between Parameters and Data)
+	pad2Len := 0
+	if c.DataCount > 0 {
+		dataRel := int(c.DataOffset) - dataBlockStart
+		if dataRel < offset || len(rawDataContent) < dataRel {
+			return offset, fmt.Errorf("invalid DataOffset for Pad2")
+		}
+		pad2Len = dataRel - offset
+	}
+	c.Pad2 = rawDataContent[offset : offset+pad2Len]
+	offset += pad2Len
+
+	// Unmarshalling data Data
+	if len(rawDataContent) < offset+int(c.DataCount) {
+		return offset, fmt.Errorf("rawDataContent too short for Data")
+	}
+	c.Data = rawDataContent[offset : offset+int(c.DataCount)]
+	offset += int(c.DataCount)
 
 	return offset, nil
 }

--- a/network/smb/smb_v10/message/commands/NtTransactResponse_test.go
+++ b/network/smb/smb_v10/message/commands/NtTransactResponse_test.go
@@ -1,0 +1,89 @@
+package commands_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+)
+
+// Test_NtTransactResponse_RoundTrip verifies that the standard SMB_COM_NT_TRANSACT
+// response format defined by MS-CIFS is marshalled and unmarshalled symmetrically,
+// including the Setup words and the padded Parameters/Data blocks.
+func Test_NtTransactResponse_RoundTrip(t *testing.T) {
+	r := commands.NewNtTransactResponse()
+	r.TotalParameterCount = 4
+	r.TotalDataCount = 5
+	r.ParameterCount = 4
+	r.DataCount = 5
+	r.SetupCount = 2
+	r.Setup = []types.USHORT{0x1234, 0xABCD}
+
+	// Parameter words byte size: Reserved1(3) + 8*ULONG(32) + SetupCount(1) + Setup(4) = 40,
+	// which is 20 words, so WordCount = 20 and the marshalled SMB_Parameters block is
+	// 1 (WordCount) + 40 = 41 bytes. The SMB_Data block then starts after the 2-byte
+	// ByteCount field. All *Offset fields are measured from the start of the SMB Header.
+	dataBlockStart := header.SMB_HEADER_SIZE + 41 + 2
+
+	r.Pad1 = []types.UCHAR{}
+	r.Parameters = []types.UCHAR{0xAA, 0xBB, 0xCC, 0xDD}
+	r.ParameterOffset = types.ULONG(dataBlockStart)
+	r.Pad2 = []types.UCHAR{0x00, 0x00, 0x00}
+	r.Data = []types.UCHAR{1, 2, 3, 4, 5}
+	r.DataOffset = types.ULONG(dataBlockStart + len(r.Parameters) + len(r.Pad2))
+
+	marshalled, err := r.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	// WordCount MUST equal SetupCount + 18 (0x12).
+	if got, want := marshalled[0], byte(r.SetupCount)+18; got != want {
+		t.Fatalf("WordCount = %d, want %d", got, want)
+	}
+
+	parsed := commands.NewNtTransactResponse()
+	if _, err := parsed.Unmarshal(marshalled); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+
+	if parsed.TotalParameterCount != r.TotalParameterCount ||
+		parsed.TotalDataCount != r.TotalDataCount ||
+		parsed.ParameterCount != r.ParameterCount ||
+		parsed.DataCount != r.DataCount ||
+		parsed.ParameterOffset != r.ParameterOffset ||
+		parsed.DataOffset != r.DataOffset {
+		t.Fatalf("count/offset mismatch: %+v", parsed)
+	}
+	if parsed.SetupCount != r.SetupCount || len(parsed.Setup) != 2 ||
+		parsed.Setup[0] != 0x1234 || parsed.Setup[1] != 0xABCD {
+		t.Fatalf("Setup mismatch: %+v", parsed.Setup)
+	}
+	if !bytes.Equal([]byte(parsed.Parameters), []byte(r.Parameters)) {
+		t.Fatalf("Parameters mismatch: got %v", parsed.Parameters)
+	}
+	if !bytes.Equal([]byte(parsed.Data), []byte(r.Data)) {
+		t.Fatalf("Data mismatch: got %v", parsed.Data)
+	}
+	if len(parsed.Pad2) != len(r.Pad2) {
+		t.Fatalf("Pad2 length mismatch: got %d, want %d", len(parsed.Pad2), len(r.Pad2))
+	}
+}
+
+// Test_NtTransactResponse_InterimEmpty verifies that an interim/error response with an
+// empty Parameter and Data section (WordCount and ByteCount both zero) is parsed without
+// error and without panicking.
+func Test_NtTransactResponse_InterimEmpty(t *testing.T) {
+	// WordCount = 0, ByteCount = 0x0000.
+	marshalled := []byte{0x00, 0x00, 0x00}
+
+	r := commands.NewNtTransactResponse()
+	if _, err := r.Unmarshal(marshalled); err != nil {
+		t.Fatalf("Unmarshal of interim response failed: %v", err)
+	}
+	if r.ParameterCount != 0 || r.DataCount != 0 || r.SetupCount != 0 {
+		t.Fatalf("expected empty interim response, got %+v", r)
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #178`

### Root Cause
`NtTransactResponse` was scaffolded as an empty stub (mirroring `Transaction2Response`): the struct embedded only `command_interface.Command` and declared none of the SMB_COM_NT_TRANSACT standard-format response fields. Its `Marshal` emitted an empty parameter/data block, and its `Unmarshal` read the parameter words and data bytes only to discard them (`_ = c.GetParameters().GetBytes()` / `_ = c.GetData().GetBytes()`), with comments stating "No parameters are sent in this message" / "No data is sent in this message". The standard response format defined by MS-CIFS could neither be represented nor round-tripped.

### Fix Description
Implements the standard SMB_COM_NT_TRANSACT response format per [MS-CIFS SMB_COM_NT_TRANSACT Response](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/dd00c842-2398-412f-b21d-bf5074a9a1c4):

- Adds the documented SMB_Parameters words in spec order: `Reserved1[3]`, `TotalParameterCount`, `TotalDataCount`, `ParameterCount`, `ParameterOffset`, `ParameterDisplacement`, `DataCount`, `DataOffset`, `DataDisplacement`, `SetupCount`, and the `Setup[SetupCount]` USHORT array.
- Adds the documented SMB_Data block: `Pad1`, `Parameters[ParameterCount]`, `Pad2`, `Data[DataCount]`.
- `Marshal` produces a `WordCount` of `SetupCount + 18`, matching the spec requirement.
- `Unmarshal` locates the `Parameters` and `Data` blocks using `ParameterOffset`/`DataOffset`, which are measured from the start of the SMB Header; the relative position within the data block is derived as `SMB_HEADER_SIZE + bytesRead + 2`, so the parse is robust to variable-length `Pad1`/`Pad2` alignment padding.
- Adds the nil-guard that lazily creates the Parameters/Data structures at the top of `Unmarshal` (matching `NegotiateResponse`), preventing a nil-pointer panic when unmarshalling into a freshly constructed value.
- Preserves the existing big-endian parameter-marshalling convention used by the sibling `NtTransactRequest`; the big-endian defect class is tracked separately and is out of scope here to keep this change focused.
- Handles the interim/error response (empty Parameter and Data sections, `WordCount` and `ByteCount` zero) by returning early.

### How Verified
- `go build ./...` succeeds.
- `go test ./network/smb/smb_v10/...` passes.
- New tests assert WordCount = SetupCount + 18, round-trip equality of all parameter fields, the Setup word array, the padded Parameters/Data blocks, and that an empty interim response parses without panic.

### Test Coverage
**Added:** `network/smb/smb_v10/message/commands/NtTransactResponse_test.go`
- `Test_NtTransactResponse_RoundTrip`
- `Test_NtTransactResponse_InterimEmpty`

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/NtTransactResponse.go`, `network/smb/smb_v10/message/commands/NtTransactResponse_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local to the `NtTransactResponse` command. The struct gained fields and the marshalled output changed from an empty block to the documented format; any caller relying on the previous empty behaviour would have been non-functional. Safe to merge without staged rollout.
