### PR TITLE
[bugfix] Fix NDR embedded conformant arrays not being hoisted (#395)

### DIFF
--- a/network/dcerpc/ndr/marshal.go
+++ b/network/dcerpc/ndr/marshal.go
@@ -56,8 +56,17 @@ func structValue(rv reflect.Value) (reflect.Value, error) {
 
 // marshalStruct marshals a struct as an NDR construction: all inline field
 // representations first, then the deferred referent bodies in field order.
+//
+// If the struct embeds a conformant array directly (a non-pointer byte slice), its
+// maximum_count is hoisted to the start of the struct and only the elements are
+// emitted in place, per [MS-RPCE] "Structure Containing a Conformant Varying Array":
+// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/7bae54af-8b6a-4672-a6a3-6bcdf131730a
 func marshalStruct(e *Encoder, rv reflect.Value) error {
 	rt := rv.Type()
+	confIdx := embeddedConformantIndex(rt, rv)
+	if confIdx >= 0 {
+		e.WriteUint32(uint32(rv.Field(confIdx).Len())) // hoisted maximum_count
+	}
 	var deferred []func() error
 	for i := 0; i < rt.NumField(); i++ {
 		f := rt.Field(i)
@@ -66,6 +75,11 @@ func marshalStruct(e *Encoder, rv reflect.Value) error {
 		}
 		tag := parseTag(f.Tag.Get("ndr"))
 		if tag.skip {
+			continue
+		}
+		if i == confIdx {
+			// The maximum_count was hoisted above; emit only the elements in place.
+			e.WriteBytes(rv.Field(i).Bytes())
 			continue
 		}
 		if err := marshalFieldInline(e, rv.Field(i), tag, &deferred); err != nil {
@@ -200,6 +214,15 @@ func marshalScalar(e *Encoder, fv reflect.Value) error {
 
 func unmarshalStruct(d *Decoder, rv reflect.Value) error {
 	rt := rv.Type()
+	confIdx := embeddedConformantIndex(rt, rv)
+	var confCount uint32
+	if confIdx >= 0 {
+		c, err := d.ReadUint32() // hoisted maximum_count
+		if err != nil {
+			return err
+		}
+		confCount = c
+	}
 	var deferred []func() error
 	for i := 0; i < rt.NumField(); i++ {
 		f := rt.Field(i)
@@ -208,6 +231,16 @@ func unmarshalStruct(d *Decoder, rv reflect.Value) error {
 		}
 		tag := parseTag(f.Tag.Get("ndr"))
 		if tag.skip {
+			continue
+		}
+		if i == confIdx {
+			b, err := d.ReadBytes(int(confCount))
+			if err != nil {
+				return err
+			}
+			out := make([]byte, len(b))
+			copy(out, b)
+			rv.Field(i).SetBytes(out)
 			continue
 		}
 		if err := unmarshalFieldInline(d, rv.Field(i), tag, &deferred); err != nil {
@@ -376,6 +409,36 @@ func unmarshalScalar(d *Decoder, fv reflect.Value) error {
 }
 
 // ---- helpers --------------------------------------------------------------------
+
+// embeddedConformantIndex returns the field index of an embedded (non-pointer)
+// conformant array member, or -1 if there is none. NDR permits at most one such
+// member per structure (the last one); if several match, the last is used.
+func embeddedConformantIndex(rt reflect.Type, rv reflect.Value) int {
+	idx := -1
+	for i := 0; i < rt.NumField(); i++ {
+		f := rt.Field(i)
+		if f.PkgPath != "" {
+			continue
+		}
+		tag := parseTag(f.Tag.Get("ndr"))
+		if tag.skip {
+			continue
+		}
+		if isEmbeddedConformantArray(rv.Field(i), tag) {
+			idx = i
+		}
+	}
+	return idx
+}
+
+// isEmbeddedConformantArray reports whether fv is an inline (non-pointer) conformant
+// byte array, i.e. a byte slice that is not itself behind a pointer. A byte slice
+// behind a pointer is a referent, not an embedded array, and is not hoisted.
+func isEmbeddedConformantArray(fv reflect.Value, tag fieldTag) bool {
+	return fv.Kind() == reflect.Slice &&
+		fv.Type().Elem().Kind() == reflect.Uint8 &&
+		!isPointerLike(fv, tag)
+}
 
 func isPointerLike(fv reflect.Value, tag fieldTag) bool {
 	if fv.Kind() == reflect.Pointer {

--- a/network/dcerpc/ndr/marshal_test.go
+++ b/network/dcerpc/ndr/marshal_test.go
@@ -242,3 +242,33 @@ func TestAlignTag_Applied(t *testing.T) {
 		t.Errorf("round trip: got %+v", out)
 	}
 }
+
+// TestEmbeddedConformantArray_Hoisted verifies that a conformant array embedded
+// directly in a struct has its maximum_count hoisted to the start (issue #395).
+func TestEmbeddedConformantArray_Hoisted(t *testing.T) {
+	type rec struct {
+		N    uint32
+		Data []byte `ndr:"conformant"`
+	}
+	in := &rec{N: 0xAABBCCDD, Data: []byte{0x01, 0x02, 0x03}}
+	raw, err := Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	want := []byte{
+		0x03, 0x00, 0x00, 0x00, // hoisted maximum_count
+		0xDD, 0xCC, 0xBB, 0xAA, // N
+		0x01, 0x02, 0x03, // elements, in place at the end
+	}
+	if !bytes.Equal(raw, want) {
+		t.Errorf("hoisted conformant array:\n got %x\nwant %x", raw, want)
+	}
+
+	var out rec
+	if err := Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out.N != in.N || !bytes.Equal(out.Data, in.Data) {
+		t.Errorf("round trip: got %+v want %+v", out, in)
+	}
+}


### PR DESCRIPTION
### Linked Issue
Closes #395

### Root Cause
The struct walker marshalled every field strictly in declaration order. For a conformant array embedded directly in a structure, NDR requires the array's `maximum_count` to be hoisted to the start of the structure (ahead of the other members), with only the elements appearing in place. Because the walker emitted the count together with the elements at the field position (via `writeConformantBytes`), a structure embedding a conformant array produced an incorrect byte layout.

### Fix Description
`marshalStruct`/`unmarshalStruct` now detect an embedded (non-pointer) conformant byte-slice member and hoist its `maximum_count` to the start of the structure, emitting/consuming only the elements in place. Detection (`isEmbeddedConformantArray`) excludes byte slices that sit behind a pointer (`unique`/`ptr`/`ref`): those are referents, where the count legitimately precedes the elements and no hoisting applies — so the existing pointer-based conformant path is unchanged. NDR permits at most one such member (the last); if several match, the last is used.

### How Verified
- `go vet` and `go test ./network/dcerpc/ndr/` pass, including the pre-existing `TestMarshal_DeferredOrdering_GoldenBytes` (pointer-behind conformant array) which is unaffected.
- New `TestEmbeddedConformantArray_Hoisted` marshals `struct{ N uint32; Data []byte \`ndr:"conformant"\` }` and asserts the layout is `maximum_count` (hoisted) then `N` then the elements, and that it round-trips.

### Test Coverage
- **Added:** `TestEmbeddedConformantArray_Hoisted` in `network/dcerpc/ndr/marshal_test.go`.

### Scope of Change
- **Files changed:** `network/dcerpc/ndr/marshal.go`, `network/dcerpc/ndr/marshal_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none — pointer-behind conformant arrays and all other types encode exactly as before.

### Risk and Rollout
Behavior changes only for structures that embed a non-pointer conformant byte slice (none in the current codebase), making a previously-incorrect layout correct; safe to merge.