### PR TITLE
Fix Message.Unmarshal to follow the AndX chain (#438)

### DIFF
--- a/network/smb/smb_v10/message/andx_chain_test.go
+++ b/network/smb/smb_v10/message/andx_chain_test.go
@@ -1,0 +1,92 @@
+package message_test
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/codes"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header/flags"
+)
+
+// TestUnmarshalFollowsAndXChain verifies that Message.Unmarshal decodes every
+// command in a batched ("AndX") message, not just the first. It assembles the
+// classic SESSION_SETUP_ANDX + TREE_CONNECT_ANDX response pair with a
+// spec-compliant (little-endian) AndXOffset and asserts the chain is recovered.
+func TestUnmarshalFollowsAndXChain(t *testing.T) {
+	// Marshal a standalone TreeConnectAndxResponse to obtain its command block
+	// (everything after the SMB header).
+	bMsg := message.NewMessage()
+	bMsg.Header.SetFlags(flags.FLAGS_REPLY)
+	bMsg.AddCommand(commands.NewTreeConnectAndxResponse())
+	bRaw, err := bMsg.Marshal()
+	if err != nil {
+		t.Fatalf("failed to marshal TreeConnectAndxResponse: %v", err)
+	}
+	bBlock := bRaw[header.SMB_HEADER_SIZE:]
+
+	// Marshal a SessionSetupAndxResponse message: header + first command block.
+	aMsg := message.NewMessage()
+	aMsg.Header.SetFlags(flags.FLAGS_REPLY)
+	aMsg.AddCommand(commands.NewSessionSetupAndxResponse())
+	aRaw, err := aMsg.Marshal()
+	if err != nil {
+		t.Fatalf("failed to marshal SessionSetupAndxResponse: %v", err)
+	}
+
+	// Assemble the batched message and patch the first command's AndX block to
+	// point at the second command. The AndX block follows the WordCount byte:
+	// AndXCommand(1) AndXReserved(1) AndXOffset(2, little-endian). AndXOffset is
+	// measured from the start of the SMB header, which is exactly len(aRaw) (the
+	// index of the second command's WordCount within the assembled buffer).
+	full := append(append([]byte{}, aRaw...), bBlock...)
+	andxCommandPos := header.SMB_HEADER_SIZE + 1
+	full[andxCommandPos] = byte(codes.SMB_COM_TREE_CONNECT_ANDX)
+	full[andxCommandPos+1] = 0x00 // AndXReserved
+	binary.LittleEndian.PutUint16(full[andxCommandPos+2:andxCommandPos+4], uint16(len(aRaw)))
+
+	out := message.NewMessage()
+	if err := out.Unmarshal(full); err != nil {
+		t.Fatalf("Unmarshal returned error: %v", err)
+	}
+
+	if _, ok := out.Command.(*commands.SessionSetupAndxResponse); !ok {
+		t.Fatalf("expected first command *SessionSetupAndxResponse, got %T", out.Command)
+	}
+	if got := out.Command.GetChainLength(); got != 2 {
+		t.Fatalf("expected chain length 2, got %d", got)
+	}
+	next := out.Command.GetNextCommand()
+	if next == nil {
+		t.Fatal("expected a chained command after the first, got nil")
+	}
+	if _, ok := next.(*commands.TreeConnectAndxResponse); !ok {
+		t.Errorf("expected chained command *TreeConnectAndxResponse, got %T", next)
+	}
+}
+
+// TestUnmarshalNonAndXLeavesNoChain verifies that a non-AndX command (here a
+// NegotiateResponse) is decoded with no chained command, i.e. the AndX-following
+// loop does not run for commands that are not batched.
+func TestUnmarshalNonAndXLeavesNoChain(t *testing.T) {
+	msg := message.NewMessage()
+	msg.Header.SetFlags(flags.FLAGS_REPLY)
+	msg.AddCommand(commands.NewNegotiateResponse())
+	raw, err := msg.Marshal()
+	if err != nil {
+		t.Fatalf("failed to marshal NegotiateResponse: %v", err)
+	}
+
+	out := message.NewMessage()
+	if err := out.Unmarshal(raw); err != nil {
+		t.Fatalf("Unmarshal returned error: %v", err)
+	}
+	if got := out.Command.GetChainLength(); got != 1 {
+		t.Errorf("expected chain length 1 for a non-AndX command, got %d", got)
+	}
+	if next := out.Command.GetNextCommand(); next != nil {
+		t.Errorf("expected no chained command, got %T", next)
+	}
+}

--- a/network/smb/smb_v10/message/commands/command_interface/command_interface.go
+++ b/network/smb/smb_v10/message/commands/command_interface/command_interface.go
@@ -201,7 +201,11 @@ func (c *Command) SetData(data *data.Data) {
 // Returns:
 //   - CommandInterface: The next command in the chain
 func (c *Command) GetNextCommand() CommandInterface {
-	if c.AndX != nil && c.IsAndX() {
+	// A chained command is present only when an AndX block has been recorded.
+	// (The guard cannot also call c.IsAndX(): from this embedded base method that
+	// call resolves to the base IsAndX, not the concrete command's override, so it
+	// would always be false and hide a linked command.)
+	if c.AndX != nil {
 		return c.NextCommand
 	}
 	return nil

--- a/network/smb/smb_v10/message/message.go
+++ b/network/smb/smb_v10/message/message.go
@@ -1,9 +1,12 @@
 package message
 
 import (
+	"encoding/binary"
 	"fmt"
 
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/andx"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/codes"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/command_interface"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header"
 )
@@ -108,36 +111,81 @@ func (m *Message) Unmarshal(marshalledData []byte) error {
 	if err != nil {
 		return err
 	}
-	marshalledData = marshalledData[bytesRead:]
+	// Keep the full message buffer: AndX offsets are measured from the start of
+	// the SMB header, so the chain can only be resolved against the whole message.
+	fullData := marshalledData
+	headerSize := bytesRead
 
-	var c command_interface.CommandInterface
-	if m.Header.IsResponse() {
-		c, err = commands.CreateResponseCommand(m.Header.Command)
-		if err != nil {
-			return err
+	// newCommand builds the appropriate command type for a command code, based on
+	// whether this message is a request or a response.
+	newCommand := func(code codes.CommandCode) (command_interface.CommandInterface, error) {
+		if m.Header.IsResponse() {
+			return commands.CreateResponseCommand(code)
 		}
-	} else {
-		c, err = commands.CreateRequestCommand(m.Header.Command)
-		if err != nil {
-			return err
-		}
+		return commands.CreateRequestCommand(code)
 	}
 
-	// Init the command
-	// This is necessary to ensure that the command is initialized
-	// and that the parameters and data are not nil
-	c.Init()
-
-	// Propagate the message's Unicode setting (SMB_FLAGS2_UNICODE) so the command
-	// decodes string fields with the correct character encoding.
-	c.SetUnicode(m.Header.Flags2.IsUnicode())
-
-	// Unmarshal the command
-	_, err = c.Unmarshal(marshalledData)
+	// Decode the first command, located immediately after the header.
+	c, err := newCommand(m.Header.Command)
 	if err != nil {
 		return err
 	}
+	// Init ensures the parameters and data structures are not nil.
+	c.Init()
+	// Propagate the message's Unicode setting (SMB_FLAGS2_UNICODE) so the command
+	// decodes string fields with the correct character encoding.
+	c.SetUnicode(m.Header.Flags2.IsUnicode())
+	if _, err = c.Unmarshal(fullData[headerSize:]); err != nil {
+		return err
+	}
 	m.Command = c
+
+	// Follow the AndX chain. A batched ("AndX") command begins its parameter words
+	// with AndXCommand(1) AndXReserved(1) AndXOffset(2, little-endian); AndXOffset
+	// is the distance in bytes from the start of the SMB header to the next
+	// command's WordCount field. Decode each chained command and link it in, until
+	// the terminator (SMB_COM_NO_ANDX_COMMAND) or a null link is reached.
+	prev := c
+	commandStart := headerSize
+	for prev.IsAndX() {
+		// WordCount(1) precedes the AndX words, so the AndX block occupies
+		// [commandStart+1 : commandStart+5].
+		if commandStart+5 > len(fullData) {
+			break
+		}
+		andxCommand := codes.CommandCode(fullData[commandStart+1])
+		andxReserved := fullData[commandStart+2]
+		andxOffset := int(binary.LittleEndian.Uint16(fullData[commandStart+3 : commandStart+5]))
+
+		if andxCommand == codes.SMB_COM_NO_ANDX_COMMAND || andxOffset == 0 {
+			break
+		}
+		if andxOffset < header.SMB_HEADER_SIZE || andxOffset >= len(fullData) {
+			return fmt.Errorf("AndX offset %d out of bounds (message is %d bytes)", andxOffset, len(fullData))
+		}
+
+		next, err := newCommand(andxCommand)
+		if err != nil {
+			return err
+		}
+		next.Init()
+		next.SetUnicode(m.Header.Flags2.IsUnicode())
+		if _, err = next.Unmarshal(fullData[andxOffset:]); err != nil {
+			return err
+		}
+
+		// GetNextCommand only traverses the chain when the command carries an AndX
+		// struct, so record the parsed linkage on the previous command before linking.
+		linkAndX := andx.NewAndX()
+		linkAndX.AndXCommand = andxCommand
+		linkAndX.AndXReserved = andxReserved
+		linkAndX.AndXOffset = uint16(andxOffset)
+		prev.SetAndX(linkAndX)
+		prev.AddCommandToChain(next)
+
+		prev = next
+		commandStart = andxOffset
+	}
 
 	return nil
 }


### PR DESCRIPTION
### Linked Issue
`Closes #438`

### Root Cause
`Message.Unmarshal` created a single command, called its `Unmarshal` once, and assigned `m.Command`, with no loop to follow the AndX chain — so every batched command after the first was silently dropped, despite the method's documented contract ("multiple parameter-data blocks will be unmarshalled sequentially"). Separately, `Command.GetNextCommand` guarded on `c.AndX != nil && c.IsAndX()`; from the embedded base method, `c.IsAndX()` resolves to the base implementation (always `false`) rather than the concrete command's override, so it always returned `nil`. The combination meant batched responses (e.g. `SESSION_SETUP_ANDX` + `TREE_CONNECT_ANDX`) could neither be decoded nor traversed.

### Fix Description
`Message.Unmarshal` now keeps the full message buffer and, after decoding the first command, follows the AndX chain: for each AndX command it reads the AndX block that follows the WordCount byte — `AndXCommand(1) AndXReserved(1) AndXOffset(2, little-endian)` — where `AndXOffset` is the distance from the start of the SMB header to the next command's WordCount. It decodes the next command at that offset (bounds-checked), records the parsed AndX linkage on the previous command, and links it via `AddCommandToChain`, stopping at the `SMB_COM_NO_ANDX_COMMAND` terminator or a null/zero link. Request vs. response command construction is selected once via a small helper. `Command.GetNextCommand` is corrected to gate solely on `c.AndX != nil` (set by the unmarshal loop only when a real successor exists), removing the broken `IsAndX()` call so the linked chain is traversable.

### How Verified
- **Tests:** `go test ./network/smb/smb_v10/...` passes. New `TestUnmarshalFollowsAndXChain` assembles a spec-compliant `SESSION_SETUP_ANDX` + `TREE_CONNECT_ANDX` reply with a little-endian `AndXOffset` and asserts the first command is `*SessionSetupAndxResponse`, the chain length is 2, and `GetNextCommand()` returns `*TreeConnectAndxResponse`. `TestUnmarshalNonAndXLeavesNoChain` confirms a `NegotiateResponse` decodes with chain length 1 and no successor, so the loop does not run for non-AndX commands.
- **Static:** the loop terminates on the `0xFF` terminator, a zero offset, an out-of-bounds offset (error), or a non-AndX command, so it cannot loop unbounded.

### Test Coverage
- **Added:** `TestUnmarshalFollowsAndXChain` and `TestUnmarshalNonAndXLeavesNoChain` in `network/smb/smb_v10/message/andx_chain_test.go`.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/message.go`, `network/smb/smb_v10/message/commands/command_interface/command_interface.go`, `network/smb/smb_v10/message/andx_chain_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none. The `GetNextCommand` correction is required for the decoded chain to be reachable; it previously always returned `nil`, and no caller depended on that.

### Risk and Rollout
Low. Non-AndX messages take the same single-command path as before (the loop never runs). Decoding follows offsets the server itself provides, with bounds checks. The high-level client currently issues unbatched commands, so existing flows are unchanged; batched server responses are now decoded.

### Notes
The AndX block is read directly from the wire in spec order (AndXCommand first, AndXOffset little-endian), matching what real servers emit. This PR touches `message.go`; it overlaps with #447 (which adds a Unicode-flag line in the same function) and may need a trivial rebase depending on merge order.
