### PR TITLE
Make LDAPS TLS certificate verification configurable via SetTLSSkipVerify (#668)

### DIFF
--- a/network/ldap/session.go
+++ b/network/ldap/session.go
@@ -46,6 +46,10 @@ type Session struct {
 	// Config
 	useldaps    bool
 	usekerberos bool
+	// tlsSkipVerify controls whether the server certificate is verified for
+	// LDAPS connections. It defaults to true (verification disabled) to preserve
+	// the historical behavior; use SetTLSSkipVerify to enable verification.
+	tlsSkipVerify bool
 }
 
 // NewSession creates a new LDAP session with the provided configuration and credentials.
@@ -88,8 +92,24 @@ func NewSession(host string, port int, credentials *credentials.Credentials, use
 	// Config
 	s.useldaps = useldaps
 	s.usekerberos = usekerberos
+	// Preserve the historical default of not verifying the server certificate.
+	s.tlsSkipVerify = true
 
 	return s, nil
+}
+
+// SetTLSSkipVerify controls whether the server certificate is verified when
+// establishing an LDAPS connection.
+//
+// Parameters:
+//
+//	skip (bool): When true (the default), the server certificate is not verified.
+//	             When false, the certificate chain and hostname are validated and
+//	             the connection fails if validation does not succeed.
+//
+// This must be called before Connect to take effect.
+func (s *Session) SetTLSSkipVerify(skip bool) {
+	s.tlsSkipVerify = skip
 }
 
 // Connect establishes a connection to the LDAP server. It supports both regular LDAP and LDAPS connections,
@@ -124,7 +144,7 @@ func (s *Session) Connect() (bool, error) {
 			fmt.Sprintf("ldaps://%s:%d", s.host, s.port),
 			ldap.DialWithTLSConfig(
 				&tls.Config{
-					InsecureSkipVerify: true,
+					InsecureSkipVerify: s.tlsSkipVerify,
 				},
 			),
 		)


### PR DESCRIPTION
### Linked Issue
Closes #668

### Root Cause
The LDAPS branch of `Connect()` built its `tls.Config` inline with `InsecureSkipVerify: true` hardcoded, with no field on `Session` or parameter on `NewSession` to influence it. As a result every LDAPS session disabled certificate verification and callers had no way to require it.

### Fix Description
Add a `tlsSkipVerify` field to `Session` and a `SetTLSSkipVerify(skip bool)` setter, and use `InsecureSkipVerify: s.tlsSkipVerify` when constructing the LDAPS `tls.Config`. `NewSession` initializes the field to `true`, preserving the existing default behavior so current callers are unaffected; a caller that wants verification calls `session.SetTLSSkipVerify(false)` before `Connect()`. This keeps the `NewSession` signature unchanged (no breakage for downstream consumers) while making the behavior controllable.

### Fix Description (alternatives considered)
Adding a parameter to `NewSession` was rejected because it would break every existing caller; flipping the default to secure was rejected because the project is offensive/assessment tooling that frequently targets hosts with untrusted certificates, and the linked issue explicitly asked to make verification configurable rather than change the default unilaterally.

### How Verified
Static reasoning over the patched `Connect()` (`network/ldap/session.go`): the LDAPS dial now reads `s.tlsSkipVerify`, which defaults to `true` from `NewSession` (identical to the previous hardcoded value) and becomes `false` only when a caller opts in via `SetTLSSkipVerify(false)`. `go build ./network/ldap/...`, `go vet ./network/ldap/`, and `go test ./network/ldap/...` all pass.

### Test Coverage
None: exercising either branch requires a live LDAPS endpoint (with a valid or invalid certificate) to observe the handshake outcome, which is not available in CI. The change threads an existing boolean into the existing `tls.Config` and is validated by compilation, vet, and existing tests.

### Scope of Change
- **Files changed:** `network/ldap/session.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none — default behavior is unchanged; verification is opt-in.

### Risk and Rollout
Default behavior is byte-for-byte identical to before (`InsecureSkipVerify: true`), so existing callers see no change; the only new behavior is available exclusively when a caller explicitly opts in. Safe to merge.
