### PR TITLE
Fix NTDS RID byte order and filter to real accounts (#721)

### DIFF
--- a/windows/database/ntds/dump.go
+++ b/windows/database/ntds/dump.go
@@ -12,6 +12,7 @@ import (
 // "ATT<type><id>"; these are the columns needed to recover account secrets.
 const (
 	AttSAMAccountName          = "ATTm590045"
+	AttSAMAccountType          = "ATTj590126"
 	AttObjectSid               = "ATTr589970"
 	AttUserAccountControl      = "ATTj589832"
 	AttUnicodePwd              = "ATTk589914" // NT hash
@@ -25,6 +26,18 @@ const (
 
 // uacAccountDisable is the ADS_UF_ACCOUNTDISABLE bit of userAccountControl.
 const uacAccountDisable = 0x0002
+
+// sAMAccountType values that identify a security principal carrying password material
+// (user / machine / trust). Group and alias objects have other values and are skipped.
+const (
+	samNormalUserAccount = 0x30000000
+	samMachineAccount    = 0x30000001
+	samTrustAccount      = 0x30000002
+)
+
+func isAccountType(t uint32) bool {
+	return t == samNormalUserAccount || t == samMachineAccount || t == samTrustAccount
+}
 
 func hexBytes(s string) []byte { b, _ := hex.DecodeString(s); return b }
 
@@ -80,12 +93,14 @@ func (a *Account) HistoryLines() []string {
 	return lines
 }
 
-// ridFromSID extracts the RID (last sub-authority) from a binary objectSid.
+// ridFromSID extracts the RID (last sub-authority) from a binary objectSid. NTDS stores
+// the objectSid with its sub-authorities big-endian, so the RID is the big-endian uint32
+// of the final four bytes.
 func ridFromSID(sid []byte) uint32 {
 	if len(sid) < 4 {
 		return 0
 	}
-	return binary.LittleEndian.Uint32(sid[len(sid)-4:])
+	return binary.BigEndian.Uint32(sid[len(sid)-4:])
 }
 
 // FindPEKList scans the datatable for the pekList attribute and decrypts it with bootKey.
@@ -125,6 +140,12 @@ func Dump(db *ese.Database, bootKey []byte, fn func(Account) error) error {
 	}
 	for cur.Next() {
 		row := cur.Row()
+		// Only objects that are security principals with password material (user /
+		// machine / trust accounts); skip groups, aliases, and other objects.
+		accountType, ok := row.Uint32(AttSAMAccountType)
+		if !ok || !isAccountType(accountType) {
+			continue
+		}
 		sid, ok := row.Raw(AttObjectSid)
 		if !ok {
 			continue

--- a/windows/database/ntds/dump_test.go
+++ b/windows/database/ntds/dump_test.go
@@ -19,7 +19,7 @@ const (
 	dvPekList  = "0200000000000000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa01eb46cbb54c926d566dc36e44e20d3946a3ad276548def414bf2828cd1559a6f5c526b2917ec2e28bc891bb52d9c16b467b20ae"
 	dvEncNT    = "0000000000000000c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c15222e8fd0bc1751323e9fc9768131b24"
 	dvEncLM    = "0000000000000000c2c2c2c2c2c2c2c2c2c2c2c2c2c2c2c235a006c017bb3f114adcda25a2f8256c"
-	dvSID      = "010500000000000515000000010000000200000003000000e8030000"
+	dvSID      = "010500000000000515000000010000000200000003000000000003e8" // RID 1000, big-endian (NTDS storage)
 	dvExpectNT = "8846f7eaee8fb117ad06bdd830b7586c"
 	dvExpectLM = "e52cac67419a9a224a3b108f3fa6cb6d"
 	dvRID      = 1000
@@ -133,6 +133,7 @@ func buildNTDSDIT(t *testing.T) []byte {
 		leafEntry(catColumn(16, 259, colTypeBin, 0, AttUnicodePwd)),
 		leafEntry(catColumn(16, 260, colTypeBin, 0, AttDBCSPwd)),
 		leafEntry(catColumn(16, 261, colTypeLong, 0, AttUserAccountControl)),
+		leafEntry(catColumn(16, 262, colTypeLong, 0, AttSAMAccountType)),
 	})
 	data := buildPage(flagRootLeaf, 0, [][]byte{
 		leafEntry(taggedRecord(map[uint32][]byte{256: hexBytes(dvPekList)})), // pek holder, no sAMAccountName
@@ -141,7 +142,8 @@ func buildNTDSDIT(t *testing.T) []byte {
 			258: hexBytes(dvSID),
 			259: hexBytes(dvEncNT),
 			260: hexBytes(dvEncLM),
-			261: u32(0x200), // userAccountControl: normal account (enabled)
+			261: u32(0x200),      // userAccountControl: normal account (enabled)
+			262: u32(0x30000000), // sAMAccountType: SAM_NORMAL_USER_ACCOUNT
 		})),
 	})
 


### PR DESCRIPTION
### Linked Issue
`Closes #721`

### Root Cause
Found by validating `windows/database/ntds` against a real Windows Server 2016 NTDS.dit (the offline path #709 added):
1. **RID byte order** — `ridFromSID` read the objectSid's last sub-authority little-endian, but NTDS stores objectSid sub-authorities **big-endian**. The RID came out byte-swapped (e.g. `4093706240` instead of `500`); because the RID keys the [MS-SAMR] 2.2.11.1 DES layer, every decrypted hash was wrong too.
2. **Account filter** — `Dump` emitted any object with a sAMAccountName + objectSid, which includes groups/aliases (they have both), producing 54 entries.

### Fix Description
1. Read the RID as the **big-endian** uint32 of the objectSid's last four bytes.
2. Filter on **`sAMAccountType`** (`ATTj590126`) being a user/machine/trust account (`0x30000000`/`1`/`2`), matching impacket secretsdump's `ACCOUNT_TYPES`.

### How Verified
- **Live NTDS.dit (Windows Server 2016)**: a real `ntds.dit` + SYSTEM hive were retrieved from a lab DC. With the boot key from the SYSTEM hive, `Dump` now produces output **byte-identical to impacket secretsdump** for every account:
  ```
  Administrator:500:aad3b435b51404eeaad3b435b51404ee:520126a03f5d5a8d836f1c4f34ede7ce:::
  Guest:501:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0:::
  DefaultAccount:503:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0:::
  TMP-W-2016$:1000:aad3b435b51404eeaad3b435b51404ee:3793e8fa4ef8c67b3690bc18f6aa251c:::
  krbtgt:502:aad3b435b51404eeaad3b435b51404ee:ecc88b9ec0249e3effe4173a389d2e82:::
  ```
  5 accounts (was 54). Before the fix: `Administrator:4093706240:...:99298ccb...` (wrong RID and hash).
- `go test ./windows/database/...`, `go vet`, full `go build ./...` — clean.

### Test Coverage
**Existing, updated:** `TestDumpNTDS` now carries a big-endian RID in its synthetic objectSid and a `sAMAccountType`, exercising both fixes; still passes.

### Scope of Change
- **Files changed:** `windows/database/ntds/dump.go` (ridFromSID big-endian, sAMAccountType filter + `AttSAMAccountType`), `dump_test.go` (fixture updated).
- **Submodule pointer updated:** no.
- **Behavioral changes outside the bug fix:** none.

### Risk and Rollout
Low and corrective: the only consumers are new (this package); the change makes output correct and impacket-equivalent.

### Notes
This resolves the "objectSid→RID byte order" caveat noted when #709 merged — now confirmed against a live `.dit`. ESE long-value reassembly remains the one open limitation (does not affect NT/LM/history, which are inline tagged data).
