### PR TITLE
Add SMB share enumeration via srvsvc NetrShareEnum (#359)

### DIFF
--- a/network/dcerpc/ms-protocols/ms-srvs/client.go
+++ b/network/dcerpc/ms-protocols/ms-srvs/client.go
@@ -1,0 +1,53 @@
+// Package mssrvs implements high-level MS-SRVS (Server Service Remote Protocol)
+// workflows over the srvsvc DCE/RPC interface
+// (4b324fc8-1670-01d3-1278-5a47bf6ee188 v3.0), carried over the \srvsvc named pipe on
+// the IPC$ tree.
+//
+// It is the protocol layer above the interface: callers hold a connected and
+// authenticated SMB v1 client and call the convenience methods here (ListShares,
+// ListSessions, GetServerInfo), which bind to srvsvc, issue the underlying
+// NetrShareEnum / NetrSessionEnum / NetrServerGetInfo calls, and project the NDR
+// containers and unions into friendly Go structs. The smbclient-ng tool's shares / who
+// / info commands are the intended consumers.
+//
+// References:
+//   - [MS-SRVS] 3.1.4.8 NetrShareEnum, 3.1.4.6 NetrSessionEnum, 3.1.4.17 NetrServerGetInfo
+//   - [MS-RPCE] DCE/RPC over SMB named pipes
+package mssrvs
+
+import (
+	"fmt"
+
+	srvsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0"
+	dcerpcclient "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	dcerpcsmb "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/transport/smb"
+	smbclient "github.com/TheManticoreProject/Manticore/network/smb/smb_v10/client"
+)
+
+// MaxPreferredLength is passed as the preferred maximum reply length of the Netr*Enum
+// calls. 0xFFFFFFFF asks the server to return every entry in a single response, so no
+// resume-handle paging is needed; this matches impacket's enumeration usage.
+const MaxPreferredLength uint32 = 0xFFFFFFFF
+
+// Client exposes MS-SRVS workflows over an established SMB v1 session. The supplied SMB
+// client MUST already be connected, have an authenticated session (SessionSetup), and
+// have a tree connected to IPC$ (TreeConnect) before any method is called.
+type Client struct {
+	smb *smbclient.Client
+}
+
+// New returns an MS-SRVS client over the given SMB v1 client.
+func New(smb *smbclient.Client) *Client {
+	return &Client{smb: smb}
+}
+
+// bind opens a fresh \srvsvc pipe and binds the srvsvc abstract syntax over it. srvsvc
+// calls are mutually independent, so each workflow runs on its own pipe and bind: a
+// fault on one cannot desync the next. The returned close function tears the pipe down.
+func (c *Client) bind() (*dcerpcclient.Client, func() error, error) {
+	rpc := dcerpcclient.NewClient(dcerpcsmb.New(c.smb, srvsvc.PipeName))
+	if err := rpc.Bind(srvsvc.SyntaxID()); err != nil {
+		return nil, nil, fmt.Errorf("mssrvs: bind srvsvc: %w", err)
+	}
+	return rpc, rpc.Close, nil
+}

--- a/network/dcerpc/ms-protocols/ms-srvs/integration_test.go
+++ b/network/dcerpc/ms-protocols/ms-srvs/integration_test.go
@@ -1,0 +1,79 @@
+//go:build integration
+
+// Live integration tests for the MS-SRVS convenience layer over the full
+// DCE/RPC-over-SMB stack. Excluded from the default build by the "integration" tag.
+// Run with:
+//
+//	DCERPC_TEST_HOST=192.168.1.27 DCERPC_TEST_USER=user DCERPC_TEST_PASS=user \
+//	go test -tags integration -v ./network/dcerpc/ms-protocols/ms-srvs/
+package mssrvs_test
+
+import (
+	"net"
+	"os"
+	"strconv"
+	"testing"
+
+	mssrvs "github.com/TheManticoreProject/Manticore/network/dcerpc/ms-protocols/ms-srvs"
+	smbclient "github.com/TheManticoreProject/Manticore/network/smb/smb_v10/client"
+	"github.com/TheManticoreProject/Manticore/windows/credentials"
+)
+
+// liveClient builds an MS-SRVS client over a live SMB session. It skips the test unless
+// DCERPC_TEST_HOST is set.
+func liveClient(t *testing.T) (*mssrvs.Client, func()) {
+	t.Helper()
+	host := os.Getenv("DCERPC_TEST_HOST")
+	if host == "" {
+		t.Skip("DCERPC_TEST_HOST not set; skipping live MS-SRVS test")
+	}
+	port := 445
+	if p := os.Getenv("DCERPC_TEST_PORT"); p != "" {
+		n, err := strconv.Atoi(p)
+		if err != nil {
+			t.Fatalf("invalid DCERPC_TEST_PORT %q: %v", p, err)
+		}
+		port = n
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		t.Fatalf("DCERPC_TEST_HOST %q is not a valid IP", host)
+	}
+	creds, err := credentials.NewCredentials(os.Getenv("DCERPC_TEST_DOMAIN"), os.Getenv("DCERPC_TEST_USER"), os.Getenv("DCERPC_TEST_PASS"), "")
+	if err != nil {
+		t.Fatalf("NewCredentials: %v", err)
+	}
+
+	smb := smbclient.NewClientUsingTCPTransport(ip, port)
+	if err := smb.Connect(ip, port); err != nil {
+		t.Fatalf("SMB Connect: %v", err)
+	}
+	smb.NativeOS, smb.NativeLanMan = "Unix", "Samba"
+	if err := smb.SessionSetup(creds); err != nil {
+		t.Fatalf("SMB SessionSetup: %v", err)
+	}
+	if err := smb.TreeConnect("IPC$"); err != nil {
+		t.Fatalf("SMB TreeConnect(IPC$): %v", err)
+	}
+	cleanup := func() {
+		_ = smb.TreeDisconnect()
+		_ = smb.Logoff()
+		_ = smb.Disconnect()
+	}
+	return mssrvs.New(smb), cleanup
+}
+
+func TestIntegration_ListShares(t *testing.T) {
+	c, cleanup := liveClient(t)
+	defer cleanup()
+	shares, err := c.ListShares()
+	if err != nil {
+		t.Fatalf("[WIRE FAIL] ListShares: %v", err)
+	}
+	if len(shares) == 0 {
+		t.Fatal("[WIRE FAIL] ListShares returned no shares (expected at least IPC$)")
+	}
+	for _, s := range shares {
+		t.Logf("[ok] share %q type=0x%08x %q", s.Name, s.Type, s.Comment)
+	}
+}

--- a/network/dcerpc/ms-protocols/ms-srvs/shares.go
+++ b/network/dcerpc/ms-protocols/ms-srvs/shares.go
@@ -1,0 +1,60 @@
+package mssrvs
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/structures"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// ShareInfo is a shared resource exported by the server: its name, STYPE_* type flags,
+// and comment ([MS-SRVS] 2.2.4.23 SHARE_INFO_1). Type carries the raw STYPE_* value,
+// including the STYPE_SPECIAL (0x80000000) and STYPE_TEMPORARY (0x40000000) high bits.
+type ShareInfo struct {
+	Name    string
+	Type    uint32
+	Comment string
+}
+
+// ListShares enumerates the shares exported by the server via NetrShareEnum at info
+// level 1 ([MS-SRVS] 3.1.4.8). It binds a fresh \srvsvc pipe for the call.
+func (c *Client) ListShares() ([]ShareInfo, error) {
+	rpc, done, err := c.bind()
+	if err != nil {
+		return nil, err
+	}
+	defer done()
+	return listShares(rpc)
+}
+
+// listShares performs the NetrShareEnum call over an already-bound invoker and projects
+// the level-1 container into ShareInfo values. It is split out so it can be unit-tested
+// with an in-memory transport.
+func listShares(rpc ndr.Invoker) ([]ShareInfo, error) {
+	resume := ndr.DWORD(0)
+	info := structures.SHARE_ENUM_STRUCT{
+		Level: 1,
+		ShareInfo: structures.SHARE_ENUM_UNION{
+			Tag:    1,
+			Level1: &structures.SHARE_INFO_1_CONTAINER{},
+		},
+	}
+
+	out, _, _, err := functions.NetrShareEnum(rpc, "", info, ndr.DWORD(MaxPreferredLength), &resume)
+	if err != nil {
+		return nil, err
+	}
+
+	container := out.ShareInfo.Level1
+	if container == nil {
+		return nil, nil
+	}
+	shares := make([]ShareInfo, 0, len(container.Buffer))
+	for _, s := range container.Buffer {
+		shares = append(shares, ShareInfo{
+			Name:    string(s.Shi1Netname),
+			Type:    uint32(s.Shi1Type),
+			Comment: string(s.Shi1Remark),
+		})
+	}
+	return shares, nil
+}

--- a/network/dcerpc/ms-protocols/ms-srvs/shares_test.go
+++ b/network/dcerpc/ms-protocols/ms-srvs/shares_test.go
@@ -1,0 +1,151 @@
+package mssrvs
+
+import (
+	"errors"
+	"testing"
+
+	srvsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/structures"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
+	dcerpcclient "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/pdu"
+)
+
+// fakeTransport is an in-memory transport.Transport for driving the DCE/RPC client
+// without a network.
+type fakeTransport struct {
+	sent      [][]byte
+	recvQueue [][]byte
+}
+
+func (f *fakeTransport) Connect() error { return nil }
+func (f *fakeTransport) Send(p []byte) error {
+	f.sent = append(f.sent, append([]byte(nil), p...))
+	return nil
+}
+func (f *fakeTransport) Recv() ([]byte, error) {
+	if len(f.recvQueue) == 0 {
+		return nil, errors.New("recv queue empty")
+	}
+	c := f.recvQueue[0]
+	f.recvQueue = f.recvQueue[1:]
+	return c, nil
+}
+func (f *fakeTransport) Close() error        { return nil }
+func (f *fakeTransport) MaxXmitFrag() uint16 { return 4280 }
+func (f *fakeTransport) MaxRecvFrag() uint16 { return 4280 }
+func (f *fakeTransport) queue(b []byte)      { f.recvQueue = append(f.recvQueue, b) }
+
+func bindAck(t *testing.T) []byte {
+	t.Helper()
+	ack := &pdu.BindAck{
+		MaxXmitFrag: 4280,
+		MaxRecvFrag: 4280,
+		Results:     []pdu.PresentationResult{{Result: pdu.ResultAcceptance, TransferSyntax: syntax.NDRTransferSyntax()}},
+	}
+	b, err := ack.Marshal()
+	if err != nil {
+		t.Fatalf("bind_ack marshal: %v", err)
+	}
+	return b
+}
+
+func responsePDU(t *testing.T, callID uint32, stubBytes []byte) []byte {
+	t.Helper()
+	resp := &pdu.Response{Stub: stubBytes}
+	resp.Header = pdu.NewHeader(pdu.PacketTypeResponse, pdu.PFCFirstFrag|pdu.PFCLastFrag, callID)
+	b, err := resp.Marshal()
+	if err != nil {
+		t.Fatalf("response marshal: %v", err)
+	}
+	return b
+}
+
+// boundClient returns a DCE/RPC client already bound to srvsvc over ft.
+func boundClient(t *testing.T, ft *fakeTransport) *dcerpcclient.Client {
+	t.Helper()
+	ft.queue(bindAck(t))
+	c := dcerpcclient.NewClient(ft)
+	if err := c.Bind(srvsvc.SyntaxID()); err != nil {
+		t.Fatalf("Bind() error = %v", err)
+	}
+	return c
+}
+
+// stub marshals v (a mirror of a srvsvc [out] response) to its NDR octet stream.
+func stub(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := ndr.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal response stub: %v", err)
+	}
+	return b
+}
+
+type shareEnumResp struct {
+	InfoStruct   structures.SHARE_ENUM_STRUCT
+	TotalEntries ndr.DWORD
+	ResumeHandle *ndr.DWORD `ndr:"unique"`
+	Status       ndr.DWORD  `ndr:"retval"`
+}
+
+func TestListShares(t *testing.T) {
+	ft := &fakeTransport{}
+	c := boundClient(t, ft)
+
+	resp := &shareEnumResp{
+		InfoStruct: structures.SHARE_ENUM_STRUCT{
+			Level: 1,
+			ShareInfo: structures.SHARE_ENUM_UNION{
+				Tag: 1,
+				Level1: &structures.SHARE_INFO_1_CONTAINER{
+					EntriesRead: 2,
+					Buffer: []structures.SHARE_INFO_1{
+						{Shi1Netname: "C$", Shi1Type: 0x80000000, Shi1Remark: "Default share"},
+						{Shi1Netname: "netlogon", Shi1Type: 0, Shi1Remark: "Logon server share"},
+					},
+				},
+			},
+		},
+		TotalEntries: 2,
+		Status:       ndr.DWORD(srvsvc.NERR_Success),
+	}
+	ft.queue(responsePDU(t, 2, stub(t, resp)))
+
+	shares, err := listShares(c)
+	if err != nil {
+		t.Fatalf("listShares() error = %v", err)
+	}
+	if len(shares) != 2 {
+		t.Fatalf("got %d shares, want 2", len(shares))
+	}
+	if shares[0].Name != "C$" || shares[0].Type != 0x80000000 || shares[0].Comment != "Default share" {
+		t.Errorf("share[0] = %+v, want {C$ 0x80000000 Default share}", shares[0])
+	}
+	if shares[1].Name != "netlogon" || shares[1].Comment != "Logon server share" {
+		t.Errorf("share[1] = %+v", shares[1])
+	}
+
+	// Verify the request opnum.
+	var req pdu.Request
+	if _, err := req.Unmarshal(ft.sent[1]); err != nil {
+		t.Fatalf("request does not parse: %v", err)
+	}
+	if req.Opnum != srvsvc.OpnumNetrShareEnum {
+		t.Errorf("opnum = %d, want %d", req.Opnum, srvsvc.OpnumNetrShareEnum)
+	}
+}
+
+func TestListShares_AccessDenied(t *testing.T) {
+	ft := &fakeTransport{}
+	c := boundClient(t, ft)
+	resp := &shareEnumResp{
+		InfoStruct: structures.SHARE_ENUM_STRUCT{Level: 1, ShareInfo: structures.SHARE_ENUM_UNION{Tag: 1}},
+		Status:     ndr.DWORD(srvsvc.ERROR_ACCESS_DENIED),
+	}
+	ft.queue(responsePDU(t, 2, stub(t, resp)))
+	if _, err := listShares(c); err == nil {
+		t.Fatal("listShares() with ACCESS_DENIED: error = nil, want non-nil")
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #359`

### Root Cause
This issue predates the DCE/RPC stack and asked for share enumeration "via DCE/RPC srvsvc." The low-level layer it describes now exists in full — the srvsvc interface already implements `NetrShareEnum` (opnum 15) and every `SHARE_INFO_*` structure with NDR round-trip tests. What was missing is the **high-level convenience method** the acceptance criteria call for (`ListShares` returning a friendly struct), the surface `smbclient-ng`'s `shares` command consumes.

### Fix Description
Introduces `network/dcerpc/ms-protocols/ms-srvs` (package `mssrvs`), the protocol layer above the srvsvc interface, and its first workflow:

- `ListShares() ([]ShareInfo, error)` — `NetrShareEnum` at info level 1, projecting the `SHARE_INFO_1` container into `{Name, Type (raw STYPE_*), Comment}`.

The package foundation lands in this PR: `Client` wraps a connected, authenticated SMB v1 client; `New` constructs it; `bind` opens a **fresh `\srvsvc` pipe** per call (srvsvc calls are independent, so a fault on one cannot desync the next); `MaxPreferredLength` (0xFFFFFFFF) requests every entry in one response (no resume-handle paging), matching impacket.

**Why a new package rather than `smb_v10/client`:** the issue's example signature puts the method on the SMB client, but the DCE/RPC SMB transport imports `network/smb/smb_v10/client`, so a srvsvc-calling method on that type would be an import cycle. The protocol layer is the correct, cycle-free home; `smbclient-ng` calls `mssrvs.New(smb).ListShares()`.

### How Verified
- `go build`, `go vet`, `go test` pass; `go build -tags integration` passes.
- A white-box unit test drives `ListShares` through the **real** v5 DCE/RPC client over an in-memory transport against a marshalled golden response, asserting the projected shares (including the STYPE_SPECIAL high bit passing through raw) and the `NetrShareEnum` opnum on the wire; a second test covers the access-denied error path.

### Test Coverage
- **Added:** `shares_test.go` (`TestListShares`, `TestListShares_AccessDenied`) and `integration_test.go` (`TestIntegration_ListShares`, build-tagged `integration`).
- **Existing:** structure-level NDR (un)marshalling of `SHARE_INFO_1` and its container is already covered by the srvsvc `structures/` tests.

### Scope of Change
- **Files changed:** all new, under `network/dcerpc/ms-protocols/ms-srvs/` (`client.go`, `shares.go`, `shares_test.go`, `integration_test.go`).
- **Submodule pointer updated:** no.
- **Behavioral changes outside the new package:** none.

### Notes
First of three stacked PRs. #360 (NetrSessionEnum) and #361 (NetrServerGetInfo) build on the package foundation introduced here and are based on this branch; their bases retarget to `main` once this merges.