### PR TITLE
Fix NDR64 enum width to four octets (#602)

### DIFF
--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/07_LsarQueryInformationPolicy.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/07_LsarQueryInformationPolicy.go
@@ -12,7 +12,7 @@ import (
 // an open policy handle and the information class selecting which union arm is returned.
 type lsarQueryInformationPolicyRequest struct {
 	PolicyHandle     structures.LSAPR_HANDLE
-	InformationClass structures.POLICY_INFORMATION_CLASS
+	InformationClass structures.POLICY_INFORMATION_CLASS `ndr:"enum"`
 }
 
 func (*lsarQueryInformationPolicyRequest) Opnum() uint16 {

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/ndr64_enum_test.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/ndr64_enum_test.go
@@ -1,0 +1,79 @@
+package functions_test
+
+import (
+	"bytes"
+	"testing"
+
+	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/structures"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/pdu"
+)
+
+// sentRequestStub drives LsarQueryInformationPolicy over ft and returns the marshalled
+// request stub. The call's result is ignored: the request is sent before the response is
+// read, and the [out] union response is not the subject of this test.
+func sentRequestStub(t *testing.T, c *client.Client, ft *fakeTransport) []byte {
+	t.Helper()
+	var handle structures.LSAPR_HANDLE // zero (20-octet) handle
+	// A null PolicyInformation referent + zero status, valid under both syntaxes.
+	ft.queue(responsePDU(t, 2, make([]byte, 12)))
+	_, _ = functions.LsarQueryInformationPolicy(c, handle, structures.PolicyLsaServerRoleInformation)
+	if len(ft.sent) < 2 {
+		t.Fatalf("sent %d PDUs, want >= 2 (bind + request)", len(ft.sent))
+	}
+	var req pdu.Request
+	if _, err := req.Unmarshal(ft.sent[1]); err != nil {
+		t.Fatalf("request does not parse: %v", err)
+	}
+	if req.Opnum != lsarpc.OpnumLsarQueryInformationPolicy {
+		t.Fatalf("opnum = %d, want %d", req.Opnum, lsarpc.OpnumLsarQueryInformationPolicy)
+	}
+	return req.Stub
+}
+
+// TestLsarQueryInformationPolicy_EnumWidthBySyntax pins the InformationClass enum width
+// to the transfer syntax: 2 octets under NDR20 (unchanged), 4 octets under NDR64. The
+// NDR64 stub matches the request captured from a live Windows Server 2016 exchange,
+// which the server accepted (a 2-octet enum was rejected with nca_s_fault_ndr).
+func TestLsarQueryInformationPolicy_EnumWidthBySyntax(t *testing.T) {
+	// NDR20: 20-octet handle + 2-octet enum (level 6) = 22 octets.
+	ft20 := &fakeTransport{}
+	c20 := boundClient(t, ft20)
+	got20 := sentRequestStub(t, c20, ft20)
+	want20 := append(make([]byte, 20), 0x06, 0x00)
+	if !bytes.Equal(got20, want20) {
+		t.Errorf("NDR20 request stub:\n got  %x\nwant %x", got20, want20)
+	}
+
+	// NDR64: 20-octet handle + 4-octet enum (level 6) = 24 octets.
+	ft64 := &fakeTransport{}
+	ack := &pdu.BindAck{
+		MaxXmitFrag: 4280, MaxRecvFrag: 4280,
+		Results: []pdu.PresentationResult{
+			{Result: pdu.ResultProviderRejection, Reason: pdu.ReasonProposedTransferSyntaxesNotSupported},
+			{Result: pdu.ResultAcceptance, TransferSyntax: syntax.NDR64TransferSyntax()},
+		},
+	}
+	ackBytes, err := ack.Marshal()
+	if err != nil {
+		t.Fatalf("bind_ack marshal: %v", err)
+	}
+	ft64.queue(ackBytes)
+	c64 := client.NewClient(ft64)
+	c64.PreferNDR64(true)
+	if err := c64.Bind(lsarpc.SyntaxID()); err != nil {
+		t.Fatalf("Bind() error = %v", err)
+	}
+	if c64.NegotiatedSyntax() != ndr.NDR64 {
+		t.Fatalf("negotiated %s, want NDR64", c64.NegotiatedSyntax())
+	}
+	got64 := sentRequestStub(t, c64, ft64)
+	want64 := append(make([]byte, 20), 0x06, 0x00, 0x00, 0x00) // captured from Windows Server 2016
+	if !bytes.Equal(got64, want64) {
+		t.Errorf("NDR64 request stub:\n got  %x\nwant %x (captured from Windows Server 2016)", got64, want64)
+	}
+}

--- a/network/dcerpc/ndr/codec.go
+++ b/network/dcerpc/ndr/codec.go
@@ -139,6 +139,17 @@ func (e *Encoder) writeCount(v uint64) {
 	e.WriteUint32(uint32(v))
 }
 
+// writeEnum writes an NDR enumerated value: 2 octets 2-aligned under NDR20, or 4 octets
+// 4-aligned under NDR64 ([MS-RPCE] section 2.2.5; an NDR enum is a 16-bit value that
+// NDR64 widens to 32 bits).
+func (e *Encoder) writeEnum(v uint64) {
+	if e.syntax == NDR64 {
+		e.WriteUint32(uint32(v))
+		return
+	}
+	e.WriteUint16(uint16(v))
+}
+
 // writeReferent writes a pointer referent id at the syntax's referent width: 4 octets
 // under NDR20, 8 octets under NDR64.
 func (e *Encoder) writeReferent(id uint64) {
@@ -283,6 +294,17 @@ func (d *Decoder) readCount() (uint64, error) {
 		return d.ReadUint64()
 	}
 	v, err := d.ReadUint32()
+	return uint64(v), err
+}
+
+// readEnum reads an NDR enumerated value at the syntax's width: 2 octets under NDR20, 4
+// octets under NDR64.
+func (d *Decoder) readEnum() (uint64, error) {
+	if d.syntax == NDR64 {
+		v, err := d.ReadUint32()
+		return uint64(v), err
+	}
+	v, err := d.ReadUint16()
 	return uint64(v), err
 }
 

--- a/network/dcerpc/ndr/marshal.go
+++ b/network/dcerpc/ndr/marshal.go
@@ -250,6 +250,10 @@ func marshalInlineValue(e *Encoder, fv reflect.Value, tag fieldTag, deferred *[]
 		return m.MarshalNDR(e)
 	}
 
+	if tag.isEnum {
+		return marshalEnum(e, fv)
+	}
+
 	if isString, wide := stringMode(fv, tag); isString {
 		if wide {
 			e.writeWString(fv.String())
@@ -304,6 +308,35 @@ func marshalInlineValue(e *Encoder, fv reflect.Value, tag fieldTag, deferred *[]
 	default:
 		return marshalScalar(e, fv)
 	}
+}
+
+// marshalEnum writes an integer-kinded value as an NDR enum (2 octets under NDR20, 4
+// under NDR64), regardless of the Go integer width. An NDR enum is always a 16-bit
+// value on the wire under NDR20.
+func marshalEnum(e *Encoder, fv reflect.Value) error {
+	switch {
+	case isUintKind(fv.Kind()):
+		e.writeEnum(fv.Uint())
+	case fv.CanInt():
+		e.writeEnum(uint64(fv.Int()))
+	default:
+		return fmt.Errorf("ndr: enum field must be an integer, got %s", fv.Kind())
+	}
+	return nil
+}
+
+// unmarshalEnum reads an NDR enum into an integer-kinded value.
+func unmarshalEnum(d *Decoder, fv reflect.Value) error {
+	v, err := d.readEnum()
+	if err != nil {
+		return err
+	}
+	if isUintKind(fv.Kind()) {
+		fv.SetUint(v)
+	} else {
+		fv.SetInt(int64(v))
+	}
+	return nil
 }
 
 // marshalScalar writes an integer or boolean primitive with NDR alignment.
@@ -482,6 +515,10 @@ func unmarshalInlineValue(d *Decoder, fv reflect.Value, tag fieldTag, deferred *
 	if m, ok := asMarshalerAddr(fv); ok {
 		d.Align(m.AlignmentNDR())
 		return m.UnmarshalNDR(d)
+	}
+
+	if tag.isEnum {
+		return unmarshalEnum(d, fv)
 	}
 
 	if isString, wide := stringMode(fv, tag); isString {
@@ -778,10 +815,16 @@ func ndrAlignment(t reflect.Type, syntax Syntax) int {
 	}
 }
 
-// fieldNDRAlignment returns the alignment of a struct field, accounting for a pointer
-// tag on a non-pointer Go type (e.g. a value struct tagged [unique]), whose inline
-// representation is a referent id rather than the field's own layout.
+// fieldNDRAlignment returns the alignment of a struct field, accounting for tags whose
+// wire representation differs from the field's Go layout: a pointer tag on a non-pointer
+// type (a referent id) and an enum (2 octets under NDR20, 4 under NDR64).
 func fieldNDRAlignment(t reflect.Type, tag fieldTag, syntax Syntax) int {
+	if tag.isEnum {
+		if syntax == NDR64 {
+			return 4
+		}
+		return 2
+	}
 	if tag.ptr != ptrNone && t.Kind() != reflect.Pointer {
 		if syntax == NDR64 {
 			return 8

--- a/network/dcerpc/ndr/types.go
+++ b/network/dcerpc/ndr/types.go
@@ -112,6 +112,7 @@ type fieldTag struct {
 	retval         bool    // RPC return value: encoded after the struct's deferred referents
 	elemPtr        ptrKind // pointer attribute of array elements (`elem=ref|unique|ptr`)
 	pipe           bool    // NDR pipe: a chunked stream ([C706] 14.7), not a normal array
+	isEnum         bool    // NDR enum: 2 octets under NDR20, 4 octets under NDR64
 
 	// Union (discriminated by an inline switch value, [C706] section 14.3.8) tags.
 	isSwitch  bool  // the union discriminant field (`switch`)
@@ -143,6 +144,8 @@ func parseTag(raw string) fieldTag {
 			t.ascii = true
 		case opt == "pipe":
 			t.pipe = true
+		case opt == "enum":
+			t.isEnum = true
 		case opt == "conformant":
 			t.conformant = true
 		case opt == "varying":


### PR DESCRIPTION
### Linked Issue
Closes #602

### Root Cause
NDR represents an enumerated type as a 2-octet value under NDR20 and a 4-octet value under NDR64 ([MS-RPCE] section 2.2.5). The reflection walker has no concept of an enum — enums are modeled as Go `uint16`, indistinguishable from a genuine 16-bit integer — so the integer scalar path encoded them as a fixed 2 octets in both syntaxes. Under NDR64 every enum-bearing request was therefore one or more octets short and misaligned, and the server rejected it with `nca_s_fault_ndr`.

### Fix Description
Introduce an explicit `ndr:"enum"` field tag and encode tagged fields at the syntax-correct width:
- `codec.go`: `writeEnum`/`readEnum` — 2 octets 2-aligned under NDR20, 4 octets 4-aligned under NDR64.
- `marshal.go`: `marshalEnum`/`unmarshalEnum` route an integer-kinded field through those helpers; `marshalInlineValue`/`unmarshalInlineValue` honour the tag; `fieldNDRAlignment` reports enum alignment (2 under NDR20, 4 under NDR64) so an enclosing structure aligns correctly under NDR64.
- `types.go`: parse the `enum` tag option.
- Tag the `InformationClass` field of `lsarQueryInformationPolicyRequest`.

The tag is opt-in and the NDR20 encoding of a tagged `uint16` enum is unchanged (still 2 octets), so NDR20 output is byte-identical. A distinct Go type was considered instead of a tag, but enums are already modeled as named `uint16` types and the codebase signals NDR semantics through tags, so a tag is consistent and non-invasive.

### How Verified
- **Runtime:** against Windows Server 2016 (NDR64 negotiated), `LsarQueryInformationPolicy` previously faulted `nca_s_fault_ndr`; after the fix the marshalled request matches the captured wire stub and the server accepts it — the call now proceeds to the still-unimplemented NDR64 union decode (`NDR64 unions are not yet supported`, tracked in #596), confirming the request is correct on the wire.
- **Tests:** `TestLsarQueryInformationPolicy_EnumWidthBySyntax` asserts a 2-octet enum under NDR20 (22-octet request) and a 4-octet enum under NDR64 (24-octet request, matching the capture). Full `go test ./network/dcerpc/...` passes; the existing NDR20 stub-byte assertions are unchanged.
- **Static:** `go build ./...`, `go vet ./network/dcerpc/ndr/...`, `gofmt` clean.

### Test Coverage
**Added:** `network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/ndr64_enum_test.go` — `TestLsarQueryInformationPolicy_EnumWidthBySyntax`.

### Scope of Change
- **Files changed:** `network/dcerpc/ndr/codec.go`, `network/dcerpc/ndr/types.go`, `network/dcerpc/ndr/marshal.go`, `network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/07_LsarQueryInformationPolicy.go`, plus the new test.
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none — NDR20 output is byte-identical; the new width applies only to NDR64 and only to fields tagged `enum`.

### Risk and Rollout
Low: opt-in tag, NDR20 unchanged. Only `InformationClass` is tagged here, so other interfaces' enum fields are not yet affected either way.

### Notes
This adds the enum mechanism and tags the one field validated against a live capture. Other enum-typed fields across the interfaces still need the `ndr:"enum"` tag for NDR64 correctness — a follow-up sweep, worth tracking separately. The NDR64 union discriminant (also a 4-octet enum) is handled as part of the union work in #596.