### PR TITLE
Add EventLog Remoting Protocol (MS-EVEN) eventlog client interface (Fixes #773)

### DIFF
--- a/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/00_ElfrClearELFW.go
+++ b/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/00_ElfrClearELFW.go
@@ -1,0 +1,35 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	eventlog "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	mseven "github.com/TheManticoreProject/Manticore/windows/protocols/ms-even"
+)
+
+// elfrClearELFWRequest carries the [in] parameters of ElfrClearELFW.
+type elfrClearELFWRequest struct {
+	LogHandle      mseven.IELF_HANDLE
+	BackupFileName *dtyp.RPC_UNICODE_STRING `ndr:"unique"`
+}
+
+func (*elfrClearELFWRequest) Opnum() uint16 { return eventlog.OpnumElfrClearELFW }
+
+// ElfrClearELFW calls ElfrClearELFW (opnum 0) ([MS-EVEN] section 3.1.4).
+func ElfrClearELFW(rpc ndr.Invoker, logHandle mseven.IELF_HANDLE, backupFileName *dtyp.RPC_UNICODE_STRING) (err error) {
+	req := &elfrClearELFWRequest{
+		LogHandle:      logHandle,
+		BackupFileName: backupFileName,
+	}
+	var resp statusResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("ElfrClearELFW: %w", err)
+		return
+	}
+	if uint32(resp.Status) != eventlog.StatusSuccess {
+		err = fmt.Errorf("ElfrClearELFW failed: %s", eventlog.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/01_ElfrBackupELFW.go
+++ b/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/01_ElfrBackupELFW.go
@@ -1,0 +1,35 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	eventlog "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	mseven "github.com/TheManticoreProject/Manticore/windows/protocols/ms-even"
+)
+
+// elfrBackupELFWRequest carries the [in] parameters of ElfrBackupELFW.
+type elfrBackupELFWRequest struct {
+	LogHandle      mseven.IELF_HANDLE
+	BackupFileName dtyp.RPC_UNICODE_STRING
+}
+
+func (*elfrBackupELFWRequest) Opnum() uint16 { return eventlog.OpnumElfrBackupELFW }
+
+// ElfrBackupELFW calls ElfrBackupELFW (opnum 1) ([MS-EVEN] section 3.1.4).
+func ElfrBackupELFW(rpc ndr.Invoker, logHandle mseven.IELF_HANDLE, backupFileName dtyp.RPC_UNICODE_STRING) (err error) {
+	req := &elfrBackupELFWRequest{
+		LogHandle:      logHandle,
+		BackupFileName: backupFileName,
+	}
+	var resp statusResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("ElfrBackupELFW: %w", err)
+		return
+	}
+	if uint32(resp.Status) != eventlog.StatusSuccess {
+		err = fmt.Errorf("ElfrBackupELFW failed: %s", eventlog.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/02_ElfrCloseEL.go
+++ b/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/02_ElfrCloseEL.go
@@ -1,0 +1,33 @@
+package functions
+
+import (
+	"fmt"
+
+	eventlog "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	mseven "github.com/TheManticoreProject/Manticore/windows/protocols/ms-even"
+)
+
+// elfrCloseELRequest carries the [in] parameters of ElfrCloseEL.
+type elfrCloseELRequest struct {
+	LogHandle mseven.IELF_HANDLE
+}
+
+func (*elfrCloseELRequest) Opnum() uint16 { return eventlog.OpnumElfrCloseEL }
+
+// ElfrCloseEL calls ElfrCloseEL (opnum 2) ([MS-EVEN] section 3.1.4).
+func ElfrCloseEL(rpc ndr.Invoker, logHandle mseven.IELF_HANDLE) (LogHandle mseven.IELF_HANDLE, err error) {
+	req := &elfrCloseELRequest{
+		LogHandle: logHandle,
+	}
+	var resp handleResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("ElfrCloseEL: %w", err)
+		return
+	}
+	LogHandle = resp.LogHandle
+	if uint32(resp.Status) != eventlog.StatusSuccess {
+		err = fmt.Errorf("ElfrCloseEL failed: %s", eventlog.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/03_ElfrDeregisterEventSource.go
+++ b/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/03_ElfrDeregisterEventSource.go
@@ -1,0 +1,35 @@
+package functions
+
+import (
+	"fmt"
+
+	eventlog "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	mseven "github.com/TheManticoreProject/Manticore/windows/protocols/ms-even"
+)
+
+// elfrDeregisterEventSourceRequest carries the [in] parameters of ElfrDeregisterEventSource.
+type elfrDeregisterEventSourceRequest struct {
+	LogHandle mseven.IELF_HANDLE
+}
+
+func (*elfrDeregisterEventSourceRequest) Opnum() uint16 {
+	return eventlog.OpnumElfrDeregisterEventSource
+}
+
+// ElfrDeregisterEventSource calls ElfrDeregisterEventSource (opnum 3) ([MS-EVEN] section 3.1.4).
+func ElfrDeregisterEventSource(rpc ndr.Invoker, logHandle mseven.IELF_HANDLE) (LogHandle mseven.IELF_HANDLE, err error) {
+	req := &elfrDeregisterEventSourceRequest{
+		LogHandle: logHandle,
+	}
+	var resp handleResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("ElfrDeregisterEventSource: %w", err)
+		return
+	}
+	LogHandle = resp.LogHandle
+	if uint32(resp.Status) != eventlog.StatusSuccess {
+		err = fmt.Errorf("ElfrDeregisterEventSource failed: %s", eventlog.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/04_ElfrNumberOfRecords.go
+++ b/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/04_ElfrNumberOfRecords.go
@@ -1,0 +1,39 @@
+package functions
+
+import (
+	"fmt"
+
+	eventlog "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	mseven "github.com/TheManticoreProject/Manticore/windows/protocols/ms-even"
+)
+
+// elfrNumberOfRecordsRequest carries the [in] parameters of ElfrNumberOfRecords.
+type elfrNumberOfRecordsRequest struct {
+	LogHandle mseven.IELF_HANDLE
+}
+
+func (*elfrNumberOfRecordsRequest) Opnum() uint16 { return eventlog.OpnumElfrNumberOfRecords }
+
+// elfrNumberOfRecordsResponse carries the [out] parameters and return value of ElfrNumberOfRecords.
+type elfrNumberOfRecordsResponse struct {
+	NumberOfRecords ndr.DWORD
+	Status          ndr.DWORD `ndr:"retval"`
+}
+
+// ElfrNumberOfRecords calls ElfrNumberOfRecords (opnum 4) ([MS-EVEN] section 3.1.4).
+func ElfrNumberOfRecords(rpc ndr.Invoker, logHandle mseven.IELF_HANDLE) (NumberOfRecords ndr.DWORD, err error) {
+	req := &elfrNumberOfRecordsRequest{
+		LogHandle: logHandle,
+	}
+	var resp elfrNumberOfRecordsResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("ElfrNumberOfRecords: %w", err)
+		return
+	}
+	NumberOfRecords = resp.NumberOfRecords
+	if uint32(resp.Status) != eventlog.StatusSuccess {
+		err = fmt.Errorf("ElfrNumberOfRecords failed: %s", eventlog.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/05_ElfrOldestRecord.go
+++ b/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/05_ElfrOldestRecord.go
@@ -1,0 +1,39 @@
+package functions
+
+import (
+	"fmt"
+
+	eventlog "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	mseven "github.com/TheManticoreProject/Manticore/windows/protocols/ms-even"
+)
+
+// elfrOldestRecordRequest carries the [in] parameters of ElfrOldestRecord.
+type elfrOldestRecordRequest struct {
+	LogHandle mseven.IELF_HANDLE
+}
+
+func (*elfrOldestRecordRequest) Opnum() uint16 { return eventlog.OpnumElfrOldestRecord }
+
+// elfrOldestRecordResponse carries the [out] parameters and return value of ElfrOldestRecord.
+type elfrOldestRecordResponse struct {
+	OldestRecordNumber ndr.DWORD
+	Status             ndr.DWORD `ndr:"retval"`
+}
+
+// ElfrOldestRecord calls ElfrOldestRecord (opnum 5) ([MS-EVEN] section 3.1.4).
+func ElfrOldestRecord(rpc ndr.Invoker, logHandle mseven.IELF_HANDLE) (OldestRecordNumber ndr.DWORD, err error) {
+	req := &elfrOldestRecordRequest{
+		LogHandle: logHandle,
+	}
+	var resp elfrOldestRecordResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("ElfrOldestRecord: %w", err)
+		return
+	}
+	OldestRecordNumber = resp.OldestRecordNumber
+	if uint32(resp.Status) != eventlog.StatusSuccess {
+		err = fmt.Errorf("ElfrOldestRecord failed: %s", eventlog.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/06_ElfrChangeNotify.go
+++ b/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/06_ElfrChangeNotify.go
@@ -1,0 +1,36 @@
+package functions
+
+import (
+	"fmt"
+
+	eventlog "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	mseven "github.com/TheManticoreProject/Manticore/windows/protocols/ms-even"
+)
+
+// elfrChangeNotifyRequest carries the [in] parameters of ElfrChangeNotify.
+type elfrChangeNotifyRequest struct {
+	LogHandle mseven.IELF_HANDLE
+	ClientId  mseven.RPC_CLIENT_ID
+	Event     ndr.DWORD
+}
+
+func (*elfrChangeNotifyRequest) Opnum() uint16 { return eventlog.OpnumElfrChangeNotify }
+
+// ElfrChangeNotify calls ElfrChangeNotify (opnum 6) ([MS-EVEN] section 3.1.4).
+func ElfrChangeNotify(rpc ndr.Invoker, logHandle mseven.IELF_HANDLE, clientId mseven.RPC_CLIENT_ID, event ndr.DWORD) (err error) {
+	req := &elfrChangeNotifyRequest{
+		LogHandle: logHandle,
+		ClientId:  clientId,
+		Event:     event,
+	}
+	var resp statusResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("ElfrChangeNotify: %w", err)
+		return
+	}
+	if uint32(resp.Status) != eventlog.StatusSuccess {
+		err = fmt.Errorf("ElfrChangeNotify failed: %s", eventlog.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/07_ElfrOpenELW.go
+++ b/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/07_ElfrOpenELW.go
@@ -1,0 +1,42 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	eventlog "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	mseven "github.com/TheManticoreProject/Manticore/windows/protocols/ms-even"
+)
+
+// elfrOpenELWRequest carries the [in] parameters of ElfrOpenELW.
+type elfrOpenELWRequest struct {
+	UNCServerName ndr.WSTR `ndr:"unique"`
+	ModuleName    dtyp.RPC_UNICODE_STRING
+	RegModuleName dtyp.RPC_UNICODE_STRING
+	MajorVersion  ndr.DWORD
+	MinorVersion  ndr.DWORD
+}
+
+func (*elfrOpenELWRequest) Opnum() uint16 { return eventlog.OpnumElfrOpenELW }
+
+// ElfrOpenELW calls ElfrOpenELW (opnum 7) ([MS-EVEN] section 3.1.4).
+func ElfrOpenELW(rpc ndr.Invoker, uNCServerName ndr.WSTR, moduleName dtyp.RPC_UNICODE_STRING, regModuleName dtyp.RPC_UNICODE_STRING, majorVersion ndr.DWORD, minorVersion ndr.DWORD) (LogHandle mseven.IELF_HANDLE, err error) {
+	req := &elfrOpenELWRequest{
+		UNCServerName: uNCServerName,
+		ModuleName:    moduleName,
+		RegModuleName: regModuleName,
+		MajorVersion:  majorVersion,
+		MinorVersion:  minorVersion,
+	}
+	var resp handleResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("ElfrOpenELW: %w", err)
+		return
+	}
+	LogHandle = resp.LogHandle
+	if uint32(resp.Status) != eventlog.StatusSuccess {
+		err = fmt.Errorf("ElfrOpenELW failed: %s", eventlog.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/08_ElfrRegisterEventSourceW.go
+++ b/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/08_ElfrRegisterEventSourceW.go
@@ -1,0 +1,42 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	eventlog "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	mseven "github.com/TheManticoreProject/Manticore/windows/protocols/ms-even"
+)
+
+// elfrRegisterEventSourceWRequest carries the [in] parameters of ElfrRegisterEventSourceW.
+type elfrRegisterEventSourceWRequest struct {
+	UNCServerName ndr.WSTR `ndr:"unique"`
+	ModuleName    dtyp.RPC_UNICODE_STRING
+	RegModuleName dtyp.RPC_UNICODE_STRING
+	MajorVersion  ndr.DWORD
+	MinorVersion  ndr.DWORD
+}
+
+func (*elfrRegisterEventSourceWRequest) Opnum() uint16 { return eventlog.OpnumElfrRegisterEventSourceW }
+
+// ElfrRegisterEventSourceW calls ElfrRegisterEventSourceW (opnum 8) ([MS-EVEN] section 3.1.4).
+func ElfrRegisterEventSourceW(rpc ndr.Invoker, uNCServerName ndr.WSTR, moduleName dtyp.RPC_UNICODE_STRING, regModuleName dtyp.RPC_UNICODE_STRING, majorVersion ndr.DWORD, minorVersion ndr.DWORD) (LogHandle mseven.IELF_HANDLE, err error) {
+	req := &elfrRegisterEventSourceWRequest{
+		UNCServerName: uNCServerName,
+		ModuleName:    moduleName,
+		RegModuleName: regModuleName,
+		MajorVersion:  majorVersion,
+		MinorVersion:  minorVersion,
+	}
+	var resp handleResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("ElfrRegisterEventSourceW: %w", err)
+		return
+	}
+	LogHandle = resp.LogHandle
+	if uint32(resp.Status) != eventlog.StatusSuccess {
+		err = fmt.Errorf("ElfrRegisterEventSourceW failed: %s", eventlog.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/09_ElfrOpenBELW.go
+++ b/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/09_ElfrOpenBELW.go
@@ -1,0 +1,40 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	eventlog "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	mseven "github.com/TheManticoreProject/Manticore/windows/protocols/ms-even"
+)
+
+// elfrOpenBELWRequest carries the [in] parameters of ElfrOpenBELW.
+type elfrOpenBELWRequest struct {
+	UNCServerName  ndr.WSTR `ndr:"unique"`
+	BackupFileName dtyp.RPC_UNICODE_STRING
+	MajorVersion   ndr.DWORD
+	MinorVersion   ndr.DWORD
+}
+
+func (*elfrOpenBELWRequest) Opnum() uint16 { return eventlog.OpnumElfrOpenBELW }
+
+// ElfrOpenBELW calls ElfrOpenBELW (opnum 9) ([MS-EVEN] section 3.1.4).
+func ElfrOpenBELW(rpc ndr.Invoker, uNCServerName ndr.WSTR, backupFileName dtyp.RPC_UNICODE_STRING, majorVersion ndr.DWORD, minorVersion ndr.DWORD) (LogHandle mseven.IELF_HANDLE, err error) {
+	req := &elfrOpenBELWRequest{
+		UNCServerName:  uNCServerName,
+		BackupFileName: backupFileName,
+		MajorVersion:   majorVersion,
+		MinorVersion:   minorVersion,
+	}
+	var resp handleResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("ElfrOpenBELW: %w", err)
+		return
+	}
+	LogHandle = resp.LogHandle
+	if uint32(resp.Status) != eventlog.StatusSuccess {
+		err = fmt.Errorf("ElfrOpenBELW failed: %s", eventlog.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/10_ElfrReadELW.go
+++ b/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/10_ElfrReadELW.go
@@ -1,0 +1,49 @@
+package functions
+
+import (
+	"fmt"
+
+	eventlog "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	mseven "github.com/TheManticoreProject/Manticore/windows/protocols/ms-even"
+)
+
+// elfrReadELWRequest carries the [in] parameters of ElfrReadELW.
+type elfrReadELWRequest struct {
+	LogHandle           mseven.IELF_HANDLE
+	ReadFlags           ndr.DWORD
+	RecordOffset        ndr.DWORD
+	NumberOfBytesToRead mseven.RULONG
+}
+
+func (*elfrReadELWRequest) Opnum() uint16 { return eventlog.OpnumElfrReadELW }
+
+// elfrReadELWResponse carries the [out] parameters and return value of ElfrReadELW.
+type elfrReadELWResponse struct {
+	Buffer                 []uint8 `ndr:"ref,size_is=NumberOfBytesToRead"`
+	NumberOfBytesRead      ndr.DWORD
+	MinNumberOfBytesNeeded ndr.DWORD
+	Status                 ndr.DWORD `ndr:"retval"`
+}
+
+// ElfrReadELW calls ElfrReadELW (opnum 10) ([MS-EVEN] section 3.1.4).
+func ElfrReadELW(rpc ndr.Invoker, logHandle mseven.IELF_HANDLE, readFlags ndr.DWORD, recordOffset ndr.DWORD, numberOfBytesToRead mseven.RULONG) (Buffer []uint8, NumberOfBytesRead ndr.DWORD, MinNumberOfBytesNeeded ndr.DWORD, err error) {
+	req := &elfrReadELWRequest{
+		LogHandle:           logHandle,
+		ReadFlags:           readFlags,
+		RecordOffset:        recordOffset,
+		NumberOfBytesToRead: numberOfBytesToRead,
+	}
+	var resp elfrReadELWResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("ElfrReadELW: %w", err)
+		return
+	}
+	Buffer = resp.Buffer
+	NumberOfBytesRead = resp.NumberOfBytesRead
+	MinNumberOfBytesNeeded = resp.MinNumberOfBytesNeeded
+	if uint32(resp.Status) != eventlog.StatusSuccess {
+		err = fmt.Errorf("ElfrReadELW failed: %s", eventlog.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/11_ElfrReportEventW.go
+++ b/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/11_ElfrReportEventW.go
@@ -1,0 +1,68 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	eventlog "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	mseven "github.com/TheManticoreProject/Manticore/windows/protocols/ms-even"
+)
+
+// elfrReportEventWRequest carries the [in] parameters of ElfrReportEventW.
+type elfrReportEventWRequest struct {
+	LogHandle     mseven.IELF_HANDLE
+	Time          ndr.DWORD
+	EventType     uint16
+	EventCategory uint16
+	EventID       ndr.DWORD
+	NumStrings    uint16
+	DataSize      ndr.DWORD
+	ComputerName  dtyp.RPC_UNICODE_STRING
+	UserSID       *dtyp.RPC_SID              `ndr:"unique"`
+	Strings       []*dtyp.RPC_UNICODE_STRING `ndr:"unique,elem=unique,size_is=NumStrings"`
+	Data          []uint8                    `ndr:"unique,size_is=DataSize"`
+	Flags         uint16
+	RecordNumber  *ndr.DWORD `ndr:"unique"`
+	TimeWritten   *ndr.DWORD `ndr:"unique"`
+}
+
+func (*elfrReportEventWRequest) Opnum() uint16 { return eventlog.OpnumElfrReportEventW }
+
+// elfrReportEventWResponse carries the [out] parameters and return value of ElfrReportEventW.
+type elfrReportEventWResponse struct {
+	RecordNumber *ndr.DWORD `ndr:"unique"`
+	TimeWritten  *ndr.DWORD `ndr:"unique"`
+	Status       ndr.DWORD  `ndr:"retval"`
+}
+
+// ElfrReportEventW calls ElfrReportEventW (opnum 11) ([MS-EVEN] section 3.1.4).
+func ElfrReportEventW(rpc ndr.Invoker, logHandle mseven.IELF_HANDLE, time ndr.DWORD, eventType uint16, eventCategory uint16, eventID ndr.DWORD, numStrings uint16, dataSize ndr.DWORD, computerName dtyp.RPC_UNICODE_STRING, userSID *dtyp.RPC_SID, strings []*dtyp.RPC_UNICODE_STRING, data []uint8, flags uint16, recordNumber *ndr.DWORD, timeWritten *ndr.DWORD) (RecordNumber *ndr.DWORD, TimeWritten *ndr.DWORD, err error) {
+	req := &elfrReportEventWRequest{
+		LogHandle:     logHandle,
+		Time:          time,
+		EventType:     eventType,
+		EventCategory: eventCategory,
+		EventID:       eventID,
+		NumStrings:    numStrings,
+		DataSize:      dataSize,
+		ComputerName:  computerName,
+		UserSID:       userSID,
+		Strings:       strings,
+		Data:          data,
+		Flags:         flags,
+		RecordNumber:  recordNumber,
+		TimeWritten:   timeWritten,
+	}
+	var resp elfrReportEventWResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("ElfrReportEventW: %w", err)
+		return
+	}
+	RecordNumber = resp.RecordNumber
+	TimeWritten = resp.TimeWritten
+	if uint32(resp.Status) != eventlog.StatusSuccess {
+		err = fmt.Errorf("ElfrReportEventW failed: %s", eventlog.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/12_ElfrClearELFA.go
+++ b/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/12_ElfrClearELFA.go
@@ -1,0 +1,34 @@
+package functions
+
+import (
+	"fmt"
+
+	eventlog "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	mseven "github.com/TheManticoreProject/Manticore/windows/protocols/ms-even"
+)
+
+// elfrClearELFARequest carries the [in] parameters of ElfrClearELFA.
+type elfrClearELFARequest struct {
+	LogHandle      mseven.IELF_HANDLE
+	BackupFileName *mseven.RPC_STRING `ndr:"unique"`
+}
+
+func (*elfrClearELFARequest) Opnum() uint16 { return eventlog.OpnumElfrClearELFA }
+
+// ElfrClearELFA calls ElfrClearELFA (opnum 12) ([MS-EVEN] section 3.1.4).
+func ElfrClearELFA(rpc ndr.Invoker, logHandle mseven.IELF_HANDLE, backupFileName *mseven.RPC_STRING) (err error) {
+	req := &elfrClearELFARequest{
+		LogHandle:      logHandle,
+		BackupFileName: backupFileName,
+	}
+	var resp statusResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("ElfrClearELFA: %w", err)
+		return
+	}
+	if uint32(resp.Status) != eventlog.StatusSuccess {
+		err = fmt.Errorf("ElfrClearELFA failed: %s", eventlog.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/13_ElfrBackupELFA.go
+++ b/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/13_ElfrBackupELFA.go
@@ -1,0 +1,34 @@
+package functions
+
+import (
+	"fmt"
+
+	eventlog "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	mseven "github.com/TheManticoreProject/Manticore/windows/protocols/ms-even"
+)
+
+// elfrBackupELFARequest carries the [in] parameters of ElfrBackupELFA.
+type elfrBackupELFARequest struct {
+	LogHandle      mseven.IELF_HANDLE
+	BackupFileName mseven.RPC_STRING
+}
+
+func (*elfrBackupELFARequest) Opnum() uint16 { return eventlog.OpnumElfrBackupELFA }
+
+// ElfrBackupELFA calls ElfrBackupELFA (opnum 13) ([MS-EVEN] section 3.1.4).
+func ElfrBackupELFA(rpc ndr.Invoker, logHandle mseven.IELF_HANDLE, backupFileName mseven.RPC_STRING) (err error) {
+	req := &elfrBackupELFARequest{
+		LogHandle:      logHandle,
+		BackupFileName: backupFileName,
+	}
+	var resp statusResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("ElfrBackupELFA: %w", err)
+		return
+	}
+	if uint32(resp.Status) != eventlog.StatusSuccess {
+		err = fmt.Errorf("ElfrBackupELFA failed: %s", eventlog.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/14_ElfrOpenELA.go
+++ b/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/14_ElfrOpenELA.go
@@ -1,0 +1,41 @@
+package functions
+
+import (
+	"fmt"
+
+	eventlog "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	mseven "github.com/TheManticoreProject/Manticore/windows/protocols/ms-even"
+)
+
+// elfrOpenELARequest carries the [in] parameters of ElfrOpenELA.
+type elfrOpenELARequest struct {
+	UNCServerName ndr.STR `ndr:"unique"`
+	ModuleName    mseven.RPC_STRING
+	RegModuleName mseven.RPC_STRING
+	MajorVersion  ndr.DWORD
+	MinorVersion  ndr.DWORD
+}
+
+func (*elfrOpenELARequest) Opnum() uint16 { return eventlog.OpnumElfrOpenELA }
+
+// ElfrOpenELA calls ElfrOpenELA (opnum 14) ([MS-EVEN] section 3.1.4).
+func ElfrOpenELA(rpc ndr.Invoker, uNCServerName ndr.STR, moduleName mseven.RPC_STRING, regModuleName mseven.RPC_STRING, majorVersion ndr.DWORD, minorVersion ndr.DWORD) (LogHandle mseven.IELF_HANDLE, err error) {
+	req := &elfrOpenELARequest{
+		UNCServerName: uNCServerName,
+		ModuleName:    moduleName,
+		RegModuleName: regModuleName,
+		MajorVersion:  majorVersion,
+		MinorVersion:  minorVersion,
+	}
+	var resp handleResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("ElfrOpenELA: %w", err)
+		return
+	}
+	LogHandle = resp.LogHandle
+	if uint32(resp.Status) != eventlog.StatusSuccess {
+		err = fmt.Errorf("ElfrOpenELA failed: %s", eventlog.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/15_ElfrRegisterEventSourceA.go
+++ b/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/15_ElfrRegisterEventSourceA.go
@@ -1,0 +1,41 @@
+package functions
+
+import (
+	"fmt"
+
+	eventlog "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	mseven "github.com/TheManticoreProject/Manticore/windows/protocols/ms-even"
+)
+
+// elfrRegisterEventSourceARequest carries the [in] parameters of ElfrRegisterEventSourceA.
+type elfrRegisterEventSourceARequest struct {
+	UNCServerName ndr.STR `ndr:"unique"`
+	ModuleName    mseven.RPC_STRING
+	RegModuleName mseven.RPC_STRING
+	MajorVersion  ndr.DWORD
+	MinorVersion  ndr.DWORD
+}
+
+func (*elfrRegisterEventSourceARequest) Opnum() uint16 { return eventlog.OpnumElfrRegisterEventSourceA }
+
+// ElfrRegisterEventSourceA calls ElfrRegisterEventSourceA (opnum 15) ([MS-EVEN] section 3.1.4).
+func ElfrRegisterEventSourceA(rpc ndr.Invoker, uNCServerName ndr.STR, moduleName mseven.RPC_STRING, regModuleName mseven.RPC_STRING, majorVersion ndr.DWORD, minorVersion ndr.DWORD) (LogHandle mseven.IELF_HANDLE, err error) {
+	req := &elfrRegisterEventSourceARequest{
+		UNCServerName: uNCServerName,
+		ModuleName:    moduleName,
+		RegModuleName: regModuleName,
+		MajorVersion:  majorVersion,
+		MinorVersion:  minorVersion,
+	}
+	var resp handleResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("ElfrRegisterEventSourceA: %w", err)
+		return
+	}
+	LogHandle = resp.LogHandle
+	if uint32(resp.Status) != eventlog.StatusSuccess {
+		err = fmt.Errorf("ElfrRegisterEventSourceA failed: %s", eventlog.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/16_ElfrOpenBELA.go
+++ b/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/16_ElfrOpenBELA.go
@@ -1,0 +1,39 @@
+package functions
+
+import (
+	"fmt"
+
+	eventlog "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	mseven "github.com/TheManticoreProject/Manticore/windows/protocols/ms-even"
+)
+
+// elfrOpenBELARequest carries the [in] parameters of ElfrOpenBELA.
+type elfrOpenBELARequest struct {
+	UNCServerName  ndr.STR `ndr:"unique"`
+	BackupFileName mseven.RPC_STRING
+	MajorVersion   ndr.DWORD
+	MinorVersion   ndr.DWORD
+}
+
+func (*elfrOpenBELARequest) Opnum() uint16 { return eventlog.OpnumElfrOpenBELA }
+
+// ElfrOpenBELA calls ElfrOpenBELA (opnum 16) ([MS-EVEN] section 3.1.4).
+func ElfrOpenBELA(rpc ndr.Invoker, uNCServerName ndr.STR, backupFileName mseven.RPC_STRING, majorVersion ndr.DWORD, minorVersion ndr.DWORD) (LogHandle mseven.IELF_HANDLE, err error) {
+	req := &elfrOpenBELARequest{
+		UNCServerName:  uNCServerName,
+		BackupFileName: backupFileName,
+		MajorVersion:   majorVersion,
+		MinorVersion:   minorVersion,
+	}
+	var resp handleResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("ElfrOpenBELA: %w", err)
+		return
+	}
+	LogHandle = resp.LogHandle
+	if uint32(resp.Status) != eventlog.StatusSuccess {
+		err = fmt.Errorf("ElfrOpenBELA failed: %s", eventlog.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/17_ElfrReadELA.go
+++ b/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/17_ElfrReadELA.go
@@ -1,0 +1,49 @@
+package functions
+
+import (
+	"fmt"
+
+	eventlog "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	mseven "github.com/TheManticoreProject/Manticore/windows/protocols/ms-even"
+)
+
+// elfrReadELARequest carries the [in] parameters of ElfrReadELA.
+type elfrReadELARequest struct {
+	LogHandle           mseven.IELF_HANDLE
+	ReadFlags           ndr.DWORD
+	RecordOffset        ndr.DWORD
+	NumberOfBytesToRead mseven.RULONG
+}
+
+func (*elfrReadELARequest) Opnum() uint16 { return eventlog.OpnumElfrReadELA }
+
+// elfrReadELAResponse carries the [out] parameters and return value of ElfrReadELA.
+type elfrReadELAResponse struct {
+	Buffer                 []uint8 `ndr:"ref,size_is=NumberOfBytesToRead"`
+	NumberOfBytesRead      ndr.DWORD
+	MinNumberOfBytesNeeded ndr.DWORD
+	Status                 ndr.DWORD `ndr:"retval"`
+}
+
+// ElfrReadELA calls ElfrReadELA (opnum 17) ([MS-EVEN] section 3.1.4).
+func ElfrReadELA(rpc ndr.Invoker, logHandle mseven.IELF_HANDLE, readFlags ndr.DWORD, recordOffset ndr.DWORD, numberOfBytesToRead mseven.RULONG) (Buffer []uint8, NumberOfBytesRead ndr.DWORD, MinNumberOfBytesNeeded ndr.DWORD, err error) {
+	req := &elfrReadELARequest{
+		LogHandle:           logHandle,
+		ReadFlags:           readFlags,
+		RecordOffset:        recordOffset,
+		NumberOfBytesToRead: numberOfBytesToRead,
+	}
+	var resp elfrReadELAResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("ElfrReadELA: %w", err)
+		return
+	}
+	Buffer = resp.Buffer
+	NumberOfBytesRead = resp.NumberOfBytesRead
+	MinNumberOfBytesNeeded = resp.MinNumberOfBytesNeeded
+	if uint32(resp.Status) != eventlog.StatusSuccess {
+		err = fmt.Errorf("ElfrReadELA failed: %s", eventlog.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/18_ElfrReportEventA.go
+++ b/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/18_ElfrReportEventA.go
@@ -1,0 +1,68 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	eventlog "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	mseven "github.com/TheManticoreProject/Manticore/windows/protocols/ms-even"
+)
+
+// elfrReportEventARequest carries the [in] parameters of ElfrReportEventA.
+type elfrReportEventARequest struct {
+	LogHandle     mseven.IELF_HANDLE
+	Time          ndr.DWORD
+	EventType     uint16
+	EventCategory uint16
+	EventID       ndr.DWORD
+	NumStrings    uint16
+	DataSize      ndr.DWORD
+	ComputerName  mseven.RPC_STRING
+	UserSID       *dtyp.RPC_SID        `ndr:"unique"`
+	Strings       []*mseven.RPC_STRING `ndr:"unique,elem=unique,size_is=NumStrings"`
+	Data          []uint8              `ndr:"unique,size_is=DataSize"`
+	Flags         uint16
+	RecordNumber  *ndr.DWORD `ndr:"unique"`
+	TimeWritten   *ndr.DWORD `ndr:"unique"`
+}
+
+func (*elfrReportEventARequest) Opnum() uint16 { return eventlog.OpnumElfrReportEventA }
+
+// elfrReportEventAResponse carries the [out] parameters and return value of ElfrReportEventA.
+type elfrReportEventAResponse struct {
+	RecordNumber *ndr.DWORD `ndr:"unique"`
+	TimeWritten  *ndr.DWORD `ndr:"unique"`
+	Status       ndr.DWORD  `ndr:"retval"`
+}
+
+// ElfrReportEventA calls ElfrReportEventA (opnum 18) ([MS-EVEN] section 3.1.4).
+func ElfrReportEventA(rpc ndr.Invoker, logHandle mseven.IELF_HANDLE, time ndr.DWORD, eventType uint16, eventCategory uint16, eventID ndr.DWORD, numStrings uint16, dataSize ndr.DWORD, computerName mseven.RPC_STRING, userSID *dtyp.RPC_SID, strings []*mseven.RPC_STRING, data []uint8, flags uint16, recordNumber *ndr.DWORD, timeWritten *ndr.DWORD) (RecordNumber *ndr.DWORD, TimeWritten *ndr.DWORD, err error) {
+	req := &elfrReportEventARequest{
+		LogHandle:     logHandle,
+		Time:          time,
+		EventType:     eventType,
+		EventCategory: eventCategory,
+		EventID:       eventID,
+		NumStrings:    numStrings,
+		DataSize:      dataSize,
+		ComputerName:  computerName,
+		UserSID:       userSID,
+		Strings:       strings,
+		Data:          data,
+		Flags:         flags,
+		RecordNumber:  recordNumber,
+		TimeWritten:   timeWritten,
+	}
+	var resp elfrReportEventAResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("ElfrReportEventA: %w", err)
+		return
+	}
+	RecordNumber = resp.RecordNumber
+	TimeWritten = resp.TimeWritten
+	if uint32(resp.Status) != eventlog.StatusSuccess {
+		err = fmt.Errorf("ElfrReportEventA failed: %s", eventlog.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/22_ElfrGetLogInformation.go
+++ b/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/22_ElfrGetLogInformation.go
@@ -1,0 +1,45 @@
+package functions
+
+import (
+	"fmt"
+
+	eventlog "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	mseven "github.com/TheManticoreProject/Manticore/windows/protocols/ms-even"
+)
+
+// elfrGetLogInformationRequest carries the [in] parameters of ElfrGetLogInformation.
+type elfrGetLogInformationRequest struct {
+	LogHandle mseven.IELF_HANDLE
+	InfoLevel ndr.DWORD
+	CbBufSize ndr.DWORD
+}
+
+func (*elfrGetLogInformationRequest) Opnum() uint16 { return eventlog.OpnumElfrGetLogInformation }
+
+// elfrGetLogInformationResponse carries the [out] parameters and return value of ElfrGetLogInformation.
+type elfrGetLogInformationResponse struct {
+	LpBuffer       []uint8 `ndr:"ref,size_is=CbBufSize"`
+	PcbBytesNeeded ndr.DWORD
+	Status         ndr.DWORD `ndr:"retval"`
+}
+
+// ElfrGetLogInformation calls ElfrGetLogInformation (opnum 22) ([MS-EVEN] section 3.1.4).
+func ElfrGetLogInformation(rpc ndr.Invoker, logHandle mseven.IELF_HANDLE, infoLevel ndr.DWORD, cbBufSize ndr.DWORD) (LpBuffer []uint8, PcbBytesNeeded ndr.DWORD, err error) {
+	req := &elfrGetLogInformationRequest{
+		LogHandle: logHandle,
+		InfoLevel: infoLevel,
+		CbBufSize: cbBufSize,
+	}
+	var resp elfrGetLogInformationResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("ElfrGetLogInformation: %w", err)
+		return
+	}
+	LpBuffer = resp.LpBuffer
+	PcbBytesNeeded = resp.PcbBytesNeeded
+	if uint32(resp.Status) != eventlog.StatusSuccess {
+		err = fmt.Errorf("ElfrGetLogInformation failed: %s", eventlog.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/24_ElfrReportEventAndSourceW.go
+++ b/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/24_ElfrReportEventAndSourceW.go
@@ -1,0 +1,72 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	eventlog "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	mseven "github.com/TheManticoreProject/Manticore/windows/protocols/ms-even"
+)
+
+// elfrReportEventAndSourceWRequest carries the [in] parameters of ElfrReportEventAndSourceW.
+type elfrReportEventAndSourceWRequest struct {
+	LogHandle     mseven.IELF_HANDLE
+	Time          ndr.DWORD
+	EventType     uint16
+	EventCategory uint16
+	EventID       ndr.DWORD
+	SourceName    dtyp.RPC_UNICODE_STRING
+	NumStrings    uint16
+	DataSize      ndr.DWORD
+	ComputerName  dtyp.RPC_UNICODE_STRING
+	UserSID       *dtyp.RPC_SID              `ndr:"unique"`
+	Strings       []*dtyp.RPC_UNICODE_STRING `ndr:"unique,elem=unique,size_is=NumStrings"`
+	Data          []uint8                    `ndr:"unique,size_is=DataSize"`
+	Flags         uint16
+	RecordNumber  *ndr.DWORD `ndr:"unique"`
+	TimeWritten   *ndr.DWORD `ndr:"unique"`
+}
+
+func (*elfrReportEventAndSourceWRequest) Opnum() uint16 {
+	return eventlog.OpnumElfrReportEventAndSourceW
+}
+
+// elfrReportEventAndSourceWResponse carries the [out] parameters and return value of ElfrReportEventAndSourceW.
+type elfrReportEventAndSourceWResponse struct {
+	RecordNumber *ndr.DWORD `ndr:"unique"`
+	TimeWritten  *ndr.DWORD `ndr:"unique"`
+	Status       ndr.DWORD  `ndr:"retval"`
+}
+
+// ElfrReportEventAndSourceW calls ElfrReportEventAndSourceW (opnum 24) ([MS-EVEN] section 3.1.4).
+func ElfrReportEventAndSourceW(rpc ndr.Invoker, logHandle mseven.IELF_HANDLE, time ndr.DWORD, eventType uint16, eventCategory uint16, eventID ndr.DWORD, sourceName dtyp.RPC_UNICODE_STRING, numStrings uint16, dataSize ndr.DWORD, computerName dtyp.RPC_UNICODE_STRING, userSID *dtyp.RPC_SID, strings []*dtyp.RPC_UNICODE_STRING, data []uint8, flags uint16, recordNumber *ndr.DWORD, timeWritten *ndr.DWORD) (RecordNumber *ndr.DWORD, TimeWritten *ndr.DWORD, err error) {
+	req := &elfrReportEventAndSourceWRequest{
+		LogHandle:     logHandle,
+		Time:          time,
+		EventType:     eventType,
+		EventCategory: eventCategory,
+		EventID:       eventID,
+		SourceName:    sourceName,
+		NumStrings:    numStrings,
+		DataSize:      dataSize,
+		ComputerName:  computerName,
+		UserSID:       userSID,
+		Strings:       strings,
+		Data:          data,
+		Flags:         flags,
+		RecordNumber:  recordNumber,
+		TimeWritten:   timeWritten,
+	}
+	var resp elfrReportEventAndSourceWResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("ElfrReportEventAndSourceW: %w", err)
+		return
+	}
+	RecordNumber = resp.RecordNumber
+	TimeWritten = resp.TimeWritten
+	if uint32(resp.Status) != eventlog.StatusSuccess {
+		err = fmt.Errorf("ElfrReportEventAndSourceW failed: %s", eventlog.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/25_ElfrReportEventExW.go
+++ b/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/25_ElfrReportEventExW.go
@@ -1,0 +1,64 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	eventlog "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	mseven "github.com/TheManticoreProject/Manticore/windows/protocols/ms-even"
+)
+
+// elfrReportEventExWRequest carries the [in] parameters of ElfrReportEventExW.
+type elfrReportEventExWRequest struct {
+	LogHandle     mseven.IELF_HANDLE
+	TimeGenerated dtyp.FILETIME
+	EventType     uint16
+	EventCategory uint16
+	EventID       ndr.DWORD
+	NumStrings    uint16
+	DataSize      ndr.DWORD
+	ComputerName  dtyp.RPC_UNICODE_STRING
+	UserSID       *dtyp.RPC_SID              `ndr:"unique"`
+	Strings       []*dtyp.RPC_UNICODE_STRING `ndr:"unique,elem=unique,size_is=NumStrings"`
+	Data          []uint8                    `ndr:"unique,size_is=DataSize"`
+	Flags         uint16
+	RecordNumber  *ndr.DWORD `ndr:"unique"`
+}
+
+func (*elfrReportEventExWRequest) Opnum() uint16 { return eventlog.OpnumElfrReportEventExW }
+
+// elfrReportEventExWResponse carries the [out] parameters and return value of ElfrReportEventExW.
+type elfrReportEventExWResponse struct {
+	RecordNumber *ndr.DWORD `ndr:"unique"`
+	Status       ndr.DWORD  `ndr:"retval"`
+}
+
+// ElfrReportEventExW calls ElfrReportEventExW (opnum 25) ([MS-EVEN] section 3.1.4).
+func ElfrReportEventExW(rpc ndr.Invoker, logHandle mseven.IELF_HANDLE, timeGenerated dtyp.FILETIME, eventType uint16, eventCategory uint16, eventID ndr.DWORD, numStrings uint16, dataSize ndr.DWORD, computerName dtyp.RPC_UNICODE_STRING, userSID *dtyp.RPC_SID, strings []*dtyp.RPC_UNICODE_STRING, data []uint8, flags uint16, recordNumber *ndr.DWORD) (RecordNumber *ndr.DWORD, err error) {
+	req := &elfrReportEventExWRequest{
+		LogHandle:     logHandle,
+		TimeGenerated: timeGenerated,
+		EventType:     eventType,
+		EventCategory: eventCategory,
+		EventID:       eventID,
+		NumStrings:    numStrings,
+		DataSize:      dataSize,
+		ComputerName:  computerName,
+		UserSID:       userSID,
+		Strings:       strings,
+		Data:          data,
+		Flags:         flags,
+		RecordNumber:  recordNumber,
+	}
+	var resp elfrReportEventExWResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("ElfrReportEventExW: %w", err)
+		return
+	}
+	RecordNumber = resp.RecordNumber
+	if uint32(resp.Status) != eventlog.StatusSuccess {
+		err = fmt.Errorf("ElfrReportEventExW failed: %s", eventlog.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/26_ElfrReportEventExA.go
+++ b/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/26_ElfrReportEventExA.go
@@ -1,0 +1,64 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	eventlog "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	mseven "github.com/TheManticoreProject/Manticore/windows/protocols/ms-even"
+)
+
+// elfrReportEventExARequest carries the [in] parameters of ElfrReportEventExA.
+type elfrReportEventExARequest struct {
+	LogHandle     mseven.IELF_HANDLE
+	TimeGenerated dtyp.FILETIME
+	EventType     uint16
+	EventCategory uint16
+	EventID       ndr.DWORD
+	NumStrings    uint16
+	DataSize      ndr.DWORD
+	ComputerName  mseven.RPC_STRING
+	UserSID       *dtyp.RPC_SID        `ndr:"unique"`
+	Strings       []*mseven.RPC_STRING `ndr:"unique,elem=unique,size_is=NumStrings"`
+	Data          []uint8              `ndr:"unique,size_is=DataSize"`
+	Flags         uint16
+	RecordNumber  *ndr.DWORD `ndr:"unique"`
+}
+
+func (*elfrReportEventExARequest) Opnum() uint16 { return eventlog.OpnumElfrReportEventExA }
+
+// elfrReportEventExAResponse carries the [out] parameters and return value of ElfrReportEventExA.
+type elfrReportEventExAResponse struct {
+	RecordNumber *ndr.DWORD `ndr:"unique"`
+	Status       ndr.DWORD  `ndr:"retval"`
+}
+
+// ElfrReportEventExA calls ElfrReportEventExA (opnum 26) ([MS-EVEN] section 3.1.4).
+func ElfrReportEventExA(rpc ndr.Invoker, logHandle mseven.IELF_HANDLE, timeGenerated dtyp.FILETIME, eventType uint16, eventCategory uint16, eventID ndr.DWORD, numStrings uint16, dataSize ndr.DWORD, computerName mseven.RPC_STRING, userSID *dtyp.RPC_SID, strings []*mseven.RPC_STRING, data []uint8, flags uint16, recordNumber *ndr.DWORD) (RecordNumber *ndr.DWORD, err error) {
+	req := &elfrReportEventExARequest{
+		LogHandle:     logHandle,
+		TimeGenerated: timeGenerated,
+		EventType:     eventType,
+		EventCategory: eventCategory,
+		EventID:       eventID,
+		NumStrings:    numStrings,
+		DataSize:      dataSize,
+		ComputerName:  computerName,
+		UserSID:       userSID,
+		Strings:       strings,
+		Data:          data,
+		Flags:         flags,
+		RecordNumber:  recordNumber,
+	}
+	var resp elfrReportEventExAResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("ElfrReportEventExA: %w", err)
+		return
+	}
+	RecordNumber = resp.RecordNumber
+	if uint32(resp.Status) != eventlog.StatusSuccess {
+		err = fmt.Errorf("ElfrReportEventExA failed: %s", eventlog.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/functions.go
+++ b/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/functions.go
@@ -1,0 +1,24 @@
+// Package functions holds the eventlog ([MS-EVEN]) method stubs, one file per opnum.
+// Each stub marshals its [in] parameters into a request stub, invokes the opnum through
+// an ndr.Invoker, and unmarshals the response stub. The shared response shapes below are
+// used by more than one method.
+package functions
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	mseven "github.com/TheManticoreProject/Manticore/windows/protocols/ms-even"
+)
+
+// statusResponse is the response stub for methods whose only [out] value is the returned
+// status (ElfrClearELFW/A, ElfrBackupELFW/A, ElfrChangeNotify).
+type statusResponse struct {
+	Status ndr.DWORD `ndr:"retval"`
+}
+
+// handleResponse is the response stub for methods that return an IELF_HANDLE context
+// handle plus a status: the Open*/Register* methods ([out] IELF_HANDLE*) and the
+// ElfrCloseEL/ElfrDeregisterEventSource methods ([in,out] IELF_HANDLE*).
+type handleResponse struct {
+	LogHandle mseven.IELF_HANDLE
+	Status    ndr.DWORD `ndr:"retval"`
+}

--- a/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/interface.go
+++ b/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/interface.go
@@ -1,0 +1,155 @@
+// Package rpcinterface_82273fdce32a18c33f78827929dc23ea_0_0 is the descriptor for the eventlog RPC interface, abstract
+// syntax 82273fdc-e32a-18c3-3f78-827929dc23ea version 0.0 ([MS-EVEN]).
+//
+// This package holds only the interface-level descriptor (abstract syntax,
+// transport endpoint, opnums, opnum<->name maps, and status constants). The NDR
+// wire types live in windows/protocols/ms-even and the method stubs in functions;
+// both depend on this package, never the reverse.
+package rpcinterface_82273fdce32a18c33f78827929dc23ea_0_0
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+)
+
+// PipeName is the IPC$-relative named pipe for the eventlog interface
+// ([MS-EVEN] 2.1: the server listens on the \PIPE\eventlog named pipe).
+const PipeName = `\eventlog`
+
+// Opnums for the on-the-wire methods. Opnums 19, 20, 21, 23 are "not used on the wire"
+// and are omitted.
+const (
+	OpnumElfrClearELFW             uint16 = 0
+	OpnumElfrBackupELFW            uint16 = 1
+	OpnumElfrCloseEL               uint16 = 2
+	OpnumElfrDeregisterEventSource uint16 = 3
+	OpnumElfrNumberOfRecords       uint16 = 4
+	OpnumElfrOldestRecord          uint16 = 5
+	OpnumElfrChangeNotify          uint16 = 6
+	OpnumElfrOpenELW               uint16 = 7
+	OpnumElfrRegisterEventSourceW  uint16 = 8
+	OpnumElfrOpenBELW              uint16 = 9
+	OpnumElfrReadELW               uint16 = 10
+	OpnumElfrReportEventW          uint16 = 11
+	OpnumElfrClearELFA             uint16 = 12
+	OpnumElfrBackupELFA            uint16 = 13
+	OpnumElfrOpenELA               uint16 = 14
+	OpnumElfrRegisterEventSourceA  uint16 = 15
+	OpnumElfrOpenBELA              uint16 = 16
+	OpnumElfrReadELA               uint16 = 17
+	OpnumElfrReportEventA          uint16 = 18
+	OpnumElfrGetLogInformation     uint16 = 22
+	OpnumElfrReportEventAndSourceW uint16 = 24
+	OpnumElfrReportEventExW        uint16 = 25
+	OpnumElfrReportEventExA        uint16 = 26
+)
+
+// Status codes returned by this interface. The methods are declared to return
+// NTSTATUS, but the EventLog Remoting Protocol reports failures as Win32 error
+// codes ([MS-EVEN] 3.1.4; [MS-ERREF] 2.2/2.3). Both families are listed here.
+const (
+	StatusSuccess uint32 = 0x00000000 // ERROR_SUCCESS
+
+	// Win32 error codes ([MS-ERREF] 2.2).
+	ErrorFileNotFound        uint32 = 0x00000002 // ERROR_FILE_NOT_FOUND
+	ErrorAccessDenied        uint32 = 0x00000005 // ERROR_ACCESS_DENIED
+	ErrorInvalidHandle       uint32 = 0x00000006 // ERROR_INVALID_HANDLE
+	ErrorNotEnoughMemory     uint32 = 0x00000008 // ERROR_NOT_ENOUGH_MEMORY
+	ErrorHandleEOF           uint32 = 0x00000026 // ERROR_HANDLE_EOF (read past the last record)
+	ErrorInvalidParameter    uint32 = 0x00000057 // ERROR_INVALID_PARAMETER
+	ErrorInsufficientBuffer  uint32 = 0x0000007A // ERROR_INSUFFICIENT_BUFFER
+	ErrorEventlogFileCorrupt uint32 = 0x000005DC // ERROR_EVENTLOG_FILE_CORRUPT
+	ErrorEventlogCantStart   uint32 = 0x000005DD // ERROR_EVENTLOG_CANT_START
+	ErrorLogFileFull         uint32 = 0x000005DE // ERROR_LOG_FILE_FULL
+	ErrorEventlogFileChanged uint32 = 0x000005DF // ERROR_EVENTLOG_FILE_CHANGED
+
+	// NTSTATUS codes ([MS-ERREF] 2.3) that the server may return directly.
+	StatusBufferTooSmall   uint32 = 0xC0000023 // STATUS_BUFFER_TOO_SMALL
+	StatusInvalidParameter uint32 = 0xC000000D // STATUS_INVALID_PARAMETER
+)
+
+// SyntaxID returns the eventlog abstract syntax identifier:
+// 82273fdc-e32a-18c3-3f78-827929dc23ea, version 0.0.
+func SyntaxID() syntax.SyntaxID {
+	return syntax.SyntaxID{
+		UUID:         guid.GUID{A: 0x82273fdc, B: 0xe32a, C: 0x18c3, D: 0x3f78, E: 0x827929dc23ea},
+		MajorVersion: 0,
+		MinorVersion: 0,
+	}
+}
+
+// StatusString returns a mnemonic for the documented status codes, otherwise the
+// hex value.
+func StatusString(status uint32) string {
+	switch status {
+	case StatusSuccess:
+		return "ERROR_SUCCESS"
+	case ErrorFileNotFound:
+		return "ERROR_FILE_NOT_FOUND"
+	case ErrorAccessDenied:
+		return "ERROR_ACCESS_DENIED"
+	case ErrorInvalidHandle:
+		return "ERROR_INVALID_HANDLE"
+	case ErrorNotEnoughMemory:
+		return "ERROR_NOT_ENOUGH_MEMORY"
+	case ErrorHandleEOF:
+		return "ERROR_HANDLE_EOF"
+	case ErrorInvalidParameter:
+		return "ERROR_INVALID_PARAMETER"
+	case ErrorInsufficientBuffer:
+		return "ERROR_INSUFFICIENT_BUFFER"
+	case ErrorEventlogFileCorrupt:
+		return "ERROR_EVENTLOG_FILE_CORRUPT"
+	case ErrorEventlogCantStart:
+		return "ERROR_EVENTLOG_CANT_START"
+	case ErrorLogFileFull:
+		return "ERROR_LOG_FILE_FULL"
+	case ErrorEventlogFileChanged:
+		return "ERROR_EVENTLOG_FILE_CHANGED"
+	case StatusBufferTooSmall:
+		return "STATUS_BUFFER_TOO_SMALL"
+	case StatusInvalidParameter:
+		return "STATUS_INVALID_PARAMETER"
+	default:
+		return fmt.Sprintf("0x%08x", status)
+	}
+}
+
+// OpnumToName maps each on-the-wire opnum to its method name; the single source of
+// truth.
+var OpnumToName = map[uint16]string{
+	OpnumElfrClearELFW:             "ElfrClearELFW",
+	OpnumElfrBackupELFW:            "ElfrBackupELFW",
+	OpnumElfrCloseEL:               "ElfrCloseEL",
+	OpnumElfrDeregisterEventSource: "ElfrDeregisterEventSource",
+	OpnumElfrNumberOfRecords:       "ElfrNumberOfRecords",
+	OpnumElfrOldestRecord:          "ElfrOldestRecord",
+	OpnumElfrChangeNotify:          "ElfrChangeNotify",
+	OpnumElfrOpenELW:               "ElfrOpenELW",
+	OpnumElfrRegisterEventSourceW:  "ElfrRegisterEventSourceW",
+	OpnumElfrOpenBELW:              "ElfrOpenBELW",
+	OpnumElfrReadELW:               "ElfrReadELW",
+	OpnumElfrReportEventW:          "ElfrReportEventW",
+	OpnumElfrClearELFA:             "ElfrClearELFA",
+	OpnumElfrBackupELFA:            "ElfrBackupELFA",
+	OpnumElfrOpenELA:               "ElfrOpenELA",
+	OpnumElfrRegisterEventSourceA:  "ElfrRegisterEventSourceA",
+	OpnumElfrOpenBELA:              "ElfrOpenBELA",
+	OpnumElfrReadELA:               "ElfrReadELA",
+	OpnumElfrReportEventA:          "ElfrReportEventA",
+	OpnumElfrGetLogInformation:     "ElfrGetLogInformation",
+	OpnumElfrReportEventAndSourceW: "ElfrReportEventAndSourceW",
+	OpnumElfrReportEventExW:        "ElfrReportEventExW",
+	OpnumElfrReportEventExA:        "ElfrReportEventExA",
+}
+
+// NameToOpnum is the reverse of OpnumToName, built at init so the two never drift.
+var NameToOpnum = func() map[string]uint16 {
+	m := make(map[string]uint16, len(OpnumToName))
+	for op, name := range OpnumToName {
+		m[name] = op
+	}
+	return m
+}()

--- a/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/interface_test.go
+++ b/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/interface_test.go
@@ -1,0 +1,64 @@
+package rpcinterface_82273fdce32a18c33f78827929dc23ea_0_0
+
+import "testing"
+
+// TestSyntaxID pins the abstract syntax: 82273fdc-e32a-18c3-3f78-827929dc23ea v0.0.
+func TestSyntaxID(t *testing.T) {
+	s := SyntaxID()
+	u := s.UUID
+	if u.A != 0x82273fdc || u.B != 0xe32a || u.C != 0x18c3 || u.D != 0x3f78 || u.E != 0x827929dc23ea {
+		t.Errorf("UUID = %s, want 82273fdc-e32a-18c3-3f78-827929dc23ea", u.ToFormatD())
+	}
+	if s.MajorVersion != 0 || s.MinorVersion != 0 {
+		t.Errorf("version = %d.%d, want 0.0", s.MajorVersion, s.MinorVersion)
+	}
+}
+
+// TestPipeName pins the transport endpoint.
+func TestPipeName(t *testing.T) {
+	if PipeName != `\eventlog` {
+		t.Errorf("PipeName = %q, want %q", PipeName, `\eventlog`)
+	}
+}
+
+// TestOpnumNameRoundTrip verifies OpnumToName and NameToOpnum are consistent, that the
+// 23 on-the-wire opnums are present exactly once, and that the four "not used on the
+// wire" opnums (19, 20, 21, 23) are absent.
+func TestOpnumNameRoundTrip(t *testing.T) {
+	wireOpnums := []uint16{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 22, 24, 25, 26}
+	if len(OpnumToName) != len(wireOpnums) {
+		t.Fatalf("OpnumToName has %d entries, want %d", len(OpnumToName), len(wireOpnums))
+	}
+	for op, name := range OpnumToName {
+		if NameToOpnum[name] != op {
+			t.Errorf("NameToOpnum[%q] = %d, want %d", name, NameToOpnum[name], op)
+		}
+	}
+	for _, op := range wireOpnums {
+		if _, ok := OpnumToName[op]; !ok {
+			t.Errorf("on-the-wire opnum %d missing from OpnumToName", op)
+		}
+	}
+	for _, gap := range []uint16{19, 20, 21, 23} {
+		if name, ok := OpnumToName[gap]; ok {
+			t.Errorf("opnum %d (%q) is NotUsedOnWire and must be absent", gap, name)
+		}
+	}
+}
+
+// TestStatusString spot-checks a few mnemonics and the hex fallback.
+func TestStatusString(t *testing.T) {
+	cases := map[uint32]string{
+		StatusSuccess:            "ERROR_SUCCESS",
+		ErrorAccessDenied:        "ERROR_ACCESS_DENIED",
+		ErrorHandleEOF:           "ERROR_HANDLE_EOF",
+		ErrorEventlogFileChanged: "ERROR_EVENTLOG_FILE_CHANGED",
+		StatusBufferTooSmall:     "STATUS_BUFFER_TOO_SMALL",
+		0xdeadbeef:               "0xdeadbeef",
+	}
+	for code, want := range cases {
+		if got := StatusString(code); got != want {
+			t.Errorf("StatusString(0x%08x) = %q, want %q", code, got, want)
+		}
+	}
+}

--- a/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/ms-even.idl
+++ b/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/ms-even.idl
@@ -1,0 +1,274 @@
+ import "ms-dtyp.idl";
+  
+ [
+     uuid(82273FDC-E32A-18C3-3F78-827929DC23EA),
+     version(0.0),
+     ms_union,
+     pointer_default(unique)
+ ]
+  
+  
+ interface eventlog
+ {
+ // the following line(s) commented out to avoid redefinition of MS-DTYP types
+ //typedef long NTSTATUS;
+  
+  
+ typedef struct _RPC_STRING
+ {
+     unsigned short Length;
+     unsigned short MaximumLength;
+     [size_is(MaximumLength), length_is(Length)] char* Buffer;
+ } RPC_STRING,  *PRPC_STRING;
+  
+ typedef struct _RPC_CLIENT_ID {
+     unsigned long UniqueProcess;
+     unsigned long UniqueThread;
+ } RPC_CLIENT_ID, *PRPC_CLIENT_ID;
+  
+ typedef [handle, unique] wchar_t * EVENTLOG_HANDLE_W;
+ typedef [handle, unique] char *  EVENTLOG_HANDLE_A;
+ typedef [context_handle] void * IELF_HANDLE;
+ typedef [range(0, 0x0007FFFF)] unsigned long RULONG;
+  
+  
+ NTSTATUS
+ ElfrClearELFW (
+     [in]           IELF_HANDLE LogHandle,
+     [in,unique]    PRPC_UNICODE_STRING BackupFileName
+     );
+  
+ NTSTATUS
+ ElfrBackupELFW (
+     [in]         IELF_HANDLE LogHandle,
+     [in]         PRPC_UNICODE_STRING BackupFileName
+     );
+  
+ NTSTATUS
+ ElfrCloseEL (
+     [in,out]        IELF_HANDLE * LogHandle
+     );
+  
+ NTSTATUS
+ ElfrDeregisterEventSource (
+     [in,out]        IELF_HANDLE * LogHandle
+     );
+  
+ NTSTATUS
+ ElfrNumberOfRecords(
+     [in]            IELF_HANDLE         LogHandle,
+     [out]           unsigned long *     NumberOfRecords
+     );
+  
+ NTSTATUS
+ ElfrOldestRecord(
+     [in]            IELF_HANDLE         LogHandle,
+     [out]           unsigned long *     OldestRecordNumber
+     );
+  
+ NTSTATUS
+ ElfrChangeNotify(
+     [in]  IELF_HANDLE         LogHandle,
+     [in]  RPC_CLIENT_ID       ClientId,
+     [in]  ULONG               Event
+     );
+  
+ NTSTATUS
+ ElfrOpenELW (
+     [in]    EVENTLOG_HANDLE_W UNCServerName,
+     [in]           PRPC_UNICODE_STRING ModuleName,
+     [in]           PRPC_UNICODE_STRING RegModuleName,
+     [in]           unsigned long MajorVersion,
+     [in]           unsigned long MinorVersion,
+     [out]          IELF_HANDLE * LogHandle
+     );
+  
+ NTSTATUS
+ ElfrRegisterEventSourceW (
+     [in]          EVENTLOG_HANDLE_W UNCServerName,
+     [in]          PRPC_UNICODE_STRING ModuleName,
+     [in]          PRPC_UNICODE_STRING RegModuleName,
+     [in]          unsigned long MajorVersion,
+     [in]          unsigned long MinorVersion,
+     [out]         IELF_HANDLE * LogHandle
+     );
+  
+ NTSTATUS
+ ElfrOpenBELW (
+     [in]          EVENTLOG_HANDLE_W UNCServerName,
+     [in]          PRPC_UNICODE_STRING BackupFileName,
+     [in]          unsigned long MajorVersion,
+     [in]          unsigned long MinorVersion,
+     [out]         IELF_HANDLE * LogHandle
+     );
+  
+ NTSTATUS
+ ElfrReadELW (
+     [in]         IELF_HANDLE     LogHandle,
+     [in]         unsigned long ReadFlags,
+     [in]         unsigned long RecordOffset,
+     [in]         RULONG NumberOfBytesToRead,
+     [out, size_is(NumberOfBytesToRead)] unsigned char * Buffer,
+     [out]        unsigned long * NumberOfBytesRead,
+     [out]        unsigned long * MinNumberOfBytesNeeded
+     );
+  
+ NTSTATUS
+ ElfrReportEventW (
+     [in]         IELF_HANDLE LogHandle,
+     [in]         unsigned long Time,
+     [in]         unsigned short EventType,
+     [in]         unsigned short EventCategory,
+     [in]         unsigned long EventID,
+     [in, range(0, 256)]       unsigned short NumStrings,
+     [in, range(0, 61440)]  unsigned long DataSize,
+     [in]         PRPC_UNICODE_STRING ComputerName,
+     [in, unique] PRPC_SID UserSID,
+     [in, size_is(NumStrings), unique] PRPC_UNICODE_STRING Strings[*],
+     [in, size_is(DataSize), unique] unsigned char * Data,
+     [in]         unsigned short Flags,
+     [in,out,unique] unsigned long * RecordNumber,
+     [in,out,unique] unsigned long * TimeWritten
+     );
+  
+ NTSTATUS
+ ElfrClearELFA (
+     [in]         IELF_HANDLE LogHandle,
+     [in,unique]  PRPC_STRING BackupFileName
+     );
+  
+ NTSTATUS
+ ElfrBackupELFA (
+     [in]         IELF_HANDLE LogHandle,
+     [in]         PRPC_STRING BackupFileName
+     );
+  
+ NTSTATUS
+ ElfrOpenELA (
+     [in]     EVENTLOG_HANDLE_A UNCServerName,
+     [in]     PRPC_STRING ModuleName,
+     [in]     PRPC_STRING RegModuleName,
+     [in]     unsigned long MajorVersion,
+     [in]     unsigned long MinorVersion,
+     [out]    IELF_HANDLE * LogHandle
+     );
+  
+ NTSTATUS
+ ElfrRegisterEventSourceA (
+     [in]     EVENTLOG_HANDLE_A UNCServerName,
+     [in]     PRPC_STRING ModuleName,
+     [in]     PRPC_STRING RegModuleName,
+     [in]     unsigned long MajorVersion,
+     [in]     unsigned long MinorVersion,
+     [out]    IELF_HANDLE * LogHandle
+     );
+  
+ NTSTATUS
+ ElfrOpenBELA (
+     [in]     EVENTLOG_HANDLE_A UNCServerName,
+     [in]     PRPC_STRING BackupFileName,
+     [in]     unsigned long MajorVersion,
+     [in]     unsigned long MinorVersion,
+     [out]    IELF_HANDLE * LogHandle
+     );
+  
+ NTSTATUS
+ ElfrReadELA (
+     [in]    IELF_HANDLE LogHandle,
+     [in]    unsigned long ReadFlags,
+     [in]    unsigned long RecordOffset,
+     [in]    RULONG NumberOfBytesToRead,
+     [out, size_is(NumberOfBytesToRead)] unsigned char * Buffer,
+     [out]   unsigned long * NumberOfBytesRead,
+     [out]   unsigned long * MinNumberOfBytesNeeded
+     );
+
+  
+ NTSTATUS
+ ElfrReportEventA (
+     [in]    IELF_HANDLE LogHandle,
+     [in]    unsigned long Time,
+     [in]    unsigned short EventType,
+     [in]    unsigned short EventCategory,
+     [in]    unsigned long EventID,
+     [in, range(0, 256)]    unsigned short NumStrings,
+     [in, range(0, 61440)]    unsigned long DataSize,
+     [in]    PRPC_STRING ComputerName,
+     [in, unique] PRPC_SID UserSID,
+     [in, size_is(NumStrings), unique] PRPC_STRING Strings[*],
+     [in, size_is(DataSize), unique] unsigned char * Data,
+     [in]    unsigned short Flags,
+     [in,out,unique] unsigned long * RecordNumber,
+     [in,out,unique] unsigned long * TimeWritten
+     );
+  
+ void Opnum19NotUsedOnWire(void);
+ void Opnum20NotUsedOnWire(void);
+ void Opnum21NotUsedOnWire(void);
+  
+ NTSTATUS
+ ElfrGetLogInformation(
+     [in]     IELF_HANDLE             LogHandle,
+     [in]     unsigned long                   InfoLevel,
+     [out, size_is(cbBufSize)] unsigned char *  lpBuffer,
+     [in, range(0, 1024)]      unsigned long  cbBufSize,
+     [out]    unsigned long *                  pcbBytesNeeded
+ );
+  
+ void Opnum23NotUsedOnWire(void); 
+
+ NTSTATUS
+ ElfrReportEventAndSourceW (
+     [in]         IELF_HANDLE LogHandle,
+     [in]         unsigned long Time,
+     [in]         unsigned short EventType,
+     [in]         unsigned short EventCategory,
+     [in]         unsigned long EventID,
+     [in]         PRPC_UNICODE_STRING SourceName,
+     [in, range(0, 256)]         unsigned short NumStrings,
+     [in, range(0, 61440)]         unsigned long DataSize,
+     [in]         PRPC_UNICODE_STRING ComputerName,
+     [in, unique] PRPC_SID UserSID,
+     [in, size_is(NumStrings), unique] PRPC_UNICODE_STRING Strings[*],
+     [in, size_is(DataSize), unique] unsigned char * Data,
+     [in]         unsigned short Flags,
+     [in,out,unique] unsigned long * RecordNumber,
+     [in,out,unique] unsigned long * TimeWritten
+     ); 
+  
+ NTSTATUS ElfrReportEventExW(
+   [in] IELF_HANDLE LogHandle,
+   [in] PFILETIME TimeGenerated,
+   [in] unsigned short EventType,
+   [in] unsigned short EventCategory,
+   [in] unsigned long EventID,
+   [in, range(0, 256)] unsigned short NumStrings,
+   [in, range(0, 61440)] unsigned long DataSize,
+   [in] PRPC_UNICODE_STRING ComputerName,
+   [in, unique] PRPC_SID UserSID,
+   [in, size_is(NumStrings), unique] PRPC_UNICODE_STRING Strings[*],
+   [in, size_is(DataSize), unique] unsigned char* Data,
+   [in] unsigned short Flags,
+   [in, out, unique] unsigned long* RecordNumber
+ );
+  
+ NTSTATUS ElfrReportEventExA(
+   [in] IELF_HANDLE LogHandle,
+   [in] PFILETIME TimeGenerated,
+   [in] unsigned short EventType,
+   [in] unsigned short EventCategory,
+   [in] unsigned long EventID,
+   [in, range(0, 256)] unsigned short NumStrings,
+   [in, range(0, 61440)] unsigned long DataSize,
+   [in] PRPC_STRING ComputerName,
+   [in, unique] PRPC_SID UserSID,
+   [in, size_is(NumStrings), unique] PRPC_STRING Strings[*],
+   [in, size_is(DataSize), unique] unsigned char* Data,
+   [in] unsigned short Flags,
+   [in, out, unique] unsigned long* RecordNumber
+ );
+  
+  
+  
+ }
+  

--- a/windows/protocols/ms-even/IELF_HANDLE.go
+++ b/windows/protocols/ms-even/IELF_HANDLE.go
@@ -1,0 +1,4 @@
+package mseven
+
+// IELF_HANDLE is an RPC context handle: 20 bytes ([MS-RPCE] 2.3.2.2, [MS-EVEN]).
+type IELF_HANDLE [20]byte

--- a/windows/protocols/ms-even/RPC_CLIENT_ID.go
+++ b/windows/protocols/ms-even/RPC_CLIENT_ID.go
@@ -1,0 +1,12 @@
+package mseven
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// RPC_CLIENT_ID identifies a client process/thread pair ([MS-EVEN] 2.2.6). Both
+// members are scalar unsigned longs; there are no pointers or arrays.
+type RPC_CLIENT_ID struct {
+	UniqueProcess ndr.DWORD
+	UniqueThread  ndr.DWORD
+}

--- a/windows/protocols/ms-even/RPC_STRING.go
+++ b/windows/protocols/ms-even/RPC_STRING.go
@@ -1,0 +1,11 @@
+package mseven
+
+// RPC_STRING is a counted ASCII string ([MS-EVEN] 2.2.7). Length and MaximumLength
+// are byte counts; Buffer is a [unique] pointer to a conformant-varying char array
+// ([size_is(MaximumLength), length_is(Length)] char*), so it is tagged unique,varying
+// — the NDR max_count/offset/actual_count words travel with the array itself.
+type RPC_STRING struct {
+	Length        uint16
+	MaximumLength uint16
+	Buffer        []byte `ndr:"unique,varying"`
+}

--- a/windows/protocols/ms-even/RULONG.go
+++ b/windows/protocols/ms-even/RULONG.go
@@ -1,0 +1,11 @@
+package mseven
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// RULONG is a range-restricted unsigned long ([MS-EVEN] 2.2.4:
+// [range(0, MAX_BATCH_BUFF)] unsigned long). It is the type of the
+// NumberOfBytesToRead argument to ElfrReadELW/ElfrReadELA. On the wire it is a
+// plain 4-octet NDR unsigned long; the range is a server-side validation bound.
+type RULONG ndr.DWORD

--- a/windows/protocols/ms-even/structures_test.go
+++ b/windows/protocols/ms-even/structures_test.go
@@ -1,0 +1,63 @@
+package mseven
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// roundTrip marshals v, unmarshals into a fresh value of the same type. v and out must be
+// pointers to the same struct type.
+func roundTrip(t *testing.T, v any, out any) {
+	t.Helper()
+	raw, err := ndr.Marshal(v)
+	if err != nil {
+		t.Fatalf("Marshal(%T): %v", v, err)
+	}
+	if err := ndr.Unmarshal(raw, out); err != nil {
+		t.Fatalf("Unmarshal(%T): %v", v, err)
+	}
+}
+
+// TestRPCClientID_RoundTrip exercises RPC_CLIENT_ID ([MS-EVEN] 2.2.6): two scalar DWORDs.
+func TestRPCClientID_RoundTrip(t *testing.T) {
+	in := RPC_CLIENT_ID{UniqueProcess: 0x11223344, UniqueThread: 0x55667788}
+	var out RPC_CLIENT_ID
+	roundTrip(t, &in, &out)
+	if !reflect.DeepEqual(in, out) {
+		t.Fatalf("RPC_CLIENT_ID round-trip: got %+v want %+v", out, in)
+	}
+}
+
+// TestRPCString_RoundTrip exercises RPC_STRING ([MS-EVEN] 2.2.7): a counted ASCII string
+// whose Buffer is a [unique] pointer to a conformant char array bounded by MaximumLength,
+// including the empty (nil pointer) case.
+func TestRPCString_RoundTrip(t *testing.T) {
+	cases := []RPC_STRING{
+		{Length: 5, MaximumLength: 5, Buffer: []byte("hello")},
+		{Length: 1, MaximumLength: 4, Buffer: []byte{0x41, 0x00, 0x00, 0x00}},
+		{Length: 0, MaximumLength: 0, Buffer: nil},
+	}
+	for _, in := range cases {
+		var out RPC_STRING
+		roundTrip(t, &in, &out)
+		if !reflect.DeepEqual(in, out) {
+			t.Fatalf("RPC_STRING round-trip: got %+v want %+v", out, in)
+		}
+	}
+}
+
+// TestIELFHandle_RoundTrip exercises IELF_HANDLE ([MS-EVEN]): a 20-byte RPC context handle.
+func TestIELFHandle_RoundTrip(t *testing.T) {
+	type wrap struct{ H IELF_HANDLE }
+	var in wrap
+	for i := range in.H {
+		in.H[i] = byte(i + 1)
+	}
+	var out wrap
+	roundTrip(t, &in, &out)
+	if !reflect.DeepEqual(in, out) {
+		t.Fatalf("IELF_HANDLE round-trip: got %+v want %+v", out, in)
+	}
+}


### PR DESCRIPTION
### Linked Issue
Closes #773

### Summary
Implements the single classic DCE/RPC interface of the EventLog Remoting Protocol ([MS-EVEN]), `eventlog`, reached over the well-known `\PIPE\eventlog` named pipe.

| Interface | UUID | Version | Opnums |
|---|---|---|---|
| `eventlog` | `82273fdc-e32a-18c3-3f78-827929dc23ea` | 0.0 | 23 on-the-wire (0–18, 22, 24–26) |

Opnums 19, 20, 21, 23 are documented as "not used on the wire" and are intentionally omitted from the opnum tables. The methods cover the open/backup/close family (`ElfrOpenELW/A`, `ElfrOpenBELW/A`, `ElfrRegisterEventSourceW/A`, `ElfrCloseEL`, `ElfrDeregisterEventSource`), read/query (`ElfrReadELW/A`, `ElfrNumberOfRecords`, `ElfrOldestRecord`, `ElfrGetLogInformation`), clear/backup (`ElfrClearELFW/A`, `ElfrBackupELFW/A`), change notification (`ElfrChangeNotify`), and the report-event family (`ElfrReportEventW/A`, `ElfrReportEventAndSourceW`, `ElfrReportEventExW/A`).

The layout follows the `dcerpc-interface-structure` split:

- **Descriptor + method stubs** under `network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/` — `interface.go` (SyntaxID, the `\eventlog` endpoint, opnum table, `OpnumToName`/`NameToOpnum`, the MS-EVEN/MS-ERREF status table) plus a `functions/` subpackage with one file per opnum and the shared `statusResponse`/`handleResponse` shapes in `functions/functions.go`. The pristine spec IDL is committed as `ms-even.idl`.
- **NDR structures** under `windows/protocols/ms-even/` (package `mseven`), one file per type, with a consolidated `structures_test.go` round-trip suite.

The interface tree holds no `structures/` subpackage; `functions` imports the structures package across the one-way boundary, and the structures package imports nothing from `network/dcerpc/interfaces`.

### Notes on modeling
- `RPC_STRING.Buffer` is a `[unique]` pointer to a conformant-varying char array (`[size_is(MaximumLength), length_is(Length)] char*`) → `ndr:"unique,varying"`, matching the live-validated MS-SAMR `RPC_STRING`. `RPC_CLIENT_ID` is two scalar `unsigned long`s; `RULONG` is the `[range(0, MAX_BATCH_BUFF)]` type of `NumberOfBytesToRead`.
- `IELF_HANDLE` is a 20-byte RPC context handle. `[in,out] IELF_HANDLE*` (Close/Deregister) appears inline in both request and response; `[out] IELF_HANDLE*` opens appear inline in the response.
- The `[handle,unique]` `EVENTLOG_HANDLE_W`/`EVENTLOG_HANDLE_A` server-name parameters are unique wide/ASCII string pointers (`ndr.WSTR`/`ndr.STR` with `ndr:"unique"`); `PFILETIME TimeGenerated` is the top-level `[in]` ref pointer, modeled inline as `dtyp.FILETIME`.
- Unattributed `[in] PRPC_UNICODE_STRING`/`PRPC_STRING` parameters are top-level pointers → `[ref]` → modeled inline (`dtyp.RPC_UNICODE_STRING` / `mseven.RPC_STRING`); the `[in,unique]` variants are `*T ndr:"unique"`, and `[in,unique] PRPC_SID` is `*dtyp.RPC_SID ndr:"unique"`.
- The report-event `[in, size_is(NumStrings), unique] PRPC_UNICODE_STRING Strings[*]` arrays are `[unique]` pointers to conformant arrays of `[unique]` string pointers → `[]*T ndr:"unique,elem=unique,size_is=NumStrings"`; `[in, size_is(DataSize), unique] unsigned char* Data` → `[]uint8 ndr:"unique,size_is=DataSize"`.
- The `[out, size_is(<in-param>)] unsigned char*` buffers (`ElfrReadELW/A`, `ElfrGetLogInformation`) follow the established codec convention (`ndr:"ref,size_is=..."`; the count is read from the wire `maximum_count` on unmarshal), as in the merged MS-RPRN/MS-SRVS interfaces.
- Methods return Win32 error / NTSTATUS codes ([MS-EVEN]/[MS-ERREF]) surfaced via `StatusString`.

### How Verified
- `gofmt -l`, `go build`, `go vet` clean over `network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/...` and `windows/protocols/ms-even/...`.
- `GOARCH=386` and `GOARCH=arm64` cross-compile clean; `-tags integration` build clean; full-repo `GOARCH=386 go build ./...` clean.
- `go test` passes — the round-trip suite exercises `RPC_STRING` (conformant-varying, incl. nil buffer), `RPC_CLIENT_ID`, and the 20-byte `IELF_HANDLE`; `interface_test.go` covers SyntaxID, PipeName, the opnum↔name inverse (incl. the NotUsedOnWire gaps), and `StatusString`.

### Test Coverage
New `windows/protocols/ms-even/structures_test.go` (structure round-trips) and `network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/interface_test.go` (descriptor invariants).