### PR TITLE
Fix LSAPR_OBJECT_ATTRIBUTES NDR64 pointer encoding (#599)

### DIFF
--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/structures/LSAPR_OBJECT_ATTRIBUTES.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/structures/LSAPR_OBJECT_ATTRIBUTES.go
@@ -4,14 +4,19 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 )
 
-// LSAPR_OBJECT_ATTRIBUTES models LSAPR_OBJECT_ATTRIBUTES ([MS-LSAD] 2.2.2.3). All fields are
-// ignored by the server except RootDirectory, which must be NULL, so each is modeled
-// as a 4-octet zero field (the four pointer members as NULL referents).
+// LSAPR_OBJECT_ATTRIBUTES models LSAPR_OBJECT_ATTRIBUTES ([MS-LSAD] 2.2.2.3). The four
+// pointer members are [unique] pointers that the server ignores (RootDirectory must be
+// NULL); they are modeled as nil typed pointers, not as scalar fields, so the codec
+// emits a real referent id whose width tracks the transfer syntax — 4 octets under
+// NDR20, 8 octets 8-aligned under NDR64 ([MS-RPCE] section 2.2.5). A nil [unique]
+// pointer marshals to a zero referent identically in NDR20 to the previous DWORD zero,
+// so NDR20 output is unchanged; under NDR64 the previous DWORD model produced a 4-octet
+// field where the server expects an 8-octet referent, faulting nca_s_fault_ndr.
 type LSAPR_OBJECT_ATTRIBUTES struct {
 	Length                   ndr.DWORD
-	RootDirectory            ndr.DWORD // [unique] NULL
-	ObjectName               ndr.DWORD // [unique] NULL
+	RootDirectory            *uint32 `ndr:"unique"` // always NULL
+	ObjectName               *uint32 `ndr:"unique"` // always NULL
 	Attributes               ndr.DWORD
-	SecurityDescriptor       ndr.DWORD // [unique] NULL
-	SecurityQualityOfService ndr.DWORD // [unique] NULL
+	SecurityDescriptor       *uint32 `ndr:"unique"` // always NULL
+	SecurityQualityOfService *uint32 `ndr:"unique"` // always NULL
 }


### PR DESCRIPTION
### Linked Issue
Closes #599

### Root Cause
The four `[unique]` pointer members of `LSAPR_OBJECT_ATTRIBUTES` (`RootDirectory`, `ObjectName`, `SecurityDescriptor`, `SecurityQualityOfService`) were declared as `ndr.DWORD`. A NULL `[unique]` pointer encodes as a 4-octet zero referent under NDR20, so typing the members as a 4-octet scalar reproduced the correct NDR20 bytes — but it is not a pointer, so the reflection walker had nothing to widen for NDR64. Under NDR64 a `[unique]` pointer is an 8-octet, 8-aligned referent id and the enclosing structure is 8-aligned ([MS-RPCE] section 2.2.5), so the DWORD model emitted a 24-octet, 4-aligned structure where the wire format requires 48 octets, 8-aligned. The malformed stub caused the server to fault `nca_s_fault_ndr`.

### Fix Description
Model the four members as nil typed pointers (`*uint32` tagged `ndr:"unique"`) rather than `ndr.DWORD` scalars. The codec then emits a real referent id whose width tracks the negotiated transfer syntax: a 4-octet zero under NDR20 (identical to the previous DWORD zero) and an 8-octet, 8-aligned zero referent under NDR64. `Length` and `Attributes` remain `ndr.DWORD` (they are genuine `ULONG` fields). The pointed-to type is irrelevant on the wire because the values are always NULL, so a minimal `*uint32` is used with an explanatory doc comment. This is the only pointer-as-DWORD shortcut in `network/dcerpc/` (verified by a repo-wide search).

### How Verified
- **Runtime (before):** `LsarOpenPolicy` with `PreferNDR64(true)` against a live Windows Server 2016 host returned `DCE/RPC fault: status nca_s_fault_ndr`.
- **Runtime (after):** the same call now completes — `LsarOpenPolicy` followed by `LsarClose` both succeed under NDR64 (request marshalled, context-handle response decoded). NDR64 negotiation for `lsarpc` and `srvsvc` was confirmed in the same run.
- **Tests:** `go test -count=1 ./network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/...` passes, including the existing `LsarOpenPolicy` stub-byte assertions, confirming NDR20 output is byte-identical. Full `go build ./...` and `go test ./network/dcerpc/...` pass.

### Test Coverage
**Existing:** the LSA function tests (`functions/functions_test.go` and siblings) assert the NDR20 `LsarOpenPolicy` request stub bytes and pass unchanged after the fix, covering the NDR20 regression. NDR64 wire correctness is covered by the live validation above; an automated NDR64 byte assertion is best added once a captured reference exists (tracked under #596).

### Scope of Change
- **Files changed:** `network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/structures/LSAPR_OBJECT_ATTRIBUTES.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none — NDR20 output is byte-identical; only the NDR64 encoding of this structure changes.

### Risk and Rollout
Low and local: one structure, one file. NDR20 callers are unaffected (byte-identical, guarded by existing stub-byte tests); the change only corrects the NDR64 encoding, which is opt-in. Safe to merge without staged rollout.

### Notes
Builds on the NDR64 support merged under #400. The remaining NDR64 work — unions and pipes — stays tracked in #596 and still fails closed.