### PR TITLE
Generic SMB client: negotiate once, route to SMB1/SMB2/SMB3 (#528)

### DIFF
--- a/network/smb/client/adapter_smb1.go
+++ b/network/smb/client/adapter_smb1.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/TheManticoreProject/Manticore/network/smb"
 	smb1 "github.com/TheManticoreProject/Manticore/network/smb/smb_v10/client"
@@ -65,9 +66,48 @@ func (b *smb1Backend) CloseFile(h FileHandle) error {
 }
 
 func (b *smb1Backend) ListDirectory(path, pattern string) ([]FileInfo, error) {
-	// SMB1 directory enumeration (TRANS2 FIND_FIRST2/FIND_NEXT2) is normalized
-	// into []FileInfo in Phase 6.
-	return nil, fmt.Errorf("ListDirectory is not yet implemented for SMB1 (Phase 6)")
+	// The SMB1 engine enumerates by a single share-relative pattern (TRANS2
+	// FIND_FIRST2/FIND_NEXT2); join the directory path and the match pattern into
+	// it, e.g. ("\\Windows", "*.ini") -> "\\Windows\\*.ini".
+	if pattern == "" {
+		pattern = "*"
+	}
+	p := path
+	if p == "" {
+		p = "\\"
+	}
+	if p[0] != '\\' {
+		p = "\\" + p
+	}
+	if p[len(p)-1] != '\\' {
+		p += "\\"
+	}
+	p += pattern
+
+	entries, err := b.engine.ListEntries(p)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]FileInfo, 0, len(entries))
+	for _, e := range entries {
+		// The SMB1 engine includes the OEM name's trailing NUL terminator in
+		// LongName; normalize it away (SMB2 names are already NUL-trimmed).
+		name := strings.TrimRight(e.LongName, "\x00")
+		if name == "." || name == ".." {
+			continue
+		}
+		out = append(out, FileInfo{
+			Name:           name,
+			FileAttributes: e.Attributes,
+			Size:           e.Size,
+			CreationTime:   e.CreatedAt,
+			LastAccessTime: e.AccessedAt,
+			LastWriteTime:  e.ModifiedAt,
+			ChangeTime:     e.ChangedAt,
+		})
+	}
+	return out, nil
 }
 
 func (b *smb1Backend) TreeDisconnect() error { return b.engine.TreeDisconnect() }

--- a/network/smb/client/adapter_smb1.go
+++ b/network/smb/client/adapter_smb1.go
@@ -1,0 +1,88 @@
+package client
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/smb"
+	smb1 "github.com/TheManticoreProject/Manticore/network/smb/smb_v10/client"
+	"github.com/TheManticoreProject/Manticore/windows/credentials"
+)
+
+// smb1Backend adapts the SMB 1.0 engine (network/smb/smb_v10/client) to the
+// version-agnostic Backend interface.
+type smb1Backend struct {
+	engine *smb1.Client
+}
+
+func newSMB1Backend(engine *smb1.Client) *smb1Backend {
+	return &smb1Backend{engine: engine}
+}
+
+func (b *smb1Backend) Dialect() smb.SMBProtocolVersion { return smb.SMB_VERSION_1_0 }
+
+func (b *smb1Backend) Login(creds *credentials.Credentials) error {
+	return b.engine.SessionSetup(creds)
+}
+
+func (b *smb1Backend) TreeConnect(share string) error {
+	return b.engine.TreeConnect(share)
+}
+
+func (b *smb1Backend) OpenFile(path string, opts OpenOptions) (FileHandle, error) {
+	fid, err := b.engine.OpenFile(path, opts.DesiredAccess, opts.ShareAccess, opts.CreateDisposition, opts.CreateOptions)
+	if err != nil {
+		return FileHandle{}, err
+	}
+	return newFileHandle(smb.SMB_VERSION_1_0, fid), nil
+}
+
+func (b *smb1Backend) ReadFile(h FileHandle, off uint64, n uint32) ([]byte, error) {
+	fid, err := b.fid(h)
+	if err != nil {
+		return nil, err
+	}
+	return b.engine.ReadFile(fid, off, n)
+}
+
+func (b *smb1Backend) WriteFile(h FileHandle, off uint64, data []byte) (uint32, error) {
+	fid, err := b.fid(h)
+	if err != nil {
+		return 0, err
+	}
+	written, err := b.engine.WriteFile(fid, off, data)
+	if err != nil {
+		return 0, err
+	}
+	return uint32(written), nil
+}
+
+func (b *smb1Backend) CloseFile(h FileHandle) error {
+	fid, err := b.fid(h)
+	if err != nil {
+		return err
+	}
+	return b.engine.CloseFile(fid)
+}
+
+func (b *smb1Backend) ListDirectory(path, pattern string) ([]FileInfo, error) {
+	// SMB1 directory enumeration (TRANS2 FIND_FIRST2/FIND_NEXT2) is normalized
+	// into []FileInfo in Phase 6.
+	return nil, fmt.Errorf("ListDirectory is not yet implemented for SMB1 (Phase 6)")
+}
+
+func (b *smb1Backend) TreeDisconnect() error { return b.engine.TreeDisconnect() }
+func (b *smb1Backend) Logoff() error         { return b.engine.Logoff() }
+func (b *smb1Backend) Disconnect() error     { return b.engine.Disconnect() }
+
+// fid unboxes an opaque FileHandle back into the SMB1 FID that produced it,
+// guarding against a handle from another backend.
+func (b *smb1Backend) fid(h FileHandle) (smb1.FID, error) {
+	fid, ok := h.raw.(smb1.FID)
+	if !ok {
+		return 0, fmt.Errorf("file handle is not an SMB1 FID (got %T)", h.raw)
+	}
+	return fid, nil
+}
+
+// Compile-time assurance that the adapter satisfies the Backend contract.
+var _ Backend = (*smb1Backend)(nil)

--- a/network/smb/client/adapter_smb2.go
+++ b/network/smb/client/adapter_smb2.go
@@ -69,10 +69,34 @@ func (b *smb2Backend) CloseFile(h FileHandle) error {
 }
 
 func (b *smb2Backend) ListDirectory(path, pattern string) ([]FileInfo, error) {
-	// The SMB2 engine exposes QueryDirectory as raw information-class bytes;
-	// normalizing those into []FileInfo lands in Phase 6 (with the MS-FSCC
-	// information-class package).
-	return nil, fmt.Errorf("ListDirectory is not yet implemented for SMB2 (Phase 6)")
+	if pattern == "" {
+		pattern = "*"
+	}
+
+	// Open the directory for enumeration.
+	fileId, err := b.engine.CreateFile(path, fileListDirectory|fileReadAttributes, shareReadWrite, fileOpen, fileDirectoryFile)
+	if err != nil {
+		return nil, fmt.Errorf("open directory %q: %w", path, err)
+	}
+	defer b.engine.CloseFile(fileId)
+
+	// Page through QUERY_DIRECTORY: the pattern applies to the first call, and
+	// subsequent calls continue from the server's cursor until it reports no more
+	// files (an empty buffer).
+	var out []FileInfo
+	search := pattern
+	for {
+		buf, err := b.engine.QueryDirectory(fileId, fileBothDirectoryInformation, search, 0)
+		if err != nil {
+			return nil, err
+		}
+		if len(buf) == 0 {
+			break
+		}
+		out = append(out, parseBothDirectoryInfo(buf)...)
+		search = "" // continuation
+	}
+	return out, nil
 }
 
 func (b *smb2Backend) TreeDisconnect() error { return b.engine.TreeDisconnect() }

--- a/network/smb/client/adapter_smb2.go
+++ b/network/smb/client/adapter_smb2.go
@@ -1,0 +1,93 @@
+package client
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/smb"
+	smb2 "github.com/TheManticoreProject/Manticore/network/smb/smb_v20/client"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/types"
+	"github.com/TheManticoreProject/Manticore/windows/credentials"
+)
+
+// smb2Backend adapts the SMB 2.x engine (network/smb/smb_v20/client) to the
+// version-agnostic Backend interface.
+type smb2Backend struct {
+	engine  *smb2.Client
+	dialect smb.SMBProtocolVersion
+}
+
+// newSMB2Backend wraps an already-negotiated SMB2 engine. The negotiated dialect
+// is resolved once; an unrecognized revision falls back to SMB 2.0.2.
+func newSMB2Backend(engine *smb2.Client) *smb2Backend {
+	dialect, ok := versionForSMB2Dialect(engine.Connection.Dialect)
+	if !ok {
+		dialect = smb.SMB_VERSION_2_0_2
+	}
+	return &smb2Backend{engine: engine, dialect: dialect}
+}
+
+func (b *smb2Backend) Dialect() smb.SMBProtocolVersion { return b.dialect }
+
+func (b *smb2Backend) Login(creds *credentials.Credentials) error {
+	return b.engine.SessionSetup(creds)
+}
+
+func (b *smb2Backend) TreeConnect(share string) error {
+	return b.engine.TreeConnect(share)
+}
+
+func (b *smb2Backend) OpenFile(path string, opts OpenOptions) (FileHandle, error) {
+	fileId, err := b.engine.CreateFile(path, opts.DesiredAccess, opts.ShareAccess, opts.CreateDisposition, opts.CreateOptions)
+	if err != nil {
+		return FileHandle{}, err
+	}
+	return newFileHandle(b.dialect, fileId), nil
+}
+
+func (b *smb2Backend) ReadFile(h FileHandle, off uint64, n uint32) ([]byte, error) {
+	fileId, err := b.fileId(h)
+	if err != nil {
+		return nil, err
+	}
+	return b.engine.ReadFile(fileId, off, n)
+}
+
+func (b *smb2Backend) WriteFile(h FileHandle, off uint64, data []byte) (uint32, error) {
+	fileId, err := b.fileId(h)
+	if err != nil {
+		return 0, err
+	}
+	return b.engine.WriteFile(fileId, off, data)
+}
+
+func (b *smb2Backend) CloseFile(h FileHandle) error {
+	fileId, err := b.fileId(h)
+	if err != nil {
+		return err
+	}
+	return b.engine.CloseFile(fileId)
+}
+
+func (b *smb2Backend) ListDirectory(path, pattern string) ([]FileInfo, error) {
+	// The SMB2 engine exposes QueryDirectory as raw information-class bytes;
+	// normalizing those into []FileInfo lands in Phase 6 (with the MS-FSCC
+	// information-class package).
+	return nil, fmt.Errorf("ListDirectory is not yet implemented for SMB2 (Phase 6)")
+}
+
+func (b *smb2Backend) TreeDisconnect() error { return b.engine.TreeDisconnect() }
+func (b *smb2Backend) Logoff() error         { return b.engine.Logoff() }
+func (b *smb2Backend) Disconnect() error     { return b.engine.Disconnect() }
+
+// fileId unboxes an opaque FileHandle back into the SMB2 file id that produced
+// it, guarding against a handle from another backend.
+func (b *smb2Backend) fileId(h FileHandle) (types.SMB2_FILEID, error) {
+	fileId, ok := h.raw.(types.SMB2_FILEID)
+	if !ok {
+		return types.SMB2_FILEID{}, fmt.Errorf("file handle is not an SMB2 file id (got %T)", h.raw)
+	}
+	return fileId, nil
+}
+
+// Compile-time assurance that the adapter satisfies the Backend contract.
+var _ Backend = (*smb2Backend)(nil)

--- a/network/smb/client/backend.go
+++ b/network/smb/client/backend.go
@@ -1,0 +1,52 @@
+package client
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/smb"
+	"github.com/TheManticoreProject/Manticore/windows/credentials"
+)
+
+// Backend is the version-agnostic contract a concrete SMB engine must satisfy to
+// be driven by the generic Client. Each engine (smb_v10, smb_v20, …) is wrapped
+// by an adapter in this package; the engines themselves do not depend on it.
+//
+// The surface is flat and stateful, mirroring the underlying engines: a backend
+// holds the current session and tree, and the methods act against them. A
+// FileHandle returned by OpenFile is opaque to the caller and must be passed
+// back to the same backend that produced it.
+type Backend interface {
+	// Dialect reports the negotiated protocol version this backend speaks.
+	Dialect() smb.SMBProtocolVersion
+
+	// Login authenticates a session with the server.
+	Login(creds *credentials.Credentials) error
+
+	// TreeConnect connects to a share (e.g. `\\server\C$`), making it the
+	// current tree for subsequent file operations.
+	TreeConnect(share string) error
+
+	// OpenFile opens or creates a file on the current tree and returns a handle.
+	OpenFile(path string, opts OpenOptions) (FileHandle, error)
+
+	// ReadFile reads up to n bytes from the open file starting at off.
+	ReadFile(h FileHandle, off uint64, n uint32) ([]byte, error)
+
+	// WriteFile writes data to the open file starting at off and returns the
+	// number of bytes written.
+	WriteFile(h FileHandle, off uint64, data []byte) (uint32, error)
+
+	// CloseFile closes a handle returned by OpenFile.
+	CloseFile(h FileHandle) error
+
+	// ListDirectory enumerates entries of a directory on the current tree that
+	// match pattern (e.g. "*").
+	ListDirectory(path, pattern string) ([]FileInfo, error)
+
+	// TreeDisconnect disconnects the current tree.
+	TreeDisconnect() error
+
+	// Logoff tears down the authenticated session.
+	Logoff() error
+
+	// Disconnect closes the underlying transport connection.
+	Disconnect() error
+}

--- a/network/smb/client/backend.go
+++ b/network/smb/client/backend.go
@@ -20,8 +20,8 @@ type Backend interface {
 	// Login authenticates a session with the server.
 	Login(creds *credentials.Credentials) error
 
-	// TreeConnect connects to a share (e.g. `\\server\C$`), making it the
-	// current tree for subsequent file operations.
+	// TreeConnect connects to a share by name (e.g. "C$"), making it the current
+	// tree for subsequent file operations. The backend forms the full UNC path.
 	TreeConnect(share string) error
 
 	// OpenFile opens or creates a file on the current tree and returns a handle.

--- a/network/smb/client/client.go
+++ b/network/smb/client/client.go
@@ -1,0 +1,105 @@
+package client
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/TheManticoreProject/Manticore/network/smb"
+	smb2 "github.com/TheManticoreProject/Manticore/network/smb/smb_v20/client"
+	"github.com/TheManticoreProject/Manticore/windows/credentials"
+)
+
+// Client is the generic, version-agnostic SMB client. It negotiates a dialect
+// once and routes every operation to a version-specific backend (SMB1/SMB2/…).
+// The surface is flat: the client holds the current session and tree, mirroring
+// the underlying engines.
+type Client struct {
+	backend Backend
+	host    string
+	port    int
+	opts    Options
+}
+
+// Dial connects to host:port, negotiates a dialect according to opts, and
+// returns a ready-to-authenticate Client.
+//
+// NOTE (Phase 3): negotiation currently forces SMB2 — it always connects with
+// the SMB2 engine. Phase 5 replaces this with the multi-protocol negotiate that
+// honors opts.Preferred and opts.Policy and can select SMB1 or SMB2/3.
+func Dial(host string, port int, opts Options) (*Client, error) {
+	ip, err := resolveHost(host)
+	if err != nil {
+		return nil, err
+	}
+
+	engine := smb2.NewClientUsingTCPTransport(ip, port)
+	if opts.Workstation != "" {
+		engine.Workstation = opts.Workstation
+	}
+	if err := engine.Connect(ip, port); err != nil {
+		return nil, fmt.Errorf("SMB2 connect/negotiate failed: %w", err)
+	}
+
+	return &Client{
+		backend: newSMB2Backend(engine),
+		host:    host,
+		port:    port,
+		opts:    opts,
+	}, nil
+}
+
+// Dialect reports the negotiated protocol version.
+func (c *Client) Dialect() smb.SMBProtocolVersion { return c.backend.Dialect() }
+
+// Login authenticates a session with the server.
+func (c *Client) Login(creds *credentials.Credentials) error { return c.backend.Login(creds) }
+
+// TreeConnect connects to a share by name (e.g. "C$"), making it the current tree.
+func (c *Client) TreeConnect(share string) error { return c.backend.TreeConnect(share) }
+
+// OpenFile opens or creates a file on the current tree and returns a handle.
+func (c *Client) OpenFile(path string, opts OpenOptions) (FileHandle, error) {
+	return c.backend.OpenFile(path, opts)
+}
+
+// ReadFile reads up to n bytes from the open file starting at off.
+func (c *Client) ReadFile(h FileHandle, off uint64, n uint32) ([]byte, error) {
+	return c.backend.ReadFile(h, off, n)
+}
+
+// WriteFile writes data to the open file at off and returns the bytes written.
+func (c *Client) WriteFile(h FileHandle, off uint64, data []byte) (uint32, error) {
+	return c.backend.WriteFile(h, off, data)
+}
+
+// CloseFile closes a handle returned by OpenFile.
+func (c *Client) CloseFile(h FileHandle) error { return c.backend.CloseFile(h) }
+
+// ListDirectory enumerates entries of a directory on the current tree.
+func (c *Client) ListDirectory(path, pattern string) ([]FileInfo, error) {
+	return c.backend.ListDirectory(path, pattern)
+}
+
+// TreeDisconnect disconnects the current tree.
+func (c *Client) TreeDisconnect() error { return c.backend.TreeDisconnect() }
+
+// Logoff tears down the authenticated session.
+func (c *Client) Logoff() error { return c.backend.Logoff() }
+
+// Disconnect closes the underlying transport connection.
+func (c *Client) Disconnect() error { return c.backend.Disconnect() }
+
+// resolveHost accepts a literal IP or a hostname and returns an IP address.
+func resolveHost(host string) (net.IP, error) {
+	if ip := net.ParseIP(host); ip != nil {
+		return ip, nil
+	}
+	ips, err := net.LookupIP(host)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve host %q: %w", host, err)
+	}
+	if len(ips) == 0 {
+		return nil, fmt.Errorf("no addresses found for host %q", host)
+	}
+	return ips[0], nil
+}

--- a/network/smb/client/client.go
+++ b/network/smb/client/client.go
@@ -5,6 +5,7 @@ import (
 	"net"
 
 	"github.com/TheManticoreProject/Manticore/network/smb"
+	smb1 "github.com/TheManticoreProject/Manticore/network/smb/smb_v10/client"
 	smb2 "github.com/TheManticoreProject/Manticore/network/smb/smb_v20/client"
 	"github.com/TheManticoreProject/Manticore/windows/credentials"
 )
@@ -23,15 +24,25 @@ type Client struct {
 // Dial connects to host:port, negotiates a dialect according to opts, and
 // returns a ready-to-authenticate Client.
 //
-// NOTE (Phase 3): negotiation currently forces SMB2 — it always connects with
-// the SMB2 engine. Phase 5 replaces this with the multi-protocol negotiate that
-// honors opts.Preferred and opts.Policy and can select SMB1 or SMB2/3.
+// NOTE (Phase 3/4): there is no real negotiation yet — the engine is chosen from
+// the first entry of opts.Preferred (the SMB1 engine when it is SMB_VERSION_1_0,
+// otherwise the SMB2 engine), and that engine performs its own native negotiate.
+// Phase 5 replaces this with the multi-protocol negotiate that honors the full
+// opts.Preferred list and opts.Policy.
 func Dial(host string, port int, opts Options) (*Client, error) {
 	ip, err := resolveHost(host)
 	if err != nil {
 		return nil, err
 	}
 
+	if len(opts.Preferred) > 0 && opts.Preferred[0] == smb.SMB_VERSION_1_0 {
+		return dialSMB1(ip, host, port, opts)
+	}
+	return dialSMB2(ip, host, port, opts)
+}
+
+// dialSMB2 connects with the SMB2 engine and performs its native negotiate.
+func dialSMB2(ip net.IP, host string, port int, opts Options) (*Client, error) {
 	engine := smb2.NewClientUsingTCPTransport(ip, port)
 	if opts.Workstation != "" {
 		engine.Workstation = opts.Workstation
@@ -39,13 +50,22 @@ func Dial(host string, port int, opts Options) (*Client, error) {
 	if err := engine.Connect(ip, port); err != nil {
 		return nil, fmt.Errorf("SMB2 connect/negotiate failed: %w", err)
 	}
+	return &Client{backend: newSMB2Backend(engine), host: host, port: port, opts: opts}, nil
+}
 
-	return &Client{
-		backend: newSMB2Backend(engine),
-		host:    host,
-		port:    port,
-		opts:    opts,
-	}, nil
+// dialSMB1 connects with the SMB1 engine and performs its native negotiate.
+func dialSMB1(ip net.IP, host string, port int, opts Options) (*Client, error) {
+	engine := smb1.NewClientUsingTCPTransport(ip, port)
+	// The SMB1 session setup requires the NativeOS / NativeLanMan fields to be set.
+	engine.NativeOS = "Manticore"
+	engine.NativeLanMan = "Manticore"
+	if opts.Workstation != "" {
+		engine.Workstation = opts.Workstation
+	}
+	if err := engine.Connect(ip, port); err != nil {
+		return nil, fmt.Errorf("SMB1 connect/negotiate failed: %w", err)
+	}
+	return &Client{backend: newSMB1Backend(engine), host: host, port: port, opts: opts}, nil
 }
 
 // Dialect reports the negotiated protocol version.

--- a/network/smb/client/client.go
+++ b/network/smb/client/client.go
@@ -24,21 +24,29 @@ type Client struct {
 // Dial connects to host:port, negotiates a dialect according to opts, and
 // returns a ready-to-authenticate Client.
 //
-// NOTE (Phase 3/4): there is no real negotiation yet — the engine is chosen from
-// the first entry of opts.Preferred (the SMB1 engine when it is SMB_VERSION_1_0,
-// otherwise the SMB2 engine), and that engine performs its own native negotiate.
-// Phase 5 replaces this with the multi-protocol negotiate that honors the full
-// opts.Preferred list and opts.Policy.
+// Selection is driven by opts.Preferred (highest priority first; defaults to all
+// supported versions, best first) and opts.Policy:
+//
+//   - PolicyStrictOrder (default) tries the preferred versions in order and
+//     returns the first the server accepts, reconnecting between attempts. It
+//     can select a lower dialect even when the server supports a higher one.
+//   - PolicyHighestInSet performs a single SMB1 multi-protocol negotiate and
+//     uses the server's highest-supported dialect within the set.
 func Dial(host string, port int, opts Options) (*Client, error) {
 	ip, err := resolveHost(host)
 	if err != nil {
 		return nil, err
 	}
 
-	if len(opts.Preferred) > 0 && opts.Preferred[0] == smb.SMB_VERSION_1_0 {
-		return dialSMB1(ip, host, port, opts)
+	prefs := opts.Preferred
+	if len(prefs) == 0 {
+		prefs = defaultPreference()
 	}
-	return dialSMB2(ip, host, port, opts)
+
+	if opts.Policy == PolicyHighestInSet {
+		return dialHighestInSet(host, ip, port, opts, prefs)
+	}
+	return dialStrictOrder(host, ip, port, opts, prefs)
 }
 
 // dialSMB2 connects with the SMB2 engine and performs its native negotiate.

--- a/network/smb/client/dialect.go
+++ b/network/smb/client/dialect.go
@@ -1,0 +1,72 @@
+package client
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/smb"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/dialects"
+)
+
+// SMB1 dialect strings (MS-CIFS) and SMB2 markers used in the dialect list of a
+// multi-protocol SMB_COM_NEGOTIATE request.
+const (
+	// SMB1DialectNTLM012 is the modern SMB1 dialect ("NT LM 0.12").
+	SMB1DialectNTLM012 = "NT LM 0.12"
+	// SMB2DialectString2002 pins SMB 2.0.2 when offered in an SMB1 negotiate.
+	SMB2DialectString2002 = "SMB 2.002"
+	// SMB2DialectStringWildcard offers "any SMB2"; the server replies with the
+	// wildcard revision 0x02FF and the client follows up with a native SMB2
+	// negotiate to pin the exact dialect.
+	SMB2DialectStringWildcard = "SMB 2.???"
+)
+
+// smb2DialectFor maps an abstract protocol version to its concrete SMB2 wire
+// dialect revision. ok is false for SMB1 (which has no 16-bit revision) and for
+// values that are not SMB2 dialects. The abstract SMB_VERSION_2_0 family marker
+// maps to the lowest real SMB2 dialect, SMB 2.0.2.
+func smb2DialectFor(v smb.SMBProtocolVersion) (dialects.Dialect, bool) {
+	switch v {
+	case smb.SMB_VERSION_2_0, smb.SMB_VERSION_2_0_2:
+		return dialects.SMB2_DIALECT_2_0_2, true
+	case smb.SMB_VERSION_2_1:
+		return dialects.SMB2_DIALECT_2_1_0, true
+	case smb.SMB_VERSION_3_0:
+		return dialects.SMB2_DIALECT_3_0_0, true
+	case smb.SMB_VERSION_3_0_2:
+		return dialects.SMB2_DIALECT_3_0_2, true
+	case smb.SMB_VERSION_3_1_1:
+		return dialects.SMB2_DIALECT_3_1_1, true
+	}
+	return 0, false
+}
+
+// versionForSMB2Dialect is the reverse mapping, used to interpret the
+// DialectRevision returned in an SMB2 NEGOTIATE response. ok is false for the
+// wildcard revision and for any value that is not a real SMB2 dialect (notably
+// 0x0200, which is the abstract family marker, not a wire dialect).
+func versionForSMB2Dialect(d dialects.Dialect) (smb.SMBProtocolVersion, bool) {
+	switch d {
+	case dialects.SMB2_DIALECT_2_0_2:
+		return smb.SMB_VERSION_2_0_2, true
+	case dialects.SMB2_DIALECT_2_1_0:
+		return smb.SMB_VERSION_2_1, true
+	case dialects.SMB2_DIALECT_3_0_0:
+		return smb.SMB_VERSION_3_0, true
+	case dialects.SMB2_DIALECT_3_0_2:
+		return smb.SMB_VERSION_3_0_2, true
+	case dialects.SMB2_DIALECT_3_1_1:
+		return smb.SMB_VERSION_3_1_1, true
+	}
+	return 0, false
+}
+
+// defaultPreference is the preference list used when Options.Preferred is empty:
+// every supported version, best first.
+func defaultPreference() []smb.SMBProtocolVersion {
+	return []smb.SMBProtocolVersion{
+		smb.SMB_VERSION_3_1_1,
+		smb.SMB_VERSION_3_0_2,
+		smb.SMB_VERSION_3_0,
+		smb.SMB_VERSION_2_1,
+		smb.SMB_VERSION_2_0_2,
+		smb.SMB_VERSION_1_0,
+	}
+}

--- a/network/smb/client/dialect.go
+++ b/network/smb/client/dialect.go
@@ -5,18 +5,11 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/dialects"
 )
 
-// SMB1 dialect strings (MS-CIFS) and SMB2 markers used in the dialect list of a
-// multi-protocol SMB_COM_NEGOTIATE request.
-const (
-	// SMB1DialectNTLM012 is the modern SMB1 dialect ("NT LM 0.12").
-	SMB1DialectNTLM012 = "NT LM 0.12"
-	// SMB2DialectString2002 pins SMB 2.0.2 when offered in an SMB1 negotiate.
-	SMB2DialectString2002 = "SMB 2.002"
-	// SMB2DialectStringWildcard offers "any SMB2"; the server replies with the
-	// wildcard revision 0x02FF and the client follows up with a native SMB2
-	// negotiate to pin the exact dialect.
-	SMB2DialectStringWildcard = "SMB 2.???"
-)
+// smb2DialectString2002 is the SMB2 dialect marker offered in a multi-protocol
+// SMB_COM_NEGOTIATE to advertise SMB 2.0.2 (the engine's current ceiling). The
+// "SMB 2.???" wildcard, which declares 2.1+ support and triggers a follow-up
+// native SMB2 negotiate, will be added when 2.1+/3.x engines exist.
+const smb2DialectString2002 = "SMB 2.002"
 
 // smb2DialectFor maps an abstract protocol version to its concrete SMB2 wire
 // dialect revision. ok is false for SMB1 (which has no 16-bit revision) and for

--- a/network/smb/client/dialect_test.go
+++ b/network/smb/client/dialect_test.go
@@ -1,0 +1,77 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/dialects"
+)
+
+func TestSMB2DialectFor(t *testing.T) {
+	cases := []struct {
+		v    smb.SMBProtocolVersion
+		want dialects.Dialect
+		ok   bool
+	}{
+		{smb.SMB_VERSION_2_0, dialects.SMB2_DIALECT_2_0_2, true}, // family marker -> 2.0.2
+		{smb.SMB_VERSION_2_0_2, dialects.SMB2_DIALECT_2_0_2, true},
+		{smb.SMB_VERSION_2_1, dialects.SMB2_DIALECT_2_1_0, true},
+		{smb.SMB_VERSION_3_0, dialects.SMB2_DIALECT_3_0_0, true},
+		{smb.SMB_VERSION_3_0_2, dialects.SMB2_DIALECT_3_0_2, true},
+		{smb.SMB_VERSION_3_1_1, dialects.SMB2_DIALECT_3_1_1, true},
+		{smb.SMB_VERSION_1_0, 0, false}, // SMB1 has no SMB2 revision
+	}
+	for _, c := range cases {
+		got, ok := smb2DialectFor(c.v)
+		if ok != c.ok || (ok && got != c.want) {
+			t.Errorf("smb2DialectFor(%s) = (0x%04x, %v), want (0x%04x, %v)", c.v, uint16(got), ok, uint16(c.want), c.ok)
+		}
+	}
+}
+
+func TestVersionForSMB2Dialect_RoundTrip(t *testing.T) {
+	// Every real SMB2 dialect must round-trip back to a concrete version.
+	for _, d := range []dialects.Dialect{
+		dialects.SMB2_DIALECT_2_0_2, dialects.SMB2_DIALECT_2_1_0,
+		dialects.SMB2_DIALECT_3_0_0, dialects.SMB2_DIALECT_3_0_2, dialects.SMB2_DIALECT_3_1_1,
+	} {
+		v, ok := versionForSMB2Dialect(d)
+		if !ok {
+			t.Errorf("versionForSMB2Dialect(0x%04x) ok=false, want true", uint16(d))
+			continue
+		}
+		back, ok := smb2DialectFor(v)
+		if !ok || back != d {
+			t.Errorf("round-trip 0x%04x -> %s -> 0x%04x failed", uint16(d), v, uint16(back))
+		}
+	}
+}
+
+func TestVersionForSMB2Dialect_RejectsNonDialects(t *testing.T) {
+	// The wildcard is not a concrete dialect.
+	if _, ok := versionForSMB2Dialect(dialects.SMB2_DIALECT_WILDCARD); ok {
+		t.Error("wildcard 0x02FF must not map to a concrete version")
+	}
+	// 0x0200 is the abstract family marker, not a real wire dialect revision.
+	if _, ok := versionForSMB2Dialect(dialects.Dialect(0x0200)); ok {
+		t.Error("0x0200 must not be accepted as a wire dialect")
+	}
+}
+
+func TestDefaultPreference(t *testing.T) {
+	pref := defaultPreference()
+	if len(pref) == 0 {
+		t.Fatal("defaultPreference() is empty")
+	}
+	for _, v := range pref {
+		if !v.IsSupported() {
+			t.Errorf("default preference contains unsupported version %s", v)
+		}
+	}
+	// Must be ordered best-first: each entry strictly greater than the next.
+	for i := 1; i < len(pref); i++ {
+		if !(pref[i-1] > pref[i]) {
+			t.Errorf("default preference not strictly descending at %d: %s !> %s", i, pref[i-1], pref[i])
+		}
+	}
+}

--- a/network/smb/client/doc.go
+++ b/network/smb/client/doc.go
@@ -1,0 +1,34 @@
+// Package client provides a single, version-agnostic SMB client.
+//
+// The caller constructs one [Client], supplies an ordered preference list of
+// protocol versions, and dials. The client negotiates the dialect once and
+// binds a version-specific backend (SMB1, SMB2, or — in future — SMB3) behind a
+// common interface. Every subsequent call (TreeConnect, OpenFile, ReadFile, …)
+// is routed to that backend, so the caller never has to know which dialect was
+// selected.
+//
+// # Backends
+//
+// Each SMB engine (network/smb/smb_v10, network/smb/smb_v20, …) is wrapped by a
+// thin adapter that satisfies the Backend interface. The dependency direction is
+// one-way: this package imports the engines; the engines never import this
+// package. Adapters live here.
+//
+// # Negotiation and preference
+//
+// Dialect selection is driven by a client-side preference list (Options.Preferred,
+// highest priority first) and a policy:
+//
+//   - PolicyStrictOrder (default) tries the preferred versions in order and
+//     selects the first one the server accepts. This honors the caller's order
+//     exactly — it can force SMB1 on a server that also supports SMB3.
+//   - PolicyHighestInSet performs a single multi-protocol negotiate over the
+//     whole set and uses the server's highest-supported dialect within it.
+//
+// Discovery uses the SMB1 multi-protocol negotiate: one request offers the SMB1
+// and SMB2 dialect markers, and the reply is dispatched on its protocol marker
+// (\xFFSMB for SMB1, \xFESMB for SMB2); the SMB2 wildcard dialect triggers a
+// second, native SMB2 negotiate to pin the exact 2.1/3.x revision.
+//
+// This package is built in phases; see .private/smb_common/docs for the plan.
+package client

--- a/network/smb/client/doc.go
+++ b/network/smb/client/doc.go
@@ -25,10 +25,18 @@
 //   - PolicyHighestInSet performs a single multi-protocol negotiate over the
 //     whole set and uses the server's highest-supported dialect within it.
 //
-// Discovery uses the SMB1 multi-protocol negotiate: one request offers the SMB1
-// and SMB2 dialect markers, and the reply is dispatched on its protocol marker
-// (\xFFSMB for SMB1, \xFESMB for SMB2); the SMB2 wildcard dialect triggers a
-// second, native SMB2 negotiate to pin the exact 2.1/3.x revision.
+// PolicyHighestInSet uses the SMB1 multi-protocol negotiate: one request offers
+// the SMB1 and SMB2 dialect markers, and the reply is dispatched on its protocol
+// marker (\xFFSMB for SMB1, \xFESMB for SMB2). The SMB2 engine's ceiling is
+// SMB 2.0.2, so the "SMB 2.002" marker is offered and the server returns a
+// concrete SMB 2.0.2 response. (When SMB 2.1+/3.x engines exist, the "SMB 2.???"
+// wildcard will be offered, with a follow-up native SMB2 negotiate to pin the
+// exact revision.)
 //
-// This package is built in phases; see .private/smb_common/docs for the plan.
+// PolicyStrictOrder instead tries the preferred versions in order with a native
+// per-engine negotiate, reconnecting between attempts and binding the first the
+// server accepts — so a lower dialect listed first is selected even when the
+// server also supports a higher one.
+//
+// Backends supported today: SMB 1.0 and SMB 2.0.2. SMB 3.x awaits its engine.
 package client

--- a/network/smb/client/example_test.go
+++ b/network/smb/client/example_test.go
@@ -1,0 +1,85 @@
+package client_test
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/TheManticoreProject/Manticore/network/smb"
+	smbclient "github.com/TheManticoreProject/Manticore/network/smb/client"
+	"github.com/TheManticoreProject/Manticore/windows/credentials"
+)
+
+// ExampleDial shows a full session: negotiate the best mutually-supported
+// dialect, authenticate, connect to a share, and read a file — without the
+// caller having to know whether SMB1 or SMB2 was selected.
+func ExampleDial() {
+	creds, err := credentials.NewCredentials("", "Administrator", "secret", "")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Empty Options: offer all supported versions, best first.
+	c, err := smbclient.Dial("fileserver", 445, smbclient.Options{})
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer c.Disconnect()
+
+	if err := c.Login(creds); err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println("negotiated", c.Dialect())
+
+	if err := c.TreeConnect("C$"); err != nil {
+		log.Fatal(err)
+	}
+	defer c.TreeDisconnect()
+
+	h, err := c.OpenFile(`Windows\win.ini`, smbclient.OpenOptions{
+		DesiredAccess:     0x80000000, // GENERIC_READ
+		ShareAccess:       0x00000001, // FILE_SHARE_READ
+		CreateDisposition: 0x00000001, // FILE_OPEN
+		CreateOptions:     0x00000040, // FILE_NON_DIRECTORY_FILE
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer c.CloseFile(h)
+
+	data, err := c.ReadFile(h, 0, 4096)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("read %d bytes\n", len(data))
+}
+
+// ExampleDial_preferenceOrder forces SMB1, falling back to SMB 2.0.2. With the
+// default PolicyStrictOrder the client selects the first version the server
+// accepts, honoring the listed order even when the server supports both.
+func ExampleDial_preferenceOrder() {
+	c, err := smbclient.Dial("fileserver", 445, smbclient.Options{
+		Preferred: []smb.SMBProtocolVersion{
+			smb.SMB_VERSION_1_0,
+			smb.SMB_VERSION_2_0_2,
+		},
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer c.Disconnect()
+	fmt.Println("negotiated", c.Dialect())
+}
+
+// ExampleClient_ListDirectory enumerates a directory; the returned FileInfo
+// values are the same regardless of the negotiated dialect.
+func ExampleClient_ListDirectory() {
+	var c *smbclient.Client // obtained from Dial + Login + TreeConnect
+
+	entries, err := c.ListDirectory("Windows", "*")
+	if err != nil {
+		log.Fatal(err)
+	}
+	for _, e := range entries {
+		fmt.Printf("%s\tdir=%v\tsize=%d\n", e.Name, e.IsDir(), e.Size)
+	}
+}

--- a/network/smb/client/fileinfo.go
+++ b/network/smb/client/fileinfo.go
@@ -1,0 +1,99 @@
+package client
+
+import (
+	"encoding/binary"
+	"strings"
+	"time"
+	"unicode/utf16"
+)
+
+// fileAttributeDirectory is the FILE_ATTRIBUTE_DIRECTORY bit (MS-FSCC 2.6).
+const fileAttributeDirectory uint32 = 0x00000010
+
+// File-open and information-class constants used to enumerate a directory over
+// SMB2 (MS-SMB2 / MS-FSCC).
+const (
+	fileListDirectory uint32 = 0x00000001 // DesiredAccess: FILE_LIST_DIRECTORY
+	fileReadAttributes uint32 = 0x00000080 // DesiredAccess: FILE_READ_ATTRIBUTES
+	fileOpen          uint32 = 0x00000001 // CreateDisposition: FILE_OPEN
+	fileDirectoryFile uint32 = 0x00000001 // CreateOptions: FILE_DIRECTORY_FILE
+	shareReadWrite    uint32 = 0x00000003 // ShareAccess: FILE_SHARE_READ|WRITE
+
+	// fileBothDirectoryInformation is the FILE_INFORMATION_CLASS used for
+	// enumeration; its FILE_BOTH_DIR_INFORMATION entries (MS-FSCC 2.4.8) carry the
+	// name, attributes, size, and timestamps needed for FileInfo.
+	fileBothDirectoryInformation uint8 = 0x03
+)
+
+// bothDirInfoFixedSize is the fixed portion of a FILE_BOTH_DIR_INFORMATION entry
+// before the variable FileName: NextEntryOffset(4) FileIndex(4) 4xFILETIME(32)
+// EndOfFile(8) AllocationSize(8) FileAttributes(4) FileNameLength(4) EaSize(4)
+// ShortNameLength(1) Reserved(1) ShortName(24).
+const bothDirInfoFixedSize = 94
+
+// parseBothDirectoryInfo decodes a buffer of consecutive FILE_BOTH_DIR_INFORMATION
+// entries (MS-FSCC 2.4.8), as returned by SMB2 QUERY_DIRECTORY, into FileInfo
+// values. FileName is UTF-16LE. The "." and ".." pseudo-entries are skipped.
+//
+// A typed MS-FSCC information-class package (#525) would replace this hand-rolled
+// decoder; it lives here until that lands.
+func parseBothDirectoryInfo(buf []byte) []FileInfo {
+	var out []FileInfo
+
+	for pos := 0; pos+bothDirInfoFixedSize <= len(buf); {
+		next := int(binary.LittleEndian.Uint32(buf[pos : pos+4]))
+		creation := filetimeToTime(binary.LittleEndian.Uint64(buf[pos+8 : pos+16]))
+		lastAccess := filetimeToTime(binary.LittleEndian.Uint64(buf[pos+16 : pos+24]))
+		lastWrite := filetimeToTime(binary.LittleEndian.Uint64(buf[pos+24 : pos+32]))
+		change := filetimeToTime(binary.LittleEndian.Uint64(buf[pos+32 : pos+40]))
+		endOfFile := binary.LittleEndian.Uint64(buf[pos+40 : pos+48])
+		allocationSize := binary.LittleEndian.Uint64(buf[pos+48 : pos+56])
+		attrs := binary.LittleEndian.Uint32(buf[pos+56 : pos+60])
+		nameLen := int(binary.LittleEndian.Uint32(buf[pos+60 : pos+64]))
+
+		name := ""
+		if nameLen > 0 && pos+bothDirInfoFixedSize+nameLen <= len(buf) {
+			name = decodeUTF16LE(buf[pos+bothDirInfoFixedSize : pos+bothDirInfoFixedSize+nameLen])
+		}
+
+		if name != "." && name != ".." {
+			out = append(out, FileInfo{
+				Name:           name,
+				FileAttributes: attrs,
+				Size:           endOfFile,
+				AllocationSize: allocationSize,
+				CreationTime:   creation,
+				LastAccessTime: lastAccess,
+				LastWriteTime:  lastWrite,
+				ChangeTime:     change,
+			})
+		}
+
+		if next == 0 {
+			break
+		}
+		pos += next
+	}
+
+	return out
+}
+
+// filetimeToTime converts a Windows FILETIME (100ns ticks since 1601-01-01 UTC)
+// to a time.Time. A zero (or sub-epoch) FILETIME maps to the zero time.
+func filetimeToTime(ft uint64) time.Time {
+	const epochDiff = 116444736000000000 // 100ns intervals between 1601-01-01 and 1970-01-01
+	if ft == 0 || ft < epochDiff {
+		return time.Time{}
+	}
+	return time.Unix(0, int64(ft-epochDiff)*100).UTC()
+}
+
+// decodeUTF16LE decodes a little-endian UTF-16 byte buffer into a string, trimming
+// any trailing NUL units.
+func decodeUTF16LE(b []byte) string {
+	u16 := make([]uint16, 0, len(b)/2)
+	for i := 0; i+1 < len(b); i += 2 {
+		u16 = append(u16, binary.LittleEndian.Uint16(b[i:i+2]))
+	}
+	return strings.TrimRight(string(utf16.Decode(u16)), "\x00")
+}

--- a/network/smb/client/fileinfo.go
+++ b/network/smb/client/fileinfo.go
@@ -13,11 +13,11 @@ const fileAttributeDirectory uint32 = 0x00000010
 // File-open and information-class constants used to enumerate a directory over
 // SMB2 (MS-SMB2 / MS-FSCC).
 const (
-	fileListDirectory uint32 = 0x00000001 // DesiredAccess: FILE_LIST_DIRECTORY
+	fileListDirectory  uint32 = 0x00000001 // DesiredAccess: FILE_LIST_DIRECTORY
 	fileReadAttributes uint32 = 0x00000080 // DesiredAccess: FILE_READ_ATTRIBUTES
-	fileOpen          uint32 = 0x00000001 // CreateDisposition: FILE_OPEN
-	fileDirectoryFile uint32 = 0x00000001 // CreateOptions: FILE_DIRECTORY_FILE
-	shareReadWrite    uint32 = 0x00000003 // ShareAccess: FILE_SHARE_READ|WRITE
+	fileOpen           uint32 = 0x00000001 // CreateDisposition: FILE_OPEN
+	fileDirectoryFile  uint32 = 0x00000001 // CreateOptions: FILE_DIRECTORY_FILE
+	shareReadWrite     uint32 = 0x00000003 // ShareAccess: FILE_SHARE_READ|WRITE
 
 	// fileBothDirectoryInformation is the FILE_INFORMATION_CLASS used for
 	// enumeration; its FILE_BOTH_DIR_INFORMATION entries (MS-FSCC 2.4.8) carry the

--- a/network/smb/client/fileinfo_test.go
+++ b/network/smb/client/fileinfo_test.go
@@ -1,0 +1,70 @@
+package client
+
+import (
+	"encoding/binary"
+	"testing"
+	"unicode/utf16"
+)
+
+// bothDirEntry builds a single FILE_BOTH_DIR_INFORMATION entry with a UTF-16LE
+// name. next is written to NextEntryOffset verbatim.
+func bothDirEntry(name string, attrs uint32, size uint64, next uint32) []byte {
+	u16 := utf16.Encode([]rune(name))
+	nameBytes := make([]byte, len(u16)*2)
+	for i, u := range u16 {
+		binary.LittleEndian.PutUint16(nameBytes[i*2:], u)
+	}
+	e := make([]byte, bothDirInfoFixedSize+len(nameBytes))
+	binary.LittleEndian.PutUint32(e[0:4], next)
+	binary.LittleEndian.PutUint64(e[40:48], size)                   // EndOfFile
+	binary.LittleEndian.PutUint64(e[48:56], size)                   // AllocationSize
+	binary.LittleEndian.PutUint32(e[56:60], attrs)                  // FileAttributes
+	binary.LittleEndian.PutUint32(e[60:64], uint32(len(nameBytes))) // FileNameLength
+	copy(e[bothDirInfoFixedSize:], nameBytes)
+	return e
+}
+
+func TestParseBothDirectoryInfo(t *testing.T) {
+	dot := bothDirEntry(".", fileAttributeDirectory, 0, 0)
+	dotdot := bothDirEntry("..", fileAttributeDirectory, 0, 0)
+	file := bothDirEntry("report.txt", 0x20 /*ARCHIVE*/, 1234, 0)
+	dir := bothDirEntry("subdir", fileAttributeDirectory, 0, 0)
+
+	// Chain: NextEntryOffset of each non-last entry is that entry's length.
+	dot[0] = byte(len(dot))
+	off := len(dot)
+	binary.LittleEndian.PutUint32(dotdot[0:4], uint32(len(dotdot)))
+	off += len(dotdot)
+	binary.LittleEndian.PutUint32(file[0:4], uint32(len(file)))
+	off += len(file)
+	_ = off
+
+	var buf []byte
+	buf = append(buf, dot...)
+	buf = append(buf, dotdot...)
+	buf = append(buf, file...)
+	buf = append(buf, dir...) // last, next=0
+
+	got := parseBothDirectoryInfo(buf)
+
+	// "." and ".." are skipped.
+	if len(got) != 2 {
+		t.Fatalf("expected 2 entries (. and .. skipped), got %d: %+v", len(got), got)
+	}
+	if got[0].Name != "report.txt" || got[0].IsDir() || got[0].Size != 1234 {
+		t.Errorf("file entry wrong: %+v", got[0])
+	}
+	if got[1].Name != "subdir" || !got[1].IsDir() {
+		t.Errorf("dir entry wrong: %+v", got[1])
+	}
+}
+
+func TestParseBothDirectoryInfo_Empty(t *testing.T) {
+	if got := parseBothDirectoryInfo(nil); got != nil {
+		t.Errorf("expected nil for empty buffer, got %+v", got)
+	}
+	// A truncated buffer (shorter than the fixed entry) yields no entries.
+	if got := parseBothDirectoryInfo(make([]byte, 10)); len(got) != 0 {
+		t.Errorf("expected no entries for truncated buffer, got %d", len(got))
+	}
+}

--- a/network/smb/client/negotiate.go
+++ b/network/smb/client/negotiate.go
@@ -13,7 +13,6 @@ import (
 	smb1flags "github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header/flags"
 	smb1flags2 "github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header/flags2"
 	smb2 "github.com/TheManticoreProject/Manticore/network/smb/smb_v20/client"
-	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/dialects"
 	smb2msg "github.com/TheManticoreProject/Manticore/network/smb/smb_v20/message"
 	smb2commands "github.com/TheManticoreProject/Manticore/network/smb/smb_v20/message/commands"
 )
@@ -155,9 +154,8 @@ func sendMultiProtocolNegotiate(t transport.Transport, wantSMB1, wantSMB2 bool) 
 		// support, after which the server replies with the wildcard revision and
 		// expects a follow-up negotiate offering 2.1+ — a 2.0.2-only follow-up is
 		// reset by Windows Server. "SMB 2.002" makes the server return a concrete
-		// SMB 2.0.2 negotiate response directly, needing no second leg. (The
-		// wildcard path in finishSMB2 remains for when 2.1+/3.x engines land.)
-		neg.Dialects.AddDialect(SMB2DialectString2002)
+		// SMB 2.0.2 negotiate response directly, needing no second leg.
+		neg.Dialects.AddDialect(smb2DialectString2002)
 	}
 	req.AddCommand(neg)
 
@@ -203,9 +201,11 @@ func finishSMB1(t transport.Transport, ip net.IP, host string, port int, opts Op
 	return &Client{backend: newSMB1Backend(engine), host: host, port: port, opts: opts}, nil
 }
 
-// finishSMB2 parses the SMB2 negotiate response, hands the live transport to the
-// SMB2 engine, and either applies the response directly or, for a wildcard
-// response, performs the native second negotiate that pins the concrete dialect.
+// finishSMB2 parses the SMB2 negotiate response and hands the live transport to
+// the SMB2 engine. Because the multi-protocol negotiate offers the "SMB 2.002"
+// marker, the server returns a concrete SMB 2.0.2 negotiate response, which is
+// applied directly. A dialect the engine cannot drive is rejected rather than
+// applied.
 func finishSMB2(t transport.Transport, ip net.IP, host string, port int, opts Options, raw []byte) (*Client, error) {
 	respMsg := smb2msg.NewMessage()
 	if _, err := respMsg.Header.Unmarshal(raw); err != nil {
@@ -222,26 +222,15 @@ func finishSMB2(t transport.Transport, ip net.IP, host string, port int, opts Op
 		return nil, fmt.Errorf("unexpected SMB2 negotiate response command: %T", respMsg.Command)
 	}
 
+	if v, ok := versionForSMB2Dialect(resp.DialectRevision); !ok || !engineSupportsSMB2(v) {
+		t.Close()
+		return nil, fmt.Errorf("server selected SMB2 dialect 0x%04x, which the engine cannot drive", uint16(resp.DialectRevision))
+	}
+
 	engine := smb2.NewFromTransport(t, ip, port)
 	if opts.Workstation != "" {
 		engine.Workstation = opts.Workstation
 	}
-
-	if resp.DialectRevision == dialects.SMB2_DIALECT_WILDCARD {
-		// Second leg: a native SMB2 NEGOTIATE pins the concrete dialect (SMB 2.0.2).
-		if err := engine.Negotiate(); err != nil {
-			t.Close()
-			return nil, fmt.Errorf("SMB2 second-stage negotiate failed: %w", err)
-		}
-	} else {
-		engine.ApplyNegotiateResponse(resp)
-	}
+	engine.ApplyNegotiateResponse(resp)
 	return &Client{backend: newSMB2Backend(engine), host: host, port: port, opts: opts}, nil
-}
-
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
 }

--- a/network/smb/client/negotiate.go
+++ b/network/smb/client/negotiate.go
@@ -1,0 +1,247 @@
+package client
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/TheManticoreProject/Manticore/network/smb"
+	"github.com/TheManticoreProject/Manticore/network/smb/common/transport"
+	smb1 "github.com/TheManticoreProject/Manticore/network/smb/smb_v10/client"
+	smb1dialects "github.com/TheManticoreProject/Manticore/network/smb/smb_v10/dialects"
+	smb1msg "github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message"
+	smb1commands "github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	smb1flags "github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header/flags"
+	smb1flags2 "github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header/flags2"
+	smb2 "github.com/TheManticoreProject/Manticore/network/smb/smb_v20/client"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/dialects"
+	smb2msg "github.com/TheManticoreProject/Manticore/network/smb/smb_v20/message"
+	smb2commands "github.com/TheManticoreProject/Manticore/network/smb/smb_v20/message/commands"
+)
+
+// engineSupportsSMB2 reports whether the SMB2 engine can drive version v. The
+// engine negotiates SMB 2.0.2; the 2.0 family marker and 2.1 map onto it, while
+// 3.x is not yet supported (a dedicated engine arrives in Phase 7).
+func engineSupportsSMB2(v smb.SMBProtocolVersion) bool {
+	switch v {
+	case smb.SMB_VERSION_2_0, smb.SMB_VERSION_2_0_2, smb.SMB_VERSION_2_1:
+		return true
+	}
+	return false
+}
+
+// dialStrictOrder tries the preferred versions in order, reconnecting between
+// attempts, and returns the first the server accepts. Consecutive versions that
+// resolve to the same engine attempt (all the SMB2 dialects) are collapsed so the
+// same connection is not retried redundantly. This honors the caller's order
+// exactly — a lower dialect listed first wins even when the server supports a
+// higher one.
+func dialStrictOrder(host string, ip net.IP, port int, opts Options, prefs []smb.SMBProtocolVersion) (*Client, error) {
+	triedSMB1, triedSMB2 := false, false
+	var lastErr error
+	attempted := false
+
+	for _, v := range prefs {
+		var (
+			c   *Client
+			err error
+		)
+		switch {
+		case v == smb.SMB_VERSION_1_0:
+			if triedSMB1 {
+				continue
+			}
+			triedSMB1 = true
+			c, err = dialSMB1(ip, host, port, opts)
+		case engineSupportsSMB2(v):
+			if triedSMB2 {
+				continue
+			}
+			triedSMB2 = true
+			c, err = dialSMB2(ip, host, port, opts)
+		default:
+			// e.g. SMB 3.x — no engine yet; skip.
+			continue
+		}
+
+		attempted = true
+		if err == nil {
+			return c, nil
+		}
+		lastErr = err
+	}
+
+	if !attempted {
+		return nil, fmt.Errorf("no supported protocol version in preference list for %s", host)
+	}
+	return nil, fmt.Errorf("no preferred dialect accepted by %s: %w", host, lastErr)
+}
+
+// wantedFamilies reports which engine families a preference list calls for: SMB1
+// when SMB_VERSION_1_0 is present, and SMB2 when any engine-supported SMB2 dialect
+// is present. Unsupported versions (3.x) contribute nothing.
+func wantedFamilies(prefs []smb.SMBProtocolVersion) (smb1, smb2 bool) {
+	for _, v := range prefs {
+		switch {
+		case v == smb.SMB_VERSION_1_0:
+			smb1 = true
+		case engineSupportsSMB2(v):
+			smb2 = true
+		}
+	}
+	return smb1, smb2
+}
+
+// dialHighestInSet performs a single SMB1 multi-protocol negotiate — one request
+// offering the requested SMB1 and SMB2 dialect markers — and binds the engine for
+// whatever the server selects (its highest within the offered set). The reply is
+// dispatched on its protocol marker; an SMB2 wildcard reply triggers a second,
+// native SMB2 negotiate to pin the concrete dialect.
+func dialHighestInSet(host string, ip net.IP, port int, opts Options, prefs []smb.SMBProtocolVersion) (*Client, error) {
+	wantSMB1, wantSMB2 := wantedFamilies(prefs)
+	if !wantSMB1 && !wantSMB2 {
+		return nil, fmt.Errorf("no supported protocol version in preference list for %s", host)
+	}
+
+	t := transport.NewTransport("tcp")
+	if err := t.Connect(ip, port); err != nil {
+		return nil, fmt.Errorf("failed to connect to %s: %w", host, err)
+	}
+
+	raw, offered, err := sendMultiProtocolNegotiate(t, wantSMB1, wantSMB2)
+	if err != nil {
+		t.Close()
+		return nil, err
+	}
+	if len(raw) < 4 || string(raw[1:4]) != "SMB" {
+		t.Close()
+		return nil, fmt.Errorf("unrecognized negotiate response from %s (% x)", host, raw[:min(4, len(raw))])
+	}
+
+	switch raw[0] {
+	case 0xFF: // SMB1
+		if !wantSMB1 {
+			t.Close()
+			return nil, fmt.Errorf("server selected SMB1 but it was not requested")
+		}
+		return finishSMB1(t, ip, host, port, opts, raw, offered)
+	case 0xFE: // SMB2
+		if !wantSMB2 {
+			t.Close()
+			return nil, fmt.Errorf("server selected SMB2 but it was not requested")
+		}
+		return finishSMB2(t, ip, host, port, opts, raw)
+	default:
+		t.Close()
+		return nil, fmt.Errorf("unrecognized negotiate response protocol marker from %s (% x)", host, raw[:4])
+	}
+}
+
+// sendMultiProtocolNegotiate builds and sends an SMB1 SMB_COM_NEGOTIATE offering
+// the requested dialect markers, and returns the raw response together with the
+// negotiate request command (its offered dialect list is needed to resolve an
+// SMB1 selection). The wildcard "SMB 2.???" marker advertises SMB2 support.
+func sendMultiProtocolNegotiate(t transport.Transport, wantSMB1, wantSMB2 bool) ([]byte, *smb1commands.NegotiateRequest, error) {
+	req := smb1msg.NewMessage()
+	req.Header.SetFlags(smb1flags.FLAGS_CANONICALIZED_PATHS | smb1flags.FLAGS_CASE_INSENSITIVE)
+	req.Header.SetFlags2(smb1flags2.FLAGS2_UNICODE | smb1flags2.FLAGS2_NT_STATUS_ERROR_CODES | smb1flags2.FLAGS2_EXTENDED_SECURITY | smb1flags2.FLAGS2_LONG_NAMES_ALLOWED)
+
+	neg := smb1commands.NewNegotiateRequest()
+	if wantSMB1 {
+		neg.Dialects.AddDialect(smb1dialects.DIALECT_NT_LM_0_12)
+	}
+	if wantSMB2 {
+		// The SMB2 engine's ceiling is SMB 2.0.2, so offer the "SMB 2.002" marker
+		// rather than the "SMB 2.???" wildcard. A wildcard offer declares 2.1+
+		// support, after which the server replies with the wildcard revision and
+		// expects a follow-up negotiate offering 2.1+ — a 2.0.2-only follow-up is
+		// reset by Windows Server. "SMB 2.002" makes the server return a concrete
+		// SMB 2.0.2 negotiate response directly, needing no second leg. (The
+		// wildcard path in finishSMB2 remains for when 2.1+/3.x engines land.)
+		neg.Dialects.AddDialect(SMB2DialectString2002)
+	}
+	req.AddCommand(neg)
+
+	marshalled, err := req.Marshal()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to marshal multi-protocol negotiate: %w", err)
+	}
+	if _, err := t.Send(marshalled); err != nil {
+		return nil, nil, fmt.Errorf("failed to send multi-protocol negotiate: %w", err)
+	}
+	raw, err := t.Receive()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to receive negotiate response: %w", err)
+	}
+	return raw, neg, nil
+}
+
+// finishSMB1 parses the SMB1 negotiate response, hands the live transport to the
+// SMB1 engine, and applies the response (SMB1 cannot renegotiate).
+func finishSMB1(t transport.Transport, ip net.IP, host string, port int, opts Options, raw []byte, offered *smb1commands.NegotiateRequest) (*Client, error) {
+	respMsg := smb1msg.NewMessage()
+	respMsg.AddCommand(offered) // attach the negotiate command so Unmarshal decodes the response
+	if err := respMsg.Unmarshal(raw); err != nil {
+		t.Close()
+		return nil, fmt.Errorf("failed to parse SMB1 negotiate response: %w", err)
+	}
+	resp, ok := respMsg.Command.(*smb1commands.NegotiateResponse)
+	if !ok {
+		t.Close()
+		return nil, fmt.Errorf("unexpected SMB1 negotiate response command: %T", respMsg.Command)
+	}
+
+	engine := smb1.NewFromTransport(t, ip, port)
+	engine.NativeOS = "Manticore"
+	engine.NativeLanMan = "Manticore"
+	if opts.Workstation != "" {
+		engine.Workstation = opts.Workstation
+	}
+	if err := engine.ApplyNegotiateResponse(resp, offered.Dialects); err != nil {
+		t.Close()
+		return nil, err
+	}
+	return &Client{backend: newSMB1Backend(engine), host: host, port: port, opts: opts}, nil
+}
+
+// finishSMB2 parses the SMB2 negotiate response, hands the live transport to the
+// SMB2 engine, and either applies the response directly or, for a wildcard
+// response, performs the native second negotiate that pins the concrete dialect.
+func finishSMB2(t transport.Transport, ip net.IP, host string, port int, opts Options, raw []byte) (*Client, error) {
+	respMsg := smb2msg.NewMessage()
+	if _, err := respMsg.Header.Unmarshal(raw); err != nil {
+		t.Close()
+		return nil, fmt.Errorf("failed to parse SMB2 negotiate response header: %w", err)
+	}
+	if _, err := respMsg.Unmarshal(raw); err != nil {
+		t.Close()
+		return nil, fmt.Errorf("failed to parse SMB2 negotiate response: %w", err)
+	}
+	resp, ok := respMsg.Command.(*smb2commands.NegotiateResponse)
+	if !ok {
+		t.Close()
+		return nil, fmt.Errorf("unexpected SMB2 negotiate response command: %T", respMsg.Command)
+	}
+
+	engine := smb2.NewFromTransport(t, ip, port)
+	if opts.Workstation != "" {
+		engine.Workstation = opts.Workstation
+	}
+
+	if resp.DialectRevision == dialects.SMB2_DIALECT_WILDCARD {
+		// Second leg: a native SMB2 NEGOTIATE pins the concrete dialect (SMB 2.0.2).
+		if err := engine.Negotiate(); err != nil {
+			t.Close()
+			return nil, fmt.Errorf("SMB2 second-stage negotiate failed: %w", err)
+		}
+	} else {
+		engine.ApplyNegotiateResponse(resp)
+	}
+	return &Client{backend: newSMB2Backend(engine), host: host, port: port, opts: opts}, nil
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/network/smb/client/negotiate_test.go
+++ b/network/smb/client/negotiate_test.go
@@ -23,9 +23,9 @@ func TestEngineSupportsSMB2(t *testing.T) {
 
 func TestWantedFamilies(t *testing.T) {
 	cases := []struct {
-		name             string
-		prefs            []smb.SMBProtocolVersion
-		wantSMB1, want2  bool
+		name            string
+		prefs           []smb.SMBProtocolVersion
+		wantSMB1, want2 bool
 	}{
 		{"empty", nil, false, false},
 		{"smb1 only", []smb.SMBProtocolVersion{smb.SMB_VERSION_1_0}, true, false},

--- a/network/smb/client/negotiate_test.go
+++ b/network/smb/client/negotiate_test.go
@@ -1,0 +1,45 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb"
+)
+
+func TestEngineSupportsSMB2(t *testing.T) {
+	supported := []smb.SMBProtocolVersion{smb.SMB_VERSION_2_0, smb.SMB_VERSION_2_0_2, smb.SMB_VERSION_2_1}
+	for _, v := range supported {
+		if !engineSupportsSMB2(v) {
+			t.Errorf("engineSupportsSMB2(%s) = false, want true", v)
+		}
+	}
+	// SMB1 is not an SMB2 dialect; 3.x has no engine yet.
+	for _, v := range []smb.SMBProtocolVersion{smb.SMB_VERSION_1_0, smb.SMB_VERSION_3_0, smb.SMB_VERSION_3_0_2, smb.SMB_VERSION_3_1_1} {
+		if engineSupportsSMB2(v) {
+			t.Errorf("engineSupportsSMB2(%s) = true, want false", v)
+		}
+	}
+}
+
+func TestWantedFamilies(t *testing.T) {
+	cases := []struct {
+		name             string
+		prefs            []smb.SMBProtocolVersion
+		wantSMB1, want2  bool
+	}{
+		{"empty", nil, false, false},
+		{"smb1 only", []smb.SMBProtocolVersion{smb.SMB_VERSION_1_0}, true, false},
+		{"smb2 only", []smb.SMBProtocolVersion{smb.SMB_VERSION_2_0_2}, false, true},
+		{"both", []smb.SMBProtocolVersion{smb.SMB_VERSION_1_0, smb.SMB_VERSION_2_0_2}, true, true},
+		{"3.x unsupported -> neither", []smb.SMBProtocolVersion{smb.SMB_VERSION_3_1_1}, false, false},
+		{"default preference -> both", defaultPreference(), true, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			s1, s2 := wantedFamilies(c.prefs)
+			if s1 != c.wantSMB1 || s2 != c.want2 {
+				t.Errorf("wantedFamilies(%v) = (%v,%v), want (%v,%v)", c.prefs, s1, s2, c.wantSMB1, c.want2)
+			}
+		})
+	}
+}

--- a/network/smb/client/types.go
+++ b/network/smb/client/types.go
@@ -80,6 +80,5 @@ type FileInfo struct {
 
 // IsDir reports whether the entry has the FILE_ATTRIBUTE_DIRECTORY flag set.
 func (fi FileInfo) IsDir() bool {
-	const fileAttributeDirectory = 0x00000010
 	return fi.FileAttributes&fileAttributeDirectory != 0
 }

--- a/network/smb/client/types.go
+++ b/network/smb/client/types.go
@@ -1,0 +1,85 @@
+package client
+
+import (
+	"time"
+
+	"github.com/TheManticoreProject/Manticore/network/smb"
+)
+
+// NegotiationPolicy controls how the client applies its preference list when
+// selecting a dialect during Dial.
+type NegotiationPolicy int
+
+const (
+	// PolicyStrictOrder tries the preferred versions in order and selects the
+	// first one the server accepts. It honors the caller's order exactly — it
+	// can select a lower dialect (e.g. SMB1) even when the server also supports
+	// a higher one. Out-of-order lists may cost a reconnect per attempt.
+	PolicyStrictOrder NegotiationPolicy = iota
+	// PolicyHighestInSet performs a single multi-protocol negotiate over the
+	// whole preference set and uses the server's highest-supported dialect
+	// within it. One round-trip; the list acts as an allow-list rather than a
+	// strict order.
+	PolicyHighestInSet
+)
+
+// Options configures a Dial.
+type Options struct {
+	// Preferred is the ordered list of protocol versions, highest priority
+	// first. When empty, the client offers all supported versions, best first.
+	Preferred []smb.SMBProtocolVersion
+	// Policy selects how Preferred is applied. The zero value is
+	// PolicyStrictOrder.
+	Policy NegotiationPolicy
+	// Workstation is the NetBIOS workstation name sent during authentication.
+	// When empty, a default is used.
+	Workstation string
+}
+
+// FileHandle is an opaque, version-agnostic handle to an open file. The backend
+// that produced it knows how to interpret the underlying value (an SMB1 FID or
+// an SMB2 file id); callers must pass it back to that same backend.
+type FileHandle struct {
+	dialect smb.SMBProtocolVersion
+	raw     any
+}
+
+// Dialect reports which protocol version's backend owns this handle.
+func (h FileHandle) Dialect() smb.SMBProtocolVersion { return h.dialect }
+
+// newFileHandle boxes a backend-specific handle value. Adapters use this; the
+// raw value stays unexported so callers cannot tamper with it.
+func newFileHandle(dialect smb.SMBProtocolVersion, raw any) FileHandle {
+	return FileHandle{dialect: dialect, raw: raw}
+}
+
+// OpenOptions carries the file-open parameters shared by every dialect. The
+// access, share, disposition, and options fields use the MS-DTYP/MS-SMB2 bit
+// definitions, which are identical across SMB1 and SMB2.
+type OpenOptions struct {
+	DesiredAccess     uint32
+	ShareAccess       uint32
+	CreateDisposition uint32
+	CreateOptions     uint32
+	FileAttributes    uint32
+}
+
+// FileInfo is a version-agnostic directory entry, normalized from the SMB1
+// TRANS2 FIND information levels and the SMB2 QUERY_DIRECTORY information
+// classes. It is populated by ListDirectory (Phase 6).
+type FileInfo struct {
+	Name           string
+	FileAttributes uint32
+	Size           uint64
+	AllocationSize uint64
+	CreationTime   time.Time
+	LastAccessTime time.Time
+	LastWriteTime  time.Time
+	ChangeTime     time.Time
+}
+
+// IsDir reports whether the entry has the FILE_ATTRIBUTE_DIRECTORY flag set.
+func (fi FileInfo) IsDir() bool {
+	const fileAttributeDirectory = 0x00000010
+	return fi.FileAttributes&fileAttributeDirectory != 0
+}

--- a/network/smb/smb_v10/client/client_functions.go
+++ b/network/smb/smb_v10/client/client_functions.go
@@ -45,6 +45,24 @@ func NewClientUsingTCPTransport(host net.IP, port int) *Client {
 	}
 }
 
+// NewFromTransport builds an SMB v1.0 client over an already-connected transport,
+// without connecting or negotiating. It is the handoff entry point used by the
+// generic SMB client (network/smb/client), which performs a multi-protocol
+// negotiate and then hands the live transport to this engine together with the
+// SMB_COM_NEGOTIATE response it received, applied via ApplyNegotiateResponse.
+func NewFromTransport(t transport.Transport, host net.IP, port int) *Client {
+	return &Client{
+		Transport: t,
+		Connection: &Connection{
+			Server: &Server{
+				Host: host,
+				Port: port,
+			},
+		},
+		Session: nil,
+	}
+}
+
 // Connect establishes a connection to an SMB server
 //
 // Returns:

--- a/network/smb/smb_v10/client/handoff_test.go
+++ b/network/smb/smb_v10/client/handoff_test.go
@@ -1,0 +1,23 @@
+package client
+
+import (
+	"net"
+	"testing"
+)
+
+// TestNewFromTransport_NoNegotiate verifies the handoff constructor builds an
+// SMB1 client with initialized connection state over a (here nil) transport,
+// without connecting or negotiating. ApplyNegotiateResponse, the other half of
+// the handoff, is exercised through the Negotiate path in the client suite.
+func TestNewFromTransport_NoNegotiate(t *testing.T) {
+	c := NewFromTransport(nil, net.ParseIP("10.0.0.1"), 445)
+	if c.Connection == nil || c.Connection.Server == nil {
+		t.Fatal("NewFromTransport did not initialize connection state")
+	}
+	if c.Session != nil {
+		t.Error("NewFromTransport should not create a session")
+	}
+	if c.GetHost().String() != "10.0.0.1" || c.GetPort() != 445 {
+		t.Errorf("host/port = %s/%d, want 10.0.0.1/445", c.GetHost(), c.GetPort())
+	}
+}

--- a/network/smb/smb_v10/client/negotiate.go
+++ b/network/smb/smb_v10/client/negotiate.go
@@ -76,7 +76,21 @@ func (c *Client) Negotiate() error {
 
 	negotiateResponse := responseMsg.Command.(*commands.NegotiateResponse)
 
-	selectedDialect, err := negotiateResponse.GetSelectedDialect(negotiateCmd.Dialects)
+	return c.ApplyNegotiateResponse(negotiateResponse, negotiateCmd.Dialects)
+}
+
+// ApplyNegotiateResponse records the negotiated connection state — selected
+// dialect, server capabilities, session key, timestamps, buffer sizes, identity,
+// security mode, and derived signing policy — from an SMB_COM_NEGOTIATE response.
+// offered is the dialect list that was sent, needed to resolve the server's
+// selected dialect from its index.
+//
+// It is shared by Negotiate, which exchanges the response on the transport, and
+// by the generic SMB client (network/smb/client), which hands over the response
+// it received during a multi-protocol negotiate (SMB1 cannot renegotiate on an
+// already-established connection).
+func (c *Client) ApplyNegotiateResponse(negotiateResponse *commands.NegotiateResponse, offered dialects.Dialects) error {
+	selectedDialect, err := negotiateResponse.GetSelectedDialect(offered)
 	if err != nil {
 		return fmt.Errorf("failed to get selected dialect: %v", err)
 	}

--- a/network/smb/smb_v20/client/client_functions.go
+++ b/network/smb/smb_v20/client/client_functions.go
@@ -29,6 +29,16 @@ func NewClientUsingNBTTransport(host net.IP, port int) *Client {
 	return newClient(transport.NewTransport("nbt"), host, port)
 }
 
+// NewFromTransport builds an SMB 2.0 client over an already-connected transport,
+// without connecting or negotiating. It is the handoff entry point used by the
+// generic SMB client (network/smb/client), which performs a multi-protocol
+// negotiate and then hands the live transport to this engine. The caller drives
+// negotiation either via Negotiate (a native SMB2 NEGOTIATE over t) or by
+// applying an already-exchanged response with ApplyNegotiateResponse.
+func NewFromTransport(t transport.Transport, host net.IP, port int) *Client {
+	return newClient(t, host, port)
+}
+
 // Connect establishes the transport connection and performs SMB2 negotiation.
 func (c *Client) Connect(ipaddr net.IP, port int) error {
 	c.Connection.Server.Host = ipaddr

--- a/network/smb/smb_v20/client/handoff_test.go
+++ b/network/smb/smb_v20/client/handoff_test.go
@@ -1,0 +1,69 @@
+package client
+
+import (
+	"net"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/dialects"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/message/commands"
+)
+
+// TestNewFromTransport_NoNegotiate verifies the handoff constructor builds a
+// client with initialized connection state and does not advance the MessageId
+// (no NEGOTIATE has occurred yet).
+func TestNewFromTransport_NoNegotiate(t *testing.T) {
+	c := NewFromTransport(nil, net.ParseIP("10.0.0.1"), 445)
+	if c.Connection == nil || c.Connection.Server == nil {
+		t.Fatal("NewFromTransport did not initialize connection state")
+	}
+	if c.Connection.MessageId != 0 {
+		t.Errorf("MessageId = %d, want 0 before negotiate", c.Connection.MessageId)
+	}
+	if c.GetPort() != 445 {
+		t.Errorf("port = %d, want 445", c.GetPort())
+	}
+}
+
+// TestApplyNegotiateResponse verifies that a handed-over NEGOTIATE response
+// populates the connection/server state and advances the MessageId to 1, since
+// NEGOTIATE occupies MessageId 0.
+func TestApplyNegotiateResponse(t *testing.T) {
+	c := NewFromTransport(nil, net.ParseIP("10.0.0.1"), 445)
+
+	resp := commands.NewNegotiateResponse()
+	resp.DialectRevision = dialects.SMB2_DIALECT_2_0_2
+	resp.MaxReadSize = 0x10000
+	resp.MaxWriteSize = 0x20000
+	resp.SecurityBuffer = []byte{0x01, 0x02, 0x03}
+
+	c.ApplyNegotiateResponse(resp)
+
+	if c.Connection.Dialect != dialects.SMB2_DIALECT_2_0_2 {
+		t.Errorf("Dialect = 0x%04x, want 0x%04x", uint16(c.Connection.Dialect), uint16(dialects.SMB2_DIALECT_2_0_2))
+	}
+	if c.Connection.Server.MaxReadSize != 0x10000 || c.Connection.Server.MaxWriteSize != 0x20000 {
+		t.Errorf("max sizes not copied: read=%d write=%d", c.Connection.Server.MaxReadSize, c.Connection.Server.MaxWriteSize)
+	}
+	if len(c.Connection.Server.SecurityBuffer) != 3 {
+		t.Errorf("security buffer not copied: %v", c.Connection.Server.SecurityBuffer)
+	}
+	if c.Connection.MessageId != 1 {
+		t.Errorf("MessageId = %d, want 1 after applying negotiate", c.Connection.MessageId)
+	}
+}
+
+// TestApplyNegotiateResponse_PreservesAdvancedMessageId verifies the MessageId is
+// not reset when it has already advanced (the Negotiate path, where MessageId 0
+// has been consumed and the counter is already at 1).
+func TestApplyNegotiateResponse_PreservesAdvancedMessageId(t *testing.T) {
+	c := NewFromTransport(nil, net.ParseIP("10.0.0.1"), 445)
+	c.Connection.MessageId = 1 // as if NEGOTIATE was already sent on this client
+
+	resp := commands.NewNegotiateResponse()
+	resp.DialectRevision = dialects.SMB2_DIALECT_2_0_2
+	c.ApplyNegotiateResponse(resp)
+
+	if c.Connection.MessageId != 1 {
+		t.Errorf("MessageId = %d, want it left at 1", c.Connection.MessageId)
+	}
+}

--- a/network/smb/smb_v20/client/negotiate.go
+++ b/network/smb/smb_v20/client/negotiate.go
@@ -37,6 +37,22 @@ func (c *Client) Negotiate() error {
 		return fmt.Errorf("unexpected negotiate response command: %T", response.Command)
 	}
 
+	c.ApplyNegotiateResponse(negotiateResponse)
+
+	return nil
+}
+
+// ApplyNegotiateResponse records the negotiated connection state — selected
+// dialect, server security mode, capabilities, maximum transfer sizes, GUID,
+// timestamps, and GSS security buffer — from an SMB2 NEGOTIATE response.
+//
+// It is shared by Negotiate, which exchanges the response on the transport, and
+// by the generic SMB client (network/smb/client), which may hand over a response
+// already exchanged as part of a multi-protocol negotiate. Because NEGOTIATE
+// occupies MessageId 0, the next request on the connection uses MessageId 1; this
+// is set here for the handoff path (in the Negotiate path the MessageId has
+// already advanced past 0).
+func (c *Client) ApplyNegotiateResponse(negotiateResponse *commands.NegotiateResponse) {
 	server := c.Connection.Server
 	c.Connection.Dialect = negotiateResponse.DialectRevision
 	server.SecurityMode = negotiateResponse.SecurityMode
@@ -49,5 +65,7 @@ func (c *Client) Negotiate() error {
 	server.ServerStartTime = negotiateResponse.ServerStartTime
 	server.SecurityBuffer = negotiateResponse.SecurityBuffer
 
-	return nil
+	if c.Connection.MessageId == 0 {
+		c.Connection.MessageId = 1
+	}
 }

--- a/network/smb/versions.go
+++ b/network/smb/versions.go
@@ -5,10 +5,18 @@ import "fmt"
 type SMBProtocolVersion uint16
 
 const (
-	SMB_VERSION_1_0   SMBProtocolVersion = 0x0100
-	SMB_VERSION_2_0   SMBProtocolVersion = 0x0200
+	SMB_VERSION_1_0 SMBProtocolVersion = 0x0100
+	// SMB_VERSION_2_0 (0x0200) is the abstract "SMB 2.0 family" marker. It is NOT
+	// a real wire dialect revision; the first concrete SMB2 dialect is SMB 2.0.2.
+	// It is retained for backward compatibility — prefer SMB_VERSION_2_0_2.
+	SMB_VERSION_2_0 SMBProtocolVersion = 0x0200
+	// SMB_VERSION_2_0_2 (0x0202) is the SMB 2.0.2 dialect revision, the lowest
+	// real SMB2 DialectRevision carried on the wire.
+	SMB_VERSION_2_0_2 SMBProtocolVersion = 0x0202
 	SMB_VERSION_2_1   SMBProtocolVersion = 0x0210
 	SMB_VERSION_3_0   SMBProtocolVersion = 0x0300
+	// SMB_VERSION_3_0_2 (0x0302) is the SMB 3.0.2 dialect revision.
+	SMB_VERSION_3_0_2 SMBProtocolVersion = 0x0302
 	SMB_VERSION_3_1_1 SMBProtocolVersion = 0x0311
 )
 
@@ -17,9 +25,19 @@ func (v SMBProtocolVersion) String() string {
 }
 
 func (v SMBProtocolVersion) IsSupported() bool {
-	return v == SMB_VERSION_1_0 || v == SMB_VERSION_2_0 || v == SMB_VERSION_2_1 || v == SMB_VERSION_3_0 || v == SMB_VERSION_3_1_1
+	switch v {
+	case SMB_VERSION_1_0, SMB_VERSION_2_0, SMB_VERSION_2_0_2, SMB_VERSION_2_1,
+		SMB_VERSION_3_0, SMB_VERSION_3_0_2, SMB_VERSION_3_1_1:
+		return true
+	}
+	return false
 }
 
 func (v SMBProtocolVersion) IsSMB2() bool {
-	return v == SMB_VERSION_2_0 || v == SMB_VERSION_2_1 || v == SMB_VERSION_3_0 || v == SMB_VERSION_3_1_1
+	switch v {
+	case SMB_VERSION_2_0, SMB_VERSION_2_0_2, SMB_VERSION_2_1,
+		SMB_VERSION_3_0, SMB_VERSION_3_0_2, SMB_VERSION_3_1_1:
+		return true
+	}
+	return false
 }

--- a/network/smb/versions_test.go
+++ b/network/smb/versions_test.go
@@ -10,8 +10,10 @@ func TestSMBProtocolVersion_String(t *testing.T) {
 	}{
 		{name: "SMB 1.0", v: SMB_VERSION_1_0, want: "SMB v1.0.0"},
 		{name: "SMB 2.0", v: SMB_VERSION_2_0, want: "SMB v2.0.0"},
+		{name: "SMB 2.0.2", v: SMB_VERSION_2_0_2, want: "SMB v2.0.2"},
 		{name: "SMB 2.1", v: SMB_VERSION_2_1, want: "SMB v2.1.0"},
 		{name: "SMB 3.0", v: SMB_VERSION_3_0, want: "SMB v3.0.0"},
+		{name: "SMB 3.0.2", v: SMB_VERSION_3_0_2, want: "SMB v3.0.2"},
 		{name: "SMB 3.1.1", v: SMB_VERSION_3_1_1, want: "SMB v3.1.1"},
 	}
 
@@ -21,5 +23,31 @@ func TestSMBProtocolVersion_String(t *testing.T) {
 				t.Errorf("SMBProtocolVersion.String() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestSMBProtocolVersion_Predicates(t *testing.T) {
+	all := []SMBProtocolVersion{
+		SMB_VERSION_1_0, SMB_VERSION_2_0, SMB_VERSION_2_0_2, SMB_VERSION_2_1,
+		SMB_VERSION_3_0, SMB_VERSION_3_0_2, SMB_VERSION_3_1_1,
+	}
+	for _, v := range all {
+		if !v.IsSupported() {
+			t.Errorf("%s: IsSupported() = false, want true", v)
+		}
+	}
+
+	if SMB_VERSION_1_0.IsSMB2() {
+		t.Error("SMB 1.0 must not be reported as SMB2")
+	}
+	for _, v := range []SMBProtocolVersion{SMB_VERSION_2_0_2, SMB_VERSION_2_1, SMB_VERSION_3_0, SMB_VERSION_3_0_2, SMB_VERSION_3_1_1} {
+		if !v.IsSMB2() {
+			t.Errorf("%s: IsSMB2() = false, want true", v)
+		}
+	}
+
+	// A value that is not a known dialect must be rejected.
+	if (SMBProtocolVersion(0x0201)).IsSupported() {
+		t.Error("unknown dialect 0x0201 must not be reported as supported")
 	}
 }


### PR DESCRIPTION
### Linked Issue
Tracks #528 (umbrella). Individual phases reference this PR.

### Overview
Umbrella PR for the generic SMB client under `network/smb/client`: one flat, version-agnostic `Client` that negotiates the dialect once (client-side preference list + policy) and routes every call into the appropriate engine (SMB1/SMB2/SMB3) behind a common `Backend` interface.

### Status
- [x] **Phase 0** — scaffolding (`doc.go`), umbrella issue #528, feature branch.
- [x] Phase 1 — `versions.go` dialect reconciliation + `Backend` interface + value types
- [x] Phase 2 — engine handoff constructors (`NewFromTransport` / `ApplyNegotiateResponse`)
- [x] Phase 3 — SMB2 adapter + facade
- [x] Phase 4 — SMB1 adapter
- [x] Phase 5 — multi-protocol negotiate + preference/policy (follow-up: #530)
- [x] Phase 6 — directory-listing unification
- [ ] Phase 7 — SMB3 adapter (future)

### Base branch
Targets `main`. The SMB 2.0 engine this wraps landed in `main` via #520.

### How Verified
- `go build ./...`, `go vet`, and package tests clean throughout.
- Live-validated through `client.Client` against Windows Server 2016 (.31, both dialects) and Windows XP (.27, SMB1-only): SMB2 and SMB1 full file-op sessions (Phases 3/4), and a 7/7 preference/policy scenario matrix (Phase 5) — StrictOrder selecting SMB2 by default, forcing SMB1 when listed first, selecting SMB2 when listed first; HighestInSet letting the server pick the highest; and SMB1 auto-discovery against the SMB1-only XP box.

### Notes
- Known limitation (Phase 5): under `PolicyStrictOrder`, probing SMB2 first against a server that silently drops it can block — the transport has no read deadline. Tracked as #530.
- Not yet included: typed MS-FSCC payloads / directory listing (#525, Phase 6); the SMB3 adapter (Phase 7).
- Design and full phase breakdown: `.private/smb_common/docs/plan-generic-smb-client.md`.