### PR TITLE
Fix srvsvc descriptor package identifier dropping a UUID hex digit

### DIFF
--- a/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/interface.go
+++ b/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/interface.go
@@ -1,4 +1,4 @@
-// Package rpcinterface_4b324fc816701d312785a47bf6ee188_3_0 is the descriptor for the
+// Package rpcinterface_4b324fc8167001d312785a47bf6ee188_3_0 is the descriptor for the
 // Server Service Remote Protocol (srvsvc) RPC interface, abstract syntax
 // 4b324fc8-1670-01d3-1278-5a47bf6ee188 version 3.0 ([MS-SRVS]).
 //
@@ -15,7 +15,7 @@
 // References:
 //   - [MS-SRVS] Server Service Remote Protocol:
 //     https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-srvs/accf23b0-0f57-441c-9185-43041f1b0ee9
-package rpcinterface_4b324fc816701d312785a47bf6ee188_3_0
+package rpcinterface_4b324fc8167001d312785a47bf6ee188_3_0
 
 import (
 	"fmt"

--- a/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/interface_test.go
+++ b/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/interface_test.go
@@ -1,4 +1,4 @@
-package rpcinterface_4b324fc816701d312785a47bf6ee188_3_0
+package rpcinterface_4b324fc8167001d312785a47bf6ee188_3_0
 
 import "testing"
 


### PR DESCRIPTION
### Summary
The srvsvc descriptor package was named `rpcinterface_4b324fc816701d312785a47bf6ee188_3_0` — 31 hex digits, having dropped the leading `0` of the UUID's third group (`01d3`).

### Location
- **File(s):** `network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/interface.go`, `interface_test.go`

### Category
`api-contract`

### Severity
`low` — the package identifier is internal and importers alias the package by path, so it compiled; but the name violates the convention and misencodes the UUID.

### Root Cause
The package-name convention is `rpcinterface_<uuid-no-dashes>_<maj>_<min>`. For `4b324fc8-1670-01d3-1278-5a47bf6ee188` the 32-digit concatenation is `4b324fc8167001d312785a47bf6ee188`; the committed name omitted one digit. (Surfaced by `tools/idlgen`, whose generated descriptor emits the full 32-digit encoding.)

### Fix Description
Renamed the package to `rpcinterface_4b324fc8167001d312785a47bf6ee188_3_0` in the package clause + doc comment of `interface.go` and the package clause of `interface_test.go`. No other file references the identifier (importers alias by path).

### How Verified
`go build`, `go vet`, and `go test -count=1` pass for the interface and its structures package; the whole `./network/dcerpc/...` tree builds.

### Test Coverage
**Existing:** the descriptor's `interface_test.go` (SyntaxID/opnum-map/StatusString) compiles and passes under the corrected package name.

### Scope of Change
- **Files changed:** `interface.go`, `interface_test.go` (package identifier only).
- **Behavioral changes outside the rename:** none.