### PR TITLE
[enhancement] Wire NDR marshalling into the DCE/RPC client via Client.Invoke

### DIFF
--- a/network/dcerpc/client/client.go
+++ b/network/dcerpc/client/client.go
@@ -27,6 +27,7 @@ package client
 import (
 	"fmt"
 
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/pdu"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/transport"
@@ -146,6 +147,29 @@ func (c *Client) Call(opnum uint16, stub []byte) ([]byte, error) {
 		return nil, fmt.Errorf("dcerpc call (opnum %d): %w", opnum, err)
 	}
 	return result, nil
+}
+
+// Invoke is the declarative counterpart to Call: it marshals the NDR request
+// structure in (whose Opnum selects the method and whose exported fields are the [in]
+// parameters), issues the call, and unmarshals the response into out (a pointer to
+// the [out] parameter structure). out may be nil when the response carries no data.
+// A fault PDU is returned as a *pdu.Fault error, as with Call.
+func (c *Client) Invoke(in ndr.Call, out any) error {
+	stub, err := ndr.Request(in)
+	if err != nil {
+		return fmt.Errorf("dcerpc invoke (opnum %d): marshal request: %w", in.Opnum(), err)
+	}
+	resp, err := c.Call(in.Opnum(), stub)
+	if err != nil {
+		return err
+	}
+	if out == nil {
+		return nil
+	}
+	if err := ndr.Response(resp, out); err != nil {
+		return fmt.Errorf("dcerpc invoke (opnum %d): unmarshal response: %w", in.Opnum(), err)
+	}
+	return nil
 }
 
 // sendRequest fragments stub into request PDUs no larger than the negotiated send

--- a/network/dcerpc/client/client_test.go
+++ b/network/dcerpc/client/client_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/pdu"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
 	"github.com/TheManticoreProject/Manticore/windows/guid"
@@ -319,5 +320,82 @@ func TestCall_CallIDMismatch(t *testing.T) {
 	ft.queue(responseBytes(t, 3, pdu.PFCFirstFrag|pdu.PFCLastFrag, []byte{0x01}))
 	if _, err := c.Call(1, nil); err == nil {
 		t.Fatal("Call() with mismatched response call_id: error = nil, want non-nil")
+	}
+}
+
+// invokeReq/invokeResp are minimal NDR structures for exercising Client.Invoke.
+type invokeReq struct {
+	A ndr.DWORD
+	B ndr.DWORD
+}
+
+func (*invokeReq) Opnum() uint16 { return 7 }
+
+type invokeResp struct {
+	X ndr.DWORD
+}
+
+func TestInvoke_MarshalsRequestAndUnmarshalsResponse(t *testing.T) {
+	ft := &fakeTransport{maxXmit: 4280, maxRecv: 4280}
+	ft.queue(bindAckBytes(t, 4280, 4280))
+	c := NewClient(ft)
+	if err := c.Bind(testSyntax()); err != nil {
+		t.Fatalf("Bind() error = %v", err)
+	}
+
+	// First call uses call_id 2; response carries one DWORD.
+	ft.queue(responseBytes(t, 2, pdu.PFCFirstFrag|pdu.PFCLastFrag, []byte{0xBE, 0xBA, 0xFE, 0xCA}))
+
+	var out invokeResp
+	if err := c.Invoke(&invokeReq{A: 0x11, B: 0x22}, &out); err != nil {
+		t.Fatalf("Invoke() error = %v", err)
+	}
+	if out.X != 0xCAFEBABE {
+		t.Errorf("out.X = %#x, want 0xcafebabe", out.X)
+	}
+
+	// The request PDU (after the bind) must carry opnum 7 and the NDR-marshalled fields.
+	var req pdu.Request
+	if _, err := req.Unmarshal(ft.sent[1]); err != nil {
+		t.Fatalf("sent request does not parse: %v", err)
+	}
+	if req.Opnum != 7 {
+		t.Errorf("opnum = %d, want 7", req.Opnum)
+	}
+	want := []byte{0x11, 0, 0, 0, 0x22, 0, 0, 0}
+	if !bytes.Equal(req.Stub, want) {
+		t.Errorf("request stub = %x, want %x", req.Stub, want)
+	}
+}
+
+func TestInvoke_NilOutSkipsResponseDecode(t *testing.T) {
+	ft := &fakeTransport{maxXmit: 4280, maxRecv: 4280}
+	ft.queue(bindAckBytes(t, 4280, 4280))
+	c := NewClient(ft)
+	if err := c.Bind(testSyntax()); err != nil {
+		t.Fatalf("Bind() error = %v", err)
+	}
+	ft.queue(responseBytes(t, 2, pdu.PFCFirstFrag|pdu.PFCLastFrag, nil))
+	if err := c.Invoke(&invokeReq{A: 1, B: 2}, nil); err != nil {
+		t.Fatalf("Invoke() with nil out: error = %v", err)
+	}
+}
+
+func TestInvoke_FaultIsReturned(t *testing.T) {
+	ft := &fakeTransport{maxXmit: 4280, maxRecv: 4280}
+	ft.queue(bindAckBytes(t, 4280, 4280))
+	c := NewClient(ft)
+	if err := c.Bind(testSyntax()); err != nil {
+		t.Fatalf("Bind() error = %v", err)
+	}
+	fault := &pdu.Fault{Status: pdu.NCASOpRngError}
+	fault.Header = pdu.NewHeader(pdu.PacketTypeFault, pdu.PFCFirstFrag|pdu.PFCLastFrag, 2)
+	ft.queue(mustMarshal(t, fault))
+
+	var out invokeResp
+	err := c.Invoke(&invokeReq{}, &out)
+	var fe *pdu.Fault
+	if !errors.As(err, &fe) {
+		t.Fatalf("Invoke() error = %v, want *pdu.Fault", err)
 	}
 }

--- a/network/dcerpc/interfaces/lsarpc/lsarpc.go
+++ b/network/dcerpc/interfaces/lsarpc/lsarpc.go
@@ -21,10 +21,10 @@
 package lsarpc
 
 import (
-	"encoding/binary"
 	"fmt"
 
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/client"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
 	"github.com/TheManticoreProject/Manticore/windows/guid"
 )
@@ -85,67 +85,68 @@ func (h PolicyHandle) IsZero() bool {
 	return true
 }
 
-// OpenPolicy2 calls LsarOpenPolicy2 (opnum 44) and returns a policy handle.
-//
-// The request stub is hand-marshalled NDR:
-//   - SystemName ([in, unique, string] wchar_t*): a NULL unique pointer (4 zero
-//     bytes). The server ignores it ([MS-LSAD] 3.1.4.4.1).
-//   - ObjectAttributes (PLSAPR_OBJECT_ATTRIBUTES, a top-level reference pointer so the
-//     struct is inline): six 4-byte fields, all zero (Length, RootDirectory,
-//     ObjectName, Attributes, SecurityDescriptor, SecurityQualityOfService). All are
-//     ignored except RootDirectory, which must be NULL.
-//   - DesiredAccess (ACCESS_MASK): the requested access, little-endian.
-func OpenPolicy2(rpc *client.Client, desiredAccess uint32) (PolicyHandle, error) {
-	stub := make([]byte, 0, 32)
-	stub = append(stub, 0, 0, 0, 0)          // SystemName: NULL unique pointer
-	stub = append(stub, make([]byte, 24)...) // ObjectAttributes: all-zero inline struct
-	stub = binary.LittleEndian.AppendUint32(stub, desiredAccess)
+// objectAttributes models LSAPR_OBJECT_ATTRIBUTES ([MS-LSAD] 2.2.2.3). All fields are
+// ignored by the server except RootDirectory, which must be NULL, so each is modeled
+// as a 4-octet zero field (the four pointer members as NULL referents).
+type objectAttributes struct {
+	Length                   ndr.DWORD
+	RootDirectory            ndr.DWORD // [unique] NULL
+	ObjectName               ndr.DWORD // [unique] NULL
+	Attributes               ndr.DWORD
+	SecurityDescriptor       ndr.DWORD // [unique] NULL
+	SecurityQualityOfService ndr.DWORD // [unique] NULL
+}
 
-	resp, err := rpc.Call(OpnumOpenPolicy2, stub)
-	if err != nil {
+// openPolicy2Request is the [in] parameter set of LsarOpenPolicy2: a NULL unique
+// SystemName pointer, an inline ObjectAttributes (a top-level [ref] struct), and the
+// desired access mask.
+type openPolicy2Request struct {
+	SystemName    *ndr.WSTR `ndr:"unique"`
+	Attributes    objectAttributes
+	DesiredAccess ndr.DWORD
+}
+
+func (*openPolicy2Request) Opnum() uint16 { return OpnumOpenPolicy2 }
+
+// closeRequest is the [in,out] parameter of LsarClose: the context handle.
+type closeRequest struct {
+	Handle PolicyHandle
+}
+
+func (*closeRequest) Opnum() uint16 { return OpnumClose }
+
+// handleResponse is the common reply shape: a 20-byte context handle followed by the
+// NTSTATUS return value.
+type handleResponse struct {
+	Handle PolicyHandle
+	Status ndr.DWORD
+}
+
+// OpenPolicy2 calls LsarOpenPolicy2 (opnum 44) and returns a policy handle.
+func OpenPolicy2(rpc *client.Client, desiredAccess uint32) (PolicyHandle, error) {
+	req := &openPolicy2Request{DesiredAccess: ndr.DWORD(desiredAccess)}
+	var resp handleResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
 		return PolicyHandle{}, fmt.Errorf("LsarOpenPolicy2: %w", err)
 	}
-	handle, status, err := parseHandleResponse(resp)
-	if err != nil {
-		return PolicyHandle{}, fmt.Errorf("LsarOpenPolicy2: %w", err)
+	if uint32(resp.Status) != StatusSuccess {
+		return resp.Handle, fmt.Errorf("LsarOpenPolicy2 failed: %s", StatusString(uint32(resp.Status)))
 	}
-	if status != StatusSuccess {
-		return handle, fmt.Errorf("LsarOpenPolicy2 failed: %s", StatusString(status))
-	}
-	return handle, nil
+	return resp.Handle, nil
 }
 
 // Close calls LsarClose (opnum 0) on a handle. On success the server returns a zeroed
 // handle, which is returned to the caller.
-//
-// LsarClose([in, out] LSAPR_HANDLE* ObjectHandle) -> NTSTATUS. The request stub is the
-// 20-byte handle; the response is the (zeroed) handle followed by the NTSTATUS.
 func Close(rpc *client.Client, handle PolicyHandle) (PolicyHandle, error) {
-	resp, err := rpc.Call(OpnumClose, handle[:])
-	if err != nil {
+	req := &closeRequest{Handle: handle}
+	var resp handleResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
 		return PolicyHandle{}, fmt.Errorf("LsarClose: %w", err)
 	}
-	out, status, err := parseHandleResponse(resp)
-	if err != nil {
-		return PolicyHandle{}, fmt.Errorf("LsarClose: %w", err)
+	if uint32(resp.Status) != StatusSuccess {
+		return resp.Handle, fmt.Errorf("LsarClose failed: %s", StatusString(uint32(resp.Status)))
 	}
-	if status != StatusSuccess {
-		return out, fmt.Errorf("LsarClose failed: %s", StatusString(status))
-	}
-	return out, nil
-}
-
-// parseHandleResponse decodes a response consisting of a 20-byte context handle
-// followed by a 4-byte NTSTATUS return value.
-func parseHandleResponse(resp []byte) (PolicyHandle, uint32, error) {
-	const want = 24
-	if len(resp) < want {
-		return PolicyHandle{}, 0, fmt.Errorf("response too short: have %d bytes, need %d", len(resp), want)
-	}
-	var h PolicyHandle
-	copy(h[:], resp[0:20])
-	status := binary.LittleEndian.Uint32(resp[20:24])
-	return h, status, nil
+	return resp.Handle, nil
 }
 
 // StatusString returns a mnemonic for the documented status codes, otherwise the hex

--- a/network/dcerpc/interfaces/lsarpc/lsarpc_test.go
+++ b/network/dcerpc/interfaces/lsarpc/lsarpc_test.go
@@ -152,9 +152,14 @@ func TestClose_RoundTrip(t *testing.T) {
 	}
 }
 
-func TestParseHandleResponse_TooShort(t *testing.T) {
-	if _, _, err := parseHandleResponse(make([]byte, 23)); err == nil {
-		t.Fatal("parseHandleResponse of short buffer: error = nil, want non-nil")
+func TestOpenPolicy2_ShortResponseErrors(t *testing.T) {
+	ft := &fakeTransport{}
+	c := boundClient(t, ft)
+	// A response stub shorter than the 24-byte handle+status must error rather than
+	// return garbage (the NDR decoder rejects the truncated read).
+	ft.queue(responsePDU(t, 2, make([]byte, 23)))
+	if _, err := OpenPolicy2(c, MaximumAllowed); err == nil {
+		t.Fatal("OpenPolicy2 with a truncated response: error = nil, want non-nil")
 	}
 }
 


### PR DESCRIPTION
### Summary

Connects the declarative `network/dcerpc/ndr` codec to the DCE/RPC client so an RPC call can be expressed as a Go struct rather than hand-marshalled bytes. This is the integration step that the NDR package was built for; it is a feature (not a bug fix), so no issue is linked.

### What this includes

- **`Client.Invoke(in ndr.Call, out any) error`** — marshals the request struct `in` (its `Opnum()` selects the method, its exported fields are the `[in]` parameters) with `ndr.Request`, issues the call via the existing `Client.Call`, and unmarshals the reply into `out` with `ndr.Response`. `out` may be nil when the response carries no data; a fault PDU surfaces as a `*pdu.Fault`, exactly as with `Call`.
- **lsarpc reimplemented declaratively** — `LsarOpenPolicy2` and `LsarClose` now use `ndr` request/response structs (`openPolicy2Request`, `closeRequest`, `handleResponse`, `objectAttributes`) through `Invoke` instead of hand-marshalled byte slices. Public signatures are unchanged.

### How Verified

- `go build ./...`, `go vet`, and `gofmt` are clean.
- `go test ./network/dcerpc/...` passes. Crucially, the pre-existing **byte-exact** lsarpc tests (`TestOpenPolicy2_RequestMarshalling` asserting the exact 32-byte request stub, `TestClose_RoundTrip` asserting the 20-byte handle stub) pass unchanged against the declarative reimplementation, proving the NDR-produced bytes are identical to the previous hand-marshalled ones.
- New client tests: `TestInvoke_MarshalsRequestAndUnmarshalsResponse` (verifies opnum, marshalled request fields, and decoded response), `TestInvoke_NilOutSkipsResponseDecode`, and `TestInvoke_FaultIsReturned`.

### Scope of Change

- **Files:** `network/dcerpc/client/{client,client_test}.go`, `network/dcerpc/interfaces/lsarpc/{lsarpc,lsarpc_test}.go`
- `client` now imports `ndr` (no cycle: `ndr` does not import `client`).
- Behavioral changes outside the wiring: none — lsarpc emits the same bytes.

### Notes

The removed unexported `parseHandleResponse` is replaced by NDR decoding; its truncation test became `TestOpenPolicy2_ShortResponseErrors`, which checks the decoder rejects an under-length response.