### PR TITLE
Implement SMB message signing and populate Server.SigningState (#439)

### DIFF
--- a/crypto/spnego/authcontext.go
+++ b/crypto/spnego/authcontext.go
@@ -24,6 +24,21 @@ type AuthContext struct {
 
 	// NTLM specific fields
 	NTLMChallenge *challenge.ChallengeMessage
+
+	// SessionKey is the session key derived during the most recent successful
+	// CreateAuthenticateTokenFromChallengeToken call. It is not transmitted on the
+	// wire; callers use it as the MAC key for SMB message signing. It is nil until
+	// authentication has produced a key (and for auth paths that do not derive one).
+	SessionKey []byte
+}
+
+// GetSessionKey returns the session key derived during authentication, or nil if
+// none has been derived yet.
+//
+// Returns:
+//   - []byte: The session key (MAC key for SMB signing), or nil
+func (ctx *AuthContext) GetSessionKey() []byte {
+	return ctx.SessionKey
 }
 
 // NewAuthContext creates a new authentication context

--- a/crypto/spnego/challenge.go
+++ b/crypto/spnego/challenge.go
@@ -69,6 +69,9 @@ func (ctx *AuthContext) processChallengeInnerTokenNTLM(innerToken []byte) ([]byt
 		return nil, fmt.Errorf("failed to create NTLM AUTHENTICATE message: %v", err)
 	}
 
+	// Retain the derived session key so callers can use it as the SMB signing MAC key.
+	ctx.SessionKey = ntlmAuth.SessionKey
+
 	ntlmAuthBytes, err := ntlmAuth.Marshal()
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal NTLM AUTHENTICATE message: %v", err)

--- a/crypto/spnego/ntlm/message/authenticate/authenticate.go
+++ b/crypto/spnego/ntlm/message/authenticate/authenticate.go
@@ -70,6 +70,12 @@ type AuthenticateMessage struct {
 
 	// EncryptedRandomSessionKey (variable): A field containing EncryptedRandomSessionKey data.
 	EncryptedRandomSessionKey []byte
+
+	// SessionKey (16 bytes): The exported session key derived during authentication.
+	// This is not transmitted on the wire; it is retained so callers (e.g. SMB message
+	// signing) can use it as the MAC key. When no key exchange is negotiated it equals
+	// the NTLMv2 SessionBaseKey. It is nil for the NTLMv1 path.
+	SessionKey []byte
 }
 
 // CreateAuthenticateMessage creates an NTLM AUTHENTICATE message
@@ -121,11 +127,17 @@ func CreateAuthenticateMessage(challenge *challenge.ChallengeMessage, username, 
 			binary.LittleEndian.PutUint64(timestamp, windowsFiletime)
 		}
 
-		msg.NtChallengeResponse, _, err = ctx.ComputeNTChallengeResponse(timestamp, blobTargetInfo)
+		var ntProofStr []byte
+		msg.NtChallengeResponse, ntProofStr, err = ctx.ComputeNTChallengeResponse(timestamp, blobTargetInfo)
 		if err != nil {
 			return nil, err
 		}
 		msg.LmChallengeResponse = ctx.ComputeLMChallengeResponse(hasTimestamp)
+
+		// Derive the session key (SessionBaseKey). No key exchange is negotiated here,
+		// so the exported session key equals the SessionBaseKey; SMB signing uses it as
+		// the MAC key.
+		msg.SessionKey = ctx.ComputeSessionBaseKey(ntProofStr)
 	} else {
 		// Use NTLMv1
 		ntlmv1Ctx, err := ntlmv1.NewNTLMv1CtxWithPassword(domain, username, password, challenge.ServerChallenge)

--- a/network/smb/smb_v10/client/file.go
+++ b/network/smb/smb_v10/client/file.go
@@ -98,6 +98,10 @@ func (c *Client) sendReceive(msg *message.Message, label string) (*message.Messa
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to marshal %s: %v", label, err)
 	}
+
+	// Sign the request in place when message signing is active for this connection.
+	responseSeq, _ := c.signOutgoing(marshalled)
+
 	fileIODump(label+" request", marshalled)
 
 	if _, err = c.Transport.Send(marshalled); err != nil {
@@ -109,6 +113,10 @@ func (c *Client) sendReceive(msg *message.Message, label string) (*message.Messa
 		return nil, nil, fmt.Errorf("failed to receive %s response: %v", label, err)
 	}
 	fileIODump(label+" response", raw)
+
+	if err = c.verifyIncoming(raw, responseSeq); err != nil {
+		return nil, nil, fmt.Errorf("%s: %v", label, err)
+	}
 
 	response := message.NewMessage()
 	if err = response.Unmarshal(raw); err != nil {

--- a/network/smb/smb_v10/client/negotiate.go
+++ b/network/smb/smb_v10/client/negotiate.go
@@ -95,5 +95,16 @@ func (c *Client) Negotiate() error {
 	c.Connection.Server.SecurityMode = negotiateResponse.SecurityMode
 	c.Connection.Server.ServerGUID = negotiateResponse.ServerGUID
 
+	// Record the server's message-signing policy so session setup can decide whether
+	// to activate signing.
+	switch {
+	case negotiateResponse.SecurityMode.IsSecuritySignatureRequired():
+		c.Connection.Server.SigningState = SigningStateRequired
+	case negotiateResponse.SecurityMode.IsSecuritySignatureEnabled():
+		c.Connection.Server.SigningState = SigningStateEnabled
+	default:
+		c.Connection.Server.SigningState = SigningStateDisabled
+	}
+
 	return nil
 }

--- a/network/smb/smb_v10/client/session.go
+++ b/network/smb/smb_v10/client/session.go
@@ -64,7 +64,8 @@ func (s *Session) SessionSetup() error {
 	}
 
 	// Set message signing flags based on server security mode
-	if s.Client.Connection.Server.SecurityMode.IsSecuritySignatureEnabled() {
+	if s.Client.Connection.Server.SecurityMode.IsSecuritySignatureEnabled() ||
+		s.Client.Connection.Server.SecurityMode.IsSecuritySignatureRequired() {
 		requestStep1Msg.Header.Flags2 |= flags2.Flags2(flags2.FLAGS2_SECURITY_SIGNATURE)
 	}
 
@@ -269,9 +270,25 @@ func (s *Session) SessionSetup() error {
 
 	requestStep2Msg.AddCommand(sessionSetupStep2Cmd)
 
+	// Determine whether to activate SMB message signing. Signing is activated only
+	// when the server requires it; the MAC key is the session key derived from the
+	// NTLM exchange above. The AUTHENTICATE request is the first signed message
+	// (sequence number 0) and bootstraps signing for the connection.
+	signingKey := authCtx.GetSessionKey()
+	signingRequired := s.Client.Connection.Server.SigningState == SigningStateRequired
+	if signingRequired && len(signingKey) == 0 {
+		return fmt.Errorf("server requires SMB signing but no session key was derived (signing requires the NTLMv2/extended-security path)")
+	}
+
 	marshalledStep2, err := requestStep2Msg.Marshal()
 	if err != nil {
 		return fmt.Errorf("failed to marshal step 2 message: %v", err)
+	}
+
+	if signingRequired {
+		s.Client.Connection.SigningSessionKey = signingKey
+		s.Client.Connection.IsSigningActive = true
+		signSMBMessage(signingKey, marshalledStep2, 0)
 	}
 
 	// Send the message
@@ -308,6 +325,19 @@ func (s *Session) SessionSetup() error {
 		} else {
 			return fmt.Errorf("session setup failed: 0x%08x", authResponseMsg.Header.Status)
 		}
+	}
+
+	// Persist the derived session key and, when signing was activated, verify the
+	// signature on the (successful) AUTHENTICATE response (sequence number 1) before
+	// arming the per-message sequence counter for subsequent requests.
+	s.SessionKey = signingKey
+	if s.Client.Connection.IsSigningActive {
+		if !verifySMBSignature(signingKey, rawAuthResponse, 1) {
+			return fmt.Errorf("session setup response failed SMB signature verification")
+		}
+		// The AUTHENTICATE request used sequence 0 and its response sequence 1, so the
+		// next outbound request uses sequence 2.
+		s.Client.Connection.ClientNextSendSequenceNumber = 2
 	}
 
 	return nil

--- a/network/smb/smb_v10/client/signing.go
+++ b/network/smb/smb_v10/client/signing.go
@@ -1,0 +1,104 @@
+package client
+
+import (
+	"crypto/hmac"
+	"crypto/md5"
+	"encoding/binary"
+	"fmt"
+)
+
+// Server signing policy states, recorded in Server.SigningState after negotiation.
+const (
+	SigningStateDisabled = "disabled"
+	SigningStateEnabled  = "enabled"
+	SigningStateRequired = "required"
+)
+
+// securitySignatureOffset is the byte offset, from the start of the SMB header, of
+// the 8-byte SecurityFeatures field that carries the message signature:
+// Protocol(4) + Command(1) + Status(4) + Flags(1) + Flags2(2) + PIDHigh(2) = 14.
+const securitySignatureOffset = 14
+
+// securitySignatureSize is the size, in bytes, of the SecuritySignature field.
+const securitySignatureSize = 8
+
+// computeSMBSignature computes the 8-byte SMB v1 message signature for a fully
+// marshalled SMB message, per [MS-CIFS] 3.1.5.1. The signature is the first 8 bytes
+// of MD5(MACKey || SMBMessage), where the message's SecuritySignature field has
+// first been set to the 32-bit sequence number (little-endian) followed by four
+// zero bytes. The input slice is not modified.
+func computeSMBSignature(macKey, message []byte, sequenceNumber uint32) [securitySignatureSize]byte {
+	// Work on a copy so the caller's buffer is untouched while we substitute the
+	// sequence number into the signature field for the digest computation.
+	buf := make([]byte, len(message))
+	copy(buf, message)
+
+	if len(buf) >= securitySignatureOffset+securitySignatureSize {
+		binary.LittleEndian.PutUint32(buf[securitySignatureOffset:securitySignatureOffset+4], sequenceNumber)
+		for i := securitySignatureOffset + 4; i < securitySignatureOffset+securitySignatureSize; i++ {
+			buf[i] = 0x00
+		}
+	}
+
+	h := md5.New()
+	h.Write(macKey)
+	h.Write(buf)
+	digest := h.Sum(nil)
+
+	var signature [securitySignatureSize]byte
+	copy(signature[:], digest[:securitySignatureSize])
+	return signature
+}
+
+// signSMBMessage computes the SMB v1 signature for the marshalled message and
+// writes it into the message's SecuritySignature field in place.
+func signSMBMessage(macKey, message []byte, sequenceNumber uint32) {
+	if len(message) < securitySignatureOffset+securitySignatureSize {
+		return
+	}
+	signature := computeSMBSignature(macKey, message, sequenceNumber)
+	copy(message[securitySignatureOffset:securitySignatureOffset+securitySignatureSize], signature[:])
+}
+
+// verifySMBSignature reports whether the marshalled message carries a valid SMB v1
+// signature for the given MAC key and expected sequence number. The comparison is
+// constant-time.
+func verifySMBSignature(macKey, message []byte, sequenceNumber uint32) bool {
+	if len(message) < securitySignatureOffset+securitySignatureSize {
+		return false
+	}
+	received := make([]byte, securitySignatureSize)
+	copy(received, message[securitySignatureOffset:securitySignatureOffset+securitySignatureSize])
+
+	expected := computeSMBSignature(macKey, message, sequenceNumber)
+	return hmac.Equal(received, expected[:])
+}
+
+// signOutgoing signs a marshalled request in place when signing is active for the
+// connection, consuming the next send sequence number. It returns the sequence
+// number expected on the matching response and whether the message was signed. When
+// signing is inactive it leaves the message untouched and returns (0, false).
+func (c *Client) signOutgoing(marshalled []byte) (uint32, bool) {
+	if c.Connection == nil || !c.Connection.IsSigningActive {
+		return 0, false
+	}
+	sequenceNumber := c.Connection.ClientNextSendSequenceNumber
+	signSMBMessage(c.Connection.SigningSessionKey, marshalled, sequenceNumber)
+	// The response carries the next sequence number; advance past both the request
+	// and its response for the following exchange.
+	c.Connection.ClientNextSendSequenceNumber += 2
+	return sequenceNumber + 1, true
+}
+
+// verifyIncoming validates the signature of a received response against the given
+// expected sequence number when signing is active. It is a no-op when signing is
+// inactive.
+func (c *Client) verifyIncoming(raw []byte, responseSequenceNumber uint32) error {
+	if c.Connection == nil || !c.Connection.IsSigningActive {
+		return nil
+	}
+	if !verifySMBSignature(c.Connection.SigningSessionKey, raw, responseSequenceNumber) {
+		return fmt.Errorf("invalid SMB message signature on response (expected sequence %d)", responseSequenceNumber)
+	}
+	return nil
+}

--- a/network/smb/smb_v10/client/signing_test.go
+++ b/network/smb/smb_v10/client/signing_test.go
@@ -1,0 +1,183 @@
+package client
+
+import (
+	"bytes"
+	"crypto/md5"
+	"encoding/binary"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/securityfeatures"
+)
+
+// TestSecuritySignatureOffsetMatchesHeader guards the securitySignatureOffset
+// constant against drift in the SMB header layout: a marshalled header MUST carry
+// its 8-byte SecurityFeatures field exactly at securitySignatureOffset.
+func TestSecuritySignatureOffsetMatchesHeader(t *testing.T) {
+	h := header.NewHeader()
+	sig := securityfeatures.NewSecurityFeaturesSecuritySignature()
+	sig.SetSecuritySignature([8]byte{0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA})
+	h.SecurityFeatures = sig
+
+	raw, err := h.Marshal()
+	if err != nil {
+		t.Fatalf("header Marshal failed: %v", err)
+	}
+	if len(raw) != header.SMB_HEADER_SIZE {
+		t.Fatalf("header is %d bytes, want %d", len(raw), header.SMB_HEADER_SIZE)
+	}
+	want := bytes.Repeat([]byte{0xAA}, securitySignatureSize)
+	if !bytes.Equal(raw[securitySignatureOffset:securitySignatureOffset+securitySignatureSize], want) {
+		t.Errorf("SecurityFeatures not at offset %d: bytes there = % x", securitySignatureOffset, raw[securitySignatureOffset:securitySignatureOffset+securitySignatureSize])
+	}
+}
+
+// makeMessage returns a deterministic pseudo-message of the given length whose
+// SecurityFeatures field (bytes 14..22) starts zeroed, as a freshly marshalled SMB
+// message would.
+func makeMessage(n int) []byte {
+	msg := make([]byte, n)
+	for i := range msg {
+		msg[i] = byte(i)
+	}
+	for i := securitySignatureOffset; i < securitySignatureOffset+securitySignatureSize && i < n; i++ {
+		msg[i] = 0
+	}
+	return msg
+}
+
+// TestComputeSMBSignatureMatchesFormula pins the signature algorithm: the 8-byte
+// signature MUST equal the first 8 bytes of MD5(MACKey || message), with the
+// message's signature field set to the little-endian sequence number followed by
+// four zero bytes. The independent computation here guards the field offset, the
+// sequence-number placement, the endianness, and the digest input order.
+func TestComputeSMBSignatureMatchesFormula(t *testing.T) {
+	key := []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
+	msg := makeMessage(64)
+	const seq = uint32(0x04030201)
+
+	// Independent reference computation.
+	ref := make([]byte, len(msg))
+	copy(ref, msg)
+	binary.LittleEndian.PutUint32(ref[securitySignatureOffset:securitySignatureOffset+4], seq)
+	for i := securitySignatureOffset + 4; i < securitySignatureOffset+8; i++ {
+		ref[i] = 0
+	}
+	sum := md5.Sum(append(append([]byte{}, key...), ref...))
+	var want [8]byte
+	copy(want[:], sum[:8])
+
+	got := computeSMBSignature(key, msg, seq)
+	if got != want {
+		t.Errorf("signature = % x, want % x", got, want)
+	}
+
+	// The input message must not have been modified.
+	if msg[securitySignatureOffset] != 0 {
+		t.Error("computeSMBSignature modified the caller's buffer")
+	}
+}
+
+// TestSignAndVerifyRoundTrip verifies a signed message validates with the same key
+// and sequence number, and that the signature is written at the right offset.
+func TestSignAndVerifyRoundTrip(t *testing.T) {
+	key := bytes.Repeat([]byte{0xAB}, 16)
+	msg := makeMessage(48)
+	const seq = uint32(7)
+
+	signSMBMessage(key, msg, seq)
+
+	if !verifySMBSignature(key, msg, seq) {
+		t.Fatal("verifySMBSignature failed on a freshly signed message")
+	}
+	// The signature must have been written into the SecurityFeatures field.
+	if bytes.Equal(msg[securitySignatureOffset:securitySignatureOffset+8], make([]byte, 8)) {
+		t.Error("signature field is still zero after signing")
+	}
+}
+
+// TestVerifyRejectsTamperingAndWrongSequence verifies that signature validation
+// fails on a modified body or a mismatched sequence number.
+func TestVerifyRejectsTamperingAndWrongSequence(t *testing.T) {
+	key := bytes.Repeat([]byte{0x5A}, 16)
+	const seq = uint32(2)
+
+	msg := makeMessage(48)
+	signSMBMessage(key, msg, seq)
+
+	// Wrong sequence number.
+	if verifySMBSignature(key, msg, seq+1) {
+		t.Error("verification passed with the wrong sequence number")
+	}
+
+	// Tampered payload (a byte outside the signature field).
+	tampered := append([]byte{}, msg...)
+	tampered[40] ^= 0xFF
+	if verifySMBSignature(key, tampered, seq) {
+		t.Error("verification passed on a tampered message")
+	}
+
+	// Wrong key.
+	if verifySMBSignature(bytes.Repeat([]byte{0x00}, 16), msg, seq) {
+		t.Error("verification passed with the wrong key")
+	}
+}
+
+// TestSignOutgoingInactiveIsNoOp verifies that when signing is inactive the message
+// is left untouched and no sequence number is consumed.
+func TestSignOutgoingInactiveIsNoOp(t *testing.T) {
+	c := &Client{Connection: &Connection{IsSigningActive: false}}
+	msg := makeMessage(48)
+	orig := append([]byte{}, msg...)
+
+	respSeq, signed := c.signOutgoing(msg)
+	if signed || respSeq != 0 {
+		t.Errorf("expected (0, false) when inactive, got (%d, %v)", respSeq, signed)
+	}
+	if !bytes.Equal(msg, orig) {
+		t.Error("message was modified while signing was inactive")
+	}
+	if err := c.verifyIncoming(msg, 0); err != nil {
+		t.Errorf("verifyIncoming should be a no-op when inactive, got %v", err)
+	}
+}
+
+// TestSignOutgoingActiveAdvancesSequence verifies that active signing signs the
+// message, returns the response sequence number, and advances the send counter by
+// two, and that the produced signature validates at the consumed sequence number.
+func TestSignOutgoingActiveAdvancesSequence(t *testing.T) {
+	key := bytes.Repeat([]byte{0xC3}, 16)
+	c := &Client{Connection: &Connection{
+		IsSigningActive:              true,
+		SigningSessionKey:            key,
+		ClientNextSendSequenceNumber: 2,
+	}}
+
+	msg := makeMessage(48)
+	respSeq, signed := c.signOutgoing(msg)
+	if !signed {
+		t.Fatal("expected the message to be signed when active")
+	}
+	if respSeq != 3 {
+		t.Errorf("expected response sequence 3, got %d", respSeq)
+	}
+	if c.Connection.ClientNextSendSequenceNumber != 4 {
+		t.Errorf("expected next send sequence 4, got %d", c.Connection.ClientNextSendSequenceNumber)
+	}
+	// The request was signed with sequence 2.
+	if !verifySMBSignature(key, msg, 2) {
+		t.Error("signed message does not validate at the consumed sequence number")
+	}
+
+	// verifyIncoming should accept a response signed at the returned sequence number.
+	resp := makeMessage(48)
+	signSMBMessage(key, resp, respSeq)
+	if err := c.verifyIncoming(resp, respSeq); err != nil {
+		t.Errorf("verifyIncoming rejected a valid response: %v", err)
+	}
+	// And reject a response with a bad signature.
+	resp[30] ^= 0xFF
+	if err := c.verifyIncoming(resp, respSeq); err == nil {
+		t.Error("verifyIncoming accepted a tampered response")
+	}
+}

--- a/network/smb/smb_v10/client/tree.go
+++ b/network/smb/smb_v10/client/tree.go
@@ -52,6 +52,9 @@ func (c *Client) TreeConnect(shareName string) error {
 		return fmt.Errorf("failed to marshal tree connect message: %v", err)
 	}
 
+	// Sign the request in place when message signing is active for this connection.
+	responseSeq, _ := c.signOutgoing(marshalledMessage)
+
 	_, err = c.Transport.Send(marshalledMessage)
 	if err != nil {
 		return fmt.Errorf("failed to send tree connect message: %v", err)
@@ -60,6 +63,10 @@ func (c *Client) TreeConnect(shareName string) error {
 	rawResponseMessage, err := c.Transport.Receive()
 	if err != nil {
 		return fmt.Errorf("failed to receive tree connect message: %v", err)
+	}
+
+	if err = c.verifyIncoming(rawResponseMessage, responseSeq); err != nil {
+		return fmt.Errorf("tree connect: %v", err)
 	}
 
 	responseMsg := message.NewMessage()


### PR DESCRIPTION
### Linked Issue
`Closes #439`

### Root Cause
The client never recorded the server's signing policy (`Negotiate` set `SecurityMode` but not `Server.SigningState`) and had no code to compute or verify SMB message signatures: the signing-related fields on `Connection`/`Server` were declared but never read or written, and the NTLM session key needed as the MAC key was not exposed by the SPNEGO layer. As a result the client always sent unsigned messages and could not complete a session against a server configured with `RequireSecuritySignature`.

### Fix Description
- **Negotiate** records the server policy in `Server.SigningState` as `disabled` / `enabled` / `required` from the negotiated `SecurityMode`.
- **SPNEGO/NTLM** now surfaces the derived session key: `AuthenticateMessage` retains the NTLMv2 `SessionBaseKey` (computed from the NTProofStr; with no key exchange negotiated this equals the exported session key), `processChallengeInnerTokenNTLM` stores it on the `AuthContext`, and `AuthContext.GetSessionKey()` returns it. This is additive and does not change any wire output.
- **Signing module** (`client/signing.go`): `computeSMBSignature` returns the first 8 bytes of `MD5(MACKey || message)` after writing the little-endian sequence number into the message's 8-byte SecurityFeatures field (offset 14), per [MS-CIFS] 3.1.5.1; plus in-place `signSMBMessage`, constant-time `verifySMBSignature`, and `signOutgoing`/`verifyIncoming` helpers that manage the per-connection send sequence number.
- **SessionSetup** activates signing only when `SigningState == required`: it uses the NTLM session key as the MAC key, signs the AUTHENTICATE request with sequence 0, verifies the response with sequence 1, and sets `ClientNextSendSequenceNumber = 2`. If a server requires signing but no session key was derived (NTLMv1/no-extended-security path), it returns a clear error.
- **All post-auth send sites** — `sendReceive` (file I/O, trans2, lifecycle, find) and `TreeConnect` — sign outgoing requests and verify the signature on responses when signing is active.

### How Verified
- **Tests:** `go build ./...`, `go test ./network/smb/smb_v10/...` and `go test ./crypto/...` pass. New `client/signing_test.go`:
  - `TestComputeSMBSignatureMatchesFormula` pins the algorithm by an independent `MD5(key || message-with-seq)` computation (guards field offset, LE sequence placement, digest input order, first-8-bytes).
  - `TestSecuritySignatureOffsetMatchesHeader` marshals a real header and asserts the SecurityFeatures field is at offset 14 (guards against header-layout drift).
  - round-trip, tamper-rejection, wrong-key/wrong-sequence rejection, inactive-is-no-op, and active-advances-sequence-by-two tests.
- **Static:** when `IsSigningActive` is false (optional/disabled servers, and all existing tests), `signOutgoing`/`verifyIncoming` are no-ops, so the marshalled bytes and control flow are identical to before.

### Test Coverage
- **Added:** `network/smb/smb_v10/client/signing_test.go` (7 tests).

### Scope of Change
- **Files changed:** `crypto/spnego/ntlm/message/authenticate/authenticate.go`, `crypto/spnego/authcontext.go`, `crypto/spnego/challenge.go`, `network/smb/smb_v10/client/{signing.go,signing_test.go,negotiate.go,session.go,file.go,tree.go}`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** the only change outside the SMB client is exposing the already-computed NTLM session key on the SPNEGO `AuthContext` (additive; no wire change), required to obtain the MAC key.

### Risk and Rollout
Signing is gated on `SigningState == required`, so against signing-optional servers (the previously working path, including the XP live-test target) `IsSigningActive` stays false and behavior is byte-for-byte unchanged. The new signing-required path is covered by unit tests for the MAC algorithm and sequence handling; it should be validated against a live signing-required server before relying on it in production, since the unit tests assert self-consistency and the documented formula rather than a captured wire vector.

### Notes
NTLMv1 (no extended session security) does not derive a session key here, so a server that both requires signing and forces NTLMv1 returns a clear "signing requires the NTLMv2/extended-security path" error rather than sending unsigned traffic.
