### PR TITLE
Fix SMB2 SET_INFO setters discarding marshal errors (#549)

### DIFF
--- a/network/smb/smb_v20/client/info.go
+++ b/network/smb/smb_v20/client/info.go
@@ -108,20 +108,29 @@ func (c *Client) QueryFsSizeInfo(fileId types.SMB2_FILEID) (*filesystem.FileFsSi
 
 // SetEndOfFile sets the logical size of an open file (truncate or extend).
 func (c *Client) SetEndOfFile(fileId types.SMB2_FILEID, size int64) error {
-	buf, _ := (&filesystem.FileEndOfFileInformation{EndOfFile: size}).Marshal()
+	buf, err := (&filesystem.FileEndOfFileInformation{EndOfFile: size}).Marshal()
+	if err != nil {
+		return fmt.Errorf("failed to marshal FILE_END_OF_FILE_INFORMATION: %w", err)
+	}
 	return c.SetInfo(fileId, commands.SMB2_0_INFO_FILE, uint8(infoclass.FileEndOfFileInformation), 0, buf)
 }
 
 // SetDeleteOnClose marks (or unmarks) an open file for deletion when its last
 // handle is closed.
 func (c *Client) SetDeleteOnClose(fileId types.SMB2_FILEID, deletePending bool) error {
-	buf, _ := (&filesystem.FileDispositionInformation{DeletePending: deletePending}).Marshal()
+	buf, err := (&filesystem.FileDispositionInformation{DeletePending: deletePending}).Marshal()
+	if err != nil {
+		return fmt.Errorf("failed to marshal FILE_DISPOSITION_INFORMATION: %w", err)
+	}
 	return c.SetInfo(fileId, commands.SMB2_0_INFO_FILE, uint8(infoclass.FileDispositionInformation), 0, buf)
 }
 
 // RenameByHandle renames the open file to newName (share-relative). The handle
 // must have been opened with DELETE access.
 func (c *Client) RenameByHandle(fileId types.SMB2_FILEID, newName string, replaceIfExists bool) error {
-	buf, _ := (&filesystem.FileRenameInformation{ReplaceIfExists: replaceIfExists, FileName: newName}).Marshal()
+	buf, err := (&filesystem.FileRenameInformation{ReplaceIfExists: replaceIfExists, FileName: newName}).Marshal()
+	if err != nil {
+		return fmt.Errorf("failed to marshal FILE_RENAME_INFORMATION: %w", err)
+	}
 	return c.SetInfo(fileId, commands.SMB2_0_INFO_FILE, uint8(infoclass.FileRenameInformation), 0, buf)
 }


### PR DESCRIPTION
### Linked Issue
Closes #549

### Root Cause
The three SET_INFO convenience setters — `SetEndOfFile`, `SetDeleteOnClose`, and `RenameByHandle` — built their payload with `buf, _ := (...).Marshal()`, binding the error returned by `Marshal` (declared `([]byte, error)` in `windows/filesystem/file_set_information.go`) to the blank identifier. A serialization failure was therefore swallowed and the resulting buffer was passed to `SetInfo` and sent on the wire unconditionally, so the caller could not distinguish a client-side marshal failure from a server rejection.

### Fix Description
Each setter now binds the error, wraps it with a self-identifying message naming the information class, and returns it before issuing the request. No SET_INFO is sent when marshalling fails. This brings the three setters in line with the query helpers in the same file, which already propagate their (un)marshal errors.

### How Verified
- **Static:** all three call sites now return `fmt.Errorf("failed to marshal ...: %w", err)` on a non-nil marshal error (info.go), so the buffer is never used when marshalling fails.
- **Runtime:** `go build ./...` and `go test ./network/smb/smb_v20/client/` pass.

### Test Coverage
**None:** the `Marshal` implementations for these three fixed-shape structures cannot currently fail (they always return a nil error), so the error branch is not reachable through the public API without an unexported stub; the change is a contract-correctness fix that guards against a future Marshal that can fail. No deterministic test exercises the new branch.

### Scope of Change
- **Files changed:** `network/smb/smb_v20/client/info.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none — the success path is unchanged.

### Risk and Rollout
Trivial and local: only adds error propagation on a path that previously discarded it.