### PR TITLE
Fix GetRemoteServerTime returning the zero time (#382)

### DIFF
--- a/network/smb/smb_v10/client/infos.go
+++ b/network/smb/smb_v10/client/infos.go
@@ -1,24 +1,30 @@
 package client
 
 import (
+	"fmt"
 	"time"
 )
 
-// GetRemoteServerTime retrieves the current time from the remote server.
+// GetRemoteServerTime returns the server's system clock as reported in the
+// SMB_COM_NEGOTIATE response.
 //
-// This function sends an SMB_COM_QUERY_TIME_REQUEST message to the server
-// and receives the server's current time in UTC.
-//
-// The query process:
-// 1. Creates and sends an SMB_COM_NEGOTIATE_REQUEST message
-// 2. Receives the SMB_COM_NEGOTIATE_RESPONSE from the server
-// 3. Validates the response command type
-// 4. Processes server capabilities and configuration
+// SMBv1 has no dedicated query-time command; the server's time is delivered in the
+// NEGOTIATE response and captured by Negotiate as Connection.Server.SystemTime (a
+// FILETIME, i.e. 100ns ticks since 1601-01-01 UTC). The returned time therefore
+// reflects the server's clock at the moment of negotiation, in UTC.
 //
 // Returns:
-//   - nil if negotiation is successful
-//   - An error if any step in the negotiation process fails (connection issues,
-//     message creation/marshalling errors, transport errors, or unexpected responses)
+//   - The server time in UTC.
+//   - An error if no connection exists or negotiation has not populated the time.
 func (c *Client) GetRemoteServerTime() (time.Time, error) {
-	return time.Time{}, nil
+	if c.Connection == nil || c.Connection.Server == nil {
+		return time.Time{}, fmt.Errorf("no connection established")
+	}
+
+	systemTime := c.Connection.Server.SystemTime
+	if systemTime.DwLowDateTime == 0 && systemTime.DwHighDateTime == 0 {
+		return time.Time{}, fmt.Errorf("server time not available; negotiate first")
+	}
+
+	return systemTime.GetTime().UTC(), nil
 }

--- a/network/smb/smb_v10/client/infos_test.go
+++ b/network/smb/smb_v10/client/infos_test.go
@@ -1,0 +1,43 @@
+package client_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/client"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+	"github.com/TheManticoreProject/Manticore/windows/ms_dtyp/common/data_structures"
+)
+
+func TestGetRemoteServerTimeReturnsNegotiatedTime(t *testing.T) {
+	want := time.Date(2021, time.June, 15, 12, 30, 45, 0, time.UTC)
+	ft := data_structures.NewFILETIMEFromTime(want)
+
+	c := &client.Client{
+		Connection: &client.Connection{
+			Server: &client.Server{SystemTime: types.SMB_TIME(*ft)},
+		},
+	}
+
+	got, err := c.GetRemoteServerTime()
+	if err != nil {
+		t.Fatalf("GetRemoteServerTime returned error: %v", err)
+	}
+	if !got.Equal(want) {
+		t.Errorf("GetRemoteServerTime = %s, want %s", got, want)
+	}
+}
+
+func TestGetRemoteServerTimeUnavailable(t *testing.T) {
+	// Zero SystemTime (negotiation has not populated it) -> error.
+	c := &client.Client{Connection: &client.Connection{Server: &client.Server{}}}
+	if _, err := c.GetRemoteServerTime(); err == nil {
+		t.Error("expected an error when server time is unavailable, got nil")
+	}
+
+	// No connection -> error.
+	empty := &client.Client{}
+	if _, err := empty.GetRemoteServerTime(); err == nil {
+		t.Error("expected an error when no connection exists, got nil")
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #382`

### Root Cause
`GetRemoteServerTime` was a stub: it returned `time.Time{}, nil` unconditionally, so the exported API silently produced a bogus (zero) time. SMBv1 has no dedicated query-time command, but the server's clock is delivered in the SMB_COM_NEGOTIATE response and is already captured by `Negotiate` as `Connection.Server.SystemTime` (a FILETIME); the stub simply never used it.

### Fix Description
Implement `GetRemoteServerTime` to convert `Connection.Server.SystemTime` (FILETIME, 100ns ticks since 1601-01-01 UTC) to a `time.Time` in UTC via the existing `FILETIME.GetTime()`. It returns an error when there is no connection/server or when `SystemTime` is still zero (negotiation has not populated it), instead of returning a meaningless 1601-era time. The doc comment is corrected to describe the actual (negotiation-sourced) behavior.

### How Verified
- **Tests:** `go test ./network/smb/smb_v10/client/...` passes. `TestGetRemoteServerTimeReturnsNegotiatedTime` sets `SystemTime` from a known time via `FILETIME` and asserts the returned time matches; `TestGetRemoteServerTimeUnavailable` asserts an error for a zero `SystemTime` and for a client with no connection.

### Test Coverage
- **Added:** `TestGetRemoteServerTimeReturnsNegotiatedTime`, `TestGetRemoteServerTimeUnavailable` in `network/smb/smb_v10/client/infos_test.go`.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/client/infos.go`, `network/smb/smb_v10/client/infos_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Trivial and local. The value reflects the server's clock at negotiation time (SMBv1 has no live time query); documented as such.
