### PR TITLE
Implement SMB_COM_MOVE obsolete-command stub message (#467)

### DIFF
--- a/network/smb/smb_v10/message/commands/0.command_casting.go
+++ b/network/smb/smb_v10/message/commands/0.command_casting.go
@@ -148,6 +148,8 @@ func CreateRequestCommand(commandCode codes.CommandCode) (command_interface.Comm
 		return NewWriteMpxSecondaryRequest(), nil
 	case codes.SMB_COM_COPY:
 		return NewCopyRequest(), nil
+	case codes.SMB_COM_MOVE:
+		return NewMoveRequest(), nil
 	default:
 		return nil, fmt.Errorf("command code not supported: %d", commandCode)
 	}
@@ -294,6 +296,8 @@ func CreateResponseCommand(commandCode codes.CommandCode) (command_interface.Com
 		return NewWriteMpxSecondaryResponse(), nil
 	case codes.SMB_COM_COPY:
 		return NewCopyResponse(), nil
+	case codes.SMB_COM_MOVE:
+		return NewMoveResponse(), nil
 	default:
 		return nil, fmt.Errorf("command code not supported: %d", commandCode)
 	}

--- a/network/smb/smb_v10/message/commands/MoveRequest.go
+++ b/network/smb/smb_v10/message/commands/MoveRequest.go
@@ -1,0 +1,116 @@
+package commands
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/andx"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/codes"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/command_interface"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/data"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/parameters"
+)
+
+// MoveRequest is the request for SMB_COM_MOVE (0x2A).
+//
+// Introduced in the LAN Manager 1.0 dialect and rendered obsolete in NT LAN Manager, this command was used to move files on the server ([MS-CIFS] §2.2.4.38). MS-CIFS does not define a message format for this obsolete command (its legacy definition appears only in [SMB-LM1X] and [XOPEN-SMB]), so it carries no parameters and no data; the
+// struct exists so the command code is represented explicitly rather than falling
+// through to a generic "command code not supported" error. Clients SHOULD NOT send it, and servers receiving it SHOULD return
+// STATUS_NOT_IMPLEMENTED.
+//
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/817ee280-ffc9-443d-b9f3-475c4c02a4f1
+type MoveRequest struct {
+	command_interface.Command
+}
+
+// NewMoveRequest creates a new MoveRequest structure
+//
+// Returns:
+// - A pointer to the new MoveRequest structure
+func NewMoveRequest() *MoveRequest {
+	c := &MoveRequest{}
+
+	c.Command.SetCommandCode(codes.SMB_COM_MOVE)
+
+	return c
+}
+
+// Marshal marshals the MoveRequest structure into a byte array
+//
+// Returns:
+// - A byte array representing the MoveRequest structure
+// - An error if the marshaling fails
+func (c *MoveRequest) Marshal() ([]byte, error) {
+	marshalledCommand := []byte{}
+
+	// Create the Parameters structure if it is nil
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Create the Data structure if it is nil
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
+
+	// In case of AndX, we need to add the parameters to the Parameters structure first
+	if c.IsAndX() {
+		if c.GetAndX() == nil {
+			c.SetAndX(andx.NewAndX())
+			c.GetAndX().AndXCommand = codes.SMB_COM_NO_ANDX_COMMAND
+		}
+
+		for _, parameter := range c.GetAndX().GetParameters() {
+			c.GetParameters().AddWord(parameter)
+		}
+	}
+
+	// Marshalling parameters
+	// MS-CIFS defines no message format for this obsolete command: no parameters are sent.
+	marshalledParameters, err := c.GetParameters().Marshal()
+	if err != nil {
+		return nil, err
+	}
+	marshalledCommand = append(marshalledCommand, marshalledParameters...)
+
+	// Marshalling data
+	// MS-CIFS defines no message format for this obsolete command: no data is sent.
+	marshalledData, err := c.GetData().Marshal()
+	if err != nil {
+		return nil, err
+	}
+	marshalledCommand = append(marshalledCommand, marshalledData...)
+
+	return marshalledCommand, nil
+}
+
+// Unmarshal unmarshals a byte array into the command structure
+//
+// Parameters:
+// - data: The byte array to unmarshal
+//
+// Returns:
+// - The number of bytes unmarshalled
+// - An error if the unmarshalling fails
+func (c *MoveRequest) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
+
+	// First unmarshal the two structures
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
+	if err != nil {
+		return 0, err
+	}
+	_ = c.GetParameters().GetBytes()
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
+	if err != nil {
+		return 0, err
+	}
+	_ = c.GetData().GetBytes()
+
+	// MS-CIFS defines no message format for this obsolete command: no parameters or data are read.
+	return 0, nil
+}

--- a/network/smb/smb_v10/message/commands/MoveResponse.go
+++ b/network/smb/smb_v10/message/commands/MoveResponse.go
@@ -1,0 +1,115 @@
+package commands
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/andx"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/codes"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/command_interface"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/data"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/parameters"
+)
+
+// MoveResponse is the response for SMB_COM_MOVE (0x2A).
+//
+// Introduced in the LAN Manager 1.0 dialect and rendered obsolete in NT LAN Manager, this command was used to move files on the server ([MS-CIFS] §2.2.4.38). MS-CIFS does not define a message format for this obsolete command (its legacy definition appears only in [SMB-LM1X] and [XOPEN-SMB]), so it carries no parameters and no data; the
+// struct exists so the command code is represented explicitly rather than falling
+// through to a generic "command code not supported" error. A server receiving the request SHOULD return STATUS_NOT_IMPLEMENTED.
+//
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/817ee280-ffc9-443d-b9f3-475c4c02a4f1
+type MoveResponse struct {
+	command_interface.Command
+}
+
+// NewMoveResponse creates a new MoveResponse structure
+//
+// Returns:
+// - A pointer to the new MoveResponse structure
+func NewMoveResponse() *MoveResponse {
+	c := &MoveResponse{}
+
+	c.Command.SetCommandCode(codes.SMB_COM_MOVE)
+
+	return c
+}
+
+// Marshal marshals the MoveResponse structure into a byte array
+//
+// Returns:
+// - A byte array representing the MoveResponse structure
+// - An error if the marshaling fails
+func (c *MoveResponse) Marshal() ([]byte, error) {
+	marshalledCommand := []byte{}
+
+	// Create the Parameters structure if it is nil
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Create the Data structure if it is nil
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
+
+	// In case of AndX, we need to add the parameters to the Parameters structure first
+	if c.IsAndX() {
+		if c.GetAndX() == nil {
+			c.SetAndX(andx.NewAndX())
+			c.GetAndX().AndXCommand = codes.SMB_COM_NO_ANDX_COMMAND
+		}
+
+		for _, parameter := range c.GetAndX().GetParameters() {
+			c.GetParameters().AddWord(parameter)
+		}
+	}
+
+	// Marshalling parameters
+	// MS-CIFS defines no message format for this obsolete command: no parameters are sent.
+	marshalledParameters, err := c.GetParameters().Marshal()
+	if err != nil {
+		return nil, err
+	}
+	marshalledCommand = append(marshalledCommand, marshalledParameters...)
+
+	// Marshalling data
+	// MS-CIFS defines no message format for this obsolete command: no data is sent.
+	marshalledData, err := c.GetData().Marshal()
+	if err != nil {
+		return nil, err
+	}
+	marshalledCommand = append(marshalledCommand, marshalledData...)
+
+	return marshalledCommand, nil
+}
+
+// Unmarshal unmarshals a byte array into the command structure
+//
+// Parameters:
+// - data: The byte array to unmarshal
+//
+// Returns:
+// - The number of bytes unmarshalled
+// - An error if the unmarshalling fails
+func (c *MoveResponse) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
+
+	// First unmarshal the two structures
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
+	if err != nil {
+		return 0, err
+	}
+	_ = c.GetParameters().GetBytes()
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
+	if err != nil {
+		return 0, err
+	}
+	_ = c.GetData().GetBytes()
+
+	// MS-CIFS defines no message format for this obsolete command: no parameters or data are read.
+	return 0, nil
+}

--- a/network/smb/smb_v10/message/commands/Move_test.go
+++ b/network/smb/smb_v10/message/commands/Move_test.go
@@ -1,0 +1,73 @@
+package commands_test
+
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/codes"
+)
+
+// TestMoveDispatch verifies that SMB_COM_MOVE (0x2A) is wired into the
+// command-casting registry for both requests and responses, so the code is represented
+// explicitly instead of reaching the generic "command code not supported" default
+// branch.
+func TestMoveDispatch(t *testing.T) {
+	req, err := commands.CreateRequestCommand(codes.SMB_COM_MOVE)
+	if err != nil {
+		t.Fatalf("CreateRequestCommand(SMB_COM_MOVE) returned error: %v", err)
+	}
+	if req == nil {
+		t.Fatal("CreateRequestCommand(SMB_COM_MOVE) returned nil command")
+	}
+	if req.GetCommandCode() != codes.SMB_COM_MOVE {
+		t.Errorf("request command code: got %v, want %v", req.GetCommandCode(), codes.SMB_COM_MOVE)
+	}
+
+	resp, err := commands.CreateResponseCommand(codes.SMB_COM_MOVE)
+	if err != nil {
+		t.Fatalf("CreateResponseCommand(SMB_COM_MOVE) returned error: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("CreateResponseCommand(SMB_COM_MOVE) returned nil command")
+	}
+	if resp.GetCommandCode() != codes.SMB_COM_MOVE {
+		t.Errorf("response command code: got %v, want %v", resp.GetCommandCode(), codes.SMB_COM_MOVE)
+	}
+}
+
+// TestMoveEmptyWireFormat verifies that the obsolete SMB_COM_MOVE command, for which
+// MS-CIFS defines no message format, carries no parameters and no data: Marshal emits only the empty WordCount and ByteCount fields
+// (WordCount=0x00, ByteCount=0x00 0x00), and the bytes round-trip through Unmarshal.
+func TestMoveEmptyWireFormat(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cmd  interface {
+			Marshal() ([]byte, error)
+			Unmarshal([]byte) (int, error)
+		}
+	}{
+		{"request", commands.NewMoveRequest()},
+		{"response", commands.NewMoveResponse()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			marshalled, err := tc.cmd.Marshal()
+			if err != nil {
+				t.Fatalf("Marshal failed: %v", err)
+			}
+			// WordCount (1 byte) = 0x00, then ByteCount (2 bytes) = 0x0000.
+			want := []byte{0x00, 0x00, 0x00}
+			if len(marshalled) != len(want) {
+				t.Fatalf("marshalled length: got %d (% x), want %d (% x)", len(marshalled), marshalled, len(want), want)
+			}
+			for i := range want {
+				if marshalled[i] != want[i] {
+					t.Fatalf("marshalled bytes: got % x, want % x", marshalled, want)
+				}
+			}
+
+			if _, err := tc.cmd.Unmarshal(marshalled); err != nil {
+				t.Fatalf("Unmarshal failed: %v", err)
+			}
+		})
+	}
+}

--- a/network/smb/smb_v10/message/commands/nil_unmarshal_sweep_test.go
+++ b/network/smb/smb_v10/message/commands/nil_unmarshal_sweep_test.go
@@ -11,6 +11,7 @@ import (
 // allCommandCodes lists every command code handled by the request/response
 // casting registry.
 var allCommandCodes = []codes.CommandCode{
+	codes.SMB_COM_MOVE,
 	codes.SMB_COM_COPY,
 	codes.SMB_COM_WRITE_MPX_SECONDARY,
 	codes.SMB_COM_READ_MPX_SECONDARY,


### PR DESCRIPTION
### Linked Issue
`Closes #467`

### Root Cause
The command-code constant `SMB_COM_MOVE` (`0x2A`) was declared in `codes/codes.go` and registered in `CommandCodeNames`, but no message structure or dispatcher wiring was ever added. As a result `CreateRequestCommand()`/`CreateResponseCommand()` fell through to their `default` branch and returned the generic `command code not supported: 42`, with no spec-aware handling of the code.

### Fix Description
Add a documented obsolete-command stub and wire it into the casting registry so the dispatcher routes `0x2A` to a defined handler instead of failing to recognize it:
- `MoveRequest` / `MoveResponse` mirror the existing empty-command pattern (e.g. `ProcessExit` and the reserved-command stubs added in #470–#477). Introduced in the LAN Manager 1.0 dialect and rendered obsolete in NT LAN Manager, this command was used to move files on the server ([MS-CIFS] §2.2.4.38). MS-CIFS does not define a message format for this obsolete command (its legacy definition appears only in [SMB-LM1X] and [XOPEN-SMB]), so the stub carries no parameters and no data; `Marshal`/`Unmarshal` emit/consume only the empty `WordCount`/`ByteCount` framing. The doc comments record the obsolete status and that a server SHOULD return `STATUS_NOT_IMPLEMENTED`.
- `case codes.SMB_COM_MOVE` added to both switches in `0.command_casting.go`.
- The code is added to `allCommandCodes` in `nil_unmarshal_sweep_test.go` so the existing nil-safety sweep now covers it.

The MS-CIFS status was confirmed against the official Microsoft Open Specifications page (§2.2.4.38): the command is obsolete and MS-CIFS does not reproduce a message format for it; the legacy wire format exists only in the external references it cites.

### How Verified
- **Tests:** `go test ./network/smb/smb_v10/message/commands` passes, including the new `TestMoveDispatch` (the code now resolves to a command instead of an error) and `TestMoveEmptyWireFormat` (empty `00 / 00 00` framing round-trips), plus the existing `TestUnmarshalOnFreshCommandDoesNotNilPanic` sweep which now exercises the new code.
- **Static:** `go build ./...` and `go vet ./network/smb/smb_v10/message/commands` are clean.

### Test Coverage
- **Added:** `network/smb/smb_v10/message/commands/Move_test.go` — `TestMoveDispatch`, `TestMoveEmptyWireFormat`. The code is also added to the `allCommandCodes` sweep in `nil_unmarshal_sweep_test.go`.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/MoveRequest.go` (new), `network/smb/smb_v10/message/commands/MoveResponse.go` (new), `network/smb/smb_v10/message/commands/Move_test.go` (new), `network/smb/smb_v10/message/commands/0.command_casting.go`, `network/smb/smb_v10/message/commands/nil_unmarshal_sweep_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Low. The change is additive — two new stub types and two dispatcher cases for a previously unhandled code; no existing command path is altered.

### Notes
MS-CIFS documents this command as obsolete and does not reproduce its wire format (the legacy definition lives only in the external references MS-CIFS cites, which it does not republish). The stub therefore carries no parameters or data, matching the issue's expected behavior of routing the code to a defined handler. Returning `STATUS_NOT_IMPLEMENTED` for a received request is a server-handler concern outside this message-layer package.
