### PR TITLE
Native Kerberos v5: credentials, credential cache, and client wiring (phase 3)

### DIFF
--- a/network/kerberos/v5/client.go
+++ b/network/kerberos/v5/client.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/credentials"
 	kerbcrypto "github.com/TheManticoreProject/Manticore/network/kerberos/v5/crypto"
 	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/messages"
 )
@@ -29,13 +30,14 @@ type KerberosClient struct {
 	realm    string
 	kdcHost  string
 
-	password string
+	cred *credentials.Credential
 
 	// Populated after a successful GetTGT call.
 	tgtTicket    messages.Ticket
 	tgtTicketRaw []byte // raw APPLICATION[1] bytes as received from KDC
 	sessionKey   []byte
 	sessionEType int
+	tgtEnc       messages.EncASRepPart // decrypted AS-REP enc-part: times, flags, sname
 	hasTGT       bool
 }
 
@@ -50,17 +52,40 @@ func NewClient(username, realm, kdcHost string) *KerberosClient {
 	}
 }
 
-// WithPassword stores the password for use in GetTGT.
+// WithPassword configures a password credential for GetTGT.
 // Returns the client to allow fluent chaining.
 func (c *KerberosClient) WithPassword(password string) *KerberosClient {
-	c.password = password
+	c.cred = credentials.NewWithPassword(c.username, c.realm, password)
 	return c
 }
 
-// WithCCache is not yet supported in the native implementation.
-// Use the gokrb5-backed KerberosInit helper for ccache-based LDAP binds.
-func (c *KerberosClient) WithCCache(_ string) error {
-	return fmt.Errorf("kerberos: ccache not supported in native implementation; use gokrb5 KerberosInit for LDAP GSSAPI binds")
+// WithCredential configures an arbitrary credential (password, NT hash, or AES
+// key). Returns the client to allow fluent chaining.
+func (c *KerberosClient) WithCredential(cred *credentials.Credential) *KerberosClient {
+	c.cred = cred
+	return c
+}
+
+// WithNTHash configures an NT-hash (overpass-the-hash) credential from a hex
+// string (accepts an "LM:NT" pair). GetTGT will request an RC4-HMAC TGT.
+func (c *KerberosClient) WithNTHash(hexHash string) error {
+	cred, err := credentials.NewWithHexNTHash(c.username, c.realm, hexHash)
+	if err != nil {
+		return err
+	}
+	c.cred = cred
+	return nil
+}
+
+// WithAESKey configures a pass-the-key credential from a hex-encoded AES key
+// (16 bytes -> AES128, 32 bytes -> AES256).
+func (c *KerberosClient) WithAESKey(hexKey string) error {
+	cred, err := credentials.NewWithHexAESKey(c.username, c.realm, hexKey)
+	if err != nil {
+		return err
+	}
+	c.cred = cred
+	return nil
 }
 
 // GetTGT requests a Ticket Granting Ticket from the KDC using the password
@@ -71,14 +96,14 @@ func (c *KerberosClient) WithCCache(_ string) error {
 // (realm+username). If the KDC returns PREAUTH_REQUIRED with different
 // etype/salt info, we retry once with the corrected values.
 func (c *KerberosClient) GetTGT() error {
-	if c.password == "" {
-		return fmt.Errorf("kerberos: no credentials configured: call WithPassword first")
+	if c.cred == nil {
+		return fmt.Errorf("kerberos: no credentials configured: call WithPassword/WithNTHash/WithAESKey/WithCredential first")
 	}
 
-	// Attempt with default AD salt. The KDC may respond with PREAUTH_REQUIRED
-	// if a different salt or etype is required.
-	etype := messages.ETypeAES256CTSHMACSHA196
-	salt := c.realm + c.username
+	// Start with the strongest etype the credential can satisfy and the AD
+	// default salt. The KDC corrects both via PREAUTH_REQUIRED if needed.
+	etype := c.cred.SupportedETypes()[0]
+	salt := c.cred.DefaultSalt()
 	resp, nonce, err := c.sendASReqWithPreauth(etype, salt, nil)
 	if err != nil {
 		return err
@@ -218,7 +243,9 @@ func (c *KerberosClient) Destroy() {
 		c.sessionKey[i] = 0
 	}
 	c.sessionKey = nil
-	c.password = ""
+	if c.cred != nil {
+		c.cred.Destroy()
+	}
 	c.hasTGT = false
 }
 
@@ -256,11 +283,7 @@ func (c *KerberosClient) sendASReq(pa_data []messages.PAData) ([]byte, int, erro
 			},
 			Till:  time.Now().UTC().Add(24 * time.Hour),
 			Nonce: nonce,
-			EType: []int{
-				messages.ETypeAES256CTSHMACSHA196,
-				messages.ETypeAES128CTSHMACSHA196,
-				messages.ETypeRC4HMAC,
-			},
+			EType: c.cred.SupportedETypes(),
 		},
 	}
 
@@ -279,8 +302,9 @@ func (c *KerberosClient) sendASReq(pa_data []messages.PAData) ([]byte, int, erro
 // PA-ETYPE-INFO2 structure embedded in a KRBError's EData.
 // Falls back to AES-256 with the default AD salt if no EData is present.
 func (c *KerberosClient) pickETypeFromError(krb_err messages.KRBError) (int, string, []byte) {
-	default_salt := c.realm + c.username
-	default_etype := messages.ETypeAES256CTSHMACSHA196
+	preferred := c.cred.SupportedETypes()
+	default_salt := c.cred.DefaultSalt()
+	default_etype := preferred[0]
 
 	if len(krb_err.EData) == 0 {
 		return default_etype, default_salt, nil
@@ -294,7 +318,7 @@ func (c *KerberosClient) pickETypeFromError(krb_err messages.KRBError) (int, str
 			if pa.PADataType == messages.PAETypeInfo2 {
 				var info messages.ETypeInfo2
 				if _, err := info.Unmarshal(pa.PADataValue); err == nil && len(info) > 0 {
-					return pickBestEType(info, default_salt)
+					return pickBestEType(info, preferred, default_salt)
 				}
 			}
 		}
@@ -303,20 +327,17 @@ func (c *KerberosClient) pickETypeFromError(krb_err messages.KRBError) (int, str
 	// Try to parse EData directly as ETYPE-INFO2.
 	var info messages.ETypeInfo2
 	if _, err := info.Unmarshal(krb_err.EData); err == nil && len(info) > 0 {
-		return pickBestEType(info, default_salt)
+		return pickBestEType(info, preferred, default_salt)
 	}
 
 	return default_etype, default_salt, nil
 }
 
-// pickBestEType selects the strongest supported etype from an ETypeInfo2 list.
-func pickBestEType(info messages.ETypeInfo2, default_salt string) (int, string, []byte) {
-	// Preference order: AES256 > AES128 > RC4.
-	preferred := []int{
-		messages.ETypeAES256CTSHMACSHA196,
-		messages.ETypeAES128CTSHMACSHA196,
-		messages.ETypeRC4HMAC,
-	}
+// pickBestEType selects, from an ETYPE-INFO2 list, the strongest etype the
+// credential can actually satisfy (preferred is the credential's supported set
+// in strength order). This prevents choosing, say, AES when only an NT hash is
+// held.
+func pickBestEType(info messages.ETypeInfo2, preferred []int, default_salt string) (int, string, []byte) {
 	for _, want := range preferred {
 		for _, entry := range info {
 			if entry.EType == want {
@@ -328,20 +349,17 @@ func pickBestEType(info messages.ETypeInfo2, default_salt string) (int, string, 
 			}
 		}
 	}
-	// Fallback to first entry.
-	e := info[0]
-	if e.Salt == "" {
-		e.Salt = default_salt
-	}
-	return e.EType, e.Salt, e.S2KParams
+	// No advertised etype is supported by the credential; fall back to the
+	// credential's strongest etype with the default salt.
+	return preferred[0], default_salt, nil
 }
 
 // sendASReqWithPreauth builds and sends an AS-REQ with PA-ENC-TIMESTAMP.
 // Returns the raw KDC response bytes and the nonce placed in the request.
 func (c *KerberosClient) sendASReqWithPreauth(etype int, salt string, s2k_params []byte) ([]byte, int, error) {
-	key, err := kerbcrypto.StringToKey(etype, c.password, salt, s2k_params)
+	key, err := c.cred.Key(etype, salt, s2k_params)
 	if err != nil {
-		return nil, 0, fmt.Errorf("kerberos: StringToKey: %w", err)
+		return nil, 0, fmt.Errorf("kerberos: derive key: %w", err)
 	}
 
 	now := time.Now().UTC()
@@ -396,9 +414,9 @@ func (c *KerberosClient) processASRep(resp []byte, etype int, salt string, s2k_p
 		return fmt.Errorf("kerberos: parse AS-REP: %w", err)
 	}
 
-	key, err := kerbcrypto.StringToKey(etype, c.password, salt, s2k_params)
+	key, err := c.cred.Key(etype, salt, s2k_params)
 	if err != nil {
-		return fmt.Errorf("kerberos: StringToKey for AS-REP decrypt: %w", err)
+		return fmt.Errorf("kerberos: derive key for AS-REP decrypt: %w", err)
 	}
 
 	enc_plain, err := kerbcrypto.Decrypt(etype, key, kerbcrypto.KeyUsageASRepEncPart, as_rep.EncPart.Cipher)
@@ -422,6 +440,7 @@ func (c *KerberosClient) processASRep(resp []byte, etype int, salt string, s2k_p
 	c.tgtTicketRaw = as_rep.TicketRaw
 	c.sessionKey = enc_as_rep.Key.KeyValue
 	c.sessionEType = enc_as_rep.Key.KeyType
+	c.tgtEnc = enc_as_rep
 	c.hasTGT = true
 	return nil
 }

--- a/network/kerberos/v5/credcache/ccache/ccache.go
+++ b/network/kerberos/v5/credcache/ccache/ccache.go
@@ -1,0 +1,373 @@
+// Package ccache reads and writes the MIT Kerberos FILE credential cache
+// (KRB5CCNAME) in format version 4, the interchange format used by Linux
+// Kerberos tooling and Impacket. Version 4 is big-endian throughout and is
+// documented at
+// https://web.mit.edu/kerberos/krb5-latest/doc/formats/ccache_file_format.html.
+//
+// Layout: a two-byte version tag (0x05 0x04), a tagged header, the default
+// client principal, then a sequence of credential entries running to EOF (no
+// count, no terminator). This package implements the wire format; building
+// entries from a live TGT/ST is done by the client layer.
+package ccache
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+)
+
+// Version4 is the file_format_version this package reads and writes.
+const Version4 = 0x0504
+
+// headerTagDeltaTime is the only defined v4 header field: two uint32s (seconds,
+// microseconds) giving the KDC-relative time offset.
+const headerTagDeltaTime = 1
+
+// Principal is a cache principal (client or server).
+type Principal struct {
+	NameType   uint32
+	Realm      string
+	Components []string
+}
+
+// Keyblock is a session key with its encryption type.
+type Keyblock struct {
+	EType    uint16
+	KeyValue []byte
+}
+
+// Address is a host address entry.
+type Address struct {
+	AddrType uint16
+	Data     []byte
+}
+
+// AuthData is an authorization-data entry.
+type AuthData struct {
+	ADType uint16
+	Data   []byte
+}
+
+// Credential is one cached ticket. Times are Unix seconds (uint32) as stored on
+// the wire; TicketFlags uses the RFC 4120 ticket-flag bit layout (bit 0 = MSB).
+type Credential struct {
+	Client       Principal
+	Server       Principal
+	Key          Keyblock
+	AuthTime     uint32
+	StartTime    uint32
+	EndTime      uint32
+	RenewTill    uint32
+	IsSKey       bool
+	TicketFlags  uint32
+	Addresses    []Address
+	AuthData     []AuthData
+	Ticket       []byte
+	SecondTicket []byte
+}
+
+// CCache is a parsed credential cache.
+type CCache struct {
+	// DeltaTime is the optional KDC time offset (seconds, microseconds). Zero
+	// means no delta-time header field is written.
+	DeltaTimeSecs    uint32
+	DeltaTimeUsecs   uint32
+	DefaultPrincipal Principal
+	Credentials      []Credential
+}
+
+// ── marshaling ──────────────────────────────────────────────────────────────
+
+func putData(buf *bytes.Buffer, data []byte) {
+	var l [4]byte
+	binary.BigEndian.PutUint32(l[:], uint32(len(data)))
+	buf.Write(l[:])
+	buf.Write(data)
+}
+
+func putPrincipal(buf *bytes.Buffer, p Principal) {
+	var u [4]byte
+	binary.BigEndian.PutUint32(u[:], p.NameType)
+	buf.Write(u[:])
+	// count of components does NOT include the realm in v2+.
+	binary.BigEndian.PutUint32(u[:], uint32(len(p.Components)))
+	buf.Write(u[:])
+	putData(buf, []byte(p.Realm))
+	for _, c := range p.Components {
+		putData(buf, []byte(c))
+	}
+}
+
+func putU16(buf *bytes.Buffer, v uint16) {
+	var b [2]byte
+	binary.BigEndian.PutUint16(b[:], v)
+	buf.Write(b[:])
+}
+
+func putU32(buf *bytes.Buffer, v uint32) {
+	var b [4]byte
+	binary.BigEndian.PutUint32(b[:], v)
+	buf.Write(b[:])
+}
+
+func putCredential(buf *bytes.Buffer, c Credential) {
+	putPrincipal(buf, c.Client)
+	putPrincipal(buf, c.Server)
+	// keyblock: v4 has a single enctype field followed by the key data.
+	putU16(buf, c.Key.EType)
+	putData(buf, c.Key.KeyValue)
+	putU32(buf, c.AuthTime)
+	putU32(buf, c.StartTime)
+	putU32(buf, c.EndTime)
+	putU32(buf, c.RenewTill)
+	if c.IsSKey {
+		buf.WriteByte(1)
+	} else {
+		buf.WriteByte(0)
+	}
+	putU32(buf, c.TicketFlags)
+	putU32(buf, uint32(len(c.Addresses)))
+	for _, a := range c.Addresses {
+		putU16(buf, a.AddrType)
+		putData(buf, a.Data)
+	}
+	putU32(buf, uint32(len(c.AuthData)))
+	for _, a := range c.AuthData {
+		putU16(buf, a.ADType)
+		putData(buf, a.Data)
+	}
+	putData(buf, c.Ticket)
+	putData(buf, c.SecondTicket)
+}
+
+// Marshal encodes the cache in ccache format version 4.
+func (cc *CCache) Marshal() ([]byte, error) {
+	var buf bytes.Buffer
+	putU16(&buf, Version4)
+
+	// Header: only the delta-time field, and only if set.
+	var hdr bytes.Buffer
+	if cc.DeltaTimeSecs != 0 || cc.DeltaTimeUsecs != 0 {
+		putU16(&hdr, headerTagDeltaTime)
+		putU16(&hdr, 8)
+		putU32(&hdr, cc.DeltaTimeSecs)
+		putU32(&hdr, cc.DeltaTimeUsecs)
+	}
+	putU16(&buf, uint16(hdr.Len()))
+	buf.Write(hdr.Bytes())
+
+	putPrincipal(&buf, cc.DefaultPrincipal)
+	for i := range cc.Credentials {
+		putCredential(&buf, cc.Credentials[i])
+	}
+	return buf.Bytes(), nil
+}
+
+// ── unmarshaling ──────────────────────────────────────────────────────────────
+
+// reader is a bounds-checked big-endian cursor over the cache bytes.
+type reader struct {
+	b   []byte
+	pos int
+}
+
+func (r *reader) need(n int) error {
+	if r.pos+n > len(r.b) {
+		return fmt.Errorf("ccache: truncated: need %d bytes at offset %d of %d", n, r.pos, len(r.b))
+	}
+	return nil
+}
+
+func (r *reader) u16() (uint16, error) {
+	if err := r.need(2); err != nil {
+		return 0, err
+	}
+	v := binary.BigEndian.Uint16(r.b[r.pos:])
+	r.pos += 2
+	return v, nil
+}
+
+func (r *reader) u32() (uint32, error) {
+	if err := r.need(4); err != nil {
+		return 0, err
+	}
+	v := binary.BigEndian.Uint32(r.b[r.pos:])
+	r.pos += 4
+	return v, nil
+}
+
+func (r *reader) u8() (byte, error) {
+	if err := r.need(1); err != nil {
+		return 0, err
+	}
+	v := r.b[r.pos]
+	r.pos++
+	return v, nil
+}
+
+func (r *reader) data() ([]byte, error) {
+	n, err := r.u32()
+	if err != nil {
+		return nil, err
+	}
+	if err := r.need(int(n)); err != nil {
+		return nil, err
+	}
+	out := make([]byte, n)
+	copy(out, r.b[r.pos:r.pos+int(n)])
+	r.pos += int(n)
+	return out, nil
+}
+
+func (r *reader) principal() (Principal, error) {
+	var p Principal
+	nt, err := r.u32()
+	if err != nil {
+		return p, err
+	}
+	p.NameType = nt
+	n, err := r.u32()
+	if err != nil {
+		return p, err
+	}
+	realm, err := r.data()
+	if err != nil {
+		return p, err
+	}
+	p.Realm = string(realm)
+	for i := uint32(0); i < n; i++ {
+		c, err := r.data()
+		if err != nil {
+			return p, err
+		}
+		p.Components = append(p.Components, string(c))
+	}
+	return p, nil
+}
+
+func (r *reader) credential() (Credential, error) {
+	var c Credential
+	var err error
+	if c.Client, err = r.principal(); err != nil {
+		return c, err
+	}
+	if c.Server, err = r.principal(); err != nil {
+		return c, err
+	}
+	if c.Key.EType, err = r.u16(); err != nil {
+		return c, err
+	}
+	if c.Key.KeyValue, err = r.data(); err != nil {
+		return c, err
+	}
+	if c.AuthTime, err = r.u32(); err != nil {
+		return c, err
+	}
+	if c.StartTime, err = r.u32(); err != nil {
+		return c, err
+	}
+	if c.EndTime, err = r.u32(); err != nil {
+		return c, err
+	}
+	if c.RenewTill, err = r.u32(); err != nil {
+		return c, err
+	}
+	skey, err := r.u8()
+	if err != nil {
+		return c, err
+	}
+	c.IsSKey = skey != 0
+	if c.TicketFlags, err = r.u32(); err != nil {
+		return c, err
+	}
+	nAddr, err := r.u32()
+	if err != nil {
+		return c, err
+	}
+	for i := uint32(0); i < nAddr; i++ {
+		at, err := r.u16()
+		if err != nil {
+			return c, err
+		}
+		d, err := r.data()
+		if err != nil {
+			return c, err
+		}
+		c.Addresses = append(c.Addresses, Address{AddrType: at, Data: d})
+	}
+	nAD, err := r.u32()
+	if err != nil {
+		return c, err
+	}
+	for i := uint32(0); i < nAD; i++ {
+		adt, err := r.u16()
+		if err != nil {
+			return c, err
+		}
+		d, err := r.data()
+		if err != nil {
+			return c, err
+		}
+		c.AuthData = append(c.AuthData, AuthData{ADType: adt, Data: d})
+	}
+	if c.Ticket, err = r.data(); err != nil {
+		return c, err
+	}
+	if c.SecondTicket, err = r.data(); err != nil {
+		return c, err
+	}
+	return c, nil
+}
+
+// Unmarshal parses a ccache. Only format version 4 is supported.
+func Unmarshal(data []byte) (*CCache, error) {
+	r := &reader{b: data}
+	ver, err := r.u16()
+	if err != nil {
+		return nil, err
+	}
+	if ver != Version4 {
+		return nil, fmt.Errorf("ccache: unsupported version 0x%04x (only 0x%04x/v4 supported)", ver, Version4)
+	}
+
+	cc := &CCache{}
+	hdrLen, err := r.u16()
+	if err != nil {
+		return nil, err
+	}
+	if err := r.need(int(hdrLen)); err != nil {
+		return nil, err
+	}
+	hdrEnd := r.pos + int(hdrLen)
+	for r.pos < hdrEnd {
+		tag, err := r.u16()
+		if err != nil {
+			return nil, err
+		}
+		flen, err := r.u16()
+		if err != nil {
+			return nil, err
+		}
+		if err := r.need(int(flen)); err != nil {
+			return nil, err
+		}
+		if tag == headerTagDeltaTime && flen == 8 {
+			cc.DeltaTimeSecs = binary.BigEndian.Uint32(r.b[r.pos:])
+			cc.DeltaTimeUsecs = binary.BigEndian.Uint32(r.b[r.pos+4:])
+		}
+		r.pos += int(flen) // skip unknown/known field body
+	}
+	r.pos = hdrEnd
+
+	if cc.DefaultPrincipal, err = r.principal(); err != nil {
+		return nil, err
+	}
+	for r.pos < len(data) {
+		cred, err := r.credential()
+		if err != nil {
+			return nil, err
+		}
+		cc.Credentials = append(cc.Credentials, cred)
+	}
+	return cc, nil
+}

--- a/network/kerberos/v5/credcache/ccache/ccache_test.go
+++ b/network/kerberos/v5/credcache/ccache/ccache_test.go
@@ -1,0 +1,126 @@
+package ccache
+
+import (
+	"bytes"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func sampleCache() *CCache {
+	return &CCache{
+		DeltaTimeSecs: 42,
+		DefaultPrincipal: Principal{
+			NameType:   1,
+			Realm:      "CORP.LOCAL",
+			Components: []string{"alice"},
+		},
+		Credentials: []Credential{
+			{
+				Client:      Principal{NameType: 1, Realm: "CORP.LOCAL", Components: []string{"alice"}},
+				Server:      Principal{NameType: 2, Realm: "CORP.LOCAL", Components: []string{"krbtgt", "CORP.LOCAL"}},
+				Key:         Keyblock{EType: 18, KeyValue: bytes.Repeat([]byte{0xAB}, 32)},
+				AuthTime:    1_700_000_000,
+				StartTime:   1_700_000_000,
+				EndTime:     1_700_036_000,
+				RenewTill:   1_700_600_000,
+				IsSKey:      false,
+				TicketFlags: 0x50e00000, // forwardable+renewable+initial+pre-authent style bits
+				Ticket:      bytes.Repeat([]byte{0x01, 0x02}, 20),
+			},
+			{
+				Client:       Principal{NameType: 1, Realm: "CORP.LOCAL", Components: []string{"alice"}},
+				Server:       Principal{NameType: 2, Realm: "CORP.LOCAL", Components: []string{"cifs", "dc01.corp.local"}},
+				Key:          Keyblock{EType: 23, KeyValue: bytes.Repeat([]byte{0xCD}, 16)},
+				EndTime:      1_700_036_000,
+				TicketFlags:  0x40a00000,
+				Addresses:    []Address{{AddrType: 2, Data: []byte{10, 0, 0, 1}}},
+				AuthData:     []AuthData{{ADType: 1, Data: []byte{9, 9, 9}}},
+				Ticket:       []byte("service-ticket-bytes"),
+				SecondTicket: []byte{},
+			},
+		},
+	}
+}
+
+func TestCCacheRoundtrip(t *testing.T) {
+	orig := sampleCache()
+	b, err := orig.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	// Version tag must be 05 04.
+	if b[0] != 0x05 || b[1] != 0x04 {
+		t.Fatalf("version tag = % X, want 05 04", b[:2])
+	}
+	got, err := Unmarshal(b)
+	if err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if !reflect.DeepEqual(orig.DefaultPrincipal, got.DefaultPrincipal) {
+		t.Errorf("default principal mismatch:\n got %+v\n want %+v", got.DefaultPrincipal, orig.DefaultPrincipal)
+	}
+	if got.DeltaTimeSecs != orig.DeltaTimeSecs {
+		t.Errorf("delta-time secs: got %d, want %d", got.DeltaTimeSecs, orig.DeltaTimeSecs)
+	}
+	if len(got.Credentials) != len(orig.Credentials) {
+		t.Fatalf("credential count: got %d, want %d", len(got.Credentials), len(orig.Credentials))
+	}
+	for i := range orig.Credentials {
+		// Normalize nil vs empty slice for the comparison of the second_ticket.
+		if len(got.Credentials[i].SecondTicket) == 0 {
+			got.Credentials[i].SecondTicket = orig.Credentials[i].SecondTicket
+		}
+		if !reflect.DeepEqual(got.Credentials[i], orig.Credentials[i]) {
+			t.Errorf("credential[%d] mismatch:\n got  %+v\n want %+v", i, got.Credentials[i], orig.Credentials[i])
+		}
+	}
+}
+
+func TestCCacheSaveLoad(t *testing.T) {
+	orig := sampleCache()
+	path := filepath.Join(t.TempDir(), "krb5cc_test")
+	if err := orig.Save(path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got.DefaultPrincipal.Realm != "CORP.LOCAL" || len(got.Credentials) != 2 {
+		t.Errorf("loaded cache wrong: %+v", got)
+	}
+	// The TGT's server must be krbtgt/CORP.LOCAL.
+	tgt := got.Credentials[0].Server
+	if len(tgt.Components) != 2 || tgt.Components[0] != "krbtgt" {
+		t.Errorf("TGT server principal wrong: %+v", tgt)
+	}
+}
+
+func TestCCacheRejectsWrongVersion(t *testing.T) {
+	if _, err := Unmarshal([]byte{0x05, 0x03, 0x00, 0x00}); err == nil {
+		t.Error("expected error for version 3 cache")
+	}
+	if _, err := Unmarshal([]byte{0x05}); err == nil {
+		t.Error("expected error for truncated input")
+	}
+}
+
+func TestCCacheEmptyHeaderNoDelta(t *testing.T) {
+	cc := &CCache{DefaultPrincipal: Principal{NameType: 1, Realm: "R", Components: []string{"u"}}}
+	b, err := cc.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// header length (bytes 2-3) must be 0 when no delta-time is set.
+	if b[2] != 0 || b[3] != 0 {
+		t.Errorf("expected empty header, got header len % X", b[2:4])
+	}
+	got, err := Unmarshal(b)
+	if err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got.DefaultPrincipal.Realm != "R" {
+		t.Errorf("principal round-trip failed: %+v", got.DefaultPrincipal)
+	}
+}

--- a/network/kerberos/v5/credcache/ccache/io.go
+++ b/network/kerberos/v5/credcache/ccache/io.go
@@ -1,0 +1,27 @@
+package ccache
+
+import (
+	"fmt"
+	"os"
+)
+
+// Save writes the cache to path in ccache v4 format, mode 0600.
+func (cc *CCache) Save(path string) error {
+	b, err := cc.Marshal()
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(path, b, 0o600); err != nil {
+		return fmt.Errorf("ccache: write %s: %w", path, err)
+	}
+	return nil
+}
+
+// Load reads and parses a ccache file.
+func Load(path string) (*CCache, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("ccache: read %s: %w", path, err)
+	}
+	return Unmarshal(b)
+}

--- a/network/kerberos/v5/credcache/kirbi/kirbi.go
+++ b/network/kerberos/v5/credcache/kirbi/kirbi.go
@@ -1,0 +1,80 @@
+// Package kirbi reads and writes ".kirbi" credential files. A .kirbi file is a
+// DER-encoded Kerberos KRB-CRED message (RFC 4120 Section 5.8.1) carrying one
+// or more tickets — the interchange format used by Rubeus and (via -k) Impacket
+// for pass-the-ticket. By convention the EncKrbCredPart is stored unencrypted
+// with etype 0, so the session key and ticket metadata are in the clear.
+package kirbi
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/messages"
+)
+
+// Bytes returns the DER encoding of a KRB-CRED (the raw .kirbi contents).
+func Bytes(cred *messages.KRBCred) ([]byte, error) {
+	return cred.Marshal()
+}
+
+// Parse decodes .kirbi bytes into a KRB-CRED.
+func Parse(data []byte) (*messages.KRBCred, error) {
+	var c messages.KRBCred
+	if _, err := c.Unmarshal(data); err != nil {
+		return nil, fmt.Errorf("kirbi: parse: %w", err)
+	}
+	return &c, nil
+}
+
+// Save writes cred to path in .kirbi (DER KRB-CRED) form, 0600.
+func Save(path string, cred *messages.KRBCred) error {
+	b, err := Bytes(cred)
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(path, b, 0o600); err != nil {
+		return fmt.Errorf("kirbi: write %s: %w", path, err)
+	}
+	return nil
+}
+
+// Load reads and parses a .kirbi file.
+func Load(path string) (*messages.KRBCred, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("kirbi: read %s: %w", path, err)
+	}
+	return Parse(b)
+}
+
+// New builds a KRB-CRED wrapping a single ticket, with the EncKrbCredPart stored
+// unencrypted (etype 0) as .kirbi conventionally does. ticketRaw is the raw
+// APPLICATION[1] ticket TLV as issued by the KDC; info carries the session key,
+// principal names, flags, and times for that ticket.
+func New(ticketRaw []byte, info messages.KrbCredInfo) (*messages.KRBCred, error) {
+	enc := messages.EncKrbCredPart{TicketInfo: []messages.KrbCredInfo{info}}
+	encBytes, err := enc.Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("kirbi: marshal enc-part: %w", err)
+	}
+	return &messages.KRBCred{
+		PVNO:       messages.KerberosV5,
+		MsgType:    messages.MsgTypeKRBCred,
+		TicketsRaw: [][]byte{ticketRaw},
+		EncPart:    messages.EncryptedData{EType: 0, Cipher: encBytes},
+	}, nil
+}
+
+// TicketInfo decodes and returns the EncKrbCredPart ticket-info entries from a
+// KRB-CRED whose enc-part is stored unencrypted (etype 0), the .kirbi
+// convention. It errors if the enc-part is encrypted (etype != 0).
+func TicketInfo(cred *messages.KRBCred) ([]messages.KrbCredInfo, error) {
+	if cred.EncPart.EType != 0 {
+		return nil, fmt.Errorf("kirbi: enc-part is encrypted (etype %d); cannot read without a key", cred.EncPart.EType)
+	}
+	var enc messages.EncKrbCredPart
+	if _, err := enc.Unmarshal(cred.EncPart.Cipher); err != nil {
+		return nil, fmt.Errorf("kirbi: parse enc-part: %w", err)
+	}
+	return enc.TicketInfo, nil
+}

--- a/network/kerberos/v5/credcache/kirbi/kirbi_test.go
+++ b/network/kerberos/v5/credcache/kirbi/kirbi_test.go
@@ -1,0 +1,117 @@
+package kirbi
+
+import (
+	"bytes"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/messages"
+)
+
+func sampleTicketAndInfo(t *testing.T) ([]byte, messages.KrbCredInfo) {
+	t.Helper()
+	tkt := messages.Ticket{
+		TktVno:  messages.KerberosV5,
+		Realm:   "CORP.LOCAL",
+		SName:   messages.PrincipalName{NameType: messages.NameTypeSRVInst, NameString: []string{"krbtgt", "CORP.LOCAL"}},
+		EncPart: messages.EncryptedData{EType: messages.ETypeAES256CTSHMACSHA196, Cipher: bytes.Repeat([]byte{0xAB}, 32)},
+	}
+	raw, err := tkt.Marshal()
+	if err != nil {
+		t.Fatalf("Ticket.Marshal: %v", err)
+	}
+	info := messages.KrbCredInfo{
+		Key:       messages.EncryptionKey{KeyType: messages.ETypeAES256CTSHMACSHA196, KeyValue: bytes.Repeat([]byte{0x11}, 32)},
+		PRealm:    "CORP.LOCAL",
+		PName:     messages.PrincipalName{NameType: messages.NameTypePrincipal, NameString: []string{"alice"}},
+		Flags:     messages.NewKerberosFlags(messages.TicketFlagForwardable, messages.TicketFlagRenewable, messages.TicketFlagInitial),
+		AuthTime:  time.Date(2026, 7, 9, 10, 0, 0, 0, time.UTC),
+		EndTime:   time.Date(2026, 7, 9, 20, 0, 0, 0, time.UTC),
+		RenewTill: time.Date(2026, 7, 16, 10, 0, 0, 0, time.UTC),
+		SRealm:    "CORP.LOCAL",
+		SName:     messages.PrincipalName{NameType: messages.NameTypeSRVInst, NameString: []string{"krbtgt", "CORP.LOCAL"}},
+	}
+	return raw, info
+}
+
+func TestKirbiNewRoundtrip(t *testing.T) {
+	raw, info := sampleTicketAndInfo(t)
+
+	cred, err := New(raw, info)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if cred.EncPart.EType != 0 {
+		t.Errorf("enc-part should be unencrypted (etype 0), got %d", cred.EncPart.EType)
+	}
+
+	blob, err := Bytes(cred)
+	if err != nil {
+		t.Fatalf("Bytes: %v", err)
+	}
+	// Sanity: a .kirbi is an APPLICATION[22] (KRB-CRED) — first byte 0x76.
+	if blob[0] != 0x76 {
+		t.Errorf("kirbi should start with APPLICATION[22] tag 0x76, got 0x%02x", blob[0])
+	}
+
+	parsed, err := Parse(blob)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if len(parsed.Tickets) != 1 || parsed.Tickets[0].Realm != "CORP.LOCAL" {
+		t.Fatalf("parsed tickets wrong: %+v", parsed.Tickets)
+	}
+
+	infos, err := TicketInfo(parsed)
+	if err != nil {
+		t.Fatalf("TicketInfo: %v", err)
+	}
+	if len(infos) != 1 {
+		t.Fatalf("ticket-info count: got %d, want 1", len(infos))
+	}
+	got := infos[0]
+	if got.PName.NameString[0] != "alice" || got.SRealm != "CORP.LOCAL" {
+		t.Errorf("ticket-info fields wrong: %+v", got)
+	}
+	if !got.EndTime.Equal(info.EndTime) || !got.RenewTill.Equal(info.RenewTill) {
+		t.Errorf("time round-trip: end=%v renew=%v", got.EndTime, got.RenewTill)
+	}
+	if !bytes.Equal(got.Key.KeyValue, info.Key.KeyValue) {
+		t.Error("session key mismatch")
+	}
+}
+
+func TestKirbiSaveLoad(t *testing.T) {
+	raw, info := sampleTicketAndInfo(t)
+	cred, err := New(raw, info)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "ticket.kirbi")
+	if err := Save(path, cred); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(loaded.Tickets) != 1 {
+		t.Fatalf("loaded tickets: %d", len(loaded.Tickets))
+	}
+	// The raw ticket bytes must survive verbatim.
+	if !bytes.Equal(loaded.TicketsRaw[0], raw) {
+		t.Error("raw ticket bytes not preserved through save/load")
+	}
+}
+
+func TestTicketInfoRejectsEncrypted(t *testing.T) {
+	cred := &messages.KRBCred{
+		PVNO:    messages.KerberosV5,
+		MsgType: messages.MsgTypeKRBCred,
+		EncPart: messages.EncryptedData{EType: messages.ETypeAES256CTSHMACSHA196, Cipher: []byte{1, 2, 3}},
+	}
+	if _, err := TicketInfo(cred); err == nil {
+		t.Error("expected error reading ticket-info from an encrypted enc-part")
+	}
+}

--- a/network/kerberos/v5/credentials/credentials.go
+++ b/network/kerberos/v5/credentials/credentials.go
@@ -1,0 +1,209 @@
+// Package credentials models the long-term secret a Kerberos client
+// authenticates with, abstracting over the three forms Active Directory
+// tooling uses: a cleartext password, an NT hash (the RC4-HMAC key — enabling
+// overpass-the-hash), or a raw AES key (enabling pass-the-key). A Credential
+// turns any of these into the per-etype key material the AS/TGS exchanges need.
+package credentials
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	kerbcrypto "github.com/TheManticoreProject/Manticore/network/kerberos/v5/crypto"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/iana"
+)
+
+// SecretKind identifies which form of long-term secret a Credential holds.
+type SecretKind int
+
+const (
+	// SecretPassword is a cleartext password; keys of any supported etype can
+	// be derived from it via string-to-key.
+	SecretPassword SecretKind = iota
+	// SecretNTHash is the NT hash (MD4 of the UTF-16LE password), which is
+	// exactly the RC4-HMAC (etype 23) key — the basis of overpass-the-hash.
+	SecretNTHash
+	// SecretAESKey is a precomputed AES key for one specific etype (17 or 18),
+	// the basis of pass-the-key.
+	SecretAESKey
+)
+
+// Credential is an immutable long-term secret bound to a principal.
+type Credential struct {
+	username string
+	realm    string // always upper-cased
+
+	kind     SecretKind
+	password string
+	ntHash   []byte // 16 bytes, when kind == SecretNTHash
+	aesKey   []byte // 16 or 32 bytes, when kind == SecretAESKey
+	aesEtype int    // 17 or 18, when kind == SecretAESKey
+}
+
+// NewWithPassword creates a password-based credential. The realm is upper-cased.
+func NewWithPassword(username, realm, password string) *Credential {
+	return &Credential{
+		username: username,
+		realm:    strings.ToUpper(realm),
+		kind:     SecretPassword,
+		password: password,
+	}
+}
+
+// NewWithNTHash creates an NT-hash (overpass-the-hash) credential from a 16-byte
+// hash. The hash is copied.
+func NewWithNTHash(username, realm string, ntHash []byte) (*Credential, error) {
+	if len(ntHash) != 16 {
+		return nil, fmt.Errorf("credentials: NT hash must be 16 bytes, got %d", len(ntHash))
+	}
+	h := make([]byte, 16)
+	copy(h, ntHash)
+	return &Credential{
+		username: username,
+		realm:    strings.ToUpper(realm),
+		kind:     SecretNTHash,
+		ntHash:   h,
+	}, nil
+}
+
+// NewWithHexNTHash creates an NT-hash credential from a 32-character hex string
+// (optionally an "LM:NT" pair, in which case the NT half is used).
+func NewWithHexNTHash(username, realm, hexHash string) (*Credential, error) {
+	if i := strings.IndexByte(hexHash, ':'); i >= 0 {
+		hexHash = hexHash[i+1:] // accept "LMHASH:NTHASH", keep the NT half
+	}
+	hexHash = strings.TrimSpace(hexHash)
+	raw, err := hex.DecodeString(hexHash)
+	if err != nil {
+		return nil, fmt.Errorf("credentials: invalid hex NT hash: %w", err)
+	}
+	return NewWithNTHash(username, realm, raw)
+}
+
+// NewWithAESKey creates a pass-the-key credential from a raw AES key. etype must
+// be 17 (AES128, 16-byte key) or 18 (AES256, 32-byte key) and match the key
+// length. The key is copied.
+func NewWithAESKey(username, realm string, etype int, key []byte) (*Credential, error) {
+	var want int
+	switch etype {
+	case iana.ETypeAES128CTSHMACSHA196:
+		want = 16
+	case iana.ETypeAES256CTSHMACSHA196:
+		want = 32
+	default:
+		return nil, fmt.Errorf("credentials: AES key etype must be 17 or 18, got %d", etype)
+	}
+	if len(key) != want {
+		return nil, fmt.Errorf("credentials: etype %d requires a %d-byte key, got %d", etype, want, len(key))
+	}
+	k := make([]byte, want)
+	copy(k, key)
+	return &Credential{
+		username: username,
+		realm:    strings.ToUpper(realm),
+		kind:     SecretAESKey,
+		aesKey:   k,
+		aesEtype: etype,
+	}, nil
+}
+
+// NewWithHexAESKey creates a pass-the-key credential from a hex-encoded AES key.
+// The etype is inferred from the key length (16 bytes -> 17, 32 bytes -> 18).
+func NewWithHexAESKey(username, realm, hexKey string) (*Credential, error) {
+	raw, err := hex.DecodeString(strings.TrimSpace(hexKey))
+	if err != nil {
+		return nil, fmt.Errorf("credentials: invalid hex AES key: %w", err)
+	}
+	switch len(raw) {
+	case 16:
+		return NewWithAESKey(username, realm, iana.ETypeAES128CTSHMACSHA196, raw)
+	case 32:
+		return NewWithAESKey(username, realm, iana.ETypeAES256CTSHMACSHA196, raw)
+	default:
+		return nil, fmt.Errorf("credentials: AES key must be 16 or 32 bytes, got %d", len(raw))
+	}
+}
+
+// Username returns the principal's account name.
+func (c *Credential) Username() string { return c.username }
+
+// Realm returns the upper-cased realm.
+func (c *Credential) Realm() string { return c.realm }
+
+// Kind returns which form of secret this credential holds.
+func (c *Credential) Kind() SecretKind { return c.kind }
+
+// DefaultSalt returns the Active Directory default string-to-key salt for a user
+// account (UPPERCASE-REALM concatenated with the account name). The KDC may
+// advertise a different salt in PA-ETYPE-INFO2; prefer that when present.
+func (c *Credential) DefaultSalt() string {
+	return c.realm + c.username
+}
+
+// Key derives the long-term key for the requested etype.
+//
+//   - Password: string-to-key over (salt, s2kparams); any supported etype.
+//   - NT hash:  only etype 23 (RC4-HMAC); the hash itself is the key.
+//   - AES key:  only the etype the key was created for.
+//
+// It returns an error if the credential cannot produce a key of that etype
+// (e.g. an NT hash cannot yield an AES key).
+func (c *Credential) Key(etype int, salt string, s2kparams []byte) ([]byte, error) {
+	switch c.kind {
+	case SecretPassword:
+		return kerbcrypto.StringToKey(etype, c.password, salt, s2kparams)
+
+	case SecretNTHash:
+		if etype != iana.ETypeRC4HMAC {
+			return nil, fmt.Errorf("credentials: NT hash can only derive the RC4-HMAC (etype 23) key, not etype %d", etype)
+		}
+		out := make([]byte, len(c.ntHash))
+		copy(out, c.ntHash)
+		return out, nil
+
+	case SecretAESKey:
+		if etype != c.aesEtype {
+			return nil, fmt.Errorf("credentials: this AES key is etype %d, cannot derive etype %d", c.aesEtype, etype)
+		}
+		out := make([]byte, len(c.aesKey))
+		copy(out, c.aesKey)
+		return out, nil
+
+	default:
+		return nil, fmt.Errorf("credentials: unknown secret kind %d", c.kind)
+	}
+}
+
+// SupportedETypes returns the etypes this credential can produce keys for, in
+// KDC-preference order (strongest first). It is used to build the AS-REQ etype
+// list so the request advertises only etypes the client can actually complete.
+func (c *Credential) SupportedETypes() []int {
+	switch c.kind {
+	case SecretPassword:
+		return []int{
+			iana.ETypeAES256CTSHMACSHA196,
+			iana.ETypeAES128CTSHMACSHA196,
+			iana.ETypeRC4HMAC,
+		}
+	case SecretNTHash:
+		return []int{iana.ETypeRC4HMAC}
+	case SecretAESKey:
+		return []int{c.aesEtype}
+	default:
+		return nil
+	}
+}
+
+// Destroy zeroes the secret material held by the credential.
+func (c *Credential) Destroy() {
+	for i := range c.ntHash {
+		c.ntHash[i] = 0
+	}
+	for i := range c.aesKey {
+		c.aesKey[i] = 0
+	}
+	c.password = ""
+	c.ntHash = nil
+	c.aesKey = nil
+}

--- a/network/kerberos/v5/credentials/credentials_test.go
+++ b/network/kerberos/v5/credentials/credentials_test.go
@@ -1,0 +1,141 @@
+package credentials
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/crypto/nt"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/iana"
+)
+
+func TestPasswordKeyMatchesNTHashForRC4(t *testing.T) {
+	c := NewWithPassword("alice", "corp.local", "Sup3rSecret!")
+	if c.Realm() != "CORP.LOCAL" {
+		t.Fatalf("realm not upper-cased: %q", c.Realm())
+	}
+	got, err := c.Key(iana.ETypeRC4HMAC, "", nil)
+	if err != nil {
+		t.Fatalf("Key(RC4): %v", err)
+	}
+	want := nt.NTHash("Sup3rSecret!")
+	if !bytes.Equal(got, want[:]) {
+		t.Errorf("RC4 key %x != NT hash %x", got, want)
+	}
+}
+
+func TestPasswordDerivesAES(t *testing.T) {
+	c := NewWithPassword("alice", "CORP.LOCAL", "password")
+	k, err := c.Key(iana.ETypeAES256CTSHMACSHA196, c.DefaultSalt(), nil)
+	if err != nil {
+		t.Fatalf("Key(AES256): %v", err)
+	}
+	if len(k) != 32 {
+		t.Errorf("AES256 key length = %d, want 32", len(k))
+	}
+}
+
+func TestOverpassTheHash(t *testing.T) {
+	hashHex := "8846f7eaee8fb117ad06bdd830b7586c" // NT hash of "password"
+	c, err := NewWithHexNTHash("alice", "corp.local", hashHex)
+	if err != nil {
+		t.Fatalf("NewWithHexNTHash: %v", err)
+	}
+
+	// RC4 key is the hash itself.
+	rc4, err := c.Key(iana.ETypeRC4HMAC, "", nil)
+	if err != nil {
+		t.Fatalf("Key(RC4): %v", err)
+	}
+	want, _ := hex.DecodeString(hashHex)
+	if !bytes.Equal(rc4, want) {
+		t.Errorf("RC4 key %x != %s", rc4, hashHex)
+	}
+	// It should equal the NT hash of "password" (sanity vs the crypto layer).
+	if h := nt.NTHash("password"); !bytes.Equal(rc4, h[:]) {
+		t.Errorf("hash does not match NTHash(\"password\")")
+	}
+
+	// An NT hash cannot yield an AES key.
+	if _, err := c.Key(iana.ETypeAES256CTSHMACSHA196, "CORP.LOCALalice", nil); err == nil {
+		t.Error("expected error deriving AES key from NT hash")
+	}
+
+	if len(c.SupportedETypes()) != 1 || c.SupportedETypes()[0] != iana.ETypeRC4HMAC {
+		t.Errorf("NT-hash SupportedETypes = %v, want [23]", c.SupportedETypes())
+	}
+}
+
+func TestPassTheKey(t *testing.T) {
+	// Accepts LM:NT form and takes the NT half.
+	c, err := NewWithHexNTHash("bob", "CORP.LOCAL", "aad3b435b51404eeaad3b435b51404ee:8846f7eaee8fb117ad06bdd830b7586c")
+	if err != nil {
+		t.Fatalf("NewWithHexNTHash LM:NT: %v", err)
+	}
+	rc4, _ := c.Key(iana.ETypeRC4HMAC, "", nil)
+	if h := nt.NTHash("password"); !bytes.Equal(rc4, h[:]) {
+		t.Errorf("LM:NT parse took wrong half")
+	}
+
+	key32 := bytes.Repeat([]byte{0xAB}, 32)
+	ck, err := NewWithAESKey("svc", "CORP.LOCAL", iana.ETypeAES256CTSHMACSHA196, key32)
+	if err != nil {
+		t.Fatalf("NewWithAESKey: %v", err)
+	}
+	got, err := ck.Key(iana.ETypeAES256CTSHMACSHA196, "ignored-salt", nil)
+	if err != nil {
+		t.Fatalf("Key(AES256): %v", err)
+	}
+	if !bytes.Equal(got, key32) {
+		t.Error("AES key round-trip mismatch")
+	}
+	// Wrong etype must fail.
+	if _, err := ck.Key(iana.ETypeAES128CTSHMACSHA196, "", nil); err == nil {
+		t.Error("expected error: AES256 key cannot serve etype 17")
+	}
+	if _, err := ck.Key(iana.ETypeRC4HMAC, "", nil); err == nil {
+		t.Error("expected error: AES key cannot serve RC4")
+	}
+}
+
+func TestNewWithHexAESKeyInfersEtype(t *testing.T) {
+	c16, err := NewWithHexAESKey("svc", "CORP.LOCAL", hex.EncodeToString(bytes.Repeat([]byte{1}, 16)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c16.SupportedETypes()[0] != iana.ETypeAES128CTSHMACSHA196 {
+		t.Errorf("16-byte key inferred etype = %v, want 17", c16.SupportedETypes())
+	}
+	c32, err := NewWithHexAESKey("svc", "CORP.LOCAL", hex.EncodeToString(bytes.Repeat([]byte{1}, 32)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c32.SupportedETypes()[0] != iana.ETypeAES256CTSHMACSHA196 {
+		t.Errorf("32-byte key inferred etype = %v, want 18", c32.SupportedETypes())
+	}
+	if _, err := NewWithHexAESKey("svc", "R", hex.EncodeToString(bytes.Repeat([]byte{1}, 24))); err == nil {
+		t.Error("expected error for 24-byte AES key")
+	}
+}
+
+func TestInvalidInputs(t *testing.T) {
+	if _, err := NewWithNTHash("a", "R", []byte{1, 2, 3}); err == nil {
+		t.Error("expected error for short NT hash")
+	}
+	if _, err := NewWithHexNTHash("a", "R", "zzzz"); err == nil {
+		t.Error("expected error for bad hex")
+	}
+	if _, err := NewWithAESKey("a", "R", 99, bytes.Repeat([]byte{1}, 32)); err == nil {
+		t.Error("expected error for bad AES etype")
+	}
+}
+
+func TestDestroyZeroesSecret(t *testing.T) {
+	h, _ := hex.DecodeString("8846f7eaee8fb117ad06bdd830b7586c")
+	c, _ := NewWithNTHash("a", "R", h)
+	c.Destroy()
+	if _, err := c.Key(iana.ETypeRC4HMAC, "", nil); err != nil {
+		// after destroy ntHash is nil -> returns empty key, not an error; ensure no panic
+		t.Logf("post-destroy Key err: %v", err)
+	}
+}

--- a/network/kerberos/v5/export.go
+++ b/network/kerberos/v5/export.go
@@ -1,0 +1,96 @@
+package kerberos
+
+import (
+	"encoding/asn1"
+	"encoding/binary"
+	"fmt"
+	"time"
+
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/credcache/ccache"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/credcache/kirbi"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/messages"
+)
+
+// tgtCredInfo builds the KrbCredInfo describing the currently held TGT from the
+// stored AS-REP enc-part (session key, flags, times, service name).
+func (c *KerberosClient) tgtCredInfo() messages.KrbCredInfo {
+	return messages.KrbCredInfo{
+		Key:       messages.EncryptionKey{KeyType: c.sessionEType, KeyValue: c.sessionKey},
+		PRealm:    c.realm,
+		PName:     messages.PrincipalName{NameType: messages.NameTypePrincipal, NameString: []string{c.username}},
+		Flags:     c.tgtEnc.Flags,
+		AuthTime:  c.tgtEnc.AuthTime,
+		StartTime: c.tgtEnc.StartTime,
+		EndTime:   c.tgtEnc.EndTime,
+		RenewTill: c.tgtEnc.RenewTill,
+		SRealm:    c.tgtEnc.SRealm,
+		SName:     c.tgtEnc.SName,
+	}
+}
+
+// ExportTGTKirbi returns the current TGT as .kirbi (DER KRB-CRED) bytes, suitable
+// for pass-the-ticket with Rubeus/Impacket. GetTGT must have succeeded first.
+func (c *KerberosClient) ExportTGTKirbi() ([]byte, error) {
+	if !c.hasTGT {
+		return nil, fmt.Errorf("kerberos: no TGT: call GetTGT first")
+	}
+	cred, err := kirbi.New(c.tgtTicketRaw, c.tgtCredInfo())
+	if err != nil {
+		return nil, err
+	}
+	return kirbi.Bytes(cred)
+}
+
+// ExportTGTCCache returns the current TGT as an MIT ccache (v4) holding a single
+// credential. GetTGT must have succeeded first.
+func (c *KerberosClient) ExportTGTCCache() (*ccache.CCache, error) {
+	if !c.hasTGT {
+		return nil, fmt.Errorf("kerberos: no TGT: call GetTGT first")
+	}
+	client := ccache.Principal{
+		NameType:   uint32(messages.NameTypePrincipal),
+		Realm:      c.realm,
+		Components: []string{c.username},
+	}
+	server := ccache.Principal{
+		NameType:   uint32(c.tgtEnc.SName.NameType),
+		Realm:      c.tgtEnc.SRealm,
+		Components: append([]string(nil), c.tgtEnc.SName.NameString...),
+	}
+	start := c.tgtEnc.StartTime
+	if start.IsZero() {
+		start = c.tgtEnc.AuthTime
+	}
+	return &ccache.CCache{
+		DefaultPrincipal: client,
+		Credentials: []ccache.Credential{{
+			Client:      client,
+			Server:      server,
+			Key:         ccache.Keyblock{EType: uint16(c.sessionEType), KeyValue: c.sessionKey},
+			AuthTime:    unixU32(c.tgtEnc.AuthTime),
+			StartTime:   unixU32(start),
+			EndTime:     unixU32(c.tgtEnc.EndTime),
+			RenewTill:   unixU32(c.tgtEnc.RenewTill),
+			TicketFlags: flagsToUint32(c.tgtEnc.Flags),
+			Ticket:      c.tgtTicketRaw,
+		}},
+	}, nil
+}
+
+// unixU32 returns t as Unix seconds in a uint32, or 0 for the zero time (rather
+// than the wrapped negative value uint32(-6795...) would give).
+func unixU32(t time.Time) uint32 {
+	if t.IsZero() {
+		return 0
+	}
+	return uint32(t.Unix())
+}
+
+// flagsToUint32 converts a KerberosFlags BIT STRING (bit 0 = MSB of the first
+// octet) to the big-endian uint32 that the ccache ticket_flags field uses. A
+// short or over-long byte slice is padded/truncated to exactly 4 bytes.
+func flagsToUint32(flags asn1.BitString) uint32 {
+	var b [4]byte
+	copy(b[:], flags.Bytes)
+	return binary.BigEndian.Uint32(b[:])
+}

--- a/network/kerberos/v5/export_test.go
+++ b/network/kerberos/v5/export_test.go
@@ -1,0 +1,109 @@
+package kerberos
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/credcache/ccache"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/credcache/kirbi"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/messages"
+)
+
+// fakeTGTClient returns a client whose TGT fields are populated by hand, so the
+// export path can be exercised without a live KDC.
+func fakeTGTClient(t *testing.T) *KerberosClient {
+	t.Helper()
+	tkt := messages.Ticket{
+		TktVno:  messages.KerberosV5,
+		Realm:   "CORP.LOCAL",
+		SName:   messages.PrincipalName{NameType: messages.NameTypeSRVInst, NameString: []string{"krbtgt", "CORP.LOCAL"}},
+		EncPart: messages.EncryptedData{EType: messages.ETypeAES256CTSHMACSHA196, Cipher: bytes.Repeat([]byte{0xAB}, 32)},
+	}
+	raw, err := tkt.Marshal()
+	if err != nil {
+		t.Fatalf("Ticket.Marshal: %v", err)
+	}
+	c := NewClient("alice", "corp.local", "10.0.0.1").WithPassword("x")
+	c.tgtTicket = tkt
+	c.tgtTicketRaw = raw
+	c.sessionKey = bytes.Repeat([]byte{0x11}, 32)
+	c.sessionEType = messages.ETypeAES256CTSHMACSHA196
+	c.tgtEnc = messages.EncASRepPart{
+		Flags:     messages.NewKerberosFlags(messages.TicketFlagForwardable, messages.TicketFlagRenewable, messages.TicketFlagInitial),
+		AuthTime:  time.Date(2026, 7, 9, 10, 0, 0, 0, time.UTC),
+		EndTime:   time.Date(2026, 7, 9, 20, 0, 0, 0, time.UTC),
+		RenewTill: time.Date(2026, 7, 16, 10, 0, 0, 0, time.UTC),
+		SRealm:    "CORP.LOCAL",
+		SName:     messages.PrincipalName{NameType: messages.NameTypeSRVInst, NameString: []string{"krbtgt", "CORP.LOCAL"}},
+	}
+	c.hasTGT = true
+	return c
+}
+
+func TestExportTGTKirbi(t *testing.T) {
+	c := fakeTGTClient(t)
+	blob, err := c.ExportTGTKirbi()
+	if err != nil {
+		t.Fatalf("ExportTGTKirbi: %v", err)
+	}
+	cred, err := kirbi.Parse(blob)
+	if err != nil {
+		t.Fatalf("kirbi.Parse: %v", err)
+	}
+	if len(cred.Tickets) != 1 || cred.Tickets[0].Realm != "CORP.LOCAL" {
+		t.Fatalf("exported kirbi tickets wrong: %+v", cred.Tickets)
+	}
+	infos, err := kirbi.TicketInfo(cred)
+	if err != nil {
+		t.Fatalf("TicketInfo: %v", err)
+	}
+	if infos[0].PName.NameString[0] != "alice" || !bytes.Equal(infos[0].Key.KeyValue, c.sessionKey) {
+		t.Errorf("exported kirbi info wrong: %+v", infos[0])
+	}
+	if !infos[0].EndTime.Equal(c.tgtEnc.EndTime) {
+		t.Errorf("endtime mismatch: %v vs %v", infos[0].EndTime, c.tgtEnc.EndTime)
+	}
+}
+
+func TestExportTGTCCache(t *testing.T) {
+	c := fakeTGTClient(t)
+	cc, err := c.ExportTGTCCache()
+	if err != nil {
+		t.Fatalf("ExportTGTCCache: %v", err)
+	}
+	blob, err := cc.Marshal()
+	if err != nil {
+		t.Fatalf("ccache.Marshal: %v", err)
+	}
+	got, err := ccache.Unmarshal(blob)
+	if err != nil {
+		t.Fatalf("ccache.Unmarshal: %v", err)
+	}
+	if got.DefaultPrincipal.Realm != "CORP.LOCAL" || got.DefaultPrincipal.Components[0] != "alice" {
+		t.Errorf("default principal wrong: %+v", got.DefaultPrincipal)
+	}
+	if len(got.Credentials) != 1 {
+		t.Fatalf("credential count: %d", len(got.Credentials))
+	}
+	cr := got.Credentials[0]
+	if cr.Server.Components[0] != "krbtgt" || cr.Key.EType != uint16(messages.ETypeAES256CTSHMACSHA196) {
+		t.Errorf("credential fields wrong: %+v", cr)
+	}
+	if uint32(c.tgtEnc.EndTime.Unix()) != cr.EndTime {
+		t.Errorf("endtime mismatch: %d vs %d", cr.EndTime, c.tgtEnc.EndTime.Unix())
+	}
+	if !bytes.Equal(cr.Ticket, c.tgtTicketRaw) {
+		t.Errorf("ticket bytes not preserved")
+	}
+}
+
+func TestExportRequiresTGT(t *testing.T) {
+	c := NewClient("alice", "corp.local", "10.0.0.1").WithPassword("x")
+	if _, err := c.ExportTGTKirbi(); err == nil {
+		t.Error("expected error exporting without a TGT")
+	}
+	if _, err := c.ExportTGTCCache(); err == nil {
+		t.Error("expected error exporting without a TGT")
+	}
+}


### PR DESCRIPTION
## Summary

Phase 3 of the native, standard-library-only Kerberos v5 implementation. Adds the credential abstraction, the two on-disk credential-cache formats, and wires both into the client — enabling overpass-the-hash, pass-the-key, and ticket export. No external dependencies are added.

**Stacked on #898** (`kerberos-native`); this PR's base is `kerberos-native` and will retarget to `main` once #898 merges. Review only the three commits unique to this branch.

## Changes

**credentials (commit d88bd485)**
- A single `Credential` type over three long-term secret forms: password (string-to-key, any etype), NT hash (the RC4-HMAC key directly — overpass-the-hash), and a raw AES key (etype 17/18 — pass-the-key). `Key(etype, salt, s2kparams)`, `SupportedETypes()`, `DefaultSalt()`, plus hex and `LM:NT` parsing. Deriving an etype the secret cannot satisfy is rejected.

**credcache/{kirbi,ccache} (commit e928ab03)**
- `kirbi`: a `.kirbi` file is a DER-encoded KRB-CRED; parse/build/load/save, with the EncKrbCredPart stored unencrypted (etype 0) as Rubeus does.
- `ccache`: MIT FILE cache format version 4 (big-endian, tagged header, single-enctype keyblock, credential sequence to EOF); bounds-checked reader, marshal/unmarshal, load/save.

**client wiring + export (commit 9b972f10)**
- Client holds a `Credential`; `WithPassword`/`WithCredential`/`WithNTHash`/`WithAESKey`. Key derivation, the AS-REQ etype list, and PREAUTH_REQUIRED etype selection are all driven by the credential (an NT-hash client requests RC4, never an unusable AES etype).
- `ExportTGTKirbi` and `ExportTGTCCache` serialize an acquired TGT for pass-the-ticket / interchange.

## How Verified

- Unit tests: `credentials` (password-RC4 key equals `NTHash(password)`, overpass/pass-the-key constraints, LM:NT parsing, validation); `kirbi` and `ccache` round-trips (including the full KRB-CRED nesting and a multi-credential ccache with addresses/authdata/delta-time/save-load); client export white-box tests that populate the TGT state and confirm `.kirbi`/ccache round-trip.
- `go test ./network/kerberos/...`, `go vet ./network/kerberos/...`, and `go build ./...` are green.

## Test Coverage

**Added:** `credentials/credentials_test.go`, `credcache/kirbi/kirbi_test.go`, `credcache/ccache/ccache_test.go`, `export_test.go`.

## Scope of Change

- **Files changed:** `network/kerberos/v5/{credentials,credcache,client.go,export.go}`.
- **Submodule pointer updated:** no.
- **Behavioral changes outside the new code:** the client's `password` field became a `Credential` (internal); `WithPassword` behaves as before. The unused `WithCCache` stub was removed.

## Notes

- Deferred to live-KDC validation: the structural split of `client.go` into `kdc/` + `transport/` packages (pure refactor of the live AS/TGS path, no unit-test net without a KDC), service-ticket (Kerberoast) export, ccache/kirbi import, and a keytab reader.
- ccache byte layout follows the MIT spec; cross-validation against `klist` is pending live testing.
