### PR TITLE
[bugfix] Fix NDR BOOL alias encoding one octet instead of four (#393)

### DIFF
--- a/network/dcerpc/ndr/marshal_test.go
+++ b/network/dcerpc/ndr/marshal_test.go
@@ -175,3 +175,45 @@ func TestMarshaler_EscapeHatch(t *testing.T) {
 		t.Errorf("round trip: got %+v want %+v", out, in)
 	}
 }
+
+// TestBOOL_IsFourOctets verifies the Windows BOOL alias encodes as a 4-octet
+// integer, not a 1-octet NDR boolean (issue #393).
+func TestBOOL_IsFourOctets(t *testing.T) {
+	type withBool struct {
+		Lead uint8
+		Flag BOOL // Windows BOOL: 4 octets
+	}
+	raw, err := Marshal(&withBool{Lead: 0x01, Flag: 1})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	// uint8 then a 4-aligned 4-octet BOOL value of 1.
+	want := []byte{0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00}
+	if !bytes.Equal(raw, want) {
+		t.Errorf("BOOL encoding:\n got %x\nwant %x", raw, want)
+	}
+
+	var out withBool
+	if err := Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out.Flag != 1 || out.Lead != 1 {
+		t.Errorf("round trip: got %+v", out)
+	}
+}
+
+// TestBOOLEAN_IsOneOctet verifies the NDR boolean (Go bool) stays a single octet.
+func TestBOOLEAN_IsOneOctet(t *testing.T) {
+	type withBoolean struct {
+		A BOOLEAN
+		B uint8
+	}
+	raw, err := Marshal(&withBoolean{A: true, B: 0x7f})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	want := []byte{0x01, 0x7f}
+	if !bytes.Equal(raw, want) {
+		t.Errorf("BOOLEAN encoding:\n got %x\nwant %x", raw, want)
+	}
+}

--- a/network/dcerpc/ndr/types.go
+++ b/network/dcerpc/ndr/types.go
@@ -15,7 +15,12 @@ type (
 	DWORD   = uint32
 	DWORD64 = uint64
 	LONG    = int32
-	BOOL    = bool
+
+	// BOOL is the Windows BOOL data type, a 4-octet integer ([MS-DTYP] 2.2.3). It is
+	// distinct from the 1-octet NDR boolean: for the latter, use Go bool (or BOOLEAN).
+	BOOL = int32
+	// BOOLEAN is the 1-octet NDR boolean ([C706] section 14.2.4).
+	BOOLEAN = bool
 
 	// WSTR is a wchar_t string ([string] wide). A field of this type marshals as a
 	// conformant+varying UTF-16LE array without needing an explicit "wstr" tag.


### PR DESCRIPTION
### Linked Issue
Closes #393

### Root Cause
The `BOOL` alias was defined as Go `bool`, which the codec encodes as the one-octet NDR `boolean`. The Windows `BOOL` data type ([MS-DTYP] 2.2.3) is a four-octet integer, so the alias conflated two distinct wire types: any field declared `BOOL` was emitted one octet wide, shifting the alignment of every subsequent field.

### Fix Description
Redefine `BOOL` as `int32` so it encodes/decodes as a four-octet integer via the existing scalar path. Add a `BOOLEAN = bool` alias for the one-octet NDR boolean so both wire types are expressible and named unambiguously. No marshalling logic changes — only the alias target and a clarifying comment.

### How Verified
- `go test ./network/dcerpc/ndr/` passes.
- New `TestBOOL_IsFourOctets` asserts a `BOOL` field marshals to four octets (`01 00 00 00 | 01 00 00 00` after a leading `uint8`) and round-trips; `TestBOOLEAN_IsOneOctet` asserts the NDR boolean stays a single octet.

### Test Coverage
- **Added:** `TestBOOL_IsFourOctets`, `TestBOOLEAN_IsOneOctet` in `network/dcerpc/ndr/marshal_test.go`.

### Scope of Change
- **Files changed:** `network/dcerpc/ndr/types.go`, `network/dcerpc/ndr/marshal_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local to the `ndr` package and safe to merge: no current caller used the `BOOL` alias, so no existing behavior regresses; the change makes a previously-incorrect encoding correct.