### PR TITLE
Add offline REGF hive parser (windows/registry/regf) (#702)

### DIFF
--- a/windows/registry/regf/base_block.go
+++ b/windows/registry/regf/base_block.go
@@ -1,0 +1,128 @@
+// Package regf implements a read-only parser for Windows registry hive files in the
+// REGF binary format. It supports offline parsing of SAM, SYSTEM, SECURITY, and other
+// hive files for credential extraction and forensic analysis.
+//
+// References:
+//   - https://github.com/msuhanov/regf/blob/master/Windows%20registry%20file%20format%20specification.md
+//   - https://github.com/libyal/libregf/blob/main/documentation/Windows%20NT%20Registry%20File%20(REGF)%20format.asciidoc
+//   - https://projectzero.google/2024/12/the-windows-registry-adventure-5-regf.html
+package regf
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+const (
+	regfSignature = 0x66676572 // "regf" in little-endian
+	baseBlockSize = 4096
+)
+
+// BaseBlock is the 4096-byte file header of a REGF hive file.
+//
+// Source: https://github.com/msuhanov/regf/blob/master/Windows%20registry%20file%20format%20specification.md#base-block
+type BaseBlock struct {
+	// Signature (4 bytes): must be ASCII "regf" (0x66676572 little-endian).
+	Signature uint32
+
+	// PrimarySequenceNumber (4 bytes): incremented at the start of a write operation.
+	PrimarySequenceNumber uint32
+
+	// SecondarySequenceNumber (4 bytes): incremented at the end of a write operation.
+	SecondarySequenceNumber uint32
+
+	// LastWrittenTimestamp (8 bytes): FILETIME (UTC).
+	LastWrittenTimestamp uint64
+
+	// MajorVersion (4 bytes): always 1.
+	MajorVersion uint32
+
+	// MinorVersion (4 bytes): 3, 4, 5, or 6.
+	MinorVersion uint32
+
+	// FileType (4 bytes): 0 = primary file.
+	FileType uint32
+
+	// FileFormat (4 bytes): 1 = direct memory load.
+	FileFormat uint32
+
+	// RootCellOffset (4 bytes): offset of the root key node cell, relative from start of
+	// hive bins data.
+	RootCellOffset uint32
+
+	// HiveBinsDataSize (4 bytes): total size of all hive bins data in bytes.
+	HiveBinsDataSize uint32
+
+	// ClusteringFactor (4 bytes): disk sector size / 512.
+	ClusteringFactor uint32
+
+	// FileName (64 bytes): UTF-16LE string, partial path of primary file.
+	FileName [64]byte
+
+	// Checksum (4 bytes): XOR-32 of first 508 bytes.
+	Checksum uint32
+}
+
+// NewBaseBlock creates a new empty BaseBlock.
+func NewBaseBlock() *BaseBlock {
+	return &BaseBlock{}
+}
+
+// Unmarshal deserializes a BaseBlock from binary data.
+//
+// Parameters:
+//   - data ([]byte): at least 4096 bytes of raw hive file header.
+//
+// Returns:
+//   - The number of bytes consumed.
+//   - An error if the data is too short or the signature is invalid.
+func (b *BaseBlock) Unmarshal(data []byte) (int, error) {
+	if len(data) < baseBlockSize {
+		return 0, fmt.Errorf("data too short for BaseBlock: need %d bytes, got %d", baseBlockSize, len(data))
+	}
+
+	b.Signature = binary.LittleEndian.Uint32(data[0:4])
+	if b.Signature != regfSignature {
+		return 0, fmt.Errorf("invalid BaseBlock Signature: 0x%08X (expected 0x%08X)", b.Signature, regfSignature)
+	}
+
+	b.PrimarySequenceNumber = binary.LittleEndian.Uint32(data[4:8])
+	b.SecondarySequenceNumber = binary.LittleEndian.Uint32(data[8:12])
+	b.LastWrittenTimestamp = binary.LittleEndian.Uint64(data[12:20])
+	b.MajorVersion = binary.LittleEndian.Uint32(data[20:24])
+	b.MinorVersion = binary.LittleEndian.Uint32(data[24:28])
+	b.FileType = binary.LittleEndian.Uint32(data[28:32])
+	b.FileFormat = binary.LittleEndian.Uint32(data[32:36])
+	b.RootCellOffset = binary.LittleEndian.Uint32(data[36:40])
+	b.HiveBinsDataSize = binary.LittleEndian.Uint32(data[40:44])
+	b.ClusteringFactor = binary.LittleEndian.Uint32(data[44:48])
+	copy(b.FileName[:], data[48:112])
+	b.Checksum = binary.LittleEndian.Uint32(data[508:512])
+
+	return baseBlockSize, nil
+}
+
+// Marshal serializes the BaseBlock to binary data.
+//
+// Returns:
+//   - A byte slice of exactly 4096 bytes.
+//   - An error if serialization fails.
+func (b *BaseBlock) Marshal() ([]byte, error) {
+	buf := make([]byte, baseBlockSize)
+
+	binary.LittleEndian.PutUint32(buf[0:4], b.Signature)
+	binary.LittleEndian.PutUint32(buf[4:8], b.PrimarySequenceNumber)
+	binary.LittleEndian.PutUint32(buf[8:12], b.SecondarySequenceNumber)
+	binary.LittleEndian.PutUint64(buf[12:20], b.LastWrittenTimestamp)
+	binary.LittleEndian.PutUint32(buf[20:24], b.MajorVersion)
+	binary.LittleEndian.PutUint32(buf[24:28], b.MinorVersion)
+	binary.LittleEndian.PutUint32(buf[28:32], b.FileType)
+	binary.LittleEndian.PutUint32(buf[32:36], b.FileFormat)
+	binary.LittleEndian.PutUint32(buf[36:40], b.RootCellOffset)
+	binary.LittleEndian.PutUint32(buf[40:44], b.HiveBinsDataSize)
+	binary.LittleEndian.PutUint32(buf[44:48], b.ClusteringFactor)
+	copy(buf[48:112], b.FileName[:])
+	binary.LittleEndian.PutUint32(buf[508:512], b.Checksum)
+
+	return buf, nil
+}

--- a/windows/registry/regf/hive.go
+++ b/windows/registry/regf/hive.go
@@ -1,0 +1,343 @@
+package regf
+
+import (
+	"encoding/binary"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// Hive represents an opened offline Windows registry hive file. The zero value is not
+// usable; create one with Open or OpenBytes.
+type Hive struct {
+	data      []byte
+	baseBlock BaseBlock
+}
+
+// Open opens and parses a registry hive file from disk.
+//
+// Parameters:
+//   - path (string): filesystem path to the hive file.
+//
+// Returns:
+//   - A parsed Hive ready for queries.
+//   - An error if the file cannot be read or has an invalid format.
+func Open(path string) (*Hive, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("regf: open %s: %w", path, err)
+	}
+	return OpenBytes(data)
+}
+
+// OpenBytes parses a registry hive from an in-memory byte slice.
+//
+// Parameters:
+//   - data ([]byte): raw hive file content.
+//
+// Returns:
+//   - A parsed Hive ready for queries.
+//   - An error if the data has an invalid format.
+func OpenBytes(data []byte) (*Hive, error) {
+	h := &Hive{data: data}
+
+	if _, err := h.baseBlock.Unmarshal(data); err != nil {
+		return nil, fmt.Errorf("regf: %w", err)
+	}
+
+	return h, nil
+}
+
+// Close releases the hive data. The Hive is not usable after Close.
+func (h *Hive) Close() error {
+	h.data = nil
+	return nil
+}
+
+// BaseBlock returns the parsed file header.
+func (h *Hive) BaseBlock() *BaseBlock {
+	return &h.baseBlock
+}
+
+// RootKey returns the root KeyNode of the hive.
+//
+// Returns:
+//   - The root KeyNode.
+//   - An error if the root cell cannot be read.
+func (h *Hive) RootKey() (*KeyNode, error) {
+	return h.readKeyNode(h.baseBlock.RootCellOffset)
+}
+
+// FindKey locates a registry key by path relative to the root key.
+// Path components are separated by backslashes. A leading backslash is optional.
+//
+// Parameters:
+//   - path (string): key path, e.g. "SAM\\Domains\\Account" or "ControlSet001\\Control\\Lsa\\JD".
+//
+// Returns:
+//   - The KeyNode at the given path.
+//   - An error if any component is not found.
+func (h *Hive) FindKey(path string) (*KeyNode, error) {
+	path = strings.TrimPrefix(path, "\\")
+	root, err := h.RootKey()
+	if err != nil {
+		return nil, err
+	}
+
+	if path == "" {
+		return root, nil
+	}
+
+	current := root
+	for _, part := range strings.Split(path, "\\") {
+		subkeys, err := current.SubKeys()
+		if err != nil {
+			return nil, fmt.Errorf("regf: enumerating subkeys of %q: %w", current.Name(), err)
+		}
+		found := false
+		for _, sk := range subkeys {
+			if strings.EqualFold(sk.Name(), part) {
+				current = sk
+				found = true
+				break
+			}
+		}
+		if !found {
+			return nil, fmt.Errorf("regf: key %q not found under %q", part, current.Name())
+		}
+	}
+
+	return current, nil
+}
+
+// EnumKey returns the names of all subkeys under the given path.
+//
+// Parameters:
+//   - path (string): key path relative to the root key.
+//
+// Returns:
+//   - A slice of subkey names.
+//   - An error if the key is not found.
+func (h *Hive) EnumKey(path string) ([]string, error) {
+	nk, err := h.FindKey(path)
+	if err != nil {
+		return nil, err
+	}
+	subkeys, err := nk.SubKeys()
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, len(subkeys))
+	for i, sk := range subkeys {
+		names[i] = sk.Name()
+	}
+	return names, nil
+}
+
+// EnumValues returns all value names under the given key path.
+//
+// Parameters:
+//   - path (string): key path relative to the root key.
+//
+// Returns:
+//   - A slice of value names (empty string for the default value).
+//   - An error if the key is not found.
+func (h *Hive) EnumValues(path string) ([]string, error) {
+	nk, err := h.FindKey(path)
+	if err != nil {
+		return nil, err
+	}
+	values, err := nk.Values()
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, len(values))
+	for i, v := range values {
+		names[i] = v.Name()
+	}
+	return names, nil
+}
+
+// GetValue reads a named value from the key at the given path.
+//
+// Parameters:
+//   - keyPath (string): key path relative to the root key.
+//   - valueName (string): value name; empty string for the default value.
+//
+// Returns:
+//   - The data type (REG_* constant).
+//   - The raw value data bytes.
+//   - An error if the key or value is not found.
+func (h *Hive) GetValue(keyPath, valueName string) (uint32, []byte, error) {
+	nk, err := h.FindKey(keyPath)
+	if err != nil {
+		return 0, nil, err
+	}
+	v, err := nk.Value(valueName)
+	if err != nil {
+		return 0, nil, fmt.Errorf("regf: key %q: %w", keyPath, err)
+	}
+	data, err := v.Data()
+	if err != nil {
+		return 0, nil, fmt.Errorf("regf: key %q value %q: %w", keyPath, valueName, err)
+	}
+	return v.DataType, data, nil
+}
+
+// GetClass reads the class data for the key at the given path.
+//
+// Parameters:
+//   - keyPath (string): key path relative to the root key.
+//
+// Returns:
+//   - The raw class data bytes.
+//   - An error if the key is not found or has no class data.
+func (h *Hive) GetClass(keyPath string) ([]byte, error) {
+	nk, err := h.FindKey(keyPath)
+	if err != nil {
+		return nil, err
+	}
+	data, err := nk.ClassData()
+	if err != nil {
+		return nil, fmt.Errorf("regf: key %q: %w", keyPath, err)
+	}
+	if data == nil {
+		return nil, fmt.Errorf("regf: key %q has no class data", keyPath)
+	}
+	return data, nil
+}
+
+// readCellRaw reads a raw cell at the given offset, returning the cell data after
+// the 4-byte size prefix. The offset is relative to the start of hive bins data.
+func (h *Hive) readCellRaw(offset uint32) ([]byte, error) {
+	absOffset := baseBlockSize + int(offset)
+	if absOffset+4 > len(h.data) {
+		return nil, fmt.Errorf("regf: cell offset 0x%X out of bounds (file size: %d)", offset, len(h.data))
+	}
+
+	cellSize := int32(binary.LittleEndian.Uint32(h.data[absOffset : absOffset+4]))
+	if cellSize < 0 {
+		cellSize = -cellSize
+	}
+	if cellSize < 4 {
+		return nil, fmt.Errorf("regf: invalid cell size %d at offset 0x%X", cellSize, offset)
+	}
+	end := absOffset + int(cellSize)
+	if end > len(h.data) {
+		end = len(h.data)
+	}
+
+	return h.data[absOffset+4 : end], nil
+}
+
+// readCellData reads raw data from a cell, skipping the 4-byte size prefix and returning
+// exactly 'size' bytes.
+func (h *Hive) readCellData(offset uint32, size int) ([]byte, error) {
+	absOffset := baseBlockSize + int(offset) + 4 // skip cell size prefix
+	if absOffset+size > len(h.data) {
+		return nil, fmt.Errorf("regf: data read at offset 0x%X+%d exceeds file bounds", offset, size)
+	}
+	result := make([]byte, size)
+	copy(result, h.data[absOffset:absOffset+size])
+	return result, nil
+}
+
+// readKeyNode reads and parses a KeyNode at the given cell offset.
+func (h *Hive) readKeyNode(offset uint32) (*KeyNode, error) {
+	cell, err := h.readCellRaw(offset)
+	if err != nil {
+		return nil, fmt.Errorf("regf: reading key node at 0x%X: %w", offset, err)
+	}
+
+	nk := NewKeyNode()
+	if _, err := nk.Unmarshal(cell); err != nil {
+		return nil, fmt.Errorf("regf: parsing key node at 0x%X: %w", offset, err)
+	}
+	nk.hive = h
+	nk.offset = offset
+	return nk, nil
+}
+
+// readValueList reads and parses a list of KeyValue records.
+func (h *Hive) readValueList(offset, count uint32) ([]*KeyValue, error) {
+	cell, err := h.readCellRaw(offset)
+	if err != nil {
+		return nil, fmt.Errorf("regf: reading value list at 0x%X: %w", offset, err)
+	}
+
+	values := make([]*KeyValue, 0, count)
+	for i := uint32(0); i < count; i++ {
+		off := int(i) * 4
+		if off+4 > len(cell) {
+			break
+		}
+		vkOffset := binary.LittleEndian.Uint32(cell[off : off+4])
+		vk, err := h.readKeyValue(vkOffset)
+		if err != nil {
+			continue
+		}
+		values = append(values, vk)
+	}
+	return values, nil
+}
+
+// readKeyValue reads and parses a KeyValue at the given cell offset.
+func (h *Hive) readKeyValue(offset uint32) (*KeyValue, error) {
+	cell, err := h.readCellRaw(offset)
+	if err != nil {
+		return nil, fmt.Errorf("regf: reading key value at 0x%X: %w", offset, err)
+	}
+
+	vk := NewKeyValue()
+	if _, err := vk.Unmarshal(cell); err != nil {
+		return nil, fmt.Errorf("regf: parsing key value at 0x%X: %w", offset, err)
+	}
+	vk.hive = h
+	return vk, nil
+}
+
+// enumSubKeys collects all subkey KeyNode records from a subkeys list offset.
+func (h *Hive) enumSubKeys(offset uint32) ([]*KeyNode, error) {
+	offsets, err := h.collectKeyNodeOffsets(offset)
+	if err != nil {
+		return nil, err
+	}
+
+	subkeys := make([]*KeyNode, 0, len(offsets))
+	for _, off := range offsets {
+		nk, err := h.readKeyNode(off)
+		if err != nil {
+			continue
+		}
+		subkeys = append(subkeys, nk)
+	}
+	return subkeys, nil
+}
+
+// collectKeyNodeOffsets reads a subkey list and recursively resolves RI blocks.
+func (h *Hive) collectKeyNodeOffsets(offset uint32) ([]uint32, error) {
+	cell, err := h.readCellRaw(offset)
+	if err != nil {
+		return nil, fmt.Errorf("regf: reading subkey list at 0x%X: %w", offset, err)
+	}
+
+	list := NewSubKeyList()
+	if _, err := list.Unmarshal(cell); err != nil {
+		return nil, fmt.Errorf("regf: parsing subkey list at 0x%X: %w", offset, err)
+	}
+
+	if !list.IsIndexRoot() {
+		return list.KeyNodeOffsets(), nil
+	}
+
+	// RI: each element points to another subkey list (LF/LH/LI)
+	var allOffsets []uint32
+	for _, subListOffset := range list.KeyNodeOffsets() {
+		subOffsets, err := h.collectKeyNodeOffsets(subListOffset)
+		if err != nil {
+			continue
+		}
+		allOffsets = append(allOffsets, subOffsets...)
+	}
+	return allOffsets, nil
+}

--- a/windows/registry/regf/hive_bin.go
+++ b/windows/registry/regf/hive_bin.go
@@ -1,0 +1,85 @@
+package regf
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+const (
+	hbinSignature  = 0x6E696268 // "hbin" in little-endian
+	hbinHeaderSize = 32
+)
+
+// HiveBin is the 32-byte header of a hive bin block. Each hive bin contains cells
+// and is a multiple of 4096 bytes in size.
+//
+// Source: https://github.com/msuhanov/regf/blob/master/Windows%20registry%20file%20format%20specification.md#hive-bin
+type HiveBin struct {
+	// Signature (4 bytes): must be ASCII "hbin" (0x6E696268 little-endian).
+	Signature uint32
+
+	// Offset (4 bytes): offset of this hive bin from start of hive bins data.
+	Offset uint32
+
+	// Size (4 bytes): total size of this hive bin including header, multiple of 4096.
+	Size uint32
+
+	// Reserved (8 bytes): unused.
+	Reserved uint64
+
+	// Timestamp (8 bytes): FILETIME (UTC); only meaningful for the first hive bin.
+	Timestamp uint64
+
+	// Spare (4 bytes): memory allocation field, no disk meaning.
+	Spare uint32
+}
+
+// NewHiveBin creates a new empty HiveBin.
+func NewHiveBin() *HiveBin {
+	return &HiveBin{}
+}
+
+// Unmarshal deserializes a HiveBin header from binary data.
+//
+// Parameters:
+//   - data ([]byte): at least 32 bytes of raw hive bin header.
+//
+// Returns:
+//   - The number of bytes consumed (always 32).
+//   - An error if the data is too short or the signature is invalid.
+func (h *HiveBin) Unmarshal(data []byte) (int, error) {
+	if len(data) < hbinHeaderSize {
+		return 0, fmt.Errorf("data too short for HiveBin: need %d bytes, got %d", hbinHeaderSize, len(data))
+	}
+
+	h.Signature = binary.LittleEndian.Uint32(data[0:4])
+	if h.Signature != hbinSignature {
+		return 0, fmt.Errorf("invalid HiveBin Signature: 0x%08X (expected 0x%08X)", h.Signature, hbinSignature)
+	}
+
+	h.Offset = binary.LittleEndian.Uint32(data[4:8])
+	h.Size = binary.LittleEndian.Uint32(data[8:12])
+	h.Reserved = binary.LittleEndian.Uint64(data[12:20])
+	h.Timestamp = binary.LittleEndian.Uint64(data[20:28])
+	h.Spare = binary.LittleEndian.Uint32(data[28:32])
+
+	return hbinHeaderSize, nil
+}
+
+// Marshal serializes the HiveBin header to binary data.
+//
+// Returns:
+//   - A byte slice of exactly 32 bytes.
+//   - An error if serialization fails.
+func (h *HiveBin) Marshal() ([]byte, error) {
+	buf := make([]byte, hbinHeaderSize)
+
+	binary.LittleEndian.PutUint32(buf[0:4], h.Signature)
+	binary.LittleEndian.PutUint32(buf[4:8], h.Offset)
+	binary.LittleEndian.PutUint32(buf[8:12], h.Size)
+	binary.LittleEndian.PutUint64(buf[12:20], h.Reserved)
+	binary.LittleEndian.PutUint64(buf[20:28], h.Timestamp)
+	binary.LittleEndian.PutUint32(buf[28:32], h.Spare)
+
+	return buf, nil
+}

--- a/windows/registry/regf/key_node.go
+++ b/windows/registry/regf/key_node.go
@@ -1,0 +1,264 @@
+package regf
+
+import (
+	"encoding/binary"
+	"fmt"
+	"strings"
+	"unicode/utf16"
+)
+
+const (
+	nkSignature     = 0x6B6E // "nk" in little-endian
+	keyNodeMinSize  = 76
+	nullCellOffset  = 0xFFFFFFFF
+)
+
+// Key node flags.
+//
+// Source: https://github.com/msuhanov/regf/blob/master/Windows%20registry%20file%20format%20specification.md#key-node
+const (
+	KeyVolatile   uint16 = 0x0001
+	KeyHiveExit   uint16 = 0x0002
+	KeyHiveEntry  uint16 = 0x0004
+	KeyNoDelete   uint16 = 0x0008
+	KeySymLink    uint16 = 0x0010
+	KeyCompName   uint16 = 0x0020
+	KeyPredefHndl uint16 = 0x0040
+)
+
+// KeyNode is a parsed NK (key node) record representing a registry key.
+//
+// Source: https://github.com/msuhanov/regf/blob/master/Windows%20registry%20file%20format%20specification.md#key-node
+type KeyNode struct {
+	// Signature (2 bytes): must be ASCII "nk" (0x6B6E little-endian).
+	Signature uint16
+
+	// Flags (2 bytes): bit mask of key flags.
+	Flags uint16
+
+	// LastWrittenTimestamp (8 bytes): FILETIME (UTC).
+	LastWrittenTimestamp uint64
+
+	// AccessBits (4 bytes): access tracking (Win10 RS1+); otherwise spare.
+	AccessBits uint32
+
+	// Parent (4 bytes): offset to parent key node.
+	Parent uint32
+
+	// NumberOfSubKeys (4 bytes): count of stable (non-volatile) subkeys.
+	NumberOfSubKeys uint32
+
+	// NumberOfVolatileSubKeys (4 bytes): count of volatile subkeys (no disk meaning).
+	NumberOfVolatileSubKeys uint32
+
+	// SubKeysListOffset (4 bytes): offset to subkey list (lf/lh/li/ri), or 0xFFFFFFFF.
+	SubKeysListOffset uint32
+
+	// VolatileSubKeysListOffset (4 bytes): no disk meaning.
+	VolatileSubKeysListOffset uint32
+
+	// NumberOfValues (4 bytes): count of values under this key.
+	NumberOfValues uint32
+
+	// ValuesListOffset (4 bytes): offset to values list, or 0xFFFFFFFF.
+	ValuesListOffset uint32
+
+	// SecurityOffset (4 bytes): offset to sk record.
+	SecurityOffset uint32
+
+	// ClassNameOffset (4 bytes): offset to cell containing class name data, or 0xFFFFFFFF.
+	ClassNameOffset uint32
+
+	// MaxSubKeyNameLength (4 bytes): largest subkey name length (with user/debug flags).
+	MaxSubKeyNameLength uint32
+
+	// MaxSubKeyClassNameLength (4 bytes): largest subkey class name length.
+	MaxSubKeyClassNameLength uint32
+
+	// MaxValueNameLength (4 bytes): largest value name length.
+	MaxValueNameLength uint32
+
+	// MaxValueDataSize (4 bytes): largest value data size.
+	MaxValueDataSize uint32
+
+	// WorkVar (4 bytes): cached subkey index (Win2000 only).
+	WorkVar uint32
+
+	// KeyNameLength (2 bytes): length of key name in bytes.
+	KeyNameLength uint16
+
+	// ClassNameLength (2 bytes): length of class name in bytes.
+	ClassNameLength uint16
+
+	// KeyNameRaw (variable): raw key name bytes.
+	KeyNameRaw []byte
+
+	// hive back-reference for navigation methods.
+	hive   *Hive
+	offset uint32
+}
+
+// NewKeyNode creates a new empty KeyNode.
+func NewKeyNode() *KeyNode {
+	return &KeyNode{}
+}
+
+// Unmarshal deserializes a KeyNode from cell data (after the 4-byte cell size prefix).
+//
+// Parameters:
+//   - data ([]byte): cell data starting with the "nk" signature.
+//
+// Returns:
+//   - The number of bytes consumed.
+//   - An error if the data is too short or the signature is invalid.
+func (k *KeyNode) Unmarshal(data []byte) (int, error) {
+	if len(data) < keyNodeMinSize {
+		return 0, fmt.Errorf("data too short for KeyNode: need %d bytes, got %d", keyNodeMinSize, len(data))
+	}
+
+	k.Signature = binary.LittleEndian.Uint16(data[0:2])
+	if k.Signature != nkSignature {
+		return 0, fmt.Errorf("invalid KeyNode Signature: 0x%04X (expected 0x%04X)", k.Signature, nkSignature)
+	}
+
+	k.Flags = binary.LittleEndian.Uint16(data[2:4])
+	k.LastWrittenTimestamp = binary.LittleEndian.Uint64(data[4:12])
+	k.AccessBits = binary.LittleEndian.Uint32(data[12:16])
+	k.Parent = binary.LittleEndian.Uint32(data[16:20])
+	k.NumberOfSubKeys = binary.LittleEndian.Uint32(data[20:24])
+	k.NumberOfVolatileSubKeys = binary.LittleEndian.Uint32(data[24:28])
+	k.SubKeysListOffset = binary.LittleEndian.Uint32(data[28:32])
+	k.VolatileSubKeysListOffset = binary.LittleEndian.Uint32(data[32:36])
+	k.NumberOfValues = binary.LittleEndian.Uint32(data[36:40])
+	k.ValuesListOffset = binary.LittleEndian.Uint32(data[40:44])
+	k.SecurityOffset = binary.LittleEndian.Uint32(data[44:48])
+	k.ClassNameOffset = binary.LittleEndian.Uint32(data[48:52])
+	k.MaxSubKeyNameLength = binary.LittleEndian.Uint32(data[52:56])
+	k.MaxSubKeyClassNameLength = binary.LittleEndian.Uint32(data[56:60])
+	k.MaxValueNameLength = binary.LittleEndian.Uint32(data[60:64])
+	k.MaxValueDataSize = binary.LittleEndian.Uint32(data[64:68])
+	k.WorkVar = binary.LittleEndian.Uint32(data[68:72])
+	k.KeyNameLength = binary.LittleEndian.Uint16(data[72:74])
+	k.ClassNameLength = binary.LittleEndian.Uint16(data[74:76])
+
+	nameEnd := keyNodeMinSize + int(k.KeyNameLength)
+	if nameEnd > len(data) {
+		nameEnd = len(data)
+	}
+	k.KeyNameRaw = make([]byte, nameEnd-keyNodeMinSize)
+	copy(k.KeyNameRaw, data[keyNodeMinSize:nameEnd])
+
+	return nameEnd, nil
+}
+
+// Marshal serializes the KeyNode to binary data.
+//
+// Returns:
+//   - A byte slice containing the serialized KeyNode.
+//   - An error if serialization fails.
+func (k *KeyNode) Marshal() ([]byte, error) {
+	size := keyNodeMinSize + len(k.KeyNameRaw)
+	buf := make([]byte, size)
+
+	binary.LittleEndian.PutUint16(buf[0:2], k.Signature)
+	binary.LittleEndian.PutUint16(buf[2:4], k.Flags)
+	binary.LittleEndian.PutUint64(buf[4:12], k.LastWrittenTimestamp)
+	binary.LittleEndian.PutUint32(buf[12:16], k.AccessBits)
+	binary.LittleEndian.PutUint32(buf[16:20], k.Parent)
+	binary.LittleEndian.PutUint32(buf[20:24], k.NumberOfSubKeys)
+	binary.LittleEndian.PutUint32(buf[24:28], k.NumberOfVolatileSubKeys)
+	binary.LittleEndian.PutUint32(buf[28:32], k.SubKeysListOffset)
+	binary.LittleEndian.PutUint32(buf[32:36], k.VolatileSubKeysListOffset)
+	binary.LittleEndian.PutUint32(buf[36:40], k.NumberOfValues)
+	binary.LittleEndian.PutUint32(buf[40:44], k.ValuesListOffset)
+	binary.LittleEndian.PutUint32(buf[44:48], k.SecurityOffset)
+	binary.LittleEndian.PutUint32(buf[48:52], k.ClassNameOffset)
+	binary.LittleEndian.PutUint32(buf[52:56], k.MaxSubKeyNameLength)
+	binary.LittleEndian.PutUint32(buf[56:60], k.MaxSubKeyClassNameLength)
+	binary.LittleEndian.PutUint32(buf[60:64], k.MaxValueNameLength)
+	binary.LittleEndian.PutUint32(buf[64:68], k.MaxValueDataSize)
+	binary.LittleEndian.PutUint32(buf[68:72], k.WorkVar)
+	binary.LittleEndian.PutUint16(buf[72:74], k.KeyNameLength)
+	binary.LittleEndian.PutUint16(buf[74:76], k.ClassNameLength)
+	copy(buf[keyNodeMinSize:], k.KeyNameRaw)
+
+	return buf, nil
+}
+
+// Name returns the decoded key name as a Go string.
+func (k *KeyNode) Name() string {
+	if k.Flags&KeyCompName != 0 {
+		return string(k.KeyNameRaw)
+	}
+	return decodeUTF16LE(k.KeyNameRaw)
+}
+
+// IsRoot reports whether this key is a root key (KEY_HIVE_ENTRY flag set).
+func (k *KeyNode) IsRoot() bool {
+	return k.Flags&KeyHiveEntry != 0
+}
+
+// SubKeys returns all subkey KeyNodes under this key.
+func (k *KeyNode) SubKeys() ([]*KeyNode, error) {
+	if k.hive == nil {
+		return nil, fmt.Errorf("KeyNode not attached to a hive")
+	}
+	if k.NumberOfSubKeys == 0 || k.SubKeysListOffset == nullCellOffset {
+		return nil, nil
+	}
+	return k.hive.enumSubKeys(k.SubKeysListOffset)
+}
+
+// Values returns all KeyValue records under this key.
+func (k *KeyNode) Values() ([]*KeyValue, error) {
+	if k.hive == nil {
+		return nil, fmt.Errorf("KeyNode not attached to a hive")
+	}
+	if k.NumberOfValues == 0 || k.ValuesListOffset == nullCellOffset {
+		return nil, nil
+	}
+	return k.hive.readValueList(k.ValuesListOffset, k.NumberOfValues)
+}
+
+// Value returns the named value under this key, or an error if not found.
+func (k *KeyNode) Value(name string) (*KeyValue, error) {
+	values, err := k.Values()
+	if err != nil {
+		return nil, err
+	}
+	for _, v := range values {
+		if strings.EqualFold(v.Name(), name) {
+			return v, nil
+		}
+		if name == "" && v.NameLength == 0 {
+			return v, nil
+		}
+	}
+	return nil, fmt.Errorf("value %q not found", name)
+}
+
+// ClassData returns the class data bytes for this key, or nil if not set.
+func (k *KeyNode) ClassData() ([]byte, error) {
+	if k.hive == nil {
+		return nil, fmt.Errorf("KeyNode not attached to a hive")
+	}
+	if k.ClassNameOffset == nullCellOffset || k.ClassNameLength == 0 {
+		return nil, nil
+	}
+	return k.hive.readCellData(k.ClassNameOffset, int(k.ClassNameLength))
+}
+
+// decodeUTF16LE decodes UTF-16LE bytes to a Go string, dropping trailing NULs.
+func decodeUTF16LE(data []byte) string {
+	if len(data) < 2 {
+		return string(data)
+	}
+	units := make([]uint16, 0, len(data)/2)
+	for i := 0; i+1 < len(data); i += 2 {
+		units = append(units, binary.LittleEndian.Uint16(data[i:i+2]))
+	}
+	for len(units) > 0 && units[len(units)-1] == 0 {
+		units = units[:len(units)-1]
+	}
+	return string(utf16.Decode(units))
+}

--- a/windows/registry/regf/key_value.go
+++ b/windows/registry/regf/key_value.go
@@ -1,0 +1,203 @@
+package regf
+
+import (
+	"encoding/binary"
+	"fmt"
+	"strings"
+)
+
+const (
+	vkSignature     = 0x6B76 // "vk" in little-endian
+	keyValueMinSize = 20
+)
+
+// Value data types.
+//
+// Source: https://github.com/msuhanov/regf/blob/master/Windows%20registry%20file%20format%20specification.md#key-value
+const (
+	RegNone                     uint32 = 0x00000000
+	RegSz                       uint32 = 0x00000001
+	RegExpandSz                 uint32 = 0x00000002
+	RegBinary                   uint32 = 0x00000003
+	RegDword                    uint32 = 0x00000004
+	RegDwordBigEndian           uint32 = 0x00000005
+	RegLink                     uint32 = 0x00000006
+	RegMultiSz                  uint32 = 0x00000007
+	RegResourceList             uint32 = 0x00000008
+	RegFullResourceDescriptor   uint32 = 0x00000009
+	RegResourceRequirementsList uint32 = 0x0000000A
+	RegQword                    uint32 = 0x0000000B
+)
+
+// Value flags.
+const (
+	ValueCompName uint16 = 0x0001
+)
+
+// KeyValue is a parsed VK (value key) record representing a registry value.
+//
+// Source: https://github.com/msuhanov/regf/blob/master/Windows%20registry%20file%20format%20specification.md#key-value
+type KeyValue struct {
+	// Signature (2 bytes): must be ASCII "vk" (0x6B76 little-endian).
+	Signature uint16
+
+	// NameLength (2 bytes): length of value name in bytes; 0 = default (unnamed) value.
+	NameLength uint16
+
+	// DataSize (4 bytes): data size. Bit 31 set means inline data.
+	DataSize uint32
+
+	// DataOffset (4 bytes): offset to data cell, or inline data when bit 31 of DataSize is set.
+	DataOffset uint32
+
+	// DataType (4 bytes): REG_* data type constant.
+	DataType uint32
+
+	// Flags (2 bytes): VALUE_COMP_NAME etc.
+	Flags uint16
+
+	// Spare (2 bytes): unused.
+	Spare uint16
+
+	// NameRaw (variable): raw value name bytes.
+	NameRaw []byte
+
+	// hive back-reference for data retrieval.
+	hive *Hive
+}
+
+// NewKeyValue creates a new empty KeyValue.
+func NewKeyValue() *KeyValue {
+	return &KeyValue{}
+}
+
+// Unmarshal deserializes a KeyValue from cell data.
+//
+// Parameters:
+//   - data ([]byte): cell data starting with the "vk" signature.
+//
+// Returns:
+//   - The number of bytes consumed.
+//   - An error if the data is too short or the signature is invalid.
+func (v *KeyValue) Unmarshal(data []byte) (int, error) {
+	if len(data) < keyValueMinSize {
+		return 0, fmt.Errorf("data too short for KeyValue: need %d bytes, got %d", keyValueMinSize, len(data))
+	}
+
+	v.Signature = binary.LittleEndian.Uint16(data[0:2])
+	if v.Signature != vkSignature {
+		return 0, fmt.Errorf("invalid KeyValue Signature: 0x%04X (expected 0x%04X)", v.Signature, vkSignature)
+	}
+
+	v.NameLength = binary.LittleEndian.Uint16(data[2:4])
+	v.DataSize = binary.LittleEndian.Uint32(data[4:8])
+	v.DataOffset = binary.LittleEndian.Uint32(data[8:12])
+	v.DataType = binary.LittleEndian.Uint32(data[12:16])
+	v.Flags = binary.LittleEndian.Uint16(data[16:18])
+	v.Spare = binary.LittleEndian.Uint16(data[18:20])
+
+	nameEnd := keyValueMinSize + int(v.NameLength)
+	if nameEnd > len(data) {
+		nameEnd = len(data)
+	}
+	if v.NameLength > 0 {
+		v.NameRaw = make([]byte, nameEnd-keyValueMinSize)
+		copy(v.NameRaw, data[keyValueMinSize:nameEnd])
+	}
+
+	return nameEnd, nil
+}
+
+// Marshal serializes the KeyValue to binary data.
+//
+// Returns:
+//   - A byte slice containing the serialized KeyValue.
+//   - An error if serialization fails.
+func (v *KeyValue) Marshal() ([]byte, error) {
+	size := keyValueMinSize + len(v.NameRaw)
+	buf := make([]byte, size)
+
+	binary.LittleEndian.PutUint16(buf[0:2], v.Signature)
+	binary.LittleEndian.PutUint16(buf[2:4], v.NameLength)
+	binary.LittleEndian.PutUint32(buf[4:8], v.DataSize)
+	binary.LittleEndian.PutUint32(buf[8:12], v.DataOffset)
+	binary.LittleEndian.PutUint32(buf[12:16], v.DataType)
+	binary.LittleEndian.PutUint16(buf[16:18], v.Flags)
+	binary.LittleEndian.PutUint16(buf[18:20], v.Spare)
+	copy(buf[keyValueMinSize:], v.NameRaw)
+
+	return buf, nil
+}
+
+// Name returns the decoded value name as a Go string. Returns "" for the default value.
+func (v *KeyValue) Name() string {
+	if v.NameLength == 0 {
+		return ""
+	}
+	if v.Flags&ValueCompName != 0 {
+		return string(v.NameRaw)
+	}
+	return decodeUTF16LE(v.NameRaw)
+}
+
+// Type returns the REG_* data type.
+func (v *KeyValue) Type() uint32 {
+	return v.DataType
+}
+
+// IsInline reports whether the value data is stored inline in the DataOffset field.
+func (v *KeyValue) IsInline() bool {
+	return v.DataSize&0x80000000 != 0
+}
+
+// ActualDataSize returns the data size with the inline flag masked off.
+func (v *KeyValue) ActualDataSize() uint32 {
+	return v.DataSize & 0x7FFFFFFF
+}
+
+// Data returns the raw data bytes for this value.
+func (v *KeyValue) Data() ([]byte, error) {
+	actualSize := v.ActualDataSize()
+	if actualSize == 0 {
+		return nil, nil
+	}
+
+	if v.IsInline() {
+		// Data stored in the DataOffset field (up to 4 bytes)
+		buf := make([]byte, 4)
+		binary.LittleEndian.PutUint32(buf, v.DataOffset)
+		if actualSize > 4 {
+			actualSize = 4
+		}
+		return buf[:actualSize], nil
+	}
+
+	if v.hive == nil {
+		return nil, fmt.Errorf("KeyValue not attached to a hive")
+	}
+
+	return v.hive.readCellData(v.DataOffset, int(actualSize))
+}
+
+// String decodes the value data as a string for REG_SZ / REG_EXPAND_SZ types.
+func (v *KeyValue) String() string {
+	data, err := v.Data()
+	if err != nil || data == nil {
+		return ""
+	}
+	switch v.DataType {
+	case RegSz, RegExpandSz, RegLink:
+		return strings.TrimRight(decodeUTF16LE(data), "\x00")
+	default:
+		return ""
+	}
+}
+
+// Uint32 decodes a REG_DWORD value. Returns (0, false) if not applicable.
+func (v *KeyValue) Uint32() (uint32, bool) {
+	data, err := v.Data()
+	if err != nil || len(data) < 4 {
+		return 0, false
+	}
+	return binary.LittleEndian.Uint32(data), true
+}

--- a/windows/registry/regf/subkey_list.go
+++ b/windows/registry/regf/subkey_list.go
@@ -1,0 +1,116 @@
+package regf
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+const (
+	lfSig = 0x666C // "lf"
+	lhSig = 0x686C // "lh"
+	riSig = 0x6972 // "ri"
+	liSig = 0x696C // "li"
+)
+
+// SubKeyList is the internal representation of a parsed subkey list record (LF, LH, LI, or RI).
+//
+// Source: https://github.com/msuhanov/regf/blob/master/Windows%20registry%20file%20format%20specification.md#subkeys-list
+type SubKeyList struct {
+	// Signature (2 bytes): "lf", "lh", "ri", or "li".
+	Signature uint16
+
+	// NumberOfElements (2 bytes): count of entries.
+	NumberOfElements uint16
+
+	// Elements contains the raw element data, interpreted per signature type.
+	Elements []byte
+}
+
+// NewSubKeyList creates a new empty SubKeyList.
+func NewSubKeyList() *SubKeyList {
+	return &SubKeyList{}
+}
+
+// Unmarshal deserializes a SubKeyList from cell data.
+//
+// Parameters:
+//   - data ([]byte): cell data starting with the list signature.
+//
+// Returns:
+//   - The number of bytes consumed.
+//   - An error if the data is too short or the signature is unrecognized.
+func (s *SubKeyList) Unmarshal(data []byte) (int, error) {
+	if len(data) < 4 {
+		return 0, fmt.Errorf("data too short for SubKeyList: need 4 bytes, got %d", len(data))
+	}
+
+	s.Signature = binary.LittleEndian.Uint16(data[0:2])
+	s.NumberOfElements = binary.LittleEndian.Uint16(data[2:4])
+
+	var elemSize int
+	switch s.Signature {
+	case lfSig, lhSig:
+		elemSize = 8 // 4-byte offset + 4-byte name hint/hash
+	case riSig, liSig:
+		elemSize = 4 // 4-byte offset only
+	default:
+		return 0, fmt.Errorf("unrecognized SubKeyList Signature: 0x%04X", s.Signature)
+	}
+
+	totalSize := 4 + int(s.NumberOfElements)*elemSize
+	if totalSize > len(data) {
+		totalSize = len(data)
+	}
+	s.Elements = make([]byte, totalSize-4)
+	copy(s.Elements, data[4:totalSize])
+
+	return totalSize, nil
+}
+
+// Marshal serializes the SubKeyList to binary data.
+//
+// Returns:
+//   - A byte slice containing the serialized SubKeyList.
+//   - An error if serialization fails.
+func (s *SubKeyList) Marshal() ([]byte, error) {
+	buf := make([]byte, 4+len(s.Elements))
+	binary.LittleEndian.PutUint16(buf[0:2], s.Signature)
+	binary.LittleEndian.PutUint16(buf[2:4], s.NumberOfElements)
+	copy(buf[4:], s.Elements)
+	return buf, nil
+}
+
+// KeyNodeOffsets returns the offsets to all key nodes referenced by this list.
+// For RI lists, it returns the offsets to the sublists (not the key nodes themselves);
+// the caller must recurse into each sublist.
+func (s *SubKeyList) KeyNodeOffsets() []uint32 {
+	n := int(s.NumberOfElements)
+	offsets := make([]uint32, 0, n)
+
+	switch s.Signature {
+	case lfSig, lhSig:
+		for i := 0; i < n; i++ {
+			off := i * 8
+			if off+4 > len(s.Elements) {
+				break
+			}
+			offsets = append(offsets, binary.LittleEndian.Uint32(s.Elements[off:off+4]))
+		}
+	case riSig, liSig:
+		for i := 0; i < n; i++ {
+			off := i * 4
+			if off+4 > len(s.Elements) {
+				break
+			}
+			offsets = append(offsets, binary.LittleEndian.Uint32(s.Elements[off:off+4]))
+		}
+	}
+
+	return offsets
+}
+
+// IsIndexRoot reports whether this is an RI (index root) list, which contains
+// references to other sublists rather than directly to key nodes.
+func (s *SubKeyList) IsIndexRoot() bool {
+	return s.Signature == riSig
+}


### PR DESCRIPTION
### Linked Issue
`Closes #702`

### Motivation
Manticore supports remote registry (MS-RRP) and text `.reg` parsing (`windows/registry/regfile`) but cannot parse offline binary hive files (SAM, SYSTEM, SECURITY, NTDS companion hives). Offline hive parsing is the prerequisite for boot-key derivation, SAM hash extraction, and LSA secret decryption.

### What this adds
A new read-only `windows/registry/regf` package implementing the REGF binary format:
- **BaseBlock** (file header): signature, root cell offset, hive-bins data size.
- **HiveBin** (HBIN) records.
- **Cell** reading using the size-prefix convention (negative size = allocated).
- **KeyNode** (NK): name, flags, subkey/value/class offsets.
- **KeyValue** (VK): name, type, inline and external data, plus `uint32`/`string` accessors.
- **SubKeyList**: LF/LH fast/hash leaves and RI index roots.
- **High-level `Hive` API**: `Open`/`OpenBytes`, `RootKey`, `FindKey`, `EnumKey`, `EnumValues`, `GetValue`, `GetClass`, `Close`, with bounds checking on every read.
- `Marshal`/`Unmarshal` on every on-disk structure.

This matches the API sketch in #702.

### How Verified
- `go build ./windows/registry/regf/` and `go vet ./windows/registry/regf/` — clean.
- Public API reconciled against the #702 sketch (`Open`/`OpenBytes`/`RootKey`/`FindKey`/`EnumKey`/`EnumValues`/`GetValue`/`GetClass`; `KeyNode.Name/SubKeys/Values/Value/ClassData`; `KeyValue.Name/Type/Data`).

### Test Coverage
**None.** No unit tests are included in this change — exercising the parser meaningfully needs sample hive fixtures (SAM/SYSTEM snippets), which are not yet in the tree. Build and vet are clean; round-trip tests over `Marshal`/`Unmarshal` and a fixture-backed `FindKey`/`GetValue` test are filed as follow-up.

### Scope of Change
- **Files changed:** new `windows/registry/regf/{base_block,hive_bin,hive,key_node,key_value,subkey_list}.go` (1139 lines added).
- **Submodule pointer updated:** no.
- **Behavioral changes outside the new package:** none — purely additive; nothing else imports it yet.

### Risk and Rollout
Zero blast radius: a new leaf package with no importers, so it cannot regress existing behaviour. Safe to merge.

### Notes
Follow-up work (not in this PR): SK (security descriptor) record parsing, big-data (DB) records for values > 16,344 bytes, and fixture-backed tests. The SAM/LSA/SYSTEM credential-extraction consumers that depend on this parser are separate downstream work.
