### PR TITLE
Add offline NTDS.dit account dumping (windows/database/ntds) (#709)

### DIFF
--- a/windows/database/ntds/dump.go
+++ b/windows/database/ntds/dump.go
@@ -1,0 +1,175 @@
+package ntds
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/windows/database/ese"
+)
+
+// NTDS datatable column names. In NTDS.dit each attribute is an ESE column named
+// "ATT<type><id>"; these are the columns needed to recover account secrets.
+const (
+	AttSAMAccountName          = "ATTm590045"
+	AttObjectSid               = "ATTr589970"
+	AttUserAccountControl      = "ATTj589832"
+	AttUnicodePwd              = "ATTk589914" // NT hash
+	AttDBCSPwd                 = "ATTk589879" // LM hash
+	AttNTPwdHistory            = "ATTk589918"
+	AttLMPwdHistory            = "ATTk589984"
+	AttPEKList                 = "ATTk590689"
+	AttUserPrincipalName       = "ATTm590480"
+	AttSupplementalCredentials = "ATTk589949"
+)
+
+// uacAccountDisable is the ADS_UF_ACCOUNTDISABLE bit of userAccountControl.
+const uacAccountDisable = 0x0002
+
+func hexBytes(s string) []byte { b, _ := hex.DecodeString(s); return b }
+
+// Empty-password hashes, used when an account has no stored NT/LM hash (matching
+// impacket's NTOWFv1(”,”) / LMOWFv1(”,”)).
+var (
+	emptyNTHash = hexBytes("31d6cfe0d16ae931b73c59d7e0c089c0")
+	emptyLMHash = hexBytes("aad3b435b51404eeaad3b435b51404ee")
+)
+
+// Account is one decrypted NTDS account.
+type Account struct {
+	SAMAccountName     string
+	RID                uint32
+	LMHash             []byte // 16 bytes
+	NTHash             []byte // 16 bytes
+	LMHistory          [][]byte
+	NTHistory          [][]byte
+	UserAccountControl uint32
+	HasUAC             bool
+}
+
+// Disabled reports whether the account's userAccountControl marks it disabled.
+func (a *Account) Disabled() bool {
+	return a.HasUAC && a.UserAccountControl&uacAccountDisable != 0
+}
+
+// SecretsdumpLine formats the account as the secretsdump line "user:rid:lm:nt:::".
+func (a *Account) SecretsdumpLine() string {
+	return fmt.Sprintf("%s:%d:%s:%s:::", a.SAMAccountName, a.RID,
+		hex.EncodeToString(a.LMHash), hex.EncodeToString(a.NTHash))
+}
+
+// HistoryLines formats the account's password-history entries as secretsdump
+// "user_historyN:rid:lm:nt:::" lines, skipping the current password (index 0).
+func (a *Account) HistoryLines() []string {
+	var lines []string
+	n := len(a.NTHistory)
+	if len(a.LMHistory) > n {
+		n = len(a.LMHistory)
+	}
+	for i := 1; i < n; i++ {
+		lm, nt := emptyLMHash, emptyNTHash
+		if i < len(a.LMHistory) {
+			lm = a.LMHistory[i]
+		}
+		if i < len(a.NTHistory) {
+			nt = a.NTHistory[i]
+		}
+		lines = append(lines, fmt.Sprintf("%s_history%d:%d:%s:%s:::", a.SAMAccountName, i-1, a.RID,
+			hex.EncodeToString(lm), hex.EncodeToString(nt)))
+	}
+	return lines
+}
+
+// ridFromSID extracts the RID (last sub-authority) from a binary objectSid.
+func ridFromSID(sid []byte) uint32 {
+	if len(sid) < 4 {
+		return 0
+	}
+	return binary.LittleEndian.Uint32(sid[len(sid)-4:])
+}
+
+// FindPEKList scans the datatable for the pekList attribute and decrypts it with bootKey.
+func FindPEKList(table *ese.Table, bootKey []byte) ([]PEK, error) {
+	cur, err := table.Rows()
+	if err != nil {
+		return nil, err
+	}
+	for cur.Next() {
+		if blob, ok := cur.Row().Raw(AttPEKList); ok {
+			return DecryptPEKList(bootKey, blob)
+		}
+	}
+	if err := cur.Err(); err != nil {
+		return nil, err
+	}
+	return nil, fmt.Errorf("ntds: pekList attribute not found in datatable")
+}
+
+// Dump iterates the datatable of an opened NTDS database, decrypts each user account's
+// secrets with the PEK list (recovered from bootKey), and invokes fn for every account
+// that has a sAMAccountName and objectSid. bootKey is the 16-byte SYSTEM boot key (the
+// caller derives it).
+func Dump(db *ese.Database, bootKey []byte, fn func(Account) error) error {
+	table, err := db.Table("datatable")
+	if err != nil {
+		return err
+	}
+	peks, err := FindPEKList(table, bootKey)
+	if err != nil {
+		return err
+	}
+
+	cur, err := table.Rows()
+	if err != nil {
+		return err
+	}
+	for cur.Next() {
+		row := cur.Row()
+		sid, ok := row.Raw(AttObjectSid)
+		if !ok {
+			continue
+		}
+		sam, ok := row.String(AttSAMAccountName)
+		if !ok || sam == "" {
+			continue
+		}
+		acct := decryptAccount(peks, row, sid, sam)
+		if err := fn(acct); err != nil {
+			return err
+		}
+	}
+	return cur.Err()
+}
+
+// decryptAccount builds an Account from a datatable row, decrypting its hash attributes.
+// Missing hashes default to the empty-password hash.
+func decryptAccount(peks []PEK, row *ese.Row, sid []byte, sam string) Account {
+	rid := ridFromSID(sid)
+	acct := Account{SAMAccountName: sam, RID: rid, NTHash: emptyNTHash, LMHash: emptyLMHash}
+
+	if blob, ok := row.Raw(AttUnicodePwd); ok {
+		if h, err := DecryptHash(peks, rid, blob); err == nil {
+			acct.NTHash = h
+		}
+	}
+	if blob, ok := row.Raw(AttDBCSPwd); ok {
+		if h, err := DecryptHash(peks, rid, blob); err == nil {
+			acct.LMHash = h
+		}
+	}
+	if uac, ok := row.Uint32(AttUserAccountControl); ok {
+		acct.UserAccountControl = uac
+		acct.HasUAC = true
+	}
+	if blob, ok := row.Raw(AttNTPwdHistory); ok {
+		if h, err := DecryptHashHistory(peks, rid, blob); err == nil {
+			acct.NTHistory = h
+		}
+	}
+	if blob, ok := row.Raw(AttLMPwdHistory); ok {
+		if h, err := DecryptHashHistory(peks, rid, blob); err == nil {
+			acct.LMHistory = h
+		}
+	}
+	return acct
+}

--- a/windows/database/ntds/dump_test.go
+++ b/windows/database/ntds/dump_test.go
@@ -1,0 +1,204 @@
+package ntds
+
+import (
+	"encoding/binary"
+	"sort"
+	"testing"
+	"unicode/utf16"
+
+	"github.com/TheManticoreProject/Manticore/windows/database/ese"
+)
+
+// This test builds a synthetic NTDS datatable (an ESE database) carrying a pekList and a
+// user object whose unicodePwd/dBCSPwd were encrypted with impacket-generated vectors,
+// then runs Dump end-to-end (ESE read -> attribute access -> PEK/hash decryption). The
+// blobs come from the same Python (impacket + pycryptodome) generator as the crypto
+// tests, so a correct result validates the whole offline pipeline.
+const (
+	dvBootKey  = "000102030405060708090a0b0c0d0e0f"
+	dvPekList  = "0200000000000000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa01eb46cbb54c926d566dc36e44e20d3946a3ad276548def414bf2828cd1559a6f5c526b2917ec2e28bc891bb52d9c16b467b20ae"
+	dvEncNT    = "0000000000000000c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c15222e8fd0bc1751323e9fc9768131b24"
+	dvEncLM    = "0000000000000000c2c2c2c2c2c2c2c2c2c2c2c2c2c2c2c235a006c017bb3f114adcda25a2f8256c"
+	dvSID      = "010500000000000515000000010000000200000003000000e8030000"
+	dvExpectNT = "8846f7eaee8fb117ad06bdd830b7586c"
+	dvExpectLM = "e52cac67419a9a224a3b108f3fa6cb6d"
+	dvRID      = 1000
+)
+
+// --- minimal ESE assembler (all-tagged datatable) ---
+
+const (
+	edbSig       = 0x89ABCDEF
+	edbPageSize  = 8192
+	flagRootLeaf = 0x01 | 0x02
+	catTypeTable = 1
+	catTypeCol   = 2
+	colTypeLong  = 4
+	colTypeBin   = 9
+	colTypeText  = 12
+	cpUnicode    = 1200
+	ddhSize      = 4
+)
+
+func u16(v int) []byte    { b := make([]byte, 2); binary.LittleEndian.PutUint16(b, uint16(v)); return b }
+func u32(v uint32) []byte { b := make([]byte, 4); binary.LittleEndian.PutUint32(b, v); return b }
+func utf16b(s string) []byte {
+	u := utf16.Encode([]rune(s))
+	b := make([]byte, len(u)*2)
+	for i, c := range u {
+		binary.LittleEndian.PutUint16(b[i*2:], c)
+	}
+	return b
+}
+func leafEntry(data []byte) []byte { return append(u16(0), data...) }
+
+func catEntry(fixed []byte, name string) []byte {
+	out := append([]byte{7, 128}, u16(ddhSize+len(fixed))...) // lastFixed,lastVar=128,varSizeOffset
+	out = append(out, fixed...)
+	out = append(out, u16(len(name))...)
+	return append(out, []byte(name)...)
+}
+func catTable(objid, dataPage uint32, name string) []byte {
+	f := append(u32(objid), u16(catTypeTable)...)
+	f = append(f, u32(objid)...)
+	f = append(f, u32(dataPage)...)
+	f = append(f, u32(0)...)
+	return catEntry(f, name)
+}
+func catColumn(objid, id, colType, codePage uint32, name string) []byte {
+	f := append(u32(objid), u16(catTypeCol)...)
+	f = append(f, u32(id)...)
+	f = append(f, u32(colType)...)
+	f = append(f, u32(0)...) // SpaceUsage
+	f = append(f, u32(0)...) // ColumnFlags
+	f = append(f, u32(codePage)...)
+	return catEntry(f, name)
+}
+
+// taggedRecord builds an all-tagged data record (no fixed/variable columns).
+func taggedRecord(cols map[uint32][]byte) []byte {
+	ids := make([]int, 0, len(cols))
+	for id := range cols {
+		ids = append(ids, int(id))
+	}
+	sort.Ints(ids)
+	arraySize := len(ids) * 4
+	var arr, vals []byte
+	off := arraySize
+	for _, id := range ids {
+		v := cols[uint32(id)]
+		arr = append(arr, u16(id)...)
+		arr = append(arr, u16(off)...) // flags clear
+		vals = append(vals, v...)
+		off += len(v)
+	}
+	rec := append([]byte{0, 127}, u16(ddhSize)...) // lastFixed=0,lastVar=127,varSizeOffset=4
+	rec = append(rec, arr...)
+	return append(rec, vals...)
+}
+
+func buildPage(pageFlags, nextPage uint32, records [][]byte) []byte {
+	page := make([]byte, edbPageSize)
+	const common, headerLen = 8, 40
+	binary.LittleEndian.PutUint32(page[common+12:], nextPage)
+	binary.LittleEndian.PutUint16(page[common+26:], uint16(len(records)+1))
+	binary.LittleEndian.PutUint32(page[common+28:], pageFlags)
+	put := func(i, size, voff int) {
+		pos := edbPageSize - 4*(i+1)
+		binary.LittleEndian.PutUint16(page[pos:], uint16(size&0x1fff))
+		binary.LittleEndian.PutUint16(page[pos+2:], uint16(voff&0x1fff))
+	}
+	put(0, 0, 0)
+	o := headerLen
+	for i, r := range records {
+		copy(page[o:], r)
+		put(i+1, len(r), o-headerLen)
+		o += len(r)
+	}
+	return page
+}
+
+func buildNTDSDIT(t *testing.T) []byte {
+	hdr := make([]byte, edbPageSize)
+	binary.LittleEndian.PutUint32(hdr[4:], edbSig)
+	binary.LittleEndian.PutUint32(hdr[8:], 0x620)
+	binary.LittleEndian.PutUint32(hdr[232:], 0x11)
+	binary.LittleEndian.PutUint32(hdr[236:], edbPageSize)
+
+	catalog := buildPage(flagRootLeaf, 0, [][]byte{
+		leafEntry(catTable(16, 5, "datatable")),
+		leafEntry(catColumn(16, 256, colTypeBin, 0, AttPEKList)),
+		leafEntry(catColumn(16, 257, colTypeText, cpUnicode, AttSAMAccountName)),
+		leafEntry(catColumn(16, 258, colTypeBin, 0, AttObjectSid)),
+		leafEntry(catColumn(16, 259, colTypeBin, 0, AttUnicodePwd)),
+		leafEntry(catColumn(16, 260, colTypeBin, 0, AttDBCSPwd)),
+		leafEntry(catColumn(16, 261, colTypeLong, 0, AttUserAccountControl)),
+	})
+	data := buildPage(flagRootLeaf, 0, [][]byte{
+		leafEntry(taggedRecord(map[uint32][]byte{256: hexBytes(dvPekList)})), // pek holder, no sAMAccountName
+		leafEntry(taggedRecord(map[uint32][]byte{
+			257: utf16b("Administrator"),
+			258: hexBytes(dvSID),
+			259: hexBytes(dvEncNT),
+			260: hexBytes(dvEncLM),
+			261: u32(0x200), // userAccountControl: normal account (enabled)
+		})),
+	})
+
+	out := append([]byte(nil), hdr...)
+	for i := 0; i < 4; i++ {
+		out = append(out, make([]byte, edbPageSize)...)
+	}
+	out = append(out, catalog...)
+	return append(out, data...)
+}
+
+func TestDumpNTDS(t *testing.T) {
+	db, err := ese.OpenBytes(buildNTDSDIT(t))
+	if err != nil {
+		t.Fatalf("ese.OpenBytes: %v", err)
+	}
+	defer db.Close()
+
+	var accounts []Account
+	if err := Dump(db, hexBytes(dvBootKey), func(a Account) error {
+		accounts = append(accounts, a)
+		return nil
+	}); err != nil {
+		t.Fatalf("Dump: %v", err)
+	}
+
+	if len(accounts) != 1 {
+		t.Fatalf("got %d accounts, want 1 (pek-holder row must be skipped)", len(accounts))
+	}
+	a := accounts[0]
+	if a.SAMAccountName != "Administrator" {
+		t.Errorf("sAMAccountName = %q, want Administrator", a.SAMAccountName)
+	}
+	if a.RID != dvRID {
+		t.Errorf("RID = %d, want %d", a.RID, dvRID)
+	}
+	if got := hexString(a.NTHash); got != dvExpectNT {
+		t.Errorf("NT hash = %s, want %s", got, dvExpectNT)
+	}
+	if got := hexString(a.LMHash); got != dvExpectLM {
+		t.Errorf("LM hash = %s, want %s", got, dvExpectLM)
+	}
+	if a.Disabled() {
+		t.Error("account reported disabled, want enabled (uac=0x200)")
+	}
+	want := "Administrator:1000:" + dvExpectLM + ":" + dvExpectNT + ":::"
+	if got := a.SecretsdumpLine(); got != want {
+		t.Errorf("SecretsdumpLine = %q, want %q", got, want)
+	}
+}
+
+func hexString(b []byte) string {
+	const hexdigits = "0123456789abcdef"
+	out := make([]byte, len(b)*2)
+	for i, c := range b {
+		out[i*2] = hexdigits[c>>4]
+		out[i*2+1] = hexdigits[c&0xf]
+	}
+	return string(out)
+}


### PR DESCRIPTION
### Linked Issue
`Closes #709`. Phase 3 (final) of offline NTDS.dit support — phases 1 (PEK/secret decryption, #718) and 2 (ESE reader, #719) are merged.

### Motivation
With the ESE reader and the PEK/secret decryptors in place, this ties them together: read an NTDS.dit datatable and recover per-account NT/LM hashes — the support #709 tracks for the downstream `DumpSecrets` local-ntds collector.

### What this adds (`windows/database/ntds`)
- **Attribute column names** (`ATT<type><id>`) for pekList, sAMAccountName, objectSid, userAccountControl, unicodePwd (NT), dBCSPwd (LM), and the history attributes.
- **`FindPEKList(table, bootKey)`** — scan the datatable for the pekList attribute and decrypt it (phase-1 `DecryptPEKList`).
- **`Dump(db, bootKey, fn)`** — iterate the datatable; for each object with a sAMAccountName + objectSid, derive the RID from the SID, decrypt `unicodePwd`/`dBCSPwd` (and history) via the phase-1 decryptors, and invoke `fn` with an `Account`. Missing hashes default to the empty-password hash (matching impacket).
- **`Account`** — names/RID/NT/LM (+history), `userAccountControl` with `Disabled()`, and `SecretsdumpLine()` / `HistoryLines()` emitting the `user:rid:lm:nt:::` / `user_historyN:...` secretsdump format.

The caller supplies the 16-byte SYSTEM boot key (boot-key derivation remains out of scope, per the issue's API).

### How Verified
- `go test ./windows/database/...`, `go vet`, full `go build ./...` — clean.
- **End-to-end, impacket-cross-validated**: the test builds a synthetic NTDS datatable (a pekList-holder row + a user object whose `unicodePwd`/`dBCSPwd` were encrypted with impacket-generated vectors), opens it through the phase-2 ESE reader, and runs `Dump`, recovering `Administrator`, RID `1000`, NT hash `8846f7ea…` ("password"), the LM hash, enabled status, and the exact secretsdump line. The same synthetic `.dit` is also confirmed well-formed by `impacket.ese` (catalog + both rows parse identically).

### Test Coverage
**Added:** `dump_test.go` — a minimal NTDS-datatable ESE assembler + the full `Dump` pipeline assertions.

### Scope of Change
- **Files changed:** new `windows/database/ntds/{dump.go,dump_test.go}`. No existing files touched.
- **Submodule pointer updated:** no.

### Risk and Rollout
Low: additive; read-only; no importers in-tree yet.

### Notes
With #718 + #719 + this, Manticore has the full offline NTDS.dit pipeline (ESE parsing + PEK/secret decryption + account dumping), closing #709. Known limitations carried from phase 2: ESE long-value separate-tree reassembly is not implemented (NTDS NT/LM/history are inline tagged data and unaffected; very large attributes such as `supplementalCredentials` would need it). The objectSid→RID extraction assumes the standard SID byte order; worth a confirming pass against a real `.dit` when one is available.
