### PR TITLE
[bugfix] Remove leftover debug fmt.Println from SMB_RESUME_KEY.Unmarshal (#342)

### DIFF
--- a/network/cifs/types/SMB_RESUME_KEY.go
+++ b/network/cifs/types/SMB_RESUME_KEY.go
@@ -92,7 +92,6 @@ func (r *SMB_RESUME_KEY) Unmarshal(data []byte) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	fmt.Println(r.SMB_STRING.Buffer)
 	if len(r.SMB_STRING.Buffer) < 21 {
 		return 0, fmt.Errorf("SMB_STRING.Buffer length is not 21")
 	}

--- a/network/smb/smb_v10/types/SMB_RESUME_KEY.go
+++ b/network/smb/smb_v10/types/SMB_RESUME_KEY.go
@@ -92,7 +92,6 @@ func (r *SMB_RESUME_KEY) Unmarshal(data []byte) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	fmt.Println(r.SMB_STRING.Buffer)
 	if len(r.SMB_STRING.Buffer) < 21 {
 		return 0, fmt.Errorf("SMB_STRING.Buffer length is not 21")
 	}


### PR DESCRIPTION
## Description

`SMB_RESUME_KEY.Unmarshal` contained a leftover debug `fmt.Println(r.SMB_STRING.Buffer)` that printed the raw resume-key buffer to stdout on every unmarshal (visible e.g. during FIND_UNIQUE/SEARCH round-trips). Removed from both mirrored copies (`network/smb/smb_v10/types` and `network/cifs/types`). `fmt` remains used by `Errorf`, so the import is unchanged.

`go build ./...` and the affected type tests pass.

Closes #342