### PR TITLE
Add MS-DNSP packed dnsRecord wire structures (Fixes #883)

### DIFF
--- a/network/dns/dnsrecord/dns_count_name.go
+++ b/network/dns/dnsrecord/dns_count_name.go
@@ -1,0 +1,182 @@
+package dnsrecord
+
+import (
+	"fmt"
+	"strings"
+)
+
+// DNS_COUNT_NAME is the on-directory form of an FQDN used inside dnsRecord attribute values
+// carried over LDAP. When a dnsRecord value is written to the directory each name is
+// converted from DNS_RPC_NAME (section 2.2.2.2.1) to DNS_COUNT_NAME, and converted back when
+// read.
+//
+// The name is encoded as a sequence of length-prefixed labels: a 1-byte label-length count is
+// inserted before the first label and in place of each "." delimiter, and the sequence is
+// null-terminated. For example "example.com" is encoded as 07 'example' 03 'com' 00, with a
+// Length of 13 and a LabelCount of 2.
+//
+// Source: [MS-DNSP] DNS_COUNT_NAME (section 2.2.2.2.2)
+// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dnsp/2af86306-3bd9-4c86-b763-fd33e16e3e5b
+type DNS_COUNT_NAME struct {
+	// Length (1 byte): The length, in bytes, of the string stored in the RawName member,
+	// including null termination. To represent an empty string, Length MUST be zero,
+	// LabelCount MUST be zero, and RawName MUST be empty.
+	Length uint8
+
+	// LabelCount (1 byte): The count of DNS labels in the RawName member.
+	LabelCount uint8
+
+	// RawName (variable): A string containing an FQDN in which a 1-byte label length count
+	// for the subsequent label has been inserted before the first label and in place of each
+	// "." delimiter. The string MUST be null-terminated. The maximum length of the string,
+	// including the null terminator, is 256 bytes.
+	RawName []byte
+}
+
+// NewDNS_COUNT_NAME creates a new, empty DNS_COUNT_NAME.
+//
+// Returns:
+// - A pointer to the new DNS_COUNT_NAME structure
+func NewDNS_COUNT_NAME() *DNS_COUNT_NAME {
+	return &DNS_COUNT_NAME{}
+}
+
+// NewDNS_COUNT_NAMEFromFQDN creates a DNS_COUNT_NAME from a dotted FQDN string.
+//
+// Parameters:
+// - fqdn: The dotted fully-qualified domain name (a trailing "." is tolerated and ignored)
+//
+// Returns:
+//   - A pointer to the populated DNS_COUNT_NAME structure
+//   - An error if any label is empty or exceeds 63 bytes, or if the encoded name exceeds
+//     the 256-byte maximum
+func NewDNS_COUNT_NAMEFromFQDN(fqdn string) (*DNS_COUNT_NAME, error) {
+	n := &DNS_COUNT_NAME{}
+	if err := n.SetFQDN(fqdn); err != nil {
+		return nil, err
+	}
+	return n, nil
+}
+
+// SetFQDN encodes the provided dotted FQDN into the RawName, Length, and LabelCount fields.
+//
+// Parameters:
+// - fqdn: The dotted fully-qualified domain name (a single trailing "." is tolerated)
+//
+// Returns:
+//   - An error if any label is empty or longer than 63 bytes, or if the encoded name
+//     (including the null terminator) exceeds 255 bytes.
+func (n *DNS_COUNT_NAME) SetFQDN(fqdn string) error {
+	// A single trailing dot denotes the root and is not a label separator.
+	fqdn = strings.TrimSuffix(fqdn, ".")
+
+	if fqdn == "" {
+		n.Length = 0
+		n.LabelCount = 0
+		n.RawName = nil
+		return nil
+	}
+
+	labels := strings.Split(fqdn, ".")
+	raw := make([]byte, 0, len(fqdn)+2)
+	for _, label := range labels {
+		if len(label) == 0 {
+			return fmt.Errorf("invalid FQDN %q: empty label", fqdn)
+		}
+		if len(label) > 63 {
+			return fmt.Errorf("invalid FQDN %q: label %q exceeds 63 bytes", fqdn, label)
+		}
+		raw = append(raw, byte(len(label)))
+		raw = append(raw, []byte(label)...)
+	}
+	// Null terminator.
+	raw = append(raw, 0x00)
+
+	// The spec states a 256-byte maximum including the terminator, but the Length field is a
+	// single byte, so the representable maximum is 255. Cap here to avoid overflowing Length.
+	if len(raw) > 255 {
+		return fmt.Errorf("invalid FQDN %q: encoded name is %d bytes, exceeds 255", fqdn, len(raw))
+	}
+
+	n.RawName = raw
+	n.Length = uint8(len(raw))
+	n.LabelCount = uint8(len(labels))
+	return nil
+}
+
+// GetFQDN decodes the RawName into a dotted FQDN string. An empty name decodes to "".
+//
+// Returns:
+// - The dotted FQDN
+// - An error if the RawName is malformed (a label length runs past the end of the buffer)
+func (n *DNS_COUNT_NAME) GetFQDN() (string, error) {
+	if len(n.RawName) == 0 {
+		return "", nil
+	}
+
+	labels := make([]string, 0, n.LabelCount)
+	offset := 0
+	for i := 0; i < int(n.LabelCount); i++ {
+		if offset >= len(n.RawName) {
+			return "", fmt.Errorf("malformed DNS_COUNT_NAME: label %d begins past end of RawName", i)
+		}
+		labelLen := int(n.RawName[offset])
+		offset++
+		if offset+labelLen > len(n.RawName) {
+			return "", fmt.Errorf("malformed DNS_COUNT_NAME: label %d length %d runs past end of RawName", i, labelLen)
+		}
+		labels = append(labels, string(n.RawName[offset:offset+labelLen]))
+		offset += labelLen
+	}
+
+	return strings.Join(labels, "."), nil
+}
+
+// Marshal marshals the DNS_COUNT_NAME structure into a byte array.
+//
+// Returns:
+// - A byte array representing the DNS_COUNT_NAME structure
+// - An error if the marshaling fails
+func (n *DNS_COUNT_NAME) Marshal() ([]byte, error) {
+	if len(n.RawName) > 255 {
+		return nil, fmt.Errorf("DNS_COUNT_NAME RawName is %d bytes, cannot exceed 255", len(n.RawName))
+	}
+
+	marshalled := make([]byte, 0, 2+len(n.RawName))
+	marshalled = append(marshalled, n.Length)
+	marshalled = append(marshalled, n.LabelCount)
+	marshalled = append(marshalled, n.RawName...)
+	return marshalled, nil
+}
+
+// Unmarshal unmarshals a byte array into the DNS_COUNT_NAME structure.
+//
+// Parameters:
+// - rawData: The byte array to unmarshal
+//
+// Returns:
+// - The number of bytes read
+// - An error if the unmarshaling fails
+func (n *DNS_COUNT_NAME) Unmarshal(rawData []byte) (int, error) {
+	if len(rawData) < 2 {
+		return 0, fmt.Errorf("rawData too short for DNS_COUNT_NAME header: %d bytes", len(rawData))
+	}
+
+	n.Length = rawData[0]
+	n.LabelCount = rawData[1]
+
+	offset := 2
+	if len(rawData) < offset+int(n.Length) {
+		return 0, fmt.Errorf("rawData too short for DNS_COUNT_NAME RawName: need %d bytes, have %d", offset+int(n.Length), len(rawData))
+	}
+
+	if n.Length == 0 {
+		n.RawName = nil
+	} else {
+		n.RawName = make([]byte, n.Length)
+		copy(n.RawName, rawData[offset:offset+int(n.Length)])
+	}
+	offset += int(n.Length)
+
+	return offset, nil
+}

--- a/network/dns/dnsrecord/dns_count_name_test.go
+++ b/network/dns/dnsrecord/dns_count_name_test.go
@@ -1,0 +1,135 @@
+package dnsrecord_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/dns/dnsrecord"
+)
+
+// TestDNSCountNameWireShape pins the exact on-directory encoding of "example.com":
+// 07 'example' 03 'com' 00, with Length 13 (including the null terminator) and LabelCount 2.
+func TestDNSCountNameWireShape(t *testing.T) {
+	n, err := dnsrecord.NewDNS_COUNT_NAMEFromFQDN("example.com")
+	if err != nil {
+		t.Fatalf("NewDNS_COUNT_NAMEFromFQDN failed: %v", err)
+	}
+
+	if n.Length != 13 {
+		t.Errorf("Length = %d; want 13", n.Length)
+	}
+	if n.LabelCount != 2 {
+		t.Errorf("LabelCount = %d; want 2", n.LabelCount)
+	}
+
+	wantRaw := []byte{0x07, 'e', 'x', 'a', 'm', 'p', 'l', 'e', 0x03, 'c', 'o', 'm', 0x00}
+	if !bytes.Equal(n.RawName, wantRaw) {
+		t.Errorf("RawName = % x; want % x", n.RawName, wantRaw)
+	}
+
+	marshalled, err := n.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+	want := append([]byte{13, 2}, wantRaw...)
+	if !bytes.Equal(marshalled, want) {
+		t.Errorf("Marshal = % x; want % x", marshalled, want)
+	}
+}
+
+// TestDNSCountNameRoundTrip round-trips several names through Marshal/Unmarshal and the
+// FQDN accessors.
+func TestDNSCountNameRoundTrip(t *testing.T) {
+	for _, fqdn := range []string{"example.com", "a.b.c.d.example.org", "single", "trailing.dot."} {
+		out, err := dnsrecord.NewDNS_COUNT_NAMEFromFQDN(fqdn)
+		if err != nil {
+			t.Fatalf("%q: NewDNS_COUNT_NAMEFromFQDN failed: %v", fqdn, err)
+		}
+		marshalled, err := out.Marshal()
+		if err != nil {
+			t.Fatalf("%q: Marshal failed: %v", fqdn, err)
+		}
+
+		in := dnsrecord.NewDNS_COUNT_NAME()
+		read, err := in.Unmarshal(marshalled)
+		if err != nil {
+			t.Fatalf("%q: Unmarshal failed: %v", fqdn, err)
+		}
+		if read != len(marshalled) {
+			t.Errorf("%q: Unmarshal read %d bytes; want %d", fqdn, read, len(marshalled))
+		}
+
+		got, err := in.GetFQDN()
+		if err != nil {
+			t.Fatalf("%q: GetFQDN failed: %v", fqdn, err)
+		}
+		// A trailing dot is normalized away on encode.
+		want := fqdn
+		if want == "trailing.dot." {
+			want = "trailing.dot"
+		}
+		if got != want {
+			t.Errorf("round trip of %q = %q; want %q", fqdn, got, want)
+		}
+	}
+}
+
+// TestDNSCountNameEmpty verifies the empty-name encoding: Length 0, LabelCount 0, no RawName.
+func TestDNSCountNameEmpty(t *testing.T) {
+	n, err := dnsrecord.NewDNS_COUNT_NAMEFromFQDN("")
+	if err != nil {
+		t.Fatalf("NewDNS_COUNT_NAMEFromFQDN(\"\") failed: %v", err)
+	}
+	if n.Length != 0 || n.LabelCount != 0 || len(n.RawName) != 0 {
+		t.Errorf("empty name = {Length:%d LabelCount:%d RawName:% x}; want all zero/empty", n.Length, n.LabelCount, n.RawName)
+	}
+
+	marshalled, err := n.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+	if !bytes.Equal(marshalled, []byte{0, 0}) {
+		t.Errorf("Marshal of empty name = % x; want 00 00", marshalled)
+	}
+
+	in := dnsrecord.NewDNS_COUNT_NAME()
+	read, err := in.Unmarshal(marshalled)
+	if err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if read != 2 {
+		t.Errorf("Unmarshal read %d bytes; want 2", read)
+	}
+	got, err := in.GetFQDN()
+	if err != nil {
+		t.Fatalf("GetFQDN failed: %v", err)
+	}
+	if got != "" {
+		t.Errorf("GetFQDN = %q; want empty", got)
+	}
+}
+
+// TestDNSCountNameRejectsBadInput verifies validation of empty and over-long labels.
+func TestDNSCountNameRejectsBadInput(t *testing.T) {
+	if _, err := dnsrecord.NewDNS_COUNT_NAMEFromFQDN("foo..bar"); err == nil {
+		t.Errorf("expected error for empty label, got nil")
+	}
+	long := make([]byte, 64)
+	for i := range long {
+		long[i] = 'a'
+	}
+	if _, err := dnsrecord.NewDNS_COUNT_NAMEFromFQDN(string(long)); err == nil {
+		t.Errorf("expected error for 64-byte label, got nil")
+	}
+}
+
+// TestDNSCountNameUnmarshalTruncated verifies that a truncated buffer is rejected rather than
+// causing an out-of-bounds read.
+func TestDNSCountNameUnmarshalTruncated(t *testing.T) {
+	// Length claims 5 bytes of RawName but only 2 are present.
+	truncated := []byte{5, 1, 0x03, 'c'}
+	in := dnsrecord.NewDNS_COUNT_NAME()
+	if _, err := in.Unmarshal(truncated); err == nil {
+		t.Errorf("expected error for truncated RawName, got nil")
+	}
+}

--- a/network/dns/dnsrecord/dns_record.go
+++ b/network/dns/dnsrecord/dns_record.go
@@ -1,0 +1,164 @@
+package dnsrecord
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+// DNSRecordVersion is the value that the Version field of a DNS_RECORD MUST carry.
+const DNSRecordVersion uint8 = 0x05
+
+// dnsRecordHeaderLength is the fixed size, in bytes, of the DNS_RECORD header that precedes
+// the variable-length Data field: DataLength(2) + Type(2) + Version(1) + Rank(1) + Flags(2) +
+// Serial(4) + TtlSeconds(4) + Reserved(4) + TimeStamp(4) = 24 bytes.
+const dnsRecordHeaderLength = 24
+
+// DNS_RECORD is the packed container that Active Directory stores in each value of the
+// dnsRecord LDAP attribute. It holds a fixed 24-byte header followed by a variable-length Data
+// field carrying the type-specific record-data payload (see DNS_RPC_RECORD_DATA,
+// section 2.2.2.2.4) selected by the Type field.
+//
+// The multi-byte header fields are little-endian except TtlSeconds, which [MS-DNSP] mandates
+// in big-endian byte order.
+//
+// Source: [MS-DNSP] dnsRecord (section 2.3.2.2)
+// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dnsp/6912b338-5472-4f59-b912-0edb536b6ed8
+type DNS_RECORD struct {
+	// DataLength (2 bytes): An unsigned binary integer containing the length, in bytes, of the
+	// Data field. Little-endian. Marshal recomputes this from the Data field.
+	DataLength uint16
+
+	// Type (2 bytes): The resource record's type. See DNS_RECORD_TYPE (section 2.2.2.1.1).
+	// Little-endian.
+	Type RecordType
+
+	// Version (1 byte): The version number associated with the resource record attribute. The
+	// value MUST be 0x05.
+	Version uint8
+
+	// Rank (1 byte): The least-significant byte of one of the RANK* flag values (see dwFlags,
+	// section 2.2.2.2.5).
+	Rank uint8
+
+	// Flags (2 bytes): Not used. The value MUST be 0x0000. Little-endian.
+	Flags uint16
+
+	// Serial (4 bytes): The serial number of the SOA record of the zone containing this
+	// resource record. Little-endian.
+	Serial uint32
+
+	// TtlSeconds (4 bytes): The record's time-to-live, in seconds. This field uses big-endian
+	// byte order.
+	TtlSeconds uint32
+
+	// Reserved (4 bytes): This field is reserved for future use. The value MUST be 0x00000000.
+	Reserved uint32
+
+	// TimeStamp (4 bytes): The time at which the record was last refreshed, in hours since
+	// 1601-01-01 00:00:00 UTC, or 0 for a static record. Little-endian.
+	TimeStamp uint32
+
+	// Data (variable): The resource record's data. See DNS_RPC_RECORD_DATA (section 2.2.2.2.4).
+	Data []byte
+}
+
+// NewDNS_RECORD creates a new DNS_RECORD with the Version field initialized to the mandatory
+// value 0x05.
+//
+// Returns:
+// - A pointer to the new DNS_RECORD structure
+func NewDNS_RECORD() *DNS_RECORD {
+	return &DNS_RECORD{
+		Version: DNSRecordVersion,
+	}
+}
+
+// SetData replaces the record's Data field and updates DataLength to match. payload is any of
+// the record-data payload structures (for example *DNS_RPC_RECORD_A); its Marshal output
+// becomes the Data field. The caller is responsible for setting Type to match the payload.
+//
+// Parameters:
+// - payload: A record-data payload exposing Marshal() ([]byte, error)
+//
+// Returns:
+// - An error if the payload fails to marshal
+func (r *DNS_RECORD) SetData(payload interface{ Marshal() ([]byte, error) }) error {
+	data, err := payload.Marshal()
+	if err != nil {
+		return fmt.Errorf("marshalling record data: %w", err)
+	}
+	if len(data) > 0xFFFF {
+		return fmt.Errorf("record data is %d bytes, exceeds the 65535-byte DataLength limit", len(data))
+	}
+	r.Data = data
+	r.DataLength = uint16(len(data))
+	return nil
+}
+
+// Marshal marshals the DNS_RECORD structure into a byte array. DataLength is recomputed from
+// the current length of the Data field so the header always matches the payload.
+//
+// Returns:
+// - A byte array representing the DNS_RECORD structure
+// - An error if the marshaling fails
+func (r *DNS_RECORD) Marshal() ([]byte, error) {
+	if len(r.Data) > 0xFFFF {
+		return nil, fmt.Errorf("record data is %d bytes, exceeds the 65535-byte DataLength limit", len(r.Data))
+	}
+	r.DataLength = uint16(len(r.Data))
+
+	marshalled := make([]byte, dnsRecordHeaderLength)
+	binary.LittleEndian.PutUint16(marshalled[0:2], r.DataLength)
+	binary.LittleEndian.PutUint16(marshalled[2:4], uint16(r.Type))
+	marshalled[4] = r.Version
+	marshalled[5] = r.Rank
+	binary.LittleEndian.PutUint16(marshalled[6:8], r.Flags)
+	binary.LittleEndian.PutUint32(marshalled[8:12], r.Serial)
+	// TtlSeconds is big-endian per [MS-DNSP] section 2.3.2.2.
+	binary.BigEndian.PutUint32(marshalled[12:16], r.TtlSeconds)
+	binary.LittleEndian.PutUint32(marshalled[16:20], r.Reserved)
+	binary.LittleEndian.PutUint32(marshalled[20:24], r.TimeStamp)
+
+	marshalled = append(marshalled, r.Data...)
+	return marshalled, nil
+}
+
+// Unmarshal unmarshals a byte array into the DNS_RECORD structure.
+//
+// Parameters:
+// - rawData: The byte array to unmarshal
+//
+// Returns:
+// - The number of bytes read (24-byte header plus DataLength bytes of Data)
+// - An error if the unmarshaling fails
+func (r *DNS_RECORD) Unmarshal(rawData []byte) (int, error) {
+	if len(rawData) < dnsRecordHeaderLength {
+		return 0, fmt.Errorf("rawData too short for DNS_RECORD header: need %d bytes, have %d", dnsRecordHeaderLength, len(rawData))
+	}
+
+	r.DataLength = binary.LittleEndian.Uint16(rawData[0:2])
+	r.Type = RecordType(binary.LittleEndian.Uint16(rawData[2:4]))
+	r.Version = rawData[4]
+	r.Rank = rawData[5]
+	r.Flags = binary.LittleEndian.Uint16(rawData[6:8])
+	r.Serial = binary.LittleEndian.Uint32(rawData[8:12])
+	// TtlSeconds is big-endian per [MS-DNSP] section 2.3.2.2.
+	r.TtlSeconds = binary.BigEndian.Uint32(rawData[12:16])
+	r.Reserved = binary.LittleEndian.Uint32(rawData[16:20])
+	r.TimeStamp = binary.LittleEndian.Uint32(rawData[20:24])
+	offset := dnsRecordHeaderLength
+
+	if len(rawData) < offset+int(r.DataLength) {
+		return 0, fmt.Errorf("rawData too short for DNS_RECORD Data: need %d bytes, have %d", offset+int(r.DataLength), len(rawData))
+	}
+
+	if r.DataLength == 0 {
+		r.Data = nil
+	} else {
+		r.Data = make([]byte, r.DataLength)
+		copy(r.Data, rawData[offset:offset+int(r.DataLength)])
+	}
+	offset += int(r.DataLength)
+
+	return offset, nil
+}

--- a/network/dns/dnsrecord/dns_record_test.go
+++ b/network/dns/dnsrecord/dns_record_test.go
@@ -1,0 +1,163 @@
+package dnsrecord_test
+
+import (
+	"bytes"
+	"net"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/dns/dnsrecord"
+)
+
+// TestDNSRecordHeaderEndianness pins the mixed-endian header layout: DataLength, Type, Flags,
+// Serial, and TimeStamp are little-endian, while TtlSeconds is big-endian per [MS-DNSP]
+// section 2.3.2.2. This is the field most likely to be marshaled incorrectly.
+func TestDNSRecordHeaderEndianness(t *testing.T) {
+	a := dnsrecord.NewDNS_RPC_RECORD_A()
+	if err := a.SetIPv4(net.ParseIP("192.0.2.1")); err != nil {
+		t.Fatalf("SetIPv4 failed: %v", err)
+	}
+
+	rec := dnsrecord.NewDNS_RECORD()
+	rec.Type = dnsrecord.DNS_TYPE_A
+	rec.Rank = 0xF0
+	rec.Serial = 0x11223344
+	rec.TtlSeconds = 0x00000E10 // 3600
+	rec.TimeStamp = 0xAABBCCDD
+	if err := rec.SetData(a); err != nil {
+		t.Fatalf("SetData failed: %v", err)
+	}
+
+	marshalled, err := rec.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	want := []byte{
+		0x04, 0x00, // DataLength = 4, little-endian
+		0x01, 0x00, // Type = DNS_TYPE_A (1), little-endian
+		0x05,       // Version = 5
+		0xF0,       // Rank
+		0x00, 0x00, // Flags = 0
+		0x44, 0x33, 0x22, 0x11, // Serial, little-endian
+		0x00, 0x00, 0x0E, 0x10, // TtlSeconds = 3600, BIG-endian
+		0x00, 0x00, 0x00, 0x00, // Reserved = 0
+		0xDD, 0xCC, 0xBB, 0xAA, // TimeStamp, little-endian
+		192, 0, 2, 1, // Data: A record
+	}
+	if !bytes.Equal(marshalled, want) {
+		t.Errorf("Marshal =\n % x\nwant\n % x", marshalled, want)
+	}
+}
+
+// TestDNSRecordRoundTripWithA round-trips a full A record through DNS_RECORD and its payload.
+func TestDNSRecordRoundTripWithA(t *testing.T) {
+	a := dnsrecord.NewDNS_RPC_RECORD_A()
+	if err := a.SetIPv4(net.ParseIP("203.0.113.9")); err != nil {
+		t.Fatalf("SetIPv4 failed: %v", err)
+	}
+	rec := dnsrecord.NewDNS_RECORD()
+	rec.Type = dnsrecord.DNS_TYPE_A
+	rec.TtlSeconds = 600
+	if err := rec.SetData(a); err != nil {
+		t.Fatalf("SetData failed: %v", err)
+	}
+
+	marshalled, err := rec.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	in := dnsrecord.NewDNS_RECORD()
+	read, err := in.Unmarshal(marshalled)
+	if err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if read != len(marshalled) {
+		t.Errorf("Unmarshal read %d bytes; want %d", read, len(marshalled))
+	}
+	if in.Type != dnsrecord.DNS_TYPE_A {
+		t.Errorf("Type = %s; want DNS_TYPE_A", in.Type)
+	}
+	if in.Version != 0x05 {
+		t.Errorf("Version = %#x; want 0x05", in.Version)
+	}
+	if in.TtlSeconds != 600 {
+		t.Errorf("TtlSeconds = %d; want 600", in.TtlSeconds)
+	}
+	if in.DataLength != 4 {
+		t.Errorf("DataLength = %d; want 4", in.DataLength)
+	}
+
+	parsed := dnsrecord.NewDNS_RPC_RECORD_A()
+	if _, err := parsed.Unmarshal(in.Data); err != nil {
+		t.Fatalf("parsing A payload failed: %v", err)
+	}
+	if got := parsed.GetIPv4().String(); got != "203.0.113.9" {
+		t.Errorf("recovered A = %q; want 203.0.113.9", got)
+	}
+}
+
+// TestDNSRecordRoundTripWithSOA exercises a variable-length payload (SOA) inside DNS_RECORD to
+// confirm DataLength is computed and honored across the header/payload boundary.
+func TestDNSRecordRoundTripWithSOA(t *testing.T) {
+	soa := dnsrecord.NewDNS_RPC_RECORD_SOA()
+	soa.DwSerialNo = 2023111401
+	soa.DwRefresh = 900
+	soa.DwRetry = 600
+	soa.DwExpire = 86400
+	soa.DwMinimumTtl = 3600
+	if err := soa.NamePrimaryServer.SetFQDN("ns1.example.com"); err != nil {
+		t.Fatalf("SetFQDN(primary) failed: %v", err)
+	}
+	if err := soa.ZoneAdminEmail.SetFQDN("hostmaster.example.com"); err != nil {
+		t.Fatalf("SetFQDN(admin) failed: %v", err)
+	}
+
+	rec := dnsrecord.NewDNS_RECORD()
+	rec.Type = dnsrecord.DNS_TYPE_SOA
+	if err := rec.SetData(soa); err != nil {
+		t.Fatalf("SetData failed: %v", err)
+	}
+
+	marshalled, err := rec.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	in := dnsrecord.NewDNS_RECORD()
+	if _, err := in.Unmarshal(marshalled); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if int(in.DataLength) != len(in.Data) {
+		t.Errorf("DataLength %d != len(Data) %d", in.DataLength, len(in.Data))
+	}
+
+	parsed := dnsrecord.NewDNS_RPC_RECORD_SOA()
+	if _, err := parsed.Unmarshal(in.Data); err != nil {
+		t.Fatalf("parsing SOA payload failed: %v", err)
+	}
+	if parsed.DwSerialNo != 2023111401 {
+		t.Errorf("recovered SOA serial = %d; want 2023111401", parsed.DwSerialNo)
+	}
+	primary, _ := parsed.NamePrimaryServer.GetFQDN()
+	if primary != "ns1.example.com" {
+		t.Errorf("recovered primary = %q; want ns1.example.com", primary)
+	}
+}
+
+// TestDNSRecordUnmarshalTruncated verifies both a short header and a Data field shorter than
+// the declared DataLength are rejected.
+func TestDNSRecordUnmarshalTruncated(t *testing.T) {
+	in := dnsrecord.NewDNS_RECORD()
+	if _, err := in.Unmarshal(make([]byte, 23)); err == nil {
+		t.Errorf("expected error for short header, got nil")
+	}
+
+	// Header declares DataLength=8 but only 2 data bytes follow.
+	header := make([]byte, 24)
+	header[0] = 0x08 // DataLength low byte
+	truncated := append(header, 0x00, 0x00)
+	if _, err := in.Unmarshal(truncated); err == nil {
+		t.Errorf("expected error for truncated Data, got nil")
+	}
+}

--- a/network/dns/dnsrecord/dns_rpc_record_a.go
+++ b/network/dns/dnsrecord/dns_rpc_record_a.go
@@ -1,0 +1,76 @@
+package dnsrecord
+
+import (
+	"fmt"
+	"net"
+)
+
+// DNS_RPC_RECORD_A is the record-data payload for a DNS_TYPE_A record. It carries a single
+// IPv4 address. In a dnsRecord attribute value the containing DNS_RECORD has a DataLength of 4
+// and a Type of DNS_TYPE_A.
+//
+// Source: [MS-DNSP] DNS_RPC_RECORD_A (section 2.2.2.2.4.1), referenced from DNS_RPC_RECORD_DATA
+// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dnsp/38b87392-7f61-4e30-9263-9f0fb832d084
+type DNS_RPC_RECORD_A struct {
+	// IPAddress (4 bytes): An IPv4 address stored in network byte order.
+	IPAddress [4]byte
+}
+
+// NewDNS_RPC_RECORD_A creates a new, empty DNS_RPC_RECORD_A.
+//
+// Returns:
+// - A pointer to the new DNS_RPC_RECORD_A structure
+func NewDNS_RPC_RECORD_A() *DNS_RPC_RECORD_A {
+	return &DNS_RPC_RECORD_A{}
+}
+
+// SetIPv4 sets the address from a net.IP. The address MUST be an IPv4 address.
+//
+// Parameters:
+// - ip: The IPv4 address to store
+//
+// Returns:
+// - An error if ip is not an IPv4 address
+func (r *DNS_RPC_RECORD_A) SetIPv4(ip net.IP) error {
+	v4 := ip.To4()
+	if v4 == nil {
+		return fmt.Errorf("DNS_RPC_RECORD_A: %q is not an IPv4 address", ip.String())
+	}
+	copy(r.IPAddress[:], v4)
+	return nil
+}
+
+// GetIPv4 returns the stored address as a net.IP.
+//
+// Returns:
+// - The IPv4 address as a net.IP
+func (r *DNS_RPC_RECORD_A) GetIPv4() net.IP {
+	return net.IPv4(r.IPAddress[0], r.IPAddress[1], r.IPAddress[2], r.IPAddress[3])
+}
+
+// Marshal marshals the DNS_RPC_RECORD_A structure into a byte array.
+//
+// Returns:
+// - A byte array representing the DNS_RPC_RECORD_A structure
+// - An error if the marshaling fails
+func (r *DNS_RPC_RECORD_A) Marshal() ([]byte, error) {
+	marshalled := make([]byte, 4)
+	copy(marshalled, r.IPAddress[:])
+	return marshalled, nil
+}
+
+// Unmarshal unmarshals a byte array into the DNS_RPC_RECORD_A structure.
+//
+// Parameters:
+// - rawData: The byte array to unmarshal
+//
+// Returns:
+// - The number of bytes read
+// - An error if the unmarshaling fails
+func (r *DNS_RPC_RECORD_A) Unmarshal(rawData []byte) (int, error) {
+	if len(rawData) < 4 {
+		return 0, fmt.Errorf("rawData too short for DNS_RPC_RECORD_A: need 4 bytes, have %d", len(rawData))
+	}
+	copy(r.IPAddress[:], rawData[:4])
+	return 4, nil
+}

--- a/network/dns/dnsrecord/dns_rpc_record_a_test.go
+++ b/network/dns/dnsrecord/dns_rpc_record_a_test.go
@@ -1,0 +1,67 @@
+package dnsrecord_test
+
+import (
+	"bytes"
+	"net"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/dns/dnsrecord"
+)
+
+// TestRecordAWireShape verifies that the IPv4 address is stored as 4 raw bytes in network
+// order (192.0.2.1 -> C0 00 02 01).
+func TestRecordAWireShape(t *testing.T) {
+	r := dnsrecord.NewDNS_RPC_RECORD_A()
+	if err := r.SetIPv4(net.ParseIP("192.0.2.1")); err != nil {
+		t.Fatalf("SetIPv4 failed: %v", err)
+	}
+
+	marshalled, err := r.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+	want := []byte{192, 0, 2, 1}
+	if !bytes.Equal(marshalled, want) {
+		t.Errorf("Marshal = % x; want % x", marshalled, want)
+	}
+}
+
+// TestRecordARoundTrip round-trips an A record and checks the recovered address.
+func TestRecordARoundTrip(t *testing.T) {
+	r := dnsrecord.NewDNS_RPC_RECORD_A()
+	if err := r.SetIPv4(net.ParseIP("10.20.30.40")); err != nil {
+		t.Fatalf("SetIPv4 failed: %v", err)
+	}
+	marshalled, err := r.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	in := dnsrecord.NewDNS_RPC_RECORD_A()
+	read, err := in.Unmarshal(marshalled)
+	if err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if read != 4 {
+		t.Errorf("Unmarshal read %d bytes; want 4", read)
+	}
+	if got := in.GetIPv4().String(); got != "10.20.30.40" {
+		t.Errorf("GetIPv4 = %q; want 10.20.30.40", got)
+	}
+}
+
+// TestRecordARejectsIPv6 verifies SetIPv4 rejects a non-IPv4 address.
+func TestRecordARejectsIPv6(t *testing.T) {
+	r := dnsrecord.NewDNS_RPC_RECORD_A()
+	if err := r.SetIPv4(net.ParseIP("2001:db8::1")); err == nil {
+		t.Errorf("expected error setting IPv6 address on A record, got nil")
+	}
+}
+
+// TestRecordAUnmarshalTruncated verifies that fewer than 4 bytes is an error.
+func TestRecordAUnmarshalTruncated(t *testing.T) {
+	in := dnsrecord.NewDNS_RPC_RECORD_A()
+	if _, err := in.Unmarshal([]byte{1, 2, 3}); err == nil {
+		t.Errorf("expected error for truncated A record, got nil")
+	}
+}

--- a/network/dns/dnsrecord/dns_rpc_record_aaaa.go
+++ b/network/dns/dnsrecord/dns_rpc_record_aaaa.go
@@ -1,0 +1,79 @@
+package dnsrecord
+
+import (
+	"fmt"
+	"net"
+)
+
+// DNS_RPC_RECORD_AAAA is the record-data payload for a DNS_TYPE_AAAA record. It carries a
+// single IPv6 address. In a dnsRecord attribute value the containing DNS_RECORD has a
+// DataLength of 16 and a Type of DNS_TYPE_AAAA.
+//
+// Source: [MS-DNSP] DNS_RPC_RECORD_AAAA (section 2.2.2.2.4.17)
+// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dnsp/ee33fef1-6e82-42d0-8107-0f6d21be072a
+type DNS_RPC_RECORD_AAAA struct {
+	// IPv6Address (16 bytes): An IPv6 address stored in network byte order.
+	IPv6Address [16]byte
+}
+
+// NewDNS_RPC_RECORD_AAAA creates a new, empty DNS_RPC_RECORD_AAAA.
+//
+// Returns:
+// - A pointer to the new DNS_RPC_RECORD_AAAA structure
+func NewDNS_RPC_RECORD_AAAA() *DNS_RPC_RECORD_AAAA {
+	return &DNS_RPC_RECORD_AAAA{}
+}
+
+// SetIPv6 sets the address from a net.IP. The address MUST be representable as a 16-byte IPv6
+// address.
+//
+// Parameters:
+// - ip: The IPv6 address to store
+//
+// Returns:
+// - An error if ip cannot be represented as a 16-byte address
+func (r *DNS_RPC_RECORD_AAAA) SetIPv6(ip net.IP) error {
+	v6 := ip.To16()
+	if v6 == nil {
+		return fmt.Errorf("DNS_RPC_RECORD_AAAA: %q is not a valid IP address", ip.String())
+	}
+	copy(r.IPv6Address[:], v6)
+	return nil
+}
+
+// GetIPv6 returns the stored address as a net.IP.
+//
+// Returns:
+// - The IPv6 address as a net.IP
+func (r *DNS_RPC_RECORD_AAAA) GetIPv6() net.IP {
+	ip := make(net.IP, 16)
+	copy(ip, r.IPv6Address[:])
+	return ip
+}
+
+// Marshal marshals the DNS_RPC_RECORD_AAAA structure into a byte array.
+//
+// Returns:
+// - A byte array representing the DNS_RPC_RECORD_AAAA structure
+// - An error if the marshaling fails
+func (r *DNS_RPC_RECORD_AAAA) Marshal() ([]byte, error) {
+	marshalled := make([]byte, 16)
+	copy(marshalled, r.IPv6Address[:])
+	return marshalled, nil
+}
+
+// Unmarshal unmarshals a byte array into the DNS_RPC_RECORD_AAAA structure.
+//
+// Parameters:
+// - rawData: The byte array to unmarshal
+//
+// Returns:
+// - The number of bytes read
+// - An error if the unmarshaling fails
+func (r *DNS_RPC_RECORD_AAAA) Unmarshal(rawData []byte) (int, error) {
+	if len(rawData) < 16 {
+		return 0, fmt.Errorf("rawData too short for DNS_RPC_RECORD_AAAA: need 16 bytes, have %d", len(rawData))
+	}
+	copy(r.IPv6Address[:], rawData[:16])
+	return 16, nil
+}

--- a/network/dns/dnsrecord/dns_rpc_record_aaaa_test.go
+++ b/network/dns/dnsrecord/dns_rpc_record_aaaa_test.go
@@ -1,0 +1,62 @@
+package dnsrecord_test
+
+import (
+	"bytes"
+	"net"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/dns/dnsrecord"
+)
+
+// TestRecordAAAAWireShape verifies that the IPv6 address is stored as 16 raw bytes in network
+// order.
+func TestRecordAAAAWireShape(t *testing.T) {
+	r := dnsrecord.NewDNS_RPC_RECORD_AAAA()
+	if err := r.SetIPv6(net.ParseIP("2001:db8::1")); err != nil {
+		t.Fatalf("SetIPv6 failed: %v", err)
+	}
+
+	marshalled, err := r.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+	if len(marshalled) != 16 {
+		t.Fatalf("Marshal produced %d bytes; want 16", len(marshalled))
+	}
+	want := []byte{0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01}
+	if !bytes.Equal(marshalled, want) {
+		t.Errorf("Marshal = % x; want % x", marshalled, want)
+	}
+}
+
+// TestRecordAAAARoundTrip round-trips an AAAA record and checks the recovered address.
+func TestRecordAAAARoundTrip(t *testing.T) {
+	r := dnsrecord.NewDNS_RPC_RECORD_AAAA()
+	if err := r.SetIPv6(net.ParseIP("fe80::20c:29ff:fe1a:2b3c")); err != nil {
+		t.Fatalf("SetIPv6 failed: %v", err)
+	}
+	marshalled, err := r.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	in := dnsrecord.NewDNS_RPC_RECORD_AAAA()
+	read, err := in.Unmarshal(marshalled)
+	if err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if read != 16 {
+		t.Errorf("Unmarshal read %d bytes; want 16", read)
+	}
+	if got := in.GetIPv6().String(); got != "fe80::20c:29ff:fe1a:2b3c" {
+		t.Errorf("GetIPv6 = %q; want fe80::20c:29ff:fe1a:2b3c", got)
+	}
+}
+
+// TestRecordAAAAUnmarshalTruncated verifies that fewer than 16 bytes is an error.
+func TestRecordAAAAUnmarshalTruncated(t *testing.T) {
+	in := dnsrecord.NewDNS_RPC_RECORD_AAAA()
+	if _, err := in.Unmarshal(make([]byte, 15)); err == nil {
+		t.Errorf("expected error for truncated AAAA record, got nil")
+	}
+}

--- a/network/dns/dnsrecord/dns_rpc_record_name_preference.go
+++ b/network/dns/dnsrecord/dns_rpc_record_name_preference.go
@@ -1,0 +1,76 @@
+package dnsrecord
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+// DNS_RPC_RECORD_NAME_PREFERENCE is the record-data payload for records that pair a 16-bit
+// preference value with an FQDN. Per [MS-DNSP] it is used for the following record types:
+//
+//	DNS_TYPE_MX, DNS_TYPE_AFSDB, DNS_TYPE_RT
+//
+// WPreference is stored in network byte order (big-endian). NameExchange is stored in
+// DNS_COUNT_NAME (section 2.2.2.2.2) form in a dnsRecord attribute value carried over LDAP.
+//
+// Source: [MS-DNSP] DNS_RPC_RECORD_NAME_PREFERENCE (section 2.2.2.2.4.8)
+// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dnsp/f647d391-6614-4c3e-b38b-4df971590eb6
+type DNS_RPC_RECORD_NAME_PREFERENCE struct {
+	// WPreference (2 bytes): The preference value for the DNS server that holds the record.
+	// Big-endian.
+	WPreference uint16
+
+	// NameExchange (variable): The FQDN of the server hosting the mail-exchange.
+	NameExchange DNS_COUNT_NAME
+}
+
+// NewDNS_RPC_RECORD_NAME_PREFERENCE creates a new, empty DNS_RPC_RECORD_NAME_PREFERENCE.
+//
+// Returns:
+// - A pointer to the new DNS_RPC_RECORD_NAME_PREFERENCE structure
+func NewDNS_RPC_RECORD_NAME_PREFERENCE() *DNS_RPC_RECORD_NAME_PREFERENCE {
+	return &DNS_RPC_RECORD_NAME_PREFERENCE{}
+}
+
+// Marshal marshals the DNS_RPC_RECORD_NAME_PREFERENCE structure into a byte array.
+//
+// Returns:
+// - A byte array representing the DNS_RPC_RECORD_NAME_PREFERENCE structure
+// - An error if the marshaling fails
+func (r *DNS_RPC_RECORD_NAME_PREFERENCE) Marshal() ([]byte, error) {
+	marshalled := make([]byte, 2)
+	binary.BigEndian.PutUint16(marshalled[0:2], r.WPreference)
+
+	exchange, err := r.NameExchange.Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("marshalling NameExchange: %w", err)
+	}
+	marshalled = append(marshalled, exchange...)
+
+	return marshalled, nil
+}
+
+// Unmarshal unmarshals a byte array into the DNS_RPC_RECORD_NAME_PREFERENCE structure.
+//
+// Parameters:
+// - rawData: The byte array to unmarshal
+//
+// Returns:
+// - The number of bytes read
+// - An error if the unmarshaling fails
+func (r *DNS_RPC_RECORD_NAME_PREFERENCE) Unmarshal(rawData []byte) (int, error) {
+	if len(rawData) < 2 {
+		return 0, fmt.Errorf("rawData too short for DNS_RPC_RECORD_NAME_PREFERENCE fixed field: need 2 bytes, have %d", len(rawData))
+	}
+
+	r.WPreference = binary.BigEndian.Uint16(rawData[0:2])
+	offset := 2
+
+	bytesRead, err := r.NameExchange.Unmarshal(rawData[offset:])
+	if err != nil {
+		return offset, fmt.Errorf("unmarshalling NameExchange: %w", err)
+	}
+	offset += bytesRead
+
+	return offset, nil
+}

--- a/network/dns/dnsrecord/dns_rpc_record_name_preference_test.go
+++ b/network/dns/dnsrecord/dns_rpc_record_name_preference_test.go
@@ -1,0 +1,57 @@
+package dnsrecord_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/dns/dnsrecord"
+)
+
+// TestRecordNamePreferenceWireShape verifies the big-endian wPreference followed by the
+// DNS_COUNT_NAME exchange name (used by MX, AFSDB, RT).
+func TestRecordNamePreferenceWireShape(t *testing.T) {
+	r := dnsrecord.NewDNS_RPC_RECORD_NAME_PREFERENCE()
+	r.WPreference = 0x000A // 10
+	if err := r.NameExchange.SetFQDN("mail.example.com"); err != nil {
+		t.Fatalf("SetFQDN failed: %v", err)
+	}
+
+	marshalled, err := r.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+	// Big-endian preference: 00 0A.
+	if !bytes.Equal(marshalled[:2], []byte{0x00, 0x0A}) {
+		t.Errorf("wPreference = % x; want 00 0A", marshalled[:2])
+	}
+}
+
+// TestRecordNamePreferenceRoundTrip round-trips an MX-style record.
+func TestRecordNamePreferenceRoundTrip(t *testing.T) {
+	r := dnsrecord.NewDNS_RPC_RECORD_NAME_PREFERENCE()
+	r.WPreference = 20
+	if err := r.NameExchange.SetFQDN("mx2.example.com"); err != nil {
+		t.Fatalf("SetFQDN failed: %v", err)
+	}
+
+	marshalled, err := r.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	in := dnsrecord.NewDNS_RPC_RECORD_NAME_PREFERENCE()
+	read, err := in.Unmarshal(marshalled)
+	if err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if read != len(marshalled) {
+		t.Errorf("Unmarshal read %d bytes; want %d", read, len(marshalled))
+	}
+	if in.WPreference != 20 {
+		t.Errorf("WPreference = %d; want 20", in.WPreference)
+	}
+	exchange, _ := in.NameExchange.GetFQDN()
+	if exchange != "mx2.example.com" {
+		t.Errorf("NameExchange = %q; want mx2.example.com", exchange)
+	}
+}

--- a/network/dns/dnsrecord/dns_rpc_record_node_name.go
+++ b/network/dns/dnsrecord/dns_rpc_record_node_name.go
@@ -1,0 +1,47 @@
+package dnsrecord
+
+// DNS_RPC_RECORD_NODE_NAME is the record-data payload for records whose data is a single
+// FQDN. Per [MS-DNSP] it is used for the following record types:
+//
+//	DNS_TYPE_PTR, DNS_TYPE_NS, DNS_TYPE_CNAME, DNS_TYPE_DNAME,
+//	DNS_TYPE_MB, DNS_TYPE_MR, DNS_TYPE_MG, DNS_TYPE_MD, DNS_TYPE_MF
+//
+// Although the specification documents nameNode in DNS_RPC_NAME (section 2.2.2.2.1) form, in a
+// dnsRecord attribute value carried over LDAP the name is stored in DNS_COUNT_NAME
+// (section 2.2.2.2.2) form.
+//
+// Source: [MS-DNSP] DNS_RPC_RECORD_NODE_NAME (section 2.2.2.2.4.2)
+// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dnsp/8f986756-f151-4f5b-bfcf-0d85be8b0d7e
+type DNS_RPC_RECORD_NODE_NAME struct {
+	// NameNode (variable): The FQDN of this node.
+	NameNode DNS_COUNT_NAME
+}
+
+// NewDNS_RPC_RECORD_NODE_NAME creates a new, empty DNS_RPC_RECORD_NODE_NAME.
+//
+// Returns:
+// - A pointer to the new DNS_RPC_RECORD_NODE_NAME structure
+func NewDNS_RPC_RECORD_NODE_NAME() *DNS_RPC_RECORD_NODE_NAME {
+	return &DNS_RPC_RECORD_NODE_NAME{}
+}
+
+// Marshal marshals the DNS_RPC_RECORD_NODE_NAME structure into a byte array.
+//
+// Returns:
+// - A byte array representing the DNS_RPC_RECORD_NODE_NAME structure
+// - An error if the marshaling fails
+func (r *DNS_RPC_RECORD_NODE_NAME) Marshal() ([]byte, error) {
+	return r.NameNode.Marshal()
+}
+
+// Unmarshal unmarshals a byte array into the DNS_RPC_RECORD_NODE_NAME structure.
+//
+// Parameters:
+// - rawData: The byte array to unmarshal
+//
+// Returns:
+// - The number of bytes read
+// - An error if the unmarshaling fails
+func (r *DNS_RPC_RECORD_NODE_NAME) Unmarshal(rawData []byte) (int, error) {
+	return r.NameNode.Unmarshal(rawData)
+}

--- a/network/dns/dnsrecord/dns_rpc_record_node_name_test.go
+++ b/network/dns/dnsrecord/dns_rpc_record_node_name_test.go
@@ -1,0 +1,44 @@
+package dnsrecord_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/dns/dnsrecord"
+)
+
+// TestRecordNodeNameRoundTrip round-trips a NODE_NAME record (used by NS, PTR, CNAME, etc.)
+// and verifies the embedded DNS_COUNT_NAME encoding.
+func TestRecordNodeNameRoundTrip(t *testing.T) {
+	r := dnsrecord.NewDNS_RPC_RECORD_NODE_NAME()
+	if err := r.NameNode.SetFQDN("host.example.com"); err != nil {
+		t.Fatalf("SetFQDN failed: %v", err)
+	}
+
+	marshalled, err := r.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+	// 04 'host' 07 'example' 03 'com' 00, prefixed by Length(21) and LabelCount(3).
+	wantRaw := []byte{0x04, 'h', 'o', 's', 't', 0x07, 'e', 'x', 'a', 'm', 'p', 'l', 'e', 0x03, 'c', 'o', 'm', 0x00}
+	want := append([]byte{byte(len(wantRaw)), 3}, wantRaw...)
+	if !bytes.Equal(marshalled, want) {
+		t.Errorf("Marshal = % x; want % x", marshalled, want)
+	}
+
+	in := dnsrecord.NewDNS_RPC_RECORD_NODE_NAME()
+	read, err := in.Unmarshal(marshalled)
+	if err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if read != len(marshalled) {
+		t.Errorf("Unmarshal read %d bytes; want %d", read, len(marshalled))
+	}
+	got, err := in.NameNode.GetFQDN()
+	if err != nil {
+		t.Fatalf("GetFQDN failed: %v", err)
+	}
+	if got != "host.example.com" {
+		t.Errorf("NameNode = %q; want host.example.com", got)
+	}
+}

--- a/network/dns/dnsrecord/dns_rpc_record_soa.go
+++ b/network/dns/dnsrecord/dns_rpc_record_soa.go
@@ -1,0 +1,113 @@
+package dnsrecord
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+// DNS_RPC_RECORD_SOA is the record-data payload for a DNS_TYPE_SOA (Start of Authority)
+// record, as specified in section 3.3.13 of [RFC1035].
+//
+// The five numeric fields are stored in network byte order (big-endian). The two names are
+// stored in DNS_COUNT_NAME (section 2.2.2.2.2) form in a dnsRecord attribute value carried
+// over LDAP (the specification documents them in DNS_RPC_NAME form for the RPC wire).
+//
+// Source: [MS-DNSP] DNS_RPC_RECORD_SOA (section 2.2.2.2.4.3)
+// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dnsp/dcd3ec16-d6bf-4bb4-9128-6172f9e5f066
+type DNS_RPC_RECORD_SOA struct {
+	// DwSerialNo (4 bytes): The serial number of the SOA record. Big-endian.
+	DwSerialNo uint32
+
+	// DwRefresh (4 bytes): The interval, in seconds, at which a secondary DNS server attempts
+	// to contact the primary DNS server for an update. Big-endian.
+	DwRefresh uint32
+
+	// DwRetry (4 bytes): The interval, in seconds, at which a secondary DNS server retries to
+	// check with the primary DNS server in case of failure. Big-endian.
+	DwRetry uint32
+
+	// DwExpire (4 bytes): The duration, in seconds, that a secondary DNS server continues to
+	// attempt updates before assuming the primary DNS server is unreachable. Big-endian.
+	DwExpire uint32
+
+	// DwMinimumTtl (4 bytes): The minimum duration, in seconds, for which record data in the
+	// zone is valid. Big-endian.
+	DwMinimumTtl uint32
+
+	// NamePrimaryServer (variable): The FQDN of the primary DNS server for this zone.
+	NamePrimaryServer DNS_COUNT_NAME
+
+	// ZoneAdminEmail (variable): The contact email address for the zone administrators.
+	ZoneAdminEmail DNS_COUNT_NAME
+}
+
+// NewDNS_RPC_RECORD_SOA creates a new, empty DNS_RPC_RECORD_SOA.
+//
+// Returns:
+// - A pointer to the new DNS_RPC_RECORD_SOA structure
+func NewDNS_RPC_RECORD_SOA() *DNS_RPC_RECORD_SOA {
+	return &DNS_RPC_RECORD_SOA{}
+}
+
+// Marshal marshals the DNS_RPC_RECORD_SOA structure into a byte array.
+//
+// Returns:
+// - A byte array representing the DNS_RPC_RECORD_SOA structure
+// - An error if the marshaling fails
+func (r *DNS_RPC_RECORD_SOA) Marshal() ([]byte, error) {
+	marshalled := make([]byte, 20)
+	binary.BigEndian.PutUint32(marshalled[0:4], r.DwSerialNo)
+	binary.BigEndian.PutUint32(marshalled[4:8], r.DwRefresh)
+	binary.BigEndian.PutUint32(marshalled[8:12], r.DwRetry)
+	binary.BigEndian.PutUint32(marshalled[12:16], r.DwExpire)
+	binary.BigEndian.PutUint32(marshalled[16:20], r.DwMinimumTtl)
+
+	primary, err := r.NamePrimaryServer.Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("marshalling NamePrimaryServer: %w", err)
+	}
+	marshalled = append(marshalled, primary...)
+
+	admin, err := r.ZoneAdminEmail.Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("marshalling ZoneAdminEmail: %w", err)
+	}
+	marshalled = append(marshalled, admin...)
+
+	return marshalled, nil
+}
+
+// Unmarshal unmarshals a byte array into the DNS_RPC_RECORD_SOA structure.
+//
+// Parameters:
+// - rawData: The byte array to unmarshal
+//
+// Returns:
+// - The number of bytes read
+// - An error if the unmarshaling fails
+func (r *DNS_RPC_RECORD_SOA) Unmarshal(rawData []byte) (int, error) {
+	if len(rawData) < 20 {
+		return 0, fmt.Errorf("rawData too short for DNS_RPC_RECORD_SOA fixed fields: need 20 bytes, have %d", len(rawData))
+	}
+
+	r.DwSerialNo = binary.BigEndian.Uint32(rawData[0:4])
+	r.DwRefresh = binary.BigEndian.Uint32(rawData[4:8])
+	r.DwRetry = binary.BigEndian.Uint32(rawData[8:12])
+	r.DwExpire = binary.BigEndian.Uint32(rawData[12:16])
+	r.DwMinimumTtl = binary.BigEndian.Uint32(rawData[16:20])
+	offset := 20
+
+	bytesRead, err := r.NamePrimaryServer.Unmarshal(rawData[offset:])
+	if err != nil {
+		return offset, fmt.Errorf("unmarshalling NamePrimaryServer: %w", err)
+	}
+	offset += bytesRead
+
+	bytesRead, err = r.ZoneAdminEmail.Unmarshal(rawData[offset:])
+	if err != nil {
+		return offset, fmt.Errorf("unmarshalling ZoneAdminEmail: %w", err)
+	}
+	offset += bytesRead
+
+	return offset, nil
+}

--- a/network/dns/dnsrecord/dns_rpc_record_soa_test.go
+++ b/network/dns/dnsrecord/dns_rpc_record_soa_test.go
@@ -1,0 +1,84 @@
+package dnsrecord_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/dns/dnsrecord"
+)
+
+// TestRecordSOAWireShape verifies the big-endian encoding of the five numeric fields and the
+// two DNS_COUNT_NAME names.
+func TestRecordSOAWireShape(t *testing.T) {
+	r := dnsrecord.NewDNS_RPC_RECORD_SOA()
+	r.DwSerialNo = 0x01020304
+	r.DwRefresh = 0x05060708
+	r.DwRetry = 0x090a0b0c
+	r.DwExpire = 0x0d0e0f10
+	r.DwMinimumTtl = 0x11121314
+	if err := r.NamePrimaryServer.SetFQDN("ns.example.com"); err != nil {
+		t.Fatalf("SetFQDN(primary) failed: %v", err)
+	}
+	if err := r.ZoneAdminEmail.SetFQDN("admin.example.com"); err != nil {
+		t.Fatalf("SetFQDN(admin) failed: %v", err)
+	}
+
+	marshalled, err := r.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	// The five DWORDs are big-endian, laid out most-significant byte first.
+	wantHeader := []byte{
+		0x01, 0x02, 0x03, 0x04,
+		0x05, 0x06, 0x07, 0x08,
+		0x09, 0x0a, 0x0b, 0x0c,
+		0x0d, 0x0e, 0x0f, 0x10,
+		0x11, 0x12, 0x13, 0x14,
+	}
+	if !bytes.Equal(marshalled[:20], wantHeader) {
+		t.Errorf("SOA numeric header = % x; want % x", marshalled[:20], wantHeader)
+	}
+}
+
+// TestRecordSOARoundTrip round-trips an SOA record and checks every field.
+func TestRecordSOARoundTrip(t *testing.T) {
+	r := dnsrecord.NewDNS_RPC_RECORD_SOA()
+	r.DwSerialNo = 42
+	r.DwRefresh = 900
+	r.DwRetry = 600
+	r.DwExpire = 86400
+	r.DwMinimumTtl = 3600
+	if err := r.NamePrimaryServer.SetFQDN("ns1.example.com"); err != nil {
+		t.Fatalf("SetFQDN(primary) failed: %v", err)
+	}
+	if err := r.ZoneAdminEmail.SetFQDN("hostmaster.example.com"); err != nil {
+		t.Fatalf("SetFQDN(admin) failed: %v", err)
+	}
+
+	marshalled, err := r.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	in := dnsrecord.NewDNS_RPC_RECORD_SOA()
+	read, err := in.Unmarshal(marshalled)
+	if err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if read != len(marshalled) {
+		t.Errorf("Unmarshal read %d bytes; want %d", read, len(marshalled))
+	}
+
+	if in.DwSerialNo != 42 || in.DwRefresh != 900 || in.DwRetry != 600 || in.DwExpire != 86400 || in.DwMinimumTtl != 3600 {
+		t.Errorf("numeric fields mismatch: %+v", in)
+	}
+	primary, _ := in.NamePrimaryServer.GetFQDN()
+	admin, _ := in.ZoneAdminEmail.GetFQDN()
+	if primary != "ns1.example.com" {
+		t.Errorf("NamePrimaryServer = %q; want ns1.example.com", primary)
+	}
+	if admin != "hostmaster.example.com" {
+		t.Errorf("ZoneAdminEmail = %q; want hostmaster.example.com", admin)
+	}
+}

--- a/network/dns/dnsrecord/dns_rpc_record_srv.go
+++ b/network/dns/dnsrecord/dns_rpc_record_srv.go
@@ -1,0 +1,85 @@
+package dnsrecord
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+// DNS_RPC_RECORD_SRV is the record-data payload for a DNS_TYPE_SRV record, as specified in
+// [RFC2782].
+//
+// The three numeric fields are stored in network byte order (big-endian). NameTarget is
+// stored in DNS_COUNT_NAME (section 2.2.2.2.2) form in a dnsRecord attribute value carried
+// over LDAP.
+//
+// Source: [MS-DNSP] DNS_RPC_RECORD_SRV (section 2.2.2.2.4.7)
+// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dnsp/db37cab7-f121-43ba-81c5-ca0e198d4b9a
+type DNS_RPC_RECORD_SRV struct {
+	// WPriority (2 bytes): The priority of the target host, per [RFC2782]. Big-endian.
+	WPriority uint16
+
+	// WWeight (2 bytes): The relative weight for the target host, per [RFC2782]. Big-endian.
+	WWeight uint16
+
+	// WPort (2 bytes): The port number for the service on the target host, per [RFC2782].
+	// Big-endian.
+	WPort uint16
+
+	// NameTarget (variable): The FQDN of the server that hosts this service.
+	NameTarget DNS_COUNT_NAME
+}
+
+// NewDNS_RPC_RECORD_SRV creates a new, empty DNS_RPC_RECORD_SRV.
+//
+// Returns:
+// - A pointer to the new DNS_RPC_RECORD_SRV structure
+func NewDNS_RPC_RECORD_SRV() *DNS_RPC_RECORD_SRV {
+	return &DNS_RPC_RECORD_SRV{}
+}
+
+// Marshal marshals the DNS_RPC_RECORD_SRV structure into a byte array.
+//
+// Returns:
+// - A byte array representing the DNS_RPC_RECORD_SRV structure
+// - An error if the marshaling fails
+func (r *DNS_RPC_RECORD_SRV) Marshal() ([]byte, error) {
+	marshalled := make([]byte, 6)
+	binary.BigEndian.PutUint16(marshalled[0:2], r.WPriority)
+	binary.BigEndian.PutUint16(marshalled[2:4], r.WWeight)
+	binary.BigEndian.PutUint16(marshalled[4:6], r.WPort)
+
+	target, err := r.NameTarget.Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("marshalling NameTarget: %w", err)
+	}
+	marshalled = append(marshalled, target...)
+
+	return marshalled, nil
+}
+
+// Unmarshal unmarshals a byte array into the DNS_RPC_RECORD_SRV structure.
+//
+// Parameters:
+// - rawData: The byte array to unmarshal
+//
+// Returns:
+// - The number of bytes read
+// - An error if the unmarshaling fails
+func (r *DNS_RPC_RECORD_SRV) Unmarshal(rawData []byte) (int, error) {
+	if len(rawData) < 6 {
+		return 0, fmt.Errorf("rawData too short for DNS_RPC_RECORD_SRV fixed fields: need 6 bytes, have %d", len(rawData))
+	}
+
+	r.WPriority = binary.BigEndian.Uint16(rawData[0:2])
+	r.WWeight = binary.BigEndian.Uint16(rawData[2:4])
+	r.WPort = binary.BigEndian.Uint16(rawData[4:6])
+	offset := 6
+
+	bytesRead, err := r.NameTarget.Unmarshal(rawData[offset:])
+	if err != nil {
+		return offset, fmt.Errorf("unmarshalling NameTarget: %w", err)
+	}
+	offset += bytesRead
+
+	return offset, nil
+}

--- a/network/dns/dnsrecord/dns_rpc_record_srv_test.go
+++ b/network/dns/dnsrecord/dns_rpc_record_srv_test.go
@@ -1,0 +1,62 @@
+package dnsrecord_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/dns/dnsrecord"
+)
+
+// TestRecordSRVWireShape verifies the big-endian encoding of wPriority/wWeight/wPort followed
+// by the DNS_COUNT_NAME target.
+func TestRecordSRVWireShape(t *testing.T) {
+	r := dnsrecord.NewDNS_RPC_RECORD_SRV()
+	r.WPriority = 0x0102
+	r.WWeight = 0x0304
+	r.WPort = 0x0050 // port 80
+	if err := r.NameTarget.SetFQDN("srv.example.com"); err != nil {
+		t.Fatalf("SetFQDN failed: %v", err)
+	}
+
+	marshalled, err := r.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+	// Big-endian words: 01 02 | 03 04 | 00 50.
+	wantHeader := []byte{0x01, 0x02, 0x03, 0x04, 0x00, 0x50}
+	if !bytes.Equal(marshalled[:6], wantHeader) {
+		t.Errorf("SRV numeric header = % x; want % x", marshalled[:6], wantHeader)
+	}
+}
+
+// TestRecordSRVRoundTrip round-trips an SRV record and checks every field.
+func TestRecordSRVRoundTrip(t *testing.T) {
+	r := dnsrecord.NewDNS_RPC_RECORD_SRV()
+	r.WPriority = 10
+	r.WWeight = 20
+	r.WPort = 389
+	if err := r.NameTarget.SetFQDN("dc01.example.com"); err != nil {
+		t.Fatalf("SetFQDN failed: %v", err)
+	}
+
+	marshalled, err := r.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	in := dnsrecord.NewDNS_RPC_RECORD_SRV()
+	read, err := in.Unmarshal(marshalled)
+	if err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if read != len(marshalled) {
+		t.Errorf("Unmarshal read %d bytes; want %d", read, len(marshalled))
+	}
+	if in.WPriority != 10 || in.WWeight != 20 || in.WPort != 389 {
+		t.Errorf("numeric fields mismatch: priority=%d weight=%d port=%d", in.WPriority, in.WWeight, in.WPort)
+	}
+	target, _ := in.NameTarget.GetFQDN()
+	if target != "dc01.example.com" {
+		t.Errorf("NameTarget = %q; want dc01.example.com", target)
+	}
+}

--- a/network/dns/dnsrecord/dns_rpc_record_ts.go
+++ b/network/dns/dnsrecord/dns_rpc_record_ts.go
@@ -1,0 +1,87 @@
+package dnsrecord
+
+import (
+	"encoding/binary"
+	"fmt"
+	"time"
+)
+
+// ticksPerSecond is the number of 100-nanosecond intervals in one second.
+const ticksPerSecond = 10_000_000
+
+// epochDeltaSeconds is the number of seconds between the Windows FILETIME epoch
+// (1601-01-01 00:00:00 UTC) and the Unix epoch (1970-01-01 00:00:00 UTC).
+const epochDeltaSeconds = 11_644_473_600
+
+// DNS_RPC_RECORD_TS is the tombstone record-data payload. When the last record set for a node
+// in a directory-server-integrated zone is deleted, the DNS server sets the node's
+// dnsTombstoned attribute to TRUE and writes a dnsRecord value of type DNS_TYPE_ZERO whose
+// data is a DNS_RPC_RECORD_TS.
+//
+// EntombedTime is stored little-endian, unlike the big-endian numeric fields of the SOA, SRV,
+// and NAME_PREFERENCE payloads.
+//
+// Source: [MS-DNSP] DNS_RPC_RECORD_TS (section 2.2.2.2.4.23); tombstone handling is described
+// in Creating and Deleting a DNS Record,
+// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dnsp/c87b1caf-904d-4d8a-a7d1-3a6908112cd3
+type DNS_RPC_RECORD_TS struct {
+	// EntombedTime (8 bytes): The time at which the record was tombstoned, expressed as the
+	// number of 100-nanosecond intervals since 1601-01-01 00:00:00 UTC. Little-endian.
+	EntombedTime uint64
+}
+
+// NewDNS_RPC_RECORD_TS creates a new, empty DNS_RPC_RECORD_TS.
+//
+// Returns:
+// - A pointer to the new DNS_RPC_RECORD_TS structure
+func NewDNS_RPC_RECORD_TS() *DNS_RPC_RECORD_TS {
+	return &DNS_RPC_RECORD_TS{}
+}
+
+// SetTime sets EntombedTime from a time.Time.
+//
+// Parameters:
+// - t: The tombstone time
+func (r *DNS_RPC_RECORD_TS) SetTime(t time.Time) {
+	utc := t.UTC()
+	ticks := (utc.Unix()+epochDeltaSeconds)*ticksPerSecond + int64(utc.Nanosecond())/100
+	r.EntombedTime = uint64(ticks)
+}
+
+// GetTime returns EntombedTime as a UTC time.Time.
+//
+// Returns:
+// - The tombstone time in UTC
+func (r *DNS_RPC_RECORD_TS) GetTime() time.Time {
+	ticks := int64(r.EntombedTime)
+	secs := ticks/ticksPerSecond - epochDeltaSeconds
+	nsec := (ticks % ticksPerSecond) * 100
+	return time.Unix(secs, nsec).UTC()
+}
+
+// Marshal marshals the DNS_RPC_RECORD_TS structure into a byte array.
+//
+// Returns:
+// - A byte array representing the DNS_RPC_RECORD_TS structure
+// - An error if the marshaling fails
+func (r *DNS_RPC_RECORD_TS) Marshal() ([]byte, error) {
+	marshalled := make([]byte, 8)
+	binary.LittleEndian.PutUint64(marshalled, r.EntombedTime)
+	return marshalled, nil
+}
+
+// Unmarshal unmarshals a byte array into the DNS_RPC_RECORD_TS structure.
+//
+// Parameters:
+// - rawData: The byte array to unmarshal
+//
+// Returns:
+// - The number of bytes read
+// - An error if the unmarshaling fails
+func (r *DNS_RPC_RECORD_TS) Unmarshal(rawData []byte) (int, error) {
+	if len(rawData) < 8 {
+		return 0, fmt.Errorf("rawData too short for DNS_RPC_RECORD_TS: need 8 bytes, have %d", len(rawData))
+	}
+	r.EntombedTime = binary.LittleEndian.Uint64(rawData[:8])
+	return 8, nil
+}

--- a/network/dns/dnsrecord/dns_rpc_record_ts_test.go
+++ b/network/dns/dnsrecord/dns_rpc_record_ts_test.go
@@ -1,0 +1,63 @@
+package dnsrecord_test
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/TheManticoreProject/Manticore/network/dns/dnsrecord"
+)
+
+// TestRecordTSWireShape verifies EntombedTime is encoded little-endian (unlike the big-endian
+// SOA/SRV/preference numeric fields).
+func TestRecordTSWireShape(t *testing.T) {
+	r := dnsrecord.NewDNS_RPC_RECORD_TS()
+	r.EntombedTime = 0x0102030405060708
+
+	marshalled, err := r.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+	// Little-endian: least-significant byte first.
+	want := []byte{0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01}
+	if !bytes.Equal(marshalled, want) {
+		t.Errorf("Marshal = % x; want % x", marshalled, want)
+	}
+}
+
+// TestRecordTSRoundTrip round-trips the raw EntombedTime value.
+func TestRecordTSRoundTrip(t *testing.T) {
+	r := dnsrecord.NewDNS_RPC_RECORD_TS()
+	r.EntombedTime = 133444736000000000
+
+	marshalled, err := r.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	in := dnsrecord.NewDNS_RPC_RECORD_TS()
+	read, err := in.Unmarshal(marshalled)
+	if err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if read != 8 {
+		t.Errorf("Unmarshal read %d bytes; want 8", read)
+	}
+	if in.EntombedTime != 133444736000000000 {
+		t.Errorf("EntombedTime = %d; want 133444736000000000", in.EntombedTime)
+	}
+}
+
+// TestRecordTSTimeConversion verifies the FILETIME (100-ns since 1601) conversion helpers by
+// round-tripping a whole-second timestamp.
+func TestRecordTSTimeConversion(t *testing.T) {
+	want := time.Date(2023, time.November, 14, 22, 13, 20, 0, time.UTC)
+
+	r := dnsrecord.NewDNS_RPC_RECORD_TS()
+	r.SetTime(want)
+
+	got := r.GetTime()
+	if !got.Equal(want) {
+		t.Errorf("GetTime = %v; want %v", got, want)
+	}
+}

--- a/network/dns/dnsrecord/doc.go
+++ b/network/dns/dnsrecord/doc.go
@@ -1,0 +1,37 @@
+// Package dnsrecord implements the byte-level wire structures of the DNS resource
+// records that Active Directory stores in the dnsRecord LDAP attribute, as specified
+// by the Domain Name Service (DNS) Server Management Protocol [MS-DNSP].
+//
+// Unlike the NDR-marshaled RPC structures under windows/protocols/ms-dnsp (which are
+// exchanged over the DnsServer RPC interface), the structures here use the packed,
+// mixed-endian on-directory format defined for the dnsRecord attribute in [MS-DNSP]
+// section 2.3.2.2. This is the format read and written by LDAP tooling that manipulates
+// AD-integrated DNS zones directly (for example dnstool.py from krbrelayx).
+//
+// The outer container is DNS_RECORD (section 2.3.2.2). Its Data field carries one of the
+// type-specific record-data payloads from DNS_RPC_RECORD_DATA (section 2.2.2.2.4), selected
+// by the Type field (a DNS_RECORD_TYPE, section 2.2.2.1.1). The payloads implemented here
+// are the ones commonly manipulated over LDAP:
+//
+//   - DNS_RPC_RECORD_A               (section 2.2.2.2.4.1)  - A
+//   - DNS_RPC_RECORD_AAAA            (section 2.2.2.2.4.17) - AAAA
+//   - DNS_RPC_RECORD_NODE_NAME       (section 2.2.2.2.4.2)  - NS, PTR, CNAME, DNAME, ...
+//   - DNS_RPC_RECORD_SOA             (section 2.2.2.2.4.3)  - SOA
+//   - DNS_RPC_RECORD_NAME_PREFERENCE (section 2.2.2.2.4.8)  - MX, AFSDB, RT
+//   - DNS_RPC_RECORD_SRV             (section 2.2.2.2.4.7)  - SRV
+//   - DNS_RPC_RECORD_TS             (section 2.2.2.2.4.23) - tombstone
+//
+// Name fields inside these payloads use DNS_COUNT_NAME (section 2.2.2.2.2), the LDAP
+// on-directory form of a name, rather than the RPC-wire DNS_RPC_NAME form: when dnsRecord
+// values are written over LDAP each name is converted from DNS_RPC_NAME to DNS_COUNT_NAME,
+// and converted back when read.
+//
+// Every structure exposes Marshal() ([]byte, error) and Unmarshal([]byte) (int, error),
+// where Unmarshal returns the number of bytes consumed. The multi-byte integer fields are
+// little-endian except where [MS-DNSP] mandates network byte order (big-endian): the
+// DNS_RECORD.TtlSeconds field, and the numeric fields of the SOA, SRV, and NAME_PREFERENCE
+// payloads.
+//
+// Reference: [MS-DNSP] dnsRecord,
+// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dnsp/6912b338-5472-4f59-b912-0edb536b6ed8
+package dnsrecord

--- a/network/dns/dnsrecord/recordtype.go
+++ b/network/dns/dnsrecord/recordtype.go
@@ -1,0 +1,120 @@
+package dnsrecord
+
+// RecordType is a 16-bit value that specifies a DNS resource record's type. It is stored
+// in the Type field of a DNS_RECORD (section 2.3.2.2) and selects which DNS_RPC_RECORD_DATA
+// (section 2.2.2.2.4) payload appears in the record's Data field.
+//
+// Source: [MS-DNSP] DNS_RECORD_TYPE (section 2.2.2.1.1)
+// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dnsp/39b03b89-2264-4063-8198-d62f62a6441a
+type RecordType uint16
+
+// DNS_RECORD_TYPE constants, per [MS-DNSP] section 2.2.2.1.1. The values are the IANA DNS
+// resource-record type codes, with the Microsoft-specific WINS/WINSR extensions in the
+// private 0xFF00 range.
+const (
+	DNS_TYPE_ZERO       RecordType = 0x0000 // An empty record type (RFC1034 3.6, RFC1035 3.2.2).
+	DNS_TYPE_A          RecordType = 0x0001 // An A record type, an IPv4 address (RFC1035 3.2.2).
+	DNS_TYPE_NS         RecordType = 0x0002 // An authoritative name-server record type.
+	DNS_TYPE_MD         RecordType = 0x0003 // A mail-destination record type.
+	DNS_TYPE_MF         RecordType = 0x0004 // A mail-forwarder record type.
+	DNS_TYPE_CNAME      RecordType = 0x0005 // The canonical name of a DNS alias.
+	DNS_TYPE_SOA        RecordType = 0x0006 // A Start of Authority (SOA) record type.
+	DNS_TYPE_MB         RecordType = 0x0007 // A mailbox record type.
+	DNS_TYPE_MG         RecordType = 0x0008 // A mail group member record type.
+	DNS_TYPE_MR         RecordType = 0x0009 // A mail-rename record type.
+	DNS_TYPE_NULL       RecordType = 0x000A // A record type for completion queries.
+	DNS_TYPE_WKS        RecordType = 0x000B // A well-known service record type.
+	DNS_TYPE_PTR        RecordType = 0x000C // An FQDN pointer record type.
+	DNS_TYPE_HINFO      RecordType = 0x000D // A host information record type.
+	DNS_TYPE_MINFO      RecordType = 0x000E // A mailbox or mailing list information record type.
+	DNS_TYPE_MX         RecordType = 0x000F // A mail-exchanger record type.
+	DNS_TYPE_TXT        RecordType = 0x0010 // A text string record type.
+	DNS_TYPE_RP         RecordType = 0x0011 // A responsible-person record type (RFC1183).
+	DNS_TYPE_AFSDB      RecordType = 0x0012 // An AFS database location record type (RFC1183).
+	DNS_TYPE_X25        RecordType = 0x0013 // An X25 PSDN address record type (RFC1183).
+	DNS_TYPE_ISDN       RecordType = 0x0014 // An ISDN address record type (RFC1183).
+	DNS_TYPE_RT         RecordType = 0x0015 // A route-through record type (RFC1183).
+	DNS_TYPE_SIG        RecordType = 0x0018 // A cryptographic public key signature record type (RFC2931).
+	DNS_TYPE_KEY        RecordType = 0x0019 // A DNSSEC public key record type (RFC2535).
+	DNS_TYPE_AAAA       RecordType = 0x001C // An IPv6 address record type (RFC3596).
+	DNS_TYPE_LOC        RecordType = 0x001D // A location information record type (RFC1876).
+	DNS_TYPE_NXT        RecordType = 0x001E // A next-domain record type (RFC2065).
+	DNS_TYPE_SRV        RecordType = 0x0021 // A server selection record type (RFC2782).
+	DNS_TYPE_ATMA       RecordType = 0x0022 // An ATM address record type.
+	DNS_TYPE_NAPTR      RecordType = 0x0023 // A NAPTR record type (RFC2915).
+	DNS_TYPE_DNAME      RecordType = 0x0027 // A DNAME record type (RFC2672).
+	DNS_TYPE_DS         RecordType = 0x002B // A DS record type (RFC4034).
+	DNS_TYPE_RRSIG      RecordType = 0x002E // An RRSIG record type (RFC4034).
+	DNS_TYPE_NSEC       RecordType = 0x002F // An NSEC record type (RFC4034).
+	DNS_TYPE_DNSKEY     RecordType = 0x0030 // A DNSKEY record type (RFC4034).
+	DNS_TYPE_DHCID      RecordType = 0x0031 // A DHCID record type (RFC4701).
+	DNS_TYPE_NSEC3      RecordType = 0x0032 // An NSEC3 record type (RFC5155).
+	DNS_TYPE_NSEC3PARAM RecordType = 0x0033 // An NSEC3PARAM record type (RFC5155).
+	DNS_TYPE_TLSA       RecordType = 0x0034 // A TLSA record type (RFC6698).
+	DNS_TYPE_ALL        RecordType = 0x00FF // A query-only type requesting all records.
+	DNS_TYPE_WINS       RecordType = 0xFF01 // A WINS forward-lookup record type (MS-WINSRA).
+	DNS_TYPE_WINSR      RecordType = 0xFF02 // A WINS reverse-lookup record type (MS-WINSRA).
+)
+
+// recordTypeNames maps the well-known DNS_RECORD_TYPE values to their [MS-DNSP] constant
+// names for String rendering.
+var recordTypeNames = map[RecordType]string{
+	DNS_TYPE_ZERO:       "DNS_TYPE_ZERO",
+	DNS_TYPE_A:          "DNS_TYPE_A",
+	DNS_TYPE_NS:         "DNS_TYPE_NS",
+	DNS_TYPE_MD:         "DNS_TYPE_MD",
+	DNS_TYPE_MF:         "DNS_TYPE_MF",
+	DNS_TYPE_CNAME:      "DNS_TYPE_CNAME",
+	DNS_TYPE_SOA:        "DNS_TYPE_SOA",
+	DNS_TYPE_MB:         "DNS_TYPE_MB",
+	DNS_TYPE_MG:         "DNS_TYPE_MG",
+	DNS_TYPE_MR:         "DNS_TYPE_MR",
+	DNS_TYPE_NULL:       "DNS_TYPE_NULL",
+	DNS_TYPE_WKS:        "DNS_TYPE_WKS",
+	DNS_TYPE_PTR:        "DNS_TYPE_PTR",
+	DNS_TYPE_HINFO:      "DNS_TYPE_HINFO",
+	DNS_TYPE_MINFO:      "DNS_TYPE_MINFO",
+	DNS_TYPE_MX:         "DNS_TYPE_MX",
+	DNS_TYPE_TXT:        "DNS_TYPE_TXT",
+	DNS_TYPE_RP:         "DNS_TYPE_RP",
+	DNS_TYPE_AFSDB:      "DNS_TYPE_AFSDB",
+	DNS_TYPE_X25:        "DNS_TYPE_X25",
+	DNS_TYPE_ISDN:       "DNS_TYPE_ISDN",
+	DNS_TYPE_RT:         "DNS_TYPE_RT",
+	DNS_TYPE_SIG:        "DNS_TYPE_SIG",
+	DNS_TYPE_KEY:        "DNS_TYPE_KEY",
+	DNS_TYPE_AAAA:       "DNS_TYPE_AAAA",
+	DNS_TYPE_LOC:        "DNS_TYPE_LOC",
+	DNS_TYPE_NXT:        "DNS_TYPE_NXT",
+	DNS_TYPE_SRV:        "DNS_TYPE_SRV",
+	DNS_TYPE_ATMA:       "DNS_TYPE_ATMA",
+	DNS_TYPE_NAPTR:      "DNS_TYPE_NAPTR",
+	DNS_TYPE_DNAME:      "DNS_TYPE_DNAME",
+	DNS_TYPE_DS:         "DNS_TYPE_DS",
+	DNS_TYPE_RRSIG:      "DNS_TYPE_RRSIG",
+	DNS_TYPE_NSEC:       "DNS_TYPE_NSEC",
+	DNS_TYPE_DNSKEY:     "DNS_TYPE_DNSKEY",
+	DNS_TYPE_DHCID:      "DNS_TYPE_DHCID",
+	DNS_TYPE_NSEC3:      "DNS_TYPE_NSEC3",
+	DNS_TYPE_NSEC3PARAM: "DNS_TYPE_NSEC3PARAM",
+	DNS_TYPE_TLSA:       "DNS_TYPE_TLSA",
+	DNS_TYPE_ALL:        "DNS_TYPE_ALL",
+	DNS_TYPE_WINS:       "DNS_TYPE_WINS",
+	DNS_TYPE_WINSR:      "DNS_TYPE_WINSR",
+}
+
+// String returns the [MS-DNSP] constant name of the record type (for example "DNS_TYPE_A"),
+// or a hexadecimal fallback of the form "RecordType(0x1234)" for values not defined in the
+// specification's table (which still MUST be enumerable per section 2.2.2.1.1).
+func (t RecordType) String() string {
+	if name, ok := recordTypeNames[t]; ok {
+		return name
+	}
+	const hexDigits = "0123456789abcdef"
+	buf := []byte("RecordType(0x0000)")
+	buf[13] = hexDigits[(t>>12)&0xF]
+	buf[14] = hexDigits[(t>>8)&0xF]
+	buf[15] = hexDigits[(t>>4)&0xF]
+	buf[16] = hexDigits[t&0xF]
+	return string(buf)
+}

--- a/network/dns/dnsrecord/recordtype_test.go
+++ b/network/dns/dnsrecord/recordtype_test.go
@@ -1,0 +1,51 @@
+package dnsrecord_test
+
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/dns/dnsrecord"
+)
+
+// TestRecordTypeValues pins the numeric values of the record types the tooling relies on,
+// including the Microsoft-specific WINS extension and the empty (ZERO) type.
+func TestRecordTypeValues(t *testing.T) {
+	tests := []struct {
+		name  string
+		typ   dnsrecord.RecordType
+		value uint16
+	}{
+		{"DNS_TYPE_ZERO", dnsrecord.DNS_TYPE_ZERO, 0},
+		{"DNS_TYPE_A", dnsrecord.DNS_TYPE_A, 1},
+		{"DNS_TYPE_NS", dnsrecord.DNS_TYPE_NS, 2},
+		{"DNS_TYPE_CNAME", dnsrecord.DNS_TYPE_CNAME, 5},
+		{"DNS_TYPE_SOA", dnsrecord.DNS_TYPE_SOA, 6},
+		{"DNS_TYPE_PTR", dnsrecord.DNS_TYPE_PTR, 12},
+		{"DNS_TYPE_MX", dnsrecord.DNS_TYPE_MX, 15},
+		{"DNS_TYPE_AAAA", dnsrecord.DNS_TYPE_AAAA, 28},
+		{"DNS_TYPE_SRV", dnsrecord.DNS_TYPE_SRV, 33},
+		{"DNS_TYPE_WINS", dnsrecord.DNS_TYPE_WINS, 65281},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if uint16(tt.typ) != tt.value {
+				t.Errorf("%s = %d; want %d", tt.name, uint16(tt.typ), tt.value)
+			}
+		})
+	}
+}
+
+// TestRecordTypeString verifies the constant-name rendering and the hexadecimal fallback for
+// values not present in the specification table.
+func TestRecordTypeString(t *testing.T) {
+	if got := dnsrecord.DNS_TYPE_SRV.String(); got != "DNS_TYPE_SRV" {
+		t.Errorf("DNS_TYPE_SRV.String() = %q; want %q", got, "DNS_TYPE_SRV")
+	}
+	if got := dnsrecord.DNS_TYPE_WINS.String(); got != "DNS_TYPE_WINS" {
+		t.Errorf("DNS_TYPE_WINS.String() = %q; want %q", got, "DNS_TYPE_WINS")
+	}
+	// 0x1234 is not defined in the table.
+	if got := dnsrecord.RecordType(0x1234).String(); got != "RecordType(0x1234)" {
+		t.Errorf("RecordType(0x1234).String() = %q; want %q", got, "RecordType(0x1234)")
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #883`

### Root Cause
Manticore modeled DNS records only in their NDR RPC-wire form (`windows/protocols/ms-dnsp`), whose `doc.go` explicitly leaves the record-data payloads as an opaque `Buffer []uint8`. The separate packed format that Active Directory persists in the `dnsRecord` LDAP attribute ([MS-DNSP] section 2.3.2.2) was never implemented, so no code could marshal or unmarshal a `dnsRecord` value. That packed format is not NDR: it is a byte-packed, mixed-endian layout whose name fields use `DNS_COUNT_NAME` (section 2.2.2.2.2) rather than the RPC-wire `DNS_RPC_NAME`, so the existing types cannot represent it.

### Fix Description
Add a new package `network/dns/dnsrecord` that implements byte-level `Marshal`/`Unmarshal` for the packed `dnsRecord` structures, in the style of the SMB command structures under `network/smb/smb_v10/message/commands`:

- `DNS_RECORD` — the 24-byte-header container (section 2.3.2.2), with `DataLength` recomputed on marshal and a `SetData` helper that accepts any payload.
- `DNS_COUNT_NAME` — the LDAP name form (section 2.2.2.2.2), with `SetFQDN`/`GetFQDN` conversion.
- `RecordType` + the `DNS_RECORD_TYPE` constant map (section 2.2.2.1.1), including A/NS/CNAME/SOA/SRV/AAAA/WINS/ZERO and a `String()` renderer.
- Record-data payloads: `DNS_RPC_RECORD_A`, `_AAAA`, `_NODE_NAME`, `_SOA`, `_SRV`, `_NAME_PREFERENCE`, `_TS`.

The layout honors the spec's mixed endianness: `DNS_RECORD.TtlSeconds` and the SOA/SRV/NAME_PREFERENCE numeric fields are big-endian, while the rest of the header and `DNS_RPC_RECORD_TS.EntombedTime` are little-endian. Each structure lives in its own file with a matching `_test.go`, and every source file cites its `learn.microsoft.com` MS-DNSP page. All wire layouts were verified against the live [MS-DNSP] documentation.

### How Verified
- `go build ./...`, `go vet ./network/dns/dnsrecord/...`, and `gofmt -l` — all clean.
- `go test ./network/dns/dnsrecord/...` — 31 tests pass.
- The tests include byte-level wire assertions on the endianness-sensitive fields: `TestDNSRecordHeaderEndianness` pins the full 24-byte header (little-endian `DataLength`/`Serial`/`TimeStamp`, big-endian `TtlSeconds`); the SOA/SRV/preference tests assert big-endian numeric layout; `TestRecordTSWireShape` asserts little-endian `EntombedTime`; `TestDNSCountNameWireShape` pins the `07 'example' 03 'com' 00` label encoding.

### Test Coverage
**Added:** one `_test.go` per structure —
`recordtype_test.go`, `dns_count_name_test.go`, `dns_record_test.go`, `dns_rpc_record_a_test.go`, `dns_rpc_record_aaaa_test.go`, `dns_rpc_record_node_name_test.go`, `dns_rpc_record_soa_test.go`, `dns_rpc_record_srv_test.go`, `dns_rpc_record_name_preference_test.go`, `dns_rpc_record_ts_test.go`. Each covers Marshal/Unmarshal round-trips, byte-level wire shape, and truncated-input rejection.

### Scope of Change
- **Files changed:** 11 source files + 10 test files, all new, under `network/dns/dnsrecord/`.
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none (new package only)

### Risk and Rollout
New self-contained package; nothing else imports it yet, so there is no regression surface. Safe to merge without staged rollout.

### Notes
One spec nuance handled explicitly: [MS-DNSP] states the `DNS_COUNT_NAME` maximum is 256 bytes including the null terminator, but the `Length` field is a single byte, so `SetFQDN` caps encoded names at 255 bytes to avoid overflowing `Length`. This is documented inline.
