### PR TITLE
Add NDR64 discriminated union support (#596)

### DIFF
--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/structures/LSAPR_POLICY_INFORMATION.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/structures/LSAPR_POLICY_INFORMATION.go
@@ -10,7 +10,7 @@ package structures
 // are distinct discriminant values, as are PolicyAccountDomainInfo (5) and
 // PolicyLocalAccountDomainInfo (14), which share LSAPR_POLICY_ACCOUNT_DOM_INFO.
 type LSAPR_POLICY_INFORMATION struct {
-	Class                        POLICY_INFORMATION_CLASS       `ndr:"switch"`
+	Class                        POLICY_INFORMATION_CLASS       `ndr:"switch,enum"`
 	PolicyAuditLogInfo           POLICY_AUDIT_LOG_INFO          `ndr:"case=1"`
 	PolicyAuditEventsInfo        LSAPR_POLICY_AUDIT_EVENTS_INFO `ndr:"case=2"`
 	PolicyPrimaryDomainInfo      LSAPR_POLICY_PRIMARY_DOM_INFO  `ndr:"case=3"`

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/structures/POLICY_LSA_SERVER_ROLE_INFO.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/structures/POLICY_LSA_SERVER_ROLE_INFO.go
@@ -2,5 +2,5 @@ package structures
 
 // POLICY_LSA_SERVER_ROLE_INFO contains the role of an LSA server ([MS-LSAD] 2.2.4.8).
 type POLICY_LSA_SERVER_ROLE_INFO struct {
-	LsaServerRole POLICY_LSA_SERVER_ROLE
+	LsaServerRole POLICY_LSA_SERVER_ROLE `ndr:"enum"`
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/structures/ndr64_union_capture_test.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/structures/ndr64_union_capture_test.go
@@ -1,0 +1,54 @@
+package structures
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// policyInfoResponse mirrors the LsarQueryInformationPolicy reply: the [out] union as a
+// [unique] pointer, then the NTSTATUS return value.
+type policyInfoResponse struct {
+	PolicyInformation *LSAPR_POLICY_INFORMATION `ndr:"unique"`
+	Status            uint32                    `ndr:"retval"`
+}
+
+// TestNDR64_PolicyInformationUnion_FromCapture decodes LSAPR_POLICY_INFORMATION union
+// responses captured from a live Windows Server 2016 LsarQueryInformationPolicy exchange
+// (NDR64), confirming the NDR64 union decoder: an 8-octet [unique] referent, a 4-octet
+// enum discriminant, and the arm aligned to 8.
+func TestNDR64_PolicyInformationUnion_FromCapture(t *testing.T) {
+	// Server-role arm (class 6): role = 3.
+	roleStub, _ := hex.DecodeString("000002000000000006000000000000000300000000000000")
+	var role policyInfoResponse
+	if err := ndr.UnmarshalAs(roleStub, &role, ndr.NDR64); err != nil {
+		t.Fatalf("decode role union: %v", err)
+	}
+	if role.PolicyInformation == nil || role.PolicyInformation.Class != PolicyLsaServerRoleInformation {
+		t.Fatalf("role: Class = %v, want %d", role.PolicyInformation, PolicyLsaServerRoleInformation)
+	}
+	if got := role.PolicyInformation.PolicyServerRoleInfo.LsaServerRole; got != 3 {
+		t.Errorf("role: LsaServerRole = %d, want 3", got)
+	}
+
+	// Account-domain arm (class 5): name + SID.
+	domStub, _ := hex.DecodeString("000002000000000005000000000000001600180000000000000002000000000000000200000000000c0000000000000000000000000000000b0000000000000054004d0050002d0057002d003200300031003600300000000400000000000000010400000000000515000000fdca06a7cba8d22c3eae86ec00000000")
+	var dom policyInfoResponse
+	if err := ndr.UnmarshalAs(domStub, &dom, ndr.NDR64); err != nil {
+		t.Fatalf("decode account-domain union: %v", err)
+	}
+	if dom.PolicyInformation == nil || dom.PolicyInformation.Class != PolicyAccountDomainInformation {
+		t.Fatalf("account-domain: Class = %v, want %d", dom.PolicyInformation, PolicyAccountDomainInformation)
+	}
+	info := dom.PolicyInformation.PolicyAccountDomainInfo
+	if name := info.DomainName.String(); name != "TMP-W-20160" {
+		t.Errorf("account-domain: DomainName = %q, want %q", name, "TMP-W-20160")
+	}
+	if info.DomainSid == nil {
+		t.Fatal("account-domain: DomainSid is nil")
+	}
+	if sid := info.DomainSid.String(); sid != "S-1-5-21-2802240253-752003275-3968249406" {
+		t.Errorf("account-domain: DomainSid = %q, want %q", sid, "S-1-5-21-2802240253-752003275-3968249406")
+	}
+}

--- a/network/dcerpc/ndr/ndr64_walker_test.go
+++ b/network/dcerpc/ndr/ndr64_walker_test.go
@@ -139,16 +139,53 @@ type hasPipe64 struct {
 	P []byte `ndr:"pipe"`
 }
 
-// TestNDR64_UnionRejected verifies a union is rejected under NDR64 (deferred to a later
-// phase) rather than emitting an unverified encoding, while NDR20 still works.
-func TestNDR64_UnionRejected(t *testing.T) {
+type enumDiscUnion struct {
+	Kind uint16 `ndr:"switch,enum"`
+	A    uint32 `ndr:"case=1"`
+}
+
+type hasEnumUnion struct {
+	U enumDiscUnion
+}
+
+// TestNDR64_Union verifies a declarative union marshals and round-trips under NDR64.
+func TestNDR64_Union(t *testing.T) {
 	v := hasUnion64{U: unionArm64{Tag: 1, A: 7}}
+	b, err := MarshalAs(v, NDR64)
+	if err != nil {
+		t.Fatalf("NDR64 union marshal: %v", err)
+	}
+	var got hasUnion64
+	if err := UnmarshalAs(b, &got, NDR64); err != nil {
+		t.Fatalf("NDR64 union unmarshal: %v", err)
+	}
+	if got.U.Tag != 1 || got.U.A != 7 {
+		t.Errorf("NDR64 union round trip: got %+v want %+v", got, v)
+	}
 	if _, err := MarshalAs(v, NDR20); err != nil {
 		t.Fatalf("NDR20 union should still marshal: %v", err)
 	}
-	_, err := MarshalAs(v, NDR64)
-	if err == nil || !strings.Contains(err.Error(), "NDR64 unions") {
-		t.Errorf("NDR64 union: err = %v, want a 'NDR64 unions' error", err)
+}
+
+// TestNDR64_UnionEnumDiscriminant pins the enum discriminant to 4 octets under NDR64 and
+// round-trips. (A 2-octet discriminant is what NDR20 uses; NDR64 widens it.)
+func TestNDR64_UnionEnumDiscriminant(t *testing.T) {
+	v := hasEnumUnion{U: enumDiscUnion{Kind: 1, A: 0xAABBCCDD}}
+	b, err := MarshalAs(v, NDR64)
+	if err != nil {
+		t.Fatalf("NDR64 marshal: %v", err)
+	}
+	// disc enum = 4 octets (01 00 00 00), then the uint32 arm (4-aligned).
+	want := []byte{0x01, 0x00, 0x00, 0x00, 0xDD, 0xCC, 0xBB, 0xAA}
+	if !bytes.Equal(b, want) {
+		t.Fatalf("NDR64 enum-discriminant union:\n got  %x\nwant %x", b, want)
+	}
+	var got hasEnumUnion
+	if err := UnmarshalAs(b, &got, NDR64); err != nil {
+		t.Fatalf("NDR64 unmarshal: %v", err)
+	}
+	if got.U.Kind != 1 || got.U.A != 0xAABBCCDD {
+		t.Errorf("round trip: got %+v want %+v", got, v)
 	}
 }
 

--- a/network/dcerpc/ndr/union.go
+++ b/network/dcerpc/ndr/union.go
@@ -1,9 +1,6 @@
 package ndr
 
-import (
-	"fmt"
-	"reflect"
-)
+import "reflect"
 
 // NDR discriminated unions, declared with struct tags rather than the Marshaler escape
 // hatch. A union is a Go struct with one field tagged `switch` (the discriminant) and
@@ -104,19 +101,22 @@ func unionArmAlignment(rt reflect.Type, syntax Syntax) int {
 // a [unique]/[ref] pointer to a structure) emits a referent id with its body deferred to
 // the end of the union construction.
 func marshalUnion(e *Encoder, rv reflect.Value, swIdx int) error {
-	if e.syntax == NDR64 {
-		return fmt.Errorf("ndr: NDR64 unions are not yet supported")
-	}
 	rt := rv.Type()
+	swf := rt.Field(swIdx)
+	swTag := parseTag(swf.Tag.Get("ndr"))
 	disc := rv.Field(swIdx)
-	// The discriminant is aligned to its own alignment. The selected arm is then aligned
-	// to the LARGEST alignment among all arms — not just the selected one — so a receiver
-	// can position the arm before it knows which arm was sent. Verified on the wire:
-	// LSAPR_POLICY_INFORMATION's 2-byte server-role arm still starts 8-aligned because
-	// other arms carry 8-byte LARGE_INTEGER members. (Note this padding follows the tag,
-	// so it does not over-align the discriminant itself.)
-	e.Align(ndrAlignment(disc.Type(), e.syntax))
-	if err := marshalScalar(e, disc); err != nil {
+	// The discriminant is aligned and encoded per its own type. An enum discriminant (the
+	// common case; tag the switch field `switch,enum`) is 2 octets under NDR20 and 4 under
+	// NDR64 ([MS-RPCE] section 2.2.5). The selected arm is then aligned to the LARGEST
+	// alignment among all arms — not just the selected one — so a receiver can position the
+	// arm before it knows which arm was sent. Verified on the wire: LSAPR_POLICY_INFORMATION's
+	// server-role arm starts 8-aligned because other arms carry 8-byte members.
+	e.Align(fieldNDRAlignment(swf.Type, swTag, e.syntax))
+	if swTag.isEnum {
+		if err := marshalEnum(e, disc); err != nil {
+			return err
+		}
+	} else if err := marshalScalar(e, disc); err != nil {
 		return err
 	}
 	armIdx := unionArm(rt, disc)
@@ -135,13 +135,16 @@ func marshalUnion(e *Encoder, rv reflect.Value, swIdx int) error {
 // unmarshalUnion reads the discriminant, selects the matching arm, and leaves the other
 // arm fields zero.
 func unmarshalUnion(d *Decoder, rv reflect.Value, swIdx int) error {
-	if d.syntax == NDR64 {
-		return fmt.Errorf("ndr: NDR64 unions are not yet supported")
-	}
 	rt := rv.Type()
+	swf := rt.Field(swIdx)
+	swTag := parseTag(swf.Tag.Get("ndr"))
 	disc := rv.Field(swIdx)
-	d.Align(ndrAlignment(disc.Type(), d.syntax)) // discriminant aligned to itself
-	if err := unmarshalScalar(d, disc); err != nil {
+	d.Align(fieldNDRAlignment(swf.Type, swTag, d.syntax)) // discriminant aligned to its type
+	if swTag.isEnum {
+		if err := unmarshalEnum(d, disc); err != nil {
+			return err
+		}
+	} else if err := unmarshalScalar(d, disc); err != nil {
 		return err
 	}
 	armIdx := unionArm(rt, disc)


### PR DESCRIPTION
### Linked Issue
Part of #596 (NDR64 unions and pipes). Implements the **union** half; NDR64 pipes remain deferred and still fail closed.

### Motivation
NDR64 marshalling of discriminated unions previously returned `NDR64 unions are not yet supported`. A live capture of `LsarQueryInformationPolicy` against Windows Server 2016 (gathered under #596) established the NDR64 union wire layout: an 8-octet `[unique]` referent to the union, a 4-octet enum discriminant, and the selected arm aligned to 8 (the largest arm alignment).

### Fix Description
- `union.go`: remove the NDR64 fail-closed guards in `marshalUnion`/`unmarshalUnion`. Encode the discriminant at its NDR width via the field's tag — an enum switch (`switch,enum`) is 2 octets under NDR20 and 4 under NDR64 — and align it with `fieldNDRAlignment`. Arm alignment already used the syntax-aware `unionArmAlignment`, so the arm lands 8-aligned under NDR64.
- Tag `LSAPR_POLICY_INFORMATION.Class` as `switch,enum` and `POLICY_LSA_SERVER_ROLE_INFO.LsaServerRole` as `enum` (the arm's enum field), so the policy-information union round-trips under NDR64.

This builds on the enum-width fix (#602): both the discriminant and enum arm fields rely on the 4-octet NDR64 enum encoding.

### How Verified
- **Runtime:** against Windows Server 2016, `LsarQueryInformationPolicy(PolicyLsaServerRoleInformation)` under NDR64 now returns success (previously `nca_s_fault_ndr`, then — after the enum fix — `NDR64 unions are not yet supported`).
- **Tests:** `TestNDR64_PolicyInformationUnion_FromCapture` decodes the captured NDR64 union responses and asserts the decoded values — server role = 3, and account-domain name `TMP-W-20160` with SID `S-1-5-21-2802240253-752003275-3968249406`. `TestNDR64_Union` and `TestNDR64_UnionEnumDiscriminant` cover round-trips and the 4-octet discriminant. Full `go test ./network/dcerpc/...` passes; existing NDR20 union tests are unchanged (NDR20 output identical).
- **Static:** `go build ./...`, `go vet`, `gofmt` clean.

### Test Coverage
**Added:** `structures/ndr64_union_capture_test.go` (`TestNDR64_PolicyInformationUnion_FromCapture`); `ndr/ndr64_walker_test.go` (`TestNDR64_Union`, `TestNDR64_UnionEnumDiscriminant`, replacing the obsolete `TestNDR64_UnionRejected`).

### Scope of Change
- **Files changed:** `network/dcerpc/ndr/union.go`, `network/dcerpc/ndr/ndr64_walker_test.go`, `structures/LSAPR_POLICY_INFORMATION.go`, `structures/POLICY_LSA_SERVER_ROLE_INFO.go`, `structures/ndr64_union_capture_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none — NDR20 union output is byte-identical; the new behavior is reachable only under NDR64.

### Risk and Rollout
Low: NDR20 unchanged; the change activates NDR64 union encode/decode, which is opt-in and now wire-validated for the LSA policy-information union.

### Notes
The DNS-domain class (`PolicyDnsDomainInformation`) of this union is blocked by a separate, pre-existing defect: `guid.GUID` marshals as 24 octets rather than 16 (filed as #604, affects NDR20 and NDR64). NDR64 pipes are still deferred under #596. A repo-wide sweep to tag remaining enum fields (#602 follow-up) is also still open.