### PR TITLE
Add SChannel, Netlogon, and Default RPC security provider constants

### DIFF
--- a/network/dcerpc/v5/pdu/sectrailer.go
+++ b/network/dcerpc/v5/pdu/sectrailer.go
@@ -14,7 +14,12 @@ const (
 	AuthTypeNone         uint8 = 0x00
 	AuthTypeGSSNegotiate uint8 = 0x09 // SPNEGO
 	AuthTypeNTLMSSP      uint8 = 0x0A // RPC_C_AUTHN_WINNT
+	AuthTypeGSSSchannel  uint8 = 0x0E // RPC_C_AUTHN_GSS_SCHANNEL
 	AuthTypeGSSKerberos  uint8 = 0x10
+	AuthTypeNetlogon     uint8 = 0x44 // RPC_C_AUTHN_NETLOGON
+	// AuthTypeDefault selects the implementation default provider; it is an SSPI
+	// selector value, not a value that appears in a sec_trailer on the wire.
+	AuthTypeDefault uint8 = 0xFF // RPC_C_AUTHN_DEFAULT
 )
 
 // Authentication levels (auth_level), as carried in the sec_trailer. Higher levels


### PR DESCRIPTION
### Summary
Define the remaining DCE/RPC `auth_type` (security provider) values from [MS-RPCE] 2.2.1.1.7 so the full set is named for reference, complementing the providers already present (`None`, `GSS_NEGOTIATE`, `NTLMSSP`, `GSS_KERBEROS`).

### Change
Added to `network/dcerpc/v5/pdu/sectrailer.go`:
- `AuthTypeGSSSchannel` = `0x0E` (`RPC_C_AUTHN_GSS_SCHANNEL`)
- `AuthTypeNetlogon` = `0x44` (`RPC_C_AUTHN_NETLOGON`)
- `AuthTypeDefault` = `0xFF` (`RPC_C_AUTHN_DEFAULT`)

`AuthTypeDefault` is documented as an SSPI provider-selection sentinel that does not appear in a sec_trailer on the wire.

### Notes
These are constants only — none are wired into `Client.SetAuth`, which still accepts NTLM exclusively. They document the value space and give future work (e.g. Kerberos #649) named references.

### How Verified
`gofmt`, `go build ./network/dcerpc/...`, and `go test ./network/dcerpc/v5/pdu/` all pass. No behavioral change.

### Scope of Change
- **Files changed:** `network/dcerpc/v5/pdu/sectrailer.go`
- **Behavioral changes:** none