### PR TITLE
SMB2: IOCTL + named-pipe transceive, enabling DCE/RPC over SMB2 (#534)

### DIFF
--- a/network/dcerpc/v5/transport/smb2/smb2_namedpipe.go
+++ b/network/dcerpc/v5/transport/smb2/smb2_namedpipe.go
@@ -1,0 +1,176 @@
+// Package smb2 implements the DCE/RPC ncacn_np protocol sequence over an SMB 2.x
+// named pipe.
+//
+// Per [MS-RPCE] 2.1.1.2, PDUs are exchanged as named-pipe writes and reads. This
+// transport uses the SMB2 FSCTL_PIPE_TRANSCEIVE optimization (the explicit MAY in
+// [MS-RPCE]): the last request PDU before a read is written and the reply read in
+// a single round-trip. Earlier fragments of a multi-fragment request are written
+// with ordinary pipe writes, and response fragments beyond the first are read with
+// ordinary pipe reads.
+//
+// It wraps an already-connected and authenticated SMB 2.x client whose tree is
+// connected to IPC$; that session's lifecycle is owned by the caller.
+package smb2
+
+import (
+	"fmt"
+	"strings"
+
+	dcerpctransport "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/transport"
+	smb2client "github.com/TheManticoreProject/Manticore/network/smb/smb_v20/client"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/types"
+	"github.com/TheManticoreProject/Manticore/windows/fileflags"
+)
+
+// Default fragment sizes proposed at Bind time.
+const (
+	DefaultMaxXmitFrag uint16 = 4280
+	DefaultMaxRecvFrag uint16 = 4280
+)
+
+// pipeConn is the subset of *smb2client.Client the transport relies on. Expressing
+// it as an interface keeps the transport unit-testable with a fake.
+type pipeConn interface {
+	CreateFile(path string, desiredAccess, shareAccess, createDisposition, createOptions uint32) (types.SMB2_FILEID, error)
+	TransactNamedPipe(fileId types.SMB2_FILEID, input []byte, maxOutputResponse uint32) ([]byte, error)
+	WriteFile(fileId types.SMB2_FILEID, offset uint64, data []byte) (uint32, error)
+	ReadFile(fileId types.SMB2_FILEID, offset uint64, length uint32) ([]byte, error)
+	CloseFile(fileId types.SMB2_FILEID) error
+}
+
+// SMBNamedPipe is a DCE/RPC transport over an SMB 2.x named pipe (ncacn_np).
+type SMBNamedPipe struct {
+	conn     pipeConn
+	pipeName string
+	fileId   types.SMB2_FILEID
+	opened   bool
+	// pending holds the most recent Send; it is written (via transceive) on the
+	// next Recv, or flushed with a plain write if another Send arrives first.
+	pending []byte
+	maxXmit uint16
+	maxRecv uint16
+}
+
+var _ dcerpctransport.Transport = (*SMBNamedPipe)(nil)
+
+// New creates an SMB2 named-pipe transport over the supplied client. The client
+// MUST already be connected, authenticated, and tree-connected to IPC$.
+//
+// pipeName is the pipe endpoint (e.g. "srvsvc" or "\\PIPE\\lsarpc"); a leading
+// backslash and a "PIPE\\" prefix are stripped, as SMB2 names are share-relative.
+func New(c *smb2client.Client, pipeName string) *SMBNamedPipe {
+	return newWithConn(c, pipeName)
+}
+
+func newWithConn(conn pipeConn, pipeName string) *SMBNamedPipe {
+	pipeName = strings.TrimPrefix(pipeName, "\\")
+	if len(pipeName) >= 5 && strings.EqualFold(pipeName[:5], "PIPE\\") {
+		pipeName = pipeName[5:]
+	}
+	return &SMBNamedPipe{
+		conn:     conn,
+		pipeName: pipeName,
+		maxXmit:  DefaultMaxXmitFrag,
+		maxRecv:  DefaultMaxRecvFrag,
+	}
+}
+
+// SetMaxFrag overrides the fragment sizes proposed at Bind time. Call before Connect.
+func (p *SMBNamedPipe) SetMaxFrag(xmit, recv uint16) {
+	p.maxXmit = xmit
+	p.maxRecv = recv
+}
+
+// Connect opens the named pipe on the SMB tree. It is idempotent.
+func (p *SMBNamedPipe) Connect() error {
+	if p.opened {
+		return nil
+	}
+	fid, err := p.conn.CreateFile(
+		p.pipeName,
+		fileflags.GENERIC_READ|fileflags.GENERIC_WRITE,
+		fileflags.FILE_SHARE_READ|fileflags.FILE_SHARE_WRITE,
+		fileflags.FILE_OPEN,
+		0,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to open named pipe %q: %w", p.pipeName, err)
+	}
+	p.fileId = fid
+	p.opened = true
+	return nil
+}
+
+// Send queues a PDU. The PDU is transmitted on the next Recv via a single
+// transceive; if another Send arrives first (a multi-fragment request), the queued
+// fragment is flushed with an ordinary pipe write.
+func (p *SMBNamedPipe) Send(pdu []byte) error {
+	if !p.opened {
+		return fmt.Errorf("named pipe %q is not open: call Connect first", p.pipeName)
+	}
+	if len(pdu) == 0 {
+		return fmt.Errorf("refusing to send an empty PDU on named pipe %q", p.pipeName)
+	}
+	if p.pending != nil {
+		if err := p.writePending(); err != nil {
+			return err
+		}
+	}
+	p.pending = pdu
+	return nil
+}
+
+func (p *SMBNamedPipe) writePending() error {
+	written, err := p.conn.WriteFile(p.fileId, 0, p.pending)
+	if err != nil {
+		return fmt.Errorf("failed to write PDU to named pipe %q: %w", p.pipeName, err)
+	}
+	if int(written) != len(p.pending) {
+		return fmt.Errorf("short write to named pipe %q: wrote %d of %d bytes", p.pipeName, written, len(p.pending))
+	}
+	p.pending = nil
+	return nil
+}
+
+// Recv returns the next chunk of the reply. The first Recv after a Send writes the
+// queued PDU and reads the reply in one transceive; subsequent Recv calls read
+// further response fragments with ordinary pipe reads.
+func (p *SMBNamedPipe) Recv() ([]byte, error) {
+	if !p.opened {
+		return nil, fmt.Errorf("named pipe %q is not open: call Connect first", p.pipeName)
+	}
+	if p.pending != nil {
+		out, err := p.conn.TransactNamedPipe(p.fileId, p.pending, uint32(p.maxRecv))
+		p.pending = nil
+		if err != nil {
+			return nil, fmt.Errorf("pipe transceive on %q failed: %w", p.pipeName, err)
+		}
+		return out, nil
+	}
+	data, err := p.conn.ReadFile(p.fileId, 0, uint32(p.maxRecv))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read from named pipe %q: %w", p.pipeName, err)
+	}
+	return data, nil
+}
+
+// Close closes the pipe handle, leaving the SMB session and tree connect intact.
+// It is idempotent.
+func (p *SMBNamedPipe) Close() error {
+	if !p.opened {
+		return nil
+	}
+	err := p.conn.CloseFile(p.fileId)
+	p.opened = false
+	p.pending = nil
+	if err != nil {
+		return fmt.Errorf("failed to close named pipe %q: %w", p.pipeName, err)
+	}
+	return nil
+}
+
+// MaxXmitFrag returns the proposed maximum transmit fragment size.
+func (p *SMBNamedPipe) MaxXmitFrag() uint16 { return p.maxXmit }
+
+// MaxRecvFrag returns the proposed maximum receive fragment size.
+func (p *SMBNamedPipe) MaxRecvFrag() uint16 { return p.maxRecv }

--- a/network/dcerpc/v5/transport/smb2/smb2_namedpipe_test.go
+++ b/network/dcerpc/v5/transport/smb2/smb2_namedpipe_test.go
@@ -1,0 +1,114 @@
+package smb2
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/types"
+)
+
+// fakePipe records the operations the transport performs.
+type fakePipe struct {
+	created       bool
+	writes        [][]byte
+	transceiveIn  [][]byte
+	reads         int
+	closed        bool
+	transceiveOut []byte
+	readOut       []byte
+}
+
+func (f *fakePipe) CreateFile(string, uint32, uint32, uint32, uint32) (types.SMB2_FILEID, error) {
+	f.created = true
+	return types.SMB2_FILEID{}, nil
+}
+func (f *fakePipe) TransactNamedPipe(_ types.SMB2_FILEID, input []byte, _ uint32) ([]byte, error) {
+	f.transceiveIn = append(f.transceiveIn, append([]byte(nil), input...))
+	return f.transceiveOut, nil
+}
+func (f *fakePipe) WriteFile(_ types.SMB2_FILEID, _ uint64, data []byte) (uint32, error) {
+	f.writes = append(f.writes, append([]byte(nil), data...))
+	return uint32(len(data)), nil
+}
+func (f *fakePipe) ReadFile(types.SMB2_FILEID, uint64, uint32) ([]byte, error) {
+	f.reads++
+	return f.readOut, nil
+}
+func (f *fakePipe) CloseFile(types.SMB2_FILEID) error { f.closed = true; return nil }
+
+func TestSingleFragment_UsesTransceive(t *testing.T) {
+	f := &fakePipe{transceiveOut: []byte("ack")}
+	p := newWithConn(f, "samr")
+	if err := p.Connect(); err != nil || !f.created {
+		t.Fatalf("Connect: err=%v created=%v", err, f.created)
+	}
+	if err := p.Send([]byte("bind")); err != nil {
+		t.Fatal(err)
+	}
+	out, err := p.Recv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(f.writes) != 0 {
+		t.Errorf("expected no plain writes for a single fragment, got %d", len(f.writes))
+	}
+	if len(f.transceiveIn) != 1 || !bytes.Equal(f.transceiveIn[0], []byte("bind")) {
+		t.Errorf("expected one transceive of \"bind\", got %v", f.transceiveIn)
+	}
+	if !bytes.Equal(out, []byte("ack")) {
+		t.Errorf("Recv = %q, want \"ack\"", out)
+	}
+}
+
+func TestMultiFragment_FlushesPriorViaWrite(t *testing.T) {
+	f := &fakePipe{transceiveOut: []byte("resp")}
+	p := newWithConn(f, "samr")
+	p.Connect()
+	p.Send([]byte("frag1"))
+	p.Send([]byte("frag2")) // flushes frag1 via a plain write
+	out, err := p.Recv()    // transceives frag2
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(f.writes) != 1 || !bytes.Equal(f.writes[0], []byte("frag1")) {
+		t.Errorf("expected frag1 written via WriteFile, got %v", f.writes)
+	}
+	if len(f.transceiveIn) != 1 || !bytes.Equal(f.transceiveIn[0], []byte("frag2")) {
+		t.Errorf("expected frag2 transceived, got %v", f.transceiveIn)
+	}
+	if !bytes.Equal(out, []byte("resp")) {
+		t.Errorf("Recv = %q, want \"resp\"", out)
+	}
+}
+
+func TestContinuationRead(t *testing.T) {
+	f := &fakePipe{transceiveOut: []byte("first"), readOut: []byte("more")}
+	p := newWithConn(f, "samr")
+	p.Connect()
+	p.Send([]byte("req"))
+	if _, err := p.Recv(); err != nil { // transceive
+		t.Fatal(err)
+	}
+	out, err := p.Recv() // no pending -> ReadFile
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.reads != 1 || !bytes.Equal(out, []byte("more")) {
+		t.Errorf("continuation read: reads=%d out=%q", f.reads, out)
+	}
+}
+
+func TestPipeNameNormalization(t *testing.T) {
+	for _, in := range []string{`\PIPE\lsarpc`, `\lsarpc`, `PIPE\lsarpc`, "lsarpc"} {
+		if p := newWithConn(&fakePipe{}, in); p.pipeName != "lsarpc" {
+			t.Errorf("pipe name %q normalized to %q, want \"lsarpc\"", in, p.pipeName)
+		}
+	}
+}
+
+func TestSendBeforeConnect(t *testing.T) {
+	p := newWithConn(&fakePipe{}, "samr")
+	if err := p.Send([]byte("x")); err == nil {
+		t.Error("expected error sending before Connect")
+	}
+}

--- a/network/smb/smb_v20/client/engine.go
+++ b/network/smb/smb_v20/client/engine.go
@@ -62,8 +62,10 @@ func (c *Client) sendReceive(msg *message.Message, label string) (*message.Messa
 
 	// Parse the header first to read the status. An SMB2 error response carries a
 	// fixed 9-byte SMB2 ERROR Response body (MS-SMB2 2.2.2), not the command-specific
-	// response, so the command body is decoded only for success and for the
-	// session-setup continuation status.
+	// response, so the command body is decoded only for statuses that carry a real
+	// command response: success, the session-setup continuation status, and
+	// STATUS_BUFFER_OVERFLOW (a warning the server returns from READ / IOCTL pipe
+	// transceive together with the partial data).
 	response := message.NewMessage()
 	if _, err = response.Header.Unmarshal(raw); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal %s response header: %w", label, err)
@@ -73,7 +75,7 @@ func (c *Client) sendReceive(msg *message.Message, label string) (*message.Messa
 	}
 
 	status := response.Header.Status
-	if status == 0x00000000 || status == ntStatusMoreProcessingRequired {
+	if status == 0x00000000 || status == ntStatusMoreProcessingRequired || status == ntStatusBufferOverflow {
 		if _, err = response.Unmarshal(raw); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal %s response: %w", label, err)
 		}

--- a/network/smb/smb_v20/client/ioctl.go
+++ b/network/smb/smb_v20/client/ioctl.go
@@ -1,0 +1,56 @@
+package client
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/types"
+	"github.com/TheManticoreProject/Manticore/windows/filesystem"
+)
+
+// Ioctl issues an SMB2 IOCTL on the open identified by fileId and returns the
+// output buffer. ctlCode is the control code; when isFsctl is true the
+// SMB2_0_IOCTL_IS_FSCTL flag is set (the usual case for FSCTL_* codes).
+// maxOutputResponse bounds the bytes the server may return.
+//
+// STATUS_BUFFER_OVERFLOW is treated as success: it is a warning that the output
+// did not fit, and the partial data that did fit is returned. Callers that need
+// the remainder (e.g. a pipe transceive whose reply spans multiple reads) issue
+// follow-up READs. Wire: SMB2 IOCTL.
+func (c *Client) Ioctl(fileId types.SMB2_FILEID, ctlCode uint32, input []byte, isFsctl bool, maxOutputResponse uint32) ([]byte, error) {
+	if c.Session == nil || c.Session.TreeId == 0 {
+		return nil, fmt.Errorf("no tree connect established")
+	}
+
+	req := commands.NewIoctlRequest()
+	req.CtlCode = types.ULONG(ctlCode)
+	req.FileId = fileId
+	req.Input = input
+	req.MaxOutputResponse = types.ULONG(maxOutputResponse)
+	if isFsctl {
+		req.Flags = commands.SMB2_0_IOCTL_IS_FSCTL
+	}
+
+	response, err := c.sendReceive(c.newRequest(req), "Ioctl")
+	if err != nil {
+		return nil, err
+	}
+	if status := statusFromResponse(response); status != 0x00000000 && status != ntStatusBufferOverflow {
+		return nil, fmt.Errorf("ioctl 0x%08x failed: %s", ctlCode, formatNTStatus(status))
+	}
+
+	ioctlResponse, ok := response.Command.(*commands.IoctlResponse)
+	if !ok {
+		return nil, fmt.Errorf("unexpected ioctl response command: %T", response.Command)
+	}
+	return ioctlResponse.Output, nil
+}
+
+// TransactNamedPipe writes a message to the named pipe identified by fileId and
+// returns the pipe's reply in a single round-trip, via FSCTL_PIPE_TRANSCEIVE. It
+// is the SMB2 basis for DCE/RPC over named pipes (ncacn_np). If the reply exceeds
+// maxOutputResponse the returned data is the portion that fit; the caller reads
+// the remainder with ReadFile.
+func (c *Client) TransactNamedPipe(fileId types.SMB2_FILEID, input []byte, maxOutputResponse uint32) ([]byte, error) {
+	return c.Ioctl(fileId, filesystem.FSCTL_PIPE_TRANSCEIVE, input, true, maxOutputResponse)
+}

--- a/network/smb/smb_v20/client/session.go
+++ b/network/smb/smb_v20/client/session.go
@@ -17,6 +17,11 @@ import (
 // (AUTHENTICATE) leg of the NTLM exchange.
 const ntStatusMoreProcessingRequired = 0xC0000016
 
+// ntStatusBufferOverflow (STATUS_BUFFER_OVERFLOW) is a warning, not an error: the
+// server returns it from READ and from an IOCTL pipe transceive together with the
+// partial data that did fit, signalling that more remains to be read.
+const ntStatusBufferOverflow = 0x80000005
+
 // SessionSetup authenticates a session with the server using NTLM over SPNEGO,
 // the SMB2 analog of the SMB 1.0 extended-security session setup. It performs the
 // two-leg NEGOTIATE -> CHALLENGE -> AUTHENTICATE exchange, capturing the

--- a/windows/filesystem/fsctl.go
+++ b/windows/filesystem/fsctl.go
@@ -1,0 +1,34 @@
+package filesystem
+
+// FSCTL control codes carried in an SMB2 IOCTL request (with the
+// SMB2_0_IOCTL_IS_FSCTL flag) or issued locally via DeviceIoControl.
+//
+// [MS-FSCC] 2.3 FSCTL Structures:
+// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/9d34c7c6-c0f6-46b4-9c00-c8b78f3b3041
+const (
+	// FSCTL_PIPE_TRANSCEIVE writes a message to a named pipe and reads the reply in
+	// a single round-trip — the basis of DCE/RPC over SMB2 (ncacn_np).
+	FSCTL_PIPE_TRANSCEIVE uint32 = 0x0011C017
+	// FSCTL_PIPE_WAIT waits for a named-pipe instance to become available.
+	FSCTL_PIPE_WAIT uint32 = 0x00110018
+	// FSCTL_PIPE_PEEK reads data from a named pipe without removing it.
+	FSCTL_PIPE_PEEK uint32 = 0x0011400C
+
+	// FSCTL_DFS_GET_REFERRALS requests the DFS referrals for a path.
+	FSCTL_DFS_GET_REFERRALS    uint32 = 0x00060194
+	FSCTL_DFS_GET_REFERRALS_EX uint32 = 0x000601B0
+
+	// FSCTL_VALIDATE_NEGOTIATE_INFO confirms the negotiated dialect/capabilities
+	// were not tampered with (SMB 3.x).
+	FSCTL_VALIDATE_NEGOTIATE_INFO uint32 = 0x00140204
+
+	// Server-side copy.
+	FSCTL_SRV_REQUEST_RESUME_KEY  uint32 = 0x00140078
+	FSCTL_SRV_COPYCHUNK           uint32 = 0x001440F2
+	FSCTL_SRV_COPYCHUNK_WRITE     uint32 = 0x001480F2
+	FSCTL_SRV_ENUMERATE_SNAPSHOTS uint32 = 0x00144064
+
+	// Reparse points.
+	FSCTL_GET_REPARSE_POINT uint32 = 0x000900A8
+	FSCTL_SET_REPARSE_POINT uint32 = 0x000900A4
+)


### PR DESCRIPTION
### Linked Issue
Part of #534 (complete the SMB 2.0 client).

### Summary
Wires the SMB2 client's IOCTL path and uses it to run DCE/RPC over SMB2 named pipes (ncacn_np) — previously only available over SMB1.

### Changes
- `windows/filesystem/fsctl.go`: FSCTL control codes ([MS-FSCC 2.3](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/9d34c7c6-c0f6-46b4-9c00-c8b78f3b3041)), including `FSCTL_PIPE_TRANSCEIVE`.
- `smb_v20` client: `Ioctl` primitive (IOCTL/FSCTL → output buffer) and `TransactNamedPipe` (FSCTL_PIPE_TRANSCEIVE — write a pipe message and read the reply in one round-trip).
- Engine: decode the command body on `STATUS_BUFFER_OVERFLOW` (a warning returned from READ / pipe transceive alongside the partial data).
- `network/dcerpc/v5/transport/smb2`: a DCE/RPC ncacn_np transport over SMB2 mirroring the SMB1 one. It transceives the last request fragment with the first read in a single round-trip; earlier request fragments are written and later response fragments are read with ordinary pipe writes/reads.

### How Verified
- `go build ./...`, `go vet`, `gofmt -l` clean; transport framing covered by unit tests with a fake pipe.
- **Live-validated against Windows Server 2016:** a DCE/RPC Bind to SAMR over SMB2 via `FSCTL_PIPE_TRANSCEIVE` succeeds end to end (IPC\$ → \\samr → bind → bind_ack).

### Scope of Change
- New: `windows/filesystem/fsctl.go`, `network/smb/smb_v20/client/ioctl.go`, `network/dcerpc/v5/transport/smb2/**`
- Modified: `network/smb/smb_v20/client/{engine,session}.go` (STATUS_BUFFER_OVERFLOW body decode + constant)

### Notes
Built on top of the `windows/filesystem` rename completion (#536), which fixed a non-building `main`.