### PR TITLE
Add file-management ops to the generic SMB client (#580)

### DIFF
--- a/network/smb/client/adapter_smb1.go
+++ b/network/smb/client/adapter_smb1.go
@@ -110,9 +110,40 @@ func (b *smb1Backend) ListDirectory(path, pattern string) ([]FileInfo, error) {
 	return out, nil
 }
 
+func (b *smb1Backend) DeleteFile(path string) error { return b.engine.DeleteFile(smb1WirePath(path)) }
+
+func (b *smb1Backend) CreateDirectory(path string) error {
+	return b.engine.CreateDirectory(smb1WirePath(path))
+}
+
+func (b *smb1Backend) DeleteDirectory(path string) error {
+	return b.engine.DeleteDirectory(smb1WirePath(path))
+}
+
+func (b *smb1Backend) RenameFile(oldPath, newPath string) error {
+	return b.engine.RenameFile(smb1WirePath(oldPath), smb1WirePath(newPath))
+}
+
+func (b *smb1Backend) CheckDirectory(path string) error {
+	return b.engine.CheckDirectory(smb1WirePath(path))
+}
+
 func (b *smb1Backend) TreeDisconnect() error { return b.engine.TreeDisconnect() }
 func (b *smb1Backend) Logoff() error         { return b.engine.Logoff() }
 func (b *smb1Backend) Disconnect() error     { return b.engine.Disconnect() }
+
+// smb1WirePath converts a generic share-relative path (no leading backslash; ""
+// for the root) into the leading-backslash form the SMB1 file-management commands
+// expect. Unlike the engine's OpenFile, those commands do not prepend it.
+func smb1WirePath(path string) string {
+	if path == "" {
+		return "\\"
+	}
+	if path[0] != '\\' {
+		return "\\" + path
+	}
+	return path
+}
 
 // fid unboxes an opaque FileHandle back into the SMB1 FID that produced it,
 // guarding against a handle from another backend.

--- a/network/smb/client/adapter_smb2.go
+++ b/network/smb/client/adapter_smb2.go
@@ -104,6 +104,29 @@ func (b *smb2Backend) ListDirectory(path, pattern string) ([]FileInfo, error) {
 	return out, nil
 }
 
+func (b *smb2Backend) DeleteFile(path string) error { return b.engine.DeleteFile(path) }
+
+func (b *smb2Backend) CreateDirectory(path string) error { return b.engine.CreateDirectory(path) }
+
+func (b *smb2Backend) DeleteDirectory(path string) error { return b.engine.DeleteDirectory(path) }
+
+func (b *smb2Backend) RenameFile(oldPath, newPath string) error {
+	// replaceIfExists=false: fail rather than clobber an existing target, matching
+	// the generic contract.
+	return b.engine.RenameFile(oldPath, newPath, false)
+}
+
+func (b *smb2Backend) CheckDirectory(path string) error {
+	st, err := b.engine.Stat(path)
+	if err != nil {
+		return err
+	}
+	if !st.IsDirectory {
+		return fmt.Errorf("%q is not a directory", path)
+	}
+	return nil
+}
+
 func (b *smb2Backend) TreeDisconnect() error { return b.engine.TreeDisconnect() }
 func (b *smb2Backend) Logoff() error         { return b.engine.Logoff() }
 func (b *smb2Backend) Disconnect() error     { return b.engine.Disconnect() }

--- a/network/smb/client/backend.go
+++ b/network/smb/client/backend.go
@@ -41,6 +41,23 @@ type Backend interface {
 	// match pattern (e.g. "*").
 	ListDirectory(path, pattern string) ([]FileInfo, error)
 
+	// DeleteFile deletes a file on the current tree.
+	DeleteFile(path string) error
+
+	// CreateDirectory creates a directory on the current tree.
+	CreateDirectory(path string) error
+
+	// DeleteDirectory removes an empty directory on the current tree.
+	DeleteDirectory(path string) error
+
+	// RenameFile renames (or moves) a file or directory on the current tree. It
+	// fails if newPath already exists.
+	RenameFile(oldPath, newPath string) error
+
+	// CheckDirectory returns nil if path names an existing directory on the
+	// current tree, and an error otherwise.
+	CheckDirectory(path string) error
+
 	// TreeDisconnect disconnects the current tree.
 	TreeDisconnect() error
 

--- a/network/smb/client/client.go
+++ b/network/smb/client/client.go
@@ -120,6 +120,25 @@ func (c *Client) ListDirectory(path, pattern string) ([]FileInfo, error) {
 	return c.backend.ListDirectory(path, pattern)
 }
 
+// DeleteFile deletes a file on the current tree.
+func (c *Client) DeleteFile(path string) error { return c.backend.DeleteFile(path) }
+
+// CreateDirectory creates a directory on the current tree.
+func (c *Client) CreateDirectory(path string) error { return c.backend.CreateDirectory(path) }
+
+// DeleteDirectory removes an empty directory on the current tree.
+func (c *Client) DeleteDirectory(path string) error { return c.backend.DeleteDirectory(path) }
+
+// RenameFile renames (or moves) a file or directory on the current tree. It fails
+// if newPath already exists.
+func (c *Client) RenameFile(oldPath, newPath string) error {
+	return c.backend.RenameFile(oldPath, newPath)
+}
+
+// CheckDirectory returns nil if path names an existing directory on the current
+// tree, and an error otherwise.
+func (c *Client) CheckDirectory(path string) error { return c.backend.CheckDirectory(path) }
+
 // TreeDisconnect disconnects the current tree.
 func (c *Client) TreeDisconnect() error { return c.backend.TreeDisconnect() }
 

--- a/network/smb/client/filemgmt_test.go
+++ b/network/smb/client/filemgmt_test.go
@@ -1,0 +1,92 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb"
+	"github.com/TheManticoreProject/Manticore/windows/credentials"
+)
+
+// recordingBackend is a no-op Backend that records the file-management calls the
+// generic Client delegates to it.
+type recordingBackend struct {
+	calls []string
+	args  []string
+}
+
+func (r *recordingBackend) Dialect() smb.SMBProtocolVersion      { return smb.SMB_VERSION_2_0_2 }
+func (r *recordingBackend) Login(*credentials.Credentials) error { return nil }
+func (r *recordingBackend) TreeConnect(string) error             { return nil }
+func (r *recordingBackend) OpenFile(string, OpenOptions) (FileHandle, error) {
+	return FileHandle{}, nil
+}
+func (r *recordingBackend) ReadFile(FileHandle, uint64, uint32) ([]byte, error)  { return nil, nil }
+func (r *recordingBackend) WriteFile(FileHandle, uint64, []byte) (uint32, error) { return 0, nil }
+func (r *recordingBackend) CloseFile(FileHandle) error                           { return nil }
+func (r *recordingBackend) ListDirectory(string, string) ([]FileInfo, error)     { return nil, nil }
+func (r *recordingBackend) TreeDisconnect() error                                { return nil }
+func (r *recordingBackend) Logoff() error                                        { return nil }
+func (r *recordingBackend) Disconnect() error                                    { return nil }
+
+func (r *recordingBackend) DeleteFile(path string) error {
+	r.calls, r.args = append(r.calls, "DeleteFile"), append(r.args, path)
+	return nil
+}
+func (r *recordingBackend) CreateDirectory(path string) error {
+	r.calls, r.args = append(r.calls, "CreateDirectory"), append(r.args, path)
+	return nil
+}
+func (r *recordingBackend) DeleteDirectory(path string) error {
+	r.calls, r.args = append(r.calls, "DeleteDirectory"), append(r.args, path)
+	return nil
+}
+func (r *recordingBackend) RenameFile(oldPath, newPath string) error {
+	r.calls, r.args = append(r.calls, "RenameFile"), append(r.args, oldPath+"->"+newPath)
+	return nil
+}
+func (r *recordingBackend) CheckDirectory(path string) error {
+	r.calls, r.args = append(r.calls, "CheckDirectory"), append(r.args, path)
+	return nil
+}
+
+// TestClientFileManagementDelegation verifies the generic Client forwards each
+// file-management call to its backend with the path(s) unchanged.
+func TestClientFileManagementDelegation(t *testing.T) {
+	rb := &recordingBackend{}
+	c := &Client{backend: rb}
+
+	if err := c.DeleteFile("dir\\f.txt"); err != nil {
+		t.Fatalf("DeleteFile: %v", err)
+	}
+	if err := c.CreateDirectory("dir\\new"); err != nil {
+		t.Fatalf("CreateDirectory: %v", err)
+	}
+	if err := c.DeleteDirectory("dir\\old"); err != nil {
+		t.Fatalf("DeleteDirectory: %v", err)
+	}
+	if err := c.RenameFile("a.txt", "b.txt"); err != nil {
+		t.Fatalf("RenameFile: %v", err)
+	}
+	if err := c.CheckDirectory("dir"); err != nil {
+		t.Fatalf("CheckDirectory: %v", err)
+	}
+
+	wantCalls := []string{"DeleteFile", "CreateDirectory", "DeleteDirectory", "RenameFile", "CheckDirectory"}
+	wantArgs := []string{"dir\\f.txt", "dir\\new", "dir\\old", "a.txt->b.txt", "dir"}
+	for i := range wantCalls {
+		if rb.calls[i] != wantCalls[i] || rb.args[i] != wantArgs[i] {
+			t.Errorf("call %d = (%s,%q), want (%s,%q)", i, rb.calls[i], rb.args[i], wantCalls[i], wantArgs[i])
+		}
+	}
+}
+
+// TestSMB1WirePath checks the leading-backslash normalization the SMB1 adapter
+// applies to file-management paths.
+func TestSMB1WirePath(t *testing.T) {
+	cases := map[string]string{"": "\\", "dir": "\\dir", "dir\\f": "\\dir\\f", "\\already": "\\already"}
+	for in, want := range cases {
+		if got := smb1WirePath(in); got != want {
+			t.Errorf("smb1WirePath(%q) = %q, want %q", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #580`

### Root Cause
The generic, version-agnostic client (`network/smb/client`) exposed open/read/write/close and `ListDirectory`, but not the file-management operations both engines already implement. A consumer needing `rm`/`mkdir`/`rmdir`/`mv`/`cd` had to bypass the facade and bind to a single engine, defeating dialect-agnostic negotiation.

### Fix Description
Adds five operations to the `Backend` interface and the generic `Client`, each routed to the negotiated backend:

- `DeleteFile(path)` / `CreateDirectory(path)` / `DeleteDirectory(path)` / `RenameFile(old, new)` / `CheckDirectory(path)`

Adapter details:
- **SMB1** (`adapter_smb1.go`): delegates to the engine's `DeleteFile`/`CreateDirectory`/`DeleteDirectory`/`RenameFile`/`CheckDirectory`, first normalizing the generic share-relative path (no leading backslash) to the leading-backslash form those commands require. The engine's `OpenFile` prepends the backslash itself, but the file-management commands do not — hence `smb1WirePath`.
- **SMB2** (`adapter_smb2.go`): passes the share-relative path straight through; `RenameFile` uses `replaceIfExists=false` (fail rather than clobber); `CheckDirectory` is implemented via the engine's `Stat`, erroring when the entry is not a directory.

The canonical path format for the generic client remains share-relative with no leading backslash (matching `OpenFile`/`ListDirectory`).

### How Verified
- `go build ./network/smb/client/`, `go vet`, `go test ./network/smb/client/` all pass; the compile-time `var _ Backend` assertions confirm both adapters satisfy the extended interface.
- A white-box delegation test drives each new `Client` method against a recording backend and asserts the call and path(s) are forwarded unchanged; a second test covers the SMB1 leading-backslash normalization.
- Exercised end-to-end by migrating the `smbclient-ng` tool onto the generic client and running `rm`/`mkdir`/`rmdir`/`mv`/`cd`/`ls` over SMB2 against a live Windows Server 2016 target.

### Test Coverage
- **Added:** `filemgmt_test.go` (`TestClientFileManagementDelegation`, `TestSMB1WirePath`).

### Scope of Change
- **Files changed:** `network/smb/client/{backend.go, client.go, adapter_smb1.go, adapter_smb2.go, filemgmt_test.go}`.
- **Submodule pointer updated:** no.
- **Behavioral changes outside the additions:** none — existing methods are untouched.

### Risk and Rollout
Low: purely additive. Existing callers and tests are unaffected. Safe to merge without staged rollout.