### PR TITLE
Fix EFSR raw-file methods to stream via the NDR pipe (#436)

### DIFF
--- a/network/dcerpc/interfaces/c681d488-d850-11d0-8c52-00c04fd90f7e/1.0/functions/01_EfsRpcReadFileRaw.go
+++ b/network/dcerpc/interfaces/c681d488-d850-11d0-8c52-00c04fd90f7e/1.0/functions/01_EfsRpcReadFileRaw.go
@@ -8,33 +8,32 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 )
 
-// efsRpcReadFileRawRequest carries the [in] parameters of EfsRpcReadFileRaw.
+// efsRpcReadFileRawRequest carries the [in] parameters of EfsRpcReadFileRaw: the
+// export context handle opened by EfsRpcOpenFileRaw.
 type efsRpcReadFileRawRequest struct {
 	HContext structures.PEXIMPORT_CONTEXT_HANDLE
 }
 
 func (*efsRpcReadFileRawRequest) Opnum() uint16 { return efsrpc.OpnumEfsRpcReadFileRaw }
 
-// efsRpcReadFileRawResponse carries the [out] parameters and return value of EfsRpcReadFileRaw.
+// efsRpcReadFileRawResponse carries the [out] EFS_EXIM_PIPE and the return value.
+// EfsOutPipe is an NDR pipe ([C706] 14.7) — the server streams the raw encrypted file
+// to the client as chunks ahead of the return value.
 type efsRpcReadFileRawResponse struct {
-	EfsOutPipe uint8
-	Status     ndr.DWORD `ndr:"retval"`
+	EfsOutPipe structures.EFS_EXIM_PIPE `ndr:"pipe"`
+	Status     ndr.DWORD                `ndr:"retval"`
 }
 
-// EfsRpcReadFileRaw calls EfsRpcReadFileRaw (opnum 1) ([MS-EFSR] — verify the parameter
-// modeling and status handling).
-func EfsRpcReadFileRaw(rpc ndr.Invoker, hContext structures.PEXIMPORT_CONTEXT_HANDLE) (EfsOutPipe uint8, err error) {
-	req := &efsRpcReadFileRawRequest{
-		HContext: hContext,
-	}
+// EfsRpcReadFileRaw calls EfsRpcReadFileRaw (opnum 1, [MS-EFSR] 3.1.4.2.2). It exports
+// the opened file as a raw encrypted stream, returning the full pipe contents.
+func EfsRpcReadFileRaw(rpc ndr.Invoker, hContext structures.PEXIMPORT_CONTEXT_HANDLE) (structures.EFS_EXIM_PIPE, error) {
+	req := &efsRpcReadFileRawRequest{HContext: hContext}
 	var resp efsRpcReadFileRawResponse
-	if err = rpc.Invoke(req, &resp); err != nil {
-		err = fmt.Errorf("EfsRpcReadFileRaw: %w", err)
-		return
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return nil, fmt.Errorf("EfsRpcReadFileRaw: %w", err)
 	}
-	EfsOutPipe = resp.EfsOutPipe
 	if uint32(resp.Status) != efsrpc.StatusSuccess {
-		err = fmt.Errorf("EfsRpcReadFileRaw failed: %s", efsrpc.StatusString(uint32(resp.Status)))
+		return resp.EfsOutPipe, fmt.Errorf("EfsRpcReadFileRaw failed: %s", efsrpc.StatusString(uint32(resp.Status)))
 	}
-	return
+	return resp.EfsOutPipe, nil
 }

--- a/network/dcerpc/interfaces/c681d488-d850-11d0-8c52-00c04fd90f7e/1.0/functions/02_EfsRpcWriteFileRaw.go
+++ b/network/dcerpc/interfaces/c681d488-d850-11d0-8c52-00c04fd90f7e/1.0/functions/02_EfsRpcWriteFileRaw.go
@@ -8,33 +8,31 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 )
 
-// efsRpcWriteFileRawRequest carries the [in] parameters of EfsRpcWriteFileRaw.
+// efsRpcWriteFileRawRequest carries the [in] parameters of EfsRpcWriteFileRaw: the
+// import context handle and the raw encrypted stream. EfsInPipe is an NDR pipe ([C706]
+// 14.7) sent as chunks after the handle.
 type efsRpcWriteFileRawRequest struct {
 	HContext  structures.PEXIMPORT_CONTEXT_HANDLE
-	EfsInPipe uint8
+	EfsInPipe structures.EFS_EXIM_PIPE `ndr:"pipe"`
 }
 
 func (*efsRpcWriteFileRawRequest) Opnum() uint16 { return efsrpc.OpnumEfsRpcWriteFileRaw }
 
-// efsRpcWriteFileRawResponse carries the [out] parameters and return value of EfsRpcWriteFileRaw.
+// efsRpcWriteFileRawResponse carries the return value of EfsRpcWriteFileRaw.
 type efsRpcWriteFileRawResponse struct {
 	Status ndr.DWORD `ndr:"retval"`
 }
 
-// EfsRpcWriteFileRaw calls EfsRpcWriteFileRaw (opnum 2) ([MS-EFSR] — verify the parameter
-// modeling and status handling).
-func EfsRpcWriteFileRaw(rpc ndr.Invoker, hContext structures.PEXIMPORT_CONTEXT_HANDLE, efsInPipe uint8) (err error) {
-	req := &efsRpcWriteFileRawRequest{
-		HContext:  hContext,
-		EfsInPipe: efsInPipe,
-	}
+// EfsRpcWriteFileRaw calls EfsRpcWriteFileRaw (opnum 2, [MS-EFSR] 3.1.4.2.3). It imports
+// a raw encrypted stream into the opened file.
+func EfsRpcWriteFileRaw(rpc ndr.Invoker, hContext structures.PEXIMPORT_CONTEXT_HANDLE, efsInPipe structures.EFS_EXIM_PIPE) error {
+	req := &efsRpcWriteFileRawRequest{HContext: hContext, EfsInPipe: efsInPipe}
 	var resp efsRpcWriteFileRawResponse
-	if err = rpc.Invoke(req, &resp); err != nil {
-		err = fmt.Errorf("EfsRpcWriteFileRaw: %w", err)
-		return
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return fmt.Errorf("EfsRpcWriteFileRaw: %w", err)
 	}
 	if uint32(resp.Status) != efsrpc.StatusSuccess {
-		err = fmt.Errorf("EfsRpcWriteFileRaw failed: %s", efsrpc.StatusString(uint32(resp.Status)))
+		return fmt.Errorf("EfsRpcWriteFileRaw failed: %s", efsrpc.StatusString(uint32(resp.Status)))
 	}
-	return
+	return nil
 }

--- a/network/dcerpc/interfaces/c681d488-d850-11d0-8c52-00c04fd90f7e/1.0/functions/pipe_test.go
+++ b/network/dcerpc/interfaces/c681d488-d850-11d0-8c52-00c04fd90f7e/1.0/functions/pipe_test.go
@@ -1,0 +1,52 @@
+package functions
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/c681d488-d850-11d0-8c52-00c04fd90f7e/1.0/structures"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// TestWriteFileRawRequest_PipeRoundTrip checks that the [in] EFS_EXIM_PIPE is marshalled
+// as an NDR pipe after the context handle and round-trips.
+func TestWriteFileRawRequest_PipeRoundTrip(t *testing.T) {
+	var h structures.PEXIMPORT_CONTEXT_HANDLE
+	for i := range h {
+		h[i] = byte(i)
+	}
+	in := &efsRpcWriteFileRawRequest{HContext: h, EfsInPipe: structures.EFS_EXIM_PIPE{0xde, 0xad, 0xbe, 0xef}}
+	raw, err := ndr.Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	// 20-byte handle, then the pipe: count=4, 4 bytes, terminating 0 count.
+	want := append(h[:], 0x04, 0x00, 0x00, 0x00, 0xde, 0xad, 0xbe, 0xef, 0x00, 0x00, 0x00, 0x00)
+	if !bytes.Equal(raw, want) {
+		t.Errorf("WriteFileRaw request wire:\n got %x\nwant %x", raw, want)
+	}
+	var out efsRpcWriteFileRawRequest
+	if err := ndr.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out.HContext != in.HContext || !bytes.Equal(out.EfsInPipe, in.EfsInPipe) {
+		t.Errorf("round trip: got %+v want %+v", out, in)
+	}
+}
+
+// TestReadFileRawResponse_PipeRoundTrip checks the [out] EFS_EXIM_PIPE stream precedes
+// the return value and round-trips.
+func TestReadFileRawResponse_PipeRoundTrip(t *testing.T) {
+	in := &efsRpcReadFileRawResponse{EfsOutPipe: structures.EFS_EXIM_PIPE{1, 2, 3, 4, 5}, Status: 0}
+	raw, err := ndr.Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var out efsRpcReadFileRawResponse
+	if err := ndr.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if !bytes.Equal(out.EfsOutPipe, in.EfsOutPipe) || out.Status != 0 {
+		t.Errorf("round trip: got pipe=%x status=%#x", out.EfsOutPipe, out.Status)
+	}
+}

--- a/network/dcerpc/interfaces/c681d488-d850-11d0-8c52-00c04fd90f7e/1.0/structures/EFS_EXIM_PIPE.go
+++ b/network/dcerpc/interfaces/c681d488-d850-11d0-8c52-00c04fd90f7e/1.0/structures/EFS_EXIM_PIPE.go
@@ -1,4 +1,7 @@
 package structures
 
-// EFS_EXIM_PIPE is a scalar typedef ([MS-EFSR]).
-type EFS_EXIM_PIPE uint8
+// EFS_EXIM_PIPE is the EFSRPC raw import/export pipe ([MS-EFSR] 2.2.7): an NDR pipe
+// of bytes (IDL `typedef pipe unsigned char`). On the wire it is a sequence of chunks
+// — each a uint32 element count followed by that many bytes — terminated by a 0-count
+// chunk ([C706] section 14.7). Marshal/unmarshal it with the `ndr:"pipe"` tag.
+type EFS_EXIM_PIPE []byte

--- a/network/dcerpc/ndr/marshal.go
+++ b/network/dcerpc/ndr/marshal.go
@@ -176,6 +176,10 @@ func marshalFieldInline(e *Encoder, fv reflect.Value, tag fieldTag, deferred *[]
 		return m.MarshalNDR(e)
 	}
 
+	if tag.pipe {
+		return marshalPipe(e, fv, tag)
+	}
+
 	if isPointerLike(fv, tag) {
 		kind := tag.ptr
 		if kind == ptrNone {
@@ -401,6 +405,10 @@ func unmarshalFieldInline(d *Decoder, fv reflect.Value, tag fieldTag, deferred *
 	if m, ok := asMarshalerAddr(fv); ok {
 		d.Align(m.AlignmentNDR())
 		return m.UnmarshalNDR(d)
+	}
+
+	if tag.pipe {
+		return unmarshalPipe(d, fv, tag)
 	}
 
 	if isPointerLike(fv, tag) {
@@ -646,7 +654,9 @@ func isUintKind(k reflect.Kind) bool {
 // array, i.e. a slice that is not itself behind a pointer. A slice behind a pointer is
 // a referent, not an embedded array, and is not hoisted.
 func isEmbeddedConformantArray(fv reflect.Value, tag fieldTag) bool {
-	return fv.Kind() == reflect.Slice && !isPointerLike(fv, tag)
+	// A pipe is a chunked stream, not a conformant array, so its count must not be
+	// hoisted to the front of the enclosing struct ([C706] 14.7).
+	return fv.Kind() == reflect.Slice && !tag.pipe && !isPointerLike(fv, tag)
 }
 
 // ndrAlignment returns the NDR alignment, in octets, of a value of type t.
@@ -745,6 +755,51 @@ func unmarshalConformantVaryingArray(d *Decoder, slice reflect.Value, elemTag fi
 // a position after the entire array body, so an array of pointers, or of structs that
 // themselves contain pointers, cannot be encoded by recursing fully into each element
 // in turn ([C706] section 14.3.10).
+// marshalPipe writes an NDR pipe ([C706] section 14.7): a sequence of chunks, each a
+// uint32 element count followed by that many element representations, terminated by an
+// empty chunk (a count of 0). The whole slice is transmitted as a single chunk. A pipe
+// of a scalar (e.g. EFS_EXIM_PIPE = pipe of bytes) goes through marshalElements, which
+// has a byte fast path.
+func marshalPipe(e *Encoder, fv reflect.Value, tag fieldTag) error {
+	if fv.Kind() != reflect.Slice {
+		return fmt.Errorf("ndr: pipe field must be a slice, got %s", fv.Kind())
+	}
+	if n := fv.Len(); n > 0 {
+		e.WriteUint32(uint32(n))
+		if err := marshalElements(e, fv, elementTag(tag)); err != nil {
+			return err
+		}
+	}
+	e.WriteUint32(0) // terminating empty chunk
+	return nil
+}
+
+// unmarshalPipe reads an NDR pipe: chunks of (uint32 count, count elements) until a
+// 0-count chunk, concatenating the chunks into the slice. unmarshalElements bounds each
+// chunk's count against the remaining input, so a hostile count cannot over-allocate.
+func unmarshalPipe(d *Decoder, fv reflect.Value, tag fieldTag) error {
+	if fv.Kind() != reflect.Slice {
+		return fmt.Errorf("ndr: pipe field must be a slice, got %s", fv.Kind())
+	}
+	acc := reflect.MakeSlice(fv.Type(), 0, 0)
+	for {
+		count, err := d.ReadUint32()
+		if err != nil {
+			return err
+		}
+		if count == 0 {
+			break
+		}
+		chunk := reflect.New(fv.Type()).Elem()
+		if err := unmarshalElements(d, chunk, int(count), elementTag(tag)); err != nil {
+			return err
+		}
+		acc = reflect.AppendSlice(acc, chunk)
+	}
+	fv.Set(acc)
+	return nil
+}
+
 func marshalElements(e *Encoder, slice reflect.Value, elemTag fieldTag) error {
 	if slice.Type().Elem().Kind() == reflect.Uint8 {
 		e.WriteBytes(slice.Bytes()) // fast path for byte arrays

--- a/network/dcerpc/ndr/pipe_test.go
+++ b/network/dcerpc/ndr/pipe_test.go
@@ -1,0 +1,98 @@
+package ndr
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+)
+
+// TestPipe_ByteWireFormat verifies an NDR byte pipe ([C706] 14.7): a uint32 chunk
+// count, the elements, then a terminating 0-count chunk; and that it round-trips.
+func TestPipe_ByteWireFormat(t *testing.T) {
+	type req struct {
+		Handle [4]byte
+		Data   []byte `ndr:"pipe"`
+	}
+	in := &req{Handle: [4]byte{0xaa, 0xbb, 0xcc, 0xdd}, Data: []byte{0x01, 0x02, 0x03}}
+	raw, err := Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	want := []byte{
+		0xaa, 0xbb, 0xcc, 0xdd, // Handle
+		0x03, 0x00, 0x00, 0x00, // chunk count = 3
+		0x01, 0x02, 0x03, // elements
+		0x00,                   // pad: the next uint32 count aligns to 4 ([C706] 14)
+		0x00, 0x00, 0x00, 0x00, // terminating empty chunk (count 0)
+	}
+	if !bytes.Equal(raw, want) {
+		t.Errorf("pipe wire:\n got %x\nwant %x", raw, want)
+	}
+	var out req
+	if err := Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if !bytes.Equal(out.Data, in.Data) || out.Handle != in.Handle {
+		t.Errorf("round trip: got %+v want %+v", out, in)
+	}
+}
+
+// TestPipe_Empty verifies an empty pipe is a single 0-count chunk and round-trips.
+func TestPipe_Empty(t *testing.T) {
+	type req struct {
+		Data []byte `ndr:"pipe"`
+	}
+	raw, err := Marshal(&req{})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if !bytes.Equal(raw, []byte{0x00, 0x00, 0x00, 0x00}) {
+		t.Errorf("empty pipe = %x, want 00000000", raw)
+	}
+	var out req
+	if err := Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if len(out.Data) != 0 {
+		t.Errorf("empty pipe round trip: got %v", out.Data)
+	}
+}
+
+// TestPipe_MultiChunk verifies that several chunks concatenate on read.
+func TestPipe_MultiChunk(t *testing.T) {
+	// Two 4-byte chunks (so each uint32 count stays 4-aligned), then the terminator.
+	raw := []byte{
+		0x04, 0x00, 0x00, 0x00, 0x11, 0x22, 0x33, 0x44,
+		0x04, 0x00, 0x00, 0x00, 0x55, 0x66, 0x77, 0x88,
+		0x00, 0x00, 0x00, 0x00,
+	}
+	type req struct {
+		Data []byte `ndr:"pipe"`
+	}
+	var out req
+	if err := Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if !bytes.Equal(out.Data, []byte{0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88}) {
+		t.Errorf("multi-chunk concat = %x, want 1122334455667788", out.Data)
+	}
+}
+
+// TestPipe_TypedElements verifies a pipe of a non-byte scalar.
+func TestPipe_TypedElements(t *testing.T) {
+	type req struct {
+		Vals []uint32 `ndr:"pipe"`
+	}
+	in := &req{Vals: []uint32{0x0a, 0x0b}}
+	raw, err := Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var out req
+	if err := Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if !reflect.DeepEqual(out.Vals, in.Vals) {
+		t.Errorf("typed pipe round trip: got %v want %v", out.Vals, in.Vals)
+	}
+}

--- a/network/dcerpc/ndr/types.go
+++ b/network/dcerpc/ndr/types.go
@@ -96,6 +96,7 @@ type fieldTag struct {
 	align        int     // explicit alignment override (0 = default)
 	retval       bool    // RPC return value: encoded after the struct's deferred referents
 	elemPtr      ptrKind // pointer attribute of array elements (`elem=ref|unique|ptr`)
+	pipe         bool    // NDR pipe: a chunked stream ([C706] 14.7), not a normal array
 
 	// Union (discriminated by an inline switch value, [C706] section 14.3.8) tags.
 	isSwitch  bool  // the union discriminant field (`switch`)
@@ -125,6 +126,8 @@ func parseTag(raw string) fieldTag {
 			t.wide = true
 		case opt == "str":
 			t.ascii = true
+		case opt == "pipe":
+			t.pipe = true
 		case opt == "conformant":
 			t.conformant = true
 		case opt == "varying":


### PR DESCRIPTION
### Linked Issue
Closes #436

### Root Cause
NDR pipes ([C706] section 14.7) — a streaming construct transmitted as a sequence of `(uint32 count, count elements)` chunks terminated by a 0-count chunk — were not modeled by the `ndr` codec or the `idlgen` generator. So when EFSR was generated, `typedef pipe unsigned char EFS_EXIM_PIPE` was degraded to its element scalar (`type EFS_EXIM_PIPE uint8`) and the `[out]`/`[in] EFS_EXIM_PIPE*` parameters of `EfsRpcReadFileRaw`/`EfsRpcWriteFileRaw` became a single `uint8`. The two raw import/export methods therefore could not carry the raw encrypted-file stream they exist for.

### Fix Description
Two parts:
1. **Codec** — add `ndr:"pipe"`. A pipe field (a slice) marshals as a single chunk (`count`, elements) plus the terminating `0` count, and unmarshals by concatenating chunks until the 0 count. `unmarshalElements` already bounds each chunk's count against the remaining input, so a hostile count cannot over-allocate. Pipe fields are excluded from conformant-array count hoisting (a pipe count must not move to the front of the enclosing struct).
2. **EFSR** — redefine `EFS_EXIM_PIPE` as a byte pipe (`type EFS_EXIM_PIPE []byte`) and tag the parameters `ndr:"pipe"`: `EfsRpcReadFileRaw` returns the streamed `[out]` pipe (which precedes the return value), `EfsRpcWriteFileRaw` sends the `[in]` pipe after the context handle.

### How Verified
- **Tests:** `ndr` codec — `TestPipe_ByteWireFormat` (asserts the exact wire: count, elements, 4-aligned terminating 0), `TestPipe_Empty`, `TestPipe_MultiChunk` (chunk concatenation), `TestPipe_TypedElements`. EFSR — `TestWriteFileRawRequest_PipeRoundTrip` (asserts `[handle][chunked pipe]` wire bytes) and `TestReadFileRawResponse_PipeRoundTrip`.
- `go build`, `go vet`, `go test` clean for `./network/dcerpc/...` (no regressions across lsarpc/srvsvc/samr/efsr/ndr).

### Test Coverage
**Added:** `network/dcerpc/ndr/pipe_test.go` (4 tests) and `.../efsr/1.0/functions/pipe_test.go` (2 tests).

### Scope of Change
- **Files changed:** `network/dcerpc/ndr/{types.go,marshal.go,pipe_test.go}`; EFSR `structures/EFS_EXIM_PIPE.go`, `functions/0{1,2}_EfsRpc{Read,Write}FileRaw.go`, `functions/pipe_test.go`.
- **Behavioral changes outside the bug fix:** none — the `pipe` tag is new, so no existing type changes behavior.

### Risk and Rollout
Low and local: the codec change only activates for fields tagged `ndr:"pipe"` (none existed before); all other paths are untouched and the full dcerpc suite passes.

### Notes
- Not live-validated (EFS raw import/export requires a configured EFS server); the wire format follows [C706] 14.7 and is covered by exact-byte unit tests.
- Follow-up (separate): teach `idlgen` to emit `ndr:"pipe"` for `typedef pipe` types so regenerating EFSR reproduces this by construction. Today the generator still degrades pipes to the element scalar, so these three files are hand-maintained.