### PR TITLE
Implement per-user quota query/set (NT_TRANSACT_QUERY_QUOTA / SET_QUOTA) (#482)

### DIFF
--- a/network/smb/smb_v10/subcommands/nt_transact_quota.go
+++ b/network/smb/smb_v10/subcommands/nt_transact_quota.go
@@ -1,0 +1,178 @@
+package subcommands
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+// MS-SMB per-user disk quota extension, carried as the NT_TRANSACT_QUERY_QUOTA and
+// NT_TRANSACT_SET_QUOTA subcommands of SMB_COM_NT_TRANSACT ([MS-SMB] sections 2.2.7.5 and
+// 2.2.7.6). The NT_Trans_Parameters of a query request are defined here, along with the
+// MS-FSCC quota records used as the NT_Trans_Data: FILE_GET_QUOTA_INFORMATION ([MS-FSCC]
+// section 2.4.41.1) names the SIDs queried, and FILE_QUOTA_INFORMATION ([MS-FSCC] section
+// 2.4.41) carries a single user's quota — it is both the query response record and the
+// record a client sends in an NT_TRANSACT_SET_QUOTA request.
+
+const (
+	ntTransQueryQuotaParametersSize  = 16 // FID(2)+ReturnSingleEntry(1)+RestartScan(1)+SidListLength(4)+StartSidLength(4)+StartSidOffset(4)
+	fileQuotaInformationFixedSize    = 40 // NextEntryOffset(4)+SidLength(4)+ChangeTime(8)+QuotaUsed(8)+QuotaThreshold(8)+QuotaLimit(8)
+	fileGetQuotaInformationFixedSize = 8  // NextEntryOffset(4)+SidLength(4)
+)
+
+// NtTransQueryQuotaRequestParameters is the NT_Trans_Parameters of an
+// NT_TRANSACT_QUERY_QUOTA request ([MS-SMB] section 2.2.7.5.1). At least one of
+// SidListLength or StartSidLength MUST be zero; if both are zero, all SIDs are enumerated.
+type NtTransQueryQuotaRequestParameters struct {
+	// FID (2 bytes): the open file/directory whose object store's quota is queried.
+	FID uint16
+	// ReturnSingleEntry (1 byte): if non-zero, return only a single SID's quota.
+	ReturnSingleEntry bool
+	// RestartScan (1 byte): if non-zero, restart the quota scan.
+	RestartScan bool
+	// SidListLength (4 bytes): length of the NT_Trans_Data SidList, or zero.
+	SidListLength uint32
+	// StartSidLength (4 bytes): length of the single start-SID entry, or zero.
+	StartSidLength uint32
+	// StartSidOffset (4 bytes): offset, from the start of NT_Trans_Data, of the start SID.
+	StartSidOffset uint32
+}
+
+func boolToByte(b bool) byte {
+	if b {
+		return 1
+	}
+	return 0
+}
+
+// Marshal serializes the 16-octet NT_Trans_Parameters block.
+func (p *NtTransQueryQuotaRequestParameters) Marshal() ([]byte, error) {
+	b := make([]byte, ntTransQueryQuotaParametersSize)
+	binary.LittleEndian.PutUint16(b[0:2], p.FID)
+	b[2] = boolToByte(p.ReturnSingleEntry)
+	b[3] = boolToByte(p.RestartScan)
+	binary.LittleEndian.PutUint32(b[4:8], p.SidListLength)
+	binary.LittleEndian.PutUint32(b[8:12], p.StartSidLength)
+	binary.LittleEndian.PutUint32(b[12:16], p.StartSidOffset)
+	return b, nil
+}
+
+// Unmarshal parses the 16-octet NT_Trans_Parameters block.
+func (p *NtTransQueryQuotaRequestParameters) Unmarshal(data []byte) (int, error) {
+	if len(data) < ntTransQueryQuotaParametersSize {
+		return 0, fmt.Errorf("subcommands: NT_TRANSACT_QUERY_QUOTA parameters require %d bytes, got %d", ntTransQueryQuotaParametersSize, len(data))
+	}
+	p.FID = binary.LittleEndian.Uint16(data[0:2])
+	p.ReturnSingleEntry = data[2] != 0
+	p.RestartScan = data[3] != 0
+	p.SidListLength = binary.LittleEndian.Uint32(data[4:8])
+	p.StartSidLength = binary.LittleEndian.Uint32(data[8:12])
+	p.StartSidOffset = binary.LittleEndian.Uint32(data[12:16])
+	return ntTransQueryQuotaParametersSize, nil
+}
+
+// NtTransQuotaResponseParameters is the NT_Trans_Parameters of an NT_TRANSACT_QUERY_QUOTA
+// response ([MS-SMB] section 2.2.7.5.2): the byte length of the returned quota data.
+type NtTransQuotaResponseParameters struct {
+	// DataLength (4 bytes): length of the returned quota information (equals TotalDataCount).
+	DataLength uint32
+}
+
+// Marshal serializes the 4-octet response parameter block.
+func (p *NtTransQuotaResponseParameters) Marshal() ([]byte, error) {
+	b := make([]byte, 4)
+	binary.LittleEndian.PutUint32(b, p.DataLength)
+	return b, nil
+}
+
+// Unmarshal parses the 4-octet response parameter block.
+func (p *NtTransQuotaResponseParameters) Unmarshal(data []byte) (int, error) {
+	if len(data) < 4 {
+		return 0, fmt.Errorf("subcommands: NT_TRANSACT_QUERY_QUOTA response parameters require 4 bytes, got %d", len(data))
+	}
+	p.DataLength = binary.LittleEndian.Uint32(data[0:4])
+	return 4, nil
+}
+
+// FileGetQuotaInformation is a single SID entry in the SidList of an
+// NT_TRANSACT_QUERY_QUOTA request ([MS-FSCC] section 2.4.41.1 FILE_GET_QUOTA_INFORMATION).
+// SidLength is derived from len(Sid) on marshal.
+type FileGetQuotaInformation struct {
+	// NextEntryOffset (4 bytes): byte offset to the next entry, or zero if this is the last.
+	NextEntryOffset uint32
+	// Sid (variable): the SID whose quota is requested.
+	Sid []byte
+}
+
+// Marshal serializes the FILE_GET_QUOTA_INFORMATION entry.
+func (e *FileGetQuotaInformation) Marshal() ([]byte, error) {
+	b := make([]byte, fileGetQuotaInformationFixedSize+len(e.Sid))
+	binary.LittleEndian.PutUint32(b[0:4], e.NextEntryOffset)
+	binary.LittleEndian.PutUint32(b[4:8], uint32(len(e.Sid)))
+	copy(b[fileGetQuotaInformationFixedSize:], e.Sid)
+	return b, nil
+}
+
+// Unmarshal parses a FILE_GET_QUOTA_INFORMATION entry, returning the bytes consumed.
+func (e *FileGetQuotaInformation) Unmarshal(data []byte) (int, error) {
+	if len(data) < fileGetQuotaInformationFixedSize {
+		return 0, fmt.Errorf("subcommands: FILE_GET_QUOTA_INFORMATION requires at least %d bytes, got %d", fileGetQuotaInformationFixedSize, len(data))
+	}
+	e.NextEntryOffset = binary.LittleEndian.Uint32(data[0:4])
+	sidLength := int(binary.LittleEndian.Uint32(data[4:8]))
+	if len(data) < fileGetQuotaInformationFixedSize+sidLength {
+		return fileGetQuotaInformationFixedSize, fmt.Errorf("subcommands: FILE_GET_QUOTA_INFORMATION SID truncated: need %d, have %d", sidLength, len(data)-fileGetQuotaInformationFixedSize)
+	}
+	e.Sid = append([]byte{}, data[fileGetQuotaInformationFixedSize:fileGetQuotaInformationFixedSize+sidLength]...)
+	return fileGetQuotaInformationFixedSize + sidLength, nil
+}
+
+// FileQuotaInformation is a single user's quota record ([MS-FSCC] section 2.4.41
+// FILE_QUOTA_INFORMATION). It is the NT_Trans_Data record of an NT_TRANSACT_QUERY_QUOTA
+// response and the record a client sends in an NT_TRANSACT_SET_QUOTA request. SidLength is
+// derived from len(Sid) on marshal. QuotaThreshold/QuotaLimit may be -1 (no limit) and
+// QuotaLimit may be -2 (delete the entry), hence the signed types.
+type FileQuotaInformation struct {
+	// NextEntryOffset (4 bytes): byte offset to the next entry, or zero if this is the last.
+	NextEntryOffset uint32
+	// ChangeTime (8 bytes): last time the quota was changed (FILETIME). Ignored on set.
+	ChangeTime uint64
+	// QuotaUsed (8 bytes): bytes of quota used by this user.
+	QuotaUsed int64
+	// QuotaThreshold (8 bytes): warning threshold in bytes, or -1 for none.
+	QuotaThreshold int64
+	// QuotaLimit (8 bytes): quota limit in bytes, -1 for none, or -2 to delete the entry.
+	QuotaLimit int64
+	// Sid (variable): the SID this quota applies to.
+	Sid []byte
+}
+
+// Marshal serializes the FILE_QUOTA_INFORMATION record.
+func (q *FileQuotaInformation) Marshal() ([]byte, error) {
+	b := make([]byte, fileQuotaInformationFixedSize+len(q.Sid))
+	binary.LittleEndian.PutUint32(b[0:4], q.NextEntryOffset)
+	binary.LittleEndian.PutUint32(b[4:8], uint32(len(q.Sid)))
+	binary.LittleEndian.PutUint64(b[8:16], q.ChangeTime)
+	binary.LittleEndian.PutUint64(b[16:24], uint64(q.QuotaUsed))
+	binary.LittleEndian.PutUint64(b[24:32], uint64(q.QuotaThreshold))
+	binary.LittleEndian.PutUint64(b[32:40], uint64(q.QuotaLimit))
+	copy(b[fileQuotaInformationFixedSize:], q.Sid)
+	return b, nil
+}
+
+// Unmarshal parses a FILE_QUOTA_INFORMATION record, returning the bytes consumed.
+func (q *FileQuotaInformation) Unmarshal(data []byte) (int, error) {
+	if len(data) < fileQuotaInformationFixedSize {
+		return 0, fmt.Errorf("subcommands: FILE_QUOTA_INFORMATION requires at least %d bytes, got %d", fileQuotaInformationFixedSize, len(data))
+	}
+	q.NextEntryOffset = binary.LittleEndian.Uint32(data[0:4])
+	sidLength := int(binary.LittleEndian.Uint32(data[4:8]))
+	q.ChangeTime = binary.LittleEndian.Uint64(data[8:16])
+	q.QuotaUsed = int64(binary.LittleEndian.Uint64(data[16:24]))
+	q.QuotaThreshold = int64(binary.LittleEndian.Uint64(data[24:32]))
+	q.QuotaLimit = int64(binary.LittleEndian.Uint64(data[32:40]))
+	if len(data) < fileQuotaInformationFixedSize+sidLength {
+		return fileQuotaInformationFixedSize, fmt.Errorf("subcommands: FILE_QUOTA_INFORMATION SID truncated: need %d, have %d", sidLength, len(data)-fileQuotaInformationFixedSize)
+	}
+	q.Sid = append([]byte{}, data[fileQuotaInformationFixedSize:fileQuotaInformationFixedSize+sidLength]...)
+	return fileQuotaInformationFixedSize + sidLength, nil
+}

--- a/network/smb/smb_v10/subcommands/nt_transact_quota_test.go
+++ b/network/smb/smb_v10/subcommands/nt_transact_quota_test.go
@@ -1,0 +1,110 @@
+package subcommands
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+// sidS110 is the binary form of the well-known SID S-1-1-0 (Everyone): Revision(1),
+// SubAuthorityCount(1), IdentifierAuthority(6, big-endian = 1), one SubAuthority(4 = 0).
+var sidS110 = []byte{0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00}
+
+func TestNtTransQueryQuotaRequestParametersGolden(t *testing.T) {
+	p := NtTransQueryQuotaRequestParameters{FID: 0x4002, ReturnSingleEntry: true}
+	got, err := p.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	want := []byte{
+		0x02, 0x40, // FID
+		0x01,                   // ReturnSingleEntry = true
+		0x00,                   // RestartScan = false
+		0x00, 0x00, 0x00, 0x00, // SidListLength
+		0x00, 0x00, 0x00, 0x00, // StartSidLength
+		0x00, 0x00, 0x00, 0x00, // StartSidOffset
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("NT_TRANSACT_QUERY_QUOTA params:\n got % x\nwant % x", got, want)
+	}
+	var out NtTransQueryQuotaRequestParameters
+	if _, err := out.Unmarshal(got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out != p {
+		t.Errorf("round trip: got %+v want %+v", out, p)
+	}
+}
+
+func TestNtTransQuotaResponseParametersRoundTrip(t *testing.T) {
+	p := NtTransQuotaResponseParameters{DataLength: 52}
+	raw, err := p.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if len(raw) != 4 || binary.LittleEndian.Uint32(raw) != 52 {
+		t.Fatalf("DataLength marshal: % x", raw)
+	}
+	var out NtTransQuotaResponseParameters
+	if _, err := out.Unmarshal(raw); err != nil || out.DataLength != 52 {
+		t.Fatalf("round trip: %+v err=%v", out, err)
+	}
+}
+
+func TestFileQuotaInformationRoundTrip(t *testing.T) {
+	q := FileQuotaInformation{
+		NextEntryOffset: 0,
+		ChangeTime:      0x01C6841B620C8459,
+		QuotaUsed:       1024,
+		QuotaThreshold:  -1, // no warning threshold
+		QuotaLimit:      -2, // delete the entry
+		Sid:             sidS110,
+	}
+	raw, err := q.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if len(raw) != fileQuotaInformationFixedSize+len(sidS110) {
+		t.Fatalf("length: got %d want %d", len(raw), fileQuotaInformationFixedSize+len(sidS110))
+	}
+	// SidLength is derived into octets [4:8].
+	if got := binary.LittleEndian.Uint32(raw[4:8]); int(got) != len(sidS110) {
+		t.Errorf("SidLength: got %d want %d", got, len(sidS110))
+	}
+	if !bytes.Equal(raw[fileQuotaInformationFixedSize:], sidS110) {
+		t.Errorf("Sid tail:\n got % x\nwant % x", raw[fileQuotaInformationFixedSize:], sidS110)
+	}
+
+	var out FileQuotaInformation
+	n, err := out.Unmarshal(raw)
+	if err != nil || n != len(raw) {
+		t.Fatalf("Unmarshal: n=%d err=%v", n, err)
+	}
+	if out.ChangeTime != q.ChangeTime || out.QuotaUsed != q.QuotaUsed ||
+		out.QuotaThreshold != q.QuotaThreshold || out.QuotaLimit != q.QuotaLimit ||
+		!bytes.Equal(out.Sid, q.Sid) {
+		t.Errorf("round trip mismatch: %+v", out)
+	}
+}
+
+func TestFileGetQuotaInformationRoundTrip(t *testing.T) {
+	e := FileGetQuotaInformation{NextEntryOffset: 0, Sid: sidS110}
+	raw, err := e.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if len(raw) != fileGetQuotaInformationFixedSize+len(sidS110) {
+		t.Fatalf("length: got %d want %d", len(raw), fileGetQuotaInformationFixedSize+len(sidS110))
+	}
+	if got := binary.LittleEndian.Uint32(raw[4:8]); int(got) != len(sidS110) {
+		t.Errorf("SidLength: got %d want %d", got, len(sidS110))
+	}
+	var out FileGetQuotaInformation
+	n, err := out.Unmarshal(raw)
+	if err != nil || n != len(raw) {
+		t.Fatalf("Unmarshal: n=%d err=%v", n, err)
+	}
+	if out.NextEntryOffset != 0 || !bytes.Equal(out.Sid, sidS110) {
+		t.Errorf("round trip mismatch: %+v", out)
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #482`

### Root Cause
The MS-SMB per-user quota extension was never implemented beyond the `NT_TRANSACT_QUERY_QUOTA` / `NT_TRANSACT_SET_QUOTA` subcommand enum values: there were no request/response parameter blocks and no quota data records anywhere under `network/smb/smb_v10`.

### Fix Description
Add the quota NT_Trans parameter blocks and the MS-FSCC quota records in the `subcommands` package (`nt_transact_quota.go`), each with `Marshal`/`Unmarshal`:
- `NtTransQueryQuotaRequestParameters` — FID(2) + ReturnSingleEntry(1) + RestartScan(1) + SidListLength(4) + StartSidLength(4) + StartSidOffset(4) = 16 octets ([MS-SMB] §2.2.7.5.1).
- `NtTransQuotaResponseParameters` — DataLength(4) ([MS-SMB] §2.2.7.5.2).
- `FileGetQuotaInformation` — NextEntryOffset(4) + SidLength(4, derived from `len(Sid)`) + Sid ([MS-FSCC] §2.4.41.1); the SidList element of a query request.
- `FileQuotaInformation` — NextEntryOffset(4) + SidLength(4, derived) + ChangeTime(8) + QuotaUsed(8) + QuotaThreshold(8) + QuotaLimit(8) + Sid ([MS-FSCC] §2.4.41); the query-response record and the record a client sends in an `NT_TRANSACT_SET_QUOTA` request. `QuotaThreshold`/`QuotaLimit` are signed (allowing -1 = no limit, -2 = delete entry).

All multi-byte fields are little-endian. The issue's "SMB_QUERY_QUOTA_INFO" corresponds to the MS-FSCC `FILE_QUOTA_INFORMATION` record that [MS-SMB] §2.2.7.5.2 references for the quota NT_Trans_Data.

### How Verified
- **Tests:** `go test ./network/smb/smb_v10/subcommands` passes, including a golden check of the 16-octet query parameter block, a `DataLength` response round-trip, and round-trips of `FileQuotaInformation` (with `QuotaThreshold=-1`, `QuotaLimit=-2`, a 12-octet S-1-1-0 SID, derived `SidLength`) and `FileGetQuotaInformation`.
- **Static:** `go build ./...` and `go vet` are clean.

### Test Coverage
- **Added:** `network/smb/smb_v10/subcommands/nt_transact_quota_test.go` — `TestNtTransQueryQuotaRequestParametersGolden`, `TestNtTransQuotaResponseParametersRoundTrip`, `TestFileQuotaInformationRoundTrip`, `TestFileGetQuotaInformationRoundTrip`.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/subcommands/nt_transact_quota.go` (new), `network/smb/smb_v10/subcommands/nt_transact_quota_test.go` (new)
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none — only new types are added.

### Notes
`NT_TRANSACT_SET_QUOTA` carries its FID in the SMB setup and its payload as a list of `FileQuotaInformation` records (no distinct NT_Trans_Parameters block), so the same record type serves both query and set. Driving full quota request/response flows is a separate higher-level concern. Not live-validated against a server.
