### PR TITLE
SMB2: CHANGE_NOTIFY and CANCEL (#534)

### DIFF
--- a/network/smb/smb_v20/client/cancel.go
+++ b/network/smb/smb_v20/client/cancel.go
@@ -1,0 +1,54 @@
+package client
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/message"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/message/header/flags"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/types"
+)
+
+// Cancel requests cancellation of the operation currently awaiting an async
+// (STATUS_PENDING) completion on this connection — for example a blocked
+// ChangeNotify. It sends an SMB2 CANCEL carrying that request's MessageId and
+// AsyncId. CANCEL itself has no response; the cancelled operation instead
+// completes with STATUS_CANCELLED, which its blocked caller observes.
+//
+// Cancel is intended to be called from a different goroutine than the one blocked
+// in the operation. It returns an error if no operation is currently pending.
+// Wire: SMB2 CANCEL.
+func (c *Client) Cancel() error {
+	messageId, asyncId, ok := c.pendingAsync()
+	if !ok {
+		return fmt.Errorf("no async operation is pending to cancel")
+	}
+	if !c.Transport.IsConnected() {
+		return fmt.Errorf("cancel: transport is not connected")
+	}
+
+	// CANCEL reuses the target request's MessageId (it is matched to the
+	// outstanding request, not allocated a new sequence number) and carries the
+	// AsyncId in the ASYNC header form.
+	msg := message.NewMessage()
+	msg.Header.MessageId = messageId
+	msg.Header.Credit = 1
+	msg.Header.SetFlags(flags.SMB2_FLAGS_ASYNC_COMMAND)
+	msg.Header.SetAsyncId(types.UINT64(asyncId))
+	if c.Session != nil {
+		msg.Header.SessionId = c.Session.SessionId
+	}
+	msg.SetCommand(commands.NewCancelRequest())
+
+	marshalled, err := msg.Marshal()
+	if err != nil {
+		return fmt.Errorf("failed to marshal cancel: %w", err)
+	}
+	if c.Session != nil && c.Session.SigningActive {
+		signMessage(c.Session.SigningKey, marshalled)
+	}
+	if _, err := c.Transport.Send(marshalled); err != nil {
+		return fmt.Errorf("failed to send cancel: %w", err)
+	}
+	return nil
+}

--- a/network/smb/smb_v20/client/changenotify.go
+++ b/network/smb/smb_v20/client/changenotify.go
@@ -1,0 +1,65 @@
+package client
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/types"
+	"github.com/TheManticoreProject/Manticore/windows/filesystem"
+)
+
+// errChangeNotifyCancelled is returned by ChangeNotify when the wait is
+// interrupted by Cancel.
+var errChangeNotifyCancelled = fmt.Errorf("change notify cancelled")
+
+// IsChangeNotifyCancelled reports whether err is the error ChangeNotify returns
+// when it was interrupted by Cancel.
+func IsChangeNotifyCancelled(err error) bool {
+	return err == errChangeNotifyCancelled
+}
+
+// ChangeNotify monitors the directory open identified by fileId and blocks until a
+// change matching completionFilter (a combination of filesystem.FILE_NOTIFY_CHANGE_*
+// bits) occurs, then returns the changes. When watchTree is set the whole subtree
+// is monitored.
+//
+// The call blocks: the server registers the watch (replying STATUS_PENDING) and
+// sends the result only when a change happens. A concurrent Cancel interrupts the
+// wait, in which case ChangeNotify returns an error for which
+// IsChangeNotifyCancelled reports true. A STATUS_NOTIFY_ENUM_DIR result (too many
+// changes to report) returns no entries and no error; the caller should
+// re-enumerate. Wire: SMB2 CHANGE_NOTIFY.
+func (c *Client) ChangeNotify(fileId types.SMB2_FILEID, completionFilter uint32, watchTree bool) ([]filesystem.FileNotifyInformation, error) {
+	if c.Session == nil || c.Session.TreeId == 0 {
+		return nil, fmt.Errorf("no tree connect established")
+	}
+
+	req := commands.NewChangeNotifyRequest()
+	req.FileId = fileId
+	req.CompletionFilter = types.ULONG(completionFilter)
+	req.OutputBufferLength = types.ULONG(c.Connection.Server.MaxTransactSize)
+	if watchTree {
+		req.Flags = commands.SMB2_WATCH_TREE
+	}
+
+	response, err := c.sendReceive(c.newRequest(req), "ChangeNotify")
+	if err != nil {
+		return nil, err
+	}
+	switch status := statusFromResponse(response); status {
+	case 0x00000000:
+		// changes available below
+	case ntStatusCancelled:
+		return nil, errChangeNotifyCancelled
+	case ntStatusNotifyEnumDir:
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("change notify failed: %s", formatNTStatus(status))
+	}
+
+	notifyResponse, ok := response.Command.(*commands.ChangeNotifyResponse)
+	if !ok {
+		return nil, fmt.Errorf("unexpected change notify response command: %T", response.Command)
+	}
+	return filesystem.ParseFileNotifyInformation(notifyResponse.OutputBuffer), nil
+}

--- a/network/smb/smb_v20/client/client_structures.go
+++ b/network/smb/smb_v20/client/client_structures.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"net"
+	"sync"
 
 	"github.com/TheManticoreProject/Manticore/network/smb/common/transport"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/capabilities"
@@ -27,6 +28,37 @@ type Client struct {
 
 	// Workstation is the client workstation name used during NTLM authentication.
 	Workstation string
+
+	// asyncMu guards the identifiers of the request currently awaiting an async
+	// (STATUS_PENDING) completion, which Cancel reads to target a pending
+	// operation (for example a blocked CHANGE_NOTIFY). Only one operation is
+	// outstanding at a time on this synchronous client.
+	asyncMu          sync.Mutex
+	pendingMessageId uint64
+	pendingAsyncId   uint64
+	hasPendingAsync  bool
+}
+
+// setPendingAsync records the in-flight async operation so a concurrent Cancel
+// can target it.
+func (c *Client) setPendingAsync(messageId, asyncId uint64) {
+	c.asyncMu.Lock()
+	c.pendingMessageId, c.pendingAsyncId, c.hasPendingAsync = messageId, asyncId, true
+	c.asyncMu.Unlock()
+}
+
+// clearPendingAsync forgets any recorded in-flight async operation.
+func (c *Client) clearPendingAsync() {
+	c.asyncMu.Lock()
+	c.hasPendingAsync = false
+	c.asyncMu.Unlock()
+}
+
+// pendingAsync returns the recorded in-flight async operation's identifiers.
+func (c *Client) pendingAsync() (messageId, asyncId uint64, ok bool) {
+	c.asyncMu.Lock()
+	defer c.asyncMu.Unlock()
+	return c.pendingMessageId, c.pendingAsyncId, c.hasPendingAsync
 }
 
 // Connection represents an established SMB2 connection between client and server.

--- a/network/smb/smb_v20/client/engine.go
+++ b/network/smb/smb_v20/client/engine.go
@@ -90,7 +90,12 @@ func (c *Client) sendReceive(msg *message.Message, label string) (*message.Messa
 		if response.Header.Status != ntStatusPending {
 			break
 		}
+		// Record this interim async operation so a concurrent Cancel can target it
+		// (e.g. to interrupt a blocked CHANGE_NOTIFY), then wait for the final
+		// response.
+		c.setPendingAsync(msg.Header.MessageId, uint64(response.Header.GetAsyncId()))
 	}
+	c.clearPendingAsync()
 
 	// Decode the command body only for statuses that carry a real command response:
 	// success, the session-setup continuation status, and STATUS_BUFFER_OVERFLOW (a

--- a/network/smb/smb_v20/client/session.go
+++ b/network/smb/smb_v20/client/session.go
@@ -28,6 +28,15 @@ const ntStatusBufferOverflow = 0x80000005
 // follows once the operation completes.
 const ntStatusPending = 0x00000103
 
+// ntStatusCancelled (STATUS_CANCELLED) is the final status of a request that was
+// cancelled via SMB2 CANCEL (e.g. a blocked CHANGE_NOTIFY).
+const ntStatusCancelled = 0xC0000120
+
+// ntStatusNotifyEnumDir (STATUS_NOTIFY_ENUM_DIR) is returned from CHANGE_NOTIFY
+// when too many changes occurred to report individually; the client should
+// re-enumerate the directory. The output buffer is empty.
+const ntStatusNotifyEnumDir = 0x0000010C
+
 // SessionSetup authenticates a session with the server using NTLM over SPNEGO,
 // the SMB2 analog of the SMB 1.0 extended-security session setup. It performs the
 // two-leg NEGOTIATE -> CHALLENGE -> AUTHENTICATE exchange, capturing the

--- a/windows/filesystem/notify.go
+++ b/windows/filesystem/notify.go
@@ -1,0 +1,93 @@
+package filesystem
+
+import (
+	"encoding/binary"
+	"unicode/utf16"
+)
+
+// CompletionFilter flags for a directory change notification: the set of changes
+// to report (SMB2 CHANGE_NOTIFY CompletionFilter / FILE_NOTIFY_CHANGE_*).
+//
+// [MS-SMB2] 2.2.35 SMB2 CHANGE_NOTIFY Request:
+// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/598f395a-e7a2-4cc8-afb3-ccb30dd2df7c
+const (
+	FILE_NOTIFY_CHANGE_FILE_NAME    uint32 = 0x00000001
+	FILE_NOTIFY_CHANGE_DIR_NAME     uint32 = 0x00000002
+	FILE_NOTIFY_CHANGE_ATTRIBUTES   uint32 = 0x00000004
+	FILE_NOTIFY_CHANGE_SIZE         uint32 = 0x00000008
+	FILE_NOTIFY_CHANGE_LAST_WRITE   uint32 = 0x00000010
+	FILE_NOTIFY_CHANGE_LAST_ACCESS  uint32 = 0x00000020
+	FILE_NOTIFY_CHANGE_CREATION     uint32 = 0x00000040
+	FILE_NOTIFY_CHANGE_EA           uint32 = 0x00000080
+	FILE_NOTIFY_CHANGE_SECURITY     uint32 = 0x00000100
+	FILE_NOTIFY_CHANGE_STREAM_NAME  uint32 = 0x00000200
+	FILE_NOTIFY_CHANGE_STREAM_SIZE  uint32 = 0x00000400
+	FILE_NOTIFY_CHANGE_STREAM_WRITE uint32 = 0x00000800
+)
+
+// FileAction is the change reported for a directory entry in a
+// FILE_NOTIFY_INFORMATION record.
+type FileAction uint32
+
+const (
+	FileActionAdded          FileAction = 0x00000001
+	FileActionRemoved        FileAction = 0x00000002
+	FileActionModified       FileAction = 0x00000003
+	FileActionRenamedOldName FileAction = 0x00000004
+	FileActionRenamedNewName FileAction = 0x00000005
+)
+
+// String renders the action name.
+func (a FileAction) String() string {
+	switch a {
+	case FileActionAdded:
+		return "ADDED"
+	case FileActionRemoved:
+		return "REMOVED"
+	case FileActionModified:
+		return "MODIFIED"
+	case FileActionRenamedOldName:
+		return "RENAMED_OLD_NAME"
+	case FileActionRenamedNewName:
+		return "RENAMED_NEW_NAME"
+	}
+	return "UNKNOWN"
+}
+
+// FileNotifyInformation is one FILE_NOTIFY_INFORMATION record: a change to a named
+// entry within a watched directory.
+//
+// [MS-FSCC] 2.7.1 FILE_NOTIFY_INFORMATION:
+// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/634043d7-7b39-47e9-9e26-bda64685e4c9
+type FileNotifyInformation struct {
+	Action   FileAction
+	FileName string // directory-relative, backslash-separated
+}
+
+// ParseFileNotifyInformation decodes a buffer of chained FILE_NOTIFY_INFORMATION
+// records (as returned by SMB2 CHANGE_NOTIFY) into FileNotifyInformation values.
+// FileName is UTF-16LE.
+func ParseFileNotifyInformation(buf []byte) []FileNotifyInformation {
+	var out []FileNotifyInformation
+	for pos := 0; pos+12 <= len(buf); {
+		next := int(binary.LittleEndian.Uint32(buf[pos : pos+4]))
+		action := FileAction(binary.LittleEndian.Uint32(buf[pos+4 : pos+8]))
+		nameLen := int(binary.LittleEndian.Uint32(buf[pos+8 : pos+12]))
+
+		name := ""
+		if nameLen > 0 && pos+12+nameLen <= len(buf) {
+			u16 := make([]uint16, nameLen/2)
+			for i := range u16 {
+				u16[i] = binary.LittleEndian.Uint16(buf[pos+12+i*2:])
+			}
+			name = string(utf16.Decode(u16))
+		}
+		out = append(out, FileNotifyInformation{Action: action, FileName: name})
+
+		if next == 0 {
+			break
+		}
+		pos += next
+	}
+	return out
+}

--- a/windows/filesystem/notify_test.go
+++ b/windows/filesystem/notify_test.go
@@ -1,0 +1,54 @@
+package filesystem
+
+import (
+	"encoding/binary"
+	"testing"
+	"unicode/utf16"
+)
+
+// notifyEntry builds one FILE_NOTIFY_INFORMATION record. next is written to
+// NextEntryOffset verbatim.
+func notifyEntry(action FileAction, name string, next uint32) []byte {
+	u16 := utf16.Encode([]rune(name))
+	nameBytes := make([]byte, len(u16)*2)
+	for i, u := range u16 {
+		binary.LittleEndian.PutUint16(nameBytes[i*2:], u)
+	}
+	e := make([]byte, 12+len(nameBytes))
+	binary.LittleEndian.PutUint32(e[0:4], next)
+	binary.LittleEndian.PutUint32(e[4:8], uint32(action))
+	binary.LittleEndian.PutUint32(e[8:12], uint32(len(nameBytes)))
+	copy(e[12:], nameBytes)
+	return e
+}
+
+func TestParseFileNotifyInformation(t *testing.T) {
+	first := notifyEntry(FileActionAdded, "a.txt", 0)
+	first[0] = byte(len(first)) // NextEntryOffset -> second entry
+	second := notifyEntry(FileActionModified, `sub\b.txt`, 0)
+
+	buf := append(append([]byte{}, first...), second...)
+	got := ParseFileNotifyInformation(buf)
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 entries, got %d: %+v", len(got), got)
+	}
+	if got[0].Action != FileActionAdded || got[0].FileName != "a.txt" {
+		t.Errorf("entry 0 = %+v", got[0])
+	}
+	if got[1].Action != FileActionModified || got[1].FileName != `sub\b.txt` {
+		t.Errorf("entry 1 = %+v", got[1])
+	}
+}
+
+func TestParseFileNotifyInformation_Empty(t *testing.T) {
+	if got := ParseFileNotifyInformation(nil); got != nil {
+		t.Errorf("expected nil for empty buffer, got %+v", got)
+	}
+}
+
+func TestFileActionString(t *testing.T) {
+	if FileActionAdded.String() != "ADDED" || FileActionRenamedNewName.String() != "RENAMED_NEW_NAME" {
+		t.Error("FileAction.String mismatch")
+	}
+}


### PR DESCRIPTION
### Linked Issue
Part of #534 (complete the SMB 2.0 client).

### Summary
Directory change notification and request cancellation, built on the engine's async `STATUS_PENDING` handling.

- **`ChangeNotify(fileId, completionFilter, watchTree)`** — SMB2 CHANGE_NOTIFY. The server registers the watch (interim `STATUS_PENDING`); the call blocks until a matching change, then returns the parsed `FILE_NOTIFY_INFORMATION` records. `STATUS_NOTIFY_ENUM_DIR` returns no entries (re-enumerate); a cancellation returns an error for which `IsChangeNotifyCancelled` is true.
- **`Cancel()`** — SMB2 CANCEL. Targets the operation currently awaiting an async completion, reusing its MessageId/AsyncId in the ASYNC header form. CANCEL has no response; the cancelled op completes with `STATUS_CANCELLED`. `sendReceive` records the in-flight async op's identifiers (mutex-guarded) so `Cancel` can be called from another goroutine while the op blocks (Go's `net.Conn` permits a concurrent write during a blocked read).
- **`windows/filesystem`** — `FILE_NOTIFY_INFORMATION` parser ([MS-FSCC 2.7.1](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/634043d7-7b39-47e9-9e26-bda64685e4c9)) + `FILE_NOTIFY_CHANGE_*` / `FILE_ACTION_*` constants.

### How Verified
- `go build ./...`, `go vet`, `gofmt -l` clean; parser unit-tested.
- **Live-validated against Windows Server 2016:** a watch firing `ADDED "trigger.txt"` for a file created from a second connection; and `Cancel` interrupting a blocked CHANGE_NOTIFY on a quiet directory (returns cancelled).

### Scope of Change
- New: `windows/filesystem/notify.go`, `network/smb/smb_v20/client/{changenotify,cancel}.go`
- Modified: `network/smb/smb_v20/client/{engine,client_structures,session}.go` (async-op tracking for Cancel; status constants)