### PR TITLE
Teach idlgen to generate NDR pipe types and the ndr:"pipe" tag

### DIFF
--- a/.claude/skills/dcerpc-interface-structure/SKILL.md
+++ b/.claude/skills/dcerpc-interface-structure/SKILL.md
@@ -351,7 +351,7 @@ Grep for `TODO(idlgen)` and reconcile each against the rules above:
 - **NDR tags the generator can't infer** — verify against this skill: fixed encrypted-password buffers, `SAMPR_LOGON_HOURS`' literal `size_is(1260)` bound, and **per-method tolerance of `STATUS_MORE_ENTRIES`/`SOME_NOT_MAPPED`** (a generated stub accepts only `StatusSuccess`; relax it for `Enumerate*`/`Lookup*`/`QueryDisplay*`).
 - **Exported-function ergonomics** — stubs mirror the request fields and use named returns; refine to friendly `string`/`uint32` parameters with conversions where it reads better.
 - **Types referenced but absent from the IDL** get a `type X struct{}` placeholder with a `TODO(idlgen)` (e.g. MS-SRVS `SERVER_INFO_100/101`); fill in their fields by hand.
-- **NDR `pipe` types** (`typedef pipe …`, e.g. MS-EFSR's `EFS_EXIM_PIPE` raw-file streaming) are parsed as their element type so the tree compiles, but pipe *streaming* is not modeled — the methods that use them need manual work.
+- **NDR `pipe` types** (`typedef pipe …`, e.g. MS-EFSR's `EFS_EXIM_PIPE`) are generated as a slice type plus `ndr:"pipe"` on the parameter (the codec marshals the [C706] 14.7 chunked stream). The whole pipe is buffered in one chunk rather than streamed incrementally, and live validation of pipe methods needs the real service — review those.
 
 If the codec genuinely lacks a feature a type needs (rather than the generator mis-modeling it), file an enhancement issue against `network/dcerpc/ndr` (or `dtyp`) and defer those methods rather than shipping code that can't be correct.
 

--- a/.claude/skills/dcerpc-interface-structure/idlgen.py
+++ b/.claude/skills/dcerpc-interface-structure/idlgen.py
@@ -228,6 +228,7 @@ class Typedef:
     enumerators: list[tuple[str, Optional[str]]] = field(default_factory=list)
     base: Optional[str] = None     # for "alias": the aliased base type spelling
     switch_type: Optional[str] = None  # for unions: [switch_type(...)]
+    is_pipe: bool = False          # `typedef pipe <base> NAME` — an NDR pipe of <base>
 
     @property
     def name(self) -> Optional[str]:
@@ -632,10 +633,11 @@ class Parser:
         return td
 
     def _parse_alias_typedef(self, attrs: dict) -> Typedef:
+        is_pipe = self.peek().value == "pipe"  # `typedef pipe <base> NAME` (parse_base_type skips the keyword)
         base = self.parse_base_type()
         names = self._parse_declarators()
         self.expect(";")
-        return Typedef(kind="alias", names=names, attrs=attrs, base=base)
+        return Typedef(kind="alias", names=names, attrs=attrs, base=base, is_pipe=is_pipe)
 
     # -- methods ----------------------------------------------------------- #
     def parse_method(self) -> Method:
@@ -904,6 +906,7 @@ class TypeResolver:
         self.scalar_alias: dict[str, str] = {}        # alias -> Go scalar
         self.ctx_handles: set[str] = set()
         self.str_handles: set[str] = set()            # [handle] wchar_t* string handles
+        self.pipes: dict[str, str] = {}               # pipe type name -> Go element type
         self.extra_names: dict[str, list[str]] = {}   # primary -> [extra non-ptr aliases]
         self.unresolved: set[str] = set()             # type names referenced but not defined
         self.enum_values: dict[str, int] = {}         # enumerator name -> numeric value
@@ -937,7 +940,11 @@ class TypeResolver:
                     self.kinds[d.name] = td.kind
             if td.kind == "alias":
                 has_value_decl = any(d.ptr == 0 for d in td.names)
-                if "context_handle" in td.attrs and td.base == "void":
+                if td.is_pipe:
+                    # NDR pipe of <base>; model as a Go slice with the `pipe` tag.
+                    if canon:
+                        self.pipes[canon] = _SCALAR.get(td.base) or _DTYP_SCALAR.get(td.base) or "byte"
+                elif "context_handle" in td.attrs and td.base == "void":
                     if canon:
                         self.ctx_handles.add(canon)
                 elif td.base == "wchar_t" and not has_value_decl:
@@ -1211,7 +1218,13 @@ def gen_structures(iface: Interface, spec: str) -> dict[str, str]:
         if td.kind == "enum":
             body = gen_enum(td, spec)
         elif td.kind == "alias":
-            if name in res.ctx_handles:
+            if name in res.pipes:
+                # NDR pipe ([C706] 14.7): a chunked stream of the element type,
+                # marshalled with the `ndr:"pipe"` tag at the parameter site.
+                body = (f"// {name} is an NDR pipe of {res.pipes[name]} ([C706] 14.7, "
+                        f"[{spec}]); transmit with the `ndr:\"pipe\"` tag.\n"
+                        f"type {name} []{res.pipes[name]}\n")
+            elif name in res.ctx_handles:
                 body = gen_ctx_handle(name, spec)
             elif name in res.scalar_alias:
                 body = gen_scalar_alias(name, res.scalar_alias[name], spec)
@@ -1271,6 +1284,10 @@ def _param_field(res: TypeResolver, p: Param) -> tuple[str, str, set]:
     inline value; [unique] or a double pointer is a `*T` referent. Top-level
     array parameters use `ref` (not `unique`) so the count is not hoisted ahead
     of a preceding context handle."""
+    # An NDR pipe parameter (the IDL declares it as `PIPE_TYPE *`) is the slice
+    # type tagged `ndr:"pipe"`; the pointer is just MIDL's pipe-param convention.
+    if p.type.base in res.pipes:
+        return "structures." + p.type.base, "pipe", set()
     go, extra_ptr, imp = res.resolve_base(p.type.base)
     imports = {imp} if imp else set()
     # Local interface types live in the structures package and must be qualified


### PR DESCRIPTION
### Summary
Follow-up to #437 (NDR pipe codec support): teach the bundled `idlgen` generator to recognize `typedef pipe <T> NAME` and emit pipe-correct Go, so interfaces with pipes (e.g. MS-EFSR) generate the streaming code by construction instead of needing it hand-written.

### Changes
- **Parser:** mark a `typedef pipe …` declaration as a pipe (`Typedef.is_pipe`); the `pipe` keyword was already skipped, now its presence is recorded.
- **Resolver:** track pipe type names → Go element type (`res.pipes`); pipe typedefs are no longer degraded to a scalar alias.
- **Structures generator:** a pipe typedef emits `type NAME []<elem>` (e.g. `type EFS_EXIM_PIPE []uint8`) with a [C706] 14.7 doc note.
- **Functions generator:** a parameter whose type is a pipe is emitted as `structures.NAME` tagged `ndr:"pipe"` (the IDL's `NAME *` is MIDL's pipe-param convention, not a real pointer), and the exported signature uses the slice type.
- Skill review note updated: pipes are now generated (not hand-work); the remaining caveats are whole-pipe buffering and live validation.

### How Verified
Regenerated MS-EFSR with the updated generator:
- `structures/EFS_EXIM_PIPE.go` → `type EFS_EXIM_PIPE []uint8`
- `EfsRpcReadFileRaw` response → `EfsOutPipe structures.EFS_EXIM_PIPE \`ndr:"pipe"\``, signature returns `structures.EFS_EXIM_PIPE`
- `EfsRpcWriteFileRaw` request → `EfsInPipe structures.EFS_EXIM_PIPE \`ndr:"pipe"\``, signature takes `structures.EFS_EXIM_PIPE`
- the generated tree builds with `go build` (0 errors).

This is functionally identical to the hand-written EFSR raw methods merged in #437, so those files are now reproducible by the generator.

### Scope of Change
- **Files changed:** `.claude/skills/dcerpc-interface-structure/idlgen.py` and `SKILL.md` only. No Go-package changes.
- **Behavioral changes outside the generator:** none. The committed EFSR files (hand-refined doc comments, `[]byte`) are left as-is — they are the reviewed/refined form of what the generator now emits.