### PR TITLE
Implement ept_lookup (opnum 2) to enumerate all registered endpoints (#622)

### DIFF
--- a/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/functions/02_EptLookup.go
+++ b/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/functions/02_EptLookup.go
@@ -1,0 +1,134 @@
+package functions
+
+import (
+	"fmt"
+
+	epm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/structures"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+)
+
+// eptLookupRequest carries the [in] parameters of ept_lookup (opnum 2). The binding
+// handle (handle_t) is not part of the NDR stub and is omitted. Object and Ifid are the
+// optional [in, ptr] object-UUID and interface filters (nil for an all-elements
+// enumeration); EntryHandle is the 20-octet context handle (null on the first call);
+// MaxEnts caps the batch ([MS-RPCE] range(0,500)).
+type eptLookupRequest struct {
+	InquiryType ndr.DWORD
+	Object      *structures.EptUUID `ndr:"ptr"`
+	Ifid        *structures.RpcIfID `ndr:"ptr"`
+	VersOption  ndr.DWORD
+	EntryHandle structures.ContextHandle
+	MaxEnts     ndr.DWORD
+}
+
+func (*eptLookupRequest) Opnum() uint16 { return epm.OpnumEptLookup }
+
+// eptLookupResponse carries the [out] parameters of ept_lookup: the advanced context
+// handle, the number of entries returned, the entries themselves (a full pointer to a
+// conformant-varying array of ept_entry_t — size_is(max_ents), length_is(num_ents)), and
+// the status.
+type eptLookupResponse struct {
+	EntryHandle structures.ContextHandle
+	NumEnts     ndr.DWORD
+	Entries     []structures.EptEntry `ndr:"ptr,varying"`
+	Status      ndr.DWORD
+}
+
+// EptLookup calls ept_lookup (opnum 2) ([C706] Appendix O, [MS-RPCE] 2.2.1.2.4) once,
+// returning a single batch of endpoint-map entries. inquiryType selects what to match
+// (use epm.EptInquiryAllElts to enumerate everything); object and ifid are the optional
+// filters; versOption is the interface-version constraint; entryHandle is null on the
+// first call and the value returned by the previous call thereafter. It returns the batch
+// of entries, the advanced entry handle, and the raw [out] status (the caller decides how
+// to treat ept_s_not_registered); err is non-nil only for transport/decoding failures.
+// Lookup wraps this with the paging loop for the common "enumerate everything" case.
+func EptLookup(rpc ndr.Invoker, inquiryType uint32, object *guid.GUID, ifid *structures.RpcIfID, versOption uint32, entryHandle structures.ContextHandle, maxEnts uint32) (entries []structures.EptEntry, next structures.ContextHandle, status uint32, err error) {
+	req := &eptLookupRequest{
+		InquiryType: ndr.DWORD(inquiryType),
+		Ifid:        ifid,
+		VersOption:  ndr.DWORD(versOption),
+		EntryHandle: entryHandle,
+		MaxEnts:     ndr.DWORD(maxEnts),
+	}
+	if object != nil {
+		u := structures.NewEptUUID(*object)
+		req.Object = &u
+	}
+
+	var resp eptLookupResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		return nil, structures.ContextHandle{}, 0, fmt.Errorf("ept_lookup: %w", err)
+	}
+
+	// num_ents is the authoritative count; clamp to the decoded array as a guard.
+	n := int(resp.NumEnts)
+	if n > len(resp.Entries) {
+		n = len(resp.Entries)
+	}
+	return resp.Entries[:n], resp.EntryHandle, uint32(resp.Status), nil
+}
+
+// eptLookupHandleFreeRequest carries the [in, out] context handle of
+// ept_lookup_handle_free (opnum 1).
+type eptLookupHandleFreeRequest struct {
+	EntryHandle structures.ContextHandle
+}
+
+func (*eptLookupHandleFreeRequest) Opnum() uint16 { return epm.OpnumEptLookupHandleFree }
+
+// eptLookupHandleFreeResponse carries the [out] (nulled) handle and status.
+type eptLookupHandleFreeResponse struct {
+	EntryHandle structures.ContextHandle
+	Status      ndr.DWORD
+}
+
+// EptLookupHandleFree calls ept_lookup_handle_free (opnum 1), releasing a lookup context
+// handle obtained from EptLookup. A full enumeration via Lookup nulls the handle on
+// completion and needs no explicit free; this is for abandoning a partial walk early.
+func EptLookupHandleFree(rpc ndr.Invoker, handle structures.ContextHandle) (structures.ContextHandle, error) {
+	req := &eptLookupHandleFreeRequest{EntryHandle: handle}
+	var resp eptLookupHandleFreeResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return structures.ContextHandle{}, fmt.Errorf("ept_lookup_handle_free: %w", err)
+	}
+	if uint32(resp.Status) != epm.EptStatusSuccess {
+		return resp.EntryHandle, fmt.Errorf("ept_lookup_handle_free failed: %s", epm.StatusString(uint32(resp.Status)))
+	}
+	return resp.EntryHandle, nil
+}
+
+// Lookup enumerates the entire endpoint map by paging ept_lookup to completion. It issues
+// EptInquiryAllElts lookups (no object/interface filter) from a null entry handle,
+// accumulating every returned ept_entry_t until the server returns a null entry handle or
+// reports ept_s_not_registered (no further matches) — both a normal end of enumeration.
+// Each entry's binding is available via EptEntry.DecodeTower / Tower.Binding. For finer
+// control (a filter, a custom batch size, or one page at a time) call EptLookup directly.
+func Lookup(rpc ndr.Invoker) ([]structures.EptEntry, error) {
+	var (
+		entries []structures.EptEntry
+		handle  structures.ContextHandle
+	)
+	for {
+		batch, next, status, err := EptLookup(rpc, epm.EptInquiryAllElts, nil, nil, epm.EptVersAll, handle, DefaultMaxEnts)
+		if err != nil {
+			return nil, err
+		}
+		if status != epm.EptStatusSuccess && status != epm.EptStatusNotRegistered {
+			return nil, fmt.Errorf("ept_lookup failed: %s", epm.StatusString(status))
+		}
+		entries = append(entries, batch...)
+		handle = next
+
+		if status == epm.EptStatusNotRegistered || handle.IsNull() {
+			return entries, nil
+		}
+		if len(batch) == 0 {
+			// The server advanced no entries but left a live handle; release it rather than
+			// loop forever (best-effort).
+			_, _ = EptLookupHandleFree(rpc, handle)
+			return entries, nil
+		}
+	}
+}

--- a/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/functions/03_EptMap.go
+++ b/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/functions/03_EptMap.go
@@ -53,7 +53,7 @@ func EptMap(rpc ndr.Invoker, object *guid.GUID, mapTower structures.Tower, maxTo
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return nil, fmt.Errorf("ept_map: %w", err)
 	}
-	if uint32(resp.Status) != epm.StatusSuccess {
+	if uint32(resp.Status) != epm.EptStatusSuccess {
 		return nil, fmt.Errorf("ept_map failed: %s", epm.StatusString(uint32(resp.Status)))
 	}
 

--- a/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/functions/functions.go
+++ b/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/functions/functions.go
@@ -13,6 +13,11 @@ import (
 // the endpoints a single interface is typically bound to.
 const DefaultMaxTowers = 4
 
+// DefaultMaxEnts is the batch size Lookup requests per ept_lookup call. ept_lookup caps
+// max_ents at 500 ([MS-RPCE] 2.2.1.2.4 range(0,500)); enumeration pages until the entry
+// handle is exhausted regardless of this value.
+const DefaultMaxEnts = 500
+
 // Map resolves the ncacn_ip_tcp endpoints bound to the given interface UUID and version
 // by building a TCP map tower and calling ept_map, then extracting the endpoints from
 // the returned towers. It is the common path for discovering the dynamic TCP port a

--- a/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/functions/functions_test.go
+++ b/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/functions/functions_test.go
@@ -1,6 +1,7 @@
 package functions_test
 
 import (
+	"bytes"
 	"encoding/binary"
 	"errors"
 	"net"
@@ -9,6 +10,7 @@ import (
 	epm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/functions"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/structures"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/pdu"
@@ -110,7 +112,7 @@ func eptMapResponseStub(tower structures.Tower, maxTowers uint32) []byte {
 	b = le32(b, uint32(len(towerBytes)))
 	b = append(b, towerBytes...)
 	b = pad4(b)
-	b = le32(b, epm.StatusSuccess) // status
+	b = le32(b, epm.EptStatusSuccess) // status
 	return b
 }
 
@@ -191,5 +193,163 @@ func TestEptMap_StatusError(t *testing.T) {
 
 	if _, err := functions.EptMap(c, nil, structures.BuildMapTowerTCP(sampleIface(), 1, 0), functions.DefaultMaxTowers); err == nil {
 		t.Fatal("EptMap() with ept_s_not_registered: error = nil, want non-nil")
+	}
+}
+
+// --- ept_lookup ---
+
+// lookupRespMirror mirrors the [out] layout of ept_lookup's response so a test can build a
+// wire stub by marshalling it through the real NDR codec (the production response type is
+// unexported). Same field types/tags => the production decoder reads it back identically.
+type lookupRespMirror struct {
+	EntryHandle structures.ContextHandle
+	NumEnts     uint32
+	Entries     []structures.EptEntry `ndr:"ptr,varying"`
+	Status      uint32
+}
+
+// eptLookupStub marshals one ept_lookup response (entry handle, entries, status).
+func eptLookupStub(t *testing.T, handle structures.ContextHandle, status uint32, entries []structures.EptEntry) []byte {
+	t.Helper()
+	b, err := ndr.Marshal(&lookupRespMirror{
+		EntryHandle: handle,
+		NumEnts:     uint32(len(entries)),
+		Entries:     entries,
+		Status:      status,
+	})
+	if err != nil {
+		t.Fatalf("marshal lookup response: %v", err)
+	}
+	return b
+}
+
+// tcpEntry builds an ept_entry_t with an ncacn_ip_tcp tower on the given port.
+func tcpEntry(obj guid.GUID, port uint16, annotation string) structures.EptEntry {
+	tw := structures.NewTwr(structures.Tower{Floors: []structures.Floor{
+		structures.InterfaceFloor(sampleIface(), 1, 0),
+		structures.TransferSyntaxFloor(),
+		{LHS: []byte{structures.FloorProtoNCACN}, RHS: []byte{0, 0}},
+		structures.TCPFloor(port),
+		structures.IPFloor(net.IPv4(10, 0, 0, 1)),
+	}})
+	return structures.EptEntry{
+		Object:     structures.NewEptUUID(obj),
+		Tower:      &tw,
+		Annotation: structures.Annotation(annotation),
+	}
+}
+
+// nonNullHandle returns a context handle with a non-zero UUID portion.
+func nonNullHandle() structures.ContextHandle {
+	var h structures.ContextHandle
+	h[4] = 0xAB // first UUID octet
+	return h
+}
+
+func TestLookup_SingleBatch(t *testing.T) {
+	ft := &fakeTransport{}
+	c := boundClient(t, ft)
+
+	entries := []structures.EptEntry{
+		tcpEntry(sampleIface(), 49664, "Service A"),
+		tcpEntry(sampleIface(), 135, "Service B"),
+	}
+	// Null handle on the response => enumeration complete after this batch.
+	ft.queue(responsePDU(t, 2, eptLookupStub(t, structures.ContextHandle{}, epm.EptStatusSuccess, entries)))
+
+	got, err := functions.Lookup(c)
+	if err != nil {
+		t.Fatalf("Lookup() error = %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d entries, want 2", len(got))
+	}
+	if got[0].Annotation != "Service A" {
+		t.Errorf("entry 0 annotation = %q, want %q", got[0].Annotation, "Service A")
+	}
+	tw, err := got[1].DecodeTower()
+	if err != nil {
+		t.Fatalf("DecodeTower: %v", err)
+	}
+	if ep, ok := tw.Endpoint(); !ok || ep.Port != 135 {
+		t.Errorf("entry 1 endpoint = %v (ok=%v), want port 135", ep, ok)
+	}
+}
+
+func TestLookup_MultiBatch(t *testing.T) {
+	ft := &fakeTransport{}
+	c := boundClient(t, ft)
+
+	h1 := nonNullHandle()
+	// Batch 1: two entries, non-null handle => more to come.
+	ft.queue(responsePDU(t, 2, eptLookupStub(t, h1, epm.EptStatusSuccess,
+		[]structures.EptEntry{tcpEntry(sampleIface(), 1000, "A"), tcpEntry(sampleIface(), 1001, "B")})))
+	// Batch 2: one entry, null handle => done.
+	ft.queue(responsePDU(t, 3, eptLookupStub(t, structures.ContextHandle{}, epm.EptStatusSuccess,
+		[]structures.EptEntry{tcpEntry(sampleIface(), 1002, "C")})))
+
+	got, err := functions.Lookup(c)
+	if err != nil {
+		t.Fatalf("Lookup() error = %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("got %d entries across batches, want 3", len(got))
+	}
+
+	// The second request must carry the entry handle returned by the first batch. Stub
+	// layout: inquiry_type(4) + object ref(4) + Ifid ref(4) + vers_option(4) = 16, then the
+	// 20-octet entry handle.
+	var req2 pdu.Request
+	if _, err := req2.Unmarshal(ft.sent[2]); err != nil {
+		t.Fatalf("second request does not parse: %v", err)
+	}
+	if got := req2.Stub[16:36]; !bytes.Equal(got, h1[:]) {
+		t.Errorf("second request entry handle = %x, want %x", got, h1[:])
+	}
+}
+
+func TestLookup_EmptyRegistry(t *testing.T) {
+	ft := &fakeTransport{}
+	c := boundClient(t, ft)
+
+	// No entries, null handle, ept_s_not_registered => clean, empty result.
+	ft.queue(responsePDU(t, 2, eptLookupStub(t, structures.ContextHandle{}, epm.EptStatusNotRegistered, nil)))
+
+	got, err := functions.Lookup(c)
+	if err != nil {
+		t.Fatalf("Lookup() error = %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("got %d entries for an empty registry, want 0", len(got))
+	}
+}
+
+func TestEptLookup_RequestShape(t *testing.T) {
+	ft := &fakeTransport{}
+	c := boundClient(t, ft)
+	ft.queue(responsePDU(t, 2, eptLookupStub(t, structures.ContextHandle{}, epm.EptStatusSuccess, nil)))
+
+	if _, err := functions.Lookup(c); err != nil {
+		t.Fatalf("Lookup() error = %v", err)
+	}
+
+	var req pdu.Request
+	if _, err := req.Unmarshal(ft.sent[1]); err != nil {
+		t.Fatalf("request does not parse: %v", err)
+	}
+	if req.Opnum != epm.OpnumEptLookup {
+		t.Errorf("opnum = %d, want %d", req.Opnum, epm.OpnumEptLookup)
+	}
+	if it := binary.LittleEndian.Uint32(req.Stub[:4]); it != epm.EptInquiryAllElts {
+		t.Errorf("inquiry_type = %d, want EptInquiryAllElts", it)
+	}
+	if obj := binary.LittleEndian.Uint32(req.Stub[4:8]); obj != 0 {
+		t.Errorf("object pointer = 0x%08x, want 0 (null)", obj)
+	}
+	if ifid := binary.LittleEndian.Uint32(req.Stub[8:12]); ifid != 0 {
+		t.Errorf("Ifid pointer = 0x%08x, want 0 (null)", ifid)
+	}
+	if max := binary.LittleEndian.Uint32(req.Stub[36:40]); max != functions.DefaultMaxEnts {
+		t.Errorf("max_ents = %d, want %d", max, functions.DefaultMaxEnts)
 	}
 }

--- a/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/functions/integration_test.go
+++ b/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/functions/integration_test.go
@@ -84,3 +84,72 @@ func TestIntegration_EptMap(t *testing.T) {
 		t.Logf("[ok] srvsvc bound at %s", ep)
 	}
 }
+
+func TestIntegration_EptLookup(t *testing.T) {
+	host := os.Getenv("DCERPC_TEST_HOST")
+	if host == "" {
+		t.Skip("DCERPC_TEST_HOST not set; skipping live ept_lookup test")
+	}
+	port := 445
+	if p := os.Getenv("DCERPC_TEST_PORT"); p != "" {
+		n, err := strconv.Atoi(p)
+		if err != nil {
+			t.Fatalf("invalid DCERPC_TEST_PORT %q: %v", p, err)
+		}
+		port = n
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		t.Fatalf("DCERPC_TEST_HOST %q is not a valid IP", host)
+	}
+	creds, err := credentials.NewCredentials(os.Getenv("DCERPC_TEST_DOMAIN"), os.Getenv("DCERPC_TEST_USER"), os.Getenv("DCERPC_TEST_PASS"), "")
+	if err != nil {
+		t.Fatalf("NewCredentials: %v", err)
+	}
+
+	smb := smbclient.NewClientUsingTCPTransport(ip, port)
+	if err := smb.Connect(ip, port); err != nil {
+		t.Fatalf("SMB Connect: %v", err)
+	}
+	defer smb.Disconnect()
+	smb.NativeOS, smb.NativeLanMan = "Unix", "Samba"
+	if err := smb.SessionSetup(creds); err != nil {
+		t.Fatalf("SMB SessionSetup: %v", err)
+	}
+	defer smb.Logoff()
+	if err := smb.TreeConnect("IPC$"); err != nil {
+		t.Fatalf("SMB TreeConnect(IPC$): %v", err)
+	}
+	defer smb.TreeDisconnect()
+
+	rpc := client.NewClient(dcerpcsmb.New(smb, epm.PipeName))
+	if err := rpc.Bind(epm.SyntaxID()); err != nil {
+		t.Fatalf("DCE/RPC Bind(ept): %v", err)
+	}
+	defer rpc.Close()
+
+	// Enumerate the whole endpoint map and render each entry as a string binding.
+	entries, err := functions.Lookup(rpc)
+	if err != nil {
+		t.Fatalf("[WIRE FAIL] ept_lookup: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("[WIRE FAIL] ept_lookup returned no entries")
+	}
+	for _, e := range entries {
+		tw, err := e.DecodeTower()
+		if err != nil {
+			t.Errorf("[WIRE FAIL] decode tower: %v", err)
+			continue
+		}
+		obj := e.Object.GUID()
+		// Endpoint() renders the ncacn_ip_tcp case; #623's Tower.Binding() generalizes this
+		// to named-pipe/HTTP towers once merged.
+		if ep, ok := tw.Endpoint(); ok {
+			t.Logf("[ok] %s  iface=%s  %q", ep, obj.ToFormatD(), e.Annotation)
+		} else {
+			t.Logf("[ok] %d-floor tower  iface=%s  %q", len(tw.Floors), obj.ToFormatD(), e.Annotation)
+		}
+	}
+	t.Logf("[ok] ept_lookup enumerated %d endpoint-map entries", len(entries))
+}

--- a/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/interface.go
+++ b/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/interface.go
@@ -27,6 +27,9 @@ const PipeName = `\epmapper`
 // Opnums for the on-the-wire ept methods ([C706] Appendix O). Only the operations
 // modelled here are listed.
 const (
+	// OpnumEptLookupHandleFree is ept_lookup_handle_free (opnum 1), which releases a
+	// lookup context handle obtained from ept_lookup.
+	OpnumEptLookupHandleFree uint16 = 1
 	// OpnumEptLookup is ept_lookup (opnum 2), which enumerates endpoint-map entries.
 	OpnumEptLookup uint16 = 2
 	// OpnumEptMap is ept_map (opnum 3), which resolves an interface to its bound
@@ -34,13 +37,35 @@ const (
 	OpnumEptMap uint16 = 3
 )
 
-// Status codes returned in the ept_map [out] error_status_t. 0 is success; the ept
-// specific codes are DCE error-status values ([C706] Appendix O / Appendix E).
+// Status codes returned in the ept_map / ept_lookup [out] error_status_t. 0 is success;
+// the ept specific codes are DCE error-status values ([C706] Appendix O / Appendix E).
+// ept_lookup additionally returns ept_s_not_registered (EptStatusNotRegistered) once no
+// further elements match, which the paging loop treats as a normal end of enumeration.
 const (
-	StatusSuccess          uint32 = 0x00000000 // rpc_s_ok
+	EptStatusSuccess       uint32 = 0x00000000 // rpc_s_ok
 	EptStatusCantPerform   uint32 = 0x16c9a0d8 // ept_s_cant_perform_op
 	EptStatusNotRegistered uint32 = 0x16c9a0d6 // ept_s_not_registered
 	EptStatusInvalidEntry  uint32 = 0x16c9a0d7 // ept_s_invalid_entry
+)
+
+// ept_lookup inquiry_type values ([C706] Appendix O / [MS-RPCE] 2.2.1.2.4): which entries
+// the endpoint mapper returns. EptInquiryAllElts enumerates the whole endpoint map and
+// ignores the object/Ifid/vers_option filters.
+const (
+	EptInquiryAllElts     uint32 = 0x00000000 // RPC_C_EP_ALL_ELTS
+	EptInquiryMatchByIf   uint32 = 0x00000001 // RPC_C_EP_MATCH_BY_IF
+	EptInquiryMatchByObj  uint32 = 0x00000002 // RPC_C_EP_MATCH_BY_OBJ
+	EptInquiryMatchByBoth uint32 = 0x00000003 // RPC_C_EP_MATCH_BY_BOTH
+)
+
+// ept_lookup vers_option values: the interface-version constraint applied when matching by
+// interface ([MS-RPCE] 2.2.1.2.4).
+const (
+	EptVersAll        uint32 = 0x00000001 // RPC_C_VERS_ALL
+	EptVersCompatible uint32 = 0x00000002 // RPC_C_VERS_COMPATIBLE
+	EptVersExact      uint32 = 0x00000003 // RPC_C_VERS_EXACT
+	EptVersMajorOnly  uint32 = 0x00000004 // RPC_C_VERS_MAJOR_ONLY
+	EptVersUpto       uint32 = 0x00000005 // RPC_C_VERS_UPTO
 )
 
 // SyntaxID returns the ept abstract syntax identifier:
@@ -57,7 +82,7 @@ func SyntaxID() syntax.SyntaxID {
 // value.
 func StatusString(status uint32) string {
 	switch status {
-	case StatusSuccess:
+	case EptStatusSuccess:
 		return "rpc_s_ok"
 	case EptStatusCantPerform:
 		return "ept_s_cant_perform_op"
@@ -72,8 +97,9 @@ func StatusString(status uint32) string {
 
 // OpnumToName maps each modelled opnum to its method name; the single source of truth.
 var OpnumToName = map[uint16]string{
-	OpnumEptLookup: "ept_lookup",
-	OpnumEptMap:    "ept_map",
+	OpnumEptLookupHandleFree: "ept_lookup_handle_free",
+	OpnumEptLookup:           "ept_lookup",
+	OpnumEptMap:              "ept_map",
 }
 
 // NameToOpnum is the reverse of OpnumToName, built at init so the two never drift.

--- a/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/interface_test.go
+++ b/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/interface_test.go
@@ -15,7 +15,7 @@ func TestSyntaxID(t *testing.T) {
 
 func TestStatusString(t *testing.T) {
 	cases := map[uint32]string{
-		StatusSuccess:          "rpc_s_ok",
+		EptStatusSuccess:       "rpc_s_ok",
 		EptStatusNotRegistered: "ept_s_not_registered",
 		0xdeadbeef:             "0xdeadbeef",
 	}

--- a/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/structures/context_handle.go
+++ b/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/structures/context_handle.go
@@ -20,6 +20,18 @@ type ContextHandle [ContextHandleSize]byte
 // Compile-time assertion that ContextHandle encodes itself as NDR.
 var _ ndr.Marshaler = (*ContextHandle)(nil)
 
+// IsNull reports whether the handle is the null context handle, i.e. its 16-octet UUID
+// (the octets after the 4-octet attributes word) is all zero. ept_lookup signals the end
+// of a paged enumeration by returning a null entry handle.
+func (h ContextHandle) IsNull() bool {
+	for _, b := range h[4:] {
+		if b != 0 {
+			return false
+		}
+	}
+	return true
+}
+
 // AlignmentNDR reports the 4-octet alignment of a context handle (its first field is the
 // 4-octet attributes word).
 func (*ContextHandle) AlignmentNDR() int { return 4 }

--- a/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/structures/ept_entry.go
+++ b/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/structures/ept_entry.go
@@ -1,0 +1,85 @@
+package structures
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// Annotation is the [string] char annotation[ept_max_annotation_size] field of an
+// ept_entry_t ([C706] Appendix O, ept_max_annotation_size = 64): a human-readable label
+// the endpoint mapper stores with each registration (e.g. "Messenger Service").
+//
+// A fixed-bound [string] array is encoded in NDR as a *varying* array — an offset and an
+// actual_count (number of characters, including the NUL terminator) followed by that many
+// octets, with no maximum_count. That two-count framing differs from the codec's general
+// conformant-varying string handling, so Annotation marshals itself.
+type Annotation string
+
+// Compile-time assertion that Annotation encodes itself as NDR.
+var _ ndr.Marshaler = (*Annotation)(nil)
+
+// AnnotationMaxSize is ept_max_annotation_size, the fixed bound of the annotation array.
+const AnnotationMaxSize = 64
+
+// AlignmentNDR reports the 4-octet alignment of the leading offset/actual_count words.
+func (*Annotation) AlignmentNDR() int { return 4 }
+
+// MarshalNDR writes the annotation as a varying char array: offset 0, actual_count
+// (string length plus the NUL terminator), then the bytes and the terminator.
+func (a *Annotation) MarshalNDR(e *ndr.Encoder) error {
+	e.Align(4)
+	s := string(*a)
+	e.WriteUint32(0)                 // offset
+	e.WriteUint32(uint32(len(s) + 1)) // actual_count, including the NUL terminator
+	e.WriteBytes([]byte(s))
+	e.WriteUint8(0) // NUL terminator
+	return nil
+}
+
+// UnmarshalNDR reads a varying char array (offset, actual_count, octets) and stores it
+// with the trailing NUL removed.
+func (a *Annotation) UnmarshalNDR(d *ndr.Decoder) error {
+	d.Align(4)
+	if _, err := d.ReadUint32(); err != nil { // offset
+		return fmt.Errorf("epm: annotation offset: %w", err)
+	}
+	n, err := d.ReadUint32() // actual_count (characters, including any NUL terminator)
+	if err != nil {
+		return fmt.Errorf("epm: annotation length: %w", err)
+	}
+	b, err := d.ReadBytes(int(n))
+	if err != nil {
+		return fmt.Errorf("epm: annotation: %w", err)
+	}
+	*a = Annotation(strings.TrimRight(string(b), "\x00"))
+	return nil
+}
+
+// EptEntry models ept_entry_t ([C706] Appendix O):
+//
+//	typedef struct {
+//	    uuid_t  object;
+//	    twr_p_t tower;
+//	    [string] char annotation[ept_max_annotation_size];
+//	} ept_entry_t;
+//
+// Object is the object UUID (often nil/zero), Tower is a [unique]/full pointer to the
+// twr_t describing the binding, and Annotation is the registration's label. It is the
+// element type of ept_lookup's [out] entries array; use DecodeTower to obtain the decoded
+// protocol Tower (and Tower.Binding for a string binding).
+type EptEntry struct {
+	Object     EptUUID
+	Tower      *Twr `ndr:"ptr"`
+	Annotation Annotation
+}
+
+// DecodeTower decodes the entry's twr_t into a protocol Tower. It errors if the entry has
+// no tower (a null pointer on the wire).
+func (e EptEntry) DecodeTower() (Tower, error) {
+	if e.Tower == nil {
+		return Tower{}, fmt.Errorf("epm: entry has no tower")
+	}
+	return e.Tower.DecodeTower()
+}

--- a/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/structures/rpc_if_id.go
+++ b/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/structures/rpc_if_id.go
@@ -1,0 +1,20 @@
+package structures
+
+import "github.com/TheManticoreProject/Manticore/windows/guid"
+
+// RpcIfID models RPC_IF_ID ([C706] Appendix O / [MS-RPCE] 2.2.1.2.4): an interface
+// identifier (UUID + 16-bit major/minor version). It is the referent of ept_lookup's
+// optional [in, ptr] Ifid parameter, used to filter the endpoint map by interface.
+//
+// UUID is the EptUUID octet form (the same fixed-octet UUID used by ept_map's object
+// pointer) so the codec emits it verbatim as part of the referent body.
+type RpcIfID struct {
+	UUID      EptUUID
+	VersMajor uint16
+	VersMinor uint16
+}
+
+// NewRpcIfID builds an RpcIfID from a GUID and an interface major/minor version.
+func NewRpcIfID(iface guid.GUID, major, minor uint16) RpcIfID {
+	return RpcIfID{UUID: NewEptUUID(iface), VersMajor: major, VersMinor: minor}
+}


### PR DESCRIPTION
### Linked Issue
Closes #622

### Summary
`ept_map` (opnum 3) resolves a *single* known interface UUID to its endpoint(s) but cannot enumerate what is registered on a host. This adds `ept_lookup` (opnum 2) plus a `Lookup` convenience that pages the entry handle to completion and returns every `ept_entry_t`. It is the prerequisite for the planned `msrpc dump`/`monitor` recon tooling (≈ impacket `rpcdump.py`).

The wire modeling was cross-checked against [MS-RPCE 2.2.1.2.4](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/86fc67d3-f44c-4a14-afeb-1e46048841c5), [C706 Appendix O](https://pubs.opengroup.org/onlinepubs/9629399/apdxo.htm), and impacket `dcerpc/v5/epm.py`.

### What this adds
**Functions (`functions/02_EptLookup.go`):**
- `EptLookup(rpc, inquiryType, object, ifid, versOption, entryHandle, maxEnts)` — one `ept_lookup` call; returns a batch of `EptEntry`, the advanced entry handle, and the raw `[out]` status (so the caller decides how to treat `ept_s_not_registered`).
- `Lookup(rpc) ([]structures.EptEntry, error)` — pages `EptInquiryAllElts` lookups from a null handle, accumulating entries until the server returns a null entry handle or `ept_s_not_registered` (a clean end of enumeration). Mirrors the existing `EptMap`/`Map` split.
- `EptLookupHandleFree(rpc, handle)` (opnum 1) — releases a handle when abandoning a partial walk; full enumeration nulls the handle and needs no explicit free.
- `DefaultMaxEnts = 500` (the IDL `range(0,500)` cap).

**Structures:**
- `EptEntry` — `ept_entry_t` (object UUID, `twr_p_t` tower, `[string] char annotation[64]`), with `DecodeTower()`.
- `RpcIfID` / `NewRpcIfID` — the `RPC_IF_ID` interface filter.
- `Annotation` — a small `ndr.Marshaler` for the fixed-bound `[string]` annotation. A fixed-bound `[string]` array is encoded in NDR as a **varying** array (`offset` + `actual_count` + octets, NUL-terminated) with **no** `maximum_count` — which differs from the codec's conformant-varying string path, so the field marshals itself. (Confirmed against impacket's `NDRUniVaryingArray`.)
- `ContextHandle.IsNull()` — the paging termination check (UUID portion all-zero).

**Interface / naming (from the EPM API naming review):**
- Status constants unified under `EptStatus*`: `StatusSuccess` → **`EptStatusSuccess`** (callers updated).
- New `EptInquiry*` (inquiry_type) and `EptVers*` (vers_option) constant sets.
- `OpnumEptLookupHandleFree` (1) added; `OpnumToName` updated.

### Modeling notes (verified)
- `entries` is `[out, length_is(num_ents), size_is(max_ents)] ept_entry_t entries[]` — a conformant-varying array, modeled `ndr:"ptr,varying"` exactly like `ept_map`'s `ITowers` (elements are structs, so no `elem=ptr`). The element's `tower` is a full pointer whose body defers after the array; the `annotation` is read inline. The existing array/struct/deferred-pointer machinery handles this — **no NDR-walker change was needed**.
- Decode reads `maximum_count`/`offset`/`actual_count` off the wire, so the change is request/response modeling only.

### How Verified
- `go test ./network/dcerpc/...` — all pass (34 packages; existing `ept_map`/tower tests unaffected by the rename).
- `go build ./...`, `go vet` (incl. `-tags integration`) clean.
- Unit tests build response stubs by marshalling an exported mirror of the `[out]` layout through the real NDR codec, so encode and decode are exercised symmetrically.

### Test Coverage
- **Added** (`functions_test.go`): `TestLookup_SingleBatch`, `TestLookup_MultiBatch` (asserts the entry handle from batch 1 is threaded into the batch-2 request), `TestLookup_EmptyRegistry` (`ept_s_not_registered` → clean empty result), `TestEptLookup_RequestShape` (opnum, `EptInquiryAllElts`, null object/Ifid pointers, `max_ents`).
- **Added** (`integration_test.go`, build-tagged): `TestIntegration_EptLookup` enumerates a live host and renders each entry.

### Scope of Change
- **Files:** `interface.go`, `interface_test.go`, `structures/{context_handle,rpc_if_id,ept_entry}.go`, `functions/{functions,02_EptLookup,03_EptMap,functions_test,integration_test}.go`. (`03_EptMap.go` / tests touched only by the `EptStatusSuccess` rename.)
- **Submodule pointer updated:** no.
- **Behavioral changes outside the feature:** the `StatusSuccess` → `EptStatusSuccess` rename (consistency), no functional change.

### Notes
Companion to #623 (PR #624), which adds `Tower.Binding()` for rendering `ncacn_np`/`ncacn_http` bindings. `Lookup` returns `[]EptEntry` rather than the issue's literal `[]Tower`, so callers keep the object UUID and annotation (`msrpc dump` needs them); the tower is reachable via `entry.DecodeTower()`. The integration test currently renders via `Endpoint()`; once #623 merges, `Tower.Binding()` generalizes it to non-TCP transports.
