### PR TITLE
Add NDR64 transfer-syntax negotiation to the v5 client (#400)

### DIFF
--- a/network/dcerpc/v5/client/client.go
+++ b/network/dcerpc/v5/client/client.go
@@ -52,6 +52,14 @@ type Client struct {
 	// derived from the bind_ack.
 	sendFragMax uint16
 
+	// preferNDR64 makes Bind additionally propose the NDR64 transfer syntax and prefer
+	// it when the server accepts it. Default false: NDR20 only, identical to before.
+	preferNDR64 bool
+
+	// negotiatedSyntax is the transfer syntax the server accepted at Bind; Invoke
+	// marshals and unmarshals stubs under it. Default NDR20.
+	negotiatedSyntax ndr.Syntax
+
 	bound bool
 }
 
@@ -62,29 +70,52 @@ func NewClient(t transport.Transport) *Client {
 	return &Client{transport: t}
 }
 
+// PreferNDR64 controls whether Bind proposes the NDR64 transfer syntax in addition to
+// NDR 2.0 and uses it when the server accepts it. It must be called before Bind. The
+// default is false (NDR 2.0 only).
+func (c *Client) PreferNDR64(enable bool) { c.preferNDR64 = enable }
+
+// NegotiatedSyntax reports the transfer syntax the server accepted at Bind. It is
+// meaningful only after a successful Bind.
+func (c *Client) NegotiatedSyntax() ndr.Syntax { return c.negotiatedSyntax }
+
 // Bind connects the transport and binds to the interface identified by
-// abstractSyntax, negotiating the NDR 2.0 transfer syntax in a single presentation
-// context. It returns an error if the server rejects the bind (bind_nak) or accepts
-// no context.
+// abstractSyntax. It proposes the NDR 2.0 transfer syntax in presentation context 0,
+// and — when PreferNDR64 is enabled — NDR64 in a second context (the established
+// negotiation pattern: one transfer syntax per context, [MS-RPCE] 2.2.2.4). The
+// transfer syntax the server accepts is recorded for subsequent calls, preferring
+// NDR64 when both are accepted. It returns an error if the server rejects the bind
+// (bind_nak) or accepts no context.
 func (c *Client) Bind(abstractSyntax syntax.SyntaxID) error {
 	if err := c.transport.Connect(); err != nil {
 		return fmt.Errorf("dcerpc bind: %w", err)
 	}
 
 	c.callID = 1
-	c.contextID = 0
+
+	// Context 0 is always NDR 2.0; an optional context 1 offers NDR64. Each context
+	// carries a single transfer syntax so the bind_ack's per-context result identifies
+	// exactly which one the server chose.
+	contexts := []pdu.ContextElement{
+		{
+			ContextID:        0,
+			AbstractSyntax:   abstractSyntax,
+			TransferSyntaxes: []syntax.SyntaxID{syntax.NDRTransferSyntax()},
+		},
+	}
+	if c.preferNDR64 {
+		contexts = append(contexts, pdu.ContextElement{
+			ContextID:        1,
+			AbstractSyntax:   abstractSyntax,
+			TransferSyntaxes: []syntax.SyntaxID{syntax.NDR64TransferSyntax()},
+		})
+	}
 
 	bind := &pdu.Bind{
 		MaxXmitFrag:  c.transport.MaxXmitFrag(),
 		MaxRecvFrag:  c.transport.MaxRecvFrag(),
 		AssocGroupID: 0,
-		ContextList: []pdu.ContextElement{
-			{
-				ContextID:        c.contextID,
-				AbstractSyntax:   abstractSyntax,
-				TransferSyntaxes: []syntax.SyntaxID{syntax.NDRTransferSyntax()},
-			},
-		},
+		ContextList:  contexts,
 	}
 	bind.Header = pdu.NewHeader(pdu.PacketTypeBind, pdu.PFCFirstFrag|pdu.PFCLastFrag, c.callID)
 
@@ -111,9 +142,12 @@ func (c *Client) Bind(abstractSyntax syntax.SyntaxID) error {
 		if _, err := ack.Unmarshal(respFrag); err != nil {
 			return fmt.Errorf("dcerpc bind: parse bind_ack: %w", err)
 		}
-		if !ack.Accepted() {
+		ctxID, negotiated, ok := selectContext(bind.ContextList, ack.Results)
+		if !ok {
 			return fmt.Errorf("dcerpc bind: server accepted no presentation context: %s", ack.String())
 		}
+		c.contextID = ctxID
+		c.negotiatedSyntax = negotiated
 		c.sendFragMax = negotiateSendMax(c.transport.MaxXmitFrag(), ack.MaxXmitFrag, ack.MaxRecvFrag)
 		c.bound = true
 		return nil
@@ -155,7 +189,7 @@ func (c *Client) Call(opnum uint16, stub []byte) ([]byte, error) {
 // the [out] parameter structure). out may be nil when the response carries no data.
 // A fault PDU is returned as a *pdu.Fault error, as with Call.
 func (c *Client) Invoke(in ndr.Call, out any) error {
-	stub, err := ndr.Request(in)
+	stub, err := ndr.RequestAs(in, c.negotiatedSyntax)
 	if err != nil {
 		return fmt.Errorf("dcerpc invoke (opnum %d): marshal request: %w", in.Opnum(), err)
 	}
@@ -166,10 +200,37 @@ func (c *Client) Invoke(in ndr.Call, out any) error {
 	if out == nil {
 		return nil
 	}
-	if err := ndr.Response(resp, out); err != nil {
+	if err := ndr.ResponseAs(resp, out, c.negotiatedSyntax); err != nil {
 		return fmt.Errorf("dcerpc invoke (opnum %d): unmarshal response: %w", in.Opnum(), err)
 	}
 	return nil
+}
+
+// selectContext chooses the accepted presentation context from a bind_ack, preferring
+// NDR64 when the server accepted it. It returns the context id to use on subsequent
+// requests and the negotiated transfer syntax. The result list is positional with the
+// proposed context list ([C706] section 12.6.3.1), so result i answers context i.
+func selectContext(contexts []pdu.ContextElement, results []pdu.PresentationResult) (uint16, ndr.Syntax, bool) {
+	var ndr20Ctx, ndr64Ctx uint16
+	var ndr20OK, ndr64OK bool
+	for i, r := range results {
+		if r.Result != pdu.ResultAcceptance || i >= len(contexts) {
+			continue
+		}
+		switch {
+		case r.TransferSyntax.Equal(syntax.NDR64TransferSyntax()):
+			ndr64Ctx, ndr64OK = contexts[i].ContextID, true
+		case r.TransferSyntax.Equal(syntax.NDRTransferSyntax()):
+			ndr20Ctx, ndr20OK = contexts[i].ContextID, true
+		}
+	}
+	if ndr64OK {
+		return ndr64Ctx, ndr.NDR64, true
+	}
+	if ndr20OK {
+		return ndr20Ctx, ndr.NDR20, true
+	}
+	return 0, ndr.NDR20, false
 }
 
 // sendRequest fragments stub into request PDUs no larger than the negotiated send

--- a/network/dcerpc/v5/client/ndr64_negotiation_test.go
+++ b/network/dcerpc/v5/client/ndr64_negotiation_test.go
@@ -1,0 +1,149 @@
+package client
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/pdu"
+)
+
+// bindAckResults builds a bind_ack with the given per-context results.
+func bindAckResults(t *testing.T, xmit, recv uint16, results ...pdu.PresentationResult) []byte {
+	t.Helper()
+	ack := &pdu.BindAck{
+		MaxXmitFrag:      xmit,
+		MaxRecvFrag:      recv,
+		SecondaryAddress: "lsarpc",
+		Results:          results,
+	}
+	return mustMarshal(t, ack)
+}
+
+func TestBind_DefaultProposesOnlyNDR20(t *testing.T) {
+	ft := &fakeTransport{maxXmit: 4280, maxRecv: 4280}
+	ft.queue(bindAckBytes(t, 4280, 4280))
+
+	c := NewClient(ft)
+	if err := c.Bind(testSyntax()); err != nil {
+		t.Fatalf("Bind() error = %v", err)
+	}
+	if c.NegotiatedSyntax() != ndr.NDR20 {
+		t.Errorf("negotiated syntax = %v, want NDR20", c.NegotiatedSyntax())
+	}
+
+	var bind pdu.Bind
+	if _, err := bind.Unmarshal(ft.sent[0]); err != nil {
+		t.Fatalf("sent bind does not parse: %v", err)
+	}
+	if len(bind.ContextList) != 1 {
+		t.Fatalf("default bind proposed %d contexts, want 1", len(bind.ContextList))
+	}
+}
+
+func TestBind_NegotiatesNDR64(t *testing.T) {
+	ft := &fakeTransport{maxXmit: 4280, maxRecv: 4280}
+	// Server accepts both contexts; the client must prefer NDR64 (context 1).
+	ft.queue(bindAckResults(t, 4280, 4280,
+		pdu.PresentationResult{Result: pdu.ResultAcceptance, TransferSyntax: syntax.NDRTransferSyntax()},
+		pdu.PresentationResult{Result: pdu.ResultAcceptance, TransferSyntax: syntax.NDR64TransferSyntax()},
+	))
+
+	c := NewClient(ft)
+	c.PreferNDR64(true)
+	if err := c.Bind(testSyntax()); err != nil {
+		t.Fatalf("Bind() error = %v", err)
+	}
+	if c.NegotiatedSyntax() != ndr.NDR64 {
+		t.Errorf("negotiated syntax = %v, want NDR64", c.NegotiatedSyntax())
+	}
+	if c.contextID != 1 {
+		t.Errorf("context id = %d, want 1 (the NDR64 context)", c.contextID)
+	}
+
+	var bind pdu.Bind
+	if _, err := bind.Unmarshal(ft.sent[0]); err != nil {
+		t.Fatalf("sent bind does not parse: %v", err)
+	}
+	if len(bind.ContextList) != 2 {
+		t.Fatalf("NDR64 bind proposed %d contexts, want 2", len(bind.ContextList))
+	}
+	if !bind.ContextList[0].TransferSyntaxes[0].Equal(syntax.NDRTransferSyntax()) {
+		t.Error("context 0 should propose NDR 2.0")
+	}
+	if !bind.ContextList[1].TransferSyntaxes[0].Equal(syntax.NDR64TransferSyntax()) {
+		t.Error("context 1 should propose NDR64")
+	}
+}
+
+func TestBind_NDR64FallsBackToNDR20(t *testing.T) {
+	ft := &fakeTransport{maxXmit: 4280, maxRecv: 4280}
+	// Server accepts NDR20 (context 0) and rejects NDR64 (context 1).
+	ft.queue(bindAckResults(t, 4280, 4280,
+		pdu.PresentationResult{Result: pdu.ResultAcceptance, TransferSyntax: syntax.NDRTransferSyntax()},
+		pdu.PresentationResult{Result: pdu.ResultProviderRejection, Reason: pdu.ReasonProposedTransferSyntaxesNotSupported},
+	))
+
+	c := NewClient(ft)
+	c.PreferNDR64(true)
+	if err := c.Bind(testSyntax()); err != nil {
+		t.Fatalf("Bind() error = %v", err)
+	}
+	if c.NegotiatedSyntax() != ndr.NDR20 {
+		t.Errorf("negotiated syntax = %v, want NDR20 (fallback)", c.NegotiatedSyntax())
+	}
+	if c.contextID != 0 {
+		t.Errorf("context id = %d, want 0 (the NDR 2.0 context)", c.contextID)
+	}
+}
+
+// confReq is an [in] parameter with a conformant array, whose NDR64 encoding (8-octet
+// maximum_count) differs from its NDR20 encoding (4-octet), so the request stub reveals
+// which transfer syntax the client used.
+type confReq struct {
+	Data []uint32 `ndr:"conformant"`
+}
+
+func (*confReq) Opnum() uint16 { return 9 }
+
+func TestInvoke_UsesNegotiatedNDR64(t *testing.T) {
+	ft := &fakeTransport{maxXmit: 4280, maxRecv: 4280}
+	ft.queue(bindAckResults(t, 4280, 4280,
+		pdu.PresentationResult{Result: pdu.ResultAcceptance, TransferSyntax: syntax.NDRTransferSyntax()},
+		pdu.PresentationResult{Result: pdu.ResultAcceptance, TransferSyntax: syntax.NDR64TransferSyntax()},
+	))
+	c := NewClient(ft)
+	c.PreferNDR64(true)
+	if err := c.Bind(testSyntax()); err != nil {
+		t.Fatalf("Bind() error = %v", err)
+	}
+
+	ft.queue(responseBytes(t, 2, pdu.PFCFirstFrag|pdu.PFCLastFrag, nil))
+
+	req := &confReq{Data: []uint32{0xAAAA, 0xBBBB}}
+	if err := c.Invoke(req, nil); err != nil {
+		t.Fatalf("Invoke() error = %v", err)
+	}
+
+	var sent pdu.Request
+	if _, err := sent.Unmarshal(ft.sent[1]); err != nil {
+		t.Fatalf("sent request does not parse: %v", err)
+	}
+	if sent.ContextID != 1 {
+		t.Errorf("request context id = %d, want 1 (NDR64)", sent.ContextID)
+	}
+
+	wantNDR64, err := ndr.MarshalAs(req, ndr.NDR64)
+	if err != nil {
+		t.Fatalf("MarshalAs NDR64: %v", err)
+	}
+	if !bytes.Equal(sent.Stub, wantNDR64) {
+		t.Errorf("request stub = %x, want NDR64 encoding %x", sent.Stub, wantNDR64)
+	}
+	// And it must not be the NDR20 encoding (the 8-octet count makes it longer).
+	ndr20, _ := ndr.Marshal(req)
+	if bytes.Equal(sent.Stub, ndr20) {
+		t.Error("request stub is the NDR20 encoding; negotiated NDR64 was not used")
+	}
+}


### PR DESCRIPTION
### Linked Issue
Part of #400 (NDR64 transfer syntax support). Phase 3 of the multi-phase implementation. **Stacked on #594** (phase 2, walker) which is itself stacked on #593 (phase 1, codec); this PR targets the phase-2 branch so its diff shows only the client changes. Retarget down the stack as the parents merge.

### Motivation
Phases 1 and 2 made the codec and the declarative walker NDR64-capable, but the connection-oriented client never proposed NDR64 at bind time and always marshalled stubs as NDR 2.0, so the new capability was unreachable end to end. NDR64 is selected purely through bind-time transfer-syntax negotiation ([MS-RPCE] 2.2.2.4) — the PDU data representation byte is unchanged — so the client must propose NDR64 and honour the server's choice.

### Fix Description
- `Client.PreferNDR64(bool)` opts into NDR64 (default off). When enabled, `Bind` proposes NDR 2.0 in presentation context 0 and NDR64 in context 1 — one transfer syntax per context, the negotiation shape Windows and impacket use — so the bind_ack's per-context result identifies exactly which syntax the server chose.
- `Bind` selects the accepted context via `selectContext`, which reads the positional `p_result_list` ([C706] 12.6.3.1), prefers NDR64 when the server accepted it, falls back to NDR 2.0, and errors if no context was accepted. The accepted context id and transfer syntax are recorded on the client.
- `Invoke` marshals the request and unmarshals the response under the negotiated syntax via `ndr.RequestAs`/`ndr.ResponseAs`, and `sendRequest` already uses the recorded context id.
- `Client.NegotiatedSyntax()` exposes the result for callers and tests.

The default path is unchanged: a single NDR 2.0 context, context id 0, and NDR20 stubs, byte-for-byte as before. An NDR64 call that reaches a union or pipe fails closed, because the walker rejects those under NDR64 (phase 2) until their own phases land.

### How Verified
- **Tests:** the existing v5 client suite passes unchanged (default NDR20 bind/call/invoke behaviour preserved). New tests in `ndr64_negotiation_test.go` drive `Bind`/`Invoke` over the in-memory transport with synthetic bind_ack PDUs: NDR64 selected when both contexts are accepted (context id 1), fallback to NDR 2.0 when NDR64 is rejected (context id 0), default proposes a single NDR 2.0 context, and `Invoke` after negotiating NDR64 sends on context 1 with a stub equal to the NDR64 encoding and not the NDR20 encoding (using a conformant-array parameter whose count width differs by syntax).
- **Static:** `go build ./...`, `go vet ./network/dcerpc/v5/...` clean.

### Test Coverage
**Added:** `network/dcerpc/v5/client/ndr64_negotiation_test.go` — `TestBind_DefaultProposesOnlyNDR20`, `TestBind_NegotiatesNDR64`, `TestBind_NDR64FallsBackToNDR20`, `TestInvoke_UsesNegotiatedNDR64`.

### Scope of Change
- **Files changed:** `network/dcerpc/v5/client/client.go`, `network/dcerpc/v5/client/ndr64_negotiation_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none — NDR64 is opt-in via `PreferNDR64`; with it off, the bind PDU, context id, and stub encoding are identical to before.

### Risk and Rollout
Low and opt-in: default behaviour is byte-identical NDR 2.0. A caller that enables NDR64 against a server that supports it will exchange NDR64 stubs for union/pipe-free interfaces and fail closed (a clear error) on the not-yet-implemented union/pipe constructs.

### Notes
The negotiation parsing is verified against synthetic bind_ack PDUs; end-to-end validation against a real server that negotiates NDR64 is recommended before production use, together with the capture-based validation of the NDR64 wire layouts noted in #594. Remaining phases under #400: NDR64 unions and NDR64 pipes (both currently fail closed).