### PR TITLE
[bugfix] Fix SessionSetup nil-pointer panic on nil credentials (#370)

### DIFF
--- a/network/smb/smb_v10/client/client_test.go
+++ b/network/smb/smb_v10/client/client_test.go
@@ -1,1 +1,40 @@
 package client_test
+
+import (
+	"net"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/client"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/securitymode"
+)
+
+// connectedMockTransport is a transport.Transport stub that reports itself as
+// connected. Send/Receive are not expected to be reached by these tests.
+type connectedMockTransport struct{}
+
+func (m *connectedMockTransport) Connect(ipaddr net.IP, port int) error { return nil }
+func (m *connectedMockTransport) Close() error                          { return nil }
+func (m *connectedMockTransport) Send(data []byte) (int, error)         { return len(data), nil }
+func (m *connectedMockTransport) Receive() ([]byte, error)              { return nil, nil }
+func (m *connectedMockTransport) IsConnected() bool                     { return true }
+
+// TestSessionSetupWithNilCredentials verifies that SessionSetup returns an error
+// rather than panicking with a nil-pointer dereference when no credentials are
+// supplied.
+func TestSessionSetupWithNilCredentials(t *testing.T) {
+	// Configure the server security mode so SessionSetup takes the user-level
+	// challenge/response path, which dereferences s.Credentials directly.
+	c := &client.Client{
+		Transport: &connectedMockTransport{},
+		Connection: &client.Connection{
+			Server: &client.Server{
+				SecurityMode: securitymode.NEGOTIATE_USER_SECURITY | securitymode.NEGOTIATE_ENCRYPT_PASSWORDS,
+			},
+		},
+	}
+
+	err := c.SessionSetup(nil)
+	if err == nil {
+		t.Fatal("expected an error when SessionSetup is called with nil credentials, got nil")
+	}
+}

--- a/network/smb/smb_v10/client/session.go
+++ b/network/smb/smb_v10/client/session.go
@@ -42,6 +42,13 @@ func (s *Session) SessionSetup() error {
 		return fmt.Errorf("transport is not connected")
 	}
 
+	// The NTLM challenge/response path and the second authentication phase both
+	// build an authentication context from s.Credentials. Reject nil credentials
+	// up front with a clear error instead of dereferencing a nil pointer later.
+	if s.Credentials == nil {
+		return fmt.Errorf("session setup requires credentials but none were provided")
+	}
+
 	// Prepare and send a NTLMSSP NEGOTIATE message =============================================================================================
 	requestStep1Msg := message.NewMessage()
 	sessionSetupCmd := commands.NewSessionSetupAndxRequest()


### PR DESCRIPTION
### Linked Issue
Closes #370

### Root Cause
`Session.SessionSetup` builds an NTLM authentication context from `s.Credentials.Domain`, `s.Credentials.Username`, and `s.Credentials.Password` on the user-level challenge/response path, and again on the unconditional second authentication phase, without ever checking that `s.Credentials` is non-nil. `Client.SessionSetup` stores whatever pointer the caller passes — including nil — into `Session.Credentials`, so a `SessionSetup(nil)` call reaches those dereferences and panics. Only the plaintext branch had a nil guard; the challenge/response and second-phase paths did not.

### Fix Description
Add a single nil-credentials guard near the top of `SessionSetup`, immediately after the transport-connected check, returning a clear error before any path can dereference `s.Credentials`. This covers every authentication path (share-level, user-level challenge/response, and plaintext) with one check. The pre-existing plaintext-branch guard is left in place to keep the diff minimal; it is now redundant but harmless. No working path is removed — with nil credentials the second authentication phase previously panicked unconditionally, so returning an error is strictly an improvement.

### How Verified
- Static: after the guard, every later use of `s.Credentials` is reached only when the pointer is non-nil.
- Tests: added `TestSessionSetupWithNilCredentials`, which configures the server security mode to `NEGOTIATE_USER_SECURITY | NEGOTIATE_ENCRYPT_PASSWORDS` so `SessionSetup` takes the challenge/response path, then calls `SessionSetup(nil)` over a connected mock transport. Verified the test panics with a nil-pointer dereference when the guard is removed and passes with it in place. `go test ./network/smb/smb_v10/client/...` passes.

### Test Coverage
**Added:** `network/smb/smb_v10/client/client_test.go` — `TestSessionSetupWithNilCredentials` (and a `connectedMockTransport` stub).

### Scope of Change
- **Files changed:** `network/smb/smb_v10/client/session.go`, `network/smb/smb_v10/client/client_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local to `SessionSetup`. The only behavioral change is that nil credentials now produce an error instead of a panic; non-nil credentials are unaffected. Safe to merge without staged rollout.