### PR TITLE
Validate Netlogon machine secret and bind token (Fixes #896)

### DIFF
--- a/network/dcerpc/v5/client/auth.go
+++ b/network/dcerpc/v5/client/auth.go
@@ -76,6 +76,12 @@ func (c *Client) SetAuthProvider(authType, authLevel uint8, sec SecurityContext,
 	if authType == pdu.AuthTypeNone {
 		return fmt.Errorf("dcerpc auth: auth_type must not be none")
 	}
+	// Netlogon authenticates the bind with an NL_AUTH_MESSAGE token; without it the bind
+	// carries a sec_trailer with an empty auth_value and the DC rejects the association,
+	// which would otherwise surface only as an opaque bind or first-call failure.
+	if authType == pdu.AuthTypeNetlogon && len(bindToken) == 0 {
+		return fmt.Errorf("dcerpc auth: netlogon (0x%02x) requires a bind token (NL_AUTH_MESSAGE)", pdu.AuthTypeNetlogon)
+	}
 	if authLevel == pdu.AuthLevelCall {
 		authLevel = pdu.AuthLevelPkt
 	}

--- a/network/dcerpc/v5/client/secctx_test.go
+++ b/network/dcerpc/v5/client/secctx_test.go
@@ -158,6 +158,21 @@ func TestUnprotectResponseStubPlumbing(t *testing.T) {
 	}
 }
 
+func TestSetAuthProviderNetlogonRequiresBindToken(t *testing.T) {
+	// Netlogon without a bind token is rejected.
+	if err := (&Client{}).SetAuthProvider(pdu.AuthTypeNetlogon, pdu.AuthLevelPktPrivacy, &fakeSecCtx{tokenLen: 56}, nil); err == nil {
+		t.Fatal("SetAuthProvider accepted netlogon with a nil bind token")
+	}
+	// Netlogon with a bind token is accepted.
+	if err := (&Client{}).SetAuthProvider(pdu.AuthTypeNetlogon, pdu.AuthLevelPktPrivacy, &fakeSecCtx{tokenLen: 56}, []byte{1, 2, 3, 4}); err != nil {
+		t.Fatalf("SetAuthProvider(netlogon, bindToken) = %v, want nil", err)
+	}
+	// A non-netlogon single-leg provider may still omit the bind token.
+	if err := (&Client{}).SetAuthProvider(pdu.AuthTypeGSSKerberos, pdu.AuthLevelPktPrivacy, &fakeSecCtx{tokenLen: 16}, nil); err != nil {
+		t.Fatalf("SetAuthProvider(non-netlogon, nil bindToken) = %v, want nil", err)
+	}
+}
+
 func TestAuthVerifierOverheadUsesProviderTokenLen(t *testing.T) {
 	c := &Client{authLevel: pdu.AuthLevelPktPrivacy, sec: &fakeSecCtx{tokenLen: 56}}
 	// 3 worst-case pad + 8-byte sec_trailer + 56-byte token.

--- a/windows/protocols/ms-nrpc/securechannel/securechannel.go
+++ b/windows/protocols/ms-nrpc/securechannel/securechannel.go
@@ -79,6 +79,21 @@ type SecureChannel struct {
 // rpc must already be bound to the Netlogon interface (an anonymous/unauthenticated binding
 // is sufficient for the handshake itself).
 func Establish(rpc ndr.Invoker, cfg SecureChannelConfig) (*SecureChannel, error) {
+	// Validate the machine secret up front so a wrong-length hash or a missing secret fails
+	// clearly here rather than deriving a bad session key and failing as ACCESS_DENIED at
+	// NetrServerAuthenticate3. An NTHash must be the raw 16 octets; anything else (including
+	// a non-nil empty slice) is treated as "not provided" and normalised to nil.
+	if len(cfg.NTHash) != 0 && len(cfg.NTHash) != 16 {
+		return nil, fmt.Errorf("netlogon secure channel: NTHash must be 16 bytes, got %d", len(cfg.NTHash))
+	}
+	var ntHash []byte
+	if len(cfg.NTHash) == 16 {
+		ntHash = cfg.NTHash
+	}
+	if cfg.Password == "" && ntHash == nil {
+		return nil, fmt.Errorf("netlogon secure channel: one of Password or a 16-byte NTHash must be set")
+	}
+
 	src := cfg.Rand
 	if src == nil {
 		src = rand.Reader
@@ -104,9 +119,9 @@ func Establish(rpc ndr.Invoker, cfg SecureChannelConfig) (*SecureChannel, error)
 
 	var sessionKey [16]byte
 	if aes {
-		sessionKey = nrpccrypto.ComputeSessionKeyAES(cfg.Password, cfg.NTHash, clientChallenge, serverChallenge)
+		sessionKey = nrpccrypto.ComputeSessionKeyAES(cfg.Password, ntHash, clientChallenge, serverChallenge)
 	} else {
-		sessionKey = nrpccrypto.ComputeSessionKeyStrongKey(cfg.Password, cfg.NTHash, clientChallenge, serverChallenge)
+		sessionKey = nrpccrypto.ComputeSessionKeyStrongKey(cfg.Password, ntHash, clientChallenge, serverChallenge)
 	}
 	credential := func(in msnrpc.NETLOGON_CREDENTIAL) msnrpc.NETLOGON_CREDENTIAL {
 		if aes {

--- a/windows/protocols/ms-nrpc/securechannel/securechannel_test.go
+++ b/windows/protocols/ms-nrpc/securechannel/securechannel_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/TheManticoreProject/Manticore/crypto/nt"
 	netlogon "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 	msnrpc "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nrpc"
@@ -213,6 +214,45 @@ func TestEstablishRejectsForgedServerCredential(t *testing.T) {
 	inv, cfg, _, _ := establishFixture(true, true, netlogon.StatusSuccess)
 	if _, err := Establish(inv, cfg); err == nil {
 		t.Fatal("Establish accepted a forged server credential")
+	}
+}
+
+// TestEstablishRejectsBadSecret confirms Establish validates the machine secret before
+// issuing any RPC: a wrong-length NTHash and a missing secret both fail fast.
+func TestEstablishRejectsBadSecret(t *testing.T) {
+	inv, cfg, _, _ := establishFixture(true, false, netlogon.StatusSuccess)
+
+	bad := cfg
+	bad.NTHash = make([]byte, 10)
+	if _, err := Establish(inv, bad); err == nil {
+		t.Error("Establish accepted a 10-byte NTHash")
+	}
+	noSecret := cfg
+	noSecret.Password = ""
+	noSecret.NTHash = nil
+	if _, err := Establish(inv, noSecret); err == nil {
+		t.Error("Establish accepted a config with neither Password nor NTHash")
+	}
+	if len(inv.opnums) != 0 {
+		t.Fatalf("Establish issued RPCs %v before validating inputs", inv.opnums)
+	}
+}
+
+// TestEstablishPassTheHash confirms a raw 16-byte NTHash (no password) drives the same
+// session key as the equivalent password, i.e. the pass-the-hash path works.
+func TestEstablishPassTheHash(t *testing.T) {
+	inv, cfg, _, sk := establishFixture(true, false, netlogon.StatusSuccess)
+	h := nt.NTHash(cfg.Password)
+	cfg.Password = ""
+	cfg.NTHash = h[:]
+	cfg.Rand = bytes.NewReader([]byte{1, 2, 3, 4, 5, 6, 7, 8}) // same fixed client challenge
+
+	sc, err := Establish(inv, cfg)
+	if err != nil {
+		t.Fatalf("Establish (pass-the-hash): %v", err)
+	}
+	if sc.SessionKey() != sk {
+		t.Errorf("session key = %x, want %x (must match the password-derived key)", sc.SessionKey(), sk)
 	}
 }
 


### PR DESCRIPTION
### Linked Issue
Closes #896. Hardening found while reviewing the Netlogon secure-channel feature.

### Root Cause
Two input-validation gaps let bad inputs fail late and opaquely:
1. `SecureChannel.Establish` fed `cfg.NTHash` and `cfg.Password` straight into session-key derivation. A wrong-length hash, a missing secret, or a non-nil empty `NTHash` slice (used as an empty HMAC key) produced a wrong session key that only failed as `STATUS_ACCESS_DENIED` at `NetrServerAuthenticate3`.
2. `Client.SetAuthProvider` accepted a nil `bindToken`; for Netlogon (auth_type `0x44`), which authenticates the bind with an `NL_AUTH_MESSAGE`, that yields a sec_trailer with an empty auth_value the DC rejects — surfacing only as an opaque bind/first-call failure.

### Fix Description
- **`Establish`** validates up front (before any RPC): `NTHash`, if present, must be 16 bytes; a non-nil empty slice is normalised to nil; and at least one of `Password`/`NTHash` must be set. The normalised hash is used for the session-key derivation.
- **`SetAuthProvider`** requires a non-empty `bindToken` when `authType == pdu.AuthTypeNetlogon`; other single-leg providers may still omit it.

Both now return a clear error instead of failing downstream.

### How Verified
- `go build ./...`, `go vet` (default and `-tags integration`), `gofmt -l` clean.
- New tests: `TestEstablishRejectsBadSecret` (wrong-length hash + missing secret fail before any RPC — asserts no opnums issued), `TestEstablishPassTheHash` (raw 16-byte `NTHash` derives the same session key as the password), `TestSetAuthProviderNetlogonRequiresBindToken` (netlogon needs a token; a non-netlogon provider does not). All existing Netlogon/NTLM tests unchanged and passing.

### Test Coverage
**Added** — `securechannel_test.go` (`TestEstablishRejectsBadSecret`, `TestEstablishPassTheHash`), `secctx_test.go` (`TestSetAuthProviderNetlogonRequiresBindToken`).

### Scope of Change
- **Files changed:** `windows/protocols/ms-nrpc/securechannel/securechannel.go`, `network/dcerpc/v5/client/auth.go` (+ their tests).
- **Behavioral change:** only rejects previously-invalid inputs earlier; valid flows (password, pass-the-hash, live AES/RC4 handshake) are unaffected.
- **Submodule pointer updated:** no.