### PR TITLE
[enhancement] Add multi-message Transaction2 response reassembly to the client (#387)

### DIFF
--- a/network/smb/smb_v10/client/find.go
+++ b/network/smb/smb_v10/client/find.go
@@ -175,49 +175,154 @@ func (c *Client) trans2(subcommand uint16, trans2Params, trans2Data []byte) ([]b
 		return nil, nil, fmt.Errorf("Transaction2 (subcommand 0x%04x) failed: 0x%08x", subcommand, response.Header.Status)
 	}
 
-	return parseTrans2Response(raw)
+	// Reassemble the response, which the server may split across several SMB
+	// messages for a large parameter/data payload. The first message has already
+	// been received; further fragments are read directly from the transport.
+	return reassembleTrans2(raw, func() ([]byte, error) {
+		next, err := c.Transport.Receive()
+		if err != nil {
+			return nil, err
+		}
+		fileIODump("Transaction2 response (continuation)", next)
+		return next, nil
+	})
 }
 
-// parseTrans2Response extracts the transaction parameter and data buffers from a
-// raw SMB_COM_TRANSACTION2 response, using the response ParameterOffset/DataOffset
-// (which are measured from the start of the SMB header) to locate them.
-func parseTrans2Response(raw []byte) ([]byte, []byte, error) {
+// trans2Fragment holds the decoded contents of a single SMB_COM_TRANSACTION2
+// response message: the total transaction sizes, the parameter/data runs carried
+// by this message, and the displacement of each run within the full transaction.
+type trans2Fragment struct {
+	totalParameterCount   int
+	totalDataCount        int
+	parameters            []byte
+	parameterDisplacement int
+	data                  []byte
+	dataDisplacement      int
+}
+
+// parseTrans2Fragment decodes one SMB_COM_TRANSACTION2 response message. The
+// ParameterOffset/DataOffset fields locate the payload runs and are measured from
+// the start of the SMB header. A short/interim response (WordCount < 10) decodes
+// to an empty fragment.
+func parseTrans2Fragment(raw []byte) (*trans2Fragment, error) {
 	hdr := header.SMB_HEADER_SIZE
 	if len(raw) < hdr+1 {
-		return nil, nil, fmt.Errorf("Transaction2 response too short")
+		return nil, fmt.Errorf("Transaction2 response too short")
 	}
 
 	wordCount := int(raw[hdr])
 	wordsStart := hdr + 1
 	if len(raw) < wordsStart+2*wordCount {
-		return nil, nil, fmt.Errorf("Transaction2 response parameter words truncated")
+		return nil, fmt.Errorf("Transaction2 response parameter words truncated")
 	}
 	// The standard response has WordCount 0x0A (10 words) before any setup words.
 	if wordCount < 10 {
-		return []byte{}, []byte{}, nil
+		return &trans2Fragment{}, nil
 	}
 
 	w := raw[wordsStart:]
+	frag := &trans2Fragment{
+		totalParameterCount:   int(binary.LittleEndian.Uint16(w[0:2])),
+		totalDataCount:        int(binary.LittleEndian.Uint16(w[2:4])),
+		parameterDisplacement: int(binary.LittleEndian.Uint16(w[10:12])),
+		dataDisplacement:      int(binary.LittleEndian.Uint16(w[16:18])),
+	}
 	paramCount := int(binary.LittleEndian.Uint16(w[6:8]))
 	paramOffset := int(binary.LittleEndian.Uint16(w[8:10]))
 	dataCount := int(binary.LittleEndian.Uint16(w[12:14]))
 	dataOffset := int(binary.LittleEndian.Uint16(w[14:16]))
 
-	var params, data []byte
 	if paramCount > 0 {
 		if paramOffset < 0 || paramOffset+paramCount > len(raw) {
-			return nil, nil, fmt.Errorf("Transaction2 parameter window [%d:%d] out of bounds (%d bytes)", paramOffset, paramOffset+paramCount, len(raw))
+			return nil, fmt.Errorf("Transaction2 parameter window [%d:%d] out of bounds (%d bytes)", paramOffset, paramOffset+paramCount, len(raw))
 		}
-		params = raw[paramOffset : paramOffset+paramCount]
+		frag.parameters = raw[paramOffset : paramOffset+paramCount]
 	}
 	if dataCount > 0 {
 		if dataOffset < 0 || dataOffset+dataCount > len(raw) {
-			return nil, nil, fmt.Errorf("Transaction2 data window [%d:%d] out of bounds (%d bytes)", dataOffset, dataOffset+dataCount, len(raw))
+			return nil, fmt.Errorf("Transaction2 data window [%d:%d] out of bounds (%d bytes)", dataOffset, dataOffset+dataCount, len(raw))
 		}
-		data = raw[dataOffset : dataOffset+dataCount]
+		frag.data = raw[dataOffset : dataOffset+dataCount]
+	}
+
+	return frag, nil
+}
+
+// parseTrans2Response extracts the parameter and data buffers from a single,
+// unfragmented SMB_COM_TRANSACTION2 response.
+func parseTrans2Response(raw []byte) ([]byte, []byte, error) {
+	frag, err := parseTrans2Fragment(raw)
+	if err != nil {
+		return nil, nil, err
+	}
+	return frag.parameters, frag.data, nil
+}
+
+// reassembleTrans2 reassembles an SMB_COM_TRANSACTION2 response that the server
+// may split across multiple SMB messages. first is the already-received first
+// response message; recvNext returns each subsequent raw message. Fragments are
+// placed into the full parameter/data buffers by their displacements, and reading
+// stops once TotalParameterCount/TotalDataCount bytes have been collected.
+func reassembleTrans2(first []byte, recvNext func() ([]byte, error)) ([]byte, []byte, error) {
+	frag, err := parseTrans2Fragment(first)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	totalParams := frag.totalParameterCount
+	totalData := frag.totalDataCount
+	params := make([]byte, totalParams)
+	data := make([]byte, totalData)
+
+	gotParams, err := placeTrans2Fragment(params, frag.parameters, frag.parameterDisplacement, "parameter")
+	if err != nil {
+		return nil, nil, err
+	}
+	gotData, err := placeTrans2Fragment(data, frag.data, frag.dataDisplacement, "data")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	for gotParams < totalParams || gotData < totalData {
+		next, err := recvNext()
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to receive Transaction2 continuation: %v", err)
+		}
+		nf, err := parseTrans2Fragment(next)
+		if err != nil {
+			return nil, nil, err
+		}
+		// A continuation that advances neither run means the server will not
+		// complete the transaction; stop rather than loop forever.
+		if len(nf.parameters) == 0 && len(nf.data) == 0 {
+			break
+		}
+		np, err := placeTrans2Fragment(params, nf.parameters, nf.parameterDisplacement, "parameter")
+		if err != nil {
+			return nil, nil, err
+		}
+		nd, err := placeTrans2Fragment(data, nf.data, nf.dataDisplacement, "data")
+		if err != nil {
+			return nil, nil, err
+		}
+		gotParams += np
+		gotData += nd
 	}
 
 	return params, data, nil
+}
+
+// placeTrans2Fragment copies a fragment run into dst at displacement, bounds-checking
+// the destination window, and returns the number of bytes copied.
+func placeTrans2Fragment(dst, run []byte, displacement int, label string) (int, error) {
+	if len(run) == 0 {
+		return 0, nil
+	}
+	if displacement < 0 || displacement+len(run) > len(dst) {
+		return 0, fmt.Errorf("Transaction2 %s fragment [%d:%d] exceeds total length %d", label, displacement, displacement+len(run), len(dst))
+	}
+	copy(dst[displacement:], run)
+	return len(run), nil
 }
 
 // parseBothDirInfo decodes a buffer of consecutive SMB_FIND_FILE_BOTH_DIRECTORY_INFO

--- a/network/smb/smb_v10/client/find_reassemble_test.go
+++ b/network/smb/smb_v10/client/find_reassemble_test.go
@@ -1,0 +1,128 @@
+package client
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"testing"
+)
+
+// makeTrans2ResponseMsg builds a raw SMB_COM_TRANSACTION2 response message carrying
+// one fragment: the given total parameter/data sizes, this fragment's parameter and
+// data runs, and their displacements. Offsets are header-relative and the payload
+// runs are placed immediately after ByteCount (Pad1 = Pad2 = 0).
+func makeTrans2ResponseMsg(totalParams int, params []byte, paramDisp int, totalData int, data []byte, dataDisp int) []byte {
+	const hdr = 32
+	const wordCount = 10
+	wordsStart := hdr + 1
+	bytesBlockStart := wordsStart + 2*wordCount + 2 // = 55
+	paramOffset := bytesBlockStart
+	dataOffset := paramOffset + len(params)
+
+	raw := make([]byte, dataOffset+len(data))
+	raw[hdr] = byte(wordCount)
+
+	w := raw[wordsStart:]
+	binary.LittleEndian.PutUint16(w[0:2], uint16(totalParams))                                           // TotalParameterCount
+	binary.LittleEndian.PutUint16(w[2:4], uint16(totalData))                                             // TotalDataCount
+	binary.LittleEndian.PutUint16(w[6:8], uint16(len(params)))                                           // ParameterCount
+	binary.LittleEndian.PutUint16(w[8:10], uint16(paramOffset))                                          // ParameterOffset
+	binary.LittleEndian.PutUint16(w[10:12], uint16(paramDisp))                                           // ParameterDisplacement
+	binary.LittleEndian.PutUint16(w[12:14], uint16(len(data)))                                           // DataCount
+	binary.LittleEndian.PutUint16(w[14:16], uint16(dataOffset))                                          // DataOffset
+	binary.LittleEndian.PutUint16(w[16:18], uint16(dataDisp))                                            // DataDisplacement
+	binary.LittleEndian.PutUint16(raw[bytesBlockStart-2:bytesBlockStart], uint16(len(params)+len(data))) // ByteCount
+
+	copy(raw[paramOffset:], params)
+	copy(raw[dataOffset:], data)
+	return raw
+}
+
+func TestReassembleTrans2SingleMessage(t *testing.T) {
+	params := []byte{0x01, 0x08}
+	data := []byte{0xA0, 0xA1, 0xA2, 0xA3}
+	msg := makeTrans2ResponseMsg(len(params), params, 0, len(data), data, 0)
+
+	gotParams, gotData, err := reassembleTrans2(msg, func() ([]byte, error) {
+		t.Fatal("recvNext must not be called when the first message is complete")
+		return nil, nil
+	})
+	if err != nil {
+		t.Fatalf("reassembleTrans2 error: %v", err)
+	}
+	if !bytes.Equal(gotParams, params) {
+		t.Errorf("params = % x, want % x", gotParams, params)
+	}
+	if !bytes.Equal(gotData, data) {
+		t.Errorf("data = % x, want % x", gotData, data)
+	}
+}
+
+func TestReassembleTrans2MultiFragment(t *testing.T) {
+	// A transaction split across two messages, for both the parameter and data runs.
+	frag1 := makeTrans2ResponseMsg(4, []byte{0x11, 0x22}, 0, 6, []byte{0xA0, 0xA1, 0xA2}, 0)
+	frag2 := makeTrans2ResponseMsg(4, []byte{0x33, 0x44}, 2, 6, []byte{0xA3, 0xA4, 0xA5}, 3)
+
+	rest := [][]byte{frag2}
+	gotParams, gotData, err := reassembleTrans2(frag1, func() ([]byte, error) {
+		if len(rest) == 0 {
+			return nil, errors.New("recvNext called too many times")
+		}
+		m := rest[0]
+		rest = rest[1:]
+		return m, nil
+	})
+	if err != nil {
+		t.Fatalf("reassembleTrans2 error: %v", err)
+	}
+	if want := []byte{0x11, 0x22, 0x33, 0x44}; !bytes.Equal(gotParams, want) {
+		t.Errorf("params = % x, want % x", gotParams, want)
+	}
+	if want := []byte{0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5}; !bytes.Equal(gotData, want) {
+		t.Errorf("data = % x, want % x", gotData, want)
+	}
+	if len(rest) != 0 {
+		t.Errorf("expected exactly one continuation to be consumed")
+	}
+}
+
+func TestReassembleTrans2OutOfBounds(t *testing.T) {
+	// A fragment whose displacement+length exceeds the declared total must be rejected.
+	msg := makeTrans2ResponseMsg(0, nil, 0, 8, []byte{0x01, 0x02, 0x03, 0x04}, 6)
+	if _, _, err := reassembleTrans2(msg, func() ([]byte, error) {
+		return nil, errors.New("should not be reached")
+	}); err == nil {
+		t.Fatal("expected out-of-bounds fragment error, got nil")
+	}
+}
+
+func TestReassembleTrans2ReceiveError(t *testing.T) {
+	// If a continuation is needed but the transport errors, the error propagates.
+	frag1 := makeTrans2ResponseMsg(0, nil, 0, 8, []byte{0xA0, 0xA1, 0xA2, 0xA3}, 0)
+	_, _, err := reassembleTrans2(frag1, func() ([]byte, error) {
+		return nil, errors.New("connection reset")
+	})
+	if err == nil {
+		t.Fatal("expected receive error to propagate, got nil")
+	}
+}
+
+func TestParseTrans2Fragment(t *testing.T) {
+	params := []byte{0x01, 0x08, 0x05, 0x00}
+	data := []byte{0xDE, 0xAD, 0xBE, 0xEF}
+	msg := makeTrans2ResponseMsg(10, params, 4, 16, data, 8)
+
+	frag, err := parseTrans2Fragment(msg)
+	if err != nil {
+		t.Fatalf("parseTrans2Fragment error: %v", err)
+	}
+	if frag.totalParameterCount != 10 || frag.totalDataCount != 16 {
+		t.Errorf("totals = (%d, %d), want (10, 16)", frag.totalParameterCount, frag.totalDataCount)
+	}
+	if frag.parameterDisplacement != 4 || frag.dataDisplacement != 8 {
+		t.Errorf("displacements = (%d, %d), want (4, 8)", frag.parameterDisplacement, frag.dataDisplacement)
+	}
+	if !bytes.Equal(frag.parameters, params) || !bytes.Equal(frag.data, data) {
+		t.Errorf("runs = (% x, % x), want (% x, % x)", frag.parameters, frag.data, params, data)
+	}
+}


### PR DESCRIPTION
## Linked Issue
Closes #387

## Motivation
A server may return an `SMB_COM_TRANSACTION2` reply across multiple SMB messages when the parameter/data payload exceeds a single buffer ([MS-CIFS] 2.2.4.46.2), using `TotalParameterCount`/`TotalDataCount` and per-message `ParameterDisplacement`/`DataDisplacement` for reassembly. The client's `trans2` previously kept only the first message and silently truncated such replies.

## What Changed
In `network/smb/smb_v10/client/find.go`:
- **`trans2`** now returns `reassembleTrans2(raw, recvNext)` instead of parsing only the first message; `recvNext` reads further messages from `c.Transport.Receive()` (with debug dumping).
- **`parseTrans2Fragment`** (new) decodes one response message into a `trans2Fragment` — `TotalParameterCount`/`TotalDataCount`, the parameter/data runs, and their displacements — with the same header-relative offset handling and bounds checks as before.
- **`reassembleTrans2`** (new) allocates the full parameter/data buffers from the totals, places each fragment run by displacement (via `placeTrans2Fragment`, which bounds-checks), and keeps reading continuations until `TotalParameterCount`/`TotalDataCount` bytes are collected; it stops on a zero-progress continuation to avoid looping forever.
- **`parseTrans2Response`** now delegates to `parseTrans2Fragment` (unchanged external behavior for single-message replies).

## Design Notes
- The reassembly loop is factored to take a `recvNext func() ([]byte, error)` rather than the `Client` directly, so it is unit-testable without live networking.
- Single-message replies make no extra transport reads (the loop condition is already satisfied).

## Acceptance Criteria Check
- ✅ Multi-message reply reassembled by displacement — `TestReassembleTrans2MultiFragment`.
- ✅ Single-message reply makes no extra reads — `TestReassembleTrans2SingleMessage` (its `recvNext` fails the test if called).
- ✅ Out-of-bounds fragment rejected — `TestReassembleTrans2OutOfBounds`.
- ✅ Transport error on a needed continuation propagates — `TestReassembleTrans2ReceiveError`.
- ✅ Fragment decoding — `TestParseTrans2Fragment`; existing `TestParseTrans2Response*` still pass via delegation.

## How Verified
- **Tests:** new `network/smb/smb_v10/client/find_reassemble_test.go` (5 tests) with a `makeTrans2ResponseMsg` helper that builds raw header-relative response messages; existing find/parse tests still pass.
- `go build ./...`, `go vet ./network/smb/smb_v10/client/`, and `go test ./network/smb/smb_v10/client/` all pass.

## Test Coverage
**Added:** `find_reassemble_test.go` — `TestReassembleTrans2SingleMessage`, `TestReassembleTrans2MultiFragment`, `TestReassembleTrans2OutOfBounds`, `TestReassembleTrans2ReceiveError`, `TestParseTrans2Fragment`.

## Scope of Change
- **Files changed:** `network/smb/smb_v10/client/find.go`, `network/smb/smb_v10/client/find_reassemble_test.go` (new)
- **Submodule pointer updated:** no
- **Public API changes:** none (internal helpers only)
- **Behavioral changes outside the stated enhancement:** none

## Risk and Rollout
Low: the common single-message path is unchanged (no extra reads, same parse output via delegation). The new behavior only engages when the first message reports more total bytes than it carries. Safe to merge.

## Notes
- Functionally depends on #385 / PR #386 (Transaction2Response.Unmarshal header-relative offsets) for the per-message decode to succeed at runtime; the two PRs touch disjoint files and do not conflict.
- Request-side `Transaction2_Secondary` fragmentation (large *requests*) remains a separate follow-up.

Closes #387