### PR TITLE
Add Messenger Service Remote Protocol (MS-MSRP) msgsvcsend and msgsvc client interfaces (Fixes #810)

### DIFF
--- a/network/dcerpc/interfaces/17fdd703-1827-4e34-79d4-24a55c53bb37/1.0/functions/00_NetrMessageNameAdd.go
+++ b/network/dcerpc/interfaces/17fdd703-1827-4e34-79d4-24a55c53bb37/1.0/functions/00_NetrMessageNameAdd.go
@@ -1,0 +1,39 @@
+package functions
+
+import (
+	"fmt"
+
+	msgsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/17fdd703-1827-4e34-79d4-24a55c53bb37/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// netrMessageNameAddRequest carries the [in] parameters of NetrMessageNameAdd.
+type netrMessageNameAddRequest struct {
+	ServerName *ndr.WSTR `ndr:"unique"`
+	MsgName    ndr.WSTR
+}
+
+func (*netrMessageNameAddRequest) Opnum() uint16 { return msgsvc.OpnumNetrMessageNameAdd }
+
+// netrMessageNameAddResponse carries the [out] parameters and return value of NetrMessageNameAdd.
+type netrMessageNameAddResponse struct {
+	Status ndr.DWORD `ndr:"retval"`
+}
+
+// NetrMessageNameAdd calls NetrMessageNameAdd (opnum 0) ([MS-MSRP] — verify the parameter
+// modeling and status handling).
+func NetrMessageNameAdd(rpc ndr.Invoker, serverName *ndr.WSTR, msgName ndr.WSTR) (err error) {
+	req := &netrMessageNameAddRequest{
+		ServerName: serverName,
+		MsgName:    msgName,
+	}
+	var resp netrMessageNameAddResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("NetrMessageNameAdd: %w", err)
+		return
+	}
+	if uint32(resp.Status) != msgsvc.StatusSuccess {
+		err = fmt.Errorf("NetrMessageNameAdd failed: %s", msgsvc.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/17fdd703-1827-4e34-79d4-24a55c53bb37/1.0/functions/01_NetrMessageNameEnum.go
+++ b/network/dcerpc/interfaces/17fdd703-1827-4e34-79d4-24a55c53bb37/1.0/functions/01_NetrMessageNameEnum.go
@@ -1,0 +1,50 @@
+package functions
+
+import (
+	"fmt"
+
+	msgsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/17fdd703-1827-4e34-79d4-24a55c53bb37/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	msmsrp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-msrp"
+)
+
+// netrMessageNameEnumRequest carries the [in] parameters of NetrMessageNameEnum.
+type netrMessageNameEnumRequest struct {
+	ServerName   *ndr.WSTR `ndr:"unique"`
+	InfoStruct   msmsrp.MSG_ENUM_STRUCT
+	PrefMaxLen   ndr.DWORD
+	ResumeHandle *ndr.DWORD `ndr:"unique"`
+}
+
+func (*netrMessageNameEnumRequest) Opnum() uint16 { return msgsvc.OpnumNetrMessageNameEnum }
+
+// netrMessageNameEnumResponse carries the [out] parameters and return value of NetrMessageNameEnum.
+type netrMessageNameEnumResponse struct {
+	InfoStruct   msmsrp.MSG_ENUM_STRUCT
+	TotalEntries ndr.DWORD
+	ResumeHandle *ndr.DWORD `ndr:"unique"`
+	Status       ndr.DWORD  `ndr:"retval"`
+}
+
+// NetrMessageNameEnum calls NetrMessageNameEnum (opnum 1) ([MS-MSRP] — verify the parameter
+// modeling and status handling).
+func NetrMessageNameEnum(rpc ndr.Invoker, serverName *ndr.WSTR, infoStruct msmsrp.MSG_ENUM_STRUCT, prefMaxLen ndr.DWORD, resumeHandle *ndr.DWORD) (InfoStruct msmsrp.MSG_ENUM_STRUCT, TotalEntries ndr.DWORD, ResumeHandle *ndr.DWORD, err error) {
+	req := &netrMessageNameEnumRequest{
+		ServerName:   serverName,
+		InfoStruct:   infoStruct,
+		PrefMaxLen:   prefMaxLen,
+		ResumeHandle: resumeHandle,
+	}
+	var resp netrMessageNameEnumResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("NetrMessageNameEnum: %w", err)
+		return
+	}
+	InfoStruct = resp.InfoStruct
+	TotalEntries = resp.TotalEntries
+	ResumeHandle = resp.ResumeHandle
+	if uint32(resp.Status) != msgsvc.StatusSuccess {
+		err = fmt.Errorf("NetrMessageNameEnum failed: %s", msgsvc.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/17fdd703-1827-4e34-79d4-24a55c53bb37/1.0/functions/02_NetrMessageNameGetInfo.go
+++ b/network/dcerpc/interfaces/17fdd703-1827-4e34-79d4-24a55c53bb37/1.0/functions/02_NetrMessageNameGetInfo.go
@@ -1,0 +1,44 @@
+package functions
+
+import (
+	"fmt"
+
+	msgsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/17fdd703-1827-4e34-79d4-24a55c53bb37/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	msmsrp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-msrp"
+)
+
+// netrMessageNameGetInfoRequest carries the [in] parameters of NetrMessageNameGetInfo.
+type netrMessageNameGetInfoRequest struct {
+	ServerName *ndr.WSTR `ndr:"unique"`
+	MsgName    ndr.WSTR
+	Level      ndr.DWORD
+}
+
+func (*netrMessageNameGetInfoRequest) Opnum() uint16 { return msgsvc.OpnumNetrMessageNameGetInfo }
+
+// netrMessageNameGetInfoResponse carries the [out] parameters and return value of NetrMessageNameGetInfo.
+type netrMessageNameGetInfoResponse struct {
+	InfoStruct msmsrp.MSG_INFO
+	Status     ndr.DWORD `ndr:"retval"`
+}
+
+// NetrMessageNameGetInfo calls NetrMessageNameGetInfo (opnum 2) ([MS-MSRP] — verify the parameter
+// modeling and status handling).
+func NetrMessageNameGetInfo(rpc ndr.Invoker, serverName *ndr.WSTR, msgName ndr.WSTR, level ndr.DWORD) (InfoStruct msmsrp.MSG_INFO, err error) {
+	req := &netrMessageNameGetInfoRequest{
+		ServerName: serverName,
+		MsgName:    msgName,
+		Level:      level,
+	}
+	var resp netrMessageNameGetInfoResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("NetrMessageNameGetInfo: %w", err)
+		return
+	}
+	InfoStruct = resp.InfoStruct
+	if uint32(resp.Status) != msgsvc.StatusSuccess {
+		err = fmt.Errorf("NetrMessageNameGetInfo failed: %s", msgsvc.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/17fdd703-1827-4e34-79d4-24a55c53bb37/1.0/functions/03_NetrMessageNameDel.go
+++ b/network/dcerpc/interfaces/17fdd703-1827-4e34-79d4-24a55c53bb37/1.0/functions/03_NetrMessageNameDel.go
@@ -1,0 +1,39 @@
+package functions
+
+import (
+	"fmt"
+
+	msgsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/17fdd703-1827-4e34-79d4-24a55c53bb37/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// netrMessageNameDelRequest carries the [in] parameters of NetrMessageNameDel.
+type netrMessageNameDelRequest struct {
+	ServerName *ndr.WSTR `ndr:"unique"`
+	MsgName    ndr.WSTR
+}
+
+func (*netrMessageNameDelRequest) Opnum() uint16 { return msgsvc.OpnumNetrMessageNameDel }
+
+// netrMessageNameDelResponse carries the [out] parameters and return value of NetrMessageNameDel.
+type netrMessageNameDelResponse struct {
+	Status ndr.DWORD `ndr:"retval"`
+}
+
+// NetrMessageNameDel calls NetrMessageNameDel (opnum 3) ([MS-MSRP] — verify the parameter
+// modeling and status handling).
+func NetrMessageNameDel(rpc ndr.Invoker, serverName *ndr.WSTR, msgName ndr.WSTR) (err error) {
+	req := &netrMessageNameDelRequest{
+		ServerName: serverName,
+		MsgName:    msgName,
+	}
+	var resp netrMessageNameDelResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("NetrMessageNameDel: %w", err)
+		return
+	}
+	if uint32(resp.Status) != msgsvc.StatusSuccess {
+		err = fmt.Errorf("NetrMessageNameDel failed: %s", msgsvc.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/17fdd703-1827-4e34-79d4-24a55c53bb37/1.0/interface.go
+++ b/network/dcerpc/interfaces/17fdd703-1827-4e34-79d4-24a55c53bb37/1.0/interface.go
@@ -1,0 +1,116 @@
+// Package rpcinterface_17fdd70318274e3479d424a55c53bb37_1_0 is the descriptor for the msgsvc RPC interface, abstract
+// syntax 17fdd703-1827-4e34-79d4-24a55c53bb37 version 1.0 ([MS-MSRP]).
+//
+// The PipeName, the NET_API_STATUS code table, and doc comments are not derivable
+// from the IDL and were filled in by hand from [MS-MSRP] and [MS-ERREF].
+package rpcinterface_17fdd70318274e3479d424a55c53bb37_1_0
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+)
+
+// PipeName is the IPC$-relative named pipe for the msgsvc interface. The message-name
+// management methods use RPC over Named Pipes (ncacn_np); [MS-MSRP] 2.1 mandates the
+// pipe \PIPE\MSGSVC.
+const PipeName = `\msgsvc`
+
+// Opnums for the on-the-wire methods ([MS-MSRP] 3.1.4).
+const (
+	OpnumNetrMessageNameAdd     uint16 = 0
+	OpnumNetrMessageNameEnum    uint16 = 1
+	OpnumNetrMessageNameGetInfo uint16 = 2
+	OpnumNetrMessageNameDel     uint16 = 3
+)
+
+// NET_API_STATUS codes returned by this interface ([MS-MSRP] 3.1.4, [MS-ERREF],
+// lmerr.h). NERR_* values are relative to NERR_BASE (2100 / 0x834).
+const (
+	StatusSuccess         uint32 = 0x00000000 // NERR_Success / ERROR_SUCCESS
+	ErrorAccessDenied     uint32 = 0x00000005 // ERROR_ACCESS_DENIED
+	ErrorNotEnoughMemory  uint32 = 0x00000008 // ERROR_NOT_ENOUGH_MEMORY
+	ErrorInvalidParameter uint32 = 0x00000057 // ERROR_INVALID_PARAMETER
+	ErrorInvalidName      uint32 = 0x0000007B // ERROR_INVALID_NAME
+	ErrorInvalidLevel     uint32 = 0x0000007C // ERROR_INVALID_LEVEL
+	NerrBufTooSmall       uint32 = 0x0000084B // NERR_BufTooSmall
+	NerrNetworkError      uint32 = 0x00000858 // NERR_NetworkError
+	NerrInternalError     uint32 = 0x0000085C // NERR_InternalError
+	NerrAlreadyExists     uint32 = 0x000008E4 // NERR_AlreadyExists
+	NerrTooManyNames      uint32 = 0x000008E5 // NERR_TooManyNames
+	NerrDelComputerName   uint32 = 0x000008E6 // NERR_DelComputerName
+	NerrNameInUse         uint32 = 0x000008EB // NERR_NameInUse
+	NerrNotLocalName      uint32 = 0x000008ED // NERR_NotLocalName
+	NerrDuplicateName     uint32 = 0x000008F9 // NERR_DuplicateName
+	NerrIncompleteDel     uint32 = 0x000008FB // NERR_IncompleteDel
+)
+
+// SyntaxID returns the msgsvc abstract syntax identifier:
+// 17fdd703-1827-4e34-79d4-24a55c53bb37, version 1.0.
+func SyntaxID() syntax.SyntaxID {
+	return syntax.SyntaxID{
+		UUID:         guid.GUID{A: 0x17fdd703, B: 0x1827, C: 0x4e34, D: 0x79d4, E: 0x24a55c53bb37},
+		MajorVersion: 1,
+		MinorVersion: 0,
+	}
+}
+
+// StatusString returns a mnemonic for the documented status codes, otherwise the
+// hex value.
+func StatusString(status uint32) string {
+	switch status {
+	case StatusSuccess:
+		return "NERR_Success"
+	case ErrorAccessDenied:
+		return "ERROR_ACCESS_DENIED"
+	case ErrorNotEnoughMemory:
+		return "ERROR_NOT_ENOUGH_MEMORY"
+	case ErrorInvalidParameter:
+		return "ERROR_INVALID_PARAMETER"
+	case ErrorInvalidName:
+		return "ERROR_INVALID_NAME"
+	case ErrorInvalidLevel:
+		return "ERROR_INVALID_LEVEL"
+	case NerrBufTooSmall:
+		return "NERR_BufTooSmall"
+	case NerrNetworkError:
+		return "NERR_NetworkError"
+	case NerrInternalError:
+		return "NERR_InternalError"
+	case NerrAlreadyExists:
+		return "NERR_AlreadyExists"
+	case NerrTooManyNames:
+		return "NERR_TooManyNames"
+	case NerrDelComputerName:
+		return "NERR_DelComputerName"
+	case NerrNameInUse:
+		return "NERR_NameInUse"
+	case NerrNotLocalName:
+		return "NERR_NotLocalName"
+	case NerrDuplicateName:
+		return "NERR_DuplicateName"
+	case NerrIncompleteDel:
+		return "NERR_IncompleteDel"
+	default:
+		return fmt.Sprintf("0x%08x", status)
+	}
+}
+
+// OpnumToName maps each on-the-wire opnum to its method name; the single source of
+// truth.
+var OpnumToName = map[uint16]string{
+	OpnumNetrMessageNameAdd:     "NetrMessageNameAdd",
+	OpnumNetrMessageNameEnum:    "NetrMessageNameEnum",
+	OpnumNetrMessageNameGetInfo: "NetrMessageNameGetInfo",
+	OpnumNetrMessageNameDel:     "NetrMessageNameDel",
+}
+
+// NameToOpnum is the reverse of OpnumToName, built at init so the two never drift.
+var NameToOpnum = func() map[string]uint16 {
+	m := make(map[string]uint16, len(OpnumToName))
+	for op, name := range OpnumToName {
+		m[name] = op
+	}
+	return m
+}()

--- a/network/dcerpc/interfaces/17fdd703-1827-4e34-79d4-24a55c53bb37/1.0/interface_test.go
+++ b/network/dcerpc/interfaces/17fdd703-1827-4e34-79d4-24a55c53bb37/1.0/interface_test.go
@@ -1,0 +1,49 @@
+package rpcinterface_17fdd70318274e3479d424a55c53bb37_1_0
+
+import "testing"
+
+// TestSyntaxID verifies the abstract syntax identity (UUID + version).
+func TestSyntaxID(t *testing.T) {
+	s := SyntaxID()
+	if got := s.UUID.ToFormatD(); got != "17fdd703-1827-4e34-79d4-24a55c53bb37" {
+		t.Fatalf("UUID = %s, want 17fdd703-1827-4e34-79d4-24a55c53bb37", got)
+	}
+	if s.MajorVersion != 1 || s.MinorVersion != 0 {
+		t.Fatalf("version = %d.%d, want 1.0", s.MajorVersion, s.MinorVersion)
+	}
+}
+
+// TestOpnums verifies the four opnums and their name mappings round-trip.
+func TestOpnums(t *testing.T) {
+	want := map[uint16]string{
+		0: "NetrMessageNameAdd",
+		1: "NetrMessageNameEnum",
+		2: "NetrMessageNameGetInfo",
+		3: "NetrMessageNameDel",
+	}
+	for op, name := range want {
+		if OpnumToName[op] != name || NameToOpnum[name] != op {
+			t.Errorf("opnum %d <-> %q mapping is inconsistent", op, name)
+		}
+	}
+	if len(OpnumToName) != len(NameToOpnum) || len(OpnumToName) != len(want) {
+		t.Fatalf("map sizes differ: OpnumToName=%d NameToOpnum=%d want=%d", len(OpnumToName), len(NameToOpnum), len(want))
+	}
+}
+
+// TestStatusString verifies mnemonic rendering of documented codes and the hex fallback.
+func TestStatusString(t *testing.T) {
+	cases := map[uint32]string{
+		StatusSuccess:     "NERR_Success",
+		ErrorAccessDenied: "ERROR_ACCESS_DENIED",
+		ErrorInvalidLevel: "ERROR_INVALID_LEVEL",
+		NerrBufTooSmall:   "NERR_BufTooSmall",
+		NerrIncompleteDel: "NERR_IncompleteDel",
+		0xdeadbeef:        "0xdeadbeef",
+	}
+	for code, want := range cases {
+		if got := StatusString(code); got != want {
+			t.Errorf("StatusString(0x%08x) = %q, want %q", code, got, want)
+		}
+	}
+}

--- a/network/dcerpc/interfaces/5a7b91f8-ff00-11d0-a9b2-00c04fb6e6fc/1.0/functions/00_NetrSendMessage.go
+++ b/network/dcerpc/interfaces/5a7b91f8-ff00-11d0-a9b2-00c04fb6e6fc/1.0/functions/00_NetrSendMessage.go
@@ -1,0 +1,48 @@
+package functions
+
+import (
+	"fmt"
+
+	msgsvcsend "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/5a7b91f8-ff00-11d0-a9b2-00c04fb6e6fc/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// netrSendMessageRequest carries the [in] parameters of NetrSendMessage.
+//
+// From/To/Text are [in, string] LPSTR (char*) — OEM-charset ASCII strings
+// ([MS-MSRP] 3.2.4.1), so each is an ndr.STR, not an ndr.WSTR. They have no explicit
+// pointer attribute, so as top-level [ref] string parameters they are transmitted
+// inline (no referent id). hRpcBinding is an explicit primitive binding handle
+// (handle_t) and is not marshalled, so it is absent from this struct.
+type netrSendMessageRequest struct {
+	From ndr.STR
+	To   ndr.STR
+	Text ndr.STR
+}
+
+func (*netrSendMessageRequest) Opnum() uint16 { return msgsvcsend.OpnumNetrSendMessage }
+
+// netrSendMessageResponse carries the return value of NetrSendMessage. NetrSendMessage
+// has no [out] parameters; error_status_t is the only result.
+type netrSendMessageResponse struct {
+	Status ndr.DWORD `ndr:"retval"`
+}
+
+// NetrSendMessage calls NetrSendMessage (opnum 0), sending a text message to a message
+// server ([MS-MSRP] 3.2.4.1). From, To and Text are OEM-charset strings.
+func NetrSendMessage(rpc ndr.Invoker, from ndr.STR, to ndr.STR, text ndr.STR) (err error) {
+	req := &netrSendMessageRequest{
+		From: from,
+		To:   to,
+		Text: text,
+	}
+	var resp netrSendMessageResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("NetrSendMessage: %w", err)
+		return
+	}
+	if uint32(resp.Status) != msgsvcsend.StatusSuccess {
+		err = fmt.Errorf("NetrSendMessage failed: %s", msgsvcsend.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/5a7b91f8-ff00-11d0-a9b2-00c04fb6e6fc/1.0/interface.go
+++ b/network/dcerpc/interfaces/5a7b91f8-ff00-11d0-a9b2-00c04fb6e6fc/1.0/interface.go
@@ -1,0 +1,101 @@
+// Package rpcinterface_5a7b91f8ff0011d0a9b200c04fb6e6fc_1_0 is the descriptor for the msgsvcsend RPC interface, abstract
+// syntax 5a7b91f8-ff00-11d0-a9b2-00c04fb6e6fc version 1.0 ([MS-MSRP]).
+//
+// The PipeName, the NET_API_STATUS code table, and doc comments are not derivable
+// from the IDL and were filled in by hand from [MS-MSRP] and [MS-ERREF].
+package rpcinterface_5a7b91f8ff0011d0a9b200c04fb6e6fc_1_0
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+)
+
+// PipeName is the IPC$-relative named pipe for the msgsvcsend interface. The primary
+// transport for NetrSendMessage is RPC over UDP (ncadg_ip_udp) with dynamic endpoints;
+// when RPC over Named Pipes (ncacn_np) is used, [MS-MSRP] 2.1 mandates \PIPE\MSGSVC.
+const PipeName = `\msgsvc`
+
+// Opnums for the on-the-wire methods ([MS-MSRP] 3.2.4).
+const (
+	OpnumNetrSendMessage uint16 = 0
+)
+
+// NET_API_STATUS / error_status_t codes returned by this interface ([MS-MSRP] 3.2.4.1,
+// [MS-ERREF], lmerr.h). NERR_* values are relative to NERR_BASE (2100 / 0x834).
+const (
+	StatusSuccess          uint32 = 0x00000000 // ERROR_SUCCESS
+	ErrorAccessDenied      uint32 = 0x00000005 // ERROR_ACCESS_DENIED
+	ErrorNotSupported      uint32 = 0x00000032 // ERROR_NOT_SUPPORTED
+	ErrorInvalidParameter  uint32 = 0x00000057 // ERROR_INVALID_PARAMETER
+	NerrNetworkError       uint32 = 0x00000858 // NERR_NetworkError
+	NerrNameNotFound       uint32 = 0x000008E1 // NERR_NameNotFound
+	NerrGrpMsgProcessor    uint32 = 0x000008E8 // NERR_GrpMsgProcessor
+	NerrPausedRemote       uint32 = 0x000008E9 // NERR_PausedRemote
+	NerrBadReceive         uint32 = 0x000008EA // NERR_BadReceive
+	NerrNameInUse          uint32 = 0x000008EB // NERR_NameInUse
+	NerrNotLocalName       uint32 = 0x000008ED // NERR_NotLocalName
+	NerrTruncatedBroadcast uint32 = 0x000008F1 // NERR_TruncatedBroadcast
+	NerrDuplicateName      uint32 = 0x000008F9 // NERR_DuplicateName
+)
+
+// SyntaxID returns the msgsvcsend abstract syntax identifier:
+// 5a7b91f8-ff00-11d0-a9b2-00c04fb6e6fc, version 1.0.
+func SyntaxID() syntax.SyntaxID {
+	return syntax.SyntaxID{
+		UUID:         guid.GUID{A: 0x5a7b91f8, B: 0xff00, C: 0x11d0, D: 0xa9b2, E: 0x00c04fb6e6fc},
+		MajorVersion: 1,
+		MinorVersion: 0,
+	}
+}
+
+// StatusString returns a mnemonic for the documented status codes, otherwise the
+// hex value.
+func StatusString(status uint32) string {
+	switch status {
+	case StatusSuccess:
+		return "ERROR_SUCCESS"
+	case ErrorAccessDenied:
+		return "ERROR_ACCESS_DENIED"
+	case ErrorNotSupported:
+		return "ERROR_NOT_SUPPORTED"
+	case ErrorInvalidParameter:
+		return "ERROR_INVALID_PARAMETER"
+	case NerrNetworkError:
+		return "NERR_NetworkError"
+	case NerrNameNotFound:
+		return "NERR_NameNotFound"
+	case NerrGrpMsgProcessor:
+		return "NERR_GrpMsgProcessor"
+	case NerrPausedRemote:
+		return "NERR_PausedRemote"
+	case NerrBadReceive:
+		return "NERR_BadReceive"
+	case NerrNameInUse:
+		return "NERR_NameInUse"
+	case NerrNotLocalName:
+		return "NERR_NotLocalName"
+	case NerrTruncatedBroadcast:
+		return "NERR_TruncatedBroadcast"
+	case NerrDuplicateName:
+		return "NERR_DuplicateName"
+	default:
+		return fmt.Sprintf("0x%08x", status)
+	}
+}
+
+// OpnumToName maps each on-the-wire opnum to its method name; the single source of
+// truth.
+var OpnumToName = map[uint16]string{
+	OpnumNetrSendMessage: "NetrSendMessage",
+}
+
+// NameToOpnum is the reverse of OpnumToName, built at init so the two never drift.
+var NameToOpnum = func() map[string]uint16 {
+	m := make(map[string]uint16, len(OpnumToName))
+	for op, name := range OpnumToName {
+		m[name] = op
+	}
+	return m
+}()

--- a/network/dcerpc/interfaces/5a7b91f8-ff00-11d0-a9b2-00c04fb6e6fc/1.0/interface_test.go
+++ b/network/dcerpc/interfaces/5a7b91f8-ff00-11d0-a9b2-00c04fb6e6fc/1.0/interface_test.go
@@ -1,0 +1,43 @@
+package rpcinterface_5a7b91f8ff0011d0a9b200c04fb6e6fc_1_0
+
+import "testing"
+
+// TestSyntaxID verifies the abstract syntax identity (UUID + version).
+func TestSyntaxID(t *testing.T) {
+	s := SyntaxID()
+	if got := s.UUID.ToFormatD(); got != "5a7b91f8-ff00-11d0-a9b2-00c04fb6e6fc" {
+		t.Fatalf("UUID = %s, want 5a7b91f8-ff00-11d0-a9b2-00c04fb6e6fc", got)
+	}
+	if s.MajorVersion != 1 || s.MinorVersion != 0 {
+		t.Fatalf("version = %d.%d, want 1.0", s.MajorVersion, s.MinorVersion)
+	}
+}
+
+// TestOpnums verifies the single opnum and its name mapping round-trips.
+func TestOpnums(t *testing.T) {
+	if OpnumNetrSendMessage != 0 {
+		t.Fatalf("OpnumNetrSendMessage = %d, want 0", OpnumNetrSendMessage)
+	}
+	if OpnumToName[0] != "NetrSendMessage" || NameToOpnum["NetrSendMessage"] != 0 {
+		t.Fatal("opnum name mapping is inconsistent")
+	}
+	if len(OpnumToName) != len(NameToOpnum) {
+		t.Fatalf("map sizes differ: %d vs %d", len(OpnumToName), len(NameToOpnum))
+	}
+}
+
+// TestStatusString verifies mnemonic rendering of documented codes and the hex fallback.
+func TestStatusString(t *testing.T) {
+	cases := map[uint32]string{
+		StatusSuccess:     "ERROR_SUCCESS",
+		ErrorAccessDenied: "ERROR_ACCESS_DENIED",
+		NerrNetworkError:  "NERR_NetworkError",
+		NerrDuplicateName: "NERR_DuplicateName",
+		0xdeadbeef:        "0xdeadbeef",
+	}
+	for code, want := range cases {
+		if got := StatusString(code); got != want {
+			t.Errorf("StatusString(0x%08x) = %q, want %q", code, got, want)
+		}
+	}
+}

--- a/windows/protocols/ms-msrp/MSG_ENUM_STRUCT.go
+++ b/windows/protocols/ms-msrp/MSG_ENUM_STRUCT.go
@@ -1,0 +1,23 @@
+package msmsrp
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// MSG_ENUM_STRUCT is the [in,out] enumeration buffer of NetrMessageNameEnum
+// ([MS-MSRP] 2.2.2.5). Level selects the MSG_ENUM_UNION arm; the union carries its own
+// inline discriminant (Tag), which callers must set equal to Level before marshalling.
+type MSG_ENUM_STRUCT struct {
+	Level   ndr.DWORD
+	MsgInfo MSG_ENUM_UNION
+}
+
+// MSG_ENUM_UNION is the [switch_is(Level)] union embedded in MSG_ENUM_STRUCT
+// ([MS-MSRP] 2.2.2). The discriminant precedes the selected arm ([C706] 14.3.8). The
+// arms are LPMSG_INFO_*_CONTAINER in the IDL (pointers to the container under
+// pointer_default(unique)), so each is modeled as a unique pointer.
+type MSG_ENUM_UNION struct {
+	Tag    ndr.DWORD             `ndr:"switch"`
+	Level0 *MSG_INFO_0_CONTAINER `ndr:"case=0,unique"`
+	Level1 *MSG_INFO_1_CONTAINER `ndr:"case=1,unique"`
+}

--- a/windows/protocols/ms-msrp/MSG_INFO.go
+++ b/windows/protocols/ms-msrp/MSG_INFO.go
@@ -1,0 +1,15 @@
+package msmsrp
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// MSG_INFO is the [switch_type(DWORD)] union returned by NetrMessageNameGetInfo
+// ([MS-MSRP] 2.2.2). The discriminant precedes the selected arm ([C706] 14.3.8). The
+// arms are LPMSG_INFO_0/LPMSG_INFO_1 in the IDL (pointers under
+// pointer_default(unique)), so each is modeled as a unique pointer.
+type MSG_INFO struct {
+	Tag      ndr.DWORD   `ndr:"switch"`
+	MsgInfo0 *MSG_INFO_0 `ndr:"case=0,unique"`
+	MsgInfo1 *MSG_INFO_1 `ndr:"case=1,unique"`
+}

--- a/windows/protocols/ms-msrp/MSG_INFO_0.go
+++ b/windows/protocols/ms-msrp/MSG_INFO_0.go
@@ -1,0 +1,11 @@
+package msmsrp
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// MSG_INFO_0 holds a single message alias name ([MS-MSRP] 2.2.2.1). msgi0_name is a
+// [string] wchar_t* (unique under pointer_default(unique)).
+type MSG_INFO_0 struct {
+	Msgi0_name *ndr.WSTR `ndr:"unique"`
+}

--- a/windows/protocols/ms-msrp/MSG_INFO_0_CONTAINER.go
+++ b/windows/protocols/ms-msrp/MSG_INFO_0_CONTAINER.go
@@ -1,0 +1,13 @@
+package msmsrp
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// MSG_INFO_0_CONTAINER is a count-prefixed array of MSG_INFO_0 ([MS-MSRP] 2.2.2.3).
+// Buffer is [size_is(EntriesRead)] LPMSG_INFO_0 — a unique pointer to a conformant
+// array, so it is modeled as a unique slice sized by EntriesRead.
+type MSG_INFO_0_CONTAINER struct {
+	EntriesRead ndr.DWORD
+	Buffer      []MSG_INFO_0 `ndr:"unique,size_is=EntriesRead"`
+}

--- a/windows/protocols/ms-msrp/MSG_INFO_1.go
+++ b/windows/protocols/ms-msrp/MSG_INFO_1.go
@@ -1,0 +1,13 @@
+package msmsrp
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// MSG_INFO_1 holds a message alias name plus its message-forwarding configuration
+// ([MS-MSRP] 2.2.2.2). The name/forward fields are [string] wchar_t* (unique).
+type MSG_INFO_1 struct {
+	Msgi1_name         *ndr.WSTR `ndr:"unique"`
+	Msgi1_forward_flag ndr.DWORD
+	Msgi1_forward      *ndr.WSTR `ndr:"unique"`
+}

--- a/windows/protocols/ms-msrp/MSG_INFO_1_CONTAINER.go
+++ b/windows/protocols/ms-msrp/MSG_INFO_1_CONTAINER.go
@@ -1,0 +1,13 @@
+package msmsrp
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// MSG_INFO_1_CONTAINER is a count-prefixed array of MSG_INFO_1 ([MS-MSRP] 2.2.2.4).
+// Buffer is [size_is(EntriesRead)] LPMSG_INFO_1 — a unique pointer to a conformant
+// array, so it is modeled as a unique slice sized by EntriesRead.
+type MSG_INFO_1_CONTAINER struct {
+	EntriesRead ndr.DWORD
+	Buffer      []MSG_INFO_1 `ndr:"unique,size_is=EntriesRead"`
+}

--- a/windows/protocols/ms-msrp/structures_test.go
+++ b/windows/protocols/ms-msrp/structures_test.go
@@ -1,0 +1,106 @@
+package msmsrp
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// roundTrip marshals in, unmarshals into a fresh value of the same type, and asserts
+// the result is deeply equal to in. This is the wire-shape acceptance gate for the
+// MS-MSRP NDR structures in the absence of a live Messenger service.
+func roundTrip[T any](t *testing.T, name string, in T) {
+	t.Helper()
+	raw, err := ndr.Marshal(&in)
+	if err != nil {
+		t.Fatalf("%s: Marshal: %v", name, err)
+	}
+	var out T
+	if err := ndr.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("%s: Unmarshal: %v", name, err)
+	}
+	if !reflect.DeepEqual(in, out) {
+		t.Errorf("%s: round trip mismatch:\n in:  %+v\n out: %+v", name, in, out)
+	}
+}
+
+func wstr(s string) *ndr.WSTR { w := ndr.WSTR(s); return &w }
+
+// TestMSG_INFO_0 covers the single [unique,string] wchar_t* name, present and null.
+func TestMSG_INFO_0(t *testing.T) {
+	roundTrip(t, "MSG_INFO_0/name", MSG_INFO_0{Msgi0_name: wstr("ALICE")})
+	roundTrip(t, "MSG_INFO_0/null", MSG_INFO_0{})
+}
+
+// TestMSG_INFO_1 covers two [unique,string] arms plus the forward flag.
+func TestMSG_INFO_1(t *testing.T) {
+	roundTrip(t, "MSG_INFO_1/full", MSG_INFO_1{
+		Msgi1_name:         wstr("ALICE"),
+		Msgi1_forward_flag: 1,
+		Msgi1_forward:      wstr("BOB"),
+	})
+	roundTrip(t, "MSG_INFO_1/no-forward", MSG_INFO_1{Msgi1_name: wstr("ALICE")})
+	roundTrip(t, "MSG_INFO_1/null", MSG_INFO_1{})
+}
+
+// TestMSG_INFO_0_CONTAINER covers the [unique] pointer to a conformant array of
+// pointer-bearing structs, plus the empty and null-buffer shapes.
+func TestMSG_INFO_0_CONTAINER(t *testing.T) {
+	roundTrip(t, "MSG_INFO_0_CONTAINER/two", MSG_INFO_0_CONTAINER{
+		EntriesRead: 2,
+		Buffer:      []MSG_INFO_0{{Msgi0_name: wstr("ALICE")}, {Msgi0_name: wstr("BOB")}},
+	})
+	roundTrip(t, "MSG_INFO_0_CONTAINER/empty", MSG_INFO_0_CONTAINER{EntriesRead: 0, Buffer: []MSG_INFO_0{}})
+}
+
+// TestMSG_INFO_1_CONTAINER mirrors the Level-1 container.
+func TestMSG_INFO_1_CONTAINER(t *testing.T) {
+	roundTrip(t, "MSG_INFO_1_CONTAINER/one", MSG_INFO_1_CONTAINER{
+		EntriesRead: 1,
+		Buffer: []MSG_INFO_1{{
+			Msgi1_name:         wstr("ALICE"),
+			Msgi1_forward_flag: 0,
+			Msgi1_forward:      nil,
+		}},
+	})
+	roundTrip(t, "MSG_INFO_1_CONTAINER/empty", MSG_INFO_1_CONTAINER{EntriesRead: 0, Buffer: []MSG_INFO_1{}})
+}
+
+// TestMSG_ENUM_STRUCT exercises the [switch_is(Level)] union across both arms; the
+// inline union Tag is set to match Level, as a caller must do before marshalling.
+func TestMSG_ENUM_STRUCT(t *testing.T) {
+	roundTrip(t, "MSG_ENUM_STRUCT/level0", MSG_ENUM_STRUCT{
+		Level: 0,
+		MsgInfo: MSG_ENUM_UNION{
+			Tag: 0,
+			Level0: &MSG_INFO_0_CONTAINER{
+				EntriesRead: 1,
+				Buffer:      []MSG_INFO_0{{Msgi0_name: wstr("ALICE")}},
+			},
+		},
+	})
+	roundTrip(t, "MSG_ENUM_STRUCT/level1", MSG_ENUM_STRUCT{
+		Level: 1,
+		MsgInfo: MSG_ENUM_UNION{
+			Tag: 1,
+			Level1: &MSG_INFO_1_CONTAINER{
+				EntriesRead: 1,
+				Buffer:      []MSG_INFO_1{{Msgi1_name: wstr("BOB"), Msgi1_forward_flag: 1, Msgi1_forward: wstr("CAROL")}},
+			},
+		},
+	})
+}
+
+// TestMSG_INFO exercises the [switch_type(DWORD)] union returned by
+// NetrMessageNameGetInfo across both arms.
+func TestMSG_INFO(t *testing.T) {
+	roundTrip(t, "MSG_INFO/level0", MSG_INFO{
+		Tag:      0,
+		MsgInfo0: &MSG_INFO_0{Msgi0_name: wstr("ALICE")},
+	})
+	roundTrip(t, "MSG_INFO/level1", MSG_INFO{
+		Tag:      1,
+		MsgInfo1: &MSG_INFO_1{Msgi1_name: wstr("ALICE"), Msgi1_forward_flag: 1, Msgi1_forward: wstr("BOB")},
+	})
+}


### PR DESCRIPTION
### Linked Issue
Closes #810

### What this adds
Client implementations of the two DCE/RPC interfaces of the Messenger Service Remote Protocol ([MS-MSRP]):

- **msgsvcsend** — abstract syntax `5a7b91f8-ff00-11d0-a9b2-00c04fb6e6fc` v1.0
  - `NetrSendMessage` (opnum 0)
- **msgsvc** — abstract syntax `17fdd703-1827-4e34-79d4-24a55c53bb37` v1.0
  - `NetrMessageNameAdd` (0), `NetrMessageNameEnum` (1), `NetrMessageNameGetInfo` (2), `NetrMessageNameDel` (3)

### Layout
Follows the project's split layout:
- **Interface tree** — descriptors + per-opnum method stubs under `network/dcerpc/interfaces/<uuid>/1.0/` (`interface.go`, `functions/NN_*.go`), each with the opnum map, `SyntaxID`, `PipeName`, and a `NET_API_STATUS` code table + `StatusString` populated from [MS-MSRP] / [MS-ERREF].
- **Structures** — the shared NDR wire types in `windows/protocols/ms-msrp/` (`package msmsrp`): `MSG_INFO_0`, `MSG_INFO_1`, `MSG_INFO_0_CONTAINER`, `MSG_INFO_1_CONTAINER`, the `MSG_ENUM_STRUCT` (`switch_is(Level)`) union, and the `MSG_INFO` (`switch_type(DWORD)`) union.

### NDR modeling notes
- `NetrSendMessage`'s `From`/`To`/`Text` are `[in,string] LPSTR` — OEM-charset ASCII strings, modeled as `ndr.STR` (not `ndr.WSTR`); the explicit `handle_t hRpcBinding` is not marshalled.
- `msgsvc` server-name params are `[handle] wchar_t*` `[unique]` wide strings; `MsgName` is a top-level `[ref]` wide string (inline).
- The container `Buffer` fields are `[size_is(EntriesRead)]` unique pointers to conformant arrays (`[]MSG_INFO_x` with `ndr:"unique,size_is=EntriesRead"`).
- Union arms are `LP*` in the IDL, so each is modeled as a unique pointer (`ndr:"case=N,unique"`); discriminants are 4-byte `ndr.DWORD`.

### How verified
- `gofmt -l` clean; `go build`, `go vet`, `go test -count=1` all pass over both the interface trees and `windows/protocols/ms-msrp`.
- 32-bit and arm64 cross-compiles (`GOARCH=386`/`arm64 go build ./...`) succeed; `go build -tags integration` succeeds.
- Structure round-trip tests (`ndr.Marshal`→`Unmarshal`→`DeepEqual`) cover every info struct, both containers, and both unions across their arms; descriptor tests cover `SyntaxID`, the opnum⇄name maps, and `StatusString`.

### Test Coverage
**Added:** `windows/protocols/ms-msrp/structures_test.go` (round-trips) and `interface_test.go` in each interface package (descriptor tests).

### Scope of Change
- **Files changed:** 16 new files under the two interface UUIDs and `windows/protocols/ms-msrp/`.
- **Behavioral changes outside the new interfaces:** none.

### Notes
Go-level round-trip tests pass; live validation against a Windows Messenger service (disabled by default since Windows Server 2003 SP1 / XP SP2) is the real acceptance gate for the union double-discriminant wire shape and is not exercised here.
