### PR TITLE
Fix GetAllCertificates to propagate LDAP query errors (#661)

### DIFF
--- a/network/ldap/certificates.go
+++ b/network/ldap/certificates.go
@@ -18,7 +18,7 @@ func (ldapSession *Session) GetAllCertificates() ([]string, error) {
 
 	ldapResults, err := ldapSession.QueryWholeSubtree("configurationNamingContext", query, attributes)
 	if err != nil {
-		return distinguishedNames, nil
+		return distinguishedNames, fmt.Errorf("error querying LDAP: %w", err)
 	}
 
 	if len(ldapResults) != 0 {


### PR DESCRIPTION
### Linked Issue
Closes #661

### Root Cause
The error branch in `GetAllCertificates` checked the error returned by `QueryWholeSubtree` but then returned the literal `nil` as the error value, discarding the captured `err`. As a result any LDAP failure (connection error, access denied) was surfaced to callers as a successful call returning an empty result set.

### Fix Description
Return the wrapped query error (`fmt.Errorf("error querying LDAP: %w", err)`) from the failure branch instead of `nil`, matching the error-propagation pattern already used by the sibling functions `GetNamesOfAllEnabledCertificates` and `GetDistinguishedNamesOfAllEnabledCertificates`.

### How Verified
Static reasoning over the patched path (`network/ldap/certificates.go` L20–L22): a non-nil error from `QueryWholeSubtree` now returns a non-nil wrapped error to the caller rather than `nil`, so a query failure is no longer indistinguishable from an empty result. `go build ./network/ldap/...` and `go test ./network/ldap/...` pass.

### Test Coverage
None: exercising the error path requires inducing an LDAP query failure against a live server, which is not available in CI. The change is a one-line error-propagation correction validated by compilation and existing tests.

### Scope of Change
- **Files changed:** `network/ldap/certificates.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local change to one error branch. Callers that previously ignored the (always-nil) error and only inspected the slice are unaffected; callers that check the error now observe real failures. Safe to merge directly.
