### PR TITLE
[bugfix] Fix unbounded allocation from attacker-controlled NDR array count (#410)

### DIFF
--- a/network/dcerpc/ndr/alloc_guard_test.go
+++ b/network/dcerpc/ndr/alloc_guard_test.go
@@ -1,0 +1,60 @@
+package ndr
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+// TestUnmarshal_HugeArrayCountRejected verifies a conformant array whose wire count
+// exceeds the remaining input is rejected instead of triggering an oversized
+// allocation (issue #410).
+func TestUnmarshal_HugeArrayCountRejected(t *testing.T) {
+	type rec struct {
+		P []uint32 `ndr:"unique,conformant"`
+	}
+	// Referent id (non-null) + a maximum_count of 0xFFFFFFFF with no element data.
+	stub := make([]byte, 8)
+	binary.LittleEndian.PutUint32(stub[0:4], 0x00020000) // referent id
+	binary.LittleEndian.PutUint32(stub[4:8], 0xFFFFFFFF) // bogus maximum_count
+
+	var out rec
+	if err := Unmarshal(stub, &out); err == nil {
+		t.Fatal("Unmarshal with an oversized array count: error = nil, want non-nil")
+	}
+}
+
+// TestUnmarshal_HugeVaryingCountRejected does the same for a conformant-varying array.
+func TestUnmarshal_HugeVaryingCountRejected(t *testing.T) {
+	type rec struct {
+		P []uint16 `ndr:"unique,varying"`
+	}
+	stub := make([]byte, 16)
+	binary.LittleEndian.PutUint32(stub[0:4], 0x00020000)   // referent id
+	binary.LittleEndian.PutUint32(stub[4:8], 0xFFFFFFFF)   // maximum_count
+	binary.LittleEndian.PutUint32(stub[8:12], 0)           // offset
+	binary.LittleEndian.PutUint32(stub[12:16], 0xFFFFFFFF) // actual_count
+
+	var out rec
+	if err := Unmarshal(stub, &out); err == nil {
+		t.Fatal("Unmarshal with an oversized varying count: error = nil, want non-nil")
+	}
+}
+
+// TestUnmarshal_ValidArrayStillWorks confirms a legitimate count is unaffected.
+func TestUnmarshal_ValidArrayStillWorks(t *testing.T) {
+	type rec struct {
+		P []uint32 `ndr:"unique,conformant"`
+	}
+	in := &rec{P: []uint32{1, 2, 3}}
+	raw, err := Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var out rec
+	if err := Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal of a valid array: %v", err)
+	}
+	if len(out.P) != 3 || out.P[2] != 3 {
+		t.Errorf("got %v", out.P)
+	}
+}

--- a/network/dcerpc/ndr/marshal.go
+++ b/network/dcerpc/ndr/marshal.go
@@ -582,6 +582,12 @@ func unmarshalElements(d *Decoder, slice reflect.Value, n int) error {
 	if n < 0 {
 		return fmt.Errorf("ndr: negative element count %d", n)
 	}
+	// Every NDR element occupies at least one octet, so a count larger than the
+	// remaining input cannot be valid. Reject it before allocating, otherwise an
+	// attacker-controlled count would size an arbitrary allocation (OOM/panic).
+	if n > d.Remaining() {
+		return fmt.Errorf("ndr: element count %d exceeds %d remaining bytes", n, d.Remaining())
+	}
 	if slice.Type().Elem().Kind() == reflect.Uint8 {
 		b, err := d.ReadBytes(n)
 		if err != nil {


### PR DESCRIPTION
### Linked Issue
Closes #410

### Root Cause
When decoding a conformant or conformant-varying array of a non-byte element type, `unmarshalElements` sized the result slice with `reflect.MakeSlice(slice.Type(), n, n)` using the count `n` read straight from the wire, before reading any elements. The `[]byte` path is implicitly bounded because `Decoder.ReadBytes` validates the length against the remaining buffer, but the generic path performed the allocation first, so a count near `0xFFFFFFFF` caused an oversized allocation (panic or OOM). DCE/RPC responses come from a remote server, making this a client-side denial of service.

### Fix Description
Reject a count larger than the remaining input before allocating. Every NDR element occupies at least one octet, so a valid count can never exceed `Decoder.Remaining()`; the check therefore preserves all legitimate inputs while capping the allocation to the actual buffer size. The guard sits in `unmarshalElements`, which backs the conformant, conformant-varying, and embedded-array decode paths, so one change covers all three.

### How Verified
- `go vet` and `go test ./network/dcerpc/ndr/` pass.
- New tests feed a `0xFFFFFFFF` `maximum_count` (and `actual_count`) for `[]uint32`/`[]uint16` arrays and assert an error rather than a crash, plus a control that a valid array still round-trips.

### Test Coverage
- **Added:** `TestUnmarshal_HugeArrayCountRejected`, `TestUnmarshal_HugeVaryingCountRejected`, `TestUnmarshal_ValidArrayStillWorks` in `network/dcerpc/ndr/alloc_guard_test.go`.

### Scope of Change
- **Files changed:** `network/dcerpc/ndr/marshal.go`, `network/dcerpc/ndr/alloc_guard_test.go`
- **Behavioral changes outside the bug fix:** none (only over-length counts, which were previously crashes, now return an error)

### Risk and Rollout
Local to the `ndr` decode path; safe to merge. Legitimate counts are unaffected; only malformed/oversized counts change from crash to a returned error.