### PR TITLE
Fix SessionSetupAndxResponse to honor SMB_FLAGS2_UNICODE when decoding strings (#381)

### DIFF
--- a/network/smb/smb_v10/message/commands/SessionSetupAndxResponse.go
+++ b/network/smb/smb_v10/message/commands/SessionSetupAndxResponse.go
@@ -239,8 +239,10 @@ func (c *SessionSetupAndxResponse) Unmarshal(rawData []byte) (int, error) {
 	// c.Pad = rawDataContent[offset : offset+padLen]
 	// offset += padLen
 
-	// TODO: Get the information from the SMB header
-	useUnicode := true
+	// Decode the NativeOS/NativeLanMan strings using the character encoding the
+	// enclosing message declared via the SMB_FLAGS2_UNICODE header flag, which the
+	// message layer propagates to this command before Unmarshal.
+	useUnicode := c.IsUnicode()
 
 	// Unmarshalling data NativeOS
 	if useUnicode {

--- a/network/smb/smb_v10/message/commands/command_interface/command_interface.go
+++ b/network/smb/smb_v10/message/commands/command_interface/command_interface.go
@@ -56,6 +56,14 @@ type CommandInterface interface {
 
 	// Init initializes the command
 	Init()
+
+	// SetUnicode records whether the enclosing SMB message uses Unicode strings
+	// (the SMB_FLAGS2_UNICODE header flag), so that Unmarshal can decode
+	// string fields with the correct character encoding.
+	SetUnicode(bool)
+
+	// IsUnicode reports whether the enclosing SMB message uses Unicode strings.
+	IsUnicode() bool
 }
 
 // Command is a struct that implements the CommandInterface
@@ -74,6 +82,11 @@ type Command struct {
 
 	// Next command
 	NextCommand CommandInterface
+
+	// Unicode records whether the enclosing SMB message uses Unicode strings
+	// (the SMB_FLAGS2_UNICODE header flag). It is set by the message layer
+	// before Unmarshal so string fields are decoded with the right encoding.
+	Unicode bool
 }
 
 // Init initializes the command
@@ -92,6 +105,22 @@ func (c *Command) Init() {
 	}
 
 	c.NextCommand = nil
+}
+
+// SetUnicode records whether the enclosing SMB message uses Unicode strings.
+//
+// Parameters:
+//   - unicode: True if the SMB_FLAGS2_UNICODE header flag is set
+func (c *Command) SetUnicode(unicode bool) {
+	c.Unicode = unicode
+}
+
+// IsUnicode reports whether the enclosing SMB message uses Unicode strings.
+//
+// Returns:
+//   - bool: True if the SMB_FLAGS2_UNICODE header flag is set
+func (c *Command) IsUnicode() bool {
+	return c.Unicode
 }
 
 // GetCommandCode returns the command code

--- a/network/smb/smb_v10/message/header/flags2/flags2.go
+++ b/network/smb/smb_v10/message/header/flags2/flags2.go
@@ -73,6 +73,10 @@ func (f Flags2) IsExtendedSecurity() bool {
 	return f&FLAGS2_EXTENDED_SECURITY != 0
 }
 
+func (f Flags2) IsUnicode() bool {
+	return f&FLAGS2_UNICODE != 0
+}
+
 func (f Flags2) IsDfs() bool {
 	return f&FLAGS2_DFS != 0
 }
@@ -83,10 +87,6 @@ func (f Flags2) IsPagingIO() bool {
 
 func (f Flags2) IsNTStatusErrorCodes() bool {
 	return f&FLAGS2_NT_STATUS_ERROR_CODES != 0
-}
-
-func (f Flags2) IsUnicode() bool {
-	return f&FLAGS2_UNICODE != 0
 }
 
 // String returns a string representation of the flags2 that are set,

--- a/network/smb/smb_v10/message/message.go
+++ b/network/smb/smb_v10/message/message.go
@@ -128,6 +128,10 @@ func (m *Message) Unmarshal(marshalledData []byte) error {
 	// and that the parameters and data are not nil
 	c.Init()
 
+	// Propagate the message's Unicode setting (SMB_FLAGS2_UNICODE) so the command
+	// decodes string fields with the correct character encoding.
+	c.SetUnicode(m.Header.Flags2.IsUnicode())
+
 	// Unmarshal the command
 	_, err = c.Unmarshal(marshalledData)
 	if err != nil {

--- a/network/smb/smb_v10/message/sessionsetup_unicode_test.go
+++ b/network/smb/smb_v10/message/sessionsetup_unicode_test.go
@@ -1,0 +1,78 @@
+package message_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header/flags"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header/flags2"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+)
+
+// roundTripSessionSetupResponse marshals a SessionSetupAndxResponse carrying the
+// given NativeOS/NativeLanMan bytes inside a reply message whose Flags2 has (or
+// lacks) the Unicode bit, then unmarshals it back and returns the decoded command.
+func roundTripSessionSetupResponse(t *testing.T, unicode bool, nativeOS, nativeLanMan []byte) *commands.SessionSetupAndxResponse {
+	t.Helper()
+
+	msg := message.NewMessage()
+	msg.Header.SetFlags(flags.FLAGS_REPLY)
+	if unicode {
+		msg.Header.Flags2 = flags2.FLAGS2_UNICODE
+	}
+
+	resp := commands.NewSessionSetupAndxResponse()
+	resp.NativeOS = []types.UCHAR(nativeOS)
+	resp.NativeLanMan = []types.UCHAR(nativeLanMan)
+	msg.AddCommand(resp)
+
+	raw, err := msg.Marshal()
+	if err != nil {
+		t.Fatalf("failed to marshal message: %v", err)
+	}
+
+	out := message.NewMessage()
+	if err := out.Unmarshal(raw); err != nil {
+		t.Fatalf("failed to unmarshal message: %v", err)
+	}
+
+	decoded, ok := out.Command.(*commands.SessionSetupAndxResponse)
+	if !ok {
+		t.Fatalf("unexpected command type %T", out.Command)
+	}
+	return decoded
+}
+
+// TestSessionSetupResponseDecodesOEMStrings verifies that, when the message does
+// not set SMB_FLAGS2_UNICODE, the NativeOS/NativeLanMan strings are decoded as
+// OEM (single-byte) strings rather than UTF-16.
+func TestSessionSetupResponseDecodesOEMStrings(t *testing.T) {
+	decoded := roundTripSessionSetupResponse(t, false, []byte("Unix\x00"), []byte("Samba\x00"))
+
+	if got := string(decoded.NativeOS); got != "Unix" {
+		t.Errorf("expected NativeOS %q, got %q", "Unix", got)
+	}
+	if got := string(decoded.NativeLanMan); got != "Samba" {
+		t.Errorf("expected NativeLanMan %q, got %q", "Samba", got)
+	}
+}
+
+// TestSessionSetupResponseDecodesUnicodeStrings verifies that, when the message
+// sets SMB_FLAGS2_UNICODE, the NativeOS/NativeLanMan strings are decoded as
+// UTF-16LE byte runs (read up to the double-null terminator).
+func TestSessionSetupResponseDecodesUnicodeStrings(t *testing.T) {
+	// UTF-16LE "Win" and "SMB" followed by a 2-byte null terminator.
+	nativeOS := []byte{'W', 0, 'i', 0, 'n', 0, 0, 0}
+	nativeLanMan := []byte{'S', 0, 'M', 0, 'B', 0, 0, 0}
+
+	decoded := roundTripSessionSetupResponse(t, true, nativeOS, nativeLanMan)
+
+	if want := []byte{'W', 0, 'i', 0, 'n', 0}; !bytes.Equal(decoded.NativeOS, want) {
+		t.Errorf("expected NativeOS bytes %v, got %v", want, []byte(decoded.NativeOS))
+	}
+	if want := []byte{'S', 0, 'M', 0, 'B', 0}; !bytes.Equal(decoded.NativeLanMan, want) {
+		t.Errorf("expected NativeLanMan bytes %v, got %v", want, []byte(decoded.NativeLanMan))
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #381`

### Root Cause
A command's `Unmarshal` receives only the command byte slice and had no access to the enclosing SMB header, so `SessionSetupAndxResponse.Unmarshal` could not tell whether the server's strings were OEM or UTF-16. It worked around this with a hardcoded `useUnicode := true` (and a `// TODO: Get the information from the SMB header`), so a non-Unicode (OEM) response had its `NativeOS`/`NativeLanMan` fields misdecoded.

### Fix Description
Plumb the message's Unicode setting down to the command layer. A `Unicode` field plus `SetUnicode`/`IsUnicode` accessors are added to the base `command_interface.Command` (and to the `CommandInterface`); because every command embeds `Command`, all commands satisfy the interface without further changes. `Message.Unmarshal` sets this flag from `Header.Flags2.IsUnicode()` immediately after `Init()` and before calling the command's `Unmarshal`. `SessionSetupAndxResponse.Unmarshal` now reads `c.IsUnicode()` instead of the hardcoded `true`, decoding `NativeOS`/`NativeLanMan` with the encoding the message actually declared.

### How Verified
- **Tests:** `go test ./network/smb/smb_v10/...` passes. New tests in `network/smb/smb_v10/message/sessionsetup_unicode_test.go`: `TestSessionSetupResponseDecodesOEMStrings` round-trips a reply without `SMB_FLAGS2_UNICODE` and asserts `NativeOS`/`NativeLanMan` decode as OEM (`"Unix"`, `"Samba"`); `TestSessionSetupResponseDecodesUnicodeStrings` round-trips a reply with the flag set and asserts the UTF-16LE byte runs are recovered up to the double-null terminator.
- **Static:** `Message.Unmarshal` sets the flag before delegating, so the command observes the correct encoding for both paths.

### Test Coverage
- **Added:** `TestSessionSetupResponseDecodesOEMStrings` and `TestSessionSetupResponseDecodesUnicodeStrings` in `network/smb/smb_v10/message/sessionsetup_unicode_test.go`.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/command_interface/command_interface.go`, `network/smb/smb_v10/message/message.go`, `network/smb/smb_v10/message/commands/SessionSetupAndxResponse.go`, `network/smb/smb_v10/message/sessionsetup_unicode_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Low. The new flag defaults to `false`; only `SessionSetupAndxResponse` consumes it today, and the message layer always sets it from the header before `Unmarshal`. The Unicode path (used against the live test servers) is preserved; the OEM path is corrected.

### Notes
The same `SetUnicode`/`IsUnicode` plumbing is now available to any other command whose string decoding depends on `SMB_FLAGS2_UNICODE`; no other command currently hardcodes the encoding.
