### PR TITLE
Fix AvPair.Unmarshal to honor AvLen and return the consumed byte count (#557)

### DIFF
--- a/crypto/spnego/ntlm/avpair/avpair.go
+++ b/crypto/spnego/ntlm/avpair/avpair.go
@@ -53,18 +53,20 @@ func (a *AvPair) Unmarshal(marshaledData []byte) (int, error) {
 		return 0, fmt.Errorf("data too short to unmarshal AV_PAIR, expected at least 4 bytes, got %d bytes", len(marshaledData))
 	}
 
-	buf := []byte{}
-
 	// AvId
 	a.AvID = AvId(binary.LittleEndian.Uint16(marshaledData[0:2]))
 
 	// AvLen
 	a.AvLen = binary.LittleEndian.Uint16(marshaledData[2:4])
 
-	// AvData
-	a.AvData = marshaledData[4:]
+	// AvData is exactly AvLen bytes following the 4-byte header.
+	if 4+int(a.AvLen) > len(marshaledData) {
+		return 0, fmt.Errorf("data too short to unmarshal AV_PAIR value, need %d bytes, got %d", 4+int(a.AvLen), len(marshaledData))
+	}
+	a.AvData = marshaledData[4 : 4+int(a.AvLen)]
 
-	return len(buf), nil
+	// Bytes consumed: the 4-byte header plus the value.
+	return 4 + int(a.AvLen), nil
 }
 
 // String returns a string representation of the AV_PAIR.

--- a/crypto/spnego/ntlm/avpair/avpair_test.go
+++ b/crypto/spnego/ntlm/avpair/avpair_test.go
@@ -147,3 +147,36 @@ func TestAvPairUnmarshalTooShort(t *testing.T) {
 		})
 	}
 }
+
+// TestAvPairUnmarshalReturnsConsumedCount verifies that Unmarshal returns the
+// number of bytes consumed (4-byte header + AvLen value) and that AvData is
+// limited to exactly AvLen bytes when the buffer carries trailing data.
+func TestAvPairUnmarshalReturnsConsumedCount(t *testing.T) {
+	// AvId=MsvAvNbComputerName, AvLen=2, value {0xAA,0xBB}, plus 3 trailing bytes
+	// belonging to a following AV_PAIR.
+	data := []byte{0x01, 0x00, 0x02, 0x00, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE}
+
+	av := avpair.AvPair{}
+	n, err := av.Unmarshal(data)
+	if err != nil {
+		t.Fatalf("Unmarshal returned error: %v", err)
+	}
+	if n != 6 {
+		t.Errorf("Unmarshal consumed = %d bytes, want 6 (4 header + 2 value)", n)
+	}
+	if !bytes.Equal(av.AvData, []byte{0xAA, 0xBB}) {
+		t.Errorf("AvData = %v, want [0xAA 0xBB] (trailing bytes must be excluded)", av.AvData)
+	}
+}
+
+// TestAvPairUnmarshalRejectsTruncatedValue verifies that an AvLen extending past
+// the buffer is rejected rather than silently over-reading.
+func TestAvPairUnmarshalRejectsTruncatedValue(t *testing.T) {
+	// AvLen=0x10 (16) but only 2 value bytes are present.
+	data := []byte{0x01, 0x00, 0x10, 0x00, 0xAA, 0xBB}
+
+	av := avpair.AvPair{}
+	if _, err := av.Unmarshal(data); err == nil {
+		t.Fatal("Unmarshal should reject an AvLen that exceeds the buffer")
+	}
+}


### PR DESCRIPTION
### Linked Issue
Closes #557

### Root Cause
`AvPair.Unmarshal` assigned `a.AvData = marshaledData[4:]` — the entire remainder of the buffer rather than the `AvLen` value bytes — with no `4+AvLen <= len` validation, and returned `len(buf)` where `buf` was an empty local slice declared earlier and never appended to. As a result the method always reported `0` bytes consumed and captured an `AvData` spanning every subsequent AV_PAIR. A caller iterating packed AV_PAIRs by the returned count could not advance (n == 0) and would misparse the data.

### Fix Description
`Unmarshal` now bounds-checks `4+int(a.AvLen)` against the buffer (returning an error on a truncated value), slices `a.AvData = marshaledData[4 : 4+int(a.AvLen)]` to exactly the declared value bytes, and returns `4 + int(a.AvLen)` as the number of bytes consumed. The unused empty `buf` local is removed.

### How Verified
- **Tests:** `TestAvPairUnmarshalReturnsConsumedCount` parses an AV_PAIR with `AvLen=2` followed by trailing bytes and asserts the method returns `6` and limits `AvData` to the two value bytes (before the fix it returned `0` and captured the trailing bytes too). `TestAvPairUnmarshalRejectsTruncatedValue` asserts an `AvLen` exceeding the buffer is rejected. The existing `TestAvPairUnmarshal` and `TestAvPairUnmarshalTooShort` still pass.
- **Runtime:** `go build ./...` and `go test ./crypto/spnego/ntlm/avpair/` pass.

### Test Coverage
**Added:** `crypto/spnego/ntlm/avpair/avpair_test.go`: `TestAvPairUnmarshalReturnsConsumedCount`, `TestAvPairUnmarshalRejectsTruncatedValue`.

### Scope of Change
- **Files changed:** `crypto/spnego/ntlm/avpair/avpair.go`, `crypto/spnego/ntlm/avpair/avpair_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none — there are no in-repo callers of `AvPair.Unmarshal` today; the change corrects the method's contract for future and test use.

### Risk and Rollout
Low: no current caller relies on the method, and the corrected return value and bounds check match the documented AV_PAIR layout.