### PR TITLE
Wire the generic SMB client to windows/fileflags

### DIFF
--- a/network/smb/client/adapter_smb2.go
+++ b/network/smb/client/adapter_smb2.go
@@ -7,6 +7,7 @@ import (
 	smb2 "github.com/TheManticoreProject/Manticore/network/smb/smb_v20/client"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/types"
 	"github.com/TheManticoreProject/Manticore/windows/credentials"
+	"github.com/TheManticoreProject/Manticore/windows/fileflags"
 )
 
 // smb2Backend adapts the SMB 2.x engine (network/smb/smb_v20/client) to the
@@ -74,7 +75,11 @@ func (b *smb2Backend) ListDirectory(path, pattern string) ([]FileInfo, error) {
 	}
 
 	// Open the directory for enumeration.
-	fileId, err := b.engine.CreateFile(path, fileListDirectory|fileReadAttributes, shareReadWrite, fileOpen, fileDirectoryFile)
+	fileId, err := b.engine.CreateFile(path,
+		fileflags.FILE_LIST_DIRECTORY|fileflags.FILE_READ_ATTRIBUTES,
+		fileflags.FILE_SHARE_READ|fileflags.FILE_SHARE_WRITE,
+		fileflags.FILE_OPEN,
+		fileflags.FILE_DIRECTORY_FILE)
 	if err != nil {
 		return nil, fmt.Errorf("open directory %q: %w", path, err)
 	}

--- a/network/smb/client/example_test.go
+++ b/network/smb/client/example_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/smb"
 	smbclient "github.com/TheManticoreProject/Manticore/network/smb/client"
 	"github.com/TheManticoreProject/Manticore/windows/credentials"
+	"github.com/TheManticoreProject/Manticore/windows/fileflags"
 )
 
 // ExampleDial shows a full session: negotiate the best mutually-supported
@@ -36,10 +37,10 @@ func ExampleDial() {
 	defer c.TreeDisconnect()
 
 	h, err := c.OpenFile(`Windows\win.ini`, smbclient.OpenOptions{
-		DesiredAccess:     0x80000000, // GENERIC_READ
-		ShareAccess:       0x00000001, // FILE_SHARE_READ
-		CreateDisposition: 0x00000001, // FILE_OPEN
-		CreateOptions:     0x00000040, // FILE_NON_DIRECTORY_FILE
+		DesiredAccess:     fileflags.GENERIC_READ | fileflags.FILE_READ_ATTRIBUTES,
+		ShareAccess:       fileflags.FILE_SHARE_READ | fileflags.FILE_SHARE_WRITE,
+		CreateDisposition: fileflags.FILE_OPEN,
+		CreateOptions:     fileflags.FILE_NON_DIRECTORY_FILE,
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/network/smb/client/fileinfo.go
+++ b/network/smb/client/fileinfo.go
@@ -7,23 +7,11 @@ import (
 	"unicode/utf16"
 )
 
-// fileAttributeDirectory is the FILE_ATTRIBUTE_DIRECTORY bit (MS-FSCC 2.6).
-const fileAttributeDirectory uint32 = 0x00000010
-
-// File-open and information-class constants used to enumerate a directory over
-// SMB2 (MS-SMB2 / MS-FSCC).
-const (
-	fileListDirectory  uint32 = 0x00000001 // DesiredAccess: FILE_LIST_DIRECTORY
-	fileReadAttributes uint32 = 0x00000080 // DesiredAccess: FILE_READ_ATTRIBUTES
-	fileOpen           uint32 = 0x00000001 // CreateDisposition: FILE_OPEN
-	fileDirectoryFile  uint32 = 0x00000001 // CreateOptions: FILE_DIRECTORY_FILE
-	shareReadWrite     uint32 = 0x00000003 // ShareAccess: FILE_SHARE_READ|WRITE
-
-	// fileBothDirectoryInformation is the FILE_INFORMATION_CLASS used for
-	// enumeration; its FILE_BOTH_DIR_INFORMATION entries (MS-FSCC 2.4.8) carry the
-	// name, attributes, size, and timestamps needed for FileInfo.
-	fileBothDirectoryInformation uint8 = 0x03
-)
+// fileBothDirectoryInformation is the FILE_INFORMATION_CLASS used for directory
+// enumeration; its FILE_BOTH_DIR_INFORMATION entries (MS-FSCC 2.4.8) carry the
+// name, attributes, size, and timestamps needed for FileInfo. (The create-time
+// access/share/disposition/options values live in windows/fileflags.)
+const fileBothDirectoryInformation uint8 = 0x03
 
 // bothDirInfoFixedSize is the fixed portion of a FILE_BOTH_DIR_INFORMATION entry
 // before the variable FileName: NextEntryOffset(4) FileIndex(4) 4xFILETIME(32)

--- a/network/smb/client/fileinfo_test.go
+++ b/network/smb/client/fileinfo_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/binary"
 	"testing"
 	"unicode/utf16"
+
+	"github.com/TheManticoreProject/Manticore/windows/fileflags"
 )
 
 // bothDirEntry builds a single FILE_BOTH_DIR_INFORMATION entry with a UTF-16LE
@@ -25,10 +27,10 @@ func bothDirEntry(name string, attrs uint32, size uint64, next uint32) []byte {
 }
 
 func TestParseBothDirectoryInfo(t *testing.T) {
-	dot := bothDirEntry(".", fileAttributeDirectory, 0, 0)
-	dotdot := bothDirEntry("..", fileAttributeDirectory, 0, 0)
+	dot := bothDirEntry(".", fileflags.FILE_ATTRIBUTE_DIRECTORY, 0, 0)
+	dotdot := bothDirEntry("..", fileflags.FILE_ATTRIBUTE_DIRECTORY, 0, 0)
 	file := bothDirEntry("report.txt", 0x20 /*ARCHIVE*/, 1234, 0)
-	dir := bothDirEntry("subdir", fileAttributeDirectory, 0, 0)
+	dir := bothDirEntry("subdir", fileflags.FILE_ATTRIBUTE_DIRECTORY, 0, 0)
 
 	// Chain: NextEntryOffset of each non-last entry is that entry's length.
 	dot[0] = byte(len(dot))

--- a/network/smb/client/types.go
+++ b/network/smb/client/types.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/TheManticoreProject/Manticore/network/smb"
+	"github.com/TheManticoreProject/Manticore/windows/fileflags"
 )
 
 // NegotiationPolicy controls how the client applies its preference list when
@@ -53,15 +54,15 @@ func newFileHandle(dialect smb.SMBProtocolVersion, raw any) FileHandle {
 	return FileHandle{dialect: dialect, raw: raw}
 }
 
-// OpenOptions carries the file-open parameters shared by every dialect. The
-// access, share, disposition, and options fields use the MS-DTYP/MS-SMB2 bit
-// definitions, which are identical across SMB1 and SMB2.
+// OpenOptions carries the file-open parameters shared by every dialect. Combine
+// the bit values from windows/fileflags with bitwise OR, e.g.
+// DesiredAccess: fileflags.GENERIC_READ | fileflags.FILE_READ_ATTRIBUTES.
 type OpenOptions struct {
-	DesiredAccess     uint32
-	ShareAccess       uint32
-	CreateDisposition uint32
-	CreateOptions     uint32
-	FileAttributes    uint32
+	DesiredAccess     uint32 // fileflags GENERIC_* / FILE_* access rights
+	ShareAccess       uint32 // fileflags FILE_SHARE_*
+	CreateDisposition uint32 // fileflags FILE_OPEN / FILE_CREATE / ...
+	CreateOptions     uint32 // fileflags FILE_DIRECTORY_FILE / FILE_NON_DIRECTORY_FILE / ...
+	FileAttributes    uint32 // fileflags FILE_ATTRIBUTE_*
 }
 
 // FileInfo is a version-agnostic directory entry, normalized from the SMB1
@@ -80,5 +81,5 @@ type FileInfo struct {
 
 // IsDir reports whether the entry has the FILE_ATTRIBUTE_DIRECTORY flag set.
 func (fi FileInfo) IsDir() bool {
-	return fi.FileAttributes&fileAttributeDirectory != 0
+	return fi.FileAttributes&fileflags.FILE_ATTRIBUTE_DIRECTORY != 0
 }


### PR DESCRIPTION
### Summary
Switch the generic SMB client (`network/smb/client`) to the shared `windows/fileflags` constants, replacing the local duplicates it carried. Follow-up now that both the generic client (#529) and `windows/fileflags` (#532) are on `main`.

### Changes
- `OpenOptions` doc and the godoc examples use `fileflags` (e.g. `fileflags.GENERIC_READ | fileflags.FILE_READ_ATTRIBUTES`).
- `FileInfo.IsDir` uses `fileflags.FILE_ATTRIBUTE_DIRECTORY`.
- The SMB2 adapter's directory open uses the `fileflags` access/share/disposition/options constants; the local lowercase duplicates in `fileinfo.go` are removed. The `QUERY_DIRECTORY` information-class constant stays (it is not a create flag).

### How Verified
- `go build ./...`, `go vet`, `gofmt -l`, and the `network/smb/client` tests all pass.
- Live-validated against Windows Server 2016: file read + 96-entry directory listing over SMB 2.0.2 through `client.Client`.

### Scope of Change
- Modified: `network/smb/client/{types,fileinfo,adapter_smb2,example_test,fileinfo_test}.go`
- Behavioral changes: none (constant values are identical)