### PR TITLE
Fix RPC_UNICODE_STRING NDR maximum_count when MaximumLength differs from Length (#485)

### DIFF
--- a/network/dcerpc/dtyp/dtyp_test.go
+++ b/network/dcerpc/dtyp/dtyp_test.go
@@ -56,8 +56,8 @@ func TestRPC_SID_GoldenAndRoundTrip(t *testing.T) {
 	}
 	want := []byte{
 		0x04, 0, 0, 0, // hoisted maximum_count (SubAuthorityCount)
-		0x01,                         // Revision
-		0x04,                         // SubAuthorityCount (derived from slice len)
+		0x01,                               // Revision
+		0x04,                               // SubAuthorityCount (derived from slice len)
 		0x00, 0x00, 0x00, 0x00, 0x00, 0x05, // IdentifierAuthority (6-octet big-endian = 5)
 		0x15, 0, 0, 0, // SubAuthority[0] = 21
 		0x01, 0, 0, 0, // SubAuthority[1] = 1
@@ -100,6 +100,42 @@ func TestRPC_UNICODE_STRING_GoldenAndRoundTrip(t *testing.T) {
 	var out RPC_UNICODE_STRING
 	if err := ndr.Unmarshal(raw, &out); err != nil {
 		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got := out.String(); got != "Hi" {
+		t.Errorf("String: got %q want %q", got, "Hi")
+	}
+}
+
+// TestRPC_UNICODE_STRING_OverAllocated covers the spec-legal case where MaximumLength
+// (buffer capacity in bytes) exceeds Length (valid chars in bytes). Per [MS-DTYP] 2.3.10
+// the wchar array's maximum_count must be MaximumLength/2 and actual_count Length/2,
+// independent of len(Buffer); only the valid Length/2 chars are transmitted.
+func TestRPC_UNICODE_STRING_OverAllocated(t *testing.T) {
+	// "Hi" valid (Length=4), capacity for 5 wchars (MaximumLength=10), buffer carries
+	// the two valid chars plus reserved slots.
+	u := RPC_UNICODE_STRING{Length: 4, MaximumLength: 10, Buffer: []uint16{'H', 'i', 0, 0, 0}}
+	raw, err := ndr.Marshal(&u)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	want := []byte{
+		0x04, 0x00, // Length (bytes)
+		0x0a, 0x00, // MaximumLength (bytes)
+		0x00, 0x00, 0x02, 0x00, // Buffer referent id
+		0x05, 0, 0, 0, // maximum_count = MaximumLength/2 = 5
+		0x00, 0, 0, 0, // offset
+		0x02, 0, 0, 0, // actual_count = Length/2 = 2
+		0x48, 0x00, 0x69, 0x00, // 'H', 'i' — only the valid chars
+	}
+	if !bytes.Equal(raw, want) {
+		t.Errorf("over-allocated RPC_UNICODE_STRING:\n got %x\nwant %x", raw, want)
+	}
+	var out RPC_UNICODE_STRING
+	if err := ndr.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out.Length != 4 || out.MaximumLength != 10 {
+		t.Errorf("counts: got Length=%d MaximumLength=%d want 4/10", out.Length, out.MaximumLength)
 	}
 	if got := out.String(); got != "Hi" {
 		t.Errorf("String: got %q want %q", got, "Hi")

--- a/network/dcerpc/dtyp/rpc_unicode_string.go
+++ b/network/dcerpc/dtyp/rpc_unicode_string.go
@@ -14,13 +14,18 @@ import "unicode/utf16"
 // [string]). Modeling Buffer as a []uint16 tagged "unique,varying" lets the walker emit
 // the referent id inline and the char-counted conformant-varying body deferred, so the
 // buffers of an array of RPC_UNICODE_STRING are correctly emitted after the whole array
-// (see issue #419). Use NewUnicodeString to set the byte counts and buffer together.
+// (see issue #419).
+//
+// The size_is/length_is divisor tags resolve the wchar array's maximum_count to
+// MaximumLength/2 and actual_count to Length/2, which differ from len(Buffer) whenever
+// the buffer is over-allocated (MaximumLength > Length, as a server may advertise). Use
+// NewUnicodeString to set the byte counts and buffer together.
 //
 // Reference: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/94a16bb6-c610-4cb9-8db6-26f15f560061
 type RPC_UNICODE_STRING struct {
-	Length        uint16 // length of the string in bytes, excluding any terminator
-	MaximumLength uint16 // size of Buffer in bytes
-	Buffer        []uint16 `ndr:"unique,varying"`
+	Length        uint16   // length of the string in bytes, excluding any terminator
+	MaximumLength uint16   // size of Buffer in bytes
+	Buffer        []uint16 `ndr:"unique,varying,size_is=MaximumLength/2,length_is=Length/2"`
 }
 
 // NewUnicodeString builds an RPC_UNICODE_STRING from a Go string, encoding it to UTF-16

--- a/network/dcerpc/ndr/marshal.go
+++ b/network/dcerpc/ndr/marshal.go
@@ -119,6 +119,7 @@ func marshalStructFields(e *Encoder, rv reflect.Value, embedded bool, deferred *
 		if tag.skip {
 			continue
 		}
+		resolveSiblingCounts(&tag, rt, rv)
 		if i == retvalIdx {
 			continue // the RPC return value is encoded last, after deferred referents
 		}
@@ -272,7 +273,14 @@ func marshalInlineValue(e *Encoder, fv reflect.Value, tag fieldTag, deferred *[]
 			maxCount = tag.sizeConst
 		}
 		if tag.varying {
-			return marshalConformantVaryingArray(e, fv, maxCount, elementTag(tag))
+			// actual_count is the slice length unless length_is fixes it (e.g.
+			// RPC_UNICODE_STRING's Length/2), in which case only that many leading
+			// elements are the valid, transmitted portion.
+			actualCount := uint32(fv.Len())
+			if tag.lengthConstSet {
+				actualCount = tag.lengthConst
+			}
+			return marshalConformantVaryingArray(e, fv, maxCount, actualCount, elementTag(tag))
 		}
 		return marshalConformantArray(e, fv, maxCount, elementTag(tag))
 	case reflect.Array:
@@ -615,14 +623,53 @@ func countTargets(rt reflect.Type, rv reflect.Value) map[string]uint64 {
 			continue
 		}
 		n := uint64(rv.Field(j).Len())
-		if tag.sizeIs != "" {
+		// A divisor form (size_is(Field/N)) names a field in different units than the
+		// elements — its value is not the element count, so it is resolved separately by
+		// resolveSiblingCounts and must not be overwritten with the slice length here.
+		if tag.sizeIs != "" && tag.sizeDiv == 0 {
 			m[tag.sizeIs] = n
 		}
-		if tag.lengthIs != "" {
+		if tag.lengthIs != "" && tag.lengthDiv == 0 {
 			m[tag.lengthIs] = n
 		}
 	}
 	return m
+}
+
+// resolveSiblingCounts rewrites a field's size_is/length_is divisor form
+// (size_is(Field/N), length_is(Field/N)) into literal maximum_count/actual_count values
+// by reading the named sibling field from rv and dividing by N. This carries count
+// fields expressed in different units than the array elements — notably
+// RPC_UNICODE_STRING, whose Length/MaximumLength are byte counts driving a wchar array
+// ([MS-DTYP] 2.3.10). Plain sibling size_is/length_is (no divisor) are left untouched;
+// their counts are derived from the array length by countTargets.
+func resolveSiblingCounts(tag *fieldTag, rt reflect.Type, rv reflect.Value) {
+	if tag.sizeIs != "" && tag.sizeDiv > 0 {
+		if v, ok := siblingUint(rt, rv, tag.sizeIs); ok {
+			tag.sizeConst = uint32(v / uint64(tag.sizeDiv))
+			tag.sizeConstSet = true
+		}
+	}
+	if tag.lengthIs != "" && tag.lengthDiv > 0 {
+		if v, ok := siblingUint(rt, rv, tag.lengthIs); ok {
+			tag.lengthConst = uint32(v / uint64(tag.lengthDiv))
+			tag.lengthConstSet = true
+		}
+	}
+}
+
+// siblingUint reads the unsigned integer value of the named field of struct value rv,
+// reporting false if there is no such field or it is not an unsigned integer kind.
+func siblingUint(rt reflect.Type, rv reflect.Value, name string) (uint64, bool) {
+	f, ok := rt.FieldByName(name)
+	if !ok || len(f.Index) != 1 {
+		return 0, false
+	}
+	fv := rv.Field(f.Index[0])
+	if !isUintKind(fv.Kind()) {
+		return 0, false
+	}
+	return fv.Uint(), true
 }
 
 // retvalIndex returns the field index tagged `ndr:"retval"` (the RPC return value),
@@ -721,15 +768,19 @@ func unmarshalConformantArray(d *Decoder, slice reflect.Value, elemTag fieldTag)
 // marshalConformantVaryingArray writes a conformant-varying array: maximum_count,
 // offset, actual_count, then the elements, per [MS-RPCE] Conformant Varying Arrays:
 // https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/3acb31b0-b873-4aaf-8503-9727ec40fbec
-// The whole slice is transmitted (offset 0, actual_count == len). maximum_count is the
-// length unless a literal size_is bound was given, in which case the constant is sent
-// while actual_count still reflects the elements actually present.
-func marshalConformantVaryingArray(e *Encoder, slice reflect.Value, maxCount uint32, elemTag fieldTag) error {
+// Only the first actualCount elements are transmitted (offset 0). actualCount is the
+// slice length unless length_is fixed it (RPC_UNICODE_STRING's Length/2), and maxCount
+// is the slice length unless a size_is bound was given, in which case those values are
+// sent while only the valid leading elements follow.
+func marshalConformantVaryingArray(e *Encoder, slice reflect.Value, maxCount, actualCount uint32, elemTag fieldTag) error {
+	if int(actualCount) > slice.Len() {
+		actualCount = uint32(slice.Len())
+	}
 	e.Align(conformantArrayAlignment(slice.Type().Elem()))
-	e.WriteUint32(maxCount)            // maximum_count
-	e.WriteUint32(0)                   // offset
-	e.WriteUint32(uint32(slice.Len())) // actual_count
-	return marshalElements(e, slice, elemTag)
+	e.WriteUint32(maxCount)    // maximum_count
+	e.WriteUint32(0)           // offset
+	e.WriteUint32(actualCount) // actual_count
+	return marshalElements(e, slice.Slice(0, int(actualCount)), elemTag)
 }
 
 // unmarshalConformantVaryingArray reads a conformant-varying array, using the

--- a/network/dcerpc/ndr/types.go
+++ b/network/dcerpc/ndr/types.go
@@ -83,20 +83,24 @@ const (
 
 // fieldTag is the parsed `ndr:"..."` struct tag.
 type fieldTag struct {
-	skip         bool
-	ptr          ptrKind
-	wide         bool    // [string] wide (UTF-16)
-	ascii        bool    // [string] ASCII
-	conformant   bool    // conformant array (size_is)
-	varying      bool    // conformant-varying array (offset + actual_count framing)
-	sizeIs       string  // sibling field naming the maximum element count
-	lengthIs     string  // sibling field naming the actual element count
-	sizeConst    uint32  // literal maximum_count (size_is(<N>)); used when sizeConstSet
-	sizeConstSet bool    // size_is was a numeric literal rather than a sibling field name
-	align        int     // explicit alignment override (0 = default)
-	retval       bool    // RPC return value: encoded after the struct's deferred referents
-	elemPtr      ptrKind // pointer attribute of array elements (`elem=ref|unique|ptr`)
-	pipe         bool    // NDR pipe: a chunked stream ([C706] 14.7), not a normal array
+	skip           bool
+	ptr            ptrKind
+	wide           bool    // [string] wide (UTF-16)
+	ascii          bool    // [string] ASCII
+	conformant     bool    // conformant array (size_is)
+	varying        bool    // conformant-varying array (offset + actual_count framing)
+	sizeIs         string  // sibling field naming the maximum element count
+	lengthIs       string  // sibling field naming the actual element count
+	sizeDiv        int     // divisor applied to the size_is sibling (size_is(Field/N)); 0 = none
+	lengthDiv      int     // divisor applied to the length_is sibling (length_is(Field/N)); 0 = none
+	sizeConst      uint32  // literal maximum_count (size_is(<N>)); used when sizeConstSet
+	sizeConstSet   bool    // size_is was a numeric literal rather than a sibling field name
+	lengthConst    uint32  // literal actual_count (length_is(<N>) or resolved sibling/divisor)
+	lengthConstSet bool    // lengthConst holds a resolved actual_count
+	align          int     // explicit alignment override (0 = default)
+	retval         bool    // RPC return value: encoded after the struct's deferred referents
+	elemPtr        ptrKind // pointer attribute of array elements (`elem=ref|unique|ptr`)
+	pipe           bool    // NDR pipe: a chunked stream ([C706] 14.7), not a normal array
 
 	// Union (discriminated by an inline switch value, [C706] section 14.3.8) tags.
 	isSwitch  bool  // the union discriminant field (`switch`)
@@ -136,19 +140,33 @@ func parseTag(raw string) fieldTag {
 			t.retval = true
 		case strings.HasPrefix(opt, "size_is="):
 			t.conformant = true
-			v := strings.TrimPrefix(opt, "size_is=")
 			// size_is(<constant>) — a literal maximum_count, e.g. [size_is(1000)] in
-			// MS-SAMR. Distinguished from a sibling field name by parsing as a number.
-			if n, err := strconv.ParseUint(v, 10, 32); err == nil {
+			// MS-SAMR. size_is(Field) names a sibling holding the count. size_is(Field/N)
+			// names a sibling whose value is in different units than the elements (e.g.
+			// RPC_UNICODE_STRING's byte counts vs. wchar elements), divided by N.
+			name, div := splitDivisor(strings.TrimPrefix(opt, "size_is="))
+			if div > 0 {
+				t.sizeIs = name
+				t.sizeDiv = div
+			} else if n, err := strconv.ParseUint(name, 10, 32); err == nil {
 				t.sizeConst = uint32(n)
 				t.sizeConstSet = true
 			} else {
-				t.sizeIs = v
+				t.sizeIs = name
 			}
 		case strings.HasPrefix(opt, "length_is="):
 			t.conformant = true
 			t.varying = true
-			t.lengthIs = strings.TrimPrefix(opt, "length_is=")
+			name, div := splitDivisor(strings.TrimPrefix(opt, "length_is="))
+			if div > 0 {
+				t.lengthIs = name
+				t.lengthDiv = div
+			} else if n, err := strconv.ParseUint(name, 10, 32); err == nil {
+				t.lengthConst = uint32(n)
+				t.lengthConstSet = true
+			} else {
+				t.lengthIs = name
+			}
 		case opt == "switch":
 			t.isSwitch = true
 		case opt == "default":
@@ -181,4 +199,19 @@ func parseTag(raw string) fieldTag {
 		}
 	}
 	return t
+}
+
+// splitDivisor parses a "Field/N" size_is/length_is operand into the sibling field name
+// and the divisor N. A value with no "/N" (a plain field name or a literal constant)
+// returns a zero divisor, leaving the caller to interpret it as before.
+func splitDivisor(s string) (string, int) {
+	i := strings.IndexByte(s, '/')
+	if i < 0 {
+		return s, 0
+	}
+	d, err := strconv.Atoi(strings.TrimSpace(s[i+1:]))
+	if err != nil || d <= 0 {
+		return s, 0
+	}
+	return strings.TrimSpace(s[:i]), d
 }


### PR DESCRIPTION
### Linked Issue
`Closes #485`

### Root Cause
The NDR reflection walker can resolve a conformant/varying array's count from a sibling field named by `size_is`/`length_is`, but only when that field holds the element count directly. `RPC_UNICODE_STRING` ([MS-DTYP] 2.3.10) is defined as `[size_is(MaximumLength/2), length_is(Length/2)] WCHAR* Buffer`, where `Length` and `MaximumLength` are **byte** counts — half the wchar element count. The tag grammar had no way to express the `/2` divisor, so `Buffer` carried no `size_is`/`length_is` and the walker fell back to the Go slice length for both `maximum_count` and `actual_count`. That is correct only while `len(Buffer) == Length/2 == MaximumLength/2`; when a server advertises an over-allocated buffer (`MaximumLength > Length`, which the spec explicitly permits), the emitted `maximum_count` is `Length/2` instead of the required `MaximumLength/2`.

### Fix Description
- Extend the `ndr` tag grammar with a divisor form: `size_is(Field/N)` and `length_is(Field/N)` name a sibling field whose value is in different units than the array elements, divided by `N`. This is a new tag form, so existing `size_is`/`length_is` usage (literal bound or plain sibling name) is unchanged.
- On marshal, `resolveSiblingCounts` reads the named sibling and divides, yielding the array's `maximum_count` (from `size_is`) and `actual_count` (from `length_is`); only the valid leading `actual_count` elements are transmitted. `countTargets` skips the divisor form so the byte-count fields keep their own values rather than being overwritten with the element count.
- Tag `RPC_UNICODE_STRING.Buffer` as `size_is=MaximumLength/2,length_is=Length/2`, a one-to-one mapping of the [MS-DTYP] IDL.

Unmarshal is unchanged: a conformant-varying array is self-describing (counts are on the wire), so the decoder already sizes `Buffer` from the wire `actual_count` and reads `Length`/`MaximumLength` as their own fields.

The [MS-DTYP] 2.3.10 IDL was confirmed against the official Microsoft Open Specifications: `typedef struct _RPC_UNICODE_STRING { unsigned short Length; unsigned short MaximumLength; [size_is(MaximumLength/2), length_is(Length/2)] WCHAR* Buffer; }`, with `Length`/`MaximumLength` in bytes (multiples of 2, `MaximumLength >= Length`).

### How Verified
- **Tests:** `go test ./network/dcerpc/...` passes, including the new `TestRPC_UNICODE_STRING_OverAllocated` and the existing `TestRPC_UNICODE_STRING_GoldenAndRoundTrip`, `TestRPC_UNICODE_STRING_Empty`, `TestArrayOfUnicodeStrings`, and `TestArrayOfUnicodeStringPointers` (the #419 array-deferral behavior).
- **Static:** `go build ./...` and `go vet ./network/dcerpc/ndr/ ./network/dcerpc/dtyp/` are clean.
- **Behavior:** marshalling `{Length: 4, MaximumLength: 10, Buffer: ['H','i',0,0,0]}` now emits `maximum_count=5`, `actual_count=2`, and only the two valid wchars, versus `maximum_count=5/actual_count=5` (all five elements) before.

### Test Coverage
- **Added:** `network/dcerpc/dtyp/dtyp_test.go` — `TestRPC_UNICODE_STRING_OverAllocated` asserts the golden wire layout (`maximum_count=MaximumLength/2`, `actual_count=Length/2`, only valid chars sent) and the unmarshal round-trip.

### Scope of Change
- **Files changed:** `network/dcerpc/ndr/types.go`, `network/dcerpc/ndr/marshal.go`, `network/dcerpc/dtyp/rpc_unicode_string.go`, `network/dcerpc/dtyp/dtyp_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Low. The new tag grammar is additive; existing `size_is`/`length_is` resolution and `countTargets` behavior are unchanged for all current call sites, and the only struct that adopts the divisor form is `RPC_UNICODE_STRING`. The canonical `NewUnicodeString` path (where `Length == MaximumLength == len(Buffer)*2`) produces byte-identical output to before.
