### PR TITLE
Add consolidated MS-DTYP package windows/ms-dtyp (Part of #858)

### DIFF
--- a/windows/ms-dtyp/ADCONNECTION_HANDLE.go
+++ b/windows/ms-dtyp/ADCONNECTION_HANDLE.go
@@ -1,0 +1,5 @@
+package msdtyp
+
+// ADCONNECTION_HANDLE
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/5faf669e-34a9-471b-aaff-8591b9650189
+type ADCONNECTION_HANDLE = uintptr

--- a/windows/ms-dtyp/BOOL.go
+++ b/windows/ms-dtyp/BOOL.go
@@ -1,0 +1,5 @@
+package msdtyp
+
+// A BOOL is a 32-bit field that is set to 1 to indicate TRUE, or 0 to indicate FALSE
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/9d81be47-232e-42cf-8f0d-7a3b29bf2eb2
+type BOOL = uint32

--- a/windows/ms-dtyp/BOOLEAN.go
+++ b/windows/ms-dtyp/BOOLEAN.go
@@ -1,0 +1,5 @@
+package msdtyp
+
+// A BOOLEAN is an 8-bit field that is set to 1 to indicate TRUE, or 0 to indicate FALSE.
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/51bbfbb1-08e2-4c13-a95e-1eaa7d310670
+type BOOLEAN = uint8

--- a/windows/ms-dtyp/BSTR.go
+++ b/windows/ms-dtyp/BSTR.go
@@ -1,0 +1,5 @@
+package msdtyp
+
+// A BSTR is a pointer to a null-terminated character string in which the string length is stored with the string.
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/692a42a9-06ce-4394-b9bc-5d2a50440168
+type BSTR = []WCHAR

--- a/windows/ms-dtyp/BYTE.go
+++ b/windows/ms-dtyp/BYTE.go
@@ -1,0 +1,5 @@
+package msdtyp
+
+// A BYTE is an 8-bit unsigned value that corresponds to a single octet in a network protocol.
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/d7edc080-e499-4219-a837-1bc40b64bb04
+type BYTE = UCHAR

--- a/windows/ms-dtyp/CHAR.go
+++ b/windows/ms-dtyp/CHAR.go
@@ -1,0 +1,6 @@
+package msdtyp
+
+// A CHAR is an 8-bit block of data that typically contains an ANSI character, as specified in [ISO/IEC-8859-1].
+// For information on the char keyword, see [C706] section 4.2.9.3.
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/77e1033f-b31d-4bd2-b3d5-9f3c9faa22eb
+type CHAR = byte

--- a/windows/ms-dtyp/DOUBLE.go
+++ b/windows/ms-dtyp/DOUBLE.go
@@ -1,0 +1,7 @@
+package msdtyp
+
+// A DOUBLE is an 8-byte, double-precision, floating-point number that represents a double-precision, 64-bit [IEEE754]
+// value with the approximate range: +/-5.0 x 10-324 through +/-1.7 x 10308.
+// The DOUBLE type can also represent not a number (NAN); positive and negative infinity; or positive and negative 0.
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/40beeef3-303a-40de-895c-11379fc42c15
+type DOUBLE = float64

--- a/windows/ms-dtyp/DWORD.go
+++ b/windows/ms-dtyp/DWORD.go
@@ -1,0 +1,6 @@
+package msdtyp
+
+// A DWORD is a 32-bit unsigned integer (range: 0 through 4294967295 decimal). Because a DWORD is unsigned,
+// its first bit (Most Significant Bit (MSB)) is not reserved for signing.
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/262627d8-3418-4627-9218-4ffe110850b2
+type DWORD = uint32

--- a/windows/ms-dtyp/DWORD32.go
+++ b/windows/ms-dtyp/DWORD32.go
@@ -1,0 +1,5 @@
+package msdtyp
+
+// A DWORD32 is a 32-bit unsigned integer.
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/e359fcc1-35c6-4bcd-964d-d59927aeea98
+type DWORD32 = uint32

--- a/windows/ms-dtyp/DWORD64.go
+++ b/windows/ms-dtyp/DWORD64.go
@@ -1,0 +1,5 @@
+package msdtyp
+
+// A DWORD64 is a 64-bit unsigned integer.
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/3f3bd817-6fdd-4db9-b542-f800f876007d
+type DWORD64 = uint64

--- a/windows/ms-dtyp/DWORDLONG.go
+++ b/windows/ms-dtyp/DWORDLONG.go
@@ -1,0 +1,5 @@
+package msdtyp
+
+// A DWORDLONG is a 64-bit unsigned integer (range: 0 through 18446744073709551615 decimal).
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/c575fb47-166c-48cd-a37c-e44cac05c3d6
+type DWORDLONG = uint64

--- a/windows/ms-dtyp/DWORD_PTR.go
+++ b/windows/ms-dtyp/DWORD_PTR.go
@@ -1,0 +1,5 @@
+package msdtyp
+
+// A DWORD_PTR is a pointer to a DWORD.
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/66d61dd8-2191-4a37-b963-e49bf0dc2579
+type DWORD_PTR = *DWORD

--- a/windows/ms-dtyp/ERROR_STATUS_T.go
+++ b/windows/ms-dtyp/ERROR_STATUS_T.go
@@ -1,0 +1,5 @@
+package msdtyp
+
+// ERROR_STATUS_T
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/802ada7f-c5fc-415e-8438-c7369bb4193b
+type ERROR_STATUS_T = ULONG

--- a/windows/ms-dtyp/EVENT_DESCRIPTOR.go
+++ b/windows/ms-dtyp/EVENT_DESCRIPTOR.go
@@ -1,0 +1,13 @@
+package msdtyp
+
+// The EVENT_DESCRIPTOR structure specifies the metadata that defines an event.
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/a6110d36-28c1-4290-b79e-26aa95a0b1a0
+type EVENT_DESCRIPTOR struct {
+	Id      USHORT
+	Version UCHAR
+	Channel UCHAR
+	Level   UCHAR
+	Opcode  UCHAR
+	Task    USHORT
+	Keyword ULONGLONG
+}

--- a/windows/ms-dtyp/EVENT_HEADER.go
+++ b/windows/ms-dtyp/EVENT_HEADER.go
@@ -1,0 +1,23 @@
+package msdtyp
+
+import ()
+
+// The EVENT_HEADER structure defines the main parameters of an event.
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/fa4f7836-06ee-4ab6-8688-386a5a85f8c5
+type EVENT_HEADER struct {
+	Size            USHORT
+	HeaderType      USHORT
+	Flags           USHORT
+	EventProperty   USHORT
+	ThreadId        ULONG
+	ProcessId       ULONG
+	TimeStamp       LARGE_INTEGER
+	ProviderId      GUID
+	EventDescriptor EVENT_DESCRIPTOR
+	KernelTime      ULONG
+	UserTime        ULONG
+	ProcessorTime   ULONG64
+	ActivityId      GUID
+}
+
+type PEVENT_HEADER *EVENT_HEADER

--- a/windows/ms-dtyp/FILETIME.go
+++ b/windows/ms-dtyp/FILETIME.go
@@ -1,0 +1,119 @@
+package msdtyp
+
+import (
+	"encoding/binary"
+	"errors"
+	"time"
+)
+
+// Thursday, January 1, 1970 1:00:00 AM GMT+01:00 in 100-nanosecond intervals
+const UnixTimestampIn100NsIntervals int64 = 116444736000000000
+
+// The FILETIME structure is a 64-bit value that represents the number of 100-nanosecond intervals
+// that have elapsed since January 1, 1601, Coordinated Universal Time (UTC).
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/2c57429b-fdd4-488f-b5fc-9e4cf020fcdf
+type FILETIME struct {
+	// dwLowDateTime: A 32-bit unsigned integer that contains the low-order bits of the file time.
+	DwLowDateTime uint32
+	// dwHighDateTime: A 32-bit unsigned integer that contains the high-order bits of the file time.
+	DwHighDateTime uint32
+}
+
+// NewFILETIMEFromTime creates a new FILETIME structure from a time.Time value.
+//
+// Parameters:
+// - t: The time.Time value to create the FILETIME structure from
+//
+// Returns:
+// - A pointer to the new FILETIME structure
+func NewFILETIMEFromTime(t time.Time) *FILETIME {
+	value := (t.UnixNano() / 100) + UnixTimestampIn100NsIntervals
+	return &FILETIME{
+		DwLowDateTime:  uint32(value & 0xFFFFFFFF),
+		DwHighDateTime: uint32((value >> 32) & 0xFFFFFFFF),
+	}
+}
+
+// ToInt64 returns the int64 representation of the FILETIME structure.
+//
+// Returns:
+// - The int64 representation of the FILETIME structure
+func (ft *FILETIME) ToInt64() int64 {
+	return (int64(ft.DwHighDateTime) & 0xFFFFFFFF << 32) | (int64(ft.DwLowDateTime) & 0xFFFFFFFF)
+}
+
+// GetTime returns the time represented by the FILETIME structure.
+//
+// Returns:
+// - The time represented by the FILETIME structure
+func (ft *FILETIME) GetTime() time.Time {
+	delta := int64(ft.ToInt64()-UnixTimestampIn100NsIntervals) * 100
+	return time.Unix(0, delta)
+}
+
+// Unmarshal deserializes a byte slice into the FILETIME structure.
+//
+// Parameters:
+// - data: A byte slice to be deserialized into the FILETIME structure
+func (ft *FILETIME) Unmarshal(data []byte) (int, error) {
+	if len(data) < 8 {
+		return 0, errors.New("data is too short to unmarshal into FILETIME")
+	}
+
+	ft.DwLowDateTime = binary.LittleEndian.Uint32(data[0:4])
+
+	ft.DwHighDateTime = binary.LittleEndian.Uint32(data[4:8])
+
+	return 8, nil
+}
+
+// Marshal serializes the FILETIME structure into a byte slice.
+// It converts the FILETIME structure into its binary representation
+// according to the SMB protocol format.
+//
+// Returns:
+// - A byte slice containing the marshalled FILETIME structure
+func (ft *FILETIME) Marshal() ([]byte, error) {
+	marshalledData := []byte{}
+
+	buf4 := make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf4, ft.DwLowDateTime)
+	marshalledData = append(marshalledData, buf4...)
+
+	buf4 = make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf4, ft.DwHighDateTime)
+	marshalledData = append(marshalledData, buf4...)
+
+	return marshalledData, nil
+}
+
+// GetUnixTimestamp returns the Unix timestamp represented by the FILETIME structure.
+//
+// Returns:
+// - The Unix timestamp as an int64
+func (ft *FILETIME) GetUnixTimestamp() int64 {
+	// Convert Windows file time (100-nanosecond intervals since January 1, 1601)
+	// to Unix time (seconds since January 1, 1970)
+	return ft.GetTime().Unix()
+}
+
+// GetTimeString returns the string representation of the FILETIME structure in UTC.
+//
+// Returns:
+// - The string representation of the FILETIME structure in UTC
+func (ft *FILETIME) GetTimeString() string {
+	return ft.GetTime().UTC().Format("2006-01-02 15:04:05.00000")
+}
+
+// String returns the string representation of the FILETIME structure in UTC.
+//
+// Returns:
+// - The string representation of the FILETIME structure in UTC
+func (ft *FILETIME) String() string {
+	return ft.GetTimeString()
+}
+
+// Uint64 returns the FILETIME as a single 64-bit value (high half in the upper 32 bits).
+func (ft FILETIME) Uint64() uint64 {
+	return uint64(ft.DwHighDateTime)<<32 | uint64(ft.DwLowDateTime)
+}

--- a/windows/ms-dtyp/FILETIME_test.go
+++ b/windows/ms-dtyp/FILETIME_test.go
@@ -1,0 +1,240 @@
+package msdtyp_test
+
+import (
+	"encoding/hex"
+	"testing"
+	"time"
+
+	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
+)
+
+func TestFILETIME_ToInt64(t *testing.T) {
+	testCases := []struct {
+		name              string
+		hexData           string
+		expectedTimestamp int64
+	}{
+		{
+			name:              "Aug 27, 2011 23:21:49.781250000 CEST",
+			hexData:           "148a5255ff64cc01",
+			expectedTimestamp: int64(0x01cc64ff55528a14),
+		},
+		{
+			name:              "Jan 1, 2000 00:00:00 UTC",
+			hexData:           "0000e1f505e0cd01",
+			expectedTimestamp: int64(0x01cde005f5e10000),
+		},
+		{
+			name:              "Dec 31, 2020 23:59:59 UTC",
+			hexData:           "00a0bf5ed095e501",
+			expectedTimestamp: int64(0x01e595d05ebfa000),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			smbTime := &msdtyp.FILETIME{}
+
+			data, err := hex.DecodeString(tc.hexData)
+			if err != nil {
+				t.Fatalf("Failed to decode hex string: %v", err)
+			}
+			smbTime.Unmarshal(data)
+
+			if timestamp := smbTime.ToInt64(); timestamp != tc.expectedTimestamp {
+				t.Errorf("Expected timestamp 0x%016x, got 0x%016x", tc.expectedTimestamp, timestamp)
+			}
+		})
+	}
+}
+
+func TestFILETIME_GetUnixTimestamp(t *testing.T) {
+	// Test case: 148a5255ff64cc01 should be Aug 27, 2011 23:21:49.781250000 CEST
+	smbTime := &msdtyp.FILETIME{}
+
+	hexData := "148a5255ff64cc01"
+	data, err := hex.DecodeString(hexData)
+	if err != nil {
+		t.Fatalf("Failed to decode hex string: %v", err)
+	}
+	smbTime.Unmarshal(data)
+
+	// Expected timestamp for Aug 27, 2011 23:21:49 UTC
+	expectedTime := time.Date(2011, time.August, 27, 21, 21, 49, 781250000, time.UTC)
+	expectedTimestamp := expectedTime.Unix()
+
+	if timestamp := smbTime.GetUnixTimestamp(); timestamp != expectedTimestamp {
+		t.Errorf("Expected timestamp %d, got %d", expectedTimestamp, timestamp)
+		t.Errorf("Expected timestamp 0x%08x, got 0x%08x", expectedTimestamp, timestamp)
+	}
+}
+
+func TestFILETIME_GetTime(t *testing.T) {
+	// Test case: 148a5255ff64cc01 should be Aug 27, 2011 23:21:49.781250000 CEST
+	smbTime := &msdtyp.FILETIME{}
+
+	hexData := "148a5255ff64cc01"
+	data, err := hex.DecodeString(hexData)
+	if err != nil {
+		t.Fatalf("Failed to decode hex string: %v", err)
+	}
+	smbTime.Unmarshal(data)
+
+	// Expected time for Aug 27, 2011 23:21:49 UTC
+	expectedTime := time.Date(2011, time.August, 27, 21, 21, 49, 781250000, time.UTC)
+
+	if gotTime := smbTime.GetTime(); !gotTime.Equal(expectedTime) {
+		t.Errorf("Expected time %s, got %s",
+			expectedTime.Format(time.RFC3339),
+			gotTime.Format(time.RFC3339))
+	}
+}
+
+func TestFILETIME_String(t *testing.T) {
+	// Test case: 148a5255ff64cc01 should be Aug 27, 2011 23:21:49.781250000 CEST
+	smbTime := &msdtyp.FILETIME{}
+
+	hexData := "148a5255ff64cc01"
+	data, err := hex.DecodeString(hexData)
+	if err != nil {
+		t.Fatalf("Failed to decode hex string: %v", err)
+	}
+	smbTime.Unmarshal(data)
+
+	// Expected string format for Aug 27, 2011 21:21:49 UTC
+	expectedString := "2011-08-27 21:21:49.78125"
+
+	if str := smbTime.String(); str != expectedString {
+		t.Errorf("Expected string %s, got %s", expectedString, str)
+	}
+}
+
+func TestFILETIME_Unmarshal(t *testing.T) {
+	smbTime := &msdtyp.FILETIME{}
+
+	hexData := "148a5255ff64cc01"
+	data, err := hex.DecodeString(hexData)
+	if err != nil {
+		t.Fatalf("Failed to decode hex string: %v", err)
+	}
+	smbTime.Unmarshal(data)
+
+	expectedHighPart := uint32(0x01cc64ff)
+	expectedLowPart := uint32(0x55528a14)
+
+	if smbTime.DwHighDateTime != expectedHighPart || smbTime.DwLowDateTime != expectedLowPart {
+		t.Errorf("Expected HighPart = 0x%08x got HighPart = 0x%08x", expectedHighPart, smbTime.DwHighDateTime)
+		t.Errorf("Expected LowPart  = 0x%08x got LowPart  = 0x%08x", expectedLowPart, smbTime.DwLowDateTime)
+	}
+
+	// Test with insufficient data
+	shortData := make([]byte, 4)
+	originalHighPart := smbTime.DwHighDateTime
+	originalLowPart := smbTime.DwLowDateTime
+
+	smbTime.Unmarshal(shortData)
+
+	if smbTime.DwHighDateTime != originalHighPart || smbTime.DwLowDateTime != originalLowPart {
+		t.Errorf("Expected no change with insufficient data, but values were modified")
+	}
+}
+
+func TestNewFILETIMEFromTime(t *testing.T) {
+	testCases := []struct {
+		name          string
+		inputTime     time.Time
+		expectedInt64 int64
+		expectedLow   uint32
+		expectedHigh  uint32
+	}{
+		{
+			name:          "Aug 27, 2011 23:21:49.781250000 UTC",
+			inputTime:     time.Date(2011, time.August, 27, 23, 21, 49, 781250000, time.UTC),
+			expectedInt64: int64(0x01cc651018db5a14),
+			expectedLow:   uint32(0x18db5a14),
+			expectedHigh:  uint32(0x01cc6510),
+		},
+		{
+			name:          "Jan 1, 2000 00:00:00 UTC",
+			inputTime:     time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+			expectedInt64: int64(0x01bf53eb256d4000),
+			expectedLow:   uint32(0x256d4000),
+			expectedHigh:  uint32(0x01bf53eb),
+		},
+		{
+			name:          "Dec 31, 2020 23:59:59 UTC",
+			inputTime:     time.Date(2020, time.December, 31, 23, 59, 59, 0, time.UTC),
+			expectedInt64: int64(0x01d6dfd10b9ce980),
+			expectedLow:   uint32(0x0b9ce980),
+			expectedHigh:  uint32(0x01d6dfd1),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fileTime := msdtyp.NewFILETIMEFromTime(tc.inputTime)
+
+			// Check that the int64 representation matches
+			if got := fileTime.ToInt64(); got != tc.expectedInt64 {
+				t.Errorf("ToInt64() = 0x%016x, want 0x%016x", got, tc.expectedInt64)
+			}
+
+			// Check that the high and low parts match
+			if fileTime.DwLowDateTime != tc.expectedLow {
+				t.Errorf("DwLowDateTime = 0x%08x, want 0x%08x", fileTime.DwLowDateTime, tc.expectedLow)
+			}
+
+			if fileTime.DwHighDateTime != tc.expectedHigh {
+				t.Errorf("DwHighDateTime = 0x%08x, want 0x%08x", fileTime.DwHighDateTime, tc.expectedHigh)
+			}
+
+			// Check that converting back to time.Time works correctly
+			if gotTime := fileTime.GetTime(); !gotTime.Equal(tc.inputTime) {
+				t.Errorf("GetTime() = %v, want %v", gotTime, tc.inputTime)
+			}
+		})
+	}
+}
+
+func TestFILETIME_MarshalUnmarshalInvolution(t *testing.T) {
+	// Create an FILETIME instance with known values
+	originalTime := &msdtyp.FILETIME{
+		DwLowDateTime:  0x55528a14,
+		DwHighDateTime: 0x01cc64ff,
+	}
+
+	// Marshal the FILETIME structure to bytes
+	marshalledData, err := originalTime.Marshal()
+	if err != nil {
+		t.Fatalf("Failed to marshal FILETIME: %v", err)
+	}
+
+	// Create a new FILETIME instance to unmarshal into
+	unmarshalledTime := &msdtyp.FILETIME{}
+
+	// Unmarshal the bytes back into the new instance
+	unmarshalledTime.Unmarshal(marshalledData)
+
+	// Verify that the original and unmarshalled instances have the same values
+	if originalTime.DwLowDateTime != unmarshalledTime.DwLowDateTime {
+		t.Errorf("LowPart values don't match: original=0x%x, unmarshalled=0x%x",
+			originalTime.DwLowDateTime, unmarshalledTime.DwLowDateTime)
+	}
+
+	if originalTime.DwHighDateTime != unmarshalledTime.DwHighDateTime {
+		t.Errorf("HighPart values don't match: original=0x%x, unmarshalled=0x%x",
+			originalTime.DwHighDateTime, unmarshalledTime.DwHighDateTime)
+	}
+
+	// Also verify that the int64 representation is preserved
+	if originalTime.ToInt64() != unmarshalledTime.ToInt64() {
+		t.Errorf("Int64 representations don't match: original=%d, unmarshalled=%d",
+			originalTime.ToInt64(), unmarshalledTime.ToInt64())
+	}
+
+	// And verify that the time representation is preserved
+	if originalTime.GetTime().Unix() != unmarshalledTime.GetTime().Unix() {
+		t.Errorf("Time representations don't match: original=%s, unmarshalled=%s",
+			originalTime.GetTime().String(), unmarshalledTime.GetTime().String())
+	}
+}

--- a/windows/ms-dtyp/FLOAT.go
+++ b/windows/ms-dtyp/FLOAT.go
@@ -1,0 +1,5 @@
+package msdtyp
+
+// A FLOAT is a base type that is specified the IEEE Format section of [C706].section 14.2.
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/73ba97b0-bbe5-483d-a0a8-46298ebcb160
+type FLOAT = float32

--- a/windows/ms-dtyp/GUID.go
+++ b/windows/ms-dtyp/GUID.go
@@ -1,0 +1,53 @@
+package msdtyp
+
+import (
+	"encoding/binary"
+
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+)
+
+// GUID is the [MS-DTYP] 2.3.4.2 GUID in its NDR-marshallable form: Data1 (4 octets),
+// Data2 (2), Data3 (2), and Data4 (8 opaque octets), for 16 octets total with 4-octet
+// alignment. Data1/2/3 are little-endian integers; Data4 is transmitted verbatim.
+//
+// The reflection walker cannot use windows/guid.GUID directly: its Go layout ends in a
+// uint64, which over-aligns the struct to 8 and inserts interior padding, so it would
+// marshal as 24 octets instead of 16. This type mirrors the wire layout exactly. Use
+// NewGUID / GUID to convert to and from windows/guid.GUID.
+//
+// Reference: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/49e490b8-f972-45d6-a3a4-99f924998d97
+type GUID struct {
+	Data1 uint32
+	Data2 uint16
+	Data3 uint16
+	Data4 [8]byte
+}
+
+// NewGUID converts a windows/guid.GUID to its NDR GUID form.
+func NewGUID(g guid.GUID) GUID {
+	b := g.ToBytes() // 16 octets: Data1/2/3 little-endian, Data4 verbatim
+	var x GUID
+	x.Data1 = binary.LittleEndian.Uint32(b[0:4])
+	x.Data2 = binary.LittleEndian.Uint16(b[4:6])
+	x.Data3 = binary.LittleEndian.Uint16(b[6:8])
+	copy(x.Data4[:], b[8:16])
+	return x
+}
+
+// GUID converts back to a windows/guid.GUID.
+func (g GUID) GUID() guid.GUID {
+	var b [16]byte
+	binary.LittleEndian.PutUint32(b[0:4], g.Data1)
+	binary.LittleEndian.PutUint16(b[4:6], g.Data2)
+	binary.LittleEndian.PutUint16(b[6:8], g.Data3)
+	copy(b[8:16], g.Data4[:])
+	var out guid.GUID
+	out.FromRawBytes(b[:])
+	return out
+}
+
+// String renders the GUID in the standard "D" format.
+func (g GUID) String() string {
+	w := g.GUID()
+	return w.ToFormatD()
+}

--- a/windows/ms-dtyp/GUID_test.go
+++ b/windows/ms-dtyp/GUID_test.go
@@ -1,0 +1,44 @@
+package msdtyp
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+)
+
+type guidWrap struct{ G GUID }
+
+// TestGUID_WireFormatFromGuidGUID verifies that a windows/guid.GUID generates the dtyp
+// NDR wire format: NewGUID(g) marshals to exactly 16 octets — identical to g.ToBytes()
+// — under both NDR20 and NDR64, and round-trips back to the original GUID.
+func TestGUID_WireFormatFromGuidGUID(t *testing.T) {
+	g, err := guid.FromString("11223344-5566-7788-99aa-bbccddeeff00")
+	if err != nil {
+		t.Fatalf("parse guid: %v", err)
+	}
+	want := g.ToBytes() // canonical 16-octet uuid_t wire form
+	if len(want) != 16 {
+		t.Fatalf("guid.ToBytes() = %d octets, want 16", len(want))
+	}
+
+	d := NewGUID(*g)
+	for _, s := range []ndr.Syntax{ndr.NDR20, ndr.NDR64} {
+		got, err := ndr.MarshalAs(&guidWrap{G: d}, s)
+		if err != nil {
+			t.Fatalf("%s marshal: %v", s, err)
+		}
+		if !bytes.Equal(got, want) {
+			t.Errorf("%s GUID wire form:\n got  %x\nwant %x", s, got, want)
+		}
+	}
+
+	// Round-trip: dtyp.GUID back to windows/guid.GUID.
+	if back := d.GUID(); !bytes.Equal(back.ToBytes(), want) {
+		t.Errorf("round trip: got %x want %x", back.ToBytes(), want)
+	}
+	if d.String() != "11223344-5566-7788-99aa-bbccddeeff00" {
+		t.Errorf("String() = %q", d.String())
+	}
+}

--- a/windows/ms-dtyp/HANDLE.go
+++ b/windows/ms-dtyp/HANDLE.go
@@ -1,0 +1,5 @@
+package msdtyp
+
+// HANDLE
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/929187f0-f25c-4b05-9497-16b066d8a912
+type HANDLE = uintptr

--- a/windows/ms-dtyp/HCALL.go
+++ b/windows/ms-dtyp/HCALL.go
@@ -1,0 +1,5 @@
+package msdtyp
+
+// HCALL
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/4958db44-2d75-4ccf-a4ba-3b8b1ec56360
+type HCALL = DWORD

--- a/windows/ms-dtyp/HRESULT.go
+++ b/windows/ms-dtyp/HRESULT.go
@@ -1,0 +1,5 @@
+package msdtyp
+
+// HRESULT
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/a9046ed2-bfb2-4d56-a719-2824afce59ac
+type HRESULT = LONG

--- a/windows/ms-dtyp/INT.go
+++ b/windows/ms-dtyp/INT.go
@@ -1,0 +1,5 @@
+package msdtyp
+
+// INT
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/2d70b269-ed8e-4a5d-8384-b3cd4d9e24f8
+type INT = int32

--- a/windows/ms-dtyp/INT16.go
+++ b/windows/ms-dtyp/INT16.go
@@ -1,0 +1,5 @@
+package msdtyp
+
+// INT16
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/c19c7f85-a511-4407-a7bf-5da9fa79d026
+type INT16 = int16

--- a/windows/ms-dtyp/INT32.go
+++ b/windows/ms-dtyp/INT32.go
@@ -1,0 +1,5 @@
+package msdtyp
+
+// INT32
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/b9218cdd-e76a-4c13-bb2d-c322dc39505b
+type INT32 = int32

--- a/windows/ms-dtyp/INT64.go
+++ b/windows/ms-dtyp/INT64.go
@@ -1,0 +1,5 @@
+package msdtyp
+
+// INT64
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/cfb2030b-0d7a-4808-8539-32f35bd9325f
+type INT64 = int64

--- a/windows/ms-dtyp/INT8.go
+++ b/windows/ms-dtyp/INT8.go
@@ -1,0 +1,5 @@
+package msdtyp
+
+// INT8
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/fc85cdcc-92f3-46ef-a2aa-501f44d0968a
+type INT8 = int8

--- a/windows/ms-dtyp/LARGE_INTEGER.go
+++ b/windows/ms-dtyp/LARGE_INTEGER.go
@@ -1,0 +1,10 @@
+package msdtyp
+
+// LARGE_INTEGER is the [MS-DTYP] 2.3.5 signed 64-bit integer. It is a named type rather
+// than a bare int64 so declarations read like the IDL and it carries 8-octet NDR
+// alignment ([C706] section 14.2.2).
+//
+// Reference: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/e904b1ba-f774-4203-ba1b-66485165ab1a
+type LARGE_INTEGER int64
+
+type PLARGE_INTEGER *LARGE_INTEGER

--- a/windows/ms-dtyp/LCID.go
+++ b/windows/ms-dtyp/LCID.go
@@ -1,0 +1,7 @@
+package msdtyp
+
+// A language code identifier structure is stored as a DWORD. The lower word contains the language identifier,
+// and the upper word contains both the sorting identifier (ID) and a reserved value. For additional details about
+// the structure and possible values, see [MS-LCID].
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/e8e4255f-5b6d-472b-8a98-ae3950bfdb9a
+type LCID = DWORD

--- a/windows/ms-dtyp/LDAP_UDP_HANDLE.go
+++ b/windows/ms-dtyp/LDAP_UDP_HANDLE.go
@@ -1,0 +1,5 @@
+package msdtyp
+
+// LDAP_UDP_HANDLE
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/b0e4f011-fea4-473f-a678-be5e5a33f4cf
+type LDAP_UDP_HANDLE = uintptr

--- a/windows/ms-dtyp/LMCSTR.go
+++ b/windows/ms-dtyp/LMCSTR.go
@@ -1,0 +1,5 @@
+package msdtyp
+
+// LMCSTR
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/34971db0-e83a-473e-aa5e-c4f3691c7f6d
+type LMCSTR = []WCHAR

--- a/windows/ms-dtyp/LMSTR.go
+++ b/windows/ms-dtyp/LMSTR.go
@@ -1,0 +1,5 @@
+package msdtyp
+
+// LMSTR
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/783140f9-5cb9-499e-a7a7-722214b27733
+type LMSTR = []WCHAR

--- a/windows/ms-dtyp/LONG.go
+++ b/windows/ms-dtyp/LONG.go
@@ -1,0 +1,6 @@
+package msdtyp
+
+// A LONG is a 32-bit signed integer, in twos-complement format (range: -2147483648 through 2147483647 decimal).
+// The first bit (Most Significant Bit (MSB)) is the signing bit.
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/29d44d70-382f-4998-9d76-8a1fe93e445c
+type LONG = int32

--- a/windows/ms-dtyp/LONG32.go
+++ b/windows/ms-dtyp/LONG32.go
@@ -1,0 +1,5 @@
+package msdtyp
+
+// A LONG32 is a 32-bit signed integer.
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/286e80a4-16fa-45d5-b97d-aeac136ef3f0
+type LONG32 = int32

--- a/windows/ms-dtyp/LONG64.go
+++ b/windows/ms-dtyp/LONG64.go
@@ -1,0 +1,5 @@
+package msdtyp
+
+// A LONG64 is a 64-bit signed integer.
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/7dc8dc9c-9d54-417a-933e-173933f0c329
+type LONG64 = int64

--- a/windows/ms-dtyp/LONGLONG.go
+++ b/windows/ms-dtyp/LONGLONG.go
@@ -1,0 +1,5 @@
+package msdtyp
+
+// A LONGLONG is a 64-bit signed integer (range: -9223372036854775808 through 9223372036854775807 decimal).
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/e34f8048-e2d0-4f5b-99fd-0b6489ee0295
+type LONGLONG = int64

--- a/windows/ms-dtyp/LONG_PTR.go
+++ b/windows/ms-dtyp/LONG_PTR.go
@@ -1,0 +1,5 @@
+package msdtyp
+
+// A LONG_PTR is a long type used for pointer precision. It is used when casting a pointer to a long type to perform pointer arithmetic.
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/bbcfb0af-8349-4e98-ad26-957e1363f714
+type LONG_PTR = uintptr

--- a/windows/ms-dtyp/LPCSTR.go
+++ b/windows/ms-dtyp/LPCSTR.go
@@ -1,0 +1,5 @@
+package msdtyp
+
+// An LPCSTR is a 32-bit pointer to a constant null-terminated string of 8-bit Windows (ANSI) characters.
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/f8d4fe46-6be8-44c9-8823-615a21d17a61
+type LPCSTR = *CHAR

--- a/windows/ms-dtyp/LPCVOID.go
+++ b/windows/ms-dtyp/LPCVOID.go
@@ -1,0 +1,5 @@
+package msdtyp
+
+// An LPCVOID is a 32-bit pointer to a constant of any type.
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/66996877-9dd4-477d-a811-30e6c1a5525d
+type LPCVOID = uintptr

--- a/windows/ms-dtyp/LPCWSTR.go
+++ b/windows/ms-dtyp/LPCWSTR.go
@@ -1,0 +1,5 @@
+package msdtyp
+
+// An LPCWSTR is a 32-bit pointer to a constant string of 16-bit Unicode characters, which MAY be null-terminated.
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/76f10dd8-699d-45e6-a53c-5aefc586da20
+type LPCWSTR = *WCHAR

--- a/windows/ms-dtyp/LPSTR.go
+++ b/windows/ms-dtyp/LPSTR.go
@@ -1,0 +1,8 @@
+package msdtyp
+
+// The LPSTR type and its alias PSTR specify a pointer to an array of 8-bit characters, which MAY be terminated by a null character.
+// In some protocols, it is acceptable to not terminate with a null character, and this option will be indicated in the specification. In this case, the LPSTR or PSTR type MUST either be tagged with the IDL modifier [string], that indicates string semantics, or be accompanied by an explicit length specifier, for example [size_is()].
+// The format of the characters MUST be specified by the protocol that uses them. Two common 8-bit formats are ANSI and UTF-8.
+// A 32-bit pointer to a string of 8-bit characters, which MAY be null-terminated.
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/3f6cc0e2-1303-4088-a26b-fb9582f29197
+type LPSTR = *CHAR

--- a/windows/ms-dtyp/LPWSTR.go
+++ b/windows/ms-dtyp/LPWSTR.go
@@ -1,0 +1,11 @@
+package msdtyp
+
+// The LPWSTR type is a 32-bit pointer to a string of 16-bit Unicode characters, which MAY be null-terminated.
+// The LPWSTR type specifies a pointer to a sequence of Unicode characters, which MAY be terminated by a null character
+// (usually referred to as "null-terminated Unicode").
+// In some protocols, an acceptable option is to not terminate a sequence of Unicode characters with a null character.
+// Where this option applies, it is indicated in the protocol specification. In this situation, the LPWSTR or PWSTR type
+// MUST either be tagged with the IDL modifier [string], which indicates string semantics, or MUST be accompanied by an
+// explicit length specifier, as specified in the RPC_UNICODE_STRING (section 2.3.10) structure.
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/50e9ef83-d6fd-4e22-a34a-2c6b4e3c24f3
+type LPWSTR = *WCHAR

--- a/windows/ms-dtyp/LUID.go
+++ b/windows/ms-dtyp/LUID.go
@@ -1,0 +1,23 @@
+package msdtyp
+
+// The LUID structure is 64-bit value guaranteed to be unique only on the system on which it was generated.
+// The uniqueness of a locally unique identifier (LUID) is guaranteed only until the system is restarted.
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/48cbee2a-0790-45f2-8269-931d7083b2c3
+type LUID struct {
+	// LowPart: The low-order bits of the structure.
+	LowPart DWORD
+	// HighPart: The high-order bits of the structure.
+	HighPart LONG
+}
+
+type PLUID *LUID
+
+// Uint64 returns the LUID as a single 64-bit value (HighPart in the upper 32 bits).
+func (l LUID) Uint64() uint64 {
+	return uint64(uint32(l.HighPart))<<32 | uint64(l.LowPart)
+}
+
+// LUIDFromUint64 splits a 64-bit value into a LUID.
+func LUIDFromUint64(v uint64) LUID {
+	return LUID{LowPart: uint32(v), HighPart: int32(v >> 32)}
+}

--- a/windows/ms-dtyp/MULTI_SZ.go
+++ b/windows/ms-dtyp/MULTI_SZ.go
@@ -1,0 +1,13 @@
+package msdtyp
+
+// The MULTI_SZ structure defines an implementation-specific type that contains a sequence of null-terminated strings,
+// terminated by an empty string (\0) so that the last two characters are both null terminators.
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/fd7b2d81-b1d7-414f-a3df-c66fabc578db
+type MULTI_SZ struct {
+	// Value: A data buffer, which is a string literal containing multiple null-terminated strings serially.
+	Value WCHAR
+	// NChar: The length, in characters, including the two terminating nulls.
+	NChar DWORD
+}
+
+type PMULTI_SZ *MULTI_SZ

--- a/windows/ms-dtyp/NET_API_STATUS.go
+++ b/windows/ms-dtyp/NET_API_STATUS.go
@@ -1,0 +1,5 @@
+package msdtyp
+
+// NET_API_STATUS
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/19cdb498-c67b-42b7-a540-4bc6a73c04f6
+type NET_API_STATUS = DWORD

--- a/windows/ms-dtyp/NTSTATUS.go
+++ b/windows/ms-dtyp/NTSTATUS.go
@@ -1,0 +1,7 @@
+package msdtyp
+
+// NTSTATUS is a standard 32-bit datatype for system-supplied status code values.
+// NTSTATUS values are used to communicate system information. They are of four types:
+// success values, information values, warnings, and error values, as specified in [MS-ERREF].
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/c8b512d5-70b1-4028-95f1-ec92d35cb51e
+type NTSTATUS = LONG

--- a/windows/ms-dtyp/OBJECT_TYPE_LIST.go
+++ b/windows/ms-dtyp/OBJECT_TYPE_LIST.go
@@ -1,0 +1,17 @@
+package msdtyp
+
+// OBJECT_TYPE_LIST
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/6f04f1f2-d070-4f70-aae7-5f98ed63e1ba
+type OBJECT_TYPE_LIST struct {
+	// Level: Specifies the level of the object type in the hierarchy of an object and its sub-objects. Level zero
+	// indicates the object itself. Level one indicates a sub-object of the object, such as a property set. Level two
+	// indicates a sub-object of the level one sub-object, such as a property. There can be a maximum of five levels
+	// numbered zero through four.
+	Level WORD
+	// Remaining: Remaining access bits for this element, used by the access check algorithm, as specified in section 2.5.3.2.
+	Remaining UINT32 // ACCESS_MASK
+	// ObjectType: A pointer to the GUID for the object or sub-object.
+	ObjectType *GUID
+}
+
+type POBJECT_TYPE_LIST *OBJECT_TYPE_LIST

--- a/windows/ms-dtyp/PCONTEXT_HANDLE.go
+++ b/windows/ms-dtyp/PCONTEXT_HANDLE.go
@@ -1,0 +1,8 @@
+package msdtyp
+
+// The PCONTEXT_HANDLE type keeps state information associated with a given client on a server. The state information is called the server's context. Clients can obtain a context handle to identify the server's context for their individual RPC sessions.
+// A context handle must be of the void * type, or a type that resolves to void *. The server program casts it to the required type.
+// The IDL attribute [context_handle], as specified in [C706], is used to declare PCONTEXT_HANDLE.
+// An interface that uses a context handle must have a binding handle for the initial binding, which has to take place before the server can return a context handle. The handle_t type is one of the predefined types of the interface definition language (IDL), which is used to create a binding handle.
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/b8d08028-e73f-4bb8-b3bf-bc8ba4734c4c
+type PCONTEXT_HANDLE = uintptr

--- a/windows/ms-dtyp/QWORD.go
+++ b/windows/ms-dtyp/QWORD.go
@@ -1,0 +1,5 @@
+package msdtyp
+
+// A QWORD is a 64-bit unsigned integer.
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/ac050bbf-a821-4fab-bccf-d95d892f428f
+type QWORD = uint64

--- a/windows/ms-dtyp/RPC_BINDING_HANDLE.go
+++ b/windows/ms-dtyp/RPC_BINDING_HANDLE.go
@@ -1,0 +1,6 @@
+package msdtyp
+
+// An RPC_BINDING_HANDLE is an untyped 32-bit pointer containing information that the RPC run-time library uses to access binding information.
+// It is directly equivalent to the type rpc_binding_handle_t described in [C706] section 3.1.4.
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/d0dffa33-812f-4214-a987-4ee149328eec
+type RPC_BINDING_HANDLE = uintptr

--- a/windows/ms-dtyp/RPC_SID.go
+++ b/windows/ms-dtyp/RPC_SID.go
@@ -1,0 +1,92 @@
+package msdtyp
+
+import (
+	"encoding/binary"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// RPC_SID is the [MS-DTYP] 2.4.2.3 marshallable security identifier. The SubAuthority
+// member is a conformant array whose element count is given by SubAuthorityCount, so
+// NDR hoists its maximum_count to the front of the structure ([C706] section 14.3.3.1);
+// the walker derives both the hoisted count and SubAuthorityCount from the slice length,
+// so callers set only SubAuthority (or use ParseSID).
+//
+// IdentifierAuthority is a 6-octet big-endian value transmitted verbatim ([MS-DTYP]
+// 2.4.1 RPC_SID_IDENTIFIER_AUTHORITY). SubAuthorityCount is capped at 15 by the spec.
+//
+// Reference: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/5cb97814-a1c2-4215-b7dc-76d1f4bfad01
+type RPC_SID struct {
+	Revision            uint8
+	SubAuthorityCount   uint8
+	IdentifierAuthority [6]byte
+	SubAuthority        []uint32 `ndr:"conformant,size_is=SubAuthorityCount"`
+}
+
+// authority returns the 48-bit identifier authority as a single value.
+func (s RPC_SID) authority() uint64 {
+	var b [8]byte
+	copy(b[2:], s.IdentifierAuthority[:])
+	return binary.BigEndian.Uint64(b[:])
+}
+
+// String renders the SID in the standard "S-R-I-S1-S2-…" textual form ([MS-DTYP]
+// 2.4.2.1 SID String Format): authorities below 2^32 are decimal, larger ones hex.
+func (s RPC_SID) String() string {
+	auth := s.authority()
+	var b strings.Builder
+	b.WriteString("S-")
+	b.WriteString(strconv.FormatUint(uint64(s.Revision), 10))
+	b.WriteString("-")
+	if auth >= 1<<32 {
+		b.WriteString("0x")
+		b.WriteString(strconv.FormatUint(auth, 16))
+	} else {
+		b.WriteString(strconv.FormatUint(auth, 10))
+	}
+	for _, sub := range s.SubAuthority {
+		b.WriteString("-")
+		b.WriteString(strconv.FormatUint(uint64(sub), 10))
+	}
+	return b.String()
+}
+
+// ParseSID parses a textual SID ("S-1-5-21-…") into an RPC_SID, setting Revision,
+// IdentifierAuthority, and the SubAuthority array (SubAuthorityCount is derived on
+// marshal). The identifier authority may be decimal or 0x-prefixed hexadecimal.
+func ParseSID(s string) (RPC_SID, error) {
+	parts := strings.Split(s, "-")
+	if len(parts) < 3 || parts[0] != "S" {
+		return RPC_SID{}, fmt.Errorf("dtyp: invalid SID %q", s)
+	}
+	rev, err := strconv.ParseUint(parts[1], 10, 8)
+	if err != nil {
+		return RPC_SID{}, fmt.Errorf("dtyp: invalid SID revision in %q: %w", s, err)
+	}
+	var auth uint64
+	if strings.HasPrefix(parts[2], "0x") || strings.HasPrefix(parts[2], "0X") {
+		auth, err = strconv.ParseUint(parts[2][2:], 16, 48)
+	} else {
+		auth, err = strconv.ParseUint(parts[2], 10, 48)
+	}
+	if err != nil {
+		return RPC_SID{}, fmt.Errorf("dtyp: invalid SID authority in %q: %w", s, err)
+	}
+	subs := parts[3:]
+	if len(subs) > 15 {
+		return RPC_SID{}, fmt.Errorf("dtyp: SID %q has %d sub-authorities, max 15", s, len(subs))
+	}
+	sid := RPC_SID{Revision: uint8(rev), SubAuthorityCount: uint8(len(subs))}
+	var ab [8]byte
+	binary.BigEndian.PutUint64(ab[:], auth)
+	copy(sid.IdentifierAuthority[:], ab[2:])
+	for _, p := range subs {
+		v, err := strconv.ParseUint(p, 10, 32)
+		if err != nil {
+			return RPC_SID{}, fmt.Errorf("dtyp: invalid SID sub-authority %q in %q: %w", p, s, err)
+		}
+		sid.SubAuthority = append(sid.SubAuthority, uint32(v))
+	}
+	return sid, nil
+}

--- a/windows/ms-dtyp/RPC_UNICODE_STRING.go
+++ b/windows/ms-dtyp/RPC_UNICODE_STRING.go
@@ -1,0 +1,52 @@
+package msdtyp
+
+import "unicode/utf16"
+
+// RPC_UNICODE_STRING is the [MS-DTYP] 2.3.10 counted Unicode string. It is the single
+// most common string carrier in the LSA/SAMR interfaces and, unlike a bare NDR wide
+// string, cannot be modeled by ndr.WSTR because of a byte-vs-char gotcha:
+//
+//   - Length and MaximumLength are counts in BYTES (each must be even), whereas
+//   - Buffer is a [unique] pointer to a conformant-varying array of wchar whose
+//     maximum_count is MaximumLength/2 and actual_count is Length/2 — counts in CHARS.
+//
+// The buffer carries no NUL terminator (it is a [size_is/length_is] array, not an NDR
+// [string]). Modeling Buffer as a []uint16 tagged "unique,varying" lets the walker emit
+// the referent id inline and the char-counted conformant-varying body deferred, so the
+// buffers of an array of RPC_UNICODE_STRING are correctly emitted after the whole array
+// (see issue #419).
+//
+// The size_is/length_is divisor tags resolve the wchar array's maximum_count to
+// MaximumLength/2 and actual_count to Length/2, which differ from len(Buffer) whenever
+// the buffer is over-allocated (MaximumLength > Length, as a server may advertise). Use
+// NewUnicodeString to set the byte counts and buffer together.
+//
+// Reference: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/94a16bb6-c610-4cb9-8db6-26f15f560061
+type RPC_UNICODE_STRING struct {
+	Length        uint16   // length of the string in bytes, excluding any terminator
+	MaximumLength uint16   // size of Buffer in bytes
+	Buffer        []uint16 `ndr:"unique,varying,size_is=MaximumLength/2,length_is=Length/2"`
+}
+
+// NewUnicodeString builds an RPC_UNICODE_STRING from a Go string, encoding it to UTF-16
+// and setting Length and MaximumLength to the byte count (2 per code unit). An empty
+// string yields a zero-length value with a NULL Buffer, matching the Windows
+// representation of an empty counted string.
+func NewUnicodeString(s string) RPC_UNICODE_STRING {
+	if s == "" {
+		return RPC_UNICODE_STRING{}
+	}
+	units := utf16.Encode([]rune(s))
+	n := uint16(len(units) * 2)
+	return RPC_UNICODE_STRING{Length: n, MaximumLength: n, Buffer: units}
+}
+
+// String decodes the Buffer (truncated to Length/2 code units, as Length governs the
+// valid portion) back to a Go string.
+func (u RPC_UNICODE_STRING) String() string {
+	units := u.Buffer
+	if n := int(u.Length / 2); n < len(units) {
+		units = units[:n]
+	}
+	return string(utf16.Decode(units))
+}

--- a/windows/ms-dtyp/SERVER_INFO_100.go
+++ b/windows/ms-dtyp/SERVER_INFO_100.go
@@ -1,0 +1,13 @@
+package msdtyp
+
+// SERVER_INFO_100
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/007c654b-7d78-49d4-9f4d-0da7c1889727
+type SERVER_INFO_100 struct {
+	// Sv100PlatformId: The platform ID.
+	Sv100PlatformId DWORD
+	// Sv100Name: The server name.
+	Sv100Name WCHAR
+}
+
+type PSERVER_INFO_100 *SERVER_INFO_100
+type LPSERVER_INFO_100 *SERVER_INFO_100

--- a/windows/ms-dtyp/SERVER_INFO_101.go
+++ b/windows/ms-dtyp/SERVER_INFO_101.go
@@ -1,0 +1,24 @@
+package msdtyp
+
+// SERVER_INFO_101
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/39c502dd-022b-4a68-9367-89fd76a23bc3
+type SERVER_INFO_101 struct {
+	// sv101_platform_id: Specifies the information level to use for platform-specific information.
+	Sv101PlatformId DWORD
+	// sv101_name: A pointer to a null-terminated Unicode UTF-16 Internet host name or NetBIOS host name of a server.
+	Sv101Name STRING
+	// sv101_version_major: Specifies the major release version number of the operating system. The server MUST set this
+	// field to an implementation-specific major release version number that corresponds to the host operating system as
+	// specified in the following table.
+	Sv101VersionMajor DWORD
+	// sv101_version_minor: Specifies the minor release version number of the operating system. The server MUST set this
+	// field to an implementation-specific minor release version number that corresponds to the host operating system as
+	// specified in the following table.
+	Sv101VersionMinor DWORD
+	// sv101_version_type: The sv101_version_type field specifies the SV_TYPE flags, which indicate the software services
+	// that are available (but not necessarily running) on the server. This member MUST be a combination of one or more of
+	// the following values.
+	Sv101VersionType DWORD
+	// sv101_comment: A pointer to a null-terminated Unicode UTF-16 string that specifies a comment that describes the server.
+	Sv101Comment STRING
+}

--- a/windows/ms-dtyp/SHORT.go
+++ b/windows/ms-dtyp/SHORT.go
@@ -1,0 +1,5 @@
+package msdtyp
+
+// A SHORT is a 16-bit signed integer(range: -32768 through 32767 decimal). The first bit (Most Significant Bit (MSB)) is the signing bit.
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/47b1e7d6-b5a1-48c3-986e-b5e5eb3f06d2
+type SHORT = int16

--- a/windows/ms-dtyp/SIZE_T.go
+++ b/windows/ms-dtyp/SIZE_T.go
@@ -1,0 +1,5 @@
+package msdtyp
+
+// SIZE_T is a ULONG_PTR representing the maximum number of bytes to which a pointer can point.
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/1dc2ff19-6fef-4c5f-b4fd-afbc2557fd81
+type SIZE_T = ULONG_PTR

--- a/windows/ms-dtyp/STRING.go
+++ b/windows/ms-dtyp/STRING.go
@@ -1,0 +1,5 @@
+package msdtyp
+
+// Unless otherwise noted, a STRING is a UCHAR buffer that represents a null-terminated string of 8-bit characters.
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/08460486-bacc-48af-8520-195ff7f80db5
+type STRING = []UCHAR

--- a/windows/ms-dtyp/SYSTEMTIME.go
+++ b/windows/ms-dtyp/SYSTEMTIME.go
@@ -1,0 +1,24 @@
+package msdtyp
+
+// SYSTEMTIME
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/2fefe8dd-ab48-4e33-a7d5-7171455a9289
+type SYSTEMTIME struct {
+	// WYear: The year.
+	WYear WORD
+	// WMonth: The month.
+	WMonth WORD
+	// WDayOfWeek: The day of the week.
+	WDayOfWeek WORD
+	// WDay: The day.
+	WDay WORD
+	// WHour: The hour.
+	WHour WORD
+	// WMinute: The minute.
+	WMinute WORD
+	// WSecond: The second.
+	WSecond WORD
+	// WMilliseconds: The milliseconds.
+	WMilliseconds WORD
+}
+
+type PSYSTEMTIME *SYSTEMTIME

--- a/windows/ms-dtyp/UCHAR.go
+++ b/windows/ms-dtyp/UCHAR.go
@@ -1,0 +1,5 @@
+package msdtyp
+
+// A UCHAR is an 8-bit integer with the range: 0 through 255 decimal. Because a UCHAR is unsigned, its first bit (Most Significant Bit (MSB)) is not reserved for signing.
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/050baef1-f978-4851-a3c7-ad701a90e54a
+type UCHAR = uint8

--- a/windows/ms-dtyp/UINT.go
+++ b/windows/ms-dtyp/UINT.go
@@ -1,0 +1,6 @@
+package msdtyp
+
+// A UINT is a 32-bit unsigned integer (range: 0 through 4294967295 decimal).
+// Because a UINT is unsigned, its first bit (Most Significant Bit (MSB)) is not reserved for signing.
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/52ddd4c3-55b9-4e03-8287-5392aac0627f
+type UINT = uint32

--- a/windows/ms-dtyp/UINT128.go
+++ b/windows/ms-dtyp/UINT128.go
@@ -1,0 +1,12 @@
+package msdtyp
+
+// UINT128
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/3b5c1a61-ece4-4dce-9c9f-c15388ba9032
+type UINT128 struct {
+	// Lower: The lower 64 bits of the 128-bit value.
+	Lower UINT64
+	// Upper: The upper 64 bits of the 128-bit value.
+	Upper UINT64
+}
+
+type PUINT128 *UINT128

--- a/windows/ms-dtyp/UINT16.go
+++ b/windows/ms-dtyp/UINT16.go
@@ -1,0 +1,5 @@
+package msdtyp
+
+// A UINT16 is a 16-bit unsigned integer (range: 0 through 65535 decimal). Because a UINT16 is unsigned, its first bit (Most Significant Bit (MSB)) is not reserved for signing.
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/6c1609ad-8592-45d3-9dfa-38e6a30ff203
+type UINT16 = uint16

--- a/windows/ms-dtyp/UINT32.go
+++ b/windows/ms-dtyp/UINT32.go
@@ -1,0 +1,6 @@
+package msdtyp
+
+// A UINT32 is a 32-bit unsigned integer (range: 0 through 4294967295 decimal).
+// Because a UINT32 is unsigned, its first bit (Most Significant Bit (MSB)) is not reserved for signing.
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/362b8d72-2245-4c33-84a8-08c69f4c302f
+type UINT32 = uint32

--- a/windows/ms-dtyp/UINT64.go
+++ b/windows/ms-dtyp/UINT64.go
@@ -1,0 +1,6 @@
+package msdtyp
+
+// A UINT64 is a 64-bit unsigned integer (range: 0 through 18446744073709551615 decimal).
+// Because a UINT64 is unsigned, its first bit (Most Significant Bit (MSB)) is not reserved for signing.
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/a7b7720f-87eb-4add-9bcb-c6ff652778ae
+type UINT64 = uint64

--- a/windows/ms-dtyp/UINT8.go
+++ b/windows/ms-dtyp/UINT8.go
@@ -1,0 +1,6 @@
+package msdtyp
+
+// A UINT8 is an 8-bit unsigned integer (range: 0 through 255 decimal).
+// Because a UINT8 is unsigned, its first bit (Most Significant Bit (MSB)) is not reserved for signing.
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/a88ed362-a905-4ed2-85f5-cfc8692c9842
+type UINT8 = uint8

--- a/windows/ms-dtyp/ULARGE_INTEGER.go
+++ b/windows/ms-dtyp/ULARGE_INTEGER.go
@@ -1,0 +1,10 @@
+package msdtyp
+
+// ULARGE_INTEGER is the [MS-DTYP] 2.3.13 unsigned 64-bit integer. It is a named type
+// rather than a bare uint64 so declarations read like the IDL and it carries 8-octet NDR
+// alignment ([C706] section 14.2.2).
+//
+// Reference: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/d7e6e5a5-6c77-4ae6-9bd5-3892b3c4641e
+type ULARGE_INTEGER uint64
+
+type PULARGE_INTEGER *ULARGE_INTEGER

--- a/windows/ms-dtyp/ULONG.go
+++ b/windows/ms-dtyp/ULONG.go
@@ -1,0 +1,5 @@
+package msdtyp
+
+// A ULONG is a 32-bit unsigned integer (range: 0 through 4294967295 decimal). Because a ULONG is unsigned, its first bit (Most Significant Bit (MSB)) is not reserved for signing.
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/32862b84-f6e6-40f9-85ca-c4faf985b822
+type ULONG = uint32

--- a/windows/ms-dtyp/ULONG32.go
+++ b/windows/ms-dtyp/ULONG32.go
@@ -1,0 +1,5 @@
+package msdtyp
+
+// A ULONG32 is an unsigned LONG32.
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/c9346e52-0765-4247-ab74-89c24ad3517b
+type ULONG32 = uint32

--- a/windows/ms-dtyp/ULONG64.go
+++ b/windows/ms-dtyp/ULONG64.go
@@ -1,0 +1,6 @@
+package msdtyp
+
+// A ULONG64 is a 64-bit unsigned integer (range: 0 through 18446744073709551615 decimal).
+// Because a ULONG64 is unsigned, its first bit (Most Significant Bit (MSB)) is not reserved for signing.
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/2dc4c492-95db-4fa6-ae2b-8546b13c9141
+type ULONG64 = uint64

--- a/windows/ms-dtyp/ULONGLONG.go
+++ b/windows/ms-dtyp/ULONGLONG.go
@@ -1,0 +1,6 @@
+package msdtyp
+
+// A ULONGLONG is a 64-bit unsigned integer (range: 0 through 18446744073709551615 decimal).
+// Because a ULONGLONG is unsigned, its first bit (Most Significant Bit (MSB)) is not reserved for signing.
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/c57d9fba-12ef-4853-b0d5-a6f472b50388
+type ULONGLONG = uint64

--- a/windows/ms-dtyp/ULONG_PTR.go
+++ b/windows/ms-dtyp/ULONG_PTR.go
@@ -1,0 +1,5 @@
+package msdtyp
+
+// A ULONG_PTR is an unsigned long type used for pointer precision. It is used when casting a pointer to a long type to perform pointer arithmetic.
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/21eec394-630d-49ed-8b4a-ab74a1614611
+type ULONG_PTR = uintptr

--- a/windows/ms-dtyp/UNC.go
+++ b/windows/ms-dtyp/UNC.go
@@ -1,0 +1,5 @@
+package msdtyp
+
+// UNC
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/62e862f4-2a51-452e-8eeb-dc4ff5ee33cc
+type UNC = string

--- a/windows/ms-dtyp/UNICODE.go
+++ b/windows/ms-dtyp/UNICODE.go
@@ -1,0 +1,5 @@
+package msdtyp
+
+// A single Unicode character.
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/845b6fa4-c34a-4b90-824d-60e98533dfb5
+type UNICODE = uint16

--- a/windows/ms-dtyp/USHORT.go
+++ b/windows/ms-dtyp/USHORT.go
@@ -1,0 +1,5 @@
+package msdtyp
+
+// A USHORT is a 16-bit unsigned integer (range: 0 through 65535 decimal). Because a USHORT is unsigned, its first bit (Most Significant Bit (MSB)) is not reserved for signing.
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/c0618c5b-362b-4e06-9cb0-8720d240cf12
+type USHORT = uint16

--- a/windows/ms-dtyp/VOID.go
+++ b/windows/ms-dtyp/VOID.go
@@ -1,0 +1,5 @@
+package msdtyp
+
+// VOID is an alias for void.
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/c0b7741b-f577-4eed-aff3-2e909df10a4d
+type VOID = struct{}

--- a/windows/ms-dtyp/WCHAR.go
+++ b/windows/ms-dtyp/WCHAR.go
@@ -1,0 +1,5 @@
+package msdtyp
+
+// A WCHAR is a 16-bit Unicode character.
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/7df7c1d5-492c-4db4-a992-5cd9e887c5d7
+type WCHAR = UNICODE

--- a/windows/ms-dtyp/WORD.go
+++ b/windows/ms-dtyp/WORD.go
@@ -1,0 +1,6 @@
+package msdtyp
+
+// A WORD is a 16-bit unsigned integer (range: 0 through 65535 decimal).
+// Because a WORD is unsigned, its first bit (Most Significant Bit (MSB)) is not reserved for signing.
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/f8573df3-a44a-4a50-b070-ac4c3aa78e3c
+type WORD = uint16

--- a/windows/ms-dtyp/doc.go
+++ b/windows/ms-dtyp/doc.go
@@ -1,0 +1,21 @@
+// Package msdtyp provides the [MS-DTYP] Windows Data Types as a single canonical set of
+// Go types shared across the codebase: the DCE/RPC interfaces and protocols (which
+// marshal them with the reflection walker in network/dcerpc/ndr via the struct tags on
+// these types), and the fixed-layout consumers (SMB, Active Directory replication).
+//
+// The package is intentionally dependency-light: it imports only windows/guid and the
+// standard library, never network/dcerpc/ndr. The `ndr:"..."` struct tags are inert
+// string metadata that the external NDR walker interprets; they do not couple this
+// package to the codec, so non-RPC consumers can reuse the same definitions without
+// pulling in the RPC stack.
+//
+// It contains the scalar type aliases ([MS-DTYP] 2.2, e.g. DWORD, WORD, WCHAR, ULONG),
+// the common structures ([MS-DTYP] 2.3, e.g. GUID, RPC_SID, RPC_UNICODE_STRING, LUID,
+// FILETIME, SYSTEMTIME, LARGE_INTEGER), and their conversion/formatting helpers.
+//
+// References:
+//   - [MS-DTYP] Windows Data Types:
+//     https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/cca27429-5689-4a16-b2b4-9325d93e4ba2
+//   - [C706] DCE 1.1: RPC, Chapter 14 "Transfer Syntax NDR":
+//     https://pubs.opengroup.org/onlinepubs/9629399/chap14.htm
+package msdtyp

--- a/windows/ms-dtyp/dtyp_roundtrip_test.go
+++ b/windows/ms-dtyp/dtyp_roundtrip_test.go
@@ -1,0 +1,276 @@
+package msdtyp
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+)
+
+func TestLUID_RoundTrip(t *testing.T) {
+	type rec struct{ ID LUID }
+	in := &rec{ID: LUID{LowPart: 0x11223344, HighPart: -2}}
+	raw, err := ndr.Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var out rec
+	if err := ndr.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out.ID != in.ID {
+		t.Errorf("round trip: got %+v want %+v", out.ID, in.ID)
+	}
+	if got := LUIDFromUint64(in.ID.Uint64()); got != in.ID {
+		t.Errorf("Uint64 round trip: got %+v want %+v", got, in.ID)
+	}
+}
+
+func TestFILETIME_GoldenAndRoundTrip(t *testing.T) {
+	type rec struct{ T FILETIME }
+	in := &rec{T: FILETIME{DwLowDateTime: 0x11223344, DwHighDateTime: 0x55667788}}
+	raw, err := ndr.Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	// Two 32-bit LE words, low half first ([MS-DTYP] 2.3.3).
+	want := []byte{0x44, 0x33, 0x22, 0x11, 0x88, 0x77, 0x66, 0x55}
+	if !bytes.Equal(raw, want) {
+		t.Errorf("FILETIME wire = % x, want % x", raw, want)
+	}
+	var out rec
+	if err := ndr.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out.T != in.T {
+		t.Errorf("FILETIME round-trip: got %+v want %+v", out.T, in.T)
+	}
+	if got := in.T.Uint64(); got != 0x5566778811223344 {
+		t.Errorf("FILETIME.Uint64() = %#x", got)
+	}
+}
+
+func TestSYSTEMTIME_GoldenAndRoundTrip(t *testing.T) {
+	type rec struct{ T SYSTEMTIME }
+	in := &rec{T: SYSTEMTIME{
+		WYear: 2026, WMonth: 7, WDayOfWeek: 4, WDay: 2,
+		WHour: 13, WMinute: 30, WSecond: 15, WMilliseconds: 500,
+	}}
+	raw, err := ndr.Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	// Eight 16-bit LE fields in declaration order ([MS-DTYP] 2.3.13).
+	want := []byte{
+		0xEA, 0x07, 0x07, 0x00, 0x04, 0x00, 0x02, 0x00,
+		0x0D, 0x00, 0x1E, 0x00, 0x0F, 0x00, 0xF4, 0x01,
+	}
+	if !bytes.Equal(raw, want) {
+		t.Errorf("SYSTEMTIME wire = % x, want % x", raw, want)
+	}
+	var out rec
+	if err := ndr.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out.T != in.T {
+		t.Errorf("SYSTEMTIME round-trip: got %+v want %+v", out.T, in.T)
+	}
+}
+
+func TestLargeInteger_RoundTrip(t *testing.T) {
+	type rec struct {
+		Q LARGE_INTEGER
+		U ULARGE_INTEGER
+	}
+	in := &rec{Q: -123456789, U: 0xDEADBEEFCAFE}
+	raw, err := ndr.Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var out rec
+	if err := ndr.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out != *in {
+		t.Errorf("round trip: got %+v want %+v", out, *in)
+	}
+}
+
+func TestRPC_SID_GoldenAndRoundTrip(t *testing.T) {
+	sid, err := ParseSID("S-1-5-21-1-2-3")
+	if err != nil {
+		t.Fatalf("ParseSID: %v", err)
+	}
+	raw, err := ndr.Marshal(&sid)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	want := []byte{
+		0x04, 0, 0, 0, // hoisted maximum_count (SubAuthorityCount)
+		0x01,                               // Revision
+		0x04,                               // SubAuthorityCount (derived from slice len)
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x05, // IdentifierAuthority (6-octet big-endian = 5)
+		0x15, 0, 0, 0, // SubAuthority[0] = 21
+		0x01, 0, 0, 0, // SubAuthority[1] = 1
+		0x02, 0, 0, 0, // SubAuthority[2] = 2
+		0x03, 0, 0, 0, // SubAuthority[3] = 3
+	}
+	if !bytes.Equal(raw, want) {
+		t.Errorf("RPC_SID:\n got %x\nwant %x", raw, want)
+	}
+	var out RPC_SID
+	if err := ndr.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got := out.String(); got != "S-1-5-21-1-2-3" {
+		t.Errorf("String: got %q want %q", got, "S-1-5-21-1-2-3")
+	}
+}
+
+func TestRPC_UNICODE_STRING_GoldenAndRoundTrip(t *testing.T) {
+	u := NewUnicodeString("Hi")
+	if u.Length != 4 || u.MaximumLength != 4 {
+		t.Fatalf("NewUnicodeString counts: got Length=%d MaximumLength=%d want 4/4", u.Length, u.MaximumLength)
+	}
+	raw, err := ndr.Marshal(&u)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	want := []byte{
+		0x04, 0x00, // Length (bytes)
+		0x04, 0x00, // MaximumLength (bytes)
+		0x00, 0x00, 0x02, 0x00, // Buffer referent id
+		0x02, 0, 0, 0, // buffer maximum_count (chars)
+		0x00, 0, 0, 0, // offset
+		0x02, 0, 0, 0, // actual_count (chars)
+		0x48, 0x00, 0x69, 0x00, // 'H', 'i'
+	}
+	if !bytes.Equal(raw, want) {
+		t.Errorf("RPC_UNICODE_STRING:\n got %x\nwant %x", raw, want)
+	}
+	var out RPC_UNICODE_STRING
+	if err := ndr.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got := out.String(); got != "Hi" {
+		t.Errorf("String: got %q want %q", got, "Hi")
+	}
+}
+
+// TestRPC_UNICODE_STRING_OverAllocated covers the spec-legal case where MaximumLength
+// (buffer capacity in bytes) exceeds Length (valid chars in bytes). Per [MS-DTYP] 2.3.10
+// the wchar array's maximum_count must be MaximumLength/2 and actual_count Length/2,
+// independent of len(Buffer); only the valid Length/2 chars are transmitted.
+func TestRPC_UNICODE_STRING_OverAllocated(t *testing.T) {
+	// "Hi" valid (Length=4), capacity for 5 wchars (MaximumLength=10), buffer carries
+	// the two valid chars plus reserved slots.
+	u := RPC_UNICODE_STRING{Length: 4, MaximumLength: 10, Buffer: []uint16{'H', 'i', 0, 0, 0}}
+	raw, err := ndr.Marshal(&u)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	want := []byte{
+		0x04, 0x00, // Length (bytes)
+		0x0a, 0x00, // MaximumLength (bytes)
+		0x00, 0x00, 0x02, 0x00, // Buffer referent id
+		0x05, 0, 0, 0, // maximum_count = MaximumLength/2 = 5
+		0x00, 0, 0, 0, // offset
+		0x02, 0, 0, 0, // actual_count = Length/2 = 2
+		0x48, 0x00, 0x69, 0x00, // 'H', 'i' — only the valid chars
+	}
+	if !bytes.Equal(raw, want) {
+		t.Errorf("over-allocated RPC_UNICODE_STRING:\n got %x\nwant %x", raw, want)
+	}
+	var out RPC_UNICODE_STRING
+	if err := ndr.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out.Length != 4 || out.MaximumLength != 10 {
+		t.Errorf("counts: got Length=%d MaximumLength=%d want 4/10", out.Length, out.MaximumLength)
+	}
+	if got := out.String(); got != "Hi" {
+		t.Errorf("String: got %q want %q", got, "Hi")
+	}
+}
+
+func TestRPC_UNICODE_STRING_Empty(t *testing.T) {
+	u := NewUnicodeString("")
+	raw, err := ndr.Marshal(&u)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	// Length=0, MaximumLength=0, Buffer=NULL referent.
+	want := []byte{0, 0, 0, 0, 0, 0, 0, 0}
+	if !bytes.Equal(raw, want) {
+		t.Errorf("empty RPC_UNICODE_STRING:\n got %x\nwant %x", raw, want)
+	}
+	var out RPC_UNICODE_STRING
+	if err := ndr.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got := out.String(); got != "" {
+		t.Errorf("String: got %q want empty", got)
+	}
+}
+
+// TestArrayOfUnicodeStrings exercises the #419 interaction: an array of structs each
+// carrying a [unique] pointer to a conformant-varying buffer. Each element's buffer
+// must be deferred past the whole array, which only round-trips with the array referent
+// ordering fix in place.
+func TestArrayOfUnicodeStrings(t *testing.T) {
+	type rec struct {
+		Names []RPC_UNICODE_STRING `ndr:"conformant"`
+	}
+	in := &rec{Names: []RPC_UNICODE_STRING{
+		NewUnicodeString("alice"),
+		NewUnicodeString("bob"),
+	}}
+	raw, err := ndr.Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var out rec
+	if err := ndr.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if len(out.Names) != 2 || out.Names[0].String() != "alice" || out.Names[1].String() != "bob" {
+		t.Errorf("round trip: got %q,%q", out.Names[0].String(), out.Names[1].String())
+	}
+}
+
+func TestArrayOfUnicodeStringPointers(t *testing.T) {
+	type rec struct {
+		Names []*RPC_UNICODE_STRING `ndr:"conformant"`
+	}
+	a := NewUnicodeString("foo")
+	b := NewUnicodeString("barbaz")
+	in := &rec{Names: []*RPC_UNICODE_STRING{&a, &b}}
+	raw, err := ndr.Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var out rec
+	if err := ndr.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if len(out.Names) != 2 || out.Names[0] == nil || out.Names[1] == nil ||
+		out.Names[0].String() != "foo" || out.Names[1].String() != "barbaz" {
+		t.Errorf("round trip mismatch: %+v", out.Names)
+	}
+}
+
+func TestParseSID_Errors(t *testing.T) {
+	for _, s := range []string{"", "1-5-21", "S-x-5", "S-1-5-" + "9999999999999999999999"} {
+		if _, err := ParseSID(s); err == nil {
+			t.Errorf("ParseSID(%q): expected error", s)
+		}
+	}
+	// Round-trip a hex authority.
+	sid, err := ParseSID("S-1-0x10000000000-1")
+	if err != nil {
+		t.Fatalf("ParseSID hex authority: %v", err)
+	}
+	if got := sid.String(); got != "S-1-0x10000000000-1" {
+		t.Errorf("hex authority round trip: got %q", got)
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Part of #858` (step 1 of 3 — the tracking issue is closed by the final PR, not this one).

### Root Cause
The repository carries two overlapping MS-DTYP packages — `network/dcerpc/dtyp` (NDR wire types, 274 importers) and `windows/ms_dtyp` (spec transcription, 19 importers) — that redeclare seven type names with divergent, and in one case non-functional, definitions. There is no shared canonical home, so the duplication cannot be removed without first creating one.

### Fix Description
Adds `windows/ms-dtyp` (`package msdtyp`), the single canonical MS-DTYP type set, as a purely additive first step (no existing code imports it yet → zero blast radius). It merges both sources:
- scalar aliases (`DWORD`, `WORD`, `WCHAR`, …) and extra structures (`EVENT_HEADER`, `SERVER_INFO_10x`, `UINT128`, `OBJECT_TYPE_LIST`, …) from `windows/ms_dtyp`, flattened from the nested `common/data_types` + `common/data_structures` layout into one flat package (matching `windows/protocols/ms-*`);
- NDR-tagged wire types (`GUID`, `RPC_SID`, `RPC_UNICODE_STRING`) from `network/dcerpc/dtyp`.

Collision resolution (7 names): `GUID` → the 16-octet wire struct (not the `guid.GUID` alias, which over-aligns to 24 under the walker); `RPC_UNICODE_STRING` → the tagged `[]uint16` conformant-varying form (not the single-`WCHAR` stub); `FILETIME`/`LUID` → identical fields, method sets unioned; `LARGE_INTEGER`/`ULARGE_INTEGER` → named scalar `int64`/`uint64` (spec-signed, preserves RPC call sites — decision D1 option C; SMB keeps its `struct{QuadPart}` form locally in PR2).

The package is dependency-light by design: it imports only `windows/guid` + stdlib, never `network/dcerpc/ndr`. The `ndr:"..."` tags are inert metadata read by the external walker, so non-RPC consumers reuse these types without pulling in the RPC stack.

### How Verified
- `go build ./windows/ms-dtyp/` and `go vet ./windows/ms-dtyp/` — clean.
- `go test ./windows/ms-dtyp/` — passes. Ran tests include the NDR round-trip/golden set (`TestGUID_WireFormatFromGuidGUID`, `TestRPC_SID_GoldenAndRoundTrip`, `TestRPC_UNICODE_STRING_GoldenAndRoundTrip`/`_OverAllocated`/`_Empty`, `TestLargeInteger_RoundTrip`, `TestFILETIME_GoldenAndRoundTrip`, `TestSYSTEMTIME_GoldenAndRoundTrip`, array-of-string round-trips) and the FILETIME time-method tests (`TestFILETIME_ToInt64`, `GetTime`, `Unmarshal`, `MarshalUnmarshalInvolution`, `NewFILETIMEFromTime`, …).
- Dependency-light guarantee checked with `go list -deps ./windows/ms-dtyp/` → the only Manticore dependency is `windows/guid`.

### Test Coverage
**Added (ported):** the NDR round-trip/golden tests from `network/dcerpc/dtyp` and the FILETIME method tests from `windows/ms_dtyp`, adapted to `package msdtyp` / `msdtyp_test`. Removed the obsolete `TestGUID_Compatibility`, which asserted the discarded `GUID = guid.GUID` alias design (GUID↔`guid.GUID` conversion is covered by `TestGUID_WireFormatFromGuidGUID`).

### Scope of Change
- **Files changed:** new package only — `windows/ms-dtyp/*.go` (types + tests + `doc.go`).
- **Submodule pointer updated:** no.
- **Behavioral changes outside the bug fix:** none — nothing imports the package yet.

### Risk and Rollout
Additive; no existing package references it, so it cannot regress current behavior. The canonical wire layouts are locked by the ported golden/round-trip tests, so the later migration PRs (2 and 3) repoint imports against a validated target. Rollback = revert the single commit.

### Notes
Follow-ups tracked under #858: PR2 migrates the 19 `windows/ms_dtyp` consumers (SMB v1/v2, AD replication) and deletes `windows/ms_dtyp`; PR3 migrates the 274 `network/dcerpc/dtyp` consumers and deletes `network/dcerpc/dtyp`, then closes #858.
