### PR TITLE
Add SMB2 NextCommand compounding to the client (#534)

### DIFF
--- a/network/smb/smb_v20/client/compound.go
+++ b/network/smb/smb_v20/client/compound.go
@@ -1,0 +1,237 @@
+package client
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/message"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/message/header"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/message/header/flags"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/types"
+)
+
+// relatedFileId is the sentinel FileId (all 0xFF) that a request in a related
+// compound chain uses to mean "the FileId produced by the preceding CREATE in
+// this chain" (MS-SMB2 3.2.4.1.4).
+var relatedFileId = types.SMB2_FILEID{
+	Persistent: 0xFFFFFFFFFFFFFFFF,
+	Volatile:   0xFFFFFFFFFFFFFFFF,
+}
+
+// compoundSegments returns the byte range of each segment in a marshalled
+// compound buffer by walking the NextCommand chain in the segment headers. A
+// non-compounded (single-message) buffer yields a one-element slice. Each
+// returned segment slice aliases buf, so signing a segment in place updates buf.
+func compoundSegments(buf []byte) ([][]byte, error) {
+	var segments [][]byte
+	offset := 0
+	for offset < len(buf) {
+		if len(buf)-offset < header.SMB2_HEADER_SIZE {
+			return nil, fmt.Errorf("compound segment at offset %d is shorter than an SMB2 header", offset)
+		}
+		h := header.NewHeader()
+		if _, err := h.Unmarshal(buf[offset:]); err != nil {
+			return nil, fmt.Errorf("parsing compound segment header at offset %d: %w", offset, err)
+		}
+		next := int(h.NextCommand)
+		if next == 0 {
+			segments = append(segments, buf[offset:])
+			break
+		}
+		if next < header.SMB2_HEADER_SIZE || offset+next > len(buf) {
+			return nil, fmt.Errorf("compound NextCommand offset %d at segment offset %d out of bounds (buffer is %d bytes)", next, offset, len(buf))
+		}
+		segments = append(segments, buf[offset:offset+next])
+		offset += next
+	}
+	return segments, nil
+}
+
+// signCompound signs each segment of a marshalled compound buffer in place. Each
+// compounded PDU carries its own signature computed over its own region (header,
+// body, and inter-segment padding for non-final segments), so they are signed
+// individually rather than over the whole buffer.
+func signCompound(key, buf []byte) error {
+	segments, err := compoundSegments(buf)
+	if err != nil {
+		return err
+	}
+	for _, seg := range segments {
+		signMessage(key, seg)
+	}
+	return nil
+}
+
+// sendReceiveCompound marshals a chain of requests into a single compounded SMB2
+// request, signs each segment when signing is active, sends it as one frame, then
+// parses the compounded response into one Message per segment. Each response
+// segment is verified (protocol id, signature when required, and MessageId
+// against the set of requests) and its command body is decoded only for statuses
+// that carry one (mirroring sendReceive). Server-initiated frames (an interleaved
+// OPLOCK_BREAK) are skipped.
+//
+// Interim STATUS_PENDING responses are not supported on the compound path: a
+// compounded chain is expected to complete synchronously. A pending segment is
+// reported as an error.
+func (c *Client) sendReceiveCompound(msgs []*message.Message, label string) ([]*message.Message, error) {
+	if !c.Transport.IsConnected() {
+		return nil, fmt.Errorf("%s: transport is not connected", label)
+	}
+	if len(msgs) == 0 {
+		return nil, fmt.Errorf("%s: no messages to send", label)
+	}
+
+	// Record the request MessageIds so each response segment can be matched back
+	// to a request it answers.
+	requestIds := make(map[uint64]bool, len(msgs))
+	for _, m := range msgs {
+		requestIds[uint64(m.Header.MessageId)] = true
+	}
+
+	marshalled, err := message.MarshalCompound(msgs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal %s: %w", label, err)
+	}
+
+	if c.Session != nil && c.Session.SigningActive {
+		if err := signCompound(c.Session.SigningKey, marshalled); err != nil {
+			return nil, fmt.Errorf("failed to sign %s: %w", label, err)
+		}
+	}
+
+	if _, err := c.Transport.Send(marshalled); err != nil {
+		return nil, fmt.Errorf("failed to send %s: %w", label, err)
+	}
+
+	// Read the response frame, skipping any leading server-initiated message
+	// (reserved MessageId), which is not a reply to this chain.
+	var raw []byte
+	for {
+		raw, err = c.Transport.Receive()
+		if err != nil {
+			return nil, fmt.Errorf("failed to receive %s response: %w", label, err)
+		}
+		probe := header.NewHeader()
+		if _, err := probe.Unmarshal(raw); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal %s response header: %w", label, err)
+		}
+		if uint64(probe.MessageId) != unsolicitedMessageId {
+			break
+		}
+	}
+
+	segments, err := compoundSegments(raw)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", label, err)
+	}
+
+	responses := make([]*message.Message, 0, len(segments))
+	for i, seg := range segments {
+		resp := message.NewMessage()
+		if _, err := resp.Header.Unmarshal(seg); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal %s response segment %d header: %w", label, i, err)
+		}
+		if !resp.Header.HasValidProtocolId() {
+			return nil, fmt.Errorf("%s response segment %d is not an SMB2 message (ProtocolId % x)", label, i, resp.Header.ProtocolId)
+		}
+
+		// Enforce signing per segment, with the same exemptions as the
+		// single-message path (MS-SMB2 3.2.5.1.3).
+		if c.Session != nil && c.Session.SigningActive && signatureRequired(resp) {
+			if !verifySignature(c.Session.SigningKey, seg) {
+				return nil, fmt.Errorf("%s response segment %d failed SMB2 signature verification", label, i)
+			}
+		}
+		if resp.Header.Credit > 0 {
+			c.Connection.Credits = resp.Header.Credit
+		}
+
+		if uint64(resp.Header.MessageId) != unsolicitedMessageId && !requestIds[uint64(resp.Header.MessageId)] {
+			return nil, fmt.Errorf("%s response segment %d MessageId %d does not match any request", label, i, uint64(resp.Header.MessageId))
+		}
+		if resp.Header.Status == ntStatusPending {
+			return nil, fmt.Errorf("%s response segment %d returned STATUS_PENDING; the compound path does not support async completion", label, i)
+		}
+
+		// Decode the command body only for statuses that carry one (mirrors
+		// sendReceive); an error segment carries the fixed SMB2 ERROR body.
+		status := resp.Header.Status
+		if status == 0x00000000 || status == ntStatusMoreProcessingRequired || status == ntStatusBufferOverflow {
+			if _, err := resp.Unmarshal(seg); err != nil {
+				return nil, fmt.Errorf("failed to unmarshal %s response segment %d: %w", label, i, err)
+			}
+		}
+		responses = append(responses, resp)
+	}
+
+	return responses, nil
+}
+
+// CreateQueryInfoClose opens path, queries the given information class on the
+// resulting handle, and closes it — all in a single compounded request
+// (SMB2_FLAGS_RELATED_OPERATIONS), so the three operations cost one network round
+// trip instead of three. It returns the QUERY_INFO output buffer.
+//
+// infoType is one of commands.SMB2_0_INFO_* and fileInfoClass the class within
+// it; additionalInformation carries the security-info bits for a security query
+// and is 0 otherwise. Wire: SMB2 CREATE + QUERY_INFO + CLOSE compounded with
+// related operations, where the QUERY_INFO and CLOSE inherit the CREATE's handle
+// via the reserved related FileId.
+func (c *Client) CreateQueryInfoClose(path string, desiredAccess, shareAccess, createDisposition, createOptions uint32, infoType, fileInfoClass uint8, additionalInformation uint32) ([]byte, error) {
+	if c.Session == nil || c.Session.TreeId == 0 {
+		return nil, fmt.Errorf("no tree connect established")
+	}
+
+	// CREATE — the first request in the chain, with the real share-relative name.
+	create := commands.NewCreateRequest()
+	create.RequestedOplockLevel = types.UCHAR(commands.SMB2_OPLOCK_LEVEL_NONE)
+	create.DesiredAccess = desiredAccess
+	create.ShareAccess = shareAccess
+	create.CreateDisposition = createDisposition
+	create.CreateOptions = createOptions
+	create.ImpersonationLevel = 0x00000002 // Impersonation
+	create.FileAttributes = 0x00000080     // FILE_ATTRIBUTE_NORMAL
+	create.Name = strings.TrimPrefix(path, "\\")
+	createMsg := c.newRequest(create)
+
+	// QUERY_INFO — inherits the CREATE's handle via the related FileId sentinel.
+	query := commands.NewQueryInfoRequest()
+	query.InfoType = types.UCHAR(infoType)
+	query.FileInfoClass = types.UCHAR(fileInfoClass)
+	query.AdditionalInformation = types.ULONG(additionalInformation)
+	query.OutputBufferLength = types.ULONG(c.Connection.Server.MaxTransactSize)
+	query.FileId = relatedFileId
+	queryMsg := c.newRequest(query)
+	queryMsg.Header.AddFlags(flags.SMB2_FLAGS_RELATED_OPERATIONS)
+
+	// CLOSE — also operates on the CREATE's handle.
+	closeReq := commands.NewCloseRequest()
+	closeReq.FileId = relatedFileId
+	closeMsg := c.newRequest(closeReq)
+	closeMsg.Header.AddFlags(flags.SMB2_FLAGS_RELATED_OPERATIONS)
+
+	responses, err := c.sendReceiveCompound([]*message.Message{createMsg, queryMsg, closeMsg}, "CreateQueryInfoClose")
+	if err != nil {
+		return nil, err
+	}
+	if len(responses) != 3 {
+		return nil, fmt.Errorf("expected 3 compounded responses, got %d", len(responses))
+	}
+
+	if status := statusFromResponse(responses[0]); status != 0x00000000 {
+		return nil, fmt.Errorf("create %q failed: %s", path, formatNTStatus(status))
+	}
+	if status := statusFromResponse(responses[1]); status != 0x00000000 {
+		return nil, fmt.Errorf("query info failed: %s", formatNTStatus(status))
+	}
+	if status := statusFromResponse(responses[2]); status != 0x00000000 {
+		return nil, fmt.Errorf("close failed: %s", formatNTStatus(status))
+	}
+
+	queryResp, ok := responses[1].Command.(*commands.QueryInfoResponse)
+	if !ok {
+		return nil, fmt.Errorf("unexpected query info response command: %T", responses[1].Command)
+	}
+	return queryResp.OutputBuffer, nil
+}

--- a/network/smb/smb_v20/client/compound_test.go
+++ b/network/smb/smb_v20/client/compound_test.go
@@ -1,0 +1,145 @@
+package client
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/message"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/message/commands/command_interface"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/message/header/flags"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/types"
+)
+
+// compoundSegment pairs a response command body with the MessageId and status its
+// header should carry.
+type compoundSegment struct {
+	cmd       command_interface.CommandInterface
+	messageId uint64
+	status    uint32
+}
+
+// cannedCompound builds the wire bytes of a compounded SMB2 response from the
+// given segments, stamping each with its MessageId and status and the
+// SERVER_TO_REDIR flag.
+func cannedCompound(t *testing.T, segs []compoundSegment) []byte {
+	t.Helper()
+	msgs := make([]*message.Message, 0, len(segs))
+	for _, s := range segs {
+		m := message.NewMessage()
+		m.Header.AddFlags(flags.SMB2_FLAGS_SERVER_TO_REDIR)
+		m.Header.MessageId = types.UINT64(s.messageId)
+		m.Header.Status = s.status
+		m.SetCommand(s.cmd)
+		msgs = append(msgs, m)
+	}
+	wire, err := message.MarshalCompound(msgs)
+	if err != nil {
+		t.Fatalf("MarshalCompound: %v", err)
+	}
+	return wire
+}
+
+// createQueryCloseResponse builds the canonical CREATE+QUERY_INFO+CLOSE compound
+// response with MessageIds 0,1,2 and the given query output buffer.
+func createQueryCloseResponse(t *testing.T, queryOutput []byte) []byte {
+	t.Helper()
+	createResp := commands.NewCreateResponse()
+	createResp.FileId = types.SMB2_FILEID{Persistent: 0xCAFE, Volatile: 0xBEEF}
+	queryResp := commands.NewQueryInfoResponse()
+	queryResp.OutputBuffer = queryOutput
+	return cannedCompound(t, []compoundSegment{
+		{createResp, 0, 0},
+		{queryResp, 1, 0},
+		{commands.NewCloseResponse(), 2, 0},
+	})
+}
+
+func TestCreateQueryInfoCloseCompound(t *testing.T) {
+	want := []byte{0xDE, 0xAD, 0xBE, 0xEF}
+	ft := &fakeTransport{responses: [][]byte{createQueryCloseResponse(t, want)}}
+	c := withConnectedTree(ft)
+
+	got, err := c.CreateQueryInfoClose("dir\\file.txt", 0x00100081, 0x07, 0x00000001, 0x00000000, commands.SMB2_0_INFO_FILE, 0x12, 0)
+	if err != nil {
+		t.Fatalf("CreateQueryInfoClose: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("query output = % x, want % x", got, want)
+	}
+
+	// One compound frame must have been sent (a single Send, not three).
+	if len(ft.sent) != 1 {
+		t.Fatalf("expected 1 compound request frame sent, got %d", len(ft.sent))
+	}
+	// The sent frame must parse into three segments, with the 2nd and 3rd marked
+	// as related operations and carrying the related FileId sentinel.
+	segs, err := compoundSegments(ft.sent[0])
+	if err != nil {
+		t.Fatalf("compoundSegments(sent): %v", err)
+	}
+	if len(segs) != 3 {
+		t.Fatalf("sent compound has %d segments, want 3", len(segs))
+	}
+	reqs, err := message.UnmarshalCompound(ft.sent[0])
+	if err != nil {
+		t.Fatalf("UnmarshalCompound(sent): %v", err)
+	}
+	if reqs[0].Header.Flags.IsRelatedOperations() {
+		t.Errorf("first request must not set RELATED_OPERATIONS")
+	}
+	for i := 1; i < 3; i++ {
+		if !reqs[i].Header.Flags.IsRelatedOperations() {
+			t.Errorf("request %d must set RELATED_OPERATIONS", i)
+		}
+	}
+}
+
+func TestSendReceiveCompoundEnforcesSigning(t *testing.T) {
+	key := []byte("0123456789abcdef")
+
+	signingClient := func(ft *fakeTransport) *Client {
+		c := newTestClient(ft)
+		c.Session = &Session{Client: c, SessionId: 0x99, TreeId: 0x5, SigningActive: true, SigningKey: key}
+		c.Connection.SessionTable[0x99] = c.Session
+		return c
+	}
+
+	t.Run("unsigned compound rejected", func(t *testing.T) {
+		ft := &fakeTransport{responses: [][]byte{createQueryCloseResponse(t, []byte{0x01})}}
+		c := signingClient(ft)
+		if _, err := c.CreateQueryInfoClose("x", 0x00100081, 0x07, 0x00000001, 0, commands.SMB2_0_INFO_FILE, 0x12, 0); err == nil {
+			t.Fatal("expected an unsigned compound response to be rejected when signing is active")
+		}
+	})
+
+	t.Run("signed compound accepted", func(t *testing.T) {
+		raw := createQueryCloseResponse(t, []byte{0x01})
+		if err := signCompound(key, raw); err != nil {
+			t.Fatalf("signCompound: %v", err)
+		}
+		ft := &fakeTransport{responses: [][]byte{raw}}
+		c := signingClient(ft)
+		if _, err := c.CreateQueryInfoClose("x", 0x00100081, 0x07, 0x00000001, 0, commands.SMB2_0_INFO_FILE, 0x12, 0); err != nil {
+			t.Fatalf("expected a correctly signed compound response to be accepted, got: %v", err)
+		}
+	})
+}
+
+func TestCreateQueryInfoCloseSurfacesSegmentError(t *testing.T) {
+	// CREATE succeeds but QUERY_INFO fails (STATUS_ACCESS_DENIED); the error must
+	// be surfaced and the CLOSE segment (an error body) must not break parsing.
+	createResp := commands.NewCreateResponse()
+	createResp.FileId = types.SMB2_FILEID{Persistent: 1, Volatile: 2}
+	raw := cannedCompound(t, []compoundSegment{
+		{createResp, 0, 0},
+		{commands.NewQueryInfoResponse(), 1, 0xC0000022}, // STATUS_ACCESS_DENIED
+		{commands.NewCloseResponse(), 2, 0},
+	})
+	ft := &fakeTransport{responses: [][]byte{raw}}
+	c := withConnectedTree(ft)
+
+	if _, err := c.CreateQueryInfoClose("x", 0x00100081, 0x07, 0x00000001, 0, commands.SMB2_0_INFO_FILE, 0x12, 0); err == nil {
+		t.Fatal("expected an error when the QUERY_INFO segment fails")
+	}
+}


### PR DESCRIPTION
### Linked Issue
Refs #534 (the optional NextCommand-compounding item). This PR intentionally does **not** close #534, which stays open.

### Summary
The SMB2 message layer has supported compounding (`MarshalCompound`/`UnmarshalCompound`) since the wire layer was built, but the client never exercised it — the last open item on #534. This wires request compounding into the client.

### What this adds
- **`sendReceiveCompound(msgs, label)`** (engine): chains a slice of requests with `MarshalCompound`, signs each segment in place when signing is active, sends the chain as a single frame, then parses the compounded response one segment at a time. Each response segment is validated exactly like the single-message path: protocol-id check, per-segment signature verification with the MS-SMB2 3.2.5.1.3 exemptions, MessageId matched against the set of requests sent, and command-body decode gated on status (an error segment's 9-byte SMB2 ERROR body is left undecoded). A leading server-initiated frame (an interleaved OPLOCK_BREAK, reserved MessageId) is skipped.
- **`signCompound` / `compoundSegments`**: split a marshalled compound buffer along the NextCommand chain and sign each PDU over its own region (header + body + inter-segment padding for non-final segments), as required for compounded signing.
- **`CreateQueryInfoClose(...)`** (public): performs a related CREATE + QUERY_INFO + CLOSE in a single round trip using `SMB2_FLAGS_RELATED_OPERATIONS`, with the QUERY_INFO and CLOSE inheriting the CREATE's handle via the reserved related FileId (all-0xFF). Returns the QUERY_INFO output buffer.

### Scope / limitations
Interim `STATUS_PENDING` (async) completion is not supported on the compound path — a compounded chain is expected to complete synchronously, and a pending segment is reported as an error. The single-message `sendReceive` remains the async-capable path. This is noted in the code and is why #534 can track any further compounding work (e.g. async compounds) if desired.

### How Verified
- **Tests (offline, fakeTransport):**
  - `TestCreateQueryInfoCloseCompound` — drives the related compound against a canned 3-segment response, asserts the query buffer is returned, that exactly **one** frame was sent, that it parses into 3 segments, and that segments 2–3 carry `RELATED_OPERATIONS` while segment 1 does not.
  - `TestSendReceiveCompoundEnforcesSigning` — with signing active, an unsigned compound response is rejected and a per-segment-signed one is accepted.
  - `TestCreateQueryInfoCloseSurfacesSegmentError` — a failing QUERY_INFO segment surfaces as an error while the trailing CLOSE segment parses cleanly.
- **Runtime:** `go build ./...` and the full `go test ./...` suite pass.

### Test Coverage
**Added:** `network/smb/smb_v20/client/compound_test.go` (the three tests above).

### Scope of Change
- **Files changed:** `network/smb/smb_v20/client/compound.go` (new), `network/smb/smb_v20/client/compound_test.go` (new)
- **Submodule pointer updated:** no
- **Behavioral changes outside the new code:** none — existing single-message operations are untouched.

### Risk and Rollout
Low: purely additive. No existing code path calls the new methods; they are opt-in and fully covered by offline tests. Live validation against a real server (and async-compound support) can follow under #534.