### PR TITLE
Add DCE/RPC endpoint mapper (epmapper) interface (#416)

### DIFF
--- a/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/functions/03_EptMap.go
+++ b/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/functions/03_EptMap.go
@@ -1,0 +1,72 @@
+package functions
+
+import (
+	"fmt"
+
+	epm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/structures"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+)
+
+// eptMapRequest carries the [in] parameters of ept_map. The explicit binding handle
+// (handle_t h) is not part of the NDR stub and is omitted. The optional object is a
+// full pointer to a uuid_t; map_tower is a full pointer to a twr_t; entry_handle is the
+// 20-octet context handle (null on the first call); max_towers caps the result.
+type eptMapRequest struct {
+	Object      *structures.EptUUID `ndr:"ptr"`
+	MapTower    *structures.Twr     `ndr:"ptr"`
+	EntryHandle structures.ContextHandle
+	MaxTowers   ndr.DWORD
+}
+
+func (*eptMapRequest) Opnum() uint16 { return epm.OpnumEptMap }
+
+// eptMapResponse carries the [out] parameters of ept_map: the (advanced) context
+// handle, the number of towers returned, the towers themselves (a full pointer to a
+// conformant-varying array of full pointers to twr_t), and the status.
+type eptMapResponse struct {
+	EntryHandle structures.ContextHandle
+	NumTowers   ndr.DWORD
+	ITowers     []*structures.Twr `ndr:"ptr,varying,elem=ptr"`
+	Status      ndr.DWORD
+}
+
+// EptMap calls ept_map (opnum 3) ([C706] Appendix O): it asks the endpoint mapper to
+// resolve the map tower to the towers of the matching bound endpoints. object is the
+// optional object UUID (nil for the usual interface lookup); maxTowers caps how many
+// towers the server returns. The decoded result towers are returned; use Tower.Endpoint
+// to extract a transport endpoint, or call Map for the common interface-to-endpoint
+// path.
+func EptMap(rpc ndr.Invoker, object *guid.GUID, mapTower structures.Tower, maxTowers uint32) ([]structures.Tower, error) {
+	twr := structures.NewTwr(mapTower)
+	req := &eptMapRequest{
+		MapTower:  &twr,
+		MaxTowers: ndr.DWORD(maxTowers),
+	}
+	if object != nil {
+		u := structures.NewEptUUID(*object)
+		req.Object = &u
+	}
+
+	var resp eptMapResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return nil, fmt.Errorf("ept_map: %w", err)
+	}
+	if uint32(resp.Status) != epm.StatusSuccess {
+		return nil, fmt.Errorf("ept_map failed: %s", epm.StatusString(uint32(resp.Status)))
+	}
+
+	towers := make([]structures.Tower, 0, len(resp.ITowers))
+	for _, tw := range resp.ITowers {
+		if tw == nil {
+			continue
+		}
+		t, err := tw.DecodeTower()
+		if err != nil {
+			return nil, fmt.Errorf("ept_map: decode tower: %w", err)
+		}
+		towers = append(towers, t)
+	}
+	return towers, nil
+}

--- a/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/functions/functions.go
+++ b/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/functions/functions.go
@@ -1,0 +1,33 @@
+// Package functions holds the endpoint mapper (ept) method stubs. Each stub depends
+// only on the small ndr.Invoker surface, so it is independent of any concrete client or
+// wire-protocol version.
+package functions
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/structures"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+)
+
+// DefaultMaxTowers is the number of towers Map asks ept_map to return. A handful covers
+// the endpoints a single interface is typically bound to.
+const DefaultMaxTowers = 4
+
+// Map resolves the ncacn_ip_tcp endpoints bound to the given interface UUID and version
+// by building a TCP map tower and calling ept_map, then extracting the endpoints from
+// the returned towers. It is the common path for discovering the dynamic TCP port a
+// service listens on; for finer control (a non-nil object, a custom tower, or the raw
+// towers) call EptMap directly.
+func Map(rpc ndr.Invoker, iface guid.GUID, ifMajor, ifMinor uint16) ([]structures.Endpoint, error) {
+	towers, err := EptMap(rpc, nil, structures.BuildMapTowerTCP(iface, ifMajor, ifMinor), DefaultMaxTowers)
+	if err != nil {
+		return nil, err
+	}
+	var eps []structures.Endpoint
+	for _, t := range towers {
+		if ep, ok := t.Endpoint(); ok {
+			eps = append(eps, ep)
+		}
+	}
+	return eps, nil
+}

--- a/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/functions/functions_test.go
+++ b/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/functions/functions_test.go
@@ -1,0 +1,195 @@
+package functions_test
+
+import (
+	"encoding/binary"
+	"errors"
+	"net"
+	"testing"
+
+	epm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/functions"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/structures"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/pdu"
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+)
+
+// fakeTransport is an in-memory transport.Transport for driving the client without a
+// network.
+type fakeTransport struct {
+	sent      [][]byte
+	recvQueue [][]byte
+}
+
+func (f *fakeTransport) Connect() error { return nil }
+func (f *fakeTransport) Send(p []byte) error {
+	f.sent = append(f.sent, append([]byte(nil), p...))
+	return nil
+}
+func (f *fakeTransport) Recv() ([]byte, error) {
+	if len(f.recvQueue) == 0 {
+		return nil, errors.New("recv queue empty")
+	}
+	c := f.recvQueue[0]
+	f.recvQueue = f.recvQueue[1:]
+	return c, nil
+}
+func (f *fakeTransport) Close() error        { return nil }
+func (f *fakeTransport) MaxXmitFrag() uint16 { return 5840 }
+func (f *fakeTransport) MaxRecvFrag() uint16 { return 5840 }
+func (f *fakeTransport) queue(b []byte)      { f.recvQueue = append(f.recvQueue, b) }
+
+func bindAck(t *testing.T) []byte {
+	t.Helper()
+	ack := &pdu.BindAck{
+		MaxXmitFrag: 5840,
+		MaxRecvFrag: 5840,
+		Results:     []pdu.PresentationResult{{Result: pdu.ResultAcceptance, TransferSyntax: syntax.NDRTransferSyntax()}},
+	}
+	b, err := ack.Marshal()
+	if err != nil {
+		t.Fatalf("bind_ack marshal: %v", err)
+	}
+	return b
+}
+
+func responsePDU(t *testing.T, callID uint32, stub []byte) []byte {
+	t.Helper()
+	resp := &pdu.Response{Stub: stub}
+	resp.Header = pdu.NewHeader(pdu.PacketTypeResponse, pdu.PFCFirstFrag|pdu.PFCLastFrag, callID)
+	b, err := resp.Marshal()
+	if err != nil {
+		t.Fatalf("response marshal: %v", err)
+	}
+	return b
+}
+
+func boundClient(t *testing.T, ft *fakeTransport) *client.Client {
+	t.Helper()
+	ft.queue(bindAck(t))
+	c := client.NewClient(ft)
+	if err := c.Bind(epm.SyntaxID()); err != nil {
+		t.Fatalf("Bind() error = %v", err)
+	}
+	return c
+}
+
+func sampleIface() guid.GUID {
+	return guid.GUID{A: 0xc681d488, B: 0xd850, C: 0x11d0, D: 0x8c52, E: 0x00c04fd90f7e}
+}
+
+// le32 appends v as a little-endian uint32.
+func le32(b []byte, v uint32) []byte { return binary.LittleEndian.AppendUint32(b, v) }
+
+// pad4 appends zero octets until len(b) is a multiple of 4.
+func pad4(b []byte) []byte {
+	for len(b)%4 != 0 {
+		b = append(b, 0)
+	}
+	return b
+}
+
+// eptMapResponseStub assembles the [out] NDR stub of an ept_map call that returns a
+// single tower resolving to the given TCP endpoint. The layout is: 20-octet context
+// handle, num_towers, the ITowers full pointer, the conformant-varying array header,
+// one element referent, the twr_t body, then the status.
+func eptMapResponseStub(tower structures.Tower, maxTowers uint32) []byte {
+	towerBytes := tower.Marshal()
+
+	var b []byte
+	b = append(b, make([]byte, structures.ContextHandleSize)...) // entry_handle
+	b = le32(b, 1)                                               // num_towers
+	b = le32(b, 0x00020000)                                      // ITowers referent id (non-null)
+	b = le32(b, maxTowers)                                       // array maximum_count (size_is)
+	b = le32(b, 0)                                               // array offset
+	b = le32(b, 1)                                               // array actual_count (length_is)
+	b = le32(b, 0x00020004)                                      // element[0] referent id (non-null)
+	// twr_t body: hoisted maximum_count, tower_length, octet string, pad to 4.
+	b = le32(b, uint32(len(towerBytes)))
+	b = le32(b, uint32(len(towerBytes)))
+	b = append(b, towerBytes...)
+	b = pad4(b)
+	b = le32(b, epm.StatusSuccess) // status
+	return b
+}
+
+func TestEptMap_RoundTrip(t *testing.T) {
+	ft := &fakeTransport{}
+	c := boundClient(t, ft)
+
+	resolved := structures.Tower{Floors: []structures.Floor{
+		structures.InterfaceFloor(sampleIface(), 1, 0),
+		structures.TransferSyntaxFloor(),
+		{LHS: []byte{structures.FloorProtoNCACN}, RHS: []byte{0, 0}},
+		structures.TCPFloor(49664),
+		structures.IPFloor(net.IPv4(10, 0, 0, 30)),
+	}}
+	ft.queue(responsePDU(t, 2, eptMapResponseStub(resolved, functions.DefaultMaxTowers)))
+
+	towers, err := functions.EptMap(c, nil, structures.BuildMapTowerTCP(sampleIface(), 1, 0), functions.DefaultMaxTowers)
+	if err != nil {
+		t.Fatalf("EptMap() error = %v", err)
+	}
+	if len(towers) != 1 {
+		t.Fatalf("got %d towers, want 1", len(towers))
+	}
+	ep, ok := towers[0].Endpoint()
+	if !ok {
+		t.Fatal("returned tower has no endpoint")
+	}
+	if ep.Port != 49664 {
+		t.Errorf("port = %d, want 49664", ep.Port)
+	}
+
+	// Verify the request: opnum 3, null object pointer, then the map tower.
+	var req pdu.Request
+	if _, err := req.Unmarshal(ft.sent[1]); err != nil {
+		t.Fatalf("request does not parse: %v", err)
+	}
+	if req.Opnum != epm.OpnumEptMap {
+		t.Errorf("opnum = %d, want %d", req.Opnum, epm.OpnumEptMap)
+	}
+	if got := binary.LittleEndian.Uint32(req.Stub[:4]); got != 0 {
+		t.Errorf("object pointer = 0x%08x, want 0 (null)", got)
+	}
+}
+
+func TestMap_ReturnsEndpoints(t *testing.T) {
+	ft := &fakeTransport{}
+	c := boundClient(t, ft)
+
+	resolved := structures.Tower{Floors: []structures.Floor{
+		structures.InterfaceFloor(sampleIface(), 1, 0),
+		structures.TransferSyntaxFloor(),
+		{LHS: []byte{structures.FloorProtoNCACN}, RHS: []byte{0, 0}},
+		structures.TCPFloor(135),
+		structures.IPFloor(net.IPv4(192, 0, 2, 1)),
+	}}
+	ft.queue(responsePDU(t, 2, eptMapResponseStub(resolved, functions.DefaultMaxTowers)))
+
+	eps, err := functions.Map(c, sampleIface(), 1, 0)
+	if err != nil {
+		t.Fatalf("Map() error = %v", err)
+	}
+	if len(eps) != 1 || eps[0].Port != 135 {
+		t.Fatalf("Map() = %v, want one endpoint on port 135", eps)
+	}
+}
+
+func TestEptMap_StatusError(t *testing.T) {
+	ft := &fakeTransport{}
+	c := boundClient(t, ft)
+
+	// num_towers = 0, null ITowers pointer, non-zero status.
+	var stub []byte
+	stub = append(stub, make([]byte, structures.ContextHandleSize)...)
+	stub = le32(stub, 0)                          // num_towers
+	stub = le32(stub, 0)                          // ITowers null pointer
+	stub = le32(stub, epm.EptStatusNotRegistered) // status
+	ft.queue(responsePDU(t, 2, stub))
+
+	if _, err := functions.EptMap(c, nil, structures.BuildMapTowerTCP(sampleIface(), 1, 0), functions.DefaultMaxTowers); err == nil {
+		t.Fatal("EptMap() with ept_s_not_registered: error = nil, want non-nil")
+	}
+}

--- a/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/functions/integration_test.go
+++ b/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/functions/integration_test.go
@@ -1,0 +1,86 @@
+//go:build integration
+
+// Live integration / wire-validation for the endpoint mapper (ept) over the full
+// DCE/RPC-over-SMB stack (the \epmapper named pipe). Excluded from the default build by
+// the "integration" tag. Run with:
+//
+//	DCERPC_TEST_HOST=192.168.1.27 DCERPC_TEST_USER=user DCERPC_TEST_PASS=user \
+//	go test -tags integration -v \
+//	  ./network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/functions/
+//
+// The same resolution also works over ncacn_ip_tcp on port 135 (see
+// network/dcerpc/v5/transport/tcp): substitute that transport for the SMB one below.
+package functions_test
+
+import (
+	"net"
+	"os"
+	"strconv"
+	"testing"
+
+	epm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/functions"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	dcerpcsmb "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/transport/smb"
+	smbclient "github.com/TheManticoreProject/Manticore/network/smb/smb_v10/client"
+	"github.com/TheManticoreProject/Manticore/windows/credentials"
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+)
+
+func TestIntegration_EptMap(t *testing.T) {
+	host := os.Getenv("DCERPC_TEST_HOST")
+	if host == "" {
+		t.Skip("DCERPC_TEST_HOST not set; skipping live ept_map test")
+	}
+	port := 445
+	if p := os.Getenv("DCERPC_TEST_PORT"); p != "" {
+		n, err := strconv.Atoi(p)
+		if err != nil {
+			t.Fatalf("invalid DCERPC_TEST_PORT %q: %v", p, err)
+		}
+		port = n
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		t.Fatalf("DCERPC_TEST_HOST %q is not a valid IP", host)
+	}
+	creds, err := credentials.NewCredentials(os.Getenv("DCERPC_TEST_DOMAIN"), os.Getenv("DCERPC_TEST_USER"), os.Getenv("DCERPC_TEST_PASS"), "")
+	if err != nil {
+		t.Fatalf("NewCredentials: %v", err)
+	}
+
+	smb := smbclient.NewClientUsingTCPTransport(ip, port)
+	if err := smb.Connect(ip, port); err != nil {
+		t.Fatalf("SMB Connect: %v", err)
+	}
+	defer smb.Disconnect()
+	smb.NativeOS, smb.NativeLanMan = "Unix", "Samba"
+	if err := smb.SessionSetup(creds); err != nil {
+		t.Fatalf("SMB SessionSetup: %v", err)
+	}
+	defer smb.Logoff()
+	if err := smb.TreeConnect("IPC$"); err != nil {
+		t.Fatalf("SMB TreeConnect(IPC$): %v", err)
+	}
+	defer smb.TreeDisconnect()
+
+	rpc := client.NewClient(dcerpcsmb.New(smb, epm.PipeName))
+	if err := rpc.Bind(epm.SyntaxID()); err != nil {
+		t.Fatalf("DCE/RPC Bind(ept): %v", err)
+	}
+	defer rpc.Close()
+
+	// Resolve srvsvc (4b324fc8-1670-01d3-1278-5a47bf6ee188 v3.0); it is registered on
+	// every Windows host with a dynamic ncacn_ip_tcp endpoint.
+	srvsvc := guid.GUID{A: 0x4b324fc8, B: 0x1670, C: 0x01d3, D: 0x1278, E: 0x5a47bf6ee188}
+	eps, err := functions.Map(rpc, srvsvc, 3, 0)
+	if err != nil {
+		t.Fatalf("[WIRE FAIL] ept_map(srvsvc): %v", err)
+	}
+	if len(eps) == 0 {
+		t.Fatal("[WIRE FAIL] ept_map(srvsvc) returned no ncacn_ip_tcp endpoints")
+	}
+	for _, ep := range eps {
+		t.Logf("[ok] srvsvc bound at %s", ep)
+	}
+}

--- a/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/interface.go
+++ b/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/interface.go
@@ -1,0 +1,86 @@
+// Package rpcinterface_e1af83085d1f11c991a408002b14a0fa_3_0 is the descriptor for the
+// endpoint mapper (ept, "epmapper") RPC interface, abstract syntax
+// e1af8308-5d1f-11c9-91a4-08002b14a0fa version 3.0 ([C706] Appendix O, [MS-RPCE]).
+//
+// The endpoint mapper resolves an interface UUID and version to a concrete transport
+// endpoint (typically the dynamic TCP port a service listens on). An RPC interface is
+// identified by its UUID and version, never by the named pipe it is reached over, so
+// the directory is named after the UUID with the version in the nested 3.0/ directory.
+//
+// This package holds only the interface-level descriptor (abstract syntax, transport
+// endpoint, opnums, opnum<->name maps, status constants). The protocol tower (twr_t)
+// and the NDR shapes live in the structures subpackage; the ept_map stub lives in
+// functions. Both depend on this package, never the reverse.
+package rpcinterface_e1af83085d1f11c991a408002b14a0fa_3_0
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+)
+
+// PipeName is the IPC$-relative named pipe for the endpoint mapper (ncacn_np). The ept
+// interface is also reachable over ncacn_ip_tcp on TCP port 135 ([MS-RPCE] 2.1).
+const PipeName = `\epmapper`
+
+// Opnums for the on-the-wire ept methods ([C706] Appendix O). Only the operations
+// modelled here are listed.
+const (
+	// OpnumEptLookup is ept_lookup (opnum 2), which enumerates endpoint-map entries.
+	OpnumEptLookup uint16 = 2
+	// OpnumEptMap is ept_map (opnum 3), which resolves an interface to its bound
+	// endpoints via a protocol tower.
+	OpnumEptMap uint16 = 3
+)
+
+// Status codes returned in the ept_map [out] error_status_t. 0 is success; the ept
+// specific codes are DCE error-status values ([C706] Appendix O / Appendix E).
+const (
+	StatusSuccess          uint32 = 0x00000000 // rpc_s_ok
+	EptStatusCantPerform   uint32 = 0x16c9a0d8 // ept_s_cant_perform_op
+	EptStatusNotRegistered uint32 = 0x16c9a0d6 // ept_s_not_registered
+	EptStatusInvalidEntry  uint32 = 0x16c9a0d7 // ept_s_invalid_entry
+)
+
+// SyntaxID returns the ept abstract syntax identifier:
+// e1af8308-5d1f-11c9-91a4-08002b14a0fa, version 3.0.
+func SyntaxID() syntax.SyntaxID {
+	return syntax.SyntaxID{
+		UUID:         guid.GUID{A: 0xe1af8308, B: 0x5d1f, C: 0x11c9, D: 0x91a4, E: 0x08002b14a0fa},
+		MajorVersion: 3,
+		MinorVersion: 0,
+	}
+}
+
+// StatusString returns a mnemonic for the documented status codes, otherwise the hex
+// value.
+func StatusString(status uint32) string {
+	switch status {
+	case StatusSuccess:
+		return "rpc_s_ok"
+	case EptStatusCantPerform:
+		return "ept_s_cant_perform_op"
+	case EptStatusNotRegistered:
+		return "ept_s_not_registered"
+	case EptStatusInvalidEntry:
+		return "ept_s_invalid_entry"
+	default:
+		return fmt.Sprintf("0x%08x", status)
+	}
+}
+
+// OpnumToName maps each modelled opnum to its method name; the single source of truth.
+var OpnumToName = map[uint16]string{
+	OpnumEptLookup: "ept_lookup",
+	OpnumEptMap:    "ept_map",
+}
+
+// NameToOpnum is the reverse of OpnumToName, built at init so the two never drift.
+var NameToOpnum = func() map[string]uint16 {
+	m := make(map[string]uint16, len(OpnumToName))
+	for op, name := range OpnumToName {
+		m[name] = op
+	}
+	return m
+}()

--- a/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/interface_test.go
+++ b/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/interface_test.go
@@ -1,0 +1,41 @@
+package rpcinterface_e1af83085d1f11c991a408002b14a0fa_3_0
+
+import "testing"
+
+func TestSyntaxID(t *testing.T) {
+	s := SyntaxID()
+	if s.MajorVersion != 3 || s.MinorVersion != 0 {
+		t.Errorf("version = %d.%d, want 3.0", s.MajorVersion, s.MinorVersion)
+	}
+	want := "e1af8308-5d1f-11c9-91a4-08002b14a0fa"
+	if got := s.UUID.ToFormatD(); got != want {
+		t.Errorf("UUID = %s, want %s", got, want)
+	}
+}
+
+func TestStatusString(t *testing.T) {
+	cases := map[uint32]string{
+		StatusSuccess:          "rpc_s_ok",
+		EptStatusNotRegistered: "ept_s_not_registered",
+		0xdeadbeef:             "0xdeadbeef",
+	}
+	for status, want := range cases {
+		if got := StatusString(status); got != want {
+			t.Errorf("StatusString(0x%08x) = %q, want %q", status, got, want)
+		}
+	}
+}
+
+func TestOpnumNameRoundTrip(t *testing.T) {
+	for op, name := range OpnumToName {
+		if NameToOpnum[name] != op {
+			t.Errorf("NameToOpnum[%q] = %d, want %d", name, NameToOpnum[name], op)
+		}
+	}
+	if len(NameToOpnum) != len(OpnumToName) {
+		t.Errorf("NameToOpnum has %d entries, OpnumToName has %d", len(NameToOpnum), len(OpnumToName))
+	}
+	if OpnumEptMap != 3 {
+		t.Errorf("OpnumEptMap = %d, want 3", OpnumEptMap)
+	}
+}

--- a/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/structures/context_handle.go
+++ b/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/structures/context_handle.go
@@ -1,0 +1,41 @@
+package structures
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// ContextHandleSize is the wire size of an ept_lookup_handle_t / ndr_context_handle: a
+// 4-octet attributes field plus a 16-octet UUID ([C706] section 4.2.16.6).
+const ContextHandleSize = 20
+
+// ContextHandle models the ept_lookup_handle_t context handle. A context handle is
+// transmitted inline as its 20 octets (not as an NDR pointer referent) and aligned to 4
+// octets; it is a Marshaler so the codec applies that alignment ahead of the handle
+// regardless of how the preceding tower octet string padded out. The zero value is the
+// null handle used on the first ept_map call.
+type ContextHandle [ContextHandleSize]byte
+
+// Compile-time assertion that ContextHandle encodes itself as NDR.
+var _ ndr.Marshaler = (*ContextHandle)(nil)
+
+// AlignmentNDR reports the 4-octet alignment of a context handle (its first field is the
+// 4-octet attributes word).
+func (*ContextHandle) AlignmentNDR() int { return 4 }
+
+// MarshalNDR writes the 20 octets of the context handle.
+func (h *ContextHandle) MarshalNDR(e *ndr.Encoder) error {
+	e.WriteBytes(h[:])
+	return nil
+}
+
+// UnmarshalNDR reads the 20 octets of the context handle.
+func (h *ContextHandle) UnmarshalNDR(d *ndr.Decoder) error {
+	b, err := d.ReadBytes(ContextHandleSize)
+	if err != nil {
+		return fmt.Errorf("epm: context handle: %w", err)
+	}
+	copy(h[:], b)
+	return nil
+}

--- a/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/structures/structures_test.go
+++ b/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/structures/structures_test.go
@@ -1,0 +1,160 @@
+package structures
+
+import (
+	"bytes"
+	"net"
+	"reflect"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+)
+
+func sampleIface() guid.GUID {
+	// efsrpc: c681d488-d850-11d0-8c52-00c04fd90f7e v1.0, an arbitrary lookup target.
+	return guid.GUID{A: 0xc681d488, B: 0xd850, C: 0x11d0, D: 0x8c52, E: 0x00c04fd90f7e}
+}
+
+func TestTower_RoundTrip(t *testing.T) {
+	in := BuildMapTowerTCP(sampleIface(), 1, 0)
+	raw := in.Marshal()
+	out, err := UnmarshalTower(raw)
+	if err != nil {
+		t.Fatalf("UnmarshalTower() error = %v", err)
+	}
+	if !reflect.DeepEqual(in, out) {
+		t.Errorf("tower round-trip mismatch:\n in  %+v\n out %+v", in, out)
+	}
+	if len(out.Floors) != 5 {
+		t.Fatalf("floor count = %d, want 5", len(out.Floors))
+	}
+	// Floor protocol identifiers, in order: interface, transfer syntax, ncacn, TCP, IP.
+	want := []byte{FloorProtoUUID, FloorProtoUUID, FloorProtoNCACN, FloorProtoTCP, FloorProtoIP}
+	for i, p := range want {
+		if got := out.Floors[i].Protocol(); got != p {
+			t.Errorf("floor %d protocol = 0x%02x, want 0x%02x", i, got, p)
+		}
+	}
+}
+
+func TestTower_EndpointTCP(t *testing.T) {
+	tower := Tower{Floors: []Floor{
+		InterfaceFloor(sampleIface(), 1, 0),
+		TransferSyntaxFloor(),
+		Floor{LHS: []byte{FloorProtoNCACN}, RHS: []byte{0, 0}},
+		TCPFloor(49664),
+		IPFloor(net.IPv4(10, 0, 0, 30)),
+	}}
+	ep, ok := tower.Endpoint()
+	if !ok {
+		t.Fatal("Endpoint() ok = false, want true")
+	}
+	if ep.Port != 49664 {
+		t.Errorf("port = %d, want 49664", ep.Port)
+	}
+	if !ep.IP.Equal(net.IPv4(10, 0, 0, 30)) {
+		t.Errorf("ip = %s, want 10.0.0.30", ep.IP)
+	}
+}
+
+func TestTower_EndpointNoTCPFloor(t *testing.T) {
+	tower := Tower{Floors: []Floor{InterfaceFloor(sampleIface(), 1, 0), TransferSyntaxFloor()}}
+	if _, ok := tower.Endpoint(); ok {
+		t.Error("Endpoint() ok = true for a tower with no TCP floor, want false")
+	}
+}
+
+func TestUnmarshalTower_Truncated(t *testing.T) {
+	if _, err := UnmarshalTower([]byte{0x05}); err == nil {
+		t.Error("UnmarshalTower(truncated) error = nil, want non-nil")
+	}
+	// A floor count of 2 but bytes for none.
+	if _, err := UnmarshalTower([]byte{0x02, 0x00}); err == nil {
+		t.Error("UnmarshalTower(missing floors) error = nil, want non-nil")
+	}
+}
+
+func TestTwr_RoundTrip(t *testing.T) {
+	tower := BuildMapTowerTCP(sampleIface(), 1, 0)
+	in := NewTwr(tower)
+
+	raw, err := ndr.Marshal(&in)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	// Conformant struct: hoisted maximum_count, then tower_length, then the octet string.
+	if len(raw) < 8 {
+		t.Fatalf("marshalled twr_t too short: %d bytes", len(raw))
+	}
+	towerBytes := tower.Marshal()
+	wantHead := make([]byte, 8)
+	// maximum_count == tower_length == len(towerBytes), both little-endian.
+	for i, n := 0, uint32(len(towerBytes)); i < 4; i++ {
+		wantHead[i] = byte(n >> (8 * uint(i)))
+		wantHead[i+4] = byte(n >> (8 * uint(i)))
+	}
+	if !bytes.Equal(raw[:8], wantHead) {
+		t.Errorf("twr_t header:\n got %x\nwant %x", raw[:8], wantHead)
+	}
+
+	var out Twr
+	if err := ndr.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if !bytes.Equal(out.TowerOctetString, in.TowerOctetString) {
+		t.Errorf("octet string round-trip mismatch:\n got %x\nwant %x", out.TowerOctetString, in.TowerOctetString)
+	}
+	got, err := out.DecodeTower()
+	if err != nil {
+		t.Fatalf("DecodeTower() error = %v", err)
+	}
+	if !reflect.DeepEqual(got, tower) {
+		t.Errorf("decoded tower mismatch")
+	}
+}
+
+func TestContextHandle_RoundTrip(t *testing.T) {
+	var in ContextHandle
+	for i := range in {
+		in[i] = byte(i + 1)
+	}
+	raw, err := ndr.Marshal(&struct{ H ContextHandle }{in})
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	if len(raw) != ContextHandleSize {
+		t.Fatalf("marshalled size = %d, want %d", len(raw), ContextHandleSize)
+	}
+	if !bytes.Equal(raw, in[:]) {
+		t.Errorf("context handle bytes:\n got %x\nwant %x", raw, in[:])
+	}
+	var out struct{ H ContextHandle }
+	if err := ndr.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if out.H != in {
+		t.Errorf("context handle round-trip = %x, want %x", out.H, in)
+	}
+}
+
+func TestEptUUID_RoundTrip(t *testing.T) {
+	g := sampleIface()
+	in := NewEptUUID(g)
+	raw, err := ndr.Marshal(&struct{ U EptUUID }{in})
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	if len(raw) != 16 {
+		t.Fatalf("marshalled size = %d, want 16", len(raw))
+	}
+	if !bytes.Equal(raw, g.ToBytes()) {
+		t.Errorf("uuid bytes:\n got %x\nwant %x", raw, g.ToBytes())
+	}
+	var out struct{ U EptUUID }
+	if err := ndr.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if got := out.U.GUID(); !got.Equal(&g) {
+		t.Errorf("uuid round-trip mismatch: got %s", got.ToFormatD())
+	}
+}

--- a/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/structures/tower.go
+++ b/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/structures/tower.go
@@ -1,0 +1,226 @@
+package structures
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+)
+
+// A protocol tower is the floor-based description of an interface-over-transport
+// binding, defined in [C706] Appendix L with the floor protocol identifiers in [C706]
+// Appendix I. It is carried in ept_map as an octet string inside a twr_t (see Twr); the
+// encoding here is that raw octet string, independent of NDR.
+//
+// References:
+//   - [C706] Appendix L (protocol tower encoding):
+//     https://pubs.opengroup.org/onlinepubs/9629399/apdxl.htm
+//   - [C706] Appendix I (protocol identifiers):
+//     https://pubs.opengroup.org/onlinepubs/9629399/apdxi.htm
+
+// Floor protocol identifier bytes, the first octet of a floor's LHS ([C706] Appendix I).
+const (
+	// FloorProtoUUID marks a floor whose LHS is a UUID plus a 16-bit major version (the
+	// interface-identifier and transfer-syntax floors). The RHS holds the 16-bit minor
+	// version.
+	FloorProtoUUID = 0x0D
+	// FloorProtoNCACN identifies the connection-oriented RPC protocol (major v5).
+	FloorProtoNCACN = 0x0B
+	// FloorProtoNCADG identifies the connectionless RPC protocol (major v4).
+	FloorProtoNCADG = 0x0A
+	// FloorProtoTCP identifies the DOD TCP floor; its RHS is a 16-bit port in big-endian
+	// order. This is the transport floor of an ncacn_ip_tcp tower.
+	FloorProtoTCP = 0x07
+	// FloorProtoUDP identifies the DOD UDP floor; its RHS is a 16-bit port in big-endian
+	// order.
+	FloorProtoUDP = 0x08
+	// FloorProtoIP identifies the DOD IP floor; its RHS is a 4-octet IPv4 address in
+	// big-endian order.
+	FloorProtoIP = 0x09
+)
+
+// Floor is one floor of a protocol tower: a length-prefixed left-hand side (protocol
+// identifier and associated data) and a length-prefixed right-hand side (addressing or
+// version data).
+type Floor struct {
+	LHS []byte
+	RHS []byte
+}
+
+// Protocol returns the floor's protocol identifier byte (the first LHS octet), or 0 if
+// the LHS is empty.
+func (f Floor) Protocol() byte {
+	if len(f.LHS) == 0 {
+		return 0
+	}
+	return f.LHS[0]
+}
+
+// Marshal serializes the floor: uint16 LHS length, LHS, uint16 RHS length, RHS (all
+// lengths little-endian).
+func (f Floor) Marshal() []byte {
+	buf := make([]byte, 0, 4+len(f.LHS)+len(f.RHS))
+	var l [2]byte
+	binary.LittleEndian.PutUint16(l[:], uint16(len(f.LHS)))
+	buf = append(buf, l[:]...)
+	buf = append(buf, f.LHS...)
+	binary.LittleEndian.PutUint16(l[:], uint16(len(f.RHS)))
+	buf = append(buf, l[:]...)
+	buf = append(buf, f.RHS...)
+	return buf
+}
+
+// unmarshalFloor parses one floor from the front of data and returns it with the number
+// of bytes consumed.
+func unmarshalFloor(data []byte) (Floor, int, error) {
+	if len(data) < 2 {
+		return Floor{}, 0, fmt.Errorf("epm: floor truncated reading LHS length")
+	}
+	off := 0
+	lhsLen := int(binary.LittleEndian.Uint16(data[off:]))
+	off += 2
+	if len(data) < off+lhsLen+2 {
+		return Floor{}, 0, fmt.Errorf("epm: floor truncated reading LHS/RHS length")
+	}
+	lhs := append([]byte(nil), data[off:off+lhsLen]...)
+	off += lhsLen
+	rhsLen := int(binary.LittleEndian.Uint16(data[off:]))
+	off += 2
+	if len(data) < off+rhsLen {
+		return Floor{}, 0, fmt.Errorf("epm: floor truncated reading RHS")
+	}
+	rhs := append([]byte(nil), data[off:off+rhsLen]...)
+	off += rhsLen
+	return Floor{LHS: lhs, RHS: rhs}, off, nil
+}
+
+// Tower is an ordered list of floors describing an interface-over-transport binding.
+type Tower struct {
+	Floors []Floor
+}
+
+// Marshal serializes the tower: a little-endian uint16 floor count followed by each
+// floor.
+func (t Tower) Marshal() []byte {
+	buf := make([]byte, 2)
+	binary.LittleEndian.PutUint16(buf, uint16(len(t.Floors)))
+	for _, f := range t.Floors {
+		buf = append(buf, f.Marshal()...)
+	}
+	return buf
+}
+
+// UnmarshalTower parses a tower octet string.
+func UnmarshalTower(data []byte) (Tower, error) {
+	if len(data) < 2 {
+		return Tower{}, fmt.Errorf("epm: tower truncated reading floor count")
+	}
+	count := int(binary.LittleEndian.Uint16(data))
+	off := 2
+	t := Tower{Floors: make([]Floor, 0, count)}
+	for i := 0; i < count; i++ {
+		f, n, err := unmarshalFloor(data[off:])
+		if err != nil {
+			return Tower{}, fmt.Errorf("epm: floor %d: %w", i, err)
+		}
+		t.Floors = append(t.Floors, f)
+		off += n
+	}
+	return t, nil
+}
+
+// uuidFloor builds a UUID-typed floor (interface identifier or transfer syntax): LHS =
+// 0x0D, 16-byte UUID, 2-byte major version; RHS = 2-byte minor version.
+func uuidFloor(id guid.GUID, major, minor uint16) Floor {
+	lhs := make([]byte, 0, 1+16+2)
+	lhs = append(lhs, FloorProtoUUID)
+	lhs = append(lhs, id.ToBytes()...)
+	var v [2]byte
+	binary.LittleEndian.PutUint16(v[:], major)
+	lhs = append(lhs, v[:]...)
+	rhs := make([]byte, 2)
+	binary.LittleEndian.PutUint16(rhs, minor)
+	return Floor{LHS: lhs, RHS: rhs}
+}
+
+// InterfaceFloor builds the interface-identifier floor (floor 1).
+func InterfaceFloor(iface guid.GUID, major, minor uint16) Floor {
+	return uuidFloor(iface, major, minor)
+}
+
+// TransferSyntaxFloor builds the NDR transfer-syntax floor (floor 2).
+func TransferSyntaxFloor() Floor {
+	nd := syntax.NDRTransferSyntax()
+	return uuidFloor(nd.UUID, nd.MajorVersion, nd.MinorVersion)
+}
+
+// protocolFloor builds a single-identifier RPC protocol floor (LHS = one identifier
+// byte) whose RHS is a 2-byte little-endian minor version.
+func protocolFloor(proto byte, minor uint16) Floor {
+	rhs := make([]byte, 2)
+	binary.LittleEndian.PutUint16(rhs, minor)
+	return Floor{LHS: []byte{proto}, RHS: rhs}
+}
+
+// TCPFloor builds the DOD TCP floor; the RHS is the 16-bit port in big-endian order.
+func TCPFloor(port uint16) Floor {
+	rhs := make([]byte, 2)
+	binary.BigEndian.PutUint16(rhs, port)
+	return Floor{LHS: []byte{FloorProtoTCP}, RHS: rhs}
+}
+
+// IPFloor builds the DOD IP floor; the RHS is the 4-octet IPv4 address in big-endian
+// (network) order.
+func IPFloor(ip net.IP) Floor {
+	rhs := make([]byte, 4)
+	if v4 := ip.To4(); v4 != nil {
+		copy(rhs, v4)
+	}
+	return Floor{LHS: []byte{FloorProtoIP}, RHS: rhs}
+}
+
+// BuildMapTowerTCP builds the 5-floor ncacn_ip_tcp tower used as the ept_map input: the
+// interface and NDR transfer-syntax floors describe what is wanted, and the
+// connection-oriented/TCP/IP floors with a zero port and address request that the
+// endpoint mapper fill in the bound endpoint.
+func BuildMapTowerTCP(iface guid.GUID, ifMajor, ifMinor uint16) Tower {
+	return Tower{Floors: []Floor{
+		InterfaceFloor(iface, ifMajor, ifMinor),
+		TransferSyntaxFloor(),
+		protocolFloor(FloorProtoNCACN, 0),
+		TCPFloor(0),
+		IPFloor(net.IPv4zero),
+	}}
+}
+
+// Endpoint is a resolved transport endpoint extracted from a tower.
+type Endpoint struct {
+	IP   net.IP
+	Port uint16
+}
+
+// String renders the endpoint as host:port.
+func (e Endpoint) String() string { return fmt.Sprintf("%s:%d", e.IP, e.Port) }
+
+// Endpoint extracts the TCP port and IPv4 address from the tower's transport floors. ok
+// is false unless a TCP floor is present; the IP is left zero if the tower carries no IP
+// floor.
+func (t Tower) Endpoint() (ep Endpoint, ok bool) {
+	var gotPort bool
+	for _, f := range t.Floors {
+		switch f.Protocol() {
+		case FloorProtoTCP:
+			if len(f.RHS) >= 2 {
+				ep.Port = binary.BigEndian.Uint16(f.RHS)
+				gotPort = true
+			}
+		case FloorProtoIP:
+			if len(f.RHS) >= 4 {
+				ep.IP = net.IPv4(f.RHS[0], f.RHS[1], f.RHS[2], f.RHS[3])
+			}
+		}
+	}
+	return ep, gotPort
+}

--- a/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/structures/twr.go
+++ b/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/structures/twr.go
@@ -1,0 +1,27 @@
+package structures
+
+// Twr models twr_t ([C706] Appendix O):
+//
+//	typedef struct {
+//	    unsigned32 tower_length;
+//	    [size_is(tower_length)] byte tower_octet_string[];
+//	} twr_t;
+//
+// It is a conformant structure: the NDR codec hoists the array's maximum_count to the
+// front of the structure and derives TowerLength from the octet-string length, so
+// callers set only TowerOctetString. The octet string itself is a protocol tower (see
+// Tower); use NewTwr / DecodeTower to convert between the two.
+type Twr struct {
+	TowerLength      uint32
+	TowerOctetString []byte `ndr:"conformant,size_is=TowerLength"`
+}
+
+// NewTwr wraps a protocol tower's octet-string encoding in a twr_t.
+func NewTwr(tower Tower) Twr {
+	return Twr{TowerOctetString: tower.Marshal()}
+}
+
+// DecodeTower parses the twr_t's octet string back into a protocol tower.
+func (t Twr) DecodeTower() (Tower, error) {
+	return UnmarshalTower(t.TowerOctetString)
+}

--- a/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/structures/uuid.go
+++ b/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/structures/uuid.go
@@ -1,0 +1,29 @@
+package structures
+
+import "github.com/TheManticoreProject/Manticore/windows/guid"
+
+// EptUUID models the uuid_t referent of ept_map's optional [in] object pointer
+// (uuid_p_t). Octets holds the 16-octet UUID exactly as it appears on the wire
+// (Data1/2/3 little-endian, Data4 big-endian), which the codec emits verbatim as the
+// referent body of the full pointer. It is a fixed-octet struct rather than an
+// ndr.Marshaler so the codec applies its normal pointer handling (a NULL referent id
+// when the field is nil); a Marshaler is intercepted before that and would be
+// dereferenced even when nil. guid.GUID is not used directly because its Go layout (a
+// trailing uint64) does not map to 16 contiguous octets under reflection.
+type EptUUID struct {
+	Octets [16]byte
+}
+
+// NewEptUUID converts a GUID to its uuid_t octet form.
+func NewEptUUID(g guid.GUID) EptUUID {
+	var u EptUUID
+	copy(u.Octets[:], g.ToBytes())
+	return u
+}
+
+// GUID converts the octets back to a guid.GUID.
+func (u EptUUID) GUID() guid.GUID {
+	var g guid.GUID
+	g.FromRawBytes(u.Octets[:])
+	return g
+}


### PR DESCRIPTION
### Linked Issue
`Closes #416`

### Root Cause
The DCE/RPC stack could only reach interfaces bound to a well-known named pipe (lsarpc, srvsvc, …) — it had no way to ask the endpoint mapper which dynamic endpoint a service listens on. Resolving an interface UUID/version to a concrete endpoint (the dynamic TCP port, in particular) is a prerequisite for making `ncacn_ip_tcp` useful, and that lookup did not exist in the connection-oriented (v5) / declarative-NDR stack.

### Fix Description
Adds the ept ("epmapper") interface, abstract syntax `e1af8308-5d1f-11c9-91a4-08002b14a0fa` version 3.0, under the UUID-versioned `network/dcerpc/interfaces/` tree (consistent with every other interface and the project's interface-structure conventions), implemented with the declarative `network/dcerpc/ndr` API.

- **Descriptor** (`interface.go`): syntax id, `\epmapper` pipe name, opnum constants (`ept_lookup` 2, `ept_map` 3), the ept status codes, and the opnum⇆name maps.
- **Protocol tower** (`structures/tower.go`): the floor-based `Tower`/`Floor` octet-string encoding ([C706] Appendix L / Appendix I), with builders for the interface, NDR transfer-syntax, ncacn, TCP, and IP floors, a `BuildMapTowerTCP` for the ncacn_ip_tcp lookup, and `Tower.Endpoint` to extract the resolved `host:port`.
- **NDR shapes**: `Twr` models `twr_t` (a conformant struct whose `tower_length`/`maximum_count` the codec derives from the octet string); `EptUUID` is the 16-octet `uuid_t` referent of the optional object pointer (a fixed-octet struct, not a Marshaler, so the codec emits a NULL referent when it is nil); `ContextHandle` is the 20-octet `ept_lookup_handle_t`, a Marshaler so the codec applies its mandatory 4-octet alignment regardless of how the preceding tower octet string padded out.
- **`ept_map`** (`functions/03_EptMap.go`): the opnum-3 stub. The request is the optional object full pointer, the map-tower full pointer, the context handle, and `max_towers`; the response is a full pointer to a conformant-varying array of full pointers to `twr_t`. `EptMap` returns the decoded towers; the `Map` helper (`functions/functions.go`) builds a TCP map tower and returns the resolved endpoints.

### How Verified
- `go build`, `go vet`, and `go test` pass for the new tree; `go build -tags integration` / `go vet -tags integration` pass for the integration test.
- Unit tests round-trip every wire shape and drive a full `ept_map` exchange through the real v5 client over an in-memory transport against a hand-assembled golden response, asserting the resolved endpoint (port/IP), the null object pointer in the marshalled request, the correct opnum, and the non-success status path.

### Test Coverage
- **Added:** `structures/structures_test.go` (`TestTower_RoundTrip`, `_EndpointTCP`, `_EndpointNoTCPFloor`, `TestUnmarshalTower_Truncated`, `TestTwr_RoundTrip`, `TestContextHandle_RoundTrip`, `TestEptUUID_RoundTrip`); `interface_test.go` (`TestSyntaxID`, `TestStatusString`, `TestOpnumNameRoundTrip`); `functions/functions_test.go` (`TestEptMap_RoundTrip`, `TestMap_ReturnsEndpoints`, `TestEptMap_StatusError`); `functions/integration_test.go` (`TestIntegration_EptMap`, build-tagged `integration`).

### Scope of Change
- **Files changed:** all new, under `network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/` (`interface.go`, `interface_test.go`, `structures/{tower,twr,uuid,context_handle}.go`, `structures/structures_test.go`, `functions/{functions,03_EptMap}.go`, `functions/{functions_test,integration_test}.go`).
- **Submodule pointer updated:** no.
- **Behavioral changes outside the new interface:** none.

### Notes
- Pairs with the `ncacn_ip_tcp` transport (#416's companion, #417 / PR #568): `Map` returns the TCP endpoint a service is bound to, which that transport then connects to. The integration test exercises ept over the existing `\epmapper` SMB pipe so this change stands alone; the same call works over ncacn_ip_tcp on port 135.
- `ept_lookup` (opnum 2) is declared in the descriptor but not yet implemented; it can be added later without affecting `ept_map`.