### PR TITLE
Implement Marshal/Unmarshal for legacy and EA information levels (#378)

### DIFF
--- a/network/smb/smb_v10/informationlevels/SMB_INFO_IS_NAME_VALID.go
+++ b/network/smb/smb_v10/informationlevels/SMB_INFO_IS_NAME_VALID.go
@@ -2,8 +2,12 @@ package informationlevels
 
 // SMB_INFO_IS_NAME_VALID
 // Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/67188e6f-1d62-41d2-a9bd-d325e5f75cc1
+//
+// This information level tests whether the requested path has valid syntax. No
+// parameters or data are returned for this information level: success/failure is
+// conveyed entirely by the SMB Header Status field, so this structure carries no
+// fields and (de)serializes to an empty byte slice.
 type SMB_INFO_IS_NAME_VALID struct {
-	// TODO: Implement this struct
 }
 
 // Marshal serializes the SMB_INFO_IS_NAME_VALID into a byte slice.

--- a/network/smb/smb_v10/informationlevels/SMB_INFO_QUERY_ALL_EAS.go
+++ b/network/smb/smb_v10/informationlevels/SMB_INFO_QUERY_ALL_EAS.go
@@ -25,9 +25,8 @@ type SMB_INFO_QUERY_ALL_EAS struct {
 // - A byte slice containing the marshalled information level structure
 // - An error if marshalling any component fails
 func (s *SMB_INFO_QUERY_ALL_EAS) Marshal() ([]byte, error) {
-	marshalled_struct := []byte{}
-
-	return marshalled_struct, nil
+	// The structure is a single SMB_FEA_LIST.
+	return s.Extendedattributelist.Marshal()
 }
 
 // Unmarshal deserializes a byte slice into the SMB_INFO_QUERY_ALL_EAS structure.
@@ -44,5 +43,6 @@ func (s *SMB_INFO_QUERY_ALL_EAS) Marshal() ([]byte, error) {
 // Returns:
 // - An error if unmarshalling any component fails or if the data format is invalid
 func (s *SMB_INFO_QUERY_ALL_EAS) Unmarshal(data []byte) (int, error) {
-	return 0, nil
+	// The structure is a single SMB_FEA_LIST.
+	return s.Extendedattributelist.Unmarshal(data)
 }

--- a/network/smb/smb_v10/informationlevels/SMB_INFO_QUERY_EAS_FROM_LIST.go
+++ b/network/smb/smb_v10/informationlevels/SMB_INFO_QUERY_EAS_FROM_LIST.go
@@ -26,9 +26,8 @@ type SMB_INFO_QUERY_EAS_FROM_LIST struct {
 // - A byte slice containing the marshalled information level structure
 // - An error if marshalling any component fails
 func (s *SMB_INFO_QUERY_EAS_FROM_LIST) Marshal() ([]byte, error) {
-	marshalled_struct := []byte{}
-
-	return marshalled_struct, nil
+	// The structure is a single SMB_FEA_LIST.
+	return s.Extendedattributelist.Marshal()
 }
 
 // Unmarshal deserializes a byte slice into the SMB_INFO_QUERY_EAS_FROM_LIST structure.
@@ -45,5 +44,6 @@ func (s *SMB_INFO_QUERY_EAS_FROM_LIST) Marshal() ([]byte, error) {
 // Returns:
 // - An error if unmarshalling any component fails or if the data format is invalid
 func (s *SMB_INFO_QUERY_EAS_FROM_LIST) Unmarshal(data []byte) (int, error) {
-	return 0, nil
+	// The structure is a single SMB_FEA_LIST.
+	return s.Extendedattributelist.Unmarshal(data)
 }

--- a/network/smb/smb_v10/informationlevels/SMB_INFO_QUERY_EA_SIZE.go
+++ b/network/smb/smb_v10/informationlevels/SMB_INFO_QUERY_EA_SIZE.go
@@ -1,9 +1,11 @@
 package informationlevels
 
 import (
+	"encoding/binary"
+	"fmt"
+
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
 )
-
 
 // SMB_INFO_QUERY_EA_SIZE
 // Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/b0a5faf7-e7cc-4b38-878d-2253a2ef9ad4
@@ -11,19 +13,19 @@ type SMB_INFO_QUERY_EA_SIZE struct {
 	// CreationDate: (2 bytes): This field contains the date when the file was created.
 	Creationdate types.SMB_DATE
 	// CreationTime: (2 bytes): This field contains the time when the file was created.
-	Creationtime types.SMB_TIME
+	Creationtime types.SMB_TIME_DOS
 	// LastAccessDate: (2 bytes): This field contains the date when the file was last
 	// accessed.
 	Lastaccessdate types.SMB_DATE
 	// LastAccessTime: (2 bytes): This field contains the time when the file was last
 	// accessed.
-	Lastaccesstime types.SMB_TIME
+	Lastaccesstime types.SMB_TIME_DOS
 	// LastWriteDate : (2 bytes): This field contains the date when data was last
 	// written to the file.
 	Lastwritedate types.SMB_DATE
 	// LastWriteTime: (2 bytes): This field contains the time when data was last
 	// written to the file.
-	Lastwritetime types.SMB_TIME
+	Lastwritetime types.SMB_TIME_DOS
 	// FileDataSize: (4 bytes): This field contains the file size, in filesystem
 	// allocation units.
 	Filedatasize types.ULONG
@@ -37,13 +39,7 @@ type SMB_INFO_QUERY_EA_SIZE struct {
 	Easize types.ULONG
 }
 
-// Marshal serializes the SMB_INFO_QUERY_EA_SIZE into a byte slice.
-//
-// This method marshals the information level structure according to the format
-// specified in MS-CIFS documentation. Information levels are used in various
-// SMB operations to determine the format of data being exchanged.
-//
-// The marshalled data follows the specific format required for this information level.
+// Marshal serializes the SMB_INFO_QUERY_EA_SIZE into a byte slice (26 bytes).
 //
 // Returns:
 // - A byte slice containing the marshalled information level structure
@@ -51,22 +47,81 @@ type SMB_INFO_QUERY_EA_SIZE struct {
 func (s *SMB_INFO_QUERY_EA_SIZE) Marshal() ([]byte, error) {
 	marshalled_struct := []byte{}
 
+	// Six 2-byte DOS date/time fields, in order.
+	dateTimeFields := []infoStandardField{
+		&s.Creationdate, &s.Creationtime,
+		&s.Lastaccessdate, &s.Lastaccesstime,
+		&s.Lastwritedate, &s.Lastwritetime,
+	}
+	for _, f := range dateTimeFields {
+		b, err := f.Marshal()
+		if err != nil {
+			return nil, err
+		}
+		marshalled_struct = append(marshalled_struct, b...)
+	}
+
+	// FileDataSize (4 bytes) and AllocationSize (4 bytes).
+	buf4 := make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf4, uint32(s.Filedatasize))
+	marshalled_struct = append(marshalled_struct, buf4...)
+	buf4 = make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf4, uint32(s.Allocationsize))
+	marshalled_struct = append(marshalled_struct, buf4...)
+
+	// Attributes (2 bytes, SMB_FILE_ATTRIBUTES).
+	attrBytes, err := s.Attributes.Marshal()
+	if err != nil {
+		return nil, err
+	}
+	marshalled_struct = append(marshalled_struct, attrBytes...)
+
+	// EaSize (4 bytes).
+	buf4 = make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf4, uint32(s.Easize))
+	marshalled_struct = append(marshalled_struct, buf4...)
+
 	return marshalled_struct, nil
 }
 
 // Unmarshal deserializes a byte slice into the SMB_INFO_QUERY_EA_SIZE structure.
 //
-// This method unmarshals the information level structure according to the format
-// specified in MS-CIFS documentation. Information levels are used in various
-// SMB operations to determine the format of data being exchanged.
-//
-// The data is expected to follow the specific format required for this information level.
-//
 // Parameters:
 // - data: A byte slice containing the serialized SMB_INFO_QUERY_EA_SIZE structure
 //
 // Returns:
+// - The number of bytes consumed
 // - An error if unmarshalling any component fails or if the data format is invalid
 func (s *SMB_INFO_QUERY_EA_SIZE) Unmarshal(data []byte) (int, error) {
-	return 0, nil
+	// 6x 2-byte date/time (12) + FileDataSize(4) + AllocationSize(4) + Attributes(2) + EaSize(4) = 26 bytes.
+	if len(data) < 26 {
+		return 0, fmt.Errorf("data too short for SMB_INFO_QUERY_EA_SIZE (need 26 bytes, have %d)", len(data))
+	}
+
+	dateTimeFields := []infoStandardField{
+		&s.Creationdate, &s.Creationtime,
+		&s.Lastaccessdate, &s.Lastaccesstime,
+		&s.Lastwritedate, &s.Lastwritetime,
+	}
+	offset := 0
+	for _, f := range dateTimeFields {
+		n, err := f.Unmarshal(data[offset:])
+		if err != nil {
+			return offset, err
+		}
+		offset += n
+	}
+
+	s.Filedatasize = types.ULONG(binary.LittleEndian.Uint32(data[offset : offset+4]))
+	offset += 4
+	s.Allocationsize = types.ULONG(binary.LittleEndian.Uint32(data[offset : offset+4]))
+	offset += 4
+	if _, err := s.Attributes.Unmarshal(data[offset : offset+2]); err != nil {
+		return offset, err
+	}
+	offset += 2
+	s.Easize = types.ULONG(binary.LittleEndian.Uint32(data[offset : offset+4]))
+	offset += 4
+
+	return offset, nil
 }

--- a/network/smb/smb_v10/informationlevels/SMB_INFO_SET_EAS.go
+++ b/network/smb/smb_v10/informationlevels/SMB_INFO_SET_EAS.go
@@ -24,9 +24,8 @@ type SMB_INFO_SET_EAS struct {
 // - A byte slice containing the marshalled information level structure
 // - An error if marshalling any component fails
 func (s *SMB_INFO_SET_EAS) Marshal() ([]byte, error) {
-	marshalled_struct := []byte{}
-
-	return marshalled_struct, nil
+	// The structure is a single SMB_FEA_LIST.
+	return s.Extendedattributelist.Marshal()
 }
 
 // Unmarshal deserializes a byte slice into the SMB_INFO_SET_EAS structure.
@@ -43,5 +42,6 @@ func (s *SMB_INFO_SET_EAS) Marshal() ([]byte, error) {
 // Returns:
 // - An error if unmarshalling any component fails or if the data format is invalid
 func (s *SMB_INFO_SET_EAS) Unmarshal(data []byte) (int, error) {
-	return 0, nil
+	// The structure is a single SMB_FEA_LIST.
+	return s.Extendedattributelist.Unmarshal(data)
 }

--- a/network/smb/smb_v10/informationlevels/SMB_INFO_STANDARD.go
+++ b/network/smb/smb_v10/informationlevels/SMB_INFO_STANDARD.go
@@ -1,9 +1,10 @@
 package informationlevels
 
 import (
+	"fmt"
+
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
 )
-
 
 // SMB_INFO_STANDARD
 // Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/3e6f3a13-6a40-4f76-af70-bb514554ea5b
@@ -11,28 +12,29 @@ type SMB_INFO_STANDARD struct {
 	// CreationDate: (2 bytes): This field contains the date when the file was created.
 	Creationdate types.SMB_DATE
 	// CreationTime: (2 bytes): This field contains the time when the file was created.
-	Creationtime types.SMB_TIME
+	Creationtime types.SMB_TIME_DOS
 	// LastAccessDate: (2 bytes): This field contains the date when the file was last
 	// accessed.
 	Lastaccessdate types.SMB_DATE
 	// LastAccessTime: (2 bytes): This field contains the time when the file was last
 	// accessed.
-	Lastaccesstime types.SMB_TIME
+	Lastaccesstime types.SMB_TIME_DOS
 	// LastWriteDate: (2 bytes): This field contains the date when data was last
 	// written to the file.
 	Lastwritedate types.SMB_DATE
 	// LastWriteTime: (2 bytes): This field contains the time when data was last
 	// written to the file.
-	Lastwritetime types.SMB_TIME
+	Lastwritetime types.SMB_TIME_DOS
 }
 
-// Marshal serializes the SMB_INFO_STANDARD into a byte slice.
-//
-// This method marshals the information level structure according to the format
-// specified in MS-CIFS documentation. Information levels are used in various
-// SMB operations to determine the format of data being exchanged.
-//
-// The marshalled data follows the specific format required for this information level.
+// marshaler is the common 2-byte (de)serialization interface implemented by
+// SMB_DATE and SMB_TIME_DOS.
+type infoStandardField interface {
+	Marshal() ([]byte, error)
+	Unmarshal([]byte) (int, error)
+}
+
+// Marshal serializes the SMB_INFO_STANDARD into a byte slice (12 bytes).
 //
 // Returns:
 // - A byte slice containing the marshalled information level structure
@@ -40,22 +42,50 @@ type SMB_INFO_STANDARD struct {
 func (s *SMB_INFO_STANDARD) Marshal() ([]byte, error) {
 	marshalled_struct := []byte{}
 
+	// Six 2-byte DOS date/time fields, in order.
+	fields := []infoStandardField{
+		&s.Creationdate, &s.Creationtime,
+		&s.Lastaccessdate, &s.Lastaccesstime,
+		&s.Lastwritedate, &s.Lastwritetime,
+	}
+	for _, f := range fields {
+		b, err := f.Marshal()
+		if err != nil {
+			return nil, err
+		}
+		marshalled_struct = append(marshalled_struct, b...)
+	}
+
 	return marshalled_struct, nil
 }
 
 // Unmarshal deserializes a byte slice into the SMB_INFO_STANDARD structure.
 //
-// This method unmarshals the information level structure according to the format
-// specified in MS-CIFS documentation. Information levels are used in various
-// SMB operations to determine the format of data being exchanged.
-//
-// The data is expected to follow the specific format required for this information level.
-//
 // Parameters:
 // - data: A byte slice containing the serialized SMB_INFO_STANDARD structure
 //
 // Returns:
+// - The number of bytes consumed
 // - An error if unmarshalling any component fails or if the data format is invalid
 func (s *SMB_INFO_STANDARD) Unmarshal(data []byte) (int, error) {
-	return 0, nil
+	// Six 2-byte DOS date/time fields = 12 bytes.
+	if len(data) < 12 {
+		return 0, fmt.Errorf("data too short for SMB_INFO_STANDARD (need 12 bytes, have %d)", len(data))
+	}
+
+	fields := []infoStandardField{
+		&s.Creationdate, &s.Creationtime,
+		&s.Lastaccessdate, &s.Lastaccesstime,
+		&s.Lastwritedate, &s.Lastwritetime,
+	}
+	offset := 0
+	for _, f := range fields {
+		n, err := f.Unmarshal(data[offset:])
+		if err != nil {
+			return offset, err
+		}
+		offset += n
+	}
+
+	return offset, nil
 }

--- a/network/smb/smb_v10/informationlevels/legacy_ea_info_test.go
+++ b/network/smb/smb_v10/informationlevels/legacy_ea_info_test.go
@@ -1,0 +1,158 @@
+package informationlevels_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/informationlevels"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+)
+
+func dosDate(y uint16, m, d uint8) types.SMB_DATE {
+	return types.SMB_DATE{Year: y, Month: m, Day: d}
+}
+func dosTime(h, m, twoSec uint8) types.SMB_TIME_DOS {
+	return types.SMB_TIME_DOS{Hours: h, Minutes: m, TwoSeconds: twoSec}
+}
+
+// TestInfoStandardRoundTrip verifies SMB_INFO_STANDARD is 12 bytes (six 2-byte DOS
+// date/time fields) and round-trips, confirming the 2-byte SMB_TIME_DOS layout.
+func TestInfoStandardRoundTrip(t *testing.T) {
+	in := &informationlevels.SMB_INFO_STANDARD{
+		Creationdate:   dosDate(2021, 6, 15),
+		Creationtime:   dosTime(12, 30, 10),
+		Lastaccessdate: dosDate(2022, 1, 2),
+		Lastaccesstime: dosTime(1, 2, 3),
+		Lastwritedate:  dosDate(2023, 12, 31),
+		Lastwritetime:  dosTime(23, 59, 29),
+	}
+	raw, err := in.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if len(raw) != 12 {
+		t.Fatalf("expected 12 bytes, got %d", len(raw))
+	}
+	out := &informationlevels.SMB_INFO_STANDARD{}
+	if n, err := out.Unmarshal(raw); err != nil || n != 12 {
+		t.Fatalf("Unmarshal: n=%d err=%v", n, err)
+	}
+	if *out != *in {
+		t.Errorf("mismatch:\n in  %+v\n out %+v", in, out)
+	}
+}
+
+// TestInfoQueryEaSizeRoundTrip verifies SMB_INFO_QUERY_EA_SIZE is 26 bytes and
+// round-trips, including the 2-byte date/time fields and SMB_FILE_ATTRIBUTES.
+func TestInfoQueryEaSizeRoundTrip(t *testing.T) {
+	in := &informationlevels.SMB_INFO_QUERY_EA_SIZE{
+		Creationdate:   dosDate(2021, 6, 15),
+		Creationtime:   dosTime(12, 30, 10),
+		Lastaccessdate: dosDate(2022, 1, 2),
+		Lastaccesstime: dosTime(1, 2, 3),
+		Lastwritedate:  dosDate(2023, 12, 31),
+		Lastwritetime:  dosTime(23, 59, 29),
+		Filedatasize:   0x1000,
+		Allocationsize: 0x200,
+		Easize:         0x40,
+	}
+	in.Attributes.SetAttributes(0x0020)
+
+	raw, err := in.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if len(raw) != 26 {
+		t.Fatalf("expected 26 bytes, got %d", len(raw))
+	}
+	out := &informationlevels.SMB_INFO_QUERY_EA_SIZE{}
+	if n, err := out.Unmarshal(raw); err != nil || n != 26 {
+		t.Fatalf("Unmarshal: n=%d err=%v", n, err)
+	}
+	if *out != *in {
+		t.Errorf("mismatch:\n in  %+v\n out %+v", in, out)
+	}
+}
+
+// TestInfoIsNameValidIsEmpty verifies SMB_INFO_IS_NAME_VALID marshals to no bytes
+// and unmarshals consuming nothing (success is conveyed via the SMB Header Status).
+func TestInfoIsNameValidIsEmpty(t *testing.T) {
+	in := &informationlevels.SMB_INFO_IS_NAME_VALID{}
+	raw, err := in.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if len(raw) != 0 {
+		t.Fatalf("expected 0 bytes, got %d", len(raw))
+	}
+	out := &informationlevels.SMB_INFO_IS_NAME_VALID{}
+	if n, err := out.Unmarshal(raw); err != nil || n != 0 {
+		t.Fatalf("Unmarshal: n=%d err=%v", n, err)
+	}
+}
+
+// TestInfoEaListRoundTrip verifies the three SMB_FEA_LIST-wrapping information
+// levels round-trip and that SizeOfListInBytes includes the 4-byte size field.
+func TestInfoEaListRoundTrip(t *testing.T) {
+	payload := []types.UCHAR{0x00, 0x04, 0x05, 0x00, 'F', 'O', 'O', 0x00, 'b', 'a', 'r', 0x00}
+
+	t.Run("QueryAllEas", func(t *testing.T) {
+		in := &informationlevels.SMB_INFO_QUERY_ALL_EAS{}
+		in.Extendedattributelist.FEAList = payload
+		raw, err := in.Marshal()
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		if len(raw) != 4+len(payload) {
+			t.Fatalf("expected %d bytes, got %d", 4+len(payload), len(raw))
+		}
+		out := &informationlevels.SMB_INFO_QUERY_ALL_EAS{}
+		if _, err := out.Unmarshal(raw); err != nil {
+			t.Fatalf("Unmarshal: %v", err)
+		}
+		if int(out.Extendedattributelist.SizeOfListInBytes) != 4+len(payload) {
+			t.Errorf("SizeOfListInBytes = %d, want %d", out.Extendedattributelist.SizeOfListInBytes, 4+len(payload))
+		}
+		if !bytes.Equal([]byte(out.Extendedattributelist.FEAList), []byte(payload)) {
+			t.Errorf("FEAList mismatch: % x", []byte(out.Extendedattributelist.FEAList))
+		}
+	})
+
+	t.Run("QueryEasFromList", func(t *testing.T) {
+		in := &informationlevels.SMB_INFO_QUERY_EAS_FROM_LIST{}
+		in.Extendedattributelist.FEAList = payload
+		raw, _ := in.Marshal()
+		out := &informationlevels.SMB_INFO_QUERY_EAS_FROM_LIST{}
+		if _, err := out.Unmarshal(raw); err != nil {
+			t.Fatalf("Unmarshal: %v", err)
+		}
+		if !bytes.Equal([]byte(out.Extendedattributelist.FEAList), []byte(payload)) {
+			t.Errorf("FEAList mismatch")
+		}
+	})
+
+	t.Run("SetEas", func(t *testing.T) {
+		in := &informationlevels.SMB_INFO_SET_EAS{}
+		in.Extendedattributelist.FEAList = payload
+		raw, _ := in.Marshal()
+		out := &informationlevels.SMB_INFO_SET_EAS{}
+		if _, err := out.Unmarshal(raw); err != nil {
+			t.Fatalf("Unmarshal: %v", err)
+		}
+		if !bytes.Equal([]byte(out.Extendedattributelist.FEAList), []byte(payload)) {
+			t.Errorf("FEAList mismatch")
+		}
+	})
+}
+
+func TestLegacyEaInfoUnmarshalBounds(t *testing.T) {
+	if _, err := (&informationlevels.SMB_INFO_STANDARD{}).Unmarshal(make([]byte, 11)); err == nil {
+		t.Error("INFO_STANDARD: expected error on 11-byte buffer")
+	}
+	if _, err := (&informationlevels.SMB_INFO_QUERY_EA_SIZE{}).Unmarshal(make([]byte, 25)); err == nil {
+		t.Error("INFO_QUERY_EA_SIZE: expected error on 25-byte buffer")
+	}
+	if _, err := (&informationlevels.SMB_INFO_QUERY_ALL_EAS{}).Unmarshal(make([]byte, 3)); err == nil {
+		t.Error("QUERY_ALL_EAS: expected error on 3-byte buffer")
+	}
+}

--- a/network/smb/smb_v10/types/SMB_FEA_LIST.go
+++ b/network/smb/smb_v10/types/SMB_FEA_LIST.go
@@ -1,10 +1,62 @@
 package types
 
-import "github.com/TheManticoreProject/Manticore/windows/ms_dtyp/common/data_types"
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/windows/ms_dtyp/common/data_types"
+)
 
 // SMB_FEA_LIST
 // Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/1ca1684e-6552-432c-bdd0-f559814bbaef
 type SMB_FEA_LIST struct {
+	// SizeOfListInBytes (4 bytes): The total size of the FEAList field plus the size
+	// of the SizeOfListInBytes field itself (4 bytes).
 	SizeOfListInBytes data_types.ULONG
-	FEAList           []data_types.UCHAR
+	// FEAList (variable): A concatenated list of SMB_FEA structures, held here as raw
+	// bytes.
+	FEAList []data_types.UCHAR
+}
+
+// Marshal serializes the SMB_FEA_LIST into a byte slice.
+//
+// Returns:
+// - A byte slice containing the marshalled SMB_FEA_LIST structure
+// - An error if marshalling fails
+func (s *SMB_FEA_LIST) Marshal() ([]byte, error) {
+	// SizeOfListInBytes counts the 4-byte size field plus the FEAList payload.
+	s.SizeOfListInBytes = data_types.ULONG(4 + len(s.FEAList))
+
+	marshalled := make([]byte, 4)
+	binary.LittleEndian.PutUint32(marshalled, uint32(s.SizeOfListInBytes))
+	marshalled = append(marshalled, s.FEAList...)
+
+	return marshalled, nil
+}
+
+// Unmarshal deserializes a byte slice into the SMB_FEA_LIST structure.
+//
+// Parameters:
+// - data: The byte slice to unmarshal
+//
+// Returns:
+// - The number of bytes consumed
+// - An error if unmarshalling fails or the data format is invalid
+func (s *SMB_FEA_LIST) Unmarshal(data []byte) (int, error) {
+	if len(data) < 4 {
+		return 0, fmt.Errorf("data too short for SMB_FEA_LIST SizeOfListInBytes")
+	}
+	s.SizeOfListInBytes = data_types.ULONG(binary.LittleEndian.Uint32(data[0:4]))
+
+	// SizeOfListInBytes includes the 4-byte size field itself.
+	if s.SizeOfListInBytes < 4 {
+		return 0, fmt.Errorf("SMB_FEA_LIST SizeOfListInBytes (%d) is smaller than the 4-byte header", s.SizeOfListInBytes)
+	}
+	payloadLen := int(s.SizeOfListInBytes) - 4
+	if len(data) < 4+payloadLen {
+		return 0, fmt.Errorf("data too short for SMB_FEA_LIST payload (need %d bytes, have %d)", payloadLen, len(data)-4)
+	}
+	s.FEAList = append([]data_types.UCHAR{}, data[4:4+payloadLen]...)
+
+	return 4 + payloadLen, nil
 }


### PR DESCRIPTION
### Linked Issue
`Closes #378`

Final batch by information-level family (legacy SMB_INFO_* + EA + the IS_NAME_VALID placeholder). This completes the package; it should be merged after the other batch PRs (#451 SET_FILE, #452 QUERY_FILE, #453 FIND_FILE, #454 FS info).

### Root Cause
The `informationlevels` structures had empty `Marshal`/`Unmarshal`. Additionally `SMB_INFO_STANDARD` and `SMB_INFO_QUERY_EA_SIZE` declared their date/time fields as `types.SMB_TIME`, which is aliased to the 8-byte `FILETIME` — but MS-CIFS legacy info levels use the 2-byte DOS `SMB_TIME`. `SMB_INFO_IS_NAME_VALID` and the three EA structures were undefined/non-functional, and the underlying `types.SMB_FEA_LIST` had no (de)serialization.

### Fix Description
Cross-checked against the MS-CIFS pages for each structure:
- **SMB_INFO_STANDARD** (12 bytes) and **SMB_INFO_QUERY_EA_SIZE** (26 bytes): changed the six date/time fields from `SMB_TIME` (8-byte FILETIME) to the spec's 2-byte `SMB_TIME_DOS`, and implemented `Marshal`/`Unmarshal` (the latter also carries `FileDataSize`, `AllocationSize`, the 2-byte `SMB_FILE_ATTRIBUTES`, and `EaSize`).
- **SMB_INFO_IS_NAME_VALID**: per the spec this level returns no parameters or data (success is conveyed via the SMB Header Status), so it has no fields and (de)serializes to an empty slice.
- **types.SMB_FEA_LIST**: implemented `Marshal`/`Unmarshal`, where `SizeOfListInBytes` is the payload length plus the 4-byte size field itself (bounds-checked).
- **SMB_INFO_QUERY_ALL_EAS / SMB_INFO_QUERY_EAS_FROM_LIST / SMB_INFO_SET_EAS**: each is a single `SMB_FEA_LIST`, so they delegate to it.

### How Verified
- **Tests:** `go build ./...` and `go test ./network/smb/smb_v10/...` pass. New round-trip tests assert `SMB_INFO_STANDARD` is 12 bytes and `SMB_INFO_QUERY_EA_SIZE` is 26 bytes (proving the 2-byte time fields), that `SMB_INFO_IS_NAME_VALID` is empty, that the three EA levels round-trip and that `SizeOfListInBytes` includes the 4-byte header, plus bounds tests for truncated buffers.
- **Static:** the 2-byte `SMB_DATE`/`SMB_TIME_DOS` sizing and the `SMB_FEA_LIST` size semantics were taken from the MS-CIFS pages fetched for each structure.

### Test Coverage
- **Added:** `TestInfoStandardRoundTrip`, `TestInfoQueryEaSizeRoundTrip`, `TestInfoIsNameValidIsEmpty`, `TestInfoEaListRoundTrip` (3 subtests), `TestLegacyEaInfoUnmarshalBounds` in `network/smb/smb_v10/informationlevels/legacy_ea_info_test.go`.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/types/SMB_FEA_LIST.go`; the six legacy/EA files under `network/smb/smb_v10/informationlevels/`; `legacy_ea_info_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** the only change outside `informationlevels/` is adding `Marshal`/`Unmarshal` to the previously method-less `types.SMB_FEA_LIST`, required for the EA information levels to function.

### Risk and Rollout
Low. These methods were no-ops before and nothing consumes them yet. The `SMB_TIME` → `SMB_TIME_DOS` field-type change corrects the wire size of two legacy info levels (8→2 bytes per field). With this batch, all 28 information-level structures have spec-correct (de)serialization.
