### PR TITLE
[enhancement] Add Setup word array to Transaction2Request for TRANS2 subcommand support (#337)

### DIFF
--- a/network/smb/smb_v10/message/commands/Transaction2Request.go
+++ b/network/smb/smb_v10/message/commands/Transaction2Request.go
@@ -116,6 +116,11 @@ type Transaction2Request struct {
 	// SetupCount is defined as a USHORT, the high order byte MUST be0x00.
 	Reserved3 types.UCHAR
 
+	// Setup (variable): An array of SetupCount USHORT setup words. For a Transaction2
+	// request this carries the subcommand code (e.g. TRANS2_FIND_FIRST2) as the first
+	// (and usually only) setup word.
+	Setup []types.USHORT
+
 	// Data
 
 	// Name (1 byte): This field is not used in SMB_COM_TRANSACTION2 requests. This
@@ -169,6 +174,7 @@ func NewTransaction2Request() *Transaction2Request {
 		DataOffset:          types.USHORT(0),
 		SetupCount:          types.UCHAR(0),
 		Reserved3:           types.UCHAR(0),
+		Setup:               []types.USHORT{},
 
 		// Data
 		Name:              types.UCHAR(0),
@@ -296,11 +302,19 @@ func (c *Transaction2Request) Marshal() ([]byte, error) {
 	binary.LittleEndian.PutUint16(buf2, uint16(c.DataOffset))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
-	// Marshalling parameter SetupCount
+	// Marshalling parameter SetupCount (the number of setup words that follow)
+	c.SetupCount = types.UCHAR(len(c.Setup))
 	rawParametersContent = append(rawParametersContent, types.UCHAR(c.SetupCount))
 
 	// Marshalling parameter Reserved3
 	rawParametersContent = append(rawParametersContent, types.UCHAR(c.Reserved3))
+
+	// Marshalling parameter Setup (SetupCount USHORT words, e.g. the TRANS2 subcommand)
+	for _, setupWord := range c.Setup {
+		buf2 = make([]byte, 2)
+		binary.LittleEndian.PutUint16(buf2, uint16(setupWord))
+		rawParametersContent = append(rawParametersContent, buf2...)
+	}
 
 	// Marshalling parameters
 	c.GetParameters().AddWordsFromBytesStream(rawParametersContent)
@@ -456,6 +470,16 @@ func (c *Transaction2Request) Unmarshal(data []byte) (int, error) {
 	}
 	c.Reserved3 = types.UCHAR(rawParametersContent[offset])
 	offset++
+
+	// Unmarshalling parameter Setup (SetupCount USHORT words)
+	c.Setup = make([]types.USHORT, 0, int(c.SetupCount))
+	for i := 0; i < int(c.SetupCount); i++ {
+		if len(rawParametersContent) < offset+2 {
+			return offset, fmt.Errorf("rawParametersContent too short for Setup word %d", i)
+		}
+		c.Setup = append(c.Setup, types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset:offset+2])))
+		offset += 2
+	}
 
 	// Then unmarshal the data
 	offset = 0

--- a/network/smb/smb_v10/message/commands/Transaction2Request_setup_test.go
+++ b/network/smb/smb_v10/message/commands/Transaction2Request_setup_test.go
@@ -1,0 +1,44 @@
+package commands_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+)
+
+// TestTransaction2RequestSetupMarshal verifies that the Setup word array is
+// marshalled with SetupCount derived from its length and each word encoded as a
+// little-endian USHORT, per [MS-CIFS] 2.2.4.46.1. The first setup word carries
+// the TRANS2 subcommand (e.g. TRANS2_FIND_FIRST2).
+func TestTransaction2RequestSetupMarshal(t *testing.T) {
+	out := commands.NewTransaction2Request()
+	out.Setup = []types.USHORT{0x0001, 0x1234} // TRANS2_FIND_FIRST2 + a second word
+
+	marshalled, err := out.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	// SetupCount must be derived from len(Setup).
+	if out.SetupCount != types.UCHAR(len(out.Setup)) {
+		t.Errorf("SetupCount = %d, want %d", out.SetupCount, len(out.Setup))
+	}
+
+	// The two setup words must appear in the parameter block as little-endian USHORTs.
+	wantWords := []byte{0x01, 0x00, 0x34, 0x12}
+	if !bytes.Contains(marshalled, wantWords) {
+		t.Errorf("marshalled output missing little-endian Setup words % x\nfull = % x", wantWords, marshalled)
+	}
+
+	// A request with no setup words must not contain them.
+	empty := commands.NewTransaction2Request()
+	emptyMarshalled, err := empty.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal (empty) failed: %v", err)
+	}
+	if len(marshalled) != len(emptyMarshalled)+4 {
+		t.Errorf("expected 4 extra bytes for 2 setup words, got delta %d", len(marshalled)-len(emptyMarshalled))
+	}
+}


### PR DESCRIPTION
## Description

`SMB_COM_TRANSACTION2` carries its subcommand code (e.g. `TRANS2_FIND_FIRST2`) in the `SMB_Parameters.Setup` array of `SetupCount` USHORT words ([MS-CIFS] 2.2.4.46.1). `Transaction2Request` had no `Setup` field, so the subcommand could not be expressed — blocking directory-enumeration flows that depend on `TRANS2_FIND_FIRST2`/`FIND_NEXT2`.

## Change

- Add `Setup []types.USHORT` field (+ constructor init).
- `Marshal`: derive `SetupCount = len(Setup)` and emit each setup word as a little-endian USHORT after `Reserved3`.
- `Unmarshal`: read `SetupCount` USHORT words into `Setup`.
- Add `TestTransaction2RequestSetupMarshal`.

Builds on the merged little-endian fix for this struct (#221/#270). This restores in-progress `feature-smb-findfiles` work that was preserved during the spec-crosscheck sweep.

Closes #337