### PR TITLE
Add key creation and deletion to REGF write support

### DIFF
--- a/windows/registry/regf/write_key.go
+++ b/windows/registry/regf/write_key.go
@@ -1,0 +1,268 @@
+package regf
+
+import (
+	"encoding/binary"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// This file extends write support (phase 2) with key creation and deletion, which edit a
+// parent's subkey list. Leaf list types (lf, lh, li) are supported; an index-root (ri)
+// subkey list — only produced for keys with very many subkeys — is rejected for edits.
+// Subkey lists are kept sorted case-insensitively, as Windows expects, and lh name hashes
+// are recomputed. Key names are written compressed (Latin-1).
+
+// subkeyEntry is one subkey-list element: the key-node offset and the subkey name (used to
+// recompute the list element's hint/hash and to keep the list sorted).
+type subkeyEntry struct {
+	offset uint32
+	name   string
+}
+
+// lhHash computes the "lh" subkey-list name hash: fold the uppercased name with a factor
+// of 37. (Matches the on-disk hash for ASCII names.)
+func lhHash(name string) uint32 {
+	var h uint32
+	for _, r := range strings.ToUpper(name) {
+		h = h*37 + uint32(r)
+	}
+	return h
+}
+
+// buildSubkeyList serializes a subkey list of the given leaf signature (lf/lh/li) from
+// entries, recomputing each element's hint (lf) or hash (lh).
+func buildSubkeyList(signature uint16, entries []subkeyEntry) []byte {
+	elemSize := 4
+	if signature == lfSig || signature == lhSig {
+		elemSize = 8
+	}
+	buf := make([]byte, 4+len(entries)*elemSize)
+	binary.LittleEndian.PutUint16(buf[0:2], signature)
+	binary.LittleEndian.PutUint16(buf[2:4], uint16(len(entries)))
+	for i, e := range entries {
+		p := 4 + i*elemSize
+		binary.LittleEndian.PutUint32(buf[p:p+4], e.offset)
+		switch signature {
+		case lfSig:
+			for j := 0; j < 4 && j < len(e.name); j++ {
+				buf[p+4+j] = e.name[j] // 4-char name hint
+			}
+		case lhSig:
+			binary.LittleEndian.PutUint32(buf[p+4:p+8], lhHash(e.name))
+		}
+	}
+	return buf
+}
+
+// bumpSKRefCount adjusts an SK record's reference count by delta, freeing the SK cell if
+// the count reaches zero on a decrement. It is a no-op for a null/invalid security offset.
+func (h *Hive) bumpSKRefCount(skOffset uint32, delta int) {
+	if skOffset == nullCellOffset {
+		return
+	}
+	c := baseBlockSize + int(skOffset) + 4
+	if c+16 > len(h.data) || binary.LittleEndian.Uint16(h.data[c:c+2]) != skSignature {
+		return
+	}
+	rc := int(binary.LittleEndian.Uint32(h.data[c+12:c+16])) + delta
+	if rc < 0 {
+		rc = 0
+	}
+	binary.LittleEndian.PutUint32(h.data[c+12:c+16], uint32(rc))
+	if rc == 0 && delta < 0 {
+		h.freeCell(skOffset)
+	}
+}
+
+// CreateKey creates an empty subkey `name` under the key at parentPath. The new key
+// inherits the parent's security descriptor (sharing its SK record). It errors if the
+// parent does not exist, the subkey already exists, or the parent's subkey list is an
+// index root (ri). The change is applied in memory; call Bytes or Save to finalize.
+func (h *Hive) CreateKey(parentPath, name string) error {
+	if h.data == nil {
+		return fmt.Errorf("regf: hive is closed")
+	}
+	parent, err := h.FindKey(parentPath)
+	if err != nil {
+		return err
+	}
+	if subs, _ := parent.SubKeys(); subs != nil {
+		for _, sk := range subs {
+			if strings.EqualFold(sk.Name(), name) {
+				return fmt.Errorf("regf: key %q already exists under %q", name, parentPath)
+			}
+		}
+	}
+
+	nk := &KeyNode{
+		Signature:         nkSignature,
+		Flags:             KeyCompName,
+		SubKeysListOffset: nullCellOffset,
+		ValuesListOffset:  nullCellOffset,
+		ClassNameOffset:   nullCellOffset,
+		SecurityOffset:    parent.SecurityOffset,
+		Parent:            parent.offset,
+		KeyNameLength:     uint16(len(name)),
+		KeyNameRaw:        []byte(name),
+	}
+	nkBytes, _ := nk.Marshal()
+	nkOff, err := h.allocateCell(len(nkBytes))
+	if err != nil {
+		return err
+	}
+	h.writeCellContent(nkOff, nkBytes)
+	h.bumpSKRefCount(parent.SecurityOffset, +1)
+
+	return h.addSubkeyToList(parent, nkOff, name)
+}
+
+// addSubkeyToList inserts a new subkey (offset+name) into the parent's subkey list, keeping
+// it sorted, and updates the parent's NumberOfSubKeys and SubKeysListOffset.
+func (h *Hive) addSubkeyToList(parent *KeyNode, newOffset uint32, newName string) error {
+	pc := baseBlockSize + int(parent.offset) + 4
+
+	if parent.SubKeysListOffset == nullCellOffset || parent.NumberOfSubKeys == 0 {
+		list := buildSubkeyList(lhSig, []subkeyEntry{{newOffset, newName}})
+		lo, err := h.allocateCell(len(list))
+		if err != nil {
+			return err
+		}
+		h.writeCellContent(lo, list)
+		binary.LittleEndian.PutUint32(h.data[pc+20:pc+24], 1)
+		binary.LittleEndian.PutUint32(h.data[pc+28:pc+32], lo)
+		return nil
+	}
+
+	entries, signature, err := h.readSubkeyEntries(parent.SubKeysListOffset)
+	if err != nil {
+		return err
+	}
+	entries = append(entries, subkeyEntry{newOffset, newName})
+	sortSubkeyEntries(entries)
+
+	list := buildSubkeyList(signature, entries)
+	lo, err := h.allocateCell(len(list))
+	if err != nil {
+		return err
+	}
+	h.writeCellContent(lo, list)
+	h.freeCell(parent.SubKeysListOffset)
+	binary.LittleEndian.PutUint32(h.data[pc+20:pc+24], parent.NumberOfSubKeys+1)
+	binary.LittleEndian.PutUint32(h.data[pc+28:pc+32], lo)
+	return nil
+}
+
+// readSubkeyEntries reads a parent's subkey list into entries (offset+name) and returns the
+// list's leaf signature. It errors on an index-root (ri) list.
+func (h *Hive) readSubkeyEntries(listOffset uint32) ([]subkeyEntry, uint16, error) {
+	cell, err := h.readCellRaw(listOffset)
+	if err != nil {
+		return nil, 0, err
+	}
+	list := NewSubKeyList()
+	if _, err := list.Unmarshal(cell); err != nil {
+		return nil, 0, err
+	}
+	if list.IsIndexRoot() {
+		return nil, 0, fmt.Errorf("regf: editing an index-root (ri) subkey list is not supported")
+	}
+	var entries []subkeyEntry
+	for _, off := range list.KeyNodeOffsets() {
+		sub, err := h.readKeyNode(off)
+		if err != nil {
+			continue
+		}
+		entries = append(entries, subkeyEntry{off, sub.Name()})
+	}
+	return entries, list.Signature, nil
+}
+
+func sortSubkeyEntries(entries []subkeyEntry) {
+	sort.Slice(entries, func(i, j int) bool {
+		return strings.ToUpper(entries[i].name) < strings.ToUpper(entries[j].name)
+	})
+}
+
+// DeleteKey removes the subkey `name` under parentPath and everything beneath it
+// (recursively freeing descendant keys, values, and their cells). It errors if the key is
+// not found or the parent's subkey list is an index root (ri).
+func (h *Hive) DeleteKey(parentPath, name string) error {
+	if h.data == nil {
+		return fmt.Errorf("regf: hive is closed")
+	}
+	parent, err := h.FindKey(parentPath)
+	if err != nil {
+		return err
+	}
+	if parent.SubKeysListOffset == nullCellOffset || parent.NumberOfSubKeys == 0 {
+		return fmt.Errorf("regf: key %q not found under %q", name, parentPath)
+	}
+
+	entries, signature, err := h.readSubkeyEntries(parent.SubKeysListOffset)
+	if err != nil {
+		return err
+	}
+	targetOffset := uint32(nullCellOffset)
+	remaining := entries[:0:0]
+	for _, e := range entries {
+		if targetOffset == nullCellOffset && strings.EqualFold(e.name, name) {
+			targetOffset = e.offset
+			continue
+		}
+		remaining = append(remaining, e)
+	}
+	if targetOffset == nullCellOffset {
+		return fmt.Errorf("regf: key %q not found under %q", name, parentPath)
+	}
+
+	h.freeKeyRecursive(targetOffset)
+
+	pc := baseBlockSize + int(parent.offset) + 4
+	if len(remaining) == 0 {
+		h.freeCell(parent.SubKeysListOffset)
+		binary.LittleEndian.PutUint32(h.data[pc+20:pc+24], 0)
+		binary.LittleEndian.PutUint32(h.data[pc+28:pc+32], nullCellOffset)
+		return nil
+	}
+	list := buildSubkeyList(signature, remaining)
+	lo, err := h.allocateCell(len(list))
+	if err != nil {
+		return err
+	}
+	h.writeCellContent(lo, list)
+	h.freeCell(parent.SubKeysListOffset)
+	binary.LittleEndian.PutUint32(h.data[pc+20:pc+24], uint32(len(remaining)))
+	binary.LittleEndian.PutUint32(h.data[pc+28:pc+32], lo)
+	return nil
+}
+
+// freeKeyRecursive frees a key node and everything it owns: its values (and their data
+// cells), its value list, its subkeys (recursively) and subkey list, its class cell, and
+// decrements its shared SK record's reference count.
+func (h *Hive) freeKeyRecursive(nkOffset uint32) {
+	nk, err := h.readKeyNode(nkOffset)
+	if err != nil {
+		h.freeCell(nkOffset)
+		return
+	}
+	if nk.ValuesListOffset != nullCellOffset && nk.NumberOfValues > 0 {
+		for _, vo := range h.valueListOffsets(nk.ValuesListOffset, nk.NumberOfValues) {
+			h.freeValueCell(vo)
+		}
+		h.freeCell(nk.ValuesListOffset)
+	}
+	if nk.SubKeysListOffset != nullCellOffset && nk.NumberOfSubKeys > 0 {
+		if offs, err := h.collectKeyNodeOffsets(nk.SubKeysListOffset); err == nil {
+			for _, so := range offs {
+				h.freeKeyRecursive(so)
+			}
+		}
+		h.freeCell(nk.SubKeysListOffset)
+	}
+	if nk.ClassNameOffset != nullCellOffset {
+		h.freeCell(nk.ClassNameOffset)
+	}
+	h.bumpSKRefCount(nk.SecurityOffset, -1)
+	h.freeCell(nkOffset)
+}

--- a/windows/registry/regf/write_key_test.go
+++ b/windows/registry/regf/write_key_test.go
@@ -1,0 +1,210 @@
+package regf
+
+import (
+	"encoding/binary"
+	"reflect"
+	"testing"
+)
+
+// buildKeyHive builds a minimal writable hive whose root carries a real SK record (so
+// created subkeys can inherit it): a single 4096-byte bin with root "ROOT" and an SK.
+func buildKeyHive() []byte {
+	a := &hiveAsm{}
+	hb := &HiveBin{Signature: hbinSignature, Size: 4096}
+	hdr, _ := hb.Marshal()
+	a.bins = append(a.bins, hdr...)
+
+	rootName := utf16le("ROOT")
+	root := &KeyNode{
+		Signature:         nkSignature,
+		Flags:             KeyHiveEntry,
+		SubKeysListOffset: nullCellOffset,
+		ValuesListOffset:  nullCellOffset,
+		ClassNameOffset:   nullCellOffset,
+		SecurityOffset:    nullCellOffset, // back-patched
+		Parent:            nullCellOffset,
+		KeyNameLength:     uint16(len(rootName)),
+		KeyNameRaw:        rootName,
+	}
+	rootb, _ := root.Marshal()
+	rootOff := a.addCell(rootb)
+	rootContent := int(rootOff) + 4
+
+	sd := sampleSecurityDescriptorBytes()
+	sk := &SecurityKey{Signature: skSignature, ReferenceCount: 1, SecurityDescriptorSize: uint32(len(sd)), SecurityDescriptor: sd}
+	skb, _ := sk.Marshal()
+	skOff := a.addCell(skb)
+	binary.LittleEndian.PutUint32(a.bins[rootContent+44:rootContent+48], skOff) // SecurityOffset at NK+44
+
+	if len(a.bins) < 4096 {
+		a.bins = append(a.bins, make([]byte, 4096-len(a.bins))...)
+	}
+
+	bb := &BaseBlock{
+		Signature:               regfSignature,
+		PrimarySequenceNumber:   1,
+		SecondarySequenceNumber: 1,
+		MajorVersion:            1,
+		MinorVersion:            6,
+		FileFormat:              1,
+		RootCellOffset:          rootOff,
+		HiveBinsDataSize:        uint32(len(a.bins)),
+		ClusteringFactor:        1,
+	}
+	bbb, _ := bb.Marshal()
+	var cs uint32
+	for i := 0; i < 508; i += 4 {
+		cs ^= binary.LittleEndian.Uint32(bbb[i : i+4])
+	}
+	switch cs {
+	case 0:
+		cs = 1
+	case 0xFFFFFFFF:
+		cs = 0xFFFFFFFE
+	}
+	binary.LittleEndian.PutUint32(bbb[508:512], cs)
+	return append(bbb, a.bins...)
+}
+
+func openKeyHive(t *testing.T) *Hive {
+	t.Helper()
+	h, err := OpenBytes(buildKeyHive())
+	if err != nil {
+		t.Fatalf("OpenBytes: %v", err)
+	}
+	return h
+}
+
+func TestCreateKeySortedAndInheritsSecurity(t *testing.T) {
+	h := openKeyHive(t)
+	// Insert out of order; the list must come back sorted case-insensitively.
+	for _, name := range []string{"System", "Software", "SAM"} {
+		if err := h.CreateKey("", name); err != nil {
+			t.Fatalf("CreateKey %s: %v", name, err)
+		}
+	}
+	keys, err := h.EnumKey("")
+	if err != nil {
+		t.Fatalf("EnumKey: %v", err)
+	}
+	if !reflect.DeepEqual(keys, []string{"SAM", "Software", "System"}) {
+		t.Errorf("EnumKey = %v, want [SAM Software System]", keys)
+	}
+
+	sub, err := h.FindKey("Software")
+	if err != nil {
+		t.Fatalf("FindKey(Software): %v", err)
+	}
+	if sub.IsRoot() {
+		t.Error("created key should not be a root key")
+	}
+	if subs, _ := sub.SubKeys(); len(subs) != 0 {
+		t.Errorf("new key has %d subkeys, want 0", len(subs))
+	}
+
+	// The created key inherits the root's security descriptor (shared SK record).
+	sd, err := h.GetSecurityDescriptor("Software")
+	if err != nil || sd == nil {
+		t.Fatalf("GetSecurityDescriptor(Software): sd=%v err=%v", sd, err)
+	}
+	if o := sd.GetOwner(); o == nil || o.SID.String() != "S-1-5-32-544" {
+		t.Errorf("inherited owner = %v, want S-1-5-32-544", o)
+	}
+}
+
+func TestCreateKeyNestedAndValue(t *testing.T) {
+	h := openKeyHive(t)
+	if err := h.CreateKey("", "A"); err != nil {
+		t.Fatalf("CreateKey A: %v", err)
+	}
+	if err := h.CreateKey("A", "B"); err != nil {
+		t.Fatalf("CreateKey A\\B: %v", err)
+	}
+	if _, err := h.FindKey("A\\B"); err != nil {
+		t.Errorf("FindKey(A\\B): %v", err)
+	}
+	if keys, _ := h.EnumKey("A"); !reflect.DeepEqual(keys, []string{"B"}) {
+		t.Errorf("EnumKey(A) = %v, want [B]", keys)
+	}
+
+	// Values can be written to a freshly created key.
+	if err := h.SetValue("A\\B", "v", RegDword, le32(0x2026)); err != nil {
+		t.Fatalf("SetValue on created key: %v", err)
+	}
+	if _, d := mustGet(t, h, "A\\B", "v"); binary.LittleEndian.Uint32(d) != 0x2026 {
+		t.Errorf("created-key value = % x, want 26 20 00 00", d)
+	}
+}
+
+func TestCreateKeyDuplicate(t *testing.T) {
+	h := openKeyHive(t)
+	if err := h.CreateKey("", "Dup"); err != nil {
+		t.Fatalf("CreateKey: %v", err)
+	}
+	if err := h.CreateKey("", "dup"); err == nil {
+		t.Error("CreateKey of an existing key (case-insensitive) returned nil error")
+	}
+}
+
+func TestDeleteKeyRecursive(t *testing.T) {
+	h := openKeyHive(t)
+	if err := h.CreateKey("", "P"); err != nil {
+		t.Fatal(err)
+	}
+	if err := h.CreateKey("P", "C"); err != nil {
+		t.Fatal(err)
+	}
+	if err := h.SetValue("P", "pv", RegDword, le32(1)); err != nil {
+		t.Fatal(err)
+	}
+	if err := h.SetValue("P\\C", "cv", RegDword, le32(2)); err != nil {
+		t.Fatal(err)
+	}
+	// Keep a sibling to confirm only the target subtree is removed.
+	if err := h.CreateKey("", "Keep"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := h.DeleteKey("", "P"); err != nil {
+		t.Fatalf("DeleteKey: %v", err)
+	}
+	if _, err := h.FindKey("P"); err == nil {
+		t.Error("P still present after delete")
+	}
+	if _, err := h.FindKey("P\\C"); err == nil {
+		t.Error("P\\C still present after recursive delete")
+	}
+	keys, _ := h.EnumKey("")
+	if !reflect.DeepEqual(keys, []string{"Keep"}) {
+		t.Errorf("after delete, EnumKey = %v, want [Keep]", keys)
+	}
+	if err := h.DeleteKey("", "Nope"); err == nil {
+		t.Error("DeleteKey of a missing key returned nil error")
+	}
+}
+
+func TestCreateKeyPersistsAndReopens(t *testing.T) {
+	h := openKeyHive(t)
+	for _, n := range []string{"Alpha", "Beta"} {
+		if err := h.CreateKey("", n); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := h.CreateKey("Alpha", "Child"); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := h.Bytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	h2, err := OpenBytes(raw)
+	if err != nil {
+		t.Fatalf("re-open: %v", err)
+	}
+	if keys, _ := h2.EnumKey(""); !reflect.DeepEqual(keys, []string{"Alpha", "Beta"}) {
+		t.Errorf("reopened EnumKey = %v, want [Alpha Beta]", keys)
+	}
+	if keys, _ := h2.EnumKey("Alpha"); !reflect.DeepEqual(keys, []string{"Child"}) {
+		t.Errorf("reopened EnumKey(Alpha) = %v, want [Child]", keys)
+	}
+}


### PR DESCRIPTION
### Linked Issue
Completes the REGF "future work" from #704 — write support **phase 2** (key creation/deletion), building on the phase-1 allocator (#711).

### Motivation
Phase 1 added value writes and the cell allocator. This adds key creation and deletion, which edit the parent's subkey list — the remaining piece of hive write support.

### What this adds
- **`CreateKey(parentPath, name)`** — allocate a key node, insert it into the parent's subkey list (creating an `lh` list when the parent has none), update `NumberOfSubKeys`. The list is kept **sorted case-insensitively** and `lh` name hashes are recomputed, as Windows expects. The new key **inherits the parent's security descriptor** (sharing its SK record, whose reference count is bumped). Duplicate names are rejected.
- **`DeleteKey(parentPath, name)`** — **recursively** free the target key and everything beneath it (descendant keys, values, and their cells), decrement the shared SK reference count (freeing the SK at zero), and remove the entry from the parent's list.
- Subkey-list helpers: `lh` hash, `lf` 4-char hint, sorted serialization for `lf`/`lh`/`li`. Index-root (`ri`) lists — only produced for keys with very many subkeys — are rejected for edits with a clear error.

### How Verified
- `go test ./windows/registry/regf/`, `go vet`, full `go build ./...` — clean.
- Tests (self-contained hive carrying a real SK so created keys inherit it): sorted creation + security inheritance (owner `S-1-5-32-544`), nested keys + a value on a created key, duplicate rejection (case-insensitive), recursive delete leaving a sibling intact, and persistence through `Bytes`/re-open.
- **Independently cross-validated with regipy**: a tree built entirely by our writer — `SAM`, `Software\Microsoft\Flag = 0xABCD`, `System`, plus a key created then `DeleteKey`'d — enumerates in regipy exactly as `ROOT → {SAM, Software→Microsoft→Flag, System}`, sorted, with the deleted key absent.

### Test Coverage
**Added:** `write_key_test.go` (`TestCreateKeySortedAndInheritsSecurity`, `TestCreateKeyNestedAndValue`, `TestCreateKeyDuplicate`, `TestDeleteKeyRecursive`, `TestCreateKeyPersistsAndReopens`).

### Scope of Change
- **Files changed:** new `write_key.go`, `write_key_test.go`. No existing files touched.
- **Submodule pointer updated:** no.
- **Behavioral changes outside scope:** none — additive; read paths and phase-1 value writes unchanged.

### Risk and Rollout
Low: new code only; mutations are bounds-checked, operate on the in-memory image, and the result is validated to re-parse and to be read by an independent parser.

### Notes
Intentionally out of scope: editing index-root (`ri`) subkey lists (rejected with an error), and free-cell coalescing (freed cells are reused individually, not merged). With this, hive write support covers keys and values end to end.
