### PR TITLE
Auto-disable logger colours when the output is not a terminal

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/go-ldap/ldap/v3 v3.4.12
 	github.com/jcmturner/gokrb5/v8 v8.4.4
 	golang.org/x/crypto v0.43.0
+	golang.org/x/term v0.36.0
 )
 
 require (
@@ -22,4 +23,5 @@ require (
 	github.com/jcmturner/goidentity/v6 v6.0.1 // indirect
 	github.com/jcmturner/rpc/v2 v2.0.3 // indirect
 	golang.org/x/net v0.46.0 // indirect
+	golang.org/x/sys v0.37.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -67,9 +67,13 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.37.0 h1:fdNQudmxPjkdUTPnLn5mdQv7Zwvbvpaxqs831goi9kQ=
+golang.org/x/sys v0.37.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.5.0/go.mod h1:jMB1sMXY+tzblOD4FWmEbocvup2/aLOaQEp7JmGp78k=
+golang.org/x/term v0.36.0 h1:zMPR+aF8gfksFprF/Nc/rd1wRS1EI6nDBGyWAvDzx2Q=
+golang.org/x/term v0.36.0/go.mod h1:Qu394IJq6V6dCBRgwqshf3mPF85AqzYEzofzRdZkWss=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -22,7 +22,29 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"golang.org/x/term"
 )
+
+// ColorMode controls when colour (and the ANSI it implies) is emitted.
+type ColorMode int
+
+const (
+	// ColorAuto emits colour only when the output is a terminal (the default).
+	ColorAuto ColorMode = iota
+	// ColorAlways always emits colour.
+	ColorAlways
+	// ColorNever never emits colour and strips ANSI sequences from the output.
+	ColorNever
+)
+
+// isTerminal reports whether w is a terminal (an *os.File backed by a tty).
+func isTerminal(w io.Writer) bool {
+	if f, ok := w.(interface{ Fd() uintptr }); ok {
+		return term.IsTerminal(int(f.Fd()))
+	}
+	return false
+}
 
 // Level is a logging level (an alias of slog.Level so the slog ecosystem interoperates).
 type Level = slog.Level
@@ -109,24 +131,37 @@ func colorFor(l slog.Level) string {
 // precision and colour policy. Multiple Logger handles (e.g. timestamped and Plain) point
 // at one config so a single setter reconfigures them together.
 type config struct {
-	mu        sync.Mutex
-	out       io.Writer
-	file      io.Writer
-	fileClose io.Closer
-	levelVar  *slog.LevelVar
-	precision TimePrecision
-	noColors  bool
-	utc       bool
+	mu            sync.Mutex
+	out           io.Writer
+	outIsTerminal bool
+	file          io.Writer
+	fileClose     io.Closer
+	levelVar      *slog.LevelVar
+	precision     TimePrecision
+	colorMode     ColorMode
+	utc           bool
 }
 
 func newConfig() *config {
-	c := &config{out: os.Stderr, levelVar: &slog.LevelVar{}, precision: Microseconds}
+	c := &config{out: os.Stderr, outIsTerminal: isTerminal(os.Stderr), levelVar: &slog.LevelVar{}, precision: Microseconds, colorMode: ColorAuto}
 	c.levelVar.Set(LevelDebug) // emit everything by default
 	return c
 }
 
+// useColor reports whether colour should be emitted (caller holds c.mu).
+func (c *config) useColor() bool {
+	switch c.colorMode {
+	case ColorAlways:
+		return true
+	case ColorNever:
+		return false
+	default: // ColorAuto
+		return c.outIsTerminal
+	}
+}
+
 // emit formats and writes one log line. The level tag is coloured unless colours are
-// disabled; the primary writer receives the line (ANSI-stripped when noColors is set) and
+// disabled; the primary writer receives the line (ANSI-stripped when colour is off) and
 // the optional file receives an always-stripped copy.
 func (c *config) emit(withTimestamp bool, precOverride TimePrecision, level slog.Level, msg string) {
 	c.mu.Lock()
@@ -139,6 +174,7 @@ func (c *config) emit(withTimestamp bool, precOverride TimePrecision, level slog
 		prec = precOverride
 	}
 
+	color := c.useColor()
 	var b strings.Builder
 	if withTimestamp {
 		now := time.Now()
@@ -150,7 +186,7 @@ func (c *config) emit(withTimestamp bool, precOverride TimePrecision, level slog
 		b.WriteString("] ")
 	}
 	if tag := tagFor(level); tag != "" {
-		if !c.noColors {
+		if color {
 			b.WriteString(colorFor(level))
 			b.WriteString(tag)
 			b.WriteString(colorReset)
@@ -164,10 +200,10 @@ func (c *config) emit(withTimestamp bool, precOverride TimePrecision, level slog
 	line := b.String()
 
 	if c.out != nil {
-		if c.noColors {
-			io.WriteString(c.out, stripANSI(line))
-		} else {
+		if color {
 			io.WriteString(c.out, line)
+		} else {
+			io.WriteString(c.out, stripANSI(line)) // strip ANSI embedded in the message too
 		}
 	}
 	if c.file != nil {
@@ -247,14 +283,27 @@ func (l *Logger) Slog() *slog.Logger { return l.sl }
 // Option configures a Logger created with New.
 type Option func(*config, *handler)
 
-func WithOutput(w io.Writer) Option { return func(c *config, _ *handler) { c.out = w } }
-func WithLevel(l Level) Option      { return func(c *config, _ *handler) { c.levelVar.Set(l) } }
-func WithTimestamp(b bool) Option   { return func(_ *config, h *handler) { h.timestamp = b } }
+func WithOutput(w io.Writer) Option {
+	return func(c *config, _ *handler) { c.out = w; c.outIsTerminal = isTerminal(w) }
+}
+func WithLevel(l Level) Option    { return func(c *config, _ *handler) { c.levelVar.Set(l) } }
+func WithTimestamp(b bool) Option { return func(_ *config, h *handler) { h.timestamp = b } }
 func WithTimePrecision(p TimePrecision) Option {
 	return func(c *config, _ *handler) { c.precision = p }
 }
-func WithNoColors(b bool) Option { return func(c *config, _ *handler) { c.noColors = b } }
-func WithUTC(b bool) Option      { return func(c *config, _ *handler) { c.utc = b } }
+func WithColorMode(m ColorMode) Option { return func(c *config, _ *handler) { c.colorMode = m } }
+func WithUTC(b bool) Option            { return func(c *config, _ *handler) { c.utc = b } }
+
+// WithNoColors disables colour (ColorNever) when true, otherwise restores ColorAuto.
+func WithNoColors(b bool) Option {
+	return func(c *config, _ *handler) {
+		if b {
+			c.colorMode = ColorNever
+		} else {
+			c.colorMode = ColorAuto
+		}
+	}
+}
 
 // New creates an independent logger with its own configuration (default: stderr, all
 // levels, microsecond timestamps, colours on). Pass it where isolated logging is needed.
@@ -293,9 +342,11 @@ func Print(msg string)               { std.Print(msg) }
 func Printf(format string, a ...any) { std.Printf(format, a...) }
 
 // SetOutput sets the primary writer of the default logger (and Plain). Default: stderr.
+// Whether colour is emitted in ColorAuto mode is re-evaluated against the new writer.
 func SetOutput(w io.Writer) {
 	sharedConfig.mu.Lock()
 	sharedConfig.out = w
+	sharedConfig.outIsTerminal = isTerminal(w)
 	sharedConfig.mu.Unlock()
 }
 
@@ -309,12 +360,22 @@ func SetTimePrecision(p TimePrecision) {
 	sharedConfig.mu.Unlock()
 }
 
-// SetNoColors enables or disables colour. When enabled, the level tags are not coloured
-// and any ANSI sequences are stripped from the output.
-func SetNoColors(b bool) {
+// SetColorMode sets when colour is emitted: ColorAuto (terminal only, the default),
+// ColorAlways, or ColorNever.
+func SetColorMode(m ColorMode) {
 	sharedConfig.mu.Lock()
-	sharedConfig.noColors = b
+	sharedConfig.colorMode = m
 	sharedConfig.mu.Unlock()
+}
+
+// SetNoColors is a convenience over SetColorMode: true selects ColorNever (no colour, ANSI
+// stripped), false restores ColorAuto (colour only when the output is a terminal).
+func SetNoColors(b bool) {
+	if b {
+		SetColorMode(ColorNever)
+	} else {
+		SetColorMode(ColorAuto)
+	}
 }
 
 // SetUTC selects UTC timestamps for the default logger.
@@ -388,10 +449,10 @@ func (c *config) rawTimestamped(prec TimePrecision, format string, a ...any) {
 	}
 	line := "[" + now.Format(layoutFor(prec)) + "] " + fmt.Sprintf(format, a...)
 	if c.out != nil {
-		if c.noColors {
-			io.WriteString(c.out, stripANSI(line))
-		} else {
+		if c.useColor() {
 			io.WriteString(c.out, line)
+		} else {
+			io.WriteString(c.out, stripANSI(line))
 		}
 	}
 	if c.file != nil {

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -59,7 +59,8 @@ func TestLevelFiltering(t *testing.T) {
 
 func TestColorsOnAndOff(t *testing.T) {
 	var on, off bytes.Buffer
-	logger.New(logger.WithOutput(&on)).Error("boom")
+	// ColorAlways forces colour even though a buffer is not a terminal.
+	logger.New(logger.WithOutput(&on), logger.WithColorMode(logger.ColorAlways)).Error("boom")
 	if !strings.Contains(on.String(), "\x1b[") {
 		t.Errorf("colours on: expected ANSI in %q", on.String())
 	}
@@ -70,6 +71,19 @@ func TestColorsOnAndOff(t *testing.T) {
 	}
 	if !strings.Contains(off.String(), "INFO: aredb\n") {
 		t.Errorf("noColors: message ANSI should be stripped; got %q", off.String())
+	}
+}
+
+func TestColorAutoDisablesOnNonTTY(t *testing.T) {
+	var buf bytes.Buffer
+	// Default mode is ColorAuto; a bytes.Buffer is not a terminal, so no colour and any
+	// embedded ANSI is stripped.
+	logger.New(logger.WithOutput(&buf)).Error("x\x1b[31my\x1b[0m")
+	if strings.Contains(buf.String(), "\x1b") {
+		t.Errorf("ColorAuto on a non-terminal should not emit/keep ANSI: %q", buf.String())
+	}
+	if !strings.Contains(buf.String(), "ERROR: xy\n") {
+		t.Errorf("got %q, want stripped \"ERROR: xy\"", buf.String())
 	}
 }
 
@@ -95,11 +109,11 @@ func TestLogToFileTeesAndStrips(t *testing.T) {
 	var term bytes.Buffer
 	// Use the package-level facade; restore global state afterwards.
 	logger.SetOutput(&term)
-	logger.SetNoColors(false) // colours on the terminal
+	logger.SetColorMode(logger.ColorAlways) // force colour even though term is a buffer
 	defer func() {
 		logger.CloseLogFile()
 		logger.SetOutput(os.Stderr)
-		logger.SetNoColors(false)
+		logger.SetColorMode(logger.ColorAuto)
 		logger.SetLevel(logger.LevelDebug)
 	}()
 


### PR DESCRIPTION
### Linked Issue
Follow-up to the logger rework (#724): auto-disable colours when the output is not a terminal.

### What this does
Colour becomes a tri-state defaulting to **auto-detect**, so logs are coloured interactively but plain when redirected to a file or pipe (no stray escape codes in captured/redirected output).

- **`ColorMode`** `{ColorAuto, ColorAlways, ColorNever}`, default **`ColorAuto`**.
- `ColorAuto` emits colour only when the primary writer is a terminal, detected via `golang.org/x/term.IsTerminal` and cached, re-evaluated whenever the output changes (`SetOutput`/`WithOutput`). A `bytes.Buffer`, pipe, or file → non-terminal → no colour and ANSI is stripped.
- `SetColorMode` / `WithColorMode` for explicit control. `SetNoColors`/`WithNoColors` are now conveniences: `true` → `ColorNever`, `false` → `ColorAuto`.

### How Verified
- `go test ./logger/` — 9 tests pass, incl. new `TestColorAutoDisablesOnNonTTY` (auto + buffer → no colour, embedded ANSI stripped). The colour-on and file-tee tests now use `ColorAlways` to force colour onto a buffer.
- `go build ./...`, `go vet ./logger/` — clean.
- Demo: writing to a pipe in `auto` mode produces no colour; `ColorAlways` forces it.

### Scope of Change
- **Files changed:** `logger/logger.go`, `logger/logger_test.go`, `go.mod`/`go.sum` (promote `golang.org/x/term` to a direct dependency — already in the build graph).
- **Behavioural change:** the default is now auto rather than always-on. On a terminal the output is identical to before; when redirected, it is now plain (the intended improvement). Explicit `ColorAlways` restores always-on.

### Risk and Rollout
Low: only the colour decision changed; level/format/file/timestamp behaviour is unchanged.
