### PR TITLE
Native Kerberos v5: MS-KILE pre-auth payloads and MS-PAC signatures (phase 4)

### DIFF
--- a/network/kerberos/v5/client.go
+++ b/network/kerberos/v5/client.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/credentials"
 	kerbcrypto "github.com/TheManticoreProject/Manticore/network/kerberos/v5/crypto"
 	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/messages"
 )
@@ -29,13 +30,14 @@ type KerberosClient struct {
 	realm    string
 	kdcHost  string
 
-	password string
+	cred *credentials.Credential
 
 	// Populated after a successful GetTGT call.
 	tgtTicket    messages.Ticket
 	tgtTicketRaw []byte // raw APPLICATION[1] bytes as received from KDC
 	sessionKey   []byte
 	sessionEType int
+	tgtEnc       messages.EncASRepPart // decrypted AS-REP enc-part: times, flags, sname
 	hasTGT       bool
 }
 
@@ -50,17 +52,40 @@ func NewClient(username, realm, kdcHost string) *KerberosClient {
 	}
 }
 
-// WithPassword stores the password for use in GetTGT.
+// WithPassword configures a password credential for GetTGT.
 // Returns the client to allow fluent chaining.
 func (c *KerberosClient) WithPassword(password string) *KerberosClient {
-	c.password = password
+	c.cred = credentials.NewWithPassword(c.username, c.realm, password)
 	return c
 }
 
-// WithCCache is not yet supported in the native implementation.
-// Use the gokrb5-backed KerberosInit helper for ccache-based LDAP binds.
-func (c *KerberosClient) WithCCache(_ string) error {
-	return fmt.Errorf("kerberos: ccache not supported in native implementation; use gokrb5 KerberosInit for LDAP GSSAPI binds")
+// WithCredential configures an arbitrary credential (password, NT hash, or AES
+// key). Returns the client to allow fluent chaining.
+func (c *KerberosClient) WithCredential(cred *credentials.Credential) *KerberosClient {
+	c.cred = cred
+	return c
+}
+
+// WithNTHash configures an NT-hash (overpass-the-hash) credential from a hex
+// string (accepts an "LM:NT" pair). GetTGT will request an RC4-HMAC TGT.
+func (c *KerberosClient) WithNTHash(hexHash string) error {
+	cred, err := credentials.NewWithHexNTHash(c.username, c.realm, hexHash)
+	if err != nil {
+		return err
+	}
+	c.cred = cred
+	return nil
+}
+
+// WithAESKey configures a pass-the-key credential from a hex-encoded AES key
+// (16 bytes -> AES128, 32 bytes -> AES256).
+func (c *KerberosClient) WithAESKey(hexKey string) error {
+	cred, err := credentials.NewWithHexAESKey(c.username, c.realm, hexKey)
+	if err != nil {
+		return err
+	}
+	c.cred = cred
+	return nil
 }
 
 // GetTGT requests a Ticket Granting Ticket from the KDC using the password
@@ -71,14 +96,14 @@ func (c *KerberosClient) WithCCache(_ string) error {
 // (realm+username). If the KDC returns PREAUTH_REQUIRED with different
 // etype/salt info, we retry once with the corrected values.
 func (c *KerberosClient) GetTGT() error {
-	if c.password == "" {
-		return fmt.Errorf("kerberos: no credentials configured: call WithPassword first")
+	if c.cred == nil {
+		return fmt.Errorf("kerberos: no credentials configured: call WithPassword/WithNTHash/WithAESKey/WithCredential first")
 	}
 
-	// Attempt with default AD salt. The KDC may respond with PREAUTH_REQUIRED
-	// if a different salt or etype is required.
-	etype := messages.ETypeAES256CTSHMACSHA196
-	salt := c.realm + c.username
+	// Start with the strongest etype the credential can satisfy and the AD
+	// default salt. The KDC corrects both via PREAUTH_REQUIRED if needed.
+	etype := c.cred.SupportedETypes()[0]
+	salt := c.cred.DefaultSalt()
 	resp, nonce, err := c.sendASReqWithPreauth(etype, salt, nil)
 	if err != nil {
 		return err
@@ -218,7 +243,9 @@ func (c *KerberosClient) Destroy() {
 		c.sessionKey[i] = 0
 	}
 	c.sessionKey = nil
-	c.password = ""
+	if c.cred != nil {
+		c.cred.Destroy()
+	}
 	c.hasTGT = false
 }
 
@@ -256,11 +283,7 @@ func (c *KerberosClient) sendASReq(pa_data []messages.PAData) ([]byte, int, erro
 			},
 			Till:  time.Now().UTC().Add(24 * time.Hour),
 			Nonce: nonce,
-			EType: []int{
-				messages.ETypeAES256CTSHMACSHA196,
-				messages.ETypeAES128CTSHMACSHA196,
-				messages.ETypeRC4HMAC,
-			},
+			EType: c.cred.SupportedETypes(),
 		},
 	}
 
@@ -279,8 +302,9 @@ func (c *KerberosClient) sendASReq(pa_data []messages.PAData) ([]byte, int, erro
 // PA-ETYPE-INFO2 structure embedded in a KRBError's EData.
 // Falls back to AES-256 with the default AD salt if no EData is present.
 func (c *KerberosClient) pickETypeFromError(krb_err messages.KRBError) (int, string, []byte) {
-	default_salt := c.realm + c.username
-	default_etype := messages.ETypeAES256CTSHMACSHA196
+	preferred := c.cred.SupportedETypes()
+	default_salt := c.cred.DefaultSalt()
+	default_etype := preferred[0]
 
 	if len(krb_err.EData) == 0 {
 		return default_etype, default_salt, nil
@@ -294,7 +318,7 @@ func (c *KerberosClient) pickETypeFromError(krb_err messages.KRBError) (int, str
 			if pa.PADataType == messages.PAETypeInfo2 {
 				var info messages.ETypeInfo2
 				if _, err := info.Unmarshal(pa.PADataValue); err == nil && len(info) > 0 {
-					return pickBestEType(info, default_salt)
+					return pickBestEType(info, preferred, default_salt)
 				}
 			}
 		}
@@ -303,20 +327,17 @@ func (c *KerberosClient) pickETypeFromError(krb_err messages.KRBError) (int, str
 	// Try to parse EData directly as ETYPE-INFO2.
 	var info messages.ETypeInfo2
 	if _, err := info.Unmarshal(krb_err.EData); err == nil && len(info) > 0 {
-		return pickBestEType(info, default_salt)
+		return pickBestEType(info, preferred, default_salt)
 	}
 
 	return default_etype, default_salt, nil
 }
 
-// pickBestEType selects the strongest supported etype from an ETypeInfo2 list.
-func pickBestEType(info messages.ETypeInfo2, default_salt string) (int, string, []byte) {
-	// Preference order: AES256 > AES128 > RC4.
-	preferred := []int{
-		messages.ETypeAES256CTSHMACSHA196,
-		messages.ETypeAES128CTSHMACSHA196,
-		messages.ETypeRC4HMAC,
-	}
+// pickBestEType selects, from an ETYPE-INFO2 list, the strongest etype the
+// credential can actually satisfy (preferred is the credential's supported set
+// in strength order). This prevents choosing, say, AES when only an NT hash is
+// held.
+func pickBestEType(info messages.ETypeInfo2, preferred []int, default_salt string) (int, string, []byte) {
 	for _, want := range preferred {
 		for _, entry := range info {
 			if entry.EType == want {
@@ -328,20 +349,17 @@ func pickBestEType(info messages.ETypeInfo2, default_salt string) (int, string, 
 			}
 		}
 	}
-	// Fallback to first entry.
-	e := info[0]
-	if e.Salt == "" {
-		e.Salt = default_salt
-	}
-	return e.EType, e.Salt, e.S2KParams
+	// No advertised etype is supported by the credential; fall back to the
+	// credential's strongest etype with the default salt.
+	return preferred[0], default_salt, nil
 }
 
 // sendASReqWithPreauth builds and sends an AS-REQ with PA-ENC-TIMESTAMP.
 // Returns the raw KDC response bytes and the nonce placed in the request.
 func (c *KerberosClient) sendASReqWithPreauth(etype int, salt string, s2k_params []byte) ([]byte, int, error) {
-	key, err := kerbcrypto.StringToKey(etype, c.password, salt, s2k_params)
+	key, err := c.cred.Key(etype, salt, s2k_params)
 	if err != nil {
-		return nil, 0, fmt.Errorf("kerberos: StringToKey: %w", err)
+		return nil, 0, fmt.Errorf("kerberos: derive key: %w", err)
 	}
 
 	now := time.Now().UTC()
@@ -396,9 +414,9 @@ func (c *KerberosClient) processASRep(resp []byte, etype int, salt string, s2k_p
 		return fmt.Errorf("kerberos: parse AS-REP: %w", err)
 	}
 
-	key, err := kerbcrypto.StringToKey(etype, c.password, salt, s2k_params)
+	key, err := c.cred.Key(etype, salt, s2k_params)
 	if err != nil {
-		return fmt.Errorf("kerberos: StringToKey for AS-REP decrypt: %w", err)
+		return fmt.Errorf("kerberos: derive key for AS-REP decrypt: %w", err)
 	}
 
 	enc_plain, err := kerbcrypto.Decrypt(etype, key, kerbcrypto.KeyUsageASRepEncPart, as_rep.EncPart.Cipher)
@@ -422,6 +440,7 @@ func (c *KerberosClient) processASRep(resp []byte, etype int, salt string, s2k_p
 	c.tgtTicketRaw = as_rep.TicketRaw
 	c.sessionKey = enc_as_rep.Key.KeyValue
 	c.sessionEType = enc_as_rep.Key.KeyType
+	c.tgtEnc = enc_as_rep
 	c.hasTGT = true
 	return nil
 }

--- a/network/kerberos/v5/credcache/ccache/ccache.go
+++ b/network/kerberos/v5/credcache/ccache/ccache.go
@@ -1,0 +1,373 @@
+// Package ccache reads and writes the MIT Kerberos FILE credential cache
+// (KRB5CCNAME) in format version 4, the interchange format used by Linux
+// Kerberos tooling and Impacket. Version 4 is big-endian throughout and is
+// documented at
+// https://web.mit.edu/kerberos/krb5-latest/doc/formats/ccache_file_format.html.
+//
+// Layout: a two-byte version tag (0x05 0x04), a tagged header, the default
+// client principal, then a sequence of credential entries running to EOF (no
+// count, no terminator). This package implements the wire format; building
+// entries from a live TGT/ST is done by the client layer.
+package ccache
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+)
+
+// Version4 is the file_format_version this package reads and writes.
+const Version4 = 0x0504
+
+// headerTagDeltaTime is the only defined v4 header field: two uint32s (seconds,
+// microseconds) giving the KDC-relative time offset.
+const headerTagDeltaTime = 1
+
+// Principal is a cache principal (client or server).
+type Principal struct {
+	NameType   uint32
+	Realm      string
+	Components []string
+}
+
+// Keyblock is a session key with its encryption type.
+type Keyblock struct {
+	EType    uint16
+	KeyValue []byte
+}
+
+// Address is a host address entry.
+type Address struct {
+	AddrType uint16
+	Data     []byte
+}
+
+// AuthData is an authorization-data entry.
+type AuthData struct {
+	ADType uint16
+	Data   []byte
+}
+
+// Credential is one cached ticket. Times are Unix seconds (uint32) as stored on
+// the wire; TicketFlags uses the RFC 4120 ticket-flag bit layout (bit 0 = MSB).
+type Credential struct {
+	Client       Principal
+	Server       Principal
+	Key          Keyblock
+	AuthTime     uint32
+	StartTime    uint32
+	EndTime      uint32
+	RenewTill    uint32
+	IsSKey       bool
+	TicketFlags  uint32
+	Addresses    []Address
+	AuthData     []AuthData
+	Ticket       []byte
+	SecondTicket []byte
+}
+
+// CCache is a parsed credential cache.
+type CCache struct {
+	// DeltaTime is the optional KDC time offset (seconds, microseconds). Zero
+	// means no delta-time header field is written.
+	DeltaTimeSecs    uint32
+	DeltaTimeUsecs   uint32
+	DefaultPrincipal Principal
+	Credentials      []Credential
+}
+
+// ── marshaling ──────────────────────────────────────────────────────────────
+
+func putData(buf *bytes.Buffer, data []byte) {
+	var l [4]byte
+	binary.BigEndian.PutUint32(l[:], uint32(len(data)))
+	buf.Write(l[:])
+	buf.Write(data)
+}
+
+func putPrincipal(buf *bytes.Buffer, p Principal) {
+	var u [4]byte
+	binary.BigEndian.PutUint32(u[:], p.NameType)
+	buf.Write(u[:])
+	// count of components does NOT include the realm in v2+.
+	binary.BigEndian.PutUint32(u[:], uint32(len(p.Components)))
+	buf.Write(u[:])
+	putData(buf, []byte(p.Realm))
+	for _, c := range p.Components {
+		putData(buf, []byte(c))
+	}
+}
+
+func putU16(buf *bytes.Buffer, v uint16) {
+	var b [2]byte
+	binary.BigEndian.PutUint16(b[:], v)
+	buf.Write(b[:])
+}
+
+func putU32(buf *bytes.Buffer, v uint32) {
+	var b [4]byte
+	binary.BigEndian.PutUint32(b[:], v)
+	buf.Write(b[:])
+}
+
+func putCredential(buf *bytes.Buffer, c Credential) {
+	putPrincipal(buf, c.Client)
+	putPrincipal(buf, c.Server)
+	// keyblock: v4 has a single enctype field followed by the key data.
+	putU16(buf, c.Key.EType)
+	putData(buf, c.Key.KeyValue)
+	putU32(buf, c.AuthTime)
+	putU32(buf, c.StartTime)
+	putU32(buf, c.EndTime)
+	putU32(buf, c.RenewTill)
+	if c.IsSKey {
+		buf.WriteByte(1)
+	} else {
+		buf.WriteByte(0)
+	}
+	putU32(buf, c.TicketFlags)
+	putU32(buf, uint32(len(c.Addresses)))
+	for _, a := range c.Addresses {
+		putU16(buf, a.AddrType)
+		putData(buf, a.Data)
+	}
+	putU32(buf, uint32(len(c.AuthData)))
+	for _, a := range c.AuthData {
+		putU16(buf, a.ADType)
+		putData(buf, a.Data)
+	}
+	putData(buf, c.Ticket)
+	putData(buf, c.SecondTicket)
+}
+
+// Marshal encodes the cache in ccache format version 4.
+func (cc *CCache) Marshal() ([]byte, error) {
+	var buf bytes.Buffer
+	putU16(&buf, Version4)
+
+	// Header: only the delta-time field, and only if set.
+	var hdr bytes.Buffer
+	if cc.DeltaTimeSecs != 0 || cc.DeltaTimeUsecs != 0 {
+		putU16(&hdr, headerTagDeltaTime)
+		putU16(&hdr, 8)
+		putU32(&hdr, cc.DeltaTimeSecs)
+		putU32(&hdr, cc.DeltaTimeUsecs)
+	}
+	putU16(&buf, uint16(hdr.Len()))
+	buf.Write(hdr.Bytes())
+
+	putPrincipal(&buf, cc.DefaultPrincipal)
+	for i := range cc.Credentials {
+		putCredential(&buf, cc.Credentials[i])
+	}
+	return buf.Bytes(), nil
+}
+
+// ── unmarshaling ──────────────────────────────────────────────────────────────
+
+// reader is a bounds-checked big-endian cursor over the cache bytes.
+type reader struct {
+	b   []byte
+	pos int
+}
+
+func (r *reader) need(n int) error {
+	if r.pos+n > len(r.b) {
+		return fmt.Errorf("ccache: truncated: need %d bytes at offset %d of %d", n, r.pos, len(r.b))
+	}
+	return nil
+}
+
+func (r *reader) u16() (uint16, error) {
+	if err := r.need(2); err != nil {
+		return 0, err
+	}
+	v := binary.BigEndian.Uint16(r.b[r.pos:])
+	r.pos += 2
+	return v, nil
+}
+
+func (r *reader) u32() (uint32, error) {
+	if err := r.need(4); err != nil {
+		return 0, err
+	}
+	v := binary.BigEndian.Uint32(r.b[r.pos:])
+	r.pos += 4
+	return v, nil
+}
+
+func (r *reader) u8() (byte, error) {
+	if err := r.need(1); err != nil {
+		return 0, err
+	}
+	v := r.b[r.pos]
+	r.pos++
+	return v, nil
+}
+
+func (r *reader) data() ([]byte, error) {
+	n, err := r.u32()
+	if err != nil {
+		return nil, err
+	}
+	if err := r.need(int(n)); err != nil {
+		return nil, err
+	}
+	out := make([]byte, n)
+	copy(out, r.b[r.pos:r.pos+int(n)])
+	r.pos += int(n)
+	return out, nil
+}
+
+func (r *reader) principal() (Principal, error) {
+	var p Principal
+	nt, err := r.u32()
+	if err != nil {
+		return p, err
+	}
+	p.NameType = nt
+	n, err := r.u32()
+	if err != nil {
+		return p, err
+	}
+	realm, err := r.data()
+	if err != nil {
+		return p, err
+	}
+	p.Realm = string(realm)
+	for i := uint32(0); i < n; i++ {
+		c, err := r.data()
+		if err != nil {
+			return p, err
+		}
+		p.Components = append(p.Components, string(c))
+	}
+	return p, nil
+}
+
+func (r *reader) credential() (Credential, error) {
+	var c Credential
+	var err error
+	if c.Client, err = r.principal(); err != nil {
+		return c, err
+	}
+	if c.Server, err = r.principal(); err != nil {
+		return c, err
+	}
+	if c.Key.EType, err = r.u16(); err != nil {
+		return c, err
+	}
+	if c.Key.KeyValue, err = r.data(); err != nil {
+		return c, err
+	}
+	if c.AuthTime, err = r.u32(); err != nil {
+		return c, err
+	}
+	if c.StartTime, err = r.u32(); err != nil {
+		return c, err
+	}
+	if c.EndTime, err = r.u32(); err != nil {
+		return c, err
+	}
+	if c.RenewTill, err = r.u32(); err != nil {
+		return c, err
+	}
+	skey, err := r.u8()
+	if err != nil {
+		return c, err
+	}
+	c.IsSKey = skey != 0
+	if c.TicketFlags, err = r.u32(); err != nil {
+		return c, err
+	}
+	nAddr, err := r.u32()
+	if err != nil {
+		return c, err
+	}
+	for i := uint32(0); i < nAddr; i++ {
+		at, err := r.u16()
+		if err != nil {
+			return c, err
+		}
+		d, err := r.data()
+		if err != nil {
+			return c, err
+		}
+		c.Addresses = append(c.Addresses, Address{AddrType: at, Data: d})
+	}
+	nAD, err := r.u32()
+	if err != nil {
+		return c, err
+	}
+	for i := uint32(0); i < nAD; i++ {
+		adt, err := r.u16()
+		if err != nil {
+			return c, err
+		}
+		d, err := r.data()
+		if err != nil {
+			return c, err
+		}
+		c.AuthData = append(c.AuthData, AuthData{ADType: adt, Data: d})
+	}
+	if c.Ticket, err = r.data(); err != nil {
+		return c, err
+	}
+	if c.SecondTicket, err = r.data(); err != nil {
+		return c, err
+	}
+	return c, nil
+}
+
+// Unmarshal parses a ccache. Only format version 4 is supported.
+func Unmarshal(data []byte) (*CCache, error) {
+	r := &reader{b: data}
+	ver, err := r.u16()
+	if err != nil {
+		return nil, err
+	}
+	if ver != Version4 {
+		return nil, fmt.Errorf("ccache: unsupported version 0x%04x (only 0x%04x/v4 supported)", ver, Version4)
+	}
+
+	cc := &CCache{}
+	hdrLen, err := r.u16()
+	if err != nil {
+		return nil, err
+	}
+	if err := r.need(int(hdrLen)); err != nil {
+		return nil, err
+	}
+	hdrEnd := r.pos + int(hdrLen)
+	for r.pos < hdrEnd {
+		tag, err := r.u16()
+		if err != nil {
+			return nil, err
+		}
+		flen, err := r.u16()
+		if err != nil {
+			return nil, err
+		}
+		if err := r.need(int(flen)); err != nil {
+			return nil, err
+		}
+		if tag == headerTagDeltaTime && flen == 8 {
+			cc.DeltaTimeSecs = binary.BigEndian.Uint32(r.b[r.pos:])
+			cc.DeltaTimeUsecs = binary.BigEndian.Uint32(r.b[r.pos+4:])
+		}
+		r.pos += int(flen) // skip unknown/known field body
+	}
+	r.pos = hdrEnd
+
+	if cc.DefaultPrincipal, err = r.principal(); err != nil {
+		return nil, err
+	}
+	for r.pos < len(data) {
+		cred, err := r.credential()
+		if err != nil {
+			return nil, err
+		}
+		cc.Credentials = append(cc.Credentials, cred)
+	}
+	return cc, nil
+}

--- a/network/kerberos/v5/credcache/ccache/ccache_test.go
+++ b/network/kerberos/v5/credcache/ccache/ccache_test.go
@@ -1,0 +1,126 @@
+package ccache
+
+import (
+	"bytes"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func sampleCache() *CCache {
+	return &CCache{
+		DeltaTimeSecs: 42,
+		DefaultPrincipal: Principal{
+			NameType:   1,
+			Realm:      "CORP.LOCAL",
+			Components: []string{"alice"},
+		},
+		Credentials: []Credential{
+			{
+				Client:      Principal{NameType: 1, Realm: "CORP.LOCAL", Components: []string{"alice"}},
+				Server:      Principal{NameType: 2, Realm: "CORP.LOCAL", Components: []string{"krbtgt", "CORP.LOCAL"}},
+				Key:         Keyblock{EType: 18, KeyValue: bytes.Repeat([]byte{0xAB}, 32)},
+				AuthTime:    1_700_000_000,
+				StartTime:   1_700_000_000,
+				EndTime:     1_700_036_000,
+				RenewTill:   1_700_600_000,
+				IsSKey:      false,
+				TicketFlags: 0x50e00000, // forwardable+renewable+initial+pre-authent style bits
+				Ticket:      bytes.Repeat([]byte{0x01, 0x02}, 20),
+			},
+			{
+				Client:       Principal{NameType: 1, Realm: "CORP.LOCAL", Components: []string{"alice"}},
+				Server:       Principal{NameType: 2, Realm: "CORP.LOCAL", Components: []string{"cifs", "dc01.corp.local"}},
+				Key:          Keyblock{EType: 23, KeyValue: bytes.Repeat([]byte{0xCD}, 16)},
+				EndTime:      1_700_036_000,
+				TicketFlags:  0x40a00000,
+				Addresses:    []Address{{AddrType: 2, Data: []byte{10, 0, 0, 1}}},
+				AuthData:     []AuthData{{ADType: 1, Data: []byte{9, 9, 9}}},
+				Ticket:       []byte("service-ticket-bytes"),
+				SecondTicket: []byte{},
+			},
+		},
+	}
+}
+
+func TestCCacheRoundtrip(t *testing.T) {
+	orig := sampleCache()
+	b, err := orig.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	// Version tag must be 05 04.
+	if b[0] != 0x05 || b[1] != 0x04 {
+		t.Fatalf("version tag = % X, want 05 04", b[:2])
+	}
+	got, err := Unmarshal(b)
+	if err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if !reflect.DeepEqual(orig.DefaultPrincipal, got.DefaultPrincipal) {
+		t.Errorf("default principal mismatch:\n got %+v\n want %+v", got.DefaultPrincipal, orig.DefaultPrincipal)
+	}
+	if got.DeltaTimeSecs != orig.DeltaTimeSecs {
+		t.Errorf("delta-time secs: got %d, want %d", got.DeltaTimeSecs, orig.DeltaTimeSecs)
+	}
+	if len(got.Credentials) != len(orig.Credentials) {
+		t.Fatalf("credential count: got %d, want %d", len(got.Credentials), len(orig.Credentials))
+	}
+	for i := range orig.Credentials {
+		// Normalize nil vs empty slice for the comparison of the second_ticket.
+		if len(got.Credentials[i].SecondTicket) == 0 {
+			got.Credentials[i].SecondTicket = orig.Credentials[i].SecondTicket
+		}
+		if !reflect.DeepEqual(got.Credentials[i], orig.Credentials[i]) {
+			t.Errorf("credential[%d] mismatch:\n got  %+v\n want %+v", i, got.Credentials[i], orig.Credentials[i])
+		}
+	}
+}
+
+func TestCCacheSaveLoad(t *testing.T) {
+	orig := sampleCache()
+	path := filepath.Join(t.TempDir(), "krb5cc_test")
+	if err := orig.Save(path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got.DefaultPrincipal.Realm != "CORP.LOCAL" || len(got.Credentials) != 2 {
+		t.Errorf("loaded cache wrong: %+v", got)
+	}
+	// The TGT's server must be krbtgt/CORP.LOCAL.
+	tgt := got.Credentials[0].Server
+	if len(tgt.Components) != 2 || tgt.Components[0] != "krbtgt" {
+		t.Errorf("TGT server principal wrong: %+v", tgt)
+	}
+}
+
+func TestCCacheRejectsWrongVersion(t *testing.T) {
+	if _, err := Unmarshal([]byte{0x05, 0x03, 0x00, 0x00}); err == nil {
+		t.Error("expected error for version 3 cache")
+	}
+	if _, err := Unmarshal([]byte{0x05}); err == nil {
+		t.Error("expected error for truncated input")
+	}
+}
+
+func TestCCacheEmptyHeaderNoDelta(t *testing.T) {
+	cc := &CCache{DefaultPrincipal: Principal{NameType: 1, Realm: "R", Components: []string{"u"}}}
+	b, err := cc.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// header length (bytes 2-3) must be 0 when no delta-time is set.
+	if b[2] != 0 || b[3] != 0 {
+		t.Errorf("expected empty header, got header len % X", b[2:4])
+	}
+	got, err := Unmarshal(b)
+	if err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got.DefaultPrincipal.Realm != "R" {
+		t.Errorf("principal round-trip failed: %+v", got.DefaultPrincipal)
+	}
+}

--- a/network/kerberos/v5/credcache/ccache/io.go
+++ b/network/kerberos/v5/credcache/ccache/io.go
@@ -1,0 +1,27 @@
+package ccache
+
+import (
+	"fmt"
+	"os"
+)
+
+// Save writes the cache to path in ccache v4 format, mode 0600.
+func (cc *CCache) Save(path string) error {
+	b, err := cc.Marshal()
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(path, b, 0o600); err != nil {
+		return fmt.Errorf("ccache: write %s: %w", path, err)
+	}
+	return nil
+}
+
+// Load reads and parses a ccache file.
+func Load(path string) (*CCache, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("ccache: read %s: %w", path, err)
+	}
+	return Unmarshal(b)
+}

--- a/network/kerberos/v5/credcache/kirbi/kirbi.go
+++ b/network/kerberos/v5/credcache/kirbi/kirbi.go
@@ -1,0 +1,80 @@
+// Package kirbi reads and writes ".kirbi" credential files. A .kirbi file is a
+// DER-encoded Kerberos KRB-CRED message (RFC 4120 Section 5.8.1) carrying one
+// or more tickets — the interchange format used by Rubeus and (via -k) Impacket
+// for pass-the-ticket. By convention the EncKrbCredPart is stored unencrypted
+// with etype 0, so the session key and ticket metadata are in the clear.
+package kirbi
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/messages"
+)
+
+// Bytes returns the DER encoding of a KRB-CRED (the raw .kirbi contents).
+func Bytes(cred *messages.KRBCred) ([]byte, error) {
+	return cred.Marshal()
+}
+
+// Parse decodes .kirbi bytes into a KRB-CRED.
+func Parse(data []byte) (*messages.KRBCred, error) {
+	var c messages.KRBCred
+	if _, err := c.Unmarshal(data); err != nil {
+		return nil, fmt.Errorf("kirbi: parse: %w", err)
+	}
+	return &c, nil
+}
+
+// Save writes cred to path in .kirbi (DER KRB-CRED) form, 0600.
+func Save(path string, cred *messages.KRBCred) error {
+	b, err := Bytes(cred)
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(path, b, 0o600); err != nil {
+		return fmt.Errorf("kirbi: write %s: %w", path, err)
+	}
+	return nil
+}
+
+// Load reads and parses a .kirbi file.
+func Load(path string) (*messages.KRBCred, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("kirbi: read %s: %w", path, err)
+	}
+	return Parse(b)
+}
+
+// New builds a KRB-CRED wrapping a single ticket, with the EncKrbCredPart stored
+// unencrypted (etype 0) as .kirbi conventionally does. ticketRaw is the raw
+// APPLICATION[1] ticket TLV as issued by the KDC; info carries the session key,
+// principal names, flags, and times for that ticket.
+func New(ticketRaw []byte, info messages.KrbCredInfo) (*messages.KRBCred, error) {
+	enc := messages.EncKrbCredPart{TicketInfo: []messages.KrbCredInfo{info}}
+	encBytes, err := enc.Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("kirbi: marshal enc-part: %w", err)
+	}
+	return &messages.KRBCred{
+		PVNO:       messages.KerberosV5,
+		MsgType:    messages.MsgTypeKRBCred,
+		TicketsRaw: [][]byte{ticketRaw},
+		EncPart:    messages.EncryptedData{EType: 0, Cipher: encBytes},
+	}, nil
+}
+
+// TicketInfo decodes and returns the EncKrbCredPart ticket-info entries from a
+// KRB-CRED whose enc-part is stored unencrypted (etype 0), the .kirbi
+// convention. It errors if the enc-part is encrypted (etype != 0).
+func TicketInfo(cred *messages.KRBCred) ([]messages.KrbCredInfo, error) {
+	if cred.EncPart.EType != 0 {
+		return nil, fmt.Errorf("kirbi: enc-part is encrypted (etype %d); cannot read without a key", cred.EncPart.EType)
+	}
+	var enc messages.EncKrbCredPart
+	if _, err := enc.Unmarshal(cred.EncPart.Cipher); err != nil {
+		return nil, fmt.Errorf("kirbi: parse enc-part: %w", err)
+	}
+	return enc.TicketInfo, nil
+}

--- a/network/kerberos/v5/credcache/kirbi/kirbi_test.go
+++ b/network/kerberos/v5/credcache/kirbi/kirbi_test.go
@@ -1,0 +1,117 @@
+package kirbi
+
+import (
+	"bytes"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/messages"
+)
+
+func sampleTicketAndInfo(t *testing.T) ([]byte, messages.KrbCredInfo) {
+	t.Helper()
+	tkt := messages.Ticket{
+		TktVno:  messages.KerberosV5,
+		Realm:   "CORP.LOCAL",
+		SName:   messages.PrincipalName{NameType: messages.NameTypeSRVInst, NameString: []string{"krbtgt", "CORP.LOCAL"}},
+		EncPart: messages.EncryptedData{EType: messages.ETypeAES256CTSHMACSHA196, Cipher: bytes.Repeat([]byte{0xAB}, 32)},
+	}
+	raw, err := tkt.Marshal()
+	if err != nil {
+		t.Fatalf("Ticket.Marshal: %v", err)
+	}
+	info := messages.KrbCredInfo{
+		Key:       messages.EncryptionKey{KeyType: messages.ETypeAES256CTSHMACSHA196, KeyValue: bytes.Repeat([]byte{0x11}, 32)},
+		PRealm:    "CORP.LOCAL",
+		PName:     messages.PrincipalName{NameType: messages.NameTypePrincipal, NameString: []string{"alice"}},
+		Flags:     messages.NewKerberosFlags(messages.TicketFlagForwardable, messages.TicketFlagRenewable, messages.TicketFlagInitial),
+		AuthTime:  time.Date(2026, 7, 9, 10, 0, 0, 0, time.UTC),
+		EndTime:   time.Date(2026, 7, 9, 20, 0, 0, 0, time.UTC),
+		RenewTill: time.Date(2026, 7, 16, 10, 0, 0, 0, time.UTC),
+		SRealm:    "CORP.LOCAL",
+		SName:     messages.PrincipalName{NameType: messages.NameTypeSRVInst, NameString: []string{"krbtgt", "CORP.LOCAL"}},
+	}
+	return raw, info
+}
+
+func TestKirbiNewRoundtrip(t *testing.T) {
+	raw, info := sampleTicketAndInfo(t)
+
+	cred, err := New(raw, info)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if cred.EncPart.EType != 0 {
+		t.Errorf("enc-part should be unencrypted (etype 0), got %d", cred.EncPart.EType)
+	}
+
+	blob, err := Bytes(cred)
+	if err != nil {
+		t.Fatalf("Bytes: %v", err)
+	}
+	// Sanity: a .kirbi is an APPLICATION[22] (KRB-CRED) — first byte 0x76.
+	if blob[0] != 0x76 {
+		t.Errorf("kirbi should start with APPLICATION[22] tag 0x76, got 0x%02x", blob[0])
+	}
+
+	parsed, err := Parse(blob)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if len(parsed.Tickets) != 1 || parsed.Tickets[0].Realm != "CORP.LOCAL" {
+		t.Fatalf("parsed tickets wrong: %+v", parsed.Tickets)
+	}
+
+	infos, err := TicketInfo(parsed)
+	if err != nil {
+		t.Fatalf("TicketInfo: %v", err)
+	}
+	if len(infos) != 1 {
+		t.Fatalf("ticket-info count: got %d, want 1", len(infos))
+	}
+	got := infos[0]
+	if got.PName.NameString[0] != "alice" || got.SRealm != "CORP.LOCAL" {
+		t.Errorf("ticket-info fields wrong: %+v", got)
+	}
+	if !got.EndTime.Equal(info.EndTime) || !got.RenewTill.Equal(info.RenewTill) {
+		t.Errorf("time round-trip: end=%v renew=%v", got.EndTime, got.RenewTill)
+	}
+	if !bytes.Equal(got.Key.KeyValue, info.Key.KeyValue) {
+		t.Error("session key mismatch")
+	}
+}
+
+func TestKirbiSaveLoad(t *testing.T) {
+	raw, info := sampleTicketAndInfo(t)
+	cred, err := New(raw, info)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "ticket.kirbi")
+	if err := Save(path, cred); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(loaded.Tickets) != 1 {
+		t.Fatalf("loaded tickets: %d", len(loaded.Tickets))
+	}
+	// The raw ticket bytes must survive verbatim.
+	if !bytes.Equal(loaded.TicketsRaw[0], raw) {
+		t.Error("raw ticket bytes not preserved through save/load")
+	}
+}
+
+func TestTicketInfoRejectsEncrypted(t *testing.T) {
+	cred := &messages.KRBCred{
+		PVNO:    messages.KerberosV5,
+		MsgType: messages.MsgTypeKRBCred,
+		EncPart: messages.EncryptedData{EType: messages.ETypeAES256CTSHMACSHA196, Cipher: []byte{1, 2, 3}},
+	}
+	if _, err := TicketInfo(cred); err == nil {
+		t.Error("expected error reading ticket-info from an encrypted enc-part")
+	}
+}

--- a/network/kerberos/v5/credentials/credentials.go
+++ b/network/kerberos/v5/credentials/credentials.go
@@ -1,0 +1,209 @@
+// Package credentials models the long-term secret a Kerberos client
+// authenticates with, abstracting over the three forms Active Directory
+// tooling uses: a cleartext password, an NT hash (the RC4-HMAC key — enabling
+// overpass-the-hash), or a raw AES key (enabling pass-the-key). A Credential
+// turns any of these into the per-etype key material the AS/TGS exchanges need.
+package credentials
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	kerbcrypto "github.com/TheManticoreProject/Manticore/network/kerberos/v5/crypto"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/iana"
+)
+
+// SecretKind identifies which form of long-term secret a Credential holds.
+type SecretKind int
+
+const (
+	// SecretPassword is a cleartext password; keys of any supported etype can
+	// be derived from it via string-to-key.
+	SecretPassword SecretKind = iota
+	// SecretNTHash is the NT hash (MD4 of the UTF-16LE password), which is
+	// exactly the RC4-HMAC (etype 23) key — the basis of overpass-the-hash.
+	SecretNTHash
+	// SecretAESKey is a precomputed AES key for one specific etype (17 or 18),
+	// the basis of pass-the-key.
+	SecretAESKey
+)
+
+// Credential is an immutable long-term secret bound to a principal.
+type Credential struct {
+	username string
+	realm    string // always upper-cased
+
+	kind     SecretKind
+	password string
+	ntHash   []byte // 16 bytes, when kind == SecretNTHash
+	aesKey   []byte // 16 or 32 bytes, when kind == SecretAESKey
+	aesEtype int    // 17 or 18, when kind == SecretAESKey
+}
+
+// NewWithPassword creates a password-based credential. The realm is upper-cased.
+func NewWithPassword(username, realm, password string) *Credential {
+	return &Credential{
+		username: username,
+		realm:    strings.ToUpper(realm),
+		kind:     SecretPassword,
+		password: password,
+	}
+}
+
+// NewWithNTHash creates an NT-hash (overpass-the-hash) credential from a 16-byte
+// hash. The hash is copied.
+func NewWithNTHash(username, realm string, ntHash []byte) (*Credential, error) {
+	if len(ntHash) != 16 {
+		return nil, fmt.Errorf("credentials: NT hash must be 16 bytes, got %d", len(ntHash))
+	}
+	h := make([]byte, 16)
+	copy(h, ntHash)
+	return &Credential{
+		username: username,
+		realm:    strings.ToUpper(realm),
+		kind:     SecretNTHash,
+		ntHash:   h,
+	}, nil
+}
+
+// NewWithHexNTHash creates an NT-hash credential from a 32-character hex string
+// (optionally an "LM:NT" pair, in which case the NT half is used).
+func NewWithHexNTHash(username, realm, hexHash string) (*Credential, error) {
+	if i := strings.IndexByte(hexHash, ':'); i >= 0 {
+		hexHash = hexHash[i+1:] // accept "LMHASH:NTHASH", keep the NT half
+	}
+	hexHash = strings.TrimSpace(hexHash)
+	raw, err := hex.DecodeString(hexHash)
+	if err != nil {
+		return nil, fmt.Errorf("credentials: invalid hex NT hash: %w", err)
+	}
+	return NewWithNTHash(username, realm, raw)
+}
+
+// NewWithAESKey creates a pass-the-key credential from a raw AES key. etype must
+// be 17 (AES128, 16-byte key) or 18 (AES256, 32-byte key) and match the key
+// length. The key is copied.
+func NewWithAESKey(username, realm string, etype int, key []byte) (*Credential, error) {
+	var want int
+	switch etype {
+	case iana.ETypeAES128CTSHMACSHA196:
+		want = 16
+	case iana.ETypeAES256CTSHMACSHA196:
+		want = 32
+	default:
+		return nil, fmt.Errorf("credentials: AES key etype must be 17 or 18, got %d", etype)
+	}
+	if len(key) != want {
+		return nil, fmt.Errorf("credentials: etype %d requires a %d-byte key, got %d", etype, want, len(key))
+	}
+	k := make([]byte, want)
+	copy(k, key)
+	return &Credential{
+		username: username,
+		realm:    strings.ToUpper(realm),
+		kind:     SecretAESKey,
+		aesKey:   k,
+		aesEtype: etype,
+	}, nil
+}
+
+// NewWithHexAESKey creates a pass-the-key credential from a hex-encoded AES key.
+// The etype is inferred from the key length (16 bytes -> 17, 32 bytes -> 18).
+func NewWithHexAESKey(username, realm, hexKey string) (*Credential, error) {
+	raw, err := hex.DecodeString(strings.TrimSpace(hexKey))
+	if err != nil {
+		return nil, fmt.Errorf("credentials: invalid hex AES key: %w", err)
+	}
+	switch len(raw) {
+	case 16:
+		return NewWithAESKey(username, realm, iana.ETypeAES128CTSHMACSHA196, raw)
+	case 32:
+		return NewWithAESKey(username, realm, iana.ETypeAES256CTSHMACSHA196, raw)
+	default:
+		return nil, fmt.Errorf("credentials: AES key must be 16 or 32 bytes, got %d", len(raw))
+	}
+}
+
+// Username returns the principal's account name.
+func (c *Credential) Username() string { return c.username }
+
+// Realm returns the upper-cased realm.
+func (c *Credential) Realm() string { return c.realm }
+
+// Kind returns which form of secret this credential holds.
+func (c *Credential) Kind() SecretKind { return c.kind }
+
+// DefaultSalt returns the Active Directory default string-to-key salt for a user
+// account (UPPERCASE-REALM concatenated with the account name). The KDC may
+// advertise a different salt in PA-ETYPE-INFO2; prefer that when present.
+func (c *Credential) DefaultSalt() string {
+	return c.realm + c.username
+}
+
+// Key derives the long-term key for the requested etype.
+//
+//   - Password: string-to-key over (salt, s2kparams); any supported etype.
+//   - NT hash:  only etype 23 (RC4-HMAC); the hash itself is the key.
+//   - AES key:  only the etype the key was created for.
+//
+// It returns an error if the credential cannot produce a key of that etype
+// (e.g. an NT hash cannot yield an AES key).
+func (c *Credential) Key(etype int, salt string, s2kparams []byte) ([]byte, error) {
+	switch c.kind {
+	case SecretPassword:
+		return kerbcrypto.StringToKey(etype, c.password, salt, s2kparams)
+
+	case SecretNTHash:
+		if etype != iana.ETypeRC4HMAC {
+			return nil, fmt.Errorf("credentials: NT hash can only derive the RC4-HMAC (etype 23) key, not etype %d", etype)
+		}
+		out := make([]byte, len(c.ntHash))
+		copy(out, c.ntHash)
+		return out, nil
+
+	case SecretAESKey:
+		if etype != c.aesEtype {
+			return nil, fmt.Errorf("credentials: this AES key is etype %d, cannot derive etype %d", c.aesEtype, etype)
+		}
+		out := make([]byte, len(c.aesKey))
+		copy(out, c.aesKey)
+		return out, nil
+
+	default:
+		return nil, fmt.Errorf("credentials: unknown secret kind %d", c.kind)
+	}
+}
+
+// SupportedETypes returns the etypes this credential can produce keys for, in
+// KDC-preference order (strongest first). It is used to build the AS-REQ etype
+// list so the request advertises only etypes the client can actually complete.
+func (c *Credential) SupportedETypes() []int {
+	switch c.kind {
+	case SecretPassword:
+		return []int{
+			iana.ETypeAES256CTSHMACSHA196,
+			iana.ETypeAES128CTSHMACSHA196,
+			iana.ETypeRC4HMAC,
+		}
+	case SecretNTHash:
+		return []int{iana.ETypeRC4HMAC}
+	case SecretAESKey:
+		return []int{c.aesEtype}
+	default:
+		return nil
+	}
+}
+
+// Destroy zeroes the secret material held by the credential.
+func (c *Credential) Destroy() {
+	for i := range c.ntHash {
+		c.ntHash[i] = 0
+	}
+	for i := range c.aesKey {
+		c.aesKey[i] = 0
+	}
+	c.password = ""
+	c.ntHash = nil
+	c.aesKey = nil
+}

--- a/network/kerberos/v5/credentials/credentials_test.go
+++ b/network/kerberos/v5/credentials/credentials_test.go
@@ -1,0 +1,141 @@
+package credentials
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/crypto/nt"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/iana"
+)
+
+func TestPasswordKeyMatchesNTHashForRC4(t *testing.T) {
+	c := NewWithPassword("alice", "corp.local", "Sup3rSecret!")
+	if c.Realm() != "CORP.LOCAL" {
+		t.Fatalf("realm not upper-cased: %q", c.Realm())
+	}
+	got, err := c.Key(iana.ETypeRC4HMAC, "", nil)
+	if err != nil {
+		t.Fatalf("Key(RC4): %v", err)
+	}
+	want := nt.NTHash("Sup3rSecret!")
+	if !bytes.Equal(got, want[:]) {
+		t.Errorf("RC4 key %x != NT hash %x", got, want)
+	}
+}
+
+func TestPasswordDerivesAES(t *testing.T) {
+	c := NewWithPassword("alice", "CORP.LOCAL", "password")
+	k, err := c.Key(iana.ETypeAES256CTSHMACSHA196, c.DefaultSalt(), nil)
+	if err != nil {
+		t.Fatalf("Key(AES256): %v", err)
+	}
+	if len(k) != 32 {
+		t.Errorf("AES256 key length = %d, want 32", len(k))
+	}
+}
+
+func TestOverpassTheHash(t *testing.T) {
+	hashHex := "8846f7eaee8fb117ad06bdd830b7586c" // NT hash of "password"
+	c, err := NewWithHexNTHash("alice", "corp.local", hashHex)
+	if err != nil {
+		t.Fatalf("NewWithHexNTHash: %v", err)
+	}
+
+	// RC4 key is the hash itself.
+	rc4, err := c.Key(iana.ETypeRC4HMAC, "", nil)
+	if err != nil {
+		t.Fatalf("Key(RC4): %v", err)
+	}
+	want, _ := hex.DecodeString(hashHex)
+	if !bytes.Equal(rc4, want) {
+		t.Errorf("RC4 key %x != %s", rc4, hashHex)
+	}
+	// It should equal the NT hash of "password" (sanity vs the crypto layer).
+	if h := nt.NTHash("password"); !bytes.Equal(rc4, h[:]) {
+		t.Errorf("hash does not match NTHash(\"password\")")
+	}
+
+	// An NT hash cannot yield an AES key.
+	if _, err := c.Key(iana.ETypeAES256CTSHMACSHA196, "CORP.LOCALalice", nil); err == nil {
+		t.Error("expected error deriving AES key from NT hash")
+	}
+
+	if len(c.SupportedETypes()) != 1 || c.SupportedETypes()[0] != iana.ETypeRC4HMAC {
+		t.Errorf("NT-hash SupportedETypes = %v, want [23]", c.SupportedETypes())
+	}
+}
+
+func TestPassTheKey(t *testing.T) {
+	// Accepts LM:NT form and takes the NT half.
+	c, err := NewWithHexNTHash("bob", "CORP.LOCAL", "aad3b435b51404eeaad3b435b51404ee:8846f7eaee8fb117ad06bdd830b7586c")
+	if err != nil {
+		t.Fatalf("NewWithHexNTHash LM:NT: %v", err)
+	}
+	rc4, _ := c.Key(iana.ETypeRC4HMAC, "", nil)
+	if h := nt.NTHash("password"); !bytes.Equal(rc4, h[:]) {
+		t.Errorf("LM:NT parse took wrong half")
+	}
+
+	key32 := bytes.Repeat([]byte{0xAB}, 32)
+	ck, err := NewWithAESKey("svc", "CORP.LOCAL", iana.ETypeAES256CTSHMACSHA196, key32)
+	if err != nil {
+		t.Fatalf("NewWithAESKey: %v", err)
+	}
+	got, err := ck.Key(iana.ETypeAES256CTSHMACSHA196, "ignored-salt", nil)
+	if err != nil {
+		t.Fatalf("Key(AES256): %v", err)
+	}
+	if !bytes.Equal(got, key32) {
+		t.Error("AES key round-trip mismatch")
+	}
+	// Wrong etype must fail.
+	if _, err := ck.Key(iana.ETypeAES128CTSHMACSHA196, "", nil); err == nil {
+		t.Error("expected error: AES256 key cannot serve etype 17")
+	}
+	if _, err := ck.Key(iana.ETypeRC4HMAC, "", nil); err == nil {
+		t.Error("expected error: AES key cannot serve RC4")
+	}
+}
+
+func TestNewWithHexAESKeyInfersEtype(t *testing.T) {
+	c16, err := NewWithHexAESKey("svc", "CORP.LOCAL", hex.EncodeToString(bytes.Repeat([]byte{1}, 16)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c16.SupportedETypes()[0] != iana.ETypeAES128CTSHMACSHA196 {
+		t.Errorf("16-byte key inferred etype = %v, want 17", c16.SupportedETypes())
+	}
+	c32, err := NewWithHexAESKey("svc", "CORP.LOCAL", hex.EncodeToString(bytes.Repeat([]byte{1}, 32)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c32.SupportedETypes()[0] != iana.ETypeAES256CTSHMACSHA196 {
+		t.Errorf("32-byte key inferred etype = %v, want 18", c32.SupportedETypes())
+	}
+	if _, err := NewWithHexAESKey("svc", "R", hex.EncodeToString(bytes.Repeat([]byte{1}, 24))); err == nil {
+		t.Error("expected error for 24-byte AES key")
+	}
+}
+
+func TestInvalidInputs(t *testing.T) {
+	if _, err := NewWithNTHash("a", "R", []byte{1, 2, 3}); err == nil {
+		t.Error("expected error for short NT hash")
+	}
+	if _, err := NewWithHexNTHash("a", "R", "zzzz"); err == nil {
+		t.Error("expected error for bad hex")
+	}
+	if _, err := NewWithAESKey("a", "R", 99, bytes.Repeat([]byte{1}, 32)); err == nil {
+		t.Error("expected error for bad AES etype")
+	}
+}
+
+func TestDestroyZeroesSecret(t *testing.T) {
+	h, _ := hex.DecodeString("8846f7eaee8fb117ad06bdd830b7586c")
+	c, _ := NewWithNTHash("a", "R", h)
+	c.Destroy()
+	if _, err := c.Key(iana.ETypeRC4HMAC, "", nil); err != nil {
+		// after destroy ntHash is nil -> returns empty key, not an error; ensure no panic
+		t.Logf("post-destroy Key err: %v", err)
+	}
+}

--- a/network/kerberos/v5/export.go
+++ b/network/kerberos/v5/export.go
@@ -1,0 +1,96 @@
+package kerberos
+
+import (
+	"encoding/asn1"
+	"encoding/binary"
+	"fmt"
+	"time"
+
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/credcache/ccache"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/credcache/kirbi"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/messages"
+)
+
+// tgtCredInfo builds the KrbCredInfo describing the currently held TGT from the
+// stored AS-REP enc-part (session key, flags, times, service name).
+func (c *KerberosClient) tgtCredInfo() messages.KrbCredInfo {
+	return messages.KrbCredInfo{
+		Key:       messages.EncryptionKey{KeyType: c.sessionEType, KeyValue: c.sessionKey},
+		PRealm:    c.realm,
+		PName:     messages.PrincipalName{NameType: messages.NameTypePrincipal, NameString: []string{c.username}},
+		Flags:     c.tgtEnc.Flags,
+		AuthTime:  c.tgtEnc.AuthTime,
+		StartTime: c.tgtEnc.StartTime,
+		EndTime:   c.tgtEnc.EndTime,
+		RenewTill: c.tgtEnc.RenewTill,
+		SRealm:    c.tgtEnc.SRealm,
+		SName:     c.tgtEnc.SName,
+	}
+}
+
+// ExportTGTKirbi returns the current TGT as .kirbi (DER KRB-CRED) bytes, suitable
+// for pass-the-ticket with Rubeus/Impacket. GetTGT must have succeeded first.
+func (c *KerberosClient) ExportTGTKirbi() ([]byte, error) {
+	if !c.hasTGT {
+		return nil, fmt.Errorf("kerberos: no TGT: call GetTGT first")
+	}
+	cred, err := kirbi.New(c.tgtTicketRaw, c.tgtCredInfo())
+	if err != nil {
+		return nil, err
+	}
+	return kirbi.Bytes(cred)
+}
+
+// ExportTGTCCache returns the current TGT as an MIT ccache (v4) holding a single
+// credential. GetTGT must have succeeded first.
+func (c *KerberosClient) ExportTGTCCache() (*ccache.CCache, error) {
+	if !c.hasTGT {
+		return nil, fmt.Errorf("kerberos: no TGT: call GetTGT first")
+	}
+	client := ccache.Principal{
+		NameType:   uint32(messages.NameTypePrincipal),
+		Realm:      c.realm,
+		Components: []string{c.username},
+	}
+	server := ccache.Principal{
+		NameType:   uint32(c.tgtEnc.SName.NameType),
+		Realm:      c.tgtEnc.SRealm,
+		Components: append([]string(nil), c.tgtEnc.SName.NameString...),
+	}
+	start := c.tgtEnc.StartTime
+	if start.IsZero() {
+		start = c.tgtEnc.AuthTime
+	}
+	return &ccache.CCache{
+		DefaultPrincipal: client,
+		Credentials: []ccache.Credential{{
+			Client:      client,
+			Server:      server,
+			Key:         ccache.Keyblock{EType: uint16(c.sessionEType), KeyValue: c.sessionKey},
+			AuthTime:    unixU32(c.tgtEnc.AuthTime),
+			StartTime:   unixU32(start),
+			EndTime:     unixU32(c.tgtEnc.EndTime),
+			RenewTill:   unixU32(c.tgtEnc.RenewTill),
+			TicketFlags: flagsToUint32(c.tgtEnc.Flags),
+			Ticket:      c.tgtTicketRaw,
+		}},
+	}, nil
+}
+
+// unixU32 returns t as Unix seconds in a uint32, or 0 for the zero time (rather
+// than the wrapped negative value uint32(-6795...) would give).
+func unixU32(t time.Time) uint32 {
+	if t.IsZero() {
+		return 0
+	}
+	return uint32(t.Unix())
+}
+
+// flagsToUint32 converts a KerberosFlags BIT STRING (bit 0 = MSB of the first
+// octet) to the big-endian uint32 that the ccache ticket_flags field uses. A
+// short or over-long byte slice is padded/truncated to exactly 4 bytes.
+func flagsToUint32(flags asn1.BitString) uint32 {
+	var b [4]byte
+	copy(b[:], flags.Bytes)
+	return binary.BigEndian.Uint32(b[:])
+}

--- a/network/kerberos/v5/export_test.go
+++ b/network/kerberos/v5/export_test.go
@@ -1,0 +1,109 @@
+package kerberos
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/credcache/ccache"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/credcache/kirbi"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/messages"
+)
+
+// fakeTGTClient returns a client whose TGT fields are populated by hand, so the
+// export path can be exercised without a live KDC.
+func fakeTGTClient(t *testing.T) *KerberosClient {
+	t.Helper()
+	tkt := messages.Ticket{
+		TktVno:  messages.KerberosV5,
+		Realm:   "CORP.LOCAL",
+		SName:   messages.PrincipalName{NameType: messages.NameTypeSRVInst, NameString: []string{"krbtgt", "CORP.LOCAL"}},
+		EncPart: messages.EncryptedData{EType: messages.ETypeAES256CTSHMACSHA196, Cipher: bytes.Repeat([]byte{0xAB}, 32)},
+	}
+	raw, err := tkt.Marshal()
+	if err != nil {
+		t.Fatalf("Ticket.Marshal: %v", err)
+	}
+	c := NewClient("alice", "corp.local", "10.0.0.1").WithPassword("x")
+	c.tgtTicket = tkt
+	c.tgtTicketRaw = raw
+	c.sessionKey = bytes.Repeat([]byte{0x11}, 32)
+	c.sessionEType = messages.ETypeAES256CTSHMACSHA196
+	c.tgtEnc = messages.EncASRepPart{
+		Flags:     messages.NewKerberosFlags(messages.TicketFlagForwardable, messages.TicketFlagRenewable, messages.TicketFlagInitial),
+		AuthTime:  time.Date(2026, 7, 9, 10, 0, 0, 0, time.UTC),
+		EndTime:   time.Date(2026, 7, 9, 20, 0, 0, 0, time.UTC),
+		RenewTill: time.Date(2026, 7, 16, 10, 0, 0, 0, time.UTC),
+		SRealm:    "CORP.LOCAL",
+		SName:     messages.PrincipalName{NameType: messages.NameTypeSRVInst, NameString: []string{"krbtgt", "CORP.LOCAL"}},
+	}
+	c.hasTGT = true
+	return c
+}
+
+func TestExportTGTKirbi(t *testing.T) {
+	c := fakeTGTClient(t)
+	blob, err := c.ExportTGTKirbi()
+	if err != nil {
+		t.Fatalf("ExportTGTKirbi: %v", err)
+	}
+	cred, err := kirbi.Parse(blob)
+	if err != nil {
+		t.Fatalf("kirbi.Parse: %v", err)
+	}
+	if len(cred.Tickets) != 1 || cred.Tickets[0].Realm != "CORP.LOCAL" {
+		t.Fatalf("exported kirbi tickets wrong: %+v", cred.Tickets)
+	}
+	infos, err := kirbi.TicketInfo(cred)
+	if err != nil {
+		t.Fatalf("TicketInfo: %v", err)
+	}
+	if infos[0].PName.NameString[0] != "alice" || !bytes.Equal(infos[0].Key.KeyValue, c.sessionKey) {
+		t.Errorf("exported kirbi info wrong: %+v", infos[0])
+	}
+	if !infos[0].EndTime.Equal(c.tgtEnc.EndTime) {
+		t.Errorf("endtime mismatch: %v vs %v", infos[0].EndTime, c.tgtEnc.EndTime)
+	}
+}
+
+func TestExportTGTCCache(t *testing.T) {
+	c := fakeTGTClient(t)
+	cc, err := c.ExportTGTCCache()
+	if err != nil {
+		t.Fatalf("ExportTGTCCache: %v", err)
+	}
+	blob, err := cc.Marshal()
+	if err != nil {
+		t.Fatalf("ccache.Marshal: %v", err)
+	}
+	got, err := ccache.Unmarshal(blob)
+	if err != nil {
+		t.Fatalf("ccache.Unmarshal: %v", err)
+	}
+	if got.DefaultPrincipal.Realm != "CORP.LOCAL" || got.DefaultPrincipal.Components[0] != "alice" {
+		t.Errorf("default principal wrong: %+v", got.DefaultPrincipal)
+	}
+	if len(got.Credentials) != 1 {
+		t.Fatalf("credential count: %d", len(got.Credentials))
+	}
+	cr := got.Credentials[0]
+	if cr.Server.Components[0] != "krbtgt" || cr.Key.EType != uint16(messages.ETypeAES256CTSHMACSHA196) {
+		t.Errorf("credential fields wrong: %+v", cr)
+	}
+	if uint32(c.tgtEnc.EndTime.Unix()) != cr.EndTime {
+		t.Errorf("endtime mismatch: %d vs %d", cr.EndTime, c.tgtEnc.EndTime.Unix())
+	}
+	if !bytes.Equal(cr.Ticket, c.tgtTicketRaw) {
+		t.Errorf("ticket bytes not preserved")
+	}
+}
+
+func TestExportRequiresTGT(t *testing.T) {
+	c := NewClient("alice", "corp.local", "10.0.0.1").WithPassword("x")
+	if _, err := c.ExportTGTKirbi(); err == nil {
+		t.Error("expected error exporting without a TGT")
+	}
+	if _, err := c.ExportTGTCCache(); err == nil {
+		t.Error("expected error exporting without a TGT")
+	}
+}

--- a/network/kerberos/v5/iana/constants.go
+++ b/network/kerberos/v5/iana/constants.go
@@ -81,6 +81,7 @@ const (
 	KeyUsageKRBPrivEncPart         = 13 // KRB-PRIV enc-part
 	KeyUsageKRBCredEncPart         = 14 // KRB-CRED enc-part
 	KeyUsageKRBSafeCksum           = 15 // KRB-SAFE cksum
+	KeyUsageKerbNonKerbCksumSalt   = 17 // KERB_NON_KERB_CKSUM_SALT (MS-PAC signatures)
 	KeyUsageADKDCIssuedCksum       = 19 // AD-KDC-ISSUED checksum
 )
 

--- a/network/kerberos/v5/mskile/padata.go
+++ b/network/kerberos/v5/mskile/padata.go
@@ -1,0 +1,143 @@
+// Package mskile implements the Microsoft-specific pre-authentication data
+// (PA-DATA) payloads that MS-KILE layers onto RFC 4120's extension point:
+// PA-PAC-REQUEST (128), PA-PAC-OPTIONS (167), and PA-SUPPORTED-ENCTYPES (165).
+// These are additive extensions — the surrounding AS-REQ/TGS-REQ messages
+// remain exactly RFC 4120's.
+package mskile
+
+import (
+	"encoding/asn1"
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/iana"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/messages"
+)
+
+// ── PA-PAC-REQUEST (padata-type 128, MS-KILE 2.2.3) ───────────────────────────
+//
+//	KERB-PA-PAC-REQUEST ::= SEQUENCE { include-pac [0] BOOLEAN }
+//
+// include-pac = TRUE asks the KDC to include a PAC; FALSE asks it to omit one
+// (used for Kerberoasting to get shorter, PAC-free service tickets).
+
+type pacRequest struct {
+	IncludePAC bool `asn1:"explicit,tag:0"`
+}
+
+// PACRequest returns the DER-encoded PA-PAC-REQUEST padata-value.
+func PACRequest(includePAC bool) ([]byte, error) {
+	return asn1.Marshal(pacRequest{IncludePAC: includePAC})
+}
+
+// ParsePACRequest decodes a PA-PAC-REQUEST padata-value.
+func ParsePACRequest(b []byte) (includePAC bool, err error) {
+	var p pacRequest
+	if _, err := asn1.Unmarshal(b, &p); err != nil {
+		return false, fmt.Errorf("mskile: parse PA-PAC-REQUEST: %w", err)
+	}
+	return p.IncludePAC, nil
+}
+
+// PACRequestPAData builds the PA-DATA element for PA-PAC-REQUEST.
+func PACRequestPAData(includePAC bool) (messages.PAData, error) {
+	v, err := PACRequest(includePAC)
+	if err != nil {
+		return messages.PAData{}, err
+	}
+	return messages.PAData{PADataType: iana.PAPACRequest, PADataValue: v}, nil
+}
+
+// ── PA-PAC-OPTIONS (padata-type 167, MS-KILE 2.2.10 / MS-SFU 2.2.5) ────────────
+//
+//	PA-PAC-OPTIONS ::= SEQUENCE { flags [0] KerberosFlags }
+//
+// The flags field is a 32-bit KerberosFlags bit string (bit 0 = MSB).
+
+// PA-PAC-OPTIONS flag bit positions.
+const (
+	PACOptionClaims                        = 0 // Claims
+	PACOptionBranchAware                   = 1 // Branch Aware
+	PACOptionForwardToFullDC               = 2 // Forward to Full DC
+	PACOptionResourceBasedConstrainedDeleg = 3 // resource-based constrained delegation (MS-SFU)
+)
+
+type pacOptions struct {
+	Flags asn1.BitString `asn1:"explicit,tag:0"`
+}
+
+// PACOptions returns the DER-encoded PA-PAC-OPTIONS padata-value with the given
+// option bits set.
+func PACOptions(bits ...int) ([]byte, error) {
+	return asn1.Marshal(pacOptions{Flags: messages.NewKerberosFlags(bits...)})
+}
+
+// ParsePACOptions decodes a PA-PAC-OPTIONS padata-value and reports which option
+// bit positions are set.
+func ParsePACOptions(b []byte) ([]int, error) {
+	var p pacOptions
+	if _, err := asn1.Unmarshal(b, &p); err != nil {
+		return nil, fmt.Errorf("mskile: parse PA-PAC-OPTIONS: %w", err)
+	}
+	var set []int
+	for i := 0; i < p.Flags.BitLength; i++ {
+		if p.Flags.At(i) == 1 {
+			set = append(set, i)
+		}
+	}
+	return set, nil
+}
+
+// PACOptionsPAData builds the PA-DATA element for PA-PAC-OPTIONS.
+func PACOptionsPAData(bits ...int) (messages.PAData, error) {
+	v, err := PACOptions(bits...)
+	if err != nil {
+		return messages.PAData{}, err
+	}
+	return messages.PAData{PADataType: iana.PAPACOptions, PADataValue: v}, nil
+}
+
+// ── PA-SUPPORTED-ENCTYPES (padata-type 165, MS-KILE 2.2.8) ─────────────────────
+//
+//	PA-SUPPORTED-ENCTYPES ::= Int32  -- a Supported Encryption Types bit field
+//
+// The padata-value is a DER-encoded INTEGER (NOT a raw little-endian word) whose
+// bits are the msDS-SupportedEncryptionTypes flags of MS-KILE 2.2.7.
+
+// Supported Encryption Types bit flags (MS-KILE 2.2.7).
+const (
+	EncTypeDESCBCCRC               = 0x00000001 // A
+	EncTypeDESCBCMD5               = 0x00000002 // B
+	EncTypeRC4HMAC                 = 0x00000004 // C
+	EncTypeAES128CTSHMACSHA196     = 0x00000008 // D
+	EncTypeAES256CTSHMACSHA196     = 0x00000010 // E
+	EncTypeFASTSupported           = 0x00000020 // F
+	EncTypeCompoundIdentity        = 0x00000040 // G
+	EncTypeClaimsSupported         = 0x00000080 // H
+	EncTypeResourceSIDCompDisabled = 0x00000100 // I
+	EncTypeAES256SK                = 0x00000200 // J: enforce AES session keys
+	EncTypeAES128CTSHMACSHA256     = 0x00000400 // K (RFC 8009)
+	EncTypeAES256CTSHMACSHA384     = 0x00000800 // L (RFC 8009)
+)
+
+// SupportedEnctypes returns the DER-encoded PA-SUPPORTED-ENCTYPES padata-value.
+func SupportedEnctypes(flags int32) ([]byte, error) {
+	return asn1.Marshal(int(flags))
+}
+
+// ParseSupportedEnctypes decodes a PA-SUPPORTED-ENCTYPES padata-value.
+func ParseSupportedEnctypes(b []byte) (int32, error) {
+	var v int
+	if _, err := asn1.Unmarshal(b, &v); err != nil {
+		return 0, fmt.Errorf("mskile: parse PA-SUPPORTED-ENCTYPES: %w", err)
+	}
+	return int32(v), nil
+}
+
+// SupportedEnctypesPAData builds the PA-DATA element for PA-SUPPORTED-ENCTYPES.
+func SupportedEnctypesPAData(flags int32) (messages.PAData, error) {
+	v, err := SupportedEnctypes(flags)
+	if err != nil {
+		return messages.PAData{}, err
+	}
+	return messages.PAData{PADataType: iana.PASupportedEnctypes, PADataValue: v}, nil
+}

--- a/network/kerberos/v5/mskile/padata_test.go
+++ b/network/kerberos/v5/mskile/padata_test.go
@@ -1,0 +1,105 @@
+package mskile
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/iana"
+)
+
+func TestPACRequestMatchesKnownEncoding(t *testing.T) {
+	// The canonical PA-PAC-REQUEST(TRUE): SEQUENCE { [0] BOOLEAN TRUE }.
+	want := []byte{0x30, 0x05, 0xa0, 0x03, 0x01, 0x01, 0xff}
+	got, err := PACRequest(true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("PACRequest(true) = % X, want % X", got, want)
+	}
+
+	inc, err := ParsePACRequest(got)
+	if err != nil || !inc {
+		t.Errorf("ParsePACRequest round-trip: inc=%v err=%v", inc, err)
+	}
+
+	falseBytes, _ := PACRequest(false)
+	if inc, _ := ParsePACRequest(falseBytes); inc {
+		t.Error("PACRequest(false) parsed as true")
+	}
+
+	pa, err := PACRequestPAData(true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pa.PADataType != iana.PAPACRequest {
+		t.Errorf("PA-DATA type = %d, want %d", pa.PADataType, iana.PAPACRequest)
+	}
+}
+
+func TestPACOptionsRoundtrip(t *testing.T) {
+	b, err := PACOptions(PACOptionResourceBasedConstrainedDeleg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// SEQUENCE { [0] BIT STRING(32) } — expect 30 07 a0 05 03 05 00 <4 bytes>.
+	if b[0] != 0x30 || b[2] != 0xa0 || b[4] != 0x03 {
+		t.Errorf("unexpected PA-PAC-OPTIONS framing: % X", b)
+	}
+	set, err := ParsePACOptions(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(set) != 1 || set[0] != PACOptionResourceBasedConstrainedDeleg {
+		t.Errorf("parsed option bits = %v, want [%d]", set, PACOptionResourceBasedConstrainedDeleg)
+	}
+
+	multi, _ := PACOptions(PACOptionClaims, PACOptionForwardToFullDC)
+	set2, _ := ParsePACOptions(multi)
+	if len(set2) != 2 || set2[0] != PACOptionClaims || set2[1] != PACOptionForwardToFullDC {
+		t.Errorf("multi-bit parse = %v", set2)
+	}
+
+	pa, err := PACOptionsPAData(PACOptionClaims)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pa.PADataType != iana.PAPACOptions {
+		t.Errorf("PA-DATA type = %d, want %d", pa.PADataType, iana.PAPACOptions)
+	}
+}
+
+func TestSupportedEnctypesRoundtrip(t *testing.T) {
+	// DC functional level >= 2012 advertises 0x1F (DES..AES256).
+	flags := int32(EncTypeRC4HMAC | EncTypeAES128CTSHMACSHA196 | EncTypeAES256CTSHMACSHA196)
+	b, err := SupportedEnctypes(flags)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// DER INTEGER: 0x1C -> 02 01 1C.
+	if b[0] != 0x02 {
+		t.Errorf("PA-SUPPORTED-ENCTYPES is not a DER INTEGER: % X", b)
+	}
+	got, err := ParseSupportedEnctypes(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != flags {
+		t.Errorf("round-trip flags = 0x%X, want 0x%X", got, flags)
+	}
+
+	// A larger value spanning multiple bytes (0x1F | claims | RBCD-ish).
+	big := int32(0x1F | EncTypeClaimsSupported | EncTypeResourceSIDCompDisabled)
+	bb, _ := SupportedEnctypes(big)
+	if v, _ := ParseSupportedEnctypes(bb); v != big {
+		t.Errorf("multi-byte round-trip = 0x%X, want 0x%X", v, big)
+	}
+
+	pa, err := SupportedEnctypesPAData(flags)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pa.PADataType != iana.PASupportedEnctypes {
+		t.Errorf("PA-DATA type = %d, want %d", pa.PADataType, iana.PASupportedEnctypes)
+	}
+}

--- a/network/kerberos/v5/pac/pac.go
+++ b/network/kerberos/v5/pac/pac.go
@@ -1,0 +1,343 @@
+// Package pac parses, builds, and verifies the Microsoft Privilege Attribute
+// Certificate (PAC, [MS-PAC]) carried in a Kerberos ticket's authorization data.
+//
+// A PAC is a PACTYPE container (little-endian, NOT NDR at the container level):
+// a cBuffers/Version header followed by a table of PAC_INFO_BUFFER entries, each
+// pointing at an 8-byte-aligned buffer. Individual buffers such as the logon
+// info (KERB_VALIDATION_INFO) are themselves NDR-encoded; this package exposes
+// those buffers as raw bytes and does not yet NDR-decode them.
+//
+// The security-relevant operations — the Server and KDC signatures ([MS-PAC]
+// 2.8, "Generation of PAC Signatures") — are implemented: both are keyed
+// checksums with key usage KERB_NON_KERB_CKSUM_SALT (17); the server signature
+// covers the entire PAC with all signature buffers' Signature fields zeroed, and
+// the KDC signature counter-signs the server signature.
+package pac
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	kerbcrypto "github.com/TheManticoreProject/Manticore/network/kerberos/v5/crypto"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/iana"
+)
+
+// PAC_INFO_BUFFER ulType values ([MS-PAC] 2.4).
+const (
+	BufferLogonInfo           = 0x00000001 // KERB_VALIDATION_INFO (NDR)
+	BufferCredentials         = 0x00000002 // PAC_CREDENTIAL_INFO
+	BufferServerChecksum      = 0x00000006 // server signature
+	BufferKDCChecksum         = 0x00000007 // KDC (krbtgt) signature
+	BufferClientInfo          = 0x0000000A // PAC_CLIENT_INFO
+	BufferConstrainedDeleg    = 0x0000000B // S4U_DELEGATION_INFO
+	BufferUPNDNSInfo          = 0x0000000C // UPN_DNS_INFO
+	BufferClientClaims        = 0x0000000D // client claims
+	BufferDeviceInfo          = 0x0000000E // PAC_DEVICE_INFO
+	BufferDeviceClaims        = 0x0000000F // device claims
+	BufferTicketChecksum      = 0x00000010 // ticket signature
+	BufferAttributesInfo      = 0x00000011 // PAC_ATTRIBUTES_INFO
+	BufferRequestorSID        = 0x00000012 // PAC_REQUESTOR
+	BufferExtendedKDCChecksum = 0x00000013 // extended KDC (full-PAC) signature
+)
+
+// PAC signature SignatureType values ([MS-PAC] 2.8). These are Kerberos checksum
+// type numbers; the RC4 value 0xFFFFFF76 is -138 as an int32.
+const (
+	sigHMACMD5     uint32 = 0xFFFFFF76 // KERB_CHECKSUM_HMAC_MD5, 16 bytes
+	sigHMACSHA1128 uint32 = 0x0000000F // HMAC_SHA1_96_AES128, 12 bytes
+	sigHMACSHA1256 uint32 = 0x00000010 // HMAC_SHA1_96_AES256, 12 bytes
+	sigHMACSHA2128 uint32 = 0x00000013 // HMAC_SHA256_128_AES128, 16 bytes (newer)
+	sigHMACSHA2256 uint32 = 0x00000014 // HMAC_SHA384_192_AES256, 24 bytes (newer)
+)
+
+// checksumSize returns the signature byte length for a PAC SignatureType.
+func checksumSize(sigType uint32) (int, bool) {
+	switch sigType {
+	case sigHMACMD5, sigHMACSHA2128:
+		return 16, true
+	case sigHMACSHA1128, sigHMACSHA1256:
+		return 12, true
+	case sigHMACSHA2256:
+		return 24, true
+	default:
+		return 0, false
+	}
+}
+
+// cksumType maps a PAC SignatureType to the checksum-type number used by the
+// crypto package (sign-extending the RC4 value to -138).
+func cksumType(sigType uint32) int {
+	return int(int32(sigType))
+}
+
+// Buffer is one PAC_INFO_BUFFER and its contents.
+type Buffer struct {
+	Type   uint32
+	Offset uint64 // offset from the start of the PAC (informational after Parse)
+	Data   []byte
+}
+
+// PAC is a parsed PACTYPE container.
+type PAC struct {
+	Version uint32
+	Buffers []Buffer
+	raw     []byte // exact bytes Parse consumed (nil for a freshly built PAC)
+}
+
+// Buffer returns the first buffer of the given ulType.
+func (p *PAC) Buffer(ulType uint32) (Buffer, bool) {
+	for _, b := range p.Buffers {
+		if b.Type == ulType {
+			return b, true
+		}
+	}
+	return Buffer{}, false
+}
+
+// Parse decodes a PACTYPE container. Buffer contents are copied out.
+func Parse(data []byte) (*PAC, error) {
+	if len(data) < 8 {
+		return nil, fmt.Errorf("pac: too short (%d bytes)", len(data))
+	}
+	cBuffers := binary.LittleEndian.Uint32(data[0:])
+	version := binary.LittleEndian.Uint32(data[4:])
+	if version != 0 {
+		return nil, fmt.Errorf("pac: unexpected version %d (want 0)", version)
+	}
+	if cBuffers > 64 {
+		return nil, fmt.Errorf("pac: implausible buffer count %d", cBuffers)
+	}
+	need := 8 + int(cBuffers)*16
+	if len(data) < need {
+		return nil, fmt.Errorf("pac: truncated info-buffer table")
+	}
+
+	p := &PAC{Version: version, raw: append([]byte(nil), data...)}
+	for i := 0; i < int(cBuffers); i++ {
+		off := 8 + i*16
+		ulType := binary.LittleEndian.Uint32(data[off:])
+		cb := binary.LittleEndian.Uint32(data[off+4:])
+		bufOff := binary.LittleEndian.Uint64(data[off+8:])
+		if bufOff > uint64(len(data)) || bufOff+uint64(cb) > uint64(len(data)) {
+			return nil, fmt.Errorf("pac: buffer %d (type 0x%x) out of range: off=%d size=%d", i, ulType, bufOff, cb)
+		}
+		p.Buffers = append(p.Buffers, Buffer{
+			Type:   ulType,
+			Offset: bufOff,
+			Data:   append([]byte(nil), data[bufOff:bufOff+uint64(cb)]...),
+		})
+	}
+	return p, nil
+}
+
+// align8 rounds n up to a multiple of 8.
+func align8(n int) int { return (n + 7) &^ 7 }
+
+// Marshal lays out the PAC in wire form: header, PAC_INFO_BUFFER table, then each
+// buffer's data 8-byte aligned. It uses the buffers' current Data verbatim (so
+// signature buffers should already be sized and, if unsigned, zero-filled).
+func (p *PAC) Marshal() ([]byte, error) {
+	n := len(p.Buffers)
+	headerLen := 8 + n*16
+	total := headerLen
+	offsets := make([]int, n)
+	for i, b := range p.Buffers {
+		total = align8(total)
+		offsets[i] = total
+		total += len(b.Data)
+	}
+	out := make([]byte, total)
+	binary.LittleEndian.PutUint32(out[0:], uint32(n))
+	binary.LittleEndian.PutUint32(out[4:], 0) // Version
+	for i, b := range p.Buffers {
+		e := 8 + i*16
+		binary.LittleEndian.PutUint32(out[e:], b.Type)
+		binary.LittleEndian.PutUint32(out[e+4:], uint32(len(b.Data)))
+		binary.LittleEndian.PutUint64(out[e+8:], uint64(offsets[i]))
+		copy(out[offsets[i]:], b.Data)
+	}
+	return out, nil
+}
+
+// signatureBufferTypes lists the buffer types whose Signature fields are zeroed
+// before the server signature is computed ([MS-PAC] "Generation of PAC
+// Signatures": server, KDC, and extended-KDC signatures are all zeroed).
+var signatureBufferTypes = map[uint32]bool{
+	BufferServerChecksum:      true,
+	BufferKDCChecksum:         true,
+	BufferExtendedKDCChecksum: true,
+}
+
+// zeroedForServerSig returns a copy of the marshaled PAC with the Signature
+// fields (the bytes after the 4-byte SignatureType) of every signature buffer
+// set to zero, as required before computing the server signature.
+func zeroedForServerSig(marshaled []byte, buffers []Buffer, offsets []int) ([]byte, error) {
+	out := append([]byte(nil), marshaled...)
+	for i, b := range buffers {
+		if !signatureBufferTypes[b.Type] {
+			continue
+		}
+		if len(b.Data) < 4 {
+			return nil, fmt.Errorf("pac: signature buffer 0x%x too short", b.Type)
+		}
+		sigType := binary.LittleEndian.Uint32(b.Data[0:])
+		sz, ok := checksumSize(sigType)
+		if !ok {
+			return nil, fmt.Errorf("pac: unsupported signature type 0x%x", sigType)
+		}
+		start := offsets[i] + 4
+		if start+sz > len(out) {
+			return nil, fmt.Errorf("pac: signature buffer 0x%x overruns PAC", b.Type)
+		}
+		for j := 0; j < sz; j++ {
+			out[start+j] = 0
+		}
+	}
+	return out, nil
+}
+
+// layout re-marshals and returns the bytes plus each buffer's offset.
+func (p *PAC) layout() ([]byte, []int) {
+	n := len(p.Buffers)
+	headerLen := 8 + n*16
+	total := headerLen
+	offsets := make([]int, n)
+	for i, b := range p.Buffers {
+		total = align8(total)
+		offsets[i] = total
+		total += len(b.Data)
+	}
+	m, _ := p.Marshal()
+	return m, offsets
+}
+
+// Sign fills the server signature (buffer 0x06) and then the KDC signature
+// (buffer 0x07) in place, using the given keys. Both use key usage
+// KERB_NON_KERB_CKSUM_SALT. The buffers must already exist, sized to
+// 4 + checksumSize(their SignatureType). Returns the fully signed marshaled PAC.
+func (p *PAC) Sign(serverKey, kdcKey []byte) ([]byte, error) {
+	srvIdx, kdcIdx := -1, -1
+	for i, b := range p.Buffers {
+		switch b.Type {
+		case BufferServerChecksum:
+			srvIdx = i
+		case BufferKDCChecksum:
+			kdcIdx = i
+		}
+	}
+	if srvIdx < 0 || kdcIdx < 0 {
+		return nil, fmt.Errorf("pac: Sign requires both server (0x06) and KDC (0x07) checksum buffers")
+	}
+
+	// Server signature: over the whole PAC with signature fields zeroed.
+	marshaled, offsets := p.layout()
+	zeroed, err := zeroedForServerSig(marshaled, p.Buffers, offsets)
+	if err != nil {
+		return nil, err
+	}
+	srvType := binary.LittleEndian.Uint32(p.Buffers[srvIdx].Data[0:])
+	srvSig, err := kerbcrypto.GetChecksum(cksumType(srvType), serverKey, iana.KeyUsageKerbNonKerbCksumSalt, zeroed)
+	if err != nil {
+		return nil, fmt.Errorf("pac: server signature: %w", err)
+	}
+	copy(p.Buffers[srvIdx].Data[4:], srvSig)
+
+	// KDC signature: counter-sign the server Signature bytes.
+	kdcType := binary.LittleEndian.Uint32(p.Buffers[kdcIdx].Data[0:])
+	kdcSig, err := kerbcrypto.GetChecksum(cksumType(kdcType), kdcKey, iana.KeyUsageKerbNonKerbCksumSalt, srvSig)
+	if err != nil {
+		return nil, fmt.Errorf("pac: KDC signature: %w", err)
+	}
+	copy(p.Buffers[kdcIdx].Data[4:], kdcSig)
+
+	return p.Marshal()
+}
+
+// VerifyServerSignature recomputes the server signature with serverKey and
+// compares it, in constant time, to the stored value. The PAC must have been
+// produced by Parse (so the exact issued bytes are available).
+func (p *PAC) VerifyServerSignature(serverKey []byte) error {
+	if p.raw == nil {
+		return fmt.Errorf("pac: VerifyServerSignature requires a parsed PAC")
+	}
+	srv, ok := p.Buffer(BufferServerChecksum)
+	if !ok {
+		return fmt.Errorf("pac: no server signature buffer")
+	}
+	if len(srv.Data) < 4 {
+		return fmt.Errorf("pac: server signature buffer too short")
+	}
+	sigType := binary.LittleEndian.Uint32(srv.Data[0:])
+	sz, ok := checksumSize(sigType)
+	if !ok {
+		return fmt.Errorf("pac: unsupported server signature type 0x%x", sigType)
+	}
+	stored := srv.Data[4 : 4+sz]
+
+	zeroed, err := p.rawZeroedForServerSig()
+	if err != nil {
+		return err
+	}
+	if !kerbcrypto.VerifyChecksum(cksumType(sigType), serverKey, iana.KeyUsageKerbNonKerbCksumSalt, zeroed, stored) {
+		return fmt.Errorf("pac: server signature verification failed")
+	}
+	return nil
+}
+
+// VerifyKDCSignature recomputes the KDC signature with the krbtgt key (over the
+// stored server-signature bytes) and compares it to the stored value.
+func (p *PAC) VerifyKDCSignature(krbtgtKey []byte) error {
+	srv, ok := p.Buffer(BufferServerChecksum)
+	if !ok {
+		return fmt.Errorf("pac: no server signature buffer")
+	}
+	kdc, ok := p.Buffer(BufferKDCChecksum)
+	if !ok {
+		return fmt.Errorf("pac: no KDC signature buffer")
+	}
+	srvType := binary.LittleEndian.Uint32(srv.Data[0:])
+	srvSz, ok := checksumSize(srvType)
+	if !ok || len(srv.Data) < 4+srvSz {
+		return fmt.Errorf("pac: bad server signature buffer")
+	}
+	serverSig := srv.Data[4 : 4+srvSz]
+
+	kdcType := binary.LittleEndian.Uint32(kdc.Data[0:])
+	kdcSz, ok := checksumSize(kdcType)
+	if !ok || len(kdc.Data) < 4+kdcSz {
+		return fmt.Errorf("pac: bad KDC signature buffer")
+	}
+	stored := kdc.Data[4 : 4+kdcSz]
+
+	if !kerbcrypto.VerifyChecksum(cksumType(kdcType), krbtgtKey, iana.KeyUsageKerbNonKerbCksumSalt, serverSig, stored) {
+		return fmt.Errorf("pac: KDC signature verification failed")
+	}
+	return nil
+}
+
+// rawZeroedForServerSig zeroes the signature fields within the originally parsed
+// bytes, locating each signature buffer by its recorded Offset.
+func (p *PAC) rawZeroedForServerSig() ([]byte, error) {
+	out := append([]byte(nil), p.raw...)
+	for _, b := range p.Buffers {
+		if !signatureBufferTypes[b.Type] {
+			continue
+		}
+		if len(b.Data) < 4 {
+			return nil, fmt.Errorf("pac: signature buffer 0x%x too short", b.Type)
+		}
+		sigType := binary.LittleEndian.Uint32(b.Data[0:])
+		sz, ok := checksumSize(sigType)
+		if !ok {
+			return nil, fmt.Errorf("pac: unsupported signature type 0x%x", sigType)
+		}
+		start := int(b.Offset) + 4
+		if start+sz > len(out) {
+			return nil, fmt.Errorf("pac: signature buffer 0x%x overruns PAC", b.Type)
+		}
+		for j := 0; j < sz; j++ {
+			out[start+j] = 0
+		}
+	}
+	return out, nil
+}

--- a/network/kerberos/v5/pac/pac_test.go
+++ b/network/kerberos/v5/pac/pac_test.go
@@ -1,0 +1,141 @@
+package pac
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+// sigBuf builds a zero-signature PAC_SIGNATURE_DATA buffer for the given
+// SignatureType and checksum size.
+func sigBuf(sigType uint32, size int) []byte {
+	b := make([]byte, 4+size)
+	binary.LittleEndian.PutUint32(b, sigType)
+	return b
+}
+
+func buildSignedPAC(t *testing.T, serverKey, kdcKey []byte) []byte {
+	t.Helper()
+	p := &PAC{
+		Buffers: []Buffer{
+			{Type: BufferLogonInfo, Data: bytes.Repeat([]byte{0xAA}, 40)},
+			{Type: BufferClientInfo, Data: []byte("client-info-bytes")},
+			{Type: BufferServerChecksum, Data: sigBuf(sigHMACSHA1256, 12)},
+			{Type: BufferKDCChecksum, Data: sigBuf(sigHMACSHA1256, 12)},
+		},
+	}
+	signed, err := p.Sign(serverKey, kdcKey)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	return signed
+}
+
+func TestPACSignVerifyRoundtrip(t *testing.T) {
+	serverKey := bytes.Repeat([]byte{0x11}, 32)
+	kdcKey := bytes.Repeat([]byte{0x22}, 32)
+
+	signed := buildSignedPAC(t, serverKey, kdcKey)
+
+	p, err := Parse(signed)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if p.Version != 0 || len(p.Buffers) != 4 {
+		t.Fatalf("parsed PAC wrong: version=%d buffers=%d", p.Version, len(p.Buffers))
+	}
+	if _, ok := p.Buffer(BufferLogonInfo); !ok {
+		t.Error("logon info buffer missing")
+	}
+
+	if err := p.VerifyServerSignature(serverKey); err != nil {
+		t.Errorf("server signature should verify: %v", err)
+	}
+	if err := p.VerifyKDCSignature(kdcKey); err != nil {
+		t.Errorf("KDC signature should verify: %v", err)
+	}
+}
+
+func TestPACWrongKeyFails(t *testing.T) {
+	serverKey := bytes.Repeat([]byte{0x11}, 32)
+	kdcKey := bytes.Repeat([]byte{0x22}, 32)
+	signed := buildSignedPAC(t, serverKey, kdcKey)
+
+	p, _ := Parse(signed)
+	if err := p.VerifyServerSignature(bytes.Repeat([]byte{0x99}, 32)); err == nil {
+		t.Error("server signature verified under the wrong key")
+	}
+	if err := p.VerifyKDCSignature(bytes.Repeat([]byte{0x99}, 32)); err == nil {
+		t.Error("KDC signature verified under the wrong key")
+	}
+}
+
+func TestPACTamperFails(t *testing.T) {
+	serverKey := bytes.Repeat([]byte{0x11}, 32)
+	kdcKey := bytes.Repeat([]byte{0x22}, 32)
+	signed := buildSignedPAC(t, serverKey, kdcKey)
+
+	// Flip a byte inside the logon-info buffer (which lies after the header/table).
+	tampered := append([]byte(nil), signed...)
+	tampered[8+4*16+0] ^= 0x01 // first byte of the first 8-aligned buffer region
+
+	p, err := Parse(tampered)
+	if err != nil {
+		t.Fatalf("Parse tampered: %v", err)
+	}
+	if err := p.VerifyServerSignature(serverKey); err == nil {
+		t.Error("server signature verified over tampered PAC data")
+	}
+}
+
+func TestPACParseRejectsGarbage(t *testing.T) {
+	if _, err := Parse([]byte{1, 2, 3}); err == nil {
+		t.Error("expected error for short PAC")
+	}
+	// version != 0
+	bad := make([]byte, 8)
+	binary.LittleEndian.PutUint32(bad[0:], 0)
+	binary.LittleEndian.PutUint32(bad[4:], 1)
+	if _, err := Parse(bad); err == nil {
+		t.Error("expected error for non-zero version")
+	}
+	// buffer offset out of range
+	oob := make([]byte, 8+16)
+	binary.LittleEndian.PutUint32(oob[0:], 1)  // cBuffers
+	binary.LittleEndian.PutUint32(oob[4:], 0)  // version
+	binary.LittleEndian.PutUint32(oob[8:], 1)  // ulType
+	binary.LittleEndian.PutUint32(oob[12:], 8) // cbBufferSize
+	binary.LittleEndian.PutUint64(oob[16:], 9999)
+	if _, err := Parse(oob); err == nil {
+		t.Error("expected error for out-of-range buffer offset")
+	}
+}
+
+func TestPACMarshalParseBufferRoundtrip(t *testing.T) {
+	p := &PAC{Buffers: []Buffer{
+		{Type: BufferLogonInfo, Data: []byte("logon")},
+		{Type: BufferUPNDNSInfo, Data: []byte("upn-dns-info-longer")},
+	}}
+	m, err := p.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := Parse(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Buffers) != 2 {
+		t.Fatalf("buffers: %d", len(got.Buffers))
+	}
+	b0, _ := got.Buffer(BufferLogonInfo)
+	b1, _ := got.Buffer(BufferUPNDNSInfo)
+	if string(b0.Data) != "logon" || string(b1.Data) != "upn-dns-info-longer" {
+		t.Errorf("buffer data round-trip mismatch: %q %q", b0.Data, b1.Data)
+	}
+	// Offsets must be 8-aligned.
+	for _, b := range got.Buffers {
+		if b.Offset%8 != 0 {
+			t.Errorf("buffer type 0x%x offset %d not 8-aligned", b.Type, b.Offset)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Phase 4 of the native, standard-library-only Kerberos v5 implementation: the Microsoft extension layer. Confirms in code what the analysis concluded — MS-KILE/MS-PAC are additive, riding RFC 4120's `padata` and `AuthorizationData` extension points. No external dependencies.

**Stacked on #899** (base `kerberos-credentials-cache`, itself stacked on #898); bases retarget as the chain merges. Review only the two commits unique to this branch.

## Changes

**mskile (commit fb71f209)** — MS-KILE PA-DATA payloads, each with encode/decode and a `messages.PAData` builder:
- PA-PAC-REQUEST (128): `SEQUENCE { include-pac [0] BOOLEAN }`; `PACRequest(true)` reproduces the exact bytes the client already sends.
- PA-PAC-OPTIONS (167): `SEQUENCE { flags [0] KerberosFlags }` with Claims / Branch-Aware / Forward-to-Full-DC / (MS-SFU) resource-based-constrained-delegation bits.
- PA-SUPPORTED-ENCTYPES (165): a DER-encoded `Int32` bit field (confirmed against MS-KILE 2.2.8 — an ASN.1 INTEGER, not a raw little-endian word), with the MS-KILE 2.2.7 `msDS-SupportedEncryptionTypes` flags.

**pac (commit cf04cec7)** — the MS-PAC PAC:
- Parse the PACTYPE container (little-endian cBuffers/Version header + PAC_INFO_BUFFER table) and expose each buffer's raw bytes by type; bounds-checked. Marshal/build with 8-byte-aligned buffers and a correct offset table.
- Server and KDC signature sign/verify per MS-PAC 2.8 and "Generation of PAC Signatures": key usage `KERB_NON_KERB_CKSUM_SALT` (17); the server signature is a keyed checksum over the whole PAC with every signature buffer's Signature field zeroed; the KDC signature counter-signs the server signature. Signature length derived from SignatureType (HMAC-MD5=16, HMAC-SHA1-96-AES=12, SHA-2 types 16/24).
- Adds the KU-17 constant to the `iana` package.

## How Verified

- `mskile`: encode/decode round-trips; `PACRequest(true)` byte-for-byte equals the known `30 05 a0 03 01 01 ff`; PA-SUPPORTED-ENCTYPES asserted to be a DER INTEGER.
- `pac`: build a signed PAC, parse it, and confirm both signatures verify; a wrong key and a tampered buffer are both rejected; container marshals/parses with 8-aligned offsets.
- `go test ./network/kerberos/...`, `go vet`, and `go build ./...` are green.

## Test Coverage

**Added:** `mskile/padata_test.go`, `pac/pac_test.go`.

## Scope of Change

- **Files changed:** new `network/kerberos/v5/{mskile,pac}` packages; one constant added to `iana`.
- **Submodule pointer updated:** no.
- **Behavioral changes outside the new code:** none.

## Notes

- NDR decoding of KERB_VALIDATION_INFO (logon-info buffer contents — group SIDs, RID, etc.) is deferred; raw buffer bytes are exposed and can be decoded later via `network/dcerpc/ndr`.
- Parsing a real AD PAC and verifying against the live service key is part of the deferred live-KDC validation.