### PR TITLE
Add Flush and Echo client operations (#384)

### DIFF
--- a/network/smb/smb_v10/client/flush_echo.go
+++ b/network/smb/smb_v10/client/flush_echo.go
@@ -1,0 +1,73 @@
+package client
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/codes"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+)
+
+// Flush requests that the server flush all buffered data for the open file
+// referenced by fid to stable storage. Passing FID 0xFFFF flushes every file the
+// client has open on the connection.
+//
+// Wire: SMB_COM_FLUSH request / response.
+func (c *Client) Flush(fid FID) error {
+	if c.Session == nil {
+		return fmt.Errorf("no session established")
+	}
+
+	msg := c.newFileIOMessage(codes.SMB_COM_FLUSH)
+
+	cmd := commands.NewFlushRequest()
+	cmd.FID = types.USHORT(fid)
+
+	msg.AddCommand(cmd)
+
+	response, _, err := c.sendReceive(msg, "Flush")
+	if err != nil {
+		return err
+	}
+
+	if response.Header.Status != 0x00000000 {
+		return fmt.Errorf("Flush failed: 0x%08x", response.Header.Status)
+	}
+
+	return nil
+}
+
+// Echo sends an SMB_COM_ECHO request carrying data and returns the data echoed
+// back by the server. It is a round-trip/keepalive check on the connection.
+//
+// Wire: SMB_COM_ECHO request / response (EchoCount 1).
+func (c *Client) Echo(data []byte) ([]byte, error) {
+	if c.Session == nil {
+		return nil, fmt.Errorf("no session established")
+	}
+
+	msg := c.newFileIOMessage(codes.SMB_COM_ECHO)
+
+	cmd := commands.NewEchoRequest()
+	// Request a single echo response carrying our data back.
+	cmd.EchoCount = types.USHORT(1)
+	cmd.Data = []types.UCHAR(data)
+
+	msg.AddCommand(cmd)
+
+	response, _, err := c.sendReceive(msg, "Echo")
+	if err != nil {
+		return nil, err
+	}
+
+	if response.Header.Status != 0x00000000 {
+		return nil, fmt.Errorf("Echo failed: 0x%08x", response.Header.Status)
+	}
+
+	echoResponse, ok := response.Command.(*commands.EchoResponse)
+	if !ok {
+		return nil, fmt.Errorf("unexpected response command: 0x%02x", response.Header.Command)
+	}
+
+	return []byte(echoResponse.Data), nil
+}

--- a/network/smb/smb_v10/client/flush_echo_test.go
+++ b/network/smb/smb_v10/client/flush_echo_test.go
@@ -1,0 +1,83 @@
+package client_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/client"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/command_interface"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header/flags"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+)
+
+// replyBytes builds a marshalled reply message carrying cmd with the given status.
+func replyBytes(t *testing.T, status uint32, cmd command_interface.CommandInterface) []byte {
+	t.Helper()
+	msg := message.NewMessage()
+	msg.Header.SetFlags(flags.FLAGS_REPLY)
+	msg.Header.Status = status
+	msg.AddCommand(cmd)
+	raw, err := msg.Marshal()
+	if err != nil {
+		t.Fatalf("failed to marshal reply: %v", err)
+	}
+	return raw
+}
+
+// sessionedClient returns a client with a session and a scripted transport that
+// replies with response.
+func sessionedClient(response []byte) *client.Client {
+	tr := &scriptedTransport{response: response}
+	return &client.Client{
+		Transport:  tr,
+		Connection: &client.Connection{Server: &client.Server{}},
+		Session:    &client.Session{},
+	}
+}
+
+func TestFlushSuccess(t *testing.T) {
+	c := sessionedClient(replyBytes(t, 0x00000000, commands.NewFlushResponse()))
+	if err := c.Flush(0xFFFF); err != nil {
+		t.Fatalf("Flush returned error: %v", err)
+	}
+}
+
+func TestFlushErrorStatus(t *testing.T) {
+	c := sessionedClient(replyBytes(t, 0xC0000008, commands.NewFlushResponse())) // STATUS_INVALID_HANDLE
+	if err := c.Flush(1); err == nil {
+		t.Fatal("expected an error on non-zero status, got nil")
+	}
+}
+
+func TestFlushWithoutSession(t *testing.T) {
+	c := &client.Client{Connection: &client.Connection{Server: &client.Server{}}}
+	if err := c.Flush(1); err == nil {
+		t.Fatal("expected an error when Flush is called without a session, got nil")
+	}
+}
+
+func TestEchoRoundTrip(t *testing.T) {
+	payload := []byte("keepalive-123")
+	resp := commands.NewEchoResponse()
+	resp.SequenceNumber = 1
+	resp.Data = []types.UCHAR(payload)
+
+	c := sessionedClient(replyBytes(t, 0x00000000, resp))
+
+	got, err := c.Echo(payload)
+	if err != nil {
+		t.Fatalf("Echo returned error: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Errorf("Echo returned %q, want %q", got, payload)
+	}
+}
+
+func TestEchoWithoutSession(t *testing.T) {
+	c := &client.Client{Connection: &client.Connection{Server: &client.Server{}}}
+	if _, err := c.Echo([]byte("x")); err == nil {
+		t.Fatal("expected an error when Echo is called without a session, got nil")
+	}
+}


### PR DESCRIPTION
### Linked Issue
Part of #384 (does not close it — first batch by operation family; Flush/Echo).

### Root Cause
`#384` tracks high-level client operations whose request/response command types already exist under `message/commands/` but have no client method. This batch adds Flush and Echo.

### Fix Description
- **`Flush(fid FID) error`** — sends `SMB_COM_FLUSH` for the given FID (0xFFFF flushes all of the client's open files), checks the response status. Wire types `FlushRequest`/`FlushResponse`.
- **`Echo(data []byte) ([]byte, error)`** — sends `SMB_COM_ECHO` with `EchoCount = 1` and returns the bytes echoed back by the server; a connection round-trip/keepalive. Wire types `EchoRequest`/`EchoResponse`.

Both reuse the existing `sendReceive` helper (so message signing, when active, applies automatically) and require an established session.

### How Verified
- **Tests:** `go test ./network/smb/smb_v10/...` passes. New tests drive each method through a scripted transport that returns a crafted reply: `TestFlushSuccess`, `TestFlushErrorStatus` (non-zero status → error), `TestFlushWithoutSession`, `TestEchoRoundTrip` (asserts the echoed payload is returned), `TestEchoWithoutSession`.

### Test Coverage
- **Added:** `TestFlushSuccess`, `TestFlushErrorStatus`, `TestFlushWithoutSession`, `TestEchoRoundTrip`, `TestEchoWithoutSession` in `network/smb/smb_v10/client/flush_echo_test.go`.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/client/flush_echo.go`, `network/smb/smb_v10/client/flush_echo_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Low and additive. Two new methods; no existing code paths change. Remaining #384 batches: TRANS2 query/set file & FS information, locking, and Seek/NtRename.
