### PR TITLE
Wire NT_TRANSACT subcommand structs into NtTransactRequest/Response builders (#508)

### DIFF
--- a/network/smb/smb_v10/message/commands/NtTransactRequest.go
+++ b/network/smb/smb_v10/message/commands/NtTransactRequest.go
@@ -100,6 +100,13 @@ type NtTransactRequest struct {
 	// the operation to be performed by the server.
 	Function types.USHORT
 
+	// Setup (variable): An array of two-byte words that provides transaction context to
+	// the server. The size and content are subcommand-specific (for example the
+	// CompletionFilter/FID/WatchTree words of NT_TRANSACT_NOTIFY_CHANGE or the
+	// FunctionCode/FID/IsFsctl/IsFlags words of NT_TRANSACT_IOCTL). SetupCount is derived
+	// from the length of this slice on marshal. See [MS-CIFS] section 2.2.4.62.1.
+	Setup []types.USHORT
+
 	// Data
 
 	// Pad1 (variable): This field SHOULD be used as an array of padding bytes to align
@@ -146,6 +153,8 @@ func NewNtTransactRequest() *NtTransactRequest {
 		DataOffset:          types.ULONG(0),
 		SetupCount:          types.UCHAR(0),
 		Function:            types.USHORT(0),
+
+		Setup: []types.USHORT{},
 
 		// Data
 		Pad1:                []types.UCHAR{},
@@ -256,13 +265,22 @@ func (c *NtTransactRequest) Marshal() ([]byte, error) {
 	binary.LittleEndian.PutUint32(buf4, uint32(c.DataOffset))
 	rawParametersContent = append(rawParametersContent, buf4...)
 
-	// Marshalling parameter SetupCount
+	// Marshalling parameter SetupCount (derived from the Setup words so the count and the
+	// array cannot disagree on the wire).
+	c.SetupCount = types.UCHAR(len(c.Setup))
 	rawParametersContent = append(rawParametersContent, types.UCHAR(c.SetupCount))
 
 	// Marshalling parameter Function
 	buf2 = make([]byte, 2)
 	binary.LittleEndian.PutUint16(buf2, uint16(c.Function))
 	rawParametersContent = append(rawParametersContent, buf2...)
+
+	// Marshalling parameter Setup (SetupCount two-byte words)
+	for _, setupWord := range c.Setup {
+		buf2 = make([]byte, 2)
+		binary.LittleEndian.PutUint16(buf2, uint16(setupWord))
+		rawParametersContent = append(rawParametersContent, buf2...)
+	}
 
 	// Marshalling parameters
 	c.GetParameters().AddWordsFromBytesStream(rawParametersContent)
@@ -406,6 +424,16 @@ func (c *NtTransactRequest) Unmarshal(rawData []byte) (int, error) {
 	}
 	c.Function = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
+
+	// Unmarshalling parameter Setup (SetupCount two-byte words)
+	if len(rawParametersContent) < offset+int(c.SetupCount)*2 {
+		return offset, fmt.Errorf("rawParametersContent too short for Setup")
+	}
+	c.Setup = make([]types.USHORT, c.SetupCount)
+	for i := 0; i < int(c.SetupCount); i++ {
+		c.Setup[i] = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
+		offset += 2
+	}
 
 	// Then unmarshal the data
 	offset = 0

--- a/network/smb/smb_v10/message/commands/NtTransactSubcommandBuilders.go
+++ b/network/smb/smb_v10/message/commands/NtTransactSubcommandBuilders.go
@@ -1,0 +1,230 @@
+package commands
+
+import (
+	"encoding/binary"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/subcommands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+)
+
+// This file wires the NT_TRANSACT subcommand payload structures (network/smb/smb_v10/
+// subcommands) into the SMB_COM_NT_TRANSACT message: request builders populate an
+// NtTransactRequest (Function, Setup words, NT_Trans_Parameters, NT_Trans_Data and the
+// associated counts) from a typed subcommand struct, and response parsers extract the
+// typed result from an NtTransactResponse. See [MS-CIFS] section 2.2.4.62 and the
+// per-subcommand sections referenced on each helper.
+
+// setupWordsFromBytes packs an even-length little-endian byte block (a subcommand's NT_Trans
+// setup) into the USHORT words carried by NtTransactRequest.Setup. An odd trailing byte, if
+// any, is zero-padded.
+func setupWordsFromBytes(b []byte) []types.USHORT {
+	words := make([]types.USHORT, (len(b)+1)/2)
+	for i := range words {
+		var lo, hi byte
+		lo = b[i*2]
+		if i*2+1 < len(b) {
+			hi = b[i*2+1]
+		}
+		words[i] = types.USHORT(uint16(lo) | uint16(hi)<<8)
+	}
+	return words
+}
+
+// uchars copies a byte slice into a []types.UCHAR (identical underlying element type).
+func uchars(b []byte) []types.UCHAR { return append([]types.UCHAR{}, b...) }
+
+// NewNtTransactIoctlSetup builds the 4-word (8-octet) NT_TRANSACT_IOCTL setup ([MS-CIFS]
+// section 2.2.7.2.1): FunctionCode(4) + FID(2) + IsFsctl(1) + IsFlags(1). For the SRV_*
+// FSCTLs, isFsctl is true and isFlags is zero.
+func NewNtTransactIoctlSetup(functionCode uint32, fid uint16, isFsctl bool, isFlags uint8) []types.USHORT {
+	b := make([]byte, 8)
+	binary.LittleEndian.PutUint32(b[0:4], functionCode)
+	binary.LittleEndian.PutUint16(b[4:6], fid)
+	if isFsctl {
+		b[6] = 1
+	}
+	b[7] = isFlags
+	return setupWordsFromBytes(b)
+}
+
+// ---- NT_TRANSACT_NOTIFY_CHANGE (0x0004) ------------------------------------------------
+
+// NewNtTransactNotifyChangeRequest builds an NT_TRANSACT_NOTIFY_CHANGE request ([MS-CIFS]
+// section 2.2.7.4.1). The arguments travel in the NT_Trans setup; the request carries no
+// NT_Trans_Parameters or NT_Trans_Data. maxParameterCount bounds the FILE_NOTIFY_INFORMATION
+// bytes the server may return.
+func NewNtTransactNotifyChangeRequest(setup subcommands.NtTransactNotifyChangeSetup, maxParameterCount uint32) (*NtTransactRequest, error) {
+	setupBytes, err := setup.Marshal()
+	if err != nil {
+		return nil, err
+	}
+	r := NewNtTransactRequest()
+	r.Function = types.USHORT(subcommands.NT_TRANSACT_NOTIFY_CHANGE)
+	r.Setup = setupWordsFromBytes(setupBytes)
+	r.SetupCount = types.UCHAR(len(r.Setup))
+	r.MaxParameterCount = types.ULONG(maxParameterCount)
+	return r, nil
+}
+
+// NotifyChangeInformation parses the FILE_NOTIFY_INFORMATION list from an
+// NT_TRANSACT_NOTIFY_CHANGE response NT_Trans_Parameters ([MS-CIFS] section 2.2.7.4.2).
+func (c *NtTransactResponse) NotifyChangeInformation() ([]subcommands.FileNotifyInformation, error) {
+	return subcommands.ParseFileNotifyInformationList(c.Parameters)
+}
+
+// ---- NT_TRANSACT_QUERY_SECURITY_DESC (0x0006) / SET_SECURITY_DESC (0x0003) --------------
+
+// NewNtTransactQuerySecurityDescRequest builds an NT_TRANSACT_QUERY_SECURITY_DESC request
+// ([MS-CIFS] section 2.2.7.6.1). The FID/SecurityInformation travel in NT_Trans_Parameters;
+// maxDataCount bounds the returned SECURITY_DESCRIPTOR and MaxParameterCount is 4 (LengthNeeded).
+func NewNtTransactQuerySecurityDescRequest(params subcommands.NtTransactSecurityDescParameters, maxDataCount uint32) (*NtTransactRequest, error) {
+	pb, err := params.Marshal()
+	if err != nil {
+		return nil, err
+	}
+	r := NewNtTransactRequest()
+	r.Function = types.USHORT(subcommands.NT_TRANSACT_QUERY_SECURITY_DESC)
+	r.NT_Trans_Parameters = uchars(pb)
+	r.TotalParameterCount = types.ULONG(len(pb))
+	r.ParameterCount = types.ULONG(len(pb))
+	r.MaxParameterCount = types.ULONG(4)
+	r.MaxDataCount = types.ULONG(maxDataCount)
+	return r, nil
+}
+
+// NewNtTransactSetSecurityDescRequest builds an NT_TRANSACT_SET_SECURITY_DESC request
+// ([MS-CIFS] section 2.2.7.3.1). FID/SecurityInformation travel in NT_Trans_Parameters and
+// the self-relative SECURITY_DESCRIPTOR travels in NT_Trans_Data.
+func NewNtTransactSetSecurityDescRequest(params subcommands.NtTransactSecurityDescParameters, securityDescriptor []byte) (*NtTransactRequest, error) {
+	pb, err := params.Marshal()
+	if err != nil {
+		return nil, err
+	}
+	r := NewNtTransactRequest()
+	r.Function = types.USHORT(subcommands.NT_TRANSACT_SET_SECURITY_DESC)
+	r.NT_Trans_Parameters = uchars(pb)
+	r.TotalParameterCount = types.ULONG(len(pb))
+	r.ParameterCount = types.ULONG(len(pb))
+	r.NT_Trans_Data = uchars(securityDescriptor)
+	r.TotalDataCount = types.ULONG(len(securityDescriptor))
+	r.DataCount = types.ULONG(len(securityDescriptor))
+	return r, nil
+}
+
+// QuerySecurityDescriptor parses an NT_TRANSACT_QUERY_SECURITY_DESC response ([MS-CIFS]
+// section 2.2.7.6.2): the LengthNeeded parameter and the returned SECURITY_DESCRIPTOR bytes.
+func (c *NtTransactResponse) QuerySecurityDescriptor() (subcommands.NtTransactQuerySecurityDescResponseParameters, []byte, error) {
+	var params subcommands.NtTransactQuerySecurityDescResponseParameters
+	if _, err := params.Unmarshal(c.Parameters); err != nil {
+		return params, nil, err
+	}
+	return params, append([]byte{}, c.Data...), nil
+}
+
+// ---- NT_TRANSACT_QUERY_QUOTA (0x0007) --------------------------------------------------
+
+// NewNtTransactQueryQuotaRequest builds an NT_TRANSACT_QUERY_QUOTA request ([MS-SMB] section
+// 2.2.7.5.1). The query parameters travel in NT_Trans_Parameters and the optional SidList
+// (FILE_GET_QUOTA_INFORMATION entries) travels in NT_Trans_Data. maxDataCount bounds the
+// returned FILE_QUOTA_INFORMATION list.
+func NewNtTransactQueryQuotaRequest(params subcommands.NtTransQueryQuotaRequestParameters, sidList []byte, maxDataCount uint32) (*NtTransactRequest, error) {
+	pb, err := params.Marshal()
+	if err != nil {
+		return nil, err
+	}
+	r := NewNtTransactRequest()
+	r.Function = types.USHORT(subcommands.NT_TRANSACT_QUERY_QUOTA)
+	r.NT_Trans_Parameters = uchars(pb)
+	r.TotalParameterCount = types.ULONG(len(pb))
+	r.ParameterCount = types.ULONG(len(pb))
+	r.NT_Trans_Data = uchars(sidList)
+	r.TotalDataCount = types.ULONG(len(sidList))
+	r.DataCount = types.ULONG(len(sidList))
+	r.MaxParameterCount = types.ULONG(4) // DataLength
+	r.MaxDataCount = types.ULONG(maxDataCount)
+	return r, nil
+}
+
+// QuotaInformation parses an NT_TRANSACT_QUERY_QUOTA response ([MS-SMB] section 2.2.7.5.2):
+// the DataLength parameter and the FILE_QUOTA_INFORMATION list in NT_Trans_Data.
+func (c *NtTransactResponse) QuotaInformation() (subcommands.NtTransQuotaResponseParameters, []subcommands.FileQuotaInformation, error) {
+	var params subcommands.NtTransQuotaResponseParameters
+	if len(c.Parameters) >= 4 {
+		if _, err := params.Unmarshal(c.Parameters); err != nil {
+			return params, nil, err
+		}
+	}
+	list, err := subcommands.ParseFileQuotaInformationList(c.Data)
+	return params, list, err
+}
+
+// ---- NT_TRANSACT_IOCTL (0x0002): server-side copy and snapshots -------------------------
+
+// NewNtTransactRequestResumeKeyRequest builds the FSCTL_SRV_REQUEST_RESUME_KEY request for
+// the source file ([MS-SMB] section 2.2.7.2): an NT_TRANSACT_IOCTL whose setup names the
+// FSCTL and the source FID, with no input data. maxDataCount bounds the returned resume-key
+// data (a 24-byte key plus a 4-byte ContextLength).
+func NewNtTransactRequestResumeKeyRequest(fid uint16, maxDataCount uint32) *NtTransactRequest {
+	r := NewNtTransactRequest()
+	r.Function = types.USHORT(subcommands.NT_TRANSACT_IOCTL)
+	r.Setup = NewNtTransactIoctlSetup(subcommands.FSCTL_SRV_REQUEST_RESUME_KEY, fid, true, 0)
+	r.SetupCount = types.UCHAR(len(r.Setup))
+	r.MaxDataCount = types.ULONG(maxDataCount)
+	return r
+}
+
+// NewNtTransactCopychunkRequest builds an FSCTL_SRV_COPYCHUNK request against the destination
+// file ([MS-SMB] section 2.2.7.2): an NT_TRANSACT_IOCTL whose setup names the FSCTL and the
+// destination FID, carrying the SRV_COPYCHUNK_COPY as input data. The response is a 12-byte
+// SRV_COPYCHUNK_RESPONSE.
+func NewNtTransactCopychunkRequest(fid uint16, copy subcommands.SrvCopychunkCopy) (*NtTransactRequest, error) {
+	db, err := copy.Marshal()
+	if err != nil {
+		return nil, err
+	}
+	r := NewNtTransactRequest()
+	r.Function = types.USHORT(subcommands.NT_TRANSACT_IOCTL)
+	r.Setup = NewNtTransactIoctlSetup(subcommands.FSCTL_SRV_COPYCHUNK, fid, true, 0)
+	r.SetupCount = types.UCHAR(len(r.Setup))
+	r.NT_Trans_Data = uchars(db)
+	r.TotalDataCount = types.ULONG(len(db))
+	r.DataCount = types.ULONG(len(db))
+	r.MaxDataCount = types.ULONG(12) // SRV_COPYCHUNK_RESPONSE
+	return r, nil
+}
+
+// NewNtTransactEnumerateSnapshotsRequest builds an FSCTL_SRV_ENUMERATE_SNAPSHOTS request
+// ([MS-SMB] section 2.2.7.3): an NT_TRANSACT_IOCTL whose setup names the FSCTL and the open
+// FID, with no input data. maxDataCount bounds the returned SRV_SNAPSHOT_ARRAY.
+func NewNtTransactEnumerateSnapshotsRequest(fid uint16, maxDataCount uint32) *NtTransactRequest {
+	r := NewNtTransactRequest()
+	r.Function = types.USHORT(subcommands.NT_TRANSACT_IOCTL)
+	r.Setup = NewNtTransactIoctlSetup(subcommands.FSCTL_SRV_ENUMERATE_SNAPSHOTS, fid, true, 0)
+	r.SetupCount = types.UCHAR(len(r.Setup))
+	r.MaxDataCount = types.ULONG(maxDataCount)
+	return r
+}
+
+// RequestResumeKey parses an FSCTL_SRV_REQUEST_RESUME_KEY response from the NT_Trans_Data
+// ([MS-SMB] section 2.2.7.2.2.2).
+func (c *NtTransactResponse) RequestResumeKey() (subcommands.SrvRequestResumeKeyResponse, error) {
+	var out subcommands.SrvRequestResumeKeyResponse
+	_, err := out.Unmarshal(c.Data)
+	return out, err
+}
+
+// CopychunkResponse parses an FSCTL_SRV_COPYCHUNK response from the NT_Trans_Data ([MS-SMB]
+// section 2.2.7.2.2.1).
+func (c *NtTransactResponse) CopychunkResponse() (subcommands.SrvCopychunkResponse, error) {
+	var out subcommands.SrvCopychunkResponse
+	_, err := out.Unmarshal(c.Data)
+	return out, err
+}
+
+// SnapshotArray parses an FSCTL_SRV_ENUMERATE_SNAPSHOTS response from the NT_Trans_Data
+// ([MS-SMB] section 2.2.7.3.2).
+func (c *NtTransactResponse) SnapshotArray() (subcommands.SrvSnapshotArray, error) {
+	var out subcommands.SrvSnapshotArray
+	_, err := out.Unmarshal(c.Data)
+	return out, err
+}

--- a/network/smb/smb_v10/message/commands/NtTransactSubcommandBuilders_test.go
+++ b/network/smb/smb_v10/message/commands/NtTransactSubcommandBuilders_test.go
@@ -1,0 +1,266 @@
+package commands_test
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/subcommands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+)
+
+// TestNtTransactRequestSetupRoundTrip verifies the new Setup-words field on
+// NtTransactRequest marshals after Function and round-trips (SetupCount derived).
+func TestNtTransactRequestSetupRoundTrip(t *testing.T) {
+	r := commands.NewNtTransactRequest()
+	r.Function = types.USHORT(subcommands.NT_TRANSACT_IOCTL)
+	r.Setup = []types.USHORT{0x0078, 0x0014, 0x4002, 0x0001}
+
+	raw, err := r.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var out commands.NtTransactRequest
+	if _, err := out.Unmarshal(raw); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out.Function != r.Function {
+		t.Errorf("Function: got 0x%04x want 0x%04x", out.Function, r.Function)
+	}
+	if out.SetupCount != 4 {
+		t.Errorf("SetupCount: got %d want 4", out.SetupCount)
+	}
+	if len(out.Setup) != 4 || out.Setup[0] != 0x0078 || out.Setup[3] != 0x0001 {
+		t.Errorf("Setup round trip: got %v", out.Setup)
+	}
+}
+
+func TestNtTransactIoctlSetup(t *testing.T) {
+	setup := commands.NewNtTransactIoctlSetup(subcommands.FSCTL_SRV_COPYCHUNK, 0x4003, true, 0)
+	if len(setup) != 4 {
+		t.Fatalf("setup words: got %d want 4", len(setup))
+	}
+	// Reassemble the 8 setup octets and check FunctionCode/FID/IsFsctl/IsFlags.
+	b := make([]byte, 8)
+	for i, w := range setup {
+		binary.LittleEndian.PutUint16(b[i*2:], uint16(w))
+	}
+	if got := binary.LittleEndian.Uint32(b[0:4]); got != subcommands.FSCTL_SRV_COPYCHUNK {
+		t.Errorf("FunctionCode: got 0x%08x want 0x%08x", got, subcommands.FSCTL_SRV_COPYCHUNK)
+	}
+	if got := binary.LittleEndian.Uint16(b[4:6]); got != 0x4003 {
+		t.Errorf("FID: got 0x%04x want 0x4003", got)
+	}
+	if b[6] != 1 || b[7] != 0 {
+		t.Errorf("IsFsctl/IsFlags: got %d/%d want 1/0", b[6], b[7])
+	}
+}
+
+func TestNotifyChangeBuilderAndResponse(t *testing.T) {
+	setup := subcommands.NtTransactNotifyChangeSetup{
+		CompletionFilter: subcommands.FILE_NOTIFY_CHANGE_NAME,
+		FID:              0x4002,
+		WatchTree:        true,
+	}
+	req, err := commands.NewNtTransactNotifyChangeRequest(setup, 0x1000)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	// Full request round-trips (setup-only, no NT_Trans_Parameters/Data).
+	raw, err := req.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var out commands.NtTransactRequest
+	if _, err := out.Unmarshal(raw); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out.Function != types.USHORT(subcommands.NT_TRANSACT_NOTIFY_CHANGE) || out.SetupCount != 4 {
+		t.Fatalf("decoded Function=0x%04x SetupCount=%d", out.Function, out.SetupCount)
+	}
+	// Setup words decode back to the notify-change setup.
+	setupBytes := make([]byte, len(out.Setup)*2)
+	for i, w := range out.Setup {
+		binary.LittleEndian.PutUint16(setupBytes[i*2:], uint16(w))
+	}
+	var decoded subcommands.NtTransactNotifyChangeSetup
+	if _, err := decoded.Unmarshal(setupBytes); err != nil {
+		t.Fatalf("decode setup: %v", err)
+	}
+	if decoded != setup {
+		t.Errorf("setup round trip: got %+v want %+v", decoded, setup)
+	}
+
+	// Response: a FILE_NOTIFY_INFORMATION list in NT_Trans_Parameters.
+	listBytes, _ := subcommands.MarshalFileNotifyInformationList([]subcommands.FileNotifyInformation{
+		{Action: subcommands.FILE_ACTION_ADDED, FileName: "a.txt"},
+		{Action: subcommands.FILE_ACTION_REMOVED, FileName: "b.log"},
+	})
+	resp := commands.NewNtTransactResponse()
+	resp.Parameters = listBytes
+	items, err := resp.NotifyChangeInformation()
+	if err != nil {
+		t.Fatalf("NotifyChangeInformation: %v", err)
+	}
+	if len(items) != 2 || items[0].FileName != "a.txt" || items[1].Action != subcommands.FILE_ACTION_REMOVED {
+		t.Errorf("notify list: %+v", items)
+	}
+}
+
+func TestSecurityDescBuilders(t *testing.T) {
+	params := subcommands.NtTransactSecurityDescParameters{
+		FID:                 0x4002,
+		SecurityInformation: subcommands.OWNER_SECURITY_INFORMATION | subcommands.DACL_SECURITY_INFORMATION,
+	}
+	descriptor := []byte{0x01, 0x00, 0x04, 0x80, 0xDE, 0xAD, 0xBE, 0xEF} // opaque self-relative SD bytes
+
+	// Query request: params in NT_Trans_Parameters, MaxParameterCount = 4.
+	q, err := commands.NewNtTransactQuerySecurityDescRequest(params, 0x400)
+	if err != nil {
+		t.Fatalf("query build: %v", err)
+	}
+	if q.Function != types.USHORT(subcommands.NT_TRANSACT_QUERY_SECURITY_DESC) || q.MaxParameterCount != 4 {
+		t.Errorf("query: Function=0x%04x MaxParameterCount=%d", q.Function, q.MaxParameterCount)
+	}
+	var qp subcommands.NtTransactSecurityDescParameters
+	if _, err := qp.Unmarshal(q.NT_Trans_Parameters); err != nil || qp != params {
+		t.Errorf("query params: %+v err=%v", qp, err)
+	}
+
+	// Set request: params + descriptor in NT_Trans_Data.
+	s, err := commands.NewNtTransactSetSecurityDescRequest(params, descriptor)
+	if err != nil {
+		t.Fatalf("set build: %v", err)
+	}
+	if s.Function != types.USHORT(subcommands.NT_TRANSACT_SET_SECURITY_DESC) {
+		t.Errorf("set Function=0x%04x", s.Function)
+	}
+	if !bytes.Equal(s.NT_Trans_Data, descriptor) || s.DataCount != types.ULONG(len(descriptor)) {
+		t.Errorf("set data mismatch: % x (count %d)", s.NT_Trans_Data, s.DataCount)
+	}
+
+	// Response: LengthNeeded parameter + descriptor data.
+	respParams := subcommands.NtTransactQuerySecurityDescResponseParameters{LengthNeeded: uint32(len(descriptor))}
+	pb, _ := respParams.Marshal()
+	resp := commands.NewNtTransactResponse()
+	resp.Parameters = pb
+	resp.Data = descriptor
+	gotParams, gotSD, err := resp.QuerySecurityDescriptor()
+	if err != nil {
+		t.Fatalf("QuerySecurityDescriptor: %v", err)
+	}
+	if gotParams.LengthNeeded != uint32(len(descriptor)) || !bytes.Equal(gotSD, descriptor) {
+		t.Errorf("query response: %+v / % x", gotParams, gotSD)
+	}
+}
+
+func TestQuotaBuilderAndResponse(t *testing.T) {
+	params := subcommands.NtTransQueryQuotaRequestParameters{FID: 0x4002, ReturnSingleEntry: true}
+	req, err := commands.NewNtTransactQueryQuotaRequest(params, nil, 0x2000)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if req.Function != types.USHORT(subcommands.NT_TRANSACT_QUERY_QUOTA) {
+		t.Errorf("Function=0x%04x", req.Function)
+	}
+	var qp subcommands.NtTransQueryQuotaRequestParameters
+	if _, err := qp.Unmarshal(req.NT_Trans_Parameters); err != nil || qp != params {
+		t.Errorf("quota params: %+v err=%v", qp, err)
+	}
+
+	// Response: DataLength parameter + one FILE_QUOTA_INFORMATION record.
+	rec := subcommands.FileQuotaInformation{QuotaUsed: 4096, QuotaThreshold: -1, QuotaLimit: -1, Sid: []byte{0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00}}
+	recBytes, _ := rec.Marshal()
+	respParams := subcommands.NtTransQuotaResponseParameters{DataLength: uint32(len(recBytes))}
+	pb, _ := respParams.Marshal()
+	resp := commands.NewNtTransactResponse()
+	resp.Parameters = pb
+	resp.Data = recBytes
+	gotParams, list, err := resp.QuotaInformation()
+	if err != nil {
+		t.Fatalf("QuotaInformation: %v", err)
+	}
+	if gotParams.DataLength != uint32(len(recBytes)) || len(list) != 1 || list[0].QuotaUsed != 4096 {
+		t.Errorf("quota response: %+v list=%+v", gotParams, list)
+	}
+}
+
+func TestCopychunkBuilderAndResponse(t *testing.T) {
+	cc := subcommands.SrvCopychunkCopy{
+		CopychunkResumeKey: [24]byte{0x2D, 0x0B},
+		Chunks:             []subcommands.SrvCopychunk{{SourceOffset: 0, DestinationOffset: 0, Length: 0x063C}},
+	}
+	req, err := commands.NewNtTransactCopychunkRequest(0x4003, cc)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if req.Function != types.USHORT(subcommands.NT_TRANSACT_IOCTL) || len(req.Setup) != 4 {
+		t.Fatalf("Function=0x%04x setup=%d", req.Function, len(req.Setup))
+	}
+	// Setup FSCTL code.
+	b := make([]byte, 8)
+	for i, w := range req.Setup {
+		binary.LittleEndian.PutUint16(b[i*2:], uint16(w))
+	}
+	if binary.LittleEndian.Uint32(b[0:4]) != subcommands.FSCTL_SRV_COPYCHUNK {
+		t.Errorf("setup FSCTL code mismatch")
+	}
+	// NT_Trans_Data round-trips to the copy struct.
+	var gotCopy subcommands.SrvCopychunkCopy
+	if _, err := gotCopy.Unmarshal(req.NT_Trans_Data); err != nil {
+		t.Fatalf("copy unmarshal: %v", err)
+	}
+	if len(gotCopy.Chunks) != 1 || gotCopy.Chunks[0].Length != 0x063C {
+		t.Errorf("copy data: %+v", gotCopy)
+	}
+
+	// Response.
+	rb, _ := (&subcommands.SrvCopychunkResponse{ChunksWritten: 1, TotalBytesWritten: 0x063C}).Marshal()
+	resp := commands.NewNtTransactResponse()
+	resp.Data = rb
+	got, err := resp.CopychunkResponse()
+	if err != nil {
+		t.Fatalf("CopychunkResponse: %v", err)
+	}
+	if got.ChunksWritten != 1 || got.TotalBytesWritten != 0x063C {
+		t.Errorf("copychunk response: %+v", got)
+	}
+}
+
+func TestSnapshotAndResumeKeyResponses(t *testing.T) {
+	// Resume-key request build.
+	rk := commands.NewNtTransactRequestResumeKeyRequest(0x4002, 0x400)
+	b := make([]byte, 8)
+	for i, w := range rk.Setup {
+		binary.LittleEndian.PutUint16(b[i*2:], uint16(w))
+	}
+	if binary.LittleEndian.Uint32(b[0:4]) != subcommands.FSCTL_SRV_REQUEST_RESUME_KEY {
+		t.Errorf("resume-key setup FSCTL mismatch")
+	}
+
+	// Resume-key response parse.
+	rkResp, _ := (&subcommands.SrvRequestResumeKeyResponse{CopychunkResumeKey: [24]byte{0xAA, 0xBB}}).Marshal()
+	resp := commands.NewNtTransactResponse()
+	resp.Data = rkResp
+	gotRK, err := resp.RequestResumeKey()
+	if err != nil || gotRK.CopychunkResumeKey[0] != 0xAA {
+		t.Fatalf("RequestResumeKey: %+v err=%v", gotRK, err)
+	}
+
+	// Snapshot enumerate request build + response parse.
+	snReq := commands.NewNtTransactEnumerateSnapshotsRequest(0x4002, 0x2000)
+	if snReq.Function != types.USHORT(subcommands.NT_TRANSACT_IOCTL) {
+		t.Errorf("snapshot Function=0x%04x", snReq.Function)
+	}
+	snBytes, _ := (&subcommands.SrvSnapshotArray{NumberOfSnapShots: 1, Snapshots: []string{"@GMT-2020.01.02-03.04.05"}}).Marshal()
+	resp2 := commands.NewNtTransactResponse()
+	resp2.Data = snBytes
+	got, err := resp2.SnapshotArray()
+	if err != nil {
+		t.Fatalf("SnapshotArray: %v", err)
+	}
+	if len(got.Snapshots) != 1 || got.Snapshots[0] != "@GMT-2020.01.02-03.04.05" {
+		t.Errorf("snapshot array: %+v", got)
+	}
+}

--- a/network/smb/smb_v10/subcommands/nt_transact_quota.go
+++ b/network/smb/smb_v10/subcommands/nt_transact_quota.go
@@ -176,3 +176,23 @@ func (q *FileQuotaInformation) Unmarshal(data []byte) (int, error) {
 	q.Sid = append([]byte{}, data[fileQuotaInformationFixedSize:fileQuotaInformationFixedSize+sidLength]...)
 	return fileQuotaInformationFixedSize + sidLength, nil
 }
+
+// ParseFileQuotaInformationList parses the NT_TRANSACT_QUERY_QUOTA response NT_Trans_Data
+// into its FILE_QUOTA_INFORMATION records, following NextEntryOffset until it is zero or
+// the buffer is exhausted.
+func ParseFileQuotaInformationList(data []byte) ([]FileQuotaInformation, error) {
+	items := []FileQuotaInformation{}
+	offset := 0
+	for offset+fileQuotaInformationFixedSize <= len(data) {
+		var rec FileQuotaInformation
+		if _, err := rec.Unmarshal(data[offset:]); err != nil {
+			return items, err
+		}
+		items = append(items, rec)
+		if rec.NextEntryOffset == 0 {
+			break
+		}
+		offset += int(rec.NextEntryOffset)
+	}
+	return items, nil
+}


### PR DESCRIPTION
### Linked Issue
`Closes #508`

### Root Cause
The NT_TRANSACT subcommand payload structures (issues #480–#484) were implemented standalone in `network/smb/smb_v10/subcommands` but never connected to the `SMB_COM_NT_TRANSACT` message layer. Worse, `NtTransactRequest` was missing the `Setup` words array entirely (it had only `SetupCount` and `Function`), so subcommands that carry their arguments in the NT_Trans setup — `NT_TRANSACT_NOTIFY_CHANGE` and the `NT_TRANSACT_IOCTL` FSCTLs — could not be represented at all.

### Fix Description
1. **`NtTransactRequest` gains the `Setup []USHORT` field** ([MS-CIFS] §2.2.4.62.1: `…SetupCount, Function, Setup[SetupCount]`). It is marshalled immediately after `Function`, `SetupCount` is derived from `len(Setup)`, and `Unmarshal` reads `SetupCount` words after `Function`. This mirrors the `Setup` field that `NtTransactResponse` already had.
2. **`NtTransactSubcommandBuilders.go`** (new, in the `commands` package, importing `subcommands`) adds request builders and response parsers:
   - `NewNtTransactIoctlSetup(functionCode, fid, isFsctl, isFlags)` — the 4-word NT_TRANSACT_IOCTL setup.
   - `NewNtTransactNotifyChangeRequest` + `(*NtTransactResponse).NotifyChangeInformation()`.
   - `NewNtTransactQuerySecurityDescRequest` / `NewNtTransactSetSecurityDescRequest` + `(*NtTransactResponse).QuerySecurityDescriptor()`.
   - `NewNtTransactQueryQuotaRequest` + `(*NtTransactResponse).QuotaInformation()`.
   - `NewNtTransactRequestResumeKeyRequest` / `NewNtTransactCopychunkRequest` / `NewNtTransactEnumerateSnapshotsRequest` + `(*NtTransactResponse).RequestResumeKey()` / `CopychunkResponse()` / `SnapshotArray()`.
   Each builder sets `Function`, the `Setup` words (for notify-change and the IOCTL FSCTLs), `NT_Trans_Parameters`/`NT_Trans_Data`, and the associated counts. Parsers read the response `Parameters`/`Data` blocks into the typed structs.
3. **`subcommands/nt_transact_quota.go`** gains `ParseFileQuotaInformationList` (walks `NextEntryOffset`), used by `QuotaInformation()`.

The IOCTL setup layout (FunctionCode/FID/IsFsctl/IsFlags) is per [MS-CIFS] §2.2.7.2 and the [MS-SMB] §2.2.7.2 copychunk example trace.

### How Verified
- **Tests:** `go test ./network/smb/smb_v10/...` passes. New tests cover the `NtTransactRequest.Setup` round-trip, the IOCTL setup, a full notify-change request round-trip (setup-only) plus response list parse, and build-then-reparse + response parse for security-descriptor, quota, copychunk, resume-key, and snapshot subcommands. The pre-existing `TestNtTransactRequestPadRoundTrip` still passes (the `Setup` addition does not disturb the Pad1/Pad2 offset logic).
- **Static:** `go build ./...` and `go vet ./network/smb/smb_v10/...` are clean.

### Test Coverage
- **Added:** `network/smb/smb_v10/message/commands/NtTransactSubcommandBuilders_test.go` — `TestNtTransactRequestSetupRoundTrip`, `TestNtTransactIoctlSetup`, `TestNotifyChangeBuilderAndResponse`, `TestSecurityDescBuilders`, `TestQuotaBuilderAndResponse`, `TestCopychunkBuilderAndResponse`, `TestSnapshotAndResumeKeyResponses`.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/commands/NtTransactRequest.go`, `network/smb/smb_v10/message/commands/NtTransactSubcommandBuilders.go` (new), `network/smb/smb_v10/message/commands/NtTransactSubcommandBuilders_test.go` (new), `network/smb/smb_v10/subcommands/nt_transact_quota.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none — the `Setup` field defaults to empty (`SetupCount` 0), so existing NT_TRANSACT marshalling is byte-identical for callers that do not set it.

### Risk and Rollout
Low. The `Setup` field is additive and empty by default (preserving existing wire output); the builders/parsers are new surface area. Not live-validated against a server; higher-level orchestration (chunking large transfers via NT_TRANSACT_SECONDARY, ParameterOffset/DataOffset computation at message-assembly time) remains the caller's responsibility.
