### PR TITLE
Support auth levels RPC_C_AUTHN_LEVEL_CALL and _PKT (#651)

### DIFF
--- a/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/functions/auth_integration_test.go
+++ b/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/functions/auth_integration_test.go
@@ -41,6 +41,8 @@ func TestIntegration_AuthenticatedBind(t *testing.T) {
 		name  string
 		level uint8
 	}{
+		{"CALL", pdu.AuthLevelCall},
+		{"PKT", pdu.AuthLevelPkt},
 		{"PKT_INTEGRITY", pdu.AuthLevelPktIntegrity},
 		{"PKT_PRIVACY", pdu.AuthLevelPktPrivacy},
 	}

--- a/network/dcerpc/v5/client/auth.go
+++ b/network/dcerpc/v5/client/auth.go
@@ -31,16 +31,24 @@ const rpcNTLMNegotiateFlags = flags.NTLMSSP_NEGOTIATE_UNICODE |
 
 // SetAuth enables RPC-level authentication for subsequent binds. authType selects the
 // security provider (only NTLM, pdu.AuthTypeNTLMSSP, is supported) and authLevel the
-// protection applied to each PDU: pdu.AuthLevelConnect authenticates the bind only,
-// while pdu.AuthLevelPktIntegrity signs and pdu.AuthLevelPktPrivacy signs and seals
-// every request. creds may carry a cleartext password or, for pass-the-hash, an NT
-// hash with no password. It must be called before Bind.
+// protection applied to each PDU: pdu.AuthLevelConnect authenticates the bind only;
+// pdu.AuthLevelCall and pdu.AuthLevelPkt attach a per-PDU authenticity verifier;
+// pdu.AuthLevelPktIntegrity additionally signs the request data; and
+// pdu.AuthLevelPktPrivacy signs and seals it. creds may carry a cleartext password or,
+// for pass-the-hash, an NT hash with no password. It must be called before Bind.
+//
+// AuthLevelCall is promoted to AuthLevelPkt: it has no distinct meaning for the
+// connection-oriented protocol, where the runtime uses packet-level protection instead
+// ([MS-RPCE] 2.2.1.1.8).
 func (c *Client) SetAuth(authType, authLevel uint8, creds *credentials.Credentials) error {
 	if authType != pdu.AuthTypeNTLMSSP {
 		return fmt.Errorf("dcerpc auth: unsupported auth_type 0x%02x (only NTLM 0x%02x is supported)", authType, pdu.AuthTypeNTLMSSP)
 	}
+	if authLevel == pdu.AuthLevelCall {
+		authLevel = pdu.AuthLevelPkt
+	}
 	switch authLevel {
-	case pdu.AuthLevelConnect, pdu.AuthLevelPktIntegrity, pdu.AuthLevelPktPrivacy:
+	case pdu.AuthLevelConnect, pdu.AuthLevelPkt, pdu.AuthLevelPktIntegrity, pdu.AuthLevelPktPrivacy:
 	default:
 		return fmt.Errorf("dcerpc auth: unsupported auth_level %d", authLevel)
 	}
@@ -56,11 +64,13 @@ func (c *Client) SetAuth(authType, authLevel uint8, creds *credentials.Credentia
 // authConfigured reports whether SetAuth selected an authenticated bind.
 func (c *Client) authConfigured() bool { return c.creds != nil && c.authType != pdu.AuthTypeNone }
 
-// protectsRequests reports whether each request PDU must carry a signed (or sealed)
-// auth verifier, which is the case once an integrity- or privacy-level security
-// context has been established.
+// protectsRequests reports whether each request PDU must carry a per-PDU auth verifier.
+// PKT, PKT_INTEGRITY, and PKT_PRIVACY all attach one (NTLM produces the same signature
+// for the first two; only PKT_PRIVACY additionally seals the stub); CONNECT
+// authenticates the bind alone. The levels are an ascending scale ([MS-RPCE]
+// 2.2.1.1.8), so a single threshold separates the per-PDU levels from CONNECT.
 func (c *Client) protectsRequests() bool {
-	return c.sec != nil && (c.authLevel == pdu.AuthLevelPktIntegrity || c.authLevel == pdu.AuthLevelPktPrivacy)
+	return c.sec != nil && c.authLevel >= pdu.AuthLevelPkt
 }
 
 // authVerifierOverhead is the worst-case number of bytes an authenticated request PDU

--- a/network/dcerpc/v5/client/auth_test.go
+++ b/network/dcerpc/v5/client/auth_test.go
@@ -22,9 +22,12 @@ func TestSetAuthValidation(t *testing.T) {
 	}{
 		{"ntlm privacy", pdu.AuthTypeNTLMSSP, pdu.AuthLevelPktPrivacy, creds, false},
 		{"ntlm integrity", pdu.AuthTypeNTLMSSP, pdu.AuthLevelPktIntegrity, creds, false},
+		{"ntlm pkt", pdu.AuthTypeNTLMSSP, pdu.AuthLevelPkt, creds, false},
+		{"ntlm call (promoted to pkt)", pdu.AuthTypeNTLMSSP, pdu.AuthLevelCall, creds, false},
 		{"ntlm connect", pdu.AuthTypeNTLMSSP, pdu.AuthLevelConnect, creds, false},
 		{"unsupported auth type", pdu.AuthTypeGSSKerberos, pdu.AuthLevelPktPrivacy, creds, true},
 		{"unsupported level (none)", pdu.AuthTypeNTLMSSP, pdu.AuthLevelNone, creds, true},
+		{"unsupported level (default)", pdu.AuthTypeNTLMSSP, pdu.AuthLevelDefault, creds, true},
 		{"nil credentials", pdu.AuthTypeNTLMSSP, pdu.AuthLevelPktPrivacy, nil, true},
 	}
 	for _, tc := range cases {
@@ -47,5 +50,21 @@ func TestSetAuthValidation(t *testing.T) {
 				t.Fatal("auth should be configured after a successful SetAuth")
 			}
 		})
+	}
+}
+
+// TestSetAuthCallPromotedToPkt verifies that the connection-oriented client maps
+// RPC_C_AUTHN_LEVEL_CALL onto PKT, which is what is carried in the sec_trailer.
+func TestSetAuthCallPromotedToPkt(t *testing.T) {
+	creds, err := credentials.NewCredentials("", "user", "pass", "")
+	if err != nil {
+		t.Fatalf("NewCredentials: %v", err)
+	}
+	c := NewClient(nil)
+	if err := c.SetAuth(pdu.AuthTypeNTLMSSP, pdu.AuthLevelCall, creds); err != nil {
+		t.Fatalf("SetAuth(call): %v", err)
+	}
+	if c.authLevel != pdu.AuthLevelPkt {
+		t.Errorf("auth level = %d, want PKT (%d) after CALL promotion", c.authLevel, pdu.AuthLevelPkt)
 	}
 }


### PR DESCRIPTION
### Linked Issue
Closes #651

### Motivation
`Client.SetAuth` accepted only `CONNECT`, `PKT_INTEGRITY`, and `PKT_PRIVACY`, rejecting the two intermediate levels `RPC_C_AUTHN_LEVEL_CALL` (3) and `RPC_C_AUTHN_LEVEL_PKT` (4). This completes the auth-level range so the client can honor a peer/policy that requests packet- or call-level protection instead of failing `SetAuth`.

### Fix Description
- `SetAuth` now accepts `pdu.AuthLevelPkt` and `pdu.AuthLevelCall`. `CALL` has no distinct meaning for connection-oriented RPC, so it is promoted to `PKT` — the same mapping the Windows runtime performs ([MS-RPCE] 2.2.1.1.8) — and `PKT` is what is carried in the sec_trailer.
- `protectsRequests` now attaches a per-PDU verifier for `PKT` and above (previously only `PKT_INTEGRITY`/`PKT_PRIVACY`), expressed as a single threshold over the ascending level scale.

No change was needed to request/response marshaling: for the NTLM provider, `PKT` and `PKT_INTEGRITY` produce the identical per-PDU signature (NTLM has a single MakeSignature), and only `PKT_PRIVACY` adds sealing — which the existing sign-vs-seal split in `marshalProtectedRequest`/`unprotectResponseStub` already handles. The sec_trailer's `auth_level` field carries the configured level so the server applies the matching protection.

### How Verified
- **Tests:** `go test ./network/dcerpc/v5/...` passes. `TestSetAuthValidation` now covers `PKT` and `CALL` (accepted) plus `DEFAULT` (rejected), and `TestSetAuthCallPromotedToPkt` asserts the CALL→PKT promotion.
- **Runtime (live Windows DC):** the `integration`-tagged authenticated-bind test now runs all four per-PDU levels; `CALL`, `PKT`, `PKT_INTEGRITY`, and `PKT_PRIVACY` each complete the NTLM bind and a signed/sealed `ept_lookup` (492 entries each).

### Test Coverage
- **Added:** `TestSetAuthCallPromotedToPkt` and new cases in `TestSetAuthValidation`; the live `auth_integration_test.go` now exercises `CALL` and `PKT` alongside the existing levels.

### Scope of Change
- **Files changed:** `network/dcerpc/v5/client/auth.go`, `network/dcerpc/v5/client/auth_test.go`, and the ept `auth_integration_test.go`.
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none — `CONNECT`/`PKT_INTEGRITY`/`PKT_PRIVACY` behavior is unchanged.

### Risk and Rollout
Low and additive: the only behavioral change is that two previously rejected levels are now accepted and map onto the existing signing path; the privacy/integrity/connect paths are untouched.