### PR TITLE
Restore ms_rrp enumeration fixes lost from main (#612, #614)

### DIFF
--- a/network/dcerpc/ms-protocols/ms-rrp/paths.go
+++ b/network/dcerpc/ms-protocols/ms-rrp/paths.go
@@ -150,20 +150,34 @@ func (r *RemoteRegistry) DeleteValueByPath(keyPath, valueName string) error {
 }
 
 // EnumKeys returns the names of all immediate subkeys of an open key, looping
-// BaseRegEnumKey until ERROR_NO_MORE_ITEMS.
+// BaseRegEnumKey until ERROR_NO_MORE_ITEMS. Subkey names are capped at 255 UTF-16 code
+// units by the registry, but the name/class buffers grow and retry the same index on
+// ERROR_MORE_DATA to stay robust if a server reports a longer name. The server counts the
+// terminating NUL in the returned name's length, so it is stripped to yield a clean Go
+// string usable as a path component.
 func (r *RemoteRegistry) EnumKeys(h Handle) ([]string, error) {
 	var names []string
-	for i := uint32(0); ; i++ {
-		nameIn := structures.RRP_UNICODE_STRING{MaximumLength: 512, Buffer: make([]uint16, 256)}
-		classIn := structures.RRP_UNICODE_STRING{MaximumLength: 512, Buffer: make([]uint16, 256)}
+	// bufLen counts UTF-16 code units; MaximumLength is that count in bytes (×2). The cap
+	// keeps MaximumLength within its uint16 field while far exceeding the 255-char limit.
+	bufLen := uint32(256)
+	const maxBufLen = uint32(16 * 1024)
+	for i := uint32(0); ; {
+		nameIn := structures.RRP_UNICODE_STRING{MaximumLength: uint16(bufLen * 2), Buffer: make([]uint16, bufLen)}
+		classIn := structures.RRP_UNICODE_STRING{MaximumLength: uint16(bufLen * 2), Buffer: make([]uint16, bufLen)}
 		nameOut, _, _, err := r.BaseRegEnumKey(h, ndr.DWORD(i), nameIn, &classIn, nil)
 		if err != nil {
 			if isStatus(err, winreg.ErrorNoMoreItems) {
 				break
 			}
+			if isStatus(err, winreg.ErrorMoreData) && bufLen < maxBufLen {
+				// The name (or class) did not fit: grow the buffers and retry the same index.
+				bufLen *= 2
+				continue
+			}
 			return names, err
 		}
-		names = append(names, nameOut.String())
+		names = append(names, strings.TrimRight(nameOut.String(), "\x00"))
+		i++
 	}
 	return names, nil
 }
@@ -179,19 +193,30 @@ func (r *RemoteRegistry) EnumKeysByPath(keyPath string) ([]string, error) {
 }
 
 // EnumValues returns all values of an open key, looping BaseRegEnumValue until
-// ERROR_NO_MORE_ITEMS.
+// ERROR_NO_MORE_ITEMS. The data buffer is negotiated per value: it grows and retries the
+// same index on ERROR_MORE_DATA (e.g. values whose data exceeds the initial buffer). The
+// server counts the terminating NUL in the returned value name's length, so it is stripped.
 func (r *RemoteRegistry) EnumValues(h Handle) ([]ValueEntry, error) {
 	var entries []ValueEntry
-	for i := uint32(0); ; i++ {
-		nameIn := structures.RRP_UNICODE_STRING{MaximumLength: 1024, Buffer: make([]uint16, 512)}
+	dataLen := uint32(1024)
+	for i := uint32(0); ; {
+		// A registry value name fits in 1023 UTF-16 code units here; only the data buffer
+		// needs to grow, so the name buffer is fixed and the data buffer is negotiated.
+		nameIn := structures.RRP_UNICODE_STRING{MaximumLength: 2048, Buffer: make([]uint16, 1024)}
 		typ := ndr.DWORD(0)
-		buf := make([]byte, 1024)
-		cb := ndr.DWORD(len(buf))
-		ln := ndr.DWORD(len(buf))
+		buf := make([]byte, dataLen)
+		cb := ndr.DWORD(dataLen)
+		ln := ndr.DWORD(dataLen)
 		nameOut, rTyp, rData, rcb, _, err := r.BaseRegEnumValue(h, ndr.DWORD(i), nameIn, &typ, buf, &cb, &ln)
 		if err != nil {
 			if isStatus(err, winreg.ErrorNoMoreItems) {
 				break
+			}
+			if isStatus(err, winreg.ErrorMoreData) && rcb != nil && uint32(*rcb) > dataLen {
+				// The value's data is larger than the current buffer: grow it and retry the
+				// same index without advancing.
+				dataLen = uint32(*rcb)
+				continue
 			}
 			return entries, err
 		}
@@ -203,7 +228,8 @@ func (r *RemoteRegistry) EnumValues(h Handle) ([]ValueEntry, error) {
 		if rTyp != nil {
 			val.Type = uint32(*rTyp)
 		}
-		entries = append(entries, ValueEntry{Name: nameOut.String(), Value: val})
+		entries = append(entries, ValueEntry{Name: strings.TrimRight(nameOut.String(), "\x00"), Value: val})
+		i++
 	}
 	return entries, nil
 }


### PR DESCRIPTION
### Linked Issues
`Closes #612`
`Closes #614`

### Root Cause
The fixes for #612 (ERROR_MORE_DATA grow-and-retry) and #614 (trailing NUL in enumerated
names) were merged onto the `feature-ms-rrp-protocol-package` branch, but `main` received
`ms_rrp` from an earlier snapshot of that branch, so neither fix is present on `main` (or in
the v1.1.2 release). `EnumKeys`/`EnumValues` on `main` still use a fixed buffer with no
`ERROR_MORE_DATA` handling and return `nameOut.String()` with the server's terminating NUL
included.

### Fix Description
Re-apply both fixes in the two convenience helpers (`network/dcerpc/ms-protocols/ms-rrp/paths.go`):

- **Buffer negotiation.** On `ERROR_MORE_DATA`, retry the same index with a larger buffer
  instead of aborting. `EnumValues` grows the data buffer to the size the server reports in
  `lpcbData`; `EnumKeys` doubles the name/class buffers, capped at 16384 code units so the
  `uint16` `MaximumLength` field cannot overflow (far beyond the 255-char subkey-name limit).
- **Trailing NUL.** Strip a trailing `\x00` from the decoded name (`strings.TrimRight`) so
  enumerated names are clean Go strings usable as path components. The faithful interface
  methods `BaseRegEnumKey`/`BaseRegEnumValue` are unchanged (they keep returning the raw
  wire value); only the ergonomic layer is cleaned.

This matches the previously-reviewed fixes; it is applied directly to `main` because the
original PRs targeted a branch that did not propagate to `main`.

### How Verified
- **Runtime (before):** enumerating `HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion`
  values against a live Windows Server 2016 host fails with
  `BaseRegEnumValue failed: ERROR_MORE_DATA` (its `DigitalProductId4` value exceeds 1 KB).
- **Runtime (after):** the same enumeration returns all 87 subkeys and 27 values with no
  error; subkey/value names are clean (no trailing NUL), so recursive enumeration that
  reuses names as path components works.
- **Tests:** `go test ./network/dcerpc/ms-protocols/ms-rrp/` passes; the live integration
  test `TestIntegration_RemoteRegistry` (`-tags integration`) passes.

### Test Coverage
**None added:** both behaviors are driven by the live server's responses (an over-sized
value for the grow path; a server-counted NUL for the name path) and there is no offline
fixture in the package that exercises `BaseRegEnumKey`/`BaseRegEnumValue` end to end. The
changes are confined to the two helpers and were verified against a live host.

### Scope of Change
- **Files changed:** `network/dcerpc/ms-protocols/ms-rrp/paths.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Low: the change only adds grow-and-retry on `ERROR_MORE_DATA` (previously a hard failure)
and strips a trailing NUL from returned names. Successful and end-of-enumeration paths are
unchanged. Safe to merge without staged rollout.
