### PR TITLE
Add per-page replication progress callback to MS-DRSR full-NC replication

### DIFF
--- a/network/dcerpc/ms-protocols/ms-drsr/client.go
+++ b/network/dcerpc/ms-protocols/ms-drsr/client.go
@@ -48,6 +48,11 @@ type Client struct {
 	serverExt *structures.DRS_EXTENSIONS_INT
 	sourceDSA structures.UUID // source DSA GUID for GetNCChanges; zero (NULL) by default
 	bound     bool
+
+	// onReplicationProgress, when non-nil, is invoked once per replicated page during
+	// full-NC replication (ReplicateNC) with the cumulative number of objects received
+	// so far. Registered via SetReplicationProgress.
+	onReplicationProgress func(objects int)
 }
 
 // compile-time assertion that Client satisfies the session contract.

--- a/network/dcerpc/ms-protocols/ms-drsr/full_nc.go
+++ b/network/dcerpc/ms-protocols/ms-drsr/full_nc.go
@@ -18,6 +18,14 @@ const (
 	maxFullNCPages = 100000
 )
 
+// SetReplicationProgress registers a callback invoked once per page during full-NC
+// replication (ReplicateNC, and therefore DCSyncAll) with the cumulative number of
+// objects received so far. The naming context's total object count is not known in
+// advance, so callers should render the value as a running count, not a percentage.
+// Pass nil to disable. Set it before starting a replication call; it is not safe to
+// change while one is in progress.
+func (c *Client) SetReplicationProgress(fn func(objects int)) { c.onReplicationProgress = fn }
+
 // ReplicateNC replicates an entire naming context (every object in ncDN, e.g.
 // "DC=lab,DC=local") by paging IDL_DRSGetNCChanges, and returns the accumulated objects.
 // Unlike ReplicateSingleObject (EXOP_REPL_OBJ), this issues no extended op and pages the
@@ -73,6 +81,10 @@ func (c *Client) ReplicateNC(ncDN string) (*ReplicationResult, error) {
 		}
 		for node := reply.PObjects; node != nil; node = node.PNextEntInf {
 			result.Objects = append(result.Objects, projectEntInf(node.Entinf))
+		}
+
+		if c.onReplicationProgress != nil {
+			c.onReplicationProgress(len(result.Objects))
 		}
 
 		if reply.FMoreData == 0 {


### PR DESCRIPTION
Adds an optional progress hook to full-NC replication so callers can surface live feedback during a long `DCSyncAll` / `ReplicateNC` cycle.

## What changed
- New `Client.SetReplicationProgress(func(objects int))` setter.
- `ReplicateNC` invokes the callback once per replicated page with the cumulative number of objects received so far, after that page is accumulated and before the `fMoreData` check (so the final page is reported too).

## Why a running count, not a percentage
The naming context object count is not known in advance — the cycle ends only when the server clears `fMoreData`. The callback therefore reports a monotonically increasing count; rendering it as a percentage is not possible without a separate up-front object-count query.

## Compatibility
The hook is a nil-checked field defaulting to `nil`, so all existing callers (`DCSyncAll`, `ReplicateNC`, tests) are unaffected and behave exactly as before.

## Verification
- `go build ./network/dcerpc/ms-protocols/ms-drsr/` and `go vet` pass.
- Consumed by the DumpSecrets `remote dcsync` progress indicator.