### PR TITLE
Add windows/fileflags package for Windows file open/attribute constants

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/logger"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/client"
 	"github.com/TheManticoreProject/Manticore/windows/credentials"
+	"github.com/TheManticoreProject/Manticore/windows/fileflags"
 	"github.com/TheManticoreProject/goopts/parser"
 )
 
@@ -134,10 +135,10 @@ func main() {
 	if writeContent != "" {
 		wfid, err := c.OpenFile(
 			filePath,
-			client.GENERIC_READ|client.GENERIC_WRITE,
-			client.FILE_SHARE_READ|client.FILE_SHARE_WRITE,
-			client.FILE_OVERWRITE_IF,
-			client.FILE_NON_DIRECTORY_FILE,
+			fileflags.GENERIC_READ|fileflags.GENERIC_WRITE,
+			fileflags.FILE_SHARE_READ|fileflags.FILE_SHARE_WRITE,
+			fileflags.FILE_OVERWRITE_IF,
+			fileflags.FILE_NON_DIRECTORY_FILE,
 		)
 		if err != nil {
 			fmt.Printf("[error] Error opening file %q for write: %s\n", filePath, err)
@@ -158,10 +159,10 @@ func main() {
 	// Open the file at the root of the share for reading.
 	fid, err := c.OpenFile(
 		filePath,
-		client.GENERIC_READ,
-		client.FILE_SHARE_READ|client.FILE_SHARE_WRITE,
-		client.FILE_OPEN,
-		client.FILE_NON_DIRECTORY_FILE,
+		fileflags.GENERIC_READ,
+		fileflags.FILE_SHARE_READ|fileflags.FILE_SHARE_WRITE,
+		fileflags.FILE_OPEN,
+		fileflags.FILE_NON_DIRECTORY_FILE,
 	)
 	if err != nil {
 		fmt.Printf("[error] Error opening file %q: %s\n", filePath, err)

--- a/network/dcerpc/interfaces/c681d488-d850-11d0-8c52-00c04fd90f7e/1.0/functions/integration_test.go
+++ b/network/dcerpc/interfaces/c681d488-d850-11d0-8c52-00c04fd90f7e/1.0/functions/integration_test.go
@@ -31,6 +31,7 @@ import (
 	dcerpcsmb "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/transport/smb"
 	smbclient "github.com/TheManticoreProject/Manticore/network/smb/smb_v10/client"
 	"github.com/TheManticoreProject/Manticore/windows/credentials"
+	"github.com/TheManticoreProject/Manticore/windows/fileflags"
 )
 
 func ws(s string) ndr.WSTR { return ndr.WSTR(s) }
@@ -85,8 +86,8 @@ func TestIntegration_Efsr(t *testing.T) {
 			return
 		}
 		defer smb.TreeDisconnect()
-		fid, err := smb.OpenFile(sharePath, smbclient.GENERIC_READ|smbclient.GENERIC_WRITE,
-			smbclient.FILE_SHARE_READ|smbclient.FILE_SHARE_WRITE, smbclient.FILE_OVERWRITE_IF, smbclient.FILE_NON_DIRECTORY_FILE)
+		fid, err := smb.OpenFile(sharePath, fileflags.GENERIC_READ|fileflags.GENERIC_WRITE,
+			fileflags.FILE_SHARE_READ|fileflags.FILE_SHARE_WRITE, fileflags.FILE_OVERWRITE_IF, fileflags.FILE_NON_DIRECTORY_FILE)
 		if err != nil {
 			t.Logf("[info] OpenFile(%s) failed: %v", sharePath, err)
 			return

--- a/network/dcerpc/v5/transport/smb/smb_namedpipe.go
+++ b/network/dcerpc/v5/transport/smb/smb_namedpipe.go
@@ -15,6 +15,7 @@ import (
 
 	dcerpctransport "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/transport"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/client"
+	"github.com/TheManticoreProject/Manticore/windows/fileflags"
 )
 
 // Default fragment sizes proposed at Bind time. 4280 (0x10B8) is the classic Windows
@@ -87,9 +88,9 @@ func (p *SMBNamedPipe) Connect() error {
 
 	fid, err := p.conn.OpenFile(
 		p.pipeName,
-		client.GENERIC_READ|client.GENERIC_WRITE,
-		client.FILE_SHARE_READ|client.FILE_SHARE_WRITE,
-		client.FILE_OPEN,
+		fileflags.GENERIC_READ|fileflags.GENERIC_WRITE,
+		fileflags.FILE_SHARE_READ|fileflags.FILE_SHARE_WRITE,
+		fileflags.FILE_OPEN,
 		0,
 	)
 	if err != nil {

--- a/network/smb/smb_v10/client/file.go
+++ b/network/smb/smb_v10/client/file.go
@@ -36,35 +36,8 @@ const (
 // FID is an opaque file handle returned by the server for an open file or directory.
 type FID uint16
 
-// NT access mask values (subset) used by OpenFile.
-const (
-	GENERIC_READ  uint32 = 0x80000000
-	GENERIC_WRITE uint32 = 0x40000000
-)
-
-// FILE_SHARE_* values for the shareAccess argument of OpenFile.
-const (
-	FILE_SHARE_NONE   uint32 = 0x00000000
-	FILE_SHARE_READ   uint32 = 0x00000001
-	FILE_SHARE_WRITE  uint32 = 0x00000002
-	FILE_SHARE_DELETE uint32 = 0x00000004
-)
-
-// CreateDisposition values for the createDisp argument of OpenFile.
-const (
-	FILE_SUPERSEDE    uint32 = 0x00000000
-	FILE_OPEN         uint32 = 0x00000001
-	FILE_CREATE       uint32 = 0x00000002
-	FILE_OPEN_IF      uint32 = 0x00000003
-	FILE_OVERWRITE    uint32 = 0x00000004
-	FILE_OVERWRITE_IF uint32 = 0x00000005
-)
-
-// CreateOptions values for the createOptions argument of OpenFile.
-const (
-	FILE_DIRECTORY_FILE     uint32 = 0x00000001
-	FILE_NON_DIRECTORY_FILE uint32 = 0x00000040
-)
+// The NT access mask, share access, create disposition, and create option values
+// that callers pass to OpenFile live in windows/fileflags.
 
 // FileIODebug, when true, dumps the raw bytes of file-I/O requests and responses
 // to stdout. It is a coarse diagnostic aid until a structured logger is wired in.

--- a/windows/fileflags/fileflags.go
+++ b/windows/fileflags/fileflags.go
@@ -1,0 +1,118 @@
+// Package fileflags holds Windows file-related bit-flag values: the access mask,
+// share access, create disposition, create options, and file attributes.
+//
+// Although they are best known as the parameters of a Win32 CreateFile /
+// NtCreateFile call and the SMB1 NT_CREATE_ANDX / SMB2 CREATE requests, several
+// are used well beyond creating a file: the access mask appears in security
+// descriptors and the SMB2 TREE_CONNECT MaximalAccess response, and the file
+// attributes appear in directory enumeration and FileBasicInformation queries.
+// They are shared by the SMB engines, the generic SMB client, and the DCE/RPC
+// named-pipe transport.
+//
+// Combine them with bitwise OR, e.g.:
+//
+//	DesiredAccess:     fileflags.GENERIC_READ | fileflags.FILE_READ_ATTRIBUTES
+//	ShareAccess:       fileflags.FILE_SHARE_READ | fileflags.FILE_SHARE_WRITE
+//	CreateDisposition: fileflags.FILE_OPEN
+//	CreateOptions:     fileflags.FILE_NON_DIRECTORY_FILE
+package fileflags
+
+// Generic and standard access rights of the access mask.
+//
+// [MS-DTYP] 2.4.3 ACCESS_MASK:
+// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/7a53f60e-e730-4dfe-bbe9-b21b62eb790b
+const (
+	// Generic rights (bits 28-31), mapped by the resource manager to object-
+	// specific rights.
+	GENERIC_ALL     uint32 = 0x10000000
+	GENERIC_EXECUTE uint32 = 0x20000000
+	GENERIC_WRITE   uint32 = 0x40000000
+	GENERIC_READ    uint32 = 0x80000000
+
+	// Standard rights (bits 16-20), common to all object types.
+	DELETE       uint32 = 0x00010000
+	READ_CONTROL uint32 = 0x00020000
+	WRITE_DAC    uint32 = 0x00040000
+	WRITE_OWNER  uint32 = 0x00080000
+	SYNCHRONIZE  uint32 = 0x00100000
+)
+
+// File, pipe, and printer specific access rights, and the directory-context
+// aliases that share the same bit values (e.g. FILE_LIST_DIRECTORY ==
+// FILE_READ_DATA). Use these in the DesiredAccess field.
+//
+// [MS-SMB2] 2.2.13.1.1 File_Pipe_Printer_Access_Mask:
+// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/77b36d0f-6016-458a-a7a0-0f4a72ae1534
+//
+// [MS-SMB2] 2.2.13.1.2 Directory_Access_Mask:
+// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/0a5934b1-80f1-4da0-b1bf-5e021c309b71
+const (
+	FILE_READ_DATA        uint32 = 0x00000001
+	FILE_LIST_DIRECTORY   uint32 = 0x00000001
+	FILE_WRITE_DATA       uint32 = 0x00000002
+	FILE_ADD_FILE         uint32 = 0x00000002
+	FILE_APPEND_DATA      uint32 = 0x00000004
+	FILE_ADD_SUBDIRECTORY uint32 = 0x00000004
+	FILE_READ_EA          uint32 = 0x00000008
+	FILE_WRITE_EA         uint32 = 0x00000010
+	FILE_EXECUTE          uint32 = 0x00000020
+	FILE_TRAVERSE         uint32 = 0x00000020
+	FILE_DELETE_CHILD     uint32 = 0x00000040
+	FILE_READ_ATTRIBUTES  uint32 = 0x00000080
+	FILE_WRITE_ATTRIBUTES uint32 = 0x00000100
+)
+
+// ShareAccess — the sharing mode granted to other openers.
+//
+// [MS-SMB2] 2.2.13 SMB2 CREATE Request:
+// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/e8fb45c1-a03d-44ca-b7ae-47385cfd7997
+const (
+	FILE_SHARE_NONE   uint32 = 0x00000000
+	FILE_SHARE_READ   uint32 = 0x00000001
+	FILE_SHARE_WRITE  uint32 = 0x00000002
+	FILE_SHARE_DELETE uint32 = 0x00000004
+)
+
+// CreateDisposition — the action taken depending on whether the file exists.
+//
+// [MS-SMB2] 2.2.13 SMB2 CREATE Request:
+// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/e8fb45c1-a03d-44ca-b7ae-47385cfd7997
+const (
+	FILE_SUPERSEDE    uint32 = 0x00000000
+	FILE_OPEN         uint32 = 0x00000001
+	FILE_CREATE       uint32 = 0x00000002
+	FILE_OPEN_IF      uint32 = 0x00000003
+	FILE_OVERWRITE    uint32 = 0x00000004
+	FILE_OVERWRITE_IF uint32 = 0x00000005
+)
+
+// CreateOptions — options applied when opening.
+//
+// [MS-SMB2] 2.2.13 SMB2 CREATE Request:
+// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/e8fb45c1-a03d-44ca-b7ae-47385cfd7997
+const (
+	FILE_DIRECTORY_FILE          uint32 = 0x00000001
+	FILE_WRITE_THROUGH           uint32 = 0x00000002
+	FILE_SEQUENTIAL_ONLY         uint32 = 0x00000004
+	FILE_NO_INTERMEDIATE_BUFFER  uint32 = 0x00000008
+	FILE_SYNCHRONOUS_IO_ALERT    uint32 = 0x00000010
+	FILE_SYNCHRONOUS_IO_NONALERT uint32 = 0x00000020
+	FILE_NON_DIRECTORY_FILE      uint32 = 0x00000040
+	FILE_RANDOM_ACCESS           uint32 = 0x00000800
+	FILE_DELETE_ON_CLOSE         uint32 = 0x00001000
+	FILE_OPEN_BY_FILE_ID         uint32 = 0x00002000
+	FILE_OPEN_FOR_BACKUP_INTENT  uint32 = 0x00004000
+)
+
+// FileAttributes — file attribute flags.
+//
+// [MS-FSCC] 2.6 File Attributes:
+// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/ca28ec38-f155-4768-81d6-4bfeb8586fc9
+const (
+	FILE_ATTRIBUTE_READONLY  uint32 = 0x00000001
+	FILE_ATTRIBUTE_HIDDEN    uint32 = 0x00000002
+	FILE_ATTRIBUTE_SYSTEM    uint32 = 0x00000004
+	FILE_ATTRIBUTE_DIRECTORY uint32 = 0x00000010
+	FILE_ATTRIBUTE_ARCHIVE   uint32 = 0x00000020
+	FILE_ATTRIBUTE_NORMAL    uint32 = 0x00000080
+)


### PR DESCRIPTION
### Summary
Introduce `windows/fileflags` as the single authoritative home for the Windows file-related bit-flag values — the access mask, share access, create disposition, create options, and file attributes — and migrate every consumer to it.

### Why a package under `windows/`, and why this name
These are Windows OS constants (the parameters of `CreateFile`/`NtCreateFile` and the SMB1 `NT_CREATE_ANDX` / SMB2 `CREATE` requests), so they belong under `windows/` alongside `ms_dtyp` etc. The name is operation-agnostic (not `createfile`) because several are used **beyond create**:
- the **access mask** (`GENERIC_*`, `FILE_READ_DATA`, `DELETE`, …) appears in security descriptors/ACEs and the SMB2 `TREE_CONNECT` `MaximalAccess` response;
- **file attributes** (`FILE_ATTRIBUTE_*`) appear in directory enumeration and `FileBasicInformation` queries.

Only share access / disposition / options are create-specific. Delete/rename/modify are information-class enums, not bit flags, so a per-operation (`create/`, `delete/`, …) split would not pay off.

### Contents
SCREAMING_CASE constants matching the Windows/MS-protocol definitions, grouped with authoritative doc links:
- Access mask generic/standard rights — [MS-DTYP 2.4.3 ACCESS_MASK](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/7a53f60e-e730-4dfe-bbe9-b21b62eb790b)
- File/pipe/printer & directory rights — [MS-SMB2 2.2.13.1.1](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/77b36d0f-6016-458a-a7a0-0f4a72ae1534) / [2.2.13.1.2](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/0a5934b1-80f1-4da0-b1bf-5e021c309b71)
- Share access / create disposition / create options — [MS-SMB2 2.2.13 SMB2 CREATE Request](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/e8fb45c1-a03d-44ca-b7ae-47385cfd7997)
- File attributes — [MS-FSCC 2.6 File Attributes](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/ca28ec38-f155-4768-81d6-4bfeb8586fc9)

### Migration (no aliases; single source of truth)
- Removed the constant block previously exported from `network/smb/smb_v10/client`.
- Migrated all consumers to `windows/fileflags`: the DCE/RPC named-pipe transport, the EFSR integration test, and `main.go`. **Values are unchanged.**

### How Verified
`go build ./...`, `go vet`, and `gofmt -l` clean; the affected packages and the migrated test compile.

### Scope of Change
- New: `windows/fileflags/fileflags.go`
- Modified: `network/smb/smb_v10/client/file.go`, `network/dcerpc/v5/transport/smb/smb_namedpipe.go`, the EFSR integration test, `main.go`
- Behavioral changes: none (constant relocation only)

### Notes
The generic SMB client (PR #529) will consume this package for its `OpenOptions` and is stacked on this branch.