### PR TITLE
[bugfix] Fix TreeConnect nil-pointer panic when called without a session (#368)

### DIFF
--- a/network/smb/smb_v10/client/client_test.go
+++ b/network/smb/smb_v10/client/client_test.go
@@ -1,1 +1,19 @@
 package client_test
+
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/client"
+)
+
+// TestTreeConnectWithoutSession verifies that calling TreeConnect before a
+// session has been established returns an error rather than panicking with a
+// nil-pointer dereference on c.Session.
+func TestTreeConnectWithoutSession(t *testing.T) {
+	c := &client.Client{}
+
+	err := c.TreeConnect("share")
+	if err == nil {
+		t.Fatal("expected an error when TreeConnect is called without a session, got nil")
+	}
+}

--- a/network/smb/smb_v10/client/tree.go
+++ b/network/smb/smb_v10/client/tree.go
@@ -19,6 +19,10 @@ type TreeConnect struct {
 }
 
 func (c *Client) TreeConnect(shareName string) error {
+	if c.Session == nil {
+		return fmt.Errorf("no session established")
+	}
+
 	requestMsg := message.NewMessage()
 	requestMsg.Header.Command = codes.SMB_COM_TREE_CONNECT_ANDX
 	requestMsg.Header.Flags = 0x0000


### PR DESCRIPTION
### Linked Issue
Closes #368

### Root Cause
`Client.TreeConnect` assigned `requestMsg.Header.UID = c.Session.SessionUID` as one of its first statements, with no check that `c.Session` is non-nil. A caller that invokes `TreeConnect` before `SessionSetup` — or after a setup attempt that left `c.Session` nil — dereferences a nil pointer and crashes. The function itself later guards `if c.Session != nil` before assigning `c.Session.TreeID`, which shows the value can legitimately be nil at entry; the entry guard used by every other client operation (`OpenFile`, `ReadFile`, `DeleteFile`, `ListEntries`, …) was simply never added here.

### Fix Description
Add the standard `if c.Session == nil { return fmt.Errorf("no session established") }` guard at the top of `TreeConnect`, matching the other client operations. This converts the crash into a clear error and is returned before any transport or message work begins. The pre-existing `if c.Session != nil` guard later in the function is left untouched to keep the change minimal.

### How Verified
- Static: with the guard, `c.Session.SessionUID` at the former L29 is reached only when `c.Session != nil`.
- Tests: added `TestTreeConnectWithoutSession`, which calls `TreeConnect` on a zero-value `Client` (nil session) and asserts an error is returned instead of a panic. `go test ./network/smb/smb_v10/client/...` passes.

### Test Coverage
**Added:** `network/smb/smb_v10/client/client_test.go` — `TestTreeConnectWithoutSession`.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/client/tree.go`, `network/smb/smb_v10/client/client_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none