### PR TITLE
Add LDAP SASL GSSAPI sign/seal security layer and channel binding (Fixes #912)

### DIFF
--- a/network/kerberos/v5/gssapi/gssapi.go
+++ b/network/kerberos/v5/gssapi/gssapi.go
@@ -68,6 +68,22 @@ func GSSChecksumValue(flags uint32, channelBindings []byte) []byte {
 	return out
 }
 
+// GSSChannelBindings marshals a gss_channel_bindings_struct (RFC 2744 §3.11) the
+// way MIT/Heimdal krb5 do when feeding it to the RFC 4121 §4.1.1 authenticator
+// checksum: little-endian initiator/acceptor address-type and address-length
+// fields (all empty here, so four zero uint32s) followed by the application-data
+// length and bytes. The returned buffer is what GSSChecksumValue MD5-hashes into
+// the checksum Bnd field. appData carries the channel-binding token itself, e.g.
+// "tls-server-end-point:" || certificate-hash for LDAP/GSSAPI over TLS.
+func GSSChannelBindings(appData []byte) []byte {
+	out := make([]byte, 16, 20+len(appData)) // initiator/acceptor addrtype+length = 0
+	l := make([]byte, 4)
+	binary.LittleEndian.PutUint32(l, uint32(len(appData)))
+	out = append(out, l...)
+	out = append(out, appData...)
+	return out
+}
+
 // WrapToken wraps a Kerberos message in the GSS-API InitialContextToken framing
 // (RFC 1964 §1.1): [APPLICATION 0] { kerberos5-OID, TOK_ID | krbMessage }.
 func WrapToken(tokID [2]byte, krbMessage []byte) ([]byte, error) {

--- a/network/kerberos/v5/gssapi/gssapi_test.go
+++ b/network/kerberos/v5/gssapi/gssapi_test.go
@@ -42,6 +42,33 @@ func TestGSSChecksumValue(t *testing.T) {
 	}
 }
 
+func TestGSSChannelBindings(t *testing.T) {
+	app := []byte("tls-server-end-point:hashbytes")
+	cb := GSSChannelBindings(app)
+
+	// 16 bytes of zeroed initiator/acceptor addrtype+length, then the LE
+	// application-data length, then the application data itself.
+	if len(cb) != 20+len(app) {
+		t.Fatalf("length = %d, want %d", len(cb), 20+len(app))
+	}
+	for i, b := range cb[:16] {
+		if b != 0 {
+			t.Errorf("byte %d of address block should be zero, got 0x%02x", i, b)
+		}
+	}
+	if got := binary.LittleEndian.Uint32(cb[16:20]); got != uint32(len(app)) {
+		t.Errorf("application-data length = %d, want %d", got, len(app))
+	}
+	if !bytes.Equal(cb[20:], app) {
+		t.Errorf("application data = %q, want %q", cb[20:], app)
+	}
+
+	// Empty bindings still carry the 16-byte address block and a zero length.
+	if got := GSSChannelBindings(nil); len(got) != 20 {
+		t.Errorf("empty bindings length = %d, want 20", len(got))
+	}
+}
+
 func TestWrapUnwrapToken(t *testing.T) {
 	msg := []byte("fake-krb-ap-req")
 	tok, err := WrapToken(TokIDAPReq, msg)

--- a/network/ldap/channel_binding.go
+++ b/network/ldap/channel_binding.go
@@ -1,0 +1,39 @@
+package ldap
+
+import (
+	"crypto/sha256"
+	"crypto/sha512"
+	"crypto/x509"
+)
+
+// tlsServerEndPointPrefix is the RFC 5929 §4 channel-binding type prefix that
+// precedes the certificate hash in the GSS-API application data.
+const tlsServerEndPointPrefix = "tls-server-end-point:"
+
+// tlsServerEndPointCBT builds the RFC 5929 "tls-server-end-point" channel-binding
+// token for an LDAPS server certificate: the ASCII prefix "tls-server-end-point:"
+// followed by the hash of the server's DER-encoded certificate. This is the
+// application-data component of the GSS-API channel bindings that Active Directory
+// validates for LDAP channel binding (a.k.a. EPA / "Extended Protection for
+// Authentication").
+func tlsServerEndPointCBT(cert *x509.Certificate) []byte {
+	return append([]byte(tlsServerEndPointPrefix), certificateHash(cert)...)
+}
+
+// certificateHash hashes a certificate's raw DER using the algorithm RFC 5929 §4.1
+// prescribes: the certificate's own signature hash, except that MD5 and SHA-1 (and
+// any unknown/unhashed signature) are upgraded to SHA-256.
+func certificateHash(cert *x509.Certificate) []byte {
+	switch cert.SignatureAlgorithm {
+	case x509.SHA384WithRSA, x509.ECDSAWithSHA384, x509.SHA384WithRSAPSS:
+		sum := sha512.Sum384(cert.Raw)
+		return sum[:]
+	case x509.SHA512WithRSA, x509.ECDSAWithSHA512, x509.SHA512WithRSAPSS:
+		sum := sha512.Sum512(cert.Raw)
+		return sum[:]
+	default:
+		// SHA-256 and, per RFC 5929, the MD5/SHA-1 and undefined cases.
+		sum := sha256.Sum256(cert.Raw)
+		return sum[:]
+	}
+}

--- a/network/ldap/kerberos_gssapi.go
+++ b/network/ldap/kerberos_gssapi.go
@@ -2,6 +2,7 @@ package ldap
 
 import (
 	"crypto/rand"
+	"encoding/binary"
 	"fmt"
 	"strings"
 
@@ -13,15 +14,42 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/messages"
 )
 
+// SASL GSSAPI security-layer bitmask (RFC 4752 §3.1): the server advertises the
+// OR of the layers it supports and the client selects exactly one bit.
+const (
+	saslLayerNone            byte = 0x01 // no security layer (auth only)
+	saslLayerIntegrity       byte = 0x02 // integrity: GSS_Wrap conf_flag = FALSE (sign)
+	saslLayerConfidentiality byte = 0x04 // confidentiality: GSS_Wrap conf_flag = TRUE (seal)
+)
+
+// saslClientMaxRecv is the maximum SASL buffer size the client advertises it can
+// receive (three octets, RFC 4752 §3.1). It matches the value Windows LDAP clients
+// send and comfortably holds large search responses.
+const saslClientMaxRecv = 0x00A00000
+
 // nativeGSSAPIClient implements go-ldap's ldap.GSSAPIClient interface using
 // Manticore's native, standard-library-only Kerberos + GSS-API stack, replacing
 // the previous gokrb5 dependency. It drives the RFC 4752 SASL GSSAPI handshake:
-// an AP-REQ (with mutual auth), the AP-REP, then the security-layer negotiation.
+// an AP-REQ (with mutual auth), the AP-REP, then the security-layer negotiation,
+// after which it can sign and/or seal subsequent LDAP PDUs.
 type nativeGSSAPIClient struct {
 	kc    *kerberos.KerberosClient
 	realm string
 	user  string
 	ctx   *gssapi.SecContext
+
+	// desiredLayer is the SASL security layer the client wants to negotiate
+	// (defaults to no security layer, preserving auth-only behaviour).
+	desiredLayer byte
+	// channelBindings is the marshalled GSS-API channel-bindings buffer to hash
+	// into the AP-REQ authenticator checksum (nil = GSS_C_NO_BINDINGS). It is set
+	// for LDAPS binds to carry the tls-server-end-point token.
+	channelBindings []byte
+
+	// negotiatedLayer and serverMaxSend record the outcome of NegotiateSaslAuth so
+	// the session can install the matching security layer on the connection.
+	negotiatedLayer byte
+	serverMaxSend   int
 }
 
 // newNativeGSSAPIClient builds a GSSAPI client and acquires a TGT for the given
@@ -40,7 +68,7 @@ func newNativeGSSAPIClient(kdc, realm string, creds *credentials.Credentials) (*
 	if err := kc.GetTGT(); err != nil {
 		return nil, fmt.Errorf("ldap gssapi: GetTGT: %w", err)
 	}
-	return &nativeGSSAPIClient{kc: kc, realm: strings.ToUpper(realm), user: user}, nil
+	return &nativeGSSAPIClient{kc: kc, realm: strings.ToUpper(realm), user: user, desiredLayer: saslLayerNone}, nil
 }
 
 // InitSecContext establishes the GSS security context. On the first call
@@ -66,15 +94,16 @@ func (g *nativeGSSAPIClient) InitSecContextWithOptions(target string, token []by
 			return nil, false, err
 		}
 		tok, ctx, err := gssapi.InitSecContext(gssapi.InitOptions{
-			TicketRaw:    ticketRaw,
-			SessionKey:   key,
-			SessionEType: ticket.EncPart.EType,
-			ClientName:   messages.PrincipalName{NameType: messages.NameTypePrincipal, NameString: []string{g.user}},
-			ClientRealm:  g.realm,
-			Flags:        gssapi.GSSMutualFlag | gssapi.GSSSequenceFlag | gssapi.GSSConfFlag | gssapi.GSSIntegFlag,
-			Mutual:       true,
-			SubKey:       subKey,
-			SubKeyEType:  ticket.EncPart.EType,
+			TicketRaw:       ticketRaw,
+			SessionKey:      key,
+			SessionEType:    ticket.EncPart.EType,
+			ClientName:      messages.PrincipalName{NameType: messages.NameTypePrincipal, NameString: []string{g.user}},
+			ClientRealm:     g.realm,
+			Flags:           gssapi.GSSMutualFlag | gssapi.GSSSequenceFlag | gssapi.GSSConfFlag | gssapi.GSSIntegFlag,
+			ChannelBindings: g.channelBindings,
+			Mutual:          true,
+			SubKey:          subKey,
+			SubKeyEType:     ticket.EncPart.EType,
 		})
 		if err != nil {
 			return nil, false, fmt.Errorf("ldap gssapi: InitSecContext: %w", err)
@@ -99,30 +128,86 @@ func (g *nativeGSSAPIClient) InitSecContextWithOptions(target string, token []by
 
 // NegotiateSaslAuth performs the RFC 4752 §3.1 final step: it GSS-unwraps the
 // server's security-layer offer (first octet = supported layers, next three =
-// max receive buffer), selects "no security layer", and returns a GSS-wrapped
-// (integrity-only) response carrying the selection and optional authzid.
+// max receive buffer), selects the client's desired layer among those offered,
+// and returns a GSS-wrapped (integrity-only, per RFC 4752) response carrying the
+// selected layer, the client's max receive buffer, and the optional authzid. The
+// negotiated layer and the server's max buffer are recorded so the session can
+// wrap subsequent PDUs accordingly.
 func (g *nativeGSSAPIClient) NegotiateSaslAuth(token []byte, authzid string) ([]byte, error) {
 	offer, _, err := g.ctx.Unwrap(token)
 	if err != nil {
 		return nil, fmt.Errorf("ldap gssapi: unwrap SASL offer: %w", err)
 	}
-	if len(offer) < 4 {
-		return nil, fmt.Errorf("ldap gssapi: short SASL offer (%d bytes)", len(offer))
+
+	resp, chosen, serverMax, err := selectSASLLayer(offer, g.desiredLayer, authzid)
+	if err != nil {
+		return nil, err
 	}
 
-	// Select "no security layer" (0x01) with a zero max buffer; append authzid.
-	resp := make([]byte, 4+len(authzid))
-	resp[0] = 0x01
-	copy(resp[4:], authzid)
-
+	// The RFC 4752 §3.1 response is always integrity-only (conf_flag = FALSE),
+	// regardless of the layer being selected.
 	out, err := g.ctx.Wrap(resp, false)
 	if err != nil {
 		return nil, fmt.Errorf("ldap gssapi: wrap SASL response: %w", err)
 	}
+	g.negotiatedLayer = chosen
+	g.serverMaxSend = serverMax
 	return out, nil
 }
 
-// DeleteSecContext releases the key material held by the client.
+// selectSASLLayer parses the RFC 4752 §3.1 server security-layer offer (first
+// octet = supported-layer bitmask, next three = the server's max receive buffer
+// in network byte order), picks the desired layer among those offered, and builds
+// the unwrapped client response (selected-layer octet, the client's own max
+// receive buffer, then the authzid). It returns the response, the chosen layer,
+// and the server's max buffer size. It is the pure, GSS-free core of the
+// negotiation so it can be unit-tested without a security context.
+func selectSASLLayer(offer []byte, desired byte, authzid string) (resp []byte, chosen byte, serverMax int, err error) {
+	if len(offer) < 4 {
+		return nil, 0, 0, fmt.Errorf("ldap gssapi: short SASL offer (%d bytes)", len(offer))
+	}
+	supported := offer[0]
+	serverMax = int(offer[1])<<16 | int(offer[2])<<8 | int(offer[3])
+
+	// The server always offers "no security layer"; default to it if unset.
+	chosen = desired
+	if chosen == 0 {
+		chosen = saslLayerNone
+	}
+	if supported&chosen == 0 {
+		return nil, 0, 0, fmt.Errorf("ldap gssapi: server does not offer requested security layer (offered 0x%02x, wanted 0x%02x)", supported, chosen)
+	}
+
+	resp = make([]byte, 4+len(authzid))
+	resp[0] = chosen
+	if chosen != saslLayerNone {
+		// Advertise the client's maximum receive buffer (three octets, network
+		// byte order); RFC 4752 requires it to be 0 when no layer is selected.
+		var b [4]byte
+		binary.BigEndian.PutUint32(b[:], uint32(saslClientMaxRecv))
+		copy(resp[1:4], b[1:4])
+	}
+	copy(resp[4:], authzid)
+	return resp, chosen, serverMax, nil
+}
+
+// securityLayer returns the saslCipher for the negotiated layer, or nil if the
+// bind negotiated no security layer (in which case the connection stays a
+// pass-through). It must be called after NegotiateSaslAuth.
+func (g *nativeGSSAPIClient) securityLayer() saslCipher {
+	if g.negotiatedLayer == 0 || g.negotiatedLayer == saslLayerNone {
+		return nil
+	}
+	return &gssSASLCipher{
+		ctx:  g.ctx,
+		seal: g.negotiatedLayer == saslLayerConfidentiality,
+		max:  g.serverMaxSend,
+	}
+}
+
+// DeleteSecContext releases the TGT key material held by the client. The
+// per-message security context (service-ticket / acceptor-subkey material) is
+// retained so an established SASL security layer keeps working after the bind.
 func (g *nativeGSSAPIClient) DeleteSecContext() error {
 	g.kc.Destroy()
 	return nil

--- a/network/ldap/kerberos_gssapi_test.go
+++ b/network/ldap/kerberos_gssapi_test.go
@@ -1,0 +1,135 @@
+package ldap
+
+import (
+	"bytes"
+	"crypto/x509"
+	"encoding/binary"
+	"testing"
+)
+
+// serverOffer builds an RFC 4752 §3.1 server security-layer offer: the supported
+// bitmask followed by the three-octet max receive buffer.
+func serverOffer(supported byte, maxBuf int) []byte {
+	var b [4]byte
+	binary.BigEndian.PutUint32(b[:], uint32(maxBuf))
+	return []byte{supported, b[1], b[2], b[3]}
+}
+
+func TestSelectSASLLayerParsesServerMax(t *testing.T) {
+	offer := serverOffer(saslLayerNone|saslLayerIntegrity|saslLayerConfidentiality, 0x00A00000)
+	_, chosen, serverMax, err := selectSASLLayer(offer, saslLayerConfidentiality, "")
+	if err != nil {
+		t.Fatalf("selectSASLLayer: %v", err)
+	}
+	if chosen != saslLayerConfidentiality {
+		t.Errorf("chosen = 0x%02x, want confidentiality 0x%02x", chosen, saslLayerConfidentiality)
+	}
+	if serverMax != 0x00A00000 {
+		t.Errorf("serverMax = %#x, want 0xA00000", serverMax)
+	}
+}
+
+func TestSelectSASLLayerResponseEncoding(t *testing.T) {
+	offer := serverOffer(saslLayerNone|saslLayerIntegrity|saslLayerConfidentiality, 0x100000)
+
+	// Integrity selected: response advertises the client max receive buffer.
+	resp, chosen, _, err := selectSASLLayer(offer, saslLayerIntegrity, "u@REALM")
+	if err != nil {
+		t.Fatalf("selectSASLLayer: %v", err)
+	}
+	if chosen != saslLayerIntegrity {
+		t.Fatalf("chosen = 0x%02x, want integrity", chosen)
+	}
+	if resp[0] != saslLayerIntegrity {
+		t.Errorf("response layer octet = 0x%02x, want 0x%02x", resp[0], saslLayerIntegrity)
+	}
+	gotMax := int(resp[1])<<16 | int(resp[2])<<8 | int(resp[3])
+	if gotMax != saslClientMaxRecv {
+		t.Errorf("client max recv = %#x, want %#x", gotMax, saslClientMaxRecv)
+	}
+	if string(resp[4:]) != "u@REALM" {
+		t.Errorf("authzid = %q, want %q", resp[4:], "u@REALM")
+	}
+}
+
+func TestSelectSASLLayerNoneZeroesMaxBuffer(t *testing.T) {
+	offer := serverOffer(saslLayerNone|saslLayerIntegrity, 0x100000)
+	resp, chosen, _, err := selectSASLLayer(offer, saslLayerNone, "")
+	if err != nil {
+		t.Fatalf("selectSASLLayer: %v", err)
+	}
+	if chosen != saslLayerNone {
+		t.Fatalf("chosen = 0x%02x, want none", chosen)
+	}
+	// RFC 4752: the max buffer field MUST be 0 when no security layer is selected.
+	if resp[1] != 0 || resp[2] != 0 || resp[3] != 0 {
+		t.Errorf("no-layer response must zero the max-buffer octets, got % x", resp[1:4])
+	}
+}
+
+func TestSelectSASLLayerDefaultsToNone(t *testing.T) {
+	offer := serverOffer(saslLayerNone|saslLayerIntegrity, 0x1000)
+	_, chosen, _, err := selectSASLLayer(offer, 0, "")
+	if err != nil {
+		t.Fatalf("selectSASLLayer: %v", err)
+	}
+	if chosen != saslLayerNone {
+		t.Errorf("unset desired layer should default to none, got 0x%02x", chosen)
+	}
+}
+
+func TestSelectSASLLayerRejectsUnofferedLayer(t *testing.T) {
+	// Server offers only integrity; requesting confidentiality must fail.
+	offer := serverOffer(saslLayerNone|saslLayerIntegrity, 0x1000)
+	if _, _, _, err := selectSASLLayer(offer, saslLayerConfidentiality, ""); err == nil {
+		t.Error("expected error when server does not offer the requested layer")
+	}
+}
+
+func TestSelectSASLLayerShortOffer(t *testing.T) {
+	if _, _, _, err := selectSASLLayer([]byte{0x01, 0x02}, saslLayerNone, ""); err == nil {
+		t.Error("expected error on a short (<4 byte) offer")
+	}
+}
+
+func TestTLSServerEndPointCBT(t *testing.T) {
+	// A minimal certificate with a SHA-256 signature: the CBT is
+	// "tls-server-end-point:" || SHA-256(cert.Raw).
+	cert := &x509.Certificate{
+		Raw:                []byte("dummy-der-bytes-for-hashing"),
+		SignatureAlgorithm: x509.SHA256WithRSA,
+	}
+	cbt := tlsServerEndPointCBT(cert)
+	if !bytes.HasPrefix(cbt, []byte(tlsServerEndPointPrefix)) {
+		t.Fatalf("CBT missing %q prefix: % x", tlsServerEndPointPrefix, cbt)
+	}
+	hash := cbt[len(tlsServerEndPointPrefix):]
+	if len(hash) != 32 {
+		t.Errorf("SHA-256 CBT hash length = %d, want 32", len(hash))
+	}
+	want := certificateHash(cert)
+	if !bytes.Equal(hash, want) {
+		t.Errorf("CBT hash does not match certificateHash")
+	}
+}
+
+func TestCertificateHashAlgorithmSelection(t *testing.T) {
+	raw := []byte("some-certificate-der")
+	cases := []struct {
+		alg    x509.SignatureAlgorithm
+		length int // RFC 5929: SHA-1/MD5 upgrade to SHA-256
+	}{
+		{x509.SHA1WithRSA, 32},
+		{x509.MD5WithRSA, 32},
+		{x509.SHA256WithRSA, 32},
+		{x509.SHA384WithRSA, 48},
+		{x509.SHA512WithRSA, 64},
+		{x509.ECDSAWithSHA384, 48},
+	}
+	for _, c := range cases {
+		cert := &x509.Certificate{Raw: raw, SignatureAlgorithm: c.alg}
+		if got := len(certificateHash(cert)); got != c.length {
+			t.Errorf("%v: hash length = %d, want %d", c.alg, got, c.length)
+		}
+	}
+}

--- a/network/ldap/saslconn.go
+++ b/network/ldap/saslconn.go
@@ -1,0 +1,172 @@
+package ldap
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+	"sync/atomic"
+	"time"
+
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/gssapi"
+)
+
+// gssWrapOverhead is a generous upper bound on the number of bytes a GSS-API
+// per-message (CFX/RC4) Wrap token adds to its plaintext: the 16-byte token
+// header, a cipher-block confounder, the trailing encrypted header, and the
+// checksum. Subtracting it from the peer's advertised maximum buffer size yields
+// a safe plaintext chunk size that never produces an over-long SASL buffer.
+const gssWrapOverhead = 128
+
+// saslConn wraps a network connection to apply the RFC 4752 SASL GSSAPI security
+// layer once it has been negotiated. Before activation it is a transparent
+// pass-through, so the plaintext SASL bind exchange flows unmodified. After
+// activate is called, every write is GSS-wrapped into a length-prefixed SASL
+// buffer and every read reassembles and GSS-unwraps such buffers, giving the LDAP
+// layer above a continuous plaintext byte stream (RFC 4752 §3.1 / RFC 2222 §3).
+type saslConn struct {
+	net.Conn
+
+	active atomic.Bool
+	cipher saslCipher
+
+	// readBuf holds plaintext recovered from the last unwrapped SASL buffer that
+	// has not yet been consumed by a Read.
+	readBuf []byte
+}
+
+// saslCipher wraps and unwraps the payload of a single SASL security-layer buffer.
+type saslCipher interface {
+	// wrap turns a plaintext chunk into the octets of one SASL buffer.
+	wrap(plaintext []byte) ([]byte, error)
+	// unwrap recovers the plaintext carried by one SASL buffer.
+	unwrap(buffer []byte) ([]byte, error)
+	// maxSend is the largest SASL buffer the peer will accept, or 0 for no limit.
+	maxSend() int
+}
+
+// gssSASLCipher is the production saslCipher: it wraps/unwraps SASL buffers with
+// GSS-API per-message tokens over an established Kerberos security context, using
+// confidentiality (seal) for the RFC 4752 confidentiality layer and integrity
+// only for the integrity layer.
+type gssSASLCipher struct {
+	ctx  *gssapi.SecContext
+	seal bool
+	max  int
+}
+
+func (c *gssSASLCipher) wrap(plaintext []byte) ([]byte, error) { return c.ctx.Wrap(plaintext, c.seal) }
+
+func (c *gssSASLCipher) unwrap(buffer []byte) ([]byte, error) {
+	pt, _, err := c.ctx.Unwrap(buffer)
+	return pt, err
+}
+
+func (c *gssSASLCipher) maxSend() int { return c.max }
+
+// newSASLConn wraps conn as a pass-through; call activate to switch on the
+// security layer once it has been negotiated during the bind.
+func newSASLConn(conn net.Conn) *saslConn {
+	return &saslConn{Conn: conn}
+}
+
+// activate switches the connection into SASL security-layer mode. It is called
+// after the GSSAPI bind has negotiated a layer, while the LDAP reader goroutine is
+// blocked in a pass-through Read; a zero read deadline nudges that blocked read so
+// it re-checks the active flag and switches to framed reads without disturbing the
+// LDAP layer.
+func (c *saslConn) activate(cipher saslCipher) {
+	c.cipher = cipher
+	c.active.Store(true)
+	// Interrupt any read currently blocked in pass-through mode so it notices the
+	// flag flip and resumes as a framed read.
+	_ = c.Conn.SetReadDeadline(time.Now())
+}
+
+// Write applies the SASL security layer to outgoing LDAP data once active,
+// splitting p into chunks small enough that each wrapped buffer fits the peer's
+// advertised maximum, and framing each as a 4-octet big-endian length followed by
+// the GSS-wrapped buffer. Before activation it writes through unchanged.
+func (c *saslConn) Write(p []byte) (int, error) {
+	if !c.active.Load() {
+		return c.Conn.Write(p)
+	}
+
+	chunk := len(p)
+	if max := c.cipher.maxSend(); max > gssWrapOverhead && max-gssWrapOverhead < chunk {
+		chunk = max - gssWrapOverhead
+	}
+
+	total := 0
+	for total < len(p) {
+		end := total + chunk
+		if end > len(p) {
+			end = len(p)
+		}
+		buf, err := c.cipher.wrap(p[total:end])
+		if err != nil {
+			return total, fmt.Errorf("ldap sasl: wrap: %w", err)
+		}
+		var hdr [4]byte
+		binary.BigEndian.PutUint32(hdr[:], uint32(len(buf)))
+		if _, err := c.Conn.Write(append(hdr[:], buf...)); err != nil {
+			return total, err
+		}
+		total = end
+	}
+	return total, nil
+}
+
+// Read reassembles the SASL security layer for incoming LDAP data once active,
+// reading one length-prefixed buffer at a time, GSS-unwrapping it, and returning
+// the recovered plaintext across as many Read calls as the caller needs. Before
+// activation it reads through unchanged; the pass-through path tolerates the read
+// deadline that activate uses to hand off cleanly.
+func (c *saslConn) Read(p []byte) (int, error) {
+	for {
+		if c.active.Load() {
+			return c.framedRead(p)
+		}
+		n, err := c.Conn.Read(p)
+		if err != nil {
+			if ne, ok := err.(net.Error); ok && ne.Timeout() {
+				// The deadline set by activate fired: clear it and re-check active.
+				_ = c.Conn.SetReadDeadline(time.Time{})
+				continue
+			}
+			return n, err
+		}
+		return n, nil
+	}
+}
+
+// framedRead serves plaintext from the current SASL buffer, reading and
+// unwrapping the next buffer from the wire when the pending plaintext is empty.
+func (c *saslConn) framedRead(p []byte) (int, error) {
+	if len(c.readBuf) == 0 {
+		// Clear any lingering deadline from the activation nudge before blocking.
+		_ = c.Conn.SetReadDeadline(time.Time{})
+
+		var hdr [4]byte
+		if _, err := io.ReadFull(c.Conn, hdr[:]); err != nil {
+			return 0, err
+		}
+		n := binary.BigEndian.Uint32(hdr[:])
+		if n == 0 {
+			return 0, nil
+		}
+		buf := make([]byte, n)
+		if _, err := io.ReadFull(c.Conn, buf); err != nil {
+			return 0, err
+		}
+		pt, err := c.cipher.unwrap(buf)
+		if err != nil {
+			return 0, fmt.Errorf("ldap sasl: unwrap: %w", err)
+		}
+		c.readBuf = pt
+	}
+
+	n := copy(p, c.readBuf)
+	c.readBuf = c.readBuf[n:]
+	return n, nil
+}

--- a/network/ldap/saslconn_test.go
+++ b/network/ldap/saslconn_test.go
@@ -1,0 +1,154 @@
+package ldap
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"net"
+	"testing"
+	"time"
+)
+
+// xorCipher is a reversible stand-in for the GSS-API per-message layer: it lets
+// the SASL framing (length prefixing, send-side chunking against maxSend, and
+// receive-side reassembly across reads) be exercised without a Kerberos context.
+type xorCipher struct{ max int }
+
+func (c xorCipher) transform(b []byte) []byte {
+	out := make([]byte, len(b))
+	for i := range b {
+		out[i] = b[i] ^ 0x5A
+	}
+	return out
+}
+func (c xorCipher) wrap(pt []byte) ([]byte, error)    { return c.transform(pt), nil }
+func (c xorCipher) unwrap(buf []byte) ([]byte, error) { return c.transform(buf), nil }
+func (c xorCipher) maxSend() int                      { return c.max }
+
+func TestSASLConnFramedRoundtrip(t *testing.T) {
+	// A max buffer just above the wrap overhead forces the send side to split a
+	// large LDAP PDU into several SASL buffers; the receive side must reassemble.
+	cipher := xorCipher{max: gssWrapOverhead + 72}
+	clientRaw, serverRaw := net.Pipe()
+
+	client := newSASLConn(clientRaw)
+	client.activate(cipher)
+	server := newSASLConn(serverRaw)
+	server.activate(cipher)
+
+	pdu := bytes.Repeat([]byte("LDAP-search-request-pdu;"), 40) // ~960 bytes
+
+	go func() {
+		if _, err := client.Write(pdu); err != nil {
+			t.Errorf("client write: %v", err)
+		}
+	}()
+
+	got := make([]byte, 0, len(pdu))
+	buf := make([]byte, 100) // small reads exercise plaintext spanning Read calls
+	for len(got) < len(pdu) {
+		n, err := server.Read(buf)
+		if err != nil {
+			t.Fatalf("server read: %v", err)
+		}
+		got = append(got, buf[:n]...)
+	}
+	if !bytes.Equal(got, pdu) {
+		t.Errorf("reassembled PDU mismatch: got %d bytes, want %d", len(got), len(pdu))
+	}
+}
+
+func TestSASLConnWireIsWrapped(t *testing.T) {
+	// The bytes on the wire must be length-prefixed and transformed (not the
+	// plaintext), confirming the security layer actually engaged.
+	cipher := xorCipher{max: 0} // 0 = no send limit: one buffer
+	clientRaw, wireRaw := net.Pipe()
+	client := newSASLConn(clientRaw)
+	client.activate(cipher)
+
+	pdu := []byte("plaintext-ldap-pdu")
+	go func() {
+		_, _ = client.Write(pdu)
+	}()
+
+	var hdr [4]byte
+	if _, err := io.ReadFull(wireRaw, hdr[:]); err != nil {
+		t.Fatalf("read length prefix: %v", err)
+	}
+	n := binary.BigEndian.Uint32(hdr[:])
+	body := make([]byte, n)
+	if _, err := io.ReadFull(wireRaw, body); err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if int(n) != len(pdu) {
+		t.Errorf("buffer length = %d, want %d", n, len(pdu))
+	}
+	if bytes.Equal(body, pdu) {
+		t.Error("wire buffer carries plaintext; security layer did not wrap it")
+	}
+	if !bytes.Equal(cipher.transform(body), pdu) {
+		t.Error("wire buffer does not unwrap back to the plaintext PDU")
+	}
+}
+
+func TestSASLConnPassThroughBeforeActivate(t *testing.T) {
+	clientRaw, serverRaw := net.Pipe()
+	client := newSASLConn(clientRaw)
+
+	msg := []byte("cleartext-bind-exchange")
+	go func() {
+		_, _ = client.Write(msg)
+	}()
+
+	buf := make([]byte, len(msg))
+	if _, err := io.ReadFull(serverRaw, buf); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !bytes.Equal(buf, msg) {
+		t.Errorf("pass-through altered bytes: got %q, want %q", buf, msg)
+	}
+}
+
+func TestSASLConnActivateNudgesBlockedRead(t *testing.T) {
+	// A read blocked in pass-through mode must hand off to the framed path once
+	// activate flips the flag, without surfacing the deadline as an error.
+	cipher := xorCipher{max: 0}
+	localRaw, remoteRaw := net.Pipe()
+	local := newSASLConn(localRaw)
+
+	type result struct {
+		data []byte
+		err  error
+	}
+	done := make(chan result, 1)
+	go func() {
+		buf := make([]byte, 64)
+		n, err := local.Read(buf) // blocks in pass-through until activate + a frame
+		done <- result{append([]byte{}, buf[:n]...), err}
+	}()
+
+	// Let the reader block, then activate (which nudges it via a read deadline).
+	time.Sleep(50 * time.Millisecond)
+	local.activate(cipher)
+
+	// Now send a framed, wrapped buffer from the peer.
+	pdu := []byte("post-activation-pdu")
+	go func() {
+		var hdr [4]byte
+		wrapped := cipher.transform(pdu)
+		binary.BigEndian.PutUint32(hdr[:], uint32(len(wrapped)))
+		_, _ = remoteRaw.Write(append(hdr[:], wrapped...))
+	}()
+
+	select {
+	case r := <-done:
+		if r.err != nil {
+			t.Fatalf("read after activation errored: %v", r.err)
+		}
+		if !bytes.Equal(r.data, pdu) {
+			t.Errorf("read after activation = %q, want %q", r.data, pdu)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("read did not complete after activation")
+	}
+}

--- a/network/ldap/session.go
+++ b/network/ldap/session.go
@@ -2,8 +2,11 @@ package ldap
 
 import (
 	"crypto/tls"
+	"crypto/x509"
 	"fmt"
+	"net"
 
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/gssapi"
 	"github.com/TheManticoreProject/Manticore/windows/credentials"
 
 	"github.com/go-ldap/ldap/v3"
@@ -47,6 +50,14 @@ type Session struct {
 	// LDAPS connections. It defaults to true (verification disabled) to preserve
 	// the historical behavior; use SetTLSSkipVerify to enable verification.
 	tlsSkipVerify bool
+	// gssapiLayer is the SASL GSSAPI security layer to negotiate for Kerberos
+	// binds (RFC 4752 §3.1). It defaults to no security layer (auth only); use
+	// SetGSSAPISigning / SetGSSAPISealing to request integrity or confidentiality.
+	gssapiLayer byte
+	// gssClient retains the GSSAPI client for the lifetime of the session so the
+	// negotiated per-message security context survives past the bind and is torn
+	// down on Close.
+	gssClient *nativeGSSAPIClient
 }
 
 // NewSession creates a new LDAP session with the provided configuration and credentials.
@@ -91,8 +102,25 @@ func NewSession(host string, port int, credentials *credentials.Credentials, use
 	s.usekerberos = usekerberos
 	// Preserve the historical default of not verifying the server certificate.
 	s.tlsSkipVerify = true
+	// Preserve the historical default of an auth-only GSSAPI bind (no ongoing
+	// sign/seal); callers opt into a security layer explicitly.
+	s.gssapiLayer = saslLayerNone
 
 	return s, nil
+}
+
+// SetGSSAPISigning requests the RFC 4752 integrity (signing) security layer for
+// Kerberos binds: after the bind, every LDAP PDU is GSS-signed and its integrity
+// verified on receipt. It must be called before Connect.
+func (s *Session) SetGSSAPISigning() {
+	s.gssapiLayer = saslLayerIntegrity
+}
+
+// SetGSSAPISealing requests the RFC 4752 confidentiality (sealing) security layer
+// for Kerberos binds: after the bind, every LDAP PDU is GSS-encrypted (which also
+// implies integrity). It must be called before Connect.
+func (s *Session) SetGSSAPISealing() {
+	s.gssapiLayer = saslLayerConfidentiality
 }
 
 // SetTLSSkipVerify controls whether the server certificate is verified when
@@ -130,44 +158,56 @@ func (s *Session) SetTLSSkipVerify(skip bool) {
 //		logger.Warn(fmt.Sprintf("Error connecting to LDAP server: %s", err))
 //	}
 func (s *Session) Connect() (bool, error) {
-	// Set up LDAP connection
-	var ldapConnection *ldap.Conn
 	var err error
 
-	// Connect to remote server
+	// Dial the transport ourselves and interpose a SASL wrapper connection so a
+	// negotiated GSSAPI security layer (sign/seal) can be applied to every LDAP
+	// PDU after the bind. The server certificate is captured for LDAPS so a
+	// tls-server-end-point channel-binding token can be sent during the bind.
+	var rawConn net.Conn
+	var serverCert *x509.Certificate
 	if s.useldaps {
-		// LDAPS connection
-		ldapConnection, err = ldap.DialURL(
-			fmt.Sprintf("ldaps://%s:%d", s.host, s.port),
-			ldap.DialWithTLSConfig(
-				&tls.Config{
-					InsecureSkipVerify: s.tlsSkipVerify,
-				},
-			),
+		tlsConn, derr := tls.DialWithDialer(
+			&net.Dialer{Timeout: ldap.DefaultTimeout},
+			"tcp",
+			fmt.Sprintf("%s:%d", s.host, s.port),
+			&tls.Config{InsecureSkipVerify: s.tlsSkipVerify},
 		)
-		if err != nil {
-			return false, fmt.Errorf("error connecting to LDAPS server: %s", err)
+		if derr != nil {
+			return false, fmt.Errorf("error connecting to LDAPS server: %s", derr)
 		}
+		if certs := tlsConn.ConnectionState().PeerCertificates; len(certs) > 0 {
+			serverCert = certs[0]
+		}
+		rawConn = tlsConn
 	} else {
-		// Regular LDAP connection
-		ldapConnection, err = ldap.DialURL(
-			fmt.Sprintf("ldap://%s:%d", s.host, s.port),
-		)
+		rawConn, err = net.DialTimeout("tcp", fmt.Sprintf("%s:%d", s.host, s.port), ldap.DefaultTimeout)
 		if err != nil {
 			return false, fmt.Errorf("error connecting to LDAP server: %s", err)
 		}
 	}
+
+	sc := newSASLConn(rawConn)
+	ldapConnection := ldap.NewConn(sc, s.useldaps)
+	ldapConnection.Start()
 
 	// Use Kerberos
 	if s.usekerberos {
 		// Native (stdlib-only) GSSAPI SASL bind; the DC is both the LDAP server
 		// and the KDC. Realm is the credentials' domain (upper-cased by the client).
 		servicePrincipalName := fmt.Sprintf("ldap/%s", s.host)
-		gssClient, err := newNativeGSSAPIClient(s.host, s.credentials.GetDomain(), s.credentials)
-		if err != nil {
-			return false, fmt.Errorf("error initializing Kerberos: %w", err)
+		gssClient, gerr := newNativeGSSAPIClient(s.host, s.credentials.GetDomain(), s.credentials)
+		if gerr != nil {
+			ldapConnection.Close()
+			return false, fmt.Errorf("error initializing Kerberos: %w", gerr)
 		}
-		defer gssClient.DeleteSecContext()
+		gssClient.desiredLayer = s.gssapiLayer
+		// Over LDAPS, bind the GSSAPI context to the TLS channel (RFC 5929
+		// tls-server-end-point), which AD requires when channel binding is enforced.
+		if serverCert != nil {
+			gssClient.channelBindings = gssapi.GSSChannelBindings(tlsServerEndPointCBT(serverCert))
+		}
+		s.gssClient = gssClient
 
 		err = ldapConnection.GSSAPIBindRequest(
 			gssClient,
@@ -177,7 +217,15 @@ func (s *Session) Connect() (bool, error) {
 			},
 		)
 		if err != nil {
+			ldapConnection.Close()
 			return false, fmt.Errorf("error binding with Kerberos: %w", err)
+		}
+
+		// Install the negotiated security layer on the connection so subsequent
+		// PDUs are signed and/or sealed. A no-security-layer bind leaves the
+		// connection as a transparent pass-through.
+		if cipher := gssClient.securityLayer(); cipher != nil {
+			sc.activate(cipher)
 		}
 	} else {
 		// Use NTLM authentification or null auth
@@ -252,5 +300,9 @@ func (s *Session) ReConnect() (bool, error) {
 func (s *Session) Close() {
 	if s.connection != nil {
 		s.connection.Close()
+	}
+	if s.gssClient != nil {
+		s.gssClient.DeleteSecContext()
+		s.gssClient = nil
 	}
 }


### PR DESCRIPTION
### Linked Issue
`Closes #912`

### Root Cause
The native GSSAPI SASL bind (`network/ldap/kerberos_gssapi.go`) hard-selected RFC 4752 "no security layer" (0x01) with a zero max buffer. It therefore authenticated but never negotiated integrity or confidentiality, and go-ldap's `GSSAPIClient` interface has no `Wrap`/`Unwrap` hooks, so no component applied a security layer to post-bind LDAP PDUs. Against a DC that requires LDAP signing/sealing this is a functional gap.

### Fix Description
Implements the RFC 4752 §3.1 security layer end to end:

- **Negotiation** (`kerberos_gssapi.go`): `NegotiateSaslAuth` now GSS-unwraps the server offer, and `selectSASLLayer` (pure, unit-tested) parses the supported-layer bitmask + 3-octet max buffer, selects the requested layer, and builds the client reply (chosen layer octet, client max receive buffer, authzid). The reply is GSS-wrapped with `conf_flag=FALSE` per the RFC. `Session` exposes `SetGSSAPISigning` / `SetGSSAPISealing`; the default stays an auth-only no-layer bind.
- **Transport** (`saslconn.go`): since go-ldap does not apply the layer itself, a `saslConn` wraps the socket. It is a transparent pass-through during the bind, then (once `activate` is called) frames each outbound PDU as `uint32 length || GSS_Wrap(chunk)` — sealed for confidentiality, signed for integrity — chunked under the peer's advertised max, and reassembles/unwraps inbound buffers into a continuous plaintext stream. `activate` nudges the LDAP reader goroutine (blocked in a pass-through read) via a read deadline so the hand-off is clean.
- **Channel binding** (`channel_binding.go`, `gssapi.GSSChannelBindings`): builds the RFC 5929 `tls-server-end-point` token (certificate hash, SHA-1/MD5 upgraded to SHA-256) and marshals it into the GSS-API channel bindings fed to the AP-REQ authenticator checksum for LDAPS binds.

### How Verified
- **Live (plaintext 389, Windows Server 2016 DC):** no-layer bind (regression), integrity/sign bind, and confidentiality/seal bind each performed a `namingContexts` read and a subtree user search that round-tripped successfully.
- **Wire capture contrast:** for the no-layer and sign binds the search filter/attributes appear in cleartext on the wire (`objectCategory`, `sAMAccountName` visible) — RFC 4752 integrity keeps plaintext with an added GSS token; for the seal bind the same tokens are absent (payload encrypted). This confirms sign and seal are distinct and both correct.
- **Unit tests:** `go test ./network/ldap/... ./network/kerberos/v5/gssapi/...` and `go vet` pass; `go test -race ./network/ldap/` clean.

### Test Coverage
**Added:**
- `network/ldap/kerberos_gssapi_test.go`: `TestSelectSASLLayer*` (offer parsing, SSF selection, no-layer max-buffer zeroing, defaulting, rejecting un-offered layers, short offer), `TestTLSServerEndPointCBT`, `TestCertificateHashAlgorithmSelection`.
- `network/ldap/saslconn_test.go`: `TestSASLConnFramedRoundtrip` (chunking + reassembly), `TestSASLConnWireIsWrapped`, `TestSASLConnPassThroughBeforeActivate`, `TestSASLConnActivateNudgesBlockedRead`.
- `network/kerberos/v5/gssapi/gssapi_test.go`: `TestGSSChannelBindings`.

### Scope of Change
- **Files changed:** `network/kerberos/v5/gssapi/gssapi.go` (+ test), `network/ldap/kerberos_gssapi.go`, `network/ldap/session.go`, new `network/ldap/channel_binding.go`, `network/ldap/saslconn.go` (+ tests).
- **Submodule pointer updated:** no.
- **Behavioral changes outside the fix:** none. The default bind path stays auth-only; LDAP dialing now goes through `net.Dial`/`tls.Dial` + `ldap.NewConn` so the transport can be interposed, matching what `ldap.DialURL` did internally.

### Notes
Live channel binding could not be exercised: the test DC presents no LDAPS server certificate on 636 (TLS handshake yields no peer certificate), so the CBT path is covered by unit tests only.