### PR TITLE
Fix out-of-bounds slice on attacker-controlled AVPair length in BuildBlobTargetInfo (#552)

### DIFF
--- a/crypto/spnego/ntlm/targetinfo/targetinfo.go
+++ b/crypto/spnego/ntlm/targetinfo/targetinfo.go
@@ -106,6 +106,12 @@ func BuildBlobTargetInfo(targetInfo []byte) []byte {
 			return result
 		}
 
+		// avLen is server-controlled; ensure the declared value bytes are present
+		// before slicing, so a length running past the buffer cannot panic. A
+		// malformed (truncated) tail stops processing rather than crashing.
+		if i+4+int(avLen) > len(targetInfo) {
+			break
+		}
 		result = append(result, targetInfo[i:i+4+int(avLen)]...)
 		i += 4 + int(avLen)
 	}

--- a/crypto/spnego/ntlm/targetinfo/targetinfo_test.go
+++ b/crypto/spnego/ntlm/targetinfo/targetinfo_test.go
@@ -1,1 +1,23 @@
 package targetinfo_test
+
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/targetinfo"
+)
+
+// TestBuildBlobTargetInfoRejectsOversizedAVPairLength verifies that an AVPair
+// whose declared length runs past the end of the buffer does not panic.
+func TestBuildBlobTargetInfoRejectsOversizedAVPairLength(t *testing.T) {
+	// One AVPair header: AvId=MsvAvNbComputerName(0x0001), AvLen=0xFFFF, but no
+	// value bytes follow — the declared length runs far past the buffer.
+	malformed := []byte{0x01, 0x00, 0xFF, 0xFF}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("BuildBlobTargetInfo panicked on an oversized AVPair length: %v", r)
+		}
+	}()
+
+	_ = targetinfo.BuildBlobTargetInfo(malformed)
+}


### PR DESCRIPTION
### Linked Issue
Closes #552

### Root Cause
`BuildBlobTargetInfo` walks the AVPairs in the server-supplied NTLM CHALLENGE TargetInfo. Its loop guard (`for i+4 <= len(targetInfo)`) only ensures the 4-byte AVPair header is in range; it then read the server-controlled `avLen` and sliced `targetInfo[i : i+4+int(avLen)]` without confirming those value bytes were present. An AVPair whose declared length ran past the end of the buffer therefore caused a slice-bounds-out-of-range panic. The sibling `ParseTargetInfo` already performs this value-length check (`offset+int(avLen) > len(targetInfo)`); `BuildBlobTargetInfo` was missing it. The function is reached with the server's challenge TargetInfo at `crypto/spnego/ntlm/message/authenticate/authenticate.go:141`, so a malicious server could crash the client during authentication.

### Fix Description
Before slicing, the loop now checks `i+4+int(avLen) > len(targetInfo)` and, on a truncated value, stops processing (`break`) and returns the AVPairs accumulated so far. `break` (rather than returning an error) was chosen because the function signature has no error return and is only ever given a well-formed TargetInfo by a conforming server; the guard exists purely to keep a malformed/hostile input from panicking. This mirrors the bounds discipline of `ParseTargetInfo`.

### How Verified
- **Tests:** `TestBuildBlobTargetInfoRejectsOversizedAVPairLength` feeds an AVPair header declaring `AvLen = 0xFFFF` with no value bytes following and asserts the call does not panic; before the fix it panicked with slice-bounds-out-of-range.
- **Runtime:** `go build ./...` and `go test ./crypto/spnego/ntlm/targetinfo/` pass.

### Test Coverage
**Added:** `crypto/spnego/ntlm/targetinfo/targetinfo_test.go`: `TestBuildBlobTargetInfoRejectsOversizedAVPairLength`.

### Scope of Change
- **Files changed:** `crypto/spnego/ntlm/targetinfo/targetinfo.go`, `crypto/spnego/ntlm/targetinfo/targetinfo_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none — a well-formed TargetInfo (every AVPair value present) is copied exactly as before.

### Risk and Rollout
Low: the guard only triggers on a TargetInfo whose AVPair length exceeds the buffer, which a conforming server never produces.