### PR TITLE
[bugfix] Align NDR conformant array size determinant to the element alignment (#411)

### DIFF
--- a/network/dcerpc/ndr/array_align_test.go
+++ b/network/dcerpc/ndr/array_align_test.go
@@ -1,0 +1,60 @@
+package ndr
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+)
+
+// TestConformantArray_Uint64DeterminantAligned verifies the maximum_count of a
+// conformant array of 8-byte elements is placed on an 8-octet boundary (issue #411).
+func TestConformantArray_Uint64Determinant(t *testing.T) {
+	type rec struct {
+		Lead uint8
+		P    []uint64 `ndr:"unique,conformant"`
+	}
+	in := &rec{Lead: 0x01, P: []uint64{0x1122334455667788}}
+	raw, err := Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	want := []byte{
+		0x01, 0x00, 0x00, 0x00, // Lead (uint8) + 3 pad to 4-align the referent id
+		0x00, 0x00, 0x02, 0x00, // referent id
+		0x01, 0x00, 0x00, 0x00, // maximum_count (4 octets) ...
+		0x00, 0x00, 0x00, 0x00, // ... then 4 pad so elements are 8-aligned
+		0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, // P[0] (uint64)
+	}
+	if !bytes.Equal(raw, want) {
+		t.Errorf("uint64 conformant array:\n got %x\nwant %x", raw, want)
+	}
+	var out rec
+	if err := Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out.Lead != 1 || !reflect.DeepEqual(out.P, in.P) {
+		t.Errorf("round trip: got %+v want %+v", out, in)
+	}
+}
+
+// TestConformantArray_Uint32DeterminantUnchanged confirms <=4-byte elements are
+// unaffected (the determinant stays 4-aligned, no extra padding).
+func TestConformantArray_Uint32DeterminantUnchanged(t *testing.T) {
+	type rec struct {
+		Lead uint8
+		P    []uint32 `ndr:"unique,conformant"`
+	}
+	raw, err := Marshal(&rec{Lead: 0x01, P: []uint32{0xAABBCCDD}})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	want := []byte{
+		0x01, 0x00, 0x00, 0x00, // Lead + pad
+		0x00, 0x00, 0x02, 0x00, // referent id
+		0x01, 0x00, 0x00, 0x00, // maximum_count (no extra pad: elements are 4-aligned)
+		0xDD, 0xCC, 0xBB, 0xAA, // P[0]
+	}
+	if !bytes.Equal(raw, want) {
+		t.Errorf("uint32 conformant array:\n got %x\nwant %x", raw, want)
+	}
+}

--- a/network/dcerpc/ndr/marshal.go
+++ b/network/dcerpc/ndr/marshal.go
@@ -67,6 +67,7 @@ func marshalStruct(e *Encoder, rv reflect.Value, embedded bool) error {
 	rt := rv.Type()
 	confIdx := embeddedConformantIndex(rt, rv)
 	if confIdx >= 0 {
+		e.Align(conformantArrayAlignment(rv.Field(confIdx).Type().Elem()))
 		e.WriteUint32(uint32(rv.Field(confIdx).Len())) // hoisted maximum_count
 	}
 	// A field named by another field's size_is/length_is is the array's count; its
@@ -248,6 +249,7 @@ func unmarshalStruct(d *Decoder, rv reflect.Value, embedded bool) error {
 	confIdx := embeddedConformantIndex(rt, rv)
 	var confCount uint32
 	if confIdx >= 0 {
+		d.Align(conformantArrayAlignment(rv.Field(confIdx).Type().Elem()))
 		c, err := d.ReadUint32() // hoisted maximum_count
 		if err != nil {
 			return err
@@ -516,16 +518,58 @@ func isEmbeddedConformantArray(fv reflect.Value, tag fieldTag) bool {
 	return fv.Kind() == reflect.Slice && !isPointerLike(fv, tag)
 }
 
+// ndrAlignment returns the NDR alignment, in octets, of a value of type t.
+func ndrAlignment(t reflect.Type) int {
+	if reflect.PointerTo(t).Implements(marshalerType) {
+		return reflect.New(t).Interface().(Marshaler).AlignmentNDR()
+	}
+	switch t.Kind() {
+	case reflect.Bool, reflect.Uint8, reflect.Int8:
+		return 1
+	case reflect.Uint16, reflect.Int16:
+		return 2
+	case reflect.Uint32, reflect.Int32, reflect.Uint, reflect.Int, reflect.String, reflect.Pointer:
+		return 4
+	case reflect.Uint64, reflect.Int64:
+		return 8
+	case reflect.Struct:
+		a := 1
+		for i := 0; i < t.NumField(); i++ {
+			if t.Field(i).PkgPath != "" {
+				continue
+			}
+			if fa := ndrAlignment(t.Field(i).Type); fa > a {
+				a = fa
+			}
+		}
+		return a
+	default:
+		return 4
+	}
+}
+
+// conformantArrayAlignment returns the alignment of a conformant array of the given
+// element type: the larger of the size determinant's alignment (4) and the element
+// alignment ([C706] section 14.3.3.1).
+func conformantArrayAlignment(elemType reflect.Type) int {
+	if a := ndrAlignment(elemType); a > 4 {
+		return a
+	}
+	return 4
+}
+
 // marshalConformantArray writes a conformant array: a maximum_count followed by the
 // elements, per [MS-RPCE] Conformant Arrays:
 // https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/140b01a3-979b-43af-b1e3-28f248db8f03
 func marshalConformantArray(e *Encoder, slice reflect.Value) error {
+	e.Align(conformantArrayAlignment(slice.Type().Elem()))
 	e.WriteUint32(uint32(slice.Len()))
 	return marshalElements(e, slice)
 }
 
 // unmarshalConformantArray reads a maximum_count-prefixed array into slice.
 func unmarshalConformantArray(d *Decoder, slice reflect.Value) error {
+	d.Align(conformantArrayAlignment(slice.Type().Elem()))
 	n, err := d.ReadUint32()
 	if err != nil {
 		return err
@@ -538,6 +582,7 @@ func unmarshalConformantArray(d *Decoder, slice reflect.Value) error {
 // https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/3acb31b0-b873-4aaf-8503-9727ec40fbec
 // The full slice is transmitted (offset 0, actual_count == maximum_count == len).
 func marshalConformantVaryingArray(e *Encoder, slice reflect.Value) error {
+	e.Align(conformantArrayAlignment(slice.Type().Elem()))
 	n := uint32(slice.Len())
 	e.WriteUint32(n) // maximum_count
 	e.WriteUint32(0) // offset
@@ -548,6 +593,7 @@ func marshalConformantVaryingArray(e *Encoder, slice reflect.Value) error {
 // unmarshalConformantVaryingArray reads a conformant-varying array, using the
 // actual_count to size the result.
 func unmarshalConformantVaryingArray(d *Decoder, slice reflect.Value) error {
+	d.Align(conformantArrayAlignment(slice.Type().Elem()))
 	if _, err := d.ReadUint32(); err != nil { // maximum_count
 		return err
 	}


### PR DESCRIPTION
### Linked Issue
Closes #411

### Root Cause
A conformant or conformant-varying array's `maximum_count` was written with `WriteUint32`, which aligns to 4 octets, and element alignment was left to the per-element writers. Per [C706] section 14.3.3.1 the array — including its size determinant — aligns to the larger of the determinant's alignment (4) and the element alignment. For elements whose alignment exceeds 4 (e.g. `uint64`, or a struct with an 8-octet member) the determinant could land on a 4-but-not-8 boundary, so the wire layout disagreed with a conformant peer.

### Fix Description
Add `conformantArrayAlignment(elemType) = max(4, ndrAlignment(elemType))` (with `ndrAlignment` covering scalars, structs, pointers, strings, and `Marshaler` types) and align the stream to it before the determinant is written or read — in `marshalConformantArray`/`marshalConformantVaryingArray`, their decode counterparts, and the embedded (hoisted) determinant in `marshalStruct`/`unmarshalStruct`. For elements with alignment <= 4 (bytes, `uint16`, `uint32`, and most structs) the value is 4, so behavior is unchanged.

### How Verified
- `go vet` and `go test ./network/dcerpc/ndr/` pass (all existing array tests unchanged).
- New tests: a `[]uint64` conformant array asserts the determinant is followed by 4 pad octets so the elements are 8-aligned and round-trips; a `[]uint32` control asserts no extra padding (no regression for <=4-byte elements).

### Test Coverage
- **Added:** `TestConformantArray_Uint64Determinant`, `TestConformantArray_Uint32DeterminantUnchanged` in `network/dcerpc/ndr/array_align_test.go`.

### Scope of Change
- **Files changed:** `network/dcerpc/ndr/marshal.go`, `network/dcerpc/ndr/array_align_test.go`
- **Behavioral changes outside the bug fix:** none (arrays of elements with alignment <= 4 are byte-for-byte identical)

### Risk and Rollout
Low blast radius: only arrays of elements with alignment > 4 change, and that change makes the layout conformant; safe to merge.