### PR TITLE
Implement SMB_COM_WRITE_BULK reserved-stub message (#476)

### DIFF
--- a/network/smb/smb_v10/message/commands/0.command_casting.go
+++ b/network/smb/smb_v10/message/commands/0.command_casting.go
@@ -138,6 +138,8 @@ func CreateRequestCommand(commandCode codes.CommandCode) (command_interface.Comm
 		return NewCloseAndTreeDiscRequest(), nil
 	case codes.SMB_COM_READ_BULK:
 		return NewReadBulkRequest(), nil
+	case codes.SMB_COM_WRITE_BULK:
+		return NewWriteBulkRequest(), nil
 	default:
 		return nil, fmt.Errorf("command code not supported: %d", commandCode)
 	}
@@ -274,6 +276,8 @@ func CreateResponseCommand(commandCode codes.CommandCode) (command_interface.Com
 		return NewCloseAndTreeDiscResponse(), nil
 	case codes.SMB_COM_READ_BULK:
 		return NewReadBulkResponse(), nil
+	case codes.SMB_COM_WRITE_BULK:
+		return NewWriteBulkResponse(), nil
 	default:
 		return nil, fmt.Errorf("command code not supported: %d", commandCode)
 	}

--- a/network/smb/smb_v10/message/commands/WriteBulkRequest.go
+++ b/network/smb/smb_v10/message/commands/WriteBulkRequest.go
@@ -1,0 +1,116 @@
+package commands
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/andx"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/codes"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/command_interface"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/data"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/parameters"
+)
+
+// WriteBulkRequest is the request for SMB_COM_WRITE_BULK (0xD9).
+//
+// This command was reserved but never implemented; no formal definition was ever provided (the related SMB_COM_READ_BULK and SMB_COM_WRITE_BULK_DATA were likewise never implemented) ([MS-CIFS] §2.2.4.72). It carries no parameters and no data; the struct
+// exists so the command code is represented explicitly rather than falling through to
+// a generic "command code not supported" error. Clients SHOULD NOT send it, and servers receiving it SHOULD return
+// STATUS_NOT_IMPLEMENTED.
+//
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/a5baa104-0ad0-4088-9d96-848aa59aef3b
+type WriteBulkRequest struct {
+	command_interface.Command
+}
+
+// NewWriteBulkRequest creates a new WriteBulkRequest structure
+//
+// Returns:
+// - A pointer to the new WriteBulkRequest structure
+func NewWriteBulkRequest() *WriteBulkRequest {
+	c := &WriteBulkRequest{}
+
+	c.Command.SetCommandCode(codes.SMB_COM_WRITE_BULK)
+
+	return c
+}
+
+// Marshal marshals the WriteBulkRequest structure into a byte array
+//
+// Returns:
+// - A byte array representing the WriteBulkRequest structure
+// - An error if the marshaling fails
+func (c *WriteBulkRequest) Marshal() ([]byte, error) {
+	marshalledCommand := []byte{}
+
+	// Create the Parameters structure if it is nil
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Create the Data structure if it is nil
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
+
+	// In case of AndX, we need to add the parameters to the Parameters structure first
+	if c.IsAndX() {
+		if c.GetAndX() == nil {
+			c.SetAndX(andx.NewAndX())
+			c.GetAndX().AndXCommand = codes.SMB_COM_NO_ANDX_COMMAND
+		}
+
+		for _, parameter := range c.GetAndX().GetParameters() {
+			c.GetParameters().AddWord(parameter)
+		}
+	}
+
+	// Marshalling parameters
+	// This command was never defined: no parameters are sent in this message.
+	marshalledParameters, err := c.GetParameters().Marshal()
+	if err != nil {
+		return nil, err
+	}
+	marshalledCommand = append(marshalledCommand, marshalledParameters...)
+
+	// Marshalling data
+	// This command was never defined: no data is sent in this message.
+	marshalledData, err := c.GetData().Marshal()
+	if err != nil {
+		return nil, err
+	}
+	marshalledCommand = append(marshalledCommand, marshalledData...)
+
+	return marshalledCommand, nil
+}
+
+// Unmarshal unmarshals a byte array into the command structure
+//
+// Parameters:
+// - data: The byte array to unmarshal
+//
+// Returns:
+// - The number of bytes unmarshalled
+// - An error if the unmarshalling fails
+func (c *WriteBulkRequest) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
+
+	// First unmarshal the two structures
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
+	if err != nil {
+		return 0, err
+	}
+	_ = c.GetParameters().GetBytes()
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
+	if err != nil {
+		return 0, err
+	}
+	_ = c.GetData().GetBytes()
+
+	// This command was never defined: no parameters and no data are sent in this message.
+	return 0, nil
+}

--- a/network/smb/smb_v10/message/commands/WriteBulkResponse.go
+++ b/network/smb/smb_v10/message/commands/WriteBulkResponse.go
@@ -1,0 +1,115 @@
+package commands
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/andx"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/codes"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/command_interface"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/data"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/parameters"
+)
+
+// WriteBulkResponse is the response for SMB_COM_WRITE_BULK (0xD9).
+//
+// This command was reserved but never implemented; no formal definition was ever provided (the related SMB_COM_READ_BULK and SMB_COM_WRITE_BULK_DATA were likewise never implemented) ([MS-CIFS] §2.2.4.72). It carries no parameters and no data; the struct
+// exists so the command code is represented explicitly rather than falling through to
+// a generic "command code not supported" error. A server receiving the request SHOULD return STATUS_NOT_IMPLEMENTED.
+//
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/a5baa104-0ad0-4088-9d96-848aa59aef3b
+type WriteBulkResponse struct {
+	command_interface.Command
+}
+
+// NewWriteBulkResponse creates a new WriteBulkResponse structure
+//
+// Returns:
+// - A pointer to the new WriteBulkResponse structure
+func NewWriteBulkResponse() *WriteBulkResponse {
+	c := &WriteBulkResponse{}
+
+	c.Command.SetCommandCode(codes.SMB_COM_WRITE_BULK)
+
+	return c
+}
+
+// Marshal marshals the WriteBulkResponse structure into a byte array
+//
+// Returns:
+// - A byte array representing the WriteBulkResponse structure
+// - An error if the marshaling fails
+func (c *WriteBulkResponse) Marshal() ([]byte, error) {
+	marshalledCommand := []byte{}
+
+	// Create the Parameters structure if it is nil
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Create the Data structure if it is nil
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
+
+	// In case of AndX, we need to add the parameters to the Parameters structure first
+	if c.IsAndX() {
+		if c.GetAndX() == nil {
+			c.SetAndX(andx.NewAndX())
+			c.GetAndX().AndXCommand = codes.SMB_COM_NO_ANDX_COMMAND
+		}
+
+		for _, parameter := range c.GetAndX().GetParameters() {
+			c.GetParameters().AddWord(parameter)
+		}
+	}
+
+	// Marshalling parameters
+	// This command was never defined: no parameters are sent in this message.
+	marshalledParameters, err := c.GetParameters().Marshal()
+	if err != nil {
+		return nil, err
+	}
+	marshalledCommand = append(marshalledCommand, marshalledParameters...)
+
+	// Marshalling data
+	// This command was never defined: no data is sent in this message.
+	marshalledData, err := c.GetData().Marshal()
+	if err != nil {
+		return nil, err
+	}
+	marshalledCommand = append(marshalledCommand, marshalledData...)
+
+	return marshalledCommand, nil
+}
+
+// Unmarshal unmarshals a byte array into the command structure
+//
+// Parameters:
+// - data: The byte array to unmarshal
+//
+// Returns:
+// - The number of bytes unmarshalled
+// - An error if the unmarshalling fails
+func (c *WriteBulkResponse) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
+
+	// First unmarshal the two structures
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
+	if err != nil {
+		return 0, err
+	}
+	_ = c.GetParameters().GetBytes()
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
+	if err != nil {
+		return 0, err
+	}
+	_ = c.GetData().GetBytes()
+
+	// This command was never defined: no parameters and no data are sent in this message.
+	return 0, nil
+}

--- a/network/smb/smb_v10/message/commands/WriteBulk_test.go
+++ b/network/smb/smb_v10/message/commands/WriteBulk_test.go
@@ -1,0 +1,73 @@
+package commands_test
+
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/codes"
+)
+
+// TestWriteBulkDispatch verifies that SMB_COM_WRITE_BULK (0xD9) is wired into the
+// command-casting registry for both requests and responses, so the code is represented
+// explicitly instead of reaching the generic "command code not supported" default
+// branch.
+func TestWriteBulkDispatch(t *testing.T) {
+	req, err := commands.CreateRequestCommand(codes.SMB_COM_WRITE_BULK)
+	if err != nil {
+		t.Fatalf("CreateRequestCommand(SMB_COM_WRITE_BULK) returned error: %v", err)
+	}
+	if req == nil {
+		t.Fatal("CreateRequestCommand(SMB_COM_WRITE_BULK) returned nil command")
+	}
+	if req.GetCommandCode() != codes.SMB_COM_WRITE_BULK {
+		t.Errorf("request command code: got %v, want %v", req.GetCommandCode(), codes.SMB_COM_WRITE_BULK)
+	}
+
+	resp, err := commands.CreateResponseCommand(codes.SMB_COM_WRITE_BULK)
+	if err != nil {
+		t.Fatalf("CreateResponseCommand(SMB_COM_WRITE_BULK) returned error: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("CreateResponseCommand(SMB_COM_WRITE_BULK) returned nil command")
+	}
+	if resp.GetCommandCode() != codes.SMB_COM_WRITE_BULK {
+		t.Errorf("response command code: got %v, want %v", resp.GetCommandCode(), codes.SMB_COM_WRITE_BULK)
+	}
+}
+
+// TestWriteBulkEmptyWireFormat verifies that the never-defined SMB_COM_WRITE_BULK command carries no
+// parameters and no data: Marshal emits only the empty WordCount and ByteCount fields
+// (WordCount=0x00, ByteCount=0x00 0x00), and the bytes round-trip through Unmarshal.
+func TestWriteBulkEmptyWireFormat(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cmd  interface {
+			Marshal() ([]byte, error)
+			Unmarshal([]byte) (int, error)
+		}
+	}{
+		{"request", commands.NewWriteBulkRequest()},
+		{"response", commands.NewWriteBulkResponse()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			marshalled, err := tc.cmd.Marshal()
+			if err != nil {
+				t.Fatalf("Marshal failed: %v", err)
+			}
+			// WordCount (1 byte) = 0x00, then ByteCount (2 bytes) = 0x0000.
+			want := []byte{0x00, 0x00, 0x00}
+			if len(marshalled) != len(want) {
+				t.Fatalf("marshalled length: got %d (% x), want %d (% x)", len(marshalled), marshalled, len(want), want)
+			}
+			for i := range want {
+				if marshalled[i] != want[i] {
+					t.Fatalf("marshalled bytes: got % x, want % x", marshalled, want)
+				}
+			}
+
+			if _, err := tc.cmd.Unmarshal(marshalled); err != nil {
+				t.Fatalf("Unmarshal failed: %v", err)
+			}
+		})
+	}
+}

--- a/network/smb/smb_v10/message/commands/nil_unmarshal_sweep_test.go
+++ b/network/smb/smb_v10/message/commands/nil_unmarshal_sweep_test.go
@@ -11,6 +11,7 @@ import (
 // allCommandCodes lists every command code handled by the request/response
 // casting registry.
 var allCommandCodes = []codes.CommandCode{
+	codes.SMB_COM_WRITE_BULK,
 	codes.SMB_COM_READ_BULK,
 	codes.SMB_COM_CLOSE_AND_TREE_DISC,
 	codes.SMB_COM_IOCTL_SECONDARY,


### PR DESCRIPTION
### Linked Issue
`Closes #476`

### Root Cause
The command-code constant `SMB_COM_WRITE_BULK` (`0xD9`) was declared in `codes/codes.go` and registered in `CommandCodeNames`, but no message structure or dispatcher wiring was ever added. As a result `CreateRequestCommand()`/`CreateResponseCommand()` fell through to their `default` branch and returned the generic `command code not supported: 217`, with no spec-aware handling of the code.

### Fix Description
Add a documented reserved-stub message for the command and wire it into the casting registry:
- `WriteBulkRequest` / `WriteBulkResponse` mirror the existing empty-command pattern (e.g. `ProcessExit`). This command was reserved but never implemented; no formal definition was ever provided (the related SMB_COM_READ_BULK and SMB_COM_WRITE_BULK_DATA were likewise never implemented) ([MS-CIFS] §2.2.4.72), so it carries no parameters and no data; `Marshal`/`Unmarshal` emit/consume only the empty `WordCount`/`ByteCount` framing. The doc comments record the reserved status and that a server SHOULD return `STATUS_NOT_IMPLEMENTED`.
- `case codes.SMB_COM_WRITE_BULK` added to both switches in `0.command_casting.go`.
- The code is added to `allCommandCodes` in `nil_unmarshal_sweep_test.go` so the existing nil-safety sweep now covers it.

The MS-CIFS status was confirmed against the official Microsoft Open Specifications page (§2.2.4.72).

### How Verified
- **Tests:** `go test ./network/smb/smb_v10/message/commands` passes, including the new `TestWriteBulkDispatch` (the code now resolves to a command instead of an error) and `TestWriteBulkEmptyWireFormat` (empty `00 / 00 00` framing round-trips), plus the existing `TestUnmarshalOnFreshCommandDoesNotNilPanic` sweep which now exercises the new code.
- **Static:** `go build ./...` and `go vet ./network/smb/smb_v10/message/commands` are clean.

### Test Coverage
- **Added:** `network/smb/smb_v10/message/commands/WriteBulk_test.go` — `TestWriteBulkDispatch`, `TestWriteBulkEmptyWireFormat`. The code is also added to the `allCommandCodes` sweep in `nil_unmarshal_sweep_test.go`.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/WriteBulkRequest.go` (new), `network/smb/smb_v10/message/commands/WriteBulkResponse.go` (new), `network/smb/smb_v10/message/commands/WriteBulk_test.go` (new), `network/smb/smb_v10/message/commands/0.command_casting.go`, `network/smb/smb_v10/message/commands/nil_unmarshal_sweep_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Low. The change is additive — two new stub types and two dispatcher cases for a previously unhandled code; no existing command path is altered.

### Notes
This command has no defined wire format (never implemented in any dialect), so the stub intentionally carries no parameters or data. Returning `STATUS_NOT_IMPLEMENTED` for a received request is a server-handler concern outside this message-layer package.
