### PR TITLE
Decode protocol towers for all common bindings (ncacn_np, ncacn_http, ncadg_ip_udp) (#623)

### DIFF
--- a/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/structures/structures_test.go
+++ b/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/structures/structures_test.go
@@ -64,6 +64,77 @@ func TestTower_EndpointNoTCPFloor(t *testing.T) {
 	}
 }
 
+func TestTower_Binding(t *testing.T) {
+	base := []Floor{
+		InterfaceFloor(sampleIface(), 1, 0),
+		TransferSyntaxFloor(),
+		{LHS: []byte{FloorProtoNCACN}, RHS: []byte{0, 0}},
+	}
+	withTransport := func(transport ...Floor) Tower {
+		return Tower{Floors: append(append([]Floor{}, base...), transport...)}
+	}
+
+	cases := []struct {
+		name    string
+		tower   Tower
+		kind    BindingKind
+		binding string
+	}{
+		{
+			name:    "ncacn_ip_tcp",
+			tower:   withTransport(TCPFloor(49664), IPFloor(net.IPv4(10, 0, 0, 30))),
+			kind:    BindingTCP,
+			binding: "ncacn_ip_tcp:10.0.0.30[49664]",
+		},
+		{
+			name:    "ncadg_ip_udp",
+			tower:   withTransport(Floor{LHS: []byte{FloorProtoUDP}, RHS: []byte{0x00, 0x87}}, IPFloor(net.IPv4(192, 0, 2, 5))),
+			kind:    BindingUDP,
+			binding: "ncadg_ip_udp:192.0.2.5[135]",
+		},
+		{
+			name:    "ncacn_np",
+			tower:   withTransport(NamedPipeFloor(`\PIPE\srvsvc`), NetBIOSFloor(`\\FILESERVER`)),
+			kind:    BindingNamedPipe,
+			binding: `ncacn_np:\\FILESERVER[\PIPE\srvsvc]`,
+		},
+		{
+			name:    "ncacn_http",
+			tower:   withTransport(HTTPFloor(593), IPFloor(net.IPv4(203, 0, 113, 9))),
+			kind:    BindingHTTP,
+			binding: "ncacn_http:203.0.113.9[593]",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			// Exercise the builders through a full Marshal/UnmarshalTower round trip so the
+			// decode path sees real wire bytes.
+			tw, err := UnmarshalTower(c.tower.Marshal())
+			if err != nil {
+				t.Fatalf("UnmarshalTower: %v", err)
+			}
+			b, err := tw.Binding()
+			if err != nil {
+				t.Fatalf("Binding() error = %v", err)
+			}
+			if b.Kind != c.kind {
+				t.Errorf("Kind = %d, want %d", b.Kind, c.kind)
+			}
+			if got := b.String(); got != c.binding {
+				t.Errorf("binding = %q, want %q", got, c.binding)
+			}
+		})
+	}
+}
+
+func TestTower_BindingNoTransportFloor(t *testing.T) {
+	tower := Tower{Floors: []Floor{InterfaceFloor(sampleIface(), 1, 0), TransferSyntaxFloor()}}
+	if _, err := tower.Binding(); err == nil {
+		t.Error("Binding() error = nil for a tower with no transport floor, want non-nil")
+	}
+}
+
 func TestUnmarshalTower_Truncated(t *testing.T) {
 	if _, err := UnmarshalTower([]byte{0x05}); err == nil {
 		t.Error("UnmarshalTower(truncated) error = nil, want non-nil")

--- a/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/structures/tower.go
+++ b/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/structures/tower.go
@@ -4,6 +4,8 @@ import (
 	"encoding/binary"
 	"fmt"
 	"net"
+	"strconv"
+	"strings"
 
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
 	"github.com/TheManticoreProject/Manticore/windows/guid"
@@ -39,6 +41,15 @@ const (
 	// FloorProtoIP identifies the DOD IP floor; its RHS is a 4-octet IPv4 address in
 	// big-endian order.
 	FloorProtoIP = 0x09
+	// FloorProtoNamedPipe identifies the named-pipe floor of an ncacn_np tower; its RHS
+	// is the NUL-terminated pipe name (e.g. "\PIPE\srvsvc").
+	FloorProtoNamedPipe = 0x0F
+	// FloorProtoNetBIOS identifies the NetBIOS host-name floor (the address floor of an
+	// ncacn_np tower); its RHS is the NUL-terminated host name.
+	FloorProtoNetBIOS = 0x11
+	// FloorProtoHTTP identifies the RPC-over-HTTP floor of an ncacn_http tower; its RHS is
+	// a 16-bit port in big-endian order.
+	FloorProtoHTTP = 0x1F
 )
 
 // Floor is one floor of a protocol tower: a length-prefixed left-hand side (protocol
@@ -181,6 +192,31 @@ func IPFloor(ip net.IP) Floor {
 	return Floor{LHS: []byte{FloorProtoIP}, RHS: rhs}
 }
 
+// nameFloor builds a single-identifier floor whose RHS is a NUL-terminated name (the
+// shared shape of the named-pipe and NetBIOS floors).
+func nameFloor(proto byte, name string) Floor {
+	rhs := make([]byte, 0, len(name)+1)
+	rhs = append(rhs, name...)
+	rhs = append(rhs, 0) // NUL terminator
+	return Floor{LHS: []byte{proto}, RHS: rhs}
+}
+
+// NamedPipeFloor builds the named-pipe floor of an ncacn_np tower; the RHS is the
+// NUL-terminated pipe name (e.g. "\PIPE\srvsvc").
+func NamedPipeFloor(name string) Floor { return nameFloor(FloorProtoNamedPipe, name) }
+
+// NetBIOSFloor builds the NetBIOS host-name floor; the RHS is the NUL-terminated host
+// name.
+func NetBIOSFloor(host string) Floor { return nameFloor(FloorProtoNetBIOS, host) }
+
+// HTTPFloor builds the RPC-over-HTTP floor; the RHS is the 16-bit port in big-endian
+// order.
+func HTTPFloor(port uint16) Floor {
+	rhs := make([]byte, 2)
+	binary.BigEndian.PutUint16(rhs, port)
+	return Floor{LHS: []byte{FloorProtoHTTP}, RHS: rhs}
+}
+
 // BuildMapTowerTCP builds the 5-floor ncacn_ip_tcp tower used as the ept_map input: the
 // interface and NDR transfer-syntax floors describe what is wanted, and the
 // connection-oriented/TCP/IP floors with a zero port and address request that the
@@ -206,7 +242,8 @@ func (e Endpoint) String() string { return fmt.Sprintf("%s:%d", e.IP, e.Port) }
 
 // Endpoint extracts the TCP port and IPv4 address from the tower's transport floors. ok
 // is false unless a TCP floor is present; the IP is left zero if the tower carries no IP
-// floor.
+// floor. It is the ncacn_ip_tcp fast path used by ept_map's Map; for any other transport
+// use Binding.
 func (t Tower) Endpoint() (ep Endpoint, ok bool) {
 	var gotPort bool
 	for _, f := range t.Floors {
@@ -223,4 +260,83 @@ func (t Tower) Endpoint() (ep Endpoint, ok bool) {
 		}
 	}
 	return ep, gotPort
+}
+
+// BindingKind identifies the transport (protocol sequence) a tower describes.
+type BindingKind uint8
+
+const (
+	// BindingUnknown marks a tower with no recognized transport/endpoint floor.
+	BindingUnknown BindingKind = iota
+	// BindingTCP is ncacn_ip_tcp (RPC over TCP).
+	BindingTCP
+	// BindingUDP is ncadg_ip_udp (connectionless RPC over UDP).
+	BindingUDP
+	// BindingNamedPipe is ncacn_np (RPC over an SMB named pipe).
+	BindingNamedPipe
+	// BindingHTTP is ncacn_http (RPC over HTTP / RPC proxy).
+	BindingHTTP
+)
+
+// Binding is a tower decoded into the components of a DCE string binding
+// (protseq:network_address[endpoint]).
+type Binding struct {
+	Kind BindingKind
+	// ProtSeq is the protocol sequence, e.g. "ncacn_ip_tcp" or "ncacn_np".
+	ProtSeq string
+	// NetworkAddress is the host: an IPv4 address (ncacn_ip_tcp/http, ncadg_ip_udp) or a
+	// NetBIOS host name (ncacn_np). It may be empty if the tower carries no address floor.
+	NetworkAddress string
+	// Endpoint is the per-transport endpoint: a decimal port (TCP/UDP/HTTP) or a pipe name
+	// (named pipe).
+	Endpoint string
+}
+
+// String renders the canonical DCE string binding, protseq:network_address[endpoint]
+// (e.g. "ncacn_ip_tcp:10.0.0.1[49664]", "ncacn_np:HOST[\\PIPE\\srvsvc]").
+func (b Binding) String() string {
+	return fmt.Sprintf("%s:%s[%s]", b.ProtSeq, b.NetworkAddress, b.Endpoint)
+}
+
+// Binding decodes the tower's transport and address floors into a Binding. It supports
+// ncacn_ip_tcp, ncadg_ip_udp, ncacn_np, and ncacn_http. ok-style failure is reported as an
+// error when no recognized transport (endpoint) floor is present.
+func (t Tower) Binding() (Binding, error) {
+	var b Binding
+	for _, f := range t.Floors {
+		switch f.Protocol() {
+		case FloorProtoTCP:
+			b.Kind, b.ProtSeq, b.Endpoint = BindingTCP, "ncacn_ip_tcp", portString(f.RHS)
+		case FloorProtoUDP:
+			b.Kind, b.ProtSeq, b.Endpoint = BindingUDP, "ncadg_ip_udp", portString(f.RHS)
+		case FloorProtoHTTP:
+			b.Kind, b.ProtSeq, b.Endpoint = BindingHTTP, "ncacn_http", portString(f.RHS)
+		case FloorProtoNamedPipe:
+			b.Kind, b.ProtSeq, b.Endpoint = BindingNamedPipe, "ncacn_np", trimName(f.RHS)
+		case FloorProtoIP:
+			if len(f.RHS) >= 4 {
+				b.NetworkAddress = net.IPv4(f.RHS[0], f.RHS[1], f.RHS[2], f.RHS[3]).String()
+			}
+		case FloorProtoNetBIOS:
+			b.NetworkAddress = trimName(f.RHS)
+		}
+	}
+	if b.Kind == BindingUnknown {
+		return b, fmt.Errorf("epm: tower has no recognized transport floor")
+	}
+	return b, nil
+}
+
+// portString decodes a big-endian 16-bit port RHS to its decimal string, or "" if the RHS
+// is too short.
+func portString(rhs []byte) string {
+	if len(rhs) < 2 {
+		return ""
+	}
+	return strconv.Itoa(int(binary.BigEndian.Uint16(rhs)))
+}
+
+// trimName decodes a NUL-terminated name RHS (pipe or host) to a Go string.
+func trimName(rhs []byte) string {
+	return strings.TrimRight(string(rhs), "\x00")
 }


### PR DESCRIPTION
### Linked Issue
Closes #623

### Summary
`Tower.Endpoint()` only decoded `ncacn_ip_tcp` (the TCP port floor + IPv4 floor), returning a `host:port` `Endpoint`. The endpoint mapper routinely returns bindings over other transports — most importantly `ncacn_np` (SMB named pipes), plus `ncacn_http` and `ncadg_ip_udp` — which `Endpoint()` silently ignored, so those endpoints rendered as an empty/zero binding and lost information. This is a prerequisite for rendering the output of `ept_lookup` (#622) for the `msrpc dump`/`monitor` tooling.

### What this adds
- **Floor protocol identifiers:** `FloorProtoNamedPipe` (0x0F), `FloorProtoNetBIOS` (0x11), `FloorProtoHTTP` (0x1F), alongside the existing TCP/UDP/IP floors.
- **Floor builders** (following the existing `<Proto>Floor` convention): `NamedPipeFloor(name)`, `NetBIOSFloor(host)`, `HTTPFloor(port)`.
- **General decoder:** `Tower.Binding() (Binding, error)` decodes a tower into the components of a DCE string binding. `Binding{ Kind BindingKind; ProtSeq, NetworkAddress, Endpoint string }` and `Binding.String()` render the canonical `protseq:network_address[endpoint]` form:
  - `ncacn_ip_tcp:<ip>[<port>]`
  - `ncadg_ip_udp:<ip>[<port>]`
  - `ncacn_np:<host>[\PIPE\<name>]`
  - `ncacn_http:<ip>[<port>]`
  `BindingKind` (`BindingTCP/UDP/NamedPipe/HTTP/Unknown`) lets callers switch on the transport without string comparisons.

RHS decoding: big-endian `uint16` for TCP/UDP/HTTP ports, `net.IPv4` for the 4-octet IP floor, NUL-terminated strings for the pipe name and NetBIOS host.

### Compatibility
`Endpoint() (Endpoint, bool)` is **kept unchanged** as the `ncacn_ip_tcp` fast path used by `ept_map`'s `Map`, so existing callers are unaffected; `Binding()` is the new general accessor.

### Out of scope
IPv6 is mentioned in the issue but has **no standard C706 / MS-RPCE protocol-tower floor** — Windows EPM towers carry only the 4-octet IPv4 floor (`0x09`) — so no IPv6 floor identifier/builder is invented here. Noted in the code rather than represented.

### How Verified
- `go test ./network/dcerpc/interfaces/e1af8308-.../3.0/...` — all pass (`ept_map` and the existing tower/`Endpoint` tests included; no regression).
- `go build` / `go vet` clean for the interface tree.

### Test Coverage
- **Added:** `TestTower_Binding` (subtests for `ncacn_ip_tcp`, `ncadg_ip_udp`, `ncacn_np`, `ncacn_http`, each driven through a full `Marshal` → `UnmarshalTower` → `Binding().String()` round trip) and `TestTower_BindingNoTransportFloor` (error when no transport floor is present).

### Scope of Change
- **Files changed:** `network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/structures/tower.go`, `.../structures/structures_test.go`.
- **Submodule pointer updated:** no.
- **Behavioral changes outside the feature:** none — `Endpoint()` is unchanged; all additions are new symbols.

### Notes
Naming follows the package's existing conventions (`FloorProto<Name>`, `<Proto>Floor`), agreed as part of an EPM API naming review. Companion to `ept_lookup` (#622), which consumes `Binding()` to render enumerated endpoints.
