### PR TITLE
Add ESE long-value (LV) reassembly (windows/database/ese)

### DIFF
--- a/windows/database/ese/catalog.go
+++ b/windows/database/ese/catalog.go
@@ -91,7 +91,13 @@ func (d *Database) addCatalogEntry(payload []byte) {
 		t.columnByID[c.ID] = c
 		t.columnByName[c.Name] = c
 
-	case catalogTypeIndex, catalogTypeLongValue:
+	case catalogTypeLongValue:
+		// The long-value B-tree root (same fixed layout as a table entry).
+		if d.currentTable != nil && len(fixed) >= 14 {
+			d.currentTable.longValuePage = binary.LittleEndian.Uint32(fixed[10:14])
+		}
+
+	case catalogTypeIndex:
 		// Not needed for row reading.
 	}
 }

--- a/windows/database/ese/ese.go
+++ b/windows/database/ese/ese.go
@@ -45,6 +45,7 @@ const (
 
 	// Tagged data type flags.
 	taggedCompressed = 0x02
+	taggedLongValue  = 0x04 // value is a long-value identifier (data lives in the LV tree)
 	taggedMultiValue = 0x08
 )
 
@@ -101,10 +102,14 @@ type Column struct {
 type Table struct {
 	Name           string
 	fatherDataPage uint32
+	longValuePage  uint32 // root of the table's long-value B-tree (0 if none)
 	columns        []*Column
 	columnByID     map[uint32]*Column
 	columnByName   map[string]*Column
 	db             *Database
+
+	lvLeaves []lvEntry // cached leaf entries of the long-value tree (lazy)
+	lvLoaded bool
 }
 
 // Columns returns the table's columns in catalog order.

--- a/windows/database/ese/ese_test.go
+++ b/windows/database/ese/ese_test.go
@@ -232,3 +232,112 @@ func TestESEReadSample(t *testing.T) {
 		t.Errorf("read %d rows, want 2", n)
 	}
 }
+
+// --- long-value (LV) fixture ---
+
+// catalogLongValue builds a CATALOG_TYPE_LONG_VALUE data definition pointing at the
+// table's long-value B-tree root page.
+func catalogLongValue(objid, lvPage uint32, name string) []byte {
+	var fixed []byte
+	fixed = append(fixed, u32le(objid)...) // FatherDataPageID (table objid)
+	fixed = append(fixed, u16le(catalogTypeLongValue)...)
+	fixed = append(fixed, u32le(objid+1)...) // Identifier
+	fixed = append(fixed, u32le(lvPage)...)  // FatherDataPageNumber (LV tree root)
+	fixed = append(fixed, u32le(0)...)       // SpaceUsage
+	return catalogEntry(fixed, name)
+}
+
+// lvRefRecord builds a datatable row: a fixed Long column and a tagged column (256) that
+// is a long-value reference (flag 0x04) carrying the 4-byte little-endian LID.
+func lvRefRecord(fixedNum uint32, lidLE []byte) []byte {
+	ddh := []byte{1, 127}          // LastFixedSize=1, LastVariableDataType=127 (no variable)
+	ddh = append(ddh, u16le(8)...) // VariableSizeOffset = 4 (ddh) + 4 (fixed) = 8 -> taggedBase
+	out := append([]byte(nil), ddh...)
+	out = append(out, u32le(fixedNum)...) // fixed col 1
+	// tagged array: one entry (id 256), offset 4 (after the 4-byte array), flag bit set.
+	out = append(out, u16le(256)...)
+	out = append(out, u16le(4|0x4000)...) // 0x4000 => per-item flag byte present
+	out = append(out, 0x04)               // tagged flag: long value
+	out = append(out, lidLE...)           // the long-value identifier
+	return out
+}
+
+// lvLeafKV builds one long-value B-tree leaf entry (explicit local key, no common key).
+func lvLeafKV(key, data []byte) []byte {
+	out := append(u16le(len(key)), key...)
+	return append(out, data...)
+}
+
+func bigBlob(n int) []byte {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte(i % 256)
+	}
+	return b
+}
+
+// buildLVSampleEDB builds a database whose single datatable row stores a 600-byte value as
+// a long value split across two segments (offsets 0 and 400) in the long-value tree.
+func buildLVSampleEDB() ([]byte, []byte) {
+	header := make([]byte, edbPageSize)
+	binary.LittleEndian.PutUint32(header[4:], eseSignature)
+	binary.LittleEndian.PutUint32(header[8:], 0x620)
+	binary.LittleEndian.PutUint32(header[232:], 0x11)
+	binary.LittleEndian.PutUint32(header[236:], edbPageSize)
+
+	catalog := buildPage(flagRoot|flagLeaf, 0, [][]byte{
+		leaf(catalogTable(16, 5, "datatable")),
+		leaf(catalogColumn(16, 1, JetColtypLong, 4, 0, "FixedNum")),
+		leaf(catalogColumn(16, 256, JetColtypLongBinary, 0, 0, "BigBlob")),
+		leaf(catalogLongValue(16, 6, "LV")), // long-value tree at page 6
+	})
+	data := buildPage(flagRoot|flagLeaf, 0, [][]byte{
+		leaf(lvRefRecord(2000, []byte{0x01, 0x00, 0x00, 0x00})), // LID 1
+	})
+
+	blob := bigBlob(600)
+	pageKey := []byte{0x00, 0x00, 0x00, 0x01} // LID reversed
+	segKey := func(off uint32) []byte {
+		b := make([]byte, 4)
+		binary.BigEndian.PutUint32(b, off)
+		return append(append([]byte(nil), pageKey...), b...)
+	}
+	lv := buildPage(flagRoot|flagLeaf|flagLongValue, 0, [][]byte{
+		lvLeafKV(pageKey, u32le(uint32(len(blob)))), // header: total size
+		lvLeafKV(segKey(0), blob[:400]),
+		lvLeafKV(segKey(400), blob[400:]),
+	})
+
+	out := append([]byte(nil), header...)
+	for i := 0; i < 4; i++ {
+		out = append(out, make([]byte, edbPageSize)...)
+	}
+	out = append(out, catalog...) // page 4
+	out = append(out, data...)    // page 5
+	out = append(out, lv...)      // page 6
+	return out, blob
+}
+
+func TestESELongValue(t *testing.T) {
+	image, want := buildLVSampleEDB()
+	db, err := OpenBytes(image)
+	if err != nil {
+		t.Fatalf("OpenBytes: %v", err)
+	}
+	defer db.Close()
+	tbl, _ := db.Table("datatable")
+	cur, err := tbl.Rows()
+	if err != nil {
+		t.Fatalf("Rows: %v", err)
+	}
+	if !cur.Next() {
+		t.Fatalf("no rows (err=%v)", cur.Err())
+	}
+	got, ok := cur.Row().Raw("BigBlob")
+	if !ok {
+		t.Fatal("BigBlob not present")
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("BigBlob reassembled to %d bytes, want %d (equal=%v)", len(got), len(want), bytes.Equal(got, want))
+	}
+}

--- a/windows/database/ese/longvalue.go
+++ b/windows/database/ese/longvalue.go
@@ -1,0 +1,137 @@
+package ese
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+)
+
+// lvEntry is one reconstructed leaf entry of a long-value B-tree: its full key and value.
+type lvEntry struct {
+	key  []byte
+	data []byte
+}
+
+// parseEntry splits a leaf/branch entry into its full key and trailing payload. When the
+// entry carries a common-key-size prefix (TAG_COMMON), the page's common key (its tag 0
+// value) supplies the shared key prefix.
+func parseEntry(flags uint8, data, commonKey []byte) (key, payload []byte, err error) {
+	off := 0
+	commonSize := 0
+	if flags&tagCommon != 0 {
+		if len(data) < 2 {
+			return nil, nil, fmt.Errorf("ese: entry too short for common key size")
+		}
+		commonSize = int(binary.LittleEndian.Uint16(data[0:2]))
+		off += 2
+	}
+	if len(data) < off+2 {
+		return nil, nil, fmt.Errorf("ese: entry too short for local key size")
+	}
+	localSize := int(binary.LittleEndian.Uint16(data[off : off+2]))
+	off += 2
+	if off+localSize > len(data) {
+		return nil, nil, fmt.Errorf("ese: entry local key runs past end")
+	}
+	localKey := data[off : off+localSize]
+	off += localSize
+	if commonSize > len(commonKey) {
+		commonSize = len(commonKey)
+	}
+	key = append(append([]byte(nil), commonKey[:commonSize]...), localKey...)
+	return key, data[off:], nil
+}
+
+// loadLongValueLeaves walks the table's long-value B-tree once and caches every leaf
+// entry (key + data) for subsequent reassembly lookups.
+func (t *Table) loadLongValueLeaves() {
+	if t.lvLoaded {
+		return
+	}
+	t.lvLoaded = true
+	if t.longValuePage == 0 || t.longValuePage == nullCellPage {
+		return
+	}
+	t.db.walkLongValueTree(t.longValuePage, 0, &t.lvLeaves)
+}
+
+// nullCellPage is the sentinel for "no page".
+const nullCellPage = 0xFFFFFFFF
+
+// walkLongValueTree recursively collects the leaf entries of a B-tree rooted at pageNum.
+func (d *Database) walkLongValueTree(pageNum uint32, depth int, out *[]lvEntry) {
+	if depth > maxCatalogDepth {
+		return
+	}
+	p, err := d.getPage(pageNum)
+	if err != nil {
+		return
+	}
+	var commonKey []byte
+	if p.firstAvailablePageTag > 0 {
+		if _, v, err := p.getTag(0); err == nil {
+			commonKey = v // page external header = common page key
+		}
+	}
+	for i := 1; i < int(p.firstAvailablePageTag); i++ {
+		flags, data, err := p.getTag(i)
+		if err != nil {
+			continue
+		}
+		if p.isLeaf() {
+			key, payload, err := parseEntry(flags, data, commonKey)
+			if err != nil {
+				continue
+			}
+			*out = append(*out, lvEntry{key: key, data: payload})
+		} else {
+			if child, err := branchChild(flags, data); err == nil {
+				d.walkLongValueTree(child, depth+1, out)
+			}
+		}
+	}
+}
+
+// resolveLongValue reassembles the long value referenced by lid (the in-record reference
+// bytes) from table t's long-value tree. The LV-tree page key is the LID reversed; data
+// segments are keyed by that page key followed by a 4-byte big-endian segment offset, and
+// are concatenated in offset order.
+func (t *Table) resolveLongValue(lid []byte) ([]byte, error) {
+	t.loadLongValueLeaves()
+	if len(t.lvLeaves) == 0 {
+		return nil, fmt.Errorf("ese: no long-value data for id % x", lid)
+	}
+	prefix := make([]byte, len(lid))
+	for i := range lid {
+		prefix[i] = lid[len(lid)-1-i] // reverse the LID -> page key
+	}
+
+	type seg struct {
+		offset int
+		data   []byte
+	}
+	var segs []seg
+	end := 0
+	for _, e := range t.lvLeaves {
+		if len(e.key) != len(prefix)+4 || !bytes.Equal(e.key[:len(prefix)], prefix) {
+			continue // header entry (key==prefix) or a different LID
+		}
+		offset := int(binary.BigEndian.Uint32(e.key[len(prefix):]))
+		data := e.data
+		if len(data) > 0 && data[0] == 0x18 {
+			return nil, fmt.Errorf("ese: compressed long value (LZXPRESS) not supported")
+		}
+		segs = append(segs, seg{offset: offset, data: data})
+		if offset+len(data) > end {
+			end = offset + len(data)
+		}
+	}
+	if len(segs) == 0 {
+		return nil, fmt.Errorf("ese: long value % x not found", lid)
+	}
+	out := make([]byte, end)
+	for _, s := range segs {
+		copy(out[s.offset:], s.data)
+	}
+	return out, nil
+}

--- a/windows/database/ese/record.go
+++ b/windows/database/ese/record.go
@@ -144,8 +144,18 @@ func decodeRecord(t *Table, payload []byte) (*Row, error) {
 				tagged = parseTaggedItems(payload, taggedBase, t.db.extendedTags())
 				taggedParsed = true
 			}
-			if v, ok := lookupTagged(payload, taggedBase, tagged, id); ok {
-				values[id] = v
+			if v, isLV, ok := lookupTagged(payload, taggedBase, tagged, id); ok {
+				if isLV {
+					// The value is a long-value identifier; reassemble it from the
+					// long-value tree, falling back to the raw reference on failure.
+					if resolved, err := t.resolveLongValue(v); err == nil {
+						values[id] = resolved
+					} else {
+						values[id] = v
+					}
+				} else {
+					values[id] = v
+				}
 			}
 		}
 	}
@@ -180,9 +190,11 @@ func parseTaggedItems(payload []byte, base int, extended bool) []taggedItem {
 }
 
 // lookupTagged returns the value bytes of tagged column id, computing its length from the
-// next tagged entry (or end of record for the last), and skipping a leading flag byte
-// when present. Compressed values are unsupported (reported absent).
-func lookupTagged(payload []byte, base int, items []taggedItem, id uint32) ([]byte, bool) {
+// next tagged entry (or end of record for the last), and skipping a leading flag byte when
+// present. It also reports whether the value is a long-value reference (flag 0x04), in
+// which case the returned bytes are the long-value identifier. Compressed inline values
+// (flag 0x02) are unsupported (reported absent).
+func lookupTagged(payload []byte, base int, items []taggedItem, id uint32) (value []byte, isLongValue bool, ok bool) {
 	for k, it := range items {
 		if it.id != id {
 			continue
@@ -196,26 +208,27 @@ func lookupTagged(payload []byte, base int, items []taggedItem, id uint32) ([]by
 		}
 		if it.flagsPresent {
 			if offsetItem >= len(payload) {
-				return nil, false
+				return nil, false, false
 			}
 			flag := payload[offsetItem]
 			offsetItem++
 			size--
 			if flag&taggedCompressed != 0 {
-				return nil, false // compressed tagged data not supported
+				return nil, false, false // compressed tagged data not supported
 			}
+			isLongValue = flag&taggedLongValue != 0
 		}
 		if size < 0 {
 			size = 0
 		}
 		if offsetItem < 0 || offsetItem > len(payload) {
-			return nil, false
+			return nil, false, false
 		}
 		end := offsetItem + size
 		if end > len(payload) {
 			end = len(payload)
 		}
-		return append([]byte(nil), payload[offsetItem:end]...), true
+		return append([]byte(nil), payload[offsetItem:end]...), isLongValue, true
 	}
-	return nil, false
+	return nil, false, false
 }


### PR DESCRIPTION
### Linked Issue
The remaining limitation noted when #709 closed: ESE long-value (separate-tree) reassembly.

### Motivation
A tagged column whose value exceeds the inline limit is stored in the table's **long-value B-tree**; the in-record value is then a long-value identifier (LID), not the data (tagged flag `0x04`). The reader previously returned the raw LID, so large attributes came back as a 4-byte reference instead of their content.

### What this adds (`windows/database/ese`)
- **Catalog**: capture the table's long-value B-tree root (`CATALOG_TYPE_LONG_VALUE` `FatherDataPageNumber`) on the owning `Table`.
- **Tagged decode**: detect the `0x04` long-value flag and treat the value as a LID.
- **`longvalue.go`**: walk the long-value B-tree once (caching its leaf entries, reconstructing full keys including common-page-key prefixes); to resolve a LID, reverse it to the page key, collect the data segments keyed by `pageKey + big-endian segment offset`, and concatenate in offset order. LZXPRESS-compressed segments (leading `0x18`) are detected and reported unsupported; on any failure the reader falls back to the raw LID reference.

### How Verified
- **Synthetic** (`TestESELongValue`): a database storing a 600-byte value across two LV segments (offsets 0 and 400) reassembles to exactly the original bytes.
- **Real Windows Server 2016 NTDS.dit** (uses LV heavily — **863** long values in `datatable`, **51** in `sd_table`): cross-validated against **`dissect.esedb`** (which resolves LVs). The LV-backed `sd_value` column — security descriptors reassembled up to **2668 bytes** — is **byte-identical** to dissect for all 96 rows.
- **No regression**: the NTDS account dump on the same `.dit` is unchanged (`Administrator:500:…:520126a0…`, etc.) — hash attributes are inline, not LV.
- `go test ./windows/database/...`, `go vet`, full `go build ./...` — clean.

### Test Coverage
**Added:** `TestESELongValue` + the LV fixture builder (`buildLVSampleEDB`, LV-tree assembler) in `ese_test.go`.

### Scope of Change
- **Files changed:** new `longvalue.go`; `ese.go` (Table LV fields + flag const), `catalog.go` (capture LV root), `record.go` (LV detection + resolution), `ese_test.go` (fixture/test). No changes outside the ese package.
- **Submodule pointer updated:** no.

### Risk and Rollout
Low: additive; the inline tagged-value path is unchanged (verified by the unchanged account dump and the existing tests). Only values explicitly flagged `0x04` now take the LV path.

### Notes
LZXPRESS-compressed long-value segments are not decompressed (rare; reported as unsupported rather than returning wrong data). This removes the last limitation from #709; large attributes such as `supplementalCredentials` are read in full (and were already inline on the test DC). Parsing `supplementalCredentials` into Kerberos keys (USER_PROPERTIES, [MS-SAMR] 2.2.10) remains separate future work.
