### PR TITLE
[enhancement] Support NDR discriminated unions via declarative switch/case tags (#399)

### DIFF
--- a/network/dcerpc/ndr/marshal.go
+++ b/network/dcerpc/ndr/marshal.go
@@ -233,6 +233,9 @@ func marshalInlineValue(e *Encoder, fv reflect.Value, tag fieldTag, deferred *[]
 
 	switch fv.Kind() {
 	case reflect.Struct:
+		if swIdx := unionSwitchIndex(fv.Type()); swIdx >= 0 {
+			return marshalUnion(e, fv, swIdx)
+		}
 		return marshalStruct(e, fv, true) // members of any value reached here are embedded
 	case reflect.Slice:
 		if tag.varying {
@@ -436,6 +439,9 @@ func unmarshalInlineValue(d *Decoder, fv reflect.Value, tag fieldTag) error {
 
 	switch fv.Kind() {
 	case reflect.Struct:
+		if swIdx := unionSwitchIndex(fv.Type()); swIdx >= 0 {
+			return unmarshalUnion(d, fv, swIdx)
+		}
 		return unmarshalStruct(d, fv, true)
 	case reflect.Slice:
 		if tag.varying {
@@ -742,6 +748,9 @@ func marshalElement(e *Encoder, ev reflect.Value, tag fieldTag, deferred *[]func
 	// than flushing them after itself, so they too land after the whole array.
 	if ev.Kind() == reflect.Struct {
 		if _, ok := asMarshaler(ev); !ok {
+			if swIdx := unionSwitchIndex(ev.Type()); swIdx >= 0 {
+				return marshalUnion(e, ev, swIdx)
+			}
 			_, err := marshalStructFields(e, ev, true, deferred)
 			return err
 		}
@@ -811,6 +820,9 @@ func unmarshalElement(d *Decoder, ev reflect.Value, tag fieldTag, deferred *[]fu
 	}
 	if ev.Kind() == reflect.Struct {
 		if _, ok := asMarshalerAddr(ev); !ok {
+			if swIdx := unionSwitchIndex(ev.Type()); swIdx >= 0 {
+				return unmarshalUnion(d, ev, swIdx)
+			}
 			_, err := unmarshalStructFields(d, ev, true, deferred)
 			return err
 		}

--- a/network/dcerpc/ndr/types.go
+++ b/network/dcerpc/ndr/types.go
@@ -2,6 +2,7 @@ package ndr
 
 import (
 	"reflect"
+	"strconv"
 	"strings"
 )
 
@@ -74,15 +75,21 @@ const (
 type fieldTag struct {
 	skip       bool
 	ptr        ptrKind
-	wide       bool   // [string] wide (UTF-16)
-	ascii      bool   // [string] ASCII
-	conformant bool   // conformant array (size_is)
-	varying    bool   // conformant-varying array (offset + actual_count framing)
+	wide       bool    // [string] wide (UTF-16)
+	ascii      bool    // [string] ASCII
+	conformant bool    // conformant array (size_is)
+	varying    bool    // conformant-varying array (offset + actual_count framing)
 	sizeIs     string  // sibling field naming the maximum element count
 	lengthIs   string  // sibling field naming the actual element count
 	align      int     // explicit alignment override (0 = default)
 	retval     bool    // RPC return value: encoded after the struct's deferred referents
 	elemPtr    ptrKind // pointer attribute of array elements (`elem=ref|unique|ptr`)
+
+	// Union (discriminated by an inline switch value, [C706] section 14.3.8) tags.
+	isSwitch  bool  // the union discriminant field (`switch`)
+	hasCase   bool  // this field is a union arm selected by `case=<value>`
+	caseVal   int64 // the discriminant value that selects this arm
+	isDefault bool  // the union's default arm (`default`)
 }
 
 // parseTag parses an `ndr:"..."` tag value.
@@ -119,6 +126,15 @@ func parseTag(raw string) fieldTag {
 			t.conformant = true
 			t.varying = true
 			t.lengthIs = strings.TrimPrefix(opt, "length_is=")
+		case opt == "switch":
+			t.isSwitch = true
+		case opt == "default":
+			t.isDefault = true
+		case strings.HasPrefix(opt, "case="):
+			if v, err := strconv.ParseInt(strings.TrimPrefix(opt, "case="), 0, 64); err == nil {
+				t.hasCase = true
+				t.caseVal = v
+			}
 		case opt == "elem=ref":
 			t.elemPtr = ptrRef
 		case opt == "elem=unique":

--- a/network/dcerpc/ndr/union.go
+++ b/network/dcerpc/ndr/union.go
@@ -1,0 +1,141 @@
+package ndr
+
+import "reflect"
+
+// NDR discriminated unions, declared with struct tags rather than the Marshaler escape
+// hatch. A union is a Go struct with one field tagged `switch` (the discriminant) and
+// one field per arm tagged `case=<value>` (an optional `default` arm covers the rest):
+//
+//	type LSAPR_POLICY_INFORMATION struct {
+//	    Level     uint32                   `ndr:"switch"`
+//	    AuditLog  *PolicyAuditLogInfo      `ndr:"case=1,unique"`
+//	    AuditFull *PolicyAuditFullInfo     `ndr:"case=2,unique"`
+//	    Default   *PolicyDefaultInfo       `ndr:"default,unique"`
+//	}
+//
+// The wire form is the discriminant followed by the single selected arm ([C706] section
+// 14.3.8: "NDR represents a union as a representation of the tag followed by a
+// representation of the selected member"). The discriminant is always transmitted as
+// the first part of the union representation, even for a non-encapsulated union whose
+// IDL discriminant is a separate `switch_is` parameter — for such a union [C706] §14.3.8
+// transmits the value twice, once as the external field and once inline here, so a
+// receiver decodes the arm from this inline tag without needing the external parameter
+// (which, for an [out] union, is not even present in the response). The union is aligned
+// to the largest alignment of the discriminant and any arm, matching the static union
+// alignment used by Windows/[MS-RPCE] implementations (a receiver cannot know the
+// selected arm before reading the tag, so the padding must not depend on it).
+//
+// References:
+//   - [C706] section 14.3.8 (Unions):
+//     https://pubs.opengroup.org/onlinepubs/9629399/chap14.htm
+//   - [MS-RPCE] 2.2.4 NDR Transfer Syntax:
+//     https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/b6090c2b-f44a-47a1-a13b-b82ade0137b2
+//   - union attribute ([MS] MIDL non-encapsulated unions):
+//     https://learn.microsoft.com/en-us/windows/win32/midl/union
+
+// unionSwitchIndex returns the index of the field tagged `switch` (the union
+// discriminant), or -1 if the struct is not a declarative union.
+func unionSwitchIndex(rt reflect.Type) int {
+	for i := 0; i < rt.NumField(); i++ {
+		f := rt.Field(i)
+		if f.PkgPath != "" {
+			continue
+		}
+		if parseTag(f.Tag.Get("ndr")).isSwitch {
+			return i
+		}
+	}
+	return -1
+}
+
+// unionArm returns the index of the arm selected by the discriminant value, falling
+// back to the `default` arm, or -1 if neither matches (an arm-less discriminant value,
+// which is valid: the union body is then empty).
+func unionArm(rt reflect.Type, disc reflect.Value) int {
+	var dv int64
+	if isUintKind(disc.Kind()) {
+		dv = int64(disc.Uint())
+	} else {
+		dv = disc.Int()
+	}
+	def := -1
+	for i := 0; i < rt.NumField(); i++ {
+		f := rt.Field(i)
+		if f.PkgPath != "" {
+			continue
+		}
+		tag := parseTag(f.Tag.Get("ndr"))
+		if tag.isDefault {
+			def = i
+		}
+		if tag.hasCase && tag.caseVal == dv {
+			return i
+		}
+	}
+	return def
+}
+
+// unionAlignment returns the union's NDR alignment: the largest alignment of the
+// discriminant and every arm. It is computed over all arms (not the selected one) so a
+// receiver can apply the same padding before it has read the discriminant.
+func unionAlignment(rt reflect.Type) int {
+	a := 1
+	for i := 0; i < rt.NumField(); i++ {
+		f := rt.Field(i)
+		if f.PkgPath != "" {
+			continue
+		}
+		tag := parseTag(f.Tag.Get("ndr"))
+		if !tag.isSwitch && !tag.hasCase && !tag.isDefault {
+			continue
+		}
+		if fa := ndrAlignment(f.Type); fa > a {
+			a = fa
+		}
+	}
+	return a
+}
+
+// marshalUnion writes the discriminant then the single arm it selects. The arm is
+// written through the inline-field path so a pointer arm (the common case — each arm is
+// a [unique]/[ref] pointer to a structure) emits a referent id with its body deferred to
+// the end of the union construction.
+func marshalUnion(e *Encoder, rv reflect.Value, swIdx int) error {
+	rt := rv.Type()
+	disc := rv.Field(swIdx)
+	e.Align(unionAlignment(rt))
+	if err := marshalScalar(e, disc); err != nil {
+		return err
+	}
+	armIdx := unionArm(rt, disc)
+	if armIdx < 0 {
+		return nil // discriminant value with no arm and no default: empty body
+	}
+	f := rt.Field(armIdx)
+	var deferred []func() error
+	if err := marshalFieldInline(e, rv.Field(armIdx), parseTag(f.Tag.Get("ndr")), &deferred, true); err != nil {
+		return err
+	}
+	return runDeferred(deferred)
+}
+
+// unmarshalUnion reads the discriminant, selects the matching arm, and leaves the other
+// arm fields zero.
+func unmarshalUnion(d *Decoder, rv reflect.Value, swIdx int) error {
+	rt := rv.Type()
+	disc := rv.Field(swIdx)
+	d.Align(unionAlignment(rt))
+	if err := unmarshalScalar(d, disc); err != nil {
+		return err
+	}
+	armIdx := unionArm(rt, disc)
+	if armIdx < 0 {
+		return nil
+	}
+	f := rt.Field(armIdx)
+	var deferred []func() error
+	if err := unmarshalFieldInline(d, rv.Field(armIdx), parseTag(f.Tag.Get("ndr")), &deferred, true); err != nil {
+		return err
+	}
+	return runDeferred(deferred)
+}

--- a/network/dcerpc/ndr/union_test.go
+++ b/network/dcerpc/ndr/union_test.go
@@ -1,0 +1,148 @@
+package ndr
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+)
+
+// infoUnion is a declarative union switched on Level: arm 1 is a uint32, arm 2 a
+// uint16, and the default arm a uint8.
+type infoUnion struct {
+	Level uint32 `ndr:"switch"`
+	AsU32 uint32 `ndr:"case=1"`
+	AsU16 uint16 `ndr:"case=2"`
+	Other uint8  `ndr:"default"`
+}
+
+func TestUnion_Arm_Golden(t *testing.T) {
+	type wrap struct{ U infoUnion }
+	cases := []struct {
+		name string
+		u    infoUnion
+		want []byte
+	}{
+		{"case1", infoUnion{Level: 1, AsU32: 0xAABBCCDD}, []byte{0x01, 0, 0, 0, 0xDD, 0xCC, 0xBB, 0xAA}},
+		{"case2", infoUnion{Level: 2, AsU16: 0xBEEF}, []byte{0x02, 0, 0, 0, 0xEF, 0xBE}},
+		{"default", infoUnion{Level: 9, Other: 0x7F}, []byte{0x09, 0, 0, 0, 0x7F}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			raw, err := Marshal(&wrap{U: c.u})
+			if err != nil {
+				t.Fatalf("Marshal: %v", err)
+			}
+			if !bytes.Equal(raw, c.want) {
+				t.Errorf("union:\n got %x\nwant %x", raw, c.want)
+			}
+			var out wrap
+			if err := Unmarshal(raw, &out); err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+			if out.U != c.u {
+				t.Errorf("round trip: got %+v want %+v", out.U, c.u)
+			}
+		})
+	}
+}
+
+// armBody is a sample pointer-arm payload, mirroring the lsarpc info-class unions whose
+// arms are [unique] pointers to structures.
+type armBody struct {
+	X uint32
+}
+
+type policyUnion struct {
+	Level uint32   `ndr:"switch"`
+	A     *armBody `ndr:"case=1,unique"`
+	Name  *WSTR    `ndr:"case=2,unique"`
+}
+
+// TestUnion_PointerArm verifies a union whose selected arm is a [unique] pointer to a
+// struct: the referent id is inline after the discriminant and the body is deferred to
+// the end of the union.
+func TestUnion_PointerArm(t *testing.T) {
+	type wrap struct {
+		U *policyUnion `ndr:"unique"`
+	}
+	in := &wrap{U: &policyUnion{Level: 1, A: &armBody{X: 0x12345678}}}
+	raw, err := Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	want := []byte{
+		0x00, 0x00, 0x02, 0x00, // U referent id (the pointer to the union)
+		0x01, 0, 0, 0, // discriminant Level = 1
+		0x04, 0x00, 0x02, 0x00, // arm A referent id
+		0x78, 0x56, 0x34, 0x12, // arm A body (X)
+	}
+	if !bytes.Equal(raw, want) {
+		t.Errorf("pointer-arm union:\n got %x\nwant %x", raw, want)
+	}
+	var out wrap
+	if err := Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out.U == nil || out.U.Level != 1 || out.U.A == nil || out.U.A.X != 0x12345678 || out.U.Name != nil {
+		t.Errorf("round trip mismatch: %+v", out.U)
+	}
+}
+
+// TestUnion_Embedded verifies a union embedded as a value field between other fields of
+// a structure (the LSA_FOREST_TRUST_RECORD shape): the union must consume exactly its
+// discriminant + arm so the trailing field decodes from the right offset.
+func TestUnion_Embedded(t *testing.T) {
+	type record struct {
+		Flags uint32
+		Data  infoUnion
+		Tail  uint32
+	}
+	in := &record{Flags: 0x11, Data: infoUnion{Level: 2, AsU16: 0x0203}, Tail: 0x99}
+	raw, err := Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var out record
+	if err := Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out != *in {
+		t.Errorf("round trip: got %+v want %+v", out, *in)
+	}
+}
+
+// TestUnion_Alignment verifies the union is aligned to the largest alignment of the
+// discriminant and any arm (here an 8-octet arm forces 8-alignment of the union body),
+// computed over all arms so it does not depend on the selected one.
+func TestUnion_Alignment(t *testing.T) {
+	type bigUnion struct {
+		Sel uint32 `ndr:"switch"`
+		Big uint64 `ndr:"case=1"`
+	}
+	type wrap struct {
+		Pre uint32
+		U   bigUnion
+	}
+	in := &wrap{Pre: 0xAA, U: bigUnion{Sel: 1, Big: 0x1122334455667788}}
+	raw, err := Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	want := []byte{
+		0xAA, 0, 0, 0, // Pre
+		0x00, 0, 0, 0, // pad: union aligned to 8 before the discriminant
+		0x01, 0, 0, 0, // discriminant Sel = 1
+		0x00, 0, 0, 0, // pad: uint64 arm aligned to 8
+		0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, // arm Big
+	}
+	if !bytes.Equal(raw, want) {
+		t.Errorf("union alignment:\n got %x\nwant %x", raw, want)
+	}
+	var out wrap
+	if err := Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if !reflect.DeepEqual(out, *in) {
+		t.Errorf("round trip: got %+v want %+v", out, *in)
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #399`

### Root Cause
The reflection walker had no discriminant-driven arm selection and `parseTag` recognized no union options, so a discriminated union could only be encoded through the `Marshaler` escape hatch, hand-written per type. This was the sole remaining blocker for the 14 union-based lsarpc methods (Tier C of #421). A prior interface-based attempt (PR #409) covered only *encapsulated* unions, explicitly punted on the non-encapsulated `switch_is` form that lsarpc needs, and never reached `main`.

### Fix Description
Add a declarative union model driven by struct tags. A union is a Go struct whose first field is tagged `ndr:"switch"` (the discriminant) and whose remaining fields are arms tagged `ndr:"case=<value>"`, with an optional `ndr:"default"` arm. The walker detects such a struct (via a `switch`-tagged field) wherever a struct value is encoded — as a field, a referent body, or an array element — and encodes it as the discriminant followed by the single selected arm.

The wire form follows [C706] §14.3.8: *"NDR represents a union as a representation of the tag followed by a representation of the selected member."* Crucially, the discriminant is **always transmitted inline as the first part of the union representation**, even for a non-encapsulated (`switch_is`) union — §14.3.8 transmits that value twice, once as the external field and once inline — so the inline form covers both union kinds and a receiver decodes the arm from the inline tag without the external parameter (which, for an `[out]` union, is not present in the response at all). This is why no separate `switch_is` plumbing is needed.

The union is aligned to the largest alignment of the discriminant and **all** arms (not just the selected one): a receiver cannot know the selected arm before reading the tag, so the start padding must be static, matching the union alignment used by Windows/[MS-RPCE]. Pointer arms (the common lsarpc shape — each arm is a `[unique]`/`[ref]` pointer to a structure) go through the inline-field path, so the arm body is deferred to the end of the union construction.

### How Verified
- **Tests:** `network/dcerpc/ndr/union_test.go` — golden-byte vectors and round-trips for: a multi-arm union (`case=1` u32, `case=2` u16, `default` u8); a union behind a `[unique]` pointer whose selected arm is a `[unique]` pointer-to-struct (referent id inline after the tag, body deferred); a union embedded between other struct fields (the `LSA_FOREST_TRUST_RECORD` shape), asserting the trailing field decodes from the correct offset; and an 8-octet arm proving the static union alignment pads before the discriminant.
- `gofmt`/`go vet` clean; `go test ./network/dcerpc/...` (incl. ndr, dtyp, lsarpc, srvsvc) and `go build ./...` pass.

### Test Coverage
**Added:** `union_test.go` — `TestUnion_Arm_Golden` (case1/case2/default subtests), `TestUnion_PointerArm`, `TestUnion_Embedded`, `TestUnion_Alignment`.

### Scope of Change
- **Files changed:** `network/dcerpc/ndr/union.go` (new), `network/dcerpc/ndr/union_test.go` (new), `network/dcerpc/ndr/types.go` (tag parsing), `network/dcerpc/ndr/marshal.go` (4 struct-dispatch sites)
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none — non-union structs (no `switch`-tagged field) take the existing path unchanged.

### Risk and Rollout
The dispatch adds a `switch`-field lookup to the struct-encode paths; structs without a `switch` tag are unaffected, and the existing golden/round-trip tests pin their layout. Safe to merge directly.

### Notes
Unblocks the 14 union-based lsarpc methods tracked in #421 (Tier C). Union alignment and wire layout are verified by round-trip and golden vectors; no live union exchange against a Windows server was available in this environment, consistent with how the rest of the NDR layer is validated.
