### PR TITLE
Migrate last legacy logger call site to new Warnf API

### DIFF
--- a/network/ldap/rid.go
+++ b/network/ldap/rid.go
@@ -61,7 +61,7 @@ func (ldapSession *Session) FindObjectSIDByRID(domain string, RID int) (string, 
 		}
 
 		if len(results) > 1 {
-			logger.Warn(fmt.Sprintf("Error: More than one result for SID '%s-%d' in the domain '%s'", domainObject.SID, RID, domain))
+			logger.Warnf("Error: More than one result for SID '%s-%d' in the domain '%s'", domainObject.SID, RID, domain)
 		} else {
 			if len(results) == 1 {
 				// One result found


### PR DESCRIPTION
## Summary

- Replace the one remaining `logger.Warn(fmt.Sprintf(...))` call with `logger.Warnf(...)` in `network/ldap/rid.go`

This is a mechanical migration following PRs #724–#726 which reworked the logger package onto `log/slog`. The old `logger.X(fmt.Sprintf(FMT, ARGS...))` pattern is replaced with `logger.Xf(FMT, ARGS...)`.

## Scope

A single live call site was found outside the logger package (all others were already commented out):

| File | Old call | New call |
|---|---|---|
| `network/ldap/rid.go:64` | `logger.Warn(fmt.Sprintf("Error: More than one result for SID '%s-%d' in the domain '%s'", ...))` | `logger.Warnf("Error: More than one result for SID '%s-%d' in the domain '%s'", ...)` |

**No behavioural change** — same log level, same message content. Timestamps now use the Microsecond default precision.

Verified with:
```
grep -rnE 'logger\.(Info|Warn|Error|Debug|Print)\(fmt\.Sprintf' --include='*.go' . | grep -v /logger/ | grep -v '//' | grep -v _test.go
```
→ zero results after the change.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./network/ldap/...`
- [x] `go test ./network/ldap/...` — all pass