### PR TITLE
Fix GUID NDR encoding to 16 octets (#604)

### DIFF
--- a/network/dcerpc/dtyp/guid.go
+++ b/network/dcerpc/dtyp/guid.go
@@ -1,0 +1,53 @@
+package dtyp
+
+import (
+	"encoding/binary"
+
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+)
+
+// GUID is the [MS-DTYP] 2.3.4.2 GUID in its NDR-marshallable form: Data1 (4 octets),
+// Data2 (2), Data3 (2), and Data4 (8 opaque octets), for 16 octets total with 4-octet
+// alignment. Data1/2/3 are little-endian integers; Data4 is transmitted verbatim.
+//
+// The reflection walker cannot use windows/guid.GUID directly: its Go layout ends in a
+// uint64, which over-aligns the struct to 8 and inserts interior padding, so it would
+// marshal as 24 octets instead of 16. This type mirrors the wire layout exactly. Use
+// NewGUID / GUID to convert to and from windows/guid.GUID.
+//
+// Reference: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/49e490b8-f972-45d6-a3a4-99f924998d97
+type GUID struct {
+	Data1 uint32
+	Data2 uint16
+	Data3 uint16
+	Data4 [8]byte
+}
+
+// NewGUID converts a windows/guid.GUID to its NDR GUID form.
+func NewGUID(g guid.GUID) GUID {
+	b := g.ToBytes() // 16 octets: Data1/2/3 little-endian, Data4 verbatim
+	var x GUID
+	x.Data1 = binary.LittleEndian.Uint32(b[0:4])
+	x.Data2 = binary.LittleEndian.Uint16(b[4:6])
+	x.Data3 = binary.LittleEndian.Uint16(b[6:8])
+	copy(x.Data4[:], b[8:16])
+	return x
+}
+
+// GUID converts back to a windows/guid.GUID.
+func (g GUID) GUID() guid.GUID {
+	var b [16]byte
+	binary.LittleEndian.PutUint32(b[0:4], g.Data1)
+	binary.LittleEndian.PutUint16(b[4:6], g.Data2)
+	binary.LittleEndian.PutUint16(b[6:8], g.Data3)
+	copy(b[8:16], g.Data4[:])
+	var out guid.GUID
+	out.FromRawBytes(b[:])
+	return out
+}
+
+// String renders the GUID in the standard "D" format.
+func (g GUID) String() string {
+	w := g.GUID()
+	return w.ToFormatD()
+}

--- a/network/dcerpc/dtyp/guid_test.go
+++ b/network/dcerpc/dtyp/guid_test.go
@@ -1,0 +1,44 @@
+package dtyp
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+)
+
+type guidWrap struct{ G GUID }
+
+// TestGUID_WireFormatFromGuidGUID verifies that a windows/guid.GUID generates the dtyp
+// NDR wire format: NewGUID(g) marshals to exactly 16 octets — identical to g.ToBytes()
+// — under both NDR20 and NDR64, and round-trips back to the original GUID.
+func TestGUID_WireFormatFromGuidGUID(t *testing.T) {
+	g, err := guid.FromString("a6500248-1cc1-4e89-b2bf-ebe99677d084")
+	if err != nil {
+		t.Fatalf("parse guid: %v", err)
+	}
+	want := g.ToBytes() // canonical 16-octet uuid_t wire form
+	if len(want) != 16 {
+		t.Fatalf("guid.ToBytes() = %d octets, want 16", len(want))
+	}
+
+	d := NewGUID(*g)
+	for _, s := range []ndr.Syntax{ndr.NDR20, ndr.NDR64} {
+		got, err := ndr.MarshalAs(&guidWrap{G: d}, s)
+		if err != nil {
+			t.Fatalf("%s marshal: %v", s, err)
+		}
+		if !bytes.Equal(got, want) {
+			t.Errorf("%s GUID wire form:\n got  %x\nwant %x", s, got, want)
+		}
+	}
+
+	// Round-trip: dtyp.GUID back to windows/guid.GUID.
+	if back := d.GUID(); !bytes.Equal(back.ToBytes(), want) {
+		t.Errorf("round trip: got %x want %x", back.ToBytes(), want)
+	}
+	if d.String() != "a6500248-1cc1-4e89-b2bf-ebe99677d084" {
+		t.Errorf("String() = %q", d.String())
+	}
+}

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/structures/LSAPR_POLICY_DNS_DOMAIN_INFO.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/structures/LSAPR_POLICY_DNS_DOMAIN_INFO.go
@@ -2,7 +2,6 @@ package structures
 
 import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
-	"github.com/TheManticoreProject/Manticore/windows/guid"
 )
 
 // LSAPR_POLICY_DNS_DOMAIN_INFO contains DNS information about the primary domain
@@ -11,6 +10,6 @@ type LSAPR_POLICY_DNS_DOMAIN_INFO struct {
 	Name          dtyp.RPC_UNICODE_STRING
 	DnsDomainName dtyp.RPC_UNICODE_STRING
 	DnsForestName dtyp.RPC_UNICODE_STRING
-	DomainGuid    guid.GUID
+	DomainGuid    dtyp.GUID
 	Sid           *dtyp.RPC_SID `ndr:"unique"`
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/structures/ndr64_union_capture_test.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/structures/ndr64_union_capture_test.go
@@ -51,4 +51,24 @@ func TestNDR64_PolicyInformationUnion_FromCapture(t *testing.T) {
 	if sid := info.DomainSid.String(); sid != "S-1-5-21-2802240253-752003275-3968249406" {
 		t.Errorf("account-domain: DomainSid = %q, want %q", sid, "S-1-5-21-2802240253-752003275-3968249406")
 	}
+
+	// DNS-domain arm (class 12): three counted strings, a 16-octet GUID, and a SID.
+	dnsStub, _ := hex.DecodeString("00000200000000000c00000000000000160018000000000000000200000000002000220000000000000002000000000020002200000000000000020000000000480250a6c11c894eb2bfebe99677d08400000200000000000c0000000000000000000000000000000b0000000000000054004d0050002d0057002d0032003000310036003000000011000000000000000000000000000000100000000000000054004d0050002d0057002d0032003000310036002e006c006f00630061006c0011000000000000000000000000000000100000000000000054004d0050002d0057002d0032003000310036002e006c006f00630061006c000400000000000000010400000000000515000000fdca06a7cba8d22c3eae86ec00000000")
+	var dns policyInfoResponse
+	if err := ndr.UnmarshalAs(dnsStub, &dns, ndr.NDR64); err != nil {
+		t.Fatalf("decode dns-domain union: %v", err)
+	}
+	if dns.PolicyInformation == nil || dns.PolicyInformation.Class != PolicyDnsDomainInformation {
+		t.Fatalf("dns-domain: Class = %v, want %d", dns.PolicyInformation, PolicyDnsDomainInformation)
+	}
+	d := dns.PolicyInformation.PolicyDnsDomainInfo
+	if d.Name.String() != "TMP-W-20160" || d.DnsDomainName.String() != "TMP-W-2016.local" || d.DnsForestName.String() != "TMP-W-2016.local" {
+		t.Errorf("dns-domain: names = %q / %q / %q", d.Name.String(), d.DnsDomainName.String(), d.DnsForestName.String())
+	}
+	if g := d.DomainGuid.String(); g != "a6500248-1cc1-4e89-b2bf-ebe99677d084" {
+		t.Errorf("dns-domain: DomainGuid = %q, want %q", g, "a6500248-1cc1-4e89-b2bf-ebe99677d084")
+	}
+	if d.Sid == nil || d.Sid.String() != "S-1-5-21-2802240253-752003275-3968249406" {
+		t.Errorf("dns-domain: Sid = %v", d.Sid)
+	}
 }


### PR DESCRIPTION
### Linked Issue
Refs #604. Fixes the GUID encoding and migrates the validated consumer (lsarpc); the remaining consumers are listed under Notes as a mechanical follow-up.

### Root Cause
`windows/guid.GUID` is `{A uint32; B uint16; C uint16; D uint16; E uint64}`. Walked by the reflection codec, the trailing `uint64` gives the struct 8-octet alignment and forces interior padding after the three short fields, so it marshals to 24 octets. A GUID is 16 octets ([MS-DTYP] 2.3.4.2: Data1 4, Data2 2, Data3 2, Data4 8). Any NDR structure embedding a `guid.GUID` was therefore mis-encoded under both NDR20 and NDR64; concretely, `LsarQueryInformationPolicy(PolicyDnsDomainInformation)` could not be decoded.

### Fix Description
Add `dtyp.GUID`, an NDR-marshallable GUID whose fields (`Data1 uint32; Data2 uint16; Data3 uint16; Data4 [8]byte`) mirror the wire layout exactly: 16 octets, 4-aligned, no interior padding. `NewGUID`/`GUID` convert to and from `windows/guid.GUID`, so a `guid.GUID` can generate the dtyp NDR wire format (byte-identical to `guid.GUID.ToBytes()`); `windows/guid` keeps no dependency on the `ndr` package (it cannot — that would invert the layering and `guid` cannot define a `Marshaler` method without importing `ndr`).

Switch `LSAPR_POLICY_DNS_DOMAIN_INFO.DomainGuid` to `dtyp.GUID`. Combined with NDR64 union support, the DNS-domain policy class now round-trips under NDR64.

### How Verified
- **Tests:** `dtyp.TestGUID_WireFormatFromGuidGUID` pins that `NewGUID(g)` marshals to exactly `g.ToBytes()` (16 octets) under NDR20 and NDR64 and round-trips. `TestNDR64_PolicyInformationUnion_FromCapture` now also decodes the captured DNS-domain union and asserts Name `TMP-W-20160`, DnsDomainName/DnsForestName `TMP-W-2016.local`, DomainGuid `a6500248-1cc1-4e89-b2bf-ebe99677d084`, and the SID. Full `go test ./network/dcerpc/...` passes.
- **Runtime:** against Windows Server 2016, `LsarQueryInformationPolicy(PolicyDnsDomainInformation)` under NDR64 now succeeds, returning the DNS name, forest name, and GUID.
- **Static:** `go build ./...`, `go vet`, `gofmt` clean.

### Test Coverage
**Added:** `network/dcerpc/dtyp/guid_test.go` (`TestGUID_WireFormatFromGuidGUID`); extended `structures/ndr64_union_capture_test.go` with the DNS-domain arm.

### Scope of Change
- **Files changed:** `network/dcerpc/dtyp/guid.go` (new), `network/dcerpc/dtyp/guid_test.go` (new), `structures/LSAPR_POLICY_DNS_DOMAIN_INFO.go`, `structures/ndr64_union_capture_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none — the only NDR struct migrated is `LSAPR_POLICY_DNS_DOMAIN_INFO`, which had no working GUID encoding before.

### Notes
Other NDR structures still embed `windows/guid.GUID` directly and remain mis-encoded by the same root cause; they should migrate to `dtyp.GUID` (converting `guid.GUID` arguments at the public boundary with `dtyp.NewGUID`). These were left out of this PR because they cannot be live-validated here:
- srvsvc DFS: `NET_DFS_ENTRY_ID.Uid`, and the `Uid`/`EntryUid` fields of `NetrDfsCreateLocalPartition`, `NetrDfsDeleteLocalPartition`, `NetrDfsCreateExitPoint`, `NetrDfsDeleteExitPoint`, `NetrDfsModifyPrefix`, `NetrDfsSetLocalVolumeState`, `NetrDfsFixLocalVolume`.
- svcctl: `RNotifyServiceStatusChange` process GUIDs and `SERVICE_TRIGGER.PTriggerSubtype`.

(Object/interface UUIDs in `syntax.SyntaxID` and the v4 PDU headers are marshalled by hand, not the walker, so they are unaffected.)