### PR TITLE
[bugfix] Fix WriteRawRequest.Unmarshal reading Pad as DataLength bytes, corrupting Data slice (#266)

### DIFF
--- a/network/smb/smb_v10/message/commands/WriteRawRequest.go
+++ b/network/smb/smb_v10/message/commands/WriteRawRequest.go
@@ -338,20 +338,19 @@ func (c *WriteRawRequest) Unmarshal(rawData []byte) (int, error) {
 	// Then unmarshal the data
 	offset = 0
 
-	// Unmarshalling data Pad
-	// TODO: Compute padding length
-	if len(rawDataContent) < offset+1 {
-		return offset, fmt.Errorf("rawParametersContent too short for Pad")
-	}
-	c.Pad = rawDataContent[offset : offset+int(c.DataLength)]
-	offset += int(c.DataLength)
-
-	// Unmarshalling data Data
-	if len(rawDataContent) < offset+int(c.DataLength) {
+	// Unmarshalling data Pad and Data
+	// Per MS-CIFS the data block is: Pad[] (variable padding) followed by Data[DataLength].
+	// Data occupies the trailing DataLength bytes; Pad is everything before it.
+	dataLen := int(c.DataLength)
+	if len(rawDataContent) < dataLen {
 		return offset, fmt.Errorf("rawDataContent too short for Data")
 	}
-	c.Data = rawDataContent[offset : offset+int(c.DataLength)]
-	offset += int(c.DataLength)
+	padLen := len(rawDataContent) - dataLen
+	c.Pad = rawDataContent[offset : offset+padLen]
+	offset += padLen
+
+	c.Data = rawDataContent[offset : offset+dataLen]
+	offset += dataLen
 
 	return offset, nil
 }


### PR DESCRIPTION
### Linked Issue
Closes #266

### Root Cause
`WriteRawRequest.Unmarshal` used `DataLength` as the size of the `Pad` field, consuming the first `DataLength` bytes of the data block as padding and then reading a second `DataLength`-byte window as `Data`. Per MS-CIFS 2.2.4.25.1, the SMB_Data block is laid out as `Pad[]` (variable-length alignment padding) followed by `Data[DataLength]` — the `Data` field is the **trailing** `DataLength` bytes, not a second block of the same size.

### Fix Description
Compute the pad length as `len(rawDataContent) - DataLength`, so `Pad` captures only the leading alignment bytes and `Data` correctly captures the trailing `DataLength` bytes. This mirrors the structure that `Marshal` produces.

### How Verified
- **Static:** After the fix, `Pad` = `rawDataContent[0 : len-DataLength]` and `Data` = `rawDataContent[len-DataLength : len]`, which is the exact inverse of `Marshal` (which appends `Pad` then `Data`). Round-trip correctness is preserved and the on-wire layout matches the spec.
- **Tests:** Existing round-trip tests pass (`go test ./network/smb/smb_v10/message/commands/`).

### Test Coverage
- **Existing:** The existing `WriteRawRequest` marshal/unmarshal round-trip test continues to pass.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/WriteRawRequest.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none