### PR TITLE
[enhancement] Derive NDR size_is/length_is counts from arrays (#401)

### DIFF
--- a/network/dcerpc/ndr/marshal.go
+++ b/network/dcerpc/ndr/marshal.go
@@ -67,6 +67,10 @@ func marshalStruct(e *Encoder, rv reflect.Value) error {
 	if confIdx >= 0 {
 		e.WriteUint32(uint32(rv.Field(confIdx).Len())) // hoisted maximum_count
 	}
+	// A field named by another field's size_is/length_is is the array's count; its
+	// value is derived from the array length so the count and the elements cannot
+	// disagree and the caller need not set it explicitly.
+	counts := countTargets(rt, rv)
 	var deferred []func() error
 	for i := 0; i < rt.NumField(); i++ {
 		f := rt.Field(i)
@@ -75,6 +79,17 @@ func marshalStruct(e *Encoder, rv reflect.Value) error {
 		}
 		tag := parseTag(f.Tag.Get("ndr"))
 		if tag.skip {
+			continue
+		}
+		if c, ok := counts[f.Name]; ok && isUintKind(rv.Field(i).Kind()) {
+			if tag.align > 0 {
+				e.Align(tag.align)
+			}
+			tmp := reflect.New(f.Type).Elem()
+			tmp.SetUint(c)
+			if err := marshalScalar(e, tmp); err != nil {
+				return fmt.Errorf("ndr: field %s: %w", f.Name, err)
+			}
 			continue
 		}
 		if i == confIdx {
@@ -437,6 +452,41 @@ func embeddedConformantIndex(rt reflect.Type, rv reflect.Value) int {
 		}
 	}
 	return idx
+}
+
+// countTargets maps the name of each field that is named by another field's
+// size_is/length_is to the element count of that array. The count is derived from the
+// array's length so the transmitted count field always matches the elements ([C706]
+// section 14.3.3.1; [MS-RPCE] Conformant Arrays).
+func countTargets(rt reflect.Type, rv reflect.Value) map[string]uint64 {
+	m := map[string]uint64{}
+	for j := 0; j < rt.NumField(); j++ {
+		f := rt.Field(j)
+		if f.PkgPath != "" {
+			continue
+		}
+		tag := parseTag(f.Tag.Get("ndr"))
+		if tag.skip || rv.Field(j).Kind() != reflect.Slice {
+			continue
+		}
+		n := uint64(rv.Field(j).Len())
+		if tag.sizeIs != "" {
+			m[tag.sizeIs] = n
+		}
+		if tag.lengthIs != "" {
+			m[tag.lengthIs] = n
+		}
+	}
+	return m
+}
+
+func isUintKind(k reflect.Kind) bool {
+	switch k {
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return true
+	default:
+		return false
+	}
 }
 
 // isEmbeddedConformantArray reports whether fv is an inline (non-pointer) conformant

--- a/network/dcerpc/ndr/sizeis_test.go
+++ b/network/dcerpc/ndr/sizeis_test.go
@@ -1,0 +1,38 @@
+package ndr
+
+import (
+	"bytes"
+	"testing"
+)
+
+// TestSizeIs_CountDerivedFromArray verifies a size_is target field is written from
+// the array length, so the caller need not set it and it cannot disagree (issue #401).
+func TestSizeIs_CountDerivedFromArray(t *testing.T) {
+	type blob struct {
+		CbData uint32 `ndr:"dword"` // size_is target for BData
+		BData  []byte `ndr:"unique,conformant,size_is=CbData"`
+	}
+	// CbData deliberately left 0; it must be derived as len(BData)=3.
+	in := &blob{BData: []byte{0xaa, 0xbb, 0xcc}}
+	raw, err := Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	want := []byte{
+		0x03, 0x00, 0x00, 0x00, // CbData, derived from len(BData)
+		0x00, 0x00, 0x02, 0x00, // BData referent id
+		0x03, 0x00, 0x00, 0x00, // BData maximum_count
+		0xaa, 0xbb, 0xcc, // BData elements
+	}
+	if !bytes.Equal(raw, want) {
+		t.Errorf("size_is derivation:\n got %x\nwant %x", raw, want)
+	}
+
+	var out blob
+	if err := Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out.CbData != 3 || !bytes.Equal(out.BData, in.BData) {
+		t.Errorf("round trip: CbData=%d BData=%x", out.CbData, out.BData)
+	}
+}

--- a/network/dcerpc/ndr/types.go
+++ b/network/dcerpc/ndr/types.go
@@ -24,9 +24,15 @@ type (
 
 	// WSTR is a wchar_t string ([string] wide). A field of this type marshals as a
 	// conformant+varying UTF-16LE array without needing an explicit "wstr" tag.
+	//
+	// Pointer semantics are explicit and controlled by the tag: a bare WSTR/STR/string
+	// field is encoded inline with no referent id (matching a top-level [ref] string
+	// parameter), while one tagged "unique" or "ptr" is encoded as a referent id with
+	// its body deferred (matching an embedded [unique,string] wchar_t*). Embedded
+	// strings in MS-RPC structures are almost always [unique]; tag them accordingly.
 	WSTR string
 	// STR is a char string ([string]). A field of this type marshals as a
-	// conformant+varying ASCII array.
+	// conformant+varying ASCII array. See WSTR for pointer semantics.
 	STR string
 )
 


### PR DESCRIPTION
### Linked Issue
Closes #401

### Root Cause
A `size_is`/`length_is` tag was parsed but never resolved against the named sibling field: the array's own `maximum_count` came from the slice length, while a separately-transmitted count field (e.g. `cbData`) carried whatever the caller happened to set. The two could silently disagree, and string pointer semantics (inline vs referent) were undocumented.

### Fix Description
On marshal, a field named by another field's `size_is`/`length_is` now has its value derived from that array's length (`countTargets`), so the transmitted count always matches the elements and the caller need not set it. Decode is unchanged: the count field reads its consistent on-wire value and the array is sized from its own conformance. The `WSTR`/`STR` doc comments now state the pointer rule explicitly (bare = inline/[ref]; `unique`/`ptr` = deferred referent).

### How Verified
- `go vet` and `go test ./network/dcerpc/ndr/` pass (existing EFS_RPC_BLOB golden/round-trip tests unchanged, since there the count already equalled the length).
- New `TestSizeIs_CountDerivedFromArray` leaves the count field zero and asserts it is emitted as the array length and round-trips.

### Test Coverage
- **Added:** `TestSizeIs_CountDerivedFromArray` in `network/dcerpc/ndr/sizeis_test.go`.

### Scope of Change
- **Files changed:** `network/dcerpc/ndr/marshal.go`, `network/dcerpc/ndr/types.go`, `network/dcerpc/ndr/sizeis_test.go`
- **Behavioral changes outside the bug fix:** none (only fields named as count targets change; previously callers had to set them to match)

### Notes
Stacked on #396 (series #397 -> #396 -> #401 -> #398 -> #399). Base retargeted to `feature-ndr-varying-arrays`; merge after #396.