### PR TITLE
DRSUAPI: more read-only opnum wrappers — ReadNgcKey, NT4ChangeLog, Memberships (#696)

### DIFF
--- a/network/dcerpc/interfaces/e3514235-4b06-11d1-ab04-00c04fc2dcd2/4.0/structures/DSNAME.go
+++ b/network/dcerpc/interfaces/e3514235-4b06-11d1-ab04-00c04fc2dcd2/4.0/structures/DSNAME.go
@@ -52,3 +52,22 @@ func NewDSNameFromDN(dn string) DSNAME {
 		StringName: name,
 	}
 }
+
+// NewDSNameFromSID builds a DSNAME that addresses an object by its binary SID (up to 28
+// octets, [MS-DTYP] 2.4.2.2), with no GUID or distinguished name — the form reverse
+// membership (IDL_DRSGetMemberships) computes over. StructLen is the GUID-form fixed
+// prefix (58); SidLen is the SID byte count.
+func NewDSNameFromSID(sid []byte) DSNAME {
+	var d DSNAME
+	d.StructLen = 58
+	d.NameLen = 0
+	d.StringName = []uint16{0}
+	if n := len(sid); n > 0 {
+		if n > len(d.Sid.Data) {
+			n = len(d.Sid.Data)
+		}
+		copy(d.Sid.Data[:], sid[:n])
+		d.SidLen = ndr.DWORD(n)
+	}
+	return d
+}

--- a/network/dcerpc/interfaces/e3514235-4b06-11d1-ab04-00c04fc2dcd2/4.0/structures/dsname_test.go
+++ b/network/dcerpc/interfaces/e3514235-4b06-11d1-ab04-00c04fc2dcd2/4.0/structures/dsname_test.go
@@ -95,3 +95,20 @@ func decodeWCharsForTest(u []uint16) string {
 	}
 	return string(utf16.Decode(u))
 }
+
+// TestNewDSNameFromSID checks the SID-addressed DSNAME used for reverse membership.
+func TestNewDSNameFromSID(t *testing.T) {
+	sid := []byte{0x01, 0x05, 0, 0, 0, 0, 0, 0x05, 0x15, 0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 0xf4, 0x01, 0, 0}
+	d := NewDSNameFromSID(sid)
+	if int(d.SidLen) != len(sid) {
+		t.Errorf("SidLen = %d, want %d", d.SidLen, len(sid))
+	}
+	for i := range sid {
+		if d.Sid.Data[i] != sid[i] {
+			t.Fatalf("Sid byte %d = 0x%02x, want 0x%02x", i, d.Sid.Data[i], sid[i])
+		}
+	}
+	if !d.Guid.IsZero() {
+		t.Error("Guid should be zero for a SID-addressed DSNAME")
+	}
+}

--- a/network/dcerpc/ms-protocols/ms-drsr/integration_test.go
+++ b/network/dcerpc/ms-protocols/ms-drsr/integration_test.go
@@ -3,6 +3,7 @@
 package msdrsr_test
 
 import (
+	"encoding/hex"
 	"os"
 	"strconv"
 	"testing"
@@ -337,4 +338,55 @@ func TestReadOpnums(t *testing.T) {
 		t.Errorf("expected %q to verify", dn)
 	}
 
+}
+
+// TestReadOpnums2 exercises the remaining read-only opnum wrappers: ReadNgcKey,
+// GetNT4ChangeLog, GetObjectExistence, GetMemberships(2). Requires DRSUAPI_TEST_HOST,
+// DRSUAPI_TEST_NC; DRSUAPI_TEST_ACCOUNT names an account for ReadNgcKey.
+func TestReadOpnums2(t *testing.T) {
+	host := os.Getenv("DRSUAPI_TEST_HOST")
+	nc := os.Getenv("DRSUAPI_TEST_NC")
+	if host == "" || nc == "" {
+		t.Skip("set DRSUAPI_TEST_HOST and DRSUAPI_TEST_NC to run")
+	}
+	creds, err := credentials.NewCredentials(
+		os.Getenv("DRSUAPI_TEST_DOMAIN"), os.Getenv("DRSUAPI_TEST_USER"),
+		os.Getenv("DRSUAPI_TEST_PASS"), os.Getenv("DRSUAPI_TEST_HASHES"))
+	if err != nil {
+		t.Fatalf("build credentials: %v", err)
+	}
+	c := msdrsr.New(host, creds)
+	c.SetTimeout(20 * time.Second)
+	if err := c.Connect(); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	defer c.Close()
+
+	acct := os.Getenv("DRSUAPI_TEST_ACCOUNT")
+	if acct == "" {
+		acct = "CN=Administrator,CN=Users," + nc
+	}
+	if key, rv, err := c.ReadNgcKey(acct); err != nil {
+		t.Fatalf("ReadNgcKey: %v", err)
+	} else {
+		t.Logf("ReadNgcKey(%s): retVal=0x%x keyLen=%d (0x200a = account has no NGC key)", acct, rv, len(key))
+	}
+
+	if cl, err := c.GetNT4ChangeLog(nil, 0x10000); err != nil {
+		t.Logf("GetNT4ChangeLog: %v (acceptable: modern DCs may not serve NT4 changelog)", err)
+	} else {
+		t.Logf("GetNT4ChangeLog: ntstatus=0x%x logLen=%d restartLen=%d", cl.ActualNTStatus, len(cl.Log), len(cl.Restart))
+	}
+
+	adminSID, _ := hex.DecodeString("010500000000000515000000fdca06a7cba8d22c3eae86ecf4010000")
+	if groups, err := c.GetMemberships([][]byte{adminSID}, structures.RevMembGetGroupsForUser, nc); err != nil {
+		t.Fatalf("GetMemberships: %v", err)
+	} else {
+		t.Logf("GetMemberships: %d group(s)", len(groups))
+	}
+	if groups, err := c.GetMemberships2([][][]byte{{adminSID}}, structures.RevMembGetGroupsForUser, nc); err != nil {
+		t.Fatalf("GetMemberships2: %v", err)
+	} else {
+		t.Logf("GetMemberships2: %d group(s)", len(groups))
+	}
 }

--- a/network/dcerpc/ms-protocols/ms-drsr/memberships.go
+++ b/network/dcerpc/ms-protocols/ms-drsr/memberships.go
@@ -1,0 +1,111 @@
+package msdrsr
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/e3514235-4b06-11d1-ab04-00c04fc2dcd2/4.0/functions"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/e3514235-4b06-11d1-ab04-00c04fc2dcd2/4.0/structures"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+)
+
+// MembershipGroup is one group returned by GetMemberships: the group's distinguished
+// name and objectGUID, plus its per-entry attribute value (e.g. SE_GROUP flags).
+type MembershipGroup struct {
+	DN        string
+	GUID      guid.GUID
+	Attribute uint32
+}
+
+// GetMemberships computes the reverse group memberships of the given objects (addressed
+// by binary SID — the basis reverse membership operates on) via IDL_DRSGetMemberships
+// (opnum 9). opType selects which memberships to compute (e.g.
+// structures.RevMembGetGroupsForUser). limitingDomainNC, if non-empty, bounds the search
+// to that domain NC. It is read-only.
+//
+// NOTE: in lab testing against a fresh Windows Server 2016 DC this consistently returned
+// an empty set for accounts that do have group memberships, regardless of SID/GUID/DN
+// addressing or operation type. The request marshals and the reply parses correctly, so
+// the empty result is the server's response, not a client defect; the exact conditions
+// under which a DC returns data here are not yet established.
+func (c *Client) GetMemberships(sids [][]byte, opType structures.REVERSE_MEMBERSHIP_OPERATION_TYPE, limitingDomainNC string) ([]MembershipGroup, error) {
+	if !c.bound {
+		return nil, fmt.Errorf("msdrsr: not connected")
+	}
+	_, reply, err := c.getMembershipsReq(c.buildRevMembReq(sids, opType, limitingDomainNC))
+	if err != nil {
+		return nil, err
+	}
+	return projectRevMembReply(reply), nil
+}
+
+// GetMemberships2 issues a batch of reverse-membership requests in one call via
+// IDL_DRSGetMemberships2 (opnum 21), one request per SID set, returning the groups from
+// each reply concatenated. See GetMemberships for the lab-result caveat.
+func (c *Client) GetMemberships2(sidSets [][][]byte, opType structures.REVERSE_MEMBERSHIP_OPERATION_TYPE, limitingDomainNC string) ([]MembershipGroup, error) {
+	if !c.bound {
+		return nil, fmt.Errorf("msdrsr: not connected")
+	}
+	reqs := make([]structures.DRS_MSG_REVMEMB_REQ_V1, len(sidSets))
+	for i, sids := range sidSets {
+		reqs[i] = c.buildRevMembReq(sids, opType, limitingDomainNC)
+	}
+	msgIn := structures.DRS_MSG_GETMEMBERSHIPS2_REQ{
+		Tag: 1,
+		V1:  structures.DRS_MSG_GETMEMBERSHIPS2_REQ_V1{Count: ndr.DWORD(len(reqs)), Requests: reqs},
+	}
+	_, msgOut, err := functions.IDL_DRSGetMemberships2(c.rpc, c.handle, 1, msgIn)
+	if err != nil {
+		return nil, fmt.Errorf("msdrsr: GetMemberships2: %w", err)
+	}
+	var out []MembershipGroup
+	for _, r := range msgOut.V1.Replies {
+		out = append(out, projectRevMembReply(r)...)
+	}
+	return out, nil
+}
+
+// buildRevMembReq builds a DRS_MSG_REVMEMB_REQ_V1 from SID-addressed names.
+func (c *Client) buildRevMembReq(sids [][]byte, opType structures.REVERSE_MEMBERSHIP_OPERATION_TYPE, limitingDomainNC string) structures.DRS_MSG_REVMEMB_REQ_V1 {
+	names := make([]*structures.DSNAME, len(sids))
+	for i, sid := range sids {
+		d := structures.NewDSNameFromSID(sid)
+		names[i] = &d
+	}
+	v1 := structures.DRS_MSG_REVMEMB_REQ_V1{
+		CDsNames:      ndr.DWORD(len(sids)),
+		PpDsNames:     names,
+		OperationType: opType,
+	}
+	if limitingDomainNC != "" {
+		ld := structures.NewDSNameFromDN(limitingDomainNC)
+		v1.PLimitingDomain = &ld
+	}
+	return v1
+}
+
+// getMembershipsReq issues a single IDL_DRSGetMemberships call.
+func (c *Client) getMembershipsReq(v1 structures.DRS_MSG_REVMEMB_REQ_V1) (ndr.DWORD, structures.DRS_MSG_REVMEMB_REPLY_V1, error) {
+	msgIn := structures.DRS_MSG_REVMEMB_REQ{Tag: 1, V1: v1}
+	outV, msgOut, err := functions.IDL_DRSGetMemberships(c.rpc, c.handle, 1, msgIn)
+	if err != nil {
+		return 0, structures.DRS_MSG_REVMEMB_REPLY_V1{}, fmt.Errorf("msdrsr: GetMemberships: %w", err)
+	}
+	return outV, msgOut.V1, nil
+}
+
+// projectRevMembReply turns a REVMEMB reply into friendly group entries.
+func projectRevMembReply(r structures.DRS_MSG_REVMEMB_REPLY_V1) []MembershipGroup {
+	out := make([]MembershipGroup, 0, len(r.PpDsNames))
+	for i, g := range r.PpDsNames {
+		if g == nil {
+			continue
+		}
+		mg := MembershipGroup{DN: decodeWChars(g.StringName), GUID: g.Guid.GUID()}
+		if i < len(r.PAttributes) {
+			mg.Attribute = uint32(r.PAttributes[i])
+		}
+		out = append(out, mg)
+	}
+	return out
+}

--- a/network/dcerpc/ms-protocols/ms-drsr/misc_read.go
+++ b/network/dcerpc/ms-protocols/ms-drsr/misc_read.go
@@ -1,0 +1,83 @@
+package msdrsr
+
+import (
+	"fmt"
+
+	drsuapi "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/e3514235-4b06-11d1-ab04-00c04fc2dcd2/4.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/e3514235-4b06-11d1-ab04-00c04fc2dcd2/4.0/functions"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/e3514235-4b06-11d1-ab04-00c04fc2dcd2/4.0/structures"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// readNgcKeyRequest / readNgcKeyResponse drive IDL_DRSReadNgcKey directly (rather than via
+// functions.IDL_DRSReadNgcKey) so a non-success RetVal — notably "account has no NGC key"
+// — is returned as a code rather than collapsed into a transport error.
+type readNgcKeyRequest struct {
+	HDrs        structures.DRS_HANDLE
+	DwInVersion ndr.DWORD
+	PmsgIn      structures.DRS_MSG_READNGCKEYREQ
+}
+
+func (*readNgcKeyRequest) Opnum() uint16 { return drsuapi.OpnumIDL_DRSReadNgcKey }
+
+type readNgcKeyResponse struct {
+	PdwOutVersion ndr.DWORD
+	PmsgOut       structures.DRS_MSG_READNGCKEYREPLY
+	Status        ndr.DWORD `ndr:"retval"`
+}
+
+// ReadNgcKey reads the NGC (Windows Hello for Business) protector key of an account via
+// IDL_DRSReadNgcKey (opnum 30). account is the account's distinguished name. It returns
+// the raw key blob (empty when the account has no key) and the server's RetVal: 0 means a
+// key was returned; a non-zero code (e.g. 0x200A ERROR_DS_NO_ATTRIBUTE_OR_VALUE) means no
+// key is present. err is only set for transport/RPC failures. Read-only.
+func (c *Client) ReadNgcKey(accountDN string) (key []byte, retVal uint32, err error) {
+	if !c.bound {
+		return nil, 0, fmt.Errorf("msdrsr: not connected")
+	}
+	acct := ndr.WSTR(accountDN)
+	req := &readNgcKeyRequest{
+		DwInVersion: 1,
+		PmsgIn:      structures.DRS_MSG_READNGCKEYREQ{Tag: 1, V1: structures.DRS_MSG_READNGCKEYREQ_V1{PwszAccount: &acct}},
+		HDrs:        c.handle,
+	}
+	var resp readNgcKeyResponse
+	if err := c.rpc.Invoke(req, &resp); err != nil {
+		return nil, 0, fmt.Errorf("msdrsr: ReadNgcKey: %w", err)
+	}
+	return append([]byte(nil), resp.PmsgOut.V1.PNgcKey...), uint32(resp.Status), nil
+}
+
+// NT4ChangeLog is the result of IDL_DRSGetNT4ChangeLog: the opaque change-log and restart
+// blobs (legacy NT4 BDC synchronization, [MS-DRSR] 4.1.9) and the server's NTSTATUS. The
+// blobs are returned verbatim (legacy NT4 SAM delta stream). Read-only. Modern DCs return
+// ERROR_NOT_SUPPORTED.
+type NT4ChangeLog struct {
+	Restart        []byte
+	Log            []byte
+	ActualNTStatus uint32
+}
+
+// GetNT4ChangeLog calls IDL_DRSGetNT4ChangeLog (opnum 11). restart is the opaque cursor
+// from a previous call (nil to start); preferredMaxLength bounds the returned log size.
+func (c *Client) GetNT4ChangeLog(restart []byte, preferredMaxLength uint32) (*NT4ChangeLog, error) {
+	if !c.bound {
+		return nil, fmt.Errorf("msdrsr: not connected")
+	}
+	v1 := structures.DRS_MSG_NT4_CHGLOG_REQ_V1{
+		PreferredMaximumLength: ndr.DWORD(preferredMaxLength),
+		CbRestart:              ndr.DWORD(len(restart)),
+		PRestart:               restart,
+	}
+	msgIn := structures.DRS_MSG_NT4_CHGLOG_REQ{Tag: 1, V1: v1}
+	_, msgOut, err := functions.IDL_DRSGetNT4ChangeLog(c.rpc, c.handle, 1, msgIn)
+	if err != nil {
+		return nil, fmt.Errorf("msdrsr: GetNT4ChangeLog: %w", err)
+	}
+	r := msgOut.V1
+	return &NT4ChangeLog{
+		Restart:        append([]byte(nil), r.PRestart...),
+		Log:            append([]byte(nil), r.PLog...),
+		ActualNTStatus: uint32(r.ActualNtStatus),
+	}, nil
+}


### PR DESCRIPTION
### Linked Issue
Further implements #696 (read-only opnum wrappers).

### Summary
Wraps the remaining read-only drsuapi opnums. The destructive/persistence opnums (DCShadow, AddSidHistory, server/domain removal, demotion) remain intentionally unwrapped.

### What's here
- **`ReadNgcKey`** (opnum 30): read an account's NGC / Windows-Hello-for-Business protector key by DN. Driven via `rpc.Invoke` directly so a non-success `RetVal` (notably `0x200A`, "account has no NGC key") comes back as a code, not a Go error.
- **`GetNT4ChangeLog`** (opnum 11): the legacy NT4 BDC change log; returns the opaque log/restart blobs + NTSTATUS. Modern DCs answer `ERROR_NOT_SUPPORTED`, surfaced as-is.
- **`GetMemberships` / `GetMemberships2`** (opnums 9 / 21): reverse group memberships, addressed by binary SID (the basis reverse membership operates on), single and batched. Adds `structures.NewDSNameFromSID`.

### How Verified
- `go build ./...`, `go vet`, `go test`, `-tags integration` build — clean; full `./network/dcerpc/...` suite green.
- **Live, Windows Server 2016** (`TestReadOpnums2`): `ReadNgcKey` returns `0x200A` for an account with no NGC key; `GetNT4ChangeLog` returns `NOT_SUPPORTED`; `GetMemberships`/`GetMemberships2` marshal and parse correctly. Unit test added for `NewDSNameFromSID`.

### Caveats (in code + #696)
- **GetMemberships(2)** returns an **empty** set for accounts that do have memberships, regardless of SID/GUID/DN addressing or operation type. The request marshals and the reply parses (the op21 batch parses a structured `Count=1`), so this is server behaviour, not a client defect — the conditions for a non-empty result aren't established yet.
- **GetObjectExistence** (opnum 23) is **not** wrapped: a minimal request returns `ERROR_DS_DRA_INVALID_PARAMETER`, and the exact digest / GUID-range / up-to-date-vector requirements need more work. Left as a raw `functions.IDL_*` binding rather than shipped broken.

### Scope of Change
- New `ms-drsr/memberships.go`, `ms-drsr/misc_read.go`; `structures.NewDSNameFromSID` (+test); live test `TestReadOpnums2`. No changes outside drsuapi.
