### PR TITLE
Fix session registration and reuse via Connection.SessionTable (#383)

### DIFF
--- a/network/smb/smb_v10/client/client_functions.go
+++ b/network/smb/smb_v10/client/client_functions.go
@@ -73,16 +73,66 @@ func (c *Client) Connect(ipaddr net.IP, port int) error {
 //
 // Returns:
 //   - An error if the session setup fails
-func (c *Client) SessionSetup(credentials *credentials.Credentials) error {
+func (c *Client) SessionSetup(creds *credentials.Credentials) error {
+	// Reuse an already-authenticated session for the same credentials if one is
+	// registered on this connection, avoiding a redundant authentication exchange.
+	if existing := c.findSessionByCredentials(creds); existing != nil {
+		c.Session = existing
+		return nil
+	}
+
 	if c.Session == nil {
 		c.Session = &Session{
 			Client:      c,
-			Credentials: credentials,
+			Credentials: creds,
 		}
 	}
 	c.Session.Client = c
+	if c.Session.Credentials == nil {
+		c.Session.Credentials = creds
+	}
 
-	return c.Session.SessionSetup()
+	if err := c.Session.SessionSetup(); err != nil {
+		return err
+	}
+
+	// Register the established session in the connection's session table, keyed by
+	// the server-assigned UID, so it can be reused and is removed on Logoff.
+	if c.Connection != nil {
+		if c.Connection.SessionTable == nil {
+			c.Connection.SessionTable = make(map[uint16]*Session)
+		}
+		c.Connection.SessionTable[c.Session.SessionUID] = c.Session
+	}
+
+	return nil
+}
+
+// findSessionByCredentials returns a session already registered on the connection
+// whose credentials match creds, or nil if none is found. A nil creds (anonymous)
+// is never matched, so anonymous setups always perform a fresh exchange.
+func (c *Client) findSessionByCredentials(creds *credentials.Credentials) *Session {
+	if creds == nil || c.Connection == nil {
+		return nil
+	}
+	for _, session := range c.Connection.SessionTable {
+		if session != nil && sameCredentials(session.Credentials, creds) {
+			return session
+		}
+	}
+	return nil
+}
+
+// sameCredentials reports whether two credential sets identify the same principal.
+func sameCredentials(a, b *credentials.Credentials) bool {
+	if a == nil || b == nil {
+		return false
+	}
+	return a.Domain == b.Domain &&
+		a.Username == b.Username &&
+		a.Password == b.Password &&
+		a.LMHash == b.LMHash &&
+		a.NTHash == b.NTHash
 }
 
 // SetHost sets the host IP address for the SMB client

--- a/network/smb/smb_v10/client/session.go
+++ b/network/smb/smb_v10/client/session.go
@@ -103,9 +103,10 @@ func (s *Session) SessionSetup() error {
 		sessionSetupCmd.UnicodePassword = []types.UCHAR{}
 
 	} else {
-		// User level access control is required by the server
-		// TODO: Look up Session from Client.Connection.SessionTable where Session.UserCredentials matches
-		// the application-supplied UserCredentials and reuse if found
+		// User level access control is required by the server.
+		// Reuse of an existing session for the same credentials is handled by
+		// Client.SessionSetup, which consults Connection.SessionTable before
+		// reaching this authentication path.
 
 		// Handle authentication based on server capabilities
 		if s.Client.Connection.Server.SecurityMode.SupportsChallengeResponseAuth() {

--- a/network/smb/smb_v10/client/session_reuse_test.go
+++ b/network/smb/smb_v10/client/session_reuse_test.go
@@ -1,0 +1,100 @@
+package client_test
+
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/client"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header/flags"
+	"github.com/TheManticoreProject/Manticore/windows/credentials"
+)
+
+// shareLevelSetupClient returns a client whose scripted transport replies to a
+// share-level session setup with the given UID (share-level completes in one round
+// trip, so a single canned response suffices).
+func shareLevelSetupClient(uid uint16) (*client.Client, *scriptedTransport) {
+	resp := message.NewMessage()
+	resp.Header.SetFlags(flags.FLAGS_REPLY)
+	resp.Header.UID = uid
+	resp.AddCommand(commands.NewSessionSetupAndxResponse())
+	raw, _ := resp.Marshal()
+
+	tr := &scriptedTransport{response: raw}
+	c := &client.Client{
+		Transport:  tr,
+		Connection: &client.Connection{Server: &client.Server{SecurityMode: 0}},
+	}
+	return c, tr
+}
+
+func TestSessionSetupRegistersSession(t *testing.T) {
+	const uid = 0x0801
+	c, _ := shareLevelSetupClient(uid)
+
+	if err := c.SessionSetup(&credentials.Credentials{Username: "alice"}); err != nil {
+		t.Fatalf("SessionSetup: %v", err)
+	}
+	if c.Connection.SessionTable[uid] != c.Session {
+		t.Errorf("session not registered in SessionTable under UID 0x%04x", uid)
+	}
+}
+
+func TestSessionSetupReusesSession(t *testing.T) {
+	const uid = 0x0900
+	c, tr := shareLevelSetupClient(uid)
+
+	creds := &credentials.Credentials{Domain: "CORP", Username: "bob", Password: "pw"}
+	if err := c.SessionSetup(creds); err != nil {
+		t.Fatalf("first SessionSetup: %v", err)
+	}
+	first := c.Session
+	sendsAfterFirst := tr.sendCount
+
+	// A second setup with equal (but distinct-pointer) credentials must reuse the
+	// registered session without another authentication exchange.
+	if err := c.SessionSetup(&credentials.Credentials{Domain: "CORP", Username: "bob", Password: "pw"}); err != nil {
+		t.Fatalf("second SessionSetup: %v", err)
+	}
+	if c.Session != first {
+		t.Error("expected the second SessionSetup to reuse the existing session")
+	}
+	if tr.sendCount != sendsAfterFirst {
+		t.Errorf("expected no additional messages on reuse, sent %d then %d", sendsAfterFirst, tr.sendCount)
+	}
+}
+
+func TestSessionSetupDifferentCredentialsDoesNotReuse(t *testing.T) {
+	const uid = 0x0A00
+	c, tr := shareLevelSetupClient(uid)
+
+	if err := c.SessionSetup(&credentials.Credentials{Username: "alice"}); err != nil {
+		t.Fatalf("first SessionSetup: %v", err)
+	}
+	sendsAfterFirst := tr.sendCount
+
+	// Different credentials must trigger a fresh exchange (more sends).
+	if err := c.SessionSetup(&credentials.Credentials{Username: "carol"}); err != nil {
+		t.Fatalf("second SessionSetup: %v", err)
+	}
+	if tr.sendCount == sendsAfterFirst {
+		t.Error("expected a fresh authentication exchange for different credentials")
+	}
+}
+
+func TestLogoffRemovesSessionFromTable(t *testing.T) {
+	tr := &capturingTransport{response: marshalResponse(t, commands.NewLogoffAndxResponse())}
+	c := newSessionClient(tr)
+	uid := c.Session.SessionUID
+	c.Connection.SessionTable = map[uint16]*client.Session{uid: c.Session}
+
+	if err := c.Logoff(); err != nil {
+		t.Fatalf("Logoff: %v", err)
+	}
+	if _, ok := c.Connection.SessionTable[uid]; ok {
+		t.Errorf("session UID 0x%04x still present in SessionTable after Logoff", uid)
+	}
+	if c.Session != nil {
+		t.Error("expected Client.Session to be nil after Logoff")
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #383`

### Root Cause
`Client.SessionSetup` created and authenticated a session but never inserted it into `Connection.SessionTable`, and the per-session authentication path carried only a `// TODO` about reuse. As a result the multi-session model was non-functional: `SessionTable` was dead state that `Logoff` only ever deleted from, and there was no session reuse.

### Fix Description
`Client.SessionSetup` now:
- consults `Connection.SessionTable` first and, if a registered session's credentials match the requested credentials, reuses it (sets `c.Session`) without performing another authentication exchange;
- otherwise performs the setup and, on success, registers the session in `Connection.SessionTable` keyed by the server-assigned UID (allocating the map if needed).

A new `findSessionByCredentials`/`sameCredentials` pair does the lookup, comparing domain, username, password, and the LM/NT hashes. Anonymous (nil) credentials are never matched, so they always perform a fresh exchange. `Logoff` already removes the UID from the table and clears `c.Session`. The stale reuse `TODO` in `session.go` is replaced with a note pointing to the wrapper.

### How Verified
- **Tests:** `go test ./network/smb/smb_v10/...` passes. New tests: `TestSessionSetupRegistersSession` (the session appears in `SessionTable` under its UID), `TestSessionSetupReusesSession` (a second setup with equal credentials reuses the session and sends no further messages), `TestSessionSetupDifferentCredentialsDoesNotReuse` (different credentials trigger a fresh exchange), `TestLogoffRemovesSessionFromTable`.

### Test Coverage
- **Added:** `TestSessionSetupRegistersSession`, `TestSessionSetupReusesSession`, `TestSessionSetupDifferentCredentialsDoesNotReuse`, `TestLogoffRemovesSessionFromTable` in `network/smb/smb_v10/client/session_reuse_test.go`.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/client/client_functions.go`, `network/smb/smb_v10/client/session.go` (comment), `network/smb/smb_v10/client/session_reuse_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none. A first-time setup behaves as before, then additionally registers the session.

### Risk and Rollout
Low. The non-reuse path is unchanged apart from the added registration; reuse only triggers on an exact credential match against an already-established session on the same connection.
