### PR TITLE
Implement server-side data copy (FSCTL_SRV_COPYCHUNK / resume key) (#480)

### DIFF
--- a/network/smb/smb_v10/subcommands/srv_copychunk.go
+++ b/network/smb/smb_v10/subcommands/srv_copychunk.go
@@ -1,0 +1,201 @@
+package subcommands
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+// MS-SMB server-side data copy ([MS-SMB] section 2.2.7.2 and 3.2.4.3 / 3.3.5.11): the
+// client opens the source and destination files, requests a copychunk resume key for the
+// source via FSCTL_SRV_REQUEST_RESUME_KEY, then issues FSCTL_SRV_COPYCHUNK against the
+// destination. Both FSCTLs are carried as the NT_TRANSACT_IOCTL FunctionCode of an
+// SMB_COM_NT_TRANSACT request, with the structures below as the NT_Trans_Data payload.
+const (
+	// FSCTL_SRV_REQUEST_RESUME_KEY requests the 24-byte copychunk resume key that uniquely
+	// identifies the open source file ([MS-SMB] section 2.2.7.2).
+	FSCTL_SRV_REQUEST_RESUME_KEY uint32 = 0x00140078
+
+	// FSCTL_SRV_COPYCHUNK performs a server-side copy of one or more chunks from the source
+	// file (identified by the resume key) into the destination file ([MS-SMB] section 2.2.7.2).
+	FSCTL_SRV_COPYCHUNK uint32 = 0x001440F2
+)
+
+// CopychunkResumeKeyLength is the fixed size, in bytes, of a copychunk resume key
+// ([MS-SMB] section 2.2.7.2.2.2): an opaque server-generated value the client echoes
+// back in the FSCTL_SRV_COPYCHUNK request.
+const CopychunkResumeKeyLength = 24
+
+const (
+	srvCopychunkSize         = 24 // SourceOffset(8) + DestinationOffset(8) + Length(4) + Reserved(4)
+	srvCopychunkResponseSize = 12 // ChunksWritten(4) + ChunkBytesWritten(4) + TotalBytesWritten(4)
+)
+
+// SrvCopychunk describes a single data range to copy server-side ([MS-SMB] section
+// 2.2.7.2.1 SRV_COPYCHUNK). One or more are carried in the Chunks array of an
+// SrvCopychunkCopy.
+type SrvCopychunk struct {
+	// SourceOffset (8 bytes): offset from the start of the source file to copy from.
+	SourceOffset uint64
+	// DestinationOffset (8 bytes): offset from the start of the destination file to copy to.
+	DestinationOffset uint64
+	// Length (4 bytes): number of bytes to copy.
+	Length uint32
+	// Reserved (4 bytes): MUST be zero and MUST be ignored on receipt.
+	Reserved uint32
+}
+
+// Marshal serializes the SRV_COPYCHUNK into its 24-byte little-endian wire form.
+func (c *SrvCopychunk) Marshal() ([]byte, error) {
+	b := make([]byte, srvCopychunkSize)
+	binary.LittleEndian.PutUint64(b[0:8], c.SourceOffset)
+	binary.LittleEndian.PutUint64(b[8:16], c.DestinationOffset)
+	binary.LittleEndian.PutUint32(b[16:20], c.Length)
+	binary.LittleEndian.PutUint32(b[20:24], c.Reserved)
+	return b, nil
+}
+
+// Unmarshal parses a 24-byte SRV_COPYCHUNK, returning the number of bytes consumed.
+func (c *SrvCopychunk) Unmarshal(data []byte) (int, error) {
+	if len(data) < srvCopychunkSize {
+		return 0, fmt.Errorf("subcommands: SRV_COPYCHUNK requires %d bytes, got %d", srvCopychunkSize, len(data))
+	}
+	c.SourceOffset = binary.LittleEndian.Uint64(data[0:8])
+	c.DestinationOffset = binary.LittleEndian.Uint64(data[8:16])
+	c.Length = binary.LittleEndian.Uint32(data[16:20])
+	c.Reserved = binary.LittleEndian.Uint32(data[20:24])
+	return srvCopychunkSize, nil
+}
+
+// SrvCopychunkCopy is the NT_Trans_Data of an FSCTL_SRV_COPYCHUNK request ([MS-SMB]
+// section 2.2.7.2.1 SRV_COPYCHUNK_COPY). The on-the-wire ChunkCount is derived from the
+// length of Chunks so the count and the array cannot disagree.
+type SrvCopychunkCopy struct {
+	// CopychunkResumeKey (24 bytes): the resume key returned by FSCTL_SRV_REQUEST_RESUME_KEY
+	// for the source file.
+	CopychunkResumeKey [CopychunkResumeKeyLength]byte
+	// Reserved (4 bytes): MUST be zero and MUST be ignored on receipt.
+	Reserved uint32
+	// Chunks: the data ranges to copy. ChunkCount on the wire equals len(Chunks).
+	Chunks []SrvCopychunk
+}
+
+// Marshal serializes the SRV_COPYCHUNK_COPY: resume key, ChunkCount, Reserved, chunks.
+func (c *SrvCopychunkCopy) Marshal() ([]byte, error) {
+	b := make([]byte, 0, CopychunkResumeKeyLength+8+len(c.Chunks)*srvCopychunkSize)
+	b = append(b, c.CopychunkResumeKey[:]...)
+
+	tmp := make([]byte, 4)
+	binary.LittleEndian.PutUint32(tmp, uint32(len(c.Chunks))) // ChunkCount
+	b = append(b, tmp...)
+	binary.LittleEndian.PutUint32(tmp, c.Reserved)
+	b = append(b, tmp...)
+
+	for i := range c.Chunks {
+		cb, err := c.Chunks[i].Marshal()
+		if err != nil {
+			return nil, err
+		}
+		b = append(b, cb...)
+	}
+	return b, nil
+}
+
+// Unmarshal parses an SRV_COPYCHUNK_COPY, returning the number of bytes consumed.
+func (c *SrvCopychunkCopy) Unmarshal(data []byte) (int, error) {
+	if len(data) < CopychunkResumeKeyLength+8 {
+		return 0, fmt.Errorf("subcommands: SRV_COPYCHUNK_COPY header requires %d bytes, got %d", CopychunkResumeKeyLength+8, len(data))
+	}
+	offset := 0
+	copy(c.CopychunkResumeKey[:], data[offset:offset+CopychunkResumeKeyLength])
+	offset += CopychunkResumeKeyLength
+
+	chunkCount := binary.LittleEndian.Uint32(data[offset : offset+4])
+	offset += 4
+	c.Reserved = binary.LittleEndian.Uint32(data[offset : offset+4])
+	offset += 4
+
+	c.Chunks = make([]SrvCopychunk, 0, chunkCount)
+	for i := uint32(0); i < chunkCount; i++ {
+		var chunk SrvCopychunk
+		n, err := chunk.Unmarshal(data[offset:])
+		if err != nil {
+			return offset, fmt.Errorf("subcommands: SRV_COPYCHUNK_COPY chunk %d: %w", i, err)
+		}
+		offset += n
+		c.Chunks = append(c.Chunks, chunk)
+	}
+	return offset, nil
+}
+
+// SrvCopychunkResponse is the NT_Trans_Data of an FSCTL_SRV_COPYCHUNK response ([MS-SMB]
+// section 2.2.7.2.2.1 SRV_COPYCHUNK_RESPONSE).
+type SrvCopychunkResponse struct {
+	// ChunksWritten (4 bytes): number of chunks successfully written.
+	ChunksWritten uint32
+	// ChunkBytesWritten (4 bytes): number of bytes written in the last (partially written) chunk.
+	ChunkBytesWritten uint32
+	// TotalBytesWritten (4 bytes): total number of bytes written.
+	TotalBytesWritten uint32
+}
+
+// Marshal serializes the SRV_COPYCHUNK_RESPONSE into its 12-byte little-endian wire form.
+func (r *SrvCopychunkResponse) Marshal() ([]byte, error) {
+	b := make([]byte, srvCopychunkResponseSize)
+	binary.LittleEndian.PutUint32(b[0:4], r.ChunksWritten)
+	binary.LittleEndian.PutUint32(b[4:8], r.ChunkBytesWritten)
+	binary.LittleEndian.PutUint32(b[8:12], r.TotalBytesWritten)
+	return b, nil
+}
+
+// Unmarshal parses a 12-byte SRV_COPYCHUNK_RESPONSE, returning the bytes consumed.
+func (r *SrvCopychunkResponse) Unmarshal(data []byte) (int, error) {
+	if len(data) < srvCopychunkResponseSize {
+		return 0, fmt.Errorf("subcommands: SRV_COPYCHUNK_RESPONSE requires %d bytes, got %d", srvCopychunkResponseSize, len(data))
+	}
+	r.ChunksWritten = binary.LittleEndian.Uint32(data[0:4])
+	r.ChunkBytesWritten = binary.LittleEndian.Uint32(data[4:8])
+	r.TotalBytesWritten = binary.LittleEndian.Uint32(data[8:12])
+	return srvCopychunkResponseSize, nil
+}
+
+// SrvRequestResumeKeyResponse is the NT_Trans_Data of an FSCTL_SRV_REQUEST_RESUME_KEY
+// response ([MS-SMB] section 2.2.7.2.2.2). The ContextLength field on the wire is derived
+// from len(Context); per the spec the extended context feature is reserved and not used,
+// so Context is normally empty.
+type SrvRequestResumeKeyResponse struct {
+	// CopychunkResumeKey (24 bytes): opaque resume key identifying the open source file.
+	CopychunkResumeKey [CopychunkResumeKeyLength]byte
+	// Context (variable): reserved/unused extended context; normally zero-length.
+	Context []byte
+}
+
+// Marshal serializes the FSCTL_SRV_REQUEST_RESUME_KEY response: resume key, ContextLength,
+// then the (normally empty) Context.
+func (r *SrvRequestResumeKeyResponse) Marshal() ([]byte, error) {
+	b := make([]byte, 0, CopychunkResumeKeyLength+4+len(r.Context))
+	b = append(b, r.CopychunkResumeKey[:]...)
+	tmp := make([]byte, 4)
+	binary.LittleEndian.PutUint32(tmp, uint32(len(r.Context))) // ContextLength
+	b = append(b, tmp...)
+	b = append(b, r.Context...)
+	return b, nil
+}
+
+// Unmarshal parses an FSCTL_SRV_REQUEST_RESUME_KEY response, returning the bytes consumed.
+func (r *SrvRequestResumeKeyResponse) Unmarshal(data []byte) (int, error) {
+	if len(data) < CopychunkResumeKeyLength+4 {
+		return 0, fmt.Errorf("subcommands: FSCTL_SRV_REQUEST_RESUME_KEY response requires at least %d bytes, got %d", CopychunkResumeKeyLength+4, len(data))
+	}
+	offset := 0
+	copy(r.CopychunkResumeKey[:], data[offset:offset+CopychunkResumeKeyLength])
+	offset += CopychunkResumeKeyLength
+
+	contextLength := binary.LittleEndian.Uint32(data[offset : offset+4])
+	offset += 4
+	if len(data) < offset+int(contextLength) {
+		return offset, fmt.Errorf("subcommands: FSCTL_SRV_REQUEST_RESUME_KEY response Context truncated: need %d, have %d", contextLength, len(data)-offset)
+	}
+	r.Context = append([]byte{}, data[offset:offset+int(contextLength)]...)
+	offset += int(contextLength)
+	return offset, nil
+}

--- a/network/smb/smb_v10/subcommands/srv_copychunk_test.go
+++ b/network/smb/smb_v10/subcommands/srv_copychunk_test.go
@@ -1,0 +1,122 @@
+package subcommands
+
+import (
+	"bytes"
+	"testing"
+)
+
+// exampleResumeKey is the 24-byte copychunk resume key from the [MS-SMB] section 2.2.7.2
+// FSCTL_SRV_COPYCHUNK example trace.
+var exampleResumeKey = [CopychunkResumeKeyLength]byte{
+	0x2D, 0x0B, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
+	0x59, 0x84, 0x0C, 0x62, 0x1B, 0x84, 0xC6, 0x01,
+	0x08, 0x0E, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+}
+
+func TestSrvCopychunkGolden(t *testing.T) {
+	c := SrvCopychunk{SourceOffset: 0x01, DestinationOffset: 0x02, Length: 0x063C}
+	got, err := c.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	want := []byte{
+		0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // SourceOffset
+		0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // DestinationOffset
+		0x3C, 0x06, 0x00, 0x00, // Length
+		0x00, 0x00, 0x00, 0x00, // Reserved
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("SRV_COPYCHUNK:\n got % x\nwant % x", got, want)
+	}
+
+	var out SrvCopychunk
+	n, err := out.Unmarshal(got)
+	if err != nil || n != srvCopychunkSize {
+		t.Fatalf("Unmarshal: n=%d err=%v", n, err)
+	}
+	if out != c {
+		t.Errorf("round trip: got %+v want %+v", out, c)
+	}
+}
+
+func TestSrvCopychunkCopyRoundTrip(t *testing.T) {
+	in := SrvCopychunkCopy{
+		CopychunkResumeKey: exampleResumeKey,
+		Chunks: []SrvCopychunk{
+			{SourceOffset: 0, DestinationOffset: 0, Length: 0x063C},
+		},
+	}
+	raw, err := in.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	// Header: 24-byte key, ChunkCount=1, Reserved=0.
+	wantHeader := append(append([]byte{}, exampleResumeKey[:]...), 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00)
+	if !bytes.Equal(raw[:32], wantHeader) {
+		t.Errorf("SRV_COPYCHUNK_COPY header:\n got % x\nwant % x", raw[:32], wantHeader)
+	}
+	if len(raw) != 32+srvCopychunkSize {
+		t.Fatalf("length: got %d want %d", len(raw), 32+srvCopychunkSize)
+	}
+
+	var out SrvCopychunkCopy
+	n, err := out.Unmarshal(raw)
+	if err != nil || n != len(raw) {
+		t.Fatalf("Unmarshal: n=%d err=%v", n, err)
+	}
+	if out.CopychunkResumeKey != in.CopychunkResumeKey || len(out.Chunks) != 1 || out.Chunks[0] != in.Chunks[0] {
+		t.Errorf("round trip mismatch: %+v", out)
+	}
+}
+
+func TestSrvCopychunkResponseGolden(t *testing.T) {
+	r := SrvCopychunkResponse{ChunksWritten: 1, ChunkBytesWritten: 0, TotalBytesWritten: 0x063C}
+	got, err := r.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	want := []byte{
+		0x01, 0x00, 0x00, 0x00, // ChunksWritten
+		0x00, 0x00, 0x00, 0x00, // ChunkBytesWritten
+		0x3C, 0x06, 0x00, 0x00, // TotalBytesWritten
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("SRV_COPYCHUNK_RESPONSE:\n got % x\nwant % x", got, want)
+	}
+	var out SrvCopychunkResponse
+	if _, err := out.Unmarshal(got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out != r {
+		t.Errorf("round trip: got %+v want %+v", out, r)
+	}
+}
+
+func TestSrvRequestResumeKeyResponseRoundTrip(t *testing.T) {
+	in := SrvRequestResumeKeyResponse{CopychunkResumeKey: exampleResumeKey}
+	raw, err := in.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	// 24-byte key followed by ContextLength = 0.
+	want := append(append([]byte{}, exampleResumeKey[:]...), 0x00, 0x00, 0x00, 0x00)
+	if !bytes.Equal(raw, want) {
+		t.Errorf("resume-key response:\n got % x\nwant % x", raw, want)
+	}
+	var out SrvRequestResumeKeyResponse
+	if _, err := out.Unmarshal(raw); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out.CopychunkResumeKey != in.CopychunkResumeKey || len(out.Context) != 0 {
+		t.Errorf("round trip mismatch: %+v", out)
+	}
+}
+
+func TestFSCTLCopychunkCodes(t *testing.T) {
+	if FSCTL_SRV_REQUEST_RESUME_KEY != 0x00140078 {
+		t.Errorf("FSCTL_SRV_REQUEST_RESUME_KEY: got 0x%08x want 0x00140078", FSCTL_SRV_REQUEST_RESUME_KEY)
+	}
+	if FSCTL_SRV_COPYCHUNK != 0x001440F2 {
+		t.Errorf("FSCTL_SRV_COPYCHUNK: got 0x%08x want 0x001440F2", FSCTL_SRV_COPYCHUNK)
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #480`

### Root Cause
The MS-SMB server-side data copy extension was never implemented: `NT_TRANSACT_IOCTL` existed only as a subcommand enum value, with no FSCTL function codes and no copychunk/resume-key structures anywhere under `network/smb/smb_v10`.

### Fix Description
Add the server-side copy FSCTL function codes and NT_Trans_Data structures in the `subcommands` package (`srv_copychunk.go`), each with `Marshal`/`Unmarshal`:
- `FSCTL_SRV_REQUEST_RESUME_KEY` (`0x00140078`) and `FSCTL_SRV_COPYCHUNK` (`0x001440F2`).
- `SrvCopychunk` — SourceOffset(8) + DestinationOffset(8) + Length(4) + Reserved(4) = 24 octets ([MS-SMB] §2.2.7.2.1).
- `SrvCopychunkCopy` — CopychunkResumeKey(24) + ChunkCount(4, derived from `len(Chunks)`) + Reserved(4) + chunks.
- `SrvCopychunkResponse` — ChunksWritten(4) + ChunkBytesWritten(4) + TotalBytesWritten(4) ([MS-SMB] §2.2.7.2.2.1).
- `SrvRequestResumeKeyResponse` — CopychunkResumeKey(24) + ContextLength(4, derived from `len(Context)`) + Context ([MS-SMB] §2.2.7.2.2.2; the extended-context feature is reserved/unused, so Context is normally empty).

All multi-byte fields are little-endian. Field sizes/order were taken from the [MS-SMB] §2.2.7.2 FSCTL_SRV_COPYCHUNK page (including the example trace) and the FSCTL_SRV_REQUEST_RESUME_KEY response page; the per-chunk trailing `Reserved` (4 octets) is per the SRV_COPYCHUNK structure definition.

### How Verified
- **Tests:** `go test ./network/smb/smb_v10/subcommands` passes, including golden byte checks for `SrvCopychunk` and `SrvCopychunkResponse`, a round-trip for `SrvCopychunkCopy` (header = 24-byte key + ChunkCount=1 + Reserved=0), a round-trip for the resume-key response (key + ContextLength=0, using the 24-byte example key from the spec trace), and a check of the two FSCTL function-code constants.
- **Static:** `go build ./...` and `go vet` are clean.

### Test Coverage
- **Added:** `network/smb/smb_v10/subcommands/srv_copychunk_test.go` — `TestSrvCopychunkGolden`, `TestSrvCopychunkCopyRoundTrip`, `TestSrvCopychunkResponseGolden`, `TestSrvRequestResumeKeyResponseRoundTrip`, `TestFSCTLCopychunkCodes`.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/subcommands/srv_copychunk.go` (new), `network/smb/smb_v10/subcommands/srv_copychunk_test.go` (new)
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none — only new types are added.

### Notes
These structures are the NT_Trans_Data payloads carried by an `NT_TRANSACT_IOCTL` request/response; wiring them into a full client copy flow (open source/dest, request resume key, issue copychunk) is a separate higher-level concern. Not live-validated against a server.
