### PR TITLE
Remove debug stdout output from NTLM NegotiateMessage.Unmarshal (#556)

### DIFF
--- a/crypto/spnego/ntlm/message/negotiate/negotiate.go
+++ b/crypto/spnego/ntlm/message/negotiate/negotiate.go
@@ -246,16 +246,6 @@ func (msg *NegotiateMessage) Unmarshal(data []byte) (int, error) {
 
 	// Read payload section
 
-	fmt.Printf("len(data): %d\n", len(data))
-
-	fmt.Printf("msg.DomainNameFields.BufferOffset: %d\n", msg.DomainNameFields.BufferOffset)
-	fmt.Printf("msg.DomainNameFields.Len: %d\n", msg.DomainNameFields.Len)
-	fmt.Printf("DomainName = data [%d:%d]\n", msg.DomainNameFields.BufferOffset, msg.DomainNameFields.BufferOffset+uint32(msg.DomainNameFields.Len))
-
-	fmt.Printf("msg.WorkstationFields.BufferOffset: %d\n", msg.WorkstationFields.BufferOffset)
-	fmt.Printf("msg.WorkstationFields.Len: %d\n", msg.WorkstationFields.Len)
-	fmt.Printf("Workstation = data [%d:%d]\n", msg.WorkstationFields.BufferOffset, msg.WorkstationFields.BufferOffset+uint32(msg.WorkstationFields.Len))
-
 	// Domain name
 	if msg.DomainNameFields.Len != 0 {
 		if msg.DomainNameFields.BufferOffset+uint32(msg.DomainNameFields.Len) > uint32(len(data)) {


### PR DESCRIPTION
### Linked Issue
Closes #556

### Root Cause
Five `fmt.Printf` debug statements were left in `NegotiateMessage.Unmarshal`. They printed the data length and the DomainName/Workstation field offsets, lengths, and slice ranges to stdout on every NTLM NEGOTIATE message parse, with no logging gate.

### Fix Description
The five `fmt.Printf` calls are removed. The surrounding parse logic (the bounds-checked DomainName/Workstation slicing) is untouched, and the `fmt` import remains in use by the error returns in the same function.

### How Verified
- **Static:** the removed lines were pure side-effecting `fmt.Printf` calls reading already-parsed fields; no parsed value depended on them, so removing them cannot change the decoded result.
- **Runtime:** `go build ./...` passes and `go test ./crypto/spnego/ntlm/message/negotiate/` passes with no stdout noise.

### Test Coverage
**Existing:** the package's existing `Unmarshal` tests continue to pass; the change only removes stdout side effects, which are not part of the parsed output.

### Scope of Change
- **Files changed:** `crypto/spnego/ntlm/message/negotiate/negotiate.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none — only stdout debug output is removed.

### Risk and Rollout
Trivial: removes debug prints with no effect on parsing.