### PR TITLE
[bugfix] Initialize Parameters/Data in command Unmarshal to prevent nil-pointer panic (#340)

### DIFF
--- a/network/smb/smb_v10/message/commands/CheckDirectoryRequest.go
+++ b/network/smb/smb_v10/message/commands/CheckDirectoryRequest.go
@@ -106,16 +106,25 @@ func (c *CheckDirectoryRequest) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *CheckDirectoryRequest) Unmarshal(data []byte) (int, error) {
+func (c *CheckDirectoryRequest) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	_ = c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/CheckDirectoryResponse.go
+++ b/network/smb/smb_v10/message/commands/CheckDirectoryResponse.go
@@ -89,16 +89,25 @@ func (c *CheckDirectoryResponse) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *CheckDirectoryResponse) Unmarshal(data []byte) (int, error) {
+func (c *CheckDirectoryResponse) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	_ = c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/ClosePrintFileRequest.go
+++ b/network/smb/smb_v10/message/commands/ClosePrintFileRequest.go
@@ -107,16 +107,25 @@ func (c *ClosePrintFileRequest) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *ClosePrintFileRequest) Unmarshal(data []byte) (int, error) {
+func (c *ClosePrintFileRequest) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/ClosePrintFileResponse.go
+++ b/network/smb/smb_v10/message/commands/ClosePrintFileResponse.go
@@ -89,16 +89,25 @@ func (c *ClosePrintFileResponse) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *ClosePrintFileResponse) Unmarshal(data []byte) (int, error) {
+func (c *ClosePrintFileResponse) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	_ = c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/CloseRequest.go
+++ b/network/smb/smb_v10/message/commands/CloseRequest.go
@@ -117,16 +117,25 @@ func (c *CloseRequest) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *CloseRequest) Unmarshal(data []byte) (int, error) {
+func (c *CloseRequest) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/CloseResponse.go
+++ b/network/smb/smb_v10/message/commands/CloseResponse.go
@@ -89,16 +89,25 @@ func (c *CloseResponse) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *CloseResponse) Unmarshal(data []byte) (int, error) {
+func (c *CloseResponse) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	_ = c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/CreateDirectoryRequest.go
+++ b/network/smb/smb_v10/message/commands/CreateDirectoryRequest.go
@@ -106,16 +106,25 @@ func (c *CreateDirectoryRequest) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *CreateDirectoryRequest) Unmarshal(data []byte) (int, error) {
+func (c *CreateDirectoryRequest) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	_ = c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/CreateDirectoryResponse.go
+++ b/network/smb/smb_v10/message/commands/CreateDirectoryResponse.go
@@ -89,16 +89,25 @@ func (c *CreateDirectoryResponse) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *CreateDirectoryResponse) Unmarshal(data []byte) (int, error) {
+func (c *CreateDirectoryResponse) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	_ = c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/CreateNewRequest.go
+++ b/network/smb/smb_v10/message/commands/CreateNewRequest.go
@@ -133,16 +133,25 @@ func (c *CreateNewRequest) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *CreateNewRequest) Unmarshal(data []byte) (int, error) {
+func (c *CreateNewRequest) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/CreateNewResponse.go
+++ b/network/smb/smb_v10/message/commands/CreateNewResponse.go
@@ -106,16 +106,25 @@ func (c *CreateNewResponse) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *CreateNewResponse) Unmarshal(data []byte) (int, error) {
+func (c *CreateNewResponse) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/CreateRequest.go
+++ b/network/smb/smb_v10/message/commands/CreateRequest.go
@@ -133,16 +133,25 @@ func (c *CreateRequest) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *CreateRequest) Unmarshal(data []byte) (int, error) {
+func (c *CreateRequest) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/CreateResponse.go
+++ b/network/smb/smb_v10/message/commands/CreateResponse.go
@@ -106,16 +106,25 @@ func (c *CreateResponse) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *CreateResponse) Unmarshal(data []byte) (int, error) {
+func (c *CreateResponse) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/CreateTemporaryRequest.go
+++ b/network/smb/smb_v10/message/commands/CreateTemporaryRequest.go
@@ -133,16 +133,25 @@ func (c *CreateTemporaryRequest) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *CreateTemporaryRequest) Unmarshal(data []byte) (int, error) {
+func (c *CreateTemporaryRequest) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/CreateTemporaryResponse.go
+++ b/network/smb/smb_v10/message/commands/CreateTemporaryResponse.go
@@ -123,16 +123,25 @@ func (c *CreateTemporaryResponse) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *CreateTemporaryResponse) Unmarshal(data []byte) (int, error) {
+func (c *CreateTemporaryResponse) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/DeleteDirectoryRequest.go
+++ b/network/smb/smb_v10/message/commands/DeleteDirectoryRequest.go
@@ -106,16 +106,25 @@ func (c *DeleteDirectoryRequest) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *DeleteDirectoryRequest) Unmarshal(data []byte) (int, error) {
+func (c *DeleteDirectoryRequest) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	_ = c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/DeleteDirectoryResponse.go
+++ b/network/smb/smb_v10/message/commands/DeleteDirectoryResponse.go
@@ -89,16 +89,25 @@ func (c *DeleteDirectoryResponse) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *DeleteDirectoryResponse) Unmarshal(data []byte) (int, error) {
+func (c *DeleteDirectoryResponse) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	_ = c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/DeleteRequest.go
+++ b/network/smb/smb_v10/message/commands/DeleteRequest.go
@@ -124,16 +124,25 @@ func (c *DeleteRequest) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *DeleteRequest) Unmarshal(data []byte) (int, error) {
+func (c *DeleteRequest) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/DeleteResponse.go
+++ b/network/smb/smb_v10/message/commands/DeleteResponse.go
@@ -89,16 +89,25 @@ func (c *DeleteResponse) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *DeleteResponse) Unmarshal(data []byte) (int, error) {
+func (c *DeleteResponse) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	_ = c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/EchoRequest.go
+++ b/network/smb/smb_v10/message/commands/EchoRequest.go
@@ -117,16 +117,25 @@ func (c *EchoRequest) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *EchoRequest) Unmarshal(data []byte) (int, error) {
+func (c *EchoRequest) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/EchoResponse.go
+++ b/network/smb/smb_v10/message/commands/EchoResponse.go
@@ -117,16 +117,25 @@ func (c *EchoResponse) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *EchoResponse) Unmarshal(data []byte) (int, error) {
+func (c *EchoResponse) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/FindClose2Request.go
+++ b/network/smb/smb_v10/message/commands/FindClose2Request.go
@@ -106,16 +106,25 @@ func (c *FindClose2Request) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *FindClose2Request) Unmarshal(data []byte) (int, error) {
+func (c *FindClose2Request) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/FindClose2Response.go
+++ b/network/smb/smb_v10/message/commands/FindClose2Response.go
@@ -89,16 +89,25 @@ func (c *FindClose2Response) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *FindClose2Response) Unmarshal(data []byte) (int, error) {
+func (c *FindClose2Response) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	_ = c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/FindCloseRequest.go
+++ b/network/smb/smb_v10/message/commands/FindCloseRequest.go
@@ -143,16 +143,25 @@ func (c *FindCloseRequest) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *FindCloseRequest) Unmarshal(data []byte) (int, error) {
+func (c *FindCloseRequest) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/FindCloseResponse.go
+++ b/network/smb/smb_v10/message/commands/FindCloseResponse.go
@@ -118,16 +118,25 @@ func (c *FindCloseResponse) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *FindCloseResponse) Unmarshal(data []byte) (int, error) {
+func (c *FindCloseResponse) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/FindRequest.go
+++ b/network/smb/smb_v10/message/commands/FindRequest.go
@@ -158,16 +158,25 @@ func (c *FindRequest) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *FindRequest) Unmarshal(data []byte) (int, error) {
+func (c *FindRequest) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/FindResponse.go
+++ b/network/smb/smb_v10/message/commands/FindResponse.go
@@ -141,16 +141,25 @@ func (c *FindResponse) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *FindResponse) Unmarshal(data []byte) (int, error) {
+func (c *FindResponse) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/FindUniqueRequest.go
+++ b/network/smb/smb_v10/message/commands/FindUniqueRequest.go
@@ -156,16 +156,25 @@ func (c *FindUniqueRequest) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *FindUniqueRequest) Unmarshal(data []byte) (int, error) {
+func (c *FindUniqueRequest) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/FindUniqueResponse.go
+++ b/network/smb/smb_v10/message/commands/FindUniqueResponse.go
@@ -141,16 +141,25 @@ func (c *FindUniqueResponse) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *FindUniqueResponse) Unmarshal(data []byte) (int, error) {
+func (c *FindUniqueResponse) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/FlushRequest.go
+++ b/network/smb/smb_v10/message/commands/FlushRequest.go
@@ -107,16 +107,25 @@ func (c *FlushRequest) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *FlushRequest) Unmarshal(data []byte) (int, error) {
+func (c *FlushRequest) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/FlushResponse.go
+++ b/network/smb/smb_v10/message/commands/FlushResponse.go
@@ -89,16 +89,25 @@ func (c *FlushResponse) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *FlushResponse) Unmarshal(data []byte) (int, error) {
+func (c *FlushResponse) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	_ = c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/IoctlRequest.go
+++ b/network/smb/smb_v10/message/commands/IoctlRequest.go
@@ -273,16 +273,25 @@ func (c *IoctlRequest) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *IoctlRequest) Unmarshal(data []byte) (int, error) {
+func (c *IoctlRequest) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/IoctlResponse.go
+++ b/network/smb/smb_v10/message/commands/IoctlResponse.go
@@ -225,16 +225,25 @@ func (c *IoctlResponse) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *IoctlResponse) Unmarshal(data []byte) (int, error) {
+func (c *IoctlResponse) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/LockAndReadRequest.go
+++ b/network/smb/smb_v10/message/commands/LockAndReadRequest.go
@@ -137,16 +137,25 @@ func (c *LockAndReadRequest) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *LockAndReadRequest) Unmarshal(data []byte) (int, error) {
+func (c *LockAndReadRequest) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/LockAndReadResponse.go
+++ b/network/smb/smb_v10/message/commands/LockAndReadResponse.go
@@ -135,16 +135,25 @@ func (c *LockAndReadResponse) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *LockAndReadResponse) Unmarshal(data []byte) (int, error) {
+func (c *LockAndReadResponse) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/LockByteRangeRequest.go
+++ b/network/smb/smb_v10/message/commands/LockByteRangeRequest.go
@@ -125,16 +125,25 @@ func (c *LockByteRangeRequest) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *LockByteRangeRequest) Unmarshal(data []byte) (int, error) {
+func (c *LockByteRangeRequest) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/LockByteRangeResponse.go
+++ b/network/smb/smb_v10/message/commands/LockByteRangeResponse.go
@@ -89,16 +89,25 @@ func (c *LockByteRangeResponse) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *LockByteRangeResponse) Unmarshal(data []byte) (int, error) {
+func (c *LockByteRangeResponse) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	_ = c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/LockingAndxRequest.go
+++ b/network/smb/smb_v10/message/commands/LockingAndxRequest.go
@@ -208,16 +208,25 @@ func (c *LockingAndxRequest) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *LockingAndxRequest) Unmarshal(data []byte) (int, error) {
+func (c *LockingAndxRequest) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}
@@ -244,14 +253,14 @@ func (c *LockingAndxRequest) Unmarshal(data []byte) (int, error) {
 
 	// Unmarshalling parameter TypeOfLock
 	if len(rawParametersContent) < offset+1 {
-		return offset, fmt.Errorf("data too short for TypeOfLock")
+		return offset, fmt.Errorf("rawData too short for TypeOfLock")
 	}
 	c.TypeOfLock = types.UCHAR(rawParametersContent[offset])
 	offset++
 
 	// Unmarshalling parameter NewOpLockLevel
 	if len(rawParametersContent) < offset+1 {
-		return offset, fmt.Errorf("data too short for NewOpLockLevel")
+		return offset, fmt.Errorf("rawData too short for NewOpLockLevel")
 	}
 	c.NewOpLockLevel = types.UCHAR(rawParametersContent[offset])
 	offset++

--- a/network/smb/smb_v10/message/commands/LockingAndxResponse.go
+++ b/network/smb/smb_v10/message/commands/LockingAndxResponse.go
@@ -94,16 +94,25 @@ func (c *LockingAndxResponse) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *LockingAndxResponse) Unmarshal(data []byte) (int, error) {
+func (c *LockingAndxResponse) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	_ = c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/LogoffAndxRequest.go
+++ b/network/smb/smb_v10/message/commands/LogoffAndxRequest.go
@@ -94,16 +94,25 @@ func (c *LogoffAndxRequest) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *LogoffAndxRequest) Unmarshal(data []byte) (int, error) {
+func (c *LogoffAndxRequest) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	_ = c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/LogoffAndxResponse.go
+++ b/network/smb/smb_v10/message/commands/LogoffAndxResponse.go
@@ -94,16 +94,25 @@ func (c *LogoffAndxResponse) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *LogoffAndxResponse) Unmarshal(data []byte) (int, error) {
+func (c *LogoffAndxResponse) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	_ = c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/NegotiateRequest.go
+++ b/network/smb/smb_v10/message/commands/NegotiateRequest.go
@@ -117,16 +117,25 @@ func (c *NegotiateRequest) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *NegotiateRequest) Unmarshal(data []byte) (int, error) {
+func (c *NegotiateRequest) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}
@@ -143,7 +152,7 @@ func (c *NegotiateRequest) Unmarshal(data []byte) (int, error) {
 
 	// Unmarshalling parameter WordCount
 	if len(rawParametersContent) < offset+1 {
-		return offset, fmt.Errorf("data too short for WordCount")
+		return offset, fmt.Errorf("rawData too short for WordCount")
 	}
 	c.WordCount = types.UCHAR(rawParametersContent[offset])
 	offset++

--- a/network/smb/smb_v10/message/commands/NtCancelRequest.go
+++ b/network/smb/smb_v10/message/commands/NtCancelRequest.go
@@ -89,16 +89,25 @@ func (c *NtCancelRequest) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *NtCancelRequest) Unmarshal(data []byte) (int, error) {
+func (c *NtCancelRequest) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	_ = c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/NtCreateAndxRequest.go
+++ b/network/smb/smb_v10/message/commands/NtCreateAndxRequest.go
@@ -252,16 +252,25 @@ func (c *NtCreateAndxRequest) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *NtCreateAndxRequest) Unmarshal(data []byte) (int, error) {
+func (c *NtCreateAndxRequest) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}
@@ -281,7 +290,7 @@ func (c *NtCreateAndxRequest) Unmarshal(data []byte) (int, error) {
 
 	// Unmarshalling parameter Reserved
 	if len(rawParametersContent) < offset+1 {
-		return offset, fmt.Errorf("data too short for Reserved")
+		return offset, fmt.Errorf("rawData too short for Reserved")
 	}
 	c.Reserved = types.UCHAR(rawParametersContent[offset])
 	offset++
@@ -358,7 +367,7 @@ func (c *NtCreateAndxRequest) Unmarshal(data []byte) (int, error) {
 
 	// Unmarshalling parameter SecurityFlags
 	if len(rawParametersContent) < offset+1 {
-		return offset, fmt.Errorf("data too short for SecurityFlags")
+		return offset, fmt.Errorf("rawData too short for SecurityFlags")
 	}
 	c.SecurityFlags = types.UCHAR(rawParametersContent[offset])
 	offset++

--- a/network/smb/smb_v10/message/commands/NtCreateAndxResponse.go
+++ b/network/smb/smb_v10/message/commands/NtCreateAndxResponse.go
@@ -233,16 +233,25 @@ func (c *NtCreateAndxResponse) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *NtCreateAndxResponse) Unmarshal(data []byte) (int, error) {
+func (c *NtCreateAndxResponse) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}
@@ -262,7 +271,7 @@ func (c *NtCreateAndxResponse) Unmarshal(data []byte) (int, error) {
 
 	// Unmarshalling parameter OpLockLevel
 	if len(rawParametersContent) < offset+1 {
-		return offset, fmt.Errorf("data too short for OpLockLevel")
+		return offset, fmt.Errorf("rawData too short for OpLockLevel")
 	}
 	c.OpLockLevel = types.UCHAR(rawParametersContent[offset])
 	offset++
@@ -361,7 +370,7 @@ func (c *NtCreateAndxResponse) Unmarshal(data []byte) (int, error) {
 
 	// Unmarshalling parameter Directory
 	if len(rawParametersContent) < offset+1 {
-		return offset, fmt.Errorf("data too short for Directory")
+		return offset, fmt.Errorf("rawData too short for Directory")
 	}
 	c.Directory = types.UCHAR(rawParametersContent[offset])
 	offset++

--- a/network/smb/smb_v10/message/commands/NtRenameRequest.go
+++ b/network/smb/smb_v10/message/commands/NtRenameRequest.go
@@ -157,16 +157,25 @@ func (c *NtRenameRequest) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *NtRenameRequest) Unmarshal(data []byte) (int, error) {
+func (c *NtRenameRequest) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/NtRenameResponse.go
+++ b/network/smb/smb_v10/message/commands/NtRenameResponse.go
@@ -89,16 +89,25 @@ func (c *NtRenameResponse) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *NtRenameResponse) Unmarshal(data []byte) (int, error) {
+func (c *NtRenameResponse) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	_ = c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/NtTransactRequest.go
+++ b/network/smb/smb_v10/message/commands/NtTransactRequest.go
@@ -290,16 +290,25 @@ func (c *NtTransactRequest) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *NtTransactRequest) Unmarshal(data []byte) (int, error) {
+func (c *NtTransactRequest) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}
@@ -316,7 +325,7 @@ func (c *NtTransactRequest) Unmarshal(data []byte) (int, error) {
 
 	// Unmarshalling parameter MaxSetupCount
 	if len(rawParametersContent) < offset+1 {
-		return offset, fmt.Errorf("data too short for MaxSetupCount")
+		return offset, fmt.Errorf("rawData too short for MaxSetupCount")
 	}
 	c.MaxSetupCount = types.UCHAR(rawParametersContent[offset])
 	offset++
@@ -386,7 +395,7 @@ func (c *NtTransactRequest) Unmarshal(data []byte) (int, error) {
 
 	// Unmarshalling parameter SetupCount
 	if len(rawParametersContent) < offset+1 {
-		return offset, fmt.Errorf("data too short for SetupCount")
+		return offset, fmt.Errorf("rawData too short for SetupCount")
 	}
 	c.SetupCount = types.UCHAR(rawParametersContent[offset])
 	offset++

--- a/network/smb/smb_v10/message/commands/NtTransactSecondaryRequest.go
+++ b/network/smb/smb_v10/message/commands/NtTransactSecondaryRequest.go
@@ -260,16 +260,25 @@ func (c *NtTransactSecondaryRequest) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *NtTransactSecondaryRequest) Unmarshal(data []byte) (int, error) {
+func (c *NtTransactSecondaryRequest) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}
@@ -349,7 +358,7 @@ func (c *NtTransactSecondaryRequest) Unmarshal(data []byte) (int, error) {
 
 	// Unmarshalling parameter Reserved2
 	if len(rawParametersContent) < offset+1 {
-		return offset, fmt.Errorf("data too short for Reserved2")
+		return offset, fmt.Errorf("rawData too short for Reserved2")
 	}
 	c.Reserved2 = types.UCHAR(rawParametersContent[offset])
 	offset++
@@ -380,7 +389,7 @@ func (c *NtTransactSecondaryRequest) Unmarshal(data []byte) (int, error) {
 	// block, Pad2, and data block are accounted for within rawDataContent.
 	pad1Length := len(rawDataContent) - parameterCount - pad2Length - dataCount
 	if pad1Length < 0 {
-		return offset, fmt.Errorf("rawDataContent too short for NT_Trans_Secondary data block")
+		return offset, fmt.Errorf("rawDataContent too short for NT_Trans_Secondary rawData block")
 	}
 
 	// Unmarshalling data Pad1

--- a/network/smb/smb_v10/message/commands/NtTransactSecondaryResponse.go
+++ b/network/smb/smb_v10/message/commands/NtTransactSecondaryResponse.go
@@ -89,16 +89,25 @@ func (c *NtTransactSecondaryResponse) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *NtTransactSecondaryResponse) Unmarshal(data []byte) (int, error) {
+func (c *NtTransactSecondaryResponse) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	_ = c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/OpenAndxRequest.go
+++ b/network/smb/smb_v10/message/commands/OpenAndxRequest.go
@@ -215,16 +215,25 @@ func (c *OpenAndxRequest) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *OpenAndxRequest) Unmarshal(data []byte) (int, error) {
+func (c *OpenAndxRequest) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/OpenAndxResponse.go
+++ b/network/smb/smb_v10/message/commands/OpenAndxResponse.go
@@ -194,16 +194,25 @@ func (c *OpenAndxResponse) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *OpenAndxResponse) Unmarshal(data []byte) (int, error) {
+func (c *OpenAndxResponse) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/OpenPrintFileRequest.go
+++ b/network/smb/smb_v10/message/commands/OpenPrintFileRequest.go
@@ -137,16 +137,25 @@ func (c *OpenPrintFileRequest) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *OpenPrintFileRequest) Unmarshal(data []byte) (int, error) {
+func (c *OpenPrintFileRequest) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/OpenPrintFileResponse.go
+++ b/network/smb/smb_v10/message/commands/OpenPrintFileResponse.go
@@ -108,16 +108,25 @@ func (c *OpenPrintFileResponse) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *OpenPrintFileResponse) Unmarshal(data []byte) (int, error) {
+func (c *OpenPrintFileResponse) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/OpenRequest.go
+++ b/network/smb/smb_v10/message/commands/OpenRequest.go
@@ -141,16 +141,25 @@ func (c *OpenRequest) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *OpenRequest) Unmarshal(data []byte) (int, error) {
+func (c *OpenRequest) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/OpenResponse.go
+++ b/network/smb/smb_v10/message/commands/OpenResponse.go
@@ -147,16 +147,25 @@ func (c *OpenResponse) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *OpenResponse) Unmarshal(data []byte) (int, error) {
+func (c *OpenResponse) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/ProcessExitRequest.go
+++ b/network/smb/smb_v10/message/commands/ProcessExitRequest.go
@@ -89,16 +89,25 @@ func (c *ProcessExitRequest) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *ProcessExitRequest) Unmarshal(data []byte) (int, error) {
+func (c *ProcessExitRequest) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	_ = c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/ProcessExitResponse.go
+++ b/network/smb/smb_v10/message/commands/ProcessExitResponse.go
@@ -89,16 +89,25 @@ func (c *ProcessExitResponse) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *ProcessExitResponse) Unmarshal(data []byte) (int, error) {
+func (c *ProcessExitResponse) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	_ = c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/QueryInformation2Request.go
+++ b/network/smb/smb_v10/message/commands/QueryInformation2Request.go
@@ -108,16 +108,25 @@ func (c *QueryInformation2Request) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *QueryInformation2Request) Unmarshal(data []byte) (int, error) {
+func (c *QueryInformation2Request) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/QueryInformation2Response.go
+++ b/network/smb/smb_v10/message/commands/QueryInformation2Response.go
@@ -195,16 +195,25 @@ func (c *QueryInformation2Response) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *QueryInformation2Response) Unmarshal(data []byte) (int, error) {
+func (c *QueryInformation2Response) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/QueryInformationDiskRequest.go
+++ b/network/smb/smb_v10/message/commands/QueryInformationDiskRequest.go
@@ -89,16 +89,25 @@ func (c *QueryInformationDiskRequest) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *QueryInformationDiskRequest) Unmarshal(data []byte) (int, error) {
+func (c *QueryInformationDiskRequest) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	_ = c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/QueryInformationDiskResponse.go
+++ b/network/smb/smb_v10/message/commands/QueryInformationDiskResponse.go
@@ -148,16 +148,25 @@ func (c *QueryInformationDiskResponse) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *QueryInformationDiskResponse) Unmarshal(data []byte) (int, error) {
+func (c *QueryInformationDiskResponse) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/QueryInformationRequest.go
+++ b/network/smb/smb_v10/message/commands/QueryInformationRequest.go
@@ -109,16 +109,25 @@ func (c *QueryInformationRequest) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *QueryInformationRequest) Unmarshal(data []byte) (int, error) {
+func (c *QueryInformationRequest) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	_ = c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/QueryInformationResponse.go
+++ b/network/smb/smb_v10/message/commands/QueryInformationResponse.go
@@ -135,16 +135,25 @@ func (c *QueryInformationResponse) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *QueryInformationResponse) Unmarshal(data []byte) (int, error) {
+func (c *QueryInformationResponse) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/ReadAndxRequest.go
+++ b/network/smb/smb_v10/message/commands/ReadAndxRequest.go
@@ -182,16 +182,25 @@ func (c *ReadAndxRequest) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *ReadAndxRequest) Unmarshal(data []byte) (int, error) {
+func (c *ReadAndxRequest) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/ReadAndxResponse.go
+++ b/network/smb/smb_v10/message/commands/ReadAndxResponse.go
@@ -165,16 +165,25 @@ func (c *ReadAndxResponse) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *ReadAndxResponse) Unmarshal(data []byte) (int, error) {
+func (c *ReadAndxResponse) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/ReadMpxRequest.go
+++ b/network/smb/smb_v10/message/commands/ReadMpxRequest.go
@@ -158,16 +158,25 @@ func (c *ReadMpxRequest) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *ReadMpxRequest) Unmarshal(data []byte) (int, error) {
+func (c *ReadMpxRequest) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/ReadMpxResponse.go
+++ b/network/smb/smb_v10/message/commands/ReadMpxResponse.go
@@ -197,16 +197,25 @@ func (c *ReadMpxResponse) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *ReadMpxResponse) Unmarshal(data []byte) (int, error) {
+func (c *ReadMpxResponse) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/ReadRawRequest.go
+++ b/network/smb/smb_v10/message/commands/ReadRawRequest.go
@@ -175,16 +175,25 @@ func (c *ReadRawRequest) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *ReadRawRequest) Unmarshal(data []byte) (int, error) {
+func (c *ReadRawRequest) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/ReadRequest.go
+++ b/network/smb/smb_v10/message/commands/ReadRequest.go
@@ -142,16 +142,25 @@ func (c *ReadRequest) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *ReadRequest) Unmarshal(data []byte) (int, error) {
+func (c *ReadRequest) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/ReadResponse.go
+++ b/network/smb/smb_v10/message/commands/ReadResponse.go
@@ -138,16 +138,25 @@ func (c *ReadResponse) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *ReadResponse) Unmarshal(data []byte) (int, error) {
+func (c *ReadResponse) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/RenameRequest.go
+++ b/network/smb/smb_v10/message/commands/RenameRequest.go
@@ -146,16 +146,25 @@ func (c *RenameRequest) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *RenameRequest) Unmarshal(data []byte) (int, error) {
+func (c *RenameRequest) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/RenameResponse.go
+++ b/network/smb/smb_v10/message/commands/RenameResponse.go
@@ -89,16 +89,25 @@ func (c *RenameResponse) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *RenameResponse) Unmarshal(data []byte) (int, error) {
+func (c *RenameResponse) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	_ = c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/SearchRequest.go
+++ b/network/smb/smb_v10/message/commands/SearchRequest.go
@@ -168,16 +168,25 @@ func (c *SearchRequest) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *SearchRequest) Unmarshal(data []byte) (int, error) {
+func (c *SearchRequest) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/SearchResponse.go
+++ b/network/smb/smb_v10/message/commands/SearchResponse.go
@@ -131,16 +131,25 @@ func (c *SearchResponse) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *SearchResponse) Unmarshal(data []byte) (int, error) {
+func (c *SearchResponse) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/SeekRequest.go
+++ b/network/smb/smb_v10/message/commands/SeekRequest.go
@@ -127,16 +127,25 @@ func (c *SeekRequest) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *SeekRequest) Unmarshal(data []byte) (int, error) {
+func (c *SeekRequest) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/SeekResponse.go
+++ b/network/smb/smb_v10/message/commands/SeekResponse.go
@@ -109,16 +109,25 @@ func (c *SeekResponse) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *SeekResponse) Unmarshal(data []byte) (int, error) {
+func (c *SeekResponse) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/SessionSetupAndxRequest.go
+++ b/network/smb/smb_v10/message/commands/SessionSetupAndxRequest.go
@@ -388,16 +388,25 @@ func (c *SessionSetupAndxRequest) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *SessionSetupAndxRequest) Unmarshal(data []byte) (int, error) {
+func (c *SessionSetupAndxRequest) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/SessionSetupAndxResponse.go
+++ b/network/smb/smb_v10/message/commands/SessionSetupAndxResponse.go
@@ -168,16 +168,25 @@ func (c *SessionSetupAndxResponse) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *SessionSetupAndxResponse) Unmarshal(data []byte) (int, error) {
+func (c *SessionSetupAndxResponse) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/SetInformation2Request.go
+++ b/network/smb/smb_v10/message/commands/SetInformation2Request.go
@@ -176,16 +176,25 @@ func (c *SetInformation2Request) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *SetInformation2Request) Unmarshal(data []byte) (int, error) {
+func (c *SetInformation2Request) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/SetInformation2Response.go
+++ b/network/smb/smb_v10/message/commands/SetInformation2Response.go
@@ -89,16 +89,25 @@ func (c *SetInformation2Response) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *SetInformation2Response) Unmarshal(data []byte) (int, error) {
+func (c *SetInformation2Response) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	_ = c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/SetInformationRequest.go
+++ b/network/smb/smb_v10/message/commands/SetInformationRequest.go
@@ -146,16 +146,25 @@ func (c *SetInformationRequest) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *SetInformationRequest) Unmarshal(data []byte) (int, error) {
+func (c *SetInformationRequest) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/SetInformationResponse.go
+++ b/network/smb/smb_v10/message/commands/SetInformationResponse.go
@@ -89,16 +89,25 @@ func (c *SetInformationResponse) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *SetInformationResponse) Unmarshal(data []byte) (int, error) {
+func (c *SetInformationResponse) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	_ = c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/Transaction2Request.go
+++ b/network/smb/smb_v10/message/commands/Transaction2Request.go
@@ -342,16 +342,25 @@ func (c *Transaction2Request) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *Transaction2Request) Unmarshal(data []byte) (int, error) {
+func (c *Transaction2Request) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}
@@ -396,14 +405,14 @@ func (c *Transaction2Request) Unmarshal(data []byte) (int, error) {
 
 	// Unmarshalling parameter MaxSetupCount
 	if len(rawParametersContent) < offset+1 {
-		return offset, fmt.Errorf("data too short for MaxSetupCount")
+		return offset, fmt.Errorf("rawData too short for MaxSetupCount")
 	}
 	c.MaxSetupCount = types.UCHAR(rawParametersContent[offset])
 	offset++
 
 	// Unmarshalling parameter Reserved1
 	if len(rawParametersContent) < offset+1 {
-		return offset, fmt.Errorf("data too short for Reserved1")
+		return offset, fmt.Errorf("rawData too short for Reserved1")
 	}
 	c.Reserved1 = types.UCHAR(rawParametersContent[offset])
 	offset++
@@ -459,14 +468,14 @@ func (c *Transaction2Request) Unmarshal(data []byte) (int, error) {
 
 	// Unmarshalling parameter SetupCount
 	if len(rawParametersContent) < offset+1 {
-		return offset, fmt.Errorf("data too short for SetupCount")
+		return offset, fmt.Errorf("rawData too short for SetupCount")
 	}
 	c.SetupCount = types.UCHAR(rawParametersContent[offset])
 	offset++
 
 	// Unmarshalling parameter Reserved3
 	if len(rawParametersContent) < offset+1 {
-		return offset, fmt.Errorf("data too short for Reserved3")
+		return offset, fmt.Errorf("rawData too short for Reserved3")
 	}
 	c.Reserved3 = types.UCHAR(rawParametersContent[offset])
 	offset++

--- a/network/smb/smb_v10/message/commands/Transaction2Response.go
+++ b/network/smb/smb_v10/message/commands/Transaction2Response.go
@@ -273,16 +273,25 @@ func (c *Transaction2Response) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *Transaction2Response) Unmarshal(data []byte) (int, error) {
+func (c *Transaction2Response) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/Transaction2SecondaryRequest.go
+++ b/network/smb/smb_v10/message/commands/Transaction2SecondaryRequest.go
@@ -255,16 +255,25 @@ func (c *Transaction2SecondaryRequest) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *Transaction2SecondaryRequest) Unmarshal(data []byte) (int, error) {
+func (c *Transaction2SecondaryRequest) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/Transaction2SecondaryResponse.go
+++ b/network/smb/smb_v10/message/commands/Transaction2SecondaryResponse.go
@@ -90,16 +90,25 @@ func (c *Transaction2SecondaryResponse) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *Transaction2SecondaryResponse) Unmarshal(data []byte) (int, error) {
+func (c *Transaction2SecondaryResponse) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	_ = c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/TransactionRequest.go
+++ b/network/smb/smb_v10/message/commands/TransactionRequest.go
@@ -381,16 +381,25 @@ func (c *TransactionRequest) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *TransactionRequest) Unmarshal(data []byte) (int, error) {
+func (c *TransactionRequest) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}
@@ -435,14 +444,14 @@ func (c *TransactionRequest) Unmarshal(data []byte) (int, error) {
 
 	// Unmarshalling parameter MaxSetupCount
 	if len(rawParametersContent) < offset+1 {
-		return offset, fmt.Errorf("data too short for MaxSetupCount")
+		return offset, fmt.Errorf("rawData too short for MaxSetupCount")
 	}
 	c.MaxSetupCount = types.UCHAR(rawParametersContent[offset])
 	offset++
 
 	// Unmarshalling parameter Reserved1
 	if len(rawParametersContent) < offset+1 {
-		return offset, fmt.Errorf("data too short for Reserved1")
+		return offset, fmt.Errorf("rawData too short for Reserved1")
 	}
 	c.Reserved1 = types.UCHAR(rawParametersContent[offset])
 	offset++
@@ -498,14 +507,14 @@ func (c *TransactionRequest) Unmarshal(data []byte) (int, error) {
 
 	// Unmarshalling parameter SetupCount
 	if len(rawParametersContent) < offset+1 {
-		return offset, fmt.Errorf("data too short for SetupCount")
+		return offset, fmt.Errorf("rawData too short for SetupCount")
 	}
 	c.SetupCount = types.UCHAR(rawParametersContent[offset])
 	offset++
 
 	// Unmarshalling parameter Reserved3
 	if len(rawParametersContent) < offset+1 {
-		return offset, fmt.Errorf("data too short for Reserved3")
+		return offset, fmt.Errorf("rawData too short for Reserved3")
 	}
 	c.Reserved3 = types.UCHAR(rawParametersContent[offset])
 	offset++

--- a/network/smb/smb_v10/message/commands/TransactionResponse.go
+++ b/network/smb/smb_v10/message/commands/TransactionResponse.go
@@ -95,16 +95,25 @@ func (c *TransactionResponse) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *TransactionResponse) Unmarshal(data []byte) (int, error) {
+func (c *TransactionResponse) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	_ = c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/TransactionSecondaryRequest.go
+++ b/network/smb/smb_v10/message/commands/TransactionSecondaryRequest.go
@@ -244,16 +244,25 @@ func (c *TransactionSecondaryRequest) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *TransactionSecondaryRequest) Unmarshal(data []byte) (int, error) {
+func (c *TransactionSecondaryRequest) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/TransactionSecondaryResponse.go
+++ b/network/smb/smb_v10/message/commands/TransactionSecondaryResponse.go
@@ -89,16 +89,25 @@ func (c *TransactionSecondaryResponse) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *TransactionSecondaryResponse) Unmarshal(data []byte) (int, error) {
+func (c *TransactionSecondaryResponse) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	_ = c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/TreeConnectAndxResponse.go
+++ b/network/smb/smb_v10/message/commands/TreeConnectAndxResponse.go
@@ -140,16 +140,25 @@ func (c *TreeConnectAndxResponse) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *TreeConnectAndxResponse) Unmarshal(data []byte) (int, error) {
+func (c *TreeConnectAndxResponse) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/TreeConnectResponse.go
+++ b/network/smb/smb_v10/message/commands/TreeConnectResponse.go
@@ -123,16 +123,25 @@ func (c *TreeConnectResponse) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *TreeConnectResponse) Unmarshal(data []byte) (int, error) {
+func (c *TreeConnectResponse) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/TreeDisconnectRequest.go
+++ b/network/smb/smb_v10/message/commands/TreeDisconnectRequest.go
@@ -89,16 +89,25 @@ func (c *TreeDisconnectRequest) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *TreeDisconnectRequest) Unmarshal(data []byte) (int, error) {
+func (c *TreeDisconnectRequest) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	_ = c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/TreeDisconnectResponse.go
+++ b/network/smb/smb_v10/message/commands/TreeDisconnectResponse.go
@@ -89,16 +89,25 @@ func (c *TreeDisconnectResponse) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *TreeDisconnectResponse) Unmarshal(data []byte) (int, error) {
+func (c *TreeDisconnectResponse) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	_ = c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/UnlockByteRangeRequest.go
+++ b/network/smb/smb_v10/message/commands/UnlockByteRangeRequest.go
@@ -129,16 +129,25 @@ func (c *UnlockByteRangeRequest) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *UnlockByteRangeRequest) Unmarshal(data []byte) (int, error) {
+func (c *UnlockByteRangeRequest) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/UnlockByteRangeResponse.go
+++ b/network/smb/smb_v10/message/commands/UnlockByteRangeResponse.go
@@ -89,16 +89,25 @@ func (c *UnlockByteRangeResponse) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *UnlockByteRangeResponse) Unmarshal(data []byte) (int, error) {
+func (c *UnlockByteRangeResponse) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	_ = c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/WriteAndCloseRequest.go
+++ b/network/smb/smb_v10/message/commands/WriteAndCloseRequest.go
@@ -182,16 +182,25 @@ func (c *WriteAndCloseRequest) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *WriteAndCloseRequest) Unmarshal(data []byte) (int, error) {
+func (c *WriteAndCloseRequest) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/WriteAndCloseResponse.go
+++ b/network/smb/smb_v10/message/commands/WriteAndCloseResponse.go
@@ -110,16 +110,25 @@ func (c *WriteAndCloseResponse) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *WriteAndCloseResponse) Unmarshal(data []byte) (int, error) {
+func (c *WriteAndCloseResponse) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/WriteAndUnlockRequest.go
+++ b/network/smb/smb_v10/message/commands/WriteAndUnlockRequest.go
@@ -161,16 +161,25 @@ func (c *WriteAndUnlockRequest) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *WriteAndUnlockRequest) Unmarshal(data []byte) (int, error) {
+func (c *WriteAndUnlockRequest) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/WriteAndUnlockResponse.go
+++ b/network/smb/smb_v10/message/commands/WriteAndUnlockResponse.go
@@ -110,16 +110,25 @@ func (c *WriteAndUnlockResponse) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *WriteAndUnlockResponse) Unmarshal(data []byte) (int, error) {
+func (c *WriteAndUnlockResponse) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/WriteAndxRequest.go
+++ b/network/smb/smb_v10/message/commands/WriteAndxRequest.go
@@ -222,16 +222,25 @@ func (c *WriteAndxRequest) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *WriteAndxRequest) Unmarshal(data []byte) (int, error) {
+func (c *WriteAndxRequest) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/WriteAndxResponse.go
+++ b/network/smb/smb_v10/message/commands/WriteAndxResponse.go
@@ -132,16 +132,25 @@ func (c *WriteAndxResponse) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *WriteAndxResponse) Unmarshal(data []byte) (int, error) {
+func (c *WriteAndxResponse) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/WriteMpxRequest.go
+++ b/network/smb/smb_v10/message/commands/WriteMpxRequest.go
@@ -205,16 +205,25 @@ func (c *WriteMpxRequest) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *WriteMpxRequest) Unmarshal(data []byte) (int, error) {
+func (c *WriteMpxRequest) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/WriteMpxResponse.go
+++ b/network/smb/smb_v10/message/commands/WriteMpxResponse.go
@@ -111,16 +111,25 @@ func (c *WriteMpxResponse) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *WriteMpxResponse) Unmarshal(data []byte) (int, error) {
+func (c *WriteMpxResponse) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/WritePrintFileRequest.go
+++ b/network/smb/smb_v10/message/commands/WritePrintFileRequest.go
@@ -125,16 +125,25 @@ func (c *WritePrintFileRequest) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *WritePrintFileRequest) Unmarshal(data []byte) (int, error) {
+func (c *WritePrintFileRequest) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/WritePrintFileResponse.go
+++ b/network/smb/smb_v10/message/commands/WritePrintFileResponse.go
@@ -89,16 +89,25 @@ func (c *WritePrintFileResponse) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *WritePrintFileResponse) Unmarshal(data []byte) (int, error) {
+func (c *WritePrintFileResponse) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	_ = c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/WriteRawFinal.go
+++ b/network/smb/smb_v10/message/commands/WriteRawFinal.go
@@ -107,16 +107,25 @@ func (c *WriteRawFinal) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *WriteRawFinal) Unmarshal(data []byte) (int, error) {
+func (c *WriteRawFinal) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/WriteRawInterim.go
+++ b/network/smb/smb_v10/message/commands/WriteRawInterim.go
@@ -109,16 +109,25 @@ func (c *WriteRawInterim) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *WriteRawInterim) Unmarshal(data []byte) (int, error) {
+func (c *WriteRawInterim) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/WriteRawRequest.go
+++ b/network/smb/smb_v10/message/commands/WriteRawRequest.go
@@ -230,16 +230,25 @@ func (c *WriteRawRequest) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *WriteRawRequest) Unmarshal(data []byte) (int, error) {
+func (c *WriteRawRequest) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/WriteRequest.go
+++ b/network/smb/smb_v10/message/commands/WriteRequest.go
@@ -161,16 +161,25 @@ func (c *WriteRequest) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *WriteRequest) Unmarshal(data []byte) (int, error) {
+func (c *WriteRequest) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/WriteResponse.go
+++ b/network/smb/smb_v10/message/commands/WriteResponse.go
@@ -111,16 +111,25 @@ func (c *WriteResponse) Marshal() ([]byte, error) {
 //
 // Returns:
 // - The number of bytes unmarshalled
-func (c *WriteResponse) Unmarshal(data []byte) (int, error) {
+func (c *WriteResponse) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
 	offset := 0
 
 	// First unmarshal the two structures
-	bytesRead, err := c.GetParameters().Unmarshal(data)
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(data[bytesRead:])
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/nil_unmarshal_sweep_test.go
+++ b/network/smb/smb_v10/message/commands/nil_unmarshal_sweep_test.go
@@ -1,0 +1,103 @@
+package commands_test
+
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/codes"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/command_interface"
+)
+
+// allCommandCodes lists every command code handled by the request/response
+// casting registry.
+var allCommandCodes = []codes.CommandCode{
+	codes.SMB_COM_CHECK_DIRECTORY,
+	codes.SMB_COM_CLOSE,
+	codes.SMB_COM_CLOSE_PRINT_FILE,
+	codes.SMB_COM_CREATE,
+	codes.SMB_COM_CREATE_DIRECTORY,
+	codes.SMB_COM_CREATE_NEW,
+	codes.SMB_COM_CREATE_TEMPORARY,
+	codes.SMB_COM_DELETE,
+	codes.SMB_COM_DELETE_DIRECTORY,
+	codes.SMB_COM_ECHO,
+	codes.SMB_COM_FIND,
+	codes.SMB_COM_FIND_CLOSE,
+	codes.SMB_COM_FIND_CLOSE2,
+	codes.SMB_COM_FIND_UNIQUE,
+	codes.SMB_COM_FLUSH,
+	codes.SMB_COM_IOCTL,
+	codes.SMB_COM_LOCK_AND_READ,
+	codes.SMB_COM_LOCK_BYTE_RANGE,
+	codes.SMB_COM_LOCKING_ANDX,
+	codes.SMB_COM_LOGOFF_ANDX,
+	codes.SMB_COM_NEGOTIATE,
+	codes.SMB_COM_NT_CANCEL,
+	codes.SMB_COM_NT_CREATE_ANDX,
+	codes.SMB_COM_NT_RENAME,
+	codes.SMB_COM_NT_TRANSACT,
+	codes.SMB_COM_NT_TRANSACT_SECONDARY,
+	codes.SMB_COM_OPEN,
+	codes.SMB_COM_OPEN_ANDX,
+	codes.SMB_COM_OPEN_PRINT_FILE,
+	codes.SMB_COM_PROCESS_EXIT,
+	codes.SMB_COM_QUERY_INFORMATION,
+	codes.SMB_COM_QUERY_INFORMATION2,
+	codes.SMB_COM_QUERY_INFORMATION_DISK,
+	codes.SMB_COM_READ,
+	codes.SMB_COM_READ_ANDX,
+	codes.SMB_COM_READ_MPX,
+	codes.SMB_COM_READ_RAW,
+	codes.SMB_COM_RENAME,
+	codes.SMB_COM_SEARCH,
+	codes.SMB_COM_SEEK,
+	codes.SMB_COM_SESSION_SETUP_ANDX,
+	codes.SMB_COM_SET_INFORMATION,
+	codes.SMB_COM_SET_INFORMATION2,
+	codes.SMB_COM_TRANSACTION,
+	codes.SMB_COM_TRANSACTION2,
+	codes.SMB_COM_TRANSACTION2_SECONDARY,
+	codes.SMB_COM_TRANSACTION_SECONDARY,
+	codes.SMB_COM_TREE_CONNECT,
+	codes.SMB_COM_TREE_CONNECT_ANDX,
+	codes.SMB_COM_TREE_DISCONNECT,
+	codes.SMB_COM_UNLOCK_BYTE_RANGE,
+	codes.SMB_COM_WRITE,
+	codes.SMB_COM_WRITE_AND_CLOSE,
+	codes.SMB_COM_WRITE_AND_UNLOCK,
+	codes.SMB_COM_WRITE_ANDX,
+	codes.SMB_COM_WRITE_MPX,
+	codes.SMB_COM_WRITE_PRINT_FILE,
+	codes.SMB_COM_WRITE_RAW,
+}
+
+// TestUnmarshalOnFreshCommandDoesNotNilPanic verifies that Unmarshal initializes
+// its embedded Parameters/Data structures (mirroring Marshal) before using them,
+// so calling Unmarshal on a freshly constructed command does not dereference a
+// nil pointer. An empty input is used so the call returns early with an error
+// instead of exercising unrelated field-parsing paths; without the nil-init
+// guard, GetParameters()/GetData() would be nil and the call would panic.
+func TestUnmarshalOnFreshCommandDoesNotNilPanic(t *testing.T) {
+	producers := map[string]func(codes.CommandCode) (command_interface.CommandInterface, error){
+		"request":  commands.CreateRequestCommand,
+		"response": commands.CreateResponseCommand,
+	}
+	for _, code := range allCommandCodes {
+		for kind, produce := range producers {
+			code, kind, produce := code, kind, produce
+			t.Run(kind+"/"+code.String(), func(t *testing.T) {
+				cmd, err := produce(code)
+				if err != nil || cmd == nil {
+					t.Skipf("no %s constructor for %s", kind, code.String())
+				}
+				defer func() {
+					if r := recover(); r != nil {
+						t.Fatalf("Unmarshal panicked on fresh %s %s: %v", kind, code.String(), r)
+					}
+				}()
+				// Must not panic on a freshly constructed command; an error is fine.
+				_, _ = cmd.Unmarshal([]byte{0x00, 0x00, 0x00})
+			})
+		}
+	}
+}


### PR DESCRIPTION
## Description

Most command `Unmarshal` methods in `network/smb/smb_v10/message/commands` call `c.GetParameters().Unmarshal(...)` / `c.GetData().Unmarshal(...)` without first initializing the embedded `Parameters`/`Data` structures. Constructors leave them nil and only `Marshal` lazily creates them, so calling `Unmarshal` on a freshly constructed command (e.g. via `CreateRequestCommand`/`CreateResponseCommand`) dereferences a nil pointer and panics — a DoS on any code path that unmarshals into a fresh command.

This is the same defect already fixed individually in #265 and #312; **111** command files were still affected.

## Change (mechanical, uniform per file)

- Add the nil-init guard that `Marshal` already uses to the top of each affected `Unmarshal`:
  ```go
  if c.GetParameters() == nil { c.SetParameters(parameters.NewParameters()) }
  if c.GetData() == nil { c.SetData(data.NewData()) }
  ```
- Rename the `data []byte` parameter to `rawData` so it no longer shadows the imported `data` package (matching the approach in the merged #323/#326).

## Test

Adds `TestUnmarshalOnFreshCommandDoesNotNilPanic` — a registry-driven table test that constructs **every** request and response type via the casting registry and asserts `Unmarshal` on a freshly constructed command does not panic. Verified it fails before the fix and passes after. `go build ./...`, `go vet`, and the full `commands` package tests pass.

## Out of scope (noted for follow-up)

While writing the test I observed two unrelated pre-existing bugs, **not** addressed here: a `NegotiateResponse.Unmarshal` slice-bounds panic on a full round-trip, and a stray debug `Println` (21-byte zero slice) reachable via `SMB_RESUME_KEY`. These deserve their own issues.

Closes #340