### PR TITLE
[enhancement] Add shared [MS-DTYP] NDR base types (#420)

### DIFF
--- a/network/dcerpc/dtyp/dtyp.go
+++ b/network/dcerpc/dtyp/dtyp.go
@@ -1,0 +1,52 @@
+// Package dtyp provides the [MS-DTYP] common data types that recur across DCE/RPC
+// interfaces (lsarpc, samr, srvsvc, …) as NDR-marshallable Go types, so each interface
+// reuses one definition instead of redeclaring the same NDR-tagged structs.
+//
+// The types are driven by the declarative reflection walker in
+// network/dcerpc/ndr (struct tags, the Marshaler escape hatch where needed), so they
+// compose into request/response structs exactly like an interface's own structures. The
+// package sits beside ndr and syntax rather than inside ndr: these are data types
+// defined by a separate specification ([MS-DTYP], not the NDR transfer syntax), and
+// they are version-neutral, used by both the connectionless (v4) and connection-
+// oriented (v5) interfaces.
+//
+// References:
+//   - [MS-DTYP] Windows Data Types:
+//     https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/cca27429-5689-4a16-b2b4-9325d93e4ba2
+//   - [MS-DTYP] Appendix A: Full IDL:
+//     https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/24637f2d-238b-4d22-b44d-fe54b024280c
+//   - [C706] DCE 1.1: RPC, Chapter 14 "Transfer Syntax NDR":
+//     https://pubs.opengroup.org/onlinepubs/9629399/chap14.htm
+package dtyp
+
+// LARGE_INTEGER is the [MS-DTYP] 2.3.5 signed 64-bit integer. It is a named type rather
+// than a bare int64 so declarations read like the IDL and it carries 8-octet NDR
+// alignment ([C706] section 14.2.2).
+//
+// Reference: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/e904b1ba-f774-4203-ba1b-66485165ab1a
+type LARGE_INTEGER int64
+
+// ULARGE_INTEGER is the [MS-DTYP] 2.3.13 unsigned 64-bit integer.
+//
+// Reference: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/d7e6e5a5-6c77-4ae6-9bd5-3892b3c4641e
+type ULARGE_INTEGER uint64
+
+// LUID is the [MS-DTYP] 2.3.7 locally unique identifier: a 64-bit value split into a
+// low (unsigned) and high (signed) 32-bit part, transmitted in that order. It is used
+// pervasively for privilege identifiers (for example by LsarLookupPrivilegeValue).
+//
+// Reference: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/48cbee2a-0790-45f2-8269-931d7083b2c3
+type LUID struct {
+	LowPart  uint32
+	HighPart int32
+}
+
+// Uint64 returns the LUID as a single 64-bit value (HighPart in the upper 32 bits).
+func (l LUID) Uint64() uint64 {
+	return uint64(uint32(l.HighPart))<<32 | uint64(l.LowPart)
+}
+
+// LUIDFromUint64 splits a 64-bit value into a LUID.
+func LUIDFromUint64(v uint64) LUID {
+	return LUID{LowPart: uint32(v), HighPart: int32(v >> 32)}
+}

--- a/network/dcerpc/dtyp/dtyp_test.go
+++ b/network/dcerpc/dtyp/dtyp_test.go
@@ -1,0 +1,189 @@
+package dtyp
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+func TestLUID_RoundTrip(t *testing.T) {
+	type rec struct{ ID LUID }
+	in := &rec{ID: LUID{LowPart: 0x11223344, HighPart: -2}}
+	raw, err := ndr.Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var out rec
+	if err := ndr.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out.ID != in.ID {
+		t.Errorf("round trip: got %+v want %+v", out.ID, in.ID)
+	}
+	if got := LUIDFromUint64(in.ID.Uint64()); got != in.ID {
+		t.Errorf("Uint64 round trip: got %+v want %+v", got, in.ID)
+	}
+}
+
+func TestLargeInteger_RoundTrip(t *testing.T) {
+	type rec struct {
+		Q LARGE_INTEGER
+		U ULARGE_INTEGER
+	}
+	in := &rec{Q: -123456789, U: 0xDEADBEEFCAFE}
+	raw, err := ndr.Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var out rec
+	if err := ndr.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out != *in {
+		t.Errorf("round trip: got %+v want %+v", out, *in)
+	}
+}
+
+func TestRPC_SID_GoldenAndRoundTrip(t *testing.T) {
+	sid, err := ParseSID("S-1-5-21-1-2-3")
+	if err != nil {
+		t.Fatalf("ParseSID: %v", err)
+	}
+	raw, err := ndr.Marshal(&sid)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	want := []byte{
+		0x04, 0, 0, 0, // hoisted maximum_count (SubAuthorityCount)
+		0x01,                         // Revision
+		0x04,                         // SubAuthorityCount (derived from slice len)
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x05, // IdentifierAuthority (6-octet big-endian = 5)
+		0x15, 0, 0, 0, // SubAuthority[0] = 21
+		0x01, 0, 0, 0, // SubAuthority[1] = 1
+		0x02, 0, 0, 0, // SubAuthority[2] = 2
+		0x03, 0, 0, 0, // SubAuthority[3] = 3
+	}
+	if !bytes.Equal(raw, want) {
+		t.Errorf("RPC_SID:\n got %x\nwant %x", raw, want)
+	}
+	var out RPC_SID
+	if err := ndr.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got := out.String(); got != "S-1-5-21-1-2-3" {
+		t.Errorf("String: got %q want %q", got, "S-1-5-21-1-2-3")
+	}
+}
+
+func TestRPC_UNICODE_STRING_GoldenAndRoundTrip(t *testing.T) {
+	u := NewUnicodeString("Hi")
+	if u.Length != 4 || u.MaximumLength != 4 {
+		t.Fatalf("NewUnicodeString counts: got Length=%d MaximumLength=%d want 4/4", u.Length, u.MaximumLength)
+	}
+	raw, err := ndr.Marshal(&u)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	want := []byte{
+		0x04, 0x00, // Length (bytes)
+		0x04, 0x00, // MaximumLength (bytes)
+		0x00, 0x00, 0x02, 0x00, // Buffer referent id
+		0x02, 0, 0, 0, // buffer maximum_count (chars)
+		0x00, 0, 0, 0, // offset
+		0x02, 0, 0, 0, // actual_count (chars)
+		0x48, 0x00, 0x69, 0x00, // 'H', 'i'
+	}
+	if !bytes.Equal(raw, want) {
+		t.Errorf("RPC_UNICODE_STRING:\n got %x\nwant %x", raw, want)
+	}
+	var out RPC_UNICODE_STRING
+	if err := ndr.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got := out.String(); got != "Hi" {
+		t.Errorf("String: got %q want %q", got, "Hi")
+	}
+}
+
+func TestRPC_UNICODE_STRING_Empty(t *testing.T) {
+	u := NewUnicodeString("")
+	raw, err := ndr.Marshal(&u)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	// Length=0, MaximumLength=0, Buffer=NULL referent.
+	want := []byte{0, 0, 0, 0, 0, 0, 0, 0}
+	if !bytes.Equal(raw, want) {
+		t.Errorf("empty RPC_UNICODE_STRING:\n got %x\nwant %x", raw, want)
+	}
+	var out RPC_UNICODE_STRING
+	if err := ndr.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got := out.String(); got != "" {
+		t.Errorf("String: got %q want empty", got)
+	}
+}
+
+// TestArrayOfUnicodeStrings exercises the #419 interaction: an array of structs each
+// carrying a [unique] pointer to a conformant-varying buffer. Each element's buffer
+// must be deferred past the whole array, which only round-trips with the array referent
+// ordering fix in place.
+func TestArrayOfUnicodeStrings(t *testing.T) {
+	type rec struct {
+		Names []RPC_UNICODE_STRING `ndr:"conformant"`
+	}
+	in := &rec{Names: []RPC_UNICODE_STRING{
+		NewUnicodeString("alice"),
+		NewUnicodeString("bob"),
+	}}
+	raw, err := ndr.Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var out rec
+	if err := ndr.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if len(out.Names) != 2 || out.Names[0].String() != "alice" || out.Names[1].String() != "bob" {
+		t.Errorf("round trip: got %q,%q", out.Names[0].String(), out.Names[1].String())
+	}
+}
+
+func TestArrayOfUnicodeStringPointers(t *testing.T) {
+	type rec struct {
+		Names []*RPC_UNICODE_STRING `ndr:"conformant"`
+	}
+	a := NewUnicodeString("foo")
+	b := NewUnicodeString("barbaz")
+	in := &rec{Names: []*RPC_UNICODE_STRING{&a, &b}}
+	raw, err := ndr.Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var out rec
+	if err := ndr.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if len(out.Names) != 2 || out.Names[0] == nil || out.Names[1] == nil ||
+		out.Names[0].String() != "foo" || out.Names[1].String() != "barbaz" {
+		t.Errorf("round trip mismatch: %+v", out.Names)
+	}
+}
+
+func TestParseSID_Errors(t *testing.T) {
+	for _, s := range []string{"", "1-5-21", "S-x-5", "S-1-5-" + "9999999999999999999999"} {
+		if _, err := ParseSID(s); err == nil {
+			t.Errorf("ParseSID(%q): expected error", s)
+		}
+	}
+	// Round-trip a hex authority.
+	sid, err := ParseSID("S-1-0x10000000000-1")
+	if err != nil {
+		t.Fatalf("ParseSID hex authority: %v", err)
+	}
+	if got := sid.String(); got != "S-1-0x10000000000-1" {
+		t.Errorf("hex authority round trip: got %q", got)
+	}
+}

--- a/network/dcerpc/dtyp/rpc_sid.go
+++ b/network/dcerpc/dtyp/rpc_sid.go
@@ -1,0 +1,92 @@
+package dtyp
+
+import (
+	"encoding/binary"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// RPC_SID is the [MS-DTYP] 2.4.2.3 marshallable security identifier. The SubAuthority
+// member is a conformant array whose element count is given by SubAuthorityCount, so
+// NDR hoists its maximum_count to the front of the structure ([C706] section 14.3.3.1);
+// the walker derives both the hoisted count and SubAuthorityCount from the slice length,
+// so callers set only SubAuthority (or use ParseSID).
+//
+// IdentifierAuthority is a 6-octet big-endian value transmitted verbatim ([MS-DTYP]
+// 2.4.1 RPC_SID_IDENTIFIER_AUTHORITY). SubAuthorityCount is capped at 15 by the spec.
+//
+// Reference: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/5cb97814-a1c2-4215-b7dc-76d1f4bfad01
+type RPC_SID struct {
+	Revision            uint8
+	SubAuthorityCount   uint8
+	IdentifierAuthority [6]byte
+	SubAuthority        []uint32 `ndr:"conformant,size_is=SubAuthorityCount"`
+}
+
+// authority returns the 48-bit identifier authority as a single value.
+func (s RPC_SID) authority() uint64 {
+	var b [8]byte
+	copy(b[2:], s.IdentifierAuthority[:])
+	return binary.BigEndian.Uint64(b[:])
+}
+
+// String renders the SID in the standard "S-R-I-S1-S2-…" textual form ([MS-DTYP]
+// 2.4.2.1 SID String Format): authorities below 2^32 are decimal, larger ones hex.
+func (s RPC_SID) String() string {
+	auth := s.authority()
+	var b strings.Builder
+	b.WriteString("S-")
+	b.WriteString(strconv.FormatUint(uint64(s.Revision), 10))
+	b.WriteString("-")
+	if auth >= 1<<32 {
+		b.WriteString("0x")
+		b.WriteString(strconv.FormatUint(auth, 16))
+	} else {
+		b.WriteString(strconv.FormatUint(auth, 10))
+	}
+	for _, sub := range s.SubAuthority {
+		b.WriteString("-")
+		b.WriteString(strconv.FormatUint(uint64(sub), 10))
+	}
+	return b.String()
+}
+
+// ParseSID parses a textual SID ("S-1-5-21-…") into an RPC_SID, setting Revision,
+// IdentifierAuthority, and the SubAuthority array (SubAuthorityCount is derived on
+// marshal). The identifier authority may be decimal or 0x-prefixed hexadecimal.
+func ParseSID(s string) (RPC_SID, error) {
+	parts := strings.Split(s, "-")
+	if len(parts) < 3 || parts[0] != "S" {
+		return RPC_SID{}, fmt.Errorf("dtyp: invalid SID %q", s)
+	}
+	rev, err := strconv.ParseUint(parts[1], 10, 8)
+	if err != nil {
+		return RPC_SID{}, fmt.Errorf("dtyp: invalid SID revision in %q: %w", s, err)
+	}
+	var auth uint64
+	if strings.HasPrefix(parts[2], "0x") || strings.HasPrefix(parts[2], "0X") {
+		auth, err = strconv.ParseUint(parts[2][2:], 16, 48)
+	} else {
+		auth, err = strconv.ParseUint(parts[2], 10, 48)
+	}
+	if err != nil {
+		return RPC_SID{}, fmt.Errorf("dtyp: invalid SID authority in %q: %w", s, err)
+	}
+	subs := parts[3:]
+	if len(subs) > 15 {
+		return RPC_SID{}, fmt.Errorf("dtyp: SID %q has %d sub-authorities, max 15", s, len(subs))
+	}
+	sid := RPC_SID{Revision: uint8(rev), SubAuthorityCount: uint8(len(subs))}
+	var ab [8]byte
+	binary.BigEndian.PutUint64(ab[:], auth)
+	copy(sid.IdentifierAuthority[:], ab[2:])
+	for _, p := range subs {
+		v, err := strconv.ParseUint(p, 10, 32)
+		if err != nil {
+			return RPC_SID{}, fmt.Errorf("dtyp: invalid SID sub-authority %q in %q: %w", p, s, err)
+		}
+		sid.SubAuthority = append(sid.SubAuthority, uint32(v))
+	}
+	return sid, nil
+}

--- a/network/dcerpc/dtyp/rpc_unicode_string.go
+++ b/network/dcerpc/dtyp/rpc_unicode_string.go
@@ -1,0 +1,47 @@
+package dtyp
+
+import "unicode/utf16"
+
+// RPC_UNICODE_STRING is the [MS-DTYP] 2.3.10 counted Unicode string. It is the single
+// most common string carrier in the LSA/SAMR interfaces and, unlike a bare NDR wide
+// string, cannot be modeled by ndr.WSTR because of a byte-vs-char gotcha:
+//
+//   - Length and MaximumLength are counts in BYTES (each must be even), whereas
+//   - Buffer is a [unique] pointer to a conformant-varying array of wchar whose
+//     maximum_count is MaximumLength/2 and actual_count is Length/2 — counts in CHARS.
+//
+// The buffer carries no NUL terminator (it is a [size_is/length_is] array, not an NDR
+// [string]). Modeling Buffer as a []uint16 tagged "unique,varying" lets the walker emit
+// the referent id inline and the char-counted conformant-varying body deferred, so the
+// buffers of an array of RPC_UNICODE_STRING are correctly emitted after the whole array
+// (see issue #419). Use NewUnicodeString to set the byte counts and buffer together.
+//
+// Reference: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/94a16bb6-c610-4cb9-8db6-26f15f560061
+type RPC_UNICODE_STRING struct {
+	Length        uint16 // length of the string in bytes, excluding any terminator
+	MaximumLength uint16 // size of Buffer in bytes
+	Buffer        []uint16 `ndr:"unique,varying"`
+}
+
+// NewUnicodeString builds an RPC_UNICODE_STRING from a Go string, encoding it to UTF-16
+// and setting Length and MaximumLength to the byte count (2 per code unit). An empty
+// string yields a zero-length value with a NULL Buffer, matching the Windows
+// representation of an empty counted string.
+func NewUnicodeString(s string) RPC_UNICODE_STRING {
+	if s == "" {
+		return RPC_UNICODE_STRING{}
+	}
+	units := utf16.Encode([]rune(s))
+	n := uint16(len(units) * 2)
+	return RPC_UNICODE_STRING{Length: n, MaximumLength: n, Buffer: units}
+}
+
+// String decodes the Buffer (truncated to Length/2 code units, as Length governs the
+// valid portion) back to a Go string.
+func (u RPC_UNICODE_STRING) String() string {
+	units := u.Buffer
+	if n := int(u.Length / 2); n < len(units) {
+		units = units[:n]
+	}
+	return string(utf16.Decode(units))
+}


### PR DESCRIPTION
### Linked Issue
`Closes #420`

> Stacked on #422 (#419). The array-of-`RPC_UNICODE_STRING` tests depend on the array referent-ordering fix, so this PR is based on that branch; GitHub will retarget it to `main` once #422 merges.

### Root Cause
The [MS-DTYP] common data types `RPC_SID`, `RPC_UNICODE_STRING`, `LUID`, and `LARGE_INTEGER` are needed by lsarpc/samr/srvsvc and every other concrete interface, but no shared package defined them, so each interface would have to redeclare the same NDR-tagged structs. `RPC_UNICODE_STRING` in particular cannot be modeled by a bare wide string because of a byte-vs-char mismatch ([MS-DTYP] 2.3.10): `Length`/`MaximumLength` are byte counts while the `Buffer` conformant-varying array is counted in chars.

### Fix Description
Add `network/dcerpc/dtyp`, a leaf package beside `ndr` and `syntax` (the types are defined by a separate spec and are version-neutral across v4/v5, so they do not belong inside the NDR transfer-syntax package). It exports:
- `RPC_SID` — embedded conformant `SubAuthority` array with the count derived from the slice length; 6-octet big-endian identifier authority; `ParseSID`/`String` helpers.
- `RPC_UNICODE_STRING` — `Buffer` modeled as `[]uint16` tagged `unique,varying`, so the walker emits the referent id inline and the char-counted conformant-varying body deferred (correct inside arrays, per #419). `NewUnicodeString` sets the byte counts and buffer together; `String` decodes.
- `LUID` (with `Uint64`/`LUIDFromUint64`), `LARGE_INTEGER`, `ULARGE_INTEGER`.

### How Verified
- **Tests:** `network/dcerpc/dtyp/dtyp_test.go` — golden-byte vectors for `RPC_SID` (`S-1-5-21-1-2-3`) and `RPC_UNICODE_STRING` ("Hi" and empty), round-trips for `LUID`/`LARGE_INTEGER`, SID parse/format incl. a hex identifier authority and error cases, and — exercising the #419 interaction — round-trips of `[]RPC_UNICODE_STRING` and `[]*RPC_UNICODE_STRING`.
- `go vet` and `go build ./...` clean.

### Test Coverage
**Added:** `dtyp_test.go` — `TestLUID_RoundTrip`, `TestLargeInteger_RoundTrip`, `TestRPC_SID_GoldenAndRoundTrip`, `TestRPC_UNICODE_STRING_GoldenAndRoundTrip`, `TestRPC_UNICODE_STRING_Empty`, `TestArrayOfUnicodeStrings`, `TestArrayOfUnicodeStringPointers`, `TestParseSID_Errors`.

### Scope of Change
- **Files changed:** new `network/dcerpc/dtyp/{dtyp,rpc_sid,rpc_unicode_string,dtyp_test}.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none (new package only)

### Notes
Unblocks the Tier B lsarpc methods tracked in #421. `MaximumLength`/`Length` model the common case where the full buffer is transmitted (`maximum_count == actual_count`); a reserved-capacity buffer is not represented, which matches client usage.
