### PR TITLE
Map FILETIME/SYSTEMTIME to the shared MS-DTYP package in idlgen (Fixes #862)

### DIFF
--- a/.claude/skills/dcerpc-interface-structure/idlgen.py
+++ b/.claude/skills/dcerpc-interface-structure/idlgen.py
@@ -886,7 +886,7 @@ _DTYP_SCALAR = {
 }
 # [MS-DTYP] aggregate types provided by windows/ms-dtyp (reuse, don't emit).
 _DTYP_STRUCT = {"RPC_SID", "RPC_UNICODE_STRING", "LARGE_INTEGER",
-                "ULARGE_INTEGER", "LUID"}
+                "ULARGE_INTEGER", "LUID", "FILETIME", "SYSTEMTIME"}
 # Built-in [MS-DTYP] pointer aliases -> canonical msdtyp type.
 _DTYP_PALIAS = {
     "PRPC_SID": "RPC_SID", "PRPC_UNICODE_STRING": "RPC_UNICODE_STRING",


### PR DESCRIPTION
### Linked Issue
`Closes #862`

### Root Cause
`idlgen.py`'s `_DTYP_STRUCT` set — the allowlist that routes [MS-DTYP] aggregate types to the shared package (`resolve_base` returns `msdtyp.<T>`) and suppresses local emission — listed only `RPC_SID`, `RPC_UNICODE_STRING`, `LARGE_INTEGER`, `ULARGE_INTEGER`, `LUID`. `FILETIME` and `SYSTEMTIME` were missing, so the generator treated them as unknown types "referenced but not defined in the IDL" and emitted an empty placeholder `type FILETIME struct{}` (0 octets) in the interface's own package.

### Fix Description
Add `FILETIME` and `SYSTEMTIME` to `_DTYP_STRUCT`. The generator now resolves both to `msdtyp.FILETIME` / `msdtyp.SYSTEMTIME` (the wire-correct, round-trip-tested types in `windows/ms-dtyp`) and emits no per-package placeholder — identical treatment to the other five [MS-DTYP] aggregates. One-line change to the set literal.

### How Verified
- `python3 -c "import ast; ast.parse(...)"` on `idlgen.py` — parses.
- Ran `gen-structures` on a minimal IDL with `FILETIME`/`SYSTEMTIME`/`LARGE_INTEGER` fields. Output:
  ```go
  import msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
  type THING struct {
      WhenFile msdtyp.FILETIME
      WhenSys  msdtyp.SYSTEMTIME
      Big      msdtyp.LARGE_INTEGER
  }
  ```
  No `FILETIME.go` / `SYSTEMTIME.go` stub was emitted.

### Test Coverage
**None:** `idlgen.py` is a stdlib-only code generator with no Go test harness in-repo; verification is the generator run above. The mapping target (`msdtyp.FILETIME`/`SYSTEMTIME`) is already covered by the round-trip/golden tests in `windows/ms-dtyp`.

### Scope of Change
- **Files changed:** `.claude/skills/dcerpc-interface-structure/idlgen.py` (one line).
- **Submodule pointer updated:** no.
- **Behavioral changes outside the bug fix:** none — only affects how the generator resolves two type names.

### Risk and Rollout
Minimal. Affects generation only, not any runtime code, and brings two types in line with the five already handled this way. Previously-generated hand-filled `FILETIME` structs in existing protocol packages are untouched; this only changes what future generation emits.

### Notes
The broken `windows/protocols/ms-par/FILETIME.go` stub that motivated this (an empty `struct{}`) is being corrected separately as part of that untracked WIP interface.
