### PR TITLE
Run MS-SRVS over the generic SMB client / any dialect (#583)

### DIFF
--- a/network/dcerpc/ms-protocols/ms-srvs/client.go
+++ b/network/dcerpc/ms-protocols/ms-srvs/client.go
@@ -20,8 +20,7 @@ import (
 
 	srvsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0"
 	dcerpcclient "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
-	dcerpcsmb "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/transport/smb"
-	smbclient "github.com/TheManticoreProject/Manticore/network/smb/smb_v10/client"
+	dcerpctransport "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/transport"
 )
 
 // MaxPreferredLength is passed as the preferred maximum reply length of the Netr*Enum
@@ -29,23 +28,38 @@ import (
 // resume-handle paging is needed; this matches impacket's enumeration usage.
 const MaxPreferredLength uint32 = 0xFFFFFFFF
 
-// Client exposes MS-SRVS workflows over an established SMB v1 session. The supplied SMB
-// client MUST already be connected, have an authenticated session (SessionSetup), and
-// have a tree connected to IPC$ (TreeConnect) before any method is called.
-type Client struct {
-	smb *smbclient.Client
+// PipeDialer opens a fresh DCE/RPC named-pipe transport for the given pipe over an
+// established, IPC$-tree-connected SMB session. It is the only capability MS-SRVS needs
+// from the SMB layer, so depending on this interface (rather than a concrete SMB
+// client) keeps mssrvs independent of the SMB dialect: the generic
+// network/smb/client.Client satisfies it (via its RPCTransport method) and routes to an
+// SMB1 or SMB2 named-pipe transport according to what was negotiated.
+type PipeDialer interface {
+	RPCTransport(pipeName string) (dcerpctransport.Transport, error)
 }
 
-// New returns an MS-SRVS client over the given SMB v1 client.
-func New(smb *smbclient.Client) *Client {
-	return &Client{smb: smb}
+// Client exposes MS-SRVS workflows over an established SMB session. The supplied dialer
+// MUST be backed by a client that is connected, authenticated, and tree-connected to
+// IPC$ before any method is called.
+type Client struct {
+	dialer PipeDialer
+}
+
+// New returns an MS-SRVS client over the given pipe dialer (typically a
+// *network/smb/client.Client).
+func New(dialer PipeDialer) *Client {
+	return &Client{dialer: dialer}
 }
 
 // bind opens a fresh \srvsvc pipe and binds the srvsvc abstract syntax over it. srvsvc
 // calls are mutually independent, so each workflow runs on its own pipe and bind: a
 // fault on one cannot desync the next. The returned close function tears the pipe down.
 func (c *Client) bind() (*dcerpcclient.Client, func() error, error) {
-	rpc := dcerpcclient.NewClient(dcerpcsmb.New(c.smb, srvsvc.PipeName))
+	transport, err := c.dialer.RPCTransport(srvsvc.PipeName)
+	if err != nil {
+		return nil, nil, fmt.Errorf("mssrvs: open srvsvc pipe: %w", err)
+	}
+	rpc := dcerpcclient.NewClient(transport)
 	if err := rpc.Bind(srvsvc.SyntaxID()); err != nil {
 		return nil, nil, fmt.Errorf("mssrvs: bind srvsvc: %w", err)
 	}

--- a/network/dcerpc/ms-protocols/ms-srvs/client_dialer_test.go
+++ b/network/dcerpc/ms-protocols/ms-srvs/client_dialer_test.go
@@ -1,0 +1,66 @@
+package mssrvs
+
+import (
+	"testing"
+
+	srvsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/structures"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	dcerpctransport "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/transport"
+)
+
+// fakePipeDialer is a PipeDialer that hands out a pre-scripted in-memory transport,
+// recording the pipe name it was asked to open.
+type fakePipeDialer struct {
+	ft        *fakeTransport
+	lastPipe  string
+	openCalls int
+}
+
+func (d *fakePipeDialer) RPCTransport(pipeName string) (dcerpctransport.Transport, error) {
+	d.lastPipe = pipeName
+	d.openCalls++
+	return d.ft, nil
+}
+
+// TestNewUsesDialerToBindSrvsvc verifies the decoupled path: New takes a PipeDialer,
+// and a workflow opens the \srvsvc pipe through it, binds, and issues the call — all
+// without any concrete SMB-client dependency.
+func TestNewUsesDialerToBindSrvsvc(t *testing.T) {
+	ft := &fakeTransport{}
+	ft.queue(bindAck(t)) // the Bind in c.bind() consumes this
+
+	// One share in a level-1 container, then the NetrShareEnum reply.
+	resp := &shareEnumResp{
+		InfoStruct: structures.SHARE_ENUM_STRUCT{
+			Level: 1,
+			ShareInfo: structures.SHARE_ENUM_UNION{
+				Tag: 1,
+				Level1: &structures.SHARE_INFO_1_CONTAINER{
+					EntriesRead: 1,
+					Buffer:      []structures.SHARE_INFO_1{{Shi1Netname: "C$", Shi1Type: 0x80000000, Shi1Remark: "Default share"}},
+				},
+			},
+		},
+		TotalEntries: 1,
+		Status:       ndr.DWORD(srvsvc.NERR_Success),
+	}
+	ft.queue(responsePDU(t, 2, stub(t, resp)))
+
+	dialer := &fakePipeDialer{ft: ft}
+	c := New(dialer)
+
+	shares, err := c.ListShares()
+	if err != nil {
+		t.Fatalf("ListShares() error = %v", err)
+	}
+	if len(shares) != 1 || shares[0].Name != "C$" {
+		t.Fatalf("shares = %+v, want one entry C$", shares)
+	}
+	if dialer.openCalls != 1 {
+		t.Errorf("dialer opened %d pipes, want 1", dialer.openCalls)
+	}
+	if dialer.lastPipe != srvsvc.PipeName {
+		t.Errorf("opened pipe %q, want %q", dialer.lastPipe, srvsvc.PipeName)
+	}
+}

--- a/network/dcerpc/ms-protocols/ms-srvs/integration_test.go
+++ b/network/dcerpc/ms-protocols/ms-srvs/integration_test.go
@@ -9,18 +9,18 @@
 package mssrvs_test
 
 import (
-	"net"
 	"os"
 	"strconv"
 	"testing"
 
 	mssrvs "github.com/TheManticoreProject/Manticore/network/dcerpc/ms-protocols/ms-srvs"
-	smbclient "github.com/TheManticoreProject/Manticore/network/smb/smb_v10/client"
+	smbclient "github.com/TheManticoreProject/Manticore/network/smb/client"
 	"github.com/TheManticoreProject/Manticore/windows/credentials"
 )
 
-// liveClient builds an MS-SRVS client over a live SMB session. It skips the test unless
-// DCERPC_TEST_HOST is set.
+// liveClient builds an MS-SRVS client over a live SMB session using the generic,
+// version-agnostic SMB client (so it runs over whichever dialect the server
+// negotiates — SMB1 or SMB2). It skips the test unless DCERPC_TEST_HOST is set.
 func liveClient(t *testing.T) (*mssrvs.Client, func()) {
 	t.Helper()
 	host := os.Getenv("DCERPC_TEST_HOST")
@@ -35,22 +35,18 @@ func liveClient(t *testing.T) (*mssrvs.Client, func()) {
 		}
 		port = n
 	}
-	ip := net.ParseIP(host)
-	if ip == nil {
-		t.Fatalf("DCERPC_TEST_HOST %q is not a valid IP", host)
-	}
 	creds, err := credentials.NewCredentials(os.Getenv("DCERPC_TEST_DOMAIN"), os.Getenv("DCERPC_TEST_USER"), os.Getenv("DCERPC_TEST_PASS"), "")
 	if err != nil {
 		t.Fatalf("NewCredentials: %v", err)
 	}
 
-	smb := smbclient.NewClientUsingTCPTransport(ip, port)
-	if err := smb.Connect(ip, port); err != nil {
-		t.Fatalf("SMB Connect: %v", err)
+	smb, err := smbclient.Dial(host, port, smbclient.Options{})
+	if err != nil {
+		t.Fatalf("SMB Dial: %v", err)
 	}
-	smb.NativeOS, smb.NativeLanMan = "Unix", "Samba"
-	if err := smb.SessionSetup(creds); err != nil {
-		t.Fatalf("SMB SessionSetup: %v", err)
+	t.Logf("negotiated %s", smb.Dialect())
+	if err := smb.Login(creds); err != nil {
+		t.Fatalf("SMB Login: %v", err)
 	}
 	if err := smb.TreeConnect("IPC$"); err != nil {
 		t.Fatalf("SMB TreeConnect(IPC$): %v", err)

--- a/network/smb/client/adapter_smb1.go
+++ b/network/smb/client/adapter_smb1.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	dcerpctransport "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/transport"
+	dcerpcsmb "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/transport/smb"
 	"github.com/TheManticoreProject/Manticore/network/smb"
 	smb1 "github.com/TheManticoreProject/Manticore/network/smb/smb_v10/client"
 	"github.com/TheManticoreProject/Manticore/windows/credentials"
@@ -126,6 +128,10 @@ func (b *smb1Backend) RenameFile(oldPath, newPath string) error {
 
 func (b *smb1Backend) CheckDirectory(path string) error {
 	return b.engine.CheckDirectory(smb1WirePath(path))
+}
+
+func (b *smb1Backend) RPCTransport(pipeName string) (dcerpctransport.Transport, error) {
+	return dcerpcsmb.New(b.engine, pipeName), nil
 }
 
 func (b *smb1Backend) TreeDisconnect() error { return b.engine.TreeDisconnect() }

--- a/network/smb/client/adapter_smb2.go
+++ b/network/smb/client/adapter_smb2.go
@@ -3,6 +3,8 @@ package client
 import (
 	"fmt"
 
+	dcerpctransport "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/transport"
+	dcerpcsmb2 "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/transport/smb2"
 	"github.com/TheManticoreProject/Manticore/network/smb"
 	smb2 "github.com/TheManticoreProject/Manticore/network/smb/smb_v20/client"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/types"
@@ -127,6 +129,10 @@ func (b *smb2Backend) CheckDirectory(path string) error {
 		return fmt.Errorf("%q is not a directory", path)
 	}
 	return nil
+}
+
+func (b *smb2Backend) RPCTransport(pipeName string) (dcerpctransport.Transport, error) {
+	return dcerpcsmb2.New(b.engine, pipeName), nil
 }
 
 func (b *smb2Backend) TreeDisconnect() error { return b.engine.TreeDisconnect() }

--- a/network/smb/client/backend.go
+++ b/network/smb/client/backend.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	dcerpctransport "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/transport"
 	"github.com/TheManticoreProject/Manticore/network/smb"
 	"github.com/TheManticoreProject/Manticore/windows/credentials"
 )
@@ -57,6 +58,13 @@ type Backend interface {
 	// CheckDirectory returns nil if path names an existing directory on the
 	// current tree, and an error otherwise.
 	CheckDirectory(path string) error
+
+	// RPCTransport opens a named pipe on the current tree (IPC$) and returns it as
+	// a DCE/RPC PDU transport, framed for the negotiated dialect. It is the bridge
+	// from the version-agnostic SMB client to the DCE/RPC stack, so callers can run
+	// MS-RPC interfaces (srvsvc, lsarpc, …) without knowing whether SMB1 or SMB2 was
+	// negotiated. The current tree must be IPC$.
+	RPCTransport(pipeName string) (dcerpctransport.Transport, error)
 
 	// TreeDisconnect disconnects the current tree.
 	TreeDisconnect() error

--- a/network/smb/client/filemgmt_test.go
+++ b/network/smb/client/filemgmt_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"testing"
 
+	dcerpctransport "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/transport"
 	"github.com/TheManticoreProject/Manticore/network/smb"
 	"github.com/TheManticoreProject/Manticore/windows/credentials"
 )
@@ -24,9 +25,12 @@ func (r *recordingBackend) ReadFile(FileHandle, uint64, uint32) ([]byte, error) 
 func (r *recordingBackend) WriteFile(FileHandle, uint64, []byte) (uint32, error) { return 0, nil }
 func (r *recordingBackend) CloseFile(FileHandle) error                           { return nil }
 func (r *recordingBackend) ListDirectory(string, string) ([]FileInfo, error)     { return nil, nil }
-func (r *recordingBackend) TreeDisconnect() error                                { return nil }
-func (r *recordingBackend) Logoff() error                                        { return nil }
-func (r *recordingBackend) Disconnect() error                                    { return nil }
+func (r *recordingBackend) RPCTransport(string) (dcerpctransport.Transport, error) {
+	return nil, nil
+}
+func (r *recordingBackend) TreeDisconnect() error { return nil }
+func (r *recordingBackend) Logoff() error         { return nil }
+func (r *recordingBackend) Disconnect() error     { return nil }
 
 func (r *recordingBackend) DeleteFile(path string) error {
 	r.calls, r.args = append(r.calls, "DeleteFile"), append(r.args, path)

--- a/network/smb/client/rpc.go
+++ b/network/smb/client/rpc.go
@@ -1,0 +1,15 @@
+package client
+
+import dcerpctransport "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/transport"
+
+// RPCTransport opens pipeName on the current tree and returns it as a DCE/RPC PDU
+// transport for the negotiated dialect (SMB1 or SMB2). It is the bridge from the
+// version-agnostic SMB client to the DCE/RPC stack: a caller binds it into a
+// network/dcerpc/v5/client.Client (which the returned value satisfies as a
+// transport.Transport) to drive MS-RPC interfaces such as srvsvc over the IPC$
+// tree, without caring which SMB dialect was negotiated.
+//
+// The current tree must be IPC$ (TreeConnect("IPC$")) before calling.
+func (c *Client) RPCTransport(pipeName string) (dcerpctransport.Transport, error) {
+	return c.backend.RPCTransport(pipeName)
+}


### PR DESCRIPTION
### Linked Issue
`Closes #583`

### Root Cause
`network/dcerpc/ms-protocols/ms-srvs` took a concrete `*smb_v10/client.Client` and built its DCE/RPC transport with `dcerpcsmb.New(...)` (the SMB1 named-pipe transport), so MS-SRVS only worked over SMB1. The generic, version-agnostic `network/smb/client` negotiates SMB1/SMB2/SMB3 but keeps its backend engine unexported, so it could neither be passed to `mssrvs.New` nor used to build a transport — even though an SMB2 named-pipe transport (`network/dcerpc/v5/transport/smb2`) already exists.

### Fix Description
Bridges the SMB layer to DCE/RPC at the right seam, in two parts:

1. **Generic client gains `RPCTransport(pipeName)`** (`Backend` + `Client`, with the pass-through in the new `rpc.go`). It returns a `network/dcerpc/v5/transport.Transport` framed for the negotiated dialect:
   - SMB1 adapter → `dcerpcsmb.New(engine, pipeName)`
   - SMB2 adapter → `dcerpcsmb2.New(engine, pipeName)`
   The generic client already binds both engines; the dcerpc transport packages depend on the SMB *engines*, never on the generic client, so there is **no import cycle**. The current tree must be IPC$.

2. **`mssrvs` decoupled from the SMB1 engine.** `New` now takes a small `PipeDialer` interface (`RPCTransport(pipeName) (transport.Transport, error)`) instead of a concrete `*smb_v10/client.Client`; `bind()` opens the `\srvsvc` pipe through it. The generic `*client.Client` satisfies `PipeDialer` structurally, so `mssrvs` depends on a one-method interface rather than any concrete SMB client (dependency inversion — `mssrvs` does not import `network/smb/client`).

The `\srvsvc` pipe name is unchanged and works for both transports (the SMB1 transport keeps the leading `\`; the SMB2 transport strips it).

### How Verified
- `go build ./...`, `go vet ./network/...`, and `go test ./network/smb/client/ ./network/dcerpc/ms-protocols/ms-srvs/` pass; `go build/vet -tags integration` passes.
- **Live (Windows Server 2016, 192.168.1.31):** the mssrvs integration test, now dialing with the generic client, **negotiated SMB 2.0.2** and `ListShares` returned the real shares (`ADMIN$`, `C$`, `IPC$`, `NETLOGON`, `SYSVOL`) — i.e. MS-SRVS ran end-to-end over SMB2, which was previously impossible.
- Unit test drives `New(dialer).ListShares()` through a fake `PipeDialer` + in-memory transport and asserts it opens exactly the `\srvsvc` pipe and binds/decodes correctly; the existing per-method unit tests are unchanged.

### Test Coverage
- **Added:** `network/dcerpc/ms-protocols/ms-srvs/client_dialer_test.go` (`TestNewUsesDialerToBindSrvsvc`); extended `network/smb/client/filemgmt_test.go`'s fake backend with `RPCTransport`.
- **Updated:** `ms-srvs/integration_test.go` now uses the generic client.
- **Existing:** the MS-SRVS per-method unit tests and the generic-client tests continue to pass.

### Scope of Change
- **Files changed:** `network/smb/client/{backend.go, rpc.go (new), adapter_smb1.go, adapter_smb2.go, filemgmt_test.go}`; `network/dcerpc/ms-protocols/ms-srvs/{client.go, integration_test.go, client_dialer_test.go (new)}`.
- **Submodule pointer updated:** no.
- **Behavioral changes outside the bridge:** none — existing generic-client and mssrvs methods are unchanged.

### Risk and Rollout
Low. The generic-client addition is purely additive (one new method). The `mssrvs.New` signature change is source-breaking for direct callers, but the only caller in-tree is the integration test (updated here); `*smb_v10/client.Client` is no longer accepted directly — callers pass the generic client (or any `PipeDialer`). Safe to merge without staged rollout.

### Notes
This unblocks wiring the smbclient-ng `shares` / `who` / `info` commands to `mssrvs.New(sm.Client())` now that `SessionManager.Client()` returns the generic client.