### PR TITLE
[bugfix] Fix SMB_STRING VARIABLE_BLOCK Unmarshal panic on short input (#366)

### DIFF
--- a/network/smb/smb_v10/types/SMB_STRING.go
+++ b/network/smb/smb_v10/types/SMB_STRING.go
@@ -250,7 +250,14 @@ func (s *SMB_STRING) Unmarshal(buffer []byte) (int, error) {
 
 	case SMB_STRING_BUFFER_FORMAT_VARIABLE_BLOCK:
 		// This field MUST be 0x05, which indicates that a variable block follows.
+		if len(buffer) < 3 {
+			return 0, fmt.Errorf("buffer too short for format 0x%02x", s.BufferFormat)
+		}
+
 		s.Length = USHORT(binary.LittleEndian.Uint16(buffer[1:3]))
+		if len(buffer) < int(s.Length)+3 {
+			return 0, fmt.Errorf("buffer too short for specified length")
+		}
 
 		// Data buffer
 		s.Buffer = make([]UCHAR, s.Length)

--- a/network/smb/smb_v10/types/SMB_STRING_test.go
+++ b/network/smb/smb_v10/types/SMB_STRING_test.go
@@ -391,3 +391,40 @@ func TestMarshalUnmarshal(t *testing.T) {
 		})
 	}
 }
+
+// TestSMB_STRING_Unmarshal_VariableBlockShortInput verifies that a truncated
+// VARIABLE_BLOCK (0x05) buffer returns an error rather than panicking with an
+// index-out-of-range while slicing the length field or the data block.
+func TestSMB_STRING_Unmarshal_VariableBlockShortInput(t *testing.T) {
+	testCases := []struct {
+		name  string
+		input []byte
+	}{
+		{
+			name:  "Only format byte (missing length field)",
+			input: []byte{types.SMB_STRING_BUFFER_FORMAT_VARIABLE_BLOCK},
+		},
+		{
+			name:  "Format byte and one length byte",
+			input: []byte{types.SMB_STRING_BUFFER_FORMAT_VARIABLE_BLOCK, 0x04},
+		},
+		{
+			name:  "Declared length exceeds available data",
+			input: []byte{types.SMB_STRING_BUFFER_FORMAT_VARIABLE_BLOCK, 0x10, 0x00, 0x41, 0x42},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			smbString := &types.SMB_STRING{}
+
+			bytesRead, err := smbString.Unmarshal(tc.input)
+			if err == nil {
+				t.Fatalf("Expected an error for truncated input %x, got nil", tc.input)
+			}
+			if bytesRead != 0 {
+				t.Errorf("Expected 0 bytes read on error, got %d", bytesRead)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Linked Issue
Closes #366

### Root Cause
The `SMB_STRING_BUFFER_FORMAT_VARIABLE_BLOCK` (0x05) branch of `SMB_STRING.Unmarshal` read the 2-byte length with `binary.LittleEndian.Uint16(buffer[1:3])` and then copied `buffer[3:3+s.Length]` without verifying the buffer was long enough for either operation. A 1- or 2-byte buffer makes the `buffer[1:3]` slice run past the end, and a declared length larger than the remaining bytes makes the data slice run past the end — both panic. The sibling buffer-format branches (0x01, 0x03) already perform these guards; the 0x05 branch was missing them, even though it is reachable from network input via `SMB_RESUME_KEY.Unmarshal`.

### Fix Description
Add the same two guards used by the other branches: `len(buffer) < 3` before reading the length field, and `len(buffer) < int(s.Length)+3` after reading it but before copying the data. Both return a descriptive error and `0` bytes read. The success path is unchanged.

### How Verified
- Static: after the guards, `buffer[1:3]` is reached only when `len(buffer) >= 3`, and `buffer[3:3+s.Length]` only when `len(buffer) >= int(s.Length)+3`, so both slices are in range.
- Tests: added `TestSMB_STRING_Unmarshal_VariableBlockShortInput` covering a lone format byte, a 1-byte length field, and a declared length that exceeds the data. `go test ./network/smb/smb_v10/types/...` passes, including the existing 0x05 round-trip cases in `TestSMB_STRING_Unmarshal` and `TestMarshalUnmarshal`.

### Test Coverage
**Added:** `network/smb/smb_v10/types/SMB_STRING_test.go` — `TestSMB_STRING_Unmarshal_VariableBlockShortInput`.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/types/SMB_STRING.go`, `network/smb/smb_v10/types/SMB_STRING_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none