### PR TITLE
Fix EPM ept_lookup and ept_map inline conformant-varying array decoding (#631, #633)

### DIFF
--- a/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/functions/02_EptLookup.go
+++ b/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/functions/02_EptLookup.go
@@ -26,13 +26,22 @@ type eptLookupRequest struct {
 func (*eptLookupRequest) Opnum() uint16 { return epm.OpnumEptLookup }
 
 // eptLookupResponse carries the [out] parameters of ept_lookup: the advanced context
-// handle, the number of entries returned, the entries themselves (a full pointer to a
-// conformant-varying array of ept_entry_t — size_is(max_ents), length_is(num_ents)), and
-// the status.
+// handle, the number of entries returned, the entries themselves, and the status.
+//
+// In the IDL ([C706] Appendix O; [MS-RPCE] 2.2.1.2.4) entries is a bare, non-pointer,
+// top-level conformant-varying array:
+//
+//	[out, length_is(*num_ents), size_is(max_ents)] ept_entry_t entries[]
+//
+// Its conformance (maximum_count) is therefore transmitted inline, immediately before the
+// array (right after num_ents), with no referent id and no hoisting to the front of the
+// parameter structure. The "inline" tag selects exactly that framing; "varying" supplies
+// the offset/actual_count words. (ept_map's ITowers is "ptr,..." because its element type
+// twr_p_t is a pointer; ept_entry_t is not, so entries[] is not pointer-prefixed.)
 type eptLookupResponse struct {
 	EntryHandle structures.ContextHandle
 	NumEnts     ndr.DWORD
-	Entries     []structures.EptEntry `ndr:"ptr,varying"`
+	Entries     []structures.EptEntry `ndr:"varying,inline"`
 	Status      ndr.DWORD
 }
 

--- a/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/functions/03_EptMap.go
+++ b/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/functions/03_EptMap.go
@@ -22,13 +22,24 @@ type eptMapRequest struct {
 
 func (*eptMapRequest) Opnum() uint16 { return epm.OpnumEptMap }
 
-// eptMapResponse carries the [out] parameters of ept_map: the (advanced) context
-// handle, the number of towers returned, the towers themselves (a full pointer to a
-// conformant-varying array of full pointers to twr_t), and the status.
+// eptMapResponse carries the [out] parameters of ept_map: the (advanced) context handle,
+// the number of towers returned, the towers themselves, and the status.
+//
+// In the IDL ([C706] Appendix O; [MS-RPCE] 2.2.1.2.5) ITowers is a bare, non-pointer,
+// top-level conformant-varying array of full pointers to twr_t:
+//
+//	[out, length_is(*num_towers), size_is(max_towers)] twr_p_t ITowers[]
+//
+// The array itself is not pointer-prefixed — only its elements (twr_p_t) are pointers. So
+// its conformance (maximum_count) is transmitted inline, immediately after num_towers,
+// with no referent id and without being hoisted to the front of the parameter structure;
+// each element then carries its own referent id with the twr_t body deferred. The "inline"
+// tag selects that framing, "varying" supplies the offset/actual_count words, and
+// "elem=ptr" makes the elements full pointers.
 type eptMapResponse struct {
 	EntryHandle structures.ContextHandle
 	NumTowers   ndr.DWORD
-	ITowers     []*structures.Twr `ndr:"ptr,varying,elem=ptr"`
+	ITowers     []*structures.Twr `ndr:"varying,inline,elem=ptr"`
 	Status      ndr.DWORD
 }
 

--- a/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/functions/functions_test.go
+++ b/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/functions/functions_test.go
@@ -10,7 +10,6 @@ import (
 	epm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/functions"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/structures"
-	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/pdu"
@@ -198,28 +197,63 @@ func TestEptMap_StatusError(t *testing.T) {
 
 // --- ept_lookup ---
 
-// lookupRespMirror mirrors the [out] layout of ept_lookup's response so a test can build a
-// wire stub by marshalling it through the real NDR codec (the production response type is
-// unexported). Same field types/tags => the production decoder reads it back identically.
-type lookupRespMirror struct {
-	EntryHandle structures.ContextHandle
-	NumEnts     uint32
-	Entries     []structures.EptEntry `ndr:"ptr,varying"`
-	Status      uint32
-}
-
-// eptLookupStub marshals one ept_lookup response (entry handle, entries, status).
+// eptLookupStub hand-assembles the [out] NDR stub of an ept_lookup call, octet by octet,
+// to pin the real wire layout independently of the production codec (mirroring
+// eptMapResponseStub). The layout per [C706] Appendix O / [MS-RPCE] 2.2.1.2.4 is:
+//
+//	entry_handle(20) | num_ents | max_count | offset | actual_count |
+//	  per entry: object uuid(16) | tower referent id(4) | annotation(varying char array)
+//	  per entry: tower body (hoisted max_count | tower_length | octet string | pad to 4)
+//	| status
+//
+// entries[] is a bare, non-pointer, top-level conformant-varying array, so its
+// maximum_count is written inline right after num_ents (no referent id, no hoisting). The
+// tower referent bodies are deferred to after every entry's inline part. max_count is set
+// to a value larger than actual_count (as a real server echoing the requested max_ents
+// does) so the test also pins that the decoder sizes the result from actual_count, not
+// max_count.
 func eptLookupStub(t *testing.T, handle structures.ContextHandle, status uint32, entries []structures.EptEntry) []byte {
 	t.Helper()
-	b, err := ndr.Marshal(&lookupRespMirror{
-		EntryHandle: handle,
-		NumEnts:     uint32(len(entries)),
-		Entries:     entries,
-		Status:      status,
-	})
-	if err != nil {
-		t.Fatalf("marshal lookup response: %v", err)
+	var b []byte
+	b = append(b, handle[:]...)           // entry_handle (20 octets)
+	b = le32(b, uint32(len(entries)))     // num_ents
+	b = le32(b, functions.DefaultMaxEnts) // array maximum_count (size_is = max_ents) — inline, no referent id
+	b = le32(b, 0)                        // array offset
+	b = le32(b, uint32(len(entries)))     // array actual_count (length_is = num_ents)
+
+	// Element inline parts, in order: object uuid, tower referent id, annotation.
+	refid := uint32(0x00020000)
+	for _, e := range entries {
+		b = append(b, e.Object.Octets[:]...) // uuid_t object (16 octets)
+		if e.Tower != nil {
+			b = le32(b, refid) // twr_p_t referent id (non-null)
+			refid += 4
+		} else {
+			b = le32(b, 0) // null tower pointer
+		}
+		// [string] char annotation[]: a varying char array — offset, actual_count
+		// (characters including the NUL terminator), the bytes, the terminator.
+		ann := string(e.Annotation)
+		b = le32(b, 0)
+		b = le32(b, uint32(len(ann)+1))
+		b = append(b, []byte(ann)...)
+		b = append(b, 0)
+		b = pad4(b) // the next element / the deferred section aligns to 4
 	}
+
+	// Deferred twr_t referent bodies, in element order.
+	for _, e := range entries {
+		if e.Tower == nil {
+			continue
+		}
+		tw := e.Tower.TowerOctetString
+		b = le32(b, uint32(len(tw))) // hoisted maximum_count (size_is(tower_length))
+		b = le32(b, uint32(len(tw))) // tower_length
+		b = append(b, tw...)
+		b = pad4(b)
+	}
+
+	b = le32(b, status) // status
 	return b
 }
 

--- a/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/functions/functions_test.go
+++ b/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/functions/functions_test.go
@@ -91,21 +91,25 @@ func pad4(b []byte) []byte {
 	return b
 }
 
-// eptMapResponseStub assembles the [out] NDR stub of an ept_map call that returns a
-// single tower resolving to the given TCP endpoint. The layout is: 20-octet context
-// handle, num_towers, the ITowers full pointer, the conformant-varying array header,
-// one element referent, the twr_t body, then the status.
+// eptMapResponseStub assembles the [out] NDR stub of an ept_map call that returns a single
+// tower resolving to the given TCP endpoint, octet by octet, to pin the real wire layout
+// (verified live against 192.168.1.31, NDR20). ITowers is a bare, non-pointer, top-level
+// conformant-varying array of twr_p_t ([C706] Appendix O; [MS-RPCE] 2.2.1.2.5), so its
+// maximum_count is written inline right after num_towers — there is NO array referent id
+// and no hoisting. The layout is: 20-octet context handle, num_towers, the inline
+// conformant-varying header (max_count, offset, actual_count), one element referent id,
+// the twr_t body, then the status. max_count is set larger than actual_count (as a server
+// echoing the requested max_towers does) to pin that the decoder sizes from actual_count.
 func eptMapResponseStub(tower structures.Tower, maxTowers uint32) []byte {
 	towerBytes := tower.Marshal()
 
 	var b []byte
 	b = append(b, make([]byte, structures.ContextHandleSize)...) // entry_handle
 	b = le32(b, 1)                                               // num_towers
-	b = le32(b, 0x00020000)                                      // ITowers referent id (non-null)
-	b = le32(b, maxTowers)                                       // array maximum_count (size_is)
+	b = le32(b, maxTowers)                                       // array maximum_count (size_is) — inline, no referent id
 	b = le32(b, 0)                                               // array offset
 	b = le32(b, 1)                                               // array actual_count (length_is)
-	b = le32(b, 0x00020004)                                      // element[0] referent id (non-null)
+	b = le32(b, 0x00020004)                                      // element[0] twr_p_t referent id (non-null)
 	// twr_t body: hoisted maximum_count, tower_length, octet string, pad to 4.
 	b = le32(b, uint32(len(towerBytes)))
 	b = le32(b, uint32(len(towerBytes)))

--- a/network/dcerpc/ndr/marshal.go
+++ b/network/dcerpc/ndr/marshal.go
@@ -785,7 +785,15 @@ func isUintKind(k reflect.Kind) bool {
 func isEmbeddedConformantArray(fv reflect.Value, tag fieldTag) bool {
 	// A pipe is a chunked stream, not a conformant array, so its count must not be
 	// hoisted to the front of the enclosing struct ([C706] 14.7).
-	return fv.Kind() == reflect.Slice && !tag.pipe && !isPointerLike(fv, tag)
+	//
+	// An "inline"-tagged slice is a top-level conformant[-varying] array whose
+	// maximum_count is transmitted in place, immediately before the array, rather than
+	// hoisted to the front of the enclosing struct. This is the form of a bare,
+	// non-pointer, top-level [out] array parameter such as ept_lookup's entries[]
+	// ([C706] Appendix O; [MS-RPCE] 2.2.1.2.4) — the structure-embedded hoist rule
+	// ([MS-RPCE] "Structure Containing a Conformant Varying Array") does not apply, so it
+	// must not be treated as an embedded conformant array.
+	return fv.Kind() == reflect.Slice && !tag.pipe && !tag.inline && !isPointerLike(fv, tag)
 }
 
 // ndrAlignment returns the NDR alignment, in octets, of a value of type t under the

--- a/network/dcerpc/ndr/types.go
+++ b/network/dcerpc/ndr/types.go
@@ -100,6 +100,7 @@ type fieldTag struct {
 	ascii          bool    // [string] ASCII
 	conformant     bool    // conformant array (size_is)
 	varying        bool    // conformant-varying array (offset + actual_count framing)
+	inline         bool    // top-level conformant array whose maximum_count is transmitted in place, not hoisted to the struct front
 	sizeIs         string  // sibling field naming the maximum element count
 	lengthIs       string  // sibling field naming the actual element count
 	sizeDiv        int     // divisor applied to the size_is sibling (size_is(Field/N)); 0 = none
@@ -150,6 +151,8 @@ func parseTag(raw string) fieldTag {
 			t.conformant = true
 		case opt == "varying":
 			t.varying = true
+		case opt == "inline":
+			t.inline = true
 		case opt == "retval":
 			t.retval = true
 		case strings.HasPrefix(opt, "size_is="):

--- a/network/dcerpc/ndr/varying_arrays_test.go
+++ b/network/dcerpc/ndr/varying_arrays_test.go
@@ -67,3 +67,88 @@ func TestEmbeddedConformantVaryingArray(t *testing.T) {
 		t.Errorf("round trip: got %+v want %+v", out, in)
 	}
 }
+
+// TestInlineConformantVaryingArray_PinsRealWire guards the "inline" tag against the
+// circular-test blind spot that hid the EPM ept_lookup/ept_map decode bug (#631, #633).
+//
+// The blind spot: a test that builds its fixture by marshalling through the codec and then
+// unmarshalling with the SAME tag agrees with itself no matter whether the tag matches the
+// real wire — so it cannot catch a bare top-level array wrongly modelled as a pointer.
+// This test sidesteps that by decoding hand-built octets laid out exactly as a server
+// sends them (the conformance count inline, no referent id, not hoisted) and then asserting
+// that the *pointer* tagging — the historical bug — cannot read those same octets. A pure
+// round-trip could not tell the two tags apart; these ground-truth bytes can.
+func TestInlineConformantVaryingArray_PinsRealWire(t *testing.T) {
+	// A bare, non-pointer, top-level conformant-varying array parameter: count words inline,
+	// no referent id, not hoisted to the struct front. Mirrors ept_lookup's
+	// `[out, size_is(max_ents), length_is(*num_ents)] ept_entry_t entries[]`.
+	type correct struct {
+		Count   uint32
+		Entries []uint32 `ndr:"varying,inline"`
+		Status  uint32
+	}
+	// The historical defect: the same array modelled as a pointer-prefixed array.
+	type buggy struct {
+		Count   uint32
+		Entries []uint32 `ndr:"ptr,varying"`
+		Status  uint32
+	}
+
+	// Ground-truth wire bytes, authored by hand rather than by the encoder:
+	//   Count | max_count | offset | actual_count | Entries[0] | Entries[1] | Status
+	// max_count (5) is deliberately larger than actual_count (2) — as a real server echoing
+	// its size_is cap does — so the test also pins that the decoder sizes the result from
+	// actual_count, not max_count.
+	wire := []byte{
+		0x02, 0, 0, 0, // Count = 2
+		0x05, 0, 0, 0, // max_count = 5 (inline conformance, NOT a referent id)
+		0x00, 0, 0, 0, // offset = 0
+		0x02, 0, 0, 0, // actual_count = 2
+		0xAA, 0, 0, 0, // Entries[0]
+		0xBB, 0, 0, 0, // Entries[1]
+		0x0D, 0xA0, 0xC9, 0x16, // Status = 0x16C9A00D
+	}
+
+	var ok correct
+	if err := Unmarshal(wire, &ok); err != nil {
+		t.Fatalf("inline decode of the real wire layout failed: %v", err)
+	}
+	if ok.Count != 2 {
+		t.Errorf("Count = %d, want 2 (max_count must NOT be hoisted ahead of Count)", ok.Count)
+	}
+	if ok.Status != 0x16C9A00D {
+		t.Errorf("Status = 0x%08x, want 0x16C9A00D", ok.Status)
+	}
+	if !reflect.DeepEqual(ok.Entries, []uint32{0xAA, 0xBB}) {
+		t.Errorf("Entries = %v, want [0xAA 0xBB] (sized from actual_count, not max_count)", ok.Entries)
+	}
+
+	// The blind-spot guard: the pointer tagging consumes max_count(5) as a referent id and
+	// then misreads the count words, so it CANNOT reproduce the correct decode of the real
+	// wire. If it could, the bytes would not discriminate the two tags and no round-trip
+	// test could ever have caught the bug.
+	var bad buggy
+	if err := Unmarshal(wire, &bad); err == nil && reflect.DeepEqual(bad.Entries, []uint32{0xAA, 0xBB}) && bad.Count == 2 && bad.Status == 0x16C9A00D {
+		t.Fatal("pointer tagging decoded the inline wire layout correctly; the wire bytes do " +
+			"not distinguish ptr from inline, so a codec round-trip could not catch this bug")
+	}
+
+	// The encoder must be symmetric with the inline layout: no referent id, the conformance
+	// count emitted in place. (Re-encoding writes max_count = len, hence 2 here.)
+	got, err := Marshal(&ok)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	want := []byte{
+		0x02, 0, 0, 0, // Count
+		0x02, 0, 0, 0, // max_count = len (inline, no referent id)
+		0x00, 0, 0, 0, // offset
+		0x02, 0, 0, 0, // actual_count
+		0xAA, 0, 0, 0, // Entries[0]
+		0xBB, 0, 0, 0, // Entries[1]
+		0x0D, 0xA0, 0xC9, 0x16, // Status
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("inline encode:\n got %x\nwant %x", got, want)
+	}
+}


### PR DESCRIPTION
### Linked Issues
`Closes #631` (ept_lookup) and `Closes #633` (ept_map)

Both are the same root-cause defect class, fixed by one shared codec addition (the `inline` NDR tag) applied to two call sites. #631's body explicitly asked to also re-verify `ept_map` against a real server — doing so surfaced #633.

### Root Cause
Both `ept_lookup` (opnum 2) and `ept_map` (opnum 3) declare their primary `[out]` array as a **bare, non-pointer, top-level conformant-varying array** ([C706] Appendix O; [MS-RPCE] 2.2.1.2.4 / 2.2.1.2.5):

```
ept_lookup: [out, length_is(*num_ents),   size_is(max_ents)]   ept_entry_t entries[]
ept_map:    [out, length_is(*num_towers),  size_is(max_towers)] twr_p_t     ITowers[]
```

For such a parameter NDR transmits the `maximum_count` **inline**, immediately before the array, with **no referent id** and **without hoisting** it to the front of the parameter struct (the [MS-RPCE] "Structure Containing a Conformant Varying Array" hoist rule applies only to arrays embedded in a *structure*, not to a top-level array parameter). The MS-RPCE redefinitions add the `ptr` attribute only to the `[in]` `object`/`Ifid` parameters — neither `[out]` array is a pointer.

Both fields were tagged `ndr:"ptr,..."`, so the decoder consumed the inline `maximum_count` as a referent id and then read the `offset`/`actual_count` words one slot early, landing `actual_count` on real payload (`entries[0].object[0:4]` = 1985123514 for ept_lookup; the status word `0x16C9A0D6` = 382312662 for ept_map) — the bogus element counts seen live.

### Fix Description
Add an opt-in `inline` NDR struct tag that marks a top-level conformant[-varying] array whose conformance is transmitted in place rather than hoisted. `isEmbeddedConformantArray` now excludes `inline`-tagged fields, so they flow through the existing inline conformant-varying codec path (`marshal`/`unmarshalConformantVaryingArray`), which already performs correct per-element pointer-referent deferral. Retag:
- `eptLookupResponse.Entries` → `ndr:"varying,inline"`
- `eptMapResponse.ITowers` → `ndr:"varying,inline,elem=ptr"` (elements remain `twr_p_t` full pointers)

Chosen over a custom `ndr.Marshaler` array type in the EPM `structures` package, which would have to re-implement element-referent deferral (each element carries a deferred `twr_t` body) and duplicate codec logic. The codec change is opt-in and backward compatible: fields without the tag behave exactly as before, and the full `network/dcerpc/...` suite passes.

### How Verified
- **Runtime (live server 192.168.1.31, Windows Server 2016, NDR20):**
  - *ept_lookup*: before, failed with `element count 1985123514 exceeds … remaining bytes`; after, a full enumeration returns **546 entries** that decode cleanly (entry [0] → `ncacn_ip_tcp:192.168.1.31[49664]`, `ncacn_np:\\TMP-W-2016[\PIPE\InitShutdown]`).
  - *ept_map*: before, failed with `element count 382312662 exceeds 0 remaining bytes`; after, mapping enumerated interfaces resolves real towers, e.g. `a500d4c6-…` → `192.168.1.31:49665`, `fb9a3757-…` → `192.168.1.31:49668`. The raw 40-octet not-registered response also confirms the inline layout exactly: `… num_towers=0 | max_count=4 | offset=0 | actual_count=0 | status=0x16C9A0D6`.
- **Tests:** `go test ./network/dcerpc/...` passes.
- **Spec cross-check:** [MS-RPCE] 2.2.1.2.4 / 2.2.1.2.5 and [C706] Appendix O confirm both arrays are bare (non-pointer) with `size_is`/`length_is`; [MS-RPCE] "Conformant Varying Arrays" confirms the inline `maximum_count, offset, actual_count` framing.

### Test Coverage
- **Changed:** `eptLookupStub` was rewritten from a codec round-trip mirror (which encoded and decoded with the same buggy tags and so could never detect a wire mismatch) to a hand-assembled octet stub that pins the real wire layout. `eptMapResponseStub` was corrected to drop the phantom leading ITowers referent id it had previously hand-built (the reason the old test passed against buggy code). Both set `max_count` larger than `actual_count` to also pin that the decoder sizes results from `actual_count`. Existing `TestLookup_*`, `TestEptLookup_RequestShape`, `TestEptMap_*`, and `TestMap_ReturnsEndpoints` exercise the corrected paths.

### Scope of Change
- **Files changed:** `network/dcerpc/ndr/types.go`, `network/dcerpc/ndr/marshal.go`, `.../3.0/functions/02_EptLookup.go`, `.../3.0/functions/03_EptMap.go`, `.../3.0/functions/functions_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Low blast radius. The codec change only affects fields carrying the new `inline` tag; all existing interfaces are untouched and the full `network/dcerpc/...` test suite passes. Safe to merge without staged rollout.