### PR TITLE
SMB2: QUERY_INFO/SET_INFO + file management, and MS-FSCC structures (#534)

### DIFF
--- a/network/smb/smb_v20/client/filemgmt.go
+++ b/network/smb/smb_v20/client/filemgmt.go
@@ -1,0 +1,130 @@
+package client
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/types"
+	"github.com/TheManticoreProject/Manticore/windows/fileflags"
+	"github.com/TheManticoreProject/Manticore/windows/ms_fscc"
+)
+
+// DeleteFile removes a file on the current tree. It opens the file with DELETE
+// access and FILE_DELETE_ON_CLOSE, so the file is removed when the handle closes.
+func (c *Client) DeleteFile(path string) error {
+	fileId, err := c.CreateFile(path,
+		fileflags.DELETE,
+		fileflags.FILE_SHARE_READ|fileflags.FILE_SHARE_WRITE|fileflags.FILE_SHARE_DELETE,
+		fileflags.FILE_OPEN,
+		fileflags.FILE_NON_DIRECTORY_FILE|fileflags.FILE_DELETE_ON_CLOSE)
+	if err != nil {
+		return err
+	}
+	return c.CloseFile(fileId)
+}
+
+// CreateDirectory creates a directory on the current tree.
+func (c *Client) CreateDirectory(path string) error {
+	fileId, err := c.CreateFile(path,
+		fileflags.FILE_LIST_DIRECTORY|fileflags.FILE_READ_ATTRIBUTES,
+		fileflags.FILE_SHARE_READ|fileflags.FILE_SHARE_WRITE,
+		fileflags.FILE_CREATE,
+		fileflags.FILE_DIRECTORY_FILE)
+	if err != nil {
+		return err
+	}
+	return c.CloseFile(fileId)
+}
+
+// DeleteDirectory removes an (empty) directory on the current tree.
+func (c *Client) DeleteDirectory(path string) error {
+	fileId, err := c.CreateFile(path,
+		fileflags.DELETE,
+		fileflags.FILE_SHARE_READ|fileflags.FILE_SHARE_WRITE|fileflags.FILE_SHARE_DELETE,
+		fileflags.FILE_OPEN,
+		fileflags.FILE_DIRECTORY_FILE|fileflags.FILE_DELETE_ON_CLOSE)
+	if err != nil {
+		return err
+	}
+	return c.CloseFile(fileId)
+}
+
+// RenameFile renames (or moves) oldPath to newPath on the current tree. Both are
+// share-relative. When replaceIfExists is false, the rename fails if newPath
+// already exists.
+func (c *Client) RenameFile(oldPath, newPath string, replaceIfExists bool) error {
+	fileId, err := c.CreateFile(oldPath,
+		fileflags.DELETE|fileflags.FILE_READ_ATTRIBUTES,
+		fileflags.FILE_SHARE_READ|fileflags.FILE_SHARE_WRITE|fileflags.FILE_SHARE_DELETE,
+		fileflags.FILE_OPEN,
+		fileflags.FILE_NON_DIRECTORY_FILE)
+	if err != nil {
+		return err
+	}
+	defer c.CloseFile(fileId)
+	return c.RenameByHandle(fileId, newPath, replaceIfExists)
+}
+
+// GetVolumeSizeInfo returns the size information of the volume backing the
+// current tree. It opens the share root and issues a filesystem QUERY_INFO.
+func (c *Client) GetVolumeSizeInfo() (*ms_fscc.FileFsSizeInformation, error) {
+	root, err := c.CreateFile("",
+		fileflags.FILE_READ_ATTRIBUTES,
+		fileflags.FILE_SHARE_READ|fileflags.FILE_SHARE_WRITE,
+		fileflags.FILE_OPEN,
+		fileflags.FILE_DIRECTORY_FILE)
+	if err != nil {
+		return nil, err
+	}
+	defer c.CloseFile(root)
+	return c.QueryFsSizeInfo(root)
+}
+
+// openForQuery opens path for attribute queries (FILE_READ_ATTRIBUTES) and returns
+// its handle; the caller closes it.
+func (c *Client) openForQuery(path string) (types.SMB2_FILEID, error) {
+	return c.CreateFile(path,
+		fileflags.FILE_READ_ATTRIBUTES,
+		fileflags.FILE_SHARE_READ|fileflags.FILE_SHARE_WRITE|fileflags.FILE_SHARE_DELETE,
+		fileflags.FILE_OPEN,
+		0)
+}
+
+// Stat opens path, queries its basic and standard information, and closes it.
+func (c *Client) Stat(path string) (*FileStat, error) {
+	fileId, err := c.openForQuery(path)
+	if err != nil {
+		return nil, err
+	}
+	defer c.CloseFile(fileId)
+
+	basic, err := c.QueryFileBasicInfo(fileId)
+	if err != nil {
+		return nil, err
+	}
+	std, err := c.QueryFileStandardInfo(fileId)
+	if err != nil {
+		return nil, err
+	}
+	return &FileStat{
+		Size:           uint64(std.EndOfFile),
+		AllocationSize: uint64(std.AllocationSize),
+		FileAttributes: basic.FileAttributes,
+		IsDirectory:    std.Directory,
+		CreationTime:   basic.CreationTime,
+		LastAccessTime: basic.LastAccessTime,
+		LastWriteTime:  basic.LastWriteTime,
+		ChangeTime:     basic.ChangeTime,
+	}, nil
+}
+
+// FileStat is a convenience summary of a file's metadata, combining
+// FILE_BASIC_INFORMATION and FILE_STANDARD_INFORMATION. FILETIME fields are raw
+// 100ns ticks since 1601-01-01 UTC.
+type FileStat struct {
+	Size           uint64
+	AllocationSize uint64
+	FileAttributes uint32
+	IsDirectory    bool
+	CreationTime   uint64
+	LastAccessTime uint64
+	LastWriteTime  uint64
+	ChangeTime     uint64
+}

--- a/network/smb/smb_v20/client/info.go
+++ b/network/smb/smb_v20/client/info.go
@@ -1,0 +1,127 @@
+package client
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/types"
+	"github.com/TheManticoreProject/Manticore/windows/ms_fscc"
+	"github.com/TheManticoreProject/Manticore/windows/ms_fscc/infoclass"
+)
+
+// QueryInfo issues an SMB2 QUERY_INFO on the open identified by fileId and returns
+// the raw output buffer (an MS-FSCC structure, a security descriptor, …). infoType
+// is one of commands.SMB2_0_INFO_* and fileInfoClass the class within it;
+// additionalInformation carries the security-info bits for security queries and is
+// 0 otherwise. Wire: SMB2 QUERY_INFO.
+func (c *Client) QueryInfo(fileId types.SMB2_FILEID, infoType, fileInfoClass uint8, additionalInformation uint32) ([]byte, error) {
+	if c.Session == nil || c.Session.TreeId == 0 {
+		return nil, fmt.Errorf("no tree connect established")
+	}
+
+	req := commands.NewQueryInfoRequest()
+	req.InfoType = types.UCHAR(infoType)
+	req.FileInfoClass = types.UCHAR(fileInfoClass)
+	req.AdditionalInformation = types.ULONG(additionalInformation)
+	req.OutputBufferLength = types.ULONG(c.Connection.Server.MaxTransactSize)
+	req.FileId = fileId
+
+	response, err := c.sendReceive(c.newRequest(req), "QueryInfo")
+	if err != nil {
+		return nil, err
+	}
+	if status := statusFromResponse(response); status != 0x00000000 {
+		return nil, fmt.Errorf("query info failed: %s", formatNTStatus(status))
+	}
+	resp, ok := response.Command.(*commands.QueryInfoResponse)
+	if !ok {
+		return nil, fmt.Errorf("unexpected query info response command: %T", response.Command)
+	}
+	return resp.OutputBuffer, nil
+}
+
+// SetInfo issues an SMB2 SET_INFO on fileId, sending buffer as the information to
+// set. Wire: SMB2 SET_INFO.
+func (c *Client) SetInfo(fileId types.SMB2_FILEID, infoType, fileInfoClass uint8, additionalInformation uint32, buffer []byte) error {
+	if c.Session == nil || c.Session.TreeId == 0 {
+		return fmt.Errorf("no tree connect established")
+	}
+
+	req := commands.NewSetInfoRequest()
+	req.InfoType = types.UCHAR(infoType)
+	req.FileInfoClass = types.UCHAR(fileInfoClass)
+	req.AdditionalInformation = types.ULONG(additionalInformation)
+	req.FileId = fileId
+	req.Buffer = buffer
+
+	response, err := c.sendReceive(c.newRequest(req), "SetInfo")
+	if err != nil {
+		return err
+	}
+	if status := statusFromResponse(response); status != 0x00000000 {
+		return fmt.Errorf("set info failed: %s", formatNTStatus(status))
+	}
+	return nil
+}
+
+// QueryFileBasicInfo returns the FILE_BASIC_INFORMATION (timestamps, attributes)
+// of an open file.
+func (c *Client) QueryFileBasicInfo(fileId types.SMB2_FILEID) (*ms_fscc.FileBasicInformation, error) {
+	raw, err := c.QueryInfo(fileId, commands.SMB2_0_INFO_FILE, uint8(infoclass.FileBasicInformation), 0)
+	if err != nil {
+		return nil, err
+	}
+	fi := &ms_fscc.FileBasicInformation{}
+	if err := fi.Unmarshal(raw); err != nil {
+		return nil, err
+	}
+	return fi, nil
+}
+
+// QueryFileStandardInfo returns the FILE_STANDARD_INFORMATION (size, link count,
+// delete/directory flags) of an open file.
+func (c *Client) QueryFileStandardInfo(fileId types.SMB2_FILEID) (*ms_fscc.FileStandardInformation, error) {
+	raw, err := c.QueryInfo(fileId, commands.SMB2_0_INFO_FILE, uint8(infoclass.FileStandardInformation), 0)
+	if err != nil {
+		return nil, err
+	}
+	fi := &ms_fscc.FileStandardInformation{}
+	if err := fi.Unmarshal(raw); err != nil {
+		return nil, err
+	}
+	return fi, nil
+}
+
+// QueryFsSizeInfo returns the FILE_FS_SIZE_INFORMATION of the volume backing the
+// open identified by fileId (any open on the tree, e.g. the share root).
+func (c *Client) QueryFsSizeInfo(fileId types.SMB2_FILEID) (*ms_fscc.FileFsSizeInformation, error) {
+	raw, err := c.QueryInfo(fileId, commands.SMB2_0_INFO_FILESYSTEM, uint8(infoclass.FileFsSizeInformation), 0)
+	if err != nil {
+		return nil, err
+	}
+	fi := &ms_fscc.FileFsSizeInformation{}
+	if err := fi.Unmarshal(raw); err != nil {
+		return nil, err
+	}
+	return fi, nil
+}
+
+// SetEndOfFile sets the logical size of an open file (truncate or extend).
+func (c *Client) SetEndOfFile(fileId types.SMB2_FILEID, size int64) error {
+	buf, _ := (&ms_fscc.FileEndOfFileInformation{EndOfFile: size}).Marshal()
+	return c.SetInfo(fileId, commands.SMB2_0_INFO_FILE, uint8(infoclass.FileEndOfFileInformation), 0, buf)
+}
+
+// SetDeleteOnClose marks (or unmarks) an open file for deletion when its last
+// handle is closed.
+func (c *Client) SetDeleteOnClose(fileId types.SMB2_FILEID, deletePending bool) error {
+	buf, _ := (&ms_fscc.FileDispositionInformation{DeletePending: deletePending}).Marshal()
+	return c.SetInfo(fileId, commands.SMB2_0_INFO_FILE, uint8(infoclass.FileDispositionInformation), 0, buf)
+}
+
+// RenameByHandle renames the open file to newName (share-relative). The handle
+// must have been opened with DELETE access.
+func (c *Client) RenameByHandle(fileId types.SMB2_FILEID, newName string, replaceIfExists bool) error {
+	buf, _ := (&ms_fscc.FileRenameInformation{ReplaceIfExists: replaceIfExists, FileName: newName}).Marshal()
+	return c.SetInfo(fileId, commands.SMB2_0_INFO_FILE, uint8(infoclass.FileRenameInformation), 0, buf)
+}

--- a/network/smb/smb_v20/message/commands/CreateRequest.go
+++ b/network/smb/smb_v20/message/commands/CreateRequest.go
@@ -101,14 +101,14 @@ func (c *CreateRequest) Marshal() ([]byte, error) {
 	binary.LittleEndian.PutUint32(buf[36:40], c.CreateDisposition)
 	binary.LittleEndian.PutUint32(buf[40:44], c.CreateOptions)
 
-	// The name (if any) begins immediately after the fixed part; offsets are
-	// measured from the start of the SMB2 header.
+	// The name begins immediately after the fixed part; offsets are measured from
+	// the start of the SMB2 header. NameOffset MUST point at the Buffer even when
+	// the name is empty (a root open): Windows rejects a zero NameOffset with
+	// STATUS_INVALID_PARAMETER. NameLength is 0 for an empty name.
 	variable := []byte{}
-	if len(nameBytes) > 0 {
-		binary.LittleEndian.PutUint16(buf[44:46], uint16(header.SMB2_HEADER_SIZE+createRequestFixedSize))
-		binary.LittleEndian.PutUint16(buf[46:48], uint16(len(nameBytes)))
-		variable = append(variable, nameBytes...)
-	}
+	binary.LittleEndian.PutUint16(buf[44:46], uint16(header.SMB2_HEADER_SIZE+createRequestFixedSize))
+	binary.LittleEndian.PutUint16(buf[46:48], uint16(len(nameBytes)))
+	variable = append(variable, nameBytes...)
 
 	if len(c.CreateContexts) > 0 {
 		// Create contexts must start on an 8-byte boundary relative to the header.

--- a/windows/filesystem/doc.go
+++ b/windows/filesystem/doc.go
@@ -1,0 +1,10 @@
+// Package filesystem holds Windows file-system data structures used over SMB and
+// by the local file-system APIs.
+//
+// Today it implements the [MS-FSCC] information classes exchanged via SMB2
+// QUERY_INFO / SET_INFO (and locally by NtQueryInformationFile /
+// NtSetInformationFile) — the FILE_*_INFORMATION and FILE_FS_*_INFORMATION
+// structures. The class numbers that select them live in the infoclass
+// subpackage. More file-system structures (reparse points, EAs, control codes,
+// …) can be added here as they are needed.
+package filesystem

--- a/windows/filesystem/file_query_information.go
+++ b/windows/filesystem/file_query_information.go
@@ -1,0 +1,94 @@
+package ms_fscc
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+// FileBasicInformation is FILE_BASIC_INFORMATION (FileInformationClass 4): the
+// timestamps and attributes of a file. FILETIME fields are 100ns ticks since
+// 1601-01-01 UTC. Fixed 40-byte wire layout.
+//
+// [MS-FSCC] 2.4.7 FileBasicInformation:
+// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/16023025-8a78-492f-8b96-c873b042ac50
+type FileBasicInformation struct {
+	CreationTime   uint64
+	LastAccessTime uint64
+	LastWriteTime  uint64
+	ChangeTime     uint64
+	FileAttributes uint32
+	Reserved       uint32
+}
+
+// FileBasicInformationSize is the fixed wire size of FILE_BASIC_INFORMATION.
+const FileBasicInformationSize = 40
+
+// Marshal encodes the structure to its 40-byte wire form.
+func (fi *FileBasicInformation) Marshal() ([]byte, error) {
+	b := make([]byte, FileBasicInformationSize)
+	binary.LittleEndian.PutUint64(b[0:8], fi.CreationTime)
+	binary.LittleEndian.PutUint64(b[8:16], fi.LastAccessTime)
+	binary.LittleEndian.PutUint64(b[16:24], fi.LastWriteTime)
+	binary.LittleEndian.PutUint64(b[24:32], fi.ChangeTime)
+	binary.LittleEndian.PutUint32(b[32:36], fi.FileAttributes)
+	binary.LittleEndian.PutUint32(b[36:40], fi.Reserved)
+	return b, nil
+}
+
+// Unmarshal decodes the structure from its wire form.
+func (fi *FileBasicInformation) Unmarshal(data []byte) error {
+	if len(data) < FileBasicInformationSize {
+		return fmt.Errorf("FILE_BASIC_INFORMATION: need %d bytes, got %d", FileBasicInformationSize, len(data))
+	}
+	fi.CreationTime = binary.LittleEndian.Uint64(data[0:8])
+	fi.LastAccessTime = binary.LittleEndian.Uint64(data[8:16])
+	fi.LastWriteTime = binary.LittleEndian.Uint64(data[16:24])
+	fi.ChangeTime = binary.LittleEndian.Uint64(data[24:32])
+	fi.FileAttributes = binary.LittleEndian.Uint32(data[32:36])
+	fi.Reserved = binary.LittleEndian.Uint32(data[36:40])
+	return nil
+}
+
+// FileStandardInformation is FILE_STANDARD_INFORMATION (FileInformationClass 5):
+// size, link count, and delete/directory flags. Fixed 24-byte wire layout.
+//
+// [MS-FSCC] 2.4.41 FileStandardInformation:
+// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/5afa7f66-619c-48f3-955f-68c4ece704ae
+type FileStandardInformation struct {
+	AllocationSize int64
+	EndOfFile      int64
+	NumberOfLinks  uint32
+	DeletePending  bool
+	Directory      bool
+}
+
+// FileStandardInformationSize is the fixed wire size of FILE_STANDARD_INFORMATION.
+const FileStandardInformationSize = 24
+
+// Unmarshal decodes the structure from its wire form.
+func (fi *FileStandardInformation) Unmarshal(data []byte) error {
+	if len(data) < FileStandardInformationSize {
+		return fmt.Errorf("FILE_STANDARD_INFORMATION: need %d bytes, got %d", FileStandardInformationSize, len(data))
+	}
+	fi.AllocationSize = int64(binary.LittleEndian.Uint64(data[0:8]))
+	fi.EndOfFile = int64(binary.LittleEndian.Uint64(data[8:16]))
+	fi.NumberOfLinks = binary.LittleEndian.Uint32(data[16:20])
+	fi.DeletePending = data[20] != 0
+	fi.Directory = data[21] != 0
+	return nil
+}
+
+// Marshal encodes the structure to its 24-byte wire form.
+func (fi *FileStandardInformation) Marshal() ([]byte, error) {
+	b := make([]byte, FileStandardInformationSize)
+	binary.LittleEndian.PutUint64(b[0:8], uint64(fi.AllocationSize))
+	binary.LittleEndian.PutUint64(b[8:16], uint64(fi.EndOfFile))
+	binary.LittleEndian.PutUint32(b[16:20], fi.NumberOfLinks)
+	if fi.DeletePending {
+		b[20] = 1
+	}
+	if fi.Directory {
+		b[21] = 1
+	}
+	return b, nil
+}

--- a/windows/filesystem/file_set_information.go
+++ b/windows/filesystem/file_set_information.go
@@ -1,0 +1,110 @@
+package ms_fscc
+
+import (
+	"encoding/binary"
+	"fmt"
+	"unicode/utf16"
+)
+
+// FileEndOfFileInformation is FILE_END_OF_FILE_INFORMATION (FileInformationClass
+// 20): sets the logical end-of-file (size) of a file.
+//
+// [MS-FSCC] 2.4.13 FileEndOfFileInformation:
+// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/75241cca-3167-472f-8058-a52d77c6bb17
+type FileEndOfFileInformation struct {
+	EndOfFile int64
+}
+
+// Marshal encodes the structure to its 8-byte wire form.
+func (fi *FileEndOfFileInformation) Marshal() ([]byte, error) {
+	b := make([]byte, 8)
+	binary.LittleEndian.PutUint64(b, uint64(fi.EndOfFile))
+	return b, nil
+}
+
+// Unmarshal decodes the structure from its wire form.
+func (fi *FileEndOfFileInformation) Unmarshal(data []byte) error {
+	if len(data) < 8 {
+		return fmt.Errorf("FILE_END_OF_FILE_INFORMATION: need 8 bytes, got %d", len(data))
+	}
+	fi.EndOfFile = int64(binary.LittleEndian.Uint64(data[0:8]))
+	return nil
+}
+
+// FileDispositionInformation is FILE_DISPOSITION_INFORMATION (FileInformationClass
+// 13): marks a file for deletion when its last handle is closed.
+//
+// [MS-FSCC] 2.4.11 FileDispositionInformation:
+// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/12c3dd1c-14f6-4229-9d29-75fb2cb392f6
+type FileDispositionInformation struct {
+	DeletePending bool
+}
+
+// Marshal encodes the structure to its 1-byte wire form.
+func (fi *FileDispositionInformation) Marshal() ([]byte, error) {
+	b := make([]byte, 1)
+	if fi.DeletePending {
+		b[0] = 1
+	}
+	return b, nil
+}
+
+// Unmarshal decodes the structure from its wire form.
+func (fi *FileDispositionInformation) Unmarshal(data []byte) error {
+	if len(data) < 1 {
+		return fmt.Errorf("FILE_DISPOSITION_INFORMATION: need 1 byte, got %d", len(data))
+	}
+	fi.DeletePending = data[0] != 0
+	return nil
+}
+
+// FileRenameInformation is the SMB2 form of FILE_RENAME_INFORMATION
+// (FileInformationClass 10): renames or moves a file. FileName is the new
+// (share-relative) name; RootDirectory MUST be 0 for network operations.
+//
+// [MS-FSCC] 2.4.34.2 FileRenameInformation for SMB2:
+// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/52aa0b70-8094-4971-862d-79793f41e6a8
+type FileRenameInformation struct {
+	ReplaceIfExists bool
+	RootDirectory   uint64
+	FileName        string
+}
+
+// Marshal encodes the structure to its wire form: ReplaceIfExists(1) Reserved(7)
+// RootDirectory(8) FileNameLength(4) FileName(UTF-16LE, not NUL-terminated).
+func (fi *FileRenameInformation) Marshal() ([]byte, error) {
+	name := utf16.Encode([]rune(fi.FileName))
+	nameBytes := make([]byte, len(name)*2)
+	for i, u := range name {
+		binary.LittleEndian.PutUint16(nameBytes[i*2:], u)
+	}
+
+	b := make([]byte, 20+len(nameBytes))
+	if fi.ReplaceIfExists {
+		b[0] = 1
+	}
+	// b[1:8] Reserved = 0
+	binary.LittleEndian.PutUint64(b[8:16], fi.RootDirectory)
+	binary.LittleEndian.PutUint32(b[16:20], uint32(len(nameBytes)))
+	copy(b[20:], nameBytes)
+	return b, nil
+}
+
+// Unmarshal decodes the structure from its wire form.
+func (fi *FileRenameInformation) Unmarshal(data []byte) error {
+	if len(data) < 20 {
+		return fmt.Errorf("FILE_RENAME_INFORMATION: need at least 20 bytes, got %d", len(data))
+	}
+	fi.ReplaceIfExists = data[0] != 0
+	fi.RootDirectory = binary.LittleEndian.Uint64(data[8:16])
+	nameLen := int(binary.LittleEndian.Uint32(data[16:20]))
+	if 20+nameLen > len(data) {
+		return fmt.Errorf("FILE_RENAME_INFORMATION: name length %d exceeds buffer", nameLen)
+	}
+	u16 := make([]uint16, nameLen/2)
+	for i := range u16 {
+		u16[i] = binary.LittleEndian.Uint16(data[20+i*2:])
+	}
+	fi.FileName = string(utf16.Decode(u16))
+	return nil
+}

--- a/windows/filesystem/filesystem_test.go
+++ b/windows/filesystem/filesystem_test.go
@@ -1,0 +1,120 @@
+package ms_fscc
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+func TestFileBasicInformation_RoundTrip(t *testing.T) {
+	in := &FileBasicInformation{
+		CreationTime:   0x01D7A0000000000A,
+		LastAccessTime: 0x01D7A0000000000B,
+		LastWriteTime:  0x01D7A0000000000C,
+		ChangeTime:     0x01D7A0000000000D,
+		FileAttributes: 0x00000020,
+	}
+	b, _ := in.Marshal()
+	if len(b) != FileBasicInformationSize {
+		t.Fatalf("size = %d, want %d", len(b), FileBasicInformationSize)
+	}
+	var out FileBasicInformation
+	if err := out.Unmarshal(b); err != nil {
+		t.Fatal(err)
+	}
+	if out != *in {
+		t.Errorf("round-trip mismatch: %+v vs %+v", out, *in)
+	}
+}
+
+func TestFileStandardInformation_RoundTrip(t *testing.T) {
+	in := &FileStandardInformation{AllocationSize: 4096, EndOfFile: 1234, NumberOfLinks: 1, DeletePending: true, Directory: false}
+	b, _ := in.Marshal()
+	if len(b) != FileStandardInformationSize {
+		t.Fatalf("size = %d, want %d", len(b), FileStandardInformationSize)
+	}
+	var out FileStandardInformation
+	if err := out.Unmarshal(b); err != nil {
+		t.Fatal(err)
+	}
+	if out != *in {
+		t.Errorf("round-trip mismatch: %+v vs %+v", out, *in)
+	}
+}
+
+func TestFileEndOfFileInformation_RoundTrip(t *testing.T) {
+	in := &FileEndOfFileInformation{EndOfFile: 0x1122334455}
+	b, _ := in.Marshal()
+	var out FileEndOfFileInformation
+	if err := out.Unmarshal(b); err != nil {
+		t.Fatal(err)
+	}
+	if out.EndOfFile != in.EndOfFile {
+		t.Errorf("EndOfFile = %d, want %d", out.EndOfFile, in.EndOfFile)
+	}
+}
+
+func TestFileDispositionInformation(t *testing.T) {
+	b, _ := (&FileDispositionInformation{DeletePending: true}).Marshal()
+	if len(b) != 1 || b[0] != 1 {
+		t.Fatalf("DeletePending=true marshalled to % x", b)
+	}
+}
+
+// TestFileRenameInformation_SMB2Layout verifies the SMB2 wire layout:
+// ReplaceIfExists(1) Reserved(7) RootDirectory(8) FileNameLength(4) FileName(UTF-16LE).
+func TestFileRenameInformation_SMB2Layout(t *testing.T) {
+	in := &FileRenameInformation{ReplaceIfExists: true, FileName: `dir\new.txt`}
+	b, _ := in.Marshal()
+
+	if b[0] != 1 {
+		t.Errorf("ReplaceIfExists byte = %d, want 1", b[0])
+	}
+	for i := 1; i < 16; i++ { // Reserved(7) + RootDirectory(8) must be zero
+		if b[i] != 0 {
+			t.Errorf("byte %d = %d, want 0 (Reserved/RootDirectory)", i, b[i])
+		}
+	}
+	nameLen := binary.LittleEndian.Uint32(b[16:20])
+	if int(nameLen) != len(in.FileName)*2 {
+		t.Errorf("FileNameLength = %d, want %d", nameLen, len(in.FileName)*2)
+	}
+	if 20+int(nameLen) != len(b) {
+		t.Errorf("total %d != 20 + name %d", len(b), nameLen)
+	}
+
+	var out FileRenameInformation
+	if err := out.Unmarshal(b); err != nil {
+		t.Fatal(err)
+	}
+	if out.FileName != in.FileName || out.ReplaceIfExists != in.ReplaceIfExists {
+		t.Errorf("round-trip mismatch: %+v vs %+v", out, *in)
+	}
+}
+
+func TestFileFsSizeInformation(t *testing.T) {
+	b := make([]byte, FileFsSizeInformationSize)
+	binary.LittleEndian.PutUint64(b[0:8], 1000)  // total units
+	binary.LittleEndian.PutUint64(b[8:16], 400)  // available units
+	binary.LittleEndian.PutUint32(b[16:20], 8)   // sectors/unit
+	binary.LittleEndian.PutUint32(b[20:24], 512) // bytes/sector
+	var fi FileFsSizeInformation
+	if err := fi.Unmarshal(b); err != nil {
+		t.Fatal(err)
+	}
+	if fi.TotalBytes() != 1000*8*512 || fi.AvailableBytes() != 400*8*512 {
+		t.Errorf("byte totals wrong: total=%d avail=%d", fi.TotalBytes(), fi.AvailableBytes())
+	}
+}
+
+func TestUnmarshal_ShortBuffers(t *testing.T) {
+	if (&FileBasicInformation{}).Unmarshal(make([]byte, 10)) == nil {
+		t.Error("expected error on short FileBasicInformation buffer")
+	}
+	if (&FileFsSizeInformation{}).Unmarshal([]byte{}) == nil {
+		t.Error("expected error on empty FileFsSizeInformation buffer")
+	}
+	// A valid empty-name rename still needs the 20-byte fixed head.
+	if (&FileRenameInformation{}).Unmarshal(make([]byte, 4)) == nil {
+		t.Error("expected error on short FileRenameInformation buffer")
+	}
+}

--- a/windows/filesystem/fs_information.go
+++ b/windows/filesystem/fs_information.go
@@ -1,0 +1,44 @@
+package ms_fscc
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+// FileFsSizeInformation is FILE_FS_SIZE_INFORMATION (FsInformationClass 3): the
+// total/available allocation units and the sector geometry of a volume. Fixed
+// 24-byte wire layout.
+//
+// [MS-FSCC] 2.5.8 FileFsSizeInformation:
+// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/e13e068c-e3a7-4dd4-bff4-87d57c30ac0c
+type FileFsSizeInformation struct {
+	TotalAllocationUnits     int64
+	AvailableAllocationUnits int64
+	SectorsPerAllocationUnit uint32
+	BytesPerSector           uint32
+}
+
+// FileFsSizeInformationSize is the fixed wire size of FILE_FS_SIZE_INFORMATION.
+const FileFsSizeInformationSize = 24
+
+// Unmarshal decodes the structure from its wire form.
+func (fi *FileFsSizeInformation) Unmarshal(data []byte) error {
+	if len(data) < FileFsSizeInformationSize {
+		return fmt.Errorf("FILE_FS_SIZE_INFORMATION: need %d bytes, got %d", FileFsSizeInformationSize, len(data))
+	}
+	fi.TotalAllocationUnits = int64(binary.LittleEndian.Uint64(data[0:8]))
+	fi.AvailableAllocationUnits = int64(binary.LittleEndian.Uint64(data[8:16]))
+	fi.SectorsPerAllocationUnit = binary.LittleEndian.Uint32(data[16:20])
+	fi.BytesPerSector = binary.LittleEndian.Uint32(data[20:24])
+	return nil
+}
+
+// TotalBytes returns the total capacity of the volume in bytes.
+func (fi *FileFsSizeInformation) TotalBytes() uint64 {
+	return uint64(fi.TotalAllocationUnits) * uint64(fi.SectorsPerAllocationUnit) * uint64(fi.BytesPerSector)
+}
+
+// AvailableBytes returns the free capacity of the volume in bytes.
+func (fi *FileFsSizeInformation) AvailableBytes() uint64 {
+	return uint64(fi.AvailableAllocationUnits) * uint64(fi.SectorsPerAllocationUnit) * uint64(fi.BytesPerSector)
+}

--- a/windows/filesystem/infoclass/infoclass.go
+++ b/windows/filesystem/infoclass/infoclass.go
@@ -1,0 +1,53 @@
+// Package infoclass holds the [MS-FSCC] FILE_INFORMATION_CLASS and
+// FILE_FS_*_INFORMATION class numbers used with SMB2 QUERY_INFO / SET_INFO. They
+// live in their own package so the class identifiers can keep their spec names
+// without colliding with the like-named structures in package ms_fscc.
+package infoclass
+
+// FileInformationClass identifies a FILE_INFORMATION_CLASS used with the
+// SMB2_0_INFO_FILE info type.
+//
+// [MS-FSCC] 2.4 File Information Classes:
+// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/4718fc40-e539-4014-8e33-b675af74e3e1
+type FileInformationClass uint8
+
+const (
+	FileDirectoryInformation       FileInformationClass = 1
+	FileFullDirectoryInformation   FileInformationClass = 2
+	FileBothDirectoryInformation   FileInformationClass = 3
+	FileBasicInformation           FileInformationClass = 4
+	FileStandardInformation        FileInformationClass = 5
+	FileInternalInformation        FileInformationClass = 6
+	FileEaInformation              FileInformationClass = 7
+	FileAccessInformation          FileInformationClass = 8
+	FileNameInformation            FileInformationClass = 9
+	FileRenameInformation          FileInformationClass = 10
+	FileLinkInformation            FileInformationClass = 11
+	FileNamesInformation           FileInformationClass = 12
+	FileDispositionInformation     FileInformationClass = 13
+	FilePositionInformation        FileInformationClass = 14
+	FileAllInformation             FileInformationClass = 18
+	FileAllocationInformation      FileInformationClass = 19
+	FileEndOfFileInformation       FileInformationClass = 20
+	FileAlternateNameInformation   FileInformationClass = 21
+	FileIdBothDirectoryInformation FileInformationClass = 37
+	FileIdFullDirectoryInformation FileInformationClass = 38
+)
+
+// FsInformationClass identifies a FILE_FS_*_INFORMATION class used with the
+// SMB2_0_INFO_FILESYSTEM info type.
+//
+// [MS-FSCC] 2.5 File System Information Classes:
+// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/ee12042a-9352-46e3-9f67-c094b75fe6c3
+type FsInformationClass uint8
+
+const (
+	FileFsVolumeInformation    FsInformationClass = 1
+	FileFsLabelInformation     FsInformationClass = 2
+	FileFsSizeInformation      FsInformationClass = 3
+	FileFsDeviceInformation    FsInformationClass = 4
+	FileFsAttributeInformation FsInformationClass = 5
+	FileFsControlInformation   FsInformationClass = 6
+	FileFsFullSizeInformation  FsInformationClass = 7
+	FileFsObjectIdInformation  FsInformationClass = 8
+)


### PR DESCRIPTION
### Linked Issue
Part of #534 (complete the SMB 2.0 client). Also realizes #525 (typed file-system information structures) incrementally.

### Summary
Wires the SMB2 client's metadata/file-management operations and adds the Windows file-system structures they decode/encode, bringing SMB2 to parity with the SMB1 client for these operations.

### New package: `windows/filesystem`
A home for Windows file-system data structures (more can be added). Today it holds the MS-FSCC information classes used over SMB2, SCREAMING-named with marshal/unmarshal and doc links:
- `infoclass` subpackage — [FILE_INFORMATION_CLASS](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/4718fc40-e539-4014-8e33-b675af74e3e1) / [FILE_FS_*](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/ee12042a-9352-46e3-9f67-c094b75fe6c3) class numbers (separate package so the spec class names don't collide with the like-named structs).
- `FILE_BASIC_INFORMATION`, `FILE_STANDARD_INFORMATION`, `FILE_END_OF_FILE_INFORMATION`, `FILE_DISPOSITION_INFORMATION`, `FILE_RENAME_INFORMATION` ([SMB2 form](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/52aa0b70-8094-4971-862d-79793f41e6a8)), `FILE_FS_SIZE_INFORMATION`.

### SMB2 client (`network/smb/smb_v20/client`)
- Primitives: `QueryInfo`, `SetInfo` (raw buffers).
- Typed helpers: `QueryFileBasicInfo`, `QueryFileStandardInfo`, `QueryFsSizeInfo`, `SetEndOfFile`, `SetDeleteOnClose`, `RenameByHandle`.
- Path helpers: `DeleteFile`, `CreateDirectory`, `DeleteDirectory`, `RenameFile`, `Stat`, `GetVolumeSizeInfo`.

### Bug fix
SMB2 CREATE left `NameOffset` = 0 for an empty name (share-root open); Windows rejects that with `STATUS_INVALID_PARAMETER`. `NameOffset` now always points at the Buffer (`NameLength` 0 for the empty name). This unblocks root opens (needed by `GetVolumeSizeInfo`).

### How Verified
- `go build ./...`, `go vet`, `gofmt -l` clean (touched files); `windows/filesystem` round-trip unit tests; existing smb_v20 suites pass (CREATE change is regression-free).
- **Live-validated against Windows Server 2016:** create/write -> query standard+basic info -> truncate (`SetEndOfFile`) -> `Stat` -> rename -> `GetVolumeSizeInfo` (root open: C\$ 50697 MiB total / 37220 MiB free) -> create/stat/delete directory -> delete file.

### Scope of Change
- New: `windows/filesystem/**`, `network/smb/smb_v20/client/{info,filemgmt}.go`
- Modified: `network/smb/smb_v20/message/commands/CreateRequest.go` (empty-name NameOffset fix)