### PR TITLE
Migrate MS-RRP winreg NDR structures to the split windows/protocols/ms-rrp layout (Fixes #828)

### DIFF
--- a/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/00_OpenClassesRoot.go
+++ b/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/00_OpenClassesRoot.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	winreg "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0"
-	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/structures"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	msrrp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-rrp"
 )
 
 // openClassesRootRequest carries the [in] parameters of OpenClassesRoot.
@@ -18,13 +18,13 @@ func (*openClassesRootRequest) Opnum() uint16 { return winreg.OpnumOpenClassesRo
 
 // openClassesRootResponse carries the [out] parameters and return value of OpenClassesRoot.
 type openClassesRootResponse struct {
-	PhKey  structures.PRPC_HKEY
+	PhKey  msrrp.PRPC_HKEY
 	Status ndr.DWORD `ndr:"retval"`
 }
 
 // OpenClassesRoot calls OpenClassesRoot (opnum 0) ([MS-RRP] — verify the parameter
 // modeling and status handling).
-func OpenClassesRoot(rpc ndr.Invoker, serverName *ndr.WSTR, samDesired ndr.DWORD) (PhKey structures.PRPC_HKEY, err error) {
+func OpenClassesRoot(rpc ndr.Invoker, serverName *ndr.WSTR, samDesired ndr.DWORD) (PhKey msrrp.PRPC_HKEY, err error) {
 	req := &openClassesRootRequest{
 		ServerName: serverName,
 		SamDesired: samDesired,

--- a/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/01_OpenCurrentUser.go
+++ b/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/01_OpenCurrentUser.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	winreg "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0"
-	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/structures"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	msrrp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-rrp"
 )
 
 // openCurrentUserRequest carries the [in] parameters of OpenCurrentUser.
@@ -18,13 +18,13 @@ func (*openCurrentUserRequest) Opnum() uint16 { return winreg.OpnumOpenCurrentUs
 
 // openCurrentUserResponse carries the [out] parameters and return value of OpenCurrentUser.
 type openCurrentUserResponse struct {
-	PhKey  structures.PRPC_HKEY
+	PhKey  msrrp.PRPC_HKEY
 	Status ndr.DWORD `ndr:"retval"`
 }
 
 // OpenCurrentUser calls OpenCurrentUser (opnum 1) ([MS-RRP] — verify the parameter
 // modeling and status handling).
-func OpenCurrentUser(rpc ndr.Invoker, serverName *ndr.WSTR, samDesired ndr.DWORD) (PhKey structures.PRPC_HKEY, err error) {
+func OpenCurrentUser(rpc ndr.Invoker, serverName *ndr.WSTR, samDesired ndr.DWORD) (PhKey msrrp.PRPC_HKEY, err error) {
 	req := &openCurrentUserRequest{
 		ServerName: serverName,
 		SamDesired: samDesired,

--- a/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/02_OpenLocalMachine.go
+++ b/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/02_OpenLocalMachine.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	winreg "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0"
-	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/structures"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	msrrp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-rrp"
 )
 
 // openLocalMachineRequest carries the [in] parameters of OpenLocalMachine.
@@ -18,13 +18,13 @@ func (*openLocalMachineRequest) Opnum() uint16 { return winreg.OpnumOpenLocalMac
 
 // openLocalMachineResponse carries the [out] parameters and return value of OpenLocalMachine.
 type openLocalMachineResponse struct {
-	PhKey  structures.PRPC_HKEY
+	PhKey  msrrp.PRPC_HKEY
 	Status ndr.DWORD `ndr:"retval"`
 }
 
 // OpenLocalMachine calls OpenLocalMachine (opnum 2) ([MS-RRP] — verify the parameter
 // modeling and status handling).
-func OpenLocalMachine(rpc ndr.Invoker, serverName *ndr.WSTR, samDesired ndr.DWORD) (PhKey structures.PRPC_HKEY, err error) {
+func OpenLocalMachine(rpc ndr.Invoker, serverName *ndr.WSTR, samDesired ndr.DWORD) (PhKey msrrp.PRPC_HKEY, err error) {
 	req := &openLocalMachineRequest{
 		ServerName: serverName,
 		SamDesired: samDesired,

--- a/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/03_OpenPerformanceData.go
+++ b/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/03_OpenPerformanceData.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	winreg "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0"
-	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/structures"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	msrrp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-rrp"
 )
 
 // openPerformanceDataRequest carries the [in] parameters of OpenPerformanceData.
@@ -18,13 +18,13 @@ func (*openPerformanceDataRequest) Opnum() uint16 { return winreg.OpnumOpenPerfo
 
 // openPerformanceDataResponse carries the [out] parameters and return value of OpenPerformanceData.
 type openPerformanceDataResponse struct {
-	PhKey  structures.PRPC_HKEY
+	PhKey  msrrp.PRPC_HKEY
 	Status ndr.DWORD `ndr:"retval"`
 }
 
 // OpenPerformanceData calls OpenPerformanceData (opnum 3) ([MS-RRP] — verify the parameter
 // modeling and status handling).
-func OpenPerformanceData(rpc ndr.Invoker, serverName *ndr.WSTR, samDesired ndr.DWORD) (PhKey structures.PRPC_HKEY, err error) {
+func OpenPerformanceData(rpc ndr.Invoker, serverName *ndr.WSTR, samDesired ndr.DWORD) (PhKey msrrp.PRPC_HKEY, err error) {
 	req := &openPerformanceDataRequest{
 		ServerName: serverName,
 		SamDesired: samDesired,

--- a/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/04_OpenUsers.go
+++ b/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/04_OpenUsers.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	winreg "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0"
-	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/structures"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	msrrp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-rrp"
 )
 
 // openUsersRequest carries the [in] parameters of OpenUsers.
@@ -18,13 +18,13 @@ func (*openUsersRequest) Opnum() uint16 { return winreg.OpnumOpenUsers }
 
 // openUsersResponse carries the [out] parameters and return value of OpenUsers.
 type openUsersResponse struct {
-	PhKey  structures.PRPC_HKEY
+	PhKey  msrrp.PRPC_HKEY
 	Status ndr.DWORD `ndr:"retval"`
 }
 
 // OpenUsers calls OpenUsers (opnum 4) ([MS-RRP] — verify the parameter
 // modeling and status handling).
-func OpenUsers(rpc ndr.Invoker, serverName *ndr.WSTR, samDesired ndr.DWORD) (PhKey structures.PRPC_HKEY, err error) {
+func OpenUsers(rpc ndr.Invoker, serverName *ndr.WSTR, samDesired ndr.DWORD) (PhKey msrrp.PRPC_HKEY, err error) {
 	req := &openUsersRequest{
 		ServerName: serverName,
 		SamDesired: samDesired,

--- a/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/05_BaseRegCloseKey.go
+++ b/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/05_BaseRegCloseKey.go
@@ -4,26 +4,26 @@ import (
 	"fmt"
 
 	winreg "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0"
-	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/structures"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	msrrp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-rrp"
 )
 
 // baseRegCloseKeyRequest carries the [in] parameters of BaseRegCloseKey.
 type baseRegCloseKeyRequest struct {
-	HKey structures.PRPC_HKEY
+	HKey msrrp.PRPC_HKEY
 }
 
 func (*baseRegCloseKeyRequest) Opnum() uint16 { return winreg.OpnumBaseRegCloseKey }
 
 // baseRegCloseKeyResponse carries the [out] parameters and return value of BaseRegCloseKey.
 type baseRegCloseKeyResponse struct {
-	HKey   structures.PRPC_HKEY
+	HKey   msrrp.PRPC_HKEY
 	Status ndr.DWORD `ndr:"retval"`
 }
 
 // BaseRegCloseKey calls BaseRegCloseKey (opnum 5) ([MS-RRP] — verify the parameter
 // modeling and status handling).
-func BaseRegCloseKey(rpc ndr.Invoker, hKey structures.PRPC_HKEY) (HKey structures.PRPC_HKEY, err error) {
+func BaseRegCloseKey(rpc ndr.Invoker, hKey msrrp.PRPC_HKEY) (HKey msrrp.PRPC_HKEY, err error) {
 	req := &baseRegCloseKeyRequest{
 		HKey: hKey,
 	}

--- a/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/06_BaseRegCreateKey.go
+++ b/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/06_BaseRegCreateKey.go
@@ -4,33 +4,33 @@ import (
 	"fmt"
 
 	winreg "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0"
-	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/structures"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	msrrp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-rrp"
 )
 
 // baseRegCreateKeyRequest carries the [in] parameters of BaseRegCreateKey.
 type baseRegCreateKeyRequest struct {
-	HKey                 structures.RPC_HKEY
-	LpSubKey             structures.RRP_UNICODE_STRING
-	LpClass              structures.RRP_UNICODE_STRING
+	HKey                 msrrp.RPC_HKEY
+	LpSubKey             msrrp.RRP_UNICODE_STRING
+	LpClass              msrrp.RRP_UNICODE_STRING
 	DwOptions            ndr.DWORD
 	SamDesired           ndr.DWORD
-	LpSecurityAttributes *structures.RPC_SECURITY_ATTRIBUTES `ndr:"unique"`
-	LpdwDisposition      *ndr.DWORD                          `ndr:"unique"`
+	LpSecurityAttributes *msrrp.RPC_SECURITY_ATTRIBUTES `ndr:"unique"`
+	LpdwDisposition      *ndr.DWORD                     `ndr:"unique"`
 }
 
 func (*baseRegCreateKeyRequest) Opnum() uint16 { return winreg.OpnumBaseRegCreateKey }
 
 // baseRegCreateKeyResponse carries the [out] parameters and return value of BaseRegCreateKey.
 type baseRegCreateKeyResponse struct {
-	PhkResult       structures.PRPC_HKEY
+	PhkResult       msrrp.PRPC_HKEY
 	LpdwDisposition *ndr.DWORD `ndr:"unique"`
 	Status          ndr.DWORD  `ndr:"retval"`
 }
 
 // BaseRegCreateKey calls BaseRegCreateKey (opnum 6) ([MS-RRP] — verify the parameter
 // modeling and status handling).
-func BaseRegCreateKey(rpc ndr.Invoker, hKey structures.RPC_HKEY, lpSubKey structures.RRP_UNICODE_STRING, lpClass structures.RRP_UNICODE_STRING, dwOptions ndr.DWORD, samDesired ndr.DWORD, lpSecurityAttributes *structures.RPC_SECURITY_ATTRIBUTES, lpdwDisposition *ndr.DWORD) (PhkResult structures.PRPC_HKEY, LpdwDisposition *ndr.DWORD, err error) {
+func BaseRegCreateKey(rpc ndr.Invoker, hKey msrrp.RPC_HKEY, lpSubKey msrrp.RRP_UNICODE_STRING, lpClass msrrp.RRP_UNICODE_STRING, dwOptions ndr.DWORD, samDesired ndr.DWORD, lpSecurityAttributes *msrrp.RPC_SECURITY_ATTRIBUTES, lpdwDisposition *ndr.DWORD) (PhkResult msrrp.PRPC_HKEY, LpdwDisposition *ndr.DWORD, err error) {
 	req := &baseRegCreateKeyRequest{
 		HKey:                 hKey,
 		LpSubKey:             lpSubKey,

--- a/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/07_BaseRegDeleteKey.go
+++ b/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/07_BaseRegDeleteKey.go
@@ -4,14 +4,14 @@ import (
 	"fmt"
 
 	winreg "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0"
-	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/structures"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	msrrp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-rrp"
 )
 
 // baseRegDeleteKeyRequest carries the [in] parameters of BaseRegDeleteKey.
 type baseRegDeleteKeyRequest struct {
-	HKey     structures.RPC_HKEY
-	LpSubKey structures.RRP_UNICODE_STRING
+	HKey     msrrp.RPC_HKEY
+	LpSubKey msrrp.RRP_UNICODE_STRING
 }
 
 func (*baseRegDeleteKeyRequest) Opnum() uint16 { return winreg.OpnumBaseRegDeleteKey }
@@ -23,7 +23,7 @@ type baseRegDeleteKeyResponse struct {
 
 // BaseRegDeleteKey calls BaseRegDeleteKey (opnum 7) ([MS-RRP] — verify the parameter
 // modeling and status handling).
-func BaseRegDeleteKey(rpc ndr.Invoker, hKey structures.RPC_HKEY, lpSubKey structures.RRP_UNICODE_STRING) (err error) {
+func BaseRegDeleteKey(rpc ndr.Invoker, hKey msrrp.RPC_HKEY, lpSubKey msrrp.RRP_UNICODE_STRING) (err error) {
 	req := &baseRegDeleteKeyRequest{
 		HKey:     hKey,
 		LpSubKey: lpSubKey,

--- a/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/08_BaseRegDeleteValue.go
+++ b/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/08_BaseRegDeleteValue.go
@@ -4,14 +4,14 @@ import (
 	"fmt"
 
 	winreg "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0"
-	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/structures"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	msrrp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-rrp"
 )
 
 // baseRegDeleteValueRequest carries the [in] parameters of BaseRegDeleteValue.
 type baseRegDeleteValueRequest struct {
-	HKey        structures.RPC_HKEY
-	LpValueName structures.RRP_UNICODE_STRING
+	HKey        msrrp.RPC_HKEY
+	LpValueName msrrp.RRP_UNICODE_STRING
 }
 
 func (*baseRegDeleteValueRequest) Opnum() uint16 { return winreg.OpnumBaseRegDeleteValue }
@@ -23,7 +23,7 @@ type baseRegDeleteValueResponse struct {
 
 // BaseRegDeleteValue calls BaseRegDeleteValue (opnum 8) ([MS-RRP] — verify the parameter
 // modeling and status handling).
-func BaseRegDeleteValue(rpc ndr.Invoker, hKey structures.RPC_HKEY, lpValueName structures.RRP_UNICODE_STRING) (err error) {
+func BaseRegDeleteValue(rpc ndr.Invoker, hKey msrrp.RPC_HKEY, lpValueName msrrp.RRP_UNICODE_STRING) (err error) {
 	req := &baseRegDeleteValueRequest{
 		HKey:        hKey,
 		LpValueName: lpValueName,

--- a/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/09_BaseRegEnumKey.go
+++ b/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/09_BaseRegEnumKey.go
@@ -5,24 +5,24 @@ import (
 
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
 	winreg "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0"
-	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/structures"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	msrrp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-rrp"
 )
 
 // baseRegEnumKeyRequest carries the [in] parameters of BaseRegEnumKey.
 type baseRegEnumKeyRequest struct {
-	HKey              structures.RPC_HKEY
+	HKey              msrrp.RPC_HKEY
 	DwIndex           ndr.DWORD
-	LpNameIn          structures.RRP_UNICODE_STRING
-	LpClassIn         *structures.RRP_UNICODE_STRING `ndr:"unique"`
-	LpftLastWriteTime *dtyp.FILETIME                 `ndr:"unique"`
+	LpNameIn          msrrp.RRP_UNICODE_STRING
+	LpClassIn         *msrrp.RRP_UNICODE_STRING `ndr:"unique"`
+	LpftLastWriteTime *dtyp.FILETIME            `ndr:"unique"`
 }
 
 func (*baseRegEnumKeyRequest) Opnum() uint16 { return winreg.OpnumBaseRegEnumKey }
 
 // baseRegEnumKeyResponse carries the [out] parameters and return value of BaseRegEnumKey.
 type baseRegEnumKeyResponse struct {
-	LpNameOut         structures.RRP_UNICODE_STRING
+	LpNameOut         msrrp.RRP_UNICODE_STRING
 	LplpClassOut      *dtyp.RPC_UNICODE_STRING `ndr:"unique"`
 	LpftLastWriteTime *dtyp.FILETIME           `ndr:"unique"`
 	Status            ndr.DWORD                `ndr:"retval"`
@@ -30,7 +30,7 @@ type baseRegEnumKeyResponse struct {
 
 // BaseRegEnumKey calls BaseRegEnumKey (opnum 9) ([MS-RRP] — verify the parameter
 // modeling and status handling).
-func BaseRegEnumKey(rpc ndr.Invoker, hKey structures.RPC_HKEY, dwIndex ndr.DWORD, lpNameIn structures.RRP_UNICODE_STRING, lpClassIn *structures.RRP_UNICODE_STRING, lpftLastWriteTime *dtyp.FILETIME) (LpNameOut structures.RRP_UNICODE_STRING, LplpClassOut *dtyp.RPC_UNICODE_STRING, LpftLastWriteTime *dtyp.FILETIME, err error) {
+func BaseRegEnumKey(rpc ndr.Invoker, hKey msrrp.RPC_HKEY, dwIndex ndr.DWORD, lpNameIn msrrp.RRP_UNICODE_STRING, lpClassIn *msrrp.RRP_UNICODE_STRING, lpftLastWriteTime *dtyp.FILETIME) (LpNameOut msrrp.RRP_UNICODE_STRING, LplpClassOut *dtyp.RPC_UNICODE_STRING, LpftLastWriteTime *dtyp.FILETIME, err error) {
 	req := &baseRegEnumKeyRequest{
 		HKey:              hKey,
 		DwIndex:           dwIndex,

--- a/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/10_BaseRegEnumValue.go
+++ b/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/10_BaseRegEnumValue.go
@@ -5,15 +5,15 @@ import (
 
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
 	winreg "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0"
-	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/structures"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	msrrp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-rrp"
 )
 
 // baseRegEnumValueRequest carries the [in] parameters of BaseRegEnumValue.
 type baseRegEnumValueRequest struct {
-	HKey          structures.RPC_HKEY
+	HKey          msrrp.RPC_HKEY
 	DwIndex       ndr.DWORD
-	LpValueNameIn structures.RRP_UNICODE_STRING
+	LpValueNameIn msrrp.RRP_UNICODE_STRING
 	LpType        *ndr.DWORD `ndr:"unique"`
 	LpData        []uint8    `ndr:"unique,varying"`
 	LpcbData      *ndr.DWORD `ndr:"unique"`
@@ -34,7 +34,7 @@ type baseRegEnumValueResponse struct {
 
 // BaseRegEnumValue calls BaseRegEnumValue (opnum 10) ([MS-RRP] — verify the parameter
 // modeling and status handling).
-func BaseRegEnumValue(rpc ndr.Invoker, hKey structures.RPC_HKEY, dwIndex ndr.DWORD, lpValueNameIn structures.RRP_UNICODE_STRING, lpType *ndr.DWORD, lpData []uint8, lpcbData *ndr.DWORD, lpcbLen *ndr.DWORD) (LpValueNameOut dtyp.RPC_UNICODE_STRING, LpType *ndr.DWORD, LpData []uint8, LpcbData *ndr.DWORD, LpcbLen *ndr.DWORD, err error) {
+func BaseRegEnumValue(rpc ndr.Invoker, hKey msrrp.RPC_HKEY, dwIndex ndr.DWORD, lpValueNameIn msrrp.RRP_UNICODE_STRING, lpType *ndr.DWORD, lpData []uint8, lpcbData *ndr.DWORD, lpcbLen *ndr.DWORD) (LpValueNameOut dtyp.RPC_UNICODE_STRING, LpType *ndr.DWORD, LpData []uint8, LpcbData *ndr.DWORD, LpcbLen *ndr.DWORD, err error) {
 	req := &baseRegEnumValueRequest{
 		HKey:          hKey,
 		DwIndex:       dwIndex,

--- a/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/11_BaseRegFlushKey.go
+++ b/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/11_BaseRegFlushKey.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 
 	winreg "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0"
-	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/structures"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	msrrp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-rrp"
 )
 
 // baseRegFlushKeyRequest carries the [in] parameters of BaseRegFlushKey.
 type baseRegFlushKeyRequest struct {
-	HKey structures.RPC_HKEY
+	HKey msrrp.RPC_HKEY
 }
 
 func (*baseRegFlushKeyRequest) Opnum() uint16 { return winreg.OpnumBaseRegFlushKey }
@@ -22,7 +22,7 @@ type baseRegFlushKeyResponse struct {
 
 // BaseRegFlushKey calls BaseRegFlushKey (opnum 11) ([MS-RRP] — verify the parameter
 // modeling and status handling).
-func BaseRegFlushKey(rpc ndr.Invoker, hKey structures.RPC_HKEY) (err error) {
+func BaseRegFlushKey(rpc ndr.Invoker, hKey msrrp.RPC_HKEY) (err error) {
 	req := &baseRegFlushKeyRequest{
 		HKey: hKey,
 	}

--- a/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/12_BaseRegGetKeySecurity.go
+++ b/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/12_BaseRegGetKeySecurity.go
@@ -4,28 +4,28 @@ import (
 	"fmt"
 
 	winreg "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0"
-	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/structures"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	msrrp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-rrp"
 )
 
 // baseRegGetKeySecurityRequest carries the [in] parameters of BaseRegGetKeySecurity.
 type baseRegGetKeySecurityRequest struct {
-	HKey                     structures.RPC_HKEY
+	HKey                     msrrp.RPC_HKEY
 	SecurityInformation      ndr.DWORD
-	PRpcSecurityDescriptorIn structures.RPC_SECURITY_DESCRIPTOR
+	PRpcSecurityDescriptorIn msrrp.RPC_SECURITY_DESCRIPTOR
 }
 
 func (*baseRegGetKeySecurityRequest) Opnum() uint16 { return winreg.OpnumBaseRegGetKeySecurity }
 
 // baseRegGetKeySecurityResponse carries the [out] parameters and return value of BaseRegGetKeySecurity.
 type baseRegGetKeySecurityResponse struct {
-	PRpcSecurityDescriptorOut structures.RPC_SECURITY_DESCRIPTOR
+	PRpcSecurityDescriptorOut msrrp.RPC_SECURITY_DESCRIPTOR
 	Status                    ndr.DWORD `ndr:"retval"`
 }
 
 // BaseRegGetKeySecurity calls BaseRegGetKeySecurity (opnum 12) ([MS-RRP] — verify the parameter
 // modeling and status handling).
-func BaseRegGetKeySecurity(rpc ndr.Invoker, hKey structures.RPC_HKEY, securityInformation ndr.DWORD, pRpcSecurityDescriptorIn structures.RPC_SECURITY_DESCRIPTOR) (PRpcSecurityDescriptorOut structures.RPC_SECURITY_DESCRIPTOR, err error) {
+func BaseRegGetKeySecurity(rpc ndr.Invoker, hKey msrrp.RPC_HKEY, securityInformation ndr.DWORD, pRpcSecurityDescriptorIn msrrp.RPC_SECURITY_DESCRIPTOR) (PRpcSecurityDescriptorOut msrrp.RPC_SECURITY_DESCRIPTOR, err error) {
 	req := &baseRegGetKeySecurityRequest{
 		HKey:                     hKey,
 		SecurityInformation:      securityInformation,

--- a/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/13_BaseRegLoadKey.go
+++ b/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/13_BaseRegLoadKey.go
@@ -4,15 +4,15 @@ import (
 	"fmt"
 
 	winreg "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0"
-	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/structures"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	msrrp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-rrp"
 )
 
 // baseRegLoadKeyRequest carries the [in] parameters of BaseRegLoadKey.
 type baseRegLoadKeyRequest struct {
-	HKey     structures.RPC_HKEY
-	LpSubKey structures.RRP_UNICODE_STRING
-	LpFile   structures.RRP_UNICODE_STRING
+	HKey     msrrp.RPC_HKEY
+	LpSubKey msrrp.RRP_UNICODE_STRING
+	LpFile   msrrp.RRP_UNICODE_STRING
 }
 
 func (*baseRegLoadKeyRequest) Opnum() uint16 { return winreg.OpnumBaseRegLoadKey }
@@ -24,7 +24,7 @@ type baseRegLoadKeyResponse struct {
 
 // BaseRegLoadKey calls BaseRegLoadKey (opnum 13) ([MS-RRP] — verify the parameter
 // modeling and status handling).
-func BaseRegLoadKey(rpc ndr.Invoker, hKey structures.RPC_HKEY, lpSubKey structures.RRP_UNICODE_STRING, lpFile structures.RRP_UNICODE_STRING) (err error) {
+func BaseRegLoadKey(rpc ndr.Invoker, hKey msrrp.RPC_HKEY, lpSubKey msrrp.RRP_UNICODE_STRING, lpFile msrrp.RRP_UNICODE_STRING) (err error) {
 	req := &baseRegLoadKeyRequest{
 		HKey:     hKey,
 		LpSubKey: lpSubKey,

--- a/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/15_BaseRegOpenKey.go
+++ b/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/15_BaseRegOpenKey.go
@@ -4,14 +4,14 @@ import (
 	"fmt"
 
 	winreg "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0"
-	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/structures"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	msrrp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-rrp"
 )
 
 // baseRegOpenKeyRequest carries the [in] parameters of BaseRegOpenKey.
 type baseRegOpenKeyRequest struct {
-	HKey       structures.RPC_HKEY
-	LpSubKey   structures.RRP_UNICODE_STRING
+	HKey       msrrp.RPC_HKEY
+	LpSubKey   msrrp.RRP_UNICODE_STRING
 	DwOptions  ndr.DWORD
 	SamDesired ndr.DWORD
 }
@@ -20,13 +20,13 @@ func (*baseRegOpenKeyRequest) Opnum() uint16 { return winreg.OpnumBaseRegOpenKey
 
 // baseRegOpenKeyResponse carries the [out] parameters and return value of BaseRegOpenKey.
 type baseRegOpenKeyResponse struct {
-	PhkResult structures.PRPC_HKEY
+	PhkResult msrrp.PRPC_HKEY
 	Status    ndr.DWORD `ndr:"retval"`
 }
 
 // BaseRegOpenKey calls BaseRegOpenKey (opnum 15) ([MS-RRP] — verify the parameter
 // modeling and status handling).
-func BaseRegOpenKey(rpc ndr.Invoker, hKey structures.RPC_HKEY, lpSubKey structures.RRP_UNICODE_STRING, dwOptions ndr.DWORD, samDesired ndr.DWORD) (PhkResult structures.PRPC_HKEY, err error) {
+func BaseRegOpenKey(rpc ndr.Invoker, hKey msrrp.RPC_HKEY, lpSubKey msrrp.RRP_UNICODE_STRING, dwOptions ndr.DWORD, samDesired ndr.DWORD) (PhkResult msrrp.PRPC_HKEY, err error) {
 	req := &baseRegOpenKeyRequest{
 		HKey:       hKey,
 		LpSubKey:   lpSubKey,

--- a/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/16_BaseRegQueryInfoKey.go
+++ b/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/16_BaseRegQueryInfoKey.go
@@ -5,14 +5,14 @@ import (
 
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
 	winreg "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0"
-	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/structures"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	msrrp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-rrp"
 )
 
 // baseRegQueryInfoKeyRequest carries the [in] parameters of BaseRegQueryInfoKey.
 type baseRegQueryInfoKeyRequest struct {
-	HKey      structures.RPC_HKEY
-	LpClassIn structures.RRP_UNICODE_STRING
+	HKey      msrrp.RPC_HKEY
+	LpClassIn msrrp.RRP_UNICODE_STRING
 }
 
 func (*baseRegQueryInfoKeyRequest) Opnum() uint16 { return winreg.OpnumBaseRegQueryInfoKey }
@@ -33,7 +33,7 @@ type baseRegQueryInfoKeyResponse struct {
 
 // BaseRegQueryInfoKey calls BaseRegQueryInfoKey (opnum 16) ([MS-RRP] — verify the parameter
 // modeling and status handling).
-func BaseRegQueryInfoKey(rpc ndr.Invoker, hKey structures.RPC_HKEY, lpClassIn structures.RRP_UNICODE_STRING) (LpClassOut dtyp.RPC_UNICODE_STRING, LpcSubKeys ndr.DWORD, LpcbMaxSubKeyLen ndr.DWORD, LpcbMaxClassLen ndr.DWORD, LpcValues ndr.DWORD, LpcbMaxValueNameLen ndr.DWORD, LpcbMaxValueLen ndr.DWORD, LpcbSecurityDescriptor ndr.DWORD, LpftLastWriteTime dtyp.FILETIME, err error) {
+func BaseRegQueryInfoKey(rpc ndr.Invoker, hKey msrrp.RPC_HKEY, lpClassIn msrrp.RRP_UNICODE_STRING) (LpClassOut dtyp.RPC_UNICODE_STRING, LpcSubKeys ndr.DWORD, LpcbMaxSubKeyLen ndr.DWORD, LpcbMaxClassLen ndr.DWORD, LpcValues ndr.DWORD, LpcbMaxValueNameLen ndr.DWORD, LpcbMaxValueLen ndr.DWORD, LpcbSecurityDescriptor ndr.DWORD, LpftLastWriteTime dtyp.FILETIME, err error) {
 	req := &baseRegQueryInfoKeyRequest{
 		HKey:      hKey,
 		LpClassIn: lpClassIn,

--- a/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/17_BaseRegQueryValue.go
+++ b/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/17_BaseRegQueryValue.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	winreg "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0"
-	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/structures"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	msrrp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-rrp"
 )
 
 // baseRegQueryValueRequest carries the [in] parameters of BaseRegQueryValue.
@@ -20,8 +20,8 @@ import (
 // derive both counts from len(LpData), transmitting an actual_count that contradicts *lpcbLen
 // and a full input body on a value read, which a DC rejects with nca_s_fault_ndr.
 type baseRegQueryValueRequest struct {
-	HKey        structures.RPC_HKEY
-	LpValueName structures.RRP_UNICODE_STRING
+	HKey        msrrp.RPC_HKEY
+	LpValueName msrrp.RRP_UNICODE_STRING
 	LpType      *ndr.DWORD `ndr:"unique"`
 	LpData      []uint8    `ndr:"unique,size_is=LpcbData,varying,length_is=LpcbLen"`
 	LpcbData    *ndr.DWORD `ndr:"unique"`
@@ -41,7 +41,7 @@ type baseRegQueryValueResponse struct {
 
 // BaseRegQueryValue calls BaseRegQueryValue (opnum 17) ([MS-RRP] — verify the parameter
 // modeling and status handling).
-func BaseRegQueryValue(rpc ndr.Invoker, hKey structures.RPC_HKEY, lpValueName structures.RRP_UNICODE_STRING, lpType *ndr.DWORD, lpData []uint8, lpcbData *ndr.DWORD, lpcbLen *ndr.DWORD) (LpType *ndr.DWORD, LpData []uint8, LpcbData *ndr.DWORD, LpcbLen *ndr.DWORD, err error) {
+func BaseRegQueryValue(rpc ndr.Invoker, hKey msrrp.RPC_HKEY, lpValueName msrrp.RRP_UNICODE_STRING, lpType *ndr.DWORD, lpData []uint8, lpcbData *ndr.DWORD, lpcbLen *ndr.DWORD) (LpType *ndr.DWORD, LpData []uint8, LpcbData *ndr.DWORD, LpcbLen *ndr.DWORD, err error) {
 	req := &baseRegQueryValueRequest{
 		HKey:        hKey,
 		LpValueName: lpValueName,

--- a/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/18_BaseRegReplaceKey.go
+++ b/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/18_BaseRegReplaceKey.go
@@ -4,16 +4,16 @@ import (
 	"fmt"
 
 	winreg "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0"
-	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/structures"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	msrrp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-rrp"
 )
 
 // baseRegReplaceKeyRequest carries the [in] parameters of BaseRegReplaceKey.
 type baseRegReplaceKeyRequest struct {
-	HKey      structures.RPC_HKEY
-	LpSubKey  structures.RRP_UNICODE_STRING
-	LpNewFile structures.RRP_UNICODE_STRING
-	LpOldFile structures.RRP_UNICODE_STRING
+	HKey      msrrp.RPC_HKEY
+	LpSubKey  msrrp.RRP_UNICODE_STRING
+	LpNewFile msrrp.RRP_UNICODE_STRING
+	LpOldFile msrrp.RRP_UNICODE_STRING
 }
 
 func (*baseRegReplaceKeyRequest) Opnum() uint16 { return winreg.OpnumBaseRegReplaceKey }
@@ -25,7 +25,7 @@ type baseRegReplaceKeyResponse struct {
 
 // BaseRegReplaceKey calls BaseRegReplaceKey (opnum 18) ([MS-RRP] — verify the parameter
 // modeling and status handling).
-func BaseRegReplaceKey(rpc ndr.Invoker, hKey structures.RPC_HKEY, lpSubKey structures.RRP_UNICODE_STRING, lpNewFile structures.RRP_UNICODE_STRING, lpOldFile structures.RRP_UNICODE_STRING) (err error) {
+func BaseRegReplaceKey(rpc ndr.Invoker, hKey msrrp.RPC_HKEY, lpSubKey msrrp.RRP_UNICODE_STRING, lpNewFile msrrp.RRP_UNICODE_STRING, lpOldFile msrrp.RRP_UNICODE_STRING) (err error) {
 	req := &baseRegReplaceKeyRequest{
 		HKey:      hKey,
 		LpSubKey:  lpSubKey,

--- a/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/19_BaseRegRestoreKey.go
+++ b/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/19_BaseRegRestoreKey.go
@@ -4,14 +4,14 @@ import (
 	"fmt"
 
 	winreg "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0"
-	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/structures"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	msrrp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-rrp"
 )
 
 // baseRegRestoreKeyRequest carries the [in] parameters of BaseRegRestoreKey.
 type baseRegRestoreKeyRequest struct {
-	HKey   structures.RPC_HKEY
-	LpFile structures.RRP_UNICODE_STRING
+	HKey   msrrp.RPC_HKEY
+	LpFile msrrp.RRP_UNICODE_STRING
 	Flags  ndr.DWORD
 }
 
@@ -24,7 +24,7 @@ type baseRegRestoreKeyResponse struct {
 
 // BaseRegRestoreKey calls BaseRegRestoreKey (opnum 19) ([MS-RRP] — verify the parameter
 // modeling and status handling).
-func BaseRegRestoreKey(rpc ndr.Invoker, hKey structures.RPC_HKEY, lpFile structures.RRP_UNICODE_STRING, flags ndr.DWORD) (err error) {
+func BaseRegRestoreKey(rpc ndr.Invoker, hKey msrrp.RPC_HKEY, lpFile msrrp.RRP_UNICODE_STRING, flags ndr.DWORD) (err error) {
 	req := &baseRegRestoreKeyRequest{
 		HKey:   hKey,
 		LpFile: lpFile,

--- a/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/20_BaseRegSaveKey.go
+++ b/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/20_BaseRegSaveKey.go
@@ -4,15 +4,15 @@ import (
 	"fmt"
 
 	winreg "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0"
-	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/structures"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	msrrp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-rrp"
 )
 
 // baseRegSaveKeyRequest carries the [in] parameters of BaseRegSaveKey.
 type baseRegSaveKeyRequest struct {
-	HKey                structures.RPC_HKEY
-	LpFile              structures.RRP_UNICODE_STRING
-	PSecurityAttributes *structures.RPC_SECURITY_ATTRIBUTES `ndr:"unique"`
+	HKey                msrrp.RPC_HKEY
+	LpFile              msrrp.RRP_UNICODE_STRING
+	PSecurityAttributes *msrrp.RPC_SECURITY_ATTRIBUTES `ndr:"unique"`
 }
 
 func (*baseRegSaveKeyRequest) Opnum() uint16 { return winreg.OpnumBaseRegSaveKey }
@@ -24,7 +24,7 @@ type baseRegSaveKeyResponse struct {
 
 // BaseRegSaveKey calls BaseRegSaveKey (opnum 20) ([MS-RRP] — verify the parameter
 // modeling and status handling).
-func BaseRegSaveKey(rpc ndr.Invoker, hKey structures.RPC_HKEY, lpFile structures.RRP_UNICODE_STRING, pSecurityAttributes *structures.RPC_SECURITY_ATTRIBUTES) (err error) {
+func BaseRegSaveKey(rpc ndr.Invoker, hKey msrrp.RPC_HKEY, lpFile msrrp.RRP_UNICODE_STRING, pSecurityAttributes *msrrp.RPC_SECURITY_ATTRIBUTES) (err error) {
 	req := &baseRegSaveKeyRequest{
 		HKey:                hKey,
 		LpFile:              lpFile,

--- a/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/21_BaseRegSetKeySecurity.go
+++ b/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/21_BaseRegSetKeySecurity.go
@@ -4,15 +4,15 @@ import (
 	"fmt"
 
 	winreg "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0"
-	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/structures"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	msrrp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-rrp"
 )
 
 // baseRegSetKeySecurityRequest carries the [in] parameters of BaseRegSetKeySecurity.
 type baseRegSetKeySecurityRequest struct {
-	HKey                   structures.RPC_HKEY
+	HKey                   msrrp.RPC_HKEY
 	SecurityInformation    ndr.DWORD
-	PRpcSecurityDescriptor structures.RPC_SECURITY_DESCRIPTOR
+	PRpcSecurityDescriptor msrrp.RPC_SECURITY_DESCRIPTOR
 }
 
 func (*baseRegSetKeySecurityRequest) Opnum() uint16 { return winreg.OpnumBaseRegSetKeySecurity }
@@ -24,7 +24,7 @@ type baseRegSetKeySecurityResponse struct {
 
 // BaseRegSetKeySecurity calls BaseRegSetKeySecurity (opnum 21) ([MS-RRP] — verify the parameter
 // modeling and status handling).
-func BaseRegSetKeySecurity(rpc ndr.Invoker, hKey structures.RPC_HKEY, securityInformation ndr.DWORD, pRpcSecurityDescriptor structures.RPC_SECURITY_DESCRIPTOR) (err error) {
+func BaseRegSetKeySecurity(rpc ndr.Invoker, hKey msrrp.RPC_HKEY, securityInformation ndr.DWORD, pRpcSecurityDescriptor msrrp.RPC_SECURITY_DESCRIPTOR) (err error) {
 	req := &baseRegSetKeySecurityRequest{
 		HKey:                   hKey,
 		SecurityInformation:    securityInformation,

--- a/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/22_BaseRegSetValue.go
+++ b/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/22_BaseRegSetValue.go
@@ -4,14 +4,14 @@ import (
 	"fmt"
 
 	winreg "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0"
-	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/structures"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	msrrp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-rrp"
 )
 
 // baseRegSetValueRequest carries the [in] parameters of BaseRegSetValue.
 type baseRegSetValueRequest struct {
-	HKey        structures.RPC_HKEY
-	LpValueName structures.RRP_UNICODE_STRING
+	HKey        msrrp.RPC_HKEY
+	LpValueName msrrp.RRP_UNICODE_STRING
 	DwType      ndr.DWORD
 	LpData      []uint8 `ndr:"ref,size_is=CbData"`
 	CbData      ndr.DWORD
@@ -26,7 +26,7 @@ type baseRegSetValueResponse struct {
 
 // BaseRegSetValue calls BaseRegSetValue (opnum 22) ([MS-RRP] — verify the parameter
 // modeling and status handling).
-func BaseRegSetValue(rpc ndr.Invoker, hKey structures.RPC_HKEY, lpValueName structures.RRP_UNICODE_STRING, dwType ndr.DWORD, lpData []uint8, cbData ndr.DWORD) (err error) {
+func BaseRegSetValue(rpc ndr.Invoker, hKey msrrp.RPC_HKEY, lpValueName msrrp.RRP_UNICODE_STRING, dwType ndr.DWORD, lpData []uint8, cbData ndr.DWORD) (err error) {
 	req := &baseRegSetValueRequest{
 		HKey:        hKey,
 		LpValueName: lpValueName,

--- a/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/23_BaseRegUnLoadKey.go
+++ b/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/23_BaseRegUnLoadKey.go
@@ -4,14 +4,14 @@ import (
 	"fmt"
 
 	winreg "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0"
-	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/structures"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	msrrp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-rrp"
 )
 
 // baseRegUnLoadKeyRequest carries the [in] parameters of BaseRegUnLoadKey.
 type baseRegUnLoadKeyRequest struct {
-	HKey     structures.RPC_HKEY
-	LpSubKey structures.RRP_UNICODE_STRING
+	HKey     msrrp.RPC_HKEY
+	LpSubKey msrrp.RRP_UNICODE_STRING
 }
 
 func (*baseRegUnLoadKeyRequest) Opnum() uint16 { return winreg.OpnumBaseRegUnLoadKey }
@@ -23,7 +23,7 @@ type baseRegUnLoadKeyResponse struct {
 
 // BaseRegUnLoadKey calls BaseRegUnLoadKey (opnum 23) ([MS-RRP] — verify the parameter
 // modeling and status handling).
-func BaseRegUnLoadKey(rpc ndr.Invoker, hKey structures.RPC_HKEY, lpSubKey structures.RRP_UNICODE_STRING) (err error) {
+func BaseRegUnLoadKey(rpc ndr.Invoker, hKey msrrp.RPC_HKEY, lpSubKey msrrp.RRP_UNICODE_STRING) (err error) {
 	req := &baseRegUnLoadKeyRequest{
 		HKey:     hKey,
 		LpSubKey: lpSubKey,

--- a/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/26_BaseRegGetVersion.go
+++ b/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/26_BaseRegGetVersion.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 
 	winreg "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0"
-	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/structures"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	msrrp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-rrp"
 )
 
 // baseRegGetVersionRequest carries the [in] parameters of BaseRegGetVersion.
 type baseRegGetVersionRequest struct {
-	HKey structures.RPC_HKEY
+	HKey msrrp.RPC_HKEY
 }
 
 func (*baseRegGetVersionRequest) Opnum() uint16 { return winreg.OpnumBaseRegGetVersion }
@@ -23,7 +23,7 @@ type baseRegGetVersionResponse struct {
 
 // BaseRegGetVersion calls BaseRegGetVersion (opnum 26) ([MS-RRP] — verify the parameter
 // modeling and status handling).
-func BaseRegGetVersion(rpc ndr.Invoker, hKey structures.RPC_HKEY) (LpdwVersion ndr.DWORD, err error) {
+func BaseRegGetVersion(rpc ndr.Invoker, hKey msrrp.RPC_HKEY) (LpdwVersion ndr.DWORD, err error) {
 	req := &baseRegGetVersionRequest{
 		HKey: hKey,
 	}

--- a/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/27_OpenCurrentConfig.go
+++ b/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/27_OpenCurrentConfig.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	winreg "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0"
-	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/structures"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	msrrp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-rrp"
 )
 
 // openCurrentConfigRequest carries the [in] parameters of OpenCurrentConfig.
@@ -18,13 +18,13 @@ func (*openCurrentConfigRequest) Opnum() uint16 { return winreg.OpnumOpenCurrent
 
 // openCurrentConfigResponse carries the [out] parameters and return value of OpenCurrentConfig.
 type openCurrentConfigResponse struct {
-	PhKey  structures.PRPC_HKEY
+	PhKey  msrrp.PRPC_HKEY
 	Status ndr.DWORD `ndr:"retval"`
 }
 
 // OpenCurrentConfig calls OpenCurrentConfig (opnum 27) ([MS-RRP] — verify the parameter
 // modeling and status handling).
-func OpenCurrentConfig(rpc ndr.Invoker, serverName *ndr.WSTR, samDesired ndr.DWORD) (PhKey structures.PRPC_HKEY, err error) {
+func OpenCurrentConfig(rpc ndr.Invoker, serverName *ndr.WSTR, samDesired ndr.DWORD) (PhKey msrrp.PRPC_HKEY, err error) {
 	req := &openCurrentConfigRequest{
 		ServerName: serverName,
 		SamDesired: samDesired,

--- a/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/29_BaseRegQueryMultipleValues.go
+++ b/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/29_BaseRegQueryMultipleValues.go
@@ -4,14 +4,14 @@ import (
 	"fmt"
 
 	winreg "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0"
-	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/structures"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	msrrp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-rrp"
 )
 
 // baseRegQueryMultipleValuesRequest carries the [in] parameters of BaseRegQueryMultipleValues.
 type baseRegQueryMultipleValuesRequest struct {
-	HKey       structures.RPC_HKEY
-	Val_listIn []structures.RVALENT `ndr:"ref,size_is=Num_vals,varying,length_is=Num_vals"`
+	HKey       msrrp.RPC_HKEY
+	Val_listIn []msrrp.RVALENT `ndr:"ref,size_is=Num_vals,varying,length_is=Num_vals"`
 	Num_vals   ndr.DWORD
 	LpvalueBuf []byte `ndr:"unique,varying"`
 	LdwTotsize ndr.DWORD
@@ -23,15 +23,15 @@ func (*baseRegQueryMultipleValuesRequest) Opnum() uint16 {
 
 // baseRegQueryMultipleValuesResponse carries the [out] parameters and return value of BaseRegQueryMultipleValues.
 type baseRegQueryMultipleValuesResponse struct {
-	Val_listOut []structures.RVALENT `ndr:"ref,size_is=Num_vals,varying,length_is=Num_vals"`
-	LpvalueBuf  []byte               `ndr:"unique,varying"`
+	Val_listOut []msrrp.RVALENT `ndr:"ref,size_is=Num_vals,varying,length_is=Num_vals"`
+	LpvalueBuf  []byte          `ndr:"unique,varying"`
 	LdwTotsize  ndr.DWORD
 	Status      ndr.DWORD `ndr:"retval"`
 }
 
 // BaseRegQueryMultipleValues calls BaseRegQueryMultipleValues (opnum 29) ([MS-RRP] — verify the parameter
 // modeling and status handling).
-func BaseRegQueryMultipleValues(rpc ndr.Invoker, hKey structures.RPC_HKEY, val_listIn []structures.RVALENT, num_vals ndr.DWORD, lpvalueBuf []byte, ldwTotsize ndr.DWORD) (Val_listOut []structures.RVALENT, LpvalueBuf []byte, LdwTotsize ndr.DWORD, err error) {
+func BaseRegQueryMultipleValues(rpc ndr.Invoker, hKey msrrp.RPC_HKEY, val_listIn []msrrp.RVALENT, num_vals ndr.DWORD, lpvalueBuf []byte, ldwTotsize ndr.DWORD) (Val_listOut []msrrp.RVALENT, LpvalueBuf []byte, LdwTotsize ndr.DWORD, err error) {
 	req := &baseRegQueryMultipleValuesRequest{
 		HKey:       hKey,
 		Val_listIn: val_listIn,

--- a/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/31_BaseRegSaveKeyEx.go
+++ b/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/31_BaseRegSaveKeyEx.go
@@ -4,15 +4,15 @@ import (
 	"fmt"
 
 	winreg "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0"
-	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/structures"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	msrrp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-rrp"
 )
 
 // baseRegSaveKeyExRequest carries the [in] parameters of BaseRegSaveKeyEx.
 type baseRegSaveKeyExRequest struct {
-	HKey                structures.RPC_HKEY
-	LpFile              structures.RRP_UNICODE_STRING
-	PSecurityAttributes *structures.RPC_SECURITY_ATTRIBUTES `ndr:"unique"`
+	HKey                msrrp.RPC_HKEY
+	LpFile              msrrp.RRP_UNICODE_STRING
+	PSecurityAttributes *msrrp.RPC_SECURITY_ATTRIBUTES `ndr:"unique"`
 	Flags               ndr.DWORD
 }
 
@@ -25,7 +25,7 @@ type baseRegSaveKeyExResponse struct {
 
 // BaseRegSaveKeyEx calls BaseRegSaveKeyEx (opnum 31) ([MS-RRP] — verify the parameter
 // modeling and status handling).
-func BaseRegSaveKeyEx(rpc ndr.Invoker, hKey structures.RPC_HKEY, lpFile structures.RRP_UNICODE_STRING, pSecurityAttributes *structures.RPC_SECURITY_ATTRIBUTES, flags ndr.DWORD) (err error) {
+func BaseRegSaveKeyEx(rpc ndr.Invoker, hKey msrrp.RPC_HKEY, lpFile msrrp.RRP_UNICODE_STRING, pSecurityAttributes *msrrp.RPC_SECURITY_ATTRIBUTES, flags ndr.DWORD) (err error) {
 	req := &baseRegSaveKeyExRequest{
 		HKey:                hKey,
 		LpFile:              lpFile,

--- a/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/32_OpenPerformanceText.go
+++ b/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/32_OpenPerformanceText.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	winreg "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0"
-	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/structures"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	msrrp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-rrp"
 )
 
 // openPerformanceTextRequest carries the [in] parameters of OpenPerformanceText.
@@ -18,13 +18,13 @@ func (*openPerformanceTextRequest) Opnum() uint16 { return winreg.OpnumOpenPerfo
 
 // openPerformanceTextResponse carries the [out] parameters and return value of OpenPerformanceText.
 type openPerformanceTextResponse struct {
-	PhKey  structures.PRPC_HKEY
+	PhKey  msrrp.PRPC_HKEY
 	Status ndr.DWORD `ndr:"retval"`
 }
 
 // OpenPerformanceText calls OpenPerformanceText (opnum 32) ([MS-RRP] — verify the parameter
 // modeling and status handling).
-func OpenPerformanceText(rpc ndr.Invoker, serverName *ndr.WSTR, samDesired ndr.DWORD) (PhKey structures.PRPC_HKEY, err error) {
+func OpenPerformanceText(rpc ndr.Invoker, serverName *ndr.WSTR, samDesired ndr.DWORD) (PhKey msrrp.PRPC_HKEY, err error) {
 	req := &openPerformanceTextRequest{
 		ServerName: serverName,
 		SamDesired: samDesired,

--- a/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/33_OpenPerformanceNlsText.go
+++ b/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/33_OpenPerformanceNlsText.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	winreg "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0"
-	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/structures"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	msrrp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-rrp"
 )
 
 // openPerformanceNlsTextRequest carries the [in] parameters of OpenPerformanceNlsText.
@@ -18,13 +18,13 @@ func (*openPerformanceNlsTextRequest) Opnum() uint16 { return winreg.OpnumOpenPe
 
 // openPerformanceNlsTextResponse carries the [out] parameters and return value of OpenPerformanceNlsText.
 type openPerformanceNlsTextResponse struct {
-	PhKey  structures.PRPC_HKEY
+	PhKey  msrrp.PRPC_HKEY
 	Status ndr.DWORD `ndr:"retval"`
 }
 
 // OpenPerformanceNlsText calls OpenPerformanceNlsText (opnum 33) ([MS-RRP] — verify the parameter
 // modeling and status handling).
-func OpenPerformanceNlsText(rpc ndr.Invoker, serverName *ndr.WSTR, samDesired ndr.DWORD) (PhKey structures.PRPC_HKEY, err error) {
+func OpenPerformanceNlsText(rpc ndr.Invoker, serverName *ndr.WSTR, samDesired ndr.DWORD) (PhKey msrrp.PRPC_HKEY, err error) {
 	req := &openPerformanceNlsTextRequest{
 		ServerName: serverName,
 		SamDesired: samDesired,

--- a/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/34_BaseRegQueryMultipleValues2.go
+++ b/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/34_BaseRegQueryMultipleValues2.go
@@ -4,14 +4,14 @@ import (
 	"fmt"
 
 	winreg "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0"
-	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/structures"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	msrrp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-rrp"
 )
 
 // baseRegQueryMultipleValues2Request carries the [in] parameters of BaseRegQueryMultipleValues2.
 type baseRegQueryMultipleValues2Request struct {
-	HKey       structures.RPC_HKEY
-	Val_listIn []structures.RVALENT `ndr:"ref,size_is=Num_vals,varying,length_is=Num_vals"`
+	HKey       msrrp.RPC_HKEY
+	Val_listIn []msrrp.RVALENT `ndr:"ref,size_is=Num_vals,varying,length_is=Num_vals"`
 	Num_vals   ndr.DWORD
 	LpvalueBuf []byte `ndr:"unique,varying"`
 	LdwTotsize ndr.DWORD
@@ -23,15 +23,15 @@ func (*baseRegQueryMultipleValues2Request) Opnum() uint16 {
 
 // baseRegQueryMultipleValues2Response carries the [out] parameters and return value of BaseRegQueryMultipleValues2.
 type baseRegQueryMultipleValues2Response struct {
-	Val_listOut     []structures.RVALENT `ndr:"ref,size_is=Num_vals,varying,length_is=Num_vals"`
-	LpvalueBuf      []byte               `ndr:"unique,varying"`
+	Val_listOut     []msrrp.RVALENT `ndr:"ref,size_is=Num_vals,varying,length_is=Num_vals"`
+	LpvalueBuf      []byte          `ndr:"unique,varying"`
 	LdwRequiredSize ndr.DWORD
 	Status          ndr.DWORD `ndr:"retval"`
 }
 
 // BaseRegQueryMultipleValues2 calls BaseRegQueryMultipleValues2 (opnum 34) ([MS-RRP] — verify the parameter
 // modeling and status handling).
-func BaseRegQueryMultipleValues2(rpc ndr.Invoker, hKey structures.RPC_HKEY, val_listIn []structures.RVALENT, num_vals ndr.DWORD, lpvalueBuf []byte, ldwTotsize ndr.DWORD) (Val_listOut []structures.RVALENT, LpvalueBuf []byte, LdwRequiredSize ndr.DWORD, err error) {
+func BaseRegQueryMultipleValues2(rpc ndr.Invoker, hKey msrrp.RPC_HKEY, val_listIn []msrrp.RVALENT, num_vals ndr.DWORD, lpvalueBuf []byte, ldwTotsize ndr.DWORD) (Val_listOut []msrrp.RVALENT, LpvalueBuf []byte, LdwRequiredSize ndr.DWORD, err error) {
 	req := &baseRegQueryMultipleValues2Request{
 		HKey:       hKey,
 		Val_listIn: val_listIn,

--- a/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/35_BaseRegDeleteKeyEx.go
+++ b/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/35_BaseRegDeleteKeyEx.go
@@ -4,14 +4,14 @@ import (
 	"fmt"
 
 	winreg "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0"
-	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/structures"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	msrrp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-rrp"
 )
 
 // baseRegDeleteKeyExRequest carries the [in] parameters of BaseRegDeleteKeyEx.
 type baseRegDeleteKeyExRequest struct {
-	HKey       structures.RPC_HKEY
-	LpSubKey   structures.RRP_UNICODE_STRING
+	HKey       msrrp.RPC_HKEY
+	LpSubKey   msrrp.RRP_UNICODE_STRING
 	AccessMask ndr.DWORD
 	Reserved   ndr.DWORD
 }
@@ -25,7 +25,7 @@ type baseRegDeleteKeyExResponse struct {
 
 // BaseRegDeleteKeyEx calls BaseRegDeleteKeyEx (opnum 35) ([MS-RRP] — verify the parameter
 // modeling and status handling).
-func BaseRegDeleteKeyEx(rpc ndr.Invoker, hKey structures.RPC_HKEY, lpSubKey structures.RRP_UNICODE_STRING, accessMask ndr.DWORD, reserved ndr.DWORD) (err error) {
+func BaseRegDeleteKeyEx(rpc ndr.Invoker, hKey msrrp.RPC_HKEY, lpSubKey msrrp.RRP_UNICODE_STRING, accessMask ndr.DWORD, reserved ndr.DWORD) (err error) {
 	req := &baseRegDeleteKeyExRequest{
 		HKey:       hKey,
 		LpSubKey:   lpSubKey,

--- a/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/integration_test.go
+++ b/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions/integration_test.go
@@ -27,7 +27,7 @@ import (
 
 	winreg "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions"
-	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/structures"
+	msrrp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-rrp"
 
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
@@ -38,7 +38,7 @@ import (
 
 // regName builds an RRP_UNICODE_STRING for a key/value name, including the terminating NUL
 // in the counted length as [MS-RRP] 3.1.1 requires.
-func regName(s string) structures.RRP_UNICODE_STRING { return dtyp.NewUnicodeString(s + "\x00") }
+func regName(s string) msrrp.RRP_UNICODE_STRING { return dtyp.NewUnicodeString(s + "\x00") }
 
 // isFault reports whether err is a DCE/RPC fault (a wire-modeling failure) rather than a
 // clean Win32 error returned by the server (which validates the wire).
@@ -137,8 +137,8 @@ func TestIntegration_Winreg(t *testing.T) {
 
 		// BaseRegEnumKey (opnum 9): exercises the [in] sized name buffer, the [out,unique]
 		// double-pointer class, and the [in,out,unique] FILETIME pointer.
-		nameIn := structures.RRP_UNICODE_STRING{Length: 0, MaximumLength: 512, Buffer: make([]uint16, 256)}
-		classIn := structures.RRP_UNICODE_STRING{Length: 0, MaximumLength: 512, Buffer: make([]uint16, 256)}
+		nameIn := msrrp.RRP_UNICODE_STRING{Length: 0, MaximumLength: 512, Buffer: make([]uint16, 256)}
+		classIn := msrrp.RRP_UNICODE_STRING{Length: 0, MaximumLength: 512, Buffer: make([]uint16, 256)}
 		if nameOut, _, _, err := functions.BaseRegEnumKey(rpc, hkey, 0, nameIn, &classIn, nil); err != nil {
 			if isFault(err) {
 				t.Errorf("[WIRE FAIL] BaseRegEnumKey: %v", err)

--- a/network/dcerpc/ms-protocols/ms-rrp/client.go
+++ b/network/dcerpc/ms-protocols/ms-rrp/client.go
@@ -25,16 +25,16 @@ import (
 	"fmt"
 
 	winreg "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0"
-	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/structures"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ms-protocols/msproto"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
 	dcerpcclient "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	msrrp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-rrp"
 )
 
 // Handle is an open registry key context handle returned by the Open*/BaseRegCreateKey/
 // BaseRegOpenKey methods. It aliases the interface's RPC_HKEY so it can be passed back to
 // any method without conversion.
-type Handle = structures.RPC_HKEY
+type Handle = msrrp.RPC_HKEY
 
 // ErrNotConnected is returned by methods invoked before a successful Connect.
 var ErrNotConnected = errors.New("ms_rrp: not connected; call Connect first")

--- a/network/dcerpc/ms-protocols/ms-rrp/keys.go
+++ b/network/dcerpc/ms-protocols/ms-rrp/keys.go
@@ -3,8 +3,8 @@ package ms_rrp
 import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions"
-	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/structures"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	msrrp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-rrp"
 )
 
 // The methods in this file mirror the winreg interface functions one-to-one: same name,
@@ -13,7 +13,7 @@ import (
 // ergonomic *ByPath helpers in paths.go are built on top of them.
 
 // OpenClassesRoot calls OpenClassesRoot (opnum 0): opens HKEY_CLASSES_ROOT.
-func (r *RemoteRegistry) OpenClassesRoot(serverName *ndr.WSTR, samDesired ndr.DWORD) (structures.PRPC_HKEY, error) {
+func (r *RemoteRegistry) OpenClassesRoot(serverName *ndr.WSTR, samDesired ndr.DWORD) (msrrp.PRPC_HKEY, error) {
 	if err := r.ensure(); err != nil {
 		return Handle{}, err
 	}
@@ -21,7 +21,7 @@ func (r *RemoteRegistry) OpenClassesRoot(serverName *ndr.WSTR, samDesired ndr.DW
 }
 
 // OpenCurrentUser calls OpenCurrentUser (opnum 1): opens HKEY_CURRENT_USER.
-func (r *RemoteRegistry) OpenCurrentUser(serverName *ndr.WSTR, samDesired ndr.DWORD) (structures.PRPC_HKEY, error) {
+func (r *RemoteRegistry) OpenCurrentUser(serverName *ndr.WSTR, samDesired ndr.DWORD) (msrrp.PRPC_HKEY, error) {
 	if err := r.ensure(); err != nil {
 		return Handle{}, err
 	}
@@ -29,7 +29,7 @@ func (r *RemoteRegistry) OpenCurrentUser(serverName *ndr.WSTR, samDesired ndr.DW
 }
 
 // OpenLocalMachine calls OpenLocalMachine (opnum 2): opens HKEY_LOCAL_MACHINE.
-func (r *RemoteRegistry) OpenLocalMachine(serverName *ndr.WSTR, samDesired ndr.DWORD) (structures.PRPC_HKEY, error) {
+func (r *RemoteRegistry) OpenLocalMachine(serverName *ndr.WSTR, samDesired ndr.DWORD) (msrrp.PRPC_HKEY, error) {
 	if err := r.ensure(); err != nil {
 		return Handle{}, err
 	}
@@ -37,7 +37,7 @@ func (r *RemoteRegistry) OpenLocalMachine(serverName *ndr.WSTR, samDesired ndr.D
 }
 
 // OpenPerformanceData calls OpenPerformanceData (opnum 3): opens HKEY_PERFORMANCE_DATA.
-func (r *RemoteRegistry) OpenPerformanceData(serverName *ndr.WSTR, samDesired ndr.DWORD) (structures.PRPC_HKEY, error) {
+func (r *RemoteRegistry) OpenPerformanceData(serverName *ndr.WSTR, samDesired ndr.DWORD) (msrrp.PRPC_HKEY, error) {
 	if err := r.ensure(); err != nil {
 		return Handle{}, err
 	}
@@ -45,7 +45,7 @@ func (r *RemoteRegistry) OpenPerformanceData(serverName *ndr.WSTR, samDesired nd
 }
 
 // OpenUsers calls OpenUsers (opnum 4): opens HKEY_USERS.
-func (r *RemoteRegistry) OpenUsers(serverName *ndr.WSTR, samDesired ndr.DWORD) (structures.PRPC_HKEY, error) {
+func (r *RemoteRegistry) OpenUsers(serverName *ndr.WSTR, samDesired ndr.DWORD) (msrrp.PRPC_HKEY, error) {
 	if err := r.ensure(); err != nil {
 		return Handle{}, err
 	}
@@ -53,7 +53,7 @@ func (r *RemoteRegistry) OpenUsers(serverName *ndr.WSTR, samDesired ndr.DWORD) (
 }
 
 // OpenCurrentConfig calls OpenCurrentConfig (opnum 27): opens HKEY_CURRENT_CONFIG.
-func (r *RemoteRegistry) OpenCurrentConfig(serverName *ndr.WSTR, samDesired ndr.DWORD) (structures.PRPC_HKEY, error) {
+func (r *RemoteRegistry) OpenCurrentConfig(serverName *ndr.WSTR, samDesired ndr.DWORD) (msrrp.PRPC_HKEY, error) {
 	if err := r.ensure(); err != nil {
 		return Handle{}, err
 	}
@@ -61,7 +61,7 @@ func (r *RemoteRegistry) OpenCurrentConfig(serverName *ndr.WSTR, samDesired ndr.
 }
 
 // OpenPerformanceText calls OpenPerformanceText (opnum 32).
-func (r *RemoteRegistry) OpenPerformanceText(serverName *ndr.WSTR, samDesired ndr.DWORD) (structures.PRPC_HKEY, error) {
+func (r *RemoteRegistry) OpenPerformanceText(serverName *ndr.WSTR, samDesired ndr.DWORD) (msrrp.PRPC_HKEY, error) {
 	if err := r.ensure(); err != nil {
 		return Handle{}, err
 	}
@@ -69,7 +69,7 @@ func (r *RemoteRegistry) OpenPerformanceText(serverName *ndr.WSTR, samDesired nd
 }
 
 // OpenPerformanceNlsText calls OpenPerformanceNlsText (opnum 33).
-func (r *RemoteRegistry) OpenPerformanceNlsText(serverName *ndr.WSTR, samDesired ndr.DWORD) (structures.PRPC_HKEY, error) {
+func (r *RemoteRegistry) OpenPerformanceNlsText(serverName *ndr.WSTR, samDesired ndr.DWORD) (msrrp.PRPC_HKEY, error) {
 	if err := r.ensure(); err != nil {
 		return Handle{}, err
 	}
@@ -77,7 +77,7 @@ func (r *RemoteRegistry) OpenPerformanceNlsText(serverName *ndr.WSTR, samDesired
 }
 
 // BaseRegCloseKey calls BaseRegCloseKey (opnum 5): releases an open key handle.
-func (r *RemoteRegistry) BaseRegCloseKey(hKey structures.PRPC_HKEY) (structures.PRPC_HKEY, error) {
+func (r *RemoteRegistry) BaseRegCloseKey(hKey msrrp.PRPC_HKEY) (msrrp.PRPC_HKEY, error) {
 	if err := r.ensure(); err != nil {
 		return Handle{}, err
 	}
@@ -85,7 +85,7 @@ func (r *RemoteRegistry) BaseRegCloseKey(hKey structures.PRPC_HKEY) (structures.
 }
 
 // BaseRegCreateKey calls BaseRegCreateKey (opnum 6): creates or opens a subkey.
-func (r *RemoteRegistry) BaseRegCreateKey(hKey structures.RPC_HKEY, lpSubKey structures.RRP_UNICODE_STRING, lpClass structures.RRP_UNICODE_STRING, dwOptions ndr.DWORD, samDesired ndr.DWORD, lpSecurityAttributes *structures.RPC_SECURITY_ATTRIBUTES, lpdwDisposition *ndr.DWORD) (structures.PRPC_HKEY, *ndr.DWORD, error) {
+func (r *RemoteRegistry) BaseRegCreateKey(hKey msrrp.RPC_HKEY, lpSubKey msrrp.RRP_UNICODE_STRING, lpClass msrrp.RRP_UNICODE_STRING, dwOptions ndr.DWORD, samDesired ndr.DWORD, lpSecurityAttributes *msrrp.RPC_SECURITY_ATTRIBUTES, lpdwDisposition *ndr.DWORD) (msrrp.PRPC_HKEY, *ndr.DWORD, error) {
 	if err := r.ensure(); err != nil {
 		return Handle{}, nil, err
 	}
@@ -93,7 +93,7 @@ func (r *RemoteRegistry) BaseRegCreateKey(hKey structures.RPC_HKEY, lpSubKey str
 }
 
 // BaseRegDeleteKey calls BaseRegDeleteKey (opnum 7): deletes a subkey with no subkeys.
-func (r *RemoteRegistry) BaseRegDeleteKey(hKey structures.RPC_HKEY, lpSubKey structures.RRP_UNICODE_STRING) error {
+func (r *RemoteRegistry) BaseRegDeleteKey(hKey msrrp.RPC_HKEY, lpSubKey msrrp.RRP_UNICODE_STRING) error {
 	if err := r.ensure(); err != nil {
 		return err
 	}
@@ -101,15 +101,15 @@ func (r *RemoteRegistry) BaseRegDeleteKey(hKey structures.RPC_HKEY, lpSubKey str
 }
 
 // BaseRegEnumKey calls BaseRegEnumKey (opnum 9): returns the subkey at dwIndex.
-func (r *RemoteRegistry) BaseRegEnumKey(hKey structures.RPC_HKEY, dwIndex ndr.DWORD, lpNameIn structures.RRP_UNICODE_STRING, lpClassIn *structures.RRP_UNICODE_STRING, lpftLastWriteTime *dtyp.FILETIME) (structures.RRP_UNICODE_STRING, *dtyp.RPC_UNICODE_STRING, *dtyp.FILETIME, error) {
+func (r *RemoteRegistry) BaseRegEnumKey(hKey msrrp.RPC_HKEY, dwIndex ndr.DWORD, lpNameIn msrrp.RRP_UNICODE_STRING, lpClassIn *msrrp.RRP_UNICODE_STRING, lpftLastWriteTime *dtyp.FILETIME) (msrrp.RRP_UNICODE_STRING, *dtyp.RPC_UNICODE_STRING, *dtyp.FILETIME, error) {
 	if err := r.ensure(); err != nil {
-		return structures.RRP_UNICODE_STRING{}, nil, nil, err
+		return msrrp.RRP_UNICODE_STRING{}, nil, nil, err
 	}
 	return functions.BaseRegEnumKey(r.rpc, hKey, dwIndex, lpNameIn, lpClassIn, lpftLastWriteTime)
 }
 
 // BaseRegFlushKey calls BaseRegFlushKey (opnum 11): writes a key's changes to disk.
-func (r *RemoteRegistry) BaseRegFlushKey(hKey structures.RPC_HKEY) error {
+func (r *RemoteRegistry) BaseRegFlushKey(hKey msrrp.RPC_HKEY) error {
 	if err := r.ensure(); err != nil {
 		return err
 	}
@@ -117,7 +117,7 @@ func (r *RemoteRegistry) BaseRegFlushKey(hKey structures.RPC_HKEY) error {
 }
 
 // BaseRegLoadKey calls BaseRegLoadKey (opnum 13): loads a hive file under a subkey.
-func (r *RemoteRegistry) BaseRegLoadKey(hKey structures.RPC_HKEY, lpSubKey structures.RRP_UNICODE_STRING, lpFile structures.RRP_UNICODE_STRING) error {
+func (r *RemoteRegistry) BaseRegLoadKey(hKey msrrp.RPC_HKEY, lpSubKey msrrp.RRP_UNICODE_STRING, lpFile msrrp.RRP_UNICODE_STRING) error {
 	if err := r.ensure(); err != nil {
 		return err
 	}
@@ -125,7 +125,7 @@ func (r *RemoteRegistry) BaseRegLoadKey(hKey structures.RPC_HKEY, lpSubKey struc
 }
 
 // BaseRegOpenKey calls BaseRegOpenKey (opnum 15): opens an existing subkey.
-func (r *RemoteRegistry) BaseRegOpenKey(hKey structures.RPC_HKEY, lpSubKey structures.RRP_UNICODE_STRING, dwOptions ndr.DWORD, samDesired ndr.DWORD) (structures.PRPC_HKEY, error) {
+func (r *RemoteRegistry) BaseRegOpenKey(hKey msrrp.RPC_HKEY, lpSubKey msrrp.RRP_UNICODE_STRING, dwOptions ndr.DWORD, samDesired ndr.DWORD) (msrrp.PRPC_HKEY, error) {
 	if err := r.ensure(); err != nil {
 		return Handle{}, err
 	}
@@ -134,7 +134,7 @@ func (r *RemoteRegistry) BaseRegOpenKey(hKey structures.RPC_HKEY, lpSubKey struc
 
 // BaseRegQueryInfoKey calls BaseRegQueryInfoKey (opnum 16): returns subkey/value counts,
 // maximum lengths, and the last-write time of a key.
-func (r *RemoteRegistry) BaseRegQueryInfoKey(hKey structures.RPC_HKEY, lpClassIn structures.RRP_UNICODE_STRING) (dtyp.RPC_UNICODE_STRING, ndr.DWORD, ndr.DWORD, ndr.DWORD, ndr.DWORD, ndr.DWORD, ndr.DWORD, ndr.DWORD, dtyp.FILETIME, error) {
+func (r *RemoteRegistry) BaseRegQueryInfoKey(hKey msrrp.RPC_HKEY, lpClassIn msrrp.RRP_UNICODE_STRING) (dtyp.RPC_UNICODE_STRING, ndr.DWORD, ndr.DWORD, ndr.DWORD, ndr.DWORD, ndr.DWORD, ndr.DWORD, ndr.DWORD, dtyp.FILETIME, error) {
 	if err := r.ensure(); err != nil {
 		return dtyp.RPC_UNICODE_STRING{}, 0, 0, 0, 0, 0, 0, 0, dtyp.FILETIME{}, err
 	}
@@ -142,7 +142,7 @@ func (r *RemoteRegistry) BaseRegQueryInfoKey(hKey structures.RPC_HKEY, lpClassIn
 }
 
 // BaseRegReplaceKey calls BaseRegReplaceKey (opnum 18).
-func (r *RemoteRegistry) BaseRegReplaceKey(hKey structures.RPC_HKEY, lpSubKey structures.RRP_UNICODE_STRING, lpNewFile structures.RRP_UNICODE_STRING, lpOldFile structures.RRP_UNICODE_STRING) error {
+func (r *RemoteRegistry) BaseRegReplaceKey(hKey msrrp.RPC_HKEY, lpSubKey msrrp.RRP_UNICODE_STRING, lpNewFile msrrp.RRP_UNICODE_STRING, lpOldFile msrrp.RRP_UNICODE_STRING) error {
 	if err := r.ensure(); err != nil {
 		return err
 	}
@@ -150,7 +150,7 @@ func (r *RemoteRegistry) BaseRegReplaceKey(hKey structures.RPC_HKEY, lpSubKey st
 }
 
 // BaseRegRestoreKey calls BaseRegRestoreKey (opnum 19).
-func (r *RemoteRegistry) BaseRegRestoreKey(hKey structures.RPC_HKEY, lpFile structures.RRP_UNICODE_STRING, flags ndr.DWORD) error {
+func (r *RemoteRegistry) BaseRegRestoreKey(hKey msrrp.RPC_HKEY, lpFile msrrp.RRP_UNICODE_STRING, flags ndr.DWORD) error {
 	if err := r.ensure(); err != nil {
 		return err
 	}
@@ -158,7 +158,7 @@ func (r *RemoteRegistry) BaseRegRestoreKey(hKey structures.RPC_HKEY, lpFile stru
 }
 
 // BaseRegSaveKey calls BaseRegSaveKey (opnum 20): saves a key and its subtree to a file.
-func (r *RemoteRegistry) BaseRegSaveKey(hKey structures.RPC_HKEY, lpFile structures.RRP_UNICODE_STRING, pSecurityAttributes *structures.RPC_SECURITY_ATTRIBUTES) error {
+func (r *RemoteRegistry) BaseRegSaveKey(hKey msrrp.RPC_HKEY, lpFile msrrp.RRP_UNICODE_STRING, pSecurityAttributes *msrrp.RPC_SECURITY_ATTRIBUTES) error {
 	if err := r.ensure(); err != nil {
 		return err
 	}
@@ -166,7 +166,7 @@ func (r *RemoteRegistry) BaseRegSaveKey(hKey structures.RPC_HKEY, lpFile structu
 }
 
 // BaseRegUnLoadKey calls BaseRegUnLoadKey (opnum 23): unloads a previously loaded hive.
-func (r *RemoteRegistry) BaseRegUnLoadKey(hKey structures.RPC_HKEY, lpSubKey structures.RRP_UNICODE_STRING) error {
+func (r *RemoteRegistry) BaseRegUnLoadKey(hKey msrrp.RPC_HKEY, lpSubKey msrrp.RRP_UNICODE_STRING) error {
 	if err := r.ensure(); err != nil {
 		return err
 	}
@@ -174,7 +174,7 @@ func (r *RemoteRegistry) BaseRegUnLoadKey(hKey structures.RPC_HKEY, lpSubKey str
 }
 
 // BaseRegGetVersion calls BaseRegGetVersion (opnum 26): returns the registry version.
-func (r *RemoteRegistry) BaseRegGetVersion(hKey structures.RPC_HKEY) (ndr.DWORD, error) {
+func (r *RemoteRegistry) BaseRegGetVersion(hKey msrrp.RPC_HKEY) (ndr.DWORD, error) {
 	if err := r.ensure(); err != nil {
 		return 0, err
 	}
@@ -182,7 +182,7 @@ func (r *RemoteRegistry) BaseRegGetVersion(hKey structures.RPC_HKEY) (ndr.DWORD,
 }
 
 // BaseRegSaveKeyEx calls BaseRegSaveKeyEx (opnum 31): saves a key with format flags.
-func (r *RemoteRegistry) BaseRegSaveKeyEx(hKey structures.RPC_HKEY, lpFile structures.RRP_UNICODE_STRING, pSecurityAttributes *structures.RPC_SECURITY_ATTRIBUTES, flags ndr.DWORD) error {
+func (r *RemoteRegistry) BaseRegSaveKeyEx(hKey msrrp.RPC_HKEY, lpFile msrrp.RRP_UNICODE_STRING, pSecurityAttributes *msrrp.RPC_SECURITY_ATTRIBUTES, flags ndr.DWORD) error {
 	if err := r.ensure(); err != nil {
 		return err
 	}
@@ -191,7 +191,7 @@ func (r *RemoteRegistry) BaseRegSaveKeyEx(hKey structures.RPC_HKEY, lpFile struc
 
 // BaseRegDeleteKeyEx calls BaseRegDeleteKeyEx (opnum 35): deletes a subkey honouring the
 // KEY_WOW64_* view selected by accessMask.
-func (r *RemoteRegistry) BaseRegDeleteKeyEx(hKey structures.RPC_HKEY, lpSubKey structures.RRP_UNICODE_STRING, accessMask ndr.DWORD, reserved ndr.DWORD) error {
+func (r *RemoteRegistry) BaseRegDeleteKeyEx(hKey msrrp.RPC_HKEY, lpSubKey msrrp.RRP_UNICODE_STRING, accessMask ndr.DWORD, reserved ndr.DWORD) error {
 	if err := r.ensure(); err != nil {
 		return err
 	}

--- a/network/dcerpc/ms-protocols/ms-rrp/paths.go
+++ b/network/dcerpc/ms-protocols/ms-rrp/paths.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
 	winreg "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0"
-	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/structures"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	msrrp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-rrp"
 )
 
 // This file holds the ergonomic, reg.exe-style helpers layered on top of the one-to-one
@@ -22,7 +22,7 @@ const maximumAllowed ndr.DWORD = 0x02000000
 
 // regName builds a NUL-terminated RRP_UNICODE_STRING for a key/value name. [MS-RRP] 3.1.1
 // counts the terminating NUL in the length, so it is appended explicitly.
-func regName(s string) structures.RRP_UNICODE_STRING {
+func regName(s string) msrrp.RRP_UNICODE_STRING {
 	return dtyp.NewUnicodeString(s + "\x00")
 }
 
@@ -162,8 +162,8 @@ func (r *RemoteRegistry) EnumKeys(h Handle) ([]string, error) {
 	bufLen := uint32(256)
 	const maxBufLen = uint32(16 * 1024)
 	for i := uint32(0); ; {
-		nameIn := structures.RRP_UNICODE_STRING{MaximumLength: uint16(bufLen * 2), Buffer: make([]uint16, bufLen)}
-		classIn := structures.RRP_UNICODE_STRING{MaximumLength: uint16(bufLen * 2), Buffer: make([]uint16, bufLen)}
+		nameIn := msrrp.RRP_UNICODE_STRING{MaximumLength: uint16(bufLen * 2), Buffer: make([]uint16, bufLen)}
+		classIn := msrrp.RRP_UNICODE_STRING{MaximumLength: uint16(bufLen * 2), Buffer: make([]uint16, bufLen)}
 		nameOut, _, _, err := r.BaseRegEnumKey(h, ndr.DWORD(i), nameIn, &classIn, nil)
 		if err != nil {
 			if isStatus(err, winreg.ErrorNoMoreItems) {
@@ -202,7 +202,7 @@ func (r *RemoteRegistry) EnumValues(h Handle) ([]ValueEntry, error) {
 	for i := uint32(0); ; {
 		// A registry value name fits in 1023 UTF-16 code units here; only the data buffer
 		// needs to grow, so the name buffer is fixed and the data buffer is negotiated.
-		nameIn := structures.RRP_UNICODE_STRING{MaximumLength: 2048, Buffer: make([]uint16, 1024)}
+		nameIn := msrrp.RRP_UNICODE_STRING{MaximumLength: 2048, Buffer: make([]uint16, 1024)}
 		typ := ndr.DWORD(0)
 		buf := make([]byte, dataLen)
 		cb := ndr.DWORD(dataLen)
@@ -258,7 +258,7 @@ func (r *RemoteRegistry) CreateKeyByPath(keyPath string, samDesired ndr.DWORD) (
 	}
 	defer r.BaseRegCloseKey(rootHandle)
 	disp := ndr.DWORD(0)
-	sk, rdisp, err := r.BaseRegCreateKey(rootHandle, regName(sub), structures.RRP_UNICODE_STRING{}, ndr.DWORD(winreg.RegOptionNonVolatile), samDesired, nil, &disp)
+	sk, rdisp, err := r.BaseRegCreateKey(rootHandle, regName(sub), msrrp.RRP_UNICODE_STRING{}, ndr.DWORD(winreg.RegOptionNonVolatile), samDesired, nil, &disp)
 	if err != nil {
 		return Handle{}, 0, err
 	}

--- a/network/dcerpc/ms-protocols/ms-rrp/security.go
+++ b/network/dcerpc/ms-protocols/ms-rrp/security.go
@@ -2,23 +2,23 @@ package ms_rrp
 
 import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions"
-	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/structures"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	msrrp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-rrp"
 )
 
 // BaseRegGetKeySecurity calls BaseRegGetKeySecurity (opnum 12): returns the parts of a
 // key's security descriptor selected by securityInformation (an OWNER/GROUP/DACL/SACL
 // bitmask).
-func (r *RemoteRegistry) BaseRegGetKeySecurity(hKey structures.RPC_HKEY, securityInformation ndr.DWORD, pRpcSecurityDescriptorIn structures.RPC_SECURITY_DESCRIPTOR) (structures.RPC_SECURITY_DESCRIPTOR, error) {
+func (r *RemoteRegistry) BaseRegGetKeySecurity(hKey msrrp.RPC_HKEY, securityInformation ndr.DWORD, pRpcSecurityDescriptorIn msrrp.RPC_SECURITY_DESCRIPTOR) (msrrp.RPC_SECURITY_DESCRIPTOR, error) {
 	if err := r.ensure(); err != nil {
-		return structures.RPC_SECURITY_DESCRIPTOR{}, err
+		return msrrp.RPC_SECURITY_DESCRIPTOR{}, err
 	}
 	return functions.BaseRegGetKeySecurity(r.rpc, hKey, securityInformation, pRpcSecurityDescriptorIn)
 }
 
 // BaseRegSetKeySecurity calls BaseRegSetKeySecurity (opnum 21): sets the parts of a key's
 // security descriptor selected by securityInformation.
-func (r *RemoteRegistry) BaseRegSetKeySecurity(hKey structures.RPC_HKEY, securityInformation ndr.DWORD, pRpcSecurityDescriptor structures.RPC_SECURITY_DESCRIPTOR) error {
+func (r *RemoteRegistry) BaseRegSetKeySecurity(hKey msrrp.RPC_HKEY, securityInformation ndr.DWORD, pRpcSecurityDescriptor msrrp.RPC_SECURITY_DESCRIPTOR) error {
 	if err := r.ensure(); err != nil {
 		return err
 	}

--- a/network/dcerpc/ms-protocols/ms-rrp/values.go
+++ b/network/dcerpc/ms-protocols/ms-rrp/values.go
@@ -8,8 +8,8 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"
 	winreg "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/functions"
-	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/structures"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	msrrp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-rrp"
 )
 
 // RegistryValue is a typed registry value: its REG_* type and its raw little-endian data
@@ -109,7 +109,7 @@ type ValueEntry struct {
 
 // BaseRegQueryValue calls BaseRegQueryValue (opnum 17). It mirrors the interface function
 // exactly (minus the invoker); for ergonomic reads use QueryValueByPath / queryValue.
-func (r *RemoteRegistry) BaseRegQueryValue(hKey structures.RPC_HKEY, lpValueName structures.RRP_UNICODE_STRING, lpType *ndr.DWORD, lpData []uint8, lpcbData *ndr.DWORD, lpcbLen *ndr.DWORD) (*ndr.DWORD, []uint8, *ndr.DWORD, *ndr.DWORD, error) {
+func (r *RemoteRegistry) BaseRegQueryValue(hKey msrrp.RPC_HKEY, lpValueName msrrp.RRP_UNICODE_STRING, lpType *ndr.DWORD, lpData []uint8, lpcbData *ndr.DWORD, lpcbLen *ndr.DWORD) (*ndr.DWORD, []uint8, *ndr.DWORD, *ndr.DWORD, error) {
 	if err := r.ensure(); err != nil {
 		return nil, nil, nil, nil, err
 	}
@@ -117,7 +117,7 @@ func (r *RemoteRegistry) BaseRegQueryValue(hKey structures.RPC_HKEY, lpValueName
 }
 
 // BaseRegSetValue calls BaseRegSetValue (opnum 22): writes a value's type and data.
-func (r *RemoteRegistry) BaseRegSetValue(hKey structures.RPC_HKEY, lpValueName structures.RRP_UNICODE_STRING, dwType ndr.DWORD, lpData []uint8, cbData ndr.DWORD) error {
+func (r *RemoteRegistry) BaseRegSetValue(hKey msrrp.RPC_HKEY, lpValueName msrrp.RRP_UNICODE_STRING, dwType ndr.DWORD, lpData []uint8, cbData ndr.DWORD) error {
 	if err := r.ensure(); err != nil {
 		return err
 	}
@@ -125,7 +125,7 @@ func (r *RemoteRegistry) BaseRegSetValue(hKey structures.RPC_HKEY, lpValueName s
 }
 
 // BaseRegDeleteValue calls BaseRegDeleteValue (opnum 8): removes a named value.
-func (r *RemoteRegistry) BaseRegDeleteValue(hKey structures.RPC_HKEY, lpValueName structures.RRP_UNICODE_STRING) error {
+func (r *RemoteRegistry) BaseRegDeleteValue(hKey msrrp.RPC_HKEY, lpValueName msrrp.RRP_UNICODE_STRING) error {
 	if err := r.ensure(); err != nil {
 		return err
 	}
@@ -133,7 +133,7 @@ func (r *RemoteRegistry) BaseRegDeleteValue(hKey structures.RPC_HKEY, lpValueNam
 }
 
 // BaseRegEnumValue calls BaseRegEnumValue (opnum 10): returns the value at dwIndex.
-func (r *RemoteRegistry) BaseRegEnumValue(hKey structures.RPC_HKEY, dwIndex ndr.DWORD, lpValueNameIn structures.RRP_UNICODE_STRING, lpType *ndr.DWORD, lpData []uint8, lpcbData *ndr.DWORD, lpcbLen *ndr.DWORD) (dtyp.RPC_UNICODE_STRING, *ndr.DWORD, []uint8, *ndr.DWORD, *ndr.DWORD, error) {
+func (r *RemoteRegistry) BaseRegEnumValue(hKey msrrp.RPC_HKEY, dwIndex ndr.DWORD, lpValueNameIn msrrp.RRP_UNICODE_STRING, lpType *ndr.DWORD, lpData []uint8, lpcbData *ndr.DWORD, lpcbLen *ndr.DWORD) (dtyp.RPC_UNICODE_STRING, *ndr.DWORD, []uint8, *ndr.DWORD, *ndr.DWORD, error) {
 	if err := r.ensure(); err != nil {
 		return dtyp.RPC_UNICODE_STRING{}, nil, nil, nil, nil, err
 	}
@@ -141,7 +141,7 @@ func (r *RemoteRegistry) BaseRegEnumValue(hKey structures.RPC_HKEY, dwIndex ndr.
 }
 
 // BaseRegQueryMultipleValues calls BaseRegQueryMultipleValues (opnum 29).
-func (r *RemoteRegistry) BaseRegQueryMultipleValues(hKey structures.RPC_HKEY, val_listIn []structures.RVALENT, num_vals ndr.DWORD, lpvalueBuf []byte, ldwTotsize ndr.DWORD) ([]structures.RVALENT, []byte, ndr.DWORD, error) {
+func (r *RemoteRegistry) BaseRegQueryMultipleValues(hKey msrrp.RPC_HKEY, val_listIn []msrrp.RVALENT, num_vals ndr.DWORD, lpvalueBuf []byte, ldwTotsize ndr.DWORD) ([]msrrp.RVALENT, []byte, ndr.DWORD, error) {
 	if err := r.ensure(); err != nil {
 		return nil, nil, 0, err
 	}
@@ -149,7 +149,7 @@ func (r *RemoteRegistry) BaseRegQueryMultipleValues(hKey structures.RPC_HKEY, va
 }
 
 // BaseRegQueryMultipleValues2 calls BaseRegQueryMultipleValues2 (opnum 34).
-func (r *RemoteRegistry) BaseRegQueryMultipleValues2(hKey structures.RPC_HKEY, val_listIn []structures.RVALENT, num_vals ndr.DWORD, lpvalueBuf []byte, ldwTotsize ndr.DWORD) ([]structures.RVALENT, []byte, ndr.DWORD, error) {
+func (r *RemoteRegistry) BaseRegQueryMultipleValues2(hKey msrrp.RPC_HKEY, val_listIn []msrrp.RVALENT, num_vals ndr.DWORD, lpvalueBuf []byte, ldwTotsize ndr.DWORD) ([]msrrp.RVALENT, []byte, ndr.DWORD, error) {
 	if err := r.ensure(); err != nil {
 		return nil, nil, 0, err
 	}

--- a/windows/protocols/ms-rrp/PRPC_HKEY.go
+++ b/windows/protocols/ms-rrp/PRPC_HKEY.go
@@ -1,4 +1,4 @@
-package structures
+package msrrp
 
 // PRPC_HKEY is an alias for RPC_HKEY ([MS-RRP]).
 type PRPC_HKEY = RPC_HKEY

--- a/windows/protocols/ms-rrp/REGSAM.go
+++ b/windows/protocols/ms-rrp/REGSAM.go
@@ -1,4 +1,4 @@
-package structures
+package msrrp
 
 import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"

--- a/windows/protocols/ms-rrp/RPC_HKEY.go
+++ b/windows/protocols/ms-rrp/RPC_HKEY.go
@@ -1,4 +1,4 @@
-package structures
+package msrrp
 
 // RPC_HKEY is an RPC context handle ([MS-RRP] 2.2.3): a 4-byte attributes field followed
 // by a 16-byte GUID, 20 bytes total ([MS-RPCE] 2.3.2.2). It is the handle to an open

--- a/windows/protocols/ms-rrp/RPC_SECURITY_ATTRIBUTES.go
+++ b/windows/protocols/ms-rrp/RPC_SECURITY_ATTRIBUTES.go
@@ -1,4 +1,4 @@
-package structures
+package msrrp
 
 import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"

--- a/windows/protocols/ms-rrp/RPC_SECURITY_DESCRIPTOR.go
+++ b/windows/protocols/ms-rrp/RPC_SECURITY_DESCRIPTOR.go
@@ -1,4 +1,4 @@
-package structures
+package msrrp
 
 import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"

--- a/windows/protocols/ms-rrp/RRP_UNICODE_STRING.go
+++ b/windows/protocols/ms-rrp/RRP_UNICODE_STRING.go
@@ -1,4 +1,4 @@
-package structures
+package msrrp
 
 import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"

--- a/windows/protocols/ms-rrp/RVALENT.go
+++ b/windows/protocols/ms-rrp/RVALENT.go
@@ -1,4 +1,4 @@
-package structures
+package msrrp
 
 import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/dtyp"

--- a/windows/protocols/ms-rrp/SECURITY_INFORMATION.go
+++ b/windows/protocols/ms-rrp/SECURITY_INFORMATION.go
@@ -1,4 +1,4 @@
-package structures
+package msrrp
 
 import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"

--- a/windows/protocols/ms-rrp/structures_test.go
+++ b/windows/protocols/ms-rrp/structures_test.go
@@ -1,4 +1,4 @@
-package structures
+package msrrp
 
 import (
 	"reflect"


### PR DESCRIPTION
### Summary

Brings the existing **winreg** RPC interface of the Windows Remote Registry Protocol ([MS-RRP]) — abstract syntax `338cd001-2244-31f1-aaaa-900038001003` v1.0, reached over `\pipe\winreg` — into the project's split interface/structure layout. The interface predated that convention: its NDR wire structures lived in a legacy `network/dcerpc/interfaces/338cd001-2244-31f1-aaaa-900038001003/1.0/structures/` subpackage (`package structures`) rather than the protocol-scoped `windows/protocols/ms-rrp/` tree used by every other interface.

This is a pure layout reconciliation — **no wire-format, opnum, or API-surface changes**.

Closes #828.

### What moved

- **8 NDR wire types** relocated from `.../1.0/structures/` (`package structures`) to `windows/protocols/ms-rrp/` (`package msrrp`), one file per type, with the single consolidated `structures_test.go` carried along: `RPC_HKEY`, `PRPC_HKEY`, `RRP_UNICODE_STRING`, `RVALENT`, `REGSAM`, `SECURITY_INFORMATION`, `RPC_SECURITY_DESCRIPTOR`, and `RPC_SECURITY_ATTRIBUTES`.
- **31 per-opnum function stubs** rewired: the structures import now points at `windows/protocols/ms-rrp` (aliased `msrrp`) and wire types are qualified `msrrp.` instead of `structures.`.
- The **`network/dcerpc/ms-protocols/ms-rrp` composition layer** (`client.go`, `keys.go`, `paths.go`, `security.go`, `values.go`) rewired the same way; its structures import is aliased `msrrp` to avoid clashing with its own `ms_rrp` package.
- The now-empty legacy `structures/` directory is removed.

### Verification

- **Completeness preserved:** all 31 on-the-wire methods still have exactly one `functions/<NN>_<Name>.go`, and the file prefixes agree with the `Opnum*` constants and `OpnumToName` map. The five `OpnumNNNotUsedOnWire` reserved slots (14, 24, 25, 28, 30) remain absent. All 8 IDL-defined structures are present.
- **Content preserved exactly:** every relocated/rewired file is the committed (`main`) source with only the mechanical transform applied — package rename for structures; import-path swap + `structures.`→`msrrp.` qualifier for functions/composition. No hand-written doc comments or NDR tags were altered.
- **Split invariants asserted:** no `structures/` subdir remains under the interface tree; `windows/protocols/ms-rrp` imports nothing under `network/dcerpc/interfaces`; the dependency direction stays one-way (functions → structures).
- `gofmt -l` clean; `go build`, `go vet`, `go test` clean over both trees.
- Cross-compiles for `GOARCH=386` and `GOARCH=arm64`; `go build -tags integration` clean.

### Reference

[MS-RRP]: Windows Remote Registry Protocol — https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rrp/