### PR TITLE
[bugfix] Fix Transaction2Response.Unmarshal to treat ParameterOffset/DataOffset as header-relative (#385)

### DIFF
--- a/network/smb/smb_v10/message/commands/Transaction2Response.go
+++ b/network/smb/smb_v10/message/commands/Transaction2Response.go
@@ -8,6 +8,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/codes"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/command_interface"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/data"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/parameters"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
 )
@@ -403,10 +404,13 @@ func (c *Transaction2Response) Unmarshal(rawData []byte) (int, error) {
 	// keeps the parse robust to zero-length or present padding.
 	offset = 0
 
-	// The number of bytes that precede the SMB_Data.Bytes block within the SMB message:
-	// the SMB_Parameters block (WordCount byte + parameter words, == bytesRead) plus the
-	// 2-byte ByteCount field of the SMB_Data block.
-	bytesBeforeData := bytesRead + 2
+	// The number of bytes from the start of the SMB Header to the start of the
+	// SMB_Data.Bytes block: the 32-byte SMB Header, plus the SMB_Parameters block
+	// (WordCount byte + parameter words, == bytesRead), plus the 2-byte ByteCount
+	// field of the SMB_Data block. ParameterOffset and DataOffset are measured from
+	// the start of the SMB Header, so the header size MUST be included here for the
+	// derived Pad1/Pad2 lengths to be correct.
+	bytesBeforeData := header.SMB_HEADER_SIZE + bytesRead + 2
 
 	// Unmarshalling data Pad1
 	pad1Length := 0

--- a/network/smb/smb_v10/message/commands/Transaction2Response_unmarshal_test.go
+++ b/network/smb/smb_v10/message/commands/Transaction2Response_unmarshal_test.go
@@ -1,0 +1,69 @@
+package commands_test
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+)
+
+// TestTransaction2ResponseUnmarshalHeaderRelativeOffsets verifies that
+// Transaction2Response.Unmarshal interprets ParameterOffset and DataOffset as
+// offsets from the start of the SMB Header (per [MS-CIFS] 2.2.4.46.2) when
+// deriving the Pad1/Pad2 alignment lengths. A real server response places the
+// data block after the 32-byte header; omitting the header size from that
+// computation shifts every payload run and overruns Trans2_Data.
+func TestTransaction2ResponseUnmarshalHeaderRelativeOffsets(t *testing.T) {
+	const wordCount = 10
+
+	trans2Params := []byte{0x01, 0x08, 0x05, 0x00} // 4 bytes (e.g. FIND_FIRST2 reply params)
+	trans2Data := []byte{0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0xA6, 0xA7}
+
+	// Layout from the start of the SMB Header:
+	//   Header(32) WordCount(1) words(20) ByteCount(2) -> Bytes block starts at 55.
+	const bytesBlockStart = 32 + 1 + 2*wordCount + 2 // 55
+	pad1 := (4 - (bytesBlockStart % 4)) % 4          // align ParameterOffset to 4
+	paramOffset := bytesBlockStart + pad1
+	afterParams := paramOffset + len(trans2Params)
+	pad2 := (4 - (afterParams % 4)) % 4
+	dataOffset := afterParams + pad2
+
+	// SMB_Parameters words (header-relative offsets are written into the words).
+	words := make([]byte, 2*wordCount)
+	binary.LittleEndian.PutUint16(words[0:2], uint16(len(trans2Params))) // TotalParameterCount
+	binary.LittleEndian.PutUint16(words[2:4], uint16(len(trans2Data)))   // TotalDataCount
+	binary.LittleEndian.PutUint16(words[6:8], uint16(len(trans2Params))) // ParameterCount
+	binary.LittleEndian.PutUint16(words[8:10], uint16(paramOffset))      // ParameterOffset (header-relative)
+	binary.LittleEndian.PutUint16(words[12:14], uint16(len(trans2Data))) // DataCount
+	binary.LittleEndian.PutUint16(words[14:16], uint16(dataOffset))      // DataOffset (header-relative)
+	// SetupCount (byte 18) and Reserved2 (byte 19) stay zero.
+
+	// SMB_Data.Bytes block: Pad1 | Trans2_Parameters | Pad2 | Trans2_Data.
+	bytesBlock := []byte{}
+	bytesBlock = append(bytesBlock, make([]byte, pad1)...)
+	bytesBlock = append(bytesBlock, trans2Params...)
+	bytesBlock = append(bytesBlock, make([]byte, pad2)...)
+	bytesBlock = append(bytesBlock, trans2Data...)
+
+	// The command bytes as handed to Unmarshal (everything after the SMB Header):
+	// WordCount | words | ByteCount | Bytes block.
+	raw := []byte{byte(wordCount)}
+	raw = append(raw, words...)
+	bc := make([]byte, 2)
+	binary.LittleEndian.PutUint16(bc, uint16(len(bytesBlock)))
+	raw = append(raw, bc...)
+	raw = append(raw, bytesBlock...)
+
+	resp := commands.NewTransaction2Response()
+	if _, err := resp.Unmarshal(raw); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+
+	if !bytes.Equal([]byte(resp.Trans2_Parameters), trans2Params) {
+		t.Errorf("Trans2_Parameters = % x, want % x", []byte(resp.Trans2_Parameters), trans2Params)
+	}
+	if !bytes.Equal([]byte(resp.Trans2_Data), trans2Data) {
+		t.Errorf("Trans2_Data = % x, want % x", []byte(resp.Trans2_Data), trans2Data)
+	}
+}


### PR DESCRIPTION
## Linked Issue
Closes #385

## Root Cause
`ParameterOffset` and `DataOffset` in an SMB_COM_TRANSACTION2 response are measured from the start of the SMB Header ([MS-CIFS] 2.2.4.46.2). `Transaction2Response.Unmarshal` derives the `Pad1`/`Pad2` alignment lengths by subtracting, from those offsets, the number of bytes that precede each payload run (`bytesBeforeData`). That count was computed as `bytesRead + 2` (the SMB_Parameters block + the 2-byte ByteCount) but **omitted the 32-byte SMB Header**, so it was 32 bytes short. Every derived pad length was therefore inflated, shifting `Trans2_Parameters`/`Trans2_Data` and overrunning the data block.

## Fix Description
Include `header.SMB_HEADER_SIZE` in `bytesBeforeData`:
```go
bytesBeforeData := header.SMB_HEADER_SIZE + bytesRead + 2
```
With the header counted, the Bytes block start is correctly 55 for a 10-word response, so `Pad1`/`Pad2` and the two payload runs land exactly. No other logic changed.

## How Verified
- **Runtime:** Reproduced against a live Samba server — a FIND_FIRST2 reply (`ParameterOffset=56`, `ParameterCount=10`, `DataOffset=68`, `DataCount=552`, `ByteCount=565`, 620-byte message) previously failed with `rawDataContent too short for Trans2_Data`; with the fix `Pad1=1`, `Pad2=2`, `Trans2_Data=[13:565]` fits exactly and unmarshals.
- **Tests:** `TestTransaction2ResponseUnmarshalHeaderRelativeOffsets` builds a response with header-relative offsets and asserts `Trans2_Parameters`/`Trans2_Data` decode correctly; it fails (`too short`) before the fix and passes after.
- `go build ./...`, `go vet`, and the full `commands` package tests pass.

## Test Coverage
**Added:** `network/smb/smb_v10/message/commands/Transaction2Response_unmarshal_test.go` — `TestTransaction2ResponseUnmarshalHeaderRelativeOffsets`.

## Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/Transaction2Response.go` (1-line fix + comment + `header` import), `Transaction2Response_unmarshal_test.go` (new)
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

## Risk and Rollout
Low blast radius: a single arithmetic correction in one Unmarshal path. It makes previously-rejected valid responses parse; interim/empty responses (handled earlier in the function) are unaffected. Safe to merge directly.

Closes #385