### PR TITLE
Fix ESE signature constant overflowing int on 32-bit builds (#737)

### DIFF
--- a/windows/database/ese/ese.go
+++ b/windows/database/ese/ese.go
@@ -22,10 +22,10 @@ import (
 )
 
 const (
-	eseSignature       = 0x89ABCDEF
-	catalogPageNumber  = 4
-	dataDefinitionSize = 4  // ESENT_DATA_DEFINITION_HEADER: LastFixedSize(1)+LastVariableDataType(1)+VariableSizeOffset(2)
-	maxCatalogDepth    = 32 // guard against a cyclic catalog B-tree
+	eseSignature       uint32 = 0x89ABCDEF // ESE/JET header magic (ulMagic); typed so it does not overflow int on 32-bit builds
+	catalogPageNumber         = 4
+	dataDefinitionSize        = 4  // ESENT_DATA_DEFINITION_HEADER: LastFixedSize(1)+LastVariableDataType(1)+VariableSizeOffset(2)
+	maxCatalogDepth           = 32 // guard against a cyclic catalog B-tree
 
 	// Page flags ([MS] FLAGS_*).
 	flagRoot      = 0x01


### PR DESCRIPTION
### Linked Issue
Closes #737

### Root Cause
`eseSignature` in `windows/database/ese/ese.go` was declared as an untyped constant with value `0x89ABCDEF`. Untyped constants adopt a default type when used in a context that requires one; passed through `fmt.Errorf`'s `...interface{}` parameter (L169), it defaulted to `int`. On the 32-bit `386` CI targets `int` is 32 bits and cannot represent `0x89ABCDEF` (2309737967 > max int32), so the package failed to compile. The comparison at L167 was fine because there the constant converts to `uint32`, which masked the problem on `amd64`/`arm64`.

### Fix Description
Declare the constant with its real on-disk type, `uint32` (the ESE header `ulMagic` field is a 32-bit little-endian value). It then converts cleanly at every use site — the `uint32` comparison at L167, the `fmt.Errorf` `%08X` argument at L169, and the `binary.LittleEndian.PutUint32` calls in the tests — on every architecture. No behavioral change on 64-bit platforms.

### How Verified
- Reproduced the failure: `CGO_ENABLED=0 GOOS=linux GOARCH=386 go test -count=1 ./windows/database/ese/...` failed to build with the overflow error before the change.
- After the fix, `go vet` is clean for `linux/386`, `linux/arm64`, `linux/amd64`, `windows/386`, and `windows/amd64` (the CI matrix), and `go test -count=1 ./windows/database/ese/...` passes on both the host arch and `GOARCH=386`.

### Test Coverage
**Existing:** the package's existing tests (`ese_test.go`) exercise the signature path via `binary.LittleEndian.PutUint32(header[4:], eseSignature)` and now compile and pass under `GOARCH=386`. No new test is needed — the defect was a compile-time overflow the existing suite covers once it builds on 32-bit.

### Scope of Change
- **Files changed:** `windows/database/ese/ese.go` (one constant typed `uint32`; the rest of the diff is gofmt realigning the const block).
- **Submodule pointer updated:** no.
- **Behavioral changes outside the bug fix:** none.