### PR TITLE
Add Telephony Remote Protocol (MS-TRP) tapsrv and remotesp client interfaces (Fixes #840)

### DIFF
--- a/network/dcerpc/interfaces/2f5f6520-ca46-1067-b319-00dd010662da/1.0/functions/00_ClientAttach.go
+++ b/network/dcerpc/interfaces/2f5f6520-ca46-1067-b319-00dd010662da/1.0/functions/00_ClientAttach.go
@@ -1,0 +1,53 @@
+package functions
+
+import (
+	"fmt"
+
+	tapsrv "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/2f5f6520-ca46-1067-b319-00dd010662da/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	mstrp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-trp"
+)
+
+// clientAttachRequest carries the [in] parameters of ClientAttach. pszDomainUser and
+// pszMachine are top-level [ref] [string] wchar_t* parameters ([MS-TRP] 3.2.4.1), so they
+// marshal inline as conformant-varying UTF-16LE strings with no referent id.
+type clientAttachRequest struct {
+	LProcessID    int32
+	PszDomainUser ndr.WSTR
+	PszMachine    ndr.WSTR
+}
+
+func (*clientAttachRequest) Opnum() uint16 { return tapsrv.OpnumClientAttach }
+
+// clientAttachResponse carries the [out] parameters and return value of ClientAttach.
+type clientAttachResponse struct {
+	PphContext         mstrp.PCONTEXT_HANDLE_TYPE
+	PhAsyncEventsEvent int32
+	Return             ndr.DWORD `ndr:"retval"`
+}
+
+// ClientAttach calls ClientAttach (opnum 0) ([MS-TRP] 3.2.4.1). The client uses it to
+// establish a session with the telephony server: lProcessID identifies the client
+// process (0xFFFFFFFF / 0xFFFFFFFD select the reduced-privilege forms described by the
+// spec), pszDomainUser is the caller's domain\user, and pszMachine the client machine
+// name. On success the server returns the tapsrv context handle plus phAsyncEventsEvent,
+// the event value used to signal asynchronous completions. The method returns 0 on
+// success or a nonzero error code.
+func ClientAttach(rpc ndr.Invoker, lProcessID int32, pszDomainUser ndr.WSTR, pszMachine ndr.WSTR) (PphContext mstrp.PCONTEXT_HANDLE_TYPE, PhAsyncEventsEvent int32, err error) {
+	req := &clientAttachRequest{
+		LProcessID:    lProcessID,
+		PszDomainUser: pszDomainUser,
+		PszMachine:    pszMachine,
+	}
+	var resp clientAttachResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("ClientAttach: %w", err)
+		return
+	}
+	PphContext = resp.PphContext
+	PhAsyncEventsEvent = resp.PhAsyncEventsEvent
+	if uint32(resp.Return) != tapsrv.StatusSuccess {
+		err = fmt.Errorf("ClientAttach failed: %s", tapsrv.StatusString(uint32(resp.Return)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/2f5f6520-ca46-1067-b319-00dd010662da/1.0/functions/01_ClientRequest.go
+++ b/network/dcerpc/interfaces/2f5f6520-ca46-1067-b319-00dd010662da/1.0/functions/01_ClientRequest.go
@@ -1,0 +1,63 @@
+package functions
+
+import (
+	"fmt"
+
+	tapsrv "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/2f5f6520-ca46-1067-b319-00dd010662da/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	mstrp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-trp"
+)
+
+// clientRequestRequest carries the [in]/[in,out] parameters of ClientRequest.
+//
+// pBuffer is a top-level [ref] pointer to a conformant-varying byte array with
+// independent bounds ([MS-TRP] 3.2.4.2): its maximum_count comes from lNeededSize (the
+// buffer capacity) and its actual_count from plUsedSize (the number of bytes actually
+// carried). Modeling it [ref] (not [unique]) suppresses both a referent id and the
+// hoisting of maximum_count ahead of the preceding context handle, matching the wire.
+type clientRequestRequest struct {
+	PhContext mstrp.PCONTEXT_HANDLE_TYPE
+	PBuffer   []uint8 `ndr:"ref,varying,size_is=LNeededSize,length_is=PlUsedSize"`
+	// LNeededSize and PlUsedSize are the IDL's signed long parameters; they are modeled as
+	// unsigned DWORDs because they are non-negative sizes and the NDR codec resolves the
+	// array's independent maximum_count/actual_count from these sibling fields (which it
+	// reads as unsigned). On the wire a signed long and a DWORD are the same 4 octets.
+	LNeededSize ndr.DWORD
+	PlUsedSize  ndr.DWORD
+}
+
+func (*clientRequestRequest) Opnum() uint16 { return tapsrv.OpnumClientRequest }
+
+// clientRequestResponse carries the [in,out] parameters of ClientRequest. ClientRequest
+// is a void method, so there is no return value on the wire: the request status is
+// delivered inside the returned pBuffer payload. On decode the array's maximum_count /
+// actual_count are read directly from the wire (size_is/length_is siblings are only
+// consulted on the marshal path), so the buffer needs only the [ref] conformant-varying
+// attributes here and lNeededSize is intentionally absent.
+type clientRequestResponse struct {
+	PBuffer    []uint8 `ndr:"ref,varying"`
+	PlUsedSize ndr.DWORD
+}
+
+// ClientRequest calls ClientRequest (opnum 1) ([MS-TRP] 3.2.4.2). The client sends a
+// packed TAPI request in pBuffer; the server processes it and returns the (possibly
+// updated) buffer in place. lNeededSize is the total capacity of pBuffer and plUsedSize
+// the number of valid bytes; both are [in,out]. The returned buffer and used size are
+// reported back to the caller. Transport-level failures surface through err; the TAPI
+// result itself is encoded within the returned buffer.
+func ClientRequest(rpc ndr.Invoker, phContext mstrp.PCONTEXT_HANDLE_TYPE, pBuffer []uint8, lNeededSize ndr.DWORD, plUsedSize ndr.DWORD) (PBuffer []uint8, PlUsedSize ndr.DWORD, err error) {
+	req := &clientRequestRequest{
+		PhContext:   phContext,
+		PBuffer:     pBuffer,
+		LNeededSize: lNeededSize,
+		PlUsedSize:  plUsedSize,
+	}
+	var resp clientRequestResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("ClientRequest: %w", err)
+		return
+	}
+	PBuffer = resp.PBuffer
+	PlUsedSize = resp.PlUsedSize
+	return
+}

--- a/network/dcerpc/interfaces/2f5f6520-ca46-1067-b319-00dd010662da/1.0/functions/02_ClientDetach.go
+++ b/network/dcerpc/interfaces/2f5f6520-ca46-1067-b319-00dd010662da/1.0/functions/02_ClientDetach.go
@@ -1,0 +1,40 @@
+package functions
+
+import (
+	"fmt"
+
+	tapsrv "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/2f5f6520-ca46-1067-b319-00dd010662da/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	mstrp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-trp"
+)
+
+// clientDetachRequest carries the [in,out] context handle of ClientDetach. The handle is
+// transmitted inline as a [ref] pointer to the 20-octet context handle.
+type clientDetachRequest struct {
+	PphContext mstrp.PCONTEXT_HANDLE_TYPE
+}
+
+func (*clientDetachRequest) Opnum() uint16 { return tapsrv.OpnumClientDetach }
+
+// clientDetachResponse carries the [in,out] context handle back. ClientDetach is a void
+// method, so there is no return value on the wire; the server returns the handle nulled
+// out on success.
+type clientDetachResponse struct {
+	PphContext mstrp.PCONTEXT_HANDLE_TYPE
+}
+
+// ClientDetach calls ClientDetach (opnum 2) ([MS-TRP] 3.2.4.3). It closes the tapsrv
+// session identified by the context handle and frees the server-side state. The server
+// returns the handle nulled out (IsZero); transport-level failures surface through err.
+func ClientDetach(rpc ndr.Invoker, pphContext mstrp.PCONTEXT_HANDLE_TYPE) (PphContext mstrp.PCONTEXT_HANDLE_TYPE, err error) {
+	req := &clientDetachRequest{
+		PphContext: pphContext,
+	}
+	var resp clientDetachResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("ClientDetach: %w", err)
+		return
+	}
+	PphContext = resp.PphContext
+	return
+}

--- a/network/dcerpc/interfaces/2f5f6520-ca46-1067-b319-00dd010662da/1.0/functions/functions_test.go
+++ b/network/dcerpc/interfaces/2f5f6520-ca46-1067-b319-00dd010662da/1.0/functions/functions_test.go
@@ -1,0 +1,83 @@
+package functions
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	mstrp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-trp"
+)
+
+// TestClientRequest_BufferWireShape pins the independent-bounds wire layout of
+// ClientRequest's pBuffer ([MS-TRP] 3.2.4.2): a top-level [ref] conformant-varying byte
+// array whose maximum_count is lNeededSize (capacity) and actual_count is plUsedSize (the
+// valid length), with no referent id. This matches the reference wire encoding used by
+// interop implementations.
+func TestClientRequest_BufferWireShape(t *testing.T) {
+	var ctx mstrp.PCONTEXT_HANDLE_TYPE
+	for i := range ctx {
+		ctx[i] = 0xAA
+	}
+	req := &clientRequestRequest{
+		PhContext:   ctx,
+		PBuffer:     []uint8{0x01, 0x02, 0x03, 0x04},
+		LNeededSize: 8, // capacity (maximum_count)
+		PlUsedSize:  4, // valid bytes (actual_count)
+	}
+	raw, err := ndr.Marshal(req)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	want := bytes.Join([][]byte{
+		bytes.Repeat([]byte{0xAA}, 20), // phContext (inline, no referent id)
+		{0x08, 0, 0, 0},                // maximum_count = lNeededSize = 8
+		{0x00, 0, 0, 0},                // offset = 0
+		{0x04, 0, 0, 0},                // actual_count = plUsedSize = 4
+		{0x01, 0x02, 0x03, 0x04},       // 4 valid bytes
+		{0x08, 0, 0, 0},                // lNeededSize field = 8
+		{0x04, 0, 0, 0},                // plUsedSize field = 4
+	}, nil)
+	if !bytes.Equal(raw, want) {
+		t.Errorf("wire mismatch:\n got  %x\n want %x", raw, want)
+	}
+}
+
+// TestClientRequest_ResponseRoundTrip confirms the void-method response (no return value
+// on the wire) decodes the returned buffer and used size. The server returns fewer valid
+// bytes than the advertised capacity.
+func TestClientRequest_ResponseRoundTrip(t *testing.T) {
+	// A response wire image: pBuffer max_count=8, offset=0, actual_count=3, 3 bytes, then
+	// the [out] plUsedSize=3.
+	raw := bytes.Join([][]byte{
+		{0x08, 0, 0, 0},    // maximum_count = 8 (advertised capacity)
+		{0x00, 0, 0, 0},    // offset = 0
+		{0x03, 0, 0, 0},    // actual_count = 3 (valid bytes)
+		{0xDE, 0xAD, 0xBE}, // 3 valid bytes
+		{0x00},             // pad to 4-align the following DWORD
+		{0x03, 0, 0, 0},    // plUsedSize = 3
+	}, nil)
+	var resp clientRequestResponse
+	if err := ndr.Unmarshal(raw, &resp); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if !reflect.DeepEqual(resp.PBuffer, []uint8{0xDE, 0xAD, 0xBE}) {
+		t.Errorf("PBuffer = %x, want deadbe", resp.PBuffer)
+	}
+	if resp.PlUsedSize != 3 {
+		t.Errorf("PlUsedSize = %d, want 3", resp.PlUsedSize)
+	}
+}
+
+// TestClientDetach_ResponseRoundTrip covers the void ClientDetach response: just the
+// nulled-out context handle, no return value.
+func TestClientDetach_ResponseRoundTrip(t *testing.T) {
+	raw := make([]byte, 20) // all-zero handle
+	var resp clientDetachResponse
+	if err := ndr.Unmarshal(raw, &resp); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if !resp.PphContext.IsZero() {
+		t.Errorf("PphContext = %x, want zero", resp.PphContext)
+	}
+}

--- a/network/dcerpc/interfaces/2f5f6520-ca46-1067-b319-00dd010662da/1.0/interface.go
+++ b/network/dcerpc/interfaces/2f5f6520-ca46-1067-b319-00dd010662da/1.0/interface.go
@@ -1,0 +1,79 @@
+// Package rpcinterface_2f5f6520ca461067b31900dd010662da_1_0 is the descriptor for the
+// tapsrv (Telephony Server) RPC interface, abstract syntax
+// 2f5f6520-ca46-1067-b319-00dd010662da version 1.0 ([MS-TRP]).
+//
+// An RPC interface is identified by its UUID and version, never by the named pipe it is
+// reached over: the directory is named after the UUID with the version in the nested
+// <maj>.<min>/ directory.
+//
+// This package holds only the interface-level descriptor (abstract syntax, transport
+// endpoint, opnums, opnum<->name maps, status constants). NDR types live in the
+// windows/protocols/ms-trp package (imported as mstrp) and method stubs in functions;
+// both depend on this package, never the reverse.
+package rpcinterface_2f5f6520ca461067b31900dd010662da_1_0
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+)
+
+// PipeName is the IPC$-relative named pipe for the tapsrv interface. Per [MS-TRP] 2.1
+// the client reaches the telephony server at the well-known endpoint \pipe\tapsrv
+// (protocol sequence ncacn_np).
+const PipeName = `\tapsrv`
+
+// Opnums for the on-the-wire methods.
+const (
+	OpnumClientAttach  uint16 = 0
+	OpnumClientRequest uint16 = 1
+	OpnumClientDetach  uint16 = 2
+)
+
+// Status codes for this interface. ClientAttach returns 0 on success and a nonzero error
+// code otherwise ([MS-TRP] 3.2.4.1); the void methods (ClientRequest, ClientDetach) carry
+// their result inside the packed TAPI buffer rather than as an RPC return value. [MS-TRP]
+// does not enumerate a named error-code table for the RPC return, so only success is
+// modeled; StatusString renders any other value as hex.
+const (
+	StatusSuccess uint32 = 0x00000000 // success (return value 0)
+)
+
+// SyntaxID returns the tapsrv abstract syntax identifier:
+// 2f5f6520-ca46-1067-b319-00dd010662da, version 1.0.
+func SyntaxID() syntax.SyntaxID {
+	return syntax.SyntaxID{
+		UUID:         guid.GUID{A: 0x2f5f6520, B: 0xca46, C: 0x1067, D: 0xb319, E: 0x00dd010662da},
+		MajorVersion: 1,
+		MinorVersion: 0,
+	}
+}
+
+// StatusString returns a mnemonic for the documented status codes, otherwise the
+// hex value.
+func StatusString(status uint32) string {
+	switch status {
+	case StatusSuccess:
+		return "STATUS_SUCCESS"
+	default:
+		return fmt.Sprintf("0x%08x", status)
+	}
+}
+
+// OpnumToName maps each on-the-wire opnum to its method name; the single source of
+// truth.
+var OpnumToName = map[uint16]string{
+	OpnumClientAttach:  "ClientAttach",
+	OpnumClientRequest: "ClientRequest",
+	OpnumClientDetach:  "ClientDetach",
+}
+
+// NameToOpnum is the reverse of OpnumToName, built at init so the two never drift.
+var NameToOpnum = func() map[string]uint16 {
+	m := make(map[string]uint16, len(OpnumToName))
+	for op, name := range OpnumToName {
+		m[name] = op
+	}
+	return m
+}()

--- a/network/dcerpc/interfaces/2f5f6520-ca46-1067-b319-00dd010662da/1.0/interface_test.go
+++ b/network/dcerpc/interfaces/2f5f6520-ca46-1067-b319-00dd010662da/1.0/interface_test.go
@@ -1,0 +1,48 @@
+package rpcinterface_2f5f6520ca461067b31900dd010662da_1_0
+
+import "testing"
+
+// TestSyntaxID checks the abstract syntax matches [MS-TRP] Appendix A.2 (tapsrv):
+// 2f5f6520-ca46-1067-b319-00dd010662da, version 1.0.
+func TestSyntaxID(t *testing.T) {
+	s := SyntaxID()
+	if got := s.UUID.ToFormatD(); got != "2f5f6520-ca46-1067-b319-00dd010662da" {
+		t.Errorf("UUID = %s, want 2f5f6520-ca46-1067-b319-00dd010662da", got)
+	}
+	if s.MajorVersion != 1 || s.MinorVersion != 0 {
+		t.Errorf("version = %d.%d, want 1.0", s.MajorVersion, s.MinorVersion)
+	}
+}
+
+// TestOpnumNameRoundTrip verifies OpnumToName and NameToOpnum are consistent inverses and
+// cover the three on-the-wire opnums.
+func TestOpnumNameRoundTrip(t *testing.T) {
+	if len(OpnumToName) != 3 {
+		t.Fatalf("OpnumToName has %d entries, want 3", len(OpnumToName))
+	}
+	for op, name := range OpnumToName {
+		if NameToOpnum[name] != op {
+			t.Errorf("NameToOpnum[%q] = %d, want %d", name, NameToOpnum[name], op)
+		}
+	}
+	if OpnumClientAttach != 0 || OpnumClientRequest != 1 || OpnumClientDetach != 2 {
+		t.Errorf("opnums = %d/%d/%d, want 0/1/2", OpnumClientAttach, OpnumClientRequest, OpnumClientDetach)
+	}
+}
+
+// TestStatusString covers the known code and the hex fallback.
+func TestStatusString(t *testing.T) {
+	if got := StatusString(StatusSuccess); got != "STATUS_SUCCESS" {
+		t.Errorf("StatusString(0) = %q, want STATUS_SUCCESS", got)
+	}
+	if got := StatusString(0x80000005); got != "0x80000005" {
+		t.Errorf("StatusString(0x80000005) = %q, want hex fallback", got)
+	}
+}
+
+// TestPipeName pins the well-known tapsrv endpoint ([MS-TRP] 2.1).
+func TestPipeName(t *testing.T) {
+	if PipeName != `\tapsrv` {
+		t.Errorf("PipeName = %q, want \\tapsrv", PipeName)
+	}
+}

--- a/network/dcerpc/interfaces/2f5f6521-ca47-1068-b319-00dd010662db/1.0/functions/00_RemoteSPAttach.go
+++ b/network/dcerpc/interfaces/2f5f6521-ca47-1068-b319-00dd010662db/1.0/functions/00_RemoteSPAttach.go
@@ -1,0 +1,41 @@
+package functions
+
+import (
+	"fmt"
+
+	remotesp "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/2f5f6521-ca47-1068-b319-00dd010662db/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	mstrp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-trp"
+)
+
+// remoteSPAttachRequest carries the (empty) [in] parameter list of RemoteSPAttach.
+type remoteSPAttachRequest struct {
+}
+
+func (*remoteSPAttachRequest) Opnum() uint16 { return remotesp.OpnumRemoteSPAttach }
+
+// remoteSPAttachResponse carries the [out] context handle and return value of
+// RemoteSPAttach.
+type remoteSPAttachResponse struct {
+	PphContext mstrp.PCONTEXT_HANDLE_TYPE2
+	Return     ndr.DWORD `ndr:"retval"`
+}
+
+// RemoteSPAttach calls RemoteSPAttach (opnum 0) ([MS-TRP] 3.1.4.1). In the protocol the
+// telephony server is the RPC client for the remotesp interface: it calls RemoteSPAttach
+// on the client (which hosts the remotesp server) to establish a reverse binding for
+// event delivery. On success the callee returns the remotesp context handle. The method
+// returns 0 on success or a nonzero error code.
+func RemoteSPAttach(rpc ndr.Invoker) (PphContext mstrp.PCONTEXT_HANDLE_TYPE2, err error) {
+	req := &remoteSPAttachRequest{}
+	var resp remoteSPAttachResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("RemoteSPAttach: %w", err)
+		return
+	}
+	PphContext = resp.PphContext
+	if uint32(resp.Return) != remotesp.StatusSuccess {
+		err = fmt.Errorf("RemoteSPAttach failed: %s", remotesp.StatusString(uint32(resp.Return)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/2f5f6521-ca47-1068-b319-00dd010662db/1.0/functions/01_RemoteSPEventProc.go
+++ b/network/dcerpc/interfaces/2f5f6521-ca47-1068-b319-00dd010662db/1.0/functions/01_RemoteSPEventProc.go
@@ -1,0 +1,46 @@
+package functions
+
+import (
+	"fmt"
+
+	remotesp "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/2f5f6521-ca47-1068-b319-00dd010662db/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	mstrp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-trp"
+)
+
+// remoteSPEventProcRequest carries the [in] parameters of RemoteSPEventProc. pBuffer is a
+// top-level conformant-varying byte array ([MS-TRP] 3.1.4.2) whose maximum_count and
+// actual_count both come from lSize; it is transmitted inline (no referent id).
+type remoteSPEventProcRequest struct {
+	PhContext mstrp.PCONTEXT_HANDLE_TYPE2
+	PBuffer   []uint8 `ndr:"ref,varying,size_is=LSize,length_is=LSize"`
+	// LSize is the IDL's signed long; modeled as an unsigned DWORD (a non-negative size,
+	// same 4 octets on the wire) so the NDR codec derives the array's maximum_count and
+	// actual_count from it and keeps the count consistent with the transmitted elements.
+	LSize ndr.DWORD
+}
+
+func (*remoteSPEventProcRequest) Opnum() uint16 { return remotesp.OpnumRemoteSPEventProc }
+
+// remoteSPEventProcResponse is empty: RemoteSPEventProc is a void method with no [out]
+// parameters, so the response stub carries no data on the wire.
+type remoteSPEventProcResponse struct {
+}
+
+// RemoteSPEventProc calls RemoteSPEventProc (opnum 1) ([MS-TRP] 3.1.4.2). The telephony
+// server invokes it on the client to push an asynchronous TAPI event: pBuffer holds the
+// packed event data of lSize bytes for the session identified by phContext. It returns no
+// value; transport-level failures surface through err.
+func RemoteSPEventProc(rpc ndr.Invoker, phContext mstrp.PCONTEXT_HANDLE_TYPE2, pBuffer []uint8, lSize ndr.DWORD) (err error) {
+	req := &remoteSPEventProcRequest{
+		PhContext: phContext,
+		PBuffer:   pBuffer,
+		LSize:     lSize,
+	}
+	var resp remoteSPEventProcResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("RemoteSPEventProc: %w", err)
+		return
+	}
+	return
+}

--- a/network/dcerpc/interfaces/2f5f6521-ca47-1068-b319-00dd010662db/1.0/functions/02_RemoteSPDetach.go
+++ b/network/dcerpc/interfaces/2f5f6521-ca47-1068-b319-00dd010662db/1.0/functions/02_RemoteSPDetach.go
@@ -1,0 +1,41 @@
+package functions
+
+import (
+	"fmt"
+
+	remotesp "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/2f5f6521-ca47-1068-b319-00dd010662db/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	mstrp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-trp"
+)
+
+// remoteSPDetachRequest carries the [in,out] context handle of RemoteSPDetach, transmitted
+// inline as a [ref] pointer to the 20-octet context handle.
+type remoteSPDetachRequest struct {
+	PphContext mstrp.PCONTEXT_HANDLE_TYPE2
+}
+
+func (*remoteSPDetachRequest) Opnum() uint16 { return remotesp.OpnumRemoteSPDetach }
+
+// remoteSPDetachResponse carries the [in,out] context handle back. RemoteSPDetach is a
+// void method, so there is no return value on the wire; the callee returns the handle
+// nulled out on success.
+type remoteSPDetachResponse struct {
+	PphContext mstrp.PCONTEXT_HANDLE_TYPE2
+}
+
+// RemoteSPDetach calls RemoteSPDetach (opnum 2) ([MS-TRP] 3.1.4.3). The telephony server
+// invokes it on the client to tear down the reverse binding established by RemoteSPAttach
+// and free the associated state. The callee returns the handle nulled out (IsZero);
+// transport-level failures surface through err.
+func RemoteSPDetach(rpc ndr.Invoker, pphContext mstrp.PCONTEXT_HANDLE_TYPE2) (PphContext mstrp.PCONTEXT_HANDLE_TYPE2, err error) {
+	req := &remoteSPDetachRequest{
+		PphContext: pphContext,
+	}
+	var resp remoteSPDetachResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("RemoteSPDetach: %w", err)
+		return
+	}
+	PphContext = resp.PphContext
+	return
+}

--- a/network/dcerpc/interfaces/2f5f6521-ca47-1068-b319-00dd010662db/1.0/functions/functions_test.go
+++ b/network/dcerpc/interfaces/2f5f6521-ca47-1068-b319-00dd010662db/1.0/functions/functions_test.go
@@ -1,0 +1,63 @@
+package functions
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	mstrp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-trp"
+)
+
+// TestRemoteSPEventProc_BufferWireShape pins the wire layout of RemoteSPEventProc's
+// pBuffer ([MS-TRP] 3.1.4.2): a top-level conformant-varying byte array transmitted inline
+// (no referent id) whose maximum_count and actual_count both equal lSize, followed by the
+// lSize field itself. lSize is derived from the slice length so the count and elements
+// cannot disagree.
+func TestRemoteSPEventProc_BufferWireShape(t *testing.T) {
+	var ctx mstrp.PCONTEXT_HANDLE_TYPE2
+	for i := range ctx {
+		ctx[i] = 0xBB
+	}
+	req := &remoteSPEventProcRequest{
+		PhContext: ctx,
+		PBuffer:   []uint8{0x11, 0x22, 0x33, 0x44},
+		LSize:     4,
+	}
+	raw, err := ndr.Marshal(req)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	want := bytes.Join([][]byte{
+		bytes.Repeat([]byte{0xBB}, 20), // phContext (inline, no referent id)
+		{0x04, 0, 0, 0},                // maximum_count = lSize = 4
+		{0x00, 0, 0, 0},                // offset = 0
+		{0x04, 0, 0, 0},                // actual_count = lSize = 4
+		{0x11, 0x22, 0x33, 0x44},       // 4 bytes
+		{0x04, 0, 0, 0},                // lSize field = 4
+	}, nil)
+	if !bytes.Equal(raw, want) {
+		t.Errorf("wire mismatch:\n got  %x\n want %x", raw, want)
+	}
+}
+
+// TestRemoteSPEventProc_EmptyResponse confirms the void method decodes an empty response
+// stub with no error (no return value on the wire).
+func TestRemoteSPEventProc_EmptyResponse(t *testing.T) {
+	var resp remoteSPEventProcResponse
+	if err := ndr.Unmarshal(nil, &resp); err != nil {
+		t.Fatalf("Unmarshal empty response: %v", err)
+	}
+}
+
+// TestRemoteSPDetach_ResponseRoundTrip covers the void RemoteSPDetach response: just the
+// nulled-out context handle, no return value.
+func TestRemoteSPDetach_ResponseRoundTrip(t *testing.T) {
+	raw := make([]byte, 20) // all-zero handle
+	var resp remoteSPDetachResponse
+	if err := ndr.Unmarshal(raw, &resp); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if !resp.PphContext.IsZero() {
+		t.Errorf("PphContext = %x, want zero", resp.PphContext)
+	}
+}

--- a/network/dcerpc/interfaces/2f5f6521-ca47-1068-b319-00dd010662db/1.0/interface.go
+++ b/network/dcerpc/interfaces/2f5f6521-ca47-1068-b319-00dd010662db/1.0/interface.go
@@ -1,0 +1,85 @@
+// Package rpcinterface_2f5f6521ca471068b31900dd010662db_1_0 is the descriptor for the
+// remotesp (Remote Service Provider) RPC interface, abstract syntax
+// 2f5f6521-ca47-1068-b319-00dd010662db version 1.0 ([MS-TRP]).
+//
+// remotesp is a reverse/callback interface: the telephony server acts as the RPC client
+// and invokes these methods on the client, which hosts the remotesp server, to push
+// asynchronous TAPI event notifications.
+//
+// An RPC interface is identified by its UUID and version, never by the transport it is
+// reached over: the directory is named after the UUID with the version in the nested
+// <maj>.<min>/ directory.
+//
+// This package holds only the interface-level descriptor (abstract syntax, transport
+// endpoint, opnums, opnum<->name maps, status constants). NDR types live in the
+// windows/protocols/ms-trp package (imported as mstrp) and method stubs in functions;
+// both depend on this package, never the reverse.
+package rpcinterface_2f5f6521ca471068b31900dd010662db_1_0
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+)
+
+// PipeName is empty for the remotesp interface: [MS-TRP] 2.1 specifies that the client
+// chooses the RPC protocol sequence and endpoint when it calls ClientAttach, and the
+// telephony server establishes the reverse connection to that client-supplied endpoint.
+// There is therefore no fixed well-known named pipe. It is retained, empty, for
+// descriptor uniformity across interfaces.
+const PipeName = ``
+
+// Opnums for the on-the-wire methods.
+const (
+	OpnumRemoteSPAttach    uint16 = 0
+	OpnumRemoteSPEventProc uint16 = 1
+	OpnumRemoteSPDetach    uint16 = 2
+)
+
+// Status codes for this interface. RemoteSPAttach returns 0 on success and a nonzero
+// error code otherwise ([MS-TRP] 3.1.4.1); the void methods (RemoteSPEventProc,
+// RemoteSPDetach) carry no RPC return value. [MS-TRP] does not enumerate a named
+// error-code table for the RPC return, so only success is modeled; StatusString renders
+// any other value as hex.
+const (
+	StatusSuccess uint32 = 0x00000000 // success (return value 0)
+)
+
+// SyntaxID returns the remotesp abstract syntax identifier:
+// 2f5f6521-ca47-1068-b319-00dd010662db, version 1.0.
+func SyntaxID() syntax.SyntaxID {
+	return syntax.SyntaxID{
+		UUID:         guid.GUID{A: 0x2f5f6521, B: 0xca47, C: 0x1068, D: 0xb319, E: 0x00dd010662db},
+		MajorVersion: 1,
+		MinorVersion: 0,
+	}
+}
+
+// StatusString returns a mnemonic for the documented status codes, otherwise the
+// hex value.
+func StatusString(status uint32) string {
+	switch status {
+	case StatusSuccess:
+		return "STATUS_SUCCESS"
+	default:
+		return fmt.Sprintf("0x%08x", status)
+	}
+}
+
+// OpnumToName maps each on-the-wire opnum to its method name; the single source of
+// truth.
+var OpnumToName = map[uint16]string{
+	OpnumRemoteSPAttach:    "RemoteSPAttach",
+	OpnumRemoteSPEventProc: "RemoteSPEventProc",
+	OpnumRemoteSPDetach:    "RemoteSPDetach",
+}
+
+// NameToOpnum is the reverse of OpnumToName, built at init so the two never drift.
+var NameToOpnum = func() map[string]uint16 {
+	m := make(map[string]uint16, len(OpnumToName))
+	for op, name := range OpnumToName {
+		m[name] = op
+	}
+	return m
+}()

--- a/network/dcerpc/interfaces/2f5f6521-ca47-1068-b319-00dd010662db/1.0/interface_test.go
+++ b/network/dcerpc/interfaces/2f5f6521-ca47-1068-b319-00dd010662db/1.0/interface_test.go
@@ -1,0 +1,49 @@
+package rpcinterface_2f5f6521ca471068b31900dd010662db_1_0
+
+import "testing"
+
+// TestSyntaxID checks the abstract syntax matches [MS-TRP] Appendix A.1 (remotesp):
+// 2f5f6521-ca47-1068-b319-00dd010662db, version 1.0.
+func TestSyntaxID(t *testing.T) {
+	s := SyntaxID()
+	if got := s.UUID.ToFormatD(); got != "2f5f6521-ca47-1068-b319-00dd010662db" {
+		t.Errorf("UUID = %s, want 2f5f6521-ca47-1068-b319-00dd010662db", got)
+	}
+	if s.MajorVersion != 1 || s.MinorVersion != 0 {
+		t.Errorf("version = %d.%d, want 1.0", s.MajorVersion, s.MinorVersion)
+	}
+}
+
+// TestOpnumNameRoundTrip verifies OpnumToName and NameToOpnum are consistent inverses and
+// cover the three on-the-wire opnums.
+func TestOpnumNameRoundTrip(t *testing.T) {
+	if len(OpnumToName) != 3 {
+		t.Fatalf("OpnumToName has %d entries, want 3", len(OpnumToName))
+	}
+	for op, name := range OpnumToName {
+		if NameToOpnum[name] != op {
+			t.Errorf("NameToOpnum[%q] = %d, want %d", name, NameToOpnum[name], op)
+		}
+	}
+	if OpnumRemoteSPAttach != 0 || OpnumRemoteSPEventProc != 1 || OpnumRemoteSPDetach != 2 {
+		t.Errorf("opnums = %d/%d/%d, want 0/1/2", OpnumRemoteSPAttach, OpnumRemoteSPEventProc, OpnumRemoteSPDetach)
+	}
+}
+
+// TestStatusString covers the known code and the hex fallback.
+func TestStatusString(t *testing.T) {
+	if got := StatusString(StatusSuccess); got != "STATUS_SUCCESS" {
+		t.Errorf("StatusString(0) = %q, want STATUS_SUCCESS", got)
+	}
+	if got := StatusString(0xdeadbeef); got != "0xdeadbeef" {
+		t.Errorf("StatusString(0xdeadbeef) = %q, want hex fallback", got)
+	}
+}
+
+// TestPipeName documents that remotesp has no fixed named pipe: [MS-TRP] 2.1 uses a
+// client-specified endpoint for the reverse callback connection, so PipeName is empty.
+func TestPipeName(t *testing.T) {
+	if PipeName != `` {
+		t.Errorf("PipeName = %q, want empty (client-specified reverse endpoint)", PipeName)
+	}
+}

--- a/windows/protocols/ms-trp/PCONTEXT_HANDLE_TYPE.go
+++ b/windows/protocols/ms-trp/PCONTEXT_HANDLE_TYPE.go
@@ -1,0 +1,25 @@
+// Package mstrp holds the NDR wire structures for the Telephony Remote Protocol
+// ([MS-TRP]): the RPC context-handle types shared by the tapsrv and remotesp interfaces.
+//
+// The interface descriptors and method stubs live under network/dcerpc/interfaces
+// (keyed by UUID/version); this package holds only the data types, so the dependency
+// direction stays functions -> structures and never the reverse.
+package mstrp
+
+// PCONTEXT_HANDLE_TYPE is the RPC context handle the tapsrv interface returns from
+// ClientAttach and threads through ClientRequest / ClientDetach ([MS-TRP] 2.2.1,
+// 3.2.4). The IDL types it as [context_handle] void *; on the wire it is a 20-octet
+// context handle (a 4-octet attributes field followed by a 16-octet GUID,
+// [MS-RPCE] 2.3.2.2), transmitted inline with no referent id.
+type PCONTEXT_HANDLE_TYPE [20]byte
+
+// IsZero reports whether the handle is all zeros (for example, after a successful
+// ClientDetach, which the server returns nulled out).
+func (h PCONTEXT_HANDLE_TYPE) IsZero() bool {
+	for _, b := range h {
+		if b != 0 {
+			return false
+		}
+	}
+	return true
+}

--- a/windows/protocols/ms-trp/PCONTEXT_HANDLE_TYPE2.go
+++ b/windows/protocols/ms-trp/PCONTEXT_HANDLE_TYPE2.go
@@ -1,0 +1,19 @@
+package mstrp
+
+// PCONTEXT_HANDLE_TYPE2 is the RPC context handle the remotesp (reverse/callback)
+// interface returns from RemoteSPAttach and threads through RemoteSPEventProc /
+// RemoteSPDetach ([MS-TRP] 2.2.2, 3.1.4). The IDL types it as [context_handle] void *;
+// on the wire it is a 20-octet context handle (a 4-octet attributes field followed by a
+// 16-octet GUID, [MS-RPCE] 2.3.2.2), transmitted inline with no referent id.
+type PCONTEXT_HANDLE_TYPE2 [20]byte
+
+// IsZero reports whether the handle is all zeros (for example, after a successful
+// RemoteSPDetach, which the server returns nulled out).
+func (h PCONTEXT_HANDLE_TYPE2) IsZero() bool {
+	for _, b := range h {
+		if b != 0 {
+			return false
+		}
+	}
+	return true
+}

--- a/windows/protocols/ms-trp/structures_test.go
+++ b/windows/protocols/ms-trp/structures_test.go
@@ -1,0 +1,89 @@
+package mstrp
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// ctxHandleHolder embeds a context handle so the round trip drives the same inline
+// (no-referent) marshalling path the tapsrv/remotesp request and response stubs use.
+type ctxHandleHolder struct {
+	Handle PCONTEXT_HANDLE_TYPE
+}
+
+// TestPCONTEXT_HANDLE_TYPE_RoundTrip confirms the 20-octet context handle marshals inline
+// as exactly 20 bytes and round-trips byte-for-byte.
+func TestPCONTEXT_HANDLE_TYPE_RoundTrip(t *testing.T) {
+	var in ctxHandleHolder
+	for i := range in.Handle {
+		in.Handle[i] = byte(i + 1)
+	}
+	raw, err := ndr.Marshal(&in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if len(raw) != 20 {
+		t.Fatalf("wire length = %d, want 20 (a context handle is 20 octets, no referent id)", len(raw))
+	}
+	if !bytes.Equal(raw, in.Handle[:]) {
+		t.Errorf("wire bytes = %x, want %x (handle transmitted inline verbatim)", raw, in.Handle[:])
+	}
+	var out ctxHandleHolder
+	if err := ndr.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out.Handle != in.Handle {
+		t.Errorf("round-trip mismatch: got %x want %x", out.Handle, in.Handle)
+	}
+}
+
+// ctxHandle2Holder embeds the remotesp context handle so it, too, is exercised through the
+// inline (no-referent) marshalling path.
+type ctxHandle2Holder struct {
+	Handle PCONTEXT_HANDLE_TYPE2
+}
+
+// TestPCONTEXT_HANDLE_TYPE2_RoundTrip confirms the remotesp 20-octet context handle
+// marshals inline as exactly 20 bytes and round-trips byte-for-byte.
+func TestPCONTEXT_HANDLE_TYPE2_RoundTrip(t *testing.T) {
+	var in ctxHandle2Holder
+	for i := range in.Handle {
+		in.Handle[i] = byte(0xF0 - i)
+	}
+	raw, err := ndr.Marshal(&in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if len(raw) != 20 {
+		t.Fatalf("wire length = %d, want 20 (a context handle is 20 octets, no referent id)", len(raw))
+	}
+	if !bytes.Equal(raw, in.Handle[:]) {
+		t.Errorf("wire bytes = %x, want %x (handle transmitted inline verbatim)", raw, in.Handle[:])
+	}
+	var out ctxHandle2Holder
+	if err := ndr.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out.Handle != in.Handle {
+		t.Errorf("round-trip mismatch: got %x want %x", out.Handle, in.Handle)
+	}
+}
+
+// TestPCONTEXT_HANDLE_IsZero covers the nulled-out handle the server returns after a
+// successful Detach.
+func TestPCONTEXT_HANDLE_IsZero(t *testing.T) {
+	var zero PCONTEXT_HANDLE_TYPE
+	if !zero.IsZero() {
+		t.Error("zero-valued PCONTEXT_HANDLE_TYPE should report IsZero()==true")
+	}
+	var zero2 PCONTEXT_HANDLE_TYPE2
+	if !zero2.IsZero() {
+		t.Error("zero-valued PCONTEXT_HANDLE_TYPE2 should report IsZero()==true")
+	}
+	nonzero := PCONTEXT_HANDLE_TYPE{0: 0x01}
+	if nonzero.IsZero() {
+		t.Error("non-zero PCONTEXT_HANDLE_TYPE should report IsZero()==false")
+	}
+}


### PR DESCRIPTION
### Summary

Implements the two classic DCE/RPC client interfaces of the Telephony Remote Protocol ([MS-TRP]):

- **tapsrv** — the Telephony Server interface an RPC client uses to drive TAPI operations on a remote server: attach a session, exchange packed TAPI request buffers, and detach.
- **remotesp** — the Remote Service Provider (reverse/callback) interface. In the protocol the telephony **server** acts as the RPC client and invokes these methods on the client (which hosts the remotesp server) to push asynchronous TAPI event notifications.

Both are classic DCE/RPC interfaces (context-handle based), not DCOM.

Closes #840.

### What's included

Two interfaces, one file per opnum, following the project's split layout.

**tapsrv** — `2f5f6520-ca46-1067-b319-00dd010662da` v1.0, well-known named pipe `\pipe\tapsrv` (protocol sequence `ncacn_np`, [MS-TRP] 2.1):

| Opnum | Method | Notes |
| --- | --- | --- |
| 0 | `ClientAttach` | returns `long`; establishes the tapsrv session |
| 1 | `ClientRequest` | void; exchanges the packed TAPI buffer in place |
| 2 | `ClientDetach` | void; closes the session |

**remotesp** — `2f5f6521-ca47-1068-b319-00dd010662db` v1.0. Per [MS-TRP] 2.1 the client chooses the RPC protocol sequence and endpoint at `ClientAttach` time and the server establishes the reverse connection to it, so there is no fixed well-known named pipe and `PipeName` is intentionally empty:

| Opnum | Method | Notes |
| --- | --- | --- |
| 0 | `RemoteSPAttach` | returns `long`; establishes the reverse binding |
| 1 | `RemoteSPEventProc` | void; pushes a packed asynchronous event |
| 2 | `RemoteSPDetach` | void; tears down the reverse binding |

All six methods are on the wire (no `NotUsedOnWire` opnums).

### Layout

- **Interface trees** — `network/dcerpc/interfaces/2f5f6520-ca46-1067-b319-00dd010662da/1.0/` and `.../2f5f6521-ca47-1068-b319-00dd010662db/1.0/`: the descriptors (`interface.go`: `SyntaxID`, `PipeName`, opnums, `OpnumToName`/`NameToOpnum`, status code + `StatusString`) and the per-opnum stubs under `functions/`, plus `interface_test.go` and `functions/functions_test.go`.
- **Structures package** — `windows/protocols/ms-trp/` (`package mstrp`): the shared context-handle types `PCONTEXT_HANDLE_TYPE` (tapsrv) and `PCONTEXT_HANDLE_TYPE2` (remotesp), plus `structures_test.go`.

### NDR modeling notes

- The `[in] handle_t` explicit RPC binding handle is not on the wire; stubs take `ndr.Invoker`.
- Context handles are 20-octet inline handles ([MS-RPCE] 2.3.2.2), modeled as `[20]byte`, transmitted inline with no referent id.
- **Void methods** (`ClientRequest`, `ClientDetach`, `RemoteSPEventProc`, `RemoteSPDetach`) carry **no** RPC return value on the wire; only `ClientAttach` and `RemoteSPAttach` return a `long`, carried as `ndr:"retval"`.
- `ClientAttach`'s `pszDomainUser` / `pszMachine` are top-level `[ref] [string] wchar_t*` parameters, modeled as bare `ndr.WSTR` (inline conformant-varying UTF-16LE, no referent id).
- `ClientRequest`'s `[in,out] pBuffer` is a top-level `[ref]` conformant-varying byte array with **independent bounds**: `maximum_count` from `lNeededSize` (capacity) and `actual_count` from `plUsedSize` (valid length). `[ref]` suppresses both the referent id and the hoisting of `maximum_count` ahead of the preceding context handle. The size fields are modeled as unsigned `ndr.DWORD` (the IDL's non-negative `long`) because the codec reads size_is/length_is sibling counts as unsigned.
- `RemoteSPEventProc`'s `pBuffer[]` is a conformant-varying byte array with `size_is == length_is == lSize`; `lSize` is a `ndr.DWORD` so the count is derived consistently with the transmitted elements.
- [MS-TRP] does not enumerate a named RPC error-code table (the TAPI result travels inside the packed buffer), so only `StatusSuccess` (0) is modeled and `StatusString` falls back to hex.

### Testing

- `gofmt`, `go build`, `go vet`, `go test` clean over both interface trees and the structures package.
- Cross-compiles under `GOARCH=386` and `GOARCH=arm64`; builds with `-tags integration`.
- `interface_test.go` pins each `SyntaxID`, the opnum⇄name round trip, `StatusString`, and the `PipeName`.
- `functions/functions_test.go` asserts the exact wire bytes of `ClientRequest` (independent-bounds buffer: `max_count=lNeededSize`, `actual_count=plUsedSize`, no referent id) and `RemoteSPEventProc`, and round-trips the void responses.
- `structures_test.go` round-trips both 20-octet context handles (inline, no referent id) and covers `IsZero`.

Wire modeling was cross-checked against the IDL and a wire-tested reference implementation.