### PR TITLE
[bugfix] Fix missing session and tree teardown methods causing resource leaks (#352)

### DIFF
--- a/network/smb/smb_v10/client/lifecycle.go
+++ b/network/smb/smb_v10/client/lifecycle.go
@@ -1,0 +1,80 @@
+package client
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/codes"
+)
+
+// TreeDisconnect releases the current tree connection (TID) on the server.
+//
+// Wire: SMB_COM_TREE_DISCONNECT request / response.
+func (c *Client) TreeDisconnect() error {
+	if c.Session == nil {
+		return fmt.Errorf("no session established")
+	}
+
+	msg := c.newFileIOMessage(codes.SMB_COM_TREE_DISCONNECT)
+	cmd := commands.NewTreeDisconnectRequest()
+	msg.AddCommand(cmd)
+
+	response, _, err := c.sendReceive(msg, "TreeDisconnect")
+	if err != nil {
+		return err
+	}
+
+	if response.Header.Status != 0x00000000 {
+		return fmt.Errorf("TreeDisconnect failed: 0x%08x", response.Header.Status)
+	}
+
+	// Remove the TID from the local tree-connect table.
+	tid := c.Session.TreeID
+	if c.Connection.TreeConnectTable != nil {
+		delete(c.Connection.TreeConnectTable, tid)
+	}
+	c.Session.TreeID = 0
+
+	return nil
+}
+
+// Logoff releases the current session (UID) on the server.
+//
+// Wire: SMB_COM_LOGOFF_ANDX request / response.
+func (c *Client) Logoff() error {
+	if c.Session == nil {
+		return fmt.Errorf("no session established")
+	}
+
+	msg := c.newFileIOMessage(codes.SMB_COM_LOGOFF_ANDX)
+	cmd := commands.NewLogoffAndxRequest()
+	msg.AddCommand(cmd)
+
+	response, _, err := c.sendReceive(msg, "LogoffAndx")
+	if err != nil {
+		return err
+	}
+
+	if response.Header.Status != 0x00000000 {
+		return fmt.Errorf("LogoffAndx failed: 0x%08x", response.Header.Status)
+	}
+
+	// Remove the session from the local session table.
+	uid := c.Session.SessionUID
+	if c.Connection.SessionTable != nil {
+		delete(c.Connection.SessionTable, uid)
+	}
+	c.Session = nil
+
+	return nil
+}
+
+// Disconnect closes the underlying transport connection to the server.
+// It does not send any SMB commands; call TreeDisconnect and Logoff first
+// for a clean teardown.
+func (c *Client) Disconnect() error {
+	if c.Transport == nil {
+		return nil
+	}
+	return c.Transport.Close()
+}


### PR DESCRIPTION
### Linked Issue
Closes #352

### Root Cause
The SMB v1.0 client exposed `Connect()`, `SessionSetup()`, and `TreeConnect()` but had no corresponding teardown methods. Server-side UIDs (session slots), TIDs (tree-connect slots), and the underlying TCP socket were leaked on every use, relying on the server's idle timeout to reclaim them.

### Fix Description
Add three new public methods in a new `lifecycle.go` file:
- **`TreeDisconnect()`** — sends `SMB_COM_TREE_DISCONNECT`, removes the TID from the local tree-connect table, and clears `Session.TreeID`.
- **`Logoff()`** — sends `SMB_COM_LOGOFF_ANDX`, removes the UID from the local session table, and nils out `Client.Session`.
- **`Disconnect()`** — calls `Transport.Close()` to release the underlying socket. Does not send any SMB commands; callers should invoke `TreeDisconnect` and `Logoff` first for a clean teardown.

All three methods reuse the existing `newFileIOMessage()` and `sendReceive()` helpers for consistency with the file-I/O methods.

### How Verified
- **Static:** Each method follows the same send/receive/check-status pattern as `OpenFile`, `CloseFile`, etc. The command structures (`TreeDisconnectRequest`, `LogoffAndxRequest`) are trivial (no fields), so marshalling cannot fail for structural reasons.
- **Tests:** `go build` and `go test` pass.

### Test Coverage
- **None:** These methods require a live SMB server to exercise; the existing test suite does not include integration tests.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/client/lifecycle.go` (new file)
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none