### PR TITLE
Fix SessionSetup to gate the NTLMSSP second step on the chosen auth mode (#440)

### DIFF
--- a/network/smb/smb_v10/client/client_test.go
+++ b/network/smb/smb_v10/client/client_test.go
@@ -5,7 +5,11 @@ import (
 	"testing"
 
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/client"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header/flags"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/securitymode"
+	"github.com/TheManticoreProject/Manticore/windows/credentials"
 )
 
 // connectedMockTransport is a transport.Transport stub that reports itself as
@@ -17,6 +21,61 @@ func (m *connectedMockTransport) Close() error                          { return
 func (m *connectedMockTransport) Send(data []byte) (int, error)         { return len(data), nil }
 func (m *connectedMockTransport) Receive() ([]byte, error)              { return nil, nil }
 func (m *connectedMockTransport) IsConnected() bool                     { return true }
+
+// scriptedTransport reports itself as connected, returns a preset payload from
+// Receive, and counts how many times Send is called so a test can assert how
+// many SMB messages were transmitted.
+type scriptedTransport struct {
+	response  []byte
+	sendCount int
+}
+
+func (m *scriptedTransport) Connect(ipaddr net.IP, port int) error { return nil }
+func (m *scriptedTransport) Close() error                          { return nil }
+func (m *scriptedTransport) Send(data []byte) (int, error)         { m.sendCount++; return len(data), nil }
+func (m *scriptedTransport) Receive() ([]byte, error)              { return m.response, nil }
+func (m *scriptedTransport) IsConnected() bool                     { return true }
+
+// TestSessionSetupShareLevelCompletesInOneRoundTrip verifies that, when the
+// server uses share-level access control, SessionSetup completes after the
+// single step-1 round trip and captures the UID, rather than falling through
+// into the NTLMSSP authenticate second step.
+func TestSessionSetupShareLevelCompletesInOneRoundTrip(t *testing.T) {
+	const wantUID = 0x0801
+
+	resp := message.NewMessage()
+	resp.Header.SetFlags(flags.FLAGS_REPLY)
+	resp.Header.UID = wantUID
+	resp.Header.Status = 0x00000000
+	resp.AddCommand(commands.NewSessionSetupAndxResponse())
+	raw, err := resp.Marshal()
+	if err != nil {
+		t.Fatalf("failed to marshal mock response: %v", err)
+	}
+
+	tr := &scriptedTransport{response: raw}
+	c := &client.Client{
+		Transport: tr,
+		Connection: &client.Connection{
+			// SecurityMode 0 => share-level access control, no challenge/response,
+			// so SessionSetup must not attempt the NTLMSSP second step.
+			Server: &client.Server{SecurityMode: 0},
+		},
+	}
+
+	if err := c.SessionSetup(&credentials.Credentials{}); err != nil {
+		t.Fatalf("share-level SessionSetup returned error: %v", err)
+	}
+	if tr.sendCount != 1 {
+		t.Errorf("expected exactly 1 message sent (no NTLMSSP second step), got %d", tr.sendCount)
+	}
+	if c.Session == nil {
+		t.Fatal("expected a session after SessionSetup, got nil")
+	}
+	if c.Session.SessionUID != wantUID {
+		t.Errorf("expected SessionUID 0x%04x, got 0x%04x", wantUID, c.Session.SessionUID)
+	}
+}
 
 // TestTreeConnectWithoutSession verifies that calling TreeConnect before a
 // session has been established returns an error rather than panicking with a

--- a/network/smb/smb_v10/client/session.go
+++ b/network/smb/smb_v10/client/session.go
@@ -81,6 +81,11 @@ func (s *Session) SessionSetup() error {
 	sessionSetupCmd.NativeOS = s.Client.NativeOS
 	sessionSetupCmd.NativeLanMan = s.Client.NativeLanMan
 
+	// Track whether step 1 used the extended-security (NTLMSSP) challenge/response
+	// path. Only that path performs the second-step authenticate exchange below;
+	// the share-level and plaintext paths complete in a single round trip.
+	useExtendedSecurity := false
+
 	// Check if we're using share level access control
 	if s.Client.Connection.Server.SecurityMode.SupportsShareLevelAccessControl() {
 		// Share level access control is required by the server
@@ -105,6 +110,7 @@ func (s *Session) SessionSetup() error {
 		if s.Client.Connection.Server.SecurityMode.SupportsChallengeResponseAuth() {
 			// Server supports challenge/response authentication
 			// Determine authentication type based on policies
+			useExtendedSecurity = true
 
 			sessionSetupCmd.VcNumber = types.USHORT(0x0000)
 			sessionSetupCmd.SessionKey = s.Client.Connection.Server.SessionKey
@@ -204,6 +210,22 @@ func (s *Session) SessionSetup() error {
 	}
 
 	challengeResponse := responseMsg.Command.(*commands.SessionSetupAndxResponse)
+
+	// Share-level and plaintext authentication complete in a single round trip.
+	// Only the extended-security (NTLMSSP) path continues to the authenticate
+	// step below; for the other paths the step-1 response is the final response,
+	// so validate its status and finalize here instead of treating the response
+	// as an NTLMSSP challenge.
+	if !useExtendedSecurity {
+		if responseMsg.Header.Status != 0x00 {
+			if name, ok := nt_status.NTStatusToStringName[nt_status.NT_STATUS(responseMsg.Header.Status)]; ok {
+				return fmt.Errorf("session setup failed: %s (0x%08x)", name, responseMsg.Header.Status)
+			}
+			return fmt.Errorf("session setup failed: 0x%08x", responseMsg.Header.Status)
+		}
+		s.SessionUID = responseMsg.Header.UID
+		return nil
+	}
 
 	// Prepare and send a NTLMSSP AUTH message ==================================================================================================
 


### PR DESCRIPTION
### Linked Issue
`Closes #440`

### Root Cause
`Session.SessionSetup` selected one of three step-1 request shapes — share-level, plaintext, or extended-security (NTLMSSP) challenge/response — based on the server's security mode. After receiving the step-1 response, however, the function had a single unconditional code path that constructed an NTLMSSP auth context and called `CreateAuthenticateTokenFromChallengeToken(challengeResponse.SecurityBlob)`, then sent a second message. The auth mode chosen in step 1 never influenced step 2, so the share-level and plaintext branches were effectively dead: their (non-NTLMSSP) step-1 response was misinterpreted as an NTLMSSP CHALLENGE and an authenticate token was computed from an empty or non-NTLMSSP blob. Only the extended-security path could complete.

### Fix Description
Introduce a `useExtendedSecurity` flag, set to true only in the challenge/response branch. After the step-1 response is received and validated as `SMB_COM_SESSION_SETUP_ANDX`, return early for the non-extended paths: the step-1 response is the final response for share-level and plaintext authentication, so the fix checks its status (formatting a known NT status name when available, mirroring the existing extended-security error handling) and, on success, records the session UID and returns. The NTLMSSP authenticate second step now runs only when `useExtendedSecurity` is true. The extended-security path is unchanged.

### How Verified
- **Tests:** `go test ./network/smb/smb_v10/client/...` passes. New test `TestSessionSetupShareLevelCompletesInOneRoundTrip` drives the share-level path (server `SecurityMode = 0`) with a scripted transport and asserts that exactly one message is sent (no NTLMSSP second step), that `SessionSetup` returns no error, and that `Session.SessionUID` is captured from the response.
- **Static:** With `useExtendedSecurity` false, control returns before the authenticate-token construction at the former unconditional path; with it true, the extended-security exchange proceeds exactly as before.

### Test Coverage
- **Added:** `TestSessionSetupShareLevelCompletesInOneRoundTrip` in `network/smb/smb_v10/client/client_test.go` (plus a `scriptedTransport` helper that counts sends and returns a preset response).

### Scope of Change
- **Files changed:** `network/smb/smb_v10/client/session.go`, `network/smb/smb_v10/client/client_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local and safe. The extended-security (NTLMSSP) path — the only one that previously worked and the one exercised by live testing — is unchanged; the fix only adds a correct early completion for the share-level and plaintext paths that previously could not succeed.

### Notes
Full signing for signing-required servers remains tracked separately in #439; this change does not address message signing.
