### PR TITLE
Fix GetAllDomains to request the dc attribute for NetBIOSName (#659)

### DIFF
--- a/network/ldap/objects.go
+++ b/network/ldap/objects.go
@@ -18,7 +18,7 @@ import (
 //   - A map where the keys are the distinguished names of the domain objects and the values are
 //     pointers to Domain objects representing the retrieved domain objects.
 func (ldapSession *Session) GetAllDomains() (map[string]*objects.Domain, error) {
-	attributes := []string{"distinguishedName", "objectSid"}
+	attributes := []string{"distinguishedName", "objectSid", "dc"}
 	query := "(objectClass=domain)"
 
 	ldapResults, err := ldapSession.QueryWholeSubtree("", query, attributes)


### PR DESCRIPTION
### Linked Issue
Closes #659

### Root Cause
`GetAllDomains` built its LDAP search with an attribute list of `{"distinguishedName", "objectSid"}` but the result-processing loop reads `entry.GetAttributeValue("dc")` to set each domain's `NetBIOSName`. Because `dc` was never requested, `GetAttributeValue` returned an empty string, so `NetBIOSName` was always blank. The sibling `GetDomain` already requests `dc`, so the omission was an inconsistency in the attribute list rather than intended behavior.

### Fix Description
Add `"dc"` to the attribute list requested by `GetAllDomains`, so the value read into `NetBIOSName` is actually retrieved. This mirrors the attribute set already used by `GetDomain`.

### How Verified
Static reasoning over the patched code (`network/ldap/objects.go` L21): the search now requests `dc`, so `entry.GetAttributeValue("dc")` at L36 resolves to the stored value instead of an empty string. `go build ./network/ldap/...` and `go test ./network/ldap/...` pass.

### Test Coverage
None: populating this field requires a live directory returning domain objects; no LDAP server is available in CI. The fix is a one-line attribute-list correction validated by compilation and existing tests.

### Scope of Change
- **Files changed:** `network/ldap/objects.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Trivial and local: requests one additional attribute on an existing query. No regression risk; safe to merge directly.
