### PR TITLE
Fix LDAP Pass-the-Hash to use NTLM hash bind (#657)

### DIFF
--- a/network/ldap/session.go
+++ b/network/ldap/session.go
@@ -175,13 +175,11 @@ func (s *Session) Connect() (bool, error) {
 	} else {
 		// Use NTLM authentification or null auth
 		if s.credentials.CanPassTheHash() {
-			// Bind with Pass the NT Hash
-			if len(s.credentials.GetPassword()) > 0 {
-				// Binding with credentials
-				err = ldapConnection.Bind(fmt.Sprintf("%s@%s", s.credentials.GetUsername(), s.credentials.GetDomain()), s.credentials.GetPassword())
-				if err != nil {
-					return false, fmt.Errorf("error binding with Pass the NT Hash: %w", err)
-				}
+			// Bind with Pass the NT Hash using an NTLMSSP bind keyed on the NT hash,
+			// not a cleartext simple bind keyed on the password.
+			err = ldapConnection.NTLMBindWithHash(s.credentials.GetDomain(), s.credentials.GetUsername(), s.credentials.GetNTHash())
+			if err != nil {
+				return false, fmt.Errorf("error binding with Pass the NT Hash: %w", err)
 			}
 		} else if len(s.credentials.GetPassword()) > 0 {
 			// Binding with credentials


### PR DESCRIPTION
### Linked Issue
Closes #657

### Root Cause
The Pass-the-Hash branch in `(*Session).Connect()` was wired to go-ldap's cleartext simple-bind API (`Bind`) using the password field, rather than the NTLM hash-bind API using the NT hash. Because `CanPassTheHash()` is true whenever an NT hash and username are present, and the standard Pass-the-Hash case supplies no password, the inner `len(GetPassword()) > 0` guard was false and the branch performed no bind at all — after which execution fell through to assign the connection and return success, leaving the session anonymous.

### Fix Description
Replace the password-keyed simple bind in the Pass-the-Hash branch with `ldapConnection.NTLMBindWithHash(domain, username, GetNTHash())`, which performs an NTLMSSP bind using the NT hash. The guard on the password is removed so the bind always executes on this path, and any bind error is propagated instead of being silently skipped. The non-hash branches (password simple bind, unauthenticated bind) are unchanged.

### How Verified
Static reasoning over the patched path (`network/ldap/session.go` L177–L183): when `CanPassTheHash()` is true, `NTLMBindWithHash` is now invoked unconditionally with the NT hash; a bind failure returns `(false, error)` rather than falling through to a false success. `go build ./network/ldap/...` and `go test ./network/ldap/...` pass.

### Test Coverage
None: the bind path requires a live LDAP/AD server with NTLM enabled to exercise end to end, which is not available in CI. The change is a direct substitution of the bind call and is covered by compilation and the existing package tests.

### Scope of Change
- **Files changed:** `network/ldap/session.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Blast radius is limited to the Pass-the-Hash authentication path. Callers using a password or unauthenticated bind are unaffected. Safe to merge without staged rollout.
