### PR TITLE
Fix NDR codec pointer double-indirection (Fixes #801)

### DIFF
--- a/network/dcerpc/ndr/double_pointer_test.go
+++ b/network/dcerpc/ndr/double_pointer_test.go
@@ -1,0 +1,128 @@
+package ndr
+
+import (
+	"bytes"
+	"testing"
+)
+
+// TestTopLevelDoublePointer verifies a top-level pointer-to-unique-pointer-to-scalar
+// (**T) emits two nested referent ids followed by the value, and round-trips. This is
+// the [MS-MQMP] CACTransferBuffer OBJECTID**/GUID** shape ([C706] 14.3.10), issue #801.
+func TestTopLevelDoublePointer(t *testing.T) {
+	type topDouble struct {
+		PP **uint32
+	}
+	v := uint32(0xAABBCCDD)
+	p := &v
+	raw, err := Marshal(&topDouble{PP: &p})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	want := []byte{
+		0x00, 0x00, 0x02, 0x00, // outer referent id (in place for a top-level [unique])
+		0x04, 0x00, 0x02, 0x00, // inner referent id
+		0xDD, 0xCC, 0xBB, 0xAA, // the value
+	}
+	if !bytes.Equal(raw, want) {
+		t.Errorf("top-level **T:\n got %x\nwant %x", raw, want)
+	}
+	var out topDouble
+	if err := Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out.PP == nil || *out.PP == nil || **out.PP != v {
+		t.Errorf("round trip: got %v", out.PP)
+	}
+}
+
+// TestEmbeddedDoublePointer verifies an embedded **T emits an outer referent id inline,
+// then defers a construction whose body is the inner referent id followed by the value.
+func TestEmbeddedDoublePointer(t *testing.T) {
+	type inner struct {
+		PP **uint32
+	}
+	type outer struct {
+		I inner
+	}
+	v := uint32(0xAABBCCDD)
+	p := &v
+	raw, err := Marshal(&outer{I: inner{PP: &p}})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	want := []byte{
+		0x00, 0x00, 0x02, 0x00, // outer referent id (embedded: placeholder, body deferred)
+		0x04, 0x00, 0x02, 0x00, // inner referent id (in the deferred referent body)
+		0xDD, 0xCC, 0xBB, 0xAA, // the value
+	}
+	if !bytes.Equal(raw, want) {
+		t.Errorf("embedded **T:\n got %x\nwant %x", raw, want)
+	}
+	var out outer
+	if err := Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out.I.PP == nil || *out.I.PP == nil || **out.I.PP != v {
+		t.Errorf("round trip: got %v", out.I.PP)
+	}
+}
+
+// TestDoublePointerNil verifies a nil inner pointer emits an outer referent id then a
+// NULL (0) inner referent, and round-trips back to a nil inner pointer.
+func TestDoublePointerNil(t *testing.T) {
+	type topDouble struct {
+		PP **uint32
+	}
+	var p *uint32 // nil inner pointer, non-nil outer
+	raw, err := Marshal(&topDouble{PP: &p})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	want := []byte{
+		0x00, 0x00, 0x02, 0x00, // outer referent id
+		0x00, 0x00, 0x00, 0x00, // inner NULL referent
+	}
+	if !bytes.Equal(raw, want) {
+		t.Errorf("nil inner **T:\n got %x\nwant %x", raw, want)
+	}
+	var out topDouble
+	if err := Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out.PP == nil || *out.PP != nil {
+		t.Errorf("round trip: expected non-nil outer, nil inner; got %v", out.PP)
+	}
+}
+
+// TestDoublePointerToConformantArray verifies a pointer-to-unique-pointer-to-conformant
+// -array (**[]T): outer referent id, inner referent id, then the array's maximum_count
+// and elements. This is the [MS-MQMP] [size_is(,n)] TYPE** shape, issue #801.
+func TestDoublePointerToConformantArray(t *testing.T) {
+	type topArr struct {
+		PP **[]uint32 `ndr:"unique"`
+	}
+	arr := []uint32{0x11111111, 0x22222222}
+	pa := &arr
+	raw, err := Marshal(&topArr{PP: &pa})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	want := []byte{
+		0x00, 0x00, 0x02, 0x00, // outer referent id
+		0x04, 0x00, 0x02, 0x00, // inner referent id
+		0x02, 0x00, 0x00, 0x00, // maximum_count = 2
+		0x11, 0x11, 0x11, 0x11,
+		0x22, 0x22, 0x22, 0x22,
+	}
+	if !bytes.Equal(raw, want) {
+		t.Errorf("**[]T:\n got %x\nwant %x", raw, want)
+	}
+	var out topArr
+	if err := Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out.PP == nil || *out.PP == nil || len(**out.PP) != 2 ||
+		(**out.PP)[0] != arr[0] || (**out.PP)[1] != arr[1] {
+		t.Errorf("round trip: got %v", out.PP)
+	}
+}

--- a/network/dcerpc/ndr/marshal.go
+++ b/network/dcerpc/ndr/marshal.go
@@ -270,6 +270,19 @@ func marshalInlineValue(e *Encoder, fv reflect.Value, tag fieldTag, deferred *[]
 	}
 
 	switch fv.Kind() {
+	case reflect.Pointer:
+		// A pointer reached as an inline value is the inner level of a multiply-indirected
+		// pointer (e.g. **T): the enclosing referent body is itself a pointer. Emit this
+		// level's referent id (0 for NULL) and then its own referent body, exactly as an
+		// embedded [unique] pointer does ([C706] section 14.3.10). marshalReferentBody
+		// dereferences one level and recurses here, so arbitrary depth (**T, ***T) works.
+		// Used by [MS-MQMP] CACTransferBuffer's OBJECTID**/GUID** fields.
+		if isNilReferent(fv) {
+			e.writeReferent(0)
+			return nil
+		}
+		e.writeReferent(e.nextReferent())
+		return marshalReferentBody(e, fv, tag)
 	case reflect.Struct:
 		if swIdx := unionSwitchIndex(fv.Type()); swIdx >= 0 {
 			return marshalUnion(e, fv, swIdx)
@@ -551,6 +564,18 @@ func unmarshalInlineValue(d *Decoder, fv reflect.Value, tag fieldTag, deferred *
 	}
 
 	switch fv.Kind() {
+	case reflect.Pointer:
+		// Symmetric with marshalInlineValue: the inner level of a multiply-indirected
+		// pointer (**T). Read this level's referent id; a NULL (0) leaves the zero value,
+		// otherwise unmarshalReferentBody allocates and recurses for the referent body.
+		refid, err := d.readReferent()
+		if err != nil {
+			return err
+		}
+		if refid == 0 {
+			return nil
+		}
+		return unmarshalReferentBody(d, fv, tag)
 	case reflect.Struct:
 		if swIdx := unionSwitchIndex(fv.Type()); swIdx >= 0 {
 			return unmarshalUnion(d, fv, swIdx)


### PR DESCRIPTION
### Linked Issue
`Closes #801`

### Root Cause
The declarative NDR codec's `marshalInlineValue`/`unmarshalInlineValue` (`network/dcerpc/ndr/marshal.go`) modelled a single level of pointer indirection. A pointer field (`*T`) is handled in `marshalFieldInline`/`unmarshalFieldInline`, which emit the referent id and defer the body; `marshalReferentBody`/`unmarshalReferentBody` then dereference exactly one level and hand the referent body to `marshalInlineValue`/`unmarshalInlineValue`. When the field is a double pointer (`**T`), that referent body is *itself* a pointer (`*T`), but the inline-value switch had no `reflect.Pointer` case — it fell through to `marshalScalar`/`unmarshalScalar` and failed with `ndr: unsupported scalar kind ptr`. The wire pattern (an outer referent id, then an inner referent id, then the body) was therefore inexpressible.

### Fix Description
Add a `reflect.Pointer` case to both `marshalInlineValue` and `unmarshalInlineValue`. On marshal it emits this level's referent id (0 for a NULL inner pointer) and recurses through `marshalReferentBody`; on unmarshal it reads the referent id, leaves the zero value on NULL, and otherwise recurses through `unmarshalReferentBody` (which allocates the inner pointer). Because `marshalReferentBody`/`unmarshalReferentBody` dereference one level and re-enter the inline-value dispatch, this composes to arbitrary depth (`**T`, `***T`) and to any inner shape — including a conformant array (`**[]T`), whose `maximum_count` and elements follow the two referent ids per [C706] 14.3.10.

The case is placed inside the existing kind switch (after the `asMarshaler` check), so the only behavior it changes is the path that previously errored — a bare pointer reaching the inline-value dispatch, which today happens only for a `**T` referent body.

This change is scoped to the codec. The deferred [MS-MQMP] `CACTransferBuffer`-carrying methods are intentionally left deferred: the issue notes a Go-level round-trip is necessary but not sufficient, and they should be validated against a live MSMQ server before being wired up.

### How Verified
- **Tests:** added `network/dcerpc/ndr/double_pointer_test.go` with byte-exact wire assertions and round-trips:
  - `TestTopLevelDoublePointer` — `**uint32`: outer refid `00000200`, inner refid `04000200`, value.
  - `TestEmbeddedDoublePointer` — `**uint32` inside a struct: outer refid emitted inline, inner refid + value in the deferred referent body.
  - `TestDoublePointerNil` — non-nil outer, nil inner: outer refid then a NULL (`00000000`) inner referent; round-trips to a nil inner pointer.
  - `TestDoublePointerToConformantArray` — `**[]uint32`: outer refid, inner refid, `maximum_count = 2`, elements.
- **Regression:** `go test ./network/dcerpc/ndr/` passes in full; `go build ./...` clean.

### Test Coverage
- **Added:** `double_pointer_test.go` (`TestTopLevelDoublePointer`, `TestEmbeddedDoublePointer`, `TestDoublePointerNil`, `TestDoublePointerToConformantArray`).

### Scope of Change
- **Files changed:** `network/dcerpc/ndr/marshal.go`, `network/dcerpc/ndr/double_pointer_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Low blast radius: the new case only intercepts a pointer value reaching the inline-value dispatch, which previously always errored, so no currently-working path changes. Safe to merge without staged rollout.

### Notes
Live-server validation of the [MS-MQMP] `CACTransferBufferV1`/`V2` buffers and wiring up the four deferred methods (`R_QMCreateRemoteCursor`, `QMSendMessageInternalEx`, `rpc_ACSendMessageEx`, `rpc_ACReceiveMessageEx`) remains follow-up work tracked by #801.