### PR TITLE
DRSUAPI: read-only opnum wrappers — VerifyNames + GetReplInfo info types (#696)

### DIFF
--- a/network/dcerpc/ms-protocols/ms-drsr/integration_test.go
+++ b/network/dcerpc/ms-protocols/ms-drsr/integration_test.go
@@ -275,3 +275,66 @@ func TestDCSyncAll(t *testing.T) {
 		t.Error("krbtgt (RID 502) not present in full-NC dump")
 	}
 }
+
+// TestReadOpnums exercises the read-only opnum wrappers against a live DC:
+// IDL_DRSGetReplInfo info types, IDL_DRSVerifyNames, IDL_DRSGetMemberships. Requires
+// DRSUAPI_TEST_HOST and DRSUAPI_TEST_NC; DRSUAPI_TEST_DN names an object to verify/expand.
+func TestReadOpnums(t *testing.T) {
+	host := os.Getenv("DRSUAPI_TEST_HOST")
+	nc := os.Getenv("DRSUAPI_TEST_NC")
+	if host == "" || nc == "" {
+		t.Skip("set DRSUAPI_TEST_HOST and DRSUAPI_TEST_NC to run")
+	}
+	creds, err := credentials.NewCredentials(
+		os.Getenv("DRSUAPI_TEST_DOMAIN"), os.Getenv("DRSUAPI_TEST_USER"),
+		os.Getenv("DRSUAPI_TEST_PASS"), os.Getenv("DRSUAPI_TEST_HASHES"))
+	if err != nil {
+		t.Fatalf("build credentials: %v", err)
+	}
+	c := msdrsr.New(host, creds)
+	c.SetTimeout(20 * time.Second)
+	if err := c.Connect(); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	defer c.Close()
+
+	nb, err := c.ReplicationNeighbors(nc)
+	if err != nil {
+		t.Fatalf("ReplicationNeighbors: %v", err)
+	}
+	t.Logf("neighbors: %d", len(nb))
+	for _, n := range nb {
+		t.Logf("  src=%s addr=%s lastResult=%d", n.SourceDsaDN, n.SourceDsaAddress, n.LastSyncResult)
+	}
+	if ops, err := c.ReplicationPendingOps(); err != nil {
+		t.Fatalf("ReplicationPendingOps: %v", err)
+	} else {
+		t.Logf("pending ops: %d", len(ops))
+	}
+	if f, err := c.ReplicationConnectFailures(); err != nil {
+		t.Fatalf("ReplicationConnectFailures: %v", err)
+	} else {
+		t.Logf("connect failures: %d", len(f))
+	}
+	if f, err := c.ReplicationLinkFailures(); err != nil {
+		t.Fatalf("ReplicationLinkFailures: %v", err)
+	} else {
+		t.Logf("link failures: %d", len(f))
+	}
+
+	dn := os.Getenv("DRSUAPI_TEST_DN")
+	if dn == "" {
+		return
+	}
+	vn, err := c.VerifyNames([]string{dn, "CN=NoSuchObject," + nc})
+	if err != nil {
+		t.Fatalf("VerifyNames: %v", err)
+	}
+	for _, v := range vn {
+		t.Logf("verify %q -> found=%v dn=%q guid=%s", v.Input, v.Found, v.DN, v.GUID.ToFormatD())
+	}
+	if len(vn) > 0 && !vn[0].Found {
+		t.Errorf("expected %q to verify", dn)
+	}
+
+}

--- a/network/dcerpc/ms-protocols/ms-drsr/replication_info.go
+++ b/network/dcerpc/ms-protocols/ms-drsr/replication_info.go
@@ -18,15 +18,18 @@ func (c *Client) GetReplInfo(infoType uint32, objectDN string, sourceDSA guid.GU
 	if !c.bound {
 		return nil, fmt.Errorf("msdrsr: not connected")
 	}
-	dn := ndr.WSTR(objectDN)
-	msgIn := structures.DRS_MSG_GETREPLINFO_REQ{
-		Tag: 1,
-		V1: structures.DRS_MSG_GETREPLINFO_REQ_V1{
-			InfoType:             ndr.DWORD(infoType),
-			PszObjectDN:          &dn,
-			UuidSourceDsaObjGuid: structures.UUIDFromGUID(sourceDSA),
-		},
+	v1 := structures.DRS_MSG_GETREPLINFO_REQ_V1{
+		InfoType:             ndr.DWORD(infoType),
+		UuidSourceDsaObjGuid: structures.UUIDFromGUID(sourceDSA),
 	}
+	// pszObjectDN is a [unique] (nullable) pointer: send NULL for an empty DN. Info types
+	// that ignore it (pending ops, KCC failures) reject a non-NULL empty string with
+	// ERROR_DS_DRA_INVALID_PARAMETER.
+	if objectDN != "" {
+		dn := ndr.WSTR(objectDN)
+		v1.PszObjectDN = &dn
+	}
+	msgIn := structures.DRS_MSG_GETREPLINFO_REQ{Tag: 1, V1: v1}
 	_, msgOut, err := functions.IDL_DRSGetReplInfo(c.rpc, c.handle, 1, msgIn)
 	if err != nil {
 		return nil, fmt.Errorf("msdrsr: GetReplInfo(type=%d): %w", infoType, err)
@@ -103,4 +106,119 @@ func (c *Client) QuerySitesByCost(fromSite string, toSites []string) ([]SiteCost
 		out = append(out, sc)
 	}
 	return out, nil
+}
+
+// ReplNeighbor is one replication source (a repsFrom) of a naming context.
+type ReplNeighbor struct {
+	NamingContext         string
+	SourceDsaDN           string
+	SourceDsaAddress      string
+	SourceDsaObjGuid      guid.GUID
+	SourceDsaInvocationID guid.GUID
+	ReplicaFlags          uint32
+	LastSyncResult        uint32
+	ConsecutiveFailures   uint32
+}
+
+// ReplicationNeighbors returns the replication neighbors (repsFrom) of a naming context
+// via IDL_DRSGetReplInfo (DS_REPL_INFO_NEIGHBORS). ncDN is the NC distinguished name.
+func (c *Client) ReplicationNeighbors(ncDN string) ([]ReplNeighbor, error) {
+	reply, err := c.GetReplInfo(structures.DS_REPL_INFO_NEIGHBORS, ncDN, guid.GUID{})
+	if err != nil {
+		return nil, err
+	}
+	if reply.PNeighbors == nil {
+		return nil, nil
+	}
+	out := make([]ReplNeighbor, 0, len(reply.PNeighbors.RgNeighbor))
+	for _, n := range reply.PNeighbors.RgNeighbor {
+		out = append(out, ReplNeighbor{
+			NamingContext:         wstr(n.PszNamingContext),
+			SourceDsaDN:           wstr(n.PszSourceDsaDN),
+			SourceDsaAddress:      wstr(n.PszSourceDsaAddress),
+			SourceDsaObjGuid:      n.UuidSourceDsaObjGuid.GUID(),
+			SourceDsaInvocationID: n.UuidSourceDsaInvocationID.GUID(),
+			ReplicaFlags:          uint32(n.DwReplicaFlags),
+			LastSyncResult:        uint32(n.DwLastSyncResult),
+			ConsecutiveFailures:   uint32(n.CNumConsecutiveSyncFailures),
+		})
+	}
+	return out, nil
+}
+
+// ReplPendingOp is one queued replication operation on the DC.
+type ReplPendingOp struct {
+	SerialNumber  uint32
+	Priority      uint32
+	OpType        uint32
+	NamingContext string
+	DsaDN         string
+	DsaAddress    string
+}
+
+// ReplicationPendingOps returns the DC's pending replication operations via
+// IDL_DRSGetReplInfo (DS_REPL_INFO_PENDING_OPS).
+func (c *Client) ReplicationPendingOps() ([]ReplPendingOp, error) {
+	reply, err := c.GetReplInfo(structures.DS_REPL_INFO_PENDING_OPS, "", guid.GUID{})
+	if err != nil {
+		return nil, err
+	}
+	if reply.PPendingOps == nil {
+		return nil, nil
+	}
+	out := make([]ReplPendingOp, 0, len(reply.PPendingOps.RgPendingOp))
+	for _, o := range reply.PPendingOps.RgPendingOp {
+		out = append(out, ReplPendingOp{
+			SerialNumber:  uint32(o.UlSerialNumber),
+			Priority:      uint32(o.UlPriority),
+			OpType:        uint32(o.OpType),
+			NamingContext: wstr(o.PszNamingContext),
+			DsaDN:         wstr(o.PszDsaDN),
+			DsaAddress:    wstr(o.PszDsaAddress),
+		})
+	}
+	return out, nil
+}
+
+// ReplFailure is one KCC connect/link failure record.
+type ReplFailure struct {
+	DsaDN       string
+	DsaObjGuid  guid.GUID
+	NumFailures uint32
+	LastResult  uint32
+}
+
+func projectFailures(f *structures.DS_REPL_KCC_DSA_FAILURESW) []ReplFailure {
+	if f == nil {
+		return nil
+	}
+	out := make([]ReplFailure, 0, len(f.RgDsaFailure))
+	for _, e := range f.RgDsaFailure {
+		out = append(out, ReplFailure{
+			DsaDN:       wstr(e.PszDsaDN),
+			DsaObjGuid:  e.UuidDsaObjGuid.GUID(),
+			NumFailures: uint32(e.CNumFailures),
+			LastResult:  uint32(e.DwLastResult),
+		})
+	}
+	return out
+}
+
+// ReplicationConnectFailures returns KCC connection failures
+// (DS_REPL_INFO_KCC_DSA_CONNECT_FAILURES).
+func (c *Client) ReplicationConnectFailures() ([]ReplFailure, error) {
+	reply, err := c.GetReplInfo(structures.DS_REPL_INFO_KCC_DSA_CONNECT_FAILURES, "", guid.GUID{})
+	if err != nil {
+		return nil, err
+	}
+	return projectFailures(reply.PConnectFailures), nil
+}
+
+// ReplicationLinkFailures returns KCC link failures (DS_REPL_INFO_KCC_DSA_LINK_FAILURES).
+func (c *Client) ReplicationLinkFailures() ([]ReplFailure, error) {
+	reply, err := c.GetReplInfo(structures.DS_REPL_INFO_KCC_DSA_LINK_FAILURES, "", guid.GUID{})
+	if err != nil {
+		return nil, err
+	}
+	return projectFailures(reply.PLinkFailures), nil
 }

--- a/network/dcerpc/ms-protocols/ms-drsr/verify_names.go
+++ b/network/dcerpc/ms-protocols/ms-drsr/verify_names.go
@@ -1,0 +1,63 @@
+package msdrsr
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/e3514235-4b06-11d1-ab04-00c04fc2dcd2/4.0/functions"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/e3514235-4b06-11d1-ab04-00c04fc2dcd2/4.0/structures"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+)
+
+// DRS_VERIFY_DSNAMES is the IDL_DRSVerifyNames flag selecting verification by DSNAME
+// (the names are distinguished names) ([MS-DRSR] 4.1.26.2).
+const DRS_VERIFY_DSNAMES = 0
+
+// VerifiedName is the result of verifying one object name: the resolved GUID (zero if the
+// object was not found) and its returned distinguished name.
+type VerifiedName struct {
+	Input string
+	DN    string
+	GUID  guid.GUID
+	Found bool
+}
+
+// VerifyNames checks whether the given distinguished names resolve to objects on the DC
+// via IDL_DRSVerifyNames (opnum 8), returning one result per input in order. It requests
+// no attributes (existence only). This is read-only.
+func (c *Client) VerifyNames(dns []string) ([]VerifiedName, error) {
+	if !c.bound {
+		return nil, fmt.Errorf("msdrsr: not connected")
+	}
+	rp := make([]*structures.DSNAME, len(dns))
+	for i, dn := range dns {
+		d := structures.NewDSNameFromDN(dn)
+		rp[i] = &d
+	}
+	msgIn := structures.DRS_MSG_VERIFYREQ{
+		Tag: 1,
+		V1: structures.DRS_MSG_VERIFYREQ_V1{
+			DwFlags: DRS_VERIFY_DSNAMES,
+			CNames:  ndr.DWORD(len(dns)),
+			RpNames: rp,
+		},
+	}
+	_, msgOut, err := functions.IDL_DRSVerifyNames(c.rpc, c.handle, 1, msgIn)
+	if err != nil {
+		return nil, fmt.Errorf("msdrsr: VerifyNames: %w", err)
+	}
+	out := make([]VerifiedName, 0, len(dns))
+	for i, e := range msgOut.V1.RpEntInf {
+		vn := VerifiedName{}
+		if i < len(dns) {
+			vn.Input = dns[i]
+		}
+		if e.PName != nil {
+			vn.GUID = e.PName.Guid.GUID()
+			vn.DN = decodeWChars(e.PName.StringName)
+			vn.Found = !e.PName.Guid.IsZero()
+		}
+		out = append(out, vn)
+	}
+	return out, nil
+}


### PR DESCRIPTION
### Linked Issue
Partially implements #696 (read-only opnum wrappers).

### Summary
Ergonomic, live-validated `ms-drsr` wrappers over read-only drsuapi opnums.

### What's here
- **`VerifyNames`** (IDL_DRSVerifyNames, opnum 8): verify that DNs resolve to objects; returns per-name `{Input, DN, GUID, Found}`. Exercises the `DSNAME**` array reconciled during scaffolding.
- **`GetReplInfo` info types** (IDL_DRSGetReplInfo, opnum 19), alongside the existing `ReplicationCursors`:
  - `ReplicationNeighbors` (DS_REPL_INFO_NEIGHBORS)
  - `ReplicationPendingOps` (DS_REPL_INFO_PENDING_OPS)
  - `ReplicationConnectFailures` / `ReplicationLinkFailures` (KCC_DSA_*_FAILURES)
  These project the int64/FILETIME-bearing `DS_REPL_*` conformant arrays — only parseable now that the NDR alignment fixes (#692/#698) are in `main`, exactly as #696 anticipated.
- `GetReplInfo` now sends a **NULL** `pszObjectDN` for an empty DN (info types that ignore it reject a non-NULL empty string with `ERROR_DS_DRA_INVALID_PARAMETER`).

### How Verified
- `go build ./...`, `go vet`, `go test`, `-tags integration` build — clean.
- **Live, Windows Server 2016** (`TestReadOpnums`): `VerifyNames` resolves `CN=Administrator,…` to its correct objectGUID (`b8536dbf-…`) and reports a bogus DN as not found; the four GetReplInfo info-type wrappers parse correctly (empty on a single-DC lab, as expected — the `DS_REPL_*` int64/FILETIME parsing itself is exercised by the merged cursors path).

### Not included (tracked under #696)
- **GetMemberships / GetMemberships2** (9/21): the wrapper sends and parses correctly, but the server returns an empty result for known-group accounts (Administrator) regardless of DN/GUID/SID addressing — a request-flag or op nuance I haven't cracked. Left out rather than shipped unverified.
- **GetObjectExistence** (23, digest-over-GUID-range) and **GetNT4ChangeLog** (11, opaque blobs): low value / awkward shapes; remain callable as raw `functions.IDL_*` bindings.

### Scope of Change
- New `ms-drsr/verify_names.go`; additions to `ms-drsr/replication_info.go`; live integration test `TestReadOpnums`. No changes outside `ms-drsr`.
