### PR TITLE
Fix DNWithBinary.Unmarshal to allow colons in DN and validate prefix (#671)

### DIFF
--- a/network/ldap/DNWithBinary.go
+++ b/network/ldap/DNWithBinary.go
@@ -20,9 +20,17 @@ const (
 )
 
 func (d *DNWithBinary) Unmarshal(rawBytes []byte) (int, error) {
-	parts := bytes.Split(rawBytes, []byte(StringFormatSeparator))
+	// Format: B:<hex-digit-count>:<hex>:<DN>. Only the first three colons are
+	// structural separators; the distinguished name may itself contain colons,
+	// so the split is limited to four fields to preserve them in the DN.
+	parts := bytes.SplitN(rawBytes, []byte(StringFormatSeparator), 4)
 	if len(parts) != 4 {
-		return 0, errors.New("rawBytes should have exactly four parts separated by colons (:)")
+		return 0, errors.New("rawBytes should have four parts separated by colons (:)")
+	}
+
+	expectedPrefix := strings.TrimSuffix(StringFormatPrefix, StringFormatSeparator)
+	if string(parts[0]) != expectedPrefix {
+		return 0, fmt.Errorf("invalid format prefix %q, expected %q", string(parts[0]), expectedPrefix)
 	}
 
 	size, err := strconv.Atoi(string(parts[1]))

--- a/network/ldap/DNWithBinary_test.go
+++ b/network/ldap/DNWithBinary_test.go
@@ -34,6 +34,18 @@ func TestUnmarshal(t *testing.T) {
 			expectError: true,
 		},
 		{
+			name:        "DN containing a colon",
+			rawBytes:    []byte("B:10:48656c6c6f:CN=a:b,OU=Users,DC=example,DC=com"),
+			expectError: false,
+			expectedDN:  "CN=a:b,OU=Users,DC=example,DC=com",
+			expectedBin: []byte{0x48, 0x65, 0x6c, 0x6c, 0x6f},
+		},
+		{
+			name:        "Invalid format prefix",
+			rawBytes:    []byte("X:10:48656c6c6f:CN=John Doe,DC=example,DC=com"),
+			expectError: true,
+		},
+		{
 			name:        "Invalid parts count",
 			rawBytes:    []byte("B:10:48656c6c6f"),
 			expectError: true,


### PR DESCRIPTION
### Linked Issue
Closes #671

### Root Cause
`DNWithBinary.Unmarshal` split the input on every colon with `bytes.Split` and required exactly four resulting parts. The DN-with-binary format `B:<count>:<hex>:<DN>` only uses the first three colons as structural separators; the trailing distinguished name may itself contain colons. Any such DN produced five or more parts and was rejected. The function also never validated the leading `B` format prefix, so malformed inputs with a different prefix were silently accepted.

### Fix Description
Switch to `bytes.SplitN(rawBytes, sep, 4)` so at most four fields are produced and colons in the DN are preserved in the final field. Add an explicit check that the first field equals the format prefix (`B`, derived from `StringFormatPrefix`), returning a descriptive error otherwise. All existing validation (size match, hex decoding, part count) is unchanged. `Marshal` already emits exactly three structural colons, so values round-trip through `Marshal`/`Unmarshal` even when the DN contains colons.

### How Verified
Added unit test cases and ran them:
```
go test ./network/ldap/ -run TestUnmarshal -v
```
All cases pass, including a DN containing a colon (`CN=a:b,...`, now parsed correctly) and an invalid prefix (`X:...`, now rejected). `go build ./network/ldap/...` passes.

### Test Coverage
Added: two cases in `TestUnmarshal` (`network/ldap/DNWithBinary_test.go`) — "DN containing a colon" (expects success with the full DN preserved) and "Invalid format prefix" (expects an error). Existing cases, including "Invalid parts count" and "Empty input", still pass.

### Scope of Change
- **Files changed:** `network/ldap/DNWithBinary.go`, `network/ldap/DNWithBinary_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Inputs that parsed before still parse identically; the change only accepts previously-rejected valid inputs (colon-bearing DNs) and rejects previously-accepted malformed ones (wrong prefix). Safe to merge directly.
