### PR TITLE
Implement Marshal/Unmarshal for QUERY_FILE information levels (#378)

### DIFF
--- a/network/smb/smb_v10/informationlevels/SMB_QUERY_FILE_ALL_INFO.go
+++ b/network/smb/smb_v10/informationlevels/SMB_QUERY_FILE_ALL_INFO.go
@@ -1,9 +1,11 @@
 package informationlevels
 
 import (
+	"encoding/binary"
+	"fmt"
+
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
 )
-
 
 // SMB_QUERY_FILE_ALL_INFO
 // Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/162baf45-4201-4b07-a397-060e868599d7
@@ -26,6 +28,9 @@ type SMB_QUERY_FILE_ALL_INFO struct {
 	// Reserved1: (4 bytes): Reserved. This field SHOULD be set to 0x00000000 by the
 	// server and MUST be ignored by the client.
 	Reserved1 types.ULONG
+	// AllocationSize: (8 bytes): This field contains the number of bytes that are
+	// allocated to the file.
+	Allocationsize types.LARGE_INTEGER
 	// EndOfFile: (8 bytes): This field contains the offset, in bytes, from the start
 	// of the file to the first byte after the end of the file.
 	Endoffile types.LARGE_INTEGER
@@ -46,15 +51,12 @@ type SMB_QUERY_FILE_ALL_INFO struct {
 	// FileNameLength: (4 bytes): This field MUST contain the length, in bytes, of the
 	// FileName field.
 	Filenamelength types.ULONG
+	// FileName: (variable): This field contains the name of the file in Unicode
+	// (UTF-16LE). It is FileNameLength bytes long; the raw bytes are stored as-is.
+	Filename []types.UCHAR
 }
 
 // Marshal serializes the SMB_QUERY_FILE_ALL_INFO into a byte slice.
-//
-// This method marshals the information level structure according to the format
-// specified in MS-CIFS documentation. Information levels are used in various
-// SMB operations to determine the format of data being exchanged.
-//
-// The marshalled data follows the specific format required for this information level.
 //
 // Returns:
 // - A byte slice containing the marshalled information level structure
@@ -62,22 +64,114 @@ type SMB_QUERY_FILE_ALL_INFO struct {
 func (s *SMB_QUERY_FILE_ALL_INFO) Marshal() ([]byte, error) {
 	marshalled_struct := []byte{}
 
+	// CreationTime, LastAccessTime, LastWriteTime, LastChangeTime (8 bytes each, FILETIME).
+	for _, ft := range []*types.FILETIME{&s.Creationtime, &s.Lastaccesstime, &s.Lastwritetime, &s.Lastchangetime} {
+		b, err := ft.Marshal()
+		if err != nil {
+			return nil, err
+		}
+		marshalled_struct = append(marshalled_struct, b...)
+	}
+
+	// ExtFileAttributes (4 bytes) and Reserved1 (4 bytes).
+	buf4 := make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf4, uint32(s.Extfileattributes))
+	marshalled_struct = append(marshalled_struct, buf4...)
+	buf4 = make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf4, uint32(s.Reserved1))
+	marshalled_struct = append(marshalled_struct, buf4...)
+
+	// AllocationSize (8 bytes) and EndOfFile (8 bytes), LARGE_INTEGER.
+	buf8 := make([]byte, 8)
+	binary.LittleEndian.PutUint64(buf8, uint64(s.Allocationsize.QuadPart))
+	marshalled_struct = append(marshalled_struct, buf8...)
+	buf8 = make([]byte, 8)
+	binary.LittleEndian.PutUint64(buf8, uint64(s.Endoffile.QuadPart))
+	marshalled_struct = append(marshalled_struct, buf8...)
+
+	// NumberOfLinks (4 bytes).
+	buf4 = make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf4, uint32(s.Numberoflinks))
+	marshalled_struct = append(marshalled_struct, buf4...)
+
+	// DeletePending (1 byte) and Directory (1 byte).
+	marshalled_struct = append(marshalled_struct, byte(s.Deletepending), byte(s.Directory))
+
+	// Reserved2 (2 bytes).
+	buf2 := make([]byte, 2)
+	binary.LittleEndian.PutUint16(buf2, uint16(s.Reserved2))
+	marshalled_struct = append(marshalled_struct, buf2...)
+
+	// EaSize (4 bytes).
+	buf4 = make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf4, uint32(s.Easize))
+	marshalled_struct = append(marshalled_struct, buf4...)
+
+	// FileNameLength (4 bytes), derived from the FileName payload.
+	s.Filenamelength = types.ULONG(len(s.Filename))
+	buf4 = make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf4, uint32(s.Filenamelength))
+	marshalled_struct = append(marshalled_struct, buf4...)
+
+	// FileName (variable).
+	marshalled_struct = append(marshalled_struct, s.Filename...)
+
 	return marshalled_struct, nil
 }
 
 // Unmarshal deserializes a byte slice into the SMB_QUERY_FILE_ALL_INFO structure.
 //
-// This method unmarshals the information level structure according to the format
-// specified in MS-CIFS documentation. Information levels are used in various
-// SMB operations to determine the format of data being exchanged.
-//
-// The data is expected to follow the specific format required for this information level.
-//
 // Parameters:
 // - data: A byte slice containing the serialized SMB_QUERY_FILE_ALL_INFO structure
 //
 // Returns:
+// - The number of bytes consumed
 // - An error if unmarshalling any component fails or if the data format is invalid
 func (s *SMB_QUERY_FILE_ALL_INFO) Unmarshal(data []byte) (int, error) {
-	return 0, nil
+	offset := 0
+
+	// CreationTime, LastAccessTime, LastWriteTime, LastChangeTime (8 bytes each, FILETIME).
+	for _, ft := range []*types.FILETIME{&s.Creationtime, &s.Lastaccesstime, &s.Lastwritetime, &s.Lastchangetime} {
+		n, err := ft.Unmarshal(data[offset:])
+		if err != nil {
+			return offset, err
+		}
+		offset += n
+	}
+
+	// Fixed fields up to and including FileNameLength: ExtFileAttributes(4) + Reserved1(4)
+	// + AllocationSize(8) + EndOfFile(8) + NumberOfLinks(4) + DeletePending(1) + Directory(1)
+	// + Reserved2(2) + EaSize(4) + FileNameLength(4) = 40 bytes after the four FILETIMEs.
+	if len(data) < offset+40 {
+		return offset, fmt.Errorf("data too short for SMB_QUERY_FILE_ALL_INFO fixed fields")
+	}
+	s.Extfileattributes = types.SMB_EXT_FILE_ATTR(binary.LittleEndian.Uint32(data[offset : offset+4]))
+	offset += 4
+	s.Reserved1 = types.ULONG(binary.LittleEndian.Uint32(data[offset : offset+4]))
+	offset += 4
+	s.Allocationsize.QuadPart = binary.LittleEndian.Uint64(data[offset : offset+8])
+	offset += 8
+	s.Endoffile.QuadPart = binary.LittleEndian.Uint64(data[offset : offset+8])
+	offset += 8
+	s.Numberoflinks = types.ULONG(binary.LittleEndian.Uint32(data[offset : offset+4]))
+	offset += 4
+	s.Deletepending = types.UCHAR(data[offset])
+	offset++
+	s.Directory = types.UCHAR(data[offset])
+	offset++
+	s.Reserved2 = types.USHORT(binary.LittleEndian.Uint16(data[offset : offset+2]))
+	offset += 2
+	s.Easize = types.ULONG(binary.LittleEndian.Uint32(data[offset : offset+4]))
+	offset += 4
+	s.Filenamelength = types.ULONG(binary.LittleEndian.Uint32(data[offset : offset+4]))
+	offset += 4
+
+	// FileName (FileNameLength bytes).
+	if len(data) < offset+int(s.Filenamelength) {
+		return offset, fmt.Errorf("data too short for FileName (need %d bytes, have %d)", s.Filenamelength, len(data)-offset)
+	}
+	s.Filename = append([]types.UCHAR{}, data[offset:offset+int(s.Filenamelength)]...)
+	offset += int(s.Filenamelength)
+
+	return offset, nil
 }

--- a/network/smb/smb_v10/informationlevels/SMB_QUERY_FILE_ALT_NAME_INFO.go
+++ b/network/smb/smb_v10/informationlevels/SMB_QUERY_FILE_ALT_NAME_INFO.go
@@ -1,9 +1,11 @@
 package informationlevels
 
 import (
+	"encoding/binary"
+	"fmt"
+
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
 )
-
 
 // SMB_QUERY_FILE_ALT_NAME_INFO
 // Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/3edd12e7-f407-4b46-9465-c6ed20e24c1a
@@ -11,15 +13,13 @@ type SMB_QUERY_FILE_ALT_NAME_INFO struct {
 	// FileNameLength: (4 bytes): This field contains the length, in bytes, of the
 	// FileName field.
 	Filenamelength types.ULONG
+	// FileName: (variable): This field contains the 8.3 name of the file in Unicode
+	// (UTF-16LE). It is FileNameLength bytes long and is not null-terminated. The raw
+	// bytes are stored as-is.
+	Filename []types.UCHAR
 }
 
 // Marshal serializes the SMB_QUERY_FILE_ALT_NAME_INFO into a byte slice.
-//
-// This method marshals the information level structure according to the format
-// specified in MS-CIFS documentation. Information levels are used in various
-// SMB operations to determine the format of data being exchanged.
-//
-// The marshalled data follows the specific format required for this information level.
 //
 // Returns:
 // - A byte slice containing the marshalled information level structure
@@ -27,22 +27,40 @@ type SMB_QUERY_FILE_ALT_NAME_INFO struct {
 func (s *SMB_QUERY_FILE_ALT_NAME_INFO) Marshal() ([]byte, error) {
 	marshalled_struct := []byte{}
 
+	// FileNameLength (4 bytes), derived from the FileName payload.
+	s.Filenamelength = types.ULONG(len(s.Filename))
+	buf4 := make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf4, uint32(s.Filenamelength))
+	marshalled_struct = append(marshalled_struct, buf4...)
+
+	// FileName (variable).
+	marshalled_struct = append(marshalled_struct, s.Filename...)
+
 	return marshalled_struct, nil
 }
 
 // Unmarshal deserializes a byte slice into the SMB_QUERY_FILE_ALT_NAME_INFO structure.
 //
-// This method unmarshals the information level structure according to the format
-// specified in MS-CIFS documentation. Information levels are used in various
-// SMB operations to determine the format of data being exchanged.
-//
-// The data is expected to follow the specific format required for this information level.
-//
 // Parameters:
 // - data: A byte slice containing the serialized SMB_QUERY_FILE_ALT_NAME_INFO structure
 //
 // Returns:
+// - The number of bytes consumed
 // - An error if unmarshalling any component fails or if the data format is invalid
 func (s *SMB_QUERY_FILE_ALT_NAME_INFO) Unmarshal(data []byte) (int, error) {
-	return 0, nil
+	// FileNameLength (4 bytes).
+	if len(data) < 4 {
+		return 0, fmt.Errorf("data too short for FileNameLength")
+	}
+	s.Filenamelength = types.ULONG(binary.LittleEndian.Uint32(data[0:4]))
+	offset := 4
+
+	// FileName (FileNameLength bytes).
+	if len(data) < offset+int(s.Filenamelength) {
+		return offset, fmt.Errorf("data too short for FileName (need %d bytes, have %d)", s.Filenamelength, len(data)-offset)
+	}
+	s.Filename = append([]types.UCHAR{}, data[offset:offset+int(s.Filenamelength)]...)
+	offset += int(s.Filenamelength)
+
+	return offset, nil
 }

--- a/network/smb/smb_v10/informationlevels/SMB_QUERY_FILE_BASIC_INFO.go
+++ b/network/smb/smb_v10/informationlevels/SMB_QUERY_FILE_BASIC_INFO.go
@@ -1,9 +1,11 @@
 package informationlevels
 
 import (
+	"encoding/binary"
+	"fmt"
+
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
 )
-
 
 // SMB_QUERY_FILE_BASIC_INFO
 // Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/3da7df75-43ba-4498-a6b3-a68ba57ec922
@@ -28,13 +30,7 @@ type SMB_QUERY_FILE_BASIC_INFO struct {
 	Reserved types.ULONG
 }
 
-// Marshal serializes the SMB_QUERY_FILE_BASIC_INFO into a byte slice.
-//
-// This method marshals the information level structure according to the format
-// specified in MS-CIFS documentation. Information levels are used in various
-// SMB operations to determine the format of data being exchanged.
-//
-// The marshalled data follows the specific format required for this information level.
+// Marshal serializes the SMB_QUERY_FILE_BASIC_INFO into a byte slice (40 bytes).
 //
 // Returns:
 // - A byte slice containing the marshalled information level structure
@@ -42,22 +38,56 @@ type SMB_QUERY_FILE_BASIC_INFO struct {
 func (s *SMB_QUERY_FILE_BASIC_INFO) Marshal() ([]byte, error) {
 	marshalled_struct := []byte{}
 
+	// CreationTime, LastAccessTime, LastWriteTime, LastChangeTime (8 bytes each, FILETIME).
+	for _, ft := range []*types.FILETIME{&s.Creationtime, &s.Lastaccesstime, &s.Lastwritetime, &s.Lastchangetime} {
+		b, err := ft.Marshal()
+		if err != nil {
+			return nil, err
+		}
+		marshalled_struct = append(marshalled_struct, b...)
+	}
+
+	// ExtFileAttributes (4 bytes).
+	buf4 := make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf4, uint32(s.Extfileattributes))
+	marshalled_struct = append(marshalled_struct, buf4...)
+
+	// Reserved (4 bytes).
+	buf4 = make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf4, uint32(s.Reserved))
+	marshalled_struct = append(marshalled_struct, buf4...)
+
 	return marshalled_struct, nil
 }
 
 // Unmarshal deserializes a byte slice into the SMB_QUERY_FILE_BASIC_INFO structure.
 //
-// This method unmarshals the information level structure according to the format
-// specified in MS-CIFS documentation. Information levels are used in various
-// SMB operations to determine the format of data being exchanged.
-//
-// The data is expected to follow the specific format required for this information level.
-//
 // Parameters:
 // - data: A byte slice containing the serialized SMB_QUERY_FILE_BASIC_INFO structure
 //
 // Returns:
+// - The number of bytes consumed
 // - An error if unmarshalling any component fails or if the data format is invalid
 func (s *SMB_QUERY_FILE_BASIC_INFO) Unmarshal(data []byte) (int, error) {
-	return 0, nil
+	offset := 0
+
+	// CreationTime, LastAccessTime, LastWriteTime, LastChangeTime (8 bytes each, FILETIME).
+	for _, ft := range []*types.FILETIME{&s.Creationtime, &s.Lastaccesstime, &s.Lastwritetime, &s.Lastchangetime} {
+		n, err := ft.Unmarshal(data[offset:])
+		if err != nil {
+			return offset, err
+		}
+		offset += n
+	}
+
+	// ExtFileAttributes (4 bytes) and Reserved (4 bytes).
+	if len(data) < offset+8 {
+		return offset, fmt.Errorf("data too short for ExtFileAttributes and Reserved")
+	}
+	s.Extfileattributes = types.SMB_EXT_FILE_ATTR(binary.LittleEndian.Uint32(data[offset : offset+4]))
+	offset += 4
+	s.Reserved = types.ULONG(binary.LittleEndian.Uint32(data[offset : offset+4]))
+	offset += 4
+
+	return offset, nil
 }

--- a/network/smb/smb_v10/informationlevels/SMB_QUERY_FILE_COMRESSION_INFO.go
+++ b/network/smb/smb_v10/informationlevels/SMB_QUERY_FILE_COMRESSION_INFO.go
@@ -1,6 +1,9 @@
 package informationlevels
 
 import (
+	"encoding/binary"
+	"fmt"
+
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
 )
 
@@ -40,6 +43,9 @@ type SMB_QUERY_FILE_COMRESSION_INFO struct {
 	// shift is the number of bits by which to left shift a 1 bit to arrive at the size
 	// of a cluster. This value is implementation-defined.
 	Clustershift types.UCHAR
+	// Reserved: (3 bytes): A 24-bit reserved value. This field SHOULD be set to
+	// 0x000000 and MUST be ignored.
+	Reserved [3]types.UCHAR
 }
 
 // Marshal serializes the SMB_QUERY_FILE_COMRESSION_INFO into a byte slice.
@@ -54,7 +60,23 @@ type SMB_QUERY_FILE_COMRESSION_INFO struct {
 // - A byte slice containing the marshalled information level structure
 // - An error if marshalling any component fails
 func (s *SMB_QUERY_FILE_COMRESSION_INFO) Marshal() ([]byte, error) {
-	marshalled_struct := []byte{}
+	marshalled_struct := make([]byte, 0, 16)
+
+	// CompressedFileSize (8 bytes, LARGE_INTEGER).
+	buf8 := make([]byte, 8)
+	binary.LittleEndian.PutUint64(buf8, uint64(s.Compressedfilesize.QuadPart))
+	marshalled_struct = append(marshalled_struct, buf8...)
+
+	// CompressionFormat (2 bytes).
+	buf2 := make([]byte, 2)
+	binary.LittleEndian.PutUint16(buf2, uint16(s.Compressionformat))
+	marshalled_struct = append(marshalled_struct, buf2...)
+
+	// CompressionUnitShift, ChunkShift, ClusterShift (1 byte each).
+	marshalled_struct = append(marshalled_struct, byte(s.Compressionunitshift), byte(s.Chunkshift), byte(s.Clustershift))
+
+	// Reserved (3 bytes).
+	marshalled_struct = append(marshalled_struct, byte(s.Reserved[0]), byte(s.Reserved[1]), byte(s.Reserved[2]))
 
 	return marshalled_struct, nil
 }
@@ -73,5 +95,18 @@ func (s *SMB_QUERY_FILE_COMRESSION_INFO) Marshal() ([]byte, error) {
 // Returns:
 // - An error if unmarshalling any component fails or if the data format is invalid
 func (s *SMB_QUERY_FILE_COMRESSION_INFO) Unmarshal(data []byte) (int, error) {
-	return 0, nil
+	// CompressedFileSize(8) + CompressionFormat(2) + 3x shift(1) + Reserved(3) = 16 bytes.
+	if len(data) < 16 {
+		return 0, fmt.Errorf("data too short for SMB_QUERY_FILE_COMPRESSION_INFO (need 16 bytes, have %d)", len(data))
+	}
+	s.Compressedfilesize.QuadPart = binary.LittleEndian.Uint64(data[0:8])
+	s.Compressionformat = types.USHORT(binary.LittleEndian.Uint16(data[8:10]))
+	s.Compressionunitshift = types.UCHAR(data[10])
+	s.Chunkshift = types.UCHAR(data[11])
+	s.Clustershift = types.UCHAR(data[12])
+	s.Reserved[0] = types.UCHAR(data[13])
+	s.Reserved[1] = types.UCHAR(data[14])
+	s.Reserved[2] = types.UCHAR(data[15])
+
+	return 16, nil
 }

--- a/network/smb/smb_v10/informationlevels/SMB_QUERY_FILE_EA_INFO.go
+++ b/network/smb/smb_v10/informationlevels/SMB_QUERY_FILE_EA_INFO.go
@@ -1,6 +1,9 @@
 package informationlevels
 
 import (
+	"encoding/binary"
+	"fmt"
+
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
 )
 
@@ -25,7 +28,10 @@ type SMB_QUERY_FILE_EA_INFO struct {
 // - A byte slice containing the marshalled information level structure
 // - An error if marshalling any component fails
 func (s *SMB_QUERY_FILE_EA_INFO) Marshal() ([]byte, error) {
-	marshalled_struct := []byte{}
+	marshalled_struct := make([]byte, 4)
+
+	// EaSize (4 bytes).
+	binary.LittleEndian.PutUint32(marshalled_struct, uint32(s.Easize))
 
 	return marshalled_struct, nil
 }
@@ -44,5 +50,11 @@ func (s *SMB_QUERY_FILE_EA_INFO) Marshal() ([]byte, error) {
 // Returns:
 // - An error if unmarshalling any component fails or if the data format is invalid
 func (s *SMB_QUERY_FILE_EA_INFO) Unmarshal(data []byte) (int, error) {
-	return 0, nil
+	// EaSize (4 bytes).
+	if len(data) < 4 {
+		return 0, fmt.Errorf("data too short for EaSize")
+	}
+	s.Easize = types.ULONG(binary.LittleEndian.Uint32(data[0:4]))
+
+	return 4, nil
 }

--- a/network/smb/smb_v10/informationlevels/SMB_QUERY_FILE_NAME_INFO.go
+++ b/network/smb/smb_v10/informationlevels/SMB_QUERY_FILE_NAME_INFO.go
@@ -1,9 +1,11 @@
 package informationlevels
 
 import (
+	"encoding/binary"
+	"fmt"
+
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
 )
-
 
 // SMB_QUERY_FILE_NAME_INFO
 // Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/0cdd9e53-bc92-4f26-8b22-ed11fc06a6d7
@@ -11,15 +13,13 @@ type SMB_QUERY_FILE_NAME_INFO struct {
 	// FileNameLength: (4 bytes): This field MUST contain the length of the FileName
 	// field in bytes.
 	Filenamelength types.ULONG
+	// FileName: (variable): This field contains the name of the file in Unicode
+	// (UTF-16LE). It is FileNameLength bytes long and is not null-terminated. The
+	// raw bytes are stored as-is.
+	Filename []types.UCHAR
 }
 
 // Marshal serializes the SMB_QUERY_FILE_NAME_INFO into a byte slice.
-//
-// This method marshals the information level structure according to the format
-// specified in MS-CIFS documentation. Information levels are used in various
-// SMB operations to determine the format of data being exchanged.
-//
-// The marshalled data follows the specific format required for this information level.
 //
 // Returns:
 // - A byte slice containing the marshalled information level structure
@@ -27,22 +27,40 @@ type SMB_QUERY_FILE_NAME_INFO struct {
 func (s *SMB_QUERY_FILE_NAME_INFO) Marshal() ([]byte, error) {
 	marshalled_struct := []byte{}
 
+	// FileNameLength (4 bytes), derived from the FileName payload.
+	s.Filenamelength = types.ULONG(len(s.Filename))
+	buf4 := make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf4, uint32(s.Filenamelength))
+	marshalled_struct = append(marshalled_struct, buf4...)
+
+	// FileName (variable).
+	marshalled_struct = append(marshalled_struct, s.Filename...)
+
 	return marshalled_struct, nil
 }
 
 // Unmarshal deserializes a byte slice into the SMB_QUERY_FILE_NAME_INFO structure.
 //
-// This method unmarshals the information level structure according to the format
-// specified in MS-CIFS documentation. Information levels are used in various
-// SMB operations to determine the format of data being exchanged.
-//
-// The data is expected to follow the specific format required for this information level.
-//
 // Parameters:
 // - data: A byte slice containing the serialized SMB_QUERY_FILE_NAME_INFO structure
 //
 // Returns:
+// - The number of bytes consumed
 // - An error if unmarshalling any component fails or if the data format is invalid
 func (s *SMB_QUERY_FILE_NAME_INFO) Unmarshal(data []byte) (int, error) {
-	return 0, nil
+	// FileNameLength (4 bytes).
+	if len(data) < 4 {
+		return 0, fmt.Errorf("data too short for FileNameLength")
+	}
+	s.Filenamelength = types.ULONG(binary.LittleEndian.Uint32(data[0:4]))
+	offset := 4
+
+	// FileName (FileNameLength bytes).
+	if len(data) < offset+int(s.Filenamelength) {
+		return offset, fmt.Errorf("data too short for FileName (need %d bytes, have %d)", s.Filenamelength, len(data)-offset)
+	}
+	s.Filename = append([]types.UCHAR{}, data[offset:offset+int(s.Filenamelength)]...)
+	offset += int(s.Filenamelength)
+
+	return offset, nil
 }

--- a/network/smb/smb_v10/informationlevels/SMB_QUERY_FILE_STANDARD_INFO.go
+++ b/network/smb/smb_v10/informationlevels/SMB_QUERY_FILE_STANDARD_INFO.go
@@ -1,6 +1,9 @@
 package informationlevels
 
 import (
+	"encoding/binary"
+	"fmt"
+
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
 )
 
@@ -34,7 +37,23 @@ type SMB_QUERY_FILE_STANDARD_INFO struct {
 // - A byte slice containing the marshalled information level structure
 // - An error if marshalling any component fails
 func (s *SMB_QUERY_FILE_STANDARD_INFO) Marshal() ([]byte, error) {
-	marshalled_struct := []byte{}
+	marshalled_struct := make([]byte, 0, 22)
+
+	// AllocationSize (8 bytes) and EndOfFile (8 bytes), LARGE_INTEGER.
+	buf8 := make([]byte, 8)
+	binary.LittleEndian.PutUint64(buf8, uint64(s.Allocationsize.QuadPart))
+	marshalled_struct = append(marshalled_struct, buf8...)
+	buf8 = make([]byte, 8)
+	binary.LittleEndian.PutUint64(buf8, uint64(s.Endoffile.QuadPart))
+	marshalled_struct = append(marshalled_struct, buf8...)
+
+	// NumberOfLinks (4 bytes).
+	buf4 := make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf4, uint32(s.Numberoflinks))
+	marshalled_struct = append(marshalled_struct, buf4...)
+
+	// DeletePending (1 byte) and Directory (1 byte).
+	marshalled_struct = append(marshalled_struct, byte(s.Deletepending), byte(s.Directory))
 
 	return marshalled_struct, nil
 }
@@ -53,5 +72,15 @@ func (s *SMB_QUERY_FILE_STANDARD_INFO) Marshal() ([]byte, error) {
 // Returns:
 // - An error if unmarshalling any component fails or if the data format is invalid
 func (s *SMB_QUERY_FILE_STANDARD_INFO) Unmarshal(data []byte) (int, error) {
-	return 0, nil
+	// AllocationSize(8) + EndOfFile(8) + NumberOfLinks(4) + DeletePending(1) + Directory(1) = 22 bytes.
+	if len(data) < 22 {
+		return 0, fmt.Errorf("data too short for SMB_QUERY_FILE_STANDARD_INFO (need 22 bytes, have %d)", len(data))
+	}
+	s.Allocationsize.QuadPart = binary.LittleEndian.Uint64(data[0:8])
+	s.Endoffile.QuadPart = binary.LittleEndian.Uint64(data[8:16])
+	s.Numberoflinks = types.ULONG(binary.LittleEndian.Uint32(data[16:20]))
+	s.Deletepending = types.UCHAR(data[20])
+	s.Directory = types.UCHAR(data[21])
+
+	return 22, nil
 }

--- a/network/smb/smb_v10/informationlevels/SMB_QUERY_FILE_STREAM_INFO.go
+++ b/network/smb/smb_v10/informationlevels/SMB_QUERY_FILE_STREAM_INFO.go
@@ -1,9 +1,11 @@
 package informationlevels
 
 import (
+	"encoding/binary"
+	"fmt"
+
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
 )
-
 
 // SMB_QUERY_FILE_STREAM_INFO
 // Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/23f37dcd-5b50-43d4-91cd-ffab868fd65e
@@ -28,15 +30,13 @@ type SMB_QUERY_FILE_STREAM_INFO struct {
 	// or cluster size of the underlying physical device. The value of this field MUST
 	// be greater than or equal to 0x0000000000000000.
 	Streamallocationsize types.LARGE_INTEGER
+	// StreamName: (variable): A sequence of Unicode (UTF-16LE) characters containing the
+	// name of the stream. It is StreamNameLength bytes long and might not be
+	// null-terminated; the raw bytes are stored as-is.
+	Streamname []types.UCHAR
 }
 
 // Marshal serializes the SMB_QUERY_FILE_STREAM_INFO into a byte slice.
-//
-// This method marshals the information level structure according to the format
-// specified in MS-CIFS documentation. Information levels are used in various
-// SMB operations to determine the format of data being exchanged.
-//
-// The marshalled data follows the specific format required for this information level.
 //
 // Returns:
 // - A byte slice containing the marshalled information level structure
@@ -44,22 +44,56 @@ type SMB_QUERY_FILE_STREAM_INFO struct {
 func (s *SMB_QUERY_FILE_STREAM_INFO) Marshal() ([]byte, error) {
 	marshalled_struct := []byte{}
 
+	// NextEntryOffset (4 bytes).
+	buf4 := make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf4, uint32(s.Nextentryoffset))
+	marshalled_struct = append(marshalled_struct, buf4...)
+
+	// StreamNameLength (4 bytes), derived from the StreamName payload.
+	s.Streamnamelength = types.ULONG(len(s.Streamname))
+	buf4 = make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf4, uint32(s.Streamnamelength))
+	marshalled_struct = append(marshalled_struct, buf4...)
+
+	// StreamSize (8 bytes) and StreamAllocationSize (8 bytes), LARGE_INTEGER.
+	buf8 := make([]byte, 8)
+	binary.LittleEndian.PutUint64(buf8, uint64(s.Streamsize.QuadPart))
+	marshalled_struct = append(marshalled_struct, buf8...)
+	buf8 = make([]byte, 8)
+	binary.LittleEndian.PutUint64(buf8, uint64(s.Streamallocationsize.QuadPart))
+	marshalled_struct = append(marshalled_struct, buf8...)
+
+	// StreamName (variable).
+	marshalled_struct = append(marshalled_struct, s.Streamname...)
+
 	return marshalled_struct, nil
 }
 
 // Unmarshal deserializes a byte slice into the SMB_QUERY_FILE_STREAM_INFO structure.
 //
-// This method unmarshals the information level structure according to the format
-// specified in MS-CIFS documentation. Information levels are used in various
-// SMB operations to determine the format of data being exchanged.
-//
-// The data is expected to follow the specific format required for this information level.
-//
 // Parameters:
 // - data: A byte slice containing the serialized SMB_QUERY_FILE_STREAM_INFO structure
 //
 // Returns:
+// - The number of bytes consumed
 // - An error if unmarshalling any component fails or if the data format is invalid
 func (s *SMB_QUERY_FILE_STREAM_INFO) Unmarshal(data []byte) (int, error) {
-	return 0, nil
+	// NextEntryOffset(4) + StreamNameLength(4) + StreamSize(8) + StreamAllocationSize(8) = 24 bytes.
+	if len(data) < 24 {
+		return 0, fmt.Errorf("data too short for SMB_QUERY_FILE_STREAM_INFO fixed fields (need 24 bytes, have %d)", len(data))
+	}
+	s.Nextentryoffset = types.ULONG(binary.LittleEndian.Uint32(data[0:4]))
+	s.Streamnamelength = types.ULONG(binary.LittleEndian.Uint32(data[4:8]))
+	s.Streamsize.QuadPart = binary.LittleEndian.Uint64(data[8:16])
+	s.Streamallocationsize.QuadPart = binary.LittleEndian.Uint64(data[16:24])
+	offset := 24
+
+	// StreamName (StreamNameLength bytes).
+	if len(data) < offset+int(s.Streamnamelength) {
+		return offset, fmt.Errorf("data too short for StreamName (need %d bytes, have %d)", s.Streamnamelength, len(data)-offset)
+	}
+	s.Streamname = append([]types.UCHAR{}, data[offset:offset+int(s.Streamnamelength)]...)
+	offset += int(s.Streamnamelength)
+
+	return offset, nil
 }

--- a/network/smb/smb_v10/informationlevels/query_file_info_test.go
+++ b/network/smb/smb_v10/informationlevels/query_file_info_test.go
@@ -1,0 +1,226 @@
+package informationlevels_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/informationlevels"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+)
+
+func TestQueryFileBasicInfoRoundTrip(t *testing.T) {
+	in := &informationlevels.SMB_QUERY_FILE_BASIC_INFO{
+		Creationtime:      types.FILETIME{DwLowDateTime: 1, DwHighDateTime: 2},
+		Lastaccesstime:    types.FILETIME{DwLowDateTime: 3, DwHighDateTime: 4},
+		Lastwritetime:     types.FILETIME{DwLowDateTime: 5, DwHighDateTime: 6},
+		Lastchangetime:    types.FILETIME{DwLowDateTime: 7, DwHighDateTime: 8},
+		Extfileattributes: types.ATTR_DIRECTORY,
+		Reserved:          0,
+	}
+	raw, err := in.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if len(raw) != 40 {
+		t.Fatalf("expected 40 bytes, got %d", len(raw))
+	}
+	out := &informationlevels.SMB_QUERY_FILE_BASIC_INFO{}
+	if n, err := out.Unmarshal(raw); err != nil || n != 40 {
+		t.Fatalf("Unmarshal: n=%d err=%v", n, err)
+	}
+	if *out != *in {
+		t.Errorf("mismatch:\n in  %+v\n out %+v", in, out)
+	}
+}
+
+func TestQueryFileStandardInfoRoundTrip(t *testing.T) {
+	in := &informationlevels.SMB_QUERY_FILE_STANDARD_INFO{
+		Numberoflinks: 3,
+		Deletepending: 1,
+		Directory:     1,
+	}
+	in.Allocationsize.QuadPart = 0x1000
+	in.Endoffile.QuadPart = 0x0ABC
+	raw, err := in.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if len(raw) != 22 {
+		t.Fatalf("expected 22 bytes, got %d", len(raw))
+	}
+	out := &informationlevels.SMB_QUERY_FILE_STANDARD_INFO{}
+	if n, err := out.Unmarshal(raw); err != nil || n != 22 {
+		t.Fatalf("Unmarshal: n=%d err=%v", n, err)
+	}
+	if *out != *in {
+		t.Errorf("mismatch:\n in  %+v\n out %+v", in, out)
+	}
+}
+
+func TestQueryFileEaInfoRoundTrip(t *testing.T) {
+	in := &informationlevels.SMB_QUERY_FILE_EA_INFO{Easize: 0xDEADBEEF}
+	raw, err := in.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if len(raw) != 4 {
+		t.Fatalf("expected 4 bytes, got %d", len(raw))
+	}
+	out := &informationlevels.SMB_QUERY_FILE_EA_INFO{}
+	if _, err := out.Unmarshal(raw); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out.Easize != in.Easize {
+		t.Errorf("EaSize = 0x%X, want 0x%X", out.Easize, in.Easize)
+	}
+}
+
+func TestQueryFileCompressionInfoRoundTrip(t *testing.T) {
+	in := &informationlevels.SMB_QUERY_FILE_COMRESSION_INFO{
+		Compressionformat:    0x0002,
+		Compressionunitshift: 16,
+		Chunkshift:           12,
+		Clustershift:         4,
+		Reserved:             [3]types.UCHAR{0, 0, 0},
+	}
+	in.Compressedfilesize.QuadPart = 0x123456
+	raw, err := in.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if len(raw) != 16 {
+		t.Fatalf("expected 16 bytes, got %d", len(raw))
+	}
+	out := &informationlevels.SMB_QUERY_FILE_COMRESSION_INFO{}
+	if n, err := out.Unmarshal(raw); err != nil || n != 16 {
+		t.Fatalf("Unmarshal: n=%d err=%v", n, err)
+	}
+	if *out != *in {
+		t.Errorf("mismatch:\n in  %+v\n out %+v", in, out)
+	}
+}
+
+// nameInfoLike is satisfied by both SMB_QUERY_FILE_NAME_INFO and
+// SMB_QUERY_FILE_ALT_NAME_INFO (identical layouts) for shared round-trip testing.
+func TestQueryFileNameInfoRoundTrip(t *testing.T) {
+	// UTF-16LE "ab.txt"
+	name := []types.UCHAR{'a', 0, 'b', 0, '.', 0, 't', 0, 'x', 0, 't', 0}
+
+	in := &informationlevels.SMB_QUERY_FILE_NAME_INFO{Filename: name}
+	raw, err := in.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if len(raw) != 4+len(name) {
+		t.Fatalf("expected %d bytes, got %d", 4+len(name), len(raw))
+	}
+	out := &informationlevels.SMB_QUERY_FILE_NAME_INFO{}
+	if _, err := out.Unmarshal(raw); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if int(out.Filenamelength) != len(name) || !bytes.Equal([]byte(out.Filename), []byte(name)) {
+		t.Errorf("FileName mismatch: len=%d bytes=% x", out.Filenamelength, []byte(out.Filename))
+	}
+
+	alt := &informationlevels.SMB_QUERY_FILE_ALT_NAME_INFO{Filename: name}
+	altRaw, err := alt.Marshal()
+	if err != nil {
+		t.Fatalf("ALT Marshal: %v", err)
+	}
+	altOut := &informationlevels.SMB_QUERY_FILE_ALT_NAME_INFO{}
+	if _, err := altOut.Unmarshal(altRaw); err != nil {
+		t.Fatalf("ALT Unmarshal: %v", err)
+	}
+	if !bytes.Equal([]byte(altOut.Filename), []byte(name)) {
+		t.Errorf("ALT FileName mismatch: % x", []byte(altOut.Filename))
+	}
+}
+
+func TestQueryFileStreamInfoRoundTrip(t *testing.T) {
+	// UTF-16LE "::$DATA"
+	streamName := []types.UCHAR{':', 0, ':', 0, '$', 0, 'D', 0, 'A', 0, 'T', 0, 'A', 0}
+
+	in := &informationlevels.SMB_QUERY_FILE_STREAM_INFO{
+		Nextentryoffset: 0,
+		Streamname:      streamName,
+	}
+	in.Streamsize.QuadPart = 0x4000
+	in.Streamallocationsize.QuadPart = 0x4096
+	raw, err := in.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if len(raw) != 24+len(streamName) {
+		t.Fatalf("expected %d bytes, got %d", 24+len(streamName), len(raw))
+	}
+	out := &informationlevels.SMB_QUERY_FILE_STREAM_INFO{}
+	if _, err := out.Unmarshal(raw); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out.Streamsize.QuadPart != in.Streamsize.QuadPart ||
+		out.Streamallocationsize.QuadPart != in.Streamallocationsize.QuadPart ||
+		int(out.Streamnamelength) != len(streamName) ||
+		!bytes.Equal([]byte(out.Streamname), []byte(streamName)) {
+		t.Errorf("mismatch:\n in  %+v\n out %+v", in, out)
+	}
+}
+
+func TestQueryFileAllInfoRoundTrip(t *testing.T) {
+	name := []types.UCHAR{'f', 0, 'o', 0, 'o', 0}
+
+	in := &informationlevels.SMB_QUERY_FILE_ALL_INFO{
+		Creationtime:      types.FILETIME{DwLowDateTime: 0x11, DwHighDateTime: 0x22},
+		Lastaccesstime:    types.FILETIME{DwLowDateTime: 0x33, DwHighDateTime: 0x44},
+		Lastwritetime:     types.FILETIME{DwLowDateTime: 0x55, DwHighDateTime: 0x66},
+		Lastchangetime:    types.FILETIME{DwLowDateTime: 0x77, DwHighDateTime: 0x88},
+		Extfileattributes: types.ATTR_ARCHIVE,
+		Reserved1:         0,
+		Numberoflinks:     1,
+		Deletepending:     0,
+		Directory:         0,
+		Reserved2:         0,
+		Easize:            0,
+		Filename:          name,
+	}
+	in.Allocationsize.QuadPart = 0x2000
+	in.Endoffile.QuadPart = 0x1234
+
+	raw, err := in.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	// 4 FILETIMEs (32) + 40 fixed bytes + FileName.
+	if len(raw) != 72+len(name) {
+		t.Fatalf("expected %d bytes, got %d", 72+len(name), len(raw))
+	}
+	out := &informationlevels.SMB_QUERY_FILE_ALL_INFO{}
+	if _, err := out.Unmarshal(raw); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out.Allocationsize.QuadPart != in.Allocationsize.QuadPart {
+		t.Errorf("AllocationSize = 0x%X, want 0x%X", out.Allocationsize.QuadPart, in.Allocationsize.QuadPart)
+	}
+	if out.Endoffile.QuadPart != in.Endoffile.QuadPart {
+		t.Errorf("EndOfFile = 0x%X, want 0x%X", out.Endoffile.QuadPart, in.Endoffile.QuadPart)
+	}
+	if int(out.Filenamelength) != len(name) || !bytes.Equal([]byte(out.Filename), []byte(name)) {
+		t.Errorf("FileName mismatch: len=%d bytes=% x", out.Filenamelength, []byte(out.Filename))
+	}
+	if out.Creationtime != in.Creationtime || out.Lastchangetime != in.Lastchangetime {
+		t.Errorf("timestamp mismatch")
+	}
+}
+
+func TestQueryFileInfoUnmarshalBounds(t *testing.T) {
+	if _, err := (&informationlevels.SMB_QUERY_FILE_STANDARD_INFO{}).Unmarshal(make([]byte, 21)); err == nil {
+		t.Error("STANDARD: expected error on 21-byte buffer")
+	}
+	if _, err := (&informationlevels.SMB_QUERY_FILE_COMRESSION_INFO{}).Unmarshal(make([]byte, 15)); err == nil {
+		t.Error("COMPRESSION: expected error on 15-byte buffer")
+	}
+	// NAME_INFO with a length that overruns the buffer.
+	bad := []byte{0xFF, 0x00, 0x00, 0x00} // FileNameLength=255, no payload
+	if _, err := (&informationlevels.SMB_QUERY_FILE_NAME_INFO{}).Unmarshal(bad); err == nil {
+		t.Error("NAME: expected error when FileNameLength overruns buffer")
+	}
+}


### PR DESCRIPTION
### Linked Issue
Part of #378 (does not close it — second batch by information-level family; QUERY_FILE).

### Root Cause
Every structure in `network/smb/smb_v10/informationlevels/` had empty `Marshal`/`Unmarshal`. Several QUERY_FILE structures were also missing fields required by MS-CIFS, so even a correct method body could not represent the wire format.

### Fix Description
Implement `Marshal`/`Unmarshal` for the TRANS2 QUERY_FILE_INFORMATION levels (MS-CIFS 2.2.8.3), little-endian with bounds-checked decoding. Each layout was cross-checked against the Microsoft Open Specifications page for that structure:
- **SMB_QUERY_FILE_BASIC_INFO** (40 bytes): 4× FILETIME + ExtFileAttributes + Reserved.
- **SMB_QUERY_FILE_STANDARD_INFO** (22 bytes): AllocationSize + EndOfFile + NumberOfLinks + DeletePending + Directory.
- **SMB_QUERY_FILE_EA_INFO** (4 bytes): EaSize.
- **SMB_QUERY_FILE_COMPRESSION_INFO** (16 bytes): added the spec `Reserved[3]` trailing bytes that the struct was missing.
- **SMB_QUERY_FILE_NAME_INFO** / **SMB_QUERY_FILE_ALT_NAME_INFO**: added the trailing `FileName` payload (UTF-16LE bytes, length = FileNameLength).
- **SMB_QUERY_FILE_STREAM_INFO**: added the trailing `StreamName` payload.
- **SMB_QUERY_FILE_ALL_INFO**: added the **missing `AllocationSize` field** (8 bytes, between `Reserved1` and `EndOfFile` per the spec — the struct previously skipped it, which would have mis-aligned every subsequent field) and the trailing `FileName`.

Length-prefixed payloads set their length field from the payload on `Marshal` and are bounds-checked against the buffer on `Unmarshal`.

### How Verified
- **Tests:** `go test ./network/smb/smb_v10/...` passes. New round-trip tests assert the fixed sizes (40/22/4/16 bytes) and that variable-length payloads (`FileName`, `StreamName`) and the newly added `AllocationSize` survive a Marshal→Unmarshal cycle, plus bounds tests for truncated buffers and an overrunning length prefix.
- **Static:** field order, sizes, and the presence of `AllocationSize`/`Reserved[3]`/trailing names were taken from the MS-CIFS pages fetched for each structure.

### Test Coverage
- **Added:** `TestQueryFileBasicInfoRoundTrip`, `TestQueryFileStandardInfoRoundTrip`, `TestQueryFileEaInfoRoundTrip`, `TestQueryFileCompressionInfoRoundTrip`, `TestQueryFileNameInfoRoundTrip`, `TestQueryFileStreamInfoRoundTrip`, `TestQueryFileAllInfoRoundTrip`, `TestQueryFileInfoUnmarshalBounds` in `network/smb/smb_v10/informationlevels/query_file_info_test.go`.

### Scope of Change
- **Files changed:** the eight `SMB_QUERY_FILE_*` files under `network/smb/smb_v10/informationlevels/` plus `query_file_info_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Low and local. These methods were no-ops before and nothing consumed them yet. Struct-shape additions (`AllocationSize`, `Reserved[3]`, `FileName`/`StreamName`) make the structures match the spec wire format. Remaining batches: FIND_FILE directory info, FS info, legacy/EA + placeholders (final batch closes #378).
