### PR TITLE
Fix unbounded recursion on cyclic ri subkey lists in REGF parser (#715)

### DIFF
--- a/windows/registry/regf/hive.go
+++ b/windows/registry/regf/hive.go
@@ -392,8 +392,21 @@ func (h *Hive) enumSubKeys(offset uint32) ([]*KeyNode, error) {
 	return subkeys, nil
 }
 
+// maxSubkeyListDepth bounds the recursion that resolves index-root (ri) subkey lists. Real
+// hives nest ri at most one or two levels; this guards against a cyclic or maliciously
+// deep ri list (which would otherwise recurse until the stack overflows).
+const maxSubkeyListDepth = 32
+
 // collectKeyNodeOffsets reads a subkey list and recursively resolves RI blocks.
 func (h *Hive) collectKeyNodeOffsets(offset uint32) ([]uint32, error) {
+	return h.collectKeyNodeOffsetsDepth(offset, 0)
+}
+
+func (h *Hive) collectKeyNodeOffsetsDepth(offset uint32, depth int) ([]uint32, error) {
+	if depth > maxSubkeyListDepth {
+		return nil, fmt.Errorf("regf: subkey list nesting too deep at 0x%X (possible cycle)", offset)
+	}
+
 	cell, err := h.readCellRaw(offset)
 	if err != nil {
 		return nil, fmt.Errorf("regf: reading subkey list at 0x%X: %w", offset, err)
@@ -408,10 +421,11 @@ func (h *Hive) collectKeyNodeOffsets(offset uint32) ([]uint32, error) {
 		return list.KeyNodeOffsets(), nil
 	}
 
-	// RI: each element points to another subkey list (LF/LH/LI)
+	// RI: each element points to another subkey list (LF/LH/LI). Recurse with a depth
+	// bound so a cyclic ri cannot recurse without limit.
 	var allOffsets []uint32
 	for _, subListOffset := range list.KeyNodeOffsets() {
-		subOffsets, err := h.collectKeyNodeOffsets(subListOffset)
+		subOffsets, err := h.collectKeyNodeOffsetsDepth(subListOffset, depth+1)
 		if err != nil {
 			continue
 		}

--- a/windows/registry/regf/robustness_test.go
+++ b/windows/registry/regf/robustness_test.go
@@ -1,0 +1,64 @@
+package regf
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+// buildCyclicRIHive builds a hive whose root's subkey list is an index-root (ri) cell with
+// a single element that points to itself — a cycle that must not crash the parser.
+func buildCyclicRIHive() []byte {
+	a := &hiveAsm{}
+	hb := &HiveBin{Signature: hbinSignature, Size: 4096}
+	hdr, _ := hb.Marshal()
+	a.bins = append(a.bins, hdr...)
+
+	rootName := utf16le("ROOT")
+	root := &KeyNode{
+		Signature: nkSignature, Flags: KeyHiveEntry, NumberOfSubKeys: 1,
+		ValuesListOffset: nullCellOffset, SecurityOffset: nullCellOffset, ClassNameOffset: nullCellOffset,
+		Parent: nullCellOffset, KeyNameLength: uint16(len(rootName)), KeyNameRaw: rootName,
+	}
+	rootb, _ := root.Marshal()
+	rootOff := a.addCell(rootb)
+	rootContent := int(rootOff) + 4
+
+	riOff := a.addCell(make([]byte, 8)) // sig(2) + count(2) + one 4-byte element
+	binary.LittleEndian.PutUint16(a.bins[int(riOff)+4:], riSig)
+	binary.LittleEndian.PutUint16(a.bins[int(riOff)+6:], 1)
+	binary.LittleEndian.PutUint32(a.bins[int(riOff)+8:], riOff) // self-reference
+
+	binary.LittleEndian.PutUint32(a.bins[rootContent+28:rootContent+32], riOff) // SubKeysListOffset
+
+	if len(a.bins) < 4096 {
+		a.bins = append(a.bins, make([]byte, 4096-len(a.bins))...)
+	}
+	bb := &BaseBlock{
+		Signature: regfSignature, MajorVersion: 1, MinorVersion: 6, FileFormat: 1,
+		RootCellOffset: rootOff, HiveBinsDataSize: uint32(len(a.bins)), ClusteringFactor: 1,
+		PrimarySequenceNumber: 1, SecondarySequenceNumber: 1,
+	}
+	bbb, _ := bb.Marshal()
+	return append(bbb, a.bins...)
+}
+
+// TestCyclicRIDoesNotRecurse verifies that enumerating a key with a self-referential ri
+// subkey list terminates (bounded by maxSubkeyListDepth) instead of overflowing the stack.
+func TestCyclicRIDoesNotRecurse(t *testing.T) {
+	h, err := OpenBytes(buildCyclicRIHive())
+	if err != nil {
+		t.Fatalf("OpenBytes: %v", err)
+	}
+	// Must return without a stack overflow; the cyclic branch yields no keys.
+	keys, err := h.EnumKey("")
+	if err != nil {
+		t.Fatalf("EnumKey: %v", err)
+	}
+	if len(keys) != 0 {
+		t.Errorf("EnumKey on a cyclic ri = %v, want none", keys)
+	}
+	// DeleteKey walks the same structure on the write path; it must also terminate.
+	if err := h.DeleteKey("", "anything"); err == nil {
+		t.Error("DeleteKey of a missing key returned nil error")
+	}
+}

--- a/windows/registry/regf/write_key.go
+++ b/windows/registry/regf/write_key.go
@@ -237,10 +237,22 @@ func (h *Hive) DeleteKey(parentPath, name string) error {
 	return nil
 }
 
+// maxKeyTreeDepth bounds the recursion when freeing a key subtree, guarding against a
+// cyclic subkey graph in a corrupt hive (Windows limits key depth well below this).
+const maxKeyTreeDepth = 512
+
 // freeKeyRecursive frees a key node and everything it owns: its values (and their data
 // cells), its value list, its subkeys (recursively) and subkey list, its class cell, and
 // decrements its shared SK record's reference count.
 func (h *Hive) freeKeyRecursive(nkOffset uint32) {
+	h.freeKeyRecursiveDepth(nkOffset, 0)
+}
+
+func (h *Hive) freeKeyRecursiveDepth(nkOffset uint32, depth int) {
+	if depth > maxKeyTreeDepth {
+		h.freeCell(nkOffset)
+		return
+	}
 	nk, err := h.readKeyNode(nkOffset)
 	if err != nil {
 		h.freeCell(nkOffset)
@@ -255,7 +267,7 @@ func (h *Hive) freeKeyRecursive(nkOffset uint32) {
 	if nk.SubKeysListOffset != nullCellOffset && nk.NumberOfSubKeys > 0 {
 		if offs, err := h.collectKeyNodeOffsets(nk.SubKeysListOffset); err == nil {
 			for _, so := range offs {
-				h.freeKeyRecursive(so)
+				h.freeKeyRecursiveDepth(so, depth+1)
 			}
 		}
 		h.freeCell(nk.SubKeysListOffset)


### PR DESCRIPTION
### Linked Issue
`Closes #715`

### Root Cause
`Hive.collectKeyNodeOffsets` resolves index-root (`ri`) subkey lists by recursing into each element's offset, with no recursion-depth limit and no visited-set. A hive whose `ri` element points back to the same `ri` cell (or nests arbitrarily deep) recurses forever and overflows the stack. Offline hives are untrusted forensic input, so any `EnumKey`/`FindKey`/`SubKeys` on such a hive crashes the process.

### Fix Description
Bound the `ri` resolution with a recursion-depth limit (`maxSubkeyListDepth = 32` — real hives nest `ri` at most a level or two). An over-deep / cyclic branch returns an error that the caller already skips (`continue`), so enumeration terminates with whatever it could resolve instead of crashing. The write-path subtree free (`freeKeyRecursive`) gets the same treatment via `maxKeyTreeDepth = 512` to guard against a cyclic subkey graph during `DeleteKey`.

Chose a depth bound over a visited-set: it is simpler, allocation-free, and a fixed small ceiling is correct for the format (legitimate `ri` nesting is shallow).

### How Verified
- New `TestCyclicRIDoesNotRecurse`: a hive with a self-referential `ri` cell — before the fix this stack-overflows (`fatal error: stack overflow`); after, `EnumKey` returns 0 keys and `DeleteKey` walks without crashing. Also confirmed read APIs are panic-safe on truncated/random input.
- `go test ./windows/registry/regf/`, `go vet`, full `go build ./...` — clean.

### Test Coverage
**Added:** `robustness_test.go` (`TestCyclicRIDoesNotRecurse`, with `buildCyclicRIHive`).

### Scope of Change
- **Files changed:** `hive.go` (depth-bounded `collectKeyNodeOffsets`), `write_key.go` (depth-bounded `freeKeyRecursive`), new `robustness_test.go`.
- **Submodule pointer updated:** no.
- **Behavioral changes outside the bug fix:** none — well-formed hives (shallow `ri`) are unaffected.

### Risk and Rollout
Low: only adds a ceiling to recursion that legitimate hives never approach.
