### PR TITLE
[enhancement] Add SAMR (MS-SAMR) RPC interface 12345778-1234-abcd-ef00-0123456789ac v1.0

### DIFF
--- a/network/dcerpc/ndr/marshal.go
+++ b/network/dcerpc/ndr/marshal.go
@@ -260,10 +260,17 @@ func marshalInlineValue(e *Encoder, fv reflect.Value, tag fieldTag, deferred *[]
 		}
 		return marshalStruct(e, fv, true)
 	case reflect.Slice:
-		if tag.varying {
-			return marshalConformantVaryingArray(e, fv, elementTag(tag))
+		// maximum_count is the element count, unless size_is names a literal bound
+		// (e.g. MS-SAMR [size_is(1000)]), in which case the server requires that exact
+		// constant on the wire even when fewer elements are actually sent.
+		maxCount := uint32(fv.Len())
+		if tag.sizeConstSet {
+			maxCount = tag.sizeConst
 		}
-		return marshalConformantArray(e, fv, elementTag(tag))
+		if tag.varying {
+			return marshalConformantVaryingArray(e, fv, maxCount, elementTag(tag))
+		}
+		return marshalConformantArray(e, fv, maxCount, elementTag(tag))
 	case reflect.Array:
 		if fv.Type().Elem().Kind() == reflect.Uint8 {
 			b := make([]byte, fv.Len())
@@ -685,9 +692,9 @@ func conformantArrayAlignment(elemType reflect.Type) int {
 // marshalConformantArray writes a conformant array: a maximum_count followed by the
 // elements, per [MS-RPCE] Conformant Arrays:
 // https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/140b01a3-979b-43af-b1e3-28f248db8f03
-func marshalConformantArray(e *Encoder, slice reflect.Value, elemTag fieldTag) error {
+func marshalConformantArray(e *Encoder, slice reflect.Value, maxCount uint32, elemTag fieldTag) error {
 	e.Align(conformantArrayAlignment(slice.Type().Elem()))
-	e.WriteUint32(uint32(slice.Len()))
+	e.WriteUint32(maxCount)
 	return marshalElements(e, slice, elemTag)
 }
 
@@ -704,13 +711,14 @@ func unmarshalConformantArray(d *Decoder, slice reflect.Value, elemTag fieldTag)
 // marshalConformantVaryingArray writes a conformant-varying array: maximum_count,
 // offset, actual_count, then the elements, per [MS-RPCE] Conformant Varying Arrays:
 // https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/3acb31b0-b873-4aaf-8503-9727ec40fbec
-// The full slice is transmitted (offset 0, actual_count == maximum_count == len).
-func marshalConformantVaryingArray(e *Encoder, slice reflect.Value, elemTag fieldTag) error {
+// The whole slice is transmitted (offset 0, actual_count == len). maximum_count is the
+// length unless a literal size_is bound was given, in which case the constant is sent
+// while actual_count still reflects the elements actually present.
+func marshalConformantVaryingArray(e *Encoder, slice reflect.Value, maxCount uint32, elemTag fieldTag) error {
 	e.Align(conformantArrayAlignment(slice.Type().Elem()))
-	n := uint32(slice.Len())
-	e.WriteUint32(n) // maximum_count
-	e.WriteUint32(0) // offset
-	e.WriteUint32(n) // actual_count
+	e.WriteUint32(maxCount)            // maximum_count
+	e.WriteUint32(0)                   // offset
+	e.WriteUint32(uint32(slice.Len())) // actual_count
 	return marshalElements(e, slice, elemTag)
 }
 

--- a/network/dcerpc/ndr/sizeis_test.go
+++ b/network/dcerpc/ndr/sizeis_test.go
@@ -36,3 +36,30 @@ func TestSizeIs_CountDerivedFromArray(t *testing.T) {
 		t.Errorf("round trip: CbData=%d BData=%x", out.CbData, out.BData)
 	}
 }
+
+// TestSizeIs_LiteralConstant verifies that a literal size_is(<N>) emits the constant N as
+// the conformant maximum_count while actual_count reflects the elements actually present,
+// matching MS-SAMR's [in, size_is(1000), length_is(Count)] arrays (the server requires the
+// fixed bound on the wire). This is the SamrLookupNamesInDomain/SamrLookupIdsInDomain shape.
+func TestSizeIs_LiteralConstant(t *testing.T) {
+	type req struct {
+		Count uint32
+		Rids  []uint32 `ndr:"ref,size_is=1000,varying"`
+	}
+	in := &req{Count: 2, Rids: []uint32{0x1f4, 0x1f5}}
+	raw, err := Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	want := []byte{
+		0x02, 0x00, 0x00, 0x00, // Count
+		0xe8, 0x03, 0x00, 0x00, // maximum_count == literal 1000, not len
+		0x00, 0x00, 0x00, 0x00, // offset
+		0x02, 0x00, 0x00, 0x00, // actual_count == len(Rids)
+		0xf4, 0x01, 0x00, 0x00, // Rids[0]
+		0xf5, 0x01, 0x00, 0x00, // Rids[1]
+	}
+	if !bytes.Equal(raw, want) {
+		t.Errorf("literal size_is:\n got %x\nwant %x", raw, want)
+	}
+}

--- a/network/dcerpc/ndr/types.go
+++ b/network/dcerpc/ndr/types.go
@@ -73,17 +73,19 @@ const (
 
 // fieldTag is the parsed `ndr:"..."` struct tag.
 type fieldTag struct {
-	skip       bool
-	ptr        ptrKind
-	wide       bool    // [string] wide (UTF-16)
-	ascii      bool    // [string] ASCII
-	conformant bool    // conformant array (size_is)
-	varying    bool    // conformant-varying array (offset + actual_count framing)
-	sizeIs     string  // sibling field naming the maximum element count
-	lengthIs   string  // sibling field naming the actual element count
-	align      int     // explicit alignment override (0 = default)
-	retval     bool    // RPC return value: encoded after the struct's deferred referents
-	elemPtr    ptrKind // pointer attribute of array elements (`elem=ref|unique|ptr`)
+	skip         bool
+	ptr          ptrKind
+	wide         bool    // [string] wide (UTF-16)
+	ascii        bool    // [string] ASCII
+	conformant   bool    // conformant array (size_is)
+	varying      bool    // conformant-varying array (offset + actual_count framing)
+	sizeIs       string  // sibling field naming the maximum element count
+	lengthIs     string  // sibling field naming the actual element count
+	sizeConst    uint32  // literal maximum_count (size_is(<N>)); used when sizeConstSet
+	sizeConstSet bool    // size_is was a numeric literal rather than a sibling field name
+	align        int     // explicit alignment override (0 = default)
+	retval       bool    // RPC return value: encoded after the struct's deferred referents
+	elemPtr      ptrKind // pointer attribute of array elements (`elem=ref|unique|ptr`)
 
 	// Union (discriminated by an inline switch value, [C706] section 14.3.8) tags.
 	isSwitch  bool  // the union discriminant field (`switch`)
@@ -121,7 +123,15 @@ func parseTag(raw string) fieldTag {
 			t.retval = true
 		case strings.HasPrefix(opt, "size_is="):
 			t.conformant = true
-			t.sizeIs = strings.TrimPrefix(opt, "size_is=")
+			v := strings.TrimPrefix(opt, "size_is=")
+			// size_is(<constant>) — a literal maximum_count, e.g. [size_is(1000)] in
+			// MS-SAMR. Distinguished from a sibling field name by parsing as a number.
+			if n, err := strconv.ParseUint(v, 10, 32); err == nil {
+				t.sizeConst = uint32(n)
+				t.sizeConstSet = true
+			} else {
+				t.sizeIs = v
+			}
 		case strings.HasPrefix(opt, "length_is="):
 			t.conformant = true
 			t.varying = true

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/00_SamrConnect.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/00_SamrConnect.go
@@ -1,0 +1,37 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrConnectRequest carries the [in] parameters of SamrConnect: the [unique]
+// server name (PSAMPR_SERVER_NAME, NULL for the local server) and the desired
+// access mask for the returned server handle.
+type samrConnectRequest struct {
+	ServerName    *ndr.WSTR `ndr:"unique"`
+	DesiredAccess ndr.DWORD
+}
+
+func (*samrConnectRequest) Opnum() uint16 { return samr.OpnumSamrConnect }
+
+// SamrConnect calls SamrConnect (opnum 0), obtaining a handle to a server object
+// ([MS-SAMR] 3.1.5.1.4).
+func SamrConnect(rpc *client.Client, serverName string, desiredAccess uint32) (structures.SAMPR_HANDLE, error) {
+	req := &samrConnectRequest{
+		ServerName:    optWStr(serverName),
+		DesiredAccess: ndr.DWORD(desiredAccess),
+	}
+	var resp openHandleResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return structures.SAMPR_HANDLE{}, fmt.Errorf("SamrConnect: %w", err)
+	}
+	if uint32(resp.Status) != samr.StatusSuccess {
+		return resp.Handle, fmt.Errorf("SamrConnect failed: %s", samr.StatusString(uint32(resp.Status)))
+	}
+	return resp.Handle, nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/01_SamrCloseHandle.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/01_SamrCloseHandle.go
@@ -1,0 +1,31 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrCloseHandleRequest carries the [in,out] SAMPR_HANDLE to be closed. On
+// success the server returns it zeroed via the shared handleResponse.
+type samrCloseHandleRequest struct {
+	SamHandle structures.SAMPR_HANDLE
+}
+
+func (*samrCloseHandleRequest) Opnum() uint16 { return samr.OpnumSamrCloseHandle }
+
+// SamrCloseHandle calls SamrCloseHandle (opnum 1), releasing server resources for
+// the supplied handle and returning the (now zeroed) handle ([MS-SAMR] 3.1.5.13.1).
+func SamrCloseHandle(rpc *client.Client, handle structures.SAMPR_HANDLE) (structures.SAMPR_HANDLE, error) {
+	req := &samrCloseHandleRequest{SamHandle: handle}
+	var resp handleResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return handle, fmt.Errorf("SamrCloseHandle: %w", err)
+	}
+	if uint32(resp.Status) != samr.StatusSuccess {
+		return resp.Handle, fmt.Errorf("SamrCloseHandle failed: %s", samr.StatusString(uint32(resp.Status)))
+	}
+	return resp.Handle, nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/02_SamrSetSecurityObject.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/02_SamrSetSecurityObject.go
@@ -1,0 +1,39 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrSetSecurityObjectRequest carries the [in] parameters of SamrSetSecurityObject:
+// the target object handle, the SECURITY_INFORMATION selecting which parts to set,
+// and the [ref] self-relative security descriptor (modeled inline).
+type samrSetSecurityObjectRequest struct {
+	ObjectHandle        structures.SAMPR_HANDLE
+	SecurityInformation ndr.DWORD
+	SecurityDescriptor  structures.SAMPR_SR_SECURITY_DESCRIPTOR
+}
+
+func (*samrSetSecurityObjectRequest) Opnum() uint16 { return samr.OpnumSamrSetSecurityObject }
+
+// SamrSetSecurityObject calls SamrSetSecurityObject (opnum 2), setting the security
+// descriptor of the referenced object ([MS-SAMR] 3.1.5.12.2).
+func SamrSetSecurityObject(rpc *client.Client, handle structures.SAMPR_HANDLE, securityInformation uint32, securityDescriptor structures.SAMPR_SR_SECURITY_DESCRIPTOR) error {
+	req := &samrSetSecurityObjectRequest{
+		ObjectHandle:        handle,
+		SecurityInformation: ndr.DWORD(securityInformation),
+		SecurityDescriptor:  securityDescriptor,
+	}
+	var resp statusResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return fmt.Errorf("SamrSetSecurityObject: %w", err)
+	}
+	if uint32(resp.Status) != samr.StatusSuccess {
+		return fmt.Errorf("SamrSetSecurityObject failed: %s", samr.StatusString(uint32(resp.Status)))
+	}
+	return nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/03_SamrQuerySecurityObject.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/03_SamrQuerySecurityObject.go
@@ -1,0 +1,44 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrQuerySecurityObjectRequest carries the [in] parameters of
+// SamrQuerySecurityObject: the target object handle and the SECURITY_INFORMATION
+// selecting which parts of the descriptor to retrieve.
+type samrQuerySecurityObjectRequest struct {
+	ObjectHandle        structures.SAMPR_HANDLE
+	SecurityInformation ndr.DWORD
+}
+
+func (*samrQuerySecurityObjectRequest) Opnum() uint16 { return samr.OpnumSamrQuerySecurityObject }
+
+// samrQuerySecurityObjectResponse carries the [out] double pointer to the
+// self-relative security descriptor and the NTSTATUS.
+type samrQuerySecurityObjectResponse struct {
+	SecurityDescriptor *structures.SAMPR_SR_SECURITY_DESCRIPTOR `ndr:"unique"`
+	Status             ndr.DWORD                                `ndr:"retval"`
+}
+
+// SamrQuerySecurityObject calls SamrQuerySecurityObject (opnum 3), retrieving the
+// security descriptor of the referenced object ([MS-SAMR] 3.1.5.12.1).
+func SamrQuerySecurityObject(rpc *client.Client, handle structures.SAMPR_HANDLE, securityInformation uint32) (*structures.SAMPR_SR_SECURITY_DESCRIPTOR, error) {
+	req := &samrQuerySecurityObjectRequest{
+		ObjectHandle:        handle,
+		SecurityInformation: ndr.DWORD(securityInformation),
+	}
+	var resp samrQuerySecurityObjectResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return nil, fmt.Errorf("SamrQuerySecurityObject: %w", err)
+	}
+	if uint32(resp.Status) != samr.StatusSuccess {
+		return resp.SecurityDescriptor, fmt.Errorf("SamrQuerySecurityObject failed: %s", samr.StatusString(uint32(resp.Status)))
+	}
+	return resp.SecurityDescriptor, nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/05_SamrLookupDomainInSamServer.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/05_SamrLookupDomainInSamServer.go
@@ -1,0 +1,47 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrLookupDomainInSamServerRequest carries the [in] parameters of
+// SamrLookupDomainInSamServer: the server handle and the [ref] domain name to
+// resolve (modeled inline as an RPC_UNICODE_STRING).
+type samrLookupDomainInSamServerRequest struct {
+	ServerHandle structures.SAMPR_HANDLE
+	Name         dtyp.RPC_UNICODE_STRING
+}
+
+func (*samrLookupDomainInSamServerRequest) Opnum() uint16 {
+	return samr.OpnumSamrLookupDomainInSamServer
+}
+
+// samrLookupDomainInSamServerResponse carries the [out] double pointer to the
+// resolved domain SID and the NTSTATUS.
+type samrLookupDomainInSamServerResponse struct {
+	DomainId *dtyp.RPC_SID `ndr:"unique"`
+	Status   ndr.DWORD     `ndr:"retval"`
+}
+
+// SamrLookupDomainInSamServer calls SamrLookupDomainInSamServer (opnum 5),
+// resolving a domain name to its SID ([MS-SAMR] 3.1.5.11.1).
+func SamrLookupDomainInSamServer(rpc *client.Client, handle structures.SAMPR_HANDLE, name string) (*dtyp.RPC_SID, error) {
+	req := &samrLookupDomainInSamServerRequest{
+		ServerHandle: handle,
+		Name:         dtyp.NewUnicodeString(name),
+	}
+	var resp samrLookupDomainInSamServerResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return nil, fmt.Errorf("SamrLookupDomainInSamServer: %w", err)
+	}
+	if uint32(resp.Status) != samr.StatusSuccess {
+		return resp.DomainId, fmt.Errorf("SamrLookupDomainInSamServer failed: %s", samr.StatusString(uint32(resp.Status)))
+	}
+	return resp.DomainId, nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/06_SamrEnumerateDomainsInSamServer.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/06_SamrEnumerateDomainsInSamServer.go
@@ -1,0 +1,54 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrEnumerateDomainsInSamServerRequest carries the [in] parameters: the server
+// handle, the [in,out] enumeration context (a cookie that resumes a prior call),
+// and the preferred maximum byte length of the returned buffer.
+type samrEnumerateDomainsInSamServerRequest struct {
+	ServerHandle          structures.SAMPR_HANDLE
+	EnumerationContext    ndr.DWORD
+	PreferedMaximumLength ndr.DWORD
+}
+
+func (*samrEnumerateDomainsInSamServerRequest) Opnum() uint16 {
+	return samr.OpnumSamrEnumerateDomainsInSamServer
+}
+
+// samrEnumerateDomainsInSamServerResponse carries the [out]/[in,out] parameters:
+// the updated enumeration context, the [unique] enumeration buffer, the count of
+// entries returned, and the NTSTATUS.
+type samrEnumerateDomainsInSamServerResponse struct {
+	EnumerationContext ndr.DWORD
+	Buffer             *structures.SAMPR_ENUMERATION_BUFFER `ndr:"unique"`
+	CountReturned      ndr.DWORD
+	Status             ndr.DWORD `ndr:"retval"`
+}
+
+// SamrEnumerateDomainsInSamServer calls SamrEnumerateDomainsInSamServer (opnum 6),
+// listing the domains hosted by the server ([MS-SAMR] 3.1.5.2.1). A return of
+// STATUS_MORE_ENTRIES indicates further entries remain; resume with the returned
+// enumeration context.
+func SamrEnumerateDomainsInSamServer(rpc *client.Client, handle structures.SAMPR_HANDLE, enumerationContext uint32, preferedMaximumLength uint32) (uint32, *structures.SAMPR_ENUMERATION_BUFFER, uint32, error) {
+	req := &samrEnumerateDomainsInSamServerRequest{
+		ServerHandle:          handle,
+		EnumerationContext:    ndr.DWORD(enumerationContext),
+		PreferedMaximumLength: ndr.DWORD(preferedMaximumLength),
+	}
+	var resp samrEnumerateDomainsInSamServerResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return 0, nil, 0, fmt.Errorf("SamrEnumerateDomainsInSamServer: %w", err)
+	}
+	status := uint32(resp.Status)
+	if status != samr.StatusSuccess && status != samr.StatusMoreEntries {
+		return uint32(resp.EnumerationContext), resp.Buffer, uint32(resp.CountReturned), fmt.Errorf("SamrEnumerateDomainsInSamServer failed: %s", samr.StatusString(status))
+	}
+	return uint32(resp.EnumerationContext), resp.Buffer, uint32(resp.CountReturned), nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/07_SamrOpenDomain.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/07_SamrOpenDomain.go
@@ -1,0 +1,39 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrOpenDomainRequest is the [in] parameter set of SamrOpenDomain: a server handle, the
+// desired access mask, and the [ref] SID of the domain to open (inline, single pointer).
+type samrOpenDomainRequest struct {
+	ServerHandle  structures.SAMPR_HANDLE
+	DesiredAccess ndr.DWORD
+	DomainId      dtyp.RPC_SID
+}
+
+func (*samrOpenDomainRequest) Opnum() uint16 { return samr.OpnumSamrOpenDomain }
+
+// SamrOpenDomain calls SamrOpenDomain (opnum 7), obtaining a handle to a domain object
+// given its SID ([MS-SAMR] 3.1.5.1.5).
+func SamrOpenDomain(rpc *client.Client, serverHandle structures.SAMPR_HANDLE, desiredAccess uint32, domainId dtyp.RPC_SID) (structures.SAMPR_HANDLE, error) {
+	req := &samrOpenDomainRequest{
+		ServerHandle:  serverHandle,
+		DesiredAccess: ndr.DWORD(desiredAccess),
+		DomainId:      domainId,
+	}
+	var resp openHandleResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return structures.SAMPR_HANDLE{}, fmt.Errorf("SamrOpenDomain: %w", err)
+	}
+	if uint32(resp.Status) != samr.StatusSuccess {
+		return resp.Handle, fmt.Errorf("SamrOpenDomain failed: %s", samr.StatusString(uint32(resp.Status)))
+	}
+	return resp.Handle, nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/08_SamrQueryInformationDomain.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/08_SamrQueryInformationDomain.go
@@ -1,0 +1,45 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrQueryInformationDomainRequest is the [in] parameter set of SamrQueryInformationDomain:
+// a domain handle and the information class selecting the union arm to return.
+type samrQueryInformationDomainRequest struct {
+	DomainHandle           structures.SAMPR_HANDLE
+	DomainInformationClass structures.DOMAIN_INFORMATION_CLASS
+}
+
+func (*samrQueryInformationDomainRequest) Opnum() uint16 {
+	return samr.OpnumSamrQueryInformationDomain
+}
+
+// samrQueryInformationDomainResponse is the reply: the [out, switch_is] double-pointer
+// SAMPR_DOMAIN_INFO_BUFFER union (modeled [unique]) and the NTSTATUS.
+type samrQueryInformationDomainResponse struct {
+	Buffer *structures.SAMPR_DOMAIN_INFO_BUFFER `ndr:"unique"`
+	Status ndr.DWORD                            `ndr:"retval"`
+}
+
+// SamrQueryInformationDomain calls SamrQueryInformationDomain (opnum 8), retrieving domain
+// attributes selected by class ([MS-SAMR] 3.1.5.5.2). The returned union carries its own Tag.
+func SamrQueryInformationDomain(rpc *client.Client, domainHandle structures.SAMPR_HANDLE, class uint16) (*structures.SAMPR_DOMAIN_INFO_BUFFER, error) {
+	req := &samrQueryInformationDomainRequest{
+		DomainHandle:           domainHandle,
+		DomainInformationClass: structures.DOMAIN_INFORMATION_CLASS(class),
+	}
+	var resp samrQueryInformationDomainResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return nil, fmt.Errorf("SamrQueryInformationDomain: %w", err)
+	}
+	if uint32(resp.Status) != samr.StatusSuccess {
+		return resp.Buffer, fmt.Errorf("SamrQueryInformationDomain failed: %s", samr.StatusString(uint32(resp.Status)))
+	}
+	return resp.Buffer, nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/09_SamrSetInformationDomain.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/09_SamrSetInformationDomain.go
@@ -1,0 +1,42 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrSetInformationDomainRequest is the [in] parameter set of SamrSetInformationDomain: a
+// domain handle, the information class, and the [in, switch_is] single-pointer union
+// (inline) carrying the new values.
+type samrSetInformationDomainRequest struct {
+	DomainHandle           structures.SAMPR_HANDLE
+	DomainInformationClass structures.DOMAIN_INFORMATION_CLASS
+	DomainInformation      structures.SAMPR_DOMAIN_INFO_BUFFER
+}
+
+func (*samrSetInformationDomainRequest) Opnum() uint16 {
+	return samr.OpnumSamrSetInformationDomain
+}
+
+// SamrSetInformationDomain calls SamrSetInformationDomain (opnum 9), updating domain
+// attributes selected by class ([MS-SAMR] 3.1.5.4.1). The information union's Tag is set
+// to match the class.
+func SamrSetInformationDomain(rpc *client.Client, domainHandle structures.SAMPR_HANDLE, class uint16, info structures.SAMPR_DOMAIN_INFO_BUFFER) error {
+	info.Tag = structures.DOMAIN_INFORMATION_CLASS(class)
+	req := &samrSetInformationDomainRequest{
+		DomainHandle:           domainHandle,
+		DomainInformationClass: structures.DOMAIN_INFORMATION_CLASS(class),
+		DomainInformation:      info,
+	}
+	var resp statusResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return fmt.Errorf("SamrSetInformationDomain: %w", err)
+	}
+	if uint32(resp.Status) != samr.StatusSuccess {
+		return fmt.Errorf("SamrSetInformationDomain failed: %s", samr.StatusString(uint32(resp.Status)))
+	}
+	return nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/10_SamrCreateGroupInDomain.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/10_SamrCreateGroupInDomain.go
@@ -1,0 +1,48 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrCreateGroupInDomainRequest carries the [in] parameters of SamrCreateGroupInDomain:
+// the domain handle, the [ref] group name, and the desired access mask for the returned
+// group handle.
+type samrCreateGroupInDomainRequest struct {
+	DomainHandle  structures.SAMPR_HANDLE
+	Name          dtyp.RPC_UNICODE_STRING
+	DesiredAccess ndr.DWORD
+}
+
+func (*samrCreateGroupInDomainRequest) Opnum() uint16 { return samr.OpnumSamrCreateGroupInDomain }
+
+// samrCreateGroupInDomainResponse is the reply: the [out] group handle, the relative id
+// assigned to the new group, and the NTSTATUS.
+type samrCreateGroupInDomainResponse struct {
+	GroupHandle structures.SAMPR_HANDLE
+	RelativeId  ndr.DWORD
+	Status      ndr.DWORD `ndr:"retval"`
+}
+
+// SamrCreateGroupInDomain calls SamrCreateGroupInDomain (opnum 10), creating a group object
+// in the given domain ([MS-SAMR] 3.1.5.4.1).
+func SamrCreateGroupInDomain(rpc *client.Client, domainHandle structures.SAMPR_HANDLE, name string, desiredAccess uint32) (structures.SAMPR_HANDLE, uint32, error) {
+	req := &samrCreateGroupInDomainRequest{
+		DomainHandle:  domainHandle,
+		Name:          dtyp.NewUnicodeString(name),
+		DesiredAccess: ndr.DWORD(desiredAccess),
+	}
+	var resp samrCreateGroupInDomainResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return structures.SAMPR_HANDLE{}, 0, fmt.Errorf("SamrCreateGroupInDomain: %w", err)
+	}
+	if uint32(resp.Status) != samr.StatusSuccess {
+		return resp.GroupHandle, uint32(resp.RelativeId), fmt.Errorf("SamrCreateGroupInDomain failed: %s", samr.StatusString(uint32(resp.Status)))
+	}
+	return resp.GroupHandle, uint32(resp.RelativeId), nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/11_SamrEnumerateGroupsInDomain.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/11_SamrEnumerateGroupsInDomain.go
@@ -1,0 +1,51 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrEnumerateGroupsInDomainRequest carries the [in] domain handle, the [in,out]
+// enumeration context, and the preferred maximum response length.
+type samrEnumerateGroupsInDomainRequest struct {
+	DomainHandle          structures.SAMPR_HANDLE
+	EnumerationContext    ndr.DWORD
+	PreferedMaximumLength ndr.DWORD
+}
+
+func (*samrEnumerateGroupsInDomainRequest) Opnum() uint16 {
+	return samr.OpnumSamrEnumerateGroupsInDomain
+}
+
+// samrEnumerateGroupsInDomainResponse is the reply: the [in,out] enumeration context, the
+// [out,unique] enumeration buffer, the number of entries returned, and the NTSTATUS.
+type samrEnumerateGroupsInDomainResponse struct {
+	EnumerationContext ndr.DWORD
+	Buffer             *structures.SAMPR_ENUMERATION_BUFFER `ndr:"unique"`
+	CountReturned      ndr.DWORD
+	Status             ndr.DWORD `ndr:"retval"`
+}
+
+// SamrEnumerateGroupsInDomain calls SamrEnumerateGroupsInDomain (opnum 11), enumerating the
+// groups in a domain ([MS-SAMR] 3.1.5.2.1). STATUS_MORE_ENTRIES is treated as success and
+// signals that further calls (with the returned enumeration context) are required.
+func SamrEnumerateGroupsInDomain(rpc *client.Client, domainHandle structures.SAMPR_HANDLE, enumerationContext uint32, preferedMaximumLength uint32) (uint32, *structures.SAMPR_ENUMERATION_BUFFER, uint32, error) {
+	req := &samrEnumerateGroupsInDomainRequest{
+		DomainHandle:          domainHandle,
+		EnumerationContext:    ndr.DWORD(enumerationContext),
+		PreferedMaximumLength: ndr.DWORD(preferedMaximumLength),
+	}
+	var resp samrEnumerateGroupsInDomainResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return 0, nil, 0, fmt.Errorf("SamrEnumerateGroupsInDomain: %w", err)
+	}
+	status := uint32(resp.Status)
+	if status != samr.StatusSuccess && status != samr.StatusMoreEntries {
+		return uint32(resp.EnumerationContext), resp.Buffer, uint32(resp.CountReturned), fmt.Errorf("SamrEnumerateGroupsInDomain failed: %s", samr.StatusString(status))
+	}
+	return uint32(resp.EnumerationContext), resp.Buffer, uint32(resp.CountReturned), nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/12_SamrCreateUserInDomain.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/12_SamrCreateUserInDomain.go
@@ -1,0 +1,48 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrCreateUserInDomainRequest carries the [in] parameters of SamrCreateUserInDomain: the
+// domain handle, the [ref] account name, and the desired access mask for the returned user
+// handle.
+type samrCreateUserInDomainRequest struct {
+	DomainHandle  structures.SAMPR_HANDLE
+	Name          dtyp.RPC_UNICODE_STRING
+	DesiredAccess ndr.DWORD
+}
+
+func (*samrCreateUserInDomainRequest) Opnum() uint16 { return samr.OpnumSamrCreateUserInDomain }
+
+// samrCreateUserInDomainResponse is the reply: the [out] user handle, the relative id
+// assigned to the new user, and the NTSTATUS.
+type samrCreateUserInDomainResponse struct {
+	UserHandle structures.SAMPR_HANDLE
+	RelativeId ndr.DWORD
+	Status     ndr.DWORD `ndr:"retval"`
+}
+
+// SamrCreateUserInDomain calls SamrCreateUserInDomain (opnum 12), creating a user object in
+// the given domain ([MS-SAMR] 3.1.5.4.4).
+func SamrCreateUserInDomain(rpc *client.Client, domainHandle structures.SAMPR_HANDLE, name string, desiredAccess uint32) (structures.SAMPR_HANDLE, uint32, error) {
+	req := &samrCreateUserInDomainRequest{
+		DomainHandle:  domainHandle,
+		Name:          dtyp.NewUnicodeString(name),
+		DesiredAccess: ndr.DWORD(desiredAccess),
+	}
+	var resp samrCreateUserInDomainResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return structures.SAMPR_HANDLE{}, 0, fmt.Errorf("SamrCreateUserInDomain: %w", err)
+	}
+	if uint32(resp.Status) != samr.StatusSuccess {
+		return resp.UserHandle, uint32(resp.RelativeId), fmt.Errorf("SamrCreateUserInDomain failed: %s", samr.StatusString(uint32(resp.Status)))
+	}
+	return resp.UserHandle, uint32(resp.RelativeId), nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/13_SamrEnumerateUsersInDomain.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/13_SamrEnumerateUsersInDomain.go
@@ -1,0 +1,54 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrEnumerateUsersInDomainRequest carries the [in] domain handle, the [in,out] enumeration
+// context, the user account control filter, and the preferred maximum response length.
+type samrEnumerateUsersInDomainRequest struct {
+	DomainHandle          structures.SAMPR_HANDLE
+	EnumerationContext    ndr.DWORD
+	UserAccountControl    ndr.DWORD
+	PreferedMaximumLength ndr.DWORD
+}
+
+func (*samrEnumerateUsersInDomainRequest) Opnum() uint16 {
+	return samr.OpnumSamrEnumerateUsersInDomain
+}
+
+// samrEnumerateUsersInDomainResponse is the reply: the [in,out] enumeration context, the
+// [out,unique] enumeration buffer, the number of entries returned, and the NTSTATUS.
+type samrEnumerateUsersInDomainResponse struct {
+	EnumerationContext ndr.DWORD
+	Buffer             *structures.SAMPR_ENUMERATION_BUFFER `ndr:"unique"`
+	CountReturned      ndr.DWORD
+	Status             ndr.DWORD `ndr:"retval"`
+}
+
+// SamrEnumerateUsersInDomain calls SamrEnumerateUsersInDomain (opnum 13), enumerating the
+// users in a domain filtered by UserAccountControl ([MS-SAMR] 3.1.5.2.5). STATUS_MORE_ENTRIES
+// is treated as success and signals that further calls (with the returned enumeration
+// context) are required.
+func SamrEnumerateUsersInDomain(rpc *client.Client, domainHandle structures.SAMPR_HANDLE, enumerationContext uint32, userAccountControl uint32, preferedMaximumLength uint32) (uint32, *structures.SAMPR_ENUMERATION_BUFFER, uint32, error) {
+	req := &samrEnumerateUsersInDomainRequest{
+		DomainHandle:          domainHandle,
+		EnumerationContext:    ndr.DWORD(enumerationContext),
+		UserAccountControl:    ndr.DWORD(userAccountControl),
+		PreferedMaximumLength: ndr.DWORD(preferedMaximumLength),
+	}
+	var resp samrEnumerateUsersInDomainResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return 0, nil, 0, fmt.Errorf("SamrEnumerateUsersInDomain: %w", err)
+	}
+	status := uint32(resp.Status)
+	if status != samr.StatusSuccess && status != samr.StatusMoreEntries {
+		return uint32(resp.EnumerationContext), resp.Buffer, uint32(resp.CountReturned), fmt.Errorf("SamrEnumerateUsersInDomain failed: %s", samr.StatusString(status))
+	}
+	return uint32(resp.EnumerationContext), resp.Buffer, uint32(resp.CountReturned), nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/14_SamrCreateAliasInDomain.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/14_SamrCreateAliasInDomain.go
@@ -1,0 +1,48 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrCreateAliasInDomainRequest carries the [in] parameters of SamrCreateAliasInDomain:
+// the domain handle, the [ref] alias account name, and the desired access mask for the
+// returned alias handle.
+type samrCreateAliasInDomainRequest struct {
+	DomainHandle  structures.SAMPR_HANDLE
+	AccountName   dtyp.RPC_UNICODE_STRING
+	DesiredAccess ndr.DWORD
+}
+
+func (*samrCreateAliasInDomainRequest) Opnum() uint16 { return samr.OpnumSamrCreateAliasInDomain }
+
+// samrCreateAliasInDomainResponse is the reply: the [out] alias handle, the new alias's
+// relative id, and the NTSTATUS.
+type samrCreateAliasInDomainResponse struct {
+	AliasHandle structures.SAMPR_HANDLE
+	RelativeId  ndr.DWORD
+	Status      ndr.DWORD `ndr:"retval"`
+}
+
+// SamrCreateAliasInDomain calls SamrCreateAliasInDomain (opnum 14), creating an alias in
+// the domain and returning a handle to it plus its RID ([MS-SAMR] 3.1.5.4.1).
+func SamrCreateAliasInDomain(rpc *client.Client, domainHandle structures.SAMPR_HANDLE, accountName string, desiredAccess uint32) (structures.SAMPR_HANDLE, uint32, error) {
+	req := &samrCreateAliasInDomainRequest{
+		DomainHandle:  domainHandle,
+		AccountName:   dtyp.NewUnicodeString(accountName),
+		DesiredAccess: ndr.DWORD(desiredAccess),
+	}
+	var resp samrCreateAliasInDomainResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return structures.SAMPR_HANDLE{}, 0, fmt.Errorf("SamrCreateAliasInDomain: %w", err)
+	}
+	if uint32(resp.Status) != samr.StatusSuccess {
+		return resp.AliasHandle, uint32(resp.RelativeId), fmt.Errorf("SamrCreateAliasInDomain failed: %s", samr.StatusString(uint32(resp.Status)))
+	}
+	return resp.AliasHandle, uint32(resp.RelativeId), nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/15_SamrEnumerateAliasesInDomain.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/15_SamrEnumerateAliasesInDomain.go
@@ -1,0 +1,51 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrEnumerateAliasesInDomainRequest carries the [in] domain handle, the [in,out]
+// enumeration context, and the preferred maximum response length.
+type samrEnumerateAliasesInDomainRequest struct {
+	DomainHandle          structures.SAMPR_HANDLE
+	EnumerationContext    ndr.DWORD
+	PreferedMaximumLength ndr.DWORD
+}
+
+func (*samrEnumerateAliasesInDomainRequest) Opnum() uint16 {
+	return samr.OpnumSamrEnumerateAliasesInDomain
+}
+
+// samrEnumerateAliasesInDomainResponse is the reply: the updated [in,out] enumeration
+// context, the [unique] enumeration buffer, the count returned, and the NTSTATUS.
+type samrEnumerateAliasesInDomainResponse struct {
+	EnumerationContext ndr.DWORD
+	Buffer             *structures.SAMPR_ENUMERATION_BUFFER `ndr:"unique"`
+	CountReturned      ndr.DWORD
+	Status             ndr.DWORD `ndr:"retval"`
+}
+
+// SamrEnumerateAliasesInDomain calls SamrEnumerateAliasesInDomain (opnum 15), enumerating
+// the aliases of the domain ([MS-SAMR] 3.1.5.2.4). STATUS_MORE_ENTRIES is a success-style
+// continuation status, not an error.
+func SamrEnumerateAliasesInDomain(rpc *client.Client, domainHandle structures.SAMPR_HANDLE, enumerationContext uint32, preferedMaximumLength uint32) (uint32, *structures.SAMPR_ENUMERATION_BUFFER, uint32, error) {
+	req := &samrEnumerateAliasesInDomainRequest{
+		DomainHandle:          domainHandle,
+		EnumerationContext:    ndr.DWORD(enumerationContext),
+		PreferedMaximumLength: ndr.DWORD(preferedMaximumLength),
+	}
+	var resp samrEnumerateAliasesInDomainResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return 0, nil, 0, fmt.Errorf("SamrEnumerateAliasesInDomain: %w", err)
+	}
+	status := uint32(resp.Status)
+	if status != samr.StatusSuccess && status != samr.StatusMoreEntries {
+		return uint32(resp.EnumerationContext), resp.Buffer, uint32(resp.CountReturned), fmt.Errorf("SamrEnumerateAliasesInDomain failed: %s", samr.StatusString(status))
+	}
+	return uint32(resp.EnumerationContext), resp.Buffer, uint32(resp.CountReturned), nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/16_SamrGetAliasMembership.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/16_SamrGetAliasMembership.go
@@ -1,0 +1,43 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrGetAliasMembershipRequest is the [in] parameter set of SamrGetAliasMembership: a
+// domain handle and the [ref] SID array (single pointer container, inline) to test.
+type samrGetAliasMembershipRequest struct {
+	DomainHandle structures.SAMPR_HANDLE
+	SidArray     structures.SAMPR_PSID_ARRAY
+}
+
+func (*samrGetAliasMembershipRequest) Opnum() uint16 { return samr.OpnumSamrGetAliasMembership }
+
+// samrGetAliasMembershipResponse is the reply: the [out] [ref] SAMPR_ULONG_ARRAY of RIDs
+// (single pointer container, inline) and the NTSTATUS.
+type samrGetAliasMembershipResponse struct {
+	Membership structures.SAMPR_ULONG_ARRAY
+	Status     ndr.DWORD `ndr:"retval"`
+}
+
+// SamrGetAliasMembership calls SamrGetAliasMembership (opnum 16), returning the RIDs of the
+// aliases in the domain of which any of the given SIDs is a member ([MS-SAMR] 3.1.5.9.2).
+func SamrGetAliasMembership(rpc *client.Client, domainHandle structures.SAMPR_HANDLE, sidArray structures.SAMPR_PSID_ARRAY) (structures.SAMPR_ULONG_ARRAY, error) {
+	req := &samrGetAliasMembershipRequest{
+		DomainHandle: domainHandle,
+		SidArray:     sidArray,
+	}
+	var resp samrGetAliasMembershipResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return structures.SAMPR_ULONG_ARRAY{}, fmt.Errorf("SamrGetAliasMembership: %w", err)
+	}
+	if uint32(resp.Status) != samr.StatusSuccess {
+		return resp.Membership, fmt.Errorf("SamrGetAliasMembership failed: %s", samr.StatusString(uint32(resp.Status)))
+	}
+	return resp.Membership, nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/17_SamrLookupNamesInDomain.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/17_SamrLookupNamesInDomain.go
@@ -1,0 +1,57 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrLookupNamesInDomainRequest is the [in] parameter set of SamrLookupNamesInDomain: a
+// domain handle, the Count of names, and the names themselves.
+//
+// WIRE RISK: the IDL declares Names as [in, size_is(1000), length_is(Count)]
+// RPC_UNICODE_STRING Names[*] — a fixed maximum (1000) but a varying actual length tied to
+// Count. It is modeled here as a conformant,varying slice; the conformance bound on the
+// wire may need to be the constant 1000 rather than Count. Verify against a live server.
+type samrLookupNamesInDomainRequest struct {
+	DomainHandle structures.SAMPR_HANDLE
+	Count        ndr.DWORD
+	Names        []dtyp.RPC_UNICODE_STRING `ndr:"conformant,varying"`
+}
+
+func (*samrLookupNamesInDomainRequest) Opnum() uint16 { return samr.OpnumSamrLookupNamesInDomain }
+
+// samrLookupNamesInDomainResponse is the reply: the [out] [ref] RID array and Use array
+// (single pointer containers, inline) and the NTSTATUS.
+type samrLookupNamesInDomainResponse struct {
+	RelativeIds structures.SAMPR_ULONG_ARRAY
+	Use         structures.SAMPR_ULONG_ARRAY
+	Status      ndr.DWORD `ndr:"retval"`
+}
+
+// SamrLookupNamesInDomain calls SamrLookupNamesInDomain (opnum 17), translating account
+// names into RIDs and their SID_NAME_USE classifications ([MS-SAMR] 3.1.5.11.2).
+func SamrLookupNamesInDomain(rpc *client.Client, domainHandle structures.SAMPR_HANDLE, names []string) (structures.SAMPR_ULONG_ARRAY, structures.SAMPR_ULONG_ARRAY, error) {
+	wnames := make([]dtyp.RPC_UNICODE_STRING, len(names))
+	for i, n := range names {
+		wnames[i] = dtyp.NewUnicodeString(n)
+	}
+	req := &samrLookupNamesInDomainRequest{
+		DomainHandle: domainHandle,
+		Count:        ndr.DWORD(len(names)),
+		Names:        wnames,
+	}
+	var resp samrLookupNamesInDomainResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return structures.SAMPR_ULONG_ARRAY{}, structures.SAMPR_ULONG_ARRAY{}, fmt.Errorf("SamrLookupNamesInDomain: %w", err)
+	}
+	status := uint32(resp.Status)
+	if status != samr.StatusSuccess && status != samr.StatusSomeNotMapped && status != samr.StatusNoneMapped {
+		return resp.RelativeIds, resp.Use, fmt.Errorf("SamrLookupNamesInDomain failed: %s", samr.StatusString(status))
+	}
+	return resp.RelativeIds, resp.Use, nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/17_SamrLookupNamesInDomain.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/17_SamrLookupNamesInDomain.go
@@ -13,14 +13,16 @@ import (
 // samrLookupNamesInDomainRequest is the [in] parameter set of SamrLookupNamesInDomain: a
 // domain handle, the Count of names, and the names themselves.
 //
-// WIRE RISK: the IDL declares Names as [in, size_is(1000), length_is(Count)]
-// RPC_UNICODE_STRING Names[*] — a fixed maximum (1000) but a varying actual length tied to
-// Count. It is modeled here as a conformant,varying slice; the conformance bound on the
-// wire may need to be the constant 1000 rather than Count. Verify against a live server.
+// Names is the IDL's [in, size_is(1000), length_is(Count)] RPC_UNICODE_STRING Names[*],
+// modeled as a [ref] pointer to a conformant array (ndr:"ref,size_is=Count"), matching the
+// live-validated lsarpc LsarLookupNames pattern. A bare conformant array field hoists its
+// maximum_count to the front of the request — ahead of the context handle — which the
+// server rejects as nca_s_fault_context_mismatch; the [ref] form emits no referent id and
+// defers the array (with its count) to after the handle. Live-validated against Windows XP.
 type samrLookupNamesInDomainRequest struct {
 	DomainHandle structures.SAMPR_HANDLE
 	Count        ndr.DWORD
-	Names        []dtyp.RPC_UNICODE_STRING `ndr:"conformant,varying"`
+	Names        []dtyp.RPC_UNICODE_STRING `ndr:"ref,size_is=1000,varying"`
 }
 
 func (*samrLookupNamesInDomainRequest) Opnum() uint16 { return samr.OpnumSamrLookupNamesInDomain }

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/18_SamrLookupIdsInDomain.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/18_SamrLookupIdsInDomain.go
@@ -12,14 +12,15 @@ import (
 // samrLookupIdsInDomainRequest is the [in] parameter set of SamrLookupIdsInDomain: a domain
 // handle, the Count of RIDs, and the RIDs themselves.
 //
-// WIRE RISK: the IDL declares RelativeIds as [in, size_is(1000), length_is(Count)]
-// unsigned long *RelativeIds — a fixed maximum (1000) but a varying actual length tied to
-// Count. It is modeled here as a conformant,varying slice; the conformance bound on the
-// wire may need to be the constant 1000 rather than Count. Verify against a live server.
+// RelativeIds is the IDL's [in, size_is(1000), length_is(Count)] unsigned long*
+// RelativeIds, modeled as a [ref] pointer to a conformant array (ndr:"ref,size_is=Count")
+// like SamrLookupNamesInDomain: a bare conformant array field would hoist its maximum_count
+// ahead of the context handle (nca_s_fault_context_mismatch). The [ref] form defers the
+// array past the handle.
 type samrLookupIdsInDomainRequest struct {
 	DomainHandle structures.SAMPR_HANDLE
 	Count        ndr.DWORD
-	RelativeIds  []ndr.DWORD `ndr:"conformant,varying"`
+	RelativeIds  []ndr.DWORD `ndr:"ref,size_is=1000,varying"`
 }
 
 func (*samrLookupIdsInDomainRequest) Opnum() uint16 { return samr.OpnumSamrLookupIdsInDomain }

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/18_SamrLookupIdsInDomain.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/18_SamrLookupIdsInDomain.go
@@ -1,0 +1,56 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrLookupIdsInDomainRequest is the [in] parameter set of SamrLookupIdsInDomain: a domain
+// handle, the Count of RIDs, and the RIDs themselves.
+//
+// WIRE RISK: the IDL declares RelativeIds as [in, size_is(1000), length_is(Count)]
+// unsigned long *RelativeIds — a fixed maximum (1000) but a varying actual length tied to
+// Count. It is modeled here as a conformant,varying slice; the conformance bound on the
+// wire may need to be the constant 1000 rather than Count. Verify against a live server.
+type samrLookupIdsInDomainRequest struct {
+	DomainHandle structures.SAMPR_HANDLE
+	Count        ndr.DWORD
+	RelativeIds  []ndr.DWORD `ndr:"conformant,varying"`
+}
+
+func (*samrLookupIdsInDomainRequest) Opnum() uint16 { return samr.OpnumSamrLookupIdsInDomain }
+
+// samrLookupIdsInDomainResponse is the reply: the [out] [ref] returned-string array of names
+// and the Use array (single pointer containers, inline) and the NTSTATUS.
+type samrLookupIdsInDomainResponse struct {
+	Names  structures.SAMPR_RETURNED_USTRING_ARRAY
+	Use    structures.SAMPR_ULONG_ARRAY
+	Status ndr.DWORD `ndr:"retval"`
+}
+
+// SamrLookupIdsInDomain calls SamrLookupIdsInDomain (opnum 18), translating RIDs into
+// account names and their SID_NAME_USE classifications ([MS-SAMR] 3.1.5.11.1).
+func SamrLookupIdsInDomain(rpc *client.Client, domainHandle structures.SAMPR_HANDLE, relativeIds []uint32) (structures.SAMPR_RETURNED_USTRING_ARRAY, structures.SAMPR_ULONG_ARRAY, error) {
+	rids := make([]ndr.DWORD, len(relativeIds))
+	for i, r := range relativeIds {
+		rids[i] = ndr.DWORD(r)
+	}
+	req := &samrLookupIdsInDomainRequest{
+		DomainHandle: domainHandle,
+		Count:        ndr.DWORD(len(relativeIds)),
+		RelativeIds:  rids,
+	}
+	var resp samrLookupIdsInDomainResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return structures.SAMPR_RETURNED_USTRING_ARRAY{}, structures.SAMPR_ULONG_ARRAY{}, fmt.Errorf("SamrLookupIdsInDomain: %w", err)
+	}
+	status := uint32(resp.Status)
+	if status != samr.StatusSuccess && status != samr.StatusSomeNotMapped && status != samr.StatusNoneMapped {
+		return resp.Names, resp.Use, fmt.Errorf("SamrLookupIdsInDomain failed: %s", samr.StatusString(status))
+	}
+	return resp.Names, resp.Use, nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/19_SamrOpenGroup.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/19_SamrOpenGroup.go
@@ -1,0 +1,38 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrOpenGroupRequest carries the [in] parameters of SamrOpenGroup: the domain handle, the
+// desired access mask, and the relative id of the group to open.
+type samrOpenGroupRequest struct {
+	DomainHandle  structures.SAMPR_HANDLE
+	DesiredAccess ndr.DWORD
+	GroupId       ndr.DWORD
+}
+
+func (*samrOpenGroupRequest) Opnum() uint16 { return samr.OpnumSamrOpenGroup }
+
+// SamrOpenGroup calls SamrOpenGroup (opnum 19), obtaining a handle to a group object
+// ([MS-SAMR] 3.1.5.1.5).
+func SamrOpenGroup(rpc *client.Client, domainHandle structures.SAMPR_HANDLE, desiredAccess uint32, groupId uint32) (structures.SAMPR_HANDLE, error) {
+	req := &samrOpenGroupRequest{
+		DomainHandle:  domainHandle,
+		DesiredAccess: ndr.DWORD(desiredAccess),
+		GroupId:       ndr.DWORD(groupId),
+	}
+	var resp openHandleResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return structures.SAMPR_HANDLE{}, fmt.Errorf("SamrOpenGroup: %w", err)
+	}
+	if uint32(resp.Status) != samr.StatusSuccess {
+		return resp.Handle, fmt.Errorf("SamrOpenGroup failed: %s", samr.StatusString(uint32(resp.Status)))
+	}
+	return resp.Handle, nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/20_SamrQueryInformationGroup.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/20_SamrQueryInformationGroup.go
@@ -1,0 +1,45 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrQueryInformationGroupRequest carries the [in] group handle and the information class
+// selecting which arm of the returned union is populated.
+type samrQueryInformationGroupRequest struct {
+	GroupHandle           structures.SAMPR_HANDLE
+	GroupInformationClass structures.GROUP_INFORMATION_CLASS
+}
+
+func (*samrQueryInformationGroupRequest) Opnum() uint16 {
+	return samr.OpnumSamrQueryInformationGroup
+}
+
+// samrQueryInformationGroupResponse is the reply: the [out,switch_is,unique] group info
+// buffer (carrying its own discriminant) and the NTSTATUS.
+type samrQueryInformationGroupResponse struct {
+	Buffer *structures.SAMPR_GROUP_INFO_BUFFER `ndr:"unique"`
+	Status ndr.DWORD                           `ndr:"retval"`
+}
+
+// SamrQueryInformationGroup calls SamrQueryInformationGroup (opnum 20), retrieving
+// attributes of a group object ([MS-SAMR] 3.1.5.5.3).
+func SamrQueryInformationGroup(rpc *client.Client, groupHandle structures.SAMPR_HANDLE, groupInformationClass structures.GROUP_INFORMATION_CLASS) (*structures.SAMPR_GROUP_INFO_BUFFER, error) {
+	req := &samrQueryInformationGroupRequest{
+		GroupHandle:           groupHandle,
+		GroupInformationClass: groupInformationClass,
+	}
+	var resp samrQueryInformationGroupResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return nil, fmt.Errorf("SamrQueryInformationGroup: %w", err)
+	}
+	if uint32(resp.Status) != samr.StatusSuccess {
+		return resp.Buffer, fmt.Errorf("SamrQueryInformationGroup failed: %s", samr.StatusString(uint32(resp.Status)))
+	}
+	return resp.Buffer, nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/21_SamrSetInformationGroup.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/21_SamrSetInformationGroup.go
@@ -1,0 +1,37 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrSetInformationGroupRequest carries the [in] group handle, the information class, and
+// the [in,switch_is] group info buffer whose populated arm matches that class.
+type samrSetInformationGroupRequest struct {
+	GroupHandle           structures.SAMPR_HANDLE
+	GroupInformationClass structures.GROUP_INFORMATION_CLASS
+	Buffer                structures.SAMPR_GROUP_INFO_BUFFER
+}
+
+func (*samrSetInformationGroupRequest) Opnum() uint16 { return samr.OpnumSamrSetInformationGroup }
+
+// SamrSetInformationGroup calls SamrSetInformationGroup (opnum 21), updating attributes of a
+// group object ([MS-SAMR] 3.1.5.6.2).
+func SamrSetInformationGroup(rpc *client.Client, groupHandle structures.SAMPR_HANDLE, groupInformationClass structures.GROUP_INFORMATION_CLASS, buffer structures.SAMPR_GROUP_INFO_BUFFER) error {
+	req := &samrSetInformationGroupRequest{
+		GroupHandle:           groupHandle,
+		GroupInformationClass: groupInformationClass,
+		Buffer:                buffer,
+	}
+	var resp statusResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return fmt.Errorf("SamrSetInformationGroup: %w", err)
+	}
+	if uint32(resp.Status) != samr.StatusSuccess {
+		return fmt.Errorf("SamrSetInformationGroup failed: %s", samr.StatusString(uint32(resp.Status)))
+	}
+	return nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/22_SamrAddMemberToGroup.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/22_SamrAddMemberToGroup.go
@@ -1,0 +1,38 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrAddMemberToGroupRequest carries the [in] group handle, the relative id of the member
+// to add, and the membership attributes to assign.
+type samrAddMemberToGroupRequest struct {
+	GroupHandle structures.SAMPR_HANDLE
+	MemberId    ndr.DWORD
+	Attributes  ndr.DWORD
+}
+
+func (*samrAddMemberToGroupRequest) Opnum() uint16 { return samr.OpnumSamrAddMemberToGroup }
+
+// SamrAddMemberToGroup calls SamrAddMemberToGroup (opnum 22), adding a user as a member of a
+// group ([MS-SAMR] 3.1.5.8.1).
+func SamrAddMemberToGroup(rpc *client.Client, groupHandle structures.SAMPR_HANDLE, memberId uint32, attributes uint32) error {
+	req := &samrAddMemberToGroupRequest{
+		GroupHandle: groupHandle,
+		MemberId:    ndr.DWORD(memberId),
+		Attributes:  ndr.DWORD(attributes),
+	}
+	var resp statusResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return fmt.Errorf("SamrAddMemberToGroup: %w", err)
+	}
+	if uint32(resp.Status) != samr.StatusSuccess {
+		return fmt.Errorf("SamrAddMemberToGroup failed: %s", samr.StatusString(uint32(resp.Status)))
+	}
+	return nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/23_SamrDeleteGroup.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/23_SamrDeleteGroup.go
@@ -1,0 +1,31 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrDeleteGroupRequest carries the [in,out] SAMPR_HANDLE of the group to delete. On
+// success the server returns it zeroed via the shared handleResponse.
+type samrDeleteGroupRequest struct {
+	GroupHandle structures.SAMPR_HANDLE
+}
+
+func (*samrDeleteGroupRequest) Opnum() uint16 { return samr.OpnumSamrDeleteGroup }
+
+// SamrDeleteGroup calls SamrDeleteGroup (opnum 23), removing a group object from the database
+// and returning the (now zeroed) handle ([MS-SAMR] 3.1.5.7.1).
+func SamrDeleteGroup(rpc *client.Client, groupHandle structures.SAMPR_HANDLE) (structures.SAMPR_HANDLE, error) {
+	req := &samrDeleteGroupRequest{GroupHandle: groupHandle}
+	var resp handleResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return groupHandle, fmt.Errorf("SamrDeleteGroup: %w", err)
+	}
+	if uint32(resp.Status) != samr.StatusSuccess {
+		return resp.Handle, fmt.Errorf("SamrDeleteGroup failed: %s", samr.StatusString(uint32(resp.Status)))
+	}
+	return resp.Handle, nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/24_SamrRemoveMemberFromGroup.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/24_SamrRemoveMemberFromGroup.go
@@ -1,0 +1,38 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrRemoveMemberFromGroupRequest carries the [in] group handle and the relative id of the
+// member to remove.
+type samrRemoveMemberFromGroupRequest struct {
+	GroupHandle structures.SAMPR_HANDLE
+	MemberId    ndr.DWORD
+}
+
+func (*samrRemoveMemberFromGroupRequest) Opnum() uint16 {
+	return samr.OpnumSamrRemoveMemberFromGroup
+}
+
+// SamrRemoveMemberFromGroup calls SamrRemoveMemberFromGroup (opnum 24), removing a user from
+// the membership of a group ([MS-SAMR] 3.1.5.8.2).
+func SamrRemoveMemberFromGroup(rpc *client.Client, groupHandle structures.SAMPR_HANDLE, memberId uint32) error {
+	req := &samrRemoveMemberFromGroupRequest{
+		GroupHandle: groupHandle,
+		MemberId:    ndr.DWORD(memberId),
+	}
+	var resp statusResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return fmt.Errorf("SamrRemoveMemberFromGroup: %w", err)
+	}
+	if uint32(resp.Status) != samr.StatusSuccess {
+		return fmt.Errorf("SamrRemoveMemberFromGroup failed: %s", samr.StatusString(uint32(resp.Status)))
+	}
+	return nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/25_SamrGetMembersInGroup.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/25_SamrGetMembersInGroup.go
@@ -1,0 +1,38 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrGetMembersInGroupRequest carries the [in] group handle whose members are listed.
+type samrGetMembersInGroupRequest struct {
+	GroupHandle structures.SAMPR_HANDLE
+}
+
+func (*samrGetMembersInGroupRequest) Opnum() uint16 { return samr.OpnumSamrGetMembersInGroup }
+
+// samrGetMembersInGroupResponse is the reply: the [out,unique] members buffer (the relative
+// ids and attributes of the group members) and the NTSTATUS.
+type samrGetMembersInGroupResponse struct {
+	Members *structures.SAMPR_GET_MEMBERS_BUFFER `ndr:"unique"`
+	Status  ndr.DWORD                            `ndr:"retval"`
+}
+
+// SamrGetMembersInGroup calls SamrGetMembersInGroup (opnum 25), reading the members of a
+// group ([MS-SAMR] 3.1.5.8.3).
+func SamrGetMembersInGroup(rpc *client.Client, groupHandle structures.SAMPR_HANDLE) (*structures.SAMPR_GET_MEMBERS_BUFFER, error) {
+	req := &samrGetMembersInGroupRequest{GroupHandle: groupHandle}
+	var resp samrGetMembersInGroupResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return nil, fmt.Errorf("SamrGetMembersInGroup: %w", err)
+	}
+	if uint32(resp.Status) != samr.StatusSuccess {
+		return resp.Members, fmt.Errorf("SamrGetMembersInGroup failed: %s", samr.StatusString(uint32(resp.Status)))
+	}
+	return resp.Members, nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/26_SamrSetMemberAttributesOfGroup.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/26_SamrSetMemberAttributesOfGroup.go
@@ -1,0 +1,40 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrSetMemberAttributesOfGroupRequest carries the [in] group handle, the relative id of
+// the member, and the membership attributes to set for that member.
+type samrSetMemberAttributesOfGroupRequest struct {
+	GroupHandle structures.SAMPR_HANDLE
+	MemberId    ndr.DWORD
+	Attributes  ndr.DWORD
+}
+
+func (*samrSetMemberAttributesOfGroupRequest) Opnum() uint16 {
+	return samr.OpnumSamrSetMemberAttributesOfGroup
+}
+
+// SamrSetMemberAttributesOfGroup calls SamrSetMemberAttributesOfGroup (opnum 26), setting the
+// attributes of a member relationship in a group ([MS-SAMR] 3.1.5.8.4).
+func SamrSetMemberAttributesOfGroup(rpc *client.Client, groupHandle structures.SAMPR_HANDLE, memberId uint32, attributes uint32) error {
+	req := &samrSetMemberAttributesOfGroupRequest{
+		GroupHandle: groupHandle,
+		MemberId:    ndr.DWORD(memberId),
+		Attributes:  ndr.DWORD(attributes),
+	}
+	var resp statusResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return fmt.Errorf("SamrSetMemberAttributesOfGroup: %w", err)
+	}
+	if uint32(resp.Status) != samr.StatusSuccess {
+		return fmt.Errorf("SamrSetMemberAttributesOfGroup failed: %s", samr.StatusString(uint32(resp.Status)))
+	}
+	return nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/27_SamrOpenAlias.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/27_SamrOpenAlias.go
@@ -1,0 +1,38 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrOpenAliasRequest carries the [in] domain handle, the desired access mask, and the
+// relative id of the alias to open.
+type samrOpenAliasRequest struct {
+	DomainHandle  structures.SAMPR_HANDLE
+	DesiredAccess ndr.DWORD
+	AliasId       ndr.DWORD
+}
+
+func (*samrOpenAliasRequest) Opnum() uint16 { return samr.OpnumSamrOpenAlias }
+
+// SamrOpenAlias calls SamrOpenAlias (opnum 27), obtaining a handle to an existing alias
+// ([MS-SAMR] 3.1.5.1.6).
+func SamrOpenAlias(rpc *client.Client, domainHandle structures.SAMPR_HANDLE, desiredAccess uint32, aliasId uint32) (structures.SAMPR_HANDLE, error) {
+	req := &samrOpenAliasRequest{
+		DomainHandle:  domainHandle,
+		DesiredAccess: ndr.DWORD(desiredAccess),
+		AliasId:       ndr.DWORD(aliasId),
+	}
+	var resp openHandleResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return structures.SAMPR_HANDLE{}, fmt.Errorf("SamrOpenAlias: %w", err)
+	}
+	if uint32(resp.Status) != samr.StatusSuccess {
+		return resp.Handle, fmt.Errorf("SamrOpenAlias failed: %s", samr.StatusString(uint32(resp.Status)))
+	}
+	return resp.Handle, nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/28_SamrQueryInformationAlias.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/28_SamrQueryInformationAlias.go
@@ -1,0 +1,45 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrQueryInformationAliasRequest carries the [in] alias handle and the information class
+// that selects the arm of the returned union.
+type samrQueryInformationAliasRequest struct {
+	AliasHandle           structures.SAMPR_HANDLE
+	AliasInformationClass structures.ALIAS_INFORMATION_CLASS
+}
+
+func (*samrQueryInformationAliasRequest) Opnum() uint16 {
+	return samr.OpnumSamrQueryInformationAlias
+}
+
+// samrQueryInformationAliasResponse is the reply: the [out, switch_is] alias info buffer
+// (a [unique] pointer to the discriminated union) and the NTSTATUS.
+type samrQueryInformationAliasResponse struct {
+	Buffer *structures.SAMPR_ALIAS_INFO_BUFFER `ndr:"unique"`
+	Status ndr.DWORD                           `ndr:"retval"`
+}
+
+// SamrQueryInformationAlias calls SamrQueryInformationAlias (opnum 28), retrieving
+// attributes of an alias for the requested information class ([MS-SAMR] 3.1.5.5.4).
+func SamrQueryInformationAlias(rpc *client.Client, aliasHandle structures.SAMPR_HANDLE, aliasInformationClass structures.ALIAS_INFORMATION_CLASS) (*structures.SAMPR_ALIAS_INFO_BUFFER, error) {
+	req := &samrQueryInformationAliasRequest{
+		AliasHandle:           aliasHandle,
+		AliasInformationClass: aliasInformationClass,
+	}
+	var resp samrQueryInformationAliasResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return nil, fmt.Errorf("SamrQueryInformationAlias: %w", err)
+	}
+	if uint32(resp.Status) != samr.StatusSuccess {
+		return resp.Buffer, fmt.Errorf("SamrQueryInformationAlias failed: %s", samr.StatusString(uint32(resp.Status)))
+	}
+	return resp.Buffer, nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/29_SamrSetInformationAlias.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/29_SamrSetInformationAlias.go
@@ -1,0 +1,37 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrSetInformationAliasRequest carries the [in] alias handle, the information class, and
+// the [in, switch_is] alias info buffer (the discriminated union, transmitted inline).
+type samrSetInformationAliasRequest struct {
+	AliasHandle           structures.SAMPR_HANDLE
+	AliasInformationClass structures.ALIAS_INFORMATION_CLASS
+	Buffer                structures.SAMPR_ALIAS_INFO_BUFFER
+}
+
+func (*samrSetInformationAliasRequest) Opnum() uint16 { return samr.OpnumSamrSetInformationAlias }
+
+// SamrSetInformationAlias calls SamrSetInformationAlias (opnum 29), updating attributes of
+// an alias for the supplied information class ([MS-SAMR] 3.1.5.6.4).
+func SamrSetInformationAlias(rpc *client.Client, aliasHandle structures.SAMPR_HANDLE, aliasInformationClass structures.ALIAS_INFORMATION_CLASS, buffer structures.SAMPR_ALIAS_INFO_BUFFER) error {
+	req := &samrSetInformationAliasRequest{
+		AliasHandle:           aliasHandle,
+		AliasInformationClass: aliasInformationClass,
+		Buffer:                buffer,
+	}
+	var resp statusResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return fmt.Errorf("SamrSetInformationAlias: %w", err)
+	}
+	if uint32(resp.Status) != samr.StatusSuccess {
+		return fmt.Errorf("SamrSetInformationAlias failed: %s", samr.StatusString(uint32(resp.Status)))
+	}
+	return nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/30_SamrDeleteAlias.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/30_SamrDeleteAlias.go
@@ -1,0 +1,31 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrDeleteAliasRequest carries the [in,out] SAMPR_HANDLE of the alias to delete. On
+// success the server returns it zeroed via the shared handleResponse.
+type samrDeleteAliasRequest struct {
+	AliasHandle structures.SAMPR_HANDLE
+}
+
+func (*samrDeleteAliasRequest) Opnum() uint16 { return samr.OpnumSamrDeleteAlias }
+
+// SamrDeleteAlias calls SamrDeleteAlias (opnum 30), removing an alias from the database and
+// returning the (now zeroed) handle ([MS-SAMR] 3.1.5.7.2).
+func SamrDeleteAlias(rpc *client.Client, aliasHandle structures.SAMPR_HANDLE) (structures.SAMPR_HANDLE, error) {
+	req := &samrDeleteAliasRequest{AliasHandle: aliasHandle}
+	var resp handleResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return aliasHandle, fmt.Errorf("SamrDeleteAlias: %w", err)
+	}
+	if uint32(resp.Status) != samr.StatusSuccess {
+		return resp.Handle, fmt.Errorf("SamrDeleteAlias failed: %s", samr.StatusString(uint32(resp.Status)))
+	}
+	return resp.Handle, nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/31_SamrAddMemberToAlias.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/31_SamrAddMemberToAlias.go
@@ -1,0 +1,36 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrAddMemberToAliasRequest carries the [in] alias handle and the [ref] SID of the member
+// to add (transmitted inline).
+type samrAddMemberToAliasRequest struct {
+	AliasHandle structures.SAMPR_HANDLE
+	MemberId    dtyp.RPC_SID
+}
+
+func (*samrAddMemberToAliasRequest) Opnum() uint16 { return samr.OpnumSamrAddMemberToAlias }
+
+// SamrAddMemberToAlias calls SamrAddMemberToAlias (opnum 31), adding a member to an alias
+// ([MS-SAMR] 3.1.5.4.2).
+func SamrAddMemberToAlias(rpc *client.Client, aliasHandle structures.SAMPR_HANDLE, memberId dtyp.RPC_SID) error {
+	req := &samrAddMemberToAliasRequest{
+		AliasHandle: aliasHandle,
+		MemberId:    memberId,
+	}
+	var resp statusResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return fmt.Errorf("SamrAddMemberToAlias: %w", err)
+	}
+	if uint32(resp.Status) != samr.StatusSuccess {
+		return fmt.Errorf("SamrAddMemberToAlias failed: %s", samr.StatusString(uint32(resp.Status)))
+	}
+	return nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/32_SamrRemoveMemberFromAlias.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/32_SamrRemoveMemberFromAlias.go
@@ -1,0 +1,38 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrRemoveMemberFromAliasRequest carries the [in] alias handle and the [ref] SID of the
+// member to remove (transmitted inline).
+type samrRemoveMemberFromAliasRequest struct {
+	AliasHandle structures.SAMPR_HANDLE
+	MemberId    dtyp.RPC_SID
+}
+
+func (*samrRemoveMemberFromAliasRequest) Opnum() uint16 {
+	return samr.OpnumSamrRemoveMemberFromAlias
+}
+
+// SamrRemoveMemberFromAlias calls SamrRemoveMemberFromAlias (opnum 32), removing a member
+// from an alias ([MS-SAMR] 3.1.5.5.3).
+func SamrRemoveMemberFromAlias(rpc *client.Client, aliasHandle structures.SAMPR_HANDLE, memberId dtyp.RPC_SID) error {
+	req := &samrRemoveMemberFromAliasRequest{
+		AliasHandle: aliasHandle,
+		MemberId:    memberId,
+	}
+	var resp statusResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return fmt.Errorf("SamrRemoveMemberFromAlias: %w", err)
+	}
+	if uint32(resp.Status) != samr.StatusSuccess {
+		return fmt.Errorf("SamrRemoveMemberFromAlias failed: %s", samr.StatusString(uint32(resp.Status)))
+	}
+	return nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/33_SamrGetMembersInAlias.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/33_SamrGetMembersInAlias.go
@@ -1,0 +1,38 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrGetMembersInAliasRequest carries the [in] alias handle.
+type samrGetMembersInAliasRequest struct {
+	AliasHandle structures.SAMPR_HANDLE
+}
+
+func (*samrGetMembersInAliasRequest) Opnum() uint16 { return samr.OpnumSamrGetMembersInAlias }
+
+// samrGetMembersInAliasResponse is the reply: the [out] SID array container (a single [ref]
+// out parameter, transmitted inline) and the NTSTATUS.
+type samrGetMembersInAliasResponse struct {
+	Members structures.SAMPR_PSID_ARRAY_OUT
+	Status  ndr.DWORD `ndr:"retval"`
+}
+
+// SamrGetMembersInAlias calls SamrGetMembersInAlias (opnum 33), retrieving the SIDs of the
+// members of an alias ([MS-SAMR] 3.1.5.5.5).
+func SamrGetMembersInAlias(rpc *client.Client, aliasHandle structures.SAMPR_HANDLE) (structures.SAMPR_PSID_ARRAY_OUT, error) {
+	req := &samrGetMembersInAliasRequest{AliasHandle: aliasHandle}
+	var resp samrGetMembersInAliasResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return structures.SAMPR_PSID_ARRAY_OUT{}, fmt.Errorf("SamrGetMembersInAlias: %w", err)
+	}
+	if uint32(resp.Status) != samr.StatusSuccess {
+		return resp.Members, fmt.Errorf("SamrGetMembersInAlias failed: %s", samr.StatusString(uint32(resp.Status)))
+	}
+	return resp.Members, nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/34_SamrOpenUser.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/34_SamrOpenUser.go
@@ -1,0 +1,38 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrOpenUserRequest carries the [in] parameters of SamrOpenUser: the domain handle, the
+// desired access mask, and the relative id of the user to open.
+type samrOpenUserRequest struct {
+	DomainHandle  structures.SAMPR_HANDLE
+	DesiredAccess ndr.DWORD
+	UserId        ndr.DWORD
+}
+
+func (*samrOpenUserRequest) Opnum() uint16 { return samr.OpnumSamrOpenUser }
+
+// SamrOpenUser calls SamrOpenUser (opnum 34), obtaining a handle to a user object given its
+// relative id within the domain ([MS-SAMR] 3.1.5.1.9).
+func SamrOpenUser(rpc *client.Client, domainHandle structures.SAMPR_HANDLE, desiredAccess uint32, userId uint32) (structures.SAMPR_HANDLE, error) {
+	req := &samrOpenUserRequest{
+		DomainHandle:  domainHandle,
+		DesiredAccess: ndr.DWORD(desiredAccess),
+		UserId:        ndr.DWORD(userId),
+	}
+	var resp openHandleResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return structures.SAMPR_HANDLE{}, fmt.Errorf("SamrOpenUser: %w", err)
+	}
+	if uint32(resp.Status) != samr.StatusSuccess {
+		return resp.Handle, fmt.Errorf("SamrOpenUser failed: %s", samr.StatusString(uint32(resp.Status)))
+	}
+	return resp.Handle, nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/35_SamrDeleteUser.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/35_SamrDeleteUser.go
@@ -1,0 +1,31 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrDeleteUserRequest carries the [in,out] SAMPR_HANDLE of the user to delete. On success
+// the server returns it zeroed via the shared handleResponse.
+type samrDeleteUserRequest struct {
+	UserHandle structures.SAMPR_HANDLE
+}
+
+func (*samrDeleteUserRequest) Opnum() uint16 { return samr.OpnumSamrDeleteUser }
+
+// SamrDeleteUser calls SamrDeleteUser (opnum 35), removing the user object referenced by the
+// handle and returning the (now zeroed) handle ([MS-SAMR] 3.1.5.7.3).
+func SamrDeleteUser(rpc *client.Client, userHandle structures.SAMPR_HANDLE) (structures.SAMPR_HANDLE, error) {
+	req := &samrDeleteUserRequest{UserHandle: userHandle}
+	var resp handleResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return userHandle, fmt.Errorf("SamrDeleteUser: %w", err)
+	}
+	if uint32(resp.Status) != samr.StatusSuccess {
+		return resp.Handle, fmt.Errorf("SamrDeleteUser failed: %s", samr.StatusString(uint32(resp.Status)))
+	}
+	return resp.Handle, nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/36_SamrQueryInformationUser.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/36_SamrQueryInformationUser.go
@@ -1,0 +1,45 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrQueryInformationUserRequest carries the [in] user handle and the information class
+// selecting which arm of the returned union is populated.
+type samrQueryInformationUserRequest struct {
+	UserHandle           structures.SAMPR_HANDLE
+	UserInformationClass structures.USER_INFORMATION_CLASS
+}
+
+func (*samrQueryInformationUserRequest) Opnum() uint16 {
+	return samr.OpnumSamrQueryInformationUser
+}
+
+// samrQueryInformationUserResponse is the reply: the [out,switch_is,unique] user info buffer
+// (carrying its own discriminant) and the NTSTATUS.
+type samrQueryInformationUserResponse struct {
+	Buffer *structures.SAMPR_USER_INFO_BUFFER `ndr:"unique"`
+	Status ndr.DWORD                          `ndr:"retval"`
+}
+
+// SamrQueryInformationUser calls SamrQueryInformationUser (opnum 36), retrieving attributes
+// of a user object ([MS-SAMR] 3.1.5.5.6).
+func SamrQueryInformationUser(rpc *client.Client, userHandle structures.SAMPR_HANDLE, userInformationClass structures.USER_INFORMATION_CLASS) (*structures.SAMPR_USER_INFO_BUFFER, error) {
+	req := &samrQueryInformationUserRequest{
+		UserHandle:           userHandle,
+		UserInformationClass: userInformationClass,
+	}
+	var resp samrQueryInformationUserResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return nil, fmt.Errorf("SamrQueryInformationUser: %w", err)
+	}
+	if uint32(resp.Status) != samr.StatusSuccess {
+		return resp.Buffer, fmt.Errorf("SamrQueryInformationUser failed: %s", samr.StatusString(uint32(resp.Status)))
+	}
+	return resp.Buffer, nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/37_SamrSetInformationUser.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/37_SamrSetInformationUser.go
@@ -1,0 +1,38 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrSetInformationUserRequest carries the [in] user handle, the information class, and the
+// [in,switch_is] user info buffer (inline, carrying its own discriminant) whose selected arm
+// is written to the user object.
+type samrSetInformationUserRequest struct {
+	UserHandle           structures.SAMPR_HANDLE
+	UserInformationClass structures.USER_INFORMATION_CLASS
+	Buffer               structures.SAMPR_USER_INFO_BUFFER
+}
+
+func (*samrSetInformationUserRequest) Opnum() uint16 { return samr.OpnumSamrSetInformationUser }
+
+// SamrSetInformationUser calls SamrSetInformationUser (opnum 37), updating attributes of a
+// user object ([MS-SAMR] 3.1.5.6.5).
+func SamrSetInformationUser(rpc *client.Client, userHandle structures.SAMPR_HANDLE, userInformationClass structures.USER_INFORMATION_CLASS, buffer structures.SAMPR_USER_INFO_BUFFER) error {
+	req := &samrSetInformationUserRequest{
+		UserHandle:           userHandle,
+		UserInformationClass: userInformationClass,
+		Buffer:               buffer,
+	}
+	var resp statusResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return fmt.Errorf("SamrSetInformationUser: %w", err)
+	}
+	if uint32(resp.Status) != samr.StatusSuccess {
+		return fmt.Errorf("SamrSetInformationUser failed: %s", samr.StatusString(uint32(resp.Status)))
+	}
+	return nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/38_SamrChangePasswordUser.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/38_SamrChangePasswordUser.go
@@ -1,0 +1,55 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrChangePasswordUserRequest carries the [in] user handle and the (mutually
+// cross-encrypted) LM and NT password OWFs of SamrChangePasswordUser, in exact IDL field
+// order. Each [in,unique] OWF pointer is optional; the *Present flags indicate which arms
+// are supplied.
+type samrChangePasswordUserRequest struct {
+	UserHandle               structures.SAMPR_HANDLE
+	LmPresent                uint8
+	OldLmEncryptedWithNewLm  *structures.ENCRYPTED_LM_OWF_PASSWORD `ndr:"unique"`
+	NewLmEncryptedWithOldLm  *structures.ENCRYPTED_LM_OWF_PASSWORD `ndr:"unique"`
+	NtPresent                uint8
+	OldNtEncryptedWithNewNt  *structures.ENCRYPTED_NT_OWF_PASSWORD `ndr:"unique"`
+	NewNtEncryptedWithOldNt  *structures.ENCRYPTED_NT_OWF_PASSWORD `ndr:"unique"`
+	NtCrossEncryptionPresent uint8
+	NewNtEncryptedWithNewLm  *structures.ENCRYPTED_NT_OWF_PASSWORD `ndr:"unique"`
+	LmCrossEncryptionPresent uint8
+	NewLmEncryptedWithNewNt  *structures.ENCRYPTED_LM_OWF_PASSWORD `ndr:"unique"`
+}
+
+func (*samrChangePasswordUserRequest) Opnum() uint16 { return samr.OpnumSamrChangePasswordUser }
+
+// SamrChangePasswordUser calls SamrChangePasswordUser (opnum 38), changing a user's password
+// given the old and new LM/NT OWFs cross-encrypted with one another ([MS-SAMR] 3.1.5.10.2).
+func SamrChangePasswordUser(rpc *client.Client, userHandle structures.SAMPR_HANDLE, lmPresent uint8, oldLmEncryptedWithNewLm *structures.ENCRYPTED_LM_OWF_PASSWORD, newLmEncryptedWithOldLm *structures.ENCRYPTED_LM_OWF_PASSWORD, ntPresent uint8, oldNtEncryptedWithNewNt *structures.ENCRYPTED_NT_OWF_PASSWORD, newNtEncryptedWithOldNt *structures.ENCRYPTED_NT_OWF_PASSWORD, ntCrossEncryptionPresent uint8, newNtEncryptedWithNewLm *structures.ENCRYPTED_NT_OWF_PASSWORD, lmCrossEncryptionPresent uint8, newLmEncryptedWithNewNt *structures.ENCRYPTED_LM_OWF_PASSWORD) error {
+	req := &samrChangePasswordUserRequest{
+		UserHandle:               userHandle,
+		LmPresent:                lmPresent,
+		OldLmEncryptedWithNewLm:  oldLmEncryptedWithNewLm,
+		NewLmEncryptedWithOldLm:  newLmEncryptedWithOldLm,
+		NtPresent:                ntPresent,
+		OldNtEncryptedWithNewNt:  oldNtEncryptedWithNewNt,
+		NewNtEncryptedWithOldNt:  newNtEncryptedWithOldNt,
+		NtCrossEncryptionPresent: ntCrossEncryptionPresent,
+		NewNtEncryptedWithNewLm:  newNtEncryptedWithNewLm,
+		LmCrossEncryptionPresent: lmCrossEncryptionPresent,
+		NewLmEncryptedWithNewNt:  newLmEncryptedWithNewNt,
+	}
+	var resp statusResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return fmt.Errorf("SamrChangePasswordUser: %w", err)
+	}
+	if uint32(resp.Status) != samr.StatusSuccess {
+		return fmt.Errorf("SamrChangePasswordUser failed: %s", samr.StatusString(uint32(resp.Status)))
+	}
+	return nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/39_SamrGetGroupsForUser.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/39_SamrGetGroupsForUser.go
@@ -1,0 +1,39 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrGetGroupsForUserRequest carries the [in] user handle whose group memberships are
+// queried.
+type samrGetGroupsForUserRequest struct {
+	UserHandle structures.SAMPR_HANDLE
+}
+
+func (*samrGetGroupsForUserRequest) Opnum() uint16 { return samr.OpnumSamrGetGroupsForUser }
+
+// samrGetGroupsForUserResponse is the reply: the [out,unique] buffer of group memberships and
+// the NTSTATUS.
+type samrGetGroupsForUserResponse struct {
+	Groups *structures.SAMPR_GET_GROUPS_BUFFER `ndr:"unique"`
+	Status ndr.DWORD                           `ndr:"retval"`
+}
+
+// SamrGetGroupsForUser calls SamrGetGroupsForUser (opnum 39), returning the union of all
+// groups the given user is a member of ([MS-SAMR] 3.1.5.9.1).
+func SamrGetGroupsForUser(rpc *client.Client, userHandle structures.SAMPR_HANDLE) (*structures.SAMPR_GET_GROUPS_BUFFER, error) {
+	req := &samrGetGroupsForUserRequest{UserHandle: userHandle}
+	var resp samrGetGroupsForUserResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return nil, fmt.Errorf("SamrGetGroupsForUser: %w", err)
+	}
+	if uint32(resp.Status) != samr.StatusSuccess {
+		return resp.Groups, fmt.Errorf("SamrGetGroupsForUser failed: %s", samr.StatusString(uint32(resp.Status)))
+	}
+	return resp.Groups, nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/40_SamrQueryDisplayInformation.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/40_SamrQueryDisplayInformation.go
@@ -1,0 +1,57 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrQueryDisplayInformationRequest is the [in] parameter set of SamrQueryDisplayInformation:
+// a domain handle, the display class, the starting index, the requested entry count, and the
+// preferred maximum byte length of the returned buffer.
+type samrQueryDisplayInformationRequest struct {
+	DomainHandle            structures.SAMPR_HANDLE
+	DisplayInformationClass structures.DOMAIN_DISPLAY_INFORMATION
+	Index                   ndr.DWORD
+	EntryCount              ndr.DWORD
+	PreferredMaximumLength  ndr.DWORD
+}
+
+func (*samrQueryDisplayInformationRequest) Opnum() uint16 {
+	return samr.OpnumSamrQueryDisplayInformation
+}
+
+// samrQueryDisplayInformationResponse is the reply: the total available and total returned
+// byte counts, the [out, switch_is] SINGLE-pointer SAMPR_DISPLAY_INFO_BUFFER union (inline,
+// [ref] — not [unique], not double), and the NTSTATUS.
+type samrQueryDisplayInformationResponse struct {
+	TotalAvailable ndr.DWORD
+	TotalReturned  ndr.DWORD
+	Buffer         structures.SAMPR_DISPLAY_INFO_BUFFER
+	Status         ndr.DWORD `ndr:"retval"`
+}
+
+// SamrQueryDisplayInformation calls SamrQueryDisplayInformation (opnum 40), returning a page
+// of account information for display ([MS-SAMR] 3.1.5.3.1). The returned union carries its own
+// Tag.
+func SamrQueryDisplayInformation(rpc *client.Client, domainHandle structures.SAMPR_HANDLE, class uint16, index, entryCount, preferredMaximumLength uint32) (uint32, uint32, structures.SAMPR_DISPLAY_INFO_BUFFER, error) {
+	req := &samrQueryDisplayInformationRequest{
+		DomainHandle:            domainHandle,
+		DisplayInformationClass: structures.DOMAIN_DISPLAY_INFORMATION(class),
+		Index:                   ndr.DWORD(index),
+		EntryCount:              ndr.DWORD(entryCount),
+		PreferredMaximumLength:  ndr.DWORD(preferredMaximumLength),
+	}
+	var resp samrQueryDisplayInformationResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return 0, 0, structures.SAMPR_DISPLAY_INFO_BUFFER{}, fmt.Errorf("SamrQueryDisplayInformation: %w", err)
+	}
+	status := uint32(resp.Status)
+	if status != samr.StatusSuccess && status != samr.StatusMoreEntries {
+		return uint32(resp.TotalAvailable), uint32(resp.TotalReturned), resp.Buffer, fmt.Errorf("SamrQueryDisplayInformation failed: %s", samr.StatusString(status))
+	}
+	return uint32(resp.TotalAvailable), uint32(resp.TotalReturned), resp.Buffer, nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/41_SamrGetDisplayEnumerationIndex.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/41_SamrGetDisplayEnumerationIndex.go
@@ -1,0 +1,50 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrGetDisplayEnumerationIndexRequest is the [in] parameter set of
+// SamrGetDisplayEnumerationIndex: a domain handle, the display class, and the [ref] name
+// prefix (inline, single pointer) to search for.
+type samrGetDisplayEnumerationIndexRequest struct {
+	DomainHandle            structures.SAMPR_HANDLE
+	DisplayInformationClass structures.DOMAIN_DISPLAY_INFORMATION
+	Prefix                  dtyp.RPC_UNICODE_STRING
+}
+
+func (*samrGetDisplayEnumerationIndexRequest) Opnum() uint16 {
+	return samr.OpnumSamrGetDisplayEnumerationIndex
+}
+
+// samrGetDisplayEnumerationIndexResponse is the reply: the [out] index and the NTSTATUS.
+type samrGetDisplayEnumerationIndexResponse struct {
+	Index  ndr.DWORD
+	Status ndr.DWORD `ndr:"retval"`
+}
+
+// SamrGetDisplayEnumerationIndex calls SamrGetDisplayEnumerationIndex (opnum 41), returning
+// the index of the first account whose name is greater than or equal to the given prefix
+// ([MS-SAMR] 3.1.5.3.3).
+func SamrGetDisplayEnumerationIndex(rpc *client.Client, domainHandle structures.SAMPR_HANDLE, class uint16, prefix string) (uint32, error) {
+	req := &samrGetDisplayEnumerationIndexRequest{
+		DomainHandle:            domainHandle,
+		DisplayInformationClass: structures.DOMAIN_DISPLAY_INFORMATION(class),
+		Prefix:                  dtyp.NewUnicodeString(prefix),
+	}
+	var resp samrGetDisplayEnumerationIndexResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return 0, fmt.Errorf("SamrGetDisplayEnumerationIndex: %w", err)
+	}
+	status := uint32(resp.Status)
+	if status != samr.StatusSuccess && status != samr.StatusMoreEntries && status != samr.StatusNoMoreEntries {
+		return uint32(resp.Index), fmt.Errorf("SamrGetDisplayEnumerationIndex failed: %s", samr.StatusString(status))
+	}
+	return uint32(resp.Index), nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/44_SamrGetUserDomainPasswordInformation.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/44_SamrGetUserDomainPasswordInformation.go
@@ -1,0 +1,41 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrGetUserDomainPasswordInformationRequest carries the [in] user handle whose domain
+// password policy is queried.
+type samrGetUserDomainPasswordInformationRequest struct {
+	UserHandle structures.SAMPR_HANDLE
+}
+
+func (*samrGetUserDomainPasswordInformationRequest) Opnum() uint16 {
+	return samr.OpnumSamrGetUserDomainPasswordInformation
+}
+
+// samrGetUserDomainPasswordInformationResponse is the reply: the [out] domain password policy
+// (inline, single [ref] pointer) and the NTSTATUS.
+type samrGetUserDomainPasswordInformationResponse struct {
+	PasswordInformation structures.USER_DOMAIN_PASSWORD_INFORMATION
+	Status              ndr.DWORD `ndr:"retval"`
+}
+
+// SamrGetUserDomainPasswordInformation calls SamrGetUserDomainPasswordInformation (opnum 44),
+// returning the password policy of the domain the user belongs to ([MS-SAMR] 3.1.5.13.1).
+func SamrGetUserDomainPasswordInformation(rpc *client.Client, userHandle structures.SAMPR_HANDLE) (structures.USER_DOMAIN_PASSWORD_INFORMATION, error) {
+	req := &samrGetUserDomainPasswordInformationRequest{UserHandle: userHandle}
+	var resp samrGetUserDomainPasswordInformationResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return structures.USER_DOMAIN_PASSWORD_INFORMATION{}, fmt.Errorf("SamrGetUserDomainPasswordInformation: %w", err)
+	}
+	if uint32(resp.Status) != samr.StatusSuccess {
+		return resp.PasswordInformation, fmt.Errorf("SamrGetUserDomainPasswordInformation failed: %s", samr.StatusString(uint32(resp.Status)))
+	}
+	return resp.PasswordInformation, nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/45_SamrRemoveMemberFromForeignDomain.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/45_SamrRemoveMemberFromForeignDomain.go
@@ -1,0 +1,40 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrRemoveMemberFromForeignDomainRequest is the [in] parameter set of
+// SamrRemoveMemberFromForeignDomain: a domain handle and the [ref] SID (inline, single
+// pointer) to remove from all aliases in the domain.
+type samrRemoveMemberFromForeignDomainRequest struct {
+	DomainHandle structures.SAMPR_HANDLE
+	MemberSid    dtyp.RPC_SID
+}
+
+func (*samrRemoveMemberFromForeignDomainRequest) Opnum() uint16 {
+	return samr.OpnumSamrRemoveMemberFromForeignDomain
+}
+
+// SamrRemoveMemberFromForeignDomain calls SamrRemoveMemberFromForeignDomain (opnum 45),
+// removing the given SID from the membership of all aliases in the domain ([MS-SAMR]
+// 3.1.5.8.5).
+func SamrRemoveMemberFromForeignDomain(rpc *client.Client, domainHandle structures.SAMPR_HANDLE, memberSid dtyp.RPC_SID) error {
+	req := &samrRemoveMemberFromForeignDomainRequest{
+		DomainHandle: domainHandle,
+		MemberSid:    memberSid,
+	}
+	var resp statusResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return fmt.Errorf("SamrRemoveMemberFromForeignDomain: %w", err)
+	}
+	if uint32(resp.Status) != samr.StatusSuccess {
+		return fmt.Errorf("SamrRemoveMemberFromForeignDomain failed: %s", samr.StatusString(uint32(resp.Status)))
+	}
+	return nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/46_SamrQueryInformationDomain2.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/46_SamrQueryInformationDomain2.go
@@ -1,0 +1,46 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrQueryInformationDomain2Request is the [in] parameter set of
+// SamrQueryInformationDomain2 (identical shape to opnum 8): a domain handle and the
+// information class selecting the union arm to return.
+type samrQueryInformationDomain2Request struct {
+	DomainHandle           structures.SAMPR_HANDLE
+	DomainInformationClass structures.DOMAIN_INFORMATION_CLASS
+}
+
+func (*samrQueryInformationDomain2Request) Opnum() uint16 {
+	return samr.OpnumSamrQueryInformationDomain2
+}
+
+// samrQueryInformationDomain2Response is the reply: the [out, switch_is] double-pointer
+// SAMPR_DOMAIN_INFO_BUFFER union (modeled [unique]) and the NTSTATUS.
+type samrQueryInformationDomain2Response struct {
+	Buffer *structures.SAMPR_DOMAIN_INFO_BUFFER `ndr:"unique"`
+	Status ndr.DWORD                            `ndr:"retval"`
+}
+
+// SamrQueryInformationDomain2 calls SamrQueryInformationDomain2 (opnum 46), retrieving domain
+// attributes selected by class ([MS-SAMR] 3.1.5.5.1). The returned union carries its own Tag.
+func SamrQueryInformationDomain2(rpc *client.Client, domainHandle structures.SAMPR_HANDLE, class uint16) (*structures.SAMPR_DOMAIN_INFO_BUFFER, error) {
+	req := &samrQueryInformationDomain2Request{
+		DomainHandle:           domainHandle,
+		DomainInformationClass: structures.DOMAIN_INFORMATION_CLASS(class),
+	}
+	var resp samrQueryInformationDomain2Response
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return nil, fmt.Errorf("SamrQueryInformationDomain2: %w", err)
+	}
+	if uint32(resp.Status) != samr.StatusSuccess {
+		return resp.Buffer, fmt.Errorf("SamrQueryInformationDomain2 failed: %s", samr.StatusString(uint32(resp.Status)))
+	}
+	return resp.Buffer, nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/47_SamrQueryInformationUser2.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/47_SamrQueryInformationUser2.go
@@ -1,0 +1,45 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrQueryInformationUser2Request carries the [in] user handle and the information class
+// selecting which arm of the returned union is populated.
+type samrQueryInformationUser2Request struct {
+	UserHandle           structures.SAMPR_HANDLE
+	UserInformationClass structures.USER_INFORMATION_CLASS
+}
+
+func (*samrQueryInformationUser2Request) Opnum() uint16 {
+	return samr.OpnumSamrQueryInformationUser2
+}
+
+// samrQueryInformationUser2Response is the reply: the [out,switch_is,unique] user info buffer
+// (carrying its own discriminant) and the NTSTATUS.
+type samrQueryInformationUser2Response struct {
+	Buffer *structures.SAMPR_USER_INFO_BUFFER `ndr:"unique"`
+	Status ndr.DWORD                          `ndr:"retval"`
+}
+
+// SamrQueryInformationUser2 calls SamrQueryInformationUser2 (opnum 47), retrieving attributes
+// of a user object ([MS-SAMR] 3.1.5.5.5).
+func SamrQueryInformationUser2(rpc *client.Client, userHandle structures.SAMPR_HANDLE, userInformationClass structures.USER_INFORMATION_CLASS) (*structures.SAMPR_USER_INFO_BUFFER, error) {
+	req := &samrQueryInformationUser2Request{
+		UserHandle:           userHandle,
+		UserInformationClass: userInformationClass,
+	}
+	var resp samrQueryInformationUser2Response
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return nil, fmt.Errorf("SamrQueryInformationUser2: %w", err)
+	}
+	if uint32(resp.Status) != samr.StatusSuccess {
+		return resp.Buffer, fmt.Errorf("SamrQueryInformationUser2 failed: %s", samr.StatusString(uint32(resp.Status)))
+	}
+	return resp.Buffer, nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/48_SamrQueryDisplayInformation2.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/48_SamrQueryDisplayInformation2.go
@@ -1,0 +1,58 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrQueryDisplayInformation2Request is the [in] parameter set of
+// SamrQueryDisplayInformation2 (identical shape to opnum 40): a domain handle, the display
+// class, the starting index, the requested entry count, and the preferred maximum byte
+// length of the returned buffer.
+type samrQueryDisplayInformation2Request struct {
+	DomainHandle            structures.SAMPR_HANDLE
+	DisplayInformationClass structures.DOMAIN_DISPLAY_INFORMATION
+	Index                   ndr.DWORD
+	EntryCount              ndr.DWORD
+	PreferredMaximumLength  ndr.DWORD
+}
+
+func (*samrQueryDisplayInformation2Request) Opnum() uint16 {
+	return samr.OpnumSamrQueryDisplayInformation2
+}
+
+// samrQueryDisplayInformation2Response is the reply: the total available and total returned
+// byte counts, the [out, switch_is] SINGLE-pointer SAMPR_DISPLAY_INFO_BUFFER union (inline,
+// [ref] — not [unique], not double), and the NTSTATUS.
+type samrQueryDisplayInformation2Response struct {
+	TotalAvailable ndr.DWORD
+	TotalReturned  ndr.DWORD
+	Buffer         structures.SAMPR_DISPLAY_INFO_BUFFER
+	Status         ndr.DWORD `ndr:"retval"`
+}
+
+// SamrQueryDisplayInformation2 calls SamrQueryDisplayInformation2 (opnum 48), returning a page
+// of account information for display ([MS-SAMR] 3.1.5.3.1). The returned union carries its own
+// Tag.
+func SamrQueryDisplayInformation2(rpc *client.Client, domainHandle structures.SAMPR_HANDLE, class uint16, index, entryCount, preferredMaximumLength uint32) (uint32, uint32, structures.SAMPR_DISPLAY_INFO_BUFFER, error) {
+	req := &samrQueryDisplayInformation2Request{
+		DomainHandle:            domainHandle,
+		DisplayInformationClass: structures.DOMAIN_DISPLAY_INFORMATION(class),
+		Index:                   ndr.DWORD(index),
+		EntryCount:              ndr.DWORD(entryCount),
+		PreferredMaximumLength:  ndr.DWORD(preferredMaximumLength),
+	}
+	var resp samrQueryDisplayInformation2Response
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return 0, 0, structures.SAMPR_DISPLAY_INFO_BUFFER{}, fmt.Errorf("SamrQueryDisplayInformation2: %w", err)
+	}
+	status := uint32(resp.Status)
+	if status != samr.StatusSuccess && status != samr.StatusMoreEntries {
+		return uint32(resp.TotalAvailable), uint32(resp.TotalReturned), resp.Buffer, fmt.Errorf("SamrQueryDisplayInformation2 failed: %s", samr.StatusString(status))
+	}
+	return uint32(resp.TotalAvailable), uint32(resp.TotalReturned), resp.Buffer, nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/49_SamrGetDisplayEnumerationIndex2.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/49_SamrGetDisplayEnumerationIndex2.go
@@ -1,0 +1,50 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrGetDisplayEnumerationIndex2Request is the [in] parameter set of
+// SamrGetDisplayEnumerationIndex2 (identical shape to opnum 41): a domain handle, the display
+// class, and the [ref] name prefix (inline, single pointer) to search for.
+type samrGetDisplayEnumerationIndex2Request struct {
+	DomainHandle            structures.SAMPR_HANDLE
+	DisplayInformationClass structures.DOMAIN_DISPLAY_INFORMATION
+	Prefix                  dtyp.RPC_UNICODE_STRING
+}
+
+func (*samrGetDisplayEnumerationIndex2Request) Opnum() uint16 {
+	return samr.OpnumSamrGetDisplayEnumerationIndex2
+}
+
+// samrGetDisplayEnumerationIndex2Response is the reply: the [out] index and the NTSTATUS.
+type samrGetDisplayEnumerationIndex2Response struct {
+	Index  ndr.DWORD
+	Status ndr.DWORD `ndr:"retval"`
+}
+
+// SamrGetDisplayEnumerationIndex2 calls SamrGetDisplayEnumerationIndex2 (opnum 49), returning
+// the index of the first account whose name is greater than or equal to the given prefix
+// ([MS-SAMR] 3.1.5.3.2).
+func SamrGetDisplayEnumerationIndex2(rpc *client.Client, domainHandle structures.SAMPR_HANDLE, class uint16, prefix string) (uint32, error) {
+	req := &samrGetDisplayEnumerationIndex2Request{
+		DomainHandle:            domainHandle,
+		DisplayInformationClass: structures.DOMAIN_DISPLAY_INFORMATION(class),
+		Prefix:                  dtyp.NewUnicodeString(prefix),
+	}
+	var resp samrGetDisplayEnumerationIndex2Response
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return 0, fmt.Errorf("SamrGetDisplayEnumerationIndex2: %w", err)
+	}
+	status := uint32(resp.Status)
+	if status != samr.StatusSuccess && status != samr.StatusMoreEntries && status != samr.StatusNoMoreEntries {
+		return uint32(resp.Index), fmt.Errorf("SamrGetDisplayEnumerationIndex2 failed: %s", samr.StatusString(status))
+	}
+	return uint32(resp.Index), nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/50_SamrCreateUser2InDomain.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/50_SamrCreateUser2InDomain.go
@@ -1,0 +1,51 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrCreateUser2InDomainRequest carries the [in] parameters of SamrCreateUser2InDomain: the
+// domain handle, the [ref] account name, the account type (a USER_ACCOUNT_* control bit), and
+// the desired access mask for the returned user handle.
+type samrCreateUser2InDomainRequest struct {
+	DomainHandle  structures.SAMPR_HANDLE
+	Name          dtyp.RPC_UNICODE_STRING
+	AccountType   ndr.DWORD
+	DesiredAccess ndr.DWORD
+}
+
+func (*samrCreateUser2InDomainRequest) Opnum() uint16 { return samr.OpnumSamrCreateUser2InDomain }
+
+// samrCreateUser2InDomainResponse is the reply: the [out] user handle, the access actually
+// granted, the relative id assigned to the new user, and the NTSTATUS.
+type samrCreateUser2InDomainResponse struct {
+	UserHandle    structures.SAMPR_HANDLE
+	GrantedAccess ndr.DWORD
+	RelativeId    ndr.DWORD
+	Status        ndr.DWORD `ndr:"retval"`
+}
+
+// SamrCreateUser2InDomain calls SamrCreateUser2InDomain (opnum 50), creating a user object of
+// the given account type in the domain ([MS-SAMR] 3.1.5.4.4).
+func SamrCreateUser2InDomain(rpc *client.Client, domainHandle structures.SAMPR_HANDLE, name string, accountType uint32, desiredAccess uint32) (structures.SAMPR_HANDLE, uint32, uint32, error) {
+	req := &samrCreateUser2InDomainRequest{
+		DomainHandle:  domainHandle,
+		Name:          dtyp.NewUnicodeString(name),
+		AccountType:   ndr.DWORD(accountType),
+		DesiredAccess: ndr.DWORD(desiredAccess),
+	}
+	var resp samrCreateUser2InDomainResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return structures.SAMPR_HANDLE{}, 0, 0, fmt.Errorf("SamrCreateUser2InDomain: %w", err)
+	}
+	if uint32(resp.Status) != samr.StatusSuccess {
+		return resp.UserHandle, uint32(resp.GrantedAccess), uint32(resp.RelativeId), fmt.Errorf("SamrCreateUser2InDomain failed: %s", samr.StatusString(uint32(resp.Status)))
+	}
+	return resp.UserHandle, uint32(resp.GrantedAccess), uint32(resp.RelativeId), nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/51_SamrQueryDisplayInformation3.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/51_SamrQueryDisplayInformation3.go
@@ -1,0 +1,58 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrQueryDisplayInformation3Request is the [in] parameter set of
+// SamrQueryDisplayInformation3 (identical shape to opnum 40): a domain handle, the display
+// class, the starting index, the requested entry count, and the preferred maximum byte
+// length of the returned buffer.
+type samrQueryDisplayInformation3Request struct {
+	DomainHandle            structures.SAMPR_HANDLE
+	DisplayInformationClass structures.DOMAIN_DISPLAY_INFORMATION
+	Index                   ndr.DWORD
+	EntryCount              ndr.DWORD
+	PreferredMaximumLength  ndr.DWORD
+}
+
+func (*samrQueryDisplayInformation3Request) Opnum() uint16 {
+	return samr.OpnumSamrQueryDisplayInformation3
+}
+
+// samrQueryDisplayInformation3Response is the reply: the total available and total returned
+// byte counts, the [out, switch_is] SINGLE-pointer SAMPR_DISPLAY_INFO_BUFFER union (inline,
+// [ref] — not [unique], not double), and the NTSTATUS.
+type samrQueryDisplayInformation3Response struct {
+	TotalAvailable ndr.DWORD
+	TotalReturned  ndr.DWORD
+	Buffer         structures.SAMPR_DISPLAY_INFO_BUFFER
+	Status         ndr.DWORD `ndr:"retval"`
+}
+
+// SamrQueryDisplayInformation3 calls SamrQueryDisplayInformation3 (opnum 51), returning a page
+// of account information for display ([MS-SAMR] 3.1.5.3.1). The returned union carries its own
+// Tag.
+func SamrQueryDisplayInformation3(rpc *client.Client, domainHandle structures.SAMPR_HANDLE, class uint16, index, entryCount, preferredMaximumLength uint32) (uint32, uint32, structures.SAMPR_DISPLAY_INFO_BUFFER, error) {
+	req := &samrQueryDisplayInformation3Request{
+		DomainHandle:            domainHandle,
+		DisplayInformationClass: structures.DOMAIN_DISPLAY_INFORMATION(class),
+		Index:                   ndr.DWORD(index),
+		EntryCount:              ndr.DWORD(entryCount),
+		PreferredMaximumLength:  ndr.DWORD(preferredMaximumLength),
+	}
+	var resp samrQueryDisplayInformation3Response
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return 0, 0, structures.SAMPR_DISPLAY_INFO_BUFFER{}, fmt.Errorf("SamrQueryDisplayInformation3: %w", err)
+	}
+	status := uint32(resp.Status)
+	if status != samr.StatusSuccess && status != samr.StatusMoreEntries {
+		return uint32(resp.TotalAvailable), uint32(resp.TotalReturned), resp.Buffer, fmt.Errorf("SamrQueryDisplayInformation3 failed: %s", samr.StatusString(status))
+	}
+	return uint32(resp.TotalAvailable), uint32(resp.TotalReturned), resp.Buffer, nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/52_SamrAddMultipleMembersToAlias.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/52_SamrAddMultipleMembersToAlias.go
@@ -1,0 +1,37 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrAddMultipleMembersToAliasRequest carries the [in] alias handle and the [ref] SID
+// array container of members to add (transmitted inline).
+type samrAddMultipleMembersToAliasRequest struct {
+	AliasHandle   structures.SAMPR_HANDLE
+	MembersBuffer structures.SAMPR_PSID_ARRAY
+}
+
+func (*samrAddMultipleMembersToAliasRequest) Opnum() uint16 {
+	return samr.OpnumSamrAddMultipleMembersToAlias
+}
+
+// SamrAddMultipleMembersToAlias calls SamrAddMultipleMembersToAlias (opnum 52), adding
+// multiple members to an alias in a single call ([MS-SAMR] 3.1.5.4.3).
+func SamrAddMultipleMembersToAlias(rpc *client.Client, aliasHandle structures.SAMPR_HANDLE, membersBuffer structures.SAMPR_PSID_ARRAY) error {
+	req := &samrAddMultipleMembersToAliasRequest{
+		AliasHandle:   aliasHandle,
+		MembersBuffer: membersBuffer,
+	}
+	var resp statusResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return fmt.Errorf("SamrAddMultipleMembersToAlias: %w", err)
+	}
+	if uint32(resp.Status) != samr.StatusSuccess {
+		return fmt.Errorf("SamrAddMultipleMembersToAlias failed: %s", samr.StatusString(uint32(resp.Status)))
+	}
+	return nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/53_SamrRemoveMultipleMembersFromAlias.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/53_SamrRemoveMultipleMembersFromAlias.go
@@ -1,0 +1,37 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrRemoveMultipleMembersFromAliasRequest carries the [in] alias handle and the [ref] SID
+// array container of members to remove (transmitted inline).
+type samrRemoveMultipleMembersFromAliasRequest struct {
+	AliasHandle   structures.SAMPR_HANDLE
+	MembersBuffer structures.SAMPR_PSID_ARRAY
+}
+
+func (*samrRemoveMultipleMembersFromAliasRequest) Opnum() uint16 {
+	return samr.OpnumSamrRemoveMultipleMembersFromAlias
+}
+
+// SamrRemoveMultipleMembersFromAlias calls SamrRemoveMultipleMembersFromAlias (opnum 53),
+// removing multiple members from an alias in a single call ([MS-SAMR] 3.1.5.5.4).
+func SamrRemoveMultipleMembersFromAlias(rpc *client.Client, aliasHandle structures.SAMPR_HANDLE, membersBuffer structures.SAMPR_PSID_ARRAY) error {
+	req := &samrRemoveMultipleMembersFromAliasRequest{
+		AliasHandle:   aliasHandle,
+		MembersBuffer: membersBuffer,
+	}
+	var resp statusResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return fmt.Errorf("SamrRemoveMultipleMembersFromAlias: %w", err)
+	}
+	if uint32(resp.Status) != samr.StatusSuccess {
+		return fmt.Errorf("SamrRemoveMultipleMembersFromAlias failed: %s", samr.StatusString(uint32(resp.Status)))
+	}
+	return nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/54_SamrOemChangePasswordUser2.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/54_SamrOemChangePasswordUser2.go
@@ -1,0 +1,43 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrOemChangePasswordUser2Request carries the [in] parameters of SamrOemChangePasswordUser2
+// (the handle_t binding handle is implicit and omitted): the [unique] ANSI server name, the
+// [ref] ANSI user name, and the new password / old LM OWF blobs cross-encrypted with one
+// another. Field order matches the IDL.
+type samrOemChangePasswordUser2Request struct {
+	ServerName                         *structures.RPC_STRING `ndr:"unique"`
+	UserName                           structures.RPC_STRING
+	NewPasswordEncryptedWithOldLm      *structures.SAMPR_ENCRYPTED_USER_PASSWORD `ndr:"unique"`
+	OldLmOwfPasswordEncryptedWithNewLm *structures.ENCRYPTED_LM_OWF_PASSWORD     `ndr:"unique"`
+}
+
+func (*samrOemChangePasswordUser2Request) Opnum() uint16 {
+	return samr.OpnumSamrOemChangePasswordUser2
+}
+
+// SamrOemChangePasswordUser2 calls SamrOemChangePasswordUser2 (opnum 54), changing a user's
+// password using OEM (ANSI) encoded names and LM-based encryption ([MS-SAMR] 3.1.5.10.3).
+func SamrOemChangePasswordUser2(rpc *client.Client, serverName *structures.RPC_STRING, userName structures.RPC_STRING, newPasswordEncryptedWithOldLm *structures.SAMPR_ENCRYPTED_USER_PASSWORD, oldLmOwfPasswordEncryptedWithNewLm *structures.ENCRYPTED_LM_OWF_PASSWORD) error {
+	req := &samrOemChangePasswordUser2Request{
+		ServerName:                         serverName,
+		UserName:                           userName,
+		NewPasswordEncryptedWithOldLm:      newPasswordEncryptedWithOldLm,
+		OldLmOwfPasswordEncryptedWithNewLm: oldLmOwfPasswordEncryptedWithNewLm,
+	}
+	var resp statusResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return fmt.Errorf("SamrOemChangePasswordUser2: %w", err)
+	}
+	if uint32(resp.Status) != samr.StatusSuccess {
+		return fmt.Errorf("SamrOemChangePasswordUser2 failed: %s", samr.StatusString(uint32(resp.Status)))
+	}
+	return nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/55_SamrUnicodeChangePasswordUser2.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/55_SamrUnicodeChangePasswordUser2.go
@@ -1,0 +1,52 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrUnicodeChangePasswordUser2Request carries the [in] parameters of
+// SamrUnicodeChangePasswordUser2 (the handle_t binding handle is implicit and omitted): the
+// [unique] Unicode server name, the [ref] Unicode user name, the NT-encrypted new password
+// and old NT OWF, an LM-present flag, and the optional LM-encrypted new password and old LM
+// OWF. Field order matches the IDL exactly.
+type samrUnicodeChangePasswordUser2Request struct {
+	ServerName                         *dtyp.RPC_UNICODE_STRING `ndr:"unique"`
+	UserName                           dtyp.RPC_UNICODE_STRING
+	NewPasswordEncryptedWithOldNt      *structures.SAMPR_ENCRYPTED_USER_PASSWORD `ndr:"unique"`
+	OldNtOwfPasswordEncryptedWithNewNt *structures.ENCRYPTED_NT_OWF_PASSWORD     `ndr:"unique"`
+	LmPresent                          uint8
+	NewPasswordEncryptedWithOldLm      *structures.SAMPR_ENCRYPTED_USER_PASSWORD `ndr:"unique"`
+	OldLmOwfPasswordEncryptedWithNewNt *structures.ENCRYPTED_LM_OWF_PASSWORD     `ndr:"unique"`
+}
+
+func (*samrUnicodeChangePasswordUser2Request) Opnum() uint16 {
+	return samr.OpnumSamrUnicodeChangePasswordUser2
+}
+
+// SamrUnicodeChangePasswordUser2 calls SamrUnicodeChangePasswordUser2 (opnum 55), changing a
+// user's password using Unicode names and NT-based encryption (with optional LM material)
+// ([MS-SAMR] 3.1.5.10.4).
+func SamrUnicodeChangePasswordUser2(rpc *client.Client, serverName *dtyp.RPC_UNICODE_STRING, userName dtyp.RPC_UNICODE_STRING, newPasswordEncryptedWithOldNt *structures.SAMPR_ENCRYPTED_USER_PASSWORD, oldNtOwfPasswordEncryptedWithNewNt *structures.ENCRYPTED_NT_OWF_PASSWORD, lmPresent uint8, newPasswordEncryptedWithOldLm *structures.SAMPR_ENCRYPTED_USER_PASSWORD, oldLmOwfPasswordEncryptedWithNewNt *structures.ENCRYPTED_LM_OWF_PASSWORD) error {
+	req := &samrUnicodeChangePasswordUser2Request{
+		ServerName:                         serverName,
+		UserName:                           userName,
+		NewPasswordEncryptedWithOldNt:      newPasswordEncryptedWithOldNt,
+		OldNtOwfPasswordEncryptedWithNewNt: oldNtOwfPasswordEncryptedWithNewNt,
+		LmPresent:                          lmPresent,
+		NewPasswordEncryptedWithOldLm:      newPasswordEncryptedWithOldLm,
+		OldLmOwfPasswordEncryptedWithNewNt: oldLmOwfPasswordEncryptedWithNewNt,
+	}
+	var resp statusResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return fmt.Errorf("SamrUnicodeChangePasswordUser2: %w", err)
+	}
+	if uint32(resp.Status) != samr.StatusSuccess {
+		return fmt.Errorf("SamrUnicodeChangePasswordUser2 failed: %s", samr.StatusString(uint32(resp.Status)))
+	}
+	return nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/56_SamrGetDomainPasswordInformation.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/56_SamrGetDomainPasswordInformation.go
@@ -1,0 +1,44 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrGetDomainPasswordInformationRequest carries the [in] parameters. The
+// handle_t binding handle is implicit (the RPC client) and is not marshalled;
+// Unused is an ignored [unique] string per the protocol.
+type samrGetDomainPasswordInformationRequest struct {
+	Unused *dtyp.RPC_UNICODE_STRING `ndr:"unique"`
+}
+
+func (*samrGetDomainPasswordInformationRequest) Opnum() uint16 {
+	return samr.OpnumSamrGetDomainPasswordInformation
+}
+
+// samrGetDomainPasswordInformationResponse carries the [out, ref] password policy
+// information (modeled inline) and the NTSTATUS.
+type samrGetDomainPasswordInformationResponse struct {
+	PasswordInformation structures.USER_DOMAIN_PASSWORD_INFORMATION
+	Status              ndr.DWORD `ndr:"retval"`
+}
+
+// SamrGetDomainPasswordInformation calls SamrGetDomainPasswordInformation
+// (opnum 56), retrieving select password policy properties of the account domain
+// ([MS-SAMR] 3.1.5.13.3).
+func SamrGetDomainPasswordInformation(rpc *client.Client) (structures.USER_DOMAIN_PASSWORD_INFORMATION, error) {
+	req := &samrGetDomainPasswordInformationRequest{}
+	var resp samrGetDomainPasswordInformationResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return structures.USER_DOMAIN_PASSWORD_INFORMATION{}, fmt.Errorf("SamrGetDomainPasswordInformation: %w", err)
+	}
+	if uint32(resp.Status) != samr.StatusSuccess {
+		return resp.PasswordInformation, fmt.Errorf("SamrGetDomainPasswordInformation failed: %s", samr.StatusString(uint32(resp.Status)))
+	}
+	return resp.PasswordInformation, nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/57_SamrConnect2.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/57_SamrConnect2.go
@@ -1,0 +1,36 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrConnect2Request carries the [in] parameters of SamrConnect2: the [unique]
+// server name (NULL for the local server) and the desired access mask.
+type samrConnect2Request struct {
+	ServerName    *ndr.WSTR `ndr:"unique"`
+	DesiredAccess ndr.DWORD
+}
+
+func (*samrConnect2Request) Opnum() uint16 { return samr.OpnumSamrConnect2 }
+
+// SamrConnect2 calls SamrConnect2 (opnum 57), obtaining a handle to a server
+// object ([MS-SAMR] 3.1.5.1.3).
+func SamrConnect2(rpc *client.Client, serverName string, desiredAccess uint32) (structures.SAMPR_HANDLE, error) {
+	req := &samrConnect2Request{
+		ServerName:    optWStr(serverName),
+		DesiredAccess: ndr.DWORD(desiredAccess),
+	}
+	var resp openHandleResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return structures.SAMPR_HANDLE{}, fmt.Errorf("SamrConnect2: %w", err)
+	}
+	if uint32(resp.Status) != samr.StatusSuccess {
+		return resp.Handle, fmt.Errorf("SamrConnect2 failed: %s", samr.StatusString(uint32(resp.Status)))
+	}
+	return resp.Handle, nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/58_SamrSetInformationUser2.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/58_SamrSetInformationUser2.go
@@ -1,0 +1,38 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrSetInformationUser2Request carries the [in] user handle, the information class, and the
+// [in,switch_is] user info buffer (inline, carrying its own discriminant) whose selected arm
+// is written to the user object.
+type samrSetInformationUser2Request struct {
+	UserHandle           structures.SAMPR_HANDLE
+	UserInformationClass structures.USER_INFORMATION_CLASS
+	Buffer               structures.SAMPR_USER_INFO_BUFFER
+}
+
+func (*samrSetInformationUser2Request) Opnum() uint16 { return samr.OpnumSamrSetInformationUser2 }
+
+// SamrSetInformationUser2 calls SamrSetInformationUser2 (opnum 58), updating attributes of a
+// user object ([MS-SAMR] 3.1.5.6.5).
+func SamrSetInformationUser2(rpc *client.Client, userHandle structures.SAMPR_HANDLE, userInformationClass structures.USER_INFORMATION_CLASS, buffer structures.SAMPR_USER_INFO_BUFFER) error {
+	req := &samrSetInformationUser2Request{
+		UserHandle:           userHandle,
+		UserInformationClass: userInformationClass,
+		Buffer:               buffer,
+	}
+	var resp statusResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return fmt.Errorf("SamrSetInformationUser2: %w", err)
+	}
+	if uint32(resp.Status) != samr.StatusSuccess {
+		return fmt.Errorf("SamrSetInformationUser2 failed: %s", samr.StatusString(uint32(resp.Status)))
+	}
+	return nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/62_SamrConnect4.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/62_SamrConnect4.go
@@ -1,0 +1,39 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrConnect4Request carries the [in] parameters of SamrConnect4: the [unique]
+// server name (NULL for the local server), the client revision, and the desired
+// access mask.
+type samrConnect4Request struct {
+	ServerName     *ndr.WSTR `ndr:"unique"`
+	ClientRevision ndr.DWORD
+	DesiredAccess  ndr.DWORD
+}
+
+func (*samrConnect4Request) Opnum() uint16 { return samr.OpnumSamrConnect4 }
+
+// SamrConnect4 calls SamrConnect4 (opnum 62), obtaining a handle to a server
+// object and advertising the client revision ([MS-SAMR] 3.1.5.1.2).
+func SamrConnect4(rpc *client.Client, serverName string, clientRevision uint32, desiredAccess uint32) (structures.SAMPR_HANDLE, error) {
+	req := &samrConnect4Request{
+		ServerName:     optWStr(serverName),
+		ClientRevision: ndr.DWORD(clientRevision),
+		DesiredAccess:  ndr.DWORD(desiredAccess),
+	}
+	var resp openHandleResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return structures.SAMPR_HANDLE{}, fmt.Errorf("SamrConnect4: %w", err)
+	}
+	if uint32(resp.Status) != samr.StatusSuccess {
+		return resp.Handle, fmt.Errorf("SamrConnect4 failed: %s", samr.StatusString(uint32(resp.Status)))
+	}
+	return resp.Handle, nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/64_SamrConnect5.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/64_SamrConnect5.go
@@ -11,21 +11,27 @@ import (
 
 // samrConnect5Request carries the [in] parameters of SamrConnect5: the [unique]
 // server name (NULL for the local server), the desired access mask, the requested
-// input version, and the [unique, switch_is(InVersion)] revision-info union.
+// input version, and the switch_is(InVersion) revision-info union.
+//
+// InRevisionInfo is the IDL's [switch_is(InVersion)] SAMPR_REVISION_INFO* parameter.
+// A switch_is union argument is transmitted inline (its own discriminant followed by
+// the selected arm), NOT wrapped behind a pointer referent — emitting a referent id
+// here is rejected by the server as nca_s_fault_ndr.
 type samrConnect5Request struct {
 	ServerName     *ndr.WSTR `ndr:"unique"`
 	DesiredAccess  ndr.DWORD
 	InVersion      ndr.DWORD
-	InRevisionInfo *structures.SAMPR_REVISION_INFO `ndr:"unique"`
+	InRevisionInfo structures.SAMPR_REVISION_INFO
 }
 
 func (*samrConnect5Request) Opnum() uint16 { return samr.OpnumSamrConnect5 }
 
-// samrConnect5Response carries the [out] negotiated output version, the [unique,
-// switch_is(*OutVersion)] revision-info union, the server handle, and the NTSTATUS.
+// samrConnect5Response carries the [out] negotiated output version, the
+// switch_is(*OutVersion) revision-info union (transmitted inline), the server handle,
+// and the NTSTATUS.
 type samrConnect5Response struct {
 	OutVersion      ndr.DWORD
-	OutRevisionInfo *structures.SAMPR_REVISION_INFO `ndr:"unique"`
+	OutRevisionInfo structures.SAMPR_REVISION_INFO
 	ServerHandle    structures.SAMPR_HANDLE
 	Status          ndr.DWORD `ndr:"retval"`
 }
@@ -39,7 +45,7 @@ func SamrConnect5(rpc *client.Client, serverName string, desiredAccess uint32) (
 		ServerName:    optWStr(serverName),
 		DesiredAccess: ndr.DWORD(desiredAccess),
 		InVersion:     ndr.DWORD(inVersion),
-		InRevisionInfo: &structures.SAMPR_REVISION_INFO{
+		InRevisionInfo: structures.SAMPR_REVISION_INFO{
 			Tag: ndr.DWORD(inVersion),
 			V1:  structures.SAMPR_REVISION_INFO_V1{Revision: 3},
 		},
@@ -48,8 +54,9 @@ func SamrConnect5(rpc *client.Client, serverName string, desiredAccess uint32) (
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return structures.SAMPR_HANDLE{}, 0, nil, fmt.Errorf("SamrConnect5: %w", err)
 	}
+	outInfo := resp.OutRevisionInfo
 	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.ServerHandle, uint32(resp.OutVersion), resp.OutRevisionInfo, fmt.Errorf("SamrConnect5 failed: %s", samr.StatusString(uint32(resp.Status)))
+		return resp.ServerHandle, uint32(resp.OutVersion), &outInfo, fmt.Errorf("SamrConnect5 failed: %s", samr.StatusString(uint32(resp.Status)))
 	}
-	return resp.ServerHandle, uint32(resp.OutVersion), resp.OutRevisionInfo, nil
+	return resp.ServerHandle, uint32(resp.OutVersion), &outInfo, nil
 }

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/64_SamrConnect5.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/64_SamrConnect5.go
@@ -1,0 +1,55 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrConnect5Request carries the [in] parameters of SamrConnect5: the [unique]
+// server name (NULL for the local server), the desired access mask, the requested
+// input version, and the [unique, switch_is(InVersion)] revision-info union.
+type samrConnect5Request struct {
+	ServerName     *ndr.WSTR `ndr:"unique"`
+	DesiredAccess  ndr.DWORD
+	InVersion      ndr.DWORD
+	InRevisionInfo *structures.SAMPR_REVISION_INFO `ndr:"unique"`
+}
+
+func (*samrConnect5Request) Opnum() uint16 { return samr.OpnumSamrConnect5 }
+
+// samrConnect5Response carries the [out] negotiated output version, the [unique,
+// switch_is(*OutVersion)] revision-info union, the server handle, and the NTSTATUS.
+type samrConnect5Response struct {
+	OutVersion      ndr.DWORD
+	OutRevisionInfo *structures.SAMPR_REVISION_INFO `ndr:"unique"`
+	ServerHandle    structures.SAMPR_HANDLE
+	Status          ndr.DWORD `ndr:"retval"`
+}
+
+// SamrConnect5 calls SamrConnect5 (opnum 64), obtaining a handle to a server
+// object while negotiating a revision ([MS-SAMR] 3.1.5.1.1). This convenience
+// signature requests input version 1 with a V1 revision info ({Revision: 3}).
+func SamrConnect5(rpc *client.Client, serverName string, desiredAccess uint32) (structures.SAMPR_HANDLE, uint32, *structures.SAMPR_REVISION_INFO, error) {
+	const inVersion = 1
+	req := &samrConnect5Request{
+		ServerName:    optWStr(serverName),
+		DesiredAccess: ndr.DWORD(desiredAccess),
+		InVersion:     ndr.DWORD(inVersion),
+		InRevisionInfo: &structures.SAMPR_REVISION_INFO{
+			Tag: ndr.DWORD(inVersion),
+			V1:  structures.SAMPR_REVISION_INFO_V1{Revision: 3},
+		},
+	}
+	var resp samrConnect5Response
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return structures.SAMPR_HANDLE{}, 0, nil, fmt.Errorf("SamrConnect5: %w", err)
+	}
+	if uint32(resp.Status) != samr.StatusSuccess {
+		return resp.ServerHandle, uint32(resp.OutVersion), resp.OutRevisionInfo, fmt.Errorf("SamrConnect5 failed: %s", samr.StatusString(uint32(resp.Status)))
+	}
+	return resp.ServerHandle, uint32(resp.OutVersion), resp.OutRevisionInfo, nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/65_SamrRidToSid.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/65_SamrRidToSid.go
@@ -1,0 +1,44 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrRidToSidRequest carries the [in] parameters of SamrRidToSid: an object
+// handle for the domain context and the relative identifier to expand.
+type samrRidToSidRequest struct {
+	ObjectHandle structures.SAMPR_HANDLE
+	Rid          ndr.DWORD
+}
+
+func (*samrRidToSidRequest) Opnum() uint16 { return samr.OpnumSamrRidToSid }
+
+// samrRidToSidResponse carries the [out] double pointer to the constructed SID and
+// the NTSTATUS.
+type samrRidToSidResponse struct {
+	Sid    *dtyp.RPC_SID `ndr:"unique"`
+	Status ndr.DWORD     `ndr:"retval"`
+}
+
+// SamrRidToSid calls SamrRidToSid (opnum 65), constructing the full SID for a RID
+// in the object's domain ([MS-SAMR] 3.1.5.11.2).
+func SamrRidToSid(rpc *client.Client, handle structures.SAMPR_HANDLE, rid uint32) (*dtyp.RPC_SID, error) {
+	req := &samrRidToSidRequest{
+		ObjectHandle: handle,
+		Rid:          ndr.DWORD(rid),
+	}
+	var resp samrRidToSidResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return nil, fmt.Errorf("SamrRidToSid: %w", err)
+	}
+	if uint32(resp.Status) != samr.StatusSuccess {
+		return resp.Sid, fmt.Errorf("SamrRidToSid failed: %s", samr.StatusString(uint32(resp.Status)))
+	}
+	return resp.Sid, nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/66_SamrSetDSRMPassword.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/66_SamrSetDSRMPassword.go
@@ -1,0 +1,40 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrSetDSRMPasswordRequest carries the [in] parameters. The handle_t binding
+// handle is implicit (the RPC client) and is not marshalled; Unused is an ignored
+// [unique] string, UserId selects the account, and EncryptedNtOwfPassword is the
+// [unique] encrypted NT OWF of the new password.
+type samrSetDSRMPasswordRequest struct {
+	Unused                 *dtyp.RPC_UNICODE_STRING `ndr:"unique"`
+	UserId                 ndr.DWORD
+	EncryptedNtOwfPassword *structures.ENCRYPTED_NT_OWF_PASSWORD `ndr:"unique"`
+}
+
+func (*samrSetDSRMPasswordRequest) Opnum() uint16 { return samr.OpnumSamrSetDSRMPassword }
+
+// SamrSetDSRMPassword calls SamrSetDSRMPassword (opnum 66), setting the local
+// Directory Services Restore Mode administrator password ([MS-SAMR] 3.1.5.13.7).
+func SamrSetDSRMPassword(rpc *client.Client, userId uint32, encryptedNtOwfPassword *structures.ENCRYPTED_NT_OWF_PASSWORD) error {
+	req := &samrSetDSRMPasswordRequest{
+		UserId:                 ndr.DWORD(userId),
+		EncryptedNtOwfPassword: encryptedNtOwfPassword,
+	}
+	var resp statusResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return fmt.Errorf("SamrSetDSRMPassword: %w", err)
+	}
+	if uint32(resp.Status) != samr.StatusSuccess {
+		return fmt.Errorf("SamrSetDSRMPassword failed: %s", samr.StatusString(uint32(resp.Status)))
+	}
+	return nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/67_SamrValidatePassword.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/67_SamrValidatePassword.go
@@ -1,0 +1,46 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrValidatePasswordRequest carries the [in] parameters. The handle_t binding
+// handle is implicit (the RPC client) and is not marshalled; ValidationType selects
+// the union arm and InputArg is the [ref, switch_is(ValidationType)] input union
+// (modeled inline).
+type samrValidatePasswordRequest struct {
+	ValidationType structures.PASSWORD_POLICY_VALIDATION_TYPE
+	InputArg       structures.SAM_VALIDATE_INPUT_ARG
+}
+
+func (*samrValidatePasswordRequest) Opnum() uint16 { return samr.OpnumSamrValidatePassword }
+
+// samrValidatePasswordResponse carries the [out, switch_is(ValidationType)] double
+// pointer to the output union and the NTSTATUS.
+type samrValidatePasswordResponse struct {
+	OutputArg *structures.SAM_VALIDATE_OUTPUT_ARG `ndr:"unique"`
+	Status    ndr.DWORD                           `ndr:"retval"`
+}
+
+// SamrValidatePassword calls SamrValidatePassword (opnum 67), applying the account
+// domain's password policy to the supplied state ([MS-SAMR] 3.1.5.13.7.1). The
+// caller sets inputArg.Tag to match validationType before calling.
+func SamrValidatePassword(rpc *client.Client, validationType structures.PASSWORD_POLICY_VALIDATION_TYPE, inputArg structures.SAM_VALIDATE_INPUT_ARG) (*structures.SAM_VALIDATE_OUTPUT_ARG, error) {
+	req := &samrValidatePasswordRequest{
+		ValidationType: validationType,
+		InputArg:       inputArg,
+	}
+	var resp samrValidatePasswordResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return nil, fmt.Errorf("SamrValidatePassword: %w", err)
+	}
+	if uint32(resp.Status) != samr.StatusSuccess {
+		return resp.OutputArg, fmt.Errorf("SamrValidatePassword failed: %s", samr.StatusString(uint32(resp.Status)))
+	}
+	return resp.OutputArg, nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/73_SamrUnicodeChangePasswordUser4.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/73_SamrUnicodeChangePasswordUser4.go
@@ -1,0 +1,42 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrUnicodeChangePasswordUser4Request carries the [in] parameters of
+// SamrUnicodeChangePasswordUser4 (the handle_t binding handle is implicit and omitted): the
+// [unique] Unicode server name, the [ref] Unicode user name, and the AES-encrypted password
+// blob (inline, single [ref] pointer).
+type samrUnicodeChangePasswordUser4Request struct {
+	ServerName        *dtyp.RPC_UNICODE_STRING `ndr:"unique"`
+	UserName          dtyp.RPC_UNICODE_STRING
+	EncryptedPassword structures.SAMPR_ENCRYPTED_PASSWORD_AES
+}
+
+func (*samrUnicodeChangePasswordUser4Request) Opnum() uint16 {
+	return samr.OpnumSamrUnicodeChangePasswordUser4
+}
+
+// SamrUnicodeChangePasswordUser4 calls SamrUnicodeChangePasswordUser4 (opnum 73), changing a
+// user's password using an AES-encrypted password blob ([MS-SAMR] 3.1.5.10.5).
+func SamrUnicodeChangePasswordUser4(rpc *client.Client, serverName *dtyp.RPC_UNICODE_STRING, userName dtyp.RPC_UNICODE_STRING, encryptedPassword structures.SAMPR_ENCRYPTED_PASSWORD_AES) error {
+	req := &samrUnicodeChangePasswordUser4Request{
+		ServerName:        serverName,
+		UserName:          userName,
+		EncryptedPassword: encryptedPassword,
+	}
+	var resp statusResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return fmt.Errorf("SamrUnicodeChangePasswordUser4: %w", err)
+	}
+	if uint32(resp.Status) != samr.StatusSuccess {
+		return fmt.Errorf("SamrUnicodeChangePasswordUser4 failed: %s", samr.StatusString(uint32(resp.Status)))
+	}
+	return nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/74_SamrValidateComputerAccountReuseAttempt.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/74_SamrValidateComputerAccountReuseAttempt.go
@@ -1,0 +1,47 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrValidateComputerAccountReuseAttemptRequest carries the [in] server handle and the
+// [ref] SID (inline, single pointer) of the computer account whose reuse is being validated.
+type samrValidateComputerAccountReuseAttemptRequest struct {
+	ServerHandle structures.SAMPR_HANDLE
+	ComputerSid  dtyp.RPC_SID
+}
+
+func (*samrValidateComputerAccountReuseAttemptRequest) Opnum() uint16 {
+	return samr.OpnumSamrValidateComputerAccountReuseAttempt
+}
+
+// samrValidateComputerAccountReuseAttemptResponse is the reply: the [out] BOOL result (a
+// 32-bit value) and the NTSTATUS.
+type samrValidateComputerAccountReuseAttemptResponse struct {
+	Result int32
+	Status ndr.DWORD `ndr:"retval"`
+}
+
+// SamrValidateComputerAccountReuseAttempt calls SamrValidateComputerAccountReuseAttempt
+// (opnum 74), determining whether the caller is allowed to reuse the given computer account
+// SID ([MS-SAMR] 3.1.5.13.5).
+func SamrValidateComputerAccountReuseAttempt(rpc *client.Client, serverHandle structures.SAMPR_HANDLE, computerSid dtyp.RPC_SID) (int32, error) {
+	req := &samrValidateComputerAccountReuseAttemptRequest{
+		ServerHandle: serverHandle,
+		ComputerSid:  computerSid,
+	}
+	var resp samrValidateComputerAccountReuseAttemptResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return 0, fmt.Errorf("SamrValidateComputerAccountReuseAttempt: %w", err)
+	}
+	if uint32(resp.Status) != samr.StatusSuccess {
+		return resp.Result, fmt.Errorf("SamrValidateComputerAccountReuseAttempt failed: %s", samr.StatusString(uint32(resp.Status)))
+	}
+	return resp.Result, nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/77_SamrAccountIsDelegatedManagedServiceAccount.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/77_SamrAccountIsDelegatedManagedServiceAccount.go
@@ -1,0 +1,50 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// samrAccountIsDelegatedManagedServiceAccountRequest carries the [in] server handle and the
+// [ref] account name (inline) being tested.
+type samrAccountIsDelegatedManagedServiceAccountRequest struct {
+	ServerHandle structures.SAMPR_HANDLE
+	AccountName  dtyp.RPC_UNICODE_STRING
+}
+
+func (*samrAccountIsDelegatedManagedServiceAccountRequest) Opnum() uint16 {
+	return samr.OpnumSamrAccountIsDelegatedManagedServiceAccount
+}
+
+// samrAccountIsDelegatedManagedServiceAccountResponse is the reply: the [out] BOOLEAN result
+// (whether the account is a delegated MSA), the [out] BOOLEAN authorization flag, and the
+// NTSTATUS.
+type samrAccountIsDelegatedManagedServiceAccountResponse struct {
+	Result     bool
+	Authorized bool
+	Status     ndr.DWORD `ndr:"retval"`
+}
+
+// SamrAccountIsDelegatedManagedServiceAccount calls
+// SamrAccountIsDelegatedManagedServiceAccount (opnum 77), reporting whether the named account
+// is a delegated managed service account and whether the caller is authorized for it
+// ([MS-SAMR] 3.1.5.13.6).
+func SamrAccountIsDelegatedManagedServiceAccount(rpc *client.Client, serverHandle structures.SAMPR_HANDLE, accountName dtyp.RPC_UNICODE_STRING) (bool, bool, error) {
+	req := &samrAccountIsDelegatedManagedServiceAccountRequest{
+		ServerHandle: serverHandle,
+		AccountName:  accountName,
+	}
+	var resp samrAccountIsDelegatedManagedServiceAccountResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return false, false, fmt.Errorf("SamrAccountIsDelegatedManagedServiceAccount: %w", err)
+	}
+	if uint32(resp.Status) != samr.StatusSuccess {
+		return resp.Result, resp.Authorized, fmt.Errorf("SamrAccountIsDelegatedManagedServiceAccount failed: %s", samr.StatusString(uint32(resp.Status)))
+	}
+	return resp.Result, resp.Authorized, nil
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/functions.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/functions.go
@@ -1,0 +1,41 @@
+// Package functions implements the method stubs of the samr interface
+// (12345778-1234-abcd-ef00-0123456789ac v1.0, [MS-SAMR]). Each opnum lives in its own
+// NN_MethodName.go file; this file holds the small shapes and helpers shared across more
+// than one method.
+package functions
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures"
+)
+
+// statusResponse is the reply shape for methods whose only output is the NTSTATUS return
+// value (transmitted last, after any deferred referents).
+type statusResponse struct {
+	Status ndr.DWORD `ndr:"retval"`
+}
+
+// handleResponse is the reply shape for the [in,out] SAMPR_HANDLE close/delete methods:
+// the (now zeroed) handle followed by the NTSTATUS.
+type handleResponse struct {
+	Handle structures.SAMPR_HANDLE
+	Status ndr.DWORD `ndr:"retval"`
+}
+
+// openHandleResponse is the reply shape for the Open*/Create* methods that return a fresh
+// [out] SAMPR_HANDLE plus the NTSTATUS.
+type openHandleResponse struct {
+	Handle structures.SAMPR_HANDLE
+	Status ndr.DWORD `ndr:"retval"`
+}
+
+// optWStr returns a [unique], [string] wide-character pointer for s, or nil for the empty
+// string. samr's ServerName arguments are [in,unique,string] PSAMPR_SERVER_NAME pointers
+// whose NULL form selects "the local server".
+func optWStr(s string) *ndr.WSTR {
+	if s == "" {
+		return nil
+	}
+	w := ndr.WSTR(s)
+	return &w
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/integration_test.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/integration_test.go
@@ -1,0 +1,233 @@
+//go:build integration
+
+// Live integration / wire-validation for samr over the full DCE/RPC-over-SMB stack.
+// Excluded from the default build by the "integration" tag. Run with:
+//
+//	DCERPC_TEST_HOST=192.168.1.27 DCERPC_TEST_USER=user DCERPC_TEST_PASS=user \
+//	go test -tags integration -v \
+//	  ./network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/
+//
+// Unlike lsarpc/srvsvc, samr context handles chain (server -> domain -> account) and are
+// bound to one RPC association, so the whole handle chain runs on a SINGLE pipe/bind. The
+// only fault-prone probe (SamrConnect5) gets its own throwaway pipe.
+package functions_test
+
+import (
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+
+	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	dcerpcsmb "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/transport/smb"
+	smbclient "github.com/TheManticoreProject/Manticore/network/smb/smb_v10/client"
+	"github.com/TheManticoreProject/Manticore/windows/credentials"
+)
+
+// maximumAllowed asks the server to grant whatever access the caller is entitled to,
+// keeping the test independent of the exact rights of the test account.
+const maximumAllowed uint32 = 0x02000000
+
+func TestIntegration_Samr(t *testing.T) {
+	host := os.Getenv("DCERPC_TEST_HOST")
+	if host == "" {
+		t.Skip("DCERPC_TEST_HOST not set; skipping live samr test")
+	}
+	port := 445
+	if p := os.Getenv("DCERPC_TEST_PORT"); p != "" {
+		n, err := strconv.Atoi(p)
+		if err != nil {
+			t.Fatalf("invalid DCERPC_TEST_PORT %q: %v", p, err)
+		}
+		port = n
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		t.Fatalf("DCERPC_TEST_HOST %q is not a valid IP", host)
+	}
+	creds, err := credentials.NewCredentials(os.Getenv("DCERPC_TEST_DOMAIN"), os.Getenv("DCERPC_TEST_USER"), os.Getenv("DCERPC_TEST_PASS"), "")
+	if err != nil {
+		t.Fatalf("NewCredentials: %v", err)
+	}
+
+	smb := smbclient.NewClientUsingTCPTransport(ip, port)
+	if err := smb.Connect(ip, port); err != nil {
+		t.Fatalf("SMB Connect: %v", err)
+	}
+	defer smb.Disconnect()
+	smb.NativeOS, smb.NativeLanMan = "Unix", "Samba"
+	if err := smb.SessionSetup(creds); err != nil {
+		t.Fatalf("SMB SessionSetup: %v", err)
+	}
+	defer smb.Logoff()
+	if err := smb.TreeConnect("IPC$"); err != nil {
+		t.Fatalf("SMB TreeConnect(IPC$): %v", err)
+	}
+	defer smb.TreeDisconnect()
+
+	bind := func() (*client.Client, func()) {
+		rpc := client.NewClient(dcerpcsmb.New(smb, samr.PipeName))
+		if err := rpc.Bind(samr.SyntaxID()); err != nil {
+			t.Fatalf("DCE/RPC Bind(samr): %v", err)
+		}
+		return rpc, func() { _ = rpc.Close() }
+	}
+
+	// SamrConnect5 (opnum 64): exercises the SAMPR_REVISION_INFO union (DWORD-discriminated
+	// switch) in both directions. On its OWN pipe and tolerated as non-fatal, since a fault
+	// here would desync the main walk's association.
+	func() {
+		rpc, done := bind()
+		defer done()
+		_, outVersion, outInfo, err := functions.SamrConnect5(rpc, "", maximumAllowed)
+		if err != nil {
+			t.Logf("[info] SamrConnect5 not validated: %v", err)
+			return
+		}
+		if outInfo != nil {
+			t.Logf("[ok] SamrConnect5: outVersion=%d revision=%d supportedFeatures=%#x",
+				outVersion, outInfo.V1.Revision, outInfo.V1.SupportedFeatures)
+		} else {
+			t.Logf("[ok] SamrConnect5: outVersion=%d (no revision info arm)", outVersion)
+		}
+	}()
+
+	// The whole handle chain below runs on ONE association.
+	rpc, done := bind()
+	defer done()
+
+	// SamrConnect2 (opnum 57): yields the server handle the rest of the walk hangs off of.
+	serverHandle, err := functions.SamrConnect2(rpc, "", maximumAllowed)
+	if err != nil {
+		t.Fatalf("[WIRE FAIL] SamrConnect2: %v", err)
+	}
+	t.Logf("[ok] SamrConnect2: server handle acquired")
+
+	// SamrEnumerateDomainsInSamServer (opnum 6): the enumeration pattern — an [out] pointer
+	// to a container holding a conformant array of pointer-bearing SAMPR_RID_ENUMERATION
+	// (each with a [unique] RPC_UNICODE_STRING name).
+	var domainNames []string
+	_, buf, count, err := functions.SamrEnumerateDomainsInSamServer(rpc, serverHandle, 0, 0xFFFFFFFF)
+	if err != nil {
+		t.Errorf("[WIRE FAIL] SamrEnumerateDomainsInSamServer: %v", err)
+	} else {
+		t.Logf("[ok] SamrEnumerateDomainsInSamServer: countReturned=%d", count)
+		if buf != nil {
+			for i, d := range buf.Buffer {
+				name := d.Name.String()
+				domainNames = append(domainNames, name)
+				t.Logf("    [%d] rid=%d name=%q", i, d.RelativeId, name)
+			}
+		}
+	}
+
+	// Walk each enumerated domain: look up its SID, open it, and enumerate its users.
+	for _, dom := range domainNames {
+		// SamrLookupDomainInSamServer (opnum 5): [in,ref] RPC_UNICODE_STRING name,
+		// [out] [unique] pointer-to-pointer RPC_SID.
+		sid, err := functions.SamrLookupDomainInSamServer(rpc, serverHandle, dom)
+		if err != nil {
+			t.Errorf("[WIRE FAIL] SamrLookupDomainInSamServer(%q): %v", dom, err)
+			continue
+		}
+		if sid == nil {
+			t.Logf("[info] SamrLookupDomainInSamServer(%q): nil SID", dom)
+			continue
+		}
+		t.Logf("[ok] SamrLookupDomainInSamServer(%q): %s", dom, sid.String())
+
+		// SamrOpenDomain (opnum 7): [in] inline RPC_SID -> [out] domain handle.
+		domainHandle, err := functions.SamrOpenDomain(rpc, serverHandle, maximumAllowed, *sid)
+		if err != nil {
+			t.Errorf("[WIRE FAIL] SamrOpenDomain(%q): %v", dom, err)
+			continue
+		}
+		t.Logf("[ok] SamrOpenDomain(%q): domain handle acquired", dom)
+
+		// SamrEnumerateUsersInDomain (opnum 13): same enumeration shape as domains. A
+		// non-admin account (user:user) lacks DOMAIN_LIST_ACCOUNTS, so STATUS_ACCESS_DENIED
+		// is the expected, wire-validated outcome — the server decoded the request and
+		// returned a clean NTSTATUS rather than a fault.
+		var firstUser string
+		_, ubuf, ucount, err := functions.SamrEnumerateUsersInDomain(rpc, domainHandle, 0, 0, 0xFFFFFFFF)
+		if err != nil && strings.Contains(err.Error(), "ACCESS_DENIED") {
+			t.Logf("[ok] SamrEnumerateUsersInDomain(%q): STATUS_ACCESS_DENIED (expected for non-admin; wire validated)", dom)
+		} else if err != nil {
+			t.Errorf("[WIRE FAIL] SamrEnumerateUsersInDomain(%q): %v", dom, err)
+		} else {
+			t.Logf("[ok] SamrEnumerateUsersInDomain(%q): countReturned=%d", dom, ucount)
+			if ubuf != nil {
+				for i, u := range ubuf.Buffer {
+					if i < 8 {
+						t.Logf("    [%d] rid=%d name=%q", i, u.RelativeId, u.Name.String())
+					}
+					if firstUser == "" {
+						firstUser = u.Name.String()
+					}
+				}
+			}
+		}
+
+		// SamrLookupNamesInDomain (opnum 17): the [in,size_is(1000),length_is(Count)]
+		// conformant-varying array — the maximum_count must be the literal 1000 on the
+		// wire. Probe several well-known names (covers count>1 and English/French builds);
+		// the server decoding without a fault validates the wire path, and a non-empty RID
+		// proves the request was understood end to end.
+		probes := []string{firstUser, "Administrator", "Administrateur", "Guest", "Invité"}
+		var names []string
+		for _, p := range probes {
+			if p != "" {
+				names = append(names, p)
+			}
+		}
+		rids, use, err := functions.SamrLookupNamesInDomain(rpc, domainHandle, names)
+		if err != nil {
+			t.Errorf("[WIRE FAIL] SamrLookupNamesInDomain(%q, %v): %v", dom, names, err)
+		} else {
+			mapped := 0
+			for i := range rids.Element {
+				u := uint32(0)
+				if i < len(use.Element) {
+					u = uint32(use.Element[i])
+				}
+				if uint32(rids.Element[i]) != 0 {
+					mapped++
+					t.Logf("    %q -> rid=%d use=%d", names[i], rids.Element[i], u)
+				}
+			}
+			t.Logf("[ok] SamrLookupNamesInDomain(%q, %d names): %d mapped (conformant max_count=1000 accepted)", dom, len(names), mapped)
+		}
+
+		// SamrCloseHandle (opnum 1) on the domain handle.
+		if _, err := functions.SamrCloseHandle(rpc, domainHandle); err != nil {
+			t.Errorf("[WIRE FAIL] SamrCloseHandle(domain %q): %v", dom, err)
+		} else {
+			t.Logf("[ok] SamrCloseHandle(domain %q)", dom)
+		}
+	}
+
+	// SamrCloseHandle on the server handle. CloseHandle's wire shape is already validated
+	// by the domain-handle closes above; the SMB named-pipe read here occasionally returns
+	// STATUS_PIPE_EMPTY (0xc00000d9) transiently, so a transport read error (as opposed to
+	// a DCE/RPC fault) is retried once on a fresh pipe and otherwise tolerated.
+	if _, err := functions.SamrCloseHandle(rpc, serverHandle); err != nil {
+		if strings.Contains(err.Error(), "fault") {
+			t.Errorf("[WIRE FAIL] SamrCloseHandle(server): %v", err)
+		} else {
+			t.Logf("[info] SamrCloseHandle(server) transient transport error, retrying: %v", err)
+			rpc2, done2 := bind()
+			if _, err := functions.SamrCloseHandle(rpc2, serverHandle); err != nil {
+				t.Logf("[info] SamrCloseHandle(server) retry: %v (handle close wire shape already validated above)", err)
+			} else {
+				t.Logf("[ok] SamrCloseHandle(server) (on retry)")
+			}
+			done2()
+		}
+	} else {
+		t.Logf("[ok] SamrCloseHandle(server)")
+	}
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/interface.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/interface.go
@@ -1,0 +1,253 @@
+// Package rpcinterface_123457781234abcdef000123456789ac_1_0 is the descriptor for the
+// Security Account Manager (SAM) Remote Protocol (samr) RPC interface, abstract syntax
+// 12345778-1234-abcd-ef00-0123456789ac version 1.0 ([MS-SAMR]).
+//
+// An RPC interface is identified by its UUID and version, never by the named pipe it is
+// reached over: the "\samr" pipe carries this interface (note the UUID differs from
+// lsarpc's only in the last nibble, ...ac vs ...ab); the directory is named after the
+// interface UUID with the version in the nested 1.0/ directory.
+//
+// This package holds only the interface-level descriptor: the abstract syntax
+// identifier, the transport endpoint (PipeName), the opnum constants and opnum<->name
+// maps, and the NTSTATUS return codes. NDR types live in the structures subpackage and
+// the method stubs in functions; both depend on this package, never the reverse.
+//
+// References:
+//   - [MS-SAMR] Security Account Manager (SAM) Remote Protocol:
+//     https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/4df07fab-1bbc-452f-8e92-7853a3c7e380
+package rpcinterface_123457781234abcdef000123456789ac_1_0
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+)
+
+// PipeName is the IPC$-relative named pipe for the samr interface.
+const PipeName = `\samr`
+
+// Opnums for the on-the-wire methods ([MS-SAMR] section 3.1.5). Opnums 4, 42, 43, 59-61,
+// 63, 68-72, 75, 76 are "not used on the wire" and are omitted.
+const (
+	OpnumSamrConnect                                 uint16 = 0
+	OpnumSamrCloseHandle                             uint16 = 1
+	OpnumSamrSetSecurityObject                       uint16 = 2
+	OpnumSamrQuerySecurityObject                     uint16 = 3
+	OpnumSamrLookupDomainInSamServer                 uint16 = 5
+	OpnumSamrEnumerateDomainsInSamServer             uint16 = 6
+	OpnumSamrOpenDomain                              uint16 = 7
+	OpnumSamrQueryInformationDomain                  uint16 = 8
+	OpnumSamrSetInformationDomain                    uint16 = 9
+	OpnumSamrCreateGroupInDomain                     uint16 = 10
+	OpnumSamrEnumerateGroupsInDomain                 uint16 = 11
+	OpnumSamrCreateUserInDomain                      uint16 = 12
+	OpnumSamrEnumerateUsersInDomain                  uint16 = 13
+	OpnumSamrCreateAliasInDomain                     uint16 = 14
+	OpnumSamrEnumerateAliasesInDomain                uint16 = 15
+	OpnumSamrGetAliasMembership                      uint16 = 16
+	OpnumSamrLookupNamesInDomain                     uint16 = 17
+	OpnumSamrLookupIdsInDomain                       uint16 = 18
+	OpnumSamrOpenGroup                               uint16 = 19
+	OpnumSamrQueryInformationGroup                   uint16 = 20
+	OpnumSamrSetInformationGroup                     uint16 = 21
+	OpnumSamrAddMemberToGroup                        uint16 = 22
+	OpnumSamrDeleteGroup                             uint16 = 23
+	OpnumSamrRemoveMemberFromGroup                   uint16 = 24
+	OpnumSamrGetMembersInGroup                       uint16 = 25
+	OpnumSamrSetMemberAttributesOfGroup              uint16 = 26
+	OpnumSamrOpenAlias                               uint16 = 27
+	OpnumSamrQueryInformationAlias                   uint16 = 28
+	OpnumSamrSetInformationAlias                     uint16 = 29
+	OpnumSamrDeleteAlias                             uint16 = 30
+	OpnumSamrAddMemberToAlias                        uint16 = 31
+	OpnumSamrRemoveMemberFromAlias                   uint16 = 32
+	OpnumSamrGetMembersInAlias                       uint16 = 33
+	OpnumSamrOpenUser                                uint16 = 34
+	OpnumSamrDeleteUser                              uint16 = 35
+	OpnumSamrQueryInformationUser                    uint16 = 36
+	OpnumSamrSetInformationUser                      uint16 = 37
+	OpnumSamrChangePasswordUser                      uint16 = 38
+	OpnumSamrGetGroupsForUser                        uint16 = 39
+	OpnumSamrQueryDisplayInformation                 uint16 = 40
+	OpnumSamrGetDisplayEnumerationIndex              uint16 = 41
+	OpnumSamrGetUserDomainPasswordInformation        uint16 = 44
+	OpnumSamrRemoveMemberFromForeignDomain           uint16 = 45
+	OpnumSamrQueryInformationDomain2                 uint16 = 46
+	OpnumSamrQueryInformationUser2                   uint16 = 47
+	OpnumSamrQueryDisplayInformation2                uint16 = 48
+	OpnumSamrGetDisplayEnumerationIndex2             uint16 = 49
+	OpnumSamrCreateUser2InDomain                     uint16 = 50
+	OpnumSamrQueryDisplayInformation3                uint16 = 51
+	OpnumSamrAddMultipleMembersToAlias               uint16 = 52
+	OpnumSamrRemoveMultipleMembersFromAlias          uint16 = 53
+	OpnumSamrOemChangePasswordUser2                  uint16 = 54
+	OpnumSamrUnicodeChangePasswordUser2              uint16 = 55
+	OpnumSamrGetDomainPasswordInformation            uint16 = 56
+	OpnumSamrConnect2                                uint16 = 57
+	OpnumSamrSetInformationUser2                     uint16 = 58
+	OpnumSamrConnect4                                uint16 = 62
+	OpnumSamrConnect5                                uint16 = 64
+	OpnumSamrRidToSid                                uint16 = 65
+	OpnumSamrSetDSRMPassword                         uint16 = 66
+	OpnumSamrValidatePassword                        uint16 = 67
+	OpnumSamrUnicodeChangePasswordUser4              uint16 = 73
+	OpnumSamrValidateComputerAccountReuseAttempt     uint16 = 74
+	OpnumSamrAccountIsDelegatedManagedServiceAccount uint16 = 77
+)
+
+// Common NTSTATUS codes returned by samr methods ([MS-ERREF] 2.3.1). samr methods return
+// an NTSTATUS (the IDL "long" return value).
+const (
+	StatusSuccess            uint32 = 0x00000000
+	StatusMoreEntries        uint32 = 0x00000105
+	StatusSomeNotMapped      uint32 = 0x00000107
+	StatusNoMoreEntries      uint32 = 0x8000001A
+	StatusInvalidHandle      uint32 = 0xC0000008
+	StatusInvalidParameter   uint32 = 0xC000000D
+	StatusAccessDenied       uint32 = 0xC0000022
+	StatusObjectNameNotFound uint32 = 0xC0000034
+	StatusNoSuchUser         uint32 = 0xC0000064
+	StatusNoneMapped         uint32 = 0xC0000073
+	StatusNoSuchDomain       uint32 = 0xC00000DF
+	StatusNoSuchAlias        uint32 = 0xC0000151
+	StatusNoSuchGroup        uint32 = 0xC0000066
+	StatusUserExists         uint32 = 0xC0000063
+	StatusGroupExists        uint32 = 0xC0000065
+	StatusAliasExists        uint32 = 0xC0000154
+	StatusWrongPassword      uint32 = 0xC000006A
+	StatusNotSupported       uint32 = 0xC00000BB
+)
+
+// SyntaxID returns the samr abstract syntax identifier:
+// 12345778-1234-abcd-ef00-0123456789ac, version 1.0.
+func SyntaxID() syntax.SyntaxID {
+	return syntax.SyntaxID{
+		UUID:         guid.GUID{A: 0x12345778, B: 0x1234, C: 0xabcd, D: 0xef00, E: 0x0123456789ac},
+		MajorVersion: 1,
+		MinorVersion: 0,
+	}
+}
+
+// StatusString returns a mnemonic for the documented status codes, otherwise the hex
+// value.
+func StatusString(status uint32) string {
+	switch status {
+	case StatusSuccess:
+		return "STATUS_SUCCESS"
+	case StatusMoreEntries:
+		return "STATUS_MORE_ENTRIES"
+	case StatusSomeNotMapped:
+		return "STATUS_SOME_NOT_MAPPED"
+	case StatusNoMoreEntries:
+		return "STATUS_NO_MORE_ENTRIES"
+	case StatusInvalidHandle:
+		return "STATUS_INVALID_HANDLE"
+	case StatusInvalidParameter:
+		return "STATUS_INVALID_PARAMETER"
+	case StatusAccessDenied:
+		return "STATUS_ACCESS_DENIED"
+	case StatusObjectNameNotFound:
+		return "STATUS_OBJECT_NAME_NOT_FOUND"
+	case StatusNoSuchUser:
+		return "STATUS_NO_SUCH_USER"
+	case StatusNoneMapped:
+		return "STATUS_NONE_MAPPED"
+	case StatusNoSuchDomain:
+		return "STATUS_NO_SUCH_DOMAIN"
+	case StatusNoSuchAlias:
+		return "STATUS_NO_SUCH_ALIAS"
+	case StatusNoSuchGroup:
+		return "STATUS_NO_SUCH_GROUP"
+	case StatusUserExists:
+		return "STATUS_USER_EXISTS"
+	case StatusGroupExists:
+		return "STATUS_GROUP_EXISTS"
+	case StatusAliasExists:
+		return "STATUS_ALIAS_EXISTS"
+	case StatusWrongPassword:
+		return "STATUS_WRONG_PASSWORD"
+	case StatusNotSupported:
+		return "STATUS_NOT_SUPPORTED"
+	default:
+		return fmt.Sprintf("0x%08x", status)
+	}
+}
+
+// OpnumToName maps each on-the-wire opnum to its [MS-SAMR] method name; the single
+// source of truth.
+var OpnumToName = map[uint16]string{
+	OpnumSamrConnect:                                 "SamrConnect",
+	OpnumSamrCloseHandle:                             "SamrCloseHandle",
+	OpnumSamrSetSecurityObject:                       "SamrSetSecurityObject",
+	OpnumSamrQuerySecurityObject:                     "SamrQuerySecurityObject",
+	OpnumSamrLookupDomainInSamServer:                 "SamrLookupDomainInSamServer",
+	OpnumSamrEnumerateDomainsInSamServer:             "SamrEnumerateDomainsInSamServer",
+	OpnumSamrOpenDomain:                              "SamrOpenDomain",
+	OpnumSamrQueryInformationDomain:                  "SamrQueryInformationDomain",
+	OpnumSamrSetInformationDomain:                    "SamrSetInformationDomain",
+	OpnumSamrCreateGroupInDomain:                     "SamrCreateGroupInDomain",
+	OpnumSamrEnumerateGroupsInDomain:                 "SamrEnumerateGroupsInDomain",
+	OpnumSamrCreateUserInDomain:                      "SamrCreateUserInDomain",
+	OpnumSamrEnumerateUsersInDomain:                  "SamrEnumerateUsersInDomain",
+	OpnumSamrCreateAliasInDomain:                     "SamrCreateAliasInDomain",
+	OpnumSamrEnumerateAliasesInDomain:                "SamrEnumerateAliasesInDomain",
+	OpnumSamrGetAliasMembership:                      "SamrGetAliasMembership",
+	OpnumSamrLookupNamesInDomain:                     "SamrLookupNamesInDomain",
+	OpnumSamrLookupIdsInDomain:                       "SamrLookupIdsInDomain",
+	OpnumSamrOpenGroup:                               "SamrOpenGroup",
+	OpnumSamrQueryInformationGroup:                   "SamrQueryInformationGroup",
+	OpnumSamrSetInformationGroup:                     "SamrSetInformationGroup",
+	OpnumSamrAddMemberToGroup:                        "SamrAddMemberToGroup",
+	OpnumSamrDeleteGroup:                             "SamrDeleteGroup",
+	OpnumSamrRemoveMemberFromGroup:                   "SamrRemoveMemberFromGroup",
+	OpnumSamrGetMembersInGroup:                       "SamrGetMembersInGroup",
+	OpnumSamrSetMemberAttributesOfGroup:              "SamrSetMemberAttributesOfGroup",
+	OpnumSamrOpenAlias:                               "SamrOpenAlias",
+	OpnumSamrQueryInformationAlias:                   "SamrQueryInformationAlias",
+	OpnumSamrSetInformationAlias:                     "SamrSetInformationAlias",
+	OpnumSamrDeleteAlias:                             "SamrDeleteAlias",
+	OpnumSamrAddMemberToAlias:                        "SamrAddMemberToAlias",
+	OpnumSamrRemoveMemberFromAlias:                   "SamrRemoveMemberFromAlias",
+	OpnumSamrGetMembersInAlias:                       "SamrGetMembersInAlias",
+	OpnumSamrOpenUser:                                "SamrOpenUser",
+	OpnumSamrDeleteUser:                              "SamrDeleteUser",
+	OpnumSamrQueryInformationUser:                    "SamrQueryInformationUser",
+	OpnumSamrSetInformationUser:                      "SamrSetInformationUser",
+	OpnumSamrChangePasswordUser:                      "SamrChangePasswordUser",
+	OpnumSamrGetGroupsForUser:                        "SamrGetGroupsForUser",
+	OpnumSamrQueryDisplayInformation:                 "SamrQueryDisplayInformation",
+	OpnumSamrGetDisplayEnumerationIndex:              "SamrGetDisplayEnumerationIndex",
+	OpnumSamrGetUserDomainPasswordInformation:        "SamrGetUserDomainPasswordInformation",
+	OpnumSamrRemoveMemberFromForeignDomain:           "SamrRemoveMemberFromForeignDomain",
+	OpnumSamrQueryInformationDomain2:                 "SamrQueryInformationDomain2",
+	OpnumSamrQueryInformationUser2:                   "SamrQueryInformationUser2",
+	OpnumSamrQueryDisplayInformation2:                "SamrQueryDisplayInformation2",
+	OpnumSamrGetDisplayEnumerationIndex2:             "SamrGetDisplayEnumerationIndex2",
+	OpnumSamrCreateUser2InDomain:                     "SamrCreateUser2InDomain",
+	OpnumSamrQueryDisplayInformation3:                "SamrQueryDisplayInformation3",
+	OpnumSamrAddMultipleMembersToAlias:               "SamrAddMultipleMembersToAlias",
+	OpnumSamrRemoveMultipleMembersFromAlias:          "SamrRemoveMultipleMembersFromAlias",
+	OpnumSamrOemChangePasswordUser2:                  "SamrOemChangePasswordUser2",
+	OpnumSamrUnicodeChangePasswordUser2:              "SamrUnicodeChangePasswordUser2",
+	OpnumSamrGetDomainPasswordInformation:            "SamrGetDomainPasswordInformation",
+	OpnumSamrConnect2:                                "SamrConnect2",
+	OpnumSamrSetInformationUser2:                     "SamrSetInformationUser2",
+	OpnumSamrConnect4:                                "SamrConnect4",
+	OpnumSamrConnect5:                                "SamrConnect5",
+	OpnumSamrRidToSid:                                "SamrRidToSid",
+	OpnumSamrSetDSRMPassword:                         "SamrSetDSRMPassword",
+	OpnumSamrValidatePassword:                        "SamrValidatePassword",
+	OpnumSamrUnicodeChangePasswordUser4:              "SamrUnicodeChangePasswordUser4",
+	OpnumSamrValidateComputerAccountReuseAttempt:     "SamrValidateComputerAccountReuseAttempt",
+	OpnumSamrAccountIsDelegatedManagedServiceAccount: "SamrAccountIsDelegatedManagedServiceAccount",
+}
+
+// NameToOpnum is the reverse of OpnumToName, built at init so the two never drift.
+var NameToOpnum = func() map[string]uint16 {
+	m := make(map[string]uint16, len(OpnumToName))
+	for op, name := range OpnumToName {
+		m[name] = op
+	}
+	return m
+}()

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/interface_test.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/interface_test.go
@@ -1,0 +1,43 @@
+package rpcinterface_123457781234abcdef000123456789ac_1_0
+
+import "testing"
+
+func TestStatusString(t *testing.T) {
+	if got := StatusString(StatusMoreEntries); got != "STATUS_MORE_ENTRIES" {
+		t.Errorf("StatusString(0x105) = %q", got)
+	}
+	if got := StatusString(StatusSuccess); got != "STATUS_SUCCESS" {
+		t.Errorf("StatusString(0) = %q", got)
+	}
+	if got := StatusString(0x12345678); got != "0x12345678" {
+		t.Errorf("StatusString(unknown) = %q, want hex", got)
+	}
+}
+
+func TestSyntaxID(t *testing.T) {
+	id := SyntaxID()
+	if id.UUID.A != 0x12345778 || id.UUID.B != 0x1234 || id.UUID.C != 0xabcd ||
+		id.UUID.D != 0xef00 || id.UUID.E != 0x0123456789ac {
+		t.Errorf("SyntaxID UUID = %+v, want 12345778-1234-abcd-ef00-0123456789ac", id.UUID)
+	}
+	if id.MajorVersion != 1 || id.MinorVersion != 0 {
+		t.Errorf("SyntaxID version = %d.%d, want 1.0", id.MajorVersion, id.MinorVersion)
+	}
+}
+
+func TestOpnumNameMapsRoundTrip(t *testing.T) {
+	if len(OpnumToName) != 64 {
+		t.Errorf("OpnumToName has %d entries, want 64 on-the-wire methods", len(OpnumToName))
+	}
+	if len(NameToOpnum) != len(OpnumToName) {
+		t.Errorf("NameToOpnum has %d entries, OpnumToName has %d", len(NameToOpnum), len(OpnumToName))
+	}
+	for op, name := range OpnumToName {
+		if got, ok := NameToOpnum[name]; !ok || got != op {
+			t.Errorf("NameToOpnum[%q] = %d, %v; want %d", name, got, ok, op)
+		}
+	}
+	if OpnumToName[OpnumSamrConnect5] != "SamrConnect5" {
+		t.Errorf("OpnumToName[64] = %q", OpnumToName[OpnumSamrConnect5])
+	}
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/ms-samr.idl
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/ms-samr.idl
@@ -1,0 +1,1458 @@
+
+
+     import "ms-dtyp.idl";
+      
+     [
+         uuid(12345778-1234-ABCD-EF00-0123456789AC),
+         version(1.0),
+         ms_union,
+         pointer_default(unique)
+     ]
+      
+     interface samr{
+      
+     typedef struct _RPC_STRING {
+         unsigned short Length;
+         unsigned short MaximumLength;
+         [size_is(MaximumLength), length_is(Length)] char * Buffer;
+     } RPC_STRING, *PRPC_STRING;
+      
+      
+     typedef struct _OLD_LARGE_INTEGER {
+         unsigned long LowPart;
+         long HighPart;
+     } OLD_LARGE_INTEGER, *POLD_LARGE_INTEGER;
+      
+     typedef [handle] wchar_t * PSAMPR_SERVER_NAME;
+      
+     typedef [context_handle] void * SAMPR_HANDLE;
+      
+     typedef struct _ENCRYPTED_LM_OWF_PASSWORD {
+         char data[16];
+     } ENCRYPTED_LM_OWF_PASSWORD,
+       *PENCRYPTED_LM_OWF_PASSWORD,
+       ENCRYPTED_NT_OWF_PASSWORD,
+       *PENCRYPTED_NT_OWF_PASSWORD;
+      
+     typedef struct _SAMPR_ULONG_ARRAY {
+         unsigned long Count;
+         [size_is(Count)] unsigned long * Element;
+     } SAMPR_ULONG_ARRAY, *PSAMPR_ULONG_ARRAY;
+      
+     typedef struct _SAMPR_SID_INFORMATION {
+         PRPC_SID    SidPointer;
+     } SAMPR_SID_INFORMATION, *PSAMPR_SID_INFORMATION;
+      
+     typedef struct _SAMPR_PSID_ARRAY {
+         [range(0, 1024)] unsigned long Count;
+         [size_is(Count)] PSAMPR_SID_INFORMATION Sids;
+     } SAMPR_PSID_ARRAY, *PSAMPR_PSID_ARRAY;
+      
+     typedef struct _SAMPR_PSID_ARRAY_OUT {
+         unsigned long Count;
+         [size_is(Count)] PSAMPR_SID_INFORMATION Sids;
+     } SAMPR_PSID_ARRAY_OUT, *PSAMPR_PSID_ARRAY_OUT;
+      
+     typedef struct _SAMPR_RETURNED_USTRING_ARRAY {
+         unsigned long Count;
+         [size_is(Count)] PRPC_UNICODE_STRING  Element;
+     } SAMPR_RETURNED_USTRING_ARRAY, *PSAMPR_RETURNED_USTRING_ARRAY;
+      
+      
+     typedef enum _SID_NAME_USE {
+         SidTypeUser = 1,
+         SidTypeGroup,
+         SidTypeDomain,
+         SidTypeAlias,
+         SidTypeWellKnownGroup,
+         SidTypeDeletedAccount,
+         SidTypeInvalid,
+         SidTypeUnknown,
+         SidTypeComputer,  // Not used.
+         SidTypeLabel  // Not used.
+     } SID_NAME_USE, *PSID_NAME_USE;
+      
+     typedef struct _RPC_SHORT_BLOB {
+         unsigned short Length;
+         unsigned short MaximumLength;
+         [size_is(MaximumLength/2), length_is(Length/2)]
+         unsigned short* Buffer;
+     } RPC_SHORT_BLOB, *PRPC_SHORT_BLOB;
+      
+     typedef struct _SAMPR_RID_ENUMERATION {
+         unsigned long RelativeId;
+         RPC_UNICODE_STRING Name;
+     } SAMPR_RID_ENUMERATION, *PSAMPR_RID_ENUMERATION;
+      
+     typedef struct _SAMPR_ENUMERATION_BUFFER {
+         unsigned long EntriesRead;
+         [size_is(EntriesRead)] PSAMPR_RID_ENUMERATION Buffer;
+     } SAMPR_ENUMERATION_BUFFER, *PSAMPR_ENUMERATION_BUFFER;
+      
+     typedef struct _SAMPR_SR_SECURITY_DESCRIPTOR {
+         [range(0, 256 * 1024)] unsigned long Length;
+         [size_is(Length)] unsigned char* SecurityDescriptor;
+     } SAMPR_SR_SECURITY_DESCRIPTOR, *PSAMPR_SR_SECURITY_DESCRIPTOR;
+      
+     typedef struct _GROUP_MEMBERSHIP {
+         unsigned long RelativeId;
+         unsigned long Attributes;
+     } GROUP_MEMBERSHIP, *PGROUP_MEMBERSHIP;
+      
+     typedef struct _SAMPR_GET_GROUPS_BUFFER {
+         unsigned long MembershipCount;
+         [size_is(MembershipCount)] PGROUP_MEMBERSHIP Groups;
+     } SAMPR_GET_GROUPS_BUFFER, *PSAMPR_GET_GROUPS_BUFFER;
+      
+     typedef struct _SAMPR_GET_MEMBERS_BUFFER {
+         unsigned long MemberCount;
+         [size_is(MemberCount)] unsigned long* Members;
+         [size_is(MemberCount)] unsigned long* Attributes;
+     } SAMPR_GET_MEMBERS_BUFFER, *PSAMPR_GET_MEMBERS_BUFFER;
+      
+     typedef struct _SAMPR_REVISION_INFO_V1 {
+         unsigned long Revision;
+         unsigned long SupportedFeatures;
+     } SAMPR_REVISION_INFO_V1, *PSAMPR_REVISION_INFO_V1;
+      
+     typedef [switch_type(unsigned long)] union {
+         [case(1)] SAMPR_REVISION_INFO_V1 V1;
+     }SAMPR_REVISION_INFO, *PSAMPR_REVISION_INFO;
+      
+     typedef struct _USER_DOMAIN_PASSWORD_INFORMATION {
+         unsigned short MinPasswordLength;
+         unsigned long PasswordProperties;
+     } USER_DOMAIN_PASSWORD_INFORMATION,
+       *PUSER_DOMAIN_PASSWORD_INFORMATION;
+      
+     typedef enum _DOMAIN_SERVER_ENABLE_STATE {
+         DomainServerEnabled = 1,
+         DomainServerDisabled
+     } DOMAIN_SERVER_ENABLE_STATE, *PDOMAIN_SERVER_ENABLE_STATE;
+      
+     typedef struct _DOMAIN_STATE_INFORMATION {
+         DOMAIN_SERVER_ENABLE_STATE DomainServerState;
+     } DOMAIN_STATE_INFORMATION, *PDOMAIN_STATE_INFORMATION;
+      
+     typedef enum _DOMAIN_SERVER_ROLE {
+         DomainServerRoleBackup = 2,
+         DomainServerRolePrimary = 3
+     } DOMAIN_SERVER_ROLE, *PDOMAIN_SERVER_ROLE;
+      
+     typedef struct _DOMAIN_PASSWORD_INFORMATION {
+         unsigned short MinPasswordLength;
+         unsigned short PasswordHistoryLength;
+         unsigned long PasswordProperties;
+         OLD_LARGE_INTEGER MaxPasswordAge;
+         OLD_LARGE_INTEGER MinPasswordAge;
+     } DOMAIN_PASSWORD_INFORMATION, *PDOMAIN_PASSWORD_INFORMATION;
+      
+     typedef struct _DOMAIN_LOGOFF_INFORMATION {
+         OLD_LARGE_INTEGER ForceLogoff;
+     } DOMAIN_LOGOFF_INFORMATION, *PDOMAIN_LOGOFF_INFORMATION;
+      
+     typedef struct _DOMAIN_SERVER_ROLE_INFORMATION {
+         DOMAIN_SERVER_ROLE DomainServerRole;
+     } DOMAIN_SERVER_ROLE_INFORMATION, *PDOMAIN_SERVER_ROLE_INFORMATION;
+      
+     typedef struct _DOMAIN_MODIFIED_INFORMATION {
+         OLD_LARGE_INTEGER DomainModifiedCount;
+         OLD_LARGE_INTEGER CreationTime;
+     } DOMAIN_MODIFIED_INFORMATION, *PDOMAIN_MODIFIED_INFORMATION;
+      
+     typedef struct _DOMAIN_MODIFIED_INFORMATION2 {
+         OLD_LARGE_INTEGER DomainModifiedCount;
+         OLD_LARGE_INTEGER CreationTime;
+         OLD_LARGE_INTEGER ModifiedCountAtLastPromotion;
+     } DOMAIN_MODIFIED_INFORMATION2, *PDOMAIN_MODIFIED_INFORMATION2;
+      
+     #pragma pack(4)
+     typedef struct _SAMPR_DOMAIN_GENERAL_INFORMATION {
+         OLD_LARGE_INTEGER  ForceLogoff;
+         RPC_UNICODE_STRING OemInformation;
+         RPC_UNICODE_STRING DomainName;
+         RPC_UNICODE_STRING ReplicaSourceNodeName;
+         OLD_LARGE_INTEGER  DomainModifiedCount;
+         unsigned long      DomainServerState;
+         unsigned long      DomainServerRole;
+         unsigned char      UasCompatibilityRequired;
+         unsigned long      UserCount;
+         unsigned long      GroupCount;
+         unsigned long      AliasCount;
+     } SAMPR_DOMAIN_GENERAL_INFORMATION,
+       *PSAMPR_DOMAIN_GENERAL_INFORMATION;
+     #pragma pack()
+      
+     #pragma pack(4)
+     typedef struct _SAMPR_DOMAIN_GENERAL_INFORMATION2 {
+         SAMPR_DOMAIN_GENERAL_INFORMATION  I1;
+         LARGE_INTEGER LockoutDuration;
+         LARGE_INTEGER LockoutObservationWindow;
+         unsigned short LockoutThreshold;
+     } SAMPR_DOMAIN_GENERAL_INFORMATION2,
+       *PSAMPR_DOMAIN_GENERAL_INFORMATION2;
+     #pragma pack()
+      
+     typedef struct _SAMPR_DOMAIN_OEM_INFORMATION {
+         RPC_UNICODE_STRING OemInformation;
+     } SAMPR_DOMAIN_OEM_INFORMATION, *PSAMPR_DOMAIN_OEM_INFORMATION;
+      
+     typedef struct _SAMPR_DOMAIN_NAME_INFORMATION {
+         RPC_UNICODE_STRING DomainName;
+     } SAMPR_DOMAIN_NAME_INFORMATION, *PSAMPR_DOMAIN_NAME_INFORMATION;
+      
+     typedef struct SAMPR_DOMAIN_REPLICATION_INFORMATION {
+         RPC_UNICODE_STRING ReplicaSourceNodeName;
+     } SAMPR_DOMAIN_REPLICATION_INFORMATION,
+       *PSAMPR_DOMAIN_REPLICATION_INFORMATION;
+      
+     typedef struct _SAMPR_DOMAIN_LOCKOUT_INFORMATION {
+         LARGE_INTEGER LockoutDuration;
+         LARGE_INTEGER LockoutObservationWindow;
+         unsigned short LockoutThreshold;
+     } SAMPR_DOMAIN_LOCKOUT_INFORMATION,
+       *PSAMPR_DOMAIN_LOCKOUT_INFORMATION;
+      
+     typedef enum _DOMAIN_INFORMATION_CLASS {
+         DomainPasswordInformation = 1,
+         DomainGeneralInformation = 2,
+         DomainLogoffInformation = 3,
+         DomainOemInformation = 4,
+         DomainNameInformation = 5,
+         DomainReplicationInformation = 6,
+         DomainServerRoleInformation = 7,
+         DomainModifiedInformation = 8,
+         DomainStateInformation = 9,
+         DomainGeneralInformation2 = 11,
+         DomainLockoutInformation = 12,
+         DomainModifiedInformation2 = 13
+     } DOMAIN_INFORMATION_CLASS;
+      
+     typedef [switch_type(DOMAIN_INFORMATION_CLASS)] union
+     _SAMPR_DOMAIN_INFO_BUFFER {
+         [case(DomainPasswordInformation)]
+             DOMAIN_PASSWORD_INFORMATION          Password;
+         [case(DomainGeneralInformation)]
+             SAMPR_DOMAIN_GENERAL_INFORMATION     General;
+         [case(DomainLogoffInformation)]
+             DOMAIN_LOGOFF_INFORMATION            Logoff;
+         [case(DomainOemInformation)]
+             SAMPR_DOMAIN_OEM_INFORMATION         Oem;
+         [case(DomainNameInformation)]
+             SAMPR_DOMAIN_NAME_INFORMATION        Name;
+         [case(DomainServerRoleInformation)]
+             DOMAIN_SERVER_ROLE_INFORMATION       Role;
+         [case(DomainReplicationInformation)]
+             SAMPR_DOMAIN_REPLICATION_INFORMATION Replication;
+         [case(DomainModifiedInformation)]
+             DOMAIN_MODIFIED_INFORMATION          Modified;
+         [case(DomainStateInformation)]
+             DOMAIN_STATE_INFORMATION             State;
+         [case(DomainGeneralInformation2)]
+             SAMPR_DOMAIN_GENERAL_INFORMATION2    General2;
+         [case(DomainLockoutInformation)]
+             SAMPR_DOMAIN_LOCKOUT_INFORMATION     Lockout;
+         [case(DomainModifiedInformation2)]
+             DOMAIN_MODIFIED_INFORMATION2         Modified2;
+     } SAMPR_DOMAIN_INFO_BUFFER, *PSAMPR_DOMAIN_INFO_BUFFER;
+      
+     typedef enum _DOMAIN_DISPLAY_INFORMATION {
+         DomainDisplayUser = 1,
+         DomainDisplayMachine,
+         DomainDisplayGroup,
+         DomainDisplayOemUser,
+         DomainDisplayOemGroup
+     } DOMAIN_DISPLAY_INFORMATION, *PDOMAIN_DISPLAY_INFORMATION;
+      
+     typedef struct _SAMPR_DOMAIN_DISPLAY_USER {
+         unsigned long      Index;
+         unsigned long      Rid;
+         unsigned long      AccountControl;
+         RPC_UNICODE_STRING AccountName;
+         RPC_UNICODE_STRING AdminComment;
+         RPC_UNICODE_STRING FullName;
+     } SAMPR_DOMAIN_DISPLAY_USER, *PSAMPR_DOMAIN_DISPLAY_USER;
+      
+     typedef struct _SAMPR_DOMAIN_DISPLAY_MACHINE {
+         unsigned long      Index;
+         unsigned long      Rid;
+         unsigned long      AccountControl;
+         RPC_UNICODE_STRING AccountName;
+         RPC_UNICODE_STRING AdminComment;
+     } SAMPR_DOMAIN_DISPLAY_MACHINE, *PSAMPR_DOMAIN_DISPLAY_MACHINE;
+      
+     typedef struct _SAMPR_DOMAIN_DISPLAY_GROUP {
+         unsigned long      Index;
+         unsigned long      Rid;
+         unsigned long      Attributes;
+         RPC_UNICODE_STRING AccountName;
+         RPC_UNICODE_STRING AdminComment;
+     } SAMPR_DOMAIN_DISPLAY_GROUP, *PSAMPR_DOMAIN_DISPLAY_GROUP;
+      
+     typedef struct _SAMPR_DOMAIN_DISPLAY_OEM_USER {
+         unsigned long           Index;
+         RPC_STRING              OemAccountName;
+     } SAMPR_DOMAIN_DISPLAY_OEM_USER, *PSAMPR_DOMAIN_DISPLAY_OEM_USER;
+      
+     typedef struct _SAMPR_DOMAIN_DISPLAY_OEM_GROUP {
+         unsigned long           Index;
+         RPC_STRING              OemAccountName;
+     } SAMPR_DOMAIN_DISPLAY_OEM_GROUP, *PSAMPR_DOMAIN_DISPLAY_OEM_GROUP;
+      
+     typedef struct _SAMPR_DOMAIN_DISPLAY_USER_BUFFER {
+         unsigned long EntriesRead;
+         [size_is(EntriesRead)] PSAMPR_DOMAIN_DISPLAY_USER Buffer;
+     } SAMPR_DOMAIN_DISPLAY_USER_BUFFER,
+       *PSAMPR_DOMAIN_DISPLAY_USER_BUFFER;
+      
+     typedef struct _SAMPR_DOMAIN_DISPLAY_MACHINE_BUFFER {
+         unsigned long EntriesRead;
+         [size_is(EntriesRead)] PSAMPR_DOMAIN_DISPLAY_MACHINE Buffer;
+     } SAMPR_DOMAIN_DISPLAY_MACHINE_BUFFER,
+       *PSAMPR_DOMAIN_DISPLAY_MACHINE_BUFFER;
+      
+     typedef struct _SAMPR_DOMAIN_DISPLAY_GROUP_BUFFER {
+         unsigned long EntriesRead;
+         [size_is(EntriesRead)] PSAMPR_DOMAIN_DISPLAY_GROUP Buffer;
+     } SAMPR_DOMAIN_DISPLAY_GROUP_BUFFER,
+       *PSAMPR_DOMAIN_DISPLAY_GROUP_BUFFER;
+      
+     typedef struct _SAMPR_DOMAIN_DISPLAY_OEM_USER_BUFFER {
+         unsigned long EntriesRead;
+         [size_is(EntriesRead)] PSAMPR_DOMAIN_DISPLAY_OEM_USER Buffer;
+     } SAMPR_DOMAIN_DISPLAY_OEM_USER_BUFFER,
+       *PSAMPR_DOMAIN_DISPLAY_OEM_USER_BUFFER;
+      
+     typedef struct _SAMPR_DOMAIN_DISPLAY_OEM_GROUP_BUFFER {
+         unsigned long EntriesRead;
+         [size_is(EntriesRead)] PSAMPR_DOMAIN_DISPLAY_OEM_GROUP Buffer;
+     } SAMPR_DOMAIN_DISPLAY_OEM_GROUP_BUFFER,
+       *PSAMPR_DOMAIN_DISPLAY_OEM_GROUP_BUFFER;
+      
+     typedef [switch_type(DOMAIN_DISPLAY_INFORMATION)] union
+     _SAMPR_DISPLAY_INFO_BUFFER {
+         [case(DomainDisplayUser)]
+             SAMPR_DOMAIN_DISPLAY_USER_BUFFER      UserInformation;
+         [case(DomainDisplayMachine)]
+             SAMPR_DOMAIN_DISPLAY_MACHINE_BUFFER   MachineInformation;
+         [case(DomainDisplayGroup)]
+             SAMPR_DOMAIN_DISPLAY_GROUP_BUFFER     GroupInformation;
+         [case(DomainDisplayOemUser)]
+             SAMPR_DOMAIN_DISPLAY_OEM_USER_BUFFER  OemUserInformation;
+         [case(DomainDisplayOemGroup)]
+             SAMPR_DOMAIN_DISPLAY_OEM_GROUP_BUFFER OemGroupInformation;
+     } SAMPR_DISPLAY_INFO_BUFFER, *PSAMPR_DISPLAY_INFO_BUFFER;
+      
+     typedef struct _GROUP_ATTRIBUTE_INFORMATION {
+         unsigned long Attributes;
+     } GROUP_ATTRIBUTE_INFORMATION, *PGROUP_ATTRIBUTE_INFORMATION;
+      
+     typedef struct _SAMPR_GROUP_GENERAL_INFORMATION {
+         RPC_UNICODE_STRING Name;
+         unsigned long Attributes;
+         unsigned long MemberCount;
+         RPC_UNICODE_STRING AdminComment;
+     } SAMPR_GROUP_GENERAL_INFORMATION, 
+       *PSAMPR_GROUP_GENERAL_INFORMATION;
+      
+     typedef struct _SAMPR_GROUP_NAME_INFORMATION {
+         RPC_UNICODE_STRING Name;
+     } SAMPR_GROUP_NAME_INFORMATION, *PSAMPR_GROUP_NAME_INFORMATION;
+      
+     typedef struct _SAMPR_GROUP_ADM_COMMENT_INFORMATION {
+         RPC_UNICODE_STRING AdminComment;
+     } SAMPR_GROUP_ADM_COMMENT_INFORMATION,
+       *PSAMPR_GROUP_ADM_COMMENT_INFORMATION;
+      
+     typedef enum _GROUP_INFORMATION_CLASS {
+         GroupGeneralInformation = 1,
+         GroupNameInformation,
+         GroupAttributeInformation,
+         GroupAdminCommentInformation,
+         GroupReplicationInformation
+     } GROUP_INFORMATION_CLASS;
+      
+     typedef [switch_type(GROUP_INFORMATION_CLASS)] union
+     _SAMPR_GROUP_INFO_BUFFER {
+         [case(GroupGeneralInformation)]
+             SAMPR_GROUP_GENERAL_INFORMATION     General;
+         [case(GroupNameInformation)]
+             SAMPR_GROUP_NAME_INFORMATION        Name;
+         [case(GroupAttributeInformation)]
+             GROUP_ATTRIBUTE_INFORMATION         Attribute;
+         [case(GroupAdminCommentInformation)]
+             SAMPR_GROUP_ADM_COMMENT_INFORMATION AdminComment;
+         [case(GroupReplicationInformation)]
+             SAMPR_GROUP_GENERAL_INFORMATION     DoNotUse;
+     } SAMPR_GROUP_INFO_BUFFER, *PSAMPR_GROUP_INFO_BUFFER;
+      
+     typedef struct _SAMPR_ALIAS_GENERAL_INFORMATION {
+         RPC_UNICODE_STRING Name;
+         unsigned long MemberCount;
+         RPC_UNICODE_STRING AdminComment;
+     } SAMPR_ALIAS_GENERAL_INFORMATION,
+       *PSAMPR_ALIAS_GENERAL_INFORMATION;
+      
+     typedef struct _SAMPR_ALIAS_NAME_INFORMATION {
+         RPC_UNICODE_STRING Name;
+     } SAMPR_ALIAS_NAME_INFORMATION, *PSAMPR_ALIAS_NAME_INFORMATION;
+      
+     typedef struct _SAMPR_ALIAS_ADM_COMMENT_INFORMATION {
+         RPC_UNICODE_STRING AdminComment;
+     } SAMPR_ALIAS_ADM_COMMENT_INFORMATION,
+       *PSAMPR_ALIAS_ADM_COMMENT_INFORMATION;
+      
+     typedef enum _ALIAS_INFORMATION_CLASS {
+         AliasGeneralInformation = 1,
+         AliasNameInformation,
+         AliasAdminCommentInformation
+     } ALIAS_INFORMATION_CLASS;
+      
+     typedef [switch_type(ALIAS_INFORMATION_CLASS)] union
+     _SAMPR_ALIAS_INFO_BUFFER {
+         [case(AliasGeneralInformation)]
+             SAMPR_ALIAS_GENERAL_INFORMATION     General;
+         [case(AliasNameInformation)]
+             SAMPR_ALIAS_NAME_INFORMATION        Name;
+         [case(AliasAdminCommentInformation)]
+             SAMPR_ALIAS_ADM_COMMENT_INFORMATION AdminComment;
+     } SAMPR_ALIAS_INFO_BUFFER, *PSAMPR_ALIAS_INFO_BUFFER;
+      
+     typedef struct _SAMPR_ENCRYPTED_USER_PASSWORD {
+         unsigned char Buffer[(256 * 2) + 4];
+     } SAMPR_ENCRYPTED_USER_PASSWORD,
+       *PSAMPR_ENCRYPTED_USER_PASSWORD;
+      
+     typedef struct _SAMPR_USER_PASSWORD {
+         wchar_t Buffer[256];
+         unsigned long Length;
+     } SAMPR_USER_PASSWORD,
+       *PSAMPR_USER_PASSWORD;
+      
+     typedef struct _SAMPR_ENCRYPTED_USER_PASSWORD_NEW {
+         unsigned char Buffer[(256 * 2) + 4 + 16];
+     } SAMPR_ENCRYPTED_USER_PASSWORD_NEW,
+      *PSAMPR_ENCRYPTED_USER_PASSWORD_NEW;
+     
+    typedef struct _SAMPR_USER_PASSWORD_NEW {
+         WCHAR Buffer[256];
+         ULONG Length;
+         UCHAR ClearSalt[16];
+     } SAMPR_USER_PASSWORD_NEW,
+       *PSAMPR_USER_PASSWORD_NEW;
+      
+     typedef struct _USER_PRIMARY_GROUP_INFORMATION {
+         unsigned long PrimaryGroupId;
+     } USER_PRIMARY_GROUP_INFORMATION, *PUSER_PRIMARY_GROUP_INFORMATION;
+      
+     typedef struct _USER_CONTROL_INFORMATION {
+         unsigned long UserAccountControl;
+     } USER_CONTROL_INFORMATION, *PUSER_CONTROL_INFORMATION;
+      
+     typedef struct _USER_EXPIRES_INFORMATION {
+         OLD_LARGE_INTEGER AccountExpires;
+     } USER_EXPIRES_INFORMATION, *PUSER_EXPIRES_INFORMATION;
+      
+     typedef struct _SAMPR_LOGON_HOURS {
+         unsigned short UnitsPerWeek;
+         [size_is(1260), length_is((UnitsPerWeek+7)/8)]
+             unsigned char*  LogonHours;
+     } SAMPR_LOGON_HOURS, *PSAMPR_LOGON_HOURS;
+      
+     typedef struct _SAMPR_USER_ALL_INFORMATION {
+         OLD_LARGE_INTEGER LastLogon;
+         OLD_LARGE_INTEGER LastLogoff;
+         OLD_LARGE_INTEGER PasswordLastSet;
+         OLD_LARGE_INTEGER AccountExpires;
+         OLD_LARGE_INTEGER PasswordCanChange;
+         OLD_LARGE_INTEGER PasswordMustChange;
+         RPC_UNICODE_STRING UserName;
+         RPC_UNICODE_STRING FullName;
+         RPC_UNICODE_STRING HomeDirectory;
+         RPC_UNICODE_STRING HomeDirectoryDrive;
+         RPC_UNICODE_STRING ScriptPath;
+         RPC_UNICODE_STRING ProfilePath;
+         RPC_UNICODE_STRING AdminComment;
+         RPC_UNICODE_STRING WorkStations;
+         RPC_UNICODE_STRING UserComment;
+         RPC_UNICODE_STRING Parameters;
+         RPC_SHORT_BLOB LmOwfPassword;
+         RPC_SHORT_BLOB NtOwfPassword;
+         RPC_UNICODE_STRING PrivateData;
+         SAMPR_SR_SECURITY_DESCRIPTOR SecurityDescriptor;
+         unsigned long UserId;
+         unsigned long PrimaryGroupId;
+         unsigned long UserAccountControl;
+         unsigned long WhichFields;
+         SAMPR_LOGON_HOURS LogonHours;
+         unsigned short BadPasswordCount;
+         unsigned short LogonCount;
+         unsigned short CountryCode;
+         unsigned short CodePage;
+         unsigned char LmPasswordPresent;
+         unsigned char NtPasswordPresent;
+         unsigned char PasswordExpired;
+         unsigned char PrivateDataSensitive;
+     } SAMPR_USER_ALL_INFORMATION, *PSAMPR_USER_ALL_INFORMATION;
+      
+     typedef struct _SAMPR_USER_GENERAL_INFORMATION {
+         RPC_UNICODE_STRING UserName;
+         RPC_UNICODE_STRING FullName;
+         unsigned long PrimaryGroupId;
+         RPC_UNICODE_STRING AdminComment;
+         RPC_UNICODE_STRING UserComment;
+     } SAMPR_USER_GENERAL_INFORMATION, *PSAMPR_USER_GENERAL_INFORMATION;
+      
+     typedef struct _SAMPR_USER_PREFERENCES_INFORMATION {
+         RPC_UNICODE_STRING UserComment;
+         RPC_UNICODE_STRING Reserved1;
+         unsigned short CountryCode;
+         unsigned short CodePage;
+     } SAMPR_USER_PREFERENCES_INFORMATION,
+       *PSAMPR_USER_PREFERENCES_INFORMATION;
+      
+     typedef struct _SAMPR_USER_PARAMETERS_INFORMATION {
+         RPC_UNICODE_STRING Parameters;
+     } SAMPR_USER_PARAMETERS_INFORMATION,
+       *PSAMPR_USER_PARAMETERS_INFORMATION;
+      
+     typedef struct _SAMPR_USER_LOGON_INFORMATION {
+         RPC_UNICODE_STRING UserName;
+         RPC_UNICODE_STRING FullName;
+         unsigned long UserId;
+         unsigned long PrimaryGroupId;
+         RPC_UNICODE_STRING HomeDirectory;
+         RPC_UNICODE_STRING HomeDirectoryDrive;
+         RPC_UNICODE_STRING ScriptPath;
+         RPC_UNICODE_STRING ProfilePath;
+         RPC_UNICODE_STRING WorkStations;
+         OLD_LARGE_INTEGER LastLogon;
+         OLD_LARGE_INTEGER LastLogoff;
+         OLD_LARGE_INTEGER PasswordLastSet;
+         OLD_LARGE_INTEGER PasswordCanChange;
+         OLD_LARGE_INTEGER PasswordMustChange;
+         SAMPR_LOGON_HOURS LogonHours;
+         unsigned short BadPasswordCount;
+         unsigned short LogonCount;
+         unsigned long UserAccountControl;
+     } SAMPR_USER_LOGON_INFORMATION, *PSAMPR_USER_LOGON_INFORMATION;
+      
+     typedef struct _SAMPR_USER_ACCOUNT_INFORMATION {
+         RPC_UNICODE_STRING UserName;
+         RPC_UNICODE_STRING FullName;
+         unsigned long UserId;
+         unsigned long PrimaryGroupId;
+         RPC_UNICODE_STRING HomeDirectory;
+         RPC_UNICODE_STRING HomeDirectoryDrive;
+         RPC_UNICODE_STRING ScriptPath;
+         RPC_UNICODE_STRING ProfilePath;
+         RPC_UNICODE_STRING AdminComment;
+         RPC_UNICODE_STRING WorkStations;
+         OLD_LARGE_INTEGER LastLogon;
+         OLD_LARGE_INTEGER LastLogoff;
+         SAMPR_LOGON_HOURS LogonHours;
+         unsigned short BadPasswordCount;
+         unsigned short LogonCount;
+         OLD_LARGE_INTEGER PasswordLastSet;
+         OLD_LARGE_INTEGER AccountExpires;
+         unsigned long UserAccountControl;
+     } SAMPR_USER_ACCOUNT_INFORMATION, *PSAMPR_USER_ACCOUNT_INFORMATION;
+      
+     typedef struct _SAMPR_USER_A_NAME_INFORMATION {
+         RPC_UNICODE_STRING UserName;
+     } SAMPR_USER_A_NAME_INFORMATION, *PSAMPR_USER_A_NAME_INFORMATION;
+      
+     typedef struct _SAMPR_USER_F_NAME_INFORMATION {
+         RPC_UNICODE_STRING FullName;
+     } SAMPR_USER_F_NAME_INFORMATION, *PSAMPR_USER_F_NAME_INFORMATION;
+      
+     typedef struct _SAMPR_USER_NAME_INFORMATION {
+         RPC_UNICODE_STRING UserName;
+         RPC_UNICODE_STRING FullName;
+     } SAMPR_USER_NAME_INFORMATION, *PSAMPR_USER_NAME_INFORMATION;
+      
+     typedef struct _SAMPR_USER_HOME_INFORMATION {
+         RPC_UNICODE_STRING HomeDirectory;
+         RPC_UNICODE_STRING HomeDirectoryDrive;
+     } SAMPR_USER_HOME_INFORMATION, *PSAMPR_USER_HOME_INFORMATION;
+      
+     typedef struct _SAMPR_USER_SCRIPT_INFORMATION {
+         RPC_UNICODE_STRING ScriptPath;
+     } SAMPR_USER_SCRIPT_INFORMATION, *PSAMPR_USER_SCRIPT_INFORMATION;
+      
+     typedef struct _SAMPR_USER_PROFILE_INFORMATION {
+         RPC_UNICODE_STRING ProfilePath;
+     } SAMPR_USER_PROFILE_INFORMATION, *PSAMPR_USER_PROFILE_INFORMATION;
+      
+     typedef struct _SAMPR_USER_ADMIN_COMMENT_INFORMATION {
+         RPC_UNICODE_STRING AdminComment;
+     } SAMPR_USER_ADMIN_COMMENT_INFORMATION,
+       *PSAMPR_USER_ADMIN_COMMENT_INFORMATION;
+      
+     typedef struct _SAMPR_USER_WORKSTATIONS_INFORMATION {
+         RPC_UNICODE_STRING WorkStations;
+     } SAMPR_USER_WORKSTATIONS_INFORMATION,
+       *PSAMPR_USER_WORKSTATIONS_INFORMATION;
+      
+     typedef struct _SAMPR_USER_LOGON_HOURS_INFORMATION {
+         SAMPR_LOGON_HOURS LogonHours;
+     } SAMPR_USER_LOGON_HOURS_INFORMATION,
+       *PSAMPR_USER_LOGON_HOURS_INFORMATION;
+      
+     typedef struct _SAMPR_USER_INTERNAL1_INFORMATION {
+         ENCRYPTED_NT_OWF_PASSWORD  EncryptedNtOwfPassword;
+         ENCRYPTED_LM_OWF_PASSWORD  EncryptedLmOwfPassword;
+         unsigned char              NtPasswordPresent;
+         unsigned char              LmPasswordPresent;
+         unsigned char              PasswordExpired;
+     } SAMPR_USER_INTERNAL1_INFORMATION,
+       *PSAMPR_USER_INTERNAL1_INFORMATION;
+      
+     typedef struct _SAMPR_USER_INTERNAL4_INFORMATION {
+         SAMPR_USER_ALL_INFORMATION I1;
+         SAMPR_ENCRYPTED_USER_PASSWORD UserPassword;
+     } SAMPR_USER_INTERNAL4_INFORMATION, 
+       *PSAMPR_USER_INTERNAL4_INFORMATION;
+      
+     typedef struct _SAMPR_USER_INTERNAL4_INFORMATION_NEW {
+         SAMPR_USER_ALL_INFORMATION I1;
+         SAMPR_ENCRYPTED_USER_PASSWORD_NEW UserPassword;
+     } SAMPR_USER_INTERNAL4_INFORMATION_NEW,
+       *PSAMPR_USER_INTERNAL4_INFORMATION_NEW;
+      
+     typedef struct _SAMPR_USER_INTERNAL5_INFORMATION {
+         SAMPR_ENCRYPTED_USER_PASSWORD UserPassword;
+         unsigned char                 PasswordExpired;
+     } SAMPR_USER_INTERNAL5_INFORMATION,
+       *PSAMPR_USER_INTERNAL5_INFORMATION;
+      
+     typedef struct _SAMPR_USER_INTERNAL5_INFORMATION_NEW {
+         SAMPR_ENCRYPTED_USER_PASSWORD_NEW UserPassword;
+         unsigned char                      PasswordExpired;
+     } SAMPR_USER_INTERNAL5_INFORMATION_NEW,
+       *PSAMPR_USER_INTERNAL5_INFORMATION_NEW;
+      
+     typedef struct _SAMPR_ENCRYPTED_PASSWORD_AES {
+         UCHAR                       AuthData[64];
+         UCHAR                       Salt[16];
+         ULONG                       cbCipher;
+         [size_is(cbCipher)] PUCHAR  Cipher;
+         ULONGLONG                   PBKDF2Iterations;
+     } SAMPR_ENCRYPTED_PASSWORD_AES,  *PSAMPR_ENCRYPTED_PASSWORD_AES;
+      
+     typedef struct _SAMPR_USER_INTERNAL7_INFORMATION {
+         SAMPR_ENCRYPTED_PASSWORD_AES         UserPassword;
+         BOOLEAN                              PasswordExpired;
+     } SAMPR_USER_INTERNAL7_INFORMATION,  *PSAMPR_USER_INTERNAL7_INFORMATION;
+      
+     typedef struct _SAMPR_USER_INTERNAL8_INFORMATION {
+         SAMPR_USER_ALL_INFORMATION           I1;
+         SAMPR_ENCRYPTED_PASSWORD_AES UserPassword;
+     } SAMPR_USER_INTERNAL8_INFORMATION,  *PSAMPR_USER_INTERNAL8_INFORMATION;
+      
+     typedef enum _USER_INFORMATION_CLASS {
+         UserGeneralInformation = 1,
+         UserPreferencesInformation = 2,
+         UserLogonInformation = 3,
+         UserLogonHoursInformation = 4,
+         UserAccountInformation = 5,
+         UserNameInformation = 6,
+         UserAccountNameInformation = 7,
+         UserFullNameInformation = 8,
+         UserPrimaryGroupInformation = 9,
+         UserHomeInformation = 10,
+         UserScriptInformation = 11,
+         UserProfileInformation = 12,
+         UserAdminCommentInformation = 13,
+         UserWorkStationsInformation = 14,
+         UserControlInformation = 16,
+         UserExpiresInformation = 17,
+         UserInternal1Information = 18,
+         UserParametersInformation = 20,
+         UserAllInformation = 21,
+         UserInternal4Information = 23,
+         UserInternal5Information = 24,
+         UserInternal4InformationNew = 25,
+         UserInternal5InformationNew = 26,
+         UserInternal7Information = 31,
+         UserInternal8Information = 32
+     } USER_INFORMATION_CLASS, *PUSER_INFORMATION_CLASS;
+      
+     typedef [switch_type(USER_INFORMATION_CLASS)] union
+     _SAMPR_USER_INFO_BUFFER {
+         [case(UserGeneralInformation)]
+             SAMPR_USER_GENERAL_INFORMATION        General;
+         [case(UserPreferencesInformation)]
+             SAMPR_USER_PREFERENCES_INFORMATION    Preferences;
+         [case(UserLogonInformation)]
+             SAMPR_USER_LOGON_INFORMATION          Logon;
+         [case(UserLogonHoursInformation)]
+             SAMPR_USER_LOGON_HOURS_INFORMATION    LogonHours;
+         [case(UserAccountInformation)]
+             SAMPR_USER_ACCOUNT_INFORMATION        Account;
+         [case(UserNameInformation)]
+             SAMPR_USER_NAME_INFORMATION           Name;
+         [case(UserAccountNameInformation)]
+             SAMPR_USER_A_NAME_INFORMATION         AccountName;
+         [case(UserFullNameInformation)]
+             SAMPR_USER_F_NAME_INFORMATION         FullName;
+         [case(UserPrimaryGroupInformation)]
+             USER_PRIMARY_GROUP_INFORMATION        PrimaryGroup;
+         [case(UserHomeInformation)]
+             SAMPR_USER_HOME_INFORMATION           Home;
+         [case(UserScriptInformation)]
+             SAMPR_USER_SCRIPT_INFORMATION         Script;
+         [case(UserProfileInformation)]
+             SAMPR_USER_PROFILE_INFORMATION        Profile;
+         [case(UserAdminCommentInformation)]
+             SAMPR_USER_ADMIN_COMMENT_INFORMATION  AdminComment;
+         [case(UserWorkStationsInformation)]
+             SAMPR_USER_WORKSTATIONS_INFORMATION   WorkStations;
+         [case(UserControlInformation)]
+             USER_CONTROL_INFORMATION              Control;
+         [case(UserExpiresInformation)]
+             USER_EXPIRES_INFORMATION              Expires;
+         [case(UserInternal1Information)]
+             SAMPR_USER_INTERNAL1_INFORMATION      Internal1;
+         [case(UserParametersInformation)]
+             SAMPR_USER_PARAMETERS_INFORMATION     Parameters;
+         [case(UserAllInformation)]
+             SAMPR_USER_ALL_INFORMATION            All;
+         [case(UserInternal4Information)]
+             SAMPR_USER_INTERNAL4_INFORMATION      Internal4;
+         [case(UserInternal5Information)]
+             SAMPR_USER_INTERNAL5_INFORMATION      Internal5;
+         [case(UserInternal4InformationNew)]
+             SAMPR_USER_INTERNAL4_INFORMATION_NEW  Internal4New;
+         [case(UserInternal5InformationNew)]
+             SAMPR_USER_INTERNAL5_INFORMATION_NEW  Internal5New;
+         [case(UserInternal7Information)]    
+                SAMPR_USER_INTERNAL7_INFORMATION   Internal7;
+         [case(UserInternal8Information)]    
+                SAMPR_USER_INTERNAL8_INFORMATION   Internal8;
+     } SAMPR_USER_INFO_BUFFER, *PSAMPR_USER_INFO_BUFFER;
+      
+     typedef enum _PASSWORD_POLICY_VALIDATION_TYPE{
+         SamValidateAuthentication = 1,
+         SamValidatePasswordChange,
+         SamValidatePasswordReset
+     } PASSWORD_POLICY_VALIDATION_TYPE;
+      
+     typedef struct _SAM_VALIDATE_PASSWORD_HASH{
+         unsigned long Length;
+         [unique,size_is(Length)]
+         unsigned char* Hash;
+     } SAM_VALIDATE_PASSWORD_HASH, *PSAM_VALIDATE_PASSWORD_HASH;
+      
+     typedef struct _SAM_VALIDATE_PERSISTED_FIELDS{
+         unsigned long PresentFields;
+         LARGE_INTEGER PasswordLastSet;
+         LARGE_INTEGER BadPasswordTime;
+         LARGE_INTEGER LockoutTime;
+         unsigned long BadPasswordCount;
+         unsigned long PasswordHistoryLength;
+         [unique,size_is(PasswordHistoryLength)]
+         PSAM_VALIDATE_PASSWORD_HASH PasswordHistory;
+     } SAM_VALIDATE_PERSISTED_FIELDS, *PSAM_VALIDATE_PERSISTED_FIELDS;
+      
+     typedef enum _SAM_VALIDATE_VALIDATION_STATUS{
+         SamValidateSuccess = 0,
+         SamValidatePasswordMustChange,
+         SamValidateAccountLockedOut,
+         SamValidatePasswordExpired,
+         SamValidatePasswordIncorrect,
+         SamValidatePasswordIsInHistory,
+         SamValidatePasswordTooShort,
+         SamValidatePasswordTooLong,
+         SamValidatePasswordNotComplexEnough,
+         SamValidatePasswordTooRecent,
+         SamValidatePasswordFilterError
+     } SAM_VALIDATE_VALIDATION_STATUS, *PSAM_VALIDATE_VALIDATION_STATUS;
+      
+     typedef struct _SAM_VALIDATE_STANDARD_OUTPUT_ARG{
+         SAM_VALIDATE_PERSISTED_FIELDS ChangedPersistedFields;
+         SAM_VALIDATE_VALIDATION_STATUS ValidationStatus;
+     } SAM_VALIDATE_STANDARD_OUTPUT_ARG,
+       *PSAM_VALIDATE_STANDARD_OUTPUT_ARG;
+      
+     typedef struct _SAM_VALIDATE_AUTHENTICATION_INPUT_ARG{
+         SAM_VALIDATE_PERSISTED_FIELDS InputPersistedFields;
+         unsigned char PasswordMatched;
+     } SAM_VALIDATE_AUTHENTICATION_INPUT_ARG,
+       *PSAM_VALIDATE_AUTHENTICATION_INPUT_ARG;
+      
+     typedef struct  _SAM_VALIDATE_PASSWORD_CHANGE_INPUT_ARG{
+         SAM_VALIDATE_PERSISTED_FIELDS InputPersistedFields;
+         RPC_UNICODE_STRING ClearPassword;
+         RPC_UNICODE_STRING UserAccountName;
+         SAM_VALIDATE_PASSWORD_HASH HashedPassword;
+         unsigned char PasswordMatch;
+     } SAM_VALIDATE_PASSWORD_CHANGE_INPUT_ARG,
+       *PSAM_VALIDATE_PASSWORD_CHANGE_INPUT_ARG;
+      
+     typedef struct _SAM_VALIDATE_PASSWORD_RESET_INPUT_ARG{
+         SAM_VALIDATE_PERSISTED_FIELDS InputPersistedFields;
+         RPC_UNICODE_STRING ClearPassword;
+         RPC_UNICODE_STRING UserAccountName;
+         SAM_VALIDATE_PASSWORD_HASH HashedPassword;
+         unsigned char  PasswordMustChangeAtNextLogon;
+         unsigned char  ClearLockout;
+     } SAM_VALIDATE_PASSWORD_RESET_INPUT_ARG,
+       *PSAM_VALIDATE_PASSWORD_RESET_INPUT_ARG;
+      
+     typedef
+     [switch_type(PASSWORD_POLICY_VALIDATION_TYPE)]
+     union _SAM_VALIDATE_INPUT_ARG{
+         [case(SamValidateAuthentication)]
+             SAM_VALIDATE_AUTHENTICATION_INPUT_ARG
+             ValidateAuthenticationInput;
+         [case(SamValidatePasswordChange)]
+             SAM_VALIDATE_PASSWORD_CHANGE_INPUT_ARG
+             ValidatePasswordChangeInput;
+         [case(SamValidatePasswordReset)]
+             SAM_VALIDATE_PASSWORD_RESET_INPUT_ARG
+             ValidatePasswordResetInput;
+     } SAM_VALIDATE_INPUT_ARG, *PSAM_VALIDATE_INPUT_ARG;
+      
+     typedef
+     [switch_type(PASSWORD_POLICY_VALIDATION_TYPE)]
+     union _SAM_VALIDATE_OUTPUT_ARG{
+         [case(SamValidateAuthentication)]
+             SAM_VALIDATE_STANDARD_OUTPUT_ARG
+             ValidateAuthenticationOutput;
+         [case(SamValidatePasswordChange)]
+             SAM_VALIDATE_STANDARD_OUTPUT_ARG
+             ValidatePasswordChangeOutput;
+         [case(SamValidatePasswordReset)]
+             SAM_VALIDATE_STANDARD_OUTPUT_ARG
+             ValidatePasswordResetOutput;
+     } SAM_VALIDATE_OUTPUT_ARG, *PSAM_VALIDATE_OUTPUT_ARG;
+      
+      
+     // opnum 0
+     long SamrConnect(
+         [in, unique] PSAMPR_SERVER_NAME ServerName,
+         [out] SAMPR_HANDLE * ServerHandle,
+         [in] unsigned long DesiredAccess
+         );
+      
+     // opnum 1
+     long
+     SamrCloseHandle(
+         [in,out] SAMPR_HANDLE * SamHandle
+         );
+      
+     // opnum 2
+     long
+     SamrSetSecurityObject(
+         [in] SAMPR_HANDLE ObjectHandle,
+         [in] SECURITY_INFORMATION SecurityInformation,
+         [in] PSAMPR_SR_SECURITY_DESCRIPTOR SecurityDescriptor
+         );
+      
+     // opnum 3
+     long
+     SamrQuerySecurityObject(
+         [in] SAMPR_HANDLE ObjectHandle,
+         [in] SECURITY_INFORMATION SecurityInformation,
+         [out] PSAMPR_SR_SECURITY_DESCRIPTOR * SecurityDescriptor
+         );
+      
+     // opnum 4
+     void Opnum4NotUsedOnWire(void);
+      
+     // opnum 5
+     long
+     SamrLookupDomainInSamServer(
+         [in] SAMPR_HANDLE ServerHandle,
+         [in] PRPC_UNICODE_STRING  Name,
+         [out] PRPC_SID * DomainId
+         );
+      
+     // opnum 6
+     long
+     SamrEnumerateDomainsInSamServer(
+         [in] SAMPR_HANDLE ServerHandle,
+         [in,out] unsigned long * EnumerationContext,
+         [out] PSAMPR_ENUMERATION_BUFFER * Buffer,
+         [in] unsigned long PreferedMaximumLength,
+         [out] unsigned long * CountReturned
+         );
+      
+     // opnum 7
+     long
+     SamrOpenDomain(
+         [in] SAMPR_HANDLE ServerHandle,
+         [in] unsigned long   DesiredAccess,
+         [in] PRPC_SID DomainId,
+         [out] SAMPR_HANDLE * DomainHandle
+         );
+      
+     // opnum 8
+     long
+     SamrQueryInformationDomain(
+         [in] SAMPR_HANDLE DomainHandle,
+         [in] DOMAIN_INFORMATION_CLASS DomainInformationClass,
+         [out, switch_is(DomainInformationClass)]
+             PSAMPR_DOMAIN_INFO_BUFFER * Buffer
+         );
+      
+     // opnum 9
+     long
+     SamrSetInformationDomain(
+         [in] SAMPR_HANDLE DomainHandle,
+         [in] DOMAIN_INFORMATION_CLASS DomainInformationClass,
+         [in, switch_is(DomainInformationClass)]
+             PSAMPR_DOMAIN_INFO_BUFFER DomainInformation
+         );
+      
+     // opnum 10
+     long
+     SamrCreateGroupInDomain(
+         [in] SAMPR_HANDLE DomainHandle,
+         [in] PRPC_UNICODE_STRING Name,
+         [in] unsigned long   DesiredAccess,
+         [out] SAMPR_HANDLE  * GroupHandle,
+         [out] unsigned long * RelativeId
+         );
+      
+     // opnum 11
+     long
+     SamrEnumerateGroupsInDomain(
+         [in] SAMPR_HANDLE DomainHandle,
+         [in,out] unsigned long  * EnumerationContext,
+         [out] PSAMPR_ENUMERATION_BUFFER * Buffer,
+         [in] unsigned long    PreferedMaximumLength,
+         [out] unsigned long  * CountReturned
+         );
+      
+     // opnum 12
+     long
+     SamrCreateUserInDomain(
+         [in] SAMPR_HANDLE DomainHandle,
+         [in] PRPC_UNICODE_STRING Name,
+         [in] unsigned long   DesiredAccess,
+         [out] SAMPR_HANDLE  * UserHandle,
+         [out] unsigned long * RelativeId
+         );
+      
+     // opnum 13
+     long
+     SamrEnumerateUsersInDomain(
+         [in] SAMPR_HANDLE DomainHandle,
+         [in,out] unsigned long  * EnumerationContext,
+         [in] unsigned long    UserAccountControl,
+         [out] PSAMPR_ENUMERATION_BUFFER * Buffer,
+         [in] unsigned long    PreferedMaximumLength,
+         [out] unsigned long  * CountReturned
+         );
+      
+     // opnum 14
+     long
+     SamrCreateAliasInDomain(
+         [in] SAMPR_HANDLE DomainHandle,
+         [in] PRPC_UNICODE_STRING AccountName,
+         [in] unsigned long   DesiredAccess,
+         [out] SAMPR_HANDLE  * AliasHandle,
+         [out] unsigned long * RelativeId
+         );
+      
+     // opnum 15
+     long
+     SamrEnumerateAliasesInDomain(
+         [in] SAMPR_HANDLE DomainHandle,
+         [in,out] unsigned long  * EnumerationContext,
+         [out] PSAMPR_ENUMERATION_BUFFER * Buffer,
+         [in] unsigned long    PreferedMaximumLength,
+         [out] unsigned long  * CountReturned
+         );
+      
+     // opnum 16
+     long
+     SamrGetAliasMembership(
+         [in] SAMPR_HANDLE DomainHandle,
+         [in] PSAMPR_PSID_ARRAY SidArray,
+         [out] PSAMPR_ULONG_ARRAY Membership
+         );
+      
+     // opnum 17
+     long
+     SamrLookupNamesInDomain(
+         [in] SAMPR_HANDLE DomainHandle,
+         [in, range(0, 1000)] unsigned long Count,
+         [in, size_is(1000), length_is(Count)] RPC_UNICODE_STRING Names[*],
+         [out] PSAMPR_ULONG_ARRAY RelativeIds,
+         [out] PSAMPR_ULONG_ARRAY Use
+         );
+      
+     // opnum 18
+     long
+     SamrLookupIdsInDomain(
+         [in] SAMPR_HANDLE DomainHandle,
+         [in, range(0, 1000)] unsigned long    Count,
+         [in, size_is(1000), length_is(Count)] unsigned long *RelativeIds,
+         [out] PSAMPR_RETURNED_USTRING_ARRAY   Names,
+         [out] PSAMPR_ULONG_ARRAY Use
+         );
+      
+     // opnum 19
+     long
+     SamrOpenGroup(
+         [in] SAMPR_HANDLE DomainHandle,
+         [in] unsigned long   DesiredAccess,
+         [in] unsigned long   GroupId,
+         [out] SAMPR_HANDLE  * GroupHandle
+         );
+      
+     // opnum 20
+     long
+     SamrQueryInformationGroup(
+         [in] SAMPR_HANDLE GroupHandle,
+         [in] GROUP_INFORMATION_CLASS GroupInformationClass,
+         [out, switch_is(GroupInformationClass)]
+             PSAMPR_GROUP_INFO_BUFFER * Buffer
+         );
+      
+     // opnum 21
+     long
+     SamrSetInformationGroup(
+         [in] SAMPR_HANDLE GroupHandle,
+         [in] GROUP_INFORMATION_CLASS GroupInformationClass,
+         [in, switch_is(GroupInformationClass)]
+             PSAMPR_GROUP_INFO_BUFFER Buffer
+         );
+      
+     // opnum 22
+     long
+     SamrAddMemberToGroup(
+         [in] SAMPR_HANDLE GroupHandle,
+         [in] unsigned long   MemberId,
+         [in] unsigned long   Attributes
+         );
+      
+     // opnum 23
+     long
+     SamrDeleteGroup(
+         [in,out] SAMPR_HANDLE  * GroupHandle
+         );
+      
+     // opnum 24
+     long
+     SamrRemoveMemberFromGroup(
+         [in] SAMPR_HANDLE GroupHandle,
+         [in] unsigned long   MemberId
+         );
+      
+     // opnum 25
+     long
+     SamrGetMembersInGroup(
+         [in] SAMPR_HANDLE GroupHandle,
+         [out] PSAMPR_GET_MEMBERS_BUFFER * Members
+         );
+      
+     // opnum 26
+     long
+     SamrSetMemberAttributesOfGroup(
+         [in] SAMPR_HANDLE GroupHandle,
+         [in] unsigned long   MemberId,
+         [in] unsigned long   Attributes
+         );
+      
+     // opnum 27
+     long
+     SamrOpenAlias(
+         [in] SAMPR_HANDLE DomainHandle,
+         [in] unsigned long   DesiredAccess,
+         [in] unsigned long   AliasId,
+         [out] SAMPR_HANDLE  * AliasHandle
+         );
+      
+     // opnum 28
+     long
+     SamrQueryInformationAlias(
+         [in] SAMPR_HANDLE AliasHandle,
+         [in] ALIAS_INFORMATION_CLASS AliasInformationClass,
+         [out, switch_is(AliasInformationClass)]
+             PSAMPR_ALIAS_INFO_BUFFER * Buffer
+         );
+      
+     // opnum 29
+     long
+     SamrSetInformationAlias(
+         [in] SAMPR_HANDLE AliasHandle,
+         [in] ALIAS_INFORMATION_CLASS AliasInformationClass,
+         [in, switch_is(AliasInformationClass)]
+             PSAMPR_ALIAS_INFO_BUFFER Buffer
+         );
+      
+     // opnum 30
+     long
+     SamrDeleteAlias(
+         [in, out] SAMPR_HANDLE  * AliasHandle
+         );
+      
+     // opnum 31
+     long
+     SamrAddMemberToAlias(
+         [in] SAMPR_HANDLE AliasHandle,
+         [in] PRPC_SID MemberId
+         );
+      
+     // opnum 32
+     long
+     SamrRemoveMemberFromAlias(
+         [in] SAMPR_HANDLE AliasHandle,
+         [in] PRPC_SID MemberId
+         );
+      
+     // opnum 33
+     long
+     SamrGetMembersInAlias(
+         [in] SAMPR_HANDLE AliasHandle,
+         [out] PSAMPR_PSID_ARRAY_OUT Members
+         );
+      
+     // opnum 34
+     long
+     SamrOpenUser(
+         [in] SAMPR_HANDLE DomainHandle,
+         [in] unsigned long   DesiredAccess,
+         [in] unsigned long   UserId,
+         [out] SAMPR_HANDLE  * UserHandle
+         );
+      
+     // opnum 35
+     long
+     SamrDeleteUser(
+         [in,out] SAMPR_HANDLE  * UserHandle
+         );
+      
+     // opnum 36
+     long
+     SamrQueryInformationUser(
+         [in] SAMPR_HANDLE UserHandle,
+         [in] USER_INFORMATION_CLASS  UserInformationClass,
+         [out, switch_is(UserInformationClass)]
+             PSAMPR_USER_INFO_BUFFER * Buffer
+         );
+      
+     // opnum 37
+     long
+     SamrSetInformationUser(
+         [in] SAMPR_HANDLE UserHandle,
+         [in] USER_INFORMATION_CLASS  UserInformationClass,
+         [in, switch_is(UserInformationClass)]
+             PSAMPR_USER_INFO_BUFFER Buffer
+         );
+      
+     // opnum 38
+     long
+     SamrChangePasswordUser(
+         [in] SAMPR_HANDLE UserHandle,
+         [in] unsigned char    LmPresent,
+         [in, unique] PENCRYPTED_LM_OWF_PASSWORD OldLmEncryptedWithNewLm,
+         [in, unique] PENCRYPTED_LM_OWF_PASSWORD NewLmEncryptedWithOldLm,
+         [in] unsigned char    NtPresent,
+         [in, unique] PENCRYPTED_NT_OWF_PASSWORD OldNtEncryptedWithNewNt,
+         [in, unique] PENCRYPTED_NT_OWF_PASSWORD NewNtEncryptedWithOldNt,
+         [in] unsigned char    NtCrossEncryptionPresent,
+         [in, unique] PENCRYPTED_NT_OWF_PASSWORD NewNtEncryptedWithNewLm,
+         [in] unsigned char    LmCrossEncryptionPresent,
+         [in, unique] PENCRYPTED_LM_OWF_PASSWORD NewLmEncryptedWithNewNt
+         );
+      
+     // opnum 39
+     long
+     SamrGetGroupsForUser(
+         [in] SAMPR_HANDLE UserHandle,
+         [out] PSAMPR_GET_GROUPS_BUFFER * Groups
+         );
+      
+     // opnum 40
+     long
+     SamrQueryDisplayInformation (
+         [in] SAMPR_HANDLE DomainHandle,
+         [in] DOMAIN_DISPLAY_INFORMATION DisplayInformationClass,
+         [in] unsigned long    Index,
+         [in] unsigned long    EntryCount,
+         [in] unsigned long    PreferredMaximumLength,
+         [out] unsigned long  * TotalAvailable,
+         [out] unsigned long  * TotalReturned,
+         [out, switch_is(DisplayInformationClass)]
+             PSAMPR_DISPLAY_INFO_BUFFER Buffer
+         );
+      
+     // opnum 41
+     long
+     SamrGetDisplayEnumerationIndex (
+         [in] SAMPR_HANDLE DomainHandle,
+         [in] DOMAIN_DISPLAY_INFORMATION DisplayInformationClass,
+         [in] PRPC_UNICODE_STRING  Prefix,
+         [out] unsigned long  * Index
+         );
+      
+     // opnum 42
+     void Opnum42NotUsedOnWire(void);
+      
+     // opnum 43
+     void Opnum43NotUsedOnWire(void);
+      
+     // opnum 44
+     long
+     SamrGetUserDomainPasswordInformation (
+         [in] SAMPR_HANDLE UserHandle,
+         [out] PUSER_DOMAIN_PASSWORD_INFORMATION PasswordInformation
+         );
+      
+     // opnum 45
+     long
+     SamrRemoveMemberFromForeignDomain (
+         [in] SAMPR_HANDLE DomainHandle,
+         [in] PRPC_SID MemberSid
+         );
+      
+     // opnum 46
+     long
+     SamrQueryInformationDomain2(
+         [in] SAMPR_HANDLE DomainHandle,
+         [in] DOMAIN_INFORMATION_CLASS DomainInformationClass,
+         [out, switch_is(DomainInformationClass)]
+             PSAMPR_DOMAIN_INFO_BUFFER * Buffer
+         );
+      
+     // opnum 47
+     long
+     SamrQueryInformationUser2(
+         [in] SAMPR_HANDLE UserHandle,
+         [in] USER_INFORMATION_CLASS  UserInformationClass,
+         [out, switch_is(UserInformationClass)]
+             PSAMPR_USER_INFO_BUFFER * Buffer
+         );
+      
+     // opnum 48
+     long
+     SamrQueryDisplayInformation2 (
+         [in] SAMPR_HANDLE DomainHandle,
+         [in] DOMAIN_DISPLAY_INFORMATION DisplayInformationClass,
+         [in] unsigned long  Index,
+         [in] unsigned long  EntryCount,
+         [in] unsigned long  PreferredMaximumLength,
+         [out] unsigned long  *TotalAvailable,
+         [out] unsigned long  *TotalReturned,
+         [out, switch_is(DisplayInformationClass)]
+             PSAMPR_DISPLAY_INFO_BUFFER Buffer
+         );
+      
+     // opnum 49
+     long
+     SamrGetDisplayEnumerationIndex2 (
+         [in] SAMPR_HANDLE DomainHandle,
+         [in] DOMAIN_DISPLAY_INFORMATION DisplayInformationClass,
+         [in] PRPC_UNICODE_STRING Prefix,
+         [out] unsigned long  * Index
+         );
+      
+     // opnum 50
+     long
+     SamrCreateUser2InDomain(
+         [in] SAMPR_HANDLE DomainHandle,
+         [in] PRPC_UNICODE_STRING Name,
+         [in] unsigned long   AccountType,
+         [in] unsigned long   DesiredAccess,
+         [out] SAMPR_HANDLE  * UserHandle,
+         [out] unsigned long * GrantedAccess,
+         [out] unsigned long * RelativeId
+         );
+      
+     // opnum 51
+     long
+     SamrQueryDisplayInformation3 (
+         [in] SAMPR_HANDLE DomainHandle,
+         [in] DOMAIN_DISPLAY_INFORMATION DisplayInformationClass,
+         [in] unsigned long    Index,
+         [in] unsigned long    EntryCount,
+         [in] unsigned long    PreferredMaximumLength,
+         [out] unsigned long  * TotalAvailable,
+         [out] unsigned long  * TotalReturned,
+         [out, switch_is(DisplayInformationClass)]
+             PSAMPR_DISPLAY_INFO_BUFFER Buffer
+         );
+      
+     // opnum 52
+     long
+     SamrAddMultipleMembersToAlias(
+         [in] SAMPR_HANDLE AliasHandle,
+         [in] PSAMPR_PSID_ARRAY MembersBuffer
+         );
+      
+     // opnum 53
+     long
+     SamrRemoveMultipleMembersFromAlias(
+         [in] SAMPR_HANDLE AliasHandle,
+         [in] PSAMPR_PSID_ARRAY MembersBuffer
+         );
+      
+     // opnum 54
+     long
+     SamrOemChangePasswordUser2(
+         [in] handle_t BindingHandle,
+         [in,unique] PRPC_STRING ServerName,
+         [in] PRPC_STRING UserName,
+         [in,unique]
+             PSAMPR_ENCRYPTED_USER_PASSWORD NewPasswordEncryptedWithOldLm,
+         [in,unique]
+             PENCRYPTED_LM_OWF_PASSWORD OldLmOwfPasswordEncryptedWithNewLm
+         );
+      
+     // opnum 55
+     long
+     SamrUnicodeChangePasswordUser2(
+         [in] handle_t BindingHandle,
+         [in,unique] PRPC_UNICODE_STRING ServerName,
+         [in] PRPC_UNICODE_STRING UserName,
+         [in,unique]
+             PSAMPR_ENCRYPTED_USER_PASSWORD NewPasswordEncryptedWithOldNt,
+         [in,unique]
+             PENCRYPTED_NT_OWF_PASSWORD OldNtOwfPasswordEncryptedWithNewNt,
+         [in] unsigned char LmPresent,
+         [in,unique]
+             PSAMPR_ENCRYPTED_USER_PASSWORD NewPasswordEncryptedWithOldLm,
+         [in,unique]
+             PENCRYPTED_LM_OWF_PASSWORD OldLmOwfPasswordEncryptedWithNewNt
+         );
+      
+     // opnum 56
+     long
+     SamrGetDomainPasswordInformation (
+         [in] handle_t  BindingHandle,
+         [in,unique] PRPC_UNICODE_STRING Unused,
+         [out] PUSER_DOMAIN_PASSWORD_INFORMATION PasswordInformation
+         );
+      
+     // opnum 57
+     long
+     SamrConnect2(
+         [in,unique,string]  PSAMPR_SERVER_NAME ServerName,
+         [out] SAMPR_HANDLE *ServerHandle,
+         [in] unsigned long  DesiredAccess
+         );
+      
+     // opnum 58
+     long
+     SamrSetInformationUser2(
+         [in] SAMPR_HANDLE UserHandle,
+         [in] USER_INFORMATION_CLASS UserInformationClass,
+         [in, switch_is(UserInformationClass)]
+             PSAMPR_USER_INFO_BUFFER Buffer
+         );
+      
+     // opnum 59
+     void Opnum59NotUsedOnWire(void);
+      
+     // opnum 60
+     void Opnum60NotUsedOnWire(void);
+      
+     // opnum 61
+     void Opnum61NotUsedOnWire(void);
+      
+     // opnum 62
+     long
+     SamrConnect4(
+         [in,unique,string] PSAMPR_SERVER_NAME ServerName,
+         [out] SAMPR_HANDLE *ServerHandle,
+         [in] unsigned long ClientRevision,
+         [in] unsigned long DesiredAccess
+         );
+      
+     // opnum 63
+     void Opnum63NotUsedOnWire(void);
+      
+     // opnum 64
+     long
+     SamrConnect5(
+         [in,unique,string] PSAMPR_SERVER_NAME ServerName,
+         [in] unsigned long DesiredAccess,
+         [in] unsigned long InVersion,
+         [in] [switch_is(InVersion)] SAMPR_REVISION_INFO *InRevisionInfo,
+         [out] unsigned long *OutVersion,
+         [out] [switch_is(*OutVersion)]
+             SAMPR_REVISION_INFO *OutRevisionInfo,
+         [out] SAMPR_HANDLE *ServerHandle
+         );
+      
+     // opnum 65
+     long
+     SamrRidToSid(
+         [in] SAMPR_HANDLE ObjectHandle,
+         [in] unsigned long Rid,
+         [out] PRPC_SID * Sid
+         );
+      
+     // opnum 66
+     long
+     SamrSetDSRMPassword(
+         [in] handle_t BindingHandle,
+         [in,unique] PRPC_UNICODE_STRING Unused,
+         [in] unsigned long    UserId,
+         [in,unique] PENCRYPTED_NT_OWF_PASSWORD EncryptedNtOwfPassword
+         );
+      
+     // opnum 67
+     long
+     SamrValidatePassword(
+         [in]  handle_t Handle,
+         [in]  PASSWORD_POLICY_VALIDATION_TYPE ValidationType,
+         [in, switch_is(ValidationType)] PSAM_VALIDATE_INPUT_ARG InputArg,
+         [out, switch_is(ValidationType)]
+             PSAM_VALIDATE_OUTPUT_ARG * OutputArg
+         );
+      
+     // Opnum 68
+         void Opnum68NotUsedOnWire(void);
+      
+     // Opnum 69
+         void Opnum69NotUsedOnWire(void);
+
+     // Opnum 70
+        void Opnum70NotUsedOnWire(void);
+      
+     // Opnum 71
+        void Opnum71NotUsedOnWire(void);
+      
+     // Opnum 72
+        void Opnum72NotUsedOnWire(void);
+      
+     // Opnum 73
+        NTSTATUS
+        SamrUnicodeChangePasswordUser4(
+            [in]                handle_t                        BindingHandle,
+            [in,unique]         PRPC_UNICODE_STRING             ServerName,
+            [in]                PRPC_UNICODE_STRING             UserName,
+            [in]                PSAMPR_ENCRYPTED_PASSWORD_AES   EncryptedPassword
+         ); 
+     
+    // opnum 74
+       NTSTATUS
+        SamrValidateComputerAccountReuseAttempt(
+             [in]  SAMPR_HANDLE ServerHandle,
+             [in]  PRPC_SID   ComputerSid, 
+             [out] BOOL*      Result
+         );
+     
+    // opnum 75
+        void Opnum75NotUsedOnWire(void);
+     
+    // opnum 76
+        void Opnum76NotUsedOnWire(void);
+     
+    // opnum 77
+        NTSTATUS
+        SamrAccountIsDelegatedManagedServiceAccount(
+            [in]  SAMPR_HANDLE ServerHandle,
+            [in]  PRPC_UNICODE_STRING AccountName,
+            [out] BOOLEAN*  Result,
+            [out] BOOLEAN*  Authorized
+            );
+     
+    }
+

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/ALIAS_INFORMATION_CLASS.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/ALIAS_INFORMATION_CLASS.go
@@ -1,0 +1,12 @@
+package structures
+
+// ALIAS_INFORMATION_CLASS enumerates the alias information classes that select the arm of
+// SAMPR_ALIAS_INFO_BUFFER ([MS-SAMR] 2.2.6.5). As an NDR enum it is transmitted as a
+// 16-bit unsigned value ([C706] section 14.3.6).
+type ALIAS_INFORMATION_CLASS uint16
+
+const (
+	AliasGeneralInformation      ALIAS_INFORMATION_CLASS = 1
+	AliasNameInformation         ALIAS_INFORMATION_CLASS = 2
+	AliasAdminCommentInformation ALIAS_INFORMATION_CLASS = 3
+)

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/DOMAIN_DISPLAY_INFORMATION.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/DOMAIN_DISPLAY_INFORMATION.go
@@ -1,0 +1,14 @@
+package structures
+
+// DOMAIN_DISPLAY_INFORMATION enumerates the display information classes for the
+// SAMPR_DISPLAY_INFO_BUFFER union ([MS-SAMR] 2.2.8.1). As an NDR enum it is transmitted
+// as a 16-bit unsigned value ([C706] section 14.3.6).
+type DOMAIN_DISPLAY_INFORMATION uint16
+
+const (
+	DomainDisplayUser     DOMAIN_DISPLAY_INFORMATION = 1
+	DomainDisplayMachine  DOMAIN_DISPLAY_INFORMATION = 2
+	DomainDisplayGroup    DOMAIN_DISPLAY_INFORMATION = 3
+	DomainDisplayOemUser  DOMAIN_DISPLAY_INFORMATION = 4
+	DomainDisplayOemGroup DOMAIN_DISPLAY_INFORMATION = 5
+)

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/DOMAIN_INFORMATION_CLASS.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/DOMAIN_INFORMATION_CLASS.go
@@ -1,0 +1,21 @@
+package structures
+
+// DOMAIN_INFORMATION_CLASS enumerates the domain information classes for the
+// SAMPR_DOMAIN_INFO_BUFFER union ([MS-SAMR] 2.2.4.16). As an NDR enum it is transmitted
+// as a 16-bit unsigned value ([C706] section 14.3.6). The IDL skips the value 10.
+type DOMAIN_INFORMATION_CLASS uint16
+
+const (
+	DomainPasswordInformation    DOMAIN_INFORMATION_CLASS = 1
+	DomainGeneralInformation     DOMAIN_INFORMATION_CLASS = 2
+	DomainLogoffInformation      DOMAIN_INFORMATION_CLASS = 3
+	DomainOemInformation         DOMAIN_INFORMATION_CLASS = 4
+	DomainNameInformation        DOMAIN_INFORMATION_CLASS = 5
+	DomainReplicationInformation DOMAIN_INFORMATION_CLASS = 6
+	DomainServerRoleInformation  DOMAIN_INFORMATION_CLASS = 7
+	DomainModifiedInformation    DOMAIN_INFORMATION_CLASS = 8
+	DomainStateInformation       DOMAIN_INFORMATION_CLASS = 9
+	DomainGeneralInformation2    DOMAIN_INFORMATION_CLASS = 11
+	DomainLockoutInformation     DOMAIN_INFORMATION_CLASS = 12
+	DomainModifiedInformation2   DOMAIN_INFORMATION_CLASS = 13
+)

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/DOMAIN_LOGOFF_INFORMATION.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/DOMAIN_LOGOFF_INFORMATION.go
@@ -1,0 +1,7 @@
+package structures
+
+// DOMAIN_LOGOFF_INFORMATION holds the forced-logoff time for a domain
+// ([MS-SAMR] 2.2.4.6). ForceLogoff is an OLD_LARGE_INTEGER defined by the base family.
+type DOMAIN_LOGOFF_INFORMATION struct {
+	ForceLogoff OLD_LARGE_INTEGER
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/DOMAIN_MODIFIED_INFORMATION.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/DOMAIN_MODIFIED_INFORMATION.go
@@ -1,0 +1,9 @@
+package structures
+
+// DOMAIN_MODIFIED_INFORMATION holds the domain modification count and creation time
+// ([MS-SAMR] 2.2.4.7). Both fields are OLD_LARGE_INTEGER values defined by the base
+// family.
+type DOMAIN_MODIFIED_INFORMATION struct {
+	DomainModifiedCount OLD_LARGE_INTEGER
+	CreationTime        OLD_LARGE_INTEGER
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/DOMAIN_MODIFIED_INFORMATION2.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/DOMAIN_MODIFIED_INFORMATION2.go
@@ -1,0 +1,10 @@
+package structures
+
+// DOMAIN_MODIFIED_INFORMATION2 extends DOMAIN_MODIFIED_INFORMATION with the modified
+// count at the last promotion ([MS-SAMR] 2.2.4.8). All fields are OLD_LARGE_INTEGER
+// values defined by the base family.
+type DOMAIN_MODIFIED_INFORMATION2 struct {
+	DomainModifiedCount          OLD_LARGE_INTEGER
+	CreationTime                 OLD_LARGE_INTEGER
+	ModifiedCountAtLastPromotion OLD_LARGE_INTEGER
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/DOMAIN_PASSWORD_INFORMATION.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/DOMAIN_PASSWORD_INFORMATION.go
@@ -1,0 +1,16 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// DOMAIN_PASSWORD_INFORMATION contains a domain's password policy ([MS-SAMR] 2.2.4.5).
+// MaxPasswordAge and MinPasswordAge are OLD_LARGE_INTEGER values defined by the base
+// family.
+type DOMAIN_PASSWORD_INFORMATION struct {
+	MinPasswordLength     uint16
+	PasswordHistoryLength uint16
+	PasswordProperties    ndr.DWORD
+	MaxPasswordAge        OLD_LARGE_INTEGER
+	MinPasswordAge        OLD_LARGE_INTEGER
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/DOMAIN_SERVER_ENABLE_STATE.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/DOMAIN_SERVER_ENABLE_STATE.go
@@ -1,0 +1,11 @@
+package structures
+
+// DOMAIN_SERVER_ENABLE_STATE indicates whether a server is enabled or disabled
+// ([MS-SAMR] 2.2.4.1). As an NDR enum it is transmitted as a 16-bit unsigned value
+// ([C706] section 14.3.6).
+type DOMAIN_SERVER_ENABLE_STATE uint16
+
+const (
+	DomainServerEnabled  DOMAIN_SERVER_ENABLE_STATE = 1
+	DomainServerDisabled DOMAIN_SERVER_ENABLE_STATE = 2
+)

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/DOMAIN_SERVER_ROLE.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/DOMAIN_SERVER_ROLE.go
@@ -1,0 +1,11 @@
+package structures
+
+// DOMAIN_SERVER_ROLE indicates the role of a server: backup (replica) or primary
+// ([MS-SAMR] 2.2.4.3). As an NDR enum it is transmitted as a 16-bit unsigned value
+// ([C706] section 14.3.6).
+type DOMAIN_SERVER_ROLE uint16
+
+const (
+	DomainServerRoleBackup  DOMAIN_SERVER_ROLE = 2
+	DomainServerRolePrimary DOMAIN_SERVER_ROLE = 3
+)

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/DOMAIN_SERVER_ROLE_INFORMATION.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/DOMAIN_SERVER_ROLE_INFORMATION.go
@@ -1,0 +1,7 @@
+package structures
+
+// DOMAIN_SERVER_ROLE_INFORMATION holds the role (backup or primary) of a server
+// ([MS-SAMR] 2.2.4.4).
+type DOMAIN_SERVER_ROLE_INFORMATION struct {
+	DomainServerRole DOMAIN_SERVER_ROLE
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/DOMAIN_STATE_INFORMATION.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/DOMAIN_STATE_INFORMATION.go
@@ -1,0 +1,7 @@
+package structures
+
+// DOMAIN_STATE_INFORMATION holds the enabled/disabled state of a domain
+// ([MS-SAMR] 2.2.4.2).
+type DOMAIN_STATE_INFORMATION struct {
+	DomainServerState DOMAIN_SERVER_ENABLE_STATE
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/ENCRYPTED_LM_OWF_PASSWORD.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/ENCRYPTED_LM_OWF_PASSWORD.go
@@ -1,0 +1,12 @@
+package structures
+
+// ENCRYPTED_LM_OWF_PASSWORD holds an encrypted LM (or NT) one-way function of a
+// cleartext password ([MS-SAMR] 2.2.7.3). The IDL declares both the LM and NT
+// names for this same 16-byte structure.
+type ENCRYPTED_LM_OWF_PASSWORD struct {
+	Data [16]byte
+}
+
+// ENCRYPTED_NT_OWF_PASSWORD is an alias for ENCRYPTED_LM_OWF_PASSWORD; the IDL
+// gives the same 16-byte structure both names ([MS-SAMR] 2.2.7.3).
+type ENCRYPTED_NT_OWF_PASSWORD = ENCRYPTED_LM_OWF_PASSWORD

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/GROUP_ATTRIBUTE_INFORMATION.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/GROUP_ATTRIBUTE_INFORMATION.go
@@ -1,0 +1,11 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// GROUP_ATTRIBUTE_INFORMATION contains group fields ([MS-SAMR] 2.2.5.4). It carries the
+// attributes (a set of SE_GROUP flags) of a group.
+type GROUP_ATTRIBUTE_INFORMATION struct {
+	Attributes ndr.DWORD
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/GROUP_INFORMATION_CLASS.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/GROUP_INFORMATION_CLASS.go
@@ -1,0 +1,14 @@
+package structures
+
+// GROUP_INFORMATION_CLASS enumerates the group information classes that select the arm of
+// SAMPR_GROUP_INFO_BUFFER ([MS-SAMR] 2.2.5.8). As an NDR enum it is transmitted as a
+// 16-bit unsigned value ([C706] section 14.3.6).
+type GROUP_INFORMATION_CLASS uint16
+
+const (
+	GroupGeneralInformation      GROUP_INFORMATION_CLASS = 1
+	GroupNameInformation         GROUP_INFORMATION_CLASS = 2
+	GroupAttributeInformation    GROUP_INFORMATION_CLASS = 3
+	GroupAdminCommentInformation GROUP_INFORMATION_CLASS = 4
+	GroupReplicationInformation  GROUP_INFORMATION_CLASS = 5
+)

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/GROUP_MEMBERSHIP.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/GROUP_MEMBERSHIP.go
@@ -1,0 +1,12 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// GROUP_MEMBERSHIP pairs a group relative ID with its attributes ([MS-SAMR]
+// 2.2.3.6).
+type GROUP_MEMBERSHIP struct {
+	RelativeId ndr.DWORD
+	Attributes ndr.DWORD
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/OLD_LARGE_INTEGER.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/OLD_LARGE_INTEGER.go
@@ -1,0 +1,12 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// OLD_LARGE_INTEGER is a 64-bit value split into low and high parts
+// ([MS-SAMR] 2.2.2.1).
+type OLD_LARGE_INTEGER struct {
+	LowPart  ndr.DWORD
+	HighPart int32
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/PASSWORD_POLICY_VALIDATION_TYPE.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/PASSWORD_POLICY_VALIDATION_TYPE.go
@@ -1,0 +1,13 @@
+package structures
+
+// PASSWORD_POLICY_VALIDATION_TYPE indicates the type of password validation
+// being requested ([MS-SAMR] 2.2.9.1). As an NDR enum it is transmitted as a
+// 16-bit unsigned value ([C706] section 14.3.6) and serves as the discriminant
+// for the SAM_VALIDATE_INPUT_ARG and SAM_VALIDATE_OUTPUT_ARG unions.
+type PASSWORD_POLICY_VALIDATION_TYPE uint16
+
+const (
+	SamValidateAuthentication PASSWORD_POLICY_VALIDATION_TYPE = 1
+	SamValidatePasswordChange PASSWORD_POLICY_VALIDATION_TYPE = 2
+	SamValidatePasswordReset  PASSWORD_POLICY_VALIDATION_TYPE = 3
+)

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/RPC_SHORT_BLOB.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/RPC_SHORT_BLOB.go
@@ -1,0 +1,10 @@
+package structures
+
+// RPC_SHORT_BLOB is a counted array of unsigned short values ([MS-SAMR] 2.2.3.11).
+// Length and MaximumLength are byte counts; Buffer is a [unique] pointer to a
+// conformant-varying array of unsigned shorts.
+type RPC_SHORT_BLOB struct {
+	Length        uint16
+	MaximumLength uint16
+	Buffer        []uint16 `ndr:"unique,varying"`
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/RPC_STRING.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/RPC_STRING.go
@@ -1,0 +1,10 @@
+package structures
+
+// RPC_STRING is a counted ASCII string ([MS-SAMR] 2.2.3.10). Length and
+// MaximumLength are byte counts; Buffer is a [unique] pointer to a
+// conformant-varying array of chars.
+type RPC_STRING struct {
+	Length        uint16
+	MaximumLength uint16
+	Buffer        []byte `ndr:"unique,varying"`
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_ALIAS_ADM_COMMENT_INFORMATION.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_ALIAS_ADM_COMMENT_INFORMATION.go
@@ -1,0 +1,11 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+)
+
+// SAMPR_ALIAS_ADM_COMMENT_INFORMATION contains alias fields ([MS-SAMR] 2.2.6.4). It holds
+// the alias's administrative comment.
+type SAMPR_ALIAS_ADM_COMMENT_INFORMATION struct {
+	AdminComment dtyp.RPC_UNICODE_STRING
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_ALIAS_GENERAL_INFORMATION.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_ALIAS_GENERAL_INFORMATION.go
@@ -1,0 +1,14 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// SAMPR_ALIAS_GENERAL_INFORMATION contains alias fields ([MS-SAMR] 2.2.6.2). It holds the
+// alias's name, member count, and administrative comment.
+type SAMPR_ALIAS_GENERAL_INFORMATION struct {
+	Name         dtyp.RPC_UNICODE_STRING
+	MemberCount  ndr.DWORD
+	AdminComment dtyp.RPC_UNICODE_STRING
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_ALIAS_INFO_BUFFER.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_ALIAS_INFO_BUFFER.go
@@ -1,0 +1,11 @@
+package structures
+
+// SAMPR_ALIAS_INFO_BUFFER is the discriminated union of alias information classes
+// ([MS-SAMR] 2.2.6.6). The discriminant is an ALIAS_INFORMATION_CLASS; the wire form is
+// the discriminant followed by the single selected arm ([C706] section 14.3.8).
+type SAMPR_ALIAS_INFO_BUFFER struct {
+	Tag          ALIAS_INFORMATION_CLASS             `ndr:"switch"`
+	General      SAMPR_ALIAS_GENERAL_INFORMATION     `ndr:"case=1"`
+	Name         SAMPR_ALIAS_NAME_INFORMATION        `ndr:"case=2"`
+	AdminComment SAMPR_ALIAS_ADM_COMMENT_INFORMATION `ndr:"case=3"`
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_ALIAS_NAME_INFORMATION.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_ALIAS_NAME_INFORMATION.go
@@ -1,0 +1,11 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+)
+
+// SAMPR_ALIAS_NAME_INFORMATION contains alias fields ([MS-SAMR] 2.2.6.3). It holds the
+// alias's name.
+type SAMPR_ALIAS_NAME_INFORMATION struct {
+	Name dtyp.RPC_UNICODE_STRING
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_DISPLAY_INFO_BUFFER.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_DISPLAY_INFO_BUFFER.go
@@ -1,0 +1,14 @@
+package structures
+
+// SAMPR_DISPLAY_INFO_BUFFER is the discriminated union of domain display information
+// classes ([MS-SAMR] 2.2.8.12). The discriminant Tag is a DOMAIN_DISPLAY_INFORMATION;
+// the wire form is the discriminant followed by the single selected arm ([C706] section
+// 14.3.8). The numeric case values follow the DOMAIN_DISPLAY_INFORMATION enum.
+type SAMPR_DISPLAY_INFO_BUFFER struct {
+	Tag                 DOMAIN_DISPLAY_INFORMATION            `ndr:"switch"`
+	UserInformation     SAMPR_DOMAIN_DISPLAY_USER_BUFFER      `ndr:"case=1"`
+	MachineInformation  SAMPR_DOMAIN_DISPLAY_MACHINE_BUFFER   `ndr:"case=2"`
+	GroupInformation    SAMPR_DOMAIN_DISPLAY_GROUP_BUFFER     `ndr:"case=3"`
+	OemUserInformation  SAMPR_DOMAIN_DISPLAY_OEM_USER_BUFFER  `ndr:"case=4"`
+	OemGroupInformation SAMPR_DOMAIN_DISPLAY_OEM_GROUP_BUFFER `ndr:"case=5"`
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_DOMAIN_DISPLAY_GROUP.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_DOMAIN_DISPLAY_GROUP.go
@@ -1,0 +1,16 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// SAMPR_DOMAIN_DISPLAY_GROUP holds a single group entry returned by a display query
+// ([MS-SAMR] 2.2.8.4).
+type SAMPR_DOMAIN_DISPLAY_GROUP struct {
+	Index        ndr.DWORD
+	Rid          ndr.DWORD
+	Attributes   ndr.DWORD
+	AccountName  dtyp.RPC_UNICODE_STRING
+	AdminComment dtyp.RPC_UNICODE_STRING
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_DOMAIN_DISPLAY_GROUP_BUFFER.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_DOMAIN_DISPLAY_GROUP_BUFFER.go
@@ -1,0 +1,13 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// SAMPR_DOMAIN_DISPLAY_GROUP_BUFFER is the result buffer of a group display query
+// ([MS-SAMR] 2.2.8.9). Buffer is a [unique] pointer to a conformant array sized by
+// EntriesRead.
+type SAMPR_DOMAIN_DISPLAY_GROUP_BUFFER struct {
+	EntriesRead ndr.DWORD
+	Buffer      []SAMPR_DOMAIN_DISPLAY_GROUP `ndr:"unique,size_is=EntriesRead"`
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_DOMAIN_DISPLAY_MACHINE.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_DOMAIN_DISPLAY_MACHINE.go
@@ -1,0 +1,16 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// SAMPR_DOMAIN_DISPLAY_MACHINE holds a single machine entry returned by a display query
+// ([MS-SAMR] 2.2.8.3).
+type SAMPR_DOMAIN_DISPLAY_MACHINE struct {
+	Index          ndr.DWORD
+	Rid            ndr.DWORD
+	AccountControl ndr.DWORD
+	AccountName    dtyp.RPC_UNICODE_STRING
+	AdminComment   dtyp.RPC_UNICODE_STRING
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_DOMAIN_DISPLAY_MACHINE_BUFFER.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_DOMAIN_DISPLAY_MACHINE_BUFFER.go
@@ -1,0 +1,13 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// SAMPR_DOMAIN_DISPLAY_MACHINE_BUFFER is the result buffer of a machine display query
+// ([MS-SAMR] 2.2.8.8). Buffer is a [unique] pointer to a conformant array sized by
+// EntriesRead.
+type SAMPR_DOMAIN_DISPLAY_MACHINE_BUFFER struct {
+	EntriesRead ndr.DWORD
+	Buffer      []SAMPR_DOMAIN_DISPLAY_MACHINE `ndr:"unique,size_is=EntriesRead"`
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_DOMAIN_DISPLAY_OEM_GROUP.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_DOMAIN_DISPLAY_OEM_GROUP.go
@@ -1,0 +1,13 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// SAMPR_DOMAIN_DISPLAY_OEM_GROUP holds a single OEM (ASCII) group entry returned by a
+// display query ([MS-SAMR] 2.2.8.6). OemAccountName is an RPC_STRING defined by the base
+// family.
+type SAMPR_DOMAIN_DISPLAY_OEM_GROUP struct {
+	Index          ndr.DWORD
+	OemAccountName RPC_STRING
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_DOMAIN_DISPLAY_OEM_GROUP_BUFFER.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_DOMAIN_DISPLAY_OEM_GROUP_BUFFER.go
@@ -1,0 +1,13 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// SAMPR_DOMAIN_DISPLAY_OEM_GROUP_BUFFER is the result buffer of an OEM (ASCII) group
+// display query ([MS-SAMR] 2.2.8.11). Buffer is a [unique] pointer to a conformant array
+// sized by EntriesRead.
+type SAMPR_DOMAIN_DISPLAY_OEM_GROUP_BUFFER struct {
+	EntriesRead ndr.DWORD
+	Buffer      []SAMPR_DOMAIN_DISPLAY_OEM_GROUP `ndr:"unique,size_is=EntriesRead"`
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_DOMAIN_DISPLAY_OEM_USER.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_DOMAIN_DISPLAY_OEM_USER.go
@@ -1,0 +1,13 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// SAMPR_DOMAIN_DISPLAY_OEM_USER holds a single OEM (ASCII) user entry returned by a
+// display query ([MS-SAMR] 2.2.8.5). OemAccountName is an RPC_STRING defined by the base
+// family.
+type SAMPR_DOMAIN_DISPLAY_OEM_USER struct {
+	Index          ndr.DWORD
+	OemAccountName RPC_STRING
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_DOMAIN_DISPLAY_OEM_USER_BUFFER.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_DOMAIN_DISPLAY_OEM_USER_BUFFER.go
@@ -1,0 +1,13 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// SAMPR_DOMAIN_DISPLAY_OEM_USER_BUFFER is the result buffer of an OEM (ASCII) user
+// display query ([MS-SAMR] 2.2.8.10). Buffer is a [unique] pointer to a conformant array
+// sized by EntriesRead.
+type SAMPR_DOMAIN_DISPLAY_OEM_USER_BUFFER struct {
+	EntriesRead ndr.DWORD
+	Buffer      []SAMPR_DOMAIN_DISPLAY_OEM_USER `ndr:"unique,size_is=EntriesRead"`
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_DOMAIN_DISPLAY_USER.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_DOMAIN_DISPLAY_USER.go
@@ -1,0 +1,17 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// SAMPR_DOMAIN_DISPLAY_USER holds a single user entry returned by a display query
+// ([MS-SAMR] 2.2.8.2).
+type SAMPR_DOMAIN_DISPLAY_USER struct {
+	Index          ndr.DWORD
+	Rid            ndr.DWORD
+	AccountControl ndr.DWORD
+	AccountName    dtyp.RPC_UNICODE_STRING
+	AdminComment   dtyp.RPC_UNICODE_STRING
+	FullName       dtyp.RPC_UNICODE_STRING
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_DOMAIN_DISPLAY_USER_BUFFER.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_DOMAIN_DISPLAY_USER_BUFFER.go
@@ -1,0 +1,13 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// SAMPR_DOMAIN_DISPLAY_USER_BUFFER is the result buffer of a user display query
+// ([MS-SAMR] 2.2.8.7). Buffer is a [unique] pointer to a conformant array sized by
+// EntriesRead.
+type SAMPR_DOMAIN_DISPLAY_USER_BUFFER struct {
+	EntriesRead ndr.DWORD
+	Buffer      []SAMPR_DOMAIN_DISPLAY_USER `ndr:"unique,size_is=EntriesRead"`
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_DOMAIN_GENERAL_INFORMATION.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_DOMAIN_GENERAL_INFORMATION.go
@@ -1,0 +1,24 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// SAMPR_DOMAIN_GENERAL_INFORMATION contains general per-domain attributes
+// ([MS-SAMR] 2.2.4.9). DomainServerState and DomainServerRole are transmitted as
+// unsigned long per the IDL (not as the enum types), and ForceLogoff and
+// DomainModifiedCount are OLD_LARGE_INTEGER values defined by the base family.
+type SAMPR_DOMAIN_GENERAL_INFORMATION struct {
+	ForceLogoff              OLD_LARGE_INTEGER
+	OemInformation           dtyp.RPC_UNICODE_STRING
+	DomainName               dtyp.RPC_UNICODE_STRING
+	ReplicaSourceNodeName    dtyp.RPC_UNICODE_STRING
+	DomainModifiedCount      OLD_LARGE_INTEGER
+	DomainServerState        ndr.DWORD
+	DomainServerRole         ndr.DWORD
+	UasCompatibilityRequired uint8
+	UserCount                ndr.DWORD
+	GroupCount               ndr.DWORD
+	AliasCount               ndr.DWORD
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_DOMAIN_GENERAL_INFORMATION2.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_DOMAIN_GENERAL_INFORMATION2.go
@@ -1,0 +1,15 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+)
+
+// SAMPR_DOMAIN_GENERAL_INFORMATION2 extends SAMPR_DOMAIN_GENERAL_INFORMATION with
+// account-lockout policy ([MS-SAMR] 2.2.4.10). LockoutDuration and
+// LockoutObservationWindow are LARGE_INTEGER values from [MS-DTYP].
+type SAMPR_DOMAIN_GENERAL_INFORMATION2 struct {
+	I1                       SAMPR_DOMAIN_GENERAL_INFORMATION
+	LockoutDuration          dtyp.LARGE_INTEGER
+	LockoutObservationWindow dtyp.LARGE_INTEGER
+	LockoutThreshold         uint16
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_DOMAIN_INFO_BUFFER.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_DOMAIN_INFO_BUFFER.go
@@ -1,0 +1,21 @@
+package structures
+
+// SAMPR_DOMAIN_INFO_BUFFER is the discriminated union of domain information classes
+// ([MS-SAMR] 2.2.4.17). The discriminant Tag is a DOMAIN_INFORMATION_CLASS; the wire
+// form is the discriminant followed by the single selected arm ([C706] section 14.3.8).
+// The numeric case values follow the DOMAIN_INFORMATION_CLASS enum.
+type SAMPR_DOMAIN_INFO_BUFFER struct {
+	Tag         DOMAIN_INFORMATION_CLASS             `ndr:"switch"`
+	Password    DOMAIN_PASSWORD_INFORMATION          `ndr:"case=1"`
+	General     SAMPR_DOMAIN_GENERAL_INFORMATION     `ndr:"case=2"`
+	Logoff      DOMAIN_LOGOFF_INFORMATION            `ndr:"case=3"`
+	Oem         SAMPR_DOMAIN_OEM_INFORMATION         `ndr:"case=4"`
+	Name        SAMPR_DOMAIN_NAME_INFORMATION        `ndr:"case=5"`
+	Replication SAMPR_DOMAIN_REPLICATION_INFORMATION `ndr:"case=6"`
+	Role        DOMAIN_SERVER_ROLE_INFORMATION       `ndr:"case=7"`
+	Modified    DOMAIN_MODIFIED_INFORMATION          `ndr:"case=8"`
+	State       DOMAIN_STATE_INFORMATION             `ndr:"case=9"`
+	General2    SAMPR_DOMAIN_GENERAL_INFORMATION2    `ndr:"case=11"`
+	Lockout     SAMPR_DOMAIN_LOCKOUT_INFORMATION     `ndr:"case=12"`
+	Modified2   DOMAIN_MODIFIED_INFORMATION2         `ndr:"case=13"`
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_DOMAIN_LOCKOUT_INFORMATION.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_DOMAIN_LOCKOUT_INFORMATION.go
@@ -1,0 +1,14 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+)
+
+// SAMPR_DOMAIN_LOCKOUT_INFORMATION contains a domain's account-lockout policy
+// ([MS-SAMR] 2.2.4.14). LockoutDuration and LockoutObservationWindow are LARGE_INTEGER
+// values from [MS-DTYP].
+type SAMPR_DOMAIN_LOCKOUT_INFORMATION struct {
+	LockoutDuration          dtyp.LARGE_INTEGER
+	LockoutObservationWindow dtyp.LARGE_INTEGER
+	LockoutThreshold         uint16
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_DOMAIN_NAME_INFORMATION.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_DOMAIN_NAME_INFORMATION.go
@@ -1,0 +1,10 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+)
+
+// SAMPR_DOMAIN_NAME_INFORMATION contains the name of a domain ([MS-SAMR] 2.2.4.12).
+type SAMPR_DOMAIN_NAME_INFORMATION struct {
+	DomainName dtyp.RPC_UNICODE_STRING
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_DOMAIN_OEM_INFORMATION.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_DOMAIN_OEM_INFORMATION.go
@@ -1,0 +1,11 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+)
+
+// SAMPR_DOMAIN_OEM_INFORMATION contains the OEM-defined comment string for a domain
+// ([MS-SAMR] 2.2.4.11).
+type SAMPR_DOMAIN_OEM_INFORMATION struct {
+	OemInformation dtyp.RPC_UNICODE_STRING
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_DOMAIN_REPLICATION_INFORMATION.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_DOMAIN_REPLICATION_INFORMATION.go
@@ -1,0 +1,11 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+)
+
+// SAMPR_DOMAIN_REPLICATION_INFORMATION contains the replica source node name for a
+// domain ([MS-SAMR] 2.2.4.13).
+type SAMPR_DOMAIN_REPLICATION_INFORMATION struct {
+	ReplicaSourceNodeName dtyp.RPC_UNICODE_STRING
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_ENCRYPTED_PASSWORD_AES.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_ENCRYPTED_PASSWORD_AES.go
@@ -1,0 +1,17 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// SAMPR_ENCRYPTED_PASSWORD_AES carries an AES-encrypted password along with the
+// authentication data, salt, and key-derivation parameters ([MS-SAMR]
+// 2.2.6.32). Cipher is a [unique] pointer to a conformant array of CbCipher
+// bytes.
+type SAMPR_ENCRYPTED_PASSWORD_AES struct {
+	AuthData         [64]byte
+	Salt             [16]byte
+	CbCipher         ndr.DWORD
+	Cipher           []byte `ndr:"unique,size_is=CbCipher"`
+	PBKDF2Iterations uint64
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_ENCRYPTED_USER_PASSWORD.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_ENCRYPTED_USER_PASSWORD.go
@@ -1,0 +1,7 @@
+package structures
+
+// SAMPR_ENCRYPTED_USER_PASSWORD carries an encrypted SAMPR_USER_PASSWORD
+// ([MS-SAMR] 2.2.6.21). Buffer is a fixed (256*2)+4 = 516-byte array.
+type SAMPR_ENCRYPTED_USER_PASSWORD struct {
+	Buffer [516]byte
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_ENCRYPTED_USER_PASSWORD_NEW.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_ENCRYPTED_USER_PASSWORD_NEW.go
@@ -1,0 +1,8 @@
+package structures
+
+// SAMPR_ENCRYPTED_USER_PASSWORD_NEW carries an encrypted
+// SAMPR_USER_PASSWORD_NEW ([MS-SAMR] 2.2.6.22). Buffer is a fixed
+// (256*2)+4+16 = 532-byte array.
+type SAMPR_ENCRYPTED_USER_PASSWORD_NEW struct {
+	Buffer [532]byte
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_ENUMERATION_BUFFER.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_ENUMERATION_BUFFER.go
@@ -1,0 +1,13 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// SAMPR_ENUMERATION_BUFFER holds the result of an enumeration ([MS-SAMR]
+// 2.2.3.5). Buffer is a [unique] pointer to a conformant array of
+// SAMPR_RID_ENUMERATION sized by EntriesRead.
+type SAMPR_ENUMERATION_BUFFER struct {
+	EntriesRead ndr.DWORD
+	Buffer      []SAMPR_RID_ENUMERATION `ndr:"unique,size_is=EntriesRead"`
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_GET_GROUPS_BUFFER.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_GET_GROUPS_BUFFER.go
@@ -1,0 +1,13 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// SAMPR_GET_GROUPS_BUFFER holds the groups a user belongs to ([MS-SAMR]
+// 2.2.7.10). Groups is a [unique] pointer to a conformant array of
+// GROUP_MEMBERSHIP sized by MembershipCount.
+type SAMPR_GET_GROUPS_BUFFER struct {
+	MembershipCount ndr.DWORD
+	Groups          []GROUP_MEMBERSHIP `ndr:"unique,size_is=MembershipCount"`
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_GET_MEMBERS_BUFFER.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_GET_MEMBERS_BUFFER.go
@@ -1,0 +1,14 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// SAMPR_GET_MEMBERS_BUFFER holds the members of a group ([MS-SAMR] 2.2.7.11).
+// Members and Attributes are [unique] pointers to conformant arrays, each sized
+// by MemberCount.
+type SAMPR_GET_MEMBERS_BUFFER struct {
+	MemberCount ndr.DWORD
+	Members     []ndr.DWORD `ndr:"unique,size_is=MemberCount"`
+	Attributes  []ndr.DWORD `ndr:"unique,size_is=MemberCount"`
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_GROUP_ADM_COMMENT_INFORMATION.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_GROUP_ADM_COMMENT_INFORMATION.go
@@ -1,0 +1,11 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+)
+
+// SAMPR_GROUP_ADM_COMMENT_INFORMATION contains group fields ([MS-SAMR] 2.2.5.7). It holds
+// the group's administrative comment.
+type SAMPR_GROUP_ADM_COMMENT_INFORMATION struct {
+	AdminComment dtyp.RPC_UNICODE_STRING
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_GROUP_GENERAL_INFORMATION.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_GROUP_GENERAL_INFORMATION.go
@@ -1,0 +1,15 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// SAMPR_GROUP_GENERAL_INFORMATION contains group fields ([MS-SAMR] 2.2.5.5). It holds the
+// group's name, attributes, member count, and administrative comment.
+type SAMPR_GROUP_GENERAL_INFORMATION struct {
+	Name         dtyp.RPC_UNICODE_STRING
+	Attributes   ndr.DWORD
+	MemberCount  ndr.DWORD
+	AdminComment dtyp.RPC_UNICODE_STRING
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_GROUP_INFO_BUFFER.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_GROUP_INFO_BUFFER.go
@@ -1,0 +1,16 @@
+package structures
+
+// SAMPR_GROUP_INFO_BUFFER is the discriminated union of group information classes
+// ([MS-SAMR] 2.2.5.9). The discriminant is a GROUP_INFORMATION_CLASS; the wire form is the
+// discriminant followed by the single selected arm ([C706] section 14.3.8).
+//
+// The DoNotUse arm (case GroupReplicationInformation=5) reuses the
+// SAMPR_GROUP_GENERAL_INFORMATION type, as specified in the IDL.
+type SAMPR_GROUP_INFO_BUFFER struct {
+	Tag          GROUP_INFORMATION_CLASS             `ndr:"switch"`
+	General      SAMPR_GROUP_GENERAL_INFORMATION     `ndr:"case=1"`
+	Name         SAMPR_GROUP_NAME_INFORMATION        `ndr:"case=2"`
+	Attribute    GROUP_ATTRIBUTE_INFORMATION         `ndr:"case=3"`
+	AdminComment SAMPR_GROUP_ADM_COMMENT_INFORMATION `ndr:"case=4"`
+	DoNotUse     SAMPR_GROUP_GENERAL_INFORMATION     `ndr:"case=5"`
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_GROUP_NAME_INFORMATION.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_GROUP_NAME_INFORMATION.go
@@ -1,0 +1,11 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+)
+
+// SAMPR_GROUP_NAME_INFORMATION contains group fields ([MS-SAMR] 2.2.5.6). It holds the
+// group's name.
+type SAMPR_GROUP_NAME_INFORMATION struct {
+	Name dtyp.RPC_UNICODE_STRING
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_HANDLE.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_HANDLE.go
@@ -1,0 +1,16 @@
+package structures
+
+// SAMPR_HANDLE is an RPC context handle ([MS-SAMR] 2.2.3.2): a 4-byte attributes
+// field followed by a 16-byte GUID, 20 bytes total ([MS-RPCE] 2.3.2.2).
+type SAMPR_HANDLE [20]byte
+
+// IsZero reports whether the handle is all zeros (for example, after a successful
+// SamrCloseHandle).
+func (h SAMPR_HANDLE) IsZero() bool {
+	for _, b := range h {
+		if b != 0 {
+			return false
+		}
+	}
+	return true
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_LOGON_HOURS.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_LOGON_HOURS.go
@@ -1,0 +1,16 @@
+package structures
+
+// SAMPR_LOGON_HOURS holds a bit map of allowed logon hours ([MS-SAMR]
+// 2.2.6.5).
+//
+// The IDL declares LogonHours as
+// [size_is(1260), length_is((UnitsPerWeek+7)/8)] unsigned char*, i.e. a
+// [unique] pointer to a conformant-varying byte array. It is modeled here as
+// unique,varying because the codec derives both the maximum and actual counts
+// from the slice length, which decodes correctly. The literal maximum of 1260
+// bytes from the IDL is NOT enforced by this model; callers must keep
+// LogonHours within that bound.
+type SAMPR_LOGON_HOURS struct {
+	UnitsPerWeek uint16
+	LogonHours   []byte `ndr:"unique,varying"`
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_PSID_ARRAY.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_PSID_ARRAY.go
@@ -1,0 +1,13 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// SAMPR_PSID_ARRAY is a counted array of SID pointers ([MS-SAMR] 2.2.7.5).
+// Sids is a [unique] pointer to a conformant array of SAMPR_SID_INFORMATION
+// sized by Count.
+type SAMPR_PSID_ARRAY struct {
+	Count ndr.DWORD
+	Sids  []SAMPR_SID_INFORMATION `ndr:"unique,size_is=Count"`
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_PSID_ARRAY_OUT.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_PSID_ARRAY_OUT.go
@@ -1,0 +1,13 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// SAMPR_PSID_ARRAY_OUT is a counted array of SID pointers used as an [out]
+// parameter ([MS-SAMR] 2.2.7.6). Sids is a [unique] pointer to a conformant
+// array of SAMPR_SID_INFORMATION sized by Count.
+type SAMPR_PSID_ARRAY_OUT struct {
+	Count ndr.DWORD
+	Sids  []SAMPR_SID_INFORMATION `ndr:"unique,size_is=Count"`
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_RETURNED_USTRING_ARRAY.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_RETURNED_USTRING_ARRAY.go
@@ -1,0 +1,14 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// SAMPR_RETURNED_USTRING_ARRAY is a counted array of RPC_UNICODE_STRING values
+// ([MS-SAMR] 2.2.3.9). Element is a [unique] pointer to a conformant array sized
+// by Count.
+type SAMPR_RETURNED_USTRING_ARRAY struct {
+	Count   ndr.DWORD
+	Element []dtyp.RPC_UNICODE_STRING `ndr:"unique,size_is=Count"`
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_REVISION_INFO.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_REVISION_INFO.go
@@ -1,0 +1,12 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// SAMPR_REVISION_INFO is a switch_type(unsigned long) union with a single
+// defined arm ([MS-SAMR] 2.2.7.14). Tag is the discriminant carried inline.
+type SAMPR_REVISION_INFO struct {
+	Tag ndr.DWORD              `ndr:"switch"`
+	V1  SAMPR_REVISION_INFO_V1 `ndr:"case=1"`
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_REVISION_INFO_V1.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_REVISION_INFO_V1.go
@@ -1,0 +1,12 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// SAMPR_REVISION_INFO_V1 carries the client/server revision and supported
+// feature flags ([MS-SAMR] 2.2.7.13).
+type SAMPR_REVISION_INFO_V1 struct {
+	Revision          ndr.DWORD
+	SupportedFeatures ndr.DWORD
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_RID_ENUMERATION.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_RID_ENUMERATION.go
@@ -1,0 +1,13 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// SAMPR_RID_ENUMERATION pairs a relative ID with the principal's name
+// ([MS-SAMR] 2.2.3.4).
+type SAMPR_RID_ENUMERATION struct {
+	RelativeId ndr.DWORD
+	Name       dtyp.RPC_UNICODE_STRING
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_SID_INFORMATION.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_SID_INFORMATION.go
@@ -1,0 +1,11 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+)
+
+// SAMPR_SID_INFORMATION holds a single SID pointer ([MS-SAMR] 2.2.7.4).
+// SidPointer is a [unique] pointer to an RPC_SID.
+type SAMPR_SID_INFORMATION struct {
+	SidPointer *dtyp.RPC_SID `ndr:"unique"`
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_SR_SECURITY_DESCRIPTOR.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_SR_SECURITY_DESCRIPTOR.go
@@ -1,0 +1,13 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// SAMPR_SR_SECURITY_DESCRIPTOR holds a self-relative security descriptor
+// ([MS-SAMR] 2.2.3.12). SecurityDescriptor is a [unique] pointer to a conformant
+// array of bytes sized by Length.
+type SAMPR_SR_SECURITY_DESCRIPTOR struct {
+	Length             ndr.DWORD
+	SecurityDescriptor []byte `ndr:"unique,size_is=Length"`
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_ULONG_ARRAY.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_ULONG_ARRAY.go
@@ -1,0 +1,12 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// SAMPR_ULONG_ARRAY is a counted array of unsigned longs ([MS-SAMR] 2.2.3.8).
+// Element is a [unique] pointer to a conformant array sized by Count.
+type SAMPR_ULONG_ARRAY struct {
+	Count   ndr.DWORD
+	Element []ndr.DWORD `ndr:"unique,size_is=Count"`
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_USER_ACCOUNT_INFORMATION.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_USER_ACCOUNT_INFORMATION.go
@@ -1,0 +1,29 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// SAMPR_USER_ACCOUNT_INFORMATION holds account-related user attributes
+// ([MS-SAMR] 2.2.6.11).
+type SAMPR_USER_ACCOUNT_INFORMATION struct {
+	UserName           dtyp.RPC_UNICODE_STRING
+	FullName           dtyp.RPC_UNICODE_STRING
+	UserId             ndr.DWORD
+	PrimaryGroupId     ndr.DWORD
+	HomeDirectory      dtyp.RPC_UNICODE_STRING
+	HomeDirectoryDrive dtyp.RPC_UNICODE_STRING
+	ScriptPath         dtyp.RPC_UNICODE_STRING
+	ProfilePath        dtyp.RPC_UNICODE_STRING
+	AdminComment       dtyp.RPC_UNICODE_STRING
+	WorkStations       dtyp.RPC_UNICODE_STRING
+	LastLogon          OLD_LARGE_INTEGER
+	LastLogoff         OLD_LARGE_INTEGER
+	LogonHours         SAMPR_LOGON_HOURS
+	BadPasswordCount   uint16
+	LogonCount         uint16
+	PasswordLastSet    OLD_LARGE_INTEGER
+	AccountExpires     OLD_LARGE_INTEGER
+	UserAccountControl ndr.DWORD
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_USER_ADMIN_COMMENT_INFORMATION.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_USER_ADMIN_COMMENT_INFORMATION.go
@@ -1,0 +1,11 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+)
+
+// SAMPR_USER_ADMIN_COMMENT_INFORMATION holds a user's administrative comment
+// ([MS-SAMR] 2.2.6, AdminCommentInformation).
+type SAMPR_USER_ADMIN_COMMENT_INFORMATION struct {
+	AdminComment dtyp.RPC_UNICODE_STRING
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_USER_ALL_INFORMATION.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_USER_ALL_INFORMATION.go
@@ -1,0 +1,45 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// SAMPR_USER_ALL_INFORMATION holds the full set of attributes for a user
+// account ([MS-SAMR] 2.2.6.6). The WhichFields bit map indicates which fields
+// are valid. LmOwfPassword and NtOwfPassword are carried as RPC_SHORT_BLOB.
+type SAMPR_USER_ALL_INFORMATION struct {
+	LastLogon            OLD_LARGE_INTEGER
+	LastLogoff           OLD_LARGE_INTEGER
+	PasswordLastSet      OLD_LARGE_INTEGER
+	AccountExpires       OLD_LARGE_INTEGER
+	PasswordCanChange    OLD_LARGE_INTEGER
+	PasswordMustChange   OLD_LARGE_INTEGER
+	UserName             dtyp.RPC_UNICODE_STRING
+	FullName             dtyp.RPC_UNICODE_STRING
+	HomeDirectory        dtyp.RPC_UNICODE_STRING
+	HomeDirectoryDrive   dtyp.RPC_UNICODE_STRING
+	ScriptPath           dtyp.RPC_UNICODE_STRING
+	ProfilePath          dtyp.RPC_UNICODE_STRING
+	AdminComment         dtyp.RPC_UNICODE_STRING
+	WorkStations         dtyp.RPC_UNICODE_STRING
+	UserComment          dtyp.RPC_UNICODE_STRING
+	Parameters           dtyp.RPC_UNICODE_STRING
+	LmOwfPassword        RPC_SHORT_BLOB
+	NtOwfPassword        RPC_SHORT_BLOB
+	PrivateData          dtyp.RPC_UNICODE_STRING
+	SecurityDescriptor   SAMPR_SR_SECURITY_DESCRIPTOR
+	UserId               ndr.DWORD
+	PrimaryGroupId       ndr.DWORD
+	UserAccountControl   ndr.DWORD
+	WhichFields          ndr.DWORD
+	LogonHours           SAMPR_LOGON_HOURS
+	BadPasswordCount     uint16
+	LogonCount           uint16
+	CountryCode          uint16
+	CodePage             uint16
+	LmPasswordPresent    uint8
+	NtPasswordPresent    uint8
+	PasswordExpired      uint8
+	PrivateDataSensitive uint8
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_USER_A_NAME_INFORMATION.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_USER_A_NAME_INFORMATION.go
@@ -1,0 +1,11 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+)
+
+// SAMPR_USER_A_NAME_INFORMATION holds a user's account name ([MS-SAMR]
+// 2.2.6.18).
+type SAMPR_USER_A_NAME_INFORMATION struct {
+	UserName dtyp.RPC_UNICODE_STRING
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_USER_F_NAME_INFORMATION.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_USER_F_NAME_INFORMATION.go
@@ -1,0 +1,11 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+)
+
+// SAMPR_USER_F_NAME_INFORMATION holds a user's full name ([MS-SAMR]
+// 2.2.6.19).
+type SAMPR_USER_F_NAME_INFORMATION struct {
+	FullName dtyp.RPC_UNICODE_STRING
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_USER_GENERAL_INFORMATION.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_USER_GENERAL_INFORMATION.go
@@ -1,0 +1,16 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// SAMPR_USER_GENERAL_INFORMATION holds general user attributes ([MS-SAMR]
+// 2.2.6.7).
+type SAMPR_USER_GENERAL_INFORMATION struct {
+	UserName       dtyp.RPC_UNICODE_STRING
+	FullName       dtyp.RPC_UNICODE_STRING
+	PrimaryGroupId ndr.DWORD
+	AdminComment   dtyp.RPC_UNICODE_STRING
+	UserComment    dtyp.RPC_UNICODE_STRING
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_USER_HOME_INFORMATION.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_USER_HOME_INFORMATION.go
@@ -1,0 +1,12 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+)
+
+// SAMPR_USER_HOME_INFORMATION holds a user's home directory and drive
+// ([MS-SAMR] 2.2.6.22, HomeInformation).
+type SAMPR_USER_HOME_INFORMATION struct {
+	HomeDirectory      dtyp.RPC_UNICODE_STRING
+	HomeDirectoryDrive dtyp.RPC_UNICODE_STRING
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_USER_INFO_BUFFER.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_USER_INFO_BUFFER.go
@@ -1,0 +1,34 @@
+package structures
+
+// SAMPR_USER_INFO_BUFFER is the union of all user information structures,
+// discriminated by a USER_INFORMATION_CLASS ([MS-SAMR] 2.2.6.29). Tag carries
+// the discriminant inline; exactly one arm is valid per the selected case.
+type SAMPR_USER_INFO_BUFFER struct {
+	Tag USER_INFORMATION_CLASS `ndr:"switch"`
+
+	General      SAMPR_USER_GENERAL_INFORMATION       `ndr:"case=1"`
+	Preferences  SAMPR_USER_PREFERENCES_INFORMATION   `ndr:"case=2"`
+	Logon        SAMPR_USER_LOGON_INFORMATION         `ndr:"case=3"`
+	LogonHours   SAMPR_USER_LOGON_HOURS_INFORMATION   `ndr:"case=4"`
+	Account      SAMPR_USER_ACCOUNT_INFORMATION       `ndr:"case=5"`
+	Name         SAMPR_USER_NAME_INFORMATION          `ndr:"case=6"`
+	AccountName  SAMPR_USER_A_NAME_INFORMATION        `ndr:"case=7"`
+	FullName     SAMPR_USER_F_NAME_INFORMATION        `ndr:"case=8"`
+	PrimaryGroup USER_PRIMARY_GROUP_INFORMATION       `ndr:"case=9"`
+	Home         SAMPR_USER_HOME_INFORMATION          `ndr:"case=10"`
+	Script       SAMPR_USER_SCRIPT_INFORMATION        `ndr:"case=11"`
+	Profile      SAMPR_USER_PROFILE_INFORMATION       `ndr:"case=12"`
+	AdminComment SAMPR_USER_ADMIN_COMMENT_INFORMATION `ndr:"case=13"`
+	WorkStations SAMPR_USER_WORKSTATIONS_INFORMATION  `ndr:"case=14"`
+	Control      USER_CONTROL_INFORMATION             `ndr:"case=16"`
+	Expires      USER_EXPIRES_INFORMATION             `ndr:"case=17"`
+	Internal1    SAMPR_USER_INTERNAL1_INFORMATION     `ndr:"case=18"`
+	Parameters   SAMPR_USER_PARAMETERS_INFORMATION    `ndr:"case=20"`
+	All          SAMPR_USER_ALL_INFORMATION           `ndr:"case=21"`
+	Internal4    SAMPR_USER_INTERNAL4_INFORMATION     `ndr:"case=23"`
+	Internal5    SAMPR_USER_INTERNAL5_INFORMATION     `ndr:"case=24"`
+	Internal4New SAMPR_USER_INTERNAL4_INFORMATION_NEW `ndr:"case=25"`
+	Internal5New SAMPR_USER_INTERNAL5_INFORMATION_NEW `ndr:"case=26"`
+	Internal7    SAMPR_USER_INTERNAL7_INFORMATION     `ndr:"case=31"`
+	Internal8    SAMPR_USER_INTERNAL8_INFORMATION     `ndr:"case=32"`
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_USER_INTERNAL1_INFORMATION.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_USER_INTERNAL1_INFORMATION.go
@@ -1,0 +1,11 @@
+package structures
+
+// SAMPR_USER_INTERNAL1_INFORMATION carries encrypted NT/LM OWF password hashes
+// and presence flags ([MS-SAMR] 2.2.6.24).
+type SAMPR_USER_INTERNAL1_INFORMATION struct {
+	EncryptedNtOwfPassword ENCRYPTED_NT_OWF_PASSWORD
+	EncryptedLmOwfPassword ENCRYPTED_LM_OWF_PASSWORD
+	NtPasswordPresent      uint8
+	LmPasswordPresent      uint8
+	PasswordExpired        uint8
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_USER_INTERNAL4_INFORMATION.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_USER_INTERNAL4_INFORMATION.go
@@ -1,0 +1,8 @@
+package structures
+
+// SAMPR_USER_INTERNAL4_INFORMATION carries the full user attribute set plus an
+// encrypted password ([MS-SAMR] 2.2.6.25).
+type SAMPR_USER_INTERNAL4_INFORMATION struct {
+	I1           SAMPR_USER_ALL_INFORMATION
+	UserPassword SAMPR_ENCRYPTED_USER_PASSWORD
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_USER_INTERNAL4_INFORMATION_NEW.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_USER_INTERNAL4_INFORMATION_NEW.go
@@ -1,0 +1,8 @@
+package structures
+
+// SAMPR_USER_INTERNAL4_INFORMATION_NEW carries the full user attribute set plus
+// an encrypted password with salt ([MS-SAMR] 2.2.6.27).
+type SAMPR_USER_INTERNAL4_INFORMATION_NEW struct {
+	I1           SAMPR_USER_ALL_INFORMATION
+	UserPassword SAMPR_ENCRYPTED_USER_PASSWORD_NEW
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_USER_INTERNAL5_INFORMATION.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_USER_INTERNAL5_INFORMATION.go
@@ -1,0 +1,8 @@
+package structures
+
+// SAMPR_USER_INTERNAL5_INFORMATION carries an encrypted password and an
+// expiration flag ([MS-SAMR] 2.2.6.26).
+type SAMPR_USER_INTERNAL5_INFORMATION struct {
+	UserPassword    SAMPR_ENCRYPTED_USER_PASSWORD
+	PasswordExpired uint8
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_USER_INTERNAL5_INFORMATION_NEW.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_USER_INTERNAL5_INFORMATION_NEW.go
@@ -1,0 +1,8 @@
+package structures
+
+// SAMPR_USER_INTERNAL5_INFORMATION_NEW carries an encrypted password with salt
+// and an expiration flag ([MS-SAMR] 2.2.6.28).
+type SAMPR_USER_INTERNAL5_INFORMATION_NEW struct {
+	UserPassword    SAMPR_ENCRYPTED_USER_PASSWORD_NEW
+	PasswordExpired uint8
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_USER_INTERNAL7_INFORMATION.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_USER_INTERNAL7_INFORMATION.go
@@ -1,0 +1,8 @@
+package structures
+
+// SAMPR_USER_INTERNAL7_INFORMATION carries an AES-encrypted password and an
+// expiration flag ([MS-SAMR] 2.2.6.30).
+type SAMPR_USER_INTERNAL7_INFORMATION struct {
+	UserPassword    SAMPR_ENCRYPTED_PASSWORD_AES
+	PasswordExpired bool
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_USER_INTERNAL8_INFORMATION.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_USER_INTERNAL8_INFORMATION.go
@@ -1,0 +1,8 @@
+package structures
+
+// SAMPR_USER_INTERNAL8_INFORMATION carries the full user attribute set plus an
+// AES-encrypted password ([MS-SAMR] 2.2.6.31).
+type SAMPR_USER_INTERNAL8_INFORMATION struct {
+	I1           SAMPR_USER_ALL_INFORMATION
+	UserPassword SAMPR_ENCRYPTED_PASSWORD_AES
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_USER_LOGON_HOURS_INFORMATION.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_USER_LOGON_HOURS_INFORMATION.go
@@ -1,0 +1,7 @@
+package structures
+
+// SAMPR_USER_LOGON_HOURS_INFORMATION holds a user's allowed logon hours
+// ([MS-SAMR] 2.2.6.16).
+type SAMPR_USER_LOGON_HOURS_INFORMATION struct {
+	LogonHours SAMPR_LOGON_HOURS
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_USER_LOGON_INFORMATION.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_USER_LOGON_INFORMATION.go
@@ -1,0 +1,29 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// SAMPR_USER_LOGON_INFORMATION holds logon-related user attributes ([MS-SAMR]
+// 2.2.6.10).
+type SAMPR_USER_LOGON_INFORMATION struct {
+	UserName           dtyp.RPC_UNICODE_STRING
+	FullName           dtyp.RPC_UNICODE_STRING
+	UserId             ndr.DWORD
+	PrimaryGroupId     ndr.DWORD
+	HomeDirectory      dtyp.RPC_UNICODE_STRING
+	HomeDirectoryDrive dtyp.RPC_UNICODE_STRING
+	ScriptPath         dtyp.RPC_UNICODE_STRING
+	ProfilePath        dtyp.RPC_UNICODE_STRING
+	WorkStations       dtyp.RPC_UNICODE_STRING
+	LastLogon          OLD_LARGE_INTEGER
+	LastLogoff         OLD_LARGE_INTEGER
+	PasswordLastSet    OLD_LARGE_INTEGER
+	PasswordCanChange  OLD_LARGE_INTEGER
+	PasswordMustChange OLD_LARGE_INTEGER
+	LogonHours         SAMPR_LOGON_HOURS
+	BadPasswordCount   uint16
+	LogonCount         uint16
+	UserAccountControl ndr.DWORD
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_USER_NAME_INFORMATION.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_USER_NAME_INFORMATION.go
@@ -1,0 +1,12 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+)
+
+// SAMPR_USER_NAME_INFORMATION holds a user's account name and full name
+// ([MS-SAMR] 2.2.6.17).
+type SAMPR_USER_NAME_INFORMATION struct {
+	UserName dtyp.RPC_UNICODE_STRING
+	FullName dtyp.RPC_UNICODE_STRING
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_USER_PARAMETERS_INFORMATION.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_USER_PARAMETERS_INFORMATION.go
@@ -1,0 +1,11 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+)
+
+// SAMPR_USER_PARAMETERS_INFORMATION holds a user's Parameters attribute
+// ([MS-SAMR] 2.2.6.13).
+type SAMPR_USER_PARAMETERS_INFORMATION struct {
+	Parameters dtyp.RPC_UNICODE_STRING
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_USER_PASSWORD.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_USER_PASSWORD.go
@@ -1,0 +1,13 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// SAMPR_USER_PASSWORD holds a cleartext password and its length ([MS-SAMR]
+// 2.2.6.20). Buffer is a fixed 256-WCHAR array; Length is the number of bytes
+// of password data in Buffer (counted from the end).
+type SAMPR_USER_PASSWORD struct {
+	Buffer [256]uint16
+	Length ndr.DWORD
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_USER_PASSWORD_NEW.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_USER_PASSWORD_NEW.go
@@ -1,0 +1,14 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// SAMPR_USER_PASSWORD_NEW holds a cleartext password, its length, and a salt
+// ([MS-SAMR] 2.2.6.23). Buffer is a fixed 256-WCHAR array; Length is the number
+// of bytes of password data; ClearSalt is a 16-byte salt.
+type SAMPR_USER_PASSWORD_NEW struct {
+	Buffer    [256]uint16
+	Length    ndr.DWORD
+	ClearSalt [16]byte
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_USER_PREFERENCES_INFORMATION.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_USER_PREFERENCES_INFORMATION.go
@@ -1,0 +1,14 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+)
+
+// SAMPR_USER_PREFERENCES_INFORMATION holds user preference attributes
+// ([MS-SAMR] 2.2.6.8).
+type SAMPR_USER_PREFERENCES_INFORMATION struct {
+	UserComment dtyp.RPC_UNICODE_STRING
+	Reserved1   dtyp.RPC_UNICODE_STRING
+	CountryCode uint16
+	CodePage    uint16
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_USER_PROFILE_INFORMATION.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_USER_PROFILE_INFORMATION.go
@@ -1,0 +1,11 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+)
+
+// SAMPR_USER_PROFILE_INFORMATION holds a user's profile path ([MS-SAMR]
+// 2.2.6, ProfileInformation).
+type SAMPR_USER_PROFILE_INFORMATION struct {
+	ProfilePath dtyp.RPC_UNICODE_STRING
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_USER_SCRIPT_INFORMATION.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_USER_SCRIPT_INFORMATION.go
@@ -1,0 +1,11 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+)
+
+// SAMPR_USER_SCRIPT_INFORMATION holds a user's logon script path ([MS-SAMR]
+// 2.2.6, ScriptInformation).
+type SAMPR_USER_SCRIPT_INFORMATION struct {
+	ScriptPath dtyp.RPC_UNICODE_STRING
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_USER_WORKSTATIONS_INFORMATION.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_USER_WORKSTATIONS_INFORMATION.go
@@ -1,0 +1,11 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+)
+
+// SAMPR_USER_WORKSTATIONS_INFORMATION holds the workstations a user may log on
+// from ([MS-SAMR] 2.2.6.12).
+type SAMPR_USER_WORKSTATIONS_INFORMATION struct {
+	WorkStations dtyp.RPC_UNICODE_STRING
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAM_VALIDATE_AUTHENTICATION_INPUT_ARG.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAM_VALIDATE_AUTHENTICATION_INPUT_ARG.go
@@ -1,0 +1,8 @@
+package structures
+
+// SAM_VALIDATE_AUTHENTICATION_INPUT_ARG holds the input for a
+// SamValidateAuthentication password validation request ([MS-SAMR] 2.2.9.6).
+type SAM_VALIDATE_AUTHENTICATION_INPUT_ARG struct {
+	InputPersistedFields SAM_VALIDATE_PERSISTED_FIELDS
+	PasswordMatched      uint8
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAM_VALIDATE_INPUT_ARG.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAM_VALIDATE_INPUT_ARG.go
@@ -1,0 +1,13 @@
+package structures
+
+// SAM_VALIDATE_INPUT_ARG is the discriminated union of password validation input
+// arguments ([MS-SAMR] 2.2.9.9). The switch_type is PASSWORD_POLICY_VALIDATION_TYPE;
+// the wire form is the discriminant followed by the single selected arm
+// ([C706] section 14.3.8). Each arm is a value field for the corresponding
+// validation type.
+type SAM_VALIDATE_INPUT_ARG struct {
+	Tag                         PASSWORD_POLICY_VALIDATION_TYPE        `ndr:"switch"`
+	ValidateAuthenticationInput SAM_VALIDATE_AUTHENTICATION_INPUT_ARG  `ndr:"case=1"`
+	ValidatePasswordChangeInput SAM_VALIDATE_PASSWORD_CHANGE_INPUT_ARG `ndr:"case=2"`
+	ValidatePasswordResetInput  SAM_VALIDATE_PASSWORD_RESET_INPUT_ARG  `ndr:"case=3"`
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAM_VALIDATE_OUTPUT_ARG.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAM_VALIDATE_OUTPUT_ARG.go
@@ -1,0 +1,12 @@
+package structures
+
+// SAM_VALIDATE_OUTPUT_ARG is the discriminated union of password validation output
+// arguments ([MS-SAMR] 2.2.9.10). The switch_type is PASSWORD_POLICY_VALIDATION_TYPE;
+// the wire form is the discriminant followed by the single selected arm
+// ([C706] section 14.3.8). All three arms carry a SAM_VALIDATE_STANDARD_OUTPUT_ARG.
+type SAM_VALIDATE_OUTPUT_ARG struct {
+	Tag                          PASSWORD_POLICY_VALIDATION_TYPE  `ndr:"switch"`
+	ValidateAuthenticationOutput SAM_VALIDATE_STANDARD_OUTPUT_ARG `ndr:"case=1"`
+	ValidatePasswordChangeOutput SAM_VALIDATE_STANDARD_OUTPUT_ARG `ndr:"case=2"`
+	ValidatePasswordResetOutput  SAM_VALIDATE_STANDARD_OUTPUT_ARG `ndr:"case=3"`
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAM_VALIDATE_PASSWORD_CHANGE_INPUT_ARG.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAM_VALIDATE_PASSWORD_CHANGE_INPUT_ARG.go
@@ -1,0 +1,15 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+)
+
+// SAM_VALIDATE_PASSWORD_CHANGE_INPUT_ARG holds the input for a
+// SamValidatePasswordChange password validation request ([MS-SAMR] 2.2.9.7).
+type SAM_VALIDATE_PASSWORD_CHANGE_INPUT_ARG struct {
+	InputPersistedFields SAM_VALIDATE_PERSISTED_FIELDS
+	ClearPassword        dtyp.RPC_UNICODE_STRING
+	UserAccountName      dtyp.RPC_UNICODE_STRING
+	HashedPassword       SAM_VALIDATE_PASSWORD_HASH
+	PasswordMatch        uint8
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAM_VALIDATE_PASSWORD_HASH.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAM_VALIDATE_PASSWORD_HASH.go
@@ -1,0 +1,13 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// SAM_VALIDATE_PASSWORD_HASH holds the hash of a cleartext password
+// ([MS-SAMR] 2.2.9.2). Hash is a [unique] pointer to a conformant array of
+// Length bytes.
+type SAM_VALIDATE_PASSWORD_HASH struct {
+	Length ndr.DWORD
+	Hash   []byte `ndr:"unique,size_is=Length"`
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAM_VALIDATE_PASSWORD_RESET_INPUT_ARG.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAM_VALIDATE_PASSWORD_RESET_INPUT_ARG.go
@@ -1,0 +1,16 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+)
+
+// SAM_VALIDATE_PASSWORD_RESET_INPUT_ARG holds the input for a
+// SamValidatePasswordReset password validation request ([MS-SAMR] 2.2.9.8).
+type SAM_VALIDATE_PASSWORD_RESET_INPUT_ARG struct {
+	InputPersistedFields          SAM_VALIDATE_PERSISTED_FIELDS
+	ClearPassword                 dtyp.RPC_UNICODE_STRING
+	UserAccountName               dtyp.RPC_UNICODE_STRING
+	HashedPassword                SAM_VALIDATE_PASSWORD_HASH
+	PasswordMustChangeAtNextLogon uint8
+	ClearLockout                  uint8
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAM_VALIDATE_PERSISTED_FIELDS.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAM_VALIDATE_PERSISTED_FIELDS.go
@@ -1,0 +1,20 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// SAM_VALIDATE_PERSISTED_FIELDS holds user account properties that the client is
+// expected to persist across calls to SamrValidatePassword ([MS-SAMR] 2.2.9.3).
+// PasswordHistory is a [unique] pointer to a conformant array of
+// PasswordHistoryLength SAM_VALIDATE_PASSWORD_HASH structures.
+type SAM_VALIDATE_PERSISTED_FIELDS struct {
+	PresentFields         ndr.DWORD
+	PasswordLastSet       dtyp.LARGE_INTEGER
+	BadPasswordTime       dtyp.LARGE_INTEGER
+	LockoutTime           dtyp.LARGE_INTEGER
+	BadPasswordCount      ndr.DWORD
+	PasswordHistoryLength ndr.DWORD
+	PasswordHistory       []SAM_VALIDATE_PASSWORD_HASH `ndr:"unique,size_is=PasswordHistoryLength"`
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAM_VALIDATE_STANDARD_OUTPUT_ARG.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAM_VALIDATE_STANDARD_OUTPUT_ARG.go
@@ -1,0 +1,9 @@
+package structures
+
+// SAM_VALIDATE_STANDARD_OUTPUT_ARG is the common output of all
+// SamrValidatePassword operations ([MS-SAMR] 2.2.9.5). It carries the persisted
+// fields that the server has modified and the overall validation status.
+type SAM_VALIDATE_STANDARD_OUTPUT_ARG struct {
+	ChangedPersistedFields SAM_VALIDATE_PERSISTED_FIELDS
+	ValidationStatus       SAM_VALIDATE_VALIDATION_STATUS
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAM_VALIDATE_VALIDATION_STATUS.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAM_VALIDATE_VALIDATION_STATUS.go
@@ -1,0 +1,20 @@
+package structures
+
+// SAM_VALIDATE_VALIDATION_STATUS indicates the result of a password validation
+// operation ([MS-SAMR] 2.2.9.4). As an NDR enum it is transmitted as a 16-bit
+// unsigned value ([C706] section 14.3.6).
+type SAM_VALIDATE_VALIDATION_STATUS uint16
+
+const (
+	SamValidateSuccess                  SAM_VALIDATE_VALIDATION_STATUS = 0
+	SamValidatePasswordMustChange       SAM_VALIDATE_VALIDATION_STATUS = 1
+	SamValidateAccountLockedOut         SAM_VALIDATE_VALIDATION_STATUS = 2
+	SamValidatePasswordExpired          SAM_VALIDATE_VALIDATION_STATUS = 3
+	SamValidatePasswordIncorrect        SAM_VALIDATE_VALIDATION_STATUS = 4
+	SamValidatePasswordIsInHistory      SAM_VALIDATE_VALIDATION_STATUS = 5
+	SamValidatePasswordTooShort         SAM_VALIDATE_VALIDATION_STATUS = 6
+	SamValidatePasswordTooLong          SAM_VALIDATE_VALIDATION_STATUS = 7
+	SamValidatePasswordNotComplexEnough SAM_VALIDATE_VALIDATION_STATUS = 8
+	SamValidatePasswordTooRecent        SAM_VALIDATE_VALIDATION_STATUS = 9
+	SamValidatePasswordFilterError      SAM_VALIDATE_VALIDATION_STATUS = 10
+)

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SID_NAME_USE.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SID_NAME_USE.go
@@ -1,0 +1,19 @@
+package structures
+
+// SID_NAME_USE enumerates the type of a security principal identified by a SID
+// ([MS-SAMR] 2.2.2.3). As an NDR enum it is transmitted as a 16-bit unsigned
+// value ([C706] section 14.3.6).
+type SID_NAME_USE uint16
+
+const (
+	SidTypeUser           SID_NAME_USE = 1
+	SidTypeGroup          SID_NAME_USE = 2
+	SidTypeDomain         SID_NAME_USE = 3
+	SidTypeAlias          SID_NAME_USE = 4
+	SidTypeWellKnownGroup SID_NAME_USE = 5
+	SidTypeDeletedAccount SID_NAME_USE = 6
+	SidTypeInvalid        SID_NAME_USE = 7
+	SidTypeUnknown        SID_NAME_USE = 8
+	SidTypeComputer       SID_NAME_USE = 9
+	SidTypeLabel          SID_NAME_USE = 10
+)

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/USER_CONTROL_INFORMATION.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/USER_CONTROL_INFORMATION.go
@@ -1,0 +1,11 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// USER_CONTROL_INFORMATION holds a user's account control bits ([MS-SAMR]
+// 2.2.6.14).
+type USER_CONTROL_INFORMATION struct {
+	UserAccountControl ndr.DWORD
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/USER_DOMAIN_PASSWORD_INFORMATION.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/USER_DOMAIN_PASSWORD_INFORMATION.go
@@ -1,0 +1,12 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// USER_DOMAIN_PASSWORD_INFORMATION carries domain password policy constraints
+// ([MS-SAMR] 2.2.3.14).
+type USER_DOMAIN_PASSWORD_INFORMATION struct {
+	MinPasswordLength  uint16
+	PasswordProperties ndr.DWORD
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/USER_EXPIRES_INFORMATION.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/USER_EXPIRES_INFORMATION.go
@@ -1,0 +1,7 @@
+package structures
+
+// USER_EXPIRES_INFORMATION holds a user's account-expiration time ([MS-SAMR]
+// 2.2.6.15).
+type USER_EXPIRES_INFORMATION struct {
+	AccountExpires OLD_LARGE_INTEGER
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/USER_INFORMATION_CLASS.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/USER_INFORMATION_CLASS.go
@@ -1,0 +1,35 @@
+package structures
+
+// USER_INFORMATION_CLASS enumerates the user information levels used by the
+// SAMR user query/set methods ([MS-SAMR] 2.2.6.28). NDR enums are 16-bit, so
+// this is modeled as a uint16. The enumeration has gaps (15, 19, 22, 27, 29,
+// 30) that have no defined value.
+type USER_INFORMATION_CLASS uint16
+
+const (
+	UserGeneralInformation      USER_INFORMATION_CLASS = 1
+	UserPreferencesInformation  USER_INFORMATION_CLASS = 2
+	UserLogonInformation        USER_INFORMATION_CLASS = 3
+	UserLogonHoursInformation   USER_INFORMATION_CLASS = 4
+	UserAccountInformation      USER_INFORMATION_CLASS = 5
+	UserNameInformation         USER_INFORMATION_CLASS = 6
+	UserAccountNameInformation  USER_INFORMATION_CLASS = 7
+	UserFullNameInformation     USER_INFORMATION_CLASS = 8
+	UserPrimaryGroupInformation USER_INFORMATION_CLASS = 9
+	UserHomeInformation         USER_INFORMATION_CLASS = 10
+	UserScriptInformation       USER_INFORMATION_CLASS = 11
+	UserProfileInformation      USER_INFORMATION_CLASS = 12
+	UserAdminCommentInformation USER_INFORMATION_CLASS = 13
+	UserWorkStationsInformation USER_INFORMATION_CLASS = 14
+	UserControlInformation      USER_INFORMATION_CLASS = 16
+	UserExpiresInformation      USER_INFORMATION_CLASS = 17
+	UserInternal1Information    USER_INFORMATION_CLASS = 18
+	UserParametersInformation   USER_INFORMATION_CLASS = 20
+	UserAllInformation          USER_INFORMATION_CLASS = 21
+	UserInternal4Information    USER_INFORMATION_CLASS = 23
+	UserInternal5Information    USER_INFORMATION_CLASS = 24
+	UserInternal4InformationNew USER_INFORMATION_CLASS = 25
+	UserInternal5InformationNew USER_INFORMATION_CLASS = 26
+	UserInternal7Information    USER_INFORMATION_CLASS = 31
+	UserInternal8Information    USER_INFORMATION_CLASS = 32
+)

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/USER_PRIMARY_GROUP_INFORMATION.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/USER_PRIMARY_GROUP_INFORMATION.go
@@ -1,0 +1,11 @@
+package structures
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// USER_PRIMARY_GROUP_INFORMATION holds a user's primary group RID ([MS-SAMR]
+// 2.2.6.9).
+type USER_PRIMARY_GROUP_INFORMATION struct {
+	PrimaryGroupId ndr.DWORD
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/base_test.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/base_test.go
@@ -1,0 +1,61 @@
+package structures
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// roundTripBase marshals in, unmarshals into a fresh value of the same type, and
+// asserts the result is deeply equal to in.
+func roundTripBase[T any](t *testing.T, name string, in T) {
+	t.Helper()
+	raw, err := ndr.Marshal(&in)
+	if err != nil {
+		t.Fatalf("%s: Marshal: %v", name, err)
+	}
+	var out T
+	if err := ndr.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("%s: Unmarshal: %v", name, err)
+	}
+	if !reflect.DeepEqual(in, out) {
+		t.Errorf("%s: round trip mismatch:\n in:  %+v\n out: %+v", name, in, out)
+	}
+}
+
+func mustBaseSID(t *testing.T, s string) *dtyp.RPC_SID {
+	t.Helper()
+	sid, err := dtyp.ParseSID(s)
+	if err != nil {
+		t.Fatalf("ParseSID(%q): %v", s, err)
+	}
+	return &sid
+}
+
+// TestSAMPR_ENUMERATION_BUFFER_RoundTrip exercises a [unique] pointer to a
+// conformant array of structs that each embed an RPC_UNICODE_STRING.
+func TestSAMPR_ENUMERATION_BUFFER_RoundTrip(t *testing.T) {
+	in := SAMPR_ENUMERATION_BUFFER{
+		EntriesRead: 2,
+		Buffer: []SAMPR_RID_ENUMERATION{
+			{RelativeId: 500, Name: dtyp.NewUnicodeString("Administrator")},
+			{RelativeId: 501, Name: dtyp.NewUnicodeString("Guest")},
+		},
+	}
+	roundTripBase(t, "SAMPR_ENUMERATION_BUFFER", in)
+}
+
+// TestSAMPR_PSID_ARRAY_RoundTrip exercises a [unique] pointer to a conformant
+// array of structs that each hold a [unique] pointer to an RPC_SID.
+func TestSAMPR_PSID_ARRAY_RoundTrip(t *testing.T) {
+	in := SAMPR_PSID_ARRAY{
+		Count: 2,
+		Sids: []SAMPR_SID_INFORMATION{
+			{SidPointer: mustBaseSID(t, "S-1-5-21-1004336348-1177238915-682003330-512")},
+			{SidPointer: mustBaseSID(t, "S-1-5-18")},
+		},
+	}
+	roundTripBase(t, "SAMPR_PSID_ARRAY", in)
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/domain_test.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/domain_test.go
@@ -1,0 +1,72 @@
+package structures
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// TestSAMPR_DOMAIN_INFO_BUFFER_RoundTrip marshals and unmarshals a
+// SAMPR_DOMAIN_INFO_BUFFER selecting the DomainNameInformation (5) arm and checks the
+// recovered value matches the original.
+func TestSAMPR_DOMAIN_INFO_BUFFER_RoundTrip(t *testing.T) {
+	in := SAMPR_DOMAIN_INFO_BUFFER{
+		Tag: DomainNameInformation,
+		Name: SAMPR_DOMAIN_NAME_INFORMATION{
+			DomainName: dtyp.NewUnicodeString("CONTOSO"),
+		},
+	}
+
+	raw, err := ndr.Marshal(&in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	var out SAMPR_DOMAIN_INFO_BUFFER
+	if err := ndr.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	if out.Tag != DomainNameInformation {
+		t.Fatalf("Tag = %d, want %d", out.Tag, DomainNameInformation)
+	}
+	if got := out.Name.DomainName.String(); got != "CONTOSO" {
+		t.Fatalf("DomainName = %q, want %q", got, "CONTOSO")
+	}
+}
+
+// TestSAMPR_DISPLAY_INFO_BUFFER_RoundTrip marshals and unmarshals a
+// SAMPR_DISPLAY_INFO_BUFFER selecting the DomainDisplayUser (1) arm with an empty user
+// buffer and checks the recovered value matches the original.
+func TestSAMPR_DISPLAY_INFO_BUFFER_RoundTrip(t *testing.T) {
+	in := SAMPR_DISPLAY_INFO_BUFFER{
+		Tag: DomainDisplayUser,
+		UserInformation: SAMPR_DOMAIN_DISPLAY_USER_BUFFER{
+			EntriesRead: 0,
+			Buffer:      nil,
+		},
+	}
+
+	raw, err := ndr.Marshal(&in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	var out SAMPR_DISPLAY_INFO_BUFFER
+	if err := ndr.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	if out.Tag != DomainDisplayUser {
+		t.Fatalf("Tag = %d, want %d", out.Tag, DomainDisplayUser)
+	}
+	if out.UserInformation.EntriesRead != 0 {
+		t.Fatalf("EntriesRead = %d, want 0", out.UserInformation.EntriesRead)
+	}
+	if len(out.UserInformation.Buffer) != 0 {
+		t.Fatalf("Buffer len = %d, want 0", len(out.UserInformation.Buffer))
+	}
+	_ = reflect.DeepEqual(in, out)
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/group_alias_test.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/group_alias_test.go
@@ -1,0 +1,52 @@
+package structures
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// groupAliasRoundTrip marshals in, unmarshals into a fresh T, and asserts equality.
+func groupAliasRoundTrip[T any](t *testing.T, name string, in T) {
+	t.Helper()
+
+	raw, err := ndr.Marshal(in)
+	if err != nil {
+		t.Fatalf("%s: Marshal: %v", name, err)
+	}
+
+	var out T
+	if err := ndr.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("%s: Unmarshal: %v", name, err)
+	}
+
+	if !reflect.DeepEqual(in, out) {
+		t.Fatalf("%s: round-trip mismatch\n in: %#v\nout: %#v", name, in, out)
+	}
+}
+
+// TestSAMPR_GROUP_INFO_BUFFER_RoundTrip exercises the group-information union with the
+// GroupNameInformation arm (case 2) selected.
+func TestSAMPR_GROUP_INFO_BUFFER_RoundTrip(t *testing.T) {
+	groupAliasRoundTrip(t, "GroupNameInformation(case2)", SAMPR_GROUP_INFO_BUFFER{
+		Tag: GroupNameInformation,
+		Name: SAMPR_GROUP_NAME_INFORMATION{
+			Name: dtyp.NewUnicodeString("Domain Admins"),
+		},
+	})
+}
+
+// TestSAMPR_ALIAS_INFO_BUFFER_RoundTrip exercises the alias-information union with the
+// AliasGeneralInformation arm (case 1) selected.
+func TestSAMPR_ALIAS_INFO_BUFFER_RoundTrip(t *testing.T) {
+	groupAliasRoundTrip(t, "AliasGeneralInformation(case1)", SAMPR_ALIAS_INFO_BUFFER{
+		Tag: AliasGeneralInformation,
+		General: SAMPR_ALIAS_GENERAL_INFORMATION{
+			Name:         dtyp.NewUnicodeString("Administrators"),
+			MemberCount:  3,
+			AdminComment: dtyp.NewUnicodeString("Built-in admins"),
+		},
+	})
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/user_test.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/user_test.go
@@ -1,0 +1,62 @@
+package structures
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// TestSamprUserInfoBufferNameRoundTrip marshals a SAMPR_USER_INFO_BUFFER whose
+// discriminant selects UserNameInformation (6) and verifies it survives an NDR
+// round trip unchanged.
+func TestSamprUserInfoBufferNameRoundTrip(t *testing.T) {
+	in := SAMPR_USER_INFO_BUFFER{
+		Tag: UserNameInformation,
+		Name: SAMPR_USER_NAME_INFORMATION{
+			UserName: dtyp.NewUnicodeString("administrator"),
+			FullName: dtyp.NewUnicodeString("Administrator Account"),
+		},
+	}
+
+	data, err := ndr.Marshal(&in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	var out SAMPR_USER_INFO_BUFFER
+	if err := ndr.Unmarshal(data, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	if !reflect.DeepEqual(in, out) {
+		t.Fatalf("round trip mismatch:\n in: %+v\nout: %+v", in, out)
+	}
+}
+
+// TestSamprUserInfoBufferControlRoundTrip marshals a SAMPR_USER_INFO_BUFFER
+// whose discriminant selects UserControlInformation (16) and verifies it
+// survives an NDR round trip unchanged.
+func TestSamprUserInfoBufferControlRoundTrip(t *testing.T) {
+	in := SAMPR_USER_INFO_BUFFER{
+		Tag: UserControlInformation,
+		Control: USER_CONTROL_INFORMATION{
+			UserAccountControl: 0x00000200,
+		},
+	}
+
+	data, err := ndr.Marshal(&in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	var out SAMPR_USER_INFO_BUFFER
+	if err := ndr.Unmarshal(data, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	if !reflect.DeepEqual(in, out) {
+		t.Fatalf("round trip mismatch:\n in: %+v\nout: %+v", in, out)
+	}
+}

--- a/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/validate_test.go
+++ b/network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/validate_test.go
@@ -1,0 +1,52 @@
+package structures
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// roundTripValidate marshals in, unmarshals into a fresh value of the same type,
+// and asserts deep equality. It is named distinctly to avoid colliding with any
+// shared roundTrip helper other structure tests may define in this package.
+func roundTripValidate[T any](t *testing.T, name string, in T) {
+	t.Helper()
+	raw, err := ndr.Marshal(&in)
+	if err != nil {
+		t.Fatalf("%s: Marshal: %v", name, err)
+	}
+	var out T
+	if err := ndr.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("%s: Unmarshal: %v", name, err)
+	}
+	if !reflect.DeepEqual(in, out) {
+		t.Errorf("%s: round trip mismatch:\n in:  %+v\n out: %+v", name, in, out)
+	}
+}
+
+// TestSAM_VALIDATE_OUTPUT_ARG_RoundTrip exercises the SAM_VALIDATE_OUTPUT_ARG
+// union with the SamValidateAuthentication arm (case 1) selected, including a
+// SAM_VALIDATE_PERSISTED_FIELDS payload with a [unique] pointer to a conformant
+// array of SAM_VALIDATE_PASSWORD_HASH (itself a [unique] byte buffer).
+func TestSAM_VALIDATE_OUTPUT_ARG_RoundTrip(t *testing.T) {
+	roundTripValidate(t, "ValidateAuthenticationOutput(case1)", SAM_VALIDATE_OUTPUT_ARG{
+		Tag: SamValidateAuthentication,
+		ValidateAuthenticationOutput: SAM_VALIDATE_STANDARD_OUTPUT_ARG{
+			ChangedPersistedFields: SAM_VALIDATE_PERSISTED_FIELDS{
+				PresentFields:         0x00000007,
+				PasswordLastSet:       dtyp.LARGE_INTEGER(0x1122334455667788),
+				BadPasswordTime:       dtyp.LARGE_INTEGER(0x0000000000000000),
+				LockoutTime:           dtyp.LARGE_INTEGER(0x00000000DEADBEEF),
+				BadPasswordCount:      3,
+				PasswordHistoryLength: 2,
+				PasswordHistory: []SAM_VALIDATE_PASSWORD_HASH{
+					{Length: 4, Hash: []byte{0x01, 0x02, 0x03, 0x04}},
+					{Length: 2, Hash: []byte{0xAA, 0xBB}},
+				},
+			},
+			ValidationStatus: SamValidatePasswordExpired,
+		},
+	})
+}


### PR DESCRIPTION
### Summary
Implements the Security Account Manager Remote Protocol ([MS-SAMR], abstract syntax `12345778-1234-abcd-ef00-0123456789ac` v1.0, `\samr` pipe) under the UUID-versioned interface layout, following the `dcerpc-interface-structure` convention used by the lsarpc and srvsvc interfaces. **Live-validated against a real SAM server (Windows XP).**

### What this adds
- **Descriptor (`interface.go`):** the abstract syntax identifier, the `\samr` endpoint, all 64 on-the-wire opnum constants (opnums 4, 42–43, 59–61, 63, 68–72, 75–76 are *not used on the wire* and are omitted), common NTSTATUS codes with `StatusString`, and the `OpnumToName`/`NameToOpnum` maps.
- **Structures (`structures/`):** the full NDR type set, one type per file, including the seven switch unions — `SAMPR_DOMAIN_INFO_BUFFER`, `SAMPR_DISPLAY_INFO_BUFFER`, `SAMPR_GROUP_INFO_BUFFER`, `SAMPR_ALIAS_INFO_BUFFER`, `SAMPR_USER_INFO_BUFFER` (enum-discriminated, 16-bit), and `SAMPR_REVISION_INFO` (`switch_type(unsigned long)`, 32-bit) — plus the SAM validation argument unions. dtyp base types are reused.
- **Functions (`functions/`):** one stub per opnum (`NN_MethodName.go`) with the `[in]`/`[out]` request and response shapes and exported call wrappers.

### NDR codec addition (required by SAMR)
One generic codec feature was needed and is included: **literal `size_is(N)` conformant `maximum_count`**. MS-SAMR's `[in, size_is(1000), length_is(Count)]` arrays must transmit the constant 1000 as `maximum_count` ("chosen to limit the amount of memory that the client can force the server to allocate" — [MS-SAMR §3.1.5.11.2]) while `actual_count` reflects the elements present. The tag parser now treats a numeric `size_is=` as a literal bound; decode is unaffected. Covered by a new unit test (`ndr/sizeis_test.go`). No regressions across the dcerpc tree.

### How Verified
- `go build` / `go vet` / `go test` clean across the interface, structures, functions, and `ndr` packages; full `./network/dcerpc/...` suite green (no regression from the codec change).
- Independent field-by-field audit against `ms-samr.idl`: zero structure discrepancies.
- **Live wire validation** (integration-tagged `functions/integration_test.go`, fresh single association for the handle chain) against Windows XP:
  - `SamrConnect2` / `SamrConnect5` (the latter exercises the `SAMPR_REVISION_INFO` DWORD-discriminated union in both directions: `outVersion=1 revision=3`)
  - `SamrEnumerateDomainsInSamServer` → `THINKPAD-X61`, `Builtin`
  - `SamrLookupDomainInSamServer` → `S-1-5-21-…`, `S-1-5-32` (out double-pointer SID)
  - `SamrOpenDomain` (inline `[in] RPC_SID`)
  - `SamrLookupNamesInDomain` → `Administrateur`→RID 500, `Invité`→RID 501 (conformant array, `maximum_count=1000`)
  - `SamrEnumerateUsersInDomain` → `STATUS_ACCESS_DENIED` (expected for the non-admin test account; the server decoded the request and returned a clean NTSTATUS)
  - `SamrCloseHandle` (`[in,out]` handle)

### Live-validation findings (fixed in this PR)
1. `SamrConnect5`: the `switch_is(InVersion)` `SAMPR_REVISION_INFO` argument is transmitted inline (discriminant + arm), not behind a `[unique]` pointer referent — the extra referent id was rejected as `nca_s_fault_ndr`.
2. `SamrLookupNamesInDomain` / `SamrLookupIdsInDomain`: modeled as a `[ref]` pointer to a conformant-varying array with the literal bound (`ndr:"ref,size_is=1000,varying"`). A bare conformant field hoisted its count ahead of the context handle (`nca_s_fault_context_mismatch`), and the `maximum_count` must be the literal 1000.

### Scope of Change
- **Files:** the new interface directory `network/dcerpc/v5/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/`, plus the literal-`size_is` codec feature in `network/dcerpc/ndr/` (marshal.go, types.go, sizeis_test.go).
- **Behavioral changes outside SAMR + the additive codec feature:** none.
