### PR TITLE
Native Kerberos v5: GSS-API context-establishment tokens (phase 7, part 1)

### DIFF
--- a/network/kerberos/v5/crypto/crypto.go
+++ b/network/kerberos/v5/crypto/crypto.go
@@ -25,6 +25,7 @@ const (
 	KeyUsageTGSRepEncSessionKey    = iana.KeyUsageTGSRepEncSessionKey
 	KeyUsageTGSRepEncSubSessionKey = iana.KeyUsageTGSRepEncSubSessionKey
 	KeyUsageAPReqAuthen            = iana.KeyUsageAPReqAuthen
+	KeyUsageAPRepEncPart           = iana.KeyUsageAPRepEncPart
 )
 
 // Sentinel errors for cryptographic operations.

--- a/network/kerberos/v5/docs/RFC4121 - The Kerberos V5 GSS-API Mechanism Version 2.txt
+++ b/network/kerberos/v5/docs/RFC4121 - The Kerberos V5 GSS-API Mechanism Version 2.txt
@@ -1,0 +1,1123 @@
+
+
+
+
+
+
+Network Working Group                                             L. Zhu
+Request for Comments: 4121                                 K. Jaganathan
+Updates: 1964                                                  Microsoft
+Category: Standards Track                                     S. Hartman
+                                                                     MIT
+                                                               July 2005
+
+
+                        The Kerberos Version 5
+   Generic Security Service Application Program Interface (GSS-API)
+                         Mechanism: Version 2
+
+Status of This Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (2005).
+
+Abstract
+
+   This document defines protocols, procedures, and conventions to be
+   employed by peers implementing the Generic Security Service
+   Application Program Interface (GSS-API) when using the Kerberos
+   Version 5 mechanism.
+
+   RFC 1964 is updated and incremental changes are proposed in response
+   to recent developments such as the introduction of Kerberos
+   cryptosystem framework.  These changes support the inclusion of new
+   cryptosystems, by defining new per-message tokens along with their
+   encryption and checksum algorithms based on the cryptosystem
+   profiles.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Zhu, et al.                 Standards Track                     [Page 1]
+
+RFC 4121               Kerberos Version 5 GSS-API              July 2005
+
+
+Table of Contents
+
+   1. Introduction ....................................................2
+   2. Key Derivation for Per-Message Tokens ...........................4
+   3. Quality of Protection ...........................................4
+   4. Definitions and Token Formats ...................................5
+      4.1. Context Establishment Tokens ...............................5
+           4.1.1. Authenticator Checksum ..............................6
+      4.2. Per-Message Tokens .........................................9
+           4.2.1. Sequence Number .....................................9
+           4.2.2. Flags Field .........................................9
+           4.2.3. EC Field ...........................................10
+           4.2.4. Encryption and Checksum Operations .................10
+           4.2.5. RRC Field ..........................................11
+           4.2.6. Message Layouts ....................................12
+      4.3. Context Deletion Tokens ...................................13
+      4.4. Token Identifier Assignment Considerations ................13
+   5. Parameter Definitions ..........................................14
+      5.1. Minor Status Codes ........................................14
+           5.1.1. Non-Kerberos-specific Codes ........................14
+           5.1.2. Kerberos-specific Codes ............................15
+      5.2. Buffer Sizes ..............................................15
+   6. Backwards Compatibility Considerations .........................15
+   7. Security Considerations ........................................16
+   8. Acknowledgements................................................17
+   9. References .....................................................18
+      9.1. Normative References ......................................18
+      9.2. Informative References ....................................18
+
+1.  Introduction
+
+   [RFC3961] defines a generic framework for describing encryption and
+   checksum types to be used with the Kerberos protocol and associated
+   protocols.
+
+   [RFC1964] describes the GSS-API mechanism for Kerberos Version 5.  It
+   defines the format of context establishment, per-message and context
+   deletion tokens, and uses algorithm identifiers for each cryptosystem
+   in per-message and context deletion tokens.
+
+   The approach taken in this document obviates the need for algorithm
+   identifiers.  This is accomplished by using the same encryption
+   algorithm, specified by the crypto profile [RFC3961] for the session
+   key or subkey that is created during context negotiation, and its
+   required checksum algorithm.  Message layouts of the per-message
+   tokens are therefore revised to remove algorithm indicators and to
+   add extra information to support the generic crypto framework
+   [RFC3961].
+
+
+
+Zhu, et al.                 Standards Track                     [Page 2]
+
+RFC 4121               Kerberos Version 5 GSS-API              July 2005
+
+
+   Tokens transferred between GSS-API peers for security context
+   establishment are also described in this document.  The data elements
+   exchanged between a GSS-API endpoint implementation and the Kerberos
+   Key Distribution Center (KDC) [RFC4120] are not specific to GSS-API
+   usage and are therefore defined within [RFC4120] rather than this
+   specification.
+
+   The new token formats specified in this document MUST be used with
+   all "newer" encryption types [RFC4120] and MAY be used with
+   encryption types that are not "newer", provided that the initiator
+   and acceptor know from the context establishment that they can both
+   process these new token formats.
+
+   "Newer" encryption types are those which have been specified along
+   with or since the new Kerberos cryptosystem specification [RFC3961],
+   as defined in section 3.1.3 of [RFC4120].  The list of not-newer
+   encryption types is as follows [RFC3961]:
+
+           Encryption Type             Assigned Number
+         ----------------------------------------------
+          des-cbc-crc                        1
+          des-cbc-md4                        2
+          des-cbc-md5                        3
+          des3-cbc-md5                       5
+          des3-cbc-sha1                      7
+          dsaWithSHA1-CmsOID                 9
+          md5WithRSAEncryption-CmsOID       10
+          sha1WithRSAEncryption-CmsOID      11
+          rc2CBC-EnvOID                     12
+          rsaEncryption-EnvOID              13
+          rsaES-OAEP-ENV-OID                14
+          des-ede3-cbc-Env-OID              15
+          des3-cbc-sha1-kd                  16
+          rc4-hmac                          23
+
+   Conventions used in this document
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in [RFC2119].
+
+   The term "little-endian order" is used for brevity to refer to the
+   least-significant-octet-first encoding, while the term "big-endian
+   order" is for the most-significant-octet-first encoding.
+
+
+
+
+
+
+
+Zhu, et al.                 Standards Track                     [Page 3]
+
+RFC 4121               Kerberos Version 5 GSS-API              July 2005
+
+
+2.  Key Derivation for Per-Message Tokens
+
+   To limit the exposure of a given key, [RFC3961] adopted "one-way"
+   "entropy-preserving" derived keys, from a base key or protocol key,
+   for different purposes or key usages.
+
+   This document defines four key usage values below that are used to
+   derive a specific key for signing and sealing messages from the
+   session key or subkey [RFC4120] created during the context
+   establishment.
+
+           Name                         Value
+         -------------------------------------
+          KG-USAGE-ACCEPTOR-SEAL         22
+          KG-USAGE-ACCEPTOR-SIGN         23
+          KG-USAGE-INITIATOR-SEAL        24
+          KG-USAGE-INITIATOR-SIGN        25
+
+   When the sender is the context acceptor, KG-USAGE-ACCEPTOR-SIGN is
+   used as the usage number in the key derivation function for deriving
+   keys to be used in MIC tokens (as defined in section 4.2.6.1).
+   KG-USAGE-ACCEPTOR-SEAL is used for Wrap tokens (as defined in section
+   4.2.6.2).  Similarly, when the sender is the context initiator,
+   KG-USAGE-INITIATOR-SIGN is used as the usage number in the key
+   derivation function for MIC tokens, while KG-USAGE-INITIATOR-SEAL is
+   used for Wrap tokens.  Even if the Wrap token does not provide for
+   confidentiality, the same usage values specified above are used.
+
+   During the context initiation and acceptance sequence, the acceptor
+   MAY assert a subkey in the AP-REP message.  If the acceptor asserts a
+   subkey, the base key is the acceptor-asserted subkey and subsequent
+   per-message tokens MUST be flagged with "AcceptorSubkey", as
+   described in section 4.2.2.  Otherwise, if the initiator asserts a
+   subkey in the AP-REQ message, the base key is this subkey;  if the
+   initiator does not assert a subkey, the base key is the session key
+   in the service ticket.
+
+3.  Quality of Protection
+
+   The GSS-API specification [RFC2743] provides Quality of Protection
+   (QOP) values that can be used by applications to request a certain
+   type of encryption or signing.  A zero QOP value is used to indicate
+   the "default" protection; applications that do not use the default
+   QOP are not guaranteed to be portable across implementations, or even
+   to inter-operate with different deployment configurations of the same
+   implementation.  Using a different algorithm than the one for which
+   the key is defined may not be appropriate.  Therefore, when the new
+   method in this document is used, the QOP value is ignored.
+
+
+
+Zhu, et al.                 Standards Track                     [Page 4]
+
+RFC 4121               Kerberos Version 5 GSS-API              July 2005
+
+
+   The encryption and checksum algorithms in per-message tokens are now
+   implicitly defined by the algorithms associated with the session key
+   or subkey.  Therefore, algorithm identifiers as described in
+   [RFC1964] are no longer needed and are removed from the new token
+   headers.
+
+4.  Definitions and Token Formats
+
+   This section provides terms and definitions, as well as descriptions
+   for tokens specific to the Kerberos Version 5 GSS-API mechanism.
+
+4.1.  Context Establishment Tokens
+
+   All context establishment tokens emitted by the Kerberos Version 5
+   GSS-API mechanism SHALL have the framing described in section 3.1 of
+   [RFC2743], as illustrated by the following pseudo-ASN.1 structures:
+
+         GSS-API DEFINITIONS ::=
+
+         BEGIN
+
+         MechType ::= OBJECT IDENTIFIER
+         -- representing Kerberos V5 mechanism
+
+         GSSAPI-Token ::=
+         -- option indication (delegation, etc.) indicated within
+         -- mechanism-specific token
+         [APPLICATION 0] IMPLICIT SEQUENCE {
+                 thisMech MechType,
+                 innerToken ANY DEFINED BY thisMech
+                    -- contents mechanism-specific
+                    -- ASN.1 structure not required
+                 }
+
+         END
+
+   The innerToken field starts with a two-octet token-identifier
+   (TOK_ID) expressed in big-endian order, followed by a Kerberos
+   message.
+
+   Following are the TOK_ID values used in the context establishment
+   tokens:
+
+          Token               TOK_ID Value in Hex
+         -----------------------------------------
+          KRB_AP_REQ            01 00
+          KRB_AP_REP            02 00
+          KRB_ERROR             03 00
+
+
+
+Zhu, et al.                 Standards Track                     [Page 5]
+
+RFC 4121               Kerberos Version 5 GSS-API              July 2005
+
+
+   Where Kerberos message KRB_AP_REQUEST, KRB_AP_REPLY, and KRB_ERROR
+   are defined in [RFC4120].
+
+   If an unknown token identifier (TOK_ID) is received in the initial
+   context establishment token, the receiver MUST return
+   GSS_S_CONTINUE_NEEDED major status, and the returned output token
+   MUST contain a KRB_ERROR message with the error code
+   KRB_AP_ERR_MSG_TYPE [RFC4120].
+
+4.1.1.  Authenticator Checksum
+
+   The authenticator in the KRB_AP_REQ message MUST include the optional
+   sequence number and the checksum field.  The checksum field is used
+   to convey service flags, channel bindings, and optional delegation
+   information.
+
+   The checksum type MUST be 0x8003.  When delegation is used, a
+   ticket-granting ticket will be transferred in a KRB_CRED message.
+   This ticket SHOULD have its forwardable flag set.  The EncryptedData
+   field of the KRB_CRED message [RFC4120] MUST be encrypted in the
+   session key of the ticket used to authenticate the context.
+
+   The authenticator checksum field SHALL have the following format:
+
+       Octet        Name      Description
+      -----------------------------------------------------------------
+       0..3         Lgth    Number of octets in Bnd field;  Represented
+                            in little-endian order;  Currently contains
+                            hex value 10 00 00 00 (16).
+       4..19        Bnd     Channel binding information, as described in
+                            section 4.1.1.2.
+       20..23       Flags   Four-octet context-establishment flags in
+                            little-endian order as described in section
+                            4.1.1.1.
+       24..25       DlgOpt  The delegation option identifier (=1) in
+                            little-endian order [optional].  This field
+                            and the next two fields are present if and
+                            only if GSS_C_DELEG_FLAG is set as described
+                            in section 4.1.1.1.
+       26..27       Dlgth   The length of the Deleg field in
+                            little-endian order [optional].
+       28..(n-1)    Deleg   A KRB_CRED message (n = Dlgth + 28)
+                            [optional].
+       n..last      Exts    Extensions [optional].
+
+   The length of the checksum field MUST be at least 24 octets when
+   GSS_C_DELEG_FLAG is not set (as described in section 4.1.1.1), and at
+   least 28 octets plus Dlgth octets when GSS_C_DELEG_FLAG is set.  When
+
+
+
+Zhu, et al.                 Standards Track                     [Page 6]
+
+RFC 4121               Kerberos Version 5 GSS-API              July 2005
+
+
+   GSS_C_DELEG_FLAG is set, the DlgOpt, Dlgth, and Deleg fields of the
+   checksum data MUST immediately follow the Flags field.  The optional
+   trailing octets (namely the "Exts" field) facilitate future
+   extensions to this mechanism.  When delegation is not used, but the
+   Exts field is present, the Exts field starts at octet 24 (DlgOpt,
+   Dlgth and Deleg are absent).
+
+   Initiators that do not support the extensions MUST NOT include more
+   than 24 octets in the checksum field (when GSS_C_DELEG_FLAG is not
+   set) or more than 28 octets plus the KRB_CRED in the Deleg field
+   (when GSS_C_DELEG_FLAG is set).  Acceptors that do not understand the
+
+   Extensions MUST ignore any octets past the Deleg field of the
+   checksum data (when GSS_C_DELEG_FLAG is set) or past the Flags field
+   of the checksum data (when GSS_C_DELEG_FLAG is not set).
+
+4.1.1.1.  Checksum Flags Field
+
+   The checksum "Flags" field is used to convey service options or
+   extension negotiation information.
+
+   The following context establishment flags are defined in [RFC2744].
+
+           Flag Name              Value
+         ---------------------------------
+          GSS_C_DELEG_FLAG           1
+          GSS_C_MUTUAL_FLAG          2
+          GSS_C_REPLAY_FLAG          4
+          GSS_C_SEQUENCE_FLAG        8
+          GSS_C_CONF_FLAG           16
+          GSS_C_INTEG_FLAG          32
+
+   Context establishment flags are exposed to the calling application.
+   If the calling application desires a particular service option, then
+   it requests that option via GSS_Init_sec_context() [RFC2743].  If the
+   corresponding return state values [RFC2743] indicate that any of the
+   above optional context level services will be active on the context,
+   the corresponding flag values in the table above MUST be set in the
+   checksum Flags field.
+
+   Flag values 4096..524288 (2^12, 2^13, ..., 2^19) are reserved for use
+   with legacy vendor-specific extensions to this mechanism.
+
+
+
+
+
+
+
+
+
+Zhu, et al.                 Standards Track                     [Page 7]
+
+RFC 4121               Kerberos Version 5 GSS-API              July 2005
+
+
+   All other flag values not specified herein are reserved for future
+   use.  Future revisions of this mechanism may use these reserved flags
+   and may rely on implementations of this version to not use such flags
+   in order to properly negotiate mechanism versions.  Undefined flag
+   values MUST be cleared by the sender, and unknown flags MUST be
+   ignored by the receiver.
+
+4.1.1.2.  Channel Binding Information
+
+   These tags are intended to be used to identify the particular
+   communications channel for which the GSS-API security context
+   establishment tokens are intended, thus limiting the scope within
+   which an intercepted context establishment token can be reused by an
+   attacker (see [RFC2743], section 1.1.6).
+
+   When using C language bindings, channel bindings are communicated to
+   the GSS-API using the following structure [RFC2744]:
+
+         typedef struct gss_channel_bindings_struct {
+            OM_uint32       initiator_addrtype;
+            gss_buffer_desc initiator_address;
+            OM_uint32       acceptor_addrtype;
+            gss_buffer_desc acceptor_address;
+            gss_buffer_desc application_data;
+         } *gss_channel_bindings_t;
+
+   The member fields and constants used for different address types are
+   defined in [RFC2744].
+
+   The "Bnd" field contains the MD5 hash of channel bindings, taken over
+   all non-null components of bindings, in order of declaration.
+   Integer fields within channel bindings are represented in little-
+   endian order for the purposes of the MD5 calculation.
+
+   In computing the contents of the Bnd field, the following detailed
+   points apply:
+
+   (1) For purposes of MD5 hash computation, each integer field and
+       input length field SHALL be formatted into four octets, using
+       little-endian octet ordering.
+
+   (2) All input length fields within gss_buffer_desc elements of a
+       gss_channel_bindings_struct even those which are zero-valued,
+       SHALL be included in the hash calculation.  The value elements of
+       gss_buffer_desc elements SHALL be dereferenced, and the resulting
+       data SHALL be included within the hash computation, only for the
+       case of gss_buffer_desc elements having non-zero length
+       specifiers.
+
+
+
+Zhu, et al.                 Standards Track                     [Page 8]
+
+RFC 4121               Kerberos Version 5 GSS-API              July 2005
+
+
+   (3) If the caller passes the value GSS_C_NO_BINDINGS instead of a
+       valid channel binding structure, the Bnd field SHALL be set to 16
+       zero-valued octets.
+
+   If the caller to GSS_Accept_sec_context [RFC2743] passes in
+   GSS_C_NO_CHANNEL_BINDINGS [RFC2744] as the channel bindings, then the
+   acceptor MAY ignore any channel bindings supplied by the initiator,
+   returning success even if the initiator did pass in channel bindings.
+
+   If the application supplies, in the channel bindings, a buffer with a
+   length field larger than 4294967295 (2^32 - 1), the implementation of
+   this mechanism MAY choose to reject the channel bindings altogether,
+   using major status GSS_S_BAD_BINDINGS [RFC2743].  In any case, the
+   size of channel-binding data buffers that can be used (interoperable,
+   without extensions) with this specification is limited to 4294967295
+   octets.
+
+4.2.  Per-Message Tokens
+
+   Two classes of tokens are defined in this section: (1) "MIC" tokens,
+   emitted by calls to GSS_GetMIC() and consumed by calls to
+   GSS_VerifyMIC(), and (2) "Wrap" tokens, emitted by calls to
+   GSS_Wrap() and consumed by calls to GSS_Unwrap().
+
+   These new per-message tokens do not include the generic GSS-API token
+   framing used by the context establishment tokens.  These new tokens
+   are designed to be used with newer crypto systems that can have
+   variable-size checksums.
+
+4.2.1.  Sequence Number
+
+   To distinguish intentionally-repeated messages from maliciously-
+   replayed ones, per-message tokens contain a sequence number field,
+   which is a 64 bit integer expressed in big-endian order.  After
+   sending a GSS_GetMIC() or GSS_Wrap() token, the sender's sequence
+   numbers SHALL be incremented by one.
+
+4.2.2.  Flags Field
+
+   The "Flags" field is a one-octet integer used to indicate a set of
+   attributes for the protected message.  For example, one flag is
+   allocated as the direction-indicator, thus preventing the acceptance
+   of the same message sent back in the reverse direction by an
+   adversary.
+
+
+
+
+
+
+
+Zhu, et al.                 Standards Track                     [Page 9]
+
+RFC 4121               Kerberos Version 5 GSS-API              July 2005
+
+
+   The meanings of bits in this field (the least significant bit is bit
+   0) are as follows:
+
+          Bit    Name             Description
+         --------------------------------------------------------------
+          0   SentByAcceptor   When set, this flag indicates the sender
+                               is the context acceptor.  When not set,
+                               it indicates the sender is the context
+                               initiator.
+          1   Sealed           When set in Wrap tokens, this flag
+                               indicates confidentiality is provided
+                               for.  It SHALL NOT be set in MIC tokens.
+          2   AcceptorSubkey   A subkey asserted by the context acceptor
+                               is used to protect the message.
+
+   The rest of available bits are reserved for future use and MUST be
+   cleared.  The receiver MUST ignore unknown flags.
+
+4.2.3.  EC Field
+
+   The "EC" (Extra Count) field is a two-octet integer field expressed
+   in big-endian order.
+
+   In Wrap tokens with confidentiality, the EC field SHALL be used to
+   encode the number of octets in the filler, as described in section
+   4.2.4.
+
+   In Wrap tokens without confidentiality, the EC field SHALL be used to
+   encode the number of octets in the trailing checksum, as described in
+   section 4.2.4.
+
+4.2.4.  Encryption and Checksum Operations
+
+   The encryption algorithms defined by the crypto profiles provide for
+   integrity protection [RFC3961].  Therefore, no separate checksum is
+   needed.
+
+   The result of decryption can be longer than the original plaintext
+   [RFC3961] and the extra trailing octets are called "crypto-system
+   residue" in this document.  However, given the size of any plaintext
+   data, one can always find a (possibly larger) size, such that when
+   padding the to-be-encrypted text to that size, there will be no
+   crypto-system residue added [RFC3961].
+
+   In Wrap tokens that provide for confidentiality, the first 16 octets
+   of the Wrap token (the "header", as defined in section 4.2.6), SHALL
+   be appended to the plaintext data before encryption.  Filler octets
+   MAY be inserted between the plaintext data and the "header."  The
+
+
+
+Zhu, et al.                 Standards Track                    [Page 10]
+
+RFC 4121               Kerberos Version 5 GSS-API              July 2005
+
+
+   values and size of the filler octets are chosen by implementations,
+   such that there SHALL be no crypto-system residue present after the
+   decryption.  The resulting Wrap token is {"header" |
+   encrypt(plaintext-data | filler | "header")}, where encrypt() is the
+   encryption operation (which provides for integrity protection)
+   defined in the crypto profile [RFC3961], and the RRC field (as
+   defined in section 4.2.5) in the to-be-encrypted header contains the
+   hex value 00 00.
+
+   In Wrap tokens that do not provide for confidentiality, the checksum
+   SHALL be calculated first over the to-be-signed plaintext data, and
+   then over the first 16 octets of the Wrap token (the "header", as
+   defined in section 4.2.6).  Both the EC field and the RRC field in
+   the token header SHALL be filled with zeroes for the purpose of
+   calculating the checksum.  The resulting Wrap token is {"header" |
+   plaintext-data | get_mic(plaintext-data | "header")}, where get_mic()
+   is the checksum operation for the required checksum mechanism of the
+   chosen encryption mechanism defined in the crypto profile [RFC3961].
+
+   The parameters for the key and the cipher-state in the encrypt() and
+   get_mic() operations have been omitted for brevity.
+
+   For MIC tokens, the checksum SHALL be calculated as follows: the
+   checksum operation is calculated first over the to-be-signed
+   plaintext data, and then over the first 16 octets of the MIC token,
+   where the checksum mechanism is the required checksum mechanism of
+   the chosen encryption mechanism defined in the crypto profile
+   [RFC3961].
+
+   The resulting Wrap and MIC tokens bind the data to the token header,
+   including the sequence number and the direction indicator.
+
+4.2.5.  RRC Field
+
+   The "RRC" (Right Rotation Count) field in Wrap tokens is added to
+   allow the data to be encrypted in-place by existing SSPI (Security
+   Service Provider Interface) [SSPI] applications that do not provide
+   an additional buffer for the trailer (the cipher text after the in-
+   place-encrypted data) in addition to the buffer for the header (the
+   cipher text before the in-place-encrypted data).  Excluding the first
+   16 octets of the token header, the resulting Wrap token in the
+   previous section is rotated to the right by "RRC" octets.  The net
+   result is that "RRC" octets of trailing octets are moved toward the
+   header.
+
+   Consider the following as an example of this rotation operation:
+   Assume that the RRC value is 3 and the token before the rotation is
+   {"header" | aa | bb | cc | dd | ee | ff | gg | hh}.  The token after
+
+
+
+Zhu, et al.                 Standards Track                    [Page 11]
+
+RFC 4121               Kerberos Version 5 GSS-API              July 2005
+
+
+   rotation would be {"header" | ff | gg | hh | aa | bb | cc | dd | ee
+   }, where {aa | bb | cc |...| hh} would be used to indicate the octet
+   sequence.
+
+   The RRC field is expressed as a two-octet integer in big-endian
+   order.
+
+   The rotation count value is chosen by the sender based on
+   implementation details.  The receiver MUST be able to interpret all
+   possible rotation count values, including rotation counts greater
+   than the length of the token.
+
+4.2.6.  Message Layouts
+
+   Per-message tokens start with a two-octet token identifier (TOK_ID)
+   field, expressed in big-endian order.  These tokens are defined
+   separately in the following sub-sections.
+
+4.2.6.1.  MIC Tokens
+
+   Use of the GSS_GetMIC() call yields a token (referred as the MIC
+   token in this document), separate from the user data being protected,
+   which can be used to verify the integrity of that data as received.
+   The token has the following format:
+
+         Octet no   Name        Description
+         --------------------------------------------------------------
+         0..1     TOK_ID     Identification field.  Tokens emitted by
+                             GSS_GetMIC() contain the hex value 04 04
+                             expressed in big-endian order in this
+                             field.
+         2        Flags      Attributes field, as described in section
+                             4.2.2.
+         3..7     Filler     Contains five octets of hex value FF.
+         8..15    SND_SEQ    Sequence number field in clear text,
+                             expressed in big-endian order.
+         16..last SGN_CKSUM  Checksum of the "to-be-signed" data and
+                             octet 0..15, as described in section 4.2.4.
+
+   The Filler field is included in the checksum calculation for
+   simplicity.
+
+
+
+
+
+
+
+
+
+
+Zhu, et al.                 Standards Track                    [Page 12]
+
+RFC 4121               Kerberos Version 5 GSS-API              July 2005
+
+
+4.2.6.2.  Wrap Tokens
+
+   Use of the GSS_Wrap() call yields a token (referred as the Wrap token
+   in this document), which consists of a descriptive header, followed
+   by a body portion that contains either the input user data in
+   plaintext concatenated with the checksum, or the input user data
+   encrypted.  The GSS_Wrap() token SHALL have the following format:
+
+         Octet no   Name        Description
+         --------------------------------------------------------------
+          0..1     TOK_ID    Identification field.  Tokens emitted by
+                             GSS_Wrap() contain the hex value 05 04
+                             expressed in big-endian order in this
+                             field.
+          2        Flags     Attributes field, as described in section
+                             4.2.2.
+          3        Filler    Contains the hex value FF.
+          4..5     EC        Contains the "extra count" field, in big-
+                             endian order as described in section 4.2.3.
+          6..7     RRC       Contains the "right rotation count" in big-
+                             endian order, as described in section
+                             4.2.5.
+          8..15    SND_SEQ   Sequence number field in clear text,
+                             expressed in big-endian order.
+          16..last Data      Encrypted data for Wrap tokens with
+                             confidentiality, or plaintext data followed
+                             by the checksum for Wrap tokens without
+                             confidentiality, as described in section
+                             4.2.4.
+
+4.3.  Context Deletion Tokens
+
+   Context deletion tokens are empty in this mechanism.  Both peers to a
+   security context invoke GSS_Delete_sec_context() [RFC2743]
+   independently, passing a null output_context_token buffer to indicate
+   that no context_token is required.  Implementations of
+   GSS_Delete_sec_context() should delete relevant locally-stored
+   context information.
+
+4.4.  Token Identifier Assignment Considerations
+
+   Token identifiers (TOK_ID) from 0x60 0x00 through 0x60 0xFF inclusive
+   are reserved and SHALL NOT be assigned.  Thus, by examining the first
+   two octets of a token, one can tell unambiguously if it is wrapped
+   with the generic GSS-API token framing.
+
+
+
+
+
+
+Zhu, et al.                 Standards Track                    [Page 13]
+
+RFC 4121               Kerberos Version 5 GSS-API              July 2005
+
+
+5.  Parameter Definitions
+
+   This section defines parameter values used by the Kerberos V5 GSS-API
+   mechanism.  It defines interface elements that support portability,
+   and assumes use of C language bindings per [RFC2744].
+
+5.1.  Minor Status Codes
+
+   This section recommends common symbolic names for minor_status values
+   to be returned by the Kerberos V5 GSS-API mechanism.  Use of these
+   definitions will enable independent implementers to enhance
+   application portability across different implementations of the
+   mechanism defined in this specification.  (In all cases,
+   implementations of GSS_Display_status() will enable callers to
+   convert minor_status indicators to text representations.)  Each
+   implementation should make available, through include files or other
+   means, a facility to translate these symbolic names into the concrete
+   values that a particular GSS-API implementation uses to represent the
+   minor_status values specified in this section.
+
+   This list may grow over time and the need for additional minor_status
+   codes, specific to particular implementations, may arise.  However,
+   it is recommended that implementations should return a minor_status
+   value as defined on a mechanism-wide basis within this section when
+   that code accurately represents reportable status rather than using a
+   separate, implementation-defined code.
+
+5.1.1.  Non-Kerberos-specific Codes
+
+         GSS_KRB5_S_G_BAD_SERVICE_NAME
+                 /* "No @ in SERVICE-NAME name string" */
+         GSS_KRB5_S_G_BAD_STRING_UID
+                 /* "STRING-UID-NAME contains nondigits" */
+         GSS_KRB5_S_G_NOUSER
+                 /* "UID does not resolve to username" */
+         GSS_KRB5_S_G_VALIDATE_FAILED
+                 /* "Validation error" */
+         GSS_KRB5_S_G_BUFFER_ALLOC
+                 /* "Couldn't allocate gss_buffer_t data" */
+         GSS_KRB5_S_G_BAD_MSG_CTX
+                 /* "Message context invalid" */
+         GSS_KRB5_S_G_WRONG_SIZE
+                 /* "Buffer is the wrong size" */
+         GSS_KRB5_S_G_BAD_USAGE
+                 /* "Credential usage type is unknown" */
+         GSS_KRB5_S_G_UNKNOWN_QOP
+                 /* "Unknown quality of protection specified" */
+
+
+
+
+Zhu, et al.                 Standards Track                    [Page 14]
+
+RFC 4121               Kerberos Version 5 GSS-API              July 2005
+
+
+5.1.2.  Kerberos-specific Codes
+
+         GSS_KRB5_S_KG_CCACHE_NOMATCH
+                 /* "Client principal in credentials does not match
+                    specified name" */
+         GSS_KRB5_S_KG_KEYTAB_NOMATCH
+                 /* "No key available for specified service
+                    principal" */
+         GSS_KRB5_S_KG_TGT_MISSING
+                 /* "No Kerberos ticket-granting ticket available" */
+         GSS_KRB5_S_KG_NO_SUBKEY
+                 /* "Authenticator has no subkey" */
+         GSS_KRB5_S_KG_CONTEXT_ESTABLISHED
+                 /* "Context is already fully established" */
+         GSS_KRB5_S_KG_BAD_SIGN_TYPE
+                 /* "Unknown signature type in token" */
+         GSS_KRB5_S_KG_BAD_LENGTH
+                 /* "Invalid field length in token" */
+         GSS_KRB5_S_KG_CTX_INCOMPLETE
+                 /* "Attempt to use incomplete security context" */
+
+5.2.  Buffer Sizes
+
+   All implementations of this specification MUST be capable of
+   accepting buffers of at least 16K octets as input to GSS_GetMIC(),
+   GSS_VerifyMIC(), and GSS_Wrap().  They MUST also be capable of
+   accepting the output_token generated by GSS_Wrap() for a 16K octet
+   input buffer as input to GSS_Unwrap().  Implementations SHOULD
+   support 64K octet input buffers, and MAY support even larger input
+   buffer sizes.
+
+6.  Backwards Compatibility Considerations
+
+   The new token formats defined in this document will only be
+   recognized by new implementations.  To address this, implementations
+   can always use the explicit sign or seal algorithm in [RFC1964] when
+   the key type corresponds to not "newer" enctypes.  As an alternative,
+   one might retry sending the message with the sign or seal algorithm
+   explicitly defined as in [RFC1964].  However, this would require
+   either the use of a mechanism such as [RFC2478] to securely negotiate
+   the method, or the use of an out-of-band mechanism to choose the
+   appropriate mechanism.  For this reason, it is RECOMMENDED that the
+   new token formats defined in this document SHOULD be used only if
+   both peers are known to support the new mechanism during context
+   negotiation because of, for example, the use of "new" enctypes.
+
+
+
+
+
+
+Zhu, et al.                 Standards Track                    [Page 15]
+
+RFC 4121               Kerberos Version 5 GSS-API              July 2005
+
+
+   GSS_Unwrap() or GSS_VerifyMIC() can process a message token as
+   follows: it can look at the first octet of the token header, and if
+   it is 0x60, then the token must carry the generic GSS-API pseudo
+   ASN.1 framing.  Otherwise, the first two octets of the token contain
+   the TOK_ID that uniquely identify the token message format.
+
+7.  Security Considerations
+
+   Channel bindings are validated by the acceptor.  The acceptor can
+   ignore the channel bindings restriction supplied by the initiator and
+   carried in the authenticator checksum, if (1) channel bindings are
+   not used by GSS_Accept_sec_context [RFC2743], and (2) the acceptor
+   does not prove to the initiator that it has the same channel bindings
+   as the initiator (even if the client requested mutual
+   authentication).  This limitation should be considered by designers
+   of applications that would use channel bindings, whether to limit the
+   use of GSS-API contexts to nodes with specific network addresses, to
+   authenticate other established, secure channels using Kerberos
+   Version 5, or for any other purpose.
+
+   Session key types are selected by the KDC.  Under the current
+   mechanism, no negotiation of algorithm types occurs, so server-side
+   (acceptor) implementations cannot request that clients not use
+   algorithm types not understood by the server.  However,
+   administrators can control what enctypes can be used for session keys
+   for this mechanism by controlling the set of the ticket session key
+   enctypes which the KDC is willing to use in tickets for a given
+   acceptor principal.  Therefore, the KDC could be given the task of
+   limiting session keys for a given service to types actually supported
+   by the Kerberos and GSSAPI software on the server.  This has a
+   drawback for cases in which a service principal name is used for both
+   GSSAPI-based and non-GSSAPI-based communication (most notably the
+   "host" service key), if the GSSAPI implementation does not understand
+   (for example) AES [RFC3962], but the Kerberos implementation does.
+   This means that AES session keys cannot be issued for that service
+   principal, which keeps the protection of non-GSSAPI services weaker
+   than necessary.  KDC administrators desiring to limit the session key
+   types to support interoperability with such GSSAPI implementations
+   should carefully weigh the reduction in protection offered by such
+   mechanisms against the benefits of interoperability.
+
+
+
+
+
+
+
+
+
+
+
+Zhu, et al.                 Standards Track                    [Page 16]
+
+RFC 4121               Kerberos Version 5 GSS-API              July 2005
+
+
+8.  Acknowledgements
+
+   Ken Raeburn and Nicolas Williams corrected many of our errors in the
+   use of generic profiles and were instrumental in the creation of this
+   document.
+
+   The text for security considerations was contributed by Nicolas
+   Williams and Ken Raeburn.
+
+   Sam Hartman and Ken Raeburn suggested the "floating trailer" idea,
+   namely the encoding of the RRC field.
+
+   Sam Hartman and Nicolas Williams recommended the replacing our
+   earlier key derivation function for directional keys with different
+   key usage numbers for each direction as well as retaining the
+   directional bit for maximum compatibility.
+
+   Paul Leach provided numerous suggestions and comments.
+
+   Scott Field, Richard Ward, Dan Simon, Kevin Damour, and Simon
+   Josefsson also provided valuable inputs on this document.
+
+   Jeffrey Hutzelman provided comments and clarifications for the text
+   related to the channel bindings.
+
+   Jeffrey Hutzelman and Russ Housley suggested many editorial changes.
+
+   Luke Howard provided implementations of this document for the Heimdal
+   code base, and helped inter-operability testing with the Microsoft
+   code base, together with Love Hornquist Astrand.  These experiments
+   formed the basis of this document.
+
+   Martin Rex provided suggestions of TOK_ID assignment recommendations,
+   thus the token tagging in this document is unambiguous if the token
+   is wrapped with the pseudo ASN.1 header.
+
+   John Linn wrote the original Kerberos Version 5 mechanism
+   specification [RFC1964], of which some text has been retained.
+
+
+
+
+
+
+
+
+
+
+
+
+
+Zhu, et al.                 Standards Track                    [Page 17]
+
+RFC 4121               Kerberos Version 5 GSS-API              July 2005
+
+
+9.  References
+
+9.1.  Normative References
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [RFC2743]  Linn, J., "Generic Security Service Application Program
+              Interface Version 2, Update 1", RFC 2743, January 2000.
+
+   [RFC2744]  Wray, J., "Generic Security Service API Version 2:
+              C-bindings", RFC 2744, January 2000.
+
+   [RFC1964]  Linn, J., "The Kerberos Version 5 GSS-API Mechanism", RFC
+              1964, June 1996.
+
+   [RFC3961]  Raeburn, K., "Encryption and Checksum Specifications for
+              Kerberos 5", RFC 3961, February 2005.
+
+   [RFC4120]  Neuman, C., Yu, T., Hartman, S., and K. Raeburn, "The
+              Kerberos Network Authentication Service (V5)", RFC 4120,
+              July 2005.
+
+9.2.  Informative References
+
+   [SSPI]     Leach, P., "Security Service Provider Interface",
+              Microsoft Developer Network (MSDN), April 2003.
+
+   [RFC3962]  Raeburn, K., "Advanced Encryption Standard (AES)
+              Encryption for Kerberos 5", RFC 3962, February 2005.
+
+   [RFC2478]  Baize, E. and D. Pinkas, "The Simple and Protected GSS-API
+              Negotiation Mechanism", RFC 2478, December 1998.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Zhu, et al.                 Standards Track                    [Page 18]
+
+RFC 4121               Kerberos Version 5 GSS-API              July 2005
+
+
+Authors' Addresses
+
+   Larry Zhu
+   One Microsoft Way
+   Redmond, WA 98052 - USA
+
+   EMail: LZhu@microsoft.com
+
+
+   Karthik Jaganathan
+   One Microsoft Way
+   Redmond, WA 98052 - USA
+
+   EMail: karthikj@microsoft.com
+
+
+   Sam Hartman
+   Massachusetts Institute of Technology
+   77 Massachusetts Avenue
+   Cambridge, MA 02139 - USA
+
+   EMail: hartmans-ietf@mit.edu
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Zhu, et al.                 Standards Track                    [Page 19]
+
+RFC 4121               Kerberos Version 5 GSS-API              July 2005
+
+
+Full Copyright Statement
+
+   Copyright (C) The Internet Society (2005).
+
+   This document is subject to the rights, licenses and restrictions
+   contained in BCP 78, and except as set forth therein, the authors
+   retain all their rights.
+
+   This document and the information contained herein are provided on an
+   "AS IS" basis and THE CONTRIBUTOR, THE ORGANIZATION HE/SHE REPRESENTS
+   OR IS SPONSORED BY (IF ANY), THE INTERNET SOCIETY AND THE INTERNET
+   ENGINEERING TASK FORCE DISCLAIM ALL WARRANTIES, EXPRESS OR IMPLIED,
+   INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE
+   INFORMATION HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+   WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Intellectual Property
+
+   The IETF takes no position regarding the validity or scope of any
+   Intellectual Property Rights or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; nor does it represent that it has
+   made any independent effort to identify any such rights.  Information
+   on the procedures with respect to rights in RFC documents can be
+   found in BCP 78 and BCP 79.
+
+   Copies of IPR disclosures made to the IETF Secretariat and any
+   assurances of licenses to be made available, or the result of an
+   attempt made to obtain a general license or permission for the use of
+   such proprietary rights by implementers or users of this
+   specification can be obtained from the IETF on-line IPR repository at
+   http://www.ietf.org/ipr.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights that may cover technology that may be required to implement
+   this standard.  Please address the information to the IETF at ietf-
+   ipr@ietf.org.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+Zhu, et al.                 Standards Track                    [Page 20]
+

--- a/network/kerberos/v5/gssapi/gssapi.go
+++ b/network/kerberos/v5/gssapi/gssapi.go
@@ -1,0 +1,261 @@
+// Package gssapi implements the Kerberos V5 GSS-API mechanism (RFC 1964 /
+// RFC 4121) context-establishment tokens: the GSS InitialContextToken framing,
+// the 0x8003 authenticator checksum that carries channel bindings and service
+// flags, building the KRB_AP_REQ token from a service ticket (InitSecContext),
+// and verifying the KRB_AP_REP mutual-authentication reply.
+//
+// This is the mechanism that plugs into SPNEGO (as the Kerberos mechToken) to
+// authenticate SMB, RPC, and LDAP. Per-message tokens (MIC/Wrap, RFC 4121 §4.2)
+// are a separate layer built on the SecContext produced here.
+package gssapi
+
+import (
+	"crypto/md5"
+	"crypto/rand"
+	"encoding/asn1"
+	"encoding/binary"
+	"fmt"
+	"time"
+
+	kerbcrypto "github.com/TheManticoreProject/Manticore/network/kerberos/v5/crypto"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/messages"
+)
+
+// MechOIDKerberos5 is the GSS-API mechanism OID for Kerberos V5
+// (1.2.840.113554.1.2.2), used as thisMech in the InitialContextToken and as a
+// mechType in SPNEGO negotiation.
+var MechOIDKerberos5 = asn1.ObjectIdentifier{1, 2, 840, 113554, 1, 2, 2}
+
+// GSS-API token identifiers (RFC 1964 §1.1): the 2-byte TOK_ID prefixing the
+// Kerberos message inside the InitialContextToken.
+var (
+	TokIDAPReq = [2]byte{0x01, 0x00} // KRB_AP_REQ
+	TokIDAPRep = [2]byte{0x02, 0x00} // KRB_AP_REP
+	TokIDError = [2]byte{0x03, 0x00} // KRB_ERROR
+)
+
+// GSS context-establishment flags (RFC 1964 §1.1.1), as they appear in the
+// 0x8003 checksum Flags field.
+const (
+	GSSDelegFlag    = 1
+	GSSMutualFlag   = 2
+	GSSReplayFlag   = 4
+	GSSSequenceFlag = 8
+	GSSConfFlag     = 16
+	GSSIntegFlag    = 32
+)
+
+// ChecksumTypeGSSAPI is the Kerberos checksum type (0x8003) used for the GSS-API
+// authenticator checksum.
+const ChecksumTypeGSSAPI = 0x8003
+
+// GSSChecksumValue builds the 0x8003 authenticator checksum value (RFC 1964
+// §1.1.1): Lgth (16, little-endian) | Bnd | Flags (little-endian). Bnd is the
+// MD5 of the channel bindings, or 16 zero bytes for GSS_C_NO_BINDINGS (nil).
+func GSSChecksumValue(flags uint32, channelBindings []byte) []byte {
+	out := make([]byte, 24)
+	binary.LittleEndian.PutUint32(out[0:], 16) // Lgth
+	if len(channelBindings) > 0 {
+		sum := md5.Sum(channelBindings)
+		copy(out[4:20], sum[:])
+	} // else 16 zero bytes
+	binary.LittleEndian.PutUint32(out[20:], flags)
+	return out
+}
+
+// WrapToken wraps a Kerberos message in the GSS-API InitialContextToken framing
+// (RFC 1964 §1.1): [APPLICATION 0] { kerberos5-OID, TOK_ID | krbMessage }.
+func WrapToken(tokID [2]byte, krbMessage []byte) ([]byte, error) {
+	oidBytes, err := asn1.Marshal(MechOIDKerberos5)
+	if err != nil {
+		return nil, err
+	}
+	inner := make([]byte, 0, len(oidBytes)+2+len(krbMessage))
+	inner = append(inner, oidBytes...)
+	inner = append(inner, tokID[0], tokID[1])
+	inner = append(inner, krbMessage...)
+	return asn1.Marshal(asn1.RawValue{Class: asn1.ClassApplication, Tag: 0, IsCompound: true, Bytes: inner})
+}
+
+// UnwrapToken parses a GSS-API InitialContextToken, verifies the kerberos5 mech
+// OID, and returns the TOK_ID and the enclosed Kerberos message bytes.
+func UnwrapToken(data []byte) (tokID [2]byte, krbMessage []byte, err error) {
+	var outer asn1.RawValue
+	if _, err = asn1.Unmarshal(data, &outer); err != nil {
+		return tokID, nil, fmt.Errorf("gssapi: parse InitialContextToken: %w", err)
+	}
+	if outer.Class != asn1.ClassApplication || outer.Tag != 0 {
+		return tokID, nil, fmt.Errorf("gssapi: not an InitialContextToken (class=%d tag=%d)", outer.Class, outer.Tag)
+	}
+	var oid asn1.ObjectIdentifier
+	rest, err := asn1.Unmarshal(outer.Bytes, &oid)
+	if err != nil {
+		return tokID, nil, fmt.Errorf("gssapi: parse mech OID: %w", err)
+	}
+	if !oid.Equal(MechOIDKerberos5) {
+		return tokID, nil, fmt.Errorf("gssapi: unexpected mech OID %v", oid)
+	}
+	if len(rest) < 2 {
+		return tokID, nil, fmt.Errorf("gssapi: token too short for TOK_ID")
+	}
+	tokID[0], tokID[1] = rest[0], rest[1]
+	return tokID, rest[2:], nil
+}
+
+// SecContext holds the state a context initiator needs to verify the AP-REP and
+// to produce/verify per-message tokens.
+type SecContext struct {
+	// SessionKey / SessionEType are the service-ticket session key.
+	SessionKey   []byte
+	SessionEType int
+	// SubKey is the client-chosen subkey placed in the authenticator (optional).
+	SubKey      []byte
+	SubKeyEType int
+	// SeqNumber is the initial sequence number sent in the authenticator.
+	SeqNumber int
+	// ctime/cusec are retained to match the AP-REP echo (mutual authentication).
+	ctime time.Time
+	cusec int
+}
+
+// InitOptions configures InitSecContext.
+type InitOptions struct {
+	// TicketRaw is the raw APPLICATION[1] service ticket (from GetTGS).
+	TicketRaw []byte
+	// SessionKey / SessionEType are that ticket's session key.
+	SessionKey   []byte
+	SessionEType int
+	// ClientName / ClientRealm identify the initiator (the ticket's client).
+	ClientName  messages.PrincipalName
+	ClientRealm string
+	// Flags are the GSS context-establishment flags for the 0x8003 checksum.
+	Flags uint32
+	// ChannelBindings is hashed into the checksum Bnd field (nil = no bindings).
+	ChannelBindings []byte
+	// Mutual requests mutual authentication (sets AP-options mutual-required and
+	// the GSS mutual flag), so the acceptor returns an AP-REP.
+	Mutual bool
+	// SubKey optionally supplies a client subkey (used to key per-message tokens);
+	// if set, SubKeyEType must be set too.
+	SubKey      []byte
+	SubKeyEType int
+}
+
+// InitSecContext builds the initiator's KRB_AP_REQ GSS token from a service
+// ticket, returning the wrapped token and the SecContext for AP-REP/per-message
+// handling. The authenticator carries the 0x8003 checksum and is encrypted with
+// the ticket session key at key usage 11 (AP-REQ authenticator).
+func InitSecContext(opts InitOptions) ([]byte, *SecContext, error) {
+	if len(opts.TicketRaw) == 0 || len(opts.SessionKey) == 0 {
+		return nil, nil, fmt.Errorf("gssapi: InitSecContext requires a ticket and session key")
+	}
+
+	flags := opts.Flags
+	if opts.Mutual {
+		flags |= GSSMutualFlag
+	}
+
+	now := time.Now().UTC()
+	cusec := now.Nanosecond() / 1000
+
+	var seqBuf [4]byte
+	if _, err := rand.Read(seqBuf[:]); err != nil {
+		return nil, nil, err
+	}
+	seqNum := int(binary.BigEndian.Uint32(seqBuf[:]) & 0x7fffffff)
+
+	cksum := &messages.Checksum{
+		CKSumType: ChecksumTypeGSSAPI,
+		Checksum:  GSSChecksumValue(flags, opts.ChannelBindings),
+	}
+	auth := &messages.Authenticator{
+		AVno:      messages.KerberosV5,
+		CRealm:    opts.ClientRealm,
+		CName:     opts.ClientName,
+		Cksum:     cksum,
+		CUSec:     cusec,
+		CTime:     now,
+		SeqNumber: seqNum,
+	}
+	if len(opts.SubKey) > 0 {
+		auth.SubKey = &messages.EncryptionKey{KeyType: opts.SubKeyEType, KeyValue: opts.SubKey}
+	}
+
+	authBytes, err := auth.Marshal()
+	if err != nil {
+		return nil, nil, fmt.Errorf("gssapi: marshal authenticator: %w", err)
+	}
+	encAuth, err := kerbcrypto.Encrypt(opts.SessionEType, opts.SessionKey, kerbcrypto.KeyUsageAPReqAuthen, authBytes)
+	if err != nil {
+		return nil, nil, fmt.Errorf("gssapi: encrypt authenticator: %w", err)
+	}
+
+	apOptions := asn1.BitString{Bytes: []byte{0x00, 0x00, 0x00, 0x00}, BitLength: 32}
+	if opts.Mutual {
+		// mutual-required is APOptions bit 2 -> byte 0, 0x20.
+		apOptions.Bytes[0] |= 0x20
+	}
+	apReq := &messages.APReq{
+		PVNO:          messages.KerberosV5,
+		MsgType:       messages.MsgTypeAPReq,
+		APOptions:     apOptions,
+		TicketRaw:     opts.TicketRaw,
+		Authenticator: messages.EncryptedData{EType: opts.SessionEType, Cipher: encAuth},
+	}
+	apReqBytes, err := apReq.Marshal()
+	if err != nil {
+		return nil, nil, fmt.Errorf("gssapi: marshal AP-REQ: %w", err)
+	}
+
+	token, err := WrapToken(TokIDAPReq, apReqBytes)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	ctx := &SecContext{
+		SessionKey:   opts.SessionKey,
+		SessionEType: opts.SessionEType,
+		SubKey:       opts.SubKey,
+		SubKeyEType:  opts.SubKeyEType,
+		SeqNumber:    seqNum,
+		ctime:        now.Truncate(time.Second),
+		cusec:        cusec,
+	}
+	return token, ctx, nil
+}
+
+// AcceptAPRep verifies a KRB_AP_REP GSS token returned by the acceptor for
+// mutual authentication: it unwraps the token, decrypts the EncAPRepPart with
+// the ticket session key (key usage 12), and checks that the echoed ctime/cusec
+// match those sent in the initiator's authenticator. On success it adopts an
+// acceptor subkey into the context if one was supplied.
+func (ctx *SecContext) AcceptAPRep(token []byte) error {
+	tokID, krbMsg, err := UnwrapToken(token)
+	if err != nil {
+		return err
+	}
+	if tokID != TokIDAPRep {
+		return fmt.Errorf("gssapi: expected AP-REP token (02 00), got %02x %02x", tokID[0], tokID[1])
+	}
+
+	var apRep messages.APRep
+	if _, err := apRep.Unmarshal(krbMsg); err != nil {
+		return fmt.Errorf("gssapi: parse AP-REP: %w", err)
+	}
+	plain, err := kerbcrypto.Decrypt(ctx.SessionEType, ctx.SessionKey, kerbcrypto.KeyUsageAPRepEncPart, apRep.EncPart.Cipher)
+	if err != nil {
+		return fmt.Errorf("gssapi: decrypt AP-REP enc-part: %w", err)
+	}
+	var enc messages.EncAPRepPart
+	if _, err := enc.Unmarshal(plain); err != nil {
+		return fmt.Errorf("gssapi: parse EncAPRepPart: %w", err)
+	}
+	if !enc.CTime.Equal(ctx.ctime) || enc.CUSec != ctx.cusec {
+		return fmt.Errorf("gssapi: AP-REP ctime/cusec mismatch (mutual authentication failed)")
+	}
+	if enc.SubKey != nil {
+		ctx.SubKey = enc.SubKey.KeyValue
+		ctx.SubKeyEType = enc.SubKey.KeyType
+	}
+	return nil
+}

--- a/network/kerberos/v5/gssapi/gssapi.go
+++ b/network/kerberos/v5/gssapi/gssapi.go
@@ -116,6 +116,11 @@ type SecContext struct {
 	// ctime/cusec are retained to match the AP-REP echo (mutual authentication).
 	ctime time.Time
 	cusec int
+	// sendSeq is the running sequence number for outgoing per-message tokens.
+	sendSeq uint64
+	// acceptorSubkey records that the base key is an acceptor-asserted subkey,
+	// so per-message tokens must set the AcceptorSubkey flag.
+	acceptorSubkey bool
 }
 
 // InitOptions configures InitSecContext.
@@ -220,6 +225,7 @@ func InitSecContext(opts InitOptions) ([]byte, *SecContext, error) {
 		SeqNumber:    seqNum,
 		ctime:        now.Truncate(time.Second),
 		cusec:        cusec,
+		sendSeq:      uint64(seqNum),
 	}
 	return token, ctx, nil
 }
@@ -256,6 +262,7 @@ func (ctx *SecContext) AcceptAPRep(token []byte) error {
 	if enc.SubKey != nil {
 		ctx.SubKey = enc.SubKey.KeyValue
 		ctx.SubKeyEType = enc.SubKey.KeyType
+		ctx.acceptorSubkey = true
 	}
 	return nil
 }

--- a/network/kerberos/v5/gssapi/gssapi_test.go
+++ b/network/kerberos/v5/gssapi/gssapi_test.go
@@ -1,0 +1,207 @@
+package gssapi
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+	"time"
+
+	kerbcrypto "github.com/TheManticoreProject/Manticore/network/kerberos/v5/crypto"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/iana"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/messages"
+)
+
+func TestGSSChecksumValue(t *testing.T) {
+	flags := uint32(GSSMutualFlag | GSSIntegFlag | GSSConfFlag)
+	cksum := GSSChecksumValue(flags, nil)
+	if len(cksum) != 24 {
+		t.Fatalf("checksum length = %d, want 24", len(cksum))
+	}
+	if binary.LittleEndian.Uint32(cksum[0:]) != 16 {
+		t.Errorf("Lgth field = %d, want 16", binary.LittleEndian.Uint32(cksum[0:]))
+	}
+	for _, b := range cksum[4:20] {
+		if b != 0 {
+			t.Errorf("Bnd should be zero for no channel bindings: % X", cksum[4:20])
+			break
+		}
+	}
+	if got := binary.LittleEndian.Uint32(cksum[20:]); got != flags {
+		t.Errorf("Flags = 0x%x, want 0x%x", got, flags)
+	}
+	// With channel bindings the Bnd field is a nonzero MD5.
+	cb := GSSChecksumValue(flags, []byte("chan-binding"))
+	allZero := true
+	for _, b := range cb[4:20] {
+		if b != 0 {
+			allZero = false
+		}
+	}
+	if allZero {
+		t.Error("Bnd should be a nonzero MD5 when channel bindings are supplied")
+	}
+}
+
+func TestWrapUnwrapToken(t *testing.T) {
+	msg := []byte("fake-krb-ap-req")
+	tok, err := WrapToken(TokIDAPReq, msg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tok[0] != 0x60 {
+		t.Errorf("token should start with 0x60 (APPLICATION 0), got 0x%02x", tok[0])
+	}
+	id, got, err := UnwrapToken(tok)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id != TokIDAPReq {
+		t.Errorf("TOK_ID = %02x %02x, want 01 00", id[0], id[1])
+	}
+	if !bytes.Equal(got, msg) {
+		t.Errorf("inner message not preserved")
+	}
+	// A non-Kerberos OID must be rejected.
+	bad := append([]byte(nil), tok...)
+	// flip a byte in the OID region
+	bad[5] ^= 0xff
+	if _, _, err := UnwrapToken(bad); err == nil {
+		t.Error("expected error for a corrupted mech OID")
+	}
+}
+
+func fakeTicketAndKey(t *testing.T) ([]byte, []byte) {
+	t.Helper()
+	tkt := messages.Ticket{
+		TktVno:  messages.KerberosV5,
+		Realm:   "CORP.LOCAL",
+		SName:   messages.PrincipalName{NameType: iana.NameTypeSRVInst, NameString: []string{"cifs", "dc01.corp.local"}},
+		EncPart: messages.EncryptedData{EType: iana.ETypeAES256CTSHMACSHA196, Cipher: bytes.Repeat([]byte{0x5a}, 32)},
+	}
+	raw, err := tkt.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw, bytes.Repeat([]byte{0x11}, 32)
+}
+
+func TestInitSecContextProducesDecryptableAPReq(t *testing.T) {
+	ticketRaw, sessionKey := fakeTicketAndKey(t)
+
+	token, ctx, err := InitSecContext(InitOptions{
+		TicketRaw:    ticketRaw,
+		SessionKey:   sessionKey,
+		SessionEType: iana.ETypeAES256CTSHMACSHA196,
+		ClientName:   messages.PrincipalName{NameType: iana.NameTypePrincipal, NameString: []string{"alice"}},
+		ClientRealm:  "CORP.LOCAL",
+		Flags:        GSSIntegFlag | GSSConfFlag,
+		Mutual:       true,
+	})
+	if err != nil {
+		t.Fatalf("InitSecContext: %v", err)
+	}
+
+	id, apReqBytes, err := UnwrapToken(token)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id != TokIDAPReq {
+		t.Fatalf("TOK_ID = %02x %02x", id[0], id[1])
+	}
+
+	var apReq messages.APReq
+	if _, err := apReq.Unmarshal(apReqBytes); err != nil {
+		t.Fatalf("parse AP-REQ: %v", err)
+	}
+	// mutual-required (APOptions bit 2) must be set.
+	if apReq.APOptions.Bytes[0]&0x20 == 0 {
+		t.Errorf("mutual-required AP option not set: % X", apReq.APOptions.Bytes)
+	}
+	if !bytes.Equal(apReq.TicketRaw, ticketRaw) {
+		t.Error("ticket not carried verbatim")
+	}
+
+	// Decrypt the authenticator with the session key at key usage 11.
+	authBytes, err := kerbcrypto.Decrypt(iana.ETypeAES256CTSHMACSHA196, sessionKey, kerbcrypto.KeyUsageAPReqAuthen, apReq.Authenticator.Cipher)
+	if err != nil {
+		t.Fatalf("decrypt authenticator: %v", err)
+	}
+	var auth messages.Authenticator
+	if _, err := auth.Unmarshal(authBytes); err != nil {
+		t.Fatalf("parse authenticator: %v", err)
+	}
+	if auth.Cksum == nil || auth.Cksum.CKSumType != ChecksumTypeGSSAPI {
+		t.Fatalf("authenticator checksum type = %v, want 0x8003", auth.Cksum)
+	}
+	if len(auth.Cksum.Checksum) != 24 {
+		t.Fatalf("0x8003 checksum length = %d, want 24", len(auth.Cksum.Checksum))
+	}
+	gotFlags := binary.LittleEndian.Uint32(auth.Cksum.Checksum[20:])
+	if gotFlags&GSSMutualFlag == 0 || gotFlags&GSSIntegFlag == 0 || gotFlags&GSSConfFlag == 0 {
+		t.Errorf("checksum flags 0x%x missing expected bits", gotFlags)
+	}
+	if auth.SeqNumber != ctx.SeqNumber {
+		t.Errorf("authenticator seq %d != ctx seq %d", auth.SeqNumber, ctx.SeqNumber)
+	}
+	if auth.CName.NameString[0] != "alice" {
+		t.Errorf("cname wrong: %+v", auth.CName)
+	}
+}
+
+// makeAPRepToken builds an AP-REP GSS token echoing ctime/cusec, encrypted under
+// the session key, as an acceptor would for mutual authentication.
+func makeAPRepToken(t *testing.T, sessionKey []byte, etype int, ctime time.Time, cusec int) []byte {
+	t.Helper()
+	enc := messages.EncAPRepPart{CTime: ctime, CUSec: cusec}
+	encBytes, err := enc.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cipher, err := kerbcrypto.Encrypt(etype, sessionKey, kerbcrypto.KeyUsageAPRepEncPart, encBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	apRep := messages.APRep{PVNO: messages.KerberosV5, MsgType: messages.MsgTypeAPRep, EncPart: messages.EncryptedData{EType: etype, Cipher: cipher}}
+	apRepBytes, err := apRep.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	token, err := WrapToken(TokIDAPRep, apRepBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return token
+}
+
+func TestAcceptAPRepMutualAuth(t *testing.T) {
+	ticketRaw, sessionKey := fakeTicketAndKey(t)
+	_, ctx, err := InitSecContext(InitOptions{
+		TicketRaw:    ticketRaw,
+		SessionKey:   sessionKey,
+		SessionEType: iana.ETypeAES256CTSHMACSHA196,
+		ClientName:   messages.PrincipalName{NameType: iana.NameTypePrincipal, NameString: []string{"alice"}},
+		ClientRealm:  "CORP.LOCAL",
+		Mutual:       true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Correct AP-REP verifies.
+	good := makeAPRepToken(t, sessionKey, iana.ETypeAES256CTSHMACSHA196, ctx.ctime, ctx.cusec)
+	if err := ctx.AcceptAPRep(good); err != nil {
+		t.Errorf("AcceptAPRep rejected a valid AP-REP: %v", err)
+	}
+
+	// Wrong ctime fails (replay / mismatch).
+	bad := makeAPRepToken(t, sessionKey, iana.ETypeAES256CTSHMACSHA196, ctx.ctime.Add(time.Second), ctx.cusec)
+	if err := ctx.AcceptAPRep(bad); err == nil {
+		t.Error("AcceptAPRep accepted an AP-REP with mismatched ctime")
+	}
+
+	// An AP-REQ token (wrong TOK_ID) is rejected.
+	apreqTok, _ := WrapToken(TokIDAPReq, []byte("x"))
+	if err := ctx.AcceptAPRep(apreqTok); err == nil {
+		t.Error("AcceptAPRep accepted a non-AP-REP token")
+	}
+}

--- a/network/kerberos/v5/gssapi/permessage.go
+++ b/network/kerberos/v5/gssapi/permessage.go
@@ -1,0 +1,244 @@
+package gssapi
+
+import (
+	"crypto/hmac"
+	"encoding/binary"
+	"fmt"
+
+	kerbcrypto "github.com/TheManticoreProject/Manticore/network/kerberos/v5/crypto"
+)
+
+// RFC 4121 §4.2.6 per-message tokens (MIC and Wrap), for the RFC 3961/3962/8009
+// (AES) crypto profiles. These provide message integrity (GetMIC/VerifyMIC) and
+// confidentiality+integrity (Wrap/Unwrap) once a context is established, and are
+// what SMB and LDAP use for signing and sealing.
+
+// RFC 4121 §2 key-usage numbers for per-message tokens.
+const (
+	kgUsageAcceptorSeal  = 22
+	kgUsageAcceptorSign  = 23
+	kgUsageInitiatorSeal = 24
+	kgUsageInitiatorSign = 25
+)
+
+// Per-message token Flags bits (RFC 4121 §4.2.2).
+const (
+	flagSentByAcceptor = 0x01
+	flagSealed         = 0x02
+	flagAcceptorSubkey = 0x04
+)
+
+var (
+	tokIDMIC  = [2]byte{0x04, 0x04}
+	tokIDWrap = [2]byte{0x05, 0x04}
+)
+
+// baseKey returns the key protecting per-message tokens: the acceptor subkey if
+// one was asserted, otherwise the ticket session key.
+func (ctx *SecContext) baseKey() ([]byte, int) {
+	if len(ctx.SubKey) > 0 {
+		return ctx.SubKey, ctx.SubKeyEType
+	}
+	return ctx.SessionKey, ctx.SessionEType
+}
+
+// initiatorFlags is the Flags byte for tokens this (initiator) context sends.
+func (ctx *SecContext) initiatorFlags(sealed bool) byte {
+	var f byte
+	if ctx.acceptorSubkey {
+		f |= flagAcceptorSubkey
+	}
+	if sealed {
+		f |= flagSealed
+	}
+	return f // SentByAcceptor stays 0 (we are the initiator)
+}
+
+func (ctx *SecContext) nextSendSeq() uint64 {
+	s := ctx.sendSeq
+	ctx.sendSeq++
+	return s
+}
+
+// micLen returns the checksum length appended to MIC / integrity-only Wrap
+// tokens for an etype.
+func micLen(etype int) int {
+	if ct, ok := kerbcrypto.ChecksumTypeForEType(etype); ok {
+		switch ct {
+		case 15, 16: // hmac-sha1-96-aes*
+			return 12
+		case 19: // hmac-sha256-128
+			return 16
+		case 20: // hmac-sha384-192
+			return 24
+		default: // hmac-md5 (rc4)
+			return 16
+		}
+	}
+	return 0
+}
+
+// rotateLeft rotates b left by n octets (undoing a right rotation by n).
+func rotateLeft(b []byte, n int) []byte {
+	if len(b) == 0 {
+		return b
+	}
+	n %= len(b)
+	out := make([]byte, len(b))
+	copy(out, b[n:])
+	copy(out[len(b)-n:], b[:n])
+	return out
+}
+
+// micHeader builds the 16-byte MIC token header.
+func micHeader(flags byte, seq uint64) []byte {
+	h := make([]byte, 16)
+	h[0], h[1] = tokIDMIC[0], tokIDMIC[1]
+	h[2] = flags
+	for i := 3; i < 8; i++ {
+		h[i] = 0xFF
+	}
+	binary.BigEndian.PutUint64(h[8:], seq)
+	return h
+}
+
+// wrapHeader builds the 16-byte Wrap token header with EC=0, RRC=0.
+func wrapHeader(flags byte, seq uint64) []byte {
+	h := make([]byte, 16)
+	h[0], h[1] = tokIDWrap[0], tokIDWrap[1]
+	h[2] = flags
+	h[3] = 0xFF
+	// EC (4..5) and RRC (6..7) left as 0.
+	binary.BigEndian.PutUint64(h[8:], seq)
+	return h
+}
+
+// MakeMIC produces a MIC token over data as the context initiator (RFC 4121
+// §4.2.6.1): checksum(data | header) keyed with the initiator-sign usage.
+func (ctx *SecContext) MakeMIC(data []byte) ([]byte, error) {
+	key, etype := ctx.baseKey()
+	ct, ok := kerbcrypto.ChecksumTypeForEType(etype)
+	if !ok {
+		return nil, fmt.Errorf("gssapi: no checksum for etype %d", etype)
+	}
+	hdr := micHeader(ctx.initiatorFlags(false), ctx.nextSendSeq())
+	sum, err := kerbcrypto.GetChecksum(ct, key, kgUsageInitiatorSign, append(append([]byte{}, data...), hdr...))
+	if err != nil {
+		return nil, err
+	}
+	return append(hdr, sum...), nil
+}
+
+// VerifyMIC verifies a MIC token received from the acceptor over data.
+func (ctx *SecContext) VerifyMIC(data, token []byte) error {
+	if len(token) < 16 {
+		return fmt.Errorf("gssapi: MIC token too short")
+	}
+	if token[0] != tokIDMIC[0] || token[1] != tokIDMIC[1] {
+		return fmt.Errorf("gssapi: not a MIC token")
+	}
+	if token[2]&flagSentByAcceptor == 0 {
+		return fmt.Errorf("gssapi: MIC token not marked as sent by acceptor")
+	}
+	key, etype := ctx.baseKey()
+	ct, ok := kerbcrypto.ChecksumTypeForEType(etype)
+	if !ok {
+		return fmt.Errorf("gssapi: no checksum for etype %d", etype)
+	}
+	hdr := token[:16]
+	got := token[16:]
+	want, err := kerbcrypto.GetChecksum(ct, key, kgUsageAcceptorSign, append(append([]byte{}, data...), hdr...))
+	if err != nil {
+		return err
+	}
+	if !hmac.Equal(got, want) {
+		return fmt.Errorf("gssapi: MIC verification failed")
+	}
+	return nil
+}
+
+// Wrap produces a Wrap token over data as the context initiator (RFC 4121
+// §4.2.6.2). With seal=true the token provides confidentiality+integrity;
+// otherwise integrity only. EC and RRC are 0 (no filler, no rotation).
+func (ctx *SecContext) Wrap(data []byte, seal bool) ([]byte, error) {
+	key, etype := ctx.baseKey()
+	hdr := wrapHeader(ctx.initiatorFlags(seal), ctx.nextSendSeq())
+
+	if seal {
+		pt := append(append([]byte{}, data...), hdr...)
+		ct, err := kerbcrypto.Encrypt(etype, key, kgUsageInitiatorSeal, pt)
+		if err != nil {
+			return nil, err
+		}
+		return append(hdr, ct...), nil
+	}
+
+	ct, ok := kerbcrypto.ChecksumTypeForEType(etype)
+	if !ok {
+		return nil, fmt.Errorf("gssapi: no checksum for etype %d", etype)
+	}
+	sum, err := kerbcrypto.GetChecksum(ct, key, kgUsageInitiatorSeal, append(append([]byte{}, data...), hdr...))
+	if err != nil {
+		return nil, err
+	}
+	out := append([]byte{}, hdr...)
+	out = append(out, data...)
+	out = append(out, sum...)
+	return out, nil
+}
+
+// Unwrap decodes a Wrap token received from the acceptor, returning the
+// plaintext data and whether it was sealed (confidential).
+func (ctx *SecContext) Unwrap(token []byte) (data []byte, sealed bool, err error) {
+	if len(token) < 16 {
+		return nil, false, fmt.Errorf("gssapi: Wrap token too short")
+	}
+	if token[0] != tokIDWrap[0] || token[1] != tokIDWrap[1] {
+		return nil, false, fmt.Errorf("gssapi: not a Wrap token")
+	}
+	flags := token[2]
+	if flags&flagSentByAcceptor == 0 {
+		return nil, false, fmt.Errorf("gssapi: Wrap token not marked as sent by acceptor")
+	}
+	sealed = flags&flagSealed != 0
+	ec := int(binary.BigEndian.Uint16(token[4:6]))
+	rrc := int(binary.BigEndian.Uint16(token[6:8]))
+	hdr := token[:16]
+	body := rotateLeft(token[16:], rrc)
+
+	key, etype := ctx.baseKey()
+
+	if sealed {
+		pt, err := kerbcrypto.Decrypt(etype, key, kgUsageAcceptorSeal, body)
+		if err != nil {
+			return nil, false, fmt.Errorf("gssapi: decrypt Wrap token: %w", err)
+		}
+		// pt = data | filler(ec) | header(16).
+		if len(pt) < 16+ec {
+			return nil, false, fmt.Errorf("gssapi: Wrap plaintext too short")
+		}
+		return pt[:len(pt)-16-ec], true, nil
+	}
+
+	ct, ok := kerbcrypto.ChecksumTypeForEType(etype)
+	if !ok {
+		return nil, false, fmt.Errorf("gssapi: no checksum for etype %d", etype)
+	}
+	ml := micLen(etype)
+	if len(body) < ml {
+		return nil, false, fmt.Errorf("gssapi: Wrap token too short for checksum")
+	}
+	payload := body[:len(body)-ml]
+	got := body[len(body)-ml:]
+	// The checksum is over data | header with EC and RRC zeroed.
+	zhdr := append([]byte{}, hdr...)
+	zhdr[4], zhdr[5], zhdr[6], zhdr[7] = 0, 0, 0, 0
+	want, err := kerbcrypto.GetChecksum(ct, key, kgUsageAcceptorSeal, append(append([]byte{}, payload...), zhdr...))
+	if err != nil {
+		return nil, false, err
+	}
+	if !hmac.Equal(got, want) {
+		return nil, false, fmt.Errorf("gssapi: Wrap integrity check failed")
+	}
+	return payload, false, nil
+}

--- a/network/kerberos/v5/gssapi/permessage_test.go
+++ b/network/kerberos/v5/gssapi/permessage_test.go
@@ -1,0 +1,195 @@
+package gssapi
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	kerbcrypto "github.com/TheManticoreProject/Manticore/network/kerberos/v5/crypto"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/iana"
+)
+
+// newTestContext returns an initiator SecContext with a fixed AES256 session key
+// (no subkey), so per-message tokens can be exercised directly.
+func newTestContext(seq uint64) *SecContext {
+	return &SecContext{
+		SessionKey:   bytes.Repeat([]byte{0x33}, 32),
+		SessionEType: iana.ETypeAES256CTSHMACSHA196,
+		sendSeq:      seq,
+	}
+}
+
+// acceptorMIC simulates the acceptor producing a MIC token over data (flag
+// SentByAcceptor set, keyed with the acceptor-sign usage).
+func acceptorMIC(t *testing.T, key []byte, etype int, seq uint64, data []byte) []byte {
+	t.Helper()
+	ct, _ := kerbcrypto.ChecksumTypeForEType(etype)
+	hdr := micHeader(flagSentByAcceptor, seq)
+	sum, err := kerbcrypto.GetChecksum(ct, key, kgUsageAcceptorSign, append(append([]byte{}, data...), hdr...))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return append(hdr, sum...)
+}
+
+func TestMICInitiatorToAcceptor(t *testing.T) {
+	ctx := newTestContext(100)
+	data := []byte("integrity-protect-me")
+
+	tok, err := ctx.MakeMIC(data)
+	if err != nil {
+		t.Fatalf("MakeMIC: %v", err)
+	}
+	if tok[0] != 0x04 || tok[1] != 0x04 {
+		t.Errorf("MIC TOK_ID = %02x %02x", tok[0], tok[1])
+	}
+	if tok[2]&flagSentByAcceptor != 0 {
+		t.Error("initiator MIC must not set SentByAcceptor")
+	}
+	if binary.BigEndian.Uint64(tok[8:16]) != 100 {
+		t.Errorf("SND_SEQ = %d, want 100", binary.BigEndian.Uint64(tok[8:16]))
+	}
+
+	// The acceptor verifies with the initiator-sign usage.
+	ct, _ := kerbcrypto.ChecksumTypeForEType(ctx.SessionEType)
+	want, _ := kerbcrypto.GetChecksum(ct, ctx.SessionKey, kgUsageInitiatorSign, append(append([]byte{}, data...), tok[:16]...))
+	if !bytes.Equal(tok[16:], want) {
+		t.Error("initiator MIC checksum does not verify under initiator-sign usage")
+	}
+
+	// Tampered data must fail that verification.
+	bad, _ := kerbcrypto.GetChecksum(ct, ctx.SessionKey, kgUsageInitiatorSign, append([]byte("tampered"), tok[:16]...))
+	if bytes.Equal(tok[16:], bad) {
+		t.Error("MIC did not depend on the data")
+	}
+}
+
+func TestVerifyMICFromAcceptor(t *testing.T) {
+	ctx := newTestContext(1)
+	data := []byte("server-signed-response")
+	tok := acceptorMIC(t, ctx.SessionKey, ctx.SessionEType, 5, data)
+
+	if err := ctx.VerifyMIC(data, tok); err != nil {
+		t.Errorf("VerifyMIC rejected a valid acceptor MIC: %v", err)
+	}
+	if err := ctx.VerifyMIC([]byte("other"), tok); err == nil {
+		t.Error("VerifyMIC accepted a MIC over different data")
+	}
+	// An initiator-flagged token must be rejected by VerifyMIC.
+	if err := ctx.VerifyMIC(data, func() []byte { tk, _ := newTestContext(5).MakeMIC(data); return tk }()); err == nil {
+		t.Error("VerifyMIC accepted an initiator-sent MIC")
+	}
+}
+
+func TestWrapSealRoundtrip(t *testing.T) {
+	ctx := newTestContext(200)
+	data := []byte("confidential-payload-of-some-length")
+
+	tok, err := ctx.Wrap(data, true)
+	if err != nil {
+		t.Fatalf("Wrap: %v", err)
+	}
+	if tok[0] != 0x05 || tok[1] != 0x04 {
+		t.Errorf("Wrap TOK_ID = %02x %02x", tok[0], tok[1])
+	}
+	if tok[2]&flagSealed == 0 {
+		t.Error("sealed Wrap must set the Sealed flag")
+	}
+	// Ciphertext must not contain the plaintext.
+	if bytes.Contains(tok, data) {
+		t.Error("sealed Wrap token leaks plaintext")
+	}
+
+	// Acceptor side: decrypt with the initiator-seal usage, strip trailing header.
+	pt, err := kerbcrypto.Decrypt(ctx.SessionEType, ctx.SessionKey, kgUsageInitiatorSeal, tok[16:])
+	if err != nil {
+		t.Fatalf("acceptor decrypt: %v", err)
+	}
+	if len(pt) < 16 || !bytes.Equal(pt[:len(pt)-16], data) {
+		t.Errorf("unwrapped plaintext mismatch")
+	}
+}
+
+func TestUnwrapSealFromAcceptor(t *testing.T) {
+	ctx := newTestContext(1)
+	data := []byte("server-sealed-data")
+
+	// Acceptor builds a sealed Wrap token (SentByAcceptor + Sealed, acceptor-seal usage).
+	hdr := wrapHeader(flagSentByAcceptor|flagSealed, 7)
+	pt := append(append([]byte{}, data...), hdr...)
+	ctext, err := kerbcrypto.Encrypt(ctx.SessionEType, ctx.SessionKey, kgUsageAcceptorSeal, pt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tok := append(hdr, ctext...)
+
+	got, sealed, err := ctx.Unwrap(tok)
+	if err != nil {
+		t.Fatalf("Unwrap: %v", err)
+	}
+	if !sealed {
+		t.Error("Unwrap reported not sealed")
+	}
+	if !bytes.Equal(got, data) {
+		t.Errorf("Unwrap data = %q, want %q", got, data)
+	}
+}
+
+func TestWrapIntegrityOnlyRoundtrip(t *testing.T) {
+	ctx := newTestContext(300)
+	data := []byte("signed-not-sealed")
+
+	tok, err := ctx.Wrap(data, false)
+	if err != nil {
+		t.Fatalf("Wrap: %v", err)
+	}
+	if tok[2]&flagSealed != 0 {
+		t.Error("integrity-only Wrap must not set the Sealed flag")
+	}
+	// Plaintext is present in the clear for integrity-only wrap.
+	if !bytes.Contains(tok, data) {
+		t.Error("integrity-only Wrap should carry plaintext")
+	}
+
+	// Acceptor verifies: recompute over payload | header(EC/RRC zeroed).
+	ct, _ := kerbcrypto.ChecksumTypeForEType(ctx.SessionEType)
+	ml := micLen(ctx.SessionEType)
+	payload := tok[16 : len(tok)-ml]
+	want, _ := kerbcrypto.GetChecksum(ct, ctx.SessionKey, kgUsageInitiatorSeal, append(append([]byte{}, payload...), tok[:16]...))
+	if !bytes.Equal(tok[len(tok)-ml:], want) {
+		t.Error("integrity-only Wrap checksum does not verify")
+	}
+	if !bytes.Equal(payload, data) {
+		t.Error("integrity-only Wrap payload mismatch")
+	}
+}
+
+func TestUnwrapRotation(t *testing.T) {
+	ctx := newTestContext(1)
+	data := []byte("rotated-sealed-data-payload")
+
+	// Acceptor seals then right-rotates the body by RRC to exercise un-rotation.
+	rrc := 5
+	hdr := wrapHeader(flagSentByAcceptor|flagSealed, 9)
+	binary.BigEndian.PutUint16(hdr[6:8], uint16(rrc))
+	// The encrypted header must carry RRC=0 (per RFC 4121); build a separate one.
+	encHdr := append([]byte{}, hdr...)
+	binary.BigEndian.PutUint16(encHdr[6:8], 0)
+	pt := append(append([]byte{}, data...), encHdr...)
+	ctext, err := kerbcrypto.Encrypt(ctx.SessionEType, ctx.SessionKey, kgUsageAcceptorSeal, pt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Right-rotate ctext by rrc.
+	n := rrc % len(ctext)
+	rotated := append(append([]byte{}, ctext[len(ctext)-n:]...), ctext[:len(ctext)-n]...)
+	tok := append(hdr, rotated...)
+
+	got, _, err := ctx.Unwrap(tok)
+	if err != nil {
+		t.Fatalf("Unwrap rotated: %v", err)
+	}
+	if !bytes.Equal(got, data) {
+		t.Errorf("rotated Unwrap data mismatch: %q", got)
+	}
+}

--- a/network/kerberos/v5/messages/authenticator.go
+++ b/network/kerberos/v5/messages/authenticator.go
@@ -68,6 +68,9 @@ type Authenticator struct {
 	CRealm string
 	// CName is the client's principal name.
 	CName PrincipalName
+	// Cksum is an optional checksum over application data. The GSS-API mechanism
+	// (RFC 1964) uses it to carry the 0x8003 channel-binding/flags structure.
+	Cksum *Checksum
 	// CUSec is the microseconds component of CTime.
 	CUSec int
 	// CTime is the client's current time (must match server time within clock skew).
@@ -87,6 +90,9 @@ func (a *Authenticator) Marshal() ([]byte, error) {
 		CUSec:     a.CUSec,
 		CTime:     a.CTime,
 		SeqNumber: a.SeqNumber,
+	}
+	if a.Cksum != nil {
+		inner.Cksum = *a.Cksum
 	}
 	if a.SubKey != nil {
 		inner.SubKey = *a.SubKey
@@ -118,6 +124,11 @@ func (a *Authenticator) Unmarshal(data []byte) (int, error) {
 	a.CUSec = inner.CUSec
 	a.CTime = inner.CTime
 	a.SeqNumber = inner.SeqNumber
+	// Cksum is optional; only set if a checksum type is present.
+	if inner.Cksum.CKSumType != 0 || len(inner.Cksum.Checksum) != 0 {
+		ck := inner.Cksum
+		a.Cksum = &ck
+	}
 	// SubKey is optional; only set if KeyType is non-zero
 	if inner.SubKey.KeyType != 0 {
 		sk := inner.SubKey


### PR DESCRIPTION
## Summary

Phase 7 (part 1) of the native, standard-library-only Kerberos v5 implementation: the Kerberos GSS-API mechanism core (RFC 1964 / RFC 4121) that will plug into SPNEGO to authenticate SMB, RPC, and LDAP. No external dependencies.

**Stacked on #902** (base `kerberos-s4u`); bases retarget as the chain merges. This is the first of several Phase 7 slices — context-establishment tokens here; per-message tokens, SPNEGO wiring, and gokrb5 removal follow.

## Changes

New `gssapi` package:
- `WrapToken` / `UnwrapToken` — the GSS InitialContextToken framing (`[APPLICATION 0] { kerberos5 mech OID, TOK_ID | krb-message }`), with the `01 00` / `02 00` / `03 00` TOK_IDs for AP-REQ / AP-REP / KRB-ERROR. This blob is exactly the Kerberos `mechToken` carried inside SPNEGO.
- `GSSChecksumValue` — the `0x8003` authenticator checksum (`Lgth | Bnd | Flags`, little-endian; `Bnd` = MD5 of channel bindings or 16 zero bytes) carrying the GSS context flags (deleg/mutual/replay/sequence/conf/integ).
- `InitSecContext` — builds the KRB_AP_REQ GSS token from a service ticket + session key (authenticator with the `0x8003` checksum, encrypted at key usage 11), returning a `SecContext`.
- `SecContext.AcceptAPRep` — verifies the KRB_AP_REP for mutual authentication (decrypts EncAPRepPart at key usage 12, checks the echoed ctime/cusec).

Supporting:
- `messages.Authenticator` now exposes an optional `Cksum` field (marshaled + unmarshaled), required to carry the `0x8003` GSS checksum.
- `crypto` re-exports `KeyUsageAPRepEncPart` (12).

## How Verified

- Unit tests: checksum layout; token wrap/unwrap incl. wrong-OID rejection; `InitSecContext` produces an AP-REQ that decrypts under the session key (KU 11) and carries the `0x8003` checksum with the requested flags and matching seq/cname; `AcceptAPRep` accepts a valid AP-REP and rejects a ctime mismatch and a wrong TOK_ID.
- `go test ./network/kerberos/...`, `go vet`, and `go build ./...` are green.

## Test Coverage

**Added:** `gssapi/gssapi_test.go`.

## Notes / remaining Phase 7 slices

- Per-message tokens (GetMIC/VerifyMIC + Wrap/Unwrap, RFC 4121 §4.2 / RFC 1964 §1.2) for SMB/LDAP signing+sealing.
- SPNEGO wiring: fill the `crypto/spnego` Kerberos stubs (`AuthContext` needs KDC/ticket material via a provider — dependency inversion).
- gokrb5 removal: re-point `network/ldap/session.go`, delete `KerberosInit`, drop `gokrb5` from `go.mod`, remove the dead `network/gssapi` skeleton.
- Consumer wiring: SMB2 session setup and DCE/RPC (`RPC_C_AUTHN_GSS_NEGOTIATE`).
- Grounded in the local RFC 1964 (`network/kerberos/v5/docs`).