### PR TITLE
Add Kerberos TGT renewal and validation (Fixes #920)

### DIFF
--- a/network/kerberos/v5/client.go
+++ b/network/kerberos/v5/client.go
@@ -583,6 +583,8 @@ const (
 	kdcOptionCNameInAddlTkt = 14 // byte 1, 0x02 (MS-SFU S4U2Proxy)
 	kdcOptionRenewableOK    = 27 // byte 3, 0x10
 	kdcOptionEncTktInSKey   = 28 // byte 3, 0x08 (user-to-user)
+	kdcOptionRenew          = 30 // byte 3, 0x02 (RFC 4120 §3.3.3 renewal)
+	kdcOptionValidate       = 31 // byte 3, 0x01 (RFC 4120 §3.3.3 validation)
 )
 
 // encodeKDCOptions packs a list of bit positions into a 32-bit BitString

--- a/network/kerberos/v5/renew.go
+++ b/network/kerberos/v5/renew.go
@@ -1,0 +1,159 @@
+package kerberos
+
+import (
+	"fmt"
+	"time"
+
+	kerbcrypto "github.com/TheManticoreProject/Manticore/network/kerberos/v5/crypto"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/messages"
+)
+
+// buildRenewalTGSReq constructs the TGS-REQ for a ticket RENEW or VALIDATE
+// exchange (RFC 4120 §3.3.3). Both are ordinary ticket-granting-service requests
+// that present the client's existing TGT via a PA-TGS-REQ AP-REQ, target the
+// ticket-granting service (krbtgt/REALM), and set exactly one distinguishing KDC
+// option — renew (bit 30) or validate (bit 31) — alongside the renewable flag so
+// the reissued ticket keeps its renewable window. The ticket to be renewed or
+// validated is the one carried in the AP-REQ (padata), not additional-tickets.
+//
+// It is factored out of Renew/Validate so the request shape can be verified
+// without a live KDC (see renew_test.go).
+func (c *KerberosClient) buildRenewalTGSReq(option, nonce int) (*messages.TGSReq, error) {
+	apReqBytes, err := c.buildAPReq()
+	if err != nil {
+		return nil, fmt.Errorf("kerberos: build AP-REQ: %w", err)
+	}
+
+	// The renewed/validated ticket is a TGT, so the requested server is the
+	// ticket-granting service of the client's own realm.
+	sname := messages.PrincipalName{
+		NameType:   messages.NameTypeSRVInst,
+		NameString: []string{"krbtgt", c.realm},
+	}
+
+	// Request an endtime as far out as the renewable window allows. RFC 4120
+	// §3.3.3: the KDC caps the new endtime at the ticket's renew-till (and its
+	// original lifetime), so asking for renew-till yields the maximal fresh
+	// endtime without over-reaching. Fall back to a 24h window when the stored
+	// TGT carries no renew-till (e.g. a validation of a non-renewable ticket).
+	till := c.now().Add(24 * time.Hour)
+	if option == kdcOptionRenew && !c.tgtEnc.RenewTill.IsZero() {
+		till = c.tgtEnc.RenewTill
+	}
+
+	return &messages.TGSReq{
+		PVNO:    messages.KerberosV5,
+		MsgType: messages.MsgTypeTGSReq,
+		PAData: []messages.PAData{
+			{PADataType: messages.PATGSReq, PADataValue: apReqBytes},
+		},
+		ReqBody: messages.KDCReqBody{
+			KDCOptions: encodeKDCOptions(kdcOptionRenewable, option),
+			Realm:      c.realm,
+			SName:      sname,
+			Till:       till,
+			Nonce:      nonce,
+			EType:      c.serviceTicketETypes(),
+		},
+	}, nil
+}
+
+// Renew refreshes the client's renewable Ticket Granting Ticket without
+// re-authenticating. It sends a TGS-REQ with the renew KDC option, presenting the
+// current TGT in a PA-TGS-REQ AP-REQ (RFC 4120 §3.3.3). The KDC returns a fresh
+// TGT with a new session key and advanced start/end times (capped at the
+// ticket's renew-till), which replaces the client's stored TGT and session key on
+// success. GetTGT must have succeeded first, and the current TGT must be
+// renewable and not past its renew-till, or the KDC rejects the request.
+func (c *KerberosClient) Renew() error {
+	return c.renewOrValidate(kdcOptionRenew, "renew")
+}
+
+// Validate turns a postdated (INVALID-flagged) TGT into a usable one once its
+// start time has passed. It sends a TGS-REQ with the validate KDC option,
+// presenting the ticket in a PA-TGS-REQ AP-REQ (RFC 4120 §3.3.3); the KDC clears
+// the INVALID flag and returns a fresh ticket, which replaces the client's stored
+// TGT and session key on success. GetTGT must have succeeded first. Many KDCs
+// (including default Active Directory policy) disable postdating, in which case
+// the KDC rejects the request.
+func (c *KerberosClient) Validate() error {
+	return c.renewOrValidate(kdcOptionValidate, "validate")
+}
+
+// renewOrValidate performs the RENEW/VALIDATE TGS exchange and, on success,
+// installs the reissued TGT (ticket, raw bytes, session key and enc-part) on the
+// client. A single KRB_AP_ERR_SKEW reply triggers a clock realignment and one
+// retry (RFC 4120 §5.9.1), mirroring the other exchanges.
+func (c *KerberosClient) renewOrValidate(option int, label string) error {
+	if !c.hasTGT {
+		return fmt.Errorf("kerberos: no TGT: call GetTGT first")
+	}
+
+	for attempt := 0; attempt < 2; attempt++ {
+		nonce := randomNonce()
+		req, err := c.buildRenewalTGSReq(option, nonce)
+		if err != nil {
+			return err
+		}
+		reqBytes, err := req.Marshal()
+		if err != nil {
+			return fmt.Errorf("kerberos: marshal %s TGS-REQ: %w", label, err)
+		}
+		resp, err := c.sendToRealm(c.realm, reqBytes)
+		if err != nil {
+			return err
+		}
+
+		var krbErr messages.KRBError
+		if _, parseErr := krbErr.Unmarshal(resp); parseErr == nil {
+			if krbErr.ErrorCode == messages.ErrSkew && attempt == 0 && c.applyClockSkew(krbErr) {
+				continue // realign to the KDC clock and retry once
+			}
+			return fmt.Errorf("kerberos: %s error %d: %s", label, krbErr.ErrorCode, krbErr.EText)
+		}
+
+		var tgsRep messages.TGSRep
+		if _, err := tgsRep.Unmarshal(resp); err != nil {
+			return fmt.Errorf("kerberos: parse %s TGS-REP: %w", label, err)
+		}
+
+		// The reply enc-part is sealed under the presented TGT's session key.
+		encPlain, err := kerbcrypto.Decrypt(c.sessionEType, c.sessionKey, kerbcrypto.KeyUsageTGSRepEncSessionKey, tgsRep.EncPart.Cipher)
+		if err != nil {
+			return fmt.Errorf("kerberos: decrypt %s TGS-REP enc-part: %w", label, err)
+		}
+		var encRep messages.EncTGSRepPart
+		if _, err := encRep.Unmarshal(encPlain); err != nil {
+			return fmt.Errorf("kerberos: parse %s EncTGSRepPart: %w", label, err)
+		}
+		if encRep.Nonce != nonce {
+			return fmt.Errorf("kerberos: %s nonce mismatch: got %d, want %d", label, encRep.Nonce, nonce)
+		}
+
+		c.storeReissuedTGT(&tgsRep, &encRep)
+		return nil
+	}
+	return fmt.Errorf("kerberos: %s: clock-skew retry exhausted", label)
+}
+
+// storeReissuedTGT replaces the client's cached TGT with the ticket returned by a
+// RENEW/VALIDATE exchange: the new ticket and its raw bytes, the new session key
+// and etype, and the refreshed ticket times/flags. Subsequent GetTGS calls then
+// use the reissued TGT.
+func (c *KerberosClient) storeReissuedTGT(rep *messages.TGSRep, enc *messages.EncTGSRepPart) {
+	c.tgtTicket = rep.Ticket
+	c.tgtTicketRaw = rep.TicketRaw
+	c.sessionKey = enc.Key.KeyValue
+	c.sessionEType = enc.Key.KeyType
+	c.tgtEnc = messages.EncASRepPart{
+		Key:       enc.Key,
+		Nonce:     enc.Nonce,
+		Flags:     enc.Flags,
+		AuthTime:  enc.AuthTime,
+		StartTime: enc.StartTime,
+		EndTime:   enc.EndTime,
+		RenewTill: enc.RenewTill,
+		SRealm:    enc.SRealm,
+		SName:     enc.SName,
+	}
+}

--- a/network/kerberos/v5/renew_test.go
+++ b/network/kerberos/v5/renew_test.go
@@ -1,0 +1,151 @@
+package kerberos
+
+import (
+	"bytes"
+	"encoding/asn1"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/messages"
+)
+
+// renewReqBody parses a marshaled TGS-REQ down to its [4] KDC-REQ-BODY.
+func renewReqBody(t *testing.T, wire []byte) asn1.RawValue {
+	t.Helper()
+	var app asn1.RawValue
+	if _, err := asn1.Unmarshal(wire, &app); err != nil {
+		t.Fatal(err)
+	}
+	if app.Class != asn1.ClassApplication || app.Tag != messages.MsgTypeTGSReq {
+		t.Fatalf("outer tag: class=%d tag=%d", app.Class, app.Tag)
+	}
+	return seqChild(t, app.Bytes, asn1.ClassContextSpecific, 4)
+}
+
+// TestRenewRequestShape verifies a RENEW TGS-REQ sets the renew option (bit 30)
+// plus renewable (bit 8), targets krbtgt/REALM, and presents the client's TGT via
+// a PA-TGS-REQ AP-REQ (RFC 4120 §3.3.3).
+func TestRenewRequestShape(t *testing.T) {
+	c := fakeTGTClient(t)
+
+	req, err := c.buildRenewalTGSReq(kdcOptionRenew, 7777)
+	if err != nil {
+		t.Fatalf("buildRenewalTGSReq: %v", err)
+	}
+	wire, err := req.Marshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	body := renewReqBody(t, wire)
+
+	// KDCOptions [0]: renew (bit 30) and renewable (bit 8) set; validate (bit 31)
+	// and enc-tkt-in-skey (bit 28) clear.
+	optElem := seqChild(t, body.Bytes, asn1.ClassContextSpecific, 0)
+	var flags asn1.BitString
+	if _, err := asn1.Unmarshal(optElem.Bytes, &flags); err != nil {
+		t.Fatalf("parse KDCOptions: %v", err)
+	}
+	if flags.At(kdcOptionRenew) != 1 {
+		t.Errorf("renew (bit 30) not set; bytes=% X", flags.Bytes)
+	}
+	if flags.At(kdcOptionRenewable) != 1 {
+		t.Errorf("renewable (bit 8) not set; bytes=% X", flags.Bytes)
+	}
+	if flags.At(kdcOptionValidate) != 0 {
+		t.Errorf("validate (bit 31) unexpectedly set")
+	}
+	if flags.At(kdcOptionEncTktInSKey) != 0 {
+		t.Errorf("enc-tkt-in-skey (bit 28) unexpectedly set")
+	}
+
+	// SName [3] must be krbtgt/REALM.
+	assertKrbtgtSName(t, body, c.realm)
+
+	// PA-DATA must carry a single PA-TGS-REQ presenting the client's TGT.
+	assertPATGSPresentsTGT(t, wire, c.tgtTicketRaw)
+}
+
+// TestValidateRequestShape verifies a VALIDATE TGS-REQ sets the validate option
+// (bit 31) rather than renew, and otherwise matches the renewal shape.
+func TestValidateRequestShape(t *testing.T) {
+	c := fakeTGTClient(t)
+
+	req, err := c.buildRenewalTGSReq(kdcOptionValidate, 8888)
+	if err != nil {
+		t.Fatalf("buildRenewalTGSReq: %v", err)
+	}
+	wire, err := req.Marshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	body := renewReqBody(t, wire)
+
+	optElem := seqChild(t, body.Bytes, asn1.ClassContextSpecific, 0)
+	var flags asn1.BitString
+	if _, err := asn1.Unmarshal(optElem.Bytes, &flags); err != nil {
+		t.Fatalf("parse KDCOptions: %v", err)
+	}
+	if flags.At(kdcOptionValidate) != 1 {
+		t.Errorf("validate (bit 31) not set; bytes=% X", flags.Bytes)
+	}
+	if flags.At(kdcOptionRenew) != 0 {
+		t.Errorf("renew (bit 30) unexpectedly set")
+	}
+
+	assertKrbtgtSName(t, body, c.realm)
+	assertPATGSPresentsTGT(t, wire, c.tgtTicketRaw)
+}
+
+// TestRenewValidateRequireTGT verifies both operations refuse to run without a
+// TGT.
+func TestRenewValidateRequireTGT(t *testing.T) {
+	c := NewClient("svc", "corp.local", "10.0.0.1").WithPassword("x")
+	if err := c.Renew(); err == nil {
+		t.Error("expected error renewing without a TGT")
+	}
+	if err := c.Validate(); err == nil {
+		t.Error("expected error validating without a TGT")
+	}
+}
+
+// assertKrbtgtSName checks the KDC-REQ-BODY's SName [3] is krbtgt/REALM.
+func assertKrbtgtSName(t *testing.T, body asn1.RawValue, realm string) {
+	t.Helper()
+	snameElem := seqChild(t, body.Bytes, asn1.ClassContextSpecific, 3)
+	var sname messages.PrincipalName
+	if _, err := asn1.Unmarshal(snameElem.Bytes, &sname); err != nil {
+		t.Fatalf("parse SName: %v", err)
+	}
+	if len(sname.NameString) != 2 || sname.NameString[0] != "krbtgt" || sname.NameString[1] != realm {
+		t.Errorf("SName not krbtgt/%s: %+v", realm, sname.NameString)
+	}
+}
+
+// assertPATGSPresentsTGT checks the TGS-REQ [3] PA-DATA holds exactly one
+// PA-TGS-REQ whose AP-REQ carries the client's TGT verbatim.
+func assertPATGSPresentsTGT(t *testing.T, wire, tgtRaw []byte) {
+	t.Helper()
+	var app asn1.RawValue
+	if _, err := asn1.Unmarshal(wire, &app); err != nil {
+		t.Fatal(err)
+	}
+	paElem := seqChild(t, app.Bytes, asn1.ClassContextSpecific, 3)
+	var paList []messages.PAData
+	if _, err := asn1.Unmarshal(paElem.Bytes, &paList); err != nil {
+		t.Fatalf("parse PA-DATA: %v", err)
+	}
+	if len(paList) != 1 || paList[0].PADataType != messages.PATGSReq {
+		t.Fatalf("expected a single PA-TGS-REQ, got %+v", paList)
+	}
+	// The AP-REQ (APPLICATION[14]) must embed the TGT (APPLICATION[1]) verbatim
+	// under its ticket [3] field, so the raw ticket bytes appear in the padata.
+	var apReq asn1.RawValue
+	if _, err := asn1.Unmarshal(paList[0].PADataValue, &apReq); err != nil {
+		t.Fatalf("parse AP-REQ: %v", err)
+	}
+	if apReq.Class != asn1.ClassApplication || apReq.Tag != messages.MsgTypeAPReq {
+		t.Fatalf("PA-TGS-REQ value is not an AP-REQ: class=%d tag=%d", apReq.Class, apReq.Tag)
+	}
+	if !bytes.Contains(paList[0].PADataValue, tgtRaw) {
+		t.Errorf("PA-TGS-REQ does not present the client's TGT verbatim")
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #920`

### Summary
Adds `Renew()` and `Validate()` to the native Kerberos v5 client. The `renew`/`validate` KDC options were defined but never set, and there were no client operations to renew a renewable TGT or validate a postdated one.

### Fix Description
Both methods issue an ordinary TGS-REQ that presents the client's existing TGT via a PA-TGS-REQ AP-REQ against the ticket-granting service (`krbtgt/REALM`), setting exactly one distinguishing KDC option — renew (bit 30) or validate (bit 31) — alongside renewable so the reissued ticket keeps its renewable window (RFC 4120 §3.3.3). The ticket to renew/validate is the one carried in the AP-REQ padata, not additional-tickets. On success the reissued ticket, raw bytes, session key and enc-part replace the client's stored TGT, so subsequent `GetTGS` calls use the fresh ticket. A single `KRB_AP_ERR_SKEW` reply triggers one clock-aligned retry, mirroring the other exchanges.

The request builder is factored out as `buildRenewalTGSReq` so the wire shape is testable without a live KDC.

### How Verified
- **Unit tests** (KDC-free): assert the renew/validate option bits, `krbtgt/REALM` sname, and that the TGT is presented verbatim in the PA-TGS-REQ.
- **Live** against a Windows Server 2016 DC: obtained a renewable TGT (renewable flag set, renew-till 7 days out), called `Renew()` — the KDC re-issued a fresh TGT (ticket bytes changed) that then worked for a real `GetTGS` (AES256 service ticket). Times stayed anchored on immediate renewal, matching the MIT `kinit -R` reference exactly. `Validate()` was exercised live and rejected with `KDC_ERR_BADOPTION` (postdating disabled by default AD policy), so it is unit-proven.

### Test Coverage
- **Added:** `TestRenewRequestShape`, `TestValidateRequestShape`, `TestRenewValidateRequireTGT` in `network/kerberos/v5/renew_test.go`.

### Scope of Change
- **Files changed:** `network/kerberos/v5/renew.go` (new), `network/kerberos/v5/renew_test.go` (new), `network/kerberos/v5/client.go` (renew/validate bit constants).
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Additive: two new methods plus two option constants. No existing code path changes behavior. Safe to merge.