### PR TITLE
Improve REGF write fidelity: preserve subkeys, maintain metadata, no-op finalize

### DIFF
--- a/windows/registry/regf/hive.go
+++ b/windows/registry/regf/hive.go
@@ -12,6 +12,7 @@ import (
 type Hive struct {
 	data      []byte
 	baseBlock BaseBlock
+	dirty     bool // set by mutating operations; gates base-block finalization in Bytes
 }
 
 // Open opens and parses a registry hive file from disk.

--- a/windows/registry/regf/write.go
+++ b/windows/registry/regf/write.go
@@ -5,7 +5,31 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 )
+
+// filetimeNow returns the current time as a Windows FILETIME (100-ns ticks since 1601).
+func filetimeNow() uint64 {
+	return uint64(time.Now().UnixNano())/100 + 116444736000000000
+}
+
+// touchKey sets a key node's LastWrittenTimestamp (NK content offset 4) to now, as Windows
+// does whenever a key's values or subkeys change.
+func (h *Hive) touchKey(nkOffset uint32) {
+	c := baseBlockSize + int(nkOffset) + 4
+	if c+12 <= len(h.data) {
+		binary.LittleEndian.PutUint64(h.data[c+4:c+12], filetimeNow())
+	}
+}
+
+// growU32 raises the uint32 at absolute position absPos to v if v is larger (used to keep
+// the NK "largest ..." hint fields at least as large as the items they describe; never
+// shrinks, so the hint stays a safe upper bound).
+func (h *Hive) growU32(absPos int, v uint32) {
+	if absPos+4 <= len(h.data) && v > binary.LittleEndian.Uint32(h.data[absPos:absPos+4]) {
+		binary.LittleEndian.PutUint32(h.data[absPos:absPos+4], v)
+	}
+}
 
 // This file implements write support for hives: a cell allocator over the hive's mutable
 // buffer, plus value create/update/delete. Mutations are applied directly to the in-memory
@@ -233,25 +257,30 @@ func (h *Hive) SetValue(keyPath, name string, dataType uint32, data []byte) erro
 		listContent := baseBlockSize + int(nk.ValuesListOffset) + 4
 		binary.LittleEndian.PutUint32(h.data[listContent+existing*4:], vkOff)
 		h.freeValueCell(oldVK)
-		return nil
+	} else {
+		// Append: grow the value list by one slot.
+		newCount := nk.NumberOfValues + 1
+		newList, err := h.allocateCell(int(newCount) * 4)
+		if err != nil {
+			return err
+		}
+		lc := baseBlockSize + int(newList) + 4
+		for i, off := range offsets {
+			binary.LittleEndian.PutUint32(h.data[lc+i*4:], off)
+		}
+		binary.LittleEndian.PutUint32(h.data[lc+len(offsets)*4:], vkOff)
+		if nk.ValuesListOffset != nullCellOffset {
+			h.freeCell(nk.ValuesListOffset)
+		}
+		binary.LittleEndian.PutUint32(h.data[nkContent+36:nkContent+40], newCount) // NumberOfValues
+		binary.LittleEndian.PutUint32(h.data[nkContent+40:nkContent+44], newList)  // ValuesListOffset
 	}
 
-	// Append: grow the value list by one slot.
-	newCount := nk.NumberOfValues + 1
-	newList, err := h.allocateCell(int(newCount) * 4)
-	if err != nil {
-		return err
-	}
-	lc := baseBlockSize + int(newList) + 4
-	for i, off := range offsets {
-		binary.LittleEndian.PutUint32(h.data[lc+i*4:], off)
-	}
-	binary.LittleEndian.PutUint32(h.data[lc+len(offsets)*4:], vkOff)
-	if nk.ValuesListOffset != nullCellOffset {
-		h.freeCell(nk.ValuesListOffset)
-	}
-	binary.LittleEndian.PutUint32(h.data[nkContent+36:nkContent+40], newCount) // NumberOfValues
-	binary.LittleEndian.PutUint32(h.data[nkContent+40:nkContent+44], newList)  // ValuesListOffset
+	// Maintain the key's metadata: timestamp and the value name/data size hints.
+	h.touchKey(nk.offset)
+	h.growU32(nkContent+60, uint32(len(name))) // MaxValueNameLength
+	h.growU32(nkContent+64, uint32(len(data))) // MaxValueDataSize
+	h.dirty = true
 	return nil
 }
 
@@ -285,6 +314,8 @@ func (h *Hive) DeleteValue(keyPath, name string) error {
 		h.freeCell(nk.ValuesListOffset)
 		binary.LittleEndian.PutUint32(h.data[nkContent+36:nkContent+40], 0)
 		binary.LittleEndian.PutUint32(h.data[nkContent+40:nkContent+44], nullCellOffset)
+		h.touchKey(nk.offset)
+		h.dirty = true
 		return nil
 	}
 
@@ -304,6 +335,8 @@ func (h *Hive) DeleteValue(keyPath, name string) error {
 	h.freeCell(nk.ValuesListOffset)
 	binary.LittleEndian.PutUint32(h.data[nkContent+36:nkContent+40], newCount)
 	binary.LittleEndian.PutUint32(h.data[nkContent+40:nkContent+44], newList)
+	h.touchKey(nk.offset)
+	h.dirty = true
 	return nil
 }
 
@@ -335,7 +368,12 @@ func (h *Hive) Bytes() ([]byte, error) {
 	if h.data == nil {
 		return nil, fmt.Errorf("regf: hive is closed")
 	}
-	h.finalize()
+	// Only rewrite the base block (sequence numbers + checksum) when the hive was actually
+	// mutated, so an unmodified hive round-trips byte-for-byte.
+	if h.dirty {
+		h.finalize()
+		h.dirty = false
+	}
 	return append([]byte(nil), h.data...), nil
 }
 

--- a/windows/registry/regf/write_fidelity_test.go
+++ b/windows/registry/regf/write_fidelity_test.go
@@ -1,0 +1,130 @@
+package regf
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+// TestBytesNoOpWhenUnmodified verifies that opening a hive and calling Bytes without any
+// mutation returns the original bytes unchanged (no sequence-number bump / checksum rewrite).
+func TestBytesNoOpWhenUnmodified(t *testing.T) {
+	orig := buildKeyHive()
+	h, err := OpenBytes(append([]byte(nil), orig...))
+	if err != nil {
+		t.Fatalf("OpenBytes: %v", err)
+	}
+	out, err := h.Bytes()
+	if err != nil {
+		t.Fatalf("Bytes: %v", err)
+	}
+	if !bytes.Equal(out, orig) {
+		t.Error("Bytes on an unmodified hive changed the image (expected byte-for-byte identity)")
+	}
+
+	// After a mutation, Bytes must finalize (bump sequence numbers).
+	if err := h.CreateKey("", "X"); err != nil {
+		t.Fatalf("CreateKey: %v", err)
+	}
+	out2, err := h.Bytes()
+	if err != nil {
+		t.Fatalf("Bytes: %v", err)
+	}
+	if binary.LittleEndian.Uint32(out2[4:8]) != 2 {
+		t.Errorf("primary sequence = %d after mutation, want 2", binary.LittleEndian.Uint32(out2[4:8]))
+	}
+}
+
+// TestWriteUpdatesTimestampAndHints verifies that mutations stamp LastWrittenTimestamp and
+// grow the NK "largest name/data" hint fields.
+func TestWriteUpdatesTimestampAndHints(t *testing.T) {
+	h := openKeyHive(t)
+
+	if err := h.SetValue("", "AVeryLongValueName", RegBinary, bytes.Repeat([]byte{1}, 300)); err != nil {
+		t.Fatalf("SetValue: %v", err)
+	}
+	root, _ := h.FindKey("")
+	if root.LastWrittenTimestamp == 0 {
+		t.Error("LastWrittenTimestamp not updated by SetValue")
+	}
+	if int(root.MaxValueNameLength) < len("AVeryLongValueName") {
+		t.Errorf("MaxValueNameLength = %d, want >= %d", root.MaxValueNameLength, len("AVeryLongValueName"))
+	}
+	if root.MaxValueDataSize < 300 {
+		t.Errorf("MaxValueDataSize = %d, want >= 300", root.MaxValueDataSize)
+	}
+
+	if err := h.CreateKey("", "ALongSubkeyName"); err != nil {
+		t.Fatalf("CreateKey: %v", err)
+	}
+	root, _ = h.FindKey("")
+	if int(root.MaxSubKeyNameLength) < len("ALongSubkeyName") {
+		t.Errorf("MaxSubKeyNameLength = %d, want >= %d", root.MaxSubKeyNameLength, len("ALongSubkeyName"))
+	}
+}
+
+// TestRebuildPreservesUnreadableSubkey verifies that rebuilding a subkey list keeps a
+// referenced subkey whose node cannot be parsed, instead of silently dropping it.
+func TestRebuildPreservesUnreadableSubkey(t *testing.T) {
+	// Build a hive: root -> lh list referencing [validSub, corruptCell].
+	a := &hiveAsm{}
+	hb := &HiveBin{Signature: hbinSignature, Size: 4096}
+	hdr, _ := hb.Marshal()
+	a.bins = append(a.bins, hdr...)
+
+	rootName := utf16le("ROOT")
+	root := &KeyNode{Signature: nkSignature, Flags: KeyHiveEntry, NumberOfSubKeys: 2,
+		ValuesListOffset: nullCellOffset, SecurityOffset: nullCellOffset, ClassNameOffset: nullCellOffset,
+		Parent: nullCellOffset, KeyNameLength: uint16(len(rootName)), KeyNameRaw: rootName}
+	rootb, _ := root.Marshal()
+	rootOff := a.addCell(rootb)
+	rootContent := int(rootOff) + 4
+
+	good := &KeyNode{Signature: nkSignature, Flags: KeyCompName, SubKeysListOffset: nullCellOffset,
+		ValuesListOffset: nullCellOffset, SecurityOffset: nullCellOffset, ClassNameOffset: nullCellOffset,
+		KeyNameLength: uint16(len("Good")), KeyNameRaw: []byte("Good")}
+	goodb, _ := good.Marshal()
+	goodOff := a.addCell(goodb)
+
+	corruptOff := a.addCell([]byte{0xFF, 0xFF, 0, 0, 0, 0, 0, 0}) // not an "nk" record
+
+	lh := &SubKeyList{Signature: lhSig, NumberOfElements: 2, Elements: make([]byte, 16)}
+	binary.LittleEndian.PutUint32(lh.Elements[0:4], goodOff)
+	binary.LittleEndian.PutUint32(lh.Elements[8:12], corruptOff)
+	lhb, _ := lh.Marshal()
+	lhOff := a.addCell(lhb)
+	binary.LittleEndian.PutUint32(a.bins[rootContent+28:rootContent+32], lhOff)
+
+	if len(a.bins) < 4096 {
+		a.bins = append(a.bins, make([]byte, 4096-len(a.bins))...)
+	}
+	bb := &BaseBlock{Signature: regfSignature, MajorVersion: 1, MinorVersion: 6, FileFormat: 1,
+		RootCellOffset: rootOff, HiveBinsDataSize: uint32(len(a.bins)), ClusteringFactor: 1,
+		PrimarySequenceNumber: 1, SecondarySequenceNumber: 1}
+	bbb, _ := bb.Marshal()
+	hive := append(bbb, a.bins...)
+
+	h, err := OpenBytes(hive)
+	if err != nil {
+		t.Fatalf("OpenBytes: %v", err)
+	}
+	entries, _, err := h.readSubkeyEntries(lhOff)
+	if err != nil {
+		t.Fatalf("readSubkeyEntries: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("readSubkeyEntries kept %d of 2 subkeys (unreadable one dropped)", len(entries))
+	}
+
+	// A CreateKey rebuild must keep the count consistent (2 existing + 1 new = 3).
+	if err := h.CreateKey("", "New"); err != nil {
+		t.Fatalf("CreateKey: %v", err)
+	}
+	root2, _ := h.FindKey("")
+	if root2.NumberOfSubKeys != 3 {
+		t.Errorf("NumberOfSubKeys = %d after CreateKey, want 3", root2.NumberOfSubKeys)
+	}
+	if got, _, _ := h.readSubkeyEntries(root2.SubKeysListOffset); len(got) != 3 {
+		t.Errorf("rebuilt subkey list has %d entries, want 3", len(got))
+	}
+}

--- a/windows/registry/regf/write_key.go
+++ b/windows/registry/regf/write_key.go
@@ -114,7 +114,16 @@ func (h *Hive) CreateKey(parentPath, name string) error {
 	h.writeCellContent(nkOff, nkBytes)
 	h.bumpSKRefCount(parent.SecurityOffset, +1)
 
-	return h.addSubkeyToList(parent, nkOff, name)
+	if err := h.addSubkeyToList(parent, nkOff, name); err != nil {
+		return err
+	}
+	// Stamp both keys and keep the parent's "largest subkey name" hint covering the new key.
+	h.touchKey(parent.offset)
+	h.touchKey(nkOff)
+	pc := baseBlockSize + int(parent.offset) + 4
+	h.growU32(pc+52, uint32(len(name))) // MaxSubKeyNameLength
+	h.dirty = true
+	return nil
 }
 
 // addSubkeyToList inserts a new subkey (offset+name) into the parent's subkey list, keeping
@@ -169,11 +178,14 @@ func (h *Hive) readSubkeyEntries(listOffset uint32) ([]subkeyEntry, uint16, erro
 	}
 	var entries []subkeyEntry
 	for _, off := range list.KeyNodeOffsets() {
-		sub, err := h.readKeyNode(off)
-		if err != nil {
-			continue
+		// Preserve every referenced subkey, even one whose node cannot be read: dropping it
+		// here would silently delete that subkey from the parent when the list is rebuilt.
+		// An unreadable node keeps an empty name (its hint/hash is then approximate).
+		name := ""
+		if sub, err := h.readKeyNode(off); err == nil {
+			name = sub.Name()
 		}
-		entries = append(entries, subkeyEntry{off, sub.Name()})
+		entries = append(entries, subkeyEntry{off, name})
 	}
 	return entries, list.Signature, nil
 }
@@ -223,6 +235,8 @@ func (h *Hive) DeleteKey(parentPath, name string) error {
 		h.freeCell(parent.SubKeysListOffset)
 		binary.LittleEndian.PutUint32(h.data[pc+20:pc+24], 0)
 		binary.LittleEndian.PutUint32(h.data[pc+28:pc+32], nullCellOffset)
+		h.touchKey(parent.offset)
+		h.dirty = true
 		return nil
 	}
 	list := buildSubkeyList(signature, remaining)
@@ -234,6 +248,8 @@ func (h *Hive) DeleteKey(parentPath, name string) error {
 	h.freeCell(parent.SubKeysListOffset)
 	binary.LittleEndian.PutUint32(h.data[pc+20:pc+24], uint32(len(remaining)))
 	binary.LittleEndian.PutUint32(h.data[pc+28:pc+32], lo)
+	h.touchKey(parent.offset)
+	h.dirty = true
 	return nil
 }
 


### PR DESCRIPTION
### Linked Issue
None — write-fidelity improvements from the REGF review (follow-up to write support #711/#712). No behavioral bug; hardens the writer.

### Summary
Three fidelity improvements found while reviewing the REGF write path:

1. **Subkey-list rebuild no longer drops an unreadable subkey.** `readSubkeyEntries` previously `continue`d past any referenced subkey whose node couldn't be parsed, so a `CreateKey`/`DeleteKey` rebuild would silently delete that sibling and leave `NumberOfSubKeys` inconsistent with the list. It now preserves the offset (best-effort empty name).
2. **Mutations maintain key metadata.** `SetValue`/`DeleteValue`/`CreateKey`/`DeleteKey` now stamp the affected key's `LastWrittenTimestamp` (FILETIME), and `SetValue`/`CreateKey` grow the parent NK's "largest name/data" hints (`MaxValueNameLength`, `MaxValueDataSize`, `MaxSubKeyNameLength`) to cover the new item — grow-only, so the hints stay a safe upper bound (Windows uses them to size enumeration buffers).
3. **`Bytes`/`Save` finalize only when mutated.** A new `Hive.dirty` flag gates the base-block rewrite, so opening a hive and serializing it unchanged round-trips **byte-for-byte** instead of bumping the sequence number and rewriting the checksum.

### How Verified
- `go test ./windows/registry/regf/`, `go vet`, full `go build ./...` — clean; no regressions in the existing read/write/recovery/txlog suite.
- New tests: `TestBytesNoOpWhenUnmodified` (identity when unmodified; sequence bumps after a mutation), `TestWriteUpdatesTimestampAndHints` (timestamp set, hints grown), `TestRebuildPreservesUnreadableSubkey` (a list referencing an unparseable subkey keeps all entries through a rebuild; `NumberOfSubKeys` stays consistent).
- **Re-validated with regipy**: a hive mutated after these changes (`Software\Microsoft\AVeryLongValueName="OK"`) reads back identically.

### Test Coverage
**Added:** `write_fidelity_test.go` (3 tests).

### Scope of Change
- **Files changed:** `hive.go` (`dirty` field), `write.go` (`dirty`/`touchKey`/`growU32`, no-op `Bytes`, SetValue/DeleteValue metadata), `write_key.go` (preserve-subkey rebuild, CreateKey/DeleteKey metadata), new `write_fidelity_test.go`.
- **Submodule pointer updated:** no.
- **Behavioral changes outside scope:** none — read paths unchanged.

### Notes
Addresses review items #1–#3. Left as future work (review #4/#5): free-cell coalescing and wide (UTF-16) key/value name writing. Hint-field units are treated as byte counts (over-estimate is safe); exact char/flag semantics are not required since they are optimization hints.
