### PR TITLE
Fix SMB1 AndX chain follower looping on a cyclic chain (#551)

### DIFF
--- a/network/smb/smb_v10/message/andx_chain_test.go
+++ b/network/smb/smb_v10/message/andx_chain_test.go
@@ -90,3 +90,49 @@ func TestUnmarshalNonAndXLeavesNoChain(t *testing.T) {
 		t.Errorf("expected no chained command, got %T", next)
 	}
 }
+
+// TestUnmarshalRejectsCyclicAndXChain verifies that a batched message whose two
+// AndX commands reference each other (A->B, B->A) is rejected with an error
+// rather than looping forever. Without a forward-progress guard, Unmarshal would
+// never terminate.
+func TestUnmarshalRejectsCyclicAndXChain(t *testing.T) {
+	// Build a SessionSetupAndxResponse message (header + command block A).
+	aMsg := message.NewMessage()
+	aMsg.Header.SetFlags(flags.FLAGS_REPLY)
+	aMsg.AddCommand(commands.NewSessionSetupAndxResponse())
+	aRaw, err := aMsg.Marshal()
+	if err != nil {
+		t.Fatalf("failed to marshal SessionSetupAndxResponse: %v", err)
+	}
+
+	// A second SessionSetupAndxResponse command block (bytes after the header).
+	bMsg := message.NewMessage()
+	bMsg.Header.SetFlags(flags.FLAGS_REPLY)
+	bMsg.AddCommand(commands.NewSessionSetupAndxResponse())
+	bRaw, err := bMsg.Marshal()
+	if err != nil {
+		t.Fatalf("failed to marshal second SessionSetupAndxResponse: %v", err)
+	}
+	bBlock := bRaw[header.SMB_HEADER_SIZE:]
+
+	full := append(append([]byte{}, aRaw...), bBlock...)
+	aOffset := header.SMB_HEADER_SIZE // command A's WordCount index
+	bOffset := len(aRaw)              // command B's WordCount index
+
+	// A's AndX block -> B.
+	aAndx := aOffset + 1
+	full[aAndx] = byte(codes.SMB_COM_SESSION_SETUP_ANDX)
+	full[aAndx+1] = 0x00
+	binary.LittleEndian.PutUint16(full[aAndx+2:aAndx+4], uint16(bOffset))
+
+	// B's AndX block -> A (the cycle).
+	bAndx := bOffset + 1
+	full[bAndx] = byte(codes.SMB_COM_SESSION_SETUP_ANDX)
+	full[bAndx+1] = 0x00
+	binary.LittleEndian.PutUint16(full[bAndx+2:bAndx+4], uint16(aOffset))
+
+	out := message.NewMessage()
+	if err := out.Unmarshal(full); err == nil {
+		t.Fatal("Unmarshal should reject a cyclic AndX chain, got nil error")
+	}
+}

--- a/network/smb/smb_v10/message/message.go
+++ b/network/smb/smb_v10/message/message.go
@@ -163,6 +163,14 @@ func (m *Message) Unmarshal(marshalledData []byte) error {
 		if andxOffset < header.SMB_HEADER_SIZE || andxOffset >= len(fullData) {
 			return fmt.Errorf("AndX offset %d out of bounds (message is %d bytes)", andxOffset, len(fullData))
 		}
+		// The chain is laid out forward in the buffer, so each command must
+		// begin strictly after the current one. Requiring the offset to advance
+		// rejects a cyclic chain (e.g. two commands whose AndXOffset fields point
+		// at each other), which would otherwise loop forever and allocate a
+		// command on every iteration.
+		if andxOffset <= commandStart {
+			return fmt.Errorf("AndX offset %d does not advance past current command at %d (cyclic chain)", andxOffset, commandStart)
+		}
 
 		next, err := newCommand(andxCommand)
 		if err != nil {


### PR DESCRIPTION
### Linked Issue
Closes #551

### Root Cause
`Message.Unmarshal` follows the SMB1 AndX command chain by repeatedly jumping to each command's `AndXOffset`. The loop validated only that the offset lay within the message (`>= SMB_HEADER_SIZE` and `< len(fullData)`); it never required the offset to advance past the command currently being parsed, and kept no record of visited offsets. Because the AndX chain is laid out forward in the buffer, a well-formed chain always advances — but a malformed response whose two in-bounds, non-terminator AndX commands point their `AndXOffset` fields at each other (A→B, B→A) satisfies every check on every iteration, so the loop never reaches a terminator and runs forever, allocating a command (`newCommand` + `AddCommandToChain`) each pass.

### Fix Description
After the existing bounds check, the loop now rejects an `AndXOffset` that does not advance past the current command's start (`andxOffset <= commandStart`) with an explicit error. Since each command in a valid chain begins strictly after the previous one, offsets must be strictly increasing; enforcing that bounds the loop to at most one pass per byte of the message and rejects any cycle or non-advancing link. A monotonic-advance check was chosen over a visited-offset set because it is O(1), needs no extra state, and matches the protocol's forward layout.

### How Verified
- **Tests:** `TestUnmarshalRejectsCyclicAndXChain` assembles two SESSION_SETUP_ANDX command blocks whose AndX offsets reference each other and asserts `Unmarshal` returns an error (before the fix this test never returns). The existing `TestUnmarshalFollowsAndXChain` (a valid forward chain) and `TestUnmarshalNonAndXLeavesNoChain` still pass, confirming legitimate chains are unaffected.
- **Runtime:** `go build ./...` and `go test ./network/smb/smb_v10/message/` pass.

### Test Coverage
**Added:** `network/smb/smb_v10/message/andx_chain_test.go`: `TestUnmarshalRejectsCyclicAndXChain`.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/message/message.go`, `network/smb/smb_v10/message/andx_chain_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none — valid forward chains advance and are unaffected.

### Risk and Rollout
Low: the new check only rejects offsets that fail to advance, which no valid AndX chain produces.