### PR TITLE
[enhancement] Support NDR conformant-varying arrays (#396)

### DIFF
--- a/network/dcerpc/ndr/marshal.go
+++ b/network/dcerpc/ndr/marshal.go
@@ -78,7 +78,12 @@ func marshalStruct(e *Encoder, rv reflect.Value) error {
 			continue
 		}
 		if i == confIdx {
-			// The maximum_count was hoisted above; emit only the elements in place.
+			// The maximum_count was hoisted above. For a conformant-varying array the
+			// offset and actual_count stay here, ahead of the elements.
+			if tag.varying {
+				e.WriteUint32(0)                         // offset
+				e.WriteUint32(uint32(rv.Field(i).Len())) // actual_count
+			}
 			if err := marshalElements(e, rv.Field(i)); err != nil {
 				return fmt.Errorf("ndr: field %s: %w", f.Name, err)
 			}
@@ -163,6 +168,9 @@ func marshalInlineValue(e *Encoder, fv reflect.Value, tag fieldTag, deferred *[]
 	case reflect.Struct:
 		return marshalStruct(e, fv)
 	case reflect.Slice:
+		if tag.varying {
+			return marshalConformantVaryingArray(e, fv)
+		}
 		return marshalConformantArray(e, fv)
 	case reflect.Array:
 		if fv.Type().Elem().Kind() == reflect.Uint8 {
@@ -232,7 +240,18 @@ func unmarshalStruct(d *Decoder, rv reflect.Value) error {
 			continue
 		}
 		if i == confIdx {
-			if err := unmarshalElements(d, rv.Field(i), int(confCount)); err != nil {
+			n := int(confCount)
+			if tag.varying {
+				if _, err := d.ReadUint32(); err != nil { // offset
+					return fmt.Errorf("ndr: field %s: %w", f.Name, err)
+				}
+				actual, err := d.ReadUint32() // actual_count
+				if err != nil {
+					return fmt.Errorf("ndr: field %s: %w", f.Name, err)
+				}
+				n = int(actual)
+			}
+			if err := unmarshalElements(d, rv.Field(i), n); err != nil {
 				return fmt.Errorf("ndr: field %s: %w", f.Name, err)
 			}
 			continue
@@ -316,6 +335,9 @@ func unmarshalInlineValue(d *Decoder, fv reflect.Value, tag fieldTag) error {
 	case reflect.Struct:
 		return unmarshalStruct(d, fv)
 	case reflect.Slice:
+		if tag.varying {
+			return unmarshalConformantVaryingArray(d, fv)
+		}
 		return unmarshalConformantArray(d, fv)
 	case reflect.Array:
 		if fv.Type().Elem().Kind() == reflect.Uint8 {
@@ -439,6 +461,34 @@ func unmarshalConformantArray(d *Decoder, slice reflect.Value) error {
 		return err
 	}
 	return unmarshalElements(d, slice, int(n))
+}
+
+// marshalConformantVaryingArray writes a conformant-varying array: maximum_count,
+// offset, actual_count, then the elements, per [MS-RPCE] Conformant Varying Arrays:
+// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/3acb31b0-b873-4aaf-8503-9727ec40fbec
+// The full slice is transmitted (offset 0, actual_count == maximum_count == len).
+func marshalConformantVaryingArray(e *Encoder, slice reflect.Value) error {
+	n := uint32(slice.Len())
+	e.WriteUint32(n) // maximum_count
+	e.WriteUint32(0) // offset
+	e.WriteUint32(n) // actual_count
+	return marshalElements(e, slice)
+}
+
+// unmarshalConformantVaryingArray reads a conformant-varying array, using the
+// actual_count to size the result.
+func unmarshalConformantVaryingArray(d *Decoder, slice reflect.Value) error {
+	if _, err := d.ReadUint32(); err != nil { // maximum_count
+		return err
+	}
+	if _, err := d.ReadUint32(); err != nil { // offset
+		return err
+	}
+	actual, err := d.ReadUint32() // actual_count
+	if err != nil {
+		return err
+	}
+	return unmarshalElements(d, slice, int(actual))
 }
 
 // marshalElements writes the elements of a slice with no count prefix. Each element

--- a/network/dcerpc/ndr/types.go
+++ b/network/dcerpc/ndr/types.go
@@ -71,7 +71,9 @@ type fieldTag struct {
 	wide       bool   // [string] wide (UTF-16)
 	ascii      bool   // [string] ASCII
 	conformant bool   // conformant array (size_is)
-	sizeIs     string // sibling field naming the element count
+	varying    bool   // conformant-varying array (offset + actual_count framing)
+	sizeIs     string // sibling field naming the maximum element count
+	lengthIs   string // sibling field naming the actual element count
 	align      int    // explicit alignment override (0 = default)
 }
 
@@ -98,9 +100,15 @@ func parseTag(raw string) fieldTag {
 			t.ascii = true
 		case opt == "conformant":
 			t.conformant = true
+		case opt == "varying":
+			t.varying = true
 		case strings.HasPrefix(opt, "size_is="):
 			t.conformant = true
 			t.sizeIs = strings.TrimPrefix(opt, "size_is=")
+		case strings.HasPrefix(opt, "length_is="):
+			t.conformant = true
+			t.varying = true
+			t.lengthIs = strings.TrimPrefix(opt, "length_is=")
 		case strings.HasPrefix(opt, "align="):
 			switch strings.TrimPrefix(opt, "align=") {
 			case "1":

--- a/network/dcerpc/ndr/varying_arrays_test.go
+++ b/network/dcerpc/ndr/varying_arrays_test.go
@@ -1,0 +1,69 @@
+package ndr
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+)
+
+// TestPointerConformantVaryingArray verifies a unique pointer to a conformant-varying
+// array carries maximum_count + offset + actual_count before the elements (issue #396).
+func TestPointerConformantVaryingArray(t *testing.T) {
+	type rec struct {
+		P []uint32 `ndr:"unique,varying"`
+	}
+	in := &rec{P: []uint32{0xAA, 0xBB}}
+	raw, err := Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	want := []byte{
+		0x00, 0x00, 0x02, 0x00, // referent id
+		0x02, 0, 0, 0, // maximum_count
+		0x00, 0, 0, 0, // offset
+		0x02, 0, 0, 0, // actual_count
+		0xAA, 0, 0, 0, // P[0]
+		0xBB, 0, 0, 0, // P[1]
+	}
+	if !bytes.Equal(raw, want) {
+		t.Errorf("conformant-varying array:\n got %x\nwant %x", raw, want)
+	}
+	var out rec
+	if err := Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if !reflect.DeepEqual(out.P, in.P) {
+		t.Errorf("round trip: got %v want %v", out.P, in.P)
+	}
+}
+
+// TestEmbeddedConformantVaryingArray verifies the hoisted max_count plus in-place
+// offset/actual_count framing for an embedded conformant-varying array.
+func TestEmbeddedConformantVaryingArray(t *testing.T) {
+	type rec struct {
+		N    uint32
+		Data []uint16 `ndr:"varying"`
+	}
+	in := &rec{N: 0x09, Data: []uint16{0x01, 0x02, 0x03}}
+	raw, err := Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	want := []byte{
+		0x03, 0, 0, 0, // hoisted maximum_count
+		0x09, 0, 0, 0, // N
+		0x00, 0, 0, 0, // offset
+		0x03, 0, 0, 0, // actual_count
+		0x01, 0x00, 0x02, 0x00, 0x03, 0x00, // elements (uint16)
+	}
+	if !bytes.Equal(raw, want) {
+		t.Errorf("embedded conformant-varying:\n got %x\nwant %x", raw, want)
+	}
+	var out rec
+	if err := Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out.N != in.N || !reflect.DeepEqual(out.Data, in.Data) {
+		t.Errorf("round trip: got %+v want %+v", out, in)
+	}
+}


### PR DESCRIPTION
### Linked Issue
Closes #396

### Root Cause
Arrays were always encoded as conformant-only (a single `maximum_count`). Conformant-varying arrays — which prefix the elements with `maximum_count`, `offset`, and `actual_count` — could not be expressed, so `[out]` parameters bounded by both `size_is` and `length_is` (common in enumerations) were unrepresentable.

### Fix Description
Add a `varying` tag option (also implied by `length_is=`) that selects conformant-varying framing. `marshalConformantVaryingArray`/`unmarshalConformantVaryingArray` write/read `maximum_count` + `offset` + `actual_count` before the elements; the actual_count sizes the decoded slice. For an embedded (hoisted) array, the `maximum_count` is hoisted to the struct start (as for conformant arrays) while `offset`/`actual_count` stay in place ahead of the elements. The full slice is transmitted (offset 0, actual_count == maximum_count == len).

### How Verified
- `go vet` and `go test ./network/dcerpc/ndr/` pass (existing conformant/array tests unchanged).
- New tests cover a unique pointer to a conformant-varying `[]uint32` (asserting the max/offset/actual framing) and an embedded conformant-varying `[]uint16` (hoisted max_count + in-place offset/actual), both with round-trip.

### Test Coverage
- **Added:** `TestPointerConformantVaryingArray`, `TestEmbeddedConformantVaryingArray` in `network/dcerpc/ndr/varying_arrays_test.go`.

### Scope of Change
- **Files changed:** `network/dcerpc/ndr/types.go`, `network/dcerpc/ndr/marshal.go`, `network/dcerpc/ndr/varying_arrays_test.go`
- **Behavioral changes outside the bug fix:** none (arrays without `varying`/`length_is` are unchanged)

### Notes
Stacked on #397 (NDR20-completion series #397 -> #396 -> #401 -> #398 -> #399). Base retargeted to `feature-ndr-array-elements` for a clean diff; merge after #397.