### PR TITLE
Add .reg file encode/decode support (#616)

### DIFF
--- a/windows/registry/regfile/decode.go
+++ b/windows/registry/regfile/decode.go
@@ -243,6 +243,12 @@ func splitLines(text string) []string {
 // foldContinuations joins lines split with a trailing backslash (regedit's long
 // hex-value wrapping) into single logical lines. Leading whitespace on each
 // continuation segment is stripped so the rejoined byte list parses cleanly.
+//
+// A backslash only continues a line within a (possibly multi-line) hex value,
+// so a continuation is never *started* from a comment, header, or key line: a
+// trailing backslash there (e.g. a path at the end of a comment) is literal.
+// Once a continuation is in progress, every following physical line is folded
+// until one does not end with a backslash.
 func foldContinuations(lines []string) []string {
 	var out []string
 	var cur strings.Builder
@@ -251,6 +257,9 @@ func foldContinuations(lines []string) []string {
 	for _, ln := range lines {
 		body := strings.TrimRight(ln, " \t")
 		continues := strings.HasSuffix(body, "\\")
+		if continues && !pending && !canStartContinuation(strings.TrimSpace(ln)) {
+			continues = false
+		}
 		if continues {
 			body = strings.TrimSuffix(body, "\\")
 		}
@@ -271,6 +280,24 @@ func foldContinuations(lines []string) []string {
 		out = append(out, cur.String())
 	}
 	return out
+}
+
+// canStartContinuation reports whether a logical line may begin a backslash
+// continuation. Only value lines wrap in regedit output; comment, header, and
+// key lines never do, so a trailing backslash on those is treated as literal.
+func canStartContinuation(trimmed string) bool {
+	switch {
+	case strings.HasPrefix(trimmed, ";"):
+		return false
+	case strings.HasPrefix(trimmed, "["):
+		return false
+	case trimmed == "REGEDIT4":
+		return false
+	case strings.HasPrefix(trimmed, "Windows Registry Editor Version"):
+		return false
+	default:
+		return true
+	}
 }
 
 // decodeToUTF8 sniffs the byte-order mark / encoding of a ".reg" file and

--- a/windows/registry/regfile/decode.go
+++ b/windows/registry/regfile/decode.go
@@ -1,0 +1,302 @@
+package regfile
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode/utf16"
+
+	"github.com/TheManticoreProject/Manticore/windows/registry"
+)
+
+// ValueLine is one value entry within a key block. Delete is true for a delete
+// directive (`"Name"=-`), in which case Value is the zero Value. Name is empty
+// for the default value (the "@" token).
+type ValueLine struct {
+	Name   string
+	Value  registry.Value
+	Delete bool
+}
+
+// KeyBlock is a key and its values, as written between two key headers in a
+// ".reg" file. Delete is true for a key-delete directive (`[-HKEY_...\Key]`),
+// in which case Values is empty.
+type KeyBlock struct {
+	Path   string
+	Delete bool
+	Values []ValueLine
+}
+
+// Parse decodes a ".reg" file into its key blocks. It is tolerant of real-world
+// inputs: it auto-detects UTF-16LE/UTF-16BE (with BOM) and UTF-8 (with or
+// without BOM) encodings, accepts both the "Windows Registry Editor Version
+// 5.00" and legacy "REGEDIT4" headers, ignores comment (";") and blank lines,
+// folds backslash line-continuations in long hex values, and understands the
+// delete directives "[-Key]" and `"Name"=-`.
+//
+// Parsing is best-effort: lines that cannot be interpreted are skipped and the
+// blocks parsed so far are still returned, with the per-line problems joined
+// into the returned error. A nil error means every non-trivial line parsed.
+func Parse(raw []byte) ([]KeyBlock, error) {
+	text := decodeToUTF8(raw)
+	lines := foldContinuations(splitLines(text))
+
+	var blocks []KeyBlock
+	var errs []error
+	cur := -1 // index into blocks of the key currently receiving values
+
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		switch {
+		case trimmed == "":
+			continue
+		case strings.HasPrefix(trimmed, ";"):
+			continue
+		case trimmed == "REGEDIT4" || strings.HasPrefix(trimmed, "Windows Registry Editor Version"):
+			continue
+		case strings.HasPrefix(trimmed, "["):
+			path, del, ok := parseKeyHeader(trimmed)
+			if !ok {
+				errs = append(errs, fmt.Errorf("line %d: malformed key header %q", i+1, trimmed))
+				continue
+			}
+			blocks = append(blocks, KeyBlock{Path: path, Delete: del})
+			cur = len(blocks) - 1
+		default:
+			if cur < 0 {
+				errs = append(errs, fmt.Errorf("line %d: value line before any key: %q", i+1, trimmed))
+				continue
+			}
+			vl, err := parseValueLine(trimmed)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("line %d: %w", i+1, err))
+				continue
+			}
+			blocks[cur].Values = append(blocks[cur].Values, vl)
+		}
+	}
+
+	return blocks, errors.Join(errs...)
+}
+
+// parseKeyHeader parses a "[...]" key line, returning the inner path and whether
+// it is a delete directive ("[-...]").
+func parseKeyHeader(line string) (path string, del bool, ok bool) {
+	if !strings.HasPrefix(line, "[") || !strings.HasSuffix(line, "]") {
+		return "", false, false
+	}
+	inner := line[1 : len(line)-1]
+	if strings.HasPrefix(inner, "-") {
+		return inner[1:], true, true
+	}
+	return inner, false, true
+}
+
+// parseValueLine parses a "name"=data (or @=data) line into a ValueLine.
+func parseValueLine(line string) (ValueLine, error) {
+	name, rest, err := splitNameValue(line)
+	if err != nil {
+		return ValueLine{}, err
+	}
+	v, del, err := parseValueData(rest)
+	if err != nil {
+		return ValueLine{}, err
+	}
+	return ValueLine{Name: name, Value: v, Delete: del}, nil
+}
+
+// splitNameValue splits a value line into its name and the data text after the
+// "=". The default value is written as "@"; named values are quoted and may
+// contain escaped quotes/backslashes.
+func splitNameValue(line string) (name, rest string, err error) {
+	switch {
+	case strings.HasPrefix(line, "@"):
+		after := strings.TrimSpace(line[1:])
+		if !strings.HasPrefix(after, "=") {
+			return "", "", fmt.Errorf("expected '=' after '@'")
+		}
+		return "", strings.TrimSpace(after[1:]), nil
+	case strings.HasPrefix(line, `"`):
+		n, after, ok := scanQuoted(line)
+		if !ok {
+			return "", "", fmt.Errorf("unterminated value name")
+		}
+		after = strings.TrimSpace(after)
+		if !strings.HasPrefix(after, "=") {
+			return "", "", fmt.Errorf("expected '=' after value name")
+		}
+		return n, strings.TrimSpace(after[1:]), nil
+	default:
+		return "", "", fmt.Errorf("malformed value line: %q", line)
+	}
+}
+
+// parseValueData parses the right-hand side of a value line into a typed value.
+// del is true for the delete directive ("-").
+func parseValueData(rest string) (v registry.Value, del bool, err error) {
+	switch {
+	case rest == "-":
+		return registry.Value{}, true, nil
+	case strings.HasPrefix(rest, `"`):
+		s, _, ok := scanQuoted(rest)
+		if !ok {
+			return registry.Value{}, false, fmt.Errorf("unterminated string value")
+		}
+		return registry.StringValue(s), false, nil
+	case strings.HasPrefix(rest, "dword:"):
+		n, err := strconv.ParseUint(strings.TrimSpace(rest[len("dword:"):]), 16, 32)
+		if err != nil {
+			return registry.Value{}, false, fmt.Errorf("invalid dword: %w", err)
+		}
+		return registry.DwordValue(uint32(n)), false, nil
+	case strings.HasPrefix(rest, "hex("):
+		closeIdx := strings.Index(rest, ")")
+		if closeIdx < 0 {
+			return registry.Value{}, false, fmt.Errorf("malformed hex(N) value: %q", rest)
+		}
+		t, err := strconv.ParseUint(strings.TrimSpace(rest[len("hex("):closeIdx]), 16, 32)
+		if err != nil {
+			return registry.Value{}, false, fmt.Errorf("invalid hex type: %w", err)
+		}
+		after := strings.TrimPrefix(strings.TrimSpace(rest[closeIdx+1:]), ":")
+		data, err := parseHexBytes(after)
+		if err != nil {
+			return registry.Value{}, false, err
+		}
+		return registry.Value{Type: uint32(t), Data: data}, false, nil
+	case strings.HasPrefix(rest, "hex:"):
+		data, err := parseHexBytes(rest[len("hex:"):])
+		if err != nil {
+			return registry.Value{}, false, err
+		}
+		return registry.Value{Type: registry.RegBinary, Data: data}, false, nil
+	default:
+		return registry.Value{}, false, fmt.Errorf("unrecognized value data: %q", rest)
+	}
+}
+
+// parseHexBytes parses a comma-separated list of two-digit hex bytes. Whitespace
+// and empty fields (from trailing commas) are ignored. An empty list yields an
+// empty, non-nil slice.
+func parseHexBytes(s string) ([]byte, error) {
+	s = strings.TrimSpace(s)
+	// Keep nil for the empty list so values round-trip against the registry
+	// constructor helpers (BinaryValue([]byte{}) etc.), which also yield nil.
+	var out []byte
+	if s == "" {
+		return out, nil
+	}
+	for _, tok := range strings.Split(s, ",") {
+		tok = strings.TrimSpace(tok)
+		if tok == "" {
+			continue
+		}
+		b, err := strconv.ParseUint(tok, 16, 8)
+		if err != nil {
+			return nil, fmt.Errorf("invalid hex byte %q: %w", tok, err)
+		}
+		out = append(out, byte(b))
+	}
+	return out, nil
+}
+
+// scanQuoted reads a double-quoted token at the start of s, unescaping `\\` and
+// `\"`. It returns the unescaped contents, the text following the closing quote,
+// and ok=false if s does not start with a quote or is unterminated.
+func scanQuoted(s string) (inner, rest string, ok bool) {
+	if len(s) == 0 || s[0] != '"' {
+		return "", s, false
+	}
+	var b strings.Builder
+	for i := 1; i < len(s); {
+		c := s[i]
+		switch {
+		case c == '\\' && i+1 < len(s):
+			n := s[i+1]
+			if n == '\\' || n == '"' {
+				b.WriteByte(n)
+				i += 2
+				continue
+			}
+			// Lone backslash (not a recognized escape): keep it literally.
+			b.WriteByte('\\')
+			i++
+		case c == '"':
+			return b.String(), s[i+1:], true
+		default:
+			b.WriteByte(c)
+			i++
+		}
+	}
+	return "", s, false
+}
+
+// splitLines normalizes CRLF/CR/LF endings and splits the text into lines.
+func splitLines(text string) []string {
+	text = strings.ReplaceAll(text, "\r\n", "\n")
+	text = strings.ReplaceAll(text, "\r", "\n")
+	return strings.Split(text, "\n")
+}
+
+// foldContinuations joins lines split with a trailing backslash (regedit's long
+// hex-value wrapping) into single logical lines. Leading whitespace on each
+// continuation segment is stripped so the rejoined byte list parses cleanly.
+func foldContinuations(lines []string) []string {
+	var out []string
+	var cur strings.Builder
+	pending := false
+
+	for _, ln := range lines {
+		body := strings.TrimRight(ln, " \t")
+		continues := strings.HasSuffix(body, "\\")
+		if continues {
+			body = strings.TrimSuffix(body, "\\")
+		}
+		if pending {
+			cur.WriteString(strings.TrimLeft(body, " \t"))
+		} else {
+			cur.WriteString(body)
+		}
+		if continues {
+			pending = true
+			continue
+		}
+		out = append(out, cur.String())
+		cur.Reset()
+		pending = false
+	}
+	if pending { // dangling continuation with no terminating line
+		out = append(out, cur.String())
+	}
+	return out
+}
+
+// decodeToUTF8 sniffs the byte-order mark / encoding of a ".reg" file and
+// returns its text as a Go (UTF-8) string. It recognizes UTF-16LE and UTF-16BE
+// (with BOM) and UTF-8 (with or without BOM); anything else is treated as
+// UTF-8/ASCII, which also covers legacy ANSI REGEDIT4 files for ASCII content.
+func decodeToUTF8(raw []byte) string {
+	switch {
+	case len(raw) >= 2 && raw[0] == 0xFF && raw[1] == 0xFE:
+		return decodeUTF16(raw[2:], binary.LittleEndian)
+	case len(raw) >= 2 && raw[0] == 0xFE && raw[1] == 0xFF:
+		return decodeUTF16(raw[2:], binary.BigEndian)
+	case len(raw) >= 3 && raw[0] == 0xEF && raw[1] == 0xBB && raw[2] == 0xBF:
+		return string(raw[3:])
+	default:
+		return string(raw)
+	}
+}
+
+// decodeUTF16 decodes UTF-16 bytes in the given byte order to a Go string (an
+// odd trailing byte is ignored).
+func decodeUTF16(b []byte, order binary.ByteOrder) string {
+	n := len(b) / 2
+	u := make([]uint16, n)
+	for i := 0; i < n; i++ {
+		u[i] = order.Uint16(b[i*2:])
+	}
+	return string(utf16.Decode(u))
+}

--- a/windows/registry/regfile/decode_test.go
+++ b/windows/registry/regfile/decode_test.go
@@ -1,0 +1,162 @@
+package regfile
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/windows/registry"
+)
+
+func TestParseUTF16LEWithBOM(t *testing.T) {
+	src := Header + "\r\n\r\n" +
+		"[HKEY_LOCAL_MACHINE\\Software\\Foo]\r\n" +
+		"\"Answer\"=dword:0000002a\r\n"
+	raw := encodeUTF16LEWithBOM(src)
+
+	blocks, err := Parse(raw)
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+	if len(blocks) != 1 || blocks[0].Path != `HKEY_LOCAL_MACHINE\Software\Foo` {
+		t.Fatalf("unexpected blocks: %#v", blocks)
+	}
+	v := blocks[0].Values[0]
+	if n, ok := v.Value.Uint32(); v.Name != "Answer" || !ok || n != 42 {
+		t.Errorf("value = %#v (n=%d ok=%v), want Answer=42", v, n, ok)
+	}
+}
+
+func TestParseREGEDIT4UTF8(t *testing.T) {
+	src := []byte("REGEDIT4\r\n\r\n" +
+		"[HKEY_CURRENT_USER\\Console]\r\n" +
+		"\"FaceName\"=\"Consolas\"\r\n")
+
+	blocks, err := Parse(src)
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+	if got := blocks[0].Values[0].Value.String(); got != "Consolas" {
+		t.Errorf("FaceName = %q, want %q", got, "Consolas")
+	}
+}
+
+func TestParseUTF8BOM(t *testing.T) {
+	src := append([]byte{0xEF, 0xBB, 0xBF}, []byte(Header+"\n[HKEY_USERS\\X]\n\"v\"=\"y\"\n")...)
+	blocks, err := Parse(src)
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+	if blocks[0].Path != `HKEY_USERS\X` || blocks[0].Values[0].Value.String() != "y" {
+		t.Errorf("unexpected blocks: %#v", blocks)
+	}
+}
+
+func TestParseIgnoresCommentsAndBlanks(t *testing.T) {
+	src := []byte(Header + "\n\n" +
+		"; this is a comment\n" +
+		"[HKEY_LOCAL_MACHINE\\K]\n" +
+		"\n" +
+		"; another comment\n" +
+		"\"v\"=dword:00000001\n")
+	blocks, err := Parse(src)
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+	if len(blocks) != 1 || len(blocks[0].Values) != 1 {
+		t.Fatalf("comments/blanks not ignored: %#v", blocks)
+	}
+}
+
+func TestParseHexContinuationMultiSz(t *testing.T) {
+	// REG_MULTI_SZ for ["ab","c"], wrapped across two lines with a backslash.
+	src := []byte(Header + "\n" +
+		"[HKEY_LOCAL_MACHINE\\K]\n" +
+		"\"Multi\"=hex(7):61,00,62,00,00,00,\\\n" +
+		"  63,00,00,00,00,00\n")
+	blocks, err := Parse(src)
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+	v := blocks[0].Values[0].Value
+	if v.Type != registry.RegMultiSz {
+		t.Fatalf("type = %d, want REG_MULTI_SZ", v.Type)
+	}
+	if got := v.MultiString(); !reflect.DeepEqual(got, []string{"ab", "c"}) {
+		t.Errorf("MultiString = %v, want [ab c]", got)
+	}
+}
+
+func TestParseDeleteDirectives(t *testing.T) {
+	src := []byte(Header + "\n" +
+		"[-HKEY_LOCAL_MACHINE\\Gone]\n" +
+		"[HKEY_LOCAL_MACHINE\\K]\n" +
+		"\"Dead\"=-\n")
+	blocks, err := Parse(src)
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+	if !blocks[0].Delete || blocks[0].Path != `HKEY_LOCAL_MACHINE\Gone` {
+		t.Errorf("key delete not parsed: %#v", blocks[0])
+	}
+	if vl := blocks[1].Values[0]; !vl.Delete || vl.Name != "Dead" {
+		t.Errorf("value delete not parsed: %#v", vl)
+	}
+}
+
+func TestParseDefaultValueToken(t *testing.T) {
+	blocks, err := Parse([]byte(Header + "\n[HKEY_X\\K]\n@=\"def\"\n"))
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+	if vl := blocks[0].Values[0]; vl.Name != "" || vl.Value.String() != "def" {
+		t.Errorf("default value = %#v, want Name=\"\" Value=def", vl)
+	}
+}
+
+// --- helper unit tests ---
+
+func TestScanQuoted(t *testing.T) {
+	cases := []struct {
+		in    string
+		inner string
+		rest  string
+		ok    bool
+	}{
+		{`"abc"=x`, "abc", "=x", true},
+		{`"a\\b\"c"`, `a\b"c`, "", true},
+		{`"unterminated`, "", `"unterminated`, false},
+		{`noquote`, "", "noquote", false},
+	}
+	for _, c := range cases {
+		inner, rest, ok := scanQuoted(c.in)
+		if inner != c.inner || rest != c.rest || ok != c.ok {
+			t.Errorf("scanQuoted(%q) = (%q, %q, %v), want (%q, %q, %v)", c.in, inner, rest, ok, c.inner, c.rest, c.ok)
+		}
+	}
+}
+
+func TestParseHexBytes(t *testing.T) {
+	got, err := parseHexBytes("de, ad,be,ef,")
+	if err != nil {
+		t.Fatalf("parseHexBytes error: %v", err)
+	}
+	if !reflect.DeepEqual(got, []byte{0xde, 0xad, 0xbe, 0xef}) {
+		t.Errorf("parseHexBytes = % x, want de ad be ef", got)
+	}
+	if got, _ := parseHexBytes("   "); got != nil {
+		t.Errorf("parseHexBytes(empty) = % x, want nil", got)
+	}
+	if _, err := parseHexBytes("zz"); err == nil {
+		t.Error("parseHexBytes(invalid) error = nil, want non-nil")
+	}
+}
+
+func TestParseValueBeforeKeyReportsError(t *testing.T) {
+	blocks, err := Parse([]byte(Header + "\n\"v\"=dword:00000001\n"))
+	if err == nil {
+		t.Error("expected error for value line before any key")
+	}
+	if len(blocks) != 0 {
+		t.Errorf("expected no blocks, got %#v", blocks)
+	}
+}

--- a/windows/registry/regfile/decode_test.go
+++ b/windows/registry/regfile/decode_test.go
@@ -103,6 +103,24 @@ func TestParseDeleteDirectives(t *testing.T) {
 	}
 }
 
+func TestParseCommentWithTrailingBackslashKeepsNextLine(t *testing.T) {
+	// A comment ending in a backslash must not swallow the following key line.
+	src := []byte(Header + "\n" +
+		"; see also C:\\Windows\\\n" +
+		"[HKEY_LOCAL_MACHINE\\K]\n" +
+		"\"v\"=dword:00000001\n")
+	blocks, err := Parse(src)
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+	if len(blocks) != 1 || blocks[0].Path != `HKEY_LOCAL_MACHINE\K` {
+		t.Fatalf("comment continuation swallowed the key line: %#v", blocks)
+	}
+	if n, ok := blocks[0].Values[0].Value.Uint32(); !ok || n != 1 {
+		t.Errorf("value lost: %#v", blocks[0].Values)
+	}
+}
+
 func TestParseDefaultValueToken(t *testing.T) {
 	blocks, err := Parse([]byte(Header + "\n[HKEY_X\\K]\n@=\"def\"\n"))
 	if err != nil {

--- a/windows/registry/regfile/encode.go
+++ b/windows/registry/regfile/encode.go
@@ -97,7 +97,15 @@ func nameToken(name string) string {
 func valueToken(v registry.Value) string {
 	switch v.Type {
 	case registry.RegSz:
-		return `"` + escaper.Replace(v.String()) + `"`
+		s := v.String()
+		// A quoted REG_SZ cannot represent a string with an interior NUL or a
+		// line break, nor data that is not a clean UTF-16LE pair sequence.
+		// regedit falls back to the raw hex(1) form for those, which also
+		// round-trips losslessly.
+		if len(v.Data)%2 != 0 || strings.ContainsAny(s, "\x00\r\n") {
+			return formatHexBytes("hex(1):", v.Data)
+		}
+		return `"` + escaper.Replace(s) + `"`
 	case registry.RegDword:
 		if n, ok := v.Uint32(); ok {
 			return fmt.Sprintf("dword:%08x", n)

--- a/windows/registry/regfile/encode.go
+++ b/windows/registry/regfile/encode.go
@@ -1,0 +1,163 @@
+// Package regfile encodes and decodes the textual ".reg" registry export
+// format produced by regedit and reg.exe (the "Windows Registry Editor Version
+// 5.00" / legacy "REGEDIT4" files).
+//
+// It is pure, network-independent logic built on the registry.Value type: the
+// encoder turns key/value blocks into the textual format, and the (tolerant)
+// decoder parses real-world ".reg" files back into structured blocks. Together
+// they let callers implement reg.exe-style EXPORT/IMPORT on top of any registry
+// backend.
+package regfile
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"strings"
+	"unicode/utf16"
+
+	"github.com/TheManticoreProject/Manticore/windows/registry"
+)
+
+// Header is the first line of a version-5 (".reg" v5.00) file. It is written in
+// UTF-16LE with a byte-order mark by Marshal.
+const Header = "Windows Registry Editor Version 5.00"
+
+// maxHexLineLen is the column past which the encoder wraps a long hex byte list
+// onto a continuation line (ending the prior line with a backslash), matching
+// regedit's ~80-column wrapping. It is cosmetic: the decoder folds continuations
+// regardless of width.
+const maxHexLineLen = 80
+
+// escaper escapes the two characters that are special inside a quoted token
+// (value name or REG_SZ data): backslash and double-quote. Backslash must be
+// replaced first.
+var escaper = strings.NewReplacer(`\`, `\\`, `"`, `\"`)
+
+// FormatKeyHeader returns the bracketed key line for path, e.g.
+// "[HKEY_LOCAL_MACHINE\Software\Foo]". When del is true it emits the delete
+// directive "[-HKEY_LOCAL_MACHINE\Software\Foo]". Backslashes in the path are
+// not escaped (they are literal path separators).
+func FormatKeyHeader(path string, del bool) string {
+	if del {
+		return "[-" + path + "]"
+	}
+	return "[" + path + "]"
+}
+
+// FormatValueLine returns a single ".reg" value line for the named value, e.g.
+// `"Name"="data"` or `@=dword:0000001f` for the default value (name == "").
+// The data token is chosen from v.Type per the ".reg" type encodings.
+func FormatValueLine(name string, v registry.Value) string {
+	return nameToken(name) + "=" + valueToken(v)
+}
+
+// FormatDeleteValueLine returns the directive that deletes the named value:
+// `"Name"=-` (or `@=-` for the default value).
+func FormatDeleteValueLine(name string) string {
+	return nameToken(name) + "=-"
+}
+
+// Marshal renders the blocks as a complete ".reg" file: the version-5 header, a
+// blank line, then each key block (its header followed by one line per value).
+// The result is UTF-16LE with a leading byte-order mark and CRLF line endings,
+// exactly as regedit writes exports.
+func Marshal(blocks []KeyBlock) []byte {
+	var b strings.Builder
+	b.WriteString(Header)
+	b.WriteString("\r\n\r\n")
+	for _, blk := range blocks {
+		b.WriteString(FormatKeyHeader(blk.Path, blk.Delete))
+		b.WriteString("\r\n")
+		if !blk.Delete {
+			for _, vl := range blk.Values {
+				if vl.Delete {
+					b.WriteString(FormatDeleteValueLine(vl.Name))
+				} else {
+					b.WriteString(FormatValueLine(vl.Name, vl.Value))
+				}
+				b.WriteString("\r\n")
+			}
+		}
+		b.WriteString("\r\n")
+	}
+	return encodeUTF16LEWithBOM(b.String())
+}
+
+// nameToken renders the left-hand side of a value line: "@" for the default
+// value, otherwise the escaped, quoted name.
+func nameToken(name string) string {
+	if name == "" {
+		return "@"
+	}
+	return `"` + escaper.Replace(name) + `"`
+}
+
+// valueToken renders the right-hand side of a value line per v.Type.
+func valueToken(v registry.Value) string {
+	switch v.Type {
+	case registry.RegSz:
+		return `"` + escaper.Replace(v.String()) + `"`
+	case registry.RegDword:
+		if n, ok := v.Uint32(); ok {
+			return fmt.Sprintf("dword:%08x", n)
+		}
+		return formatHexBytes("hex(4):", v.Data)
+	case registry.RegBinary:
+		return formatHexBytes("hex:", v.Data)
+	case registry.RegQword:
+		return formatHexBytes("hex(b):", v.Data)
+	case registry.RegExpandSz:
+		return formatHexBytes("hex(2):", v.Data)
+	case registry.RegMultiSz:
+		return formatHexBytes("hex(7):", v.Data)
+	case registry.RegNone:
+		return formatHexBytes("hex(0):", v.Data)
+	default:
+		return formatHexBytes(fmt.Sprintf("hex(%x):", v.Type), v.Data)
+	}
+}
+
+// formatHexBytes renders data as a comma-separated lowercase hex byte list
+// prefixed by prefix (e.g. "hex:" or "hex(7):"), wrapping long lists onto
+// continuation lines. Each wrapped line ends with a backslash and the next line
+// is indented two spaces, matching regedit. An empty data slice yields just the
+// prefix (e.g. "hex(0):").
+func formatHexBytes(prefix string, data []byte) string {
+	if len(data) == 0 {
+		return prefix
+	}
+	var b strings.Builder
+	line := prefix
+	for i, by := range data {
+		tok := fmt.Sprintf("%02x", by)
+		if i < len(data)-1 {
+			tok += ","
+		}
+		// Reserve one column for the trailing continuation backslash.
+		if len(line)+len(tok)+1 > maxHexLineLen {
+			b.WriteString(line)
+			b.WriteString("\\\r\n")
+			line = "  " + tok
+		} else {
+			line += tok
+		}
+	}
+	b.WriteString(line)
+	return b.String()
+}
+
+// encodeUTF16LEWithBOM encodes s as UTF-16LE prefixed by the little-endian BOM
+// (0xFFFE), the on-disk form of a version-5 ".reg" file.
+func encodeUTF16LEWithBOM(s string) []byte {
+	u := utf16.Encode([]rune(s))
+	var buf bytes.Buffer
+	buf.Grow(2 + len(u)*2)
+	buf.Write([]byte{0xFF, 0xFE}) // UTF-16LE BOM
+	tmp := make([]byte, 2)
+	for _, c := range u {
+		binary.LittleEndian.PutUint16(tmp, c)
+		buf.Write(tmp)
+	}
+	return buf.Bytes()
+}

--- a/windows/registry/regfile/encode_test.go
+++ b/windows/registry/regfile/encode_test.go
@@ -85,6 +85,23 @@ func foldOne(s string) string {
 	return strings.Join(folded, "")
 }
 
+func TestRegSzInteriorNulFallsBackToHex1(t *testing.T) {
+	// "A\x00B" as UTF-16LE + trailing NUL: an interior NUL makes the quoted form
+	// impossible, so it must be emitted (and parsed back) as hex(1).
+	v := registry.Value{Type: registry.RegSz, Data: []byte{0x41, 0x00, 0x00, 0x00, 0x42, 0x00, 0x00, 0x00}}
+	line := FormatValueLine("S", v)
+	if !strings.HasPrefix(line, `"S"=hex(1):`) {
+		t.Fatalf("interior-NUL REG_SZ not emitted as hex(1): %q", line)
+	}
+	out, err := Parse(Marshal([]KeyBlock{{Path: `HKEY_X\K`, Values: []ValueLine{{Name: "S", Value: v}}}}))
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+	if got := out[0].Values[0].Value; !reflect.DeepEqual(got, v) {
+		t.Errorf("hex(1) REG_SZ did not round-trip: got %#v, want %#v", got, v)
+	}
+}
+
 // --- round-trip: Parse(Marshal(x)) == x for every value type ---
 
 func TestRoundTrip(t *testing.T) {

--- a/windows/registry/regfile/encode_test.go
+++ b/windows/registry/regfile/encode_test.go
@@ -1,0 +1,118 @@
+package regfile
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/windows/registry"
+)
+
+func TestFormatKeyHeader(t *testing.T) {
+	const path = `HKEY_LOCAL_MACHINE\Software\Foo`
+	if got, want := FormatKeyHeader(path, false), "["+path+"]"; got != want {
+		t.Errorf("FormatKeyHeader = %q, want %q", got, want)
+	}
+	if got, want := FormatKeyHeader(path, true), "[-"+path+"]"; got != want {
+		t.Errorf("FormatKeyHeader(delete) = %q, want %q", got, want)
+	}
+}
+
+func TestFormatValueLine(t *testing.T) {
+	cases := []struct {
+		name  string
+		value registry.Value
+		want  string
+	}{
+		{"", registry.StringValue("default"), `@="default"`},
+		{"Str", registry.StringValue(`C:\dir "q"`), `"Str"="C:\\dir \"q\""`},
+		{"D", registry.DwordValue(0x1f), `"D"=dword:0000001f`},
+		{"Q", registry.QwordValue(0x1f), `"Q"=hex(b):1f,00,00,00,00,00,00,00`},
+		{"B", registry.BinaryValue([]byte{0xde, 0xad}), `"B"=hex:de,ad`},
+		{"N", registry.NoneValue(nil), `"N"=hex(0):`},
+		{"X", registry.Value{Type: 0x100, Data: []byte{0x01}}, `"X"=hex(100):01`},
+	}
+	for _, c := range cases {
+		if got := FormatValueLine(c.name, c.value); got != c.want {
+			t.Errorf("FormatValueLine(%q) = %q, want %q", c.name, got, c.want)
+		}
+	}
+}
+
+func TestFormatDeleteValueLine(t *testing.T) {
+	if got, want := FormatDeleteValueLine("Gone"), `"Gone"=-`; got != want {
+		t.Errorf("FormatDeleteValueLine = %q, want %q", got, want)
+	}
+	if got, want := FormatDeleteValueLine(""), `@=-`; got != want {
+		t.Errorf("FormatDeleteValueLine(default) = %q, want %q", got, want)
+	}
+}
+
+func TestMarshalHeaderAndBOM(t *testing.T) {
+	out := Marshal([]KeyBlock{{Path: `HKEY_CURRENT_USER\X`, Values: []ValueLine{{Name: "v", Value: registry.DwordValue(1)}}}})
+	if len(out) < 2 || out[0] != 0xFF || out[1] != 0xFE {
+		t.Fatalf("Marshal output missing UTF-16LE BOM: % x", out[:min(2, len(out))])
+	}
+	text := decodeToUTF8(out)
+	if !strings.HasPrefix(text, Header+"\r\n\r\n") {
+		t.Errorf("Marshal output does not start with header + blank line; got %q", text[:min(60, len(text))])
+	}
+}
+
+func TestHexLineWrapping(t *testing.T) {
+	data := make([]byte, 64) // long enough to force a continuation
+	for i := range data {
+		data[i] = byte(i)
+	}
+	line := FormatValueLine("Long", registry.Value{Type: registry.RegMultiSz, Data: data})
+	if !strings.Contains(line, "\\\r\n") {
+		t.Errorf("expected backslash continuation in wrapped hex line, got:\n%s", line)
+	}
+	// It must still round-trip through the folding decoder.
+	v, _, err := parseValueData(strings.TrimPrefix(foldOne(line), `"Long"=`))
+	if err != nil {
+		t.Fatalf("parseValueData after fold: %v", err)
+	}
+	if !reflect.DeepEqual(v.Data, data) {
+		t.Errorf("wrapped hex did not round-trip: got % x", v.Data)
+	}
+}
+
+// foldOne runs a single multi-physical-line string through the continuation
+// folder and returns the single logical line.
+func foldOne(s string) string {
+	folded := foldContinuations(splitLines(s))
+	return strings.Join(folded, "")
+}
+
+// --- round-trip: Parse(Marshal(x)) == x for every value type ---
+
+func TestRoundTrip(t *testing.T) {
+	in := []KeyBlock{
+		{
+			Path: `HKEY_LOCAL_MACHINE\SOFTWARE\Manticore\RegFile`,
+			Values: []ValueLine{
+				{Name: "", Value: registry.StringValue("the default value")},
+				{Name: "Str", Value: registry.StringValue(`path C:\windows\system32 and a "quote"`)},
+				{Name: "Empty", Value: registry.StringValue("")},
+				{Name: "Expand", Value: registry.ExpandStringValue("%SystemRoot%\\foo")},
+				{Name: "Dword", Value: registry.DwordValue(0xdeadbeef)},
+				{Name: "Qword", Value: registry.QwordValue(0x1122334455667788)},
+				{Name: "Bin", Value: registry.BinaryValue([]byte{0x00, 0x01, 0x7f, 0x80, 0xff})},
+				{Name: "Multi", Value: registry.MultiStringValue([]string{"alpha", "beta", "gamma gamma gamma"})},
+				{Name: "None", Value: registry.NoneValue([]byte{0x01, 0x02})},
+				{Name: "Custom", Value: registry.Value{Type: 0x77, Data: []byte{0xaa, 0xbb}}},
+				{Name: "Doomed", Delete: true},
+			},
+		},
+		{Path: `HKEY_CURRENT_USER\Software\Obsolete`, Delete: true},
+	}
+
+	out, err := Parse(Marshal(in))
+	if err != nil {
+		t.Fatalf("Parse(Marshal(in)) error: %v", err)
+	}
+	if !reflect.DeepEqual(out, in) {
+		t.Errorf("round-trip mismatch:\n got = %#v\nwant = %#v", out, in)
+	}
+}

--- a/windows/registry/registry.go
+++ b/windows/registry/registry.go
@@ -1,0 +1,171 @@
+// Package registry holds network-independent helpers for working with the
+// Windows registry as data: the REG_* value types, a typed Value carrying a
+// REG_* type and its raw little-endian bytes, and (in the regfile sub-package)
+// an encoder/decoder for the textual ".reg" export format produced by regedit
+// and reg.exe.
+//
+// Value mirrors the wire representation used by the remote registry protocol
+// (MS-RRP): a type tag plus the data bytes exactly as stored. The decode
+// helpers (String, Uint32, ...) project the bytes per Type; the constructor
+// helpers (StringValue, DwordValue, ...) build the bytes. It is intentionally
+// field-compatible with the ms_rrp RegistryValue type so callers can convert
+// between the two with a one-line struct literal.
+package registry
+
+import (
+	"encoding/binary"
+	"strings"
+	"unicode/utf16"
+)
+
+// REG_* registry value types.
+//
+// [MS-RRP] 2.2.9 / winreg REG_* constants. Values match the numeric type tags
+// carried on the wire and written in ".reg" files (e.g. hex(b) is REG_QWORD = 11).
+const (
+	RegNone                     uint32 = 0  // REG_NONE
+	RegSz                       uint32 = 1  // REG_SZ (UTF-16LE, NUL-terminated)
+	RegExpandSz                 uint32 = 2  // REG_EXPAND_SZ
+	RegBinary                   uint32 = 3  // REG_BINARY
+	RegDword                    uint32 = 4  // REG_DWORD (little-endian)
+	RegDwordBigEndian           uint32 = 5  // REG_DWORD_BIG_ENDIAN
+	RegLink                     uint32 = 6  // REG_LINK
+	RegMultiSz                  uint32 = 7  // REG_MULTI_SZ
+	RegResourceList             uint32 = 8  // REG_RESOURCE_LIST
+	RegFullResourceDescriptor   uint32 = 9  // REG_FULL_RESOURCE_DESCRIPTOR
+	RegResourceRequirementsList uint32 = 10 // REG_RESOURCE_REQUIREMENTS_LIST
+	RegQword                    uint32 = 11 // REG_QWORD (little-endian)
+)
+
+// Value is a typed registry value: its REG_* type and its raw little-endian
+// data bytes, exactly as carried on the wire and stored in the registry.
+type Value struct {
+	Type uint32
+	Data []byte
+}
+
+// String decodes REG_SZ / REG_EXPAND_SZ / REG_LINK as a UTF-16LE string
+// (trailing NULs stripped). For other types it returns the empty string; use
+// the type-specific helpers.
+func (v Value) String() string {
+	switch v.Type {
+	case RegSz, RegExpandSz, RegLink:
+		return decodeUTF16(v.Data)
+	default:
+		return ""
+	}
+}
+
+// Uint32 decodes a REG_DWORD (little-endian). ok is false if the data is too short.
+func (v Value) Uint32() (uint32, bool) {
+	if len(v.Data) < 4 {
+		return 0, false
+	}
+	return binary.LittleEndian.Uint32(v.Data), true
+}
+
+// Uint64 decodes a REG_QWORD (little-endian). ok is false if the data is too short.
+func (v Value) Uint64() (uint64, bool) {
+	if len(v.Data) < 8 {
+		return 0, false
+	}
+	return binary.LittleEndian.Uint64(v.Data), true
+}
+
+// MultiString decodes a REG_MULTI_SZ: a sequence of UTF-16LE strings, each
+// NUL-terminated, the whole terminated by an empty string. Empty trailing
+// entries are dropped.
+func (v Value) MultiString() []string {
+	if v.Type != RegMultiSz {
+		return nil
+	}
+	whole := decodeUTF16Raw(v.Data)
+	parts := strings.Split(whole, "\x00")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p == "" {
+			continue
+		}
+		out = append(out, p)
+	}
+	return out
+}
+
+// StringValue builds a REG_SZ value from a Go string.
+func StringValue(s string) Value {
+	return Value{Type: RegSz, Data: encodeUTF16(s)}
+}
+
+// ExpandStringValue builds a REG_EXPAND_SZ value from a Go string.
+func ExpandStringValue(s string) Value {
+	return Value{Type: RegExpandSz, Data: encodeUTF16(s)}
+}
+
+// DwordValue builds a REG_DWORD value (little-endian).
+func DwordValue(v uint32) Value {
+	b := make([]byte, 4)
+	binary.LittleEndian.PutUint32(b, v)
+	return Value{Type: RegDword, Data: b}
+}
+
+// QwordValue builds a REG_QWORD value (little-endian).
+func QwordValue(v uint64) Value {
+	b := make([]byte, 8)
+	binary.LittleEndian.PutUint64(b, v)
+	return Value{Type: RegQword, Data: b}
+}
+
+// BinaryValue builds a REG_BINARY value from raw bytes.
+func BinaryValue(b []byte) Value {
+	return Value{Type: RegBinary, Data: append([]byte(nil), b...)}
+}
+
+// NoneValue builds a REG_NONE value from raw bytes.
+func NoneValue(b []byte) Value {
+	return Value{Type: RegNone, Data: append([]byte(nil), b...)}
+}
+
+// MultiStringValue builds a REG_MULTI_SZ value: each string NUL-terminated, the
+// block terminated by a final empty string.
+func MultiStringValue(items []string) Value {
+	return Value{Type: RegMultiSz, Data: encodeUTF16Multi(items)}
+}
+
+// --- UTF-16LE helpers ---
+
+// encodeUTF16 encodes s as UTF-16LE with a terminating NUL (the form REG_SZ uses).
+func encodeUTF16(s string) []byte {
+	u := utf16.Encode([]rune(s))
+	b := make([]byte, len(u)*2+2)
+	for i, c := range u {
+		binary.LittleEndian.PutUint16(b[i*2:], c)
+	}
+	return b
+}
+
+// encodeUTF16Multi encodes a REG_MULTI_SZ block: each item NUL-terminated, a
+// final empty string closing the block.
+func encodeUTF16Multi(items []string) []byte {
+	var b []byte
+	for _, s := range items {
+		b = append(b, encodeUTF16(s)...)
+	}
+	b = append(b, 0x00, 0x00) // final empty string terminator
+	return b
+}
+
+// decodeUTF16 decodes UTF-16LE bytes and strips a single trailing NUL terminator.
+func decodeUTF16(b []byte) string {
+	return strings.TrimRight(decodeUTF16Raw(b), "\x00")
+}
+
+// decodeUTF16Raw decodes UTF-16LE bytes without stripping NULs (an odd trailing
+// byte is ignored).
+func decodeUTF16Raw(b []byte) string {
+	n := len(b) / 2
+	u := make([]uint16, n)
+	for i := 0; i < n; i++ {
+		u[i] = binary.LittleEndian.Uint16(b[i*2:])
+	}
+	return string(utf16.Decode(u))
+}

--- a/windows/registry/registry_test.go
+++ b/windows/registry/registry_test.go
@@ -1,0 +1,39 @@
+package registry
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestValueAccessors(t *testing.T) {
+	if got := StringValue("hello").String(); got != "hello" {
+		t.Errorf("StringValue/String round-trip = %q, want %q", got, "hello")
+	}
+	if got := ExpandStringValue("%PATH%").String(); got != "%PATH%" {
+		t.Errorf("ExpandStringValue/String round-trip = %q, want %q", got, "%PATH%")
+	}
+
+	if n, ok := DwordValue(0x1f).Uint32(); !ok || n != 0x1f {
+		t.Errorf("DwordValue/Uint32 = (%d, %v), want (31, true)", n, ok)
+	}
+	if n, ok := QwordValue(0x1122334455667788).Uint64(); !ok || n != 0x1122334455667788 {
+		t.Errorf("QwordValue/Uint64 = (%#x, %v), want (0x1122334455667788, true)", n, ok)
+	}
+
+	items := []string{"a", "bb", "ccc"}
+	if got := MultiStringValue(items).MultiString(); !reflect.DeepEqual(got, items) {
+		t.Errorf("MultiStringValue/MultiString round-trip = %v, want %v", got, items)
+	}
+}
+
+func TestUint32Short(t *testing.T) {
+	if _, ok := (Value{Type: RegDword, Data: []byte{0x01, 0x02}}).Uint32(); ok {
+		t.Error("Uint32 on short data: ok = true, want false")
+	}
+}
+
+func TestDwordEncodingLittleEndian(t *testing.T) {
+	if got := DwordValue(0x01020304).Data; !reflect.DeepEqual(got, []byte{0x04, 0x03, 0x02, 0x01}) {
+		t.Errorf("DwordValue data = % x, want 04 03 02 01", got)
+	}
+}


### PR DESCRIPTION
### Linked Issue
Closes #616

### Root Cause
This is an enhancement rather than a defect. `ms_rrp` already exposes ergonomic
registry helpers (`QueryValueByPath`, `EnumValuesByPath`, `SetValueByPath`,
`CreateKeyByPath`, …) and the `RegistryValue` type, but the textual `.reg`
export/import format (reg.exe `EXPORT` / `IMPORT`) had no implementation in the
library. Without it, every downstream tool would have to re-implement the
serialization of the Windows Registry Editor format, which is pure,
network-independent, and easy to get subtly wrong (encodings, escaping, hex
line-continuation, type tags).

### Fix Description
Add the `.reg` codec as a self-contained, network-independent package so it can
be reused without dragging in the DCE/RPC stack.

- `windows/registry/registry.go` — a leaf package defining the `REG_*` type
  constants and a `Value{Type uint32; Data []byte}` type with typed accessors
  (`String`, `Uint32`, `Uint64`, `MultiString`) and constructors (`StringValue`,
  `DwordValue`, `QwordValue`, `BinaryValue`, `NoneValue`, `MultiStringValue`).
  `Value` is intentionally field-compatible with `ms_rrp.RegistryValue`, so a
  caller converts between the two with a one-line struct literal.
- `windows/registry/regfile/encode.go` — `Header`, `FormatKeyHeader`,
  `FormatValueLine`, `FormatDeleteValueLine`, and `Marshal`, which writes a
  complete `.reg` file as UTF-16LE + BOM with CRLF line endings and regedit-style
  backslash wrapping of long hex values.
- `windows/registry/regfile/decode.go` — a tolerant `Parse` that auto-detects
  UTF-16LE/UTF-16BE and UTF-8 (with or without BOM), accepts the `Version 5.00`
  and legacy `REGEDIT4` headers, ignores comment/blank lines, folds backslash
  line-continuations, and understands the `[-key]` and `"name"=-` delete
  directives. Parsing is best-effort: per-line problems are joined into the
  returned error while still returning the blocks parsed so far.

The codec was placed under `windows/registry/` (rather than inside `ms_rrp`) to
keep it a clean leaf utility with no `network/dcerpc` dependency; the alternative
of importing `ms_rrp.RegistryValue` directly was rejected because it would invert
the layering and pull DCE/RPC dependencies into a pure-text helper.

### How Verified
- Tests: `go test ./windows/registry/...` — 21 tests pass.
- Build/vet: `go build ./...` and `go vet ./windows/registry/...` are clean.
- Round-trip: `TestRoundTrip` asserts `Parse(Marshal(x)) == x` for every value
  type (default `@`, `REG_SZ` with embedded `\`/`"`, empty string, `REG_EXPAND_SZ`,
  `REG_DWORD`, `REG_QWORD`, `REG_BINARY`, `REG_MULTI_SZ`, `REG_NONE`, generic
  `hex(<type>)`, value delete, and key delete).
- Tolerant decode: dedicated tests cover UTF-16LE+BOM, UTF-8±BOM, `REGEDIT4`,
  comments/blanks, multi-line `hex(7)` continuation, and both delete directives.

### Test Coverage
- **Added:**
  - `windows/registry/registry_test.go`: `TestValueAccessors`, `TestUint32Short`,
    `TestDwordEncodingLittleEndian`.
  - `windows/registry/regfile/encode_test.go`: `TestFormatKeyHeader`,
    `TestFormatValueLine`, `TestFormatDeleteValueLine`, `TestMarshalHeaderAndBOM`,
    `TestHexLineWrapping`, `TestRoundTrip`.
  - `windows/registry/regfile/decode_test.go`: `TestParseUTF16LEWithBOM`,
    `TestParseREGEDIT4UTF8`, `TestParseUTF8BOM`, `TestParseIgnoresCommentsAndBlanks`,
    `TestParseHexContinuationMultiSz`, `TestParseDeleteDirectives`,
    `TestParseDefaultValueToken`, `TestScanQuoted`, `TestParseHexBytes`,
    `TestParseValueBeforeKeyReportsError`.

### Scope of Change
- **Files changed:** `windows/registry/registry.go`,
  `windows/registry/registry_test.go`, `windows/registry/regfile/encode.go`,
  `windows/registry/regfile/encode_test.go`, `windows/registry/regfile/decode.go`,
  `windows/registry/regfile/decode_test.go` (all new).
- **Submodule pointer updated:** no.
- **Behavioral changes outside the bug fix:** none — all files are new; no existing
  code is modified.

### Risk and Rollout
Low blast radius: the change is purely additive (new leaf package with no
dependents yet) and has no effect on existing code paths. Safe to merge without
staged rollout.

### Notes
Library-only by design. The reg.exe `export`/`import` subcommands on top of
`ms_rrp` (walk a subtree with `EnumValuesByPath`/`EnumKeysByPath` → `Marshal`;
`Parse` → replay via `CreateKeyByPath`/`SetValueByPath`/delete helpers) are a
deliberate follow-up; the trivial `ms_rrp.RegistryValue` ⇄ `registry.Value`
conversion will live in that client.
