### PR TITLE
Fix registry enumeration helpers aborting on ERROR_MORE_DATA (#612)

### DIFF
--- a/network/dcerpc/ms-protocols/ms-rrp/paths.go
+++ b/network/dcerpc/ms-protocols/ms-rrp/paths.go
@@ -150,20 +150,32 @@ func (r *RemoteRegistry) DeleteValueByPath(keyPath, valueName string) error {
 }
 
 // EnumKeys returns the names of all immediate subkeys of an open key, looping
-// BaseRegEnumKey until ERROR_NO_MORE_ITEMS.
+// BaseRegEnumKey until ERROR_NO_MORE_ITEMS. Subkey names are capped at 255 UTF-16 code
+// units by the registry, but the name/class buffers grow and retry the same index on
+// ERROR_MORE_DATA to stay robust if a server reports a longer name.
 func (r *RemoteRegistry) EnumKeys(h Handle) ([]string, error) {
 	var names []string
-	for i := uint32(0); ; i++ {
-		nameIn := structures.RRP_UNICODE_STRING{MaximumLength: 512, Buffer: make([]uint16, 256)}
-		classIn := structures.RRP_UNICODE_STRING{MaximumLength: 512, Buffer: make([]uint16, 256)}
+	// bufLen counts UTF-16 code units; MaximumLength is that count in bytes (×2). The cap
+	// keeps MaximumLength within its uint16 field while far exceeding the 255-char limit.
+	bufLen := uint32(256)
+	const maxBufLen = uint32(16 * 1024)
+	for i := uint32(0); ; {
+		nameIn := structures.RRP_UNICODE_STRING{MaximumLength: uint16(bufLen * 2), Buffer: make([]uint16, bufLen)}
+		classIn := structures.RRP_UNICODE_STRING{MaximumLength: uint16(bufLen * 2), Buffer: make([]uint16, bufLen)}
 		nameOut, _, _, err := r.BaseRegEnumKey(h, ndr.DWORD(i), nameIn, &classIn, nil)
 		if err != nil {
 			if isStatus(err, winreg.ErrorNoMoreItems) {
 				break
 			}
+			if isStatus(err, winreg.ErrorMoreData) && bufLen < maxBufLen {
+				// The name (or class) did not fit: grow the buffers and retry the same index.
+				bufLen *= 2
+				continue
+			}
 			return names, err
 		}
 		names = append(names, nameOut.String())
+		i++
 	}
 	return names, nil
 }
@@ -179,19 +191,29 @@ func (r *RemoteRegistry) EnumKeysByPath(keyPath string) ([]string, error) {
 }
 
 // EnumValues returns all values of an open key, looping BaseRegEnumValue until
-// ERROR_NO_MORE_ITEMS.
+// ERROR_NO_MORE_ITEMS. The data buffer is negotiated per value: it grows and retries the
+// same index on ERROR_MORE_DATA (e.g. values whose data exceeds the initial buffer).
 func (r *RemoteRegistry) EnumValues(h Handle) ([]ValueEntry, error) {
 	var entries []ValueEntry
-	for i := uint32(0); ; i++ {
-		nameIn := structures.RRP_UNICODE_STRING{MaximumLength: 1024, Buffer: make([]uint16, 512)}
+	dataLen := uint32(1024)
+	for i := uint32(0); ; {
+		// A registry value name fits in 1023 UTF-16 code units here; only the data buffer
+		// needs to grow, so the name buffer is fixed and the data buffer is negotiated.
+		nameIn := structures.RRP_UNICODE_STRING{MaximumLength: 2048, Buffer: make([]uint16, 1024)}
 		typ := ndr.DWORD(0)
-		buf := make([]byte, 1024)
-		cb := ndr.DWORD(len(buf))
-		ln := ndr.DWORD(len(buf))
+		buf := make([]byte, dataLen)
+		cb := ndr.DWORD(dataLen)
+		ln := ndr.DWORD(dataLen)
 		nameOut, rTyp, rData, rcb, _, err := r.BaseRegEnumValue(h, ndr.DWORD(i), nameIn, &typ, buf, &cb, &ln)
 		if err != nil {
 			if isStatus(err, winreg.ErrorNoMoreItems) {
 				break
+			}
+			if isStatus(err, winreg.ErrorMoreData) && rcb != nil && uint32(*rcb) > dataLen {
+				// The value's data is larger than the current buffer: grow it and retry the
+				// same index without advancing.
+				dataLen = uint32(*rcb)
+				continue
 			}
 			return entries, err
 		}
@@ -204,6 +226,7 @@ func (r *RemoteRegistry) EnumValues(h Handle) ([]ValueEntry, error) {
 			val.Type = uint32(*rTyp)
 		}
 		entries = append(entries, ValueEntry{Name: nameOut.String(), Value: val})
+		i++
 	}
 	return entries, nil
 }


### PR DESCRIPTION
### Linked Issue
`Closes #612`

### Root Cause
The `EnumValues` and `EnumKeys` convenience helpers allocate fixed-size output buffers (a 1024-byte data buffer in `EnumValues`; a 256-code-unit name/class buffer in `EnumKeys`) and drive a loop that only treats `ERROR_NO_MORE_ITEMS` as a non-error sentinel. Any other status — including `ERROR_MORE_DATA`, which the server returns when the supplied buffer is too small — falls through to `return entries, err`, aborting the enumeration. The sibling `queryValue()` helper already negotiates buffer size on `ERROR_MORE_DATA`, but that idiom was never applied to the enumeration path, so the helpers silently violated their documented grow-and-retry contract.

### Fix Description
Both helpers now negotiate buffer size per item. On `ERROR_MORE_DATA` they grow the buffer and retry the *same* index without advancing the enumeration counter, mirroring the existing `queryValue()` approach:

- `EnumValues`: the data buffer (`dataLen`) starts at 1024 bytes and grows to the size the server reports in `lpcbData` (`*rcb`) before retrying.
- `EnumKeys`: the name/class buffers start at 256 code units and double on `ERROR_MORE_DATA`. Because `RPC_UNICODE_STRING.MaximumLength` is a `uint16` byte count, growth is capped at 16384 code units (32768 bytes) — far beyond the registry's 255-character subkey-name limit — so the field cannot overflow.

The loop counter is now incremented only after a value/subkey is successfully read, so a grow-and-retry re-reads the same index rather than skipping an entry.

### How Verified
**Runtime (before):** enumerating `HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion` failed with `BaseRegEnumValue failed: ERROR_MORE_DATA` (its `DigitalProductId4` value is ~1272 bytes, exceeding the old 1024-byte buffer).

**Runtime (after):** the same enumeration against a live Windows Server 2016 host now returns all 27 values (including the large `DigitalProductId4` `REG_BINARY`) and all 87 subkeys, with no error.

**Tests:** `go test ./network/dcerpc/ms-protocols/ms-rrp/` passes, and the live integration test `TestIntegration_RemoteRegistry` (`-tags integration`) passes against the same host (registry version read, subkeys enumerated, `ProductName` read).

### Test Coverage
**Existing:** `TestIntegration_RemoteRegistry` exercises `EnumKeysByPath` and the query path against a live host; the package unit tests in `paths_internal_test.go` cover the `isStatus` sentinel handling. The grow-and-retry path is data-size dependent and exercised by the live integration run; no deterministic offline fixture for an over-sized value is available in the package, so no new unit test was added.

### Scope of Change
- **Files changed:** `network/dcerpc/ms-protocols/ms-rrp/paths.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Low blast radius: the change is confined to the two enumeration helpers and only alters behavior on the `ERROR_MORE_DATA` path (previously a hard failure). Successful and end-of-enumeration paths are unchanged. Safe to merge without staged rollout.

### Notes
This branch targets `feature-ms-rrp-protocol-package` rather than `main`, because the `ms_rrp` package is not yet present on `main` — it is introduced by the feature branch this fix builds on.
