### PR TITLE
[bugfix] Fix Negotiate accepting error-status responses (#372)

### DIFF
--- a/network/smb/smb_v10/client/negotiate.go
+++ b/network/smb/smb_v10/client/negotiate.go
@@ -70,6 +70,10 @@ func (c *Client) Negotiate() error {
 		return fmt.Errorf("unexpected response command: %d", responseMsg.Header.Command)
 	}
 
+	if responseMsg.Header.Status != 0x00000000 {
+		return fmt.Errorf("negotiate failed: 0x%08x", responseMsg.Header.Status)
+	}
+
 	negotiateResponse := responseMsg.Command.(*commands.NegotiateResponse)
 
 	selectedDialect, err := negotiateResponse.GetSelectedDialect(negotiateCmd.Dialects)

--- a/network/smb/smb_v10/client/negotiate_test.go
+++ b/network/smb/smb_v10/client/negotiate_test.go
@@ -1,0 +1,53 @@
+package client_test
+
+import (
+	"net"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/client"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/codes"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header/flags"
+)
+
+// cannedTransport is a transport.Transport stub that reports itself connected,
+// accepts any Send, and returns a fixed response from Receive.
+type cannedTransport struct {
+	response []byte
+}
+
+func (m *cannedTransport) Connect(ipaddr net.IP, port int) error { return nil }
+func (m *cannedTransport) Close() error                          { return nil }
+func (m *cannedTransport) Send(data []byte) (int, error)         { return len(data), nil }
+func (m *cannedTransport) Receive() ([]byte, error)              { return m.response, nil }
+func (m *cannedTransport) IsConnected() bool                     { return true }
+
+// TestNegotiateRejectsErrorStatus verifies that Negotiate returns an error when
+// the server's NEGOTIATE response carries a non-zero Header.Status, rather than
+// treating the error response as a successful negotiation.
+func TestNegotiateRejectsErrorStatus(t *testing.T) {
+	// Build a NEGOTIATE response message whose header reports an error status but
+	// whose command body is otherwise well-formed (DialectIndex 0 selects a valid
+	// dialect, so only the status check should cause a failure).
+	respMsg := message.NewMessage()
+	respMsg.AddCommand(commands.NewNegotiateResponse())
+	respMsg.Header.Command = codes.SMB_COM_NEGOTIATE
+	// Mark the message as a reply so the client unmarshals it as a NegotiateResponse.
+	respMsg.Header.SetFlags(flags.FLAGS_REPLY)
+	respMsg.Header.Status = 0xC0000022 // STATUS_ACCESS_DENIED
+
+	raw, err := respMsg.Marshal()
+	if err != nil {
+		t.Fatalf("failed to marshal canned response: %v", err)
+	}
+
+	c := &client.Client{
+		Transport:  &cannedTransport{response: raw},
+		Connection: &client.Connection{Server: &client.Server{}},
+	}
+
+	if err := c.Negotiate(); err == nil {
+		t.Fatal("expected Negotiate to fail on an error-status response, got nil")
+	}
+}


### PR DESCRIPTION
### Linked Issue
Closes #372

### Root Cause
`Client.Negotiate` validated only that the response command code was `SMB_COM_NEGOTIATE` and then proceeded straight to consuming the response — selected dialect, capabilities, max buffer size, session key, system time, etc. It never inspected `responseMsg.Header.Status`. SMB carries operation failures in the header status field, so a server that rejects negotiation returns a NEGOTIATE response with a non-zero status and an otherwise empty/zeroed body. Because the status was ignored, that error response was treated as success and the connection was populated from zero-valued fields. The other client operations all check `Header.Status`; `Negotiate` was the exception.

### Fix Description
Add a `responseMsg.Header.Status != 0x00000000` check immediately after the command-code check, returning a descriptive error before any response field is consumed. This mirrors the status handling already used by `SessionSetup`, `TreeConnect`, and the file operations.

### How Verified
- Static: the new check sits before L80–L92, so the connection fields are populated only on a success (zero) status.
- Tests: added `TestNegotiateRejectsErrorStatus`, which feeds `Negotiate` a well-formed NEGOTIATE reply (REPLY flag set, `DialectIndex` 0 so the dialect would otherwise be accepted) carrying `STATUS_ACCESS_DENIED` over a canned mock transport. Verified the test fails (Negotiate returns nil) when the status check is removed and passes with it in place. `go test ./network/smb/smb_v10/client/...` passes.

### Test Coverage
**Added:** `network/smb/smb_v10/client/negotiate_test.go` — `TestNegotiateRejectsErrorStatus` (and a `cannedTransport` stub).

### Scope of Change
- **Files changed:** `network/smb/smb_v10/client/negotiate.go`, `network/smb/smb_v10/client/negotiate_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local to `Negotiate`. A successful (status 0) negotiation is unaffected; only error responses now fail fast instead of silently corrupting the connection. Safe to merge without staged rollout.