### PR TITLE
Fix NT_STATUS.Error() returning nil for unmapped non-success codes (#555)

### DIFF
--- a/windows/nt_status/nt_status.go
+++ b/windows/nt_status/nt_status.go
@@ -7232,5 +7232,8 @@ func (s NT_STATUS) Error() error {
 		return fmt.Errorf("NT_STATUS(0x%08x): %s", uint32(s), str)
 	}
 
-	return nil
+	// Any non-success status that is not in the map is still a failure; report a
+	// generic error rather than nil so callers checking Error() != nil do not
+	// treat an unmapped code as success.
+	return fmt.Errorf("NT_STATUS(0x%08x)", uint32(s))
 }

--- a/windows/nt_status/nt_status_test.go
+++ b/windows/nt_status/nt_status_test.go
@@ -71,9 +71,11 @@ func TestNTStatusError(t *testing.T) {
 			expectedError: true,
 		},
 		{
-			name:          "Unknown status",
+			// An unmapped, non-success status is still a failure and must report
+			// a non-nil error so callers do not mistake it for success.
+			name:          "Unknown non-success status",
 			status:        nt_status.NT_STATUS(0xFFFFFFFF),
-			expectedError: false,
+			expectedError: true,
 		},
 	}
 


### PR DESCRIPTION
### Linked Issue
Closes #555

### Root Cause
`NT_STATUS.Error()` returned `nil` for `STATUS_SUCCESS`, a formatted error for any status found in `NTStatusToGoErrorMap`, and `nil` for everything else. Because the map does not enumerate every possible status code, a non-success status that happens to be absent from the map fell through to `return nil` — indistinguishable from success. A caller using the idiomatic `if status.Error() != nil` to detect failure would treat such a code as a successful operation.

### Fix Description
The final fall-through now returns a generic non-nil error (`NT_STATUS(0x%08x)` with the raw status value) instead of `nil`. `STATUS_SUCCESS` still returns `nil` (early return) and mapped codes still return their descriptive error, so the only behavior change is that an unmapped non-success code is now reported as the failure it is.

### How Verified
- **Tests:** `TestNTStatusError`'s unmapped-status case (`0xFFFFFFFF`) now asserts a non-nil error; this case previously asserted `nil`, codifying the bug, and is updated to the corrected contract. The SUCCESS and mapped-code (`PENDING`, `TIMEOUT`) cases are unchanged and still pass.
- **Runtime:** `go build ./...` passes and the full `go test ./...` suite is green, confirming no caller depended on the previous nil-for-unmapped behavior.

### Test Coverage
**Existing (updated):** `windows/nt_status/nt_status_test.go`: `TestNTStatusError` — the unmapped-status sub-case now expects an error.

### Scope of Change
- **Files changed:** `windows/nt_status/nt_status.go`, `windows/nt_status/nt_status_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none — SUCCESS and mapped statuses are unchanged.

### Risk and Rollout
Low: the full test suite passes. The change makes `Error()` stricter (an unmapped non-success code now surfaces as an error), which is the intended correction; any code path that silently proceeded past such a code will now observe the failure.