### PR TITLE
Fix Connect to record server host/port as single source of truth (#442)

### DIFF
--- a/network/smb/smb_v10/client/client_functions.go
+++ b/network/smb/smb_v10/client/client_functions.go
@@ -49,6 +49,13 @@ func NewClientUsingTCPTransport(host net.IP, port int) *Client {
 //
 // Returns:
 func (c *Client) Connect(ipaddr net.IP, port int) error {
+	// Record the connection address as the single source of truth so that later
+	// operations (e.g. TreeConnect, which builds the UNC path from
+	// Connection.Server.Host) target the same server this connection is made to,
+	// rather than a stale value left by the constructor.
+	c.Connection.Server.Host = ipaddr
+	c.Connection.Server.Port = port
+
 	err := c.Transport.Connect(ipaddr, port)
 	if err != nil {
 		return fmt.Errorf("failed to connect to SMB server: %v", err)

--- a/network/smb/smb_v10/client/client_test.go
+++ b/network/smb/smb_v10/client/client_test.go
@@ -18,6 +18,36 @@ func (m *connectedMockTransport) Send(data []byte) (int, error)         { return
 func (m *connectedMockTransport) Receive() ([]byte, error)              { return nil, nil }
 func (m *connectedMockTransport) IsConnected() bool                     { return true }
 
+// TestConnectRecordsServerAddress verifies that Connect records its host/port
+// arguments in Connection.Server before connecting, so that later operations
+// (e.g. TreeConnect) target the same server, regardless of any value left by the
+// constructor. The mock transport reports success on Connect but returns no
+// negotiate response, so Connect itself returns an error after the address has
+// already been recorded.
+func TestConnectRecordsServerAddress(t *testing.T) {
+	c := &client.Client{
+		Transport: &connectedMockTransport{},
+		Connection: &client.Connection{
+			Server: &client.Server{
+				Host: net.IPv4(1, 1, 1, 1),
+				Port: 139,
+			},
+		},
+	}
+
+	want := net.IPv4(10, 1, 2, 3)
+	const wantPort = 4445
+
+	_ = c.Connect(want, wantPort)
+
+	if got := c.GetHost(); !got.Equal(want) {
+		t.Errorf("expected host %s after Connect, got %s", want, got)
+	}
+	if got := c.GetPort(); got != wantPort {
+		t.Errorf("expected port %d after Connect, got %d", wantPort, got)
+	}
+}
+
 // TestTreeConnectWithoutSession verifies that calling TreeConnect before a
 // session has been established returns an error rather than panicking with a
 // nil-pointer dereference on c.Session.


### PR DESCRIPTION
### Linked Issue
`Closes #442`

### Root Cause
`Client.Connect(ipaddr, port)` dialed the transport using its arguments but never assigned them to `Connection.Server.{Host,Port}`. Those fields are an independent source of truth that other code reads: `TreeConnect` builds the `\\host\share` UNC path from `Connection.Server.Host`, and `GetHost`/`GetPort` return them. When `Connect` was called with an address different from the one set by the constructor, the TCP/NBT connection and the UNC path (and the getters) referred to different servers.

### Fix Description
Record the `ipaddr`/`port` arguments into `Connection.Server.Host`/`Port` at the start of `Connect`, before dialing the transport. This makes the connection address the single source of truth that the rest of the client reads, eliminating the connect-to-A / tree-connect-to-B divergence without changing the method signature.

### How Verified
- **Tests:** `go test ./network/smb/smb_v10/client/...` passes. New test `TestConnectRecordsServerAddress` constructs a client whose `Server` holds a different address (1.1.1.1:139), calls `Connect(10.1.2.3, 4445)`, and asserts `GetHost()`/`GetPort()` return the `Connect` arguments. The mock transport reports a successful connect but returns no negotiate response, so the address is asserted to be recorded even though `Connect` then returns an error from negotiation.
- **Static:** `Connection.Server.{Host,Port}` are written before `Transport.Connect`, so any subsequent `TreeConnect`/`GetHost`/`GetPort` observe the address actually connected to.

### Test Coverage
- **Added:** `TestConnectRecordsServerAddress` in `network/smb/smb_v10/client/client_test.go`.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/client/client_functions.go`, `network/smb/smb_v10/client/client_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local and safe. Callers that already pass the same address to the constructor and to `Connect` see no behavioral change; callers that passed differing addresses now connect and tree-connect to the same (the `Connect`) address.
