### PR TITLE
[bugfix] Fix ReadFile/WriteFile truncating 64-bit offsets to 32 bits (#374)

### DIFF
--- a/network/smb/smb_v10/client/file.go
+++ b/network/smb/smb_v10/client/file.go
@@ -22,8 +22,15 @@ const (
 
 	// writeAndxDataOffset is the byte offset, measured from the start of the SMB
 	// header, at which the Data block begins in our single (non-chained) WriteAndx
-	// request: SMB header + WordCount(1) + Words + ByteCount(2) + Pad(1).
+	// request when the 32-bit-offset form (WordCount 0x0C, no OffsetHigh) is used:
+	// SMB header + WordCount(1) + Words + ByteCount(2) + Pad(1).
 	writeAndxDataOffset = header.SMB_HEADER_SIZE + 1 + writeAndxWordsSize + 2 + 1
+
+	// writeAndxDataOffset64 is the equivalent Data block offset when the 64-bit-offset
+	// form (WordCount 0x0E) is used. WriteAndxRequest.Marshal appends the 4-byte
+	// OffsetHigh word to the parameter block when OffsetHigh is non-zero, which shifts
+	// the Data block 4 bytes further from the start of the header.
+	writeAndxDataOffset64 = writeAndxDataOffset + 4
 )
 
 // FID is an opaque file handle returned by the server for an open file or directory.
@@ -222,9 +229,15 @@ func (c *Client) ReadFile(fid FID, offset uint64, maxLen uint32) ([]byte, error)
 
 		msg := c.newFileIOMessage(codes.SMB_COM_READ_ANDX)
 
+		absOffset := offset + uint64(len(result))
+
 		cmd := commands.NewReadAndxRequest()
 		cmd.FID = types.USHORT(fid)
-		cmd.Offset = types.ULONG(uint32(offset + uint64(len(result))))
+		cmd.Offset = types.ULONG(uint32(absOffset))
+		// Carry the upper 32 bits of the file offset so reads past 4 GiB target the
+		// correct location. ReadAndxRequest emits the 0x0C (64-bit) form when OffsetHigh
+		// is non-zero; for offsets below 4 GiB this stays zero and the 0x0A form is used.
+		cmd.OffsetHigh = types.ULONG(uint32(absOffset >> 32))
 		cmd.MaxCountOfBytesToReturn = types.USHORT(want)
 		cmd.MinCountOfBytesToReturn = types.USHORT(0)
 		cmd.Timeout = types.ULONG(0)
@@ -301,18 +314,29 @@ func (c *Client) WriteFile(fid FID, offset uint64, data []byte) (int, error) {
 
 		msg := c.newFileIOMessage(codes.SMB_COM_WRITE_ANDX)
 
+		absOffset := offset + uint64(written)
+
 		cmd := commands.NewWriteAndxRequest()
 		cmd.FID = types.USHORT(fid)
-		cmd.Offset = types.ULONG(uint32(offset + uint64(written)))
+		cmd.Offset = types.ULONG(uint32(absOffset))
+		// Carry the upper 32 bits of the file offset so writes past 4 GiB land at the
+		// correct location instead of wrapping at 2^32.
+		cmd.OffsetHigh = types.ULONG(uint32(absOffset >> 32))
 		cmd.Timeout = types.ULONG(0)
 		cmd.WriteMode = types.USHORT(0)
 		cmd.Remaining = types.USHORT(0)
 		cmd.Reserved = types.USHORT(0)
 		cmd.DataLength = types.USHORT(len(chunk))
 		// DataOffset is measured from the start of the SMB header (not from the AndX
-		// command's position), so it is a fixed value for our single-command layout.
-		cmd.DataOffset = types.USHORT(writeAndxDataOffset)
-		cmd.OffsetHigh = types.ULONG(0)
+		// command's position). When OffsetHigh is non-zero, WriteAndxRequest.Marshal
+		// appends the 4-byte OffsetHigh word to the parameter block, which moves the
+		// Data block 4 bytes further out; use the matching offset so the server reads
+		// the data from where it is actually placed.
+		if cmd.OffsetHigh != 0 {
+			cmd.DataOffset = types.USHORT(writeAndxDataOffset64)
+		} else {
+			cmd.DataOffset = types.USHORT(writeAndxDataOffset)
+		}
 		cmd.Pad = types.UCHAR(0)
 		cmd.Data = []types.UCHAR(chunk)
 

--- a/network/smb/smb_v10/client/file_test.go
+++ b/network/smb/smb_v10/client/file_test.go
@@ -1,0 +1,132 @@
+package client_test
+
+import (
+	"bytes"
+	"net"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/client"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/command_interface"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header/flags"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+)
+
+// capturingTransport records the last Send payload and replays a canned response.
+type capturingTransport struct {
+	sent     []byte
+	response []byte
+}
+
+func (m *capturingTransport) Connect(ipaddr net.IP, port int) error { return nil }
+func (m *capturingTransport) Close() error                          { return nil }
+func (m *capturingTransport) Send(data []byte) (int, error) {
+	m.sent = append([]byte(nil), data...)
+	return len(data), nil
+}
+func (m *capturingTransport) Receive() ([]byte, error) { return m.response, nil }
+func (m *capturingTransport) IsConnected() bool        { return true }
+
+func newSessionClient(tr *capturingTransport) *client.Client {
+	c := &client.Client{
+		Transport:  tr,
+		Connection: &client.Connection{Server: &client.Server{}},
+	}
+	c.Session = &client.Session{SessionUID: 1, TreeID: 1}
+	return c
+}
+
+func marshalResponse(t *testing.T, cmd command_interface.CommandInterface) []byte {
+	t.Helper()
+	msg := message.NewMessage()
+	msg.AddCommand(cmd) // also sets Header.Command from the command code
+	msg.Header.SetFlags(flags.FLAGS_REPLY)
+	raw, err := msg.Marshal()
+	if err != nil {
+		t.Fatalf("failed to marshal canned response: %v", err)
+	}
+	return raw
+}
+
+// TestWriteFileLargeOffsetCarriesOffsetHigh verifies that WriteFile preserves the
+// full 64-bit file offset (OffsetHigh) for writes past 4 GiB, and that the request
+// DataOffset points at the data block actually emitted.
+func TestWriteFileLargeOffsetCarriesOffsetHigh(t *testing.T) {
+	offset := uint64(0x1_0000_0010) // 4 GiB + 16: high dword = 1, low dword = 0x10
+	data := []byte("payload-bytes")
+
+	resp := commands.NewWriteAndxResponse()
+	resp.Count = types.USHORT(len(data))
+
+	tr := &capturingTransport{response: marshalResponse(t, resp)}
+	c := newSessionClient(tr)
+
+	n, err := c.WriteFile(client.FID(0x4242), offset, data)
+	if err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	if n != len(data) {
+		t.Fatalf("WriteFile wrote %d bytes, want %d", n, len(data))
+	}
+
+	// Parse the request the client actually sent.
+	reqMsg := message.NewMessage()
+	if err := reqMsg.Unmarshal(tr.sent); err != nil {
+		t.Fatalf("failed to unmarshal captured request: %v", err)
+	}
+	req, ok := reqMsg.Command.(*commands.WriteAndxRequest)
+	if !ok {
+		t.Fatalf("captured command is %T, want *WriteAndxRequest", reqMsg.Command)
+	}
+
+	if uint32(req.Offset) != uint32(offset) {
+		t.Errorf("Offset = 0x%08x, want 0x%08x", uint32(req.Offset), uint32(offset))
+	}
+	if uint32(req.OffsetHigh) != uint32(offset>>32) {
+		t.Errorf("OffsetHigh = 0x%08x, want 0x%08x (offset was truncated to 32 bits)", uint32(req.OffsetHigh), uint32(offset>>32))
+	}
+
+	// The data must actually live at the byte position the request advertises.
+	off := int(req.DataOffset)
+	if off+len(data) > len(tr.sent) {
+		t.Fatalf("DataOffset %d + len %d exceeds request size %d", off, len(data), len(tr.sent))
+	}
+	if !bytes.Equal(tr.sent[off:off+len(data)], data) {
+		t.Errorf("data at DataOffset %d = %q, want %q", off, tr.sent[off:off+len(data)], data)
+	}
+}
+
+// TestReadFileLargeOffsetCarriesOffsetHigh verifies that ReadFile preserves the
+// full 64-bit file offset (OffsetHigh) for reads past 4 GiB.
+func TestReadFileLargeOffsetCarriesOffsetHigh(t *testing.T) {
+	offset := uint64(0x2_0000_0020) // 8 GiB + 32: high dword = 2, low dword = 0x20
+
+	// A response with DataLength 0 signals end-of-file, so ReadFile issues exactly
+	// one request and returns.
+	resp := commands.NewReadAndxResponse()
+	resp.DataLength = types.USHORT(0)
+
+	tr := &capturingTransport{response: marshalResponse(t, resp)}
+	c := newSessionClient(tr)
+
+	if _, err := c.ReadFile(client.FID(0x4242), offset, 64); err != nil {
+		t.Fatalf("ReadFile returned error: %v", err)
+	}
+
+	reqMsg := message.NewMessage()
+	if err := reqMsg.Unmarshal(tr.sent); err != nil {
+		t.Fatalf("failed to unmarshal captured request: %v", err)
+	}
+	req, ok := reqMsg.Command.(*commands.ReadAndxRequest)
+	if !ok {
+		t.Fatalf("captured command is %T, want *ReadAndxRequest", reqMsg.Command)
+	}
+
+	if uint32(req.Offset) != uint32(offset) {
+		t.Errorf("Offset = 0x%08x, want 0x%08x", uint32(req.Offset), uint32(offset))
+	}
+	if uint32(req.OffsetHigh) != uint32(offset>>32) {
+		t.Errorf("OffsetHigh = 0x%08x, want 0x%08x (offset was truncated to 32 bits)", uint32(req.OffsetHigh), uint32(offset>>32))
+	}
+}


### PR DESCRIPTION
### Linked Issue
Closes #374

### Root Cause
`ReadFile` and `WriteFile` take a 64-bit `offset` but built the request offset with `uint32(offset + …)`, discarding the upper 32 bits, and `WriteFile` additionally pinned `cmd.OffsetHigh` to zero. The `ReadAndxRequest`/`WriteAndxRequest` types already model a 64-bit offset (an `OffsetHigh` field, emitted as the WordCount 0x0C/0x0E form when non-zero), but the client never populated it. As a result every read or write at an offset >= 4 GiB was sent with only the low dword, so the server operated on `offset mod 2^32` — silent wrong-location reads and silent data corruption on writes.

### Fix Description
Split the absolute offset into its low and high 32-bit halves and assign both `Offset` and `OffsetHigh` in `ReadFile` and `WriteFile`. For offsets below 4 GiB `OffsetHigh` stays zero and the on-wire form is unchanged, so there is no behavior change for the common case.

`WriteAndxRequest.Marshal` appends the 4-byte `OffsetHigh` word to the parameter block when `OffsetHigh` is non-zero, which pushes the data block 4 bytes further from the start of the header. The fixed `DataOffset` constant only accounted for the 32-bit form, so `WriteFile` now selects `writeAndxDataOffset64` (= `writeAndxDataOffset + 4`) when `OffsetHigh` is set, keeping the advertised `DataOffset` aligned with where the data is actually placed. `ReadFile` has no data block, so it only needed the `OffsetHigh` assignment.

### How Verified
- Tests: added `TestWriteFileLargeOffsetCarriesOffsetHigh` and `TestReadFileLargeOffsetCarriesOffsetHigh`. Each drives the operation at an offset above 4 GiB over a capturing mock transport, unmarshals the request the client actually sent, and asserts `Offset`/`OffsetHigh` carry the correct halves. The write test additionally asserts that the bytes at the advertised `DataOffset` equal the payload, catching the data-block/offset coupling. Verified both tests fail on the original code (`OffsetHigh = 0x00000000`) and pass with the fix.
- Full package: `go test ./network/smb/smb_v10/...` passes.

### Test Coverage
**Added:** `network/smb/smb_v10/client/file_test.go` — `TestWriteFileLargeOffsetCarriesOffsetHigh`, `TestReadFileLargeOffsetCarriesOffsetHigh`.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/client/file.go`, `network/smb/smb_v10/client/file_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Offsets below 4 GiB are byte-for-byte unchanged (OffsetHigh stays zero, same WordCount form). Only large-offset operations change, and they change from wrapping to correct. Safe to merge without staged rollout.