### PR TITLE
SMB2: ECHO, FLUSH, and byte-range LOCK/UNLOCK (#534)

### DIFF
--- a/network/smb/smb_v20/client/echo.go
+++ b/network/smb/smb_v20/client/echo.go
@@ -1,0 +1,21 @@
+package client
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/message/commands"
+)
+
+// Echo sends an SMB2 ECHO and waits for the reply. ECHO carries no data; it is a
+// keepalive that confirms the connection (and, if established, the session) is
+// still alive. Wire: SMB2 ECHO.
+func (c *Client) Echo() error {
+	response, err := c.sendReceive(c.newRequest(commands.NewEchoRequest()), "Echo")
+	if err != nil {
+		return err
+	}
+	if status := statusFromResponse(response); status != 0x00000000 {
+		return fmt.Errorf("echo failed: %s", formatNTStatus(status))
+	}
+	return nil
+}

--- a/network/smb/smb_v20/client/flush.go
+++ b/network/smb/smb_v20/client/flush.go
@@ -1,0 +1,28 @@
+package client
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/types"
+)
+
+// Flush issues an SMB2 FLUSH, asking the server to commit any buffered data for
+// the open file to stable storage before returning. Wire: SMB2 FLUSH.
+func (c *Client) Flush(fileId types.SMB2_FILEID) error {
+	if c.Session == nil || c.Session.TreeId == 0 {
+		return fmt.Errorf("no tree connect established")
+	}
+
+	req := commands.NewFlushRequest()
+	req.FileId = fileId
+
+	response, err := c.sendReceive(c.newRequest(req), "Flush")
+	if err != nil {
+		return err
+	}
+	if status := statusFromResponse(response); status != 0x00000000 {
+		return fmt.Errorf("flush failed: %s", formatNTStatus(status))
+	}
+	return nil
+}

--- a/network/smb/smb_v20/client/lock.go
+++ b/network/smb/smb_v20/client/lock.go
@@ -1,0 +1,54 @@
+package client
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/types"
+)
+
+// Lock acquires a byte-range lock on the open file: a shared (read) lock when
+// exclusive is false, or an exclusive (write) lock when true. By default the
+// server blocks until the range is available; when failImmediately is set, a
+// conflicting range returns STATUS_LOCK_NOT_GRANTED instead of waiting.
+// Wire: SMB2 LOCK.
+func (c *Client) Lock(fileId types.SMB2_FILEID, offset, length uint64, exclusive, failImmediately bool) error {
+	flags := uint32(commands.SMB2_LOCKFLAG_SHARED_LOCK)
+	if exclusive {
+		flags = commands.SMB2_LOCKFLAG_EXCLUSIVE_LOCK
+	}
+	if failImmediately {
+		flags |= commands.SMB2_LOCKFLAG_FAIL_IMMEDIATELY
+	}
+	return c.lock(fileId, offset, length, flags)
+}
+
+// Unlock releases a byte-range lock previously acquired with Lock. The offset and
+// length MUST exactly match a locked range. Wire: SMB2 LOCK (unlock flag).
+func (c *Client) Unlock(fileId types.SMB2_FILEID, offset, length uint64) error {
+	return c.lock(fileId, offset, length, commands.SMB2_LOCKFLAG_UNLOCK)
+}
+
+// lock issues an SMB2 LOCK with a single lock element carrying the given flags.
+func (c *Client) lock(fileId types.SMB2_FILEID, offset, length uint64, flags uint32) error {
+	if c.Session == nil || c.Session.TreeId == 0 {
+		return fmt.Errorf("no tree connect established")
+	}
+
+	req := commands.NewLockRequest()
+	req.FileId = fileId
+	req.Locks = []commands.LockElement{{
+		Offset: types.UINT64(offset),
+		Length: types.UINT64(length),
+		Flags:  types.ULONG(flags),
+	}}
+
+	response, err := c.sendReceive(c.newRequest(req), "Lock")
+	if err != nil {
+		return err
+	}
+	if status := statusFromResponse(response); status != 0x00000000 {
+		return fmt.Errorf("lock failed: %s", formatNTStatus(status))
+	}
+	return nil
+}


### PR DESCRIPTION
### Linked Issue
Part of #534 (complete the SMB 2.0 client).

### Summary
Wires three more SMB2 client operations, continuing parity with the SMB1 client:
- `Echo()` — SMB2 ECHO keepalive (no payload).
- `Flush(fileId)` — SMB2 FLUSH: commit an open file's buffered data to stable storage.
- `Lock(fileId, offset, length, exclusive, failImmediately)` / `Unlock(fileId, offset, length)` — SMB2 LOCK byte-range shared/exclusive locks via a single `SMB2_LOCK_ELEMENT`.

### How Verified
- `go build ./...`, `go vet`, `gofmt -l` clean.
- **Live-validated against Windows Server 2016:** Echo; Flush of a written file; an exclusive lock on one handle correctly **refusing** a conflicting lock from a second handle, then **granting** it after the first handle unlocks.

### Scope of Change
New: `network/smb/smb_v20/client/{echo,flush,lock}.go`. No changes elsewhere.