### PR TITLE
Expose negotiated connection capabilities on the generic SMB client (#585)

### DIFF
--- a/network/smb/client/adapter_smb1.go
+++ b/network/smb/client/adapter_smb1.go
@@ -23,6 +23,17 @@ func newSMB1Backend(engine *smb1.Client) *smb1Backend {
 
 func (b *smb1Backend) Dialect() smb.SMBProtocolVersion { return smb.SMB_VERSION_1_0 }
 
+func (b *smb1Backend) ConnectionInfo() ConnectionInfo {
+	s := b.engine.Connection.Server
+	// SMB1 negotiates a single MaxBufferSize, not separate read/write maxima, so it
+	// is reported for both.
+	return ConnectionInfo{
+		SigningRequired: s.SecurityMode.IsSecuritySignatureRequired(),
+		MaxReadSize:     s.MaxBufferSize,
+		MaxWriteSize:    s.MaxBufferSize,
+	}
+}
+
 func (b *smb1Backend) Login(creds *credentials.Credentials) error {
 	return b.engine.SessionSetup(creds)
 }

--- a/network/smb/client/adapter_smb2.go
+++ b/network/smb/client/adapter_smb2.go
@@ -31,6 +31,15 @@ func newSMB2Backend(engine *smb2.Client) *smb2Backend {
 
 func (b *smb2Backend) Dialect() smb.SMBProtocolVersion { return b.dialect }
 
+func (b *smb2Backend) ConnectionInfo() ConnectionInfo {
+	s := b.engine.Connection.Server
+	return ConnectionInfo{
+		SigningRequired: s.SecurityMode.IsSigningRequired(),
+		MaxReadSize:     s.MaxReadSize,
+		MaxWriteSize:    s.MaxWriteSize,
+	}
+}
+
 func (b *smb2Backend) Login(creds *credentials.Credentials) error {
 	return b.engine.SessionSetup(creds)
 }

--- a/network/smb/client/backend.go
+++ b/network/smb/client/backend.go
@@ -18,6 +18,10 @@ type Backend interface {
 	// Dialect reports the negotiated protocol version this backend speaks.
 	Dialect() smb.SMBProtocolVersion
 
+	// ConnectionInfo reports the connection capabilities negotiated with the server
+	// (signing requirement, maximum read/write sizes), normalized across dialects.
+	ConnectionInfo() ConnectionInfo
+
 	// Login authenticates a session with the server.
 	Login(creds *credentials.Credentials) error
 

--- a/network/smb/client/client.go
+++ b/network/smb/client/client.go
@@ -91,6 +91,10 @@ func dialSMB1(ip net.IP, host string, port int, opts Options) (*Client, error) {
 // Dialect reports the negotiated protocol version.
 func (c *Client) Dialect() smb.SMBProtocolVersion { return c.backend.Dialect() }
 
+// ConnectionInfo reports the connection capabilities negotiated with the server:
+// whether signing is required and the maximum read/write sizes.
+func (c *Client) ConnectionInfo() ConnectionInfo { return c.backend.ConnectionInfo() }
+
 // Login authenticates a session with the server.
 func (c *Client) Login(creds *credentials.Credentials) error { return c.backend.Login(creds) }
 

--- a/network/smb/client/filemgmt_test.go
+++ b/network/smb/client/filemgmt_test.go
@@ -11,11 +11,13 @@ import (
 // recordingBackend is a no-op Backend that records the file-management calls the
 // generic Client delegates to it.
 type recordingBackend struct {
-	calls []string
-	args  []string
+	calls    []string
+	args     []string
+	connInfo ConnectionInfo
 }
 
 func (r *recordingBackend) Dialect() smb.SMBProtocolVersion      { return smb.SMB_VERSION_2_0_2 }
+func (r *recordingBackend) ConnectionInfo() ConnectionInfo       { return r.connInfo }
 func (r *recordingBackend) Login(*credentials.Credentials) error { return nil }
 func (r *recordingBackend) TreeConnect(string) error             { return nil }
 func (r *recordingBackend) OpenFile(string, OpenOptions) (FileHandle, error) {
@@ -92,5 +94,15 @@ func TestSMB1WirePath(t *testing.T) {
 		if got := smb1WirePath(in); got != want {
 			t.Errorf("smb1WirePath(%q) = %q, want %q", in, got, want)
 		}
+	}
+}
+
+// TestClientConnectionInfoDelegation verifies Client.ConnectionInfo forwards the
+// backend's negotiated capabilities unchanged.
+func TestClientConnectionInfoDelegation(t *testing.T) {
+	want := ConnectionInfo{SigningRequired: true, MaxReadSize: 0x100000, MaxWriteSize: 0x80000}
+	c := &Client{backend: &recordingBackend{connInfo: want}}
+	if got := c.ConnectionInfo(); got != want {
+		t.Errorf("ConnectionInfo() = %+v, want %+v", got, want)
 	}
 }

--- a/network/smb/client/types.go
+++ b/network/smb/client/types.go
@@ -107,3 +107,16 @@ type FileInfo struct {
 func (fi FileInfo) IsDir() bool {
 	return fi.FileAttributes&fileflags.FILE_ATTRIBUTE_DIRECTORY != 0
 }
+
+// ConnectionInfo holds the connection capabilities negotiated with the server,
+// normalized across dialects. SMB1 negotiates a single MaxBufferSize rather than
+// separate read/write maxima, so on SMB1 both MaxReadSize and MaxWriteSize report
+// that value.
+type ConnectionInfo struct {
+	// SigningRequired reports whether the server requires SMB message signing.
+	SigningRequired bool
+	// MaxReadSize is the largest read the server will accept, in bytes.
+	MaxReadSize uint32
+	// MaxWriteSize is the largest write the server will accept, in bytes.
+	MaxWriteSize uint32
+}


### PR DESCRIPTION
### Linked Issue
`Closes #585`

### Root Cause
The generic, version-agnostic SMB client (`network/smb/client`) exposed no accessor for the connection capabilities negotiated with the server — the signing requirement and the maximum read/write sizes. The SMB2 backend's `Server` struct already stored `SecurityMode`, `MaxReadSize`, and `MaxWriteSize` from the NEGOTIATE response, and the SMB1 `Server` stored `SecurityMode` and `MaxBufferSize`, but the `Backend` interface and `Client` stopped at `Dialect()`/file ops, so a caller holding a `*client.Client` could not read them.

### Fix Description
Adds a dialect-agnostic `ConnectionInfo` accessor:

- New `ConnectionInfo` struct in `types.go`: `{ SigningRequired bool; MaxReadSize, MaxWriteSize uint32 }`.
- `Backend.ConnectionInfo() ConnectionInfo` and a `Client.ConnectionInfo()` pass-through.
- **SMB2 adapter** maps `Server.SecurityMode.IsSigningRequired()`, `Server.MaxReadSize`, `Server.MaxWriteSize`.
- **SMB1 adapter** maps `Server.SecurityMode.IsSecuritySignatureRequired()` and reports `Server.MaxBufferSize` for both read and write, since SMB1 negotiates a single buffer size rather than separate maxima (documented on the struct and in the adapter).

A single struct-returning method was chosen over three separate getters to keep the `Backend` interface lean and the value extensible; the issue lists both as acceptable.

### How Verified
- `go build ./...`, `go vet ./network/smb/client/`, and `go test ./network/smb/client/` pass.
- Unit test `TestClientConnectionInfoDelegation` asserts `Client.ConnectionInfo()` forwards the backend's value unchanged. The underlying `Server` fields are already populated and exercised by the existing live negotiate tests.

### Test Coverage
- **Added:** `TestClientConnectionInfoDelegation` in `network/smb/client/filemgmt_test.go` (plus a `connInfo` field on the test's fake backend).

### Scope of Change
- **Files changed:** `network/smb/client/{types.go, backend.go, client.go, adapter_smb1.go, adapter_smb2.go, filemgmt_test.go}`.
- **Submodule pointer updated:** no.
- **Behavioral changes outside the addition:** none — purely additive.

### Risk and Rollout
Low: one new struct and one new method routed to data the backends already hold. Safe to merge without staged rollout.

### Notes
Unblocks output parity for the `smbclient-ng` `info --server` command (Signing Required / Max read / Max write). The companion server-identity gap (NetBIOS/DNS names, OS version) is addressed separately (#586).