### PR TITLE
[bugfix] Fix Transaction-family Unmarshal Pad1/Pad2 length computation (#376)

### DIFF
--- a/network/smb/smb_v10/message/commands/NtTransactRequest.go
+++ b/network/smb/smb_v10/message/commands/NtTransactRequest.go
@@ -410,33 +410,54 @@ func (c *NtTransactRequest) Unmarshal(rawData []byte) (int, error) {
 	// Then unmarshal the data
 	offset = 0
 
-	// Unmarshalling data Pad1
-	if len(rawDataContent) < offset+int(c.ParameterOffset) {
-		return offset, fmt.Errorf("rawDataContent too short for Pad1")
+	// Unmarshalling data Pad1, NT_Trans_Parameters, Pad2, NT_Trans_Data.
+	//
+	// ParameterOffset and DataOffset are measured from the start of the SMB header,
+	// not as lengths within this data block, so they cannot be used directly as the
+	// Pad1/Pad2 byte counts. Recover the inter-block gaps from the shared
+	// header-relative base instead:
+	//   len(Pad2) = DataOffset - (ParameterOffset + ParameterCount)
+	//   len(Pad1) = remaining bytes once NT_Trans_Parameters, Pad2 and NT_Trans_Data are accounted for
+	parameterCount := int(c.ParameterCount)
+	dataCount := int(c.DataCount)
+
+	pad2Length := 0
+	if dataCount > 0 {
+		pad2Length = int(c.DataOffset) - (int(c.ParameterOffset) + parameterCount)
+		if pad2Length < 0 {
+			return offset, fmt.Errorf("invalid offsets: DataOffset precedes end of NT_Trans_Parameters")
+		}
 	}
-	c.Pad1 = rawDataContent[offset : offset+int(c.ParameterOffset)]
-	offset += int(c.ParameterOffset)
+
+	pad1Length := len(rawDataContent) - offset - parameterCount - pad2Length - dataCount
+	if pad1Length < 0 {
+		return offset, fmt.Errorf("rawDataContent too short for NT_Transact data block")
+	}
+
+	// Unmarshalling data Pad1
+	c.Pad1 = rawDataContent[offset : offset+pad1Length]
+	offset += pad1Length
 
 	// Unmarshalling data NT_Trans_Parameters
-	if len(rawDataContent) < offset+int(c.ParameterCount) {
+	if len(rawDataContent) < offset+parameterCount {
 		return offset, fmt.Errorf("rawDataContent too short for NT_Trans_Parameters")
 	}
-	c.NT_Trans_Parameters = rawDataContent[offset : offset+int(c.ParameterCount)]
-	offset += int(c.ParameterCount)
+	c.NT_Trans_Parameters = rawDataContent[offset : offset+parameterCount]
+	offset += parameterCount
 
 	// Unmarshalling data Pad2
-	if len(rawDataContent) < offset+int(c.DataOffset) {
+	if len(rawDataContent) < offset+pad2Length {
 		return offset, fmt.Errorf("rawDataContent too short for Pad2")
 	}
-	c.Pad2 = rawDataContent[offset : offset+int(c.DataOffset)]
-	offset += int(c.DataOffset)
+	c.Pad2 = rawDataContent[offset : offset+pad2Length]
+	offset += pad2Length
 
 	// Unmarshalling data NT_Trans_Data
-	if len(rawDataContent) < offset+int(c.DataCount) {
+	if len(rawDataContent) < offset+dataCount {
 		return offset, fmt.Errorf("rawDataContent too short for NT_Trans_Data")
 	}
-	c.NT_Trans_Data = rawDataContent[offset : offset+int(c.DataCount)]
-	offset += int(c.DataCount)
+	c.NT_Trans_Data = rawDataContent[offset : offset+dataCount]
+	offset += dataCount
 
 	return offset, nil
 }

--- a/network/smb/smb_v10/message/commands/Transaction2Request.go
+++ b/network/smb/smb_v10/message/commands/Transaction2Request.go
@@ -500,33 +500,54 @@ func (c *Transaction2Request) Unmarshal(rawData []byte) (int, error) {
 	c.Name = types.UCHAR(rawDataContent[offset])
 	offset++
 
-	// Unmarshalling data Pad1
-	if len(rawDataContent) < offset+int(c.ParameterOffset) {
-		return offset, fmt.Errorf("rawParametersContent too short for Pad1")
+	// Unmarshalling data Pad1, Trans2_Parameters, Pad2, Trans2_Data.
+	//
+	// ParameterOffset and DataOffset are measured from the start of the SMB header,
+	// not as lengths within this data block, so they cannot be used directly as the
+	// Pad1/Pad2 byte counts. Recover the inter-block gaps from the shared
+	// header-relative base instead:
+	//   len(Pad2) = DataOffset - (ParameterOffset + ParameterCount)
+	//   len(Pad1) = remaining bytes once Trans2_Parameters, Pad2 and Trans2_Data are accounted for
+	parameterCount := int(c.ParameterCount)
+	dataCount := int(c.DataCount)
+
+	pad2Length := 0
+	if dataCount > 0 {
+		pad2Length = int(c.DataOffset) - (int(c.ParameterOffset) + parameterCount)
+		if pad2Length < 0 {
+			return offset, fmt.Errorf("invalid offsets: DataOffset precedes end of Trans2_Parameters")
+		}
 	}
-	c.Pad1 = rawDataContent[offset : offset+int(c.ParameterOffset)]
-	offset += int(c.ParameterOffset)
+
+	pad1Length := len(rawDataContent) - offset - parameterCount - pad2Length - dataCount
+	if pad1Length < 0 {
+		return offset, fmt.Errorf("rawDataContent too short for Transaction2 data block")
+	}
+
+	// Unmarshalling data Pad1
+	c.Pad1 = rawDataContent[offset : offset+pad1Length]
+	offset += pad1Length
 
 	// Unmarshalling data Trans2_Parameters
-	if len(rawDataContent) < offset+int(c.ParameterCount) {
-		return offset, fmt.Errorf("rawParametersContent too short for Trans2_Parameters")
+	if len(rawDataContent) < offset+parameterCount {
+		return offset, fmt.Errorf("rawDataContent too short for Trans2_Parameters")
 	}
-	c.Trans2_Parameters = rawDataContent[offset : offset+int(c.ParameterCount)]
-	offset += int(c.ParameterCount)
+	c.Trans2_Parameters = rawDataContent[offset : offset+parameterCount]
+	offset += parameterCount
 
 	// Unmarshalling data Pad2
-	if len(rawDataContent) < offset+int(c.DataOffset) {
-		return offset, fmt.Errorf("rawParametersContent too short for Pad2")
+	if len(rawDataContent) < offset+pad2Length {
+		return offset, fmt.Errorf("rawDataContent too short for Pad2")
 	}
-	c.Pad2 = rawDataContent[offset : offset+int(c.DataOffset)]
-	offset += int(c.DataOffset)
+	c.Pad2 = rawDataContent[offset : offset+pad2Length]
+	offset += pad2Length
 
 	// Unmarshalling data Trans2_Data
-	if len(rawDataContent) < offset+int(c.DataCount) {
-		return offset, fmt.Errorf("rawParametersContent too short for Trans2_Data")
+	if len(rawDataContent) < offset+dataCount {
+		return offset, fmt.Errorf("rawDataContent too short for Trans2_Data")
 	}
-	c.Trans2_Data = rawDataContent[offset : offset+int(c.DataCount)]
-	offset += int(c.DataCount)
+	c.Trans2_Data = rawDataContent[offset : offset+dataCount]
+	offset += dataCount
 
 	return offset, nil
 }

--- a/network/smb/smb_v10/message/commands/Transaction2SecondaryRequest.go
+++ b/network/smb/smb_v10/message/commands/Transaction2SecondaryRequest.go
@@ -354,33 +354,54 @@ func (c *Transaction2SecondaryRequest) Unmarshal(rawData []byte) (int, error) {
 	// Then unmarshal the data
 	offset = 0
 
-	// Unmarshalling data Pad1
-	if len(rawDataContent) < offset+int(c.ParameterOffset) {
-		return offset, fmt.Errorf("rawParametersContent too short for Pad1")
+	// Unmarshalling data Pad1, Trans2_Parameters, Pad2, Trans2_Data.
+	//
+	// ParameterOffset and DataOffset are measured from the start of the SMB header,
+	// not as lengths within this data block, so they cannot be used directly as the
+	// Pad1/Pad2 byte counts. Recover the inter-block gaps from the shared
+	// header-relative base instead:
+	//   len(Pad2) = DataOffset - (ParameterOffset + ParameterCount)
+	//   len(Pad1) = remaining bytes once Trans2_Parameters, Pad2 and Trans2_Data are accounted for
+	parameterCount := int(c.ParameterCount)
+	dataCount := int(c.DataCount)
+
+	pad2Length := 0
+	if dataCount > 0 {
+		pad2Length = int(c.DataOffset) - (int(c.ParameterOffset) + parameterCount)
+		if pad2Length < 0 {
+			return offset, fmt.Errorf("invalid offsets: DataOffset precedes end of Trans2_Parameters")
+		}
 	}
-	c.Pad1 = rawDataContent[offset : offset+int(c.ParameterOffset)]
-	offset += int(c.ParameterOffset)
+
+	pad1Length := len(rawDataContent) - offset - parameterCount - pad2Length - dataCount
+	if pad1Length < 0 {
+		return offset, fmt.Errorf("rawDataContent too short for Transaction2_Secondary data block")
+	}
+
+	// Unmarshalling data Pad1
+	c.Pad1 = rawDataContent[offset : offset+pad1Length]
+	offset += pad1Length
 
 	// Unmarshalling data Trans2_Parameters
-	if len(rawDataContent) < offset+int(c.ParameterCount) {
-		return offset, fmt.Errorf("rawParametersContent too short for Trans2_Parameters")
+	if len(rawDataContent) < offset+parameterCount {
+		return offset, fmt.Errorf("rawDataContent too short for Trans2_Parameters")
 	}
-	c.Trans2_Parameters = rawDataContent[offset : offset+int(c.ParameterCount)]
-	offset += int(c.ParameterCount)
+	c.Trans2_Parameters = rawDataContent[offset : offset+parameterCount]
+	offset += parameterCount
 
 	// Unmarshalling data Pad2
-	if len(rawDataContent) < offset+int(c.DataOffset) {
-		return offset, fmt.Errorf("rawParametersContent too short for Pad2")
+	if len(rawDataContent) < offset+pad2Length {
+		return offset, fmt.Errorf("rawDataContent too short for Pad2")
 	}
-	c.Pad2 = rawDataContent[offset : offset+int(c.DataOffset)]
-	offset += int(c.DataOffset)
+	c.Pad2 = rawDataContent[offset : offset+pad2Length]
+	offset += pad2Length
 
 	// Unmarshalling data Trans2_Data
-	if len(rawDataContent) < offset+int(c.DataCount) {
-		return offset, fmt.Errorf("rawParametersContent too short for Trans2_Data")
+	if len(rawDataContent) < offset+dataCount {
+		return offset, fmt.Errorf("rawDataContent too short for Trans2_Data")
 	}
-	c.Trans2_Data = rawDataContent[offset : offset+int(c.DataCount)]
-	offset += int(c.DataCount)
+	c.Trans2_Data = rawDataContent[offset : offset+dataCount]
+	offset += dataCount
 
 	return offset, nil
 }

--- a/network/smb/smb_v10/message/commands/TransactionRequest.go
+++ b/network/smb/smb_v10/message/commands/TransactionRequest.go
@@ -539,33 +539,54 @@ func (c *TransactionRequest) Unmarshal(rawData []byte) (int, error) {
 	}
 	offset += bytesRead
 
-	// Unmarshalling data Pad1
-	if len(rawDataContent) < offset+int(c.ParameterOffset) {
-		return offset, fmt.Errorf("rawDataContent too short for Pad1")
-	}
-	c.Pad1 = rawDataContent[offset : offset+int(c.ParameterOffset)]
-	offset += int(c.ParameterOffset)
+	// Unmarshalling data Pad1, Trans_Parameters, Pad2, Trans_Data.
+	//
+	// ParameterOffset and DataOffset are measured from the start of the SMB header,
+	// not as lengths within this data block, so they cannot be used directly as the
+	// Pad1/Pad2 byte counts. Recover the inter-block gaps from the shared
+	// header-relative base instead:
+	//   len(Pad2) = DataOffset - (ParameterOffset + ParameterCount)
+	//   len(Pad1) = remaining bytes once Trans_Parameters, Pad2 and Trans_Data are accounted for
+	parameterCount := int(c.ParameterCount)
+	dataCount := int(c.DataCount)
 
-	// Unmarshalling data Trans2_Parameters
-	if len(rawDataContent) < offset+int(c.ParameterCount) {
+	pad2Length := 0
+	if dataCount > 0 {
+		pad2Length = int(c.DataOffset) - (int(c.ParameterOffset) + parameterCount)
+		if pad2Length < 0 {
+			return offset, fmt.Errorf("invalid offsets: DataOffset precedes end of Trans_Parameters")
+		}
+	}
+
+	pad1Length := len(rawDataContent) - offset - parameterCount - pad2Length - dataCount
+	if pad1Length < 0 {
+		return offset, fmt.Errorf("rawDataContent too short for Transaction data block")
+	}
+
+	// Unmarshalling data Pad1
+	c.Pad1 = rawDataContent[offset : offset+pad1Length]
+	offset += pad1Length
+
+	// Unmarshalling data Trans_Parameters
+	if len(rawDataContent) < offset+parameterCount {
 		return offset, fmt.Errorf("rawDataContent too short for Trans_Parameters")
 	}
-	c.Trans_Parameters = rawDataContent[offset : offset+int(c.ParameterCount)]
-	offset += int(c.ParameterCount)
+	c.Trans_Parameters = rawDataContent[offset : offset+parameterCount]
+	offset += parameterCount
 
 	// Unmarshalling data Pad2
-	if len(rawDataContent) < offset+int(c.DataOffset) {
+	if len(rawDataContent) < offset+pad2Length {
 		return offset, fmt.Errorf("rawDataContent too short for Pad2")
 	}
-	c.Pad2 = rawDataContent[offset : offset+int(c.DataOffset)]
-	offset += int(c.DataOffset)
+	c.Pad2 = rawDataContent[offset : offset+pad2Length]
+	offset += pad2Length
 
-	// Unmarshalling data Trans2_Data
-	if len(rawDataContent) < offset+int(c.DataCount) {
+	// Unmarshalling data Trans_Data
+	if len(rawDataContent) < offset+dataCount {
 		return offset, fmt.Errorf("rawDataContent too short for Trans_Data")
 	}
-	c.Trans_Data = rawDataContent[offset : offset+int(c.DataCount)]
-	offset += int(c.DataCount)
+	c.Trans_Data = rawDataContent[offset : offset+dataCount]
+	offset += dataCount
 
 	return offset, nil
 }

--- a/network/smb/smb_v10/message/commands/TransactionSecondaryRequest.go
+++ b/network/smb/smb_v10/message/commands/TransactionSecondaryRequest.go
@@ -336,33 +336,54 @@ func (c *TransactionSecondaryRequest) Unmarshal(rawData []byte) (int, error) {
 	// Then unmarshal the data
 	offset = 0
 
-	// Unmarshalling data Pad1
-	if len(rawDataContent) < offset+int(c.ParameterOffset) {
-		return offset, fmt.Errorf("rawDataContent too short for Pad1")
+	// Unmarshalling data Pad1, Trans2_Parameters, Pad2, Trans2_Data.
+	//
+	// ParameterOffset and DataOffset are measured from the start of the SMB header,
+	// not as lengths within this data block, so they cannot be used directly as the
+	// Pad1/Pad2 byte counts. Recover the inter-block gaps from the shared
+	// header-relative base instead:
+	//   len(Pad2) = DataOffset - (ParameterOffset + ParameterCount)
+	//   len(Pad1) = remaining bytes once Trans2_Parameters, Pad2 and Trans2_Data are accounted for
+	parameterCount := int(c.ParameterCount)
+	dataCount := int(c.DataCount)
+
+	pad2Length := 0
+	if dataCount > 0 {
+		pad2Length = int(c.DataOffset) - (int(c.ParameterOffset) + parameterCount)
+		if pad2Length < 0 {
+			return offset, fmt.Errorf("invalid offsets: DataOffset precedes end of Trans2_Parameters")
+		}
 	}
-	c.Pad1 = rawDataContent[offset : offset+int(c.ParameterOffset)]
-	offset += int(c.ParameterOffset)
+
+	pad1Length := len(rawDataContent) - offset - parameterCount - pad2Length - dataCount
+	if pad1Length < 0 {
+		return offset, fmt.Errorf("rawDataContent too short for Transaction_Secondary data block")
+	}
+
+	// Unmarshalling data Pad1
+	c.Pad1 = rawDataContent[offset : offset+pad1Length]
+	offset += pad1Length
 
 	// Unmarshalling data Trans2_Parameters
-	if len(rawDataContent) < offset+int(c.ParameterCount) {
+	if len(rawDataContent) < offset+parameterCount {
 		return offset, fmt.Errorf("rawDataContent too short for Trans2_Parameters")
 	}
-	c.Trans2_Parameters = rawDataContent[offset : offset+int(c.ParameterCount)]
-	offset += int(c.ParameterCount)
+	c.Trans2_Parameters = rawDataContent[offset : offset+parameterCount]
+	offset += parameterCount
 
 	// Unmarshalling data Pad2
-	if len(rawDataContent) < offset+int(c.DataOffset) {
+	if len(rawDataContent) < offset+pad2Length {
 		return offset, fmt.Errorf("rawDataContent too short for Pad2")
 	}
-	c.Pad2 = rawDataContent[offset : offset+int(c.DataOffset)]
-	offset += int(c.DataOffset)
+	c.Pad2 = rawDataContent[offset : offset+pad2Length]
+	offset += pad2Length
 
 	// Unmarshalling data Trans2_Data
-	if len(rawDataContent) < offset+int(c.DataCount) {
+	if len(rawDataContent) < offset+dataCount {
 		return offset, fmt.Errorf("rawDataContent too short for Trans2_Data")
 	}
-	c.Trans2_Data = rawDataContent[offset : offset+int(c.DataCount)]
-	offset += int(c.DataCount)
+	c.Trans2_Data = rawDataContent[offset : offset+dataCount]
+	offset += dataCount
 
 	return offset, nil
 }

--- a/network/smb/smb_v10/message/commands/transaction_pad_test.go
+++ b/network/smb/smb_v10/message/commands/transaction_pad_test.go
@@ -1,0 +1,142 @@
+package commands_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+)
+
+// The transaction-family requests lay out their SMB_Data block as
+// [Name?] | Pad1 | <Parameters> | Pad2 | <Data>. ParameterOffset and DataOffset
+// are header-relative offsets, not in-block lengths, so the Unmarshal must derive
+// the Pad1/Pad2 lengths from the offset differences rather than using the offsets
+// directly. These round-trip tests use a fixed, mutually consistent layout:
+//
+//	Pad1 = 1 byte, Parameters = 3 bytes, Pad2 = 2 bytes, Data = 4 bytes
+//	ParameterOffset = 59, DataOffset = 64 (= 59 + ParameterCount(3) + len(Pad2)(2))
+//
+// Before the fix the Unmarshal sliced Pad1 with length ParameterOffset (59) and
+// Pad2 with length DataOffset (64), which runs past the end of the small data
+// block and fails to round-trip.
+var (
+	padTestPad1    = []types.UCHAR{0xAA}
+	padTestParams  = []types.UCHAR{0x01, 0x02, 0x03}
+	padTestPad2    = []types.UCHAR{0xBB, 0xCC}
+	padTestData    = []types.UCHAR{0x10, 0x20, 0x30, 0x40}
+	padTestParamOf = types.USHORT(59)
+	padTestDataOf  = types.USHORT(64)
+)
+
+func assertPadRoundTrip(t *testing.T, name string, pad1, params, pad2, data []types.UCHAR) {
+	t.Helper()
+	if !bytes.Equal(pad1, padTestPad1) {
+		t.Errorf("%s: Pad1 = % x, want % x", name, pad1, padTestPad1)
+	}
+	if !bytes.Equal(params, padTestParams) {
+		t.Errorf("%s: Parameters = % x, want % x", name, params, padTestParams)
+	}
+	if !bytes.Equal(pad2, padTestPad2) {
+		t.Errorf("%s: Pad2 = % x, want % x", name, pad2, padTestPad2)
+	}
+	if !bytes.Equal(data, padTestData) {
+		t.Errorf("%s: Data = % x, want % x", name, data, padTestData)
+	}
+}
+
+func marshalUnmarshal(t *testing.T, out, in interface {
+	Marshal() ([]byte, error)
+	Unmarshal([]byte) (int, error)
+}) {
+	t.Helper()
+	raw, err := out.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+	if _, err := in.Unmarshal(raw); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+}
+
+func TestTransactionRequestPadRoundTrip(t *testing.T) {
+	out := commands.NewTransactionRequest()
+	out.Name = types.SMB_STRING{BufferFormat: types.SMB_STRING_BUFFER_FORMAT_NULL_TERMINATED_ASCII_STRING, Buffer: []types.UCHAR{}}
+	out.Pad1 = padTestPad1
+	out.Trans_Parameters = padTestParams
+	out.Pad2 = padTestPad2
+	out.Trans_Data = padTestData
+	out.ParameterCount = types.USHORT(len(padTestParams))
+	out.DataCount = types.USHORT(len(padTestData))
+	out.ParameterOffset = padTestParamOf
+	out.DataOffset = padTestDataOf
+
+	in := commands.NewTransactionRequest()
+	marshalUnmarshal(t, out, in)
+	assertPadRoundTrip(t, "TransactionRequest", in.Pad1, in.Trans_Parameters, in.Pad2, in.Trans_Data)
+}
+
+func TestTransaction2RequestPadRoundTrip(t *testing.T) {
+	out := commands.NewTransaction2Request()
+	out.Name = types.UCHAR(0x00)
+	out.Pad1 = padTestPad1
+	out.Trans2_Parameters = padTestParams
+	out.Pad2 = padTestPad2
+	out.Trans2_Data = padTestData
+	out.ParameterCount = types.USHORT(len(padTestParams))
+	out.DataCount = types.USHORT(len(padTestData))
+	out.ParameterOffset = padTestParamOf
+	out.DataOffset = padTestDataOf
+
+	in := commands.NewTransaction2Request()
+	marshalUnmarshal(t, out, in)
+	assertPadRoundTrip(t, "Transaction2Request", in.Pad1, in.Trans2_Parameters, in.Pad2, in.Trans2_Data)
+}
+
+func TestNtTransactRequestPadRoundTrip(t *testing.T) {
+	out := commands.NewNtTransactRequest()
+	out.Pad1 = padTestPad1
+	out.NT_Trans_Parameters = padTestParams
+	out.Pad2 = padTestPad2
+	out.NT_Trans_Data = padTestData
+	out.ParameterCount = types.ULONG(len(padTestParams))
+	out.DataCount = types.ULONG(len(padTestData))
+	out.ParameterOffset = types.ULONG(padTestParamOf)
+	out.DataOffset = types.ULONG(padTestDataOf)
+
+	in := commands.NewNtTransactRequest()
+	marshalUnmarshal(t, out, in)
+	assertPadRoundTrip(t, "NtTransactRequest", in.Pad1, in.NT_Trans_Parameters, in.Pad2, in.NT_Trans_Data)
+}
+
+func TestTransactionSecondaryRequestPadRoundTrip(t *testing.T) {
+	out := commands.NewTransactionSecondaryRequest()
+	out.Pad1 = padTestPad1
+	out.Trans2_Parameters = padTestParams
+	out.Pad2 = padTestPad2
+	out.Trans2_Data = padTestData
+	out.ParameterCount = types.USHORT(len(padTestParams))
+	out.DataCount = types.USHORT(len(padTestData))
+	out.ParameterOffset = padTestParamOf
+	out.DataOffset = padTestDataOf
+
+	in := commands.NewTransactionSecondaryRequest()
+	marshalUnmarshal(t, out, in)
+	assertPadRoundTrip(t, "TransactionSecondaryRequest", in.Pad1, in.Trans2_Parameters, in.Pad2, in.Trans2_Data)
+}
+
+func TestTransaction2SecondaryRequestPadRoundTrip(t *testing.T) {
+	out := commands.NewTransaction2SecondaryRequest()
+	out.Pad1 = padTestPad1
+	out.Trans2_Parameters = padTestParams
+	out.Pad2 = padTestPad2
+	out.Trans2_Data = padTestData
+	out.ParameterCount = types.USHORT(len(padTestParams))
+	out.DataCount = types.USHORT(len(padTestData))
+	out.ParameterOffset = padTestParamOf
+	out.DataOffset = padTestDataOf
+
+	in := commands.NewTransaction2SecondaryRequest()
+	marshalUnmarshal(t, out, in)
+	assertPadRoundTrip(t, "Transaction2SecondaryRequest", in.Pad1, in.Trans2_Parameters, in.Pad2, in.Trans2_Data)
+}


### PR DESCRIPTION
### Linked Issue
Closes #376

### Root Cause
`TransactionRequest`, `Transaction2Request`, `NtTransactRequest`, `TransactionSecondaryRequest`, and `Transaction2SecondaryRequest` all parse their SMB_Data block as `[Name?] | Pad1 | <Parameters> | Pad2 | <Data>`. Their `Unmarshal` sliced `Pad1` with length `ParameterOffset` and `Pad2` with length `DataOffset`. But `ParameterOffset`/`DataOffset` are offsets from the start of the SMB header (typically >= 60), not lengths within the data block, so `Pad1` consumed far too many bytes and every subsequent field was extracted from the wrong position (or the slice ran past the buffer and the method errored). The sibling `NtTransactSecondaryRequest.Unmarshal` already computed the gaps correctly, which is the reference this change follows.

### Fix Description
In each of the five `Unmarshal` methods, derive the pad lengths from the shared header-relative base instead of using the offsets as lengths:

- `len(Pad2) = DataOffset - (ParameterOffset + ParameterCount)` (clamped: a negative result is an error). When `DataCount == 0` there is no data block to align, so `len(Pad2)` is taken as 0 rather than computed from a possibly-unset `DataOffset`.
- `len(Pad1) = len(rawDataContent) - <bytes already consumed (e.g. Name)> - ParameterCount - len(Pad2) - DataCount` (clamped).

The parameter, Pad2, and data slices are then read with explicit bounds checks. For `TransactionRequest`/`Transaction2Request` the leading `Name` field is consumed first and is accounted for by the `offset` term in the `Pad1` length.

### How Verified
- Tests: added `transaction_pad_test.go` with a round-trip test per command. Each builds a request with `Pad1`=1B, parameters=3B, `Pad2`=2B, data=4B and mutually consistent `ParameterOffset=59`/`DataOffset=64`, marshals it, unmarshals into a fresh instance, and asserts all four byte slices match. Verified that all five fail on the pre-fix code ("rawDataContent too short for Pad1") and pass with the fix.
- Full package: `go test ./network/smb/smb_v10/...` passes.

### Test Coverage
**Added:** `network/smb/smb_v10/message/commands/transaction_pad_test.go` — `TestTransactionRequestPadRoundTrip`, `TestTransaction2RequestPadRoundTrip`, `TestNtTransactRequestPadRoundTrip`, `TestTransactionSecondaryRequestPadRoundTrip`, `TestTransaction2SecondaryRequestPadRoundTrip`.

### Scope of Change
- **Files changed:** the five command files above plus the new test file.
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none — only the data-block length computation in these `Unmarshal` methods changed; the marshalling side and all other fields are untouched.

### Risk and Rollout
The change only affects parsing of received transaction-family messages, which previously could not be parsed correctly at all. Marshalling is unchanged. Safe to merge without staged rollout.