### PR TITLE
Fix BaseRegQueryValue NDR array framing with pointer count siblings (#734)

### DIFF
--- a/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/17_BaseRegQueryValue.go
+++ b/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/17_BaseRegQueryValue.go
@@ -9,11 +9,21 @@ import (
 )
 
 // baseRegQueryValueRequest carries the [in] parameters of BaseRegQueryValue.
+//
+// [MS-RRP] 3.1.5.17 declares lpData as
+// [in, out, unique, size_is(*lpcbData), length_is(*lpcbLen)] LPBYTE: a unique pointer to a
+// conformant-varying byte array whose maximum_count is *lpcbData (the buffer capacity the
+// client offers) and whose actual_count is *lpcbLen (the number of valid input octets, 0 on
+// a read). The two counts are independent of the Go slice length and of each other, so the
+// tag names both sibling pointers explicitly — matching RPC_SECURITY_DESCRIPTOR's
+// CbIn/CbOut modeling in this same interface. Without size_is/length_is the marshaller would
+// derive both counts from len(LpData), transmitting an actual_count that contradicts *lpcbLen
+// and a full input body on a value read, which a DC rejects with nca_s_fault_ndr.
 type baseRegQueryValueRequest struct {
 	HKey        structures.RPC_HKEY
 	LpValueName structures.RRP_UNICODE_STRING
 	LpType      *ndr.DWORD `ndr:"unique"`
-	LpData      []uint8    `ndr:"unique,varying"`
+	LpData      []uint8    `ndr:"unique,size_is=LpcbData,varying,length_is=LpcbLen"`
 	LpcbData    *ndr.DWORD `ndr:"unique"`
 	LpcbLen     *ndr.DWORD `ndr:"unique"`
 }

--- a/network/dcerpc/ndr/marshal.go
+++ b/network/dcerpc/ndr/marshal.go
@@ -753,12 +753,23 @@ func independentVaryingBounds(tag fieldTag) bool {
 
 // siblingUint reads the unsigned integer value of the named field of struct value rv,
 // reporting false if there is no such field or it is not an unsigned integer kind.
+//
+// A size_is/length_is target may itself be a pointer to an integer: MS-RRP models the
+// count parameters of methods like BaseRegQueryValue as [in, out, unique] LPDWORD, so the
+// sibling field is a *ndr.DWORD rather than a bare DWORD. Such a pointer is dereferenced;
+// a nil pointer reports false, leaving the count to fall back to the array length.
 func siblingUint(rt reflect.Type, rv reflect.Value, name string) (uint64, bool) {
 	f, ok := rt.FieldByName(name)
 	if !ok || len(f.Index) != 1 {
 		return 0, false
 	}
 	fv := rv.Field(f.Index[0])
+	if fv.Kind() == reflect.Ptr {
+		if fv.IsNil() {
+			return 0, false
+		}
+		fv = fv.Elem()
+	}
 	if !isUintKind(fv.Kind()) {
 		return 0, false
 	}

--- a/network/dcerpc/ndr/sizeis_test.go
+++ b/network/dcerpc/ndr/sizeis_test.go
@@ -63,3 +63,40 @@ func TestSizeIs_LiteralConstant(t *testing.T) {
 		t.Errorf("literal size_is:\n got %x\nwant %x", raw, want)
 	}
 }
+
+// TestSizeIs_PointerSiblingIndependentBounds verifies that a conformant-varying array whose
+// size_is/length_is targets are *pointers* to integers (MS-RRP's [in, out, unique] LPDWORD
+// count parameters) derives its maximum_count and actual_count from the pointed-to values,
+// independent of the Go slice length. This is the BaseRegQueryValue shape: a full-capacity
+// buffer is offered (maximum_count = *lpcbData) while no input octets are transmitted on a
+// read (actual_count = *lpcbLen = 0). Before pointer siblings were resolved, both counts
+// fell back to len(Data), sending a spurious actual_count and an input body that a DC
+// rejects with nca_s_fault_ndr.
+func TestSizeIs_PointerSiblingIndependentBounds(t *testing.T) {
+	type req struct {
+		Data   []uint8 `ndr:"unique,size_is=CbData,varying,length_is=CbLen"`
+		CbData *DWORD  `ndr:"unique"`
+		CbLen  *DWORD  `ndr:"unique"`
+	}
+	capacity := DWORD(8)
+	valid := DWORD(0)
+	// Data carries 8 octets, but only *CbLen (0) are valid; none must be transmitted.
+	in := &req{Data: []byte{1, 2, 3, 4, 5, 6, 7, 8}, CbData: &capacity, CbLen: &valid}
+	raw, err := Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	want := []byte{
+		0x00, 0x00, 0x02, 0x00, // Data referent id
+		0x08, 0x00, 0x00, 0x00, // Data maximum_count == *CbData (8), not len(Data)
+		0x00, 0x00, 0x00, 0x00, // Data offset
+		0x00, 0x00, 0x00, 0x00, // Data actual_count == *CbLen (0); no data body follows
+		0x04, 0x00, 0x02, 0x00, // CbData referent id
+		0x08, 0x00, 0x00, 0x00, // CbData value
+		0x08, 0x00, 0x02, 0x00, // CbLen referent id
+		0x00, 0x00, 0x00, 0x00, // CbLen value
+	}
+	if !bytes.Equal(raw, want) {
+		t.Errorf("pointer-sibling size_is/length_is:\n got %x\nwant %x", raw, want)
+	}
+}


### PR DESCRIPTION
### Linked Issue

`Closes #734`

### Root Cause

`BaseRegQueryValue`'s `lpData` is declared by [MS-RRP] 3.1.5.17 as `[in, out, unique, size_is(*lpcbData), length_is(*lpcbLen)] LPBYTE`, but the request type tagged it plain `ndr:"unique,varying"`. With no bound tags, the marshaller derives a conformant-varying array's `maximum_count` and `actual_count` from the Go slice length, so a full-capacity buffer was transmitted as `maximum_count = actual_count = len(lpData)` with a matching input body — contradicting `*lpcbLen` (0 on a read) and sending a value-read request the DC rejects with `nca_s_fault_ndr`.

Simply adding the tags was not sufficient: the count parameters `lpcbData`/`lpcbLen` are modeled as `[in, out, unique] LPDWORD`, i.e. `*ndr.DWORD` sibling fields, and `siblingUint()` — which resolves `size_is`/`length_is` targets — only accepted bare unsigned-integer kinds and returned `false` for a pointer, silently falling back to the slice length again. The existing `RPC_SECURITY_DESCRIPTOR` in the same interface uses the identical bound shape but with bare `DWORD` siblings, so the pointer-sibling path was never exercised.

### Fix Description

Two focused changes:

1. `siblingUint()` now dereferences a pointer `size_is`/`length_is` target (a `*DWORD`-style `LPDWORD` count), returning `false` on a nil pointer so the count still falls back to the array length. This is a general NDR improvement for the common MS-RRP/MS-* `LPDWORD` count-parameter shape.
2. `baseRegQueryValueRequest.LpData` is tagged `ndr:"unique,size_is=LpcbData,varying,length_is=LpcbLen"`, mirroring `RPC_SECURITY_DESCRIPTOR`'s `CbIn`/`CbOut` modeling in the same interface. `maximum_count` and `actual_count` now track `*lpcbData`/`*lpcbLen` independent of the slice length.

Only the request type is changed; the response array (decoded from server-supplied counts on the wire) is untouched.

### How Verified

- **Unit (wire bytes):** added `TestSizeIs_PointerSiblingIndependentBounds`, which marshals the BaseRegQueryValue shape (an 8-byte buffer with `*CbData=8`, `*CbLen=0`) and asserts the exact wire layout: `maximum_count=8` (from `*CbData`), `actual_count=0` (from `*CbLen`), and no data body — independent of the slice length. Full `network/dcerpc/ndr` and `network/dcerpc/...` suites pass; `go vet` clean; `go build ./...` clean.
- **Runtime (live DC):** built the downstream `onelogon` registry scanner against this branch and ran it against a Windows Server 2016 DC (`TMP-W-2016.local`) over `\winreg`. Before the fix the call faulted with `nca_s_fault_ndr`; after the fix the server decodes the request and returns a real Win32 status (`ERROR_FILE_NOT_FOUND` — the value is absent on that DC). Both the spec-ideal framing (`*lpcbLen=0`, no input body) and a full-buffer framing are now accepted.

### Test Coverage

- **Added:** `network/dcerpc/ndr/sizeis_test.go::TestSizeIs_PointerSiblingIndependentBounds` — asserts pointer-sibling `size_is`/`length_is` counts are emitted from the pointed-to values, not the slice length.

### Scope of Change

- **Files changed:** `network/dcerpc/ndr/marshal.go`, `network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/17_BaseRegQueryValue.go`, `network/dcerpc/ndr/sizeis_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout

Low blast radius. The `siblingUint` change is additive: it only affects fields whose `size_is`/`length_is` names a pointer sibling, which previously resolved to `false` and fell back to the slice length; no existing struct with a bare-integer count sibling changes behavior. Safe to merge without staged rollout.
