### PR TITLE
Fix SMB1 session setup rejected by strict servers on empty NativeOS (#578)

### DIFF
--- a/network/smb/smb_v10/client/client_structures.go
+++ b/network/smb/smb_v10/client/client_structures.go
@@ -10,6 +10,15 @@ import (
 	"github.com/TheManticoreProject/Manticore/windows/guid"
 )
 
+// Default NativeOS / NativeLanMan strings sent in SESSION_SETUP_ANDX when the caller
+// leaves Client.NativeOS / Client.NativeLanMan empty. They must be non-empty: strict
+// servers (e.g. Windows Server 2016) reject a session setup with empty values. The
+// exact strings are informational only.
+const (
+	DefaultNativeOS     = "Unix"
+	DefaultNativeLanMan = "Samba"
+)
+
 // Client represents an SMB v1.0 client
 type Client struct {
 	// Transport is the transport layer for the client

--- a/network/smb/smb_v10/client/native_os_default_test.go
+++ b/network/smb/smb_v10/client/native_os_default_test.go
@@ -1,0 +1,55 @@
+package client_test
+
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/client"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header/flags"
+	"github.com/TheManticoreProject/Manticore/windows/credentials"
+)
+
+// TestSessionSetupDefaultsNativeStrings guards the fix for the empty-NativeOS bug:
+// strict servers (Windows Server 2016) reject a SESSION_SETUP_ANDX whose
+// NativeOS/NativeLanMan are empty, returning an empty challenge blob that then fails
+// SPNEGO parsing with "asn1: sequence truncated". When the caller leaves those fields
+// blank, SessionSetup must substitute non-empty defaults.
+func TestSessionSetupDefaultsNativeStrings(t *testing.T) {
+	// Share-level setup completes in a single round trip, so one canned response with a
+	// reply UID is enough to drive SessionSetup to completion.
+	resp := message.NewMessage()
+	resp.Header.SetFlags(flags.FLAGS_REPLY)
+	resp.Header.UID = 0x0901
+	resp.AddCommand(commands.NewSessionSetupAndxResponse())
+	raw, err := resp.Marshal()
+	if err != nil {
+		t.Fatalf("marshal canned response: %v", err)
+	}
+
+	tr := &capturingTransport{response: raw}
+	c := &client.Client{
+		Transport:  tr,
+		Connection: &client.Connection{Server: &client.Server{SecurityMode: 0}},
+	}
+	// NativeOS / NativeLanMan deliberately left empty (the smbclient-ng default state).
+
+	if err := c.SessionSetup(&credentials.Credentials{Username: "alice"}); err != nil {
+		t.Fatalf("SessionSetup: %v", err)
+	}
+
+	reqMsg := message.NewMessage()
+	if err := reqMsg.Unmarshal(tr.sent); err != nil {
+		t.Fatalf("unmarshal sent request: %v", err)
+	}
+	req, ok := reqMsg.Command.(*commands.SessionSetupAndxRequest)
+	if !ok {
+		t.Fatalf("sent command is %T, want *SessionSetupAndxRequest", reqMsg.Command)
+	}
+	if req.NativeOS != client.DefaultNativeOS {
+		t.Errorf("NativeOS = %q, want default %q", req.NativeOS, client.DefaultNativeOS)
+	}
+	if req.NativeLanMan != client.DefaultNativeLanMan {
+		t.Errorf("NativeLanMan = %q, want default %q", req.NativeLanMan, client.DefaultNativeLanMan)
+	}
+}

--- a/network/smb/smb_v10/client/session.go
+++ b/network/smb/smb_v10/client/session.go
@@ -79,8 +79,19 @@ func (s *Session) SessionSetup() error {
 	sessionSetupCmd.MaxMpxCount = s.Client.Connection.MaxMpxCount
 	sessionSetupCmd.Capabilities = s.Client.Connection.Server.Capabilities
 
+	// NativeOS / NativeLanMan are informational strings, but they MUST NOT be empty:
+	// strict servers (e.g. Windows Server 2016) reject a SESSION_SETUP_ANDX whose
+	// NativeOS/NativeLanMan are empty, replying with a DOS-class error and an empty
+	// security blob — which then fails SPNEGO parsing with "asn1: sequence truncated".
+	// Default them when the caller left them blank so every caller interoperates.
 	sessionSetupCmd.NativeOS = s.Client.NativeOS
 	sessionSetupCmd.NativeLanMan = s.Client.NativeLanMan
+	if sessionSetupCmd.NativeOS == "" {
+		sessionSetupCmd.NativeOS = DefaultNativeOS
+	}
+	if sessionSetupCmd.NativeLanMan == "" {
+		sessionSetupCmd.NativeLanMan = DefaultNativeLanMan
+	}
 
 	// Track whether step 1 used the extended-security (NTLMSSP) challenge/response
 	// path. Only that path performs the second-step authenticate exchange below;


### PR DESCRIPTION
### Linked Issue
`Closes #578`

### Root Cause
`(*Session).SessionSetup` in `network/smb/smb_v10/client/session.go` copied the caller's `Client.NativeOS` / `Client.NativeLanMan` into the `SESSION_SETUP_ANDX` request verbatim. These fields are informational, but strict servers (Windows Server 2016) reject a session setup whose `NativeOS`/`NativeLanMan` are empty: step 1 comes back as a 35-byte DOS-class error (`0x00010002`) with an empty `SecurityBlob`, and the client then fails parsing the (empty) SPNEGO token with `asn1: syntax error: sequence truncated`. Any caller that did not explicitly set the two strings — `smbclient-ng`, bare test harnesses — could not authenticate over SMB1 to such a server, and the failure looked like an ASN.1 bug rather than a session-setup rejection.

### Fix Description
Default `NativeOS`/`NativeLanMan` to non-empty values in `SessionSetup` when the caller left them blank, via new exported constants `DefaultNativeOS = "Unix"` / `DefaultNativeLanMan = "Samba"` (the strings are informational; these match what the repo's own `main.go` and integration tests already use). Applying the default in `SessionSetup` covers every construction path (`NewClientUsingTCPTransport`, `NewClientUsingNBTTransport`, `NewFromTransport`). Callers that set the fields keep full control.

### How Verified
- **Runtime (live, Windows Server 2016):** before the fix, SESSION_SETUP step 1 returned status `0x00010002` with an empty challenge → `asn1: sequence truncated`. After the fix, step 1 returns `STATUS_MORE_PROCESSING_REQUIRED (0xc0000016)` with a real challenge, step 2 returns `0x0`, and session setup succeeds — verified both with a direct `smb_v10` probe and end-to-end through the `smbclient-ng` tool (which sets neither field).
- **Tests:** `go build ./...`, `go test ./network/smb/smb_v10/...` pass.

### Test Coverage
- **Added:** `TestSessionSetupDefaultsNativeStrings` in `network/smb/smb_v10/client/native_os_default_test.go` — drives a share-level `SessionSetup` with empty client `NativeOS`/`NativeLanMan` over a capturing transport and asserts the marshalled request carries `DefaultNativeOS`/`DefaultNativeLanMan` (fails against the pre-fix verbatim copy).

### Scope of Change
- **Files changed:** `network/smb/smb_v10/client/session.go`, `network/smb/smb_v10/client/client_structures.go`, `network/smb/smb_v10/client/native_os_default_test.go`.
- **Submodule pointer updated:** no.
- **Behavioral changes outside the bug fix:** none. Callers that already set `NativeOS`/`NativeLanMan` are unaffected.

### Risk and Rollout
Low: the change only substitutes defaults for empty informational strings; non-empty values are passed through unchanged. Safe to merge without staged rollout.