### PR TITLE
[bugfix] Fix NegotiateResponse.Unmarshal slice-bounds panic on non-extended responses (#344)

### DIFF
--- a/network/smb/smb_v10/message/commands/NegotiateResponse.go
+++ b/network/smb/smb_v10/message/commands/NegotiateResponse.go
@@ -417,17 +417,27 @@ func (c *NegotiateResponse) Unmarshal(marshalledData []byte) (int, error) {
 		}
 		c.Challenge = rawDataContent[offset : offset+int(c.ChallengeLength)]
 		offset += int(c.ChallengeLength)
-		rawDataContent = rawDataContent[offset:]
 
-		// Unmarshalling data DomainName
-		domainName, offset := utils.GetNullTerminatedUnicodeString(rawDataContent)
+		// Unmarshalling data DomainName (null-terminated UTF-16LE) from the remaining bytes.
+		// GetNullTerminatedUnicodeString returns len(string)+2, which can exceed the
+		// remaining length when there is no terminator (e.g. empty data), so clamp before
+		// advancing to avoid a slice-bounds panic.
+		rest := rawDataContent[offset:]
+		domainName, n := utils.GetNullTerminatedUnicodeString(rest)
 		c.DomainName = []types.UCHAR(domainName)
-		rawDataContent = rawDataContent[offset:]
+		if n > len(rest) {
+			n = len(rest)
+		}
+		offset += n
+		rest = rest[n:]
 
-		// Unmarshalling data ServerName
-		serverName, offset := utils.GetNullTerminatedUnicodeString(rawDataContent)
+		// Unmarshalling data ServerName (null-terminated UTF-16LE)
+		serverName, m := utils.GetNullTerminatedUnicodeString(rest)
 		c.ServerName = []types.UCHAR(serverName)
-		// rawDataContent = rawDataContent[offset:]
+		if m > len(rest) {
+			m = len(rest)
+		}
+		offset += m
 	}
 
 	return offset, nil

--- a/network/smb/smb_v10/message/commands/NegotiateResponse_unmarshal_test.go
+++ b/network/smb/smb_v10/message/commands/NegotiateResponse_unmarshal_test.go
@@ -1,0 +1,34 @@
+package commands_test
+
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+)
+
+// TestNegotiateResponseUnmarshalNonExtendedNoPanic reproduces the slice-bounds
+// panic that occurred when unmarshalling a non-extended-security NegotiateResponse
+// whose data block is empty: GetNullTerminatedUnicodeString returns an offset of
+// len(string)+2, which exceeded the remaining bytes and caused a [2:0] slice on
+// the DomainName/ServerName reads. The Unmarshal must clamp the offset and not panic.
+func TestNegotiateResponseUnmarshalNonExtendedNoPanic(t *testing.T) {
+	// Default response: Capabilities has no CAP_EXTENDED_SECURITY bit, so the
+	// non-extended (Challenge + DomainName + ServerName) data layout is used.
+	out := commands.NewNegotiateResponse()
+
+	marshalled, err := out.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Unmarshal panicked: %v", r)
+		}
+	}()
+
+	in := commands.NewNegotiateResponse()
+	if _, err := in.Unmarshal(marshalled); err != nil {
+		t.Logf("Unmarshal returned error (acceptable): %v", err)
+	}
+}


### PR DESCRIPTION
## Description

`NegotiateResponse.Unmarshal` panicked with `slice bounds out of range [2:0]` when decoding a non-extended-security response (no `CAP_EXTENDED_SECURITY`) whose data block is empty or lacks a UTF-16 null terminator.

`utils.GetNullTerminatedUnicodeString` returns `len(string)+2` even when the input is empty/unterminated (no terminator actually consumed). The DomainName/ServerName decoding advanced `rawDataContent` by that offset (`rawDataContent[offset:]`), slicing past the end. The block also shadowed the outer `offset` with `:=`, so the returned byte count was wrong.

## Fix

- Clamp the offset returned by `GetNullTerminatedUnicodeString` against the remaining length before advancing/slicing.
- Remove the `offset` shadowing so the accumulated value is returned correctly.
- Add `TestNegotiateResponseUnmarshalNonExtendedNoPanic` (reproduces the panic; passes with the fix).

`go build ./...`, `go vet`, and the full `commands` package tests pass.

## Note

The underlying `utils.GetNullTerminatedUnicodeString` returning `len+2` for unterminated/empty input is fragile and shared (mirrored in `network/cifs` and `network/smb/smb_v10`); other callers may want the same guarding. Left out of scope here to keep the fix targeted.

Closes #344