### PR TITLE
Fetch RootDSE in Query only when resolving naming-context placeholders (#667)

### DIFF
--- a/network/ldap/query.go
+++ b/network/ldap/query.go
@@ -33,16 +33,23 @@ func (ldapSession *Session) Query(searchBase string, query string, attributes []
 	if len(searchBase) == 0 {
 		searchBase = "defaultNamingContext"
 	}
-	rootDSE, err := ldapSession.GetRootDSE()
-	if err != nil {
-		return nil, fmt.Errorf("error fetching RootDSE: %w", err)
-	}
-	if strings.ToLower(searchBase) == "defaultnamingcontext" {
-		searchBase = rootDSE.GetAttributeValue("defaultNamingContext")
-	} else if strings.ToLower(searchBase) == "configurationnamingcontext" {
-		searchBase = rootDSE.GetAttributeValue("configurationNamingContext")
-	} else if strings.ToLower(searchBase) == "schemanamingcontext" {
-		searchBase = fmt.Sprintf("CN=Schema,%s", rootDSE.GetAttributeValue("configurationNamingContext"))
+	// Resolve the special naming-context placeholders against the RootDSE.
+	// The RootDSE is only fetched when one of these placeholders is supplied,
+	// so a query against a concrete DN does not incur an extra round-trip.
+	switch strings.ToLower(searchBase) {
+	case "defaultnamingcontext", "configurationnamingcontext", "schemanamingcontext":
+		rootDSE, err := ldapSession.GetRootDSE()
+		if err != nil {
+			return nil, fmt.Errorf("error fetching RootDSE: %w", err)
+		}
+		switch strings.ToLower(searchBase) {
+		case "defaultnamingcontext":
+			searchBase = rootDSE.GetAttributeValue("defaultNamingContext")
+		case "configurationnamingcontext":
+			searchBase = rootDSE.GetAttributeValue("configurationNamingContext")
+		case "schemanamingcontext":
+			searchBase = fmt.Sprintf("CN=Schema,%s", rootDSE.GetAttributeValue("configurationNamingContext"))
+		}
 	}
 
 	if (scope != ldap.ScopeBaseObject) && (scope != ldap.ScopeSingleLevel) && (scope != ldap.ScopeWholeSubtree) {


### PR DESCRIPTION
### Linked Issue
Closes #667

### Root Cause
`Query` called `GetRootDSE()` unconditionally before checking whether `searchBase` was one of the special placeholders (`defaultNamingContext`, `configurationNamingContext`, `schemaNamingContext`). The fetched RootDSE is only consumed inside those branches, so for the common case of a concrete DN the extra LDAP round-trip was performed and then discarded. Because nearly every read in the package routes through `Query`, this effectively doubled the request count for most operations.

### Fix Description
Move the `GetRootDSE()` call inside a guard that runs only when `searchBase` is one of the three placeholders. A concrete DN now skips the RootDSE fetch entirely and proceeds directly to the search. The placeholder-resolution logic and its results are unchanged; the empty-`searchBase` default to `defaultNamingContext` still applies (and correctly triggers the fetch). The branch chain was rewritten as a `switch` to express "fetch once, then resolve" without duplicating the fetch per case.

### How Verified
Static reasoning over the patched `Query` (`network/ldap/query.go`): when `searchBase` is a concrete DN, none of the `switch` cases match, so `GetRootDSE()` is not called and the search runs as before; when a placeholder (or empty, which defaults to `defaultNamingContext`) is supplied, the RootDSE is fetched exactly once and the same attribute values are substituted. `go build ./network/ldap/...`, `go vet ./network/ldap/`, and `go test ./network/ldap/...` all pass.

### Test Coverage
None: exercising both paths requires a live directory (the function issues real LDAP searches and reads the RootDSE); no server is available in CI. The change preserves the existing resolution outputs and is validated by compilation, vet, and the existing package tests.

### Scope of Change
- **Files changed:** `network/ldap/query.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none — same resolved `searchBase`, fewer round-trips.

### Risk and Rollout
Behavior is identical for placeholder inputs and for concrete DNs; only the redundant round-trip is removed. Safe to merge directly.

### Notes
This branch overlaps with the fix for #669 (dead `debug` flag), which removes the now-preserved `if debug { ... }` blocks in this same resolution code. Whichever merges first, the other will need a trivial rebase; the `debug` blocks were intentionally left untouched here to keep this PR scoped to the round-trip fix.
