### PR TITLE
Fix DNS_PROPERTY integer decode for sub-DWORD values (Fixes #889)

### DIFF
--- a/windows/protocols/ms-dnsp/DNS_PROPERTY.go
+++ b/windows/protocols/ms-dnsp/DNS_PROPERTY.go
@@ -128,19 +128,31 @@ func (p *DNS_PROPERTY) Unmarshal(rawData []byte) (int, error) {
 	return offset, nil
 }
 
-// AsUint32 interprets the Data field as a little-endian 32-bit scalar, the form used by the
-// scalar zone properties (DSPROPERTY_ZONE_TYPE, DSPROPERTY_ZONE_ALLOW_UPDATE, the interval
-// properties, DSPROPERTY_ZONE_AGING_STATE, DSPROPERTY_ZONE_DCPROMO_CONVERT, and
-// DSPROPERTY_ZONE_NODE_DBFLAGS).
+// AsUint32 interprets the Data field as a little-endian integer, the form used by the scalar
+// zone properties (DSPROPERTY_ZONE_TYPE, DSPROPERTY_ZONE_ALLOW_UPDATE, the interval properties,
+// DSPROPERTY_ZONE_AGING_STATE, DSPROPERTY_ZONE_DCPROMO_CONVERT, and DSPROPERTY_ZONE_NODE_DBFLAGS).
+//
+// Although [MS-DNSP] types these properties as a DWORD, a Windows DNS server stores them in the
+// minimum number of little-endian bytes: for example DSPROPERTY_ZONE_ALLOW_UPDATE is commonly a
+// single byte. AsUint32 therefore reads up to four bytes and zero-extends, rather than requiring
+// exactly four.
 //
 // Returns:
-// - The 32-bit value
-// - An error if Data is shorter than 4 bytes
+// - The value, read from up to the first four bytes of Data (little-endian, zero-extended)
+// - An error if Data is empty
 func (p *DNS_PROPERTY) AsUint32() (uint32, error) {
-	if len(p.Data) < 4 {
-		return 0, fmt.Errorf("DNS_PROPERTY %s: Data is %d bytes, need 4 for a uint32", p.Id, len(p.Data))
+	if len(p.Data) == 0 {
+		return 0, fmt.Errorf("DNS_PROPERTY %s: Data is empty, need at least 1 byte for an integer", p.Id)
 	}
-	return binary.LittleEndian.Uint32(p.Data[0:4]), nil
+	n := len(p.Data)
+	if n > 4 {
+		n = 4
+	}
+	var v uint32
+	for i := 0; i < n; i++ {
+		v |= uint32(p.Data[i]) << (8 * i)
+	}
+	return v, nil
 }
 
 // AsZoneType interprets the Data field as a ZoneType (dwZoneType). It is meaningful for a
@@ -148,7 +160,7 @@ func (p *DNS_PROPERTY) AsUint32() (uint32, error) {
 //
 // Returns:
 // - The zone type
-// - An error if Data is shorter than 4 bytes
+// - An error if Data is empty
 func (p *DNS_PROPERTY) AsZoneType() (ZoneType, error) {
 	v, err := p.AsUint32()
 	if err != nil {
@@ -162,7 +174,7 @@ func (p *DNS_PROPERTY) AsZoneType() (ZoneType, error) {
 //
 // Returns:
 // - The dynamic-update policy
-// - An error if Data is shorter than 4 bytes
+// - An error if Data is empty
 func (p *DNS_PROPERTY) AsZoneUpdate() (ZoneUpdate, error) {
 	v, err := p.AsUint32()
 	if err != nil {

--- a/windows/protocols/ms-dnsp/DNS_PROPERTY_test.go
+++ b/windows/protocols/ms-dnsp/DNS_PROPERTY_test.go
@@ -31,6 +31,43 @@ func buildProperty(id msdnsp.PropertyId, data []byte) []byte {
 	return b
 }
 
+// TestAllowUpdateSingleByte decodes a DSPROPERTY_ZONE_ALLOW_UPDATE property stored in a single
+// byte, as a Windows DNS server actually writes it (DataLength=1, Data=0x02), rather than the
+// full DWORD described by [MS-DNSP].
+func TestAllowUpdateSingleByte(t *testing.T) {
+	raw := buildProperty(msdnsp.DSPROPERTY_ZONE_ALLOW_UPDATE, []byte{0x02})
+
+	p := &msdnsp.DNS_PROPERTY{}
+	if _, err := p.Unmarshal(raw); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if p.DataLength != 1 {
+		t.Fatalf("DataLength = %d; want 1", p.DataLength)
+	}
+	v, err := p.AsUint32()
+	if err != nil {
+		t.Fatalf("AsUint32 on 1-byte data failed: %v", err)
+	}
+	if v != 2 {
+		t.Errorf("AsUint32 = %d; want 2", v)
+	}
+	zu, err := p.AsZoneUpdate()
+	if err != nil {
+		t.Fatalf("AsZoneUpdate on 1-byte data failed: %v", err)
+	}
+	if zu != msdnsp.ZONE_UPDATE_SECURE {
+		t.Errorf("ZoneUpdate = %s; want ZONE_UPDATE_SECURE", zu)
+	}
+}
+
+// TestAsUint32EmptyData verifies AsUint32 rejects an empty Data field.
+func TestAsUint32EmptyData(t *testing.T) {
+	p := &msdnsp.DNS_PROPERTY{Id: msdnsp.DSPROPERTY_ZONE_TYPE, Data: nil}
+	if _, err := p.AsUint32(); err == nil {
+		t.Error("AsUint32 on empty Data = nil error; want error")
+	}
+}
+
 // TestZoneTypeProperty decodes a DSPROPERTY_ZONE_TYPE property.
 func TestZoneTypeProperty(t *testing.T) {
 	raw := buildProperty(msdnsp.DSPROPERTY_ZONE_TYPE, []byte{0x01, 0x00, 0x00, 0x00})


### PR DESCRIPTION
### Linked Issue
`Closes #889`

### Root Cause
`DNS_PROPERTY.AsUint32` assumed the fixed 4-byte DWORD width that [MS-DNSP] documents for the scalar zone properties. In practice a Windows DNS server stores these values in the minimum number of little-endian bytes and truncates trailing zeros, so `DSPROPERTY_ZONE_ALLOW_UPDATE` arrives as a single byte (`0x02`). The `len(Data) >= 4` guard rejected it, and `AsZoneType` / `AsZoneUpdate` inherited the failure.

### Fix Description
`AsUint32` now reads up to the first four bytes of Data as a little-endian integer and zero-extends, erroring only when Data is empty. `AsZoneType` and `AsZoneUpdate` are unchanged in signature and now succeed for sub-DWORD values. Doc comments were updated to describe the new contract.

### How Verified
- **Runtime:** against a live Windows Server 2016 DC, decoding the primary zone's `DSPROPERTY_ZONE_ALLOW_UPDATE` (stored as `DataLength=1`, `Data=0x02`) now yields `ZONE_UPDATE_SECURE` instead of an error.
- **Tests:** `go test ./windows/protocols/ms-dnsp/` passes.

### Test Coverage
- **Added:** `TestAllowUpdateSingleByte` (1-byte `0x02` decodes to `ZONE_UPDATE_SECURE` via `AsUint32`/`AsZoneUpdate`) and `TestAsUint32EmptyData` (empty Data still errors). Existing 4-byte property tests continue to pass unchanged.

### Scope of Change
- **Files changed:** `windows/protocols/ms-dnsp/DNS_PROPERTY.go`, `windows/protocols/ms-dnsp/DNS_PROPERTY_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none — only the short-Data decode path changes; 4-byte values decode identically.

### Risk and Rollout
Low. The change only widens what AsUint32 accepts (1–4 bytes instead of exactly 4); previously-working 4-byte decodes are unaffected. Safe to merge without staged rollout.
