### PR TITLE
Add local/host-service RPC interfaces to the catalog

### DIFF
--- a/network/dcerpc/interfaces/catalog/catalog_test.go
+++ b/network/dcerpc/interfaces/catalog/catalog_test.go
@@ -10,6 +10,30 @@ var (
 	unknownUUID = mustGUID("00000000-0000-0000-0000-0000000000ff")
 )
 
+func TestLocalInterfacesPresent(t *testing.T) {
+	// A few of the local/host-service interfaces added from endpoint enumeration.
+	cases := []struct {
+		uuid          string
+		major, minor  uint16
+		name, service string
+	}{
+		{"b25a52bf-e5dd-4f4a-aea6-8ca7272a0e86", 2, 0, "KeyIso", "KeyIso"},
+		{"0767a036-0d22-48aa-ba69-b619480f38cb", 1, 0, "PcaSvc", "PcaSvc"},
+		{"0e3ae095-8a23-48f4-9782-03c1594a890e", 1, 0, "NgcKsp", "NgcSvc"},
+		{"378e52b0-c0a9-11cf-822d-00aa0051e40f", 1, 0, "SASec", "Schedule"},
+	}
+	for _, c := range cases {
+		e, ok := Lookup(mustGUID(c.uuid), c.major, c.minor)
+		if !ok || e.Name != c.name || e.Service != c.service {
+			t.Errorf("Lookup(%s) = (%q/%q, %v), want (%q/%q)", c.uuid, e.Name, e.Service, ok, c.name, c.service)
+		}
+	}
+	// Service search reaches the new entries.
+	if got := SearchByService("NgcSvc"); len(got) < 5 {
+		t.Errorf("SearchByService(NgcSvc) = %d, want >= 5", len(got))
+	}
+}
+
 func TestDefault_BuildsAndIsConsistent(t *testing.T) {
 	db := Default() // panics if the seed table is malformed
 	all := db.All()

--- a/network/dcerpc/interfaces/catalog/data_local.go
+++ b/network/dcerpc/interfaces/catalog/data_local.go
@@ -1,0 +1,88 @@
+package catalog
+
+// local holds well-known local/host RPC interfaces — the per-service NCALRPC
+// and named-pipe interfaces a Windows host registers with the endpoint mapper
+// (NGC/Windows Hello, the firewall, the biometric service, …). Most are not
+// documented MS-* protocols, so the title is the friendly name the service
+// itself reports to the endpoint mapper; the implementing image and hosting
+// service are cross-checked against public Windows service references and are
+// left empty where not well-established.
+var local = []Interface{
+	// Application Information / UAC elevation (appinfo.dll, Appinfo service).
+	{UUID: mustGUID("201ef99a-7fa0-444c-9399-19ba84f12a1a"), Version: v(1, 0), Name: "AppInfo", Title: "Application Information (UAC)", Description: "Application Information service (UAC elevation).", Executable: "appinfo.dll", Service: "Appinfo"},
+	{UUID: mustGUID("58e604e8-9adb-4d2e-a464-3b0683fb1480"), Version: v(1, 0), Name: "AppInfo", Title: "Application Information (UAC)", Description: "Application Information service (UAC elevation).", Executable: "appinfo.dll", Service: "Appinfo"},
+	{UUID: mustGUID("5f54ce7d-5b79-4175-8584-cb65313a0e98"), Version: v(1, 0), Name: "AppInfo", Title: "Application Information (UAC)", Description: "Application Information service (UAC elevation).", Executable: "appinfo.dll", Service: "Appinfo"},
+	{UUID: mustGUID("fb9a3757-cff0-4db0-b9fc-bd6c131612fd"), Version: v(1, 0), Name: "AppInfo", Title: "Application Information (UAC)", Description: "Application Information service (UAC elevation).", Executable: "appinfo.dll", Service: "Appinfo"},
+	{UUID: mustGUID("fd7a0523-dc70-43dd-9b2e-9c5ed48225b1"), Version: v(1, 0), Name: "AppInfo", Title: "Application Information (UAC)", Description: "Application Information service (UAC elevation).", Executable: "appinfo.dll", Service: "Appinfo"},
+
+	// Windows Defender Firewall: Base Filtering Engine + the firewall APIs.
+	{UUID: mustGUID("dd490425-5325-4565-b774-7e27d6c09c24"), Version: v(1, 0), Name: "BFE", Title: "Base Firewall Engine API", Description: "Base Filtering Engine (Windows Filtering Platform).", Executable: "bfe.dll", Service: "BFE"},
+	{UUID: mustGUID("2fb92682-6599-42dc-ae13-bd2ca89bd11c"), Version: v(1, 0), Name: "FwApis", Title: "Windows Firewall APIs", Description: "Windows Defender Firewall management.", Executable: "mpssvc.dll", Service: "MpsSvc"},
+	{UUID: mustGUID("7f9d11bf-7fb9-436b-a812-b2d50c5d4c03"), Version: v(1, 0), Name: "FwApis", Title: "Windows Firewall APIs", Description: "Windows Defender Firewall management.", Executable: "mpssvc.dll", Service: "MpsSvc"},
+	{UUID: mustGUID("f47433c3-3e9d-4157-aad4-83aa1f5c2d4c"), Version: v(1, 0), Name: "FwApis", Title: "Windows Firewall APIs", Description: "Windows Defender Firewall management.", Executable: "mpssvc.dll", Service: "MpsSvc"},
+
+	// DHCP client.
+	{UUID: mustGUID("3c4728c5-f0ab-448b-bda1-6ce01eb0a6d5"), Version: v(1, 0), Name: "DHCPClient", Title: "DHCP Client LRPC Endpoint", Description: "DHCP client service.", Executable: "dhcpcsvc.dll", Service: "Dhcp"},
+	{UUID: mustGUID("3c4728c5-f0ab-448b-bda1-6ce01eb0a6d6"), Version: v(1, 0), Name: "DHCPv6Client", Title: "DHCPv6 Client LRPC Endpoint", Description: "DHCPv6 client service.", Executable: "dhcpcsvc6.dll", Service: "Dhcp"},
+
+	// EFS and DFS-R.
+	{UUID: mustGUID("04eeb297-cbf4-466b-8a2a-bfd6a2f10bba"), Version: v(1, 0), Name: "EfsK", Title: "EFSK RPC Interface", Description: "Encrypting File System key service interface.", Executable: "efssvc.dll"},
+	{UUID: mustGUID("897e2e5f-93f3-4376-9c9c-fd2277495c27"), Version: v(1, 0), Name: "Frs2", Title: "DFS Replication (FRS2)", Description: "Distributed File System Replication.", Executable: "dfsrs.exe", Service: "DFSR", Protocol: "MS-FRS2"},
+
+	// Group Policy client.
+	{UUID: mustGUID("2eb08e3e-639f-4fba-97b1-14f878961076"), Version: v(1, 0), Name: "GroupPolicy", Title: "Group Policy RPC Interface", Description: "Group Policy client service.", Executable: "gpsvc.dll", Service: "gpsvc"},
+
+	// CNG Key Isolation.
+	{UUID: mustGUID("b25a52bf-e5dd-4f4a-aea6-8ca7272a0e86"), Version: v(2, 0), Name: "KeyIso", Title: "CNG Key Isolation", Description: "Isolates private keys in the LSA process.", Executable: "keyiso.dll", Service: "KeyIso"},
+
+	// Microsoft Passport / Windows Hello (NGC), all hosted by ngcsvc.dll.
+	{UUID: mustGUID("0e3ae095-8a23-48f4-9782-03c1594a890e"), Version: v(1, 0), Name: "NgcKsp", Title: "NGC Service KSP RPC Interface", Description: "Windows Hello (NGC) key storage provider.", Executable: "ngcsvc.dll", Service: "NgcSvc"},
+	{UUID: mustGUID("9cbc9d3a-7586-4814-8d70-18737dcbe523"), Version: v(1, 0), Name: "NgcLocalAccountVault", Title: "NGC Service LocalAccount Vault Interface", Description: "Windows Hello (NGC) local account vault.", Executable: "ngcsvc.dll", Service: "NgcSvc"},
+	{UUID: mustGUID("c225e799-29de-42af-bc05-1e2127cc056e"), Version: v(1, 0), Name: "NgcManagement", Title: "NGC Service Management RPC Interface", Description: "Windows Hello (NGC) management.", Executable: "ngcsvc.dll", Service: "NgcSvc"},
+	{UUID: mustGUID("2c2fd034-05cb-4f44-a75d-2a5cf81499c1"), Version: v(1, 0), Name: "NgcRemotePairing", Title: "NGC Service Remote Pairing RPC Interface", Description: "Windows Hello (NGC) remote pairing.", Executable: "ngcsvc.dll", Service: "NgcSvc"},
+	{UUID: mustGUID("2b70bed6-1757-4d22-9f39-448589fbebf5"), Version: v(1, 0), Name: "NgcTicket", Title: "NGC Service Ticket RPC Interface", Description: "Windows Hello (NGC) ticket service.", Executable: "ngcsvc.dll", Service: "NgcSvc"},
+	{UUID: mustGUID("51a227ae-825b-41f2-b4a9-1ac9557a1018"), Version: v(1, 0), Name: "NgcPopKey", Title: "Ngc Pop Key Service", Description: "Windows Hello (NGC) proof-of-possession key.", Executable: "ngcsvc.dll", Service: "NgcSvc"},
+	{UUID: mustGUID("8fb74744-b2ff-4c00-be0d-9ef9a191fe1b"), Version: v(1, 0), Name: "NgcPopKey", Title: "Ngc Pop Key Service", Description: "Windows Hello (NGC) proof-of-possession key.", Executable: "ngcsvc.dll", Service: "NgcSvc"},
+
+	// NGC handler interfaces (LRPC), ngcsvc.dll.
+	{UUID: mustGUID("e6f89680-fc98-11e3-80d4-10604b681cfa"), Version: v(1, 0), Name: "INgcGidsHandler", Title: "INgcGidsHandler", Description: "Windows Hello (NGC) GIDS smart-card handler.", Executable: "ngcsvc.dll", Service: "NgcSvc"},
+	{UUID: mustGUID("2d24ff0b-1bab-404c-a0fd-42c85577bf68"), Version: v(1, 0), Name: "INgcHandler", Title: "INgcHandler", Description: "Windows Hello (NGC) handler.", Executable: "ngcsvc.dll", Service: "NgcSvc"},
+	{UUID: mustGUID("30034843-029d-46ec-8fff-5d12987f85c4"), Version: v(1, 0), Name: "INgcProvisioningHandler", Title: "INgcProvisioningHandler", Description: "Windows Hello (NGC) provisioning handler.", Executable: "ngcsvc.dll", Service: "NgcSvc"},
+	{UUID: mustGUID("8bef2320-f308-4720-b913-0129cecfa6b9"), Version: v(1, 0), Name: "IVscProvisioningHandler", Title: "IVscProvisioningHandler", Description: "Virtual smart card provisioning handler."},
+
+	// Network services.
+	{UUID: mustGUID("7ea70bcf-48af-4f6a-8968-6a440754d5fa"), Version: v(1, 0), Name: "NSI", Title: "Network Store Interface", Description: "Network Store Interface service.", Executable: "nsisvc.dll", Service: "nsi"},
+	{UUID: mustGUID("552d076a-cb29-4e44-8b6a-d15e59e2c0af"), Version: v(1, 0), Name: "IPTransition", Title: "IP Transition Configuration endpoint", Description: "IP Helper IP transition configuration.", Executable: "iphlpsvc.dll", Service: "iphlpsvc"},
+	{UUID: mustGUID("e40f7b57-7a25-4cd3-a135-7f7d3df9d16b"), Version: v(1, 0), Name: "NetworkConnectionBroker", Title: "Network Connection Broker server endpoint", Description: "Network Connection Broker.", Executable: "ncbservice.dll", Service: "NcbService"},
+	{UUID: mustGUID("5222821f-d5e2-4885-84f1-5f6185a0ec41"), Version: v(1, 0), Name: "NetworkConnectionBroker", Title: "Network Connection Broker server endpoint (NCB Reset)", Description: "Network Connection Broker (NCB reset module).", Executable: "ncbservice.dll", Service: "NcbService"},
+	{UUID: mustGUID("3473dd4d-2e88-4006-9cba-22570909dd10"), Version: v(5, 1), Name: "WinHttpAutoProxy", Title: "WinHTTP Web Proxy Auto-Discovery Service", Description: "WinHTTP WPAD proxy auto-discovery.", Executable: "winhttp.dll", Service: "WinHttpAutoProxySvc"},
+
+	// Program Compatibility Assistant, biometrics, user manager, software protection.
+	{UUID: mustGUID("0767a036-0d22-48aa-ba69-b619480f38cb"), Version: v(1, 0), Name: "PcaSvc", Title: "Program Compatibility Assistant", Description: "Program Compatibility Assistant service.", Executable: "pcasvc.dll", Service: "PcaSvc"},
+	{UUID: mustGUID("4be96a0f-9f52-4729-a51d-c70610f118b0"), Version: v(1, 0), Name: "wbiosrvc", Title: "Windows Biometric Service", Description: "Windows Biometric Service.", Executable: "wbiosrvc.dll", Service: "WbioSrvc"},
+	{UUID: mustGUID("c0e9671e-33c6-4438-9464-56b2e1b1c7b4"), Version: v(1, 0), Name: "wbiosrvc", Title: "Windows Biometric Service", Description: "Windows Biometric Service.", Executable: "wbiosrvc.dll", Service: "WbioSrvc"},
+	{UUID: mustGUID("0d3c7f20-1c8d-4654-a1b3-51563b298bda"), Version: v(1, 0), Name: "UserMgrCli", Title: "User Manager", Description: "User Manager service client interface.", Executable: "usermgr.dll", Service: "UserManager"},
+	{UUID: mustGUID("b18fbab6-56f8-4702-84e0-41053293a869"), Version: v(1, 0), Name: "UserMgrCli", Title: "User Manager", Description: "User Manager service client interface.", Executable: "usermgr.dll", Service: "UserManager"},
+	{UUID: mustGUID("9435cc56-1d9c-4924-ac7d-b60a2c3520e1"), Version: v(1, 0), Name: "SPPSVC", Title: "Software Protection Platform", Description: "Software licensing / activation service.", Executable: "sppsvc.exe", Service: "sppsvc"},
+
+	// Remote registry performance-counter interface and the legacy LanMan API.
+	{UUID: mustGUID("da5a86c5-12c2-4943-ab30-7f74a813d853"), Version: v(1, 0), Name: "RemoteRegistryPerflib", Title: "RemoteRegistry Perflib Interface", Description: "Remote performance-counter (perflib) interface.", Executable: "regsvc.dll", Service: "RemoteRegistry"},
+	{UUID: mustGUID("98716d03-89ac-44c7-bb8c-285824e51c4a"), Version: v(1, 0), Name: "XactSrv", Title: "XactSrv (LanMan API)", Description: "Legacy LanMan transaction (XactSrv) interface.", Executable: "srvsvc.dll", Service: "LanmanServer"},
+
+	// Task Scheduler SASec (legacy 'at', documented as MS-TSCH alongside ATSvc).
+	{UUID: mustGUID("378e52b0-c0a9-11cf-822d-00aa0051e40f"), Version: v(1, 0), Name: "SASec", Title: "Task Scheduler (SASec)", Description: "Task Scheduler SASec interface.", Executable: "schedsvc.dll", Service: "Schedule", Protocol: "MS-TSCH", Pipes: []string{`\pipe\atsvc`}},
+
+	// Identified by name only; implementing image not well-established.
+	{UUID: mustGUID("c49a5a70-8a7f-4e70-ba16-1e8f1f193ef1"), Version: v(1, 0), Name: "AdhApis", Title: "Adh APIs", Description: "ADH (Application Deployment Helper) APIs."},
+	{UUID: mustGUID("8337aebc-5564-46fd-bc41-7798f18d2e4b"), Version: v(1, 0), Name: "DeviceCredentialManager", Title: "Device Credential Manager RPC Interface", Description: "Device credential manager."},
+	{UUID: mustGUID("4e25f4a2-21e8-40ce-b401-32050413143a"), Version: v(1, 0), Name: "DeviceCredential", Title: "Device Credential RPC Interface", Description: "Device credential interface."},
+	{UUID: mustGUID("1a0d010f-1c33-432c-b0f5-8cf4e8053099"), Version: v(1, 0), Name: "IdSegSrv", Title: "IdSegSrv service", Description: "Identity segmentation service."},
+	{UUID: mustGUID("880fd55e-43b9-11e0-b1a8-cf4edfd72085"), Version: v(1, 0), Name: "KAPI", Title: "KAPI Service endpoint", Description: "KAPI service endpoint."},
+	{UUID: mustGUID("a111f1c5-5923-47c0-9a68-d0bafb577901"), Version: v(1, 0), Name: "NetSetup", Title: "NetSetup API", Description: "Network setup / domain-join API."},
+	{UUID: mustGUID("30adc50c-5cbc-46ce-9a0e-91914789e23c"), Version: v(1, 0), Name: "NRP", Title: "NRP server endpoint", Description: "NRP server endpoint."},
+	{UUID: mustGUID("c36be077-e14b-4fe9-8abc-e856ef4f048b"), Version: v(1, 0), Name: "ProxyManagerClient", Title: "Proxy Manager client server endpoint", Description: "Proxy manager (client)."},
+	{UUID: mustGUID("2e6035b2-e8f1-41a7-a044-656b439c4c34"), Version: v(1, 0), Name: "ProxyManagerProvider", Title: "Proxy Manager provider server endpoint", Description: "Proxy manager (provider)."},
+	{UUID: mustGUID("0b1c2170-5732-4e0e-8cd3-d9b16f3b84d7"), Version: v(0, 0), Name: "RemoteAccessCheck", Title: "RemoteAccessCheck", Description: "Remote access check interface (LSA-hosted)."},
+	{UUID: mustGUID("12e65dd8-887f-41ef-91bf-8d816c42c2e7"), Version: v(1, 0), Name: "SecureDesktop", Title: "Secure Desktop LRPC interface", Description: "Secure desktop (UAC) LRPC interface."},
+	{UUID: mustGUID("df4df73a-c52d-4e3a-8003-8437fdf8302a"), Version: v(0, 0), Name: "WindowManagerRPC", Title: "Window Manager RPC server", Description: "Window manager RPC interface."},
+}

--- a/network/dcerpc/interfaces/catalog/default.go
+++ b/network/dcerpc/interfaces/catalog/default.go
@@ -12,11 +12,15 @@ var (
 	defaultDB   *Database
 )
 
-// Default returns the built-in catalog of well-known interfaces. It panics if
-// the seed table is malformed (a programmer error caught by the package tests).
+// Default returns the built-in catalog of well-known interfaces: the curated
+// builtin table plus the local/host-service table. It panics if the seed is
+// malformed (a programmer error caught by the package tests).
 func Default() *Database {
 	defaultOnce.Do(func() {
-		db, err := New(builtin)
+		seed := make([]Interface, 0, len(builtin)+len(local))
+		seed = append(seed, builtin...)
+		seed = append(seed, local...)
+		db, err := New(seed)
 		if err != nil {
 			panic("catalog: invalid built-in data: " + err.Error())
 		}


### PR DESCRIPTION
### Summary
A live RPC endpoint enumeration surfaced 95 `(UUID, version)` interfaces absent from the catalog. This adds the **51 that could be identified** as `data_local.go` and merges them into `Default()` (26 → **77** entries). The remaining 43 are listed below as still-unidentified.

### What was added
Well-known local/host-service RPC interfaces, titled by the friendly name the service reports to the endpoint mapper, with the implementing image / hosting service cross-checked against public Windows service references:

- **Windows Hello / NGC** (ngcsvc.dll, NgcSvc): KSP, Management, Ticket, Remote Pairing, LocalAccount Vault, Pop Key, INgc*Handler
- **AppInfo / UAC** (appinfo.dll), **Secure Desktop**
- **Windows Firewall**: Base Filtering Engine (bfe.dll), Firewall APIs (mpssvc.dll)
- **CNG Key Isolation** (keyiso.dll), **Biometric** (wbiosrvc.dll), **PCA** (pcasvc.dll), **User Manager** (usermgr.dll), **Software Protection** (sppsvc.exe), **Group Policy** (gpsvc.dll)
- **DHCP/DHCPv6 client** (dhcpcsvc.dll), **NSI** (nsisvc.dll), **IP Transition** (iphlpsvc.dll), **Network Connection Broker** (ncbservice.dll), **WinHTTP auto-proxy** (winhttp.dll)
- **DFS-R / FRS2** (dfsrs.exe, MS-FRS2), **Task Scheduler SASec** (schedsvc.dll, MS-TSCH), **RemoteRegistry perflib** (regsvc.dll), **XactSrv** (srvsvc.dll), **EFSK** (efssvc.dll)
- A handful identified by name only (binary not well-established): Adh APIs, Device Credential(/Manager), IdSegSrv, KAPI, NetSetup, NRP, Proxy Manager (client/provider), RemoteAccessCheck, Window Manager.

Where the binary/service wasn't well-established it's left empty rather than guessed.

### How Verified
- `go test ./network/dcerpc/interfaces/catalog/` — pass; `go build`/`vet` clean.
- New `TestLocalInterfacesPresent` checks KeyIso/PcaSvc/NgcKsp/SASec resolve with the right service and that `SearchByService("NgcSvc")` reaches the NGC family.

### Scope of Change
- **Files:** new `catalog/data_local.go`; `catalog/default.go` (merge `builtin`+`local`); `catalog/catalog_test.go` (new test).
- **Submodule pointer updated:** no.

### Still unidentified (43)
These were observed but I could not confidently map them to an interface/binary (mostly undocumented internal NCALRPC endpoints with no friendly name in the capture). Listed for follow-up:

```
0a74ef1c-41a4-4e06-83ae-dc74fb1cdd53 v1.0   (logged on ncalrpc:[senssvc]/[IUserProfile2] — SENS/UserProfile?)
33d84484-3626-47ee-8c6f-e7e98b113be1 v2.0   (\pipe\atsvc — task scheduler family)
3a9ef155-691d-4449-8d05-09ad57031823 v1.0   (\pipe\atsvc — task scheduler family)
76f226c3-ec14-4325-8a99-6a46348418af v1.0   (\PIPE\InitShutdown / WindowsShutdown)
d95afe70-a6d5-4259-822e-2c84da1ddb0d v1.0   (\PIPE\InitShutdown / WindowsShutdown)
c9ac6db5-82b7-4e55-ae8a-e464ed7b4277 v1.0   (placeholder friendly name "Impl friendly name"; lsass-hosted)
0b6edbfa-4a24-4fc6-8a23-942b1eca65d1 v1.0
0d3e2735-cea0-4ecc-a9e2-41a2d81aed4e v1.0
0fc77b1a-95d8-4a2e-a0c0-cff54237462b v0.0
1832bcf6-cab8-41d4-85d2-c9410764f75a v1.0
1b37ca91-76b1-4f5e-a3c7-2abfc61f2bb0 v1.0
20c40295-8dba-48e6-aebf-3e78ef3bb144 v1.0
2513bcbe-6cd4-4348-855e-7efb3c336dd3 v1.0
2c7fd9ce-e706-4b40-b412-953107ef9bb0 v0.0
2d98a740-581d-41b9-aa0d-a88b9d5ce938 v1.0
3ca78105-a3a3-4a68-b458-1a606bab8fd6 v1.0
4a452661-8290-4b36-8fbe-7f4093a94978 v1.0
4c9dbf19-d39e-4bb9-90ee-8f7179b20283 v1.0
4dace966-a243-4450-ae3f-9b7bcb5315b8 v1.0
55e6b932-1979-45d6-90c5-7f6270724112 v1.0
697dcda9-3ba9-4eb2-9247-e11f1901b0d2 v1.0
76c217bc-c8b4-4201-a745-373ad9032b1a v1.0
7aeb6705-3ae6-471a-882d-f39c109edc12 v1.0
857fb1be-084f-4fb5-b59c-4b2c4be5f0cf v1.0
88abcbc3-34ea-76ae-8215-767520655a23 v0.0
8bfc3be1-6def-4e2d-af74-7c47cd0ade4a v1.0
8ec21e98-b5ce-4916-a3d6-449fa428a007 v0.0
906b0ce0-c70b-1067-b317-00dd010662da v1.0
9b008953-f195-4bf9-bde0-4471971e58ed v1.0
a500d4c6-0dd1-4543-bc0c-d5f93486eaf8 v1.0
abfb6ca3-0c5e-4734-9285-0aee72fe8d1c v1.0
ae33069b-a2a8-46ee-a235-ddfd339be281 v1.0
b1ef227e-dfa5-421e-82bb-67a6a129c496 v0.0
b3781086-6a54-489b-91c8-51d067172ab7 v1.0
b37f900a-eae4-4304-a2ab-12bb668c0188 v1.0
b8cadbaf-e84b-46b9-84f2-6f71c03f9e55 v1.0
c521facf-09a9-42c5-b155-72388595cbf0 v0.0
c605f9fb-f0a3-4e2a-a073-73560f8d9e3e v1.0
d09bdeb5-6171-4a34-bfe2-06fa82652568 v1.0
e38f5360-8572-473e-b696-1b46873beeab v1.0
e7f76134-9ef5-4949-a2d6-3368cc0988f3 v1.0
f3f09ffd-fbcf-4291-944d-70ad6e0e73bb v1.0
fc48cd89-98d6-4628-9839-86f7a3e4161a v1.0   (\pipe\LSM_API_service / [LSMApi] — Local Session Manager?)
```
