### PR TITLE
Capture and expose server identity from NTLM auth (#586)

### DIFF
--- a/crypto/spnego/server_identity.go
+++ b/crypto/spnego/server_identity.go
@@ -1,0 +1,48 @@
+package spnego
+
+import (
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/avpair"
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/targetinfo"
+	"github.com/TheManticoreProject/Manticore/encoding/utf16"
+)
+
+// ServerIdentity is the server identity advertised in the NTLM CHALLENGE: the
+// NetBIOS and DNS computer/domain names from the TargetInfo AV pairs, and the
+// operating-system version from the CHALLENGE Version field. Individual fields are
+// empty (or zero) when the server did not advertise them.
+type ServerIdentity struct {
+	NetBIOSComputerName string
+	NetBIOSDomainName   string
+	DNSComputerName     string
+	DNSDomainName       string
+	OSVersionMajor      uint8
+	OSVersionMinor      uint8
+	OSVersionBuild      uint16
+}
+
+// ServerIdentity extracts the server identity from the NTLM CHALLENGE processed
+// during authentication. ok is false when no NTLM challenge has been processed yet
+// (for example before CreateAuthenticateTokenFromChallengeToken is called, or for a
+// non-NTLM exchange).
+func (ctx *AuthContext) ServerIdentity() (ServerIdentity, bool) {
+	ch := ctx.NTLMChallenge
+	if ch == nil {
+		return ServerIdentity{}, false
+	}
+
+	var id ServerIdentity
+	// TargetInfo AV pairs carry the NetBIOS/DNS names as (non-NUL-terminated)
+	// UTF-16LE; a missing pair yields a nil slice, which decodes to "".
+	if pairs, err := targetinfo.ParseTargetInfo(ch.TargetInfo); err == nil {
+		id.NetBIOSComputerName = utf16.DecodeUTF16LE(pairs[avpair.MsvAvNbComputerName])
+		id.NetBIOSDomainName = utf16.DecodeUTF16LE(pairs[avpair.MsvAvNbDomainName])
+		id.DNSComputerName = utf16.DecodeUTF16LE(pairs[avpair.MsvAvDnsComputerName])
+		id.DNSDomainName = utf16.DecodeUTF16LE(pairs[avpair.MsvAvDnsDomainName])
+	}
+	if ch.Version != nil {
+		id.OSVersionMajor = ch.Version.ProductMajorVersion
+		id.OSVersionMinor = ch.Version.ProductMinorVersion
+		id.OSVersionBuild = ch.Version.ProductBuild
+	}
+	return id, true
+}

--- a/crypto/spnego/server_identity_test.go
+++ b/crypto/spnego/server_identity_test.go
@@ -1,0 +1,61 @@
+package spnego_test
+
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/crypto/spnego"
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/avpair"
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/message/challenge"
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/version"
+	"github.com/TheManticoreProject/Manticore/encoding/utf16"
+)
+
+// avPair marshals one TargetInfo AV pair (UTF-16LE value).
+func avPair(t *testing.T, id avpair.AvId, value string) []byte {
+	t.Helper()
+	data := utf16.EncodeUTF16LE(value)
+	p := avpair.AvPair{AvID: id, AvLen: uint16(len(data)), AvData: data}
+	b, err := p.Marshal()
+	if err != nil {
+		t.Fatalf("marshal AV pair %v: %v", id, err)
+	}
+	return b
+}
+
+func TestAuthContextServerIdentity(t *testing.T) {
+	// Build a TargetInfo blob with the four name pairs, terminated by MsvAvEOL.
+	var ti []byte
+	ti = append(ti, avPair(t, avpair.MsvAvNbComputerName, "SRV01")...)
+	ti = append(ti, avPair(t, avpair.MsvAvNbDomainName, "CORP")...)
+	ti = append(ti, avPair(t, avpair.MsvAvDnsComputerName, "srv01.corp.local")...)
+	ti = append(ti, avPair(t, avpair.MsvAvDnsDomainName, "corp.local")...)
+	ti = append(ti, avPair(t, avpair.MsvAvEOL, "")...)
+
+	ctx := &spnego.AuthContext{
+		NTLMChallenge: &challenge.ChallengeMessage{
+			TargetInfo: ti,
+			Version:    &version.Version{ProductMajorVersion: 10, ProductMinorVersion: 0, ProductBuild: 19041},
+		},
+	}
+
+	id, ok := ctx.ServerIdentity()
+	if !ok {
+		t.Fatal("ServerIdentity ok = false, want true")
+	}
+	if id.NetBIOSComputerName != "SRV01" || id.NetBIOSDomainName != "CORP" {
+		t.Errorf("NetBIOS names = %q / %q, want SRV01 / CORP", id.NetBIOSComputerName, id.NetBIOSDomainName)
+	}
+	if id.DNSComputerName != "srv01.corp.local" || id.DNSDomainName != "corp.local" {
+		t.Errorf("DNS names = %q / %q, want srv01.corp.local / corp.local", id.DNSComputerName, id.DNSDomainName)
+	}
+	if id.OSVersionMajor != 10 || id.OSVersionMinor != 0 || id.OSVersionBuild != 19041 {
+		t.Errorf("OS version = %d.%d.%d, want 10.0.19041", id.OSVersionMajor, id.OSVersionMinor, id.OSVersionBuild)
+	}
+}
+
+func TestAuthContextServerIdentityNoChallenge(t *testing.T) {
+	ctx := &spnego.AuthContext{}
+	if _, ok := ctx.ServerIdentity(); ok {
+		t.Error("ServerIdentity ok = true with no challenge, want false")
+	}
+}

--- a/network/smb/client/adapter_smb1.go
+++ b/network/smb/client/adapter_smb1.go
@@ -38,6 +38,19 @@ func (b *smb1Backend) Login(creds *credentials.Credentials) error {
 	return b.engine.SessionSetup(creds)
 }
 
+func (b *smb1Backend) ServerIdentity() ServerIdentity {
+	s := b.engine.Connection.Server
+	return ServerIdentity{
+		NetBIOSComputerName: s.NetBIOSComputerName,
+		NetBIOSDomainName:   s.NetBIOSDomainName,
+		DNSComputerName:     s.DNSComputerName,
+		DNSDomainName:       s.DNSDomainName,
+		OSVersionMajor:      s.OSVersionMajor,
+		OSVersionMinor:      s.OSVersionMinor,
+		OSVersionBuild:      s.OSVersionBuild,
+	}
+}
+
 func (b *smb1Backend) TreeConnect(share string) error {
 	return b.engine.TreeConnect(share)
 }

--- a/network/smb/client/adapter_smb2.go
+++ b/network/smb/client/adapter_smb2.go
@@ -44,6 +44,19 @@ func (b *smb2Backend) Login(creds *credentials.Credentials) error {
 	return b.engine.SessionSetup(creds)
 }
 
+func (b *smb2Backend) ServerIdentity() ServerIdentity {
+	s := b.engine.Connection.Server
+	return ServerIdentity{
+		NetBIOSComputerName: s.NetBIOSComputerName,
+		NetBIOSDomainName:   s.NetBIOSDomainName,
+		DNSComputerName:     s.DNSComputerName,
+		DNSDomainName:       s.DNSDomainName,
+		OSVersionMajor:      s.OSVersionMajor,
+		OSVersionMinor:      s.OSVersionMinor,
+		OSVersionBuild:      s.OSVersionBuild,
+	}
+}
+
 func (b *smb2Backend) TreeConnect(share string) error {
 	return b.engine.TreeConnect(share)
 }

--- a/network/smb/client/backend.go
+++ b/network/smb/client/backend.go
@@ -25,6 +25,11 @@ type Backend interface {
 	// Login authenticates a session with the server.
 	Login(creds *credentials.Credentials) error
 
+	// ServerIdentity reports the server identity (NetBIOS/DNS names, OS version)
+	// learned during authentication. It is meaningful only after a successful Login;
+	// fields are empty/zero otherwise or when the server did not advertise them.
+	ServerIdentity() ServerIdentity
+
 	// TreeConnect connects to a share by name (e.g. "C$"), making it the current
 	// tree for subsequent file operations. The backend forms the full UNC path.
 	TreeConnect(share string) error

--- a/network/smb/client/client.go
+++ b/network/smb/client/client.go
@@ -98,6 +98,10 @@ func (c *Client) ConnectionInfo() ConnectionInfo { return c.backend.ConnectionIn
 // Login authenticates a session with the server.
 func (c *Client) Login(creds *credentials.Credentials) error { return c.backend.Login(creds) }
 
+// ServerIdentity reports the server identity (NetBIOS/DNS computer and domain
+// names, OS version) advertised during NTLM authentication. Call it after Login.
+func (c *Client) ServerIdentity() ServerIdentity { return c.backend.ServerIdentity() }
+
 // TreeConnect connects to a share by name (e.g. "C$"), making it the current tree.
 func (c *Client) TreeConnect(share string) error { return c.backend.TreeConnect(share) }
 

--- a/network/smb/client/filemgmt_test.go
+++ b/network/smb/client/filemgmt_test.go
@@ -14,10 +14,12 @@ type recordingBackend struct {
 	calls    []string
 	args     []string
 	connInfo ConnectionInfo
+	identity ServerIdentity
 }
 
 func (r *recordingBackend) Dialect() smb.SMBProtocolVersion      { return smb.SMB_VERSION_2_0_2 }
 func (r *recordingBackend) ConnectionInfo() ConnectionInfo       { return r.connInfo }
+func (r *recordingBackend) ServerIdentity() ServerIdentity       { return r.identity }
 func (r *recordingBackend) Login(*credentials.Credentials) error { return nil }
 func (r *recordingBackend) TreeConnect(string) error             { return nil }
 func (r *recordingBackend) OpenFile(string, OpenOptions) (FileHandle, error) {
@@ -104,5 +106,23 @@ func TestClientConnectionInfoDelegation(t *testing.T) {
 	c := &Client{backend: &recordingBackend{connInfo: want}}
 	if got := c.ConnectionInfo(); got != want {
 		t.Errorf("ConnectionInfo() = %+v, want %+v", got, want)
+	}
+}
+
+// TestClientServerIdentityDelegation verifies Client.ServerIdentity forwards the
+// backend's captured identity unchanged.
+func TestClientServerIdentityDelegation(t *testing.T) {
+	want := ServerIdentity{
+		NetBIOSComputerName: "FILESRV",
+		NetBIOSDomainName:   "CORP",
+		DNSComputerName:     "filesrv.corp.example",
+		DNSDomainName:       "corp.example",
+		OSVersionMajor:      10,
+		OSVersionMinor:      0,
+		OSVersionBuild:      17763,
+	}
+	c := &Client{backend: &recordingBackend{identity: want}}
+	if got := c.ServerIdentity(); got != want {
+		t.Errorf("ServerIdentity() = %+v, want %+v", got, want)
 	}
 }

--- a/network/smb/client/types.go
+++ b/network/smb/client/types.go
@@ -120,3 +120,17 @@ type ConnectionInfo struct {
 	// MaxWriteSize is the largest write the server will accept, in bytes.
 	MaxWriteSize uint32
 }
+
+// ServerIdentity is the server identity learned during NTLM authentication: the
+// NetBIOS and DNS computer/domain names advertised in the CHALLENGE TargetInfo,
+// and the OS version from the CHALLENGE Version field. Fields are empty/zero when
+// the server did not advertise them or when authentication has not occurred.
+type ServerIdentity struct {
+	NetBIOSComputerName string
+	NetBIOSDomainName   string
+	DNSComputerName     string
+	DNSDomainName       string
+	OSVersionMajor      uint8
+	OSVersionMinor      uint8
+	OSVersionBuild      uint16
+}

--- a/network/smb/smb_v10/client/client_structures.go
+++ b/network/smb/smb_v10/client/client_structures.go
@@ -133,4 +133,15 @@ type Server struct {
 
 	// ServerGUID is the GUID of the server
 	ServerGUID guid.GUID
+
+	// Server identity advertised in the NTLM CHALLENGE during the extended-security
+	// session setup: the NetBIOS/DNS computer and domain names and the OS version.
+	// Populated by SessionSetup; empty/zero before authentication.
+	NetBIOSComputerName string
+	NetBIOSDomainName   string
+	DNSComputerName     string
+	DNSDomainName       string
+	OSVersionMajor      uint8
+	OSVersionMinor      uint8
+	OSVersionBuild      uint16
 }

--- a/network/smb/smb_v10/client/session.go
+++ b/network/smb/smb_v10/client/session.go
@@ -321,6 +321,19 @@ func (s *Session) SessionSetup() error {
 		return fmt.Errorf("failed to process challenge token: %v", err)
 	}
 
+	// Retain the server identity (NetBIOS/DNS names, OS version) advertised in the
+	// NTLM CHALLENGE so callers can read it after authentication.
+	if id, ok := authCtx.ServerIdentity(); ok {
+		srv := s.Client.Connection.Server
+		srv.NetBIOSComputerName = id.NetBIOSComputerName
+		srv.NetBIOSDomainName = id.NetBIOSDomainName
+		srv.DNSComputerName = id.DNSComputerName
+		srv.DNSDomainName = id.DNSDomainName
+		srv.OSVersionMajor = id.OSVersionMajor
+		srv.OSVersionMinor = id.OSVersionMinor
+		srv.OSVersionBuild = id.OSVersionBuild
+	}
+
 	sessionSetupStep2Cmd.SecurityBlob = authenticateToken
 
 	requestStep2Msg.AddCommand(sessionSetupStep2Cmd)

--- a/network/smb/smb_v20/client/client_structures.go
+++ b/network/smb/smb_v20/client/client_structures.go
@@ -115,6 +115,17 @@ type Server struct {
 	// SecurityBuffer is the GSS (SPNEGO) token returned in the NEGOTIATE response,
 	// used to seed authentication.
 	SecurityBuffer []byte
+
+	// Server identity advertised in the NTLM CHALLENGE during authentication: the
+	// NetBIOS/DNS computer and domain names and the OS version. Populated by
+	// SessionSetup; empty/zero before a successful authentication.
+	NetBIOSComputerName string
+	NetBIOSDomainName   string
+	DNSComputerName     string
+	DNSDomainName       string
+	OSVersionMajor      uint8
+	OSVersionMinor      uint8
+	OSVersionBuild      uint16
 }
 
 // Session represents an authenticated SMB2 session.

--- a/network/smb/smb_v20/client/session.go
+++ b/network/smb/smb_v20/client/session.go
@@ -162,6 +162,19 @@ func (c *Client) SessionSetup(creds *credentials.Credentials) error {
 	// server enables or requires it.
 	session.SigningActive = serverMode.IsSigningEnabled() || serverMode.IsSigningRequired()
 
+	// Retain the server identity (NetBIOS/DNS names, OS version) advertised in the
+	// NTLM CHALLENGE so callers can read it after authentication.
+	if id, ok := authCtx.ServerIdentity(); ok {
+		srv := c.Connection.Server
+		srv.NetBIOSComputerName = id.NetBIOSComputerName
+		srv.NetBIOSDomainName = id.NetBIOSDomainName
+		srv.DNSComputerName = id.DNSComputerName
+		srv.DNSDomainName = id.DNSDomainName
+		srv.OSVersionMajor = id.OSVersionMajor
+		srv.OSVersionMinor = id.OSVersionMinor
+		srv.OSVersionBuild = id.OSVersionBuild
+	}
+
 	if c.Connection.SessionTable == nil {
 		c.Connection.SessionTable = make(map[uint64]*Session)
 	}


### PR DESCRIPTION
### Linked Issue
`Closes #586`

### Root Cause
The server identity advertised during NTLM authentication — NetBIOS computer/domain names, DNS computer/domain names, and the OS version — is present in the NTLM CHALLENGE (`TargetInfo` AV pairs and the `Version` field), which the SPNEGO `AuthContext` already retains as `NTLMChallenge` after processing. But neither the SMB1 nor SMB2 session-setup path read it back, no `Server`/`Session` field stored it, and the generic `network/smb/client` exposed no accessor — so the identity was parsed and then dropped, unreachable after `Login`.

### Fix Description
Retains the identity at authentication time and surfaces it through the generic client:

1. **`crypto/spnego`** — new `AuthContext.ServerIdentity() (ServerIdentity, bool)` extracts the four NetBIOS/DNS names from the CHALLENGE `TargetInfo` AV pairs (`MsvAvNb/DnsComputerName`, `MsvAvNb/DnsDomainName`) and the OS version from the CHALLENGE `Version`. Centralizing extraction here keeps both engines from duplicating it; `ok` is false when no NTLM challenge was processed.
2. **`smb_v10` / `smb_v20` `Server` structs** — add the identity fields; both `SessionSetup` paths populate them from `authCtx.ServerIdentity()` after the challenge is processed.
3. **`network/smb/client`** — new `ServerIdentity` struct, `Backend.ServerIdentity()`, and `Client.ServerIdentity()`; each adapter maps its engine's `Server` fields, so the identity is available dialect-agnostically after `Login`.

### How Verified
- `go build ./...`, `go vet`, and `go test ./crypto/spnego/ ./network/smb/client/ ./network/smb/smb_v10/client/ ./network/smb/smb_v20/client/` all pass.
- **Live (Windows Server 2016, 192.168.1.31, over SMB 2.0.2 via the generic client):** `ServerIdentity()` returned NetBIOS `TMP-W-2016` / `TMP-W-20160`, DNS `TMP-W-2016.TMP-W-2016.local` / `TMP-W-2016.local`, and **OS 10.0 build 14393** — the correct NT version for Server 2016.
- Unit tests: `TestAuthContextServerIdentity` builds a CHALLENGE with known TargetInfo + Version and asserts extraction (plus a no-challenge case); `TestClientServerIdentityDelegation` asserts the `Client` forwards the backend value.

### Test Coverage
- **Added:** `crypto/spnego/server_identity_test.go` (`TestAuthContextServerIdentity`, `TestAuthContextServerIdentityNoChallenge`); `TestClientServerIdentityDelegation` in `network/smb/client/filemgmt_test.go` (with an `identity` field on the fake backend).

### Scope of Change
- **Files changed:** `crypto/spnego/{server_identity.go (new), server_identity_test.go (new)}`; `network/smb/smb_v10/client/{client_structures.go, session.go}`; `network/smb/smb_v20/client/{client_structures.go, session.go}`; `network/smb/client/{types.go, backend.go, client.go, adapter_smb1.go, adapter_smb2.go, filemgmt_test.go}`.
- **Submodule pointer updated:** no.
- **Behavioral changes outside the addition:** none — the new fields are populated during session setup and read only through the new accessor; the authentication exchange itself is unchanged.

### Risk and Rollout
Low: the change reads already-parsed CHALLENGE data into new fields and adds one accessor; it does not alter the NTLM exchange or any wire bytes. Safe to merge without staged rollout.

### Notes
Unblocks output parity for the `smbclient-ng` `info --server` command (NetBIOS Hostname/Domain, DNS Hostname/Domain, OS Version). The companion connection-capabilities gap (signing, max read/write) is addressed separately (#585). Both PRs touch the `Backend` interface and `filemgmt_test.go`'s fake backend, so whichever merges second needs a trivial rebase.