### PR TITLE
Fix SMB2 WriteFile panic on oversized server write count (#543)

### DIFF
--- a/network/smb/smb_v20/client/file.go
+++ b/network/smb/smb_v20/client/file.go
@@ -177,6 +177,12 @@ func (c *Client) WriteFile(fileId types.SMB2_FILEID, offset uint64, data []byte)
 		if err != nil {
 			return total, err
 		}
+		// The server-reported count is untrusted: a value larger than the chunk
+		// submitted would slice data out of range below. Clamp it to the bytes
+		// actually sent and reject the response as malformed.
+		if written > n {
+			return total, fmt.Errorf("write reported %d bytes written, more than the %d submitted", written, n)
+		}
 		total += written
 		pos += uint64(written)
 		data = data[written:]

--- a/network/smb/smb_v20/client/file_test.go
+++ b/network/smb/smb_v20/client/file_test.go
@@ -86,3 +86,21 @@ func TestCreateFileRequiresTree(t *testing.T) {
 		t.Errorf("expected CreateFile without a tree connect to error")
 	}
 }
+
+// TestWriteFileRejectsOversizedCount verifies that a server reporting a write
+// count larger than the chunk submitted is rejected as malformed rather than
+// causing an out-of-range slice panic.
+func TestWriteFileRejectsOversizedCount(t *testing.T) {
+	writeResp := commands.NewWriteResponse()
+	writeResp.Count = 99 // far more than the 5 bytes submitted
+
+	ft := &fakeTransport{responses: [][]byte{
+		cannedResponse(t, writeResp, 0, 0x5, 0x99),
+	}}
+	c := withConnectedTree(ft)
+
+	_, err := c.WriteFile(types.SMB2_FILEID{}, 0, []byte("hello"))
+	if err == nil {
+		t.Fatal("WriteFile should reject a write count larger than the bytes submitted")
+	}
+}


### PR DESCRIPTION
### Linked Issue
Closes #543

### Root Cause
`Client.WriteFile` splits a large payload across successive SMB2 WRITE requests and advances its loop by the byte count the server reports (`WriteResponse.Count`, returned from `writeChunk`). That count is attacker-controlled and was used without validation: `data = data[written:]` slices the remaining payload by `written`. Nothing constrained `written` to be no greater than the chunk that was actually submitted, so a server returning a `Count` larger than the remaining payload caused a slice-bounds-out-of-range panic, and even a smaller-but-still-oversized count inflated the returned total.

### Fix Description
After each chunk, the reported count is compared to `n` — the number of bytes submitted in that chunk. A count greater than `n` is treated as a malformed response and returned as an error (carrying the bytes confirmed written so far) before it is used to reslice. This keeps `data[written:]` provably in range and prevents the total from being inflated past what was sent. A normal short write (`written < n`) is still handled by the existing `written == 0` break and the loop's reslice.

### How Verified
- **Tests:** `TestWriteFileRejectsOversizedCount` drives WriteFile over the in-memory `fakeTransport` with a WRITE response reporting `Count = 99` against a 5-byte payload; before the fix this panics, after it returns an error. `TestCreateReadWriteClose` confirms the normal write path (`Count = 5` for 5 bytes) still succeeds.
- **Runtime:** `go build ./...` and `go test ./network/smb/smb_v20/client/` pass.

### Test Coverage
**Added:** `network/smb/smb_v20/client/file_test.go`: `TestWriteFileRejectsOversizedCount`.

### Scope of Change
- **Files changed:** `network/smb/smb_v20/client/file.go`, `network/smb/smb_v20/client/file_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none — well-behaved servers (count ≤ bytes submitted) are unaffected.

### Risk and Rollout
Local and low-risk: the new check only rejects responses that were previously capable of crashing the client.