### PR TITLE
[bugfix] Fix SMB_FILE_ATTRIBUTES.Unmarshal panic on short input (#364)

### DIFF
--- a/network/smb/smb_v10/types/SMB_FILE_ATTRIBUTES.go
+++ b/network/smb/smb_v10/types/SMB_FILE_ATTRIBUTES.go
@@ -1,6 +1,9 @@
 package types
 
-import "encoding/binary"
+import (
+	"encoding/binary"
+	"fmt"
+)
 
 // SMB_FILE_ATTRIBUTES is a structure that contains the attributes of a file
 // Sourc: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/2198f480-e047-4df0-ba64-f28eadef00b9
@@ -43,6 +46,9 @@ func (s *SMB_FILE_ATTRIBUTES) Marshal() ([]byte, error) {
 // Returns:
 // - The number of bytes unmarshalled
 func (s *SMB_FILE_ATTRIBUTES) Unmarshal(data []byte) (int, error) {
+	if len(data) < 2 {
+		return 0, fmt.Errorf("data too short to unmarshal SMB_FILE_ATTRIBUTES: got %d bytes, need 2", len(data))
+	}
 	s.Attributes = binary.LittleEndian.Uint16(data)
 	return 2, nil
 }

--- a/network/smb/smb_v10/types/SMB_FILE_ATTRIBUTES_test.go
+++ b/network/smb/smb_v10/types/SMB_FILE_ATTRIBUTES_test.go
@@ -177,3 +177,28 @@ func TestSMB_FILE_ATTRIBUTES_Unmarshal(t *testing.T) {
 		})
 	}
 }
+
+func TestSMB_FILE_ATTRIBUTES_Unmarshal_ShortInput(t *testing.T) {
+	testCases := []struct {
+		name  string
+		input []byte
+	}{
+		{name: "Empty input", input: []byte{}},
+		{name: "One byte", input: []byte{0x01}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fileAttr := &types.SMB_FILE_ATTRIBUTES{}
+
+			// Must return an error rather than panicking on a short buffer.
+			bytesRead, err := fileAttr.Unmarshal(tc.input)
+			if err == nil {
+				t.Fatalf("Expected an error for short input %v, got nil", tc.input)
+			}
+			if bytesRead != 0 {
+				t.Errorf("Expected 0 bytes read on error, got %d", bytesRead)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Linked Issue
Closes #364

### Root Cause
`SMB_FILE_ATTRIBUTES.Unmarshal` decoded its 2-byte field with `binary.LittleEndian.Uint16(data)` without first checking `len(data)`. `Uint16` reads `data[0]` and `data[1]` unconditionally, so any buffer shorter than 2 bytes triggers an index-out-of-range panic. The other fixed-width types in the package guard with a `len(data) < N` check; this one was missing it.

### Fix Description
Add a `len(data) < 2` guard at the top of `Unmarshal` that returns a descriptive error and `0` bytes read, mirroring the convention used by `SMB_DATE`, `SMB_TIME_DOS`, and the bounds-checked branches of `SMB_STRING`. No change to the success path.

### How Verified
- Static: after the guard, `binary.LittleEndian.Uint16(data)` is only reached when `len(data) >= 2`, so both indexed bytes are in range.
- Tests: added `TestSMB_FILE_ATTRIBUTES_Unmarshal_ShortInput` (empty and 1-byte inputs) asserting an error and `0` bytes read instead of a panic. `go test ./network/smb/smb_v10/types/...` passes, including the existing `TestSMB_FILE_ATTRIBUTES_Unmarshal` cases.

### Test Coverage
**Added:** `network/smb/smb_v10/types/SMB_FILE_ATTRIBUTES_test.go` — `TestSMB_FILE_ATTRIBUTES_Unmarshal_ShortInput`.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/types/SMB_FILE_ATTRIBUTES.go`, `network/smb/smb_v10/types/SMB_FILE_ATTRIBUTES_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none