### PR TITLE
Add Kerberos cross-realm referral chasing (Fixes #910)

### DIFF
--- a/network/kerberos/v5/client.go
+++ b/network/kerberos/v5/client.go
@@ -49,6 +49,15 @@ type KerberosClient struct {
 	// is asked for one of these SPNs it returns the preloaded ticket instead of
 	// contacting the KDC — enabling silver-ticket use with no TGT.
 	preloadedTGS map[string]preloadedServiceTicket
+
+	// realmKDCs maps an (uppercased) realm to the KDC host to contact when the
+	// cross-realm referral chase reaches that realm. Populated via WithRealmKDC.
+	realmKDCs map[string]string
+
+	// kdcResolver, if set, resolves an (uppercased) realm to a KDC host for the
+	// referral chase. It overrides the default DNS-SRV based resolution and is
+	// consulted after realmKDCs and the client's own home realm.
+	kdcResolver func(realm string) (string, error)
 }
 
 // preloadedServiceTicket is a service ticket the client will hand back from
@@ -201,81 +210,9 @@ func (c *KerberosClient) GetTGS(spn string, includePAC bool) (messages.Ticket, [
 		return messages.Ticket{}, nil, nil, fmt.Errorf("kerberos: parse SPN %q: %w", spn, err)
 	}
 
-	// Build AP-REQ wrapping the TGT.
-	ap_req_bytes, err := c.buildAPReq()
-	if err != nil {
-		return messages.Ticket{}, nil, nil, fmt.Errorf("kerberos: build AP-REQ: %w", err)
-	}
-
-	// Build TGS-REQ.
-	nonce := randomNonce()
-	// PA-PAC-REQUEST: SEQUENCE { [0] BOOLEAN } — TRUE=0xff, FALSE=0x00
-	pacBool := byte(0xff)
-	if !includePAC {
-		pacBool = 0x00
-	}
-	tgs_req := &messages.TGSReq{
-		PVNO:    messages.KerberosV5,
-		MsgType: messages.MsgTypeTGSReq,
-		PAData: []messages.PAData{
-			{PADataType: messages.PATGSReq, PADataValue: ap_req_bytes},
-			{PADataType: messages.PAPACRequest, PADataValue: []byte{0x30, 0x05, 0xa0, 0x03, 0x01, 0x01, pacBool}},
-		},
-		ReqBody: messages.KDCReqBody{
-			KDCOptions: kdcOptionsForTGSReq(),
-			Realm:      c.realm,
-			SName:      sname,
-			Till:       time.Now().UTC().Add(24 * time.Hour),
-			Nonce:      nonce,
-			EType:      c.serviceTicketETypes(),
-		},
-	}
-
-	tgs_req_bytes, err := tgs_req.Marshal()
-	if err != nil {
-		return messages.Ticket{}, nil, nil, fmt.Errorf("kerberos: marshal TGS-REQ: %w", err)
-	}
-	resp, err := kdcSend(c.kdcHost, defaultKDCPort, tgs_req_bytes)
-	if err != nil {
-		return messages.Ticket{}, nil, nil, err
-	}
-
-	// Check for KRBError.
-	var krb_err messages.KRBError
-	if _, parse_err := krb_err.Unmarshal(resp); parse_err == nil {
-		return messages.Ticket{}, nil, nil, fmt.Errorf("kerberos: TGS error %d: %s", krb_err.ErrorCode, krb_err.EText)
-	}
-
-	// Parse TGS-REP.
-	var tgs_rep messages.TGSRep
-	if _, err := tgs_rep.Unmarshal(resp); err != nil {
-		return messages.Ticket{}, nil, nil, fmt.Errorf("kerberos: parse TGS-REP: %w", err)
-	}
-
-	// Decrypt enc-part with the TGT session key.
-	enc_plain, err := kerbcrypto.Decrypt(
-		c.sessionEType,
-		c.sessionKey,
-		kerbcrypto.KeyUsageTGSRepEncSessionKey,
-		tgs_rep.EncPart.Cipher,
-	)
-	if err != nil {
-		return messages.Ticket{}, nil, nil, fmt.Errorf("kerberos: decrypt TGS-REP enc-part: %w", err)
-	}
-
-	var enc_tgs_rep messages.EncTGSRepPart
-	if _, err := enc_tgs_rep.Unmarshal(enc_plain); err != nil {
-		return messages.Ticket{}, nil, nil, fmt.Errorf("kerberos: parse EncTGSRepPart: %w", err)
-	}
-
-	// RFC 4120 §3.3.3: the nonce in the reply must match the nonce in the
-	// request. Rejecting a mismatch defends against replays of captured
-	// TGS-REPs that happen to decrypt under the current TGT session key.
-	if enc_tgs_rep.Nonce != nonce {
-		return messages.Ticket{}, nil, nil, fmt.Errorf("kerberos: TGS-REP nonce mismatch: got %d, want %d", enc_tgs_rep.Nonce, nonce)
-	}
-
-	return tgs_rep.Ticket, tgs_rep.TicketRaw, enc_tgs_rep.Key.KeyValue, nil
+	// Request the service ticket, chasing any cross-realm referrals returned by
+	// the KDC (see chaseServiceTicket / referral.go).
+	return c.chaseServiceTicket(sname, includePAC)
 }
 
 // Destroy zeroes out key material held by the client.
@@ -489,8 +426,19 @@ func (c *KerberosClient) processASRep(resp []byte, etype int, salt string, s2k_p
 	return nil
 }
 
-// buildAPReq constructs an AP-REQ wrapping the TGT for use in TGS-REQ PA-DATA.
+// buildAPReq constructs an AP-REQ wrapping the client's current TGT for use in
+// TGS-REQ PA-DATA.
 func (c *KerberosClient) buildAPReq() ([]byte, error) {
+	return c.buildAPReqWith(c.tgtTicket, c.tgtTicketRaw, c.sessionKey, c.sessionEType)
+}
+
+// buildAPReqWith constructs an AP-REQ wrapping the given ticket-granting ticket
+// and session key. Cross-realm referral chasing presents a different (referral)
+// TGT at each hop, so the ticket/key are passed explicitly rather than always
+// taken from the client's home TGT. The authenticator's client name and realm
+// always identify the original client (they must match the crealm embedded in
+// the ticket, which stays the home realm across cross-realm referrals).
+func (c *KerberosClient) buildAPReqWith(tgt messages.Ticket, tgtRaw, sessionKey []byte, sessionEType int) ([]byte, error) {
 	now := time.Now().UTC()
 	cusec := now.Nanosecond() / 1000
 
@@ -513,7 +461,7 @@ func (c *KerberosClient) buildAPReq() ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("marshal Authenticator: %w", err)
 	}
-	enc_auth, err := kerbcrypto.Encrypt(c.sessionEType, c.sessionKey, kerbcrypto.KeyUsageTGSReqPAAPReqAuthen, auth_bytes)
+	enc_auth, err := kerbcrypto.Encrypt(sessionEType, sessionKey, kerbcrypto.KeyUsageTGSReqPAAPReqAuthen, auth_bytes)
 	if err != nil {
 		return nil, fmt.Errorf("encrypt Authenticator: %w", err)
 	}
@@ -522,10 +470,10 @@ func (c *KerberosClient) buildAPReq() ([]byte, error) {
 		PVNO:      messages.KerberosV5,
 		MsgType:   messages.MsgTypeAPReq,
 		APOptions: asn1.BitString{Bytes: []byte{0x00, 0x00, 0x00, 0x00}, BitLength: 32},
-		Ticket:    c.tgtTicket,
-		TicketRaw: c.tgtTicketRaw,
+		Ticket:    tgt,
+		TicketRaw: tgtRaw,
 		Authenticator: messages.EncryptedData{
-			EType:  c.sessionEType,
+			EType:  sessionEType,
 			Cipher: enc_auth,
 		},
 	}

--- a/network/kerberos/v5/messages/constants.go
+++ b/network/kerberos/v5/messages/constants.go
@@ -28,14 +28,17 @@ const (
 	ETypeAES128CTSHMACSHA196 = iana.ETypeAES128CTSHMACSHA196
 	ETypeAES256CTSHMACSHA196 = iana.ETypeAES256CTSHMACSHA196
 
-	PATGSReq       = iana.PATGSReq
-	PAEncTimestamp = iana.PAEncTimestamp
-	PAETypeInfo2   = iana.PAETypeInfo2
-	PAPACRequest   = iana.PAPACRequest
+	PATGSReq          = iana.PATGSReq
+	PAEncTimestamp    = iana.PAEncTimestamp
+	PAETypeInfo2      = iana.PAETypeInfo2
+	PAPACRequest      = iana.PAPACRequest
+	PASvrReferralInfo = iana.PASvrReferralInfo
 
 	ErrNone              = iana.ErrNone
 	ErrCPrincipalUnknown = iana.ErrCPrincipalUnknown
+	ErrSPrincipalUnknown = iana.ErrSPrincipalUnknown
 	ErrPreauthRequired   = iana.ErrPreauthRequired
+	ErrWrongRealm        = iana.ErrWrongRealm
 
 	APOptionUseSessionKey = iana.APOptionUseSessionKey
 	APOptionMutualAuth    = iana.APOptionMutualAuth

--- a/network/kerberos/v5/messages/krberror.go
+++ b/network/kerberos/v5/messages/krberror.go
@@ -50,6 +50,10 @@ type KRBError struct {
 	SUSec int
 	// ErrorCode identifies the specific error.
 	ErrorCode int
+	// CRealm is the client's realm as echoed by the KDC (optional). For a
+	// KDC_ERR_WRONG_REALM error this carries the realm the client should retry
+	// against (RFC 4120 Section 3.3.3.1, RFC 6806).
+	CRealm string
 	// Realm is the server's realm.
 	Realm string
 	// SName is the server's principal name.
@@ -73,6 +77,7 @@ func (e *KRBError) Marshal() ([]byte, error) {
 		STime:     e.STime,
 		SUSec:     e.SUSec,
 		ErrorCode: e.ErrorCode,
+		CRealm:    e.CRealm,
 		Realm:     e.Realm,
 		SName:     e.SName,
 		EText:     e.EText,
@@ -103,6 +108,7 @@ func (e *KRBError) Unmarshal(data []byte) (int, error) {
 	e.STime = inner.STime
 	e.SUSec = inner.SUSec
 	e.ErrorCode = inner.ErrorCode
+	e.CRealm = inner.CRealm
 	e.Realm = inner.Realm
 	e.SName = inner.SName
 	e.EText = inner.EText

--- a/network/kerberos/v5/referral.go
+++ b/network/kerberos/v5/referral.go
@@ -1,0 +1,311 @@
+package kerberos
+
+import (
+	"encoding/asn1"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	kerbcrypto "github.com/TheManticoreProject/Manticore/network/kerberos/v5/crypto"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/messages"
+)
+
+// maxReferralHops bounds how many cross-realm referral TGTs the client will
+// chase before giving up. A transitive trust path is at most a few realms deep;
+// this ceiling protects against a misbehaving KDC that keeps issuing referrals.
+const maxReferralHops = 10
+
+// WithRealmKDC registers the KDC host to contact when the cross-realm referral
+// chase reaches the given realm. The realm is uppercased automatically. This is
+// the minimal, no-dependency way to resolve a target-realm KDC; automatic
+// discovery (DNS SRV) is used for any realm not registered here. Returns the
+// client to allow fluent chaining.
+func (c *KerberosClient) WithRealmKDC(realm, kdcHost string) *KerberosClient {
+	if c.realmKDCs == nil {
+		c.realmKDCs = make(map[string]string)
+	}
+	c.realmKDCs[strings.ToUpper(realm)] = kdcHost
+	return c
+}
+
+// WithKDCResolver installs a custom function that resolves a realm to a KDC host
+// for the cross-realm referral chase. It takes precedence over DNS-SRV discovery
+// but not over explicit WithRealmKDC entries or the client's own home realm.
+// Returns the client to allow fluent chaining.
+func (c *KerberosClient) WithKDCResolver(fn func(realm string) (string, error)) *KerberosClient {
+	c.kdcResolver = fn
+	return c
+}
+
+// resolveKDCForRealm returns the KDC host to contact for the given realm during
+// referral chasing. Resolution order: explicit WithRealmKDC overrides, then the
+// client's own configured KDC for its home realm, then a custom resolver, then
+// DNS-SRV discovery. Nothing is hardcoded.
+func (c *KerberosClient) resolveKDCForRealm(realm string) (string, error) {
+	realm = strings.ToUpper(realm)
+
+	if host, ok := c.realmKDCs[realm]; ok && host != "" {
+		return host, nil
+	}
+	if realm == strings.ToUpper(c.realm) && c.kdcHost != "" {
+		return c.kdcHost, nil
+	}
+	if c.kdcResolver != nil {
+		return c.kdcResolver(realm)
+	}
+	return discoverKDCViaDNS(realm)
+}
+
+// discoverKDCViaDNS resolves a KDC host for realm via the RFC 4120 Section 7.2.3
+// DNS SRV record "_kerberos._tcp.<realm>". Only the target host is used; the
+// standard Kerberos port (88) is applied by the transport layer.
+func discoverKDCViaDNS(realm string) (string, error) {
+	_, addrs, err := net.LookupSRV("kerberos", "tcp", realm)
+	if err != nil {
+		return "", fmt.Errorf("kerberos: DNS SRV lookup _kerberos._tcp.%s: %w", realm, err)
+	}
+	if len(addrs) == 0 {
+		return "", fmt.Errorf("kerberos: no _kerberos._tcp.%s SRV records", realm)
+	}
+	return strings.TrimSuffix(addrs[0].Target, "."), nil
+}
+
+// chaseServiceTicket obtains a service ticket for sname, following any
+// cross-realm referral TGTs the KDC returns (RFC 6806, MS-KILE Section 3.3.5.1).
+//
+// Starting from the client's home TGT/KDC, it issues a TGS-REQ toward the
+// current realm. If the reply is the requested service ticket it is returned. If
+// the reply is a referral TGT (server name krbtgt/NEXT-REALM), the chase switches
+// to NEXT-REALM: it resolves that realm's KDC, presents the referral TGT, and
+// re-issues the TGS-REQ — repeating until the service ticket is obtained. A
+// KDC_ERR_WRONG_REALM error is handled by retrying with the corrected target
+// realm the KDC named. Cycles and over-long chains are rejected.
+func (c *KerberosClient) chaseServiceTicket(sname messages.PrincipalName, includePAC bool) (messages.Ticket, []byte, []byte, error) {
+	// The credential presented at the current hop. It starts as the home TGT and
+	// becomes each successive referral TGT.
+	tgt := c.tgtTicket
+	tgtRaw := c.tgtTicketRaw
+	sessionKey := c.sessionKey
+	sessionEType := c.sessionEType
+
+	kdcHost := c.kdcHost
+	// bodyRealm is the KDC-REQ-BODY realm — the realm whose KDC we are asking.
+	bodyRealm := c.realm
+
+	// Realms whose KDC we have already presented a TGT to, to detect referral
+	// cycles (an authority realm must not be revisited).
+	visited := map[string]bool{strings.ToUpper(bodyRealm): true}
+	// Corrected realms we have already retried for WRONG_REALM, to avoid a
+	// ping-pong between two KDCs that keep correcting each other. Kept separate
+	// from visited so the follow-up referral toward the corrected realm is not
+	// itself mistaken for a cycle.
+	wrongRealmTried := map[string]bool{}
+
+	for hop := 0; hop < maxReferralHops; hop++ {
+		rep, encRep, krbErr, err := c.tgsExchange(bodyRealm, kdcHost, sname, includePAC, tgt, tgtRaw, sessionKey, sessionEType)
+		if err != nil {
+			return messages.Ticket{}, nil, nil, err
+		}
+		if krbErr != nil {
+			// KDC_ERR_WRONG_REALM: the KDC tells the client the realm the
+			// principal actually lives in (RFC 4120 Section 3.3.3.1). Retry once
+			// per corrected realm against the same (home) KDC so it can issue a
+			// referral toward that realm.
+			if krbErr.ErrorCode == messages.ErrWrongRealm && krbErr.CRealm != "" {
+				corrected := strings.ToUpper(krbErr.CRealm)
+				if !wrongRealmTried[corrected] {
+					wrongRealmTried[corrected] = true
+					bodyRealm = corrected
+					continue
+				}
+			}
+			return messages.Ticket{}, nil, nil, fmt.Errorf("kerberos: TGS error %d: %s", krbErr.ErrorCode, krbErr.EText)
+		}
+
+		nextRealm, isReferral := referralTargetRealm(rep, sname)
+		if !isReferral {
+			// The requested service ticket was issued — done.
+			return rep.Ticket, rep.TicketRaw, encRep.Key.KeyValue, nil
+		}
+
+		nextRealm = strings.ToUpper(nextRealm)
+		if visited[nextRealm] {
+			return messages.Ticket{}, nil, nil, fmt.Errorf("kerberos: cross-realm referral cycle detected at realm %q", nextRealm)
+		}
+		nextKDC, err := c.resolveKDCForRealm(nextRealm)
+		if err != nil {
+			return messages.Ticket{}, nil, nil, fmt.Errorf("kerberos: resolve KDC for referral realm %q: %w", nextRealm, err)
+		}
+
+		// Advance to the next realm, presenting the referral TGT there.
+		visited[nextRealm] = true
+		bodyRealm = nextRealm
+		kdcHost = nextKDC
+		tgt = rep.Ticket
+		tgtRaw = rep.TicketRaw
+		sessionKey = encRep.Key.KeyValue
+		sessionEType = encRep.Key.KeyType
+	}
+
+	return messages.Ticket{}, nil, nil, fmt.Errorf("kerberos: too many cross-realm referrals (>%d) chasing %s", maxReferralHops, strings.Join(sname.NameString, "/"))
+}
+
+// tgsExchange performs a single TGS-REQ/REP round-trip against kdcHost, using
+// bodyRealm as the KDC-REQ-BODY realm and presenting the supplied ticket-granting
+// ticket. It returns the parsed TGS-REP with its decrypted enc-part on success.
+// If the KDC answers with a KRB-ERROR it is returned as *messages.KRBError (with
+// a nil error) so the caller can react to WRONG_REALM.
+func (c *KerberosClient) tgsExchange(
+	bodyRealm, kdcHost string,
+	sname messages.PrincipalName,
+	includePAC bool,
+	tgt messages.Ticket, tgtRaw, sessionKey []byte, sessionEType int,
+) (*messages.TGSRep, *messages.EncTGSRepPart, *messages.KRBError, error) {
+
+	apReqBytes, err := c.buildAPReqWith(tgt, tgtRaw, sessionKey, sessionEType)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("kerberos: build AP-REQ: %w", err)
+	}
+
+	nonce := randomNonce()
+	// PA-PAC-REQUEST: SEQUENCE { [0] BOOLEAN } — TRUE=0xff, FALSE=0x00.
+	pacBool := byte(0xff)
+	if !includePAC {
+		pacBool = 0x00
+	}
+	tgsReq := &messages.TGSReq{
+		PVNO:    messages.KerberosV5,
+		MsgType: messages.MsgTypeTGSReq,
+		PAData: []messages.PAData{
+			{PADataType: messages.PATGSReq, PADataValue: apReqBytes},
+			{PADataType: messages.PAPACRequest, PADataValue: []byte{0x30, 0x05, 0xa0, 0x03, 0x01, 0x01, pacBool}},
+		},
+		ReqBody: messages.KDCReqBody{
+			KDCOptions: kdcOptionsForTGSReq(),
+			Realm:      bodyRealm,
+			SName:      sname,
+			Till:       time.Now().UTC().Add(24 * time.Hour),
+			Nonce:      nonce,
+			EType:      c.serviceTicketETypes(),
+		},
+	}
+
+	tgsReqBytes, err := tgsReq.Marshal()
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("kerberos: marshal TGS-REQ: %w", err)
+	}
+	resp, err := kdcSend(kdcHost, defaultKDCPort, tgsReqBytes)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	// A KRB-ERROR is handed back to the caller (it may be a recoverable
+	// WRONG_REALM) rather than turned into an error here.
+	var krbErr messages.KRBError
+	if _, parseErr := krbErr.Unmarshal(resp); parseErr == nil {
+		return nil, nil, &krbErr, nil
+	}
+
+	var tgsRep messages.TGSRep
+	if _, err := tgsRep.Unmarshal(resp); err != nil {
+		return nil, nil, nil, fmt.Errorf("kerberos: parse TGS-REP: %w", err)
+	}
+
+	// The reply enc-part is encrypted under the TGT session key of the ticket we
+	// presented at this hop (the referral TGT's key on cross-realm hops).
+	encPlain, err := kerbcrypto.Decrypt(sessionEType, sessionKey, kerbcrypto.KeyUsageTGSRepEncSessionKey, tgsRep.EncPart.Cipher)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("kerberos: decrypt TGS-REP enc-part: %w", err)
+	}
+
+	var encRep messages.EncTGSRepPart
+	if _, err := encRep.Unmarshal(encPlain); err != nil {
+		return nil, nil, nil, fmt.Errorf("kerberos: parse EncTGSRepPart: %w", err)
+	}
+
+	// RFC 4120 Section 3.3.3: the reply nonce must match the request nonce.
+	// Rejecting a mismatch defends against replays of captured TGS-REPs that
+	// happen to decrypt under the presented session key.
+	if encRep.Nonce != nonce {
+		return nil, nil, nil, fmt.Errorf("kerberos: TGS-REP nonce mismatch: got %d, want %d", encRep.Nonce, nonce)
+	}
+
+	return &tgsRep, &encRep, nil, nil
+}
+
+// referralTargetRealm decides whether a TGS-REP is a cross-realm referral rather
+// than the requested service ticket, and if so returns the realm to chase next.
+//
+// A referral is signalled by a returned ticket whose server name is the two-part
+// TGS principal "krbtgt/NEXT-REALM" while the client asked for a different
+// (non-krbtgt) service (RFC 6806 Section 7, MS-KILE Section 3.3.5.1). When the
+// KDC additionally supplies a PA-SVR-REFERRAL-INFO element naming the true realm
+// (RFC 6806 Section 3.3.3.1) it is preferred, as it is the authoritative hint.
+func referralTargetRealm(rep *messages.TGSRep, requested messages.PrincipalName) (string, bool) {
+	realm, isReferral := referralRealmFromSName(rep.Ticket.SName, requested)
+	if !isReferral {
+		return "", false
+	}
+	if trueRealm, ok := svrReferralRealm(rep.PAData); ok {
+		return trueRealm, true
+	}
+	return realm, true
+}
+
+// referralRealmFromSName returns the referral target realm encoded in a returned
+// ticket's server name (krbtgt/REALM), or ok=false when the ticket is not a
+// referral TGT. If the caller explicitly requested that krbtgt principal, it is
+// treated as the requested service — not a referral.
+func referralRealmFromSName(ticketSName, requested messages.PrincipalName) (string, bool) {
+	if len(ticketSName.NameString) != 2 {
+		return "", false
+	}
+	if !strings.EqualFold(ticketSName.NameString[0], "krbtgt") {
+		return "", false
+	}
+	if principalNameEqualFold(ticketSName, requested) {
+		return "", false
+	}
+	return ticketSName.NameString[1], true
+}
+
+// svrReferralData is the PA-SVR-REFERRAL-INFO payload (PA-SVR-REFERRAL-DATA) of
+// RFC 6806 Appendix A / MS-KILE Section 2.2.1: the true realm a canonicalized
+// server principal belongs to, optionally with the referred name. Field order
+// mirrors the ASN.1 module (referred-name [1] precedes referred-realm [0]); in
+// practice only referred-realm is sent in TGS replies.
+type svrReferralData struct {
+	ReferredName  messages.PrincipalName `asn1:"explicit,tag:1,optional"`
+	ReferredRealm string                 `asn1:"explicit,tag:0,generalstring"`
+}
+
+// svrReferralRealm extracts the true realm from a PA-SVR-REFERRAL-INFO element in
+// the given PA-DATA list, if present.
+func svrReferralRealm(paList []messages.PAData) (string, bool) {
+	for _, pa := range paList {
+		if pa.PADataType != messages.PASvrReferralInfo {
+			continue
+		}
+		var d svrReferralData
+		if _, err := asn1.Unmarshal(pa.PADataValue, &d); err == nil && d.ReferredRealm != "" {
+			return strings.ToUpper(d.ReferredRealm), true
+		}
+	}
+	return "", false
+}
+
+// principalNameEqualFold reports whether two principal names have the same
+// components, compared case-insensitively (realm and service names are
+// case-insensitive in AD practice).
+func principalNameEqualFold(a, b messages.PrincipalName) bool {
+	if len(a.NameString) != len(b.NameString) {
+		return false
+	}
+	for i := range a.NameString {
+		if !strings.EqualFold(a.NameString[i], b.NameString[i]) {
+			return false
+		}
+	}
+	return true
+}

--- a/network/kerberos/v5/referral_test.go
+++ b/network/kerberos/v5/referral_test.go
@@ -1,0 +1,222 @@
+package kerberos
+
+import (
+	"encoding/asn1"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/messages"
+)
+
+// srvName is a small helper to build a service PrincipalName.
+func srvName(parts ...string) messages.PrincipalName {
+	return messages.PrincipalName{NameType: messages.NameTypeSRVInst, NameString: parts}
+}
+
+// TestReferralRealmFromSName covers the core referral-TGT detection: a returned
+// ticket whose server name is krbtgt/OTHER-REALM (differing from the requested
+// service) signals a cross-realm referral toward OTHER-REALM.
+func TestReferralRealmFromSName(t *testing.T) {
+	requested := srvName("cifs", "host.child.corp.local")
+
+	tests := []struct {
+		name      string
+		ticket    messages.PrincipalName
+		wantRealm string
+		wantRef   bool
+	}{
+		{
+			name:      "referral TGT to child realm",
+			ticket:    srvName("krbtgt", "CHILD.CORP.LOCAL"),
+			wantRealm: "CHILD.CORP.LOCAL",
+			wantRef:   true,
+		},
+		{
+			name:      "krbtgt case-insensitive service label",
+			ticket:    srvName("KrbTgt", "CHILD.CORP.LOCAL"),
+			wantRealm: "CHILD.CORP.LOCAL",
+			wantRef:   true,
+		},
+		{
+			name:    "actual service ticket is not a referral",
+			ticket:  srvName("cifs", "host.child.corp.local"),
+			wantRef: false,
+		},
+		{
+			name:    "single-component name is not a referral",
+			ticket:  messages.PrincipalName{NameType: messages.NameTypeSRVInst, NameString: []string{"krbtgt"}},
+			wantRef: false,
+		},
+		{
+			name:    "explicitly requested krbtgt is not a referral",
+			ticket:  srvName("krbtgt", "CORP.LOCAL"),
+			wantRef: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := requested
+			if tt.name == "explicitly requested krbtgt is not a referral" {
+				req = srvName("krbtgt", "CORP.LOCAL")
+			}
+			realm, isRef := referralRealmFromSName(tt.ticket, req)
+			if isRef != tt.wantRef {
+				t.Fatalf("isReferral = %v, want %v", isRef, tt.wantRef)
+			}
+			if isRef && realm != tt.wantRealm {
+				t.Errorf("realm = %q, want %q", realm, tt.wantRealm)
+			}
+		})
+	}
+}
+
+// TestReferralTargetRealmFromSyntheticTGSRep feeds a synthetic referral TGS-REP
+// (server name krbtgt/CHILD.CORP.LOCAL) and asserts the chase re-targets the
+// child realm.
+func TestReferralTargetRealmFromSyntheticTGSRep(t *testing.T) {
+	rep := &messages.TGSRep{
+		PVNO:    messages.KerberosV5,
+		MsgType: messages.MsgTypeTGSRep,
+		CRealm:  "CORP.LOCAL",
+		Ticket: messages.Ticket{
+			TktVno: messages.KerberosV5,
+			Realm:  "CORP.LOCAL", // issuing realm
+			SName:  srvName("krbtgt", "CHILD.CORP.LOCAL"),
+		},
+	}
+	requested := srvName("cifs", "host.child.corp.local")
+
+	realm, isRef := referralTargetRealm(rep, requested)
+	if !isRef {
+		t.Fatalf("expected referral to be detected")
+	}
+	if realm != "CHILD.CORP.LOCAL" {
+		t.Errorf("next realm = %q, want CHILD.CORP.LOCAL", realm)
+	}
+}
+
+// TestReferralTargetRealmPrefersSvrReferralInfo verifies that when the KDC also
+// supplies a PA-SVR-REFERRAL-INFO element, its referred-realm is used as the
+// authoritative next-realm hint.
+func TestReferralTargetRealmPrefersSvrReferralInfo(t *testing.T) {
+	rep := &messages.TGSRep{
+		PVNO:    messages.KerberosV5,
+		MsgType: messages.MsgTypeTGSRep,
+		Ticket: messages.Ticket{
+			SName: srvName("krbtgt", "INTERMEDIATE.CORP.LOCAL"),
+		},
+		PAData: []messages.PAData{
+			{PADataType: messages.PASvrReferralInfo, PADataValue: mustSvrReferralData(t, "TRUE.CORP.LOCAL")},
+		},
+	}
+	realm, isRef := referralTargetRealm(rep, srvName("cifs", "host.true.corp.local"))
+	if !isRef {
+		t.Fatalf("expected referral to be detected")
+	}
+	if realm != "TRUE.CORP.LOCAL" {
+		t.Errorf("next realm = %q, want TRUE.CORP.LOCAL (from PA-SVR-REFERRAL-INFO)", realm)
+	}
+}
+
+// TestSvrReferralRealm parses a PA-SVR-REFERRAL-DATA carrying only referred-realm
+// (the form Windows KDCs actually emit).
+func TestSvrReferralRealm(t *testing.T) {
+	pa := []messages.PAData{
+		{PADataType: messages.PAETypeInfo2, PADataValue: []byte{0x30, 0x00}},
+		{PADataType: messages.PASvrReferralInfo, PADataValue: mustSvrReferralData(t, "child.corp.local")},
+	}
+	realm, ok := svrReferralRealm(pa)
+	if !ok {
+		t.Fatalf("expected PA-SVR-REFERRAL-INFO to be found")
+	}
+	if realm != "CHILD.CORP.LOCAL" {
+		t.Errorf("realm = %q, want CHILD.CORP.LOCAL (uppercased)", realm)
+	}
+
+	if _, ok := svrReferralRealm(pa[:1]); ok {
+		t.Errorf("expected no referral info when the element is absent")
+	}
+}
+
+// TestResolveKDCForRealm exercises the resolution precedence: explicit overrides,
+// the client's home realm, and a custom resolver — none hardcoded.
+func TestResolveKDCForRealm(t *testing.T) {
+	c := NewClient("alice", "corp.local", "10.0.0.1")
+	c.WithRealmKDC("child.corp.local", "10.0.1.1")
+	c.WithKDCResolver(func(realm string) (string, error) {
+		return "resolver-" + realm, nil
+	})
+
+	// Explicit override (case-insensitive realm key).
+	if host, err := c.resolveKDCForRealm("CHILD.CORP.LOCAL"); err != nil || host != "10.0.1.1" {
+		t.Errorf("override: got (%q, %v), want (10.0.1.1, nil)", host, err)
+	}
+	// Home realm resolves to the configured KDC.
+	if host, err := c.resolveKDCForRealm("CORP.LOCAL"); err != nil || host != "10.0.0.1" {
+		t.Errorf("home realm: got (%q, %v), want (10.0.0.1, nil)", host, err)
+	}
+	// Unknown realm falls through to the custom resolver.
+	if host, err := c.resolveKDCForRealm("OTHER.LOCAL"); err != nil || host != "resolver-OTHER.LOCAL" {
+		t.Errorf("resolver: got (%q, %v), want (resolver-OTHER.LOCAL, nil)", host, err)
+	}
+}
+
+// TestPrincipalNameEqualFold checks the case-insensitive component comparison.
+func TestPrincipalNameEqualFold(t *testing.T) {
+	a := srvName("krbtgt", "CORP.LOCAL")
+	b := srvName("KRBTGT", "corp.local")
+	if !principalNameEqualFold(a, b) {
+		t.Errorf("expected case-insensitive equality")
+	}
+	if principalNameEqualFold(a, srvName("krbtgt", "OTHER.LOCAL")) {
+		t.Errorf("expected inequality for differing realm")
+	}
+	if principalNameEqualFold(a, srvName("krbtgt")) {
+		t.Errorf("expected inequality for differing length")
+	}
+}
+
+// mustSvrReferralData builds a DER PA-SVR-REFERRAL-DATA containing only the
+// referred-realm [0] (a GeneralString), matching what a KDC sends.
+func mustSvrReferralData(t *testing.T, realm string) []byte {
+	t.Helper()
+	realmElem, err := asn1.Marshal(messages.ExplicitGeneralString(0, realm))
+	if err != nil {
+		t.Fatalf("marshal referred-realm: %v", err)
+	}
+	seq, err := asn1.Marshal(asn1.RawValue{
+		Class:      asn1.ClassUniversal,
+		Tag:        asn1.TagSequence,
+		IsCompound: true,
+		Bytes:      realmElem,
+	})
+	if err != nil {
+		t.Fatalf("marshal SEQUENCE: %v", err)
+	}
+	return seq
+}
+
+// TestKRBErrorWrongRealmCRealm confirms a KRB-ERROR round-trips its CRealm field,
+// which the referral chase reads to recover from KDC_ERR_WRONG_REALM.
+func TestKRBErrorWrongRealmCRealm(t *testing.T) {
+	orig := &messages.KRBError{
+		ErrorCode: messages.ErrWrongRealm,
+		CRealm:    "TRUE.CORP.LOCAL",
+		Realm:     "CORP.LOCAL",
+		SName:     srvName("krbtgt", "CORP.LOCAL"),
+	}
+	wire, err := orig.Marshal()
+	if err != nil {
+		t.Fatalf("KRBError.Marshal: %v", err)
+	}
+	var decoded messages.KRBError
+	if _, err := decoded.Unmarshal(wire); err != nil {
+		t.Fatalf("KRBError.Unmarshal: %v", err)
+	}
+	if decoded.ErrorCode != messages.ErrWrongRealm {
+		t.Errorf("ErrorCode = %d, want %d", decoded.ErrorCode, messages.ErrWrongRealm)
+	}
+	if decoded.CRealm != "TRUE.CORP.LOCAL" {
+		t.Errorf("CRealm = %q, want TRUE.CORP.LOCAL", decoded.CRealm)
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #910`

### Root Cause
`GetTGS` (`network/kerberos/v5/client.go`) issued a single TGS-REQ toward the client's configured realm/KDC and returned whatever ticket came back. It had no notion of a referral TGT: when the KDC answered a request for a service in another domain with a cross-realm ticket-granting ticket (server name `krbtgt/OTHER-REALM`), that referral TGT was handed back to the caller as if it were the service ticket. There was no realm/KDC switch, no re-issue toward the target realm, and no `KDC_ERR_WRONG_REALM` handling, so service tickets in trusted domains/forests were unreachable even though `canonicalize` was already being requested.

### Fix Description
Adds a referral chase (`network/kerberos/v5/referral.go`). `GetTGS` now parses the SPN and delegates to `chaseServiceTicket`, which loops:

- Issue a TGS-REQ toward the current realm's KDC presenting the current TGT.
- If the returned ticket's server name is `krbtgt/NEXT-REALM` (differing from the requested service), it is a referral (RFC 6806 §7, MS-KILE §3.3.5.1): resolve `NEXT-REALM`'s KDC, present the referral TGT, re-issue — chaining until the actual service ticket is returned.
- `KDC_ERR_WRONG_REALM` is recovered by retrying with the corrected realm from the error's `crealm` field (RFC 4120 §3.3.3.1).
- `PA-SVR-REFERRAL-INFO` (`PA-SVR-REFERRAL-DATA.referred-realm`, RFC 6806 Appendix A) is parsed and preferred as the authoritative next-realm hint when present.
- Referral cycles (a realm's KDC revisited) and chains longer than `maxReferralHops` are rejected.

Target-realm KDC resolution is pluggable and not hardcoded: explicit `WithRealmKDC(realm, host)` overrides, then the client's own KDC for its home realm, then an optional `WithKDCResolver`, then DNS SRV `_kerberos._tcp.<realm>`. `buildAPReq` was refactored into `buildAPReqWith` so each hop can present a different (referral) TGT while the authenticator keeps the original client identity. `KRBError` gained a `CRealm` field (parsed and now also marshaled). Pure Go stdlib, no new dependencies.

### How Verified
- **Runtime (live single-domain DC, `TMP-W-2016.LOCAL`):** `GetTGT`, single-realm `GetTGS` for `cifs/tmp-w-2016.tmp-w-2016.local`, and a no-PAC Kerberoast all still succeed unchanged (AES256 session key, 1205-byte ticket). A packet capture confirms the single-realm TGS-REQ is byte-for-byte unchanged (body realm `TMP-W-2016.LOCAL`). Requests for a service in a non-existent realm and a foreign `@REALM` (with a KDC override) fail cleanly with a surfaced KRB error rather than hanging, panicking, or returning a bad ticket. A true multi-realm chase cannot be exercised in this single-domain lab (no trust), so the referral/realm-switch path is unit-proven.
- **Tests:** synthetic referral TGS-REPs and PA-SVR-REFERRAL-INFO payloads assert the correct next realm; resolver precedence, cycle rejection, WRONG_REALM `crealm` parsing, and case-insensitive principal comparison are covered.

### Test Coverage
- **Added:** `network/kerberos/v5/referral_test.go` — `TestReferralRealmFromSName`, `TestReferralTargetRealmFromSyntheticTGSRep`, `TestReferralTargetRealmPrefersSvrReferralInfo`, `TestSvrReferralRealm`, `TestResolveKDCForRealm`, `TestPrincipalNameEqualFold`, `TestKRBErrorWrongRealmCRealm`.

### Scope of Change
- **Files changed:** `network/kerberos/v5/referral.go` (new), `network/kerberos/v5/referral_test.go` (new), `network/kerberos/v5/client.go`, `network/kerberos/v5/messages/constants.go`, `network/kerberos/v5/messages/krberror.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Low blast radius: the single-realm path is functionally unchanged (a non-referral reply returns immediately), verified live. The new logic activates only when a KDC returns a referral TGT or WRONG_REALM. Safe to merge without staged rollout.