### PR TITLE
Fix SMB2 sendReceive desyncing on unsolicited messages (#545)

### DIFF
--- a/network/smb/smb_v20/client/engine.go
+++ b/network/smb/smb_v20/client/engine.go
@@ -75,6 +75,16 @@ func (c *Client) sendReceive(msg *message.Message, label string) (*message.Messa
 			return nil, fmt.Errorf("%s response is not an SMB2 message (ProtocolId % x)", label, response.Header.ProtocolId)
 		}
 
+		// Skip server-initiated messages that can interleave with a synchronous
+		// exchange — most notably an OPLOCK_BREAK notification, which the server
+		// may send at any time once an oplock is granted and which carries the
+		// reserved MessageId 0xFFFFFFFFFFFFFFFF. Such a message is not the
+		// response to this request; consuming it as one would desynchronize the
+		// request/response stream. Keep reading for the real response.
+		if uint64(response.Header.MessageId) == unsolicitedMessageId {
+			continue
+		}
+
 		// Verify the signature when signing is active and the server signed the
 		// response (interim and final responses are both signed).
 		if c.Session != nil && c.Session.SigningActive && response.Header.Flags.IsSigned() {
@@ -87,6 +97,13 @@ func (c *Client) sendReceive(msg *message.Message, label string) (*message.Messa
 			c.Connection.Credits = response.Header.Credit
 		}
 
+		// A response must carry the MessageId of the request it answers; an
+		// interim STATUS_PENDING response and the final response both echo it.
+		// A mismatch means the stream is desynchronized.
+		if response.Header.MessageId != msg.Header.MessageId {
+			return nil, fmt.Errorf("%s response MessageId %d does not match request MessageId %d", label, uint64(response.Header.MessageId), uint64(msg.Header.MessageId))
+		}
+
 		if response.Header.Status != ntStatusPending {
 			break
 		}
@@ -96,6 +113,13 @@ func (c *Client) sendReceive(msg *message.Message, label string) (*message.Messa
 		c.setPendingAsync(msg.Header.MessageId, uint64(response.Header.GetAsyncId()))
 	}
 	c.clearPendingAsync()
+
+	// The response command code must match the request's; otherwise the server
+	// answered with a different command than was asked, indicating a corrupt or
+	// desynchronized exchange.
+	if response.Header.Command != msg.Header.Command {
+		return nil, fmt.Errorf("%s response command 0x%04x does not match request command 0x%04x", label, uint16(response.Header.Command), uint16(msg.Header.Command))
+	}
 
 	// Decode the command body only for statuses that carry a real command response:
 	// success, the session-setup continuation status, and STATUS_BUFFER_OVERFLOW (a
@@ -111,6 +135,11 @@ func (c *Client) sendReceive(msg *message.Message, label string) (*message.Messa
 
 	return response, nil
 }
+
+// unsolicitedMessageId is the reserved MessageId (0xFFFFFFFFFFFFFFFF) the server
+// stamps on messages not sent in reply to a client request, such as an
+// OPLOCK_BREAK notification (MS-SMB2 2.2.1.2).
+const unsolicitedMessageId = 0xFFFFFFFFFFFFFFFF
 
 // statusFromResponse returns the NT status code carried in a response header.
 func statusFromResponse(response *message.Message) uint32 {

--- a/network/smb/smb_v20/client/engine_test.go
+++ b/network/smb/smb_v20/client/engine_test.go
@@ -1,0 +1,73 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/message"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/message/commands/command_interface"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/message/header/flags"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/types"
+)
+
+// cannedResponseWithMessageId is cannedResponse with an explicit MessageId, used
+// to exercise the engine's request/response matching. The fakeTransport leaves a
+// non-zero MessageId untouched.
+func cannedResponseWithMessageId(t *testing.T, cmd command_interface.CommandInterface, status uint32, treeId uint32, sessionId uint64, messageId uint64) []byte {
+	t.Helper()
+	m := message.NewMessage()
+	m.Header.AddFlags(flags.SMB2_FLAGS_SERVER_TO_REDIR)
+	m.Header.Status = status
+	m.Header.TreeId = treeId
+	m.Header.SessionId = sessionId
+	m.Header.MessageId = types.UINT64(messageId)
+	m.SetCommand(cmd)
+	wire, err := m.Marshal()
+	if err != nil {
+		t.Fatalf("building canned response: %v", err)
+	}
+	return wire
+}
+
+// TestSendReceiveSkipsUnsolicitedOplockBreak verifies that an OPLOCK_BREAK
+// notification (reserved MessageId 0xFFFFFFFFFFFFFFFF) interleaved before the
+// real response is skipped rather than consumed as the operation's response.
+func TestSendReceiveSkipsUnsolicitedOplockBreak(t *testing.T) {
+	oplockBreak := commands.NewOplockBreakResponse()
+	ft := &fakeTransport{responses: [][]byte{
+		cannedResponseWithMessageId(t, oplockBreak, 0, 0x5, 0x99, unsolicitedMessageId),
+		cannedResponse(t, commands.NewCloseResponse(), 0, 0x5, 0x99),
+	}}
+	c := withConnectedTree(ft)
+
+	if err := c.CloseFile(types.SMB2_FILEID{}); err != nil {
+		t.Fatalf("CloseFile should skip the interleaved oplock break and use the real response, got: %v", err)
+	}
+}
+
+// TestSendReceiveRejectsMismatchedMessageId verifies that a response whose
+// MessageId does not match the request is rejected as a desynchronized stream.
+func TestSendReceiveRejectsMismatchedMessageId(t *testing.T) {
+	ft := &fakeTransport{responses: [][]byte{
+		cannedResponseWithMessageId(t, commands.NewCloseResponse(), 0, 0x5, 0x99, 999),
+	}}
+	c := withConnectedTree(ft)
+
+	if err := c.CloseFile(types.SMB2_FILEID{}); err == nil {
+		t.Fatal("CloseFile should reject a response with a mismatched MessageId")
+	}
+}
+
+// TestSendReceiveRejectsMismatchedCommand verifies that a response whose command
+// code does not match the request is rejected.
+func TestSendReceiveRejectsMismatchedCommand(t *testing.T) {
+	// Reply to a CLOSE request with a READ response (matching MessageId 0).
+	ft := &fakeTransport{responses: [][]byte{
+		cannedResponse(t, commands.NewReadResponse(), 0, 0x5, 0x99),
+	}}
+	c := withConnectedTree(ft)
+
+	if err := c.CloseFile(types.SMB2_FILEID{}); err == nil {
+		t.Fatal("CloseFile should reject a response carrying a different command code")
+	}
+}

--- a/network/smb/smb_v20/client/negotiate_test.go
+++ b/network/smb/smb_v20/client/negotiate_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"encoding/binary"
 	"net"
 	"testing"
 
@@ -30,6 +31,16 @@ func (f *fakeTransport) Send(data []byte) (int, error) {
 func (f *fakeTransport) Receive() ([]byte, error) {
 	resp := f.responses[0]
 	f.responses = f.responses[1:]
+	// Mirror a real server: stamp the most recently sent request's MessageId
+	// onto a response that left the field unset (0), so the engine's
+	// request/response matching is satisfied without every test plumbing a
+	// MessageId through cannedResponse. A response with an explicit MessageId
+	// (e.g. an unsolicited 0xFFFFFFFFFFFFFFFF notification) is left untouched.
+	if n := len(f.sent); n > 0 && len(resp) >= 32 {
+		if sent := f.sent[n-1]; len(sent) >= 32 && binary.LittleEndian.Uint64(resp[24:32]) == 0 {
+			copy(resp[24:32], sent[24:32])
+		}
+	}
 	return resp, nil
 }
 


### PR DESCRIPTION
### Linked Issue
Closes #545

### Root Cause
The SMB2 client's `sendReceive` receive loop treated whatever message arrived next on the connection as the response to the in-flight request. It validated the protocol identifier, signature, and credits, and tested for `STATUS_PENDING`, but never compared the response's `MessageId` or `Command` to the request. Once an oplock is granted (via `CreateFileWithOplock`), the server may send an unsolicited `OPLOCK_BREAK` notification at any time; if one arrived between a request and its response, the loop consumed it as that operation's final response (its status is not `STATUS_PENDING`), and every subsequent exchange on the connection was then misattributed by one message.

### Fix Description
The loop now applies the request/response correlation rules:

- **Skip unsolicited messages.** A received message bearing the reserved `MessageId` 0xFFFFFFFFFFFFFFFF (which the server stamps on server-initiated messages such as oplock break notifications, MS-SMB2 2.2.1.2) is not the response to this request, so the loop skips it and keeps reading.
- **Match the MessageId.** Both the interim `STATUS_PENDING` response and the final response must echo the request's `MessageId`; a mismatch is rejected as a desynchronized stream.
- **Match the command.** After the loop, the final response's command code must equal the request's, otherwise the exchange is rejected.

The documented design — `WaitOplockBreak` runs on a dedicated goroutine and must not read the connection concurrently with another operation — is unchanged; this hardens the engine against the defensive case where a notification still interleaves.

### How Verified
- **Tests:** `TestSendReceiveSkipsUnsolicitedOplockBreak` queues an OPLOCK_BREAK (MessageId 0xFFFFFFFFFFFFFFFF) ahead of the real CLOSE response and asserts CloseFile succeeds using the real response; `TestSendReceiveRejectsMismatchedMessageId` and `TestSendReceiveRejectsMismatchedCommand` assert that a response with the wrong MessageId or command code is rejected.
- **Runtime:** `go build ./...` and `go test ./network/smb/...` pass. The in-memory `fakeTransport` now echoes the sent request's MessageId onto responses that left it unset, mirroring a real server, so existing multi-operation tests satisfy the new matching.

### Test Coverage
**Added:** `network/smb/smb_v20/client/engine_test.go`: `TestSendReceiveSkipsUnsolicitedOplockBreak`, `TestSendReceiveRejectsMismatchedMessageId`, `TestSendReceiveRejectsMismatchedCommand`.

### Scope of Change
- **Files changed:** `network/smb/smb_v20/client/engine.go`, `network/smb/smb_v20/client/engine_test.go`, `network/smb/smb_v20/client/negotiate_test.go` (fakeTransport MessageId echo)
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none — well-behaved synchronous exchanges (matching MessageId and command, no interleaved notification) behave exactly as before.

### Risk and Rollout
Low: the new checks reject only responses that were previously capable of desynchronizing the stream, and skip only messages explicitly marked unsolicited. A correct server's responses always match the outstanding request.