### PR TITLE
Alias ms-rprn FILETIME to the shared MS-DTYP type (Fixes #864)

### DIFF
--- a/windows/protocols/ms-rprn/FILETIME.go
+++ b/windows/protocols/ms-rprn/FILETIME.go
@@ -1,10 +1,10 @@
 package msrprn
 
-import "github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+import (
+	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
+)
 
-// FILETIME is the [MS-DTYP] 2.3.3 64-bit value (100-ns intervals since 1601) as two
-// 32-bit halves. Referenced by the driver info structures but not defined in the MS-RPRN IDL.
-type FILETIME struct {
-	DwLowDateTime  ndr.DWORD
-	DwHighDateTime ndr.DWORD
-}
+// FILETIME is the [MS-DTYP] 2.3.3 64-bit timestamp. It is the shared msdtyp type, not a
+// per-protocol redefinition: MS-RPRN references it (in the driver info structures) but
+// does not define it in its own IDL.
+type FILETIME = msdtyp.FILETIME


### PR DESCRIPTION
### Linked Issue
`Closes #864`

### Root Cause
`ms-rprn`'s `FILETIME` was hand-filled from a generator `TODO(idlgen)` placeholder before `FILETIME` was routed to the shared package, leaving a standalone duplicate of the `[MS-DTYP]` 2.3.3 type.

### Fix Description
Replace the local `type FILETIME struct{ DwLowDateTime, DwHighDateTime ndr.DWORD }` with `type FILETIME = msdtyp.FILETIME`, reusing the canonical `windows/ms-dtyp` type — matching `ms-drsr`/`ms-nspi` and the current `idlgen` output (#862). The alias is wire-identical (two 32-bit halves, 8 octets) and keeps the `DwLowDateTime`/`DwHighDateTime` field names, so the consuming structures (`CORE_PRINTER_DRIVER`, `RPC_DRIVER_INFO_6/8`) and the RPRN interface functions are unchanged. This removes the last per-protocol `FILETIME` redefinition.

### How Verified
- `go build ./windows/protocols/ms-rprn/` and `./network/dcerpc/interfaces/12345678-1234-abcd-ef00-0123456789ab/...` (the RPRN interface) — build clean.
- `go test ./windows/protocols/ms-rprn/` — passes, including the `FILETIME` round-trip test, which confirms the wire layout is unchanged by the switch to the alias.

### Test Coverage
**Existing:** the `ms-rprn` `structures_test.go` `FILETIME` round-trip test now exercises the aliased `msdtyp.FILETIME` and passes, confirming byte-for-byte wire compatibility.

### Scope of Change
- **Files changed:** `windows/protocols/ms-rprn/FILETIME.go` (one type, now an alias).
- **Submodule pointer updated:** no.
- **Behavioral changes outside the bug fix:** none.

### Risk and Rollout
Minimal — a type alias with identical layout and field names; the round-trip test guards wire compatibility. Rollback = revert the single commit.
