### PR TITLE
Add shared msproto contracts and transport binders for MS-protocol clients

### DIFF
--- a/network/dcerpc/ms-protocols/ms-drsr/client.go
+++ b/network/dcerpc/ms-protocols/ms-drsr/client.go
@@ -22,14 +22,12 @@ import (
 	"fmt"
 	"time"
 
-	eptiface "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0"
-	eptfunctions "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/functions"
 	drsuapi "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/e3514235-4b06-11d1-ab04-00c04fc2dcd2/4.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/e3514235-4b06-11d1-ab04-00c04fc2dcd2/4.0/functions"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/e3514235-4b06-11d1-ab04-00c04fc2dcd2/4.0/structures"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ms-protocols/msproto"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
 	dcerpcclient "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
-	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/pdu"
-	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/transport/tcp"
 	"github.com/TheManticoreProject/Manticore/windows/credentials"
 )
 
@@ -52,12 +50,21 @@ type Client struct {
 	bound     bool
 }
 
+// compile-time assertion that Client satisfies the session contract.
+var _ msproto.Session = (*Client)(nil)
+
 // New returns an MS-DRSR client for the given host (IP or hostname) and credentials. By
 // default the drsuapi TCP endpoint is resolved through the endpoint mapper on TCP/135;
 // call SetPort to skip resolution and dial a known port directly.
 func New(host string, creds *credentials.Credentials) *Client {
 	return &Client{host: host, creds: creds, timeout: DefaultTimeout}
 }
+
+// Interface reports the DCE/RPC abstract syntax MS-DRSR speaks (drsuapi v4.0).
+func (c *Client) Interface() syntax.SyntaxID { return drsuapi.SyntaxID() }
+
+// IsConnected reports whether Connect has succeeded and Close has not yet run.
+func (c *Client) IsConnected() bool { return c.bound }
 
 // SetTimeout bounds each TCP dial and read. It must be called before Connect.
 func (c *Client) SetTimeout(d time.Duration) { c.timeout = d }
@@ -66,59 +73,24 @@ func (c *Client) SetTimeout(d time.Duration) { c.timeout = d }
 // directly. It must be called before Connect.
 func (c *Client) SetPort(port int) { c.port = port }
 
-// resolvePort asks the endpoint mapper on TCP/135 for the dynamic port the drsuapi
-// interface is bound to, returning the first endpoint that carries a TCP port.
-func (c *Client) resolvePort() (int, error) {
-	tr := tcp.New(c.host, tcp.EndpointMapperPort)
-	tr.SetTimeout(c.timeout)
-	ept := dcerpcclient.NewClient(tr)
-	if err := ept.Bind(eptiface.SyntaxID()); err != nil {
-		return 0, fmt.Errorf("bind endpoint mapper: %w", err)
-	}
-	defer ept.Close()
-
-	syntax := drsuapi.SyntaxID()
-	eps, err := eptfunctions.Map(ept, syntax.UUID, syntax.MajorVersion, syntax.MinorVersion)
-	if err != nil {
-		return 0, fmt.Errorf("ept_map drsuapi: %w", err)
-	}
-	for _, ep := range eps {
-		if ep.Port != 0 {
-			return int(ep.Port), nil
-		}
-	}
-	return 0, fmt.Errorf("endpoint mapper returned no TCP endpoint for drsuapi")
-}
-
 // Connect resolves the drsuapi endpoint (unless a port was set), dials it over
 // ncacn_ip_tcp, authenticates with NTLM at packet-privacy level, binds the drsuapi
 // abstract syntax, and performs the IDL_DRSBind capability handshake. On success the
 // negotiated context handle and the server's extensions are available via Handle and
 // ServerExtensions, and the connection is ready for replication calls.
+//
+// The endpoint resolution, NTLM packet-privacy setup (drsuapi rejects lower levels), and
+// bind are handled by an msproto.TCPBinder; only the drsuapi-specific IDL_DRSBind
+// capability handshake lives here.
 func (c *Client) Connect() error {
 	if c.bound {
 		return fmt.Errorf("msdrsr: already connected")
 	}
 
-	port := c.port
-	if port == 0 {
-		resolved, err := c.resolvePort()
-		if err != nil {
-			return fmt.Errorf("msdrsr: resolve drsuapi endpoint: %w", err)
-		}
-		port = resolved
-	}
-
-	tr := tcp.New(c.host, port)
-	tr.SetTimeout(c.timeout)
-	rpc := dcerpcclient.NewClient(tr)
-
-	// drsuapi requires packet privacy (sign + seal); the server rejects lower levels.
-	if err := rpc.SetAuth(pdu.AuthTypeNTLMSSP, pdu.AuthLevelPktPrivacy, c.creds); err != nil {
-		return fmt.Errorf("msdrsr: configure auth: %w", err)
-	}
-	if err := rpc.Bind(drsuapi.SyntaxID()); err != nil {
-		return fmt.Errorf("msdrsr: bind drsuapi on %s:%d: %w", c.host, port, err)
+	binder := msproto.NewTCPBinder(c.host, c.port, c.creds, c.timeout)
+	rpc, _, err := binder.Bind(drsuapi.SyntaxID())
+	if err != nil {
+		return fmt.Errorf("msdrsr: %w", err)
 	}
 
 	clientGUID := structures.NTDSAPIClientGUID()

--- a/network/dcerpc/ms-protocols/ms-rrp/client.go
+++ b/network/dcerpc/ms-protocols/ms-rrp/client.go
@@ -26,8 +26,9 @@ import (
 
 	winreg "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/structures"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ms-protocols/msproto"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
 	dcerpcclient "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
-	dcerpctransport "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/transport"
 )
 
 // Handle is an open registry key context handle returned by the Open*/BaseRegCreateKey/
@@ -38,32 +39,34 @@ type Handle = structures.RPC_HKEY
 // ErrNotConnected is returned by methods invoked before a successful Connect.
 var ErrNotConnected = errors.New("ms_rrp: not connected; call Connect first")
 
-// PipeDialer opens a fresh DCE/RPC named-pipe transport over an established, IPC$-tree-
-// connected SMB session. It is the only capability MS-RRP needs from the SMB layer, so
-// depending on this interface (rather than a concrete SMB client) keeps ms_rrp
-// independent of the SMB dialect: network/smb/client.Client satisfies it (via its
-// RPCTransport method) and routes to an SMB1 or SMB2 named-pipe transport according to
-// what was negotiated.
-type PipeDialer interface {
-	RPCTransport(pipeName string) (dcerpctransport.Transport, error)
-}
+// PipeDialer is the SMB capability MS-RRP needs: opening a named-pipe transport over an
+// established session. It is an alias of msproto.PipeDialer, shared with the other
+// named-pipe protocols; network/smb/client.Client satisfies it.
+type PipeDialer = msproto.PipeDialer
 
-// RemoteRegistry is the connected MS-RRP client. It carries the session it is reached
-// over (the pipe dialer) and, once Connect has run, the single bound \winreg association
-// that all method calls and chained key handles share.
+// RemoteRegistry is the connected MS-RRP client. It carries the binder for the session it
+// is reached over and, once Connect has run, the single bound \winreg association that all
+// method calls and chained key handles share. It is a msproto.Session: registry handles
+// chain and are scoped to that one association.
 type RemoteRegistry struct {
-	dialer    PipeDialer
+	binder    msproto.Binder
 	rpc       *dcerpcclient.Client
 	closeRPC  func() error
 	connected bool
 }
 
+// compile-time assertion that RemoteRegistry satisfies the session contract.
+var _ msproto.Session = (*RemoteRegistry)(nil)
+
 // New returns a RemoteRegistry over the given pipe dialer (typically a
 // *network/smb/client.Client). The dialer MUST be connected, authenticated, and
 // tree-connected to IPC$ before Connect is called.
 func New(dialer PipeDialer) *RemoteRegistry {
-	return &RemoteRegistry{dialer: dialer}
+	return &RemoteRegistry{binder: msproto.NewPipeBinder(dialer, winreg.PipeName)}
 }
+
+// Interface reports the DCE/RPC abstract syntax MS-RRP speaks (winreg v1.0).
+func (r *RemoteRegistry) Interface() syntax.SyntaxID { return winreg.SyntaxID() }
 
 // Connect opens the \winreg pipe and binds the winreg abstract syntax, establishing the
 // single association that all subsequent calls and key handles use. It is idempotent:
@@ -72,16 +75,12 @@ func (r *RemoteRegistry) Connect() error {
 	if r.connected {
 		return nil
 	}
-	transport, err := r.dialer.RPCTransport(winreg.PipeName)
+	rpc, closeRPC, err := r.binder.Bind(winreg.SyntaxID())
 	if err != nil {
-		return fmt.Errorf("ms_rrp: open winreg pipe: %w", err)
-	}
-	rpc := dcerpcclient.NewClient(transport)
-	if err := rpc.Bind(winreg.SyntaxID()); err != nil {
-		return fmt.Errorf("ms_rrp: bind winreg: %w", err)
+		return fmt.Errorf("ms_rrp: connect winreg: %w", err)
 	}
 	r.rpc = rpc
-	r.closeRPC = rpc.Close
+	r.closeRPC = closeRPC
 	r.connected = true
 	return nil
 }

--- a/network/dcerpc/ms-protocols/ms-srvs/client.go
+++ b/network/dcerpc/ms-protocols/ms-srvs/client.go
@@ -16,11 +16,10 @@
 package mssrvs
 
 import (
-	"fmt"
-
 	srvsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ms-protocols/msproto"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
 	dcerpcclient "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
-	dcerpctransport "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/transport"
 )
 
 // MaxPreferredLength is passed as the preferred maximum reply length of the Netr*Enum
@@ -28,40 +27,43 @@ import (
 // resume-handle paging is needed; this matches common client enumeration usage.
 const MaxPreferredLength uint32 = 0xFFFFFFFF
 
-// PipeDialer opens a fresh DCE/RPC named-pipe transport for the given pipe over an
-// established, IPC$-tree-connected SMB session. It is the only capability MS-SRVS needs
-// from the SMB layer, so depending on this interface (rather than a concrete SMB
-// client) keeps mssrvs independent of the SMB dialect: the generic
-// network/smb/client.Client satisfies it (via its RPCTransport method) and routes to an
-// SMB1 or SMB2 named-pipe transport according to what was negotiated.
-type PipeDialer interface {
-	RPCTransport(pipeName string) (dcerpctransport.Transport, error)
-}
+// PipeDialer is the SMB capability MS-SRVS needs: opening a named-pipe transport over an
+// established session. It is an alias of msproto.PipeDialer, shared with the other
+// named-pipe protocols; network/smb/client.Client satisfies it.
+type PipeDialer = msproto.PipeDialer
 
 // Client exposes MS-SRVS workflows over an established SMB session. The supplied dialer
 // MUST be backed by a client that is connected, authenticated, and tree-connected to
 // IPC$ before any method is called.
+//
+// MS-SRVS is stateless: srvsvc calls are mutually independent, so the client binds a
+// fresh \srvsvc pipe per workflow (a fault on one cannot desync the next) rather than
+// holding a persistent association. It therefore satisfies msproto.Protocol but not
+// msproto.Session.
 type Client struct {
-	dialer PipeDialer
+	binder msproto.Binder
 }
+
+// compile-time assertion that Client satisfies the shared protocol contract.
+var _ msproto.Protocol = (*Client)(nil)
 
 // New returns an MS-SRVS client over the given pipe dialer (typically a
 // *network/smb/client.Client).
 func New(dialer PipeDialer) *Client {
-	return &Client{dialer: dialer}
+	return &Client{binder: msproto.NewPipeBinder(dialer, srvsvc.PipeName)}
 }
+
+// Interface reports the DCE/RPC abstract syntax MS-SRVS speaks (srvsvc v3.0).
+func (c *Client) Interface() syntax.SyntaxID { return srvsvc.SyntaxID() }
+
+// Close releases resources held by the client. MS-SRVS holds no persistent association —
+// each workflow binds and tears down its own pipe — so there is nothing to release and
+// Close is a no-op that always returns nil. It exists to satisfy msproto.Protocol.
+func (c *Client) Close() error { return nil }
 
 // bind opens a fresh \srvsvc pipe and binds the srvsvc abstract syntax over it. srvsvc
 // calls are mutually independent, so each workflow runs on its own pipe and bind: a
 // fault on one cannot desync the next. The returned close function tears the pipe down.
 func (c *Client) bind() (*dcerpcclient.Client, func() error, error) {
-	transport, err := c.dialer.RPCTransport(srvsvc.PipeName)
-	if err != nil {
-		return nil, nil, fmt.Errorf("mssrvs: open srvsvc pipe: %w", err)
-	}
-	rpc := dcerpcclient.NewClient(transport)
-	if err := rpc.Bind(srvsvc.SyntaxID()); err != nil {
-		return nil, nil, fmt.Errorf("mssrvs: bind srvsvc: %w", err)
-	}
-	return rpc, rpc.Close, nil
+	return c.binder.Bind(srvsvc.SyntaxID())
 }

--- a/network/dcerpc/ms-protocols/msproto/binder.go
+++ b/network/dcerpc/ms-protocols/msproto/binder.go
@@ -1,0 +1,139 @@
+package msproto
+
+import (
+	"fmt"
+	"time"
+
+	eptiface "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0"
+	eptfunctions "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/functions"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
+	dcerpcclient "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/pdu"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/transport/tcp"
+	"github.com/TheManticoreProject/Manticore/windows/credentials"
+)
+
+// DefaultTCPTimeout bounds the endpoint-mapper and target TCP dials and reads when a
+// TCPBinder is built without an explicit timeout.
+const DefaultTCPTimeout = 10 * time.Second
+
+// Binder opens a transport and binds an abstract syntax over it, returning a ready
+// DCE/RPC client plus a close function that tears that transport down. It abstracts the
+// one step every MS-protocol shares (transport acquisition + bind) over the differing
+// transport provenances, so a protocol client can issue calls without embedding any
+// dial/bind plumbing of its own.
+//
+// A stateless client calls Bind once per workflow and invokes the returned closer
+// immediately; a session client calls Bind once in Connect and holds the result.
+type Binder interface {
+	// Bind opens a transport, performs any transport-level authentication the provenance
+	// requires, binds the given abstract syntax, and returns the bound client and its
+	// closer. The caller owns the close function and must call it to release the transport.
+	Bind(s syntax.SyntaxID) (*dcerpcclient.Client, func() error, error)
+}
+
+// PipeBinder binds an interface over a DCE/RPC named pipe borrowed from an established SMB
+// session. It performs no DCE/RPC-layer authentication: a named pipe inherits the security
+// context of the SMB session it rides on.
+type PipeBinder struct {
+	dialer PipeDialer
+	pipe   string
+}
+
+// NewPipeBinder returns a Binder that opens the given named pipe over dialer for every
+// Bind call. pipe is the IPC$-relative pipe name (e.g. `\srvsvc`, `\winreg`).
+func NewPipeBinder(dialer PipeDialer, pipe string) *PipeBinder {
+	return &PipeBinder{dialer: dialer, pipe: pipe}
+}
+
+// Bind opens a fresh named-pipe transport and binds s over it.
+func (b *PipeBinder) Bind(s syntax.SyntaxID) (*dcerpcclient.Client, func() error, error) {
+	transport, err := b.dialer.RPCTransport(b.pipe)
+	if err != nil {
+		return nil, nil, fmt.Errorf("msproto: open pipe %s: %w", b.pipe, err)
+	}
+	rpc := dcerpcclient.NewClient(transport)
+	if err := rpc.Bind(s); err != nil {
+		return nil, nil, fmt.Errorf("msproto: bind %s over %s: %w", s.UUID.ToFormatD(), b.pipe, err)
+	}
+	return rpc, rpc.Close, nil
+}
+
+// TCPBinder binds an interface over an owned ncacn_ip_tcp connection. Unlike a borrowed
+// pipe, this transport carries no ambient security context, so TCPBinder authenticates at
+// the DCE/RPC layer with NTLM at the configured level (packet privacy by default, which
+// the secret-bearing interfaces such as drsuapi require). When Port is zero the target
+// port is resolved through the endpoint mapper on TCP/135 for the syntax being bound.
+type TCPBinder struct {
+	Host      string
+	Port      int // 0 resolves via the endpoint mapper
+	Creds     *credentials.Credentials
+	Timeout   time.Duration
+	AuthType  uint8 // DCE/RPC auth type; defaults to NTLMSSP
+	AuthLevel uint8 // DCE/RPC auth level; defaults to packet privacy (sign + seal)
+}
+
+// NewTCPBinder returns a Binder over ncacn_ip_tcp to host authenticating with creds at
+// NTLM packet-privacy level. port may be 0 to resolve the target via the endpoint mapper;
+// a zero timeout falls back to DefaultTCPTimeout.
+func NewTCPBinder(host string, port int, creds *credentials.Credentials, timeout time.Duration) *TCPBinder {
+	if timeout == 0 {
+		timeout = DefaultTCPTimeout
+	}
+	return &TCPBinder{
+		Host:      host,
+		Port:      port,
+		Creds:     creds,
+		Timeout:   timeout,
+		AuthType:  pdu.AuthTypeNTLMSSP,
+		AuthLevel: pdu.AuthLevelPktPrivacy,
+	}
+}
+
+// Bind resolves the endpoint (unless Port is set), dials it over ncacn_ip_tcp,
+// authenticates with NTLM at the configured level, and binds s.
+func (b *TCPBinder) Bind(s syntax.SyntaxID) (*dcerpcclient.Client, func() error, error) {
+	port := b.Port
+	if port == 0 {
+		resolved, err := b.resolvePort(s)
+		if err != nil {
+			return nil, nil, fmt.Errorf("msproto: resolve endpoint: %w", err)
+		}
+		port = resolved
+	}
+
+	tr := tcp.New(b.Host, port)
+	tr.SetTimeout(b.Timeout)
+	rpc := dcerpcclient.NewClient(tr)
+
+	if err := rpc.SetAuth(b.AuthType, b.AuthLevel, b.Creds); err != nil {
+		return nil, nil, fmt.Errorf("msproto: configure auth: %w", err)
+	}
+	if err := rpc.Bind(s); err != nil {
+		return nil, nil, fmt.Errorf("msproto: bind %s on %s:%d: %w", s.UUID.ToFormatD(), b.Host, port, err)
+	}
+	return rpc, rpc.Close, nil
+}
+
+// resolvePort asks the endpoint mapper on TCP/135 for the dynamic port the given syntax is
+// bound to, returning the first endpoint that carries a TCP port.
+func (b *TCPBinder) resolvePort(s syntax.SyntaxID) (int, error) {
+	tr := tcp.New(b.Host, tcp.EndpointMapperPort)
+	tr.SetTimeout(b.Timeout)
+	ept := dcerpcclient.NewClient(tr)
+	if err := ept.Bind(eptiface.SyntaxID()); err != nil {
+		return 0, fmt.Errorf("bind endpoint mapper: %w", err)
+	}
+	defer ept.Close()
+
+	eps, err := eptfunctions.Map(ept, s.UUID, s.MajorVersion, s.MinorVersion)
+	if err != nil {
+		return 0, fmt.Errorf("ept_map: %w", err)
+	}
+	for _, ep := range eps {
+		if ep.Port != 0 {
+			return int(ep.Port), nil
+		}
+	}
+	return 0, fmt.Errorf("endpoint mapper returned no TCP endpoint")
+}

--- a/network/dcerpc/ms-protocols/msproto/binder_test.go
+++ b/network/dcerpc/ms-protocols/msproto/binder_test.go
@@ -1,0 +1,78 @@
+package msproto
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/pdu"
+	dcerpctransport "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/transport"
+)
+
+// compile-time assertions that both binders satisfy the Binder contract.
+var (
+	_ Binder = (*PipeBinder)(nil)
+	_ Binder = (*TCPBinder)(nil)
+)
+
+// fakeDialer records the pipe it was asked to open and returns a canned result.
+type fakeDialer struct {
+	gotPipe string
+	tr      dcerpctransport.Transport
+	err     error
+}
+
+func (d *fakeDialer) RPCTransport(pipeName string) (dcerpctransport.Transport, error) {
+	d.gotPipe = pipeName
+	return d.tr, d.err
+}
+
+// TestPipeBinderDialError verifies that a dialer error is wrapped (not swallowed) and that
+// the binder asks for the exact pipe it was constructed with, before any bind is attempted.
+func TestPipeBinderDialError(t *testing.T) {
+	dialErr := errors.New("boom")
+	d := &fakeDialer{err: dialErr}
+	b := NewPipeBinder(d, `\srvsvc`)
+
+	rpc, closeFn, err := b.Bind(syntax.NDRTransferSyntax())
+	if err == nil {
+		t.Fatal("expected an error when the dialer fails")
+	}
+	if !errors.Is(err, dialErr) {
+		t.Errorf("error %q does not wrap the dialer error", err)
+	}
+	if rpc != nil || closeFn != nil {
+		t.Error("no client or closer should be returned on dial failure")
+	}
+	if d.gotPipe != `\srvsvc` {
+		t.Errorf("dialed pipe = %q, want %q", d.gotPipe, `\srvsvc`)
+	}
+}
+
+// TestNewTCPBinderDefaults verifies the constructor fills in NTLM packet-privacy auth and
+// the default timeout, and preserves an explicitly supplied timeout and port.
+func TestNewTCPBinderDefaults(t *testing.T) {
+	b := NewTCPBinder("dc.example", 0, nil, 0)
+	if b.AuthType != pdu.AuthTypeNTLMSSP {
+		t.Errorf("AuthType = 0x%02x, want NTLMSSP 0x%02x", b.AuthType, pdu.AuthTypeNTLMSSP)
+	}
+	if b.AuthLevel != pdu.AuthLevelPktPrivacy {
+		t.Errorf("AuthLevel = 0x%02x, want PktPrivacy 0x%02x", b.AuthLevel, pdu.AuthLevelPktPrivacy)
+	}
+	if b.Timeout != DefaultTCPTimeout {
+		t.Errorf("Timeout = %v, want default %v", b.Timeout, DefaultTCPTimeout)
+	}
+	if b.Port != 0 {
+		t.Errorf("Port = %d, want 0 (resolve via endpoint mapper)", b.Port)
+	}
+
+	custom := 25 * time.Second
+	b2 := NewTCPBinder("dc.example", 9389, nil, custom)
+	if b2.Timeout != custom {
+		t.Errorf("Timeout = %v, want %v", b2.Timeout, custom)
+	}
+	if b2.Port != 9389 {
+		t.Errorf("Port = %d, want 9389", b2.Port)
+	}
+}

--- a/network/dcerpc/ms-protocols/msproto/protocol.go
+++ b/network/dcerpc/ms-protocols/msproto/protocol.go
@@ -1,0 +1,65 @@
+// Package msproto holds the shared contracts and transport-binding helpers common to
+// every high-level MS-protocol client (ms-srvs, ms-rrp, ms-drsr, ...).
+//
+// An MS-protocol client is the workflow layer above a single DCE/RPC interface: it binds
+// that interface's abstract syntax over some transport and exposes friendly methods. The
+// clients differ on two orthogonal axes — where the transport comes from (a borrowed SMB
+// named pipe vs. an owned ncacn_ip_tcp connection) and how long a bound association lives
+// (a persistent bind reused across calls vs. a fresh bind per call). This package captures
+// only what is genuinely common across those axes:
+//
+//   - Protocol: every client reports the abstract syntax it speaks and can be Closed.
+//   - Session:  the subset of clients that hold a persistent bound association also expose
+//     Connect/IsConnected.
+//   - Binder:   the "open a transport and bind a syntax" step, with one implementation per
+//     transport provenance (PipeBinder over SMB, TCPBinder over ncacn_ip_tcp).
+//
+// It deliberately does NOT unify context-handle types (those are interface-specific) nor
+// the bind-per-call vs. persistent-bind policy (that stays each client's choice).
+//
+// This package depends only on the DCE/RPC transport, client, syntax, and credentials
+// layers; the MS-protocol packages depend on it, never the reverse.
+package msproto
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
+	dcerpctransport "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/transport"
+)
+
+// Protocol is the contract every MS-protocol client satisfies, regardless of transport
+// provenance or session model.
+type Protocol interface {
+	// Interface reports the DCE/RPC abstract syntax (UUID + version) this protocol speaks.
+	Interface() syntax.SyntaxID
+
+	// Close releases everything the client holds — server-side context handles and any
+	// owned transport. It follows io.Closer semantics: it is safe to call when nothing is
+	// held (e.g. a stateless client, or one that never connected) and returns nil then.
+	Close() error
+}
+
+// Session is implemented by the MS-protocol clients that hold a persistent bound
+// association for the lifetime of the client (their context handles chain across calls and
+// are scoped to that one association). Stateless clients that bind a fresh transport per
+// call satisfy Protocol but not Session.
+type Session interface {
+	Protocol
+
+	// Connect establishes the persistent association (resolving endpoints and binding the
+	// abstract syntax as the protocol requires). It is idempotent: calling it on an
+	// already-connected client is a no-op that returns nil.
+	Connect() error
+
+	// IsConnected reports whether Connect has succeeded and Close has not yet run.
+	IsConnected() bool
+}
+
+// PipeDialer opens a fresh DCE/RPC named-pipe transport for the given pipe over an
+// established, IPC$-tree-connected SMB session. It is the only capability the named-pipe
+// MS-protocols (ms-srvs, ms-rrp) need from the SMB layer, so depending on this interface
+// rather than a concrete SMB client keeps them independent of the SMB dialect:
+// network/smb/client.Client satisfies it (via its RPCTransport method) and routes to an
+// SMB1 or SMB2 named-pipe transport according to what was negotiated.
+type PipeDialer interface {
+	RPCTransport(pipeName string) (dcerpctransport.Transport, error)
+}


### PR DESCRIPTION
### Linked Issue
None — this is a structural refactor, not a bug fix; no behavioural change.

### Motivation
The three high-level MS-protocol clients (ms-srvs, ms-rrp, ms-drsr) had no shared contract and each reimplemented the same "open a transport, bind the abstract syntax" plumbing. ms-rrp and ms-srvs even defined byte-identical `PipeDialer` interfaces. There was no uniform way for tooling to ask a client which interface it speaks or to release it.

### What this does
Adds `network/dcerpc/ms-protocols/msproto`, a leaf package with:

**Contracts** (small and composable, not one monolith):
- `Protocol{ Interface() syntax.SyntaxID; Close() error }` — satisfied by every client.
- `Session{ Protocol; Connect() error; IsConnected() bool }` — only the clients that hold a persistent bound association.

The split is deliberate. `ms-srvs` is stateless — it binds a fresh `\srvsvc` pipe per workflow for fault isolation — so forcing `Connect`/`Close` on it would lie about a session it doesn't have. It satisfies `Protocol` only; `ms-rrp` and `ms-drsr` satisfy `Session`.

**Transport binders** (the one step all three shared):
- `Binder{ Bind(syntax.SyntaxID) (*client.Client, func() error, error) }`.
- `PipeBinder` over a borrowed SMB named pipe (no DCE/RPC-layer auth — inherits the SMB session context).
- `TCPBinder` over an owned ncacn_ip_tcp connection: endpoint-mapper resolution + NTLM packet-privacy, generalized from the drsuapi-specific code.

**Wiring** — all three clients now go through it:
- `ms-srvs`: `bind()` delegates to a `PipeBinder`; adds `Interface()`/`Close()`; `PipeDialer` is now an alias of `msproto.PipeDialer`.
- `ms-rrp`: `Connect()` uses a `PipeBinder`; adds `Interface()`; `PipeDialer` aliased.
- `ms-drsr`: `Connect()` uses a `TCPBinder` (endpoint resolution + auth + bind moved out, leaving only the `IDL_DRSBind` capability handshake); adds `Interface()`/`IsConnected()`.

Compile-time assertions (`var _ msproto.Session = (*Client)(nil)`, etc.) pin each client to its contract.

### Non-goals
Context-handle types (`DRS_HANDLE` vs `RPC_HKEY`) and the per-call-vs-persistent bind policy are intentionally NOT unified — they are genuinely interface-specific.

### How Verified
- `go build ./...`, `go vet ./network/dcerpc/ms-protocols/...` including `-tags integration` — clean.
- New `msproto` unit tests: `TestPipeBinderDialError` (dialer error is wrapped, exact pipe requested before bind), `TestNewTCPBinderDefaults` (NTLM pkt-privacy + default/explicit timeout + port). Compile-time `Binder`/`Protocol`/`Session` assertions.
- Full `./network/dcerpc/...` suite green; each protocol's existing tests pass unchanged.

### Test Coverage
**Added:** `network/dcerpc/ms-protocols/msproto/binder_test.go` (`TestPipeBinderDialError`, `TestNewTCPBinderDefaults`) + compile-time interface assertions in `binder_test.go` and in each client.

### Scope of Change
- **Files changed:** new `msproto/{protocol.go,binder.go,binder_test.go}`; `ms-srvs/client.go`, `ms-rrp/client.go`, `ms-drsr/client.go`.
- **Submodule pointer updated:** no.
- **Behavioural changes outside the refactor:** none — same wire behaviour; the binders contain the exact dial/auth/bind logic the clients had inline.

### Risk and Rollout
Low blast radius: confined to the ms-protocols layer; the moved logic is byte-for-byte the prior behaviour, the public constructors (`New`) are unchanged, and `PipeDialer` stays source-compatible via type aliases. Safe to merge without staged rollout.
