### PR TITLE
Add DCE/RPC Kerberos PKT_PRIVACY sealing (GSS RC4 Wrap) (Fixes #913)

### DIFF
--- a/network/dcerpc/v5/client/auth.go
+++ b/network/dcerpc/v5/client/auth.go
@@ -337,6 +337,19 @@ func (c *Client) marshalProtectedRequest(req *pdu.Request) ([]byte, error) {
 		return nil, fmt.Errorf("auth token length %d does not match reserved length %d", len(authValue), tokenLen)
 	}
 
+	// A sealing provider may expand the stub (the Kerberos RC4 GSS Wrap seals the
+	// stub in an 8-octet block, so the on-wire stub can be longer than the padded
+	// plaintext). The fragment length must reflect the actual on-wire stub;
+	// re-marshal the header with the corrected frag_length. The RC4 token does not
+	// cover the PDU header, so adjusting it after signing is safe.
+	if len(onWireStub) != len(stubPad) {
+		fragLen = pdu.HeaderSize + len(bodyHdr) + len(onWireStub) + pdu.SecTrailerSize + tokenLen
+		req.Header.FragLength = uint16(fragLen)
+		if hdrBytes, err = req.Header.Marshal(); err != nil {
+			return nil, err
+		}
+	}
+
 	out := make([]byte, 0, fragLen)
 	out = append(out, hdrBytes...)
 	out = append(out, bodyHdr...)

--- a/network/dcerpc/v5/client/auth_kerberos.go
+++ b/network/dcerpc/v5/client/auth_kerberos.go
@@ -30,8 +30,11 @@ import (
 //     alter_context with the initiator's own AP-REP) establishes the context, and
 //     an RC4-HMAC service ticket is requested (the RFC 4757 per-message tokens
 //     Windows expects here).
-//   - PKT_PRIVACY (sealing) additionally needs a GSS Wrap-IOV encrypt and is not
-//     yet supported.
+//   - PKT_PRIVACY (sealing) uses the same SPNEGO/DCE-style handshake and RC4-HMAC
+//     service ticket, and additionally seals the stub with an RFC 4757 GSS Wrap
+//     token (tok_id 02 01): the stub is encrypted in place while the PDU header
+//     and sec_trailer stay sign-only, and the Wrap token travels in the
+//     auth_value.
 //
 // Call before Bind.
 func (c *Client) SetAuthKerberos(authLevel uint8, kc *kerberos.KerberosClient, spn string) error {
@@ -45,9 +48,7 @@ func (c *Client) SetAuthKerberos(authLevel uint8, kc *kerberos.KerberosClient, s
 		authLevel = pdu.AuthLevelPkt
 	}
 	switch authLevel {
-	case pdu.AuthLevelConnect, pdu.AuthLevelPkt, pdu.AuthLevelPktIntegrity:
-	case pdu.AuthLevelPktPrivacy:
-		return fmt.Errorf("dcerpc auth: kerberos PKT_PRIVACY (sealing) is not yet supported; use PKT_INTEGRITY")
+	case pdu.AuthLevelConnect, pdu.AuthLevelPkt, pdu.AuthLevelPktIntegrity, pdu.AuthLevelPktPrivacy:
 	default:
 		return fmt.Errorf("dcerpc auth: unsupported auth_level %d", authLevel)
 	}
@@ -131,9 +132,10 @@ func (c *Client) SetAuthKerberos(authLevel uint8, kc *kerberos.KerberosClient, s
 }
 
 // kerberosSecurityContext adapts a GSS-API SecContext to the RPC SecurityContext
-// interface. The per-PDU verifier is a GSS MIC token (RFC 4121 §4.2.6.1) over the
-// request/response stub; the stub itself travels in the clear (integrity only).
-// It also implements bindCompleter to complete the mutual-auth handshake.
+// interface. The per-PDU verifier is a GSS token over the request/response stub:
+// a MIC (integrity only, stub in the clear) for PKT/PKT_INTEGRITY, or an RC4-HMAC
+// Wrap token (RFC 4757 §7.4) that seals the stub for PKT_PRIVACY. It also
+// implements bindCompleter to complete the mutual-auth handshake.
 type kerberosSecurityContext struct {
 	ctx *gssapi.SecContext
 	// spnego is set for the per-message SPNEGO/DCE-style path: the acceptor's
@@ -194,18 +196,28 @@ func (k *kerberosSecurityContext) CompleteBind(bindAckAuthValue []byte) ([]byte,
 	return asn1.Marshal(asn1.RawValue{Class: asn1.ClassContextSpecific, Tag: 1, IsCompound: true, Bytes: legSeq})
 }
 
-// AuthValueLen is the GSS MIC token length: a 16-byte token header plus the
-// etype's checksum. It is independent of the seal flag (sealing is unsupported).
-func (k *kerberosSecurityContext) AuthValueLen(bool) int {
+// AuthValueLen is the GSS token length carried in the auth_value: for sealing
+// (PKT_PRIVACY) the RC4-HMAC Wrap token, otherwise the MIC token. Both are fixed
+// for a given context (the RC4 tokens have no etype-dependent variation here).
+func (k *kerberosSecurityContext) AuthValueLen(seal bool) int {
+	if seal {
+		return k.ctx.WrapTokenLen()
+	}
 	return k.ctx.MICTokenLen()
 }
 
-// ProtectRequest signs the request stub with a GSS MIC token and returns it as
-// the auth_value. Per MS-RPCE the MIC covers only the stub (pduData), not the
-// PDU header or sec_trailer, when PFC_SUPPORT_HEADER_SIGN is not negotiated.
+// ProtectRequest protects the request stub. For PKT_PRIVACY it seals the stub
+// with a GSS Wrap token and returns the encrypted stub plus the Wrap token; for
+// PKT/PKT_INTEGRITY it signs the stub with a GSS MIC token and returns the stub
+// unchanged. Per MS-RPCE the RC4 tokens cover only the stub (pduData), not the
+// PDU header or sec_trailer, so signedRegion is unused.
 func (k *kerberosSecurityContext) ProtectRequest(signedRegion, stub []byte, seal bool) ([]byte, []byte, error) {
 	if seal {
-		return nil, nil, fmt.Errorf("dcerpc auth: kerberos sealing is not supported")
+		sealed, token, err := k.ctx.Seal(stub)
+		if err != nil {
+			return nil, nil, err
+		}
+		return sealed, token, nil
 	}
 	mic, err := k.ctx.MakeMIC(stub)
 	if err != nil {
@@ -214,11 +226,12 @@ func (k *kerberosSecurityContext) ProtectRequest(signedRegion, stub []byte, seal
 	return stub, mic, nil
 }
 
-// UnprotectResponse verifies the server's GSS MIC over the response stub and
-// returns the stub unchanged (integrity only).
+// UnprotectResponse recovers the response stub. For PKT_PRIVACY it decrypts and
+// verifies the GSS Wrap token, returning the plaintext stub; otherwise it
+// verifies the GSS MIC over the (cleartext) stub and returns it unchanged.
 func (k *kerberosSecurityContext) UnprotectResponse(signedRegion, stub, authValue []byte, seal bool) ([]byte, error) {
 	if seal {
-		return nil, fmt.Errorf("dcerpc auth: kerberos sealing is not supported")
+		return k.ctx.Unseal(stub, authValue)
 	}
 	if err := k.ctx.VerifyMIC(stub, authValue); err != nil {
 		return nil, err

--- a/network/kerberos/v5/gssapi/permessage.go
+++ b/network/kerberos/v5/gssapi/permessage.go
@@ -142,6 +142,38 @@ func (ctx *SecContext) MICTokenLen() int {
 	return 16 + micLen(etype)
 }
 
+// WrapTokenLen returns the auth_value length of a DCE-style Wrap token this
+// context emits when sealing. Only the RFC 4757 RC4-HMAC Wrap token is
+// supported (the per-message format Windows RPC uses for Kerberos PKT_PRIVACY);
+// it returns 0 for other enctypes, for which Seal reports an error.
+func (ctx *SecContext) WrapTokenLen() int {
+	if _, etype := ctx.baseKey(); etype == rc4HMACEType {
+		return rc4WrapTokenLen
+	}
+	return 0
+}
+
+// Seal produces a DCE-style GSS Wrap token that seals data as the context
+// initiator, returning the encrypted stub (sealed in place) and the Wrap token
+// for the auth_value. It is used by DCE/RPC PKT_PRIVACY; the RPC header and
+// sec_trailer are not covered by the RC4 token. Only RC4-HMAC is implemented.
+func (ctx *SecContext) Seal(data []byte) (sealed, token []byte, err error) {
+	if _, etype := ctx.baseKey(); etype != rc4HMACEType {
+		return nil, nil, fmt.Errorf("gssapi: DCE-style sealing is only implemented for RC4-HMAC")
+	}
+	return ctx.sealRC4(data, ctx.nextSendSeq())
+}
+
+// Unseal decrypts and verifies a DCE-style GSS Wrap token received from the
+// acceptor, returning the recovered plaintext (including any GSS pad the caller
+// strips). Only RC4-HMAC is implemented.
+func (ctx *SecContext) Unseal(sealed, token []byte) ([]byte, error) {
+	if _, etype := ctx.baseKey(); etype != rc4HMACEType {
+		return nil, fmt.Errorf("gssapi: DCE-style unsealing is only implemented for RC4-HMAC")
+	}
+	return ctx.unsealRC4(sealed, token)
+}
+
 // MakeMIC produces a MIC token over data as the context initiator. For RC4-HMAC
 // it is the RFC 4757 §7.3 token; otherwise the RFC 4121 §4.2.6.1 CFX token
 // (checksum(data | header) keyed with the initiator-sign usage).

--- a/network/kerberos/v5/gssapi/rc4permessage.go
+++ b/network/kerberos/v5/gssapi/rc4permessage.go
@@ -3,6 +3,7 @@ package gssapi
 import (
 	"crypto/hmac"
 	"crypto/md5"
+	"crypto/rand"
 	"crypto/rc4"
 	"encoding/binary"
 	"fmt"
@@ -144,4 +145,152 @@ func rc4Encrypt(key, data []byte) []byte {
 	out := make([]byte, len(data))
 	c.XORKeyStream(out, data)
 	return out
+}
+
+// RFC 4757 §7.4 per-message Wrap token (TOK_ID 02 01) for the RC4-HMAC enctype.
+// This is the DCE-style sealing token Windows RPC expects at
+// RPC_C_AUTHN_LEVEL_PKT_PRIVACY over Kerberos. The confounder and the caller's
+// data are sealed with RC4 in one keystream; the sealed data replaces the stub
+// in the PDU (sealed in place), while the token header — TOK_ID, SGN_ALG,
+// SEAL_ALG, Filler, SND_SEQ, SGN_CKSUM, and the encrypted confounder — travels
+// in the auth_value.
+
+// rc4WrapTokenLen is the fixed length of an RC4 GSS Wrap token as it appears in
+// the auth_value: the 13-byte GSS InitialContextToken header (60 2b 06 09 <krb5
+// OID>) plus TOK_ID(2), SGN_ALG(2), SEAL_ALG(2), Filler(2), SND_SEQ(8),
+// SGN_CKSUM(8), and the encrypted Confounder(8). The sealed data is carried
+// separately (in the stub), not in the token.
+const rc4WrapTokenLen = 13 + 2 + 2 + 2 + 2 + 8 + 8 + 8
+
+// rc4GSSWrapHeader is the GSS-API InitialContextToken header for the RC4 Wrap
+// token: [APPLICATION 0] length 0x2b (the 32-byte token plus the 2+9 OID
+// prefix), then the Kerberos 5 OID.
+var rc4GSSWrapHeader = []byte{0x60, 0x2b, 0x06, 0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x12, 0x01, 0x02, 0x02}
+
+// rc4WrapPad pads the sealed region (confounder | data) to an 8-octet boundary
+// (RFC 1964 §1.2.2.3): every pad byte holds the pad length. Although RC4 is a
+// stream cipher, the arcfour GSS profile still pads to the 8-byte block used by
+// the checksum. The pad is sealed and transmitted as part of the stub.
+func rc4WrapPad(n int) []byte {
+	pad := (8 - (n % 8)) & 7
+	out := make([]byte, pad)
+	for i := range out {
+		out[i] = byte(pad)
+	}
+	return out
+}
+
+// rc4WrapSgnCksum computes the RC4 Wrap SGN_CKSUM: HMAC-MD5(Ksign, MD5(LE32(13) |
+// tokenHeader[:8] | confounder | payload)), truncated to 8 bytes, where payload
+// is data followed by its pad. Ksign is HMAC-MD5(key, "signaturekey\0"). The
+// literal 13 is the Wrap "seal" key-usage seed (the MIC token uses 15).
+func rc4WrapSgnCksum(key, hdr8, confounder, payload []byte) []byte {
+	ksign := hmacMD5(key, []byte("signaturekey\x00"))
+	buf := make([]byte, 0, 4+8+len(confounder)+len(payload))
+	buf = append(buf, le32(13)...)
+	buf = append(buf, hdr8...)
+	buf = append(buf, confounder...)
+	buf = append(buf, payload...)
+	return hmacMD5(ksign, md5sum(buf))[:8]
+}
+
+// rc4WrapCryptKey derives the RC4 key Kcrypt that seals the confounder+data.
+// Klocal is the session key with every byte XORed by 0xF0; Kcrypt is then
+// HMAC-MD5(HMAC-MD5(Klocal, LE32(0)), BE32(seq)).
+func rc4WrapCryptKey(key []byte, seq uint64) []byte {
+	klocal := make([]byte, len(key))
+	for i := range key {
+		klocal[i] = key[i] ^ 0xF0
+	}
+	beSeq := make([]byte, 4)
+	binary.BigEndian.PutUint32(beSeq, uint32(seq))
+	return hmacMD5(hmacMD5(klocal, le32(0)), beSeq)
+}
+
+// sealRC4 produces an RC4-HMAC GSS Wrap token over data as the initiator (RFC
+// 4757 §7.4) with the given sequence number. It returns the sealed stub (the
+// encrypted data | pad, with the confounder consumed to advance the keystream)
+// and the 45-byte Wrap token for the auth_value. The confounder is encrypted in
+// the same RC4 keystream and carried inside the token.
+func (ctx *SecContext) sealRC4(data []byte, seq uint64) (sealed, token []byte, err error) {
+	confounder := make([]byte, 8)
+	if _, err := rand.Read(confounder); err != nil {
+		return nil, nil, err
+	}
+	sealed, token = ctx.sealRC4WithConfounder(data, seq, confounder)
+	return sealed, token, nil
+}
+
+// sealRC4WithConfounder is the deterministic core of sealRC4 with a
+// caller-supplied confounder (used both by sealRC4 with a random confounder and
+// by known-answer tests with a fixed one).
+func (ctx *SecContext) sealRC4WithConfounder(data []byte, seq uint64, confounder []byte) (sealed, token []byte) {
+	key, _ := ctx.baseKey()
+	// TOK_ID 02 01, SGN_ALG 11 00 (HMAC), SEAL_ALG 10 00 (RC4), Filler ff ff.
+	hdr8 := []byte{0x02, 0x01, 0x11, 0x00, 0x10, 0x00, 0xff, 0xff}
+
+	pad := rc4WrapPad(len(data))
+	payload := make([]byte, 0, len(data)+len(pad))
+	payload = append(payload, data...)
+	payload = append(payload, pad...)
+
+	cksum := rc4WrapSgnCksum(key, hdr8, confounder, payload)
+	encSeq := rc4Encrypt(rc4SeqKey(key, cksum), rc4MICSeqBytes(seq, true))
+
+	kcrypt := rc4WrapCryptKey(key, seq)
+	plain := make([]byte, 0, 8+len(payload))
+	plain = append(plain, confounder...)
+	plain = append(plain, payload...)
+	enc := rc4Encrypt(kcrypt, plain)
+
+	token = make([]byte, 0, rc4WrapTokenLen)
+	token = append(token, rc4GSSWrapHeader...)
+	token = append(token, hdr8...)
+	token = append(token, encSeq...)
+	token = append(token, cksum...)
+	token = append(token, enc[:8]...) // encrypted confounder
+	return enc[8:], token
+}
+
+// unsealRC4 decrypts and verifies an RC4-HMAC GSS Wrap token received from the
+// acceptor. sealed is the on-wire (encrypted) stub; token is the auth_value. It
+// returns the recovered plaintext (data plus any GSS pad, which the caller
+// strips). The sequence number and direction are recovered from the token.
+func (ctx *SecContext) unsealRC4(sealed, token []byte) ([]byte, error) {
+	// Strip the GSS InitialContextToken header (60 xx 06 09 <OID>) if present.
+	if len(token) >= 13 && token[0] == 0x60 {
+		token = token[13:]
+	}
+	if len(token) < 32 {
+		return nil, fmt.Errorf("gssapi: RC4 Wrap token too short")
+	}
+	if token[0] != 0x02 || token[1] != 0x01 {
+		return nil, fmt.Errorf("gssapi: not an RC4 Wrap token (TOK_ID %02x %02x)", token[0], token[1])
+	}
+	hdr8 := token[:8]
+	encSeq := token[8:16]
+	cksum := token[16:24]
+	encConfounder := token[24:32]
+
+	key, _ := ctx.baseKey()
+	// Recover SND_SEQ; the acceptor direction indicator must be 0xff.
+	seqBytes := rc4Encrypt(rc4SeqKey(key, cksum), encSeq)
+	if seqBytes[4] != 0xff {
+		return nil, fmt.Errorf("gssapi: RC4 Wrap not marked as sent by acceptor")
+	}
+	seq := uint64(binary.BigEndian.Uint32(seqBytes[:4]))
+
+	kcrypt := rc4WrapCryptKey(key, seq)
+	combined := make([]byte, 0, 8+len(sealed))
+	combined = append(combined, encConfounder...)
+	combined = append(combined, sealed...)
+	plain := rc4Encrypt(kcrypt, combined)
+	confounder := plain[:8]
+	payload := plain[8:]
+
+	want := rc4WrapSgnCksum(key, hdr8, confounder, payload)
+	if !hmac.Equal(cksum, want) {
+		return nil, fmt.Errorf("gssapi: RC4 Wrap verification failed")
+	}
+	return payload, nil
 }

--- a/network/kerberos/v5/gssapi/rc4permessage_test.go
+++ b/network/kerberos/v5/gssapi/rc4permessage_test.go
@@ -45,6 +45,95 @@ func TestRC4MICRoundTrip(t *testing.T) {
 	}
 }
 
+// TestSealRC4KnownAnswer pins the RFC 4757 §7.4 RC4-HMAC GSS Wrap token (tok_id
+// 02 01) against a known-answer vector for a fixed RC4 session key, DCE/RPC
+// ept_lookup stub, sequence number 0, and a fixed confounder ("AAAAAAAA"). It
+// locks the SGN_ALG/SEAL_ALG fields, the KG_USAGE_SEAL (13) checksum, the
+// Klocal-based Kcrypt derivation, the RC4 SND_SEQ encryption, and the 45-byte
+// GSS-framed Wrap token that Windows RPC expects.
+func TestSealRC4KnownAnswer(t *testing.T) {
+	key, _ := hex.DecodeString("a3cf582b95eeb0afef5ffdddd0483fa5")
+	stub, _ := hex.DecodeString("000000000000000000000000010000000000000000000000000000000000000000000000f4010000")
+	wantCipher := "f5765e7498c679dbfa35a1309aa9eb37a08575ed260257639431c934622d80a2213c5bc983932d45"
+	wantToken := "602b06092a864886f712010202020111001000ffffd39e4030ef161206c2565dc64be78aac82d5080060625f0e"
+
+	ctx := &SecContext{SessionKey: key, SessionEType: rc4HMACEType}
+	sealed, token := ctx.sealRC4WithConfounder(stub, 0, []byte("AAAAAAAA"))
+	if got := hex.EncodeToString(sealed); got != wantCipher {
+		t.Errorf("RC4 Wrap sealed stub mismatch:\n got=%s\nwant=%s", got, wantCipher)
+	}
+	if got := hex.EncodeToString(token); got != wantToken {
+		t.Errorf("RC4 Wrap token mismatch:\n got=%s\nwant=%s", got, wantToken)
+	}
+	if len(token) != rc4WrapTokenLen {
+		t.Errorf("RC4 Wrap token length = %d, want %d", len(token), rc4WrapTokenLen)
+	}
+	if len(sealed) != len(stub) {
+		t.Errorf("sealed stub length = %d, want %d (8-aligned stub must not expand)", len(sealed), len(stub))
+	}
+}
+
+// TestSealRC4RoundTrip seals a stub and confirms an acceptor-direction Wrap
+// token round-trips through unsealRC4, that the plaintext is recovered, and
+// that tampering with either the sealed stub or the token fails verification.
+func TestSealRC4RoundTrip(t *testing.T) {
+	key, _ := hex.DecodeString("0123456789abcdef0123456789abcdef")
+	data := []byte("privacy over kerberos rpc!!") // 27 bytes -> exercises the pad-to-8
+
+	ctx := &SecContext{SessionKey: key, SessionEType: rc4HMACEType}
+	sealed, token := ctx.sealRC4Acceptor(data, 3)
+
+	// Sealing must actually encrypt: the sealed stub differs from the plaintext.
+	if len(sealed) < len(data) {
+		t.Fatalf("sealed stub too short: %d < %d", len(sealed), len(data))
+	}
+	got, err := ctx.unsealRC4(sealed, token)
+	if err != nil {
+		t.Fatalf("unsealRC4: %v", err)
+	}
+	// unsealRC4 returns data plus its GSS pad; strip the pad-length trailer.
+	if pad := int(got[len(got)-1]); pad > 0 && pad <= 8 {
+		got = got[:len(got)-pad]
+	}
+	if string(got) != string(data) {
+		t.Errorf("round-trip plaintext = %q, want %q", got, data)
+	}
+
+	// Tamper with the sealed stub: verification must fail.
+	bad := append([]byte{}, sealed...)
+	bad[0] ^= 0xff
+	if _, err := ctx.unsealRC4(bad, token); err == nil {
+		t.Error("expected verification failure on tampered sealed stub")
+	}
+	// Tamper with the checksum in the token: verification must fail.
+	badTok := append([]byte{}, token...)
+	badTok[len(badTok)-1] ^= 0xff
+	if _, err := ctx.unsealRC4(sealed, badTok); err == nil {
+		t.Error("expected verification failure on tampered token")
+	}
+}
+
+// sealRC4Acceptor builds an acceptor-direction RC4 Wrap token (direction 0xff)
+// so unsealRC4 (which expects the acceptor direction) can be exercised without a
+// live server.
+func (ctx *SecContext) sealRC4Acceptor(data []byte, seq uint64) (sealed, token []byte) {
+	key, _ := ctx.baseKey()
+	hdr8 := []byte{0x02, 0x01, 0x11, 0x00, 0x10, 0x00, 0xff, 0xff}
+	confounder := []byte("BBBBBBBB")
+	pad := rc4WrapPad(len(data))
+	payload := append(append([]byte{}, data...), pad...)
+	cksum := rc4WrapSgnCksum(key, hdr8, confounder, payload)
+	encSeq := rc4Encrypt(rc4SeqKey(key, cksum), rc4MICSeqBytes(seq, false))
+	kcrypt := rc4WrapCryptKey(key, seq)
+	enc := rc4Encrypt(kcrypt, append(append([]byte{}, confounder...), payload...))
+	token = append([]byte{}, rc4GSSWrapHeader...)
+	token = append(token, hdr8...)
+	token = append(token, encSeq...)
+	token = append(token, cksum...)
+	token = append(token, enc[:8]...)
+	return enc[8:], token
+}
+
 // makeMICRC4Acceptor builds an acceptor-direction RC4 MIC (test helper for
 // exercising verifyMICRC4).
 func (ctx *SecContext) makeMICRC4Acceptor(data []byte, seq uint64) []byte {


### PR DESCRIPTION
### Linked Issue
`Closes #913`

### Root Cause
Kerberos DCE/RPC authentication implemented CONNECT, PKT and PKT_INTEGRITY, but `RPC_C_AUTHN_LEVEL_PKT_PRIVACY` was rejected: the GSS per-message layer only produced MIC tokens (RFC 4757 §7.3 for RC4-HMAC), which sign the stub but leave it in the clear. There was no DCE-style Wrap to seal the stub while keeping the PDU header and sec_trailer sign-only, so `ProtectRequest`/`UnprotectResponse` errored on `seal` and `SetAuthKerberos` refused the level.

### Fix Description
Implement the RFC 4757 §7.4 RC4-HMAC GSS Wrap token (tok_id `02 01`) as the DCE-style sealing token Windows RPC expects over Kerberos:

- `SGN_ALG` HMAC (`11 00`), `SEAL_ALG` RC4 (`10 00`); the confounder and stub are sealed with RC4 in a single keystream keyed by `Kcrypt` (session key XOR `0xF0` per byte, then `HMAC-MD5(HMAC-MD5(Klocal, LE32(0)), BE32(seq))`).
- `SGN_CKSUM` uses the `KG_USAGE_SEAL` seed `13` (the MIC token uses `15`) over `LE32(13) | tokenHeader[:8] | confounder | data | pad`.
- `SND_SEQ` is RC4-encrypted with the same key derivation as the MIC.
- The stub is sealed in place; the 45-byte Wrap token (13-byte GSS header + 32-byte token incl. encrypted confounder) travels in the `auth_value`.

Wired through the per-message path: `SetAuthKerberos` now accepts `PKT_PRIVACY` (reusing the SPNEGO/DCE-style three-leg handshake and RC4 service ticket already used for PKT_INTEGRITY), and `ProtectRequest`/`UnprotectResponse` seal/unseal when `seal=true`. `marshalProtectedRequest` recomputes `frag_length` when the sealed region is padded up to the GSS 8-octet block, which is safe because the RC4 token does not cover the PDU header.

### How Verified
- Live against a Windows Server 2016 DC (endpoint mapper, ncacn_ip_tcp/135): a sealed `ept_lookup` at `PKT_PRIVACY` decrypts the response and recovers 579 endpoint-map entries. CONNECT, PKT and PKT_INTEGRITY still succeed (no regression).
- Wire capture (tshark) confirms the request PDU carries `auth_level=6`, `auth_type=9`, `auth_length=0x2d` (45), an `auth_value` with the exact `60 2b … 02 01 11 00 10 00 ff ff …` Wrap structure, and an encrypted stub (not the plaintext ept NDR).
- `go build ./...`, `go vet`, and `go test ./network/dcerpc/v5/... ./network/kerberos/...` all green.

### Test Coverage
**Added** (`network/kerberos/v5/gssapi/rc4permessage_test.go`):
- `TestSealRC4KnownAnswer` — pins the exact Wrap token bytes and sealed stub for a fixed key/stub/seq and confounder.
- `TestSealRC4RoundTrip` — seal then unseal recovers the plaintext (exercising the pad-to-8), and tampering with the sealed stub or the token fails verification.

### Scope of Change
- **Files changed:** `network/dcerpc/v5/client/auth_kerberos.go`, `network/dcerpc/v5/client/auth.go`, `network/kerberos/v5/gssapi/rc4permessage.go`, `network/kerberos/v5/gssapi/permessage.go`, `network/kerberos/v5/gssapi/rc4permessage_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Localized to the Kerberos per-message GSS path and the RPC request-framing branch that only triggers when a sealing provider expands the stub. PKT/PKT_INTEGRITY and NTLM paths are unchanged. Safe to merge.