### PR TITLE
Add Kerberos FAST (RFC 6113) armored pre-authentication (Fixes #917)

### DIFF
--- a/network/kerberos/v5/client.go
+++ b/network/kerberos/v5/client.go
@@ -71,6 +71,11 @@ type KerberosClient struct {
 	// subsequent retry falls inside the KDC's allowable skew window (RFC 4120
 	// Section 5.9.1). See now / applyClockSkew.
 	clockOffset time.Duration
+
+	// fast, when non-nil, holds an armor TGT enabling RFC 6113 FAST (Kerberos
+	// armoring) on the AS exchange. Configured via WithFASTArmor; consumed by
+	// GetTGT (see fast.go).
+	fast *fastArmor
 }
 
 // preloadedServiceTicket is a service ticket the client will hand back from
@@ -191,6 +196,12 @@ func (c *KerberosClient) applyClockSkew(krbErr messages.KRBError) bool {
 func (c *KerberosClient) GetTGT() error {
 	if c.cred == nil {
 		return fmt.Errorf("kerberos: no credentials configured: call WithPassword/WithNTHash/WithAESKey/WithCredential first")
+	}
+
+	// When a FAST armor TGT is configured, perform an armored AS-REQ with an
+	// encrypted-challenge factor (RFC 6113) instead of the bare PA-ENC-TIMESTAMP.
+	if c.fast != nil {
+		return c.getTGTFAST()
 	}
 
 	// Start with the strongest etype the credential can satisfy and the AD

--- a/network/kerberos/v5/crypto/prf.go
+++ b/network/kerberos/v5/crypto/prf.go
@@ -1,0 +1,140 @@
+package kerbcrypto
+
+import (
+	"crypto/aes"
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/binary"
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/iana"
+)
+
+// Key-usage numbers introduced by RFC 6113 (Kerberos FAST). They live here
+// alongside the FAST cryptographic primitives so callers pass them to Encrypt /
+// GetChecksum without re-declaring the magic numbers.
+const (
+	// KeyUsageFASTReqChksum keys the req-checksum in KrbFastArmoredReq
+	// (RFC 6113 §5.4.2, KEY_USAGE_FAST_REQ_CHKSUM = 50).
+	KeyUsageFASTReqChksum = 50
+	// KeyUsageFASTEnc keys the enc-fast-req EncryptedData in KrbFastArmoredReq
+	// (RFC 6113 §5.4.2, KEY_USAGE_FAST_ENC = 51).
+	KeyUsageFASTEnc = 51
+	// KeyUsageFASTRep keys the enc-fast-rep EncryptedData in KrbFastArmoredRep
+	// (RFC 6113 §5.4.3, KEY_USAGE_FAST_REP = 52).
+	KeyUsageFASTRep = 52
+	// KeyUsageFASTFinished keys the ticket-checksum in KrbFastFinished
+	// (RFC 6113 §5.4.3, KEY_USAGE_FAST_FINISHED = 53).
+	KeyUsageFASTFinished = 53
+	// KeyUsageEncChallengeClient keys the client's PA-ENCRYPTED-CHALLENGE
+	// (RFC 6113 §5.4.6, KEY_USAGE_ENC_CHALLENGE_CLIENT = 54).
+	KeyUsageEncChallengeClient = 54
+	// KeyUsageEncChallengeKDC keys the KDC's PA-ENCRYPTED-CHALLENGE reply
+	// (RFC 6113 §5.4.6, KEY_USAGE_ENC_CHALLENGE_KDC = 55).
+	KeyUsageEncChallengeKDC = 55
+)
+
+// PRF implements the RFC 3961 pseudo-random function for the given encryption
+// type, as required by the KRB-FX-CF2 key combination of RFC 6113. Each enctype
+// binds a specific construction:
+//
+//   - AES-CTS-HMAC-SHA1-96 (17/18), RFC 3962 §6:
+//     prf(key, s) = E(DK(key, "prf"), truncate-128(SHA-1(s)))
+//     i.e. AES-encrypt the first 16 bytes of SHA-1(s) under the "prf"-derived key.
+//   - AES-CTS-HMAC-SHA2 (19/20), RFC 8009 §5:
+//     PRF(key, s) = KDF-HMAC-SHA2(key, "prf" | s, k) with k = 256 (SHA-256)
+//     or 384 (SHA-384).
+//   - RC4-HMAC (23): HMAC-SHA1(key, s), matching the widely deployed
+//     arcfour-hmac PRF.
+//
+// The output length is fixed by the enctype (16 bytes for AES-SHA1 and RC4, the
+// full SHA-2 output for the RFC 8009 types).
+func PRF(etype int, key, input []byte) ([]byte, error) {
+	switch etype {
+	case iana.ETypeAES128CTSHMACSHA196, iana.ETypeAES256CTSHMACSHA196:
+		dk := deriveKey(key, []byte("prf"), aesKeyLen(etype))
+		block, err := aes.NewCipher(dk)
+		if err != nil {
+			return nil, err
+		}
+		h := sha1.Sum(input)
+		out := make([]byte, 16)
+		block.Encrypt(out, h[:16]) // single 16-byte block (CBC with zero IV == ECB)
+		return out, nil
+
+	case iana.ETypeAES128CTSHMACSHA256, iana.ETypeAES256CTSHMACSHA384:
+		// RFC 8009 §5: PRF(key, s) = KDF-HMAC-SHA2(key, "prf", s, k), i.e. the
+		// SP800-108 counter-mode KDF with label "prf" and s in the context
+		// position: HMAC-Hash(key, 0x00000001 | "prf" | 0x00 | s | k), where k is
+		// the hash output length in bits. k equals one full hash output, so a
+		// single iteration suffices.
+		p, _ := aes2ParamsFor(etype)
+		kBits := p.newHash().Size() * 8
+		var kbuf [4]byte
+		binary.BigEndian.PutUint32(kbuf[:], uint32(kBits))
+		mac := hmac.New(p.newHash, key)
+		mac.Write([]byte{0x00, 0x00, 0x00, 0x01}) // counter i = 1
+		mac.Write([]byte("prf"))
+		mac.Write([]byte{0x00})
+		mac.Write(input)
+		mac.Write(kbuf[:])
+		return mac.Sum(nil), nil
+
+	case iana.ETypeRC4HMAC:
+		return hmacSHA1(key, input), nil
+
+	default:
+		return nil, fmt.Errorf("%w: PRF for etype %d", ErrUnsupportedEType, etype)
+	}
+}
+
+// prfPlus implements the RFC 6113 §5.1 PRF+ expansion:
+//
+//	PRF+(key, pepper) = PRF(key, 1 | pepper) | PRF(key, 2 | pepper) | ...
+//
+// where the counter is a single octet starting at 1. It returns the first n
+// output bytes.
+func prfPlus(etype int, key []byte, pepper string, n int) ([]byte, error) {
+	out := make([]byte, 0, n)
+	for i := 1; len(out) < n; i++ {
+		if i > 255 {
+			return nil, fmt.Errorf("kerbcrypto: PRF+ counter overflow producing %d bytes", n)
+		}
+		block, err := PRF(etype, key, append([]byte{byte(i)}, pepper...))
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, block...)
+	}
+	return out[:n], nil
+}
+
+// KRBFXCF2 implements the RFC 6113 §5.1 KRB-FX-CF2 key-combination function:
+//
+//	KRB-FX-CF2(K1, K2, pepper1, pepper2) =
+//	    random-to-key( PRF+(K1, pepper1) ^ PRF+(K2, pepper2) )
+//
+// The two input keys may have different enctypes; the result adopts K1's
+// enctype (its key length drives the PRF+ output length and random-to-key).
+// For every enctype implemented here random-to-key is the identity function, so
+// the XOR of the two PRF+ streams is the combined key. The returned int is the
+// result enctype (= k1Etype).
+func KRBFXCF2(k1 []byte, k1Etype int, k2 []byte, k2Etype int, pepper1, pepper2 string) ([]byte, int, error) {
+	n := KeyLen(k1Etype)
+	if n == 0 {
+		return nil, 0, fmt.Errorf("%w: KRB-FX-CF2 output etype %d", ErrUnsupportedEType, k1Etype)
+	}
+	o1, err := prfPlus(k1Etype, k1, pepper1, n)
+	if err != nil {
+		return nil, 0, fmt.Errorf("kerbcrypto: KRB-FX-CF2 PRF+ on K1: %w", err)
+	}
+	o2, err := prfPlus(k2Etype, k2, pepper2, n)
+	if err != nil {
+		return nil, 0, fmt.Errorf("kerbcrypto: KRB-FX-CF2 PRF+ on K2: %w", err)
+	}
+	out := make([]byte, n)
+	for i := 0; i < n; i++ {
+		out[i] = o1[i] ^ o2[i]
+	}
+	return out, k1Etype, nil
+}

--- a/network/kerberos/v5/crypto/prf_test.go
+++ b/network/kerberos/v5/crypto/prf_test.go
@@ -1,0 +1,154 @@
+package kerbcrypto
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/iana"
+)
+
+func mustHex(t *testing.T, s string) []byte {
+	t.Helper()
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		t.Fatalf("bad hex %q: %v", s, err)
+	}
+	return b
+}
+
+// TestPRFAESSHA1KnownAnswer checks the RFC 3962 AES-SHA1 PRF against
+// independently computed reference values.
+func TestPRFAESSHA1KnownAnswer(t *testing.T) {
+	cases := []struct {
+		name  string
+		etype int
+		key   string
+		input string
+		want  string
+	}{
+		{"aes256", iana.ETypeAES256CTSHMACSHA196,
+			"0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+			"test-input", "d7b84749812fd1726731ab893c467309"},
+		{"aes128", iana.ETypeAES128CTSHMACSHA196,
+			"0102030405060708090a0b0c0d0e0f10",
+			"test-input", "3744a3b414aa5b406927ec729dc879d6"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := PRF(tc.etype, mustHex(t, tc.key), []byte(tc.input))
+			if err != nil {
+				t.Fatalf("PRF: %v", err)
+			}
+			if want := mustHex(t, tc.want); !bytes.Equal(got, want) {
+				t.Fatalf("PRF mismatch:\n got  %x\n want %x", got, want)
+			}
+		})
+	}
+}
+
+// TestPRFRC4KnownAnswer checks the arcfour-hmac PRF (HMAC-SHA1) output.
+func TestPRFRC4KnownAnswer(t *testing.T) {
+	got, err := PRF(iana.ETypeRC4HMAC, mustHex(t, "0102030405060708090a0b0c0d0e0f10"), []byte("test-input"))
+	if err != nil {
+		t.Fatalf("PRF: %v", err)
+	}
+	want := mustHex(t, "84fb47c2594710701cccfd586c17084a0c2180fe")
+	if !bytes.Equal(got, want) {
+		t.Fatalf("RC4 PRF mismatch:\n got  %x\n want %x", got, want)
+	}
+}
+
+// TestPRFAESSHA2KnownAnswer checks the RFC 8009 §8 PRF test vectors for the
+// AES-SHA2 enctypes.
+func TestPRFAESSHA2KnownAnswer(t *testing.T) {
+	cases := []struct {
+		name  string
+		etype int
+		key   string
+		want  string
+	}{
+		{"aes128-sha256", iana.ETypeAES128CTSHMACSHA256,
+			"3705d96080c17728a0e800eab6e0d23c",
+			"9d188616f63852fe86915bb840b4a886ff3e6bb0f819b49b893393d393854295"},
+		{"aes256-sha384", iana.ETypeAES256CTSHMACSHA384,
+			"6d404d37faf79f9df0d33568d3206698" + "00eb4836472ea8a026d16b7182460c52",
+			"9801f69a368c2bf675e59521e177d9a0" + "7f67efe1cfde8d3c8d6f6a0256e3b17d" + "b3c1b62ad1b8553360d17367eb1514d2"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := PRF(tc.etype, mustHex(t, tc.key), []byte("test"))
+			if err != nil {
+				t.Fatalf("PRF: %v", err)
+			}
+			if want := mustHex(t, tc.want); !bytes.Equal(got, want) {
+				t.Fatalf("PRF mismatch:\n got  %x\n want %x", got, want)
+			}
+		})
+	}
+}
+
+// TestKRBFXCF2KnownAnswer verifies the RFC 6113 KRB-FX-CF2 key combination
+// against reference values, including the cross-enctype case (K1 and K2 of
+// different enctypes; the result adopts K1's enctype).
+func TestKRBFXCF2KnownAnswer(t *testing.T) {
+	cases := []struct {
+		name             string
+		k1               string
+		k1Etype          int
+		k2               string
+		k2Etype          int
+		pepper1, pepper2 string
+		want             string
+	}{
+		{
+			"aes256-subkeyarmor",
+			"0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20", iana.ETypeAES256CTSHMACSHA196,
+			"2122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f40", iana.ETypeAES256CTSHMACSHA196,
+			"subkeyarmor", "ticketarmor",
+			"18b1ecfa39a1bf373bcbc098aae658fe35082a00d7d6660e6cb6fd6138404d21",
+		},
+		{
+			"aes128-subkeyarmor",
+			"0102030405060708090a0b0c0d0e0f10", iana.ETypeAES128CTSHMACSHA196,
+			"1112131415161718191a1b1c1d1e1f20", iana.ETypeAES128CTSHMACSHA196,
+			"subkeyarmor", "ticketarmor",
+			"84e6a11aecdec85598b78b8c37df3f1f",
+		},
+		{
+			"rc4-challenge",
+			"0102030405060708090a0b0c0d0e0f10", iana.ETypeRC4HMAC,
+			"1112131415161718191a1b1c1d1e1f20", iana.ETypeRC4HMAC,
+			"clientchallengearmor", "challengelongterm",
+			"a7fa55719b5140c8693af782dd1775ef",
+		},
+		{
+			"aes256-strengthenkey",
+			"0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20", iana.ETypeAES256CTSHMACSHA196,
+			"2122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f40", iana.ETypeAES256CTSHMACSHA196,
+			"strengthenkey", "replykey",
+			"eb67d71c98f3dfdfe301e7352f8dfcb11516c4fe0661cdb2995b9d67b21bf08a",
+		},
+		{
+			"cross-256-128",
+			"0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20", iana.ETypeAES256CTSHMACSHA196,
+			"0102030405060708090a0b0c0d0e0f10", iana.ETypeAES128CTSHMACSHA196,
+			"clientchallengearmor", "challengelongterm",
+			"075d94a2a0bf5f0b69a18f216b0b2d7b1679441568eae2cfadbc81d7a400ecea",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, etype, err := KRBFXCF2(mustHex(t, tc.k1), tc.k1Etype, mustHex(t, tc.k2), tc.k2Etype, tc.pepper1, tc.pepper2)
+			if err != nil {
+				t.Fatalf("KRBFXCF2: %v", err)
+			}
+			if etype != tc.k1Etype {
+				t.Fatalf("result etype = %d, want K1 etype %d", etype, tc.k1Etype)
+			}
+			if want := mustHex(t, tc.want); !bytes.Equal(got, want) {
+				t.Fatalf("KRB-FX-CF2 mismatch:\n got  %x\n want %x", got, want)
+			}
+		})
+	}
+}

--- a/network/kerberos/v5/fast.go
+++ b/network/kerberos/v5/fast.go
@@ -1,0 +1,431 @@
+package kerberos
+
+import (
+	"crypto/rand"
+	"encoding/asn1"
+	"fmt"
+	"time"
+
+	kerbcrypto "github.com/TheManticoreProject/Manticore/network/kerberos/v5/crypto"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/messages"
+)
+
+// This file implements RFC 6113 (Kerberos FAST — Flexible Authentication Secure
+// Tunneling), as profiled by MS-KILE for "Kerberos armoring", on the AS
+// exchange. FAST wraps the real AS-REQ inside a PA-FX-FAST envelope keyed by an
+// armor key that is derived from an armor TGT, and carries the client's
+// credential proof as a PA-ENCRYPTED-CHALLENGE FAST factor rather than the
+// bare PA-ENC-TIMESTAMP of RFC 4120.
+//
+// KRB-FX-CF2 pepper strings (RFC 6113 §5.4.1.1 / §5.4.3 / §5.4.6).
+const (
+	fastPepperSubkeyArmor      = "subkeyarmor"
+	fastPepperTicketArmor      = "ticketarmor"
+	fastPepperClientChallenge  = "clientchallengearmor"
+	fastPepperKDCChallenge     = "kdcchallengearmor"
+	fastPepperChallengeLongTem = "challengelongterm"
+	fastPepperStrengthenKey    = "strengthenkey"
+	fastPepperReplyKey         = "replykey"
+)
+
+// fastArmor holds the armor TGT and its session key used to armor a FAST
+// exchange (RFC 6113 §5.4.1.1, FX_FAST_ARMOR_AP_REQUEST).
+type fastArmor struct {
+	cname        string
+	realm        string
+	ticket       messages.Ticket
+	ticketRaw    []byte
+	sessionKey   []byte
+	sessionEType int
+}
+
+// WithFASTArmor enables RFC 6113 FAST (Kerberos armoring) on the AS exchange,
+// using the supplied armor TGT. cname/realm identify the armor principal (the
+// account that owns the TGT); ticket/ticketRaw are the armor TGT (raw is the
+// verbatim APPLICATION[1] bytes as issued by the KDC); sessionKey/sessionEType
+// are the armor TGT's session key. Once configured, GetTGT performs a
+// FAST-armored AS-REQ with a PA-ENCRYPTED-CHALLENGE factor. Returns the client
+// for fluent chaining.
+func (c *KerberosClient) WithFASTArmor(cname, realm string, ticket messages.Ticket, ticketRaw, sessionKey []byte, sessionEType int) *KerberosClient {
+	c.fast = &fastArmor{
+		cname:        cname,
+		realm:        realm,
+		ticket:       ticket,
+		ticketRaw:    ticketRaw,
+		sessionKey:   sessionKey,
+		sessionEType: sessionEType,
+	}
+	return c
+}
+
+// WithFASTArmorFromClient enables FAST using another client's already-acquired
+// TGT as the armor (the "self-armor" pattern when armor is the same client that
+// has a TGT). The armor client MUST have completed GetTGT. Returns the client
+// for fluent chaining.
+func (c *KerberosClient) WithFASTArmorFromClient(armor *KerberosClient) *KerberosClient {
+	return c.WithFASTArmor(armor.username, armor.realm, armor.tgtTicket, armor.tgtTicketRaw, armor.sessionKey, armor.sessionEType)
+}
+
+// FASTEnabled reports whether a FAST armor TGT has been configured.
+func (c *KerberosClient) FASTEnabled() bool { return c.fast != nil }
+
+// getTGTFAST performs a FAST-armored AS-REQ with a PA-ENCRYPTED-CHALLENGE factor
+// (RFC 6113 §5.4.6) and stores the resulting TGT on success. It is invoked by
+// GetTGT when a FAST armor has been configured via WithFASTArmor.
+func (c *KerberosClient) getTGTFAST() error {
+	if c.cred == nil {
+		return fmt.Errorf("kerberos: no credentials configured: call WithPassword/WithNTHash/WithAESKey/WithCredential first")
+	}
+	armor := c.fast
+
+	// Derive the armor key once: a fresh subkey combined with the armor TGT
+	// session key (RFC 6113 §5.4.1.1). The same armor key protects the request
+	// envelope and decrypts the reply.
+	subkey := make([]byte, kerbcrypto.KeyLen(armor.sessionEType))
+	if _, err := rand.Read(subkey); err != nil {
+		return fmt.Errorf("kerberos: FAST subkey: %w", err)
+	}
+	armorKey, armorEType, err := kerbcrypto.KRBFXCF2(
+		subkey, armor.sessionEType,
+		armor.sessionKey, armor.sessionEType,
+		fastPepperSubkeyArmor, fastPepperTicketArmor)
+	if err != nil {
+		return fmt.Errorf("kerberos: derive FAST armor key: %w", err)
+	}
+
+	// Build the FX_FAST_ARMOR_AP_REQUEST once; it carries the subkey the KDC
+	// needs to reconstruct the armor key. It is reused across retries.
+	apReq, err := c.buildArmorAPReq(subkey)
+	if err != nil {
+		return fmt.Errorf("kerberos: build FAST armor AP-REQ: %w", err)
+	}
+	fastArmorStruct := &messages.KrbFastArmor{ArmorType: messages.FXFastArmorAPRequest, ArmorValue: apReq}
+
+	// The client's long-term key starts at the strongest supported etype with
+	// the AD default salt; a PREAUTH error corrects both via PA-ETYPE-INFO2.
+	clientEType := c.cred.SupportedETypes()[0]
+	salt := c.cred.DefaultSalt()
+	var s2kParams []byte
+	var cookie *messages.PAData
+
+	// At most three attempts: one for a cookie/etype correction, one for a
+	// clock-skew correction, plus the initial try.
+	for attempt := 0; attempt < 3; attempt++ {
+		nonce := randomNonce()
+		resp, err := c.sendFASTAS(fastArmorStruct, armorKey, armorEType, clientEType, salt, s2kParams, nonce, cookie)
+		if err != nil {
+			return err
+		}
+
+		var krbErr messages.KRBError
+		if _, parseErr := krbErr.Unmarshal(resp); parseErr == nil {
+			innerErr, newCookie, info := c.parseFASTError(krbErr, armorKey, armorEType)
+			if newCookie != nil {
+				cookie = newCookie
+			}
+			// A PA-ETYPE-INFO2 inside the armored error corrects the client key.
+			if info != nil {
+				clientEType, salt, s2kParams = pickBestEType(info, c.cred.SupportedETypes(), c.cred.DefaultSalt())
+			}
+			effective := krbErr
+			if innerErr != nil {
+				effective = *innerErr
+			}
+			switch effective.ErrorCode {
+			case messages.ErrPreauthRequired:
+				if attempt < 2 {
+					continue // retry with the corrected etype/salt and cookie
+				}
+			case messages.ErrSkew:
+				if attempt < 2 && c.applyClockSkew(effective) {
+					continue
+				}
+			}
+			return fmt.Errorf("kerberos: FAST GetTGT failed (error %d): %s", effective.ErrorCode, effective.EText)
+		}
+
+		return c.processFASTASRep(resp, armorKey, armorEType, clientEType, salt, s2kParams, nonce)
+	}
+	return fmt.Errorf("kerberos: FAST GetTGT: retry budget exhausted")
+}
+
+// buildArmorAPReq builds the FX_FAST_ARMOR_AP_REQUEST AP-REQ over the armor TGT.
+// The authenticator MUST carry the subkey (RFC 6113 §5.4.1.1); it is encrypted
+// with the armor TGT session key under key usage 11 (a standalone AP-REQ, not a
+// PA-TGS-REQ).
+func (c *KerberosClient) buildArmorAPReq(subkey []byte) ([]byte, error) {
+	armor := c.fast
+	now := c.now()
+
+	auth := &messages.Authenticator{
+		AVno:   messages.KerberosV5,
+		CRealm: armor.realm,
+		CName:  messages.PrincipalName{NameType: messages.NameTypePrincipal, NameString: []string{armor.cname}},
+		CUSec:  now.Nanosecond() / 1000,
+		CTime:  now,
+		SubKey: &messages.EncryptionKey{KeyType: armor.sessionEType, KeyValue: subkey},
+	}
+	authBytes, err := auth.Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("marshal armor Authenticator: %w", err)
+	}
+	encAuth, err := kerbcrypto.Encrypt(armor.sessionEType, armor.sessionKey, kerbcrypto.KeyUsageAPReqAuthen, authBytes)
+	if err != nil {
+		return nil, fmt.Errorf("encrypt armor Authenticator: %w", err)
+	}
+
+	apReq := &messages.APReq{
+		PVNO:      messages.KerberosV5,
+		MsgType:   messages.MsgTypeAPReq,
+		APOptions: asn1.BitString{Bytes: []byte{0x00, 0x00, 0x00, 0x00}, BitLength: 32},
+		Ticket:    armor.ticket,
+		TicketRaw: armor.ticketRaw,
+		Authenticator: messages.EncryptedData{
+			EType:  armor.sessionEType,
+			Cipher: encAuth,
+		},
+	}
+	return apReq.Marshal()
+}
+
+// asReqBody builds the AS-REQ KDC-REQ-BODY requesting a TGT for this client.
+func (c *KerberosClient) asReqBody(nonce int) messages.KDCReqBody {
+	return messages.KDCReqBody{
+		KDCOptions: kdcOptionsForASReq(),
+		CName: messages.PrincipalName{
+			NameType:   messages.NameTypePrincipal,
+			NameString: []string{c.username},
+		},
+		Realm: c.realm,
+		SName: messages.PrincipalName{
+			NameType:   messages.NameTypeSRVInst,
+			NameString: []string{"krbtgt", c.realm},
+		},
+		Till:  c.now().Add(24 * time.Hour),
+		Nonce: nonce,
+		EType: c.cred.SupportedETypes(),
+	}
+}
+
+// sendFASTAS assembles and sends one FAST-armored AS-REQ with a
+// PA-ENCRYPTED-CHALLENGE factor, returning the raw KDC response.
+func (c *KerberosClient) sendFASTAS(armor *messages.KrbFastArmor, armorKey []byte, armorEType, clientEType int, salt string, s2kParams []byte, nonce int, cookie *messages.PAData) ([]byte, error) {
+	// PA-ENCRYPTED-CHALLENGE: PA-ENC-TS-ENC encrypted in the challenge key,
+	// which combines the armor key with the client long-term key (RFC 6113
+	// §5.4.6).
+	clientKey, err := c.cred.Key(clientEType, salt, s2kParams)
+	if err != nil {
+		return nil, fmt.Errorf("kerberos: derive client key: %w", err)
+	}
+	challengeKey, challEType, err := kerbcrypto.KRBFXCF2(
+		armorKey, armorEType, clientKey, clientEType,
+		fastPepperClientChallenge, fastPepperChallengeLongTem)
+	if err != nil {
+		return nil, fmt.Errorf("kerberos: derive challenge key: %w", err)
+	}
+
+	now := c.now()
+	tsBytes, err := (&messages.PAEncTSEnc{PATimestamp: now, PAUSec: now.Nanosecond() / 1000}).Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("kerberos: marshal PA-ENC-TS-ENC: %w", err)
+	}
+	encChallenge, err := kerbcrypto.Encrypt(challEType, challengeKey, kerbcrypto.KeyUsageEncChallengeClient, tsBytes)
+	if err != nil {
+		return nil, fmt.Errorf("kerberos: encrypt challenge: %w", err)
+	}
+	challengeValue, err := asn1.Marshal(messages.EncryptedData{EType: challEType, Cipher: encChallenge})
+	if err != nil {
+		return nil, fmt.Errorf("kerberos: marshal EncryptedChallenge: %w", err)
+	}
+
+	// Inner (armor-protected) padata and request body — the KDC uses these in
+	// preference to the outer ones.
+	innerPAData := []messages.PAData{
+		pacRequestPA(),
+		{PADataType: messages.PAEncryptedChallenge, PADataValue: challengeValue},
+	}
+	if cookie != nil {
+		innerPAData = append(innerPAData, *cookie)
+	}
+	innerBody := c.asReqBody(nonce)
+
+	fastReq := &messages.KrbFastReq{
+		FastOptions: messages.NewKerberosFlags(),
+		PAData:      innerPAData,
+		ReqBody:     innerBody,
+	}
+	fastReqBytes, err := fastReq.Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("kerberos: marshal KrbFastReq: %w", err)
+	}
+	encFastReq, err := kerbcrypto.Encrypt(armorEType, armorKey, kerbcrypto.KeyUsageFASTEnc, fastReqBytes)
+	if err != nil {
+		return nil, fmt.Errorf("kerberos: encrypt KrbFastReq: %w", err)
+	}
+
+	// The req-checksum is a keyed checksum over the OUTER KDC-REQ-BODY, computed
+	// with the armor key (RFC 6113 §5.4.2, key usage 50). Encode the outer body
+	// once so the transmitted bytes are byte-identical to what was checksummed.
+	outerBody := c.asReqBody(randomNonce())
+	outerBodyBytes, err := messages.EncodeKDCReqBody(outerBody)
+	if err != nil {
+		return nil, fmt.Errorf("kerberos: encode outer KDC-REQ-BODY: %w", err)
+	}
+	cksumType, ok := kerbcrypto.ChecksumTypeForEType(armorEType)
+	if !ok {
+		return nil, fmt.Errorf("kerberos: no checksum type for armor etype %d", armorEType)
+	}
+	cksum, err := kerbcrypto.GetChecksum(cksumType, armorKey, kerbcrypto.KeyUsageFASTReqChksum, outerBodyBytes)
+	if err != nil {
+		return nil, fmt.Errorf("kerberos: FAST req-checksum: %w", err)
+	}
+
+	armoredReq := &messages.KrbFastArmoredReq{
+		Armor:       armor,
+		ReqChecksum: messages.Checksum{CKSumType: cksumType, Checksum: cksum},
+		EncFastReq:  messages.EncryptedData{EType: armorEType, Cipher: encFastReq},
+	}
+	fastValue, err := messages.MarshalPAFXFastRequest(armoredReq)
+	if err != nil {
+		return nil, fmt.Errorf("kerberos: marshal PA-FX-FAST: %w", err)
+	}
+
+	// The outer AS-REQ carries only PA-FX-FAST; the KDC ignores the rest.
+	asReq := &messages.ASReq{
+		PVNO:    messages.KerberosV5,
+		MsgType: messages.MsgTypeASReq,
+		PAData:  []messages.PAData{{PADataType: messages.PAFXFast, PADataValue: fastValue}},
+		ReqBody: outerBody,
+	}
+	reqBytes, err := asReq.Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("kerberos: marshal FAST AS-REQ: %w", err)
+	}
+	return c.sendToRealm(c.realm, reqBytes)
+}
+
+// processFASTASRep validates an armored AS-REP: it decrypts the armored FAST
+// response with the armor key, applies the strengthen-key to derive the reply
+// key (RFC 6113 §5.4.3), decrypts the AS-REP enc-part, verifies nonces, and
+// stores the TGT.
+func (c *KerberosClient) processFASTASRep(resp, armorKey []byte, armorEType, clientEType int, salt string, s2kParams []byte, requestNonce int) error {
+	var asRep messages.ASRep
+	if _, err := asRep.Unmarshal(resp); err != nil {
+		return fmt.Errorf("kerberos: parse FAST AS-REP: %w", err)
+	}
+
+	fastResp, err := c.decryptFASTReply(asRep.PAData, armorKey, armorEType)
+	if err != nil {
+		return fmt.Errorf("kerberos: decrypt FAST reply: %w", err)
+	}
+	if fastResp.Nonce != requestNonce {
+		return fmt.Errorf("kerberos: FAST response nonce mismatch: got %d, want %d", fastResp.Nonce, requestNonce)
+	}
+
+	// The AS-REP enc-part is encrypted with the strengthened reply key. MS-KILE
+	// requires strengthen-key when the encrypted-challenge factor is used.
+	clientKey, err := c.cred.Key(clientEType, salt, s2kParams)
+	if err != nil {
+		return fmt.Errorf("kerberos: derive client key for reply: %w", err)
+	}
+	replyKey := clientKey
+	replyEType := clientEType
+	if fastResp.StrengthenKey != nil {
+		sk := fastResp.StrengthenKey
+		replyKey, replyEType, err = kerbcrypto.KRBFXCF2(
+			sk.KeyValue, sk.KeyType, clientKey, clientEType,
+			fastPepperStrengthenKey, fastPepperReplyKey)
+		if err != nil {
+			return fmt.Errorf("kerberos: strengthen reply key: %w", err)
+		}
+	}
+
+	encPlain, err := kerbcrypto.Decrypt(replyEType, replyKey, kerbcrypto.KeyUsageASRepEncPart, asRep.EncPart.Cipher)
+	if err != nil {
+		return fmt.Errorf("kerberos: decrypt FAST AS-REP enc-part: %w", err)
+	}
+	var encASRep messages.EncASRepPart
+	if _, err := encASRep.Unmarshal(encPlain); err != nil {
+		return fmt.Errorf("kerberos: parse EncASRepPart: %w", err)
+	}
+	if encASRep.Nonce != requestNonce {
+		return fmt.Errorf("kerberos: FAST AS-REP nonce mismatch: got %d, want %d", encASRep.Nonce, requestNonce)
+	}
+
+	c.tgtTicket = asRep.Ticket
+	c.tgtTicketRaw = asRep.TicketRaw
+	c.sessionKey = encASRep.Key.KeyValue
+	c.sessionEType = encASRep.Key.KeyType
+	c.tgtEnc = encASRep
+	c.hasTGT = true
+	return nil
+}
+
+// decryptFASTReply locates PA-FX-FAST in a reply's padata, unwraps the armored
+// reply, and decrypts the KrbFastResponse with the armor key (key usage 52).
+func (c *KerberosClient) decryptFASTReply(paData []messages.PAData, armorKey []byte, armorEType int) (*messages.KrbFastResponse, error) {
+	for _, pa := range paData {
+		if pa.PADataType != messages.PAFXFast {
+			continue
+		}
+		rep, err := messages.ParsePAFXFastReply(pa.PADataValue)
+		if err != nil {
+			return nil, err
+		}
+		plain, err := kerbcrypto.Decrypt(armorEType, armorKey, kerbcrypto.KeyUsageFASTRep, rep.EncFastRep.Cipher)
+		if err != nil {
+			return nil, fmt.Errorf("decrypt enc-fast-rep: %w", err)
+		}
+		var fastResp messages.KrbFastResponse
+		if _, err := fastResp.Unmarshal(plain); err != nil {
+			return nil, fmt.Errorf("parse KrbFastResponse: %w", err)
+		}
+		return &fastResp, nil
+	}
+	return nil, fmt.Errorf("no PA-FX-FAST in reply")
+}
+
+// parseFASTError inspects an armored KRB-ERROR: it decrypts the FAST reply (if
+// present) and extracts the nested PA-FX-ERROR (the real error), a PA-FX-COOKIE
+// to echo on retry, and any PA-ETYPE-INFO2 correcting the client key. When the
+// error is not FAST-wrapped, all return values are nil.
+func (c *KerberosClient) parseFASTError(krbErr messages.KRBError, armorKey []byte, armorEType int) (innerErr *messages.KRBError, cookie *messages.PAData, info messages.ETypeInfo2) {
+	if len(krbErr.EData) == 0 {
+		return nil, nil, nil
+	}
+	var methodData []messages.PAData
+	if _, err := asn1.Unmarshal(krbErr.EData, &methodData); err != nil {
+		return nil, nil, nil
+	}
+	fastResp, err := c.decryptFASTReply(methodData, armorKey, armorEType)
+	if err != nil {
+		return nil, nil, nil
+	}
+	for i := range fastResp.PAData {
+		pa := fastResp.PAData[i]
+		switch pa.PADataType {
+		case messages.PAFXCookie:
+			cp := pa
+			cookie = &cp
+		case messages.PAFXError:
+			var e messages.KRBError
+			if _, err := e.Unmarshal(pa.PADataValue); err == nil {
+				ec := e
+				innerErr = &ec
+			}
+		case messages.PAETypeInfo2:
+			var i2 messages.ETypeInfo2
+			if _, err := i2.Unmarshal(pa.PADataValue); err == nil && len(i2) > 0 {
+				info = i2
+			}
+		}
+	}
+	// PA-ETYPE-INFO2 may also ride in the nested error's own EData.
+	if info == nil && innerErr != nil && len(innerErr.EData) > 0 {
+		var i2 messages.ETypeInfo2
+		if _, err := i2.Unmarshal(innerErr.EData); err == nil && len(i2) > 0 {
+			info = i2
+		}
+	}
+	return innerErr, cookie, info
+}

--- a/network/kerberos/v5/messages/constants.go
+++ b/network/kerberos/v5/messages/constants.go
@@ -28,11 +28,15 @@ const (
 	ETypeAES128CTSHMACSHA196 = iana.ETypeAES128CTSHMACSHA196
 	ETypeAES256CTSHMACSHA196 = iana.ETypeAES256CTSHMACSHA196
 
-	PATGSReq          = iana.PATGSReq
-	PAEncTimestamp    = iana.PAEncTimestamp
-	PAETypeInfo2      = iana.PAETypeInfo2
-	PAPACRequest      = iana.PAPACRequest
-	PASvrReferralInfo = iana.PASvrReferralInfo
+	PATGSReq             = iana.PATGSReq
+	PAEncTimestamp       = iana.PAEncTimestamp
+	PAETypeInfo2         = iana.PAETypeInfo2
+	PAPACRequest         = iana.PAPACRequest
+	PASvrReferralInfo    = iana.PASvrReferralInfo
+	PAFXCookie           = iana.PAFXCookie
+	PAFXFast             = iana.PAFXFast
+	PAFXError            = iana.PAFXError
+	PAEncryptedChallenge = iana.PAEncryptedChallenge
 
 	ErrNone              = iana.ErrNone
 	ErrCPrincipalUnknown = iana.ErrCPrincipalUnknown

--- a/network/kerberos/v5/messages/fast.go
+++ b/network/kerberos/v5/messages/fast.go
@@ -1,0 +1,402 @@
+package messages
+
+import (
+	"encoding/asn1"
+	"fmt"
+	"time"
+)
+
+// This file implements the wire structures of RFC 6113 (A Generalized Framework
+// for Kerberos Pre-Authentication — "FAST", Flexible Authentication Secure
+// Tunneling), as profiled by MS-KILE for Kerberos armoring.
+//
+// FAST wraps an ordinary KDC-REQ inside an armored, integrity-protected
+// envelope keyed by an "armor key". The client armors an AS-REQ/TGS-REQ with
+// PA-FX-FAST (padata-type 136), carrying a KrbFastArmoredReq; the KDC replies
+// with PA-FX-FAST carrying a KrbFastArmoredRep. Errors are delivered inside the
+// armor as PA-FX-ERROR (137), and stateful replay protection cookies as
+// PA-FX-COOKIE (133).
+//
+// The Kerberos ASN.1 modules use EXPLICIT tagging, so every context tag below
+// is explicit, matching the rest of this package.
+
+// FAST armor types (RFC 6113 §5.4.1). FX_FAST_ARMOR_AP_REQUEST carries a
+// DER-encoded AP-REQ whose authenticator subkey, combined with the armor
+// ticket's session key, yields the armor key.
+const (
+	FXFastArmorAPRequest = 1 // FX_FAST_ARMOR_AP_REQUEST
+)
+
+// FastOptions bit positions (RFC 6113 §5.4.2). Bit 0 is the MSB.
+const (
+	// FastOptionHideClientNames requests that the KDC omit the client identity
+	// from error replies (a critical option).
+	FastOptionHideClientNames = 1
+)
+
+// KrbFastArmor is the FAST armor descriptor (RFC 6113 §5.4.1):
+//
+//	KrbFastArmor ::= SEQUENCE {
+//	    armor-type  [0] Int32,
+//	    armor-value [1] OCTET STRING,
+//	    ...
+//	}
+type KrbFastArmor struct {
+	ArmorType  int    `asn1:"explicit,tag:0"`
+	ArmorValue []byte `asn1:"explicit,tag:1"`
+}
+
+// Marshal encodes the KrbFastArmor SEQUENCE.
+func (a *KrbFastArmor) Marshal() ([]byte, error) { return asn1.Marshal(*a) }
+
+// Unmarshal decodes a KrbFastArmor SEQUENCE, returning bytes consumed.
+func (a *KrbFastArmor) Unmarshal(data []byte) (int, error) {
+	rest, err := asn1.Unmarshal(data, a)
+	if err != nil {
+		return 0, err
+	}
+	return len(data) - len(rest), nil
+}
+
+// krbFastReqMarshal is the GeneralString-aware marshal form of KrbFastReq: the
+// req-body is a KDC-REQ-BODY whose realm/principal names must be GeneralString
+// (Go's encoding/asn1 would otherwise emit PrintableString).
+type krbFastReqMarshal struct {
+	FastOptions asn1.BitString    `asn1:"explicit,tag:0"`
+	PAData      []PAData          `asn1:"explicit,tag:1"`
+	ReqBody     kdcReqBodyMarshal `asn1:"explicit,tag:2"`
+}
+
+// kdcReqBodyParse is a KDC-REQ-BODY unmarshal view. It exists because the
+// canonical KDCReqBody carries AdditTickets/AdditTicketsRaw with asn1:"-", which
+// Go's encoding/asn1 does not honor on decode (it would try to parse them as
+// SEQUENCE fields and fail); this view lists only the DER-present fields 0..10.
+type kdcReqBodyParse struct {
+	KDCOptions  asn1.BitString `asn1:"explicit,tag:0"`
+	CName       PrincipalName  `asn1:"explicit,tag:1,optional"`
+	Realm       string         `asn1:"explicit,tag:2,generalstring"`
+	SName       PrincipalName  `asn1:"explicit,tag:3,optional"`
+	From        time.Time      `asn1:"explicit,tag:4,optional,generalized"`
+	Till        time.Time      `asn1:"explicit,tag:5,generalized"`
+	RTime       time.Time      `asn1:"explicit,tag:6,optional,generalized"`
+	Nonce       int            `asn1:"explicit,tag:7"`
+	EType       []int          `asn1:"explicit,tag:8"`
+	Addresses   []HostAddress  `asn1:"explicit,tag:9,optional"`
+	EncAuthData EncryptedData  `asn1:"explicit,tag:10,optional"`
+}
+
+func (p kdcReqBodyParse) toKDCReqBody() KDCReqBody {
+	return KDCReqBody{
+		KDCOptions:  p.KDCOptions,
+		CName:       p.CName,
+		Realm:       p.Realm,
+		SName:       p.SName,
+		From:        p.From,
+		Till:        p.Till,
+		RTime:       p.RTime,
+		Nonce:       p.Nonce,
+		EType:       p.EType,
+		Addresses:   p.Addresses,
+		EncAuthData: p.EncAuthData,
+	}
+}
+
+// krbFastReqInner is the unmarshal form of KrbFastReq.
+type krbFastReqInner struct {
+	FastOptions asn1.BitString  `asn1:"explicit,tag:0"`
+	PAData      []PAData        `asn1:"explicit,tag:1"`
+	ReqBody     kdcReqBodyParse `asn1:"explicit,tag:2"`
+}
+
+// KrbFastReq is the plaintext of the enc-fast-req field (RFC 6113 §5.4.2):
+//
+//	KrbFastReq ::= SEQUENCE {
+//	    fast-options [0] FastOptions,
+//	    padata       [1] SEQUENCE OF PA-DATA,
+//	    req-body     [2] KDC-REQ-BODY,
+//	    ...
+//	}
+//
+// The KDC uses this inner req-body and padata in preference to the outer,
+// unprotected KDC-REQ.
+type KrbFastReq struct {
+	FastOptions asn1.BitString
+	PAData      []PAData
+	ReqBody     KDCReqBody
+}
+
+// Marshal encodes the KrbFastReq SEQUENCE with GeneralString-encoded names.
+func (r *KrbFastReq) Marshal() ([]byte, error) {
+	return asn1.Marshal(krbFastReqMarshal{
+		FastOptions: r.FastOptions,
+		PAData:      r.PAData,
+		ReqBody:     marshalKDCReqBody(r.ReqBody),
+	})
+}
+
+// Unmarshal decodes a KrbFastReq SEQUENCE, returning bytes consumed.
+func (r *KrbFastReq) Unmarshal(data []byte) (int, error) {
+	var inner krbFastReqInner
+	rest, err := asn1.Unmarshal(data, &inner)
+	if err != nil {
+		return 0, err
+	}
+	r.FastOptions = inner.FastOptions
+	r.PAData = inner.PAData
+	r.ReqBody = inner.ReqBody.toKDCReqBody()
+	return len(data) - len(rest), nil
+}
+
+// KrbFastArmoredReq is the armored FAST request (RFC 6113 §5.4.2):
+//
+//	KrbFastArmoredReq ::= SEQUENCE {
+//	    armor        [0] KrbFastArmor OPTIONAL,
+//	    req-checksum [1] Checksum,
+//	    enc-fast-req [2] EncryptedData -- KrbFastReq --,
+//	    ...
+//	}
+//
+// For an AS-REQ the armor field MUST be present. req-checksum is a keyed
+// checksum, computed with the armor key (key usage 50), over the outer
+// KDC-REQ-BODY. enc-fast-req is the KrbFastReq encrypted under the armor key
+// (key usage 51).
+type KrbFastArmoredReq struct {
+	Armor       *KrbFastArmor
+	ReqChecksum Checksum
+	EncFastReq  EncryptedData
+}
+
+type krbFastArmoredReqMarshal struct {
+	Armor       KrbFastArmor  `asn1:"explicit,tag:0,optional"`
+	ReqChecksum Checksum      `asn1:"explicit,tag:1"`
+	EncFastReq  EncryptedData `asn1:"explicit,tag:2"`
+}
+
+type krbFastArmoredReqInner struct {
+	Armor       KrbFastArmor  `asn1:"explicit,tag:0,optional"`
+	ReqChecksum Checksum      `asn1:"explicit,tag:1"`
+	EncFastReq  EncryptedData `asn1:"explicit,tag:2"`
+}
+
+// Marshal encodes the KrbFastArmoredReq SEQUENCE.
+func (r *KrbFastArmoredReq) Marshal() ([]byte, error) {
+	m := krbFastArmoredReqMarshal{ReqChecksum: r.ReqChecksum, EncFastReq: r.EncFastReq}
+	if r.Armor != nil {
+		m.Armor = *r.Armor
+	}
+	return asn1.Marshal(m)
+}
+
+// Unmarshal decodes a KrbFastArmoredReq SEQUENCE, returning bytes consumed.
+func (r *KrbFastArmoredReq) Unmarshal(data []byte) (int, error) {
+	var inner krbFastArmoredReqInner
+	rest, err := asn1.Unmarshal(data, &inner)
+	if err != nil {
+		return 0, err
+	}
+	if inner.Armor.ArmorType != 0 || len(inner.Armor.ArmorValue) != 0 {
+		a := inner.Armor
+		r.Armor = &a
+	}
+	r.ReqChecksum = inner.ReqChecksum
+	r.EncFastReq = inner.EncFastReq
+	return len(data) - len(rest), nil
+}
+
+// KrbFastArmoredRep is the armored FAST reply (RFC 6113 §5.4.3):
+//
+//	KrbFastArmoredRep ::= SEQUENCE {
+//	    enc-fast-rep [0] EncryptedData -- KrbFastResponse --,
+//	    ...
+//	}
+//
+// enc-fast-rep is a KrbFastResponse encrypted under the armor key (key usage 52).
+type KrbFastArmoredRep struct {
+	EncFastRep EncryptedData `asn1:"explicit,tag:0"`
+}
+
+// Marshal encodes the KrbFastArmoredRep SEQUENCE.
+func (r *KrbFastArmoredRep) Marshal() ([]byte, error) { return asn1.Marshal(*r) }
+
+// Unmarshal decodes a KrbFastArmoredRep SEQUENCE, returning bytes consumed.
+func (r *KrbFastArmoredRep) Unmarshal(data []byte) (int, error) {
+	rest, err := asn1.Unmarshal(data, r)
+	if err != nil {
+		return 0, err
+	}
+	return len(data) - len(rest), nil
+}
+
+// KrbFastResponse is the plaintext of enc-fast-rep (RFC 6113 §5.4.3):
+//
+//	KrbFastResponse ::= SEQUENCE {
+//	    padata         [0] SEQUENCE OF PA-DATA,
+//	    strengthen-key [1] EncryptionKey OPTIONAL,
+//	    finished       [2] KrbFastFinished OPTIONAL,
+//	    nonce          [3] UInt32,
+//	    ...
+//	}
+//
+// When strengthen-key is present the reply key is replaced by
+// KRB-FX-CF2(strengthen-key, reply-key, "strengthenkey", "replykey"). nonce
+// echoes the inner KDC-REQ-BODY nonce and MUST match it.
+type KrbFastResponse struct {
+	PAData        []PAData
+	StrengthenKey *EncryptionKey
+	Finished      *KrbFastFinished
+	Nonce         int
+}
+
+type krbFastResponseMarshal struct {
+	PAData        []PAData      `asn1:"explicit,tag:0"`
+	StrengthenKey EncryptionKey `asn1:"explicit,tag:1,optional"`
+	Finished      asn1.RawValue `asn1:"explicit,tag:2,optional"`
+	Nonce         int           `asn1:"explicit,tag:3"`
+}
+
+type krbFastResponseInner struct {
+	PAData        []PAData      `asn1:"explicit,tag:0"`
+	StrengthenKey EncryptionKey `asn1:"explicit,tag:1,optional"`
+	Finished      asn1.RawValue `asn1:"explicit,tag:2,optional"`
+	Nonce         int           `asn1:"explicit,tag:3"`
+}
+
+// Marshal encodes the KrbFastResponse SEQUENCE.
+func (r *KrbFastResponse) Marshal() ([]byte, error) {
+	m := krbFastResponseMarshal{PAData: r.PAData, Nonce: r.Nonce}
+	if r.StrengthenKey != nil {
+		m.StrengthenKey = *r.StrengthenKey
+	}
+	if r.Finished != nil {
+		fb, err := r.Finished.Marshal()
+		if err != nil {
+			return nil, err
+		}
+		m.Finished = asn1.RawValue{Class: asn1.ClassContextSpecific, Tag: 2, IsCompound: true, Bytes: fb}
+	}
+	return asn1.Marshal(m)
+}
+
+// Unmarshal decodes a KrbFastResponse SEQUENCE, returning bytes consumed.
+func (r *KrbFastResponse) Unmarshal(data []byte) (int, error) {
+	var inner krbFastResponseInner
+	rest, err := asn1.Unmarshal(data, &inner)
+	if err != nil {
+		return 0, err
+	}
+	r.PAData = inner.PAData
+	r.Nonce = inner.Nonce
+	if inner.StrengthenKey.KeyType != 0 || len(inner.StrengthenKey.KeyValue) != 0 {
+		sk := inner.StrengthenKey
+		r.StrengthenKey = &sk
+	}
+	// Finished is [2] EXPLICIT { KrbFastFinished SEQUENCE }. Go leaves the outer
+	// context tag on the RawValue and Bytes = the inner SEQUENCE TLV.
+	if len(inner.Finished.Bytes) != 0 {
+		var f KrbFastFinished
+		if _, err := f.Unmarshal(inner.Finished.Bytes); err != nil {
+			return 0, fmt.Errorf("krbfastresponse: finished: %w", err)
+		}
+		r.Finished = &f
+	}
+	return len(data) - len(rest), nil
+}
+
+// KrbFastFinished authenticates the FAST exchange to the client (RFC 6113
+// §5.4.3):
+//
+//	KrbFastFinished ::= SEQUENCE {
+//	    timestamp       [0] KerberosTime,
+//	    usec            [1] Microseconds,
+//	    crealm          [2] Realm,
+//	    cname           [3] PrincipalName,
+//	    ticket-checksum [4] Checksum,
+//	    ...
+//	}
+//
+// ticket-checksum is a keyed checksum over the issued ticket, computed with the
+// armor key (key usage 53).
+type KrbFastFinished struct {
+	Timestamp      time.Time
+	Usec           int
+	CRealm         string
+	CName          PrincipalName
+	TicketChecksum Checksum
+}
+
+type krbFastFinishedMarshal struct {
+	Timestamp      time.Time            `asn1:"explicit,tag:0,generalized"`
+	Usec           int                  `asn1:"explicit,tag:1"`
+	CRealm         asn1.RawValue        // pre-encoded [2] EXPLICIT { GeneralString }
+	CName          PrincipalNameMarshal `asn1:"explicit,tag:3"`
+	TicketChecksum Checksum             `asn1:"explicit,tag:4"`
+}
+
+type krbFastFinishedInner struct {
+	Timestamp      time.Time     `asn1:"explicit,tag:0,generalized"`
+	Usec           int           `asn1:"explicit,tag:1"`
+	CRealm         string        `asn1:"explicit,tag:2,generalstring"`
+	CName          PrincipalName `asn1:"explicit,tag:3"`
+	TicketChecksum Checksum      `asn1:"explicit,tag:4"`
+}
+
+// Marshal encodes the KrbFastFinished SEQUENCE with GeneralString names.
+func (f *KrbFastFinished) Marshal() ([]byte, error) {
+	return asn1.Marshal(krbFastFinishedMarshal{
+		Timestamp:      normalizeTime(f.Timestamp),
+		Usec:           f.Usec,
+		CRealm:         realmExplicit(2, f.CRealm),
+		CName:          MarshalPrincipalName(f.CName),
+		TicketChecksum: f.TicketChecksum,
+	})
+}
+
+// Unmarshal decodes a KrbFastFinished SEQUENCE, returning bytes consumed.
+func (f *KrbFastFinished) Unmarshal(data []byte) (int, error) {
+	var inner krbFastFinishedInner
+	rest, err := asn1.Unmarshal(data, &inner)
+	if err != nil {
+		return 0, err
+	}
+	f.Timestamp = inner.Timestamp
+	f.Usec = inner.Usec
+	f.CRealm = inner.CRealm
+	f.CName = inner.CName
+	f.TicketChecksum = inner.TicketChecksum
+	return len(data) - len(rest), nil
+}
+
+// MarshalPAFXFastRequest encodes a KrbFastArmoredReq as the PA-FX-FAST-REQUEST
+// padata-value (RFC 6113 §5.4.2):
+//
+//	PA-FX-FAST-REQUEST ::= CHOICE { armored-data [0] KrbFastArmoredReq, ... }
+//
+// A CHOICE has no SEQUENCE wrapper: the value is the chosen alternative's
+// [0] EXPLICIT context element wrapping the KrbFastArmoredReq SEQUENCE.
+func MarshalPAFXFastRequest(req *KrbFastArmoredReq) ([]byte, error) {
+	seq, err := req.Marshal()
+	if err != nil {
+		return nil, err
+	}
+	return asn1.Marshal(asn1.RawValue{Class: asn1.ClassContextSpecific, Tag: 0, IsCompound: true, Bytes: seq})
+}
+
+// ParsePAFXFastReply decodes a PA-FX-FAST-REPLY padata-value (RFC 6113 §5.4.3):
+//
+//	PA-FX-FAST-REPLY ::= CHOICE { armored-data [0] KrbFastArmoredRep, ... }
+//
+// It unwraps the [0] EXPLICIT alternative and parses the KrbFastArmoredRep.
+func ParsePAFXFastReply(data []byte) (KrbFastArmoredRep, error) {
+	var choice asn1.RawValue
+	if _, err := asn1.Unmarshal(data, &choice); err != nil {
+		return KrbFastArmoredRep{}, fmt.Errorf("pa-fx-fast-reply: %w", err)
+	}
+	if choice.Class != asn1.ClassContextSpecific || choice.Tag != 0 {
+		return KrbFastArmoredRep{}, fmt.Errorf("pa-fx-fast-reply: unexpected alternative class=%d tag=%d", choice.Class, choice.Tag)
+	}
+	var rep KrbFastArmoredRep
+	if _, err := rep.Unmarshal(choice.Bytes); err != nil {
+		return KrbFastArmoredRep{}, fmt.Errorf("pa-fx-fast-reply: armored-rep: %w", err)
+	}
+	return rep, nil
+}

--- a/network/kerberos/v5/messages/fast_test.go
+++ b/network/kerberos/v5/messages/fast_test.go
@@ -1,0 +1,186 @@
+package messages
+
+import (
+	"bytes"
+	"encoding/asn1"
+	"testing"
+	"time"
+
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/iana"
+)
+
+// marshalContextExplicit wraps seq in an EXPLICIT [tag] context element, as the
+// Kerberos ASN.1 modules do for CHOICE alternatives.
+func marshalContextExplicit(t *testing.T, tag int, seq []byte) []byte {
+	t.Helper()
+	b, err := asn1.Marshal(asn1.RawValue{Class: asn1.ClassContextSpecific, Tag: tag, IsCompound: true, Bytes: seq})
+	if err != nil {
+		t.Fatalf("marshal context [%d]: %v", tag, err)
+	}
+	return b
+}
+
+// TestKrbFastArmoredReqRoundTrip marshals a full KrbFastArmoredReq (as a client
+// would build it) and parses it back, verifying every field survives — proving
+// the request-envelope encoding is structurally sound.
+func TestKrbFastArmoredReqRoundTrip(t *testing.T) {
+	body := KDCReqBody{
+		KDCOptions: NewKerberosFlags(iana.KDCOptionForwardable, iana.KDCOptionRenewable),
+		CName:      PrincipalName{NameType: NameTypePrincipal, NameString: []string{"alice"}},
+		Realm:      "CORP.LOCAL",
+		SName:      PrincipalName{NameType: NameTypeSRVInst, NameString: []string{"krbtgt", "CORP.LOCAL"}},
+		Till:       time.Date(2030, 1, 2, 3, 4, 5, 0, time.UTC),
+		Nonce:      0x11223344,
+		EType:      []int{ETypeAES256CTSHMACSHA196, ETypeRC4HMAC},
+	}
+	fastReq := &KrbFastReq{
+		FastOptions: NewKerberosFlags(),
+		PAData:      []PAData{{PADataType: PAEncryptedChallenge, PADataValue: []byte{0x01, 0x02, 0x03}}},
+		ReqBody:     body,
+	}
+	fastReqBytes, err := fastReq.Marshal()
+	if err != nil {
+		t.Fatalf("KrbFastReq.Marshal: %v", err)
+	}
+
+	// Verify KrbFastReq itself round-trips (inner body + padata).
+	var gotFastReq KrbFastReq
+	if _, err := gotFastReq.Unmarshal(fastReqBytes); err != nil {
+		t.Fatalf("KrbFastReq.Unmarshal: %v", err)
+	}
+	if gotFastReq.ReqBody.Realm != body.Realm || gotFastReq.ReqBody.Nonce != body.Nonce {
+		t.Fatalf("KrbFastReq body mismatch: got realm=%q nonce=%d", gotFastReq.ReqBody.Realm, gotFastReq.ReqBody.Nonce)
+	}
+	if len(gotFastReq.PAData) != 1 || gotFastReq.PAData[0].PADataType != PAEncryptedChallenge {
+		t.Fatalf("KrbFastReq padata mismatch: %+v", gotFastReq.PAData)
+	}
+
+	armor := &KrbFastArmor{ArmorType: FXFastArmorAPRequest, ArmorValue: []byte("fake-ap-req-bytes")}
+	req := &KrbFastArmoredReq{
+		Armor:       armor,
+		ReqChecksum: Checksum{CKSumType: iana.CksumTypeHMACSHA196AES256, Checksum: bytes.Repeat([]byte{0xAB}, 12)},
+		EncFastReq:  EncryptedData{EType: ETypeAES256CTSHMACSHA196, Cipher: fastReqBytes},
+	}
+
+	// Round-trip via the PA-FX-FAST-REQUEST CHOICE wrapper.
+	paValue, err := MarshalPAFXFastRequest(req)
+	if err != nil {
+		t.Fatalf("MarshalPAFXFastRequest: %v", err)
+	}
+	// The CHOICE alternative is [0] context-specific constructed.
+	if paValue[0] != 0xA0 {
+		t.Fatalf("PA-FX-FAST-REQUEST should start with context [0] (0xA0), got 0x%02X", paValue[0])
+	}
+
+	var gotReq KrbFastArmoredReq
+	// Strip the [0] explicit wrapper to parse the inner SEQUENCE.
+	inner := paValue[2:] // 0xA0, length byte, then the SEQUENCE (small payload => single length byte)
+	if paValue[1] >= 0x80 {
+		inner = paValue[2+int(paValue[1]&0x7f):]
+	}
+	if _, err := gotReq.Unmarshal(inner); err != nil {
+		t.Fatalf("KrbFastArmoredReq.Unmarshal: %v", err)
+	}
+	if gotReq.Armor == nil || gotReq.Armor.ArmorType != FXFastArmorAPRequest {
+		t.Fatalf("armor not preserved: %+v", gotReq.Armor)
+	}
+	if !bytes.Equal(gotReq.Armor.ArmorValue, armor.ArmorValue) {
+		t.Fatalf("armor value mismatch")
+	}
+	if gotReq.ReqChecksum.CKSumType != iana.CksumTypeHMACSHA196AES256 {
+		t.Fatalf("checksum type mismatch: %d", gotReq.ReqChecksum.CKSumType)
+	}
+	if !bytes.Equal(gotReq.EncFastReq.Cipher, fastReqBytes) {
+		t.Fatalf("enc-fast-req cipher mismatch")
+	}
+}
+
+// TestKrbFastArmoredRepRoundTrip marshals a KrbFastArmoredRep wrapping a
+// KrbFastResponse and parses it back through the PA-FX-FAST-REPLY CHOICE,
+// exercising the strengthen-key, finished, and nonce fields the reply path
+// depends on.
+func TestKrbFastArmoredRepRoundTrip(t *testing.T) {
+	finished := &KrbFastFinished{
+		Timestamp:      time.Date(2030, 5, 6, 7, 8, 9, 0, time.UTC),
+		Usec:           123456,
+		CRealm:         "CORP.LOCAL",
+		CName:          PrincipalName{NameType: NameTypePrincipal, NameString: []string{"alice"}},
+		TicketChecksum: Checksum{CKSumType: iana.CksumTypeHMACSHA196AES256, Checksum: bytes.Repeat([]byte{0x5A}, 12)},
+	}
+	resp := &KrbFastResponse{
+		PAData:        []PAData{{PADataType: PAFXCookie, PADataValue: []byte("cookie!")}},
+		StrengthenKey: &EncryptionKey{KeyType: ETypeAES256CTSHMACSHA196, KeyValue: bytes.Repeat([]byte{0x77}, 32)},
+		Finished:      finished,
+		Nonce:         0x0BADF00D,
+	}
+	respBytes, err := resp.Marshal()
+	if err != nil {
+		t.Fatalf("KrbFastResponse.Marshal: %v", err)
+	}
+
+	// KrbFastResponse round-trip.
+	var gotResp KrbFastResponse
+	if _, err := gotResp.Unmarshal(respBytes); err != nil {
+		t.Fatalf("KrbFastResponse.Unmarshal: %v", err)
+	}
+	if gotResp.Nonce != resp.Nonce {
+		t.Fatalf("nonce mismatch: got %d", gotResp.Nonce)
+	}
+	if gotResp.StrengthenKey == nil || gotResp.StrengthenKey.KeyType != ETypeAES256CTSHMACSHA196 {
+		t.Fatalf("strengthen-key not preserved: %+v", gotResp.StrengthenKey)
+	}
+	if !bytes.Equal(gotResp.StrengthenKey.KeyValue, resp.StrengthenKey.KeyValue) {
+		t.Fatalf("strengthen-key value mismatch")
+	}
+	if gotResp.Finished == nil || gotResp.Finished.CRealm != "CORP.LOCAL" {
+		t.Fatalf("finished not preserved: %+v", gotResp.Finished)
+	}
+	if len(gotResp.Finished.CName.NameString) != 1 || gotResp.Finished.CName.NameString[0] != "alice" {
+		t.Fatalf("finished cname mismatch: %+v", gotResp.Finished.CName)
+	}
+	if len(gotResp.PAData) != 1 || gotResp.PAData[0].PADataType != PAFXCookie {
+		t.Fatalf("response padata mismatch: %+v", gotResp.PAData)
+	}
+
+	// Wrap in KrbFastArmoredRep and PA-FX-FAST-REPLY, then parse back.
+	rep := &KrbFastArmoredRep{EncFastRep: EncryptedData{EType: ETypeAES256CTSHMACSHA196, Cipher: respBytes}}
+	seq, err := rep.Marshal()
+	if err != nil {
+		t.Fatalf("KrbFastArmoredRep.Marshal: %v", err)
+	}
+	// Build the PA-FX-FAST-REPLY CHOICE [0] wrapper manually and parse it.
+	choice := marshalContextExplicit(t, 0, seq)
+	gotRep, err := ParsePAFXFastReply(choice)
+	if err != nil {
+		t.Fatalf("ParsePAFXFastReply: %v", err)
+	}
+	if gotRep.EncFastRep.EType != ETypeAES256CTSHMACSHA196 {
+		t.Fatalf("enc-fast-rep etype mismatch: %d", gotRep.EncFastRep.EType)
+	}
+	if !bytes.Equal(gotRep.EncFastRep.Cipher, respBytes) {
+		t.Fatalf("enc-fast-rep cipher mismatch")
+	}
+}
+
+// TestKrbFastResponseNoOptionals verifies that the reply parser handles a
+// KrbFastResponse without strengthen-key or finished (an error/interim reply).
+func TestKrbFastResponseNoOptionals(t *testing.T) {
+	resp := &KrbFastResponse{
+		PAData: []PAData{{PADataType: PAFXError, PADataValue: []byte{0x30, 0x00}}},
+		Nonce:  42,
+	}
+	b, err := resp.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var got KrbFastResponse
+	if _, err := got.Unmarshal(b); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got.StrengthenKey != nil || got.Finished != nil {
+		t.Fatalf("optionals should be nil, got sk=%v fin=%v", got.StrengthenKey, got.Finished)
+	}
+	if got.Nonce != 42 {
+		t.Fatalf("nonce mismatch: %d", got.Nonce)
+	}
+}

--- a/network/kerberos/v5/messages/kdcreqbody.go
+++ b/network/kerberos/v5/messages/kdcreqbody.go
@@ -91,6 +91,15 @@ func encodeKDCReqBodyForTGS(b KDCReqBody) ([]byte, error) {
 	return asn1.Marshal(asn1.RawValue{Class: asn1.ClassUniversal, Tag: asn1.TagSequence, IsCompound: true, Bytes: content})
 }
 
+// EncodeKDCReqBody marshals a KDC-REQ-BODY to its bare SEQUENCE TLV (the DER of
+// the "KDC-REQ-BODY" type, without the [4]/[2] context wrapper it carries inside
+// a KDC-REQ or KrbFastReq). It is exported for FAST (RFC 6113), whose
+// req-checksum is computed over exactly these bytes. Additional-tickets, when
+// present, are spliced in with their correct APPLICATION[1] encoding.
+func EncodeKDCReqBody(b KDCReqBody) ([]byte, error) {
+	return encodeKDCReqBodyForTGS(b)
+}
+
 // KDCReqBody is the body of a KDC request (AS-REQ or TGS-REQ),
 // as defined in RFC 4120 Section 5.4.1.
 type KDCReqBody struct {


### PR DESCRIPTION
### Linked Issue
`Closes #917`

### Summary
Implements FAST (Flexible Authentication Secure Tunneling, RFC 6113 / MS-KILE Kerberos armoring) on the AS exchange. The `PA-FX-FAST`, `PA-FX-COOKIE`, `PA-FX-ERROR`, and `PA-ENCRYPTED-CHALLENGE` types were previously defined as constants but unused; this wires them into a working armored pre-authentication flow.

### What's added
- **crypto (`crypto/prf.go`)** — the RFC 3961/3962/8009 pseudo-random function for the AES-SHA1, AES-SHA2, and RC4 enctypes; the RFC 6113 §5.1 `PRF+` expansion; and the `KRB-FX-CF2` key-combination function. Adds the FAST key-usage numbers 50–55.
- **messages (`messages/fast.go`)** — the `KrbFastArmor`, `KrbFastReq`, `KrbFastArmoredReq`, `KrbFastArmoredRep`, `KrbFastResponse`, and `KrbFastFinished` wire structures, plus `MarshalPAFXFastRequest` / `ParsePAFXFastReply` for the `PA-FX-FAST-REQUEST` / `PA-FX-FAST-REPLY` CHOICE. Exports `EncodeKDCReqBody` (the req-checksum is computed over the outer body's exact bytes).
- **client (`fast.go`, `client.go`)** — `WithFASTArmor` / `WithFASTArmorFromClient` enable FAST with a supplied armor TGT. `GetTGT` then:
  - derives the armor key from a fresh AP-REQ subkey combined with the armor TGT session key (`FX_FAST_ARMOR_AP_REQUEST`, RFC 6113 §5.4.1.1);
  - wraps the real AS-REQ body + pa-data in an integrity-protected `PA-FX-FAST` envelope (keyed req-checksum, key usage 50; enc-fast-req, key usage 51);
  - carries the credential proof as a `PA-ENCRYPTED-CHALLENGE` factor (RFC 6113 §5.4.6, key usage 54), encrypting `PA-ENC-TS-ENC` with the armor-derived challenge key;
  - decrypts the armored reply, applies the KDC's `strengthen-key` to derive the reply key, and validates nonces;
  - handles `PA-FX-COOKIE` / `PA-FX-ERROR` (with `PA-ETYPE-INFO2` and clock-skew) retries.

Pure Go standard library only; no new dependencies.

### How Verified
- **Unit tests:** PRF known-answer tests (RFC 8009 §8 vectors for AES-SHA2; independently-computed references for AES-SHA1/RC4), `KRB-FX-CF2` known-answer vectors including the cross-enctype case, and round-trip coverage of the FAST request/reply structures. `go build ./...`, `go vet`, and `go test ./network/kerberos/...` are green.
- **Live against a Windows Server 2016 KDC:** obtained a normal password TGT, then performed a FAST-armored AS-REQ with an encrypted-challenge factor (self-armored by that TGT). The KDC returned a valid armored AS-REP in one round trip, and the FAST-issued TGT drove two subsequent TGS-REQ exchanges (with-PAC and PAC-less kerberoast) successfully. A packet capture confirmed `PA-FX-FAST` (padata type 136) on the wire in both the AS-REQ (with the embedded FX_FAST_ARMOR_AP_REQUEST AP-REQ) and the AS-REP.