### PR TITLE
Add Service Witness Protocol (MS-SWN) Witness client interface (Fixes #838)

### DIFF
--- a/network/dcerpc/interfaces/ccd8c074-d0e5-4a40-92b4-d074faa6ba28/1.1/functions/00_WitnessrGetInterfaceList.go
+++ b/network/dcerpc/interfaces/ccd8c074-d0e5-4a40-92b4-d074faa6ba28/1.1/functions/00_WitnessrGetInterfaceList.go
@@ -1,0 +1,36 @@
+package functions
+
+import (
+	"fmt"
+
+	Witness "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/ccd8c074-d0e5-4a40-92b4-d074faa6ba28/1.1"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	msswn "github.com/TheManticoreProject/Manticore/windows/protocols/ms-swn"
+)
+
+// witnessrGetInterfaceListRequest carries the [in] parameters of WitnessrGetInterfaceList.
+type witnessrGetInterfaceListRequest struct {
+}
+
+func (*witnessrGetInterfaceListRequest) Opnum() uint16 { return Witness.OpnumWitnessrGetInterfaceList }
+
+// witnessrGetInterfaceListResponse carries the [out] parameters and return value of WitnessrGetInterfaceList.
+type witnessrGetInterfaceListResponse struct {
+	InterfaceList *msswn.WITNESS_INTERFACE_LIST `ndr:"unique"`
+	Status        ndr.DWORD                     `ndr:"retval"`
+}
+
+// WitnessrGetInterfaceList calls WitnessrGetInterfaceList (opnum 0) ([MS-SWN] 3.1.4.1). It returns the list of witness-capable interfaces the server exposes.
+func WitnessrGetInterfaceList(rpc ndr.Invoker) (InterfaceList *msswn.WITNESS_INTERFACE_LIST, err error) {
+	req := &witnessrGetInterfaceListRequest{}
+	var resp witnessrGetInterfaceListResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("WitnessrGetInterfaceList: %w", err)
+		return
+	}
+	InterfaceList = resp.InterfaceList
+	if uint32(resp.Status) != Witness.StatusSuccess {
+		err = fmt.Errorf("WitnessrGetInterfaceList failed: %s", Witness.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/ccd8c074-d0e5-4a40-92b4-d074faa6ba28/1.1/functions/01_WitnessrRegister.go
+++ b/network/dcerpc/interfaces/ccd8c074-d0e5-4a40-92b4-d074faa6ba28/1.1/functions/01_WitnessrRegister.go
@@ -1,0 +1,45 @@
+package functions
+
+import (
+	"fmt"
+
+	Witness "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/ccd8c074-d0e5-4a40-92b4-d074faa6ba28/1.1"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	msswn "github.com/TheManticoreProject/Manticore/windows/protocols/ms-swn"
+)
+
+// witnessrRegisterRequest carries the [in] parameters of WitnessrRegister.
+type witnessrRegisterRequest struct {
+	Version            ndr.DWORD
+	NetName            *ndr.WSTR `ndr:"unique"`
+	IpAddress          *ndr.WSTR `ndr:"unique"`
+	ClientComputerName *ndr.WSTR `ndr:"unique"`
+}
+
+func (*witnessrRegisterRequest) Opnum() uint16 { return Witness.OpnumWitnessrRegister }
+
+// witnessrRegisterResponse carries the [out] parameters and return value of WitnessrRegister.
+type witnessrRegisterResponse struct {
+	PpContext msswn.PPCONTEXT_HANDLE
+	Status    ndr.DWORD `ndr:"retval"`
+}
+
+// WitnessrRegister calls WitnessrRegister (opnum 1) ([MS-SWN] 3.1.4.2). It registers the client for resource state-change notifications on a NetName/IpAddress (Witness protocol v1).
+func WitnessrRegister(rpc ndr.Invoker, version ndr.DWORD, netName *ndr.WSTR, ipAddress *ndr.WSTR, clientComputerName *ndr.WSTR) (PpContext msswn.PPCONTEXT_HANDLE, err error) {
+	req := &witnessrRegisterRequest{
+		Version:            version,
+		NetName:            netName,
+		IpAddress:          ipAddress,
+		ClientComputerName: clientComputerName,
+	}
+	var resp witnessrRegisterResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("WitnessrRegister: %w", err)
+		return
+	}
+	PpContext = resp.PpContext
+	if uint32(resp.Status) != Witness.StatusSuccess {
+		err = fmt.Errorf("WitnessrRegister failed: %s", Witness.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/ccd8c074-d0e5-4a40-92b4-d074faa6ba28/1.1/functions/02_WitnessrUnRegister.go
+++ b/network/dcerpc/interfaces/ccd8c074-d0e5-4a40-92b4-d074faa6ba28/1.1/functions/02_WitnessrUnRegister.go
@@ -1,0 +1,37 @@
+package functions
+
+import (
+	"fmt"
+
+	Witness "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/ccd8c074-d0e5-4a40-92b4-d074faa6ba28/1.1"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	msswn "github.com/TheManticoreProject/Manticore/windows/protocols/ms-swn"
+)
+
+// witnessrUnRegisterRequest carries the [in] parameters of WitnessrUnRegister.
+type witnessrUnRegisterRequest struct {
+	PContext msswn.PCONTEXT_HANDLE
+}
+
+func (*witnessrUnRegisterRequest) Opnum() uint16 { return Witness.OpnumWitnessrUnRegister }
+
+// witnessrUnRegisterResponse carries the [out] parameters and return value of WitnessrUnRegister.
+type witnessrUnRegisterResponse struct {
+	Status ndr.DWORD `ndr:"retval"`
+}
+
+// WitnessrUnRegister calls WitnessrUnRegister (opnum 2) ([MS-SWN] 3.1.4.3). It removes a registration created by WitnessrRegister.
+func WitnessrUnRegister(rpc ndr.Invoker, pContext msswn.PCONTEXT_HANDLE) (err error) {
+	req := &witnessrUnRegisterRequest{
+		PContext: pContext,
+	}
+	var resp witnessrUnRegisterResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("WitnessrUnRegister: %w", err)
+		return
+	}
+	if uint32(resp.Status) != Witness.StatusSuccess {
+		err = fmt.Errorf("WitnessrUnRegister failed: %s", Witness.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/ccd8c074-d0e5-4a40-92b4-d074faa6ba28/1.1/functions/03_WitnessrAsyncNotify.go
+++ b/network/dcerpc/interfaces/ccd8c074-d0e5-4a40-92b4-d074faa6ba28/1.1/functions/03_WitnessrAsyncNotify.go
@@ -1,0 +1,39 @@
+package functions
+
+import (
+	"fmt"
+
+	Witness "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/ccd8c074-d0e5-4a40-92b4-d074faa6ba28/1.1"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	msswn "github.com/TheManticoreProject/Manticore/windows/protocols/ms-swn"
+)
+
+// witnessrAsyncNotifyRequest carries the [in] parameters of WitnessrAsyncNotify.
+type witnessrAsyncNotifyRequest struct {
+	PContext msswn.PCONTEXT_HANDLE_SHARED
+}
+
+func (*witnessrAsyncNotifyRequest) Opnum() uint16 { return Witness.OpnumWitnessrAsyncNotify }
+
+// witnessrAsyncNotifyResponse carries the [out] parameters and return value of WitnessrAsyncNotify.
+type witnessrAsyncNotifyResponse struct {
+	PResp  *msswn.RESP_ASYNC_NOTIFY `ndr:"unique"`
+	Status ndr.DWORD                `ndr:"retval"`
+}
+
+// WitnessrAsyncNotify calls WitnessrAsyncNotify (opnum 3) ([MS-SWN] 3.1.4.4). It long-polls the server for pending notifications on a registration; the server blocks until a notification is available.
+func WitnessrAsyncNotify(rpc ndr.Invoker, pContext msswn.PCONTEXT_HANDLE_SHARED) (PResp *msswn.RESP_ASYNC_NOTIFY, err error) {
+	req := &witnessrAsyncNotifyRequest{
+		PContext: pContext,
+	}
+	var resp witnessrAsyncNotifyResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("WitnessrAsyncNotify: %w", err)
+		return
+	}
+	PResp = resp.PResp
+	if uint32(resp.Status) != Witness.StatusSuccess {
+		err = fmt.Errorf("WitnessrAsyncNotify failed: %s", Witness.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/ccd8c074-d0e5-4a40-92b4-d074faa6ba28/1.1/functions/04_WitnessrRegisterEx.go
+++ b/network/dcerpc/interfaces/ccd8c074-d0e5-4a40-92b4-d074faa6ba28/1.1/functions/04_WitnessrRegisterEx.go
@@ -1,0 +1,51 @@
+package functions
+
+import (
+	"fmt"
+
+	Witness "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/ccd8c074-d0e5-4a40-92b4-d074faa6ba28/1.1"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	msswn "github.com/TheManticoreProject/Manticore/windows/protocols/ms-swn"
+)
+
+// witnessrRegisterExRequest carries the [in] parameters of WitnessrRegisterEx.
+type witnessrRegisterExRequest struct {
+	Version            ndr.DWORD
+	NetName            *ndr.WSTR `ndr:"unique"`
+	ShareName          *ndr.WSTR `ndr:"unique"`
+	IpAddress          *ndr.WSTR `ndr:"unique"`
+	ClientComputerName *ndr.WSTR `ndr:"unique"`
+	Flags              ndr.DWORD
+	KeepAliveTimeout   ndr.DWORD
+}
+
+func (*witnessrRegisterExRequest) Opnum() uint16 { return Witness.OpnumWitnessrRegisterEx }
+
+// witnessrRegisterExResponse carries the [out] parameters and return value of WitnessrRegisterEx.
+type witnessrRegisterExResponse struct {
+	PpContext msswn.PPCONTEXT_HANDLE
+	Status    ndr.DWORD `ndr:"retval"`
+}
+
+// WitnessrRegisterEx calls WitnessrRegisterEx (opnum 4) ([MS-SWN] 3.1.4.5). It registers the client for notifications on a specific share with optional flags and keep-alive (Witness protocol v2 only).
+func WitnessrRegisterEx(rpc ndr.Invoker, version ndr.DWORD, netName *ndr.WSTR, shareName *ndr.WSTR, ipAddress *ndr.WSTR, clientComputerName *ndr.WSTR, flags ndr.DWORD, keepAliveTimeout ndr.DWORD) (PpContext msswn.PPCONTEXT_HANDLE, err error) {
+	req := &witnessrRegisterExRequest{
+		Version:            version,
+		NetName:            netName,
+		ShareName:          shareName,
+		IpAddress:          ipAddress,
+		ClientComputerName: clientComputerName,
+		Flags:              flags,
+		KeepAliveTimeout:   keepAliveTimeout,
+	}
+	var resp witnessrRegisterExResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("WitnessrRegisterEx: %w", err)
+		return
+	}
+	PpContext = resp.PpContext
+	if uint32(resp.Status) != Witness.StatusSuccess {
+		err = fmt.Errorf("WitnessrRegisterEx failed: %s", Witness.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/ccd8c074-d0e5-4a40-92b4-d074faa6ba28/1.1/functions/05_WitnessrUnRegisterEx.go
+++ b/network/dcerpc/interfaces/ccd8c074-d0e5-4a40-92b4-d074faa6ba28/1.1/functions/05_WitnessrUnRegisterEx.go
@@ -1,0 +1,39 @@
+package functions
+
+import (
+	"fmt"
+
+	Witness "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/ccd8c074-d0e5-4a40-92b4-d074faa6ba28/1.1"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	msswn "github.com/TheManticoreProject/Manticore/windows/protocols/ms-swn"
+)
+
+// witnessrUnRegisterExRequest carries the [in] parameters of WitnessrUnRegisterEx.
+type witnessrUnRegisterExRequest struct {
+	PpContext msswn.PPCONTEXT_HANDLE
+}
+
+func (*witnessrUnRegisterExRequest) Opnum() uint16 { return Witness.OpnumWitnessrUnRegisterEx }
+
+// witnessrUnRegisterExResponse carries the [out] parameters and return value of WitnessrUnRegisterEx.
+type witnessrUnRegisterExResponse struct {
+	PpContext msswn.PPCONTEXT_HANDLE
+	Status    ndr.DWORD `ndr:"retval"`
+}
+
+// WitnessrUnRegisterEx calls WitnessrUnRegisterEx (opnum 5) ([MS-SWN] 3.1.4.6). It removes a registration created by WitnessrRegisterEx (Witness protocol v2 only).
+func WitnessrUnRegisterEx(rpc ndr.Invoker, ppContext msswn.PPCONTEXT_HANDLE) (PpContext msswn.PPCONTEXT_HANDLE, err error) {
+	req := &witnessrUnRegisterExRequest{
+		PpContext: ppContext,
+	}
+	var resp witnessrUnRegisterExResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("WitnessrUnRegisterEx: %w", err)
+		return
+	}
+	PpContext = resp.PpContext
+	if uint32(resp.Status) != Witness.StatusSuccess {
+		err = fmt.Errorf("WitnessrUnRegisterEx failed: %s", Witness.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/ccd8c074-d0e5-4a40-92b4-d074faa6ba28/1.1/interface.go
+++ b/network/dcerpc/interfaces/ccd8c074-d0e5-4a40-92b4-d074faa6ba28/1.1/interface.go
@@ -1,0 +1,117 @@
+// Package rpcinterface_ccd8c074d0e54a4092b4d074faa6ba28_1_1 is the descriptor for the
+// Witness (Service Witness Protocol) RPC interface, abstract syntax
+// ccd8c074-d0e5-4a40-92b4-d074faa6ba28 version 1.1 ([MS-SWN]).
+//
+// An RPC interface is identified by its UUID and version, never by the transport it is
+// reached over: the directory is named after the UUID with the version in the nested
+// <maj>.<min>/ directory.
+//
+// This package holds only the interface-level descriptor (abstract syntax, transport
+// endpoint, opnums, opnum<->name maps, status/version constants). NDR types live in the
+// windows/protocols/ms-swn package (imported as msswn) and method stubs in functions;
+// both depend on this package, never the reverse.
+//
+// Transport ([MS-SWN] 2.1): the Service Witness Protocol is reached over RPC dynamic
+// endpoints, protocol sequence ncacn_ip_tcp (RPC over TCP/IP), with the endpoint resolved
+// through the RPC endpoint mapper — it is NOT exposed over a named pipe. The RPC server
+// allows any user to bind and uses [MS-RPCE] to obtain the caller identity for per-method
+// access checks. PipeName is therefore empty.
+package rpcinterface_ccd8c074d0e54a4092b4d074faa6ba28_1_1
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+)
+
+// PipeName is unused for this interface: [MS-SWN] 2.1 uses ncacn_ip_tcp with a dynamic
+// endpoint (endpoint-mapper resolved), not a named pipe. It is retained, empty, for
+// descriptor uniformity across interfaces.
+const PipeName = ``
+
+// Opnums for the on-the-wire methods ([MS-SWN] 3.1.4). Opnums 4 and 5 (the *Ex methods)
+// are only applicable to Witness protocol version 2.
+const (
+	OpnumWitnessrGetInterfaceList uint16 = 0
+	OpnumWitnessrRegister         uint16 = 1
+	OpnumWitnessrUnRegister       uint16 = 2
+	OpnumWitnessrAsyncNotify      uint16 = 3
+	OpnumWitnessrRegisterEx       uint16 = 4
+	OpnumWitnessrUnRegisterEx     uint16 = 5
+)
+
+// Witness protocol versions ([MS-SWN] 2.2.2.3). The Version parameter of WitnessrRegister
+// / WitnessrRegisterEx MUST carry one of these values; anything else makes the server
+// return ERROR_REVISION_MISMATCH.
+const (
+	WitnessVersionV1 uint32 = 0x00010001 // Witness protocol version 1
+	WitnessVersionV2 uint32 = 0x00020000 // Witness protocol version 2 (enables the *Ex methods)
+)
+
+// Status codes returned by this interface. Every Witnessr* method returns a Win32 error
+// code ([MS-ERREF] 2.2, transmitted as the DWORD return value); ERROR_SUCCESS (0)
+// indicates success. These are the codes [MS-SWN] (section 3.1.4) documents its methods
+// returning.
+const (
+	StatusSuccess           uint32 = 0x00000000 // ERROR_SUCCESS
+	StatusAccessDenied      uint32 = 0x00000005 // ERROR_ACCESS_DENIED
+	StatusInvalidParameter  uint32 = 0x00000057 // ERROR_INVALID_PARAMETER
+	StatusNotFound          uint32 = 0x00000490 // ERROR_NOT_FOUND
+	StatusRevisionMismatch  uint32 = 0x0000051A // ERROR_REVISION_MISMATCH
+	StatusNoSystemResources uint32 = 0x000005AA // ERROR_NO_SYSTEM_RESOURCES
+	StatusInvalidState      uint32 = 0x0000139F // ERROR_INVALID_STATE
+)
+
+// SyntaxID returns the Witness abstract syntax identifier:
+// ccd8c074-d0e5-4a40-92b4-d074faa6ba28, version 1.1.
+func SyntaxID() syntax.SyntaxID {
+	return syntax.SyntaxID{
+		UUID:         guid.GUID{A: 0xccd8c074, B: 0xd0e5, C: 0x4a40, D: 0x92b4, E: 0xd074faa6ba28},
+		MajorVersion: 1,
+		MinorVersion: 1,
+	}
+}
+
+// StatusString returns a mnemonic for the documented status codes, otherwise the
+// hex value.
+func StatusString(status uint32) string {
+	switch status {
+	case StatusSuccess:
+		return "ERROR_SUCCESS"
+	case StatusAccessDenied:
+		return "ERROR_ACCESS_DENIED"
+	case StatusInvalidParameter:
+		return "ERROR_INVALID_PARAMETER"
+	case StatusNotFound:
+		return "ERROR_NOT_FOUND"
+	case StatusRevisionMismatch:
+		return "ERROR_REVISION_MISMATCH"
+	case StatusNoSystemResources:
+		return "ERROR_NO_SYSTEM_RESOURCES"
+	case StatusInvalidState:
+		return "ERROR_INVALID_STATE"
+	default:
+		return fmt.Sprintf("0x%08x", status)
+	}
+}
+
+// OpnumToName maps each on-the-wire opnum to its method name; the single source of
+// truth.
+var OpnumToName = map[uint16]string{
+	OpnumWitnessrGetInterfaceList: "WitnessrGetInterfaceList",
+	OpnumWitnessrRegister:         "WitnessrRegister",
+	OpnumWitnessrUnRegister:       "WitnessrUnRegister",
+	OpnumWitnessrAsyncNotify:      "WitnessrAsyncNotify",
+	OpnumWitnessrRegisterEx:       "WitnessrRegisterEx",
+	OpnumWitnessrUnRegisterEx:     "WitnessrUnRegisterEx",
+}
+
+// NameToOpnum is the reverse of OpnumToName, built at init so the two never drift.
+var NameToOpnum = func() map[string]uint16 {
+	m := make(map[string]uint16, len(OpnumToName))
+	for op, name := range OpnumToName {
+		m[name] = op
+	}
+	return m
+}()

--- a/network/dcerpc/interfaces/ccd8c074-d0e5-4a40-92b4-d074faa6ba28/1.1/interface_test.go
+++ b/network/dcerpc/interfaces/ccd8c074-d0e5-4a40-92b4-d074faa6ba28/1.1/interface_test.go
@@ -1,0 +1,91 @@
+package rpcinterface_ccd8c074d0e54a4092b4d074faa6ba28_1_1
+
+import "testing"
+
+// TestSyntaxID pins the abstract syntax identifier for the Witness interface
+// (ccd8c074-d0e5-4a40-92b4-d074faa6ba28 v1.1, [MS-SWN]).
+func TestSyntaxID(t *testing.T) {
+	s := SyntaxID()
+	if got := s.UUID.ToFormatD(); got != "ccd8c074-d0e5-4a40-92b4-d074faa6ba28" {
+		t.Errorf("UUID = %s, want ccd8c074-d0e5-4a40-92b4-d074faa6ba28", got)
+	}
+	if s.MajorVersion != 1 || s.MinorVersion != 1 {
+		t.Errorf("version = %d.%d, want 1.1", s.MajorVersion, s.MinorVersion)
+	}
+}
+
+// TestOpnumNameRoundTrip verifies OpnumToName and NameToOpnum are exact inverses and that
+// the anchor opnums resolve to the expected method names. Witness exposes 6 contiguous
+// opnums (0..5); none are "not used on the wire".
+func TestOpnumNameRoundTrip(t *testing.T) {
+	if len(OpnumToName) != len(NameToOpnum) {
+		t.Fatalf("OpnumToName (%d) and NameToOpnum (%d) differ in size",
+			len(OpnumToName), len(NameToOpnum))
+	}
+	if len(OpnumToName) != 6 {
+		t.Fatalf("OpnumToName has %d entries, want 6", len(OpnumToName))
+	}
+	if OpnumToName[OpnumWitnessrGetInterfaceList] != "WitnessrGetInterfaceList" {
+		t.Errorf("opnum 0 = %q, want WitnessrGetInterfaceList", OpnumToName[OpnumWitnessrGetInterfaceList])
+	}
+	if OpnumToName[OpnumWitnessrUnRegisterEx] != "WitnessrUnRegisterEx" {
+		t.Errorf("opnum 5 = %q, want WitnessrUnRegisterEx", OpnumToName[OpnumWitnessrUnRegisterEx])
+	}
+	for op, name := range OpnumToName {
+		if NameToOpnum[name] != op {
+			t.Errorf("round trip failed: opnum %d -> %q -> %d", op, name, NameToOpnum[name])
+		}
+	}
+}
+
+// TestOpnumContiguous checks the opnum space is exactly 0..5 with no gaps.
+func TestOpnumContiguous(t *testing.T) {
+	for op := uint16(0); op <= 5; op++ {
+		if _, ok := OpnumToName[op]; !ok {
+			t.Errorf("opnum %d missing from OpnumToName", op)
+		}
+	}
+	if _, ok := OpnumToName[6]; ok {
+		t.Errorf("opnum 6 should not exist")
+	}
+}
+
+// TestStatusString checks known Win32 mnemonics and the hex fallback.
+func TestStatusString(t *testing.T) {
+	cases := map[uint32]string{
+		StatusSuccess:           "ERROR_SUCCESS",
+		StatusAccessDenied:      "ERROR_ACCESS_DENIED",
+		StatusInvalidParameter:  "ERROR_INVALID_PARAMETER",
+		StatusNotFound:          "ERROR_NOT_FOUND",
+		StatusRevisionMismatch:  "ERROR_REVISION_MISMATCH",
+		StatusNoSystemResources: "ERROR_NO_SYSTEM_RESOURCES",
+		StatusInvalidState:      "ERROR_INVALID_STATE",
+	}
+	for code, want := range cases {
+		if got := StatusString(code); got != want {
+			t.Errorf("StatusString(0x%08x) = %q, want %q", code, got, want)
+		}
+	}
+	if got := StatusString(0xDEADBEEF); got != "0xdeadbeef" {
+		t.Errorf("StatusString(unknown) = %q, want 0xdeadbeef", got)
+	}
+}
+
+// TestProtocolVersions pins the two documented Witness protocol versions ([MS-SWN]
+// 2.2.2.3): a mismatched Version parameter makes the server return ERROR_REVISION_MISMATCH.
+func TestProtocolVersions(t *testing.T) {
+	if WitnessVersionV1 != 0x00010001 {
+		t.Errorf("WitnessVersionV1 = 0x%08x, want 0x00010001", WitnessVersionV1)
+	}
+	if WitnessVersionV2 != 0x00020000 {
+		t.Errorf("WitnessVersionV2 = 0x%08x, want 0x00020000", WitnessVersionV2)
+	}
+}
+
+// TestPipeName documents that this interface has no named pipe: [MS-SWN] 2.1 uses
+// ncacn_ip_tcp with a dynamic endpoint, so PipeName is intentionally empty.
+func TestPipeName(t *testing.T) {
+	if PipeName != `` {
+		t.Errorf("PipeName = %q, want empty (ncacn_ip_tcp dynamic endpoint)", PipeName)
+	}
+}

--- a/windows/protocols/ms-swn/PCONTEXT_HANDLE.go
+++ b/windows/protocols/ms-swn/PCONTEXT_HANDLE.go
@@ -1,0 +1,19 @@
+package msswn
+
+// PCONTEXT_HANDLE is the RPC context handle returned by WitnessrRegister /
+// WitnessrRegisterEx that identifies the client's registration on the Witness server
+// ([MS-SWN] 2.2.1.1). The IDL types it as [context_handle] void *; on the wire it is a
+// 20-octet context handle (a 4-byte attributes field followed by a 16-byte GUID,
+// [MS-RPCE] 2.3.2.2), transmitted inline with no referent id.
+type PCONTEXT_HANDLE [20]byte
+
+// IsZero reports whether the handle is all zeros (for example, after a successful
+// WitnessrUnRegister, which the server returns nulled out).
+func (h PCONTEXT_HANDLE) IsZero() bool {
+	for _, b := range h {
+		if b != 0 {
+			return false
+		}
+	}
+	return true
+}

--- a/windows/protocols/ms-swn/PCONTEXT_HANDLE_SHARED.go
+++ b/windows/protocols/ms-swn/PCONTEXT_HANDLE_SHARED.go
@@ -1,0 +1,8 @@
+package msswn
+
+// PCONTEXT_HANDLE_SHARED is the shared RPC context handle passed to WitnessrAsyncNotify
+// ([MS-SWN] 2.2.1.3). The IDL types it as [context_handle] PCONTEXT_HANDLE, allowing the
+// same registration handle to be used concurrently by the long-running AsyncNotify call
+// while other calls run; on the wire it is the same 20-octet context handle as
+// PCONTEXT_HANDLE, so it is modeled as an alias.
+type PCONTEXT_HANDLE_SHARED = PCONTEXT_HANDLE

--- a/windows/protocols/ms-swn/PPCONTEXT_HANDLE.go
+++ b/windows/protocols/ms-swn/PPCONTEXT_HANDLE.go
@@ -1,0 +1,9 @@
+package msswn
+
+// PPCONTEXT_HANDLE is the [out] / [in,out] context-handle parameter type of
+// WitnessrRegister, WitnessrRegisterEx, and WitnessrUnRegisterEx ([MS-SWN] 2.2.1.2). The
+// IDL types it as [ref] PCONTEXT_HANDLE * — a ref pointer to a context handle. A ref
+// pointer to a context handle emits no referent id, and the context handle itself is
+// transmitted inline as 20 octets, so on the wire it is identical to PCONTEXT_HANDLE and
+// is modeled as an alias.
+type PPCONTEXT_HANDLE = PCONTEXT_HANDLE

--- a/windows/protocols/ms-swn/RESP_ASYNC_NOTIFY.go
+++ b/windows/protocols/ms-swn/RESP_ASYNC_NOTIFY.go
@@ -1,0 +1,17 @@
+package msswn
+
+// RESP_ASYNC_NOTIFY is the notification response returned by WitnessrAsyncNotify
+// ([MS-SWN] 2.2.2.4). MessageType selects the shape encoded in MessageBuffer
+// (RESOURCE_CHANGE_NOTIFICATION, CLIENT_MOVE_NOTIFICATION, SHARE_MOVE_NOTIFICATION,
+// IP_CHANGE_NOTIFICATION); NumberOfMessages is the number of encoded messages; Length is
+// the byte length of MessageBuffer.
+//
+// MessageBuffer is a [size_is(Length)] [unique] PBYTE: a [unique] pointer to a conformant
+// byte array sized by Length. Its contents are an opaque, message-type-specific blob that
+// callers parse per [MS-SWN] 2.2.2 (this codec transports it as raw bytes).
+type RESP_ASYNC_NOTIFY struct {
+	MessageType      uint32
+	Length           uint32
+	NumberOfMessages uint32
+	MessageBuffer    []uint8 `ndr:"unique,size_is=Length"`
+}

--- a/windows/protocols/ms-swn/WITNESS_INTERFACE_INFO.go
+++ b/windows/protocols/ms-swn/WITNESS_INTERFACE_INFO.go
@@ -1,0 +1,24 @@
+package msswn
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// WITNESS_INTERFACE_INFO describes one witness-capable interface of the server
+// ([MS-SWN] 2.2.2.5), as returned in WITNESS_INTERFACE_LIST by WitnessrGetInterfaceList.
+//
+// InterfaceGroupName is a fixed 260-WCHAR, null-terminated interface group name. State is
+// a USHORT taking the values UNKNOWN (0x0000), AVAILABLE (0x0001), or UNAVAILABLE
+// (0x00FF). IPV4 is the interface's IPv4 address (0 if none); IPV6 is a fixed array of
+// eight USHORTs holding the IPv6 address (all zero if none). Flags is a bitmask
+// (INTERFACE_WITNESS 0x00000001 => this node runs the Witness service; otherwise the
+// low bit selects whether IPV4/IPV6 is valid per the spec). All fields are fixed size and
+// transmitted inline.
+type WITNESS_INTERFACE_INFO struct {
+	InterfaceGroupName [260]uint16
+	Version            ndr.DWORD
+	State              uint16
+	IPV4               ndr.DWORD
+	IPV6               [8]uint16
+	Flags              uint32
+}

--- a/windows/protocols/ms-swn/WITNESS_INTERFACE_LIST.go
+++ b/windows/protocols/ms-swn/WITNESS_INTERFACE_LIST.go
@@ -1,0 +1,10 @@
+package msswn
+
+// WITNESS_INTERFACE_LIST is the list of witness-capable interfaces returned by
+// WitnessrGetInterfaceList ([MS-SWN] 2.2.2.6). NumberOfInterfaces is the element count;
+// InterfaceInfo is a [size_is(NumberOfInterfaces)] [unique] pointer to a conformant array
+// of WITNESS_INTERFACE_INFO (the codec emits a referent id, then defers the array body).
+type WITNESS_INTERFACE_LIST struct {
+	NumberOfInterfaces uint32
+	InterfaceInfo      []WITNESS_INTERFACE_INFO `ndr:"unique,size_is=NumberOfInterfaces"`
+}

--- a/windows/protocols/ms-swn/structures_test.go
+++ b/windows/protocols/ms-swn/structures_test.go
@@ -1,0 +1,140 @@
+package msswn
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// TestRESP_ASYNC_NOTIFY_RoundTrip exercises the notification response: a scalar header
+// plus a [size_is(Length)] [unique] PBYTE buffer. Length must be derived from the slice
+// on marshal (the size_is reference points at the exported Go field name Length), and the
+// opaque MessageBuffer bytes must survive the round trip.
+func TestRESP_ASYNC_NOTIFY_RoundTrip(t *testing.T) {
+	in := RESP_ASYNC_NOTIFY{
+		MessageType:      1, // RESOURCE_CHANGE_NOTIFICATION
+		NumberOfMessages: 2,
+		MessageBuffer:    []uint8{0x10, 0x00, 0x00, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05},
+	}
+	raw, err := ndr.Marshal(&in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var out RESP_ASYNC_NOTIFY
+	if err := ndr.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out.Length != uint32(len(in.MessageBuffer)) {
+		t.Errorf("Length = %d, want %d (must be derived from the slice)", out.Length, len(in.MessageBuffer))
+	}
+	if out.MessageType != in.MessageType || out.NumberOfMessages != in.NumberOfMessages {
+		t.Errorf("header round-trip: got type=%d msgs=%d, want type=%d msgs=%d",
+			out.MessageType, out.NumberOfMessages, in.MessageType, in.NumberOfMessages)
+	}
+	if !reflect.DeepEqual(out.MessageBuffer, in.MessageBuffer) {
+		t.Errorf("MessageBuffer round-trip: got %v want %v", out.MessageBuffer, in.MessageBuffer)
+	}
+}
+
+// TestRESP_ASYNC_NOTIFY_NilBuffer covers a [unique] pointer that is NULL (no pending
+// messages): MessageBuffer marshals as a null referent and unmarshals back to nil.
+func TestRESP_ASYNC_NOTIFY_NilBuffer(t *testing.T) {
+	in := RESP_ASYNC_NOTIFY{MessageType: 0, NumberOfMessages: 0}
+	raw, err := ndr.Marshal(&in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var out RESP_ASYNC_NOTIFY
+	if err := ndr.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out.Length != 0 || len(out.MessageBuffer) != 0 {
+		t.Errorf("nil buffer round-trip: Length=%d len(MessageBuffer)=%d, want 0/0", out.Length, len(out.MessageBuffer))
+	}
+}
+
+// TestWITNESS_INTERFACE_INFO_RoundTrip exercises the fixed-size arrays
+// (InterfaceGroupName[260], IPV6[8]) and the scalar fields, all transmitted inline.
+func TestWITNESS_INTERFACE_INFO_RoundTrip(t *testing.T) {
+	in := WITNESS_INTERFACE_INFO{
+		Version: 0x00020000,
+		State:   0x0001, // AVAILABLE
+		IPV4:    0xC0A80101,
+		Flags:   0x00000001,
+	}
+	// "GROUP" in the group name; a couple of IPv6 words.
+	for i, c := range []uint16{'G', 'R', 'O', 'U', 'P'} {
+		in.InterfaceGroupName[i] = c
+	}
+	in.IPV6[0] = 0xfe80
+	in.IPV6[7] = 0x0001
+
+	raw, err := ndr.Marshal(&in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var out WITNESS_INTERFACE_INFO
+	if err := ndr.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if !reflect.DeepEqual(in, out) {
+		t.Errorf("round-trip mismatch:\n in=%+v\nout=%+v", in, out)
+	}
+}
+
+// TestWITNESS_INTERFACE_LIST_RoundTrip exercises a count field plus a [unique] pointer to
+// a conformant array of fixed-array-bearing structs. NumberOfInterfaces must be derived
+// from the slice on marshal.
+func TestWITNESS_INTERFACE_LIST_RoundTrip(t *testing.T) {
+	in := WITNESS_INTERFACE_LIST{
+		InterfaceInfo: []WITNESS_INTERFACE_INFO{
+			{Version: 0x00010001, State: 1, IPV4: 0x0A000001, Flags: 1},
+			{Version: 0x00020000, State: 0xFF, IPV4: 0x0A000002, Flags: 0},
+		},
+	}
+	in.InterfaceInfo[0].InterfaceGroupName[0] = 'A'
+	in.InterfaceInfo[1].InterfaceGroupName[0] = 'B'
+
+	raw, err := ndr.Marshal(&in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var out WITNESS_INTERFACE_LIST
+	if err := ndr.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out.NumberOfInterfaces != 2 || len(out.InterfaceInfo) != 2 {
+		t.Fatalf("NumberOfInterfaces=%d len(InterfaceInfo)=%d, want 2/2", out.NumberOfInterfaces, len(out.InterfaceInfo))
+	}
+	if !reflect.DeepEqual(in.InterfaceInfo, out.InterfaceInfo) {
+		t.Errorf("element round-trip mismatch:\n in=%+v\nout=%+v", in.InterfaceInfo, out.InterfaceInfo)
+	}
+}
+
+// TestPCONTEXT_HANDLE_RoundTrip covers the 20-octet context handle transmitted inline and
+// the IsZero helper.
+func TestPCONTEXT_HANDLE_RoundTrip(t *testing.T) {
+	var h PCONTEXT_HANDLE
+	if !h.IsZero() {
+		t.Errorf("zero-valued handle: IsZero() = false, want true")
+	}
+	h[0] = 0x01
+	h[19] = 0xff
+	if h.IsZero() {
+		t.Errorf("non-zero handle: IsZero() = true, want false")
+	}
+
+	type wrap struct{ H PCONTEXT_HANDLE }
+	raw, err := ndr.Marshal(&wrap{H: h})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var out wrap
+	if err := ndr.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out.H != h {
+		t.Errorf("handle round-trip: got %v want %v", out.H, h)
+	}
+}


### PR DESCRIPTION
### Summary

Implements the single RPC client interface of the Service Witness Protocol ([MS-SWN]) — `Witness` — the interface an SMB2 client uses to register with a clustered file server (Scale-Out File Server) and receive prompt, explicit notifications when a network name or its resources fail over or move.

Closes #838.

### What's included

One interface, one file per opnum, following the project's split layout.

**Witness** — `ccd8c074-d0e5-4a40-92b4-d074faa6ba28` v1.1, RPC-over-TCP (`ncacn_ip_tcp`) at a dynamic endpoint assigned by the endpoint mapper ([MS-SWN] section 2.1); it has no well-known named pipe, so `PipeName` is intentionally empty:

| Opnum | Method | Notes |
| --- | --- | --- |
| 0 | `WitnessrGetInterfaceList` | |
| 1 | `WitnessrRegister` | |
| 2 | `WitnessrUnRegister` | |
| 3 | `WitnessrAsyncNotify` | long-poll; the server blocks until a notification is pending |
| 4 | `WitnessrRegisterEx` | Witness protocol version 2 only |
| 5 | `WitnessrUnRegisterEx` | Witness protocol version 2 only |

All six methods are on the wire (no `NotUsedOnWire` opnums).

### Layout

- **Interface tree** — `network/dcerpc/interfaces/ccd8c074-d0e5-4a40-92b4-d074faa6ba28/1.1/`: the descriptor (`interface.go`: `SyntaxID`, empty `PipeName`, opnums, `OpnumToName`/`NameToOpnum`, the Witness protocol-version constants, the Win32 status codes + `StatusString`) and the per-opnum stubs under `functions/`, plus `interface_test.go`.
- **Structures package** — `windows/protocols/ms-swn/` (`package msswn`): the NDR wire types (`RESP_ASYNC_NOTIFY`, `WITNESS_INTERFACE_INFO`, `WITNESS_INTERFACE_LIST`) and the context-handle types (`PCONTEXT_HANDLE`, `PCONTEXT_HANDLE_SHARED`, `PPCONTEXT_HANDLE`), plus `structures_test.go`.

### NDR modeling notes

- The `[in] handle_t Handle` explicit RPC binding handle is omitted from every request struct (the stubs take `ndr.Invoker`).
- Context handles are 20-octet inline handles ([MS-RPCE] 2.3.2.2). `PCONTEXT_HANDLE` is `[20]byte`; `PCONTEXT_HANDLE_SHARED` (`[context_handle] PCONTEXT_HANDLE`) and `PPCONTEXT_HANDLE` (`[ref] PCONTEXT_HANDLE *`) are type aliases of it, since a ref pointer to a context handle transmits identically (20 bytes inline, no referent id).
- The double-pointer `[out]` parameters `PWITNESS_INTERFACE_LIST *` and `PRESP_ASYNC_NOTIFY *` are modeled as `*T` with `ndr:"unique"` in the response (referent id + deferred body); the DWORD return value carries `ndr:"retval"` so it is encoded after those deferred referents.
- `WitnessrUnRegisterEx`'s `[in,out] PPCONTEXT_HANDLE` appears in both the request and the response struct.
- `RESP_ASYNC_NOTIFY.MessageBuffer` (`[size_is(Length)][unique] PBYTE`) and `WITNESS_INTERFACE_LIST.InterfaceInfo` (`[size_is(NumberOfInterfaces)][unique] PWITNESS_INTERFACE_INFO`) are unique pointers to conformant arrays whose count fields are derived from the slice on marshal.
- The methods return a Win32 error code ([MS-ERREF] section 2.2); `StatusString` maps the codes [MS-SWN] documents (`ERROR_ACCESS_DENIED`, `ERROR_INVALID_PARAMETER`, `ERROR_NOT_FOUND`, `ERROR_REVISION_MISMATCH`, `ERROR_NO_SYSTEM_RESOURCES`, `ERROR_INVALID_STATE`) and falls back to raw hex.

### Testing

- `gofmt`, `go build`, `go vet`, `go test` clean over both trees.
- Cross-compiles under `GOARCH=386` and `GOARCH=arm64`; builds with `-tags integration`.
- `interface_test.go` pins the `SyntaxID`, the opnum⇄name round trip, `StatusString`, the protocol-version constants, and the empty `PipeName`; `structures_test.go` round-trips `RESP_ASYNC_NOTIFY` (with and without a buffer), `WITNESS_INTERFACE_INFO` (fixed arrays), `WITNESS_INTERFACE_LIST` (count derivation), and the context handle.
