### PR TITLE
Drop third-party tool references from NDR and Kerberos comments

### DIFF
--- a/network/dcerpc/ndr/types.go
+++ b/network/dcerpc/ndr/types.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-// Windows-style NDR type aliases, mirroring the names used in [MS-DTYP] and impacket
+// Windows-style NDR type aliases, mirroring the names used in [MS-DTYP]
 // so declarations read like the IDL. References:
 //   - [MS-DTYP] 2.2 Common Data Types:
 //     https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/cca27429-5689-4a16-b2b4-9325d93e4ba2

--- a/network/kerberos/v5/crypto/crypto_test.go
+++ b/network/kerberos/v5/crypto/crypto_test.go
@@ -260,9 +260,8 @@ func TestUnsupportedEType(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 // TestRC4HMACUsageMsgTypeEncoding verifies that usageMsgType produces the
-// fixed 4-byte little-endian uint32 encoding required by MS-KILE / RFC 4757
-// (matching impacket's pack('<I', msusage) and gokrb5's
-// binary.LittleEndian.PutUint32), for both small and >=128 values.
+// fixed 4-byte little-endian uint32 encoding required by MS-KILE / RFC 4757,
+// for both small and >=128 values.
 //
 // The regression target is values >= 128: the previous implementation used
 // binary.PutUvarint, which for 128 emits 0x80 0x01 in the first two bytes

--- a/network/kerberos/v5/crypto/rc4hmac.go
+++ b/network/kerberos/v5/crypto/rc4hmac.go
@@ -32,8 +32,7 @@ func mapRC4HMACUsage(usage int) uint32 {
 }
 
 // usageMsgType encodes a mapped usage as a 4-byte little-endian uint32,
-// matching MS-KILE Section 3.1.5.7 and RFC 4757 Section 4 (impacket's
-// pack('<I', msusage), jcmturner/gokrb5's binary.LittleEndian.PutUint32).
+// matching MS-KILE Section 3.1.5.7 and RFC 4757 Section 4.
 func usageMsgType(usage int) []byte {
 	mapped := mapRC4HMACUsage(usage)
 	tb := make([]byte, 4)


### PR DESCRIPTION
### Summary
Remove mentions of `impacket` and `jcmturner/gokrb5` from documentation comments in the NDR type aliases (`network/dcerpc/ndr/types.go`) and the Kerberos RC4-HMAC usage encoding (`network/kerberos/v5/crypto/rc4hmac.go`, `crypto_test.go`). The comments now cite only the authoritative specifications (MS-DTYP, MS-KILE, RFC 4757).

### Scope
- Comment-only edits; no functional or behavioral change.
- `go build` of both packages passes.

### Files changed
- `network/dcerpc/ndr/types.go`
- `network/kerberos/v5/crypto/rc4hmac.go`
- `network/kerberos/v5/crypto/crypto_test.go`