### PR TITLE
SMB2: OPLOCK_BREAK handling + oplock requests at CREATE (#534)

### DIFF
--- a/network/smb/smb_v20/client/file.go
+++ b/network/smb/smb_v20/client/file.go
@@ -13,17 +13,34 @@ import (
 const ntStatusEndOfFile = 0xC0000011
 
 // CreateFile opens or creates a file (or pipe) on the currently connected tree
-// and returns the server-assigned FileId.
+// and returns the server-assigned FileId. It requests no oplock.
 //
 // The path is relative to the share root; a leading backslash is stripped (an
 // SMB2 CREATE name is share-relative). Wire: SMB2 CREATE.
 func (c *Client) CreateFile(path string, desiredAccess, shareAccess, createDisposition, createOptions uint32) (types.SMB2_FILEID, error) {
+	fileId, _, err := c.createFile(path, desiredAccess, shareAccess, createDisposition, createOptions, commands.SMB2_OPLOCK_LEVEL_NONE)
+	return fileId, err
+}
+
+// CreateFileWithOplock opens or creates a file like CreateFile but also requests
+// an oplock (one of commands.SMB2_OPLOCK_LEVEL_*) and returns the oplock level the
+// server granted. When the server later needs to break that oplock — because
+// another client opens the same file — it sends an OPLOCK_BREAK notification; the
+// caller observes it with WaitOplockBreak and replies with AcknowledgeOplockBreak.
+func (c *Client) CreateFileWithOplock(path string, desiredAccess, shareAccess, createDisposition, createOptions uint32, requestedOplock uint8) (types.SMB2_FILEID, uint8, error) {
+	return c.createFile(path, desiredAccess, shareAccess, createDisposition, createOptions, requestedOplock)
+}
+
+// createFile performs an SMB2 CREATE and returns the FileId and the granted oplock
+// level.
+func (c *Client) createFile(path string, desiredAccess, shareAccess, createDisposition, createOptions uint32, requestedOplock uint8) (types.SMB2_FILEID, uint8, error) {
 	var fileId types.SMB2_FILEID
 	if c.Session == nil || c.Session.TreeId == 0 {
-		return fileId, fmt.Errorf("no tree connect established")
+		return fileId, 0, fmt.Errorf("no tree connect established")
 	}
 
 	req := commands.NewCreateRequest()
+	req.RequestedOplockLevel = types.UCHAR(requestedOplock)
 	req.DesiredAccess = desiredAccess
 	req.ShareAccess = shareAccess
 	req.CreateDisposition = createDisposition
@@ -36,17 +53,17 @@ func (c *Client) CreateFile(path string, desiredAccess, shareAccess, createDispo
 
 	response, err := c.sendReceive(c.newRequest(req), "Create")
 	if err != nil {
-		return fileId, err
+		return fileId, 0, err
 	}
 	if status := statusFromResponse(response); status != 0x00000000 {
-		return fileId, fmt.Errorf("create %q failed: %s", path, formatNTStatus(status))
+		return fileId, 0, fmt.Errorf("create %q failed: %s", path, formatNTStatus(status))
 	}
 
 	createResponse, ok := response.Command.(*commands.CreateResponse)
 	if !ok {
-		return fileId, fmt.Errorf("unexpected create response command: %T", response.Command)
+		return fileId, 0, fmt.Errorf("unexpected create response command: %T", response.Command)
 	}
-	return createResponse.FileId, nil
+	return createResponse.FileId, uint8(createResponse.OplockLevel), nil
 }
 
 // CloseFile closes an open identified by FileId. Wire: SMB2 CLOSE.

--- a/network/smb/smb_v20/client/oplock.go
+++ b/network/smb/smb_v20/client/oplock.go
@@ -1,0 +1,81 @@
+package client
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/message"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/message/commands/codes"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/types"
+)
+
+// OplockBreak is a server-initiated oplock break: the open whose oplock is being
+// broken and the level the server is breaking it down to (one of
+// commands.SMB2_OPLOCK_LEVEL_*).
+type OplockBreak struct {
+	FileId   types.SMB2_FILEID
+	NewLevel uint8
+}
+
+// WaitOplockBreak reads the next unsolicited SMB2 OPLOCK_BREAK notification from
+// the server. The server sends one when another client opens a file on which this
+// client holds an oplock (granted via CreateFileWithOplock); the caller should
+// reply with AcknowledgeOplockBreak. WaitOplockBreak blocks until a notification
+// arrives and is therefore typically run on a dedicated goroutine; it must not run
+// concurrently with another operation that reads the connection.
+func (c *Client) WaitOplockBreak() (*OplockBreak, error) {
+	if !c.Transport.IsConnected() {
+		return nil, fmt.Errorf("transport is not connected")
+	}
+
+	raw, err := c.Transport.Receive()
+	if err != nil {
+		return nil, fmt.Errorf("failed to receive oplock break: %w", err)
+	}
+
+	msg := message.NewMessage()
+	if _, err := msg.Header.Unmarshal(raw); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal oplock break header: %w", err)
+	}
+	if !msg.Header.HasValidProtocolId() {
+		return nil, fmt.Errorf("oplock break is not an SMB2 message (ProtocolId % x)", msg.Header.ProtocolId)
+	}
+	if c.Session != nil && c.Session.SigningActive && msg.Header.Flags.IsSigned() {
+		if !verifySignature(c.Session.SigningKey, raw) {
+			return nil, fmt.Errorf("oplock break failed SMB2 signature verification")
+		}
+	}
+	if msg.Header.Command != codes.SMB2_OPLOCK_BREAK {
+		return nil, fmt.Errorf("expected an OPLOCK_BREAK notification, got command 0x%04x", uint16(msg.Header.Command))
+	}
+	if _, err := msg.Unmarshal(raw); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal oplock break: %w", err)
+	}
+	notify, ok := msg.Command.(*commands.OplockBreakResponse)
+	if !ok {
+		return nil, fmt.Errorf("unexpected oplock break command: %T", msg.Command)
+	}
+	return &OplockBreak{FileId: notify.FileId, NewLevel: uint8(notify.OplockLevel)}, nil
+}
+
+// AcknowledgeOplockBreak replies to an OPLOCK_BREAK notification, accepting the
+// reduced oplock level on the given open, and waits for the server's response.
+// Wire: SMB2 OPLOCK_BREAK Acknowledgment.
+func (c *Client) AcknowledgeOplockBreak(fileId types.SMB2_FILEID, oplockLevel uint8) error {
+	if c.Session == nil || c.Session.TreeId == 0 {
+		return fmt.Errorf("no tree connect established")
+	}
+
+	req := commands.NewOplockBreakRequest()
+	req.OplockLevel = types.UCHAR(oplockLevel)
+	req.FileId = fileId
+
+	response, err := c.sendReceive(c.newRequest(req), "OplockBreakAck")
+	if err != nil {
+		return err
+	}
+	if status := statusFromResponse(response); status != 0x00000000 {
+		return fmt.Errorf("oplock break acknowledgment failed: %s", formatNTStatus(status))
+	}
+	return nil
+}


### PR DESCRIPTION
### Linked Issue
Part of #534 — the last of the SMB2 client's command operations.

### Summary
The server-initiated oplock break flow:
- **`CreateFileWithOplock(...)`** requests an oplock (`commands.SMB2_OPLOCK_LEVEL_*`) at open and returns the level the server granted. `CreateFile` is unchanged (no oplock) and now delegates to a shared `createFile` helper.
- **`WaitOplockBreak()`** reads an unsolicited OPLOCK_BREAK notification (sent when another client opens a file this client holds an oplock on), returning the affected `FileId` and the level being broken to.
- **`AcknowledgeOplockBreak(fileId, level)`** replies with the OPLOCK_BREAK Acknowledgment and waits for the server's response.

### How Verified
- `go build ./...`, `go vet`, `gofmt -l` clean; existing smb_v20 suites pass.
- **Live-validated against Windows Server 2016:** connection A opens a file and is granted a **BATCH** oplock; connection B's open of the same file triggers a break (**to level II**) delivered to A; A acknowledges, and B's open then completes.

### Test Coverage
Live-validated (the break cycle inherently requires two connections + concurrency). Fake-transport unit tests were not added.

### Scope of Change
- New: `network/smb/smb_v20/client/oplock.go`
- Modified: `network/smb/smb_v20/client/file.go` (oplock-aware CREATE)