### PR TITLE
Fix ReadAndxResponse to carry the read data payload (#380)

### DIFF
--- a/network/smb/smb_v10/message/commands/ReadAndxResponse.go
+++ b/network/smb/smb_v10/message/commands/ReadAndxResponse.go
@@ -8,9 +8,20 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/codes"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/command_interface"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/data"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/parameters"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
 )
+
+// readAndxResponseParameterWords is the fixed number of 2-byte parameter words in
+// an SMB_COM_READ_ANDX response: the 2-word AndX block plus Available,
+// DataCompactionMode, Reserved1, DataLength, DataOffset, and the 5-word Reserved2.
+const readAndxResponseParameterWords = 12
+
+// readAndxResponseDataOffset is the offset, in bytes from the start of the SMB
+// header, at which this response's data bytes begin when no pad is inserted:
+// header + WordCount(1) + parameter words + ByteCount(2).
+const readAndxResponseDataOffset = header.SMB_HEADER_SIZE + 1 + 2*readAndxResponseParameterWords + 2
 
 // ReadAndxResponse
 // Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/89d6b552-5406-445c-85d5-54c80b94a20f
@@ -43,6 +54,13 @@ type ReadAndxResponse struct {
 	// reserved in order to make the SMB_COM_READ_ANDX Response the same size as the
 	// SMB_COM_WRITE_ANDX Response.
 	Reserved2 [5]types.USHORT
+
+	// Data
+
+	// Data (variable): The actual bytes read from the file. On the wire these are
+	// located at DataOffset (measured from the start of the SMB header) and are
+	// DataLength bytes long.
+	Data []types.UCHAR
 }
 
 // NewReadAndxResponse creates a new ReadAndxResponse structure
@@ -58,6 +76,9 @@ func NewReadAndxResponse() *ReadAndxResponse {
 		Reserved1:          types.USHORT(0),
 		DataLength:         types.USHORT(0),
 		DataOffset:         types.USHORT(0),
+
+		// Data
+		Data: []types.UCHAR{},
 	}
 
 	c.Command.SetCommandCode(codes.SMB_COM_READ_ANDX)
@@ -102,7 +123,15 @@ func (c *ReadAndxResponse) Marshal() ([]byte, error) {
 	// First marshal the data and then the parameters
 	// This is because some parameters are dependent on the data, for example the size of some fields within
 	// the data will be stored in the parameters
+
+	// Place the file data immediately after the data block's ByteCount (no pad)
+	// and advertise its length and its absolute offset from the start of the SMB
+	// header so the parameter fields below carry the matching values.
+	c.DataLength = types.USHORT(len(c.Data))
+	c.DataOffset = types.USHORT(readAndxResponseDataOffset)
+
 	rawDataContent := []byte{}
+	rawDataContent = append(rawDataContent, c.Data...)
 
 	// Then marshal the parameters
 	rawParametersContent := []byte{}
@@ -187,7 +216,7 @@ func (c *ReadAndxResponse) Unmarshal(rawData []byte) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	_ = c.GetData().GetBytes()
+	rawDataContent := c.GetData().GetBytes()
 
 	// If the parameters and data are empty, this is a response containing an error code in
 	// the SMB Header Status field
@@ -245,9 +274,18 @@ func (c *ReadAndxResponse) Unmarshal(rawData []byte) (int, error) {
 		offset += 2
 	}
 
-	// Then unmarshal the data
+	// Then unmarshal the data. The file bytes are the trailing DataLength bytes of
+	// the data block; any pad inserted to align the data to DataOffset precedes them.
 	offset = 0
-	// No data is sent in this message
+	if c.DataLength > 0 {
+		if int(c.DataLength) > len(rawDataContent) {
+			return offset, fmt.Errorf("ReadAndx DataLength %d exceeds data block size %d", c.DataLength, len(rawDataContent))
+		}
+		c.Data = append([]types.UCHAR{}, rawDataContent[len(rawDataContent)-int(c.DataLength):]...)
+		offset = int(c.DataLength)
+	} else {
+		c.Data = []types.UCHAR{}
+	}
 
 	return offset, nil
 }

--- a/network/smb/smb_v10/message/commands/ReadAndxResponse_test.go
+++ b/network/smb/smb_v10/message/commands/ReadAndxResponse_test.go
@@ -1,0 +1,65 @@
+package commands
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+)
+
+// TestReadAndxResponseDataRoundTrip verifies that ReadAndxResponse can both
+// serialize the bytes read from a file and recover them on Unmarshal, with
+// DataLength/DataOffset set consistently.
+func TestReadAndxResponseDataRoundTrip(t *testing.T) {
+	payload := []byte("the quick brown fox\x00\x01\x02jumps over")
+
+	resp := NewReadAndxResponse()
+	resp.Available = types.USHORT(0)
+	resp.Data = []types.UCHAR(payload)
+
+	raw, err := resp.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	if int(resp.DataLength) != len(payload) {
+		t.Errorf("expected DataLength %d after Marshal, got %d", len(payload), resp.DataLength)
+	}
+	if resp.DataOffset != readAndxResponseDataOffset {
+		t.Errorf("expected DataOffset %d after Marshal, got %d", readAndxResponseDataOffset, resp.DataOffset)
+	}
+
+	decoded := NewReadAndxResponse()
+	if _, err := decoded.Unmarshal(raw); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+
+	if int(decoded.DataLength) != len(payload) {
+		t.Errorf("expected decoded DataLength %d, got %d", len(payload), decoded.DataLength)
+	}
+	if !bytes.Equal([]byte(decoded.Data), payload) {
+		t.Errorf("decoded data mismatch:\n want %v\n got  %v", payload, []byte(decoded.Data))
+	}
+}
+
+// TestReadAndxResponseEmptyData verifies that an end-of-file read (DataLength 0)
+// round-trips to an empty Data slice without error.
+func TestReadAndxResponseEmptyData(t *testing.T) {
+	resp := NewReadAndxResponse()
+
+	raw, err := resp.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	decoded := NewReadAndxResponse()
+	if _, err := decoded.Unmarshal(raw); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if len(decoded.Data) != 0 {
+		t.Errorf("expected empty Data, got %d bytes", len(decoded.Data))
+	}
+	if decoded.DataLength != 0 {
+		t.Errorf("expected DataLength 0, got %d", decoded.DataLength)
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #380`

### Root Cause
`ReadAndxResponse` modelled the parameter fields (`DataLength`, `DataOffset`, etc.) but had no field for the bytes read from the file. `Marshal` built an empty data block and `Unmarshal` discarded the data block (`_ = c.GetData().GetBytes()`) and ended with "No data is sent in this message". Since SMB_COM_READ_ANDX exists to return file bytes in the data block (located by `DataOffset`/`DataLength`), the structure could neither serialize nor parse its payload; the high-level client had to slice the raw response bytes itself.

### Fix Description
Add a `Data []types.UCHAR` field. On `Marshal`, the file bytes are placed immediately after the data block's `ByteCount` (no pad), and `DataLength` is set to their length while `DataOffset` is set to the constant absolute offset of the data block from the start of the SMB header (`header + WordCount(1) + 12 parameter words + ByteCount(2)`), so the emitted parameters point at the emitted data. On `Unmarshal`, the file bytes are recovered as the trailing `DataLength` bytes of the data block (any alignment pad precedes them), bounds-checked against the data block size. This trailing-bytes approach avoids depending on the command's absolute position in the message, so it works whether the command is parsed standalone or within a larger buffer. An end-of-file read (`DataLength == 0`) yields an empty `Data` slice.

### How Verified
- **Tests:** `go test ./network/smb/smb_v10/...` passes, including the existing `nil_unmarshal_sweep_test`. New `TestReadAndxResponseDataRoundTrip` marshals a response carrying a byte payload (including NULs) and asserts `DataLength`/`DataOffset` are set and the payload is recovered byte-for-byte on `Unmarshal`. `TestReadAndxResponseEmptyData` asserts an EOF read round-trips to an empty `Data` with `DataLength == 0`.
- **Static:** `Unmarshal` returns an error if `DataLength` exceeds the decoded data block, so an inconsistent length cannot read out of bounds.

### Test Coverage
- **Added:** `TestReadAndxResponseDataRoundTrip` and `TestReadAndxResponseEmptyData` in `network/smb/smb_v10/message/commands/ReadAndxResponse_test.go`.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/ReadAndxResponse.go`, `network/smb/smb_v10/message/commands/ReadAndxResponse_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none. The client's existing `ReadFile` continues to slice the raw response and is unaffected; it can now optionally read `ReadAndxResponse.Data` instead.

### Risk and Rollout
Low and local to one command type. Marshal advertises a no-pad layout (`DataOffset` = start of the data block); Unmarshal reads the trailing `DataLength` bytes, which tolerates a server-inserted pad. No other command or the message layer is affected.
