### PR TITLE
Add a catalog of well-known DCE/RPC interfaces (UUID -> metadata)

### DIFF
--- a/network/dcerpc/interfaces/catalog/catalog.go
+++ b/network/dcerpc/interfaces/catalog/catalog.go
@@ -1,0 +1,255 @@
+// Package catalog is a database of well-known DCE/RPC interfaces: it maps an
+// interface UUID (and version) to human-readable metadata — a short name, a
+// title, a description, the executable or DLL that implements the server, the
+// hosting Windows service, the MS-* protocol document, and the well-known named
+// pipe(s). It lets tooling label the raw UUIDs returned by ept_lookup / ept_map
+// (e.g. 12345678-1234-abcd-ef00-0123456789ab v1.0 -> "spoolss", MS-RPRN,
+// spoolsv.exe, Spooler service).
+//
+// The catalog is a pure data table, independent of which interfaces have a
+// client implementation under network/dcerpc/interfaces. Look entries up through
+// the package-level helpers (which use the built-in Default database) or build a
+// custom Database with New.
+package catalog
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+)
+
+// Version is a DCE/RPC interface version (major.minor).
+type Version struct {
+	Major uint16
+	Minor uint16
+}
+
+// String renders the version as "major.minor".
+func (v Version) String() string { return fmt.Sprintf("%d.%d", v.Major, v.Minor) }
+
+// Interface is one catalog entry: a specific interface UUID + version and the
+// metadata known about it. Executable is the image that implements the RPC
+// server (an .exe or a .dll loaded into a host process), e.g. "spoolsv.exe" or
+// "srvsvc.dll"; Service is the hosting Windows service name where applicable,
+// e.g. "Spooler". Fields that are not known are left empty.
+type Interface struct {
+	UUID        guid.GUID
+	Version     Version
+	Name        string   // short handle, e.g. "spoolss"
+	Title       string   // human title, e.g. "Print System Remote Protocol"
+	Description string   // one-line summary
+	Executable  string   // implementing image, e.g. "spoolsv.exe" / "srvsvc.dll"
+	Service     string   // hosting Windows service, e.g. "Spooler"
+	Protocol    string   // MS-* document id, e.g. "MS-RPRN"
+	Pipes       []string // well-known named pipe(s), e.g. `\pipe\spoolss`
+}
+
+// String renders a compact one-line label, e.g.
+// "spoolss v1.0 (MS-RPRN) [spoolsv.exe]".
+func (i Interface) String() string {
+	var b strings.Builder
+	if i.Name != "" {
+		b.WriteString(i.Name)
+	} else {
+		b.WriteString(i.UUID.ToFormatD())
+	}
+	fmt.Fprintf(&b, " v%s", i.Version)
+	if i.Protocol != "" {
+		fmt.Fprintf(&b, " (%s)", i.Protocol)
+	}
+	if i.Executable != "" {
+		fmt.Fprintf(&b, " [%s]", i.Executable)
+	}
+	return b.String()
+}
+
+// verKey identifies one entry by UUID and version.
+type verKey struct {
+	uuid  guid.GUID
+	major uint16
+	minor uint16
+}
+
+// Database is an indexed, read-only collection of catalog entries.
+type Database struct {
+	entries    []Interface
+	byUUID     map[guid.GUID][]Interface
+	byKey      map[verKey]Interface
+	byName     map[string][]Interface
+	byExec     map[string][]Interface
+	byService  map[string][]Interface
+	byProtocol map[string][]Interface
+	byPipe     map[string][]Interface
+}
+
+// New builds a Database from entries, constructing the lookup indexes. It errors
+// on a malformed catalog: an entry with an empty Name, a zero UUID, or a
+// duplicate (UUID, version).
+func New(entries []Interface) (*Database, error) {
+	db := &Database{
+		byUUID:     map[guid.GUID][]Interface{},
+		byKey:      map[verKey]Interface{},
+		byName:     map[string][]Interface{},
+		byExec:     map[string][]Interface{},
+		byService:  map[string][]Interface{},
+		byProtocol: map[string][]Interface{},
+		byPipe:     map[string][]Interface{},
+	}
+	var zero guid.GUID
+	for _, e := range entries {
+		if e.Name == "" {
+			return nil, fmt.Errorf("catalog: entry %s has an empty Name", e.UUID.ToFormatD())
+		}
+		if e.UUID == zero {
+			return nil, fmt.Errorf("catalog: entry %q has a zero UUID", e.Name)
+		}
+		k := verKey{e.UUID, e.Version.Major, e.Version.Minor}
+		if _, dup := db.byKey[k]; dup {
+			return nil, fmt.Errorf("catalog: duplicate entry for %s v%s", e.UUID.ToFormatD(), e.Version)
+		}
+		db.entries = append(db.entries, e)
+		db.byKey[k] = e
+		db.byUUID[e.UUID] = append(db.byUUID[e.UUID], e)
+		index(db.byName, e.Name, e)
+		index(db.byExec, e.Executable, e)
+		index(db.byService, e.Service, e)
+		index(db.byProtocol, e.Protocol, e)
+		for _, p := range e.Pipes {
+			index(db.byPipe, p, e)
+		}
+	}
+	// Keep each UUID's versions sorted so LookupUUID is deterministic and Resolve's
+	// fallback is the lowest known version.
+	for uuid := range db.byUUID {
+		sortInterfaces(db.byUUID[uuid])
+	}
+	return db, nil
+}
+
+// index appends e to m[lower(key)] when key is non-empty.
+func index(m map[string][]Interface, key string, e Interface) {
+	if key == "" {
+		return
+	}
+	lk := strings.ToLower(key)
+	m[lk] = append(m[lk], e)
+}
+
+// Lookup returns the entry for an exact (UUID, version), reporting whether it is
+// in the catalog.
+func (db *Database) Lookup(uuid guid.GUID, major, minor uint16) (Interface, bool) {
+	e, ok := db.byKey[verKey{uuid, major, minor}]
+	return e, ok
+}
+
+// Resolve labels a UUID/version seen on the wire: it returns the exact
+// (UUID, version) entry when present, otherwise falls back to any known version
+// of the same UUID (the lowest version, for determinism). ok is false only when
+// the UUID is entirely unknown. Use it to annotate ept_lookup results, where the
+// reported version may not be one the catalog enumerates explicitly.
+func (db *Database) Resolve(uuid guid.GUID, major, minor uint16) (Interface, bool) {
+	if e, ok := db.byKey[verKey{uuid, major, minor}]; ok {
+		return e, true
+	}
+	versions := db.byUUID[uuid]
+	if len(versions) == 0 {
+		return Interface{}, false
+	}
+	return versions[0], true
+}
+
+// LookupUUID returns every known version of a UUID, or nil if the UUID is
+// unknown. Results are sorted by version.
+func (db *Database) LookupUUID(uuid guid.GUID) []Interface {
+	return sortedCopy(db.byUUID[uuid])
+}
+
+// SearchByName returns the entries whose short Name matches (case-insensitive).
+func (db *Database) SearchByName(name string) []Interface { return db.exact(db.byName, name) }
+
+// SearchByExecutable returns the entries implemented by the given image
+// (case-insensitive), e.g. "spoolsv.exe".
+func (db *Database) SearchByExecutable(exe string) []Interface { return db.exact(db.byExec, exe) }
+
+// SearchByService returns the entries hosted by the given Windows service
+// (case-insensitive), e.g. "Spooler".
+func (db *Database) SearchByService(service string) []Interface {
+	return db.exact(db.byService, service)
+}
+
+// SearchByProtocol returns the entries for the given MS-* protocol document
+// (case-insensitive), e.g. "MS-RPRN".
+func (db *Database) SearchByProtocol(protocol string) []Interface {
+	return db.exact(db.byProtocol, protocol)
+}
+
+// SearchByPipe returns the entries reachable over the given named pipe
+// (case-insensitive), e.g. `\pipe\spoolss`.
+func (db *Database) SearchByPipe(pipe string) []Interface { return db.exact(db.byPipe, pipe) }
+
+// exact returns a sorted copy of the index bucket for the lower-cased key.
+func (db *Database) exact(idx map[string][]Interface, key string) []Interface {
+	return sortedCopy(idx[strings.ToLower(key)])
+}
+
+// Search returns every entry whose Name, Title, Description, Protocol,
+// Executable, Service, or one of its Pipes contains the given substring
+// (case-insensitive). An empty query matches nothing.
+func (db *Database) Search(substr string) []Interface {
+	if substr == "" {
+		return nil
+	}
+	q := strings.ToLower(substr)
+	var out []Interface
+	for _, e := range db.entries {
+		if entryContains(e, q) {
+			out = append(out, e)
+		}
+	}
+	return sortInterfaces(out)
+}
+
+// entryContains reports whether any text field of e contains the lower-cased q.
+func entryContains(e Interface, q string) bool {
+	fields := []string{e.Name, e.Title, e.Description, e.Protocol, e.Executable, e.Service}
+	fields = append(fields, e.Pipes...)
+	for _, f := range fields {
+		if f != "" && strings.Contains(strings.ToLower(f), q) {
+			return true
+		}
+	}
+	return false
+}
+
+// All returns every entry, sorted by name then version.
+func (db *Database) All() []Interface { return sortedCopy(db.entries) }
+
+// sortedCopy returns a sorted copy of in (never aliasing the caller's slice).
+func sortedCopy(in []Interface) []Interface {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]Interface, len(in))
+	copy(out, in)
+	return sortInterfaces(out)
+}
+
+// sortInterfaces sorts in place by Name, then UUID, then version, and returns it.
+func sortInterfaces(s []Interface) []Interface {
+	sort.Slice(s, func(i, j int) bool {
+		a, b := s[i], s[j]
+		if a.Name != b.Name {
+			return a.Name < b.Name
+		}
+		if a.UUID != b.UUID {
+			return a.UUID.ToFormatD() < b.UUID.ToFormatD()
+		}
+		if a.Version.Major != b.Version.Major {
+			return a.Version.Major < b.Version.Major
+		}
+		return a.Version.Minor < b.Version.Minor
+	})
+	return s
+}

--- a/network/dcerpc/interfaces/catalog/catalog_test.go
+++ b/network/dcerpc/interfaces/catalog/catalog_test.go
@@ -1,0 +1,145 @@
+package catalog
+
+import (
+	"testing"
+)
+
+// spoolssUUID / efsrUUID name a couple of seed entries used across tests.
+var (
+	spoolssUUID = mustGUID("12345678-1234-abcd-ef00-0123456789ab")
+	unknownUUID = mustGUID("00000000-0000-0000-0000-0000000000ff")
+)
+
+func TestDefault_BuildsAndIsConsistent(t *testing.T) {
+	db := Default() // panics if the seed table is malformed
+	all := db.All()
+	if len(all) == 0 {
+		t.Fatal("Default().All() is empty")
+	}
+	// Indexes must agree with the entry list.
+	for _, e := range all {
+		if got, ok := db.Lookup(e.UUID, e.Version.Major, e.Version.Minor); !ok || got.Name != e.Name {
+			t.Errorf("Lookup(%s v%s) = (%q, %v), want %q", e.UUID.ToFormatD(), e.Version, got.Name, ok, e.Name)
+		}
+	}
+	// All() is sorted by name.
+	for i := 1; i < len(all); i++ {
+		if all[i-1].Name > all[i].Name {
+			t.Errorf("All() not sorted: %q before %q", all[i-1].Name, all[i].Name)
+		}
+	}
+}
+
+func TestLookupExactAndMiss(t *testing.T) {
+	e, ok := Lookup(spoolssUUID, 1, 0)
+	if !ok {
+		t.Fatal("Lookup(spoolss v1.0) not found")
+	}
+	if e.Name != "spoolss" || e.Executable != "spoolsv.exe" || e.Service != "Spooler" || e.Protocol != "MS-RPRN" {
+		t.Errorf("spoolss entry = %+v", e)
+	}
+	if _, ok := Lookup(spoolssUUID, 9, 9); ok {
+		t.Error("Lookup(spoolss v9.9) found, want miss")
+	}
+	if _, ok := Lookup(unknownUUID, 0, 0); ok {
+		t.Error("Lookup(unknown) found, want miss")
+	}
+}
+
+func TestResolveFallback(t *testing.T) {
+	// Exact version present.
+	if e, ok := Resolve(spoolssUUID, 1, 0); !ok || e.Name != "spoolss" {
+		t.Errorf("Resolve exact = (%q, %v), want spoolss", e.Name, ok)
+	}
+	// Unknown version of a known UUID falls back to a known version.
+	if e, ok := Resolve(spoolssUUID, 7, 3); !ok || e.Name != "spoolss" {
+		t.Errorf("Resolve fallback = (%q, %v), want spoolss", e.Name, ok)
+	}
+	// Entirely unknown UUID.
+	if _, ok := Resolve(unknownUUID, 0, 0); ok {
+		t.Error("Resolve(unknown) ok = true, want false")
+	}
+}
+
+func TestSearchByFields(t *testing.T) {
+	if got := SearchByExecutable("SPOOLSV.EXE"); len(got) != 2 { // spoolss + IRemoteWinspool, case-insensitive
+		t.Errorf("SearchByExecutable(spoolsv.exe) = %d entries, want 2: %v", len(got), names(got))
+	}
+	if got := SearchByService("Spooler"); len(got) != 2 {
+		t.Errorf("SearchByService(Spooler) = %d, want 2: %v", len(got), names(got))
+	}
+	if got := SearchByProtocol("MS-EFSR"); len(got) != 2 { // two EFSR interface UUIDs
+		t.Errorf("SearchByProtocol(MS-EFSR) = %d, want 2: %v", len(got), names(got))
+	}
+	if got := SearchByName("efsrpc"); len(got) != 2 { // both EFSR entries share the name
+		t.Errorf("SearchByName(efsrpc) = %d, want 2: %v", len(got), names(got))
+	}
+	if got := SearchByPipe(`\pipe\spoolss`); len(got) != 2 {
+		t.Errorf("SearchByPipe(spoolss) = %d, want 2: %v", len(got), names(got))
+	}
+	if got := SearchByExecutable("nope.exe"); got != nil {
+		t.Errorf("SearchByExecutable(nope.exe) = %v, want nil", names(got))
+	}
+}
+
+func TestSearchSubstring(t *testing.T) {
+	got := Search("coercion") // spoolss, efsrpc (x2), FssagentRpc descriptions
+	if len(got) < 3 {
+		t.Errorf("Search(coercion) = %d entries, want >= 3: %v", len(got), names(got))
+	}
+	if Search("") != nil {
+		t.Error("Search(\"\") should match nothing")
+	}
+}
+
+func TestNewValidation(t *testing.T) {
+	good := mustGUID("11111111-1111-1111-1111-111111111111")
+
+	// Duplicate (UUID, version).
+	if _, err := New([]Interface{
+		{UUID: good, Version: v(1, 0), Name: "a"},
+		{UUID: good, Version: v(1, 0), Name: "b"},
+	}); err == nil {
+		t.Error("New with duplicate (UUID, version): err = nil, want error")
+	}
+	// Empty name.
+	if _, err := New([]Interface{{UUID: good, Version: v(1, 0)}}); err == nil {
+		t.Error("New with empty Name: err = nil, want error")
+	}
+	// Zero UUID.
+	if _, err := New([]Interface{{Version: v(1, 0), Name: "a"}}); err == nil {
+		t.Error("New with zero UUID: err = nil, want error")
+	}
+}
+
+func TestLookupUUIDMultiVersion(t *testing.T) {
+	u := mustGUID("22222222-2222-2222-2222-222222222222")
+	db, err := New([]Interface{
+		{UUID: u, Version: v(2, 0), Name: "iface"},
+		{UUID: u, Version: v(1, 0), Name: "iface"},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	got := db.LookupUUID(u)
+	if len(got) != 2 {
+		t.Fatalf("LookupUUID = %d versions, want 2", len(got))
+	}
+	// Sorted by version: 1.0 before 2.0.
+	if got[0].Version != (v(1, 0)) || got[1].Version != (v(2, 0)) {
+		t.Errorf("LookupUUID versions = %v, %v; want 1.0, 2.0", got[0].Version, got[1].Version)
+	}
+	// Resolve of an unlisted version falls back to the lowest.
+	if e, ok := db.Resolve(u, 5, 0); !ok || e.Version != v(1, 0) {
+		t.Errorf("Resolve fallback version = %v (ok=%v), want 1.0", e.Version, ok)
+	}
+}
+
+// names extracts entry names for readable failure messages.
+func names(in []Interface) []string {
+	out := make([]string, len(in))
+	for i, e := range in {
+		out[i] = e.Name + " v" + e.Version.String()
+	}
+	return out
+}

--- a/network/dcerpc/interfaces/catalog/data.go
+++ b/network/dcerpc/interfaces/catalog/data.go
@@ -1,0 +1,182 @@
+package catalog
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+)
+
+// mustGUID parses a hyphenated (format D) UUID, panicking on a malformed literal.
+// It keeps the seed table below readable and transcription-safe; a bad literal
+// fails the package's init/test rather than corrupting a lookup.
+func mustGUID(s string) guid.GUID {
+	g, err := guid.FromFormatD(s)
+	if err != nil {
+		panic(fmt.Sprintf("catalog: invalid UUID %q: %v", s, err))
+	}
+	return *g
+}
+
+// v is shorthand for an interface version.
+func v(major, minor uint16) Version { return Version{Major: major, Minor: minor} }
+
+// builtin is the curated catalog of well-known DCE/RPC interfaces. UUIDs are
+// taken from the MS-* protocol documents and cross-checked against impacket's
+// epm.py KNOWN_PROTOCOLS / KNOWN_UUIDS tables; Executable is the implementing
+// image (an .exe, or a .dll loaded into svchost.exe / lsass.exe). Fields that
+// are not well-established are left empty rather than guessed.
+var builtin = []Interface{
+	// --- interfaces with a client implementation in this repo ---
+	{
+		UUID: mustGUID("12345778-1234-abcd-ef00-0123456789ab"), Version: v(0, 0),
+		Name: "lsarpc", Title: "Local Security Authority (domain policy)",
+		Description: "LSA policy and translation (also MS-LSAT, MS-DSSP).",
+		Executable:  "lsasrv.dll", Protocol: "MS-LSAD", Pipes: []string{`\pipe\lsarpc`},
+	},
+	{
+		UUID: mustGUID("12345778-1234-abcd-ef00-0123456789ac"), Version: v(1, 0),
+		Name: "samr", Title: "Security Account Manager",
+		Description: "Remote SAM database access (users, groups, domains).",
+		Executable:  "samsrv.dll", Protocol: "MS-SAMR", Pipes: []string{`\pipe\samr`},
+	},
+	{
+		UUID: mustGUID("338cd001-2244-31f1-aaaa-900038001003"), Version: v(1, 0),
+		Name: "winreg", Title: "Windows Remote Registry",
+		Description: "Remote registry query and manipulation.",
+		Executable:  "regsvc.dll", Service: "RemoteRegistry", Protocol: "MS-RRP", Pipes: []string{`\pipe\winreg`},
+	},
+	{
+		UUID: mustGUID("367abb81-9844-35f1-ad32-98f038001003"), Version: v(2, 0),
+		Name: "svcctl", Title: "Service Control Manager",
+		Description: "Remote creation/control of Windows services.",
+		Executable:  "services.exe", Protocol: "MS-SCMR", Pipes: []string{`\pipe\svcctl`},
+	},
+	{
+		UUID: mustGUID("4b324fc8-1670-01d3-1278-5a47bf6ee188"), Version: v(3, 0),
+		Name: "srvsvc", Title: "Server Service",
+		Description: "Server service (shares, sessions, files).",
+		Executable:  "srvsvc.dll", Service: "LanmanServer", Protocol: "MS-SRVS", Pipes: []string{`\pipe\srvsvc`},
+	},
+	{
+		UUID: mustGUID("c681d488-d850-11d0-8c52-00c04fd90f7e"), Version: v(1, 0),
+		Name: "efsrpc", Title: "Encrypting File System Remote",
+		Description: "EFSRPC; abused for coercion (PetitPotam).",
+		Executable:  "efslsaext.dll", Protocol: "MS-EFSR", Pipes: []string{`\pipe\efsrpc`, `\pipe\lsarpc`},
+	},
+	{
+		UUID: mustGUID("e1af8308-5d1f-11c9-91a4-08002b14a0fa"), Version: v(3, 0),
+		Name: "epm", Title: "Endpoint Mapper",
+		Description: "Maps interface UUIDs to transport endpoints (port 135).",
+		Executable:  "rpcss.dll", Service: "RpcEptMapper", Protocol: "C706", Pipes: []string{`\pipe\epmapper`},
+	},
+
+	// --- other well-known interfaces ---
+	{
+		UUID: mustGUID("12345678-1234-abcd-ef00-0123456789ab"), Version: v(1, 0),
+		Name: "spoolss", Title: "Print System Remote Protocol",
+		Description: "Print spooler; abused for coercion (PrinterBug).",
+		Executable:  "spoolsv.exe", Service: "Spooler", Protocol: "MS-RPRN", Pipes: []string{`\pipe\spoolss`},
+	},
+	{
+		UUID: mustGUID("76f03f96-cdfd-44fc-a22c-64950a001209"), Version: v(1, 0),
+		Name: "IRemoteWinspool", Title: "Print System Asynchronous Remote Protocol",
+		Description: "Asynchronous print spooler interface.",
+		Executable:  "spoolsv.exe", Service: "Spooler", Protocol: "MS-PAR", Pipes: []string{`\pipe\spoolss`},
+	},
+	{
+		UUID: mustGUID("12345678-1234-abcd-ef00-01234567cffb"), Version: v(1, 0),
+		Name: "netlogon", Title: "Netlogon Remote Protocol",
+		Description: "Domain authentication; abused via Zerologon.",
+		Executable:  "netlogon.dll", Service: "Netlogon", Protocol: "MS-NRPC", Pipes: []string{`\pipe\netlogon`},
+	},
+	{
+		UUID: mustGUID("e3514235-4b06-11d1-ab04-00c04fc2dcd2"), Version: v(4, 0),
+		Name: "drsuapi", Title: "Directory Replication Service",
+		Description: "Active Directory replication (DCSync).",
+		Executable:  "ntdsai.dll", Service: "NTDS", Protocol: "MS-DRSR",
+	},
+	{
+		UUID: mustGUID("6bffd098-a112-3610-9833-46c3f87e345a"), Version: v(1, 0),
+		Name: "wkssvc", Title: "Workstation Service",
+		Description: "Workstation service (sessions, domain join).",
+		Executable:  "wkssvc.dll", Service: "LanmanWorkstation", Protocol: "MS-WKST", Pipes: []string{`\pipe\wkssvc`},
+	},
+	{
+		UUID: mustGUID("1ff70682-0a51-30e8-076d-740be8cee98b"), Version: v(1, 0),
+		Name: "atsvc", Title: "Task Scheduler (ATSvc)",
+		Description: "Legacy 'at' job scheduling.",
+		Executable:  "schedsvc.dll", Service: "Schedule", Protocol: "MS-TSCH", Pipes: []string{`\pipe\atsvc`},
+	},
+	{
+		UUID: mustGUID("86d35949-83c9-4044-b424-db363231fd0c"), Version: v(1, 0),
+		Name: "ITaskSchedulerService", Title: "Task Scheduler Service",
+		Description: "Modern task scheduler remoting.",
+		Executable:  "schedsvc.dll", Service: "Schedule", Protocol: "MS-TSCH",
+	},
+	{
+		UUID: mustGUID("82273fdc-e32a-18c3-3f78-827929dc23ea"), Version: v(0, 0),
+		Name: "eventlog", Title: "EventLog Remoting Protocol",
+		Description: "Classic event log access.",
+		Executable:  "wevtsvc.dll", Service: "EventLog", Protocol: "MS-EVEN", Pipes: []string{`\pipe\eventlog`},
+	},
+	{
+		UUID: mustGUID("f6beaff7-1e19-4fbb-9f8f-b89e2018337c"), Version: v(1, 0),
+		Name: "IEventService", Title: "EventLog Remoting Protocol v6",
+		Description: "Modern event log access.",
+		Executable:  "wevtsvc.dll", Service: "EventLog", Protocol: "MS-EVEN6",
+	},
+	{
+		UUID: mustGUID("afa8bd80-7d8a-11c9-bef4-08002b102989"), Version: v(1, 0),
+		Name: "mgmt", Title: "Remote Management",
+		Description: "DCE/RPC management interface (inq_if_ids, etc.).",
+		Executable:  "rpcss.dll", Service: "RpcSs", Protocol: "C706",
+	},
+	{
+		UUID: mustGUID("99fcfec4-5260-101b-bbcb-00aa0021347a"), Version: v(0, 0),
+		Name: "IObjectExporter", Title: "DCOM OXID Resolver",
+		Description: "DCOM object exporter / OXID resolution (port 135).",
+		Executable:  "rpcss.dll", Service: "RpcSs", Protocol: "MS-DCOM",
+	},
+	{
+		UUID: mustGUID("000001a0-0000-0000-c000-000000000046"), Version: v(0, 0),
+		Name: "ISystemActivator", Title: "DCOM Remote Activation",
+		Description: "DCOM remote object activation.",
+		Executable:  "rpcss.dll", Service: "RpcSs", Protocol: "MS-DCOM",
+	},
+	{
+		UUID: mustGUID("4d9f4ab8-7d1c-11cf-861e-0020af6e7c57"), Version: v(0, 0),
+		Name: "IActivation", Title: "DCOM Activation (legacy)",
+		Description: "Legacy DCOM activation interface.",
+		Executable:  "rpcss.dll", Service: "RpcSs", Protocol: "MS-DCOM",
+	},
+	{
+		UUID: mustGUID("f309ad18-d86a-11d0-a075-00c04fb68820"), Version: v(0, 0),
+		Name: "IWbemLevel1Login", Title: "Windows Management Instrumentation",
+		Description: "WMI remoting login interface (over DCOM).",
+		Service: "Winmgmt", Protocol: "MS-WMI",
+	},
+	{
+		UUID: mustGUID("50abc2a4-574d-40b3-9d66-ee4fd5fba076"), Version: v(5, 0),
+		Name: "dnsserver", Title: "DNS Server Management",
+		Description: "Remote DNS server administration.",
+		Executable:  "dns.exe", Service: "DNS", Protocol: "MS-DNSP",
+	},
+	{
+		UUID: mustGUID("a8e0653c-2744-4389-a61d-7373df8b2292"), Version: v(1, 0),
+		Name: "FssagentRpc", Title: "File Server Remote VSS",
+		Description: "File Server VSS agent; abused for coercion.",
+		Service: "FileServerVssAgent", Protocol: "MS-FSRVP", Pipes: []string{`\pipe\FssagentRpc`},
+	},
+	{
+		UUID: mustGUID("3919286a-b10c-11d0-9ba8-00c04fd92ef5"), Version: v(0, 0),
+		Name: "dssetup", Title: "Directory Services Setup",
+		Description: "Domain/role information (DsRoleGetPrimaryDomainInformation).",
+		Executable:  "lsasrv.dll", Protocol: "MS-DSSP", Pipes: []string{`\pipe\lsarpc`},
+	},
+	{
+		UUID: mustGUID("df1941c5-fe89-4e79-bf10-463657acf44d"), Version: v(1, 0),
+		Name: "efsrpc", Title: "Encrypting File System Remote (lsarpc binding)",
+		Description: "Alternate EFSRPC interface UUID over \\pipe\\lsarpc.",
+		Executable:  "efslsaext.dll", Protocol: "MS-EFSR", Pipes: []string{`\pipe\lsarpc`},
+	},
+}

--- a/network/dcerpc/interfaces/catalog/default.go
+++ b/network/dcerpc/interfaces/catalog/default.go
@@ -1,0 +1,60 @@
+package catalog
+
+import (
+	"sync"
+
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+)
+
+// defaultDB is the built-in catalog, constructed once from the builtin seed.
+var (
+	defaultOnce sync.Once
+	defaultDB   *Database
+)
+
+// Default returns the built-in catalog of well-known interfaces. It panics if
+// the seed table is malformed (a programmer error caught by the package tests).
+func Default() *Database {
+	defaultOnce.Do(func() {
+		db, err := New(builtin)
+		if err != nil {
+			panic("catalog: invalid built-in data: " + err.Error())
+		}
+		defaultDB = db
+	})
+	return defaultDB
+}
+
+// Lookup is Default().Lookup.
+func Lookup(uuid guid.GUID, major, minor uint16) (Interface, bool) {
+	return Default().Lookup(uuid, major, minor)
+}
+
+// Resolve is Default().Resolve.
+func Resolve(uuid guid.GUID, major, minor uint16) (Interface, bool) {
+	return Default().Resolve(uuid, major, minor)
+}
+
+// LookupUUID is Default().LookupUUID.
+func LookupUUID(uuid guid.GUID) []Interface { return Default().LookupUUID(uuid) }
+
+// SearchByName is Default().SearchByName.
+func SearchByName(name string) []Interface { return Default().SearchByName(name) }
+
+// SearchByExecutable is Default().SearchByExecutable.
+func SearchByExecutable(exe string) []Interface { return Default().SearchByExecutable(exe) }
+
+// SearchByService is Default().SearchByService.
+func SearchByService(service string) []Interface { return Default().SearchByService(service) }
+
+// SearchByProtocol is Default().SearchByProtocol.
+func SearchByProtocol(protocol string) []Interface { return Default().SearchByProtocol(protocol) }
+
+// SearchByPipe is Default().SearchByPipe.
+func SearchByPipe(pipe string) []Interface { return Default().SearchByPipe(pipe) }
+
+// Search is Default().Search.
+func Search(substr string) []Interface { return Default().Search(substr) }
+
+// All is Default().All.
+func All() []Interface { return Default().All() }


### PR DESCRIPTION
### Summary
`ept_lookup`/`ept_map` return raw interface UUIDs and versions, which mean nothing to an operator. This adds `network/dcerpc/interfaces/catalog`, a database mapping a UUID (and version) to human metadata so tooling can label endpoints, e.g. `12345678-1234-abcd-ef00-0123456789ab v1.0` → **spoolss**, MS-RPRN, `spoolsv.exe`, *Spooler* service.

It's a pure data table, independent of which interfaces have a client implementation in the repo.

### Data model
```go
type Interface struct {
    UUID        guid.GUID
    Version     Version  // {Major, Minor}
    Name        string   // "spoolss"
    Title       string   // "Print System Remote Protocol"
    Description string
    Executable  string   // implementing image: "spoolsv.exe" / "srvsvc.dll"
    Service     string   // hosting Windows service: "Spooler"
    Protocol    string   // "MS-RPRN"
    Pipes       []string // [`\pipe\spoolss`]
}
```
Per the API review: the implementing-image field is **`Executable`** (covers `.exe` and `.dll`), split from the **`Service`** name; no `Aliases`.

### API
A `Database` type indexes entries; package-level helpers operate on a built-in `Default()` catalog:
- `Lookup(uuid, major, minor)` — exact `(UUID, version)` → one entry.
- `Resolve(uuid, major, minor)` — exact, else fall back to a known version of the UUID (best-effort labeling of `ept_lookup` output).
- `LookupUUID(uuid)` — all known versions (the "return a list" case), sorted.
- `SearchByName` / `SearchByExecutable` / `SearchByService` / `SearchByProtocol` / `SearchByPipe` — exact, case-insensitive, one per field.
- `Search(substr)` — substring across all text fields.
- `All()` — the whole catalog, sorted.

`New([]Interface)` builds a custom database and **validates** the table (no empty `Name`, no zero UUID, no duplicate `(UUID, version)`); `Default()` builds the seed through `New` and panics on a malformed table (caught by tests).

### Seed data
The 7 implemented interfaces (lsarpc, samr, winreg, svcctl, srvsvc, efsr, epm) plus the high-value recon/security set: spoolss, IRemoteWinspool (MS-PAR), netlogon, drsuapi, wkssvc, atsvc + ITaskSchedulerService, eventlog + IEventService, mgmt, IObjectExporter/ISystemActivator/IActivation (DCOM), IWbemLevel1Login (WMI), dnsserver, FssagentRpc (FSRVP), dssetup, and the alternate EFSR UUID. UUIDs are written as readable strings via `mustGUID` and sourced from the MS-* docs and impacket's `epm.py` `KNOWN_PROTOCOLS`/`KNOWN_UUIDS`. Fields that aren't well-established are left empty rather than guessed.

### How Verified
- `go test ./network/dcerpc/interfaces/catalog/` — all pass; `go build ./...`, `go vet` clean.
- Tests cover: built-in integrity (indexes agree with entries, sorted), exact `Lookup` hit/miss, `Resolve` version fallback, every `SearchBy*` (incl. case-insensitivity and the two EFSR/`MS-EFSR` entries), `Search` substring, `New` validation (duplicate/empty-name/zero-UUID), and multi-version `LookupUUID`/`Resolve` via a custom `New`.

### Scope of Change
- **Files (new):** `network/dcerpc/interfaces/catalog/{catalog,default,data,catalog_test}.go`.
- **Submodule pointer updated:** no.
- **Behavioral changes outside the feature:** none — purely additive new package.

### Notes
A future `msrpc dump` becomes: `ept_lookup` → `catalog.Resolve(uuid, maj, min)` → print `binding  name (protocol)  [executable]`. The seed is intentionally curated (~26 entries); it can be extended toward the full impacket list later without API changes.
