### PR TITLE
Fix EPM ept_lookup_handle_free opnum (1 -> 4) (#634)

### DIFF
--- a/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/functions/functions_test.go
+++ b/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/functions/functions_test.go
@@ -353,3 +353,42 @@ func TestEptLookup_RequestShape(t *testing.T) {
 		t.Errorf("max_ents = %d, want %d", max, functions.DefaultMaxEnts)
 	}
 }
+
+// --- ept_lookup_handle_free ---
+
+// TestEptLookupHandleFree pins the wire contract of ept_lookup_handle_free verified live
+// against 192.168.1.31: it is opnum 4 (not 1, which is ept_delete), the request is the
+// 20-octet context handle, and the response is the nulled handle followed by the status.
+func TestEptLookupHandleFree(t *testing.T) {
+	ft := &fakeTransport{}
+	c := boundClient(t, ft)
+
+	// [out] stub: 20-octet nulled entry_handle, then status = rpc_s_ok.
+	var stub []byte
+	stub = append(stub, make([]byte, structures.ContextHandleSize)...)
+	stub = le32(stub, epm.EptStatusSuccess)
+	ft.queue(responsePDU(t, 2, stub))
+
+	in := nonNullHandle()
+	freed, err := functions.EptLookupHandleFree(c, in)
+	if err != nil {
+		t.Fatalf("EptLookupHandleFree() error = %v", err)
+	}
+	if !freed.IsNull() {
+		t.Errorf("returned handle = %x, want null", freed[:])
+	}
+
+	var req pdu.Request
+	if _, err := req.Unmarshal(ft.sent[1]); err != nil {
+		t.Fatalf("request does not parse: %v", err)
+	}
+	if req.Opnum != epm.OpnumEptLookupHandleFree {
+		t.Errorf("opnum = %d, want %d", req.Opnum, epm.OpnumEptLookupHandleFree)
+	}
+	if req.Opnum != 4 {
+		t.Errorf("opnum = %d, want 4 (ept_lookup_handle_free; opnum 1 is ept_delete)", req.Opnum)
+	}
+	if got := req.Stub[:structures.ContextHandleSize]; !bytes.Equal(got, in[:]) {
+		t.Errorf("request handle = %x, want %x", got, in[:])
+	}
+}

--- a/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/interface.go
+++ b/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/interface.go
@@ -27,14 +27,16 @@ const PipeName = `\epmapper`
 // Opnums for the on-the-wire ept methods ([C706] Appendix O). Only the operations
 // modelled here are listed.
 const (
-	// OpnumEptLookupHandleFree is ept_lookup_handle_free (opnum 1), which releases a
-	// lookup context handle obtained from ept_lookup.
-	OpnumEptLookupHandleFree uint16 = 1
 	// OpnumEptLookup is ept_lookup (opnum 2), which enumerates endpoint-map entries.
 	OpnumEptLookup uint16 = 2
 	// OpnumEptMap is ept_map (opnum 3), which resolves an interface to its bound
 	// endpoints via a protocol tower.
 	OpnumEptMap uint16 = 3
+	// OpnumEptLookupHandleFree is ept_lookup_handle_free (opnum 4), which releases a
+	// lookup context handle obtained from ept_lookup. Opnums are assigned by IDL
+	// declaration order in [C706] Appendix O: ept_insert(0), ept_delete(1), ept_lookup(2),
+	// ept_map(3), ept_lookup_handle_free(4), ept_inq_object(5), ept_mgmt_delete(6).
+	OpnumEptLookupHandleFree uint16 = 4
 )
 
 // Status codes returned in the ept_map / ept_lookup [out] error_status_t. 0 is success;


### PR DESCRIPTION
### Linked Issue
`Closes #634`

### Root Cause
DCE/RPC operation numbers are assigned by IDL declaration order. In the `ept` interface ([C706] Appendix O) the operations are: `ept_insert`(0), `ept_delete`(1), `ept_lookup`(2), `ept_map`(3), `ept_lookup_handle_free`(4), `ept_inq_object`(5), `ept_mgmt_delete`(6). `OpnumEptLookupHandleFree` was defined as `1` — the opnum of `ept_delete` — so every `ept_lookup_handle_free` call was dispatched to the wrong server operation.

### Fix Description
Set `OpnumEptLookupHandleFree` to `4` and document the full opnum ordering next to the constant so the relationship to the neighbouring operations is explicit. No other change: the request/response structures and the `EptLookupHandleFree` stub were already correct (a 20-octet context handle in, a nulled handle plus status out).

### How Verified
- **Runtime (live server 192.168.1.31, Windows Server 2016):** Obtained a valid lookup context handle via a partial `ept_lookup` (confirmed valid by continuing the enumeration with it). Before the fix, `ept_lookup_handle_free` faulted with `DCE/RPC fault: status 0x000006d8` (`EPT_S_CANT_PERFORM_OP`, because the handle was sent as the stub of `ept_delete`). After the fix, the call returns a clean 24-octet response — a nulled 20-octet handle followed by `status = 0x00000000` (`rpc_s_ok`) — and `EptLookupHandleFree` returns a null handle with no error.
- **Tests:** `go test ./network/dcerpc/...` passes, including the new test.

### Test Coverage
- **Added:** `TestEptLookupHandleFree` in `functions/functions_test.go` asserts the call is sent on opnum 4 (explicitly guarding against the `1`/`ept_delete` regression), that the request stub is the 20-octet context handle, and that the response (nulled handle + status) decodes and yields a null handle.

### Scope of Change
- **Files changed:** `network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/interface.go`, `.../3.0/functions/functions_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Notes
Independent of #632 (the inline conformant-varying array decode fixes for `ept_lookup`/`ept_map`); this branch is cut from `main` and shares no code with it. Found while verifying the EPM client end to end against a real server.
