### PR TITLE
[bugfix] Fix extended-security SessionSetupAndxRequest unmarshalling (#328)

### DIFF
--- a/network/smb/smb_v10/message/commands/SessionSetupAndxRequest.go
+++ b/network/smb/smb_v10/message/commands/SessionSetupAndxRequest.go
@@ -409,6 +409,14 @@ func (c *SessionSetupAndxRequest) Unmarshal(data []byte) (int, error) {
 		return 0, nil
 	}
 
+	// Determine which variant of the request this is from the parameter
+	// WordCount. The Capabilities field that carries CAP_EXTENDED_SECURITY is
+	// located at the end of the parameter block and therefore cannot be used to
+	// drive parsing of the fields that precede it. Per [MS-CIFS] 2.2.4.53.1 the
+	// non-extended-security request has WordCount 0x0D, while [MS-SMB] 2.2.4.5
+	// defines WordCount 0x0C for the extended-security request.
+	isExtendedSecurity := c.GetParameters().WordCount == 0x0C
+
 	// First unmarshal the parameters
 	offset = 0
 	if c.IsAndX() {
@@ -443,7 +451,7 @@ func (c *SessionSetupAndxRequest) Unmarshal(data []byte) (int, error) {
 	c.SessionKey = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
 	offset += 4
 
-	if c.Capabilities.HasCapability(capabilities.CAP_EXTENDED_SECURITY) {
+	if isExtendedSecurity {
 		// Unmarshalling parameter SecurityBlobLength
 		if len(rawParametersContent) < offset+2 {
 			return offset, fmt.Errorf("rawParametersContent too short for SecurityBlobLength")
@@ -483,13 +491,15 @@ func (c *SessionSetupAndxRequest) Unmarshal(data []byte) (int, error) {
 	// Then unmarshal the data
 	offset = 0
 
-	if c.Capabilities.HasCapability(capabilities.CAP_EXTENDED_SECURITY) {
+	if isExtendedSecurity {
 		// Unmarshalling data SecurityBlob
-		if len(rawDataContent) < offset+2 {
-			return offset, fmt.Errorf("rawDataContent too short for SecurityBlobLength")
+		// The length of the SecurityBlob is carried by the SecurityBlobLength
+		// parameter (parsed above), not by a length field inside the data block.
+		if len(rawDataContent) < offset+int(c.SecurityBlobLength) {
+			return offset, fmt.Errorf("rawDataContent too short for SecurityBlob")
 		}
-		c.SecurityBlobLength = types.USHORT(binary.LittleEndian.Uint16(rawDataContent[offset : offset+2]))
-		offset += 2
+		c.SecurityBlob = rawDataContent[offset : offset+int(c.SecurityBlobLength)]
+		offset += int(c.SecurityBlobLength)
 
 		// Unmarshalling data NativeOS
 		nativeOSdata, bytesRead := utils.ReadUntilNullTerminator(rawDataContent[offset:])

--- a/network/smb/smb_v10/message/commands/SessionSetupAndxRequest_test.go
+++ b/network/smb/smb_v10/message/commands/SessionSetupAndxRequest_test.go
@@ -1,0 +1,62 @@
+package commands_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/capabilities"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/data"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/parameters"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+)
+
+// TestSessionSetupAndxRequest_ExtendedSecurityRoundTrip verifies that, in the
+// extended-security variant, the SecurityBlob is preserved across a
+// Marshal/Unmarshal cycle and that NativeOS/NativeLanMan are parsed from the
+// correct offset (immediately after the blob). Per [MS-SMB] 2.2.4.5 / [MS-CIFS]
+// 2.2.4.53.1, the data block is SecurityBlob[SecurityBlobLength] followed by
+// NativeOS and NativeLanMan; SecurityBlobLength lives only in the parameters
+// block, not inside the data block.
+func TestSessionSetupAndxRequest_ExtendedSecurityRoundTrip(t *testing.T) {
+	securityBlob := []types.UCHAR{0x60, 0x12, 0x06, 0x06, 0x2b, 0x06, 0x01, 0x05, 0x05, 0x02}
+
+	req := commands.NewSessionSetupAndxRequest()
+	req.MaxBufferSize = 0x4104
+	req.MaxMpxCount = 50
+	req.VcNumber = 0
+	req.SessionKey = 0
+	req.Capabilities = capabilities.CAP_EXTENDED_SECURITY
+	req.SecurityBlob = securityBlob
+	req.NativeOS = "Windows"
+	req.NativeLanMan = "Manticore"
+
+	marshalled, err := req.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	parsed := commands.NewSessionSetupAndxRequest()
+	parsed.SetParameters(parameters.NewParameters())
+	parsed.SetData(data.NewData())
+	if _, err := parsed.Unmarshal(marshalled); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+
+	if parsed.SecurityBlobLength != types.USHORT(len(securityBlob)) {
+		t.Errorf("SecurityBlobLength: expected %d, got %d", len(securityBlob), parsed.SecurityBlobLength)
+	}
+
+	if !bytes.Equal([]byte(parsed.SecurityBlob), []byte(securityBlob)) {
+		t.Errorf("SecurityBlob: expected % x, got % x",
+			[]byte(securityBlob), []byte(parsed.SecurityBlob))
+	}
+
+	if parsed.NativeOS != req.NativeOS {
+		t.Errorf("NativeOS: expected %q, got %q", req.NativeOS, parsed.NativeOS)
+	}
+
+	if parsed.NativeLanMan != req.NativeLanMan {
+		t.Errorf("NativeLanMan: expected %q, got %q", req.NativeLanMan, parsed.NativeLanMan)
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #328`

### Root Cause
`SessionSetupAndxRequest.Unmarshal` made two layout decisions that broke the extended-security variant of `SMB_COM_SESSION_SETUP_ANDX`:

1. The parameter-variant branch tested `c.Capabilities.HasCapability(CAP_EXTENDED_SECURITY)`, but `Capabilities` is the last field in the parameter block and is not read until after that branch. On a freshly constructed target it is `0`, so the non-extended layout (`OEMPasswordLen` + `UnicodePasswordLen`, WordCount `0x0D`) was always used to parse an extended-security request (WordCount `0x0C`), shifting `Reserved`/`Capabilities` and failing with `rawParametersContent too short for Capabilities`.
2. The data-block branch read a 2-byte `SecurityBlobLength` from the start of the data block. Per [MS-SMB] 2.2.4.5 and [MS-CIFS] 2.2.4.53.1 that field exists only in the parameter block; the data block begins with the raw `SecurityBlob` (whose length is the already-parsed parameter), followed by `NativeOS` and `NativeLanMan`. The blob was therefore never read and the strings were parsed two bytes off — also asymmetric with `Marshal`, which writes the raw blob bytes with no embedded length.

### Fix Description
- Select the request variant from the parameter `WordCount` (`0x0C` = extended security, `0x0D` = non-extended) before parsing fields that precede `Capabilities`, and use that single decision for both the parameter and data blocks.
- In the extended-security data block, read `SecurityBlob` using the `SecurityBlobLength` parsed from the parameter block, then `NativeOS`/`NativeLanMan`. The bogus `SecurityBlobLength`-from-data read is removed.

### How Verified
- `go build ./...` and `go test ./network/smb/smb_v10/...` pass.
- Added a round-trip test that marshals an extended-security request with a non-empty `SecurityBlob`, `NativeOS`, and `NativeLanMan`, then unmarshals it and asserts all three are preserved. The test fails (parameter error + dropped blob) before the fix and passes after.

### Test Coverage
- **Added:** `network/smb/smb_v10/message/commands/SessionSetupAndxRequest_test.go` — `TestSessionSetupAndxRequest_ExtendedSecurityRoundTrip`.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/SessionSetupAndxRequest.go`, `network/smb/smb_v10/message/commands/SessionSetupAndxRequest_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local to `SessionSetupAndxRequest.Unmarshal`. The non-extended-security path is unchanged in behavior (WordCount `0x0D` continues to select it); only the extended-security path is corrected. Safe to merge directly.

### Notes
Two related observations in the same file are out of scope for this fix and left for separate review: (1) `Marshal` emits `SMB_STRING` buffer-format prefix bytes (e.g. `0x04`/`0x01`) for `AccountName`/`PrimaryDomain`, whereas [MS-CIFS] 2.2.4.53.1 specifies raw null-terminated strings for these fields; (2) the extended-security `NativeOS`/`NativeLanMan` are read with a single-byte null scan, which does not correctly terminate UTF-16LE strings when `CAP_UNICODE` is negotiated.