### PR TITLE
Add TRANS2 query/set file and filesystem information operations (#384)

### DIFF
--- a/network/smb/smb_v10/client/queryinfo.go
+++ b/network/smb/smb_v10/client/queryinfo.go
@@ -1,0 +1,219 @@
+package client
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/informationlevels"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/subcommands"
+)
+
+// TRANS2 information level codes (MS-CIFS 2.2.2.3). QUERY file levels are used with
+// QueryPathInformation/QueryFileInformation; SET file levels with
+// SetPathInformation/SetFileInformation; FS levels with QueryFsInformation.
+const (
+	InfoLevelQueryFileBasic       uint16 = 0x0101
+	InfoLevelQueryFileStandard    uint16 = 0x0102
+	InfoLevelQueryFileEA          uint16 = 0x0103
+	InfoLevelQueryFileName        uint16 = 0x0104
+	InfoLevelQueryFileAll         uint16 = 0x0107
+	InfoLevelQueryFileAltName     uint16 = 0x0108
+	InfoLevelQueryFileStream      uint16 = 0x0109
+	InfoLevelQueryFileCompression uint16 = 0x010B
+
+	InfoLevelSetFileBasic       uint16 = 0x0101
+	InfoLevelSetFileDisposition uint16 = 0x0102
+	InfoLevelSetFileAllocation  uint16 = 0x0103
+	InfoLevelSetFileEndOfFile   uint16 = 0x0104
+
+	InfoLevelQueryFsVolume    uint16 = 0x0102
+	InfoLevelQueryFsSize      uint16 = 0x0103
+	InfoLevelQueryFsDevice    uint16 = 0x0104
+	InfoLevelQueryFsAttribute uint16 = 0x0105
+)
+
+// normalizeSMBPath returns path with a single leading backslash, as expected for a
+// share-relative SMB path. An empty path becomes "\".
+func normalizeSMBPath(path string) string {
+	if len(path) == 0 {
+		return "\\"
+	}
+	if path[0] != '\\' {
+		return "\\" + path
+	}
+	return path
+}
+
+// QueryPathInformation issues TRANS2_QUERY_PATH_INFORMATION for a share-relative
+// path at the given information level and returns the raw response data bytes
+// (the information-level structure).
+func (c *Client) QueryPathInformation(path string, infoLevel uint16) ([]byte, error) {
+	if c.Session == nil {
+		return nil, fmt.Errorf("no session established")
+	}
+
+	// Parameters: InformationLevel(2) + Reserved(4) + FileName (OEM, null-terminated).
+	params := []byte{}
+	params = binary.LittleEndian.AppendUint16(params, infoLevel)
+	params = binary.LittleEndian.AppendUint32(params, 0) // Reserved
+	params = append(params, []byte(normalizeSMBPath(path))...)
+	params = append(params, 0x00)
+
+	_, data, err := c.trans2(uint16(subcommands.TRANS2_QUERY_PATH_INFORMATION), params, nil)
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+// QueryFileInformation issues TRANS2_QUERY_FILE_INFORMATION for an open FID at the
+// given information level and returns the raw response data bytes.
+func (c *Client) QueryFileInformation(fid FID, infoLevel uint16) ([]byte, error) {
+	if c.Session == nil {
+		return nil, fmt.Errorf("no session established")
+	}
+
+	// Parameters: FID(2) + InformationLevel(2).
+	params := []byte{}
+	params = binary.LittleEndian.AppendUint16(params, uint16(fid))
+	params = binary.LittleEndian.AppendUint16(params, infoLevel)
+
+	_, data, err := c.trans2(uint16(subcommands.TRANS2_QUERY_FILE_INFORMATION), params, nil)
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+// QueryFsInformation issues TRANS2_QUERY_FS_INFORMATION at the given information
+// level and returns the raw response data bytes.
+func (c *Client) QueryFsInformation(infoLevel uint16) ([]byte, error) {
+	if c.Session == nil {
+		return nil, fmt.Errorf("no session established")
+	}
+
+	// Parameters: InformationLevel(2).
+	params := binary.LittleEndian.AppendUint16([]byte{}, infoLevel)
+
+	_, data, err := c.trans2(uint16(subcommands.TRANS2_QUERY_FS_INFORMATION), params, nil)
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+// SetFileInformation issues TRANS2_SET_FILE_INFORMATION for an open FID at the
+// given information level, sending data as the information-level payload.
+func (c *Client) SetFileInformation(fid FID, infoLevel uint16, data []byte) error {
+	if c.Session == nil {
+		return fmt.Errorf("no session established")
+	}
+
+	// Parameters: FID(2) + InformationLevel(2) + Reserved(2).
+	params := []byte{}
+	params = binary.LittleEndian.AppendUint16(params, uint16(fid))
+	params = binary.LittleEndian.AppendUint16(params, infoLevel)
+	params = binary.LittleEndian.AppendUint16(params, 0) // Reserved
+
+	_, _, err := c.trans2(uint16(subcommands.TRANS2_SET_FILE_INFORMATION), params, data)
+	return err
+}
+
+// SetPathInformation issues TRANS2_SET_PATH_INFORMATION for a share-relative path
+// at the given information level, sending data as the information-level payload.
+func (c *Client) SetPathInformation(path string, infoLevel uint16, data []byte) error {
+	if c.Session == nil {
+		return fmt.Errorf("no session established")
+	}
+
+	// Parameters: InformationLevel(2) + Reserved(4) + FileName (OEM, null-terminated).
+	params := []byte{}
+	params = binary.LittleEndian.AppendUint16(params, infoLevel)
+	params = binary.LittleEndian.AppendUint32(params, 0) // Reserved
+	params = append(params, []byte(normalizeSMBPath(path))...)
+	params = append(params, 0x00)
+
+	_, _, err := c.trans2(uint16(subcommands.TRANS2_SET_PATH_INFORMATION), params, data)
+	return err
+}
+
+// --- Typed convenience wrappers -------------------------------------------------
+
+// GetFileBasicInfo queries the 64-bit timestamps and extended attributes of a
+// share-relative path.
+func (c *Client) GetFileBasicInfo(path string) (*informationlevels.SMB_QUERY_FILE_BASIC_INFO, error) {
+	data, err := c.QueryPathInformation(path, InfoLevelQueryFileBasic)
+	if err != nil {
+		return nil, err
+	}
+	info := &informationlevels.SMB_QUERY_FILE_BASIC_INFO{}
+	if _, err := info.Unmarshal(data); err != nil {
+		return nil, fmt.Errorf("failed to decode SMB_QUERY_FILE_BASIC_INFO: %v", err)
+	}
+	return info, nil
+}
+
+// GetFileStandardInfo queries the size, link count, delete-pending and directory
+// flags of a share-relative path.
+func (c *Client) GetFileStandardInfo(path string) (*informationlevels.SMB_QUERY_FILE_STANDARD_INFO, error) {
+	data, err := c.QueryPathInformation(path, InfoLevelQueryFileStandard)
+	if err != nil {
+		return nil, err
+	}
+	info := &informationlevels.SMB_QUERY_FILE_STANDARD_INFO{}
+	if _, err := info.Unmarshal(data); err != nil {
+		return nil, fmt.Errorf("failed to decode SMB_QUERY_FILE_STANDARD_INFO: %v", err)
+	}
+	return info, nil
+}
+
+// SetFileEndOfFile sets the end-of-file position (logical size) of an open file.
+func (c *Client) SetFileEndOfFile(fid FID, endOfFile uint64) error {
+	info := &informationlevels.SMB_SET_FILE_END_OF_FILE_INFO{}
+	info.Endoffile.QuadPart = endOfFile
+	data, err := info.Marshal()
+	if err != nil {
+		return err
+	}
+	return c.SetFileInformation(fid, InfoLevelSetFileEndOfFile, data)
+}
+
+// SetFileDeleteOnClose marks (or unmarks) an open file for deletion when its last
+// handle is closed.
+func (c *Client) SetFileDeleteOnClose(fid FID, deletePending bool) error {
+	info := &informationlevels.SMB_SET_FILE_DISPOSITION_INFO{}
+	if deletePending {
+		info.Deletepending = 0x01
+	}
+	data, err := info.Marshal()
+	if err != nil {
+		return err
+	}
+	return c.SetFileInformation(fid, InfoLevelSetFileDisposition, data)
+}
+
+// GetFsSizeInfo queries the volume's total/free allocation units and sector sizes.
+func (c *Client) GetFsSizeInfo() (*informationlevels.SMB_QUERY_FS_SIZE_INFO, error) {
+	data, err := c.QueryFsInformation(InfoLevelQueryFsSize)
+	if err != nil {
+		return nil, err
+	}
+	info := &informationlevels.SMB_QUERY_FS_SIZE_INFO{}
+	if _, err := info.Unmarshal(data); err != nil {
+		return nil, fmt.Errorf("failed to decode SMB_QUERY_FS_SIZE_INFO: %v", err)
+	}
+	return info, nil
+}
+
+// GetFsAttributeInfo queries the filesystem attribute flags and name.
+func (c *Client) GetFsAttributeInfo() (*informationlevels.SMB_QUERY_FS_ATTRIBUTE_INFO, error) {
+	data, err := c.QueryFsInformation(InfoLevelQueryFsAttribute)
+	if err != nil {
+		return nil, err
+	}
+	info := &informationlevels.SMB_QUERY_FS_ATTRIBUTE_INFO{}
+	if _, err := info.Unmarshal(data); err != nil {
+		return nil, fmt.Errorf("failed to decode SMB_QUERY_FS_ATTRIBUTE_INFO: %v", err)
+	}
+	return info, nil
+}

--- a/network/smb/smb_v10/client/queryinfo_test.go
+++ b/network/smb/smb_v10/client/queryinfo_test.go
@@ -1,0 +1,138 @@
+package client_test
+
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/client"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/informationlevels"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+)
+
+// trans2DataReply builds a marshalled SMB_COM_TRANSACTION2 reply whose Trans2_Data
+// block carries data. With no setup words the data block begins 55 bytes from the
+// start of the SMB header (header 32 + WordCount 1 + 10 words + ByteCount 2).
+func trans2DataReply(t *testing.T, data []byte) []byte {
+	t.Helper()
+	const dataOffset = 55
+
+	resp := commands.NewTransaction2Response()
+	resp.TotalDataCount = types.USHORT(len(data))
+	resp.DataCount = types.USHORT(len(data))
+	resp.DataOffset = types.USHORT(dataOffset)
+	resp.Trans2_Data = []types.UCHAR(data)
+
+	return marshalResponse(t, resp)
+}
+
+// sentTransaction2 decodes the captured request as a Transaction2Request.
+func sentTransaction2(t *testing.T, raw []byte) *commands.Transaction2Request {
+	t.Helper()
+	msg := message.NewMessage()
+	if err := msg.Unmarshal(raw); err != nil {
+		t.Fatalf("failed to decode sent request: %v", err)
+	}
+	req, ok := msg.Command.(*commands.Transaction2Request)
+	if !ok {
+		t.Fatalf("sent command is %T, want *Transaction2Request", msg.Command)
+	}
+	return req
+}
+
+func TestGetFileStandardInfoDecodesResponse(t *testing.T) {
+	want := &informationlevels.SMB_QUERY_FILE_STANDARD_INFO{Numberoflinks: 1, Directory: 1}
+	want.Allocationsize.QuadPart = 0x4000
+	want.Endoffile.QuadPart = 0x3210
+	infoBytes, err := want.Marshal()
+	if err != nil {
+		t.Fatalf("marshal info: %v", err)
+	}
+
+	tr := &capturingTransport{response: trans2DataReply(t, infoBytes)}
+	c := newSessionClient(tr)
+
+	got, err := c.GetFileStandardInfo("\\dir\\file.txt")
+	if err != nil {
+		t.Fatalf("GetFileStandardInfo: %v", err)
+	}
+	if got.Allocationsize.QuadPart != want.Allocationsize.QuadPart ||
+		got.Endoffile.QuadPart != want.Endoffile.QuadPart ||
+		got.Numberoflinks != want.Numberoflinks || got.Directory != want.Directory {
+		t.Errorf("decoded info mismatch:\n got %+v\n want %+v", got, want)
+	}
+
+	// The request must be TRANS2_QUERY_PATH_INFORMATION at the STANDARD level.
+	req := sentTransaction2(t, tr.sent)
+	if len(req.Setup) != 1 || uint16(req.Setup[0]) != 0x0005 {
+		t.Errorf("expected setup [0x0005] (QUERY_PATH_INFORMATION), got %v", req.Setup)
+	}
+	if len(req.Trans2_Parameters) < 2 {
+		t.Fatalf("expected information level in parameters, got %d bytes", len(req.Trans2_Parameters))
+	}
+	gotLevel := uint16(req.Trans2_Parameters[0]) | uint16(req.Trans2_Parameters[1])<<8
+	if gotLevel != client.InfoLevelQueryFileStandard {
+		t.Errorf("expected information level 0x%04x, got 0x%04x", client.InfoLevelQueryFileStandard, gotLevel)
+	}
+}
+
+func TestGetFsSizeInfoDecodesResponse(t *testing.T) {
+	want := &informationlevels.SMB_QUERY_FS_SIZE_INFO{Sectorsperallocationunit: 8, Bytespersector: 512}
+	want.Totalallocationunits.QuadPart = 0x100000
+	want.Totalfreeallocationunits.QuadPart = 0x80000
+	infoBytes, _ := want.Marshal()
+
+	tr := &capturingTransport{response: trans2DataReply(t, infoBytes)}
+	c := newSessionClient(tr)
+
+	got, err := c.GetFsSizeInfo()
+	if err != nil {
+		t.Fatalf("GetFsSizeInfo: %v", err)
+	}
+	if *got != *want {
+		t.Errorf("decoded fs size mismatch:\n got %+v\n want %+v", got, want)
+	}
+
+	req := sentTransaction2(t, tr.sent)
+	if len(req.Setup) != 1 || uint16(req.Setup[0]) != 0x0003 {
+		t.Errorf("expected setup [0x0003] (QUERY_FS_INFORMATION), got %v", req.Setup)
+	}
+}
+
+func TestSetFileEndOfFileRequestShape(t *testing.T) {
+	// SET responses carry no data; an empty TRANS2 reply with status 0 suffices.
+	tr := &capturingTransport{response: trans2DataReply(t, nil)}
+	c := newSessionClient(tr)
+
+	if err := c.SetFileEndOfFile(7, 0x1122334455); err != nil {
+		t.Fatalf("SetFileEndOfFile: %v", err)
+	}
+
+	req := sentTransaction2(t, tr.sent)
+	if len(req.Setup) != 1 || uint16(req.Setup[0]) != 0x0008 {
+		t.Errorf("expected setup [0x0008] (SET_FILE_INFORMATION), got %v", req.Setup)
+	}
+	// Parameters: FID(2) + InformationLevel(2) + Reserved(2).
+	if len(req.Trans2_Parameters) < 6 {
+		t.Fatalf("expected >=6 parameter bytes, got %d", len(req.Trans2_Parameters))
+	}
+	gotFID := uint16(req.Trans2_Parameters[0]) | uint16(req.Trans2_Parameters[1])<<8
+	gotLevel := uint16(req.Trans2_Parameters[2]) | uint16(req.Trans2_Parameters[3])<<8
+	if gotFID != 7 || gotLevel != client.InfoLevelSetFileEndOfFile {
+		t.Errorf("expected FID 7 level 0x%04x, got FID %d level 0x%04x", client.InfoLevelSetFileEndOfFile, gotFID, gotLevel)
+	}
+	// Data: the 8-byte end-of-file value.
+	if len(req.Trans2_Data) != 8 {
+		t.Errorf("expected 8 data bytes (EndOfFile), got %d", len(req.Trans2_Data))
+	}
+}
+
+func TestQueryInfoWithoutSession(t *testing.T) {
+	c := &client.Client{Connection: &client.Connection{Server: &client.Server{}}}
+	if _, err := c.GetFileBasicInfo("\\x"); err == nil {
+		t.Error("expected error without a session")
+	}
+	if err := c.SetFileEndOfFile(1, 0); err == nil {
+		t.Error("expected error without a session")
+	}
+}


### PR DESCRIPTION
### Linked Issue
Part of #384 (does not close it — second batch by operation family; TRANS2 query/set information).

### Root Cause
`Transaction2Request` and the `trans2()` helper existed, but only `FIND_FIRST2`/`FIND_NEXT2` were wired — there was no client API for querying or setting file/filesystem information, so the `informationlevels` package (now fully implemented) was unreachable from the client.

### Fix Description
Add the TRANS2 information operations, with information level codes cross-checked against the MS-CIFS "QUERY/SET Information Level Codes" tables (2.2.2.3):
- **Generic helpers**: `QueryPathInformation(path, level)`, `QueryFileInformation(fid, level)`, `QueryFsInformation(level)` return the raw information-level data; `SetFileInformation(fid, level, data)` and `SetPathInformation(path, level, data)` send it. Request parameter layouts per MS-CIFS 2.2.6.4/6/7/8/9 (e.g. QUERY_PATH = InformationLevel + Reserved(4) + OEM null-terminated FileName; SET_FILE = FID + InformationLevel + Reserved(2) + data).
- **Exported level constants** (`InfoLevelQueryFileBasic` = 0x0101, `…Standard` = 0x0102, `…All` = 0x0107, `InfoLevelSetFileEndOfFile` = 0x0104, `InfoLevelQueryFsSize` = 0x0103, `InfoLevelQueryFsAttribute` = 0x0105, etc.).
- **Typed wrappers** decoding into the `informationlevels` structs: `GetFileBasicInfo`, `GetFileStandardInfo`, `GetFsSizeInfo`, `GetFsAttributeInfo`, and `SetFileEndOfFile`, `SetFileDeleteOnClose`.

All reuse the existing `trans2()` helper (single-message transaction), so message signing applies when active.

### How Verified
- **Tests:** `go test ./network/smb/smb_v10/...` passes. Tests use a capturing transport with a crafted TRANS2 reply: `TestGetFileStandardInfoDecodesResponse` (decodes the STANDARD struct and asserts the sent request is QUERY_PATH_INFORMATION at level 0x0102), `TestGetFsSizeInfoDecodesResponse` (QUERY_FS at 0x0003), `TestSetFileEndOfFileRequestShape` (asserts SET_FILE_INFORMATION at subcommand 0x0008, FID/level parameters, and 8-byte EndOfFile data), `TestQueryInfoWithoutSession`.

### Test Coverage
- **Added:** `TestGetFileStandardInfoDecodesResponse`, `TestGetFsSizeInfoDecodesResponse`, `TestSetFileEndOfFileRequestShape`, `TestQueryInfoWithoutSession` in `network/smb/smb_v10/client/queryinfo_test.go`.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/client/queryinfo.go`, `network/smb/smb_v10/client/queryinfo_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Additive; reuses the existing single-message `trans2()` path (so it inherits its single-message-request limitation, tracked in #389). Remaining #384 batches: locking and Seek/NtRename.
