### PR TITLE
[enhancement] Add srvsvc interface (NetrRemoteTOD, NetrServerGetInfo) via the declarative NDR API

### DIFF
--- a/network/dcerpc/interfaces/srvsvc/srvsvc.go
+++ b/network/dcerpc/interfaces/srvsvc/srvsvc.go
@@ -1,0 +1,140 @@
+// Package srvsvc implements a minimal client for the Server Service Remote Protocol
+// (srvsvc, [MS-SRVS]), built on the declarative network/dcerpc/ndr API.
+//
+// The calls implemented here are the ones whose NDR is fully handled by the current
+// codec: NetrRemoteTOD (a pointer to a fixed all-DWORD structure) and
+// NetrServerGetInfo level 101 (a union whose arm is a single pointer-to-structure).
+// The enumeration calls (NetrShareEnum, NetrSessionEnum) require arrays of structures
+// that themselves contain pointers, which the codec does not yet marshal with the
+// correct (after-the-array) referent ordering, so they are intentionally omitted.
+//
+// References:
+//   - [MS-SRVS] Server Service Remote Protocol:
+//     https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-srvs/accf23b0-0f57-441c-9185-43041f1b0ee9
+//   - [MS-SRVS] NetrRemoteTOD (Opnum 28):
+//     https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-srvs/6e914f10-3280-474e-81fa-71621d5c3409
+//   - [MS-SRVS] NetrServerGetInfo (Opnum 21), section 3.1.4.17
+//   - [MS-SRVS] 2.2.4.105 TIME_OF_DAY_INFO; 2.2.4.41 SERVER_INFO_101
+package srvsvc
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/client"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+)
+
+// PipeName is the named pipe (IPC$-relative) for the srvsvc interface.
+const PipeName = `\srvsvc`
+
+// Opnums for the implemented methods ([MS-SRVS] section 3.1.4).
+const (
+	OpnumNetrServerGetInfo uint16 = 21
+	OpnumNetrRemoteTOD     uint16 = 28
+)
+
+// NERR_Success is the success return value shared by these methods.
+const NERR_Success uint32 = 0x00000000
+
+// SyntaxID returns the srvsvc abstract syntax: 4b324fc8-1670-01d3-1278-5a47bf6ee188,
+// version 3.0.
+func SyntaxID() syntax.SyntaxID {
+	return syntax.SyntaxID{
+		UUID:         guid.GUID{A: 0x4b324fc8, B: 0x1670, C: 0x01d3, D: 0x1278, E: 0x5a47bf6ee188},
+		MajorVersion: 3,
+		MinorVersion: 0,
+	}
+}
+
+// TimeOfDayInfo is TIME_OF_DAY_INFO ([MS-SRVS] 2.2.4.105): twelve 32-bit fields, no
+// pointers or arrays. tod_timezone is a signed minutes-from-GMT offset on the wire.
+type TimeOfDayInfo struct {
+	Elapsedt  ndr.DWORD // seconds since 1970-01-01 00:00:00 GMT
+	Msecs     ndr.DWORD // milliseconds since system boot
+	Hours     ndr.DWORD
+	Mins      ndr.DWORD
+	Secs      ndr.DWORD
+	Hunds     ndr.DWORD // hundredths of a second
+	Timezone  ndr.DWORD // minutes from GMT (signed)
+	Tinterval ndr.DWORD // clock tick interval in 0.0001 second units
+	Day       ndr.DWORD
+	Month     ndr.DWORD
+	Year      ndr.DWORD
+	Weekday   ndr.DWORD // 0 = Sunday
+}
+
+// remoteTODRequest is the [in] parameter set of NetrRemoteTOD. ServerName is ignored
+// by the server, so a NULL unique pointer is sent.
+type remoteTODRequest struct {
+	ServerName *ndr.WSTR `ndr:"unique"`
+}
+
+func (*remoteTODRequest) Opnum() uint16 { return OpnumNetrRemoteTOD }
+
+// remoteTODResponse is the reply: a unique pointer to the structure plus the status.
+type remoteTODResponse struct {
+	Buffer    *TimeOfDayInfo `ndr:"unique"`
+	ErrorCode ndr.DWORD      `ndr:"retval"`
+}
+
+// RemoteTOD calls NetrRemoteTOD (opnum 28) and returns the server's time-of-day info.
+func RemoteTOD(rpc *client.Client) (*TimeOfDayInfo, error) {
+	var resp remoteTODResponse
+	if err := rpc.Invoke(&remoteTODRequest{}, &resp); err != nil {
+		return nil, fmt.Errorf("NetrRemoteTOD: %w", err)
+	}
+	if uint32(resp.ErrorCode) != NERR_Success {
+		return nil, fmt.Errorf("NetrRemoteTOD failed: 0x%08x", uint32(resp.ErrorCode))
+	}
+	if resp.Buffer == nil {
+		return nil, fmt.Errorf("NetrRemoteTOD: server returned a NULL buffer")
+	}
+	return resp.Buffer, nil
+}
+
+// ServerInfo101 is SERVER_INFO_101 ([MS-SRVS] 2.2.4.41).
+type ServerInfo101 struct {
+	PlatformID   ndr.DWORD
+	Name         *ndr.WSTR `ndr:"unique"`
+	VersionMajor ndr.DWORD
+	VersionMinor ndr.DWORD
+	Type         ndr.DWORD
+	Comment      *ndr.WSTR `ndr:"unique"`
+}
+
+// serverGetInfoRequest is the [in] parameter set of NetrServerGetInfo.
+type serverGetInfoRequest struct {
+	ServerName *ndr.WSTR `ndr:"unique"`
+	Level      ndr.DWORD
+}
+
+func (*serverGetInfoRequest) Opnum() uint16 { return OpnumNetrServerGetInfo }
+
+// serverGetInfo101Response models the reply when Level is 101. The [out, switch_is]
+// SERVER_INFO union is transmitted as its discriminant followed by the selected arm;
+// for level 101 the arm is a unique pointer to a SERVER_INFO_101, so the union is
+// modeled inline as Discriminant + Info, keeping the pointer's referent in the
+// walker's deferral path.
+type serverGetInfo101Response struct {
+	Discriminant ndr.DWORD
+	Info         *ServerInfo101 `ndr:"unique"`
+	ErrorCode    ndr.DWORD      `ndr:"retval"`
+}
+
+// ServerGetInfo101 calls NetrServerGetInfo (opnum 21) at level 101 and returns the
+// server's SERVER_INFO_101 (name, version, type, comment).
+func ServerGetInfo101(rpc *client.Client) (*ServerInfo101, error) {
+	var resp serverGetInfo101Response
+	if err := rpc.Invoke(&serverGetInfoRequest{Level: 101}, &resp); err != nil {
+		return nil, fmt.Errorf("NetrServerGetInfo: %w", err)
+	}
+	if uint32(resp.ErrorCode) != NERR_Success {
+		return nil, fmt.Errorf("NetrServerGetInfo failed: 0x%08x", uint32(resp.ErrorCode))
+	}
+	if resp.Info == nil {
+		return nil, fmt.Errorf("NetrServerGetInfo: server returned a NULL info pointer")
+	}
+	return resp.Info, nil
+}

--- a/network/dcerpc/interfaces/srvsvc/srvsvc_integration_test.go
+++ b/network/dcerpc/interfaces/srvsvc/srvsvc_integration_test.go
@@ -1,0 +1,109 @@
+//go:build integration
+
+// Integration test for srvsvc over the full DCE/RPC-over-SMB stack against a live
+// server. Excluded from the default build by the "integration" tag. Run with:
+//
+//	DCERPC_TEST_HOST=192.168.1.27 \
+//	DCERPC_TEST_USER=user DCERPC_TEST_PASS=user \
+//	go test -tags integration -v ./network/dcerpc/interfaces/srvsvc/
+//
+// Optional: DCERPC_TEST_DOMAIN, DCERPC_TEST_PORT (default 445).
+package srvsvc
+
+import (
+	"net"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/client"
+	dcerpcsmb "github.com/TheManticoreProject/Manticore/network/dcerpc/transport/smb"
+	smbclient "github.com/TheManticoreProject/Manticore/network/smb/smb_v10/client"
+	"github.com/TheManticoreProject/Manticore/windows/credentials"
+)
+
+func boundClient(t *testing.T) (*client.Client, func()) {
+	t.Helper()
+	host := os.Getenv("DCERPC_TEST_HOST")
+	if host == "" {
+		t.Skip("DCERPC_TEST_HOST not set; skipping live integration test")
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		t.Fatalf("DCERPC_TEST_HOST %q is not a valid IP", host)
+	}
+	port := 445
+	if p := os.Getenv("DCERPC_TEST_PORT"); p != "" {
+		n, err := strconv.Atoi(p)
+		if err != nil {
+			t.Fatalf("invalid DCERPC_TEST_PORT %q: %v", p, err)
+		}
+		port = n
+	}
+	creds, err := credentials.NewCredentials(os.Getenv("DCERPC_TEST_DOMAIN"), os.Getenv("DCERPC_TEST_USER"), os.Getenv("DCERPC_TEST_PASS"), "")
+	if err != nil {
+		t.Fatalf("NewCredentials: %v", err)
+	}
+
+	smb := smbclient.NewClientUsingTCPTransport(ip, port)
+	if err := smb.Connect(ip, port); err != nil {
+		t.Fatalf("SMB Connect: %v", err)
+	}
+	smb.NativeOS = "Unix"
+	smb.NativeLanMan = "Samba"
+	if err := smb.SessionSetup(creds); err != nil {
+		t.Fatalf("SMB SessionSetup: %v", err)
+	}
+	if err := smb.TreeConnect("IPC$"); err != nil {
+		t.Fatalf("SMB TreeConnect(IPC$): %v", err)
+	}
+
+	rpc := client.NewClient(dcerpcsmb.New(smb, PipeName))
+	if err := rpc.Bind(SyntaxID()); err != nil {
+		t.Fatalf("DCE/RPC Bind(srvsvc): %v", err)
+	}
+	cleanup := func() {
+		_ = rpc.Close()
+		_ = smb.TreeDisconnect()
+		_ = smb.Logoff()
+		_ = smb.Disconnect()
+	}
+	return rpc, cleanup
+}
+
+func TestIntegration_RemoteTOD(t *testing.T) {
+	rpc, cleanup := boundClient(t)
+	defer cleanup()
+
+	tod, err := RemoteTOD(rpc)
+	if err != nil {
+		t.Fatalf("RemoteTOD: %v", err)
+	}
+	t.Logf("server time of day: %04d-%02d-%02d %02d:%02d:%02d (weekday %d, tz %d min)",
+		tod.Year, tod.Month, tod.Day, tod.Hours, tod.Mins, tod.Secs, tod.Weekday, int32(tod.Timezone))
+	if tod.Year < 1990 || tod.Month < 1 || tod.Month > 12 || tod.Hours > 23 {
+		t.Errorf("implausible time-of-day values: %+v", tod)
+	}
+}
+
+func TestIntegration_ServerGetInfo101(t *testing.T) {
+	rpc, cleanup := boundClient(t)
+	defer cleanup()
+
+	info, err := ServerGetInfo101(rpc)
+	if err != nil {
+		t.Fatalf("ServerGetInfo101: %v", err)
+	}
+	name, comment := "", ""
+	if info.Name != nil {
+		name = string(*info.Name)
+	}
+	if info.Comment != nil {
+		comment = string(*info.Comment)
+	}
+	t.Logf("server: name=%q version=%d.%d type=0x%08x comment=%q",
+		name, info.VersionMajor, info.VersionMinor, info.Type, comment)
+	if name == "" {
+		t.Error("ServerGetInfo101 returned an empty server name")
+	}
+}

--- a/network/dcerpc/interfaces/srvsvc/srvsvc_test.go
+++ b/network/dcerpc/interfaces/srvsvc/srvsvc_test.go
@@ -1,0 +1,99 @@
+package srvsvc
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+func wstr(s string) *ndr.WSTR { w := ndr.WSTR(s); return &w }
+
+func TestRemoteTOD_RequestBytes(t *testing.T) {
+	raw, err := ndr.Request(&remoteTODRequest{})
+	if err != nil {
+		t.Fatalf("Request: %v", err)
+	}
+	// ServerName is a NULL unique pointer: a single zero referent.
+	if !bytes.Equal(raw, []byte{0, 0, 0, 0}) {
+		t.Errorf("RemoteTOD request = %x, want 00000000", raw)
+	}
+	if (&remoteTODRequest{}).Opnum() != 28 {
+		t.Errorf("opnum = %d, want 28", (&remoteTODRequest{}).Opnum())
+	}
+}
+
+func TestRemoteTOD_ResponseRoundTrip(t *testing.T) {
+	in := &remoteTODResponse{
+		Buffer:    &TimeOfDayInfo{Elapsedt: 0x66000000, Hours: 12, Mins: 34, Secs: 56, Day: 4, Month: 6, Year: 2026, Weekday: 4},
+		ErrorCode: NERR_Success,
+	}
+	raw, err := ndr.Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	// referent id (4) + ErrorCode (4) + 12x DWORD struct (48) = 56 bytes.
+	if len(raw) != 56 {
+		t.Errorf("response length = %d, want 56", len(raw))
+	}
+	var out remoteTODResponse
+	if err := ndr.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out.Buffer == nil || *out.Buffer != *in.Buffer {
+		t.Errorf("round trip: got %+v, want %+v", out.Buffer, in.Buffer)
+	}
+}
+
+func TestServerGetInfo_RequestBytes(t *testing.T) {
+	raw, err := ndr.Request(&serverGetInfoRequest{Level: 101})
+	if err != nil {
+		t.Fatalf("Request: %v", err)
+	}
+	want := []byte{0, 0, 0, 0, 0x65, 0, 0, 0} // NULL ServerName + Level 101
+	if !bytes.Equal(raw, want) {
+		t.Errorf("ServerGetInfo request = %x, want %x", raw, want)
+	}
+}
+
+func TestServerGetInfo101_ResponseRoundTrip(t *testing.T) {
+	in := &serverGetInfo101Response{
+		Discriminant: 101,
+		Info: &ServerInfo101{
+			PlatformID:   500,
+			Name:         wstr("XPBOX"),
+			VersionMajor: 5,
+			VersionMinor: 1,
+			Type:         0x00000003,
+			Comment:      wstr("hello"),
+		},
+		ErrorCode: NERR_Success,
+	}
+	raw, err := ndr.Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var out serverGetInfo101Response
+	if err := ndr.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out.Info == nil {
+		t.Fatal("Info is nil")
+	}
+	if out.Discriminant != 101 || out.Info.PlatformID != 500 || out.Info.VersionMajor != 5 || out.Info.VersionMinor != 1 || out.Info.Type != 3 {
+		t.Errorf("scalars: %+v", out.Info)
+	}
+	if out.Info.Name == nil || *out.Info.Name != "XPBOX" {
+		t.Errorf("Name = %v, want XPBOX", out.Info.Name)
+	}
+	if out.Info.Comment == nil || *out.Info.Comment != "hello" {
+		t.Errorf("Comment = %v, want hello", out.Info.Comment)
+	}
+}
+
+func TestSyntaxID(t *testing.T) {
+	s := SyntaxID()
+	if s.String() != "4b324fc8-1670-01d3-1278-5a47bf6ee188 v3.0" {
+		t.Errorf("SyntaxID = %s", s.String())
+	}
+}

--- a/network/dcerpc/ndr/marshal.go
+++ b/network/dcerpc/ndr/marshal.go
@@ -74,6 +74,7 @@ func marshalStruct(e *Encoder, rv reflect.Value, embedded bool) error {
 	// value is derived from the array length so the count and the elements cannot
 	// disagree and the caller need not set it explicitly.
 	counts := countTargets(rt, rv)
+	retvalIdx := retvalIndex(rt)
 	var deferred []func() error
 	for i := 0; i < rt.NumField(); i++ {
 		f := rt.Field(i)
@@ -83,6 +84,9 @@ func marshalStruct(e *Encoder, rv reflect.Value, embedded bool) error {
 		tag := parseTag(f.Tag.Get("ndr"))
 		if tag.skip {
 			continue
+		}
+		if i == retvalIdx {
+			continue // the RPC return value is encoded last, after deferred referents
 		}
 		if c, ok := counts[f.Name]; ok && isUintKind(rv.Field(i).Kind()) {
 			if tag.align > 0 {
@@ -114,6 +118,19 @@ func marshalStruct(e *Encoder, rv reflect.Value, embedded bool) error {
 	for _, fn := range deferred {
 		if err := fn(); err != nil {
 			return err
+		}
+	}
+	// The RPC return value follows all [out] parameters and their deferred referents.
+	if retvalIdx >= 0 {
+		f := rt.Field(retvalIdx)
+		var rdef []func() error
+		if err := marshalFieldInline(e, rv.Field(retvalIdx), parseTag(f.Tag.Get("ndr")), &rdef, embedded); err != nil {
+			return fmt.Errorf("ndr: field %s: %w", f.Name, err)
+		}
+		for _, fn := range rdef {
+			if err := fn(); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -256,6 +273,7 @@ func unmarshalStruct(d *Decoder, rv reflect.Value, embedded bool) error {
 		}
 		confCount = c
 	}
+	retvalIdx := retvalIndex(rt)
 	var deferred []func() error
 	for i := 0; i < rt.NumField(); i++ {
 		f := rt.Field(i)
@@ -265,6 +283,9 @@ func unmarshalStruct(d *Decoder, rv reflect.Value, embedded bool) error {
 		tag := parseTag(f.Tag.Get("ndr"))
 		if tag.skip {
 			continue
+		}
+		if i == retvalIdx {
+			continue // the RPC return value is decoded last, after deferred referents
 		}
 		if i == confIdx {
 			n := int(confCount)
@@ -290,6 +311,19 @@ func unmarshalStruct(d *Decoder, rv reflect.Value, embedded bool) error {
 	for _, fn := range deferred {
 		if err := fn(); err != nil {
 			return err
+		}
+	}
+	// The RPC return value follows all [out] parameters and their deferred referents.
+	if retvalIdx >= 0 {
+		f := rt.Field(retvalIdx)
+		var rdef []func() error
+		if err := unmarshalFieldInline(d, rv.Field(retvalIdx), parseTag(f.Tag.Get("ndr")), &rdef, embedded); err != nil {
+			return fmt.Errorf("ndr: field %s: %w", f.Name, err)
+		}
+		for _, fn := range rdef {
+			if err := fn(); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -500,6 +534,22 @@ func countTargets(rt reflect.Type, rv reflect.Value) map[string]uint64 {
 		}
 	}
 	return m
+}
+
+// retvalIndex returns the field index tagged `ndr:"retval"` (the RPC return value),
+// or -1. NDR places the return value after all [out] parameters and their deferred
+// referents, so the walker handles it separately from the inline fields.
+func retvalIndex(rt reflect.Type) int {
+	for i := 0; i < rt.NumField(); i++ {
+		f := rt.Field(i)
+		if f.PkgPath != "" {
+			continue
+		}
+		if parseTag(f.Tag.Get("ndr")).retval {
+			return i
+		}
+	}
+	return -1
 }
 
 func isUintKind(k reflect.Kind) bool {

--- a/network/dcerpc/ndr/retval_test.go
+++ b/network/dcerpc/ndr/retval_test.go
@@ -1,0 +1,37 @@
+package ndr
+
+import (
+	"bytes"
+	"testing"
+)
+
+// TestRetval_EncodedAfterDeferredReferents verifies a field tagged `retval` (the RPC
+// return value) is placed after the construction's deferred pointer referents, not
+// inline with the other fields.
+func TestRetval_EncodedAfterDeferredReferents(t *testing.T) {
+	type resp struct {
+		Ptr    *uint32 `ndr:"unique"`
+		Status uint32  `ndr:"retval"`
+	}
+	v := uint32(0xAABBCCDD)
+	raw, err := Marshal(&resp{Ptr: &v, Status: 0x11})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	want := []byte{
+		0x00, 0x00, 0x02, 0x00, // Ptr referent id (inline)
+		0xDD, 0xCC, 0xBB, 0xAA, // deferred *uint32 referent
+		0x11, 0x00, 0x00, 0x00, // retval, after the deferred referent
+	}
+	if !bytes.Equal(raw, want) {
+		t.Errorf("retval ordering:\n got %x\nwant %x", raw, want)
+	}
+
+	var out resp
+	if err := Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out.Ptr == nil || *out.Ptr != v || out.Status != 0x11 {
+		t.Errorf("round trip: ptr=%v status=%#x", out.Ptr, out.Status)
+	}
+}

--- a/network/dcerpc/ndr/types.go
+++ b/network/dcerpc/ndr/types.go
@@ -81,6 +81,7 @@ type fieldTag struct {
 	sizeIs     string // sibling field naming the maximum element count
 	lengthIs   string // sibling field naming the actual element count
 	align      int    // explicit alignment override (0 = default)
+	retval     bool   // RPC return value: encoded after the struct's deferred referents
 }
 
 // parseTag parses an `ndr:"..."` tag value.
@@ -108,6 +109,8 @@ func parseTag(raw string) fieldTag {
 			t.conformant = true
 		case opt == "varying":
 			t.varying = true
+		case opt == "retval":
+			t.retval = true
 		case strings.HasPrefix(opt, "size_is="):
 			t.conformant = true
 			t.sizeIs = strings.TrimPrefix(opt, "size_is=")


### PR DESCRIPTION
### Summary

Adds `network/dcerpc/interfaces/srvsvc`, the Server Service Remote Protocol ([MS-SRVS]) client, built entirely on the declarative `ndr` API (`Client.Invoke` + tagged structs). Two calls are implemented and validated live against a Windows XP SP3 target: `NetrRemoteTOD` (opnum 28) and `NetrServerGetInfo` level 101 (opnum 21). Feature work, so no issue is linked.

It also adds one NDR engine feature that these calls require (see below).

### NDR `retval` tag (engine)

DCE/RPC places a method's **return value after all `[out]` parameters and their deferred referents**, not inline. The walker previously had no way to express that, so a response with a deferred `[out]` pointer followed by a status code was mis-encoded (the status landed inline, before the referent). lsarpc never hit this because its `[out]` handle is a fixed array with no deferred referents.

The new `ndr:"retval"` tag marks the return-value field; `marshalStruct`/`unmarshalStruct` skip it in the inline pass and process it after draining deferred referents. Covered by `TestRetval_EncodedAfterDeferredReferents`.

### srvsvc

- `RemoteTOD` → `TimeOfDayInfo` (12 DWORDs).
- `ServerGetInfo101` → `ServerInfo101` (platform id, name, version, type, comment). The `[out, switch_is(Level)]` union is modeled inline as `Discriminant + Info` (a unique pointer arm), which keeps the arm's referent in the walker's deferral path.
- The enumerations (`NetrShareEnum`/`NetrSessionEnum`) are intentionally omitted: they need arrays of structs that themselves contain pointers, which the codec does not yet order correctly (referents must follow the whole array). Noted in the package doc.

### How Verified

- `go build ./...`, `go vet`, `gofmt` clean; `go test ./network/dcerpc/...` passes.
- Unit tests assert request bytes and full round-trips (including the union+strings response and the retval ordering).
- **Live against Windows XP SP3** (gated `//go:build integration`): `RemoteTOD` returned `2026-06-04 09:01:34, tz -120 (UTC+2), weekday 4`; `ServerGetInfo101` returned `name="THINKPAD-X61" version=5.1 type=0x00011003`.

### Scope of Change

- **Files:** `network/dcerpc/ndr/{types,marshal,retval_test}.go`; `network/dcerpc/interfaces/srvsvc/{srvsvc,srvsvc_test,srvsvc_integration_test}.go`
- Behavioral changes outside the new code: none (the `retval` path only affects fields carrying that tag; existing structs are unchanged).

### Notes

`retval` is split into its own commit from the srvsvc commit for reviewability. Two commits, one PR, since srvsvc is the motivating consumer and the live test validates both together.