### PR TITLE
Support pass-the-hash for NTLM RPC authentication (#650)

### DIFF
--- a/crypto/spnego/ntlm/message/authenticate/authenticate.go
+++ b/crypto/spnego/ntlm/message/authenticate/authenticate.go
@@ -85,8 +85,50 @@ type AuthenticateMessage struct {
 	SessionKey []byte
 }
 
-// CreateAuthenticateMessage creates an NTLM AUTHENTICATE message
+// CreateAuthenticateMessage creates an NTLM AUTHENTICATE message from a cleartext
+// password. When the server negotiated extended session security it uses NTLMv2;
+// otherwise it falls back to NTLMv1.
 func CreateAuthenticateMessage(challenge *challenge.ChallengeMessage, username, password, domain, workstation string) (*AuthenticateMessage, error) {
+	var v2 *ntlmv2.NTLMv2Ctx
+	if (challenge.NegotiateFlags & flags.NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY) != 0 {
+		clientChallenge := [8]byte{}
+		if _, err := rand.Read(clientChallenge[:]); err != nil {
+			return nil, err
+		}
+		var err error
+		v2, err = ntlmv2.NewNTLMv2CtxWithPassword(domain, username, password, challenge.ServerChallenge, clientChallenge)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return newAuthenticateMessage(challenge, username, password, domain, workstation, v2)
+}
+
+// CreateAuthenticateMessageWithNTHash creates an NTLM AUTHENTICATE message from an NT
+// hash instead of a cleartext password (pass-the-hash). It requires the server to have
+// negotiated extended session security, as the derived session key needed for RPC/SMB
+// signing and sealing only exists on the NTLMv2 path; NTLMv1 pass-the-hash is not
+// supported.
+func CreateAuthenticateMessageWithNTHash(challenge *challenge.ChallengeMessage, username string, ntHash [16]byte, domain, workstation string) (*AuthenticateMessage, error) {
+	if (challenge.NegotiateFlags & flags.NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY) == 0 {
+		return nil, fmt.Errorf("pass-the-hash requires NTLMv2: server did not negotiate extended session security")
+	}
+	clientChallenge := [8]byte{}
+	if _, err := rand.Read(clientChallenge[:]); err != nil {
+		return nil, err
+	}
+	v2, err := ntlmv2.NewNTLMv2CtxWithNTHash(domain, username, ntHash, challenge.ServerChallenge, clientChallenge)
+	if err != nil {
+		return nil, err
+	}
+	return newAuthenticateMessage(challenge, username, "", domain, workstation, v2)
+}
+
+// newAuthenticateMessage builds the AUTHENTICATE message shared by the password and
+// pass-the-hash entry points. When v2 is non-nil the NTLMv2 (extended session security)
+// responses and session key are computed from it; otherwise it falls back to NTLMv1,
+// which is driven by the cleartext password.
+func newAuthenticateMessage(challenge *challenge.ChallengeMessage, username, password, domain, workstation string, v2 *ntlmv2.NTLMv2Ctx) (*AuthenticateMessage, error) {
 	// Create the AuthenticateMessage struct
 	msg := AuthenticateMessage{}
 
@@ -130,18 +172,8 @@ func CreateAuthenticateMessage(challenge *challenge.ChallengeMessage, username, 
 	// Calculate NT response
 	var err error
 
-	if (challenge.NegotiateFlags & flags.NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY) != 0 {
+	if v2 != nil {
 		// Use NTLMv2 (MS-NLMP 3.3.2)
-		clientChallenge := [8]byte{}
-		_, err = rand.Read(clientChallenge[:])
-		if err != nil {
-			return nil, err
-		}
-
-		ctx, err := ntlmv2.NewNTLMv2CtxWithPassword(domain, username, password, challenge.ServerChallenge, clientChallenge)
-		if err != nil {
-			return nil, err
-		}
 
 		// Prepare TargetInfo for the blob: add the MsvAvTargetName (SPN) AVPair, as
 		// the Windows client does. This server (Server 2016, signing required)
@@ -158,16 +190,16 @@ func CreateAuthenticateMessage(challenge *challenge.ChallengeMessage, username, 
 		}
 
 		var ntProofStr []byte
-		msg.NtChallengeResponse, ntProofStr, err = ctx.ComputeNTChallengeResponse(timestamp, blobTargetInfo)
+		msg.NtChallengeResponse, ntProofStr, err = v2.ComputeNTChallengeResponse(timestamp, blobTargetInfo)
 		if err != nil {
 			return nil, err
 		}
 		// Send a real LMv2 response (the Windows client does, even with a timestamp).
-		msg.LmChallengeResponse = ctx.ComputeLMChallengeResponse(false)
+		msg.LmChallengeResponse = v2.ComputeLMChallengeResponse(false)
 
 		// EXPERIMENT: no key exchange. The exported session key (the SMB signing MAC
 		// key) equals the SessionBaseKey.
-		msg.SessionKey = ctx.ComputeSessionBaseKey(ntProofStr)
+		msg.SessionKey = v2.ComputeSessionBaseKey(ntProofStr)
 	} else {
 		// Use NTLMv1
 		ntlmv1Ctx, err := ntlmv1.NewNTLMv1CtxWithPassword(domain, username, password, challenge.ServerChallenge)

--- a/crypto/spnego/ntlm/message/authenticate/passthehash_test.go
+++ b/crypto/spnego/ntlm/message/authenticate/passthehash_test.go
@@ -1,0 +1,63 @@
+package authenticate
+
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/crypto/nt"
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/message/challenge"
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/message/negotiate/flags"
+)
+
+// newTestChallenge builds a minimal CHALLENGE_MESSAGE for driving AUTHENTICATE
+// construction in tests, with the given negotiate flags and a fixed server challenge.
+func newTestChallenge(negFlags flags.NegotiateFlags) *challenge.ChallengeMessage {
+	return &challenge.ChallengeMessage{
+		NegotiateFlags:  negFlags,
+		ServerChallenge: [8]byte{0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef},
+	}
+}
+
+// TestCreateAuthenticateMessageWithNTHash verifies the pass-the-hash entry point
+// produces a well-formed NTLMv2 AUTHENTICATE message: a real NT/LM response and a
+// 16-byte exported session key (needed for RPC/SMB signing and sealing).
+func TestCreateAuthenticateMessageWithNTHash(t *testing.T) {
+	negFlags := flags.NTLMSSP_NEGOTIATE_UNICODE |
+		flags.NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY |
+		flags.NTLMSSP_NEGOTIATE_TARGET_INFO
+	chal := newTestChallenge(negFlags)
+	ntHash := nt.NTHash("Password")
+
+	msg, err := CreateAuthenticateMessageWithNTHash(chal, "User", ntHash, "Domain", "WORKSTATION")
+	if err != nil {
+		t.Fatalf("CreateAuthenticateMessageWithNTHash: %v", err)
+	}
+	if len(msg.SessionKey) != 16 {
+		t.Errorf("SessionKey length = %d, want 16", len(msg.SessionKey))
+	}
+	if len(msg.NtChallengeResponse) < 16 {
+		t.Errorf("NtChallengeResponse too short: %d bytes", len(msg.NtChallengeResponse))
+	}
+	if len(msg.LmChallengeResponse) != 24 {
+		t.Errorf("LmChallengeResponse length = %d, want 24", len(msg.LmChallengeResponse))
+	}
+
+	// The message must marshal and round-trip back to a parseable AUTHENTICATE.
+	raw, err := msg.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var got AuthenticateMessage
+	if _, err := got.Unmarshal(raw); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+}
+
+// TestCreateAuthenticateMessageWithNTHashRequiresNTLMv2 confirms pass-the-hash is
+// rejected when the server did not negotiate extended session security, since no
+// session key could be derived for signing/sealing.
+func TestCreateAuthenticateMessageWithNTHashRequiresNTLMv2(t *testing.T) {
+	chal := newTestChallenge(flags.NTLMSSP_NEGOTIATE_UNICODE)
+	if _, err := CreateAuthenticateMessageWithNTHash(chal, "User", nt.NTHash("Password"), "Domain", "WORKSTATION"); err == nil {
+		t.Fatal("expected error without extended session security, got nil")
+	}
+}

--- a/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/functions/auth_integration_test.go
+++ b/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/functions/auth_integration_test.go
@@ -30,7 +30,9 @@ func TestIntegration_AuthenticatedBind(t *testing.T) {
 	if host == "" {
 		t.Skip("DCERPC_TEST_HOST not set; skipping live authenticated bind test")
 	}
-	creds, err := credentials.NewCredentials(os.Getenv("DCERPC_TEST_DOMAIN"), os.Getenv("DCERPC_TEST_USER"), os.Getenv("DCERPC_TEST_PASS"), "")
+	// DCERPC_TEST_HASHES (LM:NT or NT) exercises pass-the-hash; leave it empty to use
+	// DCERPC_TEST_PASS.
+	creds, err := credentials.NewCredentials(os.Getenv("DCERPC_TEST_DOMAIN"), os.Getenv("DCERPC_TEST_USER"), os.Getenv("DCERPC_TEST_PASS"), os.Getenv("DCERPC_TEST_HASHES"))
 	if err != nil {
 		t.Fatalf("NewCredentials: %v", err)
 	}

--- a/network/dcerpc/v5/client/auth.go
+++ b/network/dcerpc/v5/client/auth.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"encoding/binary"
+	"encoding/hex"
 	"fmt"
 
 	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/message/authenticate"
@@ -32,7 +33,8 @@ const rpcNTLMNegotiateFlags = flags.NTLMSSP_NEGOTIATE_UNICODE |
 // security provider (only NTLM, pdu.AuthTypeNTLMSSP, is supported) and authLevel the
 // protection applied to each PDU: pdu.AuthLevelConnect authenticates the bind only,
 // while pdu.AuthLevelPktIntegrity signs and pdu.AuthLevelPktPrivacy signs and seals
-// every request. It must be called before Bind.
+// every request. creds may carry a cleartext password or, for pass-the-hash, an NT
+// hash with no password. It must be called before Bind.
 func (c *Client) SetAuth(authType, authLevel uint8, creds *credentials.Credentials) error {
 	if authType != pdu.AuthTypeNTLMSSP {
 		return fmt.Errorf("dcerpc auth: unsupported auth_type 0x%02x (only NTLM 0x%02x is supported)", authType, pdu.AuthTypeNTLMSSP)
@@ -75,6 +77,25 @@ func (c *Client) negotiateToken() ([]byte, error) {
 	return neg.Marshal()
 }
 
+// buildAuthenticate constructs the NTLM AUTHENTICATE message for the configured
+// credentials. When the credentials carry an NT hash but no password it authenticates
+// by pass-the-hash; otherwise it uses the cleartext password.
+func (c *Client) buildAuthenticate(chal *challenge.ChallengeMessage) (*authenticate.AuthenticateMessage, error) {
+	if c.creds.GetPassword() == "" && c.creds.CanPassTheHash() {
+		raw, err := hex.DecodeString(c.creds.GetNTHash())
+		if err != nil {
+			return nil, fmt.Errorf("decode NT hash: %w", err)
+		}
+		if len(raw) != 16 {
+			return nil, fmt.Errorf("NT hash must be 16 bytes, got %d", len(raw))
+		}
+		var ntHash [16]byte
+		copy(ntHash[:], raw)
+		return authenticate.CreateAuthenticateMessageWithNTHash(chal, c.creds.GetUsername(), ntHash, c.creds.GetDomain(), c.workstation)
+	}
+	return authenticate.CreateAuthenticateMessage(chal, c.creds.GetUsername(), c.creds.GetPassword(), c.creds.GetDomain(), c.workstation)
+}
+
 // completeAuth finishes the NTLM exchange after a bind_ack: it parses the server's
 // CHALLENGE from the bind_ack's auth_value, sends an auth3 carrying the AUTHENTICATE
 // token (to which the server sends no reply), and builds the per-message security
@@ -93,7 +114,7 @@ func (c *Client) completeAuth(bindAckFrag []byte) error {
 		return fmt.Errorf("parse challenge: %w", err)
 	}
 
-	auth, err := authenticate.CreateAuthenticateMessage(&chal, c.creds.GetUsername(), c.creds.GetPassword(), c.creds.GetDomain(), c.workstation)
+	auth, err := c.buildAuthenticate(&chal)
 	if err != nil {
 		return fmt.Errorf("build authenticate: %w", err)
 	}


### PR DESCRIPTION
### Linked Issue
Closes #650

### Motivation
The NTLM RPC authentication path added in #640/#648 built the AUTHENTICATE message from a cleartext password only. `windows/credentials.Credentials` already carries an `NTHash` (and `CanPassTheHash()`), and the SMB stack can authenticate from a hash, but an RPC caller holding only an NT hash could not establish an authenticated `PKT_INTEGRITY`/`PKT_PRIVACY` context — a common operating mode for the `TheManticoreProject/msrpc` consumer.

### Fix Description
- **`crypto/spnego/ntlm/message/authenticate`**: add `CreateAuthenticateMessageWithNTHash`, which derives the NTLMv2 responses and exported session key from an NT hash via the existing `ntlmv2.NewNTLMv2CtxWithNTHash`. The password and hash entry points now share a private `newAuthenticateMessage` core, so the password path (used by SMB session setup too) is behaviorally unchanged. Pass-the-hash requires the server to negotiate extended session security (NTLMv2); it errors otherwise, since the session key needed for signing/sealing only exists on that path (NTLMv1 PtH is not supported).
- **`network/dcerpc/v5/client`**: `completeAuth` selects the hash path when the credentials carry an NT hash and no password, decoding the 16-byte hash from `Credentials.NTHash`.

Considered and rejected: a standalone hash-only function duplicating ~120 lines of message construction. Sharing the core keeps the two entry points in lockstep and avoids drift.

### How Verified
- **Tests:** `go test ./crypto/spnego/ntlm/... ./network/dcerpc/v5/...` passes, including the unchanged password-path tests. New unit tests (`passthehash_test.go`): the hash entry point yields a 16-byte session key and a well-formed, round-trippable AUTHENTICATE, and is rejected without extended session security.
- **Runtime (live Windows DC):** the `integration`-tagged authenticated-bind test, run with only the Administrator NT hash and an empty password (`DCERPC_TEST_HASHES`), completes the NTLM handshake and a sealed `ept_lookup` at both `PKT_INTEGRITY` and `PKT_PRIVACY` (492 entries each). The password path was re-run as a regression and still passes.

### Test Coverage
- **Added:** `crypto/spnego/ntlm/message/authenticate/passthehash_test.go`; the live `auth_integration_test.go` now also drives pass-the-hash via `DCERPC_TEST_HASHES`.

### Scope of Change
- **Files changed:** `crypto/spnego/ntlm/message/authenticate/{authenticate,passthehash_test}.go`, `network/dcerpc/v5/client/auth.go`, and the ept `auth_integration_test.go`.
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none — the password path is refactored to delegate to a shared core with identical behavior.

### Risk and Rollout
Low and opt-in: pass-the-hash is reached only when credentials supply an NT hash with no password. The one shared edit refactors `CreateAuthenticateMessage` to delegate to `newAuthenticateMessage` without changing its inputs, outputs, or the NTLMv1 fallback; the existing NTLM unit tests and the live password path confirm no regression.