### PR TITLE
Render ept_lookup integration output via Tower.Binding for all transports

### DIFF
--- a/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/functions/integration_test.go
+++ b/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/functions/integration_test.go
@@ -143,10 +143,10 @@ func TestIntegration_EptLookup(t *testing.T) {
 			continue
 		}
 		obj := e.Object.GUID()
-		// Endpoint() renders the ncacn_ip_tcp case; #623's Tower.Binding() generalizes this
-		// to named-pipe/HTTP towers once merged.
-		if ep, ok := tw.Endpoint(); ok {
-			t.Logf("[ok] %s  iface=%s  %q", ep, obj.ToFormatD(), e.Annotation)
+		// Binding() renders every transport (ncacn_ip_tcp, ncacn_np, ncacn_http, ...); fall
+		// back to a floor-count summary for any tower it does not recognize.
+		if b, err := tw.Binding(); err == nil {
+			t.Logf("[ok] %s  iface=%s  %q", b, obj.ToFormatD(), e.Annotation)
 		} else {
 			t.Logf("[ok] %d-floor tower  iface=%s  %q", len(tw.Floors), obj.ToFormatD(), e.Annotation)
 		}


### PR DESCRIPTION
### Summary
Follow-up to #622 / #623 (now both merged). The `ept_lookup` live integration test rendered each enumerated entry with `Tower.Endpoint()`, which only decodes `ncacn_ip_tcp`; named-pipe and HTTP endpoints therefore logged only a floor count. With `Tower.Binding()` now on `main`, the test renders every transport (`ncacn_ip_tcp`, `ncacn_np`, `ncacn_http`, `ncadg_ip_udp`) as a canonical string binding, keeping the floor-count fallback for any tower `Binding()` does not recognize.

### Fix Description
In `TestIntegration_EptLookup`, replace the `tw.Endpoint()` rendering branch with `tw.Binding()`. This was the carryover noted when #622 landed before #623 (the test couldn't reference `Binding()` until both were merged).

### How Verified
- `go vet -tags integration ./.../3.0/functions/` — clean (the integration test now compiles against `Tower.Binding()`).
- `go test ./.../3.0/...` — all pass (the change is inside a build-tagged test, so the default suite is unaffected).

### Test Coverage
- **Existing:** the build-tagged `TestIntegration_EptLookup` (enumerates a live host); this only changes how its entries are formatted.

### Scope of Change
- **Files changed:** `network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/functions/integration_test.go` (test-only).
- **Submodule pointer updated:** no.
- **Behavioral changes outside the bug fix:** none — no library code is touched.
