### PR TITLE
Add SMB server info via srvsvc NetrServerGetInfo (#361)

### DIFF
--- a/network/dcerpc/ms-protocols/ms-srvs/integration_server_test.go
+++ b/network/dcerpc/ms-protocols/ms-srvs/integration_server_test.go
@@ -1,0 +1,16 @@
+//go:build integration
+
+package mssrvs_test
+
+import "testing"
+
+func TestIntegration_GetServerInfo(t *testing.T) {
+	c, cleanup := liveClient(t)
+	defer cleanup()
+	info, err := c.GetServerInfo()
+	if err != nil {
+		t.Fatalf("[WIRE FAIL] GetServerInfo: %v", err)
+	}
+	t.Logf("[ok] server %q version %d.%d platform=%d type=0x%08x %q",
+		info.Name, info.VersionMajor, info.VersionMinor, info.PlatformID, info.Type, info.Comment)
+}

--- a/network/dcerpc/ms-protocols/ms-srvs/server_info.go
+++ b/network/dcerpc/ms-protocols/ms-srvs/server_info.go
@@ -1,0 +1,52 @@
+package mssrvs
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// ServerInfo is the configuration of a server: platform id, name, OS version, SV_TYPE_*
+// flags, and comment ([MS-SRVS] 2.2.4.41 SERVER_INFO_101).
+type ServerInfo struct {
+	PlatformID   uint32
+	Name         string
+	VersionMajor uint32
+	VersionMinor uint32
+	Type         uint32
+	Comment      string
+}
+
+// GetServerInfo queries the server's configuration via NetrServerGetInfo at info level
+// 101 ([MS-SRVS] 3.1.4.17). It binds a fresh \srvsvc pipe for the call.
+func (c *Client) GetServerInfo() (*ServerInfo, error) {
+	rpc, done, err := c.bind()
+	if err != nil {
+		return nil, err
+	}
+	defer done()
+	return getServerInfo(rpc)
+}
+
+// getServerInfo performs the NetrServerGetInfo call over an already-bound invoker and
+// projects the level-101 union arm into a ServerInfo.
+func getServerInfo(rpc ndr.Invoker) (*ServerInfo, error) {
+	out, err := functions.NetrServerGetInfo(rpc, "", 101)
+	if err != nil {
+		return nil, err
+	}
+
+	si := out.ServerInfo101
+	if si == nil {
+		return nil, fmt.Errorf("mssrvs: NetrServerGetInfo(101) returned no SERVER_INFO_101")
+	}
+	return &ServerInfo{
+		PlatformID:   uint32(si.Sv101PlatformId),
+		Name:         string(si.Sv101Name),
+		VersionMajor: uint32(si.Sv101VersionMajor),
+		VersionMinor: uint32(si.Sv101VersionMinor),
+		Type:         uint32(si.Sv101Type),
+		Comment:      string(si.Sv101Comment),
+	}, nil
+}

--- a/network/dcerpc/ms-protocols/ms-srvs/server_info_test.go
+++ b/network/dcerpc/ms-protocols/ms-srvs/server_info_test.go
@@ -1,0 +1,70 @@
+package mssrvs
+
+import (
+	"testing"
+
+	srvsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/structures"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/pdu"
+)
+
+type serverGetInfoResp struct {
+	InfoStruct structures.SERVER_INFO
+	Status     ndr.DWORD `ndr:"retval"`
+}
+
+func TestGetServerInfo(t *testing.T) {
+	ft := &fakeTransport{}
+	c := boundClient(t, ft)
+
+	resp := &serverGetInfoResp{
+		InfoStruct: structures.SERVER_INFO{
+			Tag: 101,
+			ServerInfo101: &structures.SERVER_INFO_101{
+				Sv101PlatformId:   500,
+				Sv101Name:         "FILESERVER",
+				Sv101VersionMajor: 6,
+				Sv101VersionMinor: 1,
+				Sv101Type:         0x00000003,
+				Sv101Comment:      "main file server",
+			},
+		},
+		Status: ndr.DWORD(srvsvc.NERR_Success),
+	}
+	ft.queue(responsePDU(t, 2, stub(t, resp)))
+
+	info, err := getServerInfo(c)
+	if err != nil {
+		t.Fatalf("getServerInfo() error = %v", err)
+	}
+	if info == nil {
+		t.Fatal("getServerInfo() returned nil info")
+	}
+	if info.PlatformID != 500 || info.Name != "FILESERVER" || info.VersionMajor != 6 ||
+		info.VersionMinor != 1 || info.Type != 0x00000003 || info.Comment != "main file server" {
+		t.Errorf("server info = %+v", info)
+	}
+
+	var req pdu.Request
+	if _, err := req.Unmarshal(ft.sent[1]); err != nil {
+		t.Fatalf("request does not parse: %v", err)
+	}
+	if req.Opnum != srvsvc.OpnumNetrServerGetInfo {
+		t.Errorf("opnum = %d, want %d", req.Opnum, srvsvc.OpnumNetrServerGetInfo)
+	}
+}
+
+func TestGetServerInfo_MissingArm(t *testing.T) {
+	ft := &fakeTransport{}
+	c := boundClient(t, ft)
+	// Success status but a nil level-101 arm must be reported, not nil-dereferenced.
+	resp := &serverGetInfoResp{
+		InfoStruct: structures.SERVER_INFO{Tag: 101},
+		Status:     ndr.DWORD(srvsvc.NERR_Success),
+	}
+	ft.queue(responsePDU(t, 2, stub(t, resp)))
+	if _, err := getServerInfo(c); err == nil {
+		t.Fatal("getServerInfo() with missing arm: error = nil, want non-nil")
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #361`

> **Stacked on #360 (PR #572), which is stacked on #359 (PR #571).** Based on `feature-srvsvc-list-sessions` so the diff is only the server-info workflow; the package foundation comes from #359. Retarget to `main` once #571 and #572 merge. Review #571 → #572 → this.

### Root Cause
Like #359/#360, this issue predates the DCE/RPC stack. The srvsvc interface already implements `NetrServerGetInfo` (opnum 21) and the `SERVER_INFO_*` structures with NDR tests; the missing piece is the high-level `GetServerInfo` convenience method the `smbclient-ng` `info` command needs to print OS version / name / type.

### Fix Description
Adds the server-info workflow to the `mssrvs` protocol package:

- `GetServerInfo() (*ServerInfo, error)` — `NetrServerGetInfo` at info level 101, projecting the `SERVER_INFO_101` union arm into `{PlatformID, Name, VersionMajor, VersionMinor, Type (SV_TYPE_*), Comment}`.

It reuses the `Client`/`bind` foundation from #359 (binds a fresh `\srvsvc` pipe per call), so this PR adds only `server_info.go` and its tests.

### How Verified
- `go build`, `go vet`, `go test` pass; `go build -tags integration` / `go vet -tags integration` pass.
- A white-box unit test drives `GetServerInfo` through the real v5 DCE/RPC client over an in-memory transport against a marshalled golden response, asserting the projected fields and the `NetrServerGetInfo` opnum; a second test asserts a nil level-101 union arm is reported as an error rather than nil-dereferenced.

### Test Coverage
- **Added:** `server_info_test.go` (`TestGetServerInfo`, `TestGetServerInfo_MissingArm`) and `integration_server_test.go` (`TestIntegration_GetServerInfo`, build-tagged `integration`).
- **Existing:** structure-level NDR (un)marshalling of `SERVER_INFO_101` is already covered by the srvsvc `structures/` tests.

### Scope of Change
- **Files changed (this PR's own diff):** `server_info.go`, `server_info_test.go`, `integration_server_test.go` (all new). Other `mssrvs` files in the cross-branch diff belong to #359/#360.
- **Submodule pointer updated:** no.
- **Behavioral changes outside the new workflow:** none.

### Notes
Last of three stacked PRs (#359 → #360 → #361). The srvsvc integration suite already exercises `NetrServerGetInfo(101)` live; this PR adds the typed `ServerInfo` projection and the convenience entry point.