### PR TITLE
Fix registry enumeration helpers returning names with a trailing NUL (#614)

### DIFF
--- a/network/dcerpc/ms-protocols/ms-rrp/paths.go
+++ b/network/dcerpc/ms-protocols/ms-rrp/paths.go
@@ -174,7 +174,9 @@ func (r *RemoteRegistry) EnumKeys(h Handle) ([]string, error) {
 			}
 			return names, err
 		}
-		names = append(names, nameOut.String())
+		// The server counts the terminating NUL in the returned name's Length, so strip it
+		// to yield a clean Go string usable as a subkey name / path component.
+		names = append(names, strings.TrimRight(nameOut.String(), "\x00"))
 		i++
 	}
 	return names, nil
@@ -225,7 +227,9 @@ func (r *RemoteRegistry) EnumValues(h Handle) ([]ValueEntry, error) {
 		if rTyp != nil {
 			val.Type = uint32(*rTyp)
 		}
-		entries = append(entries, ValueEntry{Name: nameOut.String(), Value: val})
+		// The server counts the terminating NUL in the returned name's Length; strip it so
+		// the value name is a clean Go string.
+		entries = append(entries, ValueEntry{Name: strings.TrimRight(nameOut.String(), "\x00"), Value: val})
 		i++
 	}
 	return entries, nil


### PR DESCRIPTION
### Linked Issue
`Closes #614`

### Root Cause
`RPC_UNICODE_STRING.String()` decodes `Length/2` UTF-16 code units. For enumerated names the server reports `Length` inclusive of the terminating NUL, so `String()` returns a value ending in `\x00`. The `EnumKeys` and `EnumValues` convenience helpers appended that decoded value verbatim, so every enumerated subkey/value name carried a trailing NUL. This is invisible when the name is only printed, but corrupts any reuse of the name as a path component.

### Fix Description
Strip a trailing NUL from the decoded name in the two convenience helpers before returning it:
`strings.TrimRight(nameOut.String(), "\x00")` in `EnumKeys` (subkey names) and `EnumValues` (value names). The cleanup is applied in the ergonomic layer only; the faithful interface methods `BaseRegEnumKey` / `BaseRegEnumValue` continue to return the raw wire value. `RPC_UNICODE_STRING.String()` is left unchanged, since it is a generic decoder shared by many protocols and some callers may rely on its faithful, untrimmed behavior.

### How Verified
**Runtime (before):** a consumer that reused an enumerated subkey name to open a child key failed, because the name was `"sub1\x00"`:

```
error enumerating values of "HKLM\SOFTWARE\MR_C\sub1\x00": BaseRegOpenKey failed: ERROR_FILE_NOT_FOUND
```

**Runtime (after):** against a live Windows Server 2016 host, recursively enumerating a key built from a fresh `HKLM\SOFTWARE\MR_NUL\child` subtree resolved the child path cleanly (no `\x00`), and a name-scoped search returned the clean key name `HKLM\SOFTWARE\MR_NUL\child` (previously rendered with a trailing space from the NUL). This was confirmed with a consumer that does **not** itself strip NULs, so the clean names come from the patched helpers.

**Tests:** `go test ./network/dcerpc/ms-protocols/ms-rrp/` passes; the live integration test `TestIntegration_RemoteRegistry` (`-tags integration`) passes against the same host.

### Test Coverage
**None:** the trailing NUL originates from the live server's reported `Length`; there is no offline fixture in the package that drives `BaseRegEnumKey`/`BaseRegEnumValue` with a server-counted NUL, so the behavior is exercised by the live integration run rather than a new unit test. The change itself is a one-line `TrimRight` per helper.

### Scope of Change
- **Files changed:** `network/dcerpc/ms-protocols/ms-rrp/paths.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Low: the change only removes a trailing NUL terminator from returned names. Names that previously had no NUL are unaffected by `TrimRight`. Safe to merge without staged rollout.
