### PR TITLE
Implement TREE_CONNECT_ANDX extended response (#479)

### DIFF
--- a/network/smb/smb_v10/message/commands/TreeConnectAndxResponse.go
+++ b/network/smb/smb_v10/message/commands/TreeConnectAndxResponse.go
@@ -25,6 +25,22 @@ type TreeConnectAndxResponse struct {
 	// the client MUST ignore them.
 	OptionalSupport types.USHORT
 
+	// Extended selects the MS-SMB extended response form ([MS-SMB] section 2.2.4.7.2),
+	// returned when the client set TREE_CONNECT_ANDX_EXTENDED_RESPONSE in the request.
+	// When false, the base CIFS layout (WordCount 0x03) is produced and the two fields
+	// below are absent; when true, they are appended (WordCount 0x07).
+	Extended bool
+
+	// MaximalShareAccessRights (4 bytes): The maximal access rights (ACCESS_MASK) that the
+	// user who set up the tree connect has on the share. Present only in the extended
+	// response ([MS-SMB] section 2.2.4.7.2).
+	MaximalShareAccessRights types.ULONG
+
+	// GuestMaximalShareAccessRights (4 bytes): The maximal access rights (ACCESS_MASK) that
+	// the guest account has on the share, or zero if guest accounts are unsupported.
+	// Present only in the extended response.
+	GuestMaximalShareAccessRights types.ULONG
+
 	// Data
 
 	// Service (variable): The type of the shared resource to which the TID is connected.
@@ -114,6 +130,18 @@ func (c *TreeConnectAndxResponse) Marshal() ([]byte, error) {
 	binary.LittleEndian.PutUint16(buf2, uint16(c.OptionalSupport))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
+	// MS-SMB extended response fields ([MS-SMB] section 2.2.4.7.2), appended only when the
+	// extended response form was selected.
+	if c.Extended {
+		buf4 := make([]byte, 4)
+		binary.LittleEndian.PutUint32(buf4, uint32(c.MaximalShareAccessRights))
+		rawParametersContent = append(rawParametersContent, buf4...)
+
+		buf4 = make([]byte, 4)
+		binary.LittleEndian.PutUint32(buf4, uint32(c.GuestMaximalShareAccessRights))
+		rawParametersContent = append(rawParametersContent, buf4...)
+	}
+
 	// Marshalling parameters
 	c.GetParameters().AddWordsFromBytesStream(rawParametersContent)
 	marshalledParameters, err := c.GetParameters().Marshal()
@@ -182,6 +210,17 @@ func (c *TreeConnectAndxResponse) Unmarshal(rawData []byte) (int, error) {
 	}
 	c.OptionalSupport = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
+
+	// MS-SMB extended response ([MS-SMB] section 2.2.4.7.2): if 8 more parameter octets
+	// follow OptionalSupport, this is the extended form carrying MaximalShareAccessRights (4)
+	// and GuestMaximalShareAccessRights (4).
+	if len(rawParametersContent) >= offset+8 {
+		c.Extended = true
+		c.MaximalShareAccessRights = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
+		offset += 4
+		c.GuestMaximalShareAccessRights = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
+		offset += 4
+	}
 
 	// Then unmarshal the data
 	offset = 0

--- a/network/smb/smb_v10/message/commands/TreeConnectAndxResponse_test.go
+++ b/network/smb/smb_v10/message/commands/TreeConnectAndxResponse_test.go
@@ -1,0 +1,79 @@
+package commands_test
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+)
+
+// TestTreeConnectAndxResponseBaseWordCount verifies the base CIFS response still marshals
+// with WordCount 0x03 and is not decoded as extended.
+func TestTreeConnectAndxResponseBaseWordCount(t *testing.T) {
+	resp := commands.NewTreeConnectAndxResponse()
+	resp.OptionalSupport = types.USHORT(0x0001)
+
+	marshalled, err := resp.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+	if marshalled[0] != 0x03 {
+		t.Errorf("base WordCount: got 0x%02x, want 0x03", marshalled[0])
+	}
+
+	var out commands.TreeConnectAndxResponse
+	if _, err := out.Unmarshal(marshalled); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if out.Extended {
+		t.Errorf("base response decoded as Extended")
+	}
+	if out.OptionalSupport != 0x0001 {
+		t.Errorf("OptionalSupport round trip: got 0x%04x, want 0x0001", out.OptionalSupport)
+	}
+}
+
+// TestTreeConnectAndxResponseExtended verifies the MS-SMB extended response form: the two
+// ACCESS_MASK fields are appended after OptionalSupport, WordCount becomes 0x07, and the
+// message round-trips.
+func TestTreeConnectAndxResponseExtended(t *testing.T) {
+	resp := commands.NewTreeConnectAndxResponse()
+	resp.OptionalSupport = types.USHORT(0x0001)
+	resp.Extended = true
+	resp.MaximalShareAccessRights = types.ULONG(0x001F01FF)
+	resp.GuestMaximalShareAccessRights = types.ULONG(0x00120089)
+
+	marshalled, err := resp.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+	if marshalled[0] != 0x07 {
+		t.Errorf("extended WordCount: got 0x%02x, want 0x07", marshalled[0])
+	}
+
+	// Words block = 14 octets (AndX 4 + OptionalSupport 2 + two ACCESS_MASK 8); the 8
+	// extended octets are the tail of the Words block (message octets [7:15]).
+	extended := marshalled[1+6 : 1+14]
+	want := make([]byte, 8)
+	binary.LittleEndian.PutUint32(want[0:4], uint32(resp.MaximalShareAccessRights))
+	binary.LittleEndian.PutUint32(want[4:8], uint32(resp.GuestMaximalShareAccessRights))
+	if !bytes.Equal(extended, want) {
+		t.Errorf("extended fields:\n got % x\nwant % x", extended, want)
+	}
+
+	var out commands.TreeConnectAndxResponse
+	if _, err := out.Unmarshal(marshalled); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if !out.Extended {
+		t.Fatalf("extended response not decoded as Extended")
+	}
+	if out.MaximalShareAccessRights != resp.MaximalShareAccessRights {
+		t.Errorf("MaximalShareAccessRights round trip: got 0x%08x, want 0x%08x", out.MaximalShareAccessRights, resp.MaximalShareAccessRights)
+	}
+	if out.GuestMaximalShareAccessRights != resp.GuestMaximalShareAccessRights {
+		t.Errorf("GuestMaximalShareAccessRights round trip: got 0x%08x, want 0x%08x", out.GuestMaximalShareAccessRights, resp.GuestMaximalShareAccessRights)
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #479`

### Root Cause
`TreeConnectAndxResponse` implemented only the base CIFS `SMB_COM_TREE_CONNECT_ANDX` response (WordCount 0x03), carrying just `OptionalSupport`. The MS-SMB extended response form ([MS-SMB] §2.2.4.7.2), returned when the client sets `TREE_CONNECT_ANDX_EXTENDED_RESPONSE`, was never added, so `MaximalShareAccessRights` and `GuestMaximalShareAccessRights` could neither be produced nor parsed.

### Fix Description
Add the two extended ACCESS_MASK fields to `TreeConnectAndxResponse`, gated by a new `Extended bool` selector:
- `MaximalShareAccessRights` and `GuestMaximalShareAccessRights` (`types.ULONG`).
- `Marshal` appends both (after `OptionalSupport`) only when `Extended` is set; the base layout is unchanged otherwise.
- `Unmarshal` detects the extended form by the presence of 8 additional parameter octets after `OptionalSupport`, sets `Extended`, and decodes the fields.

Field sizes and order follow [MS-SMB] §2.2.4.7.2. Here the WordCount is self-consistent (base 0x03 → extended 0x07; the two 4-octet fields add 4 words), so there is no WordCount quirk as in the NT_CREATE_ANDX extended response.

### How Verified
- **Tests:** `go test ./network/smb/smb_v10/message/commands` passes, including the new `TestTreeConnectAndxResponseBaseWordCount` (base still WordCount 0x03, not decoded as extended) and `TestTreeConnectAndxResponseExtended` (golden check of the 8 extended octets, WordCount 0x07, round-trip), plus the existing nil-safety sweep.
- **Static:** `go build ./...` and `go vet` are clean.

### Test Coverage
- **Added:** `network/smb/smb_v10/message/commands/TreeConnectAndxResponse_test.go` — `TestTreeConnectAndxResponseBaseWordCount`, `TestTreeConnectAndxResponseExtended`.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/TreeConnectAndxResponse.go`, `network/smb/smb_v10/message/commands/TreeConnectAndxResponse_test.go` (new)
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none — the base layout is byte-identical when `Extended` is false.

### Risk and Rollout
Low. The extended fields are additive and gated behind `Extended`; the base response path is unchanged, and unmarshalling only reads the extra fields when the extra octets are present.
