### PR TITLE
[bugfix] Fix FindFiles returning directories despite name implying files only (#357)

### DIFF
--- a/network/smb/smb_v10/client/find.go
+++ b/network/smb/smb_v10/client/find.go
@@ -28,8 +28,8 @@ const fileAttributeDirectory = 0x00000010
 // ShortName(24).
 const bothDirInfoFixedSize = 94
 
-// FileEntry is a high-level directory entry returned by ListDirectory and ListEntries.
-type FileEntry struct {
+// Entry is a high-level directory entry (file or directory) returned by ListDirectory and ListEntries.
+type Entry struct {
 	LongName    string
 	ShortName   string
 	Size        uint64
@@ -47,7 +47,7 @@ type FileEntry struct {
 // An empty path defaults to the share root.
 //
 // Wire: TRANS2_FIND_FIRST2 / FIND_NEXT2 with "\path\*" pattern.
-func (c *Client) ListDirectory(path string) ([]FileEntry, error) {
+func (c *Client) ListDirectory(path string) ([]Entry, error) {
 	if path == "" {
 		path = "\\"
 	}
@@ -65,7 +65,7 @@ func (c *Client) ListDirectory(path string) ([]FileEntry, error) {
 //
 // pattern uses SMB wildcards and backslash separators relative to the share root
 // (e.g. "\*.txt", "\docs\report-*.pdf"). An empty pattern defaults to "\*".
-func (c *Client) ListEntries(pattern string) ([]FileEntry, error) {
+func (c *Client) ListEntries(pattern string) ([]Entry, error) {
 	if c.Session == nil {
 		return nil, fmt.Errorf("no session established")
 	}
@@ -221,10 +221,11 @@ func parseTrans2Response(raw []byte) ([]byte, []byte, error) {
 }
 
 // parseBothDirInfo decodes a buffer of consecutive SMB_FIND_FILE_BOTH_DIRECTORY_INFO
-// entries (as returned in the FIND_FIRST2/FIND_NEXT2 data) into FileEntry values.
+// entries (as returned in the FIND_FIRST2/FIND_NEXT2 data) into Entry values.
+// Each entry may represent a file or a directory.
 // FileName is decoded as OEM/ASCII because the client issues non-Unicode requests.
-func parseBothDirInfo(data []byte) []FileEntry {
-	entries := []FileEntry{}
+func parseBothDirInfo(data []byte) []Entry {
+	entries := []Entry{}
 
 	for pos := 0; pos+bothDirInfoFixedSize <= len(data); {
 		next := int(binary.LittleEndian.Uint32(data[pos : pos+4]))
@@ -247,7 +248,7 @@ func parseBothDirInfo(data []byte) []FileEntry {
 			longName = string(data[pos+bothDirInfoFixedSize : pos+bothDirInfoFixedSize+nameLen])
 		}
 
-		entries = append(entries, FileEntry{
+		entries = append(entries, Entry{
 			LongName:    longName,
 			ShortName:   shortName,
 			Size:        size,

--- a/network/smb/smb_v10/client/find.go
+++ b/network/smb/smb_v10/client/find.go
@@ -28,7 +28,7 @@ const fileAttributeDirectory = 0x00000010
 // ShortName(24).
 const bothDirInfoFixedSize = 94
 
-// FileEntry is a high-level directory entry returned by FindFiles.
+// FileEntry is a high-level directory entry returned by ListDirectory and ListEntries.
 type FileEntry struct {
 	LongName    string
 	ShortName   string
@@ -41,13 +41,31 @@ type FileEntry struct {
 	IsDirectory bool
 }
 
-// FindFiles enumerates entries matching pattern in the current tree, using
+// ListDirectory lists all entries (files and directories) in the given directory
+// on the current tree. path is a directory path using backslash separators
+// relative to the share root (e.g. "\", "\subdir", "\subdir\nested").
+// An empty path defaults to the share root.
+//
+// Wire: TRANS2_FIND_FIRST2 / FIND_NEXT2 with "\path\*" pattern.
+func (c *Client) ListDirectory(path string) ([]FileEntry, error) {
+	if path == "" {
+		path = "\\"
+	}
+	if path[len(path)-1] == '\\' {
+		path += "*"
+	} else {
+		path += "\\*"
+	}
+	return c.ListEntries(path)
+}
+
+// ListEntries enumerates entries matching pattern in the current tree, using
 // TRANS2_FIND_FIRST2 followed by as many TRANS2_FIND_NEXT2 calls as needed, and
 // always closing the search with FindClose2.
 //
 // pattern uses SMB wildcards and backslash separators relative to the share root
-// (for example "\*" lists the root). An empty pattern defaults to "\*".
-func (c *Client) FindFiles(pattern string) ([]FileEntry, error) {
+// (e.g. "\*.txt", "\docs\report-*.pdf"). An empty pattern defaults to "\*".
+func (c *Client) ListEntries(pattern string) ([]FileEntry, error) {
 	if c.Session == nil {
 		return nil, fmt.Errorf("no session established")
 	}


### PR DESCRIPTION
### Linked Issue
Closes #357

### Root Cause
`FindFiles` wraps `TRANS2_FIND_FIRST2`/`FIND_NEXT2` which returns `SMB_FIND_FILE_BOTH_DIRECTORY_INFO` entries — both files and directories. The `FileEntry` struct includes an `IsDirectory` field, but the method name `FindFiles` misleads callers into thinking only files are returned. Additionally, the method conflated two distinct use cases: simple directory listing and wildcard search.

### Fix Description
- **Rename `FindFiles` → `ListEntries`**: the new name accurately describes what the method does — list entries (files and directories) matching a wildcard pattern. No behavioral change.
- **Add `ListDirectory(path)`**: a convenience wrapper that takes a plain directory path (e.g. `\subdir`), appends `\*`, and delegates to `ListEntries`. This gives callers a simple "list this directory" API without requiring them to construct a glob pattern.

### How Verified
- **Static:** `ListDirectory` appends `\*` to the path and calls `ListEntries`, which is the renamed `FindFiles` with identical logic. `ListEntries` preserves the exact behavior of the original method.
- **Tests:** `go build` and `go test` pass. No external callers of `FindFiles` exist in the codebase.

### Test Coverage
- **Existing:** All existing internal tests (`TestParseBothDirInfo`, `TestBuildFindFirst2Params`, etc.) pass unchanged since they test the internal helpers, not the public method name.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/client/find.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none