### PR TITLE
[bugfix] Fix TreeConnectAndxRequest.Unmarshal to split Path and Service fields (#259)

### DIFF
--- a/network/smb/smb_v10/message/commands/TreeConnectAndxRequest.go
+++ b/network/smb/smb_v10/message/commands/TreeConnectAndxRequest.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
 
@@ -254,17 +255,31 @@ func (c *TreeConnectAndxRequest) Unmarshal(data []byte) (int, error) {
 	offset += int(c.PasswordLength)
 
 	// Unmarshalling data Pad
-	if len(rawDataContent) < offset+1 {
-		return offset, fmt.Errorf("rawDataContent too short for Pad")
-	}
-	c.Pad = rawDataContent[offset : offset+1]
-	offset++
+	// Per MS-CIFS 2.2.4.55.1 the Pad field is zero or one null padding bytes used
+	// only to 16-bit-align the Unicode Path; when the Password is the single null
+	// padding byte it "takes the place of the Pad[] byte" and no Pad is present.
+	// The marshaller does not emit a standalone Pad byte in the round-trippable
+	// cases, so Unmarshal MUST NOT unconditionally consume one here: doing so eats
+	// the first byte of Path. Treat all bytes after Password as Path + Service.
+	c.Pad = []types.UCHAR{}
 
 	// Unmarshalling data Path
-	c.Path = rawDataContent[offset:]
-	offset += len(c.Path)
+	// Path is a null-terminated string; it ends at (and includes) its first null
+	// byte. The bytes that follow belong to the Service field, so Path MUST NOT
+	// swallow the remainder of the buffer.
+	pathNull := bytes.IndexByte(rawDataContent[offset:], 0x00)
+	if pathNull < 0 {
+		// No terminator found: the remaining bytes are the (unterminated) Path.
+		c.Path = rawDataContent[offset:]
+		offset += len(c.Path)
+		c.Service = []types.UCHAR{}
+		return offset, nil
+	}
+	c.Path = rawDataContent[offset : offset+pathNull+1]
+	offset += pathNull + 1
 
 	// Unmarshalling data Service
+	// Service is a null-terminated OEM string that follows Path.
 	c.Service = rawDataContent[offset:]
 	offset += len(c.Service)
 

--- a/network/smb/smb_v10/message/commands/TreeConnectAndxRequest_test.go
+++ b/network/smb/smb_v10/message/commands/TreeConnectAndxRequest_test.go
@@ -1,0 +1,52 @@
+package commands_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/data"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/parameters"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+)
+
+// TestTreeConnectAndxRequestUnmarshalSplitsPathAndService verifies that
+// Unmarshal parses the null-terminated Path string up to and including its
+// terminator and parses the trailing bytes into the Service field, rather than
+// collapsing both null-terminated strings into Path.
+//
+// Per MS-CIFS 2.2.4.55.1, SMB_Data.Bytes is Password[PasswordLength], then
+// Pad[], then SMB_STRING Path (null-terminated), then OEM_STRING Service
+// (null-terminated).
+func TestTreeConnectAndxRequestUnmarshalSplitsPathAndService(t *testing.T) {
+	path := append([]types.UCHAR(`\\server\share`), 0x00)
+	service := append([]types.UCHAR("A:"), 0x00)
+
+	// Build a request and marshal it to obtain a valid wire representation.
+	src := commands.NewTreeConnectAndxRequest()
+	src.Password = []types.UCHAR{0x00} // single null padding byte, PasswordLength = 1
+	src.Path = path
+	src.Service = service
+
+	marshalled, err := src.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	// Unmarshal into a fresh request. Initialize Parameters/Data explicitly so
+	// this test does not depend on the nil-guard fix from a separate change.
+	dst := commands.NewTreeConnectAndxRequest()
+	dst.SetParameters(parameters.NewParameters())
+	dst.SetData(data.NewData())
+
+	if _, err := dst.Unmarshal(marshalled); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+
+	if !bytes.Equal([]byte(dst.Path), []byte(path)) {
+		t.Errorf("Path mismatch:\n got  %q\n want %q", []byte(dst.Path), []byte(path))
+	}
+	if !bytes.Equal([]byte(dst.Service), []byte(service)) {
+		t.Errorf("Service mismatch:\n got  %q\n want %q", []byte(dst.Service), []byte(service))
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #259`

### Root Cause
Per [MS-CIFS 2.2.4.55.1](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/90bf689a-8536-4f03-9f1b-683ee4bdd67c), `SMB_Data.Bytes` is `Password[PasswordLength]`, then `Pad[]`, then a null-terminated `SMB_STRING Path`, then a null-terminated `OEM_STRING Service`. `Unmarshal` assigned `c.Path = rawDataContent[offset:]` (the entire remainder) and then advanced `offset` past everything, so `c.Service` was always an empty slice and `Path` contained Path+Service concatenated. The terminating null byte separating the two strings was never used as a delimiter.

A second, entangled defect in the same data-parsing block compounded this: `Unmarshal` unconditionally consumed one byte as `Pad`. In the round-trippable cases the marshaller emits no standalone `Pad` byte (when the Password is the single null padding byte, that byte "takes the place of the Pad[] byte"), so consuming a Pad byte ate the first byte of `Path`. This had to be corrected for `Path` to be recovered at all.

### Fix Description
`Unmarshal` now locates the first null byte after `Password` and assigns `Path` up to and including that terminator, then assigns the remaining bytes to `Service`. If no terminator is present, the remaining bytes are treated as an unterminated `Path` and `Service` is empty. The unconditional single-byte `Pad` consume was removed (`Pad` is set to an empty slice) so it no longer corrupts `Path`; this keeps `Unmarshal` symmetric with `Marshal`, which does not emit a standalone Pad byte in these cases.

### How Verified
- `go build ./...` and `go vet` pass.
- `go test ./network/smb/smb_v10/message/commands/...` passes.
- Added regression test `TestTreeConnectAndxRequestUnmarshalSplitsPathAndService` marshals a request with `Path = \\server\share\0` and `Service = A:\0`, unmarshals it, and asserts `Path` and `Service` are recovered as separate, correctly terminated strings.

### Test Coverage
**Added:** `network/smb/smb_v10/message/commands/TreeConnectAndxRequest_test.go` — `TestTreeConnectAndxRequestUnmarshalSplitsPathAndService`.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/TreeConnectAndxRequest.go`, `network/smb/smb_v10/message/commands/TreeConnectAndxRequest_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none (the Pad correction is required for the Path/Service split to work and lives in the same contiguous data-parsing block)

### Notes
The Pad correction is in the same data-parsing region as the Path/Service split and is a prerequisite for recovering `Path`; it is included here rather than split into a separate PR because the two cannot be fixed independently without leaving `Path` corrupted.
