### PR TITLE
Fix int64 overflow in ConvertLDAPTimeStampToUnixTimeStamp (#663)

### DIFF
--- a/network/ldap/utils.go
+++ b/network/ldap/utils.go
@@ -86,8 +86,10 @@ func ConvertLDAPTimeStampToUnixTimeStamp(value string) (int64, error) {
 			// Typically for dates on year 1601
 			convertedValue = 0
 		} else {
-			delta := int64((valueInt - UnixTimestampStart) * 100)
-			convertedValue = int64(time.Unix(0, delta).Unix())
+			// Reduce the 100-nanosecond interval count to seconds directly.
+			// Scaling to nanoseconds first (* 100) overflows int64 for large
+			// values such as the 0x7FFFFFFFFFFFFFFF "never" sentinel.
+			convertedValue = (valueInt - UnixTimestampStart) / int64(1e7)
 		}
 	}
 

--- a/network/ldap/utils_test.go
+++ b/network/ldap/utils_test.go
@@ -31,6 +31,34 @@ func TestConvertSecondsToLDAPDuration(t *testing.T) {
 	}
 }
 
+func TestConvertLDAPTimeStampToUnixTimeStamp(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected int64
+	}{
+		{"Empty value", "", 0},
+		{"Epoch", "116444736000000000", 0},
+		{"One day after epoch", "116445600000000000", 86400},
+		{"Known time", "133444736000000000", 1700000000},
+		{"Before epoch (year 1601)", "0", 0},
+		// 0x7FFFFFFFFFFFFFFF "never" sentinel: must not overflow int64.
+		{"Max int64 never sentinel", "9223372036854775807", 910692730085},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ldap.ConvertLDAPTimeStampToUnixTimeStamp(tt.input)
+			if err != nil {
+				t.Fatalf("ConvertLDAPTimeStampToUnixTimeStamp(%q) returned error: %s", tt.input, err)
+			}
+			if result != tt.expected {
+				t.Errorf("ConvertLDAPTimeStampToUnixTimeStamp(%q) = %d; want %d", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
 func TestConvertUnixTimeStampToLDAPTimeStamp(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
### Linked Issue
Closes #663

### Root Cause
`ConvertLDAPTimeStampToUnixTimeStamp` first scaled the elapsed 100-nanosecond-interval count to nanoseconds (`(valueInt - UnixTimestampStart) * 100`) and then fed it to `time.Unix(0, delta)`. For large inputs the nanosecond intermediate exceeds the int64 maximum (`9.223e18`). The routinely-encountered `0x7FFFFFFFFFFFFFFF` "never" sentinel used by AD attributes such as `accountExpires` and `lastLogonTimestamp` produces a nanosecond value around `9.1e20`, which wraps around int64 before `time.Unix` is called, yielding a meaningless timestamp.

### Fix Description
Reduce the 100-nanosecond-interval count directly to seconds by dividing by `1e7` (`(valueInt - UnixTimestampStart) / int64(1e7)`) instead of multiplying up to nanoseconds. Because the elapsed-interval count and the divided result both stay within int64 for all valid inputs (including the max-int64 sentinel), the overflow is eliminated. The existing guard returning `0` for pre-1970 values is preserved.

### Fix Description (alternatives considered)
Special-casing the max-int64 sentinel was rejected because the overflow affects a range of large values, not only that single constant; dividing to seconds fixes the whole class.

### How Verified
Added a table-driven unit test (below) and ran it:
```
go test ./network/ldap/ -run TestConvertLDAPTimeStampToUnixTimeStamp -v
```
All cases pass, including the max-int64 sentinel which now returns `910692730085` rather than an overflowed value. Full package `go test ./network/ldap/...` passes.

### Test Coverage
Added: `TestConvertLDAPTimeStampToUnixTimeStamp` in `network/ldap/utils_test.go`, covering the empty input, epoch, a one-day offset, a known mid-range time, the pre-epoch (1601) zero case, and the `0x7FFFFFFFFFFFFFFF` "never" sentinel that previously overflowed.

### Scope of Change
- **Files changed:** `network/ldap/utils.go`, `network/ldap/utils_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
The conversion now yields correct seconds for the full input range; previously-correct small/mid-range values are unchanged (same arithmetic result). Safe to merge directly.
