### PR TITLE
Add SMB 3.x signing and encryption over Kerberos (Fixes #914)

### DIFF
--- a/network/smb/smb_v20/client/ccm.go
+++ b/network/smb/smb_v20/client/ccm.go
@@ -1,0 +1,200 @@
+package client
+
+import (
+	"crypto/cipher"
+	"crypto/subtle"
+	"encoding/binary"
+	"fmt"
+)
+
+// AES-CCM (Counter with CBC-MAC), as specified in RFC 3610, implemented on top
+// of a crypto/cipher.Block so no third-party dependency is required. SMB 3.x
+// uses AES-128-CCM (and AES-256-CCM) as one of its two authenticated-encryption
+// ciphers (MS-SMB2 3.1.4.3), with an 11-byte nonce and a 16-byte
+// authentication tag.
+//
+// The interface mirrors crypto/cipher AEAD semantics: ccmSeal returns
+// ciphertext || tag, and ccmOpen consumes ciphertext || tag and returns the
+// plaintext, so both fit the same TRANSFORM_HEADER wrapping used by AES-GCM.
+
+const ccmTagSize = 16
+
+// ccmSeal encrypts and authenticates plaintext with associated data, returning
+// ciphertext with the 16-byte tag appended. The nonce length determines the
+// CCM length field L (L = 15 - len(nonce)); SMB uses an 11-byte nonce (L = 4).
+func ccmSeal(block cipher.Block, nonce, plaintext, aad []byte) ([]byte, error) {
+	if block.BlockSize() != 16 {
+		return nil, fmt.Errorf("ccm: cipher block size must be 16, got %d", block.BlockSize())
+	}
+	l := 15 - len(nonce)
+	if l < 2 || l > 8 {
+		return nil, fmt.Errorf("ccm: invalid nonce length %d", len(nonce))
+	}
+
+	// The message length must fit in the L-byte length field.
+	if l < 8 {
+		maxLen := uint64(1) << (8 * uint(l))
+		if uint64(len(plaintext)) >= maxLen {
+			return nil, fmt.Errorf("ccm: plaintext too long for nonce length %d", len(nonce))
+		}
+	}
+
+	tag := ccmTag(block, nonce, plaintext, aad, l, ccmTagSize)
+
+	out := make([]byte, len(plaintext)+ccmTagSize)
+	ccmCTR(block, nonce, l, plaintext, out[:len(plaintext)])
+
+	// Encrypt the tag with counter block 0 (S_0) and append it.
+	var counter0 [16]byte
+	ccmCounterBlock(counter0[:], nonce, l, 0)
+	var s0 [16]byte
+	block.Encrypt(s0[:], counter0[:])
+	for i := 0; i < ccmTagSize; i++ {
+		out[len(plaintext)+i] = tag[i] ^ s0[i]
+	}
+	return out, nil
+}
+
+// ccmOpen verifies and decrypts ciphertext || tag with associated data,
+// returning the plaintext. It returns an error if authentication fails.
+func ccmOpen(block cipher.Block, nonce, ciphertextAndTag, aad []byte) ([]byte, error) {
+	if block.BlockSize() != 16 {
+		return nil, fmt.Errorf("ccm: cipher block size must be 16, got %d", block.BlockSize())
+	}
+	l := 15 - len(nonce)
+	if l < 2 || l > 8 {
+		return nil, fmt.Errorf("ccm: invalid nonce length %d", len(nonce))
+	}
+	if len(ciphertextAndTag) < ccmTagSize {
+		return nil, fmt.Errorf("ccm: message shorter than tag")
+	}
+
+	ctLen := len(ciphertextAndTag) - ccmTagSize
+	ciphertext := ciphertextAndTag[:ctLen]
+	receivedTag := ciphertextAndTag[ctLen:]
+
+	plaintext := make([]byte, ctLen)
+	ccmCTR(block, nonce, l, ciphertext, plaintext)
+
+	tag := ccmTag(block, nonce, plaintext, aad, l, ccmTagSize)
+	var counter0 [16]byte
+	ccmCounterBlock(counter0[:], nonce, l, 0)
+	var s0 [16]byte
+	block.Encrypt(s0[:], counter0[:])
+	expectedTag := make([]byte, ccmTagSize)
+	for i := 0; i < ccmTagSize; i++ {
+		expectedTag[i] = tag[i] ^ s0[i]
+	}
+
+	if subtle.ConstantTimeCompare(expectedTag, receivedTag) != 1 {
+		return nil, fmt.Errorf("ccm: authentication failed")
+	}
+	return plaintext, nil
+}
+
+// ccmTag computes the CBC-MAC T over the formatted blocks B_0, the AAD, and the
+// plaintext (RFC 3610 section 2.2), returning the full-block MAC before it is
+// encrypted with S_0. tagLen selects the M parameter encoded in the B_0 flags.
+func ccmTag(block cipher.Block, nonce, plaintext, aad []byte, l, tagLen int) []byte {
+	var b0 [16]byte
+	// Flags: Adata bit (bit 6) | ((M-2)/2 << 3) | (L-1).
+	flags := byte(l - 1)
+	flags |= byte((tagLen-2)/2) << 3
+	if len(aad) > 0 {
+		flags |= 1 << 6
+	}
+	b0[0] = flags
+	copy(b0[1:1+len(nonce)], nonce)
+	// Message length in the trailing L bytes, big-endian.
+	putUintBE(b0[16-l:], uint64(len(plaintext)), l)
+
+	var mac [16]byte
+	block.Encrypt(mac[:], b0[:])
+
+	// Associated data, prefixed by its encoded length, zero-padded to a block.
+	if len(aad) > 0 {
+		var enc []byte
+		alen := len(aad)
+		switch {
+		case alen < (1<<16 - 1<<8):
+			enc = make([]byte, 2)
+			binary.BigEndian.PutUint16(enc, uint16(alen))
+		case uint64(alen) <= 0xFFFFFFFF:
+			enc = make([]byte, 6)
+			enc[0], enc[1] = 0xFF, 0xFE
+			binary.BigEndian.PutUint32(enc[2:], uint32(alen))
+		default:
+			enc = make([]byte, 10)
+			enc[0], enc[1] = 0xFF, 0xFF
+			binary.BigEndian.PutUint64(enc[2:], uint64(alen))
+		}
+		// The encoded length and the associated data are concatenated and
+		// zero-padded to a block boundary as a single unit before being folded in.
+		adata := make([]byte, 0, len(enc)+len(aad))
+		adata = append(adata, enc...)
+		adata = append(adata, aad...)
+		ccmCBCMAC(block, mac[:], adata)
+	}
+
+	ccmCBCMAC(block, mac[:], plaintext)
+	return mac[:]
+}
+
+// ccmCBCMAC folds data into the running CBC-MAC state, zero-padding the final
+// partial block, as required by CCM's B-block formatting.
+func ccmCBCMAC(block cipher.Block, mac, data []byte) {
+	var buf [16]byte
+	for len(data) >= 16 {
+		for i := 0; i < 16; i++ {
+			mac[i] ^= data[i]
+		}
+		block.Encrypt(mac, mac)
+		data = data[16:]
+	}
+	if len(data) > 0 {
+		for i := range buf {
+			buf[i] = 0
+		}
+		copy(buf[:], data)
+		for i := 0; i < 16; i++ {
+			mac[i] ^= buf[i]
+		}
+		block.Encrypt(mac, mac)
+	}
+}
+
+// ccmCTR applies CCM counter-mode encryption/decryption to src, writing into
+// dst. Counter blocks A_i (i >= 1) key the keystream; A_0 is reserved for the
+// tag.
+func ccmCTR(block cipher.Block, nonce []byte, l int, src, dst []byte) {
+	var counter [16]byte
+	var keystream [16]byte
+	i := uint64(1)
+	for offset := 0; offset < len(src); offset += 16 {
+		ccmCounterBlock(counter[:], nonce, l, i)
+		block.Encrypt(keystream[:], counter[:])
+		end := offset + 16
+		if end > len(src) {
+			end = len(src)
+		}
+		for j := offset; j < end; j++ {
+			dst[j] = src[j] ^ keystream[j-offset]
+		}
+		i++
+	}
+}
+
+// ccmCounterBlock formats the CCM counter block A_i: a flags byte carrying
+// (L-1), the nonce, and the L-byte counter value.
+func ccmCounterBlock(dst, nonce []byte, l int, i uint64) {
+	dst[0] = byte(l - 1)
+	copy(dst[1:1+len(nonce)], nonce)
+	putUintBE(dst[16-l:], i, l)
+}
+
+// putUintBE writes the low n bytes of v to dst in big-endian order.
+func putUintBE(dst []byte, v uint64, n int) {
+	for i := 0; i < n; i++ {
+		dst[n-1-i] = byte(v >> (8 * uint(i)))
+	}
+}

--- a/network/smb/smb_v20/client/client_functions.go
+++ b/network/smb/smb_v20/client/client_functions.go
@@ -75,3 +75,27 @@ func (c *Client) SetPort(port int) { c.Connection.Server.Port = port }
 
 // GetPort returns the target server port.
 func (c *Client) GetPort() int { return c.Connection.Server.Port }
+
+// EnableEncryption turns on SMB 3.x per-message encryption for the current
+// session, wrapping every subsequent request in an SMB2 TRANSFORM_HEADER. It
+// requires an SMB 3.x session whose encryption keys have been derived; it
+// returns an error otherwise. The server transparently encrypts its replies once
+// it receives an encrypted request.
+func (c *Client) EnableEncryption() error {
+	if c.Session == nil {
+		return fmt.Errorf("cannot enable encryption: no session established")
+	}
+	if !isSMB3Dialect(c.Connection.Dialect) {
+		return fmt.Errorf("cannot enable encryption: dialect %s does not support SMB3 encryption", c.Connection.Dialect)
+	}
+	if len(c.Session.EncryptionKey) == 0 {
+		return fmt.Errorf("cannot enable encryption: no encryption key derived")
+	}
+	c.Session.EncryptData = true
+	return nil
+}
+
+// IsEncryptionActive reports whether the current session encrypts its traffic.
+func (c *Client) IsEncryptionActive() bool {
+	return c.Session != nil && c.Session.EncryptData
+}

--- a/network/smb/smb_v20/client/client_structures.go
+++ b/network/smb/smb_v20/client/client_structures.go
@@ -37,6 +37,13 @@ type Client struct {
 	pendingMessageId uint64
 	pendingAsyncId   uint64
 	hasPendingAsync  bool
+
+	// lastSentBytes / lastRecvBytes hold the plaintext wire bytes of the most
+	// recent request sent and final response received. They feed the SMB 3.1.1
+	// pre-authentication integrity hash, which is computed over the exact
+	// NEGOTIATE and SESSION_SETUP messages exchanged (MS-SMB2 3.1.4.2).
+	lastSentBytes []byte
+	lastRecvBytes []byte
 }
 
 // setPendingAsync records the in-flight async operation so a concurrent Cancel
@@ -77,6 +84,22 @@ type Connection struct {
 
 	// Dialect is the SMB2 dialect selected during negotiation.
 	Dialect dialects.Dialect
+
+	// Cipher is the encryption algorithm the server selected in the SMB 3.1.1
+	// SMB2_ENCRYPTION_CAPABILITIES negotiate context (e.g. AES-128-GCM). It is 0
+	// when encryption was not negotiated. For the 3.0/3.0.2 dialects it is
+	// implicitly AES-128-CCM.
+	Cipher uint16
+
+	// PreauthIntegrityHashId is the pre-authentication integrity hash algorithm
+	// the server selected for the SMB 3.1.1 dialect (SHA-512).
+	PreauthIntegrityHashId uint16
+
+	// PreauthIntegrityHashValue is the running SMB 3.1.1 pre-authentication
+	// integrity hash over the NEGOTIATE and SESSION_SETUP exchange (MS-SMB2
+	// 3.1.4.2). It seeds the per-session hash used as the KDF context. It is nil
+	// for dialects below 3.1.1.
+	PreauthIntegrityHashValue []byte
 
 	// SessionTable holds authenticated sessions on this connection, keyed by the
 	// server-assigned 64-bit SessionId.
@@ -147,12 +170,38 @@ type Session struct {
 	SessionKey []byte
 
 	// SigningKey is the key used to sign/verify messages on this session. For the
-	// SMB 2.0.2 and 2.1 dialects it is the session key itself.
+	// SMB 2.0.2 and 2.1 dialects it is the session key itself; for the SMB 3.x
+	// dialects it is derived from the session key via the SP800-108 KDF.
 	SigningKey []byte
+
+	// EncryptionKey / DecryptionKey are the SMB 3.x keys used to encrypt outgoing
+	// messages and decrypt incoming ones respectively (MS-SMB2 3.1.4.2). They are
+	// nil for the 2.x dialects, which have no encryption.
+	EncryptionKey []byte
+	DecryptionKey []byte
+
+	// ApplicationKey is the SMB 3.x key handed to higher-layer applications (for
+	// example SMB2 RPC transport). It is nil for the 2.x dialects.
+	ApplicationKey []byte
+
+	// PreauthHash is the SMB 3.1.1 per-session pre-authentication integrity hash
+	// used as the KDF context for this session's keys. It is nil for other
+	// dialects.
+	PreauthHash []byte
 
 	// SigningActive indicates that requests on this session are signed and
 	// responses are verified.
 	SigningActive bool
+
+	// EncryptData indicates that messages on this session are wrapped in an SMB2
+	// TRANSFORM_HEADER and encrypted with the negotiated cipher. When set,
+	// per-message signing is superseded by the AEAD authentication tag.
+	EncryptData bool
+
+	// nonceCounter provides the monotonically increasing nonce for the SMB2
+	// TRANSFORM_HEADER of each encrypted message, ensuring a nonce is never
+	// reused within the session (MS-SMB2 3.2.4.1.8).
+	nonceCounter uint64
 
 	// Credentials are the credentials used to authenticate the session.
 	Credentials *credentials.Credentials

--- a/network/smb/smb_v20/client/engine.go
+++ b/network/smb/smb_v20/client/engine.go
@@ -3,6 +3,7 @@ package client
 import (
 	"fmt"
 
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/dialects"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/message"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/message/commands/command_interface"
 )
@@ -19,8 +20,14 @@ func (c *Client) newRequest(command command_interface.CommandInterface) *message
 	msg.Header.MessageId = c.Connection.MessageId
 	c.Connection.MessageId++
 
-	// SMB 2.0.2: CreditCharge MUST be 0; request a single credit per message.
-	msg.Header.CreditCharge = 0
+	// The SMB 2.0.2 dialect requires CreditCharge to be 0. From SMB 2.1 onward the
+	// large-MTU credit model applies and a small (single-block) request charges 1
+	// credit; the client requests a single credit back per message.
+	if c.Connection.Dialect >= dialects.SMB2_DIALECT_2_1_0 {
+		msg.Header.CreditCharge = 1
+	} else {
+		msg.Header.CreditCharge = 0
+	}
 	msg.Header.Credit = 1
 
 	if c.Session != nil {
@@ -45,12 +52,27 @@ func (c *Client) sendReceive(msg *message.Message, label string) (*message.Messa
 		return nil, fmt.Errorf("failed to marshal %s: %w", label, err)
 	}
 
-	// Sign the request in place when signing is active for the session.
-	if c.Session != nil && c.Session.SigningActive {
-		signMessage(c.Session.SigningKey, marshalled)
+	// When the session encrypts data, the message is wrapped in an SMB2
+	// TRANSFORM_HEADER instead of being signed — the AEAD tag supersedes the
+	// per-message signature (MS-SMB2 3.1.4.4). Otherwise sign the request in place
+	// when signing is active, choosing the algorithm the negotiated dialect
+	// mandates (AES-128-CMAC for SMB 3.x, HMAC-SHA256 for SMB 2.x).
+	encrypt := c.Session != nil && c.Session.EncryptData
+	if !encrypt && c.Session != nil && c.Session.SigningActive {
+		signMessageForDialect(c.Connection.Dialect, c.Session.SigningKey, marshalled)
 	}
 
-	if _, err = c.Transport.Send(marshalled); err != nil {
+	// Preserve the plaintext wire bytes of the request for the pre-auth hash.
+	c.lastSentBytes = append([]byte(nil), marshalled...)
+
+	wire := marshalled
+	if encrypt {
+		if wire, err = c.encryptMessage(marshalled); err != nil {
+			return nil, fmt.Errorf("failed to encrypt %s: %w", label, err)
+		}
+	}
+
+	if _, err = c.Transport.Send(wire); err != nil {
 		return nil, fmt.Errorf("failed to send %s: %w", label, err)
 	}
 
@@ -65,6 +87,18 @@ func (c *Client) sendReceive(msg *message.Message, label string) (*message.Messa
 		raw, err = c.Transport.Receive()
 		if err != nil {
 			return nil, fmt.Errorf("failed to receive %s response: %w", label, err)
+		}
+
+		// A response wrapped in an SMB2 TRANSFORM_HEADER is decrypted first; the
+		// AEAD tag authenticates it, so no separate signature check is needed.
+		wasEncrypted := false
+		if isTransformHeader(raw) {
+			plaintext, derr := c.decryptMessage(raw)
+			if derr != nil {
+				return nil, fmt.Errorf("%s: %w", label, derr)
+			}
+			raw = plaintext
+			wasEncrypted = true
 		}
 
 		response = message.NewMessage()
@@ -92,8 +126,8 @@ func (c *Client) sendReceive(msg *message.Message, label string) (*message.Messa
 		// conditional on the SMB2_FLAGS_SIGNED bit, so a response that simply
 		// arrives unsigned (zeroed signature) fails verification and is
 		// rejected rather than silently accepted.
-		if c.Session != nil && c.Session.SigningActive && signatureRequired(response) {
-			if !verifySignature(c.Session.SigningKey, raw) {
+		if !wasEncrypted && c.Session != nil && c.Session.SigningActive && signatureRequired(response) {
+			if !verifySignatureForDialect(c.Connection.Dialect, c.Session.SigningKey, raw) {
 				return nil, fmt.Errorf("%s response failed SMB2 signature verification", label)
 			}
 		}
@@ -118,6 +152,9 @@ func (c *Client) sendReceive(msg *message.Message, label string) (*message.Messa
 		c.setPendingAsync(msg.Header.MessageId, uint64(response.Header.GetAsyncId()))
 	}
 	c.clearPendingAsync()
+
+	// Retain the plaintext wire bytes of the final response for the pre-auth hash.
+	c.lastRecvBytes = append([]byte(nil), raw...)
 
 	// The response command code must match the request's; otherwise the server
 	// answered with a different command than was asked, indicating a corrupt or

--- a/network/smb/smb_v20/client/negotiate.go
+++ b/network/smb/smb_v20/client/negotiate.go
@@ -1,24 +1,60 @@
 package client
 
 import (
+	"crypto/rand"
 	"fmt"
 
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/capabilities"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/dialects"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/message/commands"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/securitymode"
 )
 
-// Negotiate performs the SMB2 NEGOTIATE exchange, requesting the SMB 2.0.2
-// dialect and capturing the server's security mode, capabilities, maximum
-// transfer sizes, GUID, timestamps, and GSS security buffer.
+// preauthSaltLength is the length of the salt the client places in the SMB 3.1.1
+// SMB2_PREAUTH_INTEGRITY_CAPABILITIES negotiate context; Windows uses 32 bytes.
+const preauthSaltLength = 32
+
+// Negotiate performs the SMB2 NEGOTIATE exchange, offering the full range of
+// SMB 2.0.2 through 3.1.1 dialects and capturing the server's chosen dialect,
+// security mode, capabilities, maximum transfer sizes, GUID, timestamps, and
+// GSS security buffer.
+//
+// For the SMB 3.1.1 dialect the request carries the pre-authentication
+// integrity (SHA-512) and encryption (AES-128-GCM / AES-128-CCM) negotiate
+// contexts, and the running pre-auth integrity hash is seeded from the exact
+// NEGOTIATE request and response bytes (MS-SMB2 3.1.4.2).
 //
 // NEGOTIATE uses MessageId 0 and SessionId 0, as required by the spec.
 func (c *Client) Negotiate() error {
 	req := commands.NewNegotiateRequest()
 	req.AddDialect(dialects.SMB2_DIALECT_2_0_2)
+	req.AddDialect(dialects.SMB2_DIALECT_2_1_0)
+	req.AddDialect(dialects.SMB2_DIALECT_3_0_0)
+	req.AddDialect(dialects.SMB2_DIALECT_3_0_2)
+	req.AddDialect(dialects.SMB2_DIALECT_3_1_1)
 	req.ClientGuid = c.ClientGuid
-	// Advertise that the client supports signing.
+	// Advertise signing support and the SMB 3.x capabilities (large MTU,
+	// encryption) so the server may negotiate up to 3.1.1.
 	req.SecurityMode = securitymode.SMB2_NEGOTIATE_SIGNING_ENABLED
+	req.Capabilities = capabilities.SMB2_GLOBAL_CAP_LARGE_MTU | capabilities.SMB2_GLOBAL_CAP_ENCRYPTION
+
+	// SMB 3.1.1 negotiate contexts: pre-auth integrity (SHA-512 + random salt)
+	// and encryption ciphers in preference order (AES-128-GCM, then AES-128-CCM).
+	salt := make([]byte, preauthSaltLength)
+	if _, err := rand.Read(salt); err != nil {
+		return fmt.Errorf("negotiate: failed to generate pre-auth salt: %w", err)
+	}
+	req.Contexts = []*commands.NegotiateContext{
+		commands.NewPreauthIntegrityContext(salt),
+		commands.NewEncryptionContext([]uint16{
+			commands.SMB2_ENCRYPTION_AES128_GCM,
+			commands.SMB2_ENCRYPTION_AES128_CCM,
+		}),
+	}
+
+	// Seed the pre-auth integrity hash with 64 zero bytes; it is folded with the
+	// NEGOTIATE request and response bytes below.
+	c.Connection.PreauthIntegrityHashValue = make([]byte, preauthHashLength)
 
 	msg := c.newRequest(req)
 	// NEGOTIATE is sent before any session exists; SessionId MUST be 0.
@@ -28,6 +64,11 @@ func (c *Client) Negotiate() error {
 	if err != nil {
 		return err
 	}
+
+	// Fold the exact request and response wire bytes into the pre-auth hash.
+	c.Connection.PreauthIntegrityHashValue = preauthUpdate(c.Connection.PreauthIntegrityHashValue, c.lastSentBytes)
+	c.Connection.PreauthIntegrityHashValue = preauthUpdate(c.Connection.PreauthIntegrityHashValue, c.lastRecvBytes)
+
 	if status := statusFromResponse(response); status != 0x00000000 {
 		return fmt.Errorf("negotiate failed: 0x%08x", status)
 	}
@@ -64,6 +105,13 @@ func (c *Client) ApplyNegotiateResponse(negotiateResponse *commands.NegotiateRes
 	server.SystemTime = negotiateResponse.SystemTime
 	server.ServerStartTime = negotiateResponse.ServerStartTime
 	server.SecurityBuffer = negotiateResponse.SecurityBuffer
+
+	// SMB 3.1.1: record the server's chosen cipher and pre-auth hash algorithm
+	// from the returned negotiate contexts.
+	if negotiateResponse.DialectRevision == dialects.SMB2_DIALECT_3_1_1 {
+		c.Connection.Cipher = commands.SelectedCipher(negotiateResponse.Contexts)
+		c.Connection.PreauthIntegrityHashId = commands.SelectedPreauthHash(negotiateResponse.Contexts)
+	}
 
 	if c.Connection.MessageId == 0 {
 		c.Connection.MessageId = 1

--- a/network/smb/smb_v20/client/session.go
+++ b/network/smb/smb_v20/client/session.go
@@ -111,6 +111,12 @@ func (c *Client) SessionSetup(creds *credentials.Credentials) error {
 		return fmt.Errorf("unexpected SESSION_SETUP status: %s", formatNTStatus(status))
 	}
 
+	// Fold the first SESSION_SETUP request/response into the SMB 3.1.1 pre-auth
+	// integrity hash (started from the connection hash after NEGOTIATE).
+	sessionHash := append([]byte(nil), c.Connection.PreauthIntegrityHashValue...)
+	sessionHash = preauthUpdate(sessionHash, c.lastSentBytes)
+	sessionHash = preauthUpdate(sessionHash, c.lastRecvBytes)
+
 	sessionId := resp1.Header.SessionId
 	challengeResp, ok := resp1.Command.(*commands.SessionSetupResponse)
 	if !ok {
@@ -158,6 +164,26 @@ func (c *Client) SessionSetup(creds *credentials.Credentials) error {
 	if status := statusFromResponse(resp2); status != 0x00000000 {
 		c.Session = nil
 		return fmt.Errorf("session setup failed: %s", formatNTStatus(status))
+	}
+
+	// SMB 3.x: fold the (unsigned) AUTHENTICATE request into the pre-auth hash —
+	// the final SUCCESS response is excluded — then derive the key hierarchy and
+	// verify the server's signature over that response.
+	if isSMB3Dialect(c.Connection.Dialect) {
+		sessionHash = preauthUpdate(sessionHash, c.lastSentBytes)
+		finalRespBytes := append([]byte(nil), c.lastRecvBytes...)
+		session.PreauthHash = sessionHash
+		deriveSMB3Keys(session, c.Connection.Dialect, sessionHash)
+
+		if len(finalRespBytes) >= 64 && !verifySignatureForDialect(c.Connection.Dialect, session.SigningKey, finalRespBytes) {
+			c.Session = nil
+			return fmt.Errorf("session setup: SMB3 signature of final SESSION_SETUP response did not verify (derived signing key mismatch)")
+		}
+
+		if resp2Cmd, ok := resp2.Command.(*commands.SessionSetupResponse); ok &&
+			resp2Cmd.SessionFlags&commands.SMB2_SESSION_FLAG_ENCRYPT_DATA != 0 {
+			session.EncryptData = true
+		}
 	}
 
 	// Session established: activate signing for all subsequent requests when the

--- a/network/smb/smb_v20/client/session_kerberos.go
+++ b/network/smb/smb_v20/client/session_kerberos.go
@@ -122,6 +122,15 @@ func (c *Client) sessionSetupKerberosMechanism(mech *kerberos.SPNEGOMechanism, c
 		return err
 	}
 
+	// Capture the exact wire bytes of this SESSION_SETUP request/response for the
+	// SMB 3.1.1 pre-authentication integrity hash. The per-session hash starts
+	// from the connection hash (after NEGOTIATE) and folds in the request that
+	// carried the AP-REQ; the final SUCCESS response is excluded from the hash
+	// used to derive keys.
+	sessionHash := append([]byte(nil), c.Connection.PreauthIntegrityHashValue...)
+	sessionHash = preauthUpdate(sessionHash, c.lastSentBytes)
+	firstRespBytes := append([]byte(nil), c.lastRecvBytes...)
+
 	status := statusFromResponse(resp)
 	// STATUS_MORE_PROCESSING_REQUIRED can precede the AP-REP on some servers; both
 	// it and STATUS_SUCCESS carry the response token we need to verify.
@@ -173,9 +182,17 @@ func (c *Client) sessionSetupKerberosMechanism(mech *kerberos.SPNEGOMechanism, c
 	}
 	c.Session = session
 
+	// finalRespBytes holds the wire bytes of the SESSION_SETUP response that
+	// completed the exchange; for the SMB 3.x dialects the server signs it, and we
+	// verify that signature below to confirm the derived signing key.
+	finalRespBytes := firstRespBytes
+
 	// If the server still requires another leg (unusual for AD Kerberos), send the
 	// final NegTokenResp confirming completion before the session is usable.
 	if status == ntStatusMoreProcessingRequired {
+		// Two-leg: the interim response and the second request also feed the hash.
+		sessionHash = preauthUpdate(sessionHash, firstRespBytes)
+
 		req2 := commands.NewSessionSetupRequest()
 		req2.SecurityMode = securitymode.SMB2_NEGOTIATE_SIGNING_ENABLED
 		req2.SecurityBuffer = []byte{}
@@ -188,9 +205,31 @@ func (c *Client) sessionSetupKerberosMechanism(mech *kerberos.SPNEGOMechanism, c
 			c.Session = nil
 			return err
 		}
+		sessionHash = preauthUpdate(sessionHash, c.lastSentBytes)
+		finalRespBytes = append([]byte(nil), c.lastRecvBytes...)
 		if st := statusFromResponse(resp2); st != 0x00000000 {
 			c.Session = nil
 			return fmt.Errorf("kerberos session setup failed: %s", formatNTStatus(st))
+		}
+	}
+
+	// SMB 3.x: derive the signing/encryption/application keys from the session key
+	// via the SP800-108 KDF, using the per-session pre-auth hash as the 3.1.1 KDF
+	// context. For the 2.x dialects the session key remains the signing key.
+	if isSMB3Dialect(c.Connection.Dialect) {
+		session.PreauthHash = sessionHash
+		deriveSMB3Keys(session, c.Connection.Dialect, sessionHash)
+
+		// The server signs the final SESSION_SETUP response with the derived signing
+		// key; verify it to confirm the key hierarchy is correct.
+		if len(finalRespBytes) >= 64 && !verifySignatureForDialect(c.Connection.Dialect, session.SigningKey, finalRespBytes) {
+			c.Session = nil
+			return fmt.Errorf("kerberos session setup: SMB3 signature of final SESSION_SETUP response did not verify (derived signing key mismatch)")
+		}
+
+		// Honour a server that requires encryption for the whole session.
+		if setupResp.SessionFlags&commands.SMB2_SESSION_FLAG_ENCRYPT_DATA != 0 {
+			session.EncryptData = true
 		}
 	}
 

--- a/network/smb/smb_v20/client/signing.go
+++ b/network/smb/smb_v20/client/signing.go
@@ -1,10 +1,13 @@
 package client
 
 import (
+	"crypto/aes"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/binary"
 
+	"github.com/TheManticoreProject/Manticore/crypto/cmac"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/dialects"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/message/header"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/message/header/flags"
 )
@@ -66,4 +69,81 @@ func verifySignature(key, message []byte) bool {
 	digest := mac.Sum(nil)
 
 	return hmac.Equal(received, digest[:signSignatureLength])
+}
+
+// signMessageCMAC signs a marshalled SMB2 message in place using AES-128-CMAC,
+// the signing algorithm for the SMB 3.0, 3.0.2, and 3.1.1 dialects when no
+// alternative signing algorithm is negotiated (MS-SMB2 3.1.4.1). The procedure
+// mirrors the 2.x path — set SMB2_FLAGS_SIGNED, zero the Signature field, then
+// compute the MAC over the whole message — but uses AES-128-CMAC (RFC 4493)
+// keyed with the 16-byte SigningKey and takes the full 16-byte tag.
+func signMessageCMAC(key, message []byte) {
+	if len(message) < header.SMB2_HEADER_SIZE {
+		return
+	}
+
+	f := binary.LittleEndian.Uint32(message[signFlagsOffset : signFlagsOffset+4])
+	f |= uint32(flags.SMB2_FLAGS_SIGNED)
+	binary.LittleEndian.PutUint32(message[signFlagsOffset:signFlagsOffset+4], f)
+
+	for i := 0; i < signSignatureLength; i++ {
+		message[signSignatureOffset+i] = 0
+	}
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return
+	}
+	mac := cmac.New(block)
+	mac.Write(message)
+	digest := mac.Sum(nil)
+	copy(message[signSignatureOffset:signSignatureOffset+signSignatureLength], digest[:signSignatureLength])
+}
+
+// verifySignatureCMAC recomputes the AES-128-CMAC signature of a received SMB2
+// message and compares it in constant time to the Signature it carries. The
+// computation is done on a copy so the caller's buffer is left intact.
+func verifySignatureCMAC(key, message []byte) bool {
+	if len(message) < header.SMB2_HEADER_SIZE {
+		return false
+	}
+
+	received := make([]byte, signSignatureLength)
+	copy(received, message[signSignatureOffset:signSignatureOffset+signSignatureLength])
+
+	work := make([]byte, len(message))
+	copy(work, message)
+	for i := 0; i < signSignatureLength; i++ {
+		work[signSignatureOffset+i] = 0
+	}
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return false
+	}
+	mac := cmac.New(block)
+	mac.Write(work)
+	digest := mac.Sum(nil)
+
+	return hmac.Equal(received, digest[:signSignatureLength])
+}
+
+// signMessageForDialect signs a message in place with the algorithm mandated by
+// the negotiated dialect: AES-128-CMAC for the SMB 3.x family, HMAC-SHA256 for
+// SMB 2.0.2/2.1.
+func signMessageForDialect(dialect dialects.Dialect, key, message []byte) {
+	if isSMB3Dialect(dialect) {
+		signMessageCMAC(key, message)
+		return
+	}
+	signMessage(key, message)
+}
+
+// verifySignatureForDialect verifies a message signature with the algorithm
+// mandated by the negotiated dialect.
+func verifySignatureForDialect(dialect dialects.Dialect, key, message []byte) bool {
+	if isSMB3Dialect(dialect) {
+		return verifySignatureCMAC(key, message)
+	}
+	return verifySignature(key, message)
 }

--- a/network/smb/smb_v20/client/smb3crypto_test.go
+++ b/network/smb/smb_v20/client/smb3crypto_test.go
@@ -1,0 +1,231 @@
+package client
+
+import (
+	"bytes"
+	"crypto/aes"
+	"encoding/hex"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/dialects"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/message"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/message/commands"
+)
+
+// TestSMB3CMACSignAndVerify checks the AES-128-CMAC signing round-trip used by
+// the SMB 3.x dialects: a signed message verifies with the right key, sets the
+// SIGNED flag, and fails to verify under a wrong key or after tampering.
+func TestSMB3CMACSignAndVerify(t *testing.T) {
+	key := mustHex(t, "0B7E9C5CAC36C0F6EA9AB275298CEDCE")
+
+	m := message.NewMessage()
+	m.Header.MessageId = 7
+	m.SetCommand(commands.NewTreeDisconnectRequest())
+	wire, err := m.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	signMessageForDialect(dialects.SMB2_DIALECT_3_1_1, key, wire)
+
+	decoded := message.NewMessage()
+	if _, err := decoded.Unmarshal(wire); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if !decoded.Header.Flags.IsSigned() {
+		t.Errorf("SMB2_FLAGS_SIGNED not set after CMAC signing")
+	}
+
+	if !verifySignatureForDialect(dialects.SMB2_DIALECT_3_1_1, key, wire) {
+		t.Errorf("CMAC signature failed to verify with the correct key")
+	}
+	if verifySignatureForDialect(dialects.SMB2_DIALECT_3_1_1, mustHex(t, "00000000000000000000000000000000"), wire) {
+		t.Errorf("CMAC signature verified with a wrong key")
+	}
+	wire[len(wire)-1] ^= 0xFF
+	if verifySignatureForDialect(dialects.SMB2_DIALECT_3_1_1, key, wire) {
+		t.Errorf("CMAC signature verified for a tampered message")
+	}
+}
+
+// TestCCMKnownAnswerRFC3610 checks the AES-CCM implementation against the first
+// test vector from RFC 3610 (M=8, L=2, 8-byte AAD).
+func TestCCMKnownAnswerRFC3610(t *testing.T) {
+	key := mustHex(t, "C0C1C2C3C4C5C6C7C8C9CACBCCCDCECF")
+	nonce := mustHex(t, "00000003020100A0A1A2A3A4A5") // 13 bytes -> L=2
+	aad := mustHex(t, "0001020304050607")
+	plaintext := mustHex(t, "08090A0B0C0D0E0F101112131415161718191A1B1C1D1E")
+	// Expected ciphertext || 8-byte MAC from RFC 3610 packet vector #1.
+	wantCT := mustHex(t, "588C979A61C663D2F066D0C2C0F989806D5F6B61DAC384")
+	wantMAC := mustHex(t, "17E8D12CFDF926E0")
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		t.Fatalf("aes: %v", err)
+	}
+
+	// The RFC 3610 vector uses an 8-byte tag; exercise the generic core through a
+	// dedicated tag length rather than the SMB-fixed 16.
+	tag := ccmTag(block, nonce, plaintext, aad, 15-len(nonce), len(wantMAC))
+	var counter0 [16]byte
+	ccmCounterBlock(counter0[:], nonce, 15-len(nonce), 0)
+	var s0 [16]byte
+	block.Encrypt(s0[:], counter0[:])
+	gotMAC := make([]byte, 8)
+	for i := range gotMAC {
+		gotMAC[i] = tag[i] ^ s0[i]
+	}
+	if !bytes.Equal(gotMAC, wantMAC) {
+		t.Errorf("CCM MAC = %X, want %X", gotMAC, wantMAC)
+	}
+
+	ct := make([]byte, len(plaintext))
+	ccmCTR(block, nonce, 15-len(nonce), plaintext, ct)
+	if !bytes.Equal(ct, wantCT) {
+		t.Errorf("CCM ciphertext = %X, want %X", ct, wantCT)
+	}
+}
+
+// TestCCMSealOpenRoundTrip checks the SMB-shaped AES-128-CCM AEAD (11-byte
+// nonce, 16-byte tag) seals and opens, and rejects tampering.
+func TestCCMSealOpenRoundTrip(t *testing.T) {
+	key := mustHex(t, "00112233445566778899AABBCCDDEEFF")
+	block, _ := aes.NewCipher(key)
+	nonce := mustHex(t, "0102030405060708090A0B") // 11 bytes
+	aad := []byte("transform-header-aad-32bytes!!!!")
+	plaintext := []byte("the quick brown fox jumps over the lazy SMB dog")
+
+	sealed, err := ccmSeal(block, nonce, plaintext, aad)
+	if err != nil {
+		t.Fatalf("ccmSeal: %v", err)
+	}
+	if len(sealed) != len(plaintext)+ccmTagSize {
+		t.Fatalf("sealed length = %d, want %d", len(sealed), len(plaintext)+ccmTagSize)
+	}
+	got, err := ccmOpen(block, nonce, sealed, aad)
+	if err != nil {
+		t.Fatalf("ccmOpen: %v", err)
+	}
+	if !bytes.Equal(got, plaintext) {
+		t.Errorf("ccmOpen = %q, want %q", got, plaintext)
+	}
+	sealed[0] ^= 0xFF
+	if _, err := ccmOpen(block, nonce, sealed, aad); err == nil {
+		t.Errorf("ccmOpen accepted a tampered ciphertext")
+	}
+}
+
+// TestTransformHeaderRoundTrip checks that a message encrypted into an SMB2
+// TRANSFORM_HEADER by the client decrypts back to the original, for both the
+// AES-128-GCM and AES-128-CCM ciphers.
+func TestTransformHeaderRoundTrip(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		cipher uint16
+	}{
+		{"AES-128-GCM", commands.SMB2_ENCRYPTION_AES128_GCM},
+		{"AES-128-CCM", commands.SMB2_ENCRYPTION_AES128_CCM},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &Client{Connection: &Connection{Server: &Server{}, Dialect: dialects.SMB2_DIALECT_3_1_1, Cipher: tc.cipher}}
+			c.Session = &Session{
+				Client:        c,
+				SessionId:     0x1234567890,
+				EncryptionKey: mustHex(t, "629BCBC54422A0F572B97F45989B6073"),
+				DecryptionKey: mustHex(t, "629BCBC54422A0F572B97F45989B6073"),
+				EncryptData:   true,
+			}
+
+			m := message.NewMessage()
+			m.Header.MessageId = 5
+			m.Header.SessionId = c.Session.SessionId
+			m.SetCommand(commands.NewTreeDisconnectRequest())
+			plaintext, err := m.Marshal()
+			if err != nil {
+				t.Fatalf("Marshal: %v", err)
+			}
+
+			enc, err := c.encryptMessage(plaintext)
+			if err != nil {
+				t.Fatalf("encryptMessage: %v", err)
+			}
+			if !isTransformHeader(enc) {
+				t.Fatalf("encrypted frame does not carry the TRANSFORM_HEADER protocol id")
+			}
+			if bytes.Contains(enc[transformHeaderSize:], plaintext) {
+				t.Errorf("plaintext leaked into the encrypted body")
+			}
+
+			dec, err := c.decryptMessage(enc)
+			if err != nil {
+				t.Fatalf("decryptMessage: %v", err)
+			}
+			if !bytes.Equal(dec, plaintext) {
+				t.Errorf("round-trip mismatch:\n got %X\nwant %X", dec, plaintext)
+			}
+
+			// Tampering with the ciphertext must be detected by the AEAD tag.
+			enc[len(enc)-1] ^= 0xFF
+			if _, err := c.decryptMessage(enc); err == nil {
+				t.Errorf("decryptMessage accepted a tampered frame")
+			}
+		})
+	}
+}
+
+// TestNegotiateContextRoundTrip checks that the SMB 3.1.1 negotiate contexts
+// marshal and parse back with 8-byte alignment preserved, and that the
+// selected-cipher / selected-hash helpers read them.
+func TestNegotiateContextRoundTrip(t *testing.T) {
+	req := commands.NewNegotiateRequest()
+	for _, d := range []dialects.Dialect{
+		dialects.SMB2_DIALECT_2_0_2, dialects.SMB2_DIALECT_2_1_0,
+		dialects.SMB2_DIALECT_3_0_0, dialects.SMB2_DIALECT_3_0_2, dialects.SMB2_DIALECT_3_1_1,
+	} {
+		req.AddDialect(d)
+	}
+	salt := mustHex(t, "FA49E6578F1F3A9F4CD3E9CC14A67AA884B3D05844E0E5A118225C15887F32FF")
+	req.Contexts = []*commands.NegotiateContext{
+		commands.NewPreauthIntegrityContext(salt),
+		commands.NewEncryptionContext([]uint16{commands.SMB2_ENCRYPTION_AES128_GCM, commands.SMB2_ENCRYPTION_AES128_CCM}),
+	}
+
+	wire, err := req.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	parsed := commands.NewNegotiateRequest()
+	if _, err := parsed.Unmarshal(wire); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if len(parsed.Contexts) != 2 {
+		t.Fatalf("parsed %d contexts, want 2", len(parsed.Contexts))
+	}
+	if got := commands.SelectedPreauthHash(parsed.Contexts); got != commands.SMB2_PREAUTH_HASH_SHA_512 {
+		t.Errorf("preauth hash = 0x%04x, want SHA-512", got)
+	}
+	// The request's encryption context lists GCM first.
+	if got := commands.SelectedCipher(parsed.Contexts); got != commands.SMB2_ENCRYPTION_AES128_GCM {
+		t.Errorf("selected cipher = 0x%04x, want AES-128-GCM", got)
+	}
+}
+
+// TestPreauthHashMatchesPublishedVector reproduces the published SMB 3.1.1
+// NEGOTIATE-request pre-auth hash step: SHA-512(zeros(64) || request) must equal
+// the documented value.
+func TestPreauthHashMatchesPublishedVector(t *testing.T) {
+	negReq := mustHex(t, ""+
+		"FE534D4240000100000000000000800000000000000000000100000000000000FFFE000000000000"+
+		"00000000000000000000000000000000000000000000000024000500000000003F000000ECD86F32"+
+		"6276024F9F7752B89BB33F3A70000000020000000202100200030203110300000100260000000000"+
+		"010020000100FA49E6578F1F3A9F4CD3E9CC14A67AA884B3D05844E0E5A118225C15887F32FF0000"+
+		"0200060000000000020002000100")
+	want := mustHex(t, ""+
+		"DD94EFC5321BB618A2E208BA8920D2F422992526947A409B5037DE1E0FE8C736"+
+		"2B8C47122594CDE0CE26AA9DFC8BCDBDE0621957672623351A7540F1E54A0426")
+
+	got := preauthUpdate(make([]byte, preauthHashLength), negReq)
+	if !bytes.Equal(got, want) {
+		t.Errorf("pre-auth hash mismatch:\n got %s\nwant %s", hex.EncodeToString(got), hex.EncodeToString(want))
+	}
+}

--- a/network/smb/smb_v20/client/smb3keys.go
+++ b/network/smb/smb_v20/client/smb3keys.go
@@ -1,0 +1,114 @@
+package client
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/binary"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/dialects"
+)
+
+// preauthHashLength is the size of the SMB 3.1.1 pre-authentication integrity
+// hash (SHA-512 digest).
+const preauthHashLength = 64
+
+// preauthUpdate folds a message into the running SMB 3.1.1 pre-authentication
+// integrity hash: hash_new = SHA-512(hash_prev || message), where hash_prev is
+// the 64-byte previous value (all zero at the start of the connection). See
+// MS-SMB2 3.1.4.2 / the pre-auth integrity computation.
+func preauthUpdate(prev, message []byte) []byte {
+	h := sha512.New()
+	h.Write(prev)
+	h.Write(message)
+	return h.Sum(nil)
+}
+
+// SMB 3.x SP800-108 key-derivation labels and contexts (MS-SMB2 3.1.4.2). Each
+// string carries its trailing NUL byte, which also serves as the SP800-108
+// separator between the Label and the Context.
+var (
+	// Dialects 3.0 and 3.0.2 use constant labels and contexts.
+	kdfLabelSigning30 = []byte("SMB2AESCMAC\x00")
+	kdfContextSign30  = []byte("SmbSign\x00")
+	kdfLabelApp30     = []byte("SMB2APP\x00")
+	kdfContextApp30   = []byte("SmbRpc\x00")
+	kdfLabelCipher30  = []byte("SMB2AESCCM\x00")
+	// From the node's perspective the "ServerIn " context yields the key the
+	// client encrypts with (and the server decrypts with); "ServerOut" is the
+	// reverse. The trailing space in "ServerIn " pads it to the length of
+	// "ServerOut".
+	kdfContextServerIn  = []byte("ServerIn \x00")
+	kdfContextServerOut = []byte("ServerOut\x00")
+
+	// Dialect 3.1.1 uses distinct labels; the context is the pre-authentication
+	// integrity hash value instead of a constant.
+	kdfLabelSigning311 = []byte("SMBSigningKey\x00")
+	kdfLabelApp311     = []byte("SMBAppKey\x00")
+	kdfLabelC2SCipher  = []byte("SMBC2SCipherKey\x00")
+	kdfLabelS2CCipher  = []byte("SMBS2CCipherKey\x00")
+)
+
+// sp800108CounterKDF derives a 128-bit key using the NIST SP800-108 KDF in
+// counter mode with HMAC-SHA256 as the PRF, as required by MS-SMB2 3.1.4.2 for
+// the SMB 3.x key hierarchy. The counter width r is 32 bits and the output
+// length L is 128 bits, so a single PRF invocation produces the whole key.
+//
+// The fixed input string is [i]_32 || Label || 0x00 || Context || [L]_32 with
+// i = 1 and L = 128 (both 32-bit big-endian). The MS-SMB2 Label/Context byte
+// strings already carry their own trailing NUL, and the KDF inserts the
+// mandatory 0x00 separator between the label and the context.
+func sp800108CounterKDF(ki, label, context []byte) []byte {
+	mac := hmac.New(sha256.New, ki)
+
+	var counter [4]byte
+	binary.BigEndian.PutUint32(counter[:], 1)
+	mac.Write(counter[:])
+
+	mac.Write(label)
+	mac.Write([]byte{0x00})
+	mac.Write(context)
+
+	var length [4]byte
+	binary.BigEndian.PutUint32(length[:], 128)
+	mac.Write(length[:])
+
+	return mac.Sum(nil)[:16]
+}
+
+// deriveSMB3Keys computes the SMB 3.x signing, encryption, decryption, and
+// application keys for a session from its 16-byte SessionKey, per MS-SMB2
+// 3.1.4.2. For the 3.1.1 dialect the KDF context is the session's
+// pre-authentication integrity hash value; for 3.0/3.0.2 it is a set of fixed
+// constants. The derived SigningKey replaces the session key as the signing key
+// (unlike the 2.x dialects, where the two are identical).
+//
+// EncryptionKey is the key this client uses to encrypt the messages it sends;
+// DecryptionKey is the key it uses to decrypt the server's replies.
+func deriveSMB3Keys(session *Session, dialect dialects.Dialect, preauthHash []byte) {
+	key := session.SessionKey
+
+	switch dialect {
+	case dialects.SMB2_DIALECT_3_0_0, dialects.SMB2_DIALECT_3_0_2:
+		session.SigningKey = sp800108CounterKDF(key, kdfLabelSigning30, kdfContextSign30)
+		session.ApplicationKey = sp800108CounterKDF(key, kdfLabelApp30, kdfContextApp30)
+		session.EncryptionKey = sp800108CounterKDF(key, kdfLabelCipher30, kdfContextServerIn)
+		session.DecryptionKey = sp800108CounterKDF(key, kdfLabelCipher30, kdfContextServerOut)
+	case dialects.SMB2_DIALECT_3_1_1:
+		session.SigningKey = sp800108CounterKDF(key, kdfLabelSigning311, preauthHash)
+		session.ApplicationKey = sp800108CounterKDF(key, kdfLabelApp311, preauthHash)
+		session.EncryptionKey = sp800108CounterKDF(key, kdfLabelC2SCipher, preauthHash)
+		session.DecryptionKey = sp800108CounterKDF(key, kdfLabelS2CCipher, preauthHash)
+	}
+}
+
+// isSMB3Dialect reports whether a negotiated dialect belongs to the SMB 3.x
+// family, which uses the SP800-108 key hierarchy and AES-based signing.
+func isSMB3Dialect(d dialects.Dialect) bool {
+	switch d {
+	case dialects.SMB2_DIALECT_3_0_0, dialects.SMB2_DIALECT_3_0_2, dialects.SMB2_DIALECT_3_1_1:
+		return true
+	default:
+		return false
+	}
+}

--- a/network/smb/smb_v20/client/smb3keys_test.go
+++ b/network/smb/smb_v20/client/smb3keys_test.go
@@ -1,0 +1,70 @@
+package client
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/dialects"
+)
+
+func mustHex(t *testing.T, s string) []byte {
+	t.Helper()
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		t.Fatalf("bad hex %q: %v", s, err)
+	}
+	return b
+}
+
+// TestSMB30KeyDerivationKnownAnswer checks the SP800-108 KDF against the SMB 3.0
+// key-derivation example published by Microsoft (MS-SMB2 anatomy-of-keys).
+func TestSMB30KeyDerivationKnownAnswer(t *testing.T) {
+	sessionKey := mustHex(t, "7CD451825D0450D235424E44BA6E78CC")
+
+	s := &Session{SessionKey: sessionKey}
+	deriveSMB3Keys(s, dialects.SMB2_DIALECT_3_0_0, nil)
+
+	cases := []struct {
+		name string
+		got  []byte
+		want string
+	}{
+		{"SigningKey", s.SigningKey, "0B7E9C5CAC36C0F6EA9AB275298CEDCE"},
+		{"EncryptionKey", s.EncryptionKey, "FAD27796665B313EBB578F388632B4F7"},
+		{"DecryptionKey", s.DecryptionKey, "B0F0427F7CEB416D1D9DCC0CD4F99447"},
+		{"ApplicationKey", s.ApplicationKey, "BB23A4575AA26C721AF525AF15A87B4F"},
+	}
+	for _, c := range cases {
+		if !bytes.Equal(c.got, mustHex(t, c.want)) {
+			t.Errorf("%s = %X, want %s", c.name, c.got, c.want)
+		}
+	}
+}
+
+// TestSMB311KeyDerivationKnownAnswer checks the SP800-108 KDF against the SMB
+// 3.1.1 key-derivation example (pre-auth integrity hash as KDF context).
+func TestSMB311KeyDerivationKnownAnswer(t *testing.T) {
+	sessionKey := mustHex(t, "270E1BA896585EEB7AF3472D3B4C75A7")
+	preauth := mustHex(t, "0DD13628CC3ED218EF9DF9772D436D0887AB9814BFAE63A80AA845F36909DB79"+
+		"28622DDDAD522D9751640A459762C5A9D6BB084CBB3CE6BDADEF5D5BCE3C6C01")
+
+	s := &Session{SessionKey: sessionKey}
+	deriveSMB3Keys(s, dialects.SMB2_DIALECT_3_1_1, preauth)
+
+	cases := []struct {
+		name string
+		got  []byte
+		want string
+	}{
+		{"SigningKey", s.SigningKey, "73FE7A9A77BEF0BDE49C650D8CCB5F76"},
+		{"EncryptionKey", s.EncryptionKey, "629BCBC54422A0F572B97F45989B6073"},
+		{"DecryptionKey", s.DecryptionKey, "E2AF0DCEFAC68DA71A0DFBD0D1350D74"},
+		{"ApplicationKey", s.ApplicationKey, "6D7AD7954E9EC61E907B4D473DC178FF"},
+	}
+	for _, c := range cases {
+		if !bytes.Equal(c.got, mustHex(t, c.want)) {
+			t.Errorf("%s = %X, want %s", c.name, c.got, c.want)
+		}
+	}
+}

--- a/network/smb/smb_v20/client/transform.go
+++ b/network/smb/smb_v20/client/transform.go
@@ -1,0 +1,167 @@
+package client
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"encoding/binary"
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/message/commands"
+)
+
+// SMB2 TRANSFORM_HEADER layout (MS-SMB2 2.2.41). The header is 52 bytes and
+// precedes the encrypted SMB2 message. The bytes from the Nonce field through
+// the end of the header (offsets 20..52) form the additional authenticated data
+// (AAD); the ProtocolId and Signature fields are excluded. The Signature field
+// carries the AEAD authentication tag.
+const (
+	transformHeaderSize = 52
+
+	transformProtocolIDOffset   = 0  // 4 bytes: 0xFD 'S' 'M' 'B'
+	transformSignatureOffset    = 4  // 16 bytes: AEAD tag
+	transformNonceOffset        = 20 // 16 bytes
+	transformOrigMsgSizeOffset  = 36 // 4 bytes
+	transformReservedOffset     = 40 // 2 bytes
+	transformFlagsOffset        = 42 // 2 bytes: Flags (3.1.1) / EncryptionAlgorithm (3.0.x)
+	transformSessionIDOffset    = 44 // 8 bytes
+	transformAADStart           = transformNonceOffset
+	transformSignatureLength    = 16
+	transformNonceLength        = 16
+	gcmNonceLength              = 12
+	ccmNonceLength              = 11
+	transformEncryptedFlagValue = 0x0001 // Flags: Encrypted / EncryptionAlgorithm: AES-128-CCM
+)
+
+// transformProtocolID is the 4-byte marker prefixing an encrypted SMB2 message:
+// 0xFD 'S' 'M' 'B'.
+var transformProtocolID = [4]byte{0xFD, 'S', 'M', 'B'}
+
+// isTransformHeader reports whether a received frame begins with the SMB2
+// TRANSFORM_HEADER protocol identifier and is thus an encrypted message.
+func isTransformHeader(data []byte) bool {
+	return len(data) >= 4 &&
+		data[0] == transformProtocolID[0] &&
+		data[1] == transformProtocolID[1] &&
+		data[2] == transformProtocolID[2] &&
+		data[3] == transformProtocolID[3]
+}
+
+// aeadForCipher returns the authenticated cipher and nonce length for the
+// negotiated encryption algorithm, keyed with the supplied 16-byte key. For the
+// 3.0/3.0.2 dialects the cipher is implicitly AES-128-CCM (cipher == 0).
+func aeadForCipher(cipherID uint16, key []byte) (seal, open func(nonce, msg, aad []byte) ([]byte, error), nonceLen int, algo uint16, err error) {
+	block, berr := aes.NewCipher(key)
+	if berr != nil {
+		return nil, nil, 0, 0, fmt.Errorf("transform: %w", berr)
+	}
+
+	switch cipherID {
+	case commands.SMB2_ENCRYPTION_AES128_GCM, commands.SMB2_ENCRYPTION_AES256_GCM:
+		gcm, gerr := cipher.NewGCMWithNonceSize(block, gcmNonceLength)
+		if gerr != nil {
+			return nil, nil, 0, 0, fmt.Errorf("transform: %w", gerr)
+		}
+		seal = func(nonce, msg, aad []byte) ([]byte, error) { return gcm.Seal(nil, nonce, msg, aad), nil }
+		open = func(nonce, msg, aad []byte) ([]byte, error) { return gcm.Open(nil, nonce, msg, aad) }
+		return seal, open, gcmNonceLength, cipherID, nil
+	case commands.SMB2_ENCRYPTION_AES128_CCM, commands.SMB2_ENCRYPTION_AES256_CCM, 0:
+		seal = func(nonce, msg, aad []byte) ([]byte, error) { return ccmSeal(block, nonce, msg, aad) }
+		open = func(nonce, msg, aad []byte) ([]byte, error) { return ccmOpen(block, nonce, msg, aad) }
+		id := cipherID
+		if id == 0 {
+			id = commands.SMB2_ENCRYPTION_AES128_CCM
+		}
+		return seal, open, ccmNonceLength, id, nil
+	default:
+		return nil, nil, 0, 0, fmt.Errorf("transform: unsupported cipher 0x%04x", cipherID)
+	}
+}
+
+// encryptMessage wraps a marshalled SMB2 message in an SMB2 TRANSFORM_HEADER and
+// encrypts it with the session's EncryptionKey and the connection's negotiated
+// cipher (MS-SMB2 3.1.4.3). The 16-byte Nonce field is filled from a
+// monotonically increasing per-session counter so a nonce is never reused; the
+// AEAD tag is placed in the Signature field.
+func (c *Client) encryptMessage(plaintext []byte) ([]byte, error) {
+	if c.Session == nil || len(c.Session.EncryptionKey) == 0 {
+		return nil, fmt.Errorf("transform: no session encryption key")
+	}
+
+	seal, _, nonceLen, algo, err := aeadForCipher(c.Connection.Cipher, c.Session.EncryptionKey)
+	if err != nil {
+		return nil, err
+	}
+
+	hdr := make([]byte, transformHeaderSize)
+	copy(hdr[transformProtocolIDOffset:], transformProtocolID[:])
+
+	// Unique nonce: a per-session counter encoded little-endian in the leading
+	// bytes of the (16-byte) Nonce field. The unused trailing bytes stay zero, as
+	// the spec requires for both the AES-CCM and AES-GCM nonce structures.
+	c.Session.nonceCounter++
+	nonce := make([]byte, nonceLen)
+	binary.LittleEndian.PutUint64(nonce, c.Session.nonceCounter)
+	copy(hdr[transformNonceOffset:transformNonceOffset+transformNonceLength], nonce)
+
+	binary.LittleEndian.PutUint32(hdr[transformOrigMsgSizeOffset:], uint32(len(plaintext)))
+	binary.LittleEndian.PutUint16(hdr[transformFlagsOffset:], transformEncryptedFlagValue)
+	_ = algo // Flags == EncryptionAlgorithm value (0x0001) for the ciphers we use.
+	binary.LittleEndian.PutUint64(hdr[transformSessionIDOffset:], c.Session.SessionId)
+
+	aad := hdr[transformAADStart:transformHeaderSize]
+	sealed, err := seal(nonce, plaintext, aad)
+	if err != nil {
+		return nil, err
+	}
+
+	// Seal returns ciphertext || tag; split the trailing tag into the Signature
+	// field and keep the ciphertext as the transformed message body.
+	if len(sealed) < transformSignatureLength {
+		return nil, fmt.Errorf("transform: sealed output too short")
+	}
+	ctLen := len(sealed) - transformSignatureLength
+	copy(hdr[transformSignatureOffset:transformSignatureOffset+transformSignatureLength], sealed[ctLen:])
+
+	out := make([]byte, 0, transformHeaderSize+ctLen)
+	out = append(out, hdr...)
+	out = append(out, sealed[:ctLen]...)
+	return out, nil
+}
+
+// decryptMessage unwraps and decrypts an SMB2 TRANSFORM_HEADER frame with the
+// session's DecryptionKey, returning the plaintext SMB2 message. The AEAD tag is
+// taken from the Signature field and reattached to the ciphertext for
+// verification, so a tampered message fails to decrypt.
+func (c *Client) decryptMessage(data []byte) ([]byte, error) {
+	if c.Session == nil || len(c.Session.DecryptionKey) == 0 {
+		return nil, fmt.Errorf("transform: no session decryption key")
+	}
+	if len(data) < transformHeaderSize {
+		return nil, fmt.Errorf("transform: frame shorter than TRANSFORM_HEADER")
+	}
+
+	_, open, nonceLen, _, err := aeadForCipher(c.Connection.Cipher, c.Session.DecryptionKey)
+	if err != nil {
+		return nil, err
+	}
+
+	origSize := binary.LittleEndian.Uint32(data[transformOrigMsgSizeOffset:])
+	nonce := make([]byte, nonceLen)
+	copy(nonce, data[transformNonceOffset:transformNonceOffset+nonceLen])
+	aad := data[transformAADStart:transformHeaderSize]
+	tag := data[transformSignatureOffset : transformSignatureOffset+transformSignatureLength]
+	ciphertext := data[transformHeaderSize:]
+
+	sealed := make([]byte, 0, len(ciphertext)+transformSignatureLength)
+	sealed = append(sealed, ciphertext...)
+	sealed = append(sealed, tag...)
+
+	plaintext, err := open(nonce, sealed, aad)
+	if err != nil {
+		return nil, fmt.Errorf("transform: decryption failed: %w", err)
+	}
+	if uint32(len(plaintext)) != origSize {
+		return nil, fmt.Errorf("transform: decrypted size %d does not match OriginalMessageSize %d", len(plaintext), origSize)
+	}
+	return plaintext, nil
+}

--- a/network/smb/smb_v20/client/tree.go
+++ b/network/smb/smb_v20/client/tree.go
@@ -40,6 +40,15 @@ func (c *Client) TreeConnect(shareName string) error {
 	treeId := response.Header.TreeId
 	c.Session.TreeId = treeId
 
+	// An SMB 3.x share may require encryption; when the server sets the
+	// SMB2_SHAREFLAG_ENCRYPT_DATA flag, encrypt all subsequent traffic on this
+	// session.
+	if isSMB3Dialect(c.Connection.Dialect) &&
+		treeConnectResponse.ShareFlags&commands.SMB2_SHAREFLAG_ENCRYPT_DATA != 0 &&
+		len(c.Session.EncryptionKey) > 0 {
+		c.Session.EncryptData = true
+	}
+
 	tc := &TreeConnect{
 		Connection: c.Connection,
 		Session:    c.Session,

--- a/network/smb/smb_v20/message/commands/NegotiateContext.go
+++ b/network/smb/smb_v20/message/commands/NegotiateContext.go
@@ -1,0 +1,148 @@
+package commands
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/message/header"
+)
+
+// SMB2 NEGOTIATE context types (MS-SMB2 2.2.3.1), carried in the SMB 3.1.1
+// NEGOTIATE Request/Response after the dialects array.
+const (
+	SMB2_PREAUTH_INTEGRITY_CAPABILITIES = 0x0001
+	SMB2_ENCRYPTION_CAPABILITIES        = 0x0002
+	SMB2_COMPRESSION_CAPABILITIES       = 0x0003
+	SMB2_NETNAME_NEGOTIATE_CONTEXT_ID   = 0x0005
+	SMB2_TRANSPORT_CAPABILITIES         = 0x0006
+	SMB2_RDMA_TRANSFORM_CAPABILITIES    = 0x0007
+	SMB2_SIGNING_CAPABILITIES           = 0x0008
+)
+
+// SMB2 pre-authentication integrity hash algorithm IDs (MS-SMB2 2.2.3.1.1).
+const SMB2_PREAUTH_HASH_SHA_512 = 0x0001
+
+// SMB2 encryption cipher IDs (MS-SMB2 2.2.3.1.2).
+const (
+	SMB2_ENCRYPTION_AES128_CCM = 0x0001
+	SMB2_ENCRYPTION_AES128_GCM = 0x0002
+	SMB2_ENCRYPTION_AES256_CCM = 0x0003
+	SMB2_ENCRYPTION_AES256_GCM = 0x0004
+)
+
+// NegotiateContext is a single SMB2 NEGOTIATE context: a 2-byte type, a 2-byte
+// data length, 4 reserved bytes, and the context-specific data. On the wire the
+// contexts are 8-byte aligned relative to the start of the SMB2 header.
+//
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/15332256-522e-4a53-8cd7-0bd17678a2f7
+type NegotiateContext struct {
+	ContextType uint16
+	Data        []byte
+}
+
+// NewPreauthIntegrityContext builds an SMB2_PREAUTH_INTEGRITY_CAPABILITIES
+// context advertising the SHA-512 hash algorithm and the supplied salt.
+func NewPreauthIntegrityContext(salt []byte) *NegotiateContext {
+	data := make([]byte, 6+len(salt))
+	binary.LittleEndian.PutUint16(data[0:2], 1) // HashAlgorithmCount
+	binary.LittleEndian.PutUint16(data[2:4], uint16(len(salt)))
+	binary.LittleEndian.PutUint16(data[4:6], SMB2_PREAUTH_HASH_SHA_512)
+	copy(data[6:], salt)
+	return &NegotiateContext{ContextType: SMB2_PREAUTH_INTEGRITY_CAPABILITIES, Data: data}
+}
+
+// NewEncryptionContext builds an SMB2_ENCRYPTION_CAPABILITIES context
+// advertising the supplied ciphers in preference order.
+func NewEncryptionContext(ciphers []uint16) *NegotiateContext {
+	data := make([]byte, 2+2*len(ciphers))
+	binary.LittleEndian.PutUint16(data[0:2], uint16(len(ciphers)))
+	for i, c := range ciphers {
+		binary.LittleEndian.PutUint16(data[2+2*i:], c)
+	}
+	return &NegotiateContext{ContextType: SMB2_ENCRYPTION_CAPABILITIES, Data: data}
+}
+
+// marshalNegotiateContexts serializes a list of negotiate contexts, 8-byte
+// aligning each one relative to the start of the SMB2 header. bodyOffset is the
+// offset, within the message body, immediately after the dialects array (before
+// any alignment). It returns the padding + context bytes to append to the body
+// and the header-relative offset of the first context (the value for the
+// NegotiateContextOffset field).
+func marshalNegotiateContexts(bodyOffset int, contexts []*NegotiateContext) ([]byte, int) {
+	var out []byte
+	cur := bodyOffset
+
+	pad := func() {
+		if p := (8 - (header.SMB2_HEADER_SIZE+cur)%8) % 8; p > 0 {
+			out = append(out, make([]byte, p)...)
+			cur += p
+		}
+	}
+
+	pad()
+	first := header.SMB2_HEADER_SIZE + cur
+	for i, ctx := range contexts {
+		if i > 0 {
+			pad()
+		}
+		var h [8]byte
+		binary.LittleEndian.PutUint16(h[0:2], ctx.ContextType)
+		binary.LittleEndian.PutUint16(h[2:4], uint16(len(ctx.Data)))
+		out = append(out, h[:]...)
+		out = append(out, ctx.Data...)
+		cur += 8 + len(ctx.Data)
+	}
+	return out, first
+}
+
+// parseNegotiateContexts decodes count negotiate contexts from data, whose first
+// context begins at headerRelativeOffset (relative to the start of the SMB2
+// header). data begins at the message body (immediately after the 64-byte
+// header). Each context is 8-byte aligned relative to the header.
+func parseNegotiateContexts(data []byte, headerRelativeOffset int, count int) ([]*NegotiateContext, error) {
+	contexts := make([]*NegotiateContext, 0, count)
+	off := headerRelativeOffset - header.SMB2_HEADER_SIZE
+	for i := 0; i < count; i++ {
+		// Align to 8 relative to the header.
+		if p := (8 - (header.SMB2_HEADER_SIZE+off)%8) % 8; p > 0 {
+			off += p
+		}
+		if off+8 > len(data) {
+			return nil, fmt.Errorf("negotiate context %d header out of bounds", i)
+		}
+		ctxType := binary.LittleEndian.Uint16(data[off : off+2])
+		dataLen := int(binary.LittleEndian.Uint16(data[off+2 : off+4]))
+		off += 8
+		if off+dataLen > len(data) {
+			return nil, fmt.Errorf("negotiate context %d data out of bounds", i)
+		}
+		cd := make([]byte, dataLen)
+		copy(cd, data[off:off+dataLen])
+		contexts = append(contexts, &NegotiateContext{ContextType: ctxType, Data: cd})
+		off += dataLen
+	}
+	return contexts, nil
+}
+
+// SelectedCipher returns the cipher ID from an SMB2_ENCRYPTION_CAPABILITIES
+// context in the list (the server echoes its single chosen cipher), or 0 if
+// none is present.
+func SelectedCipher(contexts []*NegotiateContext) uint16 {
+	for _, ctx := range contexts {
+		if ctx.ContextType == SMB2_ENCRYPTION_CAPABILITIES && len(ctx.Data) >= 4 {
+			return binary.LittleEndian.Uint16(ctx.Data[2:4])
+		}
+	}
+	return 0
+}
+
+// SelectedPreauthHash returns the hash algorithm ID from an
+// SMB2_PREAUTH_INTEGRITY_CAPABILITIES context in the list, or 0 if none.
+func SelectedPreauthHash(contexts []*NegotiateContext) uint16 {
+	for _, ctx := range contexts {
+		if ctx.ContextType == SMB2_PREAUTH_INTEGRITY_CAPABILITIES && len(ctx.Data) >= 8 {
+			return binary.LittleEndian.Uint16(ctx.Data[4:6])
+		}
+	}
+	return 0
+}

--- a/network/smb/smb_v20/message/commands/NegotiateRequest.go
+++ b/network/smb/smb_v20/message/commands/NegotiateRequest.go
@@ -43,12 +43,18 @@ type NegotiateRequest struct {
 
 	// ClientStartTime (8 bytes): MUST NOT be used; the client sets this to 0. In
 	// the SMB 3.1.1 dialect this 8-byte span is reinterpreted as the negotiate
-	// context offset/count/reserved, which is deferred to the SMB 3.x work.
+	// context offset (4 bytes) + count (2 bytes) + reserved (2 bytes); when
+	// Contexts is non-empty those fields are written instead of ClientStartTime.
 	ClientStartTime types.UINT64
 
 	// Dialects (variable): The 16-bit dialect revision numbers supported by the
 	// client. DialectCount is derived from this slice on marshal.
 	Dialects []dialects.Dialect
+
+	// Contexts holds the SMB 3.1.1 negotiate contexts (pre-auth integrity,
+	// encryption, ...) appended after the dialects array. Empty for dialects
+	// below 3.1.1.
+	Contexts []*NegotiateContext
 }
 
 // NewNegotiateRequest creates a new SMB2 NEGOTIATE Request.
@@ -81,6 +87,16 @@ func (c *NegotiateRequest) Marshal() ([]byte, error) {
 		buf = append(buf, d...)
 	}
 
+	// SMB 3.1.1: append the negotiate contexts and record their header-relative
+	// offset and count in the reinterpreted ClientStartTime span.
+	if len(c.Contexts) > 0 {
+		ctxBytes, firstOffset := marshalNegotiateContexts(len(buf), c.Contexts)
+		binary.LittleEndian.PutUint32(buf[28:32], uint32(firstOffset))
+		binary.LittleEndian.PutUint16(buf[32:34], uint16(len(c.Contexts)))
+		binary.LittleEndian.PutUint16(buf[34:36], 0) // Reserved2
+		buf = append(buf, ctxBytes...)
+	}
+
 	return buf, nil
 }
 
@@ -106,6 +122,18 @@ func (c *NegotiateRequest) Unmarshal(data []byte) (int, error) {
 	for i := 0; i < dialectCount; i++ {
 		c.Dialects[i] = dialects.Dialect(binary.LittleEndian.Uint16(data[offset : offset+2]))
 		offset += 2
+	}
+
+	// SMB 3.1.1: the reinterpreted ClientStartTime span carries the negotiate
+	// context offset and count. Parse the contexts when present.
+	contextOffset := int(binary.LittleEndian.Uint32(data[28:32]))
+	contextCount := int(binary.LittleEndian.Uint16(data[32:34]))
+	if contextCount > 0 {
+		contexts, err := parseNegotiateContexts(data, contextOffset, contextCount)
+		if err != nil {
+			return 0, err
+		}
+		c.Contexts = contexts
 	}
 
 	return offset, nil

--- a/network/smb/smb_v20/message/commands/NegotiateResponse.go
+++ b/network/smb/smb_v20/message/commands/NegotiateResponse.go
@@ -66,6 +66,10 @@ type NegotiateResponse struct {
 	// SecurityBuffer (variable): The GSS security token. SecurityBufferOffset and
 	// SecurityBufferLength are computed from this on marshal.
 	SecurityBuffer []byte
+
+	// Contexts holds the SMB 3.1.1 negotiate contexts the server returned (its
+	// chosen pre-auth integrity hash and cipher). Empty for dialects below 3.1.1.
+	Contexts []*NegotiateContext
 }
 
 // NewNegotiateResponse creates a new SMB2 NEGOTIATE Response.
@@ -136,6 +140,18 @@ func (c *NegotiateResponse) Unmarshal(data []byte) (int, error) {
 		consumed = start + securityBufferLength
 	} else {
 		c.SecurityBuffer = []byte{}
+	}
+
+	// SMB 3.1.1: parse the negotiate contexts the server returned.
+	if c.NegotiateContextCount > 0 && c.NegotiateContextOffset != 0 {
+		contexts, err := parseNegotiateContexts(data, int(c.NegotiateContextOffset), int(c.NegotiateContextCount))
+		if err != nil {
+			return 0, err
+		}
+		c.Contexts = contexts
+		if end := int(c.NegotiateContextOffset) - header.SMB2_HEADER_SIZE; end > consumed && end <= len(data) {
+			consumed = len(data)
+		}
 	}
 
 	return consumed, nil

--- a/network/smb/smb_v20/message/commands/TreeConnectResponse.go
+++ b/network/smb/smb_v20/message/commands/TreeConnectResponse.go
@@ -19,6 +19,10 @@ const (
 	SMB2_SHARE_TYPE_PRINT = 0x03
 )
 
+// SMB2_SHAREFLAG_ENCRYPT_DATA indicates the server requires messages on this
+// share to be encrypted (SMB 3.x; TREE_CONNECT Response ShareFlags field).
+const SMB2_SHAREFLAG_ENCRYPT_DATA = 0x00008000
+
 // TreeConnectResponse is the SMB2 TREE_CONNECT Response body, sent by the server
 // when a TREE_CONNECT request succeeds.
 //


### PR DESCRIPTION
### Linked Issue
`Closes #914`

### Summary
Extends the SMB2 client beyond the 2.0.2/2.1 dialects to the full SMB 3.x family (3.0, 3.0.2, 3.1.1), adding the SMB 3.x cryptographic hierarchy: the SP800-108 signing/encryption key KDF, AES-128-CMAC signing, and AES-128-GCM / AES-128-CCM encryption. The client previously capped at HMAC-SHA256 signing with the signing key equal to the GSS session key, so it could neither negotiate the higher dialects nor provide SMB3 confidentiality.

### Changes
- **Negotiate** (`negotiate.go`, `NegotiateRequest.go`, `NegotiateResponse.go`, `NegotiateContext.go`): offer dialects 2.0.2 through 3.1.1, advertise `SMB2_GLOBAL_CAP_LARGE_MTU` / `SMB2_GLOBAL_CAP_ENCRYPTION`, and for 3.1.1 emit the `SMB2_PREAUTH_INTEGRITY_CAPABILITIES` (SHA-512 + salt) and `SMB2_ENCRYPTION_CAPABILITIES` (AES-128-GCM, AES-128-CCM) negotiate contexts. The server's chosen cipher and hash are parsed back from the response contexts.
- **Key derivation** (`smb3keys.go`): SP800-108 CTR-HMAC-SHA256 KDF (r=32, L=128) derives `SigningKey`, `EncryptionKey`, `DecryptionKey`, and `ApplicationKey` from the 16-byte GSS session key. For 3.1.1 the KDF context is the pre-authentication integrity hash (a SHA-512 running hash folded over the exact NEGOTIATE and SESSION_SETUP wire bytes, MS-SMB2 3.1.4.2); for 3.0/3.0.2 the labels/contexts are the fixed constants (`SMB2AESCMAC`/`SmbSign`, `SMB2AESCCM`/`ServerIn `/`ServerOut`, `SMB2APP`/`SmbRpc`).
- **Signing** (`signing.go`, `engine.go`): AES-128-CMAC for the SMB 3.x dialects (the 3.1.1 default when no signing-capabilities context is offered), HMAC-SHA256 for 2.x, dispatched by negotiated dialect. The `CreditCharge` model switches to 1 for dialects >= 2.1.
- **Encryption** (`transform.go`, `ccm.go`): SMB2 TRANSFORM_HEADER wrap/unwrap using AES-128-GCM (stdlib `crypto/cipher`) and a native AES-CCM (RFC 3610) implemented on `crypto/aes`, selected by the negotiated cipher. A per-session monotonic counter supplies the nonce; the AEAD tag lives in the Signature field and supersedes per-message signing. Encryption activates on a server-required session flag, a share `SMB2_SHAREFLAG_ENCRYPT_DATA` flag, or `EnableEncryption()`.
- Both the **Kerberos** and **NTLM** session-setup paths derive the 3.x key hierarchy and verify the server's signature over the final SESSION_SETUP response to confirm the derived signing key.

Pure Go standard library only; no new dependencies.

### How Verified
Live-validated against Windows Server 2016 (`tmp-w-2016.tmp-w-2016.local`, realm `TMP-W-2016.LOCAL`) over SMB on 445:
- Negotiated **SMB 3.1.1**, cipher **AES-128-GCM** (0x0002), pre-auth hash **SHA-512** (0x0001).
- Native-Kerberos `SessionSetupKerberos` (SPN `cifs/tmp-w-2016.tmp-w-2016.local`): the server's signature over the final SESSION_SETUP response verified against the SP800-108-derived signing key, then an **SMB3 AES-CMAC-signed** TreeConnect to `IPC$` was accepted.
- With encryption enabled, an **AES-128-GCM TRANSFORM_HEADER** TreeConnect to `C$` round-tripped end-to-end.
- No regression: the NTLM session-setup path (now over 3.1.1) derives keys, verifies the final-response signature, and signs a TreeConnect; the 2.0.2/2.1 mock-server unit tests (HMAC-SHA256 signing, `CreditCharge`=0) still pass.

### Test Coverage
**Added** (`smb3keys_test.go`, `smb3crypto_test.go`):
- `TestSMB30KeyDerivationKnownAnswer`, `TestSMB311KeyDerivationKnownAnswer` — SP800-108 KDF against the published MS-SMB2 key-derivation vectors.
- `TestSMB3CMACSignAndVerify` — AES-128-CMAC signing round-trip and tamper/wrong-key rejection.
- `TestCCMKnownAnswerRFC3610` — AES-CCM against RFC 3610 packet vector #1.
- `TestCCMSealOpenRoundTrip`, `TestTransformHeaderRoundTrip` — AES-CCM and TRANSFORM_HEADER (GCM + CCM) round-trips with tamper detection.
- `TestNegotiateContextRoundTrip` — 3.1.1 negotiate-context marshal/parse with alignment.
- `TestPreauthHashMatchesPublishedVector` — SHA-512 pre-auth hash against the published NEGOTIATE-request step.

### Scope of Change
- **Files changed:** `network/smb/smb_v20/client/{negotiate,signing,engine,session,session_kerberos,tree,client_functions,client_structures}.go`, new `client/{smb3keys,transform,ccm}.go` + tests; `message/commands/{NegotiateRequest,NegotiateResponse,TreeConnectResponse}.go`, new `commands/NegotiateContext.go`.
- **Submodule pointer updated:** no.
- **Behavioral changes outside the feature:** the client now negotiates up to SMB 3.1.1 by default (previously 2.0.2 only), so a modern server will select 3.1.1.

### Notes
The SMB 3.1.1 default signing algorithm is AES-128-CMAC (this is what the DC negotiates when no `SMB2_SIGNING_CAPABILITIES` context is offered). AES-GMAC signing and the accompanying signing-capabilities context negotiation are not included; the GCM primitive it would reuse is already present for encryption. This can follow up under a separate issue if GMAC negotiation is desired.