### PR TITLE
Add Common Internet File System (CIFS) Browser Auxiliary Protocol (MS-BRWSA) client interface

### DIFF
--- a/network/dcerpc/interfaces/6bffd098-a112-3610-9833-012892020162/0.0/functions/02_I_BrowserrQueryOtherDomains.go
+++ b/network/dcerpc/interfaces/6bffd098-a112-3610-9833-012892020162/0.0/functions/02_I_BrowserrQueryOtherDomains.go
@@ -1,0 +1,51 @@
+package functions
+
+import (
+	"fmt"
+
+	browser "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/6bffd098-a112-3610-9833-012892020162/0.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	msbrwsa "github.com/TheManticoreProject/Manticore/windows/protocols/ms-brwsa"
+)
+
+// i_BrowserrQueryOtherDomainsRequest carries the [in] and [in,out] parameters of
+// I_BrowserrQueryOtherDomains: the optional [unique] server name (ignored on receipt) and
+// the [in,out] enumeration structure whose Level selects the info arm.
+type i_BrowserrQueryOtherDomainsRequest struct {
+	ServerName *ndr.WSTR `ndr:"unique"`
+	InfoStruct msbrwsa.SERVER_ENUM_STRUCT
+}
+
+func (*i_BrowserrQueryOtherDomainsRequest) Opnum() uint16 {
+	return browser.OpnumI_BrowserrQueryOtherDomains
+}
+
+// i_BrowserrQueryOtherDomainsResponse carries the updated [in,out] structure, the [out]
+// total entry count, and the NET_API_STATUS return value.
+type i_BrowserrQueryOtherDomainsResponse struct {
+	InfoStruct   msbrwsa.SERVER_ENUM_STRUCT
+	TotalEntries ndr.DWORD
+	Status       ndr.DWORD `ndr:"retval"`
+}
+
+// I_BrowserrQueryOtherDomains calls I_BrowserrQueryOtherDomains (opnum 2), returning the
+// list of other domains configured for the target computer ([MS-BRWSA] 3.1.4.1). The
+// client SHOULD send this only to a primary domain controller acting as the domain master
+// browser. serverName is ignored on receipt (pass "" for NULL). Level MUST be 100; any
+// other value yields ERROR_INVALID_LEVEL. ERROR_MORE_DATA means not all entries were
+// returned and is not treated as a failure.
+func I_BrowserrQueryOtherDomains(rpc ndr.Invoker, serverName string, info msbrwsa.SERVER_ENUM_STRUCT) (msbrwsa.SERVER_ENUM_STRUCT, uint32, error) {
+	req := &i_BrowserrQueryOtherDomainsRequest{
+		ServerName: optWStr(serverName),
+		InfoStruct: info,
+	}
+	var resp i_BrowserrQueryOtherDomainsResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return msbrwsa.SERVER_ENUM_STRUCT{}, 0, fmt.Errorf("I_BrowserrQueryOtherDomains: %w", err)
+	}
+	status := uint32(resp.Status)
+	if status != browser.NERR_Success && status != browser.ERROR_MORE_DATA {
+		return resp.InfoStruct, uint32(resp.TotalEntries), fmt.Errorf("I_BrowserrQueryOtherDomains failed: %s", browser.StatusString(status))
+	}
+	return resp.InfoStruct, uint32(resp.TotalEntries), nil
+}

--- a/network/dcerpc/interfaces/6bffd098-a112-3610-9833-012892020162/0.0/functions/functions.go
+++ b/network/dcerpc/interfaces/6bffd098-a112-3610-9833-012892020162/0.0/functions/functions.go
@@ -1,0 +1,17 @@
+// Package functions implements the method stubs of the browser interface
+// (6bffd098-a112-3610-9833-012892020162 v0.0, [MS-BRWSA]). Each opnum lives in its own
+// NN_MethodName.go file; this file holds the small helpers shared across methods.
+package functions
+
+import "github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+
+// optWStr returns a [unique], [string] wide-character pointer for s, or nil for the empty
+// string. The browser interface's ServerName is an [in,string,unique]
+// BROWSER_IDENTIFY_HANDLE whose value is ignored on receipt; nil is a NULL pointer.
+func optWStr(s string) *ndr.WSTR {
+	if s == "" {
+		return nil
+	}
+	w := ndr.WSTR(s)
+	return &w
+}

--- a/network/dcerpc/interfaces/6bffd098-a112-3610-9833-012892020162/0.0/interface.go
+++ b/network/dcerpc/interfaces/6bffd098-a112-3610-9833-012892020162/0.0/interface.go
@@ -1,0 +1,84 @@
+// Package rpcinterface_6bffd098a11236109833012892020162_0_0 is the descriptor for the
+// browser (\browser) RPC interface, abstract syntax
+// 6bffd098-a112-3610-9833-012892020162 version 0.0 ([MS-BRWSA]).
+//
+// An RPC interface is identified by its UUID and version, never by the named pipe it is
+// reached over. This package holds only the interface-level descriptor (abstract syntax,
+// transport endpoint, opnums, opnum<->name maps, and status constants). NDR types live in
+// windows/protocols/ms-brwsa and method stubs in functions; both depend on this package,
+// never the reverse.
+package rpcinterface_6bffd098a11236109833012892020162_0_0
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+)
+
+// PipeName is the IPC$-relative named pipe for the browser interface. The CIFS Browser
+// Auxiliary Protocol is available only over the \PIPE\browser named pipe ([MS-BRWSA] 2.1).
+const PipeName = `\browser`
+
+// Opnums for the on-the-wire methods. Opnums 0, 1, 3, 4, 5, 6, 7, 8, 9, 10, 11 are "not used on the wire"
+// and are omitted.
+const (
+	OpnumI_BrowserrQueryOtherDomains uint16 = 2
+)
+
+// NET_API_STATUS codes returned by I_BrowserrQueryOtherDomains ([MS-BRWSA] 3.1.4.1;
+// values from [MS-ERREF] Win32 error codes).
+const (
+	NERR_Success            uint32 = 0x00000000 // The operation completed successfully.
+	ERROR_ACCESS_DENIED     uint32 = 0x00000005 // Access is denied.
+	ERROR_NOT_ENOUGH_MEMORY uint32 = 0x00000008 // The server could not allocate enough memory.
+	ERROR_INVALID_PARAMETER uint32 = 0x00000057 // A parameter is incorrect (e.g. InfoStruct or Level100 is NULL).
+	ERROR_INVALID_LEVEL     uint32 = 0x0000007C // The Level member is not 100.
+	ERROR_MORE_DATA         uint32 = 0x000000EA // Not all available entries were returned.
+)
+
+// SyntaxID returns the browser abstract syntax identifier:
+// 6bffd098-a112-3610-9833-012892020162, version 0.0.
+func SyntaxID() syntax.SyntaxID {
+	return syntax.SyntaxID{
+		UUID:         guid.GUID{A: 0x6bffd098, B: 0xa112, C: 0x3610, D: 0x9833, E: 0x012892020162},
+		MajorVersion: 0,
+		MinorVersion: 0,
+	}
+}
+
+// StatusString returns a mnemonic for the documented status codes, otherwise the
+// hex value.
+func StatusString(status uint32) string {
+	switch status {
+	case NERR_Success:
+		return "NERR_Success"
+	case ERROR_ACCESS_DENIED:
+		return "ERROR_ACCESS_DENIED"
+	case ERROR_NOT_ENOUGH_MEMORY:
+		return "ERROR_NOT_ENOUGH_MEMORY"
+	case ERROR_INVALID_PARAMETER:
+		return "ERROR_INVALID_PARAMETER"
+	case ERROR_INVALID_LEVEL:
+		return "ERROR_INVALID_LEVEL"
+	case ERROR_MORE_DATA:
+		return "ERROR_MORE_DATA"
+	default:
+		return fmt.Sprintf("0x%08x", status)
+	}
+}
+
+// OpnumToName maps each on-the-wire opnum to its method name; the single source of
+// truth.
+var OpnumToName = map[uint16]string{
+	OpnumI_BrowserrQueryOtherDomains: "I_BrowserrQueryOtherDomains",
+}
+
+// NameToOpnum is the reverse of OpnumToName, built at init so the two never drift.
+var NameToOpnum = func() map[string]uint16 {
+	m := make(map[string]uint16, len(OpnumToName))
+	for op, name := range OpnumToName {
+		m[name] = op
+	}
+	return m
+}()

--- a/network/dcerpc/interfaces/6bffd098-a112-3610-9833-012892020162/0.0/interface_test.go
+++ b/network/dcerpc/interfaces/6bffd098-a112-3610-9833-012892020162/0.0/interface_test.go
@@ -1,0 +1,47 @@
+package rpcinterface_6bffd098a11236109833012892020162_0_0
+
+import "testing"
+
+// TestSyntaxID verifies the abstract syntax identity (UUID + version) of the interface.
+func TestSyntaxID(t *testing.T) {
+	s := SyntaxID()
+	if got := s.UUID.ToFormatD(); got != "6bffd098-a112-3610-9833-012892020162" {
+		t.Fatalf("UUID = %s, want 6bffd098-a112-3610-9833-012892020162", got)
+	}
+	if s.MajorVersion != 0 || s.MinorVersion != 0 {
+		t.Fatalf("version = %d.%d, want 0.0", s.MajorVersion, s.MinorVersion)
+	}
+}
+
+// TestOpnums verifies the single on-the-wire opnum and the name mapping round-trip.
+func TestOpnums(t *testing.T) {
+	if OpnumI_BrowserrQueryOtherDomains != 2 {
+		t.Fatalf("OpnumI_BrowserrQueryOtherDomains = %d, want 2", OpnumI_BrowserrQueryOtherDomains)
+	}
+	if OpnumToName[2] != "I_BrowserrQueryOtherDomains" || NameToOpnum["I_BrowserrQueryOtherDomains"] != 2 {
+		t.Fatal("opnum name mapping is inconsistent")
+	}
+	if len(OpnumToName) != len(NameToOpnum) {
+		t.Fatalf("OpnumToName/NameToOpnum size mismatch: %d vs %d", len(OpnumToName), len(NameToOpnum))
+	}
+}
+
+// TestStatusString verifies mnemonic rendering and the hex fallback.
+func TestStatusString(t *testing.T) {
+	if got := StatusString(ERROR_INVALID_LEVEL); got != "ERROR_INVALID_LEVEL" {
+		t.Fatalf("StatusString(ERROR_INVALID_LEVEL) = %s", got)
+	}
+	if got := StatusString(NERR_Success); got != "NERR_Success" {
+		t.Fatalf("StatusString(NERR_Success) = %s", got)
+	}
+	if got := StatusString(0xDEADBEEF); got != "0xdeadbeef" {
+		t.Fatalf("StatusString(unknown) = %s, want 0xdeadbeef", got)
+	}
+}
+
+// TestPipeName pins the transport endpoint ([MS-BRWSA] 2.1).
+func TestPipeName(t *testing.T) {
+	if PipeName != `\browser` {
+		t.Fatalf("PipeName = %q, want %q", PipeName, `\browser`)
+	}
+}

--- a/windows/protocols/ms-brwsa/BROWSER_IDENTIFY_HANDLE.go
+++ b/windows/protocols/ms-brwsa/BROWSER_IDENTIFY_HANDLE.go
@@ -1,0 +1,9 @@
+package msbrwsa
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// BROWSER_IDENTIFY_HANDLE is a [handle] LPWSTR ([MS-BRWSA] 2.2.2.1): a generic-handle
+// alias for a wide string used as the ServerName parameter of I_BrowserrQueryOtherDomains.
+type BROWSER_IDENTIFY_HANDLE = ndr.WSTR

--- a/windows/protocols/ms-brwsa/SERVER_ENUM_STRUCT.go
+++ b/windows/protocols/ms-brwsa/SERVER_ENUM_STRUCT.go
@@ -1,0 +1,23 @@
+package msbrwsa
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// SERVER_ENUM_STRUCT holds the level and the level-tagged container returned by
+// I_BrowserrQueryOtherDomains ([MS-BRWSA] 2.2.3.2). Level MUST be 100. The switch_is(Level)
+// union's discriminant is transmitted inline as SERVER_ENUM_UNION.Tag; set both Level and
+// ServerInfo.Tag to 100 before marshalling a request.
+type SERVER_ENUM_STRUCT struct {
+	Level      ndr.DWORD
+	ServerInfo SERVER_ENUM_UNION
+}
+
+// SERVER_ENUM_UNION is the [switch_is(Level)] union of server-enumeration containers
+// ([MS-BRWSA] 2.2.3.2). Tag carries the discriminant (the level) inline, followed by the
+// selected arm. The case-100 arm is a [unique] pointer to its container
+// (LPSERVER_INFO_100_CONTAINER); the [default] arm carries nothing.
+type SERVER_ENUM_UNION struct {
+	Tag      ndr.DWORD                  `ndr:"switch"`
+	Level100 *SERVER_INFO_100_CONTAINER `ndr:"case=100,unique"`
+}

--- a/windows/protocols/ms-brwsa/SERVER_INFO_100.go
+++ b/windows/protocols/ms-brwsa/SERVER_INFO_100.go
@@ -1,0 +1,14 @@
+package msbrwsa
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// SERVER_INFO_100 contains basic information about a server ([MS-DTYP] 2.3.11, referenced
+// by [MS-BRWSA] 3.1.4.1). It is the element type of SERVER_INFO_100_CONTAINER.Buffer.
+// Sv100Name is a [string] wchar_t* field (pointer_default unique); a nil WSTR is a NULL
+// pointer on the wire.
+type SERVER_INFO_100 struct {
+	Sv100PlatformId ndr.DWORD
+	Sv100Name       ndr.WSTR `ndr:"unique"`
+}

--- a/windows/protocols/ms-brwsa/SERVER_INFO_100_CONTAINER.go
+++ b/windows/protocols/ms-brwsa/SERVER_INFO_100_CONTAINER.go
@@ -1,0 +1,14 @@
+package msbrwsa
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// SERVER_INFO_100_CONTAINER contains a count of the entries returned by
+// I_BrowserrQueryOtherDomains together with a pointer to the array of entries
+// ([MS-BRWSA] 2.2.3.1). Buffer is a [size_is(EntriesRead)] LPSERVER_INFO_100 — a [unique]
+// pointer to a conformant array of SERVER_INFO_100 sized by EntriesRead.
+type SERVER_INFO_100_CONTAINER struct {
+	EntriesRead ndr.DWORD
+	Buffer      []SERVER_INFO_100 `ndr:"unique,size_is=EntriesRead"`
+}

--- a/windows/protocols/ms-brwsa/structures_test.go
+++ b/windows/protocols/ms-brwsa/structures_test.go
@@ -1,0 +1,98 @@
+package msbrwsa
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// TestServerInfo100RoundTrip exercises the element type: a scalar platform id plus a
+// [unique] wide-string name.
+func TestServerInfo100RoundTrip(t *testing.T) {
+	for _, s := range []ndr.Syntax{ndr.NDR20, ndr.NDR64} {
+		in := SERVER_INFO_100{Sv100PlatformId: 500, Sv100Name: ndr.WSTR("CONTOSO")}
+		raw, err := ndr.MarshalAs(&in, s)
+		if err != nil {
+			t.Fatalf("%s marshal: %v", s, err)
+		}
+		var out SERVER_INFO_100
+		if err := ndr.UnmarshalAs(raw, &out, s); err != nil {
+			t.Fatalf("%s unmarshal: %v", s, err)
+		}
+		if !reflect.DeepEqual(in, out) {
+			t.Errorf("%s: SERVER_INFO_100 round-trip got %+v want %+v", s, out, in)
+		}
+	}
+}
+
+// TestServerInfo100ContainerRoundTrip exercises the [unique] pointer to a
+// [size_is(EntriesRead)] conformant array of SERVER_INFO_100 (elements carrying their own
+// [unique] string pointers).
+func TestServerInfo100ContainerRoundTrip(t *testing.T) {
+	for _, s := range []ndr.Syntax{ndr.NDR20, ndr.NDR64} {
+		in := SERVER_INFO_100_CONTAINER{
+			EntriesRead: 2,
+			Buffer: []SERVER_INFO_100{
+				{Sv100PlatformId: 500, Sv100Name: ndr.WSTR("CONTOSO")},
+				{Sv100PlatformId: 500, Sv100Name: ndr.WSTR("FABRIKAM")},
+			},
+		}
+		raw, err := ndr.MarshalAs(&in, s)
+		if err != nil {
+			t.Fatalf("%s marshal: %v", s, err)
+		}
+		var out SERVER_INFO_100_CONTAINER
+		if err := ndr.UnmarshalAs(raw, &out, s); err != nil {
+			t.Fatalf("%s unmarshal: %v", s, err)
+		}
+		if !reflect.DeepEqual(in, out) {
+			t.Errorf("%s: SERVER_INFO_100_CONTAINER round-trip got %+v want %+v", s, out, in)
+		}
+	}
+}
+
+// TestServerEnumStructCase100RoundTrip exercises the switch_is(Level) union with the
+// case-100 arm populated: a [unique] pointer to a container holding one entry.
+func TestServerEnumStructCase100RoundTrip(t *testing.T) {
+	for _, s := range []ndr.Syntax{ndr.NDR20, ndr.NDR64} {
+		in := SERVER_ENUM_STRUCT{
+			Level: 100,
+			ServerInfo: SERVER_ENUM_UNION{
+				Tag: 100,
+				Level100: &SERVER_INFO_100_CONTAINER{
+					EntriesRead: 1,
+					Buffer:      []SERVER_INFO_100{{Sv100PlatformId: 500, Sv100Name: ndr.WSTR("CORP")}},
+				},
+			},
+		}
+		raw, err := ndr.MarshalAs(&in, s)
+		if err != nil {
+			t.Fatalf("%s marshal: %v", s, err)
+		}
+		var out SERVER_ENUM_STRUCT
+		if err := ndr.UnmarshalAs(raw, &out, s); err != nil {
+			t.Fatalf("%s unmarshal: %v", s, err)
+		}
+		if !reflect.DeepEqual(in, out) {
+			t.Errorf("%s: SERVER_ENUM_STRUCT(case=100) round-trip got %+v want %+v", s, out, in)
+		}
+	}
+}
+
+// TestServerEnumStructCase100NilBuffer exercises the case-100 arm with a NULL container
+// pointer (the request shape a client sends: Level=100, no data yet).
+func TestServerEnumStructCase100NilBuffer(t *testing.T) {
+	in := SERVER_ENUM_STRUCT{Level: 100, ServerInfo: SERVER_ENUM_UNION{Tag: 100, Level100: nil}}
+	raw, err := ndr.Marshal(&in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out SERVER_ENUM_STRUCT
+	if err := ndr.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !reflect.DeepEqual(in, out) {
+		t.Errorf("SERVER_ENUM_STRUCT(nil buffer) round-trip got %+v want %+v", out, in)
+	}
+}


### PR DESCRIPTION
## Summary

Implements the **browser** RPC interface — abstract syntax `6bffd098-a112-3610-9833-012892020162`, version 0.0 ([MS-BRWSA], Common Internet File System (CIFS) Browser Auxiliary Protocol). This is the interface a client uses to ask a primary domain controller (acting as the domain master browser) for the list of other domains configured on the network.

It follows the dcerpc-interface-structure split layout:
- **Descriptor + method stub** under `network/dcerpc/interfaces/6bffd098-a112-3610-9833-012892020162/0.0/`
- **NDR wire types** under `windows/protocols/ms-brwsa/` (`package msbrwsa`)

## Linked Issue

Closes #747

## What's included

- **`interface.go`** — `SyntaxID()`, the single on-the-wire opnum `I_BrowserrQueryOtherDomains` (2), the `OpnumToName`/`NameToOpnum` maps, the `\browser` `PipeName` (§2.1), and the NET_API_STATUS table (`NERR_Success`, `ERROR_ACCESS_DENIED`, `ERROR_NOT_ENOUGH_MEMORY`, `ERROR_INVALID_PARAMETER`, `ERROR_INVALID_LEVEL`, `ERROR_MORE_DATA`) from [MS-ERREF]/[MS-BRWSA] §3.1.4.1. The eleven `OpnumNNotUsedOnWire` reserved slots are omitted.
- **`functions/02_I_BrowserrQueryOtherDomains.go`** — the opnum 2 stub. `ServerName` is an `[in,string,unique]` generic-handle string (ignored on receipt; pass `""` for NULL); `InfoStruct` is the `[in,out]` `SERVER_ENUM_STRUCT` (present in both request and response); `TotalEntries` is the `[out]` count; the trailing NET_API_STATUS is the `retval`. `ERROR_MORE_DATA` is tolerated (partial result set), not treated as a failure.
- **`windows/protocols/ms-brwsa/`** — `SERVER_ENUM_STRUCT` (the `switch_is(Level)` union whose case-100 arm is a `[unique]` pointer to its container), `SERVER_INFO_100_CONTAINER` (a `[unique]` pointer to a `[size_is(EntriesRead)]` conformant array), `SERVER_INFO_100` (the [MS-DTYP] 2.3.11 element type), and the `BROWSER_IDENTIFY_HANDLE` alias.
- **Tests** — structure wire-shape round-trips under both NDR20 and NDR64 (union case-100 populated and NULL-buffer, the container array, the element string pointer), plus the descriptor opnum/status/pipe assertions.

## How Verified

- `gofmt -l` clean; `go build`, `go vet`, `go test` green over both trees.
- Cross-compiles for `GOARCH=386` and `GOARCH=arm64`; `-tags integration` builds.
- `idlgen check` reports full opnum/structure parity — the differing files are the expected hand-refinements (corrected NDR tags on the union pointer arm and the conformant-array buffer, the status table, and the ergonomic stub signature).
- The NDR modeling was adversarially cross-checked against the wire-validated SRVSVC `SESSION_ENUM_UNION` / `SESSION_INFO_1_CONTAINER` / `NetrServerTransportEnum` precedent.

## Test Coverage

**Added:** `windows/protocols/ms-brwsa/structures_test.go` (round-trips) and `network/dcerpc/interfaces/6bffd098-a112-3610-9833-012892020162/0.0/interface_test.go` (descriptor).

## Scope of Change

- **Files changed:** 9 new files under the two trees above; no existing files touched.
- **Behavioral changes outside the interface:** none.

## Notes

Live validation against a Windows domain master browser is deferred (needs a PDC with the browser service); the wire shapes are exercised by the Go round-trip tests.
