### PR TITLE
Expose security-descriptor query on the generic SMB client (#591)

### DIFF
--- a/network/smb/client/adapter_smb1.go
+++ b/network/smb/client/adapter_smb1.go
@@ -138,6 +138,13 @@ func (b *smb1Backend) ListDirectory(path, pattern string) ([]FileInfo, error) {
 	return out, nil
 }
 
+// QuerySecurityDescriptor is not yet supported on SMB1. The SMB1 security-descriptor
+// query (NT_TRANSACT_QUERY_SECURITY_DESC) is not wired into the engine; callers that
+// need it should negotiate SMB2 or higher.
+func (b *smb1Backend) QuerySecurityDescriptor(path string, info SecurityInformation) ([]byte, error) {
+	return nil, fmt.Errorf("QuerySecurityDescriptor is not supported over SMB1; negotiate SMB2 or higher")
+}
+
 func (b *smb1Backend) DeleteFile(path string) error { return b.engine.DeleteFile(smb1WirePath(path)) }
 
 func (b *smb1Backend) CreateDirectory(path string) error {

--- a/network/smb/client/adapter_smb2.go
+++ b/network/smb/client/adapter_smb2.go
@@ -7,6 +7,7 @@ import (
 	dcerpcsmb2 "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/transport/smb2"
 	"github.com/TheManticoreProject/Manticore/network/smb"
 	smb2 "github.com/TheManticoreProject/Manticore/network/smb/smb_v20/client"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/message/commands"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/types"
 	"github.com/TheManticoreProject/Manticore/windows/credentials"
 	"github.com/TheManticoreProject/Manticore/windows/fileflags"
@@ -129,6 +130,17 @@ func (b *smb2Backend) ListDirectory(path, pattern string) ([]FileInfo, error) {
 		out = append(out, parseBothDirectoryInfo(buf)...)
 	}
 	return out, nil
+}
+
+func (b *smb2Backend) QuerySecurityDescriptor(path string, info SecurityInformation) ([]byte, error) {
+	// Open with READ_CONTROL (the access right required to read a security
+	// descriptor), then QUERY_INFO with the SECURITY info type.
+	fileId, err := b.engine.CreateFile(path, fileflags.READ_CONTROL, fileflags.FILE_SHARE_READ, fileflags.FILE_OPEN, 0)
+	if err != nil {
+		return nil, fmt.Errorf("open %q for security query: %w", path, err)
+	}
+	defer b.engine.CloseFile(fileId)
+	return b.engine.QueryInfo(fileId, commands.SMB2_0_INFO_SECURITY, 0, uint32(info))
 }
 
 func (b *smb2Backend) DeleteFile(path string) error { return b.engine.DeleteFile(path) }

--- a/network/smb/client/backend.go
+++ b/network/smb/client/backend.go
@@ -51,6 +51,12 @@ type Backend interface {
 	// match pattern (e.g. "*").
 	ListDirectory(path, pattern string) ([]FileInfo, error)
 
+	// QuerySecurityDescriptor returns the raw self-relative SECURITY_DESCRIPTOR
+	// bytes for path on the current tree. info selects which parts (owner, group,
+	// DACL, SACL) to retrieve. The bytes can be parsed with
+	// github.com/TheManticoreProject/winacl.
+	QuerySecurityDescriptor(path string, info SecurityInformation) ([]byte, error)
+
 	// DeleteFile deletes a file on the current tree.
 	DeleteFile(path string) error
 

--- a/network/smb/client/client.go
+++ b/network/smb/client/client.go
@@ -128,6 +128,13 @@ func (c *Client) ListDirectory(path, pattern string) ([]FileInfo, error) {
 	return c.backend.ListDirectory(path, pattern)
 }
 
+// QuerySecurityDescriptor returns the raw self-relative SECURITY_DESCRIPTOR bytes
+// for path on the current tree. info selects which parts (owner, group, DACL, SACL)
+// to retrieve; parse the result with github.com/TheManticoreProject/winacl.
+func (c *Client) QuerySecurityDescriptor(path string, info SecurityInformation) ([]byte, error) {
+	return c.backend.QuerySecurityDescriptor(path, info)
+}
+
 // DeleteFile deletes a file on the current tree.
 func (c *Client) DeleteFile(path string) error { return c.backend.DeleteFile(path) }
 

--- a/network/smb/client/filemgmt_test.go
+++ b/network/smb/client/filemgmt_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"bytes"
 	"testing"
 
 	dcerpctransport "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/transport"
@@ -15,6 +16,7 @@ type recordingBackend struct {
 	args     []string
 	connInfo ConnectionInfo
 	identity ServerIdentity
+	sd       []byte
 }
 
 func (r *recordingBackend) Dialect() smb.SMBProtocolVersion      { return smb.SMB_VERSION_2_0_2 }
@@ -29,6 +31,10 @@ func (r *recordingBackend) ReadFile(FileHandle, uint64, uint32) ([]byte, error) 
 func (r *recordingBackend) WriteFile(FileHandle, uint64, []byte) (uint32, error) { return 0, nil }
 func (r *recordingBackend) CloseFile(FileHandle) error                           { return nil }
 func (r *recordingBackend) ListDirectory(string, string) ([]FileInfo, error)     { return nil, nil }
+func (r *recordingBackend) QuerySecurityDescriptor(path string, info SecurityInformation) ([]byte, error) {
+	r.calls, r.args = append(r.calls, "QuerySecurityDescriptor"), append(r.args, path)
+	return r.sd, nil
+}
 func (r *recordingBackend) RPCTransport(string) (dcerpctransport.Transport, error) {
 	return nil, nil
 }
@@ -125,5 +131,23 @@ func TestClientServerIdentityDelegation(t *testing.T) {
 	c := &Client{backend: &recordingBackend{identity: want}}
 	if got := c.ServerIdentity(); got != want {
 		t.Errorf("ServerIdentity() = %+v, want %+v", got, want)
+	}
+}
+
+// TestClientQuerySecurityDescriptorDelegation verifies Client.QuerySecurityDescriptor
+// forwards the path to the backend and returns its bytes unchanged.
+func TestClientQuerySecurityDescriptorDelegation(t *testing.T) {
+	rb := &recordingBackend{sd: []byte{0x01, 0x00, 0x04, 0x80, 0xde, 0xad}}
+	c := &Client{backend: rb}
+
+	got, err := c.QuerySecurityDescriptor("dir\\secret.txt", OwnerSecurityInformation|GroupSecurityInformation|DaclSecurityInformation)
+	if err != nil {
+		t.Fatalf("QuerySecurityDescriptor() error = %v", err)
+	}
+	if !bytes.Equal(got, rb.sd) {
+		t.Errorf("descriptor bytes = %x, want %x", got, rb.sd)
+	}
+	if len(rb.calls) != 1 || rb.calls[0] != "QuerySecurityDescriptor" || rb.args[0] != "dir\\secret.txt" {
+		t.Errorf("backend call = (%v, %v), want one QuerySecurityDescriptor for dir\\secret.txt", rb.calls, rb.args)
 	}
 }

--- a/network/smb/client/types.go
+++ b/network/smb/client/types.go
@@ -141,3 +141,19 @@ type ServerIdentity struct {
 	// (use the OSVersion* fields there).
 	OSName string
 }
+
+// SecurityInformation selects which parts of a SECURITY_DESCRIPTOR a
+// QuerySecurityDescriptor call retrieves. The values are the SECURITY_INFORMATION
+// bits from [MS-DTYP] 2.4.7; combine them with bitwise OR.
+type SecurityInformation uint32
+
+const (
+	// OwnerSecurityInformation requests the owner SID.
+	OwnerSecurityInformation SecurityInformation = 0x00000001
+	// GroupSecurityInformation requests the primary-group SID.
+	GroupSecurityInformation SecurityInformation = 0x00000002
+	// DaclSecurityInformation requests the discretionary ACL.
+	DaclSecurityInformation SecurityInformation = 0x00000004
+	// SaclSecurityInformation requests the system ACL (requires extra privilege).
+	SaclSecurityInformation SecurityInformation = 0x00000008
+)


### PR DESCRIPTION
### Linked Issue
`Closes #591`

### Root Cause
The version-agnostic `network/smb/client` facade exposed `OpenFile`/`ReadFile`/`ListDirectory`/file-management but no way to query a file or directory **security descriptor**, even though the SMB2 engine already supports it (`QueryInfo` with `SMB2_0_INFO_SECURITY`). Consumers that speak only to the facade (so they work across SMB1/2/3, per #528) had to drop down to a concrete engine and re-implement the open/query/close dance, defeating dialect independence.

### Fix Description
Adds `QuerySecurityDescriptor(path string, info SecurityInformation) ([]byte, error)` to the `Backend` interface and a `Client` pass-through, returning the raw self-relative `SECURITY_DESCRIPTOR` bytes (parseable with `github.com/TheManticoreProject/winacl`).

- New `SecurityInformation` bitfield in `types.go` with the `[MS-DTYP] 2.4.7` bits (`Owner`/`Group`/`Dacl`/`Sacl SecurityInformation`).
- **SMB2 adapter:** `CreateFile(path, READ_CONTROL, FILE_SHARE_READ, FILE_OPEN, 0)` → `QueryInfo(fileId, SMB2_0_INFO_SECURITY, 0, uint32(info))` → `CloseFile` (deferred). Returns the raw output buffer.
- **SMB1 adapter:** returns a clear "not supported over SMB1; negotiate SMB2 or higher" error — the SMB1 engine does not yet wire `NT_TRANSACT_QUERY_SECURITY_DESC`. The issue explicitly permits this for now.

Raw `[]byte` was chosen over a typed result per the issue (consumers parse with `winacl`); a typed wrapper can be layered on later without changing this method.

### How Verified
- `go build ./...`, `go vet ./network/smb/client/`, and `go test ./network/smb/client/ ./network/smb/smb_v20/client/` pass.
- **Live (Windows Server 2016, 192.168.1.31, SMB 2.0.2):** `QuerySecurityDescriptor("Windows\\win.ini", Owner|Group|Dacl)` returned a 168-byte self-relative descriptor with a valid header (`revision=0x01`, control `0x8404` = SE_SELF_RELATIVE | SE_DACL_PRESENT).
- Unit test drives `Client.QuerySecurityDescriptor` through a fake backend and asserts the path is forwarded and the bytes returned unchanged.

### Test Coverage
- **Added:** `TestClientQuerySecurityDescriptorDelegation` in `network/smb/client/filemgmt_test.go` (with an `sd` field + method on the fake backend).

### Scope of Change
- **Files changed:** `network/smb/client/{types.go, backend.go, client.go, adapter_smb1.go, adapter_smb2.go, filemgmt_test.go}`.
- **Submodule pointer updated:** no.
- **Behavioral changes outside the addition:** none — purely additive.

### Risk and Rollout
Low: one new method routed to the existing SMB2 `QueryInfo`, plus a new bitfield type. SMB1 returns an error rather than silently misbehaving. Safe to merge without staged rollout.

### Notes
Unblocks the parked `acls` command in smbclient-ng. A matching `SetSecurityDescriptor` (the SMB2 engine already has `SetInfo`) is a natural follow-up but is not required for the read-only `acls` use case.