### PR TITLE
Add File Replication Service Protocol (MS-FRS1) NtFrsApi and frsrpc client interfaces (Fixes #781)

### DIFF
--- a/network/dcerpc/interfaces/d049b186-814f-11d1-9a3c-00c04fc9b232/1.1/functions/04_NtFrsApi_Rpc_Set_DsPollingIntervalW.go
+++ b/network/dcerpc/interfaces/d049b186-814f-11d1-9a3c-00c04fc9b232/1.1/functions/04_NtFrsApi_Rpc_Set_DsPollingIntervalW.go
@@ -1,0 +1,37 @@
+package functions
+
+import (
+	"fmt"
+
+	frsapi "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/d049b186-814f-11d1-9a3c-00c04fc9b232/1.1"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// ntFrsApi_Rpc_Set_DsPollingIntervalWRequest carries the [in] parameters of NtFrsApi_Rpc_Set_DsPollingIntervalW.
+type ntFrsApi_Rpc_Set_DsPollingIntervalWRequest struct {
+	UseShortInterval ndr.DWORD
+	LongInterval     ndr.DWORD
+	ShortInterval    ndr.DWORD
+}
+
+func (*ntFrsApi_Rpc_Set_DsPollingIntervalWRequest) Opnum() uint16 {
+	return frsapi.OpnumNtFrsApi_Rpc_Set_DsPollingIntervalW
+}
+
+// NtFrsApi_Rpc_Set_DsPollingIntervalW calls NtFrsApi_Rpc_Set_DsPollingIntervalW (opnum 4) ([MS-FRS1] section 3.2.4.1).
+func NtFrsApi_Rpc_Set_DsPollingIntervalW(rpc ndr.Invoker, useShortInterval ndr.DWORD, longInterval ndr.DWORD, shortInterval ndr.DWORD) (err error) {
+	req := &ntFrsApi_Rpc_Set_DsPollingIntervalWRequest{
+		UseShortInterval: useShortInterval,
+		LongInterval:     longInterval,
+		ShortInterval:    shortInterval,
+	}
+	var resp statusResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("NtFrsApi_Rpc_Set_DsPollingIntervalW: %w", err)
+		return
+	}
+	if uint32(resp.Status) != frsapi.StatusSuccess {
+		err = fmt.Errorf("NtFrsApi_Rpc_Set_DsPollingIntervalW failed: %s", frsapi.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/d049b186-814f-11d1-9a3c-00c04fc9b232/1.1/functions/05_NtFrsApi_Rpc_Get_DsPollingIntervalW.go
+++ b/network/dcerpc/interfaces/d049b186-814f-11d1-9a3c-00c04fc9b232/1.1/functions/05_NtFrsApi_Rpc_Get_DsPollingIntervalW.go
@@ -1,0 +1,41 @@
+package functions
+
+import (
+	"fmt"
+
+	frsapi "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/d049b186-814f-11d1-9a3c-00c04fc9b232/1.1"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// ntFrsApi_Rpc_Get_DsPollingIntervalWRequest carries the [in] parameters of NtFrsApi_Rpc_Get_DsPollingIntervalW.
+type ntFrsApi_Rpc_Get_DsPollingIntervalWRequest struct {
+}
+
+func (*ntFrsApi_Rpc_Get_DsPollingIntervalWRequest) Opnum() uint16 {
+	return frsapi.OpnumNtFrsApi_Rpc_Get_DsPollingIntervalW
+}
+
+// ntFrsApi_Rpc_Get_DsPollingIntervalWResponse carries the [out] parameters and return value of NtFrsApi_Rpc_Get_DsPollingIntervalW.
+type ntFrsApi_Rpc_Get_DsPollingIntervalWResponse struct {
+	Interval      ndr.DWORD
+	LongInterval  ndr.DWORD
+	ShortInterval ndr.DWORD
+	Status        ndr.DWORD `ndr:"retval"`
+}
+
+// NtFrsApi_Rpc_Get_DsPollingIntervalW calls NtFrsApi_Rpc_Get_DsPollingIntervalW (opnum 5) ([MS-FRS1] section 3.2.4.2).
+func NtFrsApi_Rpc_Get_DsPollingIntervalW(rpc ndr.Invoker) (Interval ndr.DWORD, LongInterval ndr.DWORD, ShortInterval ndr.DWORD, err error) {
+	req := &ntFrsApi_Rpc_Get_DsPollingIntervalWRequest{}
+	var resp ntFrsApi_Rpc_Get_DsPollingIntervalWResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("NtFrsApi_Rpc_Get_DsPollingIntervalW: %w", err)
+		return
+	}
+	Interval = resp.Interval
+	LongInterval = resp.LongInterval
+	ShortInterval = resp.ShortInterval
+	if uint32(resp.Status) != frsapi.StatusSuccess {
+		err = fmt.Errorf("NtFrsApi_Rpc_Get_DsPollingIntervalW failed: %s", frsapi.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/d049b186-814f-11d1-9a3c-00c04fc9b232/1.1/functions/07_NtFrsApi_Rpc_InfoW.go
+++ b/network/dcerpc/interfaces/d049b186-814f-11d1-9a3c-00c04fc9b232/1.1/functions/07_NtFrsApi_Rpc_InfoW.go
@@ -1,0 +1,42 @@
+package functions
+
+import (
+	"fmt"
+
+	frsapi "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/d049b186-814f-11d1-9a3c-00c04fc9b232/1.1"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// ntFrsApi_Rpc_InfoWRequest carries the [in] parameters of NtFrsApi_Rpc_InfoW.
+type ntFrsApi_Rpc_InfoWRequest struct {
+	BlobSize ndr.DWORD
+	Blob     []uint8 `ndr:"unique,size_is=BlobSize"`
+}
+
+func (*ntFrsApi_Rpc_InfoWRequest) Opnum() uint16 { return frsapi.OpnumNtFrsApi_Rpc_InfoW }
+
+// ntFrsApi_Rpc_InfoWResponse carries the [out] parameters and return value of NtFrsApi_Rpc_InfoW.
+type ntFrsApi_Rpc_InfoWResponse struct {
+	// Blob is the [in, out] buffer returned by the server; its maximum_count is read
+	// from the wire, so no size_is sibling is needed on the response.
+	Blob   []uint8   `ndr:"unique"`
+	Status ndr.DWORD `ndr:"retval"`
+}
+
+// NtFrsApi_Rpc_InfoW calls NtFrsApi_Rpc_InfoW (opnum 7) ([MS-FRS1] section 3.2.4.3).
+func NtFrsApi_Rpc_InfoW(rpc ndr.Invoker, blobSize ndr.DWORD, blob []uint8) (Blob []uint8, err error) {
+	req := &ntFrsApi_Rpc_InfoWRequest{
+		BlobSize: blobSize,
+		Blob:     blob,
+	}
+	var resp ntFrsApi_Rpc_InfoWResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("NtFrsApi_Rpc_InfoW: %w", err)
+		return
+	}
+	Blob = resp.Blob
+	if uint32(resp.Status) != frsapi.StatusSuccess {
+		err = fmt.Errorf("NtFrsApi_Rpc_InfoW failed: %s", frsapi.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/d049b186-814f-11d1-9a3c-00c04fc9b232/1.1/functions/08_NtFrsApi_Rpc_IsPathReplicated.go
+++ b/network/dcerpc/interfaces/d049b186-814f-11d1-9a3c-00c04fc9b232/1.1/functions/08_NtFrsApi_Rpc_IsPathReplicated.go
@@ -1,0 +1,49 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	frsapi "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/d049b186-814f-11d1-9a3c-00c04fc9b232/1.1"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// ntFrsApi_Rpc_IsPathReplicatedRequest carries the [in] parameters of NtFrsApi_Rpc_IsPathReplicated.
+type ntFrsApi_Rpc_IsPathReplicatedRequest struct {
+	Path                     *ndr.WSTR `ndr:"unique"`
+	ReplicaSetTypeOfInterest ndr.DWORD
+}
+
+func (*ntFrsApi_Rpc_IsPathReplicatedRequest) Opnum() uint16 {
+	return frsapi.OpnumNtFrsApi_Rpc_IsPathReplicated
+}
+
+// ntFrsApi_Rpc_IsPathReplicatedResponse carries the [out] parameters and return value of NtFrsApi_Rpc_IsPathReplicated.
+type ntFrsApi_Rpc_IsPathReplicatedResponse struct {
+	Replicated     ndr.DWORD
+	Primary        ndr.DWORD
+	Root           ndr.DWORD
+	ReplicaSetGuid dtyp.GUID
+	Status         ndr.DWORD `ndr:"retval"`
+}
+
+// NtFrsApi_Rpc_IsPathReplicated calls NtFrsApi_Rpc_IsPathReplicated (opnum 8) ([MS-FRS1] section 3.2.4.4).
+func NtFrsApi_Rpc_IsPathReplicated(rpc ndr.Invoker, path *ndr.WSTR, replicaSetTypeOfInterest ndr.DWORD) (Replicated ndr.DWORD, Primary ndr.DWORD, Root ndr.DWORD, ReplicaSetGuid dtyp.GUID, err error) {
+	req := &ntFrsApi_Rpc_IsPathReplicatedRequest{
+		Path:                     path,
+		ReplicaSetTypeOfInterest: replicaSetTypeOfInterest,
+	}
+	var resp ntFrsApi_Rpc_IsPathReplicatedResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("NtFrsApi_Rpc_IsPathReplicated: %w", err)
+		return
+	}
+	Replicated = resp.Replicated
+	Primary = resp.Primary
+	Root = resp.Root
+	ReplicaSetGuid = resp.ReplicaSetGuid
+	if uint32(resp.Status) != frsapi.StatusSuccess {
+		err = fmt.Errorf("NtFrsApi_Rpc_IsPathReplicated failed: %s", frsapi.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/d049b186-814f-11d1-9a3c-00c04fc9b232/1.1/functions/09_NtFrsApi_Rpc_WriterCommand.go
+++ b/network/dcerpc/interfaces/d049b186-814f-11d1-9a3c-00c04fc9b232/1.1/functions/09_NtFrsApi_Rpc_WriterCommand.go
@@ -1,0 +1,33 @@
+package functions
+
+import (
+	"fmt"
+
+	frsapi "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/d049b186-814f-11d1-9a3c-00c04fc9b232/1.1"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// ntFrsApi_Rpc_WriterCommandRequest carries the [in] parameters of NtFrsApi_Rpc_WriterCommand.
+type ntFrsApi_Rpc_WriterCommandRequest struct {
+	Command ndr.DWORD
+}
+
+func (*ntFrsApi_Rpc_WriterCommandRequest) Opnum() uint16 {
+	return frsapi.OpnumNtFrsApi_Rpc_WriterCommand
+}
+
+// NtFrsApi_Rpc_WriterCommand calls NtFrsApi_Rpc_WriterCommand (opnum 9) ([MS-FRS1] section 3.2.4.5).
+func NtFrsApi_Rpc_WriterCommand(rpc ndr.Invoker, command ndr.DWORD) (err error) {
+	req := &ntFrsApi_Rpc_WriterCommandRequest{
+		Command: command,
+	}
+	var resp statusResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("NtFrsApi_Rpc_WriterCommand: %w", err)
+		return
+	}
+	if uint32(resp.Status) != frsapi.StatusSuccess {
+		err = fmt.Errorf("NtFrsApi_Rpc_WriterCommand failed: %s", frsapi.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/d049b186-814f-11d1-9a3c-00c04fc9b232/1.1/functions/10_NtFrsApi_Rpc_ForceReplication.go
+++ b/network/dcerpc/interfaces/d049b186-814f-11d1-9a3c-00c04fc9b232/1.1/functions/10_NtFrsApi_Rpc_ForceReplication.go
@@ -1,0 +1,40 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	frsapi "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/d049b186-814f-11d1-9a3c-00c04fc9b232/1.1"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// ntFrsApi_Rpc_ForceReplicationRequest carries the [in] parameters of NtFrsApi_Rpc_ForceReplication.
+type ntFrsApi_Rpc_ForceReplicationRequest struct {
+	ReplicaSetGuid *dtyp.GUID `ndr:"unique"`
+	CxtionGuid     *dtyp.GUID `ndr:"unique"`
+	ReplicaSetName *ndr.WSTR  `ndr:"unique"`
+	PartnerDnsName *ndr.WSTR  `ndr:"unique"`
+}
+
+func (*ntFrsApi_Rpc_ForceReplicationRequest) Opnum() uint16 {
+	return frsapi.OpnumNtFrsApi_Rpc_ForceReplication
+}
+
+// NtFrsApi_Rpc_ForceReplication calls NtFrsApi_Rpc_ForceReplication (opnum 10) ([MS-FRS1] section 3.2.4.6).
+func NtFrsApi_Rpc_ForceReplication(rpc ndr.Invoker, replicaSetGuid *dtyp.GUID, cxtionGuid *dtyp.GUID, replicaSetName *ndr.WSTR, partnerDnsName *ndr.WSTR) (err error) {
+	req := &ntFrsApi_Rpc_ForceReplicationRequest{
+		ReplicaSetGuid: replicaSetGuid,
+		CxtionGuid:     cxtionGuid,
+		ReplicaSetName: replicaSetName,
+		PartnerDnsName: partnerDnsName,
+	}
+	var resp statusResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("NtFrsApi_Rpc_ForceReplication: %w", err)
+		return
+	}
+	if uint32(resp.Status) != frsapi.StatusSuccess {
+		err = fmt.Errorf("NtFrsApi_Rpc_ForceReplication failed: %s", frsapi.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/d049b186-814f-11d1-9a3c-00c04fc9b232/1.1/functions/functions.go
+++ b/network/dcerpc/interfaces/d049b186-814f-11d1-9a3c-00c04fc9b232/1.1/functions/functions.go
@@ -1,0 +1,14 @@
+// Package functions holds the NtFrsApi ([MS-FRS1]) method stubs, one file per opnum. Each
+// stub marshals its [in] parameters into a request stub, invokes the opnum through an
+// ndr.Invoker, and unmarshals the response stub. The shared response shape below is used
+// by more than one method.
+package functions
+
+import "github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+
+// statusResponse is the response stub for methods whose only [out] value is the returned
+// Win32 status (NtFrsApi_Rpc_Set_DsPollingIntervalW, NtFrsApi_Rpc_WriterCommand,
+// NtFrsApi_Rpc_ForceReplication).
+type statusResponse struct {
+	Status ndr.DWORD `ndr:"retval"`
+}

--- a/network/dcerpc/interfaces/d049b186-814f-11d1-9a3c-00c04fc9b232/1.1/interface.go
+++ b/network/dcerpc/interfaces/d049b186-814f-11d1-9a3c-00c04fc9b232/1.1/interface.go
@@ -1,0 +1,82 @@
+// Package rpcinterface_d049b186814f11d19a3c00c04fc9b232_1_1 is the descriptor for the NtFrsApi RPC interface, abstract
+// syntax d049b186-814f-11d1-9a3c-00c04fc9b232 version 1.1 ([MS-FRS1]).
+//
+// This package holds only the interface-level descriptor (abstract syntax,
+// transport endpoint, opnums, opnum<->name maps, and status constants). The NDR
+// wire types live in windows/protocols/ms-frs1 and the method stubs in functions;
+// both depend on this package, never the reverse.
+package rpcinterface_d049b186814f11d19a3c00c04fc9b232_1_1
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+)
+
+// PipeName is empty: FRS has no named-pipe endpoint. Both FRS interfaces use only the
+// ncacn_ip_tcp protocol sequence over a dynamic endpoint assigned by the RPC endpoint
+// mapper (RPCSS, port 135), optionally pinned to a static TCP port ([MS-FRS1] 2.1).
+const PipeName = ``
+
+// Opnums for the on-the-wire methods. Opnums 0, 1, 2, 3, 6 are "not used on the wire"
+// and are omitted.
+const (
+	OpnumNtFrsApi_Rpc_Set_DsPollingIntervalW uint16 = 4
+	OpnumNtFrsApi_Rpc_Get_DsPollingIntervalW uint16 = 5
+	OpnumNtFrsApi_Rpc_InfoW                  uint16 = 7
+	OpnumNtFrsApi_Rpc_IsPathReplicated       uint16 = 8
+	OpnumNtFrsApi_Rpc_WriterCommand          uint16 = 9
+	OpnumNtFrsApi_Rpc_ForceReplication       uint16 = 10
+)
+
+// Status codes returned by this interface. FRSAPI methods return a Win32 error code
+// ([MS-ERREF] 2.2): 0 on success, and all nonzero values are equivalent failures unless
+// otherwise specified ([MS-FRS1] 3.2.4). Failed access checks yield ERROR_ACCESS_DENIED.
+const (
+	StatusSuccess     uint32 = 0x00000000 // ERROR_SUCCESS
+	ErrorAccessDenied uint32 = 0x00000005 // ERROR_ACCESS_DENIED
+)
+
+// SyntaxID returns the NtFrsApi abstract syntax identifier:
+// d049b186-814f-11d1-9a3c-00c04fc9b232, version 1.1.
+func SyntaxID() syntax.SyntaxID {
+	return syntax.SyntaxID{
+		UUID:         guid.GUID{A: 0xd049b186, B: 0x814f, C: 0x11d1, D: 0x9a3c, E: 0x00c04fc9b232},
+		MajorVersion: 1,
+		MinorVersion: 1,
+	}
+}
+
+// StatusString returns a mnemonic for the documented status codes, otherwise the
+// hex value.
+func StatusString(status uint32) string {
+	switch status {
+	case StatusSuccess:
+		return "ERROR_SUCCESS"
+	case ErrorAccessDenied:
+		return "ERROR_ACCESS_DENIED"
+	default:
+		return fmt.Sprintf("0x%08x", status)
+	}
+}
+
+// OpnumToName maps each on-the-wire opnum to its method name; the single source of
+// truth.
+var OpnumToName = map[uint16]string{
+	OpnumNtFrsApi_Rpc_Set_DsPollingIntervalW: "NtFrsApi_Rpc_Set_DsPollingIntervalW",
+	OpnumNtFrsApi_Rpc_Get_DsPollingIntervalW: "NtFrsApi_Rpc_Get_DsPollingIntervalW",
+	OpnumNtFrsApi_Rpc_InfoW:                  "NtFrsApi_Rpc_InfoW",
+	OpnumNtFrsApi_Rpc_IsPathReplicated:       "NtFrsApi_Rpc_IsPathReplicated",
+	OpnumNtFrsApi_Rpc_WriterCommand:          "NtFrsApi_Rpc_WriterCommand",
+	OpnumNtFrsApi_Rpc_ForceReplication:       "NtFrsApi_Rpc_ForceReplication",
+}
+
+// NameToOpnum is the reverse of OpnumToName, built at init so the two never drift.
+var NameToOpnum = func() map[string]uint16 {
+	m := make(map[string]uint16, len(OpnumToName))
+	for op, name := range OpnumToName {
+		m[name] = op
+	}
+	return m
+}()

--- a/network/dcerpc/interfaces/d049b186-814f-11d1-9a3c-00c04fc9b232/1.1/interface_test.go
+++ b/network/dcerpc/interfaces/d049b186-814f-11d1-9a3c-00c04fc9b232/1.1/interface_test.go
@@ -1,0 +1,61 @@
+package rpcinterface_d049b186814f11d19a3c00c04fc9b232_1_1
+
+import "testing"
+
+// TestSyntaxID pins the abstract syntax: d049b186-814f-11d1-9a3c-00c04fc9b232 v1.1.
+func TestSyntaxID(t *testing.T) {
+	s := SyntaxID()
+	u := s.UUID
+	if u.A != 0xd049b186 || u.B != 0x814f || u.C != 0x11d1 || u.D != 0x9a3c || u.E != 0x00c04fc9b232 {
+		t.Errorf("UUID = %s, want d049b186-814f-11d1-9a3c-00c04fc9b232", u.ToFormatD())
+	}
+	if s.MajorVersion != 1 || s.MinorVersion != 1 {
+		t.Errorf("version = %d.%d, want 1.1", s.MajorVersion, s.MinorVersion)
+	}
+}
+
+// TestPipeName pins the transport: FRS has no named pipe (ncacn_ip_tcp only).
+func TestPipeName(t *testing.T) {
+	if PipeName != `` {
+		t.Errorf("PipeName = %q, want empty (FRS is ncacn_ip_tcp only)", PipeName)
+	}
+}
+
+// TestOpnumNameRoundTrip verifies OpnumToName and NameToOpnum are consistent, that the
+// six on-the-wire opnums (4, 5, 7, 8, 9, 10) are present exactly once, and that the
+// "not used on the wire" opnums (0, 1, 2, 3, 6) are absent.
+func TestOpnumNameRoundTrip(t *testing.T) {
+	wireOpnums := []uint16{4, 5, 7, 8, 9, 10}
+	if len(OpnumToName) != len(wireOpnums) {
+		t.Fatalf("OpnumToName has %d entries, want %d", len(OpnumToName), len(wireOpnums))
+	}
+	for op, name := range OpnumToName {
+		if NameToOpnum[name] != op {
+			t.Errorf("NameToOpnum[%q] = %d, want %d", name, NameToOpnum[name], op)
+		}
+	}
+	for _, op := range wireOpnums {
+		if _, ok := OpnumToName[op]; !ok {
+			t.Errorf("on-the-wire opnum %d missing from OpnumToName", op)
+		}
+	}
+	for _, gap := range []uint16{0, 1, 2, 3, 6} {
+		if name, ok := OpnumToName[gap]; ok {
+			t.Errorf("opnum %d (%q) is NotUsedOnWire and must be absent", gap, name)
+		}
+	}
+}
+
+// TestStatusString spot-checks the mnemonics and the hex fallback.
+func TestStatusString(t *testing.T) {
+	cases := map[uint32]string{
+		StatusSuccess:     "ERROR_SUCCESS",
+		ErrorAccessDenied: "ERROR_ACCESS_DENIED",
+		0xdeadbeef:        "0xdeadbeef",
+	}
+	for code, want := range cases {
+		if got := StatusString(code); got != want {
+			t.Errorf("StatusString(0x%08x) = %q, want %q", code, got, want)
+		}
+	}
+}

--- a/network/dcerpc/interfaces/f5cc59b4-4264-101a-8c59-08002b2f8426/1.1/functions/00_FrsRpcSendCommPkt.go
+++ b/network/dcerpc/interfaces/f5cc59b4-4264-101a-8c59-08002b2f8426/1.1/functions/00_FrsRpcSendCommPkt.go
@@ -1,0 +1,32 @@
+package functions
+
+import (
+	"fmt"
+
+	frsrpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/f5cc59b4-4264-101a-8c59-08002b2f8426/1.1"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	msfrs1 "github.com/TheManticoreProject/Manticore/windows/protocols/ms-frs1"
+)
+
+// frsRpcSendCommPktRequest carries the [in] parameters of FrsRpcSendCommPkt.
+type frsRpcSendCommPktRequest struct {
+	CommPkt msfrs1.COMM_PACKET
+}
+
+func (*frsRpcSendCommPktRequest) Opnum() uint16 { return frsrpc.OpnumFrsRpcSendCommPkt }
+
+// FrsRpcSendCommPkt calls FrsRpcSendCommPkt (opnum 0) ([MS-FRS1] section 3.3.4.4).
+func FrsRpcSendCommPkt(rpc ndr.Invoker, commPkt msfrs1.COMM_PACKET) (err error) {
+	req := &frsRpcSendCommPktRequest{
+		CommPkt: commPkt,
+	}
+	var resp statusResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("FrsRpcSendCommPkt: %w", err)
+		return
+	}
+	if uint32(resp.Status) != frsrpc.StatusSuccess {
+		err = fmt.Errorf("FrsRpcSendCommPkt failed: %s", frsrpc.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/f5cc59b4-4264-101a-8c59-08002b2f8426/1.1/functions/01_FrsRpcVerifyPromotionParent.go
+++ b/network/dcerpc/interfaces/f5cc59b4-4264-101a-8c59-08002b2f8426/1.1/functions/01_FrsRpcVerifyPromotionParent.go
@@ -1,0 +1,43 @@
+package functions
+
+import (
+	"fmt"
+
+	frsrpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/f5cc59b4-4264-101a-8c59-08002b2f8426/1.1"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// frsRpcVerifyPromotionParentRequest carries the [in] parameters of FrsRpcVerifyPromotionParent.
+type frsRpcVerifyPromotionParentRequest struct {
+	ParentAccount    *ndr.WSTR `ndr:"unique"`
+	ParentPassword   *ndr.WSTR `ndr:"unique"`
+	ReplicaSetName   *ndr.WSTR `ndr:"unique"`
+	ReplicaSetType   *ndr.WSTR `ndr:"unique"`
+	PartnerAuthLevel ndr.DWORD
+	GuidSize         ndr.DWORD
+}
+
+func (*frsRpcVerifyPromotionParentRequest) Opnum() uint16 {
+	return frsrpc.OpnumFrsRpcVerifyPromotionParent
+}
+
+// FrsRpcVerifyPromotionParent calls FrsRpcVerifyPromotionParent (opnum 1) ([MS-FRS1] section 3.3.4.5).
+func FrsRpcVerifyPromotionParent(rpc ndr.Invoker, parentAccount *ndr.WSTR, parentPassword *ndr.WSTR, replicaSetName *ndr.WSTR, replicaSetType *ndr.WSTR, partnerAuthLevel ndr.DWORD, guidSize ndr.DWORD) (err error) {
+	req := &frsRpcVerifyPromotionParentRequest{
+		ParentAccount:    parentAccount,
+		ParentPassword:   parentPassword,
+		ReplicaSetName:   replicaSetName,
+		ReplicaSetType:   replicaSetType,
+		PartnerAuthLevel: partnerAuthLevel,
+		GuidSize:         guidSize,
+	}
+	var resp statusResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("FrsRpcVerifyPromotionParent: %w", err)
+		return
+	}
+	if uint32(resp.Status) != frsrpc.StatusSuccess {
+		err = fmt.Errorf("FrsRpcVerifyPromotionParent failed: %s", frsrpc.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/f5cc59b4-4264-101a-8c59-08002b2f8426/1.1/functions/02_FrsRpcStartPromotionParent.go
+++ b/network/dcerpc/interfaces/f5cc59b4-4264-101a-8c59-08002b2f8426/1.1/functions/02_FrsRpcStartPromotionParent.go
@@ -1,0 +1,64 @@
+package functions
+
+import (
+	"fmt"
+
+	frsrpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/f5cc59b4-4264-101a-8c59-08002b2f8426/1.1"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// frsRpcStartPromotionParentRequest carries the [in] parameters of FrsRpcStartPromotionParent.
+type frsRpcStartPromotionParentRequest struct {
+	ParentAccount    *ndr.WSTR `ndr:"unique"`
+	ParentPassword   *ndr.WSTR `ndr:"unique"`
+	ReplicaSetName   *ndr.WSTR `ndr:"unique"`
+	ReplicaSetType   *ndr.WSTR `ndr:"unique"`
+	CxtionName       *ndr.WSTR `ndr:"unique"`
+	PartnerName      *ndr.WSTR `ndr:"unique"`
+	PartnerPrincName *ndr.WSTR `ndr:"unique"`
+	PartnerAuthLevel ndr.DWORD
+	GuidSize         ndr.DWORD
+	CxtionGuid       []uint8 `ndr:"unique,size_is=GuidSize"`
+	PartnerGuid      []uint8 `ndr:"unique,size_is=GuidSize"`
+	ParentGuid       []uint8 `ndr:"unique,size_is=GuidSize"`
+}
+
+func (*frsRpcStartPromotionParentRequest) Opnum() uint16 {
+	return frsrpc.OpnumFrsRpcStartPromotionParent
+}
+
+// frsRpcStartPromotionParentResponse carries the [out] parameters and return value of FrsRpcStartPromotionParent.
+type frsRpcStartPromotionParentResponse struct {
+	// ParentGuid is the [in, out] buffer returned by the server; its maximum_count is
+	// read from the wire, so no size_is sibling is needed on the response.
+	ParentGuid []uint8   `ndr:"unique"`
+	Status     ndr.DWORD `ndr:"retval"`
+}
+
+// FrsRpcStartPromotionParent calls FrsRpcStartPromotionParent (opnum 2) ([MS-FRS1] section 3.3.4.2).
+func FrsRpcStartPromotionParent(rpc ndr.Invoker, parentAccount *ndr.WSTR, parentPassword *ndr.WSTR, replicaSetName *ndr.WSTR, replicaSetType *ndr.WSTR, cxtionName *ndr.WSTR, partnerName *ndr.WSTR, partnerPrincName *ndr.WSTR, partnerAuthLevel ndr.DWORD, guidSize ndr.DWORD, cxtionGuid []uint8, partnerGuid []uint8, parentGuid []uint8) (ParentGuid []uint8, err error) {
+	req := &frsRpcStartPromotionParentRequest{
+		ParentAccount:    parentAccount,
+		ParentPassword:   parentPassword,
+		ReplicaSetName:   replicaSetName,
+		ReplicaSetType:   replicaSetType,
+		CxtionName:       cxtionName,
+		PartnerName:      partnerName,
+		PartnerPrincName: partnerPrincName,
+		PartnerAuthLevel: partnerAuthLevel,
+		GuidSize:         guidSize,
+		CxtionGuid:       cxtionGuid,
+		PartnerGuid:      partnerGuid,
+		ParentGuid:       parentGuid,
+	}
+	var resp frsRpcStartPromotionParentResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("FrsRpcStartPromotionParent: %w", err)
+		return
+	}
+	ParentGuid = resp.ParentGuid
+	if uint32(resp.Status) != frsrpc.StatusSuccess {
+		err = fmt.Errorf("FrsRpcStartPromotionParent failed: %s", frsrpc.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/f5cc59b4-4264-101a-8c59-08002b2f8426/1.1/functions/03_FrsNOP.go
+++ b/network/dcerpc/interfaces/f5cc59b4-4264-101a-8c59-08002b2f8426/1.1/functions/03_FrsNOP.go
@@ -1,0 +1,28 @@
+package functions
+
+import (
+	"fmt"
+
+	frsrpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/f5cc59b4-4264-101a-8c59-08002b2f8426/1.1"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// frsNOPRequest carries the [in] parameters of FrsNOP.
+type frsNOPRequest struct {
+}
+
+func (*frsNOPRequest) Opnum() uint16 { return frsrpc.OpnumFrsNOP }
+
+// FrsNOP calls FrsNOP (opnum 3) ([MS-FRS1] section 3.3.4.3).
+func FrsNOP(rpc ndr.Invoker) (err error) {
+	req := &frsNOPRequest{}
+	var resp statusResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("FrsNOP: %w", err)
+		return
+	}
+	if uint32(resp.Status) != frsrpc.StatusSuccess {
+		err = fmt.Errorf("FrsNOP failed: %s", frsrpc.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/f5cc59b4-4264-101a-8c59-08002b2f8426/1.1/functions/functions.go
+++ b/network/dcerpc/interfaces/f5cc59b4-4264-101a-8c59-08002b2f8426/1.1/functions/functions.go
@@ -1,0 +1,13 @@
+// Package functions holds the frsrpc ([MS-FRS1]) method stubs, one file per opnum. Each
+// stub marshals its [in] parameters into a request stub, invokes the opnum through an
+// ndr.Invoker, and unmarshals the response stub. The shared response shape below is used
+// by more than one method.
+package functions
+
+import "github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+
+// statusResponse is the response stub for methods whose only [out] value is the returned
+// Win32 status (FrsRpcSendCommPkt, FrsRpcVerifyPromotionParent, FrsNOP).
+type statusResponse struct {
+	Status ndr.DWORD `ndr:"retval"`
+}

--- a/network/dcerpc/interfaces/f5cc59b4-4264-101a-8c59-08002b2f8426/1.1/interface.go
+++ b/network/dcerpc/interfaces/f5cc59b4-4264-101a-8c59-08002b2f8426/1.1/interface.go
@@ -1,0 +1,82 @@
+// Package rpcinterface_f5cc59b44264101a8c5908002b2f8426_1_1 is the descriptor for the frsrpc RPC interface, abstract
+// syntax f5cc59b4-4264-101a-8c59-08002b2f8426 version 1.1 ([MS-FRS1]).
+//
+// This package holds only the interface-level descriptor (abstract syntax,
+// transport endpoint, opnums, opnum<->name maps, and status constants). The NDR
+// wire types live in windows/protocols/ms-frs1 and the method stubs in functions;
+// both depend on this package, never the reverse.
+package rpcinterface_f5cc59b44264101a8c5908002b2f8426_1_1
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+)
+
+// PipeName is empty: FRS has no named-pipe endpoint. Both FRS interfaces use only the
+// ncacn_ip_tcp protocol sequence over a dynamic endpoint assigned by the RPC endpoint
+// mapper (RPCSS, port 135), optionally pinned to a static TCP port ([MS-FRS1] 2.1).
+const PipeName = ``
+
+// Opnums for the on-the-wire methods. Opnums 4, 5, 6, 7, 8, 9, 10 are "not used on the wire"
+// and are omitted.
+const (
+	OpnumFrsRpcSendCommPkt           uint16 = 0
+	OpnumFrsRpcVerifyPromotionParent uint16 = 1
+	OpnumFrsRpcStartPromotionParent  uint16 = 2
+	OpnumFrsNOP                      uint16 = 3
+)
+
+// Status codes returned by this interface. FRS methods return a Win32 error code
+// ([MS-ERREF] 2.2): 0 on success, and all nonzero values are equivalent failures unless
+// otherwise specified ([MS-FRS1] 3.3.4). FrsRpcVerifyPromotionParent always returns
+// ERROR_CALL_NOT_IMPLEMENTED ([MS-FRS1] 3.3.4.2).
+const (
+	StatusSuccess           uint32 = 0x00000000 // ERROR_SUCCESS
+	ErrorAccessDenied       uint32 = 0x00000005 // ERROR_ACCESS_DENIED
+	ErrorCallNotImplemented uint32 = 0x00000078 // ERROR_CALL_NOT_IMPLEMENTED
+)
+
+// SyntaxID returns the frsrpc abstract syntax identifier:
+// f5cc59b4-4264-101a-8c59-08002b2f8426, version 1.1.
+func SyntaxID() syntax.SyntaxID {
+	return syntax.SyntaxID{
+		UUID:         guid.GUID{A: 0xf5cc59b4, B: 0x4264, C: 0x101a, D: 0x8c59, E: 0x08002b2f8426},
+		MajorVersion: 1,
+		MinorVersion: 1,
+	}
+}
+
+// StatusString returns a mnemonic for the documented status codes, otherwise the
+// hex value.
+func StatusString(status uint32) string {
+	switch status {
+	case StatusSuccess:
+		return "ERROR_SUCCESS"
+	case ErrorAccessDenied:
+		return "ERROR_ACCESS_DENIED"
+	case ErrorCallNotImplemented:
+		return "ERROR_CALL_NOT_IMPLEMENTED"
+	default:
+		return fmt.Sprintf("0x%08x", status)
+	}
+}
+
+// OpnumToName maps each on-the-wire opnum to its method name; the single source of
+// truth.
+var OpnumToName = map[uint16]string{
+	OpnumFrsRpcSendCommPkt:           "FrsRpcSendCommPkt",
+	OpnumFrsRpcVerifyPromotionParent: "FrsRpcVerifyPromotionParent",
+	OpnumFrsRpcStartPromotionParent:  "FrsRpcStartPromotionParent",
+	OpnumFrsNOP:                      "FrsNOP",
+}
+
+// NameToOpnum is the reverse of OpnumToName, built at init so the two never drift.
+var NameToOpnum = func() map[string]uint16 {
+	m := make(map[string]uint16, len(OpnumToName))
+	for op, name := range OpnumToName {
+		m[name] = op
+	}
+	return m
+}()

--- a/network/dcerpc/interfaces/f5cc59b4-4264-101a-8c59-08002b2f8426/1.1/interface_test.go
+++ b/network/dcerpc/interfaces/f5cc59b4-4264-101a-8c59-08002b2f8426/1.1/interface_test.go
@@ -1,0 +1,62 @@
+package rpcinterface_f5cc59b44264101a8c5908002b2f8426_1_1
+
+import "testing"
+
+// TestSyntaxID pins the abstract syntax: f5cc59b4-4264-101a-8c59-08002b2f8426 v1.1.
+func TestSyntaxID(t *testing.T) {
+	s := SyntaxID()
+	u := s.UUID
+	if u.A != 0xf5cc59b4 || u.B != 0x4264 || u.C != 0x101a || u.D != 0x8c59 || u.E != 0x08002b2f8426 {
+		t.Errorf("UUID = %s, want f5cc59b4-4264-101a-8c59-08002b2f8426", u.ToFormatD())
+	}
+	if s.MajorVersion != 1 || s.MinorVersion != 1 {
+		t.Errorf("version = %d.%d, want 1.1", s.MajorVersion, s.MinorVersion)
+	}
+}
+
+// TestPipeName pins the transport: FRS has no named pipe (ncacn_ip_tcp only).
+func TestPipeName(t *testing.T) {
+	if PipeName != `` {
+		t.Errorf("PipeName = %q, want empty (FRS is ncacn_ip_tcp only)", PipeName)
+	}
+}
+
+// TestOpnumNameRoundTrip verifies OpnumToName and NameToOpnum are consistent, that the
+// four on-the-wire opnums (0-3) are present exactly once, and that the "not used on the
+// wire" opnums (4-10) are absent.
+func TestOpnumNameRoundTrip(t *testing.T) {
+	wireOpnums := []uint16{0, 1, 2, 3}
+	if len(OpnumToName) != len(wireOpnums) {
+		t.Fatalf("OpnumToName has %d entries, want %d", len(OpnumToName), len(wireOpnums))
+	}
+	for op, name := range OpnumToName {
+		if NameToOpnum[name] != op {
+			t.Errorf("NameToOpnum[%q] = %d, want %d", name, NameToOpnum[name], op)
+		}
+	}
+	for _, op := range wireOpnums {
+		if _, ok := OpnumToName[op]; !ok {
+			t.Errorf("on-the-wire opnum %d missing from OpnumToName", op)
+		}
+	}
+	for _, gap := range []uint16{4, 5, 6, 7, 8, 9, 10} {
+		if name, ok := OpnumToName[gap]; ok {
+			t.Errorf("opnum %d (%q) is NotUsedOnWire and must be absent", gap, name)
+		}
+	}
+}
+
+// TestStatusString spot-checks the mnemonics and the hex fallback.
+func TestStatusString(t *testing.T) {
+	cases := map[uint32]string{
+		StatusSuccess:           "ERROR_SUCCESS",
+		ErrorAccessDenied:       "ERROR_ACCESS_DENIED",
+		ErrorCallNotImplemented: "ERROR_CALL_NOT_IMPLEMENTED",
+		0xdeadbeef:              "0xdeadbeef",
+	}
+	for code, want := range cases {
+		if got := StatusString(code); got != want {
+			t.Errorf("StatusString(0x%08x) = %q, want %q", code, got, want)
+		}
+	}
+}

--- a/windows/protocols/ms-frs1/COMM_PACKET.go
+++ b/windows/protocols/ms-frs1/COMM_PACKET.go
@@ -1,0 +1,26 @@
+package msfrs1
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// COMM_PACKET is the primary FRS replication message ([MS-FRS1] 2.2.3.5), transmitted
+// as the payload of FrsRpcSendCommPkt. The six leading DWORDs describe the packet; Pkt
+// is a [unique] pointer to a size_is(PktLen) byte buffer holding the back-to-back
+// COMM_PACKET element structures.
+//
+// DataName and DataHandle are [ignore] void* fields: per the IDL the pointer itself is
+// transmitted but its referent is not, and the spec requires both to be 0. A nil
+// [unique] pointer marshals as a NULL referent id (four zero octets), which is exactly
+// that wire form, so they are modeled as always-nil unique pointers.
+type COMM_PACKET struct {
+	Major      ndr.DWORD
+	Minor      ndr.DWORD
+	CsId       ndr.DWORD
+	MemLen     ndr.DWORD
+	PktLen     ndr.DWORD
+	UpkLen     ndr.DWORD
+	Pkt        []uint8 `ndr:"unique,size_is=PktLen"`
+	DataName   *uint32 `ndr:"unique"` // [ignore] void*, MUST be 0 (always nil on the wire)
+	DataHandle *uint32 `ndr:"unique"` // [ignore] void*, MUST be 0 (always nil on the wire)
+}

--- a/windows/protocols/ms-frs1/structures_test.go
+++ b/windows/protocols/ms-frs1/structures_test.go
@@ -1,0 +1,62 @@
+package msfrs1
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// TestCOMM_PACKET_RoundTrip exercises COMM_PACKET: six leading DWORDs, a [unique]
+// pointer to a size_is(PktLen) byte buffer, and the two [ignore] void* fields that
+// must marshal as NULL referent ids (four zero octets each) and unmarshal back to nil.
+func TestCOMM_PACKET_RoundTrip(t *testing.T) {
+	in := COMM_PACKET{
+		Major:  0,
+		Minor:  0x00000009, // NTFRS_COMM_MINOR_9
+		CsId:   1,
+		MemLen: 8,
+		UpkLen: 0,
+		Pkt:    []uint8{0x01, 0x00, 0x02, 0x00, 0xde, 0xad, 0xbe, 0xef},
+	}
+	raw, err := ndr.Marshal(&in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var out COMM_PACKET
+	if err := ndr.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out.PktLen != ndr.DWORD(len(in.Pkt)) {
+		t.Errorf("PktLen = %d, want %d (count must be derived from Pkt)", out.PktLen, len(in.Pkt))
+	}
+	if !reflect.DeepEqual(out.Pkt, in.Pkt) {
+		t.Errorf("Pkt round-trip: got %v want %v", out.Pkt, in.Pkt)
+	}
+	if out.Minor != in.Minor || out.CsId != in.CsId || out.MemLen != in.MemLen {
+		t.Errorf("scalar fields mismatch: %+v", out)
+	}
+	if out.DataName != nil || out.DataHandle != nil {
+		t.Errorf("DataName/DataHandle must round-trip to nil, got %v/%v", out.DataName, out.DataHandle)
+	}
+}
+
+// TestCOMM_PACKET_IgnoreFieldsAreNullReferents pins the wire form of the [ignore]
+// fields: with a nil Pkt the trailing bytes are Pkt's NULL referent id followed by the
+// two [ignore] NULL referent ids — twelve zero octets after the six DWORDs.
+func TestCOMM_PACKET_IgnoreFieldsAreNullReferents(t *testing.T) {
+	raw, err := ndr.Marshal(&COMM_PACKET{})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	// 6 DWORDs (24) + Pkt referent id (4) + DataName referent id (4) + DataHandle
+	// referent id (4) = 36 octets, all zero when everything is nil/0.
+	if len(raw) != 36 {
+		t.Fatalf("marshalled length = %d, want 36", len(raw))
+	}
+	for i, b := range raw {
+		if b != 0 {
+			t.Fatalf("octet %d = 0x%02x, want 0x00 (all-nil COMM_PACKET must be zero)", i, b)
+		}
+	}
+}


### PR DESCRIPTION
### Linked Issue

Closes #781

### Summary

Adds the File Replication Service Protocol ([MS-FRS1]) DCE/RPC client interfaces —
the legacy NTFRS replication protocol — following the `dcerpc-interface-structure`
split layout. MS-FRS1 Appendix A defines **two** classic RPC interfaces (neither is a
DCOM/object interface); both are implemented:

- **NtFrsApi** (FRSAPI) — abstract syntax `d049b186-814f-11d1-9a3c-00c04fc9b232` version 1.1.
- **frsrpc** (FRSRPC) — abstract syntax `f5cc59b4-4264-101a-8c59-08002b2f8426` version 1.1.

### What was added

- **Interface descriptors** —
  `network/dcerpc/interfaces/d049b186-814f-11d1-9a3c-00c04fc9b232/1.1/interface.go` and
  `network/dcerpc/interfaces/f5cc59b4-4264-101a-8c59-08002b2f8426/1.1/interface.go`:
  `SyntaxID()`, opnum constants, `OpnumToName`/`NameToOpnum` maps, and a Win32 status-code
  table (`StatusString`, [MS-ERREF] 2.2). Transport is `ncacn_ip_tcp` over a **dynamic
  endpoint** assigned by the RPC endpoint mapper (RPCSS, port 135), with **no named pipe**
  ([MS-FRS1] section 2.1), so `PipeName` is empty.
- **Method stubs** — one `functions/<NN>_<Method>.go` per on-the-wire opnum:
  - NtFrsApi (6): `NtFrsApi_Rpc_Set_DsPollingIntervalW` (4), `..._Get_DsPollingIntervalW` (5),
    `..._InfoW` (7), `..._IsPathReplicated` (8), `..._WriterCommand` (9),
    `..._ForceReplication` (10). Opnums 0–3 and 6 are `NotUsedOnWire` and omitted.
  - frsrpc (4): `FrsRpcSendCommPkt` (0), `FrsRpcVerifyPromotionParent` (1),
    `FrsRpcStartPromotionParent` (2), `FrsNOP` (3). Opnums 4–10 are `NotUsedOnWire` and omitted.
  The explicit `[in] handle_t Handle` binding handle is not marshalled and is omitted from the
  request structs. Shared status-only response shapes live in each `functions/functions.go`.
- **NDR wire structures** — `windows/protocols/ms-frs1/` (`package msfrs1`): the `COMM_PACKET`
  structure plus a consolidated `structures_test.go`.

### How Verified

- `go build`, `go vet`, `go test` clean over both interface trees and the structures package;
  `go build -tags integration` clean.
- Cross-compiles clean for `GOARCH=386` and `GOARCH=arm64` (the CI matrix legs where
  integer-width bugs surface).
- `gofmt -l` empty.
- Structure round-trip tests (`ndr.Marshal` -> `ndr.Unmarshal` -> `reflect.DeepEqual`) cover
  `COMM_PACKET`: the `[unique, size_is(PktLen)]` conformant byte buffer, and the two `[ignore]`
  `void*` fields — asserting an all-nil packet marshals to exactly 36 zero octets (six DWORDs +
  three NULL referent ids).
- Descriptor tests pin the UUID/version, the on-the-wire opnum sets and the `NotUsedOnWire`
  gaps, the `OpnumToName`/`NameToOpnum` round trip, and `StatusString`.

### Hand-refinements over the generated skeleton

The `idlgen` skeleton was reconciled against the skill's NDR rules:
- **`[unique]` vs `[ref]`** — the `[in]`/`[in,out] size_is` byte buffers that the IDL marks
  `[unique]` (`NtFrsApi_Rpc_InfoW`'s `Blob`, `FrsRpcStartPromotionParent`'s
  `CxtionGuid`/`PartnerGuid`/`ParentGuid`) were retagged from the generator's `ref` to
  `unique`, so the referent id is present on the wire as the spec requires. Response copies of
  the `[in,out]` buffers drop the `size_is` sibling (the count is `[in]`-only; the decoder reads
  `maximum_count` from the wire).
- **GUID type** — `[unique] GUID *` / `[out] GUID *` parameters use `dtyp.GUID` (the 16-octet
  NDR form), not `windows/guid.GUID` (whose trailing `uint64` marshals to 24 octets).
- **`COMM_PACKET` `[ignore]` fields** — `DataName`/`DataHandle` are `[ignore] void*` fields the
  spec requires to be 0; modeled as always-nil `unique` pointers, which marshal as a NULL
  referent id (four zero octets each) — the wire form the IDL/spec prescribe.
- **Status table** — filled `StatusSuccess`, `ErrorAccessDenied` (documented access-check
  failures), and `ErrorCallNotImplemented` (`FrsRpcVerifyPromotionParent`, [MS-FRS1] 3.3.4.5).

Cross-checked against Samba's `frsrpc.idl` and the Wireshark FRS dissector for the two trickiest
spots (the by-value `CommPkt` parameter and the `[ignore]` fields).

### Test Coverage

**Added** — `windows/protocols/ms-frs1/structures_test.go` (`COMM_PACKET` round-trip and the
NULL-referent wire-form assertion) and the two `interface_test.go` files (descriptor invariants).

### Notes / Limitations

- Live validation against a Windows FRS service was not performed (FRS is a legacy service,
  disabled by default on modern DCs). The by-value `CommPkt` modeling and the `[ignore]` field
  wire form are cross-referenced against Samba/Wireshark but should be treated as the primary
  spots to confirm against a live server.