### PR TITLE
Add ExtendedError Remote Data Structure (MS-EERR) interface descriptor and NDR structures (Fixes #769)

### DIFF
--- a/network/dcerpc/interfaces/14a8831c-bc82-11d2-8a64-0008c7457e5d/1.0/interface.go
+++ b/network/dcerpc/interfaces/14a8831c-bc82-11d2-8a64-0008c7457e5d/1.0/interface.go
@@ -1,0 +1,47 @@
+// Package rpcinterface_14a8831cbc8211d28a640008c7457e5d_1_0 is the descriptor for the
+// ExtendedError RPC interface, abstract syntax 14a8831c-bc82-11d2-8a64-0008c7457e5d
+// version 1.0 ([MS-EERR]).
+//
+// [MS-EERR] is a data-structure-only specification: the ExtendedError interface defines
+// no on-the-wire methods (opnums). Its NDR types (ExtendedErrorInfo and friends, in the
+// windows/protocols/ms-eerr package) are not carried by a dedicated RPC endpoint; they
+// are marshalled with the [C706] Type Serialization ("pickling") rules and embedded in
+// the response data of OTHER protocols to convey extended error information. There is
+// therefore no named pipe and no functions subpackage for this interface — this
+// descriptor exists only to record the abstract syntax identifier so callers that pickle
+// or interpret these structures can name the interface unambiguously.
+package rpcinterface_14a8831cbc8211d28a640008c7457e5d_1_0
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+)
+
+// PipeName is empty: the ExtendedError interface defines no on-the-wire methods and is
+// not reached over a named pipe. Its structures are pickled ([C706] type serialization)
+// and embedded in other protocols' responses (see the package doc).
+const PipeName = ``
+
+// SyntaxID returns the ExtendedError abstract syntax identifier:
+// 14a8831c-bc82-11d2-8a64-0008c7457e5d, version 1.0.
+func SyntaxID() syntax.SyntaxID {
+	return syntax.SyntaxID{
+		UUID:         guid.GUID{A: 0x14a8831c, B: 0xbc82, C: 0x11d2, D: 0x8a64, E: 0x0008c7457e5d},
+		MajorVersion: 1,
+		MinorVersion: 0,
+	}
+}
+
+// OpnumToName maps each on-the-wire opnum to its method name. [MS-EERR] defines no
+// methods, so this map is empty; it is retained for symmetry with other interface
+// descriptors and as the single source of truth for the (empty) opnum set.
+var OpnumToName = map[uint16]string{}
+
+// NameToOpnum is the reverse of OpnumToName, built at init so the two never drift.
+var NameToOpnum = func() map[string]uint16 {
+	m := make(map[string]uint16, len(OpnumToName))
+	for op, name := range OpnumToName {
+		m[name] = op
+	}
+	return m
+}()

--- a/network/dcerpc/interfaces/14a8831c-bc82-11d2-8a64-0008c7457e5d/1.0/interface_test.go
+++ b/network/dcerpc/interfaces/14a8831c-bc82-11d2-8a64-0008c7457e5d/1.0/interface_test.go
@@ -1,0 +1,34 @@
+package rpcinterface_14a8831cbc8211d28a640008c7457e5d_1_0
+
+import "testing"
+
+// TestSyntaxID checks the abstract syntax identifier for the ExtendedError interface
+// ([MS-EERR]): UUID 14a8831c-bc82-11d2-8a64-0008c7457e5d, version 1.0.
+func TestSyntaxID(t *testing.T) {
+	id := SyntaxID()
+	if got := id.UUID.ToFormatD(); got != "14a8831c-bc82-11d2-8a64-0008c7457e5d" {
+		t.Fatalf("UUID = %s, want 14a8831c-bc82-11d2-8a64-0008c7457e5d", got)
+	}
+	if id.MajorVersion != 1 || id.MinorVersion != 0 {
+		t.Fatalf("version = %d.%d, want 1.0", id.MajorVersion, id.MinorVersion)
+	}
+}
+
+// TestNoOpnums confirms [MS-EERR] defines no on-the-wire methods: both opnum maps are
+// empty and remain mutual inverses.
+func TestNoOpnums(t *testing.T) {
+	if len(OpnumToName) != 0 {
+		t.Fatalf("OpnumToName has %d entries, want 0", len(OpnumToName))
+	}
+	if len(NameToOpnum) != len(OpnumToName) {
+		t.Fatalf("NameToOpnum has %d entries, want %d", len(NameToOpnum), len(OpnumToName))
+	}
+}
+
+// TestPipeNameEmpty documents that the ExtendedError interface has no named-pipe
+// endpoint: its structures are pickled and embedded in other protocols' responses.
+func TestPipeNameEmpty(t *testing.T) {
+	if PipeName != "" {
+		t.Fatalf("PipeName = %q, want empty (interface is not bound over a pipe)", PipeName)
+	}
+}

--- a/windows/protocols/ms-eerr/BinaryEEInfo.go
+++ b/windows/protocols/ms-eerr/BinaryEEInfo.go
@@ -1,0 +1,9 @@
+package mseerr
+
+// BinaryEEInfo models the BinaryEEInfo structure ([MS-EERR] 2.2.1.3): an opaque binary
+// blob. PBlob is a [unique] pointer to a conformant byte array bounded by NSize; nil
+// when NSize is 0.
+type BinaryEEInfo struct {
+	NSize int16
+	PBlob []uint8 `ndr:"unique,size_is=NSize"`
+}

--- a/windows/protocols/ms-eerr/EEAString.go
+++ b/windows/protocols/ms-eerr/EEAString.go
@@ -1,0 +1,9 @@
+package mseerr
+
+// EEAString models the EEAString structure ([MS-EERR] 2.2.1.1): a length-prefixed ANSI
+// (byte) string. PString is a [unique] pointer to a conformant byte array bounded by
+// NLength; nil when NLength is 0.
+type EEAString struct {
+	NLength int16
+	PString []uint8 `ndr:"unique,size_is=NLength"`
+}

--- a/windows/protocols/ms-eerr/EEComputerName.go
+++ b/windows/protocols/ms-eerr/EEComputerName.go
@@ -1,0 +1,18 @@
+package mseerr
+
+// EEComputerName models the EEComputerName structure ([MS-EERR] 2.2.3): the name of
+// the computer where an error was detected. Type indicates whether a name is present;
+// Field is the non-encapsulated union selected by it.
+type EEComputerName struct {
+	Type  EEComputerNamePresent
+	Field EEComputerName_Field
+}
+
+// EEComputerName_Field is the non-encapsulated union of EEComputerName,
+// switch_is(Type) with switch_type(short) ([MS-EERR] 2.2.3, [C706] 14.3.8). The 16-bit
+// discriminant (Tag) is transmitted inline as the first part of the union. eecnpPresent
+// (1) selects Name; eecnpNotPresent (2) selects an empty arm (no field).
+type EEComputerName_Field struct {
+	Tag  int16     `ndr:"switch"`
+	Name EEUString `ndr:"case=1"`
+}

--- a/windows/protocols/ms-eerr/EEComputerNamePresent.go
+++ b/windows/protocols/ms-eerr/EEComputerNamePresent.go
@@ -1,0 +1,9 @@
+package mseerr
+
+// EEComputerNamePresent is an NDR enum, transmitted as a 16-bit value ([C706] 14.3.6, [MS-EERR]).
+type EEComputerNamePresent uint16
+
+const (
+	EecnpPresent    EEComputerNamePresent = 1
+	EecnpNotPresent EEComputerNamePresent = 2
+)

--- a/windows/protocols/ms-eerr/EEUString.go
+++ b/windows/protocols/ms-eerr/EEUString.go
@@ -1,0 +1,9 @@
+package mseerr
+
+// EEUString models the EEUString structure ([MS-EERR] 2.2.1.2): a length-prefixed
+// Unicode (UTF-16) string. PString is a [unique] pointer to a conformant array of
+// unsigned shorts bounded by NLength (a character count); nil when NLength is 0.
+type EEUString struct {
+	NLength int16
+	PString []uint16 `ndr:"unique,size_is=NLength"`
+}

--- a/windows/protocols/ms-eerr/ExtendedErrorInfo.go
+++ b/windows/protocols/ms-eerr/ExtendedErrorInfo.go
@@ -1,0 +1,23 @@
+package mseerr
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// ExtendedErrorInfo models the ExtendedErrorInfo structure ([MS-EERR] 2.2.4): one
+// node in a singly linked chain of error records. Next is a [unique] self-pointer
+// (nil terminates the chain). Params is a conformant array embedded as the final
+// struct member (not a pointer); its maximum_count is hoisted to the head of the
+// struct on the wire ([C706] 14.3.7).
+type ExtendedErrorInfo struct {
+	Next                *ExtendedErrorInfo `ndr:"unique"`
+	ComputerName        EEComputerName
+	ProcessID           ndr.DWORD
+	TimeStamp           int64
+	GeneratingComponent ndr.DWORD
+	Status              ndr.DWORD
+	DetectionLocation   uint16
+	Flags               uint16
+	NLen                int16
+	Params              []ExtendedErrorParam `ndr:"conformant,size_is=NLen"`
+}

--- a/windows/protocols/ms-eerr/ExtendedErrorInfoPtr.go
+++ b/windows/protocols/ms-eerr/ExtendedErrorInfoPtr.go
@@ -1,0 +1,4 @@
+package mseerr
+
+// ExtendedErrorInfoPtr is an alias for ExtendedErrorInfo ([MS-EERR]).
+type ExtendedErrorInfoPtr = ExtendedErrorInfo

--- a/windows/protocols/ms-eerr/ExtendedErrorParam.go
+++ b/windows/protocols/ms-eerr/ExtendedErrorParam.go
@@ -1,0 +1,24 @@
+package mseerr
+
+// ExtendedErrorParam models the ExtendedErrorParam structure ([MS-EERR] 2.2.2): a
+// tagged value carried in an ExtendedErrorInfo record. Type is the discriminant enum;
+// Field is the non-encapsulated union selected by it.
+type ExtendedErrorParam struct {
+	Type  ExtendedErrorParamTypesInternal
+	Field ExtendedErrorParam_Field
+}
+
+// ExtendedErrorParam_Field is the non-encapsulated union of ExtendedErrorParam,
+// switch_is(Type) with switch_type(short) ([MS-EERR] 2.2.2, [C706] 14.3.8). The
+// discriminant is a 16-bit short (Tag) transmitted inline as the first part of the
+// union — so the selecting value appears on the wire twice: once as the enclosing
+// ExtendedErrorParam.Type and once here. eeptiNone (6) selects an empty arm (no field).
+type ExtendedErrorParam_Field struct {
+	Tag           int16        `ndr:"switch"`
+	AnsiString    EEAString    `ndr:"case=1"`
+	UnicodeString EEUString    `ndr:"case=2"`
+	LVal          int32        `ndr:"case=3"`
+	IVal          int16        `ndr:"case=4"`
+	PVal          int64        `ndr:"case=5"`
+	Blob          BinaryEEInfo `ndr:"case=7"`
+}

--- a/windows/protocols/ms-eerr/ExtendedErrorParamTypesInternal.go
+++ b/windows/protocols/ms-eerr/ExtendedErrorParamTypesInternal.go
@@ -1,0 +1,14 @@
+package mseerr
+
+// ExtendedErrorParamTypesInternal is an NDR enum, transmitted as a 16-bit value ([C706] 14.3.6, [MS-EERR]).
+type ExtendedErrorParamTypesInternal uint16
+
+const (
+	EeptiAnsiString    ExtendedErrorParamTypesInternal = 1
+	EeptiUnicodeString ExtendedErrorParamTypesInternal = 2
+	EeptiLongVal       ExtendedErrorParamTypesInternal = 3
+	EeptiShortValue    ExtendedErrorParamTypesInternal = 4
+	EeptiPointerValue  ExtendedErrorParamTypesInternal = 5
+	EeptiNone          ExtendedErrorParamTypesInternal = 6
+	EeptiBinary        ExtendedErrorParamTypesInternal = 7
+)

--- a/windows/protocols/ms-eerr/structures_test.go
+++ b/windows/protocols/ms-eerr/structures_test.go
@@ -1,0 +1,161 @@
+package mseerr
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// roundTrip marshals v, unmarshals into a fresh value of the same type, and returns it
+// for comparison. v and out must be pointers to the same struct type.
+func roundTrip(t *testing.T, v any, out any) {
+	t.Helper()
+	raw, err := ndr.Marshal(v)
+	if err != nil {
+		t.Fatalf("Marshal(%T): %v", v, err)
+	}
+	if err := ndr.Unmarshal(raw, out); err != nil {
+		t.Fatalf("Unmarshal(%T): %v", v, err)
+	}
+}
+
+// TestEEAString_RoundTrip exercises EEAString ([MS-EERR] 2.2.1.1): a [unique] pointer to
+// a conformant byte array bounded by NLength, including the empty (nil pointer) case.
+func TestEEAString_RoundTrip(t *testing.T) {
+	cases := []EEAString{
+		{NLength: 5, PString: []uint8("hello")},
+		{NLength: 1, PString: []uint8{0x00}},
+		{NLength: 0, PString: nil},
+	}
+	for _, in := range cases {
+		var out EEAString
+		roundTrip(t, &in, &out)
+		if !reflect.DeepEqual(in, out) {
+			t.Fatalf("EEAString round-trip: got %+v want %+v", out, in)
+		}
+	}
+}
+
+// TestEEUString_RoundTrip exercises EEUString ([MS-EERR] 2.2.1.2): a [unique] pointer to
+// a conformant UTF-16 array bounded by NLength (a character count).
+func TestEEUString_RoundTrip(t *testing.T) {
+	cases := []EEUString{
+		{NLength: 4, PString: []uint16{'H', 'O', 'S', 'T'}},
+		{NLength: 0, PString: nil},
+	}
+	for _, in := range cases {
+		var out EEUString
+		roundTrip(t, &in, &out)
+		if !reflect.DeepEqual(in, out) {
+			t.Fatalf("EEUString round-trip: got %+v want %+v", out, in)
+		}
+	}
+}
+
+// TestBinaryEEInfo_RoundTrip exercises BinaryEEInfo ([MS-EERR] 2.2.1.3): a [unique]
+// pointer to a conformant byte blob bounded by NSize.
+func TestBinaryEEInfo_RoundTrip(t *testing.T) {
+	cases := []BinaryEEInfo{
+		{NSize: 3, PBlob: []uint8{0xde, 0xad, 0xbe}},
+		{NSize: 0, PBlob: nil},
+	}
+	for _, in := range cases {
+		var out BinaryEEInfo
+		roundTrip(t, &in, &out)
+		if !reflect.DeepEqual(in, out) {
+			t.Fatalf("BinaryEEInfo round-trip: got %+v want %+v", out, in)
+		}
+	}
+}
+
+// TestExtendedErrorParam_RoundTrip exercises every arm of the non-encapsulated union
+// ExtendedErrorParam ([MS-EERR] 2.2.2), including the empty eeptiNone arm. The union's
+// switch_type(short) discriminant (Field.Tag) must match the case value.
+func TestExtendedErrorParam_RoundTrip(t *testing.T) {
+	cases := []ExtendedErrorParam{
+		{Type: EeptiAnsiString, Field: ExtendedErrorParam_Field{Tag: 1, AnsiString: EEAString{NLength: 3, PString: []uint8("abc")}}},
+		{Type: EeptiUnicodeString, Field: ExtendedErrorParam_Field{Tag: 2, UnicodeString: EEUString{NLength: 2, PString: []uint16{'o', 'k'}}}},
+		{Type: EeptiLongVal, Field: ExtendedErrorParam_Field{Tag: 3, LVal: -12345}},
+		{Type: EeptiShortValue, Field: ExtendedErrorParam_Field{Tag: 4, IVal: 777}},
+		{Type: EeptiPointerValue, Field: ExtendedErrorParam_Field{Tag: 5, PVal: 0x0011223344556677}},
+		{Type: EeptiNone, Field: ExtendedErrorParam_Field{Tag: 6}},
+		{Type: EeptiBinary, Field: ExtendedErrorParam_Field{Tag: 7, Blob: BinaryEEInfo{NSize: 2, PBlob: []uint8{0x01, 0x02}}}},
+	}
+	for _, in := range cases {
+		var out ExtendedErrorParam
+		roundTrip(t, &in, &out)
+		if !reflect.DeepEqual(in, out) {
+			t.Fatalf("ExtendedErrorParam(Type=%d) round-trip: got %+v want %+v", in.Type, out, in)
+		}
+	}
+}
+
+// TestEEComputerName_RoundTrip exercises both arms of EEComputerName ([MS-EERR] 2.2.3):
+// eecnpPresent (carries an EEUString name) and eecnpNotPresent (empty arm).
+func TestEEComputerName_RoundTrip(t *testing.T) {
+	cases := []EEComputerName{
+		{Type: EecnpPresent, Field: EEComputerName_Field{Tag: 1, Name: EEUString{NLength: 3, PString: []uint16{'D', 'C', '1'}}}},
+		{Type: EecnpNotPresent, Field: EEComputerName_Field{Tag: 2}},
+	}
+	for _, in := range cases {
+		var out EEComputerName
+		roundTrip(t, &in, &out)
+		if !reflect.DeepEqual(in, out) {
+			t.Fatalf("EEComputerName(Type=%d) round-trip: got %+v want %+v", in.Type, out, in)
+		}
+	}
+}
+
+// TestExtendedErrorInfo_RoundTrip exercises a single ExtendedErrorInfo node ([MS-EERR]
+// 2.2.4) with Next nil: the embedded conformant Params array (max_count hoisted to the
+// head of the struct) and the scalar members.
+func TestExtendedErrorInfo_RoundTrip(t *testing.T) {
+	in := ExtendedErrorInfo{
+		Next:                nil,
+		ComputerName:        EEComputerName{Type: EecnpPresent, Field: EEComputerName_Field{Tag: 1, Name: EEUString{NLength: 2, PString: []uint16{'X', 'Y'}}}},
+		ProcessID:           4242,
+		TimeStamp:           0x01D9AABBCCDDEEFF,
+		GeneratingComponent: 7,
+		Status:              0xC0000022,
+		DetectionLocation:   123,
+		Flags:               0,
+		NLen:                2,
+		Params: []ExtendedErrorParam{
+			{Type: EeptiLongVal, Field: ExtendedErrorParam_Field{Tag: 3, LVal: 1}},
+			{Type: EeptiBinary, Field: ExtendedErrorParam_Field{Tag: 7, Blob: BinaryEEInfo{NSize: 1, PBlob: []uint8{0xff}}}},
+		},
+	}
+	var out ExtendedErrorInfo
+	roundTrip(t, &in, &out)
+	if !reflect.DeepEqual(in, out) {
+		t.Fatalf("ExtendedErrorInfo round-trip: got %+v want %+v", out, in)
+	}
+}
+
+// TestExtendedErrorInfo_Chain exercises the [unique] self-referential Next pointer
+// ([MS-EERR] 2.2.4): a two-node error chain terminated by a nil Next.
+func TestExtendedErrorInfo_Chain(t *testing.T) {
+	in := ExtendedErrorInfo{
+		ComputerName:      EEComputerName{Type: EecnpNotPresent, Field: EEComputerName_Field{Tag: 2}},
+		ProcessID:         1,
+		Status:            0x00000103,
+		DetectionLocation: 1,
+		NLen:              1,
+		Params:            []ExtendedErrorParam{{Type: EeptiShortValue, Field: ExtendedErrorParam_Field{Tag: 4, IVal: 9}}},
+		Next: &ExtendedErrorInfo{
+			ComputerName:      EEComputerName{Type: EecnpNotPresent, Field: EEComputerName_Field{Tag: 2}},
+			ProcessID:         2,
+			Status:            0x00000000,
+			DetectionLocation: 2,
+			NLen:              1,
+			Params:            []ExtendedErrorParam{{Type: EeptiLongVal, Field: ExtendedErrorParam_Field{Tag: 3, LVal: -1}}},
+			Next:              nil,
+		},
+	}
+	var out ExtendedErrorInfo
+	roundTrip(t, &in, &out)
+	if !reflect.DeepEqual(in, out) {
+		t.Fatalf("ExtendedErrorInfo chain round-trip: got %+v want %+v", out, in)
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #769`

### Summary
Implements the ExtendedError Remote Data Structure ([MS-EERR]), abstract syntax `14a8831c-bc82-11d2-8a64-0008c7457e5d` version 1.0. [MS-EERR] is a data-structure-only specification: the `ExtendedError` interface defines **no on-the-wire methods (opnums)** and is not reached over a named pipe — its NDR structures are pickled ([C706] type serialization) and embedded in the response data of other RPC protocols to convey extended error information.

Generated with `idlgen` from Appendix A: Full IDL, then reconciled by hand against the `dcerpc-interface-structure` convention.

### What this adds
- **Interface descriptor** — `network/dcerpc/interfaces/14a8831c-bc82-11d2-8a64-0008c7457e5d/1.0/interface.go`: `SyntaxID()`, an empty `OpnumToName`/`NameToOpnum` (no methods), and an empty `PipeName` documented as intentional (pickled/embedded structures, no pipe binding).
- **NDR structures** — `windows/protocols/ms-eerr/` (`package mseerr`), one file per type per the split layout:
  - `EEAString`, `EEUString`, `BinaryEEInfo` — length-prefixed ANSI/Unicode strings and a binary blob, each a `[unique]` pointer to a conformant array.
  - `ExtendedErrorParamTypesInternal`, `EEComputerNamePresent` — 16-bit NDR enums ([C706] 14.3.6).
  - `ExtendedErrorParam` / `EEComputerName` — structs carrying a non-encapsulated `switch_is` union with a `switch_type(short)` discriminant.
  - `ExtendedErrorInfo` — a linked-list node with a `[unique]` self-pointer (`Next`) and an embedded conformant `Params[]` array (max_count hoisted to the head of the struct).
  - `ExtendedErrorInfoPtr` — typedef alias.

### Hand-reconciliation over the generated skeleton
- Mapped IDL `__int64` → Go `int64` (`ExtendedErrorParam.PVal`, `ExtendedErrorInfo.TimeStamp`); the generator emitted the literal `__int64`.
- Fixed the self-referential pointer `Next` from the nonexistent `*tagExtendedErrorInfo` to `*ExtendedErrorInfo`.
- Corrected the trailing `Params[]` array tag from `unique` to `conformant` — it is an embedded conformant array, not a pointer.
- Exported the enum constants (`Eepti*`, `Eecnp*`) so consumers of the wire model can reference them.
- Rewrote the descriptor doc to state the no-method / no-pipe reality instead of the generic template.

### How Verified
- `gofmt -l` clean; `go build`, `go vet`, `go test -count=1` pass on both trees.
- Cross-compiled the CI matrix legs: `GOARCH=386 go build ./...` and `GOARCH=arm64 go build ./...` both succeed.
- `go build -tags integration` succeeds.

### Test Coverage
- **Added** `windows/protocols/ms-eerr/structures_test.go` — round-trips every union arm of `ExtendedErrorParam` (including the empty `eeptiNone`) and `EEComputerName`, the `[unique]`-pointer strings/blob (data and nil cases), the embedded conformant `Params[]` array, and a two-node self-referential `ExtendedErrorInfo` chain, all via `ndr.Marshal`/`ndr.Unmarshal` + `reflect.DeepEqual`.
- **Added** `interface_test.go` — asserts `SyntaxID()`, the empty opnum maps, and the empty `PipeName`.

### Scope of Change
- **Files changed:** 12 new files (interface descriptor + test; 9 structures + test).
- **Submodule pointer updated:** no.
- **Behavioral changes outside the feature:** none.