### PR TITLE
[bugfix] Fix FindResponse SMB_Data block to emit BufferFormat 0x05 and DataLength (#335)

### DIFF
--- a/network/smb/smb_v10/message/commands/FindResponse.go
+++ b/network/smb/smb_v10/message/commands/FindResponse.go
@@ -85,14 +85,27 @@ func (c *FindResponse) Marshal() ([]byte, error) {
 	// the data will be stored in the parameters
 	rawDataContent := []byte{}
 
-	// Marshalling data DirectoryInformationData
+	// Marshalling the directory information records first so we can compute DataLength
+	directoryRecords := []byte{}
 	for _, directoryInformationData := range c.DirectoryInformationData {
 		marshalledData, err := directoryInformationData.Marshal()
 		if err != nil {
 			return nil, err
 		}
-		rawDataContent = append(rawDataContent, marshalledData...)
+		directoryRecords = append(directoryRecords, marshalledData...)
 	}
+
+	// BufferFormat (1 byte): MUST be 0x05, indicating that a variable-size block follows
+	rawDataContent = append(rawDataContent, 0x05)
+
+	// DataLength (2 bytes, little-endian): size in bytes of the DirectoryInformationData array,
+	// which MUST equal 43 times the number of directory entries
+	dataLengthBuf := make([]byte, 2)
+	binary.LittleEndian.PutUint16(dataLengthBuf, uint16(len(directoryRecords)))
+	rawDataContent = append(rawDataContent, dataLengthBuf...)
+
+	// DirectoryInformationData (variable)
+	rawDataContent = append(rawDataContent, directoryRecords...)
 
 	// Then marshal the parameters
 	rawParametersContent := []byte{}
@@ -165,6 +178,18 @@ func (c *FindResponse) Unmarshal(data []byte) (int, error) {
 	// Unmarshalling data DirectoryInformationData
 	// Clear any existing entries
 	c.DirectoryInformationData = []types.SMB_DIRECTORY_INFORMATION{}
+
+	// BufferFormat (1 byte): MUST be 0x05
+	if len(rawDataContent) < offset+1 {
+		return offset, fmt.Errorf("rawDataContent too short for BufferFormat")
+	}
+	offset++
+
+	// DataLength (2 bytes, little-endian): size in bytes of the DirectoryInformationData array
+	if len(rawDataContent) < offset+2 {
+		return offset, fmt.Errorf("rawDataContent too short for DataLength")
+	}
+	offset += 2
 
 	// Each directory information entry is 43 bytes fixed size
 	const entrySize = 43

--- a/network/smb/smb_v10/message/commands/FindResponse_test.go
+++ b/network/smb/smb_v10/message/commands/FindResponse_test.go
@@ -1,0 +1,31 @@
+package commands_test
+
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+)
+
+// TestFindResponseDataBlockFraming verifies that SMB_COM_FIND Response emits the
+// SMB_Data block per [MS-CIFS] 2.2.4.59.2: a BufferFormat byte (0x05) followed by
+// a 2-byte little-endian DataLength, then the DirectoryInformationData array.
+// Previously the framing bytes were omitted and only the raw records were written.
+func TestFindResponseDataBlockFraming(t *testing.T) {
+	out := commands.NewFindResponse()
+	out.Count = types.USHORT(0)
+
+	marshalled, err := out.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	// Layout: WordCount(1)=0x01, Count(2 LE), ByteCount(2 LE)=0x0003,
+	// then the data block: BufferFormat(0x05) DataLength(00 00).
+	// With no directory entries, the last three bytes must be the empty
+	// variable-block framing 05 00 00.
+	n := len(marshalled)
+	if n < 3 || marshalled[n-3] != 0x05 || marshalled[n-2] != 0x00 || marshalled[n-1] != 0x00 {
+		t.Fatalf("data block framing missing/incorrect; full = % x", marshalled)
+	}
+}


### PR DESCRIPTION
## Description

`SMB_COM_FIND` Response wrote the `DirectoryInformationData` records directly into the SMB_Data block, omitting the `BufferFormat` (0x05) byte and the 2-byte little-endian `DataLength` field required by [MS-CIFS] 2.2.4.59.2. The sibling `FindUniqueResponse` had the identical defect, already fixed in #271/#295; `FindResponse` was missed (an earlier pass fixed only `Count` endianness in #153 and mis-judged the framing as correct).

## Fix

- `Marshal` now emits `0x05` + 2-byte little-endian `DataLength` (= total record bytes) + the records, mirroring `FindUniqueResponse`.
- `Unmarshal` skips the 3 framing bytes before reading the 43-byte records.
- Added `TestFindResponseDataBlockFraming`.

Closes #335