### PR TITLE
Add byte-range locking client operations (#384)

### DIFF
--- a/network/smb/smb_v10/client/locking.go
+++ b/network/smb/smb_v10/client/locking.go
@@ -1,0 +1,90 @@
+package client
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/codes"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+)
+
+// TypeOfLock bit flags for SMB_COM_LOCKING_ANDX (MS-CIFS 2.2.4.32.1).
+const (
+	lockTypeSharedLock = 0x01 // shared (read-only) lock; absence means exclusive
+	lockTypeLargeFiles = 0x10 // ranges are in 64-bit LOCKING_ANDX_RANGE64 format
+)
+
+// range64 builds a 64-bit lock range for the given file offset and length, owned
+// by the supplied PID.
+func range64(pid uint16, offset, length uint64) types.LOCKING_ANDX_RANGE64 {
+	return types.LOCKING_ANDX_RANGE64{
+		PID:               types.USHORT(pid),
+		ByteOffsetHigh:    types.ULONG(offset >> 32),
+		ByteOffsetLow:     types.ULONG(offset),
+		LengthInBytesHigh: types.ULONG(length >> 32),
+		LengthInBytesLow:  types.ULONG(length),
+	}
+}
+
+// LockFile locks a byte range [offset, offset+length) on the open file referenced
+// by fid. When exclusive is false the lock is a shared (read-only) lock. The
+// request fails immediately (no wait) if the range cannot be locked.
+//
+// Wire: SMB_COM_LOCKING_ANDX with a single 64-bit lock range.
+func (c *Client) LockFile(fid FID, offset, length uint64, exclusive bool) error {
+	if c.Session == nil {
+		return fmt.Errorf("no session established")
+	}
+
+	msg := c.newFileIOMessage(codes.SMB_COM_LOCKING_ANDX)
+
+	cmd := commands.NewLockingAndxRequest()
+	cmd.FID = types.USHORT(fid)
+	cmd.TypeOfLock = types.UCHAR(lockTypeLargeFiles)
+	if !exclusive {
+		cmd.TypeOfLock |= lockTypeSharedLock
+	}
+	cmd.Timeout = types.ULONG(0)
+	cmd.NumberOfRequestedLocks = types.USHORT(1)
+	cmd.Locks = []types.LOCKING_ANDX_RANGE64{range64(uint16(msg.Header.GetPID()), offset, length)}
+
+	msg.AddCommand(cmd)
+
+	response, _, err := c.sendReceive(msg, "LockingAndx(lock)")
+	if err != nil {
+		return err
+	}
+	if response.Header.Status != 0x00000000 {
+		return fmt.Errorf("LockingAndx lock failed: 0x%08x", response.Header.Status)
+	}
+	return nil
+}
+
+// UnlockFile releases a previously acquired byte-range lock [offset, offset+length)
+// on the open file referenced by fid.
+//
+// Wire: SMB_COM_LOCKING_ANDX with a single 64-bit unlock range.
+func (c *Client) UnlockFile(fid FID, offset, length uint64) error {
+	if c.Session == nil {
+		return fmt.Errorf("no session established")
+	}
+
+	msg := c.newFileIOMessage(codes.SMB_COM_LOCKING_ANDX)
+
+	cmd := commands.NewLockingAndxRequest()
+	cmd.FID = types.USHORT(fid)
+	cmd.TypeOfLock = types.UCHAR(lockTypeLargeFiles)
+	cmd.NumberOfRequestedUnlocks = types.USHORT(1)
+	cmd.Unlocks = []types.LOCKING_ANDX_RANGE64{range64(uint16(msg.Header.GetPID()), offset, length)}
+
+	msg.AddCommand(cmd)
+
+	response, _, err := c.sendReceive(msg, "LockingAndx(unlock)")
+	if err != nil {
+		return err
+	}
+	if response.Header.Status != 0x00000000 {
+		return fmt.Errorf("LockingAndx unlock failed: 0x%08x", response.Header.Status)
+	}
+	return nil
+}

--- a/network/smb/smb_v10/client/locking_test.go
+++ b/network/smb/smb_v10/client/locking_test.go
@@ -1,0 +1,89 @@
+package client_test
+
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/client"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+)
+
+// sentLockingAndx decodes the captured request as a LockingAndxRequest.
+func sentLockingAndx(t *testing.T, raw []byte) *commands.LockingAndxRequest {
+	t.Helper()
+	msg := message.NewMessage()
+	if err := msg.Unmarshal(raw); err != nil {
+		t.Fatalf("failed to decode sent request: %v", err)
+	}
+	req, ok := msg.Command.(*commands.LockingAndxRequest)
+	if !ok {
+		t.Fatalf("sent command is %T, want *LockingAndxRequest", msg.Command)
+	}
+	return req
+}
+
+func TestLockFileExclusiveRequestShape(t *testing.T) {
+	tr := &capturingTransport{response: marshalResponse(t, commands.NewLockingAndxResponse())}
+	c := newSessionClient(tr)
+
+	if err := c.LockFile(5, 0x1_0000_0020, 0x100, true); err != nil {
+		t.Fatalf("LockFile: %v", err)
+	}
+
+	req := sentLockingAndx(t, tr.sent)
+	// LARGE_FILES (0x10) set, SHARED_LOCK (0x01) clear for an exclusive lock.
+	if req.TypeOfLock&0x10 == 0 {
+		t.Errorf("expected LARGE_FILES bit set, TypeOfLock = 0x%02x", req.TypeOfLock)
+	}
+	if req.TypeOfLock&0x01 != 0 {
+		t.Errorf("expected SHARED_LOCK bit clear for exclusive lock, TypeOfLock = 0x%02x", req.TypeOfLock)
+	}
+	if req.FID != 5 || req.NumberOfRequestedLocks != 1 || req.NumberOfRequestedUnlocks != 0 {
+		t.Errorf("unexpected FID/counts: FID=%d locks=%d unlocks=%d", req.FID, req.NumberOfRequestedLocks, req.NumberOfRequestedUnlocks)
+	}
+	if len(req.Locks) != 1 {
+		t.Fatalf("expected 1 lock range, got %d", len(req.Locks))
+	}
+	lock := req.Locks[0]
+	gotOffset := uint64(lock.ByteOffsetHigh)<<32 | uint64(lock.ByteOffsetLow)
+	gotLength := uint64(lock.LengthInBytesHigh)<<32 | uint64(lock.LengthInBytesLow)
+	if gotOffset != 0x1_0000_0020 || gotLength != 0x100 {
+		t.Errorf("range mismatch: offset=0x%x length=0x%x", gotOffset, gotLength)
+	}
+}
+
+func TestLockFileSharedSetsSharedBit(t *testing.T) {
+	tr := &capturingTransport{response: marshalResponse(t, commands.NewLockingAndxResponse())}
+	c := newSessionClient(tr)
+
+	if err := c.LockFile(1, 0, 10, false); err != nil {
+		t.Fatalf("LockFile (shared): %v", err)
+	}
+	req := sentLockingAndx(t, tr.sent)
+	if req.TypeOfLock&0x01 == 0 {
+		t.Errorf("expected SHARED_LOCK bit set for a shared lock, TypeOfLock = 0x%02x", req.TypeOfLock)
+	}
+}
+
+func TestUnlockFileRequestShape(t *testing.T) {
+	tr := &capturingTransport{response: marshalResponse(t, commands.NewLockingAndxResponse())}
+	c := newSessionClient(tr)
+
+	if err := c.UnlockFile(9, 0x40, 0x80); err != nil {
+		t.Fatalf("UnlockFile: %v", err)
+	}
+	req := sentLockingAndx(t, tr.sent)
+	if req.NumberOfRequestedUnlocks != 1 || req.NumberOfRequestedLocks != 0 {
+		t.Errorf("expected 1 unlock and 0 locks, got unlocks=%d locks=%d", req.NumberOfRequestedUnlocks, req.NumberOfRequestedLocks)
+	}
+	if len(req.Unlocks) != 1 {
+		t.Fatalf("expected 1 unlock range, got %d", len(req.Unlocks))
+	}
+}
+
+func TestLockFileWithoutSession(t *testing.T) {
+	c := &client.Client{Connection: &client.Connection{Server: &client.Server{}}}
+	if err := c.LockFile(1, 0, 1, true); err == nil {
+		t.Error("expected error without a session")
+	}
+}


### PR DESCRIPTION
### Linked Issue
Part of #384 (does not close it — third batch by operation family; byte-range locking).

### Root Cause
`LockingAndxRequest` existed but had no client method, so the client could not take or release byte-range locks.

### Fix Description
Add two operations using `SMB_COM_LOCKING_ANDX`:
- **`LockFile(fid, offset, length, exclusive)`** — locks the range `[offset, offset+length)`. Sets the `LARGE_FILES` `TypeOfLock` bit (the request marshals 64-bit `LOCKING_ANDX_RANGE64` entries) and the `SHARED_LOCK` bit when `exclusive` is false. `Timeout` is 0, so a contended range fails immediately.
- **`UnlockFile(fid, offset, length)`** — releases the range via the Unlocks array.

Each sends a single 64-bit range whose owning PID is the request's SMB PID, reuses `sendReceive` (so signing applies when active), and maps a non-zero response status to an error (e.g. a lock conflict).

### How Verified
- **Tests:** `go test ./network/smb/smb_v10/...` passes. Tests decode the captured request: `TestLockFileExclusiveRequestShape` (LARGE_FILES set, SHARED_LOCK clear, FID/counts, and the 64-bit offset/length round-trip), `TestLockFileSharedSetsSharedBit`, `TestUnlockFileRequestShape` (1 unlock / 0 locks), `TestLockFileWithoutSession`.

### Test Coverage
- **Added:** `TestLockFileExclusiveRequestShape`, `TestLockFileSharedSetsSharedBit`, `TestUnlockFileRequestShape`, `TestLockFileWithoutSession` in `network/smb/smb_v10/client/locking_test.go`.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/client/locking.go`, `network/smb/smb_v10/client/locking_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Low and additive. One #384 batch remains: Seek and NtRename.
