### PR TITLE
Add Kerberos keytab (.keytab) read/write and keytab authentication (Fixes #919)

### DIFF
--- a/network/kerberos/v5/credcache/keytab/io.go
+++ b/network/kerberos/v5/credcache/keytab/io.go
@@ -1,0 +1,27 @@
+package keytab
+
+import (
+	"fmt"
+	"os"
+)
+
+// Save writes the keytab to path in versioned format 2, mode 0600.
+func (kt *Keytab) Save(path string) error {
+	b, err := kt.Marshal()
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(path, b, 0o600); err != nil {
+		return fmt.Errorf("keytab: write %s: %w", path, err)
+	}
+	return nil
+}
+
+// Load reads and parses a keytab file.
+func Load(path string) (*Keytab, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("keytab: read %s: %w", path, err)
+	}
+	return Unmarshal(b)
+}

--- a/network/kerberos/v5/credcache/keytab/keytab.go
+++ b/network/kerberos/v5/credcache/keytab/keytab.go
@@ -1,0 +1,411 @@
+// Package keytab reads and writes the MIT/Heimdal Kerberos keytab file
+// (the ".keytab" / krb5.keytab format) in versioned format 2 (magic 0x05 0x02),
+// the interchange format Unix Kerberos tooling (ktutil, kinit -kt, klist -k) uses
+// to store a principal's long-term keys on disk.
+//
+// A keytab holds one or more entries, each binding a principal to a single
+// long-term key (an enctype plus the raw key bytes) and a key version number
+// (kvno). Unlike a credential cache (see the ccache package) it stores permanent
+// keys, not tickets, so it lets a client authenticate non-interactively — the
+// keytab-based analogue of pass-the-key.
+//
+// Wire format (documented at
+// https://web.mit.edu/kerberos/krb5-devel/doc/formats/keytab_file_format.html):
+//
+//	keytab {
+//	    uint16                 file_format_version = 0x0502
+//	    keytab_entry           entries[*]         (runs to EOF)
+//	}
+//	keytab_entry {
+//	    int32                  size               // bytes that FOLLOW this field;
+//	                                              // negative = a hole (deleted entry),
+//	                                              // its magnitude is the hole length
+//	    uint16                 num_components     // v2 does NOT count the realm
+//	    counted_octet_string   realm
+//	    counted_octet_string   components[num_components]
+//	    uint32                 name_type          // v2 only
+//	    uint32                 timestamp          // Unix seconds
+//	    uint8                  vno8               // 8-bit key version number
+//	    keyblock               key
+//	    uint32                 vno                // OPTIONAL: present when >= 4 bytes
+//	                                              // remain in size and it is non-zero;
+//	                                              // supersedes vno8
+//	}
+//	keyblock             { uint16 enctype; counted_octet_string key }
+//	counted_octet_string { uint16 length; uint8 data[length] }
+//
+// Version 2 is big-endian throughout (version 1 used host byte order and folded
+// the realm into num_components; only version 2 is emitted today and is what this
+// package writes). This package implements the wire format and entry selection;
+// wiring a selected key into a live client is done by the kerberos client layer.
+package keytab
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"strings"
+
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/iana"
+)
+
+// Version2 is the file_format_version this package reads and writes: the first
+// byte is always 0x05, the second is the version (2).
+const Version2 = 0x0502
+
+// Principal identifies the account a key belongs to: one or more name
+// components, a realm, and the RFC 4120 name-type.
+type Principal struct {
+	NameType   uint32
+	Realm      string
+	Components []string
+}
+
+// String renders the principal in the conventional "comp1/comp2@REALM" form.
+func (p Principal) String() string {
+	return strings.Join(p.Components, "/") + "@" + p.Realm
+}
+
+// Entry is a single keytab record: one long-term key for one principal.
+type Entry struct {
+	Principal Principal
+	// Timestamp is when the entry was written, in Unix seconds (0 if unknown).
+	Timestamp uint32
+	// KVNO8 is the 8-bit key version number always present on the wire.
+	KVNO8 uint8
+	// KVNO is the optional 32-bit key version number. When non-zero it is written
+	// after the key and supersedes KVNO8 (kvnos above 255 need it). Zero means the
+	// 32-bit field is absent and KVNO8 is authoritative.
+	KVNO uint32
+	// EType is the key's encryption type (see iana.EType*).
+	EType uint16
+	// Key is the raw long-term key bytes.
+	Key []byte
+}
+
+// Kvno returns the effective key version number: the 32-bit KVNO when non-zero,
+// otherwise the 8-bit KVNO8.
+func (e Entry) Kvno() uint32 {
+	if e.KVNO != 0 {
+		return e.KVNO
+	}
+	return uint32(e.KVNO8)
+}
+
+// Keytab is a parsed keytab: an ordered list of key entries.
+type Keytab struct {
+	Entries []Entry
+}
+
+// New returns an empty keytab.
+func New() *Keytab { return &Keytab{} }
+
+// Add appends an entry binding a key to a principal. The 8-bit KVNO8 is set from
+// kvno (its low byte) and, when kvno exceeds 255, the 32-bit KVNO too. NameType
+// defaults to NT-PRINCIPAL when zero. The key bytes are copied.
+func (kt *Keytab) Add(principal Principal, etype int, key []byte, kvno uint32) {
+	if principal.NameType == 0 {
+		principal.NameType = iana.NameTypePrincipal
+	}
+	k := make([]byte, len(key))
+	copy(k, key)
+	e := Entry{
+		Principal: principal,
+		KVNO8:     uint8(kvno),
+		EType:     uint16(etype),
+		Key:       k,
+	}
+	if kvno > 0xff {
+		e.KVNO = kvno
+	}
+	kt.Entries = append(kt.Entries, e)
+}
+
+// ── selection ─────────────────────────────────────────────────────────────
+
+// etypeStrength orders enctypes strongest-first for "best entry" selection.
+func etypeStrength(etype uint16) int {
+	switch int(etype) {
+	case iana.ETypeAES256CTSHMACSHA196:
+		return 5
+	case iana.ETypeAES256CTSHMACSHA384:
+		return 4
+	case iana.ETypeAES128CTSHMACSHA196:
+		return 3
+	case iana.ETypeAES128CTSHMACSHA256:
+		return 2
+	case iana.ETypeRC4HMAC:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// principalMatches reports whether entry principal p matches the query string,
+// case-insensitively on the realm. The query is "comp1/comp2@REALM"; a missing
+// "@REALM" matches any realm, and an empty query matches anything.
+func principalMatches(p Principal, query string) bool {
+	if query == "" {
+		return true
+	}
+	name := query
+	realm := ""
+	if at := strings.LastIndexByte(query, '@'); at >= 0 {
+		name = query[:at]
+		realm = query[at+1:]
+	}
+	if realm != "" && !strings.EqualFold(realm, p.Realm) {
+		return false
+	}
+	return name == strings.Join(p.Components, "/")
+}
+
+// Find returns pointers to every entry matching the filter, in file order.
+// A principal of "" matches any principal; etype <= 0 matches any enctype; and
+// kvno < 0 matches any key version.
+func (kt *Keytab) Find(principal string, etype int, kvno int) []*Entry {
+	var out []*Entry
+	for i := range kt.Entries {
+		e := &kt.Entries[i]
+		if !principalMatches(e.Principal, principal) {
+			continue
+		}
+		if etype > 0 && int(e.EType) != etype {
+			continue
+		}
+		if kvno >= 0 && int(e.Kvno()) != kvno {
+			continue
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
+// Select returns the single best entry matching the filter, or nil when none
+// match. "Best" is the highest key version number, breaking ties by enctype
+// strength (AES256 > AES256-SHA2 > AES128 > AES128-SHA2 > RC4 > other). Pass
+// principal "" for any principal, etype <= 0 for any enctype, and kvno < 0 to
+// select the newest key rather than a specific version.
+func (kt *Keytab) Select(principal string, etype int, kvno int) *Entry {
+	var best *Entry
+	for _, e := range kt.Find(principal, etype, kvno) {
+		if best == nil {
+			best = e
+			continue
+		}
+		if e.Kvno() > best.Kvno() ||
+			(e.Kvno() == best.Kvno() && etypeStrength(e.EType) > etypeStrength(best.EType)) {
+			best = e
+		}
+	}
+	return best
+}
+
+// ── marshaling ──────────────────────────────────────────────────────────────
+
+func putOctetString(buf *bytes.Buffer, data []byte) {
+	var l [2]byte
+	binary.BigEndian.PutUint16(l[:], uint16(len(data)))
+	buf.Write(l[:])
+	buf.Write(data)
+}
+
+func putU16(buf *bytes.Buffer, v uint16) {
+	var b [2]byte
+	binary.BigEndian.PutUint16(b[:], v)
+	buf.Write(b[:])
+}
+
+func putU32(buf *bytes.Buffer, v uint32) {
+	var b [4]byte
+	binary.BigEndian.PutUint32(b[:], v)
+	buf.Write(b[:])
+}
+
+// marshalEntryBody encodes everything that the entry's size prefix counts: the
+// principal, timestamp, vno8, keyblock and optional 32-bit kvno.
+func marshalEntryBody(e Entry) []byte {
+	var b bytes.Buffer
+	// v2 num_components excludes the realm.
+	putU16(&b, uint16(len(e.Principal.Components)))
+	putOctetString(&b, []byte(e.Principal.Realm))
+	for _, c := range e.Principal.Components {
+		putOctetString(&b, []byte(c))
+	}
+	nt := e.Principal.NameType
+	if nt == 0 {
+		nt = iana.NameTypePrincipal
+	}
+	putU32(&b, nt)
+	putU32(&b, e.Timestamp)
+	b.WriteByte(e.KVNO8)
+	// keyblock: enctype + counted key.
+	putU16(&b, e.EType)
+	putOctetString(&b, e.Key)
+	// Optional 32-bit kvno, written only when set (supersedes vno8).
+	if e.KVNO != 0 {
+		putU32(&b, e.KVNO)
+	}
+	return b.Bytes()
+}
+
+// Marshal encodes the keytab in versioned format 2 (0x0502, big-endian).
+func (kt *Keytab) Marshal() ([]byte, error) {
+	var buf bytes.Buffer
+	putU16(&buf, Version2)
+	for i := range kt.Entries {
+		body := marshalEntryBody(kt.Entries[i])
+		// The size prefix counts the bytes that follow it (the whole entry body),
+		// not itself. It is written signed; a positive value is a valid entry.
+		putU32(&buf, uint32(int32(len(body))))
+		buf.Write(body)
+	}
+	return buf.Bytes(), nil
+}
+
+// ── unmarshaling ────────────────────────────────────────────────────────────
+
+// reader is a bounds-checked big-endian cursor over the keytab bytes.
+type reader struct {
+	b   []byte
+	pos int
+}
+
+func (r *reader) need(n int) error {
+	if n < 0 || r.pos+n > len(r.b) {
+		return fmt.Errorf("keytab: truncated: need %d bytes at offset %d of %d", n, r.pos, len(r.b))
+	}
+	return nil
+}
+
+func (r *reader) u16() (uint16, error) {
+	if err := r.need(2); err != nil {
+		return 0, err
+	}
+	v := binary.BigEndian.Uint16(r.b[r.pos:])
+	r.pos += 2
+	return v, nil
+}
+
+func (r *reader) i32() (int32, error) {
+	if err := r.need(4); err != nil {
+		return 0, err
+	}
+	v := int32(binary.BigEndian.Uint32(r.b[r.pos:]))
+	r.pos += 4
+	return v, nil
+}
+
+// octetString reads a 16-bit-length-prefixed byte string.
+func (r *reader) octetString() ([]byte, error) {
+	n, err := r.u16()
+	if err != nil {
+		return nil, err
+	}
+	if err := r.need(int(n)); err != nil {
+		return nil, err
+	}
+	out := make([]byte, n)
+	copy(out, r.b[r.pos:r.pos+int(n)])
+	r.pos += int(n)
+	return out, nil
+}
+
+// parseEntryBody decodes one entry from exactly body (the size-prefixed slice).
+func parseEntryBody(body []byte) (Entry, error) {
+	var e Entry
+	r := &reader{b: body}
+
+	nComp, err := r.u16()
+	if err != nil {
+		return e, err
+	}
+	realm, err := r.octetString()
+	if err != nil {
+		return e, err
+	}
+	e.Principal.Realm = string(realm)
+	for i := uint16(0); i < nComp; i++ {
+		c, err := r.octetString()
+		if err != nil {
+			return e, err
+		}
+		e.Principal.Components = append(e.Principal.Components, string(c))
+	}
+	nt, err := r.i32()
+	if err != nil {
+		return e, err
+	}
+	e.Principal.NameType = uint32(nt)
+	ts, err := r.i32()
+	if err != nil {
+		return e, err
+	}
+	e.Timestamp = uint32(ts)
+	if err := r.need(1); err != nil {
+		return e, err
+	}
+	e.KVNO8 = r.b[r.pos]
+	r.pos++
+	if e.EType, err = r.u16(); err != nil {
+		return e, err
+	}
+	if e.Key, err = r.octetString(); err != nil {
+		return e, err
+	}
+	// Optional 32-bit kvno: present only if >= 4 bytes remain and it is non-zero.
+	if len(body)-r.pos >= 4 {
+		v, err := r.i32()
+		if err != nil {
+			return e, err
+		}
+		if v != 0 {
+			e.KVNO = uint32(v)
+		}
+	}
+	return e, nil
+}
+
+// Unmarshal parses a keytab. Only versioned format 2 (0x0502) is supported.
+func Unmarshal(data []byte) (*Keytab, error) {
+	r := &reader{b: data}
+	ver, err := r.u16()
+	if err != nil {
+		return nil, err
+	}
+	if ver != Version2 {
+		return nil, fmt.Errorf("keytab: unsupported version 0x%04x (only 0x%04x supported)", ver, Version2)
+	}
+
+	kt := &Keytab{}
+	for r.pos < len(data) {
+		size, err := r.i32()
+		if err != nil {
+			return nil, err
+		}
+		// A length of 0 ends the file; a negative length is a hole (deleted
+		// entry) whose magnitude is the number of bytes to skip.
+		if size == 0 {
+			break
+		}
+		if size < 0 {
+			skip := int(-int64(size))
+			if err := r.need(skip); err != nil {
+				return nil, err
+			}
+			r.pos += skip
+			continue
+		}
+		if err := r.need(int(size)); err != nil {
+			return nil, err
+		}
+		body := r.b[r.pos : r.pos+int(size)]
+		r.pos += int(size)
+		e, err := parseEntryBody(body)
+		if err != nil {
+			return nil, err
+		}
+		kt.Entries = append(kt.Entries, e)
+	}
+	return kt, nil
+}

--- a/network/kerberos/v5/credcache/keytab/keytab_test.go
+++ b/network/kerberos/v5/credcache/keytab/keytab_test.go
@@ -1,0 +1,201 @@
+package keytab
+
+import (
+	"bytes"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/iana"
+)
+
+func sampleKeytab() *Keytab {
+	kt := New()
+	admin := Principal{NameType: iana.NameTypePrincipal, Realm: "CORP.LOCAL", Components: []string{"Administrator"}}
+	// AES256, AES128 and RC4 keys for the same principal at kvno 3.
+	kt.Add(admin, iana.ETypeAES256CTSHMACSHA196, bytes.Repeat([]byte{0xAB}, 32), 3)
+	kt.Add(admin, iana.ETypeAES128CTSHMACSHA196, bytes.Repeat([]byte{0xCD}, 16), 3)
+	kt.Add(admin, iana.ETypeRC4HMAC, bytes.Repeat([]byte{0xEF}, 16), 3)
+	// A service principal with two components and a large kvno forcing the
+	// 32-bit vno trailer.
+	svc := Principal{NameType: iana.NameTypeSRVInst, Realm: "CORP.LOCAL", Components: []string{"HTTP", "web.corp.local"}}
+	kt.Add(svc, iana.ETypeAES256CTSHMACSHA196, bytes.Repeat([]byte{0x11}, 32), 300)
+	return kt
+}
+
+func TestKeytabRoundtrip(t *testing.T) {
+	orig := sampleKeytab()
+	b, err := orig.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	got, err := Unmarshal(b)
+	if err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if !reflect.DeepEqual(orig, got) {
+		t.Fatalf("round-trip mismatch:\n orig=%+v\n got =%+v", orig, got)
+	}
+	// Marshaling the parsed keytab must reproduce the identical bytes.
+	b2, err := got.Marshal()
+	if err != nil {
+		t.Fatalf("re-Marshal: %v", err)
+	}
+	if !bytes.Equal(b, b2) {
+		t.Fatalf("re-marshaled bytes differ from original")
+	}
+}
+
+func TestKeytabKvnoTrailer(t *testing.T) {
+	kt := sampleKeytab()
+	b, _ := kt.Marshal()
+	got, err := Unmarshal(b)
+	if err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	// The kvno-300 entry must carry the 32-bit vno and report it via Kvno().
+	e := got.Select("HTTP/web.corp.local@CORP.LOCAL", 0, -1)
+	if e == nil {
+		t.Fatal("service entry not found")
+	}
+	if e.KVNO != 300 {
+		t.Fatalf("expected 32-bit KVNO 300, got %d", e.KVNO)
+	}
+	if e.Kvno() != 300 {
+		t.Fatalf("Kvno() = %d, want 300", e.Kvno())
+	}
+	// A small kvno stays in the 8-bit field only.
+	admin := got.Select("Administrator@CORP.LOCAL", iana.ETypeRC4HMAC, -1)
+	if admin == nil || admin.KVNO != 0 || admin.KVNO8 != 3 || admin.Kvno() != 3 {
+		t.Fatalf("admin kvno fields wrong: %+v", admin)
+	}
+}
+
+func TestKeytabSelect(t *testing.T) {
+	kt := sampleKeytab()
+
+	// No etype filter -> strongest (AES256) wins for the Administrator.
+	best := kt.Select("Administrator@CORP.LOCAL", 0, -1)
+	if best == nil || int(best.EType) != iana.ETypeAES256CTSHMACSHA196 {
+		t.Fatalf("expected AES256 as strongest, got %+v", best)
+	}
+	// Explicit etype filter selects that etype.
+	rc4 := kt.Select("Administrator@CORP.LOCAL", iana.ETypeRC4HMAC, -1)
+	if rc4 == nil || int(rc4.EType) != iana.ETypeRC4HMAC {
+		t.Fatalf("expected RC4, got %+v", rc4)
+	}
+	// Realm-less query matches, case-insensitively on realm.
+	if kt.Select("Administrator", 0, -1) == nil {
+		t.Fatal("realm-less query should match")
+	}
+	if kt.Select("Administrator@corp.local", iana.ETypeAES128CTSHMACSHA196, -1) == nil {
+		t.Fatal("case-insensitive realm match failed")
+	}
+	// Find with etype+kvno filters.
+	if hits := kt.Find("Administrator@CORP.LOCAL", 0, 3); len(hits) != 3 {
+		t.Fatalf("expected 3 entries at kvno 3, got %d", len(hits))
+	}
+	// Unknown principal / etype -> no match.
+	if kt.Select("nobody@CORP.LOCAL", 0, -1) != nil {
+		t.Fatal("unexpected match for unknown principal")
+	}
+	if kt.Select("Administrator@CORP.LOCAL", iana.ETypeDES3CBCSHA1KD, -1) != nil {
+		t.Fatal("unexpected match for absent etype")
+	}
+}
+
+// TestKeytabKnownVector parses a hand-assembled versioned-format-2 keytab and
+// verifies each decoded field, then confirms Marshal reproduces the exact bytes.
+func TestKeytabKnownVector(t *testing.T) {
+	vec := []byte{
+		0x05, 0x02, // file_format_version 0x0502
+		0x00, 0x00, 0x00, 0x19, // entry size = 25 bytes
+		0x00, 0x01, // num_components = 1
+		0x00, 0x01, 0x52, // realm "R"
+		0x00, 0x01, 0x4E, // component "N"
+		0x00, 0x00, 0x00, 0x01, // name_type = NT-PRINCIPAL
+		0x00, 0x00, 0x00, 0x00, // timestamp = 0
+		0x02,       // vno8 = 2
+		0x00, 0x17, // enctype = 23 (RC4-HMAC)
+		0x00, 0x04, 0xDE, 0xAD, 0xBE, 0xEF, // key (4 bytes)
+	}
+
+	kt, err := Unmarshal(vec)
+	if err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if len(kt.Entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(kt.Entries))
+	}
+	e := kt.Entries[0]
+	if e.Principal.Realm != "R" ||
+		!reflect.DeepEqual(e.Principal.Components, []string{"N"}) ||
+		e.Principal.NameType != iana.NameTypePrincipal {
+		t.Fatalf("principal wrong: %+v", e.Principal)
+	}
+	if e.Timestamp != 0 || e.KVNO8 != 2 || e.KVNO != 0 || e.Kvno() != 2 {
+		t.Fatalf("version/time fields wrong: %+v", e)
+	}
+	if int(e.EType) != iana.ETypeRC4HMAC || !bytes.Equal(e.Key, []byte{0xDE, 0xAD, 0xBE, 0xEF}) {
+		t.Fatalf("key fields wrong: %+v", e)
+	}
+
+	out, err := kt.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if !bytes.Equal(out, vec) {
+		t.Fatalf("Marshal did not reproduce known vector:\n got=% x\n want=% x", out, vec)
+	}
+}
+
+// TestKeytabHole verifies that a negative record length (a deleted entry / hole)
+// is skipped and the following entry is still parsed.
+func TestKeytabHole(t *testing.T) {
+	kt := New()
+	kt.Add(Principal{Realm: "R", Components: []string{"N"}}, iana.ETypeRC4HMAC, []byte{1, 2, 3, 4}, 1)
+	b, _ := kt.Marshal()
+
+	// Splice a 4-byte hole (size = -4) right after the version tag, before the
+	// real entry.
+	hole := []byte{0xFF, 0xFF, 0xFF, 0xFC, 0xAA, 0xAA, 0xAA, 0xAA} // -4 then 4 junk bytes
+	withHole := append([]byte{}, b[:2]...)
+	withHole = append(withHole, hole...)
+	withHole = append(withHole, b[2:]...)
+
+	got, err := Unmarshal(withHole)
+	if err != nil {
+		t.Fatalf("Unmarshal with hole: %v", err)
+	}
+	if len(got.Entries) != 1 || got.Entries[0].Principal.Realm != "R" {
+		t.Fatalf("hole not skipped correctly: %+v", got.Entries)
+	}
+}
+
+func TestKeytabSaveLoad(t *testing.T) {
+	kt := sampleKeytab()
+	path := filepath.Join(t.TempDir(), "test.keytab")
+	if err := kt.Save(path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !reflect.DeepEqual(kt, got) {
+		t.Fatalf("save/load mismatch")
+	}
+}
+
+func TestKeytabUnmarshalErrors(t *testing.T) {
+	if _, err := Unmarshal([]byte{0x05, 0x01}); err == nil {
+		t.Fatal("expected error on version 1")
+	}
+	if _, err := Unmarshal([]byte{0x05}); err == nil {
+		t.Fatal("expected error on truncated version")
+	}
+	// Size claims more bytes than remain.
+	if _, err := Unmarshal([]byte{0x05, 0x02, 0x00, 0x00, 0x00, 0x40, 0x01}); err == nil {
+		t.Fatal("expected truncation error")
+	}
+}

--- a/network/kerberos/v5/keytab.go
+++ b/network/kerberos/v5/keytab.go
@@ -1,0 +1,93 @@
+package kerberos
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/credcache/keytab"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/credentials"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/iana"
+)
+
+// Keytab authentication (pass-the-key from a .keytab)
+//
+// A keytab stores an account's long-term keys, so it lets a client authenticate
+// non-interactively — no password. These methods select a key from a keytab and
+// wire it into the client as an AES pass-the-key (etype 17/18) or, for RC4, an
+// overpass-the-hash NT-hash credential, exactly as WithAESKey / WithNTHash would.
+// GetTGT / GetTGS then run unchanged.
+
+// credentialFromKeytabEntry converts a selected keytab entry into a long-term
+// credential for username@realm. AES128/AES256 keys become pass-the-key
+// credentials; the RC4-HMAC key is the NT hash, so it becomes an
+// overpass-the-hash credential. Other enctypes (DES, AES-SHA2) are not supported
+// by the credentials layer.
+func credentialFromKeytabEntry(e *keytab.Entry, username, realm string) (*credentials.Credential, error) {
+	switch int(e.EType) {
+	case iana.ETypeAES128CTSHMACSHA196, iana.ETypeAES256CTSHMACSHA196:
+		return credentials.NewWithAESKey(username, realm, int(e.EType), e.Key)
+	case iana.ETypeRC4HMAC:
+		return credentials.NewWithNTHash(username, realm, e.Key)
+	default:
+		return nil, fmt.Errorf("kerberos: keytab enctype %d is not usable for authentication (need AES128/AES256/RC4)", e.EType)
+	}
+}
+
+// WithKeytab selects a long-term key from a parsed keytab and configures it as
+// the client's credential (pass-the-key), so GetTGT needs no password.
+//
+// The entry is chosen for the client's own principal (username@realm); the
+// strongest usable enctype present is preferred (AES256 > AES128 > RC4). When the
+// client was created with an empty username (NewClient("", realm, kdc)), the
+// principal of the selected entry populates the client's username. Pass etype > 0
+// to force a specific enctype instead of the strongest.
+func (c *KerberosClient) WithKeytab(kt *keytab.Keytab, etype int) error {
+	principal := ""
+	if c.username != "" {
+		principal = c.username + "@" + c.realm
+	}
+	entry := kt.Select(principal, etype, -1)
+	if entry == nil {
+		return fmt.Errorf("kerberos: no keytab entry for %q (etype %d)", principal, etype)
+	}
+
+	username := c.username
+	realm := c.realm
+	if username == "" {
+		username = entry.Principal.String()
+		if len(entry.Principal.Components) > 0 {
+			username = entry.Principal.Components[0]
+		}
+		if realm == "" {
+			realm = entry.Principal.Realm
+		}
+	}
+
+	cred, err := credentialFromKeytabEntry(entry, username, realm)
+	if err != nil {
+		return err
+	}
+	c.username = username
+	c.realm = cred.Realm()
+	c.cred = cred
+	return nil
+}
+
+// WithKeytabBytes parses keytab bytes and configures the client's credential
+// from them via WithKeytab (strongest usable enctype, etype 0).
+func (c *KerberosClient) WithKeytabBytes(data []byte) error {
+	kt, err := keytab.Unmarshal(data)
+	if err != nil {
+		return err
+	}
+	return c.WithKeytab(kt, 0)
+}
+
+// WithKeytabFile reads a .keytab file and configures the client's credential
+// from it (strongest usable enctype).
+func (c *KerberosClient) WithKeytabFile(path string) error {
+	kt, err := keytab.Load(path)
+	if err != nil {
+		return err
+	}
+	return c.WithKeytab(kt, 0)
+}


### PR DESCRIPTION
### Linked Issue
`Closes #919`

### Enhancement
Adds native (pure Go stdlib) read/write support for the MIT/Heimdal Kerberos keytab file and the ability to authenticate a client directly from a keytab.

### What was added
- **`network/kerberos/v5/credcache/keytab`** — a new credcache package (mirroring the `ccache`/`kirbi` structure) implementing the versioned keytab format 2 (magic `0x05 0x02`, big-endian):
  - `Marshal`/`Unmarshal` (bytes) and `Save`/`Load` (file), mode 0600.
  - Per-entry principal (components + realm + `name_type`), timestamp, 8-bit `vno8` and the **optional 32-bit kvno trailer** (present only when at least 4 bytes remain in the record and it is non-zero; supersedes `vno8`).
  - Signed record-length prefix with **negative-length holes** (deleted entries) skipped on read.
  - Entry selection: `Find`/`Select` by principal (case-insensitive realm), enctype, and kvno, with strongest-enctype tie-breaking.
- **`network/kerberos/v5/keytab.go`** — client integration: `WithKeytab`, `WithKeytabBytes`, `WithKeytabFile`. AES128/AES256 entries feed the credentials layer as pass-the-key; the RC4-HMAC entry feeds it as overpass-the-hash (the key *is* the NT hash). `GetTGT`/`GetTGS` then run unchanged with no password.

### How Verified
- **Unit tests** (`keytab_test.go`): round-trip of multiple entries across AES256/AES128/RC4 and small/large kvno (32-bit trailer), a hand-assembled known byte vector checked field-by-field and reproduced by `Marshal`, negative-length hole skipping, save/load, selection filters, and error cases. `go build ./...`, `go vet`, and `go test ./network/kerberos/...` all pass.
- **Live against a Windows Server 2016 DC**: derived `Administrator`'s AES256/AES128/RC4 long-term keys, wrote a keytab, then loaded it into a fresh client and obtained a TGT and a service ticket (`cifs/...`) using **only the keytab** (no password) — including a forced RC4-only path.
- **Cross-tool**: MIT `klist -k` reads the written keytab (all three entries, correct principal/enctype/kvno), and our reader parses a keytab produced independently by MIT `ktutil`.

### Test Coverage
- **Added:** `TestKeytabRoundtrip`, `TestKeytabKvnoTrailer`, `TestKeytabSelect`, `TestKeytabKnownVector`, `TestKeytabHole`, `TestKeytabSaveLoad`, `TestKeytabUnmarshalErrors`.

### Scope of Change
- **Files changed:** `network/kerberos/v5/credcache/keytab/{keytab.go,io.go,keytab_test.go}`, `network/kerberos/v5/keytab.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the enhancement:** none