### PR TITLE
Implement SMB_COM_GET_PRINT_QUEUE obsolete-command stub message (#469)

### DIFF
--- a/network/smb/smb_v10/message/commands/0.command_casting.go
+++ b/network/smb/smb_v10/message/commands/0.command_casting.go
@@ -152,6 +152,8 @@ func CreateRequestCommand(commandCode codes.CommandCode) (command_interface.Comm
 		return NewMoveRequest(), nil
 	case codes.SMB_COM_SECURITY_PACKAGE_ANDX:
 		return NewSecurityPackageAndxRequest(), nil
+	case codes.SMB_COM_GET_PRINT_QUEUE:
+		return NewGetPrintQueueRequest(), nil
 	default:
 		return nil, fmt.Errorf("command code not supported: %d", commandCode)
 	}
@@ -302,6 +304,8 @@ func CreateResponseCommand(commandCode codes.CommandCode) (command_interface.Com
 		return NewMoveResponse(), nil
 	case codes.SMB_COM_SECURITY_PACKAGE_ANDX:
 		return NewSecurityPackageAndxResponse(), nil
+	case codes.SMB_COM_GET_PRINT_QUEUE:
+		return NewGetPrintQueueResponse(), nil
 	default:
 		return nil, fmt.Errorf("command code not supported: %d", commandCode)
 	}

--- a/network/smb/smb_v10/message/commands/GetPrintQueueRequest.go
+++ b/network/smb/smb_v10/message/commands/GetPrintQueueRequest.go
@@ -1,0 +1,116 @@
+package commands
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/andx"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/codes"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/command_interface"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/data"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/parameters"
+)
+
+// GetPrintQueueRequest is the request for SMB_COM_GET_PRINT_QUEUE (0xC3).
+//
+// An original Core Protocol command rendered obsolete in NT LAN Manager, this command was used to list the items in a print queue associated with a TID ([MS-CIFS] §2.2.4.70). MS-CIFS does not define a message format for this obsolete command (its legacy definition appears only in [SMB-CORE]), so it carries no parameters and no data; the
+// struct exists so the command code is represented explicitly rather than falling
+// through to a generic "command code not supported" error. Clients SHOULD NOT send it, and servers receiving it MUST return
+// STATUS_NOT_IMPLEMENTED.
+//
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/8aaa6b27-b144-4cd6-9171-102217b1406d
+type GetPrintQueueRequest struct {
+	command_interface.Command
+}
+
+// NewGetPrintQueueRequest creates a new GetPrintQueueRequest structure
+//
+// Returns:
+// - A pointer to the new GetPrintQueueRequest structure
+func NewGetPrintQueueRequest() *GetPrintQueueRequest {
+	c := &GetPrintQueueRequest{}
+
+	c.Command.SetCommandCode(codes.SMB_COM_GET_PRINT_QUEUE)
+
+	return c
+}
+
+// Marshal marshals the GetPrintQueueRequest structure into a byte array
+//
+// Returns:
+// - A byte array representing the GetPrintQueueRequest structure
+// - An error if the marshaling fails
+func (c *GetPrintQueueRequest) Marshal() ([]byte, error) {
+	marshalledCommand := []byte{}
+
+	// Create the Parameters structure if it is nil
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Create the Data structure if it is nil
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
+
+	// In case of AndX, we need to add the parameters to the Parameters structure first
+	if c.IsAndX() {
+		if c.GetAndX() == nil {
+			c.SetAndX(andx.NewAndX())
+			c.GetAndX().AndXCommand = codes.SMB_COM_NO_ANDX_COMMAND
+		}
+
+		for _, parameter := range c.GetAndX().GetParameters() {
+			c.GetParameters().AddWord(parameter)
+		}
+	}
+
+	// Marshalling parameters
+	// MS-CIFS defines no message format for this obsolete command: no parameters are sent.
+	marshalledParameters, err := c.GetParameters().Marshal()
+	if err != nil {
+		return nil, err
+	}
+	marshalledCommand = append(marshalledCommand, marshalledParameters...)
+
+	// Marshalling data
+	// MS-CIFS defines no message format for this obsolete command: no data is sent.
+	marshalledData, err := c.GetData().Marshal()
+	if err != nil {
+		return nil, err
+	}
+	marshalledCommand = append(marshalledCommand, marshalledData...)
+
+	return marshalledCommand, nil
+}
+
+// Unmarshal unmarshals a byte array into the command structure
+//
+// Parameters:
+// - data: The byte array to unmarshal
+//
+// Returns:
+// - The number of bytes unmarshalled
+// - An error if the unmarshalling fails
+func (c *GetPrintQueueRequest) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
+
+	// First unmarshal the two structures
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
+	if err != nil {
+		return 0, err
+	}
+	_ = c.GetParameters().GetBytes()
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
+	if err != nil {
+		return 0, err
+	}
+	_ = c.GetData().GetBytes()
+
+	// MS-CIFS defines no message format for this obsolete command: no parameters or data are read.
+	return 0, nil
+}

--- a/network/smb/smb_v10/message/commands/GetPrintQueueResponse.go
+++ b/network/smb/smb_v10/message/commands/GetPrintQueueResponse.go
@@ -1,0 +1,115 @@
+package commands
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/andx"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/codes"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/command_interface"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/data"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/parameters"
+)
+
+// GetPrintQueueResponse is the response for SMB_COM_GET_PRINT_QUEUE (0xC3).
+//
+// An original Core Protocol command rendered obsolete in NT LAN Manager, this command was used to list the items in a print queue associated with a TID ([MS-CIFS] §2.2.4.70). MS-CIFS does not define a message format for this obsolete command (its legacy definition appears only in [SMB-CORE]), so it carries no parameters and no data; the
+// struct exists so the command code is represented explicitly rather than falling
+// through to a generic "command code not supported" error. A server receiving the request MUST return STATUS_NOT_IMPLEMENTED.
+//
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/8aaa6b27-b144-4cd6-9171-102217b1406d
+type GetPrintQueueResponse struct {
+	command_interface.Command
+}
+
+// NewGetPrintQueueResponse creates a new GetPrintQueueResponse structure
+//
+// Returns:
+// - A pointer to the new GetPrintQueueResponse structure
+func NewGetPrintQueueResponse() *GetPrintQueueResponse {
+	c := &GetPrintQueueResponse{}
+
+	c.Command.SetCommandCode(codes.SMB_COM_GET_PRINT_QUEUE)
+
+	return c
+}
+
+// Marshal marshals the GetPrintQueueResponse structure into a byte array
+//
+// Returns:
+// - A byte array representing the GetPrintQueueResponse structure
+// - An error if the marshaling fails
+func (c *GetPrintQueueResponse) Marshal() ([]byte, error) {
+	marshalledCommand := []byte{}
+
+	// Create the Parameters structure if it is nil
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Create the Data structure if it is nil
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
+
+	// In case of AndX, we need to add the parameters to the Parameters structure first
+	if c.IsAndX() {
+		if c.GetAndX() == nil {
+			c.SetAndX(andx.NewAndX())
+			c.GetAndX().AndXCommand = codes.SMB_COM_NO_ANDX_COMMAND
+		}
+
+		for _, parameter := range c.GetAndX().GetParameters() {
+			c.GetParameters().AddWord(parameter)
+		}
+	}
+
+	// Marshalling parameters
+	// MS-CIFS defines no message format for this obsolete command: no parameters are sent.
+	marshalledParameters, err := c.GetParameters().Marshal()
+	if err != nil {
+		return nil, err
+	}
+	marshalledCommand = append(marshalledCommand, marshalledParameters...)
+
+	// Marshalling data
+	// MS-CIFS defines no message format for this obsolete command: no data is sent.
+	marshalledData, err := c.GetData().Marshal()
+	if err != nil {
+		return nil, err
+	}
+	marshalledCommand = append(marshalledCommand, marshalledData...)
+
+	return marshalledCommand, nil
+}
+
+// Unmarshal unmarshals a byte array into the command structure
+//
+// Parameters:
+// - data: The byte array to unmarshal
+//
+// Returns:
+// - The number of bytes unmarshalled
+// - An error if the unmarshalling fails
+func (c *GetPrintQueueResponse) Unmarshal(rawData []byte) (int, error) {
+	// Initialize the Parameters structure if it is nil to avoid a nil
+	// pointer dereference when Unmarshal is called on a freshly constructed value.
+	if c.GetParameters() == nil {
+		c.SetParameters(parameters.NewParameters())
+	}
+	// Initialize the Data structure if it is nil for the same reason.
+	if c.GetData() == nil {
+		c.SetData(data.NewData())
+	}
+
+	// First unmarshal the two structures
+	bytesRead, err := c.GetParameters().Unmarshal(rawData)
+	if err != nil {
+		return 0, err
+	}
+	_ = c.GetParameters().GetBytes()
+	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
+	if err != nil {
+		return 0, err
+	}
+	_ = c.GetData().GetBytes()
+
+	// MS-CIFS defines no message format for this obsolete command: no parameters or data are read.
+	return 0, nil
+}

--- a/network/smb/smb_v10/message/commands/GetPrintQueue_test.go
+++ b/network/smb/smb_v10/message/commands/GetPrintQueue_test.go
@@ -1,0 +1,73 @@
+package commands_test
+
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/codes"
+)
+
+// TestGetPrintQueueDispatch verifies that SMB_COM_GET_PRINT_QUEUE (0xC3) is wired into the
+// command-casting registry for both requests and responses, so the code is represented
+// explicitly instead of reaching the generic "command code not supported" default
+// branch.
+func TestGetPrintQueueDispatch(t *testing.T) {
+	req, err := commands.CreateRequestCommand(codes.SMB_COM_GET_PRINT_QUEUE)
+	if err != nil {
+		t.Fatalf("CreateRequestCommand(SMB_COM_GET_PRINT_QUEUE) returned error: %v", err)
+	}
+	if req == nil {
+		t.Fatal("CreateRequestCommand(SMB_COM_GET_PRINT_QUEUE) returned nil command")
+	}
+	if req.GetCommandCode() != codes.SMB_COM_GET_PRINT_QUEUE {
+		t.Errorf("request command code: got %v, want %v", req.GetCommandCode(), codes.SMB_COM_GET_PRINT_QUEUE)
+	}
+
+	resp, err := commands.CreateResponseCommand(codes.SMB_COM_GET_PRINT_QUEUE)
+	if err != nil {
+		t.Fatalf("CreateResponseCommand(SMB_COM_GET_PRINT_QUEUE) returned error: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("CreateResponseCommand(SMB_COM_GET_PRINT_QUEUE) returned nil command")
+	}
+	if resp.GetCommandCode() != codes.SMB_COM_GET_PRINT_QUEUE {
+		t.Errorf("response command code: got %v, want %v", resp.GetCommandCode(), codes.SMB_COM_GET_PRINT_QUEUE)
+	}
+}
+
+// TestGetPrintQueueEmptyWireFormat verifies that the obsolete SMB_COM_GET_PRINT_QUEUE command, for which
+// MS-CIFS defines no message format, carries no parameters and no data: Marshal emits only the empty WordCount and ByteCount fields
+// (WordCount=0x00, ByteCount=0x00 0x00), and the bytes round-trip through Unmarshal.
+func TestGetPrintQueueEmptyWireFormat(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cmd  interface {
+			Marshal() ([]byte, error)
+			Unmarshal([]byte) (int, error)
+		}
+	}{
+		{"request", commands.NewGetPrintQueueRequest()},
+		{"response", commands.NewGetPrintQueueResponse()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			marshalled, err := tc.cmd.Marshal()
+			if err != nil {
+				t.Fatalf("Marshal failed: %v", err)
+			}
+			// WordCount (1 byte) = 0x00, then ByteCount (2 bytes) = 0x0000.
+			want := []byte{0x00, 0x00, 0x00}
+			if len(marshalled) != len(want) {
+				t.Fatalf("marshalled length: got %d (% x), want %d (% x)", len(marshalled), marshalled, len(want), want)
+			}
+			for i := range want {
+				if marshalled[i] != want[i] {
+					t.Fatalf("marshalled bytes: got % x, want % x", marshalled, want)
+				}
+			}
+
+			if _, err := tc.cmd.Unmarshal(marshalled); err != nil {
+				t.Fatalf("Unmarshal failed: %v", err)
+			}
+		})
+	}
+}

--- a/network/smb/smb_v10/message/commands/nil_unmarshal_sweep_test.go
+++ b/network/smb/smb_v10/message/commands/nil_unmarshal_sweep_test.go
@@ -11,6 +11,7 @@ import (
 // allCommandCodes lists every command code handled by the request/response
 // casting registry.
 var allCommandCodes = []codes.CommandCode{
+	codes.SMB_COM_GET_PRINT_QUEUE,
 	codes.SMB_COM_SECURITY_PACKAGE_ANDX,
 	codes.SMB_COM_MOVE,
 	codes.SMB_COM_COPY,


### PR DESCRIPTION
### Linked Issue
`Closes #469`

### Root Cause
The command-code constant `SMB_COM_GET_PRINT_QUEUE` (`0xC3`) was declared in `codes/codes.go` and registered in `CommandCodeNames`, but no message structure or dispatcher wiring was ever added. As a result `CreateRequestCommand()`/`CreateResponseCommand()` fell through to their `default` branch and returned the generic `command code not supported: 195`, with no spec-aware handling of the code.

### Fix Description
Add a documented obsolete-command stub and wire it into the casting registry so the dispatcher routes `0xC3` to a defined handler instead of failing to recognize it:
- `GetPrintQueueRequest` / `GetPrintQueueResponse` mirror the existing empty-command pattern (e.g. `ProcessExit` and the reserved-command stubs added in #470–#477). An original Core Protocol command rendered obsolete in NT LAN Manager, this command was used to list the items in a print queue associated with a TID ([MS-CIFS] §2.2.4.70). MS-CIFS does not define a message format for this obsolete command (its legacy definition appears only in [SMB-CORE]), so the stub carries no parameters and no data; `Marshal`/`Unmarshal` emit/consume only the empty `WordCount`/`ByteCount` framing. The doc comments record the obsolete status and that a server MUST return `STATUS_NOT_IMPLEMENTED`.
- `case codes.SMB_COM_GET_PRINT_QUEUE` added to both switches in `0.command_casting.go`.
- The code is added to `allCommandCodes` in `nil_unmarshal_sweep_test.go` so the existing nil-safety sweep now covers it.

The MS-CIFS status was confirmed against the official Microsoft Open Specifications page (§2.2.4.70): the command is obsolete and MS-CIFS does not reproduce a message format for it; the legacy wire format exists only in the external references it cites.

### How Verified
- **Tests:** `go test ./network/smb/smb_v10/message/commands` passes, including the new `TestGetPrintQueueDispatch` (the code now resolves to a command instead of an error) and `TestGetPrintQueueEmptyWireFormat` (empty `00 / 00 00` framing round-trips), plus the existing `TestUnmarshalOnFreshCommandDoesNotNilPanic` sweep which now exercises the new code.
- **Static:** `go build ./...` and `go vet ./network/smb/smb_v10/message/commands` are clean.

### Test Coverage
- **Added:** `network/smb/smb_v10/message/commands/GetPrintQueue_test.go` — `TestGetPrintQueueDispatch`, `TestGetPrintQueueEmptyWireFormat`. The code is also added to the `allCommandCodes` sweep in `nil_unmarshal_sweep_test.go`.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/GetPrintQueueRequest.go` (new), `network/smb/smb_v10/message/commands/GetPrintQueueResponse.go` (new), `network/smb/smb_v10/message/commands/GetPrintQueue_test.go` (new), `network/smb/smb_v10/message/commands/0.command_casting.go`, `network/smb/smb_v10/message/commands/nil_unmarshal_sweep_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Low. The change is additive — two new stub types and two dispatcher cases for a previously unhandled code; no existing command path is altered.

### Notes
MS-CIFS documents this command as obsolete and does not reproduce its wire format (the legacy definition lives only in the external references MS-CIFS cites, which it does not republish). The stub therefore carries no parameters or data, matching the issue's expected behavior of routing the code to a defined handler. Returning `STATUS_NOT_IMPLEMENTED` for a received request is a server-handler concern outside this message-layer package.
