### PR TITLE
[enhancement] Support NDR embedded [ref] pointers (#398)

### DIFF
--- a/network/dcerpc/ndr/marshal.go
+++ b/network/dcerpc/ndr/marshal.go
@@ -67,6 +67,10 @@ func marshalStruct(e *Encoder, rv reflect.Value) error {
 	if confIdx >= 0 {
 		e.WriteUint32(uint32(rv.Field(confIdx).Len())) // hoisted maximum_count
 	}
+	// A field named by another field's size_is/length_is is the array's count; its
+	// value is derived from the array length so the count and the elements cannot
+	// disagree and the caller need not set it explicitly.
+	counts := countTargets(rt, rv)
 	var deferred []func() error
 	for i := 0; i < rt.NumField(); i++ {
 		f := rt.Field(i)
@@ -75,6 +79,17 @@ func marshalStruct(e *Encoder, rv reflect.Value) error {
 		}
 		tag := parseTag(f.Tag.Get("ndr"))
 		if tag.skip {
+			continue
+		}
+		if c, ok := counts[f.Name]; ok && isUintKind(rv.Field(i).Kind()) {
+			if tag.align > 0 {
+				e.Align(tag.align)
+			}
+			tmp := reflect.New(f.Type).Elem()
+			tmp.SetUint(c)
+			if err := marshalScalar(e, tmp); err != nil {
+				return fmt.Errorf("ndr: field %s: %w", f.Name, err)
+			}
 			continue
 		}
 		if i == confIdx {
@@ -437,6 +452,41 @@ func embeddedConformantIndex(rt reflect.Type, rv reflect.Value) int {
 		}
 	}
 	return idx
+}
+
+// countTargets maps the name of each field that is named by another field's
+// size_is/length_is to the element count of that array. The count is derived from the
+// array's length so the transmitted count field always matches the elements ([C706]
+// section 14.3.3.1; [MS-RPCE] Conformant Arrays).
+func countTargets(rt reflect.Type, rv reflect.Value) map[string]uint64 {
+	m := map[string]uint64{}
+	for j := 0; j < rt.NumField(); j++ {
+		f := rt.Field(j)
+		if f.PkgPath != "" {
+			continue
+		}
+		tag := parseTag(f.Tag.Get("ndr"))
+		if tag.skip || rv.Field(j).Kind() != reflect.Slice {
+			continue
+		}
+		n := uint64(rv.Field(j).Len())
+		if tag.sizeIs != "" {
+			m[tag.sizeIs] = n
+		}
+		if tag.lengthIs != "" {
+			m[tag.lengthIs] = n
+		}
+	}
+	return m
+}
+
+func isUintKind(k reflect.Kind) bool {
+	switch k {
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return true
+	default:
+		return false
+	}
 }
 
 // isEmbeddedConformantArray reports whether fv is an inline (non-pointer) conformant

--- a/network/dcerpc/ndr/marshal.go
+++ b/network/dcerpc/ndr/marshal.go
@@ -18,7 +18,7 @@ func Marshal(v any) ([]byte, error) {
 		return nil, err
 	}
 	e := NewEncoder()
-	if err := marshalStruct(e, rv); err != nil {
+	if err := marshalStruct(e, rv, false); err != nil {
 		return nil, err
 	}
 	return e.Bytes(), nil
@@ -35,7 +35,7 @@ func Unmarshal(data []byte, v any) error {
 	if err != nil {
 		return err
 	}
-	return unmarshalStruct(NewDecoder(data), sv)
+	return unmarshalStruct(NewDecoder(data), sv, false)
 }
 
 // structValue dereferences pointers/interfaces to reach a struct value.
@@ -61,7 +61,9 @@ func structValue(rv reflect.Value) (reflect.Value, error) {
 // maximum_count is hoisted to the start of the struct and only the elements are
 // emitted in place, per [MS-RPCE] "Structure Containing a Conformant Varying Array":
 // https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/7bae54af-8b6a-4672-a6a3-6bcdf131730a
-func marshalStruct(e *Encoder, rv reflect.Value) error {
+// embedded is true when rv is not the top-level call/parameter struct, which governs
+// how [ref] pointer members are encoded ([C706] section 14.3.10).
+func marshalStruct(e *Encoder, rv reflect.Value, embedded bool) error {
 	rt := rv.Type()
 	confIdx := embeddedConformantIndex(rt, rv)
 	if confIdx >= 0 {
@@ -104,7 +106,7 @@ func marshalStruct(e *Encoder, rv reflect.Value) error {
 			}
 			continue
 		}
-		if err := marshalFieldInline(e, rv.Field(i), tag, &deferred); err != nil {
+		if err := marshalFieldInline(e, rv.Field(i), tag, &deferred, embedded); err != nil {
 			return fmt.Errorf("ndr: field %s: %w", f.Name, err)
 		}
 	}
@@ -118,7 +120,7 @@ func marshalStruct(e *Encoder, rv reflect.Value) error {
 
 // marshalFieldInline writes a field's inline representation, enqueueing the referent
 // body for pointers.
-func marshalFieldInline(e *Encoder, fv reflect.Value, tag fieldTag, deferred *[]func() error) error {
+func marshalFieldInline(e *Encoder, fv reflect.Value, tag fieldTag, deferred *[]func() error, embedded bool) error {
 	if tag.align > 0 {
 		e.Align(tag.align)
 	}
@@ -133,12 +135,20 @@ func marshalFieldInline(e *Encoder, fv reflect.Value, tag fieldTag, deferred *[]
 			kind = ptrUnique // a bare Go pointer defaults to [unique]
 		}
 		if kind == ptrRef {
-			// Reference pointers carry no referent id at the top level; the referent
-			// is marshalled inline.
 			if isNilReferent(fv) {
 				return fmt.Errorf("ndr: nil [ref] pointer")
 			}
-			return marshalReferentBody(e, fv, tag)
+			// A top-level [ref] parameter has no referent id and its referent is
+			// marshalled in place. An embedded [ref] pointer is represented by a
+			// 4-octet placeholder with its referent deferred, like other embedded
+			// pointers ([C706] section 14.3.10).
+			if !embedded {
+				return marshalReferentBody(e, fv, tag)
+			}
+			e.WriteUint32(e.nextReferent())
+			body := fv
+			*deferred = append(*deferred, func() error { return marshalReferentBody(e, body, tag) })
+			return nil
 		}
 		if isNilReferent(fv) {
 			e.WriteUint32(0) // NULL referent
@@ -181,7 +191,7 @@ func marshalInlineValue(e *Encoder, fv reflect.Value, tag fieldTag, deferred *[]
 
 	switch fv.Kind() {
 	case reflect.Struct:
-		return marshalStruct(e, fv)
+		return marshalStruct(e, fv, true) // members of any value reached here are embedded
 	case reflect.Slice:
 		if tag.varying {
 			return marshalConformantVaryingArray(e, fv)
@@ -233,7 +243,7 @@ func marshalScalar(e *Encoder, fv reflect.Value) error {
 
 // ---- unmarshalling --------------------------------------------------------------
 
-func unmarshalStruct(d *Decoder, rv reflect.Value) error {
+func unmarshalStruct(d *Decoder, rv reflect.Value, embedded bool) error {
 	rt := rv.Type()
 	confIdx := embeddedConformantIndex(rt, rv)
 	var confCount uint32
@@ -271,7 +281,7 @@ func unmarshalStruct(d *Decoder, rv reflect.Value) error {
 			}
 			continue
 		}
-		if err := unmarshalFieldInline(d, rv.Field(i), tag, &deferred); err != nil {
+		if err := unmarshalFieldInline(d, rv.Field(i), tag, &deferred, embedded); err != nil {
 			return fmt.Errorf("ndr: field %s: %w", f.Name, err)
 		}
 	}
@@ -283,7 +293,7 @@ func unmarshalStruct(d *Decoder, rv reflect.Value) error {
 	return nil
 }
 
-func unmarshalFieldInline(d *Decoder, fv reflect.Value, tag fieldTag, deferred *[]func() error) error {
+func unmarshalFieldInline(d *Decoder, fv reflect.Value, tag fieldTag, deferred *[]func() error, embedded bool) error {
 	if tag.align > 0 {
 		d.Align(tag.align)
 	}
@@ -298,7 +308,17 @@ func unmarshalFieldInline(d *Decoder, fv reflect.Value, tag fieldTag, deferred *
 			kind = ptrUnique
 		}
 		if kind == ptrRef {
-			return unmarshalReferentBody(d, fv, tag)
+			// Top-level [ref]: referent in place. Embedded [ref]: 4-octet placeholder
+			// then a deferred referent.
+			if !embedded {
+				return unmarshalReferentBody(d, fv, tag)
+			}
+			if _, err := d.ReadUint32(); err != nil {
+				return err
+			}
+			target := fv
+			*deferred = append(*deferred, func() error { return unmarshalReferentBody(d, target, tag) })
+			return nil
 		}
 		refid, err := d.ReadUint32()
 		if err != nil {
@@ -348,7 +368,7 @@ func unmarshalInlineValue(d *Decoder, fv reflect.Value, tag fieldTag) error {
 
 	switch fv.Kind() {
 	case reflect.Struct:
-		return unmarshalStruct(d, fv)
+		return unmarshalStruct(d, fv, true)
 	case reflect.Slice:
 		if tag.varying {
 			return unmarshalConformantVaryingArray(d, fv)

--- a/network/dcerpc/ndr/marshal.go
+++ b/network/dcerpc/ndr/marshal.go
@@ -78,7 +78,12 @@ func marshalStruct(e *Encoder, rv reflect.Value) error {
 			continue
 		}
 		if i == confIdx {
-			// The maximum_count was hoisted above; emit only the elements in place.
+			// The maximum_count was hoisted above. For a conformant-varying array the
+			// offset and actual_count stay here, ahead of the elements.
+			if tag.varying {
+				e.WriteUint32(0)                         // offset
+				e.WriteUint32(uint32(rv.Field(i).Len())) // actual_count
+			}
 			if err := marshalElements(e, rv.Field(i)); err != nil {
 				return fmt.Errorf("ndr: field %s: %w", f.Name, err)
 			}
@@ -163,6 +168,9 @@ func marshalInlineValue(e *Encoder, fv reflect.Value, tag fieldTag, deferred *[]
 	case reflect.Struct:
 		return marshalStruct(e, fv)
 	case reflect.Slice:
+		if tag.varying {
+			return marshalConformantVaryingArray(e, fv)
+		}
 		return marshalConformantArray(e, fv)
 	case reflect.Array:
 		if fv.Type().Elem().Kind() == reflect.Uint8 {
@@ -232,7 +240,18 @@ func unmarshalStruct(d *Decoder, rv reflect.Value) error {
 			continue
 		}
 		if i == confIdx {
-			if err := unmarshalElements(d, rv.Field(i), int(confCount)); err != nil {
+			n := int(confCount)
+			if tag.varying {
+				if _, err := d.ReadUint32(); err != nil { // offset
+					return fmt.Errorf("ndr: field %s: %w", f.Name, err)
+				}
+				actual, err := d.ReadUint32() // actual_count
+				if err != nil {
+					return fmt.Errorf("ndr: field %s: %w", f.Name, err)
+				}
+				n = int(actual)
+			}
+			if err := unmarshalElements(d, rv.Field(i), n); err != nil {
 				return fmt.Errorf("ndr: field %s: %w", f.Name, err)
 			}
 			continue
@@ -316,6 +335,9 @@ func unmarshalInlineValue(d *Decoder, fv reflect.Value, tag fieldTag) error {
 	case reflect.Struct:
 		return unmarshalStruct(d, fv)
 	case reflect.Slice:
+		if tag.varying {
+			return unmarshalConformantVaryingArray(d, fv)
+		}
 		return unmarshalConformantArray(d, fv)
 	case reflect.Array:
 		if fv.Type().Elem().Kind() == reflect.Uint8 {
@@ -439,6 +461,34 @@ func unmarshalConformantArray(d *Decoder, slice reflect.Value) error {
 		return err
 	}
 	return unmarshalElements(d, slice, int(n))
+}
+
+// marshalConformantVaryingArray writes a conformant-varying array: maximum_count,
+// offset, actual_count, then the elements, per [MS-RPCE] Conformant Varying Arrays:
+// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/3acb31b0-b873-4aaf-8503-9727ec40fbec
+// The full slice is transmitted (offset 0, actual_count == maximum_count == len).
+func marshalConformantVaryingArray(e *Encoder, slice reflect.Value) error {
+	n := uint32(slice.Len())
+	e.WriteUint32(n) // maximum_count
+	e.WriteUint32(0) // offset
+	e.WriteUint32(n) // actual_count
+	return marshalElements(e, slice)
+}
+
+// unmarshalConformantVaryingArray reads a conformant-varying array, using the
+// actual_count to size the result.
+func unmarshalConformantVaryingArray(d *Decoder, slice reflect.Value) error {
+	if _, err := d.ReadUint32(); err != nil { // maximum_count
+		return err
+	}
+	if _, err := d.ReadUint32(); err != nil { // offset
+		return err
+	}
+	actual, err := d.ReadUint32() // actual_count
+	if err != nil {
+		return err
+	}
+	return unmarshalElements(d, slice, int(actual))
 }
 
 // marshalElements writes the elements of a slice with no count prefix. Each element

--- a/network/dcerpc/ndr/ref_pointer_test.go
+++ b/network/dcerpc/ndr/ref_pointer_test.go
@@ -1,0 +1,60 @@
+package ndr
+
+import (
+	"bytes"
+	"testing"
+)
+
+// TestTopLevelRefPointer verifies a top-level [ref] pointer is marshalled in place
+// with no referent id (issue #398).
+func TestTopLevelRefPointer(t *testing.T) {
+	type topRef struct {
+		P *uint32 `ndr:"ref"`
+	}
+	v := uint32(0xAABBCCDD)
+	raw, err := Marshal(&topRef{P: &v})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	want := []byte{0xDD, 0xCC, 0xBB, 0xAA} // referent in place, no placeholder
+	if !bytes.Equal(raw, want) {
+		t.Errorf("top-level ref:\n got %x\nwant %x", raw, want)
+	}
+	var out topRef
+	if err := Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out.P == nil || *out.P != v {
+		t.Errorf("round trip: got %v", out.P)
+	}
+}
+
+// TestEmbeddedRefPointer verifies an embedded [ref] pointer emits a 4-octet
+// placeholder with its referent deferred (issue #398).
+func TestEmbeddedRefPointer(t *testing.T) {
+	type inner struct {
+		P *uint32 `ndr:"ref"`
+	}
+	type outer struct {
+		I inner
+	}
+	v := uint32(0xAABBCCDD)
+	raw, err := Marshal(&outer{I: inner{P: &v}})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	want := []byte{
+		0x00, 0x00, 0x02, 0x00, // embedded [ref] placeholder (referent id)
+		0xDD, 0xCC, 0xBB, 0xAA, // deferred referent
+	}
+	if !bytes.Equal(raw, want) {
+		t.Errorf("embedded ref:\n got %x\nwant %x", raw, want)
+	}
+	var out outer
+	if err := Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out.I.P == nil || *out.I.P != v {
+		t.Errorf("round trip: got %v", out.I.P)
+	}
+}

--- a/network/dcerpc/ndr/sizeis_test.go
+++ b/network/dcerpc/ndr/sizeis_test.go
@@ -1,0 +1,38 @@
+package ndr
+
+import (
+	"bytes"
+	"testing"
+)
+
+// TestSizeIs_CountDerivedFromArray verifies a size_is target field is written from
+// the array length, so the caller need not set it and it cannot disagree (issue #401).
+func TestSizeIs_CountDerivedFromArray(t *testing.T) {
+	type blob struct {
+		CbData uint32 `ndr:"dword"` // size_is target for BData
+		BData  []byte `ndr:"unique,conformant,size_is=CbData"`
+	}
+	// CbData deliberately left 0; it must be derived as len(BData)=3.
+	in := &blob{BData: []byte{0xaa, 0xbb, 0xcc}}
+	raw, err := Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	want := []byte{
+		0x03, 0x00, 0x00, 0x00, // CbData, derived from len(BData)
+		0x00, 0x00, 0x02, 0x00, // BData referent id
+		0x03, 0x00, 0x00, 0x00, // BData maximum_count
+		0xaa, 0xbb, 0xcc, // BData elements
+	}
+	if !bytes.Equal(raw, want) {
+		t.Errorf("size_is derivation:\n got %x\nwant %x", raw, want)
+	}
+
+	var out blob
+	if err := Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out.CbData != 3 || !bytes.Equal(out.BData, in.BData) {
+		t.Errorf("round trip: CbData=%d BData=%x", out.CbData, out.BData)
+	}
+}

--- a/network/dcerpc/ndr/types.go
+++ b/network/dcerpc/ndr/types.go
@@ -24,9 +24,15 @@ type (
 
 	// WSTR is a wchar_t string ([string] wide). A field of this type marshals as a
 	// conformant+varying UTF-16LE array without needing an explicit "wstr" tag.
+	//
+	// Pointer semantics are explicit and controlled by the tag: a bare WSTR/STR/string
+	// field is encoded inline with no referent id (matching a top-level [ref] string
+	// parameter), while one tagged "unique" or "ptr" is encoded as a referent id with
+	// its body deferred (matching an embedded [unique,string] wchar_t*). Embedded
+	// strings in MS-RPC structures are almost always [unique]; tag them accordingly.
 	WSTR string
 	// STR is a char string ([string]). A field of this type marshals as a
-	// conformant+varying ASCII array.
+	// conformant+varying ASCII array. See WSTR for pointer semantics.
 	STR string
 )
 

--- a/network/dcerpc/ndr/types.go
+++ b/network/dcerpc/ndr/types.go
@@ -71,7 +71,9 @@ type fieldTag struct {
 	wide       bool   // [string] wide (UTF-16)
 	ascii      bool   // [string] ASCII
 	conformant bool   // conformant array (size_is)
-	sizeIs     string // sibling field naming the element count
+	varying    bool   // conformant-varying array (offset + actual_count framing)
+	sizeIs     string // sibling field naming the maximum element count
+	lengthIs   string // sibling field naming the actual element count
 	align      int    // explicit alignment override (0 = default)
 }
 
@@ -98,9 +100,15 @@ func parseTag(raw string) fieldTag {
 			t.ascii = true
 		case opt == "conformant":
 			t.conformant = true
+		case opt == "varying":
+			t.varying = true
 		case strings.HasPrefix(opt, "size_is="):
 			t.conformant = true
 			t.sizeIs = strings.TrimPrefix(opt, "size_is=")
+		case strings.HasPrefix(opt, "length_is="):
+			t.conformant = true
+			t.varying = true
+			t.lengthIs = strings.TrimPrefix(opt, "length_is=")
 		case strings.HasPrefix(opt, "align="):
 			switch strings.TrimPrefix(opt, "align=") {
 			case "1":

--- a/network/dcerpc/ndr/varying_arrays_test.go
+++ b/network/dcerpc/ndr/varying_arrays_test.go
@@ -1,0 +1,69 @@
+package ndr
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+)
+
+// TestPointerConformantVaryingArray verifies a unique pointer to a conformant-varying
+// array carries maximum_count + offset + actual_count before the elements (issue #396).
+func TestPointerConformantVaryingArray(t *testing.T) {
+	type rec struct {
+		P []uint32 `ndr:"unique,varying"`
+	}
+	in := &rec{P: []uint32{0xAA, 0xBB}}
+	raw, err := Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	want := []byte{
+		0x00, 0x00, 0x02, 0x00, // referent id
+		0x02, 0, 0, 0, // maximum_count
+		0x00, 0, 0, 0, // offset
+		0x02, 0, 0, 0, // actual_count
+		0xAA, 0, 0, 0, // P[0]
+		0xBB, 0, 0, 0, // P[1]
+	}
+	if !bytes.Equal(raw, want) {
+		t.Errorf("conformant-varying array:\n got %x\nwant %x", raw, want)
+	}
+	var out rec
+	if err := Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if !reflect.DeepEqual(out.P, in.P) {
+		t.Errorf("round trip: got %v want %v", out.P, in.P)
+	}
+}
+
+// TestEmbeddedConformantVaryingArray verifies the hoisted max_count plus in-place
+// offset/actual_count framing for an embedded conformant-varying array.
+func TestEmbeddedConformantVaryingArray(t *testing.T) {
+	type rec struct {
+		N    uint32
+		Data []uint16 `ndr:"varying"`
+	}
+	in := &rec{N: 0x09, Data: []uint16{0x01, 0x02, 0x03}}
+	raw, err := Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	want := []byte{
+		0x03, 0, 0, 0, // hoisted maximum_count
+		0x09, 0, 0, 0, // N
+		0x00, 0, 0, 0, // offset
+		0x03, 0, 0, 0, // actual_count
+		0x01, 0x00, 0x02, 0x00, 0x03, 0x00, // elements (uint16)
+	}
+	if !bytes.Equal(raw, want) {
+		t.Errorf("embedded conformant-varying:\n got %x\nwant %x", raw, want)
+	}
+	var out rec
+	if err := Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out.N != in.N || !reflect.DeepEqual(out.Data, in.Data) {
+		t.Errorf("round trip: got %+v want %+v", out, in)
+	}
+}


### PR DESCRIPTION
### Linked Issue
Closes #398

### Root Cause
The walker handled every `[ref]` pointer by marshalling the referent inline with no placeholder. That is correct only for a top-level `[ref]` parameter; an embedded `[ref]` pointer (a `[ref]` member of a structure) must be represented by a 4-octet placeholder, with its referent deferred like any other embedded pointer ([C706] section 14.3.10). Embedded `[ref]` members were therefore mis-encoded.

### Fix Description
Thread an `embedded` flag through the struct walker (`marshalStruct`/`unmarshalStruct` -> `marshalFieldInline`/`unmarshalFieldInline`): false for the top-level call/parameter struct, true for any nested struct or referent body. A `[ref]` pointer is marshalled in place when not embedded, and as a 4-octet placeholder + deferred referent when embedded. The unmarshal side mirrors it (read placeholder, defer referent).

### How Verified
- `go vet` and `go test ./network/dcerpc/ndr/` pass (all existing tests unchanged; top-level pointer/struct behavior is identical).
- New tests: a top-level `*uint32` `[ref]` (referent in place, no placeholder) and an embedded `[ref]` inside a nested struct (4-octet placeholder + deferred referent), both with round-trip.

### Test Coverage
- **Added:** `TestTopLevelRefPointer`, `TestEmbeddedRefPointer` in `network/dcerpc/ndr/ref_pointer_test.go`.

### Scope of Change
- **Files changed:** `network/dcerpc/ndr/marshal.go`, `network/dcerpc/ndr/ref_pointer_test.go`
- **Behavioral changes outside the bug fix:** none

### Notes
Stacked on #401 (series #397 -> #396 -> #401 -> #398 -> #399). Base retargeted to `feature-ndr-sizeis`; merge after #401.