### PR TITLE
Implement NT_TRANSACT_NOTIFY_CHANGE payloads (#483)

### DIFF
--- a/network/smb/smb_v10/subcommands/nt_transact_notify_change.go
+++ b/network/smb/smb_v10/subcommands/nt_transact_notify_change.go
@@ -1,0 +1,195 @@
+package subcommands
+
+import (
+	"encoding/binary"
+	"fmt"
+	"unicode/utf16"
+)
+
+// NT_TRANSACT_NOTIFY_CHANGE ([MS-CIFS] section 2.2.7.4) lets a client watch an open
+// directory for changes. The request carries its arguments in the NT_Trans setup words
+// (no NT_Trans_Parameters/Data); the response returns the changed-object records as a
+// list of FILE_NOTIFY_INFORMATION structures in the NT_Trans_Parameters block.
+
+// CompletionFilter flags for the NT_TRANSACT_NOTIFY_CHANGE setup ([MS-CIFS] section
+// 2.2.7.4.1): the set of change events the client wants to be notified about.
+const (
+	FILE_NOTIFY_CHANGE_FILE_NAME    uint32 = 0x00000001
+	FILE_NOTIFY_CHANGE_DIR_NAME     uint32 = 0x00000002
+	FILE_NOTIFY_CHANGE_NAME         uint32 = 0x00000003
+	FILE_NOTIFY_CHANGE_ATTRIBUTES   uint32 = 0x00000004
+	FILE_NOTIFY_CHANGE_SIZE         uint32 = 0x00000008
+	FILE_NOTIFY_CHANGE_LAST_WRITE   uint32 = 0x00000010
+	FILE_NOTIFY_CHANGE_LAST_ACCESS  uint32 = 0x00000020
+	FILE_NOTIFY_CHANGE_CREATION     uint32 = 0x00000040
+	FILE_NOTIFY_CHANGE_EA           uint32 = 0x00000080
+	FILE_NOTIFY_CHANGE_SECURITY     uint32 = 0x00000100
+	FILE_NOTIFY_CHANGE_STREAM_NAME  uint32 = 0x00000200
+	FILE_NOTIFY_CHANGE_STREAM_SIZE  uint32 = 0x00000400
+	FILE_NOTIFY_CHANGE_STREAM_WRITE uint32 = 0x00000800
+)
+
+// FILE_ACTION_* values for FileNotifyInformation.Action ([MS-FSCC] section 2.7.1): the
+// kind of change that occurred to the named object.
+const (
+	FILE_ACTION_ADDED            uint32 = 0x00000001
+	FILE_ACTION_REMOVED          uint32 = 0x00000002
+	FILE_ACTION_MODIFIED         uint32 = 0x00000003
+	FILE_ACTION_RENAMED_OLD_NAME uint32 = 0x00000004
+	FILE_ACTION_RENAMED_NEW_NAME uint32 = 0x00000005
+)
+
+const (
+	ntTransactNotifyChangeSetupSize = 8  // CompletionFilter(4) + FID(2) + WatchTree(1) + Reserved(1)
+	fileNotifyInformationHeaderSize = 12 // NextEntryOffset(4) + Action(4) + FileNameLength(4)
+)
+
+// utf16leBytes encodes a Go string as little-endian UTF-16 octets.
+func utf16leBytes(s string) []byte {
+	units := utf16.Encode([]rune(s))
+	b := make([]byte, len(units)*2)
+	for i, u := range units {
+		binary.LittleEndian.PutUint16(b[i*2:], u)
+	}
+	return b
+}
+
+// decodeUTF16LE decodes little-endian UTF-16 octets to a Go string (a trailing odd byte,
+// if any, is ignored).
+func decodeUTF16LE(b []byte) string {
+	units := make([]uint16, len(b)/2)
+	for i := range units {
+		units[i] = binary.LittleEndian.Uint16(b[i*2:])
+	}
+	return string(utf16.Decode(units))
+}
+
+// NtTransactNotifyChangeSetup is the NT_Trans setup of an NT_TRANSACT_NOTIFY_CHANGE
+// request ([MS-CIFS] section 2.2.7.4.1). The request carries no NT_Trans_Parameters or
+// NT_Trans_Data.
+type NtTransactNotifyChangeSetup struct {
+	// CompletionFilter (4 bytes): the change events to monitor (FILE_NOTIFY_CHANGE_* flags).
+	CompletionFilter uint32
+	// FID (2 bytes): the open directory to monitor.
+	FID uint16
+	// WatchTree (1 byte): if true, all subdirectories below FID are also watched.
+	WatchTree bool
+	// Reserved (1 byte): MUST be 0x00.
+	Reserved uint8
+}
+
+// Marshal serializes the 8-octet NT_Trans setup.
+func (s *NtTransactNotifyChangeSetup) Marshal() ([]byte, error) {
+	b := make([]byte, ntTransactNotifyChangeSetupSize)
+	binary.LittleEndian.PutUint32(b[0:4], s.CompletionFilter)
+	binary.LittleEndian.PutUint16(b[4:6], s.FID)
+	b[6] = boolToByte(s.WatchTree)
+	b[7] = s.Reserved
+	return b, nil
+}
+
+// Unmarshal parses the 8-octet NT_Trans setup.
+func (s *NtTransactNotifyChangeSetup) Unmarshal(data []byte) (int, error) {
+	if len(data) < ntTransactNotifyChangeSetupSize {
+		return 0, fmt.Errorf("subcommands: NT_TRANSACT_NOTIFY_CHANGE setup requires %d bytes, got %d", ntTransactNotifyChangeSetupSize, len(data))
+	}
+	s.CompletionFilter = binary.LittleEndian.Uint32(data[0:4])
+	s.FID = binary.LittleEndian.Uint16(data[4:6])
+	s.WatchTree = data[6] != 0
+	s.Reserved = data[7]
+	return ntTransactNotifyChangeSetupSize, nil
+}
+
+// FileNotifyInformation is one changed-object record returned in the
+// NT_TRANSACT_NOTIFY_CHANGE response ([MS-FSCC] section 2.7.1). FileNameLength (in octets)
+// is derived from FileName on marshal.
+type FileNotifyInformation struct {
+	// NextEntryOffset (4 bytes): octet offset from the start of this record to the next, or
+	// zero for the last record. Always a multiple of 4. Set by MarshalFileNotifyInformationList.
+	NextEntryOffset uint32
+	// Action (4 bytes): the change that occurred (FILE_ACTION_* value).
+	Action uint32
+	// FileName: the changed object's name, relative to the watched directory (UTF-16LE on
+	// the wire, not NUL-terminated).
+	FileName string
+}
+
+// Marshal serializes a single FILE_NOTIFY_INFORMATION record (NextEntryOffset is emitted
+// from the field as-is; use MarshalFileNotifyInformationList to chain a list).
+func (f *FileNotifyInformation) Marshal() ([]byte, error) {
+	nameBytes := utf16leBytes(f.FileName)
+	b := make([]byte, fileNotifyInformationHeaderSize+len(nameBytes))
+	binary.LittleEndian.PutUint32(b[0:4], f.NextEntryOffset)
+	binary.LittleEndian.PutUint32(b[4:8], f.Action)
+	binary.LittleEndian.PutUint32(b[8:12], uint32(len(nameBytes)))
+	copy(b[fileNotifyInformationHeaderSize:], nameBytes)
+	return b, nil
+}
+
+// Unmarshal parses a single FILE_NOTIFY_INFORMATION record, returning the number of octets
+// the record itself occupies (header + FileName, ignoring any trailing alignment padding).
+func (f *FileNotifyInformation) Unmarshal(data []byte) (int, error) {
+	if len(data) < fileNotifyInformationHeaderSize {
+		return 0, fmt.Errorf("subcommands: FILE_NOTIFY_INFORMATION requires at least %d bytes, got %d", fileNotifyInformationHeaderSize, len(data))
+	}
+	f.NextEntryOffset = binary.LittleEndian.Uint32(data[0:4])
+	f.Action = binary.LittleEndian.Uint32(data[4:8])
+	nameLength := int(binary.LittleEndian.Uint32(data[8:12]))
+	if len(data) < fileNotifyInformationHeaderSize+nameLength {
+		return fileNotifyInformationHeaderSize, fmt.Errorf("subcommands: FILE_NOTIFY_INFORMATION FileName truncated: need %d, have %d", nameLength, len(data)-fileNotifyInformationHeaderSize)
+	}
+	f.FileName = decodeUTF16LE(data[fileNotifyInformationHeaderSize : fileNotifyInformationHeaderSize+nameLength])
+	return fileNotifyInformationHeaderSize + nameLength, nil
+}
+
+// align4 rounds n up to the next multiple of 4.
+func align4(n int) int { return (n + 3) &^ 3 }
+
+// MarshalFileNotifyInformationList serializes the NT_TRANSACT_NOTIFY_CHANGE response
+// NT_Trans_Parameters: a chained list of FILE_NOTIFY_INFORMATION records. Each record's
+// NextEntryOffset is computed (4-byte aligned) so the list is correctly linked, with the
+// final record's NextEntryOffset set to zero.
+func MarshalFileNotifyInformationList(items []FileNotifyInformation) ([]byte, error) {
+	out := []byte{}
+	for i := range items {
+		nameBytes := utf16leBytes(items[i].FileName)
+		recordLen := fileNotifyInformationHeaderSize + len(nameBytes)
+		padded := align4(recordLen)
+
+		var next uint32
+		if i < len(items)-1 {
+			next = uint32(padded)
+		}
+
+		hdr := make([]byte, fileNotifyInformationHeaderSize)
+		binary.LittleEndian.PutUint32(hdr[0:4], next)
+		binary.LittleEndian.PutUint32(hdr[4:8], items[i].Action)
+		binary.LittleEndian.PutUint32(hdr[8:12], uint32(len(nameBytes)))
+		out = append(out, hdr...)
+		out = append(out, nameBytes...)
+		for p := recordLen; p < padded; p++ {
+			out = append(out, 0) // alignment padding
+		}
+	}
+	return out, nil
+}
+
+// ParseFileNotifyInformationList parses the NT_TRANSACT_NOTIFY_CHANGE response
+// NT_Trans_Parameters into its FILE_NOTIFY_INFORMATION records, following NextEntryOffset
+// until it is zero or the buffer is exhausted.
+func ParseFileNotifyInformationList(data []byte) ([]FileNotifyInformation, error) {
+	items := []FileNotifyInformation{}
+	offset := 0
+	for offset+fileNotifyInformationHeaderSize <= len(data) {
+		var rec FileNotifyInformation
+		if _, err := rec.Unmarshal(data[offset:]); err != nil {
+			return items, err
+		}
+		items = append(items, rec)
+		if rec.NextEntryOffset == 0 {
+			break
+		}
+		offset += int(rec.NextEntryOffset)
+	}
+	return items, nil
+}

--- a/network/smb/smb_v10/subcommands/nt_transact_notify_change_test.go
+++ b/network/smb/smb_v10/subcommands/nt_transact_notify_change_test.go
@@ -1,0 +1,91 @@
+package subcommands
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+func TestNtTransactNotifyChangeSetupGolden(t *testing.T) {
+	s := NtTransactNotifyChangeSetup{
+		CompletionFilter: FILE_NOTIFY_CHANGE_NAME, // 0x03
+		FID:              0x4002,
+		WatchTree:        true,
+	}
+	got, err := s.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	want := []byte{
+		0x03, 0x00, 0x00, 0x00, // CompletionFilter
+		0x02, 0x40, // FID
+		0x01, // WatchTree = true
+		0x00, // Reserved
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("NT_TRANSACT_NOTIFY_CHANGE setup:\n got % x\nwant % x", got, want)
+	}
+	var out NtTransactNotifyChangeSetup
+	if _, err := out.Unmarshal(got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out != s {
+		t.Errorf("round trip: got %+v want %+v", out, s)
+	}
+}
+
+func TestFileNotifyInformationGolden(t *testing.T) {
+	f := FileNotifyInformation{Action: FILE_ACTION_ADDED, FileName: "a.txt"}
+	got, err := f.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	// FileNameLength = 5 chars * 2 = 10 octets.
+	if got := binary.LittleEndian.Uint32(got[8:12]); got != 10 {
+		t.Errorf("FileNameLength: got %d want 10", got)
+	}
+	if binary.LittleEndian.Uint32(got[4:8]) != FILE_ACTION_ADDED {
+		t.Errorf("Action mismatch")
+	}
+	if len(got) != 12+10 {
+		t.Fatalf("length: got %d want %d", len(got), 12+10)
+	}
+
+	var out FileNotifyInformation
+	n, err := out.Unmarshal(got)
+	if err != nil || n != len(got) {
+		t.Fatalf("Unmarshal: n=%d err=%v", n, err)
+	}
+	if out.Action != f.Action || out.FileName != f.FileName {
+		t.Errorf("round trip: got %+v want %+v", out, f)
+	}
+}
+
+func TestFileNotifyInformationListRoundTrip(t *testing.T) {
+	items := []FileNotifyInformation{
+		{Action: FILE_ACTION_ADDED, FileName: "new.txt"},   // 7 chars -> 14 octets, record 26 -> padded 28
+		{Action: FILE_ACTION_REMOVED, FileName: "old.txt"}, // last entry, NextEntryOffset 0
+	}
+	raw, err := MarshalFileNotifyInformationList(items)
+	if err != nil {
+		t.Fatalf("Marshal list: %v", err)
+	}
+	// First record NextEntryOffset = align4(12 + 14) = 28.
+	if got := binary.LittleEndian.Uint32(raw[0:4]); got != 28 {
+		t.Errorf("first NextEntryOffset: got %d want 28", got)
+	}
+
+	out, err := ParseFileNotifyInformationList(raw)
+	if err != nil {
+		t.Fatalf("Parse list: %v", err)
+	}
+	if len(out) != 2 {
+		t.Fatalf("entries: got %d want 2", len(out))
+	}
+	if out[0].Action != FILE_ACTION_ADDED || out[0].FileName != "new.txt" {
+		t.Errorf("entry 0: %+v", out[0])
+	}
+	if out[1].Action != FILE_ACTION_REMOVED || out[1].FileName != "old.txt" || out[1].NextEntryOffset != 0 {
+		t.Errorf("entry 1: %+v", out[1])
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #483`

### Root Cause
`NT_TRANSACT_NOTIFY_CHANGE` existed only as a subcommand enum value; there were no request setup or response data structures (CompletionFilter/WatchTree, the returned `FILE_NOTIFY_INFORMATION` list) anywhere under `network/smb/smb_v10`.

### Fix Description
Add the notify-change structures in the `subcommands` package (`nt_transact_notify_change.go`):
- `CompletionFilter` flag constants (`FILE_NOTIFY_CHANGE_*`) and action constants (`FILE_ACTION_*`).
- `NtTransactNotifyChangeSetup` — the 8-octet NT_Trans setup: CompletionFilter(4) + FID(2) + WatchTree(1) + Reserved(1), per [MS-CIFS] §2.2.7.4.1 (the request carries no NT_Trans_Parameters/Data).
- `FileNotifyInformation` — NextEntryOffset(4) + Action(4) + FileNameLength(4, octets, derived) + FileName (UTF-16LE, not NUL-terminated), per [MS-FSCC] §2.7.1.
- `MarshalFileNotifyInformationList` / `ParseFileNotifyInformationList` — the response NT_Trans_Parameters list, with 4-byte-aligned `NextEntryOffset` chaining (zero on the last record) on marshal and `NextEntryOffset`-following on parse.

All multi-byte fields are little-endian; the field sizes/order and the 4-byte alignment of `NextEntryOffset` are per the cited spec sections.

### How Verified
- **Tests:** `go test ./network/smb/smb_v10/subcommands` passes, including a golden check of the 8-octet setup, a `FileNotifyInformation` round-trip with derived FileNameLength, and a two-entry list round-trip asserting the computed first `NextEntryOffset` (`align4(12+14)=28`).
- **Static:** `go build ./...` and `go vet` are clean.

### Test Coverage
- **Added:** `network/smb/smb_v10/subcommands/nt_transact_notify_change_test.go` — `TestNtTransactNotifyChangeSetupGolden`, `TestFileNotifyInformationGolden`, `TestFileNotifyInformationListRoundTrip`.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/subcommands/nt_transact_notify_change.go` (new), `network/smb/smb_v10/subcommands/nt_transact_notify_change_test.go` (new)
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none — only new types/constants are added.

### Notes
These are the NT_Trans setup and response-parameter payloads of an `SMB_COM_NT_TRANSACT` notify-change exchange; driving the full asynchronous request/response flow is a separate higher-level concern. Not live-validated against a server.
