### PR TITLE
Decode ncalrpc towers in Tower.Binding() (#636)

### DIFF
--- a/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/structures/structures_test.go
+++ b/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/structures/structures_test.go
@@ -104,6 +104,19 @@ func TestTower_Binding(t *testing.T) {
 			kind:    BindingHTTP,
 			binding: "ncacn_http:203.0.113.9[593]",
 		},
+		{
+			// Local RPC: a 0x0C protocol floor (empty RHS) followed by a 0x10 endpoint floor
+			// whose RHS is the NUL-terminated local port name, and no address floor. This is
+			// the floor sequence carried by the majority of real Windows endpoint-map entries
+			// (verified live against 192.168.1.31; issue #636).
+			name: "ncalrpc",
+			tower: withTransport(
+				Floor{LHS: []byte{FloorProtoLRPCAssoc}, RHS: nil},
+				Floor{LHS: []byte{FloorProtoLRPC}, RHS: append([]byte("WindowsShutdown"), 0)},
+			),
+			kind:    BindingLRPC,
+			binding: "ncalrpc:[WindowsShutdown]",
+		},
 	}
 
 	for _, c := range cases {

--- a/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/structures/tower.go
+++ b/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/structures/tower.go
@@ -47,6 +47,15 @@ const (
 	// FloorProtoNetBIOS identifies the NetBIOS host-name floor (the address floor of an
 	// ncacn_np tower); its RHS is the NUL-terminated host name.
 	FloorProtoNetBIOS = 0x11
+	// FloorProtoLRPC identifies the local-RPC (ncalrpc) endpoint floor; its RHS is the
+	// NUL-terminated local port name (e.g. "WindowsShutdown"). It is the transport/endpoint
+	// floor of an ncalrpc tower, accompanied by the 0x0C protocol-identifier floor
+	// (FloorProtoLRPCAssoc). This is the most common transport in a real Windows endpoint
+	// map ([C706] Appendix I; [MS-RPCE] 2.2.1.2 protocol identifiers).
+	FloorProtoLRPC = 0x10
+	// FloorProtoLRPCAssoc is the protocol-identifier floor that accompanies an ncalrpc
+	// endpoint floor (its RHS is empty). The endpoint name lives on the 0x10 floor.
+	FloorProtoLRPCAssoc = 0x0C
 	// FloorProtoHTTP identifies the RPC-over-HTTP floor of an ncacn_http tower; its RHS is
 	// a 16-bit port in big-endian order.
 	FloorProtoHTTP = 0x1F
@@ -276,6 +285,9 @@ const (
 	BindingNamedPipe
 	// BindingHTTP is ncacn_http (RPC over HTTP / RPC proxy).
 	BindingHTTP
+	// BindingLRPC is ncalrpc (local RPC over an ALPC port). Its endpoint is the local port
+	// name and it has no network address.
+	BindingLRPC
 )
 
 // Binding is a tower decoded into the components of a DCE string binding
@@ -299,8 +311,8 @@ func (b Binding) String() string {
 }
 
 // Binding decodes the tower's transport and address floors into a Binding. It supports
-// ncacn_ip_tcp, ncadg_ip_udp, ncacn_np, and ncacn_http. ok-style failure is reported as an
-// error when no recognized transport (endpoint) floor is present.
+// ncacn_ip_tcp, ncadg_ip_udp, ncacn_np, ncacn_http, and ncalrpc. ok-style failure is
+// reported as an error when no recognized transport (endpoint) floor is present.
 func (t Tower) Binding() (Binding, error) {
 	var b Binding
 	for _, f := range t.Floors {
@@ -313,6 +325,10 @@ func (t Tower) Binding() (Binding, error) {
 			b.Kind, b.ProtSeq, b.Endpoint = BindingHTTP, "ncacn_http", portString(f.RHS)
 		case FloorProtoNamedPipe:
 			b.Kind, b.ProtSeq, b.Endpoint = BindingNamedPipe, "ncacn_np", trimName(f.RHS)
+		case FloorProtoLRPC:
+			// Local RPC: the 0x10 floor's RHS is the NUL-terminated local port name; there
+			// is no network address. (The companion 0x0C protocol floor carries no data.)
+			b.Kind, b.ProtSeq, b.Endpoint = BindingLRPC, "ncalrpc", trimName(f.RHS)
 		case FloorProtoIP:
 			if len(f.RHS) >= 4 {
 				b.NetworkAddress = net.IPv4(f.RHS[0], f.RHS[1], f.RHS[2], f.RHS[3]).String()


### PR DESCRIPTION
### Linked Issue
`Closes #636`

### Root Cause
`Tower.Binding()` decoded only the ncacn_ip_tcp (0x07), ncadg_ip_udp (0x08), ncacn_np (0x0F), and ncacn_http (0x1F) transport floors. The local-RPC (ncalrpc) transport is carried by a `0x10` endpoint floor (its RHS is the NUL-terminated local port name), accompanied by a `0x0C` protocol-identifier floor — neither of which was recognized. Any ncalrpc tower therefore matched no transport floor, so `Binding()` returned `epm: tower has no recognized transport floor` and the endpoint rendered blank, even though these are valid, useful endpoints.

### Fix Description
Add the `FloorProtoLRPC` (0x10) endpoint-floor constant and its companion `FloorProtoLRPCAssoc` (0x0C) protocol-floor constant, a `BindingLRPC` kind, and a `Binding()` case that decodes the `0x10` floor as `ProtSeq="ncalrpc"` with `Endpoint = trimName(RHS)` (the NUL-terminated port name) and no network address. `Binding.String()` then yields `ncalrpc:[<name>]`. The existing `trimName` helper is reused; no other behavior changes.

### How Verified
- **Runtime (live server 192.168.1.31, Windows Server 2016):** Before the fix, enumerating the endpoint map left **437 of 547 towers undecoded** — every one carrying a `0x10` floor — rendering as `(no binding)`. After the fix, **0 towers fail** and all 437 decode as ncalrpc, e.g. `ncalrpc:[WindowsShutdown]`, `ncalrpc:[WMsgKRpc041F50]`, `ncalrpc:[LRPC-53fff75702c65dc06b]`.
- **Tests:** `go test ./network/dcerpc/interfaces/e1af8308-.../...` passes, including the new case.
- **Spec:** floor protocol identifiers are defined in [C706] Appendix I / [MS-RPCE] 2.2.1.2; `0x10` is the local-RPC endpoint floor.

### Test Coverage
- **Added:** an `ncalrpc` case in `TestTower_Binding` (`structures_test.go`) built from the real floor sequence — a `0x0C` protocol floor (empty RHS) followed by a `0x10` endpoint floor whose RHS is the NUL-terminated name — asserting `Kind == BindingLRPC` and `String() == "ncalrpc:[WindowsShutdown]"`. It round-trips through `Marshal`/`UnmarshalTower` like the other cases, so the decode path sees real wire bytes.

### Scope of Change
- **Files changed:** `network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/structures/tower.go`, `.../structures/structures_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Notes
The issue lists optional, lower-priority follow-ups (NetBIOS-host-only ncacn_np towers and any other [C706] Appendix I transports not yet covered); those are out of scope for this change and not addressed here.
