### PR TITLE
Implement Marshal/Unmarshal for FIND_FILE directory information levels (#378)

### DIFF
--- a/network/smb/smb_v10/informationlevels/SMB_FIND_FILE_BOTH_DIRECTORY_INFO.go
+++ b/network/smb/smb_v10/informationlevels/SMB_FIND_FILE_BOTH_DIRECTORY_INFO.go
@@ -1,9 +1,15 @@
 package informationlevels
 
 import (
+	"encoding/binary"
+	"fmt"
+
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
 )
 
+// shortNameSize is the fixed size, in bytes, of the ShortName field of an
+// SMB_FIND_FILE_BOTH_DIRECTORY_INFO entry (12 WCHARs).
+const shortNameSize = 24
 
 // SMB_FIND_FILE_BOTH_DIRECTORY_INFO
 // Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/2aa849f4-1bc0-42bf-9c8f-d09f11fccc4c
@@ -50,15 +56,16 @@ type SMB_FIND_FILE_BOTH_DIRECTORY_INFO struct {
 	Shortnamelength types.UCHAR
 	// Reserved: (1 byte): This field is reserved and MUST be zero (0x00).
 	Reserved types.UCHAR
+	// ShortName: (24 bytes): This field MUST contain the 8.3 name, if any, of the file
+	// in Unicode format. It is a fixed 24-byte field; ShortNameLength gives the number
+	// of meaningful bytes.
+	Shortname [shortNameSize]types.UCHAR
+	// FileName: (variable): This field contains the long name of the file. It is
+	// FileNameLength bytes long; the raw bytes are stored as-is.
+	Filename []types.UCHAR
 }
 
 // Marshal serializes the SMB_FIND_FILE_BOTH_DIRECTORY_INFO into a byte slice.
-//
-// This method marshals the information level structure according to the format
-// specified in MS-CIFS documentation. Information levels are used in various
-// SMB operations to determine the format of data being exchanged.
-//
-// The marshalled data follows the specific format required for this information level.
 //
 // Returns:
 // - A byte slice containing the marshalled information level structure
@@ -66,22 +73,112 @@ type SMB_FIND_FILE_BOTH_DIRECTORY_INFO struct {
 func (s *SMB_FIND_FILE_BOTH_DIRECTORY_INFO) Marshal() ([]byte, error) {
 	marshalled_struct := []byte{}
 
+	// NextEntryOffset (4 bytes) and FileIndex (4 bytes).
+	buf4 := make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf4, uint32(s.Nextentryoffset))
+	marshalled_struct = append(marshalled_struct, buf4...)
+	buf4 = make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf4, uint32(s.Fileindex))
+	marshalled_struct = append(marshalled_struct, buf4...)
+
+	// CreationTime, LastAccessTime, LastWriteTime, LastChangeTime (8 bytes each, FILETIME).
+	for _, ft := range []*types.FILETIME{&s.Creationtime, &s.Lastaccesstime, &s.Lastwritetime, &s.Lastchangetime} {
+		b, err := ft.Marshal()
+		if err != nil {
+			return nil, err
+		}
+		marshalled_struct = append(marshalled_struct, b...)
+	}
+
+	// EndOfFile (8 bytes) and AllocationSize (8 bytes), LARGE_INTEGER.
+	buf8 := make([]byte, 8)
+	binary.LittleEndian.PutUint64(buf8, uint64(s.Endoffile.QuadPart))
+	marshalled_struct = append(marshalled_struct, buf8...)
+	buf8 = make([]byte, 8)
+	binary.LittleEndian.PutUint64(buf8, uint64(s.Allocationsize.QuadPart))
+	marshalled_struct = append(marshalled_struct, buf8...)
+
+	// ExtFileAttributes (4 bytes).
+	buf4 = make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf4, uint32(s.Extfileattributes))
+	marshalled_struct = append(marshalled_struct, buf4...)
+
+	// FileNameLength (4 bytes), derived from the FileName payload.
+	s.Filenamelength = types.ULONG(len(s.Filename))
+	buf4 = make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf4, uint32(s.Filenamelength))
+	marshalled_struct = append(marshalled_struct, buf4...)
+
+	// EaSize (4 bytes).
+	buf4 = make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf4, uint32(s.Easize))
+	marshalled_struct = append(marshalled_struct, buf4...)
+
+	// ShortNameLength (1 byte) and Reserved (1 byte).
+	marshalled_struct = append(marshalled_struct, byte(s.Shortnamelength), byte(s.Reserved))
+
+	// ShortName (fixed 24 bytes).
+	for i := 0; i < shortNameSize; i++ {
+		marshalled_struct = append(marshalled_struct, byte(s.Shortname[i]))
+	}
+
+	// FileName (variable).
+	marshalled_struct = append(marshalled_struct, s.Filename...)
+
 	return marshalled_struct, nil
 }
 
 // Unmarshal deserializes a byte slice into the SMB_FIND_FILE_BOTH_DIRECTORY_INFO structure.
 //
-// This method unmarshals the information level structure according to the format
-// specified in MS-CIFS documentation. Information levels are used in various
-// SMB operations to determine the format of data being exchanged.
-//
-// The data is expected to follow the specific format required for this information level.
-//
 // Parameters:
 // - data: A byte slice containing the serialized SMB_FIND_FILE_BOTH_DIRECTORY_INFO structure
 //
 // Returns:
+// - The number of bytes consumed
 // - An error if unmarshalling any component fails or if the data format is invalid
 func (s *SMB_FIND_FILE_BOTH_DIRECTORY_INFO) Unmarshal(data []byte) (int, error) {
-	return 0, nil
+	// Fixed portion: NextEntryOffset(4) + FileIndex(4) + 4x FILETIME(32) + EndOfFile(8)
+	// + AllocationSize(8) + ExtFileAttributes(4) + FileNameLength(4) + EaSize(4)
+	// + ShortNameLength(1) + Reserved(1) + ShortName(24) = 94 bytes.
+	const fixedSize = 8 + 32 + 16 + 4 + 4 + 4 + 1 + 1 + shortNameSize // 94
+	if len(data) < fixedSize {
+		return 0, fmt.Errorf("data too short for SMB_FIND_FILE_BOTH_DIRECTORY_INFO fixed fields (need %d bytes, have %d)", fixedSize, len(data))
+	}
+	s.Nextentryoffset = types.ULONG(binary.LittleEndian.Uint32(data[0:4]))
+	s.Fileindex = types.ULONG(binary.LittleEndian.Uint32(data[4:8]))
+	offset := 8
+	for _, ft := range []*types.FILETIME{&s.Creationtime, &s.Lastaccesstime, &s.Lastwritetime, &s.Lastchangetime} {
+		n, err := ft.Unmarshal(data[offset:])
+		if err != nil {
+			return offset, err
+		}
+		offset += n
+	}
+	s.Endoffile.QuadPart = binary.LittleEndian.Uint64(data[offset : offset+8])
+	offset += 8
+	s.Allocationsize.QuadPart = binary.LittleEndian.Uint64(data[offset : offset+8])
+	offset += 8
+	s.Extfileattributes = types.SMB_EXT_FILE_ATTR(binary.LittleEndian.Uint32(data[offset : offset+4]))
+	offset += 4
+	s.Filenamelength = types.ULONG(binary.LittleEndian.Uint32(data[offset : offset+4]))
+	offset += 4
+	s.Easize = types.ULONG(binary.LittleEndian.Uint32(data[offset : offset+4]))
+	offset += 4
+	s.Shortnamelength = types.UCHAR(data[offset])
+	offset++
+	s.Reserved = types.UCHAR(data[offset])
+	offset++
+	for i := 0; i < shortNameSize; i++ {
+		s.Shortname[i] = types.UCHAR(data[offset+i])
+	}
+	offset += shortNameSize
+
+	// FileName (FileNameLength bytes).
+	if len(data) < offset+int(s.Filenamelength) {
+		return offset, fmt.Errorf("data too short for FileName (need %d bytes, have %d)", s.Filenamelength, len(data)-offset)
+	}
+	s.Filename = append([]types.UCHAR{}, data[offset:offset+int(s.Filenamelength)]...)
+	offset += int(s.Filenamelength)
+
+	return offset, nil
 }

--- a/network/smb/smb_v10/informationlevels/SMB_FIND_FILE_DIRECTORY_INFO.go
+++ b/network/smb/smb_v10/informationlevels/SMB_FIND_FILE_DIRECTORY_INFO.go
@@ -1,9 +1,11 @@
 package informationlevels
 
 import (
+	"encoding/binary"
+	"fmt"
+
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
 )
-
 
 // SMB_FIND_FILE_DIRECTORY_INFO
 // Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/8be9119a-b37e-4ff5-bee7-3d7a5997dc88
@@ -38,15 +40,12 @@ type SMB_FIND_FILE_DIRECTORY_INFO struct {
 	// FileNameLength: (4 bytes): This field contains the length of the FileName field,
 	// in bytes.
 	Filenamelength types.ULONG
+	// FileName: (variable): This field contains the name of the file. It is
+	// FileNameLength bytes long; the raw bytes are stored as-is.
+	Filename []types.UCHAR
 }
 
 // Marshal serializes the SMB_FIND_FILE_DIRECTORY_INFO into a byte slice.
-//
-// This method marshals the information level structure according to the format
-// specified in MS-CIFS documentation. Information levels are used in various
-// SMB operations to determine the format of data being exchanged.
-//
-// The marshalled data follows the specific format required for this information level.
 //
 // Returns:
 // - A byte slice containing the marshalled information level structure
@@ -54,22 +53,87 @@ type SMB_FIND_FILE_DIRECTORY_INFO struct {
 func (s *SMB_FIND_FILE_DIRECTORY_INFO) Marshal() ([]byte, error) {
 	marshalled_struct := []byte{}
 
+	// NextEntryOffset (4 bytes) and FileIndex (4 bytes).
+	buf4 := make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf4, uint32(s.Nextentryoffset))
+	marshalled_struct = append(marshalled_struct, buf4...)
+	buf4 = make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf4, uint32(s.Fileindex))
+	marshalled_struct = append(marshalled_struct, buf4...)
+
+	// CreationTime, LastAccessTime, LastWriteTime, LastAttrChangeTime (8 bytes each, FILETIME).
+	for _, ft := range []*types.FILETIME{&s.Creationtime, &s.Lastaccesstime, &s.Lastwritetime, &s.Lastattrchangetime} {
+		b, err := ft.Marshal()
+		if err != nil {
+			return nil, err
+		}
+		marshalled_struct = append(marshalled_struct, b...)
+	}
+
+	// EndOfFile (8 bytes) and AllocationSize (8 bytes), LARGE_INTEGER.
+	buf8 := make([]byte, 8)
+	binary.LittleEndian.PutUint64(buf8, uint64(s.Endoffile.QuadPart))
+	marshalled_struct = append(marshalled_struct, buf8...)
+	buf8 = make([]byte, 8)
+	binary.LittleEndian.PutUint64(buf8, uint64(s.Allocationsize.QuadPart))
+	marshalled_struct = append(marshalled_struct, buf8...)
+
+	// ExtFileAttributes (4 bytes).
+	buf4 = make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf4, uint32(s.Extfileattributes))
+	marshalled_struct = append(marshalled_struct, buf4...)
+
+	// FileNameLength (4 bytes), derived from the FileName payload.
+	s.Filenamelength = types.ULONG(len(s.Filename))
+	buf4 = make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf4, uint32(s.Filenamelength))
+	marshalled_struct = append(marshalled_struct, buf4...)
+
+	// FileName (variable).
+	marshalled_struct = append(marshalled_struct, s.Filename...)
+
 	return marshalled_struct, nil
 }
 
 // Unmarshal deserializes a byte slice into the SMB_FIND_FILE_DIRECTORY_INFO structure.
 //
-// This method unmarshals the information level structure according to the format
-// specified in MS-CIFS documentation. Information levels are used in various
-// SMB operations to determine the format of data being exchanged.
-//
-// The data is expected to follow the specific format required for this information level.
-//
 // Parameters:
 // - data: A byte slice containing the serialized SMB_FIND_FILE_DIRECTORY_INFO structure
 //
 // Returns:
+// - The number of bytes consumed
 // - An error if unmarshalling any component fails or if the data format is invalid
 func (s *SMB_FIND_FILE_DIRECTORY_INFO) Unmarshal(data []byte) (int, error) {
-	return 0, nil
+	// Fixed portion: NextEntryOffset(4) + FileIndex(4) + 4x FILETIME(32) + EndOfFile(8)
+	// + AllocationSize(8) + ExtFileAttributes(4) + FileNameLength(4) = 64 bytes.
+	if len(data) < 64 {
+		return 0, fmt.Errorf("data too short for SMB_FIND_FILE_DIRECTORY_INFO fixed fields (need 64 bytes, have %d)", len(data))
+	}
+	s.Nextentryoffset = types.ULONG(binary.LittleEndian.Uint32(data[0:4]))
+	s.Fileindex = types.ULONG(binary.LittleEndian.Uint32(data[4:8]))
+	offset := 8
+	for _, ft := range []*types.FILETIME{&s.Creationtime, &s.Lastaccesstime, &s.Lastwritetime, &s.Lastattrchangetime} {
+		n, err := ft.Unmarshal(data[offset:])
+		if err != nil {
+			return offset, err
+		}
+		offset += n
+	}
+	s.Endoffile.QuadPart = binary.LittleEndian.Uint64(data[offset : offset+8])
+	offset += 8
+	s.Allocationsize.QuadPart = binary.LittleEndian.Uint64(data[offset : offset+8])
+	offset += 8
+	s.Extfileattributes = types.SMB_EXT_FILE_ATTR(binary.LittleEndian.Uint32(data[offset : offset+4]))
+	offset += 4
+	s.Filenamelength = types.ULONG(binary.LittleEndian.Uint32(data[offset : offset+4]))
+	offset += 4
+
+	// FileName (FileNameLength bytes).
+	if len(data) < offset+int(s.Filenamelength) {
+		return offset, fmt.Errorf("data too short for FileName (need %d bytes, have %d)", s.Filenamelength, len(data)-offset)
+	}
+	s.Filename = append([]types.UCHAR{}, data[offset:offset+int(s.Filenamelength)]...)
+	offset += int(s.Filenamelength)
+
+	return offset, nil
 }

--- a/network/smb/smb_v10/informationlevels/SMB_FIND_FILE_FULL_DIRECTORY_INFO.go
+++ b/network/smb/smb_v10/informationlevels/SMB_FIND_FILE_FULL_DIRECTORY_INFO.go
@@ -1,9 +1,11 @@
 package informationlevels
 
 import (
+	"encoding/binary"
+	"fmt"
+
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
 )
-
 
 // SMB_FIND_FILE_FULL_DIRECTORY_INFO
 // Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/64bd690e-d3a4-4588-96ef-0cb90b065d08
@@ -43,15 +45,12 @@ type SMB_FIND_FILE_FULL_DIRECTORY_INFO struct {
 	// EaSize: (4 bytes): This field contains the size of the file's extended attribute
 	// (EA) information, in bytes.
 	Easize types.ULONG
+	// FileName: (variable): This field contains the name of the file. It is
+	// FileNameLength bytes long; the raw bytes are stored as-is.
+	Filename []types.UCHAR
 }
 
 // Marshal serializes the SMB_FIND_FILE_FULL_DIRECTORY_INFO into a byte slice.
-//
-// This method marshals the information level structure according to the format
-// specified in MS-CIFS documentation. Information levels are used in various
-// SMB operations to determine the format of data being exchanged.
-//
-// The marshalled data follows the specific format required for this information level.
 //
 // Returns:
 // - A byte slice containing the marshalled information level structure
@@ -59,22 +58,94 @@ type SMB_FIND_FILE_FULL_DIRECTORY_INFO struct {
 func (s *SMB_FIND_FILE_FULL_DIRECTORY_INFO) Marshal() ([]byte, error) {
 	marshalled_struct := []byte{}
 
+	// NextEntryOffset (4 bytes) and FileIndex (4 bytes).
+	buf4 := make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf4, uint32(s.Nextentryoffset))
+	marshalled_struct = append(marshalled_struct, buf4...)
+	buf4 = make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf4, uint32(s.Fileindex))
+	marshalled_struct = append(marshalled_struct, buf4...)
+
+	// CreationTime, LastAccessTime, LastWriteTime, LastAttrChangeTime (8 bytes each, FILETIME).
+	for _, ft := range []*types.FILETIME{&s.Creationtime, &s.Lastaccesstime, &s.Lastwritetime, &s.Lastattrchangetime} {
+		b, err := ft.Marshal()
+		if err != nil {
+			return nil, err
+		}
+		marshalled_struct = append(marshalled_struct, b...)
+	}
+
+	// EndOfFile (8 bytes) and AllocationSize (8 bytes), LARGE_INTEGER.
+	buf8 := make([]byte, 8)
+	binary.LittleEndian.PutUint64(buf8, uint64(s.Endoffile.QuadPart))
+	marshalled_struct = append(marshalled_struct, buf8...)
+	buf8 = make([]byte, 8)
+	binary.LittleEndian.PutUint64(buf8, uint64(s.Allocationsize.QuadPart))
+	marshalled_struct = append(marshalled_struct, buf8...)
+
+	// ExtFileAttributes (4 bytes).
+	buf4 = make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf4, uint32(s.Extfileattributes))
+	marshalled_struct = append(marshalled_struct, buf4...)
+
+	// FileNameLength (4 bytes), derived from the FileName payload.
+	s.Filenamelength = types.ULONG(len(s.Filename))
+	buf4 = make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf4, uint32(s.Filenamelength))
+	marshalled_struct = append(marshalled_struct, buf4...)
+
+	// EaSize (4 bytes).
+	buf4 = make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf4, uint32(s.Easize))
+	marshalled_struct = append(marshalled_struct, buf4...)
+
+	// FileName (variable).
+	marshalled_struct = append(marshalled_struct, s.Filename...)
+
 	return marshalled_struct, nil
 }
 
 // Unmarshal deserializes a byte slice into the SMB_FIND_FILE_FULL_DIRECTORY_INFO structure.
 //
-// This method unmarshals the information level structure according to the format
-// specified in MS-CIFS documentation. Information levels are used in various
-// SMB operations to determine the format of data being exchanged.
-//
-// The data is expected to follow the specific format required for this information level.
-//
 // Parameters:
 // - data: A byte slice containing the serialized SMB_FIND_FILE_FULL_DIRECTORY_INFO structure
 //
 // Returns:
+// - The number of bytes consumed
 // - An error if unmarshalling any component fails or if the data format is invalid
 func (s *SMB_FIND_FILE_FULL_DIRECTORY_INFO) Unmarshal(data []byte) (int, error) {
-	return 0, nil
+	// Fixed portion: NextEntryOffset(4) + FileIndex(4) + 4x FILETIME(32) + EndOfFile(8)
+	// + AllocationSize(8) + ExtFileAttributes(4) + FileNameLength(4) + EaSize(4) = 68 bytes.
+	if len(data) < 68 {
+		return 0, fmt.Errorf("data too short for SMB_FIND_FILE_FULL_DIRECTORY_INFO fixed fields (need 68 bytes, have %d)", len(data))
+	}
+	s.Nextentryoffset = types.ULONG(binary.LittleEndian.Uint32(data[0:4]))
+	s.Fileindex = types.ULONG(binary.LittleEndian.Uint32(data[4:8]))
+	offset := 8
+	for _, ft := range []*types.FILETIME{&s.Creationtime, &s.Lastaccesstime, &s.Lastwritetime, &s.Lastattrchangetime} {
+		n, err := ft.Unmarshal(data[offset:])
+		if err != nil {
+			return offset, err
+		}
+		offset += n
+	}
+	s.Endoffile.QuadPart = binary.LittleEndian.Uint64(data[offset : offset+8])
+	offset += 8
+	s.Allocationsize.QuadPart = binary.LittleEndian.Uint64(data[offset : offset+8])
+	offset += 8
+	s.Extfileattributes = types.SMB_EXT_FILE_ATTR(binary.LittleEndian.Uint32(data[offset : offset+4]))
+	offset += 4
+	s.Filenamelength = types.ULONG(binary.LittleEndian.Uint32(data[offset : offset+4]))
+	offset += 4
+	s.Easize = types.ULONG(binary.LittleEndian.Uint32(data[offset : offset+4]))
+	offset += 4
+
+	// FileName (FileNameLength bytes).
+	if len(data) < offset+int(s.Filenamelength) {
+		return offset, fmt.Errorf("data too short for FileName (need %d bytes, have %d)", s.Filenamelength, len(data)-offset)
+	}
+	s.Filename = append([]types.UCHAR{}, data[offset:offset+int(s.Filenamelength)]...)
+	offset += int(s.Filenamelength)
+
+	return offset, nil
 }

--- a/network/smb/smb_v10/informationlevels/SMB_FIND_FILE_NAMES_INFO.go
+++ b/network/smb/smb_v10/informationlevels/SMB_FIND_FILE_NAMES_INFO.go
@@ -1,9 +1,11 @@
 package informationlevels
 
 import (
+	"encoding/binary"
+	"fmt"
+
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
 )
-
 
 // SMB_FIND_FILE_NAMES_INFO
 // Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/88b9968b-a36f-482a-bb30-c7a51a3e290d
@@ -18,15 +20,12 @@ type SMB_FIND_FILE_NAMES_INFO struct {
 	// FileNameLength: (4 bytes): This field MUST contain the length of the FileName
 	// field, in bytes.
 	Filenamelength types.ULONG
+	// FileName: (variable): This field contains the name of the file. It is
+	// FileNameLength bytes long; the raw bytes are stored as-is.
+	Filename []types.UCHAR
 }
 
 // Marshal serializes the SMB_FIND_FILE_NAMES_INFO into a byte slice.
-//
-// This method marshals the information level structure according to the format
-// specified in MS-CIFS documentation. Information levels are used in various
-// SMB operations to determine the format of data being exchanged.
-//
-// The marshalled data follows the specific format required for this information level.
 //
 // Returns:
 // - A byte slice containing the marshalled information level structure
@@ -34,22 +33,50 @@ type SMB_FIND_FILE_NAMES_INFO struct {
 func (s *SMB_FIND_FILE_NAMES_INFO) Marshal() ([]byte, error) {
 	marshalled_struct := []byte{}
 
+	// NextEntryOffset (4 bytes) and FileIndex (4 bytes).
+	buf4 := make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf4, uint32(s.Nextentryoffset))
+	marshalled_struct = append(marshalled_struct, buf4...)
+	buf4 = make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf4, uint32(s.Fileindex))
+	marshalled_struct = append(marshalled_struct, buf4...)
+
+	// FileNameLength (4 bytes), derived from the FileName payload.
+	s.Filenamelength = types.ULONG(len(s.Filename))
+	buf4 = make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf4, uint32(s.Filenamelength))
+	marshalled_struct = append(marshalled_struct, buf4...)
+
+	// FileName (variable).
+	marshalled_struct = append(marshalled_struct, s.Filename...)
+
 	return marshalled_struct, nil
 }
 
 // Unmarshal deserializes a byte slice into the SMB_FIND_FILE_NAMES_INFO structure.
 //
-// This method unmarshals the information level structure according to the format
-// specified in MS-CIFS documentation. Information levels are used in various
-// SMB operations to determine the format of data being exchanged.
-//
-// The data is expected to follow the specific format required for this information level.
-//
 // Parameters:
 // - data: A byte slice containing the serialized SMB_FIND_FILE_NAMES_INFO structure
 //
 // Returns:
+// - The number of bytes consumed
 // - An error if unmarshalling any component fails or if the data format is invalid
 func (s *SMB_FIND_FILE_NAMES_INFO) Unmarshal(data []byte) (int, error) {
-	return 0, nil
+	// NextEntryOffset(4) + FileIndex(4) + FileNameLength(4) = 12 bytes.
+	if len(data) < 12 {
+		return 0, fmt.Errorf("data too short for SMB_FIND_FILE_NAMES_INFO fixed fields")
+	}
+	s.Nextentryoffset = types.ULONG(binary.LittleEndian.Uint32(data[0:4]))
+	s.Fileindex = types.ULONG(binary.LittleEndian.Uint32(data[4:8]))
+	s.Filenamelength = types.ULONG(binary.LittleEndian.Uint32(data[8:12]))
+	offset := 12
+
+	// FileName (FileNameLength bytes).
+	if len(data) < offset+int(s.Filenamelength) {
+		return offset, fmt.Errorf("data too short for FileName (need %d bytes, have %d)", s.Filenamelength, len(data)-offset)
+	}
+	s.Filename = append([]types.UCHAR{}, data[offset:offset+int(s.Filenamelength)]...)
+	offset += int(s.Filenamelength)
+
+	return offset, nil
 }

--- a/network/smb/smb_v10/informationlevels/find_file_info_test.go
+++ b/network/smb/smb_v10/informationlevels/find_file_info_test.go
@@ -1,0 +1,145 @@
+package informationlevels_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/informationlevels"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+)
+
+func ft(lo, hi uint32) types.FILETIME { return types.FILETIME{DwLowDateTime: lo, DwHighDateTime: hi} }
+
+func TestFindFileNamesInfoRoundTrip(t *testing.T) {
+	name := []types.UCHAR{'a', 0, 'b', 0}
+	in := &informationlevels.SMB_FIND_FILE_NAMES_INFO{Nextentryoffset: 0x40, Fileindex: 0, Filename: name}
+	raw, err := in.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if len(raw) != 12+len(name) {
+		t.Fatalf("expected %d bytes, got %d", 12+len(name), len(raw))
+	}
+	out := &informationlevels.SMB_FIND_FILE_NAMES_INFO{}
+	if _, err := out.Unmarshal(raw); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out.Nextentryoffset != in.Nextentryoffset || int(out.Filenamelength) != len(name) || !bytes.Equal([]byte(out.Filename), []byte(name)) {
+		t.Errorf("mismatch:\n in  %+v\n out %+v", in, out)
+	}
+}
+
+func TestFindFileDirectoryInfoRoundTrip(t *testing.T) {
+	name := []types.UCHAR{'f', 0, 'o', 0, 'o', 0}
+	in := &informationlevels.SMB_FIND_FILE_DIRECTORY_INFO{
+		Nextentryoffset:    0x80,
+		Fileindex:          0,
+		Creationtime:       ft(1, 2),
+		Lastaccesstime:     ft(3, 4),
+		Lastwritetime:      ft(5, 6),
+		Lastattrchangetime: ft(7, 8),
+		Extfileattributes:  types.ATTR_DIRECTORY,
+		Filename:           name,
+	}
+	in.Endoffile.QuadPart = 0x1111
+	in.Allocationsize.QuadPart = 0x2000
+	raw, err := in.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if len(raw) != 64+len(name) {
+		t.Fatalf("expected %d bytes, got %d", 64+len(name), len(raw))
+	}
+	out := &informationlevels.SMB_FIND_FILE_DIRECTORY_INFO{}
+	if _, err := out.Unmarshal(raw); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out.Lastattrchangetime != in.Lastattrchangetime || out.Endoffile.QuadPart != in.Endoffile.QuadPart || !bytes.Equal([]byte(out.Filename), []byte(name)) {
+		t.Errorf("mismatch:\n in  %+v\n out %+v", in, out)
+	}
+}
+
+func TestFindFileFullDirectoryInfoRoundTrip(t *testing.T) {
+	name := []types.UCHAR{'b', 0, 'a', 0, 'r', 0}
+	in := &informationlevels.SMB_FIND_FILE_FULL_DIRECTORY_INFO{
+		Nextentryoffset:    0,
+		Creationtime:       ft(9, 10),
+		Lastaccesstime:     ft(11, 12),
+		Lastwritetime:      ft(13, 14),
+		Lastattrchangetime: ft(15, 16),
+		Extfileattributes:  types.ATTR_ARCHIVE,
+		Easize:             0x55,
+		Filename:           name,
+	}
+	in.Endoffile.QuadPart = 0x3333
+	in.Allocationsize.QuadPart = 0x4000
+	raw, err := in.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if len(raw) != 68+len(name) {
+		t.Fatalf("expected %d bytes, got %d", 68+len(name), len(raw))
+	}
+	out := &informationlevels.SMB_FIND_FILE_FULL_DIRECTORY_INFO{}
+	if _, err := out.Unmarshal(raw); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out.Easize != in.Easize || int(out.Filenamelength) != len(name) || !bytes.Equal([]byte(out.Filename), []byte(name)) {
+		t.Errorf("mismatch:\n in  %+v\n out %+v", in, out)
+	}
+}
+
+func TestFindFileBothDirectoryInfoRoundTrip(t *testing.T) {
+	name := []types.UCHAR{'l', 0, 'o', 0, 'n', 0, 'g', 0}
+	var short [24]types.UCHAR
+	copy(short[:], []types.UCHAR{'L', 0, 'O', 0, 'N', 0, 'G', 0, '~', 0, '1', 0})
+
+	in := &informationlevels.SMB_FIND_FILE_BOTH_DIRECTORY_INFO{
+		Nextentryoffset:   0,
+		Creationtime:      ft(0x11, 0x22),
+		Lastaccesstime:    ft(0x33, 0x44),
+		Lastwritetime:     ft(0x55, 0x66),
+		Lastchangetime:    ft(0x77, 0x88),
+		Extfileattributes: types.ATTR_NORMAL,
+		Easize:            0,
+		Shortnamelength:   12,
+		Reserved:          0,
+		Shortname:         short,
+		Filename:          name,
+	}
+	in.Endoffile.QuadPart = 0xABCD
+	in.Allocationsize.QuadPart = 0x1_0000
+
+	raw, err := in.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if len(raw) != 94+len(name) {
+		t.Fatalf("expected %d bytes, got %d", 94+len(name), len(raw))
+	}
+	out := &informationlevels.SMB_FIND_FILE_BOTH_DIRECTORY_INFO{}
+	if _, err := out.Unmarshal(raw); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out.Shortnamelength != 12 || out.Shortname != short {
+		t.Errorf("ShortName mismatch: len=%d bytes=% x", out.Shortnamelength, out.Shortname)
+	}
+	if int(out.Filenamelength) != len(name) || !bytes.Equal([]byte(out.Filename), []byte(name)) {
+		t.Errorf("FileName mismatch: len=%d bytes=% x", out.Filenamelength, []byte(out.Filename))
+	}
+	if out.Endoffile.QuadPart != in.Endoffile.QuadPart || out.Lastchangetime != in.Lastchangetime {
+		t.Errorf("fixed field mismatch")
+	}
+}
+
+func TestFindFileInfoUnmarshalBounds(t *testing.T) {
+	if _, err := (&informationlevels.SMB_FIND_FILE_DIRECTORY_INFO{}).Unmarshal(make([]byte, 63)); err == nil {
+		t.Error("DIRECTORY: expected error on 63-byte buffer")
+	}
+	if _, err := (&informationlevels.SMB_FIND_FILE_FULL_DIRECTORY_INFO{}).Unmarshal(make([]byte, 67)); err == nil {
+		t.Error("FULL_DIRECTORY: expected error on 67-byte buffer")
+	}
+	if _, err := (&informationlevels.SMB_FIND_FILE_BOTH_DIRECTORY_INFO{}).Unmarshal(make([]byte, 93)); err == nil {
+		t.Error("BOTH_DIRECTORY: expected error on 93-byte buffer")
+	}
+}


### PR DESCRIPTION
### Linked Issue
Part of #378 (does not close it — third batch by information-level family; FIND_FILE directory info).

### Root Cause
The `informationlevels` structures had empty `Marshal`/`Unmarshal`. The FIND_FILE directory-info structures also lacked their trailing variable-length `FileName` field (and, for BOTH, the fixed `ShortName` field), so they could not represent the wire format.

### Fix Description
Implement `Marshal`/`Unmarshal` for the TRANS2_FIND_FIRST2 / TRANS2_FIND_NEXT2 directory information levels (MS-CIFS 2.2.8.1), little-endian with bounds-checked decoding. Each layout was cross-checked against the Microsoft Open Specifications page:
- **SMB_FIND_FILE_NAMES_INFO**: NextEntryOffset + FileIndex + FileNameLength + added trailing `FileName`.
- **SMB_FIND_FILE_DIRECTORY_INFO** (64-byte fixed portion): added trailing `FileName`.
- **SMB_FIND_FILE_FULL_DIRECTORY_INFO** (68-byte fixed portion): `EaSize` follows `FileNameLength`; added trailing `FileName`.
- **SMB_FIND_FILE_BOTH_DIRECTORY_INFO** (94-byte fixed portion): added the fixed **24-byte `ShortName`** field (after `ShortNameLength`/`Reserved`) and the trailing `FileName`. The 94-byte fixed size matches the constant the existing client `find.go` parser uses.

Length-prefixed `FileName` payloads set `FileNameLength` from the payload on `Marshal` and are bounds-checked on `Unmarshal`. `ShortName` is a fixed 24-byte field; `ShortNameLength` indicates how many bytes are meaningful.

### How Verified
- **Tests:** `go test ./network/smb/smb_v10/...` passes. New round-trip tests assert the fixed-portion sizes (12/64/68/94 bytes), recovery of the trailing `FileName` and (for BOTH) the 24-byte `ShortName`, plus bounds tests for truncated fixed portions.
- **Static:** field order/sizes (including `LastAttrChangeTime` vs `LastChangeTime`, `EaSize` placement, and `ShortName[24]`) taken from the MS-CIFS pages fetched for each structure.

### Test Coverage
- **Added:** `TestFindFileNamesInfoRoundTrip`, `TestFindFileDirectoryInfoRoundTrip`, `TestFindFileFullDirectoryInfoRoundTrip`, `TestFindFileBothDirectoryInfoRoundTrip`, `TestFindFileInfoUnmarshalBounds` in `network/smb/smb_v10/informationlevels/find_file_info_test.go`.

### Scope of Change
- **Files changed:** the four `SMB_FIND_FILE_*` files under `network/smb/smb_v10/informationlevels/` plus `find_file_info_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Low and local. These methods were no-ops before; nothing consumes them yet. One batch remains (legacy SMB_INFO_* + EA + placeholders), which will close #378.
