### PR TITLE
Add Netlogon (MS-NRPC) client interface (#741)

### DIFF
--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/04_NetrServerReqChallenge.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/04_NetrServerReqChallenge.go
@@ -1,0 +1,51 @@
+package functions
+
+import (
+	"fmt"
+
+	netlogon "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/structures"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+type netrServerReqChallengeRequest struct {
+	PrimaryName     *ndr.WSTR `ndr:"unique"`
+	ComputerName    ndr.WSTR
+	ClientChallenge structures.NETLOGON_CREDENTIAL
+}
+
+func (*netrServerReqChallengeRequest) Opnum() uint16 { return netlogon.OpnumNetrServerReqChallenge }
+
+type netrServerReqChallengeResponse struct {
+	ServerChallenge structures.NETLOGON_CREDENTIAL
+	Status          ndr.DWORD `ndr:"retval"`
+}
+
+// NetrServerReqChallenge calls NetrServerReqChallenge ([MS-NRPC] 3.5.4.4.1, opnum 4): the
+// client sends a challenge and receives the server's challenge, the first step of secure
+// channel negotiation.
+//
+// Parameters:
+//   - rpc: A DCE/RPC client bound to the Netlogon interface.
+//   - primaryName: The DC name (empty string sends a NULL unique pointer).
+//   - computerName: The NetBIOS name of the client computer.
+//   - clientChallenge: The client challenge.
+//
+// Returns:
+//   - The server challenge, the NTSTATUS return value, and a transport error.
+func NetrServerReqChallenge(rpc ndr.Invoker, primaryName, computerName string, clientChallenge structures.NETLOGON_CREDENTIAL) (structures.NETLOGON_CREDENTIAL, uint32, error) {
+	req := &netrServerReqChallengeRequest{
+		ComputerName:    ndr.WSTR(computerName),
+		ClientChallenge: clientChallenge,
+	}
+	if primaryName != "" {
+		pn := ndr.WSTR(primaryName)
+		req.PrimaryName = &pn
+	}
+
+	var resp netrServerReqChallengeResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return structures.NETLOGON_CREDENTIAL{}, 0, fmt.Errorf("NetrServerReqChallenge: %w", err)
+	}
+	return resp.ServerChallenge, uint32(resp.Status), nil
+}

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/15_NetrServerAuthenticate2.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/15_NetrServerAuthenticate2.go
@@ -1,0 +1,64 @@
+package functions
+
+import (
+	"fmt"
+
+	netlogon "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/structures"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+type netrServerAuthenticate2Request struct {
+	PrimaryName       *ndr.WSTR `ndr:"unique"`
+	AccountName       ndr.WSTR
+	SecureChannelType netlogon.NETLOGON_SECURE_CHANNEL_TYPE `ndr:"enum"`
+	ComputerName      ndr.WSTR
+	ClientCredential  structures.NETLOGON_CREDENTIAL
+	NegotiateFlags    ndr.DWORD
+}
+
+func (*netrServerAuthenticate2Request) Opnum() uint16 {
+	return netlogon.OpnumNetrServerAuthenticate2
+}
+
+type netrServerAuthenticate2Response struct {
+	ServerCredential structures.NETLOGON_CREDENTIAL
+	NegotiateFlags   ndr.DWORD
+	Status           ndr.DWORD `ndr:"retval"`
+}
+
+// NetrServerAuthenticate2 calls NetrServerAuthenticate2 ([MS-NRPC] 3.5.4.4.2, opnum 15). It
+// returns the server-computed credential, the negotiated flags, and the raw NTSTATUS, so
+// the caller can distinguish STATUS_ACCESS_DENIED from STATUS_SUCCESS without treating the
+// former as a transport error.
+//
+// Parameters:
+//   - rpc: A DCE/RPC client bound to the Netlogon interface.
+//   - primaryName: The DC name (empty sends a NULL unique pointer).
+//   - accountName: The account being authenticated (e.g. "DC$").
+//   - secureChannelType: The secure channel kind.
+//   - computerName: The NetBIOS name of the client computer.
+//   - clientCredential: The client credential to present.
+//   - negotiateFlags: The requested negotiate flags.
+//
+// Returns:
+//   - The server credential, the negotiated flags, the NTSTATUS, and a transport error.
+func NetrServerAuthenticate2(rpc ndr.Invoker, primaryName, accountName string, secureChannelType netlogon.NETLOGON_SECURE_CHANNEL_TYPE, computerName string, clientCredential structures.NETLOGON_CREDENTIAL, negotiateFlags uint32) (structures.NETLOGON_CREDENTIAL, uint32, uint32, error) {
+	req := &netrServerAuthenticate2Request{
+		AccountName:       ndr.WSTR(accountName),
+		SecureChannelType: secureChannelType,
+		ComputerName:      ndr.WSTR(computerName),
+		ClientCredential:  clientCredential,
+		NegotiateFlags:    ndr.DWORD(negotiateFlags),
+	}
+	if primaryName != "" {
+		pn := ndr.WSTR(primaryName)
+		req.PrimaryName = &pn
+	}
+
+	var resp netrServerAuthenticate2Response
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return structures.NETLOGON_CREDENTIAL{}, 0, 0, fmt.Errorf("NetrServerAuthenticate2: %w", err)
+	}
+	return resp.ServerCredential, uint32(resp.NegotiateFlags), uint32(resp.Status), nil
+}

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/30_NetrServerPasswordSet2.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/30_NetrServerPasswordSet2.go
@@ -1,0 +1,62 @@
+package functions
+
+import (
+	"fmt"
+
+	netlogon "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/structures"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+type netrServerPasswordSet2Request struct {
+	PrimaryName       *ndr.WSTR `ndr:"unique"`
+	AccountName       ndr.WSTR
+	SecureChannelType netlogon.NETLOGON_SECURE_CHANNEL_TYPE `ndr:"enum"`
+	ComputerName      ndr.WSTR
+	Authenticator     structures.NETLOGON_AUTHENTICATOR
+	ClearNewPassword  structures.NL_TRUST_PASSWORD
+}
+
+func (*netrServerPasswordSet2Request) Opnum() uint16 {
+	return netlogon.OpnumNetrServerPasswordSet2
+}
+
+type netrServerPasswordSet2Response struct {
+	ReturnAuthenticator structures.NETLOGON_AUTHENTICATOR
+	Status              ndr.DWORD `ndr:"retval"`
+}
+
+// NetrServerPasswordSet2 calls NetrServerPasswordSet2 ([MS-NRPC] 3.5.4.4.5, opnum 30) to
+// set the account password. Passing an all-zero ClearNewPassword blanks the target
+// account's password.
+//
+// Parameters:
+//   - rpc: A DCE/RPC client bound to the Netlogon interface.
+//   - primaryName: The DC name (empty sends a NULL unique pointer).
+//   - accountName: The account whose password is being set (e.g. "DC$").
+//   - secureChannelType: The secure channel kind.
+//   - computerName: The NetBIOS name of the client computer.
+//   - authenticator: The request authenticator.
+//   - clearNewPassword: The new password structure.
+//
+// Returns:
+//   - The return authenticator, the NTSTATUS, and a transport error.
+func NetrServerPasswordSet2(rpc ndr.Invoker, primaryName, accountName string, secureChannelType netlogon.NETLOGON_SECURE_CHANNEL_TYPE, computerName string, authenticator structures.NETLOGON_AUTHENTICATOR, clearNewPassword structures.NL_TRUST_PASSWORD) (structures.NETLOGON_AUTHENTICATOR, uint32, error) {
+	req := &netrServerPasswordSet2Request{
+		AccountName:       ndr.WSTR(accountName),
+		SecureChannelType: secureChannelType,
+		ComputerName:      ndr.WSTR(computerName),
+		Authenticator:     authenticator,
+		ClearNewPassword:  clearNewPassword,
+	}
+	if primaryName != "" {
+		pn := ndr.WSTR(primaryName)
+		req.PrimaryName = &pn
+	}
+
+	var resp netrServerPasswordSet2Response
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return structures.NETLOGON_AUTHENTICATOR{}, 0, fmt.Errorf("NetrServerPasswordSet2: %w", err)
+	}
+	return resp.ReturnAuthenticator, uint32(resp.Status), nil
+}

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/crypto.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/crypto.go
@@ -1,0 +1,67 @@
+package functions
+
+import (
+	"crypto/aes"
+	"crypto/hmac"
+	"crypto/sha256"
+
+	"github.com/TheManticoreProject/Manticore/crypto/cfb8"
+	"github.com/TheManticoreProject/Manticore/crypto/nt"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/structures"
+)
+
+// ComputeSessionKeyAES derives the AES Netlogon session key ([MS-NRPC] 3.1.4.4.1). The key
+// material is the account's NT one-way function (NTOWFv1 = MD4(UTF16-LE(password))); the
+// session key is the first 16 octets of HMAC-SHA256(NTOWFv1, ClientChallenge ||
+// ServerChallenge).
+//
+// Exactly one of password or ntHash supplies the key material: when ntHash is non-nil it is
+// used directly (the raw 16-byte NT hash, e.g. for pass-the-hash), otherwise it is derived
+// from password.
+//
+// Parameters:
+//   - password: The account cleartext password, or "" when ntHash is used.
+//   - ntHash: The raw 16-byte NT hash, or nil when password is used.
+//   - clientChallenge: The client challenge.
+//   - serverChallenge: The server challenge.
+//
+// Returns:
+//   - The 16-byte AES session key.
+func ComputeSessionKeyAES(password string, ntHash []byte, clientChallenge, serverChallenge structures.NETLOGON_CREDENTIAL) [16]byte {
+	key := ntHash
+	if key == nil {
+		h := nt.NTHash(password)
+		key = h[:]
+	}
+
+	mac := hmac.New(sha256.New, key)
+	mac.Write(clientChallenge[:])
+	mac.Write(serverChallenge[:])
+	sum := mac.Sum(nil)
+
+	var sessionKey [16]byte
+	copy(sessionKey[:], sum[:16])
+	return sessionKey
+}
+
+// ComputeNetlogonCredentialAES computes a Netlogon credential ([MS-NRPC] 3.1.4.4.1) by
+// encrypting an 8-byte challenge with AES-128 in 8-bit cipher feedback (CFB8) mode under the
+// session key and an all-zero IV.
+//
+// Parameters:
+//   - challenge: The 8-byte input challenge.
+//   - sessionKey: The 16-byte AES session key.
+//
+// Returns:
+//   - The 8-byte Netlogon credential.
+func ComputeNetlogonCredentialAES(challenge structures.NETLOGON_CREDENTIAL, sessionKey [16]byte) structures.NETLOGON_CREDENTIAL {
+	block, err := aes.NewCipher(sessionKey[:])
+	if err != nil {
+		// sessionKey is always 16 bytes, so this cannot fail in practice.
+		panic(err)
+	}
+	var iv [aes.BlockSize]byte // 16 zero octets
+	var out structures.NETLOGON_CREDENTIAL
+	cfb8.NewEncrypter(block, iv[:]).XORKeyStream(out[:], challenge[:])
+	return out
+}

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/functions_test.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/functions_test.go
@@ -1,0 +1,120 @@
+package functions_test
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+
+	netlogon "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/structures"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// captureInvoker records the marshalled request stub and opnum without any network I/O, so
+// the on-the-wire NDR layout of the Netlogon requests can be asserted.
+type captureInvoker struct {
+	stub  []byte
+	opnum uint16
+}
+
+func (c *captureInvoker) Invoke(in ndr.Call, out any) error {
+	b, err := ndr.Request(in)
+	if err != nil {
+		return err
+	}
+	c.stub = b
+	c.opnum = in.Opnum()
+	return nil
+}
+
+// TestNetrServerReqChallengeMarshal checks the opnum, the trailing fixed 8-byte client
+// challenge, and that the computer name is carried as a UTF-16LE NDR string.
+func TestNetrServerReqChallengeMarshal(t *testing.T) {
+	cap := &captureInvoker{}
+	challenge := structures.NETLOGON_CREDENTIAL{1, 2, 3, 4, 5, 6, 7, 8}
+
+	if _, _, err := functions.NetrServerReqChallenge(cap, "DC", "DC", challenge); err != nil {
+		t.Fatalf("NetrServerReqChallenge: %v", err)
+	}
+	if cap.opnum != netlogon.OpnumNetrServerReqChallenge {
+		t.Fatalf("opnum = %d, want %d", cap.opnum, netlogon.OpnumNetrServerReqChallenge)
+	}
+	if got := cap.stub[len(cap.stub)-8:]; !bytes.Equal(got, challenge[:]) {
+		t.Fatalf("trailing challenge = %x, want %x", got, challenge[:])
+	}
+	if !bytes.Contains(cap.stub, []byte{'D', 0, 'C', 0}) {
+		t.Fatalf("UTF-16LE %q not found in stub %x", "DC", cap.stub)
+	}
+}
+
+// TestNetrServerAuthenticate2Marshal checks the enum width and that the negotiate flags and
+// credential are present, exercising the enum + fixed-array + scalar field tags together.
+func TestNetrServerAuthenticate2Marshal(t *testing.T) {
+	cap := &captureInvoker{}
+	cred := structures.NETLOGON_CREDENTIAL{9, 8, 7, 6, 5, 4, 3, 2}
+
+	if _, _, _, err := functions.NetrServerAuthenticate2(cap, "", "DC$", netlogon.ServerSecureChannel, "DC", cred, 0x612fffff); err != nil {
+		t.Fatalf("NetrServerAuthenticate2: %v", err)
+	}
+	if cap.opnum != netlogon.OpnumNetrServerAuthenticate2 {
+		t.Fatalf("opnum = %d, want %d", cap.opnum, netlogon.OpnumNetrServerAuthenticate2)
+	}
+	// PrimaryName is NULL -> the stub must begin with a zero referent id.
+	if len(cap.stub) < 4 || cap.stub[0] != 0 || cap.stub[1] != 0 || cap.stub[2] != 0 || cap.stub[3] != 0 {
+		t.Fatalf("expected NULL PrimaryName referent at start, got %x", cap.stub[:4])
+	}
+	// NegotiateFlags is the trailing 4-aligned DWORD.
+	flags := cap.stub[len(cap.stub)-4:]
+	if !bytes.Equal(flags, []byte{0xff, 0xff, 0x2f, 0x61}) {
+		t.Fatalf("trailing negotiate flags = %x, want ff ff 2f 61", flags)
+	}
+	if !bytes.Contains(cap.stub, cred[:]) {
+		t.Fatalf("credential %x not found in stub %x", cred[:], cap.stub)
+	}
+}
+
+// TestNetrServerPasswordSet2Marshal verifies the request carries the 516-octet all-zero
+// NL_TRUST_PASSWORD.
+func TestNetrServerPasswordSet2Marshal(t *testing.T) {
+	cap := &captureInvoker{}
+	auth := structures.NETLOGON_AUTHENTICATOR{Credential: structures.NETLOGON_CREDENTIAL{1, 1, 1, 1, 1, 1, 1, 1}, Timestamp: 0}
+
+	if _, _, err := functions.NetrServerPasswordSet2(cap, "DC", "DC$", netlogon.ServerSecureChannel, "DC", auth, structures.NL_TRUST_PASSWORD{}); err != nil {
+		t.Fatalf("NetrServerPasswordSet2: %v", err)
+	}
+	if cap.opnum != netlogon.OpnumNetrServerPasswordSet2 {
+		t.Fatalf("opnum = %d, want %d", cap.opnum, netlogon.OpnumNetrServerPasswordSet2)
+	}
+	tail := cap.stub[len(cap.stub)-516:]
+	for i, b := range tail {
+		if b != 0 {
+			t.Fatalf("ClearNewPassword octet %d = 0x%02x, want 0", i, b)
+		}
+	}
+}
+
+// TestComputeNetlogonCredentialAES pins the credential cryptography ([MS-NRPC] 3.1.4.4.1)
+// to a regression vector: AES-128-CFB8 of a fixed challenge under a fixed session key.
+func TestComputeNetlogonCredentialAES(t *testing.T) {
+	var sk [16]byte
+	for i := range sk {
+		sk[i] = byte(i)
+	}
+	challenge := structures.NETLOGON_CREDENTIAL{0, 0, 0, 0, 0x11, 0x11, 0x11, 0}
+	got := functions.ComputeNetlogonCredentialAES(challenge, sk)
+	if want := "c64020e48fee8f96"; hex.EncodeToString(got[:]) != want {
+		t.Fatalf("credential = %x, want %s", got[:], want)
+	}
+}
+
+// TestComputeSessionKeyAES pins the session-key derivation ([MS-NRPC] 3.1.4.4.1) to a
+// regression vector: first 16 octets of HMAC-SHA256(NTOWFv1(password), client || server).
+func TestComputeSessionKeyAES(t *testing.T) {
+	client := structures.NETLOGON_CREDENTIAL{'1', '2', '3', '4', '5', '6', '7', '8'}
+	server := structures.NETLOGON_CREDENTIAL{8, 7, 6, 5, 4, 3, 2, 1}
+	got := functions.ComputeSessionKeyAES("Password1", nil, client, server)
+	if want := "3a2f0633feed49dcb158b0e72d441508"; hex.EncodeToString(got[:]) != want {
+		t.Fatalf("session key = %x, want %s", got[:], want)
+	}
+}

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/interface.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/interface.go
@@ -1,0 +1,137 @@
+// Package rpcinterface_123456781234abcdef0001234567cffb_1_0 is the descriptor for the
+// Netlogon RPC interface, abstract syntax 12345678-1234-abcd-ef00-01234567cffb version 1.0
+// ([MS-NRPC]).
+//
+// Hand-written (not idlgen-generated): only the slice of MS-NRPC needed to establish and
+// use a Netlogon secure channel is modelled — NetrServerReqChallenge (4),
+// NetrServerAuthenticate2 (15) and NetrServerPasswordSet2 (30) — so the opnum table below
+// is intentionally partial and documents just the implemented methods.
+package rpcinterface_123456781234abcdef0001234567cffb_1_0
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+)
+
+// PipeName is the IPC$-relative named pipe for the Netlogon interface ([MS-NRPC] 2.1: the
+// Netlogon server listens on the \PIPE\netlogon endpoint over ncacn_np). Netlogon is also
+// reachable over ncacn_ip_tcp at a dynamic port resolved through the endpoint mapper.
+const PipeName = `\netlogon`
+
+// Opnums for the implemented on-the-wire methods ([MS-NRPC] 3.5.4.4).
+const (
+	OpnumNetrServerReqChallenge  uint16 = 4
+	OpnumNetrServerAuthenticate2 uint16 = 15
+	OpnumNetrServerPasswordSet2  uint16 = 30
+)
+
+// OpnumToName maps each implemented opnum to its method name; the single source of truth
+// for the (partial) wire numbering of this interface.
+var OpnumToName = map[uint16]string{
+	OpnumNetrServerReqChallenge:  "NetrServerReqChallenge",
+	OpnumNetrServerAuthenticate2: "NetrServerAuthenticate2",
+	OpnumNetrServerPasswordSet2:  "NetrServerPasswordSet2",
+}
+
+// NameToOpnum is the inverse of OpnumToName, derived at init.
+var NameToOpnum = func() map[string]uint16 {
+	m := make(map[string]uint16, len(OpnumToName))
+	for op, name := range OpnumToName {
+		m[name] = op
+	}
+	return m
+}()
+
+// NTSTATUS values returned by Netlogon methods ([MS-ERREF] 2.3). Netlogon returns NTSTATUS
+// (not the Win32 error_status_t that MS-RRP uses). StatusSuccess is the canonical success
+// value; StatusAccessDenied is what the server returns for a rejected secure-channel
+// credential.
+const (
+	StatusSuccess            uint32 = 0x00000000 // STATUS_SUCCESS
+	StatusInvalidParameter   uint32 = 0xC000000D // STATUS_INVALID_PARAMETER
+	StatusAccessDenied       uint32 = 0xC0000022 // STATUS_ACCESS_DENIED
+	StatusNoTrustSAMAccount  uint32 = 0xC000018B // STATUS_NO_TRUST_SAM_ACCOUNT
+	StatusNoSuchUser         uint32 = 0xC0000064 // STATUS_NO_SUCH_USER
+	StatusNotSupported       uint32 = 0xC00000BB // STATUS_NOT_SUPPORTED
+	StatusDowngradeDetected  uint32 = 0xC0000388 // STATUS_DOWNGRADE_DETECTED
+)
+
+// StatusString returns a mnemonic for the documented status codes, otherwise the hex value.
+func StatusString(status uint32) string {
+	switch status {
+	case StatusSuccess:
+		return "STATUS_SUCCESS"
+	case StatusInvalidParameter:
+		return "STATUS_INVALID_PARAMETER"
+	case StatusAccessDenied:
+		return "STATUS_ACCESS_DENIED"
+	case StatusNoTrustSAMAccount:
+		return "STATUS_NO_TRUST_SAM_ACCOUNT"
+	case StatusNoSuchUser:
+		return "STATUS_NO_SUCH_USER"
+	case StatusNotSupported:
+		return "STATUS_NOT_SUPPORTED"
+	case StatusDowngradeDetected:
+		return "STATUS_DOWNGRADE_DETECTED"
+	default:
+		return fmt.Sprintf("0x%08x", status)
+	}
+}
+
+// NETLOGON_SECURE_CHANNEL_TYPE ([MS-NRPC] 2.2.1.3.13) identifies the kind of secure channel
+// being established. It is an NDR enum (2 octets under NDR20); use the `ndr:"enum"` tag on
+// fields of this type.
+type NETLOGON_SECURE_CHANNEL_TYPE uint16
+
+const (
+	NullSecureChannel             NETLOGON_SECURE_CHANNEL_TYPE = 0
+	MsvApSecureChannel            NETLOGON_SECURE_CHANNEL_TYPE = 1
+	WorkstationSecureChannel      NETLOGON_SECURE_CHANNEL_TYPE = 2
+	TrustedDnsDomainSecureChannel NETLOGON_SECURE_CHANNEL_TYPE = 3
+	TrustedDomainSecureChannel    NETLOGON_SECURE_CHANNEL_TYPE = 4
+	UasServerSecureChannel        NETLOGON_SECURE_CHANNEL_TYPE = 5
+	ServerSecureChannel           NETLOGON_SECURE_CHANNEL_TYPE = 6
+	CdcServerSecureChannel        NETLOGON_SECURE_CHANNEL_TYPE = 7
+)
+
+// Netlogon negotiate option bits ([MS-NRPC] 3.1.4.2), one per capability letter (A–Z).
+const (
+	NegotiateAccountLockout             uint32 = 0x00000001 // A
+	NegotiateNT35BDCContinuousUpdate    uint32 = 0x00000002 // B
+	NegotiateRC4                        uint32 = 0x00000004 // C
+	NegotiatePromotionCount             uint32 = 0x00000008 // D
+	NegotiateBDCHandlingChangelogs      uint32 = 0x00000010 // E
+	NegotiateRestartFullDCSync          uint32 = 0x00000020 // F
+	NegotiateNoValidationLevel2         uint32 = 0x00000040 // G
+	NegotiateDatabaseRedo               uint32 = 0x00000080 // H
+	NegotiateRefusePasswordChange       uint32 = 0x00000100 // I
+	NegotiateSendToSAM                  uint32 = 0x00000200 // J
+	NegotiateGenericPassThrough         uint32 = 0x00000400 // K
+	NegotiateConcurrentRPC              uint32 = 0x00000800 // L
+	NegotiateAvoidUserAccountDBRepl     uint32 = 0x00001000 // M
+	NegotiateAvoidSecurityAuthorityRepl uint32 = 0x00002000 // N
+	NegotiateStrongKeys                 uint32 = 0x00004000 // O
+	NegotiateTransitiveTrusts           uint32 = 0x00008000 // P
+	NegotiateDNSTrusts                  uint32 = 0x00010000 // Q
+	NegotiatePasswordSet2               uint32 = 0x00020000 // R
+	NegotiateGetDomainInfo              uint32 = 0x00040000 // S
+	NegotiateCrossForestTrusts          uint32 = 0x00080000 // T
+	NegotiateNoNT4Emulation             uint32 = 0x00100000 // U
+	NegotiateRODCPassThrough            uint32 = 0x00200000 // V
+	NegotiateAES                        uint32 = 0x01000000 // W (AES-128 CFB8 + SHA2)
+	NegotiateAuthenticatedRPCViaLSASS   uint32 = 0x20000000 // X
+	NegotiateSecureRPC                  uint32 = 0x40000000 // Y
+	NegotiateKerberosForSecureChannel   uint32 = 0x80000000 // Z
+)
+
+// SyntaxID returns the Netlogon abstract syntax identifier:
+// 12345678-1234-abcd-ef00-01234567cffb, version 1.0.
+func SyntaxID() syntax.SyntaxID {
+	return syntax.SyntaxID{
+		UUID:         guid.GUID{A: 0x12345678, B: 0x1234, C: 0xabcd, D: 0xef00, E: 0x01234567cffb},
+		MajorVersion: 1,
+		MinorVersion: 0,
+	}
+}

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/interface_test.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/interface_test.go
@@ -1,0 +1,34 @@
+package rpcinterface_123456781234abcdef0001234567cffb_1_0
+
+import "testing"
+
+// TestSyntaxID verifies the abstract syntax identity (UUID + version) of the interface.
+func TestSyntaxID(t *testing.T) {
+	s := SyntaxID()
+	if got := s.UUID.ToFormatD(); got != "12345678-1234-abcd-ef00-01234567cffb" {
+		t.Fatalf("UUID = %s, want 12345678-1234-abcd-ef00-01234567cffb", got)
+	}
+	if s.MajorVersion != 1 || s.MinorVersion != 0 {
+		t.Fatalf("version = %d.%d, want 1.0", s.MajorVersion, s.MinorVersion)
+	}
+}
+
+// TestOpnums verifies the implemented opnums and the name mapping.
+func TestOpnums(t *testing.T) {
+	if OpnumNetrServerReqChallenge != 4 || OpnumNetrServerAuthenticate2 != 15 || OpnumNetrServerPasswordSet2 != 30 {
+		t.Fatalf("opnums = %d/%d/%d, want 4/15/30", OpnumNetrServerReqChallenge, OpnumNetrServerAuthenticate2, OpnumNetrServerPasswordSet2)
+	}
+	if OpnumToName[15] != "NetrServerAuthenticate2" || NameToOpnum["NetrServerPasswordSet2"] != 30 {
+		t.Fatal("opnum name mapping is inconsistent")
+	}
+}
+
+// TestStatusString verifies mnemonic rendering and the hex fallback.
+func TestStatusString(t *testing.T) {
+	if got := StatusString(StatusAccessDenied); got != "STATUS_ACCESS_DENIED" {
+		t.Fatalf("StatusString(AccessDenied) = %s", got)
+	}
+	if got := StatusString(0xDEADBEEF); got != "0xdeadbeef" {
+		t.Fatalf("StatusString(unknown) = %s, want 0xdeadbeef", got)
+	}
+}

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/structures/NETLOGON_AUTHENTICATOR.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/structures/NETLOGON_AUTHENTICATOR.go
@@ -1,0 +1,9 @@
+package structures
+
+// NETLOGON_AUTHENTICATOR ([MS-NRPC] 2.2.1.3.5) carries a client/server credential and a
+// timestamp. The 8-byte credential needs no alignment; the ULONG timestamp is 4-aligned,
+// landing at offset 8 (already aligned), for a 12-octet structure.
+type NETLOGON_AUTHENTICATOR struct {
+	Credential NETLOGON_CREDENTIAL
+	Timestamp  uint32
+}

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/structures/NETLOGON_CREDENTIAL.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/structures/NETLOGON_CREDENTIAL.go
@@ -1,0 +1,8 @@
+// Package structures holds the NDR wire types of the Netlogon interface
+// (12345678-1234-abcd-ef00-01234567cffb, [MS-NRPC]).
+package structures
+
+// NETLOGON_CREDENTIAL ([MS-NRPC] 2.2.1.3.4) is an opaque 8-octet challenge or credential.
+// On the wire it is a fixed array of 8 bytes with no NDR conformance framing, so a Go
+// [8]byte marshals it exactly.
+type NETLOGON_CREDENTIAL [8]byte

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/structures/NL_TRUST_PASSWORD.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/structures/NL_TRUST_PASSWORD.go
@@ -1,0 +1,10 @@
+package structures
+
+// NL_TRUST_PASSWORD ([MS-NRPC] 2.2.1.3.7) holds a new machine/trust password as a fixed
+// 256-WCHAR (512-octet) buffer followed by its byte length, for a 516-octet structure. An
+// all-zero value (empty buffer, Length 0) sets the target account password to the empty
+// string.
+type NL_TRUST_PASSWORD struct {
+	Buffer [512]byte
+	Length uint32
+}

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/structures/structures_test.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/structures/structures_test.go
@@ -1,0 +1,53 @@
+package structures
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// TestNetlogonCredentialWire verifies the 8-octet fixed-array credential marshals verbatim
+// with no NDR framing when carried as a struct field (its only use on the wire).
+func TestNetlogonCredentialWire(t *testing.T) {
+	type wrap struct{ C NETLOGON_CREDENTIAL }
+	c := NETLOGON_CREDENTIAL{1, 2, 3, 4, 5, 6, 7, 8}
+	raw, err := ndr.Marshal(&wrap{C: c})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if !bytes.Equal(raw, c[:]) {
+		t.Fatalf("credential wire = %x, want %x", raw, c[:])
+	}
+}
+
+// TestNetlogonAuthenticatorWire verifies the authenticator is a 12-octet structure (8-byte
+// credential + 4-byte timestamp) with the timestamp little-endian at offset 8.
+func TestNetlogonAuthenticatorWire(t *testing.T) {
+	a := NETLOGON_AUTHENTICATOR{Credential: NETLOGON_CREDENTIAL{1, 1, 1, 1, 1, 1, 1, 1}, Timestamp: 0x04030201}
+	raw, err := ndr.Marshal(&a)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	want := []byte{1, 1, 1, 1, 1, 1, 1, 1, 0x01, 0x02, 0x03, 0x04}
+	if !bytes.Equal(raw, want) {
+		t.Fatalf("authenticator wire = %x, want %x", raw, want)
+	}
+}
+
+// TestTrustPasswordWire verifies an all-zero NL_TRUST_PASSWORD marshals to 516 zero octets
+// (512-byte buffer + 4-byte length), the empty-password form.
+func TestTrustPasswordWire(t *testing.T) {
+	raw, err := ndr.Marshal(&NL_TRUST_PASSWORD{})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if len(raw) != 516 {
+		t.Fatalf("trust password length = %d, want 516", len(raw))
+	}
+	for i, b := range raw {
+		if b != 0 {
+			t.Fatalf("octet %d = 0x%02x, want 0", i, b)
+		}
+	}
+}


### PR DESCRIPTION
### Linked Issue

`Closes #741`

### Root Cause

The interface catalog advertised `netlogon` (MS-NRPC, `12345678-1234-abcd-ef00-01234567cffb` v1.0) but no interface package implemented it, so there was no in-library way to negotiate or use a Netlogon secure channel. The methods and their credential cryptography had to be reimplemented out-of-tree.

### Fix Description

Adds a hand-written interface package under `network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0`, following the existing per-interface layout (descriptor + `structures/` + `functions/`, `ndr.Invoker`-based stubs). It models the slice of MS-NRPC needed for a Netlogon secure channel:

- **Descriptor** (`interface.go`): `SyntaxID`, `PipeName`, the implemented opnums (4/15/30) with `OpnumToName`/`NameToOpnum`, NTSTATUS codes + `StatusString`, the `NETLOGON_SECURE_CHANNEL_TYPE` enum, and the [MS-NRPC] 3.1.4.2 negotiate-flag constants.
- **Structures** (`structures/`): `NETLOGON_CREDENTIAL`, `NETLOGON_AUTHENTICATOR`, `NL_TRUST_PASSWORD`.
- **Functions** (`functions/`): `NetrServerReqChallenge` (4), `NetrServerAuthenticate2` (15), `NetrServerPasswordSet2` (30), plus the client cryptography `ComputeSessionKeyAES` / `ComputeNetlogonCredentialAES` ([MS-NRPC] 3.1.4.4.1), the latter built on the `crypto/cfb8` package from #739.

The opnum table is intentionally partial (only the three implemented methods) and documented as such.

### How Verified

- **Tests:** `go test ./network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/...` passes.
  - Structures: fixed-array credential emits 8 octets verbatim as a field; authenticator is 12 octets (credential + LE timestamp); `NL_TRUST_PASSWORD{}` is 516 zero octets.
  - Functions: opnum + NDR layout of all three requests (NULL PrimaryName referent, UTF-16LE names, 16-bit `SecureChannelType` enum, trailing negotiate DWORD, 516-octet ClearNewPassword); regression vectors for `ComputeNetlogonCredentialAES` and `ComputeSessionKeyAES`.
  - Descriptor: `SyntaxID`, opnums, `StatusString`.
- **Runtime (live DC):** bound Netlogon via the endpoint mapper and called `NetrServerReqChallenge` against a Windows Server 2025 DC (`TMP-W-2025-DC1`) — returned `STATUS_SUCCESS` with a server challenge, confirming the on-wire framing.

### Test Coverage

- **Added:** `.../1.0/interface_test.go`, `.../1.0/structures/structures_test.go`, `.../1.0/functions/functions_test.go`.

### Scope of Change

- **Files changed:** new package only — `.../1.0/interface.go`, `interface_test.go`, `structures/{NETLOGON_CREDENTIAL,NETLOGON_AUTHENTICATOR,NL_TRUST_PASSWORD}.go`, `structures/structures_test.go`, `functions/{04_NetrServerReqChallenge,15_NetrServerAuthenticate2,30_NetrServerPasswordSet2,crypto}.go`, `functions/functions_test.go`.
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout

New, additive package; nothing else in the module imports it, so there is no regression surface. Safe to merge.

### Notes

- **Stacked on #740 (issue #739).** This branch is cut from `feature-crypto-cfb8`; its base is set to that branch so the diff shows only the Netlogon files. After #740 merges to `main`, this PR retargets to `main` automatically.
- Related: #655 (Netlogon RPC signing/sealing auth) is complementary — this PR adds the interface methods, not the RPC auth mechanism.
