### PR TITLE
[bugfix] Fix TreeConnectRequest.Unmarshal re-parsing Path for Password and Service (#234)

### DIFF
--- a/network/smb/smb_v10/message/commands/TreeConnectRequest.go
+++ b/network/smb/smb_v10/message/commands/TreeConnectRequest.go
@@ -181,21 +181,21 @@ func (c *TreeConnectRequest) Unmarshal(rawData []byte) (int, error) {
 	offset = 0
 
 	// Unmarshalling data Path
-	bytesRead, err = c.Path.Unmarshal(rawDataContent)
+	bytesRead, err = c.Path.Unmarshal(rawDataContent[offset:])
 	if err != nil {
 		return 0, err
 	}
 	offset += bytesRead
 
 	// Unmarshalling data Password
-	bytesRead, err = c.Password.Unmarshal(rawDataContent)
+	bytesRead, err = c.Password.Unmarshal(rawDataContent[offset:])
 	if err != nil {
 		return 0, err
 	}
 	offset += bytesRead
 
 	// Unmarshalling data Service
-	bytesRead, err = c.Service.Unmarshal(rawDataContent)
+	bytesRead, err = c.Service.Unmarshal(rawDataContent[offset:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/TreeConnectRequest_test.go
+++ b/network/smb/smb_v10/message/commands/TreeConnectRequest_test.go
@@ -28,3 +28,36 @@ func TestTreeConnectRequestUnmarshalInitializesStructures(t *testing.T) {
 		t.Fatalf("Unmarshal failed: %v", err)
 	}
 }
+
+// TestTreeConnectRequestUnmarshalDistinctFields verifies that Unmarshal decodes
+// the three SMB_Data OEM strings (Path, Password, Service) from consecutive
+// positions in the data block, rather than re-parsing Path for all three.
+// Per [MS-CIFS] 2.2.4.50.1, the SMB_Data block is:
+//
+//	BufferFormat1(0x04) Path\0 BufferFormat2(0x04) Password\0 BufferFormat3(0x04) Service\0
+func TestTreeConnectRequestUnmarshalDistinctFields(t *testing.T) {
+	out := commands.NewTreeConnectRequest()
+	out.Path = *types.NewOEM_STRINGFromString(`\\server\share`)
+	out.Password = *types.NewOEM_STRINGFromString("secret")
+	out.Service = *types.NewOEM_STRINGFromString("A:")
+
+	marshalled, err := out.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	in := commands.NewTreeConnectRequest()
+	if _, err := in.Unmarshal(marshalled); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+
+	if got := in.Path.GetString(); got != `\\server\share` {
+		t.Errorf("Path = %q, want %q", got, `\\server\share`)
+	}
+	if got := in.Password.GetString(); got != "secret" {
+		t.Errorf("Password = %q, want %q", got, "secret")
+	}
+	if got := in.Service.GetString(); got != "A:" {
+		t.Errorf("Service = %q, want %q", got, "A:")
+	}
+}


### PR DESCRIPTION
## Description

`SMB_COM_TREE_CONNECT` Request (`TreeConnectRequest.Unmarshal`) decoded all three `SMB_Data` OEM strings — `Path`, `Password`, and `Service` — from the start of the data block, so `Password` and `Service` re-parsed `Path` instead of advancing through the buffer.

Per [MS-CIFS] 2.2.4.50.1 the `SMB_Data` block is laid out sequentially:

```
BufferFormat1(0x04) Path\0  BufferFormat2(0x04) Password\0  BufferFormat3(0x04) Service\0
```

## Fix

`Unmarshal` now advances `offset` by the bytes consumed after each field and decodes the next field from `rawDataContent[offset:]`. Added `TestTreeConnectRequestUnmarshalDistinctFields` asserting Path/Password/Service round-trip to distinct values.

Closes #234