### PR TITLE
Fix out-of-bounds index on empty negState ENUMERATED in NegTokenResp.Unmarshal (#553)

### DIFF
--- a/crypto/spnego/negtokenresp.go
+++ b/crypto/spnego/negtokenresp.go
@@ -221,6 +221,9 @@ func (n *NegTokenResp) Unmarshal(data []byte) (int, error) {
 				if enumRaw.Tag != asn1.TagEnum {
 					return 0, fmt.Errorf("negState is not an ENUMERATED type")
 				}
+				if len(enumRaw.Bytes) == 0 {
+					return 0, fmt.Errorf("negState ENUMERATED has no content")
+				}
 				n.NegState = NegState(enumRaw.Bytes[0])
 			case 1:
 				// OBJECT IDENTIFIER inside EXPLICIT

--- a/crypto/spnego/negtokenresp_test.go
+++ b/crypto/spnego/negtokenresp_test.go
@@ -157,3 +157,25 @@ func TestMarshalUnmarshalNegTokenResp(t *testing.T) {
 		})
 	}
 }
+
+// TestUnmarshalRejectsEmptyNegStateEnum verifies that a NegTokenResp whose
+// negState ENUMERATED carries no content bytes is rejected with an error rather
+// than panicking on an out-of-range index.
+func TestUnmarshalRejectsEmptyNegStateEnum(t *testing.T) {
+	// SEQUENCE { [0] EXPLICIT { ENUMERATED (length 0) } }
+	//   30 04        SEQUENCE, length 4
+	//     a0 02      [0] context, length 2
+	//       0a 00    ENUMERATED, length 0 (no content)
+	malformed := []byte{0x30, 0x04, 0xA0, 0x02, 0x0A, 0x00}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("NegTokenResp.Unmarshal panicked on an empty negState ENUMERATED: %v", r)
+		}
+	}()
+
+	resp := &spnego.NegTokenResp{}
+	if _, err := resp.Unmarshal(malformed); err == nil {
+		t.Fatal("Unmarshal should reject an empty negState ENUMERATED, got nil error")
+	}
+}


### PR DESCRIPTION
### Linked Issue
Closes #553

### Root Cause
While decoding the SPNEGO NegTokenResp, `Unmarshal` decodes the `[0]` negState field into an `asn1.RawValue`, validates only that its tag is ENUMERATED, then reads the first content byte as `NegState(enumRaw.Bytes[0])`. It never checked that the ENUMERATED carried any content. A server challenge token with a zero-length negState ENUMERATED (correct tag, empty value) leaves `enumRaw.Bytes` empty, so the index panicked with out-of-range. The token is server-controlled and reaches this path from `crypto/spnego/challenge.go:29` (`resp.Unmarshal(securityBlob.Data)` on the server's challenge), so a malicious server could crash the client.

### Fix Description
After the tag check, the code now rejects a negState ENUMERATED with `len(enumRaw.Bytes) == 0` by returning an error, before indexing `enumRaw.Bytes[0]`.

### How Verified
- **Tests:** `TestUnmarshalRejectsEmptyNegStateEnum` feeds the minimal DER token `30 04 a0 02 0a 00` (SEQUENCE → [0] → zero-length ENUMERATED) and asserts `Unmarshal` returns an error and does not panic; before the fix it panicked with index-out-of-range. The existing `TestUnmarshalRealNegTokenResp` and `TestMarshalUnmarshalNegTokenResp` still pass.
- **Runtime:** `go build ./...` and `go test ./crypto/spnego/` pass.

### Test Coverage
**Added:** `crypto/spnego/negtokenresp_test.go`: `TestUnmarshalRejectsEmptyNegStateEnum`.

### Scope of Change
- **Files changed:** `crypto/spnego/negtokenresp.go`, `crypto/spnego/negtokenresp_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none — a well-formed negState (one content byte) is decoded exactly as before.

### Risk and Rollout
Trivial and local: adds a length check on a single field before indexing it.