### PR TITLE
Complete the windows/filesystem rename so main builds

### DIFF
--- a/network/smb/smb_v20/client/filemgmt.go
+++ b/network/smb/smb_v20/client/filemgmt.go
@@ -3,7 +3,7 @@ package client
 import (
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/types"
 	"github.com/TheManticoreProject/Manticore/windows/fileflags"
-	"github.com/TheManticoreProject/Manticore/windows/ms_fscc"
+	"github.com/TheManticoreProject/Manticore/windows/filesystem"
 )
 
 // DeleteFile removes a file on the current tree. It opens the file with DELETE
@@ -64,7 +64,7 @@ func (c *Client) RenameFile(oldPath, newPath string, replaceIfExists bool) error
 
 // GetVolumeSizeInfo returns the size information of the volume backing the
 // current tree. It opens the share root and issues a filesystem QUERY_INFO.
-func (c *Client) GetVolumeSizeInfo() (*ms_fscc.FileFsSizeInformation, error) {
+func (c *Client) GetVolumeSizeInfo() (*filesystem.FileFsSizeInformation, error) {
 	root, err := c.CreateFile("",
 		fileflags.FILE_READ_ATTRIBUTES,
 		fileflags.FILE_SHARE_READ|fileflags.FILE_SHARE_WRITE,

--- a/network/smb/smb_v20/client/info.go
+++ b/network/smb/smb_v20/client/info.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/message/commands"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/types"
-	"github.com/TheManticoreProject/Manticore/windows/ms_fscc"
-	"github.com/TheManticoreProject/Manticore/windows/ms_fscc/infoclass"
+	"github.com/TheManticoreProject/Manticore/windows/filesystem"
+	"github.com/TheManticoreProject/Manticore/windows/filesystem/infoclass"
 )
 
 // QueryInfo issues an SMB2 QUERY_INFO on the open identified by fileId and returns
@@ -66,12 +66,12 @@ func (c *Client) SetInfo(fileId types.SMB2_FILEID, infoType, fileInfoClass uint8
 
 // QueryFileBasicInfo returns the FILE_BASIC_INFORMATION (timestamps, attributes)
 // of an open file.
-func (c *Client) QueryFileBasicInfo(fileId types.SMB2_FILEID) (*ms_fscc.FileBasicInformation, error) {
+func (c *Client) QueryFileBasicInfo(fileId types.SMB2_FILEID) (*filesystem.FileBasicInformation, error) {
 	raw, err := c.QueryInfo(fileId, commands.SMB2_0_INFO_FILE, uint8(infoclass.FileBasicInformation), 0)
 	if err != nil {
 		return nil, err
 	}
-	fi := &ms_fscc.FileBasicInformation{}
+	fi := &filesystem.FileBasicInformation{}
 	if err := fi.Unmarshal(raw); err != nil {
 		return nil, err
 	}
@@ -80,12 +80,12 @@ func (c *Client) QueryFileBasicInfo(fileId types.SMB2_FILEID) (*ms_fscc.FileBasi
 
 // QueryFileStandardInfo returns the FILE_STANDARD_INFORMATION (size, link count,
 // delete/directory flags) of an open file.
-func (c *Client) QueryFileStandardInfo(fileId types.SMB2_FILEID) (*ms_fscc.FileStandardInformation, error) {
+func (c *Client) QueryFileStandardInfo(fileId types.SMB2_FILEID) (*filesystem.FileStandardInformation, error) {
 	raw, err := c.QueryInfo(fileId, commands.SMB2_0_INFO_FILE, uint8(infoclass.FileStandardInformation), 0)
 	if err != nil {
 		return nil, err
 	}
-	fi := &ms_fscc.FileStandardInformation{}
+	fi := &filesystem.FileStandardInformation{}
 	if err := fi.Unmarshal(raw); err != nil {
 		return nil, err
 	}
@@ -94,12 +94,12 @@ func (c *Client) QueryFileStandardInfo(fileId types.SMB2_FILEID) (*ms_fscc.FileS
 
 // QueryFsSizeInfo returns the FILE_FS_SIZE_INFORMATION of the volume backing the
 // open identified by fileId (any open on the tree, e.g. the share root).
-func (c *Client) QueryFsSizeInfo(fileId types.SMB2_FILEID) (*ms_fscc.FileFsSizeInformation, error) {
+func (c *Client) QueryFsSizeInfo(fileId types.SMB2_FILEID) (*filesystem.FileFsSizeInformation, error) {
 	raw, err := c.QueryInfo(fileId, commands.SMB2_0_INFO_FILESYSTEM, uint8(infoclass.FileFsSizeInformation), 0)
 	if err != nil {
 		return nil, err
 	}
-	fi := &ms_fscc.FileFsSizeInformation{}
+	fi := &filesystem.FileFsSizeInformation{}
 	if err := fi.Unmarshal(raw); err != nil {
 		return nil, err
 	}
@@ -108,20 +108,20 @@ func (c *Client) QueryFsSizeInfo(fileId types.SMB2_FILEID) (*ms_fscc.FileFsSizeI
 
 // SetEndOfFile sets the logical size of an open file (truncate or extend).
 func (c *Client) SetEndOfFile(fileId types.SMB2_FILEID, size int64) error {
-	buf, _ := (&ms_fscc.FileEndOfFileInformation{EndOfFile: size}).Marshal()
+	buf, _ := (&filesystem.FileEndOfFileInformation{EndOfFile: size}).Marshal()
 	return c.SetInfo(fileId, commands.SMB2_0_INFO_FILE, uint8(infoclass.FileEndOfFileInformation), 0, buf)
 }
 
 // SetDeleteOnClose marks (or unmarks) an open file for deletion when its last
 // handle is closed.
 func (c *Client) SetDeleteOnClose(fileId types.SMB2_FILEID, deletePending bool) error {
-	buf, _ := (&ms_fscc.FileDispositionInformation{DeletePending: deletePending}).Marshal()
+	buf, _ := (&filesystem.FileDispositionInformation{DeletePending: deletePending}).Marshal()
 	return c.SetInfo(fileId, commands.SMB2_0_INFO_FILE, uint8(infoclass.FileDispositionInformation), 0, buf)
 }
 
 // RenameByHandle renames the open file to newName (share-relative). The handle
 // must have been opened with DELETE access.
 func (c *Client) RenameByHandle(fileId types.SMB2_FILEID, newName string, replaceIfExists bool) error {
-	buf, _ := (&ms_fscc.FileRenameInformation{ReplaceIfExists: replaceIfExists, FileName: newName}).Marshal()
+	buf, _ := (&filesystem.FileRenameInformation{ReplaceIfExists: replaceIfExists, FileName: newName}).Marshal()
 	return c.SetInfo(fileId, commands.SMB2_0_INFO_FILE, uint8(infoclass.FileRenameInformation), 0, buf)
 }

--- a/windows/filesystem/file_query_information.go
+++ b/windows/filesystem/file_query_information.go
@@ -1,4 +1,4 @@
-package ms_fscc
+package filesystem
 
 import (
 	"encoding/binary"

--- a/windows/filesystem/file_set_information.go
+++ b/windows/filesystem/file_set_information.go
@@ -1,4 +1,4 @@
-package ms_fscc
+package filesystem
 
 import (
 	"encoding/binary"

--- a/windows/filesystem/filesystem_test.go
+++ b/windows/filesystem/filesystem_test.go
@@ -1,4 +1,4 @@
-package ms_fscc
+package filesystem
 
 import (
 	"encoding/binary"

--- a/windows/filesystem/fs_information.go
+++ b/windows/filesystem/fs_information.go
@@ -1,4 +1,4 @@
-package ms_fscc
+package filesystem
 
 import (
 	"encoding/binary"

--- a/windows/filesystem/infoclass/infoclass.go
+++ b/windows/filesystem/infoclass/infoclass.go
@@ -1,7 +1,7 @@
 // Package infoclass holds the [MS-FSCC] FILE_INFORMATION_CLASS and
 // FILE_FS_*_INFORMATION class numbers used with SMB2 QUERY_INFO / SET_INFO. They
 // live in their own package so the class identifiers can keep their spec names
-// without colliding with the like-named structures in package ms_fscc.
+// without colliding with the like-named structures in package filesystem.
 package infoclass
 
 // FileInformationClass identifies a FILE_INFORMATION_CLASS used with the


### PR DESCRIPTION
### Summary
The `windows/ms_fscc` → `windows/filesystem` rename merged in #535 was only partial: the directory plus `doc.go`/`infoclass` were renamed, but the struct and test files still declared `package ms_fscc` and the SMB2 client still imported `windows/ms_fscc`. `main` does not compile (`found packages filesystem (doc.go) and ms_fscc (file_query_information.go)`; `no required module provides package .../windows/ms_fscc`).

### Fix
Finish the rename:
- `package filesystem` in `file_query_information.go`, `file_set_information.go`, `fs_information.go`, `filesystem_test.go`.
- `network/smb/smb_v20/client/{info,filemgmt}.go` import and reference `windows/filesystem`.
- Correct the stale package name in the `infoclass` doc comment.

### How Verified
`go build ./...`, `go vet`, `gofmt -l` clean; `windows/filesystem` and `network/smb/smb_v20/client` tests pass.

### Scope of Change
Mechanical rename completion only; no behavioral change.