### PR TITLE
SMB2 engine: async STATUS_PENDING handling + large read/write chunking (#534)

### DIFF
--- a/network/smb/smb_v20/client/engine.go
+++ b/network/smb/smb_v20/client/engine.go
@@ -7,7 +7,6 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/message/commands/command_interface"
 )
 
-
 // newRequest builds an SMB2 request message with the header fields common to
 // every command: the next 64-bit MessageId on the connection, a one-credit
 // request (CreditCharge is 0 in the SMB 2.0.2 dialect), and — when a session is
@@ -55,43 +54,54 @@ func (c *Client) sendReceive(msg *message.Message, label string) (*message.Messa
 		return nil, fmt.Errorf("failed to send %s: %w", label, err)
 	}
 
-	raw, err := c.Transport.Receive()
-	if err != nil {
-		return nil, fmt.Errorf("failed to receive %s response: %w", label, err)
-	}
-
-	// Parse the header first to read the status. An SMB2 error response carries a
-	// fixed 9-byte SMB2 ERROR Response body (MS-SMB2 2.2.2), not the command-specific
-	// response, so the command body is decoded only for statuses that carry a real
-	// command response: success, the session-setup continuation status, and
-	// STATUS_BUFFER_OVERFLOW (a warning the server returns from READ / IOCTL pipe
-	// transceive together with the partial data).
+	// Receive the response. The server may first return one or more interim
+	// STATUS_PENDING responses (SMB2_FLAGS_ASYNC_COMMAND) for an operation it
+	// cannot complete immediately (a blocking lock, CHANGE_NOTIFY, a long IOCTL);
+	// each is verified and credited like any other response, then we keep reading
+	// until the final response arrives.
+	var raw []byte
 	response := message.NewMessage()
-	if _, err = response.Header.Unmarshal(raw); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal %s response header: %w", label, err)
-	}
-	if !response.Header.HasValidProtocolId() {
-		return nil, fmt.Errorf("%s response is not an SMB2 message (ProtocolId % x)", label, response.Header.ProtocolId)
+	for {
+		raw, err = c.Transport.Receive()
+		if err != nil {
+			return nil, fmt.Errorf("failed to receive %s response: %w", label, err)
+		}
+
+		response = message.NewMessage()
+		if _, err = response.Header.Unmarshal(raw); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal %s response header: %w", label, err)
+		}
+		if !response.Header.HasValidProtocolId() {
+			return nil, fmt.Errorf("%s response is not an SMB2 message (ProtocolId % x)", label, response.Header.ProtocolId)
+		}
+
+		// Verify the signature when signing is active and the server signed the
+		// response (interim and final responses are both signed).
+		if c.Session != nil && c.Session.SigningActive && response.Header.Flags.IsSigned() {
+			if !verifySignature(c.Session.SigningKey, raw) {
+				return nil, fmt.Errorf("%s response failed SMB2 signature verification", label)
+			}
+		}
+		// The server replenishes credits via the response Credit field.
+		if response.Header.Credit > 0 {
+			c.Connection.Credits = response.Header.Credit
+		}
+
+		if response.Header.Status != ntStatusPending {
+			break
+		}
 	}
 
+	// Decode the command body only for statuses that carry a real command response:
+	// success, the session-setup continuation status, and STATUS_BUFFER_OVERFLOW (a
+	// warning returned from READ / IOCTL pipe transceive with the partial data). An
+	// SMB2 error response carries a fixed 9-byte SMB2 ERROR Response body
+	// (MS-SMB2 2.2.2), not the command-specific response.
 	status := response.Header.Status
 	if status == 0x00000000 || status == ntStatusMoreProcessingRequired || status == ntStatusBufferOverflow {
 		if _, err = response.Unmarshal(raw); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal %s response: %w", label, err)
 		}
-	}
-
-	// Verify the response signature when signing is active and the server signed
-	// the response.
-	if c.Session != nil && c.Session.SigningActive && response.Header.Flags.IsSigned() {
-		if !verifySignature(c.Session.SigningKey, raw) {
-			return nil, fmt.Errorf("%s response failed SMB2 signature verification", label)
-		}
-	}
-
-	// The server replenishes credits via the response Credit field.
-	if response.Header.Credit > 0 {
-		c.Connection.Credits = response.Header.Credit
 	}
 
 	return response, nil

--- a/network/smb/smb_v20/client/file.go
+++ b/network/smb/smb_v20/client/file.go
@@ -75,6 +75,41 @@ func (c *Client) ReadFile(fileId types.SMB2_FILEID, offset uint64, length uint32
 		return nil, fmt.Errorf("no session established")
 	}
 
+	// A single READ is bounded by the negotiated MaxReadSize; satisfy a larger
+	// request by issuing successive reads until length bytes are read or the file
+	// ends. A request within MaxReadSize is a single read, as before.
+	maxRead := c.Connection.Server.MaxReadSize
+	if maxRead == 0 {
+		maxRead = 65536
+	}
+
+	out := make([]byte, 0, length)
+	remaining := length
+	pos := offset
+	for remaining > 0 {
+		chunk := remaining
+		if chunk > maxRead {
+			chunk = maxRead
+		}
+		data, eof, err := c.readChunk(fileId, pos, chunk)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, data...)
+		// Stop at end-of-file or a short read (the server returned less than was
+		// asked for, which for a pipe is one message and for a file is the tail).
+		if eof || len(data) == 0 || uint32(len(data)) < chunk {
+			break
+		}
+		pos += uint64(len(data))
+		remaining -= uint32(len(data))
+	}
+	return out, nil
+}
+
+// readChunk performs a single SMB2 READ of up to length bytes at offset. eof is
+// true when the server reports end-of-file (STATUS_END_OF_FILE).
+func (c *Client) readChunk(fileId types.SMB2_FILEID, offset uint64, length uint32) (data []byte, eof bool, err error) {
 	req := commands.NewReadRequest()
 	req.FileId = fileId
 	req.Offset = offset
@@ -83,20 +118,20 @@ func (c *Client) ReadFile(fileId types.SMB2_FILEID, offset uint64, length uint32
 
 	response, err := c.sendReceive(c.newRequest(req), "Read")
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	if status := statusFromResponse(response); status != 0x00000000 {
 		if status == ntStatusEndOfFile {
-			return []byte{}, nil
+			return nil, true, nil
 		}
-		return nil, fmt.Errorf("read failed: %s", formatNTStatus(status))
+		return nil, false, fmt.Errorf("read failed: %s", formatNTStatus(status))
 	}
 
 	readResponse, ok := response.Command.(*commands.ReadResponse)
 	if !ok {
-		return nil, fmt.Errorf("unexpected read response command: %T", response.Command)
+		return nil, false, fmt.Errorf("unexpected read response command: %T", response.Command)
 	}
-	return readResponse.Data, nil
+	return readResponse.Data, false, nil
 }
 
 // WriteFile writes data to the open at the given offset and returns the number of
@@ -106,6 +141,38 @@ func (c *Client) WriteFile(fileId types.SMB2_FILEID, offset uint64, data []byte)
 		return 0, fmt.Errorf("no session established")
 	}
 
+	// A single WRITE is bounded by the negotiated MaxWriteSize; split a larger
+	// payload across successive writes. A payload within MaxWriteSize is a single
+	// write, as before.
+	maxWrite := c.Connection.Server.MaxWriteSize
+	if maxWrite == 0 {
+		maxWrite = 65536
+	}
+
+	var total uint32
+	pos := offset
+	for len(data) > 0 {
+		n := uint32(len(data))
+		if n > maxWrite {
+			n = maxWrite
+		}
+		written, err := c.writeChunk(fileId, pos, data[:n])
+		if err != nil {
+			return total, err
+		}
+		total += written
+		pos += uint64(written)
+		data = data[written:]
+		if written == 0 {
+			break
+		}
+	}
+	return total, nil
+}
+
+// writeChunk performs a single SMB2 WRITE of data at offset and returns the
+// number of bytes the server accepted.
+func (c *Client) writeChunk(fileId types.SMB2_FILEID, offset uint64, data []byte) (uint32, error) {
 	req := commands.NewWriteRequest()
 	req.FileId = fileId
 	req.Offset = offset

--- a/network/smb/smb_v20/client/session.go
+++ b/network/smb/smb_v20/client/session.go
@@ -22,6 +22,12 @@ const ntStatusMoreProcessingRequired = 0xC0000016
 // partial data that did fit, signalling that more remains to be read.
 const ntStatusBufferOverflow = 0x80000005
 
+// ntStatusPending (STATUS_PENDING) is the interim status the server returns
+// (with SMB2_FLAGS_ASYNC_COMMAND set) for a request it cannot complete
+// immediately — a blocking lock, CHANGE_NOTIFY, a long IOCTL. The final response
+// follows once the operation completes.
+const ntStatusPending = 0x00000103
+
 // SessionSetup authenticates a session with the server using NTLM over SPNEGO,
 // the SMB2 analog of the SMB 1.0 extended-security session setup. It performs the
 // two-leg NEGOTIATE -> CHALLENGE -> AUTHENTICATE exchange, capturing the


### PR DESCRIPTION
### Linked Issue
Part of #534 (complete the SMB 2.0 client).

### Summary
Two engine-level improvements that the remaining operations (CHANGE_NOTIFY, large transfers) depend on.

- **Async (`STATUS_PENDING`)**: `sendReceive` loops over interim async responses. When the server can't complete a request immediately (blocking lock, CHANGE_NOTIFY, long IOCTL) it returns an interim `STATUS_PENDING` response (`SMB2_FLAGS_ASYNC_COMMAND`), then the final response later. Each interim response is signature-verified and credited; the client keeps reading until the final response arrives.
- **Large I/O**: `ReadFile`/`WriteFile` split transfers larger than the negotiated `MaxReadSize`/`MaxWriteSize` across successive READ/WRITE requests (a single request for transfers within the limit, as before). Reads stop at end-of-file or a short read.

### How Verified
- `go build ./...`, `go vet`, `gofmt -l` clean; existing smb_v20 suites pass.
- **Live-validated against Windows Server 2016** (MaxRead/MaxWrite = 65536):
  - a 143417-byte payload (> 2 chunks) written and read back across multiple chunks matches byte-for-byte;
  - a blocking byte-range lock held by connection A leaves connection B's conflicting lock **pending**, and B's lock is **granted** once A releases — exercising the interim-PENDING → final-response path end to end.

### Test Coverage
Live-validated (deterministic, including the two-connection blocking-lock scenario for the async path). Fake-transport unit tests for the chunking/PENDING loops were not added — they would require hand-built SMB2 response framing; deferred.

### Scope of Change
Modified: `network/smb/smb_v20/client/{engine,file,session}.go`.