### PR TITLE
Add Print System Asynchronous Notification Protocol (MS-PAN) IRPCAsyncNotify and IRPCRemoteObject client interfaces (Fixes #816)

### DIFF
--- a/network/dcerpc/interfaces/0b6edbfa-4a24-4fc6-8a23-942b1eca65d1/1.0/functions/00_IRPCAsyncNotify_RegisterClient.go
+++ b/network/dcerpc/interfaces/0b6edbfa-4a24-4fc6-8a23-942b1eca65d1/1.0/functions/00_IRPCAsyncNotify_RegisterClient.go
@@ -1,0 +1,60 @@
+package functions
+
+import (
+	"fmt"
+
+	IRPCAsyncNotify "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/0b6edbfa-4a24-4fc6-8a23-942b1eca65d1/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	mspan "github.com/TheManticoreProject/Manticore/windows/protocols/ms-pan"
+)
+
+// iRPCAsyncNotify_RegisterClientRequest carries the [in] parameters of IRPCAsyncNotify_RegisterClient.
+//
+// pRegistrationObj is a by-value context handle. pName is an optional ([unique])
+// UTF-16LE print-queue UNC name; pInNotificationType is a required (top-level [ref])
+// pointer to a notification-type GUID, so it is carried inline. NotifyFilter and
+// conversationStyle are 32-bit [v1_enum] values.
+type iRPCAsyncNotify_RegisterClientRequest struct {
+	PRegistrationObj    mspan.PRPCREMOTEOBJECT
+	PName               *ndr.WSTR `ndr:"unique"`
+	PInNotificationType mspan.PrintAsyncNotificationType
+	NotifyFilter        mspan.PrintAsyncNotifyUserFilter
+	ConversationStyle   mspan.PrintAsyncNotifyConversationStyle
+}
+
+func (*iRPCAsyncNotify_RegisterClientRequest) Opnum() uint16 {
+	return IRPCAsyncNotify.OpnumIRPCAsyncNotify_RegisterClient
+}
+
+// iRPCAsyncNotify_RegisterClientResponse carries the [out] parameter and HRESULT of
+// IRPCAsyncNotify_RegisterClient. ppRmtServerReferral is a [string] wchar_t** ([out]);
+// servers SHOULD return NULL and clients MUST ignore it, so it is a [unique] string
+// pointer that is normally nil.
+type iRPCAsyncNotify_RegisterClientResponse struct {
+	PpRmtServerReferral *ndr.WSTR `ndr:"unique"`
+	Status              ndr.DWORD `ndr:"retval"`
+}
+
+// IRPCAsyncNotify_RegisterClient calls IRPCAsyncNotify_RegisterClient (opnum 0)
+// ([MS-PAN] 3.1.4.1). It registers the client for the given notification type, user
+// filter, and conversation style against a remote object obtained from
+// IRPCRemoteObject_Create.
+func IRPCAsyncNotify_RegisterClient(rpc ndr.Invoker, pRegistrationObj mspan.PRPCREMOTEOBJECT, pName *ndr.WSTR, pInNotificationType mspan.PrintAsyncNotificationType, notifyFilter mspan.PrintAsyncNotifyUserFilter, conversationStyle mspan.PrintAsyncNotifyConversationStyle) (PpRmtServerReferral *ndr.WSTR, err error) {
+	req := &iRPCAsyncNotify_RegisterClientRequest{
+		PRegistrationObj:    pRegistrationObj,
+		PName:               pName,
+		PInNotificationType: pInNotificationType,
+		NotifyFilter:        notifyFilter,
+		ConversationStyle:   conversationStyle,
+	}
+	var resp iRPCAsyncNotify_RegisterClientResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("IRPCAsyncNotify_RegisterClient: %w", err)
+		return
+	}
+	PpRmtServerReferral = resp.PpRmtServerReferral
+	if uint32(resp.Status) != IRPCAsyncNotify.StatusSuccess {
+		err = fmt.Errorf("IRPCAsyncNotify_RegisterClient failed: %s", IRPCAsyncNotify.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/0b6edbfa-4a24-4fc6-8a23-942b1eca65d1/1.0/functions/01_IRPCAsyncNotify_UnregisterClient.go
+++ b/network/dcerpc/interfaces/0b6edbfa-4a24-4fc6-8a23-942b1eca65d1/1.0/functions/01_IRPCAsyncNotify_UnregisterClient.go
@@ -1,0 +1,41 @@
+package functions
+
+import (
+	"fmt"
+
+	IRPCAsyncNotify "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/0b6edbfa-4a24-4fc6-8a23-942b1eca65d1/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	mspan "github.com/TheManticoreProject/Manticore/windows/protocols/ms-pan"
+)
+
+// iRPCAsyncNotify_UnregisterClientRequest carries the [in] parameters of IRPCAsyncNotify_UnregisterClient.
+type iRPCAsyncNotify_UnregisterClientRequest struct {
+	PRegistrationObj mspan.PRPCREMOTEOBJECT
+}
+
+func (*iRPCAsyncNotify_UnregisterClientRequest) Opnum() uint16 {
+	return IRPCAsyncNotify.OpnumIRPCAsyncNotify_UnregisterClient
+}
+
+// iRPCAsyncNotify_UnregisterClientResponse carries the [out] parameters and return value of IRPCAsyncNotify_UnregisterClient.
+type iRPCAsyncNotify_UnregisterClientResponse struct {
+	Status ndr.DWORD `ndr:"retval"`
+}
+
+// IRPCAsyncNotify_UnregisterClient calls IRPCAsyncNotify_UnregisterClient (opnum 1)
+// ([MS-PAN] 3.1.4.2). It cancels a prior successful registration for the given remote
+// object.
+func IRPCAsyncNotify_UnregisterClient(rpc ndr.Invoker, pRegistrationObj mspan.PRPCREMOTEOBJECT) (err error) {
+	req := &iRPCAsyncNotify_UnregisterClientRequest{
+		PRegistrationObj: pRegistrationObj,
+	}
+	var resp iRPCAsyncNotify_UnregisterClientResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("IRPCAsyncNotify_UnregisterClient: %w", err)
+		return
+	}
+	if uint32(resp.Status) != IRPCAsyncNotify.StatusSuccess {
+		err = fmt.Errorf("IRPCAsyncNotify_UnregisterClient failed: %s", IRPCAsyncNotify.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/0b6edbfa-4a24-4fc6-8a23-942b1eca65d1/1.0/functions/03_IRPCAsyncNotify_GetNewChannel.go
+++ b/network/dcerpc/interfaces/0b6edbfa-4a24-4fc6-8a23-942b1eca65d1/1.0/functions/03_IRPCAsyncNotify_GetNewChannel.go
@@ -1,0 +1,48 @@
+package functions
+
+import (
+	"fmt"
+
+	IRPCAsyncNotify "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/0b6edbfa-4a24-4fc6-8a23-942b1eca65d1/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	mspan "github.com/TheManticoreProject/Manticore/windows/protocols/ms-pan"
+)
+
+// iRPCAsyncNotify_GetNewChannelRequest carries the [in] parameters of IRPCAsyncNotify_GetNewChannel.
+type iRPCAsyncNotify_GetNewChannelRequest struct {
+	PRemoteObj mspan.PRPCREMOTEOBJECT
+}
+
+func (*iRPCAsyncNotify_GetNewChannelRequest) Opnum() uint16 {
+	return IRPCAsyncNotify.OpnumIRPCAsyncNotify_GetNewChannel
+}
+
+// iRPCAsyncNotify_GetNewChannelResponse carries the [out] parameters and HRESULT of
+// IRPCAsyncNotify_GetNewChannel. ppChannelCtxt is [out, size_is( , *pNoOfChannels)]
+// PNOTIFYOBJECT**: the top-level [out] indirection, then a [unique] pointer to a
+// conformant array of PNoOfChannels context handles (each carried inline as 20 octets).
+type iRPCAsyncNotify_GetNewChannelResponse struct {
+	PNoOfChannels ndr.DWORD
+	PpChannelCtxt []mspan.PNOTIFYOBJECT `ndr:"unique,size_is=PNoOfChannels"`
+	Status        ndr.DWORD             `ndr:"retval"`
+}
+
+// IRPCAsyncNotify_GetNewChannel calls IRPCAsyncNotify_GetNewChannel (opnum 3)
+// ([MS-PAN] 3.1.4.3). For a bidirectional registration it returns one or more new
+// notification-channel context handles.
+func IRPCAsyncNotify_GetNewChannel(rpc ndr.Invoker, pRemoteObj mspan.PRPCREMOTEOBJECT) (PNoOfChannels ndr.DWORD, PpChannelCtxt []mspan.PNOTIFYOBJECT, err error) {
+	req := &iRPCAsyncNotify_GetNewChannelRequest{
+		PRemoteObj: pRemoteObj,
+	}
+	var resp iRPCAsyncNotify_GetNewChannelResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("IRPCAsyncNotify_GetNewChannel: %w", err)
+		return
+	}
+	PNoOfChannels = resp.PNoOfChannels
+	PpChannelCtxt = resp.PpChannelCtxt
+	if uint32(resp.Status) != IRPCAsyncNotify.StatusSuccess {
+		err = fmt.Errorf("IRPCAsyncNotify_GetNewChannel failed: %s", IRPCAsyncNotify.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/0b6edbfa-4a24-4fc6-8a23-942b1eca65d1/1.0/functions/04_IRPCAsyncNotify_GetNotificationSendResponse.go
+++ b/network/dcerpc/interfaces/0b6edbfa-4a24-4fc6-8a23-942b1eca65d1/1.0/functions/04_IRPCAsyncNotify_GetNotificationSendResponse.go
@@ -1,0 +1,60 @@
+package functions
+
+import (
+	"fmt"
+
+	IRPCAsyncNotify "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/0b6edbfa-4a24-4fc6-8a23-942b1eca65d1/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	mspan "github.com/TheManticoreProject/Manticore/windows/protocols/ms-pan"
+)
+
+// iRPCAsyncNotify_GetNotificationSendResponseRequest carries the [in]/[in,out] parameters
+// of IRPCAsyncNotify_GetNotificationSendResponse. pChannel is an [in,out] channel context
+// handle; pInNotificationData is [in, size_is(InSize), unique] byte* — a [unique] pointer
+// to a conformant byte array of InSize octets.
+type iRPCAsyncNotify_GetNotificationSendResponseRequest struct {
+	PChannel            mspan.PNOTIFYOBJECT
+	PInNotificationType *mspan.PrintAsyncNotificationType `ndr:"unique"`
+	InSize              ndr.DWORD
+	PInNotificationData []byte `ndr:"unique,size_is=InSize"`
+}
+
+func (*iRPCAsyncNotify_GetNotificationSendResponseRequest) Opnum() uint16 {
+	return IRPCAsyncNotify.OpnumIRPCAsyncNotify_GetNotificationSendResponse
+}
+
+// iRPCAsyncNotify_GetNotificationSendResponseResponse carries the [in,out]/[out] parameters
+// and HRESULT. ppOutNotificationData is [out, size_is( , *pOutSize)] byte**: the top-level
+// [out] indirection, then a [unique] pointer to a conformant array of POutSize octets.
+type iRPCAsyncNotify_GetNotificationSendResponseResponse struct {
+	PChannel              mspan.PNOTIFYOBJECT
+	PpOutNotificationType *mspan.PrintAsyncNotificationType `ndr:"unique"`
+	POutSize              ndr.DWORD
+	PpOutNotificationData []byte    `ndr:"unique,size_is=POutSize"`
+	Status                ndr.DWORD `ndr:"retval"`
+}
+
+// IRPCAsyncNotify_GetNotificationSendResponse calls IRPCAsyncNotify_GetNotificationSendResponse
+// (opnum 4) ([MS-PAN] 3.1.4.4). On a bidirectional channel it sends the client's response
+// data and blocks until the next notification (or channel closure) is returned.
+func IRPCAsyncNotify_GetNotificationSendResponse(rpc ndr.Invoker, pChannel mspan.PNOTIFYOBJECT, pInNotificationType *mspan.PrintAsyncNotificationType, inSize ndr.DWORD, pInNotificationData []byte) (PChannel mspan.PNOTIFYOBJECT, PpOutNotificationType *mspan.PrintAsyncNotificationType, POutSize ndr.DWORD, PpOutNotificationData []byte, err error) {
+	req := &iRPCAsyncNotify_GetNotificationSendResponseRequest{
+		PChannel:            pChannel,
+		PInNotificationType: pInNotificationType,
+		InSize:              inSize,
+		PInNotificationData: pInNotificationData,
+	}
+	var resp iRPCAsyncNotify_GetNotificationSendResponseResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("IRPCAsyncNotify_GetNotificationSendResponse: %w", err)
+		return
+	}
+	PChannel = resp.PChannel
+	PpOutNotificationType = resp.PpOutNotificationType
+	POutSize = resp.POutSize
+	PpOutNotificationData = resp.PpOutNotificationData
+	if uint32(resp.Status) != IRPCAsyncNotify.StatusSuccess {
+		err = fmt.Errorf("IRPCAsyncNotify_GetNotificationSendResponse failed: %s", IRPCAsyncNotify.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/0b6edbfa-4a24-4fc6-8a23-942b1eca65d1/1.0/functions/05_IRPCAsyncNotify_GetNotification.go
+++ b/network/dcerpc/interfaces/0b6edbfa-4a24-4fc6-8a23-942b1eca65d1/1.0/functions/05_IRPCAsyncNotify_GetNotification.go
@@ -1,0 +1,50 @@
+package functions
+
+import (
+	"fmt"
+
+	IRPCAsyncNotify "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/0b6edbfa-4a24-4fc6-8a23-942b1eca65d1/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	mspan "github.com/TheManticoreProject/Manticore/windows/protocols/ms-pan"
+)
+
+// iRPCAsyncNotify_GetNotificationRequest carries the [in] parameters of IRPCAsyncNotify_GetNotification.
+type iRPCAsyncNotify_GetNotificationRequest struct {
+	PRemoteObj mspan.PRPCREMOTEOBJECT
+}
+
+func (*iRPCAsyncNotify_GetNotificationRequest) Opnum() uint16 {
+	return IRPCAsyncNotify.OpnumIRPCAsyncNotify_GetNotification
+}
+
+// iRPCAsyncNotify_GetNotificationResponse carries the [out] parameters and HRESULT of
+// IRPCAsyncNotify_GetNotification. ppOutNotificationData is [out, size_is( , *pOutSize)]
+// byte**: the top-level [out] indirection, then a [unique] pointer to a conformant array
+// of POutSize octets.
+type iRPCAsyncNotify_GetNotificationResponse struct {
+	PpOutNotificationType *mspan.PrintAsyncNotificationType `ndr:"unique"`
+	POutSize              ndr.DWORD
+	PpOutNotificationData []byte    `ndr:"unique,size_is=POutSize"`
+	Status                ndr.DWORD `ndr:"retval"`
+}
+
+// IRPCAsyncNotify_GetNotification calls IRPCAsyncNotify_GetNotification (opnum 5)
+// ([MS-PAN] 3.1.4.5). For a unidirectional registration it blocks until the next
+// notification is available and returns its type and data.
+func IRPCAsyncNotify_GetNotification(rpc ndr.Invoker, pRemoteObj mspan.PRPCREMOTEOBJECT) (PpOutNotificationType *mspan.PrintAsyncNotificationType, POutSize ndr.DWORD, PpOutNotificationData []byte, err error) {
+	req := &iRPCAsyncNotify_GetNotificationRequest{
+		PRemoteObj: pRemoteObj,
+	}
+	var resp iRPCAsyncNotify_GetNotificationResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("IRPCAsyncNotify_GetNotification: %w", err)
+		return
+	}
+	PpOutNotificationType = resp.PpOutNotificationType
+	POutSize = resp.POutSize
+	PpOutNotificationData = resp.PpOutNotificationData
+	if uint32(resp.Status) != IRPCAsyncNotify.StatusSuccess {
+		err = fmt.Errorf("IRPCAsyncNotify_GetNotification failed: %s", IRPCAsyncNotify.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/0b6edbfa-4a24-4fc6-8a23-942b1eca65d1/1.0/functions/06_IRPCAsyncNotify_CloseChannel.go
+++ b/network/dcerpc/interfaces/0b6edbfa-4a24-4fc6-8a23-942b1eca65d1/1.0/functions/06_IRPCAsyncNotify_CloseChannel.go
@@ -1,0 +1,52 @@
+package functions
+
+import (
+	"fmt"
+
+	IRPCAsyncNotify "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/0b6edbfa-4a24-4fc6-8a23-942b1eca65d1/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	mspan "github.com/TheManticoreProject/Manticore/windows/protocols/ms-pan"
+)
+
+// iRPCAsyncNotify_CloseChannelRequest carries the [in]/[in,out] parameters of
+// IRPCAsyncNotify_CloseChannel. pChannel is an [in,out] channel context handle;
+// pInNotificationType is a required (top-level [ref]) pointer carried inline; pReason is
+// [in, size_is(InSize), unique] byte* — a [unique] pointer to a conformant byte array.
+type iRPCAsyncNotify_CloseChannelRequest struct {
+	PChannel            mspan.PNOTIFYOBJECT
+	PInNotificationType mspan.PrintAsyncNotificationType
+	InSize              ndr.DWORD
+	PReason             []byte `ndr:"unique,size_is=InSize"`
+}
+
+func (*iRPCAsyncNotify_CloseChannelRequest) Opnum() uint16 {
+	return IRPCAsyncNotify.OpnumIRPCAsyncNotify_CloseChannel
+}
+
+// iRPCAsyncNotify_CloseChannelResponse carries the [out] parameters and return value of IRPCAsyncNotify_CloseChannel.
+type iRPCAsyncNotify_CloseChannelResponse struct {
+	PChannel mspan.PNOTIFYOBJECT
+	Status   ndr.DWORD `ndr:"retval"`
+}
+
+// IRPCAsyncNotify_CloseChannel calls IRPCAsyncNotify_CloseChannel (opnum 6)
+// ([MS-PAN] 3.1.4.6). It closes a bidirectional notification channel, optionally
+// supplying a reason blob to the server.
+func IRPCAsyncNotify_CloseChannel(rpc ndr.Invoker, pChannel mspan.PNOTIFYOBJECT, pInNotificationType mspan.PrintAsyncNotificationType, inSize ndr.DWORD, pReason []byte) (PChannel mspan.PNOTIFYOBJECT, err error) {
+	req := &iRPCAsyncNotify_CloseChannelRequest{
+		PChannel:            pChannel,
+		PInNotificationType: pInNotificationType,
+		InSize:              inSize,
+		PReason:             pReason,
+	}
+	var resp iRPCAsyncNotify_CloseChannelResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("IRPCAsyncNotify_CloseChannel: %w", err)
+		return
+	}
+	PChannel = resp.PChannel
+	if uint32(resp.Status) != IRPCAsyncNotify.StatusSuccess {
+		err = fmt.Errorf("IRPCAsyncNotify_CloseChannel failed: %s", IRPCAsyncNotify.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/0b6edbfa-4a24-4fc6-8a23-942b1eca65d1/1.0/interface.go
+++ b/network/dcerpc/interfaces/0b6edbfa-4a24-4fc6-8a23-942b1eca65d1/1.0/interface.go
@@ -1,0 +1,103 @@
+// Package rpcinterface_0b6edbfa4a244fc68a23942b1eca65d1_1_0 is the descriptor for the IRPCAsyncNotify RPC interface, abstract
+// syntax 0b6edbfa-4a24-4fc6-8a23-942b1eca65d1 version 1.0 ([MS-PAN]).
+//
+// IRPCAsyncNotify lets a print client register for print status notifications, open
+// unidirectional/bidirectional notification channels, and exchange notification data
+// with the server ([MS-PAN] 3.1). Its methods take the remote-object context handle
+// produced by the IRPCRemoteObject interface (ae33069b-...).
+package rpcinterface_0b6edbfa4a244fc68a23942b1eca65d1_1_0
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+)
+
+// PipeName is empty: IRPCAsyncNotify has no named-pipe endpoint. Per [MS-PAN] section
+// 2.1 the interface is bound over RPC-on-TCP (ncacn_ip_tcp) at an RPC dynamic endpoint
+// assigned by the endpoint mapper ([C706] Part 4), located by the interface UUID rather
+// than a well-known port or pipe.
+const PipeName = ``
+
+// Opnums for the on-the-wire methods. Opnum 2 (Opnum2NotUsedOnWire) is "not used on the
+// wire" and is omitted.
+const (
+	OpnumIRPCAsyncNotify_RegisterClient              uint16 = 0
+	OpnumIRPCAsyncNotify_UnregisterClient            uint16 = 1
+	OpnumIRPCAsyncNotify_GetNewChannel               uint16 = 3
+	OpnumIRPCAsyncNotify_GetNotificationSendResponse uint16 = 4
+	OpnumIRPCAsyncNotify_GetNotification             uint16 = 5
+	OpnumIRPCAsyncNotify_CloseChannel                uint16 = 6
+)
+
+// Status codes. IRPCAsyncNotify methods return an HRESULT: ZERO (S_OK, 0x00000000) on
+// success, or a common [MS-ERREF] HRESULT / one of the protocol-specific values below on
+// failure ([MS-PAN] 3.1.4). The client SHOULD treat all error return values the same,
+// except where noted in the per-method processing rules.
+const (
+	StatusSuccess uint32 = 0x00000000 // S_OK
+
+	// Protocol-specific error values ([MS-PAN] 3.1.4.1 IRPCAsyncNotify_RegisterClient).
+	ErrorAccessDenied     uint32 = 0x80070005 // E_ACCESSDENIED: caller not authorized to register
+	ErrorNotEnoughMemory  uint32 = 0x8007000E // E_OUTOFMEMORY: no memory for the new registration
+	ErrorRegistrationFull uint32 = 0x80070015 // HRESULT_FROM_WIN32(ERROR_NOT_READY): registration limit reached
+	ErrorInvalidName      uint32 = 0x8007007B // HRESULT_FROM_WIN32(ERROR_INVALID_NAME): pName format invalid
+)
+
+// Access rights checked by the server when authorizing a registration
+// ([MS-PAN] 3.1.4.1). These combine the standard [MS-DTYP] ACCESS_MASK bits with
+// printing-specific bits.
+const (
+	SERVER_ALL_ACCESS  uint32 = 0x000F0003 // administer/enumerate print servers
+	PRINTER_ALL_ACCESS uint32 = 0x000F000C // basic/administrative use of print queues
+)
+
+// SyntaxID returns the IRPCAsyncNotify abstract syntax identifier:
+// 0b6edbfa-4a24-4fc6-8a23-942b1eca65d1, version 1.0.
+func SyntaxID() syntax.SyntaxID {
+	return syntax.SyntaxID{
+		UUID:         guid.GUID{A: 0x0b6edbfa, B: 0x4a24, C: 0x4fc6, D: 0x8a23, E: 0x942b1eca65d1},
+		MajorVersion: 1,
+		MinorVersion: 0,
+	}
+}
+
+// StatusString returns a mnemonic for the documented status codes, otherwise the
+// hex value.
+func StatusString(status uint32) string {
+	switch status {
+	case StatusSuccess:
+		return "S_OK"
+	case ErrorAccessDenied:
+		return "E_ACCESSDENIED"
+	case ErrorNotEnoughMemory:
+		return "E_OUTOFMEMORY"
+	case ErrorRegistrationFull:
+		return "HRESULT_FROM_WIN32(ERROR_NOT_READY)"
+	case ErrorInvalidName:
+		return "HRESULT_FROM_WIN32(ERROR_INVALID_NAME)"
+	default:
+		return fmt.Sprintf("0x%08x", status)
+	}
+}
+
+// OpnumToName maps each on-the-wire opnum to its method name; the single source of
+// truth.
+var OpnumToName = map[uint16]string{
+	OpnumIRPCAsyncNotify_RegisterClient:              "IRPCAsyncNotify_RegisterClient",
+	OpnumIRPCAsyncNotify_UnregisterClient:            "IRPCAsyncNotify_UnregisterClient",
+	OpnumIRPCAsyncNotify_GetNewChannel:               "IRPCAsyncNotify_GetNewChannel",
+	OpnumIRPCAsyncNotify_GetNotificationSendResponse: "IRPCAsyncNotify_GetNotificationSendResponse",
+	OpnumIRPCAsyncNotify_GetNotification:             "IRPCAsyncNotify_GetNotification",
+	OpnumIRPCAsyncNotify_CloseChannel:                "IRPCAsyncNotify_CloseChannel",
+}
+
+// NameToOpnum is the reverse of OpnumToName, built at init so the two never drift.
+var NameToOpnum = func() map[string]uint16 {
+	m := make(map[string]uint16, len(OpnumToName))
+	for op, name := range OpnumToName {
+		m[name] = op
+	}
+	return m
+}()

--- a/network/dcerpc/interfaces/0b6edbfa-4a24-4fc6-8a23-942b1eca65d1/1.0/interface_test.go
+++ b/network/dcerpc/interfaces/0b6edbfa-4a24-4fc6-8a23-942b1eca65d1/1.0/interface_test.go
@@ -1,0 +1,62 @@
+package rpcinterface_0b6edbfa4a244fc68a23942b1eca65d1_1_0
+
+import "testing"
+
+// TestSyntaxID checks the abstract syntax UUID and version match [MS-PAN] Appendix A.1.
+func TestSyntaxID(t *testing.T) {
+	sid := SyntaxID()
+	if got := sid.UUID.ToFormatD(); got != "0b6edbfa-4a24-4fc6-8a23-942b1eca65d1" {
+		t.Errorf("UUID = %s, want 0b6edbfa-4a24-4fc6-8a23-942b1eca65d1", got)
+	}
+	if sid.MajorVersion != 1 || sid.MinorVersion != 0 {
+		t.Errorf("version = %d.%d, want 1.0", sid.MajorVersion, sid.MinorVersion)
+	}
+}
+
+// TestPipeName pins the (empty) transport endpoint: MS-PAN is ncacn_ip_tcp only.
+func TestPipeName(t *testing.T) {
+	if PipeName != `` {
+		t.Errorf("PipeName = %q, want empty (ncacn_ip_tcp dynamic endpoint)", PipeName)
+	}
+}
+
+// TestOpnums verifies the opnums, that Opnum2NotUsedOnWire is omitted, and the name map.
+func TestOpnums(t *testing.T) {
+	if OpnumIRPCAsyncNotify_RegisterClient != 0 || OpnumIRPCAsyncNotify_GetNewChannel != 3 || OpnumIRPCAsyncNotify_CloseChannel != 6 {
+		t.Fatalf("opnums = %d/%d/%d, want 0/3/6", OpnumIRPCAsyncNotify_RegisterClient, OpnumIRPCAsyncNotify_GetNewChannel, OpnumIRPCAsyncNotify_CloseChannel)
+	}
+	// Opnum 2 (Opnum2NotUsedOnWire) MUST NOT appear in the map.
+	if _, ok := OpnumToName[2]; ok {
+		t.Error("opnum 2 (Opnum2NotUsedOnWire) must be omitted from OpnumToName")
+	}
+	if len(OpnumToName) != 6 {
+		t.Fatalf("on-the-wire method count = %d, want 6", len(OpnumToName))
+	}
+}
+
+// TestOpnumNameRoundTrip verifies OpnumToName and NameToOpnum are consistent inverses.
+func TestOpnumNameRoundTrip(t *testing.T) {
+	if len(OpnumToName) != len(NameToOpnum) {
+		t.Fatalf("OpnumToName has %d entries, NameToOpnum has %d", len(OpnumToName), len(NameToOpnum))
+	}
+	for op, name := range OpnumToName {
+		if got, ok := NameToOpnum[name]; !ok || got != op {
+			t.Errorf("NameToOpnum[%q] = %d (ok=%v), want %d", name, got, ok, op)
+		}
+	}
+}
+
+// TestStatusString spot-checks the protocol-specific HRESULT mnemonics and hex fallback.
+func TestStatusString(t *testing.T) {
+	cases := map[uint32]string{
+		StatusSuccess:     "S_OK",
+		ErrorAccessDenied: "E_ACCESSDENIED",
+		ErrorInvalidName:  "HRESULT_FROM_WIN32(ERROR_INVALID_NAME)",
+		0xdeadbeef:        "0xdeadbeef",
+	}
+	for status, want := range cases {
+		if got := StatusString(status); got != want {
+			t.Errorf("StatusString(0x%08x) = %q, want %q", status, got, want)
+		}
+	}
+}

--- a/network/dcerpc/interfaces/ae33069b-a2a8-46ee-a235-ddfd339be281/1.0/functions/00_IRPCRemoteObject_Create.go
+++ b/network/dcerpc/interfaces/ae33069b-a2a8-46ee-a235-ddfd339be281/1.0/functions/00_IRPCRemoteObject_Create.go
@@ -1,0 +1,42 @@
+package functions
+
+import (
+	"fmt"
+
+	IRPCRemoteObject "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/ae33069b-a2a8-46ee-a235-ddfd339be281/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	mspan "github.com/TheManticoreProject/Manticore/windows/protocols/ms-pan"
+)
+
+// iRPCRemoteObject_CreateRequest carries the [in] parameters of IRPCRemoteObject_Create.
+// The only [in] parameter is the explicit handle_t binding handle, which is not
+// marshalled into the request stub, so the request body is empty.
+type iRPCRemoteObject_CreateRequest struct {
+}
+
+func (*iRPCRemoteObject_CreateRequest) Opnum() uint16 {
+	return IRPCRemoteObject.OpnumIRPCRemoteObject_Create
+}
+
+// iRPCRemoteObject_CreateResponse carries the [out] parameters and return value of IRPCRemoteObject_Create.
+type iRPCRemoteObject_CreateResponse struct {
+	PpRemoteObj mspan.PRPCREMOTEOBJECT
+	Status      ndr.DWORD `ndr:"retval"`
+}
+
+// IRPCRemoteObject_Create calls IRPCRemoteObject_Create (opnum 0) ([MS-PAN] 3.1.2.4.1). It
+// creates a new remote object on the server and returns its context handle for use as the
+// registration/channel argument of the IRPCAsyncNotify methods.
+func IRPCRemoteObject_Create(rpc ndr.Invoker) (PpRemoteObj mspan.PRPCREMOTEOBJECT, err error) {
+	req := &iRPCRemoteObject_CreateRequest{}
+	var resp iRPCRemoteObject_CreateResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("IRPCRemoteObject_Create: %w", err)
+		return
+	}
+	PpRemoteObj = resp.PpRemoteObj
+	if uint32(resp.Status) != IRPCRemoteObject.StatusSuccess {
+		err = fmt.Errorf("IRPCRemoteObject_Create failed: %s", IRPCRemoteObject.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/ae33069b-a2a8-46ee-a235-ddfd339be281/1.0/functions/01_IRPCRemoteObject_Delete.go
+++ b/network/dcerpc/interfaces/ae33069b-a2a8-46ee-a235-ddfd339be281/1.0/functions/01_IRPCRemoteObject_Delete.go
@@ -1,0 +1,41 @@
+package functions
+
+import (
+	"fmt"
+
+	IRPCRemoteObject "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/ae33069b-a2a8-46ee-a235-ddfd339be281/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	mspan "github.com/TheManticoreProject/Manticore/windows/protocols/ms-pan"
+)
+
+// iRPCRemoteObject_DeleteRequest carries the [in] parameters of IRPCRemoteObject_Delete.
+type iRPCRemoteObject_DeleteRequest struct {
+	PpRemoteObj mspan.PRPCREMOTEOBJECT
+}
+
+func (*iRPCRemoteObject_DeleteRequest) Opnum() uint16 {
+	return IRPCRemoteObject.OpnumIRPCRemoteObject_Delete
+}
+
+// iRPCRemoteObject_DeleteResponse carries the [in,out] parameter of IRPCRemoteObject_Delete.
+// The method returns void ([MS-PAN] 3.1.2.4.2), so there is no HRESULT on the wire; the
+// server sets ppRemoteObj to NULL on return.
+type iRPCRemoteObject_DeleteResponse struct {
+	PpRemoteObj mspan.PRPCREMOTEOBJECT
+}
+
+// IRPCRemoteObject_Delete calls IRPCRemoteObject_Delete (opnum 1) ([MS-PAN] 3.1.2.4.2). It
+// destroys the remote object referenced by ppRemoteObj; the returned handle is the
+// server-nulled [in,out] context handle. The method has no return value.
+func IRPCRemoteObject_Delete(rpc ndr.Invoker, ppRemoteObj mspan.PRPCREMOTEOBJECT) (PpRemoteObj mspan.PRPCREMOTEOBJECT, err error) {
+	req := &iRPCRemoteObject_DeleteRequest{
+		PpRemoteObj: ppRemoteObj,
+	}
+	var resp iRPCRemoteObject_DeleteResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("IRPCRemoteObject_Delete: %w", err)
+		return
+	}
+	PpRemoteObj = resp.PpRemoteObj
+	return
+}

--- a/network/dcerpc/interfaces/ae33069b-a2a8-46ee-a235-ddfd339be281/1.0/interface.go
+++ b/network/dcerpc/interfaces/ae33069b-a2a8-46ee-a235-ddfd339be281/1.0/interface.go
@@ -1,0 +1,80 @@
+// Package rpcinterface_ae33069ba2a846eea235ddfd339be281_1_0 is the descriptor for the IRPCRemoteObject RPC interface, abstract
+// syntax ae33069b-a2a8-46ee-a235-ddfd339be281 version 1.0 ([MS-PAN]).
+//
+// IRPCRemoteObject creates and deletes the remote objects (context handles) that
+// IRPCAsyncNotify calls take as their registration/channel arguments ([MS-PAN] 3.1.2).
+package rpcinterface_ae33069ba2a846eea235ddfd339be281_1_0
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+)
+
+// PipeName is empty: IRPCRemoteObject has no named-pipe endpoint. Per [MS-PAN] section
+// 2.1 the interface is bound over RPC-on-TCP (ncacn_ip_tcp) at an RPC dynamic endpoint
+// assigned by the endpoint mapper ([C706] Part 4), located by the interface UUID rather
+// than a well-known port or pipe.
+const PipeName = ``
+
+// Opnums for the on-the-wire methods.
+const (
+	OpnumIRPCRemoteObject_Create uint16 = 0
+	OpnumIRPCRemoteObject_Delete uint16 = 1
+)
+
+// Status codes. IRPCRemoteObject_Create returns an HRESULT: ZERO (S_OK, 0x00000000) on
+// success, or a common [MS-ERREF] HRESULT on failure ([MS-PAN] 3.1.2.4).
+// IRPCRemoteObject_Delete returns void. ([MS-ERREF] section 2.1.1.)
+const (
+	StatusSuccess uint32 = 0x00000000 // S_OK
+
+	// Common [MS-ERREF] HRESULTs a server may return.
+	ErrorAccessDenied uint32 = 0x80070005 // E_ACCESSDENIED
+	ErrorOutOfMemory  uint32 = 0x8007000E // E_OUTOFMEMORY
+	ErrorInvalidArg   uint32 = 0x80070057 // E_INVALIDARG
+)
+
+// SyntaxID returns the IRPCRemoteObject abstract syntax identifier:
+// ae33069b-a2a8-46ee-a235-ddfd339be281, version 1.0.
+func SyntaxID() syntax.SyntaxID {
+	return syntax.SyntaxID{
+		UUID:         guid.GUID{A: 0xae33069b, B: 0xa2a8, C: 0x46ee, D: 0xa235, E: 0xddfd339be281},
+		MajorVersion: 1,
+		MinorVersion: 0,
+	}
+}
+
+// StatusString returns a mnemonic for the documented status codes, otherwise the
+// hex value.
+func StatusString(status uint32) string {
+	switch status {
+	case StatusSuccess:
+		return "S_OK"
+	case ErrorAccessDenied:
+		return "E_ACCESSDENIED"
+	case ErrorOutOfMemory:
+		return "E_OUTOFMEMORY"
+	case ErrorInvalidArg:
+		return "E_INVALIDARG"
+	default:
+		return fmt.Sprintf("0x%08x", status)
+	}
+}
+
+// OpnumToName maps each on-the-wire opnum to its method name; the single source of
+// truth.
+var OpnumToName = map[uint16]string{
+	OpnumIRPCRemoteObject_Create: "IRPCRemoteObject_Create",
+	OpnumIRPCRemoteObject_Delete: "IRPCRemoteObject_Delete",
+}
+
+// NameToOpnum is the reverse of OpnumToName, built at init so the two never drift.
+var NameToOpnum = func() map[string]uint16 {
+	m := make(map[string]uint16, len(OpnumToName))
+	for op, name := range OpnumToName {
+		m[name] = op
+	}
+	return m
+}()

--- a/network/dcerpc/interfaces/ae33069b-a2a8-46ee-a235-ddfd339be281/1.0/interface_test.go
+++ b/network/dcerpc/interfaces/ae33069b-a2a8-46ee-a235-ddfd339be281/1.0/interface_test.go
@@ -1,0 +1,47 @@
+package rpcinterface_ae33069ba2a846eea235ddfd339be281_1_0
+
+import "testing"
+
+// TestSyntaxID checks the abstract syntax UUID and version match [MS-PAN] Appendix A.2.
+func TestSyntaxID(t *testing.T) {
+	sid := SyntaxID()
+	if got := sid.UUID.ToFormatD(); got != "ae33069b-a2a8-46ee-a235-ddfd339be281" {
+		t.Errorf("UUID = %s, want ae33069b-a2a8-46ee-a235-ddfd339be281", got)
+	}
+	if sid.MajorVersion != 1 || sid.MinorVersion != 0 {
+		t.Errorf("version = %d.%d, want 1.0", sid.MajorVersion, sid.MinorVersion)
+	}
+}
+
+// TestPipeName pins the (empty) transport endpoint: MS-PAN is ncacn_ip_tcp only.
+func TestPipeName(t *testing.T) {
+	if PipeName != `` {
+		t.Errorf("PipeName = %q, want empty (ncacn_ip_tcp dynamic endpoint)", PipeName)
+	}
+}
+
+// TestOpnumNameRoundTrip verifies OpnumToName and NameToOpnum are consistent inverses.
+func TestOpnumNameRoundTrip(t *testing.T) {
+	if len(OpnumToName) != len(NameToOpnum) {
+		t.Fatalf("OpnumToName has %d entries, NameToOpnum has %d", len(OpnumToName), len(NameToOpnum))
+	}
+	for op, name := range OpnumToName {
+		if got, ok := NameToOpnum[name]; !ok || got != op {
+			t.Errorf("NameToOpnum[%q] = %d (ok=%v), want %d", name, got, ok, op)
+		}
+	}
+}
+
+// TestStatusString spot-checks the HRESULT mnemonics and the hex fallback.
+func TestStatusString(t *testing.T) {
+	cases := map[uint32]string{
+		StatusSuccess:     "S_OK",
+		ErrorAccessDenied: "E_ACCESSDENIED",
+		0xdeadbeef:        "0xdeadbeef",
+	}
+	for status, want := range cases {
+		if got := StatusString(status); got != want {
+			t.Errorf("StatusString(0x%08x) = %q, want %q", status, got, want)
+		}
+	}
+}

--- a/windows/protocols/ms-pan/PNOTIFYOBJECT.go
+++ b/windows/protocols/ms-pan/PNOTIFYOBJECT.go
@@ -1,0 +1,5 @@
+package mspan
+
+// PNOTIFYOBJECT is a notification-channel RPC context handle ([MS-PAN] 3.1.1): an
+// [context_handle] void* carried on the wire as a 20-octet handle ([MS-RPCE] 2.3.2.2).
+type PNOTIFYOBJECT [20]byte

--- a/windows/protocols/ms-pan/PRPCREMOTEOBJECT.go
+++ b/windows/protocols/ms-pan/PRPCREMOTEOBJECT.go
@@ -1,0 +1,6 @@
+package mspan
+
+// PRPCREMOTEOBJECT is the remote-object RPC context handle ([MS-PAN] 2.2.4): an
+// [context_handle] void* carried on the wire as a 20-octet handle ([MS-RPCE] 2.3.2.2).
+// It is created by IRPCRemoteObject_Create and consumed by the IRPCAsyncNotify methods.
+type PRPCREMOTEOBJECT [20]byte

--- a/windows/protocols/ms-pan/PrintAsyncNotificationType.go
+++ b/windows/protocols/ms-pan/PrintAsyncNotificationType.go
@@ -1,0 +1,20 @@
+package mspan
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+)
+
+// PrintAsyncNotificationType is a notification type identifier ([MS-PAN] 2.2.1): a
+// typedef of GUID in the IDL, so it is carried on the wire as a 16-octet GUID
+// (Data1/Data2/Data3 + Data4[8], 4-octet aligned).
+//
+// It is modeled on dtyp.GUID rather than windows/guid.GUID because the latter's trailing
+// uint64 does not marshal to the required 16 octets under NDR.
+type PrintAsyncNotificationType dtyp.GUID
+
+// GUID returns the notification type as a windows/guid.GUID for display and comparison.
+func (t PrintAsyncNotificationType) GUID() guid.GUID { return dtyp.GUID(t).GUID() }
+
+// String returns the canonical brace-less GUID string form of the notification type.
+func (t PrintAsyncNotificationType) String() string { return dtyp.GUID(t).String() }

--- a/windows/protocols/ms-pan/PrintAsyncNotifyConversationStyle.go
+++ b/windows/protocols/ms-pan/PrintAsyncNotifyConversationStyle.go
@@ -1,0 +1,12 @@
+package mspan
+
+// PrintAsyncNotifyConversationStyle is a [v1_enum] NDR enum ([MS-PAN] 2.2.2), so it is
+// transmitted as a 32-bit value ([C706] 14.3.6, MIDL v1_enum), not the 16-bit default.
+type PrintAsyncNotifyConversationStyle uint32
+
+// The constants keep their IDL names ([MS-PAN] 2.2.2) but are exported so callers of the
+// IRPCAsyncNotify stubs can name them across the package boundary.
+const (
+	KBiDirectional  PrintAsyncNotifyConversationStyle = 0
+	KUniDirectional PrintAsyncNotifyConversationStyle = 1
+)

--- a/windows/protocols/ms-pan/PrintAsyncNotifyUserFilter.go
+++ b/windows/protocols/ms-pan/PrintAsyncNotifyUserFilter.go
@@ -1,0 +1,12 @@
+package mspan
+
+// PrintAsyncNotifyUserFilter is a [v1_enum] NDR enum ([MS-PAN] 2.2.3), so it is
+// transmitted as a 32-bit value ([C706] 14.3.6, MIDL v1_enum), not the 16-bit default.
+type PrintAsyncNotifyUserFilter uint32
+
+// The constants keep their IDL names ([MS-PAN] 2.2.3) but are exported so callers of the
+// IRPCAsyncNotify stubs can name them across the package boundary.
+const (
+	KPerUser  PrintAsyncNotifyUserFilter = 0
+	KAllUsers PrintAsyncNotifyUserFilter = 1
+)

--- a/windows/protocols/ms-pan/structures_test.go
+++ b/windows/protocols/ms-pan/structures_test.go
@@ -1,0 +1,131 @@
+package mspan
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// roundTrip marshals in, unmarshals into a fresh value of the same type, and asserts the
+// result is deeply equal to in. This is the wire-shape acceptance gate for the MS-PAN
+// NDR types in the absence of a live Print System Asynchronous Notification server.
+func roundTrip[T any](t *testing.T, name string, in T) {
+	t.Helper()
+	raw, err := ndr.Marshal(&in)
+	if err != nil {
+		t.Fatalf("%s: Marshal: %v", name, err)
+	}
+	var out T
+	if err := ndr.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("%s: Unmarshal: %v", name, err)
+	}
+	if !reflect.DeepEqual(in, out) {
+		t.Errorf("%s: round trip mismatch:\n in:  %+v\n out: %+v", name, in, out)
+	}
+}
+
+// TestContextHandles exercises the two 20-octet context handles. NDR marshals top-level
+// structs only, so each is wrapped as it appears on the wire (an inline field).
+func TestContextHandles(t *testing.T) {
+	type remoteObj struct{ H PRPCREMOTEOBJECT }
+	type notifyObj struct{ H PNOTIFYOBJECT }
+
+	roundTrip(t, "PRPCREMOTEOBJECT", remoteObj{H: PRPCREMOTEOBJECT{
+		0x01, 0x00, 0x00, 0x00, 0xde, 0xad, 0xbe, 0xef, 0x00, 0x11,
+		0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb,
+	}})
+	roundTrip(t, "PNOTIFYOBJECT", notifyObj{H: PNOTIFYOBJECT{
+		0x00, 0x00, 0x00, 0x00, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab,
+		0xcd, 0xef, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+	}})
+}
+
+// TestPrintAsyncNotificationType exercises the GUID typedef and locks its 16-octet wire
+// size (Data1/Data2/Data3 + Data4[8]), the value the notification-type identifier is
+// carried as.
+func TestPrintAsyncNotificationType(t *testing.T) {
+	type wrap struct{ T PrintAsyncNotificationType }
+	in := wrap{T: PrintAsyncNotificationType(dtyp.GUID{
+		Data1: 0x23cbe492,
+		Data2: 0xf6bf,
+		Data3: 0x4b5b,
+		Data4: [8]byte{0xa0, 0x66, 0x8e, 0x2b, 0x1e, 0x3b, 0x1d, 0x2c},
+	})}
+	raw, err := ndr.Marshal(&in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if len(raw) != 16 {
+		t.Fatalf("PrintAsyncNotificationType wire size = %d, want 16 (typedef GUID)", len(raw))
+	}
+	roundTrip(t, "PrintAsyncNotificationType", in)
+}
+
+// TestEnumsAreV1Enum locks the [v1_enum] 32-bit width of both MS-PAN enums. A 16-bit
+// default enum would silently emit 2 octets and corrupt the wire.
+func TestEnumsAreV1Enum(t *testing.T) {
+	type conv struct {
+		V PrintAsyncNotifyConversationStyle
+	}
+	type filt struct{ V PrintAsyncNotifyUserFilter }
+
+	raw, err := ndr.Marshal(&conv{V: KUniDirectional})
+	if err != nil {
+		t.Fatalf("Marshal conversation style: %v", err)
+	}
+	if len(raw) != 4 {
+		t.Fatalf("PrintAsyncNotifyConversationStyle wire size = %d, want 4 (v1_enum)", len(raw))
+	}
+	raw, err = ndr.Marshal(&filt{V: KAllUsers})
+	if err != nil {
+		t.Fatalf("Marshal user filter: %v", err)
+	}
+	if len(raw) != 4 {
+		t.Fatalf("PrintAsyncNotifyUserFilter wire size = %d, want 4 (v1_enum)", len(raw))
+	}
+
+	roundTrip(t, "ConversationStyle/bidi", conv{V: KBiDirectional})
+	roundTrip(t, "UserFilter/perUser", filt{V: KPerUser})
+}
+
+// TestChannelArray exercises the IRPCAsyncNotify_GetNewChannel [out] shape:
+// [size_is( , *pNoOfChannels)] PNOTIFYOBJECT** — a [unique] pointer to a conformant array
+// of context handles, sized by a sibling count field.
+func TestChannelArray(t *testing.T) {
+	type resp struct {
+		Count    ndr.DWORD
+		Channels []PNOTIFYOBJECT `ndr:"unique,size_is=Count"`
+	}
+	roundTrip(t, "channels/populated", resp{
+		Count: 2,
+		Channels: []PNOTIFYOBJECT{
+			{0x01, 0x02, 0x03, 0x04},
+			{0x05, 0x06, 0x07, 0x08},
+		},
+	})
+	roundTrip(t, "channels/nil", resp{Count: 0, Channels: nil})
+}
+
+// TestNotificationBlob exercises the [size_is(N), unique] byte* notification-data shape
+// used by GetNotification / GetNotificationSendResponse / CloseChannel.
+func TestNotificationBlob(t *testing.T) {
+	type msg struct {
+		Size ndr.DWORD
+		Data []byte `ndr:"unique,size_is=Size"`
+	}
+	roundTrip(t, "blob/populated", msg{Size: 5, Data: []byte{0xde, 0xad, 0xbe, 0xef, 0x2a}})
+	roundTrip(t, "blob/nil", msg{Size: 0, Data: nil})
+}
+
+// TestOptionalString exercises the [string, unique] wchar_t* shape used by pName and
+// ppRmtServerReferral: a [unique] pointer that may be nil.
+func TestOptionalString(t *testing.T) {
+	type req struct {
+		Name *ndr.WSTR `ndr:"unique"`
+	}
+	name := ndr.WSTR(`\\server\printer`)
+	roundTrip(t, "name/present", req{Name: &name})
+	roundTrip(t, "name/nil", req{Name: nil})
+}


### PR DESCRIPTION
### Linked Issue
`Closes #816`

### Root Cause
Manticore did not implement the Print System Asynchronous Notification Protocol ([MS-PAN]). Its two RPC abstract syntaxes — IRPCAsyncNotify and IRPCRemoteObject — had no descriptor, method stubs, or NDR wire types, so neither interface could be bound or invoked.

### Fix Description
Adds both [MS-PAN] Appendix A interfaces as classic DCE/RPC interfaces, following the dcerpc-interface-structure split layout (descriptor + per-opnum function stubs under the UUID-versioned interface tree; NDR wire types in a protocol-scoped `windows/protocols/ms-pan` package).

- **IRPCRemoteObject** (`ae33069b-a2a8-46ee-a235-ddfd339be281`, v1.0): `IRPCRemoteObject_Create` (HRESULT) and `IRPCRemoteObject_Delete` (void — no return value on the wire).
- **IRPCAsyncNotify** (`0b6edbfa-4a24-4fc6-8a23-942b1eca65d1`, v1.0): 6 on-the-wire opnums (`RegisterClient`, `UnregisterClient`, `GetNewChannel`, `GetNotificationSendResponse`, `GetNotification`, `CloseChannel`); opnum 2 (`Opnum2NotUsedOnWire`) is omitted.

Both interfaces are reached over `ncacn_ip_tcp` at an RPC dynamic endpoint via the endpoint mapper ([MS-PAN] section 2.1); there is no named pipe, so `PipeName` is empty.

Wire-modeling decisions that go beyond a mechanical IDL translation:
- `PrintAsyncNotifyConversationStyle` / `PrintAsyncNotifyUserFilter` are `[v1_enum]` enums → carried as 32-bit values (not the 16-bit NDR default). Their constants are exported so callers can name them across the package boundary.
- `PrintAsyncNotificationType` is a `typedef GUID`, modeled on `dtyp.GUID` for the required 16-octet wire form.
- The `[out, size_is( , *pCount)] TYPE**` parameters (channel handles, notification data) collapse the top-level `[out]` indirection to a single `[unique]` pointer to a conformant array (`ndr:"unique,size_is=Count"`).
- `[in, unique]` byte blobs and the optional `[string, unique]` name/referral are `unique` pointers; the required (top-level `[ref]`) notification-type pointers are carried inline.
- Context handles (`PRPCREMOTEOBJECT`, `PNOTIFYOBJECT`) are 20-octet handles.

### How Verified
- `gofmt -l`, `go build`, `go vet`, `go test` over both interface trees and the structures package — all clean/pass.
- Cross-compiled `GOARCH=386 go build ./...` and `GOARCH=arm64 go build ./...`, plus `go build -tags integration` over the interface trees.
- Structure round-trip tests marshal→unmarshal each wire shape and assert byte widths, locking the `[v1_enum]` 32-bit width, the 16-octet GUID, the conformant context-handle array, the sized byte blobs, and the optional unique string.

### Test Coverage
- **Added:**
  - `windows/protocols/ms-pan/structures_test.go`: `TestContextHandles`, `TestPrintAsyncNotificationType`, `TestEnumsAreV1Enum`, `TestChannelArray`, `TestNotificationBlob`, `TestOptionalString`.
  - `.../0b6edbfa-.../1.0/interface_test.go` and `.../ae33069b-.../1.0/interface_test.go`: `TestSyntaxID`, `TestPipeName`, `TestOpnums` / `TestOpnumNameRoundTrip`, `TestStatusString`.

### Scope of Change
- **Files changed:** new files only — 2 interface trees under `network/dcerpc/interfaces/` and the new `windows/protocols/ms-pan/` package (18 files).
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Notes
Go-level round-trip is not the same as live-server validation; the wire shapes are verified against the IDL and [MS-PAN] method definitions but have not been exercised against a live print server. Integration tests behind `//go:build integration` are not included because MS-PAN uses dynamic TCP endpoints rather than a named pipe.
