### PR TITLE
Fix stale trans2 doc comment that contradicts the implementation

### DIFF
--- a/network/smb/smb_v10/client/find.go
+++ b/network/smb/smb_v10/client/find.go
@@ -177,10 +177,10 @@ func (c *Client) ListEntries(pattern string) ([]Entry, error) {
 	return entries, nil
 }
 
-// trans2 issues a single SMB_COM_TRANSACTION2 carrying the given subcommand, with
-// the supplied transaction parameter and data buffers, and returns the reassembled
-// response parameter and data buffers. It does not implement Transaction2Secondary
-// fragmentation, so the request must fit in a single message.
+// trans2 issues an SMB_COM_TRANSACTION2 carrying the given subcommand, with the supplied
+// transaction parameter and data buffers, and returns the reassembled response parameter
+// and data buffers. Requests larger than the negotiated buffer are fragmented across
+// TRANSACTION2_SECONDARY messages.
 func (c *Client) trans2(subcommand uint16, trans2Params, trans2Data []byte) ([]byte, []byte, error) {
 	// Bound the data the server may return by the negotiated buffer.
 	maxData := 0xFFFF


### PR DESCRIPTION
### Summary
Documentation-only fix: the `trans2` doc comment in `network/smb/smb_v10/client/find.go` contradicted the implementation.

### Detail
The comment said `trans2` *"does not implement Transaction2Secondary fragmentation, so the request must fit in a single message"*, but the function fragments large requests across `TRANSACTION2_SECONDARY` messages (the comment predated that support, added for #389/#463). Updated the comment to describe the actual behaviour.

### How Verified
- `go build ./network/smb/smb_v10/client/` — clean.
- Comment-only change; no code/behaviour affected.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/client/find.go` (one doc comment).
- **Submodule pointer updated:** no.
- **Behavioural changes:** none.
