### PR TITLE
Use the NT hash for SMB NTLM auth (fix pass-the-hash) (#679)

### DIFF
--- a/crypto/spnego/authcontext.go
+++ b/crypto/spnego/authcontext.go
@@ -22,6 +22,11 @@ type AuthContext struct {
 	Workstation string
 	UseUnicode  bool
 
+	// NTHash is the hex-encoded (32 hex chars) NT hash used for pass-the-hash. When set,
+	// the NTLM AUTHENTICATE is computed from this hash instead of Password, so a caller
+	// can authenticate with only the NT hash. Empty means authenticate with Password.
+	NTHash string
+
 	// NTLM specific fields
 	NTLMChallenge *challenge.ChallengeMessage
 

--- a/crypto/spnego/challenge.go
+++ b/crypto/spnego/challenge.go
@@ -1,12 +1,28 @@
 package spnego
 
 import (
+	"encoding/hex"
 	"errors"
 	"fmt"
 
 	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/message/authenticate"
 	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/message/challenge"
 )
+
+// decodeNTHash decodes a hex-encoded NT hash (32 hex characters) into the 16-byte array
+// the NTLMv2 pass-the-hash path expects.
+func decodeNTHash(ntHashHex string) ([16]byte, error) {
+	var ntHash [16]byte
+	raw, err := hex.DecodeString(ntHashHex)
+	if err != nil {
+		return ntHash, err
+	}
+	if len(raw) != 16 {
+		return ntHash, fmt.Errorf("NT hash must be 16 bytes (32 hex chars), got %d bytes", len(raw))
+	}
+	copy(ntHash[:], raw)
+	return ntHash, nil
+}
 
 // CreateAuthenticateTokenFromChallengeToken processes the server's challenge token and creates an authenticate token
 // Parameters:
@@ -63,8 +79,18 @@ func (ctx *AuthContext) processChallengeInnerTokenNTLM(innerToken []byte) ([]byt
 	// Store the challenge for later use
 	ctx.NTLMChallenge = challenge
 
-	// Create NTLM AUTHENTICATE message
-	ntlmAuth, err := authenticate.CreateAuthenticateMessage(challenge, ctx.Username, ctx.Password, ctx.Domain, ctx.Workstation)
+	// Create NTLM AUTHENTICATE message. When an NT hash is supplied (pass-the-hash),
+	// compute the response from it instead of the password.
+	var ntlmAuth *authenticate.AuthenticateMessage
+	if ctx.NTHash != "" {
+		ntHash, derr := decodeNTHash(ctx.NTHash)
+		if derr != nil {
+			return nil, fmt.Errorf("invalid NT hash for pass-the-hash: %v", derr)
+		}
+		ntlmAuth, err = authenticate.CreateAuthenticateMessageWithNTHash(challenge, ctx.Username, ntHash, ctx.Domain, ctx.Workstation)
+	} else {
+		ntlmAuth, err = authenticate.CreateAuthenticateMessage(challenge, ctx.Username, ctx.Password, ctx.Domain, ctx.Workstation)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to create NTLM AUTHENTICATE message: %v", err)
 	}

--- a/crypto/spnego/challenge_test.go
+++ b/crypto/spnego/challenge_test.go
@@ -1,0 +1,34 @@
+package spnego
+
+import "testing"
+
+func TestDecodeNTHash(t *testing.T) {
+	// A valid 32-hex NT hash decodes to its 16 raw bytes.
+	got, err := decodeNTHash("520126a03f5d5a8d836f1c4f34ede7ce")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := [16]byte{0x52, 0x01, 0x26, 0xa0, 0x3f, 0x5d, 0x5a, 0x8d, 0x83, 0x6f, 0x1c, 0x4f, 0x34, 0xed, 0xe7, 0xce}
+	if got != want {
+		t.Fatalf("decodeNTHash = %x, want %x", got, want)
+	}
+}
+
+func TestDecodeNTHashErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+	}{
+		{"too short", "520126a0"},
+		{"too long", "520126a03f5d5a8d836f1c4f34ede7ce00"},
+		{"non-hex", "zz0126a03f5d5a8d836f1c4f34ede7ce"},
+		{"empty", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := decodeNTHash(tc.in); err == nil {
+				t.Fatalf("decodeNTHash(%q) = nil error, want error", tc.in)
+			}
+		})
+	}
+}

--- a/network/smb/smb_v10/client/session.go
+++ b/network/smb/smb_v10/client/session.go
@@ -143,6 +143,8 @@ func (s *Session) SessionSetup() error {
 				s.Client.Workstation,
 				useUnicode,
 			)
+			// Pass-the-hash: when an NT hash is supplied, authenticate from it instead of the password.
+			authCtx.NTHash = s.Credentials.GetNTHash()
 
 			negotiateFlags := spnego_ntlm_negotiate_flags.NegotiateFlags(
 				spnego_ntlm_negotiate_flags.NTLMSSP_NEGOTIATE_NTLM |
@@ -270,6 +272,8 @@ func (s *Session) SessionSetup() error {
 		s.Client.Workstation,
 		useUnicode,
 	)
+	// Pass-the-hash: when an NT hash is supplied, authenticate from it instead of the password.
+	authCtx.NTHash = s.Credentials.GetNTHash()
 
 	requestStep2Msg := message.NewMessage()
 	requestStep2Msg.Header.Command = codes.SMB_COM_SESSION_SETUP_ANDX

--- a/network/smb/smb_v20/client/session.go
+++ b/network/smb/smb_v20/client/session.go
@@ -63,6 +63,8 @@ func (c *Client) SessionSetup(creds *credentials.Credentials) error {
 		c.Workstation,
 		true,
 	)
+	// Pass-the-hash: when an NT hash is supplied, authenticate from it instead of the password.
+	authCtx.NTHash = creds.GetNTHash()
 
 	negotiateFlags := spnego_ntlm_negotiate_flags.NegotiateFlags(
 		spnego_ntlm_negotiate_flags.NTLMSSP_NEGOTIATE_UNICODE |


### PR DESCRIPTION
### Linked Issue
Closes #679

### Root Cause
The SMB SPNEGO/NTLM authentication path was password-only. `spnego.AuthContext` had no field for an NT hash, and `processChallengeInnerTokenNTLM` always called the password-based `authenticate.CreateAuthenticateMessage(challenge, username, password, ...)`. The SMB1/SMB2 session-setup builders constructed the `AuthContext` from `creds.Password` alone. As a result `credentials.Credentials.NTHash` (populated from `-H`/hashes) was parsed but never used: the response was derived from an empty password, so pass-the-hash always failed with `LOGON_FAILURE`. The NT-hash entry point `CreateAuthenticateMessageWithNTHash` already existed but was unreachable from the SMB path.

### Fix Description
- Add an `NTHash` (hex) field to `spnego.AuthContext`.
- In `processChallengeInnerTokenNTLM`, when `NTHash` is set, decode it (new `decodeNTHash` helper) and build the AUTHENTICATE via the existing `CreateAuthenticateMessageWithNTHash`; otherwise keep the password path. Both share `newAuthenticateMessage`, so session-key derivation and the MIC are unchanged.
- Wire `creds.GetNTHash()` into the `AuthContext` at the three SMB session-setup sites (one SMB2, two SMB1).

`NewAuthContext`'s signature is unchanged (the field is set after construction), so the change is backward compatible.

### How Verified
- **Unit:** new `crypto/spnego/challenge_test.go` covers `decodeNTHash` (valid 32-hex → 16 bytes; rejects short/long/non-hex/empty). `go test ./crypto/spnego/` passes; `go build ./...` and `go vet` clean.
- **End-to-end (live host):** built a dependent SMB tool against this branch (via a local `replace`) and ran it against Windows Server 2016 as a local Administrator:
  - Before: `-H` with the correct NT hash → `LOGON_FAILURE`.
  - After: same `-H` authenticates and reads the target value successfully; a wrong NT hash still returns `LOGON_FAILURE`; password auth unaffected.

### Test Coverage
- **Added:** `crypto/spnego/challenge_test.go` (`TestDecodeNTHash`, `TestDecodeNTHashErrors`). The wiring itself is validated by the live end-to-end run above (network-dependent, not unit-testable here).

### Scope of Change
- **Files changed:** `crypto/spnego/authcontext.go`, `crypto/spnego/challenge.go`, `crypto/spnego/challenge_test.go`, `network/smb/smb_v20/client/session.go`, `network/smb/smb_v10/client/session.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none — the password path is unchanged; the NT-hash path only activates when an NT hash is supplied.

### Notes
Pass-the-hash on the SMB path requires NTLMv2 (extended session security), which the SMB1/SMB2 session setup already negotiates; `CreateAuthenticateMessageWithNTHash` enforces this. The direct `ncacn_ip_tcp` DCERPC auth path already consulted `CanPassTheHash` and is out of scope here.
