### PR TITLE
[bugfix] Fix SessionSetupAndxRequest prepending spurious buffer-format bytes to data-block strings (#254)

### DIFF
--- a/network/smb/smb_v10/message/commands/SessionSetupAndxRequest.go
+++ b/network/smb/smb_v10/message/commands/SessionSetupAndxRequest.go
@@ -265,51 +265,31 @@ func (c *SessionSetupAndxRequest) Marshal() ([]byte, error) {
 		// Marshalling data Pad
 		rawDataContent = append(rawDataContent, c.Pad...)
 
-		// Marshalling data AccountName
-		c.AccountName.SetBufferFormat(types.SMB_STRING_BUFFER_FORMAT_NULL_TERMINATED_ASCII_STRING)
-		bytesStream, err := c.AccountName.Marshal()
-		if err != nil {
-			return nil, err
-		}
-		rawDataContent = append(rawDataContent, bytesStream...)
+		// Marshalling data AccountName (raw null-terminated string, no buffer-format prefix)
+		rawDataContent = append(rawDataContent, c.AccountName.Buffer...)
+		rawDataContent = append(rawDataContent, 0x00)
 
-		// Marshalling data PrimaryDomain
-		c.PrimaryDomain.SetBufferFormat(types.SMB_STRING_BUFFER_FORMAT_VARIABLE_BLOCK_16BIT)
-		bytesStream, err = c.PrimaryDomain.Marshal()
-		if err != nil {
-			return nil, err
-		}
-		rawDataContent = append(rawDataContent, bytesStream...)
+		// Marshalling data PrimaryDomain (raw null-terminated string, no buffer-format prefix)
+		rawDataContent = append(rawDataContent, c.PrimaryDomain.Buffer...)
+		rawDataContent = append(rawDataContent, 0x00)
 
-		// Marshalling data NativeOS
-		nativeOSSmbString := types.SMB_STRING{}
+		// Marshalling data NativeOS (raw null-terminated string, no buffer-format prefix)
 		if c.Capabilities.HasCapability(capabilities.CAP_UNICODE) {
-			nativeOSSmbString.SetBufferFormat(types.SMB_STRING_BUFFER_FORMAT_NULL_TERMINATED_OEM_STRING_16BIT)
-			nativeOSSmbString.SetString(string(utf16.EncodeUTF16LE(c.NativeOS)))
+			rawDataContent = append(rawDataContent, utf16.EncodeUTF16LE(c.NativeOS)...)
+			rawDataContent = append(rawDataContent, 0x00, 0x00)
 		} else {
-			nativeOSSmbString.SetBufferFormat(types.SMB_STRING_BUFFER_FORMAT_NULL_TERMINATED_OEM_STRING)
-			nativeOSSmbString.SetString(c.NativeOS)
+			rawDataContent = append(rawDataContent, c.NativeOS...)
+			rawDataContent = append(rawDataContent, 0x00)
 		}
-		bytesStream, err = nativeOSSmbString.Marshal()
-		if err != nil {
-			return nil, err
-		}
-		rawDataContent = append(rawDataContent, bytesStream...)
 
-		// Marshalling data NativeLanMan
-		nativeLanManSmbString := types.SMB_STRING{}
+		// Marshalling data NativeLanMan (raw null-terminated string, no buffer-format prefix)
 		if c.Capabilities.HasCapability(capabilities.CAP_UNICODE) {
-			nativeLanManSmbString.SetBufferFormat(types.SMB_STRING_BUFFER_FORMAT_NULL_TERMINATED_OEM_STRING_16BIT)
-			nativeLanManSmbString.SetString(string(utf16.EncodeUTF16LE(c.NativeLanMan)))
+			rawDataContent = append(rawDataContent, utf16.EncodeUTF16LE(c.NativeLanMan)...)
+			rawDataContent = append(rawDataContent, 0x00, 0x00)
 		} else {
-			nativeLanManSmbString.SetBufferFormat(types.SMB_STRING_BUFFER_FORMAT_NULL_TERMINATED_OEM_STRING)
-			nativeLanManSmbString.SetString(c.NativeLanMan)
+			rawDataContent = append(rawDataContent, c.NativeLanMan...)
+			rawDataContent = append(rawDataContent, 0x00)
 		}
-		bytesStream, err = nativeLanManSmbString.Marshal()
-		if err != nil {
-			return nil, err
-		}
-		rawDataContent = append(rawDataContent, bytesStream...)
 	}
 
 	// Then marshal the parameters
@@ -545,39 +525,27 @@ func (c *SessionSetupAndxRequest) Unmarshal(rawData []byte) (int, error) {
 		c.Pad = rawDataContent[offset : offset+padLen]
 		offset += padLen
 
-		// Unmarshalling data AccountName
-		bytesRead, err = c.AccountName.Unmarshal(rawDataContent[offset:])
-		if err != nil {
-			return offset, err
-		}
-		offset += bytesRead
+		// Unmarshalling data AccountName (raw null-terminated string, no buffer-format prefix)
+		accountNameData, accountNameBytesRead := utils.ReadUntilNullTerminator(rawDataContent[offset:])
+		c.AccountName.Buffer = accountNameData
+		c.AccountName.Length = types.USHORT(len(accountNameData))
+		offset += accountNameBytesRead
 
-		// Unmarshalling data PrimaryDomain
-		bytesRead, err = c.PrimaryDomain.Unmarshal(rawDataContent[offset:])
-		if err != nil {
-			return offset, err
-		}
-		offset += bytesRead
+		// Unmarshalling data PrimaryDomain (raw null-terminated string, no buffer-format prefix)
+		primaryDomainData, primaryDomainBytesRead := utils.ReadUntilNullTerminator(rawDataContent[offset:])
+		c.PrimaryDomain.Buffer = primaryDomainData
+		c.PrimaryDomain.Length = types.USHORT(len(primaryDomainData))
+		offset += primaryDomainBytesRead
 
-		// Unmarshalling NativeOS
-		nativeOSSmbString := types.SMB_STRING{}
-		nativeOSSmbString.SetBufferFormat(types.SMB_STRING_BUFFER_FORMAT_NULL_TERMINATED_OEM_STRING)
-		nativeOSSmbString.SetString(c.NativeOS)
-		bytesRead, err = nativeOSSmbString.Unmarshal(rawDataContent[offset:])
-		if err != nil {
-			return offset, err
-		}
-		offset += bytesRead
+		// Unmarshalling NativeOS (raw null-terminated string, no buffer-format prefix)
+		nativeOSdata, nativeOSBytesRead := utils.ReadUntilNullTerminator(rawDataContent[offset:])
+		offset += nativeOSBytesRead
+		c.NativeOS = string(nativeOSdata)
 
-		// Unmarshalling NativeLanMan
-		nativeLanManSmbString := types.SMB_STRING{}
-		nativeLanManSmbString.SetBufferFormat(types.SMB_STRING_BUFFER_FORMAT_NULL_TERMINATED_OEM_STRING)
-		nativeLanManSmbString.SetString(c.NativeLanMan)
-		bytesRead, err = nativeLanManSmbString.Unmarshal(rawDataContent[offset:])
-		if err != nil {
-			return offset, err
-		}
-		offset += bytesRead
+		// Unmarshalling NativeLanMan (raw null-terminated string, no buffer-format prefix)
+		nativeLanMandata, nativeLanManBytesRead := utils.ReadUntilNullTerminator(rawDataContent[offset:])
+		offset += nativeLanManBytesRead
+		c.NativeLanMan = string(nativeLanMandata)
 	}
 
 	return offset, nil


### PR DESCRIPTION
### Linked Issue
Closes #254

### Root Cause
`SessionSetupAndxRequest.Marshal` in non-extended-security mode routed AccountName, PrimaryDomain, NativeOS, and NativeLanMan through `types.SMB_STRING.Marshal()` with explicit buffer-format codes (0x04 for AccountName, 0x01+length for PrimaryDomain, 0x02/0x03 for NativeOS/NativeLanMan). `SMB_STRING.Marshal()` unconditionally prepends the format byte (and, for some formats, a 2-byte length). Per MS-CIFS 2.2.1.1, buffer-format codes are defined for Core Protocol commands only; commands introduced in later dialects (including `SMB_COM_SESSION_SETUP_ANDX`) use raw null-terminated strings with no prefix. The Unmarshal side mirrored this by calling `SMB_STRING.Unmarshal()` which expected the format byte, making the bug symmetric but incorrect on the wire.

### Fix Description
Replace `SMB_STRING.Marshal()`/`Unmarshal()` calls for all four strings with direct byte-level serialization:
- **Marshal:** Append the raw `Buffer` bytes followed by a null terminator (single `0x00` for OEM, double `0x00 0x00` for Unicode).
- **Unmarshal:** Use `utils.ReadUntilNullTerminator()` to read each string, then populate the struct fields directly.

This matches the extended-security code path which already writes/reads NativeOS and NativeLanMan as raw strings.

### How Verified
- **Static:** The patched Marshal emits `OEMPassword | UnicodePassword | Pad | AccountName\0 | PrimaryDomain\0 | NativeOS\0 | NativeLanMan\0` with no extra bytes, matching MS-CIFS 2.2.4.53.1. Unmarshal reads the same layout.
- **Tests:** Existing round-trip tests pass (`go test ./network/smb/smb_v10/message/commands/`).

### Test Coverage
- **Existing:** The existing `SessionSetupAndxRequest` round-trip test passes with the new raw-string encoding.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/SessionSetupAndxRequest.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none