### PR TITLE
Fix Transaction2 to fragment large requests across TRANSACTION2_SECONDARY (#389)

### DIFF
--- a/network/smb/smb_v10/client/find.go
+++ b/network/smb/smb_v10/client/find.go
@@ -7,12 +7,72 @@ import (
 	"time"
 	"unicode/utf16"
 
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/codes"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/subcommands"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
 )
+
+// trans2MessageOverhead is a conservative reservation, in bytes, for the SMB header
+// and Transaction2 framing (WordCount, parameter words, ByteCount, Name, and
+// alignment padding) when bounding the payload a single message may carry.
+const trans2MessageOverhead = 128
+
+// trans2RequestChunk is one message's worth of a (possibly fragmented) Transaction2
+// request payload: a run of parameter bytes and/or data bytes together with their
+// displacements within the full parameter and data buffers.
+type trans2RequestChunk struct {
+	params                []byte
+	parameterDisplacement int
+	data                  []byte
+	dataDisplacement      int
+}
+
+// planTransaction2Chunks splits the parameter and data buffers into per-message
+// chunks, each carrying at most maxPayload payload bytes. Parameters are emitted
+// before data, and a chunk carries data only once all parameters have been placed
+// (in this or a prior chunk). At least one chunk is always returned, even for an
+// empty payload.
+func planTransaction2Chunks(params, data []byte, maxPayload int) []trans2RequestChunk {
+	if maxPayload < 1 {
+		maxPayload = 1
+	}
+
+	chunks := []trans2RequestChunk{}
+	paramPos, dataPos := 0, 0
+	for {
+		budget := maxPayload
+		chunk := trans2RequestChunk{parameterDisplacement: paramPos, dataDisplacement: dataPos}
+
+		if paramPos < len(params) {
+			n := len(params) - paramPos
+			if n > budget {
+				n = budget
+			}
+			chunk.params = params[paramPos : paramPos+n]
+			paramPos += n
+			budget -= n
+		}
+
+		// Data is only placed once every parameter byte has been emitted.
+		if paramPos == len(params) && budget > 0 && dataPos < len(data) {
+			n := len(data) - dataPos
+			if n > budget {
+				n = budget
+			}
+			chunk.data = data[dataPos : dataPos+n]
+			dataPos += n
+		}
+
+		chunks = append(chunks, chunk)
+		if paramPos >= len(params) && dataPos >= len(data) {
+			break
+		}
+	}
+	return chunks
+}
 
 // smbFindFileBothDirectoryInfo is the TRANS2_FIND information level
 // SMB_FIND_FILE_BOTH_DIRECTORY_INFO (MS-CIFS 2.2.8.1.7).
@@ -122,6 +182,26 @@ func (c *Client) ListEntries(pattern string) ([]Entry, error) {
 // response parameter and data buffers. It does not implement Transaction2Secondary
 // fragmentation, so the request must fit in a single message.
 func (c *Client) trans2(subcommand uint16, trans2Params, trans2Data []byte) ([]byte, []byte, error) {
+	// Bound the data the server may return by the negotiated buffer.
+	maxData := 0xFFFF
+	if c.Connection.Server != nil && c.Connection.Server.MaxBufferSize > 0 {
+		if budget := int(c.Connection.Server.MaxBufferSize) - 512; budget > 0 && budget < maxData {
+			maxData = budget
+		}
+	}
+
+	// Bound the request payload carried by each message by the negotiated buffer,
+	// fragmenting across TRANSACTION2_SECONDARY messages when it does not fit.
+	maxPayload := len(trans2Params) + len(trans2Data)
+	if c.Connection.Server != nil && c.Connection.Server.MaxBufferSize > 0 {
+		if budget := int(c.Connection.Server.MaxBufferSize) - trans2MessageOverhead; budget > 0 && budget < maxPayload {
+			maxPayload = budget
+		}
+	}
+	chunks := planTransaction2Chunks(trans2Params, trans2Data, maxPayload)
+
+	// Build the primary SMB_COM_TRANSACTION2 message carrying the first chunk. The
+	// TotalParameterCount/TotalDataCount fields always advertise the full payload.
 	msg := c.newFileIOMessage(codes.SMB_COM_TRANSACTION2)
 
 	cmd := commands.NewTransaction2Request()
@@ -130,14 +210,6 @@ func (c *Client) trans2(subcommand uint16, trans2Params, trans2Data []byte) ([]b
 	cmd.MaxSetupCount = types.UCHAR(0)
 	cmd.Flags = types.USHORT(0)
 	cmd.Timeout = types.ULONG(0)
-
-	// Bound the data the server may return by the negotiated buffer.
-	maxData := 0xFFFF
-	if c.Connection.Server != nil && c.Connection.Server.MaxBufferSize > 0 {
-		if budget := int(c.Connection.Server.MaxBufferSize) - 512; budget > 0 && budget < maxData {
-			maxData = budget
-		}
-	}
 	cmd.MaxDataCount = types.USHORT(maxData)
 
 	// Compute offsets. The request always carries exactly one setup word, so
@@ -150,42 +222,133 @@ func (c *Client) trans2(subcommand uint16, trans2Params, trans2Data []byte) ([]b
 	parameterOffset := preParams + pad1
 
 	cmd.TotalParameterCount = types.USHORT(len(trans2Params))
-	cmd.ParameterCount = types.USHORT(len(trans2Params))
+	cmd.TotalDataCount = types.USHORT(len(trans2Data))
+	cmd.ParameterCount = types.USHORT(len(chunks[0].params))
 	cmd.ParameterOffset = types.USHORT(parameterOffset)
 	cmd.Pad1 = make([]types.UCHAR, pad1)
-	cmd.Trans2_Parameters = []types.UCHAR(trans2Params)
+	cmd.Trans2_Parameters = []types.UCHAR(chunks[0].params)
 
-	if len(trans2Data) > 0 {
-		afterParams := parameterOffset + len(trans2Params)
+	if len(chunks[0].data) > 0 {
+		afterParams := parameterOffset + len(chunks[0].params)
 		pad2 := (4 - (afterParams % 4)) % 4
-		cmd.TotalDataCount = types.USHORT(len(trans2Data))
-		cmd.DataCount = types.USHORT(len(trans2Data))
+		cmd.DataCount = types.USHORT(len(chunks[0].data))
 		cmd.DataOffset = types.USHORT(afterParams + pad2)
 		cmd.Pad2 = make([]types.UCHAR, pad2)
-		cmd.Trans2_Data = []types.UCHAR(trans2Data)
+		cmd.Trans2_Data = []types.UCHAR(chunks[0].data)
 	}
 
 	msg.AddCommand(cmd)
 
-	response, raw, err := c.sendReceive(msg, "Transaction2")
+	// Fast path: the whole request fits in a single message. This is byte-for-byte
+	// the prior behavior, including request signing and response verification.
+	if len(chunks) == 1 {
+		response, raw, err := c.sendReceive(msg, "Transaction2")
+		if err != nil {
+			return nil, nil, err
+		}
+		if response.Header.Status != 0x00000000 {
+			return nil, nil, fmt.Errorf("Transaction2 (subcommand 0x%04x) failed: 0x%08x", subcommand, response.Header.Status)
+		}
+		return reassembleTrans2(raw, c.recvTrans2Continuation)
+	}
+
+	// Fragmented request. Per-message signing of a multi-message transaction is not
+	// supported; refuse rather than emit a wrongly-signed message.
+	if c.Connection.IsSigningActive {
+		return nil, nil, fmt.Errorf("Transaction2 request too large to send while message signing is active")
+	}
+
+	marshalledPrimary, err := msg.Marshal()
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("failed to marshal Transaction2 primary: %v", err)
+	}
+	fileIODump("Transaction2 request (primary)", marshalledPrimary)
+	if _, err = c.Transport.Send(marshalledPrimary); err != nil {
+		return nil, nil, fmt.Errorf("failed to send Transaction2 primary: %v", err)
+	}
+
+	// Send the remaining chunks as TRANSACTION2_SECONDARY continuation messages.
+	for i := 1; i < len(chunks); i++ {
+		secMsg := c.buildTransaction2Secondary(len(trans2Params), len(trans2Data), chunks[i])
+		marshalledSec, err := secMsg.Marshal()
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to marshal Transaction2 secondary %d: %v", i, err)
+		}
+		fileIODump("Transaction2 request (secondary)", marshalledSec)
+		if _, err = c.Transport.Send(marshalledSec); err != nil {
+			return nil, nil, fmt.Errorf("failed to send Transaction2 secondary %d: %v", i, err)
+		}
+	}
+
+	// The response is read only after every request message has been sent.
+	raw, err := c.Transport.Receive()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to receive Transaction2 response: %v", err)
+	}
+	fileIODump("Transaction2 response", raw)
+
+	response := message.NewMessage()
+	if err = response.Unmarshal(raw); err != nil {
+		return nil, nil, fmt.Errorf("failed to unmarshal Transaction2 response: %v", err)
 	}
 	if response.Header.Status != 0x00000000 {
 		return nil, nil, fmt.Errorf("Transaction2 (subcommand 0x%04x) failed: 0x%08x", subcommand, response.Header.Status)
 	}
+	return reassembleTrans2(raw, c.recvTrans2Continuation)
+}
 
-	// Reassemble the response, which the server may split across several SMB
-	// messages for a large parameter/data payload. The first message has already
-	// been received; further fragments are read directly from the transport.
-	return reassembleTrans2(raw, func() ([]byte, error) {
-		next, err := c.Transport.Receive()
-		if err != nil {
-			return nil, err
-		}
-		fileIODump("Transaction2 response (continuation)", next)
-		return next, nil
-	})
+// recvTrans2Continuation reads one continuation fragment of a Transaction2 response
+// directly from the transport.
+func (c *Client) recvTrans2Continuation() ([]byte, error) {
+	next, err := c.Transport.Receive()
+	if err != nil {
+		return nil, err
+	}
+	fileIODump("Transaction2 response (continuation)", next)
+	return next, nil
+}
+
+// buildTransaction2Secondary builds one SMB_COM_TRANSACTION2_SECONDARY continuation
+// message carrying chunk, advertising the full transaction totals and the chunk's
+// displacements. A SMB_COM_TRANSACTION2_SECONDARY has 9 parameter words and, unlike
+// the primary, no Name field.
+func (c *Client) buildTransaction2Secondary(totalParams, totalData int, chunk trans2RequestChunk) *message.Message {
+	msg := c.newFileIOMessage(codes.SMB_COM_TRANSACTION2_SECONDARY)
+
+	cmd := commands.NewTransaction2SecondaryRequest()
+	cmd.TotalParameterCount = types.USHORT(totalParams)
+	cmd.TotalDataCount = types.USHORT(totalData)
+	cmd.FID = types.USHORT(0xFFFF) // no FID for FIND/info transactions
+
+	const wordCount = 9
+	preParams := header.SMB_HEADER_SIZE + 1 /*WordCount*/ + 2*wordCount + 2 /*ByteCount*/
+
+	// Align the parameter run to a 4-byte boundary. ParameterOffset and Pad1 are set
+	// even when this message carries no parameters, because the decoder derives the
+	// Pad2 length from (DataOffset - ParameterOffset - ParameterCount).
+	pad1 := (4 - (preParams % 4)) % 4
+	parameterOffset := preParams + pad1
+	cmd.ParameterOffset = types.USHORT(parameterOffset)
+	cmd.Pad1 = make([]types.UCHAR, pad1)
+
+	if len(chunk.params) > 0 {
+		cmd.ParameterCount = types.USHORT(len(chunk.params))
+		cmd.ParameterDisplacement = types.USHORT(chunk.parameterDisplacement)
+		cmd.Trans2_Parameters = []types.UCHAR(chunk.params)
+	}
+
+	if len(chunk.data) > 0 {
+		end := parameterOffset + len(chunk.params)
+		pad2 := (4 - (end % 4)) % 4
+		cmd.DataCount = types.USHORT(len(chunk.data))
+		cmd.DataOffset = types.USHORT(end + pad2)
+		cmd.DataDisplacement = types.USHORT(chunk.dataDisplacement)
+		cmd.Pad2 = make([]types.UCHAR, pad2)
+		cmd.Trans2_Data = []types.UCHAR(chunk.data)
+	}
+
+	msg.AddCommand(cmd)
+	return msg
 }
 
 // trans2Fragment holds the decoded contents of a single SMB_COM_TRANSACTION2

--- a/network/smb/smb_v10/client/find_fragment_test.go
+++ b/network/smb/smb_v10/client/find_fragment_test.go
@@ -1,0 +1,171 @@
+package client
+
+import (
+	"bytes"
+	"net"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header/flags"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+)
+
+// recordingTransport records every Send payload and replays a canned response.
+type recordingTransport struct {
+	sent     [][]byte
+	response []byte
+}
+
+func (m *recordingTransport) Connect(ipaddr net.IP, port int) error { return nil }
+func (m *recordingTransport) Close() error                          { return nil }
+func (m *recordingTransport) Send(data []byte) (int, error) {
+	m.sent = append(m.sent, append([]byte(nil), data...))
+	return len(data), nil
+}
+func (m *recordingTransport) Receive() ([]byte, error) { return m.response, nil }
+func (m *recordingTransport) IsConnected() bool        { return true }
+
+func TestPlanTransaction2Chunks(t *testing.T) {
+	// Reassembling the chunk runs by displacement must reproduce the inputs, every
+	// chunk must stay within the payload budget, and data must not appear before all
+	// parameters are placed.
+	cases := []struct {
+		name           string
+		params, data   []byte
+		maxPayload     int
+		wantChunks     int
+	}{
+		{"empty", nil, nil, 16, 1},
+		{"fits in one", bytes.Repeat([]byte{1}, 10), bytes.Repeat([]byte{2}, 10), 64, 1},
+		{"params only split", bytes.Repeat([]byte{3}, 100), nil, 40, 3},
+		{"params then data", bytes.Repeat([]byte{4}, 100), bytes.Repeat([]byte{5}, 300), 64, 7},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			chunks := planTransaction2Chunks(tc.params, tc.data, tc.maxPayload)
+			if len(chunks) != tc.wantChunks {
+				t.Errorf("got %d chunks, want %d", len(chunks), tc.wantChunks)
+			}
+
+			gotParams := make([]byte, 0, len(tc.params))
+			gotData := make([]byte, 0, len(tc.data))
+			for i, ch := range chunks {
+				if len(ch.params)+len(ch.data) > tc.maxPayload {
+					t.Errorf("chunk %d payload %d exceeds budget %d", i, len(ch.params)+len(ch.data), tc.maxPayload)
+				}
+				if ch.parameterDisplacement != len(gotParams) {
+					t.Errorf("chunk %d parameterDisplacement %d, want %d", i, ch.parameterDisplacement, len(gotParams))
+				}
+				if ch.dataDisplacement != len(gotData) {
+					t.Errorf("chunk %d dataDisplacement %d, want %d", i, ch.dataDisplacement, len(gotData))
+				}
+				// Data may only appear once every parameter byte has been placed,
+				// counting this chunk's own parameters.
+				if len(ch.data) > 0 && len(gotParams)+len(ch.params) < len(tc.params) {
+					t.Errorf("chunk %d carries data before all parameters are placed", i)
+				}
+				gotParams = append(gotParams, ch.params...)
+				gotData = append(gotData, ch.data...)
+			}
+			if !bytes.Equal(gotParams, tc.params) {
+				t.Errorf("reassembled params mismatch")
+			}
+			if !bytes.Equal(gotData, tc.data) {
+				t.Errorf("reassembled data mismatch")
+			}
+		})
+	}
+}
+
+func TestTrans2FragmentsLargeRequest(t *testing.T) {
+	params := make([]byte, 100)
+	for i := range params {
+		params[i] = byte(i)
+	}
+	data := make([]byte, 300)
+	for i := range data {
+		data[i] = byte(i ^ 0xAA)
+	}
+
+	// Canned response: a single TRANS2 reply with a small data block (DataOffset 55).
+	respCmd := commands.NewTransaction2Response()
+	respCmd.TotalDataCount = types.USHORT(2)
+	respCmd.DataCount = types.USHORT(2)
+	respCmd.DataOffset = types.USHORT(55)
+	respCmd.Trans2_Data = []types.UCHAR{0xDE, 0xAD}
+	respMsg := message.NewMessage()
+	respMsg.Header.SetFlags(flags.FLAGS_REPLY)
+	respMsg.AddCommand(respCmd)
+	respRaw, err := respMsg.Marshal()
+	if err != nil {
+		t.Fatalf("marshal canned response: %v", err)
+	}
+
+	rec := &recordingTransport{response: respRaw}
+	c := &Client{
+		Transport:  rec,
+		Connection: &Connection{Server: &Server{MaxBufferSize: 192}}, // payload budget = 192-128 = 64
+		Session:    &Session{},
+	}
+
+	if _, _, err := c.trans2(0x0001, params, data); err != nil {
+		t.Fatalf("trans2: %v", err)
+	}
+
+	if len(rec.sent) < 2 {
+		t.Fatalf("expected the request to be fragmented into >= 2 messages, got %d", len(rec.sent))
+	}
+
+	// Reassemble the parameter and data runs from the emitted messages by
+	// displacement and confirm they reproduce the original buffers.
+	gotParams := make([]byte, len(params))
+	gotData := make([]byte, len(data))
+	for i, raw := range rec.sent {
+		msg := message.NewMessage()
+		if err := msg.Unmarshal(raw); err != nil {
+			t.Fatalf("decode sent message %d: %v", i, err)
+		}
+		var p, d []byte
+		var pDisp, dDisp int
+		switch cmd := msg.Command.(type) {
+		case *commands.Transaction2Request:
+			if i != 0 {
+				t.Errorf("message %d is the primary but is not first", i)
+			}
+			if int(cmd.TotalParameterCount) != len(params) || int(cmd.TotalDataCount) != len(data) {
+				t.Errorf("primary totals = (%d,%d), want (%d,%d)", cmd.TotalParameterCount, cmd.TotalDataCount, len(params), len(data))
+			}
+			p, d = []byte(cmd.Trans2_Parameters), []byte(cmd.Trans2_Data)
+			pDisp, dDisp = 0, 0
+		case *commands.Transaction2SecondaryRequest:
+			p, d = []byte(cmd.Trans2_Parameters), []byte(cmd.Trans2_Data)
+			pDisp, dDisp = int(cmd.ParameterDisplacement), int(cmd.DataDisplacement)
+		default:
+			t.Fatalf("message %d has unexpected type %T", i, msg.Command)
+		}
+		copy(gotParams[pDisp:], p)
+		copy(gotData[dDisp:], d)
+	}
+
+	if !bytes.Equal(gotParams, params) {
+		t.Error("reassembled parameters do not match the original")
+	}
+	if !bytes.Equal(gotData, data) {
+		t.Error("reassembled data does not match the original")
+	}
+}
+
+func TestTrans2FragmentationRefusedWhileSigning(t *testing.T) {
+	c := &Client{
+		Transport: &recordingTransport{},
+		Connection: &Connection{
+			Server:          &Server{MaxBufferSize: 192},
+			IsSigningActive: true,
+		},
+		Session: &Session{},
+	}
+	if _, _, err := c.trans2(0x0001, make([]byte, 100), make([]byte, 300)); err == nil {
+		t.Error("expected an error when a fragmented Transaction2 is sent with signing active")
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #389`

### Root Cause
`trans2` built a single `SMB_COM_TRANSACTION2` message carrying the entire parameter and data payload. A transaction whose parameter/data exceeded the negotiated `MaxBufferSize` therefore could not be issued at all — there was no request-side fragmentation (the response-side reassembly already existed).

### Fix Description
`trans2` now plans the request payload into per-message chunks and fragments when needed:
- `planTransaction2Chunks(params, data, maxPayload)` splits the buffers into chunks each ≤ `maxPayload`, emitting all parameter bytes before any data and only carrying data in a chunk once every parameter byte has been placed; it records each run's displacement and always returns at least one chunk.
- The first chunk is sent as the primary `SMB_COM_TRANSACTION2` (advertising the full `TotalParameterCount`/`TotalDataCount`); each remaining chunk is sent as an `SMB_COM_TRANSACTION2_SECONDARY` with the correct `ParameterCount`/`DataCount`, header-relative `ParameterOffset`/`DataOffset`, and `ParameterDisplacement`/`DataDisplacement`. The response is read only after all request messages are sent, then reassembled as before.
- The per-message payload budget is `MaxBufferSize - 128` (a conservative framing reservation); when the payload fits in one message the request is sent **exactly as before** (same single-message path, including signing and response verification).
- Fragmenting while message signing is active is refused with a clear error, since per-message signing of a multi-message transaction is not implemented — this avoids emitting a wrongly-signed message. The common callers (`ListEntries`/`ListDirectory`, the TRANS2 info operations) use small payloads and are unaffected.

### How Verified
- **Tests:** `go test ./network/smb/smb_v10/...` passes. `TestPlanTransaction2Chunks` (table) checks chunk counts, per-chunk budget, displacements, the parameters-before-data rule, and that reassembling the runs reproduces the inputs (empty, single-message, params-only split, and params-then-data cases). `TestTrans2FragmentsLargeRequest` drives `trans2` with a 100-byte parameter and 300-byte data payload and a 192-byte `MaxBufferSize`, then parses every emitted message back (primary + secondaries) and confirms the runs reassemble to the originals and the primary advertises the full totals. `TestTrans2FragmentationRefusedWhileSigning` asserts the signing guard.

### Test Coverage
- **Added:** `TestPlanTransaction2Chunks`, `TestTrans2FragmentsLargeRequest`, `TestTrans2FragmentationRefusedWhileSigning` in `network/smb/smb_v10/client/find_fragment_test.go`.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/client/find.go`, `network/smb/smb_v10/client/find_fragment_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none — a single-message request is emitted byte-for-byte as before.

### Risk and Rollout
Low. The single-message fast path is unchanged; fragmentation only engages when a payload exceeds the buffer, which current callers never do. Signing + fragmentation is explicitly refused rather than mis-signed.
