### PR TITLE
Add MS-DNSP dnsProperty attribute decoder (Fixes #885)

### DIFF
--- a/network/dns/dnsproperty/dns_property.go
+++ b/network/dns/dnsproperty/dns_property.go
@@ -69,7 +69,9 @@ func NewDNS_PROPERTY() *DNS_PROPERTY {
 // - A byte array representing the DNS_PROPERTY structure
 // - An error if the marshaling fails
 func (p *DNS_PROPERTY) Marshal() ([]byte, error) {
-	if len(p.Data) > 0xFFFFFFFF {
+	// Compare in uint64 so the 0xFFFFFFFF bound does not overflow int on 32-bit platforms
+	// (where int is 32 bits and len returns int).
+	if uint64(len(p.Data)) > 0xFFFFFFFF {
 		return nil, fmt.Errorf("property data is %d bytes, exceeds the 4294967295-byte DataLength limit", len(p.Data))
 	}
 	p.DataLength = uint32(len(p.Data))

--- a/network/dns/dnsproperty/dns_property.go
+++ b/network/dns/dnsproperty/dns_property.go
@@ -1,0 +1,240 @@
+package dnsproperty
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/TheManticoreProject/Manticore/encoding/utf16"
+)
+
+// dnsPropertyHeaderLength is the fixed size, in bytes, of the DNS_PROPERTY header that precedes
+// the variable-length Data field: DataLength(4) + NameLength(4) + Flag(4) + Version(4) + Id(4)
+// = 20 bytes.
+const dnsPropertyHeaderLength = 20
+
+// DNSPropertyVersion is the value that the Version field of a DNS_PROPERTY MUST carry.
+const DNSPropertyVersion uint32 = 0x00000001
+
+// DNS_PROPERTY is the packed container that Active Directory stores in each value of the
+// dnsProperty LDAP attribute of a DNS zone object. It holds a fixed 20-byte header, a
+// variable-length Data field of DataLength bytes carrying the property value selected by the Id
+// field (see PropertyId, section 2.3.2.1.1), and a trailing 1-byte Name field that is not used.
+//
+// All header fields are little-endian.
+//
+// Source: [MS-DNSP] dnsProperty (section 2.3.2.1)
+// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dnsp/445c7843-e4a1-4222-8c0f-630c230a4c80
+type DNS_PROPERTY struct {
+	// DataLength (4 bytes): The length, in bytes, of the Data field. Marshal recomputes this
+	// from the Data field. If 0, the property carries its default value.
+	DataLength uint32
+
+	// NameLength (4 bytes): Not used. The value MUST be ignored and assumed to be 0x00000001.
+	NameLength uint32
+
+	// Flag (4 bytes): Reserved for future use. The value MUST be 0x00000000.
+	Flag uint32
+
+	// Version (4 bytes): The version of the property attribute. The value MUST be 0x00000001.
+	Version uint32
+
+	// Id (4 bytes): The property's type, selecting how Data is interpreted.
+	Id PropertyId
+
+	// Data (variable): The property value. See the As* accessors for interpretation.
+	Data []byte
+
+	// Name (1 byte): Not used. The value MUST be of length 1 byte and MUST be ignored.
+	Name uint8
+}
+
+// NewDNS_PROPERTY creates a new DNS_PROPERTY with Version and NameLength initialized to the
+// values mandated by [MS-DNSP] section 2.3.2.1 (0x00000001 each).
+//
+// Returns:
+// - A pointer to the new DNS_PROPERTY structure
+func NewDNS_PROPERTY() *DNS_PROPERTY {
+	return &DNS_PROPERTY{
+		NameLength: 0x00000001,
+		Version:    DNSPropertyVersion,
+	}
+}
+
+// Marshal marshals the DNS_PROPERTY structure into a byte array. DataLength is recomputed from
+// the current length of the Data field so the header always matches the payload.
+//
+// Returns:
+// - A byte array representing the DNS_PROPERTY structure
+// - An error if the marshaling fails
+func (p *DNS_PROPERTY) Marshal() ([]byte, error) {
+	if len(p.Data) > 0xFFFFFFFF {
+		return nil, fmt.Errorf("property data is %d bytes, exceeds the 4294967295-byte DataLength limit", len(p.Data))
+	}
+	p.DataLength = uint32(len(p.Data))
+
+	marshalled := make([]byte, dnsPropertyHeaderLength)
+	binary.LittleEndian.PutUint32(marshalled[0:4], p.DataLength)
+	binary.LittleEndian.PutUint32(marshalled[4:8], p.NameLength)
+	binary.LittleEndian.PutUint32(marshalled[8:12], p.Flag)
+	binary.LittleEndian.PutUint32(marshalled[12:16], p.Version)
+	binary.LittleEndian.PutUint32(marshalled[16:20], uint32(p.Id))
+
+	marshalled = append(marshalled, p.Data...)
+	// The trailing Name field is a single, unused byte.
+	marshalled = append(marshalled, p.Name)
+	return marshalled, nil
+}
+
+// Unmarshal unmarshals a byte array into the DNS_PROPERTY structure.
+//
+// Parameters:
+// - rawData: The byte array to unmarshal
+//
+// Returns:
+// - The number of bytes read (20-byte header, DataLength bytes of Data, and the 1-byte Name)
+// - An error if the unmarshaling fails
+func (p *DNS_PROPERTY) Unmarshal(rawData []byte) (int, error) {
+	if len(rawData) < dnsPropertyHeaderLength {
+		return 0, fmt.Errorf("rawData too short for DNS_PROPERTY header: need %d bytes, have %d", dnsPropertyHeaderLength, len(rawData))
+	}
+
+	p.DataLength = binary.LittleEndian.Uint32(rawData[0:4])
+	p.NameLength = binary.LittleEndian.Uint32(rawData[4:8])
+	p.Flag = binary.LittleEndian.Uint32(rawData[8:12])
+	p.Version = binary.LittleEndian.Uint32(rawData[12:16])
+	p.Id = PropertyId(binary.LittleEndian.Uint32(rawData[16:20]))
+	offset := dnsPropertyHeaderLength
+
+	// The header, the Data field, and the trailing 1-byte Name field must all be present.
+	if len(rawData) < offset+int(p.DataLength)+1 {
+		return 0, fmt.Errorf("rawData too short for DNS_PROPERTY Data and Name: need %d bytes, have %d", offset+int(p.DataLength)+1, len(rawData))
+	}
+
+	if p.DataLength == 0 {
+		p.Data = nil
+	} else {
+		p.Data = make([]byte, p.DataLength)
+		copy(p.Data, rawData[offset:offset+int(p.DataLength)])
+	}
+	offset += int(p.DataLength)
+
+	p.Name = rawData[offset]
+	offset++
+
+	return offset, nil
+}
+
+// AsUint32 interprets the Data field as a little-endian 32-bit scalar, the form used by the
+// scalar zone properties (DSPROPERTY_ZONE_TYPE, DSPROPERTY_ZONE_ALLOW_UPDATE, the interval
+// properties, DSPROPERTY_ZONE_AGING_STATE, DSPROPERTY_ZONE_DCPROMO_CONVERT, and
+// DSPROPERTY_ZONE_NODE_DBFLAGS).
+//
+// Returns:
+// - The 32-bit value
+// - An error if Data is shorter than 4 bytes
+func (p *DNS_PROPERTY) AsUint32() (uint32, error) {
+	if len(p.Data) < 4 {
+		return 0, fmt.Errorf("DNS_PROPERTY %s: Data is %d bytes, need 4 for a uint32", p.Id, len(p.Data))
+	}
+	return binary.LittleEndian.Uint32(p.Data[0:4]), nil
+}
+
+// AsZoneType interprets the Data field as a ZoneType (dwZoneType). It is meaningful for a
+// DSPROPERTY_ZONE_TYPE property.
+//
+// Returns:
+// - The zone type
+// - An error if Data is shorter than 4 bytes
+func (p *DNS_PROPERTY) AsZoneType() (ZoneType, error) {
+	v, err := p.AsUint32()
+	if err != nil {
+		return 0, err
+	}
+	return ZoneType(v), nil
+}
+
+// AsZoneUpdate interprets the Data field as a ZoneUpdate (fAllowUpdate). It is meaningful for a
+// DSPROPERTY_ZONE_ALLOW_UPDATE property.
+//
+// Returns:
+// - The dynamic-update policy
+// - An error if Data is shorter than 4 bytes
+func (p *DNS_PROPERTY) AsZoneUpdate() (ZoneUpdate, error) {
+	v, err := p.AsUint32()
+	if err != nil {
+		return 0, err
+	}
+	return ZoneUpdate(v), nil
+}
+
+// AsIP4Array interprets the Data field as an IP4_ARRAY (section 2.2.3.2.1): a little-endian
+// AddrCount followed by AddrCount IPv4 addresses, each a 4-byte value in network byte order. It
+// is meaningful for the DSPROPERTY_ZONE_SCAVENGING_SERVERS, DSPROPERTY_ZONE_MASTER_SERVERS, and
+// DSPROPERTY_ZONE_AUTO_NS_SERVERS properties.
+//
+// Returns:
+// - The IPv4 addresses (an empty, non-nil slice when AddrCount is 0)
+// - An error if Data is malformed
+func (p *DNS_PROPERTY) AsIP4Array() ([]net.IP, error) {
+	if len(p.Data) < 4 {
+		return nil, fmt.Errorf("DNS_PROPERTY %s: Data is %d bytes, need at least 4 for an IP4_ARRAY", p.Id, len(p.Data))
+	}
+	count := binary.LittleEndian.Uint32(p.Data[0:4])
+	if uint64(len(p.Data)) < 4+uint64(count)*4 {
+		return nil, fmt.Errorf("DNS_PROPERTY %s: IP4_ARRAY declares %d addresses but Data holds only %d bytes", p.Id, count, len(p.Data))
+	}
+	addrs := make([]net.IP, 0, count)
+	offset := 4
+	for i := uint32(0); i < count; i++ {
+		b := p.Data[offset : offset+4]
+		addrs = append(addrs, net.IPv4(b[0], b[1], b[2], b[3]))
+		offset += 4
+	}
+	return addrs, nil
+}
+
+// AsUTF16String interprets the Data field as a null-terminated little-endian UTF-16 string, the
+// form used by the DSPROPERTY_ZONE_DELETED_FROM_HOSTNAME property. The terminating NUL, if
+// present, is removed.
+//
+// Returns:
+// - The decoded string
+func (p *DNS_PROPERTY) AsUTF16String() string {
+	return strings.TrimRight(utf16.DecodeUTF16LE(p.Data), "\x00")
+}
+
+// String returns a human-readable, one-line rendering of the property: its Id name followed by
+// an interpretation of the Data field appropriate to that Id, falling back to the raw byte
+// count for property types whose payload is not decoded here.
+func (p *DNS_PROPERTY) String() string {
+	switch p.Id {
+	case DSPROPERTY_ZONE_TYPE:
+		if v, err := p.AsZoneType(); err == nil {
+			return fmt.Sprintf("%s = %s", p.Id, v)
+		}
+	case DSPROPERTY_ZONE_ALLOW_UPDATE:
+		if v, err := p.AsZoneUpdate(); err == nil {
+			return fmt.Sprintf("%s = %s", p.Id, v)
+		}
+	case DSPROPERTY_ZONE_NOREFRESH_INTERVAL, DSPROPERTY_ZONE_REFRESH_INTERVAL,
+		DSPROPERTY_ZONE_AGING_STATE, DSPROPERTY_ZONE_AGING_ENABLED_TIME,
+		DSPROPERTY_ZONE_DCPROMO_CONVERT, DSPROPERTY_ZONE_NODE_DBFLAGS:
+		if v, err := p.AsUint32(); err == nil {
+			return fmt.Sprintf("%s = %d", p.Id, v)
+		}
+	case DSPROPERTY_ZONE_SCAVENGING_SERVERS, DSPROPERTY_ZONE_MASTER_SERVERS,
+		DSPROPERTY_ZONE_AUTO_NS_SERVERS:
+		if addrs, err := p.AsIP4Array(); err == nil {
+			ss := make([]string, len(addrs))
+			for i, a := range addrs {
+				ss[i] = a.String()
+			}
+			return fmt.Sprintf("%s = [%s]", p.Id, strings.Join(ss, ", "))
+		}
+	case DSPROPERTY_ZONE_DELETED_FROM_HOSTNAME:
+		return fmt.Sprintf("%s = %q", p.Id, p.AsUTF16String())
+	}
+	return fmt.Sprintf("%s = <%d bytes>", p.Id, len(p.Data))
+}

--- a/network/dns/dnsproperty/dns_property_test.go
+++ b/network/dns/dnsproperty/dns_property_test.go
@@ -1,0 +1,193 @@
+package dnsproperty_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/dns/dnsproperty"
+)
+
+// buildProperty assembles a raw dnsProperty value: a 20-byte little-endian header, the Data
+// field, and the trailing 1-byte Name field.
+func buildProperty(id dnsproperty.PropertyId, data []byte) []byte {
+	b := make([]byte, 20)
+	// DataLength
+	b[0] = byte(len(data))
+	b[1] = byte(len(data) >> 8)
+	b[2] = byte(len(data) >> 16)
+	b[3] = byte(len(data) >> 24)
+	// NameLength = 1
+	b[4] = 0x01
+	// Flag = 0 (b[8:12])
+	// Version = 1
+	b[12] = 0x01
+	// Id
+	b[16] = byte(id)
+	b[17] = byte(id >> 8)
+	b[18] = byte(id >> 16)
+	b[19] = byte(id >> 24)
+	b = append(b, data...)
+	b = append(b, 0x00) // Name
+	return b
+}
+
+// TestZoneTypeProperty decodes a DSPROPERTY_ZONE_TYPE property.
+func TestZoneTypeProperty(t *testing.T) {
+	raw := buildProperty(dnsproperty.DSPROPERTY_ZONE_TYPE, []byte{0x01, 0x00, 0x00, 0x00})
+
+	p := &dnsproperty.DNS_PROPERTY{}
+	read, err := p.Unmarshal(raw)
+	if err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if read != len(raw) {
+		t.Errorf("Unmarshal read %d bytes; want %d", read, len(raw))
+	}
+	if p.Id != dnsproperty.DSPROPERTY_ZONE_TYPE {
+		t.Errorf("Id = %s; want DSPROPERTY_ZONE_TYPE", p.Id)
+	}
+	zt, err := p.AsZoneType()
+	if err != nil {
+		t.Fatalf("AsZoneType failed: %v", err)
+	}
+	if zt != dnsproperty.DNS_ZONE_TYPE_PRIMARY {
+		t.Errorf("ZoneType = %s; want DNS_ZONE_TYPE_PRIMARY", zt)
+	}
+}
+
+// TestAllowUpdateProperty decodes a DSPROPERTY_ZONE_ALLOW_UPDATE property carrying the
+// insecure-update policy.
+func TestAllowUpdateProperty(t *testing.T) {
+	raw := buildProperty(dnsproperty.DSPROPERTY_ZONE_ALLOW_UPDATE, []byte{0x01, 0x00, 0x00, 0x00})
+
+	p := &dnsproperty.DNS_PROPERTY{}
+	if _, err := p.Unmarshal(raw); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	zu, err := p.AsZoneUpdate()
+	if err != nil {
+		t.Fatalf("AsZoneUpdate failed: %v", err)
+	}
+	if zu != dnsproperty.ZONE_UPDATE_UNSECURE {
+		t.Errorf("ZoneUpdate = %s; want ZONE_UPDATE_UNSECURE", zu)
+	}
+}
+
+// TestIP4ArrayProperty decodes a scavenging-servers property carrying two IPv4 addresses.
+func TestIP4ArrayProperty(t *testing.T) {
+	data := []byte{
+		0x02, 0x00, 0x00, 0x00, // AddrCount = 2
+		192, 0, 2, 1, // 192.0.2.1 (network byte order)
+		10, 20, 30, 40, // 10.20.30.40
+	}
+	raw := buildProperty(dnsproperty.DSPROPERTY_ZONE_SCAVENGING_SERVERS, data)
+
+	p := &dnsproperty.DNS_PROPERTY{}
+	if _, err := p.Unmarshal(raw); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	addrs, err := p.AsIP4Array()
+	if err != nil {
+		t.Fatalf("AsIP4Array failed: %v", err)
+	}
+	if len(addrs) != 2 {
+		t.Fatalf("AsIP4Array returned %d addresses; want 2", len(addrs))
+	}
+	if addrs[0].String() != "192.0.2.1" || addrs[1].String() != "10.20.30.40" {
+		t.Errorf("addresses = %v; want [192.0.2.1 10.20.30.40]", addrs)
+	}
+}
+
+// TestEmptyIP4Array decodes an empty IP4_ARRAY (AddrCount 0).
+func TestEmptyIP4Array(t *testing.T) {
+	raw := buildProperty(dnsproperty.DSPROPERTY_ZONE_MASTER_SERVERS, []byte{0x00, 0x00, 0x00, 0x00})
+	p := &dnsproperty.DNS_PROPERTY{}
+	if _, err := p.Unmarshal(raw); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	addrs, err := p.AsIP4Array()
+	if err != nil {
+		t.Fatalf("AsIP4Array failed: %v", err)
+	}
+	if len(addrs) != 0 {
+		t.Errorf("AsIP4Array returned %d addresses; want 0", len(addrs))
+	}
+}
+
+// TestDeletedFromHostnameProperty decodes the null-terminated UTF-16 hostname property.
+func TestDeletedFromHostnameProperty(t *testing.T) {
+	// "DC1" in UTF-16LE with a NUL terminator.
+	data := []byte{'D', 0, 'C', 0, '1', 0, 0, 0}
+	raw := buildProperty(dnsproperty.DSPROPERTY_ZONE_DELETED_FROM_HOSTNAME, data)
+
+	p := &dnsproperty.DNS_PROPERTY{}
+	if _, err := p.Unmarshal(raw); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if got := p.AsUTF16String(); got != "DC1" {
+		t.Errorf("AsUTF16String = %q; want %q", got, "DC1")
+	}
+}
+
+// TestRoundTrip marshals a property built with the constructor and checks the bytes round-trip.
+func TestRoundTrip(t *testing.T) {
+	p := dnsproperty.NewDNS_PROPERTY()
+	p.Id = dnsproperty.DSPROPERTY_ZONE_REFRESH_INTERVAL
+	p.Data = []byte{0xA8, 0x00, 0x00, 0x00} // 168 hours
+
+	marshalled, err := p.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	out := &dnsproperty.DNS_PROPERTY{}
+	read, err := out.Unmarshal(marshalled)
+	if err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if read != len(marshalled) {
+		t.Errorf("Unmarshal read %d bytes; want %d", read, len(marshalled))
+	}
+	if out.DataLength != 4 || out.Version != dnsproperty.DNSPropertyVersion {
+		t.Errorf("header mismatch: DataLength=%d Version=%d", out.DataLength, out.Version)
+	}
+	v, err := out.AsUint32()
+	if err != nil {
+		t.Fatalf("AsUint32 failed: %v", err)
+	}
+	if v != 168 {
+		t.Errorf("AsUint32 = %d; want 168", v)
+	}
+
+	remarshalled, err := out.Marshal()
+	if err != nil {
+		t.Fatalf("re-Marshal failed: %v", err)
+	}
+	if !bytes.Equal(marshalled, remarshalled) {
+		t.Errorf("round-trip mismatch:\n got % x\nwant % x", remarshalled, marshalled)
+	}
+}
+
+// TestUnmarshalTruncated verifies that a value too short for the declared Data plus Name field
+// is rejected.
+func TestUnmarshalTruncated(t *testing.T) {
+	raw := buildProperty(dnsproperty.DSPROPERTY_ZONE_TYPE, []byte{0x01, 0x00, 0x00, 0x00})
+	// Drop the trailing Name byte so the buffer is one byte short.
+	truncated := raw[:len(raw)-1]
+
+	p := &dnsproperty.DNS_PROPERTY{}
+	if _, err := p.Unmarshal(truncated); err == nil {
+		t.Errorf("expected error unmarshalling truncated property, got nil")
+	}
+}
+
+// TestStringFallback verifies String renders a byte-count fallback for an undecoded property.
+func TestStringFallback(t *testing.T) {
+	p := &dnsproperty.DNS_PROPERTY{
+		Id:   dnsproperty.DSPROPERTY_ZONE_SECURE_TIME,
+		Data: []byte{1, 2, 3, 4, 5, 6, 7, 8},
+	}
+	if got := p.String(); got != "DSPROPERTY_ZONE_SECURE_TIME = <8 bytes>" {
+		t.Errorf("String = %q; want fallback rendering", got)
+	}
+}

--- a/network/dns/dnsproperty/doc.go
+++ b/network/dns/dnsproperty/doc.go
@@ -1,0 +1,28 @@
+// Package dnsproperty implements the byte-level wire structure of the dnsProperty LDAP
+// attribute that Active Directory stores on AD-integrated DNS zone objects, as specified by
+// the Domain Name Service (DNS) Server Management Protocol [MS-DNSP].
+//
+// A dnsProperty value is the packed, on-directory form of a single zone property (zone type,
+// dynamic-update policy, aging/scavenging settings, server lists, and so on). The dnsProperty
+// attribute is multi-valued: each value carries exactly one property, so callers unmarshal one
+// DNS_PROPERTY per attribute value.
+//
+// The container is DNS_PROPERTY (section 2.3.2.1): a fixed 20-byte header (DataLength,
+// NameLength, Flag, Version, Id) followed by a variable-length Data field of DataLength bytes
+// and a trailing 1-byte Name field that is not used. All header integers are little-endian.
+// The Id field (a PropertyId, section 2.3.2.1.1) selects how the Data field is interpreted.
+//
+// The type-specific Data payloads are exposed through accessors on DNS_PROPERTY:
+//
+//   - AsUint32     - the 32-bit scalar properties (zone type, allow-update, intervals,
+//     aging state, DcPromo flag, node DB flags, ...)
+//   - AsIP4Array   - the IP4_ARRAY server lists (section 2.2.3.2.1: scavenging, master, and
+//     auto-created-NS server lists)
+//   - AsUTF16String - the DSPROPERTY_ZONE_DELETED_FROM_HOSTNAME null-terminated Unicode string
+//
+// The two most security-relevant scalar properties additionally have typed enumerations with a
+// String rendering: ZoneType (dwZoneType) and ZoneUpdate (fAllowUpdate).
+//
+// Reference: [MS-DNSP] dnsProperty,
+// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dnsp/445c7843-e4a1-4222-8c0f-630c230a4c80
+package dnsproperty

--- a/network/dns/dnsproperty/propertyid.go
+++ b/network/dns/dnsproperty/propertyid.go
@@ -1,0 +1,64 @@
+package dnsproperty
+
+// PropertyId is the 32-bit value stored in the Id field of a DNS_PROPERTY (section 2.3.2.1). It
+// specifies the type of data carried in the property's Data field.
+//
+// Source: [MS-DNSP] Property Id (section 2.3.2.1.1)
+// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dnsp/3af63871-0cc4-4179-916c-5caade55a8f3
+type PropertyId uint32
+
+// DSPROPERTY_ZONE_* constants, per [MS-DNSP] section 2.3.2.1.1.
+const (
+	DSPROPERTY_ZONE_TYPE                  PropertyId = 0x00000001 // Zone type (dwZoneType). See ZoneType.
+	DSPROPERTY_ZONE_ALLOW_UPDATE          PropertyId = 0x00000002 // Dynamic-update policy (fAllowUpdate). See ZoneUpdate.
+	DSPROPERTY_ZONE_SECURE_TIME           PropertyId = 0x00000008 // Time at which the zone became secure.
+	DSPROPERTY_ZONE_NOREFRESH_INTERVAL    PropertyId = 0x00000010 // No-refresh interval, in hours.
+	DSPROPERTY_ZONE_SCAVENGING_SERVERS    PropertyId = 0x00000011 // Scavenging servers, as an IP4_ARRAY.
+	DSPROPERTY_ZONE_AGING_ENABLED_TIME    PropertyId = 0x00000012 // Time interval before the next scavenging cycle.
+	DSPROPERTY_ZONE_REFRESH_INTERVAL      PropertyId = 0x00000020 // Refresh interval, in hours.
+	DSPROPERTY_ZONE_AGING_STATE           PropertyId = 0x00000040 // Whether aging is enabled (fAging).
+	DSPROPERTY_ZONE_DELETED_FROM_HOSTNAME PropertyId = 0x00000080 // Name of the server that deleted the zone (Unicode string).
+	DSPROPERTY_ZONE_MASTER_SERVERS        PropertyId = 0x00000081 // Zone-transfer master servers, as an IP4_ARRAY.
+	DSPROPERTY_ZONE_AUTO_NS_SERVERS       PropertyId = 0x00000082 // Servers that may auto-create a delegation, as an IP4_ARRAY.
+	DSPROPERTY_ZONE_DCPROMO_CONVERT       PropertyId = 0x00000083 // State of DcPromo zone conversion. See DcPromo Flag (section 2.3.2.1.2).
+	DSPROPERTY_ZONE_SCAVENGING_SERVERS_DA PropertyId = 0x00000090 // Scavenging servers, as a DNS_ADDR_ARRAY.
+	DSPROPERTY_ZONE_MASTER_SERVERS_DA     PropertyId = 0x00000091 // Zone-transfer master servers, as a DNS_ADDR_ARRAY.
+	DSPROPERTY_ZONE_AUTO_NS_SERVERS_DA    PropertyId = 0x00000092 // Auto-created-NS servers, as a DNS_ADDR_ARRAY.
+	DSPROPERTY_ZONE_NODE_DBFLAGS          PropertyId = 0x00000100 // Node database flags. See DNS_RPC_NODE_FLAGS (section 2.2.2.1.2).
+)
+
+// propertyIdNames maps the defined PropertyId values to their [MS-DNSP] constant names for
+// String rendering.
+var propertyIdNames = map[PropertyId]string{
+	DSPROPERTY_ZONE_TYPE:                  "DSPROPERTY_ZONE_TYPE",
+	DSPROPERTY_ZONE_ALLOW_UPDATE:          "DSPROPERTY_ZONE_ALLOW_UPDATE",
+	DSPROPERTY_ZONE_SECURE_TIME:           "DSPROPERTY_ZONE_SECURE_TIME",
+	DSPROPERTY_ZONE_NOREFRESH_INTERVAL:    "DSPROPERTY_ZONE_NOREFRESH_INTERVAL",
+	DSPROPERTY_ZONE_SCAVENGING_SERVERS:    "DSPROPERTY_ZONE_SCAVENGING_SERVERS",
+	DSPROPERTY_ZONE_AGING_ENABLED_TIME:    "DSPROPERTY_ZONE_AGING_ENABLED_TIME",
+	DSPROPERTY_ZONE_REFRESH_INTERVAL:      "DSPROPERTY_ZONE_REFRESH_INTERVAL",
+	DSPROPERTY_ZONE_AGING_STATE:           "DSPROPERTY_ZONE_AGING_STATE",
+	DSPROPERTY_ZONE_DELETED_FROM_HOSTNAME: "DSPROPERTY_ZONE_DELETED_FROM_HOSTNAME",
+	DSPROPERTY_ZONE_MASTER_SERVERS:        "DSPROPERTY_ZONE_MASTER_SERVERS",
+	DSPROPERTY_ZONE_AUTO_NS_SERVERS:       "DSPROPERTY_ZONE_AUTO_NS_SERVERS",
+	DSPROPERTY_ZONE_DCPROMO_CONVERT:       "DSPROPERTY_ZONE_DCPROMO_CONVERT",
+	DSPROPERTY_ZONE_SCAVENGING_SERVERS_DA: "DSPROPERTY_ZONE_SCAVENGING_SERVERS_DA",
+	DSPROPERTY_ZONE_MASTER_SERVERS_DA:     "DSPROPERTY_ZONE_MASTER_SERVERS_DA",
+	DSPROPERTY_ZONE_AUTO_NS_SERVERS_DA:    "DSPROPERTY_ZONE_AUTO_NS_SERVERS_DA",
+	DSPROPERTY_ZONE_NODE_DBFLAGS:          "DSPROPERTY_ZONE_NODE_DBFLAGS",
+}
+
+// String returns the [MS-DNSP] constant name of the property id (for example
+// "DSPROPERTY_ZONE_TYPE"), or a hexadecimal fallback of the form "PropertyId(0x12345678)" for
+// values not defined in the specification's table.
+func (id PropertyId) String() string {
+	if name, ok := propertyIdNames[id]; ok {
+		return name
+	}
+	const hexDigits = "0123456789abcdef"
+	buf := []byte("PropertyId(0x00000000)")
+	for i := 0; i < 8; i++ {
+		buf[len(buf)-2-i] = hexDigits[(id>>(4*i))&0xF]
+	}
+	return string(buf)
+}

--- a/network/dns/dnsproperty/propertyid_test.go
+++ b/network/dns/dnsproperty/propertyid_test.go
@@ -1,0 +1,46 @@
+package dnsproperty_test
+
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/dns/dnsproperty"
+)
+
+// TestPropertyIdString verifies known ids render as their constant names and unknown ids fall
+// back to a hex form.
+func TestPropertyIdString(t *testing.T) {
+	cases := []struct {
+		id   dnsproperty.PropertyId
+		want string
+	}{
+		{dnsproperty.DSPROPERTY_ZONE_TYPE, "DSPROPERTY_ZONE_TYPE"},
+		{dnsproperty.DSPROPERTY_ZONE_ALLOW_UPDATE, "DSPROPERTY_ZONE_ALLOW_UPDATE"},
+		{dnsproperty.DSPROPERTY_ZONE_NODE_DBFLAGS, "DSPROPERTY_ZONE_NODE_DBFLAGS"},
+		{dnsproperty.PropertyId(0xDEADBEEF), "PropertyId(0xdeadbeef)"},
+	}
+	for _, c := range cases {
+		if got := c.id.String(); got != c.want {
+			t.Errorf("PropertyId(0x%x).String() = %q; want %q", uint32(c.id), got, c.want)
+		}
+	}
+}
+
+// TestZoneTypeString verifies ZoneType rendering.
+func TestZoneTypeString(t *testing.T) {
+	if got := dnsproperty.DNS_ZONE_TYPE_PRIMARY.String(); got != "DNS_ZONE_TYPE_PRIMARY" {
+		t.Errorf("ZoneType.String() = %q; want DNS_ZONE_TYPE_PRIMARY", got)
+	}
+	if got := dnsproperty.ZoneType(0x99).String(); got != "ZoneType(0x00000099)" {
+		t.Errorf("unknown ZoneType.String() = %q; want hex fallback", got)
+	}
+}
+
+// TestZoneUpdateString verifies ZoneUpdate rendering.
+func TestZoneUpdateString(t *testing.T) {
+	if got := dnsproperty.ZONE_UPDATE_UNSECURE.String(); got != "ZONE_UPDATE_UNSECURE" {
+		t.Errorf("ZoneUpdate.String() = %q; want ZONE_UPDATE_UNSECURE", got)
+	}
+	if got := dnsproperty.ZoneUpdate(0x7).String(); got != "ZoneUpdate(0x00000007)" {
+		t.Errorf("unknown ZoneUpdate.String() = %q; want hex fallback", got)
+	}
+}

--- a/network/dns/dnsproperty/zonevalues.go
+++ b/network/dns/dnsproperty/zonevalues.go
@@ -1,0 +1,76 @@
+package dnsproperty
+
+// ZoneType is the value carried by a DSPROPERTY_ZONE_TYPE property (dwZoneType). It identifies
+// the kind of DNS zone.
+//
+// Source: [MS-DNSP] dwZoneType, referenced from DNS_RPC_ZONE_INFO (section 2.2.5.2.4.1)
+type ZoneType uint32
+
+// DNS_ZONE_TYPE_* constants.
+const (
+	DNS_ZONE_TYPE_CACHE           ZoneType = 0x00000000 // A cache (root hints) zone.
+	DNS_ZONE_TYPE_PRIMARY         ZoneType = 0x00000001 // A primary zone.
+	DNS_ZONE_TYPE_SECONDARY       ZoneType = 0x00000002 // A secondary zone.
+	DNS_ZONE_TYPE_STUB            ZoneType = 0x00000003 // A stub zone.
+	DNS_ZONE_TYPE_FORWARDER       ZoneType = 0x00000004 // A forwarder zone.
+	DNS_ZONE_TYPE_SECONDARY_CACHE ZoneType = 0x00000005 // A secondary cache zone.
+)
+
+var zoneTypeNames = map[ZoneType]string{
+	DNS_ZONE_TYPE_CACHE:           "DNS_ZONE_TYPE_CACHE",
+	DNS_ZONE_TYPE_PRIMARY:         "DNS_ZONE_TYPE_PRIMARY",
+	DNS_ZONE_TYPE_SECONDARY:       "DNS_ZONE_TYPE_SECONDARY",
+	DNS_ZONE_TYPE_STUB:            "DNS_ZONE_TYPE_STUB",
+	DNS_ZONE_TYPE_FORWARDER:       "DNS_ZONE_TYPE_FORWARDER",
+	DNS_ZONE_TYPE_SECONDARY_CACHE: "DNS_ZONE_TYPE_SECONDARY_CACHE",
+}
+
+// String returns the constant name of the zone type, or a hexadecimal fallback of the form
+// "ZoneType(0x12345678)" for undefined values.
+func (t ZoneType) String() string {
+	if name, ok := zoneTypeNames[t]; ok {
+		return name
+	}
+	return "ZoneType(0x" + hex32(uint32(t)) + ")"
+}
+
+// ZoneUpdate is the value carried by a DSPROPERTY_ZONE_ALLOW_UPDATE property (fAllowUpdate). It
+// identifies the dynamic-update policy of a zone.
+//
+// A value of ZONE_UPDATE_UNSECURE means the zone accepts unauthenticated dynamic updates, which
+// allows any host to create or overwrite records in the zone.
+//
+// Source: [MS-DNSP] fAllowUpdate, referenced from DNS_RPC_ZONE_INFO (section 2.2.5.2.4.1)
+type ZoneUpdate uint32
+
+// ZONE_UPDATE_* constants.
+const (
+	ZONE_UPDATE_OFF      ZoneUpdate = 0x00000000 // Dynamic updates are not allowed.
+	ZONE_UPDATE_UNSECURE ZoneUpdate = 0x00000001 // Both secure and unsecure dynamic updates are allowed.
+	ZONE_UPDATE_SECURE   ZoneUpdate = 0x00000002 // Only secure dynamic updates are allowed.
+)
+
+var zoneUpdateNames = map[ZoneUpdate]string{
+	ZONE_UPDATE_OFF:      "ZONE_UPDATE_OFF",
+	ZONE_UPDATE_UNSECURE: "ZONE_UPDATE_UNSECURE",
+	ZONE_UPDATE_SECURE:   "ZONE_UPDATE_SECURE",
+}
+
+// String returns the constant name of the update policy, or a hexadecimal fallback of the form
+// "ZoneUpdate(0x12345678)" for undefined values.
+func (u ZoneUpdate) String() string {
+	if name, ok := zoneUpdateNames[u]; ok {
+		return name
+	}
+	return "ZoneUpdate(0x" + hex32(uint32(u)) + ")"
+}
+
+// hex32 renders v as 8 lowercase hexadecimal digits.
+func hex32(v uint32) string {
+	const hexDigits = "0123456789abcdef"
+	buf := make([]byte, 8)
+	for i := 0; i < 8; i++ {
+		buf[7-i] = hexDigits[(v>>(4*i))&0xF]
+	}
+	return string(buf)
+}


### PR DESCRIPTION
### Linked Issue
`Closes #885`

### Root Cause
Manticore modeled the `dnsRecord` LDAP attribute (`network/dns/dnsrecord`) but never modeled its sibling `dnsProperty`, the multi-valued attribute that AD-integrated DNS zone objects use to store zone-level settings ([MS-DNSP] section 2.3.2.1). Without a decoder, those values are opaque bytes and the zone type, dynamic-update policy, aging/scavenging configuration, and server lists cannot be read.

### Fix Description
Adds a new `network/dns/dnsproperty` package that models the packed `dnsProperty` container and its property values, following the same conventions as `network/dns/dnsrecord` (per-type files, `Marshal()`/`Unmarshal() (int, error)`, doc comments citing the [MS-DNSP] section and Learn URL):

- `DNS_PROPERTY` — the container (20-byte little-endian header + variable `Data` + trailing unused `Name` byte) with `Marshal`/`Unmarshal` and a `NewDNS_PROPERTY` constructor that sets the mandated `Version`/`NameLength`.
- `PropertyId` — a typed `uint32` with all `DSPROPERTY_ZONE_*` constants (section 2.3.2.1.1) and a `String()` with a hex fallback.
- Typed value interpretations for the two security-relevant scalar properties: `ZoneType` (`dwZoneType`) and `ZoneUpdate` (`fAllowUpdate`), each with `String()`.
- `Data` accessors: `AsUint32` (scalar properties), `AsIP4Array` (the `IP4_ARRAY` server lists, section 2.2.3.2.1, decoded as network-order IPv4), `AsUTF16String` (the null-terminated Unicode hostname property), plus a `String()` that renders a property by its `Id`.

Scope was kept to LDAP-packed decoding. The NDR/RPC `IP4_ARRAY` under `windows/protocols/ms-dnsp` is a different layer and is intentionally not reused. Typed decoding of the `DNS_ADDR_ARRAY` (`*_DA`) variants is left as follow-up; those values are still accessible as raw `Data`.

### How Verified
- **Tests:** `go test ./network/dns/dnsproperty/` passes. New tests cover zone-type and allow-update decoding, `IP4_ARRAY` (populated and empty), the UTF-16 hostname property, a marshal/unmarshal round-trip, truncation rejection, `String()` fallback, and `PropertyId`/`ZoneType`/`ZoneUpdate` rendering.
- **Static:** `gofmt -l` clean and `go vet ./network/dns/dnsproperty/` clean; `go build ./...` succeeds.

### Test Coverage
- **Added:** `network/dns/dnsproperty/dns_property_test.go` (`TestZoneTypeProperty`, `TestAllowUpdateProperty`, `TestIP4ArrayProperty`, `TestEmptyIP4Array`, `TestDeletedFromHostnameProperty`, `TestRoundTrip`, `TestUnmarshalTruncated`, `TestStringFallback`) and `network/dns/dnsproperty/propertyid_test.go` (`TestPropertyIdString`, `TestZoneTypeString`, `TestZoneUpdateString`).

### Scope of Change
- **Files changed:** new package `network/dns/dnsproperty/` (`doc.go`, `propertyid.go`, `zonevalues.go`, `dns_property.go`, and two test files).
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none — this only adds a new package.

### Risk and Rollout
Additive only; no existing package imports the new code. Safe to merge without staged rollout.

### Notes
Follow-up worth filing separately: typed decoding of the `DNS_ADDR_ARRAY`-based `*_DA` server-list properties (section 2.2.3.2.3).
