### PR TITLE
Fix EFSR [in,string] FileName parameters to use [ref] not [unique] (#513)

### DIFF
--- a/.claude/skills/dcerpc-interface-structure/idlgen.py
+++ b/.claude/skills/dcerpc-interface-structure/idlgen.py
@@ -1302,7 +1302,15 @@ def _param_field(res: TypeResolver, p: Param) -> tuple[str, str, set]:
     is_unique = "unique" in p.attrs
 
     if "string" in p.attrs and arr is None:
-        return "*ndr.WSTR", "unique", set()
+        # A [string] wchar_t* parameter. Its pointer attribute decides the framing:
+        # [unique]/[ptr] -> a referent id then the wide string; [ref] (the default for a
+        # top-level parameter with no explicit attribute — pointer_default governs only
+        # embedded pointers) -> the wide string inline, no referent id.
+        if is_unique:
+            return "*ndr.WSTR", "unique", set()
+        if "ptr" in p.attrs or "full" in p.attrs:
+            return "*ndr.WSTR", "ptr", set()
+        return "ndr.WSTR", "", set()
 
     ptr_array = (arr is None) and isinstance(size, str) and ptr >= 1
     if arr is not None or ptr_array:

--- a/network/dcerpc/interfaces/c681d488-d850-11d0-8c52-00c04fd90f7e/1.0/functions/00_EfsRpcOpenFileRaw.go
+++ b/network/dcerpc/interfaces/c681d488-d850-11d0-8c52-00c04fd90f7e/1.0/functions/00_EfsRpcOpenFileRaw.go
@@ -10,7 +10,7 @@ import (
 
 // efsRpcOpenFileRawRequest carries the [in] parameters of EfsRpcOpenFileRaw.
 type efsRpcOpenFileRawRequest struct {
-	FileName *ndr.WSTR `ndr:"unique"`
+	FileName ndr.WSTR
 	Flags    int32
 }
 
@@ -24,7 +24,7 @@ type efsRpcOpenFileRawResponse struct {
 
 // EfsRpcOpenFileRaw calls EfsRpcOpenFileRaw (opnum 0) ([MS-EFSR] — verify the parameter
 // modeling and status handling).
-func EfsRpcOpenFileRaw(rpc ndr.Invoker, fileName *ndr.WSTR, flags int32) (HContext structures.PEXIMPORT_CONTEXT_HANDLE, err error) {
+func EfsRpcOpenFileRaw(rpc ndr.Invoker, fileName ndr.WSTR, flags int32) (HContext structures.PEXIMPORT_CONTEXT_HANDLE, err error) {
 	req := &efsRpcOpenFileRawRequest{
 		FileName: fileName,
 		Flags:    flags,

--- a/network/dcerpc/interfaces/c681d488-d850-11d0-8c52-00c04fd90f7e/1.0/functions/04_EfsRpcEncryptFileSrv.go
+++ b/network/dcerpc/interfaces/c681d488-d850-11d0-8c52-00c04fd90f7e/1.0/functions/04_EfsRpcEncryptFileSrv.go
@@ -9,7 +9,7 @@ import (
 
 // efsRpcEncryptFileSrvRequest carries the [in] parameters of EfsRpcEncryptFileSrv.
 type efsRpcEncryptFileSrvRequest struct {
-	FileName *ndr.WSTR `ndr:"unique"`
+	FileName ndr.WSTR
 }
 
 func (*efsRpcEncryptFileSrvRequest) Opnum() uint16 { return efsrpc.OpnumEfsRpcEncryptFileSrv }
@@ -21,7 +21,7 @@ type efsRpcEncryptFileSrvResponse struct {
 
 // EfsRpcEncryptFileSrv calls EfsRpcEncryptFileSrv (opnum 4) ([MS-EFSR] — verify the parameter
 // modeling and status handling).
-func EfsRpcEncryptFileSrv(rpc ndr.Invoker, fileName *ndr.WSTR) (err error) {
+func EfsRpcEncryptFileSrv(rpc ndr.Invoker, fileName ndr.WSTR) (err error) {
 	req := &efsRpcEncryptFileSrvRequest{
 		FileName: fileName,
 	}

--- a/network/dcerpc/interfaces/c681d488-d850-11d0-8c52-00c04fd90f7e/1.0/functions/05_EfsRpcDecryptFileSrv.go
+++ b/network/dcerpc/interfaces/c681d488-d850-11d0-8c52-00c04fd90f7e/1.0/functions/05_EfsRpcDecryptFileSrv.go
@@ -9,7 +9,7 @@ import (
 
 // efsRpcDecryptFileSrvRequest carries the [in] parameters of EfsRpcDecryptFileSrv.
 type efsRpcDecryptFileSrvRequest struct {
-	FileName *ndr.WSTR `ndr:"unique"`
+	FileName ndr.WSTR
 	OpenFlag ndr.DWORD
 }
 
@@ -22,7 +22,7 @@ type efsRpcDecryptFileSrvResponse struct {
 
 // EfsRpcDecryptFileSrv calls EfsRpcDecryptFileSrv (opnum 5) ([MS-EFSR] — verify the parameter
 // modeling and status handling).
-func EfsRpcDecryptFileSrv(rpc ndr.Invoker, fileName *ndr.WSTR, openFlag ndr.DWORD) (err error) {
+func EfsRpcDecryptFileSrv(rpc ndr.Invoker, fileName ndr.WSTR, openFlag ndr.DWORD) (err error) {
 	req := &efsRpcDecryptFileSrvRequest{
 		FileName: fileName,
 		OpenFlag: openFlag,

--- a/network/dcerpc/interfaces/c681d488-d850-11d0-8c52-00c04fd90f7e/1.0/functions/06_EfsRpcQueryUsersOnFile.go
+++ b/network/dcerpc/interfaces/c681d488-d850-11d0-8c52-00c04fd90f7e/1.0/functions/06_EfsRpcQueryUsersOnFile.go
@@ -10,7 +10,7 @@ import (
 
 // efsRpcQueryUsersOnFileRequest carries the [in] parameters of EfsRpcQueryUsersOnFile.
 type efsRpcQueryUsersOnFileRequest struct {
-	FileName *ndr.WSTR `ndr:"unique"`
+	FileName ndr.WSTR
 }
 
 func (*efsRpcQueryUsersOnFileRequest) Opnum() uint16 { return efsrpc.OpnumEfsRpcQueryUsersOnFile }
@@ -23,7 +23,7 @@ type efsRpcQueryUsersOnFileResponse struct {
 
 // EfsRpcQueryUsersOnFile calls EfsRpcQueryUsersOnFile (opnum 6) ([MS-EFSR] — verify the parameter
 // modeling and status handling).
-func EfsRpcQueryUsersOnFile(rpc ndr.Invoker, fileName *ndr.WSTR) (Users *structures.ENCRYPTION_CERTIFICATE_HASH_LIST, err error) {
+func EfsRpcQueryUsersOnFile(rpc ndr.Invoker, fileName ndr.WSTR) (Users *structures.ENCRYPTION_CERTIFICATE_HASH_LIST, err error) {
 	req := &efsRpcQueryUsersOnFileRequest{
 		FileName: fileName,
 	}

--- a/network/dcerpc/interfaces/c681d488-d850-11d0-8c52-00c04fd90f7e/1.0/functions/07_EfsRpcQueryRecoveryAgents.go
+++ b/network/dcerpc/interfaces/c681d488-d850-11d0-8c52-00c04fd90f7e/1.0/functions/07_EfsRpcQueryRecoveryAgents.go
@@ -10,7 +10,7 @@ import (
 
 // efsRpcQueryRecoveryAgentsRequest carries the [in] parameters of EfsRpcQueryRecoveryAgents.
 type efsRpcQueryRecoveryAgentsRequest struct {
-	FileName *ndr.WSTR `ndr:"unique"`
+	FileName ndr.WSTR
 }
 
 func (*efsRpcQueryRecoveryAgentsRequest) Opnum() uint16 { return efsrpc.OpnumEfsRpcQueryRecoveryAgents }
@@ -23,7 +23,7 @@ type efsRpcQueryRecoveryAgentsResponse struct {
 
 // EfsRpcQueryRecoveryAgents calls EfsRpcQueryRecoveryAgents (opnum 7) ([MS-EFSR] — verify the parameter
 // modeling and status handling).
-func EfsRpcQueryRecoveryAgents(rpc ndr.Invoker, fileName *ndr.WSTR) (RecoveryAgents *structures.ENCRYPTION_CERTIFICATE_HASH_LIST, err error) {
+func EfsRpcQueryRecoveryAgents(rpc ndr.Invoker, fileName ndr.WSTR) (RecoveryAgents *structures.ENCRYPTION_CERTIFICATE_HASH_LIST, err error) {
 	req := &efsRpcQueryRecoveryAgentsRequest{
 		FileName: fileName,
 	}

--- a/network/dcerpc/interfaces/c681d488-d850-11d0-8c52-00c04fd90f7e/1.0/functions/08_EfsRpcRemoveUsersFromFile.go
+++ b/network/dcerpc/interfaces/c681d488-d850-11d0-8c52-00c04fd90f7e/1.0/functions/08_EfsRpcRemoveUsersFromFile.go
@@ -10,7 +10,7 @@ import (
 
 // efsRpcRemoveUsersFromFileRequest carries the [in] parameters of EfsRpcRemoveUsersFromFile.
 type efsRpcRemoveUsersFromFileRequest struct {
-	FileName *ndr.WSTR `ndr:"unique"`
+	FileName ndr.WSTR
 	Users    structures.ENCRYPTION_CERTIFICATE_HASH_LIST
 }
 
@@ -23,7 +23,7 @@ type efsRpcRemoveUsersFromFileResponse struct {
 
 // EfsRpcRemoveUsersFromFile calls EfsRpcRemoveUsersFromFile (opnum 8) ([MS-EFSR] — verify the parameter
 // modeling and status handling).
-func EfsRpcRemoveUsersFromFile(rpc ndr.Invoker, fileName *ndr.WSTR, users structures.ENCRYPTION_CERTIFICATE_HASH_LIST) (err error) {
+func EfsRpcRemoveUsersFromFile(rpc ndr.Invoker, fileName ndr.WSTR, users structures.ENCRYPTION_CERTIFICATE_HASH_LIST) (err error) {
 	req := &efsRpcRemoveUsersFromFileRequest{
 		FileName: fileName,
 		Users:    users,

--- a/network/dcerpc/interfaces/c681d488-d850-11d0-8c52-00c04fd90f7e/1.0/functions/09_EfsRpcAddUsersToFile.go
+++ b/network/dcerpc/interfaces/c681d488-d850-11d0-8c52-00c04fd90f7e/1.0/functions/09_EfsRpcAddUsersToFile.go
@@ -10,7 +10,7 @@ import (
 
 // efsRpcAddUsersToFileRequest carries the [in] parameters of EfsRpcAddUsersToFile.
 type efsRpcAddUsersToFileRequest struct {
-	FileName               *ndr.WSTR `ndr:"unique"`
+	FileName               ndr.WSTR
 	EncryptionCertificates structures.ENCRYPTION_CERTIFICATE_LIST
 }
 
@@ -23,7 +23,7 @@ type efsRpcAddUsersToFileResponse struct {
 
 // EfsRpcAddUsersToFile calls EfsRpcAddUsersToFile (opnum 9) ([MS-EFSR] — verify the parameter
 // modeling and status handling).
-func EfsRpcAddUsersToFile(rpc ndr.Invoker, fileName *ndr.WSTR, encryptionCertificates structures.ENCRYPTION_CERTIFICATE_LIST) (err error) {
+func EfsRpcAddUsersToFile(rpc ndr.Invoker, fileName ndr.WSTR, encryptionCertificates structures.ENCRYPTION_CERTIFICATE_LIST) (err error) {
 	req := &efsRpcAddUsersToFileRequest{
 		FileName:               fileName,
 		EncryptionCertificates: encryptionCertificates,

--- a/network/dcerpc/interfaces/c681d488-d850-11d0-8c52-00c04fd90f7e/1.0/functions/11_EfsRpcNotSupported.go
+++ b/network/dcerpc/interfaces/c681d488-d850-11d0-8c52-00c04fd90f7e/1.0/functions/11_EfsRpcNotSupported.go
@@ -10,8 +10,8 @@ import (
 
 // efsRpcNotSupportedRequest carries the [in] parameters of EfsRpcNotSupported.
 type efsRpcNotSupportedRequest struct {
-	Reserved1   *ndr.WSTR `ndr:"unique"`
-	Reserved2   *ndr.WSTR `ndr:"unique"`
+	Reserved1   ndr.WSTR
+	Reserved2   ndr.WSTR
 	DwReserved1 ndr.DWORD
 	DwReserved2 ndr.DWORD
 	Reserved    *structures.EFS_RPC_BLOB `ndr:"unique"`
@@ -27,7 +27,7 @@ type efsRpcNotSupportedResponse struct {
 
 // EfsRpcNotSupported calls EfsRpcNotSupported (opnum 11) ([MS-EFSR] — verify the parameter
 // modeling and status handling).
-func EfsRpcNotSupported(rpc ndr.Invoker, reserved1 *ndr.WSTR, reserved2 *ndr.WSTR, dwReserved1 ndr.DWORD, dwReserved2 ndr.DWORD, reserved *structures.EFS_RPC_BLOB, bReserved ndr.BOOL) (err error) {
+func EfsRpcNotSupported(rpc ndr.Invoker, reserved1 ndr.WSTR, reserved2 ndr.WSTR, dwReserved1 ndr.DWORD, dwReserved2 ndr.DWORD, reserved *structures.EFS_RPC_BLOB, bReserved ndr.BOOL) (err error) {
 	req := &efsRpcNotSupportedRequest{
 		Reserved1:   reserved1,
 		Reserved2:   reserved2,

--- a/network/dcerpc/interfaces/c681d488-d850-11d0-8c52-00c04fd90f7e/1.0/functions/12_EfsRpcFileKeyInfo.go
+++ b/network/dcerpc/interfaces/c681d488-d850-11d0-8c52-00c04fd90f7e/1.0/functions/12_EfsRpcFileKeyInfo.go
@@ -10,7 +10,7 @@ import (
 
 // efsRpcFileKeyInfoRequest carries the [in] parameters of EfsRpcFileKeyInfo.
 type efsRpcFileKeyInfoRequest struct {
-	FileName  *ndr.WSTR `ndr:"unique"`
+	FileName  ndr.WSTR
 	InfoClass ndr.DWORD
 }
 
@@ -24,7 +24,7 @@ type efsRpcFileKeyInfoResponse struct {
 
 // EfsRpcFileKeyInfo calls EfsRpcFileKeyInfo (opnum 12) ([MS-EFSR] — verify the parameter
 // modeling and status handling).
-func EfsRpcFileKeyInfo(rpc ndr.Invoker, fileName *ndr.WSTR, infoClass ndr.DWORD) (KeyInfo *structures.EFS_RPC_BLOB, err error) {
+func EfsRpcFileKeyInfo(rpc ndr.Invoker, fileName ndr.WSTR, infoClass ndr.DWORD) (KeyInfo *structures.EFS_RPC_BLOB, err error) {
 	req := &efsRpcFileKeyInfoRequest{
 		FileName:  fileName,
 		InfoClass: infoClass,

--- a/network/dcerpc/interfaces/c681d488-d850-11d0-8c52-00c04fd90f7e/1.0/functions/13_EfsRpcDuplicateEncryptionInfoFile.go
+++ b/network/dcerpc/interfaces/c681d488-d850-11d0-8c52-00c04fd90f7e/1.0/functions/13_EfsRpcDuplicateEncryptionInfoFile.go
@@ -10,8 +10,8 @@ import (
 
 // efsRpcDuplicateEncryptionInfoFileRequest carries the [in] parameters of EfsRpcDuplicateEncryptionInfoFile.
 type efsRpcDuplicateEncryptionInfoFileRequest struct {
-	SrcFileName           *ndr.WSTR `ndr:"unique"`
-	DestFileName          *ndr.WSTR `ndr:"unique"`
+	SrcFileName           ndr.WSTR
+	DestFileName          ndr.WSTR
 	DwCreationDisposition ndr.DWORD
 	DwAttributes          ndr.DWORD
 	RelativeSD            *structures.EFS_RPC_BLOB `ndr:"unique"`
@@ -29,7 +29,7 @@ type efsRpcDuplicateEncryptionInfoFileResponse struct {
 
 // EfsRpcDuplicateEncryptionInfoFile calls EfsRpcDuplicateEncryptionInfoFile (opnum 13) ([MS-EFSR] — verify the parameter
 // modeling and status handling).
-func EfsRpcDuplicateEncryptionInfoFile(rpc ndr.Invoker, srcFileName *ndr.WSTR, destFileName *ndr.WSTR, dwCreationDisposition ndr.DWORD, dwAttributes ndr.DWORD, relativeSD *structures.EFS_RPC_BLOB, bInheritHandle ndr.BOOL) (err error) {
+func EfsRpcDuplicateEncryptionInfoFile(rpc ndr.Invoker, srcFileName ndr.WSTR, destFileName ndr.WSTR, dwCreationDisposition ndr.DWORD, dwAttributes ndr.DWORD, relativeSD *structures.EFS_RPC_BLOB, bInheritHandle ndr.BOOL) (err error) {
 	req := &efsRpcDuplicateEncryptionInfoFileRequest{
 		SrcFileName:           srcFileName,
 		DestFileName:          destFileName,

--- a/network/dcerpc/interfaces/c681d488-d850-11d0-8c52-00c04fd90f7e/1.0/functions/15_EfsRpcAddUsersToFileEx.go
+++ b/network/dcerpc/interfaces/c681d488-d850-11d0-8c52-00c04fd90f7e/1.0/functions/15_EfsRpcAddUsersToFileEx.go
@@ -12,7 +12,7 @@ import (
 type efsRpcAddUsersToFileExRequest struct {
 	DwFlags                ndr.DWORD
 	Reserved               *structures.EFS_RPC_BLOB `ndr:"unique"`
-	FileName               *ndr.WSTR                `ndr:"unique"`
+	FileName               ndr.WSTR
 	EncryptionCertificates structures.ENCRYPTION_CERTIFICATE_LIST
 }
 
@@ -25,7 +25,7 @@ type efsRpcAddUsersToFileExResponse struct {
 
 // EfsRpcAddUsersToFileEx calls EfsRpcAddUsersToFileEx (opnum 15) ([MS-EFSR] — verify the parameter
 // modeling and status handling).
-func EfsRpcAddUsersToFileEx(rpc ndr.Invoker, dwFlags ndr.DWORD, reserved *structures.EFS_RPC_BLOB, fileName *ndr.WSTR, encryptionCertificates structures.ENCRYPTION_CERTIFICATE_LIST) (err error) {
+func EfsRpcAddUsersToFileEx(rpc ndr.Invoker, dwFlags ndr.DWORD, reserved *structures.EFS_RPC_BLOB, fileName ndr.WSTR, encryptionCertificates structures.ENCRYPTION_CERTIFICATE_LIST) (err error) {
 	req := &efsRpcAddUsersToFileExRequest{
 		DwFlags:                dwFlags,
 		Reserved:               reserved,

--- a/network/dcerpc/interfaces/c681d488-d850-11d0-8c52-00c04fd90f7e/1.0/functions/16_EfsRpcFileKeyInfoEx.go
+++ b/network/dcerpc/interfaces/c681d488-d850-11d0-8c52-00c04fd90f7e/1.0/functions/16_EfsRpcFileKeyInfoEx.go
@@ -12,7 +12,7 @@ import (
 type efsRpcFileKeyInfoExRequest struct {
 	DwFileKeyInfoFlags ndr.DWORD
 	Reserved           *structures.EFS_RPC_BLOB `ndr:"unique"`
-	FileName           *ndr.WSTR                `ndr:"unique"`
+	FileName           ndr.WSTR
 	InfoClass          ndr.DWORD
 }
 
@@ -26,7 +26,7 @@ type efsRpcFileKeyInfoExResponse struct {
 
 // EfsRpcFileKeyInfoEx calls EfsRpcFileKeyInfoEx (opnum 16) ([MS-EFSR] — verify the parameter
 // modeling and status handling).
-func EfsRpcFileKeyInfoEx(rpc ndr.Invoker, dwFileKeyInfoFlags ndr.DWORD, reserved *structures.EFS_RPC_BLOB, fileName *ndr.WSTR, infoClass ndr.DWORD) (KeyInfo *structures.EFS_RPC_BLOB, err error) {
+func EfsRpcFileKeyInfoEx(rpc ndr.Invoker, dwFileKeyInfoFlags ndr.DWORD, reserved *structures.EFS_RPC_BLOB, fileName ndr.WSTR, infoClass ndr.DWORD) (KeyInfo *structures.EFS_RPC_BLOB, err error) {
 	req := &efsRpcFileKeyInfoExRequest{
 		DwFileKeyInfoFlags: dwFileKeyInfoFlags,
 		Reserved:           reserved,

--- a/network/dcerpc/interfaces/c681d488-d850-11d0-8c52-00c04fd90f7e/1.0/functions/18_EfsRpcGetEncryptedFileMetadata.go
+++ b/network/dcerpc/interfaces/c681d488-d850-11d0-8c52-00c04fd90f7e/1.0/functions/18_EfsRpcGetEncryptedFileMetadata.go
@@ -10,7 +10,7 @@ import (
 
 // efsRpcGetEncryptedFileMetadataRequest carries the [in] parameters of EfsRpcGetEncryptedFileMetadata.
 type efsRpcGetEncryptedFileMetadataRequest struct {
-	FileName *ndr.WSTR `ndr:"unique"`
+	FileName ndr.WSTR
 }
 
 func (*efsRpcGetEncryptedFileMetadataRequest) Opnum() uint16 {
@@ -25,7 +25,7 @@ type efsRpcGetEncryptedFileMetadataResponse struct {
 
 // EfsRpcGetEncryptedFileMetadata calls EfsRpcGetEncryptedFileMetadata (opnum 18) ([MS-EFSR] — verify the parameter
 // modeling and status handling).
-func EfsRpcGetEncryptedFileMetadata(rpc ndr.Invoker, fileName *ndr.WSTR) (EfsStreamBlob *structures.EFS_RPC_BLOB, err error) {
+func EfsRpcGetEncryptedFileMetadata(rpc ndr.Invoker, fileName ndr.WSTR) (EfsStreamBlob *structures.EFS_RPC_BLOB, err error) {
 	req := &efsRpcGetEncryptedFileMetadataRequest{
 		FileName: fileName,
 	}

--- a/network/dcerpc/interfaces/c681d488-d850-11d0-8c52-00c04fd90f7e/1.0/functions/19_EfsRpcSetEncryptedFileMetadata.go
+++ b/network/dcerpc/interfaces/c681d488-d850-11d0-8c52-00c04fd90f7e/1.0/functions/19_EfsRpcSetEncryptedFileMetadata.go
@@ -10,7 +10,7 @@ import (
 
 // efsRpcSetEncryptedFileMetadataRequest carries the [in] parameters of EfsRpcSetEncryptedFileMetadata.
 type efsRpcSetEncryptedFileMetadataRequest struct {
-	FileName         *ndr.WSTR                `ndr:"unique"`
+	FileName         ndr.WSTR
 	OldEfsStreamBlob *structures.EFS_RPC_BLOB `ndr:"unique"`
 	NewEfsStreamBlob structures.EFS_RPC_BLOB
 	NewEfsSignature  *structures.ENCRYPTED_FILE_METADATA_SIGNATURE `ndr:"unique"`
@@ -27,7 +27,7 @@ type efsRpcSetEncryptedFileMetadataResponse struct {
 
 // EfsRpcSetEncryptedFileMetadata calls EfsRpcSetEncryptedFileMetadata (opnum 19) ([MS-EFSR] — verify the parameter
 // modeling and status handling).
-func EfsRpcSetEncryptedFileMetadata(rpc ndr.Invoker, fileName *ndr.WSTR, oldEfsStreamBlob *structures.EFS_RPC_BLOB, newEfsStreamBlob structures.EFS_RPC_BLOB, newEfsSignature *structures.ENCRYPTED_FILE_METADATA_SIGNATURE) (err error) {
+func EfsRpcSetEncryptedFileMetadata(rpc ndr.Invoker, fileName ndr.WSTR, oldEfsStreamBlob *structures.EFS_RPC_BLOB, newEfsStreamBlob structures.EFS_RPC_BLOB, newEfsSignature *structures.ENCRYPTED_FILE_METADATA_SIGNATURE) (err error) {
 	req := &efsRpcSetEncryptedFileMetadataRequest{
 		FileName:         fileName,
 		OldEfsStreamBlob: oldEfsStreamBlob,

--- a/network/dcerpc/interfaces/c681d488-d850-11d0-8c52-00c04fd90f7e/1.0/functions/21_EfsRpcEncryptFileExSrv.go
+++ b/network/dcerpc/interfaces/c681d488-d850-11d0-8c52-00c04fd90f7e/1.0/functions/21_EfsRpcEncryptFileExSrv.go
@@ -9,7 +9,7 @@ import (
 
 // efsRpcEncryptFileExSrvRequest carries the [in] parameters of EfsRpcEncryptFileExSrv.
 type efsRpcEncryptFileExSrvRequest struct {
-	FileName            *ndr.WSTR `ndr:"unique"`
+	FileName            ndr.WSTR
 	ProtectorDescriptor *ndr.WSTR `ndr:"unique"`
 	Flags               ndr.DWORD
 }
@@ -23,7 +23,7 @@ type efsRpcEncryptFileExSrvResponse struct {
 
 // EfsRpcEncryptFileExSrv calls EfsRpcEncryptFileExSrv (opnum 21) ([MS-EFSR] — verify the parameter
 // modeling and status handling).
-func EfsRpcEncryptFileExSrv(rpc ndr.Invoker, fileName *ndr.WSTR, protectorDescriptor *ndr.WSTR, flags ndr.DWORD) (err error) {
+func EfsRpcEncryptFileExSrv(rpc ndr.Invoker, fileName ndr.WSTR, protectorDescriptor *ndr.WSTR, flags ndr.DWORD) (err error) {
 	req := &efsRpcEncryptFileExSrvRequest{
 		FileName:            fileName,
 		ProtectorDescriptor: protectorDescriptor,

--- a/network/dcerpc/interfaces/c681d488-d850-11d0-8c52-00c04fd90f7e/1.0/functions/22_EfsRpcQueryProtectors.go
+++ b/network/dcerpc/interfaces/c681d488-d850-11d0-8c52-00c04fd90f7e/1.0/functions/22_EfsRpcQueryProtectors.go
@@ -10,7 +10,7 @@ import (
 
 // efsRpcQueryProtectorsRequest carries the [in] parameters of EfsRpcQueryProtectors.
 type efsRpcQueryProtectorsRequest struct {
-	FileName *ndr.WSTR `ndr:"unique"`
+	FileName ndr.WSTR
 }
 
 func (*efsRpcQueryProtectorsRequest) Opnum() uint16 { return efsrpc.OpnumEfsRpcQueryProtectors }
@@ -23,7 +23,7 @@ type efsRpcQueryProtectorsResponse struct {
 
 // EfsRpcQueryProtectors calls EfsRpcQueryProtectors (opnum 22) ([MS-EFSR] — verify the parameter
 // modeling and status handling).
-func EfsRpcQueryProtectors(rpc ndr.Invoker, fileName *ndr.WSTR) (PpProtectorList *structures.ENCRYPTION_PROTECTOR_LIST, err error) {
+func EfsRpcQueryProtectors(rpc ndr.Invoker, fileName ndr.WSTR) (PpProtectorList *structures.ENCRYPTION_PROTECTOR_LIST, err error) {
 	req := &efsRpcQueryProtectorsRequest{
 		FileName: fileName,
 	}

--- a/network/dcerpc/interfaces/c681d488-d850-11d0-8c52-00c04fd90f7e/1.0/functions/integration_test.go
+++ b/network/dcerpc/interfaces/c681d488-d850-11d0-8c52-00c04fd90f7e/1.0/functions/integration_test.go
@@ -1,0 +1,202 @@
+//go:build integration
+
+// Live integration / wire-validation for efsrpc (MS-EFSR), including the NDR-pipe
+// raw-file methods. Excluded from the default build by the "integration" tag. Run with:
+//
+//	DCERPC_TEST_HOST=192.168.1.30 DCERPC_TEST_USER=Administrator DCERPC_TEST_PASS=admin \
+//	go test -tags integration -v \
+//	  ./network/dcerpc/interfaces/c681d488-d850-11d0-8c52-00c04fd90f7e/1.0/functions/
+//
+// The test stages a file on C$, encrypts it server-side (EfsRpcEncryptFileSrv), then
+// exports it raw through the [out] EFS_EXIM_PIPE (EfsRpcOpenFileRaw -> ReadFileRaw ->
+// CloseRaw). EFSRPC context handles chain, so that sequence runs on one association.
+//
+// Per [MS-EFSR] every method returns 0 on success or a Win32 error (MS-ERREF) on
+// failure; a clean nonzero status still proves the wire is correct, so only a DCE/RPC
+// fault (nca_s_fault_*) is treated as a wire failure here.
+package functions_test
+
+import (
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+
+	efsrpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/c681d488-d850-11d0-8c52-00c04fd90f7e/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/c681d488-d850-11d0-8c52-00c04fd90f7e/1.0/functions"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	dcerpcsmb "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/transport/smb"
+	smbclient "github.com/TheManticoreProject/Manticore/network/smb/smb_v10/client"
+	"github.com/TheManticoreProject/Manticore/windows/credentials"
+)
+
+func ws(s string) ndr.WSTR { return ndr.WSTR(s) }
+
+// isFault reports whether err is a DCE/RPC fault (a wire-modeling failure) rather than a
+// clean Win32/NTSTATUS error returned by the server (which validates the wire).
+func isFault(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "fault")
+}
+
+func TestIntegration_Efsr(t *testing.T) {
+	host := os.Getenv("DCERPC_TEST_HOST")
+	if host == "" {
+		t.Skip("DCERPC_TEST_HOST not set; skipping live efsr test")
+	}
+	port := 445
+	if p := os.Getenv("DCERPC_TEST_PORT"); p != "" {
+		n, err := strconv.Atoi(p)
+		if err != nil {
+			t.Fatalf("invalid DCERPC_TEST_PORT %q: %v", p, err)
+		}
+		port = n
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		t.Fatalf("DCERPC_TEST_HOST %q is not a valid IP", host)
+	}
+	creds, err := credentials.NewCredentials(os.Getenv("DCERPC_TEST_DOMAIN"), os.Getenv("DCERPC_TEST_USER"), os.Getenv("DCERPC_TEST_PASS"), "")
+	if err != nil {
+		t.Fatalf("NewCredentials: %v", err)
+	}
+
+	smb := smbclient.NewClientUsingTCPTransport(ip, port)
+	if err := smb.Connect(ip, port); err != nil {
+		t.Fatalf("SMB Connect: %v", err)
+	}
+	defer smb.Disconnect()
+	smb.NativeOS, smb.NativeLanMan = "Unix", "Samba"
+	if err := smb.SessionSetup(creds); err != nil {
+		t.Fatalf("SMB SessionSetup: %v", err)
+	}
+	defer smb.Logoff()
+
+	// --- Stage a file on C$ so the raw export has real data to stream. ---
+	const sharePath = `\WINDOWS\Temp\efsr_pipe_test.txt` // C$-relative
+	const serverPath = `C:\WINDOWS\Temp\efsr_pipe_test.txt`
+	payload := []byte("EFSR pipe streaming live test — " + strings.Repeat("ABCD", 64))
+	staged := false
+	func() {
+		if err := smb.TreeConnect("C$"); err != nil {
+			t.Logf("[info] TreeConnect(C$) failed (%v); skipping file staging", err)
+			return
+		}
+		defer smb.TreeDisconnect()
+		fid, err := smb.OpenFile(sharePath, smbclient.GENERIC_READ|smbclient.GENERIC_WRITE,
+			smbclient.FILE_SHARE_READ|smbclient.FILE_SHARE_WRITE, smbclient.FILE_OVERWRITE_IF, smbclient.FILE_NON_DIRECTORY_FILE)
+		if err != nil {
+			t.Logf("[info] OpenFile(%s) failed: %v", sharePath, err)
+			return
+		}
+		if _, err := smb.WriteFile(fid, 0, payload); err != nil {
+			t.Logf("[info] WriteFile failed: %v", err)
+			_ = smb.CloseFile(fid)
+			return
+		}
+		_ = smb.CloseFile(fid)
+		staged = true
+		t.Logf("[ok] staged %d-byte %s on C$", len(payload), serverPath)
+	}()
+
+	if err := smb.TreeConnect("IPC$"); err != nil {
+		t.Fatalf("SMB TreeConnect(IPC$): %v", err)
+	}
+	defer smb.TreeDisconnect()
+
+	pipeName := chooseEfsrPipe(t, smb)
+	t.Logf("[ok] bound efsrpc over %s", pipeName)
+
+	bind := func() (*client.Client, func()) {
+		rpc := client.NewClient(dcerpcsmb.New(smb, pipeName))
+		if err := rpc.Bind(efsrpc.SyntaxID()); err != nil {
+			t.Fatalf("Bind(efsrpc): %v", err)
+		}
+		return rpc, func() { _ = rpc.Close() }
+	}
+
+	// EfsRpcEncryptFileSrv (opnum 4): encrypt the staged file server-side. Validates the
+	// [in,string] FileName parameter ([ref] inline wide string).
+	if staged {
+		rpc, done := bind()
+		err := functions.EfsRpcEncryptFileSrv(rpc, ws(serverPath))
+		switch {
+		case isFault(err):
+			t.Errorf("[WIRE FAIL] EfsRpcEncryptFileSrv: %v", err)
+		case err != nil:
+			t.Logf("[ok] EfsRpcEncryptFileSrv: server returned a status (wire validated): %v", err)
+		default:
+			t.Logf("[ok] EfsRpcEncryptFileSrv(%s): encrypted", serverPath)
+		}
+		done()
+	}
+
+	// Raw-export handle chain on ONE association.
+	func() {
+		rpc, done := bind()
+		defer done()
+		hContext, err := functions.EfsRpcOpenFileRaw(rpc, ws(serverPath), 0)
+		switch {
+		case isFault(err):
+			t.Errorf("[WIRE FAIL] EfsRpcOpenFileRaw: %v", err)
+			return
+		case err != nil:
+			t.Logf("[ok] EfsRpcOpenFileRaw: server returned a status (wire validated): %v", err)
+			return // no context handle -> cannot read/close
+		}
+		t.Logf("[ok] EfsRpcOpenFileRaw: context handle acquired")
+
+		pipeData, err := functions.EfsRpcReadFileRaw(rpc, hContext)
+		switch {
+		case isFault(err):
+			t.Errorf("[WIRE FAIL] EfsRpcReadFileRaw (the [out] NDR pipe): %v", err)
+		case err != nil:
+			t.Logf("[ok] EfsRpcReadFileRaw: status (wire validated): %v", err)
+		default:
+			head := pipeData
+			if len(head) > 16 {
+				head = head[:16]
+			}
+			t.Logf("[ok] EfsRpcReadFileRaw: streamed %d bytes via the pipe; head=%x", len(pipeData), head)
+		}
+
+		if _, err := functions.EfsRpcCloseRaw(rpc, hContext); isFault(err) {
+			t.Errorf("[WIRE FAIL] EfsRpcCloseRaw: %v", err)
+		} else {
+			t.Logf("[ok] EfsRpcCloseRaw (err=%v)", err)
+		}
+	}()
+
+	// EfsRpcQueryUsersOnFile (opnum 6): another [in,string] method.
+	func() {
+		rpc, done := bind()
+		defer done()
+		users, err := functions.EfsRpcQueryUsersOnFile(rpc, ws(serverPath))
+		switch {
+		case isFault(err):
+			t.Errorf("[WIRE FAIL] EfsRpcQueryUsersOnFile: %v", err)
+		case err != nil:
+			t.Logf("[ok] EfsRpcQueryUsersOnFile: status (wire validated): %v", err)
+		default:
+			t.Logf("[ok] EfsRpcQueryUsersOnFile: users=%v", users != nil)
+		}
+	}()
+}
+
+// chooseEfsrPipe binds efsrpc, trying \efsrpc then \lsarpc on a throwaway client.
+func chooseEfsrPipe(t *testing.T, smb *smbclient.Client) string {
+	t.Helper()
+	for _, name := range []string{`\efsrpc`, `\lsarpc`} {
+		rpc := client.NewClient(dcerpcsmb.New(smb, name))
+		err := rpc.Bind(efsrpc.SyntaxID())
+		_ = rpc.Close()
+		if err == nil {
+			return name
+		}
+		t.Logf("[info] bind over %s failed: %v", name, err)
+	}
+	t.Fatalf("could not bind efsrpc over \\efsrpc or \\lsarpc")
+	return ""
+}


### PR DESCRIPTION
### Linked Issue
Closes #513

### Root Cause
The EFSR IDL declares `interface efsrpc` with no `pointer_default` and its file-path parameters as `[in, string] wchar_t* FileName` with no explicit pointer attribute. Per MIDL, a top-level pointer parameter with no explicit attribute is a `[ref]` pointer — `pointer_default` governs only embedded pointers — so it is marshalled inline with no referent id. The generator's `_param_field` unconditionally emitted `*ndr.WSTR ndr:"unique"` for any `[string]` parameter, prepending a referent id the server does not expect; every FileName-keyed EFSR method therefore faulted `nca_s_fault_ndr`.

### Fix Description
Make `_param_field` honor the parameter's pointer attribute for `[string]` parameters: explicit `[unique]`/`[ptr]` keep `*ndr.WSTR` with a referent; the default `[ref]` (no explicit attribute) becomes an inline `ndr.WSTR` (no referent id). The EFSR functions were regenerated with the fixed generator, so all FileName-bearing methods now pass the path inline. Interfaces with `pointer_default(unique)` and explicit `[unique,string]` parameters (samr/srvsvc) are unchanged — `idlgen check` on samr is identical.

### How Verified
- **Runtime (Windows Server 2003):** before, `EfsRpcEncryptFileSrv` / `EfsRpcOpenFileRaw` / `EfsRpcQueryUsersOnFile` faulted `nca_s_fault_ndr`. After, all three complete the wire round-trip and return a clean `ERROR_ACCESS_DENIED` (a documented [MS-ERREF] status — the box denies the EFS operations on the staged file), with no fault. The new integration test passes.
- **Tests:** `go build`/`go vet`/`go test ./network/dcerpc/interfaces/<efsr>/...` clean; `idlgen check` on samr unchanged (no regression to other interfaces).

### Test Coverage
**Added:** `functions/integration_test.go` (`TestIntegration_Efsr`, build-tagged `integration`) — stages a file on C$, drives the FileName methods and the EFS_EXIM_PIPE raw-export chain over one association, and classifies DCE/RPC faults as failures vs clean Win32 statuses as success.

### Scope of Change
- **Files changed:** `idlgen.py` (`_param_field` `[string]` branch) and the 16 FileName-bearing EFSR function files (regenerated); new `functions/integration_test.go`.
- **Behavioral changes outside the bug fix:** none — only `[string]` parameters with no explicit pointer attribute change (inline instead of unique), which in this repo is EFSR only.

### Notes
A live raw-pipe data transfer was not demonstrated because the test server denies EFS encryption of the staged file (`ERROR_ACCESS_DENIED`, a server EFS-policy condition, not a wire issue); the NDR pipe codec is covered by exact-byte unit tests (`ndr/pipe_test.go`, `functions/pipe_test.go`). EFSR is not exposed over `\efsrpc` on Server 2003, so the test binds over `\lsarpc`.