### PR TITLE
Add Netlogon per-message sign/seal token machinery (NL_AUTH_SHA2_SIGNATURE) (#655)

### DIFF
--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/messagesecurity.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/messagesecurity.go
@@ -1,0 +1,245 @@
+package functions
+
+// IDL source: [MS-NRPC] — this interface is translated from and verified
+// against the protocol's authoritative IDL. Full IDL (Appendix A):
+//   https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-nrpc/89f9b028-ee68-4fe2-afca-cc188f7079f7
+// A fetched copy is kept at ms-nrpc.idl in the interface directory.
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+	"io"
+
+	"github.com/TheManticoreProject/Manticore/crypto/aes/cfb8"
+	msnrpc "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nrpc"
+)
+
+// MessageSecurity produces and verifies the per-message Netlogon security tokens used when
+// Netlogon acts as its own RPC security provider (RPC_C_AUTHN_NETLOGON) with the AES cipher
+// suite negotiated ([MS-NRPC] 3.3.4.2.1). It signs (integrity) or seals (privacy) request
+// stubs with an NL_AUTH_SHA2_SIGNATURE token: an HMAC-SHA256 checksum, a per-message
+// sequence number, and — when sealing — a random confounder, with the sequence number,
+// confounder, and stub encrypted under AES-128 in 8-bit CFB mode.
+//
+// A MessageSecurity is stateful and not safe for concurrent use: the client sequence number
+// advances with every Sign/Seal call and calls must be serialized in the order the PDUs go
+// on the wire. The legacy (non-AES) RC4/HMAC-MD5 suite is not implemented here.
+type MessageSecurity struct {
+	sessionKey [16]byte
+	clientSeq  uint64
+	// confounderSrc supplies the sealing confounder; when nil, crypto/rand is used. It is a
+	// seam for deterministic testing and is never set in production code.
+	confounderSrc io.Reader
+}
+
+// NewMessageSecurityAES returns a MessageSecurity for the AES cipher suite, keyed by the
+// 16-byte Netlogon session key derived by the secure-channel handshake
+// (ComputeSessionKeyAES). The sequence number starts at zero.
+func NewMessageSecurityAES(sessionKey [16]byte) *MessageSecurity {
+	return &MessageSecurity{sessionKey: sessionKey, confounderSrc: rand.Reader}
+}
+
+// Sign builds an integrity-only NL_AUTH_SHA2_SIGNATURE token over data ([MS-NRPC] 3.3.4.2.1
+// with Confidentiality not requested): the checksum covers the token header and the
+// plaintext stub, and no confounder is included. data is left in the clear. The returned
+// token is 48 octets. The client sequence number is consumed and advanced.
+func (m *MessageSecurity) Sign(data []byte) ([]byte, error) {
+	sig := &msnrpc.NL_AUTH_SHA2_SIGNATURE{
+		SignatureAlgorithm: msnrpc.NlSignatureHMACSHA256,
+		SealAlgorithm:      msnrpc.NlSealNotEncrypted,
+		Pad:                0xffff,
+	}
+	checksum := computeSignatureAES(sig.Header(), nil, data, m.sessionKey)
+	copy(sig.Checksum[:], checksum)
+
+	derived := deriveSequenceNumber(m.clientSeq, true)
+	seqField, err := cryptSequenceNumberAES(derived, sig.Checksum[:], m.sessionKey, false)
+	if err != nil {
+		return nil, fmt.Errorf("netlogon sign: %w", err)
+	}
+	copy(sig.SequenceNumber[:], seqField)
+
+	m.clientSeq++
+	return sig.Marshal(), nil
+}
+
+// Seal builds a sealing NL_AUTH_SHA2_SIGNATURE token over data ([MS-NRPC] 3.3.4.2.1 with
+// Confidentiality requested) and returns the encrypted stub alongside it. The checksum is
+// computed over the token header, the plaintext confounder, and the plaintext stub; the
+// confounder and stub are then encrypted as one continuous AES-128-CFB8 stream keyed by the
+// session key XOR 0xF0 with IV = derivedSeq||derivedSeq. The returned token is 56 octets.
+// The client sequence number is consumed and advanced.
+func (m *MessageSecurity) Seal(data []byte) (sealed, token []byte, err error) {
+	src := m.confounderSrc
+	if src == nil {
+		src = rand.Reader
+	}
+	var confounder [8]byte
+	if _, err = io.ReadFull(src, confounder[:]); err != nil {
+		return nil, nil, fmt.Errorf("netlogon seal: read confounder: %w", err)
+	}
+
+	sig := &msnrpc.NL_AUTH_SHA2_SIGNATURE{
+		SignatureAlgorithm: msnrpc.NlSignatureHMACSHA256,
+		SealAlgorithm:      msnrpc.NlSealAES128,
+		Pad:                0xffff,
+	}
+	// The checksum is computed over the plaintext, before any encryption.
+	checksum := computeSignatureAES(sig.Header(), confounder[:], data, m.sessionKey)
+	copy(sig.Checksum[:], checksum)
+
+	derived := deriveSequenceNumber(m.clientSeq, true)
+	seqField, err := cryptSequenceNumberAES(derived, sig.Checksum[:], m.sessionKey, false)
+	if err != nil {
+		return nil, nil, fmt.Errorf("netlogon seal: %w", err)
+	}
+	copy(sig.SequenceNumber[:], seqField)
+
+	// Seal the confounder and then the stub as a single continuous CFB8 stream: the shift
+	// register state after the 8 confounder octets carries into the stub, so they must not
+	// be encrypted with separate stream objects ([MS-NRPC] 3.3.4.2.1 step 8).
+	stream, err := newSealStream(m.sessionKey, derived, false)
+	if err != nil {
+		return nil, nil, fmt.Errorf("netlogon seal: %w", err)
+	}
+	var encConfounder [8]byte
+	stream.XORKeyStream(encConfounder[:], confounder[:])
+	sealed = make([]byte, len(data))
+	stream.XORKeyStream(sealed, data)
+	copy(sig.Confounder[:], encConfounder[:])
+
+	m.clientSeq++
+	return sealed, sig.Marshal(), nil
+}
+
+// Unseal reverses Seal: it decrypts the sealed stub using the token's own encrypted
+// sequence number and confounder, then recomputes the checksum over the recovered plaintext
+// and verifies it. It is self-contained (the sequence number is recovered from the token,
+// not from a counter), so a token produced by Seal round-trips through Unseal under the same
+// session key.
+func (m *MessageSecurity) Unseal(sealed, token []byte) ([]byte, error) {
+	var sig msnrpc.NL_AUTH_SHA2_SIGNATURE
+	if err := sig.Unmarshal(token); err != nil {
+		return nil, fmt.Errorf("netlogon unseal: %w", err)
+	}
+	if !sig.Sealed() {
+		return nil, fmt.Errorf("netlogon unseal: token is integrity-only, not sealed")
+	}
+
+	derived, err := cryptSequenceNumberAES(sig.SequenceNumber[:], sig.Checksum[:], m.sessionKey, true)
+	if err != nil {
+		return nil, fmt.Errorf("netlogon unseal: %w", err)
+	}
+
+	stream, err := newSealStream(m.sessionKey, derived, true)
+	if err != nil {
+		return nil, fmt.Errorf("netlogon unseal: %w", err)
+	}
+	var confounder [8]byte
+	stream.XORKeyStream(confounder[:], sig.Confounder[:])
+	data := make([]byte, len(sealed))
+	stream.XORKeyStream(data, sealed)
+
+	want := computeSignatureAES(sig.Header(), confounder[:], data, m.sessionKey)
+	if !hmac.Equal(want, sig.Checksum[:]) {
+		return nil, fmt.Errorf("netlogon unseal: checksum mismatch")
+	}
+	return data, nil
+}
+
+// VerifySignature checks an integrity-only token against data by recomputing the HMAC-SHA256
+// checksum ([MS-NRPC] 3.3.4.2.1 step 7). It is for signed (not sealed) messages; for a
+// sealing token use Unseal, which verifies the checksum over the recovered plaintext.
+func (m *MessageSecurity) VerifySignature(data, token []byte) error {
+	var sig msnrpc.NL_AUTH_SHA2_SIGNATURE
+	if err := sig.Unmarshal(token); err != nil {
+		return fmt.Errorf("netlogon verify: %w", err)
+	}
+	if sig.Sealed() {
+		return fmt.Errorf("netlogon verify: token is a sealing token, use Unseal")
+	}
+	want := computeSignatureAES(sig.Header(), nil, data, m.sessionKey)
+	if !hmac.Equal(want, sig.Checksum[:]) {
+		return fmt.Errorf("netlogon verify: checksum mismatch")
+	}
+	return nil
+}
+
+// computeSignatureAES computes the Netlogon AES signature ([MS-NRPC] 3.3.4.2.1 step 7):
+// HMAC-SHA256(sessionKey, header[0:8] || confounder || message), truncated to 8 octets. The
+// confounder is nil for integrity-only tokens.
+func computeSignatureAES(header, confounder, message []byte, sessionKey [16]byte) []byte {
+	mac := hmac.New(sha256.New, sessionKey[:])
+	mac.Write(header[:nlAuthHeader8])
+	mac.Write(confounder)
+	mac.Write(message)
+	return mac.Sum(nil)[:8]
+}
+
+// deriveSequenceNumber renders the 64-bit client sequence number into the 8 wire octets
+// ([MS-NRPC] 3.3.4.2.1 step 5): the low 32 bits big-endian, then the high 32 bits
+// big-endian. When client is true the high-order 0x80000000 bit is set to mark a
+// client-originated token; server tokens leave it clear.
+func deriveSequenceNumber(seq uint64, client bool) []byte {
+	low := uint32(seq & 0xffffffff)
+	high := uint32((seq >> 32) & 0xffffffff)
+	if client {
+		high |= 0x80000000
+	}
+	out := make([]byte, 8)
+	binary.BigEndian.PutUint32(out[0:4], low)
+	binary.BigEndian.PutUint32(out[4:8], high)
+	return out
+}
+
+// cryptSequenceNumberAES encrypts (decrypt=false) or decrypts (decrypt=true) the 8-octet
+// sequence number with AES-128-CFB8 under the plain session key, using an IV of the first 8
+// checksum octets repeated twice ([MS-NRPC] 3.3.4.2.1 step 9).
+func cryptSequenceNumberAES(seq, checksum []byte, sessionKey [16]byte, decrypt bool) ([]byte, error) {
+	block, err := aes.NewCipher(sessionKey[:])
+	if err != nil {
+		return nil, err
+	}
+	var iv [16]byte
+	copy(iv[0:8], checksum[:8])
+	copy(iv[8:16], checksum[:8])
+	var stream cipher.Stream
+	if decrypt {
+		stream = cfb8.NewDecrypter(block, iv[:])
+	} else {
+		stream = cfb8.NewEncrypter(block, iv[:])
+	}
+	out := make([]byte, len(seq))
+	stream.XORKeyStream(out, seq)
+	return out, nil
+}
+
+// newSealStream builds the AES-128-CFB8 stream used to seal (decrypt=false) or unseal
+// (decrypt=true) the confounder and stub ([MS-NRPC] 3.3.4.2.1 step 8): keyed by the session
+// key with every octet XORed by 0xF0, with IV = derivedSeq||derivedSeq. A single stream is
+// returned so the caller can process the confounder and stub as one continuous segment.
+func newSealStream(sessionKey [16]byte, derivedSeq []byte, decrypt bool) (cipher.Stream, error) {
+	var encKey [16]byte
+	for i := range sessionKey {
+		encKey[i] = sessionKey[i] ^ 0xf0
+	}
+	block, err := aes.NewCipher(encKey[:])
+	if err != nil {
+		return nil, err
+	}
+	var iv [16]byte
+	copy(iv[0:8], derivedSeq)
+	copy(iv[8:16], derivedSeq)
+	if decrypt {
+		return cfb8.NewDecrypter(block, iv[:]), nil
+	}
+	return cfb8.NewEncrypter(block, iv[:]), nil
+}
+
+// nlAuthHeader8 is the number of leading token-header octets fed into the checksum.
+const nlAuthHeader8 = 8

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/messagesecurity_test.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/messagesecurity_test.go
@@ -1,0 +1,164 @@
+package functions
+
+// White-box tests for the Netlogon per-message security tokens. They pin the AES sign/seal
+// output byte-for-byte against vectors generated from impacket's nrpc.SIGN/SEAL (with a
+// round-trip confirmed by nrpc.UNSEAL), which is itself faithful to [MS-NRPC] 3.3.4.2.1.
+// Being in package functions lets the tests inject a deterministic confounder source.
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+)
+
+// repeatReader yields the same byte forever, so a fixed confounder can be injected into
+// Seal for deterministic output.
+type repeatReader struct{ b byte }
+
+func (r repeatReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = r.b
+	}
+	return len(p), nil
+}
+
+// Vector inputs shared by the pinned tests (see .private/plan_netlogon_rpc.md, Appendix 1).
+var (
+	vecSessionKey = [16]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
+	vecPlaintext  = []byte("NetrLogonGetCapabilities-stub-bytes!!")
+)
+
+func mustHex(t *testing.T, s string) []byte {
+	t.Helper()
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		t.Fatalf("bad hex %q: %v", s, err)
+	}
+	return b
+}
+
+// TestSealVector pins the AES sealing token and encrypted stub to the impacket vector
+// (sessionKey 00..0f, confounder 0xAA*8, sequence number 0).
+func TestSealVector(t *testing.T) {
+	m := NewMessageSecurityAES(vecSessionKey)
+	m.confounderSrc = repeatReader{0xAA}
+
+	sealed, token, err := m.Seal(vecPlaintext)
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+
+	wantSealed := "af57a4b849dee8df36b76b23dd783d234d68580a36fc7ce2e5d0aa4ec47ef23392481d372b"
+	if got := hex.EncodeToString(sealed); got != wantSealed {
+		t.Errorf("sealed stub\n got  %s\n want %s", got, wantSealed)
+	}
+	wantToken := "13001a00ffff0000a8a7c0b370691c1de5b3d4e3ccacd9f4979ba2aab4c9b01e" +
+		"000000000000000000000000000000000000000000000000"
+	if got := hex.EncodeToString(token); got != wantToken {
+		t.Errorf("token\n got  %s\n want %s", got, wantToken)
+	}
+	if len(token) != 56 {
+		t.Errorf("sealing token length = %d, want 56", len(token))
+	}
+}
+
+// TestSignVector pins the AES integrity-only token to the impacket vector.
+func TestSignVector(t *testing.T) {
+	m := NewMessageSecurityAES(vecSessionKey)
+
+	token, err := m.Sign(vecPlaintext)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	wantToken := "1300ffffffff00002bf226c4856d2bb7f596b051a3f2891f" +
+		"000000000000000000000000000000000000000000000000"
+	if got := hex.EncodeToString(token); got != wantToken {
+		t.Errorf("token\n got  %s\n want %s", got, wantToken)
+	}
+	if len(token) != 48 {
+		t.Errorf("integrity token length = %d, want 48", len(token))
+	}
+}
+
+// TestSealUnsealRoundTrip seals with one context and unseals with a fresh context under the
+// same key, confirming the token is self-contained.
+func TestSealUnsealRoundTrip(t *testing.T) {
+	sender := NewMessageSecurityAES(vecSessionKey)
+	sender.confounderSrc = repeatReader{0x5a}
+
+	sealed, token, err := sender.Seal(vecPlaintext)
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+	receiver := NewMessageSecurityAES(vecSessionKey)
+	got, err := receiver.Unseal(sealed, token)
+	if err != nil {
+		t.Fatalf("Unseal: %v", err)
+	}
+	if !bytes.Equal(got, vecPlaintext) {
+		t.Fatalf("round-trip plaintext = %x, want %x", got, vecPlaintext)
+	}
+}
+
+// TestUnsealTamperDetected confirms a flipped ciphertext byte fails the checksum.
+func TestUnsealTamperDetected(t *testing.T) {
+	m := NewMessageSecurityAES(vecSessionKey)
+	m.confounderSrc = repeatReader{0x11}
+	sealed, token, err := m.Seal(vecPlaintext)
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+	sealed[0] ^= 0x01
+	if _, err := NewMessageSecurityAES(vecSessionKey).Unseal(sealed, token); err == nil {
+		t.Fatal("Unseal accepted a tampered stub, want checksum mismatch")
+	}
+}
+
+// TestVerifySignature confirms a good signature verifies and a tampered stub is rejected.
+func TestVerifySignature(t *testing.T) {
+	token, err := NewMessageSecurityAES(vecSessionKey).Sign(vecPlaintext)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	if err := NewMessageSecurityAES(vecSessionKey).VerifySignature(vecPlaintext, token); err != nil {
+		t.Fatalf("VerifySignature (good) = %v, want nil", err)
+	}
+	tampered := append([]byte(nil), vecPlaintext...)
+	tampered[0] ^= 0x01
+	if err := NewMessageSecurityAES(vecSessionKey).VerifySignature(tampered, token); err == nil {
+		t.Fatal("VerifySignature accepted a tampered stub, want mismatch")
+	}
+}
+
+// TestSequenceNumberAdvances confirms consecutive messages carry different (encrypted)
+// sequence numbers, i.e. the counter advances per call.
+func TestSequenceNumberAdvances(t *testing.T) {
+	m := NewMessageSecurityAES(vecSessionKey)
+	t1, err := m.Sign(vecPlaintext)
+	if err != nil {
+		t.Fatalf("Sign #1: %v", err)
+	}
+	t2, err := m.Sign(vecPlaintext)
+	if err != nil {
+		t.Fatalf("Sign #2: %v", err)
+	}
+	// SequenceNumber field occupies token bytes [8:16].
+	if bytes.Equal(t1[8:16], t2[8:16]) {
+		t.Fatal("sequence number did not advance between messages")
+	}
+}
+
+// TestDeriveSequenceNumber pins the wire rendering of the counter, including the client bit.
+func TestDeriveSequenceNumber(t *testing.T) {
+	if got := hex.EncodeToString(deriveSequenceNumber(0, true)); got != "0000000080000000" {
+		t.Errorf("client seq 0 = %s, want 0000000080000000", got)
+	}
+	if got := hex.EncodeToString(deriveSequenceNumber(0, false)); got != "0000000000000000" {
+		t.Errorf("server seq 0 = %s, want 0000000000000000", got)
+	}
+	// low = 0x01020304 big-endian, high = 0x80000000 (client bit only).
+	want := mustHex(t, "0102030480000000")
+	if got := deriveSequenceNumber(0x01020304, true); !bytes.Equal(got, want) {
+		t.Errorf("seq 0x01020304 = %x, want %x", got, want)
+	}
+}

--- a/windows/protocols/ms-nrpc/NL_AUTH_SHA2_SIGNATURE.go
+++ b/windows/protocols/ms-nrpc/NL_AUTH_SHA2_SIGNATURE.go
@@ -1,0 +1,86 @@
+package msnrpc
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+// nlAuthSHA2ReservedSize is the trailing Reserved field of NL_AUTH_SHA2_SIGNATURE. The
+// sender sets it to zero and the receiver ignores it ([MS-NRPC] 2.2.1.3.3), but it is a
+// real part of the wire layout — Windows and impacket both emit it, so it is included in
+// the token length (48 octets integrity-only, 56 octets sealing).
+const nlAuthSHA2ReservedSize = 24
+
+// NL_AUTH_SHA2_SIGNATURE ([MS-NRPC] 2.2.1.3.3) is the per-message security token Netlogon
+// places after the RPC sec_trailer when acting as its own security provider with the AES
+// cipher suite negotiated: an HMAC-SHA256 checksum with AES-128 CFB8 sealing. Like
+// NL_AUTH_SIGNATURE it is a fixed little-endian layout (not NDR) and carries its own
+// Marshal/Unmarshal. It differs from the legacy token by the algorithm identifiers and a
+// trailing 24-octet Reserved field.
+//
+// The Confounder is present on the wire only when the token seals the message
+// (SealAlgorithm != NlSealNotEncrypted). On the wire the SequenceNumber and (when sealing)
+// the Confounder are encrypted; the Checksum is carried in the clear ([MS-NRPC] 3.3.4.2.1).
+type NL_AUTH_SHA2_SIGNATURE struct {
+	SignatureAlgorithm uint16
+	SealAlgorithm      uint16
+	Pad                uint16 // MUST be 0xFFFF
+	Flags              uint16 // MUST be 0x0000
+	SequenceNumber     [8]byte
+	Checksum           [8]byte
+	Confounder         [8]byte // present on the wire only when Sealed() is true
+	// Reserved [24]byte is always zero on send and ignored on receipt.
+}
+
+// Sealed reports whether the token seals (encrypts) the message, in which case the
+// Confounder is part of the wire layout.
+func (s *NL_AUTH_SHA2_SIGNATURE) Sealed() bool { return s.SealAlgorithm != NlSealNotEncrypted }
+
+// Header returns the eight header octets (the four little-endian uint16s). These are the
+// bytes fed to the HMAC-SHA256 checksum computation ([MS-NRPC] 3.3.4.2.1 step 7).
+func (s *NL_AUTH_SHA2_SIGNATURE) Header() []byte {
+	h := make([]byte, nlAuthHeaderSize)
+	binary.LittleEndian.PutUint16(h[0:2], s.SignatureAlgorithm)
+	binary.LittleEndian.PutUint16(h[2:4], s.SealAlgorithm)
+	binary.LittleEndian.PutUint16(h[4:6], s.Pad)
+	binary.LittleEndian.PutUint16(h[6:8], s.Flags)
+	return h
+}
+
+// Marshal serializes the token: the 8-byte header, the 8-byte SequenceNumber, the 8-byte
+// Checksum, the 8-byte Confounder (only when Sealed()), and the trailing 24 zero octets of
+// Reserved. The result is 48 octets for an integrity-only token and 56 octets for a sealing
+// token.
+func (s *NL_AUTH_SHA2_SIGNATURE) Marshal() []byte {
+	out := make([]byte, 0, 56)
+	out = append(out, s.Header()...)
+	out = append(out, s.SequenceNumber[:]...)
+	out = append(out, s.Checksum[:]...)
+	if s.Sealed() {
+		out = append(out, s.Confounder[:]...)
+	}
+	out = append(out, make([]byte, nlAuthSHA2ReservedSize)...)
+	return out
+}
+
+// Unmarshal parses a token from the front of data. Whether the Confounder is expected is
+// decided by SealAlgorithm, so the header is read first. The trailing Reserved field is not
+// required to be present (the receiver ignores it), so it is not enforced.
+func (s *NL_AUTH_SHA2_SIGNATURE) Unmarshal(data []byte) error {
+	if len(data) < nlAuthHeaderSize+16 {
+		return fmt.Errorf("NL_AUTH_SHA2_SIGNATURE truncated: have %d bytes, need at least %d", len(data), nlAuthHeaderSize+16)
+	}
+	s.SignatureAlgorithm = binary.LittleEndian.Uint16(data[0:2])
+	s.SealAlgorithm = binary.LittleEndian.Uint16(data[2:4])
+	s.Pad = binary.LittleEndian.Uint16(data[4:6])
+	s.Flags = binary.LittleEndian.Uint16(data[6:8])
+	copy(s.SequenceNumber[:], data[8:16])
+	copy(s.Checksum[:], data[16:24])
+	if s.Sealed() {
+		if len(data) < 32 {
+			return fmt.Errorf("NL_AUTH_SHA2_SIGNATURE sealing token truncated: have %d bytes, need at least 32", len(data))
+		}
+		copy(s.Confounder[:], data[24:32])
+	}
+	return nil
+}

--- a/windows/protocols/ms-nrpc/NL_AUTH_SIGNATURE.go
+++ b/windows/protocols/ms-nrpc/NL_AUTH_SIGNATURE.go
@@ -1,0 +1,94 @@
+package msnrpc
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+// Netlogon signature and seal algorithm identifiers ([MS-NRPC] 2.2.1.3.2/2.2.1.3.3), the
+// 16-bit little-endian values placed in the SignatureAlgorithm and SealAlgorithm fields of
+// the per-message tokens. HMAC-SHA256/AES-128 are the AES-negotiated pair; HMAC-MD5/RC4 the
+// legacy pair. NlSealNotEncrypted marks an integrity-only (signed, not sealed) token, in
+// which case the Confounder is omitted from the wire structure.
+const (
+	NlSignatureHMACMD5    uint16 = 0x0077 // HMAC-MD5 (legacy)
+	NlSignatureHMACSHA256 uint16 = 0x0013 // HMAC-SHA256 (AES)
+	NlSealNotEncrypted    uint16 = 0xffff // not sealed; Confounder absent
+	NlSealRC4             uint16 = 0x007a // RC4 (legacy)
+	NlSealAES128          uint16 = 0x001a // AES-128 CFB8
+)
+
+// nlAuthHeaderSize is the size of the fixed four-uint16 header (SignatureAlgorithm,
+// SealAlgorithm, Pad, Flags) that opens both token structures. Its first eight octets are
+// the exact bytes fed into the checksum computation ([MS-NRPC] 3.3.4.2.1 step 7).
+const nlAuthHeaderSize = 8
+
+// NL_AUTH_SIGNATURE ([MS-NRPC] 2.2.1.3.2) is the per-message security token Netlogon places
+// after the RPC sec_trailer when acting as its own security provider with the legacy
+// (non-AES) cipher suite: an HMAC-MD5 checksum with RC4 sealing. It is NOT an NDR structure
+// — it is a fixed little-endian layout, so it carries its own Marshal/Unmarshal rather than
+// relying on the ndr package. The AES cipher suite uses NL_AUTH_SHA2_SIGNATURE instead.
+//
+// The Confounder is present on the wire only when the token seals (encrypts) the message,
+// i.e. when SealAlgorithm != NlSealNotEncrypted; for an integrity-only token it is omitted.
+// On the wire the SequenceNumber and (when sealing) the Confounder are encrypted, whereas
+// the Checksum is carried in the clear ([MS-NRPC] 3.3.4.2.1).
+type NL_AUTH_SIGNATURE struct {
+	SignatureAlgorithm uint16
+	SealAlgorithm      uint16
+	Pad                uint16 // MUST be 0xFFFF
+	Flags              uint16 // MUST be 0x0000
+	SequenceNumber     [8]byte
+	Checksum           [8]byte
+	Confounder         [8]byte // present on the wire only when Sealed() is true
+}
+
+// Sealed reports whether the token seals (encrypts) the message, in which case the
+// Confounder is part of the wire layout.
+func (s *NL_AUTH_SIGNATURE) Sealed() bool { return s.SealAlgorithm != NlSealNotEncrypted }
+
+// Header returns the eight header octets (the four little-endian uint16s). These are the
+// bytes fed to the checksum computation ([MS-NRPC] 3.3.4.2.1 step 7).
+func (s *NL_AUTH_SIGNATURE) Header() []byte {
+	h := make([]byte, nlAuthHeaderSize)
+	binary.LittleEndian.PutUint16(h[0:2], s.SignatureAlgorithm)
+	binary.LittleEndian.PutUint16(h[2:4], s.SealAlgorithm)
+	binary.LittleEndian.PutUint16(h[4:6], s.Pad)
+	binary.LittleEndian.PutUint16(h[6:8], s.Flags)
+	return h
+}
+
+// Marshal serializes the token: the 8-byte header, the 8-byte SequenceNumber, the 8-byte
+// Checksum, and — only when Sealed() — the 8-byte Confounder. The result is 24 octets for
+// an integrity-only token and 32 octets for a sealing token.
+func (s *NL_AUTH_SIGNATURE) Marshal() []byte {
+	out := make([]byte, 0, 32)
+	out = append(out, s.Header()...)
+	out = append(out, s.SequenceNumber[:]...)
+	out = append(out, s.Checksum[:]...)
+	if s.Sealed() {
+		out = append(out, s.Confounder[:]...)
+	}
+	return out
+}
+
+// Unmarshal parses a token from the front of data. Whether the Confounder is expected is
+// decided by SealAlgorithm, so the header is read first.
+func (s *NL_AUTH_SIGNATURE) Unmarshal(data []byte) error {
+	if len(data) < nlAuthHeaderSize+16 {
+		return fmt.Errorf("NL_AUTH_SIGNATURE truncated: have %d bytes, need at least %d", len(data), nlAuthHeaderSize+16)
+	}
+	s.SignatureAlgorithm = binary.LittleEndian.Uint16(data[0:2])
+	s.SealAlgorithm = binary.LittleEndian.Uint16(data[2:4])
+	s.Pad = binary.LittleEndian.Uint16(data[4:6])
+	s.Flags = binary.LittleEndian.Uint16(data[6:8])
+	copy(s.SequenceNumber[:], data[8:16])
+	copy(s.Checksum[:], data[16:24])
+	if s.Sealed() {
+		if len(data) < 32 {
+			return fmt.Errorf("NL_AUTH_SIGNATURE sealing token truncated: have %d bytes, need 32", len(data))
+		}
+		copy(s.Confounder[:], data[24:32])
+	}
+	return nil
+}


### PR DESCRIPTION
### Linked Issue
Part of #655 (stage 3 of 4). This PR does **not** close #655 — the umbrella enhancement spans four stages and explicitly anticipates independent per-stage PRs. It should stay open until the client `SetAuth` wiring (stage 4) lands.

### Motivation
Netlogon can act as its own RPC security provider (`RPC_C_AUTHN_NETLOGON`, auth_type `0x44`). When it does, each PDU carries a Netlogon-specific per-message token after the sec_trailer — a different token format from NTLM's, so `crypto/spnego/ntlm/security` is not reusable. This PR implements that token machinery for the AES cipher suite, standalone and fully unit-tested, ahead of the client wiring.

### Fix Description
Adds the per-message token layer described in [MS-NRPC] 2.2.1.3.2 / 2.2.1.3.3 / 3.3.4.2.1:

- **Wire structures** (`windows/protocols/ms-nrpc/`): `NL_AUTH_SIGNATURE` (legacy) and `NL_AUTH_SHA2_SIGNATURE` (AES) as fixed little-endian layouts with explicit `Marshal`/`Unmarshal`/`Header`, plus the algorithm-id constants. These follow the sec_trailer and are not NDR, so they carry their own (de)serialization rather than using the ndr package. The SHA2 token includes the trailing 24-byte `Reserved` field, and the confounder is emitted only when sealing (48-byte integrity token / 56-byte sealing token).
- **Engine** (`.../1.0/functions/messagesecurity.go`): `MessageSecurity` with `Sign` / `Seal` / `Unseal` / `VerifySignature` for the AES suite, following 3.3.4.2.1 exactly — HMAC-SHA256 checksum computed over the plaintext (header ‖ confounder ‖ stub, truncated to 8 bytes), the sequence number rendered per step 5 (big-endian halves, client bit `0x80000000`) and encrypted under the plain session key, and the confounder and stub sealed as **one continuous** AES-128-CFB8 stream keyed by the session key XOR `0xF0`. Reuses the existing `crypto/aes/cfb8` primitive.

Placed alongside the existing `crypto.go` in the interface's `functions` package, matching the session-key/credential helpers already there.

### How Verified
- `go build ./...` and `go vet` clean; `gofmt -l` reports nothing.
- Unit tests pin `Sign` and `Seal` output **byte-for-byte** against reference vectors (token bytes + encrypted stub) generated from a spec-faithful reference implementation, with the seal/unseal round-trip confirmed.
- Tamper tests: flipping a ciphertext byte (Unseal) or a stub byte (VerifySignature) fails the checksum.

### Test Coverage
**Added** — `.../1.0/functions/messagesecurity_test.go`:
- `TestSealVector`, `TestSignVector` — byte-for-byte vector pins (also assert 56/48-byte token lengths)
- `TestSealUnsealRoundTrip` — seal on one context, unseal on a fresh one under the same key
- `TestUnsealTamperDetected`, `TestVerifySignature` — tamper detection
- `TestSequenceNumberAdvances` — per-message counter advance
- `TestDeriveSequenceNumber` — sequence-number wire rendering incl. client bit

### Scope of Change
- **Files changed:** `windows/protocols/ms-nrpc/NL_AUTH_SIGNATURE.go`, `windows/protocols/ms-nrpc/NL_AUTH_SHA2_SIGNATURE.go`, `.../1.0/functions/messagesecurity.go`, `.../1.0/functions/messagesecurity_test.go` (all new)
- **Submodule pointer updated:** no
- **Behavioral changes outside the new code:** none

### Risk and Rollout
Low blast radius: all-new files, no existing code path touched (the NTLM security context and DCE/RPC client are untouched). Nothing invokes `MessageSecurity` yet — it becomes reachable only when stage 4 wires it into the client.

### Notes
- **AES suite only.** The legacy RC4/HMAC-MD5 branch of 3.3.4.2.1 is deferred to a later stage; the `NL_AUTH_SIGNATURE` struct and constants are in place for it, but no RC4 engine is included.
- Follow-up stages tracked under #655: secure-channel session object + authenticator, the client security-context interface refactor, and `SetAuth` wiring for `0x44`.