### PR TITLE
[enhancement] Support NDR encapsulated unions (switch_is) (#399)

### DIFF
--- a/network/dcerpc/ndr/marshal.go
+++ b/network/dcerpc/ndr/marshal.go
@@ -175,6 +175,11 @@ func marshalReferentBody(e *Encoder, fv reflect.Value, tag fieldTag) error {
 // the value is itself a referent body (its own pointers create a fresh construction
 // scope via marshalStruct).
 func marshalInlineValue(e *Encoder, fv reflect.Value, tag fieldTag, deferred *[]func() error) error {
+	if u, ok := asUnion(fv); ok {
+		sw := u.SwitchValue()
+		e.WriteUint32(sw) // encapsulated discriminant (4-octet, 4-aligned)
+		return u.MarshalArm(e, sw)
+	}
 	if m, ok := asMarshaler(fv); ok {
 		e.Align(m.AlignmentNDR())
 		return m.MarshalNDR(e)
@@ -346,6 +351,13 @@ func unmarshalReferentBody(d *Decoder, fv reflect.Value, tag fieldTag) error {
 }
 
 func unmarshalInlineValue(d *Decoder, fv reflect.Value, tag fieldTag) error {
+	if u, ok := asUnion(fv); ok {
+		sw, err := d.ReadUint32()
+		if err != nil {
+			return err
+		}
+		return u.UnmarshalArm(d, sw)
+	}
 	if m, ok := asMarshalerAddr(fv); ok {
 		d.Align(m.AlignmentNDR())
 		return m.UnmarshalNDR(d)

--- a/network/dcerpc/ndr/union.go
+++ b/network/dcerpc/ndr/union.go
@@ -1,0 +1,37 @@
+package ndr
+
+import "reflect"
+
+// Union is implemented by an NDR encapsulated union: a discriminant (the switch
+// value) followed by the arm it selects. The walker writes the discriminant inline
+// (a 4-octet switch, the common MS-RPCE case) and then delegates the arm to the type.
+//
+// References:
+//   - [C706] section 14.3.8 (Unions):
+//     https://pubs.opengroup.org/onlinepubs/9629399/chap14.htm
+//   - [MS-RPCE] 2.2.4.x Union types:
+//     https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/b6090c2b-f44a-47a1-a13b-b82ade0137b2
+//
+// Non-encapsulated unions (discriminant carried by a separate switch_is parameter,
+// not inline) are not yet handled by the walker.
+type Union interface {
+	// SwitchValue returns the discriminant for the currently-set arm.
+	SwitchValue() uint32
+	// MarshalArm marshals the arm selected by sw.
+	MarshalArm(e *Encoder, sw uint32) error
+	// UnmarshalArm reads the arm selected by sw.
+	UnmarshalArm(d *Decoder, sw uint32) error
+}
+
+var unionType = reflect.TypeOf((*Union)(nil)).Elem()
+
+// asUnion returns fv (or its address) as a Union, if it implements one.
+func asUnion(fv reflect.Value) (Union, bool) {
+	if fv.Type().Implements(unionType) {
+		return fv.Interface().(Union), true
+	}
+	if fv.CanAddr() && fv.Addr().Type().Implements(unionType) {
+		return fv.Addr().Interface().(Union), true
+	}
+	return nil, false
+}

--- a/network/dcerpc/ndr/union_test.go
+++ b/network/dcerpc/ndr/union_test.go
@@ -1,0 +1,87 @@
+package ndr
+
+import (
+	"bytes"
+	"testing"
+)
+
+// levelUnion is a sample encapsulated NDR union switched on Level: arm 1 is a uint32,
+// arm 2 is a uint16.
+type levelUnion struct {
+	Level uint32
+	AsU32 uint32
+	AsU16 uint16
+}
+
+func (u *levelUnion) SwitchValue() uint32 { return u.Level }
+func (u *levelUnion) MarshalArm(e *Encoder, sw uint32) error {
+	switch sw {
+	case 1:
+		e.WriteUint32(u.AsU32)
+	case 2:
+		e.WriteUint16(u.AsU16)
+	}
+	return nil
+}
+func (u *levelUnion) UnmarshalArm(d *Decoder, sw uint32) error {
+	u.Level = sw // the union records the discriminant the walker decoded
+	switch sw {
+	case 1:
+		v, err := d.ReadUint32()
+		u.AsU32 = v
+		return err
+	case 2:
+		v, err := d.ReadUint16()
+		u.AsU16 = v
+		return err
+	}
+	return nil
+}
+
+func TestUnion_Arm1(t *testing.T) {
+	type wrap struct {
+		U levelUnion
+	}
+	raw, err := Marshal(&wrap{U: levelUnion{Level: 1, AsU32: 0xAABBCCDD}})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	want := []byte{
+		0x01, 0, 0, 0, // discriminant (switch value)
+		0xDD, 0xCC, 0xBB, 0xAA, // arm 1 (uint32)
+	}
+	if !bytes.Equal(raw, want) {
+		t.Errorf("union arm 1:\n got %x\nwant %x", raw, want)
+	}
+	var out wrap
+	if err := Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out.U.Level != 1 || out.U.AsU32 != 0xAABBCCDD {
+		t.Errorf("round trip: got %+v", out.U)
+	}
+}
+
+func TestUnion_Arm2(t *testing.T) {
+	type wrap struct {
+		U levelUnion
+	}
+	raw, err := Marshal(&wrap{U: levelUnion{Level: 2, AsU16: 0xBEEF}})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	want := []byte{
+		0x02, 0, 0, 0, // discriminant
+		0xEF, 0xBE, // arm 2 (uint16)
+	}
+	if !bytes.Equal(raw, want) {
+		t.Errorf("union arm 2:\n got %x\nwant %x", raw, want)
+	}
+	var out wrap
+	if err := Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out.U.Level != 2 || out.U.AsU16 != 0xBEEF {
+		t.Errorf("round trip: got %+v", out.U)
+	}
+}


### PR DESCRIPTION
### Linked Issue
Closes #399

### Root Cause
The declarative walker had no way to represent an NDR discriminated union; unions could only be hand-rolled through the raw `Marshaler` escape hatch, with no standard handling of the discriminant.

### Fix Description
Add a `Union` interface (`SwitchValue`, `MarshalArm`, `UnmarshalArm`). When a field's type implements it, the walker encodes an encapsulated union: it writes the 4-octet discriminant inline (the common MS-RPCE switch), then delegates the selected arm to the type; decode reads the discriminant and passes it to `UnmarshalArm`. The check runs ahead of the `Marshaler` and struct paths, so a union type (itself a Go struct) is handled as a union rather than by field reflection. Pointer-to-union and union-in-array work through the existing referent/element paths.

Scope: encapsulated unions (discriminant transmitted inline). Non-encapsulated unions, where the discriminant is carried by a separate `switch_is` parameter rather than inline, are not yet handled.

### How Verified
- `go vet` and `go test ./network/dcerpc/ndr/` pass (all prior tests unchanged).
- New tests marshal a sample level-switched union for arm 1 (uint32) and arm 2 (uint16), asserting `discriminant + arm` bytes and round-trip.

### Test Coverage
- **Added:** `TestUnion_Arm1`, `TestUnion_Arm2` in `network/dcerpc/ndr/union_test.go`.

### Scope of Change
- **Files changed:** `network/dcerpc/ndr/union.go` (new), `network/dcerpc/ndr/marshal.go`, `network/dcerpc/ndr/union_test.go`
- **Behavioral changes outside the bug fix:** none

### Notes
Final PR of the NDR20-completion series (#397 -> #396 -> #401 -> #398 -> #399). Base retargeted to `feature-ndr-embedded-ref`; merge after #398. NDR64 (#400) remains deferred by design.