### PR TITLE
[bugfix] Fix GetNullTerminatedUnicodeString panic on odd-length input (#362)

### DIFF
--- a/network/smb/smb_v10/message/commands/utils/utils.go
+++ b/network/smb/smb_v10/message/commands/utils/utils.go
@@ -11,7 +11,7 @@ package utils
 // - The offset of the next byte after the null terminator
 func GetNullTerminatedUnicodeString(data []byte) (string, int) {
 	bytesString := []byte{}
-	for i := 0; i < len(data); i += 2 {
+	for i := 0; i+1 < len(data); i += 2 {
 		if data[i] == 0 && data[i+1] == 0 {
 			break
 		} else {

--- a/network/smb/smb_v10/message/commands/utils/utils_test.go
+++ b/network/smb/smb_v10/message/commands/utils/utils_test.go
@@ -97,3 +97,39 @@ func TestGetNullTerminatedUnicodeString(t *testing.T) {
 		})
 	}
 }
+
+// TestGetNullTerminatedUnicodeStringOddLength verifies that odd-length input
+// (a dangling byte without its UTF-16 high half, and no terminator) does not
+// panic with an index-out-of-range on the data[i+1] access.
+func TestGetNullTerminatedUnicodeStringOddLength(t *testing.T) {
+	tests := []struct {
+		name           string
+		input          []byte
+		expectedString string
+	}{
+		{
+			name:           "Single dangling byte",
+			input:          []byte{'A'},
+			expectedString: "",
+		},
+		{
+			name:           "Unterminated string with trailing dangling byte",
+			input:          []byte{'H', 0, 'i', 0, 'X'},
+			expectedString: "H\x00i\x00",
+		},
+		{
+			name:           "Empty input",
+			input:          []byte{},
+			expectedString: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			str, _ := utils.GetNullTerminatedUnicodeString(tt.input)
+			if str != tt.expectedString {
+				t.Errorf("GetNullTerminatedUnicodeString() got string = %q, want %q", str, tt.expectedString)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Linked Issue
Closes #362

### Root Cause
`GetNullTerminatedUnicodeString` iterates in 2-byte steps and dereferences both `data[i]` and `data[i+1]` on every iteration. The loop bound was `i < len(data)`, which admits a final iteration where `i == len(data)-1`. For odd-length input the access `data[i+1]` then reads one byte past the slice and panics. The function assumed every input is a sequence of complete UTF-16 code units, which does not hold for truncated or malformed server responses.

### Fix Description
Change the loop bound from `i < len(data)` to `i+1 < len(data)` so both bytes of a code unit are guaranteed in range before they are read. A trailing dangling byte is treated as the end of the string, matching the function's existing terminator semantics. The change is one operator and does not alter behavior for well-formed (even-length) input.

### How Verified
- Static: with `i+1 < len(data)`, the last valid iteration index satisfies `i+1 <= len(data)-1`, so `data[i+1]` is always in bounds.
- Tests: added `TestGetNullTerminatedUnicodeStringOddLength` covering a single dangling byte, an unterminated string with a trailing dangling byte, and empty input. `go test ./network/smb/smb_v10/message/commands/utils/...` passes; existing even-length cases in `TestGetNullTerminatedUnicodeString` are unchanged.

### Test Coverage
**Added:** `network/smb/smb_v10/message/commands/utils/utils_test.go` — `TestGetNullTerminatedUnicodeStringOddLength`.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/utils/utils.go`, `network/smb/smb_v10/message/commands/utils/utils_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none