### PR TITLE
Expose server OS name and NTLMv2 support on the generic SMB client (#589)

### DIFF
--- a/crypto/spnego/server_identity.go
+++ b/crypto/spnego/server_identity.go
@@ -2,6 +2,7 @@ package spnego
 
 import (
 	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/avpair"
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/message/negotiate/flags"
 	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/targetinfo"
 	"github.com/TheManticoreProject/Manticore/encoding/utf16"
 )
@@ -45,4 +46,15 @@ func (ctx *AuthContext) ServerIdentity() (ServerIdentity, bool) {
 		id.OSVersionBuild = ch.Version.ProductBuild
 	}
 	return id, true
+}
+
+// SupportsExtendedSessionSecurity reports whether the server's NTLM CHALLENGE
+// advertised NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY — i.e. NTLM2 / NTLMv2
+// session security. It returns false when no NTLM challenge has been processed.
+func (ctx *AuthContext) SupportsExtendedSessionSecurity() bool {
+	ch := ctx.NTLMChallenge
+	if ch == nil {
+		return false
+	}
+	return ch.NegotiateFlags.HasFlag(flags.NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY)
 }

--- a/crypto/spnego/server_identity_test.go
+++ b/crypto/spnego/server_identity_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/crypto/spnego"
 	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/avpair"
 	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/message/challenge"
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/message/negotiate/flags"
 	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/version"
 	"github.com/TheManticoreProject/Manticore/encoding/utf16"
 )
@@ -57,5 +58,24 @@ func TestAuthContextServerIdentityNoChallenge(t *testing.T) {
 	ctx := &spnego.AuthContext{}
 	if _, ok := ctx.ServerIdentity(); ok {
 		t.Error("ServerIdentity ok = true with no challenge, want false")
+	}
+}
+
+func TestAuthContextSupportsExtendedSessionSecurity(t *testing.T) {
+	with := &spnego.AuthContext{NTLMChallenge: &challenge.ChallengeMessage{
+		NegotiateFlags: flags.NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY | flags.NTLMSSP_NEGOTIATE_UNICODE,
+	}}
+	if !with.SupportsExtendedSessionSecurity() {
+		t.Error("SupportsExtendedSessionSecurity = false with the flag set, want true")
+	}
+	without := &spnego.AuthContext{NTLMChallenge: &challenge.ChallengeMessage{
+		NegotiateFlags: flags.NTLMSSP_NEGOTIATE_UNICODE,
+	}}
+	if without.SupportsExtendedSessionSecurity() {
+		t.Error("SupportsExtendedSessionSecurity = true without the flag, want false")
+	}
+	none := &spnego.AuthContext{}
+	if none.SupportsExtendedSessionSecurity() {
+		t.Error("SupportsExtendedSessionSecurity = true with no challenge, want false")
 	}
 }

--- a/network/smb/client/adapter_smb1.go
+++ b/network/smb/client/adapter_smb1.go
@@ -31,6 +31,7 @@ func (b *smb1Backend) ConnectionInfo() ConnectionInfo {
 		SigningRequired: s.SecurityMode.IsSecuritySignatureRequired(),
 		MaxReadSize:     s.MaxBufferSize,
 		MaxWriteSize:    s.MaxBufferSize,
+		SupportsNTLMv2:  s.SupportsNTLMv2,
 	}
 }
 
@@ -48,6 +49,7 @@ func (b *smb1Backend) ServerIdentity() ServerIdentity {
 		OSVersionMajor:      s.OSVersionMajor,
 		OSVersionMinor:      s.OSVersionMinor,
 		OSVersionBuild:      s.OSVersionBuild,
+		OSName:              s.OSName,
 	}
 }
 

--- a/network/smb/client/adapter_smb2.go
+++ b/network/smb/client/adapter_smb2.go
@@ -37,6 +37,7 @@ func (b *smb2Backend) ConnectionInfo() ConnectionInfo {
 		SigningRequired: s.SecurityMode.IsSigningRequired(),
 		MaxReadSize:     s.MaxReadSize,
 		MaxWriteSize:    s.MaxWriteSize,
+		SupportsNTLMv2:  s.SupportsNTLMv2,
 	}
 }
 

--- a/network/smb/client/filemgmt_test.go
+++ b/network/smb/client/filemgmt_test.go
@@ -102,7 +102,7 @@ func TestSMB1WirePath(t *testing.T) {
 // TestClientConnectionInfoDelegation verifies Client.ConnectionInfo forwards the
 // backend's negotiated capabilities unchanged.
 func TestClientConnectionInfoDelegation(t *testing.T) {
-	want := ConnectionInfo{SigningRequired: true, MaxReadSize: 0x100000, MaxWriteSize: 0x80000}
+	want := ConnectionInfo{SigningRequired: true, MaxReadSize: 0x100000, MaxWriteSize: 0x80000, SupportsNTLMv2: true}
 	c := &Client{backend: &recordingBackend{connInfo: want}}
 	if got := c.ConnectionInfo(); got != want {
 		t.Errorf("ConnectionInfo() = %+v, want %+v", got, want)
@@ -117,6 +117,7 @@ func TestClientServerIdentityDelegation(t *testing.T) {
 		NetBIOSDomainName:   "CORP",
 		DNSComputerName:     "filesrv.corp.example",
 		DNSDomainName:       "corp.example",
+		OSName:              "Windows Server 2019",
 		OSVersionMajor:      10,
 		OSVersionMinor:      0,
 		OSVersionBuild:      17763,

--- a/network/smb/client/types.go
+++ b/network/smb/client/types.go
@@ -119,6 +119,9 @@ type ConnectionInfo struct {
 	MaxReadSize uint32
 	// MaxWriteSize is the largest write the server will accept, in bytes.
 	MaxWriteSize uint32
+	// SupportsNTLMv2 reports whether the server advertised NTLM2 / extended session
+	// security (NTLMv2) in its NTLM CHALLENGE. Meaningful only after Login.
+	SupportsNTLMv2 bool
 }
 
 // ServerIdentity is the server identity learned during NTLM authentication: the
@@ -133,4 +136,8 @@ type ServerIdentity struct {
 	OSVersionMajor      uint8
 	OSVersionMinor      uint8
 	OSVersionBuild      uint16
+	// OSName is the server's native OS string from the SMB1 SESSION_SETUP response.
+	// It is populated for SMB1 only; SMB2/SMB3 do not transmit an OS name on the wire
+	// (use the OSVersion* fields there).
+	OSName string
 }

--- a/network/smb/smb_v10/client/client_structures.go
+++ b/network/smb/smb_v10/client/client_structures.go
@@ -3,9 +3,9 @@ package client
 import (
 	"net"
 
+	"github.com/TheManticoreProject/Manticore/network/smb/common/transport"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/capabilities"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/securitymode"
-	"github.com/TheManticoreProject/Manticore/network/smb/common/transport"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
 	"github.com/TheManticoreProject/Manticore/windows/guid"
 )
@@ -144,4 +144,12 @@ type Server struct {
 	OSVersionMajor      uint8
 	OSVersionMinor      uint8
 	OSVersionBuild      uint16
+
+	// OSName is the server's native operating-system string from the SESSION_SETUP
+	// response (NativeOS). SMB1 only; populated by SessionSetup.
+	OSName string
+
+	// SupportsNTLMv2 reports whether the server's NTLM CHALLENGE advertised
+	// extended session security (NTLM2 / NTLMv2). Populated by SessionSetup.
+	SupportsNTLMv2 bool
 }

--- a/network/smb/smb_v10/client/session.go
+++ b/network/smb/smb_v10/client/session.go
@@ -6,6 +6,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/crypto/spnego"
 	spnego_ntlm_negotiate_flags "github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/message/negotiate/flags"
 	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/version"
+	"github.com/TheManticoreProject/Manticore/encoding/utf16"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/capabilities"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
@@ -13,7 +14,6 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header/flags"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header/flags2"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
-	"github.com/TheManticoreProject/Manticore/encoding/utf16"
 	"github.com/TheManticoreProject/Manticore/windows/credentials"
 	"github.com/TheManticoreProject/Manticore/windows/nt_status"
 )
@@ -333,6 +333,7 @@ func (s *Session) SessionSetup() error {
 		srv.OSVersionMinor = id.OSVersionMinor
 		srv.OSVersionBuild = id.OSVersionBuild
 	}
+	s.Client.Connection.Server.SupportsNTLMv2 = authCtx.SupportsExtendedSessionSecurity()
 
 	sessionSetupStep2Cmd.SecurityBlob = authenticateToken
 
@@ -382,7 +383,7 @@ func (s *Session) SessionSetup() error {
 		return fmt.Errorf("unexpected response command: %d", authResponseMsg.Header.Command)
 	}
 
-	_, ok := authResponseMsg.Command.(*commands.SessionSetupAndxResponse)
+	authResponse, ok := authResponseMsg.Command.(*commands.SessionSetupAndxResponse)
 	if !ok {
 		return fmt.Errorf("failed to cast response command to SessionSetupAndxResponse")
 	}
@@ -393,6 +394,15 @@ func (s *Session) SessionSetup() error {
 		} else {
 			return fmt.Errorf("session setup failed: 0x%08x", authResponseMsg.Header.Status)
 		}
+	}
+
+	// Retain the server's native OS string from the SESSION_SETUP response. The final
+	// (AUTHENTICATE) response is authoritative; fall back to the challenge response if
+	// the server only populated it there.
+	if osName := authResponse.NativeOSString(); osName != "" {
+		s.Client.Connection.Server.OSName = osName
+	} else if osName := challengeResponse.NativeOSString(); osName != "" {
+		s.Client.Connection.Server.OSName = osName
 	}
 
 	// Persist the derived session key and, when signing was activated, verify the

--- a/network/smb/smb_v10/message/commands/SessionSetupAndxResponse.go
+++ b/network/smb/smb_v10/message/commands/SessionSetupAndxResponse.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"fmt"
 
+	"github.com/TheManticoreProject/Manticore/encoding/utf16"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/andx"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/codes"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/command_interface"
@@ -75,6 +76,16 @@ func NewSessionSetupAndxResponse() *SessionSetupAndxResponse {
 	c.Command.SetCommandCode(codes.SMB_COM_SESSION_SETUP_ANDX)
 
 	return c
+}
+
+// NativeOSString returns the server's NativeOS as a Go string, decoding it from
+// UTF-16LE when the response used Unicode (SMB_FLAGS2_UNICODE) and from raw OEM
+// bytes otherwise. NativeOS is stored as the wire bytes up to its NUL terminator.
+func (c *SessionSetupAndxResponse) NativeOSString() string {
+	if c.IsUnicode() {
+		return utf16.DecodeUTF16LE(c.NativeOS)
+	}
+	return string(c.NativeOS)
 }
 
 // IsAndX returns true if the command is an AndX

--- a/network/smb/smb_v20/client/client_structures.go
+++ b/network/smb/smb_v20/client/client_structures.go
@@ -126,6 +126,10 @@ type Server struct {
 	OSVersionMajor      uint8
 	OSVersionMinor      uint8
 	OSVersionBuild      uint16
+
+	// SupportsNTLMv2 reports whether the server's NTLM CHALLENGE advertised
+	// extended session security (NTLM2 / NTLMv2). Populated by SessionSetup.
+	SupportsNTLMv2 bool
 }
 
 // Session represents an authenticated SMB2 session.

--- a/network/smb/smb_v20/client/session.go
+++ b/network/smb/smb_v20/client/session.go
@@ -174,6 +174,7 @@ func (c *Client) SessionSetup(creds *credentials.Credentials) error {
 		srv.OSVersionMinor = id.OSVersionMinor
 		srv.OSVersionBuild = id.OSVersionBuild
 	}
+	c.Connection.Server.SupportsNTLMv2 = authCtx.SupportsExtendedSessionSecurity()
 
 	if c.Connection.SessionTable == nil {
 		c.Connection.SessionTable = make(map[uint64]*Session)


### PR DESCRIPTION
### Linked Issue
`Closes #589`

### Root Cause
Two attributes carried in the SMB/NTLM handshake were parsed and then dropped, with no accessor on the generic `network/smb/client`:
- The SMB1 SESSION_SETUP response decodes the server's `NativeOS` string, but the session-setup flow only consumed the `SecurityBlob` and never stored `NativeOS`.
- The NTLM CHALLENGE's `NegotiateFlags` are available at auth time, but nothing checked `NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY` (NTLMv2 / extended session security) or surfaced it.

So after `Login`, neither the server OS name nor its NTLMv2 support was reachable. This follows #585 (connection capabilities) and #586 (server identity).

### Fix Description
Capture both during the handshake and expose them through the existing dialect-agnostic structs:

- **`crypto/spnego`** — `AuthContext.SupportsExtendedSessionSecurity()` reads the processed CHALLENGE's `NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY` flag (false if no challenge).
- **`smb_v10`** — `SessionSetupAndxResponse.NativeOSString()` decodes `NativeOS` (UTF-16LE when the response is Unicode, OEM otherwise, both stored as wire bytes to the NUL). `SessionSetup` records `OSName` (from the authoritative AUTHENTICATE response, falling back to the challenge response) and `SupportsNTLMv2` on `Server`.
- **`smb_v20`** — `SessionSetup` records `SupportsNTLMv2` on `Server` (SMB2 transmits no server OS name).
- **`network/smb/client`** — add `ConnectionInfo.SupportsNTLMv2` and `ServerIdentity.OSName`, mapped by each adapter. `OSName` is populated for SMB1 only; for SMB2/3 it is empty and the `OSVersion*` fields (from #586) carry the version.

### How Verified
- `go build ./...`, `go vet`, and tests for `crypto/spnego`, `network/smb/client`, `network/smb/smb_v10/...`, `network/smb/smb_v20/client` pass.
- **Live (Windows Server 2016, 192.168.1.31):**
  - over **SMB 2.0.2**: `SupportsNTLMv2=true`, `OSName=""` (not transmitted), `OSVersion=10.0.14393`.
  - over **forced SMB1**: `SupportsNTLMv2=true`, `OSName="Windows Server 2016 Standard Evaluation 14393"`, `OSVersion=10.0.14393`.
- Unit tests: `TestAuthContextSupportsExtendedSessionSecurity` (flag set / unset / no challenge); the existing generic-client delegation tests extended to assert the new `SupportsNTLMv2` and `OSName` fields.

### Test Coverage
- **Added:** `TestAuthContextSupportsExtendedSessionSecurity` in `crypto/spnego/server_identity_test.go`.
- **Existing (extended):** `TestClientConnectionInfoDelegation` and `TestClientServerIdentityDelegation` in `network/smb/client/filemgmt_test.go` now cover the new fields.

### Scope of Change
- **Files changed:** `crypto/spnego/{server_identity.go, server_identity_test.go}`; `network/smb/smb_v10/{message/commands/SessionSetupAndxResponse.go, client/client_structures.go, client/session.go}`; `network/smb/smb_v20/client/{client_structures.go, session.go}`; `network/smb/client/{types.go, adapter_smb1.go, adapter_smb2.go, filemgmt_test.go}`.
- **Submodule pointer updated:** no.
- **Behavioral changes outside the addition:** none — the new fields are populated during session setup and read only through the new accessors; the handshake itself is unchanged.

### Risk and Rollout
Low: reads already-parsed handshake data into new fields and adds two struct fields with no new wire behavior. Safe to merge without staged rollout.

### Notes
Completes the `smbclient-ng` `info --server` field set after #585/#586 ("OS Name" and "Supports NTLMv2"). As the issue notes, the separate "Login Required" (anonymous/guest bind) field is not covered here.