### PR TITLE
Fix NTLMv1 LM challenge response ignoring the supplied LM hash (#554)

### DIFF
--- a/crypto/ntlmv1/ntlmv1_ctx.go
+++ b/crypto/ntlmv1/ntlmv1_ctx.go
@@ -269,8 +269,12 @@ func (n *NTLMv1Ctx) ComputeNtChallengeResponse() ([24]byte, error) {
 //   - []byte: The 24-byte LM response
 //   - error: If key adjustment or encryption fails
 func (n *NTLMv1Ctx) ComputeLmChallengeResponse() ([24]byte, error) {
-	// Create the LM hash
-	lmHash := lm.LMHash(n.Password)
+	// Use the stored LM hash, which the constructors populate either from the
+	// password or directly from a caller-supplied hash (pass-the-hash). This
+	// mirrors ComputeNtChallengeResponse, which keys off n.NTHash; recomputing
+	// from n.Password here would discard a supplied hash, since the hash-based
+	// constructors leave Password empty.
+	lmHash := n.LMHash
 
 	// Split the LM hash into three 7-byte keys
 	key1 := lmHash[:7]

--- a/crypto/ntlmv1/ntlmv1_ctx_test.go
+++ b/crypto/ntlmv1/ntlmv1_ctx_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/hex"
 	"strings"
 	"testing"
+
+	"github.com/TheManticoreProject/Manticore/crypto/lm"
 )
 
 func Test_NTLMv1_FromPassword(t *testing.T) {
@@ -103,5 +105,36 @@ func Test_NTLMv1_ToHashcatString(t *testing.T) {
 				t.Errorf("HashcatString()\n\tgot  : %v\n\twant : %v", strings.ToUpper(hashcatString), strings.ToUpper(tc.expectedString))
 			}
 		})
+	}
+}
+
+// Test_NTLMv1_LmResponse_UsesSuppliedHash verifies that a context built from a
+// pre-computed LM hash (pass-the-hash) computes the LM challenge response from
+// that hash, matching a context built from the password whose LM hash is equal.
+func Test_NTLMv1_LmResponse_UsesSuppliedHash(t *testing.T) {
+	serverChallenge := [8]byte{0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88}
+	password := "Password123!"
+	lmHash := lm.LMHash(password)
+
+	fromPassword, err := NewNTLMv1CtxWithPassword("DOMAIN", "user", password, serverChallenge)
+	if err != nil {
+		t.Fatalf("NewNTLMv1CtxWithPassword: %v", err)
+	}
+	fromHash, err := NewNTLMv1CtxWithLMHash("DOMAIN", "user", lmHash, serverChallenge)
+	if err != nil {
+		t.Fatalf("NewNTLMv1CtxWithLMHash: %v", err)
+	}
+
+	wantResp, err := fromPassword.ComputeLmChallengeResponse()
+	if err != nil {
+		t.Fatalf("ComputeLmChallengeResponse (password): %v", err)
+	}
+	gotResp, err := fromHash.ComputeLmChallengeResponse()
+	if err != nil {
+		t.Fatalf("ComputeLmChallengeResponse (hash): %v", err)
+	}
+
+	if gotResp != wantResp {
+		t.Errorf("LM response from supplied hash = %x, want %x (it must not be derived from the empty password)", gotResp, wantResp)
 	}
 }


### PR DESCRIPTION
### Linked Issue
Closes #554

### Root Cause
`NTLMv1Ctx.ComputeLmChallengeResponse` derived the LM hash on the fly with `lm.LMHash(n.Password)` instead of reading the `LMHash` field the constructors populate. The hash-based constructors (`NewNTLMv1CtxWithLMHash`, `NewNTLMv1CtxWithHashes`, `NewNTLMv1CtxWithNTHash`) set `Password` to the empty string and store the caller's hash in `LMHash`, so the LM response was always computed from the empty-password LM hash and the supplied hash was silently discarded. The NT counterpart, `ComputeNtChallengeResponse`, correctly keys off `n.NTHash`, so the two paths were inconsistent.

### Fix Description
`ComputeLmChallengeResponse` now uses `lmHash := n.LMHash`, mirroring how the NT path uses `n.NTHash`. This is correct for every constructor: the password constructor already stores `lm.LMHash(password)` in `LMHash`, so the password flow is unchanged, while the hash-based constructors now use the hash that was actually supplied. The `lm` package remains imported (still used by the password constructor).

### How Verified
- **Tests:** `Test_NTLMv1_LmResponse_UsesSuppliedHash` builds one context from a password and another from that password's LM hash and asserts the two produce the same LM challenge response. Before the fix the hash-based context produced the empty-password response and the test failed; after it, they match. The existing `Test_NTLMv1_FromPassword` and `Test_NTLMv1_ToHashcatString` still pass, confirming the password path is unchanged.
- **Runtime:** `go build ./...` and `go test ./crypto/ntlmv1/` pass.

### Test Coverage
**Added:** `crypto/ntlmv1/ntlmv1_ctx_test.go`: `Test_NTLMv1_LmResponse_UsesSuppliedHash`.

### Scope of Change
- **Files changed:** `crypto/ntlmv1/ntlmv1_ctx.go`, `crypto/ntlmv1/ntlmv1_ctx_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none — the password-based flow yields the identical LM response as before.

### Risk and Rollout
Low: the password constructor stores `lm.LMHash(password)`, so reading `n.LMHash` produces the same value the code previously recomputed; only the hash-based constructors change behavior, in the intended direction.