### PR TITLE
[bugfix] Fix WriteAndUnlockRequest parameter marshalling to little-endian (#240)

### DIFF
--- a/network/smb/smb_v10/message/commands/WriteAndUnlockRequest.go
+++ b/network/smb/smb_v10/message/commands/WriteAndUnlockRequest.go
@@ -117,22 +117,22 @@ func (c *WriteAndUnlockRequest) Marshal() ([]byte, error) {
 
 	// Marshalling parameter FID
 	buf2 := make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.FID))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.FID))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter CountOfBytesToWrite
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.CountOfBytesToWrite))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.CountOfBytesToWrite))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter WriteOffsetInBytes
 	buf4 := make([]byte, 4)
-	binary.BigEndian.PutUint32(buf4, uint32(c.WriteOffsetInBytes))
+	binary.LittleEndian.PutUint32(buf4, uint32(c.WriteOffsetInBytes))
 	rawParametersContent = append(rawParametersContent, buf4...)
 
 	// Marshalling parameter EstimateOfRemainingBytesToBeWritten
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.EstimateOfRemainingBytesToBeWritten))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.EstimateOfRemainingBytesToBeWritten))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameters
@@ -189,28 +189,28 @@ func (c *WriteAndUnlockRequest) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for FID")
 	}
-	c.FID = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.FID = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter CountOfBytesToWrite
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for CountOfBytesToWrite")
 	}
-	c.CountOfBytesToWrite = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.CountOfBytesToWrite = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter WriteOffsetInBytes
 	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for WriteOffsetInBytes")
 	}
-	c.WriteOffsetInBytes = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	c.WriteOffsetInBytes = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
 	offset += 4
 
 	// Unmarshalling parameter EstimateOfRemainingBytesToBeWritten
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for EstimateOfRemainingBytesToBeWritten")
 	}
-	c.EstimateOfRemainingBytesToBeWritten = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.EstimateOfRemainingBytesToBeWritten = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Then unmarshal the data


### PR DESCRIPTION
## Description

`SMB_COM_WRITE_AND_UNLOCK` Request (`WriteAndUnlockRequest`) marshalled and unmarshalled all four integer parameter fields — `FID` (USHORT), `CountOfBytesToWrite` (USHORT), `WriteOffsetInBytes` (ULONG), and `EstimateOfRemainingBytesToBeWritten` (USHORT) — using `binary.BigEndian`. SMB/CIFS integers are little-endian per [MS-CIFS], and the `parameters` layer is byte-preserving, so the values were transmitted byte-swapped on the wire. Round-trip tests did not catch it because Marshal/Unmarshal were symmetrically wrong.

## Fix

Switched all 8 encode/decode sites (4 in `Marshal`, 4 in `Unmarshal`) from `binary.BigEndian` to `binary.LittleEndian`. The data block (BufferFormat 0x01 + DataLength + Data via `SMB_STRING`) was already correct.

Part of the systemic big-endian parameter-marshalling class tracked in #134.

Closes #240