### PR TITLE
NDR-decode the PAC KERB_VALIDATION_INFO logon-info buffer (Fixes #916)

### DIFF
--- a/network/kerberos/v5/pac/logoninfo.go
+++ b/network/kerberos/v5/pac/logoninfo.go
@@ -1,0 +1,154 @@
+package pac
+
+import (
+	"fmt"
+	"time"
+	"unicode/utf16"
+
+	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
+)
+
+// This file is the read side of the KERB_VALIDATION_INFO logon-info buffer: it
+// resolves a parsed PAC's ulType 0x00000001 buffer to the typed structure decoded
+// by UnmarshalKerbValidationInfo (build.go) and adds convenience accessors that
+// turn the raw NDR fields into Go strings, SIDs, and times. The decode itself is
+// symmetric with the encoder in build.go (both use the same structs and the NDR
+// "type serialization version 1" framing, [MS-RPCE] 2.2.6).
+
+// filetimeNever is the FILETIME sentinel (0x7FFFFFFFFFFFFFFF) the KDC writes for
+// "never" times such as LogoffTime, KickOffTime, and PasswordMustChange.
+const filetimeNever = uint64(0x7FFFFFFFFFFFFFFF)
+
+// LogonInfo locates the logon-info buffer (PAC_INFO_BUFFER ulType 0x00000001) and
+// NDR-decodes it into a KERB_VALIDATION_INFO ([MS-PAC] 2.5). It returns an error
+// if the PAC has no logon-info buffer or the buffer does not decode.
+func (p *PAC) LogonInfo() (*KERB_VALIDATION_INFO, error) {
+	b, ok := p.Buffer(BufferLogonInfo)
+	if !ok {
+		return nil, fmt.Errorf("pac: no logon-info buffer (ulType 0x%08x)", BufferLogonInfo)
+	}
+	return UnmarshalKerbValidationInfo(b.Data)
+}
+
+// Uint64 returns the FILETIME as a single 64-bit count of 100-nanosecond intervals
+// since 1601-01-01 (the low half is the least significant).
+func (f FILETIME) Uint64() uint64 {
+	return uint64(f.HighDateTime)<<32 | uint64(f.LowDateTime)
+}
+
+// IsNever reports whether the FILETIME is the "never" sentinel
+// (0x7FFFFFFFFFFFFFFF), used for LogoffTime/KickOffTime/PasswordMustChange when the
+// corresponding limit does not apply.
+func (f FILETIME) IsNever() bool { return f.Uint64() == filetimeNever }
+
+// Time converts the FILETIME to a Go time in UTC. A zero FILETIME (password never
+// set) and the "never" sentinel both map to the zero time.Time, so callers can
+// test the result with time.Time.IsZero. It is the inverse of FileTimeFromTime.
+func (f FILETIME) Time() time.Time {
+	v := f.Uint64()
+	if v == 0 || v == filetimeNever {
+		return time.Time{}
+	}
+	return time.Unix(0, int64(v-filetimeEpochDelta)*100).UTC()
+}
+
+// String decodes the RPC_UNICODE_STRING to a Go string. Only the first Length/2
+// UTF-16 code units are significant ([MS-DTYP] 2.3.10 counts bytes, and the buffer
+// carries no NUL terminator); any extra allocated units are dropped.
+func (u RPC_UNICODE_STRING) String() string {
+	units := u.Buffer
+	if n := int(u.Length / 2); n >= 0 && n < len(units) {
+		units = units[:n]
+	}
+	return string(utf16.Decode(units))
+}
+
+// UserName returns the account's samAccountName (EffectiveName) as a Go string.
+func (k *KERB_VALIDATION_INFO) UserName() string { return k.EffectiveName.String() }
+
+// FullNameString returns the account's display name (FullName).
+func (k *KERB_VALIDATION_INFO) FullNameString() string { return k.FullName.String() }
+
+// LogonServerName returns the NetBIOS name of the KDC that issued the ticket.
+func (k *KERB_VALIDATION_INFO) LogonServerName() string { return k.LogonServer.String() }
+
+// LogonDomainNameString returns the NetBIOS name of the account's domain.
+func (k *KERB_VALIDATION_INFO) LogonDomainNameString() string { return k.LogonDomainName.String() }
+
+// UserRID returns the account's relative identifier (UserId).
+func (k *KERB_VALIDATION_INFO) UserRID() uint32 { return k.UserId }
+
+// PrimaryGroupRID returns the RID of the account's primary group.
+func (k *KERB_VALIDATION_INFO) PrimaryGroupRID() uint32 { return k.PrimaryGroupId }
+
+// AccountControl returns the userAccountControl flags carried in the PAC.
+func (k *KERB_VALIDATION_INFO) AccountControl() uint32 { return k.UserAccountControl }
+
+// DomainSID returns the account domain's SID (LogonDomainId), or nil if absent.
+func (k *KERB_VALIDATION_INFO) DomainSID() *msdtyp.RPC_SID { return k.LogonDomainId }
+
+// sidWithRID appends a relative identifier to a domain SID and renders the result
+// in "S-1-5-21-…-<rid>" textual form. It returns "" if domain is nil.
+func sidWithRID(domain *msdtyp.RPC_SID, rid uint32) string {
+	if domain == nil {
+		return ""
+	}
+	subs := make([]uint32, 0, len(domain.SubAuthority)+1)
+	subs = append(subs, domain.SubAuthority...)
+	subs = append(subs, rid)
+	full := msdtyp.RPC_SID{
+		Revision:            domain.Revision,
+		SubAuthorityCount:   uint8(len(subs)),
+		IdentifierAuthority: domain.IdentifierAuthority,
+		SubAuthority:        subs,
+	}
+	return full.String()
+}
+
+// UserSID returns the account's SID as the domain SID with the UserId RID
+// appended, or "" if the PAC has no LogonDomainId.
+func (k *KERB_VALIDATION_INFO) UserSID() string {
+	return sidWithRID(k.LogonDomainId, k.UserId)
+}
+
+// PrimaryGroupSID returns the primary group's SID (domain SID + PrimaryGroupId),
+// or "" if the PAC has no LogonDomainId.
+func (k *KERB_VALIDATION_INFO) PrimaryGroupSID() string {
+	return sidWithRID(k.LogonDomainId, k.PrimaryGroupId)
+}
+
+// GroupRIDs returns the RIDs of the account's groups in its own domain (GroupIds).
+func (k *KERB_VALIDATION_INFO) GroupRIDs() []uint32 {
+	rids := make([]uint32, 0, len(k.GroupIds))
+	for _, g := range k.GroupIds {
+		rids = append(rids, g.RelativeId)
+	}
+	return rids
+}
+
+// GroupSIDs returns the account's account-domain group memberships (GroupIds) as
+// full SID strings (domain SID + each group RID). It returns nil if the PAC has no
+// LogonDomainId.
+func (k *KERB_VALIDATION_INFO) GroupSIDs() []string {
+	if k.LogonDomainId == nil {
+		return nil
+	}
+	sids := make([]string, 0, len(k.GroupIds))
+	for _, g := range k.GroupIds {
+		sids = append(sids, sidWithRID(k.LogonDomainId, g.RelativeId))
+	}
+	return sids
+}
+
+// ExtraSIDs returns the ExtraSids member (SIDs from domains other than the account
+// domain, e.g. universal groups and injected SIDs) as textual SID strings.
+func (k *KERB_VALIDATION_INFO) ExtraSIDs() []string {
+	sids := make([]string, 0, len(k.ExtraSids))
+	for _, s := range k.ExtraSids {
+		if s.Sid == nil {
+			continue
+		}
+		sids = append(sids, s.Sid.String())
+	}
+	return sids
+}

--- a/network/kerberos/v5/pac/logoninfo_test.go
+++ b/network/kerberos/v5/pac/logoninfo_test.go
@@ -1,0 +1,104 @@
+package pac
+
+import (
+	"testing"
+	"time"
+)
+
+// TestLogonInfoAccessors forges a PAC, parses it back, decodes the logon-info
+// buffer through PAC.LogonInfo, and asserts the typed accessors reconstruct the
+// user, group, and SID information (an encode→decode symmetry check that also
+// covers the SID-composition and string helpers).
+func TestLogonInfoAccessors(t *testing.T) {
+	key := make([]byte, 16)
+	info := sampleInfo(t)
+
+	p, err := Forge(info, "Administrator", time.Unix(1700000000, 0), 23)
+	if err != nil {
+		t.Fatalf("Forge: %v", err)
+	}
+	signed, err := p.Sign(key, key)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	parsed, err := Parse(signed)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	li, err := parsed.LogonInfo()
+	if err != nil {
+		t.Fatalf("LogonInfo: %v", err)
+	}
+
+	if li.UserName() != "Administrator" {
+		t.Errorf("UserName = %q, want Administrator", li.UserName())
+	}
+	if li.LogonDomainNameString() != "CORP" {
+		t.Errorf("LogonDomainNameString = %q, want CORP", li.LogonDomainNameString())
+	}
+	if li.LogonServerName() != "DC01" {
+		t.Errorf("LogonServerName = %q, want DC01", li.LogonServerName())
+	}
+	if li.UserRID() != 500 {
+		t.Errorf("UserRID = %d, want 500", li.UserRID())
+	}
+	if li.PrimaryGroupRID() != 513 {
+		t.Errorf("PrimaryGroupRID = %d, want 513", li.PrimaryGroupRID())
+	}
+	if li.AccountControl() != 0x00010200 {
+		t.Errorf("AccountControl = %#x, want 0x00010200", li.AccountControl())
+	}
+
+	domain := "S-1-5-21-1111111111-2222222222-3333333333"
+	if li.DomainSID() == nil || li.DomainSID().String() != domain {
+		t.Errorf("DomainSID = %v, want %s", li.DomainSID(), domain)
+	}
+	if got, want := li.UserSID(), domain+"-500"; got != want {
+		t.Errorf("UserSID = %q, want %q", got, want)
+	}
+	if got, want := li.PrimaryGroupSID(), domain+"-513"; got != want {
+		t.Errorf("PrimaryGroupSID = %q, want %q", got, want)
+	}
+
+	rids := li.GroupRIDs()
+	if len(rids) != 3 || rids[0] != 513 || rids[1] != 512 || rids[2] != 519 {
+		t.Errorf("GroupRIDs = %v, want [513 512 519]", rids)
+	}
+	gsids := li.GroupSIDs()
+	if len(gsids) != 3 || gsids[1] != domain+"-512" {
+		t.Errorf("GroupSIDs = %v", gsids)
+	}
+	esids := li.ExtraSIDs()
+	if len(esids) != 1 || esids[0] != domain+"-519" {
+		t.Errorf("ExtraSIDs = %v, want [%s-519]", esids, domain)
+	}
+}
+
+// TestFileTimeConversions checks the FILETIME helpers: the "never" sentinel and a
+// zero value both map to the zero time, and a real timestamp round-trips through
+// FileTimeFromTime.
+func TestFileTimeConversions(t *testing.T) {
+	if !NeverExpireFileTime().IsNever() {
+		t.Error("NeverExpireFileTime().IsNever() = false")
+	}
+	if !NeverExpireFileTime().Time().IsZero() {
+		t.Error("never FILETIME did not map to zero time")
+	}
+	if !(FILETIME{}).Time().IsZero() {
+		t.Error("zero FILETIME did not map to zero time")
+	}
+	want := time.Unix(1700000000, 0).UTC()
+	if got := FileTimeFromTime(want).Time(); !got.Equal(want) {
+		t.Errorf("FILETIME round-trip = %v, want %v", got, want)
+	}
+}
+
+// TestLogonInfoMissingBuffer ensures LogonInfo reports an error when the PAC has
+// no logon-info buffer.
+func TestLogonInfoMissingBuffer(t *testing.T) {
+	p := &PAC{Buffers: []Buffer{{Type: BufferClientInfo, Data: []byte("x")}}}
+	if _, err := p.LogonInfo(); err == nil {
+		t.Error("expected error for PAC without a logon-info buffer")
+	}
+}

--- a/network/kerberos/v5/pac/pac.go
+++ b/network/kerberos/v5/pac/pac.go
@@ -5,7 +5,8 @@
 // a cBuffers/Version header followed by a table of PAC_INFO_BUFFER entries, each
 // pointing at an 8-byte-aligned buffer. Individual buffers such as the logon
 // info (KERB_VALIDATION_INFO) are themselves NDR-encoded; this package exposes
-// those buffers as raw bytes and does not yet NDR-decode them.
+// those buffers as raw bytes and additionally NDR-decodes the logon info into a
+// typed KERB_VALIDATION_INFO via PAC.LogonInfo (see logoninfo.go).
 //
 // The security-relevant operations — the Server and KDC signatures ([MS-PAC]
 // 2.8, "Generation of PAC Signatures") — are implemented: both are keyed


### PR DESCRIPTION
### Linked Issue
`Closes #916`

### Root Cause
The PAC parser exposed each PAC_INFO_BUFFER only as raw bytes. The logon-info buffer (ulType 0x00000001) is an NDR "type serialization version 1" ([MS-RPCE] 2.2.6) encoding of a KERB_VALIDATION_INFO ([MS-PAC] 2.5), so its user RID, primary group, group memberships, extra SIDs, domain SID, names, account flags, and timestamps were inaccessible to callers. A type-serialization encoder for this structure already existed (ticket forging), but there was no first-class decode entry point on the PAC nor typed accessors for the decoded fields.

### Fix Description
Add `PAC.LogonInfo`, which resolves the logon-info buffer and NDR-decodes it into a `KERB_VALIDATION_INFO` via the existing `UnmarshalKerbValidationInfo` (reusing the same structs and NDR framing as the encoder, so encode/decode stay symmetric). Add convenience accessors on `KERB_VALIDATION_INFO`: `UserRID`/`PrimaryGroupRID`, `GroupRIDs`/`GroupSIDs`, `ExtraSIDs`, `DomainSID`/`UserSID`/`PrimaryGroupSID`, `UserName`/`FullNameString`/`LogonServerName`/`LogonDomainNameString`, and `AccountControl`. Add `FILETIME.Time`/`Uint64`/`IsNever` (inverse of `FileTimeFromTime`, mapping zero and the 0x7FFFFFFFFFFFFFFF sentinel to the zero time) and `RPC_UNICODE_STRING.String` (Length-truncated UTF-16 decode). Field order was cross-checked against [MS-PAC] 2.5.

### How Verified
- `go build ./...`, `go vet`, and `go test ./network/kerberos/...` all pass.
- Live-validated against a real domain controller: obtained a TGT, ran a user-to-user (U2U) TGS to self, decrypted the issued ticket's enc-part with the held TGT session key, extracted the AD-WIN2K-PAC, and decoded the DC-issued KERB_VALIDATION_INFO. The decoded fields matched the account: UserName `Administrator`, UserRID 500, PrimaryGroupRID 513, groups including 512 (Domain Admins), 518, 519, 520, the domain SID `S-1-5-21-…`, NetBIOS logon-domain name and logon-server name, all confirmed against the DC's actual values.

### Test Coverage
- **Added:** `TestLogonInfoAccessors` (forge → parse → `LogonInfo`, asserts every accessor including SID composition), `TestFileTimeConversions` (never/zero/round-trip), `TestLogonInfoMissingBuffer`. The existing `TestKerbValidationInfoRoundtrip` continues to cover the raw decode.

### Scope of Change
- **Files changed:** `network/kerberos/v5/pac/logoninfo.go` (new), `network/kerberos/v5/pac/logoninfo_test.go` (new), `network/kerberos/v5/pac/pac.go` (doc comment).
- **Submodule pointer updated:** no.
- **Behavioral changes outside the bug fix:** none.

### Risk and Rollout
Additive only (new methods and a doc-comment change); no existing behavior is modified. Safe to merge.