### PR TITLE
Fix doc examples to use NewSession instead of InitSession (#670)

### DIFF
--- a/network/ldap/modify.go
+++ b/network/ldap/modify.go
@@ -229,10 +229,9 @@ func (ldapSession *Session) OverwriteAttributeValue(distinguishedName string, at
 //
 // Example usage:
 //
-//	session := &Session{}
-//	err := session.InitSession("ldap.example.com", 389, false, true, "EXAMPLE", "user", "password", false)
+//	session, err := NewSession("ldap.example.com", 389, credentials, false, false)
 //	if err != nil {
-//		logger.Error(fmt.Sprintf("Failed to initialize session: %s", err))
+//		logger.Error(fmt.Sprintf("Failed to create session: %s", err))
 //		return
 //	}
 //	success, err := session.Connect()

--- a/network/ldap/session.go
+++ b/network/ldap/session.go
@@ -28,14 +28,13 @@ import (
 //
 // Example:
 //
-//	session := &Session{}
-//	err := session.InitSession("ldap.example.com", 389, false, true, "EXAMPLE", "user", "password", false)
+//	session, err := NewSession("ldap.example.com", 389, credentials, false, false)
 //	if err != nil {
-//		log.Fatalf("Failed to initialize session: %s", err)
+//		log.Fatalf("Failed to create session: %s", err)
 //	}
-//	success := session.Connect()
+//	success, err := session.Connect()
 //	if !success {
-//		log.Fatalf("Failed to connect to LDAP server")
+//		log.Fatalf("Failed to connect to LDAP server: %s", err)
 //	}
 type Session struct {
 	// Network


### PR DESCRIPTION
### Linked Issue
Closes #670

### Root Cause
The doc examples for the `Session` type and the `Modify` method were written against an earlier `InitSession(...)` constructor that no longer exists. When the constructor was renamed to `NewSession` with a different signature, the example comments were not updated, so the documented usage no longer compiles.

### Fix Description
Update both example blocks to call `NewSession("ldap.example.com", 389, credentials, false, false)` with its real signature and the `(*Session, error)` return, and to use the two-value `success, err := session.Connect()` form. No code behavior changes — comments only.

### How Verified
Static review of the corrected examples against the actual `NewSession` signature (`session.go` L74) and `Connect` return (`session.go` L116). `go build ./network/ldap/...` passes.

### Test Coverage
None: the change is limited to documentation comments; there is no executable behavior to test.

### Scope of Change
- **Files changed:** `network/ldap/session.go`, `network/ldap/modify.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Notes
The `Session` type doc block also lists some fields that no longer exist on the struct; that is tracked separately and intentionally left out of this focused doc fix.
