### PR TITLE
Fix ncacn_np Recv to retry on transient STATUS_PIPE_EMPTY (#732)

### DIFF
--- a/network/dcerpc/v5/transport/smb/smb_namedpipe.go
+++ b/network/dcerpc/v5/transport/smb/smb_namedpipe.go
@@ -12,10 +12,21 @@ package smb
 
 import (
 	"fmt"
+	"strings"
+	"time"
 
 	dcerpctransport "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/transport"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/client"
 	"github.com/TheManticoreProject/Manticore/windows/fileflags"
+)
+
+// Bounded retry parameters for a transiently empty pipe (see Recv). A response that
+// is not yet queued by the server typically appears within a few milliseconds; the
+// total budget is generous enough for a slow operation (such as a password change)
+// without hanging indefinitely on a genuinely dead pipe.
+const (
+	recvRetryDelay    = 20 * time.Millisecond
+	recvMaxRetryTotal = 5 * time.Second
 )
 
 // Default fragment sizes proposed at Bind time. 4280 (0x10B8) is the classic Windows
@@ -124,15 +135,37 @@ func (p *SMBNamedPipe) Send(pdu []byte) error {
 
 // Recv reads up to MaxRecvFrag bytes from the pipe. The pipe offset is meaningless,
 // so a zero offset is used.
+//
+// Per [MS-RPCE] 2.1.1.2 the response PDU is obtained as a named-pipe read, which can
+// momentarily race the server's write of that response: the read then completes with
+// STATUS_PIPE_EMPTY (0xC00000D9) even though a response is forthcoming. Rather than
+// surface that transient as a hard failure, Recv re-issues the read on the same pipe
+// handle, with a short delay, until the response arrives or the retry budget is spent.
 func (p *SMBNamedPipe) Recv() ([]byte, error) {
 	if !p.opened {
 		return nil, fmt.Errorf("named pipe %q is not open: call Connect first", p.pipeName)
 	}
-	data, err := p.conn.ReadFile(p.fid, 0, uint32(p.maxRecv))
-	if err != nil {
-		return nil, fmt.Errorf("failed to read from named pipe %q: %w", p.pipeName, err)
+
+	deadline := time.Now().Add(recvMaxRetryTotal)
+	for {
+		data, err := p.conn.ReadFile(p.fid, 0, uint32(p.maxRecv))
+		if err == nil {
+			return data, nil
+		}
+		if !isPipeEmpty(err) || time.Now().After(deadline) {
+			return nil, fmt.Errorf("failed to read from named pipe %q: %w", p.pipeName, err)
+		}
+		time.Sleep(recvRetryDelay)
 	}
-	return data, nil
+}
+
+// isPipeEmpty reports whether err is the transient "no data yet" condition on a named
+// pipe read: STATUS_PIPE_EMPTY (0xC00000D9) or its RPC equivalent RPC_NT_PIPE_EMPTY
+// (0xC0030061). ReadFile surfaces the SMB status as a lowercase hex string in the error
+// text, so the status code is matched there.
+func isPipeEmpty(err error) bool {
+	s := strings.ToLower(err.Error())
+	return strings.Contains(s, "c00000d9") || strings.Contains(s, "c0030061")
 }
 
 // Close closes the pipe handle. The underlying SMB session and tree connect are left

--- a/network/dcerpc/v5/transport/smb/smb_namedpipe_test.go
+++ b/network/dcerpc/v5/transport/smb/smb_namedpipe_test.go
@@ -20,6 +20,12 @@ type fakePipeConn struct {
 	readData []byte
 	readErr  error
 
+	// readSeq, when non-nil, supplies a result for each successive ReadFile call
+	// (the final entry repeats once exhausted). It takes precedence over
+	// readData/readErr and is used to exercise the transient-pipe-empty retry.
+	readSeq    []readResult
+	readSeqIdx int
+
 	closeErr error
 
 	// Recorded calls.
@@ -29,7 +35,14 @@ type fakePipeConn struct {
 	writeOffset uint64
 	readOffset  uint64
 	readMaxLen  uint32
+	readCount   int
 	closeCount  int
+}
+
+// readResult is one canned outcome of a ReadFile call.
+type readResult struct {
+	data []byte
+	err  error
 }
 
 func (f *fakePipeConn) OpenFile(path string, desiredAccess, shareAccess, createDisp, createOptions uint32) (client.FID, error) {
@@ -56,6 +69,14 @@ func (f *fakePipeConn) WriteFile(fid client.FID, offset uint64, data []byte) (in
 func (f *fakePipeConn) ReadFile(fid client.FID, offset uint64, maxLen uint32) ([]byte, error) {
 	f.readOffset = offset
 	f.readMaxLen = maxLen
+	f.readCount++
+	if f.readSeq != nil {
+		r := f.readSeq[f.readSeqIdx]
+		if f.readSeqIdx < len(f.readSeq)-1 {
+			f.readSeqIdx++
+		}
+		return r.data, r.err
+	}
 	if f.readErr != nil {
 		return nil, f.readErr
 	}
@@ -228,6 +249,55 @@ func TestRecv_PropagatesReadError(t *testing.T) {
 	_, err := p.Recv()
 	if !errors.Is(err, wantErr) {
 		t.Errorf("Recv() error = %v, want wrapped %v", err, wantErr)
+	}
+	// A non-pipe-empty error must fail immediately, without retrying.
+	if fake.readCount != 1 {
+		t.Errorf("ReadFile called %d times, want 1 (no retry on a hard error)", fake.readCount)
+	}
+}
+
+func TestIsPipeEmpty_ClassifiesStatus(t *testing.T) {
+	for _, tc := range []struct {
+		err  error
+		want bool
+	}{
+		{errors.New("ReadAndx failed: 0xc00000d9"), true},  // STATUS_PIPE_EMPTY
+		{errors.New("ReadAndx failed: 0xC00000D9"), true},  // case-insensitive
+		{errors.New("ReadAndx failed: 0xc0030061"), true},  // RPC_NT_PIPE_EMPTY
+		{errors.New("ReadAndx failed: 0xc0000022"), false}, // STATUS_ACCESS_DENIED
+		{errors.New("pipe broken"), false},                 // unrelated
+	} {
+		if got := isPipeEmpty(tc.err); got != tc.want {
+			t.Errorf("isPipeEmpty(%q) = %v, want %v", tc.err, got, tc.want)
+		}
+	}
+}
+
+func TestRecv_RetriesOnPipeEmptyThenSucceeds(t *testing.T) {
+	resp := []byte{0x05, 0x00, 0x0c, 0x03}
+	pipeEmpty := errors.New("ReadAndx failed: 0xc00000d9")
+	fake := &fakePipeConn{
+		openFID: 1,
+		readSeq: []readResult{
+			{nil, pipeEmpty}, // server has not queued the response yet
+			{nil, pipeEmpty}, // ...still not
+			{resp, nil},      // response arrives
+		},
+	}
+	p := newWithConn(fake, `\PIPE\lsarpc`)
+	if err := p.Connect(); err != nil {
+		t.Fatalf("Connect() error = %v", err)
+	}
+
+	got, err := p.Recv()
+	if err != nil {
+		t.Fatalf("Recv() error = %v, want nil after transient pipe-empty retries", err)
+	}
+	if !bytes.Equal(got, resp) {
+		t.Errorf("Recv() = %x, want %x", got, resp)
+	}
+	if fake.readCount != 3 {
+		t.Errorf("ReadFile called %d times, want 3 (two empties then the response)", fake.readCount)
 	}
 }
 


### PR DESCRIPTION
### Linked Issue
Closes #732

### Root Cause
Per [MS-RPCE] 2.1.1.2 a DCE/RPC response over `ncacn_np` is obtained as a named-pipe read. That read can complete with `STATUS_PIPE_EMPTY` (0xC00000D9) while the server is still producing the response — a "no data yet" condition, not a terminal error. `(*SMBNamedPipe).Recv` issued a single `ReadFile` and returned its error verbatim, so this transient race surfaced as a hard RPC failure. The same condition is already known on the wire: the SAMR functions integration test documents it and retries manually, which means the transport itself was the wrong layer to give up.

### Fix Description
`Recv` now re-issues the read on the same pipe handle when the error is the transient pipe-empty status, with a 20 ms delay between attempts and a 5 s overall budget, returning as soon as the response arrives. Non-pipe-empty errors are still returned immediately and unchanged. Classification is done by a small `isPipeEmpty` helper that matches `STATUS_PIPE_EMPTY` (0xC00000D9) and `RPC_NT_PIPE_EMPTY` (0xC0030061) in the status text `ReadFile` already produces; this avoids changing `ReadFile`'s error contract, which other callers depend on. The single-round-trip `TransactNamedPipe` form was considered but not adopted, to keep the change localized to the existing write-then-read model the transport already documents.

### How Verified
- **Runtime:** before the fix, `SamrUnicodeChangePasswordUser2` over `\samr` against a Windows Server 2016 DC failed with `failed to read from named pipe "\samr": ReadAndx failed: 0xc00000d9`; after the fix the same call succeeds and the password change takes effect (confirmed by a subsequent NTLM bind with the new password).
- **Tests:** `go test ./network/dcerpc/v5/transport/smb/` passes.

### Test Coverage
**Added:**
- `TestRecv_RetriesOnPipeEmptyThenSucceeds` — the fake pipe returns `STATUS_PIPE_EMPTY` twice then the response; asserts `Recv` returns the response and that `ReadFile` was called exactly three times.
- `TestIsPipeEmpty_ClassifiesStatus` — asserts the helper matches 0xC00000D9 (case-insensitive) and 0xC0030061, and rejects unrelated statuses such as 0xC0000022.
- `TestRecv_PropagatesReadError` extended to assert a non-pipe-empty error fails on the first read with no retry.

### Scope of Change
- **Files changed:** `network/dcerpc/v5/transport/smb/smb_namedpipe.go`, `network/dcerpc/v5/transport/smb/smb_namedpipe_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Low blast radius: the new path only triggers on the specific pipe-empty statuses, which previously failed outright, so it can only convert a former failure into a success or a bounded wait. All other read errors keep their existing immediate-failure behavior. The 5 s budget bounds the worst case on a genuinely dead pipe.
