### PR TITLE
[bugfix] Fix missing basic file management operations in SMB v1.0 client (#353)

### DIFF
--- a/network/smb/smb_v10/client/fileops.go
+++ b/network/smb/smb_v10/client/fileops.go
@@ -1,0 +1,166 @@
+package client
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/codes"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+)
+
+// DeleteFile deletes one or more files matching pattern on the current tree.
+// pattern uses backslash separators relative to the share root (e.g. "\subdir\file.txt").
+// Wildcards are permitted in the filename component.
+//
+// Wire: SMB_COM_DELETE request / response.
+func (c *Client) DeleteFile(pattern string) error {
+	if c.Session == nil {
+		return fmt.Errorf("no session established")
+	}
+
+	msg := c.newFileIOMessage(codes.SMB_COM_DELETE)
+
+	cmd := commands.NewDeleteRequest()
+	cmd.SearchAttributes = types.SMB_FILE_ATTRIBUTES{}
+	if err := cmd.FileName.SetString(pattern); err != nil {
+		return fmt.Errorf("failed to set file name: %v", err)
+	}
+
+	msg.AddCommand(cmd)
+
+	response, _, err := c.sendReceive(msg, "Delete")
+	if err != nil {
+		return err
+	}
+
+	if response.Header.Status != 0x00000000 {
+		return fmt.Errorf("Delete failed: 0x%08x", response.Header.Status)
+	}
+
+	return nil
+}
+
+// RenameFile renames (or moves) a file on the current tree.
+// oldPath and newPath use backslash separators relative to the share root.
+//
+// Wire: SMB_COM_RENAME request / response.
+func (c *Client) RenameFile(oldPath, newPath string) error {
+	if c.Session == nil {
+		return fmt.Errorf("no session established")
+	}
+
+	msg := c.newFileIOMessage(codes.SMB_COM_RENAME)
+
+	cmd := commands.NewRenameRequest()
+	cmd.SearchAttributes = types.SMB_FILE_ATTRIBUTES{}
+	if err := cmd.OldFileName.SetString(oldPath); err != nil {
+		return fmt.Errorf("failed to set old file name: %v", err)
+	}
+	if err := cmd.NewFileName.SetString(newPath); err != nil {
+		return fmt.Errorf("failed to set new file name: %v", err)
+	}
+
+	msg.AddCommand(cmd)
+
+	response, _, err := c.sendReceive(msg, "Rename")
+	if err != nil {
+		return err
+	}
+
+	if response.Header.Status != 0x00000000 {
+		return fmt.Errorf("Rename failed: 0x%08x", response.Header.Status)
+	}
+
+	return nil
+}
+
+// CreateDirectory creates a directory on the current tree.
+// path uses backslash separators relative to the share root (e.g. "\newdir").
+//
+// Wire: SMB_COM_CREATE_DIRECTORY request / response.
+func (c *Client) CreateDirectory(path string) error {
+	if c.Session == nil {
+		return fmt.Errorf("no session established")
+	}
+
+	msg := c.newFileIOMessage(codes.SMB_COM_CREATE_DIRECTORY)
+
+	cmd := commands.NewCreateDirectoryRequest()
+	if err := cmd.DirectoryName.SetString(path); err != nil {
+		return fmt.Errorf("failed to set directory name: %v", err)
+	}
+
+	msg.AddCommand(cmd)
+
+	response, _, err := c.sendReceive(msg, "CreateDirectory")
+	if err != nil {
+		return err
+	}
+
+	if response.Header.Status != 0x00000000 {
+		return fmt.Errorf("CreateDirectory failed: 0x%08x", response.Header.Status)
+	}
+
+	return nil
+}
+
+// DeleteDirectory removes an empty directory on the current tree.
+// path uses backslash separators relative to the share root (e.g. "\olddir").
+//
+// Wire: SMB_COM_DELETE_DIRECTORY request / response.
+func (c *Client) DeleteDirectory(path string) error {
+	if c.Session == nil {
+		return fmt.Errorf("no session established")
+	}
+
+	msg := c.newFileIOMessage(codes.SMB_COM_DELETE_DIRECTORY)
+
+	cmd := commands.NewDeleteDirectoryRequest()
+	if err := cmd.DirectoryName.SetString(path); err != nil {
+		return fmt.Errorf("failed to set directory name: %v", err)
+	}
+
+	msg.AddCommand(cmd)
+
+	response, _, err := c.sendReceive(msg, "DeleteDirectory")
+	if err != nil {
+		return err
+	}
+
+	if response.Header.Status != 0x00000000 {
+		return fmt.Errorf("DeleteDirectory failed: 0x%08x", response.Header.Status)
+	}
+
+	return nil
+}
+
+// CheckDirectory tests whether a path on the current tree is a valid directory.
+// path uses backslash separators relative to the share root (e.g. "\subdir").
+// Returns nil if the path is a directory, or an error otherwise.
+//
+// Wire: SMB_COM_CHECK_DIRECTORY request / response.
+func (c *Client) CheckDirectory(path string) error {
+	if c.Session == nil {
+		return fmt.Errorf("no session established")
+	}
+
+	msg := c.newFileIOMessage(codes.SMB_COM_CHECK_DIRECTORY)
+
+	cmd := commands.NewCheckDirectoryRequest()
+	if err := cmd.DirectoryName.SetString(path); err != nil {
+		return fmt.Errorf("failed to set directory name: %v", err)
+	}
+
+	msg.AddCommand(cmd)
+
+	response, _, err := c.sendReceive(msg, "CheckDirectory")
+	if err != nil {
+		return err
+	}
+
+	if response.Header.Status != 0x00000000 {
+		return fmt.Errorf("CheckDirectory failed: 0x%08x", response.Header.Status)
+	}
+
+	return nil
+}


### PR DESCRIPTION
### Linked Issue
Closes #353

### Root Cause
The SMB v1.0 client implemented file open/read/write/close and directory enumeration but lacked fundamental file-management operations. The wire-level command structures (`DeleteRequest`, `RenameRequest`, `CreateDirectoryRequest`, `DeleteDirectoryRequest`, `CheckDirectoryRequest`) were fully implemented in the commands package but had no corresponding client API methods, making them unreachable.

### Fix Description
Add five new public methods in a new `fileops.go` file:
- **`DeleteFile(pattern)`** — sends `SMB_COM_DELETE` to remove files matching a pattern (wildcards allowed in the filename component).
- **`RenameFile(oldPath, newPath)`** — sends `SMB_COM_RENAME` to rename or move a file within the share.
- **`CreateDirectory(path)`** — sends `SMB_COM_CREATE_DIRECTORY` to create a new directory.
- **`DeleteDirectory(path)`** — sends `SMB_COM_DELETE_DIRECTORY` to remove an empty directory.
- **`CheckDirectory(path)`** — sends `SMB_COM_CHECK_DIRECTORY` to verify a path is a valid directory (returns nil on success, error otherwise).

All five methods follow the same pattern as `OpenFile`/`CloseFile`: validate session, build message via `newFileIOMessage()`, populate the command struct, and use `sendReceive()` to exchange the message.

### How Verified
- **Static:** Each method uses the established send/receive pattern. The command constructors and marshalling are already tested in the commands package. The new methods populate the struct fields identically to how Marshal expects them.
- **Tests:** `go build` and `go test` pass for the full `smb_v10` subtree.

### Test Coverage
- **None:** These methods require a live SMB server. The existing test suite has no integration tests. The underlying command marshal/unmarshal is covered by existing round-trip tests in the commands package.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/client/fileops.go` (new file)
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none