### PR TITLE
[enhancement] Add DCE/RPC over SMB named pipes (ncacn_np)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,5 @@ go.work.sum
 ./bin/
 ./main.go
 
-# Local files for debug 
-./.private/
+# Local files for debug
+.private/

--- a/network/dcerpc/client/client.go
+++ b/network/dcerpc/client/client.go
@@ -1,0 +1,305 @@
+// Package client implements the high-level connection-oriented DCE/RPC client: it
+// binds to an interface and issues calls over a transport.
+//
+// The flow follows [C706] chapter 12 and [MS-RPCE]:
+//
+//  1. Bind sends a bind PDU proposing the transport's max_xmit_frag / max_recv_frag,
+//     a single presentation context (the target abstract syntax with the NDR 2.0
+//     transfer syntax), and records the server's negotiated fragment sizes from the
+//     bind_ack.
+//  2. Call serializes a request, fragments it so that no fragment exceeds the
+//     negotiated send size (PFC_FIRST_FRAG on the first, PFC_LAST_FRAG on the last,
+//     both on a single fragment), writes every fragment, then reassembles the
+//     response fragments until PFC_LAST_FRAG. A fault PDU is returned as an error.
+//
+// The call_id is constant across the fragments of one call and is incremented for
+// each new call, as required by [C706] section 12.6.2.
+//
+// References:
+//   - [C706] chapter 12 (connection-oriented protocol), "Fragmentation and
+//     Reassembly": https://pubs.opengroup.org/onlinepubs/9629399/chap12.htm
+//   - [MS-RPCE] 3.3.1.5.3 Bind Time Feature Negotiation and 2.2.2 PDU definitions:
+//     https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/87964b3c-1785-4aae-a993-734999441ed3
+//   - [MS-RPCE] 2.1.1.2 SMB (NCACN_NP):
+//     https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/7063c7bd-b48b-42e7-9154-3c2ec4113c0d
+package client
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/pdu"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/transport"
+)
+
+// requestHeaderOverhead is the fixed size of a request PDU before the stub data: the
+// 16-byte common header plus the 8-byte request body (alloc_hint, p_cont_id, opnum).
+const requestHeaderOverhead = pdu.HeaderSize + 8
+
+// Client is a connection-oriented DCE/RPC client bound to a single presentation
+// context on a transport.
+type Client struct {
+	transport transport.Transport
+
+	// callID is the call_id of the most recent call; it is incremented per call.
+	callID uint32
+
+	// contextID is the presentation context id negotiated at Bind (0 for v1).
+	contextID uint16
+
+	// sendFragMax is the largest request fragment, in bytes, the server will accept,
+	// derived from the bind_ack.
+	sendFragMax uint16
+
+	bound bool
+}
+
+// NewClient returns a DCE/RPC client over the supplied transport. The transport must
+// be ready to Connect (for ncacn_np, its SMB session and IPC$ tree connect are
+// already established).
+func NewClient(t transport.Transport) *Client {
+	return &Client{transport: t}
+}
+
+// Bind connects the transport and binds to the interface identified by
+// abstractSyntax, negotiating the NDR 2.0 transfer syntax in a single presentation
+// context. It returns an error if the server rejects the bind (bind_nak) or accepts
+// no context.
+func (c *Client) Bind(abstractSyntax syntax.SyntaxID) error {
+	if err := c.transport.Connect(); err != nil {
+		return fmt.Errorf("dcerpc bind: %w", err)
+	}
+
+	c.callID = 1
+	c.contextID = 0
+
+	bind := &pdu.Bind{
+		MaxXmitFrag:  c.transport.MaxXmitFrag(),
+		MaxRecvFrag:  c.transport.MaxRecvFrag(),
+		AssocGroupID: 0,
+		ContextList: []pdu.ContextElement{
+			{
+				ContextID:        c.contextID,
+				AbstractSyntax:   abstractSyntax,
+				TransferSyntaxes: []syntax.SyntaxID{syntax.NDRTransferSyntax()},
+			},
+		},
+	}
+	bind.Header = pdu.NewHeader(pdu.PacketTypeBind, pdu.PFCFirstFrag|pdu.PFCLastFrag, c.callID)
+
+	raw, err := bind.Marshal()
+	if err != nil {
+		return fmt.Errorf("dcerpc bind: marshal: %w", err)
+	}
+	if err := c.transport.Send(raw); err != nil {
+		return fmt.Errorf("dcerpc bind: send: %w", err)
+	}
+
+	respFrag, err := c.readFragment(&fragmentReader{t: c.transport})
+	if err != nil {
+		return fmt.Errorf("dcerpc bind: recv: %w", err)
+	}
+
+	hdr, err := pdu.PeekHeader(respFrag)
+	if err != nil {
+		return fmt.Errorf("dcerpc bind: %w", err)
+	}
+	switch hdr.PacketType {
+	case pdu.PacketTypeBindAck:
+		var ack pdu.BindAck
+		if _, err := ack.Unmarshal(respFrag); err != nil {
+			return fmt.Errorf("dcerpc bind: parse bind_ack: %w", err)
+		}
+		if !ack.Accepted() {
+			return fmt.Errorf("dcerpc bind: server accepted no presentation context: %s", ack.String())
+		}
+		c.sendFragMax = negotiateSendMax(c.transport.MaxXmitFrag(), ack.MaxXmitFrag, ack.MaxRecvFrag)
+		c.bound = true
+		return nil
+	case pdu.PacketTypeBindNak:
+		var nak pdu.BindNak
+		if _, err := nak.Unmarshal(respFrag); err != nil {
+			return fmt.Errorf("dcerpc bind: parse bind_nak: %w", err)
+		}
+		return fmt.Errorf("dcerpc bind rejected: reject_reason=%d", nak.RejectReason)
+	default:
+		return fmt.Errorf("dcerpc bind: unexpected response PDU type %s", hdr.PacketType)
+	}
+}
+
+// Call invokes the method identified by opnum, sending stub as its marshalled
+// arguments and returning the marshalled results. A fault PDU is returned as a
+// *pdu.Fault error.
+func (c *Client) Call(opnum uint16, stub []byte) ([]byte, error) {
+	if !c.bound {
+		return nil, fmt.Errorf("dcerpc call: not bound; call Bind first")
+	}
+
+	c.callID++
+
+	if err := c.sendRequest(opnum, stub); err != nil {
+		return nil, fmt.Errorf("dcerpc call (opnum %d): %w", opnum, err)
+	}
+
+	result, err := c.readResponse()
+	if err != nil {
+		return nil, fmt.Errorf("dcerpc call (opnum %d): %w", opnum, err)
+	}
+	return result, nil
+}
+
+// sendRequest fragments stub into request PDUs no larger than the negotiated send
+// size and writes each one.
+func (c *Client) sendRequest(opnum uint16, stub []byte) error {
+	// Largest stub chunk per fragment.
+	budget := int(c.sendFragMax) - requestHeaderOverhead
+	if budget <= 0 {
+		return fmt.Errorf("negotiated fragment size %d too small for a request", c.sendFragMax)
+	}
+
+	// A zero-length stub still requires one (empty) fragment.
+	for first, offset := true, 0; first || offset < len(stub); first = false {
+		end := offset + budget
+		if end > len(stub) {
+			end = len(stub)
+		}
+		chunk := stub[offset:end]
+
+		var flags pdu.PFCFlags
+		if first {
+			flags |= pdu.PFCFirstFrag
+		}
+		if end >= len(stub) {
+			flags |= pdu.PFCLastFrag
+		}
+
+		req := &pdu.Request{
+			ContextID: c.contextID,
+			Opnum:     opnum,
+			AllocHint: uint32(len(stub) - offset), // bytes remaining from this fragment on
+			Stub:      chunk,
+		}
+		req.Header = pdu.NewHeader(pdu.PacketTypeRequest, flags, c.callID)
+
+		raw, err := req.Marshal()
+		if err != nil {
+			return fmt.Errorf("marshal request fragment: %w", err)
+		}
+		if err := c.transport.Send(raw); err != nil {
+			return fmt.Errorf("send request fragment: %w", err)
+		}
+
+		offset = end
+	}
+	return nil
+}
+
+// readResponse reassembles response fragments until PFC_LAST_FRAG, returning the
+// concatenated stub data. A fault PDU is returned as a *pdu.Fault error.
+func (c *Client) readResponse() ([]byte, error) {
+	fr := &fragmentReader{t: c.transport}
+	var stub []byte
+
+	for {
+		frag, err := c.readFragment(fr)
+		if err != nil {
+			return nil, err
+		}
+
+		hdr, err := pdu.PeekHeader(frag)
+		if err != nil {
+			return nil, err
+		}
+
+		switch hdr.PacketType {
+		case pdu.PacketTypeResponse:
+			var resp pdu.Response
+			if _, err := resp.Unmarshal(frag); err != nil {
+				return nil, fmt.Errorf("parse response: %w", err)
+			}
+			if resp.Header.CallID != c.callID {
+				return nil, fmt.Errorf("response call_id %d does not match request call_id %d", resp.Header.CallID, c.callID)
+			}
+			stub = append(stub, resp.Stub...)
+			if hdr.PacketFlags.Has(pdu.PFCLastFrag) {
+				return stub, nil
+			}
+		case pdu.PacketTypeFault:
+			var fault pdu.Fault
+			if _, err := fault.Unmarshal(frag); err != nil {
+				return nil, fmt.Errorf("parse fault: %w", err)
+			}
+			return nil, &fault
+		default:
+			return nil, fmt.Errorf("unexpected response PDU type %s", hdr.PacketType)
+		}
+	}
+}
+
+// readFragment reads one complete PDU from fr.
+func (c *Client) readFragment(fr *fragmentReader) ([]byte, error) {
+	return fr.next()
+}
+
+// Close closes the underlying transport.
+func (c *Client) Close() error {
+	c.bound = false
+	return c.transport.Close()
+}
+
+// negotiateSendMax derives the maximum request fragment size from our proposal and
+// the server's bind_ack values. A request fragment must fit within what the server
+// will receive, so the smallest of the relevant limits is used.
+func negotiateSendMax(ourXmit, ackXmit, ackRecv uint16) uint16 {
+	m := ourXmit
+	if ackXmit != 0 && ackXmit < m {
+		m = ackXmit
+	}
+	if ackRecv != 0 && ackRecv < m {
+		m = ackRecv
+	}
+	return m
+}
+
+// fragmentReader turns the transport's read-sized Recv into a stream of complete
+// PDUs, buffering bytes that span or straddle reads.
+type fragmentReader struct {
+	t   transport.Transport
+	buf []byte
+}
+
+// next returns the next complete PDU, reading from the transport as needed.
+func (fr *fragmentReader) next() ([]byte, error) {
+	if err := fr.fill(pdu.HeaderSize); err != nil {
+		return nil, err
+	}
+	hdr, err := pdu.PeekHeader(fr.buf)
+	if err != nil {
+		return nil, err
+	}
+	fragLen := int(hdr.FragLength)
+	if fragLen < pdu.HeaderSize {
+		return nil, fmt.Errorf("invalid frag_length %d", fragLen)
+	}
+	if err := fr.fill(fragLen); err != nil {
+		return nil, err
+	}
+	frag := fr.buf[:fragLen]
+	fr.buf = fr.buf[fragLen:]
+	return frag, nil
+}
+
+// fill reads from the transport until the buffer holds at least n bytes.
+func (fr *fragmentReader) fill(n int) error {
+	for len(fr.buf) < n {
+		chunk, err := fr.t.Recv()
+		if err != nil {
+			return err
+		}
+		if len(chunk) == 0 {
+			return fmt.Errorf("connection closed after %d of %d expected bytes", len(fr.buf), n)
+		}
+		fr.buf = append(fr.buf, chunk...)
+	}
+	return nil
+}

--- a/network/dcerpc/client/client_test.go
+++ b/network/dcerpc/client/client_test.go
@@ -1,0 +1,323 @@
+package client
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/pdu"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+)
+
+// fakeTransport is an in-memory transport.Transport for driving the client without a
+// network. Recv pops queued chunks in order, letting tests split a PDU across reads.
+type fakeTransport struct {
+	maxXmit, maxRecv uint16
+	connectErr       error
+
+	sent      [][]byte
+	recvQueue [][]byte
+}
+
+func (f *fakeTransport) Connect() error { return f.connectErr }
+func (f *fakeTransport) Send(pdu []byte) error {
+	f.sent = append(f.sent, append([]byte(nil), pdu...))
+	return nil
+}
+func (f *fakeTransport) Recv() ([]byte, error) {
+	if len(f.recvQueue) == 0 {
+		return nil, errors.New("recv queue empty")
+	}
+	chunk := f.recvQueue[0]
+	f.recvQueue = f.recvQueue[1:]
+	return chunk, nil
+}
+func (f *fakeTransport) Close() error        { return nil }
+func (f *fakeTransport) MaxXmitFrag() uint16 { return f.maxXmit }
+func (f *fakeTransport) MaxRecvFrag() uint16 { return f.maxRecv }
+
+// queue appends one or more whole PDUs to the recv queue as a single read chunk.
+func (f *fakeTransport) queue(chunks ...[]byte) {
+	for _, c := range chunks {
+		f.recvQueue = append(f.recvQueue, c)
+	}
+}
+
+func testSyntax() syntax.SyntaxID {
+	return syntax.SyntaxID{
+		UUID:         guid.GUID{A: 0x12345678, B: 0x1234, C: 0xabcd, D: 0xef00, E: 0x0123456789ab},
+		MajorVersion: 1,
+		MinorVersion: 0,
+	}
+}
+
+func mustMarshal(t *testing.T, m interface{ Marshal() ([]byte, error) }) []byte {
+	t.Helper()
+	b, err := m.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	return b
+}
+
+func bindAckBytes(t *testing.T, xmit, recv uint16) []byte {
+	ack := &pdu.BindAck{
+		MaxXmitFrag:      xmit,
+		MaxRecvFrag:      recv,
+		SecondaryAddress: "lsarpc",
+		Results:          []pdu.PresentationResult{{Result: pdu.ResultAcceptance, TransferSyntax: syntax.NDRTransferSyntax()}},
+	}
+	return mustMarshal(t, ack)
+}
+
+func responseBytes(t *testing.T, callID uint32, flags pdu.PFCFlags, stub []byte) []byte {
+	resp := &pdu.Response{Stub: stub}
+	resp.Header = pdu.NewHeader(pdu.PacketTypeResponse, flags, callID)
+	return mustMarshal(t, resp)
+}
+
+func TestBind_Success(t *testing.T) {
+	ft := &fakeTransport{maxXmit: 4280, maxRecv: 4280}
+	ft.queue(bindAckBytes(t, 4280, 4280))
+
+	c := NewClient(ft)
+	if err := c.Bind(testSyntax()); err != nil {
+		t.Fatalf("Bind() error = %v", err)
+	}
+	if !c.bound {
+		t.Fatal("client not marked bound after successful Bind")
+	}
+	if c.sendFragMax != 4280 {
+		t.Errorf("sendFragMax = %d, want 4280", c.sendFragMax)
+	}
+
+	// Verify the bind PDU we sent.
+	if len(ft.sent) != 1 {
+		t.Fatalf("sent %d PDUs, want 1", len(ft.sent))
+	}
+	var bind pdu.Bind
+	if _, err := bind.Unmarshal(ft.sent[0]); err != nil {
+		t.Fatalf("sent bind does not parse: %v", err)
+	}
+	if bind.Header.CallID != 1 {
+		t.Errorf("bind call_id = %d, want 1", bind.Header.CallID)
+	}
+	if len(bind.ContextList) != 1 || !bind.ContextList[0].AbstractSyntax.Equal(testSyntax()) {
+		t.Errorf("bind abstract syntax not as expected: %+v", bind.ContextList)
+	}
+	if !bind.ContextList[0].TransferSyntaxes[0].Equal(syntax.NDRTransferSyntax()) {
+		t.Error("bind did not propose NDR transfer syntax")
+	}
+}
+
+func TestBind_Nak(t *testing.T) {
+	nak := &pdu.BindNak{RejectReason: pdu.ReasonProposedTransferSyntaxesNotSupported, Versions: []pdu.ProtocolVersion{{Major: 5, Minor: 0}}}
+	ft := &fakeTransport{maxXmit: 4280, maxRecv: 4280}
+	ft.queue(mustMarshal(t, nak))
+
+	c := NewClient(ft)
+	if err := c.Bind(testSyntax()); err == nil {
+		t.Fatal("Bind() with bind_nak: error = nil, want non-nil")
+	}
+	if c.bound {
+		t.Error("client marked bound after bind_nak")
+	}
+}
+
+func TestBind_NoContextAccepted(t *testing.T) {
+	ack := &pdu.BindAck{
+		MaxXmitFrag: 4280,
+		MaxRecvFrag: 4280,
+		Results:     []pdu.PresentationResult{{Result: pdu.ResultProviderRejection, Reason: pdu.ReasonAbstractSyntaxNotSupported}},
+	}
+	ft := &fakeTransport{maxXmit: 4280, maxRecv: 4280}
+	ft.queue(mustMarshal(t, ack))
+
+	c := NewClient(ft)
+	if err := c.Bind(testSyntax()); err == nil {
+		t.Fatal("Bind() with no accepted context: error = nil, want non-nil")
+	}
+}
+
+func TestBind_ConnectError(t *testing.T) {
+	ft := &fakeTransport{maxXmit: 4280, maxRecv: 4280, connectErr: errors.New("pipe open failed")}
+	c := NewClient(ft)
+	if err := c.Bind(testSyntax()); err == nil {
+		t.Fatal("Bind() with connect error: error = nil, want non-nil")
+	}
+}
+
+func TestCall_SingleFragment(t *testing.T) {
+	ft := &fakeTransport{maxXmit: 4280, maxRecv: 4280}
+	ft.queue(bindAckBytes(t, 4280, 4280))
+	c := NewClient(ft)
+	if err := c.Bind(testSyntax()); err != nil {
+		t.Fatalf("Bind() error = %v", err)
+	}
+
+	// First call uses call_id 2 (Bind used 1).
+	wantStub := []byte{0xca, 0xfe, 0xba, 0xbe}
+	ft.queue(responseBytes(t, 2, pdu.PFCFirstFrag|pdu.PFCLastFrag, wantStub))
+
+	got, err := c.Call(0x000c, []byte{0x01, 0x02})
+	if err != nil {
+		t.Fatalf("Call() error = %v", err)
+	}
+	if !bytes.Equal(got, wantStub) {
+		t.Errorf("Call() = %x, want %x", got, wantStub)
+	}
+
+	// The request PDU is sent after the bind PDU.
+	if len(ft.sent) != 2 {
+		t.Fatalf("sent %d PDUs, want 2 (bind + request)", len(ft.sent))
+	}
+	var req pdu.Request
+	if _, err := req.Unmarshal(ft.sent[1]); err != nil {
+		t.Fatalf("sent request does not parse: %v", err)
+	}
+	if req.Opnum != 0x000c {
+		t.Errorf("opnum = %d, want 12", req.Opnum)
+	}
+	if req.Header.CallID != 2 {
+		t.Errorf("request call_id = %d, want 2", req.Header.CallID)
+	}
+	if !req.Header.PacketFlags.Has(pdu.PFCFirstFrag) || !req.Header.PacketFlags.Has(pdu.PFCLastFrag) {
+		t.Errorf("single-fragment request flags = %s, want first|last", req.Header.PacketFlags)
+	}
+}
+
+func TestCall_Fault(t *testing.T) {
+	ft := &fakeTransport{maxXmit: 4280, maxRecv: 4280}
+	ft.queue(bindAckBytes(t, 4280, 4280))
+	c := NewClient(ft)
+	if err := c.Bind(testSyntax()); err != nil {
+		t.Fatalf("Bind() error = %v", err)
+	}
+
+	fault := &pdu.Fault{Status: pdu.NCASOpRngError}
+	fault.Header = pdu.NewHeader(pdu.PacketTypeFault, pdu.PFCFirstFrag|pdu.PFCLastFrag, 2)
+	ft.queue(mustMarshal(t, fault))
+
+	_, err := c.Call(0x0099, nil)
+	if err == nil {
+		t.Fatal("Call() returning a fault: error = nil, want non-nil")
+	}
+	var fe *pdu.Fault
+	if !errors.As(err, &fe) {
+		t.Fatalf("error is not *pdu.Fault: %v", err)
+	}
+	if fe.Status != pdu.NCASOpRngError {
+		t.Errorf("fault status = %#x, want %#x", fe.Status, pdu.NCASOpRngError)
+	}
+}
+
+func TestCall_MultiFragmentResponseReassembly(t *testing.T) {
+	ft := &fakeTransport{maxXmit: 4280, maxRecv: 4280}
+	ft.queue(bindAckBytes(t, 4280, 4280))
+	c := NewClient(ft)
+	if err := c.Bind(testSyntax()); err != nil {
+		t.Fatalf("Bind() error = %v", err)
+	}
+
+	part1 := []byte{0x11, 0x22, 0x33}
+	part2 := []byte{0x44, 0x55}
+	frag1 := responseBytes(t, 2, pdu.PFCFirstFrag, part1)
+	frag2 := responseBytes(t, 2, pdu.PFCLastFrag, part2)
+
+	// Concatenate both response fragments and deliver them split at an arbitrary,
+	// non-PDU-aligned boundary to exercise the fragment reader's buffering.
+	all := append(append([]byte(nil), frag1...), frag2...)
+	cut := len(frag1) - 2
+	ft.queue(all[:cut], all[cut:])
+
+	got, err := c.Call(0x0001, nil)
+	if err != nil {
+		t.Fatalf("Call() error = %v", err)
+	}
+	want := append(append([]byte(nil), part1...), part2...)
+	if !bytes.Equal(got, want) {
+		t.Errorf("reassembled stub = %x, want %x", got, want)
+	}
+}
+
+func TestCall_MultiFragmentRequest(t *testing.T) {
+	// Negotiate a tiny fragment size so the request must be split. Budget per
+	// fragment = sendFragMax - requestHeaderOverhead.
+	const frag = uint16(requestHeaderOverhead + 4) // 4 stub bytes per fragment
+	ft := &fakeTransport{maxXmit: 4280, maxRecv: 4280}
+	ft.queue(bindAckBytes(t, frag, frag))
+	c := NewClient(ft)
+	if err := c.Bind(testSyntax()); err != nil {
+		t.Fatalf("Bind() error = %v", err)
+	}
+	if c.sendFragMax != frag {
+		t.Fatalf("sendFragMax = %d, want %d", c.sendFragMax, frag)
+	}
+
+	stub := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10} // 10 bytes -> 4 + 4 + 2
+	ft.queue(responseBytes(t, 2, pdu.PFCFirstFrag|pdu.PFCLastFrag, []byte{0xff}))
+
+	if _, err := c.Call(0x0005, stub); err != nil {
+		t.Fatalf("Call() error = %v", err)
+	}
+
+	// Request fragments are everything sent after the bind PDU.
+	reqFrags := ft.sent[1:]
+	if len(reqFrags) != 3 {
+		t.Fatalf("request split into %d fragments, want 3", len(reqFrags))
+	}
+
+	var reassembled []byte
+	for i, raw := range reqFrags {
+		if len(raw) > int(frag) {
+			t.Errorf("fragment %d is %d bytes, exceeds negotiated %d", i, len(raw), frag)
+		}
+		var req pdu.Request
+		if _, err := req.Unmarshal(raw); err != nil {
+			t.Fatalf("fragment %d does not parse: %v", i, err)
+		}
+		first := req.Header.PacketFlags.Has(pdu.PFCFirstFrag)
+		last := req.Header.PacketFlags.Has(pdu.PFCLastFrag)
+		switch i {
+		case 0:
+			if !first || last {
+				t.Errorf("fragment 0 flags = %s, want first only", req.Header.PacketFlags)
+			}
+		case len(reqFrags) - 1:
+			if first || !last {
+				t.Errorf("last fragment flags = %s, want last only", req.Header.PacketFlags)
+			}
+		default:
+			if first || last {
+				t.Errorf("middle fragment %d flags = %s, want none", i, req.Header.PacketFlags)
+			}
+		}
+		reassembled = append(reassembled, req.Stub...)
+	}
+	if !bytes.Equal(reassembled, stub) {
+		t.Errorf("reassembled request stub = %x, want %x", reassembled, stub)
+	}
+}
+
+func TestCall_NotBound(t *testing.T) {
+	ft := &fakeTransport{maxXmit: 4280, maxRecv: 4280}
+	c := NewClient(ft)
+	if _, err := c.Call(1, nil); err == nil {
+		t.Fatal("Call() before Bind: error = nil, want non-nil")
+	}
+}
+
+func TestCall_CallIDMismatch(t *testing.T) {
+	ft := &fakeTransport{maxXmit: 4280, maxRecv: 4280}
+	ft.queue(bindAckBytes(t, 4280, 4280))
+	c := NewClient(ft)
+	if err := c.Bind(testSyntax()); err != nil {
+		t.Fatalf("Bind() error = %v", err)
+	}
+	// Response carries the wrong call_id (3 instead of 2).
+	ft.queue(responseBytes(t, 3, pdu.PFCFirstFrag|pdu.PFCLastFrag, []byte{0x01}))
+	if _, err := c.Call(1, nil); err == nil {
+		t.Fatal("Call() with mismatched response call_id: error = nil, want non-nil")
+	}
+}

--- a/network/dcerpc/dcerpc.go
+++ b/network/dcerpc/dcerpc.go
@@ -1,0 +1,26 @@
+// Package dcerpc implements a DCE/RPC (C706) client with the Microsoft MS-RPCE
+// extensions, layered on top of a pluggable transport.
+//
+// The connection-oriented DCE/RPC protocol carries each call as one or more PDUs
+// (Bind, Bind_Ack, Request, Response, Fault, ...) over a transport that provides a
+// request/response message exchange. The transport abstraction lives in
+// network/dcerpc/transport; the SMB named-pipe transport (protocol sequence
+// ncacn_np) lives in network/dcerpc/transport/smb and wraps an authenticated
+// network/smb/smb_v10/client.Client.
+//
+// This package currently provides the transport layer (Phase 1). The PDU layer and
+// the high-level Bind/Call client are built on top of it in later phases.
+//
+// References:
+//   - [C706] DCE 1.1: Remote Procedure Call
+//   - [MS-RPCE] Remote Procedure Call Protocol Extensions
+package dcerpc
+
+// Connection-oriented DCE/RPC protocol version, as carried in the common header of
+// every PDU ([C706] section 12.6.3.1).
+const (
+	// MajorVersion is the rpc_vers field value.
+	MajorVersion uint8 = 5
+	// MinorVersion is the rpc_vers_minor field value.
+	MinorVersion uint8 = 0
+)

--- a/network/dcerpc/interfaces/lsarpc/lsarpc.go
+++ b/network/dcerpc/interfaces/lsarpc/lsarpc.go
@@ -1,0 +1,164 @@
+// Package lsarpc implements a minimal client for the Local Security Authority
+// (Domain Policy) Remote Protocol interface (lsarpc, [MS-LSAD] / [MS-LSAT]).
+//
+// It is the first concrete DCE/RPC interface in the tree and exists to validate the
+// whole stack end to end: SMB session -> named pipe -> DCE/RPC bind -> call. Only the
+// two calls needed for that proof are implemented, LsarOpenPolicy2 (the mandatory
+// first call that returns a policy handle) and LsarClose. Their NDR is hand-marshalled
+// rather than produced by a generic NDR engine.
+//
+// References:
+//   - [MS-LSAD] Local Security Authority (Domain Policy) Remote Protocol:
+//     https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-lsad/1b5471ef-4c33-4a91-b079-dfcbb82f05cc
+//   - [MS-LSAD] LsarOpenPolicy2 (Opnum 44):
+//     https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-lsad/9456a963-7c21-4710-af77-d0a2f5a72d6b
+//   - [MS-LSAD] LsarClose (Opnum 0):
+//     https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-lsad/a0ad7d8b-bb3b-4d3d-8c2e-e0c5b3a2a8b4
+//   - [MS-LSAD] 2.2.2.1 LSAPR_HANDLE (RPC context handle):
+//     https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-lsad/0d093105-e8c8-45f7-a79d-182aafd60c6e
+//   - [MS-LSAD] 2.2.1.1.2 ACCESS_MASK for policy objects:
+//     https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-lsad/b61b7268-987a-420b-84f9-6c75f8dc8558
+package lsarpc
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/client"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+)
+
+// PipeName is the named pipe to open for the lsarpc interface. When the SMB tree is
+// connected to IPC$, the pipe is opened by its name relative to that share (the
+// "\PIPE" namespace is implicit), so the NT_CREATE_ANDX FileName is "\lsarpc" rather
+// than the MS-RPCE well-known endpoint "\pipe\lsarpc".
+const PipeName = `\lsarpc`
+
+// Opnums for the implemented methods ([MS-LSAD] section 3.1.4).
+const (
+	OpnumClose       uint16 = 0
+	OpnumOpenPolicy2 uint16 = 44
+)
+
+// Policy object access rights ([MS-LSAD] section 2.2.1.1.2), plus the generic
+// MAXIMUM_ALLOWED bit ([MS-DTYP] ACCESS_MASK).
+const (
+	PolicyViewLocalInformation  uint32 = 0x00000001
+	PolicyViewAuditInformation  uint32 = 0x00000002
+	PolicyGetPrivateInformation uint32 = 0x00000004
+	PolicyTrustAdmin            uint32 = 0x00000008
+	PolicyCreateAccount         uint32 = 0x00000010
+	PolicyLookupNames           uint32 = 0x00000800
+	MaximumAllowed              uint32 = 0x02000000
+)
+
+// Common NTSTATUS codes returned by these methods ([MS-LSAD] return values).
+const (
+	StatusSuccess          uint32 = 0x00000000
+	StatusAccessDenied     uint32 = 0xC0000022
+	StatusInvalidParameter uint32 = 0xC000000D
+)
+
+// SyntaxID returns the lsarpc abstract syntax identifier:
+// 12345778-1234-abcd-ef00-0123456789ab, version 0.0.
+func SyntaxID() syntax.SyntaxID {
+	return syntax.SyntaxID{
+		UUID:         guid.GUID{A: 0x12345778, B: 0x1234, C: 0xabcd, D: 0xef00, E: 0x0123456789ab},
+		MajorVersion: 0,
+		MinorVersion: 0,
+	}
+}
+
+// PolicyHandle is an RPC context handle (LSAPR_HANDLE): a 4-byte attributes field
+// followed by a 16-byte GUID, 20 bytes total ([MS-RPCE] 2.3.2.2, [MS-LSAD] 2.2.2.1).
+type PolicyHandle [20]byte
+
+// IsZero reports whether the handle is all zeros (for example, after a successful
+// Close).
+func (h PolicyHandle) IsZero() bool {
+	for _, b := range h {
+		if b != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// OpenPolicy2 calls LsarOpenPolicy2 (opnum 44) and returns a policy handle.
+//
+// The request stub is hand-marshalled NDR:
+//   - SystemName ([in, unique, string] wchar_t*): a NULL unique pointer (4 zero
+//     bytes). The server ignores it ([MS-LSAD] 3.1.4.4.1).
+//   - ObjectAttributes (PLSAPR_OBJECT_ATTRIBUTES, a top-level reference pointer so the
+//     struct is inline): six 4-byte fields, all zero (Length, RootDirectory,
+//     ObjectName, Attributes, SecurityDescriptor, SecurityQualityOfService). All are
+//     ignored except RootDirectory, which must be NULL.
+//   - DesiredAccess (ACCESS_MASK): the requested access, little-endian.
+func OpenPolicy2(rpc *client.Client, desiredAccess uint32) (PolicyHandle, error) {
+	stub := make([]byte, 0, 32)
+	stub = append(stub, 0, 0, 0, 0)          // SystemName: NULL unique pointer
+	stub = append(stub, make([]byte, 24)...) // ObjectAttributes: all-zero inline struct
+	stub = binary.LittleEndian.AppendUint32(stub, desiredAccess)
+
+	resp, err := rpc.Call(OpnumOpenPolicy2, stub)
+	if err != nil {
+		return PolicyHandle{}, fmt.Errorf("LsarOpenPolicy2: %w", err)
+	}
+	handle, status, err := parseHandleResponse(resp)
+	if err != nil {
+		return PolicyHandle{}, fmt.Errorf("LsarOpenPolicy2: %w", err)
+	}
+	if status != StatusSuccess {
+		return handle, fmt.Errorf("LsarOpenPolicy2 failed: %s", StatusString(status))
+	}
+	return handle, nil
+}
+
+// Close calls LsarClose (opnum 0) on a handle. On success the server returns a zeroed
+// handle, which is returned to the caller.
+//
+// LsarClose([in, out] LSAPR_HANDLE* ObjectHandle) -> NTSTATUS. The request stub is the
+// 20-byte handle; the response is the (zeroed) handle followed by the NTSTATUS.
+func Close(rpc *client.Client, handle PolicyHandle) (PolicyHandle, error) {
+	resp, err := rpc.Call(OpnumClose, handle[:])
+	if err != nil {
+		return PolicyHandle{}, fmt.Errorf("LsarClose: %w", err)
+	}
+	out, status, err := parseHandleResponse(resp)
+	if err != nil {
+		return PolicyHandle{}, fmt.Errorf("LsarClose: %w", err)
+	}
+	if status != StatusSuccess {
+		return out, fmt.Errorf("LsarClose failed: %s", StatusString(status))
+	}
+	return out, nil
+}
+
+// parseHandleResponse decodes a response consisting of a 20-byte context handle
+// followed by a 4-byte NTSTATUS return value.
+func parseHandleResponse(resp []byte) (PolicyHandle, uint32, error) {
+	const want = 24
+	if len(resp) < want {
+		return PolicyHandle{}, 0, fmt.Errorf("response too short: have %d bytes, need %d", len(resp), want)
+	}
+	var h PolicyHandle
+	copy(h[:], resp[0:20])
+	status := binary.LittleEndian.Uint32(resp[20:24])
+	return h, status, nil
+}
+
+// StatusString returns a mnemonic for the documented status codes, otherwise the hex
+// value.
+func StatusString(status uint32) string {
+	switch status {
+	case StatusSuccess:
+		return "STATUS_SUCCESS"
+	case StatusAccessDenied:
+		return "STATUS_ACCESS_DENIED"
+	case StatusInvalidParameter:
+		return "STATUS_INVALID_PARAMETER"
+	default:
+		return fmt.Sprintf("0x%08x", status)
+	}
+}

--- a/network/dcerpc/interfaces/lsarpc/lsarpc_integration_test.go
+++ b/network/dcerpc/interfaces/lsarpc/lsarpc_integration_test.go
@@ -1,0 +1,96 @@
+//go:build integration
+
+// Integration test for the full DCE/RPC-over-SMB stack against a live server.
+//
+// It is excluded from the default build by the "integration" tag, since it needs a
+// reachable SMB server. Run it with, for example:
+//
+//	DCERPC_TEST_HOST=192.168.1.27 \
+//	DCERPC_TEST_USER=user DCERPC_TEST_PASS=user \
+//	go test -tags integration -v ./network/dcerpc/interfaces/lsarpc/
+//
+// Optional: DCERPC_TEST_DOMAIN, DCERPC_TEST_PORT (default 445).
+package lsarpc
+
+import (
+	"net"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/client"
+	dcerpcsmb "github.com/TheManticoreProject/Manticore/network/dcerpc/transport/smb"
+	smbclient "github.com/TheManticoreProject/Manticore/network/smb/smb_v10/client"
+	"github.com/TheManticoreProject/Manticore/windows/credentials"
+)
+
+func TestIntegration_OpenAndClosePolicy(t *testing.T) {
+	host := os.Getenv("DCERPC_TEST_HOST")
+	if host == "" {
+		t.Skip("DCERPC_TEST_HOST not set; skipping live integration test")
+	}
+	user := os.Getenv("DCERPC_TEST_USER")
+	pass := os.Getenv("DCERPC_TEST_PASS")
+	domain := os.Getenv("DCERPC_TEST_DOMAIN")
+	port := 445
+	if p := os.Getenv("DCERPC_TEST_PORT"); p != "" {
+		n, err := strconv.Atoi(p)
+		if err != nil {
+			t.Fatalf("invalid DCERPC_TEST_PORT %q: %v", p, err)
+		}
+		port = n
+	}
+
+	ip := net.ParseIP(host)
+	if ip == nil {
+		t.Fatalf("DCERPC_TEST_HOST %q is not a valid IP", host)
+	}
+
+	creds, err := credentials.NewCredentials(domain, user, pass, "")
+	if err != nil {
+		t.Fatalf("NewCredentials: %v", err)
+	}
+
+	// Establish the SMB session and connect to the IPC$ tree that hosts named pipes.
+	smb := smbclient.NewClientUsingTCPTransport(ip, port)
+	if err := smb.Connect(ip, port); err != nil {
+		t.Fatalf("SMB Connect: %v", err)
+	}
+	defer smb.Disconnect()
+	// NativeOS/NativeLanMan must be set before SessionSetup; some servers reject the
+	// session setup otherwise (mirrors the repo's main.go).
+	smb.NativeOS = "Unix"
+	smb.NativeLanMan = "Samba"
+	if err := smb.SessionSetup(creds); err != nil {
+		t.Fatalf("SMB SessionSetup: %v", err)
+	}
+	defer smb.Logoff()
+	if err := smb.TreeConnect("IPC$"); err != nil {
+		t.Fatalf("SMB TreeConnect(IPC$): %v", err)
+	}
+	defer smb.TreeDisconnect()
+
+	// Bind DCE/RPC to lsarpc over the named pipe.
+	pipe := dcerpcsmb.New(smb, PipeName)
+	rpc := client.NewClient(pipe)
+	defer rpc.Close()
+	if err := rpc.Bind(SyntaxID()); err != nil {
+		t.Fatalf("DCE/RPC Bind(lsarpc): %v", err)
+	}
+	t.Log("bound to lsarpc")
+
+	// LsarOpenPolicy2 -> handle, then LsarClose.
+	handle, err := OpenPolicy2(rpc, MaximumAllowed)
+	if err != nil {
+		t.Fatalf("OpenPolicy2: %v", err)
+	}
+	t.Logf("OpenPolicy2 returned handle %x", handle)
+	if handle.IsZero() {
+		t.Error("OpenPolicy2 returned a zero handle on success")
+	}
+
+	if _, err := Close(rpc, handle); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	t.Log("policy handle closed")
+}

--- a/network/dcerpc/interfaces/lsarpc/lsarpc_test.go
+++ b/network/dcerpc/interfaces/lsarpc/lsarpc_test.go
@@ -1,0 +1,168 @@
+package lsarpc
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/client"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/pdu"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
+)
+
+// fakeTransport is an in-memory transport.Transport for driving the client without a
+// network.
+type fakeTransport struct {
+	sent      [][]byte
+	recvQueue [][]byte
+}
+
+func (f *fakeTransport) Connect() error { return nil }
+func (f *fakeTransport) Send(pdu []byte) error {
+	f.sent = append(f.sent, append([]byte(nil), pdu...))
+	return nil
+}
+func (f *fakeTransport) Recv() ([]byte, error) {
+	if len(f.recvQueue) == 0 {
+		return nil, errors.New("recv queue empty")
+	}
+	c := f.recvQueue[0]
+	f.recvQueue = f.recvQueue[1:]
+	return c, nil
+}
+func (f *fakeTransport) Close() error        { return nil }
+func (f *fakeTransport) MaxXmitFrag() uint16 { return 4280 }
+func (f *fakeTransport) MaxRecvFrag() uint16 { return 4280 }
+
+func (f *fakeTransport) queue(b []byte) { f.recvQueue = append(f.recvQueue, b) }
+
+func bindAck(t *testing.T) []byte {
+	t.Helper()
+	ack := &pdu.BindAck{
+		MaxXmitFrag: 4280,
+		MaxRecvFrag: 4280,
+		Results:     []pdu.PresentationResult{{Result: pdu.ResultAcceptance, TransferSyntax: syntax.NDRTransferSyntax()}},
+	}
+	b, err := ack.Marshal()
+	if err != nil {
+		t.Fatalf("bind_ack marshal: %v", err)
+	}
+	return b
+}
+
+func responsePDU(t *testing.T, callID uint32, stub []byte) []byte {
+	t.Helper()
+	resp := &pdu.Response{Stub: stub}
+	resp.Header = pdu.NewHeader(pdu.PacketTypeResponse, pdu.PFCFirstFrag|pdu.PFCLastFrag, callID)
+	b, err := resp.Marshal()
+	if err != nil {
+		t.Fatalf("response marshal: %v", err)
+	}
+	return b
+}
+
+// boundClient returns a client already bound to lsarpc over ft.
+func boundClient(t *testing.T, ft *fakeTransport) *client.Client {
+	t.Helper()
+	ft.queue(bindAck(t))
+	c := client.NewClient(ft)
+	if err := c.Bind(SyntaxID()); err != nil {
+		t.Fatalf("Bind() error = %v", err)
+	}
+	return c
+}
+
+func TestOpenPolicy2_RequestMarshalling(t *testing.T) {
+	ft := &fakeTransport{}
+	c := boundClient(t, ft)
+
+	// Canned success response: 20-byte handle + STATUS_SUCCESS. First call is call_id 2.
+	wantHandle := PolicyHandle{0x00, 0x00, 0x00, 0x00, 0xde, 0xad, 0xbe, 0xef, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}
+	respStub := append(append([]byte(nil), wantHandle[:]...), 0x00, 0x00, 0x00, 0x00)
+	ft.queue(responsePDU(t, 2, respStub))
+
+	h, err := OpenPolicy2(c, MaximumAllowed)
+	if err != nil {
+		t.Fatalf("OpenPolicy2() error = %v", err)
+	}
+	if h != wantHandle {
+		t.Errorf("handle = %x, want %x", h, wantHandle)
+	}
+
+	// Verify the request stub: NULL SystemName ptr (4) + zero ObjectAttributes (24) +
+	// DesiredAccess (4, little-endian).
+	if len(ft.sent) != 2 {
+		t.Fatalf("sent %d PDUs, want 2 (bind + request)", len(ft.sent))
+	}
+	var req pdu.Request
+	if _, err := req.Unmarshal(ft.sent[1]); err != nil {
+		t.Fatalf("request does not parse: %v", err)
+	}
+	if req.Opnum != OpnumOpenPolicy2 {
+		t.Errorf("opnum = %d, want %d", req.Opnum, OpnumOpenPolicy2)
+	}
+	wantStub := make([]byte, 0, 32)
+	wantStub = append(wantStub, 0, 0, 0, 0)
+	wantStub = append(wantStub, make([]byte, 24)...)
+	wantStub = append(wantStub, 0x00, 0x00, 0x00, 0x02) // MAXIMUM_ALLOWED 0x02000000 LE
+	if !bytes.Equal(req.Stub, wantStub) {
+		t.Errorf("request stub:\n got %x\nwant %x", req.Stub, wantStub)
+	}
+}
+
+func TestOpenPolicy2_AccessDenied(t *testing.T) {
+	ft := &fakeTransport{}
+	c := boundClient(t, ft)
+
+	respStub := append(make([]byte, 20), 0x22, 0x00, 0x00, 0xc0) // STATUS_ACCESS_DENIED
+	ft.queue(responsePDU(t, 2, respStub))
+
+	_, err := OpenPolicy2(c, PolicyViewLocalInformation)
+	if err == nil {
+		t.Fatal("OpenPolicy2() with access denied: error = nil, want non-nil")
+	}
+}
+
+func TestClose_RoundTrip(t *testing.T) {
+	ft := &fakeTransport{}
+	c := boundClient(t, ft)
+
+	// LsarClose returns a zeroed handle + STATUS_SUCCESS.
+	ft.queue(responsePDU(t, 2, make([]byte, 24)))
+
+	in := PolicyHandle{0x00, 0x00, 0x00, 0x00, 0xaa, 0xbb}
+	out, err := Close(c, in)
+	if err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	if !out.IsZero() {
+		t.Errorf("handle after Close = %x, want zeroed", out)
+	}
+
+	// The request stub is exactly the 20-byte handle.
+	var req pdu.Request
+	if _, err := req.Unmarshal(ft.sent[1]); err != nil {
+		t.Fatalf("request does not parse: %v", err)
+	}
+	if req.Opnum != OpnumClose {
+		t.Errorf("opnum = %d, want %d", req.Opnum, OpnumClose)
+	}
+	if !bytes.Equal(req.Stub, in[:]) {
+		t.Errorf("close request stub = %x, want %x", req.Stub, in[:])
+	}
+}
+
+func TestParseHandleResponse_TooShort(t *testing.T) {
+	if _, _, err := parseHandleResponse(make([]byte, 23)); err == nil {
+		t.Fatal("parseHandleResponse of short buffer: error = nil, want non-nil")
+	}
+}
+
+func TestStatusString(t *testing.T) {
+	if got := StatusString(StatusAccessDenied); got != "STATUS_ACCESS_DENIED" {
+		t.Errorf("StatusString(0xC0000022) = %q", got)
+	}
+	if got := StatusString(0x12345678); got != "0x12345678" {
+		t.Errorf("StatusString(unknown) = %q", got)
+	}
+}

--- a/network/dcerpc/pdu/bind.go
+++ b/network/dcerpc/pdu/bind.go
@@ -1,0 +1,449 @@
+package pdu
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
+)
+
+// Presentation context negotiation result codes (p_cont_def_result_t), as returned in
+// the result field of each p_result_t in a bind_ack PDU.
+//
+// References:
+//   - [C706] section 12.6.3.1 ("The bind_ack PDU"):
+//     https://pubs.opengroup.org/onlinepubs/9629399/chap12.htm
+//   - [MS-RPCE] 2.2.2.4 Presentation Context and Transfer Syntax Negotiation:
+//     https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/ca4d3552-4647-4f40-830b-fd2090adec8f
+//   - [MS-RPCE] negotiate_ack member of p_cont_def_result_t:
+//     https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/8df5c4d4-364d-468c-81fe-ec94c1b40917
+const (
+	ResultAcceptance        uint16 = 0
+	ResultUserRejection     uint16 = 1
+	ResultProviderRejection uint16 = 2
+	ResultNegotiateAck      uint16 = 3 // [MS-RPCE] bind-time feature negotiation
+)
+
+// Provider reject reasons (p_provider_reason_t / p_reject_reason_t).
+//
+// Reference: [C706] section 12.6.3.1:
+// https://pubs.opengroup.org/onlinepubs/9629399/chap12.htm
+const (
+	ReasonNotSpecified                         uint16 = 0
+	ReasonAbstractSyntaxNotSupported           uint16 = 1
+	ReasonProposedTransferSyntaxesNotSupported uint16 = 2
+	ReasonLocalLimitExceeded                   uint16 = 3
+)
+
+// align4 returns the number of padding bytes needed to align offset to a 4-byte
+// boundary.
+func align4(offset int) int { return (4 - (offset % 4)) % 4 }
+
+// ContextElement is a single presentation context proposed in a bind (or
+// alter_context) PDU: a context id, an abstract syntax (the target interface), and
+// one or more candidate transfer syntaxes (p_cont_elem_t).
+//
+// References:
+//   - [C706] section 12.6.3.1 ("The bind PDU"):
+//     https://pubs.opengroup.org/onlinepubs/9629399/chap12.htm
+//   - [MS-RPCE] 2.2.2.4 Presentation Context and Transfer Syntax Negotiation:
+//     https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/ca4d3552-4647-4f40-830b-fd2090adec8f
+type ContextElement struct {
+	ContextID        uint16
+	AbstractSyntax   syntax.SyntaxID
+	TransferSyntaxes []syntax.SyntaxID
+}
+
+// Marshal serializes a presentation context element.
+func (c *ContextElement) Marshal() ([]byte, error) {
+	if len(c.TransferSyntaxes) == 0 {
+		return nil, fmt.Errorf("context element %d has no transfer syntaxes", c.ContextID)
+	}
+	if len(c.TransferSyntaxes) > 0xFF {
+		return nil, fmt.Errorf("context element %d has too many transfer syntaxes (%d)", c.ContextID, len(c.TransferSyntaxes))
+	}
+
+	buf := make([]byte, 4)
+	binary.LittleEndian.PutUint16(buf[0:2], c.ContextID)
+	buf[2] = byte(len(c.TransferSyntaxes))
+	buf[3] = 0 // reserved
+
+	abs, err := c.AbstractSyntax.Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("context element %d: %w", c.ContextID, err)
+	}
+	buf = append(buf, abs...)
+
+	for i := range c.TransferSyntaxes {
+		ts, err := c.TransferSyntaxes[i].Marshal()
+		if err != nil {
+			return nil, fmt.Errorf("context element %d transfer syntax %d: %w", c.ContextID, i, err)
+		}
+		buf = append(buf, ts...)
+	}
+	return buf, nil
+}
+
+// Unmarshal parses a presentation context element and returns the bytes consumed.
+func (c *ContextElement) Unmarshal(data []byte) (int, error) {
+	if len(data) < 4 {
+		return 0, fmt.Errorf("context element header truncated")
+	}
+	c.ContextID = binary.LittleEndian.Uint16(data[0:2])
+	n := int(data[2])
+	pos := 4
+
+	read, err := c.AbstractSyntax.Unmarshal(data[pos:])
+	if err != nil {
+		return 0, fmt.Errorf("context element %d abstract syntax: %w", c.ContextID, err)
+	}
+	pos += read
+
+	c.TransferSyntaxes = make([]syntax.SyntaxID, 0, n)
+	for i := 0; i < n; i++ {
+		var ts syntax.SyntaxID
+		read, err := ts.Unmarshal(data[pos:])
+		if err != nil {
+			return 0, fmt.Errorf("context element %d transfer syntax %d: %w", c.ContextID, i, err)
+		}
+		pos += read
+		c.TransferSyntaxes = append(c.TransferSyntaxes, ts)
+	}
+	return pos, nil
+}
+
+// Bind is a bind PDU: it proposes the maximum fragment sizes, an association group,
+// and a list of presentation contexts to negotiate.
+//
+// References:
+//   - [C706] section 12.6.3.1 ("The bind PDU"):
+//     https://pubs.opengroup.org/onlinepubs/9629399/chap12.htm
+//   - [MS-RPCE] 2.2.2.4 Presentation Context and Transfer Syntax Negotiation:
+//     https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/ca4d3552-4647-4f40-830b-fd2090adec8f
+type Bind struct {
+	Header       Header
+	MaxXmitFrag  uint16
+	MaxRecvFrag  uint16
+	AssocGroupID uint32
+	ContextList  []ContextElement
+}
+
+// Marshal serializes the complete bind PDU, filling in the header's packet type and
+// frag_length.
+func (b *Bind) Marshal() ([]byte, error) {
+	if len(b.ContextList) == 0 {
+		return nil, fmt.Errorf("bind PDU has no presentation contexts")
+	}
+	if len(b.ContextList) > 0xFF {
+		return nil, fmt.Errorf("bind PDU has too many presentation contexts (%d)", len(b.ContextList))
+	}
+
+	body := make([]byte, 8)
+	binary.LittleEndian.PutUint16(body[0:2], b.MaxXmitFrag)
+	binary.LittleEndian.PutUint16(body[2:4], b.MaxRecvFrag)
+	binary.LittleEndian.PutUint32(body[4:8], b.AssocGroupID)
+
+	cl := make([]byte, 4)
+	cl[0] = byte(len(b.ContextList)) // n_context_elem
+	// cl[1] reserved, cl[2:4] reserved2
+	for i := range b.ContextList {
+		elem, err := b.ContextList[i].Marshal()
+		if err != nil {
+			return nil, err
+		}
+		cl = append(cl, elem...)
+	}
+	body = append(body, cl...)
+
+	if b.Header.RPCVersion == 0 && b.Header.DataRepresentation == ([4]byte{}) {
+		b.Header = NewHeader(PacketTypeBind, b.Header.PacketFlags, b.Header.CallID)
+	}
+	b.Header.PacketType = PacketTypeBind
+	b.Header.FragLength = uint16(HeaderSize + len(body))
+
+	hdr, err := b.Header.Marshal()
+	if err != nil {
+		return nil, err
+	}
+	return append(hdr, body...), nil
+}
+
+// Unmarshal parses a complete bind PDU and returns the bytes consumed.
+func (b *Bind) Unmarshal(data []byte) (int, error) {
+	pos, err := b.Header.Unmarshal(data)
+	if err != nil {
+		return 0, err
+	}
+	if b.Header.PacketType != PacketTypeBind {
+		return 0, fmt.Errorf("not a bind PDU: packet type is %s", b.Header.PacketType)
+	}
+	if len(data) < pos+12 {
+		return 0, fmt.Errorf("bind PDU truncated")
+	}
+	b.MaxXmitFrag = binary.LittleEndian.Uint16(data[pos : pos+2])
+	b.MaxRecvFrag = binary.LittleEndian.Uint16(data[pos+2 : pos+4])
+	b.AssocGroupID = binary.LittleEndian.Uint32(data[pos+4 : pos+8])
+	n := int(data[pos+8]) // n_context_elem
+	pos += 12             // skip n_context_elem + reserved + reserved2
+
+	b.ContextList = make([]ContextElement, 0, n)
+	for i := 0; i < n; i++ {
+		var elem ContextElement
+		read, err := elem.Unmarshal(data[pos:])
+		if err != nil {
+			return 0, err
+		}
+		pos += read
+		b.ContextList = append(b.ContextList, elem)
+	}
+	return pos, nil
+}
+
+// String returns a one-line summary.
+func (b *Bind) String() string {
+	return fmt.Sprintf("bind xmit=%d recv=%d assoc_group=%d contexts=%d", b.MaxXmitFrag, b.MaxRecvFrag, b.AssocGroupID, len(b.ContextList))
+}
+
+// PresentationResult is one server response in a bind_ack p_result_list (p_result_t):
+// the negotiation result, an optional reason, and the accepted transfer syntax.
+//
+// Reference: [C706] section 12.6.3.1 ("The bind_ack PDU"):
+// https://pubs.opengroup.org/onlinepubs/9629399/chap12.htm
+type PresentationResult struct {
+	Result         uint16
+	Reason         uint16
+	TransferSyntax syntax.SyntaxID
+}
+
+// Marshal serializes a single presentation result (24 bytes).
+func (r *PresentationResult) Marshal() ([]byte, error) {
+	buf := make([]byte, 4)
+	binary.LittleEndian.PutUint16(buf[0:2], r.Result)
+	binary.LittleEndian.PutUint16(buf[2:4], r.Reason)
+	ts, err := r.TransferSyntax.Marshal()
+	if err != nil {
+		return nil, err
+	}
+	return append(buf, ts...), nil
+}
+
+// Unmarshal parses a single presentation result and returns the bytes consumed.
+func (r *PresentationResult) Unmarshal(data []byte) (int, error) {
+	if len(data) < 4 {
+		return 0, fmt.Errorf("presentation result truncated")
+	}
+	r.Result = binary.LittleEndian.Uint16(data[0:2])
+	r.Reason = binary.LittleEndian.Uint16(data[2:4])
+	read, err := r.TransferSyntax.Unmarshal(data[4:])
+	if err != nil {
+		return 0, err
+	}
+	return 4 + read, nil
+}
+
+// BindAck is a bind_ack PDU: the server's response to a bind, echoing the negotiated
+// fragment sizes and reporting per-context negotiation results.
+//
+// References:
+//   - [C706] section 12.6.3.1 ("The bind_ack PDU"):
+//     https://pubs.opengroup.org/onlinepubs/9629399/chap12.htm
+//   - [MS-RPCE] 2.2.2.4 Presentation Context and Transfer Syntax Negotiation:
+//     https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/ca4d3552-4647-4f40-830b-fd2090adec8f
+type BindAck struct {
+	Header           Header
+	MaxXmitFrag      uint16
+	MaxRecvFrag      uint16
+	AssocGroupID     uint32
+	SecondaryAddress string // port_spec, without the trailing NUL
+	Results          []PresentationResult
+}
+
+// Marshal serializes the complete bind_ack PDU, including the 4-byte alignment pad
+// after the secondary address.
+func (b *BindAck) Marshal() ([]byte, error) {
+	body := make([]byte, 8)
+	binary.LittleEndian.PutUint16(body[0:2], b.MaxXmitFrag)
+	binary.LittleEndian.PutUint16(body[2:4], b.MaxRecvFrag)
+	binary.LittleEndian.PutUint32(body[4:8], b.AssocGroupID)
+
+	// sec_addr (port_any_t): a length followed by a NUL-terminated string. A length
+	// of 0 means no string at all.
+	if b.SecondaryAddress == "" {
+		body = append(body, 0x00, 0x00)
+	} else {
+		addr := append([]byte(b.SecondaryAddress), 0x00)
+		lenBuf := make([]byte, 2)
+		binary.LittleEndian.PutUint16(lenBuf, uint16(len(addr)))
+		body = append(body, lenBuf...)
+		body = append(body, addr...)
+	}
+
+	// Pad to a 4-byte boundary measured from the start of the PDU.
+	pad := align4(HeaderSize + len(body))
+	body = append(body, make([]byte, pad)...)
+
+	rl := make([]byte, 4)
+	rl[0] = byte(len(b.Results)) // n_results
+	for i := range b.Results {
+		r, err := b.Results[i].Marshal()
+		if err != nil {
+			return nil, err
+		}
+		rl = append(rl, r...)
+	}
+	body = append(body, rl...)
+
+	if b.Header.RPCVersion == 0 && b.Header.DataRepresentation == ([4]byte{}) {
+		b.Header = NewHeader(PacketTypeBindAck, b.Header.PacketFlags, b.Header.CallID)
+	}
+	b.Header.PacketType = PacketTypeBindAck
+	b.Header.FragLength = uint16(HeaderSize + len(body))
+
+	hdr, err := b.Header.Marshal()
+	if err != nil {
+		return nil, err
+	}
+	return append(hdr, body...), nil
+}
+
+// Unmarshal parses a complete bind_ack PDU and returns the bytes consumed.
+func (b *BindAck) Unmarshal(data []byte) (int, error) {
+	pos, err := b.Header.Unmarshal(data)
+	if err != nil {
+		return 0, err
+	}
+	if b.Header.PacketType != PacketTypeBindAck {
+		return 0, fmt.Errorf("not a bind_ack PDU: packet type is %s", b.Header.PacketType)
+	}
+	if len(data) < pos+10 {
+		return 0, fmt.Errorf("bind_ack PDU truncated")
+	}
+	b.MaxXmitFrag = binary.LittleEndian.Uint16(data[pos : pos+2])
+	b.MaxRecvFrag = binary.LittleEndian.Uint16(data[pos+2 : pos+4])
+	b.AssocGroupID = binary.LittleEndian.Uint32(data[pos+4 : pos+8])
+	pos += 8
+
+	addrLen := int(binary.LittleEndian.Uint16(data[pos : pos+2]))
+	pos += 2
+	if len(data) < pos+addrLen {
+		return 0, fmt.Errorf("bind_ack secondary address truncated")
+	}
+	if addrLen > 0 {
+		addr := data[pos : pos+addrLen]
+		// Strip the trailing NUL if present.
+		if n := len(addr); n > 0 && addr[n-1] == 0x00 {
+			addr = addr[:n-1]
+		}
+		b.SecondaryAddress = string(addr)
+	}
+	pos += addrLen
+
+	// Skip the 4-byte alignment pad.
+	pos += align4(pos)
+
+	if len(data) < pos+4 {
+		return 0, fmt.Errorf("bind_ack result list truncated")
+	}
+	n := int(data[pos]) // n_results
+	pos += 4            // skip n_results + reserved + reserved2
+
+	b.Results = make([]PresentationResult, 0, n)
+	for i := 0; i < n; i++ {
+		var r PresentationResult
+		read, err := r.Unmarshal(data[pos:])
+		if err != nil {
+			return 0, err
+		}
+		pos += read
+		b.Results = append(b.Results, r)
+	}
+	return pos, nil
+}
+
+// Accepted reports whether at least one presentation context was accepted.
+func (b *BindAck) Accepted() bool {
+	for _, r := range b.Results {
+		if r.Result == ResultAcceptance {
+			return true
+		}
+	}
+	return false
+}
+
+// String returns a one-line summary.
+func (b *BindAck) String() string {
+	return fmt.Sprintf("bind_ack xmit=%d recv=%d assoc_group=%d sec_addr=%q results=%d", b.MaxXmitFrag, b.MaxRecvFrag, b.AssocGroupID, b.SecondaryAddress, len(b.Results))
+}
+
+// ProtocolVersion is one supported RPC protocol version (p_rt_version_t).
+type ProtocolVersion struct {
+	Major uint8
+	Minor uint8
+}
+
+// BindNak is a bind_nak PDU: the server's rejection of a bind, with a reason and the
+// list of RPC protocol versions it supports.
+//
+// Reference: [C706] section 12.6.3.1 ("The bind_nak PDU"):
+// https://pubs.opengroup.org/onlinepubs/9629399/chap12.htm
+type BindNak struct {
+	Header       Header
+	RejectReason uint16
+	Versions     []ProtocolVersion
+}
+
+// Marshal serializes the complete bind_nak PDU.
+func (b *BindNak) Marshal() ([]byte, error) {
+	if len(b.Versions) > 0xFF {
+		return nil, fmt.Errorf("bind_nak has too many protocol versions (%d)", len(b.Versions))
+	}
+	body := make([]byte, 2)
+	binary.LittleEndian.PutUint16(body[0:2], b.RejectReason)
+	body = append(body, byte(len(b.Versions)))
+	for _, v := range b.Versions {
+		body = append(body, v.Major, v.Minor)
+	}
+
+	if b.Header.RPCVersion == 0 && b.Header.DataRepresentation == ([4]byte{}) {
+		b.Header = NewHeader(PacketTypeBindNak, b.Header.PacketFlags, b.Header.CallID)
+	}
+	b.Header.PacketType = PacketTypeBindNak
+	b.Header.FragLength = uint16(HeaderSize + len(body))
+
+	hdr, err := b.Header.Marshal()
+	if err != nil {
+		return nil, err
+	}
+	return append(hdr, body...), nil
+}
+
+// Unmarshal parses a complete bind_nak PDU and returns the bytes consumed.
+func (b *BindNak) Unmarshal(data []byte) (int, error) {
+	pos, err := b.Header.Unmarshal(data)
+	if err != nil {
+		return 0, err
+	}
+	if b.Header.PacketType != PacketTypeBindNak {
+		return 0, fmt.Errorf("not a bind_nak PDU: packet type is %s", b.Header.PacketType)
+	}
+	if len(data) < pos+3 {
+		return 0, fmt.Errorf("bind_nak PDU truncated")
+	}
+	b.RejectReason = binary.LittleEndian.Uint16(data[pos : pos+2])
+	n := int(data[pos+2])
+	pos += 3
+	if len(data) < pos+2*n {
+		return 0, fmt.Errorf("bind_nak versions truncated")
+	}
+	b.Versions = make([]ProtocolVersion, 0, n)
+	for i := 0; i < n; i++ {
+		b.Versions = append(b.Versions, ProtocolVersion{Major: data[pos], Minor: data[pos+1]})
+		pos += 2
+	}
+	return pos, nil
+}
+
+// String returns a one-line summary.
+func (b *BindNak) String() string {
+	return fmt.Sprintf("bind_nak reject_reason=%d versions=%d", b.RejectReason, len(b.Versions))
+}

--- a/network/dcerpc/pdu/fault.go
+++ b/network/dcerpc/pdu/fault.go
@@ -1,0 +1,136 @@
+package pdu
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+// Common connection-oriented RPC fault status codes (nca_* / rpc_s_*). This is a
+// subset; unknown codes are reported numerically by FaultStatus.String.
+//
+// References:
+//   - [C706] section 12.6.3.1 ("The fault PDU") and Appendix E (reject status codes):
+//     https://pubs.opengroup.org/onlinepubs/9629399/chap12.htm
+//   - [MS-RPCE] 2.2.2.5 Fault PDU:
+//     https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/55c10f44-9037-4d51-aaff-c146bd0f1988
+const (
+	NCASStatusOK             uint32 = 0x00000000
+	NCASOpRngError           uint32 = 0x1C010002 // nca_s_op_rng_error: invalid opnum
+	NCASUnkIf                uint32 = 0x1C010003 // nca_s_unk_if: unknown interface
+	NCASProtoError           uint32 = 0x1C01000B // nca_s_proto_error
+	NCASFaultIntDivByZero    uint32 = 0x1C000001 // nca_s_fault_int_div_by_zero
+	NCASFaultAddrError       uint32 = 0x1C000002 // nca_s_fault_addr_error
+	NCASFaultNDR             uint32 = 0x000006F7 // nca_s_fault_ndr: NDR could not decode
+	NCASFaultAccessDenied    uint32 = 0x00000005 // nca_s_fault_access_denied
+	NCASFaultContextMismatch uint32 = 0x1C00001A // nca_s_fault_context_mismatch
+)
+
+// FaultStatus is a fault PDU status code, with a descriptive String.
+type FaultStatus uint32
+
+// String returns a mnemonic for known status codes, otherwise the hex value.
+func (s FaultStatus) String() string {
+	switch uint32(s) {
+	case NCASStatusOK:
+		return "ok"
+	case NCASOpRngError:
+		return "nca_s_op_rng_error"
+	case NCASUnkIf:
+		return "nca_s_unk_if"
+	case NCASProtoError:
+		return "nca_s_proto_error"
+	case NCASFaultIntDivByZero:
+		return "nca_s_fault_int_div_by_zero"
+	case NCASFaultAddrError:
+		return "nca_s_fault_addr_error"
+	case NCASFaultNDR:
+		return "nca_s_fault_ndr"
+	case NCASFaultAccessDenied:
+		return "nca_s_fault_access_denied"
+	case NCASFaultContextMismatch:
+		return "nca_s_fault_context_mismatch"
+	default:
+		return fmt.Sprintf("0x%08x", uint32(s))
+	}
+}
+
+// Fault is a fault PDU: it reports that a call failed, carrying a status code and any
+// error stub data.
+//
+// References:
+//   - [C706] section 12.6.3.1 ("The fault PDU"):
+//     https://pubs.opengroup.org/onlinepubs/9629399/chap12.htm
+//   - [MS-RPCE] 2.2.2.5 Fault PDU:
+//     https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/55c10f44-9037-4d51-aaff-c146bd0f1988
+type Fault struct {
+	Header      Header
+	AllocHint   uint32
+	ContextID   uint16
+	CancelCount uint8
+	Status      uint32
+	Stub        []byte
+}
+
+// Marshal serializes the complete fault PDU.
+func (f *Fault) Marshal() ([]byte, error) {
+	body := make([]byte, 16)
+	binary.LittleEndian.PutUint32(body[0:4], f.AllocHint)
+	binary.LittleEndian.PutUint16(body[4:6], f.ContextID)
+	body[6] = f.CancelCount
+	body[7] = 0 // reserved
+	binary.LittleEndian.PutUint32(body[8:12], f.Status)
+	// body[12:16] reserved2
+	body = append(body, f.Stub...)
+
+	if f.Header.RPCVersion == 0 && f.Header.DataRepresentation == ([4]byte{}) {
+		f.Header = NewHeader(PacketTypeFault, f.Header.PacketFlags, f.Header.CallID)
+	}
+	f.Header.PacketType = PacketTypeFault
+	f.Header.FragLength = uint16(HeaderSize + len(body))
+
+	hdr, err := f.Header.Marshal()
+	if err != nil {
+		return nil, err
+	}
+	return append(hdr, body...), nil
+}
+
+// Unmarshal parses a complete fault PDU and returns the bytes consumed.
+func (f *Fault) Unmarshal(data []byte) (int, error) {
+	pos, err := f.Header.Unmarshal(data)
+	if err != nil {
+		return 0, err
+	}
+	if f.Header.PacketType != PacketTypeFault {
+		return 0, fmt.Errorf("not a fault PDU: packet type is %s", f.Header.PacketType)
+	}
+	if len(data) < pos+16 {
+		return 0, fmt.Errorf("fault PDU truncated")
+	}
+	f.AllocHint = binary.LittleEndian.Uint32(data[pos : pos+4])
+	f.ContextID = binary.LittleEndian.Uint16(data[pos+4 : pos+6])
+	f.CancelCount = data[pos+6]
+	f.Status = binary.LittleEndian.Uint32(data[pos+8 : pos+12])
+	pos += 16
+
+	end, err := stubEnd(&f.Header, len(data))
+	if err != nil {
+		return 0, err
+	}
+	if end < pos {
+		end = pos
+	}
+	f.Stub = append([]byte(nil), data[pos:end]...)
+	return end, nil
+}
+
+// Error implements the error interface so a Fault can be returned directly from a
+// call. The message includes the mnemonic status code.
+func (f *Fault) Error() string {
+	return fmt.Sprintf("DCE/RPC fault: status %s (ctx=%d)", FaultStatus(f.Status), f.ContextID)
+}
+
+// String returns a one-line summary.
+func (f *Fault) String() string {
+	return fmt.Sprintf("fault ctx=%d cancel_count=%d status=%s stub=%d bytes", f.ContextID, f.CancelCount, FaultStatus(f.Status), len(f.Stub))
+}

--- a/network/dcerpc/pdu/flags.go
+++ b/network/dcerpc/pdu/flags.go
@@ -1,0 +1,63 @@
+package pdu
+
+import "strings"
+
+// PFCFlags is the set of PFC_* flags carried in the pfc_flags field of the common
+// header.
+//
+// References:
+//   - [C706] section 12.6.3.1 (pfc_flags):
+//     https://pubs.opengroup.org/onlinepubs/9629399/chap12.htm
+//   - [MS-RPCE] 2.2.2.3 PFC_SUPPORT_HEADER_SIGN and related flags:
+//     https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/4886f349-2a73-4f9e-9262-a8404462c7e9
+type PFCFlags uint8
+
+const (
+	// PFCFirstFrag marks the first fragment of a multi-fragment PDU.
+	PFCFirstFrag PFCFlags = 0x01
+	// PFCLastFrag marks the last fragment of a multi-fragment PDU.
+	PFCLastFrag PFCFlags = 0x02
+	// PFCPendingCancel signals a pending cancel (request) or a cancel was pending
+	// (response).
+	PFCPendingCancel PFCFlags = 0x04
+	// PFCReserved is reserved.
+	PFCReserved PFCFlags = 0x08
+	// PFCConcMpx indicates support for concurrent multiplexing on the connection.
+	PFCConcMpx PFCFlags = 0x10
+	// PFCDidNotExecute indicates the server did not execute the call (response/fault).
+	PFCDidNotExecute PFCFlags = 0x20
+	// PFCMaybe indicates a "maybe" call with no response expected.
+	PFCMaybe PFCFlags = 0x40
+	// PFCObjectUuid indicates an object UUID is present in the PDU body.
+	PFCObjectUuid PFCFlags = 0x80
+)
+
+// Has reports whether all bits in flag are set.
+func (f PFCFlags) Has(flag PFCFlags) bool { return f&flag == flag }
+
+// String returns a "|"-joined list of set flag names.
+func (f PFCFlags) String() string {
+	if f == 0 {
+		return "none"
+	}
+	names := []struct {
+		flag PFCFlags
+		name string
+	}{
+		{PFCFirstFrag, "first_frag"},
+		{PFCLastFrag, "last_frag"},
+		{PFCPendingCancel, "pending_cancel"},
+		{PFCReserved, "reserved"},
+		{PFCConcMpx, "conc_mpx"},
+		{PFCDidNotExecute, "did_not_execute"},
+		{PFCMaybe, "maybe"},
+		{PFCObjectUuid, "object_uuid"},
+	}
+	var set []string
+	for _, n := range names {
+		if f.Has(n.flag) {
+			set = append(set, n.name)
+		}
+	}
+	return strings.Join(set, "|")
+}

--- a/network/dcerpc/pdu/header.go
+++ b/network/dcerpc/pdu/header.go
@@ -1,0 +1,109 @@
+// Package pdu models connection-oriented DCE/RPC protocol data units (PDUs): the
+// 16-byte common header and the Bind, Bind_Ack, Bind_Nak, Request, Response, and
+// Fault bodies ([C706] section 12, [MS-RPCE] section 2.2).
+//
+// Each PDU type embeds the common Header and represents a whole PDU. Marshal returns
+// the complete on-the-wire bytes (header included) and sets the header's frag_length;
+// Unmarshal parses a complete PDU and returns the number of bytes consumed.
+//
+// Only the little-endian data representation (DREP first byte 0x10) is supported,
+// which is what Windows and Samba always send; a big-endian DREP is rejected on
+// Unmarshal rather than silently mis-parsed.
+package pdu
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc"
+)
+
+// HeaderSize is the size, in bytes, of the connection-oriented common header.
+const HeaderSize = 16
+
+// DataRepresentationLittleEndian is the canonical packed_drep for little-endian
+// integers, ASCII characters, and IEEE floating point.
+var DataRepresentationLittleEndian = [4]byte{0x10, 0x00, 0x00, 0x00}
+
+// Header is the connection-oriented common header present at the start of every PDU.
+//
+// References:
+//   - [C706] section 12.6.3.1 (common fields of the connection-oriented PDU):
+//     https://pubs.opengroup.org/onlinepubs/9629399/chap12.htm
+//   - [MS-RPCE] 2.2.2.10 PDU Types:
+//     https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/cef9d684-f09f-4533-a54c-9255079d3e1d
+type Header struct {
+	RPCVersion         uint8
+	RPCVersionMinor    uint8
+	PacketType         PacketType
+	PacketFlags        PFCFlags
+	DataRepresentation [4]byte
+	FragLength         uint16
+	AuthLength         uint16
+	CallID             uint32
+}
+
+// NewHeader returns a header initialized for protocol version 5.0 with little-endian
+// data representation and the given packet type, flags, and call id.
+func NewHeader(pt PacketType, flags PFCFlags, callID uint32) Header {
+	return Header{
+		RPCVersion:         dcerpc.MajorVersion,
+		RPCVersionMinor:    dcerpc.MinorVersion,
+		PacketType:         pt,
+		PacketFlags:        flags,
+		DataRepresentation: DataRepresentationLittleEndian,
+		CallID:             callID,
+	}
+}
+
+// Marshal serializes the header into its 16-byte wire form.
+func (h *Header) Marshal() ([]byte, error) {
+	buf := make([]byte, HeaderSize)
+	buf[0] = h.RPCVersion
+	buf[1] = h.RPCVersionMinor
+	buf[2] = byte(h.PacketType)
+	buf[3] = byte(h.PacketFlags)
+	copy(buf[4:8], h.DataRepresentation[:])
+	binary.LittleEndian.PutUint16(buf[8:10], h.FragLength)
+	binary.LittleEndian.PutUint16(buf[10:12], h.AuthLength)
+	binary.LittleEndian.PutUint32(buf[12:16], h.CallID)
+	return buf, nil
+}
+
+// Unmarshal parses a header from the start of data and returns the bytes consumed
+// (always HeaderSize on success).
+func (h *Header) Unmarshal(data []byte) (int, error) {
+	if len(data) < HeaderSize {
+		return 0, fmt.Errorf("PDU header truncated: have %d bytes, need %d", len(data), HeaderSize)
+	}
+	h.RPCVersion = data[0]
+	h.RPCVersionMinor = data[1]
+	h.PacketType = PacketType(data[2])
+	h.PacketFlags = PFCFlags(data[3])
+	copy(h.DataRepresentation[:], data[4:8])
+	// Only little-endian integer representation is supported. The high nibble of the
+	// first DREP byte encodes the integer byte order (1 = little-endian).
+	if h.DataRepresentation[0]>>4 != 1 {
+		return 0, fmt.Errorf("unsupported data representation 0x%02x: only little-endian is supported", h.DataRepresentation[0])
+	}
+	h.FragLength = binary.LittleEndian.Uint16(data[8:10])
+	h.AuthLength = binary.LittleEndian.Uint16(data[10:12])
+	h.CallID = binary.LittleEndian.Uint32(data[12:16])
+	return HeaderSize, nil
+}
+
+// String returns a human-readable one-line summary of the header.
+func (h *Header) String() string {
+	return fmt.Sprintf("DCE/RPC v%d.%d %s flags=%s frag_len=%d auth_len=%d call_id=%d",
+		h.RPCVersion, h.RPCVersionMinor, h.PacketType, h.PacketFlags, h.FragLength, h.AuthLength, h.CallID)
+}
+
+// PeekHeader parses just the common header from the front of a complete PDU buffer.
+// It is a convenience for dispatching on PacketType before fully unmarshalling.
+func PeekHeader(data []byte) (*Header, error) {
+	h := &Header{}
+	if _, err := h.Unmarshal(data); err != nil {
+		return nil, err
+	}
+	return h, nil
+}

--- a/network/dcerpc/pdu/pdu_test.go
+++ b/network/dcerpc/pdu/pdu_test.go
@@ -1,0 +1,335 @@
+package pdu
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+)
+
+func TestHeader_GoldenBytes(t *testing.T) {
+	h := Header{
+		RPCVersion:         5,
+		RPCVersionMinor:    0,
+		PacketType:         PacketTypeBind,
+		PacketFlags:        PFCFirstFrag | PFCLastFrag,
+		DataRepresentation: DataRepresentationLittleEndian,
+		FragLength:         72,
+		AuthLength:         0,
+		CallID:             1,
+	}
+	want := []byte{
+		0x05, 0x00, 0x0b, 0x03,
+		0x10, 0x00, 0x00, 0x00,
+		0x48, 0x00, 0x00, 0x00,
+		0x01, 0x00, 0x00, 0x00,
+	}
+	got, err := h.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("header bytes:\n got %x\nwant %x", got, want)
+	}
+}
+
+func TestHeader_RejectsBigEndianDREP(t *testing.T) {
+	data := []byte{
+		0x05, 0x00, 0x0b, 0x03,
+		0x00, 0x00, 0x00, 0x00, // big-endian DREP (high nibble 0)
+		0x10, 0x00, 0x00, 0x00,
+		0x01, 0x00, 0x00, 0x00,
+	}
+	var h Header
+	if _, err := h.Unmarshal(data); err == nil {
+		t.Fatal("Unmarshal of big-endian DREP: error = nil, want non-nil")
+	}
+}
+
+func TestHeader_RoundTrip(t *testing.T) {
+	h := NewHeader(PacketTypeRequest, PFCFirstFrag, 42)
+	h.FragLength = 100
+	b, _ := h.Marshal()
+	var got Header
+	n, err := got.Unmarshal(b)
+	if err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if n != HeaderSize {
+		t.Errorf("consumed %d, want %d", n, HeaderSize)
+	}
+	if got != h {
+		t.Errorf("round trip: got %+v, want %+v", got, h)
+	}
+}
+
+func TestBind_RoundTripAndFraming(t *testing.T) {
+	b := &Bind{
+		MaxXmitFrag:  4280,
+		MaxRecvFrag:  4280,
+		AssocGroupID: 0,
+		ContextList: []ContextElement{
+			{
+				ContextID:      0,
+				AbstractSyntax: syntax.SyntaxID{UUID: guid.GUID{A: 0x12345678, B: 0x1234, C: 0xabcd, D: 0xef00, E: 0x0123456789ab}, MajorVersion: 1, MinorVersion: 0},
+				TransferSyntaxes: []syntax.SyntaxID{
+					syntax.NDRTransferSyntax(),
+				},
+			},
+		},
+	}
+	b.Header.CallID = 1
+
+	raw, err := b.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	// header(16) + xmit/recv/assoc(8) + ctxlist hdr(4) + p_cont_elem(4 + 20 + 20) = 72
+	if len(raw) != 72 {
+		t.Errorf("marshalled length = %d, want 72", len(raw))
+	}
+	if int(b.Header.FragLength) != len(raw) {
+		t.Errorf("frag_length = %d, want %d", b.Header.FragLength, len(raw))
+	}
+	if PacketType(raw[2]) != PacketTypeBind {
+		t.Errorf("ptype byte = %d, want %d (bind)", raw[2], PacketTypeBind)
+	}
+
+	var got Bind
+	n, err := got.Unmarshal(raw)
+	if err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if n != len(raw) {
+		t.Errorf("consumed %d, want %d", n, len(raw))
+	}
+	if got.MaxXmitFrag != b.MaxXmitFrag || got.MaxRecvFrag != b.MaxRecvFrag {
+		t.Errorf("frag sizes: got %d/%d", got.MaxXmitFrag, got.MaxRecvFrag)
+	}
+	if len(got.ContextList) != 1 || len(got.ContextList[0].TransferSyntaxes) != 1 {
+		t.Fatalf("context list not round-tripped: %+v", got.ContextList)
+	}
+	if !got.ContextList[0].AbstractSyntax.Equal(b.ContextList[0].AbstractSyntax) {
+		t.Error("abstract syntax not round-tripped")
+	}
+	if !got.ContextList[0].TransferSyntaxes[0].Equal(syntax.NDRTransferSyntax()) {
+		t.Error("transfer syntax not round-tripped")
+	}
+}
+
+func TestBind_RejectsEmptyContextList(t *testing.T) {
+	b := &Bind{MaxXmitFrag: 4280, MaxRecvFrag: 4280}
+	if _, err := b.Marshal(); err == nil {
+		t.Fatal("Marshal of bind with no contexts: error = nil, want non-nil")
+	}
+}
+
+func TestBindAck_RoundTripWithAlignmentPad(t *testing.T) {
+	// "lsarpc" + NUL = 7 bytes, forcing a 3-byte alignment pad before the result list.
+	ack := &BindAck{
+		MaxXmitFrag:      4280,
+		MaxRecvFrag:      4280,
+		AssocGroupID:     0x11223344,
+		SecondaryAddress: "lsarpc",
+		Results: []PresentationResult{
+			{Result: ResultAcceptance, Reason: 0, TransferSyntax: syntax.NDRTransferSyntax()},
+		},
+	}
+	raw, err := ack.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	// 16 + 8 + 2(len) + 7(addr) + 3(pad) + 4(result list hdr) + 24(one result) = 64
+	if len(raw) != 64 {
+		t.Errorf("marshalled length = %d, want 64 (alignment pad expected)", len(raw))
+	}
+
+	var got BindAck
+	if _, err := got.Unmarshal(raw); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if got.SecondaryAddress != "lsarpc" {
+		t.Errorf("SecondaryAddress = %q, want %q", got.SecondaryAddress, "lsarpc")
+	}
+	if got.AssocGroupID != 0x11223344 {
+		t.Errorf("AssocGroupID = %#x, want 0x11223344", got.AssocGroupID)
+	}
+	if len(got.Results) != 1 || got.Results[0].Result != ResultAcceptance {
+		t.Fatalf("results not round-tripped: %+v", got.Results)
+	}
+	if !got.Accepted() {
+		t.Error("Accepted() = false, want true")
+	}
+	if !got.Results[0].TransferSyntax.Equal(syntax.NDRTransferSyntax()) {
+		t.Error("result transfer syntax not round-tripped")
+	}
+}
+
+func TestBindAck_EmptySecondaryAddress(t *testing.T) {
+	ack := &BindAck{MaxXmitFrag: 4280, MaxRecvFrag: 4280}
+	raw, err := ack.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	var got BindAck
+	if _, err := got.Unmarshal(raw); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if got.SecondaryAddress != "" {
+		t.Errorf("SecondaryAddress = %q, want empty", got.SecondaryAddress)
+	}
+	if got.Accepted() {
+		t.Error("Accepted() = true on a bind_ack with no results")
+	}
+}
+
+func TestBindNak_RoundTrip(t *testing.T) {
+	nak := &BindNak{
+		RejectReason: ReasonProposedTransferSyntaxesNotSupported,
+		Versions:     []ProtocolVersion{{Major: 5, Minor: 0}},
+	}
+	raw, err := nak.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	var got BindNak
+	if _, err := got.Unmarshal(raw); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if got.RejectReason != ReasonProposedTransferSyntaxesNotSupported {
+		t.Errorf("RejectReason = %d", got.RejectReason)
+	}
+	if len(got.Versions) != 1 || got.Versions[0] != (ProtocolVersion{Major: 5, Minor: 0}) {
+		t.Errorf("Versions = %+v", got.Versions)
+	}
+}
+
+func TestRequest_RoundTrip(t *testing.T) {
+	req := &Request{
+		ContextID: 0,
+		Opnum:     0x000f,
+		Stub:      []byte{0xde, 0xad, 0xbe, 0xef},
+	}
+	req.Header.CallID = 7
+	raw, err := req.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	if PacketType(raw[2]) != PacketTypeRequest {
+		t.Errorf("ptype = %d, want request", raw[2])
+	}
+
+	var got Request
+	if _, err := got.Unmarshal(raw); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if got.Opnum != 0x000f || got.ContextID != 0 {
+		t.Errorf("opnum/ctx = %d/%d", got.Opnum, got.ContextID)
+	}
+	if got.AllocHint != 4 {
+		t.Errorf("AllocHint = %d, want 4 (defaulted to stub length)", got.AllocHint)
+	}
+	if !bytes.Equal(got.Stub, req.Stub) {
+		t.Errorf("stub = %x, want %x", got.Stub, req.Stub)
+	}
+	if got.Header.CallID != 7 {
+		t.Errorf("call_id = %d, want 7", got.Header.CallID)
+	}
+}
+
+func TestRequest_WithObjectUUID(t *testing.T) {
+	obj := &guid.GUID{A: 0xaabbccdd, B: 0x1122, C: 0x3344, D: 0x5566, E: 0x778899aabbcc}
+	req := &Request{
+		ContextID:  1,
+		Opnum:      2,
+		ObjectUUID: obj,
+		Stub:       []byte{0x01},
+	}
+	raw, err := req.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	if !req.Header.PacketFlags.Has(PFCObjectUuid) {
+		t.Error("PFCObjectUuid flag not set when ObjectUUID present")
+	}
+
+	var got Request
+	if _, err := got.Unmarshal(raw); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if got.ObjectUUID == nil || !got.ObjectUUID.Equal(obj) {
+		t.Errorf("ObjectUUID = %v, want %v", got.ObjectUUID, obj)
+	}
+	if !bytes.Equal(got.Stub, []byte{0x01}) {
+		t.Errorf("stub = %x", got.Stub)
+	}
+}
+
+func TestResponse_RoundTrip(t *testing.T) {
+	resp := &Response{
+		ContextID: 0,
+		Stub:      []byte{0x11, 0x22, 0x33},
+	}
+	raw, err := resp.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	var got Response
+	if _, err := got.Unmarshal(raw); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if !bytes.Equal(got.Stub, resp.Stub) {
+		t.Errorf("stub = %x, want %x", got.Stub, resp.Stub)
+	}
+	if got.AllocHint != 3 {
+		t.Errorf("AllocHint = %d, want 3", got.AllocHint)
+	}
+}
+
+func TestFault_RoundTripAndError(t *testing.T) {
+	f := &Fault{
+		ContextID: 0,
+		Status:    NCASOpRngError,
+	}
+	raw, err := f.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	var got Fault
+	if _, err := got.Unmarshal(raw); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if got.Status != NCASOpRngError {
+		t.Errorf("Status = %#x, want %#x", got.Status, NCASOpRngError)
+	}
+	// Fault implements error.
+	var asErr error = &got
+	if asErr.Error() == "" {
+		t.Error("Fault.Error() returned empty string")
+	}
+	if FaultStatus(got.Status).String() != "nca_s_op_rng_error" {
+		t.Errorf("status string = %q", FaultStatus(got.Status).String())
+	}
+}
+
+func TestPeekHeader_Dispatch(t *testing.T) {
+	f := &Fault{Status: NCASFaultNDR}
+	raw, _ := f.Marshal()
+	h, err := PeekHeader(raw)
+	if err != nil {
+		t.Fatalf("PeekHeader() error = %v", err)
+	}
+	if h.PacketType != PacketTypeFault {
+		t.Errorf("PacketType = %s, want fault", h.PacketType)
+	}
+}
+
+func TestUnmarshal_WrongPacketType(t *testing.T) {
+	b := &Bind{MaxXmitFrag: 1, MaxRecvFrag: 1, ContextList: []ContextElement{{TransferSyntaxes: []syntax.SyntaxID{syntax.NDRTransferSyntax()}}}}
+	raw, _ := b.Marshal()
+	var resp Response
+	if _, err := resp.Unmarshal(raw); err == nil {
+		t.Fatal("unmarshalling a bind as a response: error = nil, want non-nil")
+	}
+}

--- a/network/dcerpc/pdu/ptype.go
+++ b/network/dcerpc/pdu/ptype.go
@@ -1,0 +1,79 @@
+package pdu
+
+// PacketType identifies the kind of a connection-oriented DCE/RPC PDU, as carried in
+// the ptype field of the common header.
+//
+// References:
+//   - [C706] section 12.6.4 (PDU types):
+//     https://pubs.opengroup.org/onlinepubs/9629399/chap12.htm
+//   - [MS-RPCE] 2.2.2.10 PDU Types:
+//     https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/cef9d684-f09f-4533-a54c-9255079d3e1d
+type PacketType uint8
+
+const (
+	PacketTypeRequest          PacketType = 0
+	PacketTypePing             PacketType = 1
+	PacketTypeResponse         PacketType = 2
+	PacketTypeFault            PacketType = 3
+	PacketTypeWorking          PacketType = 4
+	PacketTypeNoCall           PacketType = 5
+	PacketTypeReject           PacketType = 6
+	PacketTypeAck              PacketType = 7
+	PacketTypeClCancel         PacketType = 8
+	PacketTypeFack             PacketType = 9
+	PacketTypeCancelAck        PacketType = 10
+	PacketTypeBind             PacketType = 11
+	PacketTypeBindAck          PacketType = 12
+	PacketTypeBindNak          PacketType = 13
+	PacketTypeAlterContext     PacketType = 14
+	PacketTypeAlterContextResp PacketType = 15
+	PacketTypeShutdown         PacketType = 17
+	PacketTypeCoCancel         PacketType = 18
+	PacketTypeOrphaned         PacketType = 19
+)
+
+// String returns the mnemonic name of the packet type.
+func (t PacketType) String() string {
+	switch t {
+	case PacketTypeRequest:
+		return "request"
+	case PacketTypePing:
+		return "ping"
+	case PacketTypeResponse:
+		return "response"
+	case PacketTypeFault:
+		return "fault"
+	case PacketTypeWorking:
+		return "working"
+	case PacketTypeNoCall:
+		return "nocall"
+	case PacketTypeReject:
+		return "reject"
+	case PacketTypeAck:
+		return "ack"
+	case PacketTypeClCancel:
+		return "cl_cancel"
+	case PacketTypeFack:
+		return "fack"
+	case PacketTypeCancelAck:
+		return "cancel_ack"
+	case PacketTypeBind:
+		return "bind"
+	case PacketTypeBindAck:
+		return "bind_ack"
+	case PacketTypeBindNak:
+		return "bind_nak"
+	case PacketTypeAlterContext:
+		return "alter_context"
+	case PacketTypeAlterContextResp:
+		return "alter_context_resp"
+	case PacketTypeShutdown:
+		return "shutdown"
+	case PacketTypeCoCancel:
+		return "co_cancel"
+	case PacketTypeOrphaned:
+		return "orphaned"
+	default:
+		return "unknown"
+	}
+}

--- a/network/dcerpc/pdu/request.go
+++ b/network/dcerpc/pdu/request.go
@@ -1,0 +1,196 @@
+package pdu
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+)
+
+// Request is a request PDU: it carries a method call (opnum) and its marshalled
+// arguments (stub data) to the server.
+//
+// When the PFC_OBJECT_UUID flag is set, a 16-byte object UUID precedes the stub data;
+// otherwise it is absent. Stub data is 8-octet aligned, which the fixed 8-byte body
+// (plus an optional 16-byte object UUID) already satisfies.
+//
+// Reference: [C706] section 12.6.3.1 ("The request PDU"):
+// https://pubs.opengroup.org/onlinepubs/9629399/chap12.htm
+type Request struct {
+	Header     Header
+	AllocHint  uint32
+	ContextID  uint16
+	Opnum      uint16
+	ObjectUUID *guid.GUID // present iff PFC_OBJECT_UUID is set
+	Stub       []byte
+}
+
+// Marshal serializes the complete request PDU. If ObjectUUID is non-nil the
+// PFC_OBJECT_UUID flag is set automatically. AllocHint defaults to len(Stub) when
+// left zero.
+func (r *Request) Marshal() ([]byte, error) {
+	allocHint := r.AllocHint
+	if allocHint == 0 {
+		allocHint = uint32(len(r.Stub))
+	}
+
+	body := make([]byte, 8)
+	binary.LittleEndian.PutUint32(body[0:4], allocHint)
+	binary.LittleEndian.PutUint16(body[4:6], r.ContextID)
+	binary.LittleEndian.PutUint16(body[6:8], r.Opnum)
+
+	if r.ObjectUUID != nil {
+		body = append(body, r.ObjectUUID.ToBytes()...)
+		r.Header.PacketFlags |= PFCObjectUuid
+	}
+	body = append(body, r.Stub...)
+
+	if r.Header.RPCVersion == 0 && r.Header.DataRepresentation == ([4]byte{}) {
+		flags := r.Header.PacketFlags
+		r.Header = NewHeader(PacketTypeRequest, flags, r.Header.CallID)
+	}
+	r.Header.PacketType = PacketTypeRequest
+	r.Header.FragLength = uint16(HeaderSize + len(body))
+
+	hdr, err := r.Header.Marshal()
+	if err != nil {
+		return nil, err
+	}
+	return append(hdr, body...), nil
+}
+
+// Unmarshal parses a complete request PDU and returns the bytes consumed.
+func (r *Request) Unmarshal(data []byte) (int, error) {
+	pos, err := r.Header.Unmarshal(data)
+	if err != nil {
+		return 0, err
+	}
+	if r.Header.PacketType != PacketTypeRequest {
+		return 0, fmt.Errorf("not a request PDU: packet type is %s", r.Header.PacketType)
+	}
+	if len(data) < pos+8 {
+		return 0, fmt.Errorf("request PDU truncated")
+	}
+	r.AllocHint = binary.LittleEndian.Uint32(data[pos : pos+4])
+	r.ContextID = binary.LittleEndian.Uint16(data[pos+4 : pos+6])
+	r.Opnum = binary.LittleEndian.Uint16(data[pos+6 : pos+8])
+	pos += 8
+
+	if r.Header.PacketFlags.Has(PFCObjectUuid) {
+		if len(data) < pos+16 {
+			return 0, fmt.Errorf("request PDU object UUID truncated")
+		}
+		r.ObjectUUID = &guid.GUID{}
+		r.ObjectUUID.FromRawBytes(data[pos : pos+16])
+		pos += 16
+	}
+
+	end, err := stubEnd(&r.Header, len(data))
+	if err != nil {
+		return 0, err
+	}
+	if end < pos {
+		return 0, fmt.Errorf("request PDU stub bounds invalid")
+	}
+	r.Stub = append([]byte(nil), data[pos:end]...)
+	return end, nil
+}
+
+// String returns a one-line summary.
+func (r *Request) String() string {
+	return fmt.Sprintf("request ctx=%d opnum=%d alloc_hint=%d stub=%d bytes", r.ContextID, r.Opnum, r.AllocHint, len(r.Stub))
+}
+
+// Response is a response PDU: it carries the marshalled return values (stub data) of
+// a successful call back to the client.
+//
+// Reference: [C706] section 12.6.3.1 ("The response PDU"):
+// https://pubs.opengroup.org/onlinepubs/9629399/chap12.htm
+type Response struct {
+	Header      Header
+	AllocHint   uint32
+	ContextID   uint16
+	CancelCount uint8
+	Stub        []byte
+}
+
+// Marshal serializes the complete response PDU.
+func (r *Response) Marshal() ([]byte, error) {
+	allocHint := r.AllocHint
+	if allocHint == 0 {
+		allocHint = uint32(len(r.Stub))
+	}
+
+	body := make([]byte, 8)
+	binary.LittleEndian.PutUint32(body[0:4], allocHint)
+	binary.LittleEndian.PutUint16(body[4:6], r.ContextID)
+	body[6] = r.CancelCount
+	body[7] = 0 // reserved
+	body = append(body, r.Stub...)
+
+	if r.Header.RPCVersion == 0 && r.Header.DataRepresentation == ([4]byte{}) {
+		r.Header = NewHeader(PacketTypeResponse, r.Header.PacketFlags, r.Header.CallID)
+	}
+	r.Header.PacketType = PacketTypeResponse
+	r.Header.FragLength = uint16(HeaderSize + len(body))
+
+	hdr, err := r.Header.Marshal()
+	if err != nil {
+		return nil, err
+	}
+	return append(hdr, body...), nil
+}
+
+// Unmarshal parses a complete response PDU and returns the bytes consumed.
+func (r *Response) Unmarshal(data []byte) (int, error) {
+	pos, err := r.Header.Unmarshal(data)
+	if err != nil {
+		return 0, err
+	}
+	if r.Header.PacketType != PacketTypeResponse {
+		return 0, fmt.Errorf("not a response PDU: packet type is %s", r.Header.PacketType)
+	}
+	if len(data) < pos+8 {
+		return 0, fmt.Errorf("response PDU truncated")
+	}
+	r.AllocHint = binary.LittleEndian.Uint32(data[pos : pos+4])
+	r.ContextID = binary.LittleEndian.Uint16(data[pos+4 : pos+6])
+	r.CancelCount = data[pos+6]
+	pos += 8
+
+	end, err := stubEnd(&r.Header, len(data))
+	if err != nil {
+		return 0, err
+	}
+	if end < pos {
+		return 0, fmt.Errorf("response PDU stub bounds invalid")
+	}
+	r.Stub = append([]byte(nil), data[pos:end]...)
+	return end, nil
+}
+
+// String returns a one-line summary.
+func (r *Response) String() string {
+	return fmt.Sprintf("response ctx=%d cancel_count=%d alloc_hint=%d stub=%d bytes", r.ContextID, r.CancelCount, r.AllocHint, len(r.Stub))
+}
+
+// stubEnd returns the index at which the stub data ends, derived from the header's
+// frag_length and auth_length. It clamps to the available buffer so a truncated read
+// does not produce an out-of-bounds slice.
+func stubEnd(h *Header, available int) (int, error) {
+	end := int(h.FragLength) - int(h.AuthLength)
+	if h.AuthLength > 0 {
+		// The auth verifier is preceded by sec_trailer (8 bytes); both sit after the
+		// stub. Subtracting auth_length alone leaves the 8-byte sec_trailer attributed
+		// to the stub, which is acceptable for v1 (no auth is negotiated) but flagged
+		// here for the future auth work.
+		end -= 8
+	}
+	if end > available {
+		end = available
+	}
+	if end < HeaderSize {
+		return 0, fmt.Errorf("frag_length %d shorter than header", h.FragLength)
+	}
+	return end, nil
+}

--- a/network/dcerpc/syntax/syntax.go
+++ b/network/dcerpc/syntax/syntax.go
@@ -1,0 +1,76 @@
+// Package syntax models DCE/RPC presentation syntax identifiers (p_syntax_id_t).
+//
+// A syntax identifier names either an abstract syntax (an interface UUID and
+// version) or a transfer syntax (an encoding such as NDR). On the wire it is a
+// 16-byte UUID followed by a 4-byte version: a 16-bit major version and a 16-bit
+// minor version, both little-endian ([C706] section 12.6).
+package syntax
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+)
+
+// Size is the marshalled size, in bytes, of a syntax identifier: 16-byte UUID plus
+// a 2-byte major and 2-byte minor version.
+const Size = 20
+
+// SyntaxID identifies an abstract or transfer syntax.
+type SyntaxID struct {
+	UUID         guid.GUID
+	MajorVersion uint16
+	MinorVersion uint16
+}
+
+// NDRTransferSyntax returns the identifier for the NDR (Network Data Representation)
+// transfer syntax, version 2.0: 8a885d04-1ceb-11c9-9fe8-08002b104860.
+func NDRTransferSyntax() SyntaxID {
+	return SyntaxID{
+		UUID:         guid.GUID{A: 0x8a885d04, B: 0x1ceb, C: 0x11c9, D: 0x9fe8, E: 0x08002b104860},
+		MajorVersion: 2,
+		MinorVersion: 0,
+	}
+}
+
+// NDR64TransferSyntax returns the identifier for the NDR64 transfer syntax, version
+// 1.0: 71710533-beba-4937-8319-b5dbef9ccc36.
+func NDR64TransferSyntax() SyntaxID {
+	return SyntaxID{
+		UUID:         guid.GUID{A: 0x71710533, B: 0xbeba, C: 0x4937, D: 0x8319, E: 0xb5dbef9ccc36},
+		MajorVersion: 1,
+		MinorVersion: 0,
+	}
+}
+
+// Equal reports whether two syntax identifiers are identical.
+func (s SyntaxID) Equal(other SyntaxID) bool {
+	return s.UUID.Equal(&other.UUID) && s.MajorVersion == other.MajorVersion && s.MinorVersion == other.MinorVersion
+}
+
+// Marshal serializes the syntax identifier into its 20-byte wire form.
+func (s SyntaxID) Marshal() ([]byte, error) {
+	buf := make([]byte, Size)
+	copy(buf[0:16], s.UUID.ToBytes())
+	binary.LittleEndian.PutUint16(buf[16:18], s.MajorVersion)
+	binary.LittleEndian.PutUint16(buf[18:20], s.MinorVersion)
+	return buf, nil
+}
+
+// Unmarshal parses a syntax identifier from data and returns the number of bytes
+// consumed.
+func (s *SyntaxID) Unmarshal(data []byte) (int, error) {
+	if len(data) < Size {
+		return 0, fmt.Errorf("syntax identifier truncated: have %d bytes, need %d", len(data), Size)
+	}
+	s.UUID.FromRawBytes(data[0:16])
+	s.MajorVersion = binary.LittleEndian.Uint16(data[16:18])
+	s.MinorVersion = binary.LittleEndian.Uint16(data[18:20])
+	return Size, nil
+}
+
+// String returns a human-readable representation, e.g. "8a885d04-...-08002b104860 v2.0".
+func (s SyntaxID) String() string {
+	return fmt.Sprintf("%s v%d.%d", s.UUID.ToFormatD(), s.MajorVersion, s.MinorVersion)
+}

--- a/network/dcerpc/syntax/syntax_test.go
+++ b/network/dcerpc/syntax/syntax_test.go
@@ -1,0 +1,63 @@
+package syntax
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestNDRTransferSyntax_GoldenBytes(t *testing.T) {
+	// 8a885d04-1ceb-11c9-9fe8-08002b104860, version 2.0.
+	// UUID wire layout: Data1/2/3 little-endian, Data4 big-endian; then major/minor LE.
+	want := []byte{
+		0x04, 0x5d, 0x88, 0x8a, // A (LE)
+		0xeb, 0x1c, // B (LE)
+		0xc9, 0x11, // C (LE)
+		0x9f, 0xe8, // D (BE)
+		0x08, 0x00, 0x2b, 0x10, 0x48, 0x60, // E (BE)
+		0x02, 0x00, // major = 2
+		0x00, 0x00, // minor = 0
+	}
+	got, err := NDRTransferSyntax().Marshal()
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("NDR syntax bytes:\n got %x\nwant %x", got, want)
+	}
+	if len(got) != Size {
+		t.Errorf("len = %d, want %d", len(got), Size)
+	}
+}
+
+func TestSyntaxID_RoundTrip(t *testing.T) {
+	for _, s := range []SyntaxID{NDRTransferSyntax(), NDR64TransferSyntax()} {
+		b, err := s.Marshal()
+		if err != nil {
+			t.Fatalf("Marshal() error = %v", err)
+		}
+		var got SyntaxID
+		n, err := got.Unmarshal(b)
+		if err != nil {
+			t.Fatalf("Unmarshal() error = %v", err)
+		}
+		if n != Size {
+			t.Errorf("Unmarshal consumed %d bytes, want %d", n, Size)
+		}
+		if !got.Equal(s) {
+			t.Errorf("round trip: got %s, want %s", got, s)
+		}
+	}
+}
+
+func TestSyntaxID_UnmarshalTruncated(t *testing.T) {
+	var s SyntaxID
+	if _, err := s.Unmarshal(make([]byte, Size-1)); err == nil {
+		t.Fatal("Unmarshal of truncated buffer: error = nil, want non-nil")
+	}
+}
+
+func TestSyntaxID_NDRvsNDR64NotEqual(t *testing.T) {
+	if NDRTransferSyntax().Equal(NDR64TransferSyntax()) {
+		t.Error("NDR and NDR64 syntaxes compare equal")
+	}
+}

--- a/network/dcerpc/transport/smb/smb_namedpipe.go
+++ b/network/dcerpc/transport/smb/smb_namedpipe.go
@@ -1,0 +1,153 @@
+// Package smb implements the DCE/RPC ncacn_np protocol sequence: DCE/RPC directly
+// over an SMB named pipe.
+//
+// Per [MS-RPCE] section 2.1.1.2 (SMB (NCACN_NP)), "All PDUs sent over SMB MUST be
+// sent as named pipe writes ... and PDUs to be received MUST be received as named
+// pipe reads." This transport therefore implements SendReceive as a pipe write
+// followed by a pipe read, wrapping an already-connected and authenticated SMB v1.0
+// client whose tree is connected to the IPC$ share. (The single-round-trip
+// TransactNamedPipe optimization for synchronous calls is an explicit MAY in
+// [MS-RPCE] and is not used here.)
+package smb
+
+import (
+	"fmt"
+
+	dcerpctransport "github.com/TheManticoreProject/Manticore/network/dcerpc/transport"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/client"
+)
+
+// Default fragment sizes proposed at Bind time. 4280 (0x10B8) is the classic Windows
+// default for RPC over named pipes; it is a safe, widely accepted value. Callers that
+// want larger fragments can override via SetMaxFrag before Connect.
+const (
+	DefaultMaxXmitFrag uint16 = 4280
+	DefaultMaxRecvFrag uint16 = 4280
+)
+
+// pipeConn is the subset of *client.Client that the named-pipe transport relies on.
+// Expressing it as an interface keeps the transport unit-testable without a live SMB
+// server: tests substitute a fake. *client.Client satisfies it.
+type pipeConn interface {
+	OpenFile(path string, desiredAccess, shareAccess, createDisp, createOptions uint32) (client.FID, error)
+	ReadFile(fid client.FID, offset uint64, maxLen uint32) ([]byte, error)
+	WriteFile(fid client.FID, offset uint64, data []byte) (int, error)
+	CloseFile(fid client.FID) error
+}
+
+// SMBNamedPipe is a DCE/RPC transport over an SMB named pipe (ncacn_np).
+type SMBNamedPipe struct {
+	conn     pipeConn
+	pipeName string
+	fid      client.FID
+	opened   bool
+	maxXmit  uint16
+	maxRecv  uint16
+}
+
+// Compile-time assertion that SMBNamedPipe implements the DCE/RPC transport contract.
+var _ dcerpctransport.Transport = (*SMBNamedPipe)(nil)
+
+// New creates a named-pipe transport over the supplied SMB client. The client MUST
+// already be connected, have an authenticated session (SessionSetup), and have a tree
+// connected to the IPC$ share (TreeConnect) before Connect is called.
+//
+// pipeName is the pipe endpoint, for example `\PIPE\lsarpc` or `\PIPE\epmapper`. A
+// leading backslash is added if absent; pipe names are case-insensitive on Windows.
+func New(c *client.Client, pipeName string) *SMBNamedPipe {
+	return newWithConn(c, pipeName)
+}
+
+// newWithConn is the internal constructor used by New and by tests; it accepts any
+// value satisfying pipeConn.
+func newWithConn(conn pipeConn, pipeName string) *SMBNamedPipe {
+	if len(pipeName) == 0 || pipeName[0] != '\\' {
+		pipeName = "\\" + pipeName
+	}
+	return &SMBNamedPipe{
+		conn:     conn,
+		pipeName: pipeName,
+		maxXmit:  DefaultMaxXmitFrag,
+		maxRecv:  DefaultMaxRecvFrag,
+	}
+}
+
+// SetMaxFrag overrides the transmit and receive fragment sizes proposed at Bind time.
+// It must be called before Connect to take effect.
+func (p *SMBNamedPipe) SetMaxFrag(xmit, recv uint16) {
+	p.maxXmit = xmit
+	p.maxRecv = recv
+}
+
+// Connect opens the named pipe on the SMB tree. It is idempotent.
+func (p *SMBNamedPipe) Connect() error {
+	if p.opened {
+		return nil
+	}
+
+	fid, err := p.conn.OpenFile(
+		p.pipeName,
+		client.GENERIC_READ|client.GENERIC_WRITE,
+		client.FILE_SHARE_READ|client.FILE_SHARE_WRITE,
+		client.FILE_OPEN,
+		0,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to open named pipe %q: %w", p.pipeName, err)
+	}
+
+	p.fid = fid
+	p.opened = true
+	return nil
+}
+
+// SendReceive writes pdu to the pipe and returns the response bytes. The pipe offset
+// is meaningless, so a zero offset is used for both the write and the read.
+func (p *SMBNamedPipe) SendReceive(pdu []byte) ([]byte, error) {
+	if !p.opened {
+		return nil, fmt.Errorf("named pipe %q is not open: call Connect first", p.pipeName)
+	}
+	if len(pdu) == 0 {
+		return nil, fmt.Errorf("refusing to send an empty PDU on named pipe %q", p.pipeName)
+	}
+
+	written, err := p.conn.WriteFile(p.fid, 0, pdu)
+	if err != nil {
+		return nil, fmt.Errorf("failed to write PDU to named pipe %q: %w", p.pipeName, err)
+	}
+	if written != len(pdu) {
+		return nil, fmt.Errorf("short write to named pipe %q: wrote %d of %d bytes", p.pipeName, written, len(pdu))
+	}
+
+	response, err := p.conn.ReadFile(p.fid, 0, uint32(p.maxRecv))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read PDU from named pipe %q: %w", p.pipeName, err)
+	}
+	if len(response) == 0 {
+		return nil, fmt.Errorf("empty response from named pipe %q", p.pipeName)
+	}
+
+	return response, nil
+}
+
+// Close closes the pipe handle. The underlying SMB session and tree connect are left
+// untouched; their lifecycle belongs to the caller that supplied the SMB client.
+// Close is idempotent.
+func (p *SMBNamedPipe) Close() error {
+	if !p.opened {
+		return nil
+	}
+
+	err := p.conn.CloseFile(p.fid)
+	p.opened = false
+	if err != nil {
+		return fmt.Errorf("failed to close named pipe %q: %w", p.pipeName, err)
+	}
+	return nil
+}
+
+// MaxXmitFrag returns the proposed maximum transmit fragment size.
+func (p *SMBNamedPipe) MaxXmitFrag() uint16 { return p.maxXmit }
+
+// MaxRecvFrag returns the proposed maximum receive fragment size.
+func (p *SMBNamedPipe) MaxRecvFrag() uint16 { return p.maxRecv }

--- a/network/dcerpc/transport/smb/smb_namedpipe.go
+++ b/network/dcerpc/transport/smb/smb_namedpipe.go
@@ -101,33 +101,37 @@ func (p *SMBNamedPipe) Connect() error {
 	return nil
 }
 
-// SendReceive writes pdu to the pipe and returns the response bytes. The pipe offset
-// is meaningless, so a zero offset is used for both the write and the read.
-func (p *SMBNamedPipe) SendReceive(pdu []byte) ([]byte, error) {
+// Send writes a complete PDU to the pipe. The pipe offset is meaningless, so a zero
+// offset is used.
+func (p *SMBNamedPipe) Send(pdu []byte) error {
 	if !p.opened {
-		return nil, fmt.Errorf("named pipe %q is not open: call Connect first", p.pipeName)
+		return fmt.Errorf("named pipe %q is not open: call Connect first", p.pipeName)
 	}
 	if len(pdu) == 0 {
-		return nil, fmt.Errorf("refusing to send an empty PDU on named pipe %q", p.pipeName)
+		return fmt.Errorf("refusing to send an empty PDU on named pipe %q", p.pipeName)
 	}
 
 	written, err := p.conn.WriteFile(p.fid, 0, pdu)
 	if err != nil {
-		return nil, fmt.Errorf("failed to write PDU to named pipe %q: %w", p.pipeName, err)
+		return fmt.Errorf("failed to write PDU to named pipe %q: %w", p.pipeName, err)
 	}
 	if written != len(pdu) {
-		return nil, fmt.Errorf("short write to named pipe %q: wrote %d of %d bytes", p.pipeName, written, len(pdu))
+		return fmt.Errorf("short write to named pipe %q: wrote %d of %d bytes", p.pipeName, written, len(pdu))
 	}
+	return nil
+}
 
-	response, err := p.conn.ReadFile(p.fid, 0, uint32(p.maxRecv))
+// Recv reads up to MaxRecvFrag bytes from the pipe. The pipe offset is meaningless,
+// so a zero offset is used.
+func (p *SMBNamedPipe) Recv() ([]byte, error) {
+	if !p.opened {
+		return nil, fmt.Errorf("named pipe %q is not open: call Connect first", p.pipeName)
+	}
+	data, err := p.conn.ReadFile(p.fid, 0, uint32(p.maxRecv))
 	if err != nil {
-		return nil, fmt.Errorf("failed to read PDU from named pipe %q: %w", p.pipeName, err)
+		return nil, fmt.Errorf("failed to read from named pipe %q: %w", p.pipeName, err)
 	}
-	if len(response) == 0 {
-		return nil, fmt.Errorf("empty response from named pipe %q", p.pipeName)
-	}
-
-	return response, nil
+	return data, nil
 }
 
 // Close closes the pipe handle. The underlying SMB session and tree connect are left

--- a/network/dcerpc/transport/smb/smb_namedpipe_test.go
+++ b/network/dcerpc/transport/smb/smb_namedpipe_test.go
@@ -1,0 +1,270 @@
+package smb
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/client"
+)
+
+// fakePipeConn is an in-memory pipeConn for exercising the transport without a live
+// SMB server. It records the arguments it was called with and returns canned results.
+type fakePipeConn struct {
+	openFID client.FID
+	openErr error
+
+	writeErr error
+	writeN   int // if zero, defaults to len(data)
+
+	readData []byte
+	readErr  error
+
+	closeErr error
+
+	// Recorded calls.
+	openedPath  string
+	openCount   int
+	written     []byte
+	writeOffset uint64
+	readOffset  uint64
+	readMaxLen  uint32
+	closeCount  int
+}
+
+func (f *fakePipeConn) OpenFile(path string, desiredAccess, shareAccess, createDisp, createOptions uint32) (client.FID, error) {
+	f.openCount++
+	f.openedPath = path
+	if f.openErr != nil {
+		return 0, f.openErr
+	}
+	return f.openFID, nil
+}
+
+func (f *fakePipeConn) WriteFile(fid client.FID, offset uint64, data []byte) (int, error) {
+	f.written = append([]byte(nil), data...)
+	f.writeOffset = offset
+	if f.writeErr != nil {
+		return 0, f.writeErr
+	}
+	if f.writeN != 0 {
+		return f.writeN, nil
+	}
+	return len(data), nil
+}
+
+func (f *fakePipeConn) ReadFile(fid client.FID, offset uint64, maxLen uint32) ([]byte, error) {
+	f.readOffset = offset
+	f.readMaxLen = maxLen
+	if f.readErr != nil {
+		return nil, f.readErr
+	}
+	return f.readData, nil
+}
+
+func (f *fakePipeConn) CloseFile(fid client.FID) error {
+	f.closeCount++
+	return f.closeErr
+}
+
+func TestNew_NormalizesPipeName(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want string
+	}{
+		{"PIPE\\lsarpc", "\\PIPE\\lsarpc"},
+		{"\\PIPE\\lsarpc", "\\PIPE\\lsarpc"},
+		{"", "\\"},
+	} {
+		p := New(nil, tc.in)
+		if p.pipeName != tc.want {
+			t.Errorf("New(%q): pipeName = %q, want %q", tc.in, p.pipeName, tc.want)
+		}
+	}
+}
+
+func TestNew_DefaultFragmentSizes(t *testing.T) {
+	p := New(nil, `\PIPE\lsarpc`)
+	if p.MaxXmitFrag() != DefaultMaxXmitFrag {
+		t.Errorf("MaxXmitFrag() = %d, want %d", p.MaxXmitFrag(), DefaultMaxXmitFrag)
+	}
+	if p.MaxRecvFrag() != DefaultMaxRecvFrag {
+		t.Errorf("MaxRecvFrag() = %d, want %d", p.MaxRecvFrag(), DefaultMaxRecvFrag)
+	}
+
+	p.SetMaxFrag(0xFFFF, 0x1000)
+	if p.MaxXmitFrag() != 0xFFFF || p.MaxRecvFrag() != 0x1000 {
+		t.Errorf("after SetMaxFrag: xmit=%d recv=%d, want 65535/4096", p.MaxXmitFrag(), p.MaxRecvFrag())
+	}
+}
+
+func TestConnect_OpensPipeWithExpectedArgs(t *testing.T) {
+	fake := &fakePipeConn{openFID: 0x4242}
+	p := newWithConn(fake, `\PIPE\lsarpc`)
+
+	if err := p.Connect(); err != nil {
+		t.Fatalf("Connect() error = %v", err)
+	}
+	if fake.openCount != 1 {
+		t.Fatalf("OpenFile called %d times, want 1", fake.openCount)
+	}
+	if fake.openedPath != `\PIPE\lsarpc` {
+		t.Errorf("OpenFile path = %q, want %q", fake.openedPath, `\PIPE\lsarpc`)
+	}
+	if p.fid != 0x4242 || !p.opened {
+		t.Errorf("after Connect: fid=%#x opened=%v, want 0x4242/true", p.fid, p.opened)
+	}
+}
+
+func TestConnect_Idempotent(t *testing.T) {
+	fake := &fakePipeConn{openFID: 1}
+	p := newWithConn(fake, `\PIPE\lsarpc`)
+
+	if err := p.Connect(); err != nil {
+		t.Fatalf("first Connect() error = %v", err)
+	}
+	if err := p.Connect(); err != nil {
+		t.Fatalf("second Connect() error = %v", err)
+	}
+	if fake.openCount != 1 {
+		t.Errorf("OpenFile called %d times, want 1 (Connect must be idempotent)", fake.openCount)
+	}
+}
+
+func TestConnect_PropagatesOpenError(t *testing.T) {
+	wantErr := errors.New("access denied")
+	fake := &fakePipeConn{openErr: wantErr}
+	p := newWithConn(fake, `\PIPE\lsarpc`)
+
+	err := p.Connect()
+	if err == nil {
+		t.Fatal("Connect() error = nil, want non-nil")
+	}
+	if !errors.Is(err, wantErr) {
+		t.Errorf("Connect() error = %v, want wrapped %v", err, wantErr)
+	}
+	if p.opened {
+		t.Error("transport marked opened after a failed Connect")
+	}
+}
+
+func TestSendReceive_WritesThenReads(t *testing.T) {
+	resp := []byte{0x05, 0x00, 0x0c, 0x03} // looks like a bind_ack header prefix
+	fake := &fakePipeConn{openFID: 7, readData: resp}
+	p := newWithConn(fake, `\PIPE\lsarpc`)
+	if err := p.Connect(); err != nil {
+		t.Fatalf("Connect() error = %v", err)
+	}
+
+	req := []byte{0x05, 0x00, 0x0b, 0x03, 0xde, 0xad}
+	got, err := p.SendReceive(req)
+	if err != nil {
+		t.Fatalf("SendReceive() error = %v", err)
+	}
+
+	if !bytes.Equal(fake.written, req) {
+		t.Errorf("written = %x, want %x", fake.written, req)
+	}
+	if fake.writeOffset != 0 || fake.readOffset != 0 {
+		t.Errorf("offsets: write=%d read=%d, want 0/0 (pipe offset is meaningless)", fake.writeOffset, fake.readOffset)
+	}
+	if fake.readMaxLen != uint32(DefaultMaxRecvFrag) {
+		t.Errorf("read maxLen = %d, want %d", fake.readMaxLen, DefaultMaxRecvFrag)
+	}
+	if !bytes.Equal(got, resp) {
+		t.Errorf("SendReceive() = %x, want %x", got, resp)
+	}
+}
+
+func TestSendReceive_RequiresConnect(t *testing.T) {
+	p := newWithConn(&fakePipeConn{}, `\PIPE\lsarpc`)
+	if _, err := p.SendReceive([]byte{0x01}); err == nil {
+		t.Fatal("SendReceive() before Connect: error = nil, want non-nil")
+	}
+}
+
+func TestSendReceive_RejectsEmptyPDU(t *testing.T) {
+	fake := &fakePipeConn{openFID: 1}
+	p := newWithConn(fake, `\PIPE\lsarpc`)
+	if err := p.Connect(); err != nil {
+		t.Fatalf("Connect() error = %v", err)
+	}
+	if _, err := p.SendReceive(nil); err == nil {
+		t.Fatal("SendReceive(nil): error = nil, want non-nil")
+	}
+	if fake.written != nil {
+		t.Error("empty PDU should not have been written")
+	}
+}
+
+func TestSendReceive_ShortWriteIsError(t *testing.T) {
+	fake := &fakePipeConn{openFID: 1, writeN: 2, readData: []byte{0xff}}
+	p := newWithConn(fake, `\PIPE\lsarpc`)
+	if err := p.Connect(); err != nil {
+		t.Fatalf("Connect() error = %v", err)
+	}
+	if _, err := p.SendReceive([]byte{0x01, 0x02, 0x03, 0x04}); err == nil {
+		t.Fatal("SendReceive() with short write: error = nil, want non-nil")
+	}
+}
+
+func TestSendReceive_PropagatesReadError(t *testing.T) {
+	wantErr := errors.New("pipe broken")
+	fake := &fakePipeConn{openFID: 1, readErr: wantErr}
+	p := newWithConn(fake, `\PIPE\lsarpc`)
+	if err := p.Connect(); err != nil {
+		t.Fatalf("Connect() error = %v", err)
+	}
+	_, err := p.SendReceive([]byte{0x01})
+	if !errors.Is(err, wantErr) {
+		t.Errorf("SendReceive() error = %v, want wrapped %v", err, wantErr)
+	}
+}
+
+func TestSendReceive_EmptyResponseIsError(t *testing.T) {
+	fake := &fakePipeConn{openFID: 1, readData: []byte{}}
+	p := newWithConn(fake, `\PIPE\lsarpc`)
+	if err := p.Connect(); err != nil {
+		t.Fatalf("Connect() error = %v", err)
+	}
+	if _, err := p.SendReceive([]byte{0x01}); err == nil {
+		t.Fatal("SendReceive() with empty response: error = nil, want non-nil")
+	}
+}
+
+func TestClose_ClosesPipeAndIsIdempotent(t *testing.T) {
+	fake := &fakePipeConn{openFID: 1}
+	p := newWithConn(fake, `\PIPE\lsarpc`)
+	if err := p.Connect(); err != nil {
+		t.Fatalf("Connect() error = %v", err)
+	}
+
+	if err := p.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	if fake.closeCount != 1 {
+		t.Errorf("CloseFile called %d times, want 1", fake.closeCount)
+	}
+	if p.opened {
+		t.Error("transport still marked opened after Close")
+	}
+
+	// Second Close is a no-op.
+	if err := p.Close(); err != nil {
+		t.Fatalf("second Close() error = %v", err)
+	}
+	if fake.closeCount != 1 {
+		t.Errorf("CloseFile called %d times after second Close, want 1", fake.closeCount)
+	}
+}
+
+func TestClose_BeforeConnectIsNoOp(t *testing.T) {
+	fake := &fakePipeConn{}
+	p := newWithConn(fake, `\PIPE\lsarpc`)
+	if err := p.Close(); err != nil {
+		t.Fatalf("Close() before Connect error = %v", err)
+	}
+	if fake.closeCount != 0 {
+		t.Errorf("CloseFile called %d times, want 0", fake.closeCount)
+	}
+}

--- a/network/dcerpc/transport/smb/smb_namedpipe_test.go
+++ b/network/dcerpc/transport/smb/smb_namedpipe_test.go
@@ -148,7 +148,7 @@ func TestConnect_PropagatesOpenError(t *testing.T) {
 	}
 }
 
-func TestSendReceive_WritesThenReads(t *testing.T) {
+func TestSendThenRecv(t *testing.T) {
 	resp := []byte{0x05, 0x00, 0x0c, 0x03} // looks like a bind_ack header prefix
 	fake := &fakePipeConn{openFID: 7, readData: resp}
 	p := newWithConn(fake, `\PIPE\lsarpc`)
@@ -157,9 +157,12 @@ func TestSendReceive_WritesThenReads(t *testing.T) {
 	}
 
 	req := []byte{0x05, 0x00, 0x0b, 0x03, 0xde, 0xad}
-	got, err := p.SendReceive(req)
+	if err := p.Send(req); err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+	got, err := p.Recv()
 	if err != nil {
-		t.Fatalf("SendReceive() error = %v", err)
+		t.Fatalf("Recv() error = %v", err)
 	}
 
 	if !bytes.Equal(fake.written, req) {
@@ -172,63 +175,59 @@ func TestSendReceive_WritesThenReads(t *testing.T) {
 		t.Errorf("read maxLen = %d, want %d", fake.readMaxLen, DefaultMaxRecvFrag)
 	}
 	if !bytes.Equal(got, resp) {
-		t.Errorf("SendReceive() = %x, want %x", got, resp)
+		t.Errorf("Recv() = %x, want %x", got, resp)
 	}
 }
 
-func TestSendReceive_RequiresConnect(t *testing.T) {
+func TestSend_RequiresConnect(t *testing.T) {
 	p := newWithConn(&fakePipeConn{}, `\PIPE\lsarpc`)
-	if _, err := p.SendReceive([]byte{0x01}); err == nil {
-		t.Fatal("SendReceive() before Connect: error = nil, want non-nil")
+	if err := p.Send([]byte{0x01}); err == nil {
+		t.Fatal("Send() before Connect: error = nil, want non-nil")
 	}
 }
 
-func TestSendReceive_RejectsEmptyPDU(t *testing.T) {
+func TestRecv_RequiresConnect(t *testing.T) {
+	p := newWithConn(&fakePipeConn{}, `\PIPE\lsarpc`)
+	if _, err := p.Recv(); err == nil {
+		t.Fatal("Recv() before Connect: error = nil, want non-nil")
+	}
+}
+
+func TestSend_RejectsEmptyPDU(t *testing.T) {
 	fake := &fakePipeConn{openFID: 1}
 	p := newWithConn(fake, `\PIPE\lsarpc`)
 	if err := p.Connect(); err != nil {
 		t.Fatalf("Connect() error = %v", err)
 	}
-	if _, err := p.SendReceive(nil); err == nil {
-		t.Fatal("SendReceive(nil): error = nil, want non-nil")
+	if err := p.Send(nil); err == nil {
+		t.Fatal("Send(nil): error = nil, want non-nil")
 	}
 	if fake.written != nil {
 		t.Error("empty PDU should not have been written")
 	}
 }
 
-func TestSendReceive_ShortWriteIsError(t *testing.T) {
-	fake := &fakePipeConn{openFID: 1, writeN: 2, readData: []byte{0xff}}
+func TestSend_ShortWriteIsError(t *testing.T) {
+	fake := &fakePipeConn{openFID: 1, writeN: 2}
 	p := newWithConn(fake, `\PIPE\lsarpc`)
 	if err := p.Connect(); err != nil {
 		t.Fatalf("Connect() error = %v", err)
 	}
-	if _, err := p.SendReceive([]byte{0x01, 0x02, 0x03, 0x04}); err == nil {
-		t.Fatal("SendReceive() with short write: error = nil, want non-nil")
+	if err := p.Send([]byte{0x01, 0x02, 0x03, 0x04}); err == nil {
+		t.Fatal("Send() with short write: error = nil, want non-nil")
 	}
 }
 
-func TestSendReceive_PropagatesReadError(t *testing.T) {
+func TestRecv_PropagatesReadError(t *testing.T) {
 	wantErr := errors.New("pipe broken")
 	fake := &fakePipeConn{openFID: 1, readErr: wantErr}
 	p := newWithConn(fake, `\PIPE\lsarpc`)
 	if err := p.Connect(); err != nil {
 		t.Fatalf("Connect() error = %v", err)
 	}
-	_, err := p.SendReceive([]byte{0x01})
+	_, err := p.Recv()
 	if !errors.Is(err, wantErr) {
-		t.Errorf("SendReceive() error = %v, want wrapped %v", err, wantErr)
-	}
-}
-
-func TestSendReceive_EmptyResponseIsError(t *testing.T) {
-	fake := &fakePipeConn{openFID: 1, readData: []byte{}}
-	p := newWithConn(fake, `\PIPE\lsarpc`)
-	if err := p.Connect(); err != nil {
-		t.Fatalf("Connect() error = %v", err)
-	}
-	if _, err := p.SendReceive([]byte{0x01}); err == nil {
-		t.Fatal("SendReceive() with empty response: error = nil, want non-nil")
+		t.Errorf("Recv() error = %v, want wrapped %v", err, wantErr)
 	}
 }
 

--- a/network/dcerpc/transport/transport.go
+++ b/network/dcerpc/transport/transport.go
@@ -1,10 +1,12 @@
 // Package transport defines the transport abstraction used by the DCE/RPC client.
 //
 // Unlike the SMB byte-stream transport (network/smb/smb_v10/transport), which frames
-// raw bytes over a socket, a DCE/RPC transport carries whole PDUs as discrete
-// messages: a connection-oriented call is strictly request -> response, so the
-// interface exposes a single SendReceive exchange rather than independent Send and
-// Receive primitives.
+// raw bytes over a socket, a DCE/RPC transport carries PDUs. A connection-oriented
+// call may span several fragments in each direction, so the interface exposes
+// independent Send and Recv primitives: the DCE/RPC client writes all request
+// fragments with Send, then reassembles the response by reading with Recv. This
+// matches the named-pipe model in [MS-RPCE] 2.1.1.2, where PDUs are written and read
+// as named pipe writes and reads.
 //
 // Concrete implementations:
 //   - network/dcerpc/transport/smb: ncacn_np, DCE/RPC over an SMB named pipe.
@@ -16,11 +18,15 @@ type Transport interface {
 	// idempotent: calling Connect on an already-connected transport is a no-op.
 	Connect() error
 
-	// SendReceive writes a single outgoing PDU and returns the bytes of the response
-	// PDU(s). The returned buffer holds up to MaxRecvFrag bytes read from the
-	// endpoint; reassembling DCE/RPC fragments that span multiple reads is the
-	// responsibility of the caller (the DCE/RPC client layer).
-	SendReceive(pdu []byte) ([]byte, error)
+	// Send writes a single complete PDU to the endpoint.
+	Send(pdu []byte) error
+
+	// Recv reads from the endpoint and returns the bytes of a single read (up to
+	// MaxRecvFrag bytes). The returned buffer may contain part of a PDU, exactly one
+	// PDU, or several PDUs; reassembling fragments across reads is the caller's
+	// responsibility. An empty result indicates the peer wrote nothing (for example,
+	// the pipe was closed).
+	Recv() ([]byte, error)
 
 	// Close tears down the endpoint. For ncacn_np it closes the pipe handle but
 	// leaves the underlying SMB session and tree connect intact, since their

--- a/network/dcerpc/transport/transport.go
+++ b/network/dcerpc/transport/transport.go
@@ -1,0 +1,38 @@
+// Package transport defines the transport abstraction used by the DCE/RPC client.
+//
+// Unlike the SMB byte-stream transport (network/smb/smb_v10/transport), which frames
+// raw bytes over a socket, a DCE/RPC transport carries whole PDUs as discrete
+// messages: a connection-oriented call is strictly request -> response, so the
+// interface exposes a single SendReceive exchange rather than independent Send and
+// Receive primitives.
+//
+// Concrete implementations:
+//   - network/dcerpc/transport/smb: ncacn_np, DCE/RPC over an SMB named pipe.
+package transport
+
+// Transport carries DCE/RPC PDUs between the client and the server.
+type Transport interface {
+	// Connect opens the underlying endpoint (for ncacn_np, the named pipe). It is
+	// idempotent: calling Connect on an already-connected transport is a no-op.
+	Connect() error
+
+	// SendReceive writes a single outgoing PDU and returns the bytes of the response
+	// PDU(s). The returned buffer holds up to MaxRecvFrag bytes read from the
+	// endpoint; reassembling DCE/RPC fragments that span multiple reads is the
+	// responsibility of the caller (the DCE/RPC client layer).
+	SendReceive(pdu []byte) ([]byte, error)
+
+	// Close tears down the endpoint. For ncacn_np it closes the pipe handle but
+	// leaves the underlying SMB session and tree connect intact, since their
+	// lifecycle is owned by the caller that supplied the SMB client.
+	Close() error
+
+	// MaxXmitFrag is the largest fragment size, in bytes, that this transport is
+	// willing to send. It is proposed in the Bind PDU; the value the server accepts
+	// is returned in the Bind_Ack and may be smaller.
+	MaxXmitFrag() uint16
+
+	// MaxRecvFrag is the largest fragment size, in bytes, that this transport is
+	// willing to receive. It is proposed in the Bind PDU alongside MaxXmitFrag.
+	MaxRecvFrag() uint16
+}


### PR DESCRIPTION
## Summary

Adds a connection-oriented DCE/RPC (MS-RPCE, C706) client layered on top of the existing SMB v1.0 named-pipe transport (protocol sequence `ncacn_np`). New code lives under `network/dcerpc/` and treats the SMB named pipe as one transport behind a DCE/RPC-specific transport interface, mirroring how `smb_v10` sits on `transport.Transport` over `tcp`/`nbt`.

Built and reviewed in four phases:

1. **Transport** (`transport/`, `transport/smb/`) — a `Send`/`Recv` transport interface and its `ncacn_np` implementation, which wraps an authenticated `smb_v10/client.Client` and writes/reads PDUs as named-pipe writes/reads ([MS-RPCE] 2.1.1.2).
2. **PDU + syntax** (`pdu/`, `syntax/`) — the 16-byte common header, `Bind`/`BindAck`/`BindNak`, `Request`/`Response`, and `Fault`, plus `SyntaxID` with NDR 2.0 / NDR64 constructors. Marshal/Unmarshal/String for each, little-endian DREP only (big-endian is rejected, not mis-parsed).
3. **Client** (`client/`) — `Bind` (single NDR-2.0 presentation context) and `Call` with request fragmentation bounded by the server-negotiated `max_xmit_frag`, response reassembly until `PFC_LAST_FRAG`, `call_id` management, and faults surfaced as a typed `*pdu.Fault` error.
4. **First interface** (`interfaces/lsarpc/`) — `LsarOpenPolicy2` and `LsarClose` with hand-marshalled NDR, as an end-to-end proof of the stack.

Field layouts, opnums, and fragmentation/`call_id` rules are cross-checked against [C706] chapter 12 and [MS-RPCE]/[MS-LSAD]; source links are in the relevant doc comments.

## Testing

- Unit tests across `transport/smb`, `pdu`, `syntax`, `client`, and `interfaces/lsarpc` — golden bytes for the common header and NDR syntax, round-trips for every PDU, multi-fragment request/response reassembly, fault handling, and the exact lsarpc request stub bytes. All hermetic; `go build ./...`, `go vet`, and `gofmt` are clean.
- A build-tagged integration test (`//go:build integration`) drives the full SMB → named pipe → bind → call path against a live server (env-configured), skipped by default.
- **Validated end to end against a live Windows XP Professional SP3 host**: `Bind(lsarpc)` succeeds, `LsarOpenPolicy2` returns a policy handle, and `LsarClose` closes it.

## Notes

- The pipe is opened by its IPC$-relative name `\lsarpc` (the `\PIPE` namespace is implicit on IPC$).
- `NativeOS`/`NativeLanMan` must be set before `SessionSetup` for this target; the integration test does so.
- No RPC-layer auth/signing or generic NDR engine yet — deferred follow-ups, along with `ncacn_ip_tcp` and additional interfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)