### PR TITLE
Add the remaining MS-FSCC information-class structures for SMB2 (#525)

### DIFF
--- a/network/smb/smb_v20/client/info.go
+++ b/network/smb/smb_v20/client/info.go
@@ -106,6 +106,91 @@ func (c *Client) QueryFsSizeInfo(fileId types.SMB2_FILEID) (*filesystem.FileFsSi
 	return fi, nil
 }
 
+// QueryFileAllInfo returns the FILE_ALL_INFORMATION (the aggregate basic,
+// standard, internal, EA, access, position, mode, alignment, and name data) of an
+// open file.
+func (c *Client) QueryFileAllInfo(fileId types.SMB2_FILEID) (*filesystem.FileAllInformation, error) {
+	raw, err := c.QueryInfo(fileId, commands.SMB2_0_INFO_FILE, uint8(infoclass.FileAllInformation), 0)
+	if err != nil {
+		return nil, err
+	}
+	fi := &filesystem.FileAllInformation{}
+	if err := fi.Unmarshal(raw); err != nil {
+		return nil, err
+	}
+	return fi, nil
+}
+
+// QueryFileNetworkOpenInfo returns the FILE_NETWORK_OPEN_INFORMATION (timestamps,
+// sizes, attributes) of an open file.
+func (c *Client) QueryFileNetworkOpenInfo(fileId types.SMB2_FILEID) (*filesystem.FileNetworkOpenInformation, error) {
+	raw, err := c.QueryInfo(fileId, commands.SMB2_0_INFO_FILE, uint8(infoclass.FileNetworkOpenInformation), 0)
+	if err != nil {
+		return nil, err
+	}
+	fi := &filesystem.FileNetworkOpenInformation{}
+	if err := fi.Unmarshal(raw); err != nil {
+		return nil, err
+	}
+	return fi, nil
+}
+
+// QueryFsVolumeInfo returns the FILE_FS_VOLUME_INFORMATION (creation time, serial
+// number, label) of the volume backing the open identified by fileId.
+func (c *Client) QueryFsVolumeInfo(fileId types.SMB2_FILEID) (*filesystem.FileFsVolumeInformation, error) {
+	raw, err := c.QueryInfo(fileId, commands.SMB2_0_INFO_FILESYSTEM, uint8(infoclass.FileFsVolumeInformation), 0)
+	if err != nil {
+		return nil, err
+	}
+	fi := &filesystem.FileFsVolumeInformation{}
+	if err := fi.Unmarshal(raw); err != nil {
+		return nil, err
+	}
+	return fi, nil
+}
+
+// QueryFsFullSizeInfo returns the FILE_FS_FULL_SIZE_INFORMATION (total and
+// caller/actual available allocation units) of the volume backing fileId.
+func (c *Client) QueryFsFullSizeInfo(fileId types.SMB2_FILEID) (*filesystem.FileFsFullSizeInformation, error) {
+	raw, err := c.QueryInfo(fileId, commands.SMB2_0_INFO_FILESYSTEM, uint8(infoclass.FileFsFullSizeInformation), 0)
+	if err != nil {
+		return nil, err
+	}
+	fi := &filesystem.FileFsFullSizeInformation{}
+	if err := fi.Unmarshal(raw); err != nil {
+		return nil, err
+	}
+	return fi, nil
+}
+
+// QueryFsAttributeInfo returns the FILE_FS_ATTRIBUTE_INFORMATION (attribute flags,
+// max component name length, file system name) of the volume backing fileId.
+func (c *Client) QueryFsAttributeInfo(fileId types.SMB2_FILEID) (*filesystem.FileFsAttributeInformation, error) {
+	raw, err := c.QueryInfo(fileId, commands.SMB2_0_INFO_FILESYSTEM, uint8(infoclass.FileFsAttributeInformation), 0)
+	if err != nil {
+		return nil, err
+	}
+	fi := &filesystem.FileFsAttributeInformation{}
+	if err := fi.Unmarshal(raw); err != nil {
+		return nil, err
+	}
+	return fi, nil
+}
+
+// QueryFsDeviceInfo returns the FILE_FS_DEVICE_INFORMATION (device type and
+// characteristics) of the volume backing fileId.
+func (c *Client) QueryFsDeviceInfo(fileId types.SMB2_FILEID) (*filesystem.FileFsDeviceInformation, error) {
+	raw, err := c.QueryInfo(fileId, commands.SMB2_0_INFO_FILESYSTEM, uint8(infoclass.FileFsDeviceInformation), 0)
+	if err != nil {
+		return nil, err
+	}
+	fi := &filesystem.FileFsDeviceInformation{}
+	if err := fi.Unmarshal(raw); err != nil {
+		return nil, err
+	}
+	return fi, nil
+}
+
 // SetEndOfFile sets the logical size of an open file (truncate or extend).
 func (c *Client) SetEndOfFile(fileId types.SMB2_FILEID, size int64) error {
 	buf, err := (&filesystem.FileEndOfFileInformation{EndOfFile: size}).Marshal()

--- a/network/smb/smb_v20/createcontext/createcontext.go
+++ b/network/smb/smb_v20/createcontext/createcontext.go
@@ -1,0 +1,147 @@
+// Package createcontext implements the SMB2_CREATE_CONTEXT structure carried in
+// the variable buffer of SMB2 CREATE requests and responses. A create context is
+// a tagged name/data pair (durable-handle request, lease request, query
+// maximal-access, allocation size, …); CREATE carries a chained list of them.
+//
+// The SMB2 CREATE command bodies keep the context list as a raw []byte
+// (CreateRequest.CreateContexts / CreateResponse.CreateContexts); this package
+// builds and parses that buffer into typed contexts.
+//
+// [MS-SMB2] 2.2.13.2 SMB2_CREATE_CONTEXT Request Values:
+// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/93a3d702-90a0-4c8a-86c4-12dfa9230f5f
+package createcontext
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+// Well-known SMB2_CREATE_CONTEXT name tags (MS-SMB2 2.2.13.2). The name is the
+// ASCII tag the server matches against; most are 4 bytes.
+var (
+	NameExtendedAttributes = []byte("ExtA") // SMB2_CREATE_EA_BUFFER
+	NameSecurityDescriptor = []byte("SecD") // SMB2_CREATE_SD_BUFFER
+	NameDurableHandleReq   = []byte("DHnQ") // SMB2_CREATE_DURABLE_HANDLE_REQUEST
+	NameDurableHandleRecon = []byte("DHnC") // SMB2_CREATE_DURABLE_HANDLE_RECONNECT
+	NameAllocationSize     = []byte("AlSi") // SMB2_CREATE_ALLOCATION_SIZE
+	NameQueryMaximalAccess = []byte("MxAc") // SMB2_CREATE_QUERY_MAXIMAL_ACCESS_REQUEST
+	NameTimewarpToken      = []byte("TWrp") // SMB2_CREATE_TIMEWARP_TOKEN
+	NameQueryOnDiskID      = []byte("QFid") // SMB2_CREATE_QUERY_ON_DISK_ID
+	NameRequestLease       = []byte("RqLs") // SMB2_CREATE_REQUEST_LEASE
+)
+
+// headerSize is the fixed SMB2_CREATE_CONTEXT header: Next(4) NameOffset(2)
+// NameLength(2) Reserved(2) DataOffset(2) DataLength(4).
+const headerSize = 16
+
+// CreateContext is a single SMB2_CREATE_CONTEXT: a name tag and its associated
+// data buffer (either may drive the create behavior; Data is empty for contexts
+// that carry only a name).
+type CreateContext struct {
+	Name []byte
+	Data []byte
+}
+
+// align8 rounds n up to the next multiple of 8.
+func align8(n int) int {
+	return (n + 7) &^ 7
+}
+
+// Marshal encodes a list of create contexts into the chained, 8-byte-aligned
+// buffer carried by CreateRequest/CreateResponse.CreateContexts. Each context's
+// Name is placed immediately after the 16-byte header; its Data (when present)
+// follows on the next 8-byte boundary. Every context except the last is padded so
+// the next begins on an 8-byte boundary, and its Next field is set accordingly.
+func Marshal(contexts []CreateContext) ([]byte, error) {
+	if len(contexts) == 0 {
+		return nil, nil
+	}
+
+	var out []byte
+	for i, ctx := range contexts {
+		nameOffset := headerSize
+		dataOffset := 0
+		// Data, when present, starts on the 8-byte boundary after the name.
+		if len(ctx.Data) > 0 {
+			dataOffset = align8(headerSize + len(ctx.Name))
+		}
+
+		segLen := headerSize + len(ctx.Name)
+		if len(ctx.Data) > 0 {
+			segLen = dataOffset + len(ctx.Data)
+		}
+
+		isLast := i == len(contexts)-1
+		padded := segLen
+		if !isLast {
+			padded = align8(segLen)
+		}
+
+		seg := make([]byte, padded)
+		if !isLast {
+			binary.LittleEndian.PutUint32(seg[0:4], uint32(padded)) // Next
+		}
+		binary.LittleEndian.PutUint16(seg[4:6], uint16(nameOffset))
+		binary.LittleEndian.PutUint16(seg[6:8], uint16(len(ctx.Name)))
+		// seg[8:10] Reserved = 0
+		if len(ctx.Data) > 0 {
+			binary.LittleEndian.PutUint16(seg[10:12], uint16(dataOffset))
+			binary.LittleEndian.PutUint32(seg[12:16], uint32(len(ctx.Data)))
+			copy(seg[dataOffset:], ctx.Data)
+		}
+		copy(seg[nameOffset:], ctx.Name)
+
+		out = append(out, seg...)
+	}
+	return out, nil
+}
+
+// Parse decodes a chained SMB2_CREATE_CONTEXT buffer into its contexts. All
+// offsets and lengths are validated against the buffer, so a malformed
+// (server-controlled) list is rejected rather than indexing out of range.
+func Parse(buf []byte) ([]CreateContext, error) {
+	var out []CreateContext
+	offset := 0
+	for offset < len(buf) {
+		if len(buf)-offset < headerSize {
+			return nil, fmt.Errorf("create context at offset %d shorter than header", offset)
+		}
+		ctx := buf[offset:]
+		next := int(binary.LittleEndian.Uint32(ctx[0:4]))
+		nameOffset := int(binary.LittleEndian.Uint16(ctx[4:6]))
+		nameLength := int(binary.LittleEndian.Uint16(ctx[6:8]))
+		dataOffset := int(binary.LittleEndian.Uint16(ctx[10:12]))
+		dataLength := int(binary.LittleEndian.Uint32(ctx[12:16]))
+
+		// The fields above index within this context. Bound the context to the
+		// remaining buffer (or to Next when set) before slicing name/data.
+		ctxEnd := len(buf) - offset
+		if next != 0 {
+			if next < headerSize || offset+next > len(buf) {
+				return nil, fmt.Errorf("create context Next %d at offset %d out of bounds", next, offset)
+			}
+			ctxEnd = next
+		}
+
+		var name, data []byte
+		if nameLength > 0 {
+			if nameOffset < headerSize || nameOffset+nameLength > ctxEnd {
+				return nil, fmt.Errorf("create context name [%d:%d] at offset %d out of bounds", nameOffset, nameOffset+nameLength, offset)
+			}
+			name = append([]byte{}, ctx[nameOffset:nameOffset+nameLength]...)
+		}
+		if dataLength > 0 {
+			if dataOffset < headerSize || dataOffset+dataLength > ctxEnd {
+				return nil, fmt.Errorf("create context data [%d:%d] at offset %d out of bounds", dataOffset, dataOffset+dataLength, offset)
+			}
+			data = append([]byte{}, ctx[dataOffset:dataOffset+dataLength]...)
+		}
+		out = append(out, CreateContext{Name: name, Data: data})
+
+		if next == 0 {
+			break
+		}
+		offset += next
+	}
+	return out, nil
+}

--- a/network/smb/smb_v20/createcontext/createcontext_test.go
+++ b/network/smb/smb_v20/createcontext/createcontext_test.go
@@ -1,0 +1,97 @@
+package createcontext
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestMarshalParseSingleNoData(t *testing.T) {
+	in := []CreateContext{{Name: NameQueryMaximalAccess}}
+	buf, err := Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	got, err := Parse(buf)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("parsed %d contexts, want 1", len(got))
+	}
+	if !bytes.Equal(got[0].Name, NameQueryMaximalAccess) {
+		t.Errorf("name = % x, want % x", got[0].Name, NameQueryMaximalAccess)
+	}
+	if len(got[0].Data) != 0 {
+		t.Errorf("expected no data, got % x", got[0].Data)
+	}
+}
+
+func TestMarshalParseWithData(t *testing.T) {
+	in := []CreateContext{
+		{Name: NameDurableHandleReq, Data: bytes.Repeat([]byte{0xAB}, 16)},
+		{Name: NameAllocationSize, Data: []byte{0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
+	}
+	buf, err := Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	got, err := Parse(buf)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("parsed %d contexts, want 2", len(got))
+	}
+	for i := range in {
+		if !bytes.Equal(got[i].Name, in[i].Name) {
+			t.Errorf("context %d name = % x, want % x", i, got[i].Name, in[i].Name)
+		}
+		if !bytes.Equal(got[i].Data, in[i].Data) {
+			t.Errorf("context %d data = % x, want % x", i, got[i].Data, in[i].Data)
+		}
+	}
+}
+
+func TestMarshalEmpty(t *testing.T) {
+	buf, err := Marshal(nil)
+	if err != nil {
+		t.Fatalf("Marshal(nil): %v", err)
+	}
+	if buf != nil {
+		t.Errorf("Marshal(nil) = % x, want nil", buf)
+	}
+}
+
+func TestParseRejectsTruncatedHeader(t *testing.T) {
+	if _, err := Parse([]byte{0x00, 0x00, 0x00}); err == nil {
+		t.Error("Parse should reject a buffer shorter than the context header")
+	}
+}
+
+func TestParseRejectsOutOfBoundsNameOffset(t *testing.T) {
+	// Build a valid single context, then corrupt its NameLength to run past the
+	// buffer; Parse must reject it rather than slicing out of range.
+	buf, err := Marshal([]CreateContext{{Name: NameRequestLease, Data: []byte{1, 2, 3, 4}}})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	// NameLength is at bytes [6:8]; set it absurdly large.
+	buf[6] = 0xFF
+	buf[7] = 0xFF
+	if _, err := Parse(buf); err == nil {
+		t.Error("Parse should reject a name length that exceeds the buffer")
+	}
+}
+
+func TestParseRejectsCyclicNext(t *testing.T) {
+	// A context whose Next points back into itself (< headerSize) is rejected.
+	buf, err := Marshal([]CreateContext{{Name: NameTimewarpToken}})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	// Set Next (bytes [0:4]) to 4, which is < headerSize.
+	buf[0] = 0x04
+	if _, err := Parse(buf); err == nil {
+		t.Error("Parse should reject a Next offset smaller than the header")
+	}
+}

--- a/windows/filesystem/file_all_information.go
+++ b/windows/filesystem/file_all_information.go
@@ -1,0 +1,111 @@
+package filesystem
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+// FileAllInformation is FILE_ALL_INFORMATION (FileInformationClass 18): the
+// aggregate query result combining the Basic, Standard, Internal, EA, Access,
+// Position, Mode, Alignment, and Name information classes for an open file.
+//
+// The small single-field classes are flattened into scalar fields here:
+// IndexNumber (FILE_INTERNAL_INFORMATION), EaSize (FILE_EA_INFORMATION),
+// AccessFlags (FILE_ACCESS_INFORMATION), CurrentByteOffset
+// (FILE_POSITION_INFORMATION), Mode (FILE_MODE_INFORMATION), and
+// AlignmentRequirement (FILE_ALIGNMENT_INFORMATION). FileName is the
+// FILE_NAME_INFORMATION value (UTF-16LE on the wire).
+//
+// [MS-FSCC] 2.4.2 FileAllInformation:
+// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/95f3056a-ebc1-4f5d-b938-3f68a44677a6
+type FileAllInformation struct {
+	Basic                FileBasicInformation
+	Standard             FileStandardInformation
+	IndexNumber          int64  // FILE_INTERNAL_INFORMATION
+	EaSize               uint32 // FILE_EA_INFORMATION
+	AccessFlags          uint32 // FILE_ACCESS_INFORMATION
+	CurrentByteOffset    int64  // FILE_POSITION_INFORMATION
+	Mode                 uint32 // FILE_MODE_INFORMATION
+	AlignmentRequirement uint32 // FILE_ALIGNMENT_INFORMATION
+	FileName             string // FILE_NAME_INFORMATION
+}
+
+// fileAllInformationFixedSize is the size of FILE_ALL_INFORMATION up to (but not
+// including) the variable FileName: Basic(40) Standard(24) Internal(8) EA(4)
+// Access(4) Position(8) Mode(4) Alignment(4) FileNameLength(4) = 100.
+const fileAllInformationFixedSize = FileBasicInformationSize + FileStandardInformationSize + 8 + 4 + 4 + 8 + 4 + 4 + 4
+
+// Marshal encodes the structure to its wire form (fixed prefix + FileName).
+func (fi *FileAllInformation) Marshal() ([]byte, error) {
+	name := encodeUTF16LE(fi.FileName)
+
+	basic, err := fi.Basic.Marshal()
+	if err != nil {
+		return nil, err
+	}
+	standard, err := fi.Standard.Marshal()
+	if err != nil {
+		return nil, err
+	}
+
+	b := make([]byte, fileAllInformationFixedSize+len(name))
+	off := 0
+	copy(b[off:], basic)
+	off += FileBasicInformationSize
+	copy(b[off:], standard)
+	off += FileStandardInformationSize
+	binary.LittleEndian.PutUint64(b[off:off+8], uint64(fi.IndexNumber))
+	off += 8
+	binary.LittleEndian.PutUint32(b[off:off+4], fi.EaSize)
+	off += 4
+	binary.LittleEndian.PutUint32(b[off:off+4], fi.AccessFlags)
+	off += 4
+	binary.LittleEndian.PutUint64(b[off:off+8], uint64(fi.CurrentByteOffset))
+	off += 8
+	binary.LittleEndian.PutUint32(b[off:off+4], fi.Mode)
+	off += 4
+	binary.LittleEndian.PutUint32(b[off:off+4], fi.AlignmentRequirement)
+	off += 4
+	binary.LittleEndian.PutUint32(b[off:off+4], uint32(len(name)))
+	off += 4
+	copy(b[off:], name)
+	return b, nil
+}
+
+// Unmarshal decodes the structure from its wire form. A buffer carrying only the
+// fixed prefix (FileNameLength 0 or a truncated name) yields an empty FileName.
+func (fi *FileAllInformation) Unmarshal(data []byte) error {
+	if len(data) < fileAllInformationFixedSize {
+		return fmt.Errorf("FILE_ALL_INFORMATION: need %d bytes, got %d", fileAllInformationFixedSize, len(data))
+	}
+	off := 0
+	if err := fi.Basic.Unmarshal(data[off : off+FileBasicInformationSize]); err != nil {
+		return err
+	}
+	off += FileBasicInformationSize
+	if err := fi.Standard.Unmarshal(data[off : off+FileStandardInformationSize]); err != nil {
+		return err
+	}
+	off += FileStandardInformationSize
+	fi.IndexNumber = int64(binary.LittleEndian.Uint64(data[off : off+8]))
+	off += 8
+	fi.EaSize = binary.LittleEndian.Uint32(data[off : off+4])
+	off += 4
+	fi.AccessFlags = binary.LittleEndian.Uint32(data[off : off+4])
+	off += 4
+	fi.CurrentByteOffset = int64(binary.LittleEndian.Uint64(data[off : off+8]))
+	off += 8
+	fi.Mode = binary.LittleEndian.Uint32(data[off : off+4])
+	off += 4
+	fi.AlignmentRequirement = binary.LittleEndian.Uint32(data[off : off+4])
+	off += 4
+	nameLen := int(binary.LittleEndian.Uint32(data[off : off+4]))
+	off += 4
+
+	if nameLen > 0 && off+nameLen <= len(data) {
+		fi.FileName = decodeUTF16LE(data[off : off+nameLen])
+	} else {
+		fi.FileName = ""
+	}
+	return nil
+}

--- a/windows/filesystem/file_directory_information.go
+++ b/windows/filesystem/file_directory_information.go
@@ -1,0 +1,347 @@
+package filesystem
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+// Directory-enumeration information classes (the payloads of SMB2 QUERY_DIRECTORY,
+// MS-FSCC 2.4). Each class is a sequence of variable-length entries chained by a
+// NextEntryOffset field; the last entry has NextEntryOffset == 0. The per-class
+// Unmarshal decodes a single entry from the start of a buffer; the package
+// Parse*List helpers walk a full multi-entry buffer.
+
+// FileFullDirectoryInformation is FILE_FULL_DIR_INFORMATION
+// (FileInformationClass 2): a directory entry with timestamps, sizes,
+// attributes, and EA size.
+//
+// [MS-FSCC] 2.4.14 FileFullDirectoryInformation:
+// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/e6d24f0e-fa87-4d8d-aa9d-a30c5cf75c0e
+type FileFullDirectoryInformation struct {
+	NextEntryOffset uint32
+	FileIndex       uint32
+	CreationTime    uint64
+	LastAccessTime  uint64
+	LastWriteTime   uint64
+	ChangeTime      uint64
+	EndOfFile       int64
+	AllocationSize  int64
+	FileAttributes  uint32
+	EaSize          uint32
+	FileName        string
+}
+
+// fileFullDirInfoFixedSize is the fixed portion preceding FileName.
+const fileFullDirInfoFixedSize = 68
+
+// Marshal encodes a single entry (fixed prefix + FileName). NextEntryOffset is
+// written verbatim; callers chaining entries set it themselves.
+func (fi *FileFullDirectoryInformation) Marshal() ([]byte, error) {
+	name := encodeUTF16LE(fi.FileName)
+	b := make([]byte, fileFullDirInfoFixedSize+len(name))
+	binary.LittleEndian.PutUint32(b[0:4], fi.NextEntryOffset)
+	binary.LittleEndian.PutUint32(b[4:8], fi.FileIndex)
+	binary.LittleEndian.PutUint64(b[8:16], fi.CreationTime)
+	binary.LittleEndian.PutUint64(b[16:24], fi.LastAccessTime)
+	binary.LittleEndian.PutUint64(b[24:32], fi.LastWriteTime)
+	binary.LittleEndian.PutUint64(b[32:40], fi.ChangeTime)
+	binary.LittleEndian.PutUint64(b[40:48], uint64(fi.EndOfFile))
+	binary.LittleEndian.PutUint64(b[48:56], uint64(fi.AllocationSize))
+	binary.LittleEndian.PutUint32(b[56:60], fi.FileAttributes)
+	binary.LittleEndian.PutUint32(b[60:64], uint32(len(name)))
+	binary.LittleEndian.PutUint32(b[64:68], fi.EaSize)
+	copy(b[fileFullDirInfoFixedSize:], name)
+	return b, nil
+}
+
+// Unmarshal decodes a single entry from the start of data.
+func (fi *FileFullDirectoryInformation) Unmarshal(data []byte) error {
+	if len(data) < fileFullDirInfoFixedSize {
+		return fmt.Errorf("FILE_FULL_DIR_INFORMATION: need %d bytes, got %d", fileFullDirInfoFixedSize, len(data))
+	}
+	fi.NextEntryOffset = binary.LittleEndian.Uint32(data[0:4])
+	fi.FileIndex = binary.LittleEndian.Uint32(data[4:8])
+	fi.CreationTime = binary.LittleEndian.Uint64(data[8:16])
+	fi.LastAccessTime = binary.LittleEndian.Uint64(data[16:24])
+	fi.LastWriteTime = binary.LittleEndian.Uint64(data[24:32])
+	fi.ChangeTime = binary.LittleEndian.Uint64(data[32:40])
+	fi.EndOfFile = int64(binary.LittleEndian.Uint64(data[40:48]))
+	fi.AllocationSize = int64(binary.LittleEndian.Uint64(data[48:56]))
+	fi.FileAttributes = binary.LittleEndian.Uint32(data[56:60])
+	nameLen := int(binary.LittleEndian.Uint32(data[60:64]))
+	fi.EaSize = binary.LittleEndian.Uint32(data[64:68])
+	if nameLen > 0 && fileFullDirInfoFixedSize+nameLen <= len(data) {
+		fi.FileName = decodeUTF16LE(data[fileFullDirInfoFixedSize : fileFullDirInfoFixedSize+nameLen])
+	}
+	return nil
+}
+
+// ParseFileFullDirectoryInformationList decodes a chained buffer of
+// FILE_FULL_DIR_INFORMATION entries.
+func ParseFileFullDirectoryInformationList(buf []byte) []FileFullDirectoryInformation {
+	var out []FileFullDirectoryInformation
+	for pos := 0; pos+fileFullDirInfoFixedSize <= len(buf); {
+		var e FileFullDirectoryInformation
+		if err := e.Unmarshal(buf[pos:]); err != nil {
+			break
+		}
+		out = append(out, e)
+		if e.NextEntryOffset == 0 {
+			break
+		}
+		pos += int(e.NextEntryOffset)
+	}
+	return out
+}
+
+// FileBothDirectoryInformation is FILE_BOTH_DIR_INFORMATION (FileInformationClass
+// 3): a FILE_FULL_DIR_INFORMATION entry plus the 8.3 short name.
+//
+// [MS-FSCC] 2.4.8 FileBothDirectoryInformation:
+// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/270df317-9ba5-4ccb-ba00-8d22be139bc5
+type FileBothDirectoryInformation struct {
+	NextEntryOffset uint32
+	FileIndex       uint32
+	CreationTime    uint64
+	LastAccessTime  uint64
+	LastWriteTime   uint64
+	ChangeTime      uint64
+	EndOfFile       int64
+	AllocationSize  int64
+	FileAttributes  uint32
+	EaSize          uint32
+	ShortName       string // 8.3 name, UTF-16LE, max 12 chars
+	FileName        string
+}
+
+// fileBothDirInfoFixedSize is the fixed portion preceding FileName: the full-dir
+// prefix (68) plus ShortNameLength(1) Reserved(1) ShortName(24).
+const fileBothDirInfoFixedSize = 94
+
+// Marshal encodes a single entry (fixed prefix + FileName).
+func (fi *FileBothDirectoryInformation) Marshal() ([]byte, error) {
+	name := encodeUTF16LE(fi.FileName)
+	short := encodeUTF16LE(fi.ShortName)
+	if len(short) > 24 {
+		return nil, fmt.Errorf("FILE_BOTH_DIR_INFORMATION: short name exceeds 24 bytes (got %d)", len(short))
+	}
+	b := make([]byte, fileBothDirInfoFixedSize+len(name))
+	binary.LittleEndian.PutUint32(b[0:4], fi.NextEntryOffset)
+	binary.LittleEndian.PutUint32(b[4:8], fi.FileIndex)
+	binary.LittleEndian.PutUint64(b[8:16], fi.CreationTime)
+	binary.LittleEndian.PutUint64(b[16:24], fi.LastAccessTime)
+	binary.LittleEndian.PutUint64(b[24:32], fi.LastWriteTime)
+	binary.LittleEndian.PutUint64(b[32:40], fi.ChangeTime)
+	binary.LittleEndian.PutUint64(b[40:48], uint64(fi.EndOfFile))
+	binary.LittleEndian.PutUint64(b[48:56], uint64(fi.AllocationSize))
+	binary.LittleEndian.PutUint32(b[56:60], fi.FileAttributes)
+	binary.LittleEndian.PutUint32(b[60:64], uint32(len(name)))
+	binary.LittleEndian.PutUint32(b[64:68], fi.EaSize)
+	b[68] = byte(len(short))
+	// b[69] Reserved = 0
+	copy(b[70:94], short)
+	copy(b[fileBothDirInfoFixedSize:], name)
+	return b, nil
+}
+
+// Unmarshal decodes a single entry from the start of data.
+func (fi *FileBothDirectoryInformation) Unmarshal(data []byte) error {
+	if len(data) < fileBothDirInfoFixedSize {
+		return fmt.Errorf("FILE_BOTH_DIR_INFORMATION: need %d bytes, got %d", fileBothDirInfoFixedSize, len(data))
+	}
+	fi.NextEntryOffset = binary.LittleEndian.Uint32(data[0:4])
+	fi.FileIndex = binary.LittleEndian.Uint32(data[4:8])
+	fi.CreationTime = binary.LittleEndian.Uint64(data[8:16])
+	fi.LastAccessTime = binary.LittleEndian.Uint64(data[16:24])
+	fi.LastWriteTime = binary.LittleEndian.Uint64(data[24:32])
+	fi.ChangeTime = binary.LittleEndian.Uint64(data[32:40])
+	fi.EndOfFile = int64(binary.LittleEndian.Uint64(data[40:48]))
+	fi.AllocationSize = int64(binary.LittleEndian.Uint64(data[48:56]))
+	fi.FileAttributes = binary.LittleEndian.Uint32(data[56:60])
+	nameLen := int(binary.LittleEndian.Uint32(data[60:64]))
+	fi.EaSize = binary.LittleEndian.Uint32(data[64:68])
+	shortLen := int(data[68])
+	if shortLen > 24 {
+		shortLen = 24
+	}
+	fi.ShortName = decodeUTF16LE(data[70 : 70+shortLen])
+	if nameLen > 0 && fileBothDirInfoFixedSize+nameLen <= len(data) {
+		fi.FileName = decodeUTF16LE(data[fileBothDirInfoFixedSize : fileBothDirInfoFixedSize+nameLen])
+	}
+	return nil
+}
+
+// ParseFileBothDirectoryInformationList decodes a chained buffer of
+// FILE_BOTH_DIR_INFORMATION entries.
+func ParseFileBothDirectoryInformationList(buf []byte) []FileBothDirectoryInformation {
+	var out []FileBothDirectoryInformation
+	for pos := 0; pos+fileBothDirInfoFixedSize <= len(buf); {
+		var e FileBothDirectoryInformation
+		if err := e.Unmarshal(buf[pos:]); err != nil {
+			break
+		}
+		out = append(out, e)
+		if e.NextEntryOffset == 0 {
+			break
+		}
+		pos += int(e.NextEntryOffset)
+	}
+	return out
+}
+
+// FileIdBothDirectoryInformation is FILE_ID_BOTH_DIR_INFORMATION
+// (FileInformationClass 37): a FILE_BOTH_DIR_INFORMATION entry plus the 64-bit
+// file id.
+//
+// [MS-FSCC] 2.4.17 FileIdBothDirectoryInformation:
+// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/9b0b9971-85aa-4651-8438-f1c4298bcb0d
+type FileIdBothDirectoryInformation struct {
+	NextEntryOffset uint32
+	FileIndex       uint32
+	CreationTime    uint64
+	LastAccessTime  uint64
+	LastWriteTime   uint64
+	ChangeTime      uint64
+	EndOfFile       int64
+	AllocationSize  int64
+	FileAttributes  uint32
+	EaSize          uint32
+	ShortName       string
+	FileId          uint64
+	FileName        string
+}
+
+// fileIdBothDirInfoFixedSize is the fixed portion preceding FileName: the both-dir
+// prefix (94) plus Reserved2(2) FileId(8).
+const fileIdBothDirInfoFixedSize = 104
+
+// Marshal encodes a single entry (fixed prefix + FileName).
+func (fi *FileIdBothDirectoryInformation) Marshal() ([]byte, error) {
+	name := encodeUTF16LE(fi.FileName)
+	short := encodeUTF16LE(fi.ShortName)
+	if len(short) > 24 {
+		return nil, fmt.Errorf("FILE_ID_BOTH_DIR_INFORMATION: short name exceeds 24 bytes (got %d)", len(short))
+	}
+	b := make([]byte, fileIdBothDirInfoFixedSize+len(name))
+	binary.LittleEndian.PutUint32(b[0:4], fi.NextEntryOffset)
+	binary.LittleEndian.PutUint32(b[4:8], fi.FileIndex)
+	binary.LittleEndian.PutUint64(b[8:16], fi.CreationTime)
+	binary.LittleEndian.PutUint64(b[16:24], fi.LastAccessTime)
+	binary.LittleEndian.PutUint64(b[24:32], fi.LastWriteTime)
+	binary.LittleEndian.PutUint64(b[32:40], fi.ChangeTime)
+	binary.LittleEndian.PutUint64(b[40:48], uint64(fi.EndOfFile))
+	binary.LittleEndian.PutUint64(b[48:56], uint64(fi.AllocationSize))
+	binary.LittleEndian.PutUint32(b[56:60], fi.FileAttributes)
+	binary.LittleEndian.PutUint32(b[60:64], uint32(len(name)))
+	binary.LittleEndian.PutUint32(b[64:68], fi.EaSize)
+	b[68] = byte(len(short))
+	// b[69] Reserved1 = 0
+	copy(b[70:94], short)
+	// b[94:96] Reserved2 = 0
+	binary.LittleEndian.PutUint64(b[96:104], fi.FileId)
+	copy(b[fileIdBothDirInfoFixedSize:], name)
+	return b, nil
+}
+
+// Unmarshal decodes a single entry from the start of data.
+func (fi *FileIdBothDirectoryInformation) Unmarshal(data []byte) error {
+	if len(data) < fileIdBothDirInfoFixedSize {
+		return fmt.Errorf("FILE_ID_BOTH_DIR_INFORMATION: need %d bytes, got %d", fileIdBothDirInfoFixedSize, len(data))
+	}
+	fi.NextEntryOffset = binary.LittleEndian.Uint32(data[0:4])
+	fi.FileIndex = binary.LittleEndian.Uint32(data[4:8])
+	fi.CreationTime = binary.LittleEndian.Uint64(data[8:16])
+	fi.LastAccessTime = binary.LittleEndian.Uint64(data[16:24])
+	fi.LastWriteTime = binary.LittleEndian.Uint64(data[24:32])
+	fi.ChangeTime = binary.LittleEndian.Uint64(data[32:40])
+	fi.EndOfFile = int64(binary.LittleEndian.Uint64(data[40:48]))
+	fi.AllocationSize = int64(binary.LittleEndian.Uint64(data[48:56]))
+	fi.FileAttributes = binary.LittleEndian.Uint32(data[56:60])
+	nameLen := int(binary.LittleEndian.Uint32(data[60:64]))
+	fi.EaSize = binary.LittleEndian.Uint32(data[64:68])
+	shortLen := int(data[68])
+	if shortLen > 24 {
+		shortLen = 24
+	}
+	fi.ShortName = decodeUTF16LE(data[70 : 70+shortLen])
+	fi.FileId = binary.LittleEndian.Uint64(data[96:104])
+	if nameLen > 0 && fileIdBothDirInfoFixedSize+nameLen <= len(data) {
+		fi.FileName = decodeUTF16LE(data[fileIdBothDirInfoFixedSize : fileIdBothDirInfoFixedSize+nameLen])
+	}
+	return nil
+}
+
+// ParseFileIdBothDirectoryInformationList decodes a chained buffer of
+// FILE_ID_BOTH_DIR_INFORMATION entries.
+func ParseFileIdBothDirectoryInformationList(buf []byte) []FileIdBothDirectoryInformation {
+	var out []FileIdBothDirectoryInformation
+	for pos := 0; pos+fileIdBothDirInfoFixedSize <= len(buf); {
+		var e FileIdBothDirectoryInformation
+		if err := e.Unmarshal(buf[pos:]); err != nil {
+			break
+		}
+		out = append(out, e)
+		if e.NextEntryOffset == 0 {
+			break
+		}
+		pos += int(e.NextEntryOffset)
+	}
+	return out
+}
+
+// FileNamesInformation is FILE_NAMES_INFORMATION (FileInformationClass 12): a
+// directory entry carrying only the file name.
+//
+// [MS-FSCC] 2.4.26 FileNamesInformation:
+// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/a289f7a8-83d2-4927-8c88-b2d328dde5b5
+type FileNamesInformation struct {
+	NextEntryOffset uint32
+	FileIndex       uint32
+	FileName        string
+}
+
+// fileNamesInfoFixedSize is the fixed portion preceding FileName.
+const fileNamesInfoFixedSize = 12
+
+// Marshal encodes a single entry (fixed prefix + FileName).
+func (fi *FileNamesInformation) Marshal() ([]byte, error) {
+	name := encodeUTF16LE(fi.FileName)
+	b := make([]byte, fileNamesInfoFixedSize+len(name))
+	binary.LittleEndian.PutUint32(b[0:4], fi.NextEntryOffset)
+	binary.LittleEndian.PutUint32(b[4:8], fi.FileIndex)
+	binary.LittleEndian.PutUint32(b[8:12], uint32(len(name)))
+	copy(b[fileNamesInfoFixedSize:], name)
+	return b, nil
+}
+
+// Unmarshal decodes a single entry from the start of data.
+func (fi *FileNamesInformation) Unmarshal(data []byte) error {
+	if len(data) < fileNamesInfoFixedSize {
+		return fmt.Errorf("FILE_NAMES_INFORMATION: need %d bytes, got %d", fileNamesInfoFixedSize, len(data))
+	}
+	fi.NextEntryOffset = binary.LittleEndian.Uint32(data[0:4])
+	fi.FileIndex = binary.LittleEndian.Uint32(data[4:8])
+	nameLen := int(binary.LittleEndian.Uint32(data[8:12]))
+	if nameLen > 0 && fileNamesInfoFixedSize+nameLen <= len(data) {
+		fi.FileName = decodeUTF16LE(data[fileNamesInfoFixedSize : fileNamesInfoFixedSize+nameLen])
+	}
+	return nil
+}
+
+// ParseFileNamesInformationList decodes a chained buffer of
+// FILE_NAMES_INFORMATION entries.
+func ParseFileNamesInformationList(buf []byte) []FileNamesInformation {
+	var out []FileNamesInformation
+	for pos := 0; pos+fileNamesInfoFixedSize <= len(buf); {
+		var e FileNamesInformation
+		if err := e.Unmarshal(buf[pos:]); err != nil {
+			break
+		}
+		out = append(out, e)
+		if e.NextEntryOffset == 0 {
+			break
+		}
+		pos += int(e.NextEntryOffset)
+	}
+	return out
+}

--- a/windows/filesystem/file_network_open_information.go
+++ b/windows/filesystem/file_network_open_information.go
@@ -1,0 +1,58 @@
+package filesystem
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+// FileNetworkOpenInformation is FILE_NETWORK_OPEN_INFORMATION
+// (FileInformationClass 34): the timestamps, sizes, and attributes returned for a
+// network-open query, equivalent to the data a CREATE response carries. FILETIME
+// fields are 100ns ticks since 1601-01-01 UTC. Fixed 56-byte wire layout.
+//
+// [MS-FSCC] 2.4.29 FileNetworkOpenInformation:
+// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/b8e3957e-f16e-49b8-b8b1-58b9b22f3f54
+type FileNetworkOpenInformation struct {
+	CreationTime   uint64
+	LastAccessTime uint64
+	LastWriteTime  uint64
+	ChangeTime     uint64
+	AllocationSize int64
+	EndOfFile      int64
+	FileAttributes uint32
+	Reserved       uint32
+}
+
+// FileNetworkOpenInformationSize is the fixed wire size of
+// FILE_NETWORK_OPEN_INFORMATION.
+const FileNetworkOpenInformationSize = 56
+
+// Marshal encodes the structure to its 56-byte wire form.
+func (fi *FileNetworkOpenInformation) Marshal() ([]byte, error) {
+	b := make([]byte, FileNetworkOpenInformationSize)
+	binary.LittleEndian.PutUint64(b[0:8], fi.CreationTime)
+	binary.LittleEndian.PutUint64(b[8:16], fi.LastAccessTime)
+	binary.LittleEndian.PutUint64(b[16:24], fi.LastWriteTime)
+	binary.LittleEndian.PutUint64(b[24:32], fi.ChangeTime)
+	binary.LittleEndian.PutUint64(b[32:40], uint64(fi.AllocationSize))
+	binary.LittleEndian.PutUint64(b[40:48], uint64(fi.EndOfFile))
+	binary.LittleEndian.PutUint32(b[48:52], fi.FileAttributes)
+	binary.LittleEndian.PutUint32(b[52:56], fi.Reserved)
+	return b, nil
+}
+
+// Unmarshal decodes the structure from its wire form.
+func (fi *FileNetworkOpenInformation) Unmarshal(data []byte) error {
+	if len(data) < FileNetworkOpenInformationSize {
+		return fmt.Errorf("FILE_NETWORK_OPEN_INFORMATION: need %d bytes, got %d", FileNetworkOpenInformationSize, len(data))
+	}
+	fi.CreationTime = binary.LittleEndian.Uint64(data[0:8])
+	fi.LastAccessTime = binary.LittleEndian.Uint64(data[8:16])
+	fi.LastWriteTime = binary.LittleEndian.Uint64(data[16:24])
+	fi.ChangeTime = binary.LittleEndian.Uint64(data[24:32])
+	fi.AllocationSize = int64(binary.LittleEndian.Uint64(data[32:40]))
+	fi.EndOfFile = int64(binary.LittleEndian.Uint64(data[40:48]))
+	fi.FileAttributes = binary.LittleEndian.Uint32(data[48:52])
+	fi.Reserved = binary.LittleEndian.Uint32(data[52:56])
+	return nil
+}

--- a/windows/filesystem/fs_information.go
+++ b/windows/filesystem/fs_information.go
@@ -42,3 +42,167 @@ func (fi *FileFsSizeInformation) TotalBytes() uint64 {
 func (fi *FileFsSizeInformation) AvailableBytes() uint64 {
 	return uint64(fi.AvailableAllocationUnits) * uint64(fi.SectorsPerAllocationUnit) * uint64(fi.BytesPerSector)
 }
+
+// FileFsVolumeInformation is FILE_FS_VOLUME_INFORMATION (FsInformationClass 1):
+// the volume creation time, serial number, label, and object-id support flag.
+// VolumeCreationTime is a FILETIME (100ns ticks since 1601-01-01 UTC). The fixed
+// 18-byte prefix is followed by the UTF-16LE VolumeLabel.
+//
+// [MS-FSCC] 2.5.9 FileFsVolumeInformation:
+// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/bf691378-c34e-4a13-976e-404ea1a87738
+type FileFsVolumeInformation struct {
+	VolumeCreationTime uint64
+	VolumeSerialNumber uint32
+	SupportsObjects    bool
+	VolumeLabel        string
+}
+
+// fileFsVolumeInfoFixedSize is the fixed portion preceding VolumeLabel:
+// VolumeCreationTime(8) VolumeSerialNumber(4) VolumeLabelLength(4)
+// SupportsObjects(1) Reserved(1).
+const fileFsVolumeInfoFixedSize = 18
+
+// Marshal encodes the structure to its wire form (fixed prefix + VolumeLabel).
+func (fi *FileFsVolumeInformation) Marshal() ([]byte, error) {
+	label := encodeUTF16LE(fi.VolumeLabel)
+	b := make([]byte, fileFsVolumeInfoFixedSize+len(label))
+	binary.LittleEndian.PutUint64(b[0:8], fi.VolumeCreationTime)
+	binary.LittleEndian.PutUint32(b[8:12], fi.VolumeSerialNumber)
+	binary.LittleEndian.PutUint32(b[12:16], uint32(len(label)))
+	if fi.SupportsObjects {
+		b[16] = 1
+	}
+	// b[17] Reserved = 0
+	copy(b[fileFsVolumeInfoFixedSize:], label)
+	return b, nil
+}
+
+// Unmarshal decodes the structure from its wire form.
+func (fi *FileFsVolumeInformation) Unmarshal(data []byte) error {
+	if len(data) < fileFsVolumeInfoFixedSize {
+		return fmt.Errorf("FILE_FS_VOLUME_INFORMATION: need %d bytes, got %d", fileFsVolumeInfoFixedSize, len(data))
+	}
+	fi.VolumeCreationTime = binary.LittleEndian.Uint64(data[0:8])
+	fi.VolumeSerialNumber = binary.LittleEndian.Uint32(data[8:12])
+	labelLen := int(binary.LittleEndian.Uint32(data[12:16]))
+	fi.SupportsObjects = data[16] != 0
+	if labelLen > 0 && fileFsVolumeInfoFixedSize+labelLen <= len(data) {
+		fi.VolumeLabel = decodeUTF16LE(data[fileFsVolumeInfoFixedSize : fileFsVolumeInfoFixedSize+labelLen])
+	}
+	return nil
+}
+
+// FileFsFullSizeInformation is FILE_FS_FULL_SIZE_INFORMATION (FsInformationClass
+// 7): like FileFsSizeInformation but distinguishing the caller's available
+// allocation units (quota-limited) from the volume's actual free units. Fixed
+// 32-byte wire layout.
+//
+// [MS-FSCC] 2.5.4 FileFsFullSizeInformation:
+// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/63768db7-9012-4209-8cca-00781e7322f5
+type FileFsFullSizeInformation struct {
+	TotalAllocationUnits           int64
+	CallerAvailableAllocationUnits int64
+	ActualAvailableAllocationUnits int64
+	SectorsPerAllocationUnit       uint32
+	BytesPerSector                 uint32
+}
+
+// FileFsFullSizeInformationSize is the fixed wire size of
+// FILE_FS_FULL_SIZE_INFORMATION.
+const FileFsFullSizeInformationSize = 32
+
+// Marshal encodes the structure to its 32-byte wire form.
+func (fi *FileFsFullSizeInformation) Marshal() ([]byte, error) {
+	b := make([]byte, FileFsFullSizeInformationSize)
+	binary.LittleEndian.PutUint64(b[0:8], uint64(fi.TotalAllocationUnits))
+	binary.LittleEndian.PutUint64(b[8:16], uint64(fi.CallerAvailableAllocationUnits))
+	binary.LittleEndian.PutUint64(b[16:24], uint64(fi.ActualAvailableAllocationUnits))
+	binary.LittleEndian.PutUint32(b[24:28], fi.SectorsPerAllocationUnit)
+	binary.LittleEndian.PutUint32(b[28:32], fi.BytesPerSector)
+	return b, nil
+}
+
+// Unmarshal decodes the structure from its wire form.
+func (fi *FileFsFullSizeInformation) Unmarshal(data []byte) error {
+	if len(data) < FileFsFullSizeInformationSize {
+		return fmt.Errorf("FILE_FS_FULL_SIZE_INFORMATION: need %d bytes, got %d", FileFsFullSizeInformationSize, len(data))
+	}
+	fi.TotalAllocationUnits = int64(binary.LittleEndian.Uint64(data[0:8]))
+	fi.CallerAvailableAllocationUnits = int64(binary.LittleEndian.Uint64(data[8:16]))
+	fi.ActualAvailableAllocationUnits = int64(binary.LittleEndian.Uint64(data[16:24]))
+	fi.SectorsPerAllocationUnit = binary.LittleEndian.Uint32(data[24:28])
+	fi.BytesPerSector = binary.LittleEndian.Uint32(data[28:32])
+	return nil
+}
+
+// FileFsAttributeInformation is FILE_FS_ATTRIBUTE_INFORMATION (FsInformationClass
+// 5): the file system's attribute flags, maximum component name length, and file
+// system name. The fixed 12-byte prefix is followed by the UTF-16LE
+// FileSystemName.
+//
+// [MS-FSCC] 2.5.1 FileFsAttributeInformation:
+// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/ebc7e6e5-4650-4e54-b17c-cf60f6fbeeaa
+type FileFsAttributeInformation struct {
+	FileSystemAttributes       uint32
+	MaximumComponentNameLength int32
+	FileSystemName             string
+}
+
+// fileFsAttributeInfoFixedSize is the fixed portion preceding FileSystemName.
+const fileFsAttributeInfoFixedSize = 12
+
+// Marshal encodes the structure to its wire form (fixed prefix + FileSystemName).
+func (fi *FileFsAttributeInformation) Marshal() ([]byte, error) {
+	name := encodeUTF16LE(fi.FileSystemName)
+	b := make([]byte, fileFsAttributeInfoFixedSize+len(name))
+	binary.LittleEndian.PutUint32(b[0:4], fi.FileSystemAttributes)
+	binary.LittleEndian.PutUint32(b[4:8], uint32(fi.MaximumComponentNameLength))
+	binary.LittleEndian.PutUint32(b[8:12], uint32(len(name)))
+	copy(b[fileFsAttributeInfoFixedSize:], name)
+	return b, nil
+}
+
+// Unmarshal decodes the structure from its wire form.
+func (fi *FileFsAttributeInformation) Unmarshal(data []byte) error {
+	if len(data) < fileFsAttributeInfoFixedSize {
+		return fmt.Errorf("FILE_FS_ATTRIBUTE_INFORMATION: need %d bytes, got %d", fileFsAttributeInfoFixedSize, len(data))
+	}
+	fi.FileSystemAttributes = binary.LittleEndian.Uint32(data[0:4])
+	fi.MaximumComponentNameLength = int32(binary.LittleEndian.Uint32(data[4:8]))
+	nameLen := int(binary.LittleEndian.Uint32(data[8:12]))
+	if nameLen > 0 && fileFsAttributeInfoFixedSize+nameLen <= len(data) {
+		fi.FileSystemName = decodeUTF16LE(data[fileFsAttributeInfoFixedSize : fileFsAttributeInfoFixedSize+nameLen])
+	}
+	return nil
+}
+
+// FileFsDeviceInformation is FILE_FS_DEVICE_INFORMATION (FsInformationClass 4):
+// the underlying device type and its characteristics. Fixed 8-byte wire layout.
+//
+// [MS-FSCC] 2.5.10 FileFsDeviceInformation:
+// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/616b66d5-b335-4e1c-8f87-b4a55e8d3e4a
+type FileFsDeviceInformation struct {
+	DeviceType      uint32
+	Characteristics uint32
+}
+
+// FileFsDeviceInformationSize is the fixed wire size of FILE_FS_DEVICE_INFORMATION.
+const FileFsDeviceInformationSize = 8
+
+// Marshal encodes the structure to its 8-byte wire form.
+func (fi *FileFsDeviceInformation) Marshal() ([]byte, error) {
+	b := make([]byte, FileFsDeviceInformationSize)
+	binary.LittleEndian.PutUint32(b[0:4], fi.DeviceType)
+	binary.LittleEndian.PutUint32(b[4:8], fi.Characteristics)
+	return b, nil
+}
+
+// Unmarshal decodes the structure from its wire form.
+func (fi *FileFsDeviceInformation) Unmarshal(data []byte) error {
+	if len(data) < FileFsDeviceInformationSize {
+		return fmt.Errorf("FILE_FS_DEVICE_INFORMATION: need %d bytes, got %d", FileFsDeviceInformationSize, len(data))
+	}
+	fi.DeviceType = binary.LittleEndian.Uint32(data[0:4])
+	fi.Characteristics = binary.LittleEndian.Uint32(data[4:8])
+	return nil
+}

--- a/windows/filesystem/fscc_information_test.go
+++ b/windows/filesystem/fscc_information_test.go
@@ -1,0 +1,252 @@
+package filesystem
+
+import (
+	"testing"
+)
+
+func TestFileNetworkOpenInformationRoundTrip(t *testing.T) {
+	in := &FileNetworkOpenInformation{
+		CreationTime:   0x01D0000000000001,
+		LastAccessTime: 0x01D0000000000002,
+		LastWriteTime:  0x01D0000000000003,
+		ChangeTime:     0x01D0000000000004,
+		AllocationSize: 4096,
+		EndOfFile:      1234,
+		FileAttributes: 0x80,
+		Reserved:       0,
+	}
+	b, err := in.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if len(b) != FileNetworkOpenInformationSize {
+		t.Fatalf("marshalled size = %d, want %d", len(b), FileNetworkOpenInformationSize)
+	}
+	var out FileNetworkOpenInformation
+	if err := out.Unmarshal(b); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out != *in {
+		t.Errorf("round trip mismatch:\n got %+v\nwant %+v", out, *in)
+	}
+	if err := (&FileNetworkOpenInformation{}).Unmarshal(b[:10]); err == nil {
+		t.Error("Unmarshal should reject a short buffer")
+	}
+}
+
+func TestFileAllInformationRoundTrip(t *testing.T) {
+	in := &FileAllInformation{
+		Basic:                FileBasicInformation{CreationTime: 11, LastAccessTime: 22, LastWriteTime: 33, ChangeTime: 44, FileAttributes: 0x20},
+		Standard:             FileStandardInformation{AllocationSize: 8192, EndOfFile: 4096, NumberOfLinks: 1, DeletePending: false, Directory: false},
+		IndexNumber:          0x1122334455667788,
+		EaSize:               7,
+		AccessFlags:          0x001F01FF,
+		CurrentByteOffset:    256,
+		Mode:                 0x10,
+		AlignmentRequirement: 1,
+		FileName:             "report.txt",
+	}
+	b, err := in.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var out FileAllInformation
+	if err := out.Unmarshal(b); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out.Basic != in.Basic || out.Standard != in.Standard || out.IndexNumber != in.IndexNumber ||
+		out.EaSize != in.EaSize || out.AccessFlags != in.AccessFlags || out.CurrentByteOffset != in.CurrentByteOffset ||
+		out.Mode != in.Mode || out.AlignmentRequirement != in.AlignmentRequirement || out.FileName != in.FileName {
+		t.Errorf("round trip mismatch:\n got %+v\nwant %+v", out, *in)
+	}
+}
+
+func TestFileBothDirectoryInformationRoundTrip(t *testing.T) {
+	in := &FileBothDirectoryInformation{
+		FileIndex:      0,
+		CreationTime:   100,
+		LastAccessTime: 200,
+		LastWriteTime:  300,
+		ChangeTime:     400,
+		EndOfFile:      512,
+		AllocationSize: 1024,
+		FileAttributes: 0x20,
+		EaSize:         0,
+		ShortName:      "REPORT~1.TXT",
+		FileName:       "report.txt",
+	}
+	b, err := in.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var out FileBothDirectoryInformation
+	if err := out.Unmarshal(b); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out.FileName != in.FileName || out.ShortName != in.ShortName || out.EndOfFile != in.EndOfFile ||
+		out.AllocationSize != in.AllocationSize || out.FileAttributes != in.FileAttributes || out.CreationTime != in.CreationTime {
+		t.Errorf("round trip mismatch:\n got %+v\nwant %+v", out, *in)
+	}
+}
+
+func TestFileIdBothDirectoryInformationRoundTrip(t *testing.T) {
+	in := &FileIdBothDirectoryInformation{
+		CreationTime:   1,
+		LastAccessTime: 2,
+		LastWriteTime:  3,
+		ChangeTime:     4,
+		EndOfFile:      99,
+		AllocationSize: 100,
+		FileAttributes: 0x10,
+		ShortName:      "DIR~1",
+		FileId:         0xAABBCCDDEEFF0011,
+		FileName:       "directory",
+	}
+	b, err := in.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var out FileIdBothDirectoryInformation
+	if err := out.Unmarshal(b); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out.FileName != in.FileName || out.ShortName != in.ShortName || out.FileId != in.FileId || out.FileAttributes != in.FileAttributes {
+		t.Errorf("round trip mismatch:\n got %+v\nwant %+v", out, *in)
+	}
+}
+
+func TestFileFullDirectoryInformationRoundTrip(t *testing.T) {
+	in := &FileFullDirectoryInformation{
+		CreationTime:   5,
+		EndOfFile:      7,
+		AllocationSize: 8,
+		FileAttributes: 0x20,
+		EaSize:         42,
+		FileName:       "a.bin",
+	}
+	b, err := in.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var out FileFullDirectoryInformation
+	if err := out.Unmarshal(b); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out.FileName != in.FileName || out.EaSize != in.EaSize || out.EndOfFile != in.EndOfFile || out.FileAttributes != in.FileAttributes {
+		t.Errorf("round trip mismatch:\n got %+v\nwant %+v", out, *in)
+	}
+}
+
+func TestDirectoryInformationListChaining(t *testing.T) {
+	// Build two chained FILE_BOTH_DIR_INFORMATION entries and parse them back.
+	e1 := &FileBothDirectoryInformation{FileName: "alpha", FileAttributes: 0x20, EndOfFile: 1}
+	e2 := &FileBothDirectoryInformation{FileName: "beta", FileAttributes: 0x20, EndOfFile: 2}
+	b1, _ := e1.Marshal()
+	b2, _ := e2.Marshal()
+	// First entry's NextEntryOffset points to the second; build the buffer.
+	e1.NextEntryOffset = uint32(len(b1))
+	b1, _ = e1.Marshal()
+	buf := append(append([]byte{}, b1...), b2...)
+
+	got := ParseFileBothDirectoryInformationList(buf)
+	if len(got) != 2 {
+		t.Fatalf("parsed %d entries, want 2", len(got))
+	}
+	if got[0].FileName != "alpha" || got[1].FileName != "beta" {
+		t.Errorf("names = %q,%q want alpha,beta", got[0].FileName, got[1].FileName)
+	}
+}
+
+func TestFileFsVolumeInformationRoundTrip(t *testing.T) {
+	in := &FileFsVolumeInformation{
+		VolumeCreationTime: 0x01D0000000000009,
+		VolumeSerialNumber: 0xDEADBEEF,
+		SupportsObjects:    true,
+		VolumeLabel:        "SYSTEM",
+	}
+	b, err := in.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var out FileFsVolumeInformation
+	if err := out.Unmarshal(b); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out != *in {
+		t.Errorf("round trip mismatch:\n got %+v\nwant %+v", out, *in)
+	}
+}
+
+func TestFileFsFullSizeInformationRoundTrip(t *testing.T) {
+	in := &FileFsFullSizeInformation{
+		TotalAllocationUnits:           1000,
+		CallerAvailableAllocationUnits: 400,
+		ActualAvailableAllocationUnits: 500,
+		SectorsPerAllocationUnit:       8,
+		BytesPerSector:                 512,
+	}
+	b, err := in.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if len(b) != FileFsFullSizeInformationSize {
+		t.Fatalf("size = %d, want %d", len(b), FileFsFullSizeInformationSize)
+	}
+	var out FileFsFullSizeInformation
+	if err := out.Unmarshal(b); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out != *in {
+		t.Errorf("round trip mismatch:\n got %+v\nwant %+v", out, *in)
+	}
+}
+
+func TestFileFsAttributeInformationRoundTrip(t *testing.T) {
+	in := &FileFsAttributeInformation{
+		FileSystemAttributes:       0x00000007,
+		MaximumComponentNameLength: 255,
+		FileSystemName:             "NTFS",
+	}
+	b, err := in.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var out FileFsAttributeInformation
+	if err := out.Unmarshal(b); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out != *in {
+		t.Errorf("round trip mismatch:\n got %+v\nwant %+v", out, *in)
+	}
+}
+
+func TestFileFsDeviceInformationRoundTrip(t *testing.T) {
+	in := &FileFsDeviceInformation{DeviceType: 7, Characteristics: 0x20}
+	b, err := in.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if len(b) != FileFsDeviceInformationSize {
+		t.Fatalf("size = %d, want %d", len(b), FileFsDeviceInformationSize)
+	}
+	var out FileFsDeviceInformation
+	if err := out.Unmarshal(b); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out != *in {
+		t.Errorf("round trip mismatch: got %+v want %+v", out, *in)
+	}
+}
+
+func TestUTF16Helpers(t *testing.T) {
+	for _, s := range []string{"", "a", "report.txt", "café", "日本語"} {
+		if got := decodeUTF16LE(encodeUTF16LE(s)); got != s {
+			t.Errorf("UTF-16 round trip for %q = %q", s, got)
+		}
+	}
+	// A trailing NUL unit must be trimmed on decode.
+	withNul := append(encodeUTF16LE("x"), 0x00, 0x00)
+	if got := decodeUTF16LE(withNul); got != "x" {
+		t.Errorf("decodeUTF16LE trailing NUL = %q, want x", got)
+	}
+}

--- a/windows/filesystem/fscc_strings.go
+++ b/windows/filesystem/fscc_strings.go
@@ -1,0 +1,28 @@
+package filesystem
+
+import (
+	"encoding/binary"
+	"strings"
+	"unicode/utf16"
+)
+
+// encodeUTF16LE encodes s as little-endian UTF-16, the on-wire form of the
+// variable name fields in MS-FSCC information-class structures.
+func encodeUTF16LE(s string) []byte {
+	u16 := utf16.Encode([]rune(s))
+	b := make([]byte, len(u16)*2)
+	for i, u := range u16 {
+		binary.LittleEndian.PutUint16(b[i*2:], u)
+	}
+	return b
+}
+
+// decodeUTF16LE decodes a little-endian UTF-16 byte buffer into a string,
+// trimming any trailing NUL units.
+func decodeUTF16LE(b []byte) string {
+	u16 := make([]uint16, 0, len(b)/2)
+	for i := 0; i+1 < len(b); i += 2 {
+		u16 = append(u16, binary.LittleEndian.Uint16(b[i:i+2]))
+	}
+	return strings.TrimRight(string(utf16.Decode(u16)), "\x00")
+}

--- a/windows/filesystem/infoclass/infoclass.go
+++ b/windows/filesystem/infoclass/infoclass.go
@@ -30,6 +30,7 @@ const (
 	FileAllocationInformation      FileInformationClass = 19
 	FileEndOfFileInformation       FileInformationClass = 20
 	FileAlternateNameInformation   FileInformationClass = 21
+	FileNetworkOpenInformation     FileInformationClass = 34
 	FileIdBothDirectoryInformation FileInformationClass = 37
 	FileIdFullDirectoryInformation FileInformationClass = 38
 )


### PR DESCRIPTION
### Linked Issue
Refs #525. Completes the typed information-class structures that were missing; #525 can be closed once this merges (or kept open if the directory-parser cleanup below is tracked there).

### Summary
`windows/filesystem/` previously held only the handful of MS-FSCC structures the SMB2 client already used (Basic, Standard, a few set-info classes, FsSize, Notify). This adds the rest of #525's scope as typed, round-trip-tested structures, plus the SMB2 `SMB2_CREATE_CONTEXT` structure, and wires the new query classes into the client.

### What this adds
**File information classes** (`windows/filesystem`):
- `FileAllInformation` (2.4.2) — the aggregate query result (Basic + Standard + Internal + EA + Access + Position + Mode + Alignment + Name).
- `FileNetworkOpenInformation` (2.4.29).

**Directory-enumeration classes** (`file_directory_information.go`), each with single-entry Marshal/Unmarshal and a chained-list parser:
- `FileFullDirectoryInformation` (2.4.14), `FileBothDirectoryInformation` (2.4.8), `FileIdBothDirectoryInformation` (2.4.17), `FileNamesInformation` (2.4.26).

**File-system information classes** (`fs_information.go`):
- `FileFsVolumeInformation` (2.5.9), `FileFsFullSizeInformation` (2.5.4), `FileFsAttributeInformation` (2.5.1), `FileFsDeviceInformation` (2.5.10).

**SMB2 create contexts** (`network/smb/smb_v20/createcontext`):
- `SMB2_CREATE_CONTEXT` list `Marshal`/`Parse` (bounds-checked against the server-controlled buffer) and the well-known context name tags (DHnQ, RqLs, MxAc, …). This lives under `smb_v20` rather than `windows/filesystem` because create contexts are SMB2-specific, not shared FSCC.

**Client wiring** (`smb_v20/client/info.go`): `QueryFileAllInfo`, `QueryFileNetworkOpenInfo`, `QueryFsVolumeInfo`, `QueryFsFullSizeInfo`, `QueryFsAttributeInfo`, `QueryFsDeviceInfo`, mirroring the existing `QueryFileBasicInfo`/`QueryFsSizeInfo` helpers, plus the `FileNetworkOpenInformation` (34) info-class constant.

### Design notes
- Variable name/label fields are UTF-16LE; a small `encodeUTF16LE`/`decodeUTF16LE` pair (`fscc_strings.go`) backs them. Directory and create-context parsers walk the NextEntryOffset / Next chains and bounds-check every offset and length, so a malformed server buffer is rejected rather than panicking.
- The fixed layouts match MS-FSCC; the FILE_BOTH_DIR_INFORMATION 94-byte fixed size is the same one the generic client's live-validated `parseBothDirectoryInfo` uses.

### Scope / out of scope
Per #525, this does not change the SMB2 command wire format — the CREATE/QUERY_INFO/SET_INFO bodies keep their raw `[]byte` buffers, and the typed structures marshal into / parse out of them. The generic client's hand-rolled `parseBothDirectoryInfo` could now delegate to `ParseFileBothDirectoryInformationList`; that cleanup is intentionally left out of this PR to keep it focused and can be a small follow-up.

### How Verified
- **Tests:** `windows/filesystem/fscc_information_test.go` round-trips every new file/FS structure and exercises the directory-list chaining and UTF-16 helpers; `network/smb/smb_v20/createcontext/createcontext_test.go` round-trips single/multi/with-data contexts and asserts malformed buffers (truncated header, out-of-bounds name length, sub-header Next) are rejected.
- **Runtime:** `go build ./...` and the full `go test ./...` suite pass.

### Test Coverage
**Added:** `windows/filesystem/fscc_information_test.go`, `network/smb/smb_v20/createcontext/createcontext_test.go`.

### Scope of Change
- **Files changed:** new `windows/filesystem/{file_all_information,file_network_open_information,file_directory_information,fscc_strings}.go` + `fscc_information_test.go`; edited `windows/filesystem/fs_information.go`, `windows/filesystem/infoclass/infoclass.go`, `network/smb/smb_v20/client/info.go`; new `network/smb/smb_v20/createcontext/` package + test.
- **Submodule pointer updated:** no
- **Behavioral changes outside the new code:** none — existing structures and client helpers are untouched; only additive.

### Risk and Rollout
Low: purely additive typed structures and client helpers, fully covered by offline round-trip tests. Live validation against a real server can follow.