### PR TITLE
Implement NT_CREATE_ANDX extended response (#478)

### DIFF
--- a/network/smb/smb_v10/message/commands/NtCreateAndxResponse.go
+++ b/network/smb/smb_v10/message/commands/NtCreateAndxResponse.go
@@ -65,6 +65,37 @@ type NtCreateAndxResponse struct {
 	// Directory (1 byte): If the returned FID represents a directory, the server MUST set this value to a nonzero value (0x01 is commonly used).
 	// If the FID is not a directory, the server MUST set this value to 0x00 (FALSE).
 	Directory types.UCHAR
+
+	// Extended selects the MS-SMB extended response form ([MS-SMB] section 2.2.4.9.2),
+	// returned when the client set NT_CREATE_REQUEST_EXTENDED_RESPONSE in the request.
+	// When false, the base CIFS layout (WordCount 0x22) is produced and the fields below
+	// are absent; when true, the four extended fields below are appended.
+	//
+	// Note: [MS-SMB] says the extended response WordCount field SHOULD be 0x2A, but the
+	// extended Words block actually occupies 50 16-bit words (the four extra fields add
+	// 32 octets to the 68-octet base). This implementation emits the self-consistent
+	// WordCount (the parameters layer requires WordCount to equal the number of words),
+	// so the message round-trips correctly rather than reproducing the spec's fixed 0x2A.
+	Extended bool
+
+	// VolumeGUID (16 bytes): A GUID that uniquely identifies the volume on which the file
+	// resides, or all-zero if the file system does not support volume GUIDs. Present only
+	// in the extended response.
+	VolumeGUID [16]byte
+
+	// FileId (8 bytes): A 64-bit opaque value that uniquely identifies the file on the
+	// volume, or zero if the file system does not support unique file IDs. Present only in
+	// the extended response.
+	FileId uint64
+
+	// MaximalAccessRights (4 bytes): The maximal access rights (ACCESS_MASK) the opening
+	// user has been granted for this open. Present only in the extended response.
+	MaximalAccessRights types.ULONG
+
+	// GuestMaximalAccessRights (4 bytes): The maximal access rights (ACCESS_MASK) the guest
+	// account has for this file, or zero if guest accounts are unsupported. Present only in
+	// the extended response.
+	GuestMaximalAccessRights types.ULONG
 }
 
 // NewNtCreateAndxResponse creates a new NtCreateAndxResponse structure
@@ -206,6 +237,28 @@ func (c *NtCreateAndxResponse) Marshal() ([]byte, error) {
 
 	// Marshalling parameter Directory
 	rawParametersContent = append(rawParametersContent, types.UCHAR(c.Directory))
+
+	// MS-SMB extended response fields ([MS-SMB] section 2.2.4.9.2), appended only when the
+	// extended response form was selected.
+	if c.Extended {
+		// VolumeGUID (16 bytes): transmitted verbatim.
+		rawParametersContent = append(rawParametersContent, c.VolumeGUID[:]...)
+
+		// FileId (8 bytes)
+		buf8 = make([]byte, 8)
+		binary.LittleEndian.PutUint64(buf8, c.FileId)
+		rawParametersContent = append(rawParametersContent, buf8...)
+
+		// MaximalAccessRights (4 bytes, ACCESS_MASK)
+		buf4 = make([]byte, 4)
+		binary.LittleEndian.PutUint32(buf4, uint32(c.MaximalAccessRights))
+		rawParametersContent = append(rawParametersContent, buf4...)
+
+		// GuestMaximalAccessRights (4 bytes, ACCESS_MASK)
+		buf4 = make([]byte, 4)
+		binary.LittleEndian.PutUint32(buf4, uint32(c.GuestMaximalAccessRights))
+		rawParametersContent = append(rawParametersContent, buf4...)
+	}
 
 	// Marshalling parameters
 	c.GetParameters().AddWordsFromBytesStream(rawParametersContent)
@@ -374,6 +427,25 @@ func (c *NtCreateAndxResponse) Unmarshal(rawData []byte) (int, error) {
 	}
 	c.Directory = types.UCHAR(rawParametersContent[offset])
 	offset++
+
+	// MS-SMB extended response ([MS-SMB] section 2.2.4.9.2): if 32 more parameter octets
+	// follow Directory, this is the extended form carrying VolumeGUID (16), FileId (8),
+	// MaximalAccessRights (4), and GuestMaximalAccessRights (4).
+	if len(rawParametersContent) >= offset+32 {
+		c.Extended = true
+
+		copy(c.VolumeGUID[:], rawParametersContent[offset:offset+16])
+		offset += 16
+
+		c.FileId = binary.LittleEndian.Uint64(rawParametersContent[offset : offset+8])
+		offset += 8
+
+		c.MaximalAccessRights = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
+		offset += 4
+
+		c.GuestMaximalAccessRights = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
+		offset += 4
+	}
 
 	// Then unmarshal the data
 	offset = 0

--- a/network/smb/smb_v10/message/commands/NtCreateAndxResponse_test.go
+++ b/network/smb/smb_v10/message/commands/NtCreateAndxResponse_test.go
@@ -1,0 +1,101 @@
+package commands_test
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+)
+
+// TestNtCreateAndxResponseBaseWordCount verifies the base CIFS response still marshals
+// with WordCount 0x22 (34 words) and that the extended fields are absent.
+func TestNtCreateAndxResponseBaseWordCount(t *testing.T) {
+	resp := commands.NewNtCreateAndxResponse()
+	resp.FID = types.USHORT(0x4321)
+
+	marshalled, err := resp.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+	if marshalled[0] != 0x22 {
+		t.Errorf("base WordCount: got 0x%02x, want 0x22", marshalled[0])
+	}
+
+	var out commands.NtCreateAndxResponse
+	if _, err := out.Unmarshal(marshalled); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if out.Extended {
+		t.Errorf("base response decoded as Extended")
+	}
+	if out.FID != 0x4321 {
+		t.Errorf("FID round trip: got 0x%04x, want 0x4321", out.FID)
+	}
+}
+
+// TestNtCreateAndxResponseExtended verifies the MS-SMB extended response form: the four
+// extended fields are appended in order (VolumeGUID, FileId, MaximalAccessRights,
+// GuestMaximalAccessRights), WordCount becomes 0x32 (50 words, self-consistent with the
+// 100-octet Words block), and the message round-trips.
+func TestNtCreateAndxResponseExtended(t *testing.T) {
+	resp := commands.NewNtCreateAndxResponse()
+	resp.FID = types.USHORT(0x4321)
+	resp.Extended = true
+	resp.VolumeGUID = [16]byte{0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f}
+	resp.FileId = 0x1122334455667788
+	resp.MaximalAccessRights = types.ULONG(0x001F01FF)
+	resp.GuestMaximalAccessRights = types.ULONG(0x00120089)
+
+	marshalled, err := resp.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	// WordCount = 50 words (0x32); Words block = 100 octets; ByteCount = 2 octets.
+	if marshalled[0] != 0x32 {
+		t.Errorf("extended WordCount: got 0x%02x, want 0x32", marshalled[0])
+	}
+	if len(marshalled) != 1+100+2 {
+		t.Fatalf("extended length: got %d, want %d", len(marshalled), 1+100+2)
+	}
+
+	// The 32 extended octets are the tail of the Words block (octets [69:101] of the
+	// message: 1 WordCount + 68 base + 32 extended).
+	extended := marshalled[1+68 : 1+100]
+	want := []byte{}
+	want = append(want, resp.VolumeGUID[:]...)
+	b8 := make([]byte, 8)
+	binary.LittleEndian.PutUint64(b8, resp.FileId)
+	want = append(want, b8...)
+	b4 := make([]byte, 4)
+	binary.LittleEndian.PutUint32(b4, uint32(resp.MaximalAccessRights))
+	want = append(want, b4...)
+	b4 = make([]byte, 4)
+	binary.LittleEndian.PutUint32(b4, uint32(resp.GuestMaximalAccessRights))
+	want = append(want, b4...)
+	if !bytes.Equal(extended, want) {
+		t.Errorf("extended fields:\n got % x\nwant % x", extended, want)
+	}
+
+	var out commands.NtCreateAndxResponse
+	if _, err := out.Unmarshal(marshalled); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if !out.Extended {
+		t.Fatalf("extended response not decoded as Extended")
+	}
+	if out.VolumeGUID != resp.VolumeGUID {
+		t.Errorf("VolumeGUID round trip: got % x, want % x", out.VolumeGUID, resp.VolumeGUID)
+	}
+	if out.FileId != resp.FileId {
+		t.Errorf("FileId round trip: got 0x%016x, want 0x%016x", out.FileId, resp.FileId)
+	}
+	if out.MaximalAccessRights != resp.MaximalAccessRights {
+		t.Errorf("MaximalAccessRights round trip: got 0x%08x, want 0x%08x", out.MaximalAccessRights, resp.MaximalAccessRights)
+	}
+	if out.GuestMaximalAccessRights != resp.GuestMaximalAccessRights {
+		t.Errorf("GuestMaximalAccessRights round trip: got 0x%08x, want 0x%08x", out.GuestMaximalAccessRights, resp.GuestMaximalAccessRights)
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #478`

### Root Cause
`NtCreateAndxResponse` implemented only the base CIFS `SMB_COM_NT_CREATE_ANDX` response (WordCount 0x22). The MS-SMB extended response form ([MS-SMB] §2.2.4.9.2), returned when the client sets `NT_CREATE_REQUEST_EXTENDED_RESPONSE`, was never added, so the `VolumeGUID`, `FileId`, `MaximalAccessRights`, and `GuestMaximalAccessRights` fields could neither be produced nor parsed.

### Fix Description
Add the four extended fields to `NtCreateAndxResponse`, gated by a new `Extended bool` selector:
- `VolumeGUID [16]byte`, `FileId uint64`, `MaximalAccessRights`/`GuestMaximalAccessRights` (`types.ULONG`, ACCESS_MASK).
- `Marshal` appends the four fields (in spec order) after `Directory` only when `Extended` is set; the base layout is unchanged when it is not.
- `Unmarshal` detects the extended form by the presence of 32 additional parameter octets after `Directory`, sets `Extended`, and decodes the fields.

The field sizes and order were taken verbatim from the [MS-SMB] §2.2.4.9.2 IDL (`GUID VolumeGUID; ULONGLONG FileId; ACCESS_MASK MaximalAccessRights; ACCESS_MASK GuestMaximalAccessRights`).

**WordCount note:** [MS-SMB] states the extended `WordCount` field SHOULD be `0x2A`, but the extended `Words` block actually occupies 50 16-bit words (the four extra fields add 32 octets to the 68-octet base). The `parameters` layer requires `WordCount` to equal the number of words, so this implementation emits the self-consistent value (`0x32`) and the message round-trips correctly; the spec's fixed `0x2A` is documented in a code comment.

### How Verified
- **Tests:** `go test ./network/smb/smb_v10/message/commands` passes, including the new `TestNtCreateAndxResponseBaseWordCount` (base still WordCount 0x22, not decoded as extended) and `TestNtCreateAndxResponseExtended` (golden check of the 32 extended octets, WordCount 0x32, full round-trip of all four fields), plus the existing nil-safety sweep.
- **Static:** `go build ./...` and `go vet` are clean.

### Test Coverage
- **Added:** `network/smb/smb_v10/message/commands/NtCreateAndxResponse_test.go` — `TestNtCreateAndxResponseBaseWordCount`, `TestNtCreateAndxResponseExtended`.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/NtCreateAndxResponse.go`, `network/smb/smb_v10/message/commands/NtCreateAndxResponse_test.go` (new)
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none — the base layout is byte-identical when `Extended` is false.

### Risk and Rollout
Low. The extended fields are additive and gated behind `Extended`; the base response path is unchanged, and unmarshalling only reads the extra fields when the extra octets are present.
