### PR TITLE
Implement SMB_COM_FIND_NOTIFY_CLOSE reserved-stub message (#474)

### DIFF
--- a/network/smb/smb_v10/message/commands/0.command_casting.go
+++ b/network/smb/smb_v10/message/commands/0.command_casting.go
@@ -48,6 +48,8 @@ func CreateRequestCommand(commandCode codes.CommandCode) (command_interface.Comm
 		return NewFindClose2Request(), nil
 	case codes.SMB_COM_FIND_UNIQUE:
 		return NewFindUniqueRequest(), nil
+	case codes.SMB_COM_FIND_NOTIFY_CLOSE:
+		return NewFindNotifyCloseRequest(), nil
 	case codes.SMB_COM_LOGOFF_ANDX:
 		return NewLogoffAndxRequest(), nil
 	case codes.SMB_COM_NT_CANCEL:
@@ -164,6 +166,8 @@ func CreateResponseCommand(commandCode codes.CommandCode) (command_interface.Com
 		return NewFindClose2Response(), nil
 	case codes.SMB_COM_FIND_UNIQUE:
 		return NewFindUniqueResponse(), nil
+	case codes.SMB_COM_FIND_NOTIFY_CLOSE:
+		return NewFindNotifyCloseResponse(), nil
 	case codes.SMB_COM_FLUSH:
 		return NewFlushResponse(), nil
 	case codes.SMB_COM_IOCTL:

--- a/network/smb/smb_v10/message/commands/FindNotifyCloseRequest.go
+++ b/network/smb/smb_v10/message/commands/FindNotifyCloseRequest.go
@@ -1,0 +1,119 @@
+package commands
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/andx"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/codes"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/command_interface"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/data"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/parameters"
+)
+
+// FindNotifyCloseRequest is the request for SMB_COM_FIND_NOTIFY_CLOSE (0x35).
+//
+// Introduced in the LAN Manager 1.2 dialect, this command was reserved but never
+// implemented, so its message format was never defined ([MS-CIFS] §2.2.4.49). It was
+// intended to close a search handle created by a TRANS2_FIND_NOTIFY_FIRST subcommand,
+// which was likewise never implemented. It carries no parameters and no data; the
+// struct exists so the command code is represented explicitly rather than falling
+// through to a generic "command code not supported" error. Clients SHOULD NOT send
+// it, and servers receiving it MUST return STATUS_NOT_IMPLEMENTED.
+//
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/98e3f3b8-adf7-4dfa-a633-91c19f0b83b0
+type FindNotifyCloseRequest struct {
+	command_interface.Command
+}
+
+// NewFindNotifyCloseRequest creates a new FindNotifyCloseRequest structure
+//
+// Returns:
+// - A pointer to the new FindNotifyCloseRequest structure
+func NewFindNotifyCloseRequest() *FindNotifyCloseRequest {
+	c := &FindNotifyCloseRequest{}
+
+	c.Command.SetCommandCode(codes.SMB_COM_FIND_NOTIFY_CLOSE)
+
+	return c
+}
+
+// Marshal marshals the FindNotifyCloseRequest structure into a byte array
+//
+// Returns:
+// - A byte array representing the FindNotifyCloseRequest structure
+// - An error if the marshaling fails
+func (c *FindNotifyCloseRequest) Marshal() ([]byte, error) {
+	marshalledCommand := []byte{}
+
+	// Create the Parameters structure if it is nil
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Create the Data structure if it is nil
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
+
+	// In case of AndX, we need to add the parameters to the Parameters structure first
+	if c.IsAndX() {
+		if c.GetAndX() == nil {
+			c.SetAndX(andx.NewAndX())
+			c.GetAndX().AndXCommand = codes.SMB_COM_NO_ANDX_COMMAND
+		}
+
+		for _, parameter := range c.GetAndX().GetParameters() {
+			c.GetParameters().AddWord(parameter)
+		}
+	}
+
+	// Marshalling parameters
+	// This command was never defined: no parameters are sent in this message.
+	marshalledParameters, err := c.GetParameters().Marshal()
+	if err != nil {
+		return nil, err
+	}
+	marshalledCommand = append(marshalledCommand, marshalledParameters...)
+
+	// Marshalling data
+	// This command was never defined: no data is sent in this message.
+	marshalledData, err := c.GetData().Marshal()
+	if err != nil {
+		return nil, err
+	}
+	marshalledCommand = append(marshalledCommand, marshalledData...)
+
+	return marshalledCommand, nil
+}
+
+// Unmarshal unmarshals a byte array into the command structure
+//
+// Parameters:
+// - data: The byte array to unmarshal
+//
+// Returns:
+// - The number of bytes unmarshalled
+// - An error if the unmarshalling fails
+func (c *FindNotifyCloseRequest) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
+
+	// First unmarshal the two structures
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
+	if err != nil {
+		return 0, err
+	}
+	_ = c.GetParameters().GetBytes()
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
+	if err != nil {
+		return 0, err
+	}
+	_ = c.GetData().GetBytes()
+
+	// This command was never defined: no parameters and no data are sent in this message.
+	return 0, nil
+}

--- a/network/smb/smb_v10/message/commands/FindNotifyCloseResponse.go
+++ b/network/smb/smb_v10/message/commands/FindNotifyCloseResponse.go
@@ -1,0 +1,117 @@
+package commands
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/andx"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/codes"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/command_interface"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/data"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/parameters"
+)
+
+// FindNotifyCloseResponse is the response for SMB_COM_FIND_NOTIFY_CLOSE (0x35).
+//
+// Introduced in the LAN Manager 1.2 dialect, this command was reserved but never
+// implemented, so its message format was never defined ([MS-CIFS] §2.2.4.49). It
+// carries no parameters and no data; the struct exists so the command code is
+// represented explicitly rather than falling through to a generic "command code not
+// supported" error. A server receiving the request MUST return STATUS_NOT_IMPLEMENTED.
+//
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/98e3f3b8-adf7-4dfa-a633-91c19f0b83b0
+type FindNotifyCloseResponse struct {
+	command_interface.Command
+}
+
+// NewFindNotifyCloseResponse creates a new FindNotifyCloseResponse structure
+//
+// Returns:
+// - A pointer to the new FindNotifyCloseResponse structure
+func NewFindNotifyCloseResponse() *FindNotifyCloseResponse {
+	c := &FindNotifyCloseResponse{}
+
+	c.Command.SetCommandCode(codes.SMB_COM_FIND_NOTIFY_CLOSE)
+
+	return c
+}
+
+// Marshal marshals the FindNotifyCloseResponse structure into a byte array
+//
+// Returns:
+// - A byte array representing the FindNotifyCloseResponse structure
+// - An error if the marshaling fails
+func (c *FindNotifyCloseResponse) Marshal() ([]byte, error) {
+	marshalledCommand := []byte{}
+
+	// Create the Parameters structure if it is nil
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Create the Data structure if it is nil
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
+
+	// In case of AndX, we need to add the parameters to the Parameters structure first
+	if c.IsAndX() {
+		if c.GetAndX() == nil {
+			c.SetAndX(andx.NewAndX())
+			c.GetAndX().AndXCommand = codes.SMB_COM_NO_ANDX_COMMAND
+		}
+
+		for _, parameter := range c.GetAndX().GetParameters() {
+			c.GetParameters().AddWord(parameter)
+		}
+	}
+
+	// Marshalling parameters
+	// This command was never defined: no parameters are sent in this message.
+	marshalledParameters, err := c.GetParameters().Marshal()
+	if err != nil {
+		return nil, err
+	}
+	marshalledCommand = append(marshalledCommand, marshalledParameters...)
+
+	// Marshalling data
+	// This command was never defined: no data is sent in this message.
+	marshalledData, err := c.GetData().Marshal()
+	if err != nil {
+		return nil, err
+	}
+	marshalledCommand = append(marshalledCommand, marshalledData...)
+
+	return marshalledCommand, nil
+}
+
+// Unmarshal unmarshals a byte array into the command structure
+//
+// Parameters:
+// - data: The byte array to unmarshal
+//
+// Returns:
+// - The number of bytes unmarshalled
+// - An error if the unmarshalling fails
+func (c *FindNotifyCloseResponse) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
+
+	// First unmarshal the two structures
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
+	if err != nil {
+		return 0, err
+	}
+	_ = c.GetParameters().GetBytes()
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
+	if err != nil {
+		return 0, err
+	}
+	_ = c.GetData().GetBytes()
+
+	// This command was never defined: no parameters and no data are sent in this message.
+	return 0, nil
+}

--- a/network/smb/smb_v10/message/commands/FindNotifyClose_test.go
+++ b/network/smb/smb_v10/message/commands/FindNotifyClose_test.go
@@ -1,0 +1,74 @@
+package commands_test
+
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/codes"
+)
+
+// TestFindNotifyCloseDispatch verifies that SMB_COM_FIND_NOTIFY_CLOSE (0x35) is wired
+// into the command-casting registry for both requests and responses, so the code is
+// represented explicitly instead of reaching the generic "command code not supported"
+// default branch.
+func TestFindNotifyCloseDispatch(t *testing.T) {
+	req, err := commands.CreateRequestCommand(codes.SMB_COM_FIND_NOTIFY_CLOSE)
+	if err != nil {
+		t.Fatalf("CreateRequestCommand(SMB_COM_FIND_NOTIFY_CLOSE) returned error: %v", err)
+	}
+	if req == nil {
+		t.Fatal("CreateRequestCommand(SMB_COM_FIND_NOTIFY_CLOSE) returned nil command")
+	}
+	if req.GetCommandCode() != codes.SMB_COM_FIND_NOTIFY_CLOSE {
+		t.Errorf("request command code: got %v, want %v", req.GetCommandCode(), codes.SMB_COM_FIND_NOTIFY_CLOSE)
+	}
+
+	resp, err := commands.CreateResponseCommand(codes.SMB_COM_FIND_NOTIFY_CLOSE)
+	if err != nil {
+		t.Fatalf("CreateResponseCommand(SMB_COM_FIND_NOTIFY_CLOSE) returned error: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("CreateResponseCommand(SMB_COM_FIND_NOTIFY_CLOSE) returned nil command")
+	}
+	if resp.GetCommandCode() != codes.SMB_COM_FIND_NOTIFY_CLOSE {
+		t.Errorf("response command code: got %v, want %v", resp.GetCommandCode(), codes.SMB_COM_FIND_NOTIFY_CLOSE)
+	}
+}
+
+// TestFindNotifyCloseEmptyWireFormat verifies that the never-defined
+// SMB_COM_FIND_NOTIFY_CLOSE command carries no parameters and no data: Marshal emits
+// only the empty WordCount and ByteCount fields (WordCount=0x00, ByteCount=0x00 0x00),
+// and the bytes round-trip through Unmarshal.
+func TestFindNotifyCloseEmptyWireFormat(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cmd  interface {
+			Marshal() ([]byte, error)
+			Unmarshal([]byte) (int, error)
+		}
+	}{
+		{"request", commands.NewFindNotifyCloseRequest()},
+		{"response", commands.NewFindNotifyCloseResponse()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			marshalled, err := tc.cmd.Marshal()
+			if err != nil {
+				t.Fatalf("Marshal failed: %v", err)
+			}
+			// WordCount (1 byte) = 0x00, then ByteCount (2 bytes) = 0x0000.
+			want := []byte{0x00, 0x00, 0x00}
+			if len(marshalled) != len(want) {
+				t.Fatalf("marshalled length: got %d (% x), want %d (% x)", len(marshalled), marshalled, len(want), want)
+			}
+			for i := range want {
+				if marshalled[i] != want[i] {
+					t.Fatalf("marshalled bytes: got % x, want % x", marshalled, want)
+				}
+			}
+
+			if _, err := tc.cmd.Unmarshal(marshalled); err != nil {
+				t.Fatalf("Unmarshal failed: %v", err)
+			}
+		})
+	}
+}

--- a/network/smb/smb_v10/message/commands/nil_unmarshal_sweep_test.go
+++ b/network/smb/smb_v10/message/commands/nil_unmarshal_sweep_test.go
@@ -24,6 +24,7 @@ var allCommandCodes = []codes.CommandCode{
 	codes.SMB_COM_FIND,
 	codes.SMB_COM_FIND_CLOSE,
 	codes.SMB_COM_FIND_CLOSE2,
+	codes.SMB_COM_FIND_NOTIFY_CLOSE,
 	codes.SMB_COM_FIND_UNIQUE,
 	codes.SMB_COM_FLUSH,
 	codes.SMB_COM_IOCTL,


### PR DESCRIPTION
### Linked Issue
`Closes #474`

### Root Cause
The command-code constant `SMB_COM_FIND_NOTIFY_CLOSE` (`0x35`) was declared in `codes/codes.go` and registered in `CommandCodeNames`, but no message structure or dispatcher wiring was ever added. As a result `CreateRequestCommand()`/`CreateResponseCommand()` fell through to their `default` branch and returned the generic `command code not supported: 53`, with no spec-aware handling of the code.

### Fix Description
Add a documented reserved-stub message for the command and wire it into the casting registry:
- `FindNotifyCloseRequest` / `FindNotifyCloseResponse` mirror the existing empty-command pattern (e.g. `ProcessExit`, and the `NewFileSize` stub added in #472). Per [MS-CIFS] §2.2.4.49 the command was introduced in LAN Manager 1.2 but "reserved but not implemented" and its format was never defined (it was intended to close a search handle from the also-unimplemented TRANS2_FIND_NOTIFY_FIRST), so it carries no parameters and no data; `Marshal`/`Unmarshal` emit/consume only the empty `WordCount`/`ByteCount` framing. The doc comments record the reserved status and that a server MUST return `STATUS_NOT_IMPLEMENTED`.
- `case codes.SMB_COM_FIND_NOTIFY_CLOSE` added to both switches in `0.command_casting.go`.
- The code is added to `allCommandCodes` in `nil_unmarshal_sweep_test.go` so the existing nil-safety sweep now covers it.

The MS-CIFS status was confirmed against the official Microsoft Open Specifications page (§2.2.4.49): "This command was introduced in the LAN Manager 1.2 dialect … and was reserved but not implemented. … servers receiving requests with this command code MUST return STATUS_NOT_IMPLEMENTED (ERRDOS/ERRbadfunc)."

### How Verified
- **Tests:** `go test ./network/smb/smb_v10/message/commands` passes, including the new `TestFindNotifyCloseDispatch` (the code now resolves to a command instead of an error) and `TestFindNotifyCloseEmptyWireFormat` (empty `00 / 00 00` framing round-trips), plus the existing `TestUnmarshalOnFreshCommandDoesNotNilPanic` sweep which now exercises the new code.
- **Static:** `go build ./...` and `go vet ./network/smb/smb_v10/message/commands` are clean.

### Test Coverage
- **Added:** `network/smb/smb_v10/message/commands/FindNotifyClose_test.go` — `TestFindNotifyCloseDispatch`, `TestFindNotifyCloseEmptyWireFormat`. The code is also added to the `allCommandCodes` sweep in `nil_unmarshal_sweep_test.go`.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/FindNotifyCloseRequest.go` (new), `network/smb/smb_v10/message/commands/FindNotifyCloseResponse.go` (new), `network/smb/smb_v10/message/commands/FindNotifyClose_test.go` (new), `network/smb/smb_v10/message/commands/0.command_casting.go`, `network/smb/smb_v10/message/commands/nil_unmarshal_sweep_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Low. The change is additive — two new stub types and two dispatcher cases for a previously unhandled code; no existing command path is altered.

### Notes
This command has no defined wire format (never implemented in any dialect), so the stub intentionally carries no parameters or data. Returning `STATUS_NOT_IMPLEMENTED` for a received request is a server-handler concern outside this message-layer package.
