### PR TITLE
Add authenticated DCE/RPC binds (NTLM auth_verifier, PKT_INTEGRITY/PKT_PRIVACY) (#640)

### DIFF
--- a/crypto/spnego/ntlm/security/security.go
+++ b/crypto/spnego/ntlm/security/security.go
@@ -1,0 +1,186 @@
+// Package security implements NTLMSSP per-message security: the message integrity
+// (signing) and confidentiality (sealing) services used by GSS_WrapEx / GSS_GetMICEx
+// once an NTLM authentication exchange has produced an exported session key.
+//
+// It implements the extended session security (NTLMv2) variant of MS-NLMP sections
+// 3.4.3 (SEAL), 3.4.4 (MAC / message signature), and 3.4.5 (SIGNKEY / SEALKEY key
+// derivation). This is the machinery a connection-oriented DCE/RPC client needs to
+// sign (PKT_INTEGRITY) and seal (PKT_PRIVACY) request stubs per [MS-RPCE] 3.3.
+//
+// References:
+//   - [MS-NLMP] 3.4 Session Security:
+//     https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-nlmp/0c2fa6f4-baf3-4f49-9a72-7c7d7c4c1bc8
+//   - [MS-NLMP] 4.2.4.4 GSS_WrapEx Examples (the known-answer test vectors):
+//     https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-nlmp/9d9ed1f4-7c91-4d54-b4b2-b87ac1f5b64a
+package security
+
+import (
+	"crypto/hmac"
+	"crypto/md5"
+	"encoding/binary"
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/crypto/rc4"
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/message/negotiate/flags"
+)
+
+// SignatureSize is the size, in bytes, of an NTLMSSP_MESSAGE_SIGNATURE
+// (version + checksum + sequence number), the value carried in the RPC auth_verifier.
+const SignatureSize = 16
+
+// Magic constants for signing- and sealing-key derivation (MS-NLMP 3.4.5.2/3.4.5.3).
+// Each includes its terminating NUL, which is part of the MD5 input.
+const (
+	clientSigningMagic = "session key to client-to-server signing key magic constant\x00"
+	serverSigningMagic = "session key to server-to-client signing key magic constant\x00"
+	clientSealingMagic = "session key to client-to-server sealing key magic constant\x00"
+	serverSealingMagic = "session key to server-to-client sealing key magic constant\x00"
+)
+
+// Context holds the per-direction signing keys, sealing RC4 stream ciphers, and
+// sequence numbers for one authenticated NTLM session. A client uses the "client"
+// keys to protect outbound PDUs and the "server" keys to verify inbound PDUs.
+//
+// A Context is not safe for concurrent use: the RC4 handles and sequence numbers are
+// stateful and advance with every message, so calls must be serialized in the same
+// order the PDUs go on (and come off) the wire.
+type Context struct {
+	negFlg flags.NegotiateFlags
+
+	clientSigningKey []byte
+	serverSigningKey []byte
+
+	clientSeal *rc4.RC4
+	serverSeal *rc4.RC4
+
+	outSeq uint32 // sequence number for outbound (client-to-server) messages
+	inSeq  uint32 // sequence number for inbound (server-to-client) messages
+}
+
+// NewContext derives the signing and sealing keys from exportedSessionKey and the
+// negotiated flags, and initializes the client and server RC4 sealing handles. With
+// extended session security each direction gets its own keys, so client and server
+// signatures never collide. negFlg must be the flags actually negotiated for the
+// session (those carried in the AUTHENTICATE message).
+func NewContext(exportedSessionKey []byte, negFlg flags.NegotiateFlags) (*Context, error) {
+	if !negFlg.HasFlag(flags.NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY) {
+		return nil, fmt.Errorf("ntlm security context: only extended session security (NTLMv2) is supported")
+	}
+	if len(exportedSessionKey) == 0 {
+		return nil, fmt.Errorf("ntlm security context: empty exported session key")
+	}
+
+	clientSealKey := deriveKey(sealingKeyInput(exportedSessionKey, negFlg), clientSealingMagic)
+	serverSealKey := deriveKey(sealingKeyInput(exportedSessionKey, negFlg), serverSealingMagic)
+
+	clientSeal, err := rc4.NewRC4WithKey(clientSealKey)
+	if err != nil {
+		return nil, fmt.Errorf("ntlm security context: client sealing key: %w", err)
+	}
+	serverSeal, err := rc4.NewRC4WithKey(serverSealKey)
+	if err != nil {
+		return nil, fmt.Errorf("ntlm security context: server sealing key: %w", err)
+	}
+
+	return &Context{
+		negFlg:           negFlg,
+		clientSigningKey: deriveKey(exportedSessionKey, clientSigningMagic),
+		serverSigningKey: deriveKey(exportedSessionKey, serverSigningMagic),
+		clientSeal:       clientSeal,
+		serverSeal:       serverSeal,
+	}, nil
+}
+
+// Sign returns the NTLMSSP_MESSAGE_SIGNATURE over message for an outbound
+// PKT_INTEGRITY PDU. The message is left in cleartext; only the signature is produced.
+// It advances the outbound sequence number.
+func (c *Context) Sign(message []byte) [SignatureSize]byte {
+	sig := c.mac(c.clientSigningKey, c.clientSeal, c.outSeq, message)
+	c.outSeq++
+	return sig
+}
+
+// SealWith encrypts messageToEncrypt for an outbound PKT_PRIVACY PDU and computes the
+// signature over messageToSign. In connection-oriented RPC the two differ: the signed
+// region is the whole PDU (header, stub, padding, sec_trailer) computed over the
+// plaintext, while only the stub and its padding are encrypted ([MS-RPCE] 3.3, NTLM2).
+// The plaintext is encrypted first so that, when key exchange is negotiated, the
+// checksum is encrypted with the subsequent keystream (MS-NLMP 3.4.3). It advances the
+// outbound sequence number once and returns the ciphertext for the encrypted region.
+func (c *Context) SealWith(messageToSign, messageToEncrypt []byte) ([]byte, [SignatureSize]byte) {
+	sealed := make([]byte, len(messageToEncrypt))
+	c.clientSeal.XORKeyStream(sealed, messageToEncrypt)
+	sig := c.mac(c.clientSigningKey, c.clientSeal, c.outSeq, messageToSign)
+	c.outSeq++
+	return sealed, sig
+}
+
+// VerifySignature checks the signature of an inbound PDU over messageToSign and
+// advances the inbound sequence number. For PKT_INTEGRITY messageToSign is the
+// cleartext PDU minus its trailing auth_value; for PKT_PRIVACY the caller must have
+// already decrypted the stub with DecryptInbound so the MAC is computed over plaintext.
+func (c *Context) VerifySignature(messageToSign []byte, sig [SignatureSize]byte) error {
+	expected := c.mac(c.serverSigningKey, c.serverSeal, c.inSeq, messageToSign)
+	c.inSeq++
+	if !hmac.Equal(expected[:], sig[:]) {
+		return fmt.Errorf("ntlm signature verification failed")
+	}
+	return nil
+}
+
+// DecryptInbound decrypts an inbound sealed region (a PKT_PRIVACY response stub plus
+// padding) in place using the server sealing stream. It neither advances the sequence
+// number nor verifies the signature; call VerifySignature afterwards over the now-
+// plaintext PDU. Decryption must precede verification so the MAC covers plaintext.
+func (c *Context) DecryptInbound(buf []byte) {
+	c.serverSeal.XORKeyStream(buf, buf)
+}
+
+// mac computes the NTLMSSP_MESSAGE_SIGNATURE with extended session security
+// (MS-NLMP 3.4.4.1): version (1) || HMAC_MD5(signingKey, seq || message)[0:8] ||
+// seq. When key exchange is negotiated the 8-byte checksum is itself encrypted with
+// the sealing handle. The caller owns the sequence-number bookkeeping.
+func (c *Context) mac(signingKey []byte, seal *rc4.RC4, seq uint32, message []byte) [SignatureSize]byte {
+	var seqBytes [4]byte
+	binary.LittleEndian.PutUint32(seqBytes[:], seq)
+
+	h := hmac.New(md5.New, signingKey)
+	h.Write(seqBytes[:])
+	h.Write(message)
+	checksum := h.Sum(nil)[:8]
+
+	if c.negFlg.HasFlag(flags.NTLMSSP_NEGOTIATE_KEY_EXCH) {
+		enc := make([]byte, 8)
+		seal.XORKeyStream(enc, checksum)
+		checksum = enc
+	}
+
+	var sig [SignatureSize]byte
+	binary.LittleEndian.PutUint32(sig[0:4], 1) // version
+	copy(sig[4:12], checksum)
+	binary.LittleEndian.PutUint32(sig[12:16], seq)
+	return sig
+}
+
+// deriveKey returns MD5(key || magic), the signing/sealing key derivation used by
+// extended session security (MS-NLMP 3.4.5.2/3.4.5.3).
+func deriveKey(key []byte, magic string) []byte {
+	h := md5.New()
+	h.Write(key)
+	h.Write([]byte(magic))
+	return h.Sum(nil)
+}
+
+// sealingKeyInput selects the portion of the exported session key used as the sealing
+// key derivation input, per the negotiated key strength (MS-NLMP 3.4.5.3): the full
+// 16 bytes for 128-bit, the first 7 for 56-bit, otherwise the first 5 (40-bit).
+func sealingKeyInput(exportedSessionKey []byte, negFlg flags.NegotiateFlags) []byte {
+	switch {
+	case negFlg.HasFlag(flags.NTLMSSP_NEGOTIATE_128):
+		return exportedSessionKey
+	case negFlg.HasFlag(flags.NTLMSSP_NEGOTIATE_56):
+		return exportedSessionKey[:7]
+	default:
+		return exportedSessionKey[:5]
+	}
+}

--- a/crypto/spnego/ntlm/security/security_test.go
+++ b/crypto/spnego/ntlm/security/security_test.go
@@ -1,0 +1,186 @@
+package security
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/crypto/rc4"
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/message/negotiate/flags"
+)
+
+// mustHex decodes a hex string or fails the test.
+func mustHex(t *testing.T, s string) []byte {
+	t.Helper()
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		t.Fatalf("bad hex %q: %v", s, err)
+	}
+	return b
+}
+
+// TestSealKnownAnswer reproduces the GSS_WrapEx worked example from MS-NLMP 4.2.4.4.
+// That example negotiates extended session security with 56-bit sealing and no key
+// exchange, so the signature checksum is the raw HMAC-MD5 (not re-encrypted). Driving
+// SEAL with the example's documented client signing/sealing keys and "Plaintext"
+// message must produce the documented sealed data and message signature. This exercises
+// the RC4 sealing stream and the MAC end to end.
+func TestSealKnownAnswer(t *testing.T) {
+	// Documented derived keys from MS-NLMP 4.2.4.4.
+	clientSigningKey := mustHex(t, "60e799be5c72fc92922ae8ebe961fb8d")
+	clientSealingKey := mustHex(t, "04dd7f014d8504d265a25cc86a3a7c06")
+	// "Plaintext" as UTF-16LE.
+	plaintext := mustHex(t, "50006c00610069006e007400650078007400")
+
+	wantSealed := mustHex(t, "a02372f6530273f3aa1eb90190ce5200c99d")
+	wantSig := mustHex(t, "01000000ff2aeb52f681793a00000000")
+
+	seal, err := rc4.NewRC4WithKey(clientSealingKey)
+	if err != nil {
+		t.Fatalf("rc4: %v", err)
+	}
+	// 56-bit, no key exchange: the checksum is left unencrypted.
+	ctx := &Context{
+		negFlg:           flags.NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY | flags.NTLMSSP_NEGOTIATE_56,
+		clientSigningKey: clientSigningKey,
+		clientSeal:       seal,
+	}
+
+	// The MS-NLMP example signs and encrypts the same buffer.
+	sealed, sig := ctx.SealWith(plaintext, plaintext)
+	if !bytes.Equal(sealed, wantSealed) {
+		t.Errorf("sealed mismatch\n got %x\nwant %x", sealed, wantSealed)
+	}
+	if !bytes.Equal(sig[:], wantSig) {
+		t.Errorf("signature mismatch\n got %x\nwant %x", sig[:], wantSig)
+	}
+}
+
+// TestSealingKeyDerivation pins deriveKey against the documented MS-NLMP 4.2.4.4
+// client sealing key: MD5(SealKey || magic) where SealKey is the 56-bit cut of the
+// session key. Since deriveKey is the single function used for every signing and
+// sealing key, this fixes the derivation for all of them.
+func TestSealingKeyDerivation(t *testing.T) {
+	sealKey56 := mustHex(t, "eb93429a8bd952") // session key cut to 56 bits
+	want := mustHex(t, "04dd7f014d8504d265a25cc86a3a7c06")
+	if got := deriveKey(sealKey56, clientSealingMagic); !bytes.Equal(got, want) {
+		t.Errorf("client sealing key\n got %x\nwant %x", got, want)
+	}
+}
+
+// TestSealingKeyInput verifies the key-strength selection of the sealing-key input.
+func TestSealingKeyInput(t *testing.T) {
+	key := mustHex(t, "000102030405060708090a0b0c0d0e0f")
+	cases := []struct {
+		name string
+		flg  flags.NegotiateFlags
+		want int
+	}{
+		{"128-bit", flags.NTLMSSP_NEGOTIATE_128, 16},
+		{"56-bit", flags.NTLMSSP_NEGOTIATE_56, 7},
+		{"40-bit", 0, 5},
+	}
+	for _, tc := range cases {
+		if got := len(sealingKeyInput(key, tc.flg)); got != tc.want {
+			t.Errorf("%s: input length %d, want %d", tc.name, got, tc.want)
+		}
+	}
+}
+
+// mirrorReceiver returns a Context whose inbound (server) keys equal the outbound
+// (client) keys derived for esk/flgs, so it can verify and unseal what a sender built
+// from the same parameters produces. This models the peer at the other end of the
+// session, where one side's client direction is the other's server direction.
+func mirrorReceiver(t *testing.T, esk []byte, flgs flags.NegotiateFlags) *Context {
+	t.Helper()
+	ctx, err := NewContext(esk, flgs)
+	if err != nil {
+		t.Fatalf("NewContext: %v", err)
+	}
+	seal, err := rc4.NewRC4WithKey(deriveKey(sealingKeyInput(esk, flgs), clientSealingMagic))
+	if err != nil {
+		t.Fatalf("rc4: %v", err)
+	}
+	ctx.serverSigningKey = deriveKey(esk, clientSigningMagic)
+	ctx.serverSeal = seal
+	return ctx
+}
+
+// TestSealUnsealRoundTrip confirms Unseal inverts Seal across several messages, with
+// the sealed bytes differing from the plaintext and the sequence numbers advancing in
+// lock step on both ends.
+func TestSealUnsealRoundTrip(t *testing.T) {
+	esk := mustHex(t, "0102030405060708090a0b0c0d0e0f10")
+	flgs := flags.NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY | flags.NTLMSSP_NEGOTIATE_128 |
+		flags.NTLMSSP_NEGOTIATE_SIGN | flags.NTLMSSP_NEGOTIATE_SEAL
+
+	sender, err := NewContext(esk, flgs)
+	if err != nil {
+		t.Fatalf("NewContext sender: %v", err)
+	}
+	receiver := mirrorReceiver(t, esk, flgs)
+
+	messages := [][]byte{
+		[]byte("first message"),
+		[]byte("second, slightly longer message"),
+		{},
+		[]byte("fourth"),
+	}
+	for i, msg := range messages {
+		sealed, sig := sender.SealWith(msg, msg)
+		if len(msg) > 0 && bytes.Equal(sealed, msg) {
+			t.Fatalf("message %d not encrypted", i)
+		}
+		// The receiver decrypts in place, then verifies over the recovered plaintext.
+		got := append([]byte(nil), sealed...)
+		receiver.DecryptInbound(got)
+		if !bytes.Equal(got, msg) {
+			t.Fatalf("message %d: recovered %q, want %q", i, got, msg)
+		}
+		if err := receiver.VerifySignature(got, sig); err != nil {
+			t.Fatalf("message %d: VerifySignature: %v", i, err)
+		}
+	}
+}
+
+// TestSignVerifyRoundTrip confirms VerifySignature accepts a Sign output and rejects a
+// tampered message, with sequence numbers advancing per message.
+func TestSignVerifyRoundTrip(t *testing.T) {
+	esk := mustHex(t, "1112131415161718191a1b1c1d1e1f20")
+	flgs := flags.NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY | flags.NTLMSSP_NEGOTIATE_128 |
+		flags.NTLMSSP_NEGOTIATE_SIGN
+
+	sender, err := NewContext(esk, flgs)
+	if err != nil {
+		t.Fatalf("NewContext sender: %v", err)
+	}
+	receiver := mirrorReceiver(t, esk, flgs)
+
+	msg := []byte("the quick brown fox")
+	sig := sender.Sign(msg)
+	if err := receiver.VerifySignature(msg, sig); err != nil {
+		t.Fatalf("VerifySignature: %v", err)
+	}
+
+	// A second message must verify under the advanced sequence number.
+	msg2 := []byte("jumps over the lazy dog")
+	sig2 := sender.Sign(msg2)
+	if err := receiver.VerifySignature(msg2, sig2); err != nil {
+		t.Fatalf("VerifySignature (2): %v", err)
+	}
+
+	// Tampering must be detected.
+	bad := mirrorReceiver(t, esk, flgs)
+	if err := bad.VerifySignature([]byte("not the original message"), sender.Sign(msg)); err == nil {
+		t.Fatal("expected signature verification failure on tampered message")
+	}
+}
+
+// TestNewContextRejectsNTLMv1 confirms the context refuses to initialize without
+// extended session security, the only signing/sealing variant implemented.
+func TestNewContextRejectsNTLMv1(t *testing.T) {
+	key := mustHex(t, "0102030405060708090a0b0c0d0e0f10")
+	if _, err := NewContext(key, flags.NTLMSSP_NEGOTIATE_128); err == nil {
+		t.Fatal("expected error for non-extended-session-security flags, got nil")
+	}
+}

--- a/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/functions/auth_integration_test.go
+++ b/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/functions/auth_integration_test.go
@@ -1,0 +1,68 @@
+//go:build integration
+
+// Live validation of RPC-level NTLM authentication (auth_verifier / sec_trailer) on the
+// connection-oriented client, exercised against the endpoint mapper over ncacn_ip_tcp.
+// Excluded from the default build by the "integration" tag. Run with:
+//
+//	DCERPC_TEST_HOST=192.168.1.31 DCERPC_TEST_USER=Administrator DCERPC_TEST_PASS='Admin123!' \
+//	go test -tags integration -v -run TestIntegration_AuthenticatedBind \
+//	  ./network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/functions/
+//
+// The bind performs the NTLM negotiate/challenge/auth3 exchange; functions.Lookup then
+// issues a signed-or-sealed ept_lookup whose response is decrypted and signature-checked
+// before the entries are decoded.
+package functions_test
+
+import (
+	"os"
+	"testing"
+
+	epm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/functions"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/pdu"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/transport/tcp"
+	"github.com/TheManticoreProject/Manticore/windows/credentials"
+)
+
+func TestIntegration_AuthenticatedBind(t *testing.T) {
+	host := os.Getenv("DCERPC_TEST_HOST")
+	if host == "" {
+		t.Skip("DCERPC_TEST_HOST not set; skipping live authenticated bind test")
+	}
+	creds, err := credentials.NewCredentials(os.Getenv("DCERPC_TEST_DOMAIN"), os.Getenv("DCERPC_TEST_USER"), os.Getenv("DCERPC_TEST_PASS"), "")
+	if err != nil {
+		t.Fatalf("NewCredentials: %v", err)
+	}
+
+	levels := []struct {
+		name  string
+		level uint8
+	}{
+		{"PKT_INTEGRITY", pdu.AuthLevelPktIntegrity},
+		{"PKT_PRIVACY", pdu.AuthLevelPktPrivacy},
+	}
+	for _, lv := range levels {
+		t.Run(lv.name, func(t *testing.T) {
+			rpc := client.NewClient(tcp.New(host, tcp.EndpointMapperPort))
+			if err := rpc.SetAuth(pdu.AuthTypeNTLMSSP, lv.level, creds); err != nil {
+				t.Fatalf("SetAuth: %v", err)
+			}
+			if err := rpc.Bind(epm.SyntaxID()); err != nil {
+				t.Fatalf("authenticated Bind(ept) at %s: %v", lv.name, err)
+			}
+			defer rpc.Close()
+
+			// A real, protected call: ept_lookup. Its response is signed (and sealed at
+			// PKT_PRIVACY); recovering and decoding entries proves the verifier round-trips.
+			entries, err := functions.Lookup(rpc)
+			if err != nil {
+				t.Fatalf("[WIRE FAIL] authenticated ept_lookup at %s: %v", lv.name, err)
+			}
+			if len(entries) == 0 {
+				t.Fatalf("[WIRE FAIL] authenticated ept_lookup at %s returned no entries", lv.name)
+			}
+			t.Logf("[ok] %s: authenticated bind + ept_lookup recovered %d endpoint-map entries", lv.name, len(entries))
+		})
+	}
+}

--- a/network/dcerpc/v5/client/auth.go
+++ b/network/dcerpc/v5/client/auth.go
@@ -1,0 +1,240 @@
+package client
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/message/authenticate"
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/message/challenge"
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/message/negotiate"
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/message/negotiate/flags"
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/security"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/pdu"
+	"github.com/TheManticoreProject/Manticore/windows/credentials"
+)
+
+// rpcNTLMNegotiateFlags are the flags proposed in the NTLM NEGOTIATE message for an
+// authenticated bind. They request extended session security (NTLMv2) with signing and
+// sealing at 128/56-bit strength, matching what the AUTHENTICATE message commits to.
+// Key exchange is deliberately not negotiated, so the exported session key equals the
+// NTLMv2 session base key and the signature checksum is not re-encrypted.
+const rpcNTLMNegotiateFlags = flags.NTLMSSP_NEGOTIATE_UNICODE |
+	flags.NTLMSSP_REQUEST_TARGET |
+	flags.NTLMSSP_NEGOTIATE_SIGN |
+	flags.NTLMSSP_NEGOTIATE_SEAL |
+	flags.NTLMSSP_NEGOTIATE_NTLM |
+	flags.NTLMSSP_NEGOTIATE_ALWAYS_SIGN |
+	flags.NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY |
+	flags.NTLMSSP_NEGOTIATE_128 |
+	flags.NTLMSSP_NEGOTIATE_56
+
+// SetAuth enables RPC-level authentication for subsequent binds. authType selects the
+// security provider (only NTLM, pdu.AuthTypeNTLMSSP, is supported) and authLevel the
+// protection applied to each PDU: pdu.AuthLevelConnect authenticates the bind only,
+// while pdu.AuthLevelPktIntegrity signs and pdu.AuthLevelPktPrivacy signs and seals
+// every request. It must be called before Bind.
+func (c *Client) SetAuth(authType, authLevel uint8, creds *credentials.Credentials) error {
+	if authType != pdu.AuthTypeNTLMSSP {
+		return fmt.Errorf("dcerpc auth: unsupported auth_type 0x%02x (only NTLM 0x%02x is supported)", authType, pdu.AuthTypeNTLMSSP)
+	}
+	switch authLevel {
+	case pdu.AuthLevelConnect, pdu.AuthLevelPktIntegrity, pdu.AuthLevelPktPrivacy:
+	default:
+		return fmt.Errorf("dcerpc auth: unsupported auth_level %d", authLevel)
+	}
+	if creds == nil {
+		return fmt.Errorf("dcerpc auth: nil credentials")
+	}
+	c.authType = authType
+	c.authLevel = authLevel
+	c.creds = creds
+	return nil
+}
+
+// authConfigured reports whether SetAuth selected an authenticated bind.
+func (c *Client) authConfigured() bool { return c.creds != nil && c.authType != pdu.AuthTypeNone }
+
+// protectsRequests reports whether each request PDU must carry a signed (or sealed)
+// auth verifier, which is the case once an integrity- or privacy-level security
+// context has been established.
+func (c *Client) protectsRequests() bool {
+	return c.sec != nil && (c.authLevel == pdu.AuthLevelPktIntegrity || c.authLevel == pdu.AuthLevelPktPrivacy)
+}
+
+// authVerifierOverhead is the worst-case number of bytes an authenticated request PDU
+// adds after the stub: up to 3 padding bytes to 4-byte-align the trailer, the 8-byte
+// sec_trailer, and the 16-byte signature.
+const authVerifierOverhead = 3 + pdu.SecTrailerSize + security.SignatureSize
+
+// negotiateToken builds the raw NTLM NEGOTIATE token carried in the bind's auth_value.
+func (c *Client) negotiateToken() ([]byte, error) {
+	neg, err := negotiate.CreateNegotiateMessage("", c.workstation, rpcNTLMNegotiateFlags, nil)
+	if err != nil {
+		return nil, err
+	}
+	return neg.Marshal()
+}
+
+// completeAuth finishes the NTLM exchange after a bind_ack: it parses the server's
+// CHALLENGE from the bind_ack's auth_value, sends an auth3 carrying the AUTHENTICATE
+// token (to which the server sends no reply), and builds the per-message security
+// context from the derived session key.
+func (c *Client) completeAuth(bindAckFrag []byte) error {
+	_, challengeBytes, err := pdu.ExtractAuthVerifier(bindAckFrag)
+	if err != nil {
+		return fmt.Errorf("read challenge: %w", err)
+	}
+	if len(challengeBytes) == 0 {
+		return fmt.Errorf("server returned no NTLM challenge in bind_ack")
+	}
+
+	var chal challenge.ChallengeMessage
+	if _, err := chal.Unmarshal(challengeBytes); err != nil {
+		return fmt.Errorf("parse challenge: %w", err)
+	}
+
+	auth, err := authenticate.CreateAuthenticateMessage(&chal, c.creds.GetUsername(), c.creds.GetPassword(), c.creds.GetDomain(), c.workstation)
+	if err != nil {
+		return fmt.Errorf("build authenticate: %w", err)
+	}
+	authBytes, err := auth.Marshal()
+	if err != nil {
+		return fmt.Errorf("marshal authenticate: %w", err)
+	}
+
+	a3 := &pdu.Auth3{
+		SecTrailer: pdu.SecTrailer{AuthType: c.authType, AuthLevel: c.authLevel, AuthContextID: c.authContextID},
+		AuthValue:  authBytes,
+	}
+	a3.Header = pdu.NewHeader(pdu.PacketTypeAuth3, pdu.PFCFirstFrag|pdu.PFCLastFrag, c.callID)
+	raw, err := a3.Marshal()
+	if err != nil {
+		return fmt.Errorf("marshal auth3: %w", err)
+	}
+	if err := c.transport.Send(raw); err != nil {
+		return fmt.Errorf("send auth3: %w", err)
+	}
+
+	if len(auth.SessionKey) == 0 {
+		return fmt.Errorf("no session key derived (NTLMv1 is not supported for RPC auth)")
+	}
+	sec, err := security.NewContext(auth.SessionKey, auth.NegotiateFlags)
+	if err != nil {
+		return fmt.Errorf("init security context: %w", err)
+	}
+	c.sec = sec
+	return nil
+}
+
+// marshalProtectedRequest serializes a request PDU with an NTLM auth verifier. The stub
+// is padded so the sec_trailer starts on a 4-byte boundary; for PKT_INTEGRITY the
+// signature covers the whole PDU (header, body, padded stub, sec_trailer) in cleartext,
+// and for PKT_PRIVACY the same region is signed over plaintext while only the stub and
+// its padding are sealed ([MS-RPCE] 3.3, NTLM2).
+func (c *Client) marshalProtectedRequest(req *pdu.Request) ([]byte, error) {
+	if req.ObjectUUID != nil {
+		return nil, fmt.Errorf("authenticated request with object UUID is not supported")
+	}
+
+	allocHint := req.AllocHint
+	if allocHint == 0 {
+		allocHint = uint32(len(req.Stub))
+	}
+	bodyHdr := make([]byte, 8)
+	binary.LittleEndian.PutUint32(bodyHdr[0:4], allocHint)
+	binary.LittleEndian.PutUint16(bodyHdr[4:6], req.ContextID)
+	binary.LittleEndian.PutUint16(bodyHdr[6:8], req.Opnum)
+
+	// The 16-byte header plus the 8-byte body keep the stub on a 4-byte boundary, so the
+	// pad needed before the sec_trailer depends only on the stub length.
+	pad := (4 - (len(req.Stub) % 4)) % 4
+	stubPad := make([]byte, len(req.Stub)+pad)
+	copy(stubPad, req.Stub)
+
+	st := pdu.SecTrailer{
+		AuthType:      c.authType,
+		AuthLevel:     c.authLevel,
+		AuthPadLength: uint8(pad),
+		AuthContextID: c.authContextID,
+	}
+
+	req.Header.PacketType = pdu.PacketTypeRequest
+	req.Header.AuthLength = uint16(security.SignatureSize)
+	fragLen := pdu.HeaderSize + len(bodyHdr) + len(stubPad) + pdu.SecTrailerSize + security.SignatureSize
+	req.Header.FragLength = uint16(fragLen)
+	hdrBytes, err := req.Header.Marshal()
+	if err != nil {
+		return nil, err
+	}
+
+	// The signed region is the whole PDU up to (but not including) the auth_value,
+	// computed over the plaintext stub.
+	toSign := make([]byte, 0, fragLen-security.SignatureSize)
+	toSign = append(toSign, hdrBytes...)
+	toSign = append(toSign, bodyHdr...)
+	toSign = append(toSign, stubPad...)
+	toSign = append(toSign, st.Marshal()...)
+
+	var onWireStub []byte
+	var sig [security.SignatureSize]byte
+	if c.authLevel == pdu.AuthLevelPktPrivacy {
+		onWireStub, sig = c.sec.SealWith(toSign, stubPad)
+	} else {
+		sig = c.sec.Sign(toSign)
+		onWireStub = stubPad
+	}
+
+	out := make([]byte, 0, fragLen)
+	out = append(out, hdrBytes...)
+	out = append(out, bodyHdr...)
+	out = append(out, onWireStub...)
+	out = append(out, st.Marshal()...)
+	out = append(out, sig[:]...)
+	return out, nil
+}
+
+// unprotectResponseStub recovers the cleartext stub from an authenticated response
+// fragment: for PKT_PRIVACY it decrypts the stub in place, then it verifies the
+// signature over the whole PDU (minus the auth_value) and strips the auth padding.
+func (c *Client) unprotectResponseStub(frag []byte) ([]byte, error) {
+	hdr, err := pdu.PeekHeader(frag)
+	if err != nil {
+		return nil, err
+	}
+	authLen := int(hdr.AuthLength)
+	if authLen != security.SignatureSize {
+		return nil, fmt.Errorf("unexpected auth_length %d, want %d", authLen, security.SignatureSize)
+	}
+	fragLen := int(hdr.FragLength)
+	if fragLen > len(frag) {
+		fragLen = len(frag)
+	}
+
+	st, authValue, err := pdu.ExtractAuthVerifier(frag)
+	if err != nil {
+		return nil, err
+	}
+	var sig [security.SignatureSize]byte
+	copy(sig[:], authValue)
+
+	stubStart := pdu.HeaderSize + 8 // response body: alloc_hint, ctx_id, cancel_count, reserved
+	stubEnd := fragLen - authLen - pdu.SecTrailerSize
+	if stubEnd < stubStart {
+		return nil, fmt.Errorf("authenticated response stub bounds invalid")
+	}
+
+	if c.authLevel == pdu.AuthLevelPktPrivacy {
+		c.sec.DecryptInbound(frag[stubStart:stubEnd])
+	}
+	// Verify over the whole PDU minus the trailing auth_value, now that the stub is
+	// plaintext.
+	if err := c.sec.VerifySignature(frag[:fragLen-authLen], sig); err != nil {
+		return nil, err
+	}
+
+	if int(st.AuthPadLength) > stubEnd-stubStart {
+		return nil, fmt.Errorf("auth_pad_length %d exceeds stub length", st.AuthPadLength)
+	}
+	stub := frag[stubStart : stubEnd-int(st.AuthPadLength)]
+	return append([]byte(nil), stub...), nil
+}

--- a/network/dcerpc/v5/client/auth_test.go
+++ b/network/dcerpc/v5/client/auth_test.go
@@ -1,0 +1,51 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/pdu"
+	"github.com/TheManticoreProject/Manticore/windows/credentials"
+)
+
+func TestSetAuthValidation(t *testing.T) {
+	creds, err := credentials.NewCredentials("", "user", "pass", "")
+	if err != nil {
+		t.Fatalf("NewCredentials: %v", err)
+	}
+
+	cases := []struct {
+		name     string
+		authType uint8
+		level    uint8
+		creds    *credentials.Credentials
+		wantErr  bool
+	}{
+		{"ntlm privacy", pdu.AuthTypeNTLMSSP, pdu.AuthLevelPktPrivacy, creds, false},
+		{"ntlm integrity", pdu.AuthTypeNTLMSSP, pdu.AuthLevelPktIntegrity, creds, false},
+		{"ntlm connect", pdu.AuthTypeNTLMSSP, pdu.AuthLevelConnect, creds, false},
+		{"unsupported auth type", pdu.AuthTypeGSSKerberos, pdu.AuthLevelPktPrivacy, creds, true},
+		{"unsupported level (none)", pdu.AuthTypeNTLMSSP, pdu.AuthLevelNone, creds, true},
+		{"nil credentials", pdu.AuthTypeNTLMSSP, pdu.AuthLevelPktPrivacy, nil, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := NewClient(nil)
+			err := c.SetAuth(tc.authType, tc.level, tc.creds)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if c.authConfigured() {
+					t.Fatal("auth must not be configured after a rejected SetAuth")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !c.authConfigured() {
+				t.Fatal("auth should be configured after a successful SetAuth")
+			}
+		})
+	}
+}

--- a/network/dcerpc/v5/client/client.go
+++ b/network/dcerpc/v5/client/client.go
@@ -27,10 +27,12 @@ package client
 import (
 	"fmt"
 
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/security"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
-	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/pdu"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/pdu"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/transport"
+	"github.com/TheManticoreProject/Manticore/windows/credentials"
 )
 
 // requestHeaderOverhead is the fixed size of a request PDU before the stub data: the
@@ -61,6 +63,15 @@ type Client struct {
 	negotiatedSyntax ndr.Syntax
 
 	bound bool
+
+	// Authentication state, configured by SetAuth and established during Bind. When
+	// authType is pdu.AuthTypeNone the bind and calls are anonymous, exactly as before.
+	authType      uint8
+	authLevel     uint8
+	authContextID uint32
+	workstation   string
+	creds         *credentials.Credentials
+	sec           *security.Context // non-nil once an authenticated bind completes
 }
 
 // NewClient returns a DCE/RPC client over the supplied transport. The transport must
@@ -119,6 +130,18 @@ func (c *Client) Bind(abstractSyntax syntax.SyntaxID) error {
 	}
 	bind.Header = pdu.NewHeader(pdu.PacketTypeBind, pdu.PFCFirstFrag|pdu.PFCLastFrag, c.callID)
 
+	// For an authenticated bind, carry an NTLM NEGOTIATE token in the bind's auth
+	// verifier; the server's CHALLENGE comes back in the bind_ack and is completed with
+	// an auth3 below.
+	if c.authConfigured() {
+		negToken, err := c.negotiateToken()
+		if err != nil {
+			return fmt.Errorf("dcerpc bind: ntlm negotiate: %w", err)
+		}
+		bind.SecTrailer = pdu.SecTrailer{AuthType: c.authType, AuthLevel: c.authLevel, AuthContextID: c.authContextID}
+		bind.AuthValue = negToken
+	}
+
 	raw, err := bind.Marshal()
 	if err != nil {
 		return fmt.Errorf("dcerpc bind: marshal: %w", err)
@@ -149,6 +172,11 @@ func (c *Client) Bind(abstractSyntax syntax.SyntaxID) error {
 		c.contextID = ctxID
 		c.negotiatedSyntax = negotiated
 		c.sendFragMax = negotiateSendMax(c.transport.MaxXmitFrag(), ack.MaxXmitFrag, ack.MaxRecvFrag)
+		if c.authConfigured() {
+			if err := c.completeAuth(respFrag); err != nil {
+				return fmt.Errorf("dcerpc bind: ntlm auth: %w", err)
+			}
+		}
 		c.bound = true
 		return nil
 	case pdu.PacketTypeBindNak:
@@ -236,8 +264,13 @@ func selectContext(contexts []pdu.ContextElement, results []pdu.PresentationResu
 // sendRequest fragments stub into request PDUs no larger than the negotiated send
 // size and writes each one.
 func (c *Client) sendRequest(opnum uint16, stub []byte) error {
-	// Largest stub chunk per fragment.
-	budget := int(c.sendFragMax) - requestHeaderOverhead
+	// Largest stub chunk per fragment, reserving room for the auth verifier when each
+	// request is signed or sealed.
+	overhead := requestHeaderOverhead
+	if c.protectsRequests() {
+		overhead += authVerifierOverhead
+	}
+	budget := int(c.sendFragMax) - overhead
 	if budget <= 0 {
 		return fmt.Errorf("negotiated fragment size %d too small for a request", c.sendFragMax)
 	}
@@ -266,7 +299,13 @@ func (c *Client) sendRequest(opnum uint16, stub []byte) error {
 		}
 		req.Header = pdu.NewHeader(pdu.PacketTypeRequest, flags, c.callID)
 
-		raw, err := req.Marshal()
+		var raw []byte
+		var err error
+		if c.protectsRequests() {
+			raw, err = c.marshalProtectedRequest(req)
+		} else {
+			raw, err = req.Marshal()
+		}
 		if err != nil {
 			return fmt.Errorf("marshal request fragment: %w", err)
 		}
@@ -305,7 +344,14 @@ func (c *Client) readResponse() ([]byte, error) {
 			if resp.Header.CallID != c.callID {
 				return nil, fmt.Errorf("response call_id %d does not match request call_id %d", resp.Header.CallID, c.callID)
 			}
-			stub = append(stub, resp.Stub...)
+			chunk := resp.Stub
+			if c.protectsRequests() && resp.Header.AuthLength > 0 {
+				chunk, err = c.unprotectResponseStub(frag)
+				if err != nil {
+					return nil, fmt.Errorf("unprotect response: %w", err)
+				}
+			}
+			stub = append(stub, chunk...)
 			if hdr.PacketFlags.Has(pdu.PFCLastFrag) {
 				return stub, nil
 			}

--- a/network/dcerpc/v5/pdu/auth3.go
+++ b/network/dcerpc/v5/pdu/auth3.go
@@ -1,0 +1,76 @@
+package pdu
+
+import (
+	"fmt"
+)
+
+// Auth3 is an rpc_auth_3 PDU: the optional third leg of an authenticated bind. After a
+// bind that carried an authentication token and a bind_ack that returned the security
+// provider's challenge, the client sends an auth3 carrying the final token (for NTLM,
+// the AUTHENTICATE message) to complete the exchange. The server sends no reply.
+//
+// The PDU is the common header, a 4-byte pad (a vestigial max_xmit_frag/max_recv_frag
+// that the server ignores), then the sec_trailer and the auth_value. The header's
+// auth_length counts only AuthValue.
+//
+// References:
+//   - [C706] section 12.6.4.2 ("The rpc_auth_3 PDU"):
+//     https://pubs.opengroup.org/onlinepubs/9629399/chap12.htm
+//   - [MS-RPCE] 2.2.2.10 PDU Types:
+//     https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/cef9d684-f09f-4533-a54c-9255079d3e1d
+type Auth3 struct {
+	Header     Header
+	SecTrailer SecTrailer
+	AuthValue  []byte
+}
+
+// Marshal serializes the complete auth3 PDU, filling in the header's packet type,
+// frag_length, and auth_length.
+func (a *Auth3) Marshal() ([]byte, error) {
+	if len(a.AuthValue) == 0 {
+		return nil, fmt.Errorf("auth3 PDU has no auth_value")
+	}
+
+	body := make([]byte, 4) // pad (ignored max_xmit_frag/max_recv_frag)
+	body = append(body, a.SecTrailer.Marshal()...)
+	body = append(body, a.AuthValue...)
+
+	if a.Header.RPCVersion == 0 && a.Header.DataRepresentation == ([4]byte{}) {
+		a.Header = NewHeader(PacketTypeAuth3, a.Header.PacketFlags, a.Header.CallID)
+	}
+	a.Header.PacketType = PacketTypeAuth3
+	a.Header.AuthLength = uint16(len(a.AuthValue))
+	a.Header.FragLength = uint16(HeaderSize + len(body))
+
+	hdr, err := a.Header.Marshal()
+	if err != nil {
+		return nil, err
+	}
+	return append(hdr, body...), nil
+}
+
+// Unmarshal parses a complete auth3 PDU and returns the bytes consumed.
+func (a *Auth3) Unmarshal(data []byte) (int, error) {
+	pos, err := a.Header.Unmarshal(data)
+	if err != nil {
+		return 0, err
+	}
+	if a.Header.PacketType != PacketTypeAuth3 {
+		return 0, fmt.Errorf("not an auth3 PDU: packet type is %s", a.Header.PacketType)
+	}
+	pos += 4 // skip the 4-byte pad
+	if len(data) < pos+SecTrailerSize {
+		return 0, fmt.Errorf("auth3 PDU sec_trailer truncated")
+	}
+	if err := a.SecTrailer.Unmarshal(data[pos:]); err != nil {
+		return 0, fmt.Errorf("auth3 PDU: %w", err)
+	}
+	pos += SecTrailerSize
+
+	authLen := int(a.Header.AuthLength)
+	if len(data) < pos+authLen {
+		return 0, fmt.Errorf("auth3 PDU auth_value truncated: have %d bytes, need %d", len(data)-pos, authLen)
+	}
+	a.AuthValue = append([]byte(nil), data[pos:pos+authLen]...)
+	return pos + authLen, nil
+}

--- a/network/dcerpc/v5/pdu/auth_test.go
+++ b/network/dcerpc/v5/pdu/auth_test.go
@@ -1,0 +1,152 @@
+package pdu
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
+)
+
+// TestSecTrailerRoundTrip verifies the 8-byte sec_trailer marshals and unmarshals
+// to identical values.
+func TestSecTrailerRoundTrip(t *testing.T) {
+	st := SecTrailer{
+		AuthType:      AuthTypeNTLMSSP,
+		AuthLevel:     AuthLevelPktPrivacy,
+		AuthPadLength: 3,
+		AuthReserved:  0,
+		AuthContextID: 0x12345678,
+	}
+	raw := st.Marshal()
+	if len(raw) != SecTrailerSize {
+		t.Fatalf("marshaled sec_trailer is %d bytes, want %d", len(raw), SecTrailerSize)
+	}
+	var got SecTrailer
+	if err := got.Unmarshal(raw); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got != st {
+		t.Errorf("round trip mismatch: got %+v, want %+v", got, st)
+	}
+}
+
+// TestAuth3RoundTrip verifies an auth3 PDU marshals and parses back, with auth_length
+// counting only the auth_value and the sec_trailer carried intact.
+func TestAuth3RoundTrip(t *testing.T) {
+	authValue := []byte("NTLM-AUTHENTICATE-token-bytes")
+	a := &Auth3{
+		SecTrailer: SecTrailer{AuthType: AuthTypeNTLMSSP, AuthLevel: AuthLevelPktPrivacy, AuthContextID: 1},
+		AuthValue:  authValue,
+	}
+	a.Header = NewHeader(PacketTypeAuth3, PFCFirstFrag|PFCLastFrag, 1)
+
+	raw, err := a.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	hdr, err := PeekHeader(raw)
+	if err != nil {
+		t.Fatalf("PeekHeader: %v", err)
+	}
+	if hdr.PacketType != PacketTypeAuth3 {
+		t.Errorf("packet type = %s, want auth3", hdr.PacketType)
+	}
+	if int(hdr.AuthLength) != len(authValue) {
+		t.Errorf("auth_length = %d, want %d", hdr.AuthLength, len(authValue))
+	}
+	if int(hdr.FragLength) != len(raw) {
+		t.Errorf("frag_length = %d, want %d", hdr.FragLength, len(raw))
+	}
+
+	var got Auth3
+	if _, err := got.Unmarshal(raw); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if !bytes.Equal(got.AuthValue, authValue) {
+		t.Errorf("auth_value = %q, want %q", got.AuthValue, authValue)
+	}
+	if got.SecTrailer != a.SecTrailer {
+		t.Errorf("sec_trailer = %+v, want %+v", got.SecTrailer, a.SecTrailer)
+	}
+}
+
+// TestBindAuthVerifier verifies a bind carrying an auth_value sets auth_length, aligns
+// the sec_trailer to a 4-byte boundary, and that ExtractAuthVerifier recovers the
+// sec_trailer and token from the marshaled PDU.
+func TestBindAuthVerifier(t *testing.T) {
+	authValue := []byte("NTLM-NEGOTIATE")
+	bind := &Bind{
+		MaxXmitFrag: 4280,
+		MaxRecvFrag: 4280,
+		ContextList: []ContextElement{{
+			ContextID:        0,
+			AbstractSyntax:   syntax.NDRTransferSyntax(),
+			TransferSyntaxes: []syntax.SyntaxID{syntax.NDRTransferSyntax()},
+		}},
+		SecTrailer: SecTrailer{AuthType: AuthTypeNTLMSSP, AuthLevel: AuthLevelPktPrivacy, AuthContextID: 0},
+		AuthValue:  authValue,
+	}
+	bind.Header = NewHeader(PacketTypeBind, PFCFirstFrag|PFCLastFrag, 1)
+
+	raw, err := bind.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	hdr, err := PeekHeader(raw)
+	if err != nil {
+		t.Fatalf("PeekHeader: %v", err)
+	}
+	if int(hdr.AuthLength) != len(authValue) {
+		t.Errorf("auth_length = %d, want %d", hdr.AuthLength, len(authValue))
+	}
+
+	st, gotValue, err := ExtractAuthVerifier(raw)
+	if err != nil {
+		t.Fatalf("ExtractAuthVerifier: %v", err)
+	}
+	if st == nil {
+		t.Fatal("ExtractAuthVerifier returned no sec_trailer")
+	}
+	if st.AuthType != AuthTypeNTLMSSP || st.AuthLevel != AuthLevelPktPrivacy {
+		t.Errorf("sec_trailer = %+v", st)
+	}
+	if !bytes.Equal(gotValue, authValue) {
+		t.Errorf("auth_value = %q, want %q", gotValue, authValue)
+	}
+
+	// The sec_trailer must begin on a 4-byte boundary from the start of the PDU.
+	trailerStart := len(raw) - len(authValue) - SecTrailerSize
+	if trailerStart%4 != 0 {
+		t.Errorf("sec_trailer starts at offset %d, not 4-byte aligned", trailerStart)
+	}
+	// The recorded auth_pad_length is the padding between the body and the trailer,
+	// which alignment keeps below 4.
+	if st.AuthPadLength >= 4 {
+		t.Errorf("auth_pad_length = %d, want < 4", st.AuthPadLength)
+	}
+}
+
+// TestExtractAuthVerifierNone confirms a PDU without an auth verifier yields nil.
+func TestExtractAuthVerifierNone(t *testing.T) {
+	bind := &Bind{
+		MaxXmitFrag: 4280,
+		MaxRecvFrag: 4280,
+		ContextList: []ContextElement{{
+			ContextID:        0,
+			AbstractSyntax:   syntax.NDRTransferSyntax(),
+			TransferSyntaxes: []syntax.SyntaxID{syntax.NDRTransferSyntax()},
+		}},
+	}
+	bind.Header = NewHeader(PacketTypeBind, PFCFirstFrag|PFCLastFrag, 1)
+	raw, err := bind.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	st, val, err := ExtractAuthVerifier(raw)
+	if err != nil {
+		t.Fatalf("ExtractAuthVerifier: %v", err)
+	}
+	if st != nil || val != nil {
+		t.Errorf("expected no auth verifier, got sec_trailer=%v value=%v", st, val)
+	}
+}

--- a/network/dcerpc/v5/pdu/bind.go
+++ b/network/dcerpc/v5/pdu/bind.go
@@ -126,10 +126,17 @@ type Bind struct {
 	MaxRecvFrag  uint16
 	AssocGroupID uint32
 	ContextList  []ContextElement
+
+	// SecTrailer and AuthValue carry an optional authentication verifier. When
+	// AuthValue is non-empty, Marshal pads the body to a 4-byte boundary, appends the
+	// sec_trailer and the auth_value (e.g. an NTLM NEGOTIATE token), and sets the
+	// header's auth_length. They are nil/empty for an unauthenticated bind.
+	SecTrailer SecTrailer
+	AuthValue  []byte
 }
 
-// Marshal serializes the complete bind PDU, filling in the header's packet type and
-// frag_length.
+// Marshal serializes the complete bind PDU, filling in the header's packet type,
+// frag_length, and — when an auth_value is present — auth_length.
 func (b *Bind) Marshal() ([]byte, error) {
 	if len(b.ContextList) == 0 {
 		return nil, fmt.Errorf("bind PDU has no presentation contexts")
@@ -155,10 +162,13 @@ func (b *Bind) Marshal() ([]byte, error) {
 	}
 	body = append(body, cl...)
 
+	body = appendAuthVerifier(body, &b.SecTrailer, b.AuthValue)
+
 	if b.Header.RPCVersion == 0 && b.Header.DataRepresentation == ([4]byte{}) {
 		b.Header = NewHeader(PacketTypeBind, b.Header.PacketFlags, b.Header.CallID)
 	}
 	b.Header.PacketType = PacketTypeBind
+	b.Header.AuthLength = uint16(len(b.AuthValue))
 	b.Header.FragLength = uint16(HeaderSize + len(body))
 
 	hdr, err := b.Header.Marshal()

--- a/network/dcerpc/v5/pdu/ptype.go
+++ b/network/dcerpc/v5/pdu/ptype.go
@@ -27,6 +27,7 @@ const (
 	PacketTypeBindNak          PacketType = 13
 	PacketTypeAlterContext     PacketType = 14
 	PacketTypeAlterContextResp PacketType = 15
+	PacketTypeAuth3            PacketType = 16
 	PacketTypeShutdown         PacketType = 17
 	PacketTypeCoCancel         PacketType = 18
 	PacketTypeOrphaned         PacketType = 19
@@ -67,6 +68,8 @@ func (t PacketType) String() string {
 		return "alter_context"
 	case PacketTypeAlterContextResp:
 		return "alter_context_resp"
+	case PacketTypeAuth3:
+		return "auth3"
 	case PacketTypeShutdown:
 		return "shutdown"
 	case PacketTypeCoCancel:

--- a/network/dcerpc/v5/pdu/request.go
+++ b/network/dcerpc/v5/pdu/request.go
@@ -175,16 +175,16 @@ func (r *Response) String() string {
 }
 
 // stubEnd returns the index at which the stub data ends, derived from the header's
-// frag_length and auth_length. It clamps to the available buffer so a truncated read
-// does not produce an out-of-bounds slice.
+// frag_length and auth_length. When the PDU carries an authentication verifier, the
+// trailing bytes are laid out as [stub][auth_pad][sec_trailer][auth_value], so the stub
+// ends auth_length + SecTrailerSize bytes before frag_length. The caller strips the
+// auth padding (recorded in the sec_trailer's auth_pad_length) separately, since this
+// helper does not parse the trailer. It clamps to the available buffer so a truncated
+// read does not produce an out-of-bounds slice.
 func stubEnd(h *Header, available int) (int, error) {
-	end := int(h.FragLength) - int(h.AuthLength)
+	end := int(h.FragLength)
 	if h.AuthLength > 0 {
-		// The auth verifier is preceded by sec_trailer (8 bytes); both sit after the
-		// stub. Subtracting auth_length alone leaves the 8-byte sec_trailer attributed
-		// to the stub, which is acceptable for v1 (no auth is negotiated) but flagged
-		// here for the future auth work.
-		end -= 8
+		end -= int(h.AuthLength) + SecTrailerSize
 	}
 	if end > available {
 		end = available

--- a/network/dcerpc/v5/pdu/sectrailer.go
+++ b/network/dcerpc/v5/pdu/sectrailer.go
@@ -1,0 +1,128 @@
+package pdu
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+// Authentication service identifiers (auth_type), as carried in the sec_trailer of an
+// authenticated PDU.
+//
+// Reference: [MS-RPCE] 2.2.1.1.7 Security Providers:
+// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/d4097450-c62f-484b-872f-ddf59a7a0d36
+const (
+	AuthTypeNone         uint8 = 0x00
+	AuthTypeGSSNegotiate uint8 = 0x09 // SPNEGO
+	AuthTypeNTLMSSP      uint8 = 0x0A // RPC_C_AUTHN_WINNT
+	AuthTypeGSSKerberos  uint8 = 0x10
+)
+
+// Authentication levels (auth_level), as carried in the sec_trailer. Higher levels
+// subsume the protection of lower ones.
+//
+// Reference: [MS-RPCE] 2.2.1.1.8 Authentication Levels:
+// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/425a7c53-c33a-4868-8e5b-2a850d40dc73
+const (
+	AuthLevelDefault      uint8 = 0x00
+	AuthLevelNone         uint8 = 0x01
+	AuthLevelConnect      uint8 = 0x02
+	AuthLevelCall         uint8 = 0x03
+	AuthLevelPkt          uint8 = 0x04
+	AuthLevelPktIntegrity uint8 = 0x05
+	AuthLevelPktPrivacy   uint8 = 0x06
+)
+
+// SecTrailerSize is the size, in bytes, of the sec_trailer (auth_verifier_co_t) header
+// that precedes the auth_value in an authenticated PDU.
+const SecTrailerSize = 8
+
+// SecTrailer is the fixed 8-byte security trailer (auth_verifier_co_t) that sits
+// between a PDU's body and its authentication token (auth_value). The header's
+// auth_length counts only the auth_value that follows this trailer, not the trailer
+// itself.
+//
+// References:
+//   - [C706] section 13.2.6.1 (the connection-oriented authentication verifier):
+//     https://pubs.opengroup.org/onlinepubs/9629399/chap13.htm
+//   - [MS-RPCE] 2.2.2.11 auth_verifier_co (sec_trailer):
+//     https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/c0fe71f3-0fd1-4a0d-aa3f-b6a36e3fbe81
+type SecTrailer struct {
+	AuthType      uint8  // security provider (auth_type)
+	AuthLevel     uint8  // protection level (auth_level)
+	AuthPadLength uint8  // bytes of padding inserted before the trailer to 4-byte-align it
+	AuthReserved  uint8  // must be zero
+	AuthContextID uint32 // identifies the security context within the connection
+}
+
+// Marshal serializes the 8-byte sec_trailer.
+func (s *SecTrailer) Marshal() []byte {
+	buf := make([]byte, SecTrailerSize)
+	buf[0] = s.AuthType
+	buf[1] = s.AuthLevel
+	buf[2] = s.AuthPadLength
+	buf[3] = s.AuthReserved
+	binary.LittleEndian.PutUint32(buf[4:8], s.AuthContextID)
+	return buf
+}
+
+// Unmarshal parses an 8-byte sec_trailer from the front of data.
+func (s *SecTrailer) Unmarshal(data []byte) error {
+	if len(data) < SecTrailerSize {
+		return fmt.Errorf("sec_trailer truncated: have %d bytes, need %d", len(data), SecTrailerSize)
+	}
+	s.AuthType = data[0]
+	s.AuthLevel = data[1]
+	s.AuthPadLength = data[2]
+	s.AuthReserved = data[3]
+	s.AuthContextID = binary.LittleEndian.Uint32(data[4:8])
+	return nil
+}
+
+// appendAuthVerifier appends an authentication verifier to a PDU body in place: it
+// pads body to a 4-byte boundary (measured from the start of the PDU, i.e. including
+// the 16-byte header), records that padding in the sec_trailer's auth_pad_length, then
+// appends the sec_trailer and the auth_value. When authValue is empty it returns body
+// unchanged. The caller is responsible for setting the header's auth_length to
+// len(authValue).
+func appendAuthVerifier(body []byte, st *SecTrailer, authValue []byte) []byte {
+	if len(authValue) == 0 {
+		return body
+	}
+	pad := align4(HeaderSize + len(body))
+	if pad > 0 {
+		body = append(body, make([]byte, pad)...)
+	}
+	st.AuthPadLength = uint8(pad)
+	body = append(body, st.Marshal()...)
+	body = append(body, authValue...)
+	return body
+}
+
+// ExtractAuthVerifier returns the sec_trailer and auth_value from the tail of a
+// complete PDU, located using the common header's auth_length: the last auth_length
+// bytes are the auth_value, preceded by the 8-byte sec_trailer. It returns nil, nil
+// when the PDU carries no authentication verifier (auth_length == 0).
+func ExtractAuthVerifier(raw []byte) (*SecTrailer, []byte, error) {
+	hdr, err := PeekHeader(raw)
+	if err != nil {
+		return nil, nil, err
+	}
+	authLen := int(hdr.AuthLength)
+	if authLen == 0 {
+		return nil, nil, nil
+	}
+	fragLen := int(hdr.FragLength)
+	if fragLen > len(raw) {
+		fragLen = len(raw)
+	}
+	trailerStart := fragLen - authLen - SecTrailerSize
+	if trailerStart < HeaderSize {
+		return nil, nil, fmt.Errorf("auth verifier overruns PDU: frag_length=%d auth_length=%d", hdr.FragLength, authLen)
+	}
+	var st SecTrailer
+	if err := st.Unmarshal(raw[trailerStart:]); err != nil {
+		return nil, nil, err
+	}
+	authValue := append([]byte(nil), raw[trailerStart+SecTrailerSize:fragLen]...)
+	return &st, authValue, nil
+}


### PR DESCRIPTION
### Linked Issue
Closes #640

### Motivation
The connection-oriented DCE/RPC client (`network/dcerpc/v5/client`) had no RPC-level authentication: `Bind` only proposed presentation contexts, with no `auth_verifier`/`sec_trailer`, no `auth3` exchange, and no signing/sealing. Every call was therefore anonymous at the RPC layer, so interfaces that require an authenticated, integrity- or privacy-protected context (e.g. `drsuapi`) rejected calls with `nca_s_fault_access_denied` before dispatch. This change adds NTLM authentication at auth levels `PKT_INTEGRITY` and `PKT_PRIVACY`.

### Design
NTLM (`RPC_C_AUTHN_WINNT`) with extended session security (NTLMv2). The work is entirely at the PDU/client layer and is transport-agnostic, so it applies over both `ncacn_ip_tcp` and `ncacn_np` with no changes to the SMB transports. Key exchange is intentionally not negotiated, so the exported session key equals the NTLMv2 session base key.

Wire behaviour was cross-checked against [MS-RPCE] 3.3 / [MS-NLMP] 3.4 and the impacket reference. For NTLM2 the signature covers the whole PDU minus the trailing `auth_value` (header + body + padded stub + `sec_trailer`), computed over plaintext; at `PKT_PRIVACY` only the stub and its padding are sealed.

### What changed
- **`crypto/spnego/ntlm/security`** (new): NTLM2 per-message signing/sealing — sign/seal key derivation (MS-NLMP 3.4.5), stateful per-direction RC4 handles, and `Sign`/`SealWith`/`VerifySignature`/`DecryptInbound` with independent inbound/outbound sequence numbers (MS-NLMP 3.4.3/3.4.4).
- **`network/dcerpc/v5/pdu`**: `SecTrailer` (auth_verifier_co) and `Auth3` codecs, the `auth3` packet type (16), auth-type/auth-level constants, an optional auth verifier on `Bind`, an `ExtractAuthVerifier` helper, and a corrected `stubEnd` that subtracts `auth_length + sec_trailer`.
- **`network/dcerpc/v5/client`**: `SetAuth(authType, authLevel, creds)`; `Bind` performs the NTLM negotiate → challenge → `auth3` exchange and builds the security context; `sendRequest` signs/seals each fragment and reserves verifier space in the fragment budget; `readResponse` decrypts and verifies protected responses.

### How Verified
- **Tests:** `go test ./network/dcerpc/v5/... ./crypto/spnego/ntlm/security/` passes. New unit tests: the MS-NLMP 4.2.4.4 GSS_WrapEx known-answer vector (`TestSealKnownAnswer`), sign/seal round-trips, sec_trailer/auth3 round-trips and bind auth-verifier alignment, and `SetAuth` validation.
- **Runtime (live Windows DC):** an `integration`-tagged test binds to the endpoint mapper over `ncacn_ip_tcp` at both `PKT_INTEGRITY` and `PKT_PRIVACY`, completes the NTLM handshake, and issues a signed/sealed `ept_lookup`; the response is decrypted and signature-verified, recovering 492 endpoint-map entries at each level.

### Test Coverage
- **Added:** `crypto/spnego/ntlm/security/security_test.go`, `network/dcerpc/v5/pdu/auth_test.go`, `network/dcerpc/v5/client/auth_test.go`, and the live `auth_integration_test.go` (build tag `integration`).

### Scope of Change
- **Files changed:** `crypto/spnego/ntlm/security/{security,security_test}.go`, `network/dcerpc/v5/pdu/{sectrailer,auth3,auth_test}.go` + edits to `bind.go`/`ptype.go`/`request.go`, `network/dcerpc/v5/client/{auth,auth_test}.go` + edits to `client.go`, and one integration test under the ept interface.
- **Submodule pointer updated:** no
- **Behavioural changes outside the bug fix:** none — anonymous binds are unchanged when `SetAuth` is not called.

### Risk and Rollout
Additive and opt-in: the authenticated path is reachable only via `SetAuth`. The one shared edit is `stubEnd`, whose previous `auth_length > 0` branch was dead code (no PDU set `auth_length`), so existing unauthenticated parsing is unaffected.