### PR TITLE
Add LDAP Add and Delete session wrappers (Fixes #881)

### DIFF
--- a/network/ldap/add.go
+++ b/network/ldap/add.go
@@ -1,0 +1,138 @@
+package ldap
+
+import (
+	goldapv3 "github.com/go-ldap/ldap/v3"
+)
+
+// AddRequest represents an LDAP add operation that creates a new entry.
+//
+// Fields:
+//   - DistinguishedName: the distinguished name (DN) of the entry to be created.
+//   - Attributes: the ordered list of attributes for the new entry. By convention
+//     the objectClass attribute is added first.
+//   - Controls: optional LDAP controls to send with the request.
+type AddRequest struct {
+	// Distinguished name
+	DistinguishedName string
+	// Attributes of the new entry
+	Attributes []*AddAttribute
+	// LDAP controls
+	Controls []goldapv3.Control
+}
+
+// AddAttribute is a single attribute (type and values) of an entry being created.
+//
+// Binary attribute values are supported: pass each value as string(bytes). The
+// underlying LDAP encoder writes attribute values as raw octet strings, so the
+// bytes are transmitted verbatim.
+type AddAttribute struct {
+	Type string
+	Vals []string
+}
+
+// NewAddRequest creates a new AddRequest for the specified distinguished name.
+//
+// Parameters:
+//   - distinguishedName: A string representing the distinguished name (DN) of the LDAP entry to be created.
+//
+// Returns:
+//   - A pointer to a newly created AddRequest instance with the specified distinguished name and an empty
+//     list of attributes.
+//
+// Example usage:
+//
+//	addRequest := NewAddRequest("cn=John Doe,dc=example,dc=com")
+//	addRequest.Attribute("objectClass", []string{"top", "person"})
+//	addRequest.Attribute("cn", []string{"John Doe"})
+//	addRequest.Attribute("sn", []string{"Doe"})
+//	err := ldapSession.Add(addRequest)
+//	if err != nil {
+//		log.Fatalf("Failed to add LDAP entry: %s", err)
+//	}
+func NewAddRequest(distinguishedName string) *AddRequest {
+	return &AddRequest{
+		DistinguishedName: distinguishedName,
+		Attributes:        make([]*AddAttribute, 0),
+	}
+}
+
+// AddControl adds a control to the AddRequest.
+//
+// Parameters:
+//   - control: A goldapv3.Control interface representing the control to be added.
+func (req *AddRequest) AddControl(control goldapv3.Control) {
+	if req.Controls == nil {
+		req.Controls = make([]goldapv3.Control, 0)
+	}
+	req.Controls = append(req.Controls, control)
+}
+
+// Attribute appends an attribute and its values to the AddRequest.
+//
+// Parameters:
+//   - attrType: A string representing the type of the attribute to be added.
+//   - attrVals: A slice of strings representing the values of the attribute.
+//
+// The function appends a new AddAttribute to the Attributes slice of the AddRequest. Attributes are kept
+// in the order in which they are appended. Binary values are supported by passing string(bytes).
+//
+// Example usage:
+//
+//	addRequest := NewAddRequest("cn=John Doe,dc=example,dc=com")
+//	addRequest.Attribute("objectClass", []string{"top", "person"})
+//	addRequest.Attribute("cn", []string{"John Doe"})
+func (req *AddRequest) Attribute(attrType string, attrVals []string) {
+	req.Attributes = append(req.Attributes, &AddAttribute{
+		Type: attrType,
+		Vals: attrVals,
+	})
+}
+
+// Add performs an LDAP add operation using the provided AddRequest, creating a new entry on the server.
+//
+// Parameters:
+//   - addRequest: A pointer to an AddRequest struct describing the entry to create.
+//
+// Returns:
+//   - An error object if the add operation fails, otherwise nil.
+//
+// The function creates a new LDAP add request using the distinguished name, attributes, and controls from
+// the provided AddRequest, then performs the add operation using the established LDAP connection.
+//
+// Example usage:
+//
+//	session, err := NewSession("ldap.example.com", 389, credentials, false, false)
+//	if err != nil {
+//		logger.Error(fmt.Sprintf("Failed to create session: %s", err))
+//		return
+//	}
+//	success, err := session.Connect()
+//	if !success {
+//		logger.Warn(fmt.Sprintf("Failed to connect to LDAP server: %s", err))
+//		return
+//	}
+//
+//	addRequest := NewAddRequest("cn=John Doe,dc=example,dc=com")
+//	addRequest.Attribute("objectClass", []string{"top", "person"})
+//	addRequest.Attribute("cn", []string{"John Doe"})
+//	addRequest.Attribute("sn", []string{"Doe"})
+//	err = session.Add(addRequest)
+//	if err != nil {
+//		logger.Error(fmt.Sprintf("Failed to add LDAP entry: %s", err))
+//	} else {
+//		logger.Info("Successfully added LDAP entry")
+//	}
+//
+// Note:
+//   - Ensure that the LDAP connection is properly established before calling this function.
+func (ldapSession *Session) Add(addRequest *AddRequest) error {
+	// Create a new add request
+	a := goldapv3.NewAddRequest(addRequest.DistinguishedName, addRequest.Controls)
+
+	// Add the attributes to the add request, preserving their order
+	for _, attribute := range addRequest.Attributes {
+		a.Attribute(attribute.Type, attribute.Vals)
+	}
+
+	return ldapSession.connection.Add(a)
+}

--- a/network/ldap/add_test.go
+++ b/network/ldap/add_test.go
@@ -1,0 +1,89 @@
+package ldap_test
+
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/ldap"
+)
+
+func TestNewAddRequest(t *testing.T) {
+	dn := "cn=John Doe,dc=example,dc=com"
+	req := ldap.NewAddRequest(dn)
+
+	if req.DistinguishedName != dn {
+		t.Errorf("DistinguishedName = %q; want %q", req.DistinguishedName, dn)
+	}
+	if req.Attributes == nil {
+		t.Errorf("Attributes = nil; want a non-nil empty slice")
+	}
+	if len(req.Attributes) != 0 {
+		t.Errorf("len(Attributes) = %d; want 0", len(req.Attributes))
+	}
+	if len(req.Controls) != 0 {
+		t.Errorf("len(Controls) = %d; want 0", len(req.Controls))
+	}
+}
+
+func TestAddRequestAttributeOrderAndValues(t *testing.T) {
+	req := ldap.NewAddRequest("cn=John Doe,dc=example,dc=com")
+	req.Attribute("objectClass", []string{"top", "person"})
+	req.Attribute("cn", []string{"John Doe"})
+	req.Attribute("sn", []string{"Doe"})
+
+	if len(req.Attributes) != 3 {
+		t.Fatalf("len(Attributes) = %d; want 3", len(req.Attributes))
+	}
+
+	// Attributes must be preserved in insertion order (objectClass first by convention).
+	wantTypes := []string{"objectClass", "cn", "sn"}
+	for i, want := range wantTypes {
+		if req.Attributes[i].Type != want {
+			t.Errorf("Attributes[%d].Type = %q; want %q", i, req.Attributes[i].Type, want)
+		}
+	}
+
+	if len(req.Attributes[0].Vals) != 2 ||
+		req.Attributes[0].Vals[0] != "top" || req.Attributes[0].Vals[1] != "person" {
+		t.Errorf("objectClass Vals = %v; want [top person]", req.Attributes[0].Vals)
+	}
+}
+
+func TestAddRequestBinaryValueRoundTrip(t *testing.T) {
+	// Binary attribute values are carried as string(bytes); the bytes must survive verbatim,
+	// including embedded NUL and high bytes.
+	raw := []byte{0x00, 0x01, 0xFF, 0x7F, 0x80, 0x00, 0xAB}
+
+	req := ldap.NewAddRequest("cn=binary,dc=example,dc=com")
+	req.Attribute("objectSid", []string{string(raw)})
+
+	if len(req.Attributes) != 1 || len(req.Attributes[0].Vals) != 1 {
+		t.Fatalf("unexpected attribute shape: %+v", req.Attributes)
+	}
+
+	got := []byte(req.Attributes[0].Vals[0])
+	if len(got) != len(raw) {
+		t.Fatalf("round-tripped length = %d; want %d", len(got), len(raw))
+	}
+	for i := range raw {
+		if got[i] != raw[i] {
+			t.Errorf("byte %d = 0x%02X; want 0x%02X", i, got[i], raw[i])
+		}
+	}
+}
+
+func TestAddRequestAddControl(t *testing.T) {
+	req := ldap.NewAddRequest("cn=John Doe,dc=example,dc=com")
+
+	controls := ldap.NewControlsWithOIDs([]string{ldap.LDAP_SERVER_PERMISSIVE_MODIFY_OID}, false)
+	for _, c := range controls {
+		req.AddControl(c)
+	}
+
+	if len(req.Controls) != len(controls) {
+		t.Fatalf("len(Controls) = %d; want %d", len(req.Controls), len(controls))
+	}
+	if req.Controls[0].GetControlType() != ldap.LDAP_SERVER_PERMISSIVE_MODIFY_OID {
+		t.Errorf("Controls[0] type = %q; want %q",
+			req.Controls[0].GetControlType(), ldap.LDAP_SERVER_PERMISSIVE_MODIFY_OID)
+	}
+}

--- a/network/ldap/delete.go
+++ b/network/ldap/delete.go
@@ -1,0 +1,67 @@
+package ldap
+
+import (
+	goldapv3 "github.com/go-ldap/ldap/v3"
+)
+
+// Delete performs an LDAP delete operation, removing the entry with the specified distinguished name.
+//
+// Parameters:
+//   - distinguishedName: A string representing the distinguished name (DN) of the LDAP entry to be deleted.
+//
+// Returns:
+//   - An error object if the delete operation fails, otherwise nil.
+//
+// The function creates a new LDAP delete request for the provided distinguished name and performs the
+// delete operation using the established LDAP connection.
+//
+// Example usage:
+//
+//	session, err := NewSession("ldap.example.com", 389, credentials, false, false)
+//	if err != nil {
+//		logger.Error(fmt.Sprintf("Failed to create session: %s", err))
+//		return
+//	}
+//	success, err := session.Connect()
+//	if !success {
+//		logger.Warn(fmt.Sprintf("Failed to connect to LDAP server: %s", err))
+//		return
+//	}
+//
+//	err = session.Delete("cn=John Doe,dc=example,dc=com")
+//	if err != nil {
+//		logger.Error(fmt.Sprintf("Failed to delete LDAP entry: %s", err))
+//	} else {
+//		logger.Info("Successfully deleted LDAP entry")
+//	}
+//
+// Note:
+//   - A standard delete operation only removes leaf entries. To delete an entry together with its
+//     descendants, use DeleteWithControls with the subtree-delete control.
+//   - Ensure that the LDAP connection is properly established before calling this function.
+func (ldapSession *Session) Delete(distinguishedName string) error {
+	return ldapSession.connection.Del(goldapv3.NewDelRequest(distinguishedName, nil))
+}
+
+// DeleteWithControls performs an LDAP delete operation with the provided controls.
+//
+// Parameters:
+//   - distinguishedName: A string representing the distinguished name (DN) of the LDAP entry to be deleted.
+//   - controls: A slice of goldapv3.Control to send with the delete request.
+//
+// Returns:
+//   - An error object if the delete operation fails, otherwise nil.
+//
+// This is the controlled form of Delete. It is useful, for example, to attach the subtree-delete control
+// (OID 1.2.840.113556.1.4.805) so that an entry is removed together with all of its descendants.
+//
+// Example usage:
+//
+//	controls := NewControlsWithOIDs([]string{"1.2.840.113556.1.4.805"}, true)
+//	err := session.DeleteWithControls("ou=Stale,dc=example,dc=com", controls)
+//	if err != nil {
+//		logger.Error(fmt.Sprintf("Failed to delete LDAP subtree: %s", err))
+//	}
+func (ldapSession *Session) DeleteWithControls(distinguishedName string, controls []goldapv3.Control) error {
+	return ldapSession.connection.Del(goldapv3.NewDelRequest(distinguishedName, controls))
+}


### PR DESCRIPTION
### Linked Issue
`Closes #881`

### Root Cause
`network/ldap.Session` wrapped only a subset of the LDAP write operations. It exposed `Modify` and its helpers, but never provided wrappers for the add and delete primitives. Because the underlying `*ldap.Conn` is stored in the unexported `Session.connection` field (`network/ldap/session.go:43`), external packages could not fall back to calling `go-ldap`'s `Conn.Add` / `Conn.Del` directly either. The two LDAP write primitives existed in the vendored `go-ldap/ldap/v3` library but were unreachable through Manticore's session API, leaving entry creation and deletion impossible through the package.

### Fix Description
Add two new files that complete the write surface, following the exact style of the existing `modify.go`:

- `network/ldap/add.go` — an exported `AddRequest` struct with a `NewAddRequest` constructor and fluent `Attribute` / `AddControl` builder methods, plus `Session.Add`, which translates the request into a `goldapv3.AddRequest` and calls the unexported connection. Attributes are preserved in insertion order (objectClass-first by convention). Binary attribute values are supported by passing `string(bytes)`, the same mechanism `Modify` already relies on, because the LDAP encoder writes values as raw octet strings.
- `network/ldap/delete.go` — `Session.Delete(dn)` for leaf deletion and `Session.DeleteWithControls(dn, controls)` for the controlled form (e.g. attaching the subtree-delete control `1.2.840.113556.1.4.805`).

The change is purely additive: no existing signature or behavior is altered, and the connection field stays unexported so callers never touch `*ldap.Conn`.

### How Verified
- `go build ./network/ldap/...` and `go vet ./network/ldap/...` — clean.
- `go test ./network/ldap/...` — all pass, including the new tests.
- Static: `Session.Add` maps `AddRequest.Attributes` one-to-one onto `goldapv3.AddRequest.Attribute` in order (`add.go`), and `Session.Delete` / `DeleteWithControls` construct `goldapv3.NewDelRequest` with and without controls (`delete.go`).

### Test Coverage
**Added:** `network/ldap/add_test.go`
- `TestNewAddRequest` — constructor initializes a non-nil empty attribute slice and correct DN.
- `TestAddRequestAttributeOrderAndValues` — attribute insertion order and values are preserved (objectClass first).
- `TestAddRequestBinaryValueRoundTrip` — a byte slice with embedded NUL and high bytes survives the `string(bytes)` → `[]byte` round trip verbatim.
- `TestAddRequestAddControl` — controls attach and carry the expected control type.

`Session.Add` / `Session.Delete` / `DeleteWithControls` are thin passthroughs to the connection and require a live LDAP server, so they are exercised via the request-builder tests rather than a networked integration test.

### Scope of Change
- **Files changed:** `network/ldap/add.go` (new), `network/ldap/delete.go` (new), `network/ldap/add_test.go` (new)
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Additive-only; introduces new methods and types without touching existing code paths. No behavioral regression risk. Safe to merge without staged rollout.
