### PR TITLE
[bugfix] Fix RPC_UNICODE_STRING and NDR pointer/struct/union wire layout (#426)

### DIFF
--- a/network/dcerpc/ndr/marshal.go
+++ b/network/dcerpc/ndr/marshal.go
@@ -95,6 +95,11 @@ func marshalStruct(e *Encoder, rv reflect.Value, embedded bool) error {
 // than marshalStruct ignore it.
 func marshalStructFields(e *Encoder, rv reflect.Value, embedded bool, deferred *[]func() error) (int, error) {
 	rt := rv.Type()
+	// A structure is aligned to the largest alignment of any of its members before its
+	// representation ([C706] section 14.2.2). The first member self-aligns to its own
+	// size, which is insufficient when a later member is wider (e.g. RPC_UNICODE_STRING,
+	// whose Buffer pointer makes it 4-aligned, following a 2-byte discriminant).
+	e.Align(ndrAlignment(rt))
 	confIdx := embeddedConformantIndex(rt, rv)
 	if confIdx >= 0 {
 		e.Align(conformantArrayAlignment(rv.Field(confIdx).Type().Elem()))
@@ -197,12 +202,19 @@ func marshalFieldInline(e *Encoder, fv reflect.Value, tag fieldTag, deferred *[]
 			return nil
 		}
 		e.WriteUint32(e.nextReferent())
+		// A top-level [unique]/[full] pointer parameter marshals its referent in place,
+		// immediately after the referent id; only an embedded pointer defers the body to
+		// the end of the enclosing construction ([C706] section 14.3.10, and observed on
+		// the wire for LSA [out] parameters such as LsarLookupSids ReferencedDomains).
+		if !embedded {
+			return marshalReferentBody(e, fv, tag)
+		}
 		body := fv
 		*deferred = append(*deferred, func() error { return marshalReferentBody(e, body, tag) })
 		return nil
 	}
 
-	return marshalInlineValue(e, fv, tag, deferred)
+	return marshalInlineValue(e, fv, tag, deferred, embedded)
 }
 
 // marshalReferentBody marshals the representation a pointer refers to.
@@ -210,13 +222,14 @@ func marshalReferentBody(e *Encoder, fv reflect.Value, tag fieldTag) error {
 	if fv.Kind() == reflect.Pointer {
 		fv = fv.Elem()
 	}
-	return marshalInlineValue(e, fv, tag, nil)
+	return marshalInlineValue(e, fv, tag, nil, true)
 }
 
 // marshalInlineValue marshals a non-pointer value in place. deferred may be nil when
 // the value is itself a referent body (its own pointers create a fresh construction
-// scope via marshalStruct).
-func marshalInlineValue(e *Encoder, fv reflect.Value, tag fieldTag, deferred *[]func() error) error {
+// scope via marshalStruct). embedded is true when the value is nested inside another
+// construction rather than being a top-level parameter.
+func marshalInlineValue(e *Encoder, fv reflect.Value, tag fieldTag, deferred *[]func() error, embedded bool) error {
 	if m, ok := asMarshaler(fv); ok {
 		e.Align(m.AlignmentNDR())
 		return m.MarshalNDR(e)
@@ -236,7 +249,16 @@ func marshalInlineValue(e *Encoder, fv reflect.Value, tag fieldTag, deferred *[]
 		if swIdx := unionSwitchIndex(fv.Type()); swIdx >= 0 {
 			return marshalUnion(e, fv, swIdx)
 		}
-		return marshalStruct(e, fv, true) // members of any value reached here are embedded
+		// A struct value nested inside another construction (embedded) is part of that
+		// construction: its pointers defer to the enclosing flush point, not the end of
+		// this struct ([C706] 14.3.12.3 — deferral iterates to the outermost construction).
+		// A top-level parameter struct, or a referent body (deferred == nil), is its own
+		// construction with its own deferral scope.
+		if embedded && deferred != nil {
+			_, err := marshalStructFields(e, fv, true, deferred)
+			return err
+		}
+		return marshalStruct(e, fv, true)
 	case reflect.Slice:
 		if tag.varying {
 			return marshalConformantVaryingArray(e, fv, elementTag(tag))
@@ -317,6 +339,7 @@ func unmarshalStruct(d *Decoder, rv reflect.Value, embedded bool) error {
 // marshalStructFields for why arrays need this. Returns the `retval` field index or -1.
 func unmarshalStructFields(d *Decoder, rv reflect.Value, embedded bool, deferred *[]func() error) (int, error) {
 	rt := rv.Type()
+	d.Align(ndrAlignment(rt)) // a structure is aligned to its largest member ([C706] 14.2.2)
 	confIdx := embeddedConformantIndex(rt, rv)
 	var confCount uint32
 	if confIdx >= 0 {
@@ -398,12 +421,18 @@ func unmarshalFieldInline(d *Decoder, fv reflect.Value, tag fieldTag, deferred *
 		if refid == 0 {
 			return nil // NULL: leave the zero value
 		}
+		// Symmetric with marshal: a top-level [unique]/[full] pointer's referent is read
+		// in place, right after the referent id; only an embedded pointer's body is
+		// deferred to the end of the enclosing construction.
+		if !embedded {
+			return unmarshalReferentBody(d, fv, tag)
+		}
 		target := fv
 		*deferred = append(*deferred, func() error { return unmarshalReferentBody(d, target, tag) })
 		return nil
 	}
 
-	return unmarshalInlineValue(d, fv, tag)
+	return unmarshalInlineValue(d, fv, tag, deferred, embedded)
 }
 
 func unmarshalReferentBody(d *Decoder, fv reflect.Value, tag fieldTag) error {
@@ -413,10 +442,10 @@ func unmarshalReferentBody(d *Decoder, fv reflect.Value, tag fieldTag) error {
 		}
 		fv = fv.Elem()
 	}
-	return unmarshalInlineValue(d, fv, tag)
+	return unmarshalInlineValue(d, fv, tag, nil, true) // a referent body is a fresh construction
 }
 
-func unmarshalInlineValue(d *Decoder, fv reflect.Value, tag fieldTag) error {
+func unmarshalInlineValue(d *Decoder, fv reflect.Value, tag fieldTag, deferred *[]func() error, embedded bool) error {
 	if m, ok := asMarshalerAddr(fv); ok {
 		d.Align(m.AlignmentNDR())
 		return m.UnmarshalNDR(d)
@@ -441,6 +470,13 @@ func unmarshalInlineValue(d *Decoder, fv reflect.Value, tag fieldTag) error {
 	case reflect.Struct:
 		if swIdx := unionSwitchIndex(fv.Type()); swIdx >= 0 {
 			return unmarshalUnion(d, fv, swIdx)
+		}
+		// Symmetric with marshal: a struct value nested inside another construction threads
+		// the enclosing deferred queue; a top-level parameter struct or a referent body
+		// (deferred == nil) starts its own construction.
+		if embedded && deferred != nil {
+			_, err := unmarshalStructFields(d, fv, true, deferred)
+			return err
 		}
 		return unmarshalStruct(d, fv, true)
 	case reflect.Slice:
@@ -755,7 +791,7 @@ func marshalElement(e *Encoder, ev reflect.Value, tag fieldTag, deferred *[]func
 			return err
 		}
 	}
-	return marshalInlineValue(e, ev, tag, nil)
+	return marshalInlineValue(e, ev, tag, nil, true)
 }
 
 // unmarshalElements reads n elements into slice (allocating a fresh backing array), in
@@ -827,7 +863,7 @@ func unmarshalElement(d *Decoder, ev reflect.Value, tag fieldTag, deferred *[]fu
 			return err
 		}
 	}
-	return unmarshalInlineValue(d, ev, tag)
+	return unmarshalInlineValue(d, ev, tag, nil, true)
 }
 
 // elementTag derives the tag applied to each element of an array from the array

--- a/network/dcerpc/ndr/marshal_test.go
+++ b/network/dcerpc/ndr/marshal_test.go
@@ -35,24 +35,28 @@ func TestMarshal_DeferredOrdering_GoldenBytes(t *testing.T) {
 		t.Fatalf("Marshal: %v", err)
 	}
 
+	// Each top-level pointer PARAMETER is its own NDR construction: its referent id is
+	// followed immediately by the referent body (only pointers EMBEDDED in a struct defer
+	// their bodies to the end of that struct). Verified against a live Windows server: an
+	// LSA [out] parameter such as LsarLookupSids' ReferencedDomains places its body in
+	// place, not deferred past the later parameters.
 	want := []byte{
-		// --- top-level inline ---
 		0x11, 0x00, 0x00, 0x00, // Flags
 		0x00, 0x00, 0x02, 0x00, // Reserved referent id (0x00020000)
-		0x04, 0x00, 0x02, 0x00, // FileName referent id (0x00020004)
-		0x22, 0x00, 0x00, 0x00, // InfoClass
-		// --- deferred[0]: Reserved (efsBlob) construction ---
+		// Reserved (efsBlob) body, in place:
 		0x02, 0x00, 0x00, 0x00, // CbData
-		0x08, 0x00, 0x02, 0x00, // BData referent id (0x00020008)
+		0x04, 0x00, 0x02, 0x00, // BData referent id (0x00020004)
 		0x02, 0x00, 0x00, 0x00, // BData conformant maximum_count
 		0xaa, 0xbb, // BData elements
-		// --- deferred[1]: FileName wstring ("A") ---
-		0x00, 0x00, // 2-byte pad to 4-align the count
+		0x00, 0x00, // 2-byte pad to 4-align the next referent
+		0x08, 0x00, 0x02, 0x00, // FileName referent id (0x00020008)
+		// FileName wstring ("A") body, in place:
 		0x02, 0x00, 0x00, 0x00, // maximum_count (incl NUL)
 		0x00, 0x00, 0x00, 0x00, // offset
 		0x02, 0x00, 0x00, 0x00, // actual_count
 		0x41, 0x00, // "A"
 		0x00, 0x00, // terminator
+		0x22, 0x00, 0x00, 0x00, // InfoClass
 	}
 	if !bytes.Equal(got, want) {
 		t.Errorf("EFSR-style marshal:\n got %x\nwant %x", got, want)

--- a/network/dcerpc/ndr/union.go
+++ b/network/dcerpc/ndr/union.go
@@ -75,10 +75,10 @@ func unionArm(rt reflect.Type, disc reflect.Value) int {
 	return def
 }
 
-// unionAlignment returns the union's NDR alignment: the largest alignment of the
-// discriminant and every arm. It is computed over all arms (not the selected one) so a
-// receiver can apply the same padding before it has read the discriminant.
-func unionAlignment(rt reflect.Type) int {
+// unionArmAlignment returns the largest NDR alignment among the union's arms (the
+// case/default fields), which is the alignment applied to the selected arm so its
+// position does not depend on which arm was sent ([C706] section 14.3.8).
+func unionArmAlignment(rt reflect.Type) int {
 	a := 1
 	for i := 0; i < rt.NumField(); i++ {
 		f := rt.Field(i)
@@ -86,7 +86,7 @@ func unionAlignment(rt reflect.Type) int {
 			continue
 		}
 		tag := parseTag(f.Tag.Get("ndr"))
-		if !tag.isSwitch && !tag.hasCase && !tag.isDefault {
+		if !tag.hasCase && !tag.isDefault {
 			continue
 		}
 		if fa := ndrAlignment(f.Type); fa > a {
@@ -103,7 +103,13 @@ func unionAlignment(rt reflect.Type) int {
 func marshalUnion(e *Encoder, rv reflect.Value, swIdx int) error {
 	rt := rv.Type()
 	disc := rv.Field(swIdx)
-	e.Align(unionAlignment(rt))
+	// The discriminant is aligned to its own alignment. The selected arm is then aligned
+	// to the LARGEST alignment among all arms — not just the selected one — so a receiver
+	// can position the arm before it knows which arm was sent. Verified on the wire:
+	// LSAPR_POLICY_INFORMATION's 2-byte server-role arm still starts 8-aligned because
+	// other arms carry 8-byte LARGE_INTEGER members. (Note this padding follows the tag,
+	// so it does not over-align the discriminant itself.)
+	e.Align(ndrAlignment(disc.Type()))
 	if err := marshalScalar(e, disc); err != nil {
 		return err
 	}
@@ -111,6 +117,7 @@ func marshalUnion(e *Encoder, rv reflect.Value, swIdx int) error {
 	if armIdx < 0 {
 		return nil // discriminant value with no arm and no default: empty body
 	}
+	e.Align(unionArmAlignment(rt))
 	f := rt.Field(armIdx)
 	var deferred []func() error
 	if err := marshalFieldInline(e, rv.Field(armIdx), parseTag(f.Tag.Get("ndr")), &deferred, true); err != nil {
@@ -124,7 +131,7 @@ func marshalUnion(e *Encoder, rv reflect.Value, swIdx int) error {
 func unmarshalUnion(d *Decoder, rv reflect.Value, swIdx int) error {
 	rt := rv.Type()
 	disc := rv.Field(swIdx)
-	d.Align(unionAlignment(rt))
+	d.Align(ndrAlignment(disc.Type())) // discriminant aligned to itself
 	if err := unmarshalScalar(d, disc); err != nil {
 		return err
 	}
@@ -132,6 +139,7 @@ func unmarshalUnion(d *Decoder, rv reflect.Value, swIdx int) error {
 	if armIdx < 0 {
 		return nil
 	}
+	d.Align(unionArmAlignment(rt)) // arm aligned to the largest alignment among all arms
 	f := rt.Field(armIdx)
 	var deferred []func() error
 	if err := unmarshalFieldInline(d, rv.Field(armIdx), parseTag(f.Tag.Get("ndr")), &deferred, true); err != nil {

--- a/network/dcerpc/ndr/union_test.go
+++ b/network/dcerpc/ndr/union_test.go
@@ -128,12 +128,14 @@ func TestUnion_Alignment(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Marshal: %v", err)
 	}
+	// The union is aligned to its discriminant (uint32 -> 4), not to the largest arm:
+	// Windows does not pre-align the union to an 8-byte arm before the tag (verified on
+	// the wire for LSAPR_POLICY_INFORMATION). The uint64 arm then self-aligns to 8 after
+	// the tag — here it already lands at offset 8, so no padding is emitted.
 	want := []byte{
 		0xAA, 0, 0, 0, // Pre
-		0x00, 0, 0, 0, // pad: union aligned to 8 before the discriminant
-		0x01, 0, 0, 0, // discriminant Sel = 1
-		0x00, 0, 0, 0, // pad: uint64 arm aligned to 8
-		0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, // arm Big
+		0x01, 0, 0, 0, // discriminant Sel = 1 (offset 4, no pre-pad)
+		0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, // arm Big (offset 8, 8-aligned)
 	}
 	if !bytes.Equal(raw, want) {
 		t.Errorf("union alignment:\n got %x\nwant %x", raw, want)

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/02_LsarEnumeratePrivileges.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/02_LsarEnumeratePrivileges.go
@@ -28,7 +28,7 @@ func (*lsarEnumeratePrivilegesRequest) Opnum() uint16 {
 type lsarEnumeratePrivilegesResponse struct {
 	EnumerationContext ndr.DWORD
 	EnumerationBuffer  structures.LSAPR_PRIVILEGE_ENUM_BUFFER
-	Status             ndr.DWORD
+	Status             ndr.DWORD `ndr:"retval"`
 }
 
 // LsarEnumeratePrivileges calls LsarEnumeratePrivileges (opnum 2), enumerating the

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/03_LsarQuerySecurityObject.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/03_LsarQuerySecurityObject.go
@@ -23,7 +23,7 @@ func (*lsarQuerySecurityObjectRequest) Opnum() uint16 { return lsarpc.OpnumLsarQ
 // descriptor (a double pointer) followed by the NTSTATUS return value.
 type lsarQuerySecurityObjectResponse struct {
 	SecurityDescriptor *structures.LSAPR_SR_SECURITY_DESCRIPTOR `ndr:"unique"`
-	Status             ndr.DWORD
+	Status             ndr.DWORD                                `ndr:"retval"`
 }
 
 // LsarQuerySecurityObject calls LsarQuerySecurityObject (opnum 3) to retrieve the security

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/07_LsarQueryInformationPolicy.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/07_LsarQueryInformationPolicy.go
@@ -24,7 +24,7 @@ func (*lsarQueryInformationPolicyRequest) Opnum() uint16 {
 // pointer in the IDL, so a [unique] pointer on the wire) and the NTSTATUS return value.
 type lsarQueryInformationPolicyResponse struct {
 	PolicyInformation *structures.LSAPR_POLICY_INFORMATION `ndr:"unique"`
-	Status            ndr.DWORD
+	Status            ndr.DWORD                            `ndr:"retval"`
 }
 
 // LsarQueryInformationPolicy calls LsarQueryInformationPolicy (opnum 7), returning the

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/11_LsarEnumerateAccounts.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/11_LsarEnumerateAccounts.go
@@ -25,7 +25,7 @@ func (*lsarEnumerateAccountsRequest) Opnum() uint16 { return lsarpc.OpnumLsarEnu
 type lsarEnumerateAccountsResponse struct {
 	EnumerationContext ndr.DWORD
 	EnumerationBuffer  structures.LSAPR_ACCOUNT_ENUM_BUFFER
-	Status             ndr.DWORD
+	Status             ndr.DWORD `ndr:"retval"`
 }
 
 // LsarEnumerateAccounts calls LsarEnumerateAccounts (opnum 11), returning a page of account

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/13_LsarEnumerateTrustedDomains.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/13_LsarEnumerateTrustedDomains.go
@@ -28,7 +28,7 @@ func (*lsarEnumerateTrustedDomainsRequest) Opnum() uint16 {
 type lsarEnumerateTrustedDomainsResponse struct {
 	EnumerationContext ndr.DWORD
 	EnumerationBuffer  structures.LSAPR_TRUSTED_ENUM_BUFFER
-	Status             ndr.DWORD
+	Status             ndr.DWORD `ndr:"retval"`
 }
 
 // LsarEnumerateTrustedDomains calls LsarEnumerateTrustedDomains (opnum 13), returning a

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/14_LsarLookupNames.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/14_LsarLookupNames.go
@@ -11,13 +11,16 @@ import (
 )
 
 // lsarLookupNamesRequest is the [in]/[in,out] parameter set of LsarLookupNames: a policy
-// handle, the count of names, a conformant array of names to translate, the [in,out]
-// TranslatedSids (a single, inline value), the lookup level, and the [in,out] mapped
-// count.
+// handle, the count of names, the names to translate, the [in,out] TranslatedSids (a
+// single, inline value), the lookup level, and the [in,out] mapped count. Names is a
+// top-level [in, size_is(Count)] PRPC_UNICODE_STRING — a [ref] pointer to a conformant
+// array, so its maximum_count belongs with the referent body, NOT hoisted to the front
+// of the request (a bare conformant slice would hoist it before PolicyHandle and desync
+// the whole stub). The "ref" tag keeps it pointer-like so it is emitted as a referent.
 type lsarLookupNamesRequest struct {
 	PolicyHandle   structures.LSAPR_HANDLE
 	Count          ndr.DWORD
-	Names          []dtyp.RPC_UNICODE_STRING `ndr:"conformant,size_is=Count"`
+	Names          []dtyp.RPC_UNICODE_STRING `ndr:"ref,size_is=Count"`
 	TranslatedSids structures.LSAPR_TRANSLATED_SIDS
 	LookupLevel    structures.LSAP_LOOKUP_LEVEL
 	MappedCount    ndr.DWORD
@@ -31,7 +34,7 @@ type lsarLookupNamesResponse struct {
 	ReferencedDomains *structures.LSAPR_REFERENCED_DOMAIN_LIST `ndr:"unique"`
 	TranslatedSids    structures.LSAPR_TRANSLATED_SIDS
 	MappedCount       ndr.DWORD
-	Status            ndr.DWORD
+	Status            ndr.DWORD `ndr:"retval"`
 }
 
 // LsarLookupNames calls LsarLookupNames (opnum 14) to translate a set of account names

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/15_LsarLookupSids.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/15_LsarLookupSids.go
@@ -28,7 +28,7 @@ type lsarLookupSidsResponse struct {
 	ReferencedDomains *structures.LSAPR_REFERENCED_DOMAIN_LIST `ndr:"unique"`
 	TranslatedNames   structures.LSAPR_TRANSLATED_NAMES
 	MappedCount       ndr.DWORD
-	Status            ndr.DWORD
+	Status            ndr.DWORD `ndr:"retval"`
 }
 
 // LsarLookupSids calls LsarLookupSids (opnum 15) to translate a set of SIDs into account

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/18_LsarEnumeratePrivilegesAccount.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/18_LsarEnumeratePrivilegesAccount.go
@@ -23,7 +23,7 @@ func (*lsarEnumeratePrivilegesAccountRequest) Opnum() uint16 {
 // the account (a [unique] double pointer) followed by the NTSTATUS return value.
 type lsarEnumeratePrivilegesAccountResponse struct {
 	Privileges *structures.LSAPR_PRIVILEGE_SET `ndr:"unique"`
-	Status     ndr.DWORD
+	Status     ndr.DWORD                       `ndr:"retval"`
 }
 
 // LsarEnumeratePrivilegesAccount calls LsarEnumeratePrivilegesAccount (opnum 18), returning

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/23_LsarGetSystemAccessAccount.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/23_LsarGetSystemAccessAccount.go
@@ -23,7 +23,7 @@ func (*lsarGetSystemAccessAccountRequest) Opnum() uint16 {
 // followed by the NTSTATUS return value.
 type lsarGetSystemAccessAccountResponse struct {
 	SystemAccess ndr.DWORD
-	Status       ndr.DWORD
+	Status       ndr.DWORD `ndr:"retval"`
 }
 
 // LsarGetSystemAccessAccount calls LsarGetSystemAccessAccount (opnum 23) and returns the

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/26_LsarQueryInfoTrustedDomain.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/26_LsarQueryInfoTrustedDomain.go
@@ -25,7 +25,7 @@ func (*lsarQueryInfoTrustedDomainRequest) Opnum() uint16 {
 // pointer in the IDL, so a [unique] pointer on the wire) and the NTSTATUS return value.
 type lsarQueryInfoTrustedDomainResponse struct {
 	TrustedDomainInformation *structures.LSAPR_TRUSTED_DOMAIN_INFO `ndr:"unique"`
-	Status                   ndr.DWORD
+	Status                   ndr.DWORD                             `ndr:"retval"`
 }
 
 // LsarQueryInfoTrustedDomain calls LsarQueryInfoTrustedDomain (opnum 26), returning the

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/30_LsarQuerySecret.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/30_LsarQuerySecret.go
@@ -32,7 +32,7 @@ type lsarQuerySecretResponse struct {
 	CurrentValueSetTime   *dtyp.LARGE_INTEGER               `ndr:"unique"`
 	EncryptedOldValue     *structures.LSAPR_CR_CIPHER_VALUE `ndr:"unique"`
 	OldValueSetTime       *dtyp.LARGE_INTEGER               `ndr:"unique"`
-	Status                ndr.DWORD
+	Status                ndr.DWORD                         `ndr:"retval"`
 }
 
 // LsarQuerySecret calls LsarQuerySecret (opnum 30) and returns the current and old

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/31_LsarLookupPrivilegeValue.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/31_LsarLookupPrivilegeValue.go
@@ -11,10 +11,13 @@ import (
 )
 
 // lsarLookupPrivilegeValueRequest is the [in] parameter set of LsarLookupPrivilegeValue:
-// the policy handle and the privilege name (a [unique] pointer to an RPC_UNICODE_STRING).
+// the policy handle and the privilege name. Name is a top-level [in] PRPC_UNICODE_STRING,
+// i.e. a [ref] pointer ([C706]: a top-level parameter pointer with no explicit attribute
+// is a reference pointer), so its referent is transmitted in place with no referent id —
+// modeled as an inline value, not a [unique] pointer.
 type lsarLookupPrivilegeValueRequest struct {
 	PolicyHandle structures.LSAPR_HANDLE
-	Name         *dtyp.RPC_UNICODE_STRING `ndr:"unique"`
+	Name         dtyp.RPC_UNICODE_STRING
 }
 
 func (*lsarLookupPrivilegeValueRequest) Opnum() uint16 {
@@ -25,16 +28,15 @@ func (*lsarLookupPrivilegeValueRequest) Opnum() uint16 {
 // (a top-level [ref] pointer, so its value is inline) and the NTSTATUS return value.
 type lsarLookupPrivilegeValueResponse struct {
 	Value  dtyp.LUID
-	Status ndr.DWORD
+	Status ndr.DWORD `ndr:"retval"`
 }
 
 // LsarLookupPrivilegeValue calls LsarLookupPrivilegeValue (opnum 31), mapping a privilege
 // name to its locally unique identifier ([MS-LSAD] 3.1.4.5.13).
 func LsarLookupPrivilegeValue(rpc *client.Client, policyHandle structures.LSAPR_HANDLE, name string) (dtyp.LUID, error) {
-	rpcName := dtyp.NewUnicodeString(name)
 	req := &lsarLookupPrivilegeValueRequest{
 		PolicyHandle: policyHandle,
-		Name:         &rpcName,
+		Name:         dtyp.NewUnicodeString(name),
 	}
 	var resp lsarLookupPrivilegeValueResponse
 	if err := rpc.Invoke(req, &resp); err != nil {

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/32_LsarLookupPrivilegeName.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/32_LsarLookupPrivilegeName.go
@@ -27,7 +27,7 @@ func (*lsarLookupPrivilegeNameRequest) Opnum() uint16 {
 // return value.
 type lsarLookupPrivilegeNameResponse struct {
 	Name   *dtyp.RPC_UNICODE_STRING `ndr:"unique"`
-	Status ndr.DWORD
+	Status ndr.DWORD                `ndr:"retval"`
 }
 
 // LsarLookupPrivilegeName calls LsarLookupPrivilegeName (opnum 32), mapping a privilege

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/33_LsarLookupPrivilegeDisplayName.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/33_LsarLookupPrivilegeDisplayName.go
@@ -15,7 +15,7 @@ import (
 // pointer to an RPC_UNICODE_STRING), and the client's language identifiers.
 type lsarLookupPrivilegeDisplayNameRequest struct {
 	PolicyHandle                structures.LSAPR_HANDLE
-	Name                        *dtyp.RPC_UNICODE_STRING `ndr:"unique"`
+	Name                        dtyp.RPC_UNICODE_STRING
 	ClientLanguage              int16
 	ClientSystemDefaultLanguage int16
 }
@@ -31,7 +31,7 @@ func (*lsarLookupPrivilegeDisplayNameRequest) Opnum() uint16 {
 type lsarLookupPrivilegeDisplayNameResponse struct {
 	DisplayName      *dtyp.RPC_UNICODE_STRING `ndr:"unique"`
 	LanguageReturned uint16
-	Status           ndr.DWORD
+	Status           ndr.DWORD `ndr:"retval"`
 }
 
 // LsarLookupPrivilegeDisplayName calls LsarLookupPrivilegeDisplayName (opnum 33), mapping a
@@ -41,7 +41,7 @@ func LsarLookupPrivilegeDisplayName(rpc *client.Client, policyHandle structures.
 	rpcName := dtyp.NewUnicodeString(name)
 	req := &lsarLookupPrivilegeDisplayNameRequest{
 		PolicyHandle:                policyHandle,
-		Name:                        &rpcName,
+		Name:                        rpcName,
 		ClientLanguage:              clientLanguage,
 		ClientSystemDefaultLanguage: clientSystemDefaultLanguage,
 	}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/35_LsarEnumerateAccountsWithUserRight.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/35_LsarEnumerateAccountsWithUserRight.go
@@ -26,7 +26,7 @@ func (*lsarEnumerateAccountsWithUserRightRequest) Opnum() uint16 {
 // holding the right (an inline [ref] struct) followed by the NTSTATUS return value.
 type lsarEnumerateAccountsWithUserRightResponse struct {
 	EnumerationBuffer structures.LSAPR_ACCOUNT_ENUM_BUFFER
-	Status            ndr.DWORD
+	Status            ndr.DWORD `ndr:"retval"`
 }
 
 // LsarEnumerateAccountsWithUserRight calls LsarEnumerateAccountsWithUserRight (opnum 35),

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/36_LsarEnumerateAccountRights.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/36_LsarEnumerateAccountRights.go
@@ -25,7 +25,7 @@ func (*lsarEnumerateAccountRightsRequest) Opnum() uint16 {
 // the account (an inline [ref] struct) followed by the NTSTATUS return value.
 type lsarEnumerateAccountRightsResponse struct {
 	UserRights structures.LSAPR_USER_RIGHT_SET
-	Status     ndr.DWORD
+	Status     ndr.DWORD `ndr:"retval"`
 }
 
 // LsarEnumerateAccountRights calls LsarEnumerateAccountRights (opnum 36), returning the set

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/39_LsarQueryTrustedDomainInfo.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/39_LsarQueryTrustedDomainInfo.go
@@ -27,7 +27,7 @@ func (*lsarQueryTrustedDomainInfoRequest) Opnum() uint16 {
 // pointer in the IDL, so a [unique] pointer on the wire) and the NTSTATUS return value.
 type lsarQueryTrustedDomainInfoResponse struct {
 	TrustedDomainInformation *structures.LSAPR_TRUSTED_DOMAIN_INFO `ndr:"unique"`
-	Status                   ndr.DWORD
+	Status                   ndr.DWORD                             `ndr:"retval"`
 }
 
 // LsarQueryTrustedDomainInfo calls LsarQueryTrustedDomainInfo (opnum 39), returning the

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/43_LsarRetrievePrivateData.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/43_LsarRetrievePrivateData.go
@@ -27,7 +27,7 @@ func (*lsarRetrievePrivateDataRequest) Opnum() uint16 { return lsarpc.OpnumLsarR
 // the server followed by the NTSTATUS return value.
 type lsarRetrievePrivateDataResponse struct {
 	EncryptedData *structures.LSAPR_CR_CIPHER_VALUE `ndr:"unique"`
-	Status        ndr.DWORD
+	Status        ndr.DWORD                         `ndr:"retval"`
 }
 
 // LsarRetrievePrivateData calls LsarRetrievePrivateData (opnum 43) and returns the

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/45_LsarGetUserName.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/45_LsarGetUserName.go
@@ -25,7 +25,7 @@ func (*lsarGetUserNameRequest) Opnum() uint16 { return lsarpc.OpnumLsarGetUserNa
 type lsarGetUserNameResponse struct {
 	UserName   *dtyp.RPC_UNICODE_STRING `ndr:"unique"`
 	DomainName *dtyp.RPC_UNICODE_STRING `ndr:"unique"`
-	Status     ndr.DWORD
+	Status     ndr.DWORD                `ndr:"retval"`
 }
 
 // LsarGetUserName calls LsarGetUserName (opnum 45) to retrieve the name (and domain) of

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/46_LsarQueryInformationPolicy2.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/46_LsarQueryInformationPolicy2.go
@@ -25,7 +25,7 @@ func (*lsarQueryInformationPolicy2Request) Opnum() uint16 {
 // pointer in the IDL, so a [unique] pointer on the wire) and the NTSTATUS return value.
 type lsarQueryInformationPolicy2Response struct {
 	PolicyInformation *structures.LSAPR_POLICY_INFORMATION `ndr:"unique"`
-	Status            ndr.DWORD
+	Status            ndr.DWORD                            `ndr:"retval"`
 }
 
 // LsarQueryInformationPolicy2 calls LsarQueryInformationPolicy2 (opnum 46), returning the

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/48_LsarQueryTrustedDomainInfoByName.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/48_LsarQueryTrustedDomainInfoByName.go
@@ -15,7 +15,7 @@ import (
 // and the information class selecting which union arm is returned.
 type lsarQueryTrustedDomainInfoByNameRequest struct {
 	PolicyHandle      structures.LSAPR_HANDLE
-	TrustedDomainName *dtyp.RPC_UNICODE_STRING `ndr:"unique"`
+	TrustedDomainName dtyp.RPC_UNICODE_STRING
 	InformationClass  structures.TRUSTED_INFORMATION_CLASS
 }
 
@@ -27,7 +27,7 @@ func (*lsarQueryTrustedDomainInfoByNameRequest) Opnum() uint16 {
 // pointer in the IDL, so a [unique] pointer on the wire) and the NTSTATUS return value.
 type lsarQueryTrustedDomainInfoByNameResponse struct {
 	TrustedDomainInformation *structures.LSAPR_TRUSTED_DOMAIN_INFO `ndr:"unique"`
-	Status                   ndr.DWORD
+	Status                   ndr.DWORD                             `ndr:"retval"`
 }
 
 // LsarQueryTrustedDomainInfoByName calls LsarQueryTrustedDomainInfoByName (opnum 48),
@@ -37,7 +37,7 @@ func LsarQueryTrustedDomainInfoByName(rpc *client.Client, policyHandle structure
 	name := dtyp.NewUnicodeString(trustedDomainName)
 	req := &lsarQueryTrustedDomainInfoByNameRequest{
 		PolicyHandle:      policyHandle,
-		TrustedDomainName: &name,
+		TrustedDomainName: name,
 		InformationClass:  infoClass,
 	}
 	var resp lsarQueryTrustedDomainInfoByNameResponse

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/49_LsarSetTrustedDomainInfoByName.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/49_LsarSetTrustedDomainInfoByName.go
@@ -15,7 +15,7 @@ import (
 // information.
 type lsarSetTrustedDomainInfoByNameRequest struct {
 	PolicyHandle             structures.LSAPR_HANDLE
-	TrustedDomainName        *dtyp.RPC_UNICODE_STRING `ndr:"unique"`
+	TrustedDomainName        dtyp.RPC_UNICODE_STRING
 	InformationClass         structures.TRUSTED_INFORMATION_CLASS
 	TrustedDomainInformation structures.LSAPR_TRUSTED_DOMAIN_INFO
 }
@@ -32,7 +32,7 @@ func LsarSetTrustedDomainInfoByName(rpc *client.Client, policyHandle structures.
 	name := dtyp.NewUnicodeString(trustedDomainName)
 	req := &lsarSetTrustedDomainInfoByNameRequest{
 		PolicyHandle:             policyHandle,
-		TrustedDomainName:        &name,
+		TrustedDomainName:        name,
 		InformationClass:         infoClass,
 		TrustedDomainInformation: info,
 	}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/50_LsarEnumerateTrustedDomainsEx.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/50_LsarEnumerateTrustedDomainsEx.go
@@ -28,7 +28,7 @@ func (*lsarEnumerateTrustedDomainsExRequest) Opnum() uint16 {
 type lsarEnumerateTrustedDomainsExResponse struct {
 	EnumerationContext ndr.DWORD
 	EnumerationBuffer  structures.LSAPR_TRUSTED_ENUM_BUFFER_EX
-	Status             ndr.DWORD
+	Status             ndr.DWORD `ndr:"retval"`
 }
 
 // LsarEnumerateTrustedDomainsEx calls LsarEnumerateTrustedDomainsEx (opnum 50), returning a

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/53_LsarQueryDomainInformationPolicy.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/53_LsarQueryDomainInformationPolicy.go
@@ -25,7 +25,7 @@ func (*lsarQueryDomainInformationPolicyRequest) Opnum() uint16 {
 // pointer in the IDL, so a [unique] pointer on the wire) and the NTSTATUS return value.
 type lsarQueryDomainInformationPolicyResponse struct {
 	PolicyDomainInformation *structures.LSAPR_POLICY_DOMAIN_INFORMATION `ndr:"unique"`
-	Status                  ndr.DWORD
+	Status                  ndr.DWORD                                   `ndr:"retval"`
 }
 
 // LsarQueryDomainInformationPolicy calls LsarQueryDomainInformationPolicy (opnum 53),

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/55_LsarOpenTrustedDomainByName.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/55_LsarOpenTrustedDomainByName.go
@@ -15,7 +15,7 @@ import (
 // domain to open, and the desired access mask for the returned handle.
 type lsarOpenTrustedDomainByNameRequest struct {
 	PolicyHandle      structures.LSAPR_HANDLE
-	TrustedDomainName *dtyp.RPC_UNICODE_STRING `ndr:"unique"`
+	TrustedDomainName dtyp.RPC_UNICODE_STRING
 	DesiredAccess     ndr.DWORD
 }
 
@@ -29,7 +29,7 @@ func LsarOpenTrustedDomainByName(rpc *client.Client, policyHandle structures.LSA
 	name := dtyp.NewUnicodeString(trustedDomainName)
 	req := &lsarOpenTrustedDomainByNameRequest{
 		PolicyHandle:      policyHandle,
-		TrustedDomainName: &name,
+		TrustedDomainName: name,
 		DesiredAccess:     ndr.DWORD(desiredAccess),
 	}
 	var resp handleResponse

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/57_LsarLookupSids2.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/57_LsarLookupSids2.go
@@ -30,7 +30,7 @@ type lsarLookupSids2Response struct {
 	ReferencedDomains *structures.LSAPR_REFERENCED_DOMAIN_LIST `ndr:"unique"`
 	TranslatedNames   structures.LSAPR_TRANSLATED_NAMES_EX
 	MappedCount       ndr.DWORD
-	Status            ndr.DWORD
+	Status            ndr.DWORD `ndr:"retval"`
 }
 
 // LsarLookupSids2 calls LsarLookupSids2 (opnum 57) to translate a set of SIDs into

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/58_LsarLookupNames2.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/58_LsarLookupNames2.go
@@ -16,7 +16,7 @@ import (
 type lsarLookupNames2Request struct {
 	PolicyHandle   structures.LSAPR_HANDLE
 	Count          ndr.DWORD
-	Names          []dtyp.RPC_UNICODE_STRING `ndr:"conformant,size_is=Count"`
+	Names          []dtyp.RPC_UNICODE_STRING `ndr:"ref,size_is=Count"`
 	TranslatedSids structures.LSAPR_TRANSLATED_SIDS_EX
 	LookupLevel    structures.LSAP_LOOKUP_LEVEL
 	MappedCount    ndr.DWORD
@@ -32,7 +32,7 @@ type lsarLookupNames2Response struct {
 	ReferencedDomains *structures.LSAPR_REFERENCED_DOMAIN_LIST `ndr:"unique"`
 	TranslatedSids    structures.LSAPR_TRANSLATED_SIDS_EX
 	MappedCount       ndr.DWORD
-	Status            ndr.DWORD
+	Status            ndr.DWORD `ndr:"retval"`
 }
 
 // LsarLookupNames2 calls LsarLookupNames2 (opnum 58) to translate a set of account names

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/68_LsarLookupNames3.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/68_LsarLookupNames3.go
@@ -15,7 +15,7 @@ import (
 type lsarLookupNames3Request struct {
 	PolicyHandle   structures.LSAPR_HANDLE
 	Count          ndr.DWORD
-	Names          []dtyp.RPC_UNICODE_STRING `ndr:"conformant,size_is=Count"`
+	Names          []dtyp.RPC_UNICODE_STRING `ndr:"ref,size_is=Count"`
 	TranslatedSids structures.LSAPR_TRANSLATED_SIDS_EX2
 	LookupLevel    structures.LSAP_LOOKUP_LEVEL
 	MappedCount    ndr.DWORD
@@ -31,7 +31,7 @@ type lsarLookupNames3Response struct {
 	ReferencedDomains *structures.LSAPR_REFERENCED_DOMAIN_LIST `ndr:"unique"`
 	TranslatedSids    structures.LSAPR_TRANSLATED_SIDS_EX2
 	MappedCount       ndr.DWORD
-	Status            ndr.DWORD
+	Status            ndr.DWORD `ndr:"retval"`
 }
 
 // LsarLookupNames3 calls LsarLookupNames3 (opnum 68) to translate a set of account names

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/73_LsarQueryForestTrustInformation.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/73_LsarQueryForestTrustInformation.go
@@ -27,7 +27,7 @@ func (*lsarQueryForestTrustInformationRequest) Opnum() uint16 {
 // information returned by the server followed by the NTSTATUS return value.
 type lsarQueryForestTrustInformationResponse struct {
 	ForestTrustInfo *structures.LSA_FOREST_TRUST_INFORMATION `ndr:"unique"`
-	Status          ndr.DWORD
+	Status          ndr.DWORD                                `ndr:"retval"`
 }
 
 // LsarQueryForestTrustInformation calls LsarQueryForestTrustInformation (opnum 73) and

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/74_LsarSetForestTrustInformation.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/74_LsarSetForestTrustInformation.go
@@ -31,7 +31,7 @@ func (*lsarSetForestTrustInformationRequest) Opnum() uint16 {
 // describing any conflicts with existing trusts followed by the NTSTATUS return value.
 type lsarSetForestTrustInformationResponse struct {
 	CollisionInfo *structures.LSA_FOREST_TRUST_COLLISION_INFORMATION `ndr:"unique"`
-	Status        ndr.DWORD
+	Status        ndr.DWORD                                          `ndr:"retval"`
 }
 
 // LsarSetForestTrustInformation calls LsarSetForestTrustInformation (opnum 74), establishing

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/76_LsarLookupSids3.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/76_LsarLookupSids3.go
@@ -30,7 +30,7 @@ type lsarLookupSids3Response struct {
 	ReferencedDomains *structures.LSAPR_REFERENCED_DOMAIN_LIST `ndr:"unique"`
 	TranslatedNames   structures.LSAPR_TRANSLATED_NAMES_EX
 	MappedCount       ndr.DWORD
-	Status            ndr.DWORD
+	Status            ndr.DWORD `ndr:"retval"`
 }
 
 // LsarLookupSids3 calls LsarLookupSids3 (opnum 76) to translate a set of SIDs into account

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/77_LsarLookupNames4.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/77_LsarLookupNames4.go
@@ -16,7 +16,7 @@ import (
 // translated SIDs plus LookupOptions/ClientRevision).
 type lsarLookupNames4Request struct {
 	Count          ndr.DWORD
-	Names          []dtyp.RPC_UNICODE_STRING `ndr:"conformant,size_is=Count"`
+	Names          []dtyp.RPC_UNICODE_STRING `ndr:"ref,size_is=Count"`
 	TranslatedSids structures.LSAPR_TRANSLATED_SIDS_EX2
 	LookupLevel    structures.LSAP_LOOKUP_LEVEL
 	MappedCount    ndr.DWORD
@@ -32,7 +32,7 @@ type lsarLookupNames4Response struct {
 	ReferencedDomains *structures.LSAPR_REFERENCED_DOMAIN_LIST `ndr:"unique"`
 	TranslatedSids    structures.LSAPR_TRANSLATED_SIDS_EX2
 	MappedCount       ndr.DWORD
-	Status            ndr.DWORD
+	Status            ndr.DWORD `ndr:"retval"`
 }
 
 // LsarLookupNames4 calls LsarLookupNames4 (opnum 77) to translate a set of account names

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/functions.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/functions.go
@@ -18,11 +18,11 @@ import (
 // Open*/Create* methods).
 type handleResponse struct {
 	Handle structures.LSAPR_HANDLE
-	Status ndr.DWORD
+	Status ndr.DWORD `ndr:"retval"`
 }
 
 // statusResponse is the reply shape for methods with no [out] parameters beyond the
 // NTSTATUS return value (the Set*/Add*/Remove*/Delete* methods).
 type statusResponse struct {
-	Status ndr.DWORD
+	Status ndr.DWORD `ndr:"retval"`
 }

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/live_validation_test.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/live_validation_test.go
@@ -1,0 +1,241 @@
+//go:build integration
+
+// Live-DC wire-validation harness for the lsarpc methods whose NDR is more complex than
+// the basic OpenPolicy2/Close path (issue #421 follow-up). It exercises only READ-ONLY
+// methods (Query/Lookup/Enumerate) — it never creates, sets, or deletes server state.
+//
+// For each method it classifies the outcome:
+//   - decoded OK   : the call returned STATUS_SUCCESS and the response NDR decoded;
+//   - server status: the server returned an NTSTATUS (e.g. ACCESS_DENIED) — the request
+//     was understood and the status decoded, so the wire path is valid;
+//   - WIRE FAIL    : a transport/fault/NDR error — the request marshalling or response
+//     decoding is wrong. This is the only outcome that fails the test.
+//
+// Run with:
+//
+//	DCERPC_TEST_HOST=192.168.1.27 DCERPC_TEST_USER=user DCERPC_TEST_PASS=user \
+//	go test -tags integration -run TestLiveValidation -v \
+//	  ./network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/
+package functions_test
+
+import (
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/structures"
+	dcerpcsmb "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/transport/smb"
+	smbclient "github.com/TheManticoreProject/Manticore/network/smb/smb_v10/client"
+	"github.com/TheManticoreProject/Manticore/windows/credentials"
+)
+
+// classify reports the wire outcome of a method call:
+//   - nil error                 -> decoded OK (STATUS_SUCCESS, response NDR decoded);
+//   - transport/pipe/fault error -> WIRE FAIL (request marshalling or response decode
+//     wrong; the server faulted or tore down the pipe);
+//   - "<Method> failed: <ntstatus>" -> the server returned an application NTSTATUS, i.e.
+//     the request was understood and the status decoded.
+//
+// Returns (wireOK, decodedSuccess).
+func classify(t *testing.T, method string, err error) (bool, bool) {
+	t.Helper()
+	if err == nil {
+		t.Logf("[decoded OK]    %s", method)
+		return true, true
+	}
+	msg := err.Error()
+	transport := strings.Contains(msg, "named pipe") || strings.Contains(msg, "ReadAndx") ||
+		strings.Contains(msg, "dcerpc call") || strings.Contains(msg, "fault") ||
+		strings.Contains(msg, "unmarshal") || strings.Contains(msg, "decode")
+	// Our method wrappers report a decoded NTSTATUS as "<Method> failed: <status>".
+	appStatus := strings.Contains(msg, "failed: STATUS_") || strings.Contains(msg, "failed: 0x")
+	if appStatus && !transport {
+		t.Logf("[server status] %s -> %v", method, err)
+		return true, false
+	}
+	t.Errorf("[WIRE FAIL]     %s -> %v", method, err)
+	return false, false
+}
+
+func TestLiveValidation(t *testing.T) {
+	host := os.Getenv("DCERPC_TEST_HOST")
+	if host == "" {
+		t.Skip("DCERPC_TEST_HOST not set; skipping live validation")
+	}
+	port := 445
+	if p := os.Getenv("DCERPC_TEST_PORT"); p != "" {
+		n, err := strconv.Atoi(p)
+		if err != nil {
+			t.Fatalf("invalid DCERPC_TEST_PORT %q: %v", p, err)
+		}
+		port = n
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		t.Fatalf("DCERPC_TEST_HOST %q is not a valid IP", host)
+	}
+	creds, err := credentials.NewCredentials(os.Getenv("DCERPC_TEST_DOMAIN"), os.Getenv("DCERPC_TEST_USER"), os.Getenv("DCERPC_TEST_PASS"), "")
+	if err != nil {
+		t.Fatalf("NewCredentials: %v", err)
+	}
+
+	smb := smbclient.NewClientUsingTCPTransport(ip, port)
+	if err := smb.Connect(ip, port); err != nil {
+		t.Fatalf("SMB Connect: %v", err)
+	}
+	defer smb.Disconnect()
+	smb.NativeOS = "Unix"
+	smb.NativeLanMan = "Samba"
+	if err := smb.SessionSetup(creds); err != nil {
+		t.Fatalf("SMB SessionSetup: %v", err)
+	}
+	defer smb.Logoff()
+	if err := smb.TreeConnect("IPC$"); err != nil {
+		t.Fatalf("SMB TreeConnect(IPC$): %v", err)
+	}
+	defer smb.TreeDisconnect()
+
+	// withPolicy runs fn on a FRESH pipe + bind + policy handle, so a method that faults
+	// or tears down the pipe cannot corrupt the next method's result.
+	withPolicy := func(name string, fn func(rpc *client.Client, policy structures.LSAPR_HANDLE)) {
+		rpc := client.NewClient(dcerpcsmb.New(smb, lsarpc.PipeName))
+		defer rpc.Close()
+		if err := rpc.Bind(lsarpc.SyntaxID()); err != nil {
+			t.Errorf("[WIRE FAIL]     %s: bind: %v", name, err)
+			return
+		}
+		policy, err := functions.LsarOpenPolicy2(rpc, lsarpc.MaximumAllowed)
+		if err != nil {
+			t.Errorf("[setup fail]    %s: OpenPolicy2: %v", name, err)
+			return
+		}
+		defer func() { _, _ = functions.LsarClose(rpc, policy) }()
+		fn(rpc, policy)
+	}
+
+	// --- Union path: LsarQueryInformationPolicy (union decode + RPC_UNICODE_STRING + SID) ---
+	withPolicy("LsarQueryInformationPolicy(AccountDomain)", func(rpc *client.Client, policy structures.LSAPR_HANDLE) {
+		info, err := functions.LsarQueryInformationPolicy(rpc, policy, structures.PolicyAccountDomainInformation)
+		if _, ok := classify(t, "LsarQueryInformationPolicy(AccountDomain)", err); ok && err == nil {
+			ad := info.PolicyAccountDomainInfo
+			sid := "<nil>"
+			if ad.DomainSid != nil {
+				sid = ad.DomainSid.String()
+			}
+			t.Logf("    account domain: name=%q sid=%s", ad.DomainName.String(), sid)
+		}
+	})
+	withPolicy("LsarQueryInformationPolicy(PrimaryDomain)", func(rpc *client.Client, policy structures.LSAPR_HANDLE) {
+		info, err := functions.LsarQueryInformationPolicy(rpc, policy, structures.PolicyPrimaryDomainInformation)
+		if _, ok := classify(t, "LsarQueryInformationPolicy(PrimaryDomain)", err); ok && err == nil {
+			pd := info.PolicyPrimaryDomainInfo
+			sid := "<nil>"
+			if pd.Sid != nil {
+				sid = pd.Sid.String()
+			}
+			t.Logf("    primary domain: name=%q sid=%s", pd.Name.String(), sid)
+		}
+	})
+
+	// Isolation probe: a union arm with NO RPC_UNICODE_STRING (server-role = a bare enum),
+	// to tell whether union failures are the union machinery or the string type.
+	withPolicy("LsarQueryInformationPolicy(ServerRole)", func(rpc *client.Client, policy structures.LSAPR_HANDLE) {
+		info, err := functions.LsarQueryInformationPolicy(rpc, policy, structures.PolicyLsaServerRoleInformation)
+		if _, ok := classify(t, "LsarQueryInformationPolicy(ServerRole)", err); ok && err == nil {
+			t.Logf("    server role = %d", info.PolicyServerRoleInfo.LsaServerRole)
+		}
+	})
+
+	// --- SID->name: LsarLookupSids (SID array in + translated-names array out + referenced domains) ---
+	withPolicy("LsarLookupSids", func(rpc *client.Client, policy structures.LSAPR_HANDLE) {
+		var sidInfos []structures.LSAPR_SID_INFORMATION
+		for _, s := range []string{"S-1-5-32-544", "S-1-1-0", "S-1-5-18"} {
+			sid, perr := dtyp.ParseSID(s)
+			if perr != nil {
+				t.Fatalf("ParseSID(%s): %v", s, perr)
+			}
+			sidInfos = append(sidInfos, structures.LSAPR_SID_INFORMATION{Sid: &sid})
+		}
+		sidBuf := structures.LSAPR_SID_ENUM_BUFFER{Entries: uint32(len(sidInfos)), SidInfo: sidInfos}
+		dom, names, mapped, err := functions.LsarLookupSids(rpc, policy, sidBuf, structures.LsapLookupWksta)
+		if _, ok := classify(t, "LsarLookupSids(Administrators,Everyone,System)", err); ok && err == nil {
+			t.Logf("    mapped=%d names.Entries=%d", mapped, names.Entries)
+			for i, n := range names.Names {
+				d := "?"
+				if dom != nil && int(n.DomainIndex) >= 0 && int(n.DomainIndex) < len(dom.Domains) {
+					d = dom.Domains[n.DomainIndex].Name.String()
+				}
+				t.Logf("    [%d] use=%d name=%q domain=%q", i, n.Use, n.Name.String(), d)
+			}
+		}
+	})
+
+	// --- name->SID: LsarLookupNames (RPC_UNICODE_STRING array in + translated-sids out) ---
+	withPolicy("LsarLookupNames", func(rpc *client.Client, policy structures.LSAPR_HANDLE) {
+		names := []dtyp.RPC_UNICODE_STRING{dtyp.NewUnicodeString("Administrator"), dtyp.NewUnicodeString("Guest")}
+		dom, sids, mapped, err := functions.LsarLookupNames(rpc, policy, names, structures.LsapLookupWksta)
+		if _, ok := classify(t, "LsarLookupNames(Administrator,Guest)", err); ok && err == nil {
+			t.Logf("    mapped=%d sids.Entries=%d referencedDomains=%d", mapped, sids.Entries, domCount(dom))
+			for i, s := range sids.Sids {
+				t.Logf("    [%d] use=%d rid=%d domainIndex=%d", i, s.Use, s.RelativeId, s.DomainIndex)
+			}
+		}
+	})
+
+	// --- LUID + string: LsarLookupPrivilegeValue then LsarLookupPrivilegeName ---
+	withPolicy("LsarLookupPrivilegeValue/Name", func(rpc *client.Client, policy structures.LSAPR_HANDLE) {
+		luid, err := functions.LsarLookupPrivilegeValue(rpc, policy, "SeShutdownPrivilege")
+		if _, ok := classify(t, "LsarLookupPrivilegeValue(SeShutdownPrivilege)", err); ok && err == nil {
+			t.Logf("    LUID = {low=%#x high=%#x}", luid.LowPart, luid.HighPart)
+			name, err := functions.LsarLookupPrivilegeName(rpc, policy, luid)
+			if _, ok := classify(t, "LsarLookupPrivilegeName(<luid>)", err); ok && err == nil && name != nil {
+				t.Logf("    name = %q", name.String())
+			}
+		}
+	})
+
+	// --- Array-of-pointer-struct buffers ---
+	withPolicy("LsarEnumeratePrivileges", func(rpc *client.Client, policy structures.LSAPR_HANDLE) {
+		_, buf, err := functions.LsarEnumeratePrivileges(rpc, policy, 0, 0x10000)
+		if _, ok := classify(t, "LsarEnumeratePrivileges", err); ok && err == nil {
+			t.Logf("    privileges returned: %d", buf.Entries)
+			for i, p := range buf.Privileges {
+				if i >= 5 {
+					t.Logf("    ... (%d total)", buf.Entries)
+					break
+				}
+				t.Logf("    [%d] %q luid={low=%#x high=%#x}", i, p.Name.String(), p.LocalValue.LowPart, p.LocalValue.HighPart)
+			}
+		}
+	})
+	withPolicy("LsarEnumerateAccounts", func(rpc *client.Client, policy structures.LSAPR_HANDLE) {
+		buf, _, err := functions.LsarEnumerateAccounts(rpc, policy, 0, 0x10000)
+		if _, ok := classify(t, "LsarEnumerateAccounts", err); ok && err == nil {
+			t.Logf("    accounts returned: %d", buf.EntriesRead)
+			for i, a := range buf.Information {
+				if i >= 8 {
+					t.Logf("    ... (%d total)", buf.EntriesRead)
+					break
+				}
+				sid := "<nil>"
+				if a.Sid != nil {
+					sid = a.Sid.String()
+				}
+				t.Logf("    [%d] %s", i, sid)
+			}
+		}
+	})
+}
+
+func domCount(d *structures.LSAPR_REFERENCED_DOMAIN_LIST) uint32 {
+	if d == nil {
+		return 0
+	}
+	return d.Entries
+}


### PR DESCRIPTION
### Linked Issue
Closes #426.

### Root Cause
`RPC_UNICODE_STRING` failing on the wire was a symptom of four NDR codec defects (in `network/dcerpc/ndr`) plus two lsarpc parameter-modeling mistakes. All were invisible to Go-internal round-trip tests because marshal and unmarshal shared the same wrong assumptions; they only appeared against a real server. Diagnosed by capturing live LSA responses from Windows XP SP3 and hand-decoding them, cross-checked against [C706] ch. 14 and [MS-DTYP].

The codec defects:
1. **Top-level pointer deferral** — a top-level `[unique]`/`[full]` pointer parameter deferred its referent body to the end of the construction; NDR transmits it in place, right after the referent id. Only *embedded* pointers defer. ([C706] 14.3.10)
2. **Struct alignment** — a structure was not aligned to its largest member before its first field, so an `RPC_UNICODE_STRING` after a 2-byte field decoded 2 bytes misaligned. ([C706] 14.2.2)
3. **Deferral scope** — an inline struct *value* flushed its embedded pointers at its own end instead of the enclosing construction's. Each top-level parameter is its own construction; only nested struct values thread the parent queue. ([C706] 14.3.12.3)
4. **Union alignment** — unions pre-aligned the whole union to the largest-arm alignment before the discriminant. In fact the discriminant aligns to itself, and the *selected arm* aligns to the largest-arm alignment after the tag (verified: a 2-byte server-role arm still starts 8-aligned because sibling arms hold `LARGE_INTEGER`).

The lsarpc mistakes:
5. Response `Status` fields were not tagged as the RPC **retval**, so they decoded before the `[out]` deferred referents.
6. Top-level `[in] PRPC_UNICODE_STRING` params were modeled `[unique]` (spurious referent id → `nca_s_fault_ndr`), and `[in, size_is]` name arrays as bare conformant slices (count hoisted ahead of the policy handle → `nca_s_fault_context_mismatch`); both are `[ref]` pointers.

### Fix Description
`marshal.go`: top-level unique/full pointers marshal/unmarshal their referent in place; structs align to `ndrAlignment`; inline struct values thread the enclosing deferred queue only when embedded. `union.go`: align the discriminant to itself and the arm to the max-arm alignment after the tag. lsarpc: `Status` → `ndr:"retval"`; `[in]` string params → inline `[ref]` values; `[in,size_is]` name arrays → `ref` pointers to conformant arrays. Golden tests updated to the spec-correct (wire-verified) layouts.

### How Verified
- **Live**, against Windows XP SP3 (192.168.1.27): an integration-gated `TestLiveValidation` harness drives `LsarQueryInformationPolicy` (AccountDomain/PrimaryDomain/ServerRole — the union path), `LsarLookupSids`/`LsarLookupNames`, `LsarLookupPrivilegeValue`/`LsarLookupPrivilegeName`, and `LsarEnumeratePrivileges`/`LsarEnumerateAccounts`. All decode correctly (e.g. `THINKPAD-X61`/`S-1-5-21-…`, `Administrateurs`@`BUILTIN`, 29 privileges, 12 accounts).
- **Offline**: hand-decoded captured response bytes; full `go test ./network/dcerpc/...` passes (incl. updated golden + round-trip tests).

### Test Coverage
**Added:** `functions/live_validation_test.go` (integration-gated). Updated `ndr` golden tests (`TestMarshal_DeferredOrdering_GoldenBytes`, `TestUnion_Alignment`) to the wire-verified layouts.

### Scope of Change
- **Files changed:** `network/dcerpc/ndr/{marshal,union}.go` (+ their tests); the lsarpc `functions/` stubs (retval tags + param modeling) and a new harness.
- **Submodule pointer updated:** no.
- **Behavioral changes outside the bug fix:** none (the codec change is wire-correctness; existing interfaces re-tested).

### Risk and Rollout
The codec changes affect every NDR consumer, so the full `network/dcerpc/...` suite (v4 + v5 + srvsvc) was re-run and passes. The new behavior matches captured Windows bytes and [C706]. Safe to merge.
