### PR TITLE
Native Kerberos v5: MS-SFU S4U (phase 6)

### DIFF
--- a/network/kerberos/v5/client.go
+++ b/network/kerberos/v5/client.go
@@ -492,11 +492,12 @@ func (c *KerberosClient) buildAPReq() ([]byte, error) {
 // Bit positions for KDCOptions (RFC 4120 Section 5.4.1, RFC 6806 for canonicalize).
 // Bit 0 is the MSB; bit N sits in byte N/8 at position 7-(N%8).
 const (
-	kdcOptionForwardable  = 1  // byte 0, 0x40
-	kdcOptionProxiable    = 3  // byte 0, 0x10
-	kdcOptionRenewable    = 8  // byte 1, 0x80
-	kdcOptionCanonicalize = 15 // byte 1, 0x01 (RFC 6806)
-	kdcOptionRenewableOK  = 27 // byte 3, 0x10
+	kdcOptionForwardable    = 1  // byte 0, 0x40
+	kdcOptionProxiable      = 3  // byte 0, 0x10
+	kdcOptionRenewable      = 8  // byte 1, 0x80
+	kdcOptionCanonicalize   = 15 // byte 1, 0x01 (RFC 6806)
+	kdcOptionCNameInAddlTkt = 14 // byte 1, 0x02 (MS-SFU S4U2Proxy)
+	kdcOptionRenewableOK    = 27 // byte 3, 0x10
 )
 
 // encodeKDCOptions packs a list of bit positions into a 32-bit BitString

--- a/network/kerberos/v5/client.go
+++ b/network/kerberos/v5/client.go
@@ -498,6 +498,7 @@ const (
 	kdcOptionCanonicalize   = 15 // byte 1, 0x01 (RFC 6806)
 	kdcOptionCNameInAddlTkt = 14 // byte 1, 0x02 (MS-SFU S4U2Proxy)
 	kdcOptionRenewableOK    = 27 // byte 3, 0x10
+	kdcOptionEncTktInSKey   = 28 // byte 3, 0x08 (user-to-user)
 )
 
 // encodeKDCOptions packs a list of bit positions into a 32-bit BitString

--- a/network/kerberos/v5/crypto/checksum.go
+++ b/network/kerberos/v5/crypto/checksum.go
@@ -47,6 +47,27 @@ func VerifyChecksum(cksumType int, key []byte, usage int, data, want []byte) boo
 	return hmac.Equal(got, want)
 }
 
+// ChecksumTypeForEType returns the checksum type paired with an encryption type
+// (RFC 3961/3962/8009/4757), i.e. the checksum an authenticator or PA-FOR-USER
+// should use when keyed with a key of that etype. Reports false for unsupported
+// etypes.
+func ChecksumTypeForEType(etype int) (int, bool) {
+	switch etype {
+	case iana.ETypeRC4HMAC:
+		return iana.CksumTypeHMACMD5, true
+	case iana.ETypeAES128CTSHMACSHA196:
+		return iana.CksumTypeHMACSHA196AES128, true
+	case iana.ETypeAES256CTSHMACSHA196:
+		return iana.CksumTypeHMACSHA196AES256, true
+	case iana.ETypeAES128CTSHMACSHA256:
+		return iana.CksumTypeHMACSHA256128AES128, true
+	case iana.ETypeAES256CTSHMACSHA384:
+		return iana.CksumTypeHMACSHA384192AES256, true
+	default:
+		return 0, false
+	}
+}
+
 // aesSHA1Checksum implements the RFC 3961 simplified-profile checksum used by
 // the AES-SHA1 enctypes (cksumtype 15/16): Kc = DK(base-key, usage | 0x99),
 // then HMAC-SHA1(Kc, data) truncated to 96 bits (12 bytes). keyLen is the AES

--- a/network/kerberos/v5/iana/constants.go
+++ b/network/kerberos/v5/iana/constants.go
@@ -96,6 +96,7 @@ const (
 	PAPKASReq            = 16  // PA-PK-AS-REQ (PKINIT, MS-PKCA)
 	PAPKASRep            = 17  // PA-PK-AS-REP (PKINIT, MS-PKCA)
 	PAETypeInfo2         = 19  // PA-ETYPE-INFO2 (replaces PA-ETYPE-INFO)
+	PAForUser            = 129 // PA-FOR-USER (MS-SFU S4U2Self)
 	PASvrReferralInfo    = 20  // PA-SVR-REFERRAL-INFO (RFC 6806)
 	PAPACRequest         = 128 // KERB-PA-PAC-REQUEST (MS-KILE)
 	PAFXCookie           = 133 // PA-FX-COOKIE (RFC 6113 FAST)

--- a/network/kerberos/v5/messages/additickets_test.go
+++ b/network/kerberos/v5/messages/additickets_test.go
@@ -1,0 +1,108 @@
+package messages
+
+import (
+	"bytes"
+	"encoding/asn1"
+	"testing"
+	"time"
+)
+
+// childByTag parses a SEQUENCE TLV and returns the first element whose
+// class/tag match.
+func childByTag(t *testing.T, seqTLV []byte, class, tag int) asn1.RawValue {
+	t.Helper()
+	var seq asn1.RawValue
+	if _, err := asn1.Unmarshal(seqTLV, &seq); err != nil {
+		t.Fatalf("parse SEQUENCE: %v", err)
+	}
+	rest := seq.Bytes
+	for len(rest) > 0 {
+		var e asn1.RawValue
+		r, err := asn1.Unmarshal(rest, &e)
+		if err != nil {
+			t.Fatalf("iterate SEQUENCE: %v", err)
+		}
+		if e.Class == class && e.Tag == tag {
+			return e
+		}
+		rest = r
+	}
+	t.Fatalf("no element with class=%d tag=%d", class, tag)
+	return asn1.RawValue{}
+}
+
+func sampleTicket(t *testing.T) (Ticket, []byte) {
+	t.Helper()
+	tkt := Ticket{
+		TktVno:  KerberosV5,
+		Realm:   "CORP.LOCAL",
+		SName:   PrincipalName{NameType: NameTypeSRVInst, NameString: []string{"cifs", "dc01.corp.local"}},
+		EncPart: EncryptedData{EType: ETypeAES256CTSHMACSHA196, Cipher: bytes.Repeat([]byte{0x5a}, 16)},
+	}
+	raw, err := tkt.Marshal()
+	if err != nil {
+		t.Fatalf("Ticket.Marshal: %v", err)
+	}
+	return tkt, raw
+}
+
+// TestKDCReqBodyAdditionalTicketsEncoding verifies that additional-tickets are
+// spliced in as [11] EXPLICIT SEQUENCE OF Ticket with each ticket kept in its
+// APPLICATION[1] form and fully recoverable.
+func TestKDCReqBodyAdditionalTicketsEncoding(t *testing.T) {
+	_, tktRaw := sampleTicket(t)
+
+	body := KDCReqBody{
+		KDCOptions:      NewKerberosFlags(1),
+		Realm:           "CORP.LOCAL",
+		SName:           PrincipalName{NameType: NameTypeSRVInst, NameString: []string{"host", "target"}},
+		Till:            time.Date(2026, 7, 9, 20, 0, 0, 0, time.UTC),
+		Nonce:           12345,
+		EType:           []int{ETypeAES256CTSHMACSHA196},
+		AdditTicketsRaw: [][]byte{tktRaw},
+	}
+	bodyTLV, err := encodeKDCReqBodyForTGS(body)
+	if err != nil {
+		t.Fatalf("encodeKDCReqBodyForTGS: %v", err)
+	}
+
+	// body -> [11] -> SEQUENCE OF -> first element must be APPLICATION[1].
+	// elem11.Bytes is the SEQUENCE-OF Ticket TLV (the [11] EXPLICIT content).
+	elem11 := childByTag(t, bodyTLV, asn1.ClassContextSpecific, 11)
+	first := childByTag(t, elem11.Bytes, asn1.ClassApplication, 1)
+	if !bytes.Equal(first.FullBytes, tktRaw) {
+		t.Errorf("additional ticket bytes not preserved verbatim")
+	}
+	// And it must reparse as a Ticket.
+	var got Ticket
+	if _, err := got.Unmarshal(first.FullBytes); err != nil {
+		t.Fatalf("reparse additional ticket: %v", err)
+	}
+	if got.Realm != "CORP.LOCAL" || got.SName.NameString[0] != "cifs" {
+		t.Errorf("additional ticket fields wrong: %+v", got)
+	}
+}
+
+// TestKDCReqBodyNoAdditionalTickets confirms the body is unchanged (no [11])
+// when there are no additional tickets.
+func TestKDCReqBodyNoAdditionalTickets(t *testing.T) {
+	body := KDCReqBody{
+		KDCOptions: NewKerberosFlags(1),
+		Realm:      "CORP.LOCAL",
+		SName:      PrincipalName{NameType: NameTypeSRVInst, NameString: []string{"host", "target"}},
+		Till:       time.Date(2026, 7, 9, 20, 0, 0, 0, time.UTC),
+		Nonce:      1,
+		EType:      []int{ETypeAES256CTSHMACSHA196},
+	}
+	withHelper, err := encodeKDCReqBodyForTGS(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plain, err := asn1.Marshal(marshalKDCReqBody(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(withHelper, plain) {
+		t.Error("body with no additional tickets should equal the plain struct marshal")
+	}
+}

--- a/network/kerberos/v5/messages/kdcreqbody.go
+++ b/network/kerberos/v5/messages/kdcreqbody.go
@@ -12,36 +12,83 @@ import (
 // Realm has no struct tag: Go ignores explicit,tag:N for asn1.RawValue fields, so
 // realmExplicit() pre-builds the [2] EXPLICIT { GeneralString } wrapper instead.
 type kdcReqBodyMarshal struct {
-	KDCOptions   asn1.BitString       `asn1:"explicit,tag:0"`
-	CName        PrincipalNameMarshal `asn1:"explicit,tag:1,optional"`
-	Realm        asn1.RawValue        // pre-encoded as [2] EXPLICIT { GeneralString } by realmExplicit
-	SName        PrincipalNameMarshal `asn1:"explicit,tag:3,optional"`
-	From         time.Time            `asn1:"explicit,tag:4,optional,generalized"`
-	Till         time.Time            `asn1:"explicit,tag:5,generalized"`
-	RTime        time.Time            `asn1:"explicit,tag:6,optional,generalized"`
-	Nonce        int                  `asn1:"explicit,tag:7"`
-	EType        []int                `asn1:"explicit,tag:8"`
-	Addresses    []HostAddress        `asn1:"explicit,tag:9,optional"`
-	EncAuthData  EncryptedData        `asn1:"explicit,tag:10,optional"`
-	AdditTickets []Ticket             `asn1:"explicit,tag:11,optional"`
+	KDCOptions  asn1.BitString       `asn1:"explicit,tag:0"`
+	CName       PrincipalNameMarshal `asn1:"explicit,tag:1,optional"`
+	Realm       asn1.RawValue        // pre-encoded as [2] EXPLICIT { GeneralString } by realmExplicit
+	SName       PrincipalNameMarshal `asn1:"explicit,tag:3,optional"`
+	From        time.Time            `asn1:"explicit,tag:4,optional,generalized"`
+	Till        time.Time            `asn1:"explicit,tag:5,generalized"`
+	RTime       time.Time            `asn1:"explicit,tag:6,optional,generalized"`
+	Nonce       int                  `asn1:"explicit,tag:7"`
+	EType       []int                `asn1:"explicit,tag:8"`
+	Addresses   []HostAddress        `asn1:"explicit,tag:9,optional"`
+	EncAuthData EncryptedData        `asn1:"explicit,tag:10,optional"`
+	// additional-tickets [11] is NOT a struct field: Go's encoding/asn1 would
+	// emit each Ticket as a bare SEQUENCE instead of its APPLICATION[1] form.
+	// It is spliced in by encodeKDCReqBodyForTGS when present.
 }
 
-// marshalKDCReqBody converts a KDCReqBody to its GeneralString-encoded form.
+// marshalKDCReqBody converts a KDCReqBody to its GeneralString-encoded form
+// (fields 0-10; additional-tickets are handled separately).
 func marshalKDCReqBody(b KDCReqBody) kdcReqBodyMarshal {
 	return kdcReqBodyMarshal{
-		KDCOptions:   b.KDCOptions,
-		CName:        MarshalPrincipalName(b.CName),
-		Realm:        realmExplicit(2, b.Realm),
-		SName:        MarshalPrincipalName(b.SName),
-		From:         b.From,
-		Till:         b.Till,
-		RTime:        b.RTime,
-		Nonce:        b.Nonce,
-		EType:        b.EType,
-		Addresses:    b.Addresses,
-		EncAuthData:  b.EncAuthData,
-		AdditTickets: b.AdditTickets,
+		KDCOptions:  b.KDCOptions,
+		CName:       MarshalPrincipalName(b.CName),
+		Realm:       realmExplicit(2, b.Realm),
+		SName:       MarshalPrincipalName(b.SName),
+		From:        b.From,
+		Till:        b.Till,
+		RTime:       b.RTime,
+		Nonce:       b.Nonce,
+		EType:       b.EType,
+		Addresses:   b.Addresses,
+		EncAuthData: b.EncAuthData,
 	}
+}
+
+// encodeKDCReqBodyForTGS marshals a KDC-REQ-BODY and, when the body carries
+// additional-tickets, splices in a correctly-encoded [11] EXPLICIT SEQUENCE OF
+// Ticket (each an APPLICATION[1] TLV). AdditTicketsRaw is preferred (verbatim
+// KDC-issued bytes); otherwise AdditTickets are marshaled. Returns the complete
+// KDC-REQ-BODY SEQUENCE TLV.
+func encodeKDCReqBodyForTGS(b KDCReqBody) ([]byte, error) {
+	base, err := asn1.Marshal(marshalKDCReqBody(b))
+	if err != nil {
+		return nil, err
+	}
+	if len(b.AdditTicketsRaw) == 0 && len(b.AdditTickets) == 0 {
+		return base, nil
+	}
+
+	var tktTLVs []byte
+	for _, raw := range b.AdditTicketsRaw {
+		tktTLVs = append(tktTLVs, raw...)
+	}
+	for i := range b.AdditTickets {
+		m, err := b.AdditTickets[i].Marshal()
+		if err != nil {
+			return nil, err
+		}
+		tktTLVs = append(tktTLVs, m...)
+	}
+	seqOf, err := asn1.Marshal(asn1.RawValue{Class: asn1.ClassUniversal, Tag: asn1.TagSequence, IsCompound: true, Bytes: tktTLVs})
+	if err != nil {
+		return nil, err
+	}
+	elem11, err := asn1.Marshal(asn1.RawValue{Class: asn1.ClassContextSpecific, Tag: 11, IsCompound: true, Bytes: seqOf})
+	if err != nil {
+		return nil, err
+	}
+
+	// Splice elem11 into the base body SEQUENCE's content.
+	var body asn1.RawValue
+	if _, err := asn1.Unmarshal(base, &body); err != nil {
+		return nil, err
+	}
+	content := make([]byte, 0, len(body.Bytes)+len(elem11))
+	content = append(content, body.Bytes...)
+	content = append(content, elem11...)
+	return asn1.Marshal(asn1.RawValue{Class: asn1.ClassUniversal, Tag: asn1.TagSequence, IsCompound: true, Bytes: content})
 }
 
 // KDCReqBody is the body of a KDC request (AS-REQ or TGS-REQ),
@@ -69,6 +116,12 @@ type KDCReqBody struct {
 	Addresses []HostAddress `asn1:"explicit,tag:9,optional"`
 	// EncAuthData contains encrypted authorization data (optional, TGS-REQ).
 	EncAuthData EncryptedData `asn1:"explicit,tag:10,optional"`
-	// AdditTickets contains additional tickets (optional, for TGS renewal/forwarding).
-	AdditTickets []Ticket `asn1:"explicit,tag:11,optional"`
+	// AdditTickets holds additional tickets (parsed form) for the TGS-REQ
+	// additional-tickets field — used by U2U and S4U2Proxy. Marshaled by
+	// encodeKDCReqBodyForTGS (not by generic asn1, which would mis-encode the
+	// APPLICATION[1] tickets), hence asn1:"-".
+	AdditTickets []Ticket `asn1:"-"`
+	// AdditTicketsRaw holds the raw APPLICATION[1] bytes of additional tickets,
+	// preferred over AdditTickets on marshal to re-emit KDC-issued bytes verbatim.
+	AdditTicketsRaw [][]byte `asn1:"-"`
 }

--- a/network/kerberos/v5/messages/tgsreq.go
+++ b/network/kerberos/v5/messages/tgsreq.go
@@ -18,11 +18,13 @@ type tgsReqInner struct {
 }
 
 // tgsReqMarshal is the inner SEQUENCE for marshaling — uses GeneralString types.
+// ReqBody is a pre-encoded [4] EXPLICIT { KDC-REQ-BODY } RawValue so that
+// additional-tickets can be spliced correctly (see encodeKDCReqBodyForTGS).
 type tgsReqMarshal struct {
-	PVNO    int               `asn1:"explicit,tag:1"`
-	MsgType int               `asn1:"explicit,tag:2"`
-	PAData  []PAData          `asn1:"explicit,tag:3,optional"`
-	ReqBody kdcReqBodyMarshal `asn1:"explicit,tag:4"`
+	PVNO    int           `asn1:"explicit,tag:1"`
+	MsgType int           `asn1:"explicit,tag:2"`
+	PAData  []PAData      `asn1:"explicit,tag:3,optional"`
+	ReqBody asn1.RawValue // pre-encoded [4] EXPLICIT { KDC-REQ-BODY }
 }
 
 // TGSReq is a Kerberos TGS-REQ (Ticket Granting Service Request) message,
@@ -42,11 +44,15 @@ type TGSReq struct {
 
 // Marshal encodes the TGS-REQ as an ASN.1 APPLICATION[12] wrapped SEQUENCE.
 func (r *TGSReq) Marshal() ([]byte, error) {
+	bodyTLV, err := encodeKDCReqBodyForTGS(r.ReqBody)
+	if err != nil {
+		return nil, err
+	}
 	inner := tgsReqMarshal{
 		PVNO:    KerberosV5,
 		MsgType: MsgTypeTGSReq,
 		PAData:  r.PAData,
-		ReqBody: marshalKDCReqBody(r.ReqBody),
+		ReqBody: asn1.RawValue{Class: asn1.ClassContextSpecific, Tag: 4, IsCompound: true, Bytes: bodyTLV},
 	}
 	seq_bytes, err := asn1.Marshal(inner)
 	if err != nil {

--- a/network/kerberos/v5/messages/types.go
+++ b/network/kerberos/v5/messages/types.go
@@ -102,6 +102,14 @@ func realmExplicit(tag int, s string) asn1.RawValue {
 	return asn1.RawValue{Class: asn1.ClassContextSpecific, Tag: tag, IsCompound: true, Bytes: gsBytes}
 }
 
+// ExplicitGeneralString returns s encoded as an ASN.1 [tag] EXPLICIT
+// { GeneralString } context element. Exported for other packages (e.g. the
+// MS-SFU PA-FOR-USER builder) that must emit GeneralString fields the standard
+// library would otherwise encode as PrintableString.
+func ExplicitGeneralString(tag int, s string) asn1.RawValue {
+	return realmExplicit(tag, s)
+}
+
 // PrincipalNameMarshal is the wire representation of PrincipalName for marshaling.
 // It uses []asn1.RawValue (GeneralString) instead of []string, which Go's asn1
 // would incorrectly encode as PrintableString.

--- a/network/kerberos/v5/s4u.go
+++ b/network/kerberos/v5/s4u.go
@@ -1,0 +1,114 @@
+package kerberos
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	kerbcrypto "github.com/TheManticoreProject/Manticore/network/kerberos/v5/crypto"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/messages"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/sfu"
+)
+
+// S4U2Self performs the MS-SFU S4U2Self exchange: the service (this client's
+// principal), holding its own TGT, requests a service ticket to itself on behalf
+// of the user (impersonateUser, impersonateRealm), identified only by name. It
+// is the first half of constrained delegation and, on its own, a way to obtain a
+// usable service ticket (with the target user's PAC) for any user without their
+// secret — subject to the account's delegation configuration.
+//
+// GetTGT must have succeeded first (the client must hold its service TGT). If
+// impersonateRealm is empty the client's realm is used. Returns the service
+// ticket, its raw APPLICATION[1] bytes, and the ticket session key.
+func (c *KerberosClient) S4U2Self(impersonateUser, impersonateRealm string) (messages.Ticket, []byte, []byte, error) {
+	if !c.hasTGT {
+		return messages.Ticket{}, nil, nil, fmt.Errorf("kerberos: no TGT: call GetTGT first")
+	}
+	if impersonateUser == "" {
+		return messages.Ticket{}, nil, nil, fmt.Errorf("kerberos: S4U2Self requires a user to impersonate")
+	}
+	if impersonateRealm == "" {
+		impersonateRealm = c.realm
+	} else {
+		impersonateRealm = strings.ToUpper(impersonateRealm)
+	}
+
+	// PA-FOR-USER identifies the impersonated user, protected by a checksum keyed
+	// with this service's TGT session key.
+	userName := messages.PrincipalName{
+		NameType:   messages.NameTypePrincipal,
+		NameString: []string{impersonateUser},
+	}
+	paForUser, err := sfu.BuildPAForUser(userName, impersonateRealm, c.sessionKey, c.sessionEType)
+	if err != nil {
+		return messages.Ticket{}, nil, nil, fmt.Errorf("kerberos: build PA-FOR-USER: %w", err)
+	}
+
+	// AP-REQ over the service's own TGT.
+	apReqBytes, err := c.buildAPReq()
+	if err != nil {
+		return messages.Ticket{}, nil, nil, fmt.Errorf("kerberos: build AP-REQ: %w", err)
+	}
+
+	// The requested server is the service itself (its own account).
+	self := messages.PrincipalName{
+		NameType:   messages.NameTypePrincipal,
+		NameString: []string{c.username},
+	}
+
+	nonce := randomNonce()
+	tgsReq := &messages.TGSReq{
+		PVNO:    messages.KerberosV5,
+		MsgType: messages.MsgTypeTGSReq,
+		PAData: []messages.PAData{
+			{PADataType: messages.PATGSReq, PADataValue: apReqBytes},
+			paForUser,
+			{PADataType: messages.PAPACRequest, PADataValue: []byte{0x30, 0x05, 0xa0, 0x03, 0x01, 0x01, 0xff}},
+		},
+		ReqBody: messages.KDCReqBody{
+			KDCOptions: kdcOptionsForTGSReq(),
+			Realm:      c.realm,
+			SName:      self,
+			Till:       time.Now().UTC().Add(24 * time.Hour),
+			Nonce:      nonce,
+			EType: []int{
+				messages.ETypeAES256CTSHMACSHA196,
+				messages.ETypeAES128CTSHMACSHA196,
+				messages.ETypeRC4HMAC,
+			},
+		},
+	}
+
+	tgsReqBytes, err := tgsReq.Marshal()
+	if err != nil {
+		return messages.Ticket{}, nil, nil, fmt.Errorf("kerberos: marshal S4U2Self TGS-REQ: %w", err)
+	}
+	resp, err := kdcSend(c.kdcHost, defaultKDCPort, tgsReqBytes)
+	if err != nil {
+		return messages.Ticket{}, nil, nil, err
+	}
+
+	var krbErr messages.KRBError
+	if _, parseErr := krbErr.Unmarshal(resp); parseErr == nil {
+		return messages.Ticket{}, nil, nil, fmt.Errorf("kerberos: S4U2Self error %d: %s", krbErr.ErrorCode, krbErr.EText)
+	}
+
+	var tgsRep messages.TGSRep
+	if _, err := tgsRep.Unmarshal(resp); err != nil {
+		return messages.Ticket{}, nil, nil, fmt.Errorf("kerberos: parse S4U2Self TGS-REP: %w", err)
+	}
+
+	encPlain, err := kerbcrypto.Decrypt(c.sessionEType, c.sessionKey, kerbcrypto.KeyUsageTGSRepEncSessionKey, tgsRep.EncPart.Cipher)
+	if err != nil {
+		return messages.Ticket{}, nil, nil, fmt.Errorf("kerberos: decrypt S4U2Self TGS-REP enc-part: %w", err)
+	}
+	var encTGSRep messages.EncTGSRepPart
+	if _, err := encTGSRep.Unmarshal(encPlain); err != nil {
+		return messages.Ticket{}, nil, nil, fmt.Errorf("kerberos: parse S4U2Self EncTGSRepPart: %w", err)
+	}
+	if encTGSRep.Nonce != nonce {
+		return messages.Ticket{}, nil, nil, fmt.Errorf("kerberos: S4U2Self nonce mismatch: got %d, want %d", encTGSRep.Nonce, nonce)
+	}
+
+	return tgsRep.Ticket, tgsRep.TicketRaw, encTGSRep.Key.KeyValue, nil
+}

--- a/network/kerberos/v5/s4u.go
+++ b/network/kerberos/v5/s4u.go
@@ -7,6 +7,7 @@ import (
 
 	kerbcrypto "github.com/TheManticoreProject/Manticore/network/kerberos/v5/crypto"
 	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/messages"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/mskile"
 	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/sfu"
 )
 
@@ -108,6 +109,101 @@ func (c *KerberosClient) S4U2Self(impersonateUser, impersonateRealm string) (mes
 	}
 	if encTGSRep.Nonce != nonce {
 		return messages.Ticket{}, nil, nil, fmt.Errorf("kerberos: S4U2Self nonce mismatch: got %d, want %d", encTGSRep.Nonce, nonce)
+	}
+
+	return tgsRep.Ticket, tgsRep.TicketRaw, encTGSRep.Key.KeyValue, nil
+}
+
+// S4U2Proxy performs the MS-SFU S4U2Proxy exchange: the service, holding its own
+// TGT and a service ticket obtained on behalf of a user (typically from
+// S4U2Self), requests a service ticket to a target service (targetSPN) as that
+// user. It is the second half of constrained delegation.
+//
+// s4u2selfTicketRaw is the raw APPLICATION[1] bytes of the user's service ticket
+// to this service (the S4U2Self result). The request sets the cname-in-addl-tkt
+// KDC option, carries that ticket in additional-tickets, and includes
+// PA-PAC-OPTIONS with the resource-based-constrained-delegation bit. Returns the
+// service ticket to the target, its raw bytes, and the ticket session key.
+func (c *KerberosClient) S4U2Proxy(targetSPN string, s4u2selfTicketRaw []byte) (messages.Ticket, []byte, []byte, error) {
+	if !c.hasTGT {
+		return messages.Ticket{}, nil, nil, fmt.Errorf("kerberos: no TGT: call GetTGT first")
+	}
+	if len(s4u2selfTicketRaw) == 0 {
+		return messages.Ticket{}, nil, nil, fmt.Errorf("kerberos: S4U2Proxy requires the S4U2Self service ticket")
+	}
+
+	sname, err := parseSPN(targetSPN, c.realm)
+	if err != nil {
+		return messages.Ticket{}, nil, nil, fmt.Errorf("kerberos: parse target SPN %q: %w", targetSPN, err)
+	}
+
+	apReqBytes, err := c.buildAPReq()
+	if err != nil {
+		return messages.Ticket{}, nil, nil, fmt.Errorf("kerberos: build AP-REQ: %w", err)
+	}
+
+	pacOptions, err := mskile.PACOptionsPAData(mskile.PACOptionResourceBasedConstrainedDeleg)
+	if err != nil {
+		return messages.Ticket{}, nil, nil, fmt.Errorf("kerberos: build PA-PAC-OPTIONS: %w", err)
+	}
+
+	nonce := randomNonce()
+	tgsReq := &messages.TGSReq{
+		PVNO:    messages.KerberosV5,
+		MsgType: messages.MsgTypeTGSReq,
+		PAData: []messages.PAData{
+			{PADataType: messages.PATGSReq, PADataValue: apReqBytes},
+			pacOptions,
+		},
+		ReqBody: messages.KDCReqBody{
+			KDCOptions: encodeKDCOptions(
+				kdcOptionForwardable,
+				kdcOptionRenewable,
+				kdcOptionCanonicalize,
+				kdcOptionCNameInAddlTkt,
+			),
+			Realm: c.realm,
+			SName: sname,
+			Till:  time.Now().UTC().Add(24 * time.Hour),
+			Nonce: nonce,
+			EType: []int{
+				messages.ETypeAES256CTSHMACSHA196,
+				messages.ETypeAES128CTSHMACSHA196,
+				messages.ETypeRC4HMAC,
+			},
+			AdditTicketsRaw: [][]byte{s4u2selfTicketRaw},
+		},
+	}
+
+	tgsReqBytes, err := tgsReq.Marshal()
+	if err != nil {
+		return messages.Ticket{}, nil, nil, fmt.Errorf("kerberos: marshal S4U2Proxy TGS-REQ: %w", err)
+	}
+	resp, err := kdcSend(c.kdcHost, defaultKDCPort, tgsReqBytes)
+	if err != nil {
+		return messages.Ticket{}, nil, nil, err
+	}
+
+	var krbErr messages.KRBError
+	if _, parseErr := krbErr.Unmarshal(resp); parseErr == nil {
+		return messages.Ticket{}, nil, nil, fmt.Errorf("kerberos: S4U2Proxy error %d: %s", krbErr.ErrorCode, krbErr.EText)
+	}
+
+	var tgsRep messages.TGSRep
+	if _, err := tgsRep.Unmarshal(resp); err != nil {
+		return messages.Ticket{}, nil, nil, fmt.Errorf("kerberos: parse S4U2Proxy TGS-REP: %w", err)
+	}
+
+	encPlain, err := kerbcrypto.Decrypt(c.sessionEType, c.sessionKey, kerbcrypto.KeyUsageTGSRepEncSessionKey, tgsRep.EncPart.Cipher)
+	if err != nil {
+		return messages.Ticket{}, nil, nil, fmt.Errorf("kerberos: decrypt S4U2Proxy TGS-REP enc-part: %w", err)
+	}
+	var encTGSRep messages.EncTGSRepPart
+	if _, err := encTGSRep.Unmarshal(encPlain); err != nil {
+		return messages.Ticket{}, nil, nil, fmt.Errorf("kerberos: parse S4U2Proxy EncTGSRepPart: %w", err)
+	}
+	if encTGSRep.Nonce != nonce {
+		return messages.Ticket{}, nil, nil, fmt.Errorf("kerberos: S4U2Proxy nonce mismatch: got %d, want %d", encTGSRep.Nonce, nonce)
 	}
 
 	return tgsRep.Ticket, tgsRep.TicketRaw, encTGSRep.Key.KeyValue, nil

--- a/network/kerberos/v5/sfu/foruser.go
+++ b/network/kerberos/v5/sfu/foruser.go
@@ -1,0 +1,126 @@
+// Package sfu implements the Microsoft Service for User and Constrained
+// Delegation extensions ([MS-SFU]) that layer onto RFC 4120's TGS exchange:
+// PA-FOR-USER (S4U2Self) and the padata used for S4U2Proxy. Like the rest of
+// the MS extensions, these ride the RFC's padata / additional-tickets extension
+// points — the TGS-REQ/REP messages are unchanged.
+package sfu
+
+import (
+	"encoding/asn1"
+	"encoding/binary"
+	"fmt"
+
+	kerbcrypto "github.com/TheManticoreProject/Manticore/network/kerberos/v5/crypto"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/iana"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/messages"
+)
+
+// authPackageKerberos is the fixed auth-package value in PA-FOR-USER ([MS-SFU]
+// 2.2.1): the authentication mechanism name, which MUST be "Kerberos".
+const authPackageKerberos = "Kerberos"
+
+// s4uByteArray builds the S4UByteArray checksummed by PA-FOR-USER ([MS-SFU]
+// 2.2.1): the userName.name-type as a 4-byte little-endian integer, followed by
+// each userName.name-string component, then userRealm, then auth-package — with
+// no null terminators.
+func s4uByteArray(userName messages.PrincipalName, userRealm, authPackage string) []byte {
+	buf := make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf, uint32(userName.NameType))
+	for _, s := range userName.NameString {
+		buf = append(buf, []byte(s)...)
+	}
+	buf = append(buf, []byte(userRealm)...)
+	buf = append(buf, []byte(authPackage)...)
+	return buf
+}
+
+// BuildPAForUser builds the PA-FOR-USER pre-authentication data element used in
+// an S4U2Self TGS-REQ, on behalf of the user (userName, userRealm). The keyed
+// checksum is computed with the requesting service's TGT session key at key
+// usage KERB_NON_KERB_CKSUM_SALT (17).
+//
+// [MS-SFU] 2.2.1 specifies KERB_CHECKSUM_HMAC_MD5, which is correct when the TGT
+// session key is RC4. For AES TGT session keys, modern KDCs expect the checksum
+// type paired with the session key's enctype; this function selects that type
+// from sessionKeyEType so it interoperates with current Active Directory.
+func BuildPAForUser(userName messages.PrincipalName, userRealm string, sessionKey []byte, sessionKeyEType int) (messages.PAData, error) {
+	cksumType, ok := kerbcrypto.ChecksumTypeForEType(sessionKeyEType)
+	if !ok {
+		return messages.PAData{}, fmt.Errorf("sfu: unsupported session-key etype %d", sessionKeyEType)
+	}
+	buf := s4uByteArray(userName, userRealm, authPackageKerberos)
+	sum, err := kerbcrypto.GetChecksum(cksumType, sessionKey, iana.KeyUsageKerbNonKerbCksumSalt, buf)
+	if err != nil {
+		return messages.PAData{}, fmt.Errorf("sfu: PA-FOR-USER checksum: %w", err)
+	}
+
+	userNameElem, err := asn1.MarshalWithParams(messages.MarshalPrincipalName(userName), "explicit,tag:0")
+	if err != nil {
+		return messages.PAData{}, err
+	}
+	userRealmElem, err := asn1.Marshal(messages.ExplicitGeneralString(1, userRealm))
+	if err != nil {
+		return messages.PAData{}, err
+	}
+	cksumElem, err := asn1.MarshalWithParams(messages.Checksum{CKSumType: cksumType, Checksum: sum}, "explicit,tag:2")
+	if err != nil {
+		return messages.PAData{}, err
+	}
+	authPkgElem, err := asn1.Marshal(messages.ExplicitGeneralString(3, authPackageKerberos))
+	if err != nil {
+		return messages.PAData{}, err
+	}
+
+	body := make([]byte, 0, len(userNameElem)+len(userRealmElem)+len(cksumElem)+len(authPkgElem))
+	body = append(body, userNameElem...)
+	body = append(body, userRealmElem...)
+	body = append(body, cksumElem...)
+	body = append(body, authPkgElem...)
+
+	seq, err := asn1.Marshal(asn1.RawValue{Class: asn1.ClassUniversal, Tag: asn1.TagSequence, IsCompound: true, Bytes: body})
+	if err != nil {
+		return messages.PAData{}, err
+	}
+	return messages.PAData{PADataType: iana.PAForUser, PADataValue: seq}, nil
+}
+
+// PAForUser is the decoded content of a PA-FOR-USER element.
+type PAForUser struct {
+	UserName    messages.PrincipalName
+	UserRealm   string
+	Cksum       messages.Checksum
+	AuthPackage string
+}
+
+type paForUserInner struct {
+	UserName    messages.PrincipalName `asn1:"explicit,tag:0"`
+	UserRealm   string                 `asn1:"explicit,tag:1,generalstring"`
+	Cksum       messages.Checksum      `asn1:"explicit,tag:2"`
+	AuthPackage string                 `asn1:"explicit,tag:3,generalstring"`
+}
+
+// ParsePAForUser decodes a PA-FOR-USER padata-value.
+func ParsePAForUser(b []byte) (*PAForUser, error) {
+	var inner paForUserInner
+	if _, err := asn1.Unmarshal(b, &inner); err != nil {
+		return nil, fmt.Errorf("sfu: parse PA-FOR-USER: %w", err)
+	}
+	return &PAForUser{
+		UserName:    inner.UserName,
+		UserRealm:   inner.UserRealm,
+		Cksum:       inner.Cksum,
+		AuthPackage: inner.AuthPackage,
+	}, nil
+}
+
+// VerifyPAForUser recomputes the PA-FOR-USER checksum with the given TGT session
+// key and reports whether it matches, defending against tampering with the
+// impersonated identity.
+func VerifyPAForUser(p *PAForUser, sessionKey []byte, sessionKeyEType int) bool {
+	cksumType, ok := kerbcrypto.ChecksumTypeForEType(sessionKeyEType)
+	if !ok || cksumType != p.Cksum.CKSumType {
+		return false
+	}
+	buf := s4uByteArray(p.UserName, p.UserRealm, p.AuthPackage)
+	return kerbcrypto.VerifyChecksum(cksumType, sessionKey, iana.KeyUsageKerbNonKerbCksumSalt, buf, p.Cksum.Checksum)
+}

--- a/network/kerberos/v5/sfu/foruser_test.go
+++ b/network/kerberos/v5/sfu/foruser_test.go
@@ -1,0 +1,84 @@
+package sfu
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/iana"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/messages"
+)
+
+func impersonated() messages.PrincipalName {
+	return messages.PrincipalName{NameType: iana.NameTypePrincipal, NameString: []string{"administrator"}}
+}
+
+func TestBuildParsePAForUserRoundtrip(t *testing.T) {
+	key := bytes.Repeat([]byte{0x42}, 32) // AES256 TGT session key
+	pa, err := BuildPAForUser(impersonated(), "CORP.LOCAL", key, iana.ETypeAES256CTSHMACSHA196)
+	if err != nil {
+		t.Fatalf("BuildPAForUser: %v", err)
+	}
+	if pa.PADataType != iana.PAForUser {
+		t.Errorf("padata type = %d, want %d", pa.PADataType, iana.PAForUser)
+	}
+
+	p, err := ParsePAForUser(pa.PADataValue)
+	if err != nil {
+		t.Fatalf("ParsePAForUser: %v", err)
+	}
+	if len(p.UserName.NameString) != 1 || p.UserName.NameString[0] != "administrator" {
+		t.Errorf("userName mismatch: %+v", p.UserName)
+	}
+	if p.UserRealm != "CORP.LOCAL" {
+		t.Errorf("userRealm = %q", p.UserRealm)
+	}
+	if p.AuthPackage != "Kerberos" {
+		t.Errorf("auth-package = %q, want Kerberos", p.AuthPackage)
+	}
+	if p.Cksum.CKSumType != iana.CksumTypeHMACSHA196AES256 {
+		t.Errorf("cksum type = %d, want %d (paired with AES256)", p.Cksum.CKSumType, iana.CksumTypeHMACSHA196AES256)
+	}
+	if !VerifyPAForUser(p, key, iana.ETypeAES256CTSHMACSHA196) {
+		t.Error("VerifyPAForUser rejected a valid element")
+	}
+}
+
+func TestPAForUserChecksumTypeFollowsSessionKey(t *testing.T) {
+	// RC4 session key -> KERB_CHECKSUM_HMAC_MD5 (the [MS-SFU] literal type).
+	rc4Key := bytes.Repeat([]byte{0x11}, 16)
+	pa, err := BuildPAForUser(impersonated(), "CORP.LOCAL", rc4Key, iana.ETypeRC4HMAC)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p, _ := ParsePAForUser(pa.PADataValue)
+	if p.Cksum.CKSumType != iana.CksumTypeHMACMD5 {
+		t.Errorf("RC4 session key should use HMAC-MD5 checksum (-138), got %d", p.Cksum.CKSumType)
+	}
+	if !VerifyPAForUser(p, rc4Key, iana.ETypeRC4HMAC) {
+		t.Error("RC4 PA-FOR-USER did not verify")
+	}
+}
+
+func TestVerifyPAForUserDetectsTamper(t *testing.T) {
+	key := bytes.Repeat([]byte{0x42}, 32)
+	pa, _ := BuildPAForUser(impersonated(), "CORP.LOCAL", key, iana.ETypeAES256CTSHMACSHA196)
+	p, _ := ParsePAForUser(pa.PADataValue)
+
+	// Change the impersonated user; the checksum must no longer match.
+	p.UserName.NameString[0] = "guest"
+	if VerifyPAForUser(p, key, iana.ETypeAES256CTSHMACSHA196) {
+		t.Error("VerifyPAForUser accepted a tampered impersonation target")
+	}
+
+	// Wrong session key must also fail.
+	p2, _ := ParsePAForUser(pa.PADataValue)
+	if VerifyPAForUser(p2, bytes.Repeat([]byte{0x99}, 32), iana.ETypeAES256CTSHMACSHA196) {
+		t.Error("VerifyPAForUser accepted the wrong session key")
+	}
+}
+
+func TestBuildPAForUserRejectsBadEType(t *testing.T) {
+	if _, err := BuildPAForUser(impersonated(), "R", bytes.Repeat([]byte{1}, 16), 999); err == nil {
+		t.Error("expected error for unsupported session-key etype")
+	}
+}

--- a/network/kerberos/v5/u2u.go
+++ b/network/kerberos/v5/u2u.go
@@ -1,0 +1,114 @@
+package kerberos
+
+import (
+	"fmt"
+	"time"
+
+	kerbcrypto "github.com/TheManticoreProject/Manticore/network/kerberos/v5/crypto"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/messages"
+)
+
+// buildU2UTGSReq constructs the TGS-REQ for a user-to-user exchange: a normal
+// PA-TGS-REQ (AP-REQ over the client's TGT), the ENC-TKT-IN-SKEY KDC option, the
+// target user's TGT in additional-tickets, and the target user as sname. It is
+// separated from GetTGSU2U so the request shape can be tested without a KDC.
+func (c *KerberosClient) buildU2UTGSReq(targetUser, targetRealm string, targetTGTRaw []byte, nonce int) (*messages.TGSReq, error) {
+	apReqBytes, err := c.buildAPReq()
+	if err != nil {
+		return nil, fmt.Errorf("kerberos: build AP-REQ: %w", err)
+	}
+	sname := messages.PrincipalName{
+		NameType:   messages.NameTypePrincipal,
+		NameString: []string{targetUser},
+	}
+	realm := c.realm
+	if targetRealm != "" {
+		realm = targetRealm
+	}
+	return &messages.TGSReq{
+		PVNO:    messages.KerberosV5,
+		MsgType: messages.MsgTypeTGSReq,
+		PAData: []messages.PAData{
+			{PADataType: messages.PATGSReq, PADataValue: apReqBytes},
+		},
+		ReqBody: messages.KDCReqBody{
+			KDCOptions: encodeKDCOptions(
+				kdcOptionForwardable,
+				kdcOptionRenewable,
+				kdcOptionCanonicalize,
+				kdcOptionEncTktInSKey,
+			),
+			Realm: realm,
+			SName: sname,
+			Till:  time.Now().UTC().Add(24 * time.Hour),
+			Nonce: nonce,
+			EType: []int{
+				messages.ETypeAES256CTSHMACSHA196,
+				messages.ETypeAES128CTSHMACSHA196,
+				messages.ETypeRC4HMAC,
+			},
+			AdditTicketsRaw: [][]byte{targetTGTRaw},
+		},
+	}, nil
+}
+
+// GetTGSU2U performs a user-to-user (U2U) TGS exchange: it requests a service
+// ticket to the target user (targetUser in targetRealm, or the client's realm
+// if empty), presenting the target user's TGT (targetTGTRaw, raw APPLICATION[1]
+// bytes) in additional-tickets with the ENC-TKT-IN-SKEY option. The KDC issues a
+// ticket whose enc-part is encrypted with the session key of the target's TGT
+// (not a long-term key), which the target verifies via an AP-REQ carrying the
+// USE-SESSION-KEY option.
+//
+// GetTGT must have succeeded first (for the client's own TGT). Returns the
+// service ticket, its raw bytes, and the ticket session key.
+func (c *KerberosClient) GetTGSU2U(targetUser, targetRealm string, targetTGTRaw []byte) (messages.Ticket, []byte, []byte, error) {
+	if !c.hasTGT {
+		return messages.Ticket{}, nil, nil, fmt.Errorf("kerberos: no TGT: call GetTGT first")
+	}
+	if targetUser == "" {
+		return messages.Ticket{}, nil, nil, fmt.Errorf("kerberos: U2U requires a target user")
+	}
+	if len(targetTGTRaw) == 0 {
+		return messages.Ticket{}, nil, nil, fmt.Errorf("kerberos: U2U requires the target user's TGT")
+	}
+
+	nonce := randomNonce()
+	tgsReq, err := c.buildU2UTGSReq(targetUser, targetRealm, targetTGTRaw, nonce)
+	if err != nil {
+		return messages.Ticket{}, nil, nil, err
+	}
+
+	tgsReqBytes, err := tgsReq.Marshal()
+	if err != nil {
+		return messages.Ticket{}, nil, nil, fmt.Errorf("kerberos: marshal U2U TGS-REQ: %w", err)
+	}
+	resp, err := kdcSend(c.kdcHost, defaultKDCPort, tgsReqBytes)
+	if err != nil {
+		return messages.Ticket{}, nil, nil, err
+	}
+
+	var krbErr messages.KRBError
+	if _, parseErr := krbErr.Unmarshal(resp); parseErr == nil {
+		return messages.Ticket{}, nil, nil, fmt.Errorf("kerberos: U2U error %d: %s", krbErr.ErrorCode, krbErr.EText)
+	}
+
+	var tgsRep messages.TGSRep
+	if _, err := tgsRep.Unmarshal(resp); err != nil {
+		return messages.Ticket{}, nil, nil, fmt.Errorf("kerberos: parse U2U TGS-REP: %w", err)
+	}
+
+	encPlain, err := kerbcrypto.Decrypt(c.sessionEType, c.sessionKey, kerbcrypto.KeyUsageTGSRepEncSessionKey, tgsRep.EncPart.Cipher)
+	if err != nil {
+		return messages.Ticket{}, nil, nil, fmt.Errorf("kerberos: decrypt U2U TGS-REP enc-part: %w", err)
+	}
+	var encTGSRep messages.EncTGSRepPart
+	if _, err := encTGSRep.Unmarshal(encPlain); err != nil {
+		return messages.Ticket{}, nil, nil, fmt.Errorf("kerberos: parse U2U EncTGSRepPart: %w", err)
+	}
+	if encTGSRep.Nonce != nonce {
+		return messages.Ticket{}, nil, nil, fmt.Errorf("kerberos: U2U nonce mismatch: got %d, want %d", encTGSRep.Nonce, nonce)
+	}
+
+	return tgsRep.Ticket, tgsRep.TicketRaw, encTGSRep.Key.KeyValue, nil
+}

--- a/network/kerberos/v5/u2u_test.go
+++ b/network/kerberos/v5/u2u_test.go
@@ -1,0 +1,103 @@
+package kerberos
+
+import (
+	"bytes"
+	"encoding/asn1"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/messages"
+)
+
+// seqChild parses a SEQUENCE TLV and returns the first element with the given
+// class/tag.
+func seqChild(t *testing.T, seqTLV []byte, class, tag int) asn1.RawValue {
+	t.Helper()
+	var seq asn1.RawValue
+	if _, err := asn1.Unmarshal(seqTLV, &seq); err != nil {
+		t.Fatalf("parse SEQUENCE: %v", err)
+	}
+	rest := seq.Bytes
+	for len(rest) > 0 {
+		var e asn1.RawValue
+		r, err := asn1.Unmarshal(rest, &e)
+		if err != nil {
+			t.Fatalf("iterate: %v", err)
+		}
+		if e.Class == class && e.Tag == tag {
+			return e
+		}
+		rest = r
+	}
+	t.Fatalf("no element class=%d tag=%d", class, tag)
+	return asn1.RawValue{}
+}
+
+func TestU2URequestShape(t *testing.T) {
+	c := fakeTGTClient(t) // from export_test.go: a client with a populated TGT
+
+	// The target user's TGT (any APPLICATION[1] ticket for this structural test).
+	targetTkt := messages.Ticket{
+		TktVno:  messages.KerberosV5,
+		Realm:   "CORP.LOCAL",
+		SName:   messages.PrincipalName{NameType: messages.NameTypeSRVInst, NameString: []string{"krbtgt", "CORP.LOCAL"}},
+		EncPart: messages.EncryptedData{EType: messages.ETypeAES256CTSHMACSHA196, Cipher: bytes.Repeat([]byte{0x7a}, 16)},
+	}
+	targetTGTRaw, err := targetTkt.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req, err := c.buildU2UTGSReq("victim", "", targetTGTRaw, 4242)
+	if err != nil {
+		t.Fatalf("buildU2UTGSReq: %v", err)
+	}
+	wire, err := req.Marshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	// APPLICATION[12] -> inner SEQUENCE -> [4] body.
+	var app asn1.RawValue
+	if _, err := asn1.Unmarshal(wire, &app); err != nil {
+		t.Fatal(err)
+	}
+	if app.Class != asn1.ClassApplication || app.Tag != messages.MsgTypeTGSReq {
+		t.Fatalf("outer tag: class=%d tag=%d", app.Class, app.Tag)
+	}
+	bodyElem := seqChild(t, app.Bytes, asn1.ClassContextSpecific, 4)
+
+	// KDCOptions [0]: BIT STRING; ENC-TKT-IN-SKEY is bit 28 -> byte 3, 0x08.
+	optElem := seqChild(t, bodyElem.Bytes, asn1.ClassContextSpecific, 0)
+	var flags asn1.BitString
+	if _, err := asn1.Unmarshal(optElem.Bytes, &flags); err != nil {
+		t.Fatalf("parse KDCOptions: %v", err)
+	}
+	if flags.At(kdcOptionEncTktInSKey) != 1 {
+		t.Errorf("ENC-TKT-IN-SKEY (bit 28) not set; bytes=% X", flags.Bytes)
+	}
+	if flags.At(kdcOptionForwardable) != 1 {
+		t.Errorf("forwardable (bit 1) not set")
+	}
+
+	// additional-tickets [11] -> SEQUENCE OF -> first is APPLICATION[1], and it
+	// must be the target TGT verbatim.
+	addl := seqChild(t, bodyElem.Bytes, asn1.ClassContextSpecific, 11)
+	tkt := seqChild(t, addl.Bytes, asn1.ClassApplication, 1)
+	if !bytes.Equal(tkt.FullBytes, targetTGTRaw) {
+		t.Errorf("additional ticket is not the target TGT verbatim")
+	}
+}
+
+func TestGetTGSU2UValidatesInputs(t *testing.T) {
+	c := NewClient("svc", "corp.local", "10.0.0.1").WithPassword("x")
+	if _, _, _, err := c.GetTGSU2U("victim", "", []byte{1}); err == nil {
+		t.Error("expected error without a TGT")
+	}
+	c2 := fakeTGTClient(t)
+	if _, _, _, err := c2.GetTGSU2U("", "", []byte{1}); err == nil {
+		t.Error("expected error with empty target user")
+	}
+	if _, _, _, err := c2.GetTGSU2U("victim", "", nil); err == nil {
+		t.Error("expected error with no target TGT")
+	}
+}


### PR DESCRIPTION
## Summary

Phase 6 of the native, standard-library-only Kerberos v5 implementation: the MS-SFU Service-for-User / constrained-delegation extensions, layered on RFC 4120's TGS exchange (padata + additional-tickets extension points; the TGS-REQ/REP messages are unchanged).

**Stacked on #898** (base `kerberos-native`, which now holds phases 0-5). This PR is being built incrementally — S4U2Self first; S4U2Proxy (with the additional-tickets marshaling fix) follows on this branch.

## Changes (so far)

- New `sfu` package: `BuildPAForUser` / `ParsePAForUser` / `VerifyPAForUser` for PA-FOR-USER (padata type 129). The keyed checksum over `name-type(LE32) ‖ name-strings ‖ realm ‖ auth-package` uses key usage `KERB_NON_KERB_CKSUM_SALT` (17). [MS-SFU] 2.2.1 specifies HMAC-MD5 (correct for an RC4 TGT session key); for AES session keys the checksum type paired with the key's enctype is used, matching modern AD.
- `KerberosClient.S4U2Self(user, realm)` — requests a service ticket to the client's own principal on behalf of an arbitrary user, via PA-FOR-USER over the service's TGT.
- Supporting helpers: `crypto.ChecksumTypeForEType`, `messages.ExplicitGeneralString`, `iana.PAForUser`.

## How Verified

- `sfu` unit tests: PA-FOR-USER build/parse round-trip; the checksum type follows the session-key etype (RC4→HMAC-MD5, AES→paired); tampering with the impersonated identity or the key is rejected.
- `go test ./network/kerberos/...`, `go vet`, and `go build ./...` are green.

## Test Coverage

**Added:** `sfu/foruser_test.go`. S4U2Self's live exchange requires a KDC (deferred live validation), consistent with GetTGT/GetTGS.

## Notes / follow-up on this branch

- **S4U2Proxy is pending** and depends on fixing a latent bug: `KDCReqBody.AdditTickets []Ticket` (tag 11) would not emit `APPLICATION[1]` tickets correctly (the same stdlib `encoding/asn1` mis-encoding worked around for KRB-CRED). The fix (marshal additional-tickets via the DER builder) plus S4U2Proxy (constrained-delegation KDC options + PA-PAC-OPTIONS RBCD) will be added here.