### PR TITLE
Move MS-EVEN6 context-handle type out of the functions stub into ms-even6 (Fixes #855)

### DIFF
--- a/network/dcerpc/interfaces/f6beaff7-1e19-4fbb-9f8f-b89e2018337c/1.0/functions/13_EvtRpcClose.go
+++ b/network/dcerpc/interfaces/f6beaff7-1e19-4fbb-9f8f-b89e2018337c/1.0/functions/13_EvtRpcClose.go
@@ -5,18 +5,12 @@ import (
 
 	IEventService "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/f6beaff7-1e19-4fbb-9f8f-b89e2018337c/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	mseven6 "github.com/TheManticoreProject/Manticore/windows/protocols/ms-even6"
 )
-
-// ContextHandle is the 20-octet RPC context handle ([MS-RPCE] 2.3.2.2) that EvtRpcClose
-// closes. The IDL types it as a generic [in, out] context_handle void**, so it accepts any
-// of the interface's handles (log query, log handle, operation control, subscription, …);
-// callers convert their typed [20]byte handle to this type. It is transmitted inline (no
-// referent id), matching every other context handle in this interface.
-type ContextHandle [20]byte
 
 // evtRpcCloseRequest carries the [in] parameter of EvtRpcClose.
 type evtRpcCloseRequest struct {
-	Handle ContextHandle
+	Handle mseven6.CONTEXT_HANDLE
 }
 
 func (*evtRpcCloseRequest) Opnum() uint16 { return IEventService.OpnumEvtRpcClose }
@@ -24,19 +18,19 @@ func (*evtRpcCloseRequest) Opnum() uint16 { return IEventService.OpnumEvtRpcClos
 // evtRpcCloseResponse carries the [out] parameter and return value of EvtRpcClose. On
 // success the server returns the handle nulled out.
 type evtRpcCloseResponse struct {
-	Handle ContextHandle
+	Handle mseven6.CONTEXT_HANDLE
 	Status ndr.DWORD `ndr:"retval"`
 }
 
 // EvtRpcClose calls EvtRpcClose (opnum 13) ([MS-EVEN6] 3.1.4.35). It closes the context
 // handle and returns the server's (nulled) handle value.
-func EvtRpcClose(rpc ndr.Invoker, handle ContextHandle) (ContextHandle, error) {
+func EvtRpcClose(rpc ndr.Invoker, handle mseven6.CONTEXT_HANDLE) (mseven6.CONTEXT_HANDLE, error) {
 	req := &evtRpcCloseRequest{
 		Handle: handle,
 	}
 	var resp evtRpcCloseResponse
 	if err := rpc.Invoke(req, &resp); err != nil {
-		return ContextHandle{}, fmt.Errorf("EvtRpcClose: %w", err)
+		return mseven6.CONTEXT_HANDLE{}, fmt.Errorf("EvtRpcClose: %w", err)
 	}
 	if uint32(resp.Status) != IEventService.StatusSuccess {
 		return resp.Handle, fmt.Errorf("EvtRpcClose failed: %s", IEventService.StatusString(uint32(resp.Status)))

--- a/windows/protocols/ms-even6/CONTEXT_HANDLE.go
+++ b/windows/protocols/ms-even6/CONTEXT_HANDLE.go
@@ -1,0 +1,9 @@
+package mseven6
+
+// CONTEXT_HANDLE is the generic 20-octet RPC context handle ([MS-RPCE] 2.3.2.2) used by
+// EvtRpcClose. The IDL types it as an [in, out] context_handle void**, so it accepts any
+// of the interface's typed handles (log query, log handle, operation control,
+// subscription, …); callers convert their typed [20]byte handle to this type. It is
+// transmitted inline (no referent id), matching every other context handle in this
+// interface.
+type CONTEXT_HANDLE [20]byte


### PR DESCRIPTION
### Linked Issue
`Closes #855`

### Root Cause
The generic RPC context-handle type used by `EvtRpcClose` was added directly to the opnum stub file rather than to the protocol's shared structure package. Per the project's DCE/RPC layout contract, `functions/` files hold only opnum stubs and private request/response shapes; exported NDR data types belong in `windows/protocols/ms-xxx/`. This was the only exported type declared inside any interface's `functions/` directory.

### Fix Description
Add `windows/protocols/ms-even6/CONTEXT_HANDLE.go` defining `type CONTEXT_HANDLE [20]byte` (screaming-case, matching the package's existing `PCONTEXT_HANDLE_*` types), and update `functions/13_EvtRpcClose.go` to drop the inline `ContextHandle` declaration and use `mseven6.CONTEXT_HANDLE` in the request/response shapes and the `EvtRpcClose` signature. The 20-octet wire representation and inline (no-referent) transmission are unchanged.

### How Verified
- `go build ./windows/protocols/ms-even6/ ./network/dcerpc/interfaces/f6beaff7-1e19-4fbb-9f8f-b89e2018337c/...` — passes.
- `go vet` on the interface tree — clean.
- `go build -tags integration` on the interface tree — passes.
- `grep -rn '^type [A-Z]' network/dcerpc/interfaces/*/*/functions/*.go` (excluding tests / request / response) now returns nothing.

### Test Coverage
**None:** the change relocates a type declaration without altering its wire layout or any logic; the existing `ms-even6` package builds and the interface's stubs compile against the moved type. No new behavior is introduced to test, and the type is a fixed 20-byte array with no marshalling logic of its own.

### Scope of Change
- **Files changed:** 1 added (`windows/protocols/ms-even6/CONTEXT_HANDLE.go`), 1 modified (`functions/13_EvtRpcClose.go`).
- **Submodule pointer updated:** no.
- **Behavioral changes outside the bug fix:** none.

### Risk and Rollout
Local relocation of one type; no wire or logic change. Safe to merge directly.
