### PR TITLE
Add ncacn_ip_tcp transport for DCE/RPC (#417)

### DIFF
--- a/network/dcerpc/v5/transport/tcp/integration_test.go
+++ b/network/dcerpc/v5/transport/tcp/integration_test.go
@@ -1,0 +1,57 @@
+//go:build integration
+
+package tcp_test
+
+import (
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/transport/tcp"
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+)
+
+// eptSyntax is the endpoint mapper (ept) abstract syntax,
+// e1af8308-5d1f-11c9-91a4-08002b14a0fa version 3.0. The endpoint mapper always listens
+// on TCP port 135, so it is a stable target for proving the ncacn_ip_tcp transport.
+func eptSyntax() syntax.SyntaxID {
+	return syntax.SyntaxID{
+		UUID:         guid.GUID{A: 0xe1af8308, B: 0x5d1f, C: 0x11c9, D: 0x91a4, E: 0x08002b14a0fa},
+		MajorVersion: 3,
+		MinorVersion: 0,
+	}
+}
+
+// TestTCPTransport_BindEndpointMapper binds the ept interface over ncacn_ip_tcp against
+// a live host. It is skipped unless DCERPC_TCP_TEST_HOST is set; the port defaults to
+// 135 and can be overridden with DCERPC_TCP_TEST_PORT.
+//
+//	DCERPC_TCP_TEST_HOST=10.0.0.30 go test -tags integration \
+//	    ./network/dcerpc/v5/transport/tcp/
+func TestTCPTransport_BindEndpointMapper(t *testing.T) {
+	host := os.Getenv("DCERPC_TCP_TEST_HOST")
+	if host == "" {
+		t.Skip("set DCERPC_TCP_TEST_HOST to run the ncacn_ip_tcp integration test")
+	}
+	port := tcp.EndpointMapperPort
+	if p := os.Getenv("DCERPC_TCP_TEST_PORT"); p != "" {
+		n, err := strconv.Atoi(p)
+		if err != nil {
+			t.Fatalf("invalid DCERPC_TCP_TEST_PORT %q: %v", p, err)
+		}
+		port = n
+	}
+
+	tr := tcp.New(host, port)
+	tr.SetTimeout(10 * time.Second)
+
+	c := client.NewClient(tr)
+	defer c.Close()
+
+	if err := c.Bind(eptSyntax()); err != nil {
+		t.Fatalf("Bind(ept) over ncacn_ip_tcp to %s:%d failed: %v", host, port, err)
+	}
+}

--- a/network/dcerpc/v5/transport/tcp/tcp.go
+++ b/network/dcerpc/v5/transport/tcp/tcp.go
@@ -1,0 +1,186 @@
+// Package tcp implements the DCE/RPC ncacn_ip_tcp protocol sequence: DCE/RPC
+// directly over a TCP connection.
+//
+// Unlike ncacn_np (network/dcerpc/v5/transport/smb), which carries PDUs as SMB named
+// pipe writes and reads, ncacn_ip_tcp has no intermediate framing: each PDU is written
+// straight to the socket and the receive side is driven by the common header's
+// frag_length. This transport therefore implements Send as a single socket write of a
+// complete PDU and Recv as a single socket read; reassembling fragments across reads is
+// the DCE/RPC client's responsibility (its fragmentReader buffers by frag_length).
+//
+// The endpoint is an explicit host and port. The endpoint mapper (ept) on TCP port 135
+// resolves the dynamic port a service listens on; see the epm interface
+// (network/dcerpc/interfaces/...) for that lookup.
+//
+// References:
+//   - [C706] chapter 12 (connection-oriented protocol) and Appendix I/L:
+//     https://pubs.opengroup.org/onlinepubs/9629399/chap12.htm
+//   - [MS-RPCE] 2.1.1.1 (RPC over TCP/IP, ncacn_ip_tcp):
+//     https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/08c5dcde-be40-4d1a-aa8a-1c84acebabf0
+package tcp
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"time"
+
+	dcerpctransport "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/transport"
+)
+
+// EndpointMapperPort is the well-known TCP port of the endpoint mapper (ept), used to
+// resolve the dynamic port of a service before connecting to it.
+const EndpointMapperPort = 135
+
+// Default fragment sizes proposed at Bind time. 5840 (0x16D0) is the classic Windows
+// default for RPC over TCP. Callers that want different fragments can override via
+// SetMaxFrag before Connect.
+const (
+	DefaultMaxXmitFrag uint16 = 5840
+	DefaultMaxRecvFrag uint16 = 5840
+)
+
+// socket is the subset of net.Conn the transport relies on. Expressing it as an
+// interface keeps the transport unit-testable without a live server: tests substitute a
+// net.Pipe end or a fake. *net.TCPConn (and any net.Conn) satisfies it.
+type socket interface {
+	io.ReadWriteCloser
+	SetReadDeadline(t time.Time) error
+}
+
+// TCPTransport is a DCE/RPC transport over a TCP connection (ncacn_ip_tcp).
+type TCPTransport struct {
+	address string
+	timeout time.Duration
+
+	// dial opens the connection to address; it is overridable in tests.
+	dial func(address string, timeout time.Duration) (socket, error)
+
+	conn    socket
+	maxXmit uint16
+	maxRecv uint16
+}
+
+// Compile-time assertion that TCPTransport implements the DCE/RPC transport contract.
+var _ dcerpctransport.Transport = (*TCPTransport)(nil)
+
+// New creates a TCP transport that will connect to the given host and port. host may be
+// an IPv4 address, IPv6 address, or hostname; the port is the explicit RPC endpoint
+// (use EndpointMapperPort to talk to the endpoint mapper).
+func New(host string, port int) *TCPTransport {
+	return &TCPTransport{
+		address: net.JoinHostPort(host, strconv.Itoa(port)),
+		dial:    dialTCP,
+		maxXmit: DefaultMaxXmitFrag,
+		maxRecv: DefaultMaxRecvFrag,
+	}
+}
+
+// dialTCP is the production dialer: a plain TCP connection bounded by timeout.
+func dialTCP(address string, timeout time.Duration) (socket, error) {
+	conn, err := net.DialTimeout("tcp", address, timeout)
+	if err != nil {
+		return nil, err
+	}
+	return conn, nil
+}
+
+// SetTimeout bounds Connect and each subsequent Recv: Connect fails if the connection
+// cannot be established within d, and Recv fails if no data arrives within d. A
+// non-positive d removes the bound (blocking I/O). It must be called before Connect to
+// affect the dial.
+func (t *TCPTransport) SetTimeout(d time.Duration) {
+	if d < 0 {
+		d = 0
+	}
+	t.timeout = d
+}
+
+// SetMaxFrag overrides the transmit and receive fragment sizes proposed at Bind time.
+// It must be called before Connect to take effect.
+func (t *TCPTransport) SetMaxFrag(xmit, recv uint16) {
+	t.maxXmit = xmit
+	t.maxRecv = recv
+}
+
+// Connect opens the TCP connection. It is idempotent.
+func (t *TCPTransport) Connect() error {
+	if t.conn != nil {
+		return nil
+	}
+	conn, err := t.dial(t.address, t.timeout)
+	if err != nil {
+		return fmt.Errorf("ncacn_ip_tcp: connect to %s: %w", t.address, err)
+	}
+	t.conn = conn
+	return nil
+}
+
+// Send writes a complete PDU to the socket. A net.Conn write returns a non-nil error
+// whenever fewer than len(pdu) bytes are written, so a single Write suffices.
+func (t *TCPTransport) Send(pdu []byte) error {
+	if t.conn == nil {
+		return fmt.Errorf("ncacn_ip_tcp: not connected to %s: call Connect first", t.address)
+	}
+	if len(pdu) == 0 {
+		return fmt.Errorf("ncacn_ip_tcp: refusing to send an empty PDU to %s", t.address)
+	}
+	n, err := t.conn.Write(pdu)
+	if err != nil {
+		return fmt.Errorf("ncacn_ip_tcp: write PDU to %s: %w", t.address, err)
+	}
+	if n != len(pdu) {
+		return fmt.Errorf("ncacn_ip_tcp: short write to %s: wrote %d of %d bytes", t.address, n, len(pdu))
+	}
+	return nil
+}
+
+// Recv reads up to MaxRecvFrag bytes from the socket and returns them. The result may
+// hold part of a PDU, exactly one PDU, or several PDUs; the caller reassembles by
+// frag_length. A read that returns no data before the peer closes the connection is
+// reported as an error.
+func (t *TCPTransport) Recv() ([]byte, error) {
+	if t.conn == nil {
+		return nil, fmt.Errorf("ncacn_ip_tcp: not connected to %s: call Connect first", t.address)
+	}
+
+	var deadline time.Time
+	if t.timeout > 0 {
+		deadline = time.Now().Add(t.timeout)
+	}
+	if err := t.conn.SetReadDeadline(deadline); err != nil {
+		return nil, fmt.Errorf("ncacn_ip_tcp: set read deadline on %s: %w", t.address, err)
+	}
+
+	buf := make([]byte, t.maxRecv)
+	for {
+		n, err := t.conn.Read(buf)
+		if n > 0 {
+			return buf[:n], nil
+		}
+		if err != nil {
+			return nil, fmt.Errorf("ncacn_ip_tcp: read from %s: %w", t.address, err)
+		}
+		// A compliant io.Reader returns (0, nil) only rarely; loop until data or error.
+	}
+}
+
+// Close tears down the TCP connection. It is idempotent.
+func (t *TCPTransport) Close() error {
+	if t.conn == nil {
+		return nil
+	}
+	err := t.conn.Close()
+	t.conn = nil
+	if err != nil {
+		return fmt.Errorf("ncacn_ip_tcp: close %s: %w", t.address, err)
+	}
+	return nil
+}
+
+// MaxXmitFrag returns the proposed maximum transmit fragment size.
+func (t *TCPTransport) MaxXmitFrag() uint16 { return t.maxXmit }
+
+// MaxRecvFrag returns the proposed maximum receive fragment size.
+func (t *TCPTransport) MaxRecvFrag() uint16 { return t.maxRecv }

--- a/network/dcerpc/v5/transport/tcp/tcp_test.go
+++ b/network/dcerpc/v5/transport/tcp/tcp_test.go
@@ -1,0 +1,173 @@
+package tcp
+
+import (
+	"bytes"
+	"net"
+	"testing"
+	"time"
+
+	dcerpctransport "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/transport"
+)
+
+// pipeTransport returns a TCP transport whose dialer hands back one end of an in-memory
+// net.Pipe, together with the other (peer) end the test drives, and a counter of dial
+// calls. net.Pipe is synchronous, so reads/writes on either end are exercised from a
+// goroutine.
+func pipeTransport(t *testing.T) (tr *TCPTransport, peer net.Conn, dials *int) {
+	t.Helper()
+	clientEnd, peerEnd := net.Pipe()
+	n := 0
+	tr = New("198.51.100.7", 49152)
+	tr.dial = func(address string, timeout time.Duration) (socket, error) {
+		n++
+		return clientEnd, nil
+	}
+	return tr, peerEnd, &n
+}
+
+func TestTCPTransport_ImplementsInterface(t *testing.T) {
+	var _ dcerpctransport.Transport = New("127.0.0.1", 135)
+}
+
+func TestTCPTransport_Defaults(t *testing.T) {
+	tr := New("127.0.0.1", 135)
+	if tr.MaxXmitFrag() != DefaultMaxXmitFrag {
+		t.Errorf("MaxXmitFrag = %d, want %d", tr.MaxXmitFrag(), DefaultMaxXmitFrag)
+	}
+	if tr.MaxRecvFrag() != DefaultMaxRecvFrag {
+		t.Errorf("MaxRecvFrag = %d, want %d", tr.MaxRecvFrag(), DefaultMaxRecvFrag)
+	}
+	if tr.address != "127.0.0.1:135" {
+		t.Errorf("address = %q, want 127.0.0.1:135", tr.address)
+	}
+}
+
+func TestTCPTransport_AddressIPv6(t *testing.T) {
+	tr := New("fe80::1", 135)
+	if tr.address != "[fe80::1]:135" {
+		t.Errorf("address = %q, want [fe80::1]:135", tr.address)
+	}
+}
+
+func TestTCPTransport_SetMaxFrag(t *testing.T) {
+	tr := New("127.0.0.1", 135)
+	tr.SetMaxFrag(1024, 2048)
+	if tr.MaxXmitFrag() != 1024 || tr.MaxRecvFrag() != 2048 {
+		t.Errorf("frag sizes = %d/%d, want 1024/2048", tr.MaxXmitFrag(), tr.MaxRecvFrag())
+	}
+}
+
+func TestTCPTransport_ConnectIdempotent(t *testing.T) {
+	tr, peer, dials := pipeTransport(t)
+	defer peer.Close()
+	defer tr.Close()
+
+	if err := tr.Connect(); err != nil {
+		t.Fatalf("Connect() error = %v", err)
+	}
+	if err := tr.Connect(); err != nil {
+		t.Fatalf("second Connect() error = %v", err)
+	}
+	if *dials != 1 {
+		t.Errorf("dialed %d times, want 1 (Connect must be idempotent)", *dials)
+	}
+}
+
+func TestTCPTransport_SendWritesWholePDU(t *testing.T) {
+	tr, peer, _ := pipeTransport(t)
+	defer peer.Close()
+	defer tr.Close()
+	if err := tr.Connect(); err != nil {
+		t.Fatalf("Connect() error = %v", err)
+	}
+
+	pdu := []byte{0x05, 0x00, 0x0b, 0x03, 0xde, 0xad, 0xbe, 0xef}
+	got := make(chan []byte, 1)
+	go func() {
+		b := make([]byte, len(pdu))
+		_, _ = peer.Read(b)
+		got <- b
+	}()
+
+	if err := tr.Send(pdu); err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+	if received := <-got; !bytes.Equal(received, pdu) {
+		t.Errorf("peer received %x, want %x", received, pdu)
+	}
+}
+
+func TestTCPTransport_RecvReturnsPeerBytes(t *testing.T) {
+	tr, peer, _ := pipeTransport(t)
+	defer peer.Close()
+	defer tr.Close()
+	if err := tr.Connect(); err != nil {
+		t.Fatalf("Connect() error = %v", err)
+	}
+
+	payload := []byte{0x05, 0x00, 0x02, 0x03, 0x10, 0x00, 0x00, 0x00}
+	go func() { _, _ = peer.Write(payload) }()
+
+	got, err := tr.Recv()
+	if err != nil {
+		t.Fatalf("Recv() error = %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Errorf("Recv() = %x, want %x", got, payload)
+	}
+}
+
+func TestTCPTransport_RecvErrorsOnClose(t *testing.T) {
+	tr, peer, _ := pipeTransport(t)
+	defer tr.Close()
+	if err := tr.Connect(); err != nil {
+		t.Fatalf("Connect() error = %v", err)
+	}
+	peer.Close()
+	if _, err := tr.Recv(); err == nil {
+		t.Fatal("Recv() after peer close: error = nil, want non-nil")
+	}
+}
+
+func TestTCPTransport_SendBeforeConnect(t *testing.T) {
+	tr := New("127.0.0.1", 135)
+	if err := tr.Send([]byte{1, 2, 3}); err == nil {
+		t.Fatal("Send() before Connect: error = nil, want non-nil")
+	}
+}
+
+func TestTCPTransport_SendEmptyPDU(t *testing.T) {
+	tr, peer, _ := pipeTransport(t)
+	defer peer.Close()
+	defer tr.Close()
+	if err := tr.Connect(); err != nil {
+		t.Fatalf("Connect() error = %v", err)
+	}
+	if err := tr.Send(nil); err == nil {
+		t.Fatal("Send(nil): error = nil, want non-nil")
+	}
+}
+
+func TestTCPTransport_RecvBeforeConnect(t *testing.T) {
+	tr := New("127.0.0.1", 135)
+	if _, err := tr.Recv(); err == nil {
+		t.Fatal("Recv() before Connect: error = nil, want non-nil")
+	}
+}
+
+func TestTCPTransport_CloseIdempotent(t *testing.T) {
+	tr, peer, _ := pipeTransport(t)
+	defer peer.Close()
+	if err := tr.Connect(); err != nil {
+		t.Fatalf("Connect() error = %v", err)
+	}
+	if err := tr.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	if err := tr.Close(); err != nil {
+		t.Fatalf("second Close() error = %v", err)
+	}
+	if tr.conn != nil {
+		t.Error("conn not cleared after Close")
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #417`

### Root Cause
The DCE/RPC client (`network/dcerpc/v5/client`) is transport-agnostic — it talks to a `transport.Transport` (`Connect`/`Send`/`Recv`/`Close`/`MaxXmitFrag`/`MaxRecvFrag`) — but the only implementation was `transport/smb` (named pipes over SMB). Services reachable over TCP (the common case for dynamically-bound interfaces) could not be reached, and the transport abstraction had never been exercised by a second, non-SMB implementation.

### Fix Description
Adds `network/dcerpc/v5/transport/tcp`, a `transport.Transport` over a plain TCP connection (ncacn_ip_tcp). DCE/RPC over TCP has no intermediate framing: each PDU is written straight to the socket, and the receive side is driven by the common header's `frag_length`, which the client's existing `fragmentReader` already reassembles. `Send` therefore performs a single socket write of a complete PDU and `Recv` performs a single socket read of up to `MaxRecvFrag` bytes.

The endpoint is an explicit host and port (`tcp.New(host, port)`); `EndpointMapperPort` (135) is exported for talking to the endpoint mapper. `SetTimeout` bounds the dial and each read; `SetMaxFrag` overrides the proposed fragment sizes (default 5840, the classic Windows ncacn_ip_tcp value). The connection is abstracted behind a small `socket` interface so the transport is unit-testable without a live server.

The `network/tcp` package was intentionally not reused: it frames every payload with a 4-byte Direct TCP / NetBIOS session header, which is SMB-specific and absent from ncacn_ip_tcp.

### How Verified
- `go build`, `go vet`, `go test ./network/dcerpc/v5/transport/tcp/` all pass.
- Unit tests drive the transport over an in-memory `net.Pipe`: Connect idempotency (single dial), whole-PDU writes, Recv returning peer bytes, Recv erroring on peer close, and the not-connected / empty-PDU guards.
- `go build -tags integration` and `go vet -tags integration` pass for the integration test, which binds the ept interface over ncacn_ip_tcp against a live host (skipped unless `DCERPC_TCP_TEST_HOST` is set).

### Test Coverage
- **Added:** `tcp_test.go` (`TestTCPTransport_ImplementsInterface`, `_Defaults`, `_AddressIPv6`, `_SetMaxFrag`, `_ConnectIdempotent`, `_SendWritesWholePDU`, `_RecvReturnsPeerBytes`, `_RecvErrorsOnClose`, `_SendBeforeConnect`, `_SendEmptyPDU`, `_RecvBeforeConnect`, `_CloseIdempotent`) and `integration_test.go` (`TestTCPTransport_BindEndpointMapper`, build-tagged `integration`).

### Scope of Change
- **Files changed:** `network/dcerpc/v5/transport/tcp/tcp.go`, `tcp_test.go`, `integration_test.go` (all new).
- **Submodule pointer updated:** no.
- **Behavioral changes outside the bug fix:** none.

### Notes
Pairs with the endpoint mapper interface (#416), which resolves the dynamic TCP port a service listens on before connecting.