### PR TITLE
[bugfix] Fix FindClose2Request and LockAndReadResponse marshalling parameters big-endian (#134)

### DIFF
--- a/network/smb/smb_v10/message/commands/FindClose2Request.go
+++ b/network/smb/smb_v10/message/commands/FindClose2Request.go
@@ -77,7 +77,7 @@ func (c *FindClose2Request) Marshal() ([]byte, error) {
 
 	// Marshalling parameter SearchHandle
 	buf2 := make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, uint16(c.SearchHandle))
+	binary.LittleEndian.PutUint16(buf2, uint16(c.SearchHandle))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
 	// Marshalling parameters
@@ -143,7 +143,7 @@ func (c *FindClose2Request) Unmarshal(rawData []byte) (int, error) {
 	if len(rawParametersContent) < offset+2 {
 		return offset, fmt.Errorf("rawParametersContent too short for SearchHandle")
 	}
-	c.SearchHandle = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.SearchHandle = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Then unmarshal the data

--- a/network/smb/smb_v10/message/commands/LockAndReadResponse.go
+++ b/network/smb/smb_v10/message/commands/LockAndReadResponse.go
@@ -105,7 +105,7 @@ func (c *LockAndReadResponse) Marshal() ([]byte, error) {
 	// Marshalling parameter Reserved (4 USHORT = 8 bytes, all MUST be 0x00)
 	for _, reservedWord := range c.Reserved {
 		bufReserved := make([]byte, 2)
-		binary.BigEndian.PutUint16(bufReserved, uint16(reservedWord))
+		binary.LittleEndian.PutUint16(bufReserved, uint16(reservedWord))
 		rawParametersContent = append(rawParametersContent, bufReserved...)
 	}
 
@@ -180,7 +180,7 @@ func (c *LockAndReadResponse) Unmarshal(rawData []byte) (int, error) {
 		if len(rawParametersContent) < offset+2 {
 			return offset, fmt.Errorf("rawParametersContent too short for Reserved")
 		}
-		c.Reserved[i] = types.USHORT(binary.BigEndian.Uint16(rawParametersContent[offset : offset+2]))
+		c.Reserved[i] = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 		offset += 2
 	}
 


### PR DESCRIPTION
### Linked Issue
Closes #134

### Root Cause
The generated command structures defaulted to `binary.BigEndian` for parameter fields. Most files were corrected in earlier fixes, but `FindClose2Request.go` (SearchHandle) and `LockAndReadResponse.go` (Reserved) were missed. SMB/CIFS integer fields are little-endian on the wire, and the `parameters` layer is byte-preserving, so the byte order chosen in the command struct is what reaches the wire.

### Fix Description
Replace `binary.BigEndian` with `binary.LittleEndian` in both Marshal and Unmarshal for:
- `FindClose2Request.SearchHandle` (USHORT)
- `LockAndReadResponse.Reserved` (4 × USHORT)

These are the last two command files under `network/smb/smb_v10/message/commands/` that used `binary.BigEndian` for parameter words (excluding `andx/andx.go` which operates within the parameters layer itself).

### How Verified
- **Static:** After the fix, `grep -r 'binary.BigEndian' network/smb/smb_v10/message/commands/*.go` returns no matches. The only remaining BigEndian usage is in `andx/andx.go`, which is part of the parameters layer internals.
- **Tests:** `go test ./network/smb/smb_v10/message/commands/` passes.

### Test Coverage
- **Existing:** Round-trip marshal/unmarshal tests pass. Note per #134: symmetric tests do not catch endianness bugs; wire-level or golden-byte tests are recommended for future verification.

### Scope of Change
- **Files changed:** `FindClose2Request.go`, `LockAndReadResponse.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none