### PR TITLE
Add File Server Remote VSS Protocol (MS-FSRVP) FileServerVssAgent client interface (Fixes #785)

### DIFF
--- a/network/dcerpc/interfaces/a8e0653c-2744-4389-a61d-7373df8b2292/1.0/functions/00_GetSupportedVersion.go
+++ b/network/dcerpc/interfaces/a8e0653c-2744-4389-a61d-7373df8b2292/1.0/functions/00_GetSupportedVersion.go
@@ -1,0 +1,38 @@
+package functions
+
+import (
+	"fmt"
+
+	FileServerVssAgent "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/a8e0653c-2744-4389-a61d-7373df8b2292/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// getSupportedVersionRequest carries the [in] parameters of GetSupportedVersion.
+type getSupportedVersionRequest struct {
+}
+
+func (*getSupportedVersionRequest) Opnum() uint16 { return FileServerVssAgent.OpnumGetSupportedVersion }
+
+// getSupportedVersionResponse carries the [out] parameters and return value of GetSupportedVersion.
+type getSupportedVersionResponse struct {
+	MinVersion ndr.DWORD
+	MaxVersion ndr.DWORD
+	Status     ndr.DWORD `ndr:"retval"`
+}
+
+// GetSupportedVersion calls GetSupportedVersion (opnum 0) ([MS-FSRVP] — verify the parameter
+// modeling and status handling).
+func GetSupportedVersion(rpc ndr.Invoker) (MinVersion ndr.DWORD, MaxVersion ndr.DWORD, err error) {
+	req := &getSupportedVersionRequest{}
+	var resp getSupportedVersionResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("GetSupportedVersion: %w", err)
+		return
+	}
+	MinVersion = resp.MinVersion
+	MaxVersion = resp.MaxVersion
+	if uint32(resp.Status) != FileServerVssAgent.StatusSuccess {
+		err = fmt.Errorf("GetSupportedVersion failed: %s", FileServerVssAgent.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/a8e0653c-2744-4389-a61d-7373df8b2292/1.0/functions/01_SetContext.go
+++ b/network/dcerpc/interfaces/a8e0653c-2744-4389-a61d-7373df8b2292/1.0/functions/01_SetContext.go
@@ -1,0 +1,37 @@
+package functions
+
+import (
+	"fmt"
+
+	FileServerVssAgent "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/a8e0653c-2744-4389-a61d-7373df8b2292/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// setContextRequest carries the [in] parameters of SetContext.
+type setContextRequest struct {
+	Context ndr.DWORD
+}
+
+func (*setContextRequest) Opnum() uint16 { return FileServerVssAgent.OpnumSetContext }
+
+// setContextResponse carries the [out] parameters and return value of SetContext.
+type setContextResponse struct {
+	Status ndr.DWORD `ndr:"retval"`
+}
+
+// SetContext calls SetContext (opnum 1) ([MS-FSRVP] — verify the parameter
+// modeling and status handling).
+func SetContext(rpc ndr.Invoker, context ndr.DWORD) (err error) {
+	req := &setContextRequest{
+		Context: context,
+	}
+	var resp setContextResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("SetContext: %w", err)
+		return
+	}
+	if uint32(resp.Status) != FileServerVssAgent.StatusSuccess {
+		err = fmt.Errorf("SetContext failed: %s", FileServerVssAgent.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/a8e0653c-2744-4389-a61d-7373df8b2292/1.0/functions/02_StartShadowCopySet.go
+++ b/network/dcerpc/interfaces/a8e0653c-2744-4389-a61d-7373df8b2292/1.0/functions/02_StartShadowCopySet.go
@@ -1,0 +1,41 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	FileServerVssAgent "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/a8e0653c-2744-4389-a61d-7373df8b2292/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+)
+
+// startShadowCopySetRequest carries the [in] parameters of StartShadowCopySet.
+type startShadowCopySetRequest struct {
+	ClientShadowCopySetId dtyp.GUID
+}
+
+func (*startShadowCopySetRequest) Opnum() uint16 { return FileServerVssAgent.OpnumStartShadowCopySet }
+
+// startShadowCopySetResponse carries the [out] parameters and return value of StartShadowCopySet.
+type startShadowCopySetResponse struct {
+	PShadowCopySetId dtyp.GUID
+	Status           ndr.DWORD `ndr:"retval"`
+}
+
+// StartShadowCopySet calls StartShadowCopySet (opnum 2) ([MS-FSRVP] — verify the parameter
+// modeling and status handling).
+func StartShadowCopySet(rpc ndr.Invoker, clientShadowCopySetId guid.GUID) (PShadowCopySetId guid.GUID, err error) {
+	req := &startShadowCopySetRequest{
+		ClientShadowCopySetId: dtyp.NewGUID(clientShadowCopySetId),
+	}
+	var resp startShadowCopySetResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("StartShadowCopySet: %w", err)
+		return
+	}
+	PShadowCopySetId = resp.PShadowCopySetId.GUID()
+	if uint32(resp.Status) != FileServerVssAgent.StatusSuccess {
+		err = fmt.Errorf("StartShadowCopySet failed: %s", FileServerVssAgent.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/a8e0653c-2744-4389-a61d-7373df8b2292/1.0/functions/03_AddToShadowCopySet.go
+++ b/network/dcerpc/interfaces/a8e0653c-2744-4389-a61d-7373df8b2292/1.0/functions/03_AddToShadowCopySet.go
@@ -1,0 +1,45 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	FileServerVssAgent "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/a8e0653c-2744-4389-a61d-7373df8b2292/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+)
+
+// addToShadowCopySetRequest carries the [in] parameters of AddToShadowCopySet.
+type addToShadowCopySetRequest struct {
+	ClientShadowCopyId dtyp.GUID
+	ShadowCopySetId    dtyp.GUID
+	ShareName          ndr.WSTR
+}
+
+func (*addToShadowCopySetRequest) Opnum() uint16 { return FileServerVssAgent.OpnumAddToShadowCopySet }
+
+// addToShadowCopySetResponse carries the [out] parameters and return value of AddToShadowCopySet.
+type addToShadowCopySetResponse struct {
+	PShadowCopyId dtyp.GUID
+	Status        ndr.DWORD `ndr:"retval"`
+}
+
+// AddToShadowCopySet calls AddToShadowCopySet (opnum 3) ([MS-FSRVP] — verify the parameter
+// modeling and status handling).
+func AddToShadowCopySet(rpc ndr.Invoker, clientShadowCopyId guid.GUID, shadowCopySetId guid.GUID, shareName ndr.WSTR) (PShadowCopyId guid.GUID, err error) {
+	req := &addToShadowCopySetRequest{
+		ClientShadowCopyId: dtyp.NewGUID(clientShadowCopyId),
+		ShadowCopySetId:    dtyp.NewGUID(shadowCopySetId),
+		ShareName:          shareName,
+	}
+	var resp addToShadowCopySetResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("AddToShadowCopySet: %w", err)
+		return
+	}
+	PShadowCopyId = resp.PShadowCopyId.GUID()
+	if uint32(resp.Status) != FileServerVssAgent.StatusSuccess {
+		err = fmt.Errorf("AddToShadowCopySet failed: %s", FileServerVssAgent.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/a8e0653c-2744-4389-a61d-7373df8b2292/1.0/functions/04_CommitShadowCopySet.go
+++ b/network/dcerpc/interfaces/a8e0653c-2744-4389-a61d-7373df8b2292/1.0/functions/04_CommitShadowCopySet.go
@@ -1,0 +1,41 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	FileServerVssAgent "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/a8e0653c-2744-4389-a61d-7373df8b2292/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+)
+
+// commitShadowCopySetRequest carries the [in] parameters of CommitShadowCopySet.
+type commitShadowCopySetRequest struct {
+	ShadowCopySetId       dtyp.GUID
+	TimeOutInMilliseconds ndr.DWORD
+}
+
+func (*commitShadowCopySetRequest) Opnum() uint16 { return FileServerVssAgent.OpnumCommitShadowCopySet }
+
+// commitShadowCopySetResponse carries the [out] parameters and return value of CommitShadowCopySet.
+type commitShadowCopySetResponse struct {
+	Status ndr.DWORD `ndr:"retval"`
+}
+
+// CommitShadowCopySet calls CommitShadowCopySet (opnum 4) ([MS-FSRVP] — verify the parameter
+// modeling and status handling).
+func CommitShadowCopySet(rpc ndr.Invoker, shadowCopySetId guid.GUID, timeOutInMilliseconds ndr.DWORD) (err error) {
+	req := &commitShadowCopySetRequest{
+		ShadowCopySetId:       dtyp.NewGUID(shadowCopySetId),
+		TimeOutInMilliseconds: timeOutInMilliseconds,
+	}
+	var resp commitShadowCopySetResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("CommitShadowCopySet: %w", err)
+		return
+	}
+	if uint32(resp.Status) != FileServerVssAgent.StatusSuccess {
+		err = fmt.Errorf("CommitShadowCopySet failed: %s", FileServerVssAgent.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/a8e0653c-2744-4389-a61d-7373df8b2292/1.0/functions/05_ExposeShadowCopySet.go
+++ b/network/dcerpc/interfaces/a8e0653c-2744-4389-a61d-7373df8b2292/1.0/functions/05_ExposeShadowCopySet.go
@@ -1,0 +1,41 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	FileServerVssAgent "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/a8e0653c-2744-4389-a61d-7373df8b2292/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+)
+
+// exposeShadowCopySetRequest carries the [in] parameters of ExposeShadowCopySet.
+type exposeShadowCopySetRequest struct {
+	ShadowCopySetId       dtyp.GUID
+	TimeOutInMilliseconds ndr.DWORD
+}
+
+func (*exposeShadowCopySetRequest) Opnum() uint16 { return FileServerVssAgent.OpnumExposeShadowCopySet }
+
+// exposeShadowCopySetResponse carries the [out] parameters and return value of ExposeShadowCopySet.
+type exposeShadowCopySetResponse struct {
+	Status ndr.DWORD `ndr:"retval"`
+}
+
+// ExposeShadowCopySet calls ExposeShadowCopySet (opnum 5) ([MS-FSRVP] — verify the parameter
+// modeling and status handling).
+func ExposeShadowCopySet(rpc ndr.Invoker, shadowCopySetId guid.GUID, timeOutInMilliseconds ndr.DWORD) (err error) {
+	req := &exposeShadowCopySetRequest{
+		ShadowCopySetId:       dtyp.NewGUID(shadowCopySetId),
+		TimeOutInMilliseconds: timeOutInMilliseconds,
+	}
+	var resp exposeShadowCopySetResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("ExposeShadowCopySet: %w", err)
+		return
+	}
+	if uint32(resp.Status) != FileServerVssAgent.StatusSuccess {
+		err = fmt.Errorf("ExposeShadowCopySet failed: %s", FileServerVssAgent.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/a8e0653c-2744-4389-a61d-7373df8b2292/1.0/functions/06_RecoveryCompleteShadowCopySet.go
+++ b/network/dcerpc/interfaces/a8e0653c-2744-4389-a61d-7373df8b2292/1.0/functions/06_RecoveryCompleteShadowCopySet.go
@@ -1,0 +1,41 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	FileServerVssAgent "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/a8e0653c-2744-4389-a61d-7373df8b2292/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+)
+
+// recoveryCompleteShadowCopySetRequest carries the [in] parameters of RecoveryCompleteShadowCopySet.
+type recoveryCompleteShadowCopySetRequest struct {
+	ShadowCopySetId dtyp.GUID
+}
+
+func (*recoveryCompleteShadowCopySetRequest) Opnum() uint16 {
+	return FileServerVssAgent.OpnumRecoveryCompleteShadowCopySet
+}
+
+// recoveryCompleteShadowCopySetResponse carries the [out] parameters and return value of RecoveryCompleteShadowCopySet.
+type recoveryCompleteShadowCopySetResponse struct {
+	Status ndr.DWORD `ndr:"retval"`
+}
+
+// RecoveryCompleteShadowCopySet calls RecoveryCompleteShadowCopySet (opnum 6) ([MS-FSRVP] — verify the parameter
+// modeling and status handling).
+func RecoveryCompleteShadowCopySet(rpc ndr.Invoker, shadowCopySetId guid.GUID) (err error) {
+	req := &recoveryCompleteShadowCopySetRequest{
+		ShadowCopySetId: dtyp.NewGUID(shadowCopySetId),
+	}
+	var resp recoveryCompleteShadowCopySetResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("RecoveryCompleteShadowCopySet: %w", err)
+		return
+	}
+	if uint32(resp.Status) != FileServerVssAgent.StatusSuccess {
+		err = fmt.Errorf("RecoveryCompleteShadowCopySet failed: %s", FileServerVssAgent.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/a8e0653c-2744-4389-a61d-7373df8b2292/1.0/functions/07_AbortShadowCopySet.go
+++ b/network/dcerpc/interfaces/a8e0653c-2744-4389-a61d-7373df8b2292/1.0/functions/07_AbortShadowCopySet.go
@@ -1,0 +1,39 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	FileServerVssAgent "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/a8e0653c-2744-4389-a61d-7373df8b2292/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+)
+
+// abortShadowCopySetRequest carries the [in] parameters of AbortShadowCopySet.
+type abortShadowCopySetRequest struct {
+	ShadowCopySetId dtyp.GUID
+}
+
+func (*abortShadowCopySetRequest) Opnum() uint16 { return FileServerVssAgent.OpnumAbortShadowCopySet }
+
+// abortShadowCopySetResponse carries the [out] parameters and return value of AbortShadowCopySet.
+type abortShadowCopySetResponse struct {
+	Status ndr.DWORD `ndr:"retval"`
+}
+
+// AbortShadowCopySet calls AbortShadowCopySet (opnum 7) ([MS-FSRVP] — verify the parameter
+// modeling and status handling).
+func AbortShadowCopySet(rpc ndr.Invoker, shadowCopySetId guid.GUID) (err error) {
+	req := &abortShadowCopySetRequest{
+		ShadowCopySetId: dtyp.NewGUID(shadowCopySetId),
+	}
+	var resp abortShadowCopySetResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("AbortShadowCopySet: %w", err)
+		return
+	}
+	if uint32(resp.Status) != FileServerVssAgent.StatusSuccess {
+		err = fmt.Errorf("AbortShadowCopySet failed: %s", FileServerVssAgent.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/a8e0653c-2744-4389-a61d-7373df8b2292/1.0/functions/08_IsPathSupported.go
+++ b/network/dcerpc/interfaces/a8e0653c-2744-4389-a61d-7373df8b2292/1.0/functions/08_IsPathSupported.go
@@ -1,0 +1,43 @@
+package functions
+
+import (
+	"fmt"
+
+	FileServerVssAgent "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/a8e0653c-2744-4389-a61d-7373df8b2292/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// isPathSupportedRequest carries the [in] parameters of IsPathSupported.
+type isPathSupportedRequest struct {
+	ShareName ndr.WSTR
+}
+
+func (*isPathSupportedRequest) Opnum() uint16 { return FileServerVssAgent.OpnumIsPathSupported }
+
+// isPathSupportedResponse carries the [out] parameters and return value of IsPathSupported.
+// OwnerMachineName is [out][string] LPWSTR* — a [unique] pointer to a wide string (the
+// outer * is the [out] by-reference mechanism and is not transmitted).
+type isPathSupportedResponse struct {
+	SupportedByThisProvider ndr.BOOL
+	OwnerMachineName        *ndr.WSTR `ndr:"unique"`
+	Status                  ndr.DWORD `ndr:"retval"`
+}
+
+// IsPathSupported calls IsPathSupported (opnum 8) ([MS-FSRVP] — verify the parameter
+// modeling and status handling).
+func IsPathSupported(rpc ndr.Invoker, shareName ndr.WSTR) (SupportedByThisProvider ndr.BOOL, OwnerMachineName *ndr.WSTR, err error) {
+	req := &isPathSupportedRequest{
+		ShareName: shareName,
+	}
+	var resp isPathSupportedResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("IsPathSupported: %w", err)
+		return
+	}
+	SupportedByThisProvider = resp.SupportedByThisProvider
+	OwnerMachineName = resp.OwnerMachineName
+	if uint32(resp.Status) != FileServerVssAgent.StatusSuccess {
+		err = fmt.Errorf("IsPathSupported failed: %s", FileServerVssAgent.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/a8e0653c-2744-4389-a61d-7373df8b2292/1.0/functions/09_IsPathShadowCopied.go
+++ b/network/dcerpc/interfaces/a8e0653c-2744-4389-a61d-7373df8b2292/1.0/functions/09_IsPathShadowCopied.go
@@ -1,0 +1,41 @@
+package functions
+
+import (
+	"fmt"
+
+	FileServerVssAgent "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/a8e0653c-2744-4389-a61d-7373df8b2292/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// isPathShadowCopiedRequest carries the [in] parameters of IsPathShadowCopied.
+type isPathShadowCopiedRequest struct {
+	ShareName ndr.WSTR
+}
+
+func (*isPathShadowCopiedRequest) Opnum() uint16 { return FileServerVssAgent.OpnumIsPathShadowCopied }
+
+// isPathShadowCopiedResponse carries the [out] parameters and return value of IsPathShadowCopied.
+type isPathShadowCopiedResponse struct {
+	ShadowCopyPresent       ndr.BOOL
+	ShadowCopyCompatibility int32
+	Status                  ndr.DWORD `ndr:"retval"`
+}
+
+// IsPathShadowCopied calls IsPathShadowCopied (opnum 9) ([MS-FSRVP] — verify the parameter
+// modeling and status handling).
+func IsPathShadowCopied(rpc ndr.Invoker, shareName ndr.WSTR) (ShadowCopyPresent ndr.BOOL, ShadowCopyCompatibility int32, err error) {
+	req := &isPathShadowCopiedRequest{
+		ShareName: shareName,
+	}
+	var resp isPathShadowCopiedResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("IsPathShadowCopied: %w", err)
+		return
+	}
+	ShadowCopyPresent = resp.ShadowCopyPresent
+	ShadowCopyCompatibility = resp.ShadowCopyCompatibility
+	if uint32(resp.Status) != FileServerVssAgent.StatusSuccess {
+		err = fmt.Errorf("IsPathShadowCopied failed: %s", FileServerVssAgent.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/a8e0653c-2744-4389-a61d-7373df8b2292/1.0/functions/10_GetShareMapping.go
+++ b/network/dcerpc/interfaces/a8e0653c-2744-4389-a61d-7373df8b2292/1.0/functions/10_GetShareMapping.go
@@ -1,0 +1,48 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	FileServerVssAgent "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/a8e0653c-2744-4389-a61d-7373df8b2292/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+	msfsrvp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-fsrvp"
+)
+
+// getShareMappingRequest carries the [in] parameters of GetShareMapping.
+type getShareMappingRequest struct {
+	ShadowCopyId    dtyp.GUID
+	ShadowCopySetId dtyp.GUID
+	ShareName       ndr.WSTR
+	Level           ndr.DWORD
+}
+
+func (*getShareMappingRequest) Opnum() uint16 { return FileServerVssAgent.OpnumGetShareMapping }
+
+// getShareMappingResponse carries the [out] parameters and return value of GetShareMapping.
+type getShareMappingResponse struct {
+	ShareMapping msfsrvp.FSSAGENT_SHARE_MAPPING
+	Status       ndr.DWORD `ndr:"retval"`
+}
+
+// GetShareMapping calls GetShareMapping (opnum 10) ([MS-FSRVP] — verify the parameter
+// modeling and status handling).
+func GetShareMapping(rpc ndr.Invoker, shadowCopyId guid.GUID, shadowCopySetId guid.GUID, shareName ndr.WSTR, level ndr.DWORD) (ShareMapping msfsrvp.FSSAGENT_SHARE_MAPPING, err error) {
+	req := &getShareMappingRequest{
+		ShadowCopyId:    dtyp.NewGUID(shadowCopyId),
+		ShadowCopySetId: dtyp.NewGUID(shadowCopySetId),
+		ShareName:       shareName,
+		Level:           level,
+	}
+	var resp getShareMappingResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("GetShareMapping: %w", err)
+		return
+	}
+	ShareMapping = resp.ShareMapping
+	if uint32(resp.Status) != FileServerVssAgent.StatusSuccess {
+		err = fmt.Errorf("GetShareMapping failed: %s", FileServerVssAgent.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/a8e0653c-2744-4389-a61d-7373df8b2292/1.0/functions/11_DeleteShareMapping.go
+++ b/network/dcerpc/interfaces/a8e0653c-2744-4389-a61d-7373df8b2292/1.0/functions/11_DeleteShareMapping.go
@@ -1,0 +1,43 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	FileServerVssAgent "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/a8e0653c-2744-4389-a61d-7373df8b2292/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+)
+
+// deleteShareMappingRequest carries the [in] parameters of DeleteShareMapping.
+type deleteShareMappingRequest struct {
+	ShadowCopySetId dtyp.GUID
+	ShadowCopyId    dtyp.GUID
+	ShareName       ndr.WSTR
+}
+
+func (*deleteShareMappingRequest) Opnum() uint16 { return FileServerVssAgent.OpnumDeleteShareMapping }
+
+// deleteShareMappingResponse carries the [out] parameters and return value of DeleteShareMapping.
+type deleteShareMappingResponse struct {
+	Status ndr.DWORD `ndr:"retval"`
+}
+
+// DeleteShareMapping calls DeleteShareMapping (opnum 11) ([MS-FSRVP] — verify the parameter
+// modeling and status handling).
+func DeleteShareMapping(rpc ndr.Invoker, shadowCopySetId guid.GUID, shadowCopyId guid.GUID, shareName ndr.WSTR) (err error) {
+	req := &deleteShareMappingRequest{
+		ShadowCopySetId: dtyp.NewGUID(shadowCopySetId),
+		ShadowCopyId:    dtyp.NewGUID(shadowCopyId),
+		ShareName:       shareName,
+	}
+	var resp deleteShareMappingResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("DeleteShareMapping: %w", err)
+		return
+	}
+	if uint32(resp.Status) != FileServerVssAgent.StatusSuccess {
+		err = fmt.Errorf("DeleteShareMapping failed: %s", FileServerVssAgent.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/a8e0653c-2744-4389-a61d-7373df8b2292/1.0/functions/12_PrepareShadowCopySet.go
+++ b/network/dcerpc/interfaces/a8e0653c-2744-4389-a61d-7373df8b2292/1.0/functions/12_PrepareShadowCopySet.go
@@ -1,0 +1,43 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	FileServerVssAgent "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/a8e0653c-2744-4389-a61d-7373df8b2292/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+)
+
+// prepareShadowCopySetRequest carries the [in] parameters of PrepareShadowCopySet.
+type prepareShadowCopySetRequest struct {
+	ShadowCopySetId       dtyp.GUID
+	TimeOutInMilliseconds ndr.DWORD
+}
+
+func (*prepareShadowCopySetRequest) Opnum() uint16 {
+	return FileServerVssAgent.OpnumPrepareShadowCopySet
+}
+
+// prepareShadowCopySetResponse carries the [out] parameters and return value of PrepareShadowCopySet.
+type prepareShadowCopySetResponse struct {
+	Status ndr.DWORD `ndr:"retval"`
+}
+
+// PrepareShadowCopySet calls PrepareShadowCopySet (opnum 12) ([MS-FSRVP] — verify the parameter
+// modeling and status handling).
+func PrepareShadowCopySet(rpc ndr.Invoker, shadowCopySetId guid.GUID, timeOutInMilliseconds ndr.DWORD) (err error) {
+	req := &prepareShadowCopySetRequest{
+		ShadowCopySetId:       dtyp.NewGUID(shadowCopySetId),
+		TimeOutInMilliseconds: timeOutInMilliseconds,
+	}
+	var resp prepareShadowCopySetResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("PrepareShadowCopySet: %w", err)
+		return
+	}
+	if uint32(resp.Status) != FileServerVssAgent.StatusSuccess {
+		err = fmt.Errorf("PrepareShadowCopySet failed: %s", FileServerVssAgent.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/a8e0653c-2744-4389-a61d-7373df8b2292/1.0/interface.go
+++ b/network/dcerpc/interfaces/a8e0653c-2744-4389-a61d-7373df8b2292/1.0/interface.go
@@ -1,0 +1,133 @@
+// Package rpcinterface_a8e0653c27444389a61d7373df8b2292_1_0 is the descriptor for the FileServerVssAgent RPC interface, abstract
+// syntax a8e0653c-2744-4389-a61d-7373df8b2292 version 1.0 ([MS-FSRVP]).
+//
+// This package holds only the interface-level descriptor (abstract syntax, transport
+// endpoint, opnums, opnum<->name maps, status codes). The PipeName ("FssagentRpc",
+// [MS-FSRVP] 2.1) and the status-code table ([MS-FSRVP] 2.2.4) are not carried by the
+// IDL and were filled in from the specification. NDR wire types live in
+// windows/protocols/ms-fsrvp and method stubs in functions; both depend on this
+// package, never the reverse.
+package rpcinterface_a8e0653c27444389a61d7373df8b2292_1_0
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+)
+
+// PipeName is the IPC$-relative named pipe for the FileServerVssAgent interface
+// ([MS-FSRVP] section 2.1 Transport: the "FssagentRpc" named pipe over ncacn_np).
+const PipeName = `\FssagentRpc`
+
+// Opnums for the on-the-wire methods.
+const (
+	OpnumGetSupportedVersion           uint16 = 0
+	OpnumSetContext                    uint16 = 1
+	OpnumStartShadowCopySet            uint16 = 2
+	OpnumAddToShadowCopySet            uint16 = 3
+	OpnumCommitShadowCopySet           uint16 = 4
+	OpnumExposeShadowCopySet           uint16 = 5
+	OpnumRecoveryCompleteShadowCopySet uint16 = 6
+	OpnumAbortShadowCopySet            uint16 = 7
+	OpnumIsPathSupported               uint16 = 8
+	OpnumIsPathShadowCopied            uint16 = 9
+	OpnumGetShareMapping               uint16 = 10
+	OpnumDeleteShareMapping            uint16 = 11
+	OpnumPrepareShadowCopySet          uint16 = 12
+)
+
+// Status codes. FSRVP methods return an HRESULT/error code: ZERO (0x00000000) on
+// success, common [MS-ERREF] HRESULTs, or the FSRVP-specific codes below
+// ([MS-FSRVP] section 2.2.4 Error Codes).
+const (
+	StatusSuccess uint32 = 0x00000000
+
+	// Common [MS-ERREF] HRESULTs referenced by FSRVP method processing rules.
+	ErrorInvalidArg   uint32 = 0x80070057 // E_INVALIDARG
+	ErrorAccessDenied uint32 = 0x80070005 // E_ACCESSDENIED
+	ErrorOutOfMemory  uint32 = 0x8007000E // E_OUTOFMEMORY
+
+	// FSRVP-specific error codes ([MS-FSRVP] 2.2.4).
+	FsrvpEBadState                uint32 = 0x80042301 // FSRVP_E_BAD_STATE
+	FsrvpENotSupported            uint32 = 0x8004230C // FSRVP_E_NOT_SUPPORTED
+	FsrvpEObjectAlreadyExists     uint32 = 0x8004230D // FSRVP_E_OBJECT_ALREADY_EXISTS
+	FsrvpEObjectNotFound          uint32 = 0x80042308 // FSRVP_E_OBJECT_NOT_FOUND
+	FsrvpEShadowCopySetInProgress uint32 = 0x80042316 // FSRVP_E_SHADOW_COPY_SET_IN_PROGRESS
+	FsrvpEUnsupportedContext      uint32 = 0x8004231B // FSRVP_E_UNSUPPORTED_CONTEXT
+	FsrvpEShadowcopysetIdMismatch uint32 = 0x80042501 // FSRVP_E_SHADOWCOPYSET_ID_MISMATCH
+	FsrvpEWaitTimeout             uint32 = 0x00000102 // FSRVP_E_WAIT_TIMEOUT
+	FsrvpEWaitFailed              uint32 = 0xFFFFFFFF // FSRVP_E_WAIT_FAILED
+)
+
+// SyntaxID returns the FileServerVssAgent abstract syntax identifier:
+// a8e0653c-2744-4389-a61d-7373df8b2292, version 1.0.
+func SyntaxID() syntax.SyntaxID {
+	return syntax.SyntaxID{
+		UUID:         guid.GUID{A: 0xa8e0653c, B: 0x2744, C: 0x4389, D: 0xa61d, E: 0x7373df8b2292},
+		MajorVersion: 1,
+		MinorVersion: 0,
+	}
+}
+
+// StatusString returns a mnemonic for the documented status codes, otherwise the
+// hex value.
+func StatusString(status uint32) string {
+	switch status {
+	case StatusSuccess:
+		return "ZERO"
+	case ErrorInvalidArg:
+		return "E_INVALIDARG"
+	case ErrorAccessDenied:
+		return "E_ACCESSDENIED"
+	case ErrorOutOfMemory:
+		return "E_OUTOFMEMORY"
+	case FsrvpEBadState:
+		return "FSRVP_E_BAD_STATE"
+	case FsrvpENotSupported:
+		return "FSRVP_E_NOT_SUPPORTED"
+	case FsrvpEObjectAlreadyExists:
+		return "FSRVP_E_OBJECT_ALREADY_EXISTS"
+	case FsrvpEObjectNotFound:
+		return "FSRVP_E_OBJECT_NOT_FOUND"
+	case FsrvpEShadowCopySetInProgress:
+		return "FSRVP_E_SHADOW_COPY_SET_IN_PROGRESS"
+	case FsrvpEUnsupportedContext:
+		return "FSRVP_E_UNSUPPORTED_CONTEXT"
+	case FsrvpEShadowcopysetIdMismatch:
+		return "FSRVP_E_SHADOWCOPYSET_ID_MISMATCH"
+	case FsrvpEWaitTimeout:
+		return "FSRVP_E_WAIT_TIMEOUT"
+	case FsrvpEWaitFailed:
+		return "FSRVP_E_WAIT_FAILED"
+	default:
+		return fmt.Sprintf("0x%08x", status)
+	}
+}
+
+// OpnumToName maps each on-the-wire opnum to its method name; the single source of
+// truth.
+var OpnumToName = map[uint16]string{
+	OpnumGetSupportedVersion:           "GetSupportedVersion",
+	OpnumSetContext:                    "SetContext",
+	OpnumStartShadowCopySet:            "StartShadowCopySet",
+	OpnumAddToShadowCopySet:            "AddToShadowCopySet",
+	OpnumCommitShadowCopySet:           "CommitShadowCopySet",
+	OpnumExposeShadowCopySet:           "ExposeShadowCopySet",
+	OpnumRecoveryCompleteShadowCopySet: "RecoveryCompleteShadowCopySet",
+	OpnumAbortShadowCopySet:            "AbortShadowCopySet",
+	OpnumIsPathSupported:               "IsPathSupported",
+	OpnumIsPathShadowCopied:            "IsPathShadowCopied",
+	OpnumGetShareMapping:               "GetShareMapping",
+	OpnumDeleteShareMapping:            "DeleteShareMapping",
+	OpnumPrepareShadowCopySet:          "PrepareShadowCopySet",
+}
+
+// NameToOpnum is the reverse of OpnumToName, built at init so the two never drift.
+var NameToOpnum = func() map[string]uint16 {
+	m := make(map[string]uint16, len(OpnumToName))
+	for op, name := range OpnumToName {
+		m[name] = op
+	}
+	return m
+}()

--- a/network/dcerpc/interfaces/a8e0653c-2744-4389-a61d-7373df8b2292/1.0/interface_test.go
+++ b/network/dcerpc/interfaces/a8e0653c-2744-4389-a61d-7373df8b2292/1.0/interface_test.go
@@ -1,0 +1,55 @@
+package rpcinterface_a8e0653c27444389a61d7373df8b2292_1_0
+
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+)
+
+// TestSyntaxID confirms the abstract syntax is the FileServerVssAgent UUID/version
+// (a8e0653c-2744-4389-a61d-7373df8b2292 v1.0, [MS-FSRVP] 2.1).
+func TestSyntaxID(t *testing.T) {
+	want, err := guid.FromString("a8e0653c-2744-4389-a61d-7373df8b2292")
+	if err != nil {
+		t.Fatalf("FromString: %v", err)
+	}
+	id := SyntaxID()
+	if id.UUID != *want {
+		t.Errorf("UUID = %s, want %s", id.UUID.ToFormatD(), want.ToFormatD())
+	}
+	if id.MajorVersion != 1 || id.MinorVersion != 0 {
+		t.Errorf("version = %d.%d, want 1.0", id.MajorVersion, id.MinorVersion)
+	}
+}
+
+// TestOpnumNameRoundTrip verifies OpnumToName covers all 13 on-the-wire methods and that
+// NameToOpnum is a faithful inverse.
+func TestOpnumNameRoundTrip(t *testing.T) {
+	if len(OpnumToName) != 13 {
+		t.Fatalf("OpnumToName has %d entries, want 13", len(OpnumToName))
+	}
+	if len(NameToOpnum) != len(OpnumToName) {
+		t.Fatalf("NameToOpnum has %d entries, want %d", len(NameToOpnum), len(OpnumToName))
+	}
+	for op, name := range OpnumToName {
+		if got, ok := NameToOpnum[name]; !ok || got != op {
+			t.Errorf("NameToOpnum[%q] = %d (ok=%v), want %d", name, got, ok, op)
+		}
+	}
+}
+
+// TestStatusString spot-checks the known-code mnemonics and the hex fallback.
+func TestStatusString(t *testing.T) {
+	cases := map[uint32]string{
+		StatusSuccess:                 "ZERO",
+		FsrvpEBadState:                "FSRVP_E_BAD_STATE",
+		FsrvpEShadowcopysetIdMismatch: "FSRVP_E_SHADOWCOPYSET_ID_MISMATCH",
+		FsrvpEWaitFailed:              "FSRVP_E_WAIT_FAILED",
+		0xdeadbeef:                    "0xdeadbeef",
+	}
+	for code, want := range cases {
+		if got := StatusString(code); got != want {
+			t.Errorf("StatusString(0x%08x) = %q, want %q", code, got, want)
+		}
+	}
+}

--- a/windows/protocols/ms-fsrvp/FSSAGENT_SHARE_MAPPING.go
+++ b/windows/protocols/ms-fsrvp/FSSAGENT_SHARE_MAPPING.go
@@ -1,0 +1,15 @@
+package msfsrvp
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// FSSAGENT_SHARE_MAPPING is the [switch_type(unsigned long)] union of share-mapping
+// levels ([MS-FSRVP] 2.2.3.1). Tag carries the discriminant inline, followed by the
+// selected arm; the case(1) arm is a [unique] pointer to the level-1 mapping (the IDL
+// declares PFSSAGENT_SHARE_MAPPING_1 under pointer_default(unique)). The [default] arm
+// is empty.
+type FSSAGENT_SHARE_MAPPING struct {
+	Tag           ndr.DWORD                 `ndr:"switch"`
+	ShareMapping1 *FSSAGENT_SHARE_MAPPING_1 `ndr:"case=1,unique"`
+}

--- a/windows/protocols/ms-fsrvp/FSSAGENT_SHARE_MAPPING_1.go
+++ b/windows/protocols/ms-fsrvp/FSSAGENT_SHARE_MAPPING_1.go
@@ -1,0 +1,19 @@
+package msfsrvp
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// FSSAGENT_SHARE_MAPPING_1 models FSSAGENT_SHARE_MAPPING_1 ([MS-FSRVP] 2.2.3.2): the
+// level-1 shadow-copy share mapping. The two IDs are [MS-DTYP] GUIDs (16 octets on the
+// wire) — modeled as dtyp.GUID, not windows/guid.GUID whose uint64 tail would marshal to
+// 24 octets. ShareNameUNC/ShadowCopyShareName are [unique][string] LPWSTR referents;
+// CreationTimestamp is a LONGLONG (FILETIME as a signed 64-bit count).
+type FSSAGENT_SHARE_MAPPING_1 struct {
+	ShadowCopySetId     dtyp.GUID
+	ShadowCopyId        dtyp.GUID
+	ShareNameUNC        *ndr.WSTR `ndr:"unique"`
+	ShadowCopyShareName *ndr.WSTR `ndr:"unique"`
+	CreationTimestamp   int64
+}

--- a/windows/protocols/ms-fsrvp/structures_test.go
+++ b/windows/protocols/ms-fsrvp/structures_test.go
@@ -1,0 +1,104 @@
+package msfsrvp
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+)
+
+// roundTrip marshals in, unmarshals into a fresh value of the same type, and asserts
+// the result is deeply equal to in. This is the wire-shape acceptance gate for the
+// MS-FSRVP (FssagentRpc) NDR structures in the absence of a live File Server VSS agent.
+func roundTrip[T any](t *testing.T, name string, in T) {
+	t.Helper()
+	raw, err := ndr.Marshal(&in)
+	if err != nil {
+		t.Fatalf("%s: Marshal: %v", name, err)
+	}
+	var out T
+	if err := ndr.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("%s: Unmarshal: %v", name, err)
+	}
+	if !reflect.DeepEqual(in, out) {
+		t.Errorf("%s: round trip mismatch:\n in:  %+v\n out: %+v", name, in, out)
+	}
+}
+
+func wstr(s string) *ndr.WSTR { w := ndr.WSTR(s); return &w }
+
+func mustGUID(t *testing.T, s string) dtyp.GUID {
+	t.Helper()
+	g, err := guid.FromString(s)
+	if err != nil {
+		t.Fatalf("FromString(%q): %v", s, err)
+	}
+	return dtyp.NewGUID(*g)
+}
+
+// TestGUIDFieldWidth pins the wire width: an FSSAGENT_SHARE_MAPPING_1 with NULL strings
+// marshals its two dtyp.GUIDs as 16 octets each (32 total) + a 4-byte referent-id word
+// for each NULL LPWSTR (null referent id = 0) + 8-byte LONGLONG. This guards against a
+// regression back to windows/guid.GUID (which would over-align to 24 octets/GUID).
+func TestGUIDFieldWidth(t *testing.T) {
+	raw, err := ndr.Marshal(&FSSAGENT_SHARE_MAPPING_1{})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	// 16 + 16 (GUIDs) + 4 + 4 (two null unique referent ids) + 8 (LONGLONG) = 48.
+	if len(raw) != 48 {
+		t.Fatalf("FSSAGENT_SHARE_MAPPING_1 marshalled to %d bytes, want 48 (16-octet GUIDs); a 24-octet GUID would push this to 64", len(raw))
+	}
+}
+
+// TestFSSAGENT_SHARE_MAPPING_1 exercises the level-1 share mapping ([MS-FSRVP] 2.2.3.2):
+// two GUIDs, two [unique][string] LPWSTR pointers, and a LONGLONG timestamp. Both the
+// populated case and the NULL-string case (the [unique] referents absent) must survive.
+func TestFSSAGENT_SHARE_MAPPING_1(t *testing.T) {
+	roundTrip(t, "FSSAGENT_SHARE_MAPPING_1/populated", FSSAGENT_SHARE_MAPPING_1{
+		ShadowCopySetId:     mustGUID(t, "11111111-2222-3333-4444-555555555555"),
+		ShadowCopyId:        mustGUID(t, "66666666-7777-8888-9999-aaaaaaaaaaaa"),
+		ShareNameUNC:        wstr(`\\server\share`),
+		ShadowCopyShareName: wstr(`\\server\share@{GMT}`),
+		CreationTimestamp:   133000000000000000,
+	})
+
+	roundTrip(t, "FSSAGENT_SHARE_MAPPING_1/nil-strings", FSSAGENT_SHARE_MAPPING_1{
+		ShadowCopySetId:     mustGUID(t, "11111111-2222-3333-4444-555555555555"),
+		ShadowCopyId:        mustGUID(t, "66666666-7777-8888-9999-aaaaaaaaaaaa"),
+		ShareNameUNC:        nil,
+		ShadowCopyShareName: nil,
+		CreationTimestamp:   0,
+	})
+}
+
+// TestFSSAGENT_SHARE_MAPPING exercises the [switch_type(unsigned long)] union GetShareMapping
+// returns ([MS-FSRVP] 2.2.3.1): the 4-byte discriminant inline, then the case(1) arm — a
+// [unique] pointer to a level-1 mapping. Covers the selected arm, the NULL-referent request
+// shape, and the [default] (empty) arm.
+func TestFSSAGENT_SHARE_MAPPING(t *testing.T) {
+	roundTrip(t, "FSSAGENT_SHARE_MAPPING/case1", FSSAGENT_SHARE_MAPPING{
+		Tag: 1,
+		ShareMapping1: &FSSAGENT_SHARE_MAPPING_1{
+			ShadowCopySetId:     mustGUID(t, "11111111-2222-3333-4444-555555555555"),
+			ShadowCopyId:        mustGUID(t, "66666666-7777-8888-9999-aaaaaaaaaaaa"),
+			ShareNameUNC:        wstr(`\\server\share`),
+			ShadowCopyShareName: wstr(`\\server\share@{GMT}`),
+			CreationTimestamp:   133000000000000000,
+		},
+	})
+
+	// Level 1 requested, arm pointer NULL (the [unique] referent is absent on the wire).
+	roundTrip(t, "FSSAGENT_SHARE_MAPPING/case1-nil", FSSAGENT_SHARE_MAPPING{
+		Tag:           1,
+		ShareMapping1: nil,
+	})
+
+	// [default] arm: any discriminant other than 1 selects the empty arm.
+	roundTrip(t, "FSSAGENT_SHARE_MAPPING/default", FSSAGENT_SHARE_MAPPING{
+		Tag:           0,
+		ShareMapping1: nil,
+	})
+}


### PR DESCRIPTION
### Linked Issue

Closes #785

### Summary

Adds the File Server Remote VSS Protocol ([MS-FSRVP]) `FileServerVssAgent` DCE/RPC
client interface, following the `dcerpc-interface-structure` split layout. MS-FSRVP
Appendix A defines a single classic RPC interface (not a DCOM/object interface):

- **FileServerVssAgent** — abstract syntax `a8e0653c-2744-4389-a61d-7373df8b2292` version 1.0.

FSRVP lets a client remotely create and manage volume shadow copies of SMB file shares
on a file server (it is also the interface abused by the ShadowCoerce coercion technique).

### What was added

- **Interface descriptor** —
  `network/dcerpc/interfaces/a8e0653c-2744-4389-a61d-7373df8b2292/1.0/interface.go`:
  `SyntaxID()`, the 13 opnum constants, `OpnumToName`/`NameToOpnum` maps, and the FSRVP
  status-code table (`StatusString`: the FSRVP-specific `FSRVP_E_*` codes from [MS-FSRVP]
  section 2.2.4 plus the common `E_INVALIDARG`/`E_ACCESSDENIED`/`E_OUTOFMEMORY` HRESULTs).
  Transport is `ncacn_np` over the **`FssagentRpc`** named pipe ([MS-FSRVP] section 2.1),
  so `PipeName` is `\FssagentRpc` (IPC$-relative).
- **Method stubs** — one `functions/<NN>_<Method>.go` per on-the-wire opnum (13 total):
  `GetSupportedVersion` (0), `SetContext` (1), `StartShadowCopySet` (2),
  `AddToShadowCopySet` (3), `CommitShadowCopySet` (4), `ExposeShadowCopySet` (5),
  `RecoveryCompleteShadowCopySet` (6), `AbortShadowCopySet` (7), `IsPathSupported` (8),
  `IsPathShadowCopied` (9), `GetShareMapping` (10), `DeleteShareMapping` (11),
  `PrepareShadowCopySet` (12).
- **NDR wire structures** — `windows/protocols/ms-fsrvp/` (`package msfsrvp`):
  `FSSAGENT_SHARE_MAPPING_1` and the `FSSAGENT_SHARE_MAPPING` `[switch_type(unsigned long)]`
  union, plus a consolidated `structures_test.go`.

### Hand-refinements over the generated skeleton

The `idlgen` skeleton was reconciled against the skill's NDR rules:

- **GUID type** — all wire GUIDs (the `FSSAGENT_SHARE_MAPPING_1` IDs and every `[in]`/`[out]`
  `GUID` parameter) use `dtyp.GUID` (the 16-octet NDR form), not `windows/guid.GUID` (whose
  trailing `uint64` over-aligns and marshals to 24 octets). The exported functions keep the
  friendly `guid.GUID` signature and convert at the boundary with `dtyp.NewGUID` / `.GUID()`.
  Matches the MS-FRS2/MS-FRS1 convention (#784/#782).
- **Share-mapping union arm** — `FSSAGENT_SHARE_MAPPING`'s `case(1)` arm is a `[unique]`
  pointer to `FSSAGENT_SHARE_MAPPING_1` (`*FSSAGENT_SHARE_MAPPING_1` `ndr:"case=1,unique"`),
  because the IDL declares `PFSSAGENT_SHARE_MAPPING_1` under `pointer_default(unique)`; the
  4-byte discriminant precedes the arm. The `[out][switch_is(Level)] PFSSAGENT_SHARE_MAPPING`
  parameter is transmitted inline (the top-level `[out]` pointer is not a wire referent).
- **`LPWSTR*` output** — `IsPathSupported`'s `[out][string] LPWSTR* OwnerMachineName` is a
  `*ndr.WSTR` `ndr:"unique"` (the inner `LPWSTR` is a unique referent; the outer `*` is the
  `[out]` mechanism). The `[out] BOOL*`/`long*` scalars stay inline; `[in][string] LPWSTR`
  parameters are bare `ndr.WSTR` (top-level `[in]` parameter pointers default to `[ref]`).
- **Status table** — filled in from [MS-FSRVP] 2.2.4 (`FSRVP_E_BAD_STATE` 0x80042301,
  `FSRVP_E_SHADOW_COPY_SET_IN_PROGRESS` 0x80042316, `FSRVP_E_NOT_SUPPORTED` 0x8004230C,
  `FSRVP_E_OBJECT_NOT_FOUND` 0x80042308, `FSRVP_E_SHADOWCOPYSET_ID_MISMATCH` 0x80042501, …),
  which the IDL does not carry.

### How Verified

- `gofmt -l` empty; `go build`, `go vet`, `go test` clean over the interface tree and the
  `windows/protocols/ms-fsrvp` structures package.
- Cross-compiles clean for `GOARCH=386` and `GOARCH=arm64` (the CI matrix legs where
  integer-width bugs surface); `go build -tags integration` clean.
- Structure round-trip tests (`ndr.Marshal` → `ndr.Unmarshal` → `reflect.DeepEqual`) cover the
  level-1 mapping (populated and with NULL `[unique]` strings) and the union with the `case(1)`
  arm selected, the NULL-referent request shape, and the `[default]` arm. A `TestGUIDFieldWidth`
  pins the 16-octet GUID width (guarding against a regression to the 24-octet `windows/guid.GUID`).
- Descriptor tests pin the UUID/version, the 13 opnums, the `OpnumToName`/`NameToOpnum` round
  trip, and `StatusString`.

### Notes / Limitations

- Live validation against a Windows file server exposing the FSRVP agent was not performed. The
  `GetShareMapping` `switch_is` union (whose discriminant is transmitted inline, per the NDR
  convention) is the primary spot to confirm against a live server.