### PR TITLE
Add SMB session enumeration via srvsvc NetrSessionEnum (#360)

### DIFF
--- a/network/dcerpc/ms-protocols/ms-srvs/integration_sessions_test.go
+++ b/network/dcerpc/ms-protocols/ms-srvs/integration_sessions_test.go
@@ -1,0 +1,20 @@
+//go:build integration
+
+package mssrvs_test
+
+import "testing"
+
+func TestIntegration_ListSessions(t *testing.T) {
+	c, cleanup := liveClient(t)
+	defer cleanup()
+	// Session enumeration typically requires administrative rights; a privilege error
+	// here is the server's policy, not a wire defect, so only log it.
+	sessions, err := c.ListSessions()
+	if err != nil {
+		t.Logf("ListSessions: %v (often requires admin rights)", err)
+		return
+	}
+	for _, s := range sessions {
+		t.Logf("[ok] session client=%q user=%q active=%ds idle=%ds", s.ClientName, s.UserName, s.ActiveSecs, s.IdleSecs)
+	}
+}

--- a/network/dcerpc/ms-protocols/ms-srvs/sessions.go
+++ b/network/dcerpc/ms-protocols/ms-srvs/sessions.go
@@ -1,0 +1,61 @@
+package mssrvs
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/structures"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// SessionInfo is an active session on the server: the connecting client's name, the
+// authenticated user, and the active/idle times in seconds ([MS-SRVS] 2.2.4.15
+// SESSION_INFO_10).
+type SessionInfo struct {
+	ClientName string
+	UserName   string
+	ActiveSecs uint32
+	IdleSecs   uint32
+}
+
+// ListSessions enumerates the active sessions on the server via NetrSessionEnum at info
+// level 10 ([MS-SRVS] 3.1.4.6). It binds a fresh \srvsvc pipe for the call. The server
+// typically requires administrative rights to enumerate sessions.
+func (c *Client) ListSessions() ([]SessionInfo, error) {
+	rpc, done, err := c.bind()
+	if err != nil {
+		return nil, err
+	}
+	defer done()
+	return listSessions(rpc)
+}
+
+// listSessions performs the NetrSessionEnum call over an already-bound invoker and
+// projects the level-10 container into SessionInfo values.
+func listSessions(rpc ndr.Invoker) ([]SessionInfo, error) {
+	info := structures.SESSION_ENUM_STRUCT{
+		Level: 10,
+		SessionInfo: structures.SESSION_ENUM_UNION{
+			Tag:     10,
+			Level10: &structures.SESSION_INFO_10_CONTAINER{},
+		},
+	}
+
+	out, _, _, err := functions.NetrSessionEnum(rpc, "", "", "", info, MaxPreferredLength, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	container := out.SessionInfo.Level10
+	if container == nil {
+		return nil, nil
+	}
+	sessions := make([]SessionInfo, 0, len(container.Buffer))
+	for _, s := range container.Buffer {
+		sessions = append(sessions, SessionInfo{
+			ClientName: string(s.Sesi10Cname),
+			UserName:   string(s.Sesi10Username),
+			ActiveSecs: uint32(s.Sesi10Time),
+			IdleSecs:   uint32(s.Sesi10IdleTime),
+		})
+	}
+	return sessions, nil
+}

--- a/network/dcerpc/ms-protocols/ms-srvs/sessions_test.go
+++ b/network/dcerpc/ms-protocols/ms-srvs/sessions_test.go
@@ -1,0 +1,60 @@
+package mssrvs
+
+import (
+	"testing"
+
+	srvsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/structures"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/pdu"
+)
+
+type sessionEnumResp struct {
+	InfoStruct   structures.SESSION_ENUM_STRUCT
+	TotalEntries ndr.DWORD
+	ResumeHandle *ndr.DWORD `ndr:"unique"`
+	Status       ndr.DWORD  `ndr:"retval"`
+}
+
+func TestListSessions(t *testing.T) {
+	ft := &fakeTransport{}
+	c := boundClient(t, ft)
+
+	resp := &sessionEnumResp{
+		InfoStruct: structures.SESSION_ENUM_STRUCT{
+			Level: 10,
+			SessionInfo: structures.SESSION_ENUM_UNION{
+				Tag: 10,
+				Level10: &structures.SESSION_INFO_10_CONTAINER{
+					EntriesRead: 1,
+					Buffer: []structures.SESSION_INFO_10{
+						{Sesi10Cname: "\\\\10.0.0.5", Sesi10Username: "ADMIN", Sesi10Time: 3600, Sesi10IdleTime: 12},
+					},
+				},
+			},
+		},
+		TotalEntries: 1,
+		Status:       ndr.DWORD(srvsvc.NERR_Success),
+	}
+	ft.queue(responsePDU(t, 2, stub(t, resp)))
+
+	sessions, err := listSessions(c)
+	if err != nil {
+		t.Fatalf("listSessions() error = %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("got %d sessions, want 1", len(sessions))
+	}
+	got := sessions[0]
+	if got.ClientName != "\\\\10.0.0.5" || got.UserName != "ADMIN" || got.ActiveSecs != 3600 || got.IdleSecs != 12 {
+		t.Errorf("session[0] = %+v", got)
+	}
+
+	var req pdu.Request
+	if _, err := req.Unmarshal(ft.sent[1]); err != nil {
+		t.Fatalf("request does not parse: %v", err)
+	}
+	if req.Opnum != srvsvc.OpnumNetrSessionEnum {
+		t.Errorf("opnum = %d, want %d", req.Opnum, srvsvc.OpnumNetrSessionEnum)
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #360`

### Background
The original #360 PR (#572) was a stacked PR based on the #359 branch. When #359 merged to `main`, #572 was merged into its (stale) base branch instead of being retargeted to `main`, so the session-enumeration code never actually reached `main` and #360 stayed open. This PR lands it directly on `main`. Now that the package foundation (`client.go`) is on `main` via #359, this no longer needs to be stacked — it builds independently.

### Fix Description
Adds the session-enumeration workflow to the `mssrvs` protocol package:

- `ListSessions() ([]SessionInfo, error)` — `NetrSessionEnum` at info level 10, projecting the `SESSION_INFO_10` container into `{ClientName, UserName, ActiveSecs, IdleSecs}`.

Reuses the `Client`/`bind`/`MaxPreferredLength` foundation already on `main`; binds a fresh `\srvsvc` pipe per call.

### How Verified
- `go build`, `go vet`, `go test`, and `go build -tags integration` pass against `main`.
- A white-box unit test drives `ListSessions` through the real v5 DCE/RPC client over an in-memory transport against a marshalled golden response, asserting the projected session and the `NetrSessionEnum` opnum on the wire.

### Test Coverage
- **Added:** `sessions_test.go` (`TestListSessions`), `integration_sessions_test.go` (`TestIntegration_ListSessions`, build-tagged `integration`).
- **Existing:** structure-level NDR (un)marshalling of `SESSION_INFO_10` is already covered by the srvsvc `structures/` tests.

### Scope of Change
- **Files changed:** `network/dcerpc/ms-protocols/ms-srvs/{sessions.go, sessions_test.go, integration_sessions_test.go}` (all new).
- **Submodule pointer updated:** no.
- **Behavioral changes outside the new workflow:** none.

### Notes
`ListSessions` typically requires administrative rights on the target; the integration test logs (rather than fails on) a privilege error since that is server policy, not a wire defect.