### PR TITLE
Implement Marshal/Unmarshal for filesystem information levels (#378)

### DIFF
--- a/network/smb/smb_v10/informationlevels/SMB_INFO_ALLOCATION.go
+++ b/network/smb/smb_v10/informationlevels/SMB_INFO_ALLOCATION.go
@@ -1,6 +1,9 @@
 package informationlevels
 
 import (
+	"encoding/binary"
+	"fmt"
+
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
 )
 
@@ -34,7 +37,16 @@ type SMB_INFO_ALLOCATION struct {
 // - A byte slice containing the marshalled information level structure
 // - An error if marshalling any component fails
 func (s *SMB_INFO_ALLOCATION) Marshal() ([]byte, error) {
-	marshalled_struct := []byte{}
+	marshalled_struct := make([]byte, 18)
+
+	// idFileSystem (4) + cSectorUnit (4) + cUnit (4) + cUnitAvailable (4).
+	binary.LittleEndian.PutUint32(marshalled_struct[0:4], uint32(s.Idfilesystem))
+	binary.LittleEndian.PutUint32(marshalled_struct[4:8], uint32(s.Csectorunit))
+	binary.LittleEndian.PutUint32(marshalled_struct[8:12], uint32(s.Cunit))
+	binary.LittleEndian.PutUint32(marshalled_struct[12:16], uint32(s.Cunitavailable))
+
+	// cbSector (2).
+	binary.LittleEndian.PutUint16(marshalled_struct[16:18], uint16(s.Cbsector))
 
 	return marshalled_struct, nil
 }
@@ -53,5 +65,14 @@ func (s *SMB_INFO_ALLOCATION) Marshal() ([]byte, error) {
 // Returns:
 // - An error if unmarshalling any component fails or if the data format is invalid
 func (s *SMB_INFO_ALLOCATION) Unmarshal(data []byte) (int, error) {
-	return 0, nil
+	if len(data) < 18 {
+		return 0, fmt.Errorf("data too short for SMB_INFO_ALLOCATION (need 18 bytes, have %d)", len(data))
+	}
+	s.Idfilesystem = types.ULONG(binary.LittleEndian.Uint32(data[0:4]))
+	s.Csectorunit = types.ULONG(binary.LittleEndian.Uint32(data[4:8]))
+	s.Cunit = types.ULONG(binary.LittleEndian.Uint32(data[8:12]))
+	s.Cunitavailable = types.ULONG(binary.LittleEndian.Uint32(data[12:16]))
+	s.Cbsector = types.USHORT(binary.LittleEndian.Uint16(data[16:18]))
+
+	return 18, nil
 }

--- a/network/smb/smb_v10/informationlevels/SMB_INFO_VOLUME.go
+++ b/network/smb/smb_v10/informationlevels/SMB_INFO_VOLUME.go
@@ -1,9 +1,11 @@
 package informationlevels
 
 import (
+	"encoding/binary"
+	"fmt"
+
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
 )
-
 
 // SMB_INFO_VOLUME
 // Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/13d589f5-67e9-49e8-8c33-7b04b8f7cd8c
@@ -13,17 +15,13 @@ type SMB_INFO_VOLUME struct {
 	// cCharCount: (1 byte): This field contains the number of characters in the
 	// VolumeLabel field.
 	Ccharcount types.UCHAR
-	// VolumeLabel: (variable): This field contains the volume label.
-	Volumelabel types.SMB_STRING
+	// VolumeLabel: (variable): This field contains the volume label. On the wire it is
+	// cCharCount bytes with no buffer-format prefix, so it is held as a raw byte slice
+	// rather than a buffer-format-prefixed SMB_STRING.
+	Volumelabel []types.UCHAR
 }
 
 // Marshal serializes the SMB_INFO_VOLUME into a byte slice.
-//
-// This method marshals the information level structure according to the format
-// specified in MS-CIFS documentation. Information levels are used in various
-// SMB operations to determine the format of data being exchanged.
-//
-// The marshalled data follows the specific format required for this information level.
 //
 // Returns:
 // - A byte slice containing the marshalled information level structure
@@ -31,22 +29,44 @@ type SMB_INFO_VOLUME struct {
 func (s *SMB_INFO_VOLUME) Marshal() ([]byte, error) {
 	marshalled_struct := []byte{}
 
+	// ulVolSerialNbr (4 bytes).
+	buf4 := make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf4, uint32(s.Ulvolserialnbr))
+	marshalled_struct = append(marshalled_struct, buf4...)
+
+	// cCharCount (1 byte), derived from the VolumeLabel payload.
+	s.Ccharcount = types.UCHAR(len(s.Volumelabel))
+	marshalled_struct = append(marshalled_struct, byte(s.Ccharcount))
+
+	// VolumeLabel (cCharCount bytes).
+	marshalled_struct = append(marshalled_struct, s.Volumelabel...)
+
 	return marshalled_struct, nil
 }
 
 // Unmarshal deserializes a byte slice into the SMB_INFO_VOLUME structure.
 //
-// This method unmarshals the information level structure according to the format
-// specified in MS-CIFS documentation. Information levels are used in various
-// SMB operations to determine the format of data being exchanged.
-//
-// The data is expected to follow the specific format required for this information level.
-//
 // Parameters:
 // - data: A byte slice containing the serialized SMB_INFO_VOLUME structure
 //
 // Returns:
+// - The number of bytes consumed
 // - An error if unmarshalling any component fails or if the data format is invalid
 func (s *SMB_INFO_VOLUME) Unmarshal(data []byte) (int, error) {
-	return 0, nil
+	// ulVolSerialNbr(4) + cCharCount(1) = 5 bytes.
+	if len(data) < 5 {
+		return 0, fmt.Errorf("data too short for SMB_INFO_VOLUME fixed fields (need 5 bytes, have %d)", len(data))
+	}
+	s.Ulvolserialnbr = types.ULONG(binary.LittleEndian.Uint32(data[0:4]))
+	s.Ccharcount = types.UCHAR(data[4])
+	offset := 5
+
+	// VolumeLabel (cCharCount bytes).
+	if len(data) < offset+int(s.Ccharcount) {
+		return offset, fmt.Errorf("data too short for VolumeLabel (need %d bytes, have %d)", s.Ccharcount, len(data)-offset)
+	}
+	s.Volumelabel = append([]types.UCHAR{}, data[offset:offset+int(s.Ccharcount)]...)
+	offset += int(s.Ccharcount)
+
+	return offset, nil
 }

--- a/network/smb/smb_v10/informationlevels/SMB_QUERY_FS_ATTRIBUTE_INFO.go
+++ b/network/smb/smb_v10/informationlevels/SMB_QUERY_FS_ATTRIBUTE_INFO.go
@@ -1,18 +1,30 @@
 package informationlevels
 
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+)
+
 // SMB_QUERY_FS_ATTRIBUTE_INFO
 // Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/1011206a-55c5-4dbf-aff0-119514136940
 type SMB_QUERY_FS_ATTRIBUTE_INFO struct {
-	// TODO: Implement this struct
+	// FileSystemAttributes: (4 bytes): A 32-bit field of flags that contains the file
+	// system's attributes (e.g. FILE_CASE_SENSITIVE_SEARCH, FILE_UNICODE_ON_DISK).
+	Filesystemattributes types.ULONG
+	// MaxFileNameLengthInBytes: (4 bytes): The maximum size, in bytes, of a file name
+	// on the file system.
+	Maxfilenamelengthinbytes types.ULONG
+	// LengthOfFileSystemName: (4 bytes): The size, in bytes, of the FileSystemName
+	// field.
+	Lengthoffilesystemname types.ULONG
+	// FileSystemName: (variable): The Unicode-encoded (UTF-16LE) name of the file
+	// system. It is LengthOfFileSystemName bytes long; the raw bytes are stored as-is.
+	Filesystemname []types.UCHAR
 }
 
 // Marshal serializes the SMB_QUERY_FS_ATTRIBUTE_INFO into a byte slice.
-//
-// This method marshals the information level structure according to the format
-// specified in MS-CIFS documentation. Information levels are used in various
-// SMB operations to determine the format of data being exchanged.
-//
-// The marshalled data follows the specific format required for this information level.
 //
 // Returns:
 // - A byte slice containing the marshalled information level structure
@@ -20,22 +32,52 @@ type SMB_QUERY_FS_ATTRIBUTE_INFO struct {
 func (s *SMB_QUERY_FS_ATTRIBUTE_INFO) Marshal() ([]byte, error) {
 	marshalled_struct := []byte{}
 
+	// FileSystemAttributes (4 bytes).
+	buf4 := make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf4, uint32(s.Filesystemattributes))
+	marshalled_struct = append(marshalled_struct, buf4...)
+
+	// MaxFileNameLengthInBytes (4 bytes).
+	buf4 = make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf4, uint32(s.Maxfilenamelengthinbytes))
+	marshalled_struct = append(marshalled_struct, buf4...)
+
+	// LengthOfFileSystemName (4 bytes), derived from the FileSystemName payload.
+	s.Lengthoffilesystemname = types.ULONG(len(s.Filesystemname))
+	buf4 = make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf4, uint32(s.Lengthoffilesystemname))
+	marshalled_struct = append(marshalled_struct, buf4...)
+
+	// FileSystemName (variable).
+	marshalled_struct = append(marshalled_struct, s.Filesystemname...)
+
 	return marshalled_struct, nil
 }
 
 // Unmarshal deserializes a byte slice into the SMB_QUERY_FS_ATTRIBUTE_INFO structure.
 //
-// This method unmarshals the information level structure according to the format
-// specified in MS-CIFS documentation. Information levels are used in various
-// SMB operations to determine the format of data being exchanged.
-//
-// The data is expected to follow the specific format required for this information level.
-//
 // Parameters:
 // - data: A byte slice containing the serialized SMB_QUERY_FS_ATTRIBUTE_INFO structure
 //
 // Returns:
+// - The number of bytes consumed
 // - An error if unmarshalling any component fails or if the data format is invalid
 func (s *SMB_QUERY_FS_ATTRIBUTE_INFO) Unmarshal(data []byte) (int, error) {
-	return 0, nil
+	// FileSystemAttributes(4) + MaxFileNameLengthInBytes(4) + LengthOfFileSystemName(4) = 12 bytes.
+	if len(data) < 12 {
+		return 0, fmt.Errorf("data too short for SMB_QUERY_FS_ATTRIBUTE_INFO fixed fields (need 12 bytes, have %d)", len(data))
+	}
+	s.Filesystemattributes = types.ULONG(binary.LittleEndian.Uint32(data[0:4]))
+	s.Maxfilenamelengthinbytes = types.ULONG(binary.LittleEndian.Uint32(data[4:8]))
+	s.Lengthoffilesystemname = types.ULONG(binary.LittleEndian.Uint32(data[8:12]))
+	offset := 12
+
+	// FileSystemName (LengthOfFileSystemName bytes).
+	if len(data) < offset+int(s.Lengthoffilesystemname) {
+		return offset, fmt.Errorf("data too short for FileSystemName (need %d bytes, have %d)", s.Lengthoffilesystemname, len(data)-offset)
+	}
+	s.Filesystemname = append([]types.UCHAR{}, data[offset:offset+int(s.Lengthoffilesystemname)]...)
+	offset += int(s.Lengthoffilesystemname)
+
+	return offset, nil
 }

--- a/network/smb/smb_v10/informationlevels/SMB_QUERY_FS_DEVICE_INFO.go
+++ b/network/smb/smb_v10/informationlevels/SMB_QUERY_FS_DEVICE_INFO.go
@@ -1,6 +1,9 @@
 package informationlevels
 
 import (
+	"encoding/binary"
+	"fmt"
+
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
 )
 
@@ -28,7 +31,11 @@ type SMB_QUERY_FS_DEVICE_INFO struct {
 // - A byte slice containing the marshalled information level structure
 // - An error if marshalling any component fails
 func (s *SMB_QUERY_FS_DEVICE_INFO) Marshal() ([]byte, error) {
-	marshalled_struct := []byte{}
+	marshalled_struct := make([]byte, 8)
+
+	// DeviceType (4) + DeviceCharacteristics (4).
+	binary.LittleEndian.PutUint32(marshalled_struct[0:4], uint32(s.Devicetype))
+	binary.LittleEndian.PutUint32(marshalled_struct[4:8], uint32(s.Devicecharacteristics))
 
 	return marshalled_struct, nil
 }
@@ -47,5 +54,11 @@ func (s *SMB_QUERY_FS_DEVICE_INFO) Marshal() ([]byte, error) {
 // Returns:
 // - An error if unmarshalling any component fails or if the data format is invalid
 func (s *SMB_QUERY_FS_DEVICE_INFO) Unmarshal(data []byte) (int, error) {
-	return 0, nil
+	if len(data) < 8 {
+		return 0, fmt.Errorf("data too short for SMB_QUERY_FS_DEVICE_INFO (need 8 bytes, have %d)", len(data))
+	}
+	s.Devicetype = types.ULONG(binary.LittleEndian.Uint32(data[0:4]))
+	s.Devicecharacteristics = types.ULONG(binary.LittleEndian.Uint32(data[4:8]))
+
+	return 8, nil
 }

--- a/network/smb/smb_v10/informationlevels/SMB_QUERY_FS_SIZE_INFO.go
+++ b/network/smb/smb_v10/informationlevels/SMB_QUERY_FS_SIZE_INFO.go
@@ -1,6 +1,9 @@
 package informationlevels
 
 import (
+	"encoding/binary"
+	"fmt"
+
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
 )
 
@@ -33,7 +36,15 @@ type SMB_QUERY_FS_SIZE_INFO struct {
 // - A byte slice containing the marshalled information level structure
 // - An error if marshalling any component fails
 func (s *SMB_QUERY_FS_SIZE_INFO) Marshal() ([]byte, error) {
-	marshalled_struct := []byte{}
+	marshalled_struct := make([]byte, 24)
+
+	// TotalAllocationUnits (8) + TotalFreeAllocationUnits (8), LARGE_INTEGER.
+	binary.LittleEndian.PutUint64(marshalled_struct[0:8], uint64(s.Totalallocationunits.QuadPart))
+	binary.LittleEndian.PutUint64(marshalled_struct[8:16], uint64(s.Totalfreeallocationunits.QuadPart))
+
+	// SectorsPerAllocationUnit (4) + BytesPerSector (4).
+	binary.LittleEndian.PutUint32(marshalled_struct[16:20], uint32(s.Sectorsperallocationunit))
+	binary.LittleEndian.PutUint32(marshalled_struct[20:24], uint32(s.Bytespersector))
 
 	return marshalled_struct, nil
 }
@@ -52,5 +63,13 @@ func (s *SMB_QUERY_FS_SIZE_INFO) Marshal() ([]byte, error) {
 // Returns:
 // - An error if unmarshalling any component fails or if the data format is invalid
 func (s *SMB_QUERY_FS_SIZE_INFO) Unmarshal(data []byte) (int, error) {
-	return 0, nil
+	if len(data) < 24 {
+		return 0, fmt.Errorf("data too short for SMB_QUERY_FS_SIZE_INFO (need 24 bytes, have %d)", len(data))
+	}
+	s.Totalallocationunits.QuadPart = binary.LittleEndian.Uint64(data[0:8])
+	s.Totalfreeallocationunits.QuadPart = binary.LittleEndian.Uint64(data[8:16])
+	s.Sectorsperallocationunit = types.ULONG(binary.LittleEndian.Uint32(data[16:20]))
+	s.Bytespersector = types.ULONG(binary.LittleEndian.Uint32(data[20:24]))
+
+	return 24, nil
 }

--- a/network/smb/smb_v10/informationlevels/SMB_QUERY_FS_VOLUME_INFO.go
+++ b/network/smb/smb_v10/informationlevels/SMB_QUERY_FS_VOLUME_INFO.go
@@ -1,9 +1,11 @@
 package informationlevels
 
 import (
+	"encoding/binary"
+	"fmt"
+
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
 )
-
 
 // SMB_QUERY_FS_VOLUME_INFO
 // Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/879f3ae2-b029-4b3b-8043-c830fc517b28
@@ -16,16 +18,14 @@ type SMB_QUERY_FS_VOLUME_INFO struct {
 	// VolumeLabelSize: (4 bytes): This field contains the size of the VolumeLabel
 	// field, in bytes.
 	Volumelabelsize types.ULONG
+	// Reserved: (2 bytes): Reserved.
 	Reserved types.USHORT
+	// VolumeLabel: (variable): This field contains the Unicode-encoded (UTF-16LE)
+	// volume label. It is VolumeLabelSize bytes long; the raw bytes are stored as-is.
+	Volumelabel []types.UCHAR
 }
 
 // Marshal serializes the SMB_QUERY_FS_VOLUME_INFO into a byte slice.
-//
-// This method marshals the information level structure according to the format
-// specified in MS-CIFS documentation. Information levels are used in various
-// SMB operations to determine the format of data being exchanged.
-//
-// The marshalled data follows the specific format required for this information level.
 //
 // Returns:
 // - A byte slice containing the marshalled information level structure
@@ -33,22 +33,62 @@ type SMB_QUERY_FS_VOLUME_INFO struct {
 func (s *SMB_QUERY_FS_VOLUME_INFO) Marshal() ([]byte, error) {
 	marshalled_struct := []byte{}
 
+	// VolumeCreationTime (8 bytes, FILETIME).
+	b, err := s.Volumecreationtime.Marshal()
+	if err != nil {
+		return nil, err
+	}
+	marshalled_struct = append(marshalled_struct, b...)
+
+	// SerialNumber (4 bytes).
+	buf4 := make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf4, uint32(s.Serialnumber))
+	marshalled_struct = append(marshalled_struct, buf4...)
+
+	// VolumeLabelSize (4 bytes), derived from the VolumeLabel payload.
+	s.Volumelabelsize = types.ULONG(len(s.Volumelabel))
+	buf4 = make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf4, uint32(s.Volumelabelsize))
+	marshalled_struct = append(marshalled_struct, buf4...)
+
+	// Reserved (2 bytes).
+	buf2 := make([]byte, 2)
+	binary.LittleEndian.PutUint16(buf2, uint16(s.Reserved))
+	marshalled_struct = append(marshalled_struct, buf2...)
+
+	// VolumeLabel (variable).
+	marshalled_struct = append(marshalled_struct, s.Volumelabel...)
+
 	return marshalled_struct, nil
 }
 
 // Unmarshal deserializes a byte slice into the SMB_QUERY_FS_VOLUME_INFO structure.
 //
-// This method unmarshals the information level structure according to the format
-// specified in MS-CIFS documentation. Information levels are used in various
-// SMB operations to determine the format of data being exchanged.
-//
-// The data is expected to follow the specific format required for this information level.
-//
 // Parameters:
 // - data: A byte slice containing the serialized SMB_QUERY_FS_VOLUME_INFO structure
 //
 // Returns:
+// - The number of bytes consumed
 // - An error if unmarshalling any component fails or if the data format is invalid
 func (s *SMB_QUERY_FS_VOLUME_INFO) Unmarshal(data []byte) (int, error) {
-	return 0, nil
+	// VolumeCreationTime(8) + SerialNumber(4) + VolumeLabelSize(4) + Reserved(2) = 18 bytes.
+	if len(data) < 18 {
+		return 0, fmt.Errorf("data too short for SMB_QUERY_FS_VOLUME_INFO fixed fields (need 18 bytes, have %d)", len(data))
+	}
+	if _, err := s.Volumecreationtime.Unmarshal(data[0:8]); err != nil {
+		return 0, err
+	}
+	s.Serialnumber = types.ULONG(binary.LittleEndian.Uint32(data[8:12]))
+	s.Volumelabelsize = types.ULONG(binary.LittleEndian.Uint32(data[12:16]))
+	s.Reserved = types.USHORT(binary.LittleEndian.Uint16(data[16:18]))
+	offset := 18
+
+	// VolumeLabel (VolumeLabelSize bytes).
+	if len(data) < offset+int(s.Volumelabelsize) {
+		return offset, fmt.Errorf("data too short for VolumeLabel (need %d bytes, have %d)", s.Volumelabelsize, len(data)-offset)
+	}
+	s.Volumelabel = append([]types.UCHAR{}, data[offset:offset+int(s.Volumelabelsize)]...)
+	offset += int(s.Volumelabelsize)
+
+	return offset, nil
 }

--- a/network/smb/smb_v10/informationlevels/fs_info_test.go
+++ b/network/smb/smb_v10/informationlevels/fs_info_test.go
@@ -1,0 +1,156 @@
+package informationlevels_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/informationlevels"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+)
+
+func TestFsSizeInfoRoundTrip(t *testing.T) {
+	in := &informationlevels.SMB_QUERY_FS_SIZE_INFO{Sectorsperallocationunit: 8, Bytespersector: 512}
+	in.Totalallocationunits.QuadPart = 0x10000
+	in.Totalfreeallocationunits.QuadPart = 0x8000
+	raw, err := in.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if len(raw) != 24 {
+		t.Fatalf("expected 24 bytes, got %d", len(raw))
+	}
+	out := &informationlevels.SMB_QUERY_FS_SIZE_INFO{}
+	if n, err := out.Unmarshal(raw); err != nil || n != 24 {
+		t.Fatalf("Unmarshal: n=%d err=%v", n, err)
+	}
+	if *out != *in {
+		t.Errorf("mismatch:\n in  %+v\n out %+v", in, out)
+	}
+}
+
+func TestFsDeviceInfoRoundTrip(t *testing.T) {
+	in := &informationlevels.SMB_QUERY_FS_DEVICE_INFO{Devicetype: 0x0007, Devicecharacteristics: 0x0010}
+	raw, err := in.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if len(raw) != 8 {
+		t.Fatalf("expected 8 bytes, got %d", len(raw))
+	}
+	out := &informationlevels.SMB_QUERY_FS_DEVICE_INFO{}
+	if _, err := out.Unmarshal(raw); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if *out != *in {
+		t.Errorf("mismatch:\n in  %+v\n out %+v", in, out)
+	}
+}
+
+func TestInfoAllocationRoundTrip(t *testing.T) {
+	in := &informationlevels.SMB_INFO_ALLOCATION{
+		Idfilesystem:   0,
+		Csectorunit:    8,
+		Cunit:          0x100000,
+		Cunitavailable: 0x80000,
+		Cbsector:       512,
+	}
+	raw, err := in.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if len(raw) != 18 {
+		t.Fatalf("expected 18 bytes, got %d", len(raw))
+	}
+	out := &informationlevels.SMB_INFO_ALLOCATION{}
+	if n, err := out.Unmarshal(raw); err != nil || n != 18 {
+		t.Fatalf("Unmarshal: n=%d err=%v", n, err)
+	}
+	if *out != *in {
+		t.Errorf("mismatch:\n in  %+v\n out %+v", in, out)
+	}
+}
+
+func TestFsVolumeInfoRoundTrip(t *testing.T) {
+	label := []types.UCHAR{'D', 0, 'A', 0, 'T', 0, 'A', 0}
+	in := &informationlevels.SMB_QUERY_FS_VOLUME_INFO{
+		Volumecreationtime: types.FILETIME{DwLowDateTime: 0xAA, DwHighDateTime: 0xBB},
+		Serialnumber:       0x12345678,
+		Reserved:           0,
+		Volumelabel:        label,
+	}
+	raw, err := in.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if len(raw) != 18+len(label) {
+		t.Fatalf("expected %d bytes, got %d", 18+len(label), len(raw))
+	}
+	out := &informationlevels.SMB_QUERY_FS_VOLUME_INFO{}
+	if _, err := out.Unmarshal(raw); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out.Serialnumber != in.Serialnumber || int(out.Volumelabelsize) != len(label) || !bytes.Equal([]byte(out.Volumelabel), []byte(label)) {
+		t.Errorf("mismatch:\n in  %+v\n out %+v", in, out)
+	}
+}
+
+func TestFsAttributeInfoRoundTrip(t *testing.T) {
+	name := []types.UCHAR{'N', 0, 'T', 0, 'F', 0, 'S', 0}
+	in := &informationlevels.SMB_QUERY_FS_ATTRIBUTE_INFO{
+		Filesystemattributes:     0x00000007,
+		Maxfilenamelengthinbytes: 255,
+		Filesystemname:           name,
+	}
+	raw, err := in.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if len(raw) != 12+len(name) {
+		t.Fatalf("expected %d bytes, got %d", 12+len(name), len(raw))
+	}
+	out := &informationlevels.SMB_QUERY_FS_ATTRIBUTE_INFO{}
+	if _, err := out.Unmarshal(raw); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out.Filesystemattributes != in.Filesystemattributes || out.Maxfilenamelengthinbytes != in.Maxfilenamelengthinbytes ||
+		int(out.Lengthoffilesystemname) != len(name) || !bytes.Equal([]byte(out.Filesystemname), []byte(name)) {
+		t.Errorf("mismatch:\n in  %+v\n out %+v", in, out)
+	}
+}
+
+func TestInfoVolumeRoundTrip(t *testing.T) {
+	label := []types.UCHAR{'H', 'O', 'M', 'E'} // OEM, 1 byte/char
+	in := &informationlevels.SMB_INFO_VOLUME{Ulvolserialnbr: 0xCAFEBABE, Volumelabel: label}
+	raw, err := in.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if len(raw) != 5+len(label) {
+		t.Fatalf("expected %d bytes, got %d", 5+len(label), len(raw))
+	}
+	if int(raw[4]) != len(label) {
+		t.Errorf("cCharCount byte = %d, want %d", raw[4], len(label))
+	}
+	out := &informationlevels.SMB_INFO_VOLUME{}
+	if _, err := out.Unmarshal(raw); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out.Ulvolserialnbr != in.Ulvolserialnbr || int(out.Ccharcount) != len(label) || !bytes.Equal([]byte(out.Volumelabel), []byte(label)) {
+		t.Errorf("mismatch:\n in  %+v\n out %+v", in, out)
+	}
+}
+
+func TestFsInfoUnmarshalBounds(t *testing.T) {
+	if _, err := (&informationlevels.SMB_QUERY_FS_SIZE_INFO{}).Unmarshal(make([]byte, 23)); err == nil {
+		t.Error("FS_SIZE: expected error on 23-byte buffer")
+	}
+	if _, err := (&informationlevels.SMB_INFO_ALLOCATION{}).Unmarshal(make([]byte, 17)); err == nil {
+		t.Error("INFO_ALLOCATION: expected error on 17-byte buffer")
+	}
+	if _, err := (&informationlevels.SMB_QUERY_FS_VOLUME_INFO{}).Unmarshal(make([]byte, 17)); err == nil {
+		t.Error("FS_VOLUME: expected error on 17-byte buffer")
+	}
+	if _, err := (&informationlevels.SMB_QUERY_FS_ATTRIBUTE_INFO{}).Unmarshal(make([]byte, 11)); err == nil {
+		t.Error("FS_ATTRIBUTE: expected error on 11-byte buffer")
+	}
+}


### PR DESCRIPTION
### Linked Issue
Part of #378 (does not close it — fourth batch by information-level family; filesystem info).

### Root Cause
The `informationlevels` structures had empty `Marshal`/`Unmarshal`. Several FS-info structures were missing fields (trailing `VolumeLabel`), one was an empty placeholder (`SMB_QUERY_FS_ATTRIBUTE_INFO`), and `SMB_INFO_VOLUME` modelled its label with a buffer-format-prefixed `SMB_STRING` that does not match the wire layout.

### Fix Description
Implement `Marshal`/`Unmarshal` for the TRANS2_QUERY_FS_INFORMATION levels (MS-CIFS 2.2.8.2), little-endian with bounds-checked decoding. Each layout was cross-checked against the Microsoft Open Specifications page:
- **SMB_QUERY_FS_SIZE_INFO** (24 bytes), **SMB_QUERY_FS_DEVICE_INFO** (8 bytes), **SMB_INFO_ALLOCATION** (18 bytes): fixed layouts.
- **SMB_QUERY_FS_VOLUME_INFO**: 18-byte fixed head (VolumeCreationTime + SerialNumber + VolumeLabelSize + Reserved) plus the added trailing `VolumeLabel`.
- **SMB_QUERY_FS_ATTRIBUTE_INFO**: defined the previously-empty placeholder struct as `FileSystemAttributes` (4) + `MaxFileNameLengthInBytes` (4) + `LengthOfFileSystemName` (4) + trailing `FileSystemName`.
- **SMB_INFO_VOLUME**: `VolumeLabel` changed from `SMB_STRING` to raw `[]UCHAR` of `cCharCount` bytes. The spec declares the field type as `SMB_STRING`, but on the wire here it is `cCharCount` characters with no buffer-format byte; the project's `SMB_STRING.Marshal` would emit a spurious buffer-format prefix, so a raw byte slice is the correct representation.

### How Verified
- **Tests:** `go test ./network/smb/smb_v10/...` passes. New round-trip tests assert the fixed sizes (24/8/18 bytes), recovery of the variable `VolumeLabel`/`FileSystemName` payloads, that `SMB_INFO_VOLUME` emits `cCharCount` with no buffer-format byte, and bounds errors on truncated buffers.
- **Static:** field order/sizes (including the 2-byte `Reserved` before `VolumeLabel`, and the full `FS_ATTRIBUTE` field list) taken from the MS-CIFS pages fetched for each structure.

### Test Coverage
- **Added:** `TestFsSizeInfoRoundTrip`, `TestFsDeviceInfoRoundTrip`, `TestInfoAllocationRoundTrip`, `TestFsVolumeInfoRoundTrip`, `TestFsAttributeInfoRoundTrip`, `TestInfoVolumeRoundTrip`, `TestFsInfoUnmarshalBounds` in `network/smb/smb_v10/informationlevels/fs_info_test.go`.

### Scope of Change
- **Files changed:** the six FS-info files under `network/smb/smb_v10/informationlevels/` plus `fs_info_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Low and local. These methods were no-ops before; nothing consumes them yet. One batch remains (legacy SMB_INFO_* date/time + EA + the IS_NAME_VALID placeholder), which will close #378.
