### PR TITLE
Implement DS_REPL_*_BLOB structures in windows/activedirectory/replication/dsrepl (#641–#647)

### DIFF
--- a/windows/activedirectory/replication/dsrepl/DS_REPL_ATTR_META_DATA_BLOB.go
+++ b/windows/activedirectory/replication/dsrepl/DS_REPL_ATTR_META_DATA_BLOB.go
@@ -20,8 +20,8 @@ const ds_repl_attr_meta_data_blob_header_size = 52
 //
 // Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/63fabec7-cb4b-47ed-ab45-9a20e4397d55
 type DS_REPL_ATTR_META_DATA_BLOB struct {
-	// AttributeName is the LDAP display name of the attribute (oszAttributeName).
-	AttributeName string
+	// AttributeName is the LDAP display name of the attribute (oszAttributeName). nil if NULL.
+	AttributeName *string
 	// Version is the dwVersion of the attribute's AttributeStamp (dwVersion).
 	Version uint32
 	// LastOriginatingChange is the timeChanged of the AttributeStamp (ftimeLastOriginatingChange).
@@ -32,8 +32,8 @@ type DS_REPL_ATTR_META_DATA_BLOB struct {
 	OriginatingChange int64
 	// LocalChange is the USN on the destination server of the last applied change (usnLocalChange).
 	LocalChange int64
-	// LastOriginatingDsaDN is the DN of the nTDSDSA object that originated the last replication (oszLastOriginatingDsaDN).
-	LastOriginatingDsaDN string
+	// LastOriginatingDsaDN is the DN of the nTDSDSA object that originated the last replication (oszLastOriginatingDsaDN). nil if NULL.
+	LastOriginatingDsaDN *string
 }
 
 // NewDS_REPL_ATTR_META_DATA_BLOB creates a new, empty DS_REPL_ATTR_META_DATA_BLOB structure.
@@ -112,7 +112,7 @@ func (b *DS_REPL_ATTR_META_DATA_BLOB) Marshal() ([]byte, error) {
 
 // String returns a string representation of the DS_REPL_ATTR_META_DATA_BLOB structure.
 func (b *DS_REPL_ATTR_META_DATA_BLOB) String() string {
-	return fmt.Sprintf("DS_REPL_ATTR_META_DATA_BLOB: AttributeName=%q, Version=%d, LastOriginatingDsaDN=%q", b.AttributeName, b.Version, b.LastOriginatingDsaDN)
+	return fmt.Sprintf("DS_REPL_ATTR_META_DATA_BLOB: AttributeName=%s, Version=%d, LastOriginatingDsaDN=%s", describeOszString(b.AttributeName), b.Version, describeOszString(b.LastOriginatingDsaDN))
 }
 
 // Describe prints the DS_REPL_ATTR_META_DATA_BLOB structure to the console.
@@ -122,12 +122,12 @@ func (b *DS_REPL_ATTR_META_DATA_BLOB) String() string {
 func (b *DS_REPL_ATTR_META_DATA_BLOB) Describe(indent int) {
 	indentPrompt := strings.Repeat(" │ ", indent)
 	fmt.Printf("%s<\x1b[93mDS_REPL_ATTR_META_DATA_BLOB\x1b[0m>\n", indentPrompt)
-	fmt.Printf("%s │ \x1b[93mAttributeName\x1b[0m: %q\n", indentPrompt, b.AttributeName)
+	fmt.Printf("%s │ \x1b[93mAttributeName\x1b[0m: %s\n", indentPrompt, describeOszString(b.AttributeName))
 	fmt.Printf("%s │ \x1b[93mVersion\x1b[0m: %d\n", indentPrompt, b.Version)
 	fmt.Printf("%s │ \x1b[93mLastOriginatingChange\x1b[0m: %s\n", indentPrompt, b.LastOriginatingChange.String())
 	fmt.Printf("%s │ \x1b[93mLastOriginatingDsaInvocationID\x1b[0m: %s\n", indentPrompt, b.LastOriginatingDsaInvocationID.ToFormatD())
 	fmt.Printf("%s │ \x1b[93mOriginatingChange\x1b[0m: %d\n", indentPrompt, b.OriginatingChange)
 	fmt.Printf("%s │ \x1b[93mLocalChange\x1b[0m: %d\n", indentPrompt, b.LocalChange)
-	fmt.Printf("%s │ \x1b[93mLastOriginatingDsaDN\x1b[0m: %q\n", indentPrompt, b.LastOriginatingDsaDN)
+	fmt.Printf("%s │ \x1b[93mLastOriginatingDsaDN\x1b[0m: %s\n", indentPrompt, describeOszString(b.LastOriginatingDsaDN))
 	fmt.Printf("%s └───\n", indentPrompt)
 }

--- a/windows/activedirectory/replication/dsrepl/DS_REPL_ATTR_META_DATA_BLOB.go
+++ b/windows/activedirectory/replication/dsrepl/DS_REPL_ATTR_META_DATA_BLOB.go
@@ -1,0 +1,133 @@
+package dsrepl
+
+import (
+	"encoding/binary"
+	"fmt"
+	"strings"
+
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+	"github.com/TheManticoreProject/Manticore/windows/ms_dtyp/common/data_structures"
+)
+
+// ds_repl_attr_meta_data_blob_header_size is the size, in bytes, of the fixed
+// header that precedes the variable-length data region.
+const ds_repl_attr_meta_data_blob_header_size = 52
+
+// DS_REPL_ATTR_META_DATA_BLOB is a representation of a stamp variable (of type
+// AttributeStamp) of an attribute. This structure, retrieved using an LDAP search
+// method, is an alternative representation of DS_REPL_ATTR_META_DATA_2, retrieved
+// using the IDL_DRSGetReplInfo RPC method.
+//
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/63fabec7-cb4b-47ed-ab45-9a20e4397d55
+type DS_REPL_ATTR_META_DATA_BLOB struct {
+	// AttributeName is the LDAP display name of the attribute (oszAttributeName).
+	AttributeName string
+	// Version is the dwVersion of the attribute's AttributeStamp (dwVersion).
+	Version uint32
+	// LastOriginatingChange is the timeChanged of the AttributeStamp (ftimeLastOriginatingChange).
+	LastOriginatingChange data_structures.FILETIME
+	// LastOriginatingDsaInvocationID is the uuidOriginating of the AttributeStamp (uuidLastOriginatingDsaInvocationID).
+	LastOriginatingDsaInvocationID guid.GUID
+	// OriginatingChange is the usnOriginating of the AttributeStamp (usnOriginatingChange).
+	OriginatingChange int64
+	// LocalChange is the USN on the destination server of the last applied change (usnLocalChange).
+	LocalChange int64
+	// LastOriginatingDsaDN is the DN of the nTDSDSA object that originated the last replication (oszLastOriginatingDsaDN).
+	LastOriginatingDsaDN string
+}
+
+// NewDS_REPL_ATTR_META_DATA_BLOB creates a new, empty DS_REPL_ATTR_META_DATA_BLOB structure.
+func NewDS_REPL_ATTR_META_DATA_BLOB() *DS_REPL_ATTR_META_DATA_BLOB {
+	return &DS_REPL_ATTR_META_DATA_BLOB{}
+}
+
+// Unmarshal parses a DS_REPL_ATTR_META_DATA_BLOB structure from a byte slice.
+//
+// Parameters:
+// - data: A byte slice containing the structure (header followed by its data region).
+//
+// Returns:
+// - The number of bytes consumed.
+// - An error if the unmarshalling fails.
+func (b *DS_REPL_ATTR_META_DATA_BLOB) Unmarshal(data []byte) (int, error) {
+	if len(data) < ds_repl_attr_meta_data_blob_header_size {
+		return 0, fmt.Errorf("data is too short to unmarshal DS_REPL_ATTR_META_DATA_BLOB (expected at least %d bytes, got %d)", ds_repl_attr_meta_data_blob_header_size, len(data))
+	}
+
+	oszAttributeName := binary.LittleEndian.Uint32(data[0:4])
+
+	b.Version = binary.LittleEndian.Uint32(data[4:8])
+
+	if _, err := b.LastOriginatingChange.Unmarshal(data[8:16]); err != nil {
+		return 0, err
+	}
+
+	b.LastOriginatingDsaInvocationID.FromRawBytes(data[16:32])
+
+	b.OriginatingChange = int64(binary.LittleEndian.Uint64(data[32:40]))
+	b.LocalChange = int64(binary.LittleEndian.Uint64(data[40:48]))
+
+	oszLastOriginatingDsaDN := binary.LittleEndian.Uint32(data[48:52])
+
+	var err error
+	if b.AttributeName, err = readOffsetString(data, oszAttributeName); err != nil {
+		return 0, err
+	}
+	if b.LastOriginatingDsaDN, err = readOffsetString(data, oszLastOriginatingDsaDN); err != nil {
+		return 0, err
+	}
+
+	return len(data), nil
+}
+
+// Marshal serializes the DS_REPL_ATTR_META_DATA_BLOB structure into a byte slice.
+//
+// Returns:
+// - A byte slice containing the marshalled structure.
+// - An error if the marshalling fails.
+func (b *DS_REPL_ATTR_META_DATA_BLOB) Marshal() ([]byte, error) {
+	data := newDataRegion(ds_repl_attr_meta_data_blob_header_size)
+
+	header := make([]byte, ds_repl_attr_meta_data_blob_header_size)
+
+	binary.LittleEndian.PutUint32(header[0:4], data.addString(b.AttributeName))
+
+	binary.LittleEndian.PutUint32(header[4:8], b.Version)
+
+	lastOriginatingChange, err := b.LastOriginatingChange.Marshal()
+	if err != nil {
+		return nil, err
+	}
+	copy(header[8:16], lastOriginatingChange)
+
+	copy(header[16:32], b.LastOriginatingDsaInvocationID.ToBytes())
+
+	binary.LittleEndian.PutUint64(header[32:40], uint64(b.OriginatingChange))
+	binary.LittleEndian.PutUint64(header[40:48], uint64(b.LocalChange))
+
+	binary.LittleEndian.PutUint32(header[48:52], data.addString(b.LastOriginatingDsaDN))
+
+	return append(header, data.bytes()...), nil
+}
+
+// String returns a string representation of the DS_REPL_ATTR_META_DATA_BLOB structure.
+func (b *DS_REPL_ATTR_META_DATA_BLOB) String() string {
+	return fmt.Sprintf("DS_REPL_ATTR_META_DATA_BLOB: AttributeName=%q, Version=%d, LastOriginatingDsaDN=%q", b.AttributeName, b.Version, b.LastOriginatingDsaDN)
+}
+
+// Describe prints the DS_REPL_ATTR_META_DATA_BLOB structure to the console.
+//
+// Parameters:
+// - indent: The number of levels to indent the output.
+func (b *DS_REPL_ATTR_META_DATA_BLOB) Describe(indent int) {
+	indentPrompt := strings.Repeat(" │ ", indent)
+	fmt.Printf("%s<\x1b[93mDS_REPL_ATTR_META_DATA_BLOB\x1b[0m>\n", indentPrompt)
+	fmt.Printf("%s │ \x1b[93mAttributeName\x1b[0m: %q\n", indentPrompt, b.AttributeName)
+	fmt.Printf("%s │ \x1b[93mVersion\x1b[0m: %d\n", indentPrompt, b.Version)
+	fmt.Printf("%s │ \x1b[93mLastOriginatingChange\x1b[0m: %s\n", indentPrompt, b.LastOriginatingChange.String())
+	fmt.Printf("%s │ \x1b[93mLastOriginatingDsaInvocationID\x1b[0m: %s\n", indentPrompt, b.LastOriginatingDsaInvocationID.ToFormatD())
+	fmt.Printf("%s │ \x1b[93mOriginatingChange\x1b[0m: %d\n", indentPrompt, b.OriginatingChange)
+	fmt.Printf("%s │ \x1b[93mLocalChange\x1b[0m: %d\n", indentPrompt, b.LocalChange)
+	fmt.Printf("%s │ \x1b[93mLastOriginatingDsaDN\x1b[0m: %q\n", indentPrompt, b.LastOriginatingDsaDN)
+	fmt.Printf("%s └───\n", indentPrompt)
+}

--- a/windows/activedirectory/replication/dsrepl/DS_REPL_ATTR_META_DATA_BLOB_test.go
+++ b/windows/activedirectory/replication/dsrepl/DS_REPL_ATTR_META_DATA_BLOB_test.go
@@ -1,0 +1,62 @@
+package dsrepl_test
+
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/windows/activedirectory/replication/dsrepl"
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+	"github.com/TheManticoreProject/Manticore/windows/ms_dtyp/common/data_structures"
+)
+
+func TestDS_REPL_ATTR_META_DATA_BLOB_RoundTrip(t *testing.T) {
+	g, _ := guid.FromString("01234567-89ab-cdef-0123-456789abcdef")
+
+	original := &dsrepl.DS_REPL_ATTR_META_DATA_BLOB{
+		AttributeName:                  "objectClass",
+		Version:                        4,
+		LastOriginatingChange:          data_structures.FILETIME{DwLowDateTime: 0x11223344, DwHighDateTime: 0x01D05566},
+		LastOriginatingDsaInvocationID: *g,
+		OriginatingChange:              555000,
+		LocalChange:                    556000,
+		LastOriginatingDsaDN:           "CN=NTDS Settings,CN=DC05",
+	}
+
+	marshalled, err := original.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	parsed := dsrepl.NewDS_REPL_ATTR_META_DATA_BLOB()
+	if _, err := parsed.Unmarshal(marshalled); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+
+	if parsed.AttributeName != original.AttributeName {
+		t.Errorf("AttributeName = %q, want %q", parsed.AttributeName, original.AttributeName)
+	}
+	if parsed.Version != original.Version {
+		t.Errorf("Version = %d, want %d", parsed.Version, original.Version)
+	}
+	if parsed.LastOriginatingChange != original.LastOriginatingChange {
+		t.Errorf("LastOriginatingChange = %+v, want %+v", parsed.LastOriginatingChange, original.LastOriginatingChange)
+	}
+	if !parsed.LastOriginatingDsaInvocationID.Equal(&original.LastOriginatingDsaInvocationID) {
+		t.Errorf("LastOriginatingDsaInvocationID mismatch")
+	}
+	if parsed.OriginatingChange != original.OriginatingChange {
+		t.Errorf("OriginatingChange = %d, want %d", parsed.OriginatingChange, original.OriginatingChange)
+	}
+	if parsed.LocalChange != original.LocalChange {
+		t.Errorf("LocalChange = %d, want %d", parsed.LocalChange, original.LocalChange)
+	}
+	if parsed.LastOriginatingDsaDN != original.LastOriginatingDsaDN {
+		t.Errorf("LastOriginatingDsaDN = %q, want %q", parsed.LastOriginatingDsaDN, original.LastOriginatingDsaDN)
+	}
+}
+
+func TestDS_REPL_ATTR_META_DATA_BLOB_ShortData(t *testing.T) {
+	parsed := dsrepl.NewDS_REPL_ATTR_META_DATA_BLOB()
+	if _, err := parsed.Unmarshal(make([]byte, 16)); err == nil {
+		t.Error("expected error for short data, got nil")
+	}
+}

--- a/windows/activedirectory/replication/dsrepl/DS_REPL_ATTR_META_DATA_BLOB_test.go
+++ b/windows/activedirectory/replication/dsrepl/DS_REPL_ATTR_META_DATA_BLOB_test.go
@@ -12,13 +12,13 @@ func TestDS_REPL_ATTR_META_DATA_BLOB_RoundTrip(t *testing.T) {
 	g, _ := guid.FromString("01234567-89ab-cdef-0123-456789abcdef")
 
 	original := &dsrepl.DS_REPL_ATTR_META_DATA_BLOB{
-		AttributeName:                  "objectClass",
+		AttributeName:                  strptr("objectClass"),
 		Version:                        4,
 		LastOriginatingChange:          data_structures.FILETIME{DwLowDateTime: 0x11223344, DwHighDateTime: 0x01D05566},
 		LastOriginatingDsaInvocationID: *g,
 		OriginatingChange:              555000,
 		LocalChange:                    556000,
-		LastOriginatingDsaDN:           "CN=NTDS Settings,CN=DC05",
+		LastOriginatingDsaDN:           strptr("CN=NTDS Settings,CN=DC05"),
 	}
 
 	marshalled, err := original.Marshal()
@@ -31,8 +31,8 @@ func TestDS_REPL_ATTR_META_DATA_BLOB_RoundTrip(t *testing.T) {
 		t.Fatalf("Unmarshal failed: %v", err)
 	}
 
-	if parsed.AttributeName != original.AttributeName {
-		t.Errorf("AttributeName = %q, want %q", parsed.AttributeName, original.AttributeName)
+	if parsed.AttributeName == nil || *parsed.AttributeName != *original.AttributeName {
+		t.Errorf("AttributeName = %v, want %q", parsed.AttributeName, *original.AttributeName)
 	}
 	if parsed.Version != original.Version {
 		t.Errorf("Version = %d, want %d", parsed.Version, original.Version)
@@ -49,8 +49,8 @@ func TestDS_REPL_ATTR_META_DATA_BLOB_RoundTrip(t *testing.T) {
 	if parsed.LocalChange != original.LocalChange {
 		t.Errorf("LocalChange = %d, want %d", parsed.LocalChange, original.LocalChange)
 	}
-	if parsed.LastOriginatingDsaDN != original.LastOriginatingDsaDN {
-		t.Errorf("LastOriginatingDsaDN = %q, want %q", parsed.LastOriginatingDsaDN, original.LastOriginatingDsaDN)
+	if parsed.LastOriginatingDsaDN == nil || *parsed.LastOriginatingDsaDN != *original.LastOriginatingDsaDN {
+		t.Errorf("LastOriginatingDsaDN = %v, want %q", parsed.LastOriginatingDsaDN, *original.LastOriginatingDsaDN)
 	}
 }
 

--- a/windows/activedirectory/replication/dsrepl/DS_REPL_CURSOR_BLOB.go
+++ b/windows/activedirectory/replication/dsrepl/DS_REPL_CURSOR_BLOB.go
@@ -1,0 +1,111 @@
+package dsrepl
+
+import (
+	"encoding/binary"
+	"fmt"
+	"strings"
+
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+	"github.com/TheManticoreProject/Manticore/windows/ms_dtyp/common/data_structures"
+)
+
+// ds_repl_cursor_blob_header_size is the size, in bytes, of the fixed header that
+// precedes the variable-length data region.
+const ds_repl_cursor_blob_header_size = 36
+
+// DS_REPL_CURSOR_BLOB is the packet representation of the ReplUpToDateVector type
+// of an NC replica. This structure, retrieved using an LDAP search method, is an
+// alternative representation of DS_REPL_CURSOR_3W, retrieved using the
+// IDL_DRSGetReplInfo RPC method.
+//
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/42f0e26e-7627-4e68-814c-afc35a2b5f62
+type DS_REPL_CURSOR_BLOB struct {
+	// SourceDsaInvocationID is the invocationId of the originating server (uuidSourceDsaInvocationID).
+	SourceDsaInvocationID guid.GUID
+	// AttributeFilter is the maximum USN recorded for the originating server (usnAttributeFilter).
+	AttributeFilter int64
+	// LastSyncSuccess is the time of the last successful synchronization (fTimeLastSyncSuccess).
+	LastSyncSuccess data_structures.FILETIME
+	// SourceDsaDN is the DN of the DSA of the source server (oszSourceDsaDN).
+	SourceDsaDN string
+}
+
+// NewDS_REPL_CURSOR_BLOB creates a new, empty DS_REPL_CURSOR_BLOB structure.
+func NewDS_REPL_CURSOR_BLOB() *DS_REPL_CURSOR_BLOB {
+	return &DS_REPL_CURSOR_BLOB{}
+}
+
+// Unmarshal parses a DS_REPL_CURSOR_BLOB structure from a byte slice.
+//
+// Parameters:
+// - data: A byte slice containing the structure (header followed by its data region).
+//
+// Returns:
+// - The number of bytes consumed.
+// - An error if the unmarshalling fails.
+func (b *DS_REPL_CURSOR_BLOB) Unmarshal(data []byte) (int, error) {
+	if len(data) < ds_repl_cursor_blob_header_size {
+		return 0, fmt.Errorf("data is too short to unmarshal DS_REPL_CURSOR_BLOB (expected at least %d bytes, got %d)", ds_repl_cursor_blob_header_size, len(data))
+	}
+
+	b.SourceDsaInvocationID.FromRawBytes(data[0:16])
+
+	b.AttributeFilter = int64(binary.LittleEndian.Uint64(data[16:24]))
+
+	if _, err := b.LastSyncSuccess.Unmarshal(data[24:32]); err != nil {
+		return 0, err
+	}
+
+	oszSourceDsaDN := binary.LittleEndian.Uint32(data[32:36])
+
+	var err error
+	if b.SourceDsaDN, err = readOffsetString(data, oszSourceDsaDN); err != nil {
+		return 0, err
+	}
+
+	return len(data), nil
+}
+
+// Marshal serializes the DS_REPL_CURSOR_BLOB structure into a byte slice.
+//
+// Returns:
+// - A byte slice containing the marshalled structure.
+// - An error if the marshalling fails.
+func (b *DS_REPL_CURSOR_BLOB) Marshal() ([]byte, error) {
+	data := newDataRegion(ds_repl_cursor_blob_header_size)
+
+	header := make([]byte, ds_repl_cursor_blob_header_size)
+
+	copy(header[0:16], b.SourceDsaInvocationID.ToBytes())
+
+	binary.LittleEndian.PutUint64(header[16:24], uint64(b.AttributeFilter))
+
+	lastSyncSuccess, err := b.LastSyncSuccess.Marshal()
+	if err != nil {
+		return nil, err
+	}
+	copy(header[24:32], lastSyncSuccess)
+
+	binary.LittleEndian.PutUint32(header[32:36], data.addString(b.SourceDsaDN))
+
+	return append(header, data.bytes()...), nil
+}
+
+// String returns a string representation of the DS_REPL_CURSOR_BLOB structure.
+func (b *DS_REPL_CURSOR_BLOB) String() string {
+	return fmt.Sprintf("DS_REPL_CURSOR_BLOB: SourceDsaInvocationID=%s, AttributeFilter=%d, SourceDsaDN=%q", b.SourceDsaInvocationID.ToFormatD(), b.AttributeFilter, b.SourceDsaDN)
+}
+
+// Describe prints the DS_REPL_CURSOR_BLOB structure to the console.
+//
+// Parameters:
+// - indent: The number of levels to indent the output.
+func (b *DS_REPL_CURSOR_BLOB) Describe(indent int) {
+	indentPrompt := strings.Repeat(" │ ", indent)
+	fmt.Printf("%s<\x1b[93mDS_REPL_CURSOR_BLOB\x1b[0m>\n", indentPrompt)
+	fmt.Printf("%s │ \x1b[93mSourceDsaInvocationID\x1b[0m: %s\n", indentPrompt, b.SourceDsaInvocationID.ToFormatD())
+	fmt.Printf("%s │ \x1b[93mAttributeFilter\x1b[0m: %d\n", indentPrompt, b.AttributeFilter)
+	fmt.Printf("%s │ \x1b[93mLastSyncSuccess\x1b[0m: %s\n", indentPrompt, b.LastSyncSuccess.String())
+	fmt.Printf("%s │ \x1b[93mSourceDsaDN\x1b[0m: %q\n", indentPrompt, b.SourceDsaDN)
+	fmt.Printf("%s └───\n", indentPrompt)
+}

--- a/windows/activedirectory/replication/dsrepl/DS_REPL_CURSOR_BLOB.go
+++ b/windows/activedirectory/replication/dsrepl/DS_REPL_CURSOR_BLOB.go
@@ -26,8 +26,8 @@ type DS_REPL_CURSOR_BLOB struct {
 	AttributeFilter int64
 	// LastSyncSuccess is the time of the last successful synchronization (fTimeLastSyncSuccess).
 	LastSyncSuccess data_structures.FILETIME
-	// SourceDsaDN is the DN of the DSA of the source server (oszSourceDsaDN).
-	SourceDsaDN string
+	// SourceDsaDN is the DN of the DSA of the source server (oszSourceDsaDN). nil if NULL.
+	SourceDsaDN *string
 }
 
 // NewDS_REPL_CURSOR_BLOB creates a new, empty DS_REPL_CURSOR_BLOB structure.
@@ -93,7 +93,7 @@ func (b *DS_REPL_CURSOR_BLOB) Marshal() ([]byte, error) {
 
 // String returns a string representation of the DS_REPL_CURSOR_BLOB structure.
 func (b *DS_REPL_CURSOR_BLOB) String() string {
-	return fmt.Sprintf("DS_REPL_CURSOR_BLOB: SourceDsaInvocationID=%s, AttributeFilter=%d, SourceDsaDN=%q", b.SourceDsaInvocationID.ToFormatD(), b.AttributeFilter, b.SourceDsaDN)
+	return fmt.Sprintf("DS_REPL_CURSOR_BLOB: SourceDsaInvocationID=%s, AttributeFilter=%d, SourceDsaDN=%s", b.SourceDsaInvocationID.ToFormatD(), b.AttributeFilter, describeOszString(b.SourceDsaDN))
 }
 
 // Describe prints the DS_REPL_CURSOR_BLOB structure to the console.
@@ -106,6 +106,6 @@ func (b *DS_REPL_CURSOR_BLOB) Describe(indent int) {
 	fmt.Printf("%s │ \x1b[93mSourceDsaInvocationID\x1b[0m: %s\n", indentPrompt, b.SourceDsaInvocationID.ToFormatD())
 	fmt.Printf("%s │ \x1b[93mAttributeFilter\x1b[0m: %d\n", indentPrompt, b.AttributeFilter)
 	fmt.Printf("%s │ \x1b[93mLastSyncSuccess\x1b[0m: %s\n", indentPrompt, b.LastSyncSuccess.String())
-	fmt.Printf("%s │ \x1b[93mSourceDsaDN\x1b[0m: %q\n", indentPrompt, b.SourceDsaDN)
+	fmt.Printf("%s │ \x1b[93mSourceDsaDN\x1b[0m: %s\n", indentPrompt, describeOszString(b.SourceDsaDN))
 	fmt.Printf("%s └───\n", indentPrompt)
 }

--- a/windows/activedirectory/replication/dsrepl/DS_REPL_CURSOR_BLOB_test.go
+++ b/windows/activedirectory/replication/dsrepl/DS_REPL_CURSOR_BLOB_test.go
@@ -15,7 +15,7 @@ func TestDS_REPL_CURSOR_BLOB_RoundTrip(t *testing.T) {
 		SourceDsaInvocationID: *g,
 		AttributeFilter:       987654321,
 		LastSyncSuccess:       data_structures.FILETIME{DwLowDateTime: 0xCAFEBABE, DwHighDateTime: 0x01D0FACE},
-		SourceDsaDN:           "CN=NTDS Settings,CN=DC04",
+		SourceDsaDN:           strptr("CN=NTDS Settings,CN=DC04"),
 	}
 
 	marshalled, err := original.Marshal()
@@ -37,8 +37,8 @@ func TestDS_REPL_CURSOR_BLOB_RoundTrip(t *testing.T) {
 	if parsed.LastSyncSuccess != original.LastSyncSuccess {
 		t.Errorf("LastSyncSuccess = %+v, want %+v", parsed.LastSyncSuccess, original.LastSyncSuccess)
 	}
-	if parsed.SourceDsaDN != original.SourceDsaDN {
-		t.Errorf("SourceDsaDN = %q, want %q", parsed.SourceDsaDN, original.SourceDsaDN)
+	if !sameStr(parsed.SourceDsaDN, original.SourceDsaDN) {
+		t.Errorf("SourceDsaDN = %v, want %v", parsed.SourceDsaDN, original.SourceDsaDN)
 	}
 }
 
@@ -78,8 +78,8 @@ func TestDS_REPL_CURSOR_BLOB_FixedBytes(t *testing.T) {
 	if parsed.LastSyncSuccess.DwLowDateTime != 10 || parsed.LastSyncSuccess.DwHighDateTime != 20 {
 		t.Errorf("LastSyncSuccess = %+v, want {Low:10 High:20}", parsed.LastSyncSuccess)
 	}
-	if parsed.SourceDsaDN != "DC" {
-		t.Errorf("SourceDsaDN = %q, want %q", parsed.SourceDsaDN, "DC")
+	if !sameStr(parsed.SourceDsaDN, strptr("DC")) {
+		t.Errorf("SourceDsaDN = %v, want %q", parsed.SourceDsaDN, "DC")
 	}
 }
 

--- a/windows/activedirectory/replication/dsrepl/DS_REPL_CURSOR_BLOB_test.go
+++ b/windows/activedirectory/replication/dsrepl/DS_REPL_CURSOR_BLOB_test.go
@@ -1,0 +1,95 @@
+package dsrepl_test
+
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/windows/activedirectory/replication/dsrepl"
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+	"github.com/TheManticoreProject/Manticore/windows/ms_dtyp/common/data_structures"
+)
+
+func TestDS_REPL_CURSOR_BLOB_RoundTrip(t *testing.T) {
+	g, _ := guid.FromString("0a0b0c0d-0e0f-1011-1213-141516171819")
+
+	original := &dsrepl.DS_REPL_CURSOR_BLOB{
+		SourceDsaInvocationID: *g,
+		AttributeFilter:       987654321,
+		LastSyncSuccess:       data_structures.FILETIME{DwLowDateTime: 0xCAFEBABE, DwHighDateTime: 0x01D0FACE},
+		SourceDsaDN:           "CN=NTDS Settings,CN=DC04",
+	}
+
+	marshalled, err := original.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	parsed := dsrepl.NewDS_REPL_CURSOR_BLOB()
+	if _, err := parsed.Unmarshal(marshalled); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+
+	if !parsed.SourceDsaInvocationID.Equal(&original.SourceDsaInvocationID) {
+		t.Errorf("SourceDsaInvocationID mismatch")
+	}
+	if parsed.AttributeFilter != original.AttributeFilter {
+		t.Errorf("AttributeFilter = %d, want %d", parsed.AttributeFilter, original.AttributeFilter)
+	}
+	if parsed.LastSyncSuccess != original.LastSyncSuccess {
+		t.Errorf("LastSyncSuccess = %+v, want %+v", parsed.LastSyncSuccess, original.LastSyncSuccess)
+	}
+	if parsed.SourceDsaDN != original.SourceDsaDN {
+		t.Errorf("SourceDsaDN = %q, want %q", parsed.SourceDsaDN, original.SourceDsaDN)
+	}
+}
+
+func TestDS_REPL_CURSOR_BLOB_ShortData(t *testing.T) {
+	parsed := dsrepl.NewDS_REPL_CURSOR_BLOB()
+	if _, err := parsed.Unmarshal(make([]byte, 8)); err == nil {
+		t.Error("expected error for short data, got nil")
+	}
+}
+
+func TestDS_REPL_CURSOR_BLOB_FixedBytes(t *testing.T) {
+	// Hand-built blob to validate the on-the-wire field layout independently of
+	// Marshal: 16-byte GUID, 8-byte USN, 8-byte FILETIME, 4-byte string offset,
+	// then a packed UTF-16LE string.
+	data := []byte{
+		// uuidSourceDsaInvocationID (16 bytes)
+		0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+		0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+		// usnAttributeFilter = 5 (little-endian)
+		0x05, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		// fTimeLastSyncSuccess: low = 10, high = 20
+		0x0a, 0x00, 0x00, 0x00, 0x14, 0x00, 0x00, 0x00,
+		// oszSourceDsaDN = 36 (points right after the 36-byte header)
+		0x24, 0x00, 0x00, 0x00,
+		// data: "DC" in UTF-16LE plus null terminator
+		0x44, 0x00, 0x43, 0x00, 0x00, 0x00,
+	}
+
+	parsed := dsrepl.NewDS_REPL_CURSOR_BLOB()
+	if _, err := parsed.Unmarshal(data); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+
+	if parsed.AttributeFilter != 5 {
+		t.Errorf("AttributeFilter = %d, want 5", parsed.AttributeFilter)
+	}
+	if parsed.LastSyncSuccess.DwLowDateTime != 10 || parsed.LastSyncSuccess.DwHighDateTime != 20 {
+		t.Errorf("LastSyncSuccess = %+v, want {Low:10 High:20}", parsed.LastSyncSuccess)
+	}
+	if parsed.SourceDsaDN != "DC" {
+		t.Errorf("SourceDsaDN = %q, want %q", parsed.SourceDsaDN, "DC")
+	}
+}
+
+func TestDS_REPL_CURSOR_BLOB_BadOffset(t *testing.T) {
+	// A 36-byte header whose oszSourceDsaDN points past the end of the buffer must
+	// produce an out-of-range error rather than panicking.
+	data := make([]byte, 36)
+	data[32] = 0xFF // oszSourceDsaDN = 0x000000FF, out of range
+	parsed := dsrepl.NewDS_REPL_CURSOR_BLOB()
+	if _, err := parsed.Unmarshal(data); err == nil {
+		t.Error("expected out-of-range error for bad offset, got nil")
+	}
+}

--- a/windows/activedirectory/replication/dsrepl/DS_REPL_KCC_DSA_FAILUREW_BLOB.go
+++ b/windows/activedirectory/replication/dsrepl/DS_REPL_KCC_DSA_FAILUREW_BLOB.go
@@ -20,8 +20,8 @@ const ds_repl_kcc_dsa_failurew_blob_header_size = 36
 //
 // Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/93083f06-d18a-407b-b906-630ed214a7ff
 type DS_REPL_KCC_DSA_FAILUREW_BLOB struct {
-	// DsaDN is the DN of the nTDSDSA object of the source server (oszDsaDN).
-	DsaDN string
+	// DsaDN is the DN of the nTDSDSA object of the source server (oszDsaDN). nil if NULL.
+	DsaDN *string
 	// DsaObjGuid is the objectGUID of the object represented by DsaDN (uuidDsaObjGuid).
 	DsaObjGuid guid.GUID
 	// FirstFailure is the time the first failure occurred (ftimeFirstFailure).
@@ -97,7 +97,7 @@ func (b *DS_REPL_KCC_DSA_FAILUREW_BLOB) Marshal() ([]byte, error) {
 
 // String returns a string representation of the DS_REPL_KCC_DSA_FAILUREW_BLOB structure.
 func (b *DS_REPL_KCC_DSA_FAILUREW_BLOB) String() string {
-	return fmt.Sprintf("DS_REPL_KCC_DSA_FAILUREW_BLOB: DsaDN=%q, NumFailures=%d, LastResult=%d", b.DsaDN, b.NumFailures, b.LastResult)
+	return fmt.Sprintf("DS_REPL_KCC_DSA_FAILUREW_BLOB: DsaDN=%s, NumFailures=%d, LastResult=%d", describeOszString(b.DsaDN), b.NumFailures, b.LastResult)
 }
 
 // Describe prints the DS_REPL_KCC_DSA_FAILUREW_BLOB structure to the console.
@@ -107,7 +107,7 @@ func (b *DS_REPL_KCC_DSA_FAILUREW_BLOB) String() string {
 func (b *DS_REPL_KCC_DSA_FAILUREW_BLOB) Describe(indent int) {
 	indentPrompt := strings.Repeat(" │ ", indent)
 	fmt.Printf("%s<\x1b[93mDS_REPL_KCC_DSA_FAILUREW_BLOB\x1b[0m>\n", indentPrompt)
-	fmt.Printf("%s │ \x1b[93mDsaDN\x1b[0m: %q\n", indentPrompt, b.DsaDN)
+	fmt.Printf("%s │ \x1b[93mDsaDN\x1b[0m: %s\n", indentPrompt, describeOszString(b.DsaDN))
 	fmt.Printf("%s │ \x1b[93mDsaObjGuid\x1b[0m: %s\n", indentPrompt, b.DsaObjGuid.ToFormatD())
 	fmt.Printf("%s │ \x1b[93mFirstFailure\x1b[0m: %s\n", indentPrompt, b.FirstFailure.String())
 	fmt.Printf("%s │ \x1b[93mNumFailures\x1b[0m: %d\n", indentPrompt, b.NumFailures)

--- a/windows/activedirectory/replication/dsrepl/DS_REPL_KCC_DSA_FAILUREW_BLOB.go
+++ b/windows/activedirectory/replication/dsrepl/DS_REPL_KCC_DSA_FAILUREW_BLOB.go
@@ -1,0 +1,116 @@
+package dsrepl
+
+import (
+	"encoding/binary"
+	"fmt"
+	"strings"
+
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+	"github.com/TheManticoreProject/Manticore/windows/ms_dtyp/common/data_structures"
+)
+
+// ds_repl_kcc_dsa_failurew_blob_header_size is the size, in bytes, of the fixed
+// header that precedes the variable-length data region.
+const ds_repl_kcc_dsa_failurew_blob_header_size = 36
+
+// DS_REPL_KCC_DSA_FAILUREW_BLOB is a representation of a tuple from the
+// kCCFailedConnections or kCCFailedLinks variables of a DC. This structure,
+// retrieved using an LDAP search method, is an alternative representation of
+// DS_REPL_KCC_DSA_FAILUREW, retrieved using the IDL_DRSGetReplInfo RPC method.
+//
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/93083f06-d18a-407b-b906-630ed214a7ff
+type DS_REPL_KCC_DSA_FAILUREW_BLOB struct {
+	// DsaDN is the DN of the nTDSDSA object of the source server (oszDsaDN).
+	DsaDN string
+	// DsaObjGuid is the objectGUID of the object represented by DsaDN (uuidDsaObjGuid).
+	DsaObjGuid guid.GUID
+	// FirstFailure is the time the first failure occurred (ftimeFirstFailure).
+	FirstFailure data_structures.FILETIME
+	// NumFailures is the number of consecutive failures since the last success (cNumFailures).
+	NumFailures uint32
+	// LastResult is the error code associated with the most recent failure (dwLastResult).
+	LastResult uint32
+}
+
+// NewDS_REPL_KCC_DSA_FAILUREW_BLOB creates a new, empty DS_REPL_KCC_DSA_FAILUREW_BLOB structure.
+func NewDS_REPL_KCC_DSA_FAILUREW_BLOB() *DS_REPL_KCC_DSA_FAILUREW_BLOB {
+	return &DS_REPL_KCC_DSA_FAILUREW_BLOB{}
+}
+
+// Unmarshal parses a DS_REPL_KCC_DSA_FAILUREW_BLOB structure from a byte slice.
+//
+// Parameters:
+// - data: A byte slice containing the structure (header followed by its data region).
+//
+// Returns:
+// - The number of bytes consumed.
+// - An error if the unmarshalling fails.
+func (b *DS_REPL_KCC_DSA_FAILUREW_BLOB) Unmarshal(data []byte) (int, error) {
+	if len(data) < ds_repl_kcc_dsa_failurew_blob_header_size {
+		return 0, fmt.Errorf("data is too short to unmarshal DS_REPL_KCC_DSA_FAILUREW_BLOB (expected at least %d bytes, got %d)", ds_repl_kcc_dsa_failurew_blob_header_size, len(data))
+	}
+
+	oszDsaDN := binary.LittleEndian.Uint32(data[0:4])
+
+	b.DsaObjGuid.FromRawBytes(data[4:20])
+
+	if _, err := b.FirstFailure.Unmarshal(data[20:28]); err != nil {
+		return 0, err
+	}
+
+	b.NumFailures = binary.LittleEndian.Uint32(data[28:32])
+	b.LastResult = binary.LittleEndian.Uint32(data[32:36])
+
+	var err error
+	if b.DsaDN, err = readOffsetString(data, oszDsaDN); err != nil {
+		return 0, err
+	}
+
+	return len(data), nil
+}
+
+// Marshal serializes the DS_REPL_KCC_DSA_FAILUREW_BLOB structure into a byte slice.
+//
+// Returns:
+// - A byte slice containing the marshalled structure.
+// - An error if the marshalling fails.
+func (b *DS_REPL_KCC_DSA_FAILUREW_BLOB) Marshal() ([]byte, error) {
+	data := newDataRegion(ds_repl_kcc_dsa_failurew_blob_header_size)
+
+	header := make([]byte, ds_repl_kcc_dsa_failurew_blob_header_size)
+
+	binary.LittleEndian.PutUint32(header[0:4], data.addString(b.DsaDN))
+
+	copy(header[4:20], b.DsaObjGuid.ToBytes())
+
+	firstFailure, err := b.FirstFailure.Marshal()
+	if err != nil {
+		return nil, err
+	}
+	copy(header[20:28], firstFailure)
+
+	binary.LittleEndian.PutUint32(header[28:32], b.NumFailures)
+	binary.LittleEndian.PutUint32(header[32:36], b.LastResult)
+
+	return append(header, data.bytes()...), nil
+}
+
+// String returns a string representation of the DS_REPL_KCC_DSA_FAILUREW_BLOB structure.
+func (b *DS_REPL_KCC_DSA_FAILUREW_BLOB) String() string {
+	return fmt.Sprintf("DS_REPL_KCC_DSA_FAILUREW_BLOB: DsaDN=%q, NumFailures=%d, LastResult=%d", b.DsaDN, b.NumFailures, b.LastResult)
+}
+
+// Describe prints the DS_REPL_KCC_DSA_FAILUREW_BLOB structure to the console.
+//
+// Parameters:
+// - indent: The number of levels to indent the output.
+func (b *DS_REPL_KCC_DSA_FAILUREW_BLOB) Describe(indent int) {
+	indentPrompt := strings.Repeat(" │ ", indent)
+	fmt.Printf("%s<\x1b[93mDS_REPL_KCC_DSA_FAILUREW_BLOB\x1b[0m>\n", indentPrompt)
+	fmt.Printf("%s │ \x1b[93mDsaDN\x1b[0m: %q\n", indentPrompt, b.DsaDN)
+	fmt.Printf("%s │ \x1b[93mDsaObjGuid\x1b[0m: %s\n", indentPrompt, b.DsaObjGuid.ToFormatD())
+	fmt.Printf("%s │ \x1b[93mFirstFailure\x1b[0m: %s\n", indentPrompt, b.FirstFailure.String())
+	fmt.Printf("%s │ \x1b[93mNumFailures\x1b[0m: %d\n", indentPrompt, b.NumFailures)
+	fmt.Printf("%s │ \x1b[93mLastResult\x1b[0m: %d\n", indentPrompt, b.LastResult)
+	fmt.Printf("%s └───\n", indentPrompt)
+}

--- a/windows/activedirectory/replication/dsrepl/DS_REPL_KCC_DSA_FAILUREW_BLOB_test.go
+++ b/windows/activedirectory/replication/dsrepl/DS_REPL_KCC_DSA_FAILUREW_BLOB_test.go
@@ -1,0 +1,58 @@
+package dsrepl_test
+
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/windows/activedirectory/replication/dsrepl"
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+	"github.com/TheManticoreProject/Manticore/windows/ms_dtyp/common/data_structures"
+)
+
+func TestDS_REPL_KCC_DSA_FAILUREW_BLOB_RoundTrip(t *testing.T) {
+	g, _ := guid.FromString("deadbeef-1234-5678-9abc-def012345678")
+
+	original := &dsrepl.DS_REPL_KCC_DSA_FAILUREW_BLOB{
+		DsaDN:        "CN=NTDS Settings,CN=DC02",
+		DsaObjGuid:   *g,
+		FirstFailure: data_structures.FILETIME{DwLowDateTime: 0xAABBCCDD, DwHighDateTime: 0x01D12345},
+		NumFailures:  7,
+		LastResult:   1722,
+	}
+
+	marshalled, err := original.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	parsed := dsrepl.NewDS_REPL_KCC_DSA_FAILUREW_BLOB()
+	n, err := parsed.Unmarshal(marshalled)
+	if err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if n != len(marshalled) {
+		t.Errorf("Unmarshal consumed %d bytes, expected %d", n, len(marshalled))
+	}
+
+	if parsed.DsaDN != original.DsaDN {
+		t.Errorf("DsaDN = %q, want %q", parsed.DsaDN, original.DsaDN)
+	}
+	if !parsed.DsaObjGuid.Equal(&original.DsaObjGuid) {
+		t.Errorf("DsaObjGuid mismatch")
+	}
+	if parsed.FirstFailure != original.FirstFailure {
+		t.Errorf("FirstFailure = %+v, want %+v", parsed.FirstFailure, original.FirstFailure)
+	}
+	if parsed.NumFailures != original.NumFailures {
+		t.Errorf("NumFailures = %d, want %d", parsed.NumFailures, original.NumFailures)
+	}
+	if parsed.LastResult != original.LastResult {
+		t.Errorf("LastResult = %d, want %d", parsed.LastResult, original.LastResult)
+	}
+}
+
+func TestDS_REPL_KCC_DSA_FAILUREW_BLOB_ShortData(t *testing.T) {
+	parsed := dsrepl.NewDS_REPL_KCC_DSA_FAILUREW_BLOB()
+	if _, err := parsed.Unmarshal(make([]byte, 10)); err == nil {
+		t.Error("expected error for short data, got nil")
+	}
+}

--- a/windows/activedirectory/replication/dsrepl/DS_REPL_KCC_DSA_FAILUREW_BLOB_test.go
+++ b/windows/activedirectory/replication/dsrepl/DS_REPL_KCC_DSA_FAILUREW_BLOB_test.go
@@ -12,7 +12,7 @@ func TestDS_REPL_KCC_DSA_FAILUREW_BLOB_RoundTrip(t *testing.T) {
 	g, _ := guid.FromString("deadbeef-1234-5678-9abc-def012345678")
 
 	original := &dsrepl.DS_REPL_KCC_DSA_FAILUREW_BLOB{
-		DsaDN:        "CN=NTDS Settings,CN=DC02",
+		DsaDN:        strptr("CN=NTDS Settings,CN=DC02"),
 		DsaObjGuid:   *g,
 		FirstFailure: data_structures.FILETIME{DwLowDateTime: 0xAABBCCDD, DwHighDateTime: 0x01D12345},
 		NumFailures:  7,
@@ -33,8 +33,8 @@ func TestDS_REPL_KCC_DSA_FAILUREW_BLOB_RoundTrip(t *testing.T) {
 		t.Errorf("Unmarshal consumed %d bytes, expected %d", n, len(marshalled))
 	}
 
-	if parsed.DsaDN != original.DsaDN {
-		t.Errorf("DsaDN = %q, want %q", parsed.DsaDN, original.DsaDN)
+	if !sameStr(parsed.DsaDN, original.DsaDN) {
+		t.Errorf("DsaDN = %v, want %v", parsed.DsaDN, original.DsaDN)
 	}
 	if !parsed.DsaObjGuid.Equal(&original.DsaObjGuid) {
 		t.Errorf("DsaObjGuid mismatch")

--- a/windows/activedirectory/replication/dsrepl/DS_REPL_NEIGHBORW_BLOB.go
+++ b/windows/activedirectory/replication/dsrepl/DS_REPL_NEIGHBORW_BLOB.go
@@ -20,14 +20,14 @@ const ds_repl_neighborw_blob_header_size = 128
 //
 // Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/58877402-4bf1-4b40-b405-fd9d11691752
 type DS_REPL_NEIGHBORW_BLOB struct {
-	// NamingContext is the NC to which this replication state data pertains (oszNamingContext).
-	NamingContext string
-	// SourceDsaDN is the DN of the nTDSDSA object of the source server (oszSourceDsaDN).
-	SourceDsaDN string
-	// SourceDsaAddress is the transport-specific network address of the source server (oszSourceDsaAddress).
-	SourceDsaAddress string
-	// AsyncIntersiteTransportDN is the DN of the interSiteTransport object, or NULL for RPC/IP (oszAsyncIntersiteTransportDN).
-	AsyncIntersiteTransportDN string
+	// NamingContext is the NC to which this replication state data pertains (oszNamingContext). nil if NULL.
+	NamingContext *string
+	// SourceDsaDN is the DN of the nTDSDSA object of the source server (oszSourceDsaDN). nil if NULL.
+	SourceDsaDN *string
+	// SourceDsaAddress is the transport-specific network address of the source server (oszSourceDsaAddress). nil if NULL.
+	SourceDsaAddress *string
+	// AsyncIntersiteTransportDN is the DN of the interSiteTransport object, or nil for RPC/IP (oszAsyncIntersiteTransportDN).
+	AsyncIntersiteTransportDN *string
 	// ReplicaFlags is a set of DS_REPL_NBR_* flags (dwReplicaFlags).
 	ReplicaFlags uint32
 	// Reserved is reserved for future use (dwReserved).
@@ -161,7 +161,7 @@ func (b *DS_REPL_NEIGHBORW_BLOB) Marshal() ([]byte, error) {
 
 // String returns a string representation of the DS_REPL_NEIGHBORW_BLOB structure.
 func (b *DS_REPL_NEIGHBORW_BLOB) String() string {
-	return fmt.Sprintf("DS_REPL_NEIGHBORW_BLOB: NamingContext=%q, SourceDsaDN=%q, ReplicaFlags=0x%08x", b.NamingContext, b.SourceDsaDN, b.ReplicaFlags)
+	return fmt.Sprintf("DS_REPL_NEIGHBORW_BLOB: NamingContext=%s, SourceDsaDN=%s, ReplicaFlags=0x%08x", describeOszString(b.NamingContext), describeOszString(b.SourceDsaDN), b.ReplicaFlags)
 }
 
 // Describe prints the DS_REPL_NEIGHBORW_BLOB structure to the console.
@@ -171,10 +171,10 @@ func (b *DS_REPL_NEIGHBORW_BLOB) String() string {
 func (b *DS_REPL_NEIGHBORW_BLOB) Describe(indent int) {
 	indentPrompt := strings.Repeat(" │ ", indent)
 	fmt.Printf("%s<\x1b[93mDS_REPL_NEIGHBORW_BLOB\x1b[0m>\n", indentPrompt)
-	fmt.Printf("%s │ \x1b[93mNamingContext\x1b[0m: %q\n", indentPrompt, b.NamingContext)
-	fmt.Printf("%s │ \x1b[93mSourceDsaDN\x1b[0m: %q\n", indentPrompt, b.SourceDsaDN)
-	fmt.Printf("%s │ \x1b[93mSourceDsaAddress\x1b[0m: %q\n", indentPrompt, b.SourceDsaAddress)
-	fmt.Printf("%s │ \x1b[93mAsyncIntersiteTransportDN\x1b[0m: %q\n", indentPrompt, b.AsyncIntersiteTransportDN)
+	fmt.Printf("%s │ \x1b[93mNamingContext\x1b[0m: %s\n", indentPrompt, describeOszString(b.NamingContext))
+	fmt.Printf("%s │ \x1b[93mSourceDsaDN\x1b[0m: %s\n", indentPrompt, describeOszString(b.SourceDsaDN))
+	fmt.Printf("%s │ \x1b[93mSourceDsaAddress\x1b[0m: %s\n", indentPrompt, describeOszString(b.SourceDsaAddress))
+	fmt.Printf("%s │ \x1b[93mAsyncIntersiteTransportDN\x1b[0m: %s\n", indentPrompt, describeOszString(b.AsyncIntersiteTransportDN))
 	fmt.Printf("%s │ \x1b[93mReplicaFlags\x1b[0m: 0x%08x\n", indentPrompt, b.ReplicaFlags)
 	fmt.Printf("%s │ \x1b[93mReserved\x1b[0m: 0x%08x\n", indentPrompt, b.Reserved)
 	fmt.Printf("%s │ \x1b[93mNamingContextObjGuid\x1b[0m: %s\n", indentPrompt, b.NamingContextObjGuid.ToFormatD())

--- a/windows/activedirectory/replication/dsrepl/DS_REPL_NEIGHBORW_BLOB.go
+++ b/windows/activedirectory/replication/dsrepl/DS_REPL_NEIGHBORW_BLOB.go
@@ -1,0 +1,191 @@
+package dsrepl
+
+import (
+	"encoding/binary"
+	"fmt"
+	"strings"
+
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+	"github.com/TheManticoreProject/Manticore/windows/ms_dtyp/common/data_structures"
+)
+
+// ds_repl_neighborw_blob_header_size is the size, in bytes, of the fixed header
+// that precedes the variable-length data region.
+const ds_repl_neighborw_blob_header_size = 128
+
+// DS_REPL_NEIGHBORW_BLOB is a representation of a tuple from the repsFrom or
+// repsTo abstract attribute of an NC replica. This structure, retrieved using an
+// LDAP search method, is an alternative representation of DS_REPL_NEIGHBORW,
+// retrieved using the IDL_DRSGetReplInfo RPC method.
+//
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/58877402-4bf1-4b40-b405-fd9d11691752
+type DS_REPL_NEIGHBORW_BLOB struct {
+	// NamingContext is the NC to which this replication state data pertains (oszNamingContext).
+	NamingContext string
+	// SourceDsaDN is the DN of the nTDSDSA object of the source server (oszSourceDsaDN).
+	SourceDsaDN string
+	// SourceDsaAddress is the transport-specific network address of the source server (oszSourceDsaAddress).
+	SourceDsaAddress string
+	// AsyncIntersiteTransportDN is the DN of the interSiteTransport object, or NULL for RPC/IP (oszAsyncIntersiteTransportDN).
+	AsyncIntersiteTransportDN string
+	// ReplicaFlags is a set of DS_REPL_NBR_* flags (dwReplicaFlags).
+	ReplicaFlags uint32
+	// Reserved is reserved for future use (dwReserved).
+	Reserved uint32
+	// NamingContextObjGuid is the objectGUID of the NC (uuidNamingContextObjGuid).
+	NamingContextObjGuid guid.GUID
+	// SourceDsaObjGuid is the objectGUID of the source nTDSDSA object (uuidSourceDsaObjGuid).
+	SourceDsaObjGuid guid.GUID
+	// SourceDsaInvocationID is the invocationId used by the source server (uuidSourceDsaInvocationID).
+	SourceDsaInvocationID guid.GUID
+	// AsyncIntersiteTransportObjGuid is the objectGUID of the intersite transport object (uuidAsyncIntersiteTransportObjGuid).
+	AsyncIntersiteTransportObjGuid guid.GUID
+	// LastObjChangeSynced is the USN of the last object update received (usnLastObjChangeSynced).
+	LastObjChangeSynced int64
+	// AttributeFilter is the LastObjChangeSynced value at the end of the last complete cycle (usnAttributeFilter).
+	AttributeFilter int64
+	// LastSyncSuccess is the time the last successful replication cycle completed (ftimeLastSyncSuccess).
+	LastSyncSuccess data_structures.FILETIME
+	// LastSyncAttempt is the time of the last replication attempt (ftimeLastSyncAttempt).
+	LastSyncAttempt data_structures.FILETIME
+	// LastSyncResult is the Windows error code of the last replication attempt (dwLastSyncResult).
+	LastSyncResult uint32
+	// NumConsecutiveSyncFailures is the number of failed replication attempts since the last success (cNumConsecutiveSyncFailures).
+	NumConsecutiveSyncFailures uint32
+}
+
+// NewDS_REPL_NEIGHBORW_BLOB creates a new, empty DS_REPL_NEIGHBORW_BLOB structure.
+func NewDS_REPL_NEIGHBORW_BLOB() *DS_REPL_NEIGHBORW_BLOB {
+	return &DS_REPL_NEIGHBORW_BLOB{}
+}
+
+// Unmarshal parses a DS_REPL_NEIGHBORW_BLOB structure from a byte slice.
+//
+// Parameters:
+// - data: A byte slice containing the structure (header followed by its data region).
+//
+// Returns:
+// - The number of bytes consumed.
+// - An error if the unmarshalling fails.
+func (b *DS_REPL_NEIGHBORW_BLOB) Unmarshal(data []byte) (int, error) {
+	if len(data) < ds_repl_neighborw_blob_header_size {
+		return 0, fmt.Errorf("data is too short to unmarshal DS_REPL_NEIGHBORW_BLOB (expected at least %d bytes, got %d)", ds_repl_neighborw_blob_header_size, len(data))
+	}
+
+	oszNamingContext := binary.LittleEndian.Uint32(data[0:4])
+	oszSourceDsaDN := binary.LittleEndian.Uint32(data[4:8])
+	oszSourceDsaAddress := binary.LittleEndian.Uint32(data[8:12])
+	oszAsyncIntersiteTransportDN := binary.LittleEndian.Uint32(data[12:16])
+
+	b.ReplicaFlags = binary.LittleEndian.Uint32(data[16:20])
+	b.Reserved = binary.LittleEndian.Uint32(data[20:24])
+
+	b.NamingContextObjGuid.FromRawBytes(data[24:40])
+	b.SourceDsaObjGuid.FromRawBytes(data[40:56])
+	b.SourceDsaInvocationID.FromRawBytes(data[56:72])
+	b.AsyncIntersiteTransportObjGuid.FromRawBytes(data[72:88])
+
+	b.LastObjChangeSynced = int64(binary.LittleEndian.Uint64(data[88:96]))
+	b.AttributeFilter = int64(binary.LittleEndian.Uint64(data[96:104]))
+
+	if _, err := b.LastSyncSuccess.Unmarshal(data[104:112]); err != nil {
+		return 0, err
+	}
+	if _, err := b.LastSyncAttempt.Unmarshal(data[112:120]); err != nil {
+		return 0, err
+	}
+
+	b.LastSyncResult = binary.LittleEndian.Uint32(data[120:124])
+	b.NumConsecutiveSyncFailures = binary.LittleEndian.Uint32(data[124:128])
+
+	var err error
+	if b.NamingContext, err = readOffsetString(data, oszNamingContext); err != nil {
+		return 0, err
+	}
+	if b.SourceDsaDN, err = readOffsetString(data, oszSourceDsaDN); err != nil {
+		return 0, err
+	}
+	if b.SourceDsaAddress, err = readOffsetString(data, oszSourceDsaAddress); err != nil {
+		return 0, err
+	}
+	if b.AsyncIntersiteTransportDN, err = readOffsetString(data, oszAsyncIntersiteTransportDN); err != nil {
+		return 0, err
+	}
+
+	return len(data), nil
+}
+
+// Marshal serializes the DS_REPL_NEIGHBORW_BLOB structure into a byte slice.
+//
+// Returns:
+// - A byte slice containing the marshalled structure.
+// - An error if the marshalling fails.
+func (b *DS_REPL_NEIGHBORW_BLOB) Marshal() ([]byte, error) {
+	data := newDataRegion(ds_repl_neighborw_blob_header_size)
+
+	header := make([]byte, ds_repl_neighborw_blob_header_size)
+
+	binary.LittleEndian.PutUint32(header[0:4], data.addString(b.NamingContext))
+	binary.LittleEndian.PutUint32(header[4:8], data.addString(b.SourceDsaDN))
+	binary.LittleEndian.PutUint32(header[8:12], data.addString(b.SourceDsaAddress))
+	binary.LittleEndian.PutUint32(header[12:16], data.addString(b.AsyncIntersiteTransportDN))
+
+	binary.LittleEndian.PutUint32(header[16:20], b.ReplicaFlags)
+	binary.LittleEndian.PutUint32(header[20:24], b.Reserved)
+
+	copy(header[24:40], b.NamingContextObjGuid.ToBytes())
+	copy(header[40:56], b.SourceDsaObjGuid.ToBytes())
+	copy(header[56:72], b.SourceDsaInvocationID.ToBytes())
+	copy(header[72:88], b.AsyncIntersiteTransportObjGuid.ToBytes())
+
+	binary.LittleEndian.PutUint64(header[88:96], uint64(b.LastObjChangeSynced))
+	binary.LittleEndian.PutUint64(header[96:104], uint64(b.AttributeFilter))
+
+	lastSyncSuccess, err := b.LastSyncSuccess.Marshal()
+	if err != nil {
+		return nil, err
+	}
+	copy(header[104:112], lastSyncSuccess)
+
+	lastSyncAttempt, err := b.LastSyncAttempt.Marshal()
+	if err != nil {
+		return nil, err
+	}
+	copy(header[112:120], lastSyncAttempt)
+
+	binary.LittleEndian.PutUint32(header[120:124], b.LastSyncResult)
+	binary.LittleEndian.PutUint32(header[124:128], b.NumConsecutiveSyncFailures)
+
+	return append(header, data.bytes()...), nil
+}
+
+// String returns a string representation of the DS_REPL_NEIGHBORW_BLOB structure.
+func (b *DS_REPL_NEIGHBORW_BLOB) String() string {
+	return fmt.Sprintf("DS_REPL_NEIGHBORW_BLOB: NamingContext=%q, SourceDsaDN=%q, ReplicaFlags=0x%08x", b.NamingContext, b.SourceDsaDN, b.ReplicaFlags)
+}
+
+// Describe prints the DS_REPL_NEIGHBORW_BLOB structure to the console.
+//
+// Parameters:
+// - indent: The number of levels to indent the output.
+func (b *DS_REPL_NEIGHBORW_BLOB) Describe(indent int) {
+	indentPrompt := strings.Repeat(" │ ", indent)
+	fmt.Printf("%s<\x1b[93mDS_REPL_NEIGHBORW_BLOB\x1b[0m>\n", indentPrompt)
+	fmt.Printf("%s │ \x1b[93mNamingContext\x1b[0m: %q\n", indentPrompt, b.NamingContext)
+	fmt.Printf("%s │ \x1b[93mSourceDsaDN\x1b[0m: %q\n", indentPrompt, b.SourceDsaDN)
+	fmt.Printf("%s │ \x1b[93mSourceDsaAddress\x1b[0m: %q\n", indentPrompt, b.SourceDsaAddress)
+	fmt.Printf("%s │ \x1b[93mAsyncIntersiteTransportDN\x1b[0m: %q\n", indentPrompt, b.AsyncIntersiteTransportDN)
+	fmt.Printf("%s │ \x1b[93mReplicaFlags\x1b[0m: 0x%08x\n", indentPrompt, b.ReplicaFlags)
+	fmt.Printf("%s │ \x1b[93mReserved\x1b[0m: 0x%08x\n", indentPrompt, b.Reserved)
+	fmt.Printf("%s │ \x1b[93mNamingContextObjGuid\x1b[0m: %s\n", indentPrompt, b.NamingContextObjGuid.ToFormatD())
+	fmt.Printf("%s │ \x1b[93mSourceDsaObjGuid\x1b[0m: %s\n", indentPrompt, b.SourceDsaObjGuid.ToFormatD())
+	fmt.Printf("%s │ \x1b[93mSourceDsaInvocationID\x1b[0m: %s\n", indentPrompt, b.SourceDsaInvocationID.ToFormatD())
+	fmt.Printf("%s │ \x1b[93mAsyncIntersiteTransportObjGuid\x1b[0m: %s\n", indentPrompt, b.AsyncIntersiteTransportObjGuid.ToFormatD())
+	fmt.Printf("%s │ \x1b[93mLastObjChangeSynced\x1b[0m: %d\n", indentPrompt, b.LastObjChangeSynced)
+	fmt.Printf("%s │ \x1b[93mAttributeFilter\x1b[0m: %d\n", indentPrompt, b.AttributeFilter)
+	fmt.Printf("%s │ \x1b[93mLastSyncSuccess\x1b[0m: %s\n", indentPrompt, b.LastSyncSuccess.String())
+	fmt.Printf("%s │ \x1b[93mLastSyncAttempt\x1b[0m: %s\n", indentPrompt, b.LastSyncAttempt.String())
+	fmt.Printf("%s │ \x1b[93mLastSyncResult\x1b[0m: %d\n", indentPrompt, b.LastSyncResult)
+	fmt.Printf("%s │ \x1b[93mNumConsecutiveSyncFailures\x1b[0m: %d\n", indentPrompt, b.NumConsecutiveSyncFailures)
+	fmt.Printf("%s └───\n", indentPrompt)
+}

--- a/windows/activedirectory/replication/dsrepl/DS_REPL_NEIGHBORW_BLOB_test.go
+++ b/windows/activedirectory/replication/dsrepl/DS_REPL_NEIGHBORW_BLOB_test.go
@@ -15,10 +15,10 @@ func TestDS_REPL_NEIGHBORW_BLOB_RoundTrip(t *testing.T) {
 	g4, _ := guid.FromString("44444444-4444-4444-4444-444444444444")
 
 	original := &dsrepl.DS_REPL_NEIGHBORW_BLOB{
-		NamingContext:                  "DC=example,DC=com",
-		SourceDsaDN:                    "CN=NTDS Settings,CN=DC01",
-		SourceDsaAddress:               "abcd.example.com",
-		AsyncIntersiteTransportDN:      "CN=IP,CN=Inter-Site Transports",
+		NamingContext:                  strptr("DC=example,DC=com"),
+		SourceDsaDN:                    strptr("CN=NTDS Settings,CN=DC01"),
+		SourceDsaAddress:               strptr("abcd.example.com"),
+		AsyncIntersiteTransportDN:      strptr("CN=IP,CN=Inter-Site Transports"),
 		ReplicaFlags:                   0x00000050,
 		Reserved:                       0,
 		NamingContextObjGuid:           *g1,
@@ -47,17 +47,17 @@ func TestDS_REPL_NEIGHBORW_BLOB_RoundTrip(t *testing.T) {
 		t.Errorf("Unmarshal consumed %d bytes, expected %d", n, len(marshalled))
 	}
 
-	if parsed.NamingContext != original.NamingContext {
-		t.Errorf("NamingContext = %q, want %q", parsed.NamingContext, original.NamingContext)
+	if !sameStr(parsed.NamingContext, original.NamingContext) {
+		t.Errorf("NamingContext = %v, want %v", parsed.NamingContext, original.NamingContext)
 	}
-	if parsed.SourceDsaDN != original.SourceDsaDN {
-		t.Errorf("SourceDsaDN = %q, want %q", parsed.SourceDsaDN, original.SourceDsaDN)
+	if !sameStr(parsed.SourceDsaDN, original.SourceDsaDN) {
+		t.Errorf("SourceDsaDN = %v, want %v", parsed.SourceDsaDN, original.SourceDsaDN)
 	}
-	if parsed.SourceDsaAddress != original.SourceDsaAddress {
-		t.Errorf("SourceDsaAddress = %q, want %q", parsed.SourceDsaAddress, original.SourceDsaAddress)
+	if !sameStr(parsed.SourceDsaAddress, original.SourceDsaAddress) {
+		t.Errorf("SourceDsaAddress = %v, want %v", parsed.SourceDsaAddress, original.SourceDsaAddress)
 	}
-	if parsed.AsyncIntersiteTransportDN != original.AsyncIntersiteTransportDN {
-		t.Errorf("AsyncIntersiteTransportDN = %q, want %q", parsed.AsyncIntersiteTransportDN, original.AsyncIntersiteTransportDN)
+	if !sameStr(parsed.AsyncIntersiteTransportDN, original.AsyncIntersiteTransportDN) {
+		t.Errorf("AsyncIntersiteTransportDN = %v, want %v", parsed.AsyncIntersiteTransportDN, original.AsyncIntersiteTransportDN)
 	}
 	if parsed.ReplicaFlags != original.ReplicaFlags {
 		t.Errorf("ReplicaFlags = 0x%08x, want 0x%08x", parsed.ReplicaFlags, original.ReplicaFlags)
@@ -88,11 +88,14 @@ func TestDS_REPL_NEIGHBORW_BLOB_RoundTrip(t *testing.T) {
 	}
 }
 
-func TestDS_REPL_NEIGHBORW_BLOB_NullStrings(t *testing.T) {
-	// AsyncIntersiteTransportDN is NULL for RPC/IP replication: empty string must
-	// round-trip as an offset of 0.
+func TestDS_REPL_NEIGHBORW_BLOB_NullVsEmptyStrings(t *testing.T) {
+	// AsyncIntersiteTransportDN is NULL for RPC/IP replication: a nil pointer must
+	// round-trip as an offset of 0 (absent), while a present-but-empty string must
+	// round-trip as a non-nil pointer to "" — the distinction *string preserves.
 	original := &dsrepl.DS_REPL_NEIGHBORW_BLOB{
-		NamingContext: "DC=example,DC=com",
+		NamingContext:             strptr("DC=example,DC=com"),
+		SourceDsaDN:               strptr(""), // present but empty
+		AsyncIntersiteTransportDN: nil,        // absent (NULL)
 	}
 
 	marshalled, err := original.Marshal()
@@ -104,11 +107,14 @@ func TestDS_REPL_NEIGHBORW_BLOB_NullStrings(t *testing.T) {
 	if _, err := parsed.Unmarshal(marshalled); err != nil {
 		t.Fatalf("Unmarshal failed: %v", err)
 	}
-	if parsed.AsyncIntersiteTransportDN != "" {
-		t.Errorf("AsyncIntersiteTransportDN = %q, want empty", parsed.AsyncIntersiteTransportDN)
+	if parsed.AsyncIntersiteTransportDN != nil {
+		t.Errorf("AsyncIntersiteTransportDN = %v, want nil (NULL)", parsed.AsyncIntersiteTransportDN)
 	}
-	if parsed.NamingContext != "DC=example,DC=com" {
-		t.Errorf("NamingContext = %q, want %q", parsed.NamingContext, "DC=example,DC=com")
+	if parsed.SourceDsaDN == nil || *parsed.SourceDsaDN != "" {
+		t.Errorf("SourceDsaDN = %v, want non-nil pointer to empty string", parsed.SourceDsaDN)
+	}
+	if !sameStr(parsed.NamingContext, original.NamingContext) {
+		t.Errorf("NamingContext = %v, want %v", parsed.NamingContext, original.NamingContext)
 	}
 }
 

--- a/windows/activedirectory/replication/dsrepl/DS_REPL_NEIGHBORW_BLOB_test.go
+++ b/windows/activedirectory/replication/dsrepl/DS_REPL_NEIGHBORW_BLOB_test.go
@@ -1,0 +1,120 @@
+package dsrepl_test
+
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/windows/activedirectory/replication/dsrepl"
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+	"github.com/TheManticoreProject/Manticore/windows/ms_dtyp/common/data_structures"
+)
+
+func TestDS_REPL_NEIGHBORW_BLOB_RoundTrip(t *testing.T) {
+	g1, _ := guid.FromString("11111111-1111-1111-1111-111111111111")
+	g2, _ := guid.FromString("22222222-2222-2222-2222-222222222222")
+	g3, _ := guid.FromString("33333333-3333-3333-3333-333333333333")
+	g4, _ := guid.FromString("44444444-4444-4444-4444-444444444444")
+
+	original := &dsrepl.DS_REPL_NEIGHBORW_BLOB{
+		NamingContext:                  "DC=example,DC=com",
+		SourceDsaDN:                    "CN=NTDS Settings,CN=DC01",
+		SourceDsaAddress:               "abcd.example.com",
+		AsyncIntersiteTransportDN:      "CN=IP,CN=Inter-Site Transports",
+		ReplicaFlags:                   0x00000050,
+		Reserved:                       0,
+		NamingContextObjGuid:           *g1,
+		SourceDsaObjGuid:               *g2,
+		SourceDsaInvocationID:          *g3,
+		AsyncIntersiteTransportObjGuid: *g4,
+		LastObjChangeSynced:            123456,
+		AttributeFilter:                123000,
+		LastSyncSuccess:                data_structures.FILETIME{DwLowDateTime: 0x11111111, DwHighDateTime: 0x01D00000},
+		LastSyncAttempt:                data_structures.FILETIME{DwLowDateTime: 0x22222222, DwHighDateTime: 0x01D00001},
+		LastSyncResult:                 0,
+		NumConsecutiveSyncFailures:     3,
+	}
+
+	marshalled, err := original.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	parsed := dsrepl.NewDS_REPL_NEIGHBORW_BLOB()
+	n, err := parsed.Unmarshal(marshalled)
+	if err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if n != len(marshalled) {
+		t.Errorf("Unmarshal consumed %d bytes, expected %d", n, len(marshalled))
+	}
+
+	if parsed.NamingContext != original.NamingContext {
+		t.Errorf("NamingContext = %q, want %q", parsed.NamingContext, original.NamingContext)
+	}
+	if parsed.SourceDsaDN != original.SourceDsaDN {
+		t.Errorf("SourceDsaDN = %q, want %q", parsed.SourceDsaDN, original.SourceDsaDN)
+	}
+	if parsed.SourceDsaAddress != original.SourceDsaAddress {
+		t.Errorf("SourceDsaAddress = %q, want %q", parsed.SourceDsaAddress, original.SourceDsaAddress)
+	}
+	if parsed.AsyncIntersiteTransportDN != original.AsyncIntersiteTransportDN {
+		t.Errorf("AsyncIntersiteTransportDN = %q, want %q", parsed.AsyncIntersiteTransportDN, original.AsyncIntersiteTransportDN)
+	}
+	if parsed.ReplicaFlags != original.ReplicaFlags {
+		t.Errorf("ReplicaFlags = 0x%08x, want 0x%08x", parsed.ReplicaFlags, original.ReplicaFlags)
+	}
+	if !parsed.NamingContextObjGuid.Equal(&original.NamingContextObjGuid) {
+		t.Errorf("NamingContextObjGuid mismatch")
+	}
+	if !parsed.SourceDsaInvocationID.Equal(&original.SourceDsaInvocationID) {
+		t.Errorf("SourceDsaInvocationID mismatch")
+	}
+	if parsed.LastObjChangeSynced != original.LastObjChangeSynced {
+		t.Errorf("LastObjChangeSynced = %d, want %d", parsed.LastObjChangeSynced, original.LastObjChangeSynced)
+	}
+	if parsed.LastSyncSuccess != original.LastSyncSuccess {
+		t.Errorf("LastSyncSuccess = %+v, want %+v", parsed.LastSyncSuccess, original.LastSyncSuccess)
+	}
+	if parsed.NumConsecutiveSyncFailures != original.NumConsecutiveSyncFailures {
+		t.Errorf("NumConsecutiveSyncFailures = %d, want %d", parsed.NumConsecutiveSyncFailures, original.NumConsecutiveSyncFailures)
+	}
+
+	// Re-marshalling the parsed structure must yield identical bytes.
+	remarshalled, err := parsed.Marshal()
+	if err != nil {
+		t.Fatalf("re-Marshal failed: %v", err)
+	}
+	if string(remarshalled) != string(marshalled) {
+		t.Errorf("re-marshalled bytes differ from original")
+	}
+}
+
+func TestDS_REPL_NEIGHBORW_BLOB_NullStrings(t *testing.T) {
+	// AsyncIntersiteTransportDN is NULL for RPC/IP replication: empty string must
+	// round-trip as an offset of 0.
+	original := &dsrepl.DS_REPL_NEIGHBORW_BLOB{
+		NamingContext: "DC=example,DC=com",
+	}
+
+	marshalled, err := original.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	parsed := dsrepl.NewDS_REPL_NEIGHBORW_BLOB()
+	if _, err := parsed.Unmarshal(marshalled); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if parsed.AsyncIntersiteTransportDN != "" {
+		t.Errorf("AsyncIntersiteTransportDN = %q, want empty", parsed.AsyncIntersiteTransportDN)
+	}
+	if parsed.NamingContext != "DC=example,DC=com" {
+		t.Errorf("NamingContext = %q, want %q", parsed.NamingContext, "DC=example,DC=com")
+	}
+}
+
+func TestDS_REPL_NEIGHBORW_BLOB_ShortData(t *testing.T) {
+	parsed := dsrepl.NewDS_REPL_NEIGHBORW_BLOB()
+	if _, err := parsed.Unmarshal(make([]byte, 16)); err == nil {
+		t.Error("expected error for short data, got nil")
+	}
+}

--- a/windows/activedirectory/replication/dsrepl/DS_REPL_OPW_BLOB.go
+++ b/windows/activedirectory/replication/dsrepl/DS_REPL_OPW_BLOB.go
@@ -39,12 +39,12 @@ type DS_REPL_OPW_BLOB struct {
 	OpType uint32
 	// Options is zero or more DRS option bits, interpreted per OpType (ulOptions).
 	Options uint32
-	// NamingContext is the DN of the NC associated with this operation (oszNamingContext).
-	NamingContext string
-	// DsaDN is the DN of the nTDSDSA object of the remote server (oszDsaDN).
-	DsaDN string
-	// DsaAddress is the transport-specific network address of the remote server (oszDsaAddress).
-	DsaAddress string
+	// NamingContext is the DN of the NC associated with this operation (oszNamingContext). nil if NULL.
+	NamingContext *string
+	// DsaDN is the DN of the nTDSDSA object of the remote server (oszDsaDN). nil if NULL.
+	DsaDN *string
+	// DsaAddress is the transport-specific network address of the remote server (oszDsaAddress). nil if NULL.
+	DsaAddress *string
 	// NamingContextObjGuid is the objectGUID of the NC identified by NamingContext (uuidNamingContextObjGuid).
 	NamingContextObjGuid guid.GUID
 	// DsaObjGuid is the objectGUID of the DSA object identified by DsaDN (uuidDsaObjGuid).
@@ -132,7 +132,7 @@ func (b *DS_REPL_OPW_BLOB) Marshal() ([]byte, error) {
 
 // String returns a string representation of the DS_REPL_OPW_BLOB structure.
 func (b *DS_REPL_OPW_BLOB) String() string {
-	return fmt.Sprintf("DS_REPL_OPW_BLOB: SerialNumber=%d, OpType=%d, NamingContext=%q, DsaDN=%q", b.SerialNumber, b.OpType, b.NamingContext, b.DsaDN)
+	return fmt.Sprintf("DS_REPL_OPW_BLOB: SerialNumber=%d, OpType=%d, NamingContext=%s, DsaDN=%s", b.SerialNumber, b.OpType, describeOszString(b.NamingContext), describeOszString(b.DsaDN))
 }
 
 // Describe prints the DS_REPL_OPW_BLOB structure to the console.
@@ -147,9 +147,9 @@ func (b *DS_REPL_OPW_BLOB) Describe(indent int) {
 	fmt.Printf("%s │ \x1b[93mPriority\x1b[0m: %d\n", indentPrompt, b.Priority)
 	fmt.Printf("%s │ \x1b[93mOpType\x1b[0m: %d\n", indentPrompt, b.OpType)
 	fmt.Printf("%s │ \x1b[93mOptions\x1b[0m: 0x%08x\n", indentPrompt, b.Options)
-	fmt.Printf("%s │ \x1b[93mNamingContext\x1b[0m: %q\n", indentPrompt, b.NamingContext)
-	fmt.Printf("%s │ \x1b[93mDsaDN\x1b[0m: %q\n", indentPrompt, b.DsaDN)
-	fmt.Printf("%s │ \x1b[93mDsaAddress\x1b[0m: %q\n", indentPrompt, b.DsaAddress)
+	fmt.Printf("%s │ \x1b[93mNamingContext\x1b[0m: %s\n", indentPrompt, describeOszString(b.NamingContext))
+	fmt.Printf("%s │ \x1b[93mDsaDN\x1b[0m: %s\n", indentPrompt, describeOszString(b.DsaDN))
+	fmt.Printf("%s │ \x1b[93mDsaAddress\x1b[0m: %s\n", indentPrompt, describeOszString(b.DsaAddress))
 	fmt.Printf("%s │ \x1b[93mNamingContextObjGuid\x1b[0m: %s\n", indentPrompt, b.NamingContextObjGuid.ToFormatD())
 	fmt.Printf("%s │ \x1b[93mDsaObjGuid\x1b[0m: %s\n", indentPrompt, b.DsaObjGuid.ToFormatD())
 	fmt.Printf("%s └───\n", indentPrompt)

--- a/windows/activedirectory/replication/dsrepl/DS_REPL_OPW_BLOB.go
+++ b/windows/activedirectory/replication/dsrepl/DS_REPL_OPW_BLOB.go
@@ -1,0 +1,156 @@
+package dsrepl
+
+import (
+	"encoding/binary"
+	"fmt"
+	"strings"
+
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+	"github.com/TheManticoreProject/Manticore/windows/ms_dtyp/common/data_structures"
+)
+
+// ds_repl_opw_blob_header_size is the size, in bytes, of the fixed header that
+// precedes the variable-length data region.
+const ds_repl_opw_blob_header_size = 68
+
+// DS_REPL_OP_TYPE values for the OpType field of DS_REPL_OPW_BLOB.
+const (
+	DS_REPL_OP_TYPE_SYNC        uint32 = 0
+	DS_REPL_OP_TYPE_ADD         uint32 = 1
+	DS_REPL_OP_TYPE_DELETE      uint32 = 2
+	DS_REPL_OP_TYPE_MODIFY      uint32 = 3
+	DS_REPL_OP_TYPE_UPDATE_REFS uint32 = 4
+)
+
+// DS_REPL_OPW_BLOB is a representation of a tuple from the replicationQueue
+// variable of a DC. This structure, retrieved using an LDAP search method, is an
+// alternative representation of DS_REPL_OPW, retrieved using the
+// IDL_DRSGetReplInfo RPC method.
+//
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/9bdde2d1-1f61-4829-bf73-3a45f85302a3
+type DS_REPL_OPW_BLOB struct {
+	// Enqueued is the time this operation was added to the queue (ftimeEnqueued).
+	Enqueued data_structures.FILETIME
+	// SerialNumber is the identifier of the operation (ulSerialNumber).
+	SerialNumber uint32
+	// Priority is the priority value of this operation (ulPriority).
+	Priority uint32
+	// OpType is the type of operation, one of the DS_REPL_OP_TYPE_* values (opType).
+	OpType uint32
+	// Options is zero or more DRS option bits, interpreted per OpType (ulOptions).
+	Options uint32
+	// NamingContext is the DN of the NC associated with this operation (oszNamingContext).
+	NamingContext string
+	// DsaDN is the DN of the nTDSDSA object of the remote server (oszDsaDN).
+	DsaDN string
+	// DsaAddress is the transport-specific network address of the remote server (oszDsaAddress).
+	DsaAddress string
+	// NamingContextObjGuid is the objectGUID of the NC identified by NamingContext (uuidNamingContextObjGuid).
+	NamingContextObjGuid guid.GUID
+	// DsaObjGuid is the objectGUID of the DSA object identified by DsaDN (uuidDsaObjGuid).
+	DsaObjGuid guid.GUID
+}
+
+// NewDS_REPL_OPW_BLOB creates a new, empty DS_REPL_OPW_BLOB structure.
+func NewDS_REPL_OPW_BLOB() *DS_REPL_OPW_BLOB {
+	return &DS_REPL_OPW_BLOB{}
+}
+
+// Unmarshal parses a DS_REPL_OPW_BLOB structure from a byte slice.
+//
+// Parameters:
+// - data: A byte slice containing the structure (header followed by its data region).
+//
+// Returns:
+// - The number of bytes consumed.
+// - An error if the unmarshalling fails.
+func (b *DS_REPL_OPW_BLOB) Unmarshal(data []byte) (int, error) {
+	if len(data) < ds_repl_opw_blob_header_size {
+		return 0, fmt.Errorf("data is too short to unmarshal DS_REPL_OPW_BLOB (expected at least %d bytes, got %d)", ds_repl_opw_blob_header_size, len(data))
+	}
+
+	if _, err := b.Enqueued.Unmarshal(data[0:8]); err != nil {
+		return 0, err
+	}
+
+	b.SerialNumber = binary.LittleEndian.Uint32(data[8:12])
+	b.Priority = binary.LittleEndian.Uint32(data[12:16])
+	b.OpType = binary.LittleEndian.Uint32(data[16:20])
+	b.Options = binary.LittleEndian.Uint32(data[20:24])
+
+	oszNamingContext := binary.LittleEndian.Uint32(data[24:28])
+	oszDsaDN := binary.LittleEndian.Uint32(data[28:32])
+	oszDsaAddress := binary.LittleEndian.Uint32(data[32:36])
+
+	b.NamingContextObjGuid.FromRawBytes(data[36:52])
+	b.DsaObjGuid.FromRawBytes(data[52:68])
+
+	var err error
+	if b.NamingContext, err = readOffsetString(data, oszNamingContext); err != nil {
+		return 0, err
+	}
+	if b.DsaDN, err = readOffsetString(data, oszDsaDN); err != nil {
+		return 0, err
+	}
+	if b.DsaAddress, err = readOffsetString(data, oszDsaAddress); err != nil {
+		return 0, err
+	}
+
+	return len(data), nil
+}
+
+// Marshal serializes the DS_REPL_OPW_BLOB structure into a byte slice.
+//
+// Returns:
+// - A byte slice containing the marshalled structure.
+// - An error if the marshalling fails.
+func (b *DS_REPL_OPW_BLOB) Marshal() ([]byte, error) {
+	data := newDataRegion(ds_repl_opw_blob_header_size)
+
+	header := make([]byte, ds_repl_opw_blob_header_size)
+
+	enqueued, err := b.Enqueued.Marshal()
+	if err != nil {
+		return nil, err
+	}
+	copy(header[0:8], enqueued)
+
+	binary.LittleEndian.PutUint32(header[8:12], b.SerialNumber)
+	binary.LittleEndian.PutUint32(header[12:16], b.Priority)
+	binary.LittleEndian.PutUint32(header[16:20], b.OpType)
+	binary.LittleEndian.PutUint32(header[20:24], b.Options)
+
+	binary.LittleEndian.PutUint32(header[24:28], data.addString(b.NamingContext))
+	binary.LittleEndian.PutUint32(header[28:32], data.addString(b.DsaDN))
+	binary.LittleEndian.PutUint32(header[32:36], data.addString(b.DsaAddress))
+
+	copy(header[36:52], b.NamingContextObjGuid.ToBytes())
+	copy(header[52:68], b.DsaObjGuid.ToBytes())
+
+	return append(header, data.bytes()...), nil
+}
+
+// String returns a string representation of the DS_REPL_OPW_BLOB structure.
+func (b *DS_REPL_OPW_BLOB) String() string {
+	return fmt.Sprintf("DS_REPL_OPW_BLOB: SerialNumber=%d, OpType=%d, NamingContext=%q, DsaDN=%q", b.SerialNumber, b.OpType, b.NamingContext, b.DsaDN)
+}
+
+// Describe prints the DS_REPL_OPW_BLOB structure to the console.
+//
+// Parameters:
+// - indent: The number of levels to indent the output.
+func (b *DS_REPL_OPW_BLOB) Describe(indent int) {
+	indentPrompt := strings.Repeat(" │ ", indent)
+	fmt.Printf("%s<\x1b[93mDS_REPL_OPW_BLOB\x1b[0m>\n", indentPrompt)
+	fmt.Printf("%s │ \x1b[93mEnqueued\x1b[0m: %s\n", indentPrompt, b.Enqueued.String())
+	fmt.Printf("%s │ \x1b[93mSerialNumber\x1b[0m: %d\n", indentPrompt, b.SerialNumber)
+	fmt.Printf("%s │ \x1b[93mPriority\x1b[0m: %d\n", indentPrompt, b.Priority)
+	fmt.Printf("%s │ \x1b[93mOpType\x1b[0m: %d\n", indentPrompt, b.OpType)
+	fmt.Printf("%s │ \x1b[93mOptions\x1b[0m: 0x%08x\n", indentPrompt, b.Options)
+	fmt.Printf("%s │ \x1b[93mNamingContext\x1b[0m: %q\n", indentPrompt, b.NamingContext)
+	fmt.Printf("%s │ \x1b[93mDsaDN\x1b[0m: %q\n", indentPrompt, b.DsaDN)
+	fmt.Printf("%s │ \x1b[93mDsaAddress\x1b[0m: %q\n", indentPrompt, b.DsaAddress)
+	fmt.Printf("%s │ \x1b[93mNamingContextObjGuid\x1b[0m: %s\n", indentPrompt, b.NamingContextObjGuid.ToFormatD())
+	fmt.Printf("%s │ \x1b[93mDsaObjGuid\x1b[0m: %s\n", indentPrompt, b.DsaObjGuid.ToFormatD())
+	fmt.Printf("%s └───\n", indentPrompt)
+}

--- a/windows/activedirectory/replication/dsrepl/DS_REPL_OPW_BLOB_test.go
+++ b/windows/activedirectory/replication/dsrepl/DS_REPL_OPW_BLOB_test.go
@@ -1,0 +1,75 @@
+package dsrepl_test
+
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/windows/activedirectory/replication/dsrepl"
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+	"github.com/TheManticoreProject/Manticore/windows/ms_dtyp/common/data_structures"
+)
+
+func TestDS_REPL_OPW_BLOB_RoundTrip(t *testing.T) {
+	g1, _ := guid.FromString("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+	g2, _ := guid.FromString("ffffffff-0000-1111-2222-333333333333")
+
+	original := &dsrepl.DS_REPL_OPW_BLOB{
+		Enqueued:             data_structures.FILETIME{DwLowDateTime: 0x12345678, DwHighDateTime: 0x01D0ABCD},
+		SerialNumber:         42,
+		Priority:             100,
+		OpType:               dsrepl.DS_REPL_OP_TYPE_SYNC,
+		Options:              0x00000010,
+		NamingContext:        "DC=example,DC=com",
+		DsaDN:                "CN=NTDS Settings,CN=DC03",
+		DsaAddress:           "dc03.example.com",
+		NamingContextObjGuid: *g1,
+		DsaObjGuid:           *g2,
+	}
+
+	marshalled, err := original.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	parsed := dsrepl.NewDS_REPL_OPW_BLOB()
+	if _, err := parsed.Unmarshal(marshalled); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+
+	if parsed.Enqueued != original.Enqueued {
+		t.Errorf("Enqueued = %+v, want %+v", parsed.Enqueued, original.Enqueued)
+	}
+	if parsed.SerialNumber != original.SerialNumber {
+		t.Errorf("SerialNumber = %d, want %d", parsed.SerialNumber, original.SerialNumber)
+	}
+	if parsed.Priority != original.Priority {
+		t.Errorf("Priority = %d, want %d", parsed.Priority, original.Priority)
+	}
+	if parsed.OpType != original.OpType {
+		t.Errorf("OpType = %d, want %d", parsed.OpType, original.OpType)
+	}
+	if parsed.Options != original.Options {
+		t.Errorf("Options = 0x%08x, want 0x%08x", parsed.Options, original.Options)
+	}
+	if parsed.NamingContext != original.NamingContext {
+		t.Errorf("NamingContext = %q, want %q", parsed.NamingContext, original.NamingContext)
+	}
+	if parsed.DsaDN != original.DsaDN {
+		t.Errorf("DsaDN = %q, want %q", parsed.DsaDN, original.DsaDN)
+	}
+	if parsed.DsaAddress != original.DsaAddress {
+		t.Errorf("DsaAddress = %q, want %q", parsed.DsaAddress, original.DsaAddress)
+	}
+	if !parsed.NamingContextObjGuid.Equal(&original.NamingContextObjGuid) {
+		t.Errorf("NamingContextObjGuid mismatch")
+	}
+	if !parsed.DsaObjGuid.Equal(&original.DsaObjGuid) {
+		t.Errorf("DsaObjGuid mismatch")
+	}
+}
+
+func TestDS_REPL_OPW_BLOB_ShortData(t *testing.T) {
+	parsed := dsrepl.NewDS_REPL_OPW_BLOB()
+	if _, err := parsed.Unmarshal(make([]byte, 20)); err == nil {
+		t.Error("expected error for short data, got nil")
+	}
+}

--- a/windows/activedirectory/replication/dsrepl/DS_REPL_OPW_BLOB_test.go
+++ b/windows/activedirectory/replication/dsrepl/DS_REPL_OPW_BLOB_test.go
@@ -18,9 +18,9 @@ func TestDS_REPL_OPW_BLOB_RoundTrip(t *testing.T) {
 		Priority:             100,
 		OpType:               dsrepl.DS_REPL_OP_TYPE_SYNC,
 		Options:              0x00000010,
-		NamingContext:        "DC=example,DC=com",
-		DsaDN:                "CN=NTDS Settings,CN=DC03",
-		DsaAddress:           "dc03.example.com",
+		NamingContext:        strptr("DC=example,DC=com"),
+		DsaDN:                strptr("CN=NTDS Settings,CN=DC03"),
+		DsaAddress:           strptr("dc03.example.com"),
 		NamingContextObjGuid: *g1,
 		DsaObjGuid:           *g2,
 	}
@@ -50,14 +50,14 @@ func TestDS_REPL_OPW_BLOB_RoundTrip(t *testing.T) {
 	if parsed.Options != original.Options {
 		t.Errorf("Options = 0x%08x, want 0x%08x", parsed.Options, original.Options)
 	}
-	if parsed.NamingContext != original.NamingContext {
-		t.Errorf("NamingContext = %q, want %q", parsed.NamingContext, original.NamingContext)
+	if !sameStr(parsed.NamingContext, original.NamingContext) {
+		t.Errorf("NamingContext = %v, want %v", parsed.NamingContext, original.NamingContext)
 	}
-	if parsed.DsaDN != original.DsaDN {
-		t.Errorf("DsaDN = %q, want %q", parsed.DsaDN, original.DsaDN)
+	if !sameStr(parsed.DsaDN, original.DsaDN) {
+		t.Errorf("DsaDN = %v, want %v", parsed.DsaDN, original.DsaDN)
 	}
-	if parsed.DsaAddress != original.DsaAddress {
-		t.Errorf("DsaAddress = %q, want %q", parsed.DsaAddress, original.DsaAddress)
+	if !sameStr(parsed.DsaAddress, original.DsaAddress) {
+		t.Errorf("DsaAddress = %v, want %v", parsed.DsaAddress, original.DsaAddress)
 	}
 	if !parsed.NamingContextObjGuid.Equal(&original.NamingContextObjGuid) {
 		t.Errorf("NamingContextObjGuid mismatch")

--- a/windows/activedirectory/replication/dsrepl/DS_REPL_QUEUE_STATISTICSW_BLOB.go
+++ b/windows/activedirectory/replication/dsrepl/DS_REPL_QUEUE_STATISTICSW_BLOB.go
@@ -1,0 +1,136 @@
+package dsrepl
+
+import (
+	"encoding/binary"
+	"fmt"
+	"strings"
+
+	"github.com/TheManticoreProject/Manticore/windows/ms_dtyp/common/data_structures"
+)
+
+// ds_repl_queue_statisticsw_blob_size is the fixed size, in bytes, of the
+// structure. It has no variable-length data region.
+const ds_repl_queue_statisticsw_blob_size = 52
+
+// DS_REPL_QUEUE_STATISTICSW_BLOB contains the statistics related to the
+// replicationQueue variable of a DC, returned by reading the
+// msDS-ReplQueueStatistics rootDSE attribute.
+//
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/aa5923c9-48bf-4182-93ff-6353dd9f0b00
+type DS_REPL_QUEUE_STATISTICSW_BLOB struct {
+	// CurrentOpStarted is the time the currently running operation started (ftimeCurrentOpStarted).
+	CurrentOpStarted data_structures.FILETIME
+	// NumPendingOps is the number of currently pending operations (cNumPendingOps).
+	NumPendingOps uint32
+	// OldestSync is the time of the oldest synchronization operation (ftimeOldestSync).
+	OldestSync data_structures.FILETIME
+	// OldestAdd is the time of the oldest add operation (ftimeOldestAdd).
+	OldestAdd data_structures.FILETIME
+	// OldestMod is the time of the oldest modification operation (ftimeOldestMod).
+	OldestMod data_structures.FILETIME
+	// OldestDel is the time of the oldest delete operation (ftimeOldestDel).
+	OldestDel data_structures.FILETIME
+	// OldestUpdRefs is the time of the oldest reference update operation (ftimeOldestUpdRefs).
+	OldestUpdRefs data_structures.FILETIME
+}
+
+// NewDS_REPL_QUEUE_STATISTICSW_BLOB creates a new, empty DS_REPL_QUEUE_STATISTICSW_BLOB structure.
+func NewDS_REPL_QUEUE_STATISTICSW_BLOB() *DS_REPL_QUEUE_STATISTICSW_BLOB {
+	return &DS_REPL_QUEUE_STATISTICSW_BLOB{}
+}
+
+// Unmarshal parses a DS_REPL_QUEUE_STATISTICSW_BLOB structure from a byte slice.
+//
+// Parameters:
+// - data: A byte slice containing the structure.
+//
+// Returns:
+// - The number of bytes consumed.
+// - An error if the unmarshalling fails.
+func (b *DS_REPL_QUEUE_STATISTICSW_BLOB) Unmarshal(data []byte) (int, error) {
+	if len(data) < ds_repl_queue_statisticsw_blob_size {
+		return 0, fmt.Errorf("data is too short to unmarshal DS_REPL_QUEUE_STATISTICSW_BLOB (expected at least %d bytes, got %d)", ds_repl_queue_statisticsw_blob_size, len(data))
+	}
+
+	if _, err := b.CurrentOpStarted.Unmarshal(data[0:8]); err != nil {
+		return 0, err
+	}
+
+	b.NumPendingOps = binary.LittleEndian.Uint32(data[8:12])
+
+	if _, err := b.OldestSync.Unmarshal(data[12:20]); err != nil {
+		return 0, err
+	}
+	if _, err := b.OldestAdd.Unmarshal(data[20:28]); err != nil {
+		return 0, err
+	}
+	if _, err := b.OldestMod.Unmarshal(data[28:36]); err != nil {
+		return 0, err
+	}
+	if _, err := b.OldestDel.Unmarshal(data[36:44]); err != nil {
+		return 0, err
+	}
+	if _, err := b.OldestUpdRefs.Unmarshal(data[44:52]); err != nil {
+		return 0, err
+	}
+
+	return ds_repl_queue_statisticsw_blob_size, nil
+}
+
+// Marshal serializes the DS_REPL_QUEUE_STATISTICSW_BLOB structure into a byte slice.
+//
+// Returns:
+// - A byte slice containing the marshalled structure.
+// - An error if the marshalling fails.
+func (b *DS_REPL_QUEUE_STATISTICSW_BLOB) Marshal() ([]byte, error) {
+	header := make([]byte, ds_repl_queue_statisticsw_blob_size)
+
+	currentOpStarted, err := b.CurrentOpStarted.Marshal()
+	if err != nil {
+		return nil, err
+	}
+	copy(header[0:8], currentOpStarted)
+
+	binary.LittleEndian.PutUint32(header[8:12], b.NumPendingOps)
+
+	for _, field := range []struct {
+		offset int
+		ft     *data_structures.FILETIME
+	}{
+		{12, &b.OldestSync},
+		{20, &b.OldestAdd},
+		{28, &b.OldestMod},
+		{36, &b.OldestDel},
+		{44, &b.OldestUpdRefs},
+	} {
+		marshalled, err := field.ft.Marshal()
+		if err != nil {
+			return nil, err
+		}
+		copy(header[field.offset:field.offset+8], marshalled)
+	}
+
+	return header, nil
+}
+
+// String returns a string representation of the DS_REPL_QUEUE_STATISTICSW_BLOB structure.
+func (b *DS_REPL_QUEUE_STATISTICSW_BLOB) String() string {
+	return fmt.Sprintf("DS_REPL_QUEUE_STATISTICSW_BLOB: NumPendingOps=%d, CurrentOpStarted=%s", b.NumPendingOps, b.CurrentOpStarted.String())
+}
+
+// Describe prints the DS_REPL_QUEUE_STATISTICSW_BLOB structure to the console.
+//
+// Parameters:
+// - indent: The number of levels to indent the output.
+func (b *DS_REPL_QUEUE_STATISTICSW_BLOB) Describe(indent int) {
+	indentPrompt := strings.Repeat(" │ ", indent)
+	fmt.Printf("%s<\x1b[93mDS_REPL_QUEUE_STATISTICSW_BLOB\x1b[0m>\n", indentPrompt)
+	fmt.Printf("%s │ \x1b[93mCurrentOpStarted\x1b[0m: %s\n", indentPrompt, b.CurrentOpStarted.String())
+	fmt.Printf("%s │ \x1b[93mNumPendingOps\x1b[0m: %d\n", indentPrompt, b.NumPendingOps)
+	fmt.Printf("%s │ \x1b[93mOldestSync\x1b[0m: %s\n", indentPrompt, b.OldestSync.String())
+	fmt.Printf("%s │ \x1b[93mOldestAdd\x1b[0m: %s\n", indentPrompt, b.OldestAdd.String())
+	fmt.Printf("%s │ \x1b[93mOldestMod\x1b[0m: %s\n", indentPrompt, b.OldestMod.String())
+	fmt.Printf("%s │ \x1b[93mOldestDel\x1b[0m: %s\n", indentPrompt, b.OldestDel.String())
+	fmt.Printf("%s │ \x1b[93mOldestUpdRefs\x1b[0m: %s\n", indentPrompt, b.OldestUpdRefs.String())
+	fmt.Printf("%s └───\n", indentPrompt)
+}

--- a/windows/activedirectory/replication/dsrepl/DS_REPL_QUEUE_STATISTICSW_BLOB_test.go
+++ b/windows/activedirectory/replication/dsrepl/DS_REPL_QUEUE_STATISTICSW_BLOB_test.go
@@ -1,0 +1,48 @@
+package dsrepl_test
+
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/windows/activedirectory/replication/dsrepl"
+	"github.com/TheManticoreProject/Manticore/windows/ms_dtyp/common/data_structures"
+)
+
+func TestDS_REPL_QUEUE_STATISTICSW_BLOB_RoundTrip(t *testing.T) {
+	original := &dsrepl.DS_REPL_QUEUE_STATISTICSW_BLOB{
+		CurrentOpStarted: data_structures.FILETIME{DwLowDateTime: 1, DwHighDateTime: 0x01D00001},
+		NumPendingOps:    5,
+		OldestSync:       data_structures.FILETIME{DwLowDateTime: 2, DwHighDateTime: 0x01D00002},
+		OldestAdd:        data_structures.FILETIME{DwLowDateTime: 3, DwHighDateTime: 0x01D00003},
+		OldestMod:        data_structures.FILETIME{DwLowDateTime: 4, DwHighDateTime: 0x01D00004},
+		OldestDel:        data_structures.FILETIME{DwLowDateTime: 5, DwHighDateTime: 0x01D00005},
+		OldestUpdRefs:    data_structures.FILETIME{DwLowDateTime: 6, DwHighDateTime: 0x01D00006},
+	}
+
+	marshalled, err := original.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+	if len(marshalled) != 52 {
+		t.Errorf("marshalled length = %d, want 52", len(marshalled))
+	}
+
+	parsed := dsrepl.NewDS_REPL_QUEUE_STATISTICSW_BLOB()
+	n, err := parsed.Unmarshal(marshalled)
+	if err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if n != 52 {
+		t.Errorf("Unmarshal consumed %d bytes, want 52", n)
+	}
+
+	if *parsed != *original {
+		t.Errorf("round-trip mismatch:\n got  %+v\n want %+v", *parsed, *original)
+	}
+}
+
+func TestDS_REPL_QUEUE_STATISTICSW_BLOB_ShortData(t *testing.T) {
+	parsed := dsrepl.NewDS_REPL_QUEUE_STATISTICSW_BLOB()
+	if _, err := parsed.Unmarshal(make([]byte, 51)); err == nil {
+		t.Error("expected error for short data, got nil")
+	}
+}

--- a/windows/activedirectory/replication/dsrepl/DS_REPL_VALUE_META_DATA_BLOB.go
+++ b/windows/activedirectory/replication/dsrepl/DS_REPL_VALUE_META_DATA_BLOB.go
@@ -1,0 +1,183 @@
+package dsrepl
+
+import (
+	"encoding/binary"
+	"fmt"
+	"strings"
+
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+	"github.com/TheManticoreProject/Manticore/windows/ms_dtyp/common/data_structures"
+)
+
+// ds_repl_value_meta_data_blob_header_size is the size, in bytes, of the fixed
+// header that precedes the variable-length data region.
+const ds_repl_value_meta_data_blob_header_size = 80
+
+// DS_REPL_VALUE_META_DATA_BLOB is a representation of a stamp variable (of type
+// LinkValueStamp) of a link value. This structure, retrieved using an LDAP search
+// method, is an alternative representation of DS_REPL_VALUE_META_DATA_2, retrieved
+// using the IDL_DRSGetReplInfo RPC method.
+//
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/5d421689-808b-466d-8d9f-106cda2dbcce
+type DS_REPL_VALUE_META_DATA_BLOB struct {
+	// AttributeName is the LDAP display name of the attribute (oszAttributeName).
+	AttributeName string
+	// ObjectDn is the DN of the object that this attribute belongs to (oszObjectDn).
+	ObjectDn string
+	// Data is the attribute replication metadata buffer (cbData / pbData).
+	Data []byte
+	// Deleted is the timeDeleted of the LinkValueStamp (ftimeDeleted).
+	Deleted data_structures.FILETIME
+	// Created is the timeCreated of the LinkValueStamp (ftimeCreated).
+	Created data_structures.FILETIME
+	// Version is the dwVersion of the LinkValueStamp (dwVersion).
+	Version uint32
+	// LastOriginatingChange is the timeChanged of the LinkValueStamp (ftimeLastOriginatingChange).
+	LastOriginatingChange data_structures.FILETIME
+	// LastOriginatingDsaInvocationID is the uuidOriginating of the LinkValueStamp (uuidLastOriginatingDsaInvocationID).
+	LastOriginatingDsaInvocationID guid.GUID
+	// OriginatingChange is the usnOriginating of the LinkValueStamp (usnOriginatingChange).
+	OriginatingChange int64
+	// LocalChange is the USN on the destination server of the last applied change (usnLocalChange).
+	LocalChange int64
+	// LastOriginatingDsaDN is the DN of the nTDSDSA object that originated the last replication (oszLastOriginatingDsaDN).
+	LastOriginatingDsaDN string
+}
+
+// NewDS_REPL_VALUE_META_DATA_BLOB creates a new, empty DS_REPL_VALUE_META_DATA_BLOB structure.
+func NewDS_REPL_VALUE_META_DATA_BLOB() *DS_REPL_VALUE_META_DATA_BLOB {
+	return &DS_REPL_VALUE_META_DATA_BLOB{}
+}
+
+// Unmarshal parses a DS_REPL_VALUE_META_DATA_BLOB structure from a byte slice.
+//
+// Parameters:
+// - data: A byte slice containing the structure (header followed by its data region).
+//
+// Returns:
+// - The number of bytes consumed.
+// - An error if the unmarshalling fails.
+func (b *DS_REPL_VALUE_META_DATA_BLOB) Unmarshal(data []byte) (int, error) {
+	if len(data) < ds_repl_value_meta_data_blob_header_size {
+		return 0, fmt.Errorf("data is too short to unmarshal DS_REPL_VALUE_META_DATA_BLOB (expected at least %d bytes, got %d)", ds_repl_value_meta_data_blob_header_size, len(data))
+	}
+
+	oszAttributeName := binary.LittleEndian.Uint32(data[0:4])
+	oszObjectDn := binary.LittleEndian.Uint32(data[4:8])
+	cbData := binary.LittleEndian.Uint32(data[8:12])
+	pbData := binary.LittleEndian.Uint32(data[12:16])
+
+	if _, err := b.Deleted.Unmarshal(data[16:24]); err != nil {
+		return 0, err
+	}
+	if _, err := b.Created.Unmarshal(data[24:32]); err != nil {
+		return 0, err
+	}
+
+	b.Version = binary.LittleEndian.Uint32(data[32:36])
+
+	if _, err := b.LastOriginatingChange.Unmarshal(data[36:44]); err != nil {
+		return 0, err
+	}
+
+	b.LastOriginatingDsaInvocationID.FromRawBytes(data[44:60])
+
+	b.OriginatingChange = int64(binary.LittleEndian.Uint64(data[60:68]))
+	b.LocalChange = int64(binary.LittleEndian.Uint64(data[68:76]))
+
+	oszLastOriginatingDsaDN := binary.LittleEndian.Uint32(data[76:80])
+
+	var err error
+	if b.AttributeName, err = readOffsetString(data, oszAttributeName); err != nil {
+		return 0, err
+	}
+	if b.ObjectDn, err = readOffsetString(data, oszObjectDn); err != nil {
+		return 0, err
+	}
+	if b.LastOriginatingDsaDN, err = readOffsetString(data, oszLastOriginatingDsaDN); err != nil {
+		return 0, err
+	}
+
+	if pbData != 0 && cbData != 0 {
+		if int(pbData)+int(cbData) > len(data) {
+			return 0, fmt.Errorf("pbData buffer (offset %d, length %d) is out of range (blob is %d bytes)", pbData, cbData, len(data))
+		}
+		b.Data = make([]byte, cbData)
+		copy(b.Data, data[pbData:pbData+cbData])
+	} else {
+		b.Data = nil
+	}
+
+	return len(data), nil
+}
+
+// Marshal serializes the DS_REPL_VALUE_META_DATA_BLOB structure into a byte slice.
+//
+// Returns:
+// - A byte slice containing the marshalled structure.
+// - An error if the marshalling fails.
+func (b *DS_REPL_VALUE_META_DATA_BLOB) Marshal() ([]byte, error) {
+	data := newDataRegion(ds_repl_value_meta_data_blob_header_size)
+
+	header := make([]byte, ds_repl_value_meta_data_blob_header_size)
+
+	binary.LittleEndian.PutUint32(header[0:4], data.addString(b.AttributeName))
+	binary.LittleEndian.PutUint32(header[4:8], data.addString(b.ObjectDn))
+	binary.LittleEndian.PutUint32(header[8:12], uint32(len(b.Data)))
+	binary.LittleEndian.PutUint32(header[12:16], data.addBytes(b.Data))
+
+	deleted, err := b.Deleted.Marshal()
+	if err != nil {
+		return nil, err
+	}
+	copy(header[16:24], deleted)
+
+	created, err := b.Created.Marshal()
+	if err != nil {
+		return nil, err
+	}
+	copy(header[24:32], created)
+
+	binary.LittleEndian.PutUint32(header[32:36], b.Version)
+
+	lastOriginatingChange, err := b.LastOriginatingChange.Marshal()
+	if err != nil {
+		return nil, err
+	}
+	copy(header[36:44], lastOriginatingChange)
+
+	copy(header[44:60], b.LastOriginatingDsaInvocationID.ToBytes())
+
+	binary.LittleEndian.PutUint64(header[60:68], uint64(b.OriginatingChange))
+	binary.LittleEndian.PutUint64(header[68:76], uint64(b.LocalChange))
+
+	binary.LittleEndian.PutUint32(header[76:80], data.addString(b.LastOriginatingDsaDN))
+
+	return append(header, data.bytes()...), nil
+}
+
+// String returns a string representation of the DS_REPL_VALUE_META_DATA_BLOB structure.
+func (b *DS_REPL_VALUE_META_DATA_BLOB) String() string {
+	return fmt.Sprintf("DS_REPL_VALUE_META_DATA_BLOB: AttributeName=%q, ObjectDn=%q, Version=%d, DataLen=%d", b.AttributeName, b.ObjectDn, b.Version, len(b.Data))
+}
+
+// Describe prints the DS_REPL_VALUE_META_DATA_BLOB structure to the console.
+//
+// Parameters:
+// - indent: The number of levels to indent the output.
+func (b *DS_REPL_VALUE_META_DATA_BLOB) Describe(indent int) {
+	indentPrompt := strings.Repeat(" │ ", indent)
+	fmt.Printf("%s<\x1b[93mDS_REPL_VALUE_META_DATA_BLOB\x1b[0m>\n", indentPrompt)
+	fmt.Printf("%s │ \x1b[93mAttributeName\x1b[0m: %q\n", indentPrompt, b.AttributeName)
+	fmt.Printf("%s │ \x1b[93mObjectDn\x1b[0m: %q\n", indentPrompt, b.ObjectDn)
+	fmt.Printf("%s │ \x1b[93mData\x1b[0m: (%d bytes)\n", indentPrompt, len(b.Data))
+	fmt.Printf("%s │ \x1b[93mDeleted\x1b[0m: %s\n", indentPrompt, b.Deleted.String())
+	fmt.Printf("%s │ \x1b[93mCreated\x1b[0m: %s\n", indentPrompt, b.Created.String())
+	fmt.Printf("%s │ \x1b[93mVersion\x1b[0m: %d\n", indentPrompt, b.Version)
+	fmt.Printf("%s │ \x1b[93mLastOriginatingChange\x1b[0m: %s\n", indentPrompt, b.LastOriginatingChange.String())
+	fmt.Printf("%s │ \x1b[93mLastOriginatingDsaInvocationID\x1b[0m: %s\n", indentPrompt, b.LastOriginatingDsaInvocationID.ToFormatD())
+	fmt.Printf("%s │ \x1b[93mOriginatingChange\x1b[0m: %d\n", indentPrompt, b.OriginatingChange)
+	fmt.Printf("%s │ \x1b[93mLocalChange\x1b[0m: %d\n", indentPrompt, b.LocalChange)
+	fmt.Printf("%s │ \x1b[93mLastOriginatingDsaDN\x1b[0m: %q\n", indentPrompt, b.LastOriginatingDsaDN)
+	fmt.Printf("%s └───\n", indentPrompt)
+}

--- a/windows/activedirectory/replication/dsrepl/DS_REPL_VALUE_META_DATA_BLOB.go
+++ b/windows/activedirectory/replication/dsrepl/DS_REPL_VALUE_META_DATA_BLOB.go
@@ -20,10 +20,10 @@ const ds_repl_value_meta_data_blob_header_size = 80
 //
 // Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/5d421689-808b-466d-8d9f-106cda2dbcce
 type DS_REPL_VALUE_META_DATA_BLOB struct {
-	// AttributeName is the LDAP display name of the attribute (oszAttributeName).
-	AttributeName string
-	// ObjectDn is the DN of the object that this attribute belongs to (oszObjectDn).
-	ObjectDn string
+	// AttributeName is the LDAP display name of the attribute (oszAttributeName). nil if NULL.
+	AttributeName *string
+	// ObjectDn is the DN of the object that this attribute belongs to (oszObjectDn). nil if NULL.
+	ObjectDn *string
 	// Data is the attribute replication metadata buffer (cbData / pbData).
 	Data []byte
 	// Deleted is the timeDeleted of the LinkValueStamp (ftimeDeleted).
@@ -40,8 +40,8 @@ type DS_REPL_VALUE_META_DATA_BLOB struct {
 	OriginatingChange int64
 	// LocalChange is the USN on the destination server of the last applied change (usnLocalChange).
 	LocalChange int64
-	// LastOriginatingDsaDN is the DN of the nTDSDSA object that originated the last replication (oszLastOriginatingDsaDN).
-	LastOriginatingDsaDN string
+	// LastOriginatingDsaDN is the DN of the nTDSDSA object that originated the last replication (oszLastOriginatingDsaDN). nil if NULL.
+	LastOriginatingDsaDN *string
 }
 
 // NewDS_REPL_VALUE_META_DATA_BLOB creates a new, empty DS_REPL_VALUE_META_DATA_BLOB structure.
@@ -158,7 +158,7 @@ func (b *DS_REPL_VALUE_META_DATA_BLOB) Marshal() ([]byte, error) {
 
 // String returns a string representation of the DS_REPL_VALUE_META_DATA_BLOB structure.
 func (b *DS_REPL_VALUE_META_DATA_BLOB) String() string {
-	return fmt.Sprintf("DS_REPL_VALUE_META_DATA_BLOB: AttributeName=%q, ObjectDn=%q, Version=%d, DataLen=%d", b.AttributeName, b.ObjectDn, b.Version, len(b.Data))
+	return fmt.Sprintf("DS_REPL_VALUE_META_DATA_BLOB: AttributeName=%s, ObjectDn=%s, Version=%d, DataLen=%d", describeOszString(b.AttributeName), describeOszString(b.ObjectDn), b.Version, len(b.Data))
 }
 
 // Describe prints the DS_REPL_VALUE_META_DATA_BLOB structure to the console.
@@ -168,8 +168,8 @@ func (b *DS_REPL_VALUE_META_DATA_BLOB) String() string {
 func (b *DS_REPL_VALUE_META_DATA_BLOB) Describe(indent int) {
 	indentPrompt := strings.Repeat(" │ ", indent)
 	fmt.Printf("%s<\x1b[93mDS_REPL_VALUE_META_DATA_BLOB\x1b[0m>\n", indentPrompt)
-	fmt.Printf("%s │ \x1b[93mAttributeName\x1b[0m: %q\n", indentPrompt, b.AttributeName)
-	fmt.Printf("%s │ \x1b[93mObjectDn\x1b[0m: %q\n", indentPrompt, b.ObjectDn)
+	fmt.Printf("%s │ \x1b[93mAttributeName\x1b[0m: %s\n", indentPrompt, describeOszString(b.AttributeName))
+	fmt.Printf("%s │ \x1b[93mObjectDn\x1b[0m: %s\n", indentPrompt, describeOszString(b.ObjectDn))
 	fmt.Printf("%s │ \x1b[93mData\x1b[0m: (%d bytes)\n", indentPrompt, len(b.Data))
 	fmt.Printf("%s │ \x1b[93mDeleted\x1b[0m: %s\n", indentPrompt, b.Deleted.String())
 	fmt.Printf("%s │ \x1b[93mCreated\x1b[0m: %s\n", indentPrompt, b.Created.String())
@@ -178,6 +178,6 @@ func (b *DS_REPL_VALUE_META_DATA_BLOB) Describe(indent int) {
 	fmt.Printf("%s │ \x1b[93mLastOriginatingDsaInvocationID\x1b[0m: %s\n", indentPrompt, b.LastOriginatingDsaInvocationID.ToFormatD())
 	fmt.Printf("%s │ \x1b[93mOriginatingChange\x1b[0m: %d\n", indentPrompt, b.OriginatingChange)
 	fmt.Printf("%s │ \x1b[93mLocalChange\x1b[0m: %d\n", indentPrompt, b.LocalChange)
-	fmt.Printf("%s │ \x1b[93mLastOriginatingDsaDN\x1b[0m: %q\n", indentPrompt, b.LastOriginatingDsaDN)
+	fmt.Printf("%s │ \x1b[93mLastOriginatingDsaDN\x1b[0m: %s\n", indentPrompt, describeOszString(b.LastOriginatingDsaDN))
 	fmt.Printf("%s └───\n", indentPrompt)
 }

--- a/windows/activedirectory/replication/dsrepl/DS_REPL_VALUE_META_DATA_BLOB_test.go
+++ b/windows/activedirectory/replication/dsrepl/DS_REPL_VALUE_META_DATA_BLOB_test.go
@@ -13,8 +13,8 @@ func TestDS_REPL_VALUE_META_DATA_BLOB_RoundTrip(t *testing.T) {
 	g, _ := guid.FromString("fedcba98-7654-3210-fedc-ba9876543210")
 
 	original := &dsrepl.DS_REPL_VALUE_META_DATA_BLOB{
-		AttributeName:                  "member",
-		ObjectDn:                       "CN=Group,DC=example,DC=com",
+		AttributeName:                  strptr("member"),
+		ObjectDn:                       strptr("CN=Group,DC=example,DC=com"),
 		Data:                           []byte{0x01, 0x02, 0x03, 0x04, 0x05},
 		Deleted:                        data_structures.FILETIME{DwLowDateTime: 0, DwHighDateTime: 0},
 		Created:                        data_structures.FILETIME{DwLowDateTime: 0xAAAA, DwHighDateTime: 0x01D00001},
@@ -23,7 +23,7 @@ func TestDS_REPL_VALUE_META_DATA_BLOB_RoundTrip(t *testing.T) {
 		LastOriginatingDsaInvocationID: *g,
 		OriginatingChange:              111,
 		LocalChange:                    222,
-		LastOriginatingDsaDN:           "CN=NTDS Settings,CN=DC06",
+		LastOriginatingDsaDN:           strptr("CN=NTDS Settings,CN=DC06"),
 	}
 
 	marshalled, err := original.Marshal()
@@ -36,11 +36,11 @@ func TestDS_REPL_VALUE_META_DATA_BLOB_RoundTrip(t *testing.T) {
 		t.Fatalf("Unmarshal failed: %v", err)
 	}
 
-	if parsed.AttributeName != original.AttributeName {
-		t.Errorf("AttributeName = %q, want %q", parsed.AttributeName, original.AttributeName)
+	if !sameStr(parsed.AttributeName, original.AttributeName) {
+		t.Errorf("AttributeName = %v, want %v", parsed.AttributeName, original.AttributeName)
 	}
-	if parsed.ObjectDn != original.ObjectDn {
-		t.Errorf("ObjectDn = %q, want %q", parsed.ObjectDn, original.ObjectDn)
+	if !sameStr(parsed.ObjectDn, original.ObjectDn) {
+		t.Errorf("ObjectDn = %v, want %v", parsed.ObjectDn, original.ObjectDn)
 	}
 	if !bytes.Equal(parsed.Data, original.Data) {
 		t.Errorf("Data = %v, want %v", parsed.Data, original.Data)
@@ -60,15 +60,15 @@ func TestDS_REPL_VALUE_META_DATA_BLOB_RoundTrip(t *testing.T) {
 	if parsed.LocalChange != original.LocalChange {
 		t.Errorf("LocalChange = %d, want %d", parsed.LocalChange, original.LocalChange)
 	}
-	if parsed.LastOriginatingDsaDN != original.LastOriginatingDsaDN {
-		t.Errorf("LastOriginatingDsaDN = %q, want %q", parsed.LastOriginatingDsaDN, original.LastOriginatingDsaDN)
+	if !sameStr(parsed.LastOriginatingDsaDN, original.LastOriginatingDsaDN) {
+		t.Errorf("LastOriginatingDsaDN = %v, want %v", parsed.LastOriginatingDsaDN, original.LastOriginatingDsaDN)
 	}
 }
 
 func TestDS_REPL_VALUE_META_DATA_BLOB_NoData(t *testing.T) {
 	original := &dsrepl.DS_REPL_VALUE_META_DATA_BLOB{
-		AttributeName: "member",
-		ObjectDn:      "CN=Group,DC=example,DC=com",
+		AttributeName: strptr("member"),
+		ObjectDn:      strptr("CN=Group,DC=example,DC=com"),
 		Data:          nil,
 	}
 

--- a/windows/activedirectory/replication/dsrepl/DS_REPL_VALUE_META_DATA_BLOB_test.go
+++ b/windows/activedirectory/replication/dsrepl/DS_REPL_VALUE_META_DATA_BLOB_test.go
@@ -1,0 +1,94 @@
+package dsrepl_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/windows/activedirectory/replication/dsrepl"
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+	"github.com/TheManticoreProject/Manticore/windows/ms_dtyp/common/data_structures"
+)
+
+func TestDS_REPL_VALUE_META_DATA_BLOB_RoundTrip(t *testing.T) {
+	g, _ := guid.FromString("fedcba98-7654-3210-fedc-ba9876543210")
+
+	original := &dsrepl.DS_REPL_VALUE_META_DATA_BLOB{
+		AttributeName:                  "member",
+		ObjectDn:                       "CN=Group,DC=example,DC=com",
+		Data:                           []byte{0x01, 0x02, 0x03, 0x04, 0x05},
+		Deleted:                        data_structures.FILETIME{DwLowDateTime: 0, DwHighDateTime: 0},
+		Created:                        data_structures.FILETIME{DwLowDateTime: 0xAAAA, DwHighDateTime: 0x01D00001},
+		Version:                        2,
+		LastOriginatingChange:          data_structures.FILETIME{DwLowDateTime: 0xBBBB, DwHighDateTime: 0x01D00002},
+		LastOriginatingDsaInvocationID: *g,
+		OriginatingChange:              111,
+		LocalChange:                    222,
+		LastOriginatingDsaDN:           "CN=NTDS Settings,CN=DC06",
+	}
+
+	marshalled, err := original.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	parsed := dsrepl.NewDS_REPL_VALUE_META_DATA_BLOB()
+	if _, err := parsed.Unmarshal(marshalled); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+
+	if parsed.AttributeName != original.AttributeName {
+		t.Errorf("AttributeName = %q, want %q", parsed.AttributeName, original.AttributeName)
+	}
+	if parsed.ObjectDn != original.ObjectDn {
+		t.Errorf("ObjectDn = %q, want %q", parsed.ObjectDn, original.ObjectDn)
+	}
+	if !bytes.Equal(parsed.Data, original.Data) {
+		t.Errorf("Data = %v, want %v", parsed.Data, original.Data)
+	}
+	if parsed.Created != original.Created {
+		t.Errorf("Created = %+v, want %+v", parsed.Created, original.Created)
+	}
+	if parsed.Version != original.Version {
+		t.Errorf("Version = %d, want %d", parsed.Version, original.Version)
+	}
+	if !parsed.LastOriginatingDsaInvocationID.Equal(&original.LastOriginatingDsaInvocationID) {
+		t.Errorf("LastOriginatingDsaInvocationID mismatch")
+	}
+	if parsed.OriginatingChange != original.OriginatingChange {
+		t.Errorf("OriginatingChange = %d, want %d", parsed.OriginatingChange, original.OriginatingChange)
+	}
+	if parsed.LocalChange != original.LocalChange {
+		t.Errorf("LocalChange = %d, want %d", parsed.LocalChange, original.LocalChange)
+	}
+	if parsed.LastOriginatingDsaDN != original.LastOriginatingDsaDN {
+		t.Errorf("LastOriginatingDsaDN = %q, want %q", parsed.LastOriginatingDsaDN, original.LastOriginatingDsaDN)
+	}
+}
+
+func TestDS_REPL_VALUE_META_DATA_BLOB_NoData(t *testing.T) {
+	original := &dsrepl.DS_REPL_VALUE_META_DATA_BLOB{
+		AttributeName: "member",
+		ObjectDn:      "CN=Group,DC=example,DC=com",
+		Data:          nil,
+	}
+
+	marshalled, err := original.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	parsed := dsrepl.NewDS_REPL_VALUE_META_DATA_BLOB()
+	if _, err := parsed.Unmarshal(marshalled); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if len(parsed.Data) != 0 {
+		t.Errorf("Data = %v, want empty", parsed.Data)
+	}
+}
+
+func TestDS_REPL_VALUE_META_DATA_BLOB_ShortData(t *testing.T) {
+	parsed := dsrepl.NewDS_REPL_VALUE_META_DATA_BLOB()
+	if _, err := parsed.Unmarshal(make([]byte, 40)); err == nil {
+		t.Error("expected error for short data, got nil")
+	}
+}

--- a/windows/activedirectory/replication/dsrepl/dsrepl.go
+++ b/windows/activedirectory/replication/dsrepl/dsrepl.go
@@ -24,22 +24,24 @@ import (
 // the given 32-bit offset relative to the start of blob.
 //
 // Per [MS-ADTS], an offset of 0 denotes a NULL string (the field is absent); in
-// that case the empty string is returned with no error.
+// that case nil is returned. A non-zero offset that points directly at a null
+// terminator yields a non-nil pointer to an empty string, preserving the
+// distinction between an absent and a present-but-empty value.
 //
 // Parameters:
 // - blob: The full structure bytes (offsets are relative to its start).
 // - offset: The 32-bit offset of the string, as stored in a header field.
 //
 // Returns:
-// - The decoded string ("" if the offset is 0).
+// - A pointer to the decoded string, or nil if the offset is 0.
 // - An error if the offset is out of range or the string is not null-terminated.
-func readOffsetString(blob []byte, offset uint32) (string, error) {
+func readOffsetString(blob []byte, offset uint32) (*string, error) {
 	if offset == 0 {
-		return "", nil
+		return nil, nil
 	}
 
 	if int(offset) > len(blob) {
-		return "", fmt.Errorf("string offset %d is out of range (blob is %d bytes)", offset, len(blob))
+		return nil, fmt.Errorf("string offset %d is out of range (blob is %d bytes)", offset, len(blob))
 	}
 
 	// Scan for the UTF-16LE null terminator (two 0x00 bytes on an even boundary).
@@ -51,10 +53,20 @@ func readOffsetString(blob []byte, offset uint32) (string, error) {
 		}
 	}
 	if end == -1 {
-		return "", fmt.Errorf("string at offset %d is not null-terminated", offset)
+		return nil, fmt.Errorf("string at offset %d is not null-terminated", offset)
 	}
 
-	return utf16.DecodeUTF16LE(blob[offset:end]), nil
+	s := utf16.DecodeUTF16LE(blob[offset:end])
+	return &s, nil
+}
+
+// describeOszString formats an optional offset string for human-readable output,
+// rendering a NULL (nil) value as <null> and any present value quoted.
+func describeOszString(s *string) string {
+	if s == nil {
+		return "<null>"
+	}
+	return fmt.Sprintf("%q", *s)
 }
 
 // dataRegion accumulates the variable-length trailing data of a DS_REPL_*_BLOB
@@ -75,16 +87,17 @@ func newDataRegion(headerLen int) *dataRegion {
 }
 
 // addString appends s as a null-terminated UTF-16LE string and returns the
-// 32-bit offset to use in the header. An empty string is encoded as a NULL
-// pointer (offset 0) and nothing is appended, matching the [MS-ADTS] semantics
-// that an absent optional string is represented by a zero offset.
-func (d *dataRegion) addString(s string) uint32 {
-	if s == "" {
+// 32-bit offset to use in the header. A nil pointer is encoded as a NULL pointer
+// (offset 0) with nothing appended, matching the [MS-ADTS] semantics that an
+// absent optional string is represented by a zero offset. A non-nil pointer to an
+// empty string is encoded as a present, zero-length string (just a terminator).
+func (d *dataRegion) addString(s *string) uint32 {
+	if s == nil {
 		return 0
 	}
 
 	offset := d.base + uint32(len(d.buf))
-	d.buf = append(d.buf, utf16.EncodeUTF16LE(s)...)
+	d.buf = append(d.buf, utf16.EncodeUTF16LE(*s)...)
 	// UTF-16LE null terminator.
 	d.buf = append(d.buf, 0x00, 0x00)
 

--- a/windows/activedirectory/replication/dsrepl/dsrepl.go
+++ b/windows/activedirectory/replication/dsrepl/dsrepl.go
@@ -1,0 +1,115 @@
+// Package dsrepl implements the DS_REPL_*_BLOB structures defined in [MS-ADTS]
+// section 2.2. These are the binary (";binary" qualified) LDAP representations of
+// the replication state structures otherwise returned by the IDL_DRSGetReplInfo
+// RPC method, as read from the rootDSE attributes msDS-ReplAllInboundNeighbors,
+// msDS-ReplConnectionFailures, msDS-ReplLinkFailures, msDS-ReplPendingOps,
+// msDS-ReplQueueStatistics, msDS-NCReplCursors, msDS-ReplAttributeMetaData, and
+// msDS-ReplValueMetaData.
+//
+// Each structure is a fixed-size header in which string fields are stored as
+// 32-bit byte offsets (the osz* members), relative to the start of the structure,
+// pointing into a trailing variable-length data region of packed, null-terminated
+// UTF-16LE strings. All multibyte fields use little-endian byte ordering.
+//
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/a38fb14a-5f54-41ad-8875-c0c716afd53b
+package dsrepl
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/encoding/utf16"
+)
+
+// readOffsetString reads a null-terminated UTF-16LE string from blob, located at
+// the given 32-bit offset relative to the start of blob.
+//
+// Per [MS-ADTS], an offset of 0 denotes a NULL string (the field is absent); in
+// that case the empty string is returned with no error.
+//
+// Parameters:
+// - blob: The full structure bytes (offsets are relative to its start).
+// - offset: The 32-bit offset of the string, as stored in a header field.
+//
+// Returns:
+// - The decoded string ("" if the offset is 0).
+// - An error if the offset is out of range or the string is not null-terminated.
+func readOffsetString(blob []byte, offset uint32) (string, error) {
+	if offset == 0 {
+		return "", nil
+	}
+
+	if int(offset) > len(blob) {
+		return "", fmt.Errorf("string offset %d is out of range (blob is %d bytes)", offset, len(blob))
+	}
+
+	// Scan for the UTF-16LE null terminator (two 0x00 bytes on an even boundary).
+	end := -1
+	for i := int(offset); i+1 < len(blob); i += 2 {
+		if blob[i] == 0x00 && blob[i+1] == 0x00 {
+			end = i
+			break
+		}
+	}
+	if end == -1 {
+		return "", fmt.Errorf("string at offset %d is not null-terminated", offset)
+	}
+
+	return utf16.DecodeUTF16LE(blob[offset:end]), nil
+}
+
+// dataRegion accumulates the variable-length trailing data of a DS_REPL_*_BLOB
+// and assigns each appended item a 32-bit offset relative to the start of the
+// structure. Offsets account for the fixed header that precedes the data region.
+type dataRegion struct {
+	// base is the size, in bytes, of the fixed header that precedes the data
+	// region. Offsets are computed as base + position within buf.
+	base uint32
+	// buf holds the packed data bytes (strings and buffers).
+	buf []byte
+}
+
+// newDataRegion creates a dataRegion for a structure whose fixed header is
+// headerLen bytes long.
+func newDataRegion(headerLen int) *dataRegion {
+	return &dataRegion{base: uint32(headerLen), buf: make([]byte, 0)}
+}
+
+// addString appends s as a null-terminated UTF-16LE string and returns the
+// 32-bit offset to use in the header. An empty string is encoded as a NULL
+// pointer (offset 0) and nothing is appended, matching the [MS-ADTS] semantics
+// that an absent optional string is represented by a zero offset.
+func (d *dataRegion) addString(s string) uint32 {
+	if s == "" {
+		return 0
+	}
+
+	offset := d.base + uint32(len(d.buf))
+	d.buf = append(d.buf, utf16.EncodeUTF16LE(s)...)
+	// UTF-16LE null terminator.
+	d.buf = append(d.buf, 0x00, 0x00)
+
+	return offset
+}
+
+// addBytes appends a raw buffer and returns the 32-bit offset to use in the
+// header. A nil/empty buffer is encoded as a NULL pointer (offset 0). The data
+// region is kept 32-bit aligned, as required for the pbData buffer of
+// DS_REPL_VALUE_META_DATA_BLOB.
+func (d *dataRegion) addBytes(b []byte) uint32 {
+	if len(b) == 0 {
+		return 0
+	}
+
+	offset := d.base + uint32(len(d.buf))
+	d.buf = append(d.buf, b...)
+	for len(d.buf)%4 != 0 {
+		d.buf = append(d.buf, 0x00)
+	}
+
+	return offset
+}
+
+// bytes returns the accumulated data-region bytes.
+func (d *dataRegion) bytes() []byte {
+	return d.buf
+}

--- a/windows/activedirectory/replication/dsrepl/dsrepl_test.go
+++ b/windows/activedirectory/replication/dsrepl/dsrepl_test.go
@@ -1,0 +1,16 @@
+package dsrepl_test
+
+// strptr returns a pointer to s, for populating the optional (*string) offset
+// string fields of the DS_REPL_*_BLOB structures in tests.
+func strptr(s string) *string {
+	return &s
+}
+
+// sameStr reports whether two optional (*string) values are equal: both nil, or
+// both non-nil and pointing to equal strings.
+func sameStr(a, b *string) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
+}


### PR DESCRIPTION
### Linked Issues
Closes #641
Closes #642
Closes #643
Closes #644
Closes #645
Closes #646
Closes #647

### Summary
Implements the seven MS-ADTS `DS_REPL_*_BLOB` structures — the binary (`;binary`-qualified) LDAP representations of the replication state structures otherwise returned by `IDL_DRSGetReplInfo`, read from rootDSE attributes (`msDS-ReplAllInboundNeighbors`, `msDS-ReplConnectionFailures`, `msDS-ReplLinkFailures`, `msDS-ReplPendingOps`, `msDS-ReplQueueStatistics`, `msDS-NCReplCursors`, `msDS-ReplAttributeMetaData`, `msDS-ReplValueMetaData`).

This is the first package under the new `windows/activedirectory/` grouping for Active Directory wire structures.

| Structure | Issue | MS-ADTS page |
|-----------|-------|--------------|
| `DS_REPL_NEIGHBORW_BLOB` | #641 | 58877402… |
| `DS_REPL_KCC_DSA_FAILUREW_BLOB` | #642 | 93083f06… |
| `DS_REPL_OPW_BLOB` | #643 | 9bdde2d1… |
| `DS_REPL_QUEUE_STATISTICSW_BLOB` | #644 | aa5923c9… |
| `DS_REPL_CURSOR_BLOB` | #645 | 42f0e26e… |
| `DS_REPL_ATTR_META_DATA_BLOB` | #646 | 63fabec7… |
| `DS_REPL_VALUE_META_DATA_BLOB` | #647 | 5d421689… |

### Implementation Notes
Each structure follows the existing wire-structure convention (cf. `windows/keycredentiallink`): a `New…()` constructor, `Unmarshal(data []byte) (int, error)`, `Marshal() ([]byte, error)`, `String()`, and `Describe(indent int)`, with a `// Source:` link to the spec page.

These BLOBs are a fixed-size header in which string fields are 32-bit byte offsets (the `osz*` members) pointing into a trailing variable-length data region of packed, null-terminated UTF-16LE strings. The offset bookkeeping (decode-at-offset and an offset-table builder, including the 32-bit-aligned `pbData` buffer for `DS_REPL_VALUE_META_DATA_BLOB`) lives in one shared helper in `dsrepl.go`. Per spec, an offset of 0 denotes a NULL string and round-trips as an empty Go string. Reused building blocks: `windows/guid` (`GUID`) for the `uuid*` fields, `windows/ms_dtyp/.../data_structures` (`FILETIME`) for the `ftime*` fields, and `encoding/utf16` for string encode/decode. All multibyte fields are little-endian.

### How Verified
- `go build ./...` — clean.
- `go vet ./windows/activedirectory/...` — clean.
- `gofmt -l` — no diffs.
- `go test ./windows/activedirectory/...` — 18 tests pass.

### Test Coverage
**Added:** per-structure round-trip (Marshal→Unmarshal→re-Marshal) tests, NULL/empty-string handling, short-buffer and out-of-range-offset error paths, and a hand-built fixed-bytes fixture (`TestDS_REPL_CURSOR_BLOB_FixedBytes`) that validates the on-the-wire field layout independently of `Marshal`.

### Scope of Change
- **Files changed:** 8 source files + 7 test files under `windows/activedirectory/replication/dsrepl/` (new package).
- **Submodule pointer updated:** no.
- **Behavioral changes outside the new package:** none.