### PR TITLE
Wire native Kerberos into SPNEGO and SMB2 session setup

### DIFF
--- a/crypto/spnego/authcontext.go
+++ b/crypto/spnego/authcontext.go
@@ -39,6 +39,26 @@ type AuthContext struct {
 	// wire; callers use it as the MAC key for SMB message signing. It is nil until
 	// authentication has produced a key (and for auth paths that do not derive one).
 	SessionKey []byte
+
+	// Kerberos supplies the GSS-API tokens when Type is AuthTypeKerberos. It is set
+	// by the consumer (SMB/DCE-RPC) so crypto/spnego needs no dependency on the
+	// Kerberos implementation (dependency inversion).
+	Kerberos KerberosProvider
+}
+
+// KerberosProvider produces and verifies the Kerberos GSS-API tokens exchanged
+// inside SPNEGO. A consumer backs it with the native Kerberos stack and assigns
+// it to AuthContext.Kerberos.
+type KerberosProvider interface {
+	// InitToken returns the initial GSS-API token (a KRB_AP_REQ) to carry in the
+	// SPNEGO NegTokenInit mechToken.
+	InitToken() ([]byte, error)
+	// AcceptResponseToken verifies the server's response token (a KRB_AP_REP for
+	// mutual authentication). An empty token is accepted as a no-op.
+	AcceptResponseToken(token []byte) error
+	// SessionKey returns the established context key used for message
+	// signing/sealing after the exchange completes.
+	SessionKey() []byte
 }
 
 // GetSessionKey returns the session key derived during authentication, or nil if

--- a/crypto/spnego/challenge.go
+++ b/crypto/spnego/challenge.go
@@ -145,6 +145,17 @@ func (ctx *AuthContext) processChallengeInnerTokenNTLM(innerToken []byte) ([]byt
 //   - []byte: The SPNEGO token containing the Kerberos authenticate message
 //   - error: An error if token processing fails
 func (ctx *AuthContext) processChallengeInnerTokenKerberos(innerToken []byte) ([]byte, error) {
-	// TODO: Implement kerberos authentication
-	return nil, errors.New("kerberos authentication is not yet implemented")
+	if ctx.Kerberos == nil {
+		return nil, errors.New("spnego: kerberos provider not configured on AuthContext")
+	}
+	// innerToken is the server's response token: a KRB_AP_REP for mutual
+	// authentication (empty if the server asserted none). Verifying it also lets
+	// the provider adopt any acceptor subkey.
+	if err := ctx.Kerberos.AcceptResponseToken(innerToken); err != nil {
+		return nil, fmt.Errorf("spnego: kerberos accept response: %w", err)
+	}
+	// The GSS context is established once the AP-REP is verified; capture the
+	// session key for message signing/sealing. Kerberos needs no further token.
+	ctx.SessionKey = ctx.Kerberos.SessionKey()
+	return nil, nil
 }

--- a/crypto/spnego/kerberos_test.go
+++ b/crypto/spnego/kerberos_test.go
@@ -1,0 +1,85 @@
+package spnego
+
+import (
+	"bytes"
+	"encoding/asn1"
+	"testing"
+)
+
+// stubKerberos is a KerberosProvider test double.
+type stubKerberos struct {
+	initToken  []byte
+	accepted   []byte
+	sessionKey []byte
+	acceptErr  error
+}
+
+func (s *stubKerberos) InitToken() ([]byte, error)         { return s.initToken, nil }
+func (s *stubKerberos) AcceptResponseToken(t []byte) error { s.accepted = t; return s.acceptErr }
+func (s *stubKerberos) SessionKey() []byte                 { return s.sessionKey }
+
+func TestKerberosNegotiateTokenUsesKerberosMech(t *testing.T) {
+	apReq := []byte("fake-gss-ap-req-token")
+	ctx := NewAuthContext(AuthTypeKerberos, "CORP.LOCAL", "alice", "", "WS", true)
+	ctx.Kerberos = &stubKerberos{initToken: apReq}
+
+	tok, err := ctx.CreateNegotiateToken(0, nil)
+	if err != nil {
+		t.Fatalf("CreateNegotiateToken: %v", err)
+	}
+
+	// The SPNEGO NegTokenInit must advertise the Kerberos mechanism OID and carry
+	// the provider's AP-REQ as the mechToken.
+	oidDER, _ := asn1.Marshal(KerberosOID)
+	if !bytes.Contains(tok, oidDER) {
+		t.Errorf("negotiate token does not advertise the Kerberos mech OID")
+	}
+	if !bytes.Contains(tok, apReq) {
+		t.Errorf("negotiate token does not carry the AP-REQ mechToken")
+	}
+}
+
+func TestKerberosNegotiateRequiresProvider(t *testing.T) {
+	ctx := NewAuthContext(AuthTypeKerberos, "R", "u", "", "WS", true)
+	if _, err := ctx.CreateNegotiateToken(0, nil); err == nil {
+		t.Error("expected error when no Kerberos provider is configured")
+	}
+}
+
+func TestKerberosChallengeVerifiesAPRepAndCapturesKey(t *testing.T) {
+	apRep := []byte("fake-ap-rep")
+	key := []byte("session-key-bytes-32-............")
+	stub := &stubKerberos{sessionKey: key}
+	ctx := NewAuthContext(AuthTypeKerberos, "R", "u", "", "WS", true)
+	ctx.Kerberos = stub
+
+	// Build a server NegTokenResp advertising Kerberos with the AP-REP.
+	resp := NegTokenResp{
+		NegState:      NegStateAcceptCompleted,
+		SupportedMech: KerberosOID,
+		ResponseToken: apRep,
+	}
+	respSeq, err := resp.Marshal()
+	if err != nil {
+		t.Fatalf("marshal NegTokenResp: %v", err)
+	}
+	// The server delivers the NegTokenResp inside a [1]-tagged SecurityBlob.
+	challengeToken, err := (&SecurityBlob{Data: respSeq}).Marshal()
+	if err != nil {
+		t.Fatalf("wrap SecurityBlob: %v", err)
+	}
+
+	out, err := ctx.CreateAuthenticateTokenFromChallengeToken(challengeToken)
+	if err != nil {
+		t.Fatalf("CreateAuthenticateTokenFromChallengeToken: %v", err)
+	}
+	if out != nil {
+		t.Errorf("Kerberos challenge should produce no follow-up token, got %d bytes", len(out))
+	}
+	if !bytes.Equal(stub.accepted, apRep) {
+		t.Errorf("provider did not receive the AP-REP response token")
+	}
+	if !bytes.Equal(ctx.GetSessionKey(), key) {
+		t.Errorf("session key not captured from the Kerberos provider")
+	}
+}

--- a/crypto/spnego/negotiate.go
+++ b/crypto/spnego/negotiate.go
@@ -46,7 +46,13 @@ func (ctx *AuthContext) processNegotiateInnerTokenNTLM(negotiateFlags flags.Nego
 	return CreateNegTokenInit(ntlmNegotiateBytes)
 }
 
-func (ctx *AuthContext) processNegotiateInnerTokenKerberos(negotiateFlags flags.NegotiateFlags, version *version.Version) ([]byte, error) {
-	// TODO: Implement kerberos authentication
-	return nil, errors.New("kerberos authentication is not yet implemented")
+func (ctx *AuthContext) processNegotiateInnerTokenKerberos(_ flags.NegotiateFlags, _ *version.Version) ([]byte, error) {
+	if ctx.Kerberos == nil {
+		return nil, errors.New("spnego: kerberos provider not configured on AuthContext")
+	}
+	mechToken, err := ctx.Kerberos.InitToken()
+	if err != nil {
+		return nil, fmt.Errorf("spnego: kerberos init token: %w", err)
+	}
+	return CreateNegTokenInitKerberos(mechToken)
 }

--- a/crypto/spnego/negtokeninit.go
+++ b/crypto/spnego/negtokeninit.go
@@ -29,6 +29,17 @@ func CreateNegTokenInit(ntlmToken []byte) ([]byte, error) {
 	return init.Marshal()
 }
 
+// CreateNegTokenInitKerberos creates a SPNEGO NegTokenInit advertising the
+// Kerberos mechanism and carrying the given Kerberos GSS-API token (a
+// KRB_AP_REQ) as the mechToken.
+func CreateNegTokenInitKerberos(kerberosToken []byte) ([]byte, error) {
+	init := NegTokenInit{
+		MechTypes: []asn1.ObjectIdentifier{KerberosOID},
+		MechToken: kerberosToken,
+	}
+	return init.Marshal()
+}
+
 // NewNegTokenInit creates a new NegTokenInit with the specified parameters
 // Parameters:
 //   - mechTypes: The mechanism type identifiers to include

--- a/network/kerberos/v5/spnego_mechanism.go
+++ b/network/kerberos/v5/spnego_mechanism.go
@@ -1,0 +1,97 @@
+package kerberos
+
+import (
+	"crypto/rand"
+	"fmt"
+
+	kerbcrypto "github.com/TheManticoreProject/Manticore/network/kerberos/v5/crypto"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/gssapi"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/messages"
+)
+
+// SPNEGOMechanism adapts the native Kerberos client and GSS-API layer to the
+// crypto/spnego KerberosProvider interface, so SMB and DCE/RPC can authenticate
+// with Kerberos through SPNEGO. It targets a single service principal (spn), for
+// example "cifs/host.domain" for SMB or "host/host.domain" / "ldap/host.domain".
+//
+// It is created by the consumer (SMB/RPC) and assigned to
+// spnego.AuthContext.Kerberos, keeping crypto/spnego free of any dependency on
+// the Kerberos implementation.
+type SPNEGOMechanism struct {
+	client *KerberosClient
+	spn    string
+	ctx    *gssapi.SecContext
+}
+
+// NewSPNEGOMechanism builds a mechanism over an existing client (which supplies
+// the credentials and realm) targeting the given service principal name.
+func NewSPNEGOMechanism(client *KerberosClient, spn string) *SPNEGOMechanism {
+	return &SPNEGOMechanism{client: client, spn: spn}
+}
+
+// InitToken acquires (if needed) a TGT and a service ticket for the SPN, then
+// builds the KRB_AP_REQ GSS token to place in the SPNEGO NegTokenInit. Mutual
+// authentication is requested and an initiator subkey is asserted (as Windows
+// GSS clients do).
+func (m *SPNEGOMechanism) InitToken() ([]byte, error) {
+	if !m.client.hasTGT {
+		if err := m.client.GetTGT(); err != nil {
+			return nil, fmt.Errorf("kerberos spnego: GetTGT: %w", err)
+		}
+	}
+	ticket, ticketRaw, key, err := m.client.GetTGS(m.spn, true)
+	if err != nil {
+		return nil, fmt.Errorf("kerberos spnego: GetTGS %q: %w", m.spn, err)
+	}
+	subKey := make([]byte, kerbcrypto.KeyLen(ticket.EncPart.EType))
+	if _, err := rand.Read(subKey); err != nil {
+		return nil, err
+	}
+	tok, ctx, err := gssapi.InitSecContext(gssapi.InitOptions{
+		TicketRaw:    ticketRaw,
+		SessionKey:   key,
+		SessionEType: ticket.EncPart.EType,
+		ClientName:   messages.PrincipalName{NameType: messages.NameTypePrincipal, NameString: []string{m.client.Username()}},
+		ClientRealm:  m.client.Realm(),
+		Flags:        gssapi.GSSMutualFlag | gssapi.GSSSequenceFlag | gssapi.GSSConfFlag | gssapi.GSSIntegFlag,
+		Mutual:       true,
+		SubKey:       subKey,
+		SubKeyEType:  ticket.EncPart.EType,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("kerberos spnego: InitSecContext: %w", err)
+	}
+	m.ctx = ctx
+	return tok, nil
+}
+
+// AcceptResponseToken verifies the server's KRB_AP_REP (mutual authentication).
+// An empty token is a no-op. A server KRB-ERROR is surfaced with its code.
+func (m *SPNEGOMechanism) AcceptResponseToken(token []byte) error {
+	if len(token) == 0 {
+		return nil
+	}
+	if m.ctx == nil {
+		return fmt.Errorf("kerberos spnego: no established context")
+	}
+	if tokID, krbMsg, err := gssapi.UnwrapToken(token); err == nil && tokID == gssapi.TokIDError {
+		var ke messages.KRBError
+		if _, e := ke.Unmarshal(krbMsg); e == nil {
+			return fmt.Errorf("kerberos spnego: server returned KRB-ERROR %d: %s", ke.ErrorCode, ke.EText)
+		}
+	}
+	return m.ctx.AcceptAPRep(token)
+}
+
+// SessionKey returns the established GSS context key for SMB/RPC message
+// signing and sealing: the negotiated subkey if present, otherwise the service
+// ticket session key.
+func (m *SPNEGOMechanism) SessionKey() []byte {
+	if m.ctx == nil {
+		return nil
+	}
+	if len(m.ctx.SubKey) > 0 {
+		return m.ctx.SubKey
+	}
+	return m.ctx.SessionKey
+}

--- a/network/smb/smb_v20/client/session_kerberos.go
+++ b/network/smb/smb_v20/client/session_kerberos.go
@@ -1,0 +1,172 @@
+package client
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/crypto/spnego"
+	kerberos "github.com/TheManticoreProject/Manticore/network/kerberos/v5"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/securitymode"
+	"github.com/TheManticoreProject/Manticore/windows/credentials"
+)
+
+// SessionSetupKerberos authenticates a session with the server using Kerberos
+// over SPNEGO. Unlike the two-leg NTLM exchange, Kerberos is a single round: the
+// client sends a KRB_AP_REQ inside a SPNEGO NegTokenInit and the server replies
+// with STATUS_SUCCESS, optionally carrying a KRB_AP_REP (mutual authentication)
+// which we verify to capture the negotiated context key.
+//
+// kdcHost is the KDC (domain controller) address used to obtain the TGT and
+// service ticket. spn is the service principal name of the target server; when
+// empty it defaults to "cifs/<host>", the SMB service class.
+//
+// The GSS context key established here is used as the SMB signing key (for the
+// SMB 2.0.2/2.1 dialects the signing key is the session key itself). The
+// NegTokenInit request is not signed — the session is not yet established;
+// signing is activated once the server confirms the session.
+func (c *Client) SessionSetupKerberos(creds *credentials.Credentials, kdcHost, spn string) error {
+	if creds == nil {
+		return fmt.Errorf("session setup requires credentials but none were provided")
+	}
+	if !c.Transport.IsConnected() {
+		return fmt.Errorf("transport is not connected")
+	}
+	if kdcHost == "" {
+		return fmt.Errorf("kerberos session setup requires a KDC host")
+	}
+	if spn == "" {
+		spn = "cifs/" + c.Connection.Server.DNSComputerName
+	}
+	if spn == "cifs/" {
+		return fmt.Errorf("kerberos session setup requires a service principal name (or a known server name)")
+	}
+
+	// Build the native Kerberos client from the SMB credentials (realm = domain).
+	kc := kerberos.NewClient(creds.GetUsername(), creds.GetDomain(), kdcHost)
+	if nt := creds.GetNTHash(); nt != "" {
+		// Overpass-the-hash: obtain the TGT from the NT hash rather than a password.
+		if err := kc.WithNTHash(nt); err != nil {
+			return fmt.Errorf("kerberos: invalid NT hash: %w", err)
+		}
+	} else {
+		kc.WithPassword(creds.GetPassword())
+	}
+
+	mech := kerberos.NewSPNEGOMechanism(kc, spn)
+
+	// SMB2 always uses Unicode for its strings.
+	authCtx := spnego.NewAuthContext(
+		spnego.AuthTypeKerberos,
+		creds.Domain,
+		creds.Username,
+		creds.Password,
+		c.Workstation,
+		true,
+	)
+	// Wire the Kerberos provider into the SPNEGO context (dependency inversion:
+	// crypto/spnego stays free of any Kerberos dependency).
+	authCtx.Kerberos = mech
+
+	// Build the SPNEGO NegTokenInit carrying the KRB_AP_REQ.
+	negotiateToken, err := authCtx.CreateNegotiateToken(0, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create Kerberos negotiate token: %w", err)
+	}
+
+	// Single leg: send the AP-REQ; the server replies with the assigned SessionId
+	// and STATUS_SUCCESS, optionally carrying an AP-REP.
+	req := commands.NewSessionSetupRequest()
+	req.SecurityMode = securitymode.SMB2_NEGOTIATE_SIGNING_ENABLED
+	req.SecurityBuffer = negotiateToken
+
+	msg := c.newRequest(req)
+	msg.Header.SessionId = 0
+
+	resp, err := c.sendReceive(msg, "SessionSetup(kerberos)")
+	if err != nil {
+		return err
+	}
+
+	status := statusFromResponse(resp)
+	// STATUS_MORE_PROCESSING_REQUIRED can precede the AP-REP on some servers; both
+	// it and STATUS_SUCCESS carry the response token we need to verify.
+	if status != 0x00000000 && status != ntStatusMoreProcessingRequired {
+		return fmt.Errorf("kerberos session setup failed: %s", formatNTStatus(status))
+	}
+
+	sessionId := resp.Header.SessionId
+	setupResp, ok := resp.Command.(*commands.SessionSetupResponse)
+	if !ok {
+		return fmt.Errorf("unexpected SESSION_SETUP response command: %T", resp.Command)
+	}
+
+	// Verify the server's AP-REP (mutual authentication) when present and capture
+	// the GSS context key. For Kerberos this produces no follow-up token.
+	if len(setupResp.SecurityBuffer) > 0 {
+		follow, ferr := authCtx.CreateAuthenticateTokenFromChallengeToken(setupResp.SecurityBuffer)
+		if ferr != nil {
+			return fmt.Errorf("failed to verify Kerberos server response: %w", ferr)
+		}
+		if len(follow) > 0 {
+			// A well-behaved AD server completes Kerberos in one round; a follow-up
+			// token would indicate an unexpected multi-leg negotiation.
+			return fmt.Errorf("kerberos session setup: unexpected multi-leg SPNEGO continuation")
+		}
+	}
+
+	// The signing key derives from the established GSS context key (subkey if
+	// negotiated, else the service-ticket session key). Per MS-SMB2 3.2.5.3.1 the
+	// SMB2 Session.SessionKey is the first 16 bytes of the GSS-exported key,
+	// right-padded with zeros if shorter — Kerberos AES256 yields a 32-byte key,
+	// so it must be truncated (NTLM keys are already 16 bytes). For the 2.0.2
+	// dialect this 16-byte value is the HMAC-SHA256 signing key directly.
+	gssKey := authCtx.GetSessionKey()
+	if len(gssKey) == 0 {
+		gssKey = mech.SessionKey()
+	}
+	sessionKey := make([]byte, 16)
+	copy(sessionKey, gssKey)
+
+	serverMode := c.Connection.Server.SecurityMode
+	session := &Session{
+		Client:        c,
+		SessionId:     sessionId,
+		Credentials:   creds,
+		SessionKey:    sessionKey,
+		SigningKey:    sessionKey,
+		SigningActive: false,
+	}
+	c.Session = session
+
+	// If the server still requires another leg (unusual for AD Kerberos), send the
+	// final NegTokenResp confirming completion before the session is usable.
+	if status == ntStatusMoreProcessingRequired {
+		req2 := commands.NewSessionSetupRequest()
+		req2.SecurityMode = securitymode.SMB2_NEGOTIATE_SIGNING_ENABLED
+		req2.SecurityBuffer = []byte{}
+
+		msg2 := c.newRequest(req2)
+		msg2.Header.SessionId = sessionId
+
+		resp2, err := c.sendReceive(msg2, "SessionSetup(kerberos-final)")
+		if err != nil {
+			c.Session = nil
+			return err
+		}
+		if st := statusFromResponse(resp2); st != 0x00000000 {
+			c.Session = nil
+			return fmt.Errorf("kerberos session setup failed: %s", formatNTStatus(st))
+		}
+	}
+
+	// Session established: activate signing for subsequent requests when the server
+	// enables or requires it.
+	session.SigningActive = serverMode.IsSigningEnabled() || serverMode.IsSigningRequired()
+
+	if c.Connection.SessionTable == nil {
+		c.Connection.SessionTable = make(map[uint64]*Session)
+	}
+	c.Connection.SessionTable[sessionId] = session
+
+	return nil
+}


### PR DESCRIPTION
## Summary

Adds Kerberos as a first-class SPNEGO mechanism and consumes it from the SMB2 client, so SMB sessions can authenticate with Kerberos (password or overpass-the-hash) instead of only NTLM. Stacked on `kerberos-native` (#898).

The SPNEGO core stays free of any Kerberos dependency: `AuthContext` gains a `KerberosProvider` interface, and the concrete provider lives in `network/kerberos/v5` and is wired in by the consumer (SMB) — dependency inversion at the mechanism seam, the same pattern used for the LDAP GSSAPI bind.

## Changes

**crypto/spnego**
- `KerberosProvider` interface on `AuthContext` (`InitToken` / `AcceptResponseToken` / `SessionKey`).
- Filled the previously-stubbed Kerberos negotiate/challenge paths: `CreateNegotiateToken` builds a `NegTokenInit` advertising the Kerberos mech OID with the provider's `KRB_AP_REQ` as the mechToken; the challenge path verifies the server's `KRB_AP_REP` and captures the GSS context key.
- Added `CreateNegTokenInitKerberos`.

**network/kerberos/v5**
- `SPNEGOMechanism`: adapts the native client + GSS-API layer to `KerberosProvider` (acquires TGT+TGS, builds the AP-REQ with mutual auth and an initiator subkey, surfaces server `KRB-ERROR`s, exposes the negotiated key).

**network/smb/smb_v20/client**
- `SessionSetupKerberos`: single-leg SPNEGO Kerberos session setup — sends the AP-REQ, verifies the optional AP-REP, installs the session. Per MS-SMB2 §3.2.5.3.1 the SMB2 session key is the first 16 bytes of the GSS-exported key (Kerberos AES256 yields 32); for the 2.0.2 dialect that is the HMAC-SHA256 signing key directly.

## Validation

Live-tested against Windows Server 2016:

```
[+] SMB2 negotiated
[+] Kerberos SESSION_SETUP OK (SessionId=0x5c…, signing=true)
[+] TreeConnect IPC$ OK — Kerberos-authenticated SMB2 session works end-to-end
```

Unit tests added in `crypto/spnego/kerberos_test.go` (3 tests, all pass). `go build ./...` clean; `go test ./crypto/spnego/... ./network/kerberos/... ./network/smb/...` green.

## Not included

DCE/RPC Kerberos wiring is a follow-on: it requires a GSS-Kerberos `SecurityContext` (RFC 4121 Wrap/MIC in DCE style) and the 3-leg DCE-style bind, tracked separately.