### PR TITLE
Add DCOM Remote Protocol (MS-DCOM) IObjectExporter (OXID resolver) client interface

### DIFF
--- a/network/dcerpc/interfaces/99fcfec4-5260-101b-bbcb-00aa0021347a/0.0/functions/00_ResolveOxid.go
+++ b/network/dcerpc/interfaces/99fcfec4-5260-101b-bbcb-00aa0021347a/0.0/functions/00_ResolveOxid.go
@@ -1,0 +1,56 @@
+package functions
+
+import (
+	"fmt"
+
+	IObjectExporter "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/99fcfec4-5260-101b-bbcb-00aa0021347a/0.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	msdcom "github.com/TheManticoreProject/Manticore/windows/protocols/ms-dcom"
+)
+
+// resolveOxidRequest carries the [in] parameters of ResolveOxid. The explicit binding
+// handle (handle_t hRpc) is not part of the NDR stub and is omitted. pOxid is a [ref]
+// pointer to an OXID, so it is transmitted inline; arRequestedProtseqs is a [ref] pointer
+// to a conformant array of protocol sequence identifiers (its maximum_count travels with
+// the array, no referent id).
+type resolveOxidRequest struct {
+	POxid               msdcom.OXID
+	CRequestedProtseqs  uint16
+	ArRequestedProtseqs []uint16 `ndr:"ref,size_is=CRequestedProtseqs"`
+}
+
+func (*resolveOxidRequest) Opnum() uint16 { return IObjectExporter.OpnumResolveOxid }
+
+// resolveOxidResponse carries the [out] parameters and return value of ResolveOxid.
+// ppdsaOxidBindings is [out, ref] DUALSTRINGARRAY **: the outer [ref] is the by-reference
+// out slot (inline), and the inner pointer takes the interface's unique default, so the
+// field is a *DUALSTRINGARRAY tagged "unique" (referent id, then the deferred body).
+type resolveOxidResponse struct {
+	PpdsaOxidBindings *msdcom.DUALSTRINGARRAY `ndr:"unique"`
+	PipidRemUnknown   msdcom.IPID
+	PAuthnHint        ndr.DWORD
+	Status            ndr.DWORD `ndr:"retval"`
+}
+
+// ResolveOxid calls ResolveOxid (opnum 0) ([MS-DCOM] 3.1.2.5.1.1): it resolves an OXID to
+// the string and security bindings of the object exporter and the IPID of that exporter's
+// IRemUnknown interface.
+func ResolveOxid(rpc ndr.Invoker, pOxid msdcom.OXID, cRequestedProtseqs uint16, arRequestedProtseqs []uint16) (PpdsaOxidBindings *msdcom.DUALSTRINGARRAY, PipidRemUnknown msdcom.IPID, PAuthnHint ndr.DWORD, err error) {
+	req := &resolveOxidRequest{
+		POxid:               pOxid,
+		CRequestedProtseqs:  cRequestedProtseqs,
+		ArRequestedProtseqs: arRequestedProtseqs,
+	}
+	var resp resolveOxidResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("ResolveOxid: %w", err)
+		return
+	}
+	PpdsaOxidBindings = resp.PpdsaOxidBindings
+	PipidRemUnknown = resp.PipidRemUnknown
+	PAuthnHint = resp.PAuthnHint
+	if uint32(resp.Status) != IObjectExporter.StatusSuccess {
+		err = fmt.Errorf("ResolveOxid failed: %s", IObjectExporter.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/99fcfec4-5260-101b-bbcb-00aa0021347a/0.0/functions/01_SimplePing.go
+++ b/network/dcerpc/interfaces/99fcfec4-5260-101b-bbcb-00aa0021347a/0.0/functions/01_SimplePing.go
@@ -1,0 +1,40 @@
+package functions
+
+import (
+	"fmt"
+
+	IObjectExporter "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/99fcfec4-5260-101b-bbcb-00aa0021347a/0.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	msdcom "github.com/TheManticoreProject/Manticore/windows/protocols/ms-dcom"
+)
+
+// simplePingRequest carries the [in] parameters of SimplePing. pSetId is a [ref] pointer
+// to a SETID and is transmitted inline.
+type simplePingRequest struct {
+	PSetId msdcom.SETID
+}
+
+func (*simplePingRequest) Opnum() uint16 { return IObjectExporter.OpnumSimplePing }
+
+// simplePingResponse carries the [out] parameters and return value of SimplePing.
+type simplePingResponse struct {
+	Status ndr.DWORD `ndr:"retval"`
+}
+
+// SimplePing calls SimplePing (opnum 1) ([MS-DCOM] 3.1.2.5.1.5): it pings the object
+// resolver ping set identified by pSetId to keep its objects alive. The set must already
+// exist (created by ComplexPing); SimplePing cannot modify set membership.
+func SimplePing(rpc ndr.Invoker, pSetId msdcom.SETID) (err error) {
+	req := &simplePingRequest{
+		PSetId: pSetId,
+	}
+	var resp simplePingResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("SimplePing: %w", err)
+		return
+	}
+	if uint32(resp.Status) != IObjectExporter.StatusSuccess {
+		err = fmt.Errorf("SimplePing failed: %s", IObjectExporter.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/99fcfec4-5260-101b-bbcb-00aa0021347a/0.0/functions/02_ComplexPing.go
+++ b/network/dcerpc/interfaces/99fcfec4-5260-101b-bbcb-00aa0021347a/0.0/functions/02_ComplexPing.go
@@ -1,0 +1,59 @@
+package functions
+
+import (
+	"fmt"
+
+	IObjectExporter "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/99fcfec4-5260-101b-bbcb-00aa0021347a/0.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	msdcom "github.com/TheManticoreProject/Manticore/windows/protocols/ms-dcom"
+)
+
+// complexPingRequest carries the [in]/[in,out] parameters of ComplexPing. pSetId is a
+// [ref] pointer to a SETID (transmitted inline); addToSet and delFromSet are [unique]
+// pointers to conformant arrays of OIDs, so each carries a referent id followed by the
+// deferred array body (maximum_count + elements) when non-null.
+type complexPingRequest struct {
+	PSetId      msdcom.SETID
+	SequenceNum uint16
+	CAddToSet   uint16
+	CDelFromSet uint16
+	AddToSet    []msdcom.OID `ndr:"unique,size_is=CAddToSet"`
+	DelFromSet  []msdcom.OID `ndr:"unique,size_is=CDelFromSet"`
+}
+
+func (*complexPingRequest) Opnum() uint16 { return IObjectExporter.OpnumComplexPing }
+
+// complexPingResponse carries the [in,out] and [out] parameters and return value of
+// ComplexPing. pSetId is the (possibly server-assigned) ping set id; it is [in,out] so it
+// appears in both the request and the response.
+type complexPingResponse struct {
+	PSetId             msdcom.SETID
+	PPingBackoffFactor uint16
+	Status             ndr.DWORD `ndr:"retval"`
+}
+
+// ComplexPing calls ComplexPing (opnum 2) ([MS-DCOM] 3.1.2.5.1.6): it maintains an object
+// resolver ping set, adding and removing OIDs from the set identified by pSetId (zero on
+// the first call, whereupon the server assigns and returns a new set id). Keeping objects
+// in a pinged set prevents the server from reclaiming them.
+func ComplexPing(rpc ndr.Invoker, pSetId msdcom.SETID, sequenceNum uint16, cAddToSet uint16, cDelFromSet uint16, addToSet []msdcom.OID, delFromSet []msdcom.OID) (PSetId msdcom.SETID, PPingBackoffFactor uint16, err error) {
+	req := &complexPingRequest{
+		PSetId:      pSetId,
+		SequenceNum: sequenceNum,
+		CAddToSet:   cAddToSet,
+		CDelFromSet: cDelFromSet,
+		AddToSet:    addToSet,
+		DelFromSet:  delFromSet,
+	}
+	var resp complexPingResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("ComplexPing: %w", err)
+		return
+	}
+	PSetId = resp.PSetId
+	PPingBackoffFactor = resp.PPingBackoffFactor
+	if uint32(resp.Status) != IObjectExporter.StatusSuccess {
+		err = fmt.Errorf("ComplexPing failed: %s", IObjectExporter.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/99fcfec4-5260-101b-bbcb-00aa0021347a/0.0/functions/03_ServerAlive.go
+++ b/network/dcerpc/interfaces/99fcfec4-5260-101b-bbcb-00aa0021347a/0.0/functions/03_ServerAlive.go
@@ -1,0 +1,35 @@
+package functions
+
+import (
+	"fmt"
+
+	IObjectExporter "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/99fcfec4-5260-101b-bbcb-00aa0021347a/0.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// serverAliveRequest carries the [in] parameters of ServerAlive.
+type serverAliveRequest struct {
+}
+
+func (*serverAliveRequest) Opnum() uint16 { return IObjectExporter.OpnumServerAlive }
+
+// serverAliveResponse carries the [out] parameters and return value of ServerAlive.
+type serverAliveResponse struct {
+	Status ndr.DWORD `ndr:"retval"`
+}
+
+// ServerAlive calls ServerAlive (opnum 3) ([MS-DCOM] 3.1.2.5.1.3): it tests whether the
+// object resolver is alive and reachable. It takes no marshaled parameters and returns
+// only a status; ServerAlive2 is preferred as it also reports version and bindings.
+func ServerAlive(rpc ndr.Invoker) (err error) {
+	req := &serverAliveRequest{}
+	var resp serverAliveResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("ServerAlive: %w", err)
+		return
+	}
+	if uint32(resp.Status) != IObjectExporter.StatusSuccess {
+		err = fmt.Errorf("ServerAlive failed: %s", IObjectExporter.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/99fcfec4-5260-101b-bbcb-00aa0021347a/0.0/functions/04_ResolveOxid2.go
+++ b/network/dcerpc/interfaces/99fcfec4-5260-101b-bbcb-00aa0021347a/0.0/functions/04_ResolveOxid2.go
@@ -1,0 +1,53 @@
+package functions
+
+import (
+	"fmt"
+
+	IObjectExporter "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/99fcfec4-5260-101b-bbcb-00aa0021347a/0.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	msdcom "github.com/TheManticoreProject/Manticore/windows/protocols/ms-dcom"
+)
+
+// resolveOxid2Request carries the [in] parameters of ResolveOxid2. See resolveOxidRequest
+// for the pointer/array modeling notes; the parameters are identical to ResolveOxid.
+type resolveOxid2Request struct {
+	POxid               msdcom.OXID
+	CRequestedProtseqs  uint16
+	ArRequestedProtseqs []uint16 `ndr:"ref,size_is=CRequestedProtseqs"`
+}
+
+func (*resolveOxid2Request) Opnum() uint16 { return IObjectExporter.OpnumResolveOxid2 }
+
+// resolveOxid2Response carries the [out] parameters and return value of ResolveOxid2. It
+// adds the object exporter's COMVERSION to the ResolveOxid result; ppdsaOxidBindings is
+// modeled as *DUALSTRINGARRAY "unique" for the same reason as in ResolveOxid.
+type resolveOxid2Response struct {
+	PpdsaOxidBindings *msdcom.DUALSTRINGARRAY `ndr:"unique"`
+	PipidRemUnknown   msdcom.IPID
+	PAuthnHint        ndr.DWORD
+	PComVersion       msdcom.COMVERSION
+	Status            ndr.DWORD `ndr:"retval"`
+}
+
+// ResolveOxid2 calls ResolveOxid2 (opnum 4) ([MS-DCOM] 3.1.2.5.1.2): like ResolveOxid, but
+// it also returns the COMVERSION of the object exporter.
+func ResolveOxid2(rpc ndr.Invoker, pOxid msdcom.OXID, cRequestedProtseqs uint16, arRequestedProtseqs []uint16) (PpdsaOxidBindings *msdcom.DUALSTRINGARRAY, PipidRemUnknown msdcom.IPID, PAuthnHint ndr.DWORD, PComVersion msdcom.COMVERSION, err error) {
+	req := &resolveOxid2Request{
+		POxid:               pOxid,
+		CRequestedProtseqs:  cRequestedProtseqs,
+		ArRequestedProtseqs: arRequestedProtseqs,
+	}
+	var resp resolveOxid2Response
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("ResolveOxid2: %w", err)
+		return
+	}
+	PpdsaOxidBindings = resp.PpdsaOxidBindings
+	PipidRemUnknown = resp.PipidRemUnknown
+	PAuthnHint = resp.PAuthnHint
+	PComVersion = resp.PComVersion
+	if uint32(resp.Status) != IObjectExporter.StatusSuccess {
+		err = fmt.Errorf("ResolveOxid2 failed: %s", IObjectExporter.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/99fcfec4-5260-101b-bbcb-00aa0021347a/0.0/functions/05_ServerAlive2.go
+++ b/network/dcerpc/interfaces/99fcfec4-5260-101b-bbcb-00aa0021347a/0.0/functions/05_ServerAlive2.go
@@ -1,0 +1,45 @@
+package functions
+
+import (
+	"fmt"
+
+	IObjectExporter "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/99fcfec4-5260-101b-bbcb-00aa0021347a/0.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	msdcom "github.com/TheManticoreProject/Manticore/windows/protocols/ms-dcom"
+)
+
+// serverAlive2Request carries the [in] parameters of ServerAlive2.
+type serverAlive2Request struct {
+}
+
+func (*serverAlive2Request) Opnum() uint16 { return IObjectExporter.OpnumServerAlive2 }
+
+// serverAlive2Response carries the [out] parameters and return value of ServerAlive2.
+// ppdsaOrBindings is [out, ref] DUALSTRINGARRAY ** — the string/security bindings the
+// object resolver supports — modeled as *DUALSTRINGARRAY "unique" (see ResolveOxid).
+type serverAlive2Response struct {
+	PComVersion     msdcom.COMVERSION
+	PpdsaOrBindings *msdcom.DUALSTRINGARRAY `ndr:"unique"`
+	PReserved       ndr.DWORD
+	Status          ndr.DWORD `ndr:"retval"`
+}
+
+// ServerAlive2 calls ServerAlive2 (opnum 5) ([MS-DCOM] 3.1.2.5.1.4): it tests whether the
+// object resolver is alive and returns its COMVERSION and the string/security bindings it
+// supports. It is the method a client uses to discover a working RPC protocol sequence
+// ([MS-DCOM] 2.1).
+func ServerAlive2(rpc ndr.Invoker) (PComVersion msdcom.COMVERSION, PpdsaOrBindings *msdcom.DUALSTRINGARRAY, PReserved ndr.DWORD, err error) {
+	req := &serverAlive2Request{}
+	var resp serverAlive2Response
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("ServerAlive2: %w", err)
+		return
+	}
+	PComVersion = resp.PComVersion
+	PpdsaOrBindings = resp.PpdsaOrBindings
+	PReserved = resp.PReserved
+	if uint32(resp.Status) != IObjectExporter.StatusSuccess {
+		err = fmt.Errorf("ServerAlive2 failed: %s", IObjectExporter.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/99fcfec4-5260-101b-bbcb-00aa0021347a/0.0/interface.go
+++ b/network/dcerpc/interfaces/99fcfec4-5260-101b-bbcb-00aa0021347a/0.0/interface.go
@@ -1,0 +1,100 @@
+// Package rpcinterface_99fcfec45260101bbbcb00aa0021347a_0_0 is the descriptor for the
+// IObjectExporter (IOXIDResolver) RPC interface, abstract syntax
+// 99fcfec4-5260-101b-bbcb-00aa0021347a version 0.0 ([MS-DCOM]).
+//
+// IObjectExporter is the object resolver interface of the DCOM Remote Protocol: it
+// resolves OXIDs to object exporter bindings (ResolveOxid/ResolveOxid2), tests server
+// liveness (ServerAlive/ServerAlive2), and maintains the ping sets that keep remote
+// objects alive (SimplePing/ComplexPing). Unlike the rest of MS-DCOM it is a classic,
+// non-object RPC interface: it uses an explicit binding handle (handle_t) and carries no
+// ORPCTHIS/ORPCTHAT, so it is modeled here while the object (ORPC) interfaces are not.
+//
+// An RPC interface is identified by its UUID and version, never by the transport it is
+// reached over, so the directory is named after the UUID with the version in the nested
+// 0.0/ directory.
+package rpcinterface_99fcfec45260101bbbcb00aa0021347a_0_0
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+)
+
+// PipeName is unused for this interface: IObjectExporter (the DCOM object resolver) is not
+// served over a named pipe. It is reached through the RPC endpoint mapper / well-known
+// endpoints ([MS-DCOM] 2.1) — over ncacn_ip_tcp on TCP port 135 and any other RPC protocol
+// sequence the resolver responds to; a client discovers a working sequence with
+// ServerAlive2. It is retained, empty, for descriptor uniformity across interfaces (the
+// same convention as the other endpoint-mapper-resolved TCP interfaces in this tree);
+// feeding an empty pipe to a named-pipe binder fails loudly rather than binding the wrong
+// endpoint.
+const PipeName = ``
+
+// Opnums for the on-the-wire methods ([MS-DCOM] 3.1.2.5.1). All six opnums are used on the
+// wire (IObjectExporter defines no OpnumNNotUsedOnWire placeholders).
+const (
+	OpnumResolveOxid  uint16 = 0
+	OpnumSimplePing   uint16 = 1
+	OpnumComplexPing  uint16 = 2
+	OpnumServerAlive  uint16 = 3
+	OpnumResolveOxid2 uint16 = 4
+	OpnumServerAlive2 uint16 = 5
+)
+
+// Status codes returned by this interface. IObjectExporter methods return error_status_t,
+// an RPC/Win32 status ([C706]; [MS-ERREF] 2.2). RPC_S_OK indicates success; the OR_* codes
+// are the object resolver specific failures. Any other Win32/RPC status can also surface.
+const (
+	StatusSuccess uint32 = 0x00000000 // RPC_S_OK
+	OrInvalidOxid uint32 = 0x00000776 // OR_INVALID_OXID: the object exporter identifier is not known
+	OrInvalidOid  uint32 = 0x00000777 // OR_INVALID_OID: the object identifier is not known
+	OrInvalidSet  uint32 = 0x00000778 // OR_INVALID_SET: the ping set identifier is not known
+)
+
+// SyntaxID returns the IObjectExporter abstract syntax identifier:
+// 99fcfec4-5260-101b-bbcb-00aa0021347a, version 0.0.
+func SyntaxID() syntax.SyntaxID {
+	return syntax.SyntaxID{
+		UUID:         guid.GUID{A: 0x99fcfec4, B: 0x5260, C: 0x101b, D: 0xbbcb, E: 0x00aa0021347a},
+		MajorVersion: 0,
+		MinorVersion: 0,
+	}
+}
+
+// StatusString returns a mnemonic for the documented status codes, otherwise the
+// hex value.
+func StatusString(status uint32) string {
+	switch status {
+	case StatusSuccess:
+		return "RPC_S_OK"
+	case OrInvalidOxid:
+		return "OR_INVALID_OXID"
+	case OrInvalidOid:
+		return "OR_INVALID_OID"
+	case OrInvalidSet:
+		return "OR_INVALID_SET"
+	default:
+		return fmt.Sprintf("0x%08x", status)
+	}
+}
+
+// OpnumToName maps each on-the-wire opnum to its method name; the single source of
+// truth.
+var OpnumToName = map[uint16]string{
+	OpnumResolveOxid:  "ResolveOxid",
+	OpnumSimplePing:   "SimplePing",
+	OpnumComplexPing:  "ComplexPing",
+	OpnumServerAlive:  "ServerAlive",
+	OpnumResolveOxid2: "ResolveOxid2",
+	OpnumServerAlive2: "ServerAlive2",
+}
+
+// NameToOpnum is the reverse of OpnumToName, built at init so the two never drift.
+var NameToOpnum = func() map[string]uint16 {
+	m := make(map[string]uint16, len(OpnumToName))
+	for op, name := range OpnumToName {
+		m[name] = op
+	}
+	return m
+}()

--- a/network/dcerpc/interfaces/99fcfec4-5260-101b-bbcb-00aa0021347a/0.0/interface_test.go
+++ b/network/dcerpc/interfaces/99fcfec4-5260-101b-bbcb-00aa0021347a/0.0/interface_test.go
@@ -1,0 +1,56 @@
+package rpcinterface_99fcfec45260101bbbcb00aa0021347a_0_0
+
+import "testing"
+
+// TestSyntaxID verifies the abstract syntax identity (UUID + version) of IObjectExporter.
+func TestSyntaxID(t *testing.T) {
+	s := SyntaxID()
+	if got := s.UUID.ToFormatD(); got != "99fcfec4-5260-101b-bbcb-00aa0021347a" {
+		t.Fatalf("UUID = %s, want 99fcfec4-5260-101b-bbcb-00aa0021347a", got)
+	}
+	if s.MajorVersion != 0 || s.MinorVersion != 0 {
+		t.Fatalf("version = %d.%d, want 0.0", s.MajorVersion, s.MinorVersion)
+	}
+}
+
+// TestOpnums verifies the six opnums and that OpnumToName/NameToOpnum stay in sync.
+func TestOpnums(t *testing.T) {
+	want := map[uint16]string{
+		0: "ResolveOxid",
+		1: "SimplePing",
+		2: "ComplexPing",
+		3: "ServerAlive",
+		4: "ResolveOxid2",
+		5: "ServerAlive2",
+	}
+	if len(OpnumToName) != len(want) {
+		t.Fatalf("OpnumToName has %d entries, want %d", len(OpnumToName), len(want))
+	}
+	for op, name := range want {
+		if OpnumToName[op] != name {
+			t.Fatalf("OpnumToName[%d] = %q, want %q", op, OpnumToName[op], name)
+		}
+		if NameToOpnum[name] != op {
+			t.Fatalf("NameToOpnum[%q] = %d, want %d", name, NameToOpnum[name], op)
+		}
+	}
+	if len(OpnumToName) != len(NameToOpnum) {
+		t.Fatalf("map sizes differ: %d vs %d", len(OpnumToName), len(NameToOpnum))
+	}
+}
+
+// TestStatusString verifies mnemonic rendering of the documented codes and the hex fallback.
+func TestStatusString(t *testing.T) {
+	cases := map[uint32]string{
+		StatusSuccess: "RPC_S_OK",
+		OrInvalidOxid: "OR_INVALID_OXID",
+		OrInvalidOid:  "OR_INVALID_OID",
+		OrInvalidSet:  "OR_INVALID_SET",
+		0xdeadbeef:    "0xdeadbeef",
+	}
+	for code, want := range cases {
+		if got := StatusString(code); got != want {
+			t.Fatalf("StatusString(0x%08x) = %s, want %s", code, got, want)
+		}
+	}
+}

--- a/network/dcerpc/interfaces/99fcfec4-5260-101b-bbcb-00aa0021347a/0.0/ms-dcom.idl
+++ b/network/dcerpc/interfaces/99fcfec4-5260-101b-bbcb-00aa0021347a/0.0/ms-dcom.idl
@@ -1,0 +1,443 @@
+ import "ms-dtyp.idl";
+  
+  
+ typedef GUID CLSID;
+ typedef GUID IID;
+ typedef unsigned hyper ID;
+ typedef unsigned hyper OXID;
+        
+ typedef unsigned hyper OID;        
+ typedef unsigned hyper SETID;      
+ typedef GUID    IPID;
+ typedef GUID    CID;
+  
+ #define REFGUID const GUID *
+ #define REFIID const IID *
+  
+ typedef REFGUID REFIPID;
+  
+ typedef struct tagCOMVERSION
+ {
+     unsigned short MajorVersion;    
+     unsigned short MinorVersion;    
+ } COMVERSION;
+  
+ typedef struct tagORPC_EXTENT
+ {
+     GUID                    id;     
+     unsigned long           size;   
+     [size_is((size+7)&~7)]  byte data[]; 
+ } ORPC_EXTENT;
+  
+ typedef struct tagORPC_EXTENT_ARRAY
+ {
+     unsigned long size;     
+     unsigned long reserved;
+     [size_is((size+1)&~1,), unique] ORPC_EXTENT **extent;
+ } ORPC_EXTENT_ARRAY;
+  
+ typedef struct tagORPCTHIS
+ {
+     COMVERSION      version;    
+     unsigned long   flags;      
+     unsigned long   reserved1;  
+     CID             cid;        
+     [unique] ORPC_EXTENT_ARRAY *extensions;
+ } ORPCTHIS;
+  
+ typedef struct tagORPCTHAT
+ {
+     unsigned long  flags;
+     [unique] ORPC_EXTENT_ARRAY *extensions;
+ } ORPCTHAT;
+  
+ typedef struct tagDUALSTRINGARRAY
+ {
+     unsigned short wNumEntries;
+     unsigned short wSecurityOffset;
+     [size_is(wNumEntries)] unsigned short aStringArray[];
+ } DUALSTRINGARRAY;
+  
+ enum tagCPFLAGS
+ {
+     CPFLAG_PROPAGATE                    = 0x1,
+     CPFLAG_EXPOSE                       = 0x2,
+     CPFLAG_ENVOY                        = 0x4,
+ };
+  
+ typedef struct tagMInterfacePointer
+ {
+     unsigned long           ulCntData;          
+     [size_is(ulCntData)] byte abData[];
+ } MInterfacePointer;
+  
+ typedef [unique] MInterfacePointer * PMInterfacePointer;
+  
+ typedef struct tagErrorObjectData
+ {
+     DWORD  dwVersion;
+     DWORD  dwHelpContext;
+     IID    iid;
+     [unique,string]wchar_t* pszSource;
+     [unique,string]wchar_t* pszDescription;
+     [unique,string]wchar_t* pszHelpFile;
+ } ErrorObjectData;
+  
+ [
+     uuid(4d9f4ab8-7d1c-11cf-861e-0020af6e7c57),
+     pointer_default(unique)
+ ]
+ interface IActivation
+ {
+     const unsigned long MAX_REQUESTED_INTERFACES = 0x8000;
+     const unsigned long MAX_REQUESTED_PROTSEQS = 0x8000;
+  
+ error_status_t RemoteActivation(
+         [in] handle_t                               hRpc,
+         [in] ORPCTHIS                              *ORPCthis,
+         [out] ORPCTHAT                             *ORPCthat,
+         [in] GUID                                  *Clsid,
+         [in, string, unique] wchar_t               *pwszObjectName,
+         [in, unique] MInterfacePointer             *pObjectStorage,
+         [in] DWORD                                  ClientImpLevel,
+         [in] DWORD                                  Mode,
+         [in,range(1,MAX_REQUESTED_INTERFACES)]DWORD Interfaces,
+         [in,unique,size_is(Interfaces)] IID        *pIIDs,
+         [in,range(0,MAX_REQUESTED_PROTSEQS)]
+              unsigned short                    cRequestedProtseqs,
+         [in, size_is(cRequestedProtseqs)]
+                unsigned short                  aRequestedProtseqs[],
+         [out] OXID                             *pOxid,
+         [out] DUALSTRINGARRAY                  **ppdsaOxidBindings,
+         [out] IPID                             *pipidRemUnknown,
+         [out] DWORD                                *pAuthnHint,
+         [out] COMVERSION                           *pServerVersion,
+         [out] HRESULT                              *phr,
+         [out,size_is(Interfaces), disable_consistency_check] 
+                                 MInterfacePointer **ppInterfaceData,
+         [out,size_is(Interfaces), disable_consistency_check] 
+                                 HRESULT            *pResults
+         );
+ }
+  
+ [
+     uuid(000001A0-0000-0000-C000-000000000046),
+     pointer_default(unique)
+ ]
+ interface IRemoteSCMActivator 
+ {
+  void Opnum0NotUsedOnWire(void);
+  void Opnum1NotUsedOnWire(void);
+  void Opnum2NotUsedOnWire(void);
+  
+ HRESULT RemoteGetClassObject(
+                     [in] handle_t rpc,
+                     [in] ORPCTHIS *orpcthis,
+                     [out] ORPCTHAT *orpcthat,
+                     [in,unique]  MInterfacePointer *pActProperties,
+                     [out] MInterfacePointer **ppActProperties
+                     );
+  
+ HRESULT RemoteCreateInstance(
+                     [in] handle_t rpc,
+                     [in] ORPCTHIS *orpcthis,
+                     [out] ORPCTHAT *orpcthat,
+                     [in,unique]  MInterfacePointer *pUnkOuter,
+                     [in,unique]  MInterfacePointer *pActProperties,
+                     [out] MInterfacePointer **ppActProperties
+                     );
+ }
+  
+ [
+     uuid(99fcfec4-5260-101b-bbcb-00aa0021347a),
+     pointer_default(unique)
+ ]
+  
+ interface IObjectExporter
+ {
+     [idempotent] error_status_t ResolveOxid
+     (
+ [in]       handle_t        hRpc,
+ [in]       OXID           *pOxid,
+ [in]       unsigned short  cRequestedProtseqs,
+ [in,  ref, size_is(cRequestedProtseqs)]
+    unsigned short  arRequestedProtseqs[],
+ [out, ref] DUALSTRINGARRAY **ppdsaOxidBindings,
+ [out, ref] IPID            *pipidRemUnknown,
+ [out, ref] DWORD           *pAuthnHint
+     );
+  
+ [idempotent] error_status_t SimplePing
+     (
+ [in]  handle_t  hRpc,
+ [in]  SETID    *pSetId 
+     );
+  
+ [idempotent] error_status_t ComplexPing
+     (
+ [in]       handle_t        hRpc,
+ [in, out]  SETID          *pSetId,
+ [in]       unsigned short  SequenceNum,
+ [in]       unsigned short  cAddToSet,
+ [in]       unsigned short  cDelFromSet,
+ [in, unique, size_is(cAddToSet)]   OID AddToSet[],
+ [in, unique, size_is(cDelFromSet)] OID DelFromSet[],
+ [out]      unsigned short *pPingBackoffFactor      
+     );
+  
+ [idempotent] error_status_t ServerAlive
+     (
+ [in]       handle_t        hRpc
+     );
+  
+  
+ [idempotent] error_status_t ResolveOxid2
+     (
+ [in]       handle_t        hRpc,
+ [in]       OXID           *pOxid,
+ [in]       unsigned short  cRequestedProtseqs,
+ [in,  ref, size_is(cRequestedProtseqs)]
+    unsigned short  arRequestedProtseqs[],
+ [out, ref] DUALSTRINGARRAY **ppdsaOxidBindings,
+ [out, ref] IPID            *pipidRemUnknown,
+ [out, ref] DWORD           *pAuthnHint,
+ [out, ref] COMVERSION      *pComVersion
+     );
+  
+     [idempotent] error_status_t ServerAlive2
+     (
+ [in]       handle_t        hRpc,
+ [out, ref] COMVERSION      *pComVersion,
+ [out, ref] DUALSTRINGARRAY **ppdsaOrBindings,
+ [out, ref] DWORD           *pReserved
+     );
+ }
+  
+ typedef struct tagSTDOBJREF
+ {
+     unsigned long  flags;              
+     unsigned long  cPublicRefs;        
+     OXID           oxid;               
+     OID            oid;                
+     IPID           ipid;               
+ } STDOBJREF;
+  
+ typedef struct tagREMQIRESULT
+ {
+     HRESULT         hResult;
+     STDOBJREF       std;
+ } REMQIRESULT;
+  
+ typedef struct tagREMINTERFACEREF
+ {
+     IPID            ipid;
+     unsigned long   cPublicRefs;
+     unsigned long   cPrivateRefs;
+ } REMINTERFACEREF;
+  
+ typedef [disable_consistency_check] REMQIRESULT* PREMQIRESULT;
+ typedef [disable_consistency_check] MInterfacePointer* 
+                                     PMInterfacePointerInternal; 
+  
+ [
+ object,
+ uuid(00000000-0000-0000-C000-000000000046),
+ pointer_default(unique)
+ ]
+ interface IUnknown
+ {
+ HRESULT Opnum0NotUsedOnWire(void);
+ HRESULT Opnum1NotUsedOnWire(void);
+ HRESULT Opnum2NotUsedOnWire(void);
+ };
+  
+ [
+     object,
+     uuid(00000131-0000-0000-C000-000000000046) 
+ ]
+ interface IRemUnknown : IUnknown
+ {
+     HRESULT RemQueryInterface
+     (
+         [in] REFIPID                         ripid,
+         [in] unsigned long                   cRefs,
+         [in] unsigned short                  cIids,
+         [in, size_is(cIids)] IID            *iids,
+         [out, size_is(,cIids)] PREMQIRESULT *ppQIResults
+     );
+  
+ HRESULT RemAddRef
+     (
+         [in] unsigned short cInterfaceRefs,
+         [in, size_is(cInterfaceRefs)] REMINTERFACEREF
+                                        InterfaceRefs[],
+         [out, size_is(cInterfaceRefs)] HRESULT *pResults
+     );
+  
+ HRESULT RemRelease
+     (
+         [in] unsigned short cInterfaceRefs,
+         [in, size_is(cInterfaceRefs)] REMINTERFACEREF 
+                                       InterfaceRefs[]
+     );
+ }
+  
+ [
+     object,
+     uuid(00000143-0000-0000-C000-000000000046) 
+ ]
+ interface IRemUnknown2 : IRemUnknown
+ {
+     HRESULT RemQueryInterface2
+     (
+         [in] REFIPID                                      ripid,
+         [in] unsigned short                               cIids,
+         [in, size_is(cIids)] IID                         *iids,
+         [out, size_is(cIids)] HRESULT                    *phr,
+         [out, size_is(cIids)] PMInterfacePointerInternal *ppMIF
+     );
+ }
+  
+ const unsigned long MIN_ACTPROP_LIMIT = 1;
+ const unsigned long MAX_ACTPROP_LIMIT = 10;
+  
+ typedef struct _COSERVERINFO
+ {
+     DWORD              dwReserved1;
+     [string ] wchar_t* pwszName;
+     DWORD *            pdwReserved;
+     DWORD              dwReserved2;
+ } COSERVERINFO;
+  
+ typedef struct _customREMOTE_REQUEST_SCM_INFO
+ {
+     DWORD                           ClientImpLevel;
+     [range (0, MAX_REQUESTED_PROTSEQS)] unsigned short 
+                                         cRequestedProtseqs;
+     [size_is(cRequestedProtseqs)]
+     unsigned short                  *pRequestedProtseqs;
+ } customREMOTE_REQUEST_SCM_INFO;
+  
+ typedef struct _customREMOTE_REPLY_SCM_INFO
+ {
+     OXID                            Oxid;
+     DUALSTRINGARRAY                 *pdsaOxidBindings;
+     IPID                            ipidRemUnknown;
+     DWORD                           authnHint;
+     COMVERSION                      serverVersion;
+ } customREMOTE_REPLY_SCM_INFO;
+  
+ typedef struct tagInstantiationInfoData
+ {
+     CLSID classId;
+     DWORD classCtx;
+     DWORD actvflags;
+     long  fIsSurrogate;
+     [range (1,MAX_REQUESTED_INTERFACES)] DWORD cIID;
+     DWORD instFlag;
+     [size_is(cIID)] IID   *pIID;
+     DWORD thisSize;
+     COMVERSION clientCOMVersion;
+ } InstantiationInfoData;
+  
+ typedef struct tagLocationInfoData
+ {
+     [string] wchar_t  *machineName;
+     DWORD processId;
+     DWORD apartmentId;
+     DWORD contextId;
+ } LocationInfoData;
+  
+ typedef struct tagActivationContextInfoData
+ {
+    long  clientOK;
+    long  bReserved1;
+    DWORD dwReserved1;
+    DWORD dwReserved2;
+    MInterfacePointer *pIFDClientCtx;
+    MInterfacePointer *pIFDPrototypeCtx;
+ } ActivationContextInfoData;
+    
+ typedef struct tagCustomHeader
+ {
+     DWORD totalSize;
+     DWORD headerSize;     
+     DWORD dwReserved;
+     DWORD destCtx;
+     [range (MIN_ACTPROP_LIMIT, MAX_ACTPROP_LIMIT)] DWORD cIfs;
+     CLSID classInfoClsid;
+     [size_is(cIfs)] CLSID *pclsid;
+     [size_is(cIfs)] DWORD *pSizes;
+     DWORD *pdwReserved;
+ } CustomHeader;
+  
+ typedef struct tagPropsOutInfo
+ {
+     [range (1, MAX_REQUESTED_INTERFACES)] DWORD cIfs;
+     [size_is(cIfs)] IID *piid;
+     [size_is(cIfs)] HRESULT *phresults;
+     [size_is(cIfs)] MInterfacePointer **ppIntfData;
+ } PropsOutInfo;
+  
+ typedef struct tagSecurityInfoData
+ {
+     DWORD           dwAuthnFlags;
+     COSERVERINFO    *pServerInfo;
+     DWORD           *pdwReserved;
+ } SecurityInfoData;
+  
+ typedef struct tagScmRequestInfoData
+ {
+     DWORD  *pdwReserved;
+     customREMOTE_REQUEST_SCM_INFO *remoteRequest;
+ } ScmRequestInfoData;
+  
+ typedef struct tagScmReplyInfoData
+ {
+     DWORD *pdwReserved;
+     customREMOTE_REPLY_SCM_INFO *remoteReply;
+ } ScmReplyInfoData;
+  
+ typedef struct tagInstanceInfoData
+ {
+     [string] wchar_t *fileName;
+     DWORD   mode;
+     MInterfacePointer *ifdROT;
+     MInterfacePointer *ifdStg;
+ } InstanceInfoData;
+  
+ typedef enum
+ {
+     SPD_FLAG_USE_CONSOLE_SESSION   = 0x00000001,
+     SPD_FLAG_USE_DEFAULT_AUTHN_LVL = 0x00000002,
+ } SPD_FLAGS;
+     
+ typedef struct tagSpecialPropertiesData
+ {
+     unsigned long dwSessionId;
+     long  fRemoteThisSessionId;        
+     long  fClientImpersonating;
+     long  fPartitionIDPresent;  
+     DWORD dwDefaultAuthnLvl;    
+     GUID  guidPartition;        
+     DWORD dwPRTFlags;           
+     DWORD dwOrigClsctx;
+     DWORD dwFlags;
+     DWORD Reserved1;
+     unsigned __int64 Reserved2;               
+     DWORD Reserved3[5]; 
+ } SpecialPropertiesData;
+  
+ typedef struct tagSpecialPropertiesData_Alternate
+ {
+     unsigned long dwSessionId;
+     long  fRemoteThisSessionId;        
+     long  fClientImpersonating;
+     long  fPartitionIDPresent;  
+     DWORD dwDefaultAuthnLvl;    
+     GUID  guidPartition;        
+     DWORD dwPRTFlags;           
+     DWORD dwOrigClsctx;
+     DWORD dwFlags;
+     DWORD Reserved3[8]; 
+ } SpecialPropertiesData_Alternate;

--- a/windows/protocols/ms-dcom/COMVERSION.go
+++ b/windows/protocols/ms-dcom/COMVERSION.go
@@ -1,0 +1,8 @@
+package msdcom
+
+// COMVERSION models COMVERSION ([MS-DCOM] 2.2.11): the major and minor version of the
+// DCOM protocol used by a client or server.
+type COMVERSION struct {
+	MajorVersion uint16
+	MinorVersion uint16
+}

--- a/windows/protocols/ms-dcom/DUALSTRINGARRAY.go
+++ b/windows/protocols/ms-dcom/DUALSTRINGARRAY.go
@@ -1,0 +1,13 @@
+package msdcom
+
+// DUALSTRINGARRAY models DUALSTRINGARRAY ([MS-DCOM] 2.2.19): a marshaled set of network
+// and security bindings. aStringArray is a bare inline conformant array (a member with
+// [], not a pointer), so its maximum_count is transmitted in place with no referent id —
+// it is tagged "conformant", never "unique". It holds wNumEntries unsigned shorts: a
+// sequence of STRINGBINDING entries (network bindings) terminated by a null, followed at
+// wSecurityOffset by a sequence of SECURITYBINDING entries terminated by a null.
+type DUALSTRINGARRAY struct {
+	WNumEntries     uint16
+	WSecurityOffset uint16
+	AStringArray    []uint16 `ndr:"conformant,size_is=WNumEntries"`
+}

--- a/windows/protocols/ms-dcom/IPID.go
+++ b/windows/protocols/ms-dcom/IPID.go
@@ -1,0 +1,20 @@
+package msdcom
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+)
+
+// IPID is an interface pointer identifier ([MS-DCOM] 2.2.16): a GUID that identifies a
+// specific interface on an object exporter. It is a typedef of GUID in the IDL, so it is
+// carried on the wire as a 16-octet GUID (Data1/Data2/Data3 + Data4[8], 4-octet aligned).
+//
+// It is modeled on dtyp.GUID rather than windows/guid.GUID because the latter's trailing
+// uint64 does not marshal to the required 16 octets under NDR.
+type IPID dtyp.GUID
+
+// GUID returns the IPID as a windows/guid.GUID for display and comparison.
+func (i IPID) GUID() guid.GUID { return dtyp.GUID(i).GUID() }
+
+// String returns the canonical brace-less GUID string form of the IPID.
+func (i IPID) String() string { return dtyp.GUID(i).String() }

--- a/windows/protocols/ms-dcom/OID.go
+++ b/windows/protocols/ms-dcom/OID.go
@@ -1,0 +1,5 @@
+package msdcom
+
+// OID is an object identifier ([MS-DCOM] 2.2.5): a 64-bit value that identifies an
+// object within an object exporter's ping set. Carried as unsigned hyper.
+type OID uint64

--- a/windows/protocols/ms-dcom/OXID.go
+++ b/windows/protocols/ms-dcom/OXID.go
@@ -1,0 +1,5 @@
+package msdcom
+
+// OXID is an object exporter identifier ([MS-DCOM] 2.2.4): a 64-bit value that
+// identifies an object exporter within an object resolver. Carried as unsigned hyper.
+type OXID uint64

--- a/windows/protocols/ms-dcom/SETID.go
+++ b/windows/protocols/ms-dcom/SETID.go
@@ -1,0 +1,5 @@
+package msdcom
+
+// SETID is a ping set identifier ([MS-DCOM] 2.2.7): a 64-bit value that identifies a
+// ping set maintained by an object resolver. Carried as unsigned hyper.
+type SETID uint64

--- a/windows/protocols/ms-dcom/structures_test.go
+++ b/windows/protocols/ms-dcom/structures_test.go
@@ -1,0 +1,84 @@
+package msdcom
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// roundTrip marshals in, unmarshals into a fresh value of the same type, and asserts the
+// result is deeply equal to in. This is the wire-shape acceptance gate for the MS-DCOM
+// IObjectExporter (IOXIDResolver) NDR structures in the absence of a live object resolver.
+func roundTrip[T any](t *testing.T, name string, in T) {
+	t.Helper()
+	raw, err := ndr.Marshal(&in)
+	if err != nil {
+		t.Fatalf("%s: Marshal: %v", name, err)
+	}
+	var out T
+	if err := ndr.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("%s: Unmarshal: %v", name, err)
+	}
+	if !reflect.DeepEqual(in, out) {
+		t.Errorf("%s: round trip mismatch:\n in:  %+v\n out: %+v", name, in, out)
+	}
+}
+
+// TestCOMVERSION exercises the fixed two-uint16 version structure.
+func TestCOMVERSION(t *testing.T) {
+	roundTrip(t, "COMVERSION", COMVERSION{MajorVersion: 5, MinorVersion: 7})
+}
+
+// TestDUALSTRINGARRAY exercises the bare inline conformant array (aStringArray) whose
+// maximum_count is transmitted in place with no referent id. The buffer is the wNumEntries
+// unsigned shorts holding the string bindings followed by the security bindings.
+func TestDUALSTRINGARRAY(t *testing.T) {
+	roundTrip(t, "DUALSTRINGARRAY/populated", DUALSTRINGARRAY{
+		WNumEntries:     6,
+		WSecurityOffset: 4,
+		// two STRINGBINDING shorts + null, then a SECURITYBINDING short + null.
+		AStringArray: []uint16{0x0007, 0x4142, 0x0000, 0x000a, 0x0000, 0x0000},
+	})
+	roundTrip(t, "DUALSTRINGARRAY/empty", DUALSTRINGARRAY{
+		WNumEntries:     0,
+		WSecurityOffset: 0,
+		AStringArray:    []uint16{},
+	})
+}
+
+// TestScalarTypedefs exercises the unsigned hyper aliases OXID/OID/SETID. NDR marshals
+// top-level structs only, so they are wrapped (as they appear on the wire — inline fields
+// of a request/response struct).
+func TestScalarTypedefs(t *testing.T) {
+	type scalars struct {
+		Oxid  OXID
+		Oid   OID
+		SetId SETID
+	}
+	roundTrip(t, "scalars", scalars{
+		Oxid:  0x1122334455667788,
+		Oid:   0x0102030405060708,
+		SetId: 0xfedcba9876543210,
+	})
+}
+
+// TestIPID exercises the GUID-shaped IPID, which must marshal to exactly 16 octets.
+func TestIPID(t *testing.T) {
+	ipid := IPID{Data1: 0x00000131, Data2: 0x0000, Data3: 0x0000,
+		Data4: [8]byte{0xc0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46}}
+	roundTrip(t, "IPID", ipid)
+
+	raw, err := ndr.Marshal(&ipid)
+	if err != nil {
+		t.Fatalf("IPID: Marshal: %v", err)
+	}
+	if len(raw) != 16 {
+		t.Fatalf("IPID marshaled to %d octets, want 16", len(raw))
+	}
+	// The IPID must render identically through its own helper and the shared dtyp.GUID.
+	if got, want := ipid.String(), dtyp.GUID(ipid).String(); got != want {
+		t.Fatalf("IPID/dtyp.GUID string mismatch: %s vs %s", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

Implements the **IObjectExporter** (IOXIDResolver) RPC interface — abstract syntax `99fcfec4-5260-101b-bbcb-00aa0021347a`, version 0.0 ([MS-DCOM], Distributed Component Object Model (DCOM) Remote Protocol). IObjectExporter is the DCOM **object resolver**: it resolves OXIDs to object exporter bindings, tests server liveness, and maintains the ping sets that keep remote objects alive.

Unlike the rest of MS-DCOM, IObjectExporter is a **classic, non-object RPC interface** — explicit `handle_t` binding, no `ORPCTHIS`/`ORPCTHAT`, no `[object]` attribute — so it is modeled as a plain DCE/RPC interface. The DCOM object/activation interfaces (`IActivation`, `IRemoteSCMActivator`, `IRemUnknown`/`IRemUnknown2`, `IUnknown`) are **out of scope**: they are `[object]`/ORPC interfaces that require object activation which the classic RPC interface tree does not model.

It follows the `dcerpc-interface-structure` split layout:
- **Descriptor + method stubs** under `network/dcerpc/interfaces/99fcfec4-5260-101b-bbcb-00aa0021347a/0.0/`
- **NDR wire types** under `windows/protocols/ms-dcom/` (`package msdcom`)

## What's included

- **`interface.go`** — `SyntaxID()`, the **six on-the-wire opnums** (`ResolveOxid` 0, `SimplePing` 1, `ComplexPing` 2, `ServerAlive` 3, `ResolveOxid2` 4, `ServerAlive2` 5), the `OpnumToName`/`NameToOpnum` maps, and the `error_status_t` status table (`RPC_S_OK` + the object-resolver `OR_INVALID_OXID`/`OR_INVALID_OID`/`OR_INVALID_SET` codes from [MS-ERREF] 2.2). IObjectExporter is **not** a named-pipe interface: per [MS-DCOM] 2.1 the object resolver is reached through the RPC endpoint mapper / well-known endpoints (`ncacn_ip_tcp` TCP port 135). `PipeName` is an empty documented placeholder retained for descriptor uniformity (same treatment as MS-CMRP / MS-DRSR).
- **`functions/00_ResolveOxid.go` … `05_ServerAlive2.go`** — one stub per opnum. `ResolveOxid`/`ResolveOxid2` return the exporter's `*DUALSTRINGARRAY` bindings, the `IPID` of its `IRemUnknown`, an auth hint (and, for v2, `COMVERSION`); `ServerAlive2` returns the resolver `COMVERSION` and its bindings (the method a client uses to discover a working protocol sequence); `SimplePing`/`ComplexPing` manage ping sets; `ServerAlive` takes no marshaled parameters.
- **`windows/protocols/ms-dcom/`** — `OXID`/`OID`/`SETID` (`unsigned hyper`), `IPID` (modeled on `dtyp.GUID` so it marshals to exactly 16 octets — `windows/guid.GUID` would not), `COMVERSION`, and `DUALSTRINGARRAY`.
- **Tests** — structure round-trips (the bare inline conformant `DUALSTRINGARRAY` incl. the empty case, the scalar typedefs, and a 16-octet assertion for `IPID`) in `structures_test.go`; descriptor opnum/status/syntax tests in `interface_test.go`.
- The unmodified spec IDL is committed as `ms-dcom.idl` for reference.

## NDR modeling notes

- `[out, ref] DUALSTRINGARRAY **` → `*DUALSTRINGARRAY` tagged `unique`: the top-level `[out, ref]` outer pointer has no wire representation, and the inner pointer takes the interface's `pointer_default(unique)` (referent id + deferred body).
- `DUALSTRINGARRAY.aStringArray` is a bare inline conformant array member (`[size_is] short arr[]`, no pointer) → `conformant` (hoisted `maximum_count`, no referent id), **not** `unique`.
- `[in, unique, size_is] OID AddToSet[]` / `DelFromSet[]` → `unique` (each carries a referent id); `[in, ref, size_is] short arRequestedProtseqs[]` → `ref` (no referent id).
- Top-level parameter pointers (`[in] OXID *`, `[in,out] SETID *`, the `[out, ref]` `IPID`/`COMVERSION`/`DWORD`) are transmitted inline.

## Verification

- `gofmt -l` clean; `go build`, `go vet`, `go test` green over both trees (`99fcfec4-…/0.0/…` and `windows/protocols/ms-dcom/…`).
- Cross-compiles for `GOARCH=386` and `GOARCH=arm64`; `-tags integration` builds.
- Opnum parity checked: 6 function files == 6 opnum constants == 6 `OpnumToName` entries.

Live validation against a Windows object resolver is deferred (needs a reachable host over `ncacn_ip_tcp:135`); the wire shapes are exercised by the Go round-trip tests, and a byte-level check confirms the `DUALSTRINGARRAY` conformant array hoists `maximum_count` and the `IPID` marshals to 16 octets, as a real server expects.

Closes #755
