### PR TITLE
Add NDR64 transfer-syntax plumbing to the NDR codec (#400)

### DIFF
--- a/network/dcerpc/ndr/codec.go
+++ b/network/dcerpc/ndr/codec.go
@@ -6,8 +6,14 @@
 // primitive encoding; the reflection walker in marshal.go drives it from struct tags
 // so callers can declare an RPC call as a Go struct (see Call, Marshal, Unmarshal).
 //
-// Scope: NDR20, little-endian (the standard Windows data representation, DREP 0x10).
-// Big-endian and NDR64 (8-byte counts/referents) are out of scope.
+// The codec is transfer-syntax aware: an Encoder/Decoder carries a Syntax (NDR20 or
+// NDR64) that governs the width and alignment of NDR counts and referent ids (4 octets
+// 4-aligned for NDR20, 8 octets 8-aligned for NDR64; [MS-RPCE] section 2.2.5). Scalar
+// primitives keep their natural width in both syntaxes. The declarative walker
+// (Marshal/Unmarshal) and the v5 client still default to NDR20; the NDR64 path is being
+// introduced incrementally and is reachable through NewEncoderForSyntax/
+// NewDecoderForSyntax. Both syntaxes are little-endian (the standard Windows data
+// representation, DREP 0x10); big-endian is out of scope.
 //
 // References:
 //   - [C706] DCE 1.1: RPC, Chapter 14 "Transfer Syntax NDR":
@@ -35,21 +41,50 @@ type Marshaler interface {
 	UnmarshalNDR(*Decoder) error
 }
 
+// Syntax selects the NDR transfer syntax an Encoder/Decoder operates under. It governs
+// the on-the-wire width and alignment of NDR counts (maximum_count, offset,
+// actual_count) and referent ids, which differ between the two syntaxes ([MS-RPCE]
+// section 2.2.5). NDR20 is the zero value, so an Encoder/Decoder built without an
+// explicit syntax behaves as the classic NDR 2.0 codec.
+type Syntax int
+
+const (
+	// NDR20 is NDR transfer syntax version 2.0: 4-octet counts and referent ids.
+	NDR20 Syntax = iota
+	// NDR64 is the NDR64 transfer syntax: 8-octet counts and referent ids.
+	NDR64
+)
+
+// String returns the syntax name for diagnostics.
+func (s Syntax) String() string {
+	if s == NDR64 {
+		return "NDR64"
+	}
+	return "NDR20"
+}
+
 // Encoder builds an NDR octet stream. Alignment is computed relative to the start of
 // the stream, as required by [C706] section 14.2.2.
 type Encoder struct {
 	buf     []byte
-	nextRef uint32
+	nextRef uint64
+	syntax  Syntax
 }
 
 // firstReferentID is the referent id assigned to the first non-null pointer. The
 // exact value is irrelevant on the wire (a receiver only checks non-null for
 // unique/full pointers); an arbitrary non-zero base matching common implementations
 // is used.
-const firstReferentID uint32 = 0x00020000
+const firstReferentID uint64 = 0x00020000
 
-// NewEncoder returns an empty encoder.
+// NewEncoder returns an empty encoder for the NDR20 transfer syntax.
 func NewEncoder() *Encoder { return &Encoder{nextRef: firstReferentID} }
+
+// NewEncoderForSyntax returns an empty encoder for the given transfer syntax.
+func NewEncoderForSyntax(s Syntax) *Encoder { return &Encoder{nextRef: firstReferentID, syntax: s} }
+
+// Syntax reports the transfer syntax the encoder operates under.
+func (e *Encoder) Syntax() Syntax { return e.syntax }
 
 // Bytes returns the accumulated octet stream.
 func (e *Encoder) Bytes() []byte { return e.buf }
@@ -92,10 +127,37 @@ func (e *Encoder) WriteUint64(v uint64) {
 	e.buf = binary.LittleEndian.AppendUint64(e.buf, v)
 }
 
-// nextReferent returns the next referent id for a non-null pointer.
-func (e *Encoder) nextReferent() uint32 {
+// writeCount writes an NDR count or length determinant — a maximum_count, offset, or
+// actual_count — as a 4-octet value 4-aligned under NDR20, or an 8-octet value
+// 8-aligned under NDR64 ([MS-RPCE] section 2.2.5). Counts are non-negative, so a uint64
+// carries either width.
+func (e *Encoder) writeCount(v uint64) {
+	if e.syntax == NDR64 {
+		e.WriteUint64(v)
+		return
+	}
+	e.WriteUint32(uint32(v))
+}
+
+// writeReferent writes a pointer referent id at the syntax's referent width: 4 octets
+// under NDR20, 8 octets under NDR64.
+func (e *Encoder) writeReferent(id uint64) {
+	if e.syntax == NDR64 {
+		e.WriteUint64(id)
+		return
+	}
+	e.WriteUint32(uint32(id))
+}
+
+// nextReferent returns the next referent id for a non-null pointer, advancing by the
+// syntax's referent width.
+func (e *Encoder) nextReferent() uint64 {
 	id := e.nextRef
-	e.nextRef += 4
+	if e.syntax == NDR64 {
+		e.nextRef += 8
+	} else {
+		e.nextRef += 4
+	}
 	return id
 }
 
@@ -105,10 +167,10 @@ func (e *Encoder) nextReferent() uint32 {
 // https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/db6a89db-2c88-4ae7-90de-fca23929abab
 func (e *Encoder) writeWString(s string) {
 	units := utf16.EncodeUTF16LE(s) // 2 octets per code unit, no terminator
-	count := uint32(len(units)/2) + 1
-	e.WriteUint32(count) // maximum_count
-	e.WriteUint32(0)     // offset
-	e.WriteUint32(count) // actual_count
+	count := uint64(len(units)/2) + 1
+	e.writeCount(count) // maximum_count
+	e.writeCount(0)     // offset
+	e.writeCount(count) // actual_count
 	e.WriteBytes(units)
 	e.WriteUint16(0) // NUL terminator
 }
@@ -116,10 +178,10 @@ func (e *Encoder) writeWString(s string) {
 // writeAString writes a char string ([string]) as a conformant+varying array of
 // octets. The counts include the NUL terminator.
 func (e *Encoder) writeAString(s string) {
-	count := uint32(len(s)) + 1
-	e.WriteUint32(count) // maximum_count
-	e.WriteUint32(0)     // offset
-	e.WriteUint32(count) // actual_count
+	count := uint64(len(s)) + 1
+	e.writeCount(count) // maximum_count
+	e.writeCount(0)     // offset
+	e.writeCount(count) // actual_count
 	e.WriteBytes([]byte(s))
 	e.WriteUint8(0) // NUL terminator
 }
@@ -128,19 +190,26 @@ func (e *Encoder) writeAString(s string) {
 // elements ([MS-RPCE] Conformant Arrays:
 // https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/140b01a3-979b-43af-b1e3-28f248db8f03).
 func (e *Encoder) writeConformantBytes(b []byte) {
-	e.WriteUint32(uint32(len(b)))
+	e.writeCount(uint64(len(b)))
 	e.WriteBytes(b)
 }
 
 // Decoder reads an NDR octet stream produced under the little-endian data
 // representation.
 type Decoder struct {
-	data []byte
-	pos  int
+	data   []byte
+	pos    int
+	syntax Syntax
 }
 
-// NewDecoder returns a decoder over data.
+// NewDecoder returns a decoder over data for the NDR20 transfer syntax.
 func NewDecoder(data []byte) *Decoder { return &Decoder{data: data} }
+
+// NewDecoderForSyntax returns a decoder over data for the given transfer syntax.
+func NewDecoderForSyntax(data []byte, s Syntax) *Decoder { return &Decoder{data: data, syntax: s} }
+
+// Syntax reports the transfer syntax the decoder operates under.
+func (d *Decoder) Syntax() Syntax { return d.syntax }
 
 // Pos returns the current read offset.
 func (d *Decoder) Pos() int { return d.pos }
@@ -207,16 +276,36 @@ func (d *Decoder) ReadUint64() (uint64, error) {
 	return binary.LittleEndian.Uint64(b), nil
 }
 
+// readCount reads an NDR count or length determinant at the syntax's width: 4 octets
+// 4-aligned under NDR20, or 8 octets 8-aligned under NDR64 ([MS-RPCE] section 2.2.5).
+func (d *Decoder) readCount() (uint64, error) {
+	if d.syntax == NDR64 {
+		return d.ReadUint64()
+	}
+	v, err := d.ReadUint32()
+	return uint64(v), err
+}
+
+// readReferent reads a pointer referent id at the syntax's referent width: 4 octets
+// under NDR20, 8 octets under NDR64.
+func (d *Decoder) readReferent() (uint64, error) {
+	if d.syntax == NDR64 {
+		return d.ReadUint64()
+	}
+	v, err := d.ReadUint32()
+	return uint64(v), err
+}
+
 // readWString reads a conformant+varying UTF-16LE string and returns it with the NUL
 // terminator removed.
 func (d *Decoder) readWString() (string, error) {
-	if _, err := d.ReadUint32(); err != nil { // maximum_count
+	if _, err := d.readCount(); err != nil { // maximum_count
 		return "", err
 	}
-	if _, err := d.ReadUint32(); err != nil { // offset
+	if _, err := d.readCount(); err != nil { // offset
 		return "", err
 	}
-	actual, err := d.ReadUint32() // actual_count (code units, incl. terminator)
+	actual, err := d.readCount() // actual_count (code units, incl. terminator)
 	if err != nil {
 		return "", err
 	}
@@ -230,13 +319,13 @@ func (d *Decoder) readWString() (string, error) {
 // readAString reads a conformant+varying ASCII string and returns it with the NUL
 // terminator removed.
 func (d *Decoder) readAString() (string, error) {
-	if _, err := d.ReadUint32(); err != nil { // maximum_count
+	if _, err := d.readCount(); err != nil { // maximum_count
 		return "", err
 	}
-	if _, err := d.ReadUint32(); err != nil { // offset
+	if _, err := d.readCount(); err != nil { // offset
 		return "", err
 	}
-	actual, err := d.ReadUint32() // actual_count (octets, incl. terminator)
+	actual, err := d.readCount() // actual_count (octets, incl. terminator)
 	if err != nil {
 		return "", err
 	}
@@ -249,7 +338,7 @@ func (d *Decoder) readAString() (string, error) {
 
 // readConformantBytes reads a maximum_count-prefixed byte array.
 func (d *Decoder) readConformantBytes() ([]byte, error) {
-	n, err := d.ReadUint32()
+	n, err := d.readCount()
 	if err != nil {
 		return nil, err
 	}

--- a/network/dcerpc/ndr/marshal.go
+++ b/network/dcerpc/ndr/marshal.go
@@ -103,7 +103,7 @@ func marshalStructFields(e *Encoder, rv reflect.Value, embedded bool, deferred *
 	confIdx := embeddedConformantIndex(rt, rv)
 	if confIdx >= 0 {
 		e.Align(conformantArrayAlignment(rv.Field(confIdx).Type().Elem()))
-		e.WriteUint32(uint32(rv.Field(confIdx).Len())) // hoisted maximum_count
+		e.writeCount(uint64(rv.Field(confIdx).Len())) // hoisted maximum_count
 	}
 	// A field named by another field's size_is/length_is is the array's count; its
 	// value is derived from the array length so the count and the elements cannot
@@ -138,8 +138,8 @@ func marshalStructFields(e *Encoder, rv reflect.Value, embedded bool, deferred *
 			// The maximum_count was hoisted above. For a conformant-varying array the
 			// offset and actual_count stay here, ahead of the elements.
 			if tag.varying {
-				e.WriteUint32(0)                         // offset
-				e.WriteUint32(uint32(rv.Field(i).Len())) // actual_count
+				e.writeCount(0)                         // offset
+				e.writeCount(uint64(rv.Field(i).Len())) // actual_count
 			}
 			if err := marshalElements(e, rv.Field(i), elementTag(tag)); err != nil {
 				return -1, fmt.Errorf("ndr: field %s: %w", f.Name, err)
@@ -192,21 +192,21 @@ func marshalFieldInline(e *Encoder, fv reflect.Value, tag fieldTag, deferred *[]
 			}
 			// A top-level [ref] parameter has no referent id and its referent is
 			// marshalled in place. An embedded [ref] pointer is represented by a
-			// 4-octet placeholder with its referent deferred, like other embedded
-			// pointers ([C706] section 14.3.10).
+			// referent-id placeholder (4 octets under NDR20, 8 under NDR64) with its
+			// referent deferred, like other embedded pointers ([C706] section 14.3.10).
 			if !embedded {
 				return marshalReferentBody(e, fv, tag)
 			}
-			e.WriteUint32(e.nextReferent())
+			e.writeReferent(e.nextReferent())
 			body := fv
 			*deferred = append(*deferred, func() error { return marshalReferentBody(e, body, tag) })
 			return nil
 		}
 		if isNilReferent(fv) {
-			e.WriteUint32(0) // NULL referent
+			e.writeReferent(0) // NULL referent
 			return nil
 		}
-		e.WriteUint32(e.nextReferent())
+		e.writeReferent(e.nextReferent())
 		// A top-level [unique]/[full] pointer parameter marshals its referent in place,
 		// immediately after the referent id; only an embedded pointer defers the body to
 		// the end of the enclosing construction ([C706] section 14.3.10, and observed on
@@ -360,10 +360,10 @@ func unmarshalStructFields(d *Decoder, rv reflect.Value, embedded bool, deferred
 	rt := rv.Type()
 	d.Align(ndrAlignment(rt)) // a structure is aligned to its largest member ([C706] 14.2.2)
 	confIdx := embeddedConformantIndex(rt, rv)
-	var confCount uint32
+	var confCount uint64
 	if confIdx >= 0 {
 		d.Align(conformantArrayAlignment(rv.Field(confIdx).Type().Elem()))
-		c, err := d.ReadUint32() // hoisted maximum_count
+		c, err := d.readCount() // hoisted maximum_count
 		if err != nil {
 			return -1, err
 		}
@@ -385,10 +385,10 @@ func unmarshalStructFields(d *Decoder, rv reflect.Value, embedded bool, deferred
 		if i == confIdx {
 			n := int(confCount)
 			if tag.varying {
-				if _, err := d.ReadUint32(); err != nil { // offset
+				if _, err := d.readCount(); err != nil { // offset
 					return -1, fmt.Errorf("ndr: field %s: %w", f.Name, err)
 				}
-				actual, err := d.ReadUint32() // actual_count
+				actual, err := d.readCount() // actual_count
 				if err != nil {
 					return -1, fmt.Errorf("ndr: field %s: %w", f.Name, err)
 				}
@@ -425,19 +425,19 @@ func unmarshalFieldInline(d *Decoder, fv reflect.Value, tag fieldTag, deferred *
 			kind = ptrUnique
 		}
 		if kind == ptrRef {
-			// Top-level [ref]: referent in place. Embedded [ref]: 4-octet placeholder
-			// then a deferred referent.
+			// Top-level [ref]: referent in place. Embedded [ref]: a referent-id
+			// placeholder (4 octets under NDR20, 8 under NDR64) then a deferred referent.
 			if !embedded {
 				return unmarshalReferentBody(d, fv, tag)
 			}
-			if _, err := d.ReadUint32(); err != nil {
+			if _, err := d.readReferent(); err != nil {
 				return err
 			}
 			target := fv
 			*deferred = append(*deferred, func() error { return unmarshalReferentBody(d, target, tag) })
 			return nil
 		}
-		refid, err := d.ReadUint32()
+		refid, err := d.readReferent()
 		if err != nil {
 			return err
 		}
@@ -751,14 +751,14 @@ func conformantArrayAlignment(elemType reflect.Type) int {
 // https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/140b01a3-979b-43af-b1e3-28f248db8f03
 func marshalConformantArray(e *Encoder, slice reflect.Value, maxCount uint32, elemTag fieldTag) error {
 	e.Align(conformantArrayAlignment(slice.Type().Elem()))
-	e.WriteUint32(maxCount)
+	e.writeCount(uint64(maxCount))
 	return marshalElements(e, slice, elemTag)
 }
 
 // unmarshalConformantArray reads a maximum_count-prefixed array into slice.
 func unmarshalConformantArray(d *Decoder, slice reflect.Value, elemTag fieldTag) error {
 	d.Align(conformantArrayAlignment(slice.Type().Elem()))
-	n, err := d.ReadUint32()
+	n, err := d.readCount()
 	if err != nil {
 		return err
 	}
@@ -777,9 +777,9 @@ func marshalConformantVaryingArray(e *Encoder, slice reflect.Value, maxCount, ac
 		actualCount = uint32(slice.Len())
 	}
 	e.Align(conformantArrayAlignment(slice.Type().Elem()))
-	e.WriteUint32(maxCount)    // maximum_count
-	e.WriteUint32(0)           // offset
-	e.WriteUint32(actualCount) // actual_count
+	e.writeCount(uint64(maxCount))    // maximum_count
+	e.writeCount(0)                   // offset
+	e.writeCount(uint64(actualCount)) // actual_count
 	return marshalElements(e, slice.Slice(0, int(actualCount)), elemTag)
 }
 
@@ -787,13 +787,13 @@ func marshalConformantVaryingArray(e *Encoder, slice reflect.Value, maxCount, ac
 // actual_count to size the result.
 func unmarshalConformantVaryingArray(d *Decoder, slice reflect.Value, elemTag fieldTag) error {
 	d.Align(conformantArrayAlignment(slice.Type().Elem()))
-	if _, err := d.ReadUint32(); err != nil { // maximum_count
+	if _, err := d.readCount(); err != nil { // maximum_count
 		return err
 	}
-	if _, err := d.ReadUint32(); err != nil { // offset
+	if _, err := d.readCount(); err != nil { // offset
 		return err
 	}
-	actual, err := d.ReadUint32() // actual_count
+	actual, err := d.readCount() // actual_count
 	if err != nil {
 		return err
 	}
@@ -811,6 +811,10 @@ func unmarshalConformantVaryingArray(d *Decoder, slice reflect.Value, elemTag fi
 // empty chunk (a count of 0). The whole slice is transmitted as a single chunk. A pipe
 // of a scalar (e.g. EFS_EXIM_PIPE = pipe of bytes) goes through marshalElements, which
 // has a byte fast path.
+//
+// The chunk count is kept a 4-octet value here regardless of syntax: NDR64 pipe framing
+// is not yet verified against [MS-RPCE] section 2.2.5 and is handled in a later phase,
+// so it deliberately does not route through writeCount.
 func marshalPipe(e *Encoder, fv reflect.Value, tag fieldTag) error {
 	if fv.Kind() != reflect.Slice {
 		return fmt.Errorf("ndr: pipe field must be a slice, got %s", fv.Kind())
@@ -885,10 +889,10 @@ func marshalElement(e *Encoder, ev reflect.Value, tag fieldTag, deferred *[]func
 			}
 		} else {
 			if isNilReferent(ev) {
-				e.WriteUint32(0) // NULL referent
+				e.writeReferent(0) // NULL referent
 				return nil
 			}
-			e.WriteUint32(e.nextReferent())
+			e.writeReferent(e.nextReferent())
 		}
 		body := ev
 		*deferred = append(*deferred, func() error { return marshalReferentBody(e, body, tag) })
@@ -956,7 +960,7 @@ func unmarshalElement(d *Decoder, ev reflect.Value, tag fieldTag, deferred *[]fu
 			kind = ptrUnique
 		}
 		if kind != ptrRef {
-			refid, err := d.ReadUint32()
+			refid, err := d.readReferent()
 			if err != nil {
 				return err
 			}

--- a/network/dcerpc/ndr/syntax_codec_test.go
+++ b/network/dcerpc/ndr/syntax_codec_test.go
@@ -1,0 +1,125 @@
+package ndr
+
+import (
+	"bytes"
+	"testing"
+)
+
+// TestSyntax_Default verifies NDR20 is the zero value, so a codec built without an
+// explicit syntax behaves as the classic NDR 2.0 codec.
+func TestSyntax_Default(t *testing.T) {
+	if got := NewEncoder().Syntax(); got != NDR20 {
+		t.Errorf("NewEncoder syntax = %v, want NDR20", got)
+	}
+	if got := NewDecoder(nil).Syntax(); got != NDR20 {
+		t.Errorf("NewDecoder syntax = %v, want NDR20", got)
+	}
+	if got := NewEncoderForSyntax(NDR64).Syntax(); got != NDR64 {
+		t.Errorf("NewEncoderForSyntax(NDR64) syntax = %v, want NDR64", got)
+	}
+	if NDR20.String() != "NDR20" || NDR64.String() != "NDR64" {
+		t.Errorf("Syntax.String: got %q/%q, want NDR20/NDR64", NDR20.String(), NDR64.String())
+	}
+}
+
+// TestWriteCount_NDR20Equivalence pins the count helper to the historical NDR20 wire
+// form: a 4-octet little-endian value, 4-aligned, identical to a direct WriteUint32.
+func TestWriteCount_NDR20Equivalence(t *testing.T) {
+	via := NewEncoder()
+	via.writeCount(0x11223344)
+
+	direct := NewEncoder()
+	direct.WriteUint32(0x11223344)
+
+	if !bytes.Equal(via.Bytes(), direct.Bytes()) {
+		t.Errorf("writeCount NDR20:\n got %x\nwant %x", via.Bytes(), direct.Bytes())
+	}
+	want := []byte{0x44, 0x33, 0x22, 0x11}
+	if !bytes.Equal(via.Bytes(), want) {
+		t.Errorf("writeCount NDR20 bytes:\n got %x\nwant %x", via.Bytes(), want)
+	}
+}
+
+// TestWriteCount_NDR64 pins the count helper's NDR64 wire form: an 8-octet
+// little-endian value, 8-aligned ([MS-RPCE] section 2.2.5).
+func TestWriteCount_NDR64(t *testing.T) {
+	e := NewEncoderForSyntax(NDR64)
+	e.WriteUint8(0x01)       // force a non-8-aligned offset
+	e.writeCount(0x11223344) // must 8-align: 7 pad bytes after the uint8
+	want := []byte{
+		0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // uint8 + 7 pad
+		0x44, 0x33, 0x22, 0x11, 0x00, 0x00, 0x00, 0x00, // 8-octet count
+	}
+	if !bytes.Equal(e.Bytes(), want) {
+		t.Errorf("writeCount NDR64:\n got %x\nwant %x", e.Bytes(), want)
+	}
+}
+
+// TestCount_RoundTrip exercises the count helpers symmetrically in both syntaxes.
+func TestCount_RoundTrip(t *testing.T) {
+	for _, s := range []Syntax{NDR20, NDR64} {
+		for _, v := range []uint64{0, 1, 0xffff, 0x7fffffff} {
+			e := NewEncoderForSyntax(s)
+			e.writeCount(v)
+			got, err := NewDecoderForSyntax(e.Bytes(), s).readCount()
+			if err != nil {
+				t.Fatalf("%v readCount(%d): %v", s, v, err)
+			}
+			if got != v {
+				t.Errorf("%v count round trip: got %d want %d", s, got, v)
+			}
+		}
+	}
+}
+
+// TestReferent_Width verifies the referent id width and the per-syntax allocation
+// stride: 4 octets / +4 under NDR20, 8 octets / +8 under NDR64.
+func TestReferent_Width(t *testing.T) {
+	e20 := NewEncoder()
+	id0 := e20.nextReferent()
+	id1 := e20.nextReferent()
+	if id0 != firstReferentID || id1 != firstReferentID+4 {
+		t.Errorf("NDR20 referent stride: got %#x,%#x want %#x,%#x", id0, id1, firstReferentID, firstReferentID+4)
+	}
+	e20b := NewEncoder()
+	e20b.writeReferent(firstReferentID)
+	if want := []byte{0x00, 0x00, 0x02, 0x00}; !bytes.Equal(e20b.Bytes(), want) {
+		t.Errorf("NDR20 referent bytes:\n got %x\nwant %x", e20b.Bytes(), want)
+	}
+
+	e64 := NewEncoderForSyntax(NDR64)
+	jd0 := e64.nextReferent()
+	jd1 := e64.nextReferent()
+	if jd0 != firstReferentID || jd1 != firstReferentID+8 {
+		t.Errorf("NDR64 referent stride: got %#x,%#x want %#x,%#x", jd0, jd1, firstReferentID, firstReferentID+8)
+	}
+	e64b := NewEncoderForSyntax(NDR64)
+	e64b.writeReferent(firstReferentID)
+	if want := []byte{0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00}; !bytes.Equal(e64b.Bytes(), want) {
+		t.Errorf("NDR64 referent bytes:\n got %x\nwant %x", e64b.Bytes(), want)
+	}
+}
+
+// TestWString_NDR64Counts verifies the conformant-varying string framing carries
+// 8-octet counts under NDR64 while the UTF-16LE body is unchanged.
+func TestWString_NDR64Counts(t *testing.T) {
+	e := NewEncoderForSyntax(NDR64)
+	e.writeWString("AB")
+	want := []byte{
+		0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // maximum_count (3, incl NUL)
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // offset
+		0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // actual_count
+		0x41, 0x00, 0x42, 0x00, // "AB"
+		0x00, 0x00, // terminator
+	}
+	if !bytes.Equal(e.Bytes(), want) {
+		t.Errorf("NDR64 wstring:\n got %x\nwant %x", e.Bytes(), want)
+	}
+	got, err := NewDecoderForSyntax(e.Bytes(), NDR64).readWString()
+	if err != nil {
+		t.Fatalf("NDR64 readWString: %v", err)
+	}
+	if got != "AB" {
+		t.Errorf("NDR64 wstring round trip: got %q want %q", got, "AB")
+	}
+}


### PR DESCRIPTION
### Linked Issue
Part of #400 (NDR64 transfer syntax support). This is phase 1 of a multi-phase implementation; it lands the codec plumbing only and does not yet change any production wire output.

### Motivation
The NDR codec (`network/dcerpc/ndr`) implements only NDR transfer syntax 2.0 ("NDR20"): counts (`maximum_count`, `offset`, `actual_count`) and pointer referent ids are hardcoded as 4-octet little-endian values throughout `codec.go` and the reflection walker in `marshal.go`. NDR64 encodes those same elements as 8-octet, 8-aligned values. Supporting NDR64 requires the codec to vary the width and alignment of counts and referents by transfer syntax, which the current `Encoder`/`Decoder` cannot express.

### Fix Description
Makes the codec transfer-syntax aware without changing NDR20 behaviour:

- Adds a `Syntax` type with `NDR20`/`NDR64` constants. `NDR20` is the zero value, so an `Encoder`/`Decoder` built the existing way is unchanged.
- Threads a `syntax` field through `Encoder`/`Decoder`; adds `NewEncoderForSyntax`/`NewDecoderForSyntax` constructors and `Syntax()` accessors. Existing `NewEncoder`/`NewDecoder` keep their signatures and default to NDR20.
- Adds width-aware helpers `writeCount`/`readCount` (counts) and `writeReferent`/`readReferent` (referent ids), and makes `nextReferent` return `uint64` with a per-syntax allocation stride. Each helper emits 4 octets 4-aligned under NDR20, 8 octets 8-aligned under NDR64.
- Routes every count and referent site in `codec.go` (`writeWString`/`writeAString`/`writeConformantBytes` and the read twins) and `marshal.go` (hoisted `maximum_count`, conformant-varying `offset`/`actual_count`, conformant array determinants, and all referent-id reads/writes) through these helpers.

Scalar struct fields keep their natural width in both syntaxes and are left as `WriteUint32`/`ReadUint32`. Pipe chunk counts are deliberately left 4-octet with a code comment: NDR64 pipe framing is not yet verified against the spec and is deferred to a later phase rather than encoding an unverified assumption.

The declarative walker (`Marshal`/`Unmarshal`) and the v5 client still construct NDR20 codecs, so the NDR64 path is reachable only via the new constructors. Wiring NDR64 into the walker, alignment helpers, unions, pipes, and the client bind negotiation are the subjects of later phases.

### How Verified
- **Tests:** the entire existing `go test ./network/dcerpc/...` suite passes unchanged, proving NDR20 output is byte-identical after the reroute. New tests in `network/dcerpc/ndr/syntax_codec_test.go` assert NDR20 equivalence (`writeCount` == `WriteUint32`), the NDR64 8-octet/8-aligned count and referent widths, the referent allocation stride (+4 vs +8), and conformant-varying string framing under NDR64, plus symmetric round-trips in both syntaxes.
- **Static:** `go build ./...` and `go vet ./network/dcerpc/ndr/...` are clean; `gofmt` reports no diffs.

### Test Coverage
**Added:** `network/dcerpc/ndr/syntax_codec_test.go` — `TestSyntax_Default`, `TestWriteCount_NDR20Equivalence`, `TestWriteCount_NDR64`, `TestCount_RoundTrip`, `TestReferent_Width`, `TestWString_NDR64Counts`.

### Scope of Change
- **Files changed:** `network/dcerpc/ndr/codec.go`, `network/dcerpc/ndr/marshal.go`, `network/dcerpc/ndr/syntax_codec_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none — NDR20 output is byte-identical; the new NDR64 width is not reachable through the public walker or client in this phase.

### Risk and Rollout
Low blast radius: production paths still build NDR20 codecs, so the change is a no-op on the wire and is guarded by the unchanged existing test suite. Safe to merge without staged rollout.

### Notes
Follow-up phases (tracked under #400): NDR64 in the reflection walker and alignment helpers, NDR64 unions, NDR64 pipes, and client bind-time transfer-syntax negotiation.