### PR TITLE
Add Kerberos KDC discovery and transport robustness (Fixes #911)

### DIFF
--- a/network/kerberos/v5/asreproast.go
+++ b/network/kerberos/v5/asreproast.go
@@ -70,7 +70,7 @@ func ASREPRoast(username, realm, kdcHost string) (*ASREPRoastResult, error) {
 		return nil, fmt.Errorf("asreproast: marshal AS-REQ: %w", err)
 	}
 
-	resp, err := kdcSend(kdcHost, defaultKDCPort, req_bytes)
+	resp, err := kdcSend(nil, kdcHost, defaultKDCPort, req_bytes)
 	if err != nil {
 		return nil, err
 	}

--- a/network/kerberos/v5/client.go
+++ b/network/kerberos/v5/client.go
@@ -5,6 +5,7 @@ import (
 	"encoding/asn1"
 	"encoding/binary"
 	"fmt"
+	"net"
 	"strings"
 	"time"
 
@@ -58,6 +59,18 @@ type KerberosClient struct {
 	// referral chase. It overrides the default DNS-SRV based resolution and is
 	// consulted after realmKDCs and the client's own home realm.
 	kdcResolver func(realm string) (string, error)
+
+	// resolver is the DNS resolver used for KDC discovery (SRV lookups) and for
+	// resolving KDC hostnames to A/AAAA addresses. nil uses net.DefaultResolver.
+	// A custom resolver (see WithResolver) lets callers direct Kerberos DNS at a
+	// specific server without touching the host resolver configuration.
+	resolver *net.Resolver
+
+	// clockOffset is added to the local clock when stamping outgoing requests. It
+	// starts at zero and is set from a KRB_AP_ERR_SKEW reply's server time so a
+	// subsequent retry falls inside the KDC's allowable skew window (RFC 4120
+	// Section 5.9.1). See now / applyClockSkew.
+	clockOffset time.Duration
 }
 
 // preloadedServiceTicket is a service ticket the client will hand back from
@@ -137,6 +150,37 @@ func (c *KerberosClient) WithAESKey(hexKey string) error {
 	return nil
 }
 
+// WithResolver installs the DNS resolver used for KDC discovery (SRV lookups)
+// and for resolving KDC hostnames to A/AAAA addresses. Passing nil restores the
+// default (net.DefaultResolver). This lets a caller point Kerberos DNS at a
+// specific server (e.g. the domain controller) without altering system-wide
+// resolver configuration. Returns the client to allow fluent chaining.
+func (c *KerberosClient) WithResolver(r *net.Resolver) *KerberosClient {
+	c.resolver = r
+	return c
+}
+
+// now returns the current UTC time adjusted by the negotiated clock offset. All
+// outgoing timestamps (PA-ENC-TIMESTAMP, Authenticator ctime) are stamped with
+// it so a KRB_AP_ERR_SKEW retry lands inside the KDC's skew window.
+func (c *KerberosClient) now() time.Time {
+	return time.Now().UTC().Add(c.clockOffset)
+}
+
+// applyClockSkew records the offset between the client's clock and the KDC's,
+// derived from the server time in a KRB_AP_ERR_SKEW reply, so a retry uses a
+// timestamp the KDC will accept (RFC 4120 Section 5.9.1). It reports false when
+// the error carries no usable server time, in which case no retry is warranted.
+func (c *KerberosClient) applyClockSkew(krbErr messages.KRBError) bool {
+	if krbErr.STime.IsZero() {
+		return false
+	}
+	// Offset the local clock forward/back to match the KDC. Reference the raw
+	// system clock (not c.now()) so repeated applications don't compound.
+	c.clockOffset = krbErr.STime.UTC().Sub(time.Now().UTC())
+	return true
+}
+
 // GetTGT requests a Ticket Granting Ticket from the KDC using the password
 // configured via WithPassword.
 //
@@ -153,22 +197,36 @@ func (c *KerberosClient) GetTGT() error {
 	// default salt. The KDC corrects both via PREAUTH_REQUIRED if needed.
 	etype := c.cred.SupportedETypes()[0]
 	salt := c.cred.DefaultSalt()
-	resp, nonce, err := c.sendASReqWithPreauth(etype, salt, nil)
-	if err != nil {
-		return err
-	}
 
-	// If the KDC requires a different etype/salt, it responds with PREAUTH_REQUIRED.
-	var krb_err messages.KRBError
-	if _, parse_err := krb_err.Unmarshal(resp); parse_err == nil {
-		if krb_err.ErrorCode == messages.ErrPreauthRequired {
-			etype, salt, s2k_params := c.pickETypeFromError(krb_err)
-			return c.doASReqWithPreauth(etype, salt, s2k_params)
+	// At most two attempts: the second only ever follows a KRB_AP_ERR_SKEW, after
+	// the clock offset has been applied (RFC 4120 Section 5.9.1).
+	for attempt := 0; attempt < 2; attempt++ {
+		resp, nonce, err := c.sendASReqWithPreauth(etype, salt, nil)
+		if err != nil {
+			return err
 		}
-		return fmt.Errorf("kerberos: KDC error %d: %s", krb_err.ErrorCode, krb_err.EText)
-	}
 
-	return c.processASRep(resp, etype, salt, nil, nonce)
+		var krb_err messages.KRBError
+		if _, parse_err := krb_err.Unmarshal(resp); parse_err == nil {
+			switch krb_err.ErrorCode {
+			case messages.ErrPreauthRequired:
+				// The KDC wants a different etype/salt; retry with the corrected
+				// values (that path applies its own skew retry).
+				etype, salt, s2k_params := c.pickETypeFromError(krb_err)
+				return c.doASReqWithPreauth(etype, salt, s2k_params)
+			case messages.ErrSkew:
+				if attempt == 0 && c.applyClockSkew(krb_err) {
+					continue // retry with the KDC-aligned clock
+				}
+				return fmt.Errorf("kerberos: KDC clock skew too great (error %d): %s", krb_err.ErrorCode, krb_err.EText)
+			default:
+				return fmt.Errorf("kerberos: KDC error %d: %s", krb_err.ErrorCode, krb_err.EText)
+			}
+		}
+
+		return c.processASRep(resp, etype, salt, nil, nonce)
+	}
+	return fmt.Errorf("kerberos: GetTGT: clock-skew retry exhausted")
 }
 
 // pacRequestPA returns a PA-PAC-REQUEST PAData element with include-pac = TRUE.
@@ -262,7 +320,7 @@ func (c *KerberosClient) sendASReq(pa_data []messages.PAData) ([]byte, int, erro
 				NameType:   messages.NameTypeSRVInst,
 				NameString: []string{"krbtgt", c.realm},
 			},
-			Till:  time.Now().UTC().Add(24 * time.Hour),
+			Till:  c.now().Add(24 * time.Hour),
 			Nonce: nonce,
 			EType: c.cred.SupportedETypes(),
 		},
@@ -272,11 +330,22 @@ func (c *KerberosClient) sendASReq(pa_data []messages.PAData) ([]byte, int, erro
 	if err != nil {
 		return nil, 0, fmt.Errorf("kerberos: marshal AS-REQ: %w", err)
 	}
-	resp, err := kdcSend(c.kdcHost, defaultKDCPort, req_bytes)
+	resp, err := c.sendToRealm(c.realm, req_bytes)
 	if err != nil {
 		return nil, 0, err
 	}
 	return resp, nonce, nil
+}
+
+// sendToRealm discovers the KDC endpoints serving realm (explicit config, custom
+// resolver, or DNS SRV) and sends msg, failing over across them (see
+// endpointsForRealm and kdcSendEndpoints).
+func (c *KerberosClient) sendToRealm(realm string, msg []byte) ([]byte, error) {
+	endpoints, err := c.endpointsForRealm(realm)
+	if err != nil {
+		return nil, err
+	}
+	return kdcSendEndpoints(c.resolver, endpoints, msg)
 }
 
 // pickETypeFromError extracts the preferred etype, salt and S2KParams from the
@@ -343,7 +412,7 @@ func (c *KerberosClient) sendASReqWithPreauth(etype int, salt string, s2k_params
 		return nil, 0, fmt.Errorf("kerberos: derive key: %w", err)
 	}
 
-	now := time.Now().UTC()
+	now := c.now()
 	ts := &messages.PAEncTSEnc{
 		PATimestamp: now,
 		PAUSec:      now.Nanosecond() / 1000,
@@ -371,19 +440,26 @@ func (c *KerberosClient) sendASReqWithPreauth(etype int, salt string, s2k_params
 	return c.sendASReq(pa_data)
 }
 
-// doASReqWithPreauth sends an AS-REQ with PA-ENC-TIMESTAMP and processes the AS-REP.
+// doASReqWithPreauth sends an AS-REQ with PA-ENC-TIMESTAMP and processes the
+// AS-REP. On KRB_AP_ERR_SKEW it applies the KDC clock offset and retries once.
 func (c *KerberosClient) doASReqWithPreauth(etype int, salt string, s2k_params []byte) error {
-	resp, nonce, err := c.sendASReqWithPreauth(etype, salt, s2k_params)
-	if err != nil {
-		return err
-	}
+	for attempt := 0; attempt < 2; attempt++ {
+		resp, nonce, err := c.sendASReqWithPreauth(etype, salt, s2k_params)
+		if err != nil {
+			return err
+		}
 
-	var krb_err messages.KRBError
-	if _, parse_err := krb_err.Unmarshal(resp); parse_err == nil {
-		return fmt.Errorf("kerberos: GetTGT failed (error %d): %s", krb_err.ErrorCode, krb_err.EText)
-	}
+		var krb_err messages.KRBError
+		if _, parse_err := krb_err.Unmarshal(resp); parse_err == nil {
+			if krb_err.ErrorCode == messages.ErrSkew && attempt == 0 && c.applyClockSkew(krb_err) {
+				continue // retry with the KDC-aligned clock
+			}
+			return fmt.Errorf("kerberos: GetTGT failed (error %d): %s", krb_err.ErrorCode, krb_err.EText)
+		}
 
-	return c.processASRep(resp, etype, salt, s2k_params, nonce)
+		return c.processASRep(resp, etype, salt, s2k_params, nonce)
+	}
+	return fmt.Errorf("kerberos: GetTGT: clock-skew retry exhausted")
 }
 
 // processASRep decrypts the AS-REP enc-part, verifies that the returned nonce
@@ -439,7 +515,7 @@ func (c *KerberosClient) buildAPReq() ([]byte, error) {
 // always identify the original client (they must match the crealm embedded in
 // the ticket, which stays the home realm across cross-realm referrals).
 func (c *KerberosClient) buildAPReqWith(tgt messages.Ticket, tgtRaw, sessionKey []byte, sessionEType int) ([]byte, error) {
-	now := time.Now().UTC()
+	now := c.now()
 	cusec := now.Nanosecond() / 1000
 
 	var seq_buf [4]byte

--- a/network/kerberos/v5/discovery.go
+++ b/network/kerberos/v5/discovery.go
@@ -1,0 +1,190 @@
+package kerberos
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"net"
+	"sort"
+	"strings"
+)
+
+// KDC discovery via DNS SRV records (RFC 4120 Section 7.2.3, RFC 2782).
+//
+// When no KDC host is configured for a realm, the client locates the realm's
+// KDCs through the SRV records "_kerberos._tcp.<realm>" and "_kerberos._udp.
+// <realm>". Records are ordered by RFC 2782 rules — ascending priority, then a
+// weighted shuffle within each priority — and tried in that order with failover
+// (see kdcSendEndpoints). The SRV target host and port are honoured, so a KDC
+// on a non-standard port is reached correctly.
+
+// endpointsForRealm returns the ordered list of KDC endpoints to contact for the
+// given realm. Resolution order mirrors resolveKDCForRealm — explicit
+// WithRealmKDC overrides, then the client's own configured KDC for its home
+// realm, then a custom WithKDCResolver, then DNS-SRV discovery — but yields the
+// full failover list rather than a single host. Nothing is hardcoded.
+func (c *KerberosClient) endpointsForRealm(realm string) ([]kdcEndpoint, error) {
+	realm = strings.ToUpper(realm)
+
+	if host, ok := c.realmKDCs[realm]; ok && host != "" {
+		return []kdcEndpoint{{host: host, port: defaultKDCPort}}, nil
+	}
+	if realm == strings.ToUpper(c.realm) && c.kdcHost != "" {
+		return []kdcEndpoint{{host: c.kdcHost, port: defaultKDCPort}}, nil
+	}
+	if c.kdcResolver != nil {
+		host, err := c.kdcResolver(realm)
+		if err != nil {
+			return nil, err
+		}
+		return []kdcEndpoint{{host: host, port: defaultKDCPort}}, nil
+	}
+	return c.discoverKDCEndpoints(realm)
+}
+
+// discoverKDCEndpoints resolves a realm's KDCs from DNS SRV records, querying
+// both the TCP and UDP service names and merging the results into a single
+// failover-ordered list (RFC 4120 Section 7.2.3). Both records normally point at
+// the same KDCs; the merge de-duplicates by host:port while preserving the
+// RFC 2782 ordering.
+func (c *KerberosClient) discoverKDCEndpoints(realm string) ([]kdcEndpoint, error) {
+	var records []*net.SRV
+	var firstErr error
+	for _, proto := range []string{"tcp", "udp"} {
+		recs, err := c.lookupKerberosSRV(proto, realm)
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		records = append(records, recs...)
+	}
+	if len(records) == 0 {
+		if firstErr != nil {
+			return nil, fmt.Errorf("kerberos: DNS SRV discovery for realm %q: %w", realm, firstErr)
+		}
+		return nil, fmt.Errorf("kerberos: no _kerberos SRV records for realm %q", realm)
+	}
+	endpoints := orderSRVEndpoints(records)
+	if len(endpoints) == 0 {
+		return nil, fmt.Errorf("kerberos: no usable _kerberos SRV records for realm %q", realm)
+	}
+	return endpoints, nil
+}
+
+// lookupKerberosSRV performs the "_kerberos._<proto>.<realm>" SRV lookup through
+// the client's resolver (nil uses net.DefaultResolver). Splitting it out lets
+// tests inject records without real DNS.
+func (c *KerberosClient) lookupKerberosSRV(proto, realm string) ([]*net.SRV, error) {
+	resolver := c.resolver
+	if resolver == nil {
+		resolver = net.DefaultResolver
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+	_, addrs, err := resolver.LookupSRV(ctx, "kerberos", proto, realm)
+	if err != nil {
+		return nil, fmt.Errorf("_kerberos._%s.%s: %w", proto, realm, err)
+	}
+	return addrs, nil
+}
+
+// orderSRVEndpoints turns raw SRV records into an ordered, de-duplicated list of
+// KDC endpoints following RFC 2782: records are grouped by priority (lowest
+// first) and, within each priority group, ordered by a weighted random shuffle
+// so higher-weight targets are more likely to be tried first while every target
+// still appears exactly once (giving deterministic failover coverage). A target
+// of "." (RFC 2782 "service decidedly not available") is dropped.
+func orderSRVEndpoints(records []*net.SRV) []kdcEndpoint {
+	return orderSRVEndpointsRand(records, rand.Float64)
+}
+
+// orderSRVEndpointsRand is orderSRVEndpoints with an injectable [0,1) random
+// source, so the weighted selection can be exercised deterministically in tests.
+func orderSRVEndpointsRand(records []*net.SRV, randFloat func() float64) []kdcEndpoint {
+	// Work on a copy so the caller's slice is not reordered.
+	recs := make([]*net.SRV, 0, len(records))
+	for _, r := range records {
+		if r == nil || r.Target == "." || r.Target == "" {
+			continue
+		}
+		recs = append(recs, r)
+	}
+
+	// Stable primary sort by priority (ascending). The weighted shuffle below
+	// only reorders within a priority group.
+	sort.SliceStable(recs, func(i, j int) bool {
+		return recs[i].Priority < recs[j].Priority
+	})
+
+	ordered := make([]*net.SRV, 0, len(recs))
+	for i := 0; i < len(recs); {
+		// Find the extent of the current priority group.
+		j := i
+		for j < len(recs) && recs[j].Priority == recs[i].Priority {
+			j++
+		}
+		ordered = append(ordered, weightedOrder(recs[i:j], randFloat)...)
+		i = j
+	}
+
+	// Map to endpoints, de-duplicating by host:port while preserving order.
+	seen := make(map[string]bool, len(ordered))
+	endpoints := make([]kdcEndpoint, 0, len(ordered))
+	for _, r := range ordered {
+		host := strings.TrimSuffix(r.Target, ".")
+		ep := kdcEndpoint{host: host, port: int(r.Port)}
+		key := ep.String()
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		endpoints = append(endpoints, ep)
+	}
+	return endpoints
+}
+
+// weightedOrder orders one priority group by the RFC 2782 weighting algorithm:
+// repeatedly pick a record with probability proportional to its weight, remove
+// it, and repeat, producing a full ordering (not just a first choice) so the
+// list doubles as a failover sequence. Records of weight 0 are still selectable
+// (with low probability, and always eventually), per the RFC.
+func weightedOrder(group []*net.SRV, randFloat func() float64) []*net.SRV {
+	remaining := make([]*net.SRV, len(group))
+	copy(remaining, group)
+
+	result := make([]*net.SRV, 0, len(group))
+	for len(remaining) > 0 {
+		total := 0
+		for _, r := range remaining {
+			total += int(r.Weight)
+		}
+
+		var pick int
+		if total == 0 {
+			// All weights zero: pick uniformly at random.
+			pick = int(randFloat() * float64(len(remaining)))
+			if pick >= len(remaining) {
+				pick = len(remaining) - 1
+			}
+		} else {
+			// RFC 2782: pick the record whose running weight sum first meets or
+			// exceeds a random point in [0,total).
+			target := randFloat() * float64(total)
+			running := 0.0
+			pick = len(remaining) - 1
+			for idx, r := range remaining {
+				running += float64(r.Weight)
+				if running >= target {
+					pick = idx
+					break
+				}
+			}
+		}
+
+		result = append(result, remaining[pick])
+		remaining = append(remaining[:pick], remaining[pick+1:]...)
+	}
+	return result
+}

--- a/network/kerberos/v5/discovery_test.go
+++ b/network/kerberos/v5/discovery_test.go
@@ -1,0 +1,166 @@
+package kerberos
+
+import (
+	"net"
+	"testing"
+)
+
+// seqRandFloat returns a deterministic [0,1) "random" source that walks a fixed
+// sequence, so weighted SRV selection can be exercised reproducibly.
+func seqRandFloat(values ...float64) func() float64 {
+	i := 0
+	return func() float64 {
+		v := values[i%len(values)]
+		i++
+		return v
+	}
+}
+
+// TestOrderSRVEndpointsPriority verifies that endpoints are ordered by ascending
+// priority: every record in a lower-priority group must precede every record in
+// a higher-priority group, regardless of weight.
+func TestOrderSRVEndpointsPriority(t *testing.T) {
+	records := []*net.SRV{
+		{Target: "kdc-hi.corp.local.", Port: 88, Priority: 20, Weight: 100},
+		{Target: "kdc-lo.corp.local.", Port: 88, Priority: 0, Weight: 0},
+		{Target: "kdc-mid.corp.local.", Port: 88, Priority: 10, Weight: 50},
+	}
+	got := orderSRVEndpointsRand(records, seqRandFloat(0.5))
+	wantOrder := []string{"kdc-lo.corp.local", "kdc-mid.corp.local", "kdc-hi.corp.local"}
+	if len(got) != len(wantOrder) {
+		t.Fatalf("got %d endpoints, want %d: %v", len(got), len(wantOrder), got)
+	}
+	for i, host := range wantOrder {
+		if got[i].host != host {
+			t.Errorf("endpoint[%d].host = %q, want %q (full: %v)", i, got[i].host, host, got)
+		}
+		if got[i].port != 88 {
+			t.Errorf("endpoint[%d].port = %d, want 88", i, got[i].port)
+		}
+	}
+}
+
+// TestOrderSRVEndpointsFailoverComplete verifies that within a priority group the
+// weighted shuffle still yields every target exactly once, so the list is a
+// complete failover sequence.
+func TestOrderSRVEndpointsFailoverComplete(t *testing.T) {
+	records := []*net.SRV{
+		{Target: "a.corp.local.", Port: 88, Priority: 0, Weight: 10},
+		{Target: "b.corp.local.", Port: 88, Priority: 0, Weight: 20},
+		{Target: "c.corp.local.", Port: 88, Priority: 0, Weight: 30},
+	}
+	got := orderSRVEndpointsRand(records, seqRandFloat(0.1, 0.9, 0.5, 0.2))
+	if len(got) != 3 {
+		t.Fatalf("got %d endpoints, want 3: %v", len(got), got)
+	}
+	seen := map[string]int{}
+	for _, ep := range got {
+		seen[ep.host]++
+	}
+	for _, host := range []string{"a.corp.local", "b.corp.local", "c.corp.local"} {
+		if seen[host] != 1 {
+			t.Errorf("host %q appeared %d times, want exactly 1 (full: %v)", host, seen[host], got)
+		}
+	}
+}
+
+// TestOrderSRVEndpointsWeightPreference verifies the RFC 2782 weighting: with a
+// random point that falls inside the first record's weight span, that record is
+// picked first even when it is not first in the input slice.
+func TestOrderSRVEndpointsWeightPreference(t *testing.T) {
+	records := []*net.SRV{
+		{Target: "heavy.corp.local.", Port: 88, Priority: 0, Weight: 90},
+		{Target: "light.corp.local.", Port: 88, Priority: 0, Weight: 10},
+	}
+	// target = 0.05*100 = 5 -> falls within heavy's [0,90) span -> heavy first.
+	got := orderSRVEndpointsRand(records, seqRandFloat(0.05, 0.5))
+	if got[0].host != "heavy.corp.local" {
+		t.Errorf("first endpoint = %q, want heavy.corp.local (higher weight)", got[0].host)
+	}
+
+	// A point past heavy's span selects light first.
+	got = orderSRVEndpointsRand(records, seqRandFloat(0.95, 0.5))
+	if got[0].host != "light.corp.local" {
+		t.Errorf("first endpoint = %q, want light.corp.local", got[0].host)
+	}
+}
+
+// TestOrderSRVEndpointsDropsNullTarget verifies the RFC 2782 "." target (service
+// explicitly not available) and empty targets are dropped.
+func TestOrderSRVEndpointsDropsNullTarget(t *testing.T) {
+	records := []*net.SRV{
+		{Target: ".", Port: 0, Priority: 0, Weight: 0},
+		{Target: "", Port: 0, Priority: 0, Weight: 0},
+		{Target: "real.corp.local.", Port: 88, Priority: 0, Weight: 0},
+	}
+	got := orderSRVEndpointsRand(records, seqRandFloat(0.5))
+	if len(got) != 1 || got[0].host != "real.corp.local" {
+		t.Fatalf("got %v, want single real.corp.local endpoint", got)
+	}
+}
+
+// TestOrderSRVEndpointsDedup verifies duplicate host:port pairs (e.g. the same
+// KDC advertised under both _tcp and _udp) collapse to one entry.
+func TestOrderSRVEndpointsDedup(t *testing.T) {
+	records := []*net.SRV{
+		{Target: "kdc.corp.local.", Port: 88, Priority: 0, Weight: 0},
+		{Target: "kdc.corp.local.", Port: 88, Priority: 0, Weight: 0},
+		{Target: "kdc.corp.local.", Port: 8888, Priority: 0, Weight: 0},
+	}
+	got := orderSRVEndpointsRand(records, seqRandFloat(0.5, 0.5, 0.5))
+	if len(got) != 2 {
+		t.Fatalf("got %d endpoints, want 2 (dedup by host:port): %v", len(got), got)
+	}
+}
+
+// TestEndpointsForRealmPrecedence checks the resolution order used before any
+// DNS SRV discovery: explicit WithRealmKDC, then the home realm's configured
+// KDC, then a custom resolver — all yielding the standard port 88.
+func TestEndpointsForRealmPrecedence(t *testing.T) {
+	c := NewClient("alice", "corp.local", "10.0.0.1")
+	c.WithRealmKDC("child.corp.local", "10.0.1.1")
+	c.WithKDCResolver(func(realm string) (string, error) { return "resolver-" + realm, nil })
+
+	cases := []struct{ realm, wantHost string }{
+		{"CHILD.CORP.LOCAL", "10.0.1.1"},        // explicit override
+		{"CORP.LOCAL", "10.0.0.1"},              // home realm
+		{"OTHER.LOCAL", "resolver-OTHER.LOCAL"}, // custom resolver
+	}
+	for _, tc := range cases {
+		eps, err := c.endpointsForRealm(tc.realm)
+		if err != nil {
+			t.Fatalf("endpointsForRealm(%q): %v", tc.realm, err)
+		}
+		if len(eps) != 1 || eps[0].host != tc.wantHost || eps[0].port != defaultKDCPort {
+			t.Errorf("endpointsForRealm(%q) = %v, want single %s:%d", tc.realm, eps, tc.wantHost, defaultKDCPort)
+		}
+	}
+}
+
+// TestKDCSendEndpointsFailover verifies transport failover: dialing a closed
+// port on the first endpoint fails, and kdcSendEndpoints moves on to the next.
+// (Both point at closed ports so no live KDC is required; the assertion is that
+// every endpoint is attempted and the aggregate error names the count.)
+func TestKDCSendEndpointsFailover(t *testing.T) {
+	// Two endpoints on the loopback with almost-certainly-closed high ports.
+	endpoints := []kdcEndpoint{
+		{host: "127.0.0.1", port: 1},
+		{host: "127.0.0.1", port: 2},
+	}
+	_, err := kdcSendEndpoints(nil, endpoints, []byte{0x00})
+	if err == nil {
+		t.Fatal("expected failure when all endpoints are unreachable")
+	}
+	// The error should report that all endpoints were tried.
+	if got := err.Error(); got == "" {
+		t.Fatal("expected a descriptive aggregate error")
+	}
+}
+
+// TestKDCSendEndpointsEmpty verifies an empty endpoint list is a clean error, not
+// a panic.
+func TestKDCSendEndpointsEmpty(t *testing.T) {
+	if _, err := kdcSendEndpoints(nil, nil, []byte{0x00}); err == nil {
+		t.Fatal("expected error for empty endpoint list")
+	}
+}

--- a/network/kerberos/v5/messages/constants.go
+++ b/network/kerberos/v5/messages/constants.go
@@ -38,6 +38,8 @@ const (
 	ErrCPrincipalUnknown = iana.ErrCPrincipalUnknown
 	ErrSPrincipalUnknown = iana.ErrSPrincipalUnknown
 	ErrPreauthRequired   = iana.ErrPreauthRequired
+	ErrSkew              = iana.ErrSkew
+	ErrResponseTooBig    = iana.ErrResponseTooBig
 	ErrWrongRealm        = iana.ErrWrongRealm
 
 	APOptionUseSessionKey = iana.APOptionUseSessionKey

--- a/network/kerberos/v5/referral.go
+++ b/network/kerberos/v5/referral.go
@@ -3,7 +3,6 @@ package kerberos
 import (
 	"encoding/asn1"
 	"fmt"
-	"net"
 	"strings"
 	"time"
 
@@ -38,37 +37,18 @@ func (c *KerberosClient) WithKDCResolver(fn func(realm string) (string, error)) 
 	return c
 }
 
-// resolveKDCForRealm returns the KDC host to contact for the given realm during
-// referral chasing. Resolution order: explicit WithRealmKDC overrides, then the
-// client's own configured KDC for its home realm, then a custom resolver, then
-// DNS-SRV discovery. Nothing is hardcoded.
+// resolveKDCForRealm returns the primary KDC host to contact for the given realm
+// during referral chasing. Resolution order: explicit WithRealmKDC overrides,
+// then the client's own configured KDC for its home realm, then a custom
+// resolver, then DNS-SRV discovery (see endpointsForRealm). The full failover
+// list is available via endpointsForRealm; this helper exposes just the first
+// (highest-priority) host for callers that want a single name.
 func (c *KerberosClient) resolveKDCForRealm(realm string) (string, error) {
-	realm = strings.ToUpper(realm)
-
-	if host, ok := c.realmKDCs[realm]; ok && host != "" {
-		return host, nil
-	}
-	if realm == strings.ToUpper(c.realm) && c.kdcHost != "" {
-		return c.kdcHost, nil
-	}
-	if c.kdcResolver != nil {
-		return c.kdcResolver(realm)
-	}
-	return discoverKDCViaDNS(realm)
-}
-
-// discoverKDCViaDNS resolves a KDC host for realm via the RFC 4120 Section 7.2.3
-// DNS SRV record "_kerberos._tcp.<realm>". Only the target host is used; the
-// standard Kerberos port (88) is applied by the transport layer.
-func discoverKDCViaDNS(realm string) (string, error) {
-	_, addrs, err := net.LookupSRV("kerberos", "tcp", realm)
+	endpoints, err := c.endpointsForRealm(realm)
 	if err != nil {
-		return "", fmt.Errorf("kerberos: DNS SRV lookup _kerberos._tcp.%s: %w", realm, err)
+		return "", err
 	}
-	if len(addrs) == 0 {
-		return "", fmt.Errorf("kerberos: no _kerberos._tcp.%s SRV records", realm)
-	}
-	return strings.TrimSuffix(addrs[0].Target, "."), nil
+	return endpoints[0].host, nil
 }
 
 // chaseServiceTicket obtains a service ticket for sname, following any
@@ -89,9 +69,13 @@ func (c *KerberosClient) chaseServiceTicket(sname messages.PrincipalName, includ
 	sessionKey := c.sessionKey
 	sessionEType := c.sessionEType
 
-	kdcHost := c.kdcHost
 	// bodyRealm is the KDC-REQ-BODY realm — the realm whose KDC we are asking.
 	bodyRealm := c.realm
+	// endpoints are the failover-ordered KDCs serving bodyRealm.
+	endpoints, err := c.endpointsForRealm(bodyRealm)
+	if err != nil {
+		return messages.Ticket{}, nil, nil, fmt.Errorf("kerberos: resolve KDC for realm %q: %w", bodyRealm, err)
+	}
 
 	// Realms whose KDC we have already presented a TGT to, to detect referral
 	// cycles (an authority realm must not be revisited).
@@ -101,9 +85,11 @@ func (c *KerberosClient) chaseServiceTicket(sname messages.PrincipalName, includ
 	// from visited so the follow-up referral toward the corrected realm is not
 	// itself mistaken for a cycle.
 	wrongRealmTried := map[string]bool{}
+	// skewRetried guards the single KRB_AP_ERR_SKEW retry.
+	skewRetried := false
 
 	for hop := 0; hop < maxReferralHops; hop++ {
-		rep, encRep, krbErr, err := c.tgsExchange(bodyRealm, kdcHost, sname, includePAC, tgt, tgtRaw, sessionKey, sessionEType)
+		rep, encRep, krbErr, err := c.tgsExchange(bodyRealm, endpoints, sname, includePAC, tgt, tgtRaw, sessionKey, sessionEType)
 		if err != nil {
 			return messages.Ticket{}, nil, nil, err
 		}
@@ -120,6 +106,12 @@ func (c *KerberosClient) chaseServiceTicket(sname messages.PrincipalName, includ
 					continue
 				}
 			}
+			// KRB_AP_ERR_SKEW: align our clock to the KDC's and retry the same hop
+			// once (RFC 4120 Section 5.9.1).
+			if krbErr.ErrorCode == messages.ErrSkew && !skewRetried && c.applyClockSkew(*krbErr) {
+				skewRetried = true
+				continue
+			}
 			return messages.Ticket{}, nil, nil, fmt.Errorf("kerberos: TGS error %d: %s", krbErr.ErrorCode, krbErr.EText)
 		}
 
@@ -133,7 +125,7 @@ func (c *KerberosClient) chaseServiceTicket(sname messages.PrincipalName, includ
 		if visited[nextRealm] {
 			return messages.Ticket{}, nil, nil, fmt.Errorf("kerberos: cross-realm referral cycle detected at realm %q", nextRealm)
 		}
-		nextKDC, err := c.resolveKDCForRealm(nextRealm)
+		nextEndpoints, err := c.endpointsForRealm(nextRealm)
 		if err != nil {
 			return messages.Ticket{}, nil, nil, fmt.Errorf("kerberos: resolve KDC for referral realm %q: %w", nextRealm, err)
 		}
@@ -141,7 +133,7 @@ func (c *KerberosClient) chaseServiceTicket(sname messages.PrincipalName, includ
 		// Advance to the next realm, presenting the referral TGT there.
 		visited[nextRealm] = true
 		bodyRealm = nextRealm
-		kdcHost = nextKDC
+		endpoints = nextEndpoints
 		tgt = rep.Ticket
 		tgtRaw = rep.TicketRaw
 		sessionKey = encRep.Key.KeyValue
@@ -151,13 +143,15 @@ func (c *KerberosClient) chaseServiceTicket(sname messages.PrincipalName, includ
 	return messages.Ticket{}, nil, nil, fmt.Errorf("kerberos: too many cross-realm referrals (>%d) chasing %s", maxReferralHops, strings.Join(sname.NameString, "/"))
 }
 
-// tgsExchange performs a single TGS-REQ/REP round-trip against kdcHost, using
-// bodyRealm as the KDC-REQ-BODY realm and presenting the supplied ticket-granting
-// ticket. It returns the parsed TGS-REP with its decrypted enc-part on success.
-// If the KDC answers with a KRB-ERROR it is returned as *messages.KRBError (with
-// a nil error) so the caller can react to WRONG_REALM.
+// tgsExchange performs a single TGS-REQ/REP round-trip against the given KDC
+// endpoints (failing over across them), using bodyRealm as the KDC-REQ-BODY
+// realm and presenting the supplied ticket-granting ticket. It returns the
+// parsed TGS-REP with its decrypted enc-part on success. If the KDC answers with
+// a KRB-ERROR it is returned as *messages.KRBError (with a nil error) so the
+// caller can react to WRONG_REALM or KRB_AP_ERR_SKEW.
 func (c *KerberosClient) tgsExchange(
-	bodyRealm, kdcHost string,
+	bodyRealm string,
+	endpoints []kdcEndpoint,
 	sname messages.PrincipalName,
 	includePAC bool,
 	tgt messages.Ticket, tgtRaw, sessionKey []byte, sessionEType int,
@@ -185,7 +179,7 @@ func (c *KerberosClient) tgsExchange(
 			KDCOptions: kdcOptionsForTGSReq(),
 			Realm:      bodyRealm,
 			SName:      sname,
-			Till:       time.Now().UTC().Add(24 * time.Hour),
+			Till:       c.now().Add(24 * time.Hour),
 			Nonce:      nonce,
 			EType:      c.serviceTicketETypes(),
 		},
@@ -195,7 +189,7 @@ func (c *KerberosClient) tgsExchange(
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("kerberos: marshal TGS-REQ: %w", err)
 	}
-	resp, err := kdcSend(kdcHost, defaultKDCPort, tgsReqBytes)
+	resp, err := kdcSendEndpoints(c.resolver, endpoints, tgsReqBytes)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/network/kerberos/v5/s4u.go
+++ b/network/kerberos/v5/s4u.go
@@ -70,7 +70,7 @@ func (c *KerberosClient) S4U2Self(impersonateUser, impersonateRealm string) (mes
 			KDCOptions: kdcOptionsForTGSReq(),
 			Realm:      c.realm,
 			SName:      self,
-			Till:       time.Now().UTC().Add(24 * time.Hour),
+			Till:       c.now().Add(24 * time.Hour),
 			Nonce:      nonce,
 			EType: []int{
 				messages.ETypeAES256CTSHMACSHA196,
@@ -84,7 +84,7 @@ func (c *KerberosClient) S4U2Self(impersonateUser, impersonateRealm string) (mes
 	if err != nil {
 		return messages.Ticket{}, nil, nil, fmt.Errorf("kerberos: marshal S4U2Self TGS-REQ: %w", err)
 	}
-	resp, err := kdcSend(c.kdcHost, defaultKDCPort, tgsReqBytes)
+	resp, err := c.sendToRealm(c.realm, tgsReqBytes)
 	if err != nil {
 		return messages.Ticket{}, nil, nil, err
 	}
@@ -164,7 +164,7 @@ func (c *KerberosClient) S4U2Proxy(targetSPN string, s4u2selfTicketRaw []byte) (
 			),
 			Realm: c.realm,
 			SName: sname,
-			Till:  time.Now().UTC().Add(24 * time.Hour),
+			Till:  c.now().Add(24 * time.Hour),
 			Nonce: nonce,
 			EType: []int{
 				messages.ETypeAES256CTSHMACSHA196,
@@ -179,7 +179,7 @@ func (c *KerberosClient) S4U2Proxy(targetSPN string, s4u2selfTicketRaw []byte) (
 	if err != nil {
 		return messages.Ticket{}, nil, nil, fmt.Errorf("kerberos: marshal S4U2Proxy TGS-REQ: %w", err)
 	}
-	resp, err := kdcSend(c.kdcHost, defaultKDCPort, tgsReqBytes)
+	resp, err := c.sendToRealm(c.realm, tgsReqBytes)
 	if err != nil {
 		return messages.Ticket{}, nil, nil, err
 	}

--- a/network/kerberos/v5/skew_test.go
+++ b/network/kerberos/v5/skew_test.go
@@ -1,0 +1,76 @@
+package kerberos
+
+import (
+	"testing"
+	"time"
+
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/messages"
+)
+
+// TestApplyClockSkewForward verifies that when the KDC clock is ahead of the
+// client, the computed offset shifts the client's now() to match the KDC within
+// a small tolerance.
+func TestApplyClockSkewForward(t *testing.T) {
+	c := NewClient("alice", "corp.local", "10.0.0.1")
+
+	// KDC reports a time 10 minutes ahead of ours.
+	serverTime := time.Now().UTC().Add(10 * time.Minute)
+	if !c.applyClockSkew(messages.KRBError{STime: serverTime}) {
+		t.Fatal("applyClockSkew returned false for a valid server time")
+	}
+
+	drift := c.now().Sub(serverTime)
+	if drift < -2*time.Second || drift > 2*time.Second {
+		t.Errorf("after skew correction now()=%v drifts %v from server time %v, want ~0",
+			c.now(), drift, serverTime)
+	}
+	// The offset must be roughly +10 minutes.
+	if c.clockOffset < 9*time.Minute || c.clockOffset > 11*time.Minute {
+		t.Errorf("clockOffset = %v, want ~10m", c.clockOffset)
+	}
+}
+
+// TestApplyClockSkewBackward covers a KDC that is behind the client.
+func TestApplyClockSkewBackward(t *testing.T) {
+	c := NewClient("alice", "corp.local", "10.0.0.1")
+	serverTime := time.Now().UTC().Add(-7 * time.Minute)
+	if !c.applyClockSkew(messages.KRBError{STime: serverTime}) {
+		t.Fatal("applyClockSkew returned false")
+	}
+	if c.clockOffset > -6*time.Minute || c.clockOffset < -8*time.Minute {
+		t.Errorf("clockOffset = %v, want ~-7m", c.clockOffset)
+	}
+	drift := c.now().Sub(serverTime)
+	if drift < -2*time.Second || drift > 2*time.Second {
+		t.Errorf("now() drifts %v from server time, want ~0", drift)
+	}
+}
+
+// TestApplyClockSkewNoServerTime verifies a KRB-ERROR without a server time is
+// not actionable (no retry warranted).
+func TestApplyClockSkewNoServerTime(t *testing.T) {
+	c := NewClient("alice", "corp.local", "10.0.0.1")
+	if c.applyClockSkew(messages.KRBError{}) {
+		t.Error("applyClockSkew should return false when STime is zero")
+	}
+	if c.clockOffset != 0 {
+		t.Errorf("clockOffset = %v, want 0 (unchanged)", c.clockOffset)
+	}
+}
+
+// TestClockSkewNotCompounded verifies applying skew twice does not accumulate:
+// the offset is always measured from the raw system clock, so a second identical
+// correction yields the same offset.
+func TestClockSkewNotCompounded(t *testing.T) {
+	c := NewClient("alice", "corp.local", "10.0.0.1")
+	serverTime := time.Now().UTC().Add(5 * time.Minute)
+
+	c.applyClockSkew(messages.KRBError{STime: serverTime})
+	first := c.clockOffset
+	c.applyClockSkew(messages.KRBError{STime: serverTime})
+	second := c.clockOffset
+
+	if diff := first - second; diff < -2*time.Second || diff > 2*time.Second {
+		t.Errorf("offset compounded: first=%v second=%v", first, second)
+	}
+}

--- a/network/kerberos/v5/transport.go
+++ b/network/kerberos/v5/transport.go
@@ -4,11 +4,15 @@
 package kerberos
 
 import (
+	"context"
 	"encoding/binary"
 	"fmt"
 	"io"
 	"net"
+	"strconv"
 	"time"
+
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/messages"
 )
 
 // defaultKDCPort is the standard Kerberos port.
@@ -24,24 +28,144 @@ const udpMaxSize = 1400
 // krbErrorTag is the APPLICATION[30] tag byte that identifies a KRB-ERROR message.
 const krbErrorTag = 0x7e
 
-// kdcSend sends a Kerberos message to the KDC.
-// It tries UDP first for small messages, then falls back to TCP.
-// If UDP returns a KRB-ERROR, TCP is always attempted — Windows KDCs sometimes
-// return stale or protocol-level errors over UDP even when TCP would succeed.
-// UDP has no length prefix; TCP uses the RFC 4120 4-byte big-endian prefix.
-func kdcSend(kdc_host string, kdc_port int, msg []byte) ([]byte, error) {
+// kdcEndpoint is a single candidate KDC: a host (name or IP literal) and the
+// port to reach it on. Discovery (DNS SRV) and explicit configuration both
+// produce these; the transport fails over across a list of them in order.
+type kdcEndpoint struct {
+	host string
+	port int
+}
+
+// String renders the endpoint as host:port for diagnostics.
+func (e kdcEndpoint) String() string {
+	return net.JoinHostPort(e.host, strconv.Itoa(e.port))
+}
+
+// kdcSendEndpoints sends msg to the first KDC endpoint that answers, failing over
+// across the list in order. Failover is triggered only by transport-level errors
+// (DNS failure, connection refused, timeout); a KDC that answers with a
+// KRB-ERROR has still "answered" and that reply is returned to the caller — the
+// next endpoint is not tried, because a protocol error (e.g. PREAUTH_REQUIRED)
+// would be identical from every replica.
+func kdcSendEndpoints(resolver *net.Resolver, endpoints []kdcEndpoint, msg []byte) ([]byte, error) {
+	if len(endpoints) == 0 {
+		return nil, fmt.Errorf("kerberos: no KDC endpoints to contact")
+	}
+	var lastErr error
+	for _, ep := range endpoints {
+		resp, err := kdcSend(resolver, ep.host, ep.port, msg)
+		if err == nil {
+			return resp, nil
+		}
+		lastErr = fmt.Errorf("kerberos: KDC %s: %w", ep, err)
+	}
+	return nil, fmt.Errorf("kerberos: all %d KDC endpoint(s) failed, last error: %w", len(endpoints), lastErr)
+}
+
+// kdcSend sends a Kerberos message to a single KDC host, resolving it to one or
+// more IP addresses (A and AAAA — IPv4 and IPv6) and trying each until one
+// answers. For each address it tries UDP first for small messages, then falls
+// back to TCP.
+//
+// TCP is attempted when the UDP datagram fails, comes back empty, or carries a
+// KRB-ERROR — most importantly KRB_ERR_RESPONSE_TOO_BIG, the KDC's explicit
+// signal that its answer did not fit a datagram and must be retried over TCP
+// (RFC 4120 Section 7.2.1). Windows KDCs also occasionally return stale or
+// protocol-level errors over UDP that succeed over TCP, so any UDP KRB-ERROR
+// prompts a TCP retry. UDP has no length prefix; TCP uses the RFC 4120 4-byte
+// big-endian prefix.
+func kdcSend(resolver *net.Resolver, kdc_host string, kdc_port int, msg []byte) ([]byte, error) {
+	addrs, err := resolveKDCAddrs(resolver, kdc_host)
+	if err != nil {
+		return nil, err
+	}
+	var lastErr error
+	for _, addr := range addrs {
+		resp, err := kdcSendAddr(addr, kdc_port, msg)
+		if err == nil {
+			return resp, nil
+		}
+		lastErr = err
+	}
+	return nil, lastErr
+}
+
+// kdcSendAddr sends msg to a single already-resolved IP address, applying the
+// UDP-first / TCP-fallback policy described on kdcSend.
+func kdcSendAddr(ip string, kdc_port int, msg []byte) ([]byte, error) {
 	if len(msg) <= udpMaxSize {
-		resp, err := kdcSendUDP(kdc_host, kdc_port, msg)
-		if err == nil && len(resp) > 0 && resp[0] != krbErrorTag {
+		resp, err := kdcSendUDP(ip, kdc_port, msg)
+		if !shouldRetryOverTCP(resp, err) {
 			return resp, nil
 		}
 	}
-	return kdcSendTCP(kdc_host, kdc_port, msg)
+	return kdcSendTCP(ip, kdc_port, msg)
+}
+
+// shouldRetryOverTCP decides, from a UDP attempt's result, whether the request
+// must be re-sent over TCP. It is true when UDP failed outright, returned an
+// empty datagram, or the KDC answered with a KRB-ERROR (in particular
+// KRB_ERR_RESPONSE_TOO_BIG, RFC 4120 Section 7.2.1). It is factored out so the
+// UDP→TCP decision can be unit-tested without a live KDC.
+func shouldRetryOverTCP(udpResp []byte, udpErr error) bool {
+	if udpErr != nil || len(udpResp) == 0 {
+		return true
+	}
+	return udpResp[0] == krbErrorTag
+}
+
+// responseTooBigOverUDP reports whether a reply is a KRB-ERROR carrying
+// KRB_ERR_RESPONSE_TOO_BIG (RFC 4120 Section 7.2.1) — the KDC's explicit signal
+// that the datagram answer did not fit and the request must be retried over TCP.
+func responseTooBigOverUDP(resp []byte) bool {
+	code, ok := krbErrorCode(resp)
+	return ok && code == messages.ErrResponseTooBig
+}
+
+// krbErrorCode returns the error code of a KRB-ERROR reply, or ok=false when the
+// bytes are not a KRB-ERROR (e.g. an AS-REP/TGS-REP).
+func krbErrorCode(resp []byte) (int, bool) {
+	if len(resp) == 0 || resp[0] != krbErrorTag {
+		return 0, false
+	}
+	var krbErr messages.KRBError
+	if _, err := krbErr.Unmarshal(resp); err != nil {
+		return 0, false
+	}
+	return krbErr.ErrorCode, true
+}
+
+// resolveKDCAddrs resolves a KDC host to a list of IP-literal dial targets. An
+// input that is already an IP literal is returned unchanged. Hostnames are
+// resolved through the supplied resolver (nil uses net.DefaultResolver),
+// returning both IPv4 (A) and IPv6 (AAAA) addresses so either family can be
+// reached.
+func resolveKDCAddrs(resolver *net.Resolver, host string) ([]string, error) {
+	if ip := net.ParseIP(host); ip != nil {
+		return []string{host}, nil
+	}
+	if resolver == nil {
+		resolver = net.DefaultResolver
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+	ipAddrs, err := resolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return nil, fmt.Errorf("kerberos: resolve KDC host %q: %w", host, err)
+	}
+	if len(ipAddrs) == 0 {
+		return nil, fmt.Errorf("kerberos: KDC host %q resolved to no addresses", host)
+	}
+	addrs := make([]string, 0, len(ipAddrs))
+	for _, ia := range ipAddrs {
+		addrs = append(addrs, ia.IP.String())
+	}
+	return addrs, nil
 }
 
 // kdcSendUDP sends msg over UDP and returns the raw response (no length prefix).
 func kdcSendUDP(kdc_host string, kdc_port int, msg []byte) ([]byte, error) {
-	addr, err := net.ResolveUDPAddr("udp", net.JoinHostPort(kdc_host, fmt.Sprintf("%d", kdc_port)))
+	addr, err := net.ResolveUDPAddr("udp", net.JoinHostPort(kdc_host, strconv.Itoa(kdc_port)))
 	if err != nil {
 		return nil, err
 	}
@@ -66,7 +190,7 @@ func kdcSendUDP(kdc_host string, kdc_port int, msg []byte) ([]byte, error) {
 
 // kdcSendTCP sends msg over TCP using the RFC 4120 4-byte big-endian length prefix.
 func kdcSendTCP(kdc_host string, kdc_port int, msg []byte) ([]byte, error) {
-	addr := net.JoinHostPort(kdc_host, fmt.Sprintf("%d", kdc_port))
+	addr := net.JoinHostPort(kdc_host, strconv.Itoa(kdc_port))
 	conn, err := net.DialTimeout("tcp", addr, defaultTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("kerberos: connect to KDC %s: %w", addr, err)

--- a/network/kerberos/v5/transport_test.go
+++ b/network/kerberos/v5/transport_test.go
@@ -1,0 +1,94 @@
+package kerberos
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/messages"
+)
+
+// mustMarshalKRBError builds a wire KRB-ERROR with the given error code.
+func mustMarshalKRBError(t *testing.T, code int) []byte {
+	t.Helper()
+	e := &messages.KRBError{
+		ErrorCode: code,
+		STime:     time.Now().UTC(),
+		Realm:     "CORP.LOCAL",
+		SName:     srvName("krbtgt", "CORP.LOCAL"),
+	}
+	b, err := e.Marshal()
+	if err != nil {
+		t.Fatalf("marshal KRB-ERROR: %v", err)
+	}
+	return b
+}
+
+// TestShouldRetryOverTCP covers the UDP->TCP decision: transport failure, empty
+// datagram, and any KRB-ERROR reply all force a TCP retry; a normal AS-REP does
+// not.
+func TestShouldRetryOverTCP(t *testing.T) {
+	krbErr := mustMarshalKRBError(t, messages.ErrResponseTooBig)
+
+	tests := []struct {
+		name string
+		resp []byte
+		err  error
+		want bool
+	}{
+		{"udp error", nil, errors.New("timeout"), true},
+		{"empty datagram", []byte{}, nil, true},
+		{"krb-error reply", krbErr, nil, true},
+		{"as-rep reply", []byte{0x6b, 0x01, 0x02}, nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldRetryOverTCP(tt.resp, tt.err); got != tt.want {
+				t.Errorf("shouldRetryOverTCP = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestResponseTooBigOverUDP verifies KRB_ERR_RESPONSE_TOO_BIG is recognised while
+// other KRB-ERRORs and non-error replies are not.
+func TestResponseTooBigOverUDP(t *testing.T) {
+	if !responseTooBigOverUDP(mustMarshalKRBError(t, messages.ErrResponseTooBig)) {
+		t.Error("expected RESPONSE_TOO_BIG to be recognised")
+	}
+	if responseTooBigOverUDP(mustMarshalKRBError(t, messages.ErrPreauthRequired)) {
+		t.Error("PREAUTH_REQUIRED must not be classed as RESPONSE_TOO_BIG")
+	}
+	if responseTooBigOverUDP([]byte{0x6b, 0x01, 0x02}) {
+		t.Error("a non-KRB-ERROR reply must not be classed as RESPONSE_TOO_BIG")
+	}
+	if responseTooBigOverUDP(nil) {
+		t.Error("empty reply must not be classed as RESPONSE_TOO_BIG")
+	}
+}
+
+// TestKRBErrorCode confirms the error code is extracted from a KRB-ERROR and that
+// non-error bytes report ok=false.
+func TestKRBErrorCode(t *testing.T) {
+	code, ok := krbErrorCode(mustMarshalKRBError(t, messages.ErrSkew))
+	if !ok || code != messages.ErrSkew {
+		t.Errorf("krbErrorCode = (%d, %v), want (%d, true)", code, ok, messages.ErrSkew)
+	}
+	if _, ok := krbErrorCode([]byte{0x6b, 0x01}); ok {
+		t.Error("expected ok=false for non-KRB-ERROR bytes")
+	}
+}
+
+// TestResolveKDCAddrsIPLiteral verifies IP literals (IPv4 and IPv6) pass through
+// without a DNS lookup, so no resolver is required.
+func TestResolveKDCAddrsIPLiteral(t *testing.T) {
+	for _, ip := range []string{"10.7.0.10", "::1", "fe80::1"} {
+		addrs, err := resolveKDCAddrs(nil, ip)
+		if err != nil {
+			t.Fatalf("resolveKDCAddrs(%q): %v", ip, err)
+		}
+		if len(addrs) != 1 || addrs[0] != ip {
+			t.Errorf("resolveKDCAddrs(%q) = %v, want [%q]", ip, addrs, ip)
+		}
+	}
+}

--- a/network/kerberos/v5/u2u.go
+++ b/network/kerberos/v5/u2u.go
@@ -40,7 +40,7 @@ func (c *KerberosClient) buildU2UTGSReq(targetUser, targetRealm string, targetTG
 			),
 			Realm: realm,
 			SName: sname,
-			Till:  time.Now().UTC().Add(24 * time.Hour),
+			Till:  c.now().Add(24 * time.Hour),
 			Nonce: nonce,
 			EType: []int{
 				messages.ETypeAES256CTSHMACSHA196,
@@ -83,7 +83,7 @@ func (c *KerberosClient) GetTGSU2U(targetUser, targetRealm string, targetTGTRaw 
 	if err != nil {
 		return messages.Ticket{}, nil, nil, fmt.Errorf("kerberos: marshal U2U TGS-REQ: %w", err)
 	}
-	resp, err := kdcSend(c.kdcHost, defaultKDCPort, tgsReqBytes)
+	resp, err := c.sendToRealm(c.realm, tgsReqBytes)
 	if err != nil {
 		return messages.Ticket{}, nil, nil, err
 	}


### PR DESCRIPTION
### Linked Issue
`Closes #911`

### Summary
Adds KDC discovery and transport-robustness to the native Kerberos v5 client (`network/kerberos/v5/`): DNS SRV discovery with failover, `KRB_AP_ERR_SKEW` clock-offset retry, `KRB_ERR_RESPONSE_TOO_BIG` UDP→TCP retry, and IPv4/IPv6 resolution. Builds on and unifies with the existing realm→KDC resolver (`WithRealmKDC`/`WithKDCResolver`).

### Fix Description
- **DNS SRV discovery** (`discovery.go`): when no KDC host is configured for a realm, the client resolves `_kerberos._tcp.<realm>` and `_kerberos._udp.<realm>`, merges and de-duplicates the records, and orders them per RFC 2782 — ascending priority, then a weighted shuffle within each priority group that still yields a complete failover sequence. The SRV target host and port are honoured (non-standard ports work). Resolution precedence is unchanged: explicit `WithRealmKDC`, then the home realm's configured KDC, then a custom `WithKDCResolver`, then SRV discovery.
- **Failover transport** (`transport.go`): `kdcSendEndpoints` tries each discovered endpoint in order, failing over only on transport-level errors (DNS failure, connection refused, timeout) — a KDC that answers with a KRB-ERROR has answered, so its reply is returned rather than masked by trying the next replica.
- **Response-too-big** (`transport.go`): each endpoint is resolved to its A/AAAA addresses; for each, UDP is tried first for small messages and the request is retried over TCP when UDP fails, returns empty, or the KDC answers with a KRB-ERROR — most importantly `KRB_ERR_RESPONSE_TOO_BIG` (RFC 4120 §7.2.1). The decision is factored into `shouldRetryOverTCP` for unit testing.
- **Clock-skew retry** (`client.go`, `referral.go`): all outgoing timestamps are stamped through `c.now()` = system clock + negotiated offset. On `KRB_AP_ERR_SKEW` the client derives the offset from the reply's server time (`applyClockSkew`) and retries once — in the AS path (`GetTGT`/`doASReqWithPreauth`) and the TGS/referral path (`chaseServiceTicket`). The offset is always measured from the raw clock so repeated corrections do not compound.
- **IPv6**: `resolveKDCAddrs` returns both A and AAAA addresses; IP literals (v4 and v6) pass through without a lookup. A new `WithResolver` lets callers direct Kerberos DNS at a specific server.

### How Verified
Live-validated against the lab DC (`10.7.0.10`, realm `TMP-W-2016.LOCAL`) with a `net.Resolver` pointed at the DC:
- **SRV discovery**: with no explicit KDC host, `_kerberos._tcp.TMP-W-2016.LOCAL` resolved to `TMP-W-2016.TMP-W-2016.local:88`; `GetTGT` and `GetTGS` succeeded through the discovered address.
- **Clock-skew retry**: a client pre-set 10 minutes fast triggered `KRB_AP_ERR_SKEW` (error 37) from the KDC; the client realigned its clock to the server time and retried to a TGT. A packet capture on the wire confirmed the sequence AS-REQ → error 37 (SKEW) → AS-REQ → AS-REP.
- **Response-too-big**: the same capture showed the Windows KDC returning error 52 (`KRB_ERR_RESPONSE_TOO_BIG`) over UDP and the client completing over TCP.
- **No regression**: baseline `GetTGT`/`GetTGS` unaffected.

### Test Coverage
**Added** (`go test ./network/kerberos/...` green):
- `discovery_test.go` — SRV priority ordering, weighted selection, full-failover completeness, null/`.`-target drop, host:port dedup, resolver precedence, transport failover, empty-endpoint error.
- `transport_test.go` — `shouldRetryOverTCP`, `responseTooBigOverUDP`, `krbErrorCode`, IPv4/IPv6 literal pass-through.
- `skew_test.go` — forward/backward offset computation, no-server-time no-op, non-compounding.

### Scope of Change
- **Files changed:** `discovery.go` (new), `transport.go`, `client.go`, `referral.go`, `s4u.go`, `u2u.go`, `asreproast.go`, `messages/constants.go`, plus tests.
- **Submodule pointer updated:** no
- **Behavioral changes outside the feature:** none — existing single-host usage (`NewClient(...)` with an explicit host) is unchanged.

### Risk and Rollout
Local to the Kerberos v5 client. Callers passing an explicit KDC host keep the previous single-endpoint behavior; discovery/failover only engages when no host is configured. Safe to merge.