### PR TITLE
Add idlgen fetch: pull the IDL straight from an MS Open Specs Full IDL page

### DIFF
--- a/.claude/skills/dcerpc-interface-structure/SKILL.md
+++ b/.claude/skills/dcerpc-interface-structure/SKILL.md
@@ -320,9 +320,21 @@ Live-test note: set `smb.NativeOS`/`smb.NativeLanMan` before `SessionSetup`, and
 
 **Generate the skeleton with the bundled `idlgen.py` first — do not hand-write the tree.** The generator (`idlgen.py`, in this skill directory) encodes every convention in this document — package naming, the single-vs-double pointer rule, `dtyp` reuse, the union/array tag rules, the opnum maps — and emits a skeleton that **builds and `go vet`s with zero errors** out of the box (validated against lsarpc, srvsvc, and samr). This skill is then the reference for reviewing the ~10–20% the IDL can't express. Everything below (the NDR modeling reference, pointer/response rules, templates) is exactly what the generator emits and what you verify by hand.
 
-It is a stdlib-only Python script; run it from the repo root (it resolves the Go import path from the nearest `go.mod` above `--out-root`) with `gofmt` on `PATH`. Subcommands: `parse` (AST/summary), `gen-descriptor`, `gen-structures`, `gen-functions`, `generate` (whole tree), `check` (drift report).
+It is a stdlib-only Python script; run it from the repo root (it resolves the Go import path from the nearest `go.mod` above `--out-root`) with `gofmt` on `PATH`. Subcommands: `fetch` (download the IDL from the spec), `parse` (AST/summary), `gen-descriptor`, `gen-structures`, `gen-functions`, `generate` (whole tree), `check` (drift report).
 
-### 1. Generate the tree
+### 1. Get the IDL
+
+Each interface's IDL is published on its Microsoft Open Specifications **"Appendix A: Full IDL"** page. Fetch it straight from there:
+
+```sh
+python3 .claude/skills/dcerpc-interface-structure/idlgen.py fetch \
+    https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-efsr/4a25b8e1-fd90-41b6-9301-62ed71334436 \
+    --out ms-efsr.idl
+```
+
+`fetch` downloads the page, concatenates its `<pre>` IDL blocks in order, normalizes the HTML entities and `&nbsp;` indentation, writes the `.idl`, sanity-parses it (printing the interface name + method/typedef counts), and prints a suggested `generate` command. It needs network access and honours the standard `HTTP(S)_PROXY` env vars. (If you already have the `.idl` on disk, skip this step.)
+
+### 2. Generate the tree
 
 ```sh
 python3 .claude/skills/dcerpc-interface-structure/idlgen.py generate <iface>.idl \
@@ -331,7 +343,7 @@ python3 .claude/skills/dcerpc-interface-structure/idlgen.py generate <iface>.idl
 
 This writes `interface.go`, `structures/*.go`, and `functions/<NN>_<Method>.go` under `network/dcerpc/interfaces/<uuid>/<maj>.<min>/` (opnums skip `OpnumNNotUsedOnWire`; the import path is derived from `go.mod`), runs `gofmt`, and prints the count of `TODO(idlgen)` markers. Drive the layers individually when needed: `parse` (AST/summary), `gen-descriptor`, `gen-structures`, `gen-functions`.
 
-### 2. Review what the IDL cannot carry (`TODO(idlgen)` markers + known hard cases)
+### 3. Review what the IDL cannot carry (`TODO(idlgen)` markers + known hard cases)
 
 Grep for `TODO(idlgen)` and reconcile each against the rules above:
 
@@ -339,10 +351,11 @@ Grep for `TODO(idlgen)` and reconcile each against the rules above:
 - **NDR tags the generator can't infer** — verify against this skill: fixed encrypted-password buffers, `SAMPR_LOGON_HOURS`' literal `size_is(1260)` bound, and **per-method tolerance of `STATUS_MORE_ENTRIES`/`SOME_NOT_MAPPED`** (a generated stub accepts only `StatusSuccess`; relax it for `Enumerate*`/`Lookup*`/`QueryDisplay*`).
 - **Exported-function ergonomics** — stubs mirror the request fields and use named returns; refine to friendly `string`/`uint32` parameters with conversions where it reads better.
 - **Types referenced but absent from the IDL** get a `type X struct{}` placeholder with a `TODO(idlgen)` (e.g. MS-SRVS `SERVER_INFO_100/101`); fill in their fields by hand.
+- **NDR `pipe` types** (`typedef pipe …`, e.g. MS-EFSR's `EFS_EXIM_PIPE` raw-file streaming) are parsed as their element type so the tree compiles, but pipe *streaming* is not modeled — the methods that use them need manual work.
 
 If the codec genuinely lacks a feature a type needs (rather than the generator mis-modeling it), file an enhancement issue against `network/dcerpc/ndr` (or `dtyp`) and defer those methods rather than shipping code that can't be correct.
 
-### 3. Verify
+### 4. Verify
 
 `gofmt -w`, then `go build`, `go vet`, `go test ./<path>/...`, and `go build -tags integration ./<path>/...`. Then **live-validate** — the real acceptance gate (see Tests). Cross-check completeness (count parity is not enough — verify each opnum number):
 
@@ -352,7 +365,7 @@ grep -aoE '\b[A-Z][A-Za-z0-9]+\(' <iface>.idl   # real methods (filter to the in
 
 Confirm: (a) every IDL method has exactly one `functions/<NN>_<Name>.go` and exported func; (b) no extras; (c) the file prefix `NN` == the IDL `// Opnum NN` == the `Opnum<Name>` constant; (d) `NotUsedOnWire` opnums are absent.
 
-### 4. Keep regenerations and edits reconcilable: `check`
+### 5. Keep regenerations and edits reconcilable: `check`
 
 ```sh
 python3 .claude/skills/dcerpc-interface-structure/idlgen.py check <iface>.idl \

--- a/.claude/skills/dcerpc-interface-structure/idlgen.py
+++ b/.claude/skills/dcerpc-interface-structure/idlgen.py
@@ -52,6 +52,37 @@ def read_idl(path: str) -> str:
     return raw.decode("utf-8", errors="replace")
 
 
+def fetch_idl(url: str) -> str:
+    """Download a Microsoft Open Specifications "Appendix A: Full IDL" page and
+    return the IDL text. The IDL is rendered as one or more <pre> code blocks; we
+    concatenate them in document order, strip any inner markup, and unescape HTML
+    entities. Needs network access (honours the standard HTTP(S)_PROXY env vars).
+
+    Example:
+        https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-efsr/4a25b8e1-fd90-41b6-9301-62ed71334436
+    """
+    import html as _html
+    import urllib.request
+
+    req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0 (idlgen)"})
+    doc = urllib.request.urlopen(req, timeout=30).read().decode("utf-8", "replace")
+    blocks = re.findall(r"<pre[^>]*>(.*?)</pre>", doc, re.S)
+    if not blocks:
+        raise ParseError(f"no <pre> code blocks found at {url} (is it an "
+                         f"'Appendix A: Full IDL' page?)")
+    parts = [_html.unescape(re.sub(r"<[^>]+>", "", b)) for b in blocks]
+    # MS Learn renders indentation with &nbsp; (U+00A0) and may use Unicode
+    # spaces/zero-width chars; normalize to plain ASCII whitespace.
+    text = "\n".join(parts)
+    return text.replace("\xa0", " ").replace("​", "").replace("﻿", "")
+
+
+def spec_tag_from_url(url: str) -> Optional[str]:
+    """Best-effort [MS-XXX] spec tag from an openspecs URL (.../ms-efsr/... -> MS-EFSR)."""
+    m = re.search(r"/(ms-[a-z0-9]+)/", url)
+    return m.group(1).upper() if m else None
+
+
 # --------------------------------------------------------------------------- #
 # Tokenizer
 # --------------------------------------------------------------------------- #
@@ -90,7 +121,7 @@ def tokenize(src: str) -> list[Token]:
             i += 1
             at_line_start = True
             continue
-        if c in " \t\r":
+        if c in " \t\r\xa0":  # \xa0 = non-breaking space, common in pasted/HTML IDL
             i += 1
             continue
         # Preprocessor line: from `#` to end of line, emitted whole.
@@ -350,6 +381,11 @@ class Parser:
         Handles `unsigned long`, `wchar_t`, `void`, struct/union/enum tag refs,
         and plain typedef names."""
         words: list[str] = []
+        # NDR `pipe` modifier (a streaming type, e.g. `typedef pipe unsigned char T`):
+        # skip it and parse the element type. Pipe streaming is not modeled — the
+        # methods that use the pipe type need manual review.
+        if self.peek().value == "pipe":
+            self.next()
         # struct/union/enum used inline as a type reference: `struct _FOO`
         if self.peek().value in ("struct", "union", "enum"):
             words.append(self.next().value)
@@ -1462,6 +1498,10 @@ def main(argv: list[str]) -> int:
     p.add_argument("--json", action="store_true", help="dump the full AST as JSON")
     p.add_argument("--quiet", action="store_true", help="only report parse errors")
 
+    ft = sub.add_parser("fetch", help="download the IDL from an MS Open Specs 'Appendix A: Full IDL' page")
+    ft.add_argument("url", help="learn.microsoft.com 'Appendix A: Full IDL' page URL")
+    ft.add_argument("--out", default=None, help="output .idl file (default: stdout)")
+
     g = sub.add_parser("gen-descriptor", help="generate interface.go from an .idl")
     g.add_argument("idl", help="path to the .idl file")
     g.add_argument("--pipe", default=None, help="named pipe (default: \\<interface>)")
@@ -1516,6 +1556,34 @@ def main(argv: list[str]) -> int:
                 print("no interfaces found", file=sys.stderr)
                 return 1
             print(summarize(ifaces))
+        return 0
+
+    if args.cmd == "fetch":
+        try:
+            idl = fetch_idl(args.url)
+        except (ParseError, OSError) as e:
+            print(f"FETCH ERROR: {e}", file=sys.stderr)
+            return 1
+        if args.out:
+            with open(args.out, "w") as fh:
+                fh.write(idl)
+            print(f"wrote {args.out}", file=sys.stderr)
+        else:
+            sys.stdout.write(idl)
+        # Best-effort sanity parse + a suggested generate command.
+        try:
+            ifaces = Parser(tokenize(idl), filename=args.url).parse()
+            spec = spec_tag_from_url(args.url) or "MS-XXX"
+            for iface in ifaces:
+                wire = sum(1 for m in iface.methods if is_on_the_wire(m))
+                print(f"  parsed interface {iface.name}: {wire} on-the-wire methods, "
+                      f"{len(iface.typedefs)} typedefs", file=sys.stderr)
+            if args.out and ifaces:
+                print(f"  next: python3 {sys.argv[0]} generate {args.out} "
+                      f"--out-root network/dcerpc/interfaces --spec {spec} "
+                      f"--pipe '\\<pipe>'", file=sys.stderr)
+        except (LexError, ParseError) as e:
+            print(f"  warning: fetched IDL did not parse cleanly: {e}", file=sys.stderr)
         return 0
 
     if args.cmd == "gen-descriptor":


### PR DESCRIPTION
### Summary
Adds a `fetch` subcommand to the bundled `idlgen` so a whole interface can be generated directly from its Microsoft Open Specifications **"Appendix A: Full IDL"** web page — no manual copy/paste of the IDL.

```sh
python3 .claude/skills/dcerpc-interface-structure/idlgen.py fetch \
    https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-efsr/4a25b8e1-fd90-41b6-9301-62ed71334436 \
    --out ms-efsr.idl
```

`fetch` downloads the page, concatenates its `<pre>` IDL blocks in document order, strips inner markup, unescapes HTML entities, normalizes `&nbsp;` / zero-width characters, and writes a clean `.idl`. It then sanity-parses the result (printing the interface name + method/typedef counts) and prints a suggested `generate` command with the `[MS-XXX]` spec tag derived from the URL. Needs network access; honours `HTTP(S)_PROXY`.

### Parser robustness (needed by real spec IDLs)
- Tolerate the non-breaking space `U+00A0` as whitespace (MS Learn renders code indentation with `&nbsp;`).
- Skip the NDR `pipe` type modifier (`typedef pipe …`, e.g. MS-EFSR's `EFS_EXIM_PIPE`) so the tree still parses and compiles. Pipe *streaming* is not modeled and is flagged for manual review.

### Skill
The `dcerpc-interface-structure` skill now leads with a **"1. Get the IDL"** step using `fetch` (steps renumbered 1–5), lists `fetch` among the subcommands, and notes the `pipe`-type limitation in the review surface.

### How Verified
End-to-end against **MS-EFSR**, fetched live from learn.microsoft.com (an interface never hand-implemented here):
- `fetch` → clean `.idl`; sanity-parse reports `efsrpc`, 20 on-the-wire methods, 17 typedefs.
- `generate` → 38 files (descriptor + structures + functions).
- `go build` and `go vet`: **0 errors**.

### Scope of Change
- **Files:** `.claude/skills/dcerpc-interface-structure/idlgen.py` (new `fetch` subcommand + parser robustness) and `SKILL.md` (workflow). No changes to existing Go packages.