### PR TITLE
Add ms_rrp protocol package with RemoteRegistry client

### DIFF
--- a/network/dcerpc/ms-protocols/ms-rrp/client.go
+++ b/network/dcerpc/ms-protocols/ms-rrp/client.go
@@ -1,0 +1,111 @@
+// Package ms_rrp implements the high-level MS-RRP (Windows Remote Registry Protocol)
+// client API over the winreg DCE/RPC interface
+// (338cd001-2244-31f1-aaaa-900038001003 v1.0), carried over the \winreg named pipe on
+// the IPC$ tree.
+//
+// It is the protocol layer above the interface: callers hold a connected and
+// authenticated SMB client and drive a RemoteRegistry, which binds winreg once and then
+// exposes every interface method by its exact name (OpenLocalMachine, BaseRegOpenKey,
+// BaseRegQueryValue, ...) as a method on the struct, plus a small set of ergonomic,
+// reg.exe-style helpers (OpenKeyByPath, QueryValueByPath, EnumKeys, ...).
+//
+// Unlike the stateless MS-SRVS layer, registry context handles CHAIN
+// (HKLM -> subkey -> close) and are scoped to the RPC association, so RemoteRegistry
+// binds a SINGLE \winreg pipe in Connect and reuses it for the lifetime of the client; a
+// handle obtained on one association cannot be used on another. Close tears the pipe
+// down, which releases any server-side handles.
+//
+// References:
+//   - [MS-RRP] 3.1.5 winreg method behaviours; 2.2.4 REGSAM; [MS-ERREF] 2.2 Win32 codes
+//   - [MS-RPCE] DCE/RPC over SMB named pipes
+package ms_rrp
+
+import (
+	"errors"
+	"fmt"
+
+	winreg "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/structures"
+	dcerpcclient "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	dcerpctransport "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/transport"
+)
+
+// Handle is an open registry key context handle returned by the Open*/BaseRegCreateKey/
+// BaseRegOpenKey methods. It aliases the interface's RPC_HKEY so it can be passed back to
+// any method without conversion.
+type Handle = structures.RPC_HKEY
+
+// ErrNotConnected is returned by methods invoked before a successful Connect.
+var ErrNotConnected = errors.New("ms_rrp: not connected; call Connect first")
+
+// PipeDialer opens a fresh DCE/RPC named-pipe transport over an established, IPC$-tree-
+// connected SMB session. It is the only capability MS-RRP needs from the SMB layer, so
+// depending on this interface (rather than a concrete SMB client) keeps ms_rrp
+// independent of the SMB dialect: network/smb/client.Client satisfies it (via its
+// RPCTransport method) and routes to an SMB1 or SMB2 named-pipe transport according to
+// what was negotiated.
+type PipeDialer interface {
+	RPCTransport(pipeName string) (dcerpctransport.Transport, error)
+}
+
+// RemoteRegistry is the connected MS-RRP client. It carries the session it is reached
+// over (the pipe dialer) and, once Connect has run, the single bound \winreg association
+// that all method calls and chained key handles share.
+type RemoteRegistry struct {
+	dialer    PipeDialer
+	rpc       *dcerpcclient.Client
+	closeRPC  func() error
+	connected bool
+}
+
+// New returns a RemoteRegistry over the given pipe dialer (typically a
+// *network/smb/client.Client). The dialer MUST be connected, authenticated, and
+// tree-connected to IPC$ before Connect is called.
+func New(dialer PipeDialer) *RemoteRegistry {
+	return &RemoteRegistry{dialer: dialer}
+}
+
+// Connect opens the \winreg pipe and binds the winreg abstract syntax, establishing the
+// single association that all subsequent calls and key handles use. It is idempotent:
+// calling it on an already-connected client is a no-op.
+func (r *RemoteRegistry) Connect() error {
+	if r.connected {
+		return nil
+	}
+	transport, err := r.dialer.RPCTransport(winreg.PipeName)
+	if err != nil {
+		return fmt.Errorf("ms_rrp: open winreg pipe: %w", err)
+	}
+	rpc := dcerpcclient.NewClient(transport)
+	if err := rpc.Bind(winreg.SyntaxID()); err != nil {
+		return fmt.Errorf("ms_rrp: bind winreg: %w", err)
+	}
+	r.rpc = rpc
+	r.closeRPC = rpc.Close
+	r.connected = true
+	return nil
+}
+
+// Close tears down the winreg association, releasing any server-side key handles still
+// open on it. It is safe to call on a client that was never connected.
+func (r *RemoteRegistry) Close() error {
+	if !r.connected || r.closeRPC == nil {
+		return nil
+	}
+	err := r.closeRPC()
+	r.rpc = nil
+	r.closeRPC = nil
+	r.connected = false
+	return err
+}
+
+// IsConnected reports whether Connect has succeeded and Close has not yet run.
+func (r *RemoteRegistry) IsConnected() bool { return r.connected && r.rpc != nil }
+
+// ensure guards method calls against use before Connect.
+func (r *RemoteRegistry) ensure() error {
+	if !r.connected || r.rpc == nil {
+		return ErrNotConnected
+	}
+	return nil
+}

--- a/network/dcerpc/ms-protocols/ms-rrp/client_test.go
+++ b/network/dcerpc/ms-protocols/ms-rrp/client_test.go
@@ -1,0 +1,201 @@
+package ms_rrp_test
+
+import (
+	"encoding/binary"
+	"errors"
+	"testing"
+
+	ms_rrp "github.com/TheManticoreProject/Manticore/network/dcerpc/ms-protocols/ms-rrp"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/pdu"
+	dcerpctransport "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/transport"
+)
+
+// fakeTransport is an in-memory dcerpc transport.Transport for driving RemoteRegistry
+// without a network.
+type fakeTransport struct {
+	sent      [][]byte
+	recvQueue [][]byte
+}
+
+func (f *fakeTransport) Connect() error { return nil }
+func (f *fakeTransport) Send(p []byte) error {
+	f.sent = append(f.sent, append([]byte(nil), p...))
+	return nil
+}
+func (f *fakeTransport) Recv() ([]byte, error) {
+	if len(f.recvQueue) == 0 {
+		return nil, errors.New("recv queue empty")
+	}
+	c := f.recvQueue[0]
+	f.recvQueue = f.recvQueue[1:]
+	return c, nil
+}
+func (f *fakeTransport) Close() error        { return nil }
+func (f *fakeTransport) MaxXmitFrag() uint16 { return 5840 }
+func (f *fakeTransport) MaxRecvFrag() uint16 { return 5840 }
+func (f *fakeTransport) queue(b []byte)      { f.recvQueue = append(f.recvQueue, b) }
+
+// fakeDialer hands the same fakeTransport to RemoteRegistry.Connect.
+type fakeDialer struct{ ft *fakeTransport }
+
+func (d *fakeDialer) RPCTransport(string) (dcerpctransport.Transport, error) { return d.ft, nil }
+
+func bindAck(t *testing.T) []byte {
+	t.Helper()
+	ack := &pdu.BindAck{
+		MaxXmitFrag: 5840,
+		MaxRecvFrag: 5840,
+		Results:     []pdu.PresentationResult{{Result: pdu.ResultAcceptance, TransferSyntax: syntax.NDRTransferSyntax()}},
+	}
+	b, err := ack.Marshal()
+	if err != nil {
+		t.Fatalf("bind_ack marshal: %v", err)
+	}
+	return b
+}
+
+func responsePDU(t *testing.T, callID uint32, stub []byte) []byte {
+	t.Helper()
+	resp := &pdu.Response{Stub: stub}
+	resp.Header = pdu.NewHeader(pdu.PacketTypeResponse, pdu.PFCFirstFrag|pdu.PFCLastFrag, callID)
+	b, err := resp.Marshal()
+	if err != nil {
+		t.Fatalf("response marshal: %v", err)
+	}
+	return b
+}
+
+func le32(b []byte, v uint32) []byte { return binary.LittleEndian.AppendUint32(b, v) }
+
+// connected returns a RemoteRegistry whose Connect has bound over ft (with a queued
+// bind_ack), ready for one or more queued method responses.
+func connected(t *testing.T, ft *fakeTransport) *ms_rrp.RemoteRegistry {
+	t.Helper()
+	ft.queue(bindAck(t))
+	r := ms_rrp.New(&fakeDialer{ft: ft})
+	if err := r.Connect(); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	if !r.IsConnected() {
+		t.Fatal("IsConnected = false after Connect")
+	}
+	return r
+}
+
+// TestMethodsBeforeConnect verifies the not-connected guard fires instead of panicking on
+// a nil association.
+func TestMethodsBeforeConnect(t *testing.T) {
+	r := ms_rrp.New(&fakeDialer{ft: &fakeTransport{}})
+	if _, err := r.OpenLocalMachine(nil, 0); !errors.Is(err, ms_rrp.ErrNotConnected) {
+		t.Errorf("OpenLocalMachine before Connect: err = %v, want ErrNotConnected", err)
+	}
+	if _, err := r.BaseRegGetVersion(ms_rrp.Handle{}); !errors.Is(err, ms_rrp.ErrNotConnected) {
+		t.Errorf("BaseRegGetVersion before Connect: err = %v, want ErrNotConnected", err)
+	}
+	if r.IsConnected() {
+		t.Error("IsConnected = true before Connect")
+	}
+}
+
+// TestOpenLocalMachine drives the opnum-2 round-trip: a 20-byte context handle plus a
+// success status.
+func TestOpenLocalMachine(t *testing.T) {
+	ft := &fakeTransport{}
+	r := connected(t, ft)
+
+	var stub []byte
+	handle := make([]byte, 20)
+	for i := range handle {
+		handle[i] = byte(i + 1)
+	}
+	stub = append(stub, handle...) // PhKey
+	stub = le32(stub, 0)           // status = ERROR_SUCCESS
+	ft.queue(responsePDU(t, 2, stub))
+
+	h, err := r.OpenLocalMachine(nil, 0x00020019)
+	if err != nil {
+		t.Fatalf("OpenLocalMachine: %v", err)
+	}
+	if h.IsZero() {
+		t.Error("returned handle is zero")
+	}
+}
+
+// TestBaseRegGetVersion drives the opnum-26 round-trip: a [out] DWORD then status.
+func TestBaseRegGetVersion(t *testing.T) {
+	ft := &fakeTransport{}
+	r := connected(t, ft)
+
+	var stub []byte
+	stub = le32(stub, 6) // LpdwVersion
+	stub = le32(stub, 0) // status
+	ft.queue(responsePDU(t, 2, stub))
+
+	ver, err := r.BaseRegGetVersion(ms_rrp.Handle{})
+	if err != nil {
+		t.Fatalf("BaseRegGetVersion: %v", err)
+	}
+	if uint32(ver) != 6 {
+		t.Errorf("version = %d, want 6", uint32(ver))
+	}
+}
+
+// TestStatusErrorSurfaced confirms a non-success Win32 status becomes a Go error.
+func TestStatusErrorSurfaced(t *testing.T) {
+	ft := &fakeTransport{}
+	r := connected(t, ft)
+
+	var stub []byte
+	stub = append(stub, make([]byte, 20)...) // PhKey (zero)
+	stub = le32(stub, 5)                     // status = ERROR_ACCESS_DENIED
+	ft.queue(responsePDU(t, 2, stub))
+
+	if _, err := r.OpenLocalMachine(nil, 0); err == nil {
+		t.Fatal("OpenLocalMachine with ERROR_ACCESS_DENIED: err = nil, want non-nil")
+	}
+}
+
+// TestCloseTearsDown verifies Close flips IsConnected and is safe to repeat.
+func TestCloseTearsDown(t *testing.T) {
+	ft := &fakeTransport{}
+	r := connected(t, ft)
+	if err := r.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if r.IsConnected() {
+		t.Error("IsConnected = true after Close")
+	}
+	if err := r.Close(); err != nil {
+		t.Errorf("second Close: %v", err)
+	}
+}
+
+func TestRegistryValueCodecs(t *testing.T) {
+	if got := ms_rrp.StringValue("Hello").String(); got != "Hello" {
+		t.Errorf("StringValue/String round-trip = %q", got)
+	}
+	if got := ms_rrp.ExpandStringValue("%PATH%").String(); got != "%PATH%" {
+		t.Errorf("ExpandStringValue/String round-trip = %q", got)
+	}
+	if v, ok := ms_rrp.DwordValue(0xDEADBEEF).Uint32(); !ok || v != 0xDEADBEEF {
+		t.Errorf("DwordValue/Uint32 round-trip = %#x, ok=%v", v, ok)
+	}
+	if v, ok := ms_rrp.QwordValue(0x1122334455667788).Uint64(); !ok || v != 0x1122334455667788 {
+		t.Errorf("QwordValue/Uint64 round-trip = %#x, ok=%v", v, ok)
+	}
+	multi := ms_rrp.MultiStringValue([]string{"a", "bb", "ccc"}).MultiString()
+	if len(multi) != 3 || multi[0] != "a" || multi[1] != "bb" || multi[2] != "ccc" {
+		t.Errorf("MultiStringValue/MultiString round-trip = %v", multi)
+	}
+	if v, ok := ms_rrp.DwordValue(0).Uint64(); ok {
+		t.Errorf("Uint64 on a 4-byte REG_DWORD should report ok=false, got %#x", v)
+	}
+	raw := []byte{0xAA, 0xBB, 0xCC}
+	if bv := ms_rrp.BinaryValue(raw); bv.Type != 3 || len(bv.Data) != 3 || bv.Data[0] != 0xAA {
+		t.Errorf("BinaryValue round-trip = %+v", bv)
+	}
+	if got := ms_rrp.DwordValue(1).String(); got != "" {
+		t.Errorf("String on a REG_DWORD should be empty, got %q", got)
+	}
+}

--- a/network/dcerpc/ms-protocols/ms-rrp/consts.go
+++ b/network/dcerpc/ms-protocols/ms-rrp/consts.go
@@ -1,0 +1,55 @@
+package ms_rrp
+
+import (
+	winreg "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// REGSAM access rights ([MS-RRP] 2.2.4), re-exported from the winreg interface and typed
+// as ndr.DWORD so they can be passed directly as the samDesired argument of the Open* /
+// BaseRegOpenKey / BaseRegCreateKey methods without conversion or importing the interface
+// package.
+const (
+	KeyQueryValue       = ndr.DWORD(winreg.KeyQueryValue)
+	KeySetValue         = ndr.DWORD(winreg.KeySetValue)
+	KeyCreateSubKey     = ndr.DWORD(winreg.KeyCreateSubKey)
+	KeyEnumerateSubKeys = ndr.DWORD(winreg.KeyEnumerateSubKeys)
+	KeyNotify           = ndr.DWORD(winreg.KeyNotify)
+	KeyCreateLink       = ndr.DWORD(winreg.KeyCreateLink)
+	KeyWow6464Key       = ndr.DWORD(winreg.KeyWow64_64Key)
+	KeyWow6432Key       = ndr.DWORD(winreg.KeyWow64_32Key)
+	KeyRead             = ndr.DWORD(winreg.KeyRead)
+	KeyWrite            = ndr.DWORD(winreg.KeyWrite)
+	KeyExecute          = ndr.DWORD(winreg.KeyExecute)
+	KeyAllAccess        = ndr.DWORD(winreg.KeyAllAccess)
+
+	// MaximumAllowed is MAXIMUM_ALLOWED ([MS-DTYP] 2.4.3): grant the most access the caller
+	// is permitted.
+	MaximumAllowed = maximumAllowed
+)
+
+// dwOptions for BaseRegCreateKey ([MS-RRP] 3.1.5.7), re-exported and typed as ndr.DWORD.
+const (
+	RegOptionNonVolatile = ndr.DWORD(winreg.RegOptionNonVolatile)
+	RegOptionVolatile    = ndr.DWORD(winreg.RegOptionVolatile)
+)
+
+// Registry value types (the RegistryValue.Type / dwType field) ([MS-RRP] 3.1.1.6),
+// re-exported from the winreg interface as plain uint32 to match RegistryValue.Type.
+const (
+	RegNone     = winreg.RegNone
+	RegSz       = winreg.RegSz
+	RegExpandSz = winreg.RegExpandSz
+	RegBinary   = winreg.RegBinary
+	RegDword    = winreg.RegDword
+	RegLink     = winreg.RegLink
+	RegMultiSz  = winreg.RegMultiSz
+	RegQword    = winreg.RegQword
+)
+
+// Key-creation disposition values returned by BaseRegCreateKey / CreateKeyByPath
+// ([MS-RRP] 3.1.5.7).
+const (
+	RegCreatedNewKey     = winreg.RegCreatedNewKey
+	RegOpenedExistingKey = winreg.RegOpenedExistingKey
+)

--- a/network/dcerpc/ms-protocols/ms-rrp/integration_test.go
+++ b/network/dcerpc/ms-protocols/ms-rrp/integration_test.go
@@ -1,0 +1,94 @@
+//go:build integration
+
+// Live integration tests for the MS-RRP convenience layer over the full DCE/RPC-over-SMB
+// stack. Excluded from the default build by the "integration" tag. Run with:
+//
+//	DCERPC_TEST_HOST=192.168.1.30 DCERPC_TEST_USER=Administrator DCERPC_TEST_PASS=admin \
+//	go test -tags integration -v ./network/dcerpc/ms-protocols/ms-rrp/
+//
+// The Remote Registry service must be running on the target. The test reads the registry
+// version, enumerates a well-known key's subkeys, and reads the ProductName value, all on
+// the single bound association RemoteRegistry maintains.
+package ms_rrp_test
+
+import (
+	"os"
+	"strconv"
+	"testing"
+
+	ms_rrp "github.com/TheManticoreProject/Manticore/network/dcerpc/ms-protocols/ms-rrp"
+	smbclient "github.com/TheManticoreProject/Manticore/network/smb/client"
+	"github.com/TheManticoreProject/Manticore/windows/credentials"
+)
+
+func liveRegistry(t *testing.T) (*ms_rrp.RemoteRegistry, func()) {
+	t.Helper()
+	host := os.Getenv("DCERPC_TEST_HOST")
+	if host == "" {
+		t.Skip("DCERPC_TEST_HOST not set; skipping live MS-RRP test")
+	}
+	port := 445
+	if p := os.Getenv("DCERPC_TEST_PORT"); p != "" {
+		n, err := strconv.Atoi(p)
+		if err != nil {
+			t.Fatalf("invalid DCERPC_TEST_PORT %q: %v", p, err)
+		}
+		port = n
+	}
+	creds, err := credentials.NewCredentials(os.Getenv("DCERPC_TEST_DOMAIN"), os.Getenv("DCERPC_TEST_USER"), os.Getenv("DCERPC_TEST_PASS"), "")
+	if err != nil {
+		t.Fatalf("NewCredentials: %v", err)
+	}
+	smb, err := smbclient.Dial(host, port, smbclient.Options{})
+	if err != nil {
+		t.Fatalf("SMB Dial: %v", err)
+	}
+	if err := smb.Login(creds); err != nil {
+		t.Fatalf("SMB Login: %v", err)
+	}
+	if err := smb.TreeConnect("IPC$"); err != nil {
+		t.Fatalf("SMB TreeConnect(IPC$): %v", err)
+	}
+	reg := ms_rrp.New(smb)
+	if err := reg.Connect(); err != nil {
+		t.Fatalf("RemoteRegistry.Connect: %v", err)
+	}
+	cleanup := func() {
+		_ = reg.Close()
+		_ = smb.TreeDisconnect()
+		_ = smb.Logoff()
+		_ = smb.Disconnect()
+	}
+	return reg, cleanup
+}
+
+func TestIntegration_RemoteRegistry(t *testing.T) {
+	reg, cleanup := liveRegistry(t)
+	defer cleanup()
+
+	hklm, err := reg.OpenLocalMachine(nil, ms_rrp.KeyRead)
+	if err != nil {
+		t.Fatalf("OpenLocalMachine: %v", err)
+	}
+	defer reg.BaseRegCloseKey(hklm)
+
+	if ver, err := reg.BaseRegGetVersion(hklm); err != nil {
+		t.Errorf("BaseRegGetVersion: %v", err)
+	} else {
+		t.Logf("[ok] registry version %d", uint32(ver))
+	}
+
+	const cv = `HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion`
+	subkeys, err := reg.EnumKeysByPath(cv)
+	if err != nil {
+		t.Errorf("EnumKeysByPath(%s): %v", cv, err)
+	} else {
+		t.Logf("[ok] %s has %d subkeys", cv, len(subkeys))
+	}
+
+	if v, err := reg.QueryValueByPath(cv, "ProductName"); err != nil {
+		t.Errorf("QueryValueByPath ProductName: %v", err)
+	} else {
+		t.Logf("[ok] ProductName = %q (type %d)", v.String(), v.Type)
+	}
+}

--- a/network/dcerpc/ms-protocols/ms-rrp/keys.go
+++ b/network/dcerpc/ms-protocols/ms-rrp/keys.go
@@ -1,0 +1,199 @@
+package ms_rrp
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/structures"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// The methods in this file mirror the winreg interface functions one-to-one: same name,
+// same parameters and returns, minus the leading rpc invoker (the bound association is
+// taken from the RemoteRegistry). They are the faithful, low-level surface; the
+// ergonomic *ByPath helpers in paths.go are built on top of them.
+
+// OpenClassesRoot calls OpenClassesRoot (opnum 0): opens HKEY_CLASSES_ROOT.
+func (r *RemoteRegistry) OpenClassesRoot(serverName *ndr.WSTR, samDesired ndr.DWORD) (structures.PRPC_HKEY, error) {
+	if err := r.ensure(); err != nil {
+		return Handle{}, err
+	}
+	return functions.OpenClassesRoot(r.rpc, serverName, samDesired)
+}
+
+// OpenCurrentUser calls OpenCurrentUser (opnum 1): opens HKEY_CURRENT_USER.
+func (r *RemoteRegistry) OpenCurrentUser(serverName *ndr.WSTR, samDesired ndr.DWORD) (structures.PRPC_HKEY, error) {
+	if err := r.ensure(); err != nil {
+		return Handle{}, err
+	}
+	return functions.OpenCurrentUser(r.rpc, serverName, samDesired)
+}
+
+// OpenLocalMachine calls OpenLocalMachine (opnum 2): opens HKEY_LOCAL_MACHINE.
+func (r *RemoteRegistry) OpenLocalMachine(serverName *ndr.WSTR, samDesired ndr.DWORD) (structures.PRPC_HKEY, error) {
+	if err := r.ensure(); err != nil {
+		return Handle{}, err
+	}
+	return functions.OpenLocalMachine(r.rpc, serverName, samDesired)
+}
+
+// OpenPerformanceData calls OpenPerformanceData (opnum 3): opens HKEY_PERFORMANCE_DATA.
+func (r *RemoteRegistry) OpenPerformanceData(serverName *ndr.WSTR, samDesired ndr.DWORD) (structures.PRPC_HKEY, error) {
+	if err := r.ensure(); err != nil {
+		return Handle{}, err
+	}
+	return functions.OpenPerformanceData(r.rpc, serverName, samDesired)
+}
+
+// OpenUsers calls OpenUsers (opnum 4): opens HKEY_USERS.
+func (r *RemoteRegistry) OpenUsers(serverName *ndr.WSTR, samDesired ndr.DWORD) (structures.PRPC_HKEY, error) {
+	if err := r.ensure(); err != nil {
+		return Handle{}, err
+	}
+	return functions.OpenUsers(r.rpc, serverName, samDesired)
+}
+
+// OpenCurrentConfig calls OpenCurrentConfig (opnum 27): opens HKEY_CURRENT_CONFIG.
+func (r *RemoteRegistry) OpenCurrentConfig(serverName *ndr.WSTR, samDesired ndr.DWORD) (structures.PRPC_HKEY, error) {
+	if err := r.ensure(); err != nil {
+		return Handle{}, err
+	}
+	return functions.OpenCurrentConfig(r.rpc, serverName, samDesired)
+}
+
+// OpenPerformanceText calls OpenPerformanceText (opnum 32).
+func (r *RemoteRegistry) OpenPerformanceText(serverName *ndr.WSTR, samDesired ndr.DWORD) (structures.PRPC_HKEY, error) {
+	if err := r.ensure(); err != nil {
+		return Handle{}, err
+	}
+	return functions.OpenPerformanceText(r.rpc, serverName, samDesired)
+}
+
+// OpenPerformanceNlsText calls OpenPerformanceNlsText (opnum 33).
+func (r *RemoteRegistry) OpenPerformanceNlsText(serverName *ndr.WSTR, samDesired ndr.DWORD) (structures.PRPC_HKEY, error) {
+	if err := r.ensure(); err != nil {
+		return Handle{}, err
+	}
+	return functions.OpenPerformanceNlsText(r.rpc, serverName, samDesired)
+}
+
+// BaseRegCloseKey calls BaseRegCloseKey (opnum 5): releases an open key handle.
+func (r *RemoteRegistry) BaseRegCloseKey(hKey structures.PRPC_HKEY) (structures.PRPC_HKEY, error) {
+	if err := r.ensure(); err != nil {
+		return Handle{}, err
+	}
+	return functions.BaseRegCloseKey(r.rpc, hKey)
+}
+
+// BaseRegCreateKey calls BaseRegCreateKey (opnum 6): creates or opens a subkey.
+func (r *RemoteRegistry) BaseRegCreateKey(hKey structures.RPC_HKEY, lpSubKey structures.RRP_UNICODE_STRING, lpClass structures.RRP_UNICODE_STRING, dwOptions ndr.DWORD, samDesired ndr.DWORD, lpSecurityAttributes *structures.RPC_SECURITY_ATTRIBUTES, lpdwDisposition *ndr.DWORD) (structures.PRPC_HKEY, *ndr.DWORD, error) {
+	if err := r.ensure(); err != nil {
+		return Handle{}, nil, err
+	}
+	return functions.BaseRegCreateKey(r.rpc, hKey, lpSubKey, lpClass, dwOptions, samDesired, lpSecurityAttributes, lpdwDisposition)
+}
+
+// BaseRegDeleteKey calls BaseRegDeleteKey (opnum 7): deletes a subkey with no subkeys.
+func (r *RemoteRegistry) BaseRegDeleteKey(hKey structures.RPC_HKEY, lpSubKey structures.RRP_UNICODE_STRING) error {
+	if err := r.ensure(); err != nil {
+		return err
+	}
+	return functions.BaseRegDeleteKey(r.rpc, hKey, lpSubKey)
+}
+
+// BaseRegEnumKey calls BaseRegEnumKey (opnum 9): returns the subkey at dwIndex.
+func (r *RemoteRegistry) BaseRegEnumKey(hKey structures.RPC_HKEY, dwIndex ndr.DWORD, lpNameIn structures.RRP_UNICODE_STRING, lpClassIn *structures.RRP_UNICODE_STRING, lpftLastWriteTime *dtyp.FILETIME) (structures.RRP_UNICODE_STRING, *dtyp.RPC_UNICODE_STRING, *dtyp.FILETIME, error) {
+	if err := r.ensure(); err != nil {
+		return structures.RRP_UNICODE_STRING{}, nil, nil, err
+	}
+	return functions.BaseRegEnumKey(r.rpc, hKey, dwIndex, lpNameIn, lpClassIn, lpftLastWriteTime)
+}
+
+// BaseRegFlushKey calls BaseRegFlushKey (opnum 11): writes a key's changes to disk.
+func (r *RemoteRegistry) BaseRegFlushKey(hKey structures.RPC_HKEY) error {
+	if err := r.ensure(); err != nil {
+		return err
+	}
+	return functions.BaseRegFlushKey(r.rpc, hKey)
+}
+
+// BaseRegLoadKey calls BaseRegLoadKey (opnum 13): loads a hive file under a subkey.
+func (r *RemoteRegistry) BaseRegLoadKey(hKey structures.RPC_HKEY, lpSubKey structures.RRP_UNICODE_STRING, lpFile structures.RRP_UNICODE_STRING) error {
+	if err := r.ensure(); err != nil {
+		return err
+	}
+	return functions.BaseRegLoadKey(r.rpc, hKey, lpSubKey, lpFile)
+}
+
+// BaseRegOpenKey calls BaseRegOpenKey (opnum 15): opens an existing subkey.
+func (r *RemoteRegistry) BaseRegOpenKey(hKey structures.RPC_HKEY, lpSubKey structures.RRP_UNICODE_STRING, dwOptions ndr.DWORD, samDesired ndr.DWORD) (structures.PRPC_HKEY, error) {
+	if err := r.ensure(); err != nil {
+		return Handle{}, err
+	}
+	return functions.BaseRegOpenKey(r.rpc, hKey, lpSubKey, dwOptions, samDesired)
+}
+
+// BaseRegQueryInfoKey calls BaseRegQueryInfoKey (opnum 16): returns subkey/value counts,
+// maximum lengths, and the last-write time of a key.
+func (r *RemoteRegistry) BaseRegQueryInfoKey(hKey structures.RPC_HKEY, lpClassIn structures.RRP_UNICODE_STRING) (dtyp.RPC_UNICODE_STRING, ndr.DWORD, ndr.DWORD, ndr.DWORD, ndr.DWORD, ndr.DWORD, ndr.DWORD, ndr.DWORD, dtyp.FILETIME, error) {
+	if err := r.ensure(); err != nil {
+		return dtyp.RPC_UNICODE_STRING{}, 0, 0, 0, 0, 0, 0, 0, dtyp.FILETIME{}, err
+	}
+	return functions.BaseRegQueryInfoKey(r.rpc, hKey, lpClassIn)
+}
+
+// BaseRegReplaceKey calls BaseRegReplaceKey (opnum 18).
+func (r *RemoteRegistry) BaseRegReplaceKey(hKey structures.RPC_HKEY, lpSubKey structures.RRP_UNICODE_STRING, lpNewFile structures.RRP_UNICODE_STRING, lpOldFile structures.RRP_UNICODE_STRING) error {
+	if err := r.ensure(); err != nil {
+		return err
+	}
+	return functions.BaseRegReplaceKey(r.rpc, hKey, lpSubKey, lpNewFile, lpOldFile)
+}
+
+// BaseRegRestoreKey calls BaseRegRestoreKey (opnum 19).
+func (r *RemoteRegistry) BaseRegRestoreKey(hKey structures.RPC_HKEY, lpFile structures.RRP_UNICODE_STRING, flags ndr.DWORD) error {
+	if err := r.ensure(); err != nil {
+		return err
+	}
+	return functions.BaseRegRestoreKey(r.rpc, hKey, lpFile, flags)
+}
+
+// BaseRegSaveKey calls BaseRegSaveKey (opnum 20): saves a key and its subtree to a file.
+func (r *RemoteRegistry) BaseRegSaveKey(hKey structures.RPC_HKEY, lpFile structures.RRP_UNICODE_STRING, pSecurityAttributes *structures.RPC_SECURITY_ATTRIBUTES) error {
+	if err := r.ensure(); err != nil {
+		return err
+	}
+	return functions.BaseRegSaveKey(r.rpc, hKey, lpFile, pSecurityAttributes)
+}
+
+// BaseRegUnLoadKey calls BaseRegUnLoadKey (opnum 23): unloads a previously loaded hive.
+func (r *RemoteRegistry) BaseRegUnLoadKey(hKey structures.RPC_HKEY, lpSubKey structures.RRP_UNICODE_STRING) error {
+	if err := r.ensure(); err != nil {
+		return err
+	}
+	return functions.BaseRegUnLoadKey(r.rpc, hKey, lpSubKey)
+}
+
+// BaseRegGetVersion calls BaseRegGetVersion (opnum 26): returns the registry version.
+func (r *RemoteRegistry) BaseRegGetVersion(hKey structures.RPC_HKEY) (ndr.DWORD, error) {
+	if err := r.ensure(); err != nil {
+		return 0, err
+	}
+	return functions.BaseRegGetVersion(r.rpc, hKey)
+}
+
+// BaseRegSaveKeyEx calls BaseRegSaveKeyEx (opnum 31): saves a key with format flags.
+func (r *RemoteRegistry) BaseRegSaveKeyEx(hKey structures.RPC_HKEY, lpFile structures.RRP_UNICODE_STRING, pSecurityAttributes *structures.RPC_SECURITY_ATTRIBUTES, flags ndr.DWORD) error {
+	if err := r.ensure(); err != nil {
+		return err
+	}
+	return functions.BaseRegSaveKeyEx(r.rpc, hKey, lpFile, pSecurityAttributes, flags)
+}
+
+// BaseRegDeleteKeyEx calls BaseRegDeleteKeyEx (opnum 35): deletes a subkey honouring the
+// KEY_WOW64_* view selected by accessMask.
+func (r *RemoteRegistry) BaseRegDeleteKeyEx(hKey structures.RPC_HKEY, lpSubKey structures.RRP_UNICODE_STRING, accessMask ndr.DWORD, reserved ndr.DWORD) error {
+	if err := r.ensure(); err != nil {
+		return err
+	}
+	return functions.BaseRegDeleteKeyEx(r.rpc, hKey, lpSubKey, accessMask, reserved)
+}

--- a/network/dcerpc/ms-protocols/ms-rrp/paths.go
+++ b/network/dcerpc/ms-protocols/ms-rrp/paths.go
@@ -1,0 +1,259 @@
+package ms_rrp
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	winreg "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/structures"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// This file holds the ergonomic, reg.exe-style helpers layered on top of the one-to-one
+// interface methods. They accept Go string paths ("HKLM\\Software\\...") and value names,
+// open and close the necessary handles, and project results into Go types. The method
+// names here are deliberately distinct from the interface method names.
+
+// maximumAllowed is MAXIMUM_ALLOWED ([MS-DTYP] 2.4.3): asks the server to grant the most
+// access the caller is permitted. Used when opening a transient root handle whose only job
+// is to host a create/delete of a subkey beneath it.
+const maximumAllowed ndr.DWORD = 0x02000000
+
+// regName builds a NUL-terminated RRP_UNICODE_STRING for a key/value name. [MS-RRP] 3.1.1
+// counts the terminating NUL in the length, so it is appended explicitly.
+func regName(s string) structures.RRP_UNICODE_STRING {
+	return dtyp.NewUnicodeString(s + "\x00")
+}
+
+// isStatus reports whether err carries the given winreg Win32 status code, matched by the
+// mnemonic the interface stubs embed in their error text (e.g. ERROR_NO_MORE_ITEMS). This
+// lets enumeration/query loops treat the documented terminal codes as sentinels rather
+// than hard failures.
+func isStatus(err error, code uint32) bool {
+	return err != nil && strings.Contains(err.Error(), winreg.StatusString(code))
+}
+
+// splitRegistryPath splits "HKLM\\Software\\Foo" into the root mnemonic ("HKLM") and the
+// remaining subkey path ("Software\\Foo"). Leading/trailing backslashes and spaces are
+// trimmed; a path with no subkey returns an empty subkey.
+func splitRegistryPath(path string) (root, subkey string) {
+	path = strings.Trim(strings.TrimSpace(path), `\`)
+	if i := strings.IndexByte(path, '\\'); i >= 0 {
+		return path[:i], path[i+1:]
+	}
+	return path, ""
+}
+
+// openRoot opens the predefined root key named by root (HKLM, HKEY_LOCAL_MACHINE, HKCU,
+// HKCR, HKU, HKCC, HKPD and their long forms), returning its handle.
+func (r *RemoteRegistry) openRoot(root string, samDesired ndr.DWORD) (Handle, error) {
+	switch strings.ToUpper(strings.TrimSpace(root)) {
+	case "HKLM", "HKEY_LOCAL_MACHINE":
+		return r.OpenLocalMachine(nil, samDesired)
+	case "HKCU", "HKEY_CURRENT_USER":
+		return r.OpenCurrentUser(nil, samDesired)
+	case "HKCR", "HKEY_CLASSES_ROOT":
+		return r.OpenClassesRoot(nil, samDesired)
+	case "HKU", "HKEY_USERS":
+		return r.OpenUsers(nil, samDesired)
+	case "HKCC", "HKEY_CURRENT_CONFIG":
+		return r.OpenCurrentConfig(nil, samDesired)
+	case "HKPD", "HKEY_PERFORMANCE_DATA":
+		return r.OpenPerformanceData(nil, samDesired)
+	default:
+		return Handle{}, fmt.Errorf("ms_rrp: unknown registry root %q", root)
+	}
+}
+
+// OpenKeyByPath opens the key at a full path such as "HKLM\\SOFTWARE\\Microsoft", with the
+// requested access. The caller owns the returned handle and must BaseRegCloseKey it. The
+// transient root handle is closed before returning.
+func (r *RemoteRegistry) OpenKeyByPath(keyPath string, samDesired ndr.DWORD) (Handle, error) {
+	root, sub := splitRegistryPath(keyPath)
+	h, err := r.openRoot(root, samDesired)
+	if err != nil {
+		return Handle{}, err
+	}
+	if sub == "" {
+		return h, nil
+	}
+	sk, err := r.BaseRegOpenKey(h, regName(sub), 0, samDesired)
+	_, _ = r.BaseRegCloseKey(h) // the subkey handle is independent of the root handle
+	if err != nil {
+		return Handle{}, err
+	}
+	return sk, nil
+}
+
+// queryValue reads a single value under an open key, negotiating the data buffer size: it
+// grows and retries on ERROR_MORE_DATA.
+func (r *RemoteRegistry) queryValue(h Handle, valueName string) (RegistryValue, error) {
+	bufLen := uint32(256)
+	for attempts := 0; attempts < 5; attempts++ {
+		buf := make([]byte, bufLen)
+		typ := ndr.DWORD(0)
+		cb := ndr.DWORD(bufLen)
+		ln := ndr.DWORD(bufLen)
+		rTyp, rData, rcb, _, err := r.BaseRegQueryValue(h, regName(valueName), &typ, buf, &cb, &ln)
+		if err != nil {
+			if isStatus(err, winreg.ErrorMoreData) && rcb != nil && uint32(*rcb) > bufLen {
+				bufLen = uint32(*rcb)
+				continue
+			}
+			return RegistryValue{}, err
+		}
+		n := bufLen
+		if rcb != nil {
+			n = uint32(*rcb)
+		}
+		if int(n) > len(rData) {
+			n = uint32(len(rData))
+		}
+		out := RegistryValue{Data: append([]byte(nil), rData[:n]...)}
+		if rTyp != nil {
+			out.Type = uint32(*rTyp)
+		}
+		return out, nil
+	}
+	return RegistryValue{}, fmt.Errorf("ms_rrp: value %q under the key kept requesting a larger buffer", valueName)
+}
+
+// QueryValueByPath opens keyPath for read, reads valueName, and closes the key.
+func (r *RemoteRegistry) QueryValueByPath(keyPath, valueName string) (RegistryValue, error) {
+	h, err := r.OpenKeyByPath(keyPath, winreg.KeyQueryValue)
+	if err != nil {
+		return RegistryValue{}, err
+	}
+	defer r.BaseRegCloseKey(h)
+	return r.queryValue(h, valueName)
+}
+
+// SetValueByPath opens keyPath for write, writes value under valueName, and closes the key.
+func (r *RemoteRegistry) SetValueByPath(keyPath, valueName string, value RegistryValue) error {
+	h, err := r.OpenKeyByPath(keyPath, winreg.KeySetValue)
+	if err != nil {
+		return err
+	}
+	defer r.BaseRegCloseKey(h)
+	return r.BaseRegSetValue(h, regName(valueName), ndr.DWORD(value.Type), value.Data, ndr.DWORD(len(value.Data)))
+}
+
+// DeleteValueByPath opens keyPath for write, removes valueName, and closes the key.
+func (r *RemoteRegistry) DeleteValueByPath(keyPath, valueName string) error {
+	h, err := r.OpenKeyByPath(keyPath, winreg.KeySetValue)
+	if err != nil {
+		return err
+	}
+	defer r.BaseRegCloseKey(h)
+	return r.BaseRegDeleteValue(h, regName(valueName))
+}
+
+// EnumKeys returns the names of all immediate subkeys of an open key, looping
+// BaseRegEnumKey until ERROR_NO_MORE_ITEMS.
+func (r *RemoteRegistry) EnumKeys(h Handle) ([]string, error) {
+	var names []string
+	for i := uint32(0); ; i++ {
+		nameIn := structures.RRP_UNICODE_STRING{MaximumLength: 512, Buffer: make([]uint16, 256)}
+		classIn := structures.RRP_UNICODE_STRING{MaximumLength: 512, Buffer: make([]uint16, 256)}
+		nameOut, _, _, err := r.BaseRegEnumKey(h, ndr.DWORD(i), nameIn, &classIn, nil)
+		if err != nil {
+			if isStatus(err, winreg.ErrorNoMoreItems) {
+				break
+			}
+			return names, err
+		}
+		names = append(names, nameOut.String())
+	}
+	return names, nil
+}
+
+// EnumKeysByPath opens keyPath, enumerates its subkeys, and closes the key.
+func (r *RemoteRegistry) EnumKeysByPath(keyPath string) ([]string, error) {
+	h, err := r.OpenKeyByPath(keyPath, winreg.KeyEnumerateSubKeys)
+	if err != nil {
+		return nil, err
+	}
+	defer r.BaseRegCloseKey(h)
+	return r.EnumKeys(h)
+}
+
+// EnumValues returns all values of an open key, looping BaseRegEnumValue until
+// ERROR_NO_MORE_ITEMS.
+func (r *RemoteRegistry) EnumValues(h Handle) ([]ValueEntry, error) {
+	var entries []ValueEntry
+	for i := uint32(0); ; i++ {
+		nameIn := structures.RRP_UNICODE_STRING{MaximumLength: 1024, Buffer: make([]uint16, 512)}
+		typ := ndr.DWORD(0)
+		buf := make([]byte, 1024)
+		cb := ndr.DWORD(len(buf))
+		ln := ndr.DWORD(len(buf))
+		nameOut, rTyp, rData, rcb, _, err := r.BaseRegEnumValue(h, ndr.DWORD(i), nameIn, &typ, buf, &cb, &ln)
+		if err != nil {
+			if isStatus(err, winreg.ErrorNoMoreItems) {
+				break
+			}
+			return entries, err
+		}
+		n := len(rData)
+		if rcb != nil && int(*rcb) < n {
+			n = int(*rcb)
+		}
+		val := RegistryValue{Data: append([]byte(nil), rData[:n]...)}
+		if rTyp != nil {
+			val.Type = uint32(*rTyp)
+		}
+		entries = append(entries, ValueEntry{Name: nameOut.String(), Value: val})
+	}
+	return entries, nil
+}
+
+// EnumValuesByPath opens keyPath, enumerates its values, and closes the key.
+func (r *RemoteRegistry) EnumValuesByPath(keyPath string) ([]ValueEntry, error) {
+	h, err := r.OpenKeyByPath(keyPath, winreg.KeyQueryValue)
+	if err != nil {
+		return nil, err
+	}
+	defer r.BaseRegCloseKey(h)
+	return r.EnumValues(h)
+}
+
+// CreateKeyByPath creates (or opens, if it already exists) the key at keyPath, returning
+// the new handle and the disposition (RegCreatedNewKey / RegOpenedExistingKey). The caller
+// must BaseRegCloseKey the returned handle.
+func (r *RemoteRegistry) CreateKeyByPath(keyPath string, samDesired ndr.DWORD) (Handle, ndr.DWORD, error) {
+	root, sub := splitRegistryPath(keyPath)
+	if sub == "" {
+		return Handle{}, 0, fmt.Errorf("ms_rrp: cannot create a root key %q", root)
+	}
+	rootHandle, err := r.openRoot(root, maximumAllowed)
+	if err != nil {
+		return Handle{}, 0, err
+	}
+	defer r.BaseRegCloseKey(rootHandle)
+	disp := ndr.DWORD(0)
+	sk, rdisp, err := r.BaseRegCreateKey(rootHandle, regName(sub), structures.RRP_UNICODE_STRING{}, ndr.DWORD(winreg.RegOptionNonVolatile), samDesired, nil, &disp)
+	if err != nil {
+		return Handle{}, 0, err
+	}
+	d := disp
+	if rdisp != nil {
+		d = *rdisp
+	}
+	return sk, d, nil
+}
+
+// DeleteKeyByPath deletes the key at keyPath. The key must have no subkeys (per
+// BaseRegDeleteKey). Root keys cannot be deleted.
+func (r *RemoteRegistry) DeleteKeyByPath(keyPath string) error {
+	root, sub := splitRegistryPath(keyPath)
+	if sub == "" {
+		return fmt.Errorf("ms_rrp: refusing to delete root key %q", root)
+	}
+	rootHandle, err := r.openRoot(root, maximumAllowed)
+	if err != nil {
+		return err
+	}
+	defer r.BaseRegCloseKey(rootHandle)
+	return r.BaseRegDeleteKey(rootHandle, regName(sub))
+}

--- a/network/dcerpc/ms-protocols/ms-rrp/paths_internal_test.go
+++ b/network/dcerpc/ms-protocols/ms-rrp/paths_internal_test.go
@@ -1,0 +1,62 @@
+package ms_rrp
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	winreg "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0"
+)
+
+func TestSplitRegistryPath(t *testing.T) {
+	cases := []struct {
+		in, root, sub string
+	}{
+		{`HKLM\Software\Microsoft`, "HKLM", `Software\Microsoft`},
+		{`\HKEY_LOCAL_MACHINE\SYSTEM\`, "HKEY_LOCAL_MACHINE", "SYSTEM"},
+		{`HKCU`, "HKCU", ""},
+		{`  HKU\.DEFAULT  `, "HKU", ".DEFAULT"},
+	}
+	for _, c := range cases {
+		root, sub := splitRegistryPath(c.in)
+		if root != c.root || sub != c.sub {
+			t.Errorf("splitRegistryPath(%q) = (%q, %q), want (%q, %q)", c.in, root, sub, c.root, c.sub)
+		}
+	}
+}
+
+func TestRegNameTerminatorCounted(t *testing.T) {
+	// "Foo" is 3 wchars; with the appended NUL the counted byte Length must be 8.
+	u := regName("Foo")
+	if u.Length != 8 {
+		t.Errorf("regName(\"Foo\").Length = %d, want 8 (3 chars + NUL, in bytes)", u.Length)
+	}
+}
+
+func TestIsStatus(t *testing.T) {
+	err := fmt.Errorf("BaseRegEnumKey failed: %s", winreg.StatusString(winreg.ErrorNoMoreItems))
+	if !isStatus(err, winreg.ErrorNoMoreItems) {
+		t.Error("isStatus did not match ERROR_NO_MORE_ITEMS")
+	}
+	if isStatus(err, winreg.ErrorAccessDenied) {
+		t.Error("isStatus matched the wrong code")
+	}
+	if isStatus(nil, winreg.ErrorNoMoreItems) {
+		t.Error("isStatus(nil) should be false")
+	}
+	if isStatus(errors.New("plain"), winreg.ErrorMoreData) {
+		t.Error("isStatus matched an unrelated error")
+	}
+}
+
+func TestUTF16RoundTrip(t *testing.T) {
+	for _, s := range []string{"", "A", "Hello, World", "Ünîcödé", `C:\Windows`} {
+		if got := decodeUTF16(encodeUTF16(s)); got != s {
+			t.Errorf("utf16 round-trip %q = %q", s, got)
+		}
+	}
+	// encodeUTF16 must append exactly one NUL terminator (2 octets).
+	if n := len(encodeUTF16("AB")); n != 6 {
+		t.Errorf("encodeUTF16(\"AB\") len = %d, want 6 (2 chars + NUL)", n)
+	}
+}

--- a/network/dcerpc/ms-protocols/ms-rrp/security.go
+++ b/network/dcerpc/ms-protocols/ms-rrp/security.go
@@ -1,0 +1,26 @@
+package ms_rrp
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/structures"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// BaseRegGetKeySecurity calls BaseRegGetKeySecurity (opnum 12): returns the parts of a
+// key's security descriptor selected by securityInformation (an OWNER/GROUP/DACL/SACL
+// bitmask).
+func (r *RemoteRegistry) BaseRegGetKeySecurity(hKey structures.RPC_HKEY, securityInformation ndr.DWORD, pRpcSecurityDescriptorIn structures.RPC_SECURITY_DESCRIPTOR) (structures.RPC_SECURITY_DESCRIPTOR, error) {
+	if err := r.ensure(); err != nil {
+		return structures.RPC_SECURITY_DESCRIPTOR{}, err
+	}
+	return functions.BaseRegGetKeySecurity(r.rpc, hKey, securityInformation, pRpcSecurityDescriptorIn)
+}
+
+// BaseRegSetKeySecurity calls BaseRegSetKeySecurity (opnum 21): sets the parts of a key's
+// security descriptor selected by securityInformation.
+func (r *RemoteRegistry) BaseRegSetKeySecurity(hKey structures.RPC_HKEY, securityInformation ndr.DWORD, pRpcSecurityDescriptor structures.RPC_SECURITY_DESCRIPTOR) error {
+	if err := r.ensure(); err != nil {
+		return err
+	}
+	return functions.BaseRegSetKeySecurity(r.rpc, hKey, securityInformation, pRpcSecurityDescriptor)
+}

--- a/network/dcerpc/ms-protocols/ms-rrp/values.go
+++ b/network/dcerpc/ms-protocols/ms-rrp/values.go
@@ -1,0 +1,196 @@
+package ms_rrp
+
+import (
+	"encoding/binary"
+	"strings"
+	"unicode/utf16"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	winreg "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/structures"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// RegistryValue is a typed registry value: its REG_* type and its raw little-endian data
+// bytes, exactly as carried on the wire. The decode helpers (String, Uint32, ...) project
+// the bytes per Type; the constructor helpers (StringValue, DwordValue, ...) build the
+// bytes for SetValue.
+type RegistryValue struct {
+	Type uint32
+	Data []byte
+}
+
+// String decodes REG_SZ / REG_EXPAND_SZ / REG_LINK as a UTF-16LE string (trailing NULs
+// stripped). For other types it returns the empty string; use the type-specific helpers.
+func (v RegistryValue) String() string {
+	switch v.Type {
+	case winreg.RegSz, winreg.RegExpandSz, winreg.RegLink:
+		return decodeUTF16(v.Data)
+	default:
+		return ""
+	}
+}
+
+// Uint32 decodes a REG_DWORD (little-endian). ok is false if the data is too short.
+func (v RegistryValue) Uint32() (uint32, bool) {
+	if len(v.Data) < 4 {
+		return 0, false
+	}
+	return binary.LittleEndian.Uint32(v.Data), true
+}
+
+// Uint64 decodes a REG_QWORD (little-endian). ok is false if the data is too short.
+func (v RegistryValue) Uint64() (uint64, bool) {
+	if len(v.Data) < 8 {
+		return 0, false
+	}
+	return binary.LittleEndian.Uint64(v.Data), true
+}
+
+// MultiString decodes a REG_MULTI_SZ: a sequence of UTF-16LE strings, each NUL-terminated,
+// the whole terminated by an empty string. Empty trailing entries are dropped.
+func (v RegistryValue) MultiString() []string {
+	if v.Type != winreg.RegMultiSz {
+		return nil
+	}
+	whole := decodeUTF16Raw(v.Data)
+	parts := strings.Split(whole, "\x00")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p == "" {
+			continue
+		}
+		out = append(out, p)
+	}
+	return out
+}
+
+// StringValue builds a REG_SZ value from a Go string.
+func StringValue(s string) RegistryValue {
+	return RegistryValue{Type: winreg.RegSz, Data: encodeUTF16(s)}
+}
+
+// ExpandStringValue builds a REG_EXPAND_SZ value from a Go string.
+func ExpandStringValue(s string) RegistryValue {
+	return RegistryValue{Type: winreg.RegExpandSz, Data: encodeUTF16(s)}
+}
+
+// DwordValue builds a REG_DWORD value (little-endian).
+func DwordValue(v uint32) RegistryValue {
+	b := make([]byte, 4)
+	binary.LittleEndian.PutUint32(b, v)
+	return RegistryValue{Type: winreg.RegDword, Data: b}
+}
+
+// QwordValue builds a REG_QWORD value (little-endian).
+func QwordValue(v uint64) RegistryValue {
+	b := make([]byte, 8)
+	binary.LittleEndian.PutUint64(b, v)
+	return RegistryValue{Type: winreg.RegQword, Data: b}
+}
+
+// BinaryValue builds a REG_BINARY value from raw bytes.
+func BinaryValue(b []byte) RegistryValue {
+	return RegistryValue{Type: winreg.RegBinary, Data: append([]byte(nil), b...)}
+}
+
+// MultiStringValue builds a REG_MULTI_SZ value: each string NUL-terminated, the block
+// terminated by a final empty string.
+func MultiStringValue(items []string) RegistryValue {
+	return RegistryValue{Type: winreg.RegMultiSz, Data: encodeUTF16Multi(items)}
+}
+
+// ValueEntry pairs a value's name with its typed data, as returned by EnumValues.
+type ValueEntry struct {
+	Name  string
+	Value RegistryValue
+}
+
+// BaseRegQueryValue calls BaseRegQueryValue (opnum 17). It mirrors the interface function
+// exactly (minus the invoker); for ergonomic reads use QueryValueByPath / queryValue.
+func (r *RemoteRegistry) BaseRegQueryValue(hKey structures.RPC_HKEY, lpValueName structures.RRP_UNICODE_STRING, lpType *ndr.DWORD, lpData []uint8, lpcbData *ndr.DWORD, lpcbLen *ndr.DWORD) (*ndr.DWORD, []uint8, *ndr.DWORD, *ndr.DWORD, error) {
+	if err := r.ensure(); err != nil {
+		return nil, nil, nil, nil, err
+	}
+	return functions.BaseRegQueryValue(r.rpc, hKey, lpValueName, lpType, lpData, lpcbData, lpcbLen)
+}
+
+// BaseRegSetValue calls BaseRegSetValue (opnum 22): writes a value's type and data.
+func (r *RemoteRegistry) BaseRegSetValue(hKey structures.RPC_HKEY, lpValueName structures.RRP_UNICODE_STRING, dwType ndr.DWORD, lpData []uint8, cbData ndr.DWORD) error {
+	if err := r.ensure(); err != nil {
+		return err
+	}
+	return functions.BaseRegSetValue(r.rpc, hKey, lpValueName, dwType, lpData, cbData)
+}
+
+// BaseRegDeleteValue calls BaseRegDeleteValue (opnum 8): removes a named value.
+func (r *RemoteRegistry) BaseRegDeleteValue(hKey structures.RPC_HKEY, lpValueName structures.RRP_UNICODE_STRING) error {
+	if err := r.ensure(); err != nil {
+		return err
+	}
+	return functions.BaseRegDeleteValue(r.rpc, hKey, lpValueName)
+}
+
+// BaseRegEnumValue calls BaseRegEnumValue (opnum 10): returns the value at dwIndex.
+func (r *RemoteRegistry) BaseRegEnumValue(hKey structures.RPC_HKEY, dwIndex ndr.DWORD, lpValueNameIn structures.RRP_UNICODE_STRING, lpType *ndr.DWORD, lpData []uint8, lpcbData *ndr.DWORD, lpcbLen *ndr.DWORD) (dtyp.RPC_UNICODE_STRING, *ndr.DWORD, []uint8, *ndr.DWORD, *ndr.DWORD, error) {
+	if err := r.ensure(); err != nil {
+		return dtyp.RPC_UNICODE_STRING{}, nil, nil, nil, nil, err
+	}
+	return functions.BaseRegEnumValue(r.rpc, hKey, dwIndex, lpValueNameIn, lpType, lpData, lpcbData, lpcbLen)
+}
+
+// BaseRegQueryMultipleValues calls BaseRegQueryMultipleValues (opnum 29).
+func (r *RemoteRegistry) BaseRegQueryMultipleValues(hKey structures.RPC_HKEY, val_listIn []structures.RVALENT, num_vals ndr.DWORD, lpvalueBuf []byte, ldwTotsize ndr.DWORD) ([]structures.RVALENT, []byte, ndr.DWORD, error) {
+	if err := r.ensure(); err != nil {
+		return nil, nil, 0, err
+	}
+	return functions.BaseRegQueryMultipleValues(r.rpc, hKey, val_listIn, num_vals, lpvalueBuf, ldwTotsize)
+}
+
+// BaseRegQueryMultipleValues2 calls BaseRegQueryMultipleValues2 (opnum 34).
+func (r *RemoteRegistry) BaseRegQueryMultipleValues2(hKey structures.RPC_HKEY, val_listIn []structures.RVALENT, num_vals ndr.DWORD, lpvalueBuf []byte, ldwTotsize ndr.DWORD) ([]structures.RVALENT, []byte, ndr.DWORD, error) {
+	if err := r.ensure(); err != nil {
+		return nil, nil, 0, err
+	}
+	return functions.BaseRegQueryMultipleValues2(r.rpc, hKey, val_listIn, num_vals, lpvalueBuf, ldwTotsize)
+}
+
+// --- UTF-16LE helpers ---
+
+// encodeUTF16 encodes s as UTF-16LE with a terminating NUL (the form REG_SZ uses).
+func encodeUTF16(s string) []byte {
+	u := utf16.Encode([]rune(s))
+	b := make([]byte, len(u)*2+2)
+	for i, c := range u {
+		binary.LittleEndian.PutUint16(b[i*2:], c)
+	}
+	return b
+}
+
+// encodeUTF16Multi encodes a REG_MULTI_SZ block: each item NUL-terminated, a final empty
+// string closing the block.
+func encodeUTF16Multi(items []string) []byte {
+	var b []byte
+	for _, s := range items {
+		b = append(b, encodeUTF16(s)...)
+	}
+	b = append(b, 0x00, 0x00) // final empty string terminator
+	return b
+}
+
+// decodeUTF16 decodes UTF-16LE bytes and strips a single trailing NUL terminator.
+func decodeUTF16(b []byte) string {
+	return strings.TrimRight(decodeUTF16Raw(b), "\x00")
+}
+
+// decodeUTF16Raw decodes UTF-16LE bytes without stripping NULs (an odd trailing byte is
+// ignored).
+func decodeUTF16Raw(b []byte) string {
+	n := len(b) / 2
+	u := make([]uint16, n)
+	for i := 0; i < n; i++ {
+		u[i] = binary.LittleEndian.Uint16(b[i*2:])
+	}
+	return string(utf16.Decode(u))
+}


### PR DESCRIPTION
### Summary
Adds `network/dcerpc/ms-protocols/ms-rrp` (package `ms_rrp`), the high-level MS-RRP (Windows Remote Registry) client layer over the existing `winreg` DCE/RPC interface (`338cd001-2244-31f1-aaaa-900038001003` v1.0). This is the protocol layer above the interface — the reg.exe / reg.py-equivalent client API.

### `RemoteRegistry`
A struct carrying the session it is reached over (the SMB pipe dialer) and, after `Connect`, the **single bound `\winreg` association** that every call and chained key handle shares. Unlike the stateless MS-SRVS layer, registry context handles chain (`HKLM → subkey → close`) and are association-scoped, so `RemoteRegistry` binds once in `Connect` and reuses it until `Close`.

Lifecycle: `New(dialer)`, `Connect()`, `Close()`, `IsConnected()`.

### API surface
- **All 31 winreg interface functions exposed as identically named methods** on `RemoteRegistry` (`OpenLocalMachine`, `BaseRegOpenKey`, `BaseRegQueryValue`, `BaseRegSetValue`, `BaseRegEnumKey`, `BaseRegCreateKey`, `BaseRegDeleteKeyEx`, …), each delegating to the interface function over the bound association (minus the explicit invoker argument).
- **reg.exe-style convenience helpers** (distinct names): `OpenKeyByPath`, `QueryValueByPath`, `SetValueByPath`, `DeleteValueByPath`, `EnumKeys`/`EnumKeysByPath`, `EnumValues`/`EnumValuesByPath`, `CreateKeyByPath`, `DeleteKeyByPath`, with `HKLM\…` / `HKEY_LOCAL_MACHINE\…` root parsing.
- **Typed `RegistryValue`** (`Type` + raw bytes) with constructors (`StringValue`, `DwordValue`, `QwordValue`, `BinaryValue`, `MultiStringValue`, `ExpandStringValue`) and decoders (`String`, `Uint32`, `Uint64`, `MultiString`).
- **Re-exported REGSAM rights, value types, dispositions** (typed for direct use), so callers need not import the interface package.

### Tests
- Unit tests with an in-memory DCE/RPC transport: `Connect` (bind), `OpenLocalMachine`, `BaseRegGetVersion`, status-error surfacing, `Close` idempotency, the not-connected guard, path parsing, UTF-16 round-trips, and value codecs.
- Live `integration_test.go` (behind `//go:build integration`): `OpenLocalMachine → BaseRegGetVersion → EnumKeysByPath → QueryValueByPath ProductName`, gated on `DCERPC_TEST_HOST`.

### Verification
`gofmt`, `go build ./...`, `go vet`, `go test ./network/dcerpc/ms-protocols/ms-rrp/...` (green), and `go build -tags integration` all pass. No changes to the existing winreg interface.

### Notes
- The interface's `BaseRegQueryValue` / `BaseRegEnumValue` data buffers are modeled `unique,varying` upstream; the convenience read path negotiates buffer size on `ERROR_MORE_DATA`. The live integration test is the real wire gate for those paths.