### PR TITLE
Add Seek, NtRename and CreateHardLink client operations (#384)

### DIFF
--- a/network/smb/smb_v10/client/seek_rename.go
+++ b/network/smb/smb_v10/client/seek_rename.go
@@ -1,0 +1,101 @@
+package client
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/codes"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+)
+
+// Seek mode values for Seek (MS-CIFS 2.2.4.43.1).
+const (
+	SeekModeStart   uint16 = 0 // offset is relative to the start of the file
+	SeekModeCurrent uint16 = 1 // offset is relative to the current file pointer
+	SeekModeEnd     uint16 = 2 // offset is relative to the end of the file
+)
+
+// NT_RENAME information levels (MS-CIFS 2.2.4.65.1).
+const (
+	infoNtRenameSetLinkInfo uint16 = 0x0103 // create a hard link
+	infoNtRenameRenameFile  uint16 = 0x0104 // in-place rename
+)
+
+// Seek sets the file pointer of the open file referenced by fid and returns the
+// resulting absolute file position (bytes from the start of the file). mode is one
+// of SeekModeStart/SeekModeCurrent/SeekModeEnd and offset is a signed displacement.
+//
+// Wire: SMB_COM_SEEK request / response.
+func (c *Client) Seek(fid FID, mode uint16, offset int32) (uint32, error) {
+	if c.Session == nil {
+		return 0, fmt.Errorf("no session established")
+	}
+
+	msg := c.newFileIOMessage(codes.SMB_COM_SEEK)
+
+	cmd := commands.NewSeekRequest()
+	cmd.FID = types.USHORT(fid)
+	cmd.Mode = types.USHORT(mode)
+	cmd.Offset = types.LONG(offset)
+
+	msg.AddCommand(cmd)
+
+	response, _, err := c.sendReceive(msg, "Seek")
+	if err != nil {
+		return 0, err
+	}
+	if response.Header.Status != 0x00000000 {
+		return 0, fmt.Errorf("Seek failed: 0x%08x", response.Header.Status)
+	}
+
+	seekResponse, ok := response.Command.(*commands.SeekResponse)
+	if !ok {
+		return 0, fmt.Errorf("unexpected response command: 0x%02x", response.Header.Command)
+	}
+
+	return uint32(seekResponse.Offset), nil
+}
+
+// ntRename issues SMB_COM_NT_RENAME for the given information level. oldPath and
+// newPath are share-relative paths using backslash separators.
+func (c *Client) ntRename(oldPath, newPath string, informationLevel uint16) error {
+	if c.Session == nil {
+		return fmt.Errorf("no session established")
+	}
+
+	msg := c.newFileIOMessage(codes.SMB_COM_NT_RENAME)
+
+	cmd := commands.NewNtRenameRequest()
+	cmd.SearchAttributes = types.SMB_FILE_ATTRIBUTES{}
+	cmd.InformationLevel = types.USHORT(informationLevel)
+	if err := cmd.OldFileName.SetString(oldPath); err != nil {
+		return fmt.Errorf("failed to set old file name: %v", err)
+	}
+	if err := cmd.NewFileName.SetString(newPath); err != nil {
+		return fmt.Errorf("failed to set new file name: %v", err)
+	}
+
+	msg.AddCommand(cmd)
+
+	response, _, err := c.sendReceive(msg, "NtRename")
+	if err != nil {
+		return err
+	}
+	if response.Header.Status != 0x00000000 {
+		return fmt.Errorf("NtRename failed: 0x%08x", response.Header.Status)
+	}
+	return nil
+}
+
+// NtRename performs an in-place rename of oldPath to newPath using
+// SMB_COM_NT_RENAME (SMB_NT_RENAME_RENAME_FILE). Unlike the legacy RenameFile,
+// wildcards are not supported.
+func (c *Client) NtRename(oldPath, newPath string) error {
+	return c.ntRename(oldPath, newPath, infoNtRenameRenameFile)
+}
+
+// CreateHardLink creates a hard link at linkPath that refers to the existing file
+// existingPath, using SMB_COM_NT_RENAME (SMB_NT_RENAME_SET_LINK_INFO).
+func (c *Client) CreateHardLink(existingPath, linkPath string) error {
+	return c.ntRename(existingPath, linkPath, infoNtRenameSetLinkInfo)
+}

--- a/network/smb/smb_v10/client/seek_rename_test.go
+++ b/network/smb/smb_v10/client/seek_rename_test.go
@@ -1,0 +1,88 @@
+package client_test
+
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/client"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+)
+
+func TestSeekReturnsNewOffset(t *testing.T) {
+	resp := commands.NewSeekResponse()
+	resp.Offset = types.ULONG(0x12345)
+
+	tr := &capturingTransport{response: marshalResponse(t, resp)}
+	c := newSessionClient(tr)
+
+	got, err := c.Seek(3, client.SeekModeEnd, -16)
+	if err != nil {
+		t.Fatalf("Seek: %v", err)
+	}
+	if got != 0x12345 {
+		t.Errorf("Seek returned 0x%x, want 0x12345", got)
+	}
+
+	// Verify the request carried the FID, mode, and signed offset.
+	msg := message.NewMessage()
+	if err := msg.Unmarshal(tr.sent); err != nil {
+		t.Fatalf("decode sent: %v", err)
+	}
+	req, ok := msg.Command.(*commands.SeekRequest)
+	if !ok {
+		t.Fatalf("sent command is %T, want *SeekRequest", msg.Command)
+	}
+	if req.FID != 3 || uint16(req.Mode) != client.SeekModeEnd || int32(req.Offset) != -16 {
+		t.Errorf("unexpected request: FID=%d Mode=%d Offset=%d", req.FID, req.Mode, int32(req.Offset))
+	}
+}
+
+func TestNtRenameRequestShape(t *testing.T) {
+	tr := &capturingTransport{response: marshalResponse(t, commands.NewNtRenameResponse())}
+	c := newSessionClient(tr)
+
+	if err := c.NtRename("\\a.txt", "\\b.txt"); err != nil {
+		t.Fatalf("NtRename: %v", err)
+	}
+	req := sentNtRename(t, tr.sent)
+	if uint16(req.InformationLevel) != 0x0104 {
+		t.Errorf("expected InformationLevel 0x0104 (RENAME_FILE), got 0x%04x", req.InformationLevel)
+	}
+}
+
+func TestCreateHardLinkRequestShape(t *testing.T) {
+	tr := &capturingTransport{response: marshalResponse(t, commands.NewNtRenameResponse())}
+	c := newSessionClient(tr)
+
+	if err := c.CreateHardLink("\\orig.txt", "\\link.txt"); err != nil {
+		t.Fatalf("CreateHardLink: %v", err)
+	}
+	req := sentNtRename(t, tr.sent)
+	if uint16(req.InformationLevel) != 0x0103 {
+		t.Errorf("expected InformationLevel 0x0103 (SET_LINK_INFO), got 0x%04x", req.InformationLevel)
+	}
+}
+
+func TestSeekAndRenameWithoutSession(t *testing.T) {
+	c := &client.Client{Connection: &client.Connection{Server: &client.Server{}}}
+	if _, err := c.Seek(1, client.SeekModeStart, 0); err == nil {
+		t.Error("expected error without a session (Seek)")
+	}
+	if err := c.NtRename("\\a", "\\b"); err == nil {
+		t.Error("expected error without a session (NtRename)")
+	}
+}
+
+func sentNtRename(t *testing.T, raw []byte) *commands.NtRenameRequest {
+	t.Helper()
+	msg := message.NewMessage()
+	if err := msg.Unmarshal(raw); err != nil {
+		t.Fatalf("decode sent: %v", err)
+	}
+	req, ok := msg.Command.(*commands.NtRenameRequest)
+	if !ok {
+		t.Fatalf("sent command is %T, want *NtRenameRequest", msg.Command)
+	}
+	return req
+}


### PR DESCRIPTION
### Linked Issue
`Closes #384`

Final batch (Seek + NtRename). Should be merged after the other #384 batches (#457 Flush/Echo, #458 TRANS2 query/set info, #459 locking).

### Root Cause
`SeekRequest`/`SeekResponse` and `NtRenameRequest` existed but had no client method, so seeking and the NT rename / hard-link operations were unavailable.

### Fix Description
- **`Seek(fid, mode, offset) (uint32, error)`** — `SMB_COM_SEEK`; sets the file pointer (modes `SeekModeStart`/`SeekModeCurrent`/`SeekModeEnd`, signed 32-bit offset) and returns the resulting absolute position.
- **`NtRename(oldPath, newPath)`** — `SMB_COM_NT_RENAME` with `InformationLevel = SMB_NT_RENAME_RENAME_FILE` (0x0104), an in-place rename (no wildcards).
- **`CreateHardLink(existingPath, linkPath)`** — `SMB_COM_NT_RENAME` with `InformationLevel = SMB_NT_RENAME_SET_LINK_INFO` (0x0103), creating a hard link.

Information level values were cross-checked against MS-CIFS 2.2.4.65.1. All reuse `sendReceive`.

### How Verified
- **Tests:** `go test ./network/smb/smb_v10/...` passes. `TestSeekReturnsNewOffset` asserts the returned offset and that the request carries the FID/mode/signed offset; `TestNtRenameRequestShape` and `TestCreateHardLinkRequestShape` assert the correct `InformationLevel` (0x0104 / 0x0103); `TestSeekAndRenameWithoutSession` covers the no-session guard.

### Test Coverage
- **Added:** `TestSeekReturnsNewOffset`, `TestNtRenameRequestShape`, `TestCreateHardLinkRequestShape`, `TestSeekAndRenameWithoutSession` in `network/smb/smb_v10/client/seek_rename_test.go`.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/client/seek_rename.go`, `network/smb/smb_v10/client/seek_rename_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Notes
This completes #384. The high-level client now also exposes Flush/Echo (#457), TRANS2 query/set file & FS information (#458), and byte-range locking (#459). The legacy `SMB_COM_QUERY_INFORMATION(2)`/`SET_INFORMATION(2)` commands noted in the issue are intentionally left unimplemented in favor of the TRANS2 information operations, which supersede them.
