### PR TITLE
Add NTDS PEK and secret decryption primitives (windows/database/ntds) (#709)

### DIFF
--- a/windows/database/ntds/decrypt.go
+++ b/windows/database/ntds/decrypt.go
@@ -1,0 +1,170 @@
+// Package ntds implements the secret-decryption primitives for offline NTDS.dit
+// (Active Directory database) analysis: decrypting the Password Encryption Key (PEK)
+// list with a SYSTEM boot key, and decrypting the per-account hash blobs stored in
+// NTDS attributes (unicodePwd, dBCSPwd, ntPwdHistory, lmPwdHistory, ...).
+//
+// The decryption matches the reference behaviour of impacket's secretsdump
+// (NTDSHashes): a PEK-keyed outer layer (RC4 or AES depending on the format version)
+// followed by the RID-keyed DES layer of [MS-SAMR] 2.2.11.1. It is independent of how
+// the encrypted bytes are obtained — an offline ESE reader or a remote DRSUAPI reply
+// can both feed these functions.
+//
+// References:
+//   - [MS-SAMR] 2.2.11.1 Encrypting/Decrypting an NT or LM Hash Value
+//   - impacket secretsdump.py NTDSHashes (__removeRC4Layer / __removeDESLayer, PEKLIST_*)
+package ntds
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/des"
+	"crypto/md5"
+	"crypto/rc4"
+	"encoding/binary"
+	"fmt"
+)
+
+// PEK is a 16-byte Password Encryption Key recovered from the pekList attribute.
+type PEK []byte
+
+// transformKey expands a 7-byte key into the 8-byte odd-parity DES key used by the
+// RID-based hash encryption ([MS-SAMR] 2.2.11.1.2 / 5.1.3).
+func transformKey(in []byte) []byte {
+	out := make([]byte, 8)
+	out[0] = in[0] >> 1
+	out[1] = ((in[0] & 0x01) << 6) | (in[1] >> 2)
+	out[2] = ((in[1] & 0x03) << 5) | (in[2] >> 3)
+	out[3] = ((in[2] & 0x07) << 4) | (in[3] >> 4)
+	out[4] = ((in[3] & 0x0F) << 3) | (in[4] >> 5)
+	out[5] = ((in[4] & 0x1F) << 2) | (in[5] >> 6)
+	out[6] = ((in[5] & 0x3F) << 1) | (in[6] >> 7)
+	out[7] = in[6] & 0x7F
+	for i := range out {
+		out[i] = (out[i] << 1) & 0xFE
+	}
+	return out
+}
+
+// deriveDESKeys derives the two DES keys (Key1, Key2) from a RID, per [MS-SAMR]
+// 2.2.11.1.3: the RID is taken little-endian and its bytes reshuffled into two 7-byte
+// keys that transformKey expands.
+func deriveDESKeys(rid uint32) (key1, key2 []byte) {
+	var b [4]byte
+	binary.LittleEndian.PutUint32(b[:], rid)
+	key1 = transformKey([]byte{b[0], b[1], b[2], b[3], b[0], b[1], b[2]})
+	key2 = transformKey([]byte{b[3], b[0], b[1], b[2], b[3], b[0], b[1]})
+	return key1, key2
+}
+
+// removeDESLayer strips the RID-keyed DES layer from a 16-byte hash: the first 8 bytes
+// are DES-decrypted with Key1 and the second 8 with Key2.
+func removeDESLayer(hash []byte, rid uint32) ([]byte, error) {
+	if len(hash) < 16 {
+		return nil, fmt.Errorf("ntds: hash too short for DES layer: %d bytes", len(hash))
+	}
+	key1, key2 := deriveDESKeys(rid)
+	c1, err := des.NewCipher(key1)
+	if err != nil {
+		return nil, fmt.Errorf("ntds: DES key1: %w", err)
+	}
+	c2, err := des.NewCipher(key2)
+	if err != nil {
+		return nil, fmt.Errorf("ntds: DES key2: %w", err)
+	}
+	out := make([]byte, 16)
+	c1.Decrypt(out[0:8], hash[0:8])
+	c2.Decrypt(out[8:16], hash[8:16])
+	return out, nil
+}
+
+// decryptAESCBC decrypts value with key under AES-CBC using iv, zero-padding a trailing
+// partial block (matching impacket's decryptAES). A 16-byte key selects AES-128.
+func decryptAESCBC(key, value, iv []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("ntds: AES key: %w", err)
+	}
+	if len(iv) < aes.BlockSize {
+		return nil, fmt.Errorf("ntds: AES IV too short: %d bytes", len(iv))
+	}
+	data := value
+	if r := len(data) % aes.BlockSize; r != 0 {
+		data = append(append([]byte(nil), data...), make([]byte, aes.BlockSize-r)...)
+	}
+	out := make([]byte, len(data))
+	cipher.NewCBCDecrypter(block, iv[:aes.BlockSize]).CryptBlocks(out, data)
+	return out, nil
+}
+
+// decryptBlob removes the PEK-keyed outer layer of an encrypted attribute blob,
+// returning the inner DES-layered hash bytes (16 for a single hash, a multiple of 16
+// for a history). The blob's header selects the PEK index (byte 4) and the algorithm
+// (byte 0 == 0x13 means AES, otherwise RC4):
+//
+//	[0:8]   Header (Header[0]=algorithm tag, Header[4]=PEK index)
+//	[8:24]  KeyMaterial (RC4 salt, or AES IV)
+//	RC4:    [24:]    EncryptedHash
+//	AES:    [24:28]  Unknown, [28:] EncryptedHash
+func decryptBlob(peks []PEK, blob []byte) ([]byte, error) {
+	if len(blob) < 24 {
+		return nil, fmt.Errorf("ntds: encrypted blob too short: %d bytes", len(blob))
+	}
+	header := blob[0:8]
+	keyMaterial := blob[8:24]
+	idx := int(header[4])
+	if idx < 0 || idx >= len(peks) {
+		return nil, fmt.Errorf("ntds: PEK index %d out of range (have %d)", idx, len(peks))
+	}
+
+	if header[0] == 0x13 {
+		if len(blob) < 28 {
+			return nil, fmt.Errorf("ntds: AES blob too short: %d bytes", len(blob))
+		}
+		return decryptAESCBC(peks[idx], blob[28:], keyMaterial)
+	}
+
+	h := md5.New()
+	h.Write(peks[idx])
+	h.Write(keyMaterial)
+	c, err := rc4.NewCipher(h.Sum(nil))
+	if err != nil {
+		return nil, fmt.Errorf("ntds: RC4 key: %w", err)
+	}
+	enc := blob[24:]
+	out := make([]byte, len(enc))
+	c.XORKeyStream(out, enc)
+	return out, nil
+}
+
+// DecryptHash decrypts a single-hash attribute blob (e.g. unicodePwd / dBCSPwd) using
+// the PEK list and the account's RID, returning the raw 16-byte NT or LM hash. The PEK
+// index is taken from the blob header.
+func DecryptHash(peks []PEK, rid uint32, encrypted []byte) ([]byte, error) {
+	plain, err := decryptBlob(peks, encrypted)
+	if err != nil {
+		return nil, err
+	}
+	if len(plain) < 16 {
+		return nil, fmt.Errorf("ntds: decrypted hash too short: %d bytes", len(plain))
+	}
+	return removeDESLayer(plain[:16], rid)
+}
+
+// DecryptHashHistory decrypts a hash-history attribute blob (ntPwdHistory /
+// lmPwdHistory) using the PEK list and the account's RID, returning the sequence of
+// raw 16-byte hashes (most recent first, as stored).
+func DecryptHashHistory(peks []PEK, rid uint32, encrypted []byte) ([][]byte, error) {
+	plain, err := decryptBlob(peks, encrypted)
+	if err != nil {
+		return nil, err
+	}
+	var out [][]byte
+	for i := 0; i+16 <= len(plain); i += 16 {
+		h, err := removeDESLayer(plain[i:i+16], rid)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, h)
+	}
+	return out, nil
+}

--- a/windows/database/ntds/ntds_test.go
+++ b/windows/database/ntds/ntds_test.go
@@ -1,0 +1,110 @@
+package ntds
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+)
+
+// The vectors below were produced independently in Python (impacket's transformKey +
+// pycryptodome AES/DES/RC4/MD5), so a matching Go result cross-validates the whole
+// decryption chain against impacket's NTDSHashes behaviour. bootKey, PEK, RID and the
+// expected hashes are fixed; see the generator in the PR description.
+const (
+	vecBootKey    = "000102030405060708090a0b0c0d0e0f"
+	vecPEK        = "11111111111111111111111111111111"
+	vecRID        = 500
+	vecNT         = "31d6cfe0d16ae931b73c59d7e0c089c0" // empty password
+	vecNT2        = "8846f7eaee8fb117ad06bdd830b7586c" // "password"
+	vecPekListRC4 = "0200000000000000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa01eb46cbb54c926d566dc36e44e20d3946a3ad276548def414bf2828cd1559a6f5c526b2917ec2e28bc891bb52d9c16b467b20ae"
+	vecPekListAES = "0300000000000000bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbc39afd91d9c08639d2b9ba5164af295fc0c882f4b49f03f76c7a17779d6da072c4e8260f08ecbe541e01bccd19663ef79b246a11b831e98ec6d292f1172b837d"
+	vecHashRC4    = "0000000000000000cccccccccccccccccccccccccccccccc79844a39148e7b88768caac1f96caba6"
+	vecHashAES    = "1300000000000000dddddddddddddddddddddddddddddddd00000000d311e3bdbf0024e051a53759f80e2b71"
+	vecHistRC4    = "0000000000000000eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee21ce6082c5db0c5d0a2d5ec09d7b8478be753ac8ee36b9c66a741f872ca6891e"
+)
+
+func mustHex(t *testing.T, s string) []byte {
+	t.Helper()
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		t.Fatalf("bad hex %q: %v", s, err)
+	}
+	return b
+}
+
+func TestDecryptPEKListRC4(t *testing.T) {
+	peks, err := DecryptPEKList(mustHex(t, vecBootKey), mustHex(t, vecPekListRC4))
+	if err != nil {
+		t.Fatalf("DecryptPEKList: %v", err)
+	}
+	if len(peks) != 1 {
+		t.Fatalf("got %d PEKs, want 1", len(peks))
+	}
+	if hex.EncodeToString(peks[0]) != vecPEK {
+		t.Errorf("PEK = %x, want %s", peks[0], vecPEK)
+	}
+}
+
+func TestDecryptPEKListAES(t *testing.T) {
+	peks, err := DecryptPEKList(mustHex(t, vecBootKey), mustHex(t, vecPekListAES))
+	if err != nil {
+		t.Fatalf("DecryptPEKList: %v", err)
+	}
+	if len(peks) != 1 || hex.EncodeToString(peks[0]) != vecPEK {
+		t.Fatalf("PEKs = %x, want one PEK %s", peks, vecPEK)
+	}
+}
+
+func TestDecryptHashRC4AndAES(t *testing.T) {
+	peks := []PEK{mustHex(t, vecPEK)}
+	for _, tc := range []struct {
+		name, blob string
+	}{
+		{"RC4", vecHashRC4},
+		{"AES", vecHashAES},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := DecryptHash(peks, vecRID, mustHex(t, tc.blob))
+			if err != nil {
+				t.Fatalf("DecryptHash: %v", err)
+			}
+			if hex.EncodeToString(got) != vecNT {
+				t.Errorf("hash = %x, want %s", got, vecNT)
+			}
+		})
+	}
+}
+
+func TestDecryptHashHistory(t *testing.T) {
+	peks := []PEK{mustHex(t, vecPEK)}
+	hist, err := DecryptHashHistory(peks, vecRID, mustHex(t, vecHistRC4))
+	if err != nil {
+		t.Fatalf("DecryptHashHistory: %v", err)
+	}
+	if len(hist) != 2 {
+		t.Fatalf("got %d history entries, want 2", len(hist))
+	}
+	if hex.EncodeToString(hist[0]) != vecNT || hex.EncodeToString(hist[1]) != vecNT2 {
+		t.Errorf("history = [%x %x], want [%s %s]", hist[0], hist[1], vecNT, vecNT2)
+	}
+}
+
+func TestDeriveDESKeysVector(t *testing.T) {
+	// Cross-checked against impacket transformKey for RID 500.
+	k1, k2 := deriveDESKeys(500)
+	if !bytes.Equal(k1, mustHex(t, "f40040000ea00400")) || !bytes.Equal(k2, mustHex(t, "007a00200006d002")) {
+		t.Errorf("RID 500 DES keys = %x / %x, want f40040000ea00400 / 007a00200006d002", k1, k2)
+	}
+}
+
+func TestDecryptErrors(t *testing.T) {
+	if _, err := DecryptPEKList(make([]byte, 8), make([]byte, 64)); err == nil {
+		t.Error("short boot key accepted")
+	}
+	if _, err := DecryptPEKList(make([]byte, 16), []byte{0x99, 0, 0, 0}); err == nil {
+		t.Error("unknown pekList format / short list accepted")
+	}
+	if _, err := DecryptHash([]PEK{mustHex(t, vecPEK)}, 1, make([]byte, 4)); err == nil {
+		t.Error("short blob accepted")
+	}
+}

--- a/windows/database/ntds/pek.go
+++ b/windows/database/ntds/pek.go
@@ -1,0 +1,104 @@
+package ntds
+
+import (
+	"crypto/md5"
+	"crypto/rc4"
+	"encoding/binary"
+	"fmt"
+)
+
+const (
+	// pekListHeaderLen is the size of the encrypted pekList header (8) plus its key
+	// material (16) before the encrypted body.
+	pekListHeaderLen = 24
+	// pekPlainHeaderLen is the fixed header at the start of the decrypted pekList,
+	// before the PEK entries.
+	pekPlainHeaderLen = 32
+	// pekEntryLen is the size of one decrypted PEK entry: a 4-byte prefix (index, or
+	// header+padding) followed by the 16-byte key.
+	pekEntryLen = 20
+	// rc4Rounds is the number of key-material rounds folded into the MD5 derivation of
+	// the RC4 key in the legacy pekList format.
+	rc4Rounds = 1000
+)
+
+// DecryptPEKList decrypts the pekList attribute with the SYSTEM boot key and returns the
+// contained PEKs (usually one). Both on-disk formats are supported, selected by the
+// first header byte:
+//
+//   - 0x02 (up to Windows Server 2012 R2): RC4 keyed by MD5(bootKey + keyMaterial*1000).
+//   - 0x03 (Windows Server 2016+): AES-CBC keyed by bootKey, IV = keyMaterial.
+//
+// bootKey is the 16-byte boot key derived from the SYSTEM hive (the caller supplies it;
+// boot-key derivation is out of scope here).
+func DecryptPEKList(bootKey, pekList []byte) ([]PEK, error) {
+	if len(bootKey) < 16 {
+		return nil, fmt.Errorf("ntds: boot key too short: %d bytes", len(bootKey))
+	}
+	if len(pekList) < pekListHeaderLen {
+		return nil, fmt.Errorf("ntds: pekList too short: %d bytes", len(pekList))
+	}
+	header := pekList[0:8]
+	keyMaterial := pekList[8:24]
+	encrypted := pekList[24:]
+
+	switch header[0] {
+	case 0x02:
+		md := md5.New()
+		md.Write(bootKey[:16])
+		for i := 0; i < rc4Rounds; i++ {
+			md.Write(keyMaterial)
+		}
+		c, err := rc4.NewCipher(md.Sum(nil))
+		if err != nil {
+			return nil, fmt.Errorf("ntds: pekList RC4 key: %w", err)
+		}
+		plain := make([]byte, len(encrypted))
+		c.XORKeyStream(plain, encrypted)
+		return parsePEKListRC4(plain), nil
+
+	case 0x03:
+		plain, err := decryptAESCBC(bootKey[:16], encrypted, keyMaterial)
+		if err != nil {
+			return nil, err
+		}
+		return parsePEKListAES(plain), nil
+
+	default:
+		return nil, fmt.Errorf("ntds: unknown pekList format 0x%02X", header[0])
+	}
+}
+
+// parsePEKListRC4 extracts the PEK keys from a decrypted legacy (RC4) pekList: a 32-byte
+// header followed by fixed 20-byte entries whose last 16 bytes are the key.
+func parsePEKListRC4(plain []byte) []PEK {
+	if len(plain) < pekPlainHeaderLen {
+		return nil
+	}
+	body := plain[pekPlainHeaderLen:]
+	var peks []PEK
+	for off := 0; off+pekEntryLen <= len(body); off += pekEntryLen {
+		peks = append(peks, PEK(append([]byte(nil), body[off+4:off+pekEntryLen]...)))
+	}
+	return peks
+}
+
+// parsePEKListAES extracts the PEK keys from a decrypted AES pekList: a 32-byte header
+// followed by entries of a 4-byte little-endian index and a 16-byte key, in ascending
+// index order; parsing stops at the first non-sequential index (the list terminator).
+func parsePEKListAES(plain []byte) []PEK {
+	if len(plain) < pekPlainHeaderLen {
+		return nil
+	}
+	body := plain[pekPlainHeaderLen:]
+	var peks []PEK
+	want := uint32(0)
+	for off := 0; off+pekEntryLen <= len(body); off += pekEntryLen {
+		if binary.LittleEndian.Uint32(body[off:off+4]) != want {
+			break
+		}
+		peks = append(peks, PEK(append([]byte(nil), body[off+4:off+pekEntryLen]...)))
+		want++
+	}
+	return peks
+}


### PR DESCRIPTION
### Linked Issue
First phase of #709 (offline NTDS.dit support). This delivers the **secret-decryption primitives**; the ESE/JET database reader (phase 2) and the NTDS attribute-access layer (phase 3) follow as separate PRs.

### Motivation
`#709` needs NTDS.dit parsing **and** PEK-based decryption, neither of which existed in Manticore. The decryption layer is self-contained and fully cross-validatable now, so it lands first; it is independent of how the encrypted bytes are obtained (an offline ESE reader or a remote DRSUAPI reply can both feed these functions).

### What this adds (`windows/database/ntds`)
- **`DecryptPEKList(bootKey, pekList)`** — recover the Password Encryption Keys, both on-disk formats selected by header byte:
  - `0x02` (≤ Win2012R2): RC4 keyed by `MD5(bootKey + keyMaterial×1000)`.
  - `0x03` (Win2016+): AES-CBC keyed by `bootKey`, IV = `keyMaterial`.
- **`DecryptHash` / `DecryptHashHistory(peks, rid, encrypted)`** — strip the PEK-keyed outer layer (per-blob: header `0x13` ⇒ AES-CBC, else RC4 keyed by `MD5(PEK+keyMaterial)`), then remove the RID-keyed DES layer ([MS-SAMR] 2.2.11.1) → raw 16-byte NT/LM hashes; history splits into 16-byte entries. PEK index is read from the blob header.
- RID→DES key derivation (`deriveDESKeys`/`transformKey`) and an AES-CBC helper.

Boot-key derivation from the SYSTEM hive is the **caller's** responsibility (out of scope), matching the issue's `DecryptPEKList(bootKey, ...)` API shape.

### How Verified
- `go test ./windows/database/ntds/`, `go vet`, full `go build ./...` — clean.
- **Cross-validated against impacket**: every test vector (PEK list RC4 & AES, single hash RC4 & AES, a two-entry history, and the RID-500 DES key pair) was generated independently in Python with impacket's `transformKey` + pycryptodome AES/DES/RC4/MD5, and the Go implementation recovers the identical PEK / NT hash (`31d6cfe0…` empty-pw and `8846f7ea…` "password").

### Generator (for reproducing the vectors)
Python using `impacket.crypto.transformKey` + pycryptodome: build a `\x02`/`\x03` pekList encrypting a known PEK, and `CRYPTED_HASH`/`CRYPTED_HASHW16`/`CRYPTED_HISTORY` blobs encrypting a DES-layered known NT hash for RID 500; the committed test asserts the Go output matches.

### Test Coverage
**Added:** `ntds_test.go` — PEK list (RC4/AES), hash (RC4/AES), history, DES-key vector, and error paths.

### Scope of Change
- **Files changed:** new `windows/database/ntds/{decrypt.go,pek.go,ntds_test.go}`. No existing files touched.
- **Submodule pointer updated:** no.

### Risk and Rollout
Low: a new leaf package with no importers yet; pure functions, fully unit-tested.

### Notes
**Next:** phase 2 — `windows/database/ese` ESE/JET-Blue reader (DB header, pages, B+-tree, catalog, records, long values), validated by a synthetic `.dit` read back with `impacket.ese`; phase 3 — NTDS attribute access (`ATT*` column map → user objects → these decryptors → `domain\user:rid:lm:nt:::`).
