### PR TITLE
Delegate generic-client directory parsing to the typed FSCC parser (#525)

### DIFF
--- a/network/smb/client/fileinfo.go
+++ b/network/smb/client/fileinfo.go
@@ -1,10 +1,9 @@
 package client
 
 import (
-	"encoding/binary"
-	"strings"
 	"time"
-	"unicode/utf16"
+
+	"github.com/TheManticoreProject/Manticore/windows/filesystem"
 )
 
 // fileBothDirectoryInformation is the FILE_INFORMATION_CLASS used for directory
@@ -13,56 +12,28 @@ import (
 // access/share/disposition/options values live in windows/fileflags.)
 const fileBothDirectoryInformation uint8 = 0x03
 
-// bothDirInfoFixedSize is the fixed portion of a FILE_BOTH_DIR_INFORMATION entry
-// before the variable FileName: NextEntryOffset(4) FileIndex(4) 4xFILETIME(32)
-// EndOfFile(8) AllocationSize(8) FileAttributes(4) FileNameLength(4) EaSize(4)
-// ShortNameLength(1) Reserved(1) ShortName(24).
-const bothDirInfoFixedSize = 94
-
 // parseBothDirectoryInfo decodes a buffer of consecutive FILE_BOTH_DIR_INFORMATION
 // entries (MS-FSCC 2.4.8), as returned by SMB2 QUERY_DIRECTORY, into FileInfo
-// values. FileName is UTF-16LE. The "." and ".." pseudo-entries are skipped.
-//
-// A typed MS-FSCC information-class package (#525) would replace this hand-rolled
-// decoder; it lives here until that lands.
+// values. The "." and ".." pseudo-entries are skipped. Decoding is delegated to
+// the typed windows/filesystem parser; this maps each entry's FILETIME fields to
+// time.Time and projects the subset FileInfo exposes.
 func parseBothDirectoryInfo(buf []byte) []FileInfo {
 	var out []FileInfo
-
-	for pos := 0; pos+bothDirInfoFixedSize <= len(buf); {
-		next := int(binary.LittleEndian.Uint32(buf[pos : pos+4]))
-		creation := filetimeToTime(binary.LittleEndian.Uint64(buf[pos+8 : pos+16]))
-		lastAccess := filetimeToTime(binary.LittleEndian.Uint64(buf[pos+16 : pos+24]))
-		lastWrite := filetimeToTime(binary.LittleEndian.Uint64(buf[pos+24 : pos+32]))
-		change := filetimeToTime(binary.LittleEndian.Uint64(buf[pos+32 : pos+40]))
-		endOfFile := binary.LittleEndian.Uint64(buf[pos+40 : pos+48])
-		allocationSize := binary.LittleEndian.Uint64(buf[pos+48 : pos+56])
-		attrs := binary.LittleEndian.Uint32(buf[pos+56 : pos+60])
-		nameLen := int(binary.LittleEndian.Uint32(buf[pos+60 : pos+64]))
-
-		name := ""
-		if nameLen > 0 && pos+bothDirInfoFixedSize+nameLen <= len(buf) {
-			name = decodeUTF16LE(buf[pos+bothDirInfoFixedSize : pos+bothDirInfoFixedSize+nameLen])
+	for _, e := range filesystem.ParseFileBothDirectoryInformationList(buf) {
+		if e.FileName == "." || e.FileName == ".." {
+			continue
 		}
-
-		if name != "." && name != ".." {
-			out = append(out, FileInfo{
-				Name:           name,
-				FileAttributes: attrs,
-				Size:           endOfFile,
-				AllocationSize: allocationSize,
-				CreationTime:   creation,
-				LastAccessTime: lastAccess,
-				LastWriteTime:  lastWrite,
-				ChangeTime:     change,
-			})
-		}
-
-		if next == 0 {
-			break
-		}
-		pos += next
+		out = append(out, FileInfo{
+			Name:           e.FileName,
+			FileAttributes: e.FileAttributes,
+			Size:           uint64(e.EndOfFile),
+			AllocationSize: uint64(e.AllocationSize),
+			CreationTime:   filetimeToTime(e.CreationTime),
+			LastAccessTime: filetimeToTime(e.LastAccessTime),
+			LastWriteTime:  filetimeToTime(e.LastWriteTime),
+			ChangeTime:     filetimeToTime(e.ChangeTime),
+		})
 	}
-
 	return out
 }
 
@@ -74,14 +45,4 @@ func filetimeToTime(ft uint64) time.Time {
 		return time.Time{}
 	}
 	return time.Unix(0, int64(ft-epochDiff)*100).UTC()
-}
-
-// decodeUTF16LE decodes a little-endian UTF-16 byte buffer into a string, trimming
-// any trailing NUL units.
-func decodeUTF16LE(b []byte) string {
-	u16 := make([]uint16, 0, len(b)/2)
-	for i := 0; i+1 < len(b); i += 2 {
-		u16 = append(u16, binary.LittleEndian.Uint16(b[i:i+2]))
-	}
-	return strings.TrimRight(string(utf16.Decode(u16)), "\x00")
 }

--- a/network/smb/client/fileinfo_test.go
+++ b/network/smb/client/fileinfo_test.go
@@ -3,27 +3,26 @@ package client
 import (
 	"encoding/binary"
 	"testing"
-	"unicode/utf16"
 
 	"github.com/TheManticoreProject/Manticore/windows/fileflags"
+	"github.com/TheManticoreProject/Manticore/windows/filesystem"
 )
 
-// bothDirEntry builds a single FILE_BOTH_DIR_INFORMATION entry with a UTF-16LE
-// name. next is written to NextEntryOffset verbatim.
+// bothDirEntry builds a single FILE_BOTH_DIR_INFORMATION entry via the typed
+// windows/filesystem marshaller. next is written to NextEntryOffset verbatim.
 func bothDirEntry(name string, attrs uint32, size uint64, next uint32) []byte {
-	u16 := utf16.Encode([]rune(name))
-	nameBytes := make([]byte, len(u16)*2)
-	for i, u := range u16 {
-		binary.LittleEndian.PutUint16(nameBytes[i*2:], u)
+	e := &filesystem.FileBothDirectoryInformation{
+		NextEntryOffset: next,
+		EndOfFile:       int64(size),
+		AllocationSize:  int64(size),
+		FileAttributes:  attrs,
+		FileName:        name,
 	}
-	e := make([]byte, bothDirInfoFixedSize+len(nameBytes))
-	binary.LittleEndian.PutUint32(e[0:4], next)
-	binary.LittleEndian.PutUint64(e[40:48], size)                   // EndOfFile
-	binary.LittleEndian.PutUint64(e[48:56], size)                   // AllocationSize
-	binary.LittleEndian.PutUint32(e[56:60], attrs)                  // FileAttributes
-	binary.LittleEndian.PutUint32(e[60:64], uint32(len(nameBytes))) // FileNameLength
-	copy(e[bothDirInfoFixedSize:], nameBytes)
-	return e
+	b, err := e.Marshal()
+	if err != nil {
+		panic(err)
+	}
+	return b
 }
 
 func TestParseBothDirectoryInfo(t *testing.T) {
@@ -33,13 +32,9 @@ func TestParseBothDirectoryInfo(t *testing.T) {
 	dir := bothDirEntry("subdir", fileflags.FILE_ATTRIBUTE_DIRECTORY, 0, 0)
 
 	// Chain: NextEntryOffset of each non-last entry is that entry's length.
-	dot[0] = byte(len(dot))
-	off := len(dot)
+	binary.LittleEndian.PutUint32(dot[0:4], uint32(len(dot)))
 	binary.LittleEndian.PutUint32(dotdot[0:4], uint32(len(dotdot)))
-	off += len(dotdot)
 	binary.LittleEndian.PutUint32(file[0:4], uint32(len(file)))
-	off += len(file)
-	_ = off
 
 	var buf []byte
 	buf = append(buf, dot...)


### PR DESCRIPTION
### Linked Issue
Refs #525 — the follow-up cleanup noted when the typed MS-FSCC structures landed (#566).

### Summary
The generic SMB client (`network/smb/client`) carried a hand-rolled FILE_BOTH_DIR_INFORMATION decoder (`parseBothDirectoryInfo`) with its own offset arithmetic, `bothDirInfoFixedSize` constant, and `decodeUTF16LE` helper. Its doc comment explicitly said it would be replaced once a typed MS-FSCC information-class package existed. That package now exists (#566), so this swaps the duplicate decoder for `filesystem.ParseFileBothDirectoryInformationList`.

### Root Cause / Motivation
Duplicated wire-layout decoding: the same FILE_BOTH_DIR_INFORMATION layout was decoded both in `windows/filesystem` (typed) and inline in the generic client. Keeping two copies risks them drifting and was only ever a stopgap pending #525.

### Fix Description
`parseBothDirectoryInfo` now iterates `filesystem.ParseFileBothDirectoryInformationList(buf)`, skips the "."/".." pseudo-entries, and projects each typed entry into the client's `FileInfo` (mapping the FILETIME fields through the retained `filetimeToTime`). The now-unused `bothDirInfoFixedSize` constant and `decodeUTF16LE` helper (and the `encoding/binary`/`strings`/`unicode/utf16` imports) are removed. The `fileBothDirectoryInformation` info-class constant stays (used by the adapter's QUERY_DIRECTORY call).

### How Verified
- **Tests:** `TestParseBothDirectoryInfo` and `TestParseBothDirectoryInfo_Empty` are retained; their entry builder now uses the typed `filesystem.FileBothDirectoryInformation.Marshal` instead of hand-packing bytes, exercising the typed marshal→parse path end to end. Both assert unchanged behavior ("."/".." skipped, file vs. dir classification, size).
- **Runtime:** `go build ./...` and the full `go test ./...` suite pass.

### Test Coverage
**Existing (updated):** `network/smb/client/fileinfo_test.go` — same assertions, typed entry builder.

### Scope of Change
- **Files changed:** `network/smb/client/fileinfo.go`, `network/smb/client/fileinfo_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes:** none — directory enumeration produces the same `FileInfo` results; this is an internal decoding-source swap.

### Risk and Rollout
Low: behavior-preserving refactor backed by the existing directory-parse tests and the typed parser's own round-trip tests.