### PR TITLE
Wire Netlogon RPC secure-channel auth into the DCE/RPC client (#655)

### DIFF
--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/netlogon_live_integration_test.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/netlogon_live_integration_test.go
@@ -1,0 +1,111 @@
+//go:build integration
+
+// Live integration test for the Netlogon secure channel and RPC_C_AUTHN_NETLOGON transport
+// sealing over the full DCE/RPC-over-SMB stack. Excluded from the default build by the
+// "integration" tag. Requires a reachable DC and a machine account whose password is known.
+//
+//	DCERPC_TEST_HOST=192.168.1.39 DCERPC_TEST_USER=Administrator DCERPC_TEST_PASS='Admin123!' \
+//	NETLOGON_COMPUTER=MANTICORE1 NETLOGON_PASS='Manticore1Pass!' \
+//	NETLOGON_SERVER='\\TMP-W-2016' NETLOGON_DOMAIN=TMP-W-2016.local \
+//	go test -tags integration -v -run Integration_Netlogon \
+//	  ./network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/
+package functions_test
+
+import (
+	"os"
+	"testing"
+
+	netlogon "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	dcerpcclient "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/pdu"
+	smbclient "github.com/TheManticoreProject/Manticore/network/smb/client"
+	"github.com/TheManticoreProject/Manticore/windows/credentials"
+	msnrpc "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nrpc"
+)
+
+func TestIntegration_NetlogonSecureChannel(t *testing.T) {
+	host := os.Getenv("DCERPC_TEST_HOST")
+	computer := os.Getenv("NETLOGON_COMPUTER") // machine account name without the trailing '$'
+	machinePass := os.Getenv("NETLOGON_PASS")  // that account's cleartext password
+	if host == "" || computer == "" || machinePass == "" {
+		t.Skip("set DCERPC_TEST_HOST, NETLOGON_COMPUTER and NETLOGON_PASS to run the live Netlogon test")
+	}
+	serverName := os.Getenv("NETLOGON_SERVER") // DC name for the ServerName parameter, e.g. \\DC01
+	domain := os.Getenv("NETLOGON_DOMAIN")     // domain in the NL_AUTH_MESSAGE bind token
+
+	creds, err := credentials.NewCredentials(os.Getenv("DCERPC_TEST_DOMAIN"), os.Getenv("DCERPC_TEST_USER"), os.Getenv("DCERPC_TEST_PASS"), "")
+	if err != nil {
+		t.Fatalf("NewCredentials: %v", err)
+	}
+	smb, err := smbclient.Dial(host, 445, smbclient.Options{})
+	if err != nil {
+		t.Fatalf("SMB Dial: %v", err)
+	}
+	defer smb.Disconnect()
+	if err := smb.Login(creds); err != nil {
+		t.Fatalf("SMB Login: %v", err)
+	}
+	defer smb.Logoff()
+	if err := smb.TreeConnect("IPC$"); err != nil {
+		t.Fatalf("SMB TreeConnect(IPC$): %v", err)
+	}
+	defer smb.TreeDisconnect()
+
+	// ---- Binding #1: anonymous, for the secure-channel handshake (Stage A) ----
+	tr1, err := smb.RPCTransport(netlogon.PipeName)
+	if err != nil {
+		t.Fatalf("RPCTransport #1: %v", err)
+	}
+	rpc1 := dcerpcclient.NewClient(tr1)
+	if err := rpc1.Bind(netlogon.SyntaxID()); err != nil {
+		t.Fatalf("bind #1 (anon netlogon): %v", err)
+	}
+
+	sc, err := functions.Establish(rpc1, functions.SecureChannelConfig{
+		ComputerName:      computer,
+		AccountName:       computer + "$",
+		SecureChannelType: msnrpc.WorkstationSecureChannel,
+		Password:          machinePass,
+	})
+	if err != nil {
+		t.Fatalf("STAGE A FAILED — SecureChannel.Establish: %v", err)
+	}
+	_ = rpc1.Close()
+	t.Logf("[STAGE A ok] secure channel established; session key %x, negotiated flags %#08x",
+		sc.SessionKey(), sc.NegotiateFlags())
+
+	// ---- Binding #2: RPC_C_AUTHN_NETLOGON sealed (PR-D) ----
+	tr2, err := smb.RPCTransport(netlogon.PipeName)
+	if err != nil {
+		t.Fatalf("RPCTransport #2: %v", err)
+	}
+	rpc2 := dcerpcclient.NewClient(tr2)
+	defer rpc2.Close()
+
+	provider := functions.NewNetlogonSecurityContext(sc.SessionKey())
+	bindToken := msnrpc.BuildClientNlAuthMessage(computer, domain).Marshal()
+	if err := rpc2.SetAuthProvider(pdu.AuthTypeNetlogon, pdu.AuthLevelPktPrivacy, provider, bindToken); err != nil {
+		t.Fatalf("SetAuthProvider(netlogon): %v", err)
+	}
+	if err := rpc2.Bind(netlogon.SyntaxID()); err != nil {
+		t.Fatalf("PR-D FAILED — sealed netlogon bind: %v", err)
+	}
+	t.Logf("[PR-D ok] RPC_C_AUTHN_NETLOGON sealed bind accepted")
+
+	// Decisive end-to-end call: NetrLogonGetCapabilities validates the secure channel. A
+	// STATUS_SUCCESS return means the server accepted our sealed request stub, verified our
+	// application authenticator, and returned a sealed response we unsealed; verifying the
+	// ReturnAuthenticator proves the rolling credential is in lockstep.
+	comp := ndr.WSTR(computer)
+	auth := sc.NextAuthenticator()
+	ret, caps, err := functions.NetrLogonGetCapabilities(rpc2, ndr.WSTR(serverName), &comp, auth, msnrpc.NETLOGON_AUTHENTICATOR{}, 1)
+	if err != nil {
+		t.Fatalf("PR-D FAILED — NetrLogonGetCapabilities over sealed channel: %v", err)
+	}
+	if err := sc.VerifyResponseAuthenticator(ret); err != nil {
+		t.Fatalf("PR-D FAILED — server ReturnAuthenticator did not verify: %v", err)
+	}
+	t.Logf("[PR-D ok] sealed NetrLogonGetCapabilities round-trip verified; capabilities %#08x", uint32(caps.ServerCapabilities))
+}

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/rpcsecurity.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/rpcsecurity.go
@@ -1,0 +1,59 @@
+package functions
+
+// IDL source: [MS-NRPC] — this interface is translated from and verified
+// against the protocol's authoritative IDL. Full IDL (Appendix A):
+//   https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-nrpc/89f9b028-ee68-4fe2-afca-cc188f7079f7
+// A fetched copy is kept at ms-nrpc.idl in the interface directory.
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+)
+
+// NetlogonSecurityContext adapts the Netlogon per-message MessageSecurity to the DCE/RPC
+// client's SecurityContext, so a connection can protect its PDUs with RPC_C_AUTHN_NETLOGON
+// (auth_type 0x44). Unlike NTLM, Netlogon signs and seals only the stub, not the whole PDU
+// ([MS-NRPC] 3.3.4.2.1, confirmed against Windows: the token covers pduData, not the RPC
+// header or sec_trailer), so both directions ignore the client's signedRegion argument and
+// operate on the stub. A context is stateful (its sequence number advances per request) and
+// must not be shared across connections.
+type NetlogonSecurityContext struct {
+	ms *MessageSecurity
+}
+
+// NewNetlogonSecurityContext builds an RPC security provider for the AES cipher suite from a
+// secure-channel session key (SecureChannel.SessionKey). It is passed to the client's
+// SetAuthProvider together with the NL_AUTH_MESSAGE bind token.
+func NewNetlogonSecurityContext(sessionKey [16]byte) *NetlogonSecurityContext {
+	return &NetlogonSecurityContext{ms: NewMessageSecurityAES(sessionKey)}
+}
+
+// AuthValueLen is the NL_AUTH_SHA2_SIGNATURE length: 56 octets when sealing (the confounder
+// is present), 48 when only signing.
+func (n *NetlogonSecurityContext) AuthValueLen(seal bool) int {
+	if seal {
+		return 56
+	}
+	return 48
+}
+
+// ProtectRequest seals (privacy) or signs (integrity) the request stub, returning the
+// on-wire stub and the NL_AUTH_SHA2_SIGNATURE token.
+func (n *NetlogonSecurityContext) ProtectRequest(_, stub []byte, seal bool) ([]byte, []byte, error) {
+	if seal {
+		return n.ms.Seal(stub)
+	}
+	token, err := n.ms.Sign(stub)
+	return stub, token, err
+}
+
+// UnprotectResponse unseals (privacy) or verifies (integrity) the response stub against its
+// token, returning the recovered plaintext stub.
+func (n *NetlogonSecurityContext) UnprotectResponse(_, stub, authValue []byte, seal bool) ([]byte, error) {
+	if seal {
+		return n.ms.Unseal(stub, authValue)
+	}
+	return stub, n.ms.VerifySignature(stub, authValue)
+}
+
+// Compile-time check that the adapter satisfies the client's provider interface.
+var _ client.SecurityContext = (*NetlogonSecurityContext)(nil)

--- a/network/dcerpc/v5/client/auth.go
+++ b/network/dcerpc/v5/client/auth.go
@@ -61,8 +61,42 @@ func (c *Client) SetAuth(authType, authLevel uint8, creds *credentials.Credentia
 	return nil
 }
 
-// authConfigured reports whether SetAuth selected an authenticated bind.
-func (c *Client) authConfigured() bool { return c.creds != nil && c.authType != pdu.AuthTypeNone }
+// SetAuthProvider configures an authenticated bind with a caller-supplied single-leg
+// security provider, for SSPs whose session key is established out of band and whose bind
+// completes in one round trip (no challenge/auth3) — Netlogon (auth_type 0x44) in
+// particular. sec protects and unprotects each PDU; bindToken is the auth_value carried in
+// the bind PDU (for Netlogon, a marshalled NL_AUTH_MESSAGE), or nil. This is the seam that
+// keeps the client free of any specific SSP's dependencies: the provider and its bind token
+// are built by the caller. Unlike SetAuth (NTLM), the security context is active
+// immediately, so protected calls work as soon as Bind returns. Call before Bind.
+func (c *Client) SetAuthProvider(authType, authLevel uint8, sec SecurityContext, bindToken []byte) error {
+	if sec == nil {
+		return fmt.Errorf("dcerpc auth: nil security provider")
+	}
+	if authType == pdu.AuthTypeNone {
+		return fmt.Errorf("dcerpc auth: auth_type must not be none")
+	}
+	if authLevel == pdu.AuthLevelCall {
+		authLevel = pdu.AuthLevelPkt
+	}
+	switch authLevel {
+	case pdu.AuthLevelConnect, pdu.AuthLevelPkt, pdu.AuthLevelPktIntegrity, pdu.AuthLevelPktPrivacy:
+	default:
+		return fmt.Errorf("dcerpc auth: unsupported auth_level %d", authLevel)
+	}
+	c.authType = authType
+	c.authLevel = authLevel
+	c.sec = sec
+	c.bindToken = bindToken
+	return nil
+}
+
+// authConfigured reports whether an authenticated bind was selected, by either SetAuth
+// (NTLM, which supplies creds and derives the context during Bind) or SetAuthProvider (a
+// single-leg provider, which supplies the context up front).
+func (c *Client) authConfigured() bool {
+	return c.authType != pdu.AuthTypeNone && (c.creds != nil || c.sec != nil)
+}
 
 // protectsRequests reports whether each request PDU must carry a per-PDU auth verifier.
 // PKT, PKT_INTEGRITY, and PKT_PRIVACY all attach one (NTLM produces the same signature
@@ -81,8 +115,13 @@ func (c *Client) authVerifierOverhead() int {
 	return 3 + pdu.SecTrailerSize + c.sec.AuthValueLen(c.authLevel == pdu.AuthLevelPktPrivacy)
 }
 
-// negotiateToken builds the raw NTLM NEGOTIATE token carried in the bind's auth_value.
+// negotiateToken builds the auth_value carried in the bind's auth verifier. For a single-leg
+// provider (SetAuthProvider) it is the caller-supplied bind token; for NTLM it is a freshly
+// built NEGOTIATE message.
 func (c *Client) negotiateToken() ([]byte, error) {
+	if c.authType != pdu.AuthTypeNTLMSSP {
+		return c.bindToken, nil
+	}
 	neg, err := negotiate.CreateNegotiateMessage("", c.workstation, rpcNTLMNegotiateFlags, nil)
 	if err != nil {
 		return nil, err
@@ -109,11 +148,17 @@ func (c *Client) buildAuthenticate(chal *challenge.ChallengeMessage) (*authentic
 	return authenticate.CreateAuthenticateMessage(chal, c.creds.GetUsername(), c.creds.GetPassword(), c.creds.GetDomain(), c.workstation)
 }
 
-// completeAuth finishes the NTLM exchange after a bind_ack: it parses the server's
-// CHALLENGE from the bind_ack's auth_value, sends an auth3 carrying the AUTHENTICATE
-// token (to which the server sends no reply), and builds the per-message security
-// context from the derived session key.
+// completeAuth finishes the authenticated bind after a bind_ack. For a single-leg provider
+// (SetAuthProvider, e.g. Netlogon) the security context is already active and the session
+// key was established out of band, so there is no auth3 and nothing to derive — the
+// bind_ack (which for Netlogon carries the server's NL_AUTH_MESSAGE) is simply accepted.
+// For NTLM it parses the server's CHALLENGE from the bind_ack's auth_value, sends an auth3
+// carrying the AUTHENTICATE token (to which the server sends no reply), and builds the
+// per-message security context from the derived session key.
 func (c *Client) completeAuth(bindAckFrag []byte) error {
+	if c.authType != pdu.AuthTypeNTLMSSP {
+		return nil
+	}
 	_, challengeBytes, err := pdu.ExtractAuthVerifier(bindAckFrag)
 	if err != nil {
 		return fmt.Errorf("read challenge: %w", err)

--- a/network/dcerpc/v5/client/auth.go
+++ b/network/dcerpc/v5/client/auth.go
@@ -75,8 +75,11 @@ func (c *Client) protectsRequests() bool {
 
 // authVerifierOverhead is the worst-case number of bytes an authenticated request PDU
 // adds after the stub: up to 3 padding bytes to 4-byte-align the trailer, the 8-byte
-// sec_trailer, and the 16-byte signature.
-const authVerifierOverhead = 3 + pdu.SecTrailerSize + security.SignatureSize
+// sec_trailer, and the auth_value token. The token size is provider-specific (NTLM: 16;
+// Netlogon: larger), so it is taken from the active security context at its sealing level.
+func (c *Client) authVerifierOverhead() int {
+	return 3 + pdu.SecTrailerSize + c.sec.AuthValueLen(c.authLevel == pdu.AuthLevelPktPrivacy)
+}
 
 // negotiateToken builds the raw NTLM NEGOTIATE token carried in the bind's auth_value.
 func (c *Client) negotiateToken() ([]byte, error) {
@@ -153,20 +156,24 @@ func (c *Client) completeAuth(bindAckFrag []byte) error {
 	if err != nil {
 		return fmt.Errorf("init security context: %w", err)
 	}
-	c.sec = sec
+	c.sec = &ntlmSecurityContext{ctx: sec}
 	c.sessionKey = append([]byte(nil), auth.SessionKey...)
 	return nil
 }
 
-// marshalProtectedRequest serializes a request PDU with an NTLM auth verifier. The stub
-// is padded so the sec_trailer starts on a 4-byte boundary; for PKT_INTEGRITY the
-// signature covers the whole PDU (header, body, padded stub, sec_trailer) in cleartext,
-// and for PKT_PRIVACY the same region is signed over plaintext while only the stub and
-// its padding are sealed ([MS-RPCE] 3.3, NTLM2).
+// marshalProtectedRequest serializes a request PDU with a per-PDU auth verifier. The stub
+// is padded so the sec_trailer starts on a 4-byte boundary; the security context signs the
+// PDU (for PKT_INTEGRITY) or signs and seals the stub (for PKT_PRIVACY). The auth_value
+// token format and which bytes are signed are provider-specific — the client supplies both
+// the whole signed region (header, body, padded stub, sec_trailer, over plaintext) and the
+// padded stub, and the provider uses whichever it needs.
 func (c *Client) marshalProtectedRequest(req *pdu.Request) ([]byte, error) {
 	if req.ObjectUUID != nil {
 		return nil, fmt.Errorf("authenticated request with object UUID is not supported")
 	}
+
+	seal := c.authLevel == pdu.AuthLevelPktPrivacy
+	tokenLen := c.sec.AuthValueLen(seal)
 
 	allocHint := req.AllocHint
 	if allocHint == 0 {
@@ -191,8 +198,8 @@ func (c *Client) marshalProtectedRequest(req *pdu.Request) ([]byte, error) {
 	}
 
 	req.Header.PacketType = pdu.PacketTypeRequest
-	req.Header.AuthLength = uint16(security.SignatureSize)
-	fragLen := pdu.HeaderSize + len(bodyHdr) + len(stubPad) + pdu.SecTrailerSize + security.SignatureSize
+	req.Header.AuthLength = uint16(tokenLen)
+	fragLen := pdu.HeaderSize + len(bodyHdr) + len(stubPad) + pdu.SecTrailerSize + tokenLen
 	req.Header.FragLength = uint16(fragLen)
 	hdrBytes, err := req.Header.Marshal()
 	if err != nil {
@@ -201,19 +208,18 @@ func (c *Client) marshalProtectedRequest(req *pdu.Request) ([]byte, error) {
 
 	// The signed region is the whole PDU up to (but not including) the auth_value,
 	// computed over the plaintext stub.
-	toSign := make([]byte, 0, fragLen-security.SignatureSize)
-	toSign = append(toSign, hdrBytes...)
-	toSign = append(toSign, bodyHdr...)
-	toSign = append(toSign, stubPad...)
-	toSign = append(toSign, st.Marshal()...)
+	signedRegion := make([]byte, 0, fragLen-tokenLen)
+	signedRegion = append(signedRegion, hdrBytes...)
+	signedRegion = append(signedRegion, bodyHdr...)
+	signedRegion = append(signedRegion, stubPad...)
+	signedRegion = append(signedRegion, st.Marshal()...)
 
-	var onWireStub []byte
-	var sig [security.SignatureSize]byte
-	if c.authLevel == pdu.AuthLevelPktPrivacy {
-		onWireStub, sig = c.sec.SealWith(toSign, stubPad)
-	} else {
-		sig = c.sec.Sign(toSign)
-		onWireStub = stubPad
+	onWireStub, authValue, err := c.sec.ProtectRequest(signedRegion, stubPad, seal)
+	if err != nil {
+		return nil, err
+	}
+	if len(authValue) != tokenLen {
+		return nil, fmt.Errorf("auth token length %d does not match reserved length %d", len(authValue), tokenLen)
 	}
 
 	out := make([]byte, 0, fragLen)
@@ -221,21 +227,24 @@ func (c *Client) marshalProtectedRequest(req *pdu.Request) ([]byte, error) {
 	out = append(out, bodyHdr...)
 	out = append(out, onWireStub...)
 	out = append(out, st.Marshal()...)
-	out = append(out, sig[:]...)
+	out = append(out, authValue...)
 	return out, nil
 }
 
 // unprotectResponseStub recovers the cleartext stub from an authenticated response
-// fragment: for PKT_PRIVACY it decrypts the stub in place, then it verifies the
-// signature over the whole PDU (minus the auth_value) and strips the auth padding.
+// fragment: the security context decrypts the stub in place (for PKT_PRIVACY) and verifies
+// its per-PDU token, after which the auth padding is stripped. The token length and the
+// verified region are provider-specific, so both the signed region (whole PDU minus the
+// auth_value) and the stub sub-slice are handed to the provider.
 func (c *Client) unprotectResponseStub(frag []byte) ([]byte, error) {
 	hdr, err := pdu.PeekHeader(frag)
 	if err != nil {
 		return nil, err
 	}
+	seal := c.authLevel == pdu.AuthLevelPktPrivacy
 	authLen := int(hdr.AuthLength)
-	if authLen != security.SignatureSize {
-		return nil, fmt.Errorf("unexpected auth_length %d, want %d", authLen, security.SignatureSize)
+	if want := c.sec.AuthValueLen(seal); authLen != want {
+		return nil, fmt.Errorf("unexpected auth_length %d, want %d", authLen, want)
 	}
 	fragLen := int(hdr.FragLength)
 	if fragLen > len(frag) {
@@ -246,8 +255,6 @@ func (c *Client) unprotectResponseStub(frag []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	var sig [security.SignatureSize]byte
-	copy(sig[:], authValue)
 
 	stubStart := pdu.HeaderSize + 8 // response body: alloc_hint, ctx_id, cancel_count, reserved
 	stubEnd := fragLen - authLen - pdu.SecTrailerSize
@@ -255,18 +262,17 @@ func (c *Client) unprotectResponseStub(frag []byte) ([]byte, error) {
 		return nil, fmt.Errorf("authenticated response stub bounds invalid")
 	}
 
-	if c.authLevel == pdu.AuthLevelPktPrivacy {
-		c.sec.DecryptInbound(frag[stubStart:stubEnd])
-	}
-	// Verify over the whole PDU minus the trailing auth_value, now that the stub is
-	// plaintext.
-	if err := c.sec.VerifySignature(frag[:fragLen-authLen], sig); err != nil {
+	// signedRegion is the whole PDU up to the auth_value; stub is a sub-slice of it, so an
+	// in-place decrypt by the provider is reflected in signedRegion before verification.
+	signedRegion := frag[:fragLen-authLen]
+	plainStub, err := c.sec.UnprotectResponse(signedRegion, frag[stubStart:stubEnd], authValue, seal)
+	if err != nil {
 		return nil, err
 	}
 
-	if int(st.AuthPadLength) > stubEnd-stubStart {
+	if int(st.AuthPadLength) > len(plainStub) {
 		return nil, fmt.Errorf("auth_pad_length %d exceeds stub length", st.AuthPadLength)
 	}
-	stub := frag[stubStart : stubEnd-int(st.AuthPadLength)]
+	stub := plainStub[:len(plainStub)-int(st.AuthPadLength)]
 	return append([]byte(nil), stub...), nil
 }

--- a/network/dcerpc/v5/client/client.go
+++ b/network/dcerpc/v5/client/client.go
@@ -70,8 +70,11 @@ type Client struct {
 	authContextID uint32
 	workstation   string
 	creds         *credentials.Credentials
-	sec           securityContext // non-nil once an authenticated bind completes
+	sec           SecurityContext // non-nil once an authenticated bind completes
 	sessionKey    []byte          // NTLM exported session key, captured at completeAuth
+	// bindToken is the auth_value carried in the bind PDU for a single-leg provider
+	// (e.g. Netlogon) configured via SetAuthProvider; nil for the NTLM multi-leg flow.
+	bindToken []byte
 }
 
 // SessionKey returns the NTLM exported session key established during an authenticated

--- a/network/dcerpc/v5/client/client.go
+++ b/network/dcerpc/v5/client/client.go
@@ -27,7 +27,6 @@ package client
 import (
 	"fmt"
 
-	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/security"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/pdu"
@@ -71,8 +70,8 @@ type Client struct {
 	authContextID uint32
 	workstation   string
 	creds         *credentials.Credentials
-	sec           *security.Context // non-nil once an authenticated bind completes
-	sessionKey    []byte            // NTLM exported session key, captured at completeAuth
+	sec           securityContext // non-nil once an authenticated bind completes
+	sessionKey    []byte          // NTLM exported session key, captured at completeAuth
 }
 
 // SessionKey returns the NTLM exported session key established during an authenticated
@@ -275,7 +274,7 @@ func (c *Client) sendRequest(opnum uint16, stub []byte) error {
 	// request is signed or sealed.
 	overhead := requestHeaderOverhead
 	if c.protectsRequests() {
-		overhead += authVerifierOverhead
+		overhead += c.authVerifierOverhead()
 	}
 	budget := int(c.sendFragMax) - overhead
 	if budget <= 0 {

--- a/network/dcerpc/v5/client/secctx.go
+++ b/network/dcerpc/v5/client/secctx.go
@@ -6,13 +6,13 @@ import (
 	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/security"
 )
 
-// securityContext protects outbound request stubs and unprotects inbound response stubs for
+// SecurityContext protects outbound request stubs and unprotects inbound response stubs for
 // an authenticated connection-oriented RPC session. Each security provider (NTLM today,
 // Netlogon next) supplies its own auth_value token format and chooses which bytes it signs:
 // NTLM signs the whole PDU and so uses signedRegion, whereas a provider that signs only the
 // stub can ignore signedRegion and operate on stub. The client owns PDU framing (stub
 // padding, header fields, sec_trailer), which is provider-independent ([MS-RPCE] 2.2.2.11).
-type securityContext interface {
+type SecurityContext interface {
 	// AuthValueLen returns the auth_value byte length this provider emits, given whether the
 	// request is sealed (PKT_PRIVACY) or only signed (PKT/PKT_INTEGRITY). It must be known
 	// before the PDU header is marshalled, since it feeds auth_length and frag_length.
@@ -33,7 +33,7 @@ type securityContext interface {
 	UnprotectResponse(signedRegion, stub, authValue []byte, seal bool) (plainStub []byte, err error)
 }
 
-// ntlmSecurityContext adapts an NTLM *security.Context to securityContext. NTLM's token is a
+// ntlmSecurityContext adapts an NTLM *security.Context to SecurityContext. NTLM's token is a
 // fixed 16-byte MESSAGE_SIGNATURE and its signature covers the whole PDU, so both directions
 // operate over signedRegion; only the stub is sealed for PKT_PRIVACY ([MS-RPCE] 3.3, NTLM2).
 type ntlmSecurityContext struct{ ctx *security.Context }

--- a/network/dcerpc/v5/client/secctx.go
+++ b/network/dcerpc/v5/client/secctx.go
@@ -1,0 +1,70 @@
+package client
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/security"
+)
+
+// securityContext protects outbound request stubs and unprotects inbound response stubs for
+// an authenticated connection-oriented RPC session. Each security provider (NTLM today,
+// Netlogon next) supplies its own auth_value token format and chooses which bytes it signs:
+// NTLM signs the whole PDU and so uses signedRegion, whereas a provider that signs only the
+// stub can ignore signedRegion and operate on stub. The client owns PDU framing (stub
+// padding, header fields, sec_trailer), which is provider-independent ([MS-RPCE] 2.2.2.11).
+type securityContext interface {
+	// AuthValueLen returns the auth_value byte length this provider emits, given whether the
+	// request is sealed (PKT_PRIVACY) or only signed (PKT/PKT_INTEGRITY). It must be known
+	// before the PDU header is marshalled, since it feeds auth_length and frag_length.
+	AuthValueLen(seal bool) int
+
+	// ProtectRequest produces the on-wire stub and the auth_value for one outbound request
+	// fragment. signedRegion is the marshalled PDU from the header through the sec_trailer
+	// (auth_value excluded) computed over the plaintext stub; stub is the padded stub as a
+	// separate buffer. When seal is true the returned stub is encrypted, otherwise it equals
+	// stub. signedRegion MUST NOT be mutated.
+	ProtectRequest(signedRegion, stub []byte, seal bool) (onWireStub, authValue []byte, err error)
+
+	// UnprotectResponse recovers the plaintext stub from one inbound response fragment.
+	// signedRegion and stub are overlapping views into the same fragment buffer — stub is a
+	// sub-slice of signedRegion — so when seal is true the provider decrypts the stub in
+	// place (which updates signedRegion) before verifying integrity. It returns the recovered
+	// plaintext stub (still including any auth padding, which the caller strips).
+	UnprotectResponse(signedRegion, stub, authValue []byte, seal bool) (plainStub []byte, err error)
+}
+
+// ntlmSecurityContext adapts an NTLM *security.Context to securityContext. NTLM's token is a
+// fixed 16-byte MESSAGE_SIGNATURE and its signature covers the whole PDU, so both directions
+// operate over signedRegion; only the stub is sealed for PKT_PRIVACY ([MS-RPCE] 3.3, NTLM2).
+type ntlmSecurityContext struct{ ctx *security.Context }
+
+// AuthValueLen is the fixed NTLM signature size regardless of seal level.
+func (n *ntlmSecurityContext) AuthValueLen(bool) int { return security.SignatureSize }
+
+// ProtectRequest signs signedRegion (and, when sealing, encrypts the stub) exactly as the
+// NTLM2 sender rules require.
+func (n *ntlmSecurityContext) ProtectRequest(signedRegion, stub []byte, seal bool) ([]byte, []byte, error) {
+	if seal {
+		onWire, sig := n.ctx.SealWith(signedRegion, stub)
+		return onWire, sig[:], nil
+	}
+	sig := n.ctx.Sign(signedRegion)
+	return stub, sig[:], nil
+}
+
+// UnprotectResponse decrypts the stub in place (when sealed) and then verifies the signature
+// over the whole PDU, matching the NTLM2 receiver rules.
+func (n *ntlmSecurityContext) UnprotectResponse(signedRegion, stub, authValue []byte, seal bool) ([]byte, error) {
+	if len(authValue) != security.SignatureSize {
+		return nil, fmt.Errorf("unexpected auth_length %d, want %d", len(authValue), security.SignatureSize)
+	}
+	var sig [security.SignatureSize]byte
+	copy(sig[:], authValue)
+	if seal {
+		n.ctx.DecryptInbound(stub)
+	}
+	if err := n.ctx.VerifySignature(signedRegion, sig); err != nil {
+		return nil, err
+	}
+	return stub, nil
+}

--- a/network/dcerpc/v5/client/secctx_test.go
+++ b/network/dcerpc/v5/client/secctx_test.go
@@ -1,0 +1,195 @@
+package client
+
+// White-box tests for the security-context seam. They use a fake securityContext to pin the
+// client's PDU framing (auth_length/frag_length, byte order, pad stripping) independent of
+// any provider's crypto, and confirm the client asks the provider for the token length and
+// hands it the signed region and stub. NTLM crypto itself is covered in the security package.
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/pdu"
+)
+
+// fakeSecCtx is a deterministic securityContext: it "seals" by XORing the stub with 0xFF
+// (reversible and observable on the wire) and emits a token of tokenLen 0xAB bytes. It
+// records what it was handed so tests can assert the client passed the right slices.
+type fakeSecCtx struct {
+	tokenLen   int
+	shortToken bool // return a wrong-length token to exercise the client's length check
+
+	gotSignedRegion []byte
+	gotStub         []byte
+	gotSeal         bool
+	gotAuthValue    []byte
+	unprotectCalled bool
+}
+
+func (f *fakeSecCtx) AuthValueLen(bool) int { return f.tokenLen }
+
+func (f *fakeSecCtx) ProtectRequest(signedRegion, stub []byte, seal bool) ([]byte, []byte, error) {
+	f.gotSignedRegion = append([]byte(nil), signedRegion...)
+	f.gotStub = append([]byte(nil), stub...)
+	f.gotSeal = seal
+	onWire := append([]byte(nil), stub...)
+	if seal {
+		for i := range onWire {
+			onWire[i] ^= 0xff
+		}
+	}
+	n := f.tokenLen
+	if f.shortToken {
+		n--
+	}
+	return onWire, bytes.Repeat([]byte{0xAB}, n), nil
+}
+
+func (f *fakeSecCtx) UnprotectResponse(signedRegion, stub, authValue []byte, seal bool) ([]byte, error) {
+	f.unprotectCalled = true
+	f.gotSeal = seal
+	f.gotAuthValue = append([]byte(nil), authValue...)
+	out := append([]byte(nil), stub...)
+	if seal {
+		for i := range out {
+			out[i] ^= 0xff
+		}
+	}
+	return out, nil
+}
+
+func TestMarshalProtectedRequestFraming(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		level uint8
+		seal  bool
+	}{
+		{"privacy seals stub", pdu.AuthLevelPktPrivacy, true},
+		{"integrity leaves stub", pdu.AuthLevelPktIntegrity, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := &fakeSecCtx{tokenLen: 16}
+			c := &Client{authType: pdu.AuthTypeNTLMSSP, authLevel: tc.level, sec: fake}
+
+			stub := []byte("hello-rpc-stub!") // 15 bytes -> 1 pad byte -> 16
+			req := &pdu.Request{ContextID: 0, Opnum: 5, Stub: stub}
+			req.Header = pdu.NewHeader(pdu.PacketTypeRequest, pdu.PFCFirstFrag|pdu.PFCLastFrag, 1)
+
+			raw, err := c.marshalProtectedRequest(req)
+			if err != nil {
+				t.Fatalf("marshalProtectedRequest: %v", err)
+			}
+
+			hdr, err := pdu.PeekHeader(raw)
+			if err != nil {
+				t.Fatalf("PeekHeader: %v", err)
+			}
+			if hdr.AuthLength != 16 {
+				t.Errorf("auth_length = %d, want 16", hdr.AuthLength)
+			}
+			if int(hdr.FragLength) != len(raw) {
+				t.Errorf("frag_length = %d, want %d", hdr.FragLength, len(raw))
+			}
+
+			// Layout: header(16) | bodyHdr(8) | onWireStub(16) | sec_trailer(8) | token(16).
+			const stubStart = pdu.HeaderSize + 8
+			stubPad := make([]byte, 16)
+			copy(stubPad, stub)
+			onWire := raw[stubStart : stubStart+16]
+			want := append([]byte(nil), stubPad...)
+			if tc.seal {
+				for i := range want {
+					want[i] ^= 0xff
+				}
+			}
+			if !bytes.Equal(onWire, want) {
+				t.Errorf("on-wire stub = %x, want %x", onWire, want)
+			}
+			token := raw[len(raw)-16:]
+			if !bytes.Equal(token, bytes.Repeat([]byte{0xAB}, 16)) {
+				t.Errorf("token = %x, want 16x0xAB", token)
+			}
+			// sec_trailer auth_pad_length is the third byte of the trailer.
+			if got := raw[stubStart+16+2]; got != 1 {
+				t.Errorf("auth_pad_length = %d, want 1", got)
+			}
+			if fake.gotSeal != tc.seal {
+				t.Errorf("provider seal flag = %v, want %v", fake.gotSeal, tc.seal)
+			}
+			if len(fake.gotSignedRegion) != len(raw)-16 {
+				t.Errorf("signed region len = %d, want %d", len(fake.gotSignedRegion), len(raw)-16)
+			}
+			if !bytes.Equal(fake.gotStub, stubPad) {
+				t.Errorf("provider stub = %x, want %x", fake.gotStub, stubPad)
+			}
+		})
+	}
+}
+
+func TestMarshalProtectedRequestTokenLengthMismatch(t *testing.T) {
+	fake := &fakeSecCtx{tokenLen: 16, shortToken: true}
+	c := &Client{authType: pdu.AuthTypeNTLMSSP, authLevel: pdu.AuthLevelPktIntegrity, sec: fake}
+	req := &pdu.Request{Opnum: 1, Stub: []byte("x")}
+	req.Header = pdu.NewHeader(pdu.PacketTypeRequest, pdu.PFCFirstFrag|pdu.PFCLastFrag, 1)
+	if _, err := c.marshalProtectedRequest(req); err == nil {
+		t.Fatal("expected error when provider returns a token of the wrong length")
+	}
+}
+
+func TestUnprotectResponseStubPlumbing(t *testing.T) {
+	fake := &fakeSecCtx{tokenLen: 16}
+	c := &Client{authType: pdu.AuthTypeNTLMSSP, authLevel: pdu.AuthLevelPktIntegrity, sec: fake}
+
+	stub := []byte("resp-stub-data") // 14 bytes -> 2 pad bytes
+	frag := buildResponseFrag(t, stub, pdu.AuthLevelPktIntegrity, bytes.Repeat([]byte{0xCD}, 16))
+
+	got, err := c.unprotectResponseStub(frag)
+	if err != nil {
+		t.Fatalf("unprotectResponseStub: %v", err)
+	}
+	if !bytes.Equal(got, stub) {
+		t.Errorf("recovered stub = %q, want %q (pad must be stripped)", got, stub)
+	}
+	if !fake.unprotectCalled {
+		t.Error("provider UnprotectResponse was not called")
+	}
+	if !bytes.Equal(fake.gotAuthValue, bytes.Repeat([]byte{0xCD}, 16)) {
+		t.Errorf("provider auth_value = %x, want 16x0xCD", fake.gotAuthValue)
+	}
+}
+
+func TestAuthVerifierOverheadUsesProviderTokenLen(t *testing.T) {
+	c := &Client{authLevel: pdu.AuthLevelPktPrivacy, sec: &fakeSecCtx{tokenLen: 56}}
+	// 3 worst-case pad + 8-byte sec_trailer + 56-byte token.
+	if got := c.authVerifierOverhead(); got != 3+pdu.SecTrailerSize+56 {
+		t.Errorf("authVerifierOverhead = %d, want %d", got, 3+pdu.SecTrailerSize+56)
+	}
+}
+
+// buildResponseFrag assembles a minimal authenticated response fragment: header, 8-byte
+// response body header, padded stub, sec_trailer, and token.
+func buildResponseFrag(t *testing.T, stub []byte, authLevel uint8, token []byte) []byte {
+	t.Helper()
+	pad := (4 - len(stub)%4) % 4
+	stubPad := make([]byte, len(stub)+pad)
+	copy(stubPad, stub)
+	st := pdu.SecTrailer{AuthType: pdu.AuthTypeNTLMSSP, AuthLevel: authLevel, AuthPadLength: uint8(pad)}
+
+	body := make([]byte, 8) // response body header (alloc_hint, ctx_id, cancel_count, reserved)
+	h := pdu.NewHeader(pdu.PacketTypeResponse, pdu.PFCFirstFrag|pdu.PFCLastFrag, 1)
+	fragLen := pdu.HeaderSize + len(body) + len(stubPad) + pdu.SecTrailerSize + len(token)
+	h.AuthLength = uint16(len(token))
+	h.FragLength = uint16(fragLen)
+	hb, err := h.Marshal()
+	if err != nil {
+		t.Fatalf("header marshal: %v", err)
+	}
+
+	frag := make([]byte, 0, fragLen)
+	frag = append(frag, hb...)
+	frag = append(frag, body...)
+	frag = append(frag, stubPad...)
+	frag = append(frag, st.Marshal()...)
+	frag = append(frag, token...)
+	return frag
+}

--- a/windows/protocols/ms-nrpc/NL_AUTH_MESSAGE.go
+++ b/windows/protocols/ms-nrpc/NL_AUTH_MESSAGE.go
@@ -1,0 +1,93 @@
+package msnrpc
+
+import (
+	"encoding/binary"
+	"fmt"
+	"strings"
+)
+
+// NL_AUTH_MESSAGE message types and flag bits ([MS-NRPC] 2.2.1.3.1). The client sends a
+// request message in the RPC bind auth_value; the server replies with a response message in
+// the bind_ack. The flags describe which name fields the Buffer carries, in the fixed order
+// NetBIOS domain, NetBIOS host, DNS domain, DNS host, then (last) the UTF-8 NetBIOS host.
+const (
+	NlAuthMessageNetbiosDomain   uint32 = 0x00000001
+	NlAuthMessageNetbiosHost     uint32 = 0x00000002
+	NlAuthMessageDNSDomain       uint32 = 0x00000004
+	NlAuthMessageDNSHost         uint32 = 0x00000008
+	NlAuthMessageNetbiosHostUTF8 uint32 = 0x00000010
+
+	NlAuthMessageTypeRequest  uint32 = 0x00000000
+	NlAuthMessageTypeResponse uint32 = 0x00000001
+)
+
+// NL_AUTH_MESSAGE ([MS-NRPC] 2.2.1.3.1) is the token carried in the RPC bind/bind_ack
+// auth_value when Netlogon is its own security provider (RPC_C_AUTHN_NETLOGON). It is a
+// fixed 8-byte header (MessageType, Flags) followed by a variable Buffer of null-terminated
+// name strings selected by Flags. It is not NDR — it carries its own Marshal/Unmarshal.
+type NL_AUTH_MESSAGE struct {
+	MessageType uint32
+	Flags       uint32
+	Buffer      []byte
+}
+
+// Marshal serializes the token: the two little-endian header DWORDs then the Buffer.
+func (m *NL_AUTH_MESSAGE) Marshal() []byte {
+	out := make([]byte, 8+len(m.Buffer))
+	binary.LittleEndian.PutUint32(out[0:4], m.MessageType)
+	binary.LittleEndian.PutUint32(out[4:8], m.Flags)
+	copy(out[8:], m.Buffer)
+	return out
+}
+
+// Unmarshal parses a token from data. The Buffer is the remainder after the 8-byte header;
+// its interpretation follows Flags, but a client only needs to confirm the server returned a
+// response, so the fields are not further decoded here.
+func (m *NL_AUTH_MESSAGE) Unmarshal(data []byte) error {
+	if len(data) < 8 {
+		return fmt.Errorf("NL_AUTH_MESSAGE truncated: have %d bytes, need at least 8", len(data))
+	}
+	m.MessageType = binary.LittleEndian.Uint32(data[0:4])
+	m.Flags = binary.LittleEndian.Uint32(data[4:8])
+	m.Buffer = append([]byte(nil), data[8:]...)
+	return nil
+}
+
+// compressedUTF8DNS encodes a DNS domain as length-prefixed labels terminated by a zero
+// octet ([MS-NRPC] 2.2.1.3.1, the DNS-domain field uses the [RFC1035] label form without
+// pointer compression), e.g. "corp.example.com" -> 04 'corp' 07 'example' 03 'com' 00.
+func compressedUTF8DNS(domain string) []byte {
+	var out []byte
+	for _, label := range strings.Split(domain, ".") {
+		out = append(out, byte(len(label)))
+		out = append(out, label...)
+	}
+	return append(out, 0x00)
+}
+
+// BuildClientNlAuthMessage builds the client request NL_AUTH_MESSAGE for the RPC bind
+// ([MS-NRPC] 3.1.4.1). computerName is the client NetBIOS host name (no trailing '$'). A
+// domain containing a '.' is treated as a DNS domain (NetBIOS host + DNS domain fields);
+// otherwise it is treated as a NetBIOS domain (NetBIOS domain + host fields). Both forms
+// additionally append the UTF-8 NetBIOS host field, matching what Windows and impacket send.
+func BuildClientNlAuthMessage(computerName, domain string) *NL_AUTH_MESSAGE {
+	m := &NL_AUTH_MESSAGE{MessageType: NlAuthMessageTypeRequest}
+	if strings.Contains(domain, ".") {
+		m.Flags = NlAuthMessageNetbiosHost | NlAuthMessageDNSDomain
+		m.Buffer = append(m.Buffer, computerName...)
+		m.Buffer = append(m.Buffer, 0x00)
+		m.Buffer = append(m.Buffer, compressedUTF8DNS(domain)...)
+	} else {
+		m.Flags = NlAuthMessageNetbiosDomain | NlAuthMessageNetbiosHost
+		m.Buffer = append(m.Buffer, domain...)
+		m.Buffer = append(m.Buffer, 0x00)
+		m.Buffer = append(m.Buffer, computerName...)
+		m.Buffer = append(m.Buffer, 0x00)
+	}
+	// The UTF-8 NetBIOS host is always appended last: a length octet, the name, and a NUL.
+	m.Flags |= NlAuthMessageNetbiosHostUTF8
+	m.Buffer = append(m.Buffer, byte(len(computerName)))
+	m.Buffer = append(m.Buffer, computerName...)
+	m.Buffer = append(m.Buffer, 0x00)
+	return m
+}

--- a/windows/protocols/ms-nrpc/NL_AUTH_MESSAGE_test.go
+++ b/windows/protocols/ms-nrpc/NL_AUTH_MESSAGE_test.go
@@ -1,0 +1,53 @@
+package msnrpc
+
+import (
+	"encoding/hex"
+	"testing"
+)
+
+// TestBuildClientNlAuthMessage pins both name forms byte-for-byte against impacket's
+// getSSPType1 output.
+func TestBuildClientNlAuthMessage(t *testing.T) {
+	tests := []struct {
+		name     string
+		computer string
+		domain   string
+		want     string
+	}{
+		{
+			name:     "DNS domain",
+			computer: "MANTICORE1",
+			domain:   "TMP-W-2016.local",
+			want:     "00000000160000004d414e5449434f524531000a544d502d572d32303136056c6f63616c000a4d414e5449434f52453100",
+		},
+		{
+			name:     "NetBIOS domain",
+			computer: "MANTICORE1",
+			domain:   "TMP-W-2016",
+			want:     "0000000013000000544d502d572d32303136004d414e5449434f524531000a4d414e5449434f52453100",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := hex.EncodeToString(BuildClientNlAuthMessage(tc.computer, tc.domain).Marshal())
+			if got != tc.want {
+				t.Errorf("NL_AUTH_MESSAGE\n got  %s\n want %s", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestNLAuthMessageRoundTrip checks Unmarshal recovers the header of a marshalled token.
+func TestNLAuthMessageRoundTrip(t *testing.T) {
+	orig := BuildClientNlAuthMessage("HOST", "example.com")
+	var got NL_AUTH_MESSAGE
+	if err := got.Unmarshal(orig.Marshal()); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got.MessageType != NlAuthMessageTypeRequest {
+		t.Errorf("MessageType = %d, want %d", got.MessageType, NlAuthMessageTypeRequest)
+	}
+	if got.Flags != orig.Flags {
+		t.Errorf("Flags = %#x, want %#x", got.Flags, orig.Flags)
+	}
+}


### PR DESCRIPTION
### Linked Issue
Part of #655 (the client-wiring stage — the final core stage). Does **not** close #655; the optional legacy RC4/DES cipher suite remains. Builds on the merged secure-channel session (#892) and per-message token (#891).

This PR is the complete Stage C in two commits: (1) the behaviour-preserving security-context interface refactor, and (2) the Netlogon RPC provider + client wiring, **live-validated against a Windows Server 2016 DC**.

### Root Cause / Motivation
Some Netlogon operations require an `RPC_C_AUTHN_NETLOGON` (auth_type `0x44`) context whose session key comes from the Netlogon secure channel, with a per-PDU token format (`NL_AUTH_SHA2_SIGNATURE`) unrelated to NTLM's. The client hardcoded the NTLM `*security.Context` and its fixed 16-byte signature and had no way to bind as a second provider, so none of these code paths were reachable.

### Fix Description
**Commit 1 — security-context interface (behaviour-preserving for NTLM):**
- `client.SecurityContext` (`AuthValueLen`/`ProtectRequest`/`UnprotectResponse`). The client hands the provider both the whole signed region and the padded stub, so each provider signs what its wire format needs — NTLM signs the whole PDU, Netlogon signs only the stub.
- `ntlmSecurityContext` adapter reproduces the NTLM2 behaviour that was inline; the fixed `security.SignatureSize` is replaced by the provider's `AuthValueLen`.

**Commit 2 — Netlogon provider + wiring:**
- `msnrpc.NL_AUTH_MESSAGE` (MS-NRPC 2.2.1.3.1) + a client bind-token builder (NetBIOS/DNS forms), pinned byte-for-byte to the reference SSP token.
- `functions.NetlogonSecurityContext` adapts the merged `MessageSecurity` to `SecurityContext`; it signs/seals only the stub (confirmed against Windows), token length 48/56.
- `client.SetAuthProvider`: a single-leg-provider seam for SSPs whose session key is established out of band and whose bind is one round trip (no challenge/auth3). `negotiateToken`/`completeAuth` branch on auth_type; the NTLM three-leg path is untouched. `SecurityContext` is exported so providers live outside the client package (no layering inversion — `functions` imports `client`, not the reverse).

### How Verified
- `go build ./...`, `go vet` (default and `-tags integration`), `gofmt -l` all clean.
- Existing NTLM auth tests pass **unmodified** (behaviour preserved); client framing tests and the netlogon crypto/vector tests pass.
- **Live, against a Windows Server 2016 DC** (machine account, then deleted), via the build-tagged integration test:
  - Stage A — AES secure channel establishes; `NetrServerAuthenticate3` succeeds and the server credential verifies (session-key crypto proven end to end).
  - PR-D — `RPC_C_AUTHN_NETLOGON` `PKT_PRIVACY` bind accepted; a sealed `NetrLogonGetCapabilities` round-trips: the server decrypted our AES-sealed request, validated our application authenticator, and we unsealed its response and verified the `ReturnAuthenticator`. Negotiated flags `0x212fffff`.

### Test Coverage
**Added** — `windows/protocols/ms-nrpc/NL_AUTH_MESSAGE_test.go` (token bytes + round-trip), `.../functions/netlogon_live_integration_test.go` (build tag `integration`; env-driven, skips without `DCERPC_TEST_HOST`/`NETLOGON_COMPUTER`/`NETLOGON_PASS`). Client framing tests from commit 1 (`secctx_test.go`) cover the interface contract.

### Scope of Change
- **client:** `secctx.go` (exported interface + NTLM adapter), `auth.go` (`SetAuthProvider`, single-leg branches), `client.go` (`bindToken` field).
- **msnrpc:** `NL_AUTH_MESSAGE.go` — new.
- **netlogon functions:** `rpcsecurity.go` (adapter), `netlogon_live_integration_test.go` — new.
- **Submodule pointer updated:** no. **NTLM behaviour change:** none.

### Notes
- AES cipher suite only; the legacy RC4/HMAC-MD5 path is a separate optional follow-up under #655.
- The integration test provisions nothing; the machine account used for validation was created and deleted out of band.