### PR TITLE
Implement previous-versions enumeration (FSCTL_SRV_ENUMERATE_SNAPSHOTS) (#481)

### DIFF
--- a/network/smb/smb_v10/subcommands/srv_snapshot_array.go
+++ b/network/smb/smb_v10/subcommands/srv_snapshot_array.go
@@ -1,0 +1,103 @@
+package subcommands
+
+import (
+	"encoding/binary"
+	"fmt"
+	"unicode/utf16"
+)
+
+// FSCTL_SRV_ENUMERATE_SNAPSHOTS enumerates the available previous-version (snapshot /
+// shadow-copy) timestamps of an open file or directory ([MS-SMB] section 2.2.7.3). Like
+// the copychunk FSCTLs, it is carried as the NT_TRANSACT_IOCTL FunctionCode of an
+// SMB_COM_NT_TRANSACT request; the SrvSnapshotArray below is the response NT_Trans_Data.
+const FSCTL_SRV_ENUMERATE_SNAPSHOTS uint32 = 0x00144064
+
+const srvSnapshotArrayHeaderSize = 12 // NumberOfSnapShots(4) + NumberOfSnapShotsReturned(4) + SnapShotArraySize(4)
+
+// SrvSnapshotArray is the NT_Trans_Data of an FSCTL_SRV_ENUMERATE_SNAPSHOTS response
+// ([MS-SMB] section 2.2.7.3.2 SRV_SNAPSHOT_ARRAY). The on-the-wire SnapShotArraySize and
+// the SnapShotMultiSZ list are derived from / parsed into Snapshots.
+type SrvSnapshotArray struct {
+	// NumberOfSnapShots (4 bytes): total number of snapshots the object store has of this
+	// file. May exceed len(Snapshots) if the client's buffer could not hold them all.
+	NumberOfSnapShots uint32
+
+	// NumberOfSnapShotsReturned (4 bytes): the number of snapshots actually returned in this
+	// response (equals len(Snapshots) on marshal).
+	NumberOfSnapShotsReturned uint32
+
+	// Snapshots: the returned snapshot labels, each of the form "@GMT-YYYY.MM.DD-HH.MM.SS".
+	// On the wire they are a NUL-terminated UTF-16LE multi-SZ (an extra terminating NUL
+	// closes the list; an empty list is two NUL characters).
+	Snapshots []string
+}
+
+// snapshotMultiSZ builds the UTF-16LE multi-SZ encoding of the snapshot list: each entry
+// NUL-terminated, the whole list closed by one additional NUL; an empty list is two NULs
+// ([MS-SMB] section 2.2.7.3.2).
+func (a *SrvSnapshotArray) snapshotMultiSZ() []uint16 {
+	if len(a.Snapshots) == 0 {
+		return []uint16{0, 0}
+	}
+	units := []uint16{}
+	for _, s := range a.Snapshots {
+		units = append(units, utf16.Encode([]rune(s))...)
+		units = append(units, 0) // per-entry NUL terminator
+	}
+	units = append(units, 0) // additional list-terminating NUL
+	return units
+}
+
+// Marshal serializes the SRV_SNAPSHOT_ARRAY: the three counts followed by the multi-SZ.
+// NumberOfSnapShotsReturned and SnapShotArraySize are set from the Snapshots list, while
+// NumberOfSnapShots is taken from the field (it can legitimately exceed the returned count).
+func (a *SrvSnapshotArray) Marshal() ([]byte, error) {
+	units := a.snapshotMultiSZ()
+	multiSZ := make([]byte, len(units)*2)
+	for i, u := range units {
+		binary.LittleEndian.PutUint16(multiSZ[i*2:], u)
+	}
+
+	b := make([]byte, srvSnapshotArrayHeaderSize+len(multiSZ))
+	binary.LittleEndian.PutUint32(b[0:4], a.NumberOfSnapShots)
+	binary.LittleEndian.PutUint32(b[4:8], uint32(len(a.Snapshots)))
+	binary.LittleEndian.PutUint32(b[8:12], uint32(len(multiSZ)))
+	copy(b[srvSnapshotArrayHeaderSize:], multiSZ)
+	return b, nil
+}
+
+// Unmarshal parses an SRV_SNAPSHOT_ARRAY, returning the number of bytes consumed. The
+// multi-SZ is decoded into Snapshots; a probe response that carries only the header (no
+// room for the list) yields an empty Snapshots slice.
+func (a *SrvSnapshotArray) Unmarshal(data []byte) (int, error) {
+	if len(data) < srvSnapshotArrayHeaderSize {
+		return 0, fmt.Errorf("subcommands: SRV_SNAPSHOT_ARRAY requires at least %d bytes, got %d", srvSnapshotArrayHeaderSize, len(data))
+	}
+	a.NumberOfSnapShots = binary.LittleEndian.Uint32(data[0:4])
+	a.NumberOfSnapShotsReturned = binary.LittleEndian.Uint32(data[4:8])
+	arraySize := int(binary.LittleEndian.Uint32(data[8:12]))
+
+	// The list occupies SnapShotArraySize octets, but a buffer-probe response may omit it,
+	// so read only what is actually present.
+	avail := len(data) - srvSnapshotArrayHeaderSize
+	if arraySize > avail {
+		arraySize = avail
+	}
+	multiSZ := data[srvSnapshotArrayHeaderSize : srvSnapshotArrayHeaderSize+arraySize]
+
+	a.Snapshots = nil
+	var cur []uint16
+	for i := 0; i+1 < len(multiSZ); i += 2 {
+		u := binary.LittleEndian.Uint16(multiSZ[i:])
+		if u == 0 {
+			if len(cur) == 0 {
+				break // empty entry → list terminator
+			}
+			a.Snapshots = append(a.Snapshots, string(utf16.Decode(cur)))
+			cur = nil
+			continue
+		}
+		cur = append(cur, u)
+	}
+	return srvSnapshotArrayHeaderSize + arraySize, nil
+}

--- a/network/smb/smb_v10/subcommands/srv_snapshot_array_test.go
+++ b/network/smb/smb_v10/subcommands/srv_snapshot_array_test.go
@@ -1,0 +1,100 @@
+package subcommands
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+	"unicode/utf16"
+)
+
+func TestFSCTLEnumerateSnapshotsCode(t *testing.T) {
+	if FSCTL_SRV_ENUMERATE_SNAPSHOTS != 0x00144064 {
+		t.Errorf("FSCTL_SRV_ENUMERATE_SNAPSHOTS: got 0x%08x want 0x00144064", FSCTL_SRV_ENUMERATE_SNAPSHOTS)
+	}
+}
+
+func TestSrvSnapshotArrayRoundTrip(t *testing.T) {
+	in := SrvSnapshotArray{
+		NumberOfSnapShots: 2,
+		Snapshots: []string{
+			"@GMT-2020.01.02-03.04.05",
+			"@GMT-2021.06.07-08.09.10",
+		},
+	}
+	raw, err := in.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	// Header: NumberOfSnapShots=2, NumberOfSnapShotsReturned=2, SnapShotArraySize=len(multiSZ).
+	if got := binary.LittleEndian.Uint32(raw[0:4]); got != 2 {
+		t.Errorf("NumberOfSnapShots: got %d want 2", got)
+	}
+	if got := binary.LittleEndian.Uint32(raw[4:8]); got != 2 {
+		t.Errorf("NumberOfSnapShotsReturned: got %d want 2", got)
+	}
+	// Each label is 24 UTF-16 units; multi-SZ = (24+1)*2 entries-with-NUL + 1 final NUL.
+	wantUnits := (24 + 1) + (24 + 1) + 1
+	if got := binary.LittleEndian.Uint32(raw[8:12]); int(got) != wantUnits*2 {
+		t.Errorf("SnapShotArraySize: got %d want %d", got, wantUnits*2)
+	}
+
+	var out SrvSnapshotArray
+	n, err := out.Unmarshal(raw)
+	if err != nil || n != len(raw) {
+		t.Fatalf("Unmarshal: n=%d err=%v", n, err)
+	}
+	if out.NumberOfSnapShots != 2 || out.NumberOfSnapShotsReturned != 2 || len(out.Snapshots) != 2 {
+		t.Fatalf("round trip counts: %+v", out)
+	}
+	if out.Snapshots[0] != in.Snapshots[0] || out.Snapshots[1] != in.Snapshots[1] {
+		t.Errorf("snapshots round trip: got %q want %q", out.Snapshots, in.Snapshots)
+	}
+}
+
+func TestSrvSnapshotArrayEmpty(t *testing.T) {
+	// A response advertising 5 available snapshots but returning none: the multi-SZ is two
+	// UTF-16 NUL characters (4 octets).
+	in := SrvSnapshotArray{NumberOfSnapShots: 5}
+	raw, err := in.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	want := make([]byte, 12+4)
+	binary.LittleEndian.PutUint32(want[0:4], 5)
+	binary.LittleEndian.PutUint32(want[4:8], 0)
+	binary.LittleEndian.PutUint32(want[8:12], 4)
+	// trailing 4 octets are the two NUL WCHARs (already zero)
+	if !bytes.Equal(raw, want) {
+		t.Errorf("empty SRV_SNAPSHOT_ARRAY:\n got % x\nwant % x", raw, want)
+	}
+
+	var out SrvSnapshotArray
+	if _, err := out.Unmarshal(raw); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out.NumberOfSnapShots != 5 || len(out.Snapshots) != 0 {
+		t.Errorf("empty round trip: %+v", out)
+	}
+}
+
+// TestSrvSnapshotArrayGoldenList checks the exact multi-SZ encoding of a single label.
+func TestSrvSnapshotArrayGoldenList(t *testing.T) {
+	in := SrvSnapshotArray{NumberOfSnapShots: 1, Snapshots: []string{"@GMT-2020.01.02-03.04.05"}}
+	raw, err := in.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	multiSZ := raw[12:]
+	want := []byte{}
+	for _, u := range utf16.Encode([]rune("@GMT-2020.01.02-03.04.05")) {
+		b := make([]byte, 2)
+		binary.LittleEndian.PutUint16(b, u)
+		want = append(want, b...)
+	}
+	want = append(want, 0x00, 0x00) // per-entry NUL
+	want = append(want, 0x00, 0x00) // list-terminating NUL
+	if !bytes.Equal(multiSZ, want) {
+		t.Errorf("multi-SZ:\n got % x\nwant % x", multiSZ, want)
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #481`

### Root Cause
The MS-SMB previous-versions extension was never implemented: `NT_TRANSACT_IOCTL` existed only as a subcommand enum value, with no `FSCTL_SRV_ENUMERATE_SNAPSHOTS` function code and no `SRV_SNAPSHOT_ARRAY` structure anywhere under `network/smb/smb_v10`.

### Fix Description
Add the snapshot-enumeration FSCTL code and response structure in the `subcommands` package (`srv_snapshot_array.go`):
- `FSCTL_SRV_ENUMERATE_SNAPSHOTS` (`0x00144064`).
- `SrvSnapshotArray` — `NumberOfSnapShots` (4) + `NumberOfSnapShotsReturned` (4) + `SnapShotArraySize` (4) + `SnapShotMultiSZ` (variable), per [MS-SMB] §2.2.7.3.2.
- `Snapshots []string` holds the `@GMT-YYYY.MM.DD-HH.MM.SS` labels. `Marshal` encodes them as a UTF-16LE multi-SZ (each entry NUL-terminated, the list closed by one additional NUL; an empty list is two NUL characters) and derives `NumberOfSnapShotsReturned`/`SnapShotArraySize`; `Unmarshal` parses the multi-SZ back into the slice and tolerates a header-only buffer-probe response.

### How Verified
- **Tests:** `go test ./network/smb/smb_v10/subcommands` passes, including `TestSrvSnapshotArrayRoundTrip` (two labels), `TestSrvSnapshotArrayEmpty` (golden 16-octet header + two-NUL list for a 0-returned/5-available probe), `TestSrvSnapshotArrayGoldenList` (exact UTF-16LE multi-SZ bytes for one label), and the FSCTL code check.
- **Static:** `go build ./...` and `go vet` are clean.

### Test Coverage
- **Added:** `network/smb/smb_v10/subcommands/srv_snapshot_array_test.go` — `TestFSCTLEnumerateSnapshotsCode`, `TestSrvSnapshotArrayRoundTrip`, `TestSrvSnapshotArrayEmpty`, `TestSrvSnapshotArrayGoldenList`.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/subcommands/srv_snapshot_array.go` (new), `network/smb/smb_v10/subcommands/srv_snapshot_array_test.go` (new)
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none — only a new type and constant are added.

### Notes
This is the NT_Trans_Data payload of an `NT_TRANSACT_IOCTL` response; driving a full enumerate-snapshots request flow is a separate higher-level concern. Not live-validated against a server.
