### PR TITLE
Implement SMB_COM_NEW_FILE_SIZE reserved-stub message (#472)

### DIFF
--- a/network/smb/smb_v10/message/commands/0.command_casting.go
+++ b/network/smb/smb_v10/message/commands/0.command_casting.go
@@ -126,6 +126,8 @@ func CreateRequestCommand(commandCode codes.CommandCode) (command_interface.Comm
 		return NewWriteRawRequest(), nil
 	case codes.SMB_COM_LOCK_AND_READ:
 		return NewLockAndReadRequest(), nil
+	case codes.SMB_COM_NEW_FILE_SIZE:
+		return NewNewFileSizeRequest(), nil
 	default:
 		return nil, fmt.Errorf("command code not supported: %d", commandCode)
 	}
@@ -250,6 +252,8 @@ func CreateResponseCommand(commandCode codes.CommandCode) (command_interface.Com
 		return NewWriteRawFinal(), nil
 	case codes.SMB_COM_CLOSE_PRINT_FILE:
 		return NewClosePrintFileResponse(), nil
+	case codes.SMB_COM_NEW_FILE_SIZE:
+		return NewNewFileSizeResponse(), nil
 	default:
 		return nil, fmt.Errorf("command code not supported: %d", commandCode)
 	}

--- a/network/smb/smb_v10/message/commands/NewFileSizeRequest.go
+++ b/network/smb/smb_v10/message/commands/NewFileSizeRequest.go
@@ -1,0 +1,117 @@
+package commands
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/andx"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/codes"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/command_interface"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/data"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/parameters"
+)
+
+// NewFileSizeRequest is the request for SMB_COM_NEW_FILE_SIZE (0x30).
+//
+// This command was reserved but never implemented, and its message format was
+// never defined ([MS-CIFS] §2.2.4.44). It carries no parameters and no data; the
+// struct exists so the command code is represented explicitly rather than falling
+// through to a generic "command code not supported" error. Clients SHOULD NOT send
+// it, and servers receiving it SHOULD return STATUS_NOT_IMPLEMENTED.
+//
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/e3b0e8ec-a0f3-48d7-92b9-25715e5ec6c8
+type NewFileSizeRequest struct {
+	command_interface.Command
+}
+
+// NewNewFileSizeRequest creates a new NewFileSizeRequest structure
+//
+// Returns:
+// - A pointer to the new NewFileSizeRequest structure
+func NewNewFileSizeRequest() *NewFileSizeRequest {
+	c := &NewFileSizeRequest{}
+
+	c.Command.SetCommandCode(codes.SMB_COM_NEW_FILE_SIZE)
+
+	return c
+}
+
+// Marshal marshals the NewFileSizeRequest structure into a byte array
+//
+// Returns:
+// - A byte array representing the NewFileSizeRequest structure
+// - An error if the marshaling fails
+func (c *NewFileSizeRequest) Marshal() ([]byte, error) {
+	marshalledCommand := []byte{}
+
+	// Create the Parameters structure if it is nil
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Create the Data structure if it is nil
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
+
+	// In case of AndX, we need to add the parameters to the Parameters structure first
+	if c.IsAndX() {
+		if c.GetAndX() == nil {
+			c.SetAndX(andx.NewAndX())
+			c.GetAndX().AndXCommand = codes.SMB_COM_NO_ANDX_COMMAND
+		}
+
+		for _, parameter := range c.GetAndX().GetParameters() {
+			c.GetParameters().AddWord(parameter)
+		}
+	}
+
+	// Marshalling parameters
+	// This command was never defined: no parameters are sent in this message.
+	marshalledParameters, err := c.GetParameters().Marshal()
+	if err != nil {
+		return nil, err
+	}
+	marshalledCommand = append(marshalledCommand, marshalledParameters...)
+
+	// Marshalling data
+	// This command was never defined: no data is sent in this message.
+	marshalledData, err := c.GetData().Marshal()
+	if err != nil {
+		return nil, err
+	}
+	marshalledCommand = append(marshalledCommand, marshalledData...)
+
+	return marshalledCommand, nil
+}
+
+// Unmarshal unmarshals a byte array into the command structure
+//
+// Parameters:
+// - data: The byte array to unmarshal
+//
+// Returns:
+// - The number of bytes unmarshalled
+// - An error if the unmarshalling fails
+func (c *NewFileSizeRequest) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
+
+	// First unmarshal the two structures
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
+	if err != nil {
+		return 0, err
+	}
+	_ = c.GetParameters().GetBytes()
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
+	if err != nil {
+		return 0, err
+	}
+	_ = c.GetData().GetBytes()
+
+	// This command was never defined: no parameters and no data are sent in this message.
+	return 0, nil
+}

--- a/network/smb/smb_v10/message/commands/NewFileSizeResponse.go
+++ b/network/smb/smb_v10/message/commands/NewFileSizeResponse.go
@@ -1,0 +1,117 @@
+package commands
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/andx"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/codes"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/command_interface"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/data"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/parameters"
+)
+
+// NewFileSizeResponse is the response for SMB_COM_NEW_FILE_SIZE (0x30).
+//
+// This command was reserved but never implemented, and its message format was
+// never defined ([MS-CIFS] §2.2.4.44). It carries no parameters and no data; the
+// struct exists so the command code is represented explicitly rather than falling
+// through to a generic "command code not supported" error. A server receiving the
+// request SHOULD return STATUS_NOT_IMPLEMENTED.
+//
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/e3b0e8ec-a0f3-48d7-92b9-25715e5ec6c8
+type NewFileSizeResponse struct {
+	command_interface.Command
+}
+
+// NewNewFileSizeResponse creates a new NewFileSizeResponse structure
+//
+// Returns:
+// - A pointer to the new NewFileSizeResponse structure
+func NewNewFileSizeResponse() *NewFileSizeResponse {
+	c := &NewFileSizeResponse{}
+
+	c.Command.SetCommandCode(codes.SMB_COM_NEW_FILE_SIZE)
+
+	return c
+}
+
+// Marshal marshals the NewFileSizeResponse structure into a byte array
+//
+// Returns:
+// - A byte array representing the NewFileSizeResponse structure
+// - An error if the marshaling fails
+func (c *NewFileSizeResponse) Marshal() ([]byte, error) {
+	marshalledCommand := []byte{}
+
+	// Create the Parameters structure if it is nil
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Create the Data structure if it is nil
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
+
+	// In case of AndX, we need to add the parameters to the Parameters structure first
+	if c.IsAndX() {
+		if c.GetAndX() == nil {
+			c.SetAndX(andx.NewAndX())
+			c.GetAndX().AndXCommand = codes.SMB_COM_NO_ANDX_COMMAND
+		}
+
+		for _, parameter := range c.GetAndX().GetParameters() {
+			c.GetParameters().AddWord(parameter)
+		}
+	}
+
+	// Marshalling parameters
+	// This command was never defined: no parameters are sent in this message.
+	marshalledParameters, err := c.GetParameters().Marshal()
+	if err != nil {
+		return nil, err
+	}
+	marshalledCommand = append(marshalledCommand, marshalledParameters...)
+
+	// Marshalling data
+	// This command was never defined: no data is sent in this message.
+	marshalledData, err := c.GetData().Marshal()
+	if err != nil {
+		return nil, err
+	}
+	marshalledCommand = append(marshalledCommand, marshalledData...)
+
+	return marshalledCommand, nil
+}
+
+// Unmarshal unmarshals a byte array into the command structure
+//
+// Parameters:
+// - data: The byte array to unmarshal
+//
+// Returns:
+// - The number of bytes unmarshalled
+// - An error if the unmarshalling fails
+func (c *NewFileSizeResponse) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
+
+	// First unmarshal the two structures
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
+	if err != nil {
+		return 0, err
+	}
+	_ = c.GetParameters().GetBytes()
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
+	if err != nil {
+		return 0, err
+	}
+	_ = c.GetData().GetBytes()
+
+	// This command was never defined: no parameters and no data are sent in this message.
+	return 0, nil
+}

--- a/network/smb/smb_v10/message/commands/NewFileSize_test.go
+++ b/network/smb/smb_v10/message/commands/NewFileSize_test.go
@@ -1,0 +1,74 @@
+package commands_test
+
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/codes"
+)
+
+// TestNewFileSizeDispatch verifies that SMB_COM_NEW_FILE_SIZE (0x30) is wired into
+// the command-casting registry for both requests and responses, so the code is
+// represented explicitly instead of reaching the generic "command code not
+// supported" default branch.
+func TestNewFileSizeDispatch(t *testing.T) {
+	req, err := commands.CreateRequestCommand(codes.SMB_COM_NEW_FILE_SIZE)
+	if err != nil {
+		t.Fatalf("CreateRequestCommand(SMB_COM_NEW_FILE_SIZE) returned error: %v", err)
+	}
+	if req == nil {
+		t.Fatal("CreateRequestCommand(SMB_COM_NEW_FILE_SIZE) returned nil command")
+	}
+	if req.GetCommandCode() != codes.SMB_COM_NEW_FILE_SIZE {
+		t.Errorf("request command code: got %v, want %v", req.GetCommandCode(), codes.SMB_COM_NEW_FILE_SIZE)
+	}
+
+	resp, err := commands.CreateResponseCommand(codes.SMB_COM_NEW_FILE_SIZE)
+	if err != nil {
+		t.Fatalf("CreateResponseCommand(SMB_COM_NEW_FILE_SIZE) returned error: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("CreateResponseCommand(SMB_COM_NEW_FILE_SIZE) returned nil command")
+	}
+	if resp.GetCommandCode() != codes.SMB_COM_NEW_FILE_SIZE {
+		t.Errorf("response command code: got %v, want %v", resp.GetCommandCode(), codes.SMB_COM_NEW_FILE_SIZE)
+	}
+}
+
+// TestNewFileSizeEmptyWireFormat verifies that the never-defined SMB_COM_NEW_FILE_SIZE
+// command carries no parameters and no data: Marshal emits only the empty WordCount
+// and ByteCount fields (WordCount=0x00, ByteCount=0x00 0x00), and the bytes round-trip
+// through Unmarshal.
+func TestNewFileSizeEmptyWireFormat(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cmd  interface {
+			Marshal() ([]byte, error)
+			Unmarshal([]byte) (int, error)
+		}
+	}{
+		{"request", commands.NewNewFileSizeRequest()},
+		{"response", commands.NewNewFileSizeResponse()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			marshalled, err := tc.cmd.Marshal()
+			if err != nil {
+				t.Fatalf("Marshal failed: %v", err)
+			}
+			// WordCount (1 byte) = 0x00, then ByteCount (2 bytes) = 0x0000.
+			want := []byte{0x00, 0x00, 0x00}
+			if len(marshalled) != len(want) {
+				t.Fatalf("marshalled length: got %d (% x), want %d (% x)", len(marshalled), marshalled, len(want), want)
+			}
+			for i := range want {
+				if marshalled[i] != want[i] {
+					t.Fatalf("marshalled bytes: got % x, want % x", marshalled, want)
+				}
+			}
+
+			if _, err := tc.cmd.Unmarshal(marshalled); err != nil {
+				t.Fatalf("Unmarshal failed: %v", err)
+			}
+		})
+	}
+}

--- a/network/smb/smb_v10/message/commands/nil_unmarshal_sweep_test.go
+++ b/network/smb/smb_v10/message/commands/nil_unmarshal_sweep_test.go
@@ -32,6 +32,7 @@ var allCommandCodes = []codes.CommandCode{
 	codes.SMB_COM_LOCKING_ANDX,
 	codes.SMB_COM_LOGOFF_ANDX,
 	codes.SMB_COM_NEGOTIATE,
+	codes.SMB_COM_NEW_FILE_SIZE,
 	codes.SMB_COM_NT_CANCEL,
 	codes.SMB_COM_NT_CREATE_ANDX,
 	codes.SMB_COM_NT_RENAME,


### PR DESCRIPTION
### Linked Issue
`Closes #472`

### Root Cause
The command-code constant `SMB_COM_NEW_FILE_SIZE` (`0x30`) was declared in `codes/codes.go` and registered in `CommandCodeNames`, but no message structure or dispatcher wiring was ever added. As a result `CreateRequestCommand()`/`CreateResponseCommand()` fell through to their `default` branch and returned the generic `command code not supported: 48`, with no spec-aware handling of the code.

### Fix Description
Add a documented reserved-stub message for the command and wire it into the casting registry:
- `NewFileSizeRequest` / `NewFileSizeResponse` mirror the existing empty-command pattern (e.g. `ProcessExit`). Per [MS-CIFS] §2.2.4.44 the command was "reserved but not implemented" and "never defined," so it carries no parameters and no data; `Marshal`/`Unmarshal` emit/consume only the empty `WordCount`/`ByteCount` framing. The doc comments record the reserved status and that a server SHOULD return `STATUS_NOT_IMPLEMENTED`.
- `case codes.SMB_COM_NEW_FILE_SIZE` added to both switches in `0.command_casting.go`.
- The code is added to `allCommandCodes` in `nil_unmarshal_sweep_test.go` so the existing nil-safety sweep now covers it.

The MS-CIFS status was confirmed against the official Microsoft Open Specifications page (§2.2.4.44): "This command was reserved but not implemented. It was also never defined. ... servers receiving requests with this command code SHOULD return STATUS_NOT_IMPLEMENTED."

### How Verified
- **Tests:** `go test ./network/smb/smb_v10/message/commands` passes, including the new `TestNewFileSizeDispatch` (the code now resolves to a command instead of an error) and `TestNewFileSizeEmptyWireFormat` (empty `00 / 00 00` framing round-trips), plus the existing `TestUnmarshalOnFreshCommandDoesNotNilPanic` sweep which now exercises the new code.
- **Static:** `go build ./...` and `go vet ./network/smb/smb_v10/message/commands` are clean.

### Test Coverage
- **Added:** `network/smb/smb_v10/message/commands/NewFileSize_test.go` — `TestNewFileSizeDispatch`, `TestNewFileSizeEmptyWireFormat`. The code is also added to the `allCommandCodes` sweep in `nil_unmarshal_sweep_test.go`.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/NewFileSizeRequest.go` (new), `network/smb/smb_v10/message/commands/NewFileSizeResponse.go` (new), `network/smb/smb_v10/message/commands/NewFileSize_test.go` (new), `network/smb/smb_v10/message/commands/0.command_casting.go`, `network/smb/smb_v10/message/commands/nil_unmarshal_sweep_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Low. The change is additive — two new stub types and two dispatcher cases for a previously unhandled code; no existing command path is altered.

### Notes
This command has no defined wire format (never implemented in any dialect), so the stub intentionally carries no parameters or data. Returning `STATUS_NOT_IMPLEMENTED` for a received request is a server-handler concern outside this message-layer package.
