### PR TITLE
[enhancement] Add generic NDR marshalling for DCE/RPC

### DIFF
--- a/network/dcerpc/ndr/codec.go
+++ b/network/dcerpc/ndr/codec.go
@@ -1,0 +1,271 @@
+// Package ndr implements the DCE/RPC Network Data Representation (NDR) transfer
+// syntax, version 2.0 (the "NDR20" little-endian encoding used by Windows RPC), with
+// a declarative, reflection-driven API for marshalling RPC call structures.
+//
+// The low-level codec (Encoder/Decoder) handles NDR's stream-relative alignment and
+// primitive encoding; the reflection walker in marshal.go drives it from struct tags
+// so callers can declare an RPC call as a Go struct (see Call, Marshal, Unmarshal).
+//
+// Scope: NDR20, little-endian (the standard Windows data representation, DREP 0x10).
+// Big-endian and NDR64 (8-byte counts/referents) are out of scope.
+//
+// References:
+//   - [C706] DCE 1.1: RPC, Chapter 14 "Transfer Syntax NDR":
+//     https://pubs.opengroup.org/onlinepubs/9629399/chap14.htm
+//   - [MS-RPCE] Transfer Syntax NDR types:
+//     https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/b6090c2b-f44a-47a1-a13b-b82ade0137b2
+package ndr
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/encoding/utf16"
+)
+
+// Marshaler is implemented by types that encode themselves as NDR, bypassing the
+// reflection walker. It is the escape hatch for unions and any layout the declarative
+// tags do not cover.
+type Marshaler interface {
+	// AlignmentNDR reports the type's NDR alignment (1, 2, 4, or 8).
+	AlignmentNDR() int
+	// MarshalNDR appends the type's NDR representation to the encoder.
+	MarshalNDR(*Encoder) error
+	// UnmarshalNDR reads the type's NDR representation from the decoder.
+	UnmarshalNDR(*Decoder) error
+}
+
+// Encoder builds an NDR octet stream. Alignment is computed relative to the start of
+// the stream, as required by [C706] section 14.2.2.
+type Encoder struct {
+	buf     []byte
+	nextRef uint32
+}
+
+// firstReferentID is the referent id assigned to the first non-null pointer. The
+// exact value is irrelevant on the wire (a receiver only checks non-null for
+// unique/full pointers); an arbitrary non-zero base matching common implementations
+// is used.
+const firstReferentID uint32 = 0x00020000
+
+// NewEncoder returns an empty encoder.
+func NewEncoder() *Encoder { return &Encoder{nextRef: firstReferentID} }
+
+// Bytes returns the accumulated octet stream.
+func (e *Encoder) Bytes() []byte { return e.buf }
+
+// Len returns the current stream length, which is the offset alignment is measured
+// against.
+func (e *Encoder) Len() int { return len(e.buf) }
+
+// Align pads the stream with zero octets so the next write begins on a multiple of n.
+func (e *Encoder) Align(n int) {
+	if n <= 1 {
+		return
+	}
+	for len(e.buf)%n != 0 {
+		e.buf = append(e.buf, 0)
+	}
+}
+
+// WriteBytes appends raw octets with no alignment.
+func (e *Encoder) WriteBytes(b []byte) { e.buf = append(e.buf, b...) }
+
+// WriteUint8 appends a 1-octet value.
+func (e *Encoder) WriteUint8(v uint8) { e.buf = append(e.buf, v) }
+
+// WriteUint16 appends a 2-octet little-endian value, 2-aligned.
+func (e *Encoder) WriteUint16(v uint16) {
+	e.Align(2)
+	e.buf = binary.LittleEndian.AppendUint16(e.buf, v)
+}
+
+// WriteUint32 appends a 4-octet little-endian value, 4-aligned.
+func (e *Encoder) WriteUint32(v uint32) {
+	e.Align(4)
+	e.buf = binary.LittleEndian.AppendUint32(e.buf, v)
+}
+
+// WriteUint64 appends an 8-octet little-endian value, 8-aligned.
+func (e *Encoder) WriteUint64(v uint64) {
+	e.Align(8)
+	e.buf = binary.LittleEndian.AppendUint64(e.buf, v)
+}
+
+// nextReferent returns the next referent id for a non-null pointer.
+func (e *Encoder) nextReferent() uint32 {
+	id := e.nextRef
+	e.nextRef += 4
+	return id
+}
+
+// writeWString writes a wchar_t string ([string] wide) as a conformant+varying array
+// of UTF-16LE code units. The maximum and actual counts include the NUL terminator,
+// per [MS-RPCE] Conformant Varying Strings:
+// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/db6a89db-2c88-4ae7-90de-fca23929abab
+func (e *Encoder) writeWString(s string) {
+	units := utf16.EncodeUTF16LE(s) // 2 octets per code unit, no terminator
+	count := uint32(len(units)/2) + 1
+	e.WriteUint32(count) // maximum_count
+	e.WriteUint32(0)     // offset
+	e.WriteUint32(count) // actual_count
+	e.WriteBytes(units)
+	e.WriteUint16(0) // NUL terminator
+}
+
+// writeAString writes a char string ([string]) as a conformant+varying array of
+// octets. The counts include the NUL terminator.
+func (e *Encoder) writeAString(s string) {
+	count := uint32(len(s)) + 1
+	e.WriteUint32(count) // maximum_count
+	e.WriteUint32(0)     // offset
+	e.WriteUint32(count) // actual_count
+	e.WriteBytes([]byte(s))
+	e.WriteUint8(0) // NUL terminator
+}
+
+// writeConformantBytes writes a [size_is] byte array: a maximum_count followed by the
+// elements ([MS-RPCE] Conformant Arrays:
+// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/140b01a3-979b-43af-b1e3-28f248db8f03).
+func (e *Encoder) writeConformantBytes(b []byte) {
+	e.WriteUint32(uint32(len(b)))
+	e.WriteBytes(b)
+}
+
+// Decoder reads an NDR octet stream produced under the little-endian data
+// representation.
+type Decoder struct {
+	data []byte
+	pos  int
+}
+
+// NewDecoder returns a decoder over data.
+func NewDecoder(data []byte) *Decoder { return &Decoder{data: data} }
+
+// Pos returns the current read offset.
+func (d *Decoder) Pos() int { return d.pos }
+
+// Remaining returns the number of unread octets.
+func (d *Decoder) Remaining() int { return len(d.data) - d.pos }
+
+// Align advances the read position to the next multiple of n.
+func (d *Decoder) Align(n int) {
+	if n <= 1 {
+		return
+	}
+	for d.pos%n != 0 {
+		d.pos++
+	}
+}
+
+// ReadBytes returns the next n octets.
+func (d *Decoder) ReadBytes(n int) ([]byte, error) {
+	if n < 0 || d.pos+n > len(d.data) {
+		return nil, fmt.Errorf("ndr: read of %d bytes at offset %d exceeds stream length %d", n, d.pos, len(d.data))
+	}
+	b := d.data[d.pos : d.pos+n]
+	d.pos += n
+	return b, nil
+}
+
+// ReadUint8 reads a 1-octet value.
+func (d *Decoder) ReadUint8() (uint8, error) {
+	b, err := d.ReadBytes(1)
+	if err != nil {
+		return 0, err
+	}
+	return b[0], nil
+}
+
+// ReadUint16 reads a 2-octet little-endian value, 2-aligned.
+func (d *Decoder) ReadUint16() (uint16, error) {
+	d.Align(2)
+	b, err := d.ReadBytes(2)
+	if err != nil {
+		return 0, err
+	}
+	return binary.LittleEndian.Uint16(b), nil
+}
+
+// ReadUint32 reads a 4-octet little-endian value, 4-aligned.
+func (d *Decoder) ReadUint32() (uint32, error) {
+	d.Align(4)
+	b, err := d.ReadBytes(4)
+	if err != nil {
+		return 0, err
+	}
+	return binary.LittleEndian.Uint32(b), nil
+}
+
+// ReadUint64 reads an 8-octet little-endian value, 8-aligned.
+func (d *Decoder) ReadUint64() (uint64, error) {
+	d.Align(8)
+	b, err := d.ReadBytes(8)
+	if err != nil {
+		return 0, err
+	}
+	return binary.LittleEndian.Uint64(b), nil
+}
+
+// readWString reads a conformant+varying UTF-16LE string and returns it with the NUL
+// terminator removed.
+func (d *Decoder) readWString() (string, error) {
+	if _, err := d.ReadUint32(); err != nil { // maximum_count
+		return "", err
+	}
+	if _, err := d.ReadUint32(); err != nil { // offset
+		return "", err
+	}
+	actual, err := d.ReadUint32() // actual_count (code units, incl. terminator)
+	if err != nil {
+		return "", err
+	}
+	b, err := d.ReadBytes(int(actual) * 2)
+	if err != nil {
+		return "", err
+	}
+	return trimTerminator(utf16.DecodeUTF16LE(b)), nil
+}
+
+// readAString reads a conformant+varying ASCII string and returns it with the NUL
+// terminator removed.
+func (d *Decoder) readAString() (string, error) {
+	if _, err := d.ReadUint32(); err != nil { // maximum_count
+		return "", err
+	}
+	if _, err := d.ReadUint32(); err != nil { // offset
+		return "", err
+	}
+	actual, err := d.ReadUint32() // actual_count (octets, incl. terminator)
+	if err != nil {
+		return "", err
+	}
+	b, err := d.ReadBytes(int(actual))
+	if err != nil {
+		return "", err
+	}
+	return trimTerminator(string(b)), nil
+}
+
+// readConformantBytes reads a maximum_count-prefixed byte array.
+func (d *Decoder) readConformantBytes() ([]byte, error) {
+	n, err := d.ReadUint32()
+	if err != nil {
+		return nil, err
+	}
+	b, err := d.ReadBytes(int(n))
+	if err != nil {
+		return nil, err
+	}
+	out := make([]byte, len(b))
+	copy(out, b)
+	return out, nil
+}
+
+// trimTerminator removes a single trailing NUL, the NDR string terminator.
+func trimTerminator(s string) string {
+	if n := len(s); n > 0 && s[n-1] == 0 {
+		return s[:n-1]
+	}
+	return s
+}

--- a/network/dcerpc/ndr/codec_test.go
+++ b/network/dcerpc/ndr/codec_test.go
@@ -1,0 +1,83 @@
+package ndr
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestEncoder_Alignment(t *testing.T) {
+	e := NewEncoder()
+	e.WriteUint8(0x01)
+	e.WriteUint32(0x02) // must 4-align: 3 pad bytes after the uint8
+	want := []byte{0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00}
+	if !bytes.Equal(e.Bytes(), want) {
+		t.Errorf("aligned encode:\n got %x\nwant %x", e.Bytes(), want)
+	}
+}
+
+func TestEncoder_Uint64Alignment(t *testing.T) {
+	e := NewEncoder()
+	e.WriteUint16(0xaabb)
+	e.WriteUint64(0x1122334455667788) // 8-align: 6 pad bytes after the uint16
+	want := []byte{
+		0xbb, 0xaa, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11,
+	}
+	if !bytes.Equal(e.Bytes(), want) {
+		t.Errorf("got %x want %x", e.Bytes(), want)
+	}
+}
+
+func TestWString_GoldenBytes(t *testing.T) {
+	e := NewEncoder()
+	e.writeWString("AB")
+	// count = 3 (incl NUL); offset 0; actual 3; "A\0" "B\0" little-endian; NUL terminator.
+	want := []byte{
+		0x03, 0x00, 0x00, 0x00, // maximum_count
+		0x00, 0x00, 0x00, 0x00, // offset
+		0x03, 0x00, 0x00, 0x00, // actual_count
+		0x41, 0x00, 0x42, 0x00, // "AB"
+		0x00, 0x00, // terminator
+	}
+	if !bytes.Equal(e.Bytes(), want) {
+		t.Errorf("wstring:\n got %x\nwant %x", e.Bytes(), want)
+	}
+}
+
+func TestWString_RoundTrip(t *testing.T) {
+	for _, s := range []string{"", "A", `\\host\share\file.txt`, "Ünîçødé"} {
+		e := NewEncoder()
+		e.writeWString(s)
+		got, err := NewDecoder(e.Bytes()).readWString()
+		if err != nil {
+			t.Fatalf("readWString(%q): %v", s, err)
+		}
+		if got != s {
+			t.Errorf("round trip: got %q want %q", got, s)
+		}
+	}
+}
+
+func TestConformantBytes_RoundTrip(t *testing.T) {
+	in := []byte{0xaa, 0xbb, 0xcc}
+	e := NewEncoder()
+	e.writeConformantBytes(in)
+	want := []byte{0x03, 0x00, 0x00, 0x00, 0xaa, 0xbb, 0xcc}
+	if !bytes.Equal(e.Bytes(), want) {
+		t.Fatalf("conformant bytes:\n got %x\nwant %x", e.Bytes(), want)
+	}
+	got, err := NewDecoder(e.Bytes()).readConformantBytes()
+	if err != nil {
+		t.Fatalf("readConformantBytes: %v", err)
+	}
+	if !bytes.Equal(got, in) {
+		t.Errorf("round trip: got %x want %x", got, in)
+	}
+}
+
+func TestDecoder_BoundsChecked(t *testing.T) {
+	d := NewDecoder([]byte{0x01, 0x02})
+	if _, err := d.ReadUint32(); err == nil {
+		t.Fatal("ReadUint32 on a 2-byte stream: error = nil, want non-nil")
+	}
+}

--- a/network/dcerpc/ndr/marshal.go
+++ b/network/dcerpc/ndr/marshal.go
@@ -1,0 +1,426 @@
+package ndr
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// Marshal encodes v (a struct or pointer to struct) into an NDR octet stream. Each
+// exported field is marshalled in declaration order according to its `ndr:"..."` tag.
+//
+// Pointers (Go pointer fields, or value fields tagged "unique"/"ptr") are encoded as a
+// referent id inline with their referent body deferred to the end of the enclosing
+// construction, per the deferral rule in [C706] section 14.3.10:
+// https://pubs.opengroup.org/onlinepubs/9629399/chap14.htm
+func Marshal(v any) ([]byte, error) {
+	rv, err := structValue(reflect.ValueOf(v))
+	if err != nil {
+		return nil, err
+	}
+	e := NewEncoder()
+	if err := marshalStruct(e, rv); err != nil {
+		return nil, err
+	}
+	return e.Bytes(), nil
+}
+
+// Unmarshal decodes an NDR octet stream into v, which must be a non-nil pointer to a
+// struct.
+func Unmarshal(data []byte, v any) error {
+	rv := reflect.ValueOf(v)
+	if rv.Kind() != reflect.Pointer || rv.IsNil() {
+		return fmt.Errorf("ndr: Unmarshal requires a non-nil pointer, got %T", v)
+	}
+	sv, err := structValue(rv)
+	if err != nil {
+		return err
+	}
+	return unmarshalStruct(NewDecoder(data), sv)
+}
+
+// structValue dereferences pointers/interfaces to reach a struct value.
+func structValue(rv reflect.Value) (reflect.Value, error) {
+	for rv.Kind() == reflect.Pointer || rv.Kind() == reflect.Interface {
+		if rv.IsNil() {
+			return reflect.Value{}, fmt.Errorf("ndr: nil value")
+		}
+		rv = rv.Elem()
+	}
+	if rv.Kind() != reflect.Struct {
+		return reflect.Value{}, fmt.Errorf("ndr: expected a struct, got %s", rv.Kind())
+	}
+	return rv, nil
+}
+
+// ---- marshalling ----------------------------------------------------------------
+
+// marshalStruct marshals a struct as an NDR construction: all inline field
+// representations first, then the deferred referent bodies in field order.
+func marshalStruct(e *Encoder, rv reflect.Value) error {
+	rt := rv.Type()
+	var deferred []func() error
+	for i := 0; i < rt.NumField(); i++ {
+		f := rt.Field(i)
+		if f.PkgPath != "" { // unexported
+			continue
+		}
+		tag := parseTag(f.Tag.Get("ndr"))
+		if tag.skip {
+			continue
+		}
+		if err := marshalFieldInline(e, rv.Field(i), tag, &deferred); err != nil {
+			return fmt.Errorf("ndr: field %s: %w", f.Name, err)
+		}
+	}
+	for _, fn := range deferred {
+		if err := fn(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// marshalFieldInline writes a field's inline representation, enqueueing the referent
+// body for pointers.
+func marshalFieldInline(e *Encoder, fv reflect.Value, tag fieldTag, deferred *[]func() error) error {
+	if m, ok := asMarshaler(fv); ok {
+		e.Align(m.AlignmentNDR())
+		return m.MarshalNDR(e)
+	}
+
+	if isPointerLike(fv, tag) {
+		kind := tag.ptr
+		if kind == ptrNone {
+			kind = ptrUnique // a bare Go pointer defaults to [unique]
+		}
+		if kind == ptrRef {
+			// Reference pointers carry no referent id at the top level; the referent
+			// is marshalled inline.
+			if isNilReferent(fv) {
+				return fmt.Errorf("ndr: nil [ref] pointer")
+			}
+			return marshalReferentBody(e, fv, tag)
+		}
+		if isNilReferent(fv) {
+			e.WriteUint32(0) // NULL referent
+			return nil
+		}
+		e.WriteUint32(e.nextReferent())
+		body := fv
+		*deferred = append(*deferred, func() error { return marshalReferentBody(e, body, tag) })
+		return nil
+	}
+
+	return marshalInlineValue(e, fv, tag, deferred)
+}
+
+// marshalReferentBody marshals the representation a pointer refers to.
+func marshalReferentBody(e *Encoder, fv reflect.Value, tag fieldTag) error {
+	if fv.Kind() == reflect.Pointer {
+		fv = fv.Elem()
+	}
+	return marshalInlineValue(e, fv, tag, nil)
+}
+
+// marshalInlineValue marshals a non-pointer value in place. deferred may be nil when
+// the value is itself a referent body (its own pointers create a fresh construction
+// scope via marshalStruct).
+func marshalInlineValue(e *Encoder, fv reflect.Value, tag fieldTag, deferred *[]func() error) error {
+	if m, ok := asMarshaler(fv); ok {
+		e.Align(m.AlignmentNDR())
+		return m.MarshalNDR(e)
+	}
+
+	if isString, wide := stringMode(fv, tag); isString {
+		if wide {
+			e.writeWString(fv.String())
+		} else {
+			e.writeAString(fv.String())
+		}
+		return nil
+	}
+
+	switch fv.Kind() {
+	case reflect.Struct:
+		return marshalStruct(e, fv)
+	case reflect.Slice:
+		if fv.Type().Elem().Kind() == reflect.Uint8 {
+			e.writeConformantBytes(fv.Bytes())
+			return nil
+		}
+		return fmt.Errorf("ndr: unsupported slice element %s", fv.Type().Elem().Kind())
+	case reflect.Array:
+		if fv.Type().Elem().Kind() == reflect.Uint8 {
+			b := make([]byte, fv.Len())
+			reflect.Copy(reflect.ValueOf(b), fv)
+			e.WriteBytes(b)
+			return nil
+		}
+		return fmt.Errorf("ndr: unsupported array element %s", fv.Type().Elem().Kind())
+	default:
+		return marshalScalar(e, fv)
+	}
+}
+
+// marshalScalar writes an integer or boolean primitive with NDR alignment.
+func marshalScalar(e *Encoder, fv reflect.Value) error {
+	switch fv.Kind() {
+	case reflect.Bool:
+		if fv.Bool() {
+			e.WriteUint8(1)
+		} else {
+			e.WriteUint8(0)
+		}
+	case reflect.Uint8:
+		e.WriteUint8(uint8(fv.Uint()))
+	case reflect.Uint16:
+		e.WriteUint16(uint16(fv.Uint()))
+	case reflect.Uint32, reflect.Uint:
+		e.WriteUint32(uint32(fv.Uint()))
+	case reflect.Uint64:
+		e.WriteUint64(fv.Uint())
+	case reflect.Int8:
+		e.WriteUint8(uint8(fv.Int()))
+	case reflect.Int16:
+		e.WriteUint16(uint16(fv.Int()))
+	case reflect.Int32, reflect.Int:
+		e.WriteUint32(uint32(fv.Int()))
+	case reflect.Int64:
+		e.WriteUint64(uint64(fv.Int()))
+	default:
+		return fmt.Errorf("ndr: unsupported scalar kind %s", fv.Kind())
+	}
+	return nil
+}
+
+// ---- unmarshalling --------------------------------------------------------------
+
+func unmarshalStruct(d *Decoder, rv reflect.Value) error {
+	rt := rv.Type()
+	var deferred []func() error
+	for i := 0; i < rt.NumField(); i++ {
+		f := rt.Field(i)
+		if f.PkgPath != "" {
+			continue
+		}
+		tag := parseTag(f.Tag.Get("ndr"))
+		if tag.skip {
+			continue
+		}
+		if err := unmarshalFieldInline(d, rv.Field(i), tag, &deferred); err != nil {
+			return fmt.Errorf("ndr: field %s: %w", f.Name, err)
+		}
+	}
+	for _, fn := range deferred {
+		if err := fn(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func unmarshalFieldInline(d *Decoder, fv reflect.Value, tag fieldTag, deferred *[]func() error) error {
+	if m, ok := asMarshalerAddr(fv); ok {
+		d.Align(m.AlignmentNDR())
+		return m.UnmarshalNDR(d)
+	}
+
+	if isPointerLike(fv, tag) {
+		kind := tag.ptr
+		if kind == ptrNone {
+			kind = ptrUnique
+		}
+		if kind == ptrRef {
+			return unmarshalReferentBody(d, fv, tag)
+		}
+		refid, err := d.ReadUint32()
+		if err != nil {
+			return err
+		}
+		if refid == 0 {
+			return nil // NULL: leave the zero value
+		}
+		target := fv
+		*deferred = append(*deferred, func() error { return unmarshalReferentBody(d, target, tag) })
+		return nil
+	}
+
+	return unmarshalInlineValue(d, fv, tag)
+}
+
+func unmarshalReferentBody(d *Decoder, fv reflect.Value, tag fieldTag) error {
+	if fv.Kind() == reflect.Pointer {
+		if fv.IsNil() {
+			fv.Set(reflect.New(fv.Type().Elem()))
+		}
+		fv = fv.Elem()
+	}
+	return unmarshalInlineValue(d, fv, tag)
+}
+
+func unmarshalInlineValue(d *Decoder, fv reflect.Value, tag fieldTag) error {
+	if m, ok := asMarshalerAddr(fv); ok {
+		d.Align(m.AlignmentNDR())
+		return m.UnmarshalNDR(d)
+	}
+
+	if isString, wide := stringMode(fv, tag); isString {
+		var s string
+		var err error
+		if wide {
+			s, err = d.readWString()
+		} else {
+			s, err = d.readAString()
+		}
+		if err != nil {
+			return err
+		}
+		fv.SetString(s)
+		return nil
+	}
+
+	switch fv.Kind() {
+	case reflect.Struct:
+		return unmarshalStruct(d, fv)
+	case reflect.Slice:
+		if fv.Type().Elem().Kind() == reflect.Uint8 {
+			b, err := d.readConformantBytes()
+			if err != nil {
+				return err
+			}
+			fv.SetBytes(b)
+			return nil
+		}
+		return fmt.Errorf("ndr: unsupported slice element %s", fv.Type().Elem().Kind())
+	case reflect.Array:
+		if fv.Type().Elem().Kind() == reflect.Uint8 {
+			b, err := d.ReadBytes(fv.Len())
+			if err != nil {
+				return err
+			}
+			reflect.Copy(fv, reflect.ValueOf(b))
+			return nil
+		}
+		return fmt.Errorf("ndr: unsupported array element %s", fv.Type().Elem().Kind())
+	default:
+		return unmarshalScalar(d, fv)
+	}
+}
+
+func unmarshalScalar(d *Decoder, fv reflect.Value) error {
+	switch fv.Kind() {
+	case reflect.Bool:
+		v, err := d.ReadUint8()
+		if err != nil {
+			return err
+		}
+		fv.SetBool(v != 0)
+	case reflect.Uint8:
+		v, err := d.ReadUint8()
+		if err != nil {
+			return err
+		}
+		fv.SetUint(uint64(v))
+	case reflect.Uint16:
+		v, err := d.ReadUint16()
+		if err != nil {
+			return err
+		}
+		fv.SetUint(uint64(v))
+	case reflect.Uint32, reflect.Uint:
+		v, err := d.ReadUint32()
+		if err != nil {
+			return err
+		}
+		fv.SetUint(uint64(v))
+	case reflect.Uint64:
+		v, err := d.ReadUint64()
+		if err != nil {
+			return err
+		}
+		fv.SetUint(v)
+	case reflect.Int8:
+		v, err := d.ReadUint8()
+		if err != nil {
+			return err
+		}
+		fv.SetInt(int64(int8(v)))
+	case reflect.Int16:
+		v, err := d.ReadUint16()
+		if err != nil {
+			return err
+		}
+		fv.SetInt(int64(int16(v)))
+	case reflect.Int32, reflect.Int:
+		v, err := d.ReadUint32()
+		if err != nil {
+			return err
+		}
+		fv.SetInt(int64(int32(v)))
+	case reflect.Int64:
+		v, err := d.ReadUint64()
+		if err != nil {
+			return err
+		}
+		fv.SetInt(int64(v))
+	default:
+		return fmt.Errorf("ndr: unsupported scalar kind %s", fv.Kind())
+	}
+	return nil
+}
+
+// ---- helpers --------------------------------------------------------------------
+
+func isPointerLike(fv reflect.Value, tag fieldTag) bool {
+	if fv.Kind() == reflect.Pointer {
+		return true
+	}
+	return tag.ptr != ptrNone
+}
+
+func isNilReferent(fv reflect.Value) bool {
+	switch fv.Kind() {
+	case reflect.Pointer, reflect.Slice:
+		return fv.IsNil()
+	default:
+		return false // value strings are always present
+	}
+}
+
+// stringMode reports whether fv is an NDR string and, if so, whether it is wide
+// (UTF-16). The named aliases WSTR/STR select the mode by type; a plain string uses
+// the tag and defaults to wide (the common MS-RPC case).
+func stringMode(fv reflect.Value, tag fieldTag) (isString, wide bool) {
+	switch {
+	case fv.Type() == wstrType:
+		return true, true
+	case fv.Type() == strType:
+		return true, false
+	case fv.Kind() == reflect.String:
+		return true, !tag.ascii
+	default:
+		return false, false
+	}
+}
+
+func asMarshaler(fv reflect.Value) (Marshaler, bool) {
+	if fv.Type().Implements(marshalerType) {
+		return fv.Interface().(Marshaler), true
+	}
+	if fv.CanAddr() && fv.Addr().Type().Implements(marshalerType) {
+		return fv.Addr().Interface().(Marshaler), true
+	}
+	return nil, false
+}
+
+func asMarshalerAddr(fv reflect.Value) (Marshaler, bool) {
+	if fv.CanAddr() && fv.Addr().Type().Implements(marshalerType) {
+		return fv.Addr().Interface().(Marshaler), true
+	}
+	if fv.Type().Implements(marshalerType) {
+		return fv.Interface().(Marshaler), true
+	}
+	return nil, false
+}
+
+var marshalerType = reflect.TypeOf((*Marshaler)(nil)).Elem()

--- a/network/dcerpc/ndr/marshal_test.go
+++ b/network/dcerpc/ndr/marshal_test.go
@@ -1,0 +1,177 @@
+package ndr
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+)
+
+// efsBlob models EFS_RPC_BLOB { DWORD cbData; [size_is(cbData)] byte* bData; }.
+type efsBlob struct {
+	CbData DWORD  `ndr:"dword"`
+	BData  []byte `ndr:"unique,conformant,size_is=CbData"`
+}
+
+// efsCall models an EFSR-style call: scalar, unique pointer to struct, wide string
+// pointer, scalar.
+type efsCall struct {
+	Flags     DWORD    `ndr:"dword"`
+	Reserved  *efsBlob `ndr:"unique"`
+	FileName  WSTR     `ndr:"unique"`
+	InfoClass DWORD    `ndr:"dword"`
+}
+
+func (*efsCall) Opnum() uint16 { return 16 }
+
+func TestMarshal_DeferredOrdering_GoldenBytes(t *testing.T) {
+	call := &efsCall{
+		Flags:     0x11,
+		Reserved:  &efsBlob{CbData: 2, BData: []byte{0xaa, 0xbb}},
+		FileName:  "A",
+		InfoClass: 0x22,
+	}
+	got, err := Marshal(call)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	want := []byte{
+		// --- top-level inline ---
+		0x11, 0x00, 0x00, 0x00, // Flags
+		0x00, 0x00, 0x02, 0x00, // Reserved referent id (0x00020000)
+		0x04, 0x00, 0x02, 0x00, // FileName referent id (0x00020004)
+		0x22, 0x00, 0x00, 0x00, // InfoClass
+		// --- deferred[0]: Reserved (efsBlob) construction ---
+		0x02, 0x00, 0x00, 0x00, // CbData
+		0x08, 0x00, 0x02, 0x00, // BData referent id (0x00020008)
+		0x02, 0x00, 0x00, 0x00, // BData conformant maximum_count
+		0xaa, 0xbb, // BData elements
+		// --- deferred[1]: FileName wstring ("A") ---
+		0x00, 0x00, // 2-byte pad to 4-align the count
+		0x02, 0x00, 0x00, 0x00, // maximum_count (incl NUL)
+		0x00, 0x00, 0x00, 0x00, // offset
+		0x02, 0x00, 0x00, 0x00, // actual_count
+		0x41, 0x00, // "A"
+		0x00, 0x00, // terminator
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("EFSR-style marshal:\n got %x\nwant %x", got, want)
+	}
+}
+
+func TestMarshalUnmarshal_RoundTrip(t *testing.T) {
+	in := &efsCall{
+		Flags:     0xdeadbeef,
+		Reserved:  &efsBlob{CbData: 3, BData: []byte{1, 2, 3}},
+		FileName:  `\\host\share`,
+		InfoClass: 7,
+	}
+	raw, err := Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var out efsCall
+	if err := Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if !reflect.DeepEqual(in, &out) {
+		t.Errorf("round trip mismatch:\n in  %+v (blob %+v)\n out %+v (blob %+v)", in, in.Reserved, &out, out.Reserved)
+	}
+}
+
+func TestMarshal_NullPointer(t *testing.T) {
+	call := &efsCall{Flags: 1, Reserved: nil, FileName: "x", InfoClass: 2}
+	raw, err := Marshal(call)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	// Reserved is the second field: its referent id must be 0 (NULL).
+	if !bytes.Equal(raw[4:8], []byte{0, 0, 0, 0}) {
+		t.Errorf("NULL Reserved referent = %x, want 00000000", raw[4:8])
+	}
+
+	var out efsCall
+	if err := Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out.Reserved != nil {
+		t.Errorf("Reserved = %+v, want nil after a NULL referent", out.Reserved)
+	}
+}
+
+func TestRequest_UsesOpnumlessMarshalling(t *testing.T) {
+	// Request marshals only the struct's fields (Opnum is a method, not a field).
+	call := &efsCall{Flags: 0x11, FileName: "A", InfoClass: 0x22}
+	raw, err := Request(call)
+	if err != nil {
+		t.Fatalf("Request: %v", err)
+	}
+	if len(raw) < 4 || !bytes.Equal(raw[0:4], []byte{0x11, 0x00, 0x00, 0x00}) {
+		t.Errorf("Request stub does not start with Flags: %x", raw)
+	}
+	if call.Opnum() != 16 {
+		t.Errorf("Opnum = %d, want 16", call.Opnum())
+	}
+}
+
+func TestScalars_RoundTrip(t *testing.T) {
+	type scalars struct {
+		A bool   `ndr:"bool"`
+		B uint8  `ndr:"byte"`
+		C uint16 `ndr:"word"`
+		D uint32 `ndr:"dword"`
+		E uint64 `ndr:"hyper"`
+		F int32  `ndr:"long"`
+	}
+	in := &scalars{A: true, B: 0x7f, C: 0xbeef, D: 0xdeadbeef, E: 0x1122334455667788, F: -5}
+	raw, err := Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var out scalars
+	if err := Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if *in != out {
+		t.Errorf("round trip: in %+v out %+v", in, out)
+	}
+}
+
+// fixedThing is a custom NDR type using the Marshaler escape hatch: a fixed 4-byte
+// value with 4-byte alignment.
+type fixedThing struct{ V uint32 }
+
+func (f *fixedThing) AlignmentNDR() int { return 4 }
+func (f *fixedThing) MarshalNDR(e *Encoder) error {
+	e.WriteUint32(f.V)
+	return nil
+}
+func (f *fixedThing) UnmarshalNDR(d *Decoder) error {
+	v, err := d.ReadUint32()
+	f.V = v
+	return err
+}
+
+func TestMarshaler_EscapeHatch(t *testing.T) {
+	type wrap struct {
+		Lead uint8
+		T    fixedThing
+	}
+	in := &wrap{Lead: 0x01, T: fixedThing{V: 0xcafebabe}}
+	raw, err := Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	// uint8 then 4-aligned custom uint32.
+	want := []byte{0x01, 0x00, 0x00, 0x00, 0xbe, 0xba, 0xfe, 0xca}
+	if !bytes.Equal(raw, want) {
+		t.Errorf("escape hatch:\n got %x\nwant %x", raw, want)
+	}
+	var out wrap
+	if err := Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out != *in {
+		t.Errorf("round trip: got %+v want %+v", out, in)
+	}
+}

--- a/network/dcerpc/ndr/types.go
+++ b/network/dcerpc/ndr/types.go
@@ -1,0 +1,116 @@
+package ndr
+
+import (
+	"reflect"
+	"strings"
+)
+
+// Windows-style NDR type aliases, mirroring the names used in [MS-DTYP] and impacket
+// so declarations read like the IDL. References:
+//   - [MS-DTYP] 2.2 Common Data Types:
+//     https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/cca27429-5689-4a16-b2b4-9325d93e4ba2
+type (
+	BYTE    = uint8
+	WORD    = uint16
+	DWORD   = uint32
+	DWORD64 = uint64
+	LONG    = int32
+	BOOL    = bool
+
+	// WSTR is a wchar_t string ([string] wide). A field of this type marshals as a
+	// conformant+varying UTF-16LE array without needing an explicit "wstr" tag.
+	WSTR string
+	// STR is a char string ([string]). A field of this type marshals as a
+	// conformant+varying ASCII array.
+	STR string
+)
+
+// wstrType and strType are cached reflect.Types for the named string aliases.
+var (
+	wstrType = reflect.TypeOf(WSTR(""))
+	strType  = reflect.TypeOf(STR(""))
+)
+
+// Call is implemented by a request structure to provide its operation number. Its
+// exported fields are the [in] parameters, marshalled in declaration order.
+type Call interface {
+	Opnum() uint16
+}
+
+// Request marshals an RPC call's [in] parameters into a stub buffer suitable for
+// network/dcerpc/client.Client.Call(call.Opnum(), stub).
+func Request(call Call) ([]byte, error) {
+	return Marshal(call)
+}
+
+// Response unmarshals an RPC response stub into out (a pointer to the [out] parameter
+// structure).
+func Response(stub []byte, out any) error {
+	return Unmarshal(stub, out)
+}
+
+// ptrKind is the NDR pointer attribute of a field.
+type ptrKind int
+
+const (
+	ptrNone   ptrKind = iota // not a pointer
+	ptrUnique                // [unique]
+	ptrRef                   // [ref]
+	ptrFull                  // [ptr] (full pointer)
+)
+
+// fieldTag is the parsed `ndr:"..."` struct tag.
+type fieldTag struct {
+	skip       bool
+	ptr        ptrKind
+	wide       bool   // [string] wide (UTF-16)
+	ascii      bool   // [string] ASCII
+	conformant bool   // conformant array (size_is)
+	sizeIs     string // sibling field naming the element count
+	align      int    // explicit alignment override (0 = default)
+}
+
+// parseTag parses an `ndr:"..."` tag value.
+func parseTag(raw string) fieldTag {
+	var t fieldTag
+	if raw == "-" {
+		t.skip = true
+		return t
+	}
+	for _, opt := range strings.Split(raw, ",") {
+		opt = strings.TrimSpace(opt)
+		switch {
+		case opt == "":
+		case opt == "unique":
+			t.ptr = ptrUnique
+		case opt == "ref":
+			t.ptr = ptrRef
+		case opt == "ptr", opt == "full":
+			t.ptr = ptrFull
+		case opt == "wstr":
+			t.wide = true
+		case opt == "str":
+			t.ascii = true
+		case opt == "conformant":
+			t.conformant = true
+		case strings.HasPrefix(opt, "size_is="):
+			t.conformant = true
+			t.sizeIs = strings.TrimPrefix(opt, "size_is=")
+		case strings.HasPrefix(opt, "align="):
+			switch strings.TrimPrefix(opt, "align=") {
+			case "1":
+				t.align = 1
+			case "2":
+				t.align = 2
+			case "4":
+				t.align = 4
+			case "8":
+				t.align = 8
+			}
+		// Scalar hints (dword/word/byte/hyper/bool) are accepted for documentation
+		// but the wire type is inferred from the Go kind, so they need no handling.
+		default:
+		}
+	}
+	return t
+}


### PR DESCRIPTION
### Summary

Adds `network/dcerpc/ndr`, a generic Network Data Representation (NDR) codec for DCE/RPC with a declarative, reflection-driven API. An RPC call is declared as a Go struct with `ndr:"..."` field tags and marshalled/unmarshalled automatically, in the spirit of impacket's `NDRCALL`/`structure = (...)`. This is a feature addition (not a bug fix), so no issue is linked.

### What this includes

- **`codec.go`** — `Encoder`/`Decoder` implementing NDR20, little-endian: stream-relative alignment (gaps before each primitive), integer/boolean primitives, conformant+varying UTF-16 and ASCII strings (terminator counted), and conformant byte arrays.
- **`marshal.go`** — reflection walker `Marshal`/`Unmarshal` driven by struct tags: `unique`/`full`/`ref` pointers with **deferred referent bodies** (the NDR deferral rule), nested structs, strings, `size_is` conformant byte arrays, fixed `[N]byte`, and a `Marshaler` interface escape hatch for custom layouts (unions, etc.).
- **`types.go`** — Windows-style aliases (`DWORD`, `WORD`, `BYTE`, `WSTR`, `STR`) and a `Call` interface with `Request`/`Response` helpers producing/consuming the RPC stub.

Example (EFSR-style):
```go
type EfsRpcFileKeyInfoEx struct {
    DwFileKeyInfoFlags ndr.DWORD `ndr:"dword"`
    Reserved           *EfsBlob  `ndr:"unique"`
    FileName           ndr.WSTR  `ndr:"unique"`
    InfoClass          ndr.DWORD `ndr:"dword"`
}
func (*EfsRpcFileKeyInfoEx) Opnum() uint16 { return 16 }

stub, _ := ndr.Request(&EfsRpcFileKeyInfoEx{ FileName: `\\host\share`, ... })
```

### How verified

- `go build ./...`, `go vet ./network/dcerpc/ndr/`, and `gofmt` are clean.
- Unit tests pass (`go test ./network/dcerpc/ndr/`), including a **golden-bytes** test for an EFSR-style struct (scalar + unique pointer-to-struct + wide-string pointer + conformant byte array) that asserts the exact on-the-wire layout and verifies deferred-referent ordering against a hand-computed reference.

### Test coverage

Added: alignment (`TestEncoder_Alignment`, `TestEncoder_Uint64Alignment`), wide strings (`TestWString_GoldenBytes`, `TestWString_RoundTrip`), conformant bytes, decoder bounds, deferred ordering (`TestMarshal_DeferredOrdering_GoldenBytes`), round-trip, NULL pointer, scalars, and the `Marshaler` escape hatch.

### Scope of change

- **Files changed:** `network/dcerpc/ndr/{codec,marshal,types}.go` + tests. New package; nothing else touched.
- **Behavioral changes outside the new package:** none.

### Notes

- Scope is NDR20, little-endian (the standard Windows data representation). NDR64, varying-only and multi-dimensional arrays, and automatic union dispatch are out of scope for this change; the `Marshaler` interface covers irregular types in the meantime.
- All field layouts cross-checked against [C706] chapter 14 and the [MS-RPCE] NDR pages, with source links in the doc comments.