### PR TITLE
[enhancement] Add client.FindFiles directory enumeration via TRANS2_FIND_FIRST2/FIND_NEXT2 (#346)

### DIFF
--- a/network/smb/smb_v10/client/find.go
+++ b/network/smb/smb_v10/client/find.go
@@ -1,0 +1,318 @@
+package client
+
+import (
+	"encoding/binary"
+	"fmt"
+	"strings"
+	"time"
+	"unicode/utf16"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/codes"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/subcommands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+)
+
+// smbFindFileBothDirectoryInfo is the TRANS2_FIND information level
+// SMB_FIND_FILE_BOTH_DIRECTORY_INFO (MS-CIFS 2.2.8.1.7).
+const smbFindFileBothDirectoryInfo = 0x0104
+
+// fileAttributeDirectory is the SMB_EXT_FILE_ATTR bit marking a directory.
+const fileAttributeDirectory = 0x00000010
+
+// bothDirInfoFixedSize is the size of the fixed portion of an
+// SMB_FIND_FILE_BOTH_DIRECTORY_INFO entry, before the variable FileName:
+// NextEntryOffset(4) FileIndex(4) 4xFILETIME(32) EndOfFile(8) AllocationSize(8)
+// ExtFileAttributes(4) FileNameLength(4) EaSize(4) ShortNameLength(1) Reserved(1)
+// ShortName(24).
+const bothDirInfoFixedSize = 94
+
+// FileEntry is a high-level directory entry returned by FindFiles.
+type FileEntry struct {
+	LongName    string
+	ShortName   string
+	Size        uint64
+	Attributes  uint32
+	CreatedAt   time.Time
+	AccessedAt  time.Time
+	ModifiedAt  time.Time
+	ChangedAt   time.Time
+	IsDirectory bool
+}
+
+// FindFiles enumerates entries matching pattern in the current tree, using
+// TRANS2_FIND_FIRST2 followed by as many TRANS2_FIND_NEXT2 calls as needed, and
+// always closing the search with FindClose2.
+//
+// pattern uses SMB wildcards and backslash separators relative to the share root
+// (for example "\*" lists the root). An empty pattern defaults to "\*".
+func (c *Client) FindFiles(pattern string) ([]FileEntry, error) {
+	if c.Session == nil {
+		return nil, fmt.Errorf("no session established")
+	}
+
+	if pattern == "" {
+		pattern = "\\*"
+	}
+	if pattern[0] != '\\' {
+		pattern = "\\" + pattern
+	}
+
+	// TRANS2_FIND_FIRST2.
+	respParams, respData, err := c.trans2(uint16(subcommands.TRANS2_FIND_FIRST2), buildFindFirst2Params(pattern), nil)
+	if err != nil {
+		return nil, err
+	}
+	if len(respParams) < 6 {
+		return nil, fmt.Errorf("FIND_FIRST2 response parameters too short (%d bytes)", len(respParams))
+	}
+
+	sid := binary.LittleEndian.Uint16(respParams[0:2])
+	searchCount := binary.LittleEndian.Uint16(respParams[2:4])
+	endOfSearch := binary.LittleEndian.Uint16(respParams[4:6])
+
+	entries := parseBothDirInfo(respData)
+
+	// TRANS2_FIND_NEXT2 until the server reports end-of-search or returns nothing.
+	for endOfSearch == 0 && searchCount > 0 {
+		respParams, respData, err = c.trans2(uint16(subcommands.TRANS2_FIND_NEXT2), buildFindNext2Params(sid), nil)
+		if err != nil {
+			break
+		}
+		if len(respParams) < 4 {
+			break
+		}
+		searchCount = binary.LittleEndian.Uint16(respParams[0:2])
+		endOfSearch = binary.LittleEndian.Uint16(respParams[2:4])
+
+		next := parseBothDirInfo(respData)
+		if len(next) == 0 {
+			break
+		}
+		entries = append(entries, next...)
+	}
+
+	// Always release the search handle, even on a partial enumeration.
+	_ = c.findClose2(sid)
+
+	return entries, nil
+}
+
+// trans2 issues a single SMB_COM_TRANSACTION2 carrying the given subcommand, with
+// the supplied transaction parameter and data buffers, and returns the reassembled
+// response parameter and data buffers. It does not implement Transaction2Secondary
+// fragmentation, so the request must fit in a single message.
+func (c *Client) trans2(subcommand uint16, trans2Params, trans2Data []byte) ([]byte, []byte, error) {
+	msg := c.newFileIOMessage(codes.SMB_COM_TRANSACTION2)
+
+	cmd := commands.NewTransaction2Request()
+	cmd.Setup = []types.USHORT{types.USHORT(subcommand)}
+	cmd.MaxParameterCount = types.USHORT(1024)
+	cmd.MaxSetupCount = types.UCHAR(0)
+	cmd.Flags = types.USHORT(0)
+	cmd.Timeout = types.ULONG(0)
+
+	// Bound the data the server may return by the negotiated buffer.
+	maxData := 0xFFFF
+	if c.Connection.Server != nil && c.Connection.Server.MaxBufferSize > 0 {
+		if budget := int(c.Connection.Server.MaxBufferSize) - 512; budget > 0 && budget < maxData {
+			maxData = budget
+		}
+	}
+	cmd.MaxDataCount = types.USHORT(maxData)
+
+	// Compute offsets. The request always carries exactly one setup word, so
+	// WordCount = 14 fixed words + 1 setup word = 15.
+	const wordCount = 14 + 1
+	// Bytes from the start of the SMB header to the end of the Name byte: the data
+	// block on the wire is ByteCount(2) + Name(1) + Pad1 + Trans2_Parameters + ...
+	preParams := header.SMB_HEADER_SIZE + 1 /*WordCount*/ + 2*wordCount + 2 /*ByteCount*/ + 1 /*Name*/
+	pad1 := (4 - (preParams % 4)) % 4
+	parameterOffset := preParams + pad1
+
+	cmd.TotalParameterCount = types.USHORT(len(trans2Params))
+	cmd.ParameterCount = types.USHORT(len(trans2Params))
+	cmd.ParameterOffset = types.USHORT(parameterOffset)
+	cmd.Pad1 = make([]types.UCHAR, pad1)
+	cmd.Trans2_Parameters = []types.UCHAR(trans2Params)
+
+	if len(trans2Data) > 0 {
+		afterParams := parameterOffset + len(trans2Params)
+		pad2 := (4 - (afterParams % 4)) % 4
+		cmd.TotalDataCount = types.USHORT(len(trans2Data))
+		cmd.DataCount = types.USHORT(len(trans2Data))
+		cmd.DataOffset = types.USHORT(afterParams + pad2)
+		cmd.Pad2 = make([]types.UCHAR, pad2)
+		cmd.Trans2_Data = []types.UCHAR(trans2Data)
+	}
+
+	msg.AddCommand(cmd)
+
+	response, raw, err := c.sendReceive(msg, "Transaction2")
+	if err != nil {
+		return nil, nil, err
+	}
+	if response.Header.Status != 0x00000000 {
+		return nil, nil, fmt.Errorf("Transaction2 (subcommand 0x%04x) failed: 0x%08x", subcommand, response.Header.Status)
+	}
+
+	return parseTrans2Response(raw)
+}
+
+// parseTrans2Response extracts the transaction parameter and data buffers from a
+// raw SMB_COM_TRANSACTION2 response, using the response ParameterOffset/DataOffset
+// (which are measured from the start of the SMB header) to locate them.
+func parseTrans2Response(raw []byte) ([]byte, []byte, error) {
+	hdr := header.SMB_HEADER_SIZE
+	if len(raw) < hdr+1 {
+		return nil, nil, fmt.Errorf("Transaction2 response too short")
+	}
+
+	wordCount := int(raw[hdr])
+	wordsStart := hdr + 1
+	if len(raw) < wordsStart+2*wordCount {
+		return nil, nil, fmt.Errorf("Transaction2 response parameter words truncated")
+	}
+	// The standard response has WordCount 0x0A (10 words) before any setup words.
+	if wordCount < 10 {
+		return []byte{}, []byte{}, nil
+	}
+
+	w := raw[wordsStart:]
+	paramCount := int(binary.LittleEndian.Uint16(w[6:8]))
+	paramOffset := int(binary.LittleEndian.Uint16(w[8:10]))
+	dataCount := int(binary.LittleEndian.Uint16(w[12:14]))
+	dataOffset := int(binary.LittleEndian.Uint16(w[14:16]))
+
+	var params, data []byte
+	if paramCount > 0 {
+		if paramOffset < 0 || paramOffset+paramCount > len(raw) {
+			return nil, nil, fmt.Errorf("Transaction2 parameter window [%d:%d] out of bounds (%d bytes)", paramOffset, paramOffset+paramCount, len(raw))
+		}
+		params = raw[paramOffset : paramOffset+paramCount]
+	}
+	if dataCount > 0 {
+		if dataOffset < 0 || dataOffset+dataCount > len(raw) {
+			return nil, nil, fmt.Errorf("Transaction2 data window [%d:%d] out of bounds (%d bytes)", dataOffset, dataOffset+dataCount, len(raw))
+		}
+		data = raw[dataOffset : dataOffset+dataCount]
+	}
+
+	return params, data, nil
+}
+
+// parseBothDirInfo decodes a buffer of consecutive SMB_FIND_FILE_BOTH_DIRECTORY_INFO
+// entries (as returned in the FIND_FIRST2/FIND_NEXT2 data) into FileEntry values.
+// FileName is decoded as OEM/ASCII because the client issues non-Unicode requests.
+func parseBothDirInfo(data []byte) []FileEntry {
+	entries := []FileEntry{}
+
+	for pos := 0; pos+bothDirInfoFixedSize <= len(data); {
+		next := int(binary.LittleEndian.Uint32(data[pos : pos+4]))
+		createdAt := filetimeToTime(binary.LittleEndian.Uint64(data[pos+8 : pos+16]))
+		accessedAt := filetimeToTime(binary.LittleEndian.Uint64(data[pos+16 : pos+24]))
+		modifiedAt := filetimeToTime(binary.LittleEndian.Uint64(data[pos+24 : pos+32]))
+		changedAt := filetimeToTime(binary.LittleEndian.Uint64(data[pos+32 : pos+40]))
+		size := binary.LittleEndian.Uint64(data[pos+40 : pos+48])
+		attrs := binary.LittleEndian.Uint32(data[pos+56 : pos+60])
+		nameLen := int(binary.LittleEndian.Uint32(data[pos+60 : pos+64]))
+		shortNameLen := int(data[pos+68])
+
+		shortName := ""
+		if shortNameLen > 0 && shortNameLen <= 24 {
+			shortName = decodeUTF16LE(data[pos+70 : pos+70+shortNameLen])
+		}
+
+		longName := ""
+		if nameLen > 0 && pos+bothDirInfoFixedSize+nameLen <= len(data) {
+			longName = string(data[pos+bothDirInfoFixedSize : pos+bothDirInfoFixedSize+nameLen])
+		}
+
+		entries = append(entries, FileEntry{
+			LongName:    longName,
+			ShortName:   shortName,
+			Size:        size,
+			Attributes:  attrs,
+			CreatedAt:   createdAt,
+			AccessedAt:  accessedAt,
+			ModifiedAt:  modifiedAt,
+			ChangedAt:   changedAt,
+			IsDirectory: attrs&fileAttributeDirectory != 0,
+		})
+
+		if next == 0 {
+			break
+		}
+		pos += next
+	}
+
+	return entries
+}
+
+// findClose2 releases a search handle obtained from FIND_FIRST2.
+//
+// Wire: FindClose2Request / FindClose2Response.
+func (c *Client) findClose2(sid uint16) error {
+	msg := c.newFileIOMessage(codes.SMB_COM_FIND_CLOSE2)
+
+	cmd := commands.NewFindClose2Request()
+	cmd.SearchHandle = types.USHORT(sid)
+
+	msg.AddCommand(cmd)
+
+	response, _, err := c.sendReceive(msg, "FindClose2")
+	if err != nil {
+		return err
+	}
+	if response.Header.Status != 0x00000000 {
+		return fmt.Errorf("FindClose2 failed: 0x%08x", response.Header.Status)
+	}
+	return nil
+}
+
+// buildFindFirst2Params builds the TRANS2_FIND_FIRST2 transaction parameters.
+func buildFindFirst2Params(pattern string) []byte {
+	b := []byte{}
+	b = binary.LittleEndian.AppendUint16(b, 0x0016) // SearchAttributes: include hidden/system/directory
+	b = binary.LittleEndian.AppendUint16(b, 512)    // SearchCount: max entries per response
+	b = binary.LittleEndian.AppendUint16(b, 0x0000) // Flags: none (the search is closed explicitly)
+	b = binary.LittleEndian.AppendUint16(b, smbFindFileBothDirectoryInfo)
+	b = binary.LittleEndian.AppendUint32(b, 0) // SearchStorageType
+	b = append(b, []byte(pattern)...)
+	b = append(b, 0x00) // null-terminated OEM pattern
+	return b
+}
+
+// buildFindNext2Params builds the TRANS2_FIND_NEXT2 transaction parameters that
+// continue a search from the server's cursor.
+func buildFindNext2Params(sid uint16) []byte {
+	b := []byte{}
+	b = binary.LittleEndian.AppendUint16(b, sid) // SID (search handle)
+	b = binary.LittleEndian.AppendUint16(b, 512) // SearchCount
+	b = binary.LittleEndian.AppendUint16(b, smbFindFileBothDirectoryInfo)
+	b = binary.LittleEndian.AppendUint32(b, 0)      // ResumeKey (unused; we did not request resume keys)
+	b = binary.LittleEndian.AppendUint16(b, 0x0008) // Flags: SMB_FIND_CONTINUE_FROM_LAST
+	b = append(b, 0x00)                             // FileName: empty (resume from server cursor)
+	return b
+}
+
+// filetimeToTime converts a Windows FILETIME (100ns ticks since 1601-01-01 UTC)
+// to a time.Time. A zero FILETIME maps to the zero time.
+func filetimeToTime(ft uint64) time.Time {
+	const epochDiff = 116444736000000000 // 100ns intervals between 1601-01-01 and 1970-01-01
+	if ft == 0 || ft < epochDiff {
+		return time.Time{}
+	}
+	return time.Unix(0, int64(ft-epochDiff)*100).UTC()
+}
+
+// decodeUTF16LE decodes a little-endian UTF-16 byte buffer into a string, trimming
+// any trailing NUL units.
+func decodeUTF16LE(b []byte) string {
+	u16 := make([]uint16, 0, len(b)/2)
+	for i := 0; i+1 < len(b); i += 2 {
+		u16 = append(u16, binary.LittleEndian.Uint16(b[i:i+2]))
+	}
+	return strings.TrimRight(string(utf16.Decode(u16)), "\x00")
+}

--- a/network/smb/smb_v10/client/find_internal_test.go
+++ b/network/smb/smb_v10/client/find_internal_test.go
@@ -1,0 +1,187 @@
+package client
+
+import (
+	"encoding/binary"
+	"testing"
+	"time"
+)
+
+// makeBothDirInfoEntry builds one SMB_FIND_FILE_BOTH_DIRECTORY_INFO record
+// (MS-CIFS 2.2.8.1.7): a 94-byte fixed portion followed by the OEM FileName.
+func makeBothDirInfoEntry(name string, short string, size uint64, attrs uint32, created, accessed, modified, changed uint64, next uint32) []byte {
+	fixed := make([]byte, bothDirInfoFixedSize)
+	binary.LittleEndian.PutUint32(fixed[0:4], next)
+	binary.LittleEndian.PutUint64(fixed[8:16], created)
+	binary.LittleEndian.PutUint64(fixed[16:24], accessed)
+	binary.LittleEndian.PutUint64(fixed[24:32], modified)
+	binary.LittleEndian.PutUint64(fixed[32:40], changed)
+	binary.LittleEndian.PutUint64(fixed[40:48], size)
+	binary.LittleEndian.PutUint32(fixed[56:60], attrs)
+	binary.LittleEndian.PutUint32(fixed[60:64], uint32(len(name)))
+	// ShortName: UTF-16LE in the 24-byte field at offset 70, length byte at 68.
+	su16 := []byte{}
+	for _, r := range short {
+		su16 = binary.LittleEndian.AppendUint16(su16, uint16(r))
+	}
+	fixed[68] = byte(len(su16))
+	copy(fixed[70:94], su16)
+	return append(fixed, []byte(name)...)
+}
+
+func TestParseBothDirInfo(t *testing.T) {
+	const tick = uint64(116444736000000000) // FILETIME for the Unix epoch
+	dir := makeBothDirInfoEntry("subdir", "SUBDIR", 0, fileAttributeDirectory, tick, tick, tick, tick, uint32(bothDirInfoFixedSize+len("subdir")))
+	file := makeBothDirInfoEntry("report.txt", "REPORT~1.TXT", 4096, 0x20, tick+10_000_000, tick, tick, tick, 0)
+
+	entries := parseBothDirInfo(append(dir, file...))
+
+	if len(entries) != 2 {
+		t.Fatalf("got %d entries, want 2", len(entries))
+	}
+
+	if entries[0].LongName != "subdir" {
+		t.Errorf("entry0 LongName = %q, want %q", entries[0].LongName, "subdir")
+	}
+	if entries[0].ShortName != "SUBDIR" {
+		t.Errorf("entry0 ShortName = %q, want %q", entries[0].ShortName, "SUBDIR")
+	}
+	if !entries[0].IsDirectory {
+		t.Errorf("entry0 should be a directory (attrs=0x%x)", entries[0].Attributes)
+	}
+
+	if entries[1].LongName != "report.txt" {
+		t.Errorf("entry1 LongName = %q, want %q", entries[1].LongName, "report.txt")
+	}
+	if entries[1].Size != 4096 {
+		t.Errorf("entry1 Size = %d, want 4096", entries[1].Size)
+	}
+	if entries[1].IsDirectory {
+		t.Errorf("entry1 should not be a directory")
+	}
+	if !entries[1].CreatedAt.Equal(time.Unix(1, 0).UTC()) {
+		t.Errorf("entry1 CreatedAt = %v, want 1970-01-01T00:00:01Z", entries[1].CreatedAt)
+	}
+}
+
+func TestParseBothDirInfoEmpty(t *testing.T) {
+	if got := parseBothDirInfo(nil); len(got) != 0 {
+		t.Errorf("parseBothDirInfo(nil) = %d entries, want 0", len(got))
+	}
+	// A truncated buffer (shorter than the fixed portion) yields no entries and no panic.
+	if got := parseBothDirInfo(make([]byte, bothDirInfoFixedSize-1)); len(got) != 0 {
+		t.Errorf("parseBothDirInfo(truncated) = %d entries, want 0", len(got))
+	}
+}
+
+func TestParseTrans2Response(t *testing.T) {
+	// Build a minimal standard Transaction2 response: 32-byte header placeholder,
+	// WordCount=10, 10 parameter words, then parameter and data buffers located by
+	// ParameterOffset/DataOffset (measured from the header start).
+	const hdr = 32
+	wordCount := 10
+	params := []byte{0xAA, 0xBB}
+	data := []byte{0x01, 0x02, 0x03}
+
+	wordsStart := hdr + 1
+	paramOffset := wordsStart + 2*wordCount + 2 // after words + ByteCount
+	dataOffset := paramOffset + len(params)
+
+	raw := make([]byte, dataOffset+len(data))
+	raw[hdr] = byte(wordCount)
+	w := raw[wordsStart:]
+	binary.LittleEndian.PutUint16(w[6:8], uint16(len(params)))  // ParameterCount
+	binary.LittleEndian.PutUint16(w[8:10], uint16(paramOffset)) // ParameterOffset
+	binary.LittleEndian.PutUint16(w[12:14], uint16(len(data)))  // DataCount
+	binary.LittleEndian.PutUint16(w[14:16], uint16(dataOffset)) // DataOffset
+	copy(raw[paramOffset:], params)
+	copy(raw[dataOffset:], data)
+
+	gotParams, gotData, err := parseTrans2Response(raw)
+	if err != nil {
+		t.Fatalf("parseTrans2Response error: %v", err)
+	}
+	if string(gotParams) != string(params) {
+		t.Errorf("params = % x, want % x", gotParams, params)
+	}
+	if string(gotData) != string(data) {
+		t.Errorf("data = % x, want % x", gotData, data)
+	}
+}
+
+func TestParseTrans2ResponseInterim(t *testing.T) {
+	// WordCount < 10 (interim/short response) yields empty params/data, no error.
+	raw := make([]byte, 32+1)
+	raw[32] = 0
+	params, data, err := parseTrans2Response(raw)
+	if err != nil || len(params) != 0 || len(data) != 0 {
+		t.Fatalf("interim parse = (%v, %v, %v), want empty/no error", params, data, err)
+	}
+}
+
+func TestParseTrans2ResponseOutOfBounds(t *testing.T) {
+	const hdr = 32
+	wordCount := 10
+	wordsStart := hdr + 1
+	raw := make([]byte, wordsStart+2*wordCount)
+	raw[hdr] = byte(wordCount)
+	w := raw[wordsStart:]
+	binary.LittleEndian.PutUint16(w[6:8], 100)   // ParameterCount far beyond buffer
+	binary.LittleEndian.PutUint16(w[8:10], 9999) // ParameterOffset out of bounds
+	if _, _, err := parseTrans2Response(raw); err == nil {
+		t.Fatal("expected out-of-bounds error, got nil")
+	}
+}
+
+func TestFiletimeToTime(t *testing.T) {
+	if !filetimeToTime(0).IsZero() {
+		t.Error("filetimeToTime(0) should be the zero time")
+	}
+	const epoch = uint64(116444736000000000)
+	if got := filetimeToTime(epoch); !got.Equal(time.Unix(0, 0).UTC()) {
+		t.Errorf("filetimeToTime(epoch) = %v, want 1970-01-01T00:00:00Z", got)
+	}
+	if got := filetimeToTime(epoch + 10_000_000); !got.Equal(time.Unix(1, 0).UTC()) {
+		t.Errorf("filetimeToTime(epoch+1s) = %v, want 1970-01-01T00:00:01Z", got)
+	}
+}
+
+func TestDecodeUTF16LE(t *testing.T) {
+	in := []byte{0x41, 0x00, 0x42, 0x00, 0x00, 0x00} // "AB" + NUL
+	if got := decodeUTF16LE(in); got != "AB" {
+		t.Errorf("decodeUTF16LE = %q, want %q", got, "AB")
+	}
+	if got := decodeUTF16LE(nil); got != "" {
+		t.Errorf("decodeUTF16LE(nil) = %q, want empty", got)
+	}
+}
+
+func TestBuildFindFirst2Params(t *testing.T) {
+	b := buildFindFirst2Params("\\*")
+	// SearchAttributes, SearchCount, Flags, InformationLevel, SearchStorageType(4), pattern, NUL
+	if len(b) != 2+2+2+2+4+len("\\*")+1 {
+		t.Fatalf("unexpected length %d", len(b))
+	}
+	if binary.LittleEndian.Uint16(b[6:8]) != smbFindFileBothDirectoryInfo {
+		t.Errorf("InformationLevel = 0x%04x, want 0x%04x", binary.LittleEndian.Uint16(b[6:8]), smbFindFileBothDirectoryInfo)
+	}
+	if b[len(b)-1] != 0x00 {
+		t.Error("pattern must be NUL-terminated")
+	}
+	if string(b[12:len(b)-1]) != "\\*" {
+		t.Errorf("pattern = %q, want %q", string(b[12:len(b)-1]), "\\*")
+	}
+}
+
+func TestBuildFindNext2Params(t *testing.T) {
+	b := buildFindNext2Params(0x1234)
+	if binary.LittleEndian.Uint16(b[0:2]) != 0x1234 {
+		t.Errorf("SID = 0x%04x, want 0x1234", binary.LittleEndian.Uint16(b[0:2]))
+	}
+	if binary.LittleEndian.Uint16(b[4:6]) != smbFindFileBothDirectoryInfo {
+		t.Errorf("InformationLevel = 0x%04x, want 0x%04x", binary.LittleEndian.Uint16(b[4:6]), smbFindFileBothDirectoryInfo)
+	}
+	// Flags must request SMB_FIND_CONTINUE_FROM_LAST (0x0008).
+	if binary.LittleEndian.Uint16(b[10:12]) != 0x0008 {
+		t.Errorf("Flags = 0x%04x, want 0x0008", binary.LittleEndian.Uint16(b[10:12]))
+	}
+}


### PR DESCRIPTION
## Linked Issue
Closes #346

## Motivation
The SMBv1 client could negotiate, tree-connect, and do basic file I/O but had no way to enumerate a directory. `Client.FindFiles` provides the directory-listing primitive that backs `ls`-style commands and traversal, unblocking the `feature-smb-findfiles` work.

## What Changed
New file `network/smb/smb_v10/client/find.go`:
- `FileEntry` — high-level directory entry (long/short name, size, attributes, the four timestamps, `IsDirectory`).
- `Client.FindFiles(pattern)` — issues `TRANS2_FIND_FIRST2`, then loops `TRANS2_FIND_NEXT2` until `EndOfSearch` or an empty page, accumulating entries; defaults an empty pattern to `\\*` and prefixes a missing leading backslash; always calls `FIND_CLOSE2` to release the search handle.
- `Client.trans2(subcommand, params, data)` — builds a single `SMB_COM_TRANSACTION2` (one setup word → WordCount 15), computes 4-byte-aligned Pad1/ParameterOffset and Pad2/DataOffset, bounds `MaxDataCount` by the negotiated buffer, and returns the reassembled response buffers.
- `parseTrans2Response` — locates the response parameter/data windows via the header-relative `ParameterOffset`/`DataOffset`, with bounds checks; treats a short/interim response (WordCount < 10) as empty.
- `parseBothDirInfo` — decodes consecutive `SMB_FIND_FILE_BOTH_DIRECTORY_INFO` records (fixed 94-byte portion + OEM FileName), following `NextEntryOffset`.
- Helpers `buildFindFirst2Params`, `buildFindNext2Params`, `filetimeToTime`, `decodeUTF16LE`.

## Design Notes
- The client issues **non-Unicode** Transaction2 requests (`newFileIOMessage` sets Flags2 without `FLAGS2_UNICODE`), so `FileName` is decoded as OEM/ASCII while the always-Unicode 8.3 `ShortName` field is decoded as UTF-16LE — consistent with [MS-CIFS] 2.2.8.1.7.
- Single-message transactions only; `Transaction2_Secondary` fragmentation is intentionally deferred (see Notes).

## Acceptance Criteria Check
- ✅ `FindFiles` returns a populated `FileEntry` per entry — `TestParseBothDirInfo`.
- ✅ Empty pattern → `\\*`, missing leading backslash prefixed — handled at the top of `FindFiles`.
- ✅ Search handle always released via `FIND_CLOSE2` — `defer`-style unconditional `c.findClose2(sid)` after the loop.
- ✅ Wire parsing covered by unit tests — `TestParseBothDirInfo`, `TestParseBothDirInfoEmpty`, `TestParseTrans2Response`, `TestParseTrans2ResponseInterim`, `TestParseTrans2ResponseOutOfBounds`, `TestFiletimeToTime`, `TestDecodeUTF16LE`, `TestBuildFindFirst2Params`, `TestBuildFindNext2Params`.
- ✅ `go build ./...`, `go vet`, `go test ./network/smb/smb_v10/client/` all pass.

## How Verified
- **Tests:** 9 new unit tests over the pure wire-parsing/build helpers (white-box `package client`), including a synthetic two-entry both-dir-info buffer (file + directory) and out-of-bounds/interim Transaction2 responses.
- **Build/vet:** `go build ./...`, `go vet ./network/smb/smb_v10/client/` clean.

## Test Coverage
**Added:** `network/smb/smb_v10/client/find_internal_test.go` — the nine tests listed above.

## Scope of Change
- **Files changed:** `network/smb/smb_v10/client/find.go` (new), `network/smb/smb_v10/client/find_internal_test.go` (new)
- **Submodule pointer updated:** no
- **Public API changes:** additive — new `Client.FindFiles` and `FileEntry`; nothing removed or altered
- **Behavioral changes outside the stated enhancement:** none

## Notes
- `Transaction2_Secondary` fragmentation (for parameter/data blocks exceeding a single message) is deferred and can be a follow-up enhancement.
- The runtime end-to-end path (`FindFiles` against a live server) is exercised by the recovered `main.go` listing demo, which is kept separate from this PR.