### PR TITLE
Tag DCE/RPC enum fields for NDR64 (#602)

### DIFF
--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/08_LsarSetInformationPolicy.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/08_LsarSetInformationPolicy.go
@@ -13,7 +13,7 @@ import (
 // new policy information.
 type lsarSetInformationPolicyRequest struct {
 	PolicyHandle      structures.LSAPR_HANDLE
-	InformationClass  structures.POLICY_INFORMATION_CLASS
+	InformationClass  structures.POLICY_INFORMATION_CLASS `ndr:"enum"`
 	PolicyInformation structures.LSAPR_POLICY_INFORMATION
 }
 

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/14_LsarLookupNames.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/14_LsarLookupNames.go
@@ -21,7 +21,7 @@ type lsarLookupNamesRequest struct {
 	Count          ndr.DWORD
 	Names          []dtyp.RPC_UNICODE_STRING `ndr:"ref,size_is=Count"`
 	TranslatedSids structures.LSAPR_TRANSLATED_SIDS
-	LookupLevel    structures.LSAP_LOOKUP_LEVEL
+	LookupLevel    structures.LSAP_LOOKUP_LEVEL `ndr:"enum"`
 	MappedCount    ndr.DWORD
 }
 

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/15_LsarLookupSids.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/15_LsarLookupSids.go
@@ -15,7 +15,7 @@ type lsarLookupSidsRequest struct {
 	PolicyHandle    structures.LSAPR_HANDLE
 	SidEnumBuffer   structures.LSAPR_SID_ENUM_BUFFER
 	TranslatedNames structures.LSAPR_TRANSLATED_NAMES
-	LookupLevel     structures.LSAP_LOOKUP_LEVEL
+	LookupLevel     structures.LSAP_LOOKUP_LEVEL `ndr:"enum"`
 	MappedCount     ndr.DWORD
 }
 

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/26_LsarQueryInfoTrustedDomain.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/26_LsarQueryInfoTrustedDomain.go
@@ -13,7 +13,7 @@ import (
 // returned.
 type lsarQueryInfoTrustedDomainRequest struct {
 	TrustedDomainHandle structures.LSAPR_HANDLE
-	InformationClass    structures.TRUSTED_INFORMATION_CLASS
+	InformationClass    structures.TRUSTED_INFORMATION_CLASS `ndr:"enum"`
 }
 
 func (*lsarQueryInfoTrustedDomainRequest) Opnum() uint16 {

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/27_LsarSetInformationTrustedDomain.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/27_LsarSetInformationTrustedDomain.go
@@ -13,7 +13,7 @@ import (
 // the inline [ref] union value carrying the new trusted-domain information.
 type lsarSetInformationTrustedDomainRequest struct {
 	TrustedDomainHandle      structures.LSAPR_HANDLE
-	InformationClass         structures.TRUSTED_INFORMATION_CLASS
+	InformationClass         structures.TRUSTED_INFORMATION_CLASS `ndr:"enum"`
 	TrustedDomainInformation structures.LSAPR_TRUSTED_DOMAIN_INFO
 }
 

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/39_LsarQueryTrustedDomainInfo.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/39_LsarQueryTrustedDomainInfo.go
@@ -14,8 +14,8 @@ import (
 // class selecting which union arm is returned.
 type lsarQueryTrustedDomainInfoRequest struct {
 	PolicyHandle     structures.LSAPR_HANDLE
-	TrustedDomainSid *dtyp.RPC_SID `ndr:"unique"`
-	InformationClass structures.TRUSTED_INFORMATION_CLASS
+	TrustedDomainSid *dtyp.RPC_SID                        `ndr:"unique"`
+	InformationClass structures.TRUSTED_INFORMATION_CLASS `ndr:"enum"`
 }
 
 func (*lsarQueryTrustedDomainInfoRequest) Opnum() uint16 {

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/40_LsarSetTrustedDomainInfo.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/40_LsarSetTrustedDomainInfo.go
@@ -14,8 +14,8 @@ import (
 // and the inline [ref] union value carrying the new trusted-domain information.
 type lsarSetTrustedDomainInfoRequest struct {
 	PolicyHandle             structures.LSAPR_HANDLE
-	TrustedDomainSid         *dtyp.RPC_SID `ndr:"unique"`
-	InformationClass         structures.TRUSTED_INFORMATION_CLASS
+	TrustedDomainSid         *dtyp.RPC_SID                        `ndr:"unique"`
+	InformationClass         structures.TRUSTED_INFORMATION_CLASS `ndr:"enum"`
 	TrustedDomainInformation structures.LSAPR_TRUSTED_DOMAIN_INFO
 }
 

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/46_LsarQueryInformationPolicy2.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/46_LsarQueryInformationPolicy2.go
@@ -13,7 +13,7 @@ import (
 // which union arm is returned.
 type lsarQueryInformationPolicy2Request struct {
 	PolicyHandle     structures.LSAPR_HANDLE
-	InformationClass structures.POLICY_INFORMATION_CLASS
+	InformationClass structures.POLICY_INFORMATION_CLASS `ndr:"enum"`
 }
 
 func (*lsarQueryInformationPolicy2Request) Opnum() uint16 {

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/47_LsarSetInformationPolicy2.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/47_LsarSetInformationPolicy2.go
@@ -13,7 +13,7 @@ import (
 // new policy information.
 type lsarSetInformationPolicy2Request struct {
 	PolicyHandle      structures.LSAPR_HANDLE
-	InformationClass  structures.POLICY_INFORMATION_CLASS
+	InformationClass  structures.POLICY_INFORMATION_CLASS `ndr:"enum"`
 	PolicyInformation structures.LSAPR_POLICY_INFORMATION
 }
 

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/48_LsarQueryTrustedDomainInfoByName.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/48_LsarQueryTrustedDomainInfoByName.go
@@ -15,7 +15,7 @@ import (
 type lsarQueryTrustedDomainInfoByNameRequest struct {
 	PolicyHandle      structures.LSAPR_HANDLE
 	TrustedDomainName dtyp.RPC_UNICODE_STRING
-	InformationClass  structures.TRUSTED_INFORMATION_CLASS
+	InformationClass  structures.TRUSTED_INFORMATION_CLASS `ndr:"enum"`
 }
 
 func (*lsarQueryTrustedDomainInfoByNameRequest) Opnum() uint16 {

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/49_LsarSetTrustedDomainInfoByName.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/49_LsarSetTrustedDomainInfoByName.go
@@ -16,7 +16,7 @@ import (
 type lsarSetTrustedDomainInfoByNameRequest struct {
 	PolicyHandle             structures.LSAPR_HANDLE
 	TrustedDomainName        dtyp.RPC_UNICODE_STRING
-	InformationClass         structures.TRUSTED_INFORMATION_CLASS
+	InformationClass         structures.TRUSTED_INFORMATION_CLASS `ndr:"enum"`
 	TrustedDomainInformation structures.LSAPR_TRUSTED_DOMAIN_INFO
 }
 

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/53_LsarQueryDomainInformationPolicy.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/53_LsarQueryDomainInformationPolicy.go
@@ -13,7 +13,7 @@ import (
 // selecting which union arm is returned.
 type lsarQueryDomainInformationPolicyRequest struct {
 	PolicyHandle     structures.LSAPR_HANDLE
-	InformationClass structures.POLICY_DOMAIN_INFORMATION_CLASS
+	InformationClass structures.POLICY_DOMAIN_INFORMATION_CLASS `ndr:"enum"`
 }
 
 func (*lsarQueryDomainInformationPolicyRequest) Opnum() uint16 {

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/54_LsarSetDomainInformationPolicy.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/54_LsarSetDomainInformationPolicy.go
@@ -13,7 +13,7 @@ import (
 // [in, unique] union pointer carrying the new policy domain information (NULL deletes it).
 type lsarSetDomainInformationPolicyRequest struct {
 	PolicyHandle            structures.LSAPR_HANDLE
-	InformationClass        structures.POLICY_DOMAIN_INFORMATION_CLASS
+	InformationClass        structures.POLICY_DOMAIN_INFORMATION_CLASS  `ndr:"enum"`
 	PolicyDomainInformation *structures.LSAPR_POLICY_DOMAIN_INFORMATION `ndr:"unique"`
 }
 

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/57_LsarLookupSids2.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/57_LsarLookupSids2.go
@@ -15,7 +15,7 @@ type lsarLookupSids2Request struct {
 	PolicyHandle    structures.LSAPR_HANDLE
 	SidEnumBuffer   structures.LSAPR_SID_ENUM_BUFFER
 	TranslatedNames structures.LSAPR_TRANSLATED_NAMES_EX
-	LookupLevel     structures.LSAP_LOOKUP_LEVEL
+	LookupLevel     structures.LSAP_LOOKUP_LEVEL `ndr:"enum"`
 	MappedCount     ndr.DWORD
 	LookupOptions   ndr.DWORD
 	ClientRevision  ndr.DWORD

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/58_LsarLookupNames2.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/58_LsarLookupNames2.go
@@ -17,7 +17,7 @@ type lsarLookupNames2Request struct {
 	Count          ndr.DWORD
 	Names          []dtyp.RPC_UNICODE_STRING `ndr:"ref,size_is=Count"`
 	TranslatedSids structures.LSAPR_TRANSLATED_SIDS_EX
-	LookupLevel    structures.LSAP_LOOKUP_LEVEL
+	LookupLevel    structures.LSAP_LOOKUP_LEVEL `ndr:"enum"`
 	MappedCount    ndr.DWORD
 	LookupOptions  ndr.DWORD
 	ClientRevision ndr.DWORD

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/68_LsarLookupNames3.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/68_LsarLookupNames3.go
@@ -16,7 +16,7 @@ type lsarLookupNames3Request struct {
 	Count          ndr.DWORD
 	Names          []dtyp.RPC_UNICODE_STRING `ndr:"ref,size_is=Count"`
 	TranslatedSids structures.LSAPR_TRANSLATED_SIDS_EX2
-	LookupLevel    structures.LSAP_LOOKUP_LEVEL
+	LookupLevel    structures.LSAP_LOOKUP_LEVEL `ndr:"enum"`
 	MappedCount    ndr.DWORD
 	LookupOptions  ndr.DWORD
 	ClientRevision ndr.DWORD

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/73_LsarQueryForestTrustInformation.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/73_LsarQueryForestTrustInformation.go
@@ -15,7 +15,7 @@ import (
 type lsarQueryForestTrustInformationRequest struct {
 	PolicyHandle      structures.LSAPR_HANDLE
 	TrustedDomainName dtyp.RPC_UNICODE_STRING
-	HighestRecordType structures.LSA_FOREST_TRUST_RECORD_TYPE
+	HighestRecordType structures.LSA_FOREST_TRUST_RECORD_TYPE `ndr:"enum"`
 }
 
 func (*lsarQueryForestTrustInformationRequest) Opnum() uint16 {

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/74_LsarSetForestTrustInformation.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/74_LsarSetForestTrustInformation.go
@@ -17,7 +17,7 @@ import (
 type lsarSetForestTrustInformationRequest struct {
 	PolicyHandle      structures.LSAPR_HANDLE
 	TrustedDomainName dtyp.RPC_UNICODE_STRING
-	HighestRecordType structures.LSA_FOREST_TRUST_RECORD_TYPE
+	HighestRecordType structures.LSA_FOREST_TRUST_RECORD_TYPE `ndr:"enum"`
 	ForestTrustInfo   structures.LSA_FOREST_TRUST_INFORMATION
 	CheckOnly         uint8
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/76_LsarLookupSids3.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/76_LsarLookupSids3.go
@@ -15,7 +15,7 @@ import (
 type lsarLookupSids3Request struct {
 	SidEnumBuffer   structures.LSAPR_SID_ENUM_BUFFER
 	TranslatedNames structures.LSAPR_TRANSLATED_NAMES_EX
-	LookupLevel     structures.LSAP_LOOKUP_LEVEL
+	LookupLevel     structures.LSAP_LOOKUP_LEVEL `ndr:"enum"`
 	MappedCount     ndr.DWORD
 	LookupOptions   ndr.DWORD
 	ClientRevision  ndr.DWORD

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/77_LsarLookupNames4.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/77_LsarLookupNames4.go
@@ -17,7 +17,7 @@ type lsarLookupNames4Request struct {
 	Count          ndr.DWORD
 	Names          []dtyp.RPC_UNICODE_STRING `ndr:"ref,size_is=Count"`
 	TranslatedSids structures.LSAPR_TRANSLATED_SIDS_EX2
-	LookupLevel    structures.LSAP_LOOKUP_LEVEL
+	LookupLevel    structures.LSAP_LOOKUP_LEVEL `ndr:"enum"`
 	MappedCount    ndr.DWORD
 	LookupOptions  ndr.DWORD
 	ClientRevision ndr.DWORD

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/structures/LSAPR_POLICY_DOMAIN_INFORMATION.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/structures/LSAPR_POLICY_DOMAIN_INFORMATION.go
@@ -6,7 +6,7 @@ package structures
 // single selected arm ([C706] section 14.3.8). Case values follow the enum: QoS=1,
 // Efs=2, KerbTicket=3.
 type LSAPR_POLICY_DOMAIN_INFORMATION struct {
-	Class                            POLICY_DOMAIN_INFORMATION_CLASS       `ndr:"switch"`
+	Class                            POLICY_DOMAIN_INFORMATION_CLASS       `ndr:"switch,enum"`
 	PolicyDomainQualityOfServiceInfo POLICY_DOMAIN_QUALITY_OF_SERVICE_INFO `ndr:"case=1"`
 	PolicyDomainEfsInfo              LSAPR_POLICY_DOMAIN_EFS_INFO          `ndr:"case=2"`
 	PolicyDomainKerbTicketInfo       POLICY_DOMAIN_KERBEROS_TICKET_INFO    `ndr:"case=3"`

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/structures/LSAPR_TRANSLATED_NAME.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/structures/LSAPR_TRANSLATED_NAME.go
@@ -8,7 +8,7 @@ import (
 // index ([MS-LSAT] 2.2.20). Use is an NDR enum (16-bit on the wire); DomainIndex is a
 // signed long.
 type LSAPR_TRANSLATED_NAME struct {
-	Use         SID_NAME_USE
+	Use         SID_NAME_USE `ndr:"enum"`
 	Name        dtyp.RPC_UNICODE_STRING
 	DomainIndex int32
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/structures/LSAPR_TRANSLATED_NAME_EX.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/structures/LSAPR_TRANSLATED_NAME_EX.go
@@ -8,7 +8,7 @@ import (
 // LSAPR_TRANSLATED_NAME_EX extends LSAPR_TRANSLATED_NAME with a Flags field ([MS-LSAT]
 // 2.2.22). Use is an NDR enum (16-bit on the wire); DomainIndex is a signed long.
 type LSAPR_TRANSLATED_NAME_EX struct {
-	Use         SID_NAME_USE
+	Use         SID_NAME_USE `ndr:"enum"`
 	Name        dtyp.RPC_UNICODE_STRING
 	DomainIndex int32
 	Flags       ndr.DWORD

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/structures/LSAPR_TRANSLATED_SID_EX.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/structures/LSAPR_TRANSLATED_SID_EX.go
@@ -7,7 +7,7 @@ import (
 // LSAPR_TRANSLATED_SID_EX extends LSA_TRANSLATED_SID with a Flags field ([MS-LSAT]
 // 2.2.24). Use is an NDR enum (16-bit on the wire); DomainIndex is a signed long.
 type LSAPR_TRANSLATED_SID_EX struct {
-	Use         SID_NAME_USE
+	Use         SID_NAME_USE `ndr:"enum"`
 	RelativeId  ndr.DWORD
 	DomainIndex int32
 	Flags       ndr.DWORD

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/structures/LSAPR_TRANSLATED_SID_EX2.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/structures/LSAPR_TRANSLATED_SID_EX2.go
@@ -9,7 +9,7 @@ import (
 // translation result ([MS-LSAT] 2.2.26). Use is an NDR enum (16-bit on the wire); Sid is
 // a [unique] pointer to an RPC_SID; DomainIndex is a signed long.
 type LSAPR_TRANSLATED_SID_EX2 struct {
-	Use         SID_NAME_USE
+	Use         SID_NAME_USE  `ndr:"enum"`
 	Sid         *dtyp.RPC_SID `ndr:"unique"`
 	DomainIndex int32
 	Flags       ndr.DWORD

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/structures/LSAPR_TRUSTED_DOMAIN_INFO.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/structures/LSAPR_TRUSTED_DOMAIN_INFO.go
@@ -8,7 +8,7 @@ package structures
 // The TrustedDomainInformationBasic arm (case 5) is a LSAPR_TRUST_INFORMATION, since
 // LSAPR_TRUSTED_DOMAIN_INFORMATION_BASIC is an IDL typedef of that existing type.
 type LSAPR_TRUSTED_DOMAIN_INFO struct {
-	Class                   TRUSTED_INFORMATION_CLASS                      `ndr:"switch"`
+	Class                   TRUSTED_INFORMATION_CLASS                      `ndr:"switch,enum"`
 	TrustedDomainNameInfo   LSAPR_TRUSTED_DOMAIN_NAME_INFO                 `ndr:"case=1"`
 	TrustedControllersInfo  LSAPR_TRUSTED_CONTROLLERS_INFO                 `ndr:"case=2"`
 	TrustedPosixOffsetInfo  TRUSTED_POSIX_OFFSET_INFO                      `ndr:"case=3"`

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/structures/LSA_FOREST_TRUST_COLLISION_RECORD.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/structures/LSA_FOREST_TRUST_COLLISION_RECORD.go
@@ -9,7 +9,7 @@ import (
 // 2.2.7.26). Name is an LSA_UNICODE_STRING (the same wire form as RPC_UNICODE_STRING).
 type LSA_FOREST_TRUST_COLLISION_RECORD struct {
 	Index ndr.DWORD
-	Type  LSA_FOREST_TRUST_COLLISION_RECORD_TYPE
+	Type  LSA_FOREST_TRUST_COLLISION_RECORD_TYPE `ndr:"enum"`
 	Flags ndr.DWORD
 	Name  dtyp.RPC_UNICODE_STRING
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/structures/LSA_FOREST_TRUST_RECORD.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/structures/LSA_FOREST_TRUST_RECORD.go
@@ -13,7 +13,7 @@ import (
 // the same LSA_UNICODE_STRING (RPC_UNICODE_STRING) type, one per case value. The
 // [default] arm carries an LSA_FOREST_TRUST_BINARY_DATA.
 type LSA_FOREST_TRUST_DATA struct {
-	ForestTrustType LSA_FOREST_TRUST_RECORD_TYPE `ndr:"switch"`
+	ForestTrustType LSA_FOREST_TRUST_RECORD_TYPE `ndr:"switch,enum"`
 	TopLevelName    dtyp.RPC_UNICODE_STRING      `ndr:"case=0"`
 	TopLevelNameEx  dtyp.RPC_UNICODE_STRING      `ndr:"case=1"`
 	DomainInfo      LSA_FOREST_TRUST_DOMAIN_INFO `ndr:"case=2"`
@@ -24,7 +24,7 @@ type LSA_FOREST_TRUST_DATA struct {
 // 2.2.7.21). ForestTrustData is a union switched on ForestTrustType.
 type LSA_FOREST_TRUST_RECORD struct {
 	Flags           ndr.DWORD
-	ForestTrustType LSA_FOREST_TRUST_RECORD_TYPE
+	ForestTrustType LSA_FOREST_TRUST_RECORD_TYPE `ndr:"enum"`
 	Time            dtyp.LARGE_INTEGER
 	ForestTrustData LSA_FOREST_TRUST_DATA
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/structures/LSA_TRANSLATED_SID.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/structures/LSA_TRANSLATED_SID.go
@@ -8,7 +8,7 @@ import (
 // ([MS-LSAT] 2.2.18). Use is an NDR enum (16-bit on the wire); DomainIndex is a signed
 // long.
 type LSA_TRANSLATED_SID struct {
-	Use         SID_NAME_USE
+	Use         SID_NAME_USE `ndr:"enum"`
 	RelativeId  ndr.DWORD
 	DomainIndex int32
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/08_SamrQueryInformationDomain.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/08_SamrQueryInformationDomain.go
@@ -12,7 +12,7 @@ import (
 // a domain handle and the information class selecting the union arm to return.
 type samrQueryInformationDomainRequest struct {
 	DomainHandle           structures.SAMPR_HANDLE
-	DomainInformationClass structures.DOMAIN_INFORMATION_CLASS
+	DomainInformationClass structures.DOMAIN_INFORMATION_CLASS `ndr:"enum"`
 }
 
 func (*samrQueryInformationDomainRequest) Opnum() uint16 {

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/09_SamrSetInformationDomain.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/09_SamrSetInformationDomain.go
@@ -13,7 +13,7 @@ import (
 // (inline) carrying the new values.
 type samrSetInformationDomainRequest struct {
 	DomainHandle           structures.SAMPR_HANDLE
-	DomainInformationClass structures.DOMAIN_INFORMATION_CLASS
+	DomainInformationClass structures.DOMAIN_INFORMATION_CLASS `ndr:"enum"`
 	DomainInformation      structures.SAMPR_DOMAIN_INFO_BUFFER
 }
 

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/20_SamrQueryInformationGroup.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/20_SamrQueryInformationGroup.go
@@ -12,7 +12,7 @@ import (
 // selecting which arm of the returned union is populated.
 type samrQueryInformationGroupRequest struct {
 	GroupHandle           structures.SAMPR_HANDLE
-	GroupInformationClass structures.GROUP_INFORMATION_CLASS
+	GroupInformationClass structures.GROUP_INFORMATION_CLASS `ndr:"enum"`
 }
 
 func (*samrQueryInformationGroupRequest) Opnum() uint16 {

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/21_SamrSetInformationGroup.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/21_SamrSetInformationGroup.go
@@ -12,7 +12,7 @@ import (
 // the [in,switch_is] group info buffer whose populated arm matches that class.
 type samrSetInformationGroupRequest struct {
 	GroupHandle           structures.SAMPR_HANDLE
-	GroupInformationClass structures.GROUP_INFORMATION_CLASS
+	GroupInformationClass structures.GROUP_INFORMATION_CLASS `ndr:"enum"`
 	Buffer                structures.SAMPR_GROUP_INFO_BUFFER
 }
 

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/28_SamrQueryInformationAlias.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/28_SamrQueryInformationAlias.go
@@ -12,7 +12,7 @@ import (
 // that selects the arm of the returned union.
 type samrQueryInformationAliasRequest struct {
 	AliasHandle           structures.SAMPR_HANDLE
-	AliasInformationClass structures.ALIAS_INFORMATION_CLASS
+	AliasInformationClass structures.ALIAS_INFORMATION_CLASS `ndr:"enum"`
 }
 
 func (*samrQueryInformationAliasRequest) Opnum() uint16 {

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/29_SamrSetInformationAlias.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/29_SamrSetInformationAlias.go
@@ -12,7 +12,7 @@ import (
 // the [in, switch_is] alias info buffer (the discriminated union, transmitted inline).
 type samrSetInformationAliasRequest struct {
 	AliasHandle           structures.SAMPR_HANDLE
-	AliasInformationClass structures.ALIAS_INFORMATION_CLASS
+	AliasInformationClass structures.ALIAS_INFORMATION_CLASS `ndr:"enum"`
 	Buffer                structures.SAMPR_ALIAS_INFO_BUFFER
 }
 

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/36_SamrQueryInformationUser.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/36_SamrQueryInformationUser.go
@@ -12,7 +12,7 @@ import (
 // selecting which arm of the returned union is populated.
 type samrQueryInformationUserRequest struct {
 	UserHandle           structures.SAMPR_HANDLE
-	UserInformationClass structures.USER_INFORMATION_CLASS
+	UserInformationClass structures.USER_INFORMATION_CLASS `ndr:"enum"`
 }
 
 func (*samrQueryInformationUserRequest) Opnum() uint16 {

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/37_SamrSetInformationUser.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/37_SamrSetInformationUser.go
@@ -13,7 +13,7 @@ import (
 // is written to the user object.
 type samrSetInformationUserRequest struct {
 	UserHandle           structures.SAMPR_HANDLE
-	UserInformationClass structures.USER_INFORMATION_CLASS
+	UserInformationClass structures.USER_INFORMATION_CLASS `ndr:"enum"`
 	Buffer               structures.SAMPR_USER_INFO_BUFFER
 }
 

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/40_SamrQueryDisplayInformation.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/40_SamrQueryDisplayInformation.go
@@ -13,7 +13,7 @@ import (
 // preferred maximum byte length of the returned buffer.
 type samrQueryDisplayInformationRequest struct {
 	DomainHandle            structures.SAMPR_HANDLE
-	DisplayInformationClass structures.DOMAIN_DISPLAY_INFORMATION
+	DisplayInformationClass structures.DOMAIN_DISPLAY_INFORMATION `ndr:"enum"`
 	Index                   ndr.DWORD
 	EntryCount              ndr.DWORD
 	PreferredMaximumLength  ndr.DWORD

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/41_SamrGetDisplayEnumerationIndex.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/41_SamrGetDisplayEnumerationIndex.go
@@ -14,7 +14,7 @@ import (
 // prefix (inline, single pointer) to search for.
 type samrGetDisplayEnumerationIndexRequest struct {
 	DomainHandle            structures.SAMPR_HANDLE
-	DisplayInformationClass structures.DOMAIN_DISPLAY_INFORMATION
+	DisplayInformationClass structures.DOMAIN_DISPLAY_INFORMATION `ndr:"enum"`
 	Prefix                  dtyp.RPC_UNICODE_STRING
 }
 

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/46_SamrQueryInformationDomain2.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/46_SamrQueryInformationDomain2.go
@@ -13,7 +13,7 @@ import (
 // information class selecting the union arm to return.
 type samrQueryInformationDomain2Request struct {
 	DomainHandle           structures.SAMPR_HANDLE
-	DomainInformationClass structures.DOMAIN_INFORMATION_CLASS
+	DomainInformationClass structures.DOMAIN_INFORMATION_CLASS `ndr:"enum"`
 }
 
 func (*samrQueryInformationDomain2Request) Opnum() uint16 {

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/47_SamrQueryInformationUser2.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/47_SamrQueryInformationUser2.go
@@ -12,7 +12,7 @@ import (
 // selecting which arm of the returned union is populated.
 type samrQueryInformationUser2Request struct {
 	UserHandle           structures.SAMPR_HANDLE
-	UserInformationClass structures.USER_INFORMATION_CLASS
+	UserInformationClass structures.USER_INFORMATION_CLASS `ndr:"enum"`
 }
 
 func (*samrQueryInformationUser2Request) Opnum() uint16 {

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/48_SamrQueryDisplayInformation2.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/48_SamrQueryDisplayInformation2.go
@@ -14,7 +14,7 @@ import (
 // length of the returned buffer.
 type samrQueryDisplayInformation2Request struct {
 	DomainHandle            structures.SAMPR_HANDLE
-	DisplayInformationClass structures.DOMAIN_DISPLAY_INFORMATION
+	DisplayInformationClass structures.DOMAIN_DISPLAY_INFORMATION `ndr:"enum"`
 	Index                   ndr.DWORD
 	EntryCount              ndr.DWORD
 	PreferredMaximumLength  ndr.DWORD

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/49_SamrGetDisplayEnumerationIndex2.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/49_SamrGetDisplayEnumerationIndex2.go
@@ -14,7 +14,7 @@ import (
 // class, and the [ref] name prefix (inline, single pointer) to search for.
 type samrGetDisplayEnumerationIndex2Request struct {
 	DomainHandle            structures.SAMPR_HANDLE
-	DisplayInformationClass structures.DOMAIN_DISPLAY_INFORMATION
+	DisplayInformationClass structures.DOMAIN_DISPLAY_INFORMATION `ndr:"enum"`
 	Prefix                  dtyp.RPC_UNICODE_STRING
 }
 

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/51_SamrQueryDisplayInformation3.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/51_SamrQueryDisplayInformation3.go
@@ -14,7 +14,7 @@ import (
 // length of the returned buffer.
 type samrQueryDisplayInformation3Request struct {
 	DomainHandle            structures.SAMPR_HANDLE
-	DisplayInformationClass structures.DOMAIN_DISPLAY_INFORMATION
+	DisplayInformationClass structures.DOMAIN_DISPLAY_INFORMATION `ndr:"enum"`
 	Index                   ndr.DWORD
 	EntryCount              ndr.DWORD
 	PreferredMaximumLength  ndr.DWORD

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/58_SamrSetInformationUser2.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/58_SamrSetInformationUser2.go
@@ -13,7 +13,7 @@ import (
 // is written to the user object.
 type samrSetInformationUser2Request struct {
 	UserHandle           structures.SAMPR_HANDLE
-	UserInformationClass structures.USER_INFORMATION_CLASS
+	UserInformationClass structures.USER_INFORMATION_CLASS `ndr:"enum"`
 	Buffer               structures.SAMPR_USER_INFO_BUFFER
 }
 

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/67_SamrValidatePassword.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/67_SamrValidatePassword.go
@@ -13,7 +13,7 @@ import (
 // the union arm and InputArg is the [ref, switch_is(ValidationType)] input union
 // (modeled inline).
 type samrValidatePasswordRequest struct {
-	ValidationType structures.PASSWORD_POLICY_VALIDATION_TYPE
+	ValidationType structures.PASSWORD_POLICY_VALIDATION_TYPE `ndr:"enum"`
 	InputArg       structures.SAM_VALIDATE_INPUT_ARG
 }
 

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/DOMAIN_SERVER_ROLE_INFORMATION.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/DOMAIN_SERVER_ROLE_INFORMATION.go
@@ -3,5 +3,5 @@ package structures
 // DOMAIN_SERVER_ROLE_INFORMATION holds the role (backup or primary) of a server
 // ([MS-SAMR] 2.2.4.4).
 type DOMAIN_SERVER_ROLE_INFORMATION struct {
-	DomainServerRole DOMAIN_SERVER_ROLE
+	DomainServerRole DOMAIN_SERVER_ROLE `ndr:"enum"`
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/DOMAIN_STATE_INFORMATION.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/DOMAIN_STATE_INFORMATION.go
@@ -3,5 +3,5 @@ package structures
 // DOMAIN_STATE_INFORMATION holds the enabled/disabled state of a domain
 // ([MS-SAMR] 2.2.4.2).
 type DOMAIN_STATE_INFORMATION struct {
-	DomainServerState DOMAIN_SERVER_ENABLE_STATE
+	DomainServerState DOMAIN_SERVER_ENABLE_STATE `ndr:"enum"`
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_ALIAS_INFO_BUFFER.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_ALIAS_INFO_BUFFER.go
@@ -4,7 +4,7 @@ package structures
 // ([MS-SAMR] 2.2.6.6). The discriminant is an ALIAS_INFORMATION_CLASS; the wire form is
 // the discriminant followed by the single selected arm ([C706] section 14.3.8).
 type SAMPR_ALIAS_INFO_BUFFER struct {
-	Tag          ALIAS_INFORMATION_CLASS             `ndr:"switch"`
+	Tag          ALIAS_INFORMATION_CLASS             `ndr:"switch,enum"`
 	General      SAMPR_ALIAS_GENERAL_INFORMATION     `ndr:"case=1"`
 	Name         SAMPR_ALIAS_NAME_INFORMATION        `ndr:"case=2"`
 	AdminComment SAMPR_ALIAS_ADM_COMMENT_INFORMATION `ndr:"case=3"`

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_DISPLAY_INFO_BUFFER.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_DISPLAY_INFO_BUFFER.go
@@ -5,7 +5,7 @@ package structures
 // the wire form is the discriminant followed by the single selected arm ([C706] section
 // 14.3.8). The numeric case values follow the DOMAIN_DISPLAY_INFORMATION enum.
 type SAMPR_DISPLAY_INFO_BUFFER struct {
-	Tag                 DOMAIN_DISPLAY_INFORMATION            `ndr:"switch"`
+	Tag                 DOMAIN_DISPLAY_INFORMATION            `ndr:"switch,enum"`
 	UserInformation     SAMPR_DOMAIN_DISPLAY_USER_BUFFER      `ndr:"case=1"`
 	MachineInformation  SAMPR_DOMAIN_DISPLAY_MACHINE_BUFFER   `ndr:"case=2"`
 	GroupInformation    SAMPR_DOMAIN_DISPLAY_GROUP_BUFFER     `ndr:"case=3"`

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_DOMAIN_INFO_BUFFER.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_DOMAIN_INFO_BUFFER.go
@@ -5,7 +5,7 @@ package structures
 // form is the discriminant followed by the single selected arm ([C706] section 14.3.8).
 // The numeric case values follow the DOMAIN_INFORMATION_CLASS enum.
 type SAMPR_DOMAIN_INFO_BUFFER struct {
-	Tag         DOMAIN_INFORMATION_CLASS             `ndr:"switch"`
+	Tag         DOMAIN_INFORMATION_CLASS             `ndr:"switch,enum"`
 	Password    DOMAIN_PASSWORD_INFORMATION          `ndr:"case=1"`
 	General     SAMPR_DOMAIN_GENERAL_INFORMATION     `ndr:"case=2"`
 	Logoff      DOMAIN_LOGOFF_INFORMATION            `ndr:"case=3"`

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_GROUP_INFO_BUFFER.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_GROUP_INFO_BUFFER.go
@@ -7,7 +7,7 @@ package structures
 // The DoNotUse arm (case GroupReplicationInformation=5) reuses the
 // SAMPR_GROUP_GENERAL_INFORMATION type, as specified in the IDL.
 type SAMPR_GROUP_INFO_BUFFER struct {
-	Tag          GROUP_INFORMATION_CLASS             `ndr:"switch"`
+	Tag          GROUP_INFORMATION_CLASS             `ndr:"switch,enum"`
 	General      SAMPR_GROUP_GENERAL_INFORMATION     `ndr:"case=1"`
 	Name         SAMPR_GROUP_NAME_INFORMATION        `ndr:"case=2"`
 	Attribute    GROUP_ATTRIBUTE_INFORMATION         `ndr:"case=3"`

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_USER_INFO_BUFFER.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAMPR_USER_INFO_BUFFER.go
@@ -4,7 +4,7 @@ package structures
 // discriminated by a USER_INFORMATION_CLASS ([MS-SAMR] 2.2.6.29). Tag carries
 // the discriminant inline; exactly one arm is valid per the selected case.
 type SAMPR_USER_INFO_BUFFER struct {
-	Tag USER_INFORMATION_CLASS `ndr:"switch"`
+	Tag USER_INFORMATION_CLASS `ndr:"switch,enum"`
 
 	General      SAMPR_USER_GENERAL_INFORMATION       `ndr:"case=1"`
 	Preferences  SAMPR_USER_PREFERENCES_INFORMATION   `ndr:"case=2"`

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAM_VALIDATE_INPUT_ARG.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAM_VALIDATE_INPUT_ARG.go
@@ -6,7 +6,7 @@ package structures
 // ([C706] section 14.3.8). Each arm is a value field for the corresponding
 // validation type.
 type SAM_VALIDATE_INPUT_ARG struct {
-	Tag                         PASSWORD_POLICY_VALIDATION_TYPE        `ndr:"switch"`
+	Tag                         PASSWORD_POLICY_VALIDATION_TYPE        `ndr:"switch,enum"`
 	ValidateAuthenticationInput SAM_VALIDATE_AUTHENTICATION_INPUT_ARG  `ndr:"case=1"`
 	ValidatePasswordChangeInput SAM_VALIDATE_PASSWORD_CHANGE_INPUT_ARG `ndr:"case=2"`
 	ValidatePasswordResetInput  SAM_VALIDATE_PASSWORD_RESET_INPUT_ARG  `ndr:"case=3"`

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAM_VALIDATE_OUTPUT_ARG.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAM_VALIDATE_OUTPUT_ARG.go
@@ -5,7 +5,7 @@ package structures
 // the wire form is the discriminant followed by the single selected arm
 // ([C706] section 14.3.8). All three arms carry a SAM_VALIDATE_STANDARD_OUTPUT_ARG.
 type SAM_VALIDATE_OUTPUT_ARG struct {
-	Tag                          PASSWORD_POLICY_VALIDATION_TYPE  `ndr:"switch"`
+	Tag                          PASSWORD_POLICY_VALIDATION_TYPE  `ndr:"switch,enum"`
 	ValidateAuthenticationOutput SAM_VALIDATE_STANDARD_OUTPUT_ARG `ndr:"case=1"`
 	ValidatePasswordChangeOutput SAM_VALIDATE_STANDARD_OUTPUT_ARG `ndr:"case=2"`
 	ValidatePasswordResetOutput  SAM_VALIDATE_STANDARD_OUTPUT_ARG `ndr:"case=3"`

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAM_VALIDATE_STANDARD_OUTPUT_ARG.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/SAM_VALIDATE_STANDARD_OUTPUT_ARG.go
@@ -5,5 +5,5 @@ package structures
 // fields that the server has modified and the overall validation status.
 type SAM_VALIDATE_STANDARD_OUTPUT_ARG struct {
 	ChangedPersistedFields SAM_VALIDATE_PERSISTED_FIELDS
-	ValidationStatus       SAM_VALIDATE_VALIDATION_STATUS
+	ValidationStatus       SAM_VALIDATE_VALIDATION_STATUS `ndr:"enum"`
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/ndr64_enum_test.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/structures/ndr64_enum_test.go
@@ -1,0 +1,31 @@
+package structures
+
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// TestNDR64_DomainServerRole_EnumWidth confirms the enum-field tagging sweep: a
+// DOMAIN_SERVER_ROLE field marshals as 2 octets under NDR20 and 4 under NDR64.
+func TestNDR64_DomainServerRole_EnumWidth(t *testing.T) {
+	v := DOMAIN_SERVER_ROLE_INFORMATION{DomainServerRole: DomainServerRolePrimary} // = 3
+	n20, err := ndr.MarshalAs(&v, ndr.NDR20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(n20) != 2 || n20[0] != 0x03 {
+		t.Errorf("NDR20 = % x, want 03 00", n20)
+	}
+	n64, err := ndr.MarshalAs(&v, ndr.NDR64)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(n64) != 4 || n64[0] != 0x03 {
+		t.Errorf("NDR64 = % x, want 03 00 00 00", n64)
+	}
+	var out DOMAIN_SERVER_ROLE_INFORMATION
+	if err := ndr.UnmarshalAs(n64, &out, ndr.NDR64); err != nil || out.DomainServerRole != DomainServerRolePrimary {
+		t.Errorf("NDR64 round trip: %v, %v", out, err)
+	}
+}


### PR DESCRIPTION
### Linked Issue
Completes the enum-width work from #602 (mechanism + first field landed in #603); this is the repo-wide tagging sweep noted as follow-up there.

### Motivation
NDR encodes an enum as 2 octets under NDR20 and 4 under NDR64. #603 added the `ndr:"enum"` tag and the codec support, but only tagged the one field validated against a live capture (`LsarQueryInformationPolicy`). Every other enum-typed field across lsarpc and samr was still untagged, so those calls would fault under NDR64 once exercised.

### Fix Description
Apply `ndr:"enum"` to every remaining enum-typed field — 57 fields across 56 files:
- **Value fields** (e.g. `SID_NAME_USE Use` in the LSA translated-name/SID structs, `DOMAIN_SERVER_ROLE`, `DOMAIN_SERVER_ENABLE_STATE`, `SAM_VALIDATE_VALIDATION_STATUS`, `LSA_FOREST_TRUST_*_TYPE`) get `ndr:"enum"`.
- **Union discriminants** (the `switch` field of the SAMPR `*_INFO_BUFFER` unions, `SAM_VALIDATE_*_ARG`, `SAMPR_DISPLAY_INFO_BUFFER`, `LSAPR_POLICY_DOMAIN_INFORMATION`, `LSAPR_TRUSTED_DOMAIN_INFO`, `LSA_FOREST_TRUST_RECORD`) go from `switch` to `switch,enum`.
- **Function request stubs** that carry an information-class/level (the samr `Samr{Query,Set}Information*` / display functions, and lsarpc `Lsar{Query,Set}*` / `LsarLookup{Names,Sids}*`) get `ndr:"enum"` on their class/level field.

All of these are 2-octet MIDL enums (named `uint16` types with value constants), so the NDR20 encoding is unchanged (an enum still marshals via `WriteUint16`); the existing stub-byte tests confirm byte-identical NDR20 output. The 4-octet `[v1_enum]` types (e.g. svcctl `SC_ACTION_TYPE`, modeled as a wider type and pinned by `TestSCActionTypeWidth`) are deliberately left untouched.

### How Verified
- **Tests:** new `TestNDR64_DomainServerRole_EnumWidth` (samr) asserts 2 octets under NDR20 and 4 under NDR64 for a tagged field, with a round-trip. Full `go test ./network/dcerpc/...` passes — the existing samr/lsarpc NDR20 stub-byte assertions are unchanged, confirming no NDR20 regression.
- **Static:** `go build ./...`, `go vet ./network/dcerpc/...`, `gofmt` clean.

### Test Coverage
**Added:** `samr/.../structures/ndr64_enum_test.go` (`TestNDR64_DomainServerRole_EnumWidth`). The enum encoding itself and a union enum discriminant are already pinned by tests from #603/#605; this sweep is mechanical tag application guarded by the unchanged NDR20 suite.

### Scope of Change
- **Files changed:** 56 lsarpc/samr structure and function files (one-line tag edits) plus the new samr test.
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none — NDR20 output is byte-identical; only the NDR64 width of these enum fields changes.

### Risk and Rollout
Low: tag-only edits, NDR20 unchanged and test-guarded. The samr paths are not exercised against a live server here, but the change is the same proven enum-width rule already live-validated for lsarpc in #603/#605.

### Notes
With this, enum width is correct across the interfaces. Remaining NDR64 work: the GUID consumer fixes (#606/#607, in review) and NDR64 pipes (#596).