### PR TITLE
Remove dead debug flag and unreachable logging in Query (#669)

### DIFF
--- a/network/ldap/query.go
+++ b/network/ldap/query.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/TheManticoreProject/Manticore/logger"
-
 	"github.com/go-ldap/ldap/v3"
 )
 
@@ -31,8 +29,6 @@ import (
 // If the search is successful, it returns the search results. If an error occurs, it logs a warning
 // and returns an empty slice.
 func (ldapSession *Session) Query(searchBase string, query string, attributes []string, scope int) ([]*ldap.Entry, error) {
-	debug := false
-
 	// Parsing parameters
 	if len(searchBase) == 0 {
 		searchBase = "defaultNamingContext"
@@ -42,19 +38,10 @@ func (ldapSession *Session) Query(searchBase string, query string, attributes []
 		return nil, fmt.Errorf("error fetching RootDSE: %w", err)
 	}
 	if strings.ToLower(searchBase) == "defaultnamingcontext" {
-		if debug {
-			logger.Debug(fmt.Sprintf("Using defaultNamingContext %s ...\n", rootDSE.GetAttributeValue("defaultNamingContext")))
-		}
 		searchBase = rootDSE.GetAttributeValue("defaultNamingContext")
 	} else if strings.ToLower(searchBase) == "configurationnamingcontext" {
-		if debug {
-			logger.Debug(fmt.Sprintf("Using configurationNamingContext %s ...\n", rootDSE.GetAttributeValue("configurationNamingContext")))
-		}
 		searchBase = rootDSE.GetAttributeValue("configurationNamingContext")
 	} else if strings.ToLower(searchBase) == "schemanamingcontext" {
-		if debug {
-			logger.Debug(fmt.Sprintf("Using schemaNamingContext CN=Schema,%s ...\n", rootDSE.GetAttributeValue("configurationNamingContext")))
-		}
 		searchBase = fmt.Sprintf("CN=Schema,%s", rootDSE.GetAttributeValue("configurationNamingContext"))
 	}
 


### PR DESCRIPTION
### Linked Issue
Closes #669

### Root Cause
`Query` declared a local `debug := false` that was never reassigned, so the three `if debug { logger.Debug(...) }` guards around the naming-context resolution were permanently false and unreachable. The flag was a placeholder that was never wired to any configurable source.

### Fix Description
Remove the `debug` local and the three unreachable `if debug { ... }` logging blocks, keeping the actual `searchBase` resolution logic intact. With the only `logger` references gone, the now-unused `logger` import is removed as well. No reachable behavior changes — only dead code is deleted.

### Fix Description (alternatives considered)
Wiring `debug` to a real session/logger setting was considered but rejected as out of scope: the `Session` type exposes no debug toggle, so introducing one is a feature rather than a defect fix. Removing the dead code restores an honest reading of the function; logging can be reintroduced deliberately if a debug option is added later.

### How Verified
Static reasoning over the patched `Query` (`network/ldap/query.go`): the resolution branches are unchanged aside from removing the dead guards, and no remaining code references `debug` or `logger`. `go build ./network/ldap/...`, `go vet ./network/ldap/`, and `go test ./network/ldap/...` all pass.

### Test Coverage
None: the change only deletes unreachable code and an unused import; there is no new behavior to test, and existing tests continue to pass.

### Scope of Change
- **Files changed:** `network/ldap/query.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Notes
This branch overlaps with the fix for #667 (RootDSE fetched on every `Query`), which restructures the same resolution block. Whichever merges first, the other will need a trivial rebase.
