### PR TITLE
Bound DNS probe with a timeout and stop treating partial failures as fatal in GetDomainDNSServers (#672)

### DIFF
--- a/network/ldap/domain_controllers.go
+++ b/network/ldap/domain_controllers.go
@@ -3,27 +3,35 @@ package ldap
 import (
 	"fmt"
 	"net"
-	"strings"
+	"time"
 
 	"github.com/TheManticoreProject/Manticore/network/ldap/ldap_attributes"
 )
+
+// dnsProbeTimeout bounds each TCP connection attempt to a domain controller's
+// DNS port so a single unresponsive host cannot stall the whole enumeration.
+const dnsProbeTimeout = 2 * time.Second
 
 // GetDomainDNSServers retrieves the IP addresses of DNS servers from both read-only domain controllers
 // and domain controllers in the LDAP session. It attempts to establish a TCP connection to port 53
 // (DNS service) on each hostname found in the domain controllers. If the connection is successful,
 // it extracts the IP address of the DNS server and adds it to the list of DNS servers.
 //
+// A domain controller that is unreachable or not serving DNS is skipped rather
+// than treated as a fatal error: the function returns the DNS servers it could
+// reach. An error is only returned when the domain controllers themselves cannot
+// be listed.
+//
 // Returns:
-// - A slice of strings containing the IP addresses of the DNS servers.
-// - An error if any issues occur during the retrieval process.
+// - A slice of strings containing the IP addresses of the reachable DNS servers.
+// - An error if the domain controllers could not be listed.
 func (ldapSession *Session) GetDomainDNSServers() ([]string, error) {
 	dnsServers := []string{}
-	var errList []string
 
 	probe := func(hostname string) {
-		conn, err := net.Dial("tcp", hostname+":53")
+		conn, err := net.DialTimeout("tcp", hostname+":53", dnsProbeTimeout)
 		if err != nil {
-			errList = append(errList, fmt.Sprintf("Error connecting to %s: %s", hostname, err))
+			// Host is unreachable or not serving DNS; skip it.
 			return
 		}
 		defer conn.Close()
@@ -32,7 +40,6 @@ func (ldapSession *Session) GetDomainDNSServers() ([]string, error) {
 		// Use net.SplitHostPort so IPv6 addresses ("[::1]:53") are handled correctly.
 		host, _, splitErr := net.SplitHostPort(conn.RemoteAddr().String())
 		if splitErr != nil {
-			errList = append(errList, fmt.Sprintf("Error parsing remote address for %s: %s", hostname, splitErr))
 			return
 		}
 		dnsServers = append(dnsServers, host)
@@ -60,10 +67,6 @@ func (ldapSession *Session) GetDomainDNSServers() ([]string, error) {
 		for _, hostname := range readOnlyDomainControllersMap[distinguishedName] {
 			probe(hostname)
 		}
-	}
-
-	if len(errList) > 0 {
-		return dnsServers, fmt.Errorf("encountered errors: %s", strings.Join(errList, "; "))
 	}
 
 	return dnsServers, nil


### PR DESCRIPTION
### Linked Issue
Closes #672

### Root Cause
`GetDomainDNSServers` probed each domain-controller hostname with `net.Dial` (no deadline) sequentially, so any unreachable or filtered host stalled the whole enumeration for the OS default TCP connect timeout, once per host. Separately, every probe failure was accumulated into `errList` and the function returned a non-nil error whenever the list was non-empty — so a run where some DCs answered and others did not returned both valid results and an error, conflating partial failure with total failure.

### Fix Description
Two changes:
1. Replace `net.Dial` with `net.DialTimeout("tcp", host+":53", dnsProbeTimeout)`, introducing a `dnsProbeTimeout` constant (2s) so each probe is bounded and an unresponsive host cannot block the run.
2. Treat an unreachable or non-DNS-serving domain controller as a skip, not an error: drop the `errList` accumulation and the final aggregated-error return. The function now returns the DNS servers it could reach with a `nil` error. Hard failures — being unable to *list* the domain controllers or read-only domain controllers — still return an error as before. The now-unused `strings` import is removed.

### Fix Description (alternatives considered)
Returning probe errors alongside results (the previous contract) was rejected because an unreachable DC is an expected, non-fatal condition for this discovery function; surfacing it as an error caused callers to discard otherwise-valid results. Distinguishing "no DNS servers found" from "some probes failed" is left to the caller inspecting the returned slice.

### How Verified
Static reasoning over the patched function (`network/ldap/domain_controllers.go`): each `probe` now uses a 2s-bounded dial and returns silently on failure; the function returns `dnsServers, nil` after probing, and still returns wrapped errors from `GetAllDomainControllers` / `GetAllReadOnlyDomainControllers`. `go build ./network/ldap/...`, `go vet ./network/ldap/`, and `go test ./network/ldap/...` all pass.

### Test Coverage
None: the function performs live TCP dials against domain-controller hosts discovered via LDAP, which requires a directory and reachable hosts not available in CI. The change is validated by compilation, vet, and the existing package tests; the timeout and skip-on-failure behavior is evident from the dial call and control flow.

### Scope of Change
- **Files changed:** `network/ldap/domain_controllers.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none beyond the intended contract change (probe failures no longer returned as an error).

### Risk and Rollout
Callers that previously relied on the aggregated probe error will no longer receive it; they should inspect the returned slice instead. The hard-failure error paths (DC listing) are unchanged. Latency is now bounded per host. Safe to merge.
