### PR TITLE
[enhancement] Support NDR conformant arrays of arbitrary element types (#397)

### DIFF
--- a/network/dcerpc/ndr/array_elements_test.go
+++ b/network/dcerpc/ndr/array_elements_test.go
@@ -1,0 +1,98 @@
+package ndr
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+)
+
+// TestEmbeddedConformantArray_Uint32 verifies a hoisted conformant array of a
+// non-byte scalar element type (issue #397).
+func TestEmbeddedConformantArray_Uint32(t *testing.T) {
+	type rec struct {
+		N    uint32
+		Vals []uint32 `ndr:"conformant"`
+	}
+	in := &rec{N: 0x11, Vals: []uint32{0xAA, 0xBB}}
+	raw, err := Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	want := []byte{
+		0x02, 0, 0, 0, // hoisted maximum_count
+		0x11, 0, 0, 0, // N
+		0xAA, 0, 0, 0, // Vals[0]
+		0xBB, 0, 0, 0, // Vals[1]
+	}
+	if !bytes.Equal(raw, want) {
+		t.Errorf("uint32 array:\n got %x\nwant %x", raw, want)
+	}
+	var out rec
+	if err := Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out.N != in.N || !reflect.DeepEqual(out.Vals, in.Vals) {
+		t.Errorf("round trip: got %+v want %+v", out, in)
+	}
+}
+
+// TestPointerConformantArray_Uint32 verifies a unique pointer to a conformant array
+// of uint32 (no hoisting; count travels with the referent).
+func TestPointerConformantArray_Uint32(t *testing.T) {
+	type rec struct {
+		P []uint32 `ndr:"unique,conformant"`
+	}
+	in := &rec{P: []uint32{0x01, 0x02}}
+	raw, err := Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	want := []byte{
+		0x00, 0x00, 0x02, 0x00, // referent id
+		0x02, 0, 0, 0, // maximum_count (in referent)
+		0x01, 0, 0, 0, // P[0]
+		0x02, 0, 0, 0, // P[1]
+	}
+	if !bytes.Equal(raw, want) {
+		t.Errorf("pointer uint32 array:\n got %x\nwant %x", raw, want)
+	}
+	var out rec
+	if err := Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if !reflect.DeepEqual(out.P, in.P) {
+		t.Errorf("round trip: got %+v want %+v", out.P, in.P)
+	}
+}
+
+// TestConformantArray_StructElements verifies a conformant array whose elements are
+// structs.
+func TestConformantArray_StructElements(t *testing.T) {
+	type pair struct {
+		A uint16
+		B uint16
+	}
+	type rec struct {
+		Items []pair `ndr:"conformant"`
+	}
+	in := &rec{Items: []pair{{1, 2}, {3, 4}}}
+	raw, err := Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	want := []byte{
+		0x02, 0, 0, 0, // hoisted maximum_count
+		0x01, 0x00, 0x02, 0x00, // pair{1,2}
+		0x03, 0x00, 0x04, 0x00, // pair{3,4}
+	}
+	if !bytes.Equal(raw, want) {
+		t.Errorf("struct array:\n got %x\nwant %x", raw, want)
+	}
+	var out rec
+	if err := Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if !reflect.DeepEqual(out.Items, in.Items) {
+		t.Errorf("round trip: got %+v want %+v", out.Items, in.Items)
+	}
+}

--- a/network/dcerpc/ndr/marshal.go
+++ b/network/dcerpc/ndr/marshal.go
@@ -79,7 +79,9 @@ func marshalStruct(e *Encoder, rv reflect.Value) error {
 		}
 		if i == confIdx {
 			// The maximum_count was hoisted above; emit only the elements in place.
-			e.WriteBytes(rv.Field(i).Bytes())
+			if err := marshalElements(e, rv.Field(i)); err != nil {
+				return fmt.Errorf("ndr: field %s: %w", f.Name, err)
+			}
 			continue
 		}
 		if err := marshalFieldInline(e, rv.Field(i), tag, &deferred); err != nil {
@@ -161,11 +163,7 @@ func marshalInlineValue(e *Encoder, fv reflect.Value, tag fieldTag, deferred *[]
 	case reflect.Struct:
 		return marshalStruct(e, fv)
 	case reflect.Slice:
-		if fv.Type().Elem().Kind() == reflect.Uint8 {
-			e.writeConformantBytes(fv.Bytes())
-			return nil
-		}
-		return fmt.Errorf("ndr: unsupported slice element %s", fv.Type().Elem().Kind())
+		return marshalConformantArray(e, fv)
 	case reflect.Array:
 		if fv.Type().Elem().Kind() == reflect.Uint8 {
 			b := make([]byte, fv.Len())
@@ -234,13 +232,9 @@ func unmarshalStruct(d *Decoder, rv reflect.Value) error {
 			continue
 		}
 		if i == confIdx {
-			b, err := d.ReadBytes(int(confCount))
-			if err != nil {
-				return err
+			if err := unmarshalElements(d, rv.Field(i), int(confCount)); err != nil {
+				return fmt.Errorf("ndr: field %s: %w", f.Name, err)
 			}
-			out := make([]byte, len(b))
-			copy(out, b)
-			rv.Field(i).SetBytes(out)
 			continue
 		}
 		if err := unmarshalFieldInline(d, rv.Field(i), tag, &deferred); err != nil {
@@ -322,15 +316,7 @@ func unmarshalInlineValue(d *Decoder, fv reflect.Value, tag fieldTag) error {
 	case reflect.Struct:
 		return unmarshalStruct(d, fv)
 	case reflect.Slice:
-		if fv.Type().Elem().Kind() == reflect.Uint8 {
-			b, err := d.readConformantBytes()
-			if err != nil {
-				return err
-			}
-			fv.SetBytes(b)
-			return nil
-		}
-		return fmt.Errorf("ndr: unsupported slice element %s", fv.Type().Elem().Kind())
+		return unmarshalConformantArray(d, fv)
 	case reflect.Array:
 		if fv.Type().Elem().Kind() == reflect.Uint8 {
 			b, err := d.ReadBytes(fv.Len())
@@ -432,12 +418,68 @@ func embeddedConformantIndex(rt reflect.Type, rv reflect.Value) int {
 }
 
 // isEmbeddedConformantArray reports whether fv is an inline (non-pointer) conformant
-// byte array, i.e. a byte slice that is not itself behind a pointer. A byte slice
-// behind a pointer is a referent, not an embedded array, and is not hoisted.
+// array, i.e. a slice that is not itself behind a pointer. A slice behind a pointer is
+// a referent, not an embedded array, and is not hoisted.
 func isEmbeddedConformantArray(fv reflect.Value, tag fieldTag) bool {
-	return fv.Kind() == reflect.Slice &&
-		fv.Type().Elem().Kind() == reflect.Uint8 &&
-		!isPointerLike(fv, tag)
+	return fv.Kind() == reflect.Slice && !isPointerLike(fv, tag)
+}
+
+// marshalConformantArray writes a conformant array: a maximum_count followed by the
+// elements, per [MS-RPCE] Conformant Arrays:
+// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/140b01a3-979b-43af-b1e3-28f248db8f03
+func marshalConformantArray(e *Encoder, slice reflect.Value) error {
+	e.WriteUint32(uint32(slice.Len()))
+	return marshalElements(e, slice)
+}
+
+// unmarshalConformantArray reads a maximum_count-prefixed array into slice.
+func unmarshalConformantArray(d *Decoder, slice reflect.Value) error {
+	n, err := d.ReadUint32()
+	if err != nil {
+		return err
+	}
+	return unmarshalElements(d, slice, int(n))
+}
+
+// marshalElements writes the elements of a slice with no count prefix. Each element
+// is marshalled via the inline-value path, so any supported element type (scalars,
+// structs, Marshaler types) is handled with its natural alignment.
+func marshalElements(e *Encoder, slice reflect.Value) error {
+	if slice.Type().Elem().Kind() == reflect.Uint8 {
+		e.WriteBytes(slice.Bytes()) // fast path for byte arrays
+		return nil
+	}
+	for i := 0; i < slice.Len(); i++ {
+		if err := marshalInlineValue(e, slice.Index(i), fieldTag{}, nil); err != nil {
+			return fmt.Errorf("element %d: %w", i, err)
+		}
+	}
+	return nil
+}
+
+// unmarshalElements reads n elements into slice (allocating a fresh backing array).
+func unmarshalElements(d *Decoder, slice reflect.Value, n int) error {
+	if n < 0 {
+		return fmt.Errorf("ndr: negative element count %d", n)
+	}
+	if slice.Type().Elem().Kind() == reflect.Uint8 {
+		b, err := d.ReadBytes(n)
+		if err != nil {
+			return err
+		}
+		out := make([]byte, n)
+		copy(out, b)
+		slice.SetBytes(out)
+		return nil
+	}
+	out := reflect.MakeSlice(slice.Type(), n, n)
+	for i := 0; i < n; i++ {
+		if err := unmarshalInlineValue(d, out.Index(i), fieldTag{}); err != nil {
+			return fmt.Errorf("element %d: %w", i, err)
+		}
+	}
+	slice.Set(out)
+	return nil
 }
 
 func isPointerLike(fv reflect.Value, tag fieldTag) bool {


### PR DESCRIPTION
### Linked Issue
Closes #397

### Root Cause
The reflection walker handled conformant arrays only when the element kind was `Uint8`; slices of any other element type were rejected. This blocked interfaces whose IDL uses `[size_is]` arrays of `DWORD`, `WORD`, or structures.

### Fix Description
Generalize array handling to any supported element type. `marshalConformantArray`/`unmarshalConformantArray` write/read a `maximum_count` followed by the elements, and `marshalElements`/`unmarshalElements` encode each element through the inline-value path (with a byte-slice fast path). The embedded-array hoisting from #395 now applies to any non-pointer slice, not just `[]byte`. Element alignment falls out of the aligned primitive writers.

Scope: elements that are scalars, structs, or `Marshaler` types. Pointers inside array elements and multi-dimensional arrays remain out of scope.

### How Verified
- `go vet` and `go test ./network/dcerpc/ndr/` pass, including pre-existing byte-array and hoisting tests (unchanged for `[]byte`).
- New tests cover an embedded `[]uint32`, a unique pointer to `[]uint32`, and a conformant array of struct elements, asserting exact bytes and round-trip.

### Test Coverage
- **Added:** `TestEmbeddedConformantArray_Uint32`, `TestPointerConformantArray_Uint32`, `TestConformantArray_StructElements` in `network/dcerpc/ndr/array_elements_test.go`.

### Scope of Change
- **Files changed:** `network/dcerpc/ndr/marshal.go`, `network/dcerpc/ndr/array_elements_test.go`
- **Behavioral changes outside the bug fix:** none

### Notes
Stacked on #404; merge after #404. First of the NDR20-completion series (#397 -> #396 -> #401 -> #398 -> #399). Base retargeted to `bugfix-ndr-conformant-hoisting` for a clean review diff.