### PR TITLE
Implement Marshal/Unmarshal for SET_FILE information levels (#378)

### DIFF
--- a/network/smb/smb_v10/informationlevels/SMB_SET_FILE_ALLOCATION_INFO.go
+++ b/network/smb/smb_v10/informationlevels/SMB_SET_FILE_ALLOCATION_INFO.go
@@ -1,6 +1,9 @@
 package informationlevels
 
 import (
+	"encoding/binary"
+	"fmt"
+
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
 )
 
@@ -27,7 +30,10 @@ type SMB_SET_FILE_ALLOCATION_INFO struct {
 // - A byte slice containing the marshalled information level structure
 // - An error if marshalling any component fails
 func (s *SMB_SET_FILE_ALLOCATION_INFO) Marshal() ([]byte, error) {
-	marshalled_struct := []byte{}
+	marshalled_struct := make([]byte, 8)
+
+	// AllocationSize (8 bytes, LARGE_INTEGER).
+	binary.LittleEndian.PutUint64(marshalled_struct, uint64(s.Allocationsize.QuadPart))
 
 	return marshalled_struct, nil
 }
@@ -46,5 +52,11 @@ func (s *SMB_SET_FILE_ALLOCATION_INFO) Marshal() ([]byte, error) {
 // Returns:
 // - An error if unmarshalling any component fails or if the data format is invalid
 func (s *SMB_SET_FILE_ALLOCATION_INFO) Unmarshal(data []byte) (int, error) {
-	return 0, nil
+	// AllocationSize (8 bytes, LARGE_INTEGER).
+	if len(data) < 8 {
+		return 0, fmt.Errorf("data too short for AllocationSize")
+	}
+	s.Allocationsize.QuadPart = binary.LittleEndian.Uint64(data[0:8])
+
+	return 8, nil
 }

--- a/network/smb/smb_v10/informationlevels/SMB_SET_FILE_BASIC_INFO.go
+++ b/network/smb/smb_v10/informationlevels/SMB_SET_FILE_BASIC_INFO.go
@@ -1,6 +1,9 @@
 package informationlevels
 
 import (
+	"encoding/binary"
+	"fmt"
+
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
 )
 
@@ -65,6 +68,25 @@ type SMB_SET_FILE_BASIC_INFO struct {
 func (s *SMB_SET_FILE_BASIC_INFO) Marshal() ([]byte, error) {
 	marshalled_struct := []byte{}
 
+	// CreationTime, LastAccessTime, LastWriteTime, ChangeTime (8 bytes each, FILETIME).
+	for _, ft := range []*types.FILETIME{&s.Creationtime, &s.Lastaccesstime, &s.Lastwritetime, &s.Changetime} {
+		b, err := ft.Marshal()
+		if err != nil {
+			return nil, err
+		}
+		marshalled_struct = append(marshalled_struct, b...)
+	}
+
+	// ExtFileAttributes (4 bytes).
+	buf4 := make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf4, uint32(s.Extfileattributes))
+	marshalled_struct = append(marshalled_struct, buf4...)
+
+	// Reserved (4 bytes).
+	buf4 = make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf4, uint32(s.Reserved))
+	marshalled_struct = append(marshalled_struct, buf4...)
+
 	return marshalled_struct, nil
 }
 
@@ -82,5 +104,25 @@ func (s *SMB_SET_FILE_BASIC_INFO) Marshal() ([]byte, error) {
 // Returns:
 // - An error if unmarshalling any component fails or if the data format is invalid
 func (s *SMB_SET_FILE_BASIC_INFO) Unmarshal(data []byte) (int, error) {
-	return 0, nil
+	offset := 0
+
+	// CreationTime, LastAccessTime, LastWriteTime, ChangeTime (8 bytes each, FILETIME).
+	for _, ft := range []*types.FILETIME{&s.Creationtime, &s.Lastaccesstime, &s.Lastwritetime, &s.Changetime} {
+		n, err := ft.Unmarshal(data[offset:])
+		if err != nil {
+			return offset, err
+		}
+		offset += n
+	}
+
+	// ExtFileAttributes (4 bytes) and Reserved (4 bytes).
+	if len(data) < offset+8 {
+		return offset, fmt.Errorf("data too short for ExtFileAttributes and Reserved")
+	}
+	s.Extfileattributes = types.SMB_EXT_FILE_ATTR(binary.LittleEndian.Uint32(data[offset : offset+4]))
+	offset += 4
+	s.Reserved = types.ULONG(binary.LittleEndian.Uint32(data[offset : offset+4]))
+	offset += 4
+
+	return offset, nil
 }

--- a/network/smb/smb_v10/informationlevels/SMB_SET_FILE_DISPOSITION_INFO.go
+++ b/network/smb/smb_v10/informationlevels/SMB_SET_FILE_DISPOSITION_INFO.go
@@ -1,6 +1,8 @@
 package informationlevels
 
 import (
+	"fmt"
+
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
 )
 
@@ -25,9 +27,8 @@ type SMB_SET_FILE_DISPOSITION_INFO struct {
 // - A byte slice containing the marshalled information level structure
 // - An error if marshalling any component fails
 func (s *SMB_SET_FILE_DISPOSITION_INFO) Marshal() ([]byte, error) {
-	marshalled_struct := []byte{}
-
-	return marshalled_struct, nil
+	// DeletePending (1 byte).
+	return []byte{byte(s.Deletepending)}, nil
 }
 
 // Unmarshal deserializes a byte slice into the SMB_SET_FILE_DISPOSITION_INFO structure.
@@ -44,5 +45,11 @@ func (s *SMB_SET_FILE_DISPOSITION_INFO) Marshal() ([]byte, error) {
 // Returns:
 // - An error if unmarshalling any component fails or if the data format is invalid
 func (s *SMB_SET_FILE_DISPOSITION_INFO) Unmarshal(data []byte) (int, error) {
-	return 0, nil
+	// DeletePending (1 byte).
+	if len(data) < 1 {
+		return 0, fmt.Errorf("data too short for DeletePending")
+	}
+	s.Deletepending = types.UCHAR(data[0])
+
+	return 1, nil
 }

--- a/network/smb/smb_v10/informationlevels/SMB_SET_FILE_END_OF_FILE_INFO.go
+++ b/network/smb/smb_v10/informationlevels/SMB_SET_FILE_END_OF_FILE_INFO.go
@@ -1,6 +1,9 @@
 package informationlevels
 
 import (
+	"encoding/binary"
+	"fmt"
+
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
 )
 
@@ -29,7 +32,10 @@ type SMB_SET_FILE_END_OF_FILE_INFO struct {
 // - A byte slice containing the marshalled information level structure
 // - An error if marshalling any component fails
 func (s *SMB_SET_FILE_END_OF_FILE_INFO) Marshal() ([]byte, error) {
-	marshalled_struct := []byte{}
+	marshalled_struct := make([]byte, 8)
+
+	// EndOfFile (8 bytes, LARGE_INTEGER).
+	binary.LittleEndian.PutUint64(marshalled_struct, uint64(s.Endoffile.QuadPart))
 
 	return marshalled_struct, nil
 }
@@ -48,5 +54,11 @@ func (s *SMB_SET_FILE_END_OF_FILE_INFO) Marshal() ([]byte, error) {
 // Returns:
 // - An error if unmarshalling any component fails or if the data format is invalid
 func (s *SMB_SET_FILE_END_OF_FILE_INFO) Unmarshal(data []byte) (int, error) {
-	return 0, nil
+	// EndOfFile (8 bytes, LARGE_INTEGER).
+	if len(data) < 8 {
+		return 0, fmt.Errorf("data too short for EndOfFile")
+	}
+	s.Endoffile.QuadPart = binary.LittleEndian.Uint64(data[0:8])
+
+	return 8, nil
 }

--- a/network/smb/smb_v10/informationlevels/set_file_info_test.go
+++ b/network/smb/smb_v10/informationlevels/set_file_info_test.go
@@ -1,0 +1,126 @@
+package informationlevels_test
+
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/informationlevels"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+)
+
+// TestSetFileBasicInfoRoundTrip verifies SMB_SET_FILE_BASIC_INFO marshals to the
+// spec size (40 bytes) and round-trips every field.
+func TestSetFileBasicInfoRoundTrip(t *testing.T) {
+	in := &informationlevels.SMB_SET_FILE_BASIC_INFO{
+		Creationtime:      types.FILETIME{DwLowDateTime: 0x11111111, DwHighDateTime: 0x22222222},
+		Lastaccesstime:    types.FILETIME{DwLowDateTime: 0x33333333, DwHighDateTime: 0x44444444},
+		Lastwritetime:     types.FILETIME{DwLowDateTime: 0x55555555, DwHighDateTime: 0x66666666},
+		Changetime:        types.FILETIME{DwLowDateTime: 0x77777777, DwHighDateTime: 0x88888888},
+		Extfileattributes: types.ATTR_HIDDEN | types.ATTR_ARCHIVE,
+		Reserved:          0xDEADBEEF,
+	}
+
+	raw, err := in.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+	if len(raw) != 40 {
+		t.Fatalf("expected 40 bytes, got %d", len(raw))
+	}
+
+	out := &informationlevels.SMB_SET_FILE_BASIC_INFO{}
+	n, err := out.Unmarshal(raw)
+	if err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if n != 40 {
+		t.Errorf("expected 40 bytes consumed, got %d", n)
+	}
+	if *out != *in {
+		t.Errorf("round-trip mismatch:\n in  %+v\n out %+v", in, out)
+	}
+}
+
+// TestSetFileAllocationInfoRoundTrip verifies SMB_SET_FILE_ALLOCATION_INFO is an
+// 8-byte LARGE_INTEGER that round-trips.
+func TestSetFileAllocationInfoRoundTrip(t *testing.T) {
+	in := &informationlevels.SMB_SET_FILE_ALLOCATION_INFO{}
+	in.Allocationsize.QuadPart = 0x0123456789ABCDEF
+
+	raw, err := in.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+	if len(raw) != 8 {
+		t.Fatalf("expected 8 bytes, got %d", len(raw))
+	}
+
+	out := &informationlevels.SMB_SET_FILE_ALLOCATION_INFO{}
+	if _, err := out.Unmarshal(raw); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if out.Allocationsize.QuadPart != in.Allocationsize.QuadPart {
+		t.Errorf("AllocationSize = 0x%X, want 0x%X", out.Allocationsize.QuadPart, in.Allocationsize.QuadPart)
+	}
+}
+
+// TestSetFileEndOfFileInfoRoundTrip verifies SMB_SET_FILE_END_OF_FILE_INFO is an
+// 8-byte LARGE_INTEGER that round-trips.
+func TestSetFileEndOfFileInfoRoundTrip(t *testing.T) {
+	in := &informationlevels.SMB_SET_FILE_END_OF_FILE_INFO{}
+	in.Endoffile.QuadPart = 0xFEDCBA9876543210
+
+	raw, err := in.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+	if len(raw) != 8 {
+		t.Fatalf("expected 8 bytes, got %d", len(raw))
+	}
+
+	out := &informationlevels.SMB_SET_FILE_END_OF_FILE_INFO{}
+	if _, err := out.Unmarshal(raw); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if out.Endoffile.QuadPart != in.Endoffile.QuadPart {
+		t.Errorf("EndOfFile = 0x%X, want 0x%X", out.Endoffile.QuadPart, in.Endoffile.QuadPart)
+	}
+}
+
+// TestSetFileDispositionInfoRoundTrip verifies SMB_SET_FILE_DISPOSITION_INFO is a
+// single DeletePending byte that round-trips.
+func TestSetFileDispositionInfoRoundTrip(t *testing.T) {
+	in := &informationlevels.SMB_SET_FILE_DISPOSITION_INFO{Deletepending: 0x01}
+
+	raw, err := in.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+	if len(raw) != 1 || raw[0] != 0x01 {
+		t.Fatalf("expected [0x01], got % x", raw)
+	}
+
+	out := &informationlevels.SMB_SET_FILE_DISPOSITION_INFO{}
+	if _, err := out.Unmarshal(raw); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if out.Deletepending != in.Deletepending {
+		t.Errorf("DeletePending = %d, want %d", out.Deletepending, in.Deletepending)
+	}
+}
+
+// TestSetFileInfoUnmarshalBounds verifies truncated buffers return an error rather
+// than panicking.
+func TestSetFileInfoUnmarshalBounds(t *testing.T) {
+	if _, err := (&informationlevels.SMB_SET_FILE_BASIC_INFO{}).Unmarshal(make([]byte, 39)); err == nil {
+		t.Error("SMB_SET_FILE_BASIC_INFO: expected error on 39-byte buffer")
+	}
+	if _, err := (&informationlevels.SMB_SET_FILE_ALLOCATION_INFO{}).Unmarshal(make([]byte, 7)); err == nil {
+		t.Error("SMB_SET_FILE_ALLOCATION_INFO: expected error on 7-byte buffer")
+	}
+	if _, err := (&informationlevels.SMB_SET_FILE_END_OF_FILE_INFO{}).Unmarshal(make([]byte, 7)); err == nil {
+		t.Error("SMB_SET_FILE_END_OF_FILE_INFO: expected error on 7-byte buffer")
+	}
+	if _, err := (&informationlevels.SMB_SET_FILE_DISPOSITION_INFO{}).Unmarshal(nil); err == nil {
+		t.Error("SMB_SET_FILE_DISPOSITION_INFO: expected error on empty buffer")
+	}
+}


### PR DESCRIPTION
### Linked Issue
Part of #378 (does not close it — first of several batches by information-level family).

### Root Cause
Every structure in `network/smb/smb_v10/informationlevels/` had a `Marshal` that returned an empty slice and an `Unmarshal` that returned `(0, nil)`, so no TRANS2 information level could be serialized or parsed. This PR addresses the SET_FILE family.

### Fix Description
Implement `Marshal`/`Unmarshal` for the four TRANS2 SET_FILE/SET_PATH information levels, with field layouts cross-checked against the MS-CIFS specification:
- **SMB_SET_FILE_BASIC_INFO** (MS-CIFS 2.2.8.4.4): `CreationTime`, `LastAccessTime`, `LastWriteTime`, `ChangeTime` (8-byte FILETIME each) + `ExtFileAttributes` (4) + `Reserved` (4) = 40 bytes.
- **SMB_SET_FILE_ALLOCATION_INFO** (2.2.8.4.6): `AllocationSize` (8-byte LARGE_INTEGER).
- **SMB_SET_FILE_END_OF_FILE_INFO** (2.2.8.4.7): `EndOfFile` (8-byte LARGE_INTEGER).
- **SMB_SET_FILE_DISPOSITION_INFO** (2.2.8.4.5): `DeletePending` (1 byte).

All integers are little-endian; FILETIME fields use the existing `FILETIME.Marshal`/`Unmarshal`. `Unmarshal` bounds-checks the buffer before each field and returns the number of bytes consumed. These four structures' existing field definitions already matched the spec, so only the method bodies were added (no struct-shape changes in this batch).

### How Verified
- **Tests:** `go test ./network/smb/smb_v10/...` passes. New round-trip tests assert the marshalled sizes (40/8/8/1 bytes) and that every field survives a Marshal→Unmarshal cycle, plus a bounds test asserting truncated buffers return an error instead of panicking.
- **Static:** field order, sizes, and types match the MS-CIFS pages fetched for each structure.

### Test Coverage
- **Added:** `TestSetFileBasicInfoRoundTrip`, `TestSetFileAllocationInfoRoundTrip`, `TestSetFileEndOfFileInfoRoundTrip`, `TestSetFileDispositionInfoRoundTrip`, `TestSetFileInfoUnmarshalBounds` in `network/smb/smb_v10/informationlevels/set_file_info_test.go`.

### Scope of Change
- **Files changed:** `SMB_SET_FILE_BASIC_INFO.go`, `SMB_SET_FILE_ALLOCATION_INFO.go`, `SMB_SET_FILE_END_OF_FILE_INFO.go`, `SMB_SET_FILE_DISPOSITION_INFO.go`, `set_file_info_test.go` (all under `network/smb/smb_v10/informationlevels/`)
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Low and local. These methods were previously no-ops; nothing consumed them yet. The remaining information-level families (query-file, FIND_FILE directory info, FS info, EA/volume, placeholders) follow in separate PRs; the final batch closes #378.
