### PR TITLE
Add W32Time Remote Protocol (MS-W32T) W32Time interface (Fixes #848)

### DIFF
--- a/network/dcerpc/interfaces/8fb6d884-2388-11d0-8c35-00c04fda2795/4.1/functions/00_W32TimeSync.go
+++ b/network/dcerpc/interfaces/8fb6d884-2388-11d0-8c35-00c04fda2795/4.1/functions/00_W32TimeSync.go
@@ -1,0 +1,38 @@
+package functions
+
+import (
+	"fmt"
+
+	W32Time "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/8fb6d884-2388-11d0-8c35-00c04fda2795/4.1"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// w32TimeSyncRequest carries the [in] parameters of W32TimeSync.
+type w32TimeSyncRequest struct {
+	UWait   ndr.DWORD
+	UlFlags ndr.DWORD
+}
+
+func (*w32TimeSyncRequest) Opnum() uint16 { return W32Time.OpnumW32TimeSync }
+
+// w32TimeSyncResponse carries the [out] parameters and return value of W32TimeSync.
+type w32TimeSyncResponse struct {
+	Status ndr.DWORD `ndr:"retval"`
+}
+
+// W32TimeSync calls W32TimeSync (opnum 0) ([MS-W32T] section 3.2.4).
+func W32TimeSync(rpc ndr.Invoker, uWait ndr.DWORD, ulFlags ndr.DWORD) (err error) {
+	req := &w32TimeSyncRequest{
+		UWait:   uWait,
+		UlFlags: ulFlags,
+	}
+	var resp w32TimeSyncResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("W32TimeSync: %w", err)
+		return
+	}
+	if uint32(resp.Status) != W32Time.StatusSuccess {
+		err = fmt.Errorf("W32TimeSync failed: %s", W32Time.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/8fb6d884-2388-11d0-8c35-00c04fda2795/4.1/functions/01_W32TimeGetNetlogonServiceBits.go
+++ b/network/dcerpc/interfaces/8fb6d884-2388-11d0-8c35-00c04fda2795/4.1/functions/01_W32TimeGetNetlogonServiceBits.go
@@ -1,0 +1,35 @@
+package functions
+
+import (
+	"fmt"
+
+	W32Time "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/8fb6d884-2388-11d0-8c35-00c04fda2795/4.1"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// w32TimeGetNetlogonServiceBitsRequest carries the [in] parameters of W32TimeGetNetlogonServiceBits.
+type w32TimeGetNetlogonServiceBitsRequest struct {
+}
+
+func (*w32TimeGetNetlogonServiceBitsRequest) Opnum() uint16 {
+	return W32Time.OpnumW32TimeGetNetlogonServiceBits
+}
+
+// w32TimeGetNetlogonServiceBitsResponse carries the [out] parameters and return value of W32TimeGetNetlogonServiceBits.
+type w32TimeGetNetlogonServiceBitsResponse struct {
+	Status ndr.DWORD `ndr:"retval"`
+}
+
+// W32TimeGetNetlogonServiceBits calls W32TimeGetNetlogonServiceBits (opnum 1) ([MS-W32T] section 3.2.4).
+func W32TimeGetNetlogonServiceBits(rpc ndr.Invoker) (err error) {
+	req := &w32TimeGetNetlogonServiceBitsRequest{}
+	var resp w32TimeGetNetlogonServiceBitsResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("W32TimeGetNetlogonServiceBits: %w", err)
+		return
+	}
+	if uint32(resp.Status) != W32Time.StatusSuccess {
+		err = fmt.Errorf("W32TimeGetNetlogonServiceBits failed: %s", W32Time.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/8fb6d884-2388-11d0-8c35-00c04fda2795/4.1/functions/02_W32TimeQueryProviderStatus.go
+++ b/network/dcerpc/interfaces/8fb6d884-2388-11d0-8c35-00c04fda2795/4.1/functions/02_W32TimeQueryProviderStatus.go
@@ -1,0 +1,43 @@
+package functions
+
+import (
+	"fmt"
+
+	W32Time "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/8fb6d884-2388-11d0-8c35-00c04fda2795/4.1"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	msw32t "github.com/TheManticoreProject/Manticore/windows/protocols/ms-w32t"
+)
+
+// w32TimeQueryProviderStatusRequest carries the [in] parameters of W32TimeQueryProviderStatus.
+type w32TimeQueryProviderStatusRequest struct {
+	UlFlags      ndr.DWORD
+	PwszProvider ndr.WSTR
+}
+
+func (*w32TimeQueryProviderStatusRequest) Opnum() uint16 {
+	return W32Time.OpnumW32TimeQueryProviderStatus
+}
+
+// w32TimeQueryProviderStatusResponse carries the [out] parameters and return value of W32TimeQueryProviderStatus.
+type w32TimeQueryProviderStatusResponse struct {
+	PProviderInfo *msw32t.W32TIME_PROVIDER_INFO `ndr:"unique"`
+	Status        ndr.DWORD                     `ndr:"retval"`
+}
+
+// W32TimeQueryProviderStatus calls W32TimeQueryProviderStatus (opnum 2) ([MS-W32T] section 3.2.4).
+func W32TimeQueryProviderStatus(rpc ndr.Invoker, ulFlags ndr.DWORD, pwszProvider ndr.WSTR) (PProviderInfo *msw32t.W32TIME_PROVIDER_INFO, err error) {
+	req := &w32TimeQueryProviderStatusRequest{
+		UlFlags:      ulFlags,
+		PwszProvider: pwszProvider,
+	}
+	var resp w32TimeQueryProviderStatusResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("W32TimeQueryProviderStatus: %w", err)
+		return
+	}
+	PProviderInfo = resp.PProviderInfo
+	if uint32(resp.Status) != W32Time.StatusSuccess {
+		err = fmt.Errorf("W32TimeQueryProviderStatus failed: %s", W32Time.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/8fb6d884-2388-11d0-8c35-00c04fda2795/4.1/functions/03_W32TimeQuerySource.go
+++ b/network/dcerpc/interfaces/8fb6d884-2388-11d0-8c35-00c04fda2795/4.1/functions/03_W32TimeQuerySource.go
@@ -1,0 +1,38 @@
+package functions
+
+import (
+	"fmt"
+
+	W32Time "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/8fb6d884-2388-11d0-8c35-00c04fda2795/4.1"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// w32TimeQuerySourceRequest carries the [in] parameters of W32TimeQuerySource.
+type w32TimeQuerySourceRequest struct {
+}
+
+func (*w32TimeQuerySourceRequest) Opnum() uint16 { return W32Time.OpnumW32TimeQuerySource }
+
+// w32TimeQuerySourceResponse carries the [out] parameters and return value of W32TimeQuerySource.
+// pwszSource is [out, string] wchar_t** — the outer pointer is the [ref] out slot and the
+// inner [unique,string] pointer is transmitted as a referent id followed by the string body.
+type w32TimeQuerySourceResponse struct {
+	PwszSource *ndr.WSTR `ndr:"unique"`
+	Status     ndr.DWORD `ndr:"retval"`
+}
+
+// W32TimeQuerySource calls W32TimeQuerySource (opnum 3) ([MS-W32T] 3.2.4.4). It returns the
+// name of the current time source, or nil when the server sends a null string pointer.
+func W32TimeQuerySource(rpc ndr.Invoker) (PwszSource *ndr.WSTR, err error) {
+	req := &w32TimeQuerySourceRequest{}
+	var resp w32TimeQuerySourceResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("W32TimeQuerySource: %w", err)
+		return
+	}
+	PwszSource = resp.PwszSource
+	if uint32(resp.Status) != W32Time.StatusSuccess {
+		err = fmt.Errorf("W32TimeQuerySource failed: %s", W32Time.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/8fb6d884-2388-11d0-8c35-00c04fda2795/4.1/functions/04_W32TimeQueryProviderConfiguration.go
+++ b/network/dcerpc/interfaces/8fb6d884-2388-11d0-8c35-00c04fda2795/4.1/functions/04_W32TimeQueryProviderConfiguration.go
@@ -1,0 +1,43 @@
+package functions
+
+import (
+	"fmt"
+
+	W32Time "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/8fb6d884-2388-11d0-8c35-00c04fda2795/4.1"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	msw32t "github.com/TheManticoreProject/Manticore/windows/protocols/ms-w32t"
+)
+
+// w32TimeQueryProviderConfigurationRequest carries the [in] parameters of W32TimeQueryProviderConfiguration.
+type w32TimeQueryProviderConfigurationRequest struct {
+	UlFlags      ndr.DWORD
+	PwszProvider ndr.WSTR
+}
+
+func (*w32TimeQueryProviderConfigurationRequest) Opnum() uint16 {
+	return W32Time.OpnumW32TimeQueryProviderConfiguration
+}
+
+// w32TimeQueryProviderConfigurationResponse carries the [out] parameters and return value of W32TimeQueryProviderConfiguration.
+type w32TimeQueryProviderConfigurationResponse struct {
+	PConfigurationProviderInfo *msw32t.W32TIME_CONFIGURATION_PROVIDER `ndr:"unique"`
+	Status                     ndr.DWORD                              `ndr:"retval"`
+}
+
+// W32TimeQueryProviderConfiguration calls W32TimeQueryProviderConfiguration (opnum 4) ([MS-W32T] section 3.2.4).
+func W32TimeQueryProviderConfiguration(rpc ndr.Invoker, ulFlags ndr.DWORD, pwszProvider ndr.WSTR) (PConfigurationProviderInfo *msw32t.W32TIME_CONFIGURATION_PROVIDER, err error) {
+	req := &w32TimeQueryProviderConfigurationRequest{
+		UlFlags:      ulFlags,
+		PwszProvider: pwszProvider,
+	}
+	var resp w32TimeQueryProviderConfigurationResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("W32TimeQueryProviderConfiguration: %w", err)
+		return
+	}
+	PConfigurationProviderInfo = resp.PConfigurationProviderInfo
+	if uint32(resp.Status) != W32Time.StatusSuccess {
+		err = fmt.Errorf("W32TimeQueryProviderConfiguration failed: %s", W32Time.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/8fb6d884-2388-11d0-8c35-00c04fda2795/4.1/functions/05_W32TimeQueryConfiguration.go
+++ b/network/dcerpc/interfaces/8fb6d884-2388-11d0-8c35-00c04fda2795/4.1/functions/05_W32TimeQueryConfiguration.go
@@ -1,0 +1,38 @@
+package functions
+
+import (
+	"fmt"
+
+	W32Time "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/8fb6d884-2388-11d0-8c35-00c04fda2795/4.1"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	msw32t "github.com/TheManticoreProject/Manticore/windows/protocols/ms-w32t"
+)
+
+// w32TimeQueryConfigurationRequest carries the [in] parameters of W32TimeQueryConfiguration.
+type w32TimeQueryConfigurationRequest struct {
+}
+
+func (*w32TimeQueryConfigurationRequest) Opnum() uint16 {
+	return W32Time.OpnumW32TimeQueryConfiguration
+}
+
+// w32TimeQueryConfigurationResponse carries the [out] parameters and return value of W32TimeQueryConfiguration.
+type w32TimeQueryConfigurationResponse struct {
+	PConfigurationInfo *msw32t.W32TIME_CONFIGURATION_INFO `ndr:"unique"`
+	Status             ndr.DWORD                          `ndr:"retval"`
+}
+
+// W32TimeQueryConfiguration calls W32TimeQueryConfiguration (opnum 5) ([MS-W32T] section 3.2.4).
+func W32TimeQueryConfiguration(rpc ndr.Invoker) (PConfigurationInfo *msw32t.W32TIME_CONFIGURATION_INFO, err error) {
+	req := &w32TimeQueryConfigurationRequest{}
+	var resp w32TimeQueryConfigurationResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("W32TimeQueryConfiguration: %w", err)
+		return
+	}
+	PConfigurationInfo = resp.PConfigurationInfo
+	if uint32(resp.Status) != W32Time.StatusSuccess {
+		err = fmt.Errorf("W32TimeQueryConfiguration failed: %s", W32Time.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/8fb6d884-2388-11d0-8c35-00c04fda2795/4.1/functions/06_W32TimeQueryStatus.go
+++ b/network/dcerpc/interfaces/8fb6d884-2388-11d0-8c35-00c04fda2795/4.1/functions/06_W32TimeQueryStatus.go
@@ -1,0 +1,36 @@
+package functions
+
+import (
+	"fmt"
+
+	W32Time "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/8fb6d884-2388-11d0-8c35-00c04fda2795/4.1"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	msw32t "github.com/TheManticoreProject/Manticore/windows/protocols/ms-w32t"
+)
+
+// w32TimeQueryStatusRequest carries the [in] parameters of W32TimeQueryStatus.
+type w32TimeQueryStatusRequest struct {
+}
+
+func (*w32TimeQueryStatusRequest) Opnum() uint16 { return W32Time.OpnumW32TimeQueryStatus }
+
+// w32TimeQueryStatusResponse carries the [out] parameters and return value of W32TimeQueryStatus.
+type w32TimeQueryStatusResponse struct {
+	PStatusInfo *msw32t.W32TIME_STATUS_INFO `ndr:"unique"`
+	Status      ndr.DWORD                   `ndr:"retval"`
+}
+
+// W32TimeQueryStatus calls W32TimeQueryStatus (opnum 6) ([MS-W32T] section 3.2.4).
+func W32TimeQueryStatus(rpc ndr.Invoker) (PStatusInfo *msw32t.W32TIME_STATUS_INFO, err error) {
+	req := &w32TimeQueryStatusRequest{}
+	var resp w32TimeQueryStatusResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("W32TimeQueryStatus: %w", err)
+		return
+	}
+	PStatusInfo = resp.PStatusInfo
+	if uint32(resp.Status) != W32Time.StatusSuccess {
+		err = fmt.Errorf("W32TimeQueryStatus failed: %s", W32Time.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/8fb6d884-2388-11d0-8c35-00c04fda2795/4.1/functions/07_W32TimeLog.go
+++ b/network/dcerpc/interfaces/8fb6d884-2388-11d0-8c35-00c04fda2795/4.1/functions/07_W32TimeLog.go
@@ -1,0 +1,33 @@
+package functions
+
+import (
+	"fmt"
+
+	W32Time "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/8fb6d884-2388-11d0-8c35-00c04fda2795/4.1"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// w32TimeLogRequest carries the [in] parameters of W32TimeLog.
+type w32TimeLogRequest struct {
+}
+
+func (*w32TimeLogRequest) Opnum() uint16 { return W32Time.OpnumW32TimeLog }
+
+// w32TimeLogResponse carries the [out] parameters and return value of W32TimeLog.
+type w32TimeLogResponse struct {
+	Status ndr.DWORD `ndr:"retval"`
+}
+
+// W32TimeLog calls W32TimeLog (opnum 7) ([MS-W32T] section 3.2.4).
+func W32TimeLog(rpc ndr.Invoker) (err error) {
+	req := &w32TimeLogRequest{}
+	var resp w32TimeLogResponse
+	if err = rpc.Invoke(req, &resp); err != nil {
+		err = fmt.Errorf("W32TimeLog: %w", err)
+		return
+	}
+	if uint32(resp.Status) != W32Time.StatusSuccess {
+		err = fmt.Errorf("W32TimeLog failed: %s", W32Time.StatusString(uint32(resp.Status)))
+	}
+	return
+}

--- a/network/dcerpc/interfaces/8fb6d884-2388-11d0-8c35-00c04fda2795/4.1/interface.go
+++ b/network/dcerpc/interfaces/8fb6d884-2388-11d0-8c35-00c04fda2795/4.1/interface.go
@@ -1,0 +1,113 @@
+// Package rpcinterface_8fb6d884238811d08c3500c04fda2795_4_1 is the descriptor for the W32Time RPC interface, abstract
+// syntax 8fb6d884-2388-11d0-8c35-00c04fda2795 version 4.1 ([MS-W32T]).
+//
+// This package holds only the interface-level descriptor (abstract syntax, transport
+// endpoints, opnums, opnum<->name maps, and the Win32 status-code table). The NDR
+// types live in windows/protocols/ms-w32t and the method stubs in the functions
+// subpackage; both depend on this package, never the reverse.
+package rpcinterface_8fb6d884238811d08c3500c04fda2795_4_1
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+)
+
+// PipeName is the IPC$-relative named pipe for the W32Time interface ([MS-W32T]
+// section 2.1). \W32TIME serves the unauthenticated RPC interface; the authenticated
+// interface is served over \W32TIME_ALT (RPC negotiates authentication on the client's
+// behalf, [MS-RPCE] sections 2.2.2.11 and 5.1.1). Both reach this same abstract syntax.
+const (
+	PipeName    = `\W32TIME`
+	PipeNameAlt = `\W32TIME_ALT`
+)
+
+// Opnums for the on-the-wire methods.
+const (
+	OpnumW32TimeSync                       uint16 = 0
+	OpnumW32TimeGetNetlogonServiceBits     uint16 = 1
+	OpnumW32TimeQueryProviderStatus        uint16 = 2
+	OpnumW32TimeQuerySource                uint16 = 3
+	OpnumW32TimeQueryProviderConfiguration uint16 = 4
+	OpnumW32TimeQueryConfiguration         uint16 = 5
+	OpnumW32TimeQueryStatus                uint16 = 6
+	OpnumW32TimeLog                        uint16 = 7
+)
+
+// Status codes returned by this interface. Every W32Time method returns a Win32 error
+// code as its RPC return value ([MS-W32T] section 3.2.4): 0 (ERROR_SUCCESS) on success,
+// otherwise one of the standard Win32 codes below ([MS-ERREF] section 2.2).
+const (
+	StatusSuccess           uint32 = 0x00000000 // ERROR_SUCCESS
+	ErrorFileNotFound       uint32 = 0x00000002 // ERROR_FILE_NOT_FOUND
+	ErrorAccessDenied       uint32 = 0x00000005 // ERROR_ACCESS_DENIED
+	ErrorNotEnoughMemory    uint32 = 0x00000008 // ERROR_NOT_ENOUGH_MEMORY
+	ErrorInvalidData        uint32 = 0x0000000D // ERROR_INVALID_DATA
+	ErrorNotSupported       uint32 = 0x00000032 // ERROR_NOT_SUPPORTED
+	ErrorInvalidParameter   uint32 = 0x00000057 // ERROR_INVALID_PARAMETER
+	ErrorInsufficientBuffer uint32 = 0x0000007A // ERROR_INSUFFICIENT_BUFFER
+	ErrorServiceNotActive   uint32 = 0x00000426 // ERROR_SERVICE_NOT_ACTIVE
+	ErrorTimeout            uint32 = 0x000005B4 // ERROR_TIMEOUT
+)
+
+// SyntaxID returns the W32Time abstract syntax identifier:
+// 8fb6d884-2388-11d0-8c35-00c04fda2795, version 4.1.
+func SyntaxID() syntax.SyntaxID {
+	return syntax.SyntaxID{
+		UUID:         guid.GUID{A: 0x8fb6d884, B: 0x2388, C: 0x11d0, D: 0x8c35, E: 0x00c04fda2795},
+		MajorVersion: 4,
+		MinorVersion: 1,
+	}
+}
+
+// StatusString returns a mnemonic for the documented status codes, otherwise the
+// hex value.
+func StatusString(status uint32) string {
+	switch status {
+	case StatusSuccess:
+		return "ERROR_SUCCESS"
+	case ErrorFileNotFound:
+		return "ERROR_FILE_NOT_FOUND"
+	case ErrorAccessDenied:
+		return "ERROR_ACCESS_DENIED"
+	case ErrorNotEnoughMemory:
+		return "ERROR_NOT_ENOUGH_MEMORY"
+	case ErrorInvalidData:
+		return "ERROR_INVALID_DATA"
+	case ErrorNotSupported:
+		return "ERROR_NOT_SUPPORTED"
+	case ErrorInvalidParameter:
+		return "ERROR_INVALID_PARAMETER"
+	case ErrorInsufficientBuffer:
+		return "ERROR_INSUFFICIENT_BUFFER"
+	case ErrorServiceNotActive:
+		return "ERROR_SERVICE_NOT_ACTIVE"
+	case ErrorTimeout:
+		return "ERROR_TIMEOUT"
+	default:
+		return fmt.Sprintf("0x%08x", status)
+	}
+}
+
+// OpnumToName maps each on-the-wire opnum to its method name; the single source of
+// truth.
+var OpnumToName = map[uint16]string{
+	OpnumW32TimeSync:                       "W32TimeSync",
+	OpnumW32TimeGetNetlogonServiceBits:     "W32TimeGetNetlogonServiceBits",
+	OpnumW32TimeQueryProviderStatus:        "W32TimeQueryProviderStatus",
+	OpnumW32TimeQuerySource:                "W32TimeQuerySource",
+	OpnumW32TimeQueryProviderConfiguration: "W32TimeQueryProviderConfiguration",
+	OpnumW32TimeQueryConfiguration:         "W32TimeQueryConfiguration",
+	OpnumW32TimeQueryStatus:                "W32TimeQueryStatus",
+	OpnumW32TimeLog:                        "W32TimeLog",
+}
+
+// NameToOpnum is the reverse of OpnumToName, built at init so the two never drift.
+var NameToOpnum = func() map[string]uint16 {
+	m := make(map[string]uint16, len(OpnumToName))
+	for op, name := range OpnumToName {
+		m[name] = op
+	}
+	return m
+}()

--- a/network/dcerpc/interfaces/8fb6d884-2388-11d0-8c35-00c04fda2795/4.1/interface_test.go
+++ b/network/dcerpc/interfaces/8fb6d884-2388-11d0-8c35-00c04fda2795/4.1/interface_test.go
@@ -1,0 +1,54 @@
+package rpcinterface_8fb6d884238811d08c3500c04fda2795_4_1
+
+import "testing"
+
+// TestSyntaxID pins the abstract syntax identifier for the W32Time interface
+// (8fb6d884-2388-11d0-8c35-00c04fda2795 v4.1, [MS-W32T]).
+func TestSyntaxID(t *testing.T) {
+	s := SyntaxID()
+	if got := s.UUID.ToFormatD(); got != "8fb6d884-2388-11d0-8c35-00c04fda2795" {
+		t.Errorf("UUID = %s, want 8fb6d884-2388-11d0-8c35-00c04fda2795", got)
+	}
+	if s.MajorVersion != 4 || s.MinorVersion != 1 {
+		t.Errorf("version = %d.%d, want 4.1", s.MajorVersion, s.MinorVersion)
+	}
+}
+
+// TestOpnumNameRoundTrip verifies OpnumToName and NameToOpnum are exact inverses and
+// cover every opnum 0..7.
+func TestOpnumNameRoundTrip(t *testing.T) {
+	if len(OpnumToName) != 8 {
+		t.Fatalf("OpnumToName has %d entries, want 8", len(OpnumToName))
+	}
+	if len(NameToOpnum) != len(OpnumToName) {
+		t.Fatalf("NameToOpnum has %d entries, OpnumToName has %d", len(NameToOpnum), len(OpnumToName))
+	}
+	for op, n := range OpnumToName {
+		if NameToOpnum[n] != op {
+			t.Errorf("round trip failed: opnum %d -> %q -> %d", op, n, NameToOpnum[n])
+		}
+	}
+}
+
+// TestStatusString checks a documented mnemonic, the success mnemonic, and the hex fallback.
+func TestStatusString(t *testing.T) {
+	if got := StatusString(StatusSuccess); got != "ERROR_SUCCESS" {
+		t.Errorf("StatusString(StatusSuccess) = %q, want ERROR_SUCCESS", got)
+	}
+	if got := StatusString(ErrorAccessDenied); got != "ERROR_ACCESS_DENIED" {
+		t.Errorf("StatusString(ErrorAccessDenied) = %q, want ERROR_ACCESS_DENIED", got)
+	}
+	if got := StatusString(0xDEADBEEF); got != "0xdeadbeef" {
+		t.Errorf("StatusString(unknown) = %q, want 0xdeadbeef", got)
+	}
+}
+
+// TestPipeName pins the [MS-W32T] section 2.1 well-known endpoints.
+func TestPipeName(t *testing.T) {
+	if PipeName != `\W32TIME` {
+		t.Errorf("PipeName = %q, want %q", PipeName, `\W32TIME`)
+	}
+	if PipeNameAlt != `\W32TIME_ALT` {
+		t.Errorf("PipeNameAlt = %q, want %q", PipeNameAlt, `\W32TIME_ALT`)
+	}
+}

--- a/windows/protocols/ms-w32t/W32TIME_CONFIGURATION_ADVANCED.go
+++ b/windows/protocols/ms-w32t/W32TIME_CONFIGURATION_ADVANCED.go
@@ -1,0 +1,26 @@
+package msw32t
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// W32TIME_CONFIGURATION_ADVANCED ([MS-W32T]).
+type W32TIME_CONFIGURATION_ADVANCED struct {
+	UlSize                     ndr.DWORD
+	UlFrequencyCorrectRate     ndr.DWORD
+	UlPollAdjustFactor         ndr.DWORD
+	UlLargePhaseOffset         ndr.DWORD
+	UlSpikeWatchPeriod         ndr.DWORD
+	UlLocalClockDispersion     ndr.DWORD
+	UlHoldPeriod               ndr.DWORD
+	UlPhaseCorrectRate         ndr.DWORD
+	UlUpdateInterval           ndr.DWORD
+	UlFrequencyCorrectRateFlag ndr.DWORD
+	UlPollAdjustFactorFlag     ndr.DWORD
+	UlLargePhaseOffsetFlag     ndr.DWORD
+	UlSpikeWatchPeriodFlag     ndr.DWORD
+	UlLocalClockDispersionFlag ndr.DWORD
+	UlHoldPeriodFlag           ndr.DWORD
+	UlPhaseCorrectRateFlag     ndr.DWORD
+	UlUpdateIntervalFlag       ndr.DWORD
+}

--- a/windows/protocols/ms-w32t/W32TIME_CONFIGURATION_BASIC.go
+++ b/windows/protocols/ms-w32t/W32TIME_CONFIGURATION_BASIC.go
@@ -1,0 +1,26 @@
+package msw32t
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// W32TIME_CONFIGURATION_BASIC ([MS-W32T]).
+type W32TIME_CONFIGURATION_BASIC struct {
+	UlSize                      ndr.DWORD
+	UlEventLogFlags             ndr.DWORD
+	UlAnnounceFlags             ndr.DWORD
+	UlTimeJumpAuditOffset       ndr.DWORD
+	UlMinPollInterval           ndr.DWORD
+	UlMaxPollInterval           ndr.DWORD
+	UlMaxNegPhaseCorrection     ndr.DWORD
+	UlMaxPosPhaseCorrection     ndr.DWORD
+	UlMaxAllowedPhaseOffset     ndr.DWORD
+	UlEventLogFlagsFlag         ndr.DWORD
+	UlAnnounceFlagsFlag         ndr.DWORD
+	UlTimeJumpAuditOffsetFlag   ndr.DWORD
+	UlMinPollIntervalFlag       ndr.DWORD
+	UlMaxPollIntervalFlag       ndr.DWORD
+	UlMaxNegPhaseCorrectionFlag ndr.DWORD
+	UlMaxPosPhaseCorrectionFlag ndr.DWORD
+	UlMaxAllowedPhaseOffsetFlag ndr.DWORD
+}

--- a/windows/protocols/ms-w32t/W32TIME_CONFIGURATION_DEFAULT.go
+++ b/windows/protocols/ms-w32t/W32TIME_CONFIGURATION_DEFAULT.go
@@ -1,0 +1,18 @@
+package msw32t
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// W32TIME_CONFIGURATION_DEFAULT ([MS-W32T]).
+type W32TIME_CONFIGURATION_DEFAULT struct {
+	UlSize               ndr.DWORD
+	WszFileLogName       *ndr.WSTR `ndr:"unique"`
+	WszFileLogEntries    *ndr.WSTR `ndr:"unique"`
+	UlFileLogSize        ndr.DWORD
+	UlFileLogFlags       ndr.DWORD
+	UlFileLogNameFlag    ndr.DWORD
+	UlFileLogEntriesFlag ndr.DWORD
+	UlFileLogSizeFlag    ndr.DWORD
+	UlFileLogFlagsFlag   ndr.DWORD
+}

--- a/windows/protocols/ms-w32t/W32TIME_CONFIGURATION_INFO.go
+++ b/windows/protocols/ms-w32t/W32TIME_CONFIGURATION_INFO.go
@@ -1,0 +1,17 @@
+package msw32t
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// W32TIME_CONFIGURATION_INFO ([MS-W32T]).
+type W32TIME_CONFIGURATION_INFO struct {
+	UlSize          ndr.DWORD
+	BasicConfig     W32TIME_CONFIGURATION_BASIC
+	AdvancedConfig  W32TIME_CONFIGURATION_ADVANCED
+	DefaultConfig   W32TIME_CONFIGURATION_DEFAULT
+	CProviderConfig ndr.DWORD
+	PProviderConfig []*W32TIME_CONFIGURATION_PROVIDER `ndr:"elem=unique,unique,size_is=CProviderConfig"`
+	CEntries        ndr.DWORD
+	PEntries        []W32TIME_ENTRY `ndr:"unique,size_is=CEntries"`
+}

--- a/windows/protocols/ms-w32t/W32TIME_CONFIGURATION_PROVIDER.go
+++ b/windows/protocols/ms-w32t/W32TIME_CONFIGURATION_PROVIDER.go
@@ -1,0 +1,19 @@
+package msw32t
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// W32TIME_CONFIGURATION_PROVIDER ([MS-W32T]).
+type W32TIME_CONFIGURATION_PROVIDER struct {
+	UlSize              ndr.DWORD
+	UlInputProvider     ndr.DWORD
+	UlEnabled           ndr.DWORD
+	WszDllName          *ndr.WSTR `ndr:"unique"`
+	WszProviderName     *ndr.WSTR `ndr:"unique"`
+	UlDllNameFlag       ndr.DWORD
+	UlProviderNameFlag  ndr.DWORD
+	UlInputProviderFlag ndr.DWORD
+	UlEnabledFlag       ndr.DWORD
+	PProviderConfig     *W32TIME_PROVIDER_CONFIG `ndr:"unique"`
+}

--- a/windows/protocols/ms-w32t/W32TIME_ENTRY.go
+++ b/windows/protocols/ms-w32t/W32TIME_ENTRY.go
@@ -1,0 +1,13 @@
+package msw32t
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// W32TIME_ENTRY ([MS-W32T]).
+type W32TIME_ENTRY struct {
+	UlSize   ndr.DWORD
+	WszName  *ndr.WSTR `ndr:"unique"`
+	WszValue *ndr.WSTR `ndr:"unique"`
+	WszHelp  *ndr.WSTR `ndr:"unique"`
+}

--- a/windows/protocols/ms-w32t/W32TIME_HARDWARE_PROVIDER_DATA.go
+++ b/windows/protocols/ms-w32t/W32TIME_HARDWARE_PROVIDER_DATA.go
@@ -1,0 +1,13 @@
+package msw32t
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// W32TIME_HARDWARE_PROVIDER_DATA ([MS-W32T]).
+type W32TIME_HARDWARE_PROVIDER_DATA struct {
+	UlSize                 ndr.DWORD
+	UlError                ndr.DWORD
+	UlErrorMsgId           ndr.DWORD
+	WszReferenceIdentifier *ndr.WSTR `ndr:"unique"`
+}

--- a/windows/protocols/ms-w32t/W32TIME_NTPCLIENT_PROVIDER_CONFIG_DATA.go
+++ b/windows/protocols/ms-w32t/W32TIME_NTPCLIENT_PROVIDER_CONFIG_DATA.go
@@ -1,0 +1,32 @@
+package msw32t
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// W32TIME_NTPCLIENT_PROVIDER_CONFIG_DATA ([MS-W32T]).
+type W32TIME_NTPCLIENT_PROVIDER_CONFIG_DATA struct {
+	UlSize                                 ndr.DWORD
+	UlAllowNonstandardModeCombinations     ndr.DWORD
+	UlCrossSiteSyncFlags                   ndr.DWORD
+	UlResolvePeerBackoffMinutes            ndr.DWORD
+	UlResolvePeerBackoffMaxTimes           ndr.DWORD
+	UlCompatibilityFlags                   ndr.DWORD
+	UlEventLogFlags                        ndr.DWORD
+	UlLargeSampleSkew                      ndr.DWORD
+	UlSpecialPollInterval                  ndr.DWORD
+	WszType                                *ndr.WSTR `ndr:"unique"`
+	WszNtpServer                           *ndr.WSTR `ndr:"unique"`
+	UlAllowNonstandardModeCombinationsFlag ndr.DWORD
+	UlCrossSiteSyncFlagsFlag               ndr.DWORD
+	UlResolvePeerBackoffMinutesFlag        ndr.DWORD
+	UlResolvePeerBackoffMaxTimesFlag       ndr.DWORD
+	UlCompatibilityFlagsFlag               ndr.DWORD
+	UlEventLogFlagsFlag                    ndr.DWORD
+	UlLargeSampleSkewFlag                  ndr.DWORD
+	UlSpecialPollIntervalFlag              ndr.DWORD
+	UlTypeFlag                             ndr.DWORD
+	UlNtpServerFlag                        ndr.DWORD
+	CEntries                               ndr.DWORD
+	PEntries                               []W32TIME_ENTRY `ndr:"unique,size_is=CEntries"`
+}

--- a/windows/protocols/ms-w32t/W32TIME_NTPSERVER_PROVIDER_CONFIG_DATA.go
+++ b/windows/protocols/ms-w32t/W32TIME_NTPSERVER_PROVIDER_CONFIG_DATA.go
@@ -1,0 +1,16 @@
+package msw32t
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// W32TIME_NTPSERVER_PROVIDER_CONFIG_DATA ([MS-W32T]).
+type W32TIME_NTPSERVER_PROVIDER_CONFIG_DATA struct {
+	UlSize                                 ndr.DWORD
+	UlAllowNonstandardModeCombinations     ndr.DWORD
+	UlAllowNonstandardModeCombinationsFlag ndr.DWORD
+	UlEventLogFlags                        ndr.DWORD
+	UlEventLogFlagsFlag                    ndr.DWORD
+	CEntries                               ndr.DWORD
+	PEntries                               []W32TIME_ENTRY `ndr:"unique,size_is=CEntries"`
+}

--- a/windows/protocols/ms-w32t/W32TIME_NTP_PEER_INFO.go
+++ b/windows/protocols/ms-w32t/W32TIME_NTP_PEER_INFO.go
@@ -1,0 +1,23 @@
+package msw32t
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// W32TIME_NTP_PEER_INFO ([MS-W32T]).
+type W32TIME_NTP_PEER_INFO struct {
+	UlSize                ndr.DWORD
+	UlResolveAttempts     ndr.DWORD
+	U64TimeRemaining      uint64
+	U64LastSuccessfulSync uint64
+	UlLastSyncError       ndr.DWORD
+	UlLastSyncErrorMsgId  ndr.DWORD
+	UlValidDataCounter    ndr.DWORD
+	UlAuthTypeMsgId       ndr.DWORD
+	WszUniqueName         *ndr.WSTR `ndr:"unique"`
+	UlMode                uint8
+	UlStratum             uint8
+	UlReachability        uint8
+	UlPeerPollInterval    uint8
+	UlHostPollInterval    uint8
+}

--- a/windows/protocols/ms-w32t/W32TIME_NTP_PROVIDER_DATA.go
+++ b/windows/protocols/ms-w32t/W32TIME_NTP_PROVIDER_DATA.go
@@ -1,0 +1,14 @@
+package msw32t
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// W32TIME_NTP_PROVIDER_DATA ([MS-W32T]).
+type W32TIME_NTP_PROVIDER_DATA struct {
+	UlSize       ndr.DWORD
+	UlError      ndr.DWORD
+	UlErrorMsgId ndr.DWORD
+	CPeerInfo    ndr.DWORD
+	PPeerInfo    []W32TIME_NTP_PEER_INFO `ndr:"unique,size_is=CPeerInfo"`
+}

--- a/windows/protocols/ms-w32t/W32TIME_PROVIDER_CONFIG.go
+++ b/windows/protocols/ms-w32t/W32TIME_PROVIDER_CONFIG.go
@@ -1,0 +1,12 @@
+package msw32t
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// W32TIME_PROVIDER_CONFIG ([MS-W32T]).
+type W32TIME_PROVIDER_CONFIG struct {
+	UlSize              ndr.DWORD
+	UlProviderType      ndr.DWORD
+	PProviderConfigData *W32TIME_PROVIDER_CONFIG_DATA `ndr:"unique"`
+}

--- a/windows/protocols/ms-w32t/W32TIME_PROVIDER_CONFIG_DATA.go
+++ b/windows/protocols/ms-w32t/W32TIME_PROVIDER_CONFIG_DATA.go
@@ -1,0 +1,16 @@
+package msw32t
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// W32TIME_PROVIDER_CONFIG_DATA is the non-encapsulated discriminated union
+// ([MS-W32T] 2.2.10) selected by W32TIME_PROVIDER_CONFIG.ulProviderType. The
+// discriminant (switch_type(unsigned long) -> 4-byte DWORD) is transmitted inline
+// ahead of the selected arm ([C706] 14.3.8). Both arms are [unique] pointers in the
+// IDL (PW32TIME_NTPCLIENT_PROVIDER_CONFIG_DATA / PW32TIME_NTPSERVER_PROVIDER_CONFIG_DATA).
+type W32TIME_PROVIDER_CONFIG_DATA struct {
+	Tag                          ndr.DWORD                               `ndr:"switch"`
+	PNtpClientProviderConfigData *W32TIME_NTPCLIENT_PROVIDER_CONFIG_DATA `ndr:"case=0,unique"`
+	PNtpServerProviderConfigData *W32TIME_NTPSERVER_PROVIDER_CONFIG_DATA `ndr:"case=1,unique"`
+}

--- a/windows/protocols/ms-w32t/W32TIME_PROVIDER_DATA.go
+++ b/windows/protocols/ms-w32t/W32TIME_PROVIDER_DATA.go
@@ -1,0 +1,15 @@
+package msw32t
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// W32TIME_PROVIDER_DATA is the non-encapsulated discriminated union ([MS-W32T] 2.2.6)
+// selected by W32TIME_PROVIDER_INFO.ulProviderType. The discriminant
+// (switch_type(unsigned long) -> 4-byte DWORD) is transmitted inline ahead of the
+// selected arm ([C706] 14.3.8). Both arms are [unique] pointers.
+type W32TIME_PROVIDER_DATA struct {
+	Tag                   ndr.DWORD                       `ndr:"switch"`
+	PNtpProviderData      *W32TIME_NTP_PROVIDER_DATA      `ndr:"case=0,unique"`
+	PHardwareProviderData *W32TIME_HARDWARE_PROVIDER_DATA `ndr:"case=1,unique"`
+}

--- a/windows/protocols/ms-w32t/W32TIME_PROVIDER_INFO.go
+++ b/windows/protocols/ms-w32t/W32TIME_PROVIDER_INFO.go
@@ -1,0 +1,11 @@
+package msw32t
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// W32TIME_PROVIDER_INFO ([MS-W32T]).
+type W32TIME_PROVIDER_INFO struct {
+	UlProviderType ndr.DWORD
+	ProviderData   W32TIME_PROVIDER_DATA
+}

--- a/windows/protocols/ms-w32t/W32TIME_STATUS_INFO.go
+++ b/windows/protocols/ms-w32t/W32TIME_STATUS_INFO.go
@@ -1,0 +1,28 @@
+package msw32t
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// W32TIME_STATUS_INFO ([MS-W32T]).
+type W32TIME_STATUS_INFO struct {
+	UlSize                ndr.DWORD
+	ELeapIndicator        ndr.DWORD
+	NStratum              ndr.DWORD
+	NPollInterval         int32
+	RefidSource           ndr.DWORD
+	QwLastSyncTicks       uint64
+	ToRootDelay           int64
+	TpRootDispersion      uint64
+	NClockPrecision       int32
+	WszSource             *ndr.WSTR `ndr:"unique"`
+	ToSysPhaseOffset      int64
+	UlLcState             ndr.DWORD
+	UlTSFlags             ndr.DWORD
+	UlClockRate           ndr.DWORD
+	UlNetlogonServiceBits ndr.DWORD
+	ELastSyncResult       ndr.DWORD
+	TpTimeLastGoodSync    uint64
+	CEntries              ndr.DWORD
+	PEntries              []W32TIME_ENTRY `ndr:"unique,size_is=CEntries"`
+}

--- a/windows/protocols/ms-w32t/structures_test.go
+++ b/windows/protocols/ms-w32t/structures_test.go
@@ -1,0 +1,182 @@
+package msw32t
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+// wstr returns a pointer to an ndr.WSTR carrying s, for building [unique] string fields.
+func wstr(s string) *ndr.WSTR {
+	w := ndr.WSTR(s)
+	return &w
+}
+
+// roundTrip marshals in, unmarshals into a fresh value of the same type, and asserts deep
+// equality — the wire-shape acceptance check for a structure's NDR tags.
+func roundTrip[T any](t *testing.T, name string, in T) {
+	t.Helper()
+	raw, err := ndr.Marshal(&in)
+	if err != nil {
+		t.Fatalf("%s: Marshal: %v", name, err)
+	}
+	var out T
+	if err := ndr.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("%s: Unmarshal: %v", name, err)
+	}
+	if !reflect.DeepEqual(in, out) {
+		t.Errorf("%s: round trip mismatch:\n in:  %+v\n out: %+v", name, in, out)
+	}
+}
+
+// TestW32TIME_ENTRY_RoundTrip covers a struct of three [unique] wide-string pointers, with
+// both the populated and the all-nil cases.
+func TestW32TIME_ENTRY_RoundTrip(t *testing.T) {
+	roundTrip(t, "W32TIME_ENTRY", W32TIME_ENTRY{
+		UlSize:   40,
+		WszName:  wstr("NtpServer"),
+		WszValue: wstr("time.windows.com,0x9"),
+		WszHelp:  wstr("List of peers"),
+	})
+	roundTrip(t, "W32TIME_ENTRY/nil-strings", W32TIME_ENTRY{UlSize: 8})
+}
+
+// TestW32TIME_NTP_PEER_INFO_RoundTrip covers a struct interleaving DWORDs, 64-bit fields, a
+// [unique] string, and a run of unsigned char fields.
+func TestW32TIME_NTP_PEER_INFO_RoundTrip(t *testing.T) {
+	roundTrip(t, "W32TIME_NTP_PEER_INFO", W32TIME_NTP_PEER_INFO{
+		UlSize:                72,
+		UlResolveAttempts:     3,
+		U64TimeRemaining:      0x0000000100000000,
+		U64LastSuccessfulSync: 0x01d9a1b2c3d4e5f6,
+		UlLastSyncError:       0,
+		UlLastSyncErrorMsgId:  0,
+		UlValidDataCounter:    12,
+		UlAuthTypeMsgId:       1,
+		WszUniqueName:         wstr("time.windows.com"),
+		UlMode:                3,
+		UlStratum:             2,
+		UlReachability:        0xFF,
+		UlPeerPollInterval:    10,
+		UlHostPollInterval:    6,
+	})
+}
+
+// TestW32TIME_NTP_PROVIDER_DATA_RoundTrip covers a [unique] size_is array of pointer-free
+// structs, plus the empty-array case.
+func TestW32TIME_NTP_PROVIDER_DATA_RoundTrip(t *testing.T) {
+	roundTrip(t, "W32TIME_NTP_PROVIDER_DATA", W32TIME_NTP_PROVIDER_DATA{
+		UlSize:       64,
+		UlError:      0,
+		UlErrorMsgId: 0,
+		CPeerInfo:    2,
+		PPeerInfo: []W32TIME_NTP_PEER_INFO{
+			{UlSize: 72, WszUniqueName: wstr("peer-a"), UlStratum: 2},
+			{UlSize: 72, WszUniqueName: wstr("peer-b"), UlStratum: 3},
+		},
+	})
+	roundTrip(t, "W32TIME_NTP_PROVIDER_DATA/empty", W32TIME_NTP_PROVIDER_DATA{UlSize: 16})
+}
+
+// TestW32TIME_PROVIDER_INFO_RoundTrip covers the switch_is(ulProviderType) union carried by
+// value, with each pointer arm selected in turn.
+func TestW32TIME_PROVIDER_INFO_RoundTrip(t *testing.T) {
+	roundTrip(t, "W32TIME_PROVIDER_INFO/ntp", W32TIME_PROVIDER_INFO{
+		UlProviderType: 0,
+		ProviderData: W32TIME_PROVIDER_DATA{
+			Tag: 0,
+			PNtpProviderData: &W32TIME_NTP_PROVIDER_DATA{
+				UlSize:    64,
+				CPeerInfo: 1,
+				PPeerInfo: []W32TIME_NTP_PEER_INFO{{UlSize: 72, WszUniqueName: wstr("peer")}},
+			},
+		},
+	})
+	roundTrip(t, "W32TIME_PROVIDER_INFO/hardware", W32TIME_PROVIDER_INFO{
+		UlProviderType: 1,
+		ProviderData: W32TIME_PROVIDER_DATA{
+			Tag: 1,
+			PHardwareProviderData: &W32TIME_HARDWARE_PROVIDER_DATA{
+				UlSize:                 32,
+				WszReferenceIdentifier: wstr("GPS"),
+			},
+		},
+	})
+}
+
+// TestW32TIME_PROVIDER_CONFIG_RoundTrip covers a [unique] pointer to the switch_is union
+// whose arms are themselves [unique] pointers, for both cases.
+func TestW32TIME_PROVIDER_CONFIG_RoundTrip(t *testing.T) {
+	roundTrip(t, "W32TIME_PROVIDER_CONFIG/client", W32TIME_PROVIDER_CONFIG{
+		UlSize:         48,
+		UlProviderType: 0,
+		PProviderConfigData: &W32TIME_PROVIDER_CONFIG_DATA{
+			Tag: 0,
+			PNtpClientProviderConfigData: &W32TIME_NTPCLIENT_PROVIDER_CONFIG_DATA{
+				UlSize:                48,
+				UlSpecialPollInterval: 3600,
+				WszType:               wstr("NTP"),
+				WszNtpServer:          wstr("time.windows.com,0x9"),
+				CEntries:              1,
+				PEntries:              []W32TIME_ENTRY{{UlSize: 16, WszName: wstr("k")}},
+			},
+		},
+	})
+	roundTrip(t, "W32TIME_PROVIDER_CONFIG/server", W32TIME_PROVIDER_CONFIG{
+		UlSize:         48,
+		UlProviderType: 1,
+		PProviderConfigData: &W32TIME_PROVIDER_CONFIG_DATA{
+			Tag: 1,
+			PNtpServerProviderConfigData: &W32TIME_NTPSERVER_PROVIDER_CONFIG_DATA{
+				UlSize:          24,
+				UlEventLogFlags: 2,
+				CEntries:        0,
+			},
+		},
+	})
+	roundTrip(t, "W32TIME_PROVIDER_CONFIG/nil", W32TIME_PROVIDER_CONFIG{UlSize: 12})
+}
+
+// TestW32TIME_CONFIGURATION_INFO_RoundTrip covers the top-level configuration blob: three
+// nested value structs, a size_is array of [unique] pointers, and a size_is array of structs.
+func TestW32TIME_CONFIGURATION_INFO_RoundTrip(t *testing.T) {
+	roundTrip(t, "W32TIME_CONFIGURATION_INFO", W32TIME_CONFIGURATION_INFO{
+		UlSize:          200,
+		BasicConfig:     W32TIME_CONFIGURATION_BASIC{UlSize: 68, UlAnnounceFlags: 0x0A, UlMinPollInterval: 6},
+		AdvancedConfig:  W32TIME_CONFIGURATION_ADVANCED{UlSize: 68, UlPollAdjustFactor: 5},
+		DefaultConfig:   W32TIME_CONFIGURATION_DEFAULT{UlSize: 36, WszFileLogName: wstr("C:\\w32tm.log")},
+		CProviderConfig: 2,
+		PProviderConfig: []*W32TIME_CONFIGURATION_PROVIDER{
+			{UlSize: 40, UlEnabled: 1, WszProviderName: wstr("NtpClient")},
+			{UlSize: 40, UlEnabled: 1, WszProviderName: wstr("NtpServer")},
+		},
+		CEntries: 1,
+		PEntries: []W32TIME_ENTRY{{UlSize: 16, WszName: wstr("Type"), WszValue: wstr("NTP")}},
+	})
+	roundTrip(t, "W32TIME_CONFIGURATION_INFO/empty", W32TIME_CONFIGURATION_INFO{UlSize: 40})
+}
+
+// TestW32TIME_STATUS_INFO_RoundTrip covers the status blob mixing signed/unsigned 64-bit
+// fields, a [unique] string, and a size_is array of entries.
+func TestW32TIME_STATUS_INFO_RoundTrip(t *testing.T) {
+	roundTrip(t, "W32TIME_STATUS_INFO", W32TIME_STATUS_INFO{
+		UlSize:             128,
+		ELeapIndicator:     0,
+		NStratum:           3,
+		NPollInterval:      -6,
+		RefidSource:        0x4C4F434C,
+		QwLastSyncTicks:    0x01d9a1b2c3d4e5f6,
+		ToRootDelay:        -12345,
+		TpRootDispersion:   6789,
+		NClockPrecision:    -20,
+		WszSource:          wstr("time.windows.com"),
+		ToSysPhaseOffset:   -42,
+		UlLcState:          2,
+		ELastSyncResult:    0,
+		TpTimeLastGoodSync: 0x01d9a1b200000000,
+		CEntries:           1,
+		PEntries:           []W32TIME_ENTRY{{UlSize: 16, WszName: wstr("LastSync")}},
+	})
+	roundTrip(t, "W32TIME_STATUS_INFO/nil-source", W32TIME_STATUS_INFO{UlSize: 64, NStratum: 1})
+}


### PR DESCRIPTION
## Summary

Implements the **W32Time Remote Protocol ([MS-W32T])** — the single classic DCE/RPC `W32Time` interface — in the UUID-versioned split layout. The descriptor and per-opnum function stubs live under `network/dcerpc/interfaces/8fb6d884-2388-11d0-8c35-00c04fda2795/4.1/`; every NDR wire structure lives under `windows/protocols/ms-w32t` (package `msw32t`).

Closes #848.

## Interface (8 on-the-wire opnums)

| Interface | UUID | Version | Named pipe |
|---|---|---|---|
| W32Time | `8fb6d884-2388-11d0-8c35-00c04fda2795` | 4.1 | `\W32TIME` (unauth) / `\W32TIME_ALT` (auth) |

| Opnum | Method |
|---|---|
| 0 | `W32TimeSync` |
| 1 | `W32TimeGetNetlogonServiceBits` |
| 2 | `W32TimeQueryProviderStatus` |
| 3 | `W32TimeQuerySource` |
| 4 | `W32TimeQueryProviderConfiguration` |
| 5 | `W32TimeQueryConfiguration` |
| 6 | `W32TimeQueryStatus` |
| 7 | `W32TimeLog` |

## What's included

- **Descriptor** — `SyntaxID` (UUID/version 4.1), the two well-known endpoints (`PipeName` = `\W32TIME` unauthenticated, `PipeNameAlt` = `\W32TIME_ALT` authenticated, per [MS-W32T] §2.1), opnum⇄name maps, and a Win32 status table + `StatusString` ([MS-ERREF]) since every method returns an `unsigned long` Win32 error.
- **Structures** — all 16 IDL typedefs: `W32TIME_NTP_PEER_INFO`, `W32TIME_NTP_PROVIDER_DATA`, `W32TIME_HARDWARE_PROVIDER_DATA`, the `W32TIME_PROVIDER_DATA` / `W32TIME_PROVIDER_CONFIG_DATA` non-encapsulated `switch_is(ulProviderType)` unions, `W32TIME_PROVIDER_INFO`/`_CONFIG`, `W32TIME_ENTRY`, the NTP client/server config-data blobs, `W32TIME_CONFIGURATION_{BASIC,ADVANCED,DEFAULT,PROVIDER,INFO}`, and `W32TIME_STATUS_INFO`.
- **Tests** — descriptor tests (SyntaxID / opnum-map round-trip / StatusString / both pipe names) and NDR round-trip tests for both unions (each pointer arm selected), the `size_is` arrays of structs, the array of `[unique]` pointers, the nested configuration blob, and the mixed signed/unsigned 64-bit status blob.

## Modeling notes

- Both provider unions carry `[unique]` pointer arms with a 4-byte `switch_type(unsigned long)` discriminant, transmitted inline per the codec's non-encapsulated-union convention ([C706] §14.3.8).
- `W32TimeQuerySource`'s `[out, string] wchar_t**` and the `[out, ref] PTYPE*` returns (opnums 2/4/5/6) are modeled as `*T ndr:"unique"` (outer `[ref]` out-slot, inner `[unique]` referent). `[in, string] wchar_t*` provider names are top-level `[ref]` strings (inline `ndr.WSTR`).

## Verification

`gofmt -l` clean; `go build`, `go vet`, `go test` all pass for both trees; `GOARCH=386` / `GOARCH=arm64` and `-tags integration` cross-compile clean.

## Known limitations (unverified against a live server)

- Wire-level behavior is not live-validated (no Windows Time server available). The non-encapsulated union discriminant layout and the double-pointer response shapes follow the codec's documented, live-validated conventions and round-trip in Go, but the exact bytes against a real `w32time` service are not observed here.
