### PR TITLE
Add Netlogon secure-channel session and authenticator (#655)

### DIFF
--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/crypto.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/crypto.go
@@ -9,6 +9,7 @@ import (
 	"crypto/aes"
 	"crypto/hmac"
 	"crypto/sha256"
+	"encoding/binary"
 
 	"github.com/TheManticoreProject/Manticore/crypto/aes/cfb8"
 	"github.com/TheManticoreProject/Manticore/crypto/nt"
@@ -69,4 +70,37 @@ func ComputeNetlogonCredentialAES(challenge msnrpc.NETLOGON_CREDENTIAL, sessionK
 	var out msnrpc.NETLOGON_CREDENTIAL
 	cfb8.NewEncrypter(block, iv[:]).XORKeyStream(out[:], challenge[:])
 	return out
+}
+
+// addToCredential adds delta to a credential ([MS-NRPC] 3.1.4.5): the least-significant 4
+// octets are treated as a little-endian 32-bit integer and delta is added with overflow
+// ignored; the most-significant 4 octets are left unchanged. This is the arithmetic used to
+// advance the stored credential by a timestamp or by the constant 1.
+func addToCredential(cred msnrpc.NETLOGON_CREDENTIAL, delta uint32) msnrpc.NETLOGON_CREDENTIAL {
+	var out msnrpc.NETLOGON_CREDENTIAL
+	low := binary.LittleEndian.Uint32(cred[0:4]) + delta // uint32 wraps mod 2^32
+	binary.LittleEndian.PutUint32(out[0:4], low)
+	copy(out[4:8], cred[4:8])
+	return out
+}
+
+// ComputeNetlogonAuthenticatorAES computes a client Netlogon authenticator ([MS-NRPC]
+// 3.1.4.5) for the AES cipher suite: it adds timestamp to the stored credential (low 32
+// bits, overflow ignored) and encrypts the sum with the session key
+// (ComputeNetlogonCredentialAES). This is a pure function — it does not advance the caller's
+// stored credential; a caller that maintains a rolling secure channel should use
+// SecureChannel, which applies the stored-credential updates the protocol requires.
+//
+// Parameters:
+//   - storedCredential: The current stored client credential.
+//   - timestamp: The authenticator timestamp (seconds since 1970-01-01 UTC).
+//   - sessionKey: The 16-byte AES session key.
+//
+// Returns:
+//   - The NETLOGON_AUTHENTICATOR to send with the request.
+func ComputeNetlogonAuthenticatorAES(storedCredential msnrpc.NETLOGON_CREDENTIAL, timestamp uint32, sessionKey [16]byte) msnrpc.NETLOGON_AUTHENTICATOR {
+	return msnrpc.NETLOGON_AUTHENTICATOR{
+		Credential: ComputeNetlogonCredentialAES(addToCredential(storedCredential, timestamp), sessionKey),
+		Timestamp:  timestamp,
+	}
 }

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/securechannel.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/securechannel.go
@@ -1,0 +1,168 @@
+package functions
+
+// IDL source: [MS-NRPC] — this interface is translated from and verified
+// against the protocol's authoritative IDL. Full IDL (Appendix A):
+//   https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-nrpc/89f9b028-ee68-4fe2-afca-cc188f7079f7
+// A fetched copy is kept at ms-nrpc.idl in the interface directory.
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"fmt"
+	"io"
+	"time"
+
+	logon "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	msnrpc "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nrpc"
+)
+
+// DefaultNegotiateFlags is a capable client negotiate-flag set ([MS-NRPC] 3.1.4.2) that
+// advertises AES/strong-key secure-channel support. Establish forces NegotiateAES on top of
+// whatever flags it is given, because SecureChannel implements only the AES cipher suite.
+const DefaultNegotiateFlags uint32 = 0x212fffff
+
+// SecureChannelConfig holds the inputs to Establish. Exactly one of Password or NTHash
+// supplies the machine-account secret: NTHash (the raw 16-byte NT hash) takes precedence
+// when non-nil, otherwise the NT one-way function of Password is used.
+type SecureChannelConfig struct {
+	// PrimaryName is the DC name (the server principal), e.g. "DC01". Empty sends a NULL
+	// PrimaryName, which asks the server to use its own name.
+	PrimaryName string
+	// ComputerName is the client's NetBIOS computer name (without the trailing '$'), e.g.
+	// "WORKSTATION".
+	ComputerName string
+	// AccountName is the account the channel authenticates as, typically the machine account
+	// "COMPUTER$" ([MS-NRPC] 3.1.4.1).
+	AccountName string
+	// SecureChannelType is the kind of secure channel being set up, e.g.
+	// WorkstationSecureChannel or ServerSecureChannel.
+	SecureChannelType msnrpc.NETLOGON_SECURE_CHANNEL_TYPE
+	// Password is the account cleartext password; ignored when NTHash is set.
+	Password string
+	// NTHash is the raw 16-byte NT hash of the account secret (pass-the-hash); nil to derive
+	// the key material from Password instead.
+	NTHash []byte
+	// NegotiateFlags is the client negotiate-flag set; zero selects DefaultNegotiateFlags.
+	NegotiateFlags uint32
+	// Rand is the source of the 8-byte client challenge; nil selects crypto/rand. It exists
+	// as a seam for deterministic testing and must be left nil in production.
+	Rand io.Reader
+}
+
+// SecureChannel is an established Netlogon secure channel ([MS-NRPC] 3.1.4): it holds the
+// negotiated AES session key and negotiate flags and maintains the rolling stored credential
+// used to compute and verify per-call Netlogon authenticators (3.1.4.5).
+//
+// A SecureChannel is stateful and not safe for concurrent use: the stored credential
+// advances on every NextAuthenticator/VerifyResponseAuthenticator call, and the two must be
+// paired around each authenticated request in the order the calls go on the wire.
+type SecureChannel struct {
+	sessionKey       [16]byte
+	negotiateFlags   uint32
+	clientStoredCred msnrpc.NETLOGON_CREDENTIAL
+	now              func() time.Time
+}
+
+// Establish runs the Netlogon secure-channel handshake over the bound RPC connection rpc
+// ([MS-NRPC] 3.1.4.1, AES suite): it generates a client challenge, exchanges it for the
+// server challenge via NetrServerReqChallenge (opnum 4), derives the AES session key, and
+// proves possession of the machine secret via NetrServerAuthenticate3 (opnum 26). It then
+// verifies the server's returned credential equals ComputeNetlogonCredentialAES of the
+// server challenge before returning the channel; a mismatch means the server did not prove
+// knowledge of the shared secret and the channel is rejected.
+//
+// rpc must already be bound to the Netlogon interface (an anonymous/unauthenticated binding
+// is sufficient for the handshake itself).
+func Establish(rpc ndr.Invoker, cfg SecureChannelConfig) (*SecureChannel, error) {
+	src := cfg.Rand
+	if src == nil {
+		src = rand.Reader
+	}
+	var clientChallenge msnrpc.NETLOGON_CREDENTIAL
+	if _, err := io.ReadFull(src, clientChallenge[:]); err != nil {
+		return nil, fmt.Errorf("netlogon secure channel: generate client challenge: %w", err)
+	}
+
+	serverChallenge, status, err := NetrServerReqChallenge(rpc, cfg.PrimaryName, cfg.ComputerName, clientChallenge)
+	if err != nil {
+		return nil, fmt.Errorf("netlogon secure channel: NetrServerReqChallenge: %w", err)
+	}
+	if status != logon.StatusSuccess {
+		return nil, fmt.Errorf("netlogon secure channel: NetrServerReqChallenge: %s", logon.StatusString(status))
+	}
+
+	sessionKey := ComputeSessionKeyAES(cfg.Password, cfg.NTHash, clientChallenge, serverChallenge)
+	clientCredential := ComputeNetlogonCredentialAES(clientChallenge, sessionKey)
+
+	flags := cfg.NegotiateFlags
+	if flags == 0 {
+		flags = DefaultNegotiateFlags
+	}
+	flags |= logon.NegotiateAES
+
+	var primaryPtr *ndr.WSTR
+	if cfg.PrimaryName != "" {
+		p := ndr.WSTR(cfg.PrimaryName)
+		primaryPtr = &p
+	}
+
+	serverCredential, negFlags, _, err := NetrServerAuthenticate3(
+		rpc,
+		primaryPtr,
+		ndr.WSTR(cfg.AccountName),
+		cfg.SecureChannelType,
+		ndr.WSTR(cfg.ComputerName),
+		clientCredential,
+		ndr.DWORD(flags),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("netlogon secure channel: NetrServerAuthenticate3: %w", err)
+	}
+
+	expectedServer := ComputeNetlogonCredentialAES(serverChallenge, sessionKey)
+	if subtle.ConstantTimeCompare(expectedServer[:], serverCredential[:]) != 1 {
+		return nil, fmt.Errorf("netlogon secure channel: server credential mismatch (access denied or wrong machine secret)")
+	}
+
+	return &SecureChannel{
+		sessionKey:       sessionKey,
+		negotiateFlags:   uint32(negFlags),
+		clientStoredCred: clientCredential,
+		now:              time.Now,
+	}, nil
+}
+
+// SessionKey returns the negotiated 16-byte AES session key.
+func (s *SecureChannel) SessionKey() [16]byte { return s.sessionKey }
+
+// NegotiateFlags returns the negotiate flags the server agreed to (its echoed subset).
+func (s *SecureChannel) NegotiateFlags() uint32 { return s.negotiateFlags }
+
+// NextAuthenticator computes the client authenticator to send with the next authenticated
+// request ([MS-NRPC] 3.1.4.5 step 1): it advances the stored credential by the current
+// timestamp and encrypts the result under the session key. It mutates the channel state, so
+// each call yields the authenticator for exactly one request and must be followed by a
+// VerifyResponseAuthenticator on the server's reply.
+func (s *SecureChannel) NextAuthenticator() msnrpc.NETLOGON_AUTHENTICATOR {
+	ts := uint32(s.now().Unix())
+	s.clientStoredCred = addToCredential(s.clientStoredCred, ts)
+	return msnrpc.NETLOGON_AUTHENTICATOR{
+		Credential: ComputeNetlogonCredentialAES(s.clientStoredCred, s.sessionKey),
+		Timestamp:  ts,
+	}
+}
+
+// VerifyResponseAuthenticator validates the server's return authenticator ([MS-NRPC]
+// 3.1.4.5 step 3): it advances the stored credential by one and checks that encrypting it
+// under the session key reproduces the server's credential, in constant time. A mismatch
+// means the secure channel is no longer valid and the caller should re-establish it. It must
+// be called once per request, paired with the preceding NextAuthenticator.
+func (s *SecureChannel) VerifyResponseAuthenticator(server msnrpc.NETLOGON_AUTHENTICATOR) error {
+	s.clientStoredCred = addToCredential(s.clientStoredCred, 1)
+	expected := ComputeNetlogonCredentialAES(s.clientStoredCred, s.sessionKey)
+	if subtle.ConstantTimeCompare(expected[:], server.Credential[:]) != 1 {
+		return fmt.Errorf("netlogon secure channel: server authenticator mismatch (channel invalid, re-establish)")
+	}
+	return nil
+}

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/securechannel_test.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/securechannel_test.go
@@ -1,0 +1,200 @@
+package functions
+
+// White-box tests for the Netlogon secure channel. Being in package functions lets the
+// scripted invoker populate the unexported response structs directly and lets the rolling
+// test drive an independent server mirror of [MS-NRPC] 3.1.4.5. The authenticator vector is
+// pinned against impacket's ComputeNetlogonAuthenticatorAES.
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"testing"
+	"time"
+
+	netlogon "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	msnrpc "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nrpc"
+)
+
+var scSessionKey = [16]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
+
+// TestComputeNetlogonAuthenticatorAESVector pins the authenticator arithmetic to the
+// impacket vector: stored 0x11*8, timestamp 0x11223344, session key 00..0f.
+func TestComputeNetlogonAuthenticatorAESVector(t *testing.T) {
+	stored := msnrpc.NETLOGON_CREDENTIAL{0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11}
+	auth := ComputeNetlogonAuthenticatorAES(stored, 0x11223344, scSessionKey)
+	if got := hex.EncodeToString(auth.Credential[:]); got != "934de307ed961bf9" {
+		t.Errorf("credential = %s, want 934de307ed961bf9", got)
+	}
+	if auth.Timestamp != 0x11223344 {
+		t.Errorf("timestamp = %#x, want 0x11223344", auth.Timestamp)
+	}
+}
+
+// TestAddToCredential pins the low-32-bit little-endian add with overflow ignored and the
+// high 4 bytes left untouched ([MS-NRPC] 3.1.4.5).
+func TestAddToCredential(t *testing.T) {
+	// 0xFFFFFFFF + 2 wraps to 0x00000001 in the low DWORD; high DWORD unchanged.
+	in := msnrpc.NETLOGON_CREDENTIAL{0xff, 0xff, 0xff, 0xff, 0xaa, 0xbb, 0xcc, 0xdd}
+	got := addToCredential(in, 2)
+	want := msnrpc.NETLOGON_CREDENTIAL{0x01, 0x00, 0x00, 0x00, 0xaa, 0xbb, 0xcc, 0xdd}
+	if got != want {
+		t.Errorf("addToCredential = %x, want %x", got, want)
+	}
+}
+
+// TestSecureChannelRolling drives NextAuthenticator/VerifyResponseAuthenticator across
+// several calls against an independent server mirror of 3.1.4.5, confirming the client and
+// server stored-credential accumulators stay in lockstep.
+func TestSecureChannelRolling(t *testing.T) {
+	seed := msnrpc.NETLOGON_CREDENTIAL{0x7e, 0x0a, 0xa0, 0x52, 0x63, 0xd9, 0xe4, 0xee}
+	timestamps := []uint32{0x1000, 0x1005, 0x100a, 0x2000}
+	idx := 0
+	sc := &SecureChannel{
+		sessionKey:       scSessionKey,
+		clientStoredCred: seed,
+		now:              func() time.Time { t := time.Unix(int64(timestamps[idx]), 0); idx++; return t },
+	}
+
+	serverStored := seed // server seeds its stored credential identically
+	for _, ts := range timestamps {
+		auth := sc.NextAuthenticator()
+		if auth.Timestamp != ts {
+			t.Fatalf("timestamp = %#x, want %#x", auth.Timestamp, ts)
+		}
+		// Server side ([MS-NRPC] 3.1.4.5 step 2): stored += ts, verify, stored += 1, respond.
+		serverStored = addToCredential(serverStored, ts)
+		if want := ComputeNetlogonCredentialAES(serverStored, scSessionKey); want != auth.Credential {
+			t.Fatalf("ts %#x: client credential %x, server expected %x", ts, auth.Credential, want)
+		}
+		serverStored = addToCredential(serverStored, 1)
+		resp := msnrpc.NETLOGON_AUTHENTICATOR{
+			Credential: ComputeNetlogonCredentialAES(serverStored, scSessionKey),
+			Timestamp:  ts,
+		}
+		if err := sc.VerifyResponseAuthenticator(resp); err != nil {
+			t.Fatalf("ts %#x: VerifyResponseAuthenticator: %v", ts, err)
+		}
+	}
+}
+
+// TestVerifyResponseRejectsForgedAuthenticator confirms a bad server credential is rejected.
+func TestVerifyResponseRejectsForgedAuthenticator(t *testing.T) {
+	sc := &SecureChannel{
+		sessionKey:       scSessionKey,
+		clientStoredCred: msnrpc.NETLOGON_CREDENTIAL{1, 2, 3, 4, 5, 6, 7, 8},
+		now:              func() time.Time { return time.Unix(0x3000, 0) },
+	}
+	sc.NextAuthenticator()
+	if err := sc.VerifyResponseAuthenticator(msnrpc.NETLOGON_AUTHENTICATOR{}); err == nil {
+		t.Fatal("VerifyResponseAuthenticator accepted an all-zero server authenticator")
+	}
+}
+
+// scriptInvoker answers the two handshake RPCs from canned data, records the opnums seen and
+// the credential the client sent, and can forge the server credential or fail ReqChallenge.
+type scriptInvoker struct {
+	serverChallenge msnrpc.NETLOGON_CREDENTIAL
+	sessionKey      [16]byte
+	reqStatus       uint32
+	forgeServer     bool
+	opnums          []uint16
+	gotClientCred   msnrpc.NETLOGON_CREDENTIAL
+	gotAccountName  ndr.WSTR
+}
+
+func (s *scriptInvoker) Invoke(in ndr.Call, out any) error {
+	s.opnums = append(s.opnums, in.Opnum())
+	switch o := out.(type) {
+	case *netrServerReqChallengeResponse:
+		o.ServerChallenge = s.serverChallenge
+		o.Status = ndr.DWORD(s.reqStatus)
+	case *netrServerAuthenticate3Response:
+		req := in.(*netrServerAuthenticate3Request)
+		s.gotClientCred = req.ClientCredential
+		s.gotAccountName = req.AccountName
+		cred := ComputeNetlogonCredentialAES(s.serverChallenge, s.sessionKey)
+		if s.forgeServer {
+			cred[0] ^= 0xff
+		}
+		o.ServerCredential = cred
+		o.NegotiateFlags = req.NegotiateFlags
+		o.Status = ndr.DWORD(netlogon.StatusSuccess)
+	default:
+		return fmt.Errorf("scriptInvoker: unexpected response type %T", out)
+	}
+	return nil
+}
+
+// establishFixture builds a scripted invoker and config for a fixed client/server challenge
+// and password, so the handshake is fully deterministic.
+func establishFixture(forge bool, reqStatus uint32) (*scriptInvoker, SecureChannelConfig, msnrpc.NETLOGON_CREDENTIAL, [16]byte) {
+	clientChallenge := msnrpc.NETLOGON_CREDENTIAL{1, 2, 3, 4, 5, 6, 7, 8}
+	serverChallenge := msnrpc.NETLOGON_CREDENTIAL{8, 7, 6, 5, 4, 3, 2, 1}
+	const password = "Machine$Pass1"
+	sk := ComputeSessionKeyAES(password, nil, clientChallenge, serverChallenge)
+	inv := &scriptInvoker{serverChallenge: serverChallenge, sessionKey: sk, reqStatus: reqStatus, forgeServer: forge}
+	cfg := SecureChannelConfig{
+		PrimaryName:       "DC01",
+		ComputerName:      "WS01",
+		AccountName:       "WS01$",
+		SecureChannelType: msnrpc.WorkstationSecureChannel,
+		Password:          password,
+		Rand:              bytes.NewReader(clientChallenge[:]),
+	}
+	return inv, cfg, clientChallenge, sk
+}
+
+// TestEstablishHappyPath verifies the handshake sequence, the derived session key, the
+// seeded stored credential, and the credential the client sent in NetrServerAuthenticate3.
+func TestEstablishHappyPath(t *testing.T) {
+	inv, cfg, clientChallenge, sk := establishFixture(false, netlogon.StatusSuccess)
+
+	sc, err := Establish(inv, cfg)
+	if err != nil {
+		t.Fatalf("Establish: %v", err)
+	}
+	if inv.opnums[0] != netlogon.OpnumNetrServerReqChallenge || inv.opnums[1] != netlogon.OpnumNetrServerAuthenticate3 {
+		t.Fatalf("opnum sequence = %v, want [4 26]", inv.opnums)
+	}
+	if sc.SessionKey() != sk {
+		t.Errorf("session key = %x, want %x", sc.SessionKey(), sk)
+	}
+	// The stored credential is seeded to the client credential = Compute(clientChallenge).
+	wantSeed := ComputeNetlogonCredentialAES(clientChallenge, sk)
+	if sc.clientStoredCred != wantSeed {
+		t.Errorf("seeded stored credential = %x, want %x", sc.clientStoredCred, wantSeed)
+	}
+	if inv.gotClientCred != wantSeed {
+		t.Errorf("client credential sent = %x, want %x", inv.gotClientCred, wantSeed)
+	}
+	if inv.gotAccountName != ndr.WSTR("WS01$") {
+		t.Errorf("account name sent = %q, want %q", inv.gotAccountName, "WS01$")
+	}
+	// AES must be negotiated regardless of the caller's flags (cfg left NegotiateFlags 0).
+	if sc.NegotiateFlags()&netlogon.NegotiateAES == 0 {
+		t.Errorf("negotiate flags %#x missing NegotiateAES", sc.NegotiateFlags())
+	}
+}
+
+// TestEstablishRejectsForgedServerCredential confirms Establish fails when the server does
+// not prove knowledge of the shared secret.
+func TestEstablishRejectsForgedServerCredential(t *testing.T) {
+	inv, cfg, _, _ := establishFixture(true, netlogon.StatusSuccess)
+	if _, err := Establish(inv, cfg); err == nil {
+		t.Fatal("Establish accepted a forged server credential")
+	}
+}
+
+// TestEstablishReqChallengeStatusError confirms a non-success ReqChallenge status aborts the
+// handshake before NetrServerAuthenticate3 is called.
+func TestEstablishReqChallengeStatusError(t *testing.T) {
+	inv, cfg, _, _ := establishFixture(false, netlogon.StatusAccessDenied)
+	if _, err := Establish(inv, cfg); err == nil {
+		t.Fatal("Establish ignored a failed NetrServerReqChallenge status")
+	}
+	if len(inv.opnums) != 1 || inv.opnums[0] != netlogon.OpnumNetrServerReqChallenge {
+		t.Fatalf("opnums = %v, want just [4] (no Authenticate3 after failure)", inv.opnums)
+	}
+}


### PR DESCRIPTION
### Linked Issue
Part of #655 (secure-channel session stage). This PR does **not** close #655 — the umbrella enhancement spans multiple stages and explicitly anticipates independent per-stage PRs. It should stay open until the client `SetAuth` wiring lands.

Builds on the per-message token machinery in #891; both are independent of each other and of the client wiring.

### Motivation
Methods that run over a Netlogon secure channel (NetrServerPasswordSet2, NetrLogonSamLogon*, NetrServerTrustPasswordsGet, …) authenticate at the application layer with a rolling `NETLOGON_AUTHENTICATOR`, whose value derives from the session key established by the challenge/response handshake. That handshake and the authenticator arithmetic did not exist as a reusable unit; callers could invoke the raw opnums but had nothing to derive the session key or produce/verify authenticators. This PR provides that.

### Fix Description
Implements [MS-NRPC] 3.1.4.1 (session-key negotiation) and 3.1.4.5 (authenticator computation/verification) for the AES cipher suite:

- **Authenticator arithmetic** (`crypto.go`): `addToCredential` adds a delta to the least-significant 4 octets of a credential (little-endian, overflow ignored, high 4 octets untouched), and `ComputeNetlogonAuthenticatorAES` adds the timestamp to the stored credential and encrypts the sum under the session key. The latter is a pure function documented as such.
- **`SecureChannel` + `Establish`** (`securechannel.go`): generates the client challenge (from `crypto/rand`, injectable for tests), runs `NetrServerReqChallenge` → `ComputeSessionKeyAES` → `NetrServerAuthenticate3` over a bound RPC connection, and — before returning — verifies the server's returned credential equals `ComputeNetlogonCredentialAES(serverChallenge)`, rejecting the channel otherwise. `NegotiateAES` is forced on.
- **Rolling credential**: `NextAuthenticator` (stored += timestamp, then encrypt) and `VerifyResponseAuthenticator` (stored += 1, encrypt, constant-time compare) implement the 3.1.4.5 running accumulator exactly, so the client and server stored credentials stay in lockstep across calls.

Config is passed as a `SecureChannelConfig` struct (machine account name, computer/primary name, channel type, and either a password or a raw NT hash for pass-the-hash).

### How Verified
- `go build ./...`, `go vet`, and `gofmt -l` all clean.
- Unit tests pin `ComputeNetlogonAuthenticatorAES` **byte-for-byte** to a reference vector, and drive the full rolling protocol across four calls against an independent in-test server mirror of 3.1.4.5 (both sides' accumulators must match at every step).
- Handshake tests use a scripted invoker: the happy path asserts the opnum sequence (4 then 26), the derived session key, the seeded stored credential, and the credential/account name actually sent; negative tests confirm a forged server credential and a failed `NetrServerReqChallenge` status both abort.

### Test Coverage
**Added** — `.../1.0/functions/securechannel_test.go`:
- `TestComputeNetlogonAuthenticatorAESVector`, `TestAddToCredential` — arithmetic pins
- `TestSecureChannelRolling` — multi-call rolling vs. an independent server mirror
- `TestVerifyResponseRejectsForgedAuthenticator`
- `TestEstablishHappyPath`, `TestEstablishRejectsForgedServerCredential`, `TestEstablishReqChallengeStatusError`

### Scope of Change
- **Files changed:** `.../1.0/functions/crypto.go` (added authenticator arithmetic; `encoding/binary` import), `.../1.0/functions/securechannel.go` (new), `.../1.0/functions/securechannel_test.go` (new)
- **Submodule pointer updated:** no
- **Behavioral changes outside the new code:** none (existing crypto helpers and method stubs are untouched)

### Risk and Rollout
Low blast radius: additive only, no existing code path modified. `SecureChannel` is not yet invoked by any client; it becomes reachable when the secure-channel methods and the RPC-level wiring adopt it.

### Notes
- **AES cipher suite only.** The legacy RC4/HMAC-MD5 strong-key and DES session-key paths ([MS-NRPC] 3.1.4.3.1 legacy branch) are deferred; `Establish` forces `NegotiateAES`.
- Live validation against a DC with a real machine account is deferred to the client-wiring stage, where a full sealed round-trip can be exercised.
- Remaining stages tracked under #655: the client security-context interface refactor and `SetAuth` wiring for auth_type `0x44`, plus the optional legacy cipher suite.