### PR TITLE
Add NDR64 support to the declarative NDR walker (#400)

### DIFF
--- a/network/dcerpc/ndr/marshal.go
+++ b/network/dcerpc/ndr/marshal.go
@@ -12,12 +12,18 @@ import (
 // referent id inline with their referent body deferred to the end of the enclosing
 // construction, per the deferral rule in [C706] section 14.3.10:
 // https://pubs.opengroup.org/onlinepubs/9629399/chap14.htm
-func Marshal(v any) ([]byte, error) {
+func Marshal(v any) ([]byte, error) { return MarshalAs(v, NDR20) }
+
+// MarshalAs is Marshal under an explicit transfer syntax. NDR64 widens counts and
+// referent ids to 8 octets and aligns them to 8 ([MS-RPCE] section 2.2.5). NDR64
+// unions and pipes are not yet supported and marshalling a value that contains one
+// returns an error rather than emitting an unverified encoding.
+func MarshalAs(v any, syntax Syntax) ([]byte, error) {
 	rv, err := structValue(reflect.ValueOf(v))
 	if err != nil {
 		return nil, err
 	}
-	e := NewEncoder()
+	e := NewEncoderForSyntax(syntax)
 	if err := marshalStruct(e, rv, false); err != nil {
 		return nil, err
 	}
@@ -26,7 +32,11 @@ func Marshal(v any) ([]byte, error) {
 
 // Unmarshal decodes an NDR octet stream into v, which must be a non-nil pointer to a
 // struct.
-func Unmarshal(data []byte, v any) error {
+func Unmarshal(data []byte, v any) error { return UnmarshalAs(data, v, NDR20) }
+
+// UnmarshalAs is Unmarshal under an explicit transfer syntax. See MarshalAs for the
+// NDR64 semantics and the union/pipe limitation.
+func UnmarshalAs(data []byte, v any, syntax Syntax) error {
 	rv := reflect.ValueOf(v)
 	if rv.Kind() != reflect.Pointer || rv.IsNil() {
 		return fmt.Errorf("ndr: Unmarshal requires a non-nil pointer, got %T", v)
@@ -35,7 +45,7 @@ func Unmarshal(data []byte, v any) error {
 	if err != nil {
 		return err
 	}
-	return unmarshalStruct(NewDecoder(data), sv, false)
+	return unmarshalStruct(NewDecoderForSyntax(data, syntax), sv, false)
 }
 
 // structValue dereferences pointers/interfaces to reach a struct value.
@@ -99,10 +109,10 @@ func marshalStructFields(e *Encoder, rv reflect.Value, embedded bool, deferred *
 	// representation ([C706] section 14.2.2). The first member self-aligns to its own
 	// size, which is insufficient when a later member is wider (e.g. RPC_UNICODE_STRING,
 	// whose Buffer pointer makes it 4-aligned, following a 2-byte discriminant).
-	e.Align(ndrAlignment(rt))
+	e.Align(ndrAlignment(rt, e.syntax))
 	confIdx := embeddedConformantIndex(rt, rv)
 	if confIdx >= 0 {
-		e.Align(conformantArrayAlignment(rv.Field(confIdx).Type().Elem()))
+		e.Align(conformantArrayAlignment(rv.Field(confIdx).Type().Elem(), e.syntax))
 		e.writeCount(uint64(rv.Field(confIdx).Len())) // hoisted maximum_count
 	}
 	// A field named by another field's size_is/length_is is the array's count; its
@@ -358,11 +368,11 @@ func unmarshalStruct(d *Decoder, rv reflect.Value, embedded bool) error {
 // marshalStructFields for why arrays need this. Returns the `retval` field index or -1.
 func unmarshalStructFields(d *Decoder, rv reflect.Value, embedded bool, deferred *[]func() error) (int, error) {
 	rt := rv.Type()
-	d.Align(ndrAlignment(rt)) // a structure is aligned to its largest member ([C706] 14.2.2)
+	d.Align(ndrAlignment(rt, d.syntax)) // a structure is aligned to its largest member ([C706] 14.2.2)
 	confIdx := embeddedConformantIndex(rt, rv)
 	var confCount uint64
 	if confIdx >= 0 {
-		d.Align(conformantArrayAlignment(rv.Field(confIdx).Type().Elem()))
+		d.Align(conformantArrayAlignment(rv.Field(confIdx).Type().Elem(), d.syntax))
 		c, err := d.readCount() // hoisted maximum_count
 		if err != nil {
 			return -1, err
@@ -706,8 +716,12 @@ func isEmbeddedConformantArray(fv reflect.Value, tag fieldTag) bool {
 	return fv.Kind() == reflect.Slice && !tag.pipe && !isPointerLike(fv, tag)
 }
 
-// ndrAlignment returns the NDR alignment, in octets, of a value of type t.
-func ndrAlignment(t reflect.Type) int {
+// ndrAlignment returns the NDR alignment, in octets, of a value of type t under the
+// given transfer syntax. Strings, pointers, and slices lead with a referent id or a
+// conformance count, which widen from 4 octets 4-aligned (NDR20) to 8 octets 8-aligned
+// (NDR64), so those kinds align to 8 under NDR64 ([MS-RPCE] section 2.2.5). Fixed scalar
+// kinds keep their natural alignment in both syntaxes.
+func ndrAlignment(t reflect.Type, syntax Syntax) int {
 	if reflect.PointerTo(t).Implements(marshalerType) {
 		return reflect.New(t).Interface().(Marshaler).AlignmentNDR()
 	}
@@ -716,17 +730,45 @@ func ndrAlignment(t reflect.Type) int {
 		return 1
 	case reflect.Uint16, reflect.Int16:
 		return 2
-	case reflect.Uint32, reflect.Int32, reflect.Uint, reflect.Int, reflect.String, reflect.Pointer:
+	case reflect.Uint32, reflect.Int32, reflect.Uint, reflect.Int:
 		return 4
 	case reflect.Uint64, reflect.Int64:
 		return 8
+	case reflect.String, reflect.Pointer, reflect.Slice:
+		// A string/slice begins with a conformance count and a pointer with a referent
+		// id; both are 8-octet 8-aligned under NDR64 and 4-octet 4-aligned under NDR20.
+		if syntax == NDR64 {
+			return 8
+		}
+		return 4
+	case reflect.Array:
+		// A fixed array aligns to its element. Under NDR20 the historical behaviour is
+		// the catch-all alignment of 4, preserved to keep NDR20 output byte-identical.
+		if syntax == NDR64 {
+			return ndrAlignment(t.Elem(), syntax)
+		}
+		return 4
 	case reflect.Struct:
 		a := 1
 		for i := 0; i < t.NumField(); i++ {
-			if t.Field(i).PkgPath != "" {
+			f := t.Field(i)
+			if f.PkgPath != "" {
 				continue
 			}
-			if fa := ndrAlignment(t.Field(i).Type); fa > a {
+			// NDR20 aligns to the widest member type, ignoring tags (preserved exactly).
+			// NDR64 is tag-aware: a value field tagged as a pointer ([unique]/[ref]/[ptr])
+			// is a referent id inline, so it aligns to 8 regardless of the value's layout.
+			var fa int
+			if syntax == NDR64 {
+				tag := parseTag(f.Tag.Get("ndr"))
+				if tag.skip {
+					continue
+				}
+				fa = fieldNDRAlignment(f.Type, tag, syntax)
+			} else {
+				fa = ndrAlignment(f.Type, syntax)
+			}
+			if fa > a {
 				a = fa
 			}
 		}
@@ -736,28 +778,46 @@ func ndrAlignment(t reflect.Type) int {
 	}
 }
 
+// fieldNDRAlignment returns the alignment of a struct field, accounting for a pointer
+// tag on a non-pointer Go type (e.g. a value struct tagged [unique]), whose inline
+// representation is a referent id rather than the field's own layout.
+func fieldNDRAlignment(t reflect.Type, tag fieldTag, syntax Syntax) int {
+	if tag.ptr != ptrNone && t.Kind() != reflect.Pointer {
+		if syntax == NDR64 {
+			return 8
+		}
+		return 4
+	}
+	return ndrAlignment(t, syntax)
+}
+
 // conformantArrayAlignment returns the alignment of a conformant array of the given
-// element type: the larger of the size determinant's alignment (4) and the element
-// alignment ([C706] section 14.3.3.1).
-func conformantArrayAlignment(elemType reflect.Type) int {
-	if a := ndrAlignment(elemType); a > 4 {
+// element type under the given syntax: the larger of the size determinant's alignment
+// (4 under NDR20, 8 under NDR64) and the element alignment ([C706] section 14.3.3.1,
+// [MS-RPCE] section 2.2.5).
+func conformantArrayAlignment(elemType reflect.Type, syntax Syntax) int {
+	det := 4
+	if syntax == NDR64 {
+		det = 8
+	}
+	if a := ndrAlignment(elemType, syntax); a > det {
 		return a
 	}
-	return 4
+	return det
 }
 
 // marshalConformantArray writes a conformant array: a maximum_count followed by the
 // elements, per [MS-RPCE] Conformant Arrays:
 // https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/140b01a3-979b-43af-b1e3-28f248db8f03
 func marshalConformantArray(e *Encoder, slice reflect.Value, maxCount uint32, elemTag fieldTag) error {
-	e.Align(conformantArrayAlignment(slice.Type().Elem()))
+	e.Align(conformantArrayAlignment(slice.Type().Elem(), e.syntax))
 	e.writeCount(uint64(maxCount))
 	return marshalElements(e, slice, elemTag)
 }
 
 // unmarshalConformantArray reads a maximum_count-prefixed array into slice.
 func unmarshalConformantArray(d *Decoder, slice reflect.Value, elemTag fieldTag) error {
-	d.Align(conformantArrayAlignment(slice.Type().Elem()))
+	d.Align(conformantArrayAlignment(slice.Type().Elem(), d.syntax))
 	n, err := d.readCount()
 	if err != nil {
 		return err
@@ -776,7 +836,7 @@ func marshalConformantVaryingArray(e *Encoder, slice reflect.Value, maxCount, ac
 	if int(actualCount) > slice.Len() {
 		actualCount = uint32(slice.Len())
 	}
-	e.Align(conformantArrayAlignment(slice.Type().Elem()))
+	e.Align(conformantArrayAlignment(slice.Type().Elem(), e.syntax))
 	e.writeCount(uint64(maxCount))    // maximum_count
 	e.writeCount(0)                   // offset
 	e.writeCount(uint64(actualCount)) // actual_count
@@ -786,7 +846,7 @@ func marshalConformantVaryingArray(e *Encoder, slice reflect.Value, maxCount, ac
 // unmarshalConformantVaryingArray reads a conformant-varying array, using the
 // actual_count to size the result.
 func unmarshalConformantVaryingArray(d *Decoder, slice reflect.Value, elemTag fieldTag) error {
-	d.Align(conformantArrayAlignment(slice.Type().Elem()))
+	d.Align(conformantArrayAlignment(slice.Type().Elem(), d.syntax))
 	if _, err := d.readCount(); err != nil { // maximum_count
 		return err
 	}
@@ -812,10 +872,13 @@ func unmarshalConformantVaryingArray(d *Decoder, slice reflect.Value, elemTag fi
 // of a scalar (e.g. EFS_EXIM_PIPE = pipe of bytes) goes through marshalElements, which
 // has a byte fast path.
 //
-// The chunk count is kept a 4-octet value here regardless of syntax: NDR64 pipe framing
-// is not yet verified against [MS-RPCE] section 2.2.5 and is handled in a later phase,
-// so it deliberately does not route through writeCount.
+// NDR64 pipe framing is not yet verified against [MS-RPCE] section 2.2.5 and is handled
+// in a later phase, so marshalling a pipe under NDR64 returns an error rather than
+// emitting an unverified encoding.
 func marshalPipe(e *Encoder, fv reflect.Value, tag fieldTag) error {
+	if e.syntax == NDR64 {
+		return fmt.Errorf("ndr: NDR64 pipes are not yet supported")
+	}
 	if fv.Kind() != reflect.Slice {
 		return fmt.Errorf("ndr: pipe field must be a slice, got %s", fv.Kind())
 	}
@@ -833,6 +896,9 @@ func marshalPipe(e *Encoder, fv reflect.Value, tag fieldTag) error {
 // 0-count chunk, concatenating the chunks into the slice. unmarshalElements bounds each
 // chunk's count against the remaining input, so a hostile count cannot over-allocate.
 func unmarshalPipe(d *Decoder, fv reflect.Value, tag fieldTag) error {
+	if d.syntax == NDR64 {
+		return fmt.Errorf("ndr: NDR64 pipes are not yet supported")
+	}
 	if fv.Kind() != reflect.Slice {
 		return fmt.Errorf("ndr: pipe field must be a slice, got %s", fv.Kind())
 	}

--- a/network/dcerpc/ndr/ndr64_walker_test.go
+++ b/network/dcerpc/ndr/ndr64_walker_test.go
@@ -1,0 +1,166 @@
+package ndr
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// sidLikeNDR64 mirrors RPC_SID: a structure embedding a conformant array, so its
+// maximum_count is hoisted to the front of the struct ([C706] 14.3.3.1) — 8 octets,
+// 8-aligned under NDR64.
+type sidLikeNDR64 struct {
+	Revision uint8
+	Count    uint8
+	Auth     [6]byte
+	Sub      []uint32 `ndr:"conformant,size_is=Count"`
+}
+
+// TestNDR64_EmbeddedConformantArray pins the NDR64 layout of a SID-shaped struct: an
+// 8-octet hoisted maximum_count, then the fixed members, then the 4-byte elements.
+func TestNDR64_EmbeddedConformantArray(t *testing.T) {
+	v := sidLikeNDR64{Revision: 1, Auth: [6]byte{0, 0, 0, 0, 0, 5}, Sub: []uint32{32, 544}}
+	got, err := MarshalAs(v, NDR64)
+	if err != nil {
+		t.Fatalf("MarshalAs NDR64: %v", err)
+	}
+	want := []byte{
+		0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // maximum_count = 2 (8 octets)
+		0x01,                               // Revision
+		0x02,                               // SubAuthorityCount (derived from len)
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x05, // IdentifierAuthority (6 octets, big-endian)
+		0x20, 0x00, 0x00, 0x00, // 32
+		0x20, 0x02, 0x00, 0x00, // 544
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("NDR64 SID layout:\n got %x\nwant %x", got, want)
+	}
+
+	var rt sidLikeNDR64
+	if err := UnmarshalAs(got, &rt, NDR64); err != nil {
+		t.Fatalf("UnmarshalAs NDR64: %v", err)
+	}
+	if rt.Revision != 1 || rt.Count != 2 || rt.Auth != v.Auth || len(rt.Sub) != 2 || rt.Sub[0] != 32 || rt.Sub[1] != 544 {
+		t.Errorf("NDR64 SID round trip: got %+v want %+v", rt, v)
+	}
+}
+
+type innerNDR64 struct{ X uint32 }
+
+type outerNDR64 struct {
+	A uint32
+	P *innerNDR64 `ndr:"unique"`
+}
+
+// TestNDR64_UniquePointer pins the NDR64 layout of a [unique] pointer member: a struct
+// alignment of 8 (the referent widens to 8 octets), an 8-octet referent id, then the
+// pointed-to struct marshalled in place (a top-level pointer's body is not deferred).
+func TestNDR64_UniquePointer(t *testing.T) {
+	v := outerNDR64{A: 0x11111111, P: &innerNDR64{X: 0x22222222}}
+	got, err := MarshalAs(v, NDR64)
+	if err != nil {
+		t.Fatalf("MarshalAs NDR64: %v", err)
+	}
+	want := []byte{
+		0x11, 0x11, 0x11, 0x11, // A
+		0x00, 0x00, 0x00, 0x00, // pad: referent id 8-aligned under NDR64
+		0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, // referent id (8 octets)
+		0x22, 0x22, 0x22, 0x22, // P.X
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("NDR64 unique pointer layout:\n got %x\nwant %x", got, want)
+	}
+
+	var rt outerNDR64
+	if err := UnmarshalAs(got, &rt, NDR64); err != nil {
+		t.Fatalf("UnmarshalAs NDR64: %v", err)
+	}
+	if rt.A != v.A || rt.P == nil || rt.P.X != v.P.X {
+		t.Errorf("NDR64 unique pointer round trip: got %+v want %+v", rt, v)
+	}
+}
+
+type uniStrNDR64 struct {
+	Length uint16
+	MaxLen uint16
+	Buffer []uint16 `ndr:"unique,varying,size_is=MaxLen/2,length_is=Length/2"`
+}
+
+// TestNDR64_ConformantVaryingString round-trips an RPC_UNICODE_STRING-shaped value
+// under NDR64, exercising 8-octet referent id, divisor-resolved counts, and the
+// conformant-varying framing.
+func TestNDR64_ConformantVaryingString(t *testing.T) {
+	v := uniStrNDR64{Length: 4, MaxLen: 4, Buffer: []uint16{0x48, 0x69}} // "Hi"
+	b, err := MarshalAs(v, NDR64)
+	if err != nil {
+		t.Fatalf("MarshalAs NDR64: %v", err)
+	}
+	var rt uniStrNDR64
+	if err := UnmarshalAs(b, &rt, NDR64); err != nil {
+		t.Fatalf("UnmarshalAs NDR64: %v", err)
+	}
+	if rt.Length != 4 || rt.MaxLen != 4 || len(rt.Buffer) != 2 || rt.Buffer[0] != 0x48 || rt.Buffer[1] != 0x69 {
+		t.Errorf("NDR64 unicode string round trip: got %+v want %+v", rt, v)
+	}
+}
+
+// TestNDR64_ScalarStructMatchesNDR20 confirms a struct with no counts or referents is
+// byte-identical under both syntaxes (nothing widens).
+func TestNDR64_ScalarStructMatchesNDR20(t *testing.T) {
+	type flat struct {
+		A uint16
+		B uint32
+		C uint64
+	}
+	v := flat{A: 0xaabb, B: 0xccddeeff, C: 0x0102030405060708}
+	n20, err := MarshalAs(v, NDR20)
+	if err != nil {
+		t.Fatalf("NDR20: %v", err)
+	}
+	n64, err := MarshalAs(v, NDR64)
+	if err != nil {
+		t.Fatalf("NDR64: %v", err)
+	}
+	if !bytes.Equal(n20, n64) {
+		t.Errorf("scalar struct differs by syntax:\nNDR20 %x\nNDR64 %x", n20, n64)
+	}
+}
+
+type unionArm64 struct {
+	Tag uint32 `ndr:"switch"`
+	A   uint32 `ndr:"case=1"`
+}
+
+type hasUnion64 struct {
+	U unionArm64
+}
+
+type hasPipe64 struct {
+	P []byte `ndr:"pipe"`
+}
+
+// TestNDR64_UnionRejected verifies a union is rejected under NDR64 (deferred to a later
+// phase) rather than emitting an unverified encoding, while NDR20 still works.
+func TestNDR64_UnionRejected(t *testing.T) {
+	v := hasUnion64{U: unionArm64{Tag: 1, A: 7}}
+	if _, err := MarshalAs(v, NDR20); err != nil {
+		t.Fatalf("NDR20 union should still marshal: %v", err)
+	}
+	_, err := MarshalAs(v, NDR64)
+	if err == nil || !strings.Contains(err.Error(), "NDR64 unions") {
+		t.Errorf("NDR64 union: err = %v, want a 'NDR64 unions' error", err)
+	}
+}
+
+// TestNDR64_PipeRejected verifies a pipe is rejected under NDR64 rather than emitting an
+// unverified encoding, while NDR20 still works.
+func TestNDR64_PipeRejected(t *testing.T) {
+	v := hasPipe64{P: []byte{1, 2, 3}}
+	if _, err := MarshalAs(v, NDR20); err != nil {
+		t.Fatalf("NDR20 pipe should still marshal: %v", err)
+	}
+	_, err := MarshalAs(v, NDR64)
+	if err == nil || !strings.Contains(err.Error(), "NDR64 pipes") {
+		t.Errorf("NDR64 pipe: err = %v, want a 'NDR64 pipes' error", err)
+	}
+}

--- a/network/dcerpc/ndr/types.go
+++ b/network/dcerpc/ndr/types.go
@@ -65,10 +65,21 @@ func Request(call Call) ([]byte, error) {
 	return Marshal(call)
 }
 
+// RequestAs is Request under an explicit transfer syntax, used by a client that has
+// negotiated NDR64 ([MS-RPCE] section 2.2.5).
+func RequestAs(call Call, syntax Syntax) ([]byte, error) {
+	return MarshalAs(call, syntax)
+}
+
 // Response unmarshals an RPC response stub into out (a pointer to the [out] parameter
 // structure).
 func Response(stub []byte, out any) error {
 	return Unmarshal(stub, out)
+}
+
+// ResponseAs is Response under an explicit transfer syntax.
+func ResponseAs(stub []byte, out any, syntax Syntax) error {
+	return UnmarshalAs(stub, out, syntax)
 }
 
 // ptrKind is the NDR pointer attribute of a field.

--- a/network/dcerpc/ndr/union.go
+++ b/network/dcerpc/ndr/union.go
@@ -1,6 +1,9 @@
 package ndr
 
-import "reflect"
+import (
+	"fmt"
+	"reflect"
+)
 
 // NDR discriminated unions, declared with struct tags rather than the Marshaler escape
 // hatch. A union is a Go struct with one field tagged `switch` (the discriminant) and
@@ -78,7 +81,7 @@ func unionArm(rt reflect.Type, disc reflect.Value) int {
 // unionArmAlignment returns the largest NDR alignment among the union's arms (the
 // case/default fields), which is the alignment applied to the selected arm so its
 // position does not depend on which arm was sent ([C706] section 14.3.8).
-func unionArmAlignment(rt reflect.Type) int {
+func unionArmAlignment(rt reflect.Type, syntax Syntax) int {
 	a := 1
 	for i := 0; i < rt.NumField(); i++ {
 		f := rt.Field(i)
@@ -89,7 +92,7 @@ func unionArmAlignment(rt reflect.Type) int {
 		if !tag.hasCase && !tag.isDefault {
 			continue
 		}
-		if fa := ndrAlignment(f.Type); fa > a {
+		if fa := ndrAlignment(f.Type, syntax); fa > a {
 			a = fa
 		}
 	}
@@ -101,6 +104,9 @@ func unionArmAlignment(rt reflect.Type) int {
 // a [unique]/[ref] pointer to a structure) emits a referent id with its body deferred to
 // the end of the union construction.
 func marshalUnion(e *Encoder, rv reflect.Value, swIdx int) error {
+	if e.syntax == NDR64 {
+		return fmt.Errorf("ndr: NDR64 unions are not yet supported")
+	}
 	rt := rv.Type()
 	disc := rv.Field(swIdx)
 	// The discriminant is aligned to its own alignment. The selected arm is then aligned
@@ -109,7 +115,7 @@ func marshalUnion(e *Encoder, rv reflect.Value, swIdx int) error {
 	// LSAPR_POLICY_INFORMATION's 2-byte server-role arm still starts 8-aligned because
 	// other arms carry 8-byte LARGE_INTEGER members. (Note this padding follows the tag,
 	// so it does not over-align the discriminant itself.)
-	e.Align(ndrAlignment(disc.Type()))
+	e.Align(ndrAlignment(disc.Type(), e.syntax))
 	if err := marshalScalar(e, disc); err != nil {
 		return err
 	}
@@ -117,7 +123,7 @@ func marshalUnion(e *Encoder, rv reflect.Value, swIdx int) error {
 	if armIdx < 0 {
 		return nil // discriminant value with no arm and no default: empty body
 	}
-	e.Align(unionArmAlignment(rt))
+	e.Align(unionArmAlignment(rt, e.syntax))
 	f := rt.Field(armIdx)
 	var deferred []func() error
 	if err := marshalFieldInline(e, rv.Field(armIdx), parseTag(f.Tag.Get("ndr")), &deferred, true); err != nil {
@@ -129,9 +135,12 @@ func marshalUnion(e *Encoder, rv reflect.Value, swIdx int) error {
 // unmarshalUnion reads the discriminant, selects the matching arm, and leaves the other
 // arm fields zero.
 func unmarshalUnion(d *Decoder, rv reflect.Value, swIdx int) error {
+	if d.syntax == NDR64 {
+		return fmt.Errorf("ndr: NDR64 unions are not yet supported")
+	}
 	rt := rv.Type()
 	disc := rv.Field(swIdx)
-	d.Align(ndrAlignment(disc.Type())) // discriminant aligned to itself
+	d.Align(ndrAlignment(disc.Type(), d.syntax)) // discriminant aligned to itself
 	if err := unmarshalScalar(d, disc); err != nil {
 		return err
 	}
@@ -139,7 +148,7 @@ func unmarshalUnion(d *Decoder, rv reflect.Value, swIdx int) error {
 	if armIdx < 0 {
 		return nil
 	}
-	d.Align(unionArmAlignment(rt)) // arm aligned to the largest alignment among all arms
+	d.Align(unionArmAlignment(rt, d.syntax)) // arm aligned to the largest alignment among all arms
 	f := rt.Field(armIdx)
 	var deferred []func() error
 	if err := unmarshalFieldInline(d, rv.Field(armIdx), parseTag(f.Tag.Get("ndr")), &deferred, true); err != nil {


### PR DESCRIPTION
### Linked Issue
Part of #400 (NDR64 transfer syntax support). Phase 2 of the multi-phase implementation. **Stacked on #593** (phase 1, codec plumbing) — this PR targets the phase-1 branch so its diff shows only the walker changes; retarget to `main` once #593 merges.

### Motivation
Phase 1 made the low-level codec transfer-syntax aware (8-octet counts and referent ids under NDR64) but the reflection walker still only ever built NDR20 codecs, and its alignment logic assumed 4-octet counts/referents. Under NDR64 a string, pointer, or conformant array leads with an 8-octet, 8-aligned value, which changes the alignment of any structure that contains one. Without that, declarative structs cannot be marshalled or unmarshalled as NDR64.

### Fix Description
Threads the encoder/decoder `Syntax` through the walker's alignment logic and adds syntax-aware entry points:

- `ndrAlignment` and `conformantArrayAlignment` take a `Syntax`. Under NDR64, `string`/`pointer`/`slice` kinds align to 8 (their referent id or conformance count is 8 octets), a fixed array aligns to its element, and the conformant-array size determinant is 8-aligned. Structure alignment becomes tag-aware under NDR64 so a value field tagged `[unique]`/`[ref]`/`[ptr]` aligns to 8 as the referent id it encodes to. **NDR20 alignment is computed exactly as before**, so NDR20 output stays byte-identical.
- Adds `MarshalAs`/`UnmarshalAs` (ndr) and `RequestAs`/`ResponseAs` (the `Call` helpers). `Marshal`/`Unmarshal`/`Request`/`Response` are now thin NDR20 wrappers, so existing callers and all 275 interface stubs are unchanged.
- `marshalUnion`/`unmarshalUnion` and `marshalPipe`/`unmarshalPipe` return an explicit error under NDR64 ("NDR64 unions/pipes are not yet supported") instead of emitting an unverified encoding. NDR64 union and pipe framing are addressed in their own later phases.

### How Verified
- **Tests:** the full `go test ./network/dcerpc/...` suite passes unchanged, confirming NDR20 output is byte-identical after threading syntax through alignment. New tests in `network/dcerpc/ndr/ndr64_walker_test.go` assert the NDR64 byte layout (not just round-trips) for a SID-shaped struct with an embedded conformant array, a `[unique]` pointer-to-struct, and that a counts-free scalar struct is identical under both syntaxes; they round-trip a conformant-varying string with divisor-resolved counts; and they assert unions and pipes are rejected under NDR64 while still marshalling under NDR20.
- **Static:** `go build ./...` and `go vet ./network/dcerpc/ndr/...` are clean; `gofmt` reports no diffs.

### Test Coverage
**Added:** `network/dcerpc/ndr/ndr64_walker_test.go` — `TestNDR64_EmbeddedConformantArray`, `TestNDR64_UniquePointer`, `TestNDR64_ConformantVaryingString`, `TestNDR64_ScalarStructMatchesNDR20`, `TestNDR64_UnionRejected`, `TestNDR64_PipeRejected`.

### Scope of Change
- **Files changed:** `network/dcerpc/ndr/marshal.go`, `network/dcerpc/ndr/types.go`, `network/dcerpc/ndr/union.go`, `network/dcerpc/ndr/ndr64_walker_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none — NDR20 output is byte-identical; NDR64 is reachable only through the new `*As` entry points, which no production caller invokes yet (the v5 client still binds NDR20).

### Risk and Rollout
Low: production paths still construct NDR20 codecs and emit identical bytes, guarded by the unchanged existing suite. NDR64 marshalling is opt-in via `MarshalAs`/`UnmarshalAs` and fails closed (errors) for the unverified union/pipe cases.

### Notes
The NDR64 layouts implemented here (8-octet counts/referents, 8-alignment, struct = max member alignment, hoisted conformance count) are validated by hand-computed golden bytes derived from [MS-RPCE] section 2.2.5 and by internal round-trips. Validation against captured real-world Windows NDR64 traffic is recommended before relying on NDR64 in production and is planned as part of the client-negotiation phase. Remaining phases under #400: NDR64 unions, NDR64 pipes, and client bind-time transfer-syntax negotiation.