### PR TITLE
Add native Kerberos authentication to the DCE/RPC client

### DIFF
--- a/crypto/spnego/authcontext.go
+++ b/crypto/spnego/authcontext.go
@@ -39,6 +39,26 @@ type AuthContext struct {
 	// wire; callers use it as the MAC key for SMB message signing. It is nil until
 	// authentication has produced a key (and for auth paths that do not derive one).
 	SessionKey []byte
+
+	// Kerberos supplies the GSS-API tokens when Type is AuthTypeKerberos. It is set
+	// by the consumer (SMB/DCE-RPC) so crypto/spnego needs no dependency on the
+	// Kerberos implementation (dependency inversion).
+	Kerberos KerberosProvider
+}
+
+// KerberosProvider produces and verifies the Kerberos GSS-API tokens exchanged
+// inside SPNEGO. A consumer backs it with the native Kerberos stack and assigns
+// it to AuthContext.Kerberos.
+type KerberosProvider interface {
+	// InitToken returns the initial GSS-API token (a KRB_AP_REQ) to carry in the
+	// SPNEGO NegTokenInit mechToken.
+	InitToken() ([]byte, error)
+	// AcceptResponseToken verifies the server's response token (a KRB_AP_REP for
+	// mutual authentication). An empty token is accepted as a no-op.
+	AcceptResponseToken(token []byte) error
+	// SessionKey returns the established context key used for message
+	// signing/sealing after the exchange completes.
+	SessionKey() []byte
 }
 
 // GetSessionKey returns the session key derived during authentication, or nil if

--- a/crypto/spnego/challenge.go
+++ b/crypto/spnego/challenge.go
@@ -145,6 +145,17 @@ func (ctx *AuthContext) processChallengeInnerTokenNTLM(innerToken []byte) ([]byt
 //   - []byte: The SPNEGO token containing the Kerberos authenticate message
 //   - error: An error if token processing fails
 func (ctx *AuthContext) processChallengeInnerTokenKerberos(innerToken []byte) ([]byte, error) {
-	// TODO: Implement kerberos authentication
-	return nil, errors.New("kerberos authentication is not yet implemented")
+	if ctx.Kerberos == nil {
+		return nil, errors.New("spnego: kerberos provider not configured on AuthContext")
+	}
+	// innerToken is the server's response token: a KRB_AP_REP for mutual
+	// authentication (empty if the server asserted none). Verifying it also lets
+	// the provider adopt any acceptor subkey.
+	if err := ctx.Kerberos.AcceptResponseToken(innerToken); err != nil {
+		return nil, fmt.Errorf("spnego: kerberos accept response: %w", err)
+	}
+	// The GSS context is established once the AP-REP is verified; capture the
+	// session key for message signing/sealing. Kerberos needs no further token.
+	ctx.SessionKey = ctx.Kerberos.SessionKey()
+	return nil, nil
 }

--- a/crypto/spnego/kerberos_test.go
+++ b/crypto/spnego/kerberos_test.go
@@ -1,0 +1,85 @@
+package spnego
+
+import (
+	"bytes"
+	"encoding/asn1"
+	"testing"
+)
+
+// stubKerberos is a KerberosProvider test double.
+type stubKerberos struct {
+	initToken  []byte
+	accepted   []byte
+	sessionKey []byte
+	acceptErr  error
+}
+
+func (s *stubKerberos) InitToken() ([]byte, error)         { return s.initToken, nil }
+func (s *stubKerberos) AcceptResponseToken(t []byte) error { s.accepted = t; return s.acceptErr }
+func (s *stubKerberos) SessionKey() []byte                 { return s.sessionKey }
+
+func TestKerberosNegotiateTokenUsesKerberosMech(t *testing.T) {
+	apReq := []byte("fake-gss-ap-req-token")
+	ctx := NewAuthContext(AuthTypeKerberos, "CORP.LOCAL", "alice", "", "WS", true)
+	ctx.Kerberos = &stubKerberos{initToken: apReq}
+
+	tok, err := ctx.CreateNegotiateToken(0, nil)
+	if err != nil {
+		t.Fatalf("CreateNegotiateToken: %v", err)
+	}
+
+	// The SPNEGO NegTokenInit must advertise the Kerberos mechanism OID and carry
+	// the provider's AP-REQ as the mechToken.
+	oidDER, _ := asn1.Marshal(KerberosOID)
+	if !bytes.Contains(tok, oidDER) {
+		t.Errorf("negotiate token does not advertise the Kerberos mech OID")
+	}
+	if !bytes.Contains(tok, apReq) {
+		t.Errorf("negotiate token does not carry the AP-REQ mechToken")
+	}
+}
+
+func TestKerberosNegotiateRequiresProvider(t *testing.T) {
+	ctx := NewAuthContext(AuthTypeKerberos, "R", "u", "", "WS", true)
+	if _, err := ctx.CreateNegotiateToken(0, nil); err == nil {
+		t.Error("expected error when no Kerberos provider is configured")
+	}
+}
+
+func TestKerberosChallengeVerifiesAPRepAndCapturesKey(t *testing.T) {
+	apRep := []byte("fake-ap-rep")
+	key := []byte("session-key-bytes-32-............")
+	stub := &stubKerberos{sessionKey: key}
+	ctx := NewAuthContext(AuthTypeKerberos, "R", "u", "", "WS", true)
+	ctx.Kerberos = stub
+
+	// Build a server NegTokenResp advertising Kerberos with the AP-REP.
+	resp := NegTokenResp{
+		NegState:      NegStateAcceptCompleted,
+		SupportedMech: KerberosOID,
+		ResponseToken: apRep,
+	}
+	respSeq, err := resp.Marshal()
+	if err != nil {
+		t.Fatalf("marshal NegTokenResp: %v", err)
+	}
+	// The server delivers the NegTokenResp inside a [1]-tagged SecurityBlob.
+	challengeToken, err := (&SecurityBlob{Data: respSeq}).Marshal()
+	if err != nil {
+		t.Fatalf("wrap SecurityBlob: %v", err)
+	}
+
+	out, err := ctx.CreateAuthenticateTokenFromChallengeToken(challengeToken)
+	if err != nil {
+		t.Fatalf("CreateAuthenticateTokenFromChallengeToken: %v", err)
+	}
+	if out != nil {
+		t.Errorf("Kerberos challenge should produce no follow-up token, got %d bytes", len(out))
+	}
+	if !bytes.Equal(stub.accepted, apRep) {
+		t.Errorf("provider did not receive the AP-REP response token")
+	}
+	if !bytes.Equal(ctx.GetSessionKey(), key) {
+		t.Errorf("session key not captured from the Kerberos provider")
+	}
+}

--- a/crypto/spnego/negotiate.go
+++ b/crypto/spnego/negotiate.go
@@ -46,7 +46,13 @@ func (ctx *AuthContext) processNegotiateInnerTokenNTLM(negotiateFlags flags.Nego
 	return CreateNegTokenInit(ntlmNegotiateBytes)
 }
 
-func (ctx *AuthContext) processNegotiateInnerTokenKerberos(negotiateFlags flags.NegotiateFlags, version *version.Version) ([]byte, error) {
-	// TODO: Implement kerberos authentication
-	return nil, errors.New("kerberos authentication is not yet implemented")
+func (ctx *AuthContext) processNegotiateInnerTokenKerberos(_ flags.NegotiateFlags, _ *version.Version) ([]byte, error) {
+	if ctx.Kerberos == nil {
+		return nil, errors.New("spnego: kerberos provider not configured on AuthContext")
+	}
+	mechToken, err := ctx.Kerberos.InitToken()
+	if err != nil {
+		return nil, fmt.Errorf("spnego: kerberos init token: %w", err)
+	}
+	return CreateNegTokenInitKerberos(mechToken)
 }

--- a/crypto/spnego/negtokeninit.go
+++ b/crypto/spnego/negtokeninit.go
@@ -29,6 +29,17 @@ func CreateNegTokenInit(ntlmToken []byte) ([]byte, error) {
 	return init.Marshal()
 }
 
+// CreateNegTokenInitKerberos creates a SPNEGO NegTokenInit advertising the
+// Kerberos mechanism and carrying the given Kerberos GSS-API token (a
+// KRB_AP_REQ) as the mechToken.
+func CreateNegTokenInitKerberos(kerberosToken []byte) ([]byte, error) {
+	init := NegTokenInit{
+		MechTypes: []asn1.ObjectIdentifier{KerberosOID},
+		MechToken: kerberosToken,
+	}
+	return init.Marshal()
+}
+
 // NewNegTokenInit creates a new NegTokenInit with the specified parameters
 // Parameters:
 //   - mechTypes: The mechanism type identifiers to include

--- a/crypto/spnego/oid.go
+++ b/crypto/spnego/oid.go
@@ -26,6 +26,11 @@ var (
 	// iso.org.dod.internet.private.enterprise.Microsoft.security.mechanisms.Kerberos
 	// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-spng/211417c4-11ef-46c0-a8fb-f178a51c2088
 	KerberosOID = asn1.ObjectIdentifier{1, 2, 840, 113554, 1, 2, 2}
+
+	// MSKerberosOID: 1.2.840.48018.1.2.2 — Microsoft's legacy "MS KRB5" mechanism
+	// OID. Windows advertises this in the SPNEGO mechTypes for Kerberos, and it is
+	// what Windows RPC clients send, so it is used for the RPC Negotiate bind.
+	MSKerberosOID = asn1.ObjectIdentifier{1, 2, 840, 48018, 1, 2, 2}
 )
 
 // OIDtoString converts an OID to a human-readable string representation

--- a/network/dcerpc/v5/client/auth.go
+++ b/network/dcerpc/v5/client/auth.go
@@ -161,30 +161,44 @@ func (c *Client) buildAuthenticate(chal *challenge.ChallengeMessage) (*authentic
 // For NTLM it parses the server's CHALLENGE from the bind_ack's auth_value, sends an auth3
 // carrying the AUTHENTICATE token (to which the server sends no reply), and builds the
 // per-message security context from the derived session key.
-func (c *Client) completeAuth(bindAckFrag []byte) error {
+//
+// It returns an optional continuation token: under Kerberos GSS_C_DCE_STYLE the
+// handshake has a third leg (the initiator's AP-REP), which the caller sends in
+// an alter_context PDU. NTLM and single-leg providers return a nil continuation.
+func (c *Client) completeAuth(bindAckFrag []byte) ([]byte, error) {
 	if c.authType != pdu.AuthTypeNTLMSSP {
-		return nil
+		// A single-leg provider whose context needs the bind_ack's auth_value to
+		// finish establishing (Kerberos mutual auth: verify the KRB_AP_REP and adopt
+		// any acceptor subkey). Providers without this need (Netlogon) are unchanged.
+		if bc, ok := c.sec.(bindCompleter); ok {
+			_, authValue, err := pdu.ExtractAuthVerifier(bindAckFrag)
+			if err != nil {
+				return nil, fmt.Errorf("read bind_ack auth verifier: %w", err)
+			}
+			return bc.CompleteBind(authValue)
+		}
+		return nil, nil
 	}
 	_, challengeBytes, err := pdu.ExtractAuthVerifier(bindAckFrag)
 	if err != nil {
-		return fmt.Errorf("read challenge: %w", err)
+		return nil, fmt.Errorf("read challenge: %w", err)
 	}
 	if len(challengeBytes) == 0 {
-		return fmt.Errorf("server returned no NTLM challenge in bind_ack")
+		return nil, fmt.Errorf("server returned no NTLM challenge in bind_ack")
 	}
 
 	var chal challenge.ChallengeMessage
 	if _, err := chal.Unmarshal(challengeBytes); err != nil {
-		return fmt.Errorf("parse challenge: %w", err)
+		return nil, fmt.Errorf("parse challenge: %w", err)
 	}
 
 	auth, err := c.buildAuthenticate(&chal)
 	if err != nil {
-		return fmt.Errorf("build authenticate: %w", err)
+		return nil, fmt.Errorf("build authenticate: %w", err)
 	}
 	authBytes, err := auth.Marshal()
 	if err != nil {
-		return fmt.Errorf("marshal authenticate: %w", err)
+		return nil, fmt.Errorf("marshal authenticate: %w", err)
 	}
 
 	a3 := &pdu.Auth3{
@@ -194,22 +208,72 @@ func (c *Client) completeAuth(bindAckFrag []byte) error {
 	a3.Header = pdu.NewHeader(pdu.PacketTypeAuth3, pdu.PFCFirstFrag|pdu.PFCLastFrag, c.callID)
 	raw, err := a3.Marshal()
 	if err != nil {
-		return fmt.Errorf("marshal auth3: %w", err)
+		return nil, fmt.Errorf("marshal auth3: %w", err)
 	}
 	if err := c.transport.Send(raw); err != nil {
-		return fmt.Errorf("send auth3: %w", err)
+		return nil, fmt.Errorf("send auth3: %w", err)
 	}
 
 	if len(auth.SessionKey) == 0 {
-		return fmt.Errorf("no session key derived (NTLMv1 is not supported for RPC auth)")
+		return nil, fmt.Errorf("no session key derived (NTLMv1 is not supported for RPC auth)")
 	}
 	sec, err := security.NewContext(auth.SessionKey, auth.NegotiateFlags)
 	if err != nil {
-		return fmt.Errorf("init security context: %w", err)
+		return nil, fmt.Errorf("init security context: %w", err)
 	}
 	c.sec = &ntlmSecurityContext{ctx: sec}
 	c.sessionKey = append([]byte(nil), auth.SessionKey...)
-	return nil
+	return nil, nil
+}
+
+// sendAuthContinuation sends the DCE-style third-leg continuation token (the
+// initiator's KRB_AP_REP, wrapped in a SPNEGO NegTokenResp) in an alter_context
+// PDU carrying the same presentation contexts, and consumes the
+// alter_context_response that completes context establishment. Windows negotiates
+// the Kerberos DCE-style third leg via alter_context (which the server answers),
+// not auth3.
+func (c *Client) sendAuthContinuation(contexts []pdu.ContextElement, authValue []byte) error {
+	alter := &pdu.Bind{
+		MaxXmitFrag:  c.transport.MaxXmitFrag(),
+		MaxRecvFrag:  c.transport.MaxRecvFrag(),
+		AssocGroupID: 0,
+		ContextList:  contexts,
+		SecTrailer:   pdu.SecTrailer{AuthType: c.authType, AuthLevel: c.authLevel, AuthContextID: c.authContextID},
+		AuthValue:    authValue,
+	}
+	alter.Header = pdu.NewHeader(pdu.PacketTypeAlterContext, pdu.PFCFirstFrag|pdu.PFCLastFrag, c.callID)
+	raw, err := alter.Marshal()
+	if err != nil {
+		return fmt.Errorf("marshal alter_context: %w", err)
+	}
+	// Bind.Marshal forces PTYPE=bind; an alter_context PDU is wire-identical to a
+	// bind but with PTYPE=alter_context (offset 2 of the common header).
+	if len(raw) > 2 {
+		raw[2] = byte(pdu.PacketTypeAlterContext)
+	}
+	if err := c.transport.Send(raw); err != nil {
+		return fmt.Errorf("send alter_context: %w", err)
+	}
+	respFrag, err := c.readFragment(&fragmentReader{t: c.transport})
+	if err != nil {
+		return fmt.Errorf("recv alter_context_response: %w", err)
+	}
+	hdr, err := pdu.PeekHeader(respFrag)
+	if err != nil {
+		return fmt.Errorf("alter_context_response: %w", err)
+	}
+	switch hdr.PacketType {
+	case pdu.PacketTypeAlterContextResp:
+		return nil
+	case pdu.PacketTypeBindNak:
+		var nak pdu.BindNak
+		if _, err := nak.Unmarshal(respFrag); err != nil {
+			return fmt.Errorf("parse bind_nak: %w", err)
+		}
+		return fmt.Errorf("alter_context rejected: reject_reason=%d", nak.RejectReason)
+	default:
+		return fmt.Errorf("unexpected alter_context response PDU type %s", hdr.PacketType)
+	}
 }
 
 // marshalProtectedRequest serializes a request PDU with a per-PDU auth verifier. The stub

--- a/network/dcerpc/v5/client/auth_kerberos.go
+++ b/network/dcerpc/v5/client/auth_kerberos.go
@@ -1,0 +1,227 @@
+package client
+
+import (
+	"crypto/rand"
+	"encoding/asn1"
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/crypto/spnego"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/pdu"
+	kerberos "github.com/TheManticoreProject/Manticore/network/kerberos/v5"
+	kerbcrypto "github.com/TheManticoreProject/Manticore/network/kerberos/v5/crypto"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/gssapi"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/messages"
+)
+
+// SetAuthKerberos configures an authenticated bind using native Kerberos. It
+// acquires a TGT (if the client does not already hold one) and a service ticket
+// for spn, builds the KRB_AP_REQ carried in the bind's auth verifier, and
+// installs a per-message security context. Mutual authentication is always
+// requested so the acceptor's KRB_AP_REP can be verified.
+//
+// The auth level selects both the RPC security provider and the per-PDU
+// protection:
+//
+//   - CONNECT authenticates the bind only, as raw Kerberos (auth_type 0x10) with
+//     a GSS-wrapped AP-REQ and a single mutual-auth round.
+//   - PKT / PKT_INTEGRITY protect each PDU with a GSS MIC. Windows requires these
+//     to be negotiated through SPNEGO (auth_type 0x09, RPC_C_AUTHN_GSS_NEGOTIATE)
+//     with GSS_C_DCE_STYLE: a three-leg handshake (bind AP-REQ, bind_ack AP-REP,
+//     alter_context with the initiator's own AP-REP) establishes the context, and
+//     an RC4-HMAC service ticket is requested (the RFC 4757 per-message tokens
+//     Windows expects here).
+//   - PKT_PRIVACY (sealing) additionally needs a GSS Wrap-IOV encrypt and is not
+//     yet supported.
+//
+// Call before Bind.
+func (c *Client) SetAuthKerberos(authLevel uint8, kc *kerberos.KerberosClient, spn string) error {
+	if kc == nil {
+		return fmt.Errorf("dcerpc auth: nil kerberos client")
+	}
+	if spn == "" {
+		return fmt.Errorf("dcerpc auth: kerberos requires a service principal name")
+	}
+	if authLevel == pdu.AuthLevelCall {
+		authLevel = pdu.AuthLevelPkt
+	}
+	switch authLevel {
+	case pdu.AuthLevelConnect, pdu.AuthLevelPkt, pdu.AuthLevelPktIntegrity:
+	case pdu.AuthLevelPktPrivacy:
+		return fmt.Errorf("dcerpc auth: kerberos PKT_PRIVACY (sealing) is not yet supported; use PKT_INTEGRITY")
+	default:
+		return fmt.Errorf("dcerpc auth: unsupported auth_level %d", authLevel)
+	}
+	perMessage := authLevel >= pdu.AuthLevelPkt
+
+	if !kc.HasTGT() {
+		if err := kc.GetTGT(); err != nil {
+			return fmt.Errorf("dcerpc auth: kerberos GetTGT: %w", err)
+		}
+	}
+	if perMessage {
+		// Windows RPC's DCE-style per-message protection interoperates with RC4 on
+		// this class of server; request an RC4 service ticket.
+		kc.PreferRC4ServiceTicket()
+	}
+	ticket, ticketRaw, key, err := kc.GetTGS(spn, true)
+	if err != nil {
+		return fmt.Errorf("dcerpc auth: kerberos GetTGS %q: %w", spn, err)
+	}
+
+	// Windows requires GSS_C_DCE_STYLE for per-PDU protection (the three-leg
+	// handshake). Connect-level authentication does not use it.
+	flags := uint32(gssapi.GSSMutualFlag | gssapi.GSSReplayFlag | gssapi.GSSSequenceFlag | gssapi.GSSConfFlag | gssapi.GSSIntegFlag)
+	if perMessage {
+		flags |= gssapi.GSSDCEStyleFlag
+	}
+	initOpts := gssapi.InitOptions{
+		TicketRaw:    ticketRaw,
+		SessionKey:   key,
+		SessionEType: ticket.EncPart.EType,
+		ClientName:   messages.PrincipalName{NameType: messages.NameTypePrincipal, NameString: []string{kc.Username()}},
+		ClientRealm:  kc.Realm(),
+		Flags:        flags,
+		Mutual:       true,
+		// DCE/RPC seeds the acceptor's per-message receive sequence from the
+		// authenticator sequence number and starts its per-PDU counter at 0.
+		ZeroSeqNumber: perMessage,
+	}
+	if !perMessage {
+		// Connect level asserts an initiator subkey (as generic Windows GSS clients
+		// do). The DCE-style per-message path omits it so the acceptor chooses the
+		// subkey, matching the Windows RPC client.
+		subKey := make([]byte, kerbcrypto.KeyLen(ticket.EncPart.EType))
+		if _, err := rand.Read(subKey); err != nil {
+			return err
+		}
+		initOpts.SubKey = subKey
+		initOpts.SubKeyEType = ticket.EncPart.EType
+	}
+	apReq, ctx, err := gssapi.InitSecContext(initOpts)
+	if err != nil {
+		return fmt.Errorf("dcerpc auth: kerberos InitSecContext: %w", err)
+	}
+
+	sec := &kerberosSecurityContext{ctx: ctx, spnego: perMessage}
+	c.authLevel = authLevel
+	c.sec = sec
+	// A non-zero auth_context_id identifies the security context across the bind,
+	// alter_context, and request PDUs (Windows correlates the per-PDU verifier to
+	// the established context by this id; a zero id is not honored).
+	c.authContextID = 79231
+	if perMessage {
+		// RPC_C_AUTHN_GSS_NEGOTIATE: the bind carries a SPNEGO NegTokenInit that
+		// advertises the (MS) Kerberos mechanism and wraps the AP-REQ as its
+		// mechToken.
+		c.authType = pdu.AuthTypeGSSNegotiate
+		bindToken, err := (&spnego.NegTokenInit{
+			MechTypes: []asn1.ObjectIdentifier{spnego.MSKerberosOID},
+			MechToken: apReq,
+		}).Marshal()
+		if err != nil {
+			return fmt.Errorf("dcerpc auth: marshal SPNEGO NegTokenInit: %w", err)
+		}
+		c.bindToken = bindToken
+	} else {
+		// RPC_C_AUTHN_GSS_KERBEROS: the bind carries the bare GSS Kerberos token.
+		c.authType = pdu.AuthTypeGSSKerberos
+		c.bindToken = apReq
+	}
+	return nil
+}
+
+// kerberosSecurityContext adapts a GSS-API SecContext to the RPC SecurityContext
+// interface. The per-PDU verifier is a GSS MIC token (RFC 4121 §4.2.6.1) over the
+// request/response stub; the stub itself travels in the clear (integrity only).
+// It also implements bindCompleter to complete the mutual-auth handshake.
+type kerberosSecurityContext struct {
+	ctx *gssapi.SecContext
+	// spnego is set for the per-message SPNEGO/DCE-style path: the acceptor's
+	// tokens are SPNEGO NegTokenResp envelopes carrying bare Kerberos AP-REP
+	// messages, and a third leg (the initiator's own AP-REP) is required.
+	spnego bool
+}
+
+// CompleteBind completes the mutual-authentication handshake from the bind_ack's
+// auth_value and returns an optional continuation token for the third leg. For
+// the SPNEGO/DCE-style path it unwraps the NegTokenResp, verifies the acceptor's
+// bare AP-REP, and returns its own AP-REP wrapped in a NegTokenResp (sent in an
+// alter_context). For connect-level raw Kerberos it verifies the GSS-wrapped
+// AP-REP and returns no continuation.
+func (k *kerberosSecurityContext) CompleteBind(bindAckAuthValue []byte) ([]byte, error) {
+	if len(bindAckAuthValue) == 0 {
+		return nil, nil
+	}
+	if !k.spnego {
+		return nil, k.ctx.AcceptAPRep(bindAckAuthValue)
+	}
+
+	// The acceptor's NegTokenResp is carried in a [1] context tag; unwrap it to
+	// the bare SEQUENCE the parser expects.
+	var wrapped asn1.RawValue
+	if _, err := asn1.Unmarshal(bindAckAuthValue, &wrapped); err != nil {
+		return nil, fmt.Errorf("dcerpc auth: parse SPNEGO response wrapper: %w", err)
+	}
+	respBytes := bindAckAuthValue
+	if wrapped.Class == asn1.ClassContextSpecific && wrapped.Tag == 1 {
+		respBytes = wrapped.Bytes
+	}
+	var resp spnego.NegTokenResp
+	if _, err := resp.Unmarshal(respBytes); err != nil {
+		return nil, fmt.Errorf("dcerpc auth: parse SPNEGO NegTokenResp: %w", err)
+	}
+	if resp.NegState == spnego.NegStateReject {
+		return nil, fmt.Errorf("dcerpc auth: SPNEGO negotiation rejected")
+	}
+	// resp.ResponseToken is a bare KRB_AP_REP (SPNEGO carries the raw mechanism
+	// token in continuation exchanges).
+	if err := k.ctx.AcceptAPRepRaw(resp.ResponseToken); err != nil {
+		return nil, err
+	}
+	apRep, err := k.ctx.MakeAPRep()
+	if err != nil {
+		return nil, err
+	}
+	// Per-PDU GSS tokens use a zero-based sequence counter after the DCE-style
+	// handshake completes.
+	k.ctx.ResetSendSeq(0)
+	// The third leg is the initiator's AP-REP in a NegTokenResp carrying only the
+	// responseToken (no negState, no mechListMIC), wrapped in the [1] tag.
+	legSeq, err := (&spnego.NegTokenResp{ResponseToken: apRep, SuppressNegState: true}).Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("dcerpc auth: marshal SPNEGO leg-3: %w", err)
+	}
+	return asn1.Marshal(asn1.RawValue{Class: asn1.ClassContextSpecific, Tag: 1, IsCompound: true, Bytes: legSeq})
+}
+
+// AuthValueLen is the GSS MIC token length: a 16-byte token header plus the
+// etype's checksum. It is independent of the seal flag (sealing is unsupported).
+func (k *kerberosSecurityContext) AuthValueLen(bool) int {
+	return k.ctx.MICTokenLen()
+}
+
+// ProtectRequest signs the request stub with a GSS MIC token and returns it as
+// the auth_value. Per MS-RPCE the MIC covers only the stub (pduData), not the
+// PDU header or sec_trailer, when PFC_SUPPORT_HEADER_SIGN is not negotiated.
+func (k *kerberosSecurityContext) ProtectRequest(signedRegion, stub []byte, seal bool) ([]byte, []byte, error) {
+	if seal {
+		return nil, nil, fmt.Errorf("dcerpc auth: kerberos sealing is not supported")
+	}
+	mic, err := k.ctx.MakeMIC(stub)
+	if err != nil {
+		return nil, nil, err
+	}
+	return stub, mic, nil
+}
+
+// UnprotectResponse verifies the server's GSS MIC over the response stub and
+// returns the stub unchanged (integrity only).
+func (k *kerberosSecurityContext) UnprotectResponse(signedRegion, stub, authValue []byte, seal bool) ([]byte, error) {
+	if seal {
+		return nil, fmt.Errorf("dcerpc auth: kerberos sealing is not supported")
+	}
+	if err := k.ctx.VerifyMIC(stub, authValue); err != nil {
+		return nil, err
+	}
+	return stub, nil
+}

--- a/network/dcerpc/v5/client/client.go
+++ b/network/dcerpc/v5/client/client.go
@@ -182,8 +182,16 @@ func (c *Client) Bind(abstractSyntax syntax.SyntaxID) error {
 		c.negotiatedSyntax = negotiated
 		c.sendFragMax = negotiateSendMax(c.transport.MaxXmitFrag(), ack.MaxXmitFrag, ack.MaxRecvFrag)
 		if c.authConfigured() {
-			if err := c.completeAuth(respFrag); err != nil {
-				return fmt.Errorf("dcerpc bind: ntlm auth: %w", err)
+			continuation, err := c.completeAuth(respFrag)
+			if err != nil {
+				return fmt.Errorf("dcerpc bind: auth: %w", err)
+			}
+			// Kerberos GSS_C_DCE_STYLE requires a third leg: the initiator's AP-REP,
+			// carried in an alter_context PDU, before the context is usable.
+			if len(continuation) > 0 {
+				if err := c.sendAuthContinuation(bind.ContextList, continuation); err != nil {
+					return fmt.Errorf("dcerpc bind: auth continuation: %w", err)
+				}
 			}
 		}
 		c.bound = true

--- a/network/dcerpc/v5/client/secctx.go
+++ b/network/dcerpc/v5/client/secctx.go
@@ -33,6 +33,17 @@ type SecurityContext interface {
 	UnprotectResponse(signedRegion, stub, authValue []byte, seal bool) (plainStub []byte, err error)
 }
 
+// bindCompleter is an optional capability of a SecurityContext whose establishment
+// needs the bind_ack's auth_value — Kerberos mutual authentication verifies the
+// KRB_AP_REP returned in the bind_ack. It returns an optional continuation token:
+// under GSS_C_DCE_STYLE the handshake has a third leg (the initiator's own
+// AP-REP), which the client sends in an alter_context PDU. A nil continuation
+// means the context is fully established after the bind_ack. Providers that
+// establish their context entirely up front (Netlogon) do not implement it.
+type bindCompleter interface {
+	CompleteBind(bindAckAuthValue []byte) (continuation []byte, err error)
+}
+
 // ntlmSecurityContext adapts an NTLM *security.Context to SecurityContext. NTLM's token is a
 // fixed 16-byte MESSAGE_SIGNATURE and its signature covers the whole PDU, so both directions
 // operate over signedRegion; only the stub is sealed for PKT_PRIVACY ([MS-RPCE] 3.3, NTLM2).

--- a/network/kerberos/v5/client.go
+++ b/network/kerberos/v5/client.go
@@ -39,6 +39,31 @@ type KerberosClient struct {
 	sessionEType int
 	tgtEnc       messages.EncASRepPart // decrypted AS-REP enc-part: times, flags, sname
 	hasTGT       bool
+
+	// stETypes overrides the etype list requested in the TGS-REQ (the service
+	// ticket's session-key etype). nil requests AES256, AES128, then RC4.
+	stETypes []int
+}
+
+// PreferRC4ServiceTicket makes GetTGS request an RC4-HMAC service ticket (RC4
+// session key). Windows RPC's DCE-style Kerberos per-message protection is only
+// interoperable with RC4 on some servers, so the DCE/RPC client forces it.
+func (c *KerberosClient) PreferRC4ServiceTicket() *KerberosClient {
+	c.stETypes = []int{messages.ETypeRC4HMAC}
+	return c
+}
+
+// serviceTicketETypes returns the TGS-REQ etype list: the override if set,
+// otherwise the default strongest-first list.
+func (c *KerberosClient) serviceTicketETypes() []int {
+	if len(c.stETypes) > 0 {
+		return c.stETypes
+	}
+	return []int{
+		messages.ETypeAES256CTSHMACSHA196,
+		messages.ETypeAES128CTSHMACSHA196,
+		messages.ETypeRC4HMAC,
+	}
 }
 
 // NewClient creates a new KerberosClient for the given username, realm and KDC host.
@@ -182,11 +207,7 @@ func (c *KerberosClient) GetTGS(spn string, includePAC bool) (messages.Ticket, [
 			SName:      sname,
 			Till:       time.Now().UTC().Add(24 * time.Hour),
 			Nonce:      nonce,
-			EType: []int{
-				messages.ETypeAES256CTSHMACSHA196,
-				messages.ETypeAES128CTSHMACSHA196,
-				messages.ETypeRC4HMAC,
-			},
+			EType:      c.serviceTicketETypes(),
 		},
 	}
 
@@ -257,6 +278,9 @@ func (c *KerberosClient) Realm() string { return c.realm }
 
 // KDCHost returns the KDC host configured for this client.
 func (c *KerberosClient) KDCHost() string { return c.kdcHost }
+
+// HasTGT reports whether a Ticket Granting Ticket has been acquired (via GetTGT).
+func (c *KerberosClient) HasTGT() bool { return c.hasTGT }
 
 // ── internal helpers ──────────────────────────────────────────────────────────
 

--- a/network/kerberos/v5/credcache/ccache/ccache.go
+++ b/network/kerberos/v5/credcache/ccache/ccache.go
@@ -1,6 +1,6 @@
 // Package ccache reads and writes the MIT Kerberos FILE credential cache
 // (KRB5CCNAME) in format version 4, the interchange format used by Linux
-// Kerberos tooling and Impacket. Version 4 is big-endian throughout and is
+// Kerberos tooling. Version 4 is big-endian throughout and is
 // documented at
 // https://web.mit.edu/kerberos/krb5-latest/doc/formats/ccache_file_format.html.
 //

--- a/network/kerberos/v5/credcache/kirbi/kirbi.go
+++ b/network/kerberos/v5/credcache/kirbi/kirbi.go
@@ -1,7 +1,7 @@
 // Package kirbi reads and writes ".kirbi" credential files. A .kirbi file is a
 // DER-encoded Kerberos KRB-CRED message (RFC 4120 Section 5.8.1) carrying one
-// or more tickets — the interchange format used by Rubeus and (via -k) Impacket
-// for pass-the-ticket. By convention the EncKrbCredPart is stored unencrypted
+// or more tickets — the interchange format used by Rubeus and Windows Kerberos
+// tooling for pass-the-ticket. By convention the EncKrbCredPart is stored unencrypted
 // with etype 0, so the session key and ticket metadata are in the clear.
 package kirbi
 

--- a/network/kerberos/v5/export.go
+++ b/network/kerberos/v5/export.go
@@ -29,7 +29,7 @@ func (c *KerberosClient) tgtCredInfo() messages.KrbCredInfo {
 }
 
 // ExportTGTKirbi returns the current TGT as .kirbi (DER KRB-CRED) bytes, suitable
-// for pass-the-ticket with Rubeus/Impacket. GetTGT must have succeeded first.
+// for pass-the-ticket with Rubeus. GetTGT must have succeeded first.
 func (c *KerberosClient) ExportTGTKirbi() ([]byte, error) {
 	if !c.hasTGT {
 		return nil, fmt.Errorf("kerberos: no TGT: call GetTGT first")

--- a/network/kerberos/v5/gssapi/gssapi.go
+++ b/network/kerberos/v5/gssapi/gssapi.go
@@ -43,6 +43,11 @@ const (
 	GSSSequenceFlag = 8
 	GSSConfFlag     = 16
 	GSSIntegFlag    = 32
+	// GSSDCEStyleFlag (GSS_C_DCE_STYLE) selects the DCE RPC three-leg mutual
+	// authentication style. Windows RPC requires it for per-message protection
+	// (PKT_INTEGRITY / PKT_PRIVACY); with it the acceptor's AP-REP is followed by
+	// a third leg carrying the initiator's own AP-REP.
+	GSSDCEStyleFlag = 0x1000
 )
 
 // ChecksumTypeGSSAPI is the Kerberos checksum type (0x8003) used for the GSS-API
@@ -121,6 +126,9 @@ type SecContext struct {
 	// acceptorSubkey records that the base key is an acceptor-asserted subkey,
 	// so per-message tokens must set the AcceptorSubkey flag.
 	acceptorSubkey bool
+	// acceptorSeq is the sequence number the acceptor placed in its AP-REP. The
+	// DCE-style third-leg AP-REP must echo it (krb5_rd_rep_dce checks it).
+	acceptorSeq int
 }
 
 // InitOptions configures InitSecContext.
@@ -144,6 +152,10 @@ type InitOptions struct {
 	// if set, SubKeyEType must be set too.
 	SubKey      []byte
 	SubKeyEType int
+	// ZeroSeqNumber sets the authenticator sequence number to 0 instead of a
+	// random value. DCE/RPC requires it (the acceptor's per-message receive
+	// sequence is seeded from it, and the per-PDU counter starts at 0).
+	ZeroSeqNumber bool
 }
 
 // InitSecContext builds the initiator's KRB_AP_REQ GSS token from a service
@@ -163,11 +175,17 @@ func InitSecContext(opts InitOptions) ([]byte, *SecContext, error) {
 	now := time.Now().UTC()
 	cusec := now.Nanosecond() / 1000
 
-	var seqBuf [4]byte
-	if _, err := rand.Read(seqBuf[:]); err != nil {
-		return nil, nil, err
+	// The initiator's authenticator sequence number seeds the acceptor's expected
+	// per-message receive sequence. DCE/RPC (which starts its per-PDU counter at 0)
+	// requires it to be 0; other callers use a random value.
+	seqNum := 0
+	if !opts.ZeroSeqNumber {
+		var seqBuf [4]byte
+		if _, err := rand.Read(seqBuf[:]); err != nil {
+			return nil, nil, err
+		}
+		seqNum = int(binary.BigEndian.Uint32(seqBuf[:]) & 0x7fffffff)
 	}
-	seqNum := int(binary.BigEndian.Uint32(seqBuf[:]) & 0x7fffffff)
 
 	cksum := &messages.Checksum{
 		CKSumType: ChecksumTypeGSSAPI,
@@ -243,7 +261,20 @@ func (ctx *SecContext) AcceptAPRep(token []byte) error {
 	if tokID != TokIDAPRep {
 		return fmt.Errorf("gssapi: expected AP-REP token (02 00), got %02x %02x", tokID[0], tokID[1])
 	}
+	return ctx.acceptAPRepMessage(krbMsg)
+}
 
+// AcceptAPRepRaw verifies a bare KRB_AP_REP (APPLICATION[15]) that is not wrapped
+// in a GSS InitialContextToken. DCE RPC (GSS_C_DCE_STYLE) carries the acceptor's
+// AP-REP this way, since the GSS framing OID appears only on the first token.
+func (ctx *SecContext) AcceptAPRepRaw(apRep []byte) error {
+	return ctx.acceptAPRepMessage(apRep)
+}
+
+// acceptAPRepMessage decrypts and verifies a KRB_AP_REP message body: it checks
+// the echoed ctime/cusec against the initiator's authenticator (mutual
+// authentication) and adopts an acceptor subkey into the context if present.
+func (ctx *SecContext) acceptAPRepMessage(krbMsg []byte) error {
 	var apRep messages.APRep
 	if _, err := apRep.Unmarshal(krbMsg); err != nil {
 		return fmt.Errorf("gssapi: parse AP-REP: %w", err)
@@ -264,5 +295,37 @@ func (ctx *SecContext) AcceptAPRep(token []byte) error {
 		ctx.SubKeyEType = enc.SubKey.KeyType
 		ctx.acceptorSubkey = true
 	}
+	ctx.acceptorSeq = enc.SeqNumber
 	return nil
+}
+
+// MakeAPRep builds the initiator's own KRB_AP_REP as a bare APPLICATION[15]
+// message (no GSS wrapper), for the third leg of the DCE-style mutual-auth
+// handshake (GSS_C_DCE_STYLE). Following the Windows/MIT behaviour, it uses a
+// fresh timestamp (not the echoed authenticator time), carries the sequence
+// number the acceptor sent in its AP-REP, has no subkey, and is encrypted with
+// the ticket session key (key usage 12).
+func (ctx *SecContext) MakeAPRep() ([]byte, error) {
+	now := time.Now().UTC()
+	enc := messages.EncAPRepPart{
+		CTime: now,
+		CUSec: now.Nanosecond() / 1000,
+		// The DCE-style acceptor validates that the third-leg AP-REP echoes the
+		// sequence number it sent in its own AP-REP (krb5_rd_rep_dce).
+		SeqNumber: ctx.acceptorSeq,
+	}
+	encBytes, err := enc.Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("gssapi: marshal EncAPRepPart: %w", err)
+	}
+	cipher, err := kerbcrypto.Encrypt(ctx.SessionEType, ctx.SessionKey, kerbcrypto.KeyUsageAPRepEncPart, encBytes)
+	if err != nil {
+		return nil, fmt.Errorf("gssapi: encrypt EncAPRepPart: %w", err)
+	}
+	apRep := messages.APRep{
+		PVNO:    messages.KerberosV5,
+		MsgType: messages.MsgTypeAPRep,
+		EncPart: messages.EncryptedData{EType: ctx.SessionEType, Cipher: cipher},
+	}
+	return apRep.Marshal()
 }

--- a/network/kerberos/v5/gssapi/permessage.go
+++ b/network/kerberos/v5/gssapi/permessage.go
@@ -60,6 +60,11 @@ func (ctx *SecContext) nextSendSeq() uint64 {
 	return s
 }
 
+// ResetSendSeq overrides the running per-message send sequence. DCE/RPC uses a
+// zero-based per-PDU counter for its GSS tokens rather than the AP-REQ
+// authenticator sequence.
+func (ctx *SecContext) ResetSendSeq(seq uint64) { ctx.sendSeq = seq }
+
 // micLen returns the checksum length appended to MIC / integrity-only Wrap
 // tokens for an etype.
 func micLen(etype int) int {
@@ -126,10 +131,25 @@ func wrapHeader(flags byte, seq uint64) []byte {
 	return h
 }
 
-// MakeMIC produces a MIC token over data as the context initiator (RFC 4121
-// §4.2.6.1): checksum(data | header) keyed with the initiator-sign usage.
+// MICTokenLen returns the length of a MIC token this context emits: for RC4-HMAC
+// the fixed RFC 4757 token length, otherwise the 16-byte CFX header plus the base
+// key's etype checksum.
+func (ctx *SecContext) MICTokenLen() int {
+	_, etype := ctx.baseKey()
+	if etype == rc4HMACEType {
+		return rc4MICTokenLen
+	}
+	return 16 + micLen(etype)
+}
+
+// MakeMIC produces a MIC token over data as the context initiator. For RC4-HMAC
+// it is the RFC 4757 §7.3 token; otherwise the RFC 4121 §4.2.6.1 CFX token
+// (checksum(data | header) keyed with the initiator-sign usage).
 func (ctx *SecContext) MakeMIC(data []byte) ([]byte, error) {
 	key, etype := ctx.baseKey()
+	if etype == rc4HMACEType {
+		return ctx.makeMICRC4(data, ctx.nextSendSeq()), nil
+	}
 	ct, ok := kerbcrypto.ChecksumTypeForEType(etype)
 	if !ok {
 		return nil, fmt.Errorf("gssapi: no checksum for etype %d", etype)
@@ -144,6 +164,9 @@ func (ctx *SecContext) MakeMIC(data []byte) ([]byte, error) {
 
 // VerifyMIC verifies a MIC token received from the acceptor over data.
 func (ctx *SecContext) VerifyMIC(data, token []byte) error {
+	if _, etype := ctx.baseKey(); etype == rc4HMACEType {
+		return ctx.verifyMICRC4(data, token)
+	}
 	if len(token) < 16 {
 		return fmt.Errorf("gssapi: MIC token too short")
 	}

--- a/network/kerberos/v5/gssapi/rc4permessage.go
+++ b/network/kerberos/v5/gssapi/rc4permessage.go
@@ -1,0 +1,147 @@
+package gssapi
+
+import (
+	"crypto/hmac"
+	"crypto/md5"
+	"crypto/rc4"
+	"encoding/binary"
+	"fmt"
+)
+
+// RFC 4757 §7.3 per-message MIC token for the RC4-HMAC (arcfour) enctype. Windows
+// RPC's DCE-style Kerberos uses this legacy token format (TOK_ID 01 01), wrapped
+// in the GSS-API InitialContextToken framing, rather than the RFC 4121 CFX token
+// (04 04). The signed data is carried out of band (the RPC stub); only the token
+// travels in the auth_value.
+
+const rc4HMACEType = 23
+
+// rc4MICTokenLen is the fixed length of an RC4 GSS MIC token: the 13-byte GSS
+// InitialContextToken header (60 23 06 09 <krb5 OID>) plus TOK_ID(2), SGN_ALG(2),
+// Filler(4), SND_SEQ(8), and SGN_CKSUM(8).
+const rc4MICTokenLen = 13 + 2 + 2 + 4 + 8 + 8
+
+// rc4GSSHeader is the GSS-API InitialContextToken header for a 35-byte RC4
+// per-message token: [APPLICATION 0] length 0x23, then the Kerberos 5 OID.
+var rc4GSSHeader = []byte{0x60, 0x23, 0x06, 0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x12, 0x01, 0x02, 0x02}
+
+func hmacMD5(key, data []byte) []byte {
+	h := hmac.New(md5.New, key)
+	h.Write(data)
+	return h.Sum(nil)
+}
+
+func md5sum(data []byte) []byte {
+	s := md5.Sum(data)
+	return s[:]
+}
+
+func le32(v uint32) []byte {
+	b := make([]byte, 4)
+	binary.LittleEndian.PutUint32(b, v)
+	return b
+}
+
+// rc4MICPad returns the RC4 MIC pad: the data is padded to a 4-byte boundary with
+// the pad length byte (RFC 4757 / MIT behaviour). The pad is folded into the
+// checksum only; it is not transmitted.
+func rc4MICPad(n int) []byte {
+	pad := (4 - (n % 4)) & 3
+	out := make([]byte, pad)
+	for i := range out {
+		out[i] = byte(pad)
+	}
+	return out
+}
+
+// rc4MICSeqBytes builds the 8-byte SND_SEQ field before encryption: the 32-bit
+// sequence number (big-endian) followed by the 4-byte direction indicator (0x00
+// for initiator-sent tokens, 0xff for acceptor-sent tokens).
+func rc4MICSeqBytes(seq uint64, initiator bool) []byte {
+	b := make([]byte, 8)
+	binary.BigEndian.PutUint32(b[:4], uint32(seq))
+	dir := byte(0x00)
+	if !initiator {
+		dir = 0xff
+	}
+	for i := 4; i < 8; i++ {
+		b[i] = dir
+	}
+	return b
+}
+
+// makeMICRC4 produces an RC4-HMAC GSS MIC token over data with the given sequence
+// number, as the initiator (RFC 4757 §7.3).
+func (ctx *SecContext) makeMICRC4(data []byte, seq uint64) []byte {
+	key, _ := ctx.baseKey()
+	hdr8 := []byte{0x01, 0x01, 0x11, 0x00, 0xff, 0xff, 0xff, 0xff}
+	seqBytes := rc4MICSeqBytes(seq, true)
+	cksum := rc4SgnCksum(key, hdr8, data)
+	encSeq := rc4Encrypt(rc4SeqKey(key, cksum), seqBytes)
+
+	token := make([]byte, 0, rc4MICTokenLen)
+	token = append(token, rc4GSSHeader...)
+	token = append(token, hdr8...)
+	token = append(token, encSeq...)
+	token = append(token, cksum...)
+	return token
+}
+
+// verifyMICRC4 verifies an RC4-HMAC GSS MIC token received from the acceptor over
+// data. It accepts the token either bare or wrapped in the InitialContextToken.
+func (ctx *SecContext) verifyMICRC4(data, token []byte) error {
+	// Strip the GSS InitialContextToken header (60 xx 06 09 <OID>) if present.
+	if len(token) >= 13 && token[0] == 0x60 {
+		token = token[13:]
+	}
+	if len(token) < 24 {
+		return fmt.Errorf("gssapi: RC4 MIC token too short")
+	}
+	if token[0] != 0x01 || token[1] != 0x01 {
+		return fmt.Errorf("gssapi: not an RC4 MIC token (TOK_ID %02x %02x)", token[0], token[1])
+	}
+	hdr8 := token[:8]
+	encSeq := token[8:16]
+	got := token[16:24]
+
+	key, _ := ctx.baseKey()
+	want := rc4SgnCksum(key, hdr8, data)
+	if !hmac.Equal(got, want) {
+		return fmt.Errorf("gssapi: RC4 MIC verification failed")
+	}
+	// Decrypt SND_SEQ and confirm the acceptor direction indicator.
+	seq := rc4Encrypt(rc4SeqKey(key, got), encSeq)
+	if seq[4] != 0xff {
+		return fmt.Errorf("gssapi: RC4 MIC not marked as sent by acceptor")
+	}
+	return nil
+}
+
+// rc4SgnCksum computes the RC4 MIC SGN_CKSUM: HMAC-MD5(Ksign, MD5(LE32(15) |
+// tokenHeader[:8] | data | pad)), truncated to 8 bytes. Ksign is HMAC-MD5(key,
+// "signaturekey\0"). The literal 15 is the MIC "sign" key-usage seed.
+func rc4SgnCksum(key, hdr8, data []byte) []byte {
+	ksign := hmacMD5(key, []byte("signaturekey\x00"))
+	buf := make([]byte, 0, 4+8+len(data)+3)
+	buf = append(buf, le32(15)...)
+	buf = append(buf, hdr8...)
+	buf = append(buf, data...)
+	buf = append(buf, rc4MICPad(len(data))...)
+	return hmacMD5(ksign, md5sum(buf))[:8]
+}
+
+// rc4SeqKey derives the RC4 key that encrypts the SND_SEQ field: HMAC-MD5(
+// HMAC-MD5(key, LE32(0)), SGN_CKSUM).
+func rc4SeqKey(key, sgnCksum []byte) []byte {
+	return hmacMD5(hmacMD5(key, le32(0)), sgnCksum)
+}
+
+func rc4Encrypt(key, data []byte) []byte {
+	c, err := rc4.NewCipher(key)
+	if err != nil {
+		return nil
+	}
+	out := make([]byte, len(data))
+	c.XORKeyStream(out, data)
+	return out
+}

--- a/network/kerberos/v5/gssapi/rc4permessage_test.go
+++ b/network/kerberos/v5/gssapi/rc4permessage_test.go
@@ -1,0 +1,61 @@
+package gssapi
+
+import (
+	"encoding/hex"
+	"testing"
+)
+
+// TestMakeMICRC4KnownAnswer checks the RFC 4757 §7.3 RC4-HMAC GSS MIC token
+// against a value produced by impacket's GSSAPI.GSS_GetMIC for the same inputs
+// (RC4 session key, DCE/RPC ept_lookup stub, sequence number 0). This pins the
+// exact key derivation (Ksign / Kseq), the MD5+HMAC-MD5 checksum, the RC4
+// sequence-number encryption, and the GSS InitialContextToken framing that
+// Windows RPC requires — validated live against a Windows DC.
+func TestMakeMICRC4KnownAnswer(t *testing.T) {
+	key, _ := hex.DecodeString("a3cf582b95eeb0afef5ffdddd0483fa5")
+	stub, _ := hex.DecodeString("000000000000000000000000010000000000000000000000000000000000000000000000f4010000")
+	want := "602306092a864886f71201020201011100ffffffffb3444d9050582818fc830a339f8f21b8"
+
+	ctx := &SecContext{SessionKey: key, SessionEType: rc4HMACEType}
+	mic, err := ctx.MakeMIC(stub)
+	if err != nil {
+		t.Fatalf("MakeMIC: %v", err)
+	}
+	if got := hex.EncodeToString(mic); got != want {
+		t.Errorf("RC4 MIC mismatch:\n got=%s\nwant=%s", got, want)
+	}
+	if len(mic) != rc4MICTokenLen {
+		t.Errorf("RC4 MIC length = %d, want %d", len(mic), rc4MICTokenLen)
+	}
+}
+
+// TestRC4MICRoundTrip confirms an acceptor-direction token verifies, and that a
+// tampered message fails verification.
+func TestRC4MICRoundTrip(t *testing.T) {
+	key, _ := hex.DecodeString("0123456789abcdef0123456789abcdef")
+	data := []byte("the quick brown fox")
+	ctx := &SecContext{SessionKey: key, SessionEType: rc4HMACEType}
+
+	acc := ctx.makeMICRC4Acceptor(data, 0)
+	if err := ctx.verifyMICRC4(data, acc); err != nil {
+		t.Fatalf("verifyMICRC4: %v", err)
+	}
+	if err := ctx.verifyMICRC4([]byte("tampered"), acc); err == nil {
+		t.Error("expected verification failure on tampered data")
+	}
+}
+
+// makeMICRC4Acceptor builds an acceptor-direction RC4 MIC (test helper for
+// exercising verifyMICRC4).
+func (ctx *SecContext) makeMICRC4Acceptor(data []byte, seq uint64) []byte {
+	key, _ := ctx.baseKey()
+	hdr8 := []byte{0x01, 0x01, 0x11, 0x00, 0xff, 0xff, 0xff, 0xff}
+	seqBytes := rc4MICSeqBytes(seq, false)
+	cksum := rc4SgnCksum(key, hdr8, data)
+	encSeq := rc4Encrypt(rc4SeqKey(key, cksum), seqBytes)
+	token := append([]byte{}, rc4GSSHeader...)
+	token = append(token, hdr8...)
+	token = append(token, encSeq...)
+	token = append(token, cksum...)
+	return token
+}

--- a/network/kerberos/v5/gssapi/rc4permessage_test.go
+++ b/network/kerberos/v5/gssapi/rc4permessage_test.go
@@ -6,11 +6,11 @@ import (
 )
 
 // TestMakeMICRC4KnownAnswer checks the RFC 4757 §7.3 RC4-HMAC GSS MIC token
-// against a value produced by impacket's GSSAPI.GSS_GetMIC for the same inputs
-// (RC4 session key, DCE/RPC ept_lookup stub, sequence number 0). This pins the
-// exact key derivation (Ksign / Kseq), the MD5+HMAC-MD5 checksum, the RC4
-// sequence-number encryption, and the GSS InitialContextToken framing that
-// Windows RPC requires — validated live against a Windows DC.
+// against a known-answer vector for a fixed RC4 session key, DCE/RPC ept_lookup
+// stub, and sequence number 0. This pins the exact key derivation (Ksign /
+// Kseq), the MD5+HMAC-MD5 checksum, the RC4 sequence-number encryption, and the
+// GSS InitialContextToken framing that Windows RPC requires — validated live
+// against a Windows DC.
 func TestMakeMICRC4KnownAnswer(t *testing.T) {
 	key, _ := hex.DecodeString("a3cf582b95eeb0afef5ffdddd0483fa5")
 	stub, _ := hex.DecodeString("000000000000000000000000010000000000000000000000000000000000000000000000f4010000")

--- a/network/kerberos/v5/spnego_mechanism.go
+++ b/network/kerberos/v5/spnego_mechanism.go
@@ -1,0 +1,97 @@
+package kerberos
+
+import (
+	"crypto/rand"
+	"fmt"
+
+	kerbcrypto "github.com/TheManticoreProject/Manticore/network/kerberos/v5/crypto"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/gssapi"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/messages"
+)
+
+// SPNEGOMechanism adapts the native Kerberos client and GSS-API layer to the
+// crypto/spnego KerberosProvider interface, so SMB and DCE/RPC can authenticate
+// with Kerberos through SPNEGO. It targets a single service principal (spn), for
+// example "cifs/host.domain" for SMB or "host/host.domain" / "ldap/host.domain".
+//
+// It is created by the consumer (SMB/RPC) and assigned to
+// spnego.AuthContext.Kerberos, keeping crypto/spnego free of any dependency on
+// the Kerberos implementation.
+type SPNEGOMechanism struct {
+	client *KerberosClient
+	spn    string
+	ctx    *gssapi.SecContext
+}
+
+// NewSPNEGOMechanism builds a mechanism over an existing client (which supplies
+// the credentials and realm) targeting the given service principal name.
+func NewSPNEGOMechanism(client *KerberosClient, spn string) *SPNEGOMechanism {
+	return &SPNEGOMechanism{client: client, spn: spn}
+}
+
+// InitToken acquires (if needed) a TGT and a service ticket for the SPN, then
+// builds the KRB_AP_REQ GSS token to place in the SPNEGO NegTokenInit. Mutual
+// authentication is requested and an initiator subkey is asserted (as Windows
+// GSS clients do).
+func (m *SPNEGOMechanism) InitToken() ([]byte, error) {
+	if !m.client.hasTGT {
+		if err := m.client.GetTGT(); err != nil {
+			return nil, fmt.Errorf("kerberos spnego: GetTGT: %w", err)
+		}
+	}
+	ticket, ticketRaw, key, err := m.client.GetTGS(m.spn, true)
+	if err != nil {
+		return nil, fmt.Errorf("kerberos spnego: GetTGS %q: %w", m.spn, err)
+	}
+	subKey := make([]byte, kerbcrypto.KeyLen(ticket.EncPart.EType))
+	if _, err := rand.Read(subKey); err != nil {
+		return nil, err
+	}
+	tok, ctx, err := gssapi.InitSecContext(gssapi.InitOptions{
+		TicketRaw:    ticketRaw,
+		SessionKey:   key,
+		SessionEType: ticket.EncPart.EType,
+		ClientName:   messages.PrincipalName{NameType: messages.NameTypePrincipal, NameString: []string{m.client.Username()}},
+		ClientRealm:  m.client.Realm(),
+		Flags:        gssapi.GSSMutualFlag | gssapi.GSSSequenceFlag | gssapi.GSSConfFlag | gssapi.GSSIntegFlag,
+		Mutual:       true,
+		SubKey:       subKey,
+		SubKeyEType:  ticket.EncPart.EType,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("kerberos spnego: InitSecContext: %w", err)
+	}
+	m.ctx = ctx
+	return tok, nil
+}
+
+// AcceptResponseToken verifies the server's KRB_AP_REP (mutual authentication).
+// An empty token is a no-op. A server KRB-ERROR is surfaced with its code.
+func (m *SPNEGOMechanism) AcceptResponseToken(token []byte) error {
+	if len(token) == 0 {
+		return nil
+	}
+	if m.ctx == nil {
+		return fmt.Errorf("kerberos spnego: no established context")
+	}
+	if tokID, krbMsg, err := gssapi.UnwrapToken(token); err == nil && tokID == gssapi.TokIDError {
+		var ke messages.KRBError
+		if _, e := ke.Unmarshal(krbMsg); e == nil {
+			return fmt.Errorf("kerberos spnego: server returned KRB-ERROR %d: %s", ke.ErrorCode, ke.EText)
+		}
+	}
+	return m.ctx.AcceptAPRep(token)
+}
+
+// SessionKey returns the established GSS context key for SMB/RPC message
+// signing and sealing: the negotiated subkey if present, otherwise the service
+// ticket session key.
+func (m *SPNEGOMechanism) SessionKey() []byte {
+	if m.ctx == nil {
+		return nil
+	}
+	if len(m.ctx.SubKey) > 0 {
+		return m.ctx.SubKey
+	}
+	return m.ctx.SessionKey
+}

--- a/network/smb/smb_v20/client/session_kerberos.go
+++ b/network/smb/smb_v20/client/session_kerberos.go
@@ -1,0 +1,172 @@
+package client
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/crypto/spnego"
+	kerberos "github.com/TheManticoreProject/Manticore/network/kerberos/v5"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/securitymode"
+	"github.com/TheManticoreProject/Manticore/windows/credentials"
+)
+
+// SessionSetupKerberos authenticates a session with the server using Kerberos
+// over SPNEGO. Unlike the two-leg NTLM exchange, Kerberos is a single round: the
+// client sends a KRB_AP_REQ inside a SPNEGO NegTokenInit and the server replies
+// with STATUS_SUCCESS, optionally carrying a KRB_AP_REP (mutual authentication)
+// which we verify to capture the negotiated context key.
+//
+// kdcHost is the KDC (domain controller) address used to obtain the TGT and
+// service ticket. spn is the service principal name of the target server; when
+// empty it defaults to "cifs/<host>", the SMB service class.
+//
+// The GSS context key established here is used as the SMB signing key (for the
+// SMB 2.0.2/2.1 dialects the signing key is the session key itself). The
+// NegTokenInit request is not signed — the session is not yet established;
+// signing is activated once the server confirms the session.
+func (c *Client) SessionSetupKerberos(creds *credentials.Credentials, kdcHost, spn string) error {
+	if creds == nil {
+		return fmt.Errorf("session setup requires credentials but none were provided")
+	}
+	if !c.Transport.IsConnected() {
+		return fmt.Errorf("transport is not connected")
+	}
+	if kdcHost == "" {
+		return fmt.Errorf("kerberos session setup requires a KDC host")
+	}
+	if spn == "" {
+		spn = "cifs/" + c.Connection.Server.DNSComputerName
+	}
+	if spn == "cifs/" {
+		return fmt.Errorf("kerberos session setup requires a service principal name (or a known server name)")
+	}
+
+	// Build the native Kerberos client from the SMB credentials (realm = domain).
+	kc := kerberos.NewClient(creds.GetUsername(), creds.GetDomain(), kdcHost)
+	if nt := creds.GetNTHash(); nt != "" {
+		// Overpass-the-hash: obtain the TGT from the NT hash rather than a password.
+		if err := kc.WithNTHash(nt); err != nil {
+			return fmt.Errorf("kerberos: invalid NT hash: %w", err)
+		}
+	} else {
+		kc.WithPassword(creds.GetPassword())
+	}
+
+	mech := kerberos.NewSPNEGOMechanism(kc, spn)
+
+	// SMB2 always uses Unicode for its strings.
+	authCtx := spnego.NewAuthContext(
+		spnego.AuthTypeKerberos,
+		creds.Domain,
+		creds.Username,
+		creds.Password,
+		c.Workstation,
+		true,
+	)
+	// Wire the Kerberos provider into the SPNEGO context (dependency inversion:
+	// crypto/spnego stays free of any Kerberos dependency).
+	authCtx.Kerberos = mech
+
+	// Build the SPNEGO NegTokenInit carrying the KRB_AP_REQ.
+	negotiateToken, err := authCtx.CreateNegotiateToken(0, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create Kerberos negotiate token: %w", err)
+	}
+
+	// Single leg: send the AP-REQ; the server replies with the assigned SessionId
+	// and STATUS_SUCCESS, optionally carrying an AP-REP.
+	req := commands.NewSessionSetupRequest()
+	req.SecurityMode = securitymode.SMB2_NEGOTIATE_SIGNING_ENABLED
+	req.SecurityBuffer = negotiateToken
+
+	msg := c.newRequest(req)
+	msg.Header.SessionId = 0
+
+	resp, err := c.sendReceive(msg, "SessionSetup(kerberos)")
+	if err != nil {
+		return err
+	}
+
+	status := statusFromResponse(resp)
+	// STATUS_MORE_PROCESSING_REQUIRED can precede the AP-REP on some servers; both
+	// it and STATUS_SUCCESS carry the response token we need to verify.
+	if status != 0x00000000 && status != ntStatusMoreProcessingRequired {
+		return fmt.Errorf("kerberos session setup failed: %s", formatNTStatus(status))
+	}
+
+	sessionId := resp.Header.SessionId
+	setupResp, ok := resp.Command.(*commands.SessionSetupResponse)
+	if !ok {
+		return fmt.Errorf("unexpected SESSION_SETUP response command: %T", resp.Command)
+	}
+
+	// Verify the server's AP-REP (mutual authentication) when present and capture
+	// the GSS context key. For Kerberos this produces no follow-up token.
+	if len(setupResp.SecurityBuffer) > 0 {
+		follow, ferr := authCtx.CreateAuthenticateTokenFromChallengeToken(setupResp.SecurityBuffer)
+		if ferr != nil {
+			return fmt.Errorf("failed to verify Kerberos server response: %w", ferr)
+		}
+		if len(follow) > 0 {
+			// A well-behaved AD server completes Kerberos in one round; a follow-up
+			// token would indicate an unexpected multi-leg negotiation.
+			return fmt.Errorf("kerberos session setup: unexpected multi-leg SPNEGO continuation")
+		}
+	}
+
+	// The signing key derives from the established GSS context key (subkey if
+	// negotiated, else the service-ticket session key). Per MS-SMB2 3.2.5.3.1 the
+	// SMB2 Session.SessionKey is the first 16 bytes of the GSS-exported key,
+	// right-padded with zeros if shorter — Kerberos AES256 yields a 32-byte key,
+	// so it must be truncated (NTLM keys are already 16 bytes). For the 2.0.2
+	// dialect this 16-byte value is the HMAC-SHA256 signing key directly.
+	gssKey := authCtx.GetSessionKey()
+	if len(gssKey) == 0 {
+		gssKey = mech.SessionKey()
+	}
+	sessionKey := make([]byte, 16)
+	copy(sessionKey, gssKey)
+
+	serverMode := c.Connection.Server.SecurityMode
+	session := &Session{
+		Client:        c,
+		SessionId:     sessionId,
+		Credentials:   creds,
+		SessionKey:    sessionKey,
+		SigningKey:    sessionKey,
+		SigningActive: false,
+	}
+	c.Session = session
+
+	// If the server still requires another leg (unusual for AD Kerberos), send the
+	// final NegTokenResp confirming completion before the session is usable.
+	if status == ntStatusMoreProcessingRequired {
+		req2 := commands.NewSessionSetupRequest()
+		req2.SecurityMode = securitymode.SMB2_NEGOTIATE_SIGNING_ENABLED
+		req2.SecurityBuffer = []byte{}
+
+		msg2 := c.newRequest(req2)
+		msg2.Header.SessionId = sessionId
+
+		resp2, err := c.sendReceive(msg2, "SessionSetup(kerberos-final)")
+		if err != nil {
+			c.Session = nil
+			return err
+		}
+		if st := statusFromResponse(resp2); st != 0x00000000 {
+			c.Session = nil
+			return fmt.Errorf("kerberos session setup failed: %s", formatNTStatus(st))
+		}
+	}
+
+	// Session established: activate signing for subsequent requests when the server
+	// enables or requires it.
+	session.SigningActive = serverMode.IsSigningEnabled() || serverMode.IsSigningRequired()
+
+	if c.Connection.SessionTable == nil {
+		c.Connection.SessionTable = make(map[uint64]*Session)
+	}
+	c.Connection.SessionTable[sessionId] = session
+
+	return nil
+}


### PR DESCRIPTION
## Summary

Adds RPC-level Kerberos to the connection-oriented DCE/RPC client, so binds can authenticate with Kerberos and per-PDU traffic is protected with GSS message integrity. Stacked on `kerberos-spnego-smbrpc` (the SMB2/SPNEGO Kerberos PR), which is itself stacked on `kerberos-native` (#898).

Live-validated against Windows Server 2016: an authenticated bind + `ept_lookup` recovers the full endpoint map at CONNECT, PKT, and PKT_INTEGRITY.

```
[+] CONNECT: authenticated bind + mutual AP-REP verified
[+] PKT: signed bind + ept_lookup recovered 579 endpoint-map entries
[+] PKT_INTEGRITY: signed bind + ept_lookup recovered 579 endpoint-map entries
```

## What it does

`Client.SetAuthKerberos(authLevel, kerberosClient, spn)` acquires a TGT (if needed) and a service ticket, builds the `KRB_AP_REQ`, installs a per-message security context, and requests mutual authentication.

- **CONNECT** uses raw Kerberos (`auth_type` 0x10) with a GSS-wrapped AP-REQ and a single mutual-auth round.
- **PKT / PKT_INTEGRITY** negotiate through SPNEGO (`auth_type` 0x09) with `GSS_C_DCE_STYLE`: a three-leg handshake (bind AP-REQ → bind_ack AP-REP → `alter_context` with the initiator's own AP-REP) establishes the context; the per-PDU verifier is a GSS MIC over the request stub.
- **PKT_PRIVACY** (sealing) is not yet supported and returns a clear error (needs GSS Wrap-IOV).

The DCE-style Kerberos wire behaviour was reverse-engineered against a reference implementation and is exact: `GSS_C_DCE_STYLE` **and** `GSS_C_REPLAY_FLAG` in the authenticator checksum; the third leg via `alter_context` (answered by `alter_context_response`), not `auth3`; a **zero** authenticator sequence number (which seeds the acceptor's expected per-message receive sequence); a non-zero, consistent `auth_context_id`; and an **RC4-HMAC** service ticket with RFC 4757 §7.3 per-message MIC tokens (Windows RPC rejects AES here).

## Changes

**network/dcerpc/v5/client**
- `SetAuthKerberos` + `kerberosSecurityContext` (`auth_kerberos.go`).
- Generalized bind completion: `completeAuth` returns an optional continuation token, which `Bind` sends in an `alter_context` (the DCE-style third leg). NTLM and Netlogon paths are unaffected. New optional `bindCompleter` capability on `SecurityContext`.

**network/kerberos/v5/gssapi**
- `AcceptAPRepRaw` / `MakeAPRep` for the DCE-style bare `KRB_AP_REP` exchange; `GSS_C_DCE_STYLE` flag; `ZeroSeqNumber` option.
- RFC 4757 §7.3 RC4-HMAC per-message MIC tokens (`rc4permessage.go`); `MakeMIC`/`VerifyMIC` dispatch on enctype. Includes a known-answer unit test validated against the reference implementation.

**network/kerberos/v5**
- `PreferRC4ServiceTicket` — request an RC4-HMAC service ticket for the RPC DCE-style path.

**crypto/spnego**
- Add the MS KRB5 mechanism OID (1.2.840.48018.1.2.2) advertised in the SPNEGO mechTypes.

## Validation

- Live: CONNECT / PKT / PKT_INTEGRITY authenticated bind + `ept_lookup` against Windows Server 2016.
- Unit: RC4 MIC known-answer + round-trip tests; `go build ./...` and `go test ./network/dcerpc/v5/... ./network/kerberos/... ./crypto/spnego/ ./network/smb/...` all green.
- Regression: the NTLM authenticated RPC bind (all four levels) still passes live — the `completeAuth` refactor is transparent to it.