### PR TITLE
Land NDR64 walker and client negotiation on main (#400)

### DIFF
--- a/network/dcerpc/ndr/marshal.go
+++ b/network/dcerpc/ndr/marshal.go
@@ -12,12 +12,18 @@ import (
 // referent id inline with their referent body deferred to the end of the enclosing
 // construction, per the deferral rule in [C706] section 14.3.10:
 // https://pubs.opengroup.org/onlinepubs/9629399/chap14.htm
-func Marshal(v any) ([]byte, error) {
+func Marshal(v any) ([]byte, error) { return MarshalAs(v, NDR20) }
+
+// MarshalAs is Marshal under an explicit transfer syntax. NDR64 widens counts and
+// referent ids to 8 octets and aligns them to 8 ([MS-RPCE] section 2.2.5). NDR64
+// unions and pipes are not yet supported and marshalling a value that contains one
+// returns an error rather than emitting an unverified encoding.
+func MarshalAs(v any, syntax Syntax) ([]byte, error) {
 	rv, err := structValue(reflect.ValueOf(v))
 	if err != nil {
 		return nil, err
 	}
-	e := NewEncoder()
+	e := NewEncoderForSyntax(syntax)
 	if err := marshalStruct(e, rv, false); err != nil {
 		return nil, err
 	}
@@ -26,7 +32,11 @@ func Marshal(v any) ([]byte, error) {
 
 // Unmarshal decodes an NDR octet stream into v, which must be a non-nil pointer to a
 // struct.
-func Unmarshal(data []byte, v any) error {
+func Unmarshal(data []byte, v any) error { return UnmarshalAs(data, v, NDR20) }
+
+// UnmarshalAs is Unmarshal under an explicit transfer syntax. See MarshalAs for the
+// NDR64 semantics and the union/pipe limitation.
+func UnmarshalAs(data []byte, v any, syntax Syntax) error {
 	rv := reflect.ValueOf(v)
 	if rv.Kind() != reflect.Pointer || rv.IsNil() {
 		return fmt.Errorf("ndr: Unmarshal requires a non-nil pointer, got %T", v)
@@ -35,7 +45,7 @@ func Unmarshal(data []byte, v any) error {
 	if err != nil {
 		return err
 	}
-	return unmarshalStruct(NewDecoder(data), sv, false)
+	return unmarshalStruct(NewDecoderForSyntax(data, syntax), sv, false)
 }
 
 // structValue dereferences pointers/interfaces to reach a struct value.
@@ -99,10 +109,10 @@ func marshalStructFields(e *Encoder, rv reflect.Value, embedded bool, deferred *
 	// representation ([C706] section 14.2.2). The first member self-aligns to its own
 	// size, which is insufficient when a later member is wider (e.g. RPC_UNICODE_STRING,
 	// whose Buffer pointer makes it 4-aligned, following a 2-byte discriminant).
-	e.Align(ndrAlignment(rt))
+	e.Align(ndrAlignment(rt, e.syntax))
 	confIdx := embeddedConformantIndex(rt, rv)
 	if confIdx >= 0 {
-		e.Align(conformantArrayAlignment(rv.Field(confIdx).Type().Elem()))
+		e.Align(conformantArrayAlignment(rv.Field(confIdx).Type().Elem(), e.syntax))
 		e.writeCount(uint64(rv.Field(confIdx).Len())) // hoisted maximum_count
 	}
 	// A field named by another field's size_is/length_is is the array's count; its
@@ -358,11 +368,11 @@ func unmarshalStruct(d *Decoder, rv reflect.Value, embedded bool) error {
 // marshalStructFields for why arrays need this. Returns the `retval` field index or -1.
 func unmarshalStructFields(d *Decoder, rv reflect.Value, embedded bool, deferred *[]func() error) (int, error) {
 	rt := rv.Type()
-	d.Align(ndrAlignment(rt)) // a structure is aligned to its largest member ([C706] 14.2.2)
+	d.Align(ndrAlignment(rt, d.syntax)) // a structure is aligned to its largest member ([C706] 14.2.2)
 	confIdx := embeddedConformantIndex(rt, rv)
 	var confCount uint64
 	if confIdx >= 0 {
-		d.Align(conformantArrayAlignment(rv.Field(confIdx).Type().Elem()))
+		d.Align(conformantArrayAlignment(rv.Field(confIdx).Type().Elem(), d.syntax))
 		c, err := d.readCount() // hoisted maximum_count
 		if err != nil {
 			return -1, err
@@ -706,8 +716,12 @@ func isEmbeddedConformantArray(fv reflect.Value, tag fieldTag) bool {
 	return fv.Kind() == reflect.Slice && !tag.pipe && !isPointerLike(fv, tag)
 }
 
-// ndrAlignment returns the NDR alignment, in octets, of a value of type t.
-func ndrAlignment(t reflect.Type) int {
+// ndrAlignment returns the NDR alignment, in octets, of a value of type t under the
+// given transfer syntax. Strings, pointers, and slices lead with a referent id or a
+// conformance count, which widen from 4 octets 4-aligned (NDR20) to 8 octets 8-aligned
+// (NDR64), so those kinds align to 8 under NDR64 ([MS-RPCE] section 2.2.5). Fixed scalar
+// kinds keep their natural alignment in both syntaxes.
+func ndrAlignment(t reflect.Type, syntax Syntax) int {
 	if reflect.PointerTo(t).Implements(marshalerType) {
 		return reflect.New(t).Interface().(Marshaler).AlignmentNDR()
 	}
@@ -716,17 +730,45 @@ func ndrAlignment(t reflect.Type) int {
 		return 1
 	case reflect.Uint16, reflect.Int16:
 		return 2
-	case reflect.Uint32, reflect.Int32, reflect.Uint, reflect.Int, reflect.String, reflect.Pointer:
+	case reflect.Uint32, reflect.Int32, reflect.Uint, reflect.Int:
 		return 4
 	case reflect.Uint64, reflect.Int64:
 		return 8
+	case reflect.String, reflect.Pointer, reflect.Slice:
+		// A string/slice begins with a conformance count and a pointer with a referent
+		// id; both are 8-octet 8-aligned under NDR64 and 4-octet 4-aligned under NDR20.
+		if syntax == NDR64 {
+			return 8
+		}
+		return 4
+	case reflect.Array:
+		// A fixed array aligns to its element. Under NDR20 the historical behaviour is
+		// the catch-all alignment of 4, preserved to keep NDR20 output byte-identical.
+		if syntax == NDR64 {
+			return ndrAlignment(t.Elem(), syntax)
+		}
+		return 4
 	case reflect.Struct:
 		a := 1
 		for i := 0; i < t.NumField(); i++ {
-			if t.Field(i).PkgPath != "" {
+			f := t.Field(i)
+			if f.PkgPath != "" {
 				continue
 			}
-			if fa := ndrAlignment(t.Field(i).Type); fa > a {
+			// NDR20 aligns to the widest member type, ignoring tags (preserved exactly).
+			// NDR64 is tag-aware: a value field tagged as a pointer ([unique]/[ref]/[ptr])
+			// is a referent id inline, so it aligns to 8 regardless of the value's layout.
+			var fa int
+			if syntax == NDR64 {
+				tag := parseTag(f.Tag.Get("ndr"))
+				if tag.skip {
+					continue
+				}
+				fa = fieldNDRAlignment(f.Type, tag, syntax)
+			} else {
+				fa = ndrAlignment(f.Type, syntax)
+			}
+			if fa > a {
 				a = fa
 			}
 		}
@@ -736,28 +778,46 @@ func ndrAlignment(t reflect.Type) int {
 	}
 }
 
+// fieldNDRAlignment returns the alignment of a struct field, accounting for a pointer
+// tag on a non-pointer Go type (e.g. a value struct tagged [unique]), whose inline
+// representation is a referent id rather than the field's own layout.
+func fieldNDRAlignment(t reflect.Type, tag fieldTag, syntax Syntax) int {
+	if tag.ptr != ptrNone && t.Kind() != reflect.Pointer {
+		if syntax == NDR64 {
+			return 8
+		}
+		return 4
+	}
+	return ndrAlignment(t, syntax)
+}
+
 // conformantArrayAlignment returns the alignment of a conformant array of the given
-// element type: the larger of the size determinant's alignment (4) and the element
-// alignment ([C706] section 14.3.3.1).
-func conformantArrayAlignment(elemType reflect.Type) int {
-	if a := ndrAlignment(elemType); a > 4 {
+// element type under the given syntax: the larger of the size determinant's alignment
+// (4 under NDR20, 8 under NDR64) and the element alignment ([C706] section 14.3.3.1,
+// [MS-RPCE] section 2.2.5).
+func conformantArrayAlignment(elemType reflect.Type, syntax Syntax) int {
+	det := 4
+	if syntax == NDR64 {
+		det = 8
+	}
+	if a := ndrAlignment(elemType, syntax); a > det {
 		return a
 	}
-	return 4
+	return det
 }
 
 // marshalConformantArray writes a conformant array: a maximum_count followed by the
 // elements, per [MS-RPCE] Conformant Arrays:
 // https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/140b01a3-979b-43af-b1e3-28f248db8f03
 func marshalConformantArray(e *Encoder, slice reflect.Value, maxCount uint32, elemTag fieldTag) error {
-	e.Align(conformantArrayAlignment(slice.Type().Elem()))
+	e.Align(conformantArrayAlignment(slice.Type().Elem(), e.syntax))
 	e.writeCount(uint64(maxCount))
 	return marshalElements(e, slice, elemTag)
 }
 
 // unmarshalConformantArray reads a maximum_count-prefixed array into slice.
 func unmarshalConformantArray(d *Decoder, slice reflect.Value, elemTag fieldTag) error {
-	d.Align(conformantArrayAlignment(slice.Type().Elem()))
+	d.Align(conformantArrayAlignment(slice.Type().Elem(), d.syntax))
 	n, err := d.readCount()
 	if err != nil {
 		return err
@@ -776,7 +836,7 @@ func marshalConformantVaryingArray(e *Encoder, slice reflect.Value, maxCount, ac
 	if int(actualCount) > slice.Len() {
 		actualCount = uint32(slice.Len())
 	}
-	e.Align(conformantArrayAlignment(slice.Type().Elem()))
+	e.Align(conformantArrayAlignment(slice.Type().Elem(), e.syntax))
 	e.writeCount(uint64(maxCount))    // maximum_count
 	e.writeCount(0)                   // offset
 	e.writeCount(uint64(actualCount)) // actual_count
@@ -786,7 +846,7 @@ func marshalConformantVaryingArray(e *Encoder, slice reflect.Value, maxCount, ac
 // unmarshalConformantVaryingArray reads a conformant-varying array, using the
 // actual_count to size the result.
 func unmarshalConformantVaryingArray(d *Decoder, slice reflect.Value, elemTag fieldTag) error {
-	d.Align(conformantArrayAlignment(slice.Type().Elem()))
+	d.Align(conformantArrayAlignment(slice.Type().Elem(), d.syntax))
 	if _, err := d.readCount(); err != nil { // maximum_count
 		return err
 	}
@@ -812,10 +872,13 @@ func unmarshalConformantVaryingArray(d *Decoder, slice reflect.Value, elemTag fi
 // of a scalar (e.g. EFS_EXIM_PIPE = pipe of bytes) goes through marshalElements, which
 // has a byte fast path.
 //
-// The chunk count is kept a 4-octet value here regardless of syntax: NDR64 pipe framing
-// is not yet verified against [MS-RPCE] section 2.2.5 and is handled in a later phase,
-// so it deliberately does not route through writeCount.
+// NDR64 pipe framing is not yet verified against [MS-RPCE] section 2.2.5 and is handled
+// in a later phase, so marshalling a pipe under NDR64 returns an error rather than
+// emitting an unverified encoding.
 func marshalPipe(e *Encoder, fv reflect.Value, tag fieldTag) error {
+	if e.syntax == NDR64 {
+		return fmt.Errorf("ndr: NDR64 pipes are not yet supported")
+	}
 	if fv.Kind() != reflect.Slice {
 		return fmt.Errorf("ndr: pipe field must be a slice, got %s", fv.Kind())
 	}
@@ -833,6 +896,9 @@ func marshalPipe(e *Encoder, fv reflect.Value, tag fieldTag) error {
 // 0-count chunk, concatenating the chunks into the slice. unmarshalElements bounds each
 // chunk's count against the remaining input, so a hostile count cannot over-allocate.
 func unmarshalPipe(d *Decoder, fv reflect.Value, tag fieldTag) error {
+	if d.syntax == NDR64 {
+		return fmt.Errorf("ndr: NDR64 pipes are not yet supported")
+	}
 	if fv.Kind() != reflect.Slice {
 		return fmt.Errorf("ndr: pipe field must be a slice, got %s", fv.Kind())
 	}

--- a/network/dcerpc/ndr/ndr64_walker_test.go
+++ b/network/dcerpc/ndr/ndr64_walker_test.go
@@ -1,0 +1,166 @@
+package ndr
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// sidLikeNDR64 mirrors RPC_SID: a structure embedding a conformant array, so its
+// maximum_count is hoisted to the front of the struct ([C706] 14.3.3.1) — 8 octets,
+// 8-aligned under NDR64.
+type sidLikeNDR64 struct {
+	Revision uint8
+	Count    uint8
+	Auth     [6]byte
+	Sub      []uint32 `ndr:"conformant,size_is=Count"`
+}
+
+// TestNDR64_EmbeddedConformantArray pins the NDR64 layout of a SID-shaped struct: an
+// 8-octet hoisted maximum_count, then the fixed members, then the 4-byte elements.
+func TestNDR64_EmbeddedConformantArray(t *testing.T) {
+	v := sidLikeNDR64{Revision: 1, Auth: [6]byte{0, 0, 0, 0, 0, 5}, Sub: []uint32{32, 544}}
+	got, err := MarshalAs(v, NDR64)
+	if err != nil {
+		t.Fatalf("MarshalAs NDR64: %v", err)
+	}
+	want := []byte{
+		0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // maximum_count = 2 (8 octets)
+		0x01,                               // Revision
+		0x02,                               // SubAuthorityCount (derived from len)
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x05, // IdentifierAuthority (6 octets, big-endian)
+		0x20, 0x00, 0x00, 0x00, // 32
+		0x20, 0x02, 0x00, 0x00, // 544
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("NDR64 SID layout:\n got %x\nwant %x", got, want)
+	}
+
+	var rt sidLikeNDR64
+	if err := UnmarshalAs(got, &rt, NDR64); err != nil {
+		t.Fatalf("UnmarshalAs NDR64: %v", err)
+	}
+	if rt.Revision != 1 || rt.Count != 2 || rt.Auth != v.Auth || len(rt.Sub) != 2 || rt.Sub[0] != 32 || rt.Sub[1] != 544 {
+		t.Errorf("NDR64 SID round trip: got %+v want %+v", rt, v)
+	}
+}
+
+type innerNDR64 struct{ X uint32 }
+
+type outerNDR64 struct {
+	A uint32
+	P *innerNDR64 `ndr:"unique"`
+}
+
+// TestNDR64_UniquePointer pins the NDR64 layout of a [unique] pointer member: a struct
+// alignment of 8 (the referent widens to 8 octets), an 8-octet referent id, then the
+// pointed-to struct marshalled in place (a top-level pointer's body is not deferred).
+func TestNDR64_UniquePointer(t *testing.T) {
+	v := outerNDR64{A: 0x11111111, P: &innerNDR64{X: 0x22222222}}
+	got, err := MarshalAs(v, NDR64)
+	if err != nil {
+		t.Fatalf("MarshalAs NDR64: %v", err)
+	}
+	want := []byte{
+		0x11, 0x11, 0x11, 0x11, // A
+		0x00, 0x00, 0x00, 0x00, // pad: referent id 8-aligned under NDR64
+		0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, // referent id (8 octets)
+		0x22, 0x22, 0x22, 0x22, // P.X
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("NDR64 unique pointer layout:\n got %x\nwant %x", got, want)
+	}
+
+	var rt outerNDR64
+	if err := UnmarshalAs(got, &rt, NDR64); err != nil {
+		t.Fatalf("UnmarshalAs NDR64: %v", err)
+	}
+	if rt.A != v.A || rt.P == nil || rt.P.X != v.P.X {
+		t.Errorf("NDR64 unique pointer round trip: got %+v want %+v", rt, v)
+	}
+}
+
+type uniStrNDR64 struct {
+	Length uint16
+	MaxLen uint16
+	Buffer []uint16 `ndr:"unique,varying,size_is=MaxLen/2,length_is=Length/2"`
+}
+
+// TestNDR64_ConformantVaryingString round-trips an RPC_UNICODE_STRING-shaped value
+// under NDR64, exercising 8-octet referent id, divisor-resolved counts, and the
+// conformant-varying framing.
+func TestNDR64_ConformantVaryingString(t *testing.T) {
+	v := uniStrNDR64{Length: 4, MaxLen: 4, Buffer: []uint16{0x48, 0x69}} // "Hi"
+	b, err := MarshalAs(v, NDR64)
+	if err != nil {
+		t.Fatalf("MarshalAs NDR64: %v", err)
+	}
+	var rt uniStrNDR64
+	if err := UnmarshalAs(b, &rt, NDR64); err != nil {
+		t.Fatalf("UnmarshalAs NDR64: %v", err)
+	}
+	if rt.Length != 4 || rt.MaxLen != 4 || len(rt.Buffer) != 2 || rt.Buffer[0] != 0x48 || rt.Buffer[1] != 0x69 {
+		t.Errorf("NDR64 unicode string round trip: got %+v want %+v", rt, v)
+	}
+}
+
+// TestNDR64_ScalarStructMatchesNDR20 confirms a struct with no counts or referents is
+// byte-identical under both syntaxes (nothing widens).
+func TestNDR64_ScalarStructMatchesNDR20(t *testing.T) {
+	type flat struct {
+		A uint16
+		B uint32
+		C uint64
+	}
+	v := flat{A: 0xaabb, B: 0xccddeeff, C: 0x0102030405060708}
+	n20, err := MarshalAs(v, NDR20)
+	if err != nil {
+		t.Fatalf("NDR20: %v", err)
+	}
+	n64, err := MarshalAs(v, NDR64)
+	if err != nil {
+		t.Fatalf("NDR64: %v", err)
+	}
+	if !bytes.Equal(n20, n64) {
+		t.Errorf("scalar struct differs by syntax:\nNDR20 %x\nNDR64 %x", n20, n64)
+	}
+}
+
+type unionArm64 struct {
+	Tag uint32 `ndr:"switch"`
+	A   uint32 `ndr:"case=1"`
+}
+
+type hasUnion64 struct {
+	U unionArm64
+}
+
+type hasPipe64 struct {
+	P []byte `ndr:"pipe"`
+}
+
+// TestNDR64_UnionRejected verifies a union is rejected under NDR64 (deferred to a later
+// phase) rather than emitting an unverified encoding, while NDR20 still works.
+func TestNDR64_UnionRejected(t *testing.T) {
+	v := hasUnion64{U: unionArm64{Tag: 1, A: 7}}
+	if _, err := MarshalAs(v, NDR20); err != nil {
+		t.Fatalf("NDR20 union should still marshal: %v", err)
+	}
+	_, err := MarshalAs(v, NDR64)
+	if err == nil || !strings.Contains(err.Error(), "NDR64 unions") {
+		t.Errorf("NDR64 union: err = %v, want a 'NDR64 unions' error", err)
+	}
+}
+
+// TestNDR64_PipeRejected verifies a pipe is rejected under NDR64 rather than emitting an
+// unverified encoding, while NDR20 still works.
+func TestNDR64_PipeRejected(t *testing.T) {
+	v := hasPipe64{P: []byte{1, 2, 3}}
+	if _, err := MarshalAs(v, NDR20); err != nil {
+		t.Fatalf("NDR20 pipe should still marshal: %v", err)
+	}
+	_, err := MarshalAs(v, NDR64)
+	if err == nil || !strings.Contains(err.Error(), "NDR64 pipes") {
+		t.Errorf("NDR64 pipe: err = %v, want a 'NDR64 pipes' error", err)
+	}
+}

--- a/network/dcerpc/ndr/types.go
+++ b/network/dcerpc/ndr/types.go
@@ -65,10 +65,21 @@ func Request(call Call) ([]byte, error) {
 	return Marshal(call)
 }
 
+// RequestAs is Request under an explicit transfer syntax, used by a client that has
+// negotiated NDR64 ([MS-RPCE] section 2.2.5).
+func RequestAs(call Call, syntax Syntax) ([]byte, error) {
+	return MarshalAs(call, syntax)
+}
+
 // Response unmarshals an RPC response stub into out (a pointer to the [out] parameter
 // structure).
 func Response(stub []byte, out any) error {
 	return Unmarshal(stub, out)
+}
+
+// ResponseAs is Response under an explicit transfer syntax.
+func ResponseAs(stub []byte, out any, syntax Syntax) error {
+	return UnmarshalAs(stub, out, syntax)
 }
 
 // ptrKind is the NDR pointer attribute of a field.

--- a/network/dcerpc/ndr/union.go
+++ b/network/dcerpc/ndr/union.go
@@ -1,6 +1,9 @@
 package ndr
 
-import "reflect"
+import (
+	"fmt"
+	"reflect"
+)
 
 // NDR discriminated unions, declared with struct tags rather than the Marshaler escape
 // hatch. A union is a Go struct with one field tagged `switch` (the discriminant) and
@@ -78,7 +81,7 @@ func unionArm(rt reflect.Type, disc reflect.Value) int {
 // unionArmAlignment returns the largest NDR alignment among the union's arms (the
 // case/default fields), which is the alignment applied to the selected arm so its
 // position does not depend on which arm was sent ([C706] section 14.3.8).
-func unionArmAlignment(rt reflect.Type) int {
+func unionArmAlignment(rt reflect.Type, syntax Syntax) int {
 	a := 1
 	for i := 0; i < rt.NumField(); i++ {
 		f := rt.Field(i)
@@ -89,7 +92,7 @@ func unionArmAlignment(rt reflect.Type) int {
 		if !tag.hasCase && !tag.isDefault {
 			continue
 		}
-		if fa := ndrAlignment(f.Type); fa > a {
+		if fa := ndrAlignment(f.Type, syntax); fa > a {
 			a = fa
 		}
 	}
@@ -101,6 +104,9 @@ func unionArmAlignment(rt reflect.Type) int {
 // a [unique]/[ref] pointer to a structure) emits a referent id with its body deferred to
 // the end of the union construction.
 func marshalUnion(e *Encoder, rv reflect.Value, swIdx int) error {
+	if e.syntax == NDR64 {
+		return fmt.Errorf("ndr: NDR64 unions are not yet supported")
+	}
 	rt := rv.Type()
 	disc := rv.Field(swIdx)
 	// The discriminant is aligned to its own alignment. The selected arm is then aligned
@@ -109,7 +115,7 @@ func marshalUnion(e *Encoder, rv reflect.Value, swIdx int) error {
 	// LSAPR_POLICY_INFORMATION's 2-byte server-role arm still starts 8-aligned because
 	// other arms carry 8-byte LARGE_INTEGER members. (Note this padding follows the tag,
 	// so it does not over-align the discriminant itself.)
-	e.Align(ndrAlignment(disc.Type()))
+	e.Align(ndrAlignment(disc.Type(), e.syntax))
 	if err := marshalScalar(e, disc); err != nil {
 		return err
 	}
@@ -117,7 +123,7 @@ func marshalUnion(e *Encoder, rv reflect.Value, swIdx int) error {
 	if armIdx < 0 {
 		return nil // discriminant value with no arm and no default: empty body
 	}
-	e.Align(unionArmAlignment(rt))
+	e.Align(unionArmAlignment(rt, e.syntax))
 	f := rt.Field(armIdx)
 	var deferred []func() error
 	if err := marshalFieldInline(e, rv.Field(armIdx), parseTag(f.Tag.Get("ndr")), &deferred, true); err != nil {
@@ -129,9 +135,12 @@ func marshalUnion(e *Encoder, rv reflect.Value, swIdx int) error {
 // unmarshalUnion reads the discriminant, selects the matching arm, and leaves the other
 // arm fields zero.
 func unmarshalUnion(d *Decoder, rv reflect.Value, swIdx int) error {
+	if d.syntax == NDR64 {
+		return fmt.Errorf("ndr: NDR64 unions are not yet supported")
+	}
 	rt := rv.Type()
 	disc := rv.Field(swIdx)
-	d.Align(ndrAlignment(disc.Type())) // discriminant aligned to itself
+	d.Align(ndrAlignment(disc.Type(), d.syntax)) // discriminant aligned to itself
 	if err := unmarshalScalar(d, disc); err != nil {
 		return err
 	}
@@ -139,7 +148,7 @@ func unmarshalUnion(d *Decoder, rv reflect.Value, swIdx int) error {
 	if armIdx < 0 {
 		return nil
 	}
-	d.Align(unionArmAlignment(rt)) // arm aligned to the largest alignment among all arms
+	d.Align(unionArmAlignment(rt, d.syntax)) // arm aligned to the largest alignment among all arms
 	f := rt.Field(armIdx)
 	var deferred []func() error
 	if err := unmarshalFieldInline(d, rv.Field(armIdx), parseTag(f.Tag.Get("ndr")), &deferred, true); err != nil {

--- a/network/dcerpc/v5/client/client.go
+++ b/network/dcerpc/v5/client/client.go
@@ -52,6 +52,14 @@ type Client struct {
 	// derived from the bind_ack.
 	sendFragMax uint16
 
+	// preferNDR64 makes Bind additionally propose the NDR64 transfer syntax and prefer
+	// it when the server accepts it. Default false: NDR20 only, identical to before.
+	preferNDR64 bool
+
+	// negotiatedSyntax is the transfer syntax the server accepted at Bind; Invoke
+	// marshals and unmarshals stubs under it. Default NDR20.
+	negotiatedSyntax ndr.Syntax
+
 	bound bool
 }
 
@@ -62,29 +70,52 @@ func NewClient(t transport.Transport) *Client {
 	return &Client{transport: t}
 }
 
+// PreferNDR64 controls whether Bind proposes the NDR64 transfer syntax in addition to
+// NDR 2.0 and uses it when the server accepts it. It must be called before Bind. The
+// default is false (NDR 2.0 only).
+func (c *Client) PreferNDR64(enable bool) { c.preferNDR64 = enable }
+
+// NegotiatedSyntax reports the transfer syntax the server accepted at Bind. It is
+// meaningful only after a successful Bind.
+func (c *Client) NegotiatedSyntax() ndr.Syntax { return c.negotiatedSyntax }
+
 // Bind connects the transport and binds to the interface identified by
-// abstractSyntax, negotiating the NDR 2.0 transfer syntax in a single presentation
-// context. It returns an error if the server rejects the bind (bind_nak) or accepts
-// no context.
+// abstractSyntax. It proposes the NDR 2.0 transfer syntax in presentation context 0,
+// and — when PreferNDR64 is enabled — NDR64 in a second context (the established
+// negotiation pattern: one transfer syntax per context, [MS-RPCE] 2.2.2.4). The
+// transfer syntax the server accepts is recorded for subsequent calls, preferring
+// NDR64 when both are accepted. It returns an error if the server rejects the bind
+// (bind_nak) or accepts no context.
 func (c *Client) Bind(abstractSyntax syntax.SyntaxID) error {
 	if err := c.transport.Connect(); err != nil {
 		return fmt.Errorf("dcerpc bind: %w", err)
 	}
 
 	c.callID = 1
-	c.contextID = 0
+
+	// Context 0 is always NDR 2.0; an optional context 1 offers NDR64. Each context
+	// carries a single transfer syntax so the bind_ack's per-context result identifies
+	// exactly which one the server chose.
+	contexts := []pdu.ContextElement{
+		{
+			ContextID:        0,
+			AbstractSyntax:   abstractSyntax,
+			TransferSyntaxes: []syntax.SyntaxID{syntax.NDRTransferSyntax()},
+		},
+	}
+	if c.preferNDR64 {
+		contexts = append(contexts, pdu.ContextElement{
+			ContextID:        1,
+			AbstractSyntax:   abstractSyntax,
+			TransferSyntaxes: []syntax.SyntaxID{syntax.NDR64TransferSyntax()},
+		})
+	}
 
 	bind := &pdu.Bind{
 		MaxXmitFrag:  c.transport.MaxXmitFrag(),
 		MaxRecvFrag:  c.transport.MaxRecvFrag(),
 		AssocGroupID: 0,
-		ContextList: []pdu.ContextElement{
-			{
-				ContextID:        c.contextID,
-				AbstractSyntax:   abstractSyntax,
-				TransferSyntaxes: []syntax.SyntaxID{syntax.NDRTransferSyntax()},
-			},
-		},
+		ContextList:  contexts,
 	}
 	bind.Header = pdu.NewHeader(pdu.PacketTypeBind, pdu.PFCFirstFrag|pdu.PFCLastFrag, c.callID)
 
@@ -111,9 +142,12 @@ func (c *Client) Bind(abstractSyntax syntax.SyntaxID) error {
 		if _, err := ack.Unmarshal(respFrag); err != nil {
 			return fmt.Errorf("dcerpc bind: parse bind_ack: %w", err)
 		}
-		if !ack.Accepted() {
+		ctxID, negotiated, ok := selectContext(bind.ContextList, ack.Results)
+		if !ok {
 			return fmt.Errorf("dcerpc bind: server accepted no presentation context: %s", ack.String())
 		}
+		c.contextID = ctxID
+		c.negotiatedSyntax = negotiated
 		c.sendFragMax = negotiateSendMax(c.transport.MaxXmitFrag(), ack.MaxXmitFrag, ack.MaxRecvFrag)
 		c.bound = true
 		return nil
@@ -155,7 +189,7 @@ func (c *Client) Call(opnum uint16, stub []byte) ([]byte, error) {
 // the [out] parameter structure). out may be nil when the response carries no data.
 // A fault PDU is returned as a *pdu.Fault error, as with Call.
 func (c *Client) Invoke(in ndr.Call, out any) error {
-	stub, err := ndr.Request(in)
+	stub, err := ndr.RequestAs(in, c.negotiatedSyntax)
 	if err != nil {
 		return fmt.Errorf("dcerpc invoke (opnum %d): marshal request: %w", in.Opnum(), err)
 	}
@@ -166,10 +200,37 @@ func (c *Client) Invoke(in ndr.Call, out any) error {
 	if out == nil {
 		return nil
 	}
-	if err := ndr.Response(resp, out); err != nil {
+	if err := ndr.ResponseAs(resp, out, c.negotiatedSyntax); err != nil {
 		return fmt.Errorf("dcerpc invoke (opnum %d): unmarshal response: %w", in.Opnum(), err)
 	}
 	return nil
+}
+
+// selectContext chooses the accepted presentation context from a bind_ack, preferring
+// NDR64 when the server accepted it. It returns the context id to use on subsequent
+// requests and the negotiated transfer syntax. The result list is positional with the
+// proposed context list ([C706] section 12.6.3.1), so result i answers context i.
+func selectContext(contexts []pdu.ContextElement, results []pdu.PresentationResult) (uint16, ndr.Syntax, bool) {
+	var ndr20Ctx, ndr64Ctx uint16
+	var ndr20OK, ndr64OK bool
+	for i, r := range results {
+		if r.Result != pdu.ResultAcceptance || i >= len(contexts) {
+			continue
+		}
+		switch {
+		case r.TransferSyntax.Equal(syntax.NDR64TransferSyntax()):
+			ndr64Ctx, ndr64OK = contexts[i].ContextID, true
+		case r.TransferSyntax.Equal(syntax.NDRTransferSyntax()):
+			ndr20Ctx, ndr20OK = contexts[i].ContextID, true
+		}
+	}
+	if ndr64OK {
+		return ndr64Ctx, ndr.NDR64, true
+	}
+	if ndr20OK {
+		return ndr20Ctx, ndr.NDR20, true
+	}
+	return 0, ndr.NDR20, false
 }
 
 // sendRequest fragments stub into request PDUs no larger than the negotiated send

--- a/network/dcerpc/v5/client/ndr64_negotiation_test.go
+++ b/network/dcerpc/v5/client/ndr64_negotiation_test.go
@@ -1,0 +1,149 @@
+package client
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/pdu"
+)
+
+// bindAckResults builds a bind_ack with the given per-context results.
+func bindAckResults(t *testing.T, xmit, recv uint16, results ...pdu.PresentationResult) []byte {
+	t.Helper()
+	ack := &pdu.BindAck{
+		MaxXmitFrag:      xmit,
+		MaxRecvFrag:      recv,
+		SecondaryAddress: "lsarpc",
+		Results:          results,
+	}
+	return mustMarshal(t, ack)
+}
+
+func TestBind_DefaultProposesOnlyNDR20(t *testing.T) {
+	ft := &fakeTransport{maxXmit: 4280, maxRecv: 4280}
+	ft.queue(bindAckBytes(t, 4280, 4280))
+
+	c := NewClient(ft)
+	if err := c.Bind(testSyntax()); err != nil {
+		t.Fatalf("Bind() error = %v", err)
+	}
+	if c.NegotiatedSyntax() != ndr.NDR20 {
+		t.Errorf("negotiated syntax = %v, want NDR20", c.NegotiatedSyntax())
+	}
+
+	var bind pdu.Bind
+	if _, err := bind.Unmarshal(ft.sent[0]); err != nil {
+		t.Fatalf("sent bind does not parse: %v", err)
+	}
+	if len(bind.ContextList) != 1 {
+		t.Fatalf("default bind proposed %d contexts, want 1", len(bind.ContextList))
+	}
+}
+
+func TestBind_NegotiatesNDR64(t *testing.T) {
+	ft := &fakeTransport{maxXmit: 4280, maxRecv: 4280}
+	// Server accepts both contexts; the client must prefer NDR64 (context 1).
+	ft.queue(bindAckResults(t, 4280, 4280,
+		pdu.PresentationResult{Result: pdu.ResultAcceptance, TransferSyntax: syntax.NDRTransferSyntax()},
+		pdu.PresentationResult{Result: pdu.ResultAcceptance, TransferSyntax: syntax.NDR64TransferSyntax()},
+	))
+
+	c := NewClient(ft)
+	c.PreferNDR64(true)
+	if err := c.Bind(testSyntax()); err != nil {
+		t.Fatalf("Bind() error = %v", err)
+	}
+	if c.NegotiatedSyntax() != ndr.NDR64 {
+		t.Errorf("negotiated syntax = %v, want NDR64", c.NegotiatedSyntax())
+	}
+	if c.contextID != 1 {
+		t.Errorf("context id = %d, want 1 (the NDR64 context)", c.contextID)
+	}
+
+	var bind pdu.Bind
+	if _, err := bind.Unmarshal(ft.sent[0]); err != nil {
+		t.Fatalf("sent bind does not parse: %v", err)
+	}
+	if len(bind.ContextList) != 2 {
+		t.Fatalf("NDR64 bind proposed %d contexts, want 2", len(bind.ContextList))
+	}
+	if !bind.ContextList[0].TransferSyntaxes[0].Equal(syntax.NDRTransferSyntax()) {
+		t.Error("context 0 should propose NDR 2.0")
+	}
+	if !bind.ContextList[1].TransferSyntaxes[0].Equal(syntax.NDR64TransferSyntax()) {
+		t.Error("context 1 should propose NDR64")
+	}
+}
+
+func TestBind_NDR64FallsBackToNDR20(t *testing.T) {
+	ft := &fakeTransport{maxXmit: 4280, maxRecv: 4280}
+	// Server accepts NDR20 (context 0) and rejects NDR64 (context 1).
+	ft.queue(bindAckResults(t, 4280, 4280,
+		pdu.PresentationResult{Result: pdu.ResultAcceptance, TransferSyntax: syntax.NDRTransferSyntax()},
+		pdu.PresentationResult{Result: pdu.ResultProviderRejection, Reason: pdu.ReasonProposedTransferSyntaxesNotSupported},
+	))
+
+	c := NewClient(ft)
+	c.PreferNDR64(true)
+	if err := c.Bind(testSyntax()); err != nil {
+		t.Fatalf("Bind() error = %v", err)
+	}
+	if c.NegotiatedSyntax() != ndr.NDR20 {
+		t.Errorf("negotiated syntax = %v, want NDR20 (fallback)", c.NegotiatedSyntax())
+	}
+	if c.contextID != 0 {
+		t.Errorf("context id = %d, want 0 (the NDR 2.0 context)", c.contextID)
+	}
+}
+
+// confReq is an [in] parameter with a conformant array, whose NDR64 encoding (8-octet
+// maximum_count) differs from its NDR20 encoding (4-octet), so the request stub reveals
+// which transfer syntax the client used.
+type confReq struct {
+	Data []uint32 `ndr:"conformant"`
+}
+
+func (*confReq) Opnum() uint16 { return 9 }
+
+func TestInvoke_UsesNegotiatedNDR64(t *testing.T) {
+	ft := &fakeTransport{maxXmit: 4280, maxRecv: 4280}
+	ft.queue(bindAckResults(t, 4280, 4280,
+		pdu.PresentationResult{Result: pdu.ResultAcceptance, TransferSyntax: syntax.NDRTransferSyntax()},
+		pdu.PresentationResult{Result: pdu.ResultAcceptance, TransferSyntax: syntax.NDR64TransferSyntax()},
+	))
+	c := NewClient(ft)
+	c.PreferNDR64(true)
+	if err := c.Bind(testSyntax()); err != nil {
+		t.Fatalf("Bind() error = %v", err)
+	}
+
+	ft.queue(responseBytes(t, 2, pdu.PFCFirstFrag|pdu.PFCLastFrag, nil))
+
+	req := &confReq{Data: []uint32{0xAAAA, 0xBBBB}}
+	if err := c.Invoke(req, nil); err != nil {
+		t.Fatalf("Invoke() error = %v", err)
+	}
+
+	var sent pdu.Request
+	if _, err := sent.Unmarshal(ft.sent[1]); err != nil {
+		t.Fatalf("sent request does not parse: %v", err)
+	}
+	if sent.ContextID != 1 {
+		t.Errorf("request context id = %d, want 1 (NDR64)", sent.ContextID)
+	}
+
+	wantNDR64, err := ndr.MarshalAs(req, ndr.NDR64)
+	if err != nil {
+		t.Fatalf("MarshalAs NDR64: %v", err)
+	}
+	if !bytes.Equal(sent.Stub, wantNDR64) {
+		t.Errorf("request stub = %x, want NDR64 encoding %x", sent.Stub, wantNDR64)
+	}
+	// And it must not be the NDR20 encoding (the 8-octet count makes it longer).
+	ndr20, _ := ndr.Marshal(req)
+	if bytes.Equal(sent.Stub, ndr20) {
+		t.Error("request stub is the NDR20 encoding; negotiated NDR64 was not used")
+	}
+}


### PR DESCRIPTION
### Linked Issue
Part of #400 (NDR64 transfer syntax support). Re-lands the work from #594 (walker) and #595 (client negotiation), which were merged into the stacked intermediate branch rather than into `main` and so never reached it.

### Root Cause
The NDR64 work was opened as a stack of three PRs: #593 (codec plumbing) → `main`, #594 (walker) → the #593 branch, #595 (client negotiation) → the #594 branch. Only #593 merged into `main`. #594 and #595 were merged into `enhancement-ndr64-codec-plumbing` instead of being retargeted to `main` first, so their merge commits are not ancestors of `main`. As a result `main` has only the dormant Phase 1 codec primitives: `MarshalAs`/`RequestAs`/`PreferNDR64` are absent and the walker cannot produce or consume NDR64.

### Fix Description
Brings the Phase 2 and Phase 3 changes onto `main` by cherry-picking the two original code commits (`867ba15` walker, `a8e3bbf` client negotiation) onto current `main`, avoiding the nested PR-merge commits from the original stack for a clean two-commit history. No code was rewritten; the content is identical to what was approved in #594 and #595. The change is conflict-free against `main` (the only intervening change was unrelated Kerberos SPN work).

Contents (already reviewed in #594/#595):
- **Walker (#594):** `ndrAlignment`/`conformantArrayAlignment` are syntax-aware (8-octet, 8-aligned counts/referents under NDR64; tag-aware struct alignment); adds `MarshalAs`/`UnmarshalAs` and `RequestAs`/`ResponseAs`; unions and pipes fail closed under NDR64 pending verification (#596). NDR20 output is byte-identical.
- **Client negotiation (#595):** `Client.PreferNDR64` opts into proposing NDR64 in a second presentation context; `Bind` records the accepted transfer syntax (preferring NDR64, falling back to NDR 2.0); `Invoke` marshals/unmarshals under the negotiated syntax. Default behaviour is unchanged.

### How Verified
- **Tests:** full `go test ./network/dcerpc/...` passes. NDR20 output is byte-identical (existing suite); NDR64 walker golden-byte and round-trip tests and the client negotiation tests from #594/#595 are included and pass.
- **Static:** `go build ./...` clean. `git diff --stat origin/main` is exactly the six expected files (+508/-46); a trial merge into `main` was conflict-free.

### Test Coverage
**Existing (from #594/#595):** `network/dcerpc/ndr/ndr64_walker_test.go` and `network/dcerpc/v5/client/ndr64_negotiation_test.go`.

### Scope of Change
- **Files changed:** `network/dcerpc/ndr/marshal.go`, `network/dcerpc/ndr/types.go`, `network/dcerpc/ndr/union.go`, `network/dcerpc/ndr/ndr64_walker_test.go`, `network/dcerpc/v5/client/client.go`, `network/dcerpc/v5/client/ndr64_negotiation_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none — NDR20 output is byte-identical and NDR64 is opt-in.

### Risk and Rollout
Low: the diff is already-reviewed code, NDR20 behaviour is unchanged, and NDR64 is opt-in and fails closed on the unverified union/pipe constructs. Safe to merge without staged rollout.

### Notes
After this merges, `main` contains the full verified NDR64 surface (codec, walker, client negotiation). The remaining work — NDR64 unions and pipes — stays tracked in #596 pending capture-based verification. To avoid recurrence of the stranded-merge issue, future stacked PRs should be retargeted to `main` before merging once their parent lands.