### PR TITLE
Fix AndX.Marshal/Unmarshal AndXOffset byte order (#441)

### DIFF
--- a/network/smb/smb_v10/message/commands/andx/andx.go
+++ b/network/smb/smb_v10/message/commands/andx/andx.go
@@ -43,7 +43,7 @@ func (a *AndX) Marshal() ([]byte, error) {
 	marshalled_andx = append(marshalled_andx, a.AndXReserved)
 
 	buf2 := make([]byte, 2)
-	binary.BigEndian.PutUint16(buf2, a.AndXOffset)
+	binary.LittleEndian.PutUint16(buf2, a.AndXOffset)
 	marshalled_andx = append(marshalled_andx, buf2...)
 
 	return marshalled_andx, nil
@@ -62,7 +62,7 @@ func (a *AndX) Unmarshal(data []byte) (int, error) {
 
 	a.AndXReserved = data[1]
 
-	a.AndXOffset = binary.BigEndian.Uint16(data[2:4])
+	a.AndXOffset = binary.LittleEndian.Uint16(data[2:4])
 
 	return 4, nil
 }

--- a/network/smb/smb_v10/message/commands/andx/andx_test.go
+++ b/network/smb/smb_v10/message/commands/andx/andx_test.go
@@ -54,7 +54,7 @@ func TestAndX_Marshal(t *testing.T) {
 				AndXReserved: 0x00,
 				AndXOffset:   0x1234,
 			},
-			expected:    []byte{0x2A, 0x00, 0x12, 0x34},
+			expected:    []byte{0x2A, 0x00, 0x34, 0x12},
 			expectError: false,
 		},
 		{
@@ -99,7 +99,7 @@ func TestAndX_Unmarshal(t *testing.T) {
 	}{
 		{
 			name: "Valid data",
-			data: []byte{0x2A, 0x00, 0x12, 0x34},
+			data: []byte{0x2A, 0x00, 0x34, 0x12},
 			expected: &andx.AndX{
 				AndXCommand:  0x2A,
 				AndXReserved: 0x00,


### PR DESCRIPTION
### Linked Issue
`Closes #441`

### Root Cause
`AndXOffset` is a 16-bit field in the SMB AndX block and, like every other SMB wire field, is little-endian. `AndX.Marshal` and `AndX.Unmarshal` used `binary.BigEndian` for this field, so the two offset bytes were emitted and consumed in the wrong order. The package's unit test was written to match the incorrect encoding, locking the defect in.

### Fix Description
Switch `AndX.Marshal` and `AndX.Unmarshal` to `binary.LittleEndian` for `AndXOffset`, and update `andx_test.go` so the marshal expectation and the unmarshal input use the correct little-endian byte sequence (`0x1234` ↔ `{0x34, 0x12}`). The two single-byte fields (`AndXCommand`, `AndXReserved`) are unaffected.

### How Verified
- **Tests:** `go test ./network/smb/smb_v10/message/commands/andx/...` passes. `TestAndX_Marshal` now asserts `AndXOffset = 0x1234` marshals to `{0x2A, 0x00, 0x34, 0x12}`; `TestAndX_Unmarshal` asserts `{0x2A, 0x00, 0x34, 0x12}` decodes to `AndXOffset = 0x1234`; the round trip is symmetric.
- **Static:** `AndXOffset` is now encoded consistently with the rest of the package, which is little-endian throughout.

### Test Coverage
- **Existing:** `TestAndX_Marshal` and `TestAndX_Unmarshal` in `network/smb/smb_v10/message/commands/andx/andx_test.go`, updated to assert the correct little-endian encoding.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/andx/andx.go`, `network/smb/smb_v10/message/commands/andx/andx_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local and safe. The current command marshal path serializes the AndX header via the little-endian `parameters` words path rather than `AndX.Marshal`, so existing client traffic is unaffected; this corrects the exported helpers and their test.
