### PR TITLE
Fix SMB negotiation blocking on silently-dropped dialect probes (#530)

### DIFF
--- a/network/netbios/nbt/nbt.go
+++ b/network/netbios/nbt/nbt.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"time"
 
 	"github.com/TheManticoreProject/Manticore/network/netbios"
 )
@@ -11,7 +12,8 @@ import (
 // NBTTransport implements the Transport interface for NetBIOS over TCP
 // Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/45170055-a0cd-4910-9228-801d5bf7ac84
 type NBTTransport struct {
-	conn net.Conn
+	conn    net.Conn
+	timeout time.Duration
 }
 
 // NewNBTTransport creates a new NetBIOS over TCP transport
@@ -35,13 +37,23 @@ func (n *NBTTransport) Connect(ipaddr net.IP, port int) error {
 		address = fmt.Sprintf("[%s]:%d", ipaddr.String(), port)
 	}
 
-	conn, err := net.Dial("tcp", address)
+	conn, err := net.DialTimeout("tcp", address, n.timeout)
 	if err != nil {
 		return fmt.Errorf("failed to connect via TCP: %v", err)
 	}
 	n.conn = conn
 
 	return nil
+}
+
+// SetTimeout bounds Connect and each subsequent Receive: Connect fails if the
+// TCP connection cannot be established within d, and Receive fails if a frame
+// does not arrive within d. A non-positive d removes the bound (blocking I/O).
+func (n *NBTTransport) SetTimeout(d time.Duration) {
+	if d < 0 {
+		d = 0
+	}
+	n.timeout = d
 }
 
 // Close terminates the NetBIOS over TCP connection
@@ -78,6 +90,15 @@ func (n *NBTTransport) Send(data []byte) (int, error) {
 func (n *NBTTransport) Receive() ([]byte, error) {
 	if !n.IsConnected() {
 		return nil, fmt.Errorf("not connected")
+	}
+
+	// Apply the configured read deadline (a zero deadline blocks forever)
+	var deadline time.Time
+	if n.timeout > 0 {
+		deadline = time.Now().Add(n.timeout)
+	}
+	if err := n.conn.SetReadDeadline(deadline); err != nil {
+		return nil, fmt.Errorf("failed to set read deadline: %v", err)
 	}
 
 	// Read NetBIOS header

--- a/network/netbios/nbt/nbt_test.go
+++ b/network/netbios/nbt/nbt_test.go
@@ -3,6 +3,7 @@ package nbt_test
 import (
 	"net"
 	"testing"
+	"time"
 
 	"github.com/TheManticoreProject/Manticore/network/netbios/nbt"
 )
@@ -62,4 +63,41 @@ func TestNBTTransport_Send(t *testing.T) {
 	}
 
 	tr.Close()
+}
+
+func TestNBTTransport_ReceiveTimesOutOnSilentServer(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start test server: %v", err)
+	}
+	defer ln.Close()
+
+	// Accept the connection but never write anything.
+	go func() {
+		c, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer c.Close()
+		select {}
+	}()
+
+	addr := ln.Addr().(*net.TCPAddr)
+
+	tr := nbt.NewNBTTransport()
+	tr.SetTimeout(100 * time.Millisecond)
+	if err := tr.Connect(addr.IP, addr.Port); err != nil {
+		t.Fatalf("NBTTransport.Connect() error = %v", err)
+	}
+	defer tr.Close()
+
+	start := time.Now()
+	_, err = tr.Receive()
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("NBTTransport.Receive() should time out on a silent server, got nil error")
+	}
+	if elapsed > 5*time.Second {
+		t.Fatalf("NBTTransport.Receive() took %v to fail, want a bounded timeout", elapsed)
+	}
 }

--- a/network/smb/client/client.go
+++ b/network/smb/client/client.go
@@ -50,18 +50,27 @@ func Dial(host string, port int, opts Options) (*Client, error) {
 }
 
 // dialSMB2 connects with the SMB2 engine and performs its native negotiate.
+// The connect/negotiate exchange runs under the per-attempt dial timeout so a
+// server that silently drops the probe fails the attempt instead of blocking;
+// the bound is lifted once the dialect is established.
 func dialSMB2(ip net.IP, host string, port int, opts Options) (*Client, error) {
 	engine := smb2.NewClientUsingTCPTransport(ip, port)
 	if opts.Workstation != "" {
 		engine.Workstation = opts.Workstation
 	}
+	engine.Transport.SetTimeout(opts.dialTimeout())
 	if err := engine.Connect(ip, port); err != nil {
+		engine.Transport.Close()
 		return nil, fmt.Errorf("SMB2 connect/negotiate failed: %w", err)
 	}
+	engine.Transport.SetTimeout(0)
 	return &Client{backend: newSMB2Backend(engine), host: host, port: port, opts: opts}, nil
 }
 
 // dialSMB1 connects with the SMB1 engine and performs its native negotiate.
+// The connect/negotiate exchange runs under the per-attempt dial timeout so a
+// server that silently drops the probe fails the attempt instead of blocking;
+// the bound is lifted once the dialect is established.
 func dialSMB1(ip net.IP, host string, port int, opts Options) (*Client, error) {
 	engine := smb1.NewClientUsingTCPTransport(ip, port)
 	// The SMB1 session setup requires the NativeOS / NativeLanMan fields to be set.
@@ -70,9 +79,12 @@ func dialSMB1(ip net.IP, host string, port int, opts Options) (*Client, error) {
 	if opts.Workstation != "" {
 		engine.Workstation = opts.Workstation
 	}
+	engine.Transport.SetTimeout(opts.dialTimeout())
 	if err := engine.Connect(ip, port); err != nil {
+		engine.Transport.Close()
 		return nil, fmt.Errorf("SMB1 connect/negotiate failed: %w", err)
 	}
+	engine.Transport.SetTimeout(0)
 	return &Client{backend: newSMB1Backend(engine), host: host, port: port, opts: opts}, nil
 }
 

--- a/network/smb/client/negotiate.go
+++ b/network/smb/client/negotiate.go
@@ -102,6 +102,10 @@ func dialHighestInSet(host string, ip net.IP, port int, opts Options, prefs []sm
 	}
 
 	t := transport.NewTransport("tcp")
+	// Bound the connect/negotiate exchange so an unresponsive server fails the
+	// dial instead of blocking forever; finishSMB1/finishSMB2 lift the bound
+	// once the dialect is established.
+	t.SetTimeout(opts.dialTimeout())
 	if err := t.Connect(ip, port); err != nil {
 		return nil, fmt.Errorf("failed to connect to %s: %w", host, err)
 	}
@@ -198,6 +202,7 @@ func finishSMB1(t transport.Transport, ip net.IP, host string, port int, opts Op
 		t.Close()
 		return nil, err
 	}
+	t.SetTimeout(0) // negotiation is done; lift the per-attempt bound
 	return &Client{backend: newSMB1Backend(engine), host: host, port: port, opts: opts}, nil
 }
 
@@ -232,5 +237,6 @@ func finishSMB2(t transport.Transport, ip net.IP, host string, port int, opts Op
 		engine.Workstation = opts.Workstation
 	}
 	engine.ApplyNegotiateResponse(resp)
+	t.SetTimeout(0) // negotiation is done; lift the per-attempt bound
 	return &Client{backend: newSMB2Backend(engine), host: host, port: port, opts: opts}, nil
 }

--- a/network/smb/client/negotiate_test.go
+++ b/network/smb/client/negotiate_test.go
@@ -1,7 +1,9 @@
 package client
 
 import (
+	"net"
 	"testing"
+	"time"
 
 	"github.com/TheManticoreProject/Manticore/network/smb"
 )
@@ -41,5 +43,107 @@ func TestWantedFamilies(t *testing.T) {
 				t.Errorf("wantedFamilies(%v) = (%v,%v), want (%v,%v)", c.prefs, s1, s2, c.wantSMB1, c.want2)
 			}
 		})
+	}
+}
+
+func TestOptionsDialTimeout(t *testing.T) {
+	cases := []struct {
+		name string
+		in   time.Duration
+		want time.Duration
+	}{
+		{"zero applies default", 0, DefaultDialTimeout},
+		{"negative disables", -1, 0},
+		{"explicit value kept", 3 * time.Second, 3 * time.Second},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := (Options{DialTimeout: c.in}).dialTimeout(); got != c.want {
+				t.Errorf("Options{DialTimeout: %v}.dialTimeout() = %v, want %v", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+// TestDialStrictOrderFailsOnSilentServer reproduces the scenario of a server
+// that accepts the TCP connection but never answers a negotiate probe (e.g. an
+// SMB1-only host receiving an SMB2-framed request). Dial must fail within the
+// per-attempt bound instead of blocking forever.
+func TestDialStrictOrderFailsOnSilentServer(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start test server: %v", err)
+	}
+	defer ln.Close()
+
+	// Accept every probe connection but never write a response.
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			defer c.Close()
+		}
+	}()
+
+	addr := ln.Addr().(*net.TCPAddr)
+	done := make(chan error, 1)
+	go func() {
+		_, err := Dial(addr.IP.String(), addr.Port, Options{
+			Preferred:   []smb.SMBProtocolVersion{smb.SMB_VERSION_2_0_2, smb.SMB_VERSION_1_0},
+			Policy:      PolicyStrictOrder,
+			DialTimeout: 200 * time.Millisecond,
+		})
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("Dial should fail against a server that never answers, got nil error")
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("Dial blocked past the per-attempt bound against a silent server")
+	}
+}
+
+// TestDialHighestInSetFailsOnSilentServer is the PolicyHighestInSet variant:
+// the single multi-protocol negotiate must also fail within the bound.
+func TestDialHighestInSetFailsOnSilentServer(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start test server: %v", err)
+	}
+	defer ln.Close()
+
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			defer c.Close()
+		}
+	}()
+
+	addr := ln.Addr().(*net.TCPAddr)
+	done := make(chan error, 1)
+	go func() {
+		_, err := Dial(addr.IP.String(), addr.Port, Options{
+			Preferred:   []smb.SMBProtocolVersion{smb.SMB_VERSION_2_0_2, smb.SMB_VERSION_1_0},
+			Policy:      PolicyHighestInSet,
+			DialTimeout: 200 * time.Millisecond,
+		})
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("Dial should fail against a server that never answers, got nil error")
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("Dial blocked past the per-attempt bound against a silent server")
 	}
 }

--- a/network/smb/client/types.go
+++ b/network/smb/client/types.go
@@ -35,6 +35,30 @@ type Options struct {
 	// Workstation is the NetBIOS workstation name sent during authentication.
 	// When empty, a default is used.
 	Workstation string
+	// DialTimeout bounds each connect/negotiate attempt during Dial, so that a
+	// server which silently drops a probe (e.g. an SMB1-only host receiving an
+	// SMB2 negotiate) fails the attempt instead of blocking forever, letting
+	// PolicyStrictOrder move on to the next preferred version. The bound is
+	// lifted once negotiation completes, so it does not constrain long-blocking
+	// operations such as CHANGE_NOTIFY. Zero applies DefaultDialTimeout; a
+	// negative value disables the bound.
+	DialTimeout time.Duration
+}
+
+// DefaultDialTimeout is the per-attempt connect/negotiate bound applied when
+// Options.DialTimeout is zero.
+const DefaultDialTimeout = 10 * time.Second
+
+// dialTimeout resolves the effective per-attempt bound from the options: zero
+// means DefaultDialTimeout, negative means unbounded.
+func (o Options) dialTimeout() time.Duration {
+	switch {
+	case o.DialTimeout < 0:
+		return 0
+	case o.DialTimeout == 0:
+		return DefaultDialTimeout
+	}
+	return o.DialTimeout
 }
 
 // FileHandle is an opaque, version-agnostic handle to an open file. The backend

--- a/network/smb/common/transport/transport.go
+++ b/network/smb/common/transport/transport.go
@@ -3,6 +3,7 @@ package transport
 import (
 	"net"
 	"strings"
+	"time"
 
 	"github.com/TheManticoreProject/Manticore/network/netbios/nbt"
 	"github.com/TheManticoreProject/Manticore/network/tcp"
@@ -18,6 +19,12 @@ type Transport interface {
 	Receive() ([]byte, error)
 
 	IsConnected() bool
+
+	// SetTimeout bounds Connect and each subsequent Receive: Connect fails if
+	// the connection cannot be established within d, and Receive fails if a
+	// frame does not arrive within d. A non-positive d removes the bound
+	// (blocking I/O), which is the initial state of every transport.
+	SetTimeout(d time.Duration)
 }
 
 func NewTransport(transportType string) Transport {

--- a/network/smb/common/transport/transport_test.go
+++ b/network/smb/common/transport/transport_test.go
@@ -3,6 +3,7 @@ package transport_test
 import (
 	"net"
 	"testing"
+	"time"
 
 	"github.com/TheManticoreProject/Manticore/network/smb/common/transport"
 )
@@ -49,6 +50,8 @@ func (m *MockTransport) Receive() ([]byte, error) {
 func (m *MockTransport) IsConnected() bool {
 	return m.connected
 }
+
+func (m *MockTransport) SetTimeout(time.Duration) {}
 
 func TestNewTransport(t *testing.T) {
 	tests := []struct {

--- a/network/smb/smb_v10/client/client_test.go
+++ b/network/smb/smb_v10/client/client_test.go
@@ -3,6 +3,7 @@ package client_test
 import (
 	"net"
 	"testing"
+	"time"
 
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/client"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message"
@@ -21,6 +22,7 @@ func (m *connectedMockTransport) Close() error                          { return
 func (m *connectedMockTransport) Send(data []byte) (int, error)         { return len(data), nil }
 func (m *connectedMockTransport) Receive() ([]byte, error)              { return nil, nil }
 func (m *connectedMockTransport) IsConnected() bool                     { return true }
+func (m *connectedMockTransport) SetTimeout(time.Duration)              {}
 
 // scriptedTransport reports itself as connected, returns a preset payload from
 // Receive, and counts how many times Send is called so a test can assert how
@@ -35,6 +37,7 @@ func (m *scriptedTransport) Close() error                          { return nil 
 func (m *scriptedTransport) Send(data []byte) (int, error)         { m.sendCount++; return len(data), nil }
 func (m *scriptedTransport) Receive() ([]byte, error)              { return m.response, nil }
 func (m *scriptedTransport) IsConnected() bool                     { return true }
+func (m *scriptedTransport) SetTimeout(time.Duration)              {}
 
 // TestSessionSetupShareLevelCompletesInOneRoundTrip verifies that, when the
 // server uses share-level access control, SessionSetup completes after the

--- a/network/smb/smb_v10/client/file_test.go
+++ b/network/smb/smb_v10/client/file_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"net"
 	"testing"
+	"time"
 
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/client"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message"
@@ -27,6 +28,7 @@ func (m *capturingTransport) Send(data []byte) (int, error) {
 }
 func (m *capturingTransport) Receive() ([]byte, error) { return m.response, nil }
 func (m *capturingTransport) IsConnected() bool        { return true }
+func (m *capturingTransport) SetTimeout(time.Duration) {}
 
 func newSessionClient(tr *capturingTransport) *client.Client {
 	c := &client.Client{

--- a/network/smb/smb_v10/client/find_fragment_test.go
+++ b/network/smb/smb_v10/client/find_fragment_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"net"
 	"testing"
+	"time"
 
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
@@ -25,6 +26,7 @@ func (m *recordingTransport) Send(data []byte) (int, error) {
 }
 func (m *recordingTransport) Receive() ([]byte, error) { return m.response, nil }
 func (m *recordingTransport) IsConnected() bool        { return true }
+func (m *recordingTransport) SetTimeout(time.Duration) {}
 
 func TestPlanTransaction2Chunks(t *testing.T) {
 	// Reassembling the chunk runs by displacement must reproduce the inputs, every

--- a/network/smb/smb_v10/client/negotiate_test.go
+++ b/network/smb/smb_v10/client/negotiate_test.go
@@ -3,6 +3,7 @@ package client_test
 import (
 	"net"
 	"testing"
+	"time"
 
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/client"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message"
@@ -22,6 +23,7 @@ func (m *cannedTransport) Close() error                          { return nil }
 func (m *cannedTransport) Send(data []byte) (int, error)         { return len(data), nil }
 func (m *cannedTransport) Receive() ([]byte, error)              { return m.response, nil }
 func (m *cannedTransport) IsConnected() bool                     { return true }
+func (m *cannedTransport) SetTimeout(time.Duration)              {}
 
 // TestNegotiateRejectsErrorStatus verifies that Negotiate returns an error when
 // the server's NEGOTIATE response carries a non-zero Header.Status, rather than

--- a/network/smb/smb_v20/client/negotiate_test.go
+++ b/network/smb/smb_v20/client/negotiate_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"net"
 	"testing"
+	"time"
 
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/dialects"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/message"
@@ -23,6 +24,7 @@ type fakeTransport struct {
 func (f *fakeTransport) Connect(net.IP, int) error { f.connected = true; return nil }
 func (f *fakeTransport) Close() error              { f.connected = false; return nil }
 func (f *fakeTransport) IsConnected() bool         { return f.connected }
+func (f *fakeTransport) SetTimeout(time.Duration)  {}
 func (f *fakeTransport) Send(data []byte) (int, error) {
 	f.sent = append(f.sent, append([]byte{}, data...))
 	return len(data), nil

--- a/network/tcp/tcp.go
+++ b/network/tcp/tcp.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"time"
 )
 
 // MaxDirectTCPPayloadSize caps the payload size accepted from a single Direct TCP frame.
@@ -15,7 +16,8 @@ const MaxDirectTCPPayloadSize = 1 * 1024 * 1024
 // TCPTransport implements the Transport interface for Direct TCP transport
 // Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb/f906c680-330c-43ae-9a71-f854e24aeee6
 type TCPTransport struct {
-	conn net.Conn
+	conn    net.Conn
+	timeout time.Duration
 }
 
 // NewTCPTransport creates a new Direct TCP transport
@@ -39,13 +41,23 @@ func (t *TCPTransport) Connect(ipaddr net.IP, port int) error {
 		address = fmt.Sprintf("[%s]:%d", ipaddr.String(), port)
 	}
 
-	conn, err := net.Dial("tcp", address)
+	conn, err := net.DialTimeout("tcp", address, t.timeout)
 	if err != nil {
 		return fmt.Errorf("failed to connect via TCP: %v", err)
 	}
 	t.conn = conn
 
 	return nil
+}
+
+// SetTimeout bounds Connect and each subsequent Receive: Connect fails if the
+// TCP connection cannot be established within d, and Receive fails if a frame
+// does not arrive within d. A non-positive d removes the bound (blocking I/O).
+func (t *TCPTransport) SetTimeout(d time.Duration) {
+	if d < 0 {
+		d = 0
+	}
+	t.timeout = d
 }
 
 // Close terminates the Direct TCP connection
@@ -80,6 +92,15 @@ func (t *TCPTransport) Send(data []byte) (int, error) {
 func (t *TCPTransport) Receive() ([]byte, error) {
 	if !t.IsConnected() {
 		return nil, fmt.Errorf("not connected")
+	}
+
+	// Apply the configured read deadline (a zero deadline blocks forever)
+	var deadline time.Time
+	if t.timeout > 0 {
+		deadline = time.Now().Add(t.timeout)
+	}
+	if err := t.conn.SetReadDeadline(deadline); err != nil {
+		return nil, fmt.Errorf("failed to set read deadline: %v", err)
 	}
 
 	// Read Direct TCP header (4 bytes)

--- a/network/tcp/tcp_test.go
+++ b/network/tcp/tcp_test.go
@@ -4,6 +4,7 @@ import (
 	"net"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/TheManticoreProject/Manticore/network/tcp"
 )
@@ -136,5 +137,49 @@ func TestTCPTransport_ReceiveRejectsOversizedLength(t *testing.T) {
 	_, err = tr.Receive()
 	if err == nil {
 		t.Fatal("TCPTransport.Receive() should return error for oversized length, got nil")
+	}
+}
+
+func TestTCPTransport_ReceiveTimesOutOnSilentServer(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start test server: %v", err)
+	}
+	defer ln.Close()
+
+	// Accept the connection but never write anything.
+	go func() {
+		c, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer c.Close()
+		select {}
+	}()
+
+	host, portStr, err := net.SplitHostPort(ln.Addr().String())
+	if err != nil {
+		t.Fatalf("failed to parse listener address: %v", err)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("failed to parse port: %v", err)
+	}
+
+	tr := tcp.NewTCPTransport()
+	tr.SetTimeout(100 * time.Millisecond)
+	if err := tr.Connect(net.ParseIP(host), port); err != nil {
+		t.Fatalf("TCPTransport.Connect() error = %v", err)
+	}
+	defer tr.Close()
+
+	start := time.Now()
+	_, err = tr.Receive()
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("TCPTransport.Receive() should time out on a silent server, got nil error")
+	}
+	if elapsed > 5*time.Second {
+		t.Fatalf("TCPTransport.Receive() took %v to fail, want a bounded timeout", elapsed)
 	}
 }


### PR DESCRIPTION
### Linked Issue
Closes #530

### Root Cause
The common SMB transport layer (`network/smb/common/transport`, backed by `network/tcp` and `network/netbios/nbt`) performed blocking reads with no deadline: `Receive()` used `io.ReadFull` on a connection that never had a read deadline set, and `Connect()` used `net.Dial` with no bound. When the generic client's `PolicyStrictOrder` probed a dialect the server silently drops — e.g. an SMB2-framed NEGOTIATE sent to an SMB1-only host, which neither answers nor resets — the probe blocked indefinitely inside `Receive()`, so `Dial` never returned and never advanced to the next preferred version.

### Fix Description
Adds a `SetTimeout(d time.Duration)` method to the `transport.Transport` interface and both implementations (`TCPTransport`, `NBTTransport`): `Connect` dials via `net.DialTimeout`, and `Receive` applies a per-call read deadline when a bound is set (a non-positive value keeps today's blocking behavior, which remains the initial state).

The generic client gains `Options.DialTimeout`: each connect/negotiate attempt (`dialSMB1`, `dialSMB2`, and the `PolicyHighestInSet` multi-protocol negotiate) runs under this bound — zero applies a 10 s default (`DefaultDialTimeout`), negative disables it — and the bound is lifted with `SetTimeout(0)` once the dialect is established, so long-blocking post-negotiate operations such as CHANGE_NOTIFY are unaffected. A failed probe attempt now also closes its transport, so strict-order retries do not leak the previous attempt's connection.

The per-attempt-deadline alternative (deadline managed only by the negotiator, no transport API change) was rejected because the transport interface exposes no access to the underlying `net.Conn`, so a deadline capability on the transport is required either way; making it part of the interface keeps every implementation honest.

### How Verified
- **Tests:** the new `TestDialStrictOrderFailsOnSilentServer` reproduces the issue's scenario (a listener that accepts and never writes, preference list `[SMB 2.0.2, SMB 1.0]`): before the fix `Dial` blocks forever; with it, both probes fail at the 200 ms bound and `Dial` returns an error in ~0.4 s.
- **Runtime:** `go test ./...` passes across the repository.

### Test Coverage
**Added:**
- `network/tcp/tcp_test.go`: `TestTCPTransport_ReceiveTimesOutOnSilentServer`
- `network/netbios/nbt/nbt_test.go`: `TestNBTTransport_ReceiveTimesOutOnSilentServer`
- `network/smb/client/negotiate_test.go`: `TestOptionsDialTimeout` (zero→default, negative→disabled, explicit kept), `TestDialStrictOrderFailsOnSilentServer`, `TestDialHighestInSetFailsOnSilentServer`

### Scope of Change
- **Files changed:** `network/tcp/tcp.go`, `network/netbios/nbt/nbt.go`, `network/smb/common/transport/transport.go`, `network/smb/client/{client,negotiate,types}.go`, plus their tests and one-line no-op `SetTimeout` additions to the existing transport test fakes (`smb_v10/client`, `smb_v20/client`, `common/transport`).
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none — transports start unbounded, and engines used directly (outside the generic client's `Dial`) behave exactly as before unless `SetTimeout` is called.

### Risk and Rollout
Low blast radius: the default path through the engines is unchanged (timeout zero ⇒ blocking I/O as today). The only behavioral change is within generic-client `Dial`, where attempts are now bounded by default (10 s) — a server slower than that to answer a NEGOTIATE would now fail the dial, which is the intended trade-off and can be relaxed via `Options.DialTimeout`.