### PR TITLE
Fix NTLM DomainName case mismatch breaking FQDN auth (#576)

### DIFF
--- a/crypto/spnego/ntlm/message/authenticate/authenticate.go
+++ b/crypto/spnego/ntlm/message/authenticate/authenticate.go
@@ -108,13 +108,21 @@ func CreateAuthenticateMessage(challenge *challenge.ChallengeMessage, username, 
 	// Determine if we should use Unicode
 	useUnicode := (challenge.NegotiateFlags & flags.NTLMSSP_NEGOTIATE_UNICODE) != 0
 
-	// Prepare domain, username, and workstation
+	// Prepare domain, username, and workstation.
+	//
+	// DomainName MUST be carried with its original case: it has to match, byte for
+	// byte, the domain folded into NTOWFv2 below (NTLMv2 uppercases only the username,
+	// never the domain — MS-NLMP 3.3.2). Uppercasing it here while NTOWFv2 used the
+	// caller's case made the server recompute a different NTProofStr and reject any
+	// mixed/lower-case domain (e.g. an FQDN like "host.example.local") with
+	// STATUS_LOGON_FAILURE; it only worked when the domain was already upper-case or
+	// empty.
 	if useUnicode {
-		msg.DomainName = utf16.EncodeUTF16LE(strings.ToUpper(domain))
+		msg.DomainName = utf16.EncodeUTF16LE(domain)
 		msg.UserName = utf16.EncodeUTF16LE(username)
 		msg.Workstation = utf16.EncodeUTF16LE(strings.ToUpper(workstation))
 	} else {
-		msg.DomainName = []byte(strings.ToUpper(domain))
+		msg.DomainName = []byte(domain)
 		msg.UserName = []byte(username)
 		msg.Workstation = []byte(strings.ToUpper(workstation))
 	}

--- a/crypto/spnego/ntlm/message/authenticate/authenticate_test.go
+++ b/crypto/spnego/ntlm/message/authenticate/authenticate_test.go
@@ -7,7 +7,33 @@ import (
 	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/message/authenticate"
 	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/message/challenge"
 	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/message/negotiate/flags"
+	"github.com/TheManticoreProject/Manticore/encoding/utf16"
 )
+
+// TestDomainNamePreservesCase guards against re-introducing the bug where the
+// AUTHENTICATE DomainName field was upper-cased. NTLMv2 folds the domain into NTOWFv2
+// with its original case (only the username is upper-cased, MS-NLMP 3.3.2), so the
+// DomainName field MUST carry the same case; upper-casing it made the server compute a
+// different NTProofStr and reject mixed/lower-case domains (e.g. an FQDN) with
+// STATUS_LOGON_FAILURE.
+func TestDomainNamePreservesCase(t *testing.T) {
+	challengeMsg := &challenge.ChallengeMessage{
+		NegotiateFlags: flags.NTLMSSP_NEGOTIATE_UNICODE | flags.NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY,
+	}
+	copy(challengeMsg.ServerChallenge[:], []byte{1, 2, 3, 4, 5, 6, 7, 8})
+
+	const domain = "TMP-W-2016.local" // mixed case, as an FQDN is typically supplied
+	authMsg, err := authenticate.CreateAuthenticateMessage(challengeMsg, "Administrator", "pass", domain, "WORKSTATION")
+	if err != nil {
+		t.Fatalf("CreateAuthenticateMessage: %v", err)
+	}
+
+	want := utf16.EncodeUTF16LE(domain)
+	if !bytes.Equal(authMsg.DomainName, want) {
+		t.Errorf("DomainName field was altered (case not preserved)\n got %q\nwant %q",
+			utf16.DecodeUTF16LE(authMsg.DomainName), domain)
+	}
+}
 
 func TestMarshalUnmarshal(t *testing.T) {
 	// Create a challenge message with some flags


### PR DESCRIPTION
### Linked Issue
`Closes #576`

### Root Cause
In `CreateAuthenticateMessage` (`crypto/spnego/ntlm/message/authenticate/authenticate.go`), the AUTHENTICATE `DomainName` field was built with `strings.ToUpper(domain)`, but the NTLMv2 response a few lines below computes NTOWFv2 from the **original-case** `domain` (`ntlmv2.NewNTLMv2CtxWithPassword(domain, …)`). Per MS-NLMP 3.3.2, NTOWFv2 upper-cases only the *username*, never the domain. The server validates by recomputing NTProofStr using the domain as carried in the `DomainName` field; because that field was upper-cased while the client's NTProofStr was built from the original case, the two NTProofStr values differed and the server returned `STATUS_LOGON_FAILURE (0xc000006d)`. It only worked when the supplied domain was already all upper-case or empty (where `ToUpper` is a no-op).

### Fix Description
Carry the `DomainName` field with its original case (drop `strings.ToUpper` on the domain in both the Unicode and OEM branches) so it matches the domain folded into NTOWFv2. The username field was already case-preserving, and NTOWFv2 still upper-cases the username internally, so the change is limited to the domain. The workstation field is left untouched. The fix lives in shared `crypto/spnego`, so it benefits both the SMB1 (`smb_v10`) and SMB2 (`smb_v20`) clients.

### How Verified
- **Runtime (live, Windows Server 2016):** before the fix, `domain="TMP-W-2016.local"` (lower-case FQDN) → `LOGON_FAILURE`; `domain="TMP-W-2016.LOCAL"` (upper) and `""` → success. After the fix, all of `TMP-W-2016.local`, `tmp-w-2016.local`, `TMP-W-2016.LOCAL`, `""`, and `.` authenticate successfully with SMB signing active.
- **Static:** the `DomainName` field now equals `utf16.EncodeUTF16LE(domain)`, identical to the value used to build NTOWFv2, so client and server compute the same NTProofStr.
- **Tests:** `go build ./...`, plus `go test ./crypto/... ./network/smb/smb_v10/client/... ./network/smb/smb_v20/client/...` all pass.

### Test Coverage
- **Added:** `TestDomainNamePreservesCase` in `crypto/spnego/ntlm/message/authenticate/authenticate_test.go` — asserts the `DomainName` field of a generated AUTHENTICATE message equals the UTF-16LE encoding of the supplied mixed-case domain (fails against the pre-fix upper-casing).

### Scope of Change
- **Files changed:** `crypto/spnego/ntlm/message/authenticate/authenticate.go`, `crypto/spnego/ntlm/message/authenticate/authenticate_test.go`.
- **Submodule pointer updated:** no.
- **Behavioral changes outside the bug fix:** none.

### Risk and Rollout
Low blast radius: the change only stops upper-casing the NTLM domain. Domains that previously worked were already upper-case or empty, for which the behavior is unchanged; mixed/lower-case domains that previously failed now work. Safe to merge without staged rollout.