### PR TITLE
Fix SMB2 client accepting unsigned responses when signing is active (#544)

### DIFF
--- a/network/smb/smb_v20/client/engine.go
+++ b/network/smb/smb_v20/client/engine.go
@@ -75,9 +75,14 @@ func (c *Client) sendReceive(msg *message.Message, label string) (*message.Messa
 			return nil, fmt.Errorf("%s response is not an SMB2 message (ProtocolId % x)", label, response.Header.ProtocolId)
 		}
 
-		// Verify the signature when signing is active and the server signed the
-		// response (interim and final responses are both signed).
-		if c.Session != nil && c.Session.SigningActive && response.Header.Flags.IsSigned() {
+		// Enforce signing when it is active for the session. Per MS-SMB2
+		// 3.2.5.1.3, the client MUST verify the signature of every received
+		// message, exempting only interim responses (STATUS_PENDING) and
+		// messages with MessageId 0xFFFFFFFFFFFFFFFF; verification is not
+		// conditional on the SMB2_FLAGS_SIGNED bit, so a response that simply
+		// arrives unsigned (zeroed signature) fails verification and is
+		// rejected rather than silently accepted.
+		if c.Session != nil && c.Session.SigningActive && signatureRequired(response) {
 			if !verifySignature(c.Session.SigningKey, raw) {
 				return nil, fmt.Errorf("%s response failed SMB2 signature verification", label)
 			}
@@ -110,6 +115,25 @@ func (c *Client) sendReceive(msg *message.Message, label string) (*message.Messa
 	}
 
 	return response, nil
+}
+
+// unsolicitedMessageId is the reserved MessageId (0xFFFFFFFFFFFFFFFF) the server
+// stamps on messages not sent in reply to a client request, such as an
+// OPLOCK_BREAK notification. Signature verification is not mandatory for these.
+const unsolicitedMessageId = 0xFFFFFFFFFFFFFFFF
+
+// signatureRequired reports whether a received message must carry a valid
+// signature when session signing is active, per MS-SMB2 3.2.5.1.3. Interim
+// responses (STATUS_PENDING) and messages with the reserved MessageId are
+// exempt; every other message must be verified.
+func signatureRequired(response *message.Message) bool {
+	if response.Header.Status == ntStatusPending {
+		return false
+	}
+	if uint64(response.Header.MessageId) == unsolicitedMessageId {
+		return false
+	}
+	return true
 }
 
 // statusFromResponse returns the NT status code carried in a response header.

--- a/network/smb/smb_v20/client/signing_test.go
+++ b/network/smb/smb_v20/client/signing_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/message"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/types"
 )
 
 func TestSignAndVerifyRoundTrip(t *testing.T) {
@@ -48,4 +49,40 @@ func TestVerifyRejectsShortMessage(t *testing.T) {
 	if verifySignature([]byte("key"), make([]byte, 10)) {
 		t.Errorf("verifySignature should reject a sub-header-length message")
 	}
+}
+
+// TestSendReceiveEnforcesSigning verifies that when session signing is active a
+// final response is accepted only when correctly signed: an unsigned response is
+// rejected (MS-SMB2 3.2.5.1.3), and a properly signed one is accepted.
+func TestSendReceiveEnforcesSigning(t *testing.T) {
+	key := []byte("0123456789abcdef")
+
+	signingSession := func(c *Client) {
+		c.Session = &Session{Client: c, SessionId: 0x99, TreeId: 0x5, SigningActive: true, SigningKey: key}
+		c.Connection.SessionTable[0x99] = c.Session
+	}
+
+	t.Run("unsigned response rejected", func(t *testing.T) {
+		ft := &fakeTransport{responses: [][]byte{
+			cannedResponse(t, commands.NewCloseResponse(), 0, 0x5, 0x99), // unsigned
+		}}
+		c := newTestClient(ft)
+		signingSession(c)
+
+		if err := c.CloseFile(types.SMB2_FILEID{}); err == nil {
+			t.Fatal("expected an unsigned response to be rejected when signing is active")
+		}
+	})
+
+	t.Run("signed response accepted", func(t *testing.T) {
+		raw := cannedResponse(t, commands.NewCloseResponse(), 0, 0x5, 0x99)
+		signMessage(key, raw)
+		ft := &fakeTransport{responses: [][]byte{raw}}
+		c := newTestClient(ft)
+		signingSession(c)
+
+		if err := c.CloseFile(types.SMB2_FILEID{}); err != nil {
+			t.Fatalf("expected a correctly signed response to be accepted, got: %v", err)
+		}
+	})
 }


### PR DESCRIPTION
### Linked Issue
Closes #544

### Root Cause
In `sendReceive`, the signature-verification step was gated on `response.Header.Flags.IsSigned()` — it ran only when the server set the `SMB2_FLAGS_SIGNED` bit. That treats the absence of the flag as exempting the message from verification, so on a session with signing active an attacker (or a faulty server) could deliver a forged or tampered response simply by clearing the signed flag, and it would fall straight through to credit accounting and body decoding as if authentic. The integrity guarantee signing exists to provide was therefore void.

### Fix Description
MS-SMB2 §3.2.5.1.3 states that when `Session.SigningRequired` is TRUE the client MUST verify the signature of every received message and discard it on failure, exempting only interim responses (status `STATUS_PENDING`) and messages bearing the reserved `MessageId` 0xFFFFFFFFFFFFFFFF — verification is *not* conditional on the signed flag. The fix replaces the `IsSigned()` gate with a `signatureRequired()` predicate encoding exactly those two exemptions. When signing is active and the message is not exempt, `verifySignature` is always called; an unsigned response has a zeroed signature field that cannot match the recomputed HMAC, so it now fails verification and the response is rejected instead of accepted.

The interim-response exemption is preserved (the loop still processes `STATUS_PENDING` responses, which are now explicitly skipped by `signatureRequired`). `WaitOplockBreak` in `oplock.go` keeps its existing `IsSigned()` check: oplock break notifications carry the reserved `MessageId` and are exempt from mandatory verification per the same section, so no change is needed there.

### How Verified
- **Tests:** `TestSendReceiveEnforcesSigning` drives `CloseFile` over the in-memory transport on a session with `SigningActive`; the "unsigned response rejected" subtest feeds an unsigned CLOSE response and asserts an error (before the fix it was accepted), and "signed response accepted" feeds the same response signed with the session key and asserts success.
- **Runtime:** `go build ./...` and `go test ./network/smb/smb_v20/...` pass.

### Test Coverage
**Added:** `network/smb/smb_v20/client/signing_test.go`: `TestSendReceiveEnforcesSigning` (unsigned-rejected and signed-accepted subtests).

### Scope of Change
- **Files changed:** `network/smb/smb_v20/client/engine.go`, `network/smb/smb_v20/client/signing_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none — sessions without signing active are unaffected, and correctly signed responses are accepted exactly as before.

### Risk and Rollout
Low: the change only tightens acceptance on signing-active sessions. A server that negotiates signing but fails to sign a response would now have that response rejected — which is the intended, spec-required behavior.