### PR TITLE
Move endpoint mapper (ept) NDR structures to shared ms-rpce package (Fixes #854)

### DIFF
--- a/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/functions/02_EptLookup.go
+++ b/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/functions/02_EptLookup.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 
 	epm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0"
-	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/structures"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 	"github.com/TheManticoreProject/Manticore/windows/guid"
+	msrpce "github.com/TheManticoreProject/Manticore/windows/protocols/ms-rpce"
 )
 
 // eptLookupRequest carries the [in] parameters of ept_lookup (opnum 2). The binding
@@ -16,10 +16,10 @@ import (
 // MaxEnts caps the batch ([MS-RPCE] range(0,500)).
 type eptLookupRequest struct {
 	InquiryType ndr.DWORD
-	Object      *structures.EptUUID `ndr:"ptr"`
-	Ifid        *structures.RpcIfID `ndr:"ptr"`
+	Object      *msrpce.EptUUID `ndr:"ptr"`
+	Ifid        *msrpce.RpcIfID `ndr:"ptr"`
 	VersOption  ndr.DWORD
-	EntryHandle structures.ContextHandle
+	EntryHandle msrpce.ContextHandle
 	MaxEnts     ndr.DWORD
 }
 
@@ -39,9 +39,9 @@ func (*eptLookupRequest) Opnum() uint16 { return epm.OpnumEptLookup }
 // the offset/actual_count words. (ept_map's ITowers is "ptr,..." because its element type
 // twr_p_t is a pointer; ept_entry_t is not, so entries[] is not pointer-prefixed.)
 type eptLookupResponse struct {
-	EntryHandle structures.ContextHandle
+	EntryHandle msrpce.ContextHandle
 	NumEnts     ndr.DWORD
-	Entries     []structures.EptEntry `ndr:"varying,inline"`
+	Entries     []msrpce.EptEntry `ndr:"varying,inline"`
 	Status      ndr.DWORD
 }
 
@@ -53,7 +53,7 @@ type eptLookupResponse struct {
 // of entries, the advanced entry handle, and the raw [out] status (the caller decides how
 // to treat ept_s_not_registered); err is non-nil only for transport/decoding failures.
 // Lookup wraps this with the paging loop for the common "enumerate everything" case.
-func EptLookup(rpc ndr.Invoker, inquiryType uint32, object *guid.GUID, ifid *structures.RpcIfID, versOption uint32, entryHandle structures.ContextHandle, maxEnts uint32) (entries []structures.EptEntry, next structures.ContextHandle, status uint32, err error) {
+func EptLookup(rpc ndr.Invoker, inquiryType uint32, object *guid.GUID, ifid *msrpce.RpcIfID, versOption uint32, entryHandle msrpce.ContextHandle, maxEnts uint32) (entries []msrpce.EptEntry, next msrpce.ContextHandle, status uint32, err error) {
 	req := &eptLookupRequest{
 		InquiryType: ndr.DWORD(inquiryType),
 		Ifid:        ifid,
@@ -62,13 +62,13 @@ func EptLookup(rpc ndr.Invoker, inquiryType uint32, object *guid.GUID, ifid *str
 		MaxEnts:     ndr.DWORD(maxEnts),
 	}
 	if object != nil {
-		u := structures.NewEptUUID(*object)
+		u := msrpce.NewEptUUID(*object)
 		req.Object = &u
 	}
 
 	var resp eptLookupResponse
 	if err = rpc.Invoke(req, &resp); err != nil {
-		return nil, structures.ContextHandle{}, 0, fmt.Errorf("ept_lookup: %w", err)
+		return nil, msrpce.ContextHandle{}, 0, fmt.Errorf("ept_lookup: %w", err)
 	}
 
 	// num_ents is the authoritative count; clamp to the decoded array as a guard.
@@ -82,25 +82,25 @@ func EptLookup(rpc ndr.Invoker, inquiryType uint32, object *guid.GUID, ifid *str
 // eptLookupHandleFreeRequest carries the [in, out] context handle of
 // ept_lookup_handle_free (opnum 1).
 type eptLookupHandleFreeRequest struct {
-	EntryHandle structures.ContextHandle
+	EntryHandle msrpce.ContextHandle
 }
 
 func (*eptLookupHandleFreeRequest) Opnum() uint16 { return epm.OpnumEptLookupHandleFree }
 
 // eptLookupHandleFreeResponse carries the [out] (nulled) handle and status.
 type eptLookupHandleFreeResponse struct {
-	EntryHandle structures.ContextHandle
+	EntryHandle msrpce.ContextHandle
 	Status      ndr.DWORD
 }
 
 // EptLookupHandleFree calls ept_lookup_handle_free (opnum 1), releasing a lookup context
 // handle obtained from EptLookup. A full enumeration via Lookup nulls the handle on
 // completion and needs no explicit free; this is for abandoning a partial walk early.
-func EptLookupHandleFree(rpc ndr.Invoker, handle structures.ContextHandle) (structures.ContextHandle, error) {
+func EptLookupHandleFree(rpc ndr.Invoker, handle msrpce.ContextHandle) (msrpce.ContextHandle, error) {
 	req := &eptLookupHandleFreeRequest{EntryHandle: handle}
 	var resp eptLookupHandleFreeResponse
 	if err := rpc.Invoke(req, &resp); err != nil {
-		return structures.ContextHandle{}, fmt.Errorf("ept_lookup_handle_free: %w", err)
+		return msrpce.ContextHandle{}, fmt.Errorf("ept_lookup_handle_free: %w", err)
 	}
 	if uint32(resp.Status) != epm.EptStatusSuccess {
 		return resp.EntryHandle, fmt.Errorf("ept_lookup_handle_free failed: %s", epm.StatusString(uint32(resp.Status)))
@@ -114,10 +114,10 @@ func EptLookupHandleFree(rpc ndr.Invoker, handle structures.ContextHandle) (stru
 // reports ept_s_not_registered (no further matches) — both a normal end of enumeration.
 // Each entry's binding is available via EptEntry.DecodeTower / Tower.Binding. For finer
 // control (a filter, a custom batch size, or one page at a time) call EptLookup directly.
-func Lookup(rpc ndr.Invoker) ([]structures.EptEntry, error) {
+func Lookup(rpc ndr.Invoker) ([]msrpce.EptEntry, error) {
 	var (
-		entries []structures.EptEntry
-		handle  structures.ContextHandle
+		entries []msrpce.EptEntry
+		handle  msrpce.ContextHandle
 	)
 	for {
 		batch, next, status, err := EptLookup(rpc, epm.EptInquiryAllElts, nil, nil, epm.EptVersAll, handle, DefaultMaxEnts)

--- a/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/functions/03_EptMap.go
+++ b/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/functions/03_EptMap.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 
 	epm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0"
-	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/structures"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 	"github.com/TheManticoreProject/Manticore/windows/guid"
+	msrpce "github.com/TheManticoreProject/Manticore/windows/protocols/ms-rpce"
 )
 
 // eptMapRequest carries the [in] parameters of ept_map. The explicit binding handle
@@ -14,9 +14,9 @@ import (
 // full pointer to a uuid_t; map_tower is a full pointer to a twr_t; entry_handle is the
 // 20-octet context handle (null on the first call); max_towers caps the result.
 type eptMapRequest struct {
-	Object      *structures.EptUUID `ndr:"ptr"`
-	MapTower    *structures.Twr     `ndr:"ptr"`
-	EntryHandle structures.ContextHandle
+	Object      *msrpce.EptUUID `ndr:"ptr"`
+	MapTower    *msrpce.Twr     `ndr:"ptr"`
+	EntryHandle msrpce.ContextHandle
 	MaxTowers   ndr.DWORD
 }
 
@@ -37,9 +37,9 @@ func (*eptMapRequest) Opnum() uint16 { return epm.OpnumEptMap }
 // tag selects that framing, "varying" supplies the offset/actual_count words, and
 // "elem=ptr" makes the elements full pointers.
 type eptMapResponse struct {
-	EntryHandle structures.ContextHandle
+	EntryHandle msrpce.ContextHandle
 	NumTowers   ndr.DWORD
-	ITowers     []*structures.Twr `ndr:"varying,inline,elem=ptr"`
+	ITowers     []*msrpce.Twr `ndr:"varying,inline,elem=ptr"`
 	Status      ndr.DWORD
 }
 
@@ -49,14 +49,14 @@ type eptMapResponse struct {
 // towers the server returns. The decoded result towers are returned; use Tower.Endpoint
 // to extract a transport endpoint, or call Map for the common interface-to-endpoint
 // path.
-func EptMap(rpc ndr.Invoker, object *guid.GUID, mapTower structures.Tower, maxTowers uint32) ([]structures.Tower, error) {
-	twr := structures.NewTwr(mapTower)
+func EptMap(rpc ndr.Invoker, object *guid.GUID, mapTower msrpce.Tower, maxTowers uint32) ([]msrpce.Tower, error) {
+	twr := msrpce.NewTwr(mapTower)
 	req := &eptMapRequest{
 		MapTower:  &twr,
 		MaxTowers: ndr.DWORD(maxTowers),
 	}
 	if object != nil {
-		u := structures.NewEptUUID(*object)
+		u := msrpce.NewEptUUID(*object)
 		req.Object = &u
 	}
 
@@ -68,7 +68,7 @@ func EptMap(rpc ndr.Invoker, object *guid.GUID, mapTower structures.Tower, maxTo
 		return nil, fmt.Errorf("ept_map failed: %s", epm.StatusString(uint32(resp.Status)))
 	}
 
-	towers := make([]structures.Tower, 0, len(resp.ITowers))
+	towers := make([]msrpce.Tower, 0, len(resp.ITowers))
 	for _, tw := range resp.ITowers {
 		if tw == nil {
 			continue

--- a/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/functions/functions.go
+++ b/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/functions/functions.go
@@ -4,9 +4,9 @@
 package functions
 
 import (
-	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/structures"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 	"github.com/TheManticoreProject/Manticore/windows/guid"
+	msrpce "github.com/TheManticoreProject/Manticore/windows/protocols/ms-rpce"
 )
 
 // DefaultMaxTowers is the number of towers Map asks ept_map to return. A handful covers
@@ -23,12 +23,12 @@ const DefaultMaxEnts = 500
 // the returned towers. It is the common path for discovering the dynamic TCP port a
 // service listens on; for finer control (a non-nil object, a custom tower, or the raw
 // towers) call EptMap directly.
-func Map(rpc ndr.Invoker, iface guid.GUID, ifMajor, ifMinor uint16) ([]structures.Endpoint, error) {
-	towers, err := EptMap(rpc, nil, structures.BuildMapTowerTCP(iface, ifMajor, ifMinor), DefaultMaxTowers)
+func Map(rpc ndr.Invoker, iface guid.GUID, ifMajor, ifMinor uint16) ([]msrpce.Endpoint, error) {
+	towers, err := EptMap(rpc, nil, msrpce.BuildMapTowerTCP(iface, ifMajor, ifMinor), DefaultMaxTowers)
 	if err != nil {
 		return nil, err
 	}
-	var eps []structures.Endpoint
+	var eps []msrpce.Endpoint
 	for _, t := range towers {
 		if ep, ok := t.Endpoint(); ok {
 			eps = append(eps, ep)

--- a/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/functions/functions_test.go
+++ b/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/functions/functions_test.go
@@ -9,11 +9,11 @@ import (
 
 	epm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/functions"
-	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/structures"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/pdu"
 	"github.com/TheManticoreProject/Manticore/windows/guid"
+	msrpce "github.com/TheManticoreProject/Manticore/windows/protocols/ms-rpce"
 )
 
 // fakeTransport is an in-memory transport.Transport for driving the client without a
@@ -100,16 +100,16 @@ func pad4(b []byte) []byte {
 // conformant-varying header (max_count, offset, actual_count), one element referent id,
 // the twr_t body, then the status. max_count is set larger than actual_count (as a server
 // echoing the requested max_towers does) to pin that the decoder sizes from actual_count.
-func eptMapResponseStub(tower structures.Tower, maxTowers uint32) []byte {
+func eptMapResponseStub(tower msrpce.Tower, maxTowers uint32) []byte {
 	towerBytes := tower.Marshal()
 
 	var b []byte
-	b = append(b, make([]byte, structures.ContextHandleSize)...) // entry_handle
-	b = le32(b, 1)                                               // num_towers
-	b = le32(b, maxTowers)                                       // array maximum_count (size_is) — inline, no referent id
-	b = le32(b, 0)                                               // array offset
-	b = le32(b, 1)                                               // array actual_count (length_is)
-	b = le32(b, 0x00020004)                                      // element[0] twr_p_t referent id (non-null)
+	b = append(b, make([]byte, msrpce.ContextHandleSize)...) // entry_handle
+	b = le32(b, 1)                                           // num_towers
+	b = le32(b, maxTowers)                                   // array maximum_count (size_is) — inline, no referent id
+	b = le32(b, 0)                                           // array offset
+	b = le32(b, 1)                                           // array actual_count (length_is)
+	b = le32(b, 0x00020004)                                  // element[0] twr_p_t referent id (non-null)
 	// twr_t body: hoisted maximum_count, tower_length, octet string, pad to 4.
 	b = le32(b, uint32(len(towerBytes)))
 	b = le32(b, uint32(len(towerBytes)))
@@ -123,16 +123,16 @@ func TestEptMap_RoundTrip(t *testing.T) {
 	ft := &fakeTransport{}
 	c := boundClient(t, ft)
 
-	resolved := structures.Tower{Floors: []structures.Floor{
-		structures.InterfaceFloor(sampleIface(), 1, 0),
-		structures.TransferSyntaxFloor(),
-		{LHS: []byte{structures.FloorProtoNCACN}, RHS: []byte{0, 0}},
-		structures.TCPFloor(49664),
-		structures.IPFloor(net.IPv4(10, 0, 0, 30)),
+	resolved := msrpce.Tower{Floors: []msrpce.Floor{
+		msrpce.InterfaceFloor(sampleIface(), 1, 0),
+		msrpce.TransferSyntaxFloor(),
+		{LHS: []byte{msrpce.FloorProtoNCACN}, RHS: []byte{0, 0}},
+		msrpce.TCPFloor(49664),
+		msrpce.IPFloor(net.IPv4(10, 0, 0, 30)),
 	}}
 	ft.queue(responsePDU(t, 2, eptMapResponseStub(resolved, functions.DefaultMaxTowers)))
 
-	towers, err := functions.EptMap(c, nil, structures.BuildMapTowerTCP(sampleIface(), 1, 0), functions.DefaultMaxTowers)
+	towers, err := functions.EptMap(c, nil, msrpce.BuildMapTowerTCP(sampleIface(), 1, 0), functions.DefaultMaxTowers)
 	if err != nil {
 		t.Fatalf("EptMap() error = %v", err)
 	}
@@ -164,12 +164,12 @@ func TestMap_ReturnsEndpoints(t *testing.T) {
 	ft := &fakeTransport{}
 	c := boundClient(t, ft)
 
-	resolved := structures.Tower{Floors: []structures.Floor{
-		structures.InterfaceFloor(sampleIface(), 1, 0),
-		structures.TransferSyntaxFloor(),
-		{LHS: []byte{structures.FloorProtoNCACN}, RHS: []byte{0, 0}},
-		structures.TCPFloor(135),
-		structures.IPFloor(net.IPv4(192, 0, 2, 1)),
+	resolved := msrpce.Tower{Floors: []msrpce.Floor{
+		msrpce.InterfaceFloor(sampleIface(), 1, 0),
+		msrpce.TransferSyntaxFloor(),
+		{LHS: []byte{msrpce.FloorProtoNCACN}, RHS: []byte{0, 0}},
+		msrpce.TCPFloor(135),
+		msrpce.IPFloor(net.IPv4(192, 0, 2, 1)),
 	}}
 	ft.queue(responsePDU(t, 2, eptMapResponseStub(resolved, functions.DefaultMaxTowers)))
 
@@ -188,13 +188,13 @@ func TestEptMap_StatusError(t *testing.T) {
 
 	// num_towers = 0, null ITowers pointer, non-zero status.
 	var stub []byte
-	stub = append(stub, make([]byte, structures.ContextHandleSize)...)
+	stub = append(stub, make([]byte, msrpce.ContextHandleSize)...)
 	stub = le32(stub, 0)                          // num_towers
 	stub = le32(stub, 0)                          // ITowers null pointer
 	stub = le32(stub, epm.EptStatusNotRegistered) // status
 	ft.queue(responsePDU(t, 2, stub))
 
-	if _, err := functions.EptMap(c, nil, structures.BuildMapTowerTCP(sampleIface(), 1, 0), functions.DefaultMaxTowers); err == nil {
+	if _, err := functions.EptMap(c, nil, msrpce.BuildMapTowerTCP(sampleIface(), 1, 0), functions.DefaultMaxTowers); err == nil {
 		t.Fatal("EptMap() with ept_s_not_registered: error = nil, want non-nil")
 	}
 }
@@ -216,7 +216,7 @@ func TestEptMap_StatusError(t *testing.T) {
 // to a value larger than actual_count (as a real server echoing the requested max_ents
 // does) so the test also pins that the decoder sizes the result from actual_count, not
 // max_count.
-func eptLookupStub(t *testing.T, handle structures.ContextHandle, status uint32, entries []structures.EptEntry) []byte {
+func eptLookupStub(t *testing.T, handle msrpce.ContextHandle, status uint32, entries []msrpce.EptEntry) []byte {
 	t.Helper()
 	var b []byte
 	b = append(b, handle[:]...)           // entry_handle (20 octets)
@@ -262,24 +262,24 @@ func eptLookupStub(t *testing.T, handle structures.ContextHandle, status uint32,
 }
 
 // tcpEntry builds an ept_entry_t with an ncacn_ip_tcp tower on the given port.
-func tcpEntry(obj guid.GUID, port uint16, annotation string) structures.EptEntry {
-	tw := structures.NewTwr(structures.Tower{Floors: []structures.Floor{
-		structures.InterfaceFloor(sampleIface(), 1, 0),
-		structures.TransferSyntaxFloor(),
-		{LHS: []byte{structures.FloorProtoNCACN}, RHS: []byte{0, 0}},
-		structures.TCPFloor(port),
-		structures.IPFloor(net.IPv4(10, 0, 0, 1)),
+func tcpEntry(obj guid.GUID, port uint16, annotation string) msrpce.EptEntry {
+	tw := msrpce.NewTwr(msrpce.Tower{Floors: []msrpce.Floor{
+		msrpce.InterfaceFloor(sampleIface(), 1, 0),
+		msrpce.TransferSyntaxFloor(),
+		{LHS: []byte{msrpce.FloorProtoNCACN}, RHS: []byte{0, 0}},
+		msrpce.TCPFloor(port),
+		msrpce.IPFloor(net.IPv4(10, 0, 0, 1)),
 	}})
-	return structures.EptEntry{
-		Object:     structures.NewEptUUID(obj),
+	return msrpce.EptEntry{
+		Object:     msrpce.NewEptUUID(obj),
 		Tower:      &tw,
-		Annotation: structures.Annotation(annotation),
+		Annotation: msrpce.Annotation(annotation),
 	}
 }
 
 // nonNullHandle returns a context handle with a non-zero UUID portion.
-func nonNullHandle() structures.ContextHandle {
-	var h structures.ContextHandle
+func nonNullHandle() msrpce.ContextHandle {
+	var h msrpce.ContextHandle
 	h[4] = 0xAB // first UUID octet
 	return h
 }
@@ -288,12 +288,12 @@ func TestLookup_SingleBatch(t *testing.T) {
 	ft := &fakeTransport{}
 	c := boundClient(t, ft)
 
-	entries := []structures.EptEntry{
+	entries := []msrpce.EptEntry{
 		tcpEntry(sampleIface(), 49664, "Service A"),
 		tcpEntry(sampleIface(), 135, "Service B"),
 	}
 	// Null handle on the response => enumeration complete after this batch.
-	ft.queue(responsePDU(t, 2, eptLookupStub(t, structures.ContextHandle{}, epm.EptStatusSuccess, entries)))
+	ft.queue(responsePDU(t, 2, eptLookupStub(t, msrpce.ContextHandle{}, epm.EptStatusSuccess, entries)))
 
 	got, err := functions.Lookup(c)
 	if err != nil {
@@ -321,10 +321,10 @@ func TestLookup_MultiBatch(t *testing.T) {
 	h1 := nonNullHandle()
 	// Batch 1: two entries, non-null handle => more to come.
 	ft.queue(responsePDU(t, 2, eptLookupStub(t, h1, epm.EptStatusSuccess,
-		[]structures.EptEntry{tcpEntry(sampleIface(), 1000, "A"), tcpEntry(sampleIface(), 1001, "B")})))
+		[]msrpce.EptEntry{tcpEntry(sampleIface(), 1000, "A"), tcpEntry(sampleIface(), 1001, "B")})))
 	// Batch 2: one entry, null handle => done.
-	ft.queue(responsePDU(t, 3, eptLookupStub(t, structures.ContextHandle{}, epm.EptStatusSuccess,
-		[]structures.EptEntry{tcpEntry(sampleIface(), 1002, "C")})))
+	ft.queue(responsePDU(t, 3, eptLookupStub(t, msrpce.ContextHandle{}, epm.EptStatusSuccess,
+		[]msrpce.EptEntry{tcpEntry(sampleIface(), 1002, "C")})))
 
 	got, err := functions.Lookup(c)
 	if err != nil {
@@ -351,7 +351,7 @@ func TestLookup_EmptyRegistry(t *testing.T) {
 	c := boundClient(t, ft)
 
 	// No entries, null handle, ept_s_not_registered => clean, empty result.
-	ft.queue(responsePDU(t, 2, eptLookupStub(t, structures.ContextHandle{}, epm.EptStatusNotRegistered, nil)))
+	ft.queue(responsePDU(t, 2, eptLookupStub(t, msrpce.ContextHandle{}, epm.EptStatusNotRegistered, nil)))
 
 	got, err := functions.Lookup(c)
 	if err != nil {
@@ -365,7 +365,7 @@ func TestLookup_EmptyRegistry(t *testing.T) {
 func TestEptLookup_RequestShape(t *testing.T) {
 	ft := &fakeTransport{}
 	c := boundClient(t, ft)
-	ft.queue(responsePDU(t, 2, eptLookupStub(t, structures.ContextHandle{}, epm.EptStatusSuccess, nil)))
+	ft.queue(responsePDU(t, 2, eptLookupStub(t, msrpce.ContextHandle{}, epm.EptStatusSuccess, nil)))
 
 	if _, err := functions.Lookup(c); err != nil {
 		t.Fatalf("Lookup() error = %v", err)
@@ -403,7 +403,7 @@ func TestEptLookupHandleFree(t *testing.T) {
 
 	// [out] stub: 20-octet nulled entry_handle, then status = rpc_s_ok.
 	var stub []byte
-	stub = append(stub, make([]byte, structures.ContextHandleSize)...)
+	stub = append(stub, make([]byte, msrpce.ContextHandleSize)...)
 	stub = le32(stub, epm.EptStatusSuccess)
 	ft.queue(responsePDU(t, 2, stub))
 
@@ -426,7 +426,7 @@ func TestEptLookupHandleFree(t *testing.T) {
 	if req.Opnum != 4 {
 		t.Errorf("opnum = %d, want 4 (ept_lookup_handle_free; opnum 1 is ept_delete)", req.Opnum)
 	}
-	if got := req.Stub[:structures.ContextHandleSize]; !bytes.Equal(got, in[:]) {
+	if got := req.Stub[:msrpce.ContextHandleSize]; !bytes.Equal(got, in[:]) {
 		t.Errorf("request handle = %x, want %x", got, in[:])
 	}
 }

--- a/windows/protocols/ms-rpce/context_handle.go
+++ b/windows/protocols/ms-rpce/context_handle.go
@@ -1,4 +1,4 @@
-package structures
+package msrpce
 
 import (
 	"fmt"

--- a/windows/protocols/ms-rpce/ept_entry.go
+++ b/windows/protocols/ms-rpce/ept_entry.go
@@ -1,4 +1,4 @@
-package structures
+package msrpce
 
 import (
 	"fmt"
@@ -31,7 +31,7 @@ func (*Annotation) AlignmentNDR() int { return 4 }
 func (a *Annotation) MarshalNDR(e *ndr.Encoder) error {
 	e.Align(4)
 	s := string(*a)
-	e.WriteUint32(0)                 // offset
+	e.WriteUint32(0)                  // offset
 	e.WriteUint32(uint32(len(s) + 1)) // actual_count, including the NUL terminator
 	e.WriteBytes([]byte(s))
 	e.WriteUint8(0) // NUL terminator

--- a/windows/protocols/ms-rpce/rpc_if_id.go
+++ b/windows/protocols/ms-rpce/rpc_if_id.go
@@ -1,4 +1,4 @@
-package structures
+package msrpce
 
 import "github.com/TheManticoreProject/Manticore/windows/guid"
 

--- a/windows/protocols/ms-rpce/structures_test.go
+++ b/windows/protocols/ms-rpce/structures_test.go
@@ -1,4 +1,4 @@
-package structures
+package msrpce
 
 import (
 	"bytes"

--- a/windows/protocols/ms-rpce/tower.go
+++ b/windows/protocols/ms-rpce/tower.go
@@ -1,4 +1,4 @@
-package structures
+package msrpce
 
 import (
 	"encoding/binary"

--- a/windows/protocols/ms-rpce/twr.go
+++ b/windows/protocols/ms-rpce/twr.go
@@ -1,4 +1,4 @@
-package structures
+package msrpce
 
 // Twr models twr_t ([C706] Appendix O):
 //

--- a/windows/protocols/ms-rpce/uuid.go
+++ b/windows/protocols/ms-rpce/uuid.go
@@ -1,4 +1,4 @@
-package structures
+package msrpce
 
 import "github.com/TheManticoreProject/Manticore/windows/guid"
 


### PR DESCRIPTION
### Linked Issue
`Closes #854`

### Root Cause
The `ept`/`epmapper` interface predates the project convention that interface directories under `network/dcerpc/interfaces/<uuid>/<ver>/` contain only the descriptor (`interface.go`) and the `functions/` opnum stubs, with all NDR wire structures living in a shared per-protocol package under `windows/protocols/`. As a result it was the last interface in the tree still carrying a local `structures/` subpackage, and its endpoint-mapper types could not be reused outside the interface's own stubs.

### Fix Description
Relocate the interface's NDR structures to a new shared package `windows/protocols/ms-rpce` (`package msrpce`) — the endpoint mapper is specified in `[C706]` Appendix O and `[MS-RPCE]`, so `ms-rpce` is the correct protocol home. Moved via `git mv` (history preserved): `context_handle.go`, `ept_entry.go`, `rpc_if_id.go`, `tower.go`, `twr.go`, `uuid.go`, and `structures_test.go`, changing only their package clause. The four `functions/` files (`02_EptLookup.go`, `03_EptMap.go`, `functions.go`, `functions_test.go`) now import `msrpce` in place of the deleted local `structures` subpackage. No type definitions or wire behavior changed. The interface directory now holds only `interface.go` + `functions/`, matching every other interface.

### How Verified
- `go build ./windows/protocols/ms-rpce/ ./network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/...` — passes.
- `go vet` on the same paths — clean.
- `go build -tags integration` on the interface tree — passes.
- `go test ./windows/protocols/ms-rpce/ ./network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/...` — all pass (the relocated `structures_test.go` round-trips still pass under the new package).
- `find network/dcerpc/interfaces -type d -name structures` now returns nothing.

### Test Coverage
**Existing:** the moved `structures_test.go` (now `windows/protocols/ms-rpce/structures_test.go`) and the interface's `functions_test.go` continue to exercise the round-trips and stubs against the relocated types.

### Scope of Change
- **Files changed:** 7 moved (`structures/` → `windows/protocols/ms-rpce/`), 4 modified (`functions/`).
- **Submodule pointer updated:** no.
- **Behavioral changes outside the bug fix:** none.

### Risk and Rollout
Pure code-relocation with import repointing; no wire or logic change. Blast radius is limited to consumers of the `ept` interface, which reference it through `functions/` and are unaffected. Safe to merge directly.
