### PR TITLE
Add MS-SRVS share/session/server-info helpers (#359, #360, #361)

### DIFF
--- a/network/dcerpc/ms-protocols/ms-srvs/client.go
+++ b/network/dcerpc/ms-protocols/ms-srvs/client.go
@@ -1,0 +1,53 @@
+// Package mssrvs implements high-level MS-SRVS (Server Service Remote Protocol)
+// workflows over the srvsvc DCE/RPC interface
+// (4b324fc8-1670-01d3-1278-5a47bf6ee188 v3.0), carried over the \srvsvc named pipe on
+// the IPC$ tree.
+//
+// It is the protocol layer above the interface: callers hold a connected and
+// authenticated SMB v1 client and call the convenience methods here (ListShares,
+// ListSessions, GetServerInfo), which bind to srvsvc, issue the underlying
+// NetrShareEnum / NetrSessionEnum / NetrServerGetInfo calls, and project the NDR
+// containers and unions into friendly Go structs. The smbclient-ng tool's shares / who
+// / info commands are the intended consumers.
+//
+// References:
+//   - [MS-SRVS] 3.1.4.8 NetrShareEnum, 3.1.4.6 NetrSessionEnum, 3.1.4.17 NetrServerGetInfo
+//   - [MS-RPCE] DCE/RPC over SMB named pipes
+package mssrvs
+
+import (
+	"fmt"
+
+	srvsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0"
+	dcerpcclient "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	dcerpcsmb "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/transport/smb"
+	smbclient "github.com/TheManticoreProject/Manticore/network/smb/smb_v10/client"
+)
+
+// MaxPreferredLength is passed as the preferred maximum reply length of the Netr*Enum
+// calls. 0xFFFFFFFF asks the server to return every entry in a single response, so no
+// resume-handle paging is needed; this matches impacket's enumeration usage.
+const MaxPreferredLength uint32 = 0xFFFFFFFF
+
+// Client exposes MS-SRVS workflows over an established SMB v1 session. The supplied SMB
+// client MUST already be connected, have an authenticated session (SessionSetup), and
+// have a tree connected to IPC$ (TreeConnect) before any method is called.
+type Client struct {
+	smb *smbclient.Client
+}
+
+// New returns an MS-SRVS client over the given SMB v1 client.
+func New(smb *smbclient.Client) *Client {
+	return &Client{smb: smb}
+}
+
+// bind opens a fresh \srvsvc pipe and binds the srvsvc abstract syntax over it. srvsvc
+// calls are mutually independent, so each workflow runs on its own pipe and bind: a
+// fault on one cannot desync the next. The returned close function tears the pipe down.
+func (c *Client) bind() (*dcerpcclient.Client, func() error, error) {
+	rpc := dcerpcclient.NewClient(dcerpcsmb.New(c.smb, srvsvc.PipeName))
+	if err := rpc.Bind(srvsvc.SyntaxID()); err != nil {
+		return nil, nil, fmt.Errorf("mssrvs: bind srvsvc: %w", err)
+	}
+	return rpc, rpc.Close, nil
+}

--- a/network/dcerpc/ms-protocols/ms-srvs/integration_test.go
+++ b/network/dcerpc/ms-protocols/ms-srvs/integration_test.go
@@ -1,0 +1,103 @@
+//go:build integration
+
+// Live integration test for the MS-SRVS convenience layer over the full
+// DCE/RPC-over-SMB stack. Excluded from the default build by the "integration" tag.
+// Run with:
+//
+//	DCERPC_TEST_HOST=192.168.1.27 DCERPC_TEST_USER=user DCERPC_TEST_PASS=user \
+//	go test -tags integration -v ./network/dcerpc/ms-protocols/ms-srvs/
+package mssrvs_test
+
+import (
+	"net"
+	"os"
+	"strconv"
+	"testing"
+
+	mssrvs "github.com/TheManticoreProject/Manticore/network/dcerpc/ms-protocols/ms-srvs"
+	smbclient "github.com/TheManticoreProject/Manticore/network/smb/smb_v10/client"
+	"github.com/TheManticoreProject/Manticore/windows/credentials"
+)
+
+func liveClient(t *testing.T) (*mssrvs.Client, func()) {
+	t.Helper()
+	host := os.Getenv("DCERPC_TEST_HOST")
+	if host == "" {
+		t.Skip("DCERPC_TEST_HOST not set; skipping live MS-SRVS test")
+	}
+	port := 445
+	if p := os.Getenv("DCERPC_TEST_PORT"); p != "" {
+		n, err := strconv.Atoi(p)
+		if err != nil {
+			t.Fatalf("invalid DCERPC_TEST_PORT %q: %v", p, err)
+		}
+		port = n
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		t.Fatalf("DCERPC_TEST_HOST %q is not a valid IP", host)
+	}
+	creds, err := credentials.NewCredentials(os.Getenv("DCERPC_TEST_DOMAIN"), os.Getenv("DCERPC_TEST_USER"), os.Getenv("DCERPC_TEST_PASS"), "")
+	if err != nil {
+		t.Fatalf("NewCredentials: %v", err)
+	}
+
+	smb := smbclient.NewClientUsingTCPTransport(ip, port)
+	if err := smb.Connect(ip, port); err != nil {
+		t.Fatalf("SMB Connect: %v", err)
+	}
+	smb.NativeOS, smb.NativeLanMan = "Unix", "Samba"
+	if err := smb.SessionSetup(creds); err != nil {
+		t.Fatalf("SMB SessionSetup: %v", err)
+	}
+	if err := smb.TreeConnect("IPC$"); err != nil {
+		t.Fatalf("SMB TreeConnect(IPC$): %v", err)
+	}
+	cleanup := func() {
+		_ = smb.TreeDisconnect()
+		_ = smb.Logoff()
+		_ = smb.Disconnect()
+	}
+	return mssrvs.New(smb), cleanup
+}
+
+func TestIntegration_ListShares(t *testing.T) {
+	c, cleanup := liveClient(t)
+	defer cleanup()
+	shares, err := c.ListShares()
+	if err != nil {
+		t.Fatalf("[WIRE FAIL] ListShares: %v", err)
+	}
+	if len(shares) == 0 {
+		t.Fatal("[WIRE FAIL] ListShares returned no shares (expected at least IPC$)")
+	}
+	for _, s := range shares {
+		t.Logf("[ok] share %q type=0x%08x %q", s.Name, s.Type, s.Comment)
+	}
+}
+
+func TestIntegration_GetServerInfo(t *testing.T) {
+	c, cleanup := liveClient(t)
+	defer cleanup()
+	info, err := c.GetServerInfo()
+	if err != nil {
+		t.Fatalf("[WIRE FAIL] GetServerInfo: %v", err)
+	}
+	t.Logf("[ok] server %q version %d.%d platform=%d type=0x%08x %q",
+		info.Name, info.VersionMajor, info.VersionMinor, info.PlatformID, info.Type, info.Comment)
+}
+
+func TestIntegration_ListSessions(t *testing.T) {
+	c, cleanup := liveClient(t)
+	defer cleanup()
+	// Session enumeration typically requires administrative rights; a privilege error
+	// here is the server's policy, not a wire defect, so only log it.
+	sessions, err := c.ListSessions()
+	if err != nil {
+		t.Logf("ListSessions: %v (often requires admin rights)", err)
+		return
+	}
+	for _, s := range sessions {
+		t.Logf("[ok] session client=%q user=%q active=%ds idle=%ds", s.ClientName, s.UserName, s.ActiveSecs, s.IdleSecs)
+	}
+}

--- a/network/dcerpc/ms-protocols/ms-srvs/server_info.go
+++ b/network/dcerpc/ms-protocols/ms-srvs/server_info.go
@@ -1,0 +1,52 @@
+package mssrvs
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// ServerInfo is the configuration of a server: platform id, name, OS version, SV_TYPE_*
+// flags, and comment ([MS-SRVS] 2.2.4.41 SERVER_INFO_101).
+type ServerInfo struct {
+	PlatformID   uint32
+	Name         string
+	VersionMajor uint32
+	VersionMinor uint32
+	Type         uint32
+	Comment      string
+}
+
+// GetServerInfo queries the server's configuration via NetrServerGetInfo at info level
+// 101 ([MS-SRVS] 3.1.4.17). It binds a fresh \srvsvc pipe for the call.
+func (c *Client) GetServerInfo() (*ServerInfo, error) {
+	rpc, done, err := c.bind()
+	if err != nil {
+		return nil, err
+	}
+	defer done()
+	return getServerInfo(rpc)
+}
+
+// getServerInfo performs the NetrServerGetInfo call over an already-bound invoker and
+// projects the level-101 union arm into a ServerInfo.
+func getServerInfo(rpc ndr.Invoker) (*ServerInfo, error) {
+	out, err := functions.NetrServerGetInfo(rpc, "", 101)
+	if err != nil {
+		return nil, err
+	}
+
+	si := out.ServerInfo101
+	if si == nil {
+		return nil, fmt.Errorf("mssrvs: NetrServerGetInfo(101) returned no SERVER_INFO_101")
+	}
+	return &ServerInfo{
+		PlatformID:   uint32(si.Sv101PlatformId),
+		Name:         string(si.Sv101Name),
+		VersionMajor: uint32(si.Sv101VersionMajor),
+		VersionMinor: uint32(si.Sv101VersionMinor),
+		Type:         uint32(si.Sv101Type),
+		Comment:      string(si.Sv101Comment),
+	}, nil
+}

--- a/network/dcerpc/ms-protocols/ms-srvs/sessions.go
+++ b/network/dcerpc/ms-protocols/ms-srvs/sessions.go
@@ -1,0 +1,61 @@
+package mssrvs
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/structures"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// SessionInfo is an active session on the server: the connecting client's name, the
+// authenticated user, and the active/idle times in seconds ([MS-SRVS] 2.2.4.15
+// SESSION_INFO_10).
+type SessionInfo struct {
+	ClientName string
+	UserName   string
+	ActiveSecs uint32
+	IdleSecs   uint32
+}
+
+// ListSessions enumerates the active sessions on the server via NetrSessionEnum at info
+// level 10 ([MS-SRVS] 3.1.4.6). It binds a fresh \srvsvc pipe for the call. The server
+// typically requires administrative rights to enumerate sessions.
+func (c *Client) ListSessions() ([]SessionInfo, error) {
+	rpc, done, err := c.bind()
+	if err != nil {
+		return nil, err
+	}
+	defer done()
+	return listSessions(rpc)
+}
+
+// listSessions performs the NetrSessionEnum call over an already-bound invoker and
+// projects the level-10 container into SessionInfo values.
+func listSessions(rpc ndr.Invoker) ([]SessionInfo, error) {
+	info := structures.SESSION_ENUM_STRUCT{
+		Level: 10,
+		SessionInfo: structures.SESSION_ENUM_UNION{
+			Tag:     10,
+			Level10: &structures.SESSION_INFO_10_CONTAINER{},
+		},
+	}
+
+	out, _, _, err := functions.NetrSessionEnum(rpc, "", "", "", info, MaxPreferredLength, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	container := out.SessionInfo.Level10
+	if container == nil {
+		return nil, nil
+	}
+	sessions := make([]SessionInfo, 0, len(container.Buffer))
+	for _, s := range container.Buffer {
+		sessions = append(sessions, SessionInfo{
+			ClientName: string(s.Sesi10Cname),
+			UserName:   string(s.Sesi10Username),
+			ActiveSecs: uint32(s.Sesi10Time),
+			IdleSecs:   uint32(s.Sesi10IdleTime),
+		})
+	}
+	return sessions, nil
+}

--- a/network/dcerpc/ms-protocols/ms-srvs/shares.go
+++ b/network/dcerpc/ms-protocols/ms-srvs/shares.go
@@ -1,0 +1,60 @@
+package mssrvs
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/structures"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// ShareInfo is a shared resource exported by the server: its name, STYPE_* type flags,
+// and comment ([MS-SRVS] 2.2.4.23 SHARE_INFO_1). Type carries the raw STYPE_* value,
+// including the STYPE_SPECIAL (0x80000000) and STYPE_TEMPORARY (0x40000000) high bits.
+type ShareInfo struct {
+	Name    string
+	Type    uint32
+	Comment string
+}
+
+// ListShares enumerates the shares exported by the server via NetrShareEnum at info
+// level 1 ([MS-SRVS] 3.1.4.8). It binds a fresh \srvsvc pipe for the call.
+func (c *Client) ListShares() ([]ShareInfo, error) {
+	rpc, done, err := c.bind()
+	if err != nil {
+		return nil, err
+	}
+	defer done()
+	return listShares(rpc)
+}
+
+// listShares performs the NetrShareEnum call over an already-bound invoker and projects
+// the level-1 container into ShareInfo values. It is split out so it can be unit-tested
+// with an in-memory transport.
+func listShares(rpc ndr.Invoker) ([]ShareInfo, error) {
+	resume := ndr.DWORD(0)
+	info := structures.SHARE_ENUM_STRUCT{
+		Level: 1,
+		ShareInfo: structures.SHARE_ENUM_UNION{
+			Tag:    1,
+			Level1: &structures.SHARE_INFO_1_CONTAINER{},
+		},
+	}
+
+	out, _, _, err := functions.NetrShareEnum(rpc, "", info, ndr.DWORD(MaxPreferredLength), &resume)
+	if err != nil {
+		return nil, err
+	}
+
+	container := out.ShareInfo.Level1
+	if container == nil {
+		return nil, nil
+	}
+	shares := make([]ShareInfo, 0, len(container.Buffer))
+	for _, s := range container.Buffer {
+		shares = append(shares, ShareInfo{
+			Name:    string(s.Shi1Netname),
+			Type:    uint32(s.Shi1Type),
+			Comment: string(s.Shi1Remark),
+		})
+	}
+	return shares, nil
+}

--- a/network/dcerpc/ms-protocols/ms-srvs/srvsvc_test.go
+++ b/network/dcerpc/ms-protocols/ms-srvs/srvsvc_test.go
@@ -1,0 +1,267 @@
+package mssrvs
+
+import (
+	"errors"
+	"testing"
+
+	srvsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/structures"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
+	dcerpcclient "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/pdu"
+)
+
+// fakeTransport is an in-memory transport.Transport for driving the DCE/RPC client
+// without a network.
+type fakeTransport struct {
+	sent      [][]byte
+	recvQueue [][]byte
+}
+
+func (f *fakeTransport) Connect() error { return nil }
+func (f *fakeTransport) Send(p []byte) error {
+	f.sent = append(f.sent, append([]byte(nil), p...))
+	return nil
+}
+func (f *fakeTransport) Recv() ([]byte, error) {
+	if len(f.recvQueue) == 0 {
+		return nil, errors.New("recv queue empty")
+	}
+	c := f.recvQueue[0]
+	f.recvQueue = f.recvQueue[1:]
+	return c, nil
+}
+func (f *fakeTransport) Close() error        { return nil }
+func (f *fakeTransport) MaxXmitFrag() uint16 { return 4280 }
+func (f *fakeTransport) MaxRecvFrag() uint16 { return 4280 }
+func (f *fakeTransport) queue(b []byte)      { f.recvQueue = append(f.recvQueue, b) }
+
+func bindAck(t *testing.T) []byte {
+	t.Helper()
+	ack := &pdu.BindAck{
+		MaxXmitFrag: 4280,
+		MaxRecvFrag: 4280,
+		Results:     []pdu.PresentationResult{{Result: pdu.ResultAcceptance, TransferSyntax: syntax.NDRTransferSyntax()}},
+	}
+	b, err := ack.Marshal()
+	if err != nil {
+		t.Fatalf("bind_ack marshal: %v", err)
+	}
+	return b
+}
+
+func responsePDU(t *testing.T, callID uint32, stub []byte) []byte {
+	t.Helper()
+	resp := &pdu.Response{Stub: stub}
+	resp.Header = pdu.NewHeader(pdu.PacketTypeResponse, pdu.PFCFirstFrag|pdu.PFCLastFrag, callID)
+	b, err := resp.Marshal()
+	if err != nil {
+		t.Fatalf("response marshal: %v", err)
+	}
+	return b
+}
+
+// boundClient returns a DCE/RPC client already bound to srvsvc over ft.
+func boundClient(t *testing.T, ft *fakeTransport) *dcerpcclient.Client {
+	t.Helper()
+	ft.queue(bindAck(t))
+	c := dcerpcclient.NewClient(ft)
+	if err := c.Bind(srvsvc.SyntaxID()); err != nil {
+		t.Fatalf("Bind() error = %v", err)
+	}
+	return c
+}
+
+// stub marshals v (a mirror of a srvsvc [out] response) to its NDR octet stream.
+func stub(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := ndr.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal response stub: %v", err)
+	}
+	return b
+}
+
+// ---- NetrShareEnum / ListShares -------------------------------------------------
+
+type shareEnumResp struct {
+	InfoStruct   structures.SHARE_ENUM_STRUCT
+	TotalEntries ndr.DWORD
+	ResumeHandle *ndr.DWORD `ndr:"unique"`
+	Status       ndr.DWORD  `ndr:"retval"`
+}
+
+func TestListShares(t *testing.T) {
+	ft := &fakeTransport{}
+	c := boundClient(t, ft)
+
+	resp := &shareEnumResp{
+		InfoStruct: structures.SHARE_ENUM_STRUCT{
+			Level: 1,
+			ShareInfo: structures.SHARE_ENUM_UNION{
+				Tag: 1,
+				Level1: &structures.SHARE_INFO_1_CONTAINER{
+					EntriesRead: 2,
+					Buffer: []structures.SHARE_INFO_1{
+						{Shi1Netname: "C$", Shi1Type: 0x80000000, Shi1Remark: "Default share"},
+						{Shi1Netname: "netlogon", Shi1Type: 0, Shi1Remark: "Logon server share"},
+					},
+				},
+			},
+		},
+		TotalEntries: 2,
+		Status:       ndr.DWORD(srvsvc.NERR_Success),
+	}
+	ft.queue(responsePDU(t, 2, stub(t, resp)))
+
+	shares, err := listShares(c)
+	if err != nil {
+		t.Fatalf("listShares() error = %v", err)
+	}
+	if len(shares) != 2 {
+		t.Fatalf("got %d shares, want 2", len(shares))
+	}
+	if shares[0].Name != "C$" || shares[0].Type != 0x80000000 || shares[0].Comment != "Default share" {
+		t.Errorf("share[0] = %+v, want {C$ 0x80000000 Default share}", shares[0])
+	}
+	if shares[1].Name != "netlogon" || shares[1].Comment != "Logon server share" {
+		t.Errorf("share[1] = %+v", shares[1])
+	}
+
+	// Verify the request opnum.
+	var req pdu.Request
+	if _, err := req.Unmarshal(ft.sent[1]); err != nil {
+		t.Fatalf("request does not parse: %v", err)
+	}
+	if req.Opnum != srvsvc.OpnumNetrShareEnum {
+		t.Errorf("opnum = %d, want %d", req.Opnum, srvsvc.OpnumNetrShareEnum)
+	}
+}
+
+func TestListShares_AccessDenied(t *testing.T) {
+	ft := &fakeTransport{}
+	c := boundClient(t, ft)
+	resp := &shareEnumResp{
+		InfoStruct: structures.SHARE_ENUM_STRUCT{Level: 1, ShareInfo: structures.SHARE_ENUM_UNION{Tag: 1}},
+		Status:     ndr.DWORD(srvsvc.ERROR_ACCESS_DENIED),
+	}
+	ft.queue(responsePDU(t, 2, stub(t, resp)))
+	if _, err := listShares(c); err == nil {
+		t.Fatal("listShares() with ACCESS_DENIED: error = nil, want non-nil")
+	}
+}
+
+// ---- NetrSessionEnum / ListSessions ---------------------------------------------
+
+type sessionEnumResp struct {
+	InfoStruct   structures.SESSION_ENUM_STRUCT
+	TotalEntries ndr.DWORD
+	ResumeHandle *ndr.DWORD `ndr:"unique"`
+	Status       ndr.DWORD  `ndr:"retval"`
+}
+
+func TestListSessions(t *testing.T) {
+	ft := &fakeTransport{}
+	c := boundClient(t, ft)
+
+	resp := &sessionEnumResp{
+		InfoStruct: structures.SESSION_ENUM_STRUCT{
+			Level: 10,
+			SessionInfo: structures.SESSION_ENUM_UNION{
+				Tag: 10,
+				Level10: &structures.SESSION_INFO_10_CONTAINER{
+					EntriesRead: 1,
+					Buffer: []structures.SESSION_INFO_10{
+						{Sesi10Cname: "\\\\10.0.0.5", Sesi10Username: "ADMIN", Sesi10Time: 3600, Sesi10IdleTime: 12},
+					},
+				},
+			},
+		},
+		TotalEntries: 1,
+		Status:       ndr.DWORD(srvsvc.NERR_Success),
+	}
+	ft.queue(responsePDU(t, 2, stub(t, resp)))
+
+	sessions, err := listSessions(c)
+	if err != nil {
+		t.Fatalf("listSessions() error = %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("got %d sessions, want 1", len(sessions))
+	}
+	got := sessions[0]
+	if got.ClientName != "\\\\10.0.0.5" || got.UserName != "ADMIN" || got.ActiveSecs != 3600 || got.IdleSecs != 12 {
+		t.Errorf("session[0] = %+v", got)
+	}
+
+	var req pdu.Request
+	if _, err := req.Unmarshal(ft.sent[1]); err != nil {
+		t.Fatalf("request does not parse: %v", err)
+	}
+	if req.Opnum != srvsvc.OpnumNetrSessionEnum {
+		t.Errorf("opnum = %d, want %d", req.Opnum, srvsvc.OpnumNetrSessionEnum)
+	}
+}
+
+// ---- NetrServerGetInfo / GetServerInfo ------------------------------------------
+
+type serverGetInfoResp struct {
+	InfoStruct structures.SERVER_INFO
+	Status     ndr.DWORD `ndr:"retval"`
+}
+
+func TestGetServerInfo(t *testing.T) {
+	ft := &fakeTransport{}
+	c := boundClient(t, ft)
+
+	resp := &serverGetInfoResp{
+		InfoStruct: structures.SERVER_INFO{
+			Tag: 101,
+			ServerInfo101: &structures.SERVER_INFO_101{
+				Sv101PlatformId:   500,
+				Sv101Name:         "FILESERVER",
+				Sv101VersionMajor: 6,
+				Sv101VersionMinor: 1,
+				Sv101Type:         0x00000003,
+				Sv101Comment:      "main file server",
+			},
+		},
+		Status: ndr.DWORD(srvsvc.NERR_Success),
+	}
+	ft.queue(responsePDU(t, 2, stub(t, resp)))
+
+	info, err := getServerInfo(c)
+	if err != nil {
+		t.Fatalf("getServerInfo() error = %v", err)
+	}
+	if info == nil {
+		t.Fatal("getServerInfo() returned nil info")
+	}
+	if info.PlatformID != 500 || info.Name != "FILESERVER" || info.VersionMajor != 6 ||
+		info.VersionMinor != 1 || info.Type != 0x00000003 || info.Comment != "main file server" {
+		t.Errorf("server info = %+v", info)
+	}
+
+	var req pdu.Request
+	if _, err := req.Unmarshal(ft.sent[1]); err != nil {
+		t.Fatalf("request does not parse: %v", err)
+	}
+	if req.Opnum != srvsvc.OpnumNetrServerGetInfo {
+		t.Errorf("opnum = %d, want %d", req.Opnum, srvsvc.OpnumNetrServerGetInfo)
+	}
+}
+
+func TestGetServerInfo_MissingArm(t *testing.T) {
+	ft := &fakeTransport{}
+	c := boundClient(t, ft)
+	// Success status but a nil level-101 arm must be reported, not nil-dereferenced.
+	resp := &serverGetInfoResp{
+		InfoStruct: structures.SERVER_INFO{Tag: 101},
+		Status:     ndr.DWORD(srvsvc.NERR_Success),
+	}
+	ft.queue(responsePDU(t, 2, stub(t, resp)))
+	if _, err := getServerInfo(c); err == nil {
+		t.Fatal("getServerInfo() with missing arm: error = nil, want non-nil")
+	}
+}


### PR DESCRIPTION
### Linked Issues
`Closes #359`
`Closes #360`
`Closes #361`

### Root Cause
Issues #359/#360/#361 predate the DCE/RPC stack and asked for share / session / server-info enumeration "via DCE/RPC srvsvc." The low-level layer they describe now exists in full — the srvsvc interface (`4b324fc8-1670-01d3-1278-5a47bf6ee188` v3.0) already implements `NetrShareEnum` (opnum 15), `NetrSessionEnum` (12), and `NetrServerGetInfo` (21), along with every `SHARE_INFO_*` / `SESSION_INFO_*` / `SERVER_INFO_*` structure and their NDR round-trip tests. What was still missing is the **high-level convenience surface** each issue's acceptance criteria call for (`ListShares` / `ListSessions` / `GetServerInfo` returning friendly Go structs) — the surface the `smbclient-ng` shares/who/info commands consume.

### Fix Description
Adds `network/dcerpc/ms-protocols/ms-srvs` (package `mssrvs`), the protocol layer above the srvsvc interface. A `Client` wraps a connected, authenticated SMB v1 client; each method binds a **fresh `\srvsvc` pipe** (srvsvc calls are mutually independent, so a fault on one cannot desync the next), issues the underlying srvsvc call, and projects the NDR container/union into a friendly struct:

- `ListShares() ([]ShareInfo, error)` — `NetrShareEnum` level 1 (name, STYPE_* type, comment).
- `ListSessions() ([]SessionInfo, error)` — `NetrSessionEnum` level 10 (client name, user, active/idle secs).
- `GetServerInfo() (*ServerInfo, error)` — `NetrServerGetInfo` level 101 (platform id, name, version, SV_TYPE_* type, comment).

All three use `MAX_PREFERRED_LENGTH` (0xFFFFFFFF) so the server returns every entry in one response (no resume-handle paging), matching impacket.

**Why a new package rather than `smb_v10/client`:** the issues' example signatures put these methods on the SMB client, but the DCE/RPC SMB transport imports `network/smb/smb_v10/client`, so a srvsvc-calling method on that type would be an import cycle. The skill's protocol layer (`ms-protocols/`) is the correct home and composes the interface cleanly; `smbclient-ng` calls `mssrvs.New(smb).ListShares()`.

### How Verified
- `go build`, `go vet`, `go test` pass for the new package; `go build -tags integration` / `go vet -tags integration` pass for the integration test.
- White-box unit tests drive each method through the **real** v5 DCE/RPC client over an in-memory transport against a marshalled golden response, asserting the projected structs (including the STYPE_SPECIAL high bit passing through raw), the correct opnum on the wire, the access-denied error path, and the nil-union-arm guard.

### Test Coverage
- **Added:** `srvsvc_test.go` (`TestListShares`, `TestListShares_AccessDenied`, `TestListSessions`, `TestGetServerInfo`, `TestGetServerInfo_MissingArm`) and `integration_test.go` (`TestIntegration_ListShares`, `_GetServerInfo`, `_ListSessions`, build-tagged `integration`).
- **Existing:** structure-level NDR (un)marshalling of `SHARE_INFO_1`, `SESSION_INFO_10`, `SERVER_INFO_101` and their containers is already covered by the srvsvc `structures/` tests (`share_test.go`, `server_test.go`, `conn_file_session_test.go`), satisfying each issue's NDR-test criterion.

### Scope of Change
- **Files changed:** all new, under `network/dcerpc/ms-protocols/ms-srvs/` (`client.go`, `shares.go`, `sessions.go`, `server_info.go`, `srvsvc_test.go`, `integration_test.go`).
- **Submodule pointer updated:** no.
- **Behavioral changes outside the new package:** none.

### Notes
- The srvsvc integration test already exercises `NetrServerGetInfo(101)` live; this PR adds the typed `ServerInfo`/`ShareInfo`/`SessionInfo` projections and the convenience entry points on top.
- `ListSessions` typically requires administrative rights on the target; the integration test logs (rather than fails on) a privilege error since that is server policy, not a wire defect.