### PR TITLE
Support AES per-message for DCE-style Kerberos RPC (Fixes #915)

### DIFF
--- a/network/dcerpc/v5/client/auth.go
+++ b/network/dcerpc/v5/client/auth.go
@@ -118,7 +118,9 @@ func (c *Client) protectsRequests() bool {
 // sec_trailer, and the auth_value token. The token size is provider-specific (NTLM: 16;
 // Netlogon: larger), so it is taken from the active security context at its sealing level.
 func (c *Client) authVerifierOverhead() int {
-	return 3 + pdu.SecTrailerSize + c.sec.AuthValueLen(c.authLevel == pdu.AuthLevelPktPrivacy)
+	// A negative stub length requests the largest token the provider can emit, so
+	// the reservation is safe for any fragment stub size.
+	return 3 + pdu.SecTrailerSize + c.sec.AuthValueLen(c.authLevel == pdu.AuthLevelPktPrivacy, -1)
 }
 
 // negotiateToken builds the auth_value carried in the bind's auth verifier. For a single-leg
@@ -288,7 +290,6 @@ func (c *Client) marshalProtectedRequest(req *pdu.Request) ([]byte, error) {
 	}
 
 	seal := c.authLevel == pdu.AuthLevelPktPrivacy
-	tokenLen := c.sec.AuthValueLen(seal)
 
 	allocHint := req.AllocHint
 	if allocHint == 0 {
@@ -304,6 +305,10 @@ func (c *Client) marshalProtectedRequest(req *pdu.Request) ([]byte, error) {
 	pad := (4 - (len(req.Stub) % 4)) % 4
 	stubPad := make([]byte, len(req.Stub)+pad)
 	copy(stubPad, req.Stub)
+
+	// The auth_value length can depend on the padded stub length (the AES Kerberos
+	// Wrap token grows with the stub's block padding), so it is computed here.
+	tokenLen := c.sec.AuthValueLen(seal, len(stubPad))
 
 	st := pdu.SecTrailer{
 		AuthType:      c.authType,
@@ -371,8 +376,14 @@ func (c *Client) unprotectResponseStub(frag []byte) ([]byte, error) {
 	}
 	seal := c.authLevel == pdu.AuthLevelPktPrivacy
 	authLen := int(hdr.AuthLength)
-	if want := c.sec.AuthValueLen(seal); authLen != want {
-		return nil, fmt.Errorf("unexpected auth_length %d, want %d", authLen, want)
+	// A signing token is a fixed size, so verify the auth_length up front. Sealed
+	// (PKT_PRIVACY) Kerberos Wrap tokens vary in length with the sender's block
+	// padding (the AES CFX EC filler), so their length is validated by the
+	// provider's Unseal rather than compared to a fixed expectation here.
+	if !seal {
+		if want := c.sec.AuthValueLen(seal, 0); authLen != want {
+			return nil, fmt.Errorf("unexpected auth_length %d, want %d", authLen, want)
+		}
 	}
 	fragLen := int(hdr.FragLength)
 	if fragLen > len(frag) {

--- a/network/dcerpc/v5/client/auth_kerberos.go
+++ b/network/dcerpc/v5/client/auth_kerberos.go
@@ -27,14 +27,15 @@ import (
 //   - PKT / PKT_INTEGRITY protect each PDU with a GSS MIC. Windows requires these
 //     to be negotiated through SPNEGO (auth_type 0x09, RPC_C_AUTHN_GSS_NEGOTIATE)
 //     with GSS_C_DCE_STYLE: a three-leg handshake (bind AP-REQ, bind_ack AP-REP,
-//     alter_context with the initiator's own AP-REP) establishes the context, and
-//     an RC4-HMAC service ticket is requested (the RFC 4757 per-message tokens
-//     Windows expects here).
-//   - PKT_PRIVACY (sealing) uses the same SPNEGO/DCE-style handshake and RC4-HMAC
-//     service ticket, and additionally seals the stub with an RFC 4757 GSS Wrap
-//     token (tok_id 02 01): the stub is encrypted in place while the PDU header
-//     and sec_trailer stay sign-only, and the Wrap token travels in the
-//     auth_value.
+//     alter_context with the initiator's own AP-REP) establishes the context. The
+//     MIC token type follows the negotiated session key: an RFC 4121 CFX MIC
+//     (tok_id 04 04) for an AES ticket, or the RFC 4757 MIC (tok_id 01 01) for an
+//     RC4 ticket.
+//   - PKT_PRIVACY (sealing) uses the same SPNEGO/DCE-style handshake and, matching
+//     the MIC path, seals the stub with the enctype-appropriate GSS Wrap token: an
+//     RFC 4121 CFX Wrap (tok_id 05 04) for AES or the RFC 4757 Wrap (tok_id 02 01)
+//     for RC4. The stub is encrypted in place while the PDU header and sec_trailer
+//     stay sign-only, and the Wrap token travels in the auth_value.
 //
 // Call before Bind.
 func (c *Client) SetAuthKerberos(authLevel uint8, kc *kerberos.KerberosClient, spn string) error {
@@ -59,12 +60,12 @@ func (c *Client) SetAuthKerberos(authLevel uint8, kc *kerberos.KerberosClient, s
 			return fmt.Errorf("dcerpc auth: kerberos GetTGT: %w", err)
 		}
 	}
-	if perMessage {
-		// Windows RPC's DCE-style per-message protection interoperates with RC4 on
-		// this class of server; request an RC4 service ticket.
-		kc.PreferRC4ServiceTicket()
-	}
-	ticket, ticketRaw, key, err := kc.GetTGS(spn, true)
+	// The per-message token type follows the negotiated service-ticket session
+	// key: an AES ticket yields RFC 4121 CFX tokens, an RC4 ticket the RFC 4757
+	// tokens. No enctype is forced here — the client's TGS-REQ prefers AES, so an
+	// AES-capable target produces AES per-message protection, and a target that
+	// can only issue an RC4 session key transparently falls back to RC4 tokens.
+	_, ticketRaw, key, keyEType, err := kc.GetTGS(spn, true)
 	if err != nil {
 		return fmt.Errorf("dcerpc auth: kerberos GetTGS %q: %w", spn, err)
 	}
@@ -78,7 +79,7 @@ func (c *Client) SetAuthKerberos(authLevel uint8, kc *kerberos.KerberosClient, s
 	initOpts := gssapi.InitOptions{
 		TicketRaw:    ticketRaw,
 		SessionKey:   key,
-		SessionEType: ticket.EncPart.EType,
+		SessionEType: keyEType,
 		ClientName:   messages.PrincipalName{NameType: messages.NameTypePrincipal, NameString: []string{kc.Username()}},
 		ClientRealm:  kc.Realm(),
 		Flags:        flags,
@@ -91,12 +92,12 @@ func (c *Client) SetAuthKerberos(authLevel uint8, kc *kerberos.KerberosClient, s
 		// Connect level asserts an initiator subkey (as generic Windows GSS clients
 		// do). The DCE-style per-message path omits it so the acceptor chooses the
 		// subkey, matching the Windows RPC client.
-		subKey := make([]byte, kerbcrypto.KeyLen(ticket.EncPart.EType))
+		subKey := make([]byte, kerbcrypto.KeyLen(keyEType))
 		if _, err := rand.Read(subKey); err != nil {
 			return err
 		}
 		initOpts.SubKey = subKey
-		initOpts.SubKeyEType = ticket.EncPart.EType
+		initOpts.SubKeyEType = keyEType
 	}
 	apReq, ctx, err := gssapi.InitSecContext(initOpts)
 	if err != nil {
@@ -133,8 +134,9 @@ func (c *Client) SetAuthKerberos(authLevel uint8, kc *kerberos.KerberosClient, s
 
 // kerberosSecurityContext adapts a GSS-API SecContext to the RPC SecurityContext
 // interface. The per-PDU verifier is a GSS token over the request/response stub:
-// a MIC (integrity only, stub in the clear) for PKT/PKT_INTEGRITY, or an RC4-HMAC
-// Wrap token (RFC 4757 §7.4) that seals the stub for PKT_PRIVACY. It also
+// a MIC (integrity only, stub in the clear) for PKT/PKT_INTEGRITY, or a Wrap token
+// that seals the stub for PKT_PRIVACY. The token family (RFC 4121 CFX for AES,
+// RFC 4757 for RC4) follows the negotiated session/subkey enctype. It also
 // implements bindCompleter to complete the mutual-auth handshake.
 type kerberosSecurityContext struct {
 	ctx *gssapi.SecContext
@@ -197,11 +199,12 @@ func (k *kerberosSecurityContext) CompleteBind(bindAckAuthValue []byte) ([]byte,
 }
 
 // AuthValueLen is the GSS token length carried in the auth_value: for sealing
-// (PKT_PRIVACY) the RC4-HMAC Wrap token, otherwise the MIC token. Both are fixed
-// for a given context (the RC4 tokens have no etype-dependent variation here).
-func (k *kerberosSecurityContext) AuthValueLen(seal bool) int {
+// (PKT_PRIVACY) the Wrap token, otherwise the MIC token. The length depends on
+// the negotiated enctype (CFX header plus the etype checksum for AES, or the
+// fixed RFC 4757 layout for RC4).
+func (k *kerberosSecurityContext) AuthValueLen(seal bool, stubLen int) int {
 	if seal {
-		return k.ctx.WrapTokenLen()
+		return k.ctx.WrapTokenLen(stubLen)
 	}
 	return k.ctx.MICTokenLen()
 }
@@ -209,8 +212,8 @@ func (k *kerberosSecurityContext) AuthValueLen(seal bool) int {
 // ProtectRequest protects the request stub. For PKT_PRIVACY it seals the stub
 // with a GSS Wrap token and returns the encrypted stub plus the Wrap token; for
 // PKT/PKT_INTEGRITY it signs the stub with a GSS MIC token and returns the stub
-// unchanged. Per MS-RPCE the RC4 tokens cover only the stub (pduData), not the
-// PDU header or sec_trailer, so signedRegion is unused.
+// unchanged. Per MS-RPCE the Kerberos per-message tokens cover only the stub
+// (pduData), not the PDU header or sec_trailer, so signedRegion is unused.
 func (k *kerberosSecurityContext) ProtectRequest(signedRegion, stub []byte, seal bool) ([]byte, []byte, error) {
 	if seal {
 		sealed, token, err := k.ctx.Seal(stub)

--- a/network/dcerpc/v5/client/secctx.go
+++ b/network/dcerpc/v5/client/secctx.go
@@ -14,9 +14,13 @@ import (
 // padding, header fields, sec_trailer), which is provider-independent ([MS-RPCE] 2.2.2.11).
 type SecurityContext interface {
 	// AuthValueLen returns the auth_value byte length this provider emits, given whether the
-	// request is sealed (PKT_PRIVACY) or only signed (PKT/PKT_INTEGRITY). It must be known
-	// before the PDU header is marshalled, since it feeds auth_length and frag_length.
-	AuthValueLen(seal bool) int
+	// request is sealed (PKT_PRIVACY) or only signed (PKT/PKT_INTEGRITY) and the length of the
+	// padded stub being protected. It must be known before the PDU header is marshalled, since
+	// it feeds auth_length and frag_length. Most providers emit a fixed-size token independent
+	// of the stub (NTLM, and the RC4 Kerberos tokens); the AES Kerberos Wrap token grows with
+	// the stub's block padding, so stubLen is consulted. A negative stubLen requests the
+	// largest possible length, for worst-case trailer sizing before the stub length is fixed.
+	AuthValueLen(seal bool, stubLen int) int
 
 	// ProtectRequest produces the on-wire stub and the auth_value for one outbound request
 	// fragment. signedRegion is the marshalled PDU from the header through the sec_trailer
@@ -49,8 +53,8 @@ type bindCompleter interface {
 // operate over signedRegion; only the stub is sealed for PKT_PRIVACY ([MS-RPCE] 3.3, NTLM2).
 type ntlmSecurityContext struct{ ctx *security.Context }
 
-// AuthValueLen is the fixed NTLM signature size regardless of seal level.
-func (n *ntlmSecurityContext) AuthValueLen(bool) int { return security.SignatureSize }
+// AuthValueLen is the fixed NTLM signature size regardless of seal level or stub length.
+func (n *ntlmSecurityContext) AuthValueLen(bool, int) int { return security.SignatureSize }
 
 // ProtectRequest signs signedRegion (and, when sealing, encrypts the stub) exactly as the
 // NTLM2 sender rules require.

--- a/network/dcerpc/v5/client/secctx_test.go
+++ b/network/dcerpc/v5/client/secctx_test.go
@@ -26,7 +26,7 @@ type fakeSecCtx struct {
 	unprotectCalled bool
 }
 
-func (f *fakeSecCtx) AuthValueLen(bool) int { return f.tokenLen }
+func (f *fakeSecCtx) AuthValueLen(bool, int) int { return f.tokenLen }
 
 func (f *fakeSecCtx) ProtectRequest(signedRegion, stub []byte, seal bool) ([]byte, []byte, error) {
 	f.gotSignedRegion = append([]byte(nil), signedRegion...)

--- a/network/kerberos/v5/client.go
+++ b/network/kerberos/v5/client.go
@@ -25,7 +25,7 @@ import (
 //	c := kerberos.NewClient("john", "CORP.LOCAL", "10.0.0.1")
 //	c.WithPassword("secret")
 //	if err := c.GetTGT(); err != nil { ... }
-//	ticket, ticketRaw, sessionKey, err := c.GetTGS("cifs/dc01.corp.local", true)
+//	ticket, ticketRaw, sessionKey, sessionEType, err := c.GetTGS("cifs/dc01.corp.local", true)
 type KerberosClient struct {
 	username string
 	realm    string
@@ -251,21 +251,26 @@ func pacRequestPA() messages.PAData {
 //
 // Returns the parsed service Ticket, the raw APPLICATION[1] ticket bytes as
 // received from the KDC (suitable for verbatim re-emission in a downstream
-// AP-REQ via messages.APReq{TicketRaw: ...}.Marshal), and the associated
-// session key bytes.
-func (c *KerberosClient) GetTGS(spn string, includePAC bool) (messages.Ticket, []byte, []byte, error) {
+// AP-REQ via messages.APReq{TicketRaw: ...}.Marshal), the associated session
+// key bytes, and the session key's encryption type. The session-key etype is
+// the KDC's choice and is not necessarily the ticket's own encryption type
+// (the server long-term key etype): a Windows KDC can, for example, wrap an
+// AES256 ticket around an RC4 session key. Callers keying the AP-REQ
+// authenticator or per-message GSS tokens must use this returned etype, not
+// Ticket.EncPart.EType.
+func (c *KerberosClient) GetTGS(spn string, includePAC bool) (messages.Ticket, []byte, []byte, int, error) {
 	// A preloaded (forged silver / captured) service ticket for this SPN is
 	// returned directly, with no TGT and no KDC round-trip.
 	if pt, ok := c.preloadedTGS[normalizeSPN(spn)]; ok {
-		return pt.ticket, pt.ticketRaw, pt.sessionKey, nil
+		return pt.ticket, pt.ticketRaw, pt.sessionKey, pt.sessionEType, nil
 	}
 	if !c.hasTGT {
-		return messages.Ticket{}, nil, nil, fmt.Errorf("kerberos: no TGT: call GetTGT first")
+		return messages.Ticket{}, nil, nil, 0, fmt.Errorf("kerberos: no TGT: call GetTGT first")
 	}
 
 	sname, err := parseSPN(spn, c.realm)
 	if err != nil {
-		return messages.Ticket{}, nil, nil, fmt.Errorf("kerberos: parse SPN %q: %w", spn, err)
+		return messages.Ticket{}, nil, nil, 0, fmt.Errorf("kerberos: parse SPN %q: %w", spn, err)
 	}
 
 	// Request the service ticket, chasing any cross-realm referrals returned by

--- a/network/kerberos/v5/gssapi/permessage.go
+++ b/network/kerberos/v5/gssapi/permessage.go
@@ -143,35 +143,134 @@ func (ctx *SecContext) MICTokenLen() int {
 }
 
 // WrapTokenLen returns the auth_value length of a DCE-style Wrap token this
-// context emits when sealing. Only the RFC 4757 RC4-HMAC Wrap token is
-// supported (the per-message format Windows RPC uses for Kerberos PKT_PRIVACY);
-// it returns 0 for other enctypes, for which Seal reports an error.
-func (ctx *SecContext) WrapTokenLen() int {
-	if _, etype := ctx.baseKey(); etype == rc4HMACEType {
+// context emits when sealing a stub of dataLen bytes. For RC4-HMAC it is the
+// fixed RFC 4757 token (the sealed data is expanded in the stub, not the token,
+// so dataLen is irrelevant). For an AES CFX Wrap token (RFC 4121 §4.2), the
+// sealed data replaces the stub in place at the same length and the token
+// carries the 16-byte header, the encrypted copy of that header, the checksum,
+// the confounder and EC filler octets — so the length is
+// 48 + EC + checksum, where EC pads the plaintext to the cipher block size. A
+// negative dataLen requests the maximum possible length (largest EC), used to
+// size the auth trailer before the exact stub length is known.
+func (ctx *SecContext) WrapTokenLen(dataLen int) int {
+	_, etype := ctx.baseKey()
+	if etype == rc4HMACEType {
 		return rc4WrapTokenLen
 	}
-	return 0
+	return 48 + wrapAESExtraCount(dataLen) + micLen(etype)
 }
+
+// wrapAESExtraCount is the EC (extra-count) filler an AES CFX Wrap token adds to
+// pad the plaintext up to the 16-octet cipher block size (RFC 4121 §4.2.3). A
+// negative dataLen returns the maximum EC (a full-minus-one block short), used
+// when sizing the auth trailer before the stub length is fixed.
+func wrapAESExtraCount(dataLen int) int {
+	if dataLen < 0 {
+		return 12
+	}
+	return (aesWrapBlock - dataLen%aesWrapBlock) & (aesWrapBlock - 1)
+}
+
+// aesWrapBlock is the cipher block size the AES CFX Wrap token pads to.
+const aesWrapBlock = 16
 
 // Seal produces a DCE-style GSS Wrap token that seals data as the context
 // initiator, returning the encrypted stub (sealed in place) and the Wrap token
 // for the auth_value. It is used by DCE/RPC PKT_PRIVACY; the RPC header and
-// sec_trailer are not covered by the RC4 token. Only RC4-HMAC is implemented.
+// sec_trailer are not covered by the token. RC4-HMAC uses the RFC 4757 token,
+// every other enctype the RFC 4121 CFX Wrap token.
 func (ctx *SecContext) Seal(data []byte) (sealed, token []byte, err error) {
-	if _, etype := ctx.baseKey(); etype != rc4HMACEType {
-		return nil, nil, fmt.Errorf("gssapi: DCE-style sealing is only implemented for RC4-HMAC")
+	if _, etype := ctx.baseKey(); etype == rc4HMACEType {
+		return ctx.sealRC4(data, ctx.nextSendSeq())
 	}
-	return ctx.sealRC4(data, ctx.nextSendSeq())
+	return ctx.sealAES(data, ctx.nextSendSeq())
 }
 
 // Unseal decrypts and verifies a DCE-style GSS Wrap token received from the
-// acceptor, returning the recovered plaintext (including any GSS pad the caller
-// strips). Only RC4-HMAC is implemented.
+// acceptor, returning the recovered plaintext (including any RPC auth pad the
+// caller strips). RC4-HMAC uses the RFC 4757 token, every other enctype the RFC
+// 4121 CFX Wrap token.
 func (ctx *SecContext) Unseal(sealed, token []byte) ([]byte, error) {
-	if _, etype := ctx.baseKey(); etype != rc4HMACEType {
-		return nil, fmt.Errorf("gssapi: DCE-style unsealing is only implemented for RC4-HMAC")
+	if _, etype := ctx.baseKey(); etype == rc4HMACEType {
+		return ctx.unsealRC4(sealed, token)
 	}
-	return ctx.unsealRC4(sealed, token)
+	return ctx.unsealAES(sealed, token)
+}
+
+// sealAES produces an RFC 4121 §4.2.6.2 CFX Wrap token (tok_id 05 04) with
+// confidentiality, in the DCE style Windows RPC expects: the stub is encrypted
+// in place at its original length while the token (auth_value) carries the
+// cleartext 16-byte header followed by the rotated remainder of the ciphertext
+// (the encrypted header copy, the checksum and the confounder). EC pads the
+// plaintext to the cipher block size and RRC = confounder+checksum length, so
+// that after the right-rotation the stub-sized run of ciphertext lands in place.
+func (ctx *SecContext) sealAES(data []byte, seq uint64) (sealed, token []byte, err error) {
+	key, etype := ctx.baseKey()
+	ec := wrapAESExtraCount(len(data))
+	rrc := aesWrapBlock + micLen(etype) // confounder + checksum length
+
+	// The header used inside the encrypted plaintext carries EC with RRC=0
+	// (RFC 4121 §4.2.4: the checksum/encryption is computed with RRC zeroed).
+	hdr := wrapHeader(ctx.initiatorFlags(true), seq)
+	binary.BigEndian.PutUint16(hdr[4:6], uint16(ec))
+
+	plain := make([]byte, 0, len(data)+ec+16)
+	plain = append(plain, data...)
+	plain = append(plain, make([]byte, ec)...)
+	plain = append(plain, hdr...)
+	cipher, err := kerbcrypto.Encrypt(etype, key, kgUsageInitiatorSeal, plain)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// The transmitted header carries the real RRC; rotate the ciphertext right by
+	// RRC+EC so the leading stub-length run can be sent in place.
+	binary.BigEndian.PutUint16(hdr[6:8], uint16(rrc))
+	rotated := rotateRight(cipher, rrc+ec)
+	split := 16 + rrc + ec
+	if split > len(rotated) {
+		return nil, nil, fmt.Errorf("gssapi: AES Wrap ciphertext too short")
+	}
+	sealed = rotated[split:]
+	token = append(append([]byte{}, hdr...), rotated[:split]...)
+	return sealed, token, nil
+}
+
+// unsealAES decrypts and verifies an RFC 4121 CFX Wrap token received from the
+// acceptor. sealed is the in-place encrypted stub; token is the auth_value (the
+// cleartext header plus the rotated ciphertext remainder). The header's EC/RRC
+// reassemble and unrotate the full ciphertext, which is decrypted with the
+// acceptor-seal usage; the trailing header copy and EC filler are stripped.
+func (ctx *SecContext) unsealAES(sealed, token []byte) ([]byte, error) {
+	if len(token) < 16 {
+		return nil, fmt.Errorf("gssapi: AES Wrap token too short")
+	}
+	if token[0] != tokIDWrap[0] || token[1] != tokIDWrap[1] {
+		return nil, fmt.Errorf("gssapi: not a Wrap token (tok_id %02x %02x)", token[0], token[1])
+	}
+	if token[2]&flagSentByAcceptor == 0 {
+		return nil, fmt.Errorf("gssapi: Wrap token not marked as sent by acceptor")
+	}
+	if token[2]&flagSealed == 0 {
+		return nil, fmt.Errorf("gssapi: Wrap token is not sealed")
+	}
+	ec := int(binary.BigEndian.Uint16(token[4:6]))
+	rrc := int(binary.BigEndian.Uint16(token[6:8]))
+	key, etype := ctx.baseKey()
+
+	// Rejoin the rotated ciphertext (token bytes after the 16-byte header, then
+	// the in-place sealed stub) and undo the right-rotation.
+	rotated := append(append([]byte{}, token[16:]...), sealed...)
+	cipher := rotateLeft(rotated, rrc+ec)
+	plain, err := kerbcrypto.Decrypt(etype, key, kgUsageAcceptorSeal, cipher)
+	if err != nil {
+		return nil, fmt.Errorf("gssapi: decrypt AES Wrap token: %w", err)
+	}
+	// plain = data | filler(ec) | header(16).
+	if len(plain) < 16+ec {
+		return nil, fmt.Errorf("gssapi: AES Wrap plaintext too short")
+	}
+	return plain[:len(plain)-16-ec], nil
 }
 
 // MakeMIC produces a MIC token over data as the context initiator. For RC4-HMAC

--- a/network/kerberos/v5/gssapi/permessage_test.go
+++ b/network/kerberos/v5/gssapi/permessage_test.go
@@ -198,6 +198,114 @@ func TestUnwrapIntegrityFromAcceptor(t *testing.T) {
 	}
 }
 
+// acceptorSealDCE simulates the acceptor emitting a DCE-style AES CFX Wrap token
+// (SentByAcceptor + Sealed, acceptor-seal usage) for the given data with the
+// requested EC filler, returning the in-place sealed stub and the auth_value
+// token — the shape Windows RPC returns at PKT_PRIVACY.
+func acceptorSealDCE(t *testing.T, key []byte, etype int, seq uint64, data []byte, ec int) (sealed, token []byte) {
+	t.Helper()
+	rrc := aesWrapBlock + micLen(etype)
+	hdr := wrapHeader(flagSentByAcceptor|flagSealed, seq)
+	binary.BigEndian.PutUint16(hdr[4:6], uint16(ec))
+	plain := make([]byte, 0, len(data)+ec+16)
+	plain = append(plain, data...)
+	plain = append(plain, make([]byte, ec)...)
+	plain = append(plain, hdr...)
+	cipher, err := kerbcrypto.Encrypt(etype, key, kgUsageAcceptorSeal, plain)
+	if err != nil {
+		t.Fatal(err)
+	}
+	binary.BigEndian.PutUint16(hdr[6:8], uint16(rrc))
+	rotated := rotateRight(cipher, rrc+ec)
+	split := 16 + rrc + ec
+	return rotated[split:], append(append([]byte{}, hdr...), rotated[:split]...)
+}
+
+func TestSealDCEInitiatorStructure(t *testing.T) {
+	// Exercise several stub lengths, including one already block-aligned, to cover
+	// the EC filler arithmetic.
+	for _, n := range []int{0, 4, 16, 20, 33, 64} {
+		ctx := newTestContext(200)
+		ctx.acceptorSubkey = true // DCE-style: the base key is the acceptor subkey
+		data := bytes.Repeat([]byte{0x5a}, n)
+
+		sealed, tok, err := ctx.Seal(data)
+		if err != nil {
+			t.Fatalf("n=%d Seal: %v", n, err)
+		}
+		if tok[0] != 0x05 || tok[1] != 0x04 {
+			t.Errorf("n=%d Wrap TOK_ID = %02x %02x", n, tok[0], tok[1])
+		}
+		if tok[2]&flagSealed == 0 || tok[2]&flagAcceptorSubkey == 0 {
+			t.Errorf("n=%d flags = %02x, want Sealed+AcceptorSubkey", n, tok[2])
+		}
+		if tok[2]&flagSentByAcceptor != 0 {
+			t.Errorf("n=%d initiator token must not set SentByAcceptor", n)
+		}
+		// The stub is sealed in place: same length as the plaintext, and does not
+		// appear in the clear.
+		if len(sealed) != n {
+			t.Errorf("n=%d sealed length = %d, want %d", n, len(sealed), n)
+		}
+		if n > 0 && bytes.Contains(sealed, data) {
+			t.Errorf("n=%d sealed stub leaks plaintext", n)
+		}
+		// The auth_value length must match what WrapTokenLen advertises for this stub.
+		if want := ctx.WrapTokenLen(n); len(tok) != want {
+			t.Errorf("n=%d token length = %d, want %d", n, len(tok), want)
+		}
+	}
+}
+
+func TestSealUnsealDCERoundtrip(t *testing.T) {
+	// A pair of contexts sharing the acceptor subkey: the acceptor seals, the
+	// initiator context unseals. Includes ec=16 (a full filler block over
+	// already-aligned data) as Windows emits.
+	key := bytes.Repeat([]byte{0x42}, 32)
+	etype := iana.ETypeAES256CTSHMACSHA196
+	for _, tc := range []struct {
+		data []byte
+		ec   int
+	}{
+		{[]byte("short"), 11},
+		{bytes.Repeat([]byte{1}, 16), 16}, // aligned data, full-block filler
+		{bytes.Repeat([]byte{2}, 40), 8},
+		{[]byte("odd-length-confidential-stub!!"), 2},
+	} {
+		ctx := newTestContext(1)
+		ctx.SessionKey = key
+		ctx.acceptorSubkey = true
+		ctx.SubKey = key
+		ctx.SubKeyEType = etype
+
+		sealed, tok := acceptorSealDCE(t, key, etype, 9, tc.data, tc.ec)
+		if len(sealed) != len(tc.data) {
+			t.Errorf("sealed length = %d, want %d", len(sealed), len(tc.data))
+		}
+		got, err := ctx.Unseal(sealed, tok)
+		if err != nil {
+			t.Fatalf("Unseal (ec=%d): %v", tc.ec, err)
+		}
+		if !bytes.Equal(got, tc.data) {
+			t.Errorf("Unseal data = %q, want %q", got, tc.data)
+		}
+	}
+}
+
+func TestUnsealDCERejectsUnsealed(t *testing.T) {
+	ctx := newTestContext(1)
+	ctx.acceptorSubkey = true
+	// A MIC-style token (not a Wrap token) must be rejected by the sealing path.
+	if _, err := ctx.Unseal([]byte("x"), micHeader(flagSentByAcceptor, 1)); err == nil {
+		t.Error("Unseal accepted a non-Wrap token")
+	}
+	// A Wrap token from the initiator direction must be rejected.
+	badFlags := wrapHeader(flagSealed, 1)
+	if _, err := ctx.Unseal([]byte("x"), append(badFlags, make([]byte, 44)...)); err == nil {
+		t.Error("Unseal accepted an initiator-flagged Wrap token")
+	}
+}
+
 func TestUnwrapRotation(t *testing.T) {
 	ctx := newTestContext(1)
 	data := []byte("rotated-sealed-data-payload")

--- a/network/kerberos/v5/kerberoast.go
+++ b/network/kerberos/v5/kerberoast.go
@@ -25,7 +25,7 @@ type KerberoastResult struct {
 // To obtain an RC4 (NT-hash-crackable) ticket, ensure RC4 is offered; the KDC
 // returns the strongest etype the service account key supports.
 func (c *KerberosClient) Kerberoast(spn string) (*KerberoastResult, error) {
-	ticket, _, _, err := c.GetTGS(spn, false)
+	ticket, _, _, _, err := c.GetTGS(spn, false)
 	if err != nil {
 		return nil, err
 	}

--- a/network/kerberos/v5/referral.go
+++ b/network/kerberos/v5/referral.go
@@ -61,7 +61,7 @@ func (c *KerberosClient) resolveKDCForRealm(realm string) (string, error) {
 // re-issues the TGS-REQ — repeating until the service ticket is obtained. A
 // KDC_ERR_WRONG_REALM error is handled by retrying with the corrected target
 // realm the KDC named. Cycles and over-long chains are rejected.
-func (c *KerberosClient) chaseServiceTicket(sname messages.PrincipalName, includePAC bool) (messages.Ticket, []byte, []byte, error) {
+func (c *KerberosClient) chaseServiceTicket(sname messages.PrincipalName, includePAC bool) (messages.Ticket, []byte, []byte, int, error) {
 	// The credential presented at the current hop. It starts as the home TGT and
 	// becomes each successive referral TGT.
 	tgt := c.tgtTicket
@@ -74,7 +74,7 @@ func (c *KerberosClient) chaseServiceTicket(sname messages.PrincipalName, includ
 	// endpoints are the failover-ordered KDCs serving bodyRealm.
 	endpoints, err := c.endpointsForRealm(bodyRealm)
 	if err != nil {
-		return messages.Ticket{}, nil, nil, fmt.Errorf("kerberos: resolve KDC for realm %q: %w", bodyRealm, err)
+		return messages.Ticket{}, nil, nil, 0, fmt.Errorf("kerberos: resolve KDC for realm %q: %w", bodyRealm, err)
 	}
 
 	// Realms whose KDC we have already presented a TGT to, to detect referral
@@ -91,7 +91,7 @@ func (c *KerberosClient) chaseServiceTicket(sname messages.PrincipalName, includ
 	for hop := 0; hop < maxReferralHops; hop++ {
 		rep, encRep, krbErr, err := c.tgsExchange(bodyRealm, endpoints, sname, includePAC, tgt, tgtRaw, sessionKey, sessionEType)
 		if err != nil {
-			return messages.Ticket{}, nil, nil, err
+			return messages.Ticket{}, nil, nil, 0, err
 		}
 		if krbErr != nil {
 			// KDC_ERR_WRONG_REALM: the KDC tells the client the realm the
@@ -112,22 +112,22 @@ func (c *KerberosClient) chaseServiceTicket(sname messages.PrincipalName, includ
 				skewRetried = true
 				continue
 			}
-			return messages.Ticket{}, nil, nil, fmt.Errorf("kerberos: TGS error %d: %s", krbErr.ErrorCode, krbErr.EText)
+			return messages.Ticket{}, nil, nil, 0, fmt.Errorf("kerberos: TGS error %d: %s", krbErr.ErrorCode, krbErr.EText)
 		}
 
 		nextRealm, isReferral := referralTargetRealm(rep, sname)
 		if !isReferral {
 			// The requested service ticket was issued — done.
-			return rep.Ticket, rep.TicketRaw, encRep.Key.KeyValue, nil
+			return rep.Ticket, rep.TicketRaw, encRep.Key.KeyValue, encRep.Key.KeyType, nil
 		}
 
 		nextRealm = strings.ToUpper(nextRealm)
 		if visited[nextRealm] {
-			return messages.Ticket{}, nil, nil, fmt.Errorf("kerberos: cross-realm referral cycle detected at realm %q", nextRealm)
+			return messages.Ticket{}, nil, nil, 0, fmt.Errorf("kerberos: cross-realm referral cycle detected at realm %q", nextRealm)
 		}
 		nextEndpoints, err := c.endpointsForRealm(nextRealm)
 		if err != nil {
-			return messages.Ticket{}, nil, nil, fmt.Errorf("kerberos: resolve KDC for referral realm %q: %w", nextRealm, err)
+			return messages.Ticket{}, nil, nil, 0, fmt.Errorf("kerberos: resolve KDC for referral realm %q: %w", nextRealm, err)
 		}
 
 		// Advance to the next realm, presenting the referral TGT there.
@@ -140,7 +140,7 @@ func (c *KerberosClient) chaseServiceTicket(sname messages.PrincipalName, includ
 		sessionEType = encRep.Key.KeyType
 	}
 
-	return messages.Ticket{}, nil, nil, fmt.Errorf("kerberos: too many cross-realm referrals (>%d) chasing %s", maxReferralHops, strings.Join(sname.NameString, "/"))
+	return messages.Ticket{}, nil, nil, 0, fmt.Errorf("kerberos: too many cross-realm referrals (>%d) chasing %s", maxReferralHops, strings.Join(sname.NameString, "/"))
 }
 
 // tgsExchange performs a single TGS-REQ/REP round-trip against the given KDC

--- a/network/kerberos/v5/spnego_mechanism.go
+++ b/network/kerberos/v5/spnego_mechanism.go
@@ -41,24 +41,24 @@ func (m *SPNEGOMechanism) InitToken() ([]byte, error) {
 			return nil, fmt.Errorf("kerberos spnego: GetTGT: %w", err)
 		}
 	}
-	ticket, ticketRaw, key, err := m.client.GetTGS(m.spn, true)
+	_, ticketRaw, key, keyEType, err := m.client.GetTGS(m.spn, true)
 	if err != nil {
 		return nil, fmt.Errorf("kerberos spnego: GetTGS %q: %w", m.spn, err)
 	}
-	subKey := make([]byte, kerbcrypto.KeyLen(ticket.EncPart.EType))
+	subKey := make([]byte, kerbcrypto.KeyLen(keyEType))
 	if _, err := rand.Read(subKey); err != nil {
 		return nil, err
 	}
 	tok, ctx, err := gssapi.InitSecContext(gssapi.InitOptions{
 		TicketRaw:    ticketRaw,
 		SessionKey:   key,
-		SessionEType: ticket.EncPart.EType,
+		SessionEType: keyEType,
 		ClientName:   messages.PrincipalName{NameType: messages.NameTypePrincipal, NameString: []string{m.client.Username()}},
 		ClientRealm:  m.client.Realm(),
 		Flags:        gssapi.GSSMutualFlag | gssapi.GSSSequenceFlag | gssapi.GSSConfFlag | gssapi.GSSIntegFlag,
 		Mutual:       true,
 		SubKey:       subKey,
-		SubKeyEType:  ticket.EncPart.EType,
+		SubKeyEType:  keyEType,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("kerberos spnego: InitSecContext: %w", err)

--- a/network/ldap/kerberos_gssapi.go
+++ b/network/ldap/kerberos_gssapi.go
@@ -83,27 +83,27 @@ func (g *nativeGSSAPIClient) InitSecContext(target string, token []byte) ([]byte
 // which this native mechanism does not need.
 func (g *nativeGSSAPIClient) InitSecContextWithOptions(target string, token []byte, _ []int) ([]byte, bool, error) {
 	if g.ctx == nil {
-		ticket, ticketRaw, key, err := g.kc.GetTGS(target, true)
+		_, ticketRaw, key, keyEType, err := g.kc.GetTGS(target, true)
 		if err != nil {
 			return nil, false, fmt.Errorf("ldap gssapi: GetTGS %q: %w", target, err)
 		}
 		// Assert an initiator subkey of the session-key etype, as Windows GSS
 		// clients do; AD's RFC 4121 (AES) acceptor expects one.
-		subKey := make([]byte, kerbcrypto.KeyLen(ticket.EncPart.EType))
+		subKey := make([]byte, kerbcrypto.KeyLen(keyEType))
 		if _, err := rand.Read(subKey); err != nil {
 			return nil, false, err
 		}
 		tok, ctx, err := gssapi.InitSecContext(gssapi.InitOptions{
 			TicketRaw:       ticketRaw,
 			SessionKey:      key,
-			SessionEType:    ticket.EncPart.EType,
+			SessionEType:    keyEType,
 			ClientName:      messages.PrincipalName{NameType: messages.NameTypePrincipal, NameString: []string{g.user}},
 			ClientRealm:     g.realm,
 			Flags:           gssapi.GSSMutualFlag | gssapi.GSSSequenceFlag | gssapi.GSSConfFlag | gssapi.GSSIntegFlag,
 			ChannelBindings: g.channelBindings,
 			Mutual:          true,
 			SubKey:          subKey,
-			SubKeyEType:     ticket.EncPart.EType,
+			SubKeyEType:     keyEType,
 		})
 		if err != nil {
 			return nil, false, fmt.Errorf("ldap gssapi: InitSecContext: %w", err)

--- a/windows/protocols/ms-nrpc/securechannel/rpcsecurity.go
+++ b/windows/protocols/ms-nrpc/securechannel/rpcsecurity.go
@@ -31,8 +31,9 @@ func NewNetlogonSecurityContext(sc *SecureChannel) *NetlogonSecurityContext {
 }
 
 // AuthValueLen is the token length: AES (NL_AUTH_SHA2_SIGNATURE) 56 sealing / 48 signing;
-// legacy (NL_AUTH_SIGNATURE) 32 sealing / 24 signing.
-func (n *NetlogonSecurityContext) AuthValueLen(seal bool) int {
+// legacy (NL_AUTH_SIGNATURE) 32 sealing / 24 signing. The Netlogon token is a fixed size, so
+// the stub length is not consulted.
+func (n *NetlogonSecurityContext) AuthValueLen(seal bool, _ int) int {
 	if n.aes {
 		if seal {
 			return 56


### PR DESCRIPTION
### Linked Issue
`Closes #915`

### Root Cause
The DCE/RPC Kerberos per-message path was originally brought up against a server where only an RC4-HMAC service ticket had been proven to interoperate, so `SetAuthKerberos` called `PreferRC4ServiceTicket()` for every per-message level and the GSS layer only implemented the RFC 4757 RC4 tokens. On a target where RC4 is disabled, no RC4 service ticket can be obtained and PKT/PKT_INTEGRITY/PKT_PRIVACY over Kerberos cannot be established at all. Re-testing showed the AES RFC 4121 (CFX) per-message tokens interoperate fine under GSS_C_DCE_STYLE; the RC4-only constraint was an over-restriction, not a server requirement.

A second, latent defect compounded this: `GetTGS` returned only the ticket bytes and the session key, and every caller keyed the AP-REQ authenticator and per-message tokens from `Ticket.EncPart.EType` — the service's long-term key etype. That is not necessarily the session-key etype: a Windows KDC can wrap an AES256 ticket around an RC4 session key. When the two differ, the authenticator would be encrypted under the wrong etype/key length.

### Fix Description
- Remove the forced RC4 downgrade. The per-message GSS token family is now chosen from the negotiated service-ticket session/subkey enctype: RFC 4121 CFX tokens (MIC `04 04`, Wrap `05 04`) for an AES ticket, RFC 4757 tokens (`01 01` / `02 01`) for RC4. The client's TGS-REQ already prefers AES, so AES-capable targets get AES protection and RC4-only targets transparently fall back.
- Implement the DCE-style AES CFX Wrap token (`Seal`/`Unseal`) for PKT_PRIVACY. The stub is sealed in place at its original length; the auth_value carries the cleartext header, the encrypted header copy, the checksum, the confounder and the EC block-padding filler (`48 + EC + checksum` bytes). Because that length depends on the stub's block padding, `SecurityContext.AuthValueLen` now takes the padded stub length, and the receive-side length check is relaxed for sealing (the Wrap token is validated structurally by `Unseal`).
- `GetTGS` now returns the real session-key encryption type; all callers (RPC, LDAP, SMB/SPNEGO, kerberoast) use it instead of `Ticket.EncPart.EType`.

### How Verified
Live against a Windows Server 2016 DC, endpoint mapper over `ncacn_ip_tcp` (135), authenticated bind + `ept_lookup`:
- **AES256 end-to-end** (session key etype 18, confirmed on the wire): CONNECT bind + mutual AP-REP; PKT and PKT_INTEGRITY recover 579 endpoint-map entries via AES CFX MIC; PKT_PRIVACY recovers 579 entries via the AES CFX Wrap (sealed).
- **RC4 fallback** (forced RC4 session key): PKT_INTEGRITY and PKT_PRIVACY both still recover 579 entries via the RFC 4757 tokens.
- **No regression** in the other Kerberos consumers: LDAP GSSAPI sign/seal round-trips and SMB 3.1.1 Kerberos signing + GCM encryption both validated live.
- `go build ./...`, `go vet ./...`, and `go test ./network/...` all green.

### Test Coverage
**Added** (`network/kerberos/v5/gssapi/permessage_test.go`):
- `TestSealDCEInitiatorStructure` — asserts the AES Wrap token id/flags, that the sealed stub keeps the plaintext length, no plaintext leak, and that the emitted length matches `WrapTokenLen`, across several stub lengths.
- `TestSealUnsealDCERoundtrip` — acceptor-sealed AES Wrap tokens (including a full-block EC filler over already-aligned data, as Windows emits) round-trip through `Unseal`.
- `TestUnsealDCERejectsUnsealed` — non-Wrap and initiator-flagged tokens are rejected.

### Scope of Change
- **Files changed:** `network/dcerpc/v5/client/{auth.go,auth_kerberos.go,secctx.go,secctx_test.go}`, `network/kerberos/v5/{client.go,referral.go,kerberoast.go,spnego_mechanism.go}`, `network/kerberos/v5/gssapi/{permessage.go,permessage_test.go}`, `network/ldap/kerberos_gssapi.go`, `windows/protocols/ms-nrpc/securechannel/rpcsecurity.go`.
- **Submodule pointer updated:** no.
- **Behavioral changes outside the bug fix:** none. The `GetTGS` signature and `AuthValueLen` interface gained a parameter; all in-tree implementers and callers are updated, and behavior is unchanged for the common case where the session-key etype equals the ticket etype.

### Risk and Rollout
Blast radius is the Kerberos service-ticket API and the RPC auth trailer sizing. The `AuthValueLen` change only affects sealing length (NTLM and Netlogon return fixed sizes as before); the `GetTGS` etype is identical to the previous value whenever the session and ticket etypes match (the usual case), so existing LDAP/SMB paths are unchanged and were re-validated live. Safe to merge without staged rollout.