### PR TITLE
Implement NT_TRANSACT_QUERY_SECURITY_DESC / SET_SECURITY_DESC payloads (#484)

### DIFF
--- a/network/smb/smb_v10/subcommands/nt_transact_security_desc.go
+++ b/network/smb/smb_v10/subcommands/nt_transact_security_desc.go
@@ -1,0 +1,88 @@
+package subcommands
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+// NT_TRANSACT_QUERY_SECURITY_DESC ([MS-CIFS] section 2.2.7.6) and
+// NT_TRANSACT_SET_SECURITY_DESC ([MS-CIFS] section 2.2.7.3) let a client read and apply a
+// file's self-relative SECURITY_DESCRIPTOR over SMB. Both carry their arguments in the
+// NT_Trans_Parameters block (FID + SecurityInformation); the descriptor itself travels as
+// the NT_Trans_Data and is treated here as an opaque blob ([MS-DTYP] section 2.4.6).
+
+// SecurityInformation flags ([MS-CIFS] sections 2.2.7.3.1 / 2.2.7.6.1): which parts of the
+// security descriptor a query or set operation applies to. They may be OR-ed together.
+const (
+	OWNER_SECURITY_INFORMATION uint32 = 0x00000001
+	GROUP_SECURITY_INFORMATION uint32 = 0x00000002
+	DACL_SECURITY_INFORMATION  uint32 = 0x00000004
+	SACL_SECURITY_INFORMATION  uint32 = 0x00000008
+)
+
+const (
+	ntTransactSecurityDescParametersSize    = 8 // FID(2) + Reserved(2) + SecurityInformation(4)
+	ntTransactQuerySecDescResponseParamSize = 4 // LengthNeeded(4)
+)
+
+// NtTransactSecurityDescParameters is the NT_Trans_Parameters block of an
+// NT_TRANSACT_QUERY_SECURITY_DESC request ([MS-CIFS] section 2.2.7.6.1, where the last
+// field is named SecurityInfoFields) and of an NT_TRANSACT_SET_SECURITY_DESC request
+// ([MS-CIFS] section 2.2.7.3.1, SecurityInformation). The two requests share this layout;
+// a set request additionally carries the SECURITY_DESCRIPTOR as its NT_Trans_Data, and a
+// query response carries LengthNeeded (see NtTransactQuerySecurityDescResponseParameters)
+// plus the descriptor as its NT_Trans_Data.
+type NtTransactSecurityDescParameters struct {
+	// FID (2 bytes): the open file whose security descriptor is queried or set.
+	FID uint16
+	// Reserved (2 bytes): MUST be 0x0000.
+	Reserved uint16
+	// SecurityInformation (4 bytes): the security-descriptor fields to query/set
+	// (OWNER/GROUP/DACL/SACL_SECURITY_INFORMATION flags).
+	SecurityInformation uint32
+}
+
+// Marshal serializes the 8-octet NT_Trans_Parameters block.
+func (p *NtTransactSecurityDescParameters) Marshal() ([]byte, error) {
+	b := make([]byte, ntTransactSecurityDescParametersSize)
+	binary.LittleEndian.PutUint16(b[0:2], p.FID)
+	binary.LittleEndian.PutUint16(b[2:4], p.Reserved)
+	binary.LittleEndian.PutUint32(b[4:8], p.SecurityInformation)
+	return b, nil
+}
+
+// Unmarshal parses the 8-octet NT_Trans_Parameters block.
+func (p *NtTransactSecurityDescParameters) Unmarshal(data []byte) (int, error) {
+	if len(data) < ntTransactSecurityDescParametersSize {
+		return 0, fmt.Errorf("subcommands: NT_TRANSACT security-descriptor parameters require %d bytes, got %d", ntTransactSecurityDescParametersSize, len(data))
+	}
+	p.FID = binary.LittleEndian.Uint16(data[0:2])
+	p.Reserved = binary.LittleEndian.Uint16(data[2:4])
+	p.SecurityInformation = binary.LittleEndian.Uint32(data[4:8])
+	return ntTransactSecurityDescParametersSize, nil
+}
+
+// NtTransactQuerySecurityDescResponseParameters is the NT_Trans_Parameters block of an
+// NT_TRANSACT_QUERY_SECURITY_DESC response ([MS-CIFS] section 2.2.7.6.2). The descriptor
+// itself is returned as the response NT_Trans_Data; if the client's buffer was too small,
+// LengthNeeded reports the required size and the NT_Trans_Data is empty.
+type NtTransactQuerySecurityDescResponseParameters struct {
+	// LengthNeeded (4 bytes): the length, in octets, of the returned (or required) descriptor.
+	LengthNeeded uint32
+}
+
+// Marshal serializes the 4-octet response parameter block.
+func (p *NtTransactQuerySecurityDescResponseParameters) Marshal() ([]byte, error) {
+	b := make([]byte, ntTransactQuerySecDescResponseParamSize)
+	binary.LittleEndian.PutUint32(b, p.LengthNeeded)
+	return b, nil
+}
+
+// Unmarshal parses the 4-octet response parameter block.
+func (p *NtTransactQuerySecurityDescResponseParameters) Unmarshal(data []byte) (int, error) {
+	if len(data) < ntTransactQuerySecDescResponseParamSize {
+		return 0, fmt.Errorf("subcommands: NT_TRANSACT_QUERY_SECURITY_DESC response parameters require %d bytes, got %d", ntTransactQuerySecDescResponseParamSize, len(data))
+	}
+	p.LengthNeeded = binary.LittleEndian.Uint32(data[0:4])
+	return ntTransactQuerySecDescResponseParamSize, nil
+}

--- a/network/smb/smb_v10/subcommands/nt_transact_security_desc_test.go
+++ b/network/smb/smb_v10/subcommands/nt_transact_security_desc_test.go
@@ -1,0 +1,50 @@
+package subcommands
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestNtTransactSecurityDescParametersGolden(t *testing.T) {
+	// Query/set the DACL+OWNER of FID 0x4002.
+	p := NtTransactSecurityDescParameters{
+		FID:                 0x4002,
+		SecurityInformation: OWNER_SECURITY_INFORMATION | DACL_SECURITY_INFORMATION, // 0x05
+	}
+	got, err := p.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	want := []byte{
+		0x02, 0x40, // FID
+		0x00, 0x00, // Reserved
+		0x05, 0x00, 0x00, 0x00, // SecurityInformation = OWNER|DACL
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("security-desc params:\n got % x\nwant % x", got, want)
+	}
+	var out NtTransactSecurityDescParameters
+	n, err := out.Unmarshal(got)
+	if err != nil || n != ntTransactSecurityDescParametersSize {
+		t.Fatalf("Unmarshal: n=%d err=%v", n, err)
+	}
+	if out != p {
+		t.Errorf("round trip: got %+v want %+v", out, p)
+	}
+}
+
+func TestNtTransactQuerySecurityDescResponseParametersRoundTrip(t *testing.T) {
+	p := NtTransactQuerySecurityDescResponseParameters{LengthNeeded: 0x94}
+	raw, err := p.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	want := []byte{0x94, 0x00, 0x00, 0x00}
+	if !bytes.Equal(raw, want) {
+		t.Errorf("LengthNeeded:\n got % x\nwant % x", raw, want)
+	}
+	var out NtTransactQuerySecurityDescResponseParameters
+	if _, err := out.Unmarshal(raw); err != nil || out.LengthNeeded != 0x94 {
+		t.Fatalf("round trip: %+v err=%v", out, err)
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #484`

### Root Cause
`NT_TRANSACT_QUERY_SECURITY_DESC` and `NT_TRANSACT_SET_SECURITY_DESC` existed only as subcommand enum values; there were no request/response parameter structures (FID, SecurityInformation, LengthNeeded) anywhere under `network/smb/smb_v10`.

### Fix Description
Add the security-descriptor NT_Trans_Parameters structures in the `subcommands` package (`nt_transact_security_desc.go`):
- `SecurityInformation` flag constants (`OWNER`/`GROUP`/`DACL`/`SACL_SECURITY_INFORMATION`).
- `NtTransactSecurityDescParameters` — FID(2) + Reserved(2) + SecurityInformation(4) = 8 octets. This is the shared request NT_Trans_Parameters for both query ([MS-CIFS] §2.2.7.6.1, field named `SecurityInfoFields`) and set ([MS-CIFS] §2.2.7.3.1, `SecurityInformation`).
- `NtTransactQuerySecurityDescResponseParameters` — LengthNeeded(4), the query response NT_Trans_Parameters ([MS-CIFS] §2.2.7.6.2).

The SECURITY_DESCRIPTOR itself is the NT_Trans_Data (self-relative form, [MS-DTYP] §2.4.6) and is carried by the caller as an opaque blob — parsing/validating its internal structure is an [MS-DTYP] concern outside this transport-layer package. As the issue notes, query and set share the same FID + SecurityInformation machinery, so a single parameters struct serves both request directions.

### How Verified
- **Tests:** `go test ./network/smb/smb_v10/subcommands` passes, including a golden check of the 8-octet parameter block (FID + Reserved + `OWNER|DACL` = 0x05) and a `LengthNeeded` response round-trip.
- **Static:** `go build ./...` and `go vet` are clean.

### Test Coverage
- **Added:** `network/smb/smb_v10/subcommands/nt_transact_security_desc_test.go` — `TestNtTransactSecurityDescParametersGolden`, `TestNtTransactQuerySecurityDescResponseParametersRoundTrip`.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/subcommands/nt_transact_security_desc.go` (new), `network/smb/smb_v10/subcommands/nt_transact_security_desc_test.go` (new)
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none — only new types/constants are added.

### Notes
The descriptor blob (NT_Trans_Data) is intentionally opaque here; building/parsing a full self-relative SECURITY_DESCRIPTOR is [MS-DTYP] work. Driving the full query/set request/response flow is a separate higher-level concern. Not live-validated against a server.
