### PR TITLE
[bugfix] Fix NDR align=N struct tag being ignored (#394)

### DIFF
--- a/network/dcerpc/ndr/marshal.go
+++ b/network/dcerpc/ndr/marshal.go
@@ -83,6 +83,9 @@ func marshalStruct(e *Encoder, rv reflect.Value) error {
 // marshalFieldInline writes a field's inline representation, enqueueing the referent
 // body for pointers.
 func marshalFieldInline(e *Encoder, fv reflect.Value, tag fieldTag, deferred *[]func() error) error {
+	if tag.align > 0 {
+		e.Align(tag.align)
+	}
 	if m, ok := asMarshaler(fv); ok {
 		e.Align(m.AlignmentNDR())
 		return m.MarshalNDR(e)
@@ -220,6 +223,9 @@ func unmarshalStruct(d *Decoder, rv reflect.Value) error {
 }
 
 func unmarshalFieldInline(d *Decoder, fv reflect.Value, tag fieldTag, deferred *[]func() error) error {
+	if tag.align > 0 {
+		d.Align(tag.align)
+	}
 	if m, ok := asMarshalerAddr(fv); ok {
 		d.Align(m.AlignmentNDR())
 		return m.UnmarshalNDR(d)

--- a/network/dcerpc/ndr/marshal_test.go
+++ b/network/dcerpc/ndr/marshal_test.go
@@ -217,3 +217,28 @@ func TestBOOLEAN_IsOneOctet(t *testing.T) {
 		t.Errorf("BOOLEAN encoding:\n got %x\nwant %x", raw, want)
 	}
 }
+
+// TestAlignTag_Applied verifies the align=N struct tag inserts padding (issue #394).
+func TestAlignTag_Applied(t *testing.T) {
+	type withAlign struct {
+		A uint8
+		B uint32 `ndr:"align=8"`
+	}
+	raw, err := Marshal(&withAlign{A: 1, B: 2})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	// A at offset 0; align=8 pads to offset 8; B (4 octets) at offset 8.
+	want := []byte{0x01, 0, 0, 0, 0, 0, 0, 0, 0x02, 0, 0, 0}
+	if !bytes.Equal(raw, want) {
+		t.Errorf("align=8:\n got %x\nwant %x", raw, want)
+	}
+
+	var out withAlign
+	if err := Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out != (withAlign{A: 1, B: 2}) {
+		t.Errorf("round trip: got %+v", out)
+	}
+}


### PR DESCRIPTION
### Linked Issue
Closes #394

### Root Cause
`parseTag` recorded the `align=N` option into `fieldTag.align`, but the marshal and unmarshal walkers never read that field, so the explicit alignment override was silently discarded and only the default per-type alignment applied.

### Fix Description
Honor `fieldTag.align` at the start of `marshalFieldInline` and `unmarshalFieldInline`: when set, align the stream to that boundary before the field is encoded/decoded. It is applied before the per-type alignment, so a smaller natural alignment becomes a no-op and a larger explicit alignment takes effect. Placing it ahead of the `Marshaler` escape hatch means custom types also honor an explicit override.

### How Verified
- `go vet` and `go test ./network/dcerpc/ndr/` pass.
- New `TestAlignTag_Applied` marshals `struct{ A uint8; B uint32 \`ndr:"align=8"\` }` and asserts `B` lands at offset 8 (`01` + seven pad octets + `02 00 00 00`) and round-trips, where the default would place it at offset 4.

### Test Coverage
- **Added:** `TestAlignTag_Applied` in `network/dcerpc/ndr/marshal_test.go`.

### Scope of Change
- **Files changed:** `network/dcerpc/ndr/marshal.go`, `network/dcerpc/ndr/marshal_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local to the `ndr` package; only fields that carry an `align=N` tag change behavior, and no current caller uses one, so nothing existing regresses.