### PR TITLE
[bugfix] Fix OpenResponse parameter block: little-endian integers and 4-byte UTIME LastModified (#190)

### DIFF
--- a/network/smb/smb_v10/message/commands/OpenResponse.go
+++ b/network/smb/smb_v10/message/commands/OpenResponse.go
@@ -27,7 +27,8 @@ type OpenResponse struct {
 	FileAttrs types.SMB_FILE_ATTRIBUTES
 
 	// LastModified (4 bytes): The time of the last modification to the opened file.
-	LastModified types.FILETIME
+	// Per [MS-CIFS] this is a 4-byte UTIME, not an 8-byte FILETIME.
+	LastModified types.ULONG
 
 	// FileSize (4 bytes): The current size of the opened file, in bytes.
 	FileSize types.ULONG
@@ -46,7 +47,7 @@ func NewOpenResponse() *OpenResponse {
 		// Parameters
 		FID:          types.USHORT(0),
 		FileAttrs:    types.SMB_FILE_ATTRIBUTES{},
-		LastModified: types.FILETIME{},
+		LastModified: types.ULONG(0),
 		FileSize:     types.ULONG(0),
 		AccessMode:   types.USHORT(0),
 	}
@@ -95,7 +96,7 @@ func (c *OpenResponse) Marshal() ([]byte, error) {
 
 	// Marshalling parameter FID
 	buf2 := make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.FID))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.FID))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameter FileAttrs
@@ -105,21 +106,19 @@ func (c *OpenResponse) Marshal() ([]byte, error) {
 	}
 	rawParametersContent = append(rawParametersContent, byteStream...)
 
-	// Marshalling parameter LastModified
-	bytesStream, err := c.LastModified.Marshal()
-	if err != nil {
-		return nil, err
-	}
-	rawParametersContent = append(rawParametersContent, bytesStream...)
+	// Marshalling parameter LastModified (4-byte UTIME, little-endian)
+	buf4 := make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf4, uint32(c.LastModified))
+	rawParametersContent = append(rawParametersContent, buf4...)
 
 	// Marshalling parameter FileSize
-	buf4 := make([]byte, 4)
-	binary.BigEndian.PutUint32(buf4, uint32(c.FileSize))
+	buf4 = make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf4, uint32(c.FileSize))
 	rawParametersContent = append(rawParametersContent, buf4...)
 
 	// Marshalling parameter AccessMode
 	buf2 = make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.AccessMode))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.AccessMode))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameters
@@ -176,7 +175,7 @@ func (c *OpenResponse) Unmarshal(data []byte) (int, error) {
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for FID")
 	}
-	c.FID = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.FID = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter FileAttrs
@@ -189,28 +188,25 @@ func (c *OpenResponse) Unmarshal(data []byte) (int, error) {
 	}
 	offset += bytesRead
 
-	// Unmarshalling parameter LastModified
-	if len(rawParametersContent) < offset+8 {
+	// Unmarshalling parameter LastModified (4-byte UTIME, little-endian)
+	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for LastModified")
 	}
-	bytesRead, err = c.LastModified.Unmarshal(rawParametersContent[offset : offset+8])
-	if err != nil {
-		return 0, err
-	}
-	offset += bytesRead
+	c.LastModified = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
+	offset += 4
 
 	// Unmarshalling parameter FileSize
 	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for FileSize")
 	}
-	c.FileSize = types.ULONG(binary.BigEndian.Uint32(rawParametersContent[offset : offset+4]))
+	c.FileSize = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
 	offset += 4
 
 	// Unmarshalling parameter AccessMode
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for AccessMode")
 	}
-	c.AccessMode = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.AccessMode = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Then unmarshal the data

--- a/network/smb/smb_v10/message/commands/OpenResponse_test.go
+++ b/network/smb/smb_v10/message/commands/OpenResponse_test.go
@@ -1,0 +1,47 @@
+package commands_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+)
+
+// TestOpenResponseWireFormat verifies that SMB_COM_OPEN Response marshals its
+// parameter block per [MS-CIFS] 2.2.4.4.2: WordCount = 0x07 (14 bytes of Words),
+// all integers little-endian, and LastModified as a 4-byte UTIME (not an 8-byte
+// FILETIME).
+func TestOpenResponseWireFormat(t *testing.T) {
+	out := commands.NewOpenResponse()
+	out.FID = types.USHORT(0x1234)
+	out.LastModified = types.ULONG(0x11223344)
+	out.FileSize = types.ULONG(0xAABBCCDD)
+	out.AccessMode = types.USHORT(0x0102)
+
+	marshalled, err := out.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	// Expected wire bytes:
+	//   WordCount    = 0x07
+	//   FID          = 34 12          (0x1234, little-endian)
+	//   FileAttrs    = 00 00
+	//   LastModified = 44 33 22 11    (0x11223344, 4-byte UTIME, little-endian)
+	//   FileSize     = dd cc bb aa    (0xAABBCCDD, little-endian)
+	//   AccessMode   = 02 01          (0x0102, little-endian)
+	//   ByteCount    = 00 00
+	want := []byte{
+		0x07,
+		0x34, 0x12,
+		0x00, 0x00,
+		0x44, 0x33, 0x22, 0x11,
+		0xdd, 0xcc, 0xbb, 0xaa,
+		0x02, 0x01,
+		0x00, 0x00,
+	}
+	if !bytes.Equal(marshalled, want) {
+		t.Errorf("Marshal mismatch:\n got = % x\nwant = % x", marshalled, want)
+	}
+}


### PR DESCRIPTION
## Description

`SMB_COM_OPEN` Response (`OpenResponse`) had two coupled wire-format defects in its parameter block (per [MS-CIFS] 2.2.4.4.2, `WordCount` MUST be `0x07` = 14 bytes of Words, all integers little-endian):

1. **`LastModified` sized as an 8-byte `FILETIME` instead of a 4-byte `UTIME`.** This inflated the Words block to 16 bytes (`WordCount` 0x09) instead of 14 (0x07) and shifted `FileSize` and `AccessMode` by 4 bytes — a malformed response.
2. **`FID`, `FileSize`, and `AccessMode` marshalled/unmarshalled big-endian.** SMB/CIFS integers are little-endian and the `parameters` layer is byte-preserving, so they were transmitted byte-swapped.

Both touch the same Marshal/Unmarshal parameter region and cannot be split into non-overlapping changes, so they are fixed together (mirroring the merged CloseRequest UTIME+endianness fix).

## Fix

- Retyped `LastModified` from `types.FILETIME` to `types.ULONG`, marshalled/unmarshalled as a 4-byte little-endian value (the `CloseRequest` UTIME convention).
- Switched `FID`, `FileSize`, `AccessMode` to `binary.LittleEndian` in both directions.
- Corrected the `LastModified` unmarshal length guard from `offset+8` to `offset+4`.
- Added `TestOpenResponseWireFormat` asserting the exact golden bytes (WordCount 0x07, little-endian fields, 4-byte UTIME).

Part of the systemic big-endian class tracked in #134.

Closes #190