### PR TITLE
Add Live Remote Event Capture (LREC) Protocol (MS-LREC) NetEventForwarder client interface (Fixes #793)

### DIFF
--- a/network/dcerpc/interfaces/22e5386d-8b12-4bf0-b0ec-6a1ea419e366/1.0/functions/00_RpcNetEventOpenSession.go
+++ b/network/dcerpc/interfaces/22e5386d-8b12-4bf0-b0ec-6a1ea419e366/1.0/functions/00_RpcNetEventOpenSession.go
@@ -1,0 +1,44 @@
+package functions
+
+import (
+	"fmt"
+
+	NetEventForwarder "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/22e5386d-8b12-4bf0-b0ec-6a1ea419e366/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	mslrec "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lrec"
+)
+
+// rpcNetEventOpenSessionRequest carries the [in] parameters of RpcNetEventOpenSession.
+type rpcNetEventOpenSessionRequest struct {
+	LoggerName ndr.WSTR
+}
+
+func (*rpcNetEventOpenSessionRequest) Opnum() uint16 {
+	return NetEventForwarder.OpnumRpcNetEventOpenSession
+}
+
+// rpcNetEventOpenSessionResponse carries the [out] parameters and return value of RpcNetEventOpenSession.
+type rpcNetEventOpenSessionResponse struct {
+	SessionHandle mslrec.PSESSION_HANDLE
+	Status        ndr.DWORD `ndr:"retval"`
+}
+
+// RpcNetEventOpenSession calls RpcNetEventOpenSession (opnum 0) ([MS-LREC] 3.1.4.2.1),
+// opening a context handle to the running event session named loggerName (the Name of a
+// previously started MSFT_NetEventSession). On success the server begins accumulating
+// matching events and returns the session handle.
+func RpcNetEventOpenSession(rpc ndr.Invoker, loggerName ndr.WSTR) (SessionHandle mslrec.PSESSION_HANDLE, err error) {
+	req := &rpcNetEventOpenSessionRequest{
+		LoggerName: loggerName,
+	}
+	var resp rpcNetEventOpenSessionResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("RpcNetEventOpenSession: %w", err)
+		return
+	}
+	SessionHandle = resp.SessionHandle
+	if uint32(resp.Status) != NetEventForwarder.StatusSuccess {
+		err = fmt.Errorf("RpcNetEventOpenSession failed: %s", NetEventForwarder.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/22e5386d-8b12-4bf0-b0ec-6a1ea419e366/1.0/functions/01_RpcNetEventReceiveData.go
+++ b/network/dcerpc/interfaces/22e5386d-8b12-4bf0-b0ec-6a1ea419e366/1.0/functions/01_RpcNetEventReceiveData.go
@@ -1,0 +1,44 @@
+package functions
+
+import (
+	"fmt"
+
+	NetEventForwarder "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/22e5386d-8b12-4bf0-b0ec-6a1ea419e366/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	mslrec "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lrec"
+)
+
+// rpcNetEventReceiveDataRequest carries the [in] parameters of RpcNetEventReceiveData.
+type rpcNetEventReceiveDataRequest struct {
+	SessionHandle mslrec.PSESSION_HANDLE
+}
+
+func (*rpcNetEventReceiveDataRequest) Opnum() uint16 {
+	return NetEventForwarder.OpnumRpcNetEventReceiveData
+}
+
+// rpcNetEventReceiveDataResponse carries the [out] parameters and return value of RpcNetEventReceiveData.
+type rpcNetEventReceiveDataResponse struct {
+	EventBuffer mslrec.EVENT_BUFFER
+	Status      ndr.DWORD `ndr:"retval"`
+}
+
+// RpcNetEventReceiveData calls RpcNetEventReceiveData (opnum 1) ([MS-LREC] 3.1.4.2.2),
+// draining buffered events for the session referenced by sessionHandle. The returned
+// EVENT_BUFFER holds one or more NET_EVENT_DATA_HEADER structures with their payloads;
+// the server determines the buffer size and may block until enough events accumulate.
+func RpcNetEventReceiveData(rpc ndr.Invoker, sessionHandle mslrec.PSESSION_HANDLE) (EventBuffer mslrec.EVENT_BUFFER, err error) {
+	req := &rpcNetEventReceiveDataRequest{
+		SessionHandle: sessionHandle,
+	}
+	var resp rpcNetEventReceiveDataResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("RpcNetEventReceiveData: %w", err)
+		return
+	}
+	EventBuffer = resp.EventBuffer
+	if uint32(resp.Status) != NetEventForwarder.StatusSuccess {
+		err = fmt.Errorf("RpcNetEventReceiveData failed: %s", NetEventForwarder.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/22e5386d-8b12-4bf0-b0ec-6a1ea419e366/1.0/functions/02_RpcNetEventCloseSession.go
+++ b/network/dcerpc/interfaces/22e5386d-8b12-4bf0-b0ec-6a1ea419e366/1.0/functions/02_RpcNetEventCloseSession.go
@@ -1,0 +1,40 @@
+package functions
+
+import (
+	"fmt"
+
+	NetEventForwarder "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/22e5386d-8b12-4bf0-b0ec-6a1ea419e366/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	mslrec "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lrec"
+)
+
+// rpcNetEventCloseSessionRequest carries the [in,out] parameter of RpcNetEventCloseSession:
+// the session context handle to close.
+type rpcNetEventCloseSessionRequest struct {
+	SessionHandle mslrec.PSESSION_HANDLE
+}
+
+func (*rpcNetEventCloseSessionRequest) Opnum() uint16 {
+	return NetEventForwarder.OpnumRpcNetEventCloseSession
+}
+
+// rpcNetEventCloseSessionResponse carries the [in,out] parameter of RpcNetEventCloseSession.
+// The method is declared `void` in the IDL, so there is no return value on the wire —
+// the response contains only the (server-zeroed) context handle.
+type rpcNetEventCloseSessionResponse struct {
+	SessionHandle mslrec.PSESSION_HANDLE
+}
+
+// RpcNetEventCloseSession calls RpcNetEventCloseSession (opnum 2) ([MS-LREC] 3.1.4.2.3),
+// closing the event session referenced by sessionHandle. The method returns void; on
+// success the server returns a zeroed context handle, which is returned to the caller.
+func RpcNetEventCloseSession(rpc ndr.Invoker, sessionHandle mslrec.PSESSION_HANDLE) (mslrec.PSESSION_HANDLE, error) {
+	req := &rpcNetEventCloseSessionRequest{
+		SessionHandle: sessionHandle,
+	}
+	var resp rpcNetEventCloseSessionResponse
+	if err := rpc.Invoke(req, &resp); err != nil {
+		return mslrec.PSESSION_HANDLE{}, fmt.Errorf("RpcNetEventCloseSession: %w", err)
+	}
+	return resp.SessionHandle, nil
+}

--- a/network/dcerpc/interfaces/22e5386d-8b12-4bf0-b0ec-6a1ea419e366/1.0/interface.go
+++ b/network/dcerpc/interfaces/22e5386d-8b12-4bf0-b0ec-6a1ea419e366/1.0/interface.go
@@ -1,0 +1,76 @@
+// Package rpcinterface_22e5386d8b124bf0b0ec6a1ea419e366_1_0 is the descriptor for the NetEventForwarder RPC interface, abstract
+// syntax 22e5386d-8b12-4bf0-b0ec-6a1ea419e366 version 1.0 ([MS-LREC]).
+//
+// The NetEventForwarder interface implements the Live Remote Event Capture (LREC)
+// Protocol: a management station opens a context handle to a running event session on a
+// target host, drains buffered events, and closes the session.
+package rpcinterface_22e5386d8b124bf0b0ec6a1ea419e366_1_0
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+)
+
+// PipeName is retained for descriptor uniformity, but NetEventForwarder is NOT a
+// named-pipe interface: per [MS-LREC] 2.1 the protocol is carried over ncacn_ip_tcp on a
+// dynamic endpoint that the client resolves through the endpoint mapper (TCP/135). The
+// client MUST authenticate with RPC_C_AUTHN_GSS_NEGOTIATE and SHOULD request
+// RPC_C_AUTHN_LEVEL_PKT_PRIVACY. This constant is not the standard binding for this
+// interface.
+const PipeName = `\NetEventForwarder`
+
+// Opnums for the on-the-wire methods.
+const (
+	OpnumRpcNetEventOpenSession  uint16 = 0
+	OpnumRpcNetEventReceiveData  uint16 = 1
+	OpnumRpcNetEventCloseSession uint16 = 2
+)
+
+// Status codes returned by this interface. Every method that returns a DWORD returns a
+// Win32 error code ([MS-ERREF] 2.2): ERROR_SUCCESS on success, or a nonzero code on
+// failure. [MS-LREC] 3.1.4.2 enumerates no specific failure codes — "all error values
+// MUST be treated the same" — so only success is named; StatusString renders any other
+// code as hex.
+const (
+	StatusSuccess uint32 = 0x00000000 // ERROR_SUCCESS
+)
+
+// SyntaxID returns the NetEventForwarder abstract syntax identifier:
+// 22e5386d-8b12-4bf0-b0ec-6a1ea419e366, version 1.0.
+func SyntaxID() syntax.SyntaxID {
+	return syntax.SyntaxID{
+		UUID:         guid.GUID{A: 0x22e5386d, B: 0x8b12, C: 0x4bf0, D: 0xb0ec, E: 0x6a1ea419e366},
+		MajorVersion: 1,
+		MinorVersion: 0,
+	}
+}
+
+// StatusString returns a mnemonic for the documented status codes, otherwise the
+// hex value.
+func StatusString(status uint32) string {
+	switch status {
+	case StatusSuccess:
+		return "ERROR_SUCCESS"
+	default:
+		return fmt.Sprintf("0x%08x", status)
+	}
+}
+
+// OpnumToName maps each on-the-wire opnum to its method name; the single source of
+// truth.
+var OpnumToName = map[uint16]string{
+	OpnumRpcNetEventOpenSession:  "RpcNetEventOpenSession",
+	OpnumRpcNetEventReceiveData:  "RpcNetEventReceiveData",
+	OpnumRpcNetEventCloseSession: "RpcNetEventCloseSession",
+}
+
+// NameToOpnum is the reverse of OpnumToName, built at init so the two never drift.
+var NameToOpnum = func() map[string]uint16 {
+	m := make(map[string]uint16, len(OpnumToName))
+	for op, name := range OpnumToName {
+		m[name] = op
+	}
+	return m
+}()

--- a/network/dcerpc/interfaces/22e5386d-8b12-4bf0-b0ec-6a1ea419e366/1.0/interface_test.go
+++ b/network/dcerpc/interfaces/22e5386d-8b12-4bf0-b0ec-6a1ea419e366/1.0/interface_test.go
@@ -1,0 +1,37 @@
+package rpcinterface_22e5386d8b124bf0b0ec6a1ea419e366_1_0
+
+import "testing"
+
+// TestSyntaxID verifies the abstract syntax identity (UUID + version) of the interface.
+func TestSyntaxID(t *testing.T) {
+	s := SyntaxID()
+	if got := s.UUID.ToFormatD(); got != "22e5386d-8b12-4bf0-b0ec-6a1ea419e366" {
+		t.Fatalf("UUID = %s, want 22e5386d-8b12-4bf0-b0ec-6a1ea419e366", got)
+	}
+	if s.MajorVersion != 1 || s.MinorVersion != 0 {
+		t.Fatalf("version = %d.%d, want 1.0", s.MajorVersion, s.MinorVersion)
+	}
+}
+
+// TestOpnums verifies the implemented opnums and the name mapping.
+func TestOpnums(t *testing.T) {
+	if OpnumRpcNetEventOpenSession != 0 || OpnumRpcNetEventReceiveData != 1 || OpnumRpcNetEventCloseSession != 2 {
+		t.Fatalf("opnums = %d/%d/%d, want 0/1/2", OpnumRpcNetEventOpenSession, OpnumRpcNetEventReceiveData, OpnumRpcNetEventCloseSession)
+	}
+	if OpnumToName[0] != "RpcNetEventOpenSession" || NameToOpnum["RpcNetEventCloseSession"] != 2 {
+		t.Fatal("opnum name mapping is inconsistent")
+	}
+	if len(OpnumToName) != len(NameToOpnum) {
+		t.Fatalf("OpnumToName (%d) and NameToOpnum (%d) disagree on size", len(OpnumToName), len(NameToOpnum))
+	}
+}
+
+// TestStatusString verifies mnemonic rendering and the hex fallback.
+func TestStatusString(t *testing.T) {
+	if got := StatusString(StatusSuccess); got != "ERROR_SUCCESS" {
+		t.Fatalf("StatusString(StatusSuccess) = %s, want ERROR_SUCCESS", got)
+	}
+	if got := StatusString(0xDEADBEEF); got != "0xdeadbeef" {
+		t.Fatalf("StatusString(unknown) = %s, want 0xdeadbeef", got)
+	}
+}

--- a/windows/protocols/ms-lrec/EVENT_BUFFER.go
+++ b/windows/protocols/ms-lrec/EVENT_BUFFER.go
@@ -1,0 +1,19 @@
+package mslrec
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// EVENT_BUFFER holds the block of event data returned by RpcNetEventReceiveData
+// ([MS-LREC] 2.2.2.1). Buffer carries one or more NET_EVENT_DATA_HEADER structures
+// ([MS-LREC] 2.3.2.2) each followed by its event payload, optionally terminated by a
+// NET_EVENT_LOST structure ([MS-LREC] 2.3.2.3) when events were dropped.
+//
+// The IDL declares Buffer as [size_is(BufferLength)] byte*; under the assumed
+// pointer_default(unique) it is a [unique] pointer to a conformant array of bytes, so it
+// is modeled as a slice tagged unique + size_is (a referent id, then the array body whose
+// maximum_count is BufferLength).
+type EVENT_BUFFER struct {
+	BufferLength ndr.DWORD
+	Buffer       []uint8 `ndr:"unique,size_is=BufferLength"`
+}

--- a/windows/protocols/ms-lrec/PSESSION_HANDLE.go
+++ b/windows/protocols/ms-lrec/PSESSION_HANDLE.go
@@ -1,0 +1,25 @@
+package mslrec
+
+// PSESSION_HANDLE is the RPC context handle that references an active event session on
+// the server ([MS-LREC] 2.2.1.1). The IDL declares it as [context_handle] void*; on the
+// wire it is the 20-byte ndr_context_handle representation — a 4-byte attributes field
+// followed by a 16-byte GUID ([MS-RPCE] 2.3.2.2) — transmitted by value, never as a
+// referent pointer.
+//
+// RpcNetEventOpenSession and RpcNetEventCloseSession declare the parameter as
+// PSESSION_HANDLE* (a pointer to the handle). Because a context handle is always
+// transmitted as its 20-byte value, that extra indirection is a C-language artifact with
+// no separate NDR referent, so both the by-value ([in]) and by-pointer ([out]/[in,out])
+// parameters are modeled as this same value type.
+type PSESSION_HANDLE [20]byte
+
+// IsZero reports whether the handle is all zeros — for example, the nulled handle a
+// server returns from RpcNetEventCloseSession after tearing the session down.
+func (h PSESSION_HANDLE) IsZero() bool {
+	for _, b := range h {
+		if b != 0 {
+			return false
+		}
+	}
+	return true
+}

--- a/windows/protocols/ms-lrec/structures_test.go
+++ b/windows/protocols/ms-lrec/structures_test.go
@@ -1,0 +1,57 @@
+package mslrec
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// roundTrip marshals in, unmarshals into a fresh value of the same type, and asserts the
+// result is deeply equal to in.
+func roundTrip[T any](t *testing.T, name string, in T) {
+	t.Helper()
+	raw, err := ndr.Marshal(&in)
+	if err != nil {
+		t.Fatalf("%s: Marshal: %v", name, err)
+	}
+	var out T
+	if err := ndr.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("%s: Unmarshal: %v", name, err)
+	}
+	if !reflect.DeepEqual(in, out) {
+		t.Errorf("%s: round trip mismatch:\n in:  %+v\n out: %+v", name, in, out)
+	}
+}
+
+// TestEVENT_BUFFER_RoundTrip exercises the [unique] pointer to a conformant byte array:
+// BufferLength drives the array maximum_count via size_is.
+func TestEVENT_BUFFER_RoundTrip(t *testing.T) {
+	roundTrip(t, "EVENT_BUFFER", EVENT_BUFFER{
+		BufferLength: 6,
+		Buffer:       []uint8{0xde, 0xad, 0xbe, 0xef, 0x01, 0x02},
+	})
+}
+
+// TestEVENT_BUFFER_Empty exercises the empty-buffer case (BufferLength 0, no payload),
+// which the server returns when no events are ready.
+func TestEVENT_BUFFER_Empty(t *testing.T) {
+	roundTrip(t, "EVENT_BUFFER-empty", EVENT_BUFFER{
+		BufferLength: 0,
+		Buffer:       []uint8{},
+	})
+}
+
+// TestPSESSION_HANDLE_RoundTrip exercises the 20-byte context handle (wrapped in a struct,
+// since a context handle only ever appears as a field of a request/response), and IsZero
+// verifies the nulled-handle predicate used after a session close.
+func TestPSESSION_HANDLE_RoundTrip(t *testing.T) {
+	h := PSESSION_HANDLE{0x01, 0x00, 0x00, 0x00, 0xde, 0xad, 0xbe, 0xef}
+	roundTrip(t, "PSESSION_HANDLE", struct{ H PSESSION_HANDLE }{h})
+	if h.IsZero() {
+		t.Fatal("IsZero() = true for a non-zero handle")
+	}
+	if !(PSESSION_HANDLE{}).IsZero() {
+		t.Fatal("IsZero() = false for the zero handle")
+	}
+}


### PR DESCRIPTION
### Linked Issue

Closes #793

### Summary

Adds the Live Remote Event Capture (LREC) Protocol ([MS-LREC]) `NetEventForwarder`
DCE/RPC client interface, following the `dcerpc-interface-structure` split layout.
MS-LREC Appendix A defines a single classic RPC interface (not a DCOM/object interface):

- **NetEventForwarder** — abstract syntax `22e5386d-8b12-4bf0-b0ec-6a1ea419e366` version 1.0.

MS-LREC lets a management station monitor events on a target system across a network: a
client opens a context handle to a running event session, drains buffered events (one or
more `NET_EVENT_DATA_HEADER` structures plus payloads), and closes the session.

### What was added

- **Interface descriptor** —
  `network/dcerpc/interfaces/22e5386d-8b12-4bf0-b0ec-6a1ea419e366/1.0/interface.go`:
  `SyntaxID()`, the 3 on-the-wire opnum constants (0–2), `OpnumToName`/`NameToOpnum`
  maps, and `StatusString`. Per [MS-LREC] section 2.1 the interface is carried over
  `ncacn_ip_tcp` on a **dynamic endpoint** resolved through the endpoint mapper
  (TCP/135) with `RPC_C_AUTHN_GSS_NEGOTIATE` (SHOULD `RPC_C_AUTHN_LEVEL_PKT_PRIVACY`) —
  there is **no named pipe**, so `PipeName` is retained only for descriptor uniformity
  and documented as such (matching the DRSUAPI precedent). Each DWORD-returning method
  returns a Win32 error code ([MS-ERREF]); the IDL carries no fixed per-method code set,
  so only `ERROR_SUCCESS` is named and other values render as hex.
- **Method stubs** — `functions/00_RpcNetEventOpenSession.go`,
  `01_RpcNetEventReceiveData.go`, `02_RpcNetEventCloseSession.go` (one file per opnum),
  each with its `[in]`-parameter request, response, and a typed wrapper.
- **Wire structures** — under `windows/protocols/ms-lrec/` (package `mslrec`), one file
  per type: `EVENT_BUFFER` (the returned event block) and `PSESSION_HANDLE` (the RPC
  context handle, with an `IsZero` helper).

### Notes on wire modeling

- `EVENT_BUFFER.Buffer` is IDL `[size_is(BufferLength)] byte*`; under the assumed
  `pointer_default(unique)` it is a `[unique]` pointer to a conformant byte array,
  tagged `ndr:"unique,size_is=BufferLength"`.
- `PSESSION_HANDLE` is `[context_handle] void*` — the 20-byte `ndr_context_handle`
  ([MS-RPCE] 2.3.2.2), transmitted by value; the `PSESSION_HANDLE*` parameters carry no
  separate NDR referent, so both the by-value and by-pointer parameters use the same
  value type.
- `LoggerName` is a top-level `[in, string] wchar_t*` with no explicit pointer
  attribute, so it is a reference pointer (inline `ndr.WSTR`, no referent id).
- `RpcNetEventCloseSession` is declared `void`; its response carries only the
  server-zeroed `[in,out]` context handle and no return value on the wire.

### Tests

- `windows/protocols/ms-lrec/structures_test.go` — NDR round-trip tests for the
  populated and empty `EVENT_BUFFER` and the `PSESSION_HANDLE` context handle / `IsZero`.
- `interface_test.go` — pins the abstract syntax id, the opnum↔name maps (0–2), and
  `StatusString`.

`gofmt`, `go vet`, `go test`, and `GOARCH=386`/`GOARCH=arm64` cross-builds all pass.