### PR TITLE
Fix LLMNR DNS name compression to be message-relative (Fixes #943)

### DIFF
--- a/network/llmnr/domain_name/domain_name.go
+++ b/network/llmnr/domain_name/domain_name.go
@@ -31,13 +31,30 @@ func (d *DomainName) Marshal() ([]byte, error) {
 
 // Unmarshal decodes a domain name from data starting at offset 0 and sets the receiver.
 // It returns the number of bytes consumed from data.
+//
+// This entry point treats data as if the name started at the very beginning of
+// the message, so it can only resolve compression pointers that reference bytes
+// present in data. When the name lives inside a larger message and may contain
+// 0xC0 compression pointers that reference earlier bytes, callers must use
+// UnmarshalFromMessage instead so the pointers resolve against the message origin.
 func (d *DomainName) Unmarshal(data []byte) (int, error) {
-	name, n, err := DecodeDomainName(data, 0)
+	return d.UnmarshalFromMessage(data, 0)
+}
+
+// UnmarshalFromMessage decodes a domain name located at offset inside the full
+// message buffer and sets the receiver. Compression pointers (0xC0) are resolved
+// relative to the start of message, as mandated by RFC 1035 §4.1.4.
+//
+// It returns the number of bytes consumed in the original stream at offset. A
+// compression pointer consumes exactly two bytes at the point it appears,
+// regardless of the length of the name it references.
+func (d *DomainName) UnmarshalFromMessage(message []byte, offset int) (int, error) {
+	name, newOffset, err := DecodeDomainName(message, offset)
 	if err != nil {
 		return 0, err
 	}
 	*d = DomainName(name)
-	return n, nil
+	return newOffset - offset, nil
 }
 
 // ValidateDomainName validates a domain name according to LLMNR/DNS label rules.
@@ -71,9 +88,15 @@ func EncodeDomainName(name string) ([]byte, error) {
 	return buf, nil
 }
 
-// DecodeDomainName parses a domain name from LLMNR/DNS wire format starting at offset.
-// It returns the decoded name, the new offset (past the encoded name in the original stream),
-// and an error if decoding fails.
+// DecodeDomainName parses a domain name from LLMNR/DNS wire format located at
+// offset inside the full message buffer data. Because DNS/LLMNR compression
+// pointers are offsets from the start of the message (RFC 1035 §4.1.4), data
+// MUST be the whole message (starting at the header ID field) rather than a
+// sub-slice, otherwise 0xC0 pointers resolve against the wrong origin.
+//
+// It returns the decoded name, the new offset (past the encoded name in the
+// original stream — a compression pointer counts as exactly two bytes at the
+// point it appears), and an error if decoding fails.
 func DecodeDomainName(data []byte, offset int) (string, int, error) {
 	if offset < 0 || offset >= len(data) {
 		return "", offset, fmt.Errorf("offset out of bounds")
@@ -84,15 +107,53 @@ func DecodeDomainName(data []byte, offset int) (string, int, error) {
 	jumped := false
 	labels := []string{}
 
-	// To avoid infinite loops on malformed data with pointer cycles
-	maxSteps := 256
+	// visited records every offset at which we begin reading a label or a
+	// pointer. Revisiting an offset means the message contains a compression
+	// pointer cycle (or an overlapping name), which we reject instead of
+	// looping forever. Combined with the strictly-backward pointer check
+	// below, this guarantees termination on malformed data.
+	visited := make(map[int]struct{})
 
-	for steps := 0; steps < maxSteps; steps++ {
+	for {
 		if offset >= len(data) {
 			return "", originalOffset, fmt.Errorf("truncated name")
 		}
 
 		length := int(data[offset])
+
+		// Pointer (11xxxxxx): a two-octet compression pointer whose low 14
+		// bits are an offset from the start of the message (RFC 1035 §4.1.4).
+		if length&constants.LabelPointer == constants.LabelPointer {
+			// Need one more byte for the pointer
+			if offset+1 >= len(data) {
+				return "", originalOffset, fmt.Errorf("truncated pointer")
+			}
+			ptr := int(binary.BigEndian.Uint16(data[offset:]) & 0x3FFF)
+			if !jumped {
+				// A pointer consumes exactly two bytes from the original
+				// stream, regardless of the length of the name it references.
+				consumed += 2
+			}
+			// A pointer may only reference a prior occurrence of a name, i.e.
+			// it must point strictly backwards. Forward and self references are
+			// rejected per RFC guidance and to guarantee decoding terminates.
+			if ptr >= offset {
+				return "", originalOffset, fmt.Errorf("invalid pointer: not a backward reference")
+			}
+			if _, seen := visited[ptr]; seen {
+				return "", originalOffset, fmt.Errorf("invalid pointer: cycle detected")
+			}
+			visited[offset] = struct{}{}
+			// Follow the pointer
+			offset = ptr
+			jumped = true
+			continue
+		}
+
+		if _, seen := visited[offset]; seen {
+			return "", originalOffset, fmt.Errorf("invalid name: cycle detected")
+		}
+		visited[offset] = struct{}{}
 
 		// End of name
 		if length == 0 {
@@ -100,26 +161,6 @@ func DecodeDomainName(data []byte, offset int) (string, int, error) {
 				consumed++ // account for the zero byte only when not following a pointer
 			}
 			break
-		}
-
-		// Pointer (11xxxxxx)
-		if length&constants.LabelPointer == constants.LabelPointer {
-			// Need one more byte for the pointer
-			if offset+1 >= len(data) {
-				return "", originalOffset, fmt.Errorf("truncated pointer")
-			}
-			ptr := int(binary.BigEndian.Uint16(data[offset:]) & 0x3FFF)
-			if ptr >= len(data) {
-				return "", originalOffset, fmt.Errorf("invalid pointer")
-			}
-			if !jumped {
-				// We consume two bytes from the original stream for the pointer
-				consumed += 2
-			}
-			// Follow the pointer
-			offset = ptr
-			jumped = true
-			continue
 		}
 
 		// Regular label

--- a/network/llmnr/domain_name/domain_name_test.go
+++ b/network/llmnr/domain_name/domain_name_test.go
@@ -3,6 +3,7 @@ package domain_name_test
 import (
 	"bytes"
 	"testing"
+	"time"
 
 	"github.com/TheManticoreProject/Manticore/network/llmnr/domain_name"
 	"github.com/TheManticoreProject/Manticore/network/llmnr/errors"
@@ -72,6 +73,101 @@ func TestDecodeDomainName(t *testing.T) {
 			}
 			if decoded != test.expected {
 				t.Errorf("DecodeDomainName = %v; want %v", decoded, test.expected)
+			}
+		})
+	}
+}
+
+// TestDecodeDomainNameCompressionPointer verifies that a 0xC0 compression
+// pointer is resolved relative to the start of the message (RFC 1035 §4.1.4)
+// and that it consumes exactly two bytes at the point it appears, regardless of
+// the length of the name it references.
+func TestDecodeDomainNameCompressionPointer(t *testing.T) {
+	// The full name "example.com" lives at offset 2, preceded by two filler
+	// bytes so the pointer offset is non-zero. A second name at offset 15 is a
+	// single label "www" followed by a pointer (0xC0 0x02) back to the name at
+	// offset 2, yielding "www.example.com".
+	msg := []byte{
+		0xAA, 0xBB, // filler (e.g. would be part of the header in a real message)
+		7, 'e', 'x', 'a', 'm', 'p', 'l', 'e', 3, 'c', 'o', 'm', 0, // offset 2..14
+		3, 'w', 'w', 'w', 0xC0, 0x02, // offset 15: "www" + pointer to offset 2
+	}
+
+	// Decode the compressed name at offset 15.
+	name, newOffset, err := domain_name.DecodeDomainName(msg, 15)
+	if err != nil {
+		t.Fatalf("failed to decode compressed name: %v", err)
+	}
+	if name != "www.example.com" {
+		t.Errorf("compressed name = %q; want %q", name, "www.example.com")
+	}
+	// "www" label (1+3 bytes) + pointer (2 bytes) = 6 bytes consumed in the
+	// original stream: offset 15 -> 21.
+	if newOffset != 21 {
+		t.Errorf("new offset = %d; want %d", newOffset, 21)
+	}
+
+	// Decoding the referenced name directly must yield the suffix.
+	suffix, _, err := domain_name.DecodeDomainName(msg, 2)
+	if err != nil {
+		t.Fatalf("failed to decode referenced name: %v", err)
+	}
+	if suffix != "example.com" {
+		t.Errorf("referenced name = %q; want %q", suffix, "example.com")
+	}
+}
+
+// TestDecodeDomainNamePointerLoopRejected ensures malformed packets with
+// compression pointer loops (self, forward, or cyclic references) are rejected
+// with an error instead of looping forever or panicking.
+func TestDecodeDomainNamePointerLoopRejected(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+		// offset to start decoding at
+		offset int
+	}{
+		{
+			name:   "self pointer at offset 0",
+			data:   []byte{0xC0, 0x00},
+			offset: 0,
+		},
+		{
+			name: "forward pointer",
+			// offset 0: pointer to offset 2; offset 2: pointer to offset 0.
+			// The first pointer references a later offset and is rejected.
+			data:   []byte{0xC0, 0x02, 0xC0, 0x00},
+			offset: 0,
+		},
+		{
+			name: "label then self pointer",
+			// "a" label followed by a pointer that jumps back onto itself.
+			data:   []byte{1, 'a', 0xC0, 0x02},
+			offset: 0,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			done := make(chan struct{})
+			var err error
+			go func() {
+				defer func() {
+					if r := recover(); r != nil {
+						t.Errorf("DecodeDomainName panicked: %v", r)
+					}
+					close(done)
+				}()
+				_, _, err = domain_name.DecodeDomainName(test.data, test.offset)
+			}()
+
+			select {
+			case <-done:
+				if err == nil {
+					t.Errorf("expected error for pointer loop, got nil")
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatalf("DecodeDomainName did not terminate (pointer loop)")
 			}
 		})
 	}

--- a/network/llmnr/message/message.go
+++ b/network/llmnr/message/message.go
@@ -382,59 +382,62 @@ func (m *Message) Unmarshal(data []byte) (int, error) {
 		return 0, fmt.Errorf("message too short")
 	}
 
-	// Unmarshal header
-	bytesRead := 0
-	bytesReadHeader, err := m.Header.Unmarshal(data[bytesRead : bytesRead+header.HeaderSize])
+	// Unmarshal header. From here on we track an absolute offset into data so
+	// that 0xC0 compression pointers, which are relative to the start of the
+	// message (RFC 1035 §4.1.4), resolve against the message origin rather than
+	// against a sub-slice.
+	offset := 0
+	bytesReadHeader, err := m.Header.Unmarshal(data[offset : offset+header.HeaderSize])
 	if err != nil {
 		return 0, fmt.Errorf("error unmarshalling header: %w", err)
 	}
-	bytesRead += bytesReadHeader
+	offset += bytesReadHeader
 
 	// Decode questions
 	for i := uint16(0); i < m.Header.QDCount; i++ {
 		q := question.Question{}
-		n, err := q.Unmarshal(data[bytesRead:])
+		n, err := q.UnmarshalFromMessage(data, offset)
 		if err != nil {
 			return 0, fmt.Errorf("error unmarshalling question: %w", err)
 		}
-		bytesRead += n
+		offset += n
 		m.Questions = append(m.Questions, q)
 	}
 
 	// Decode answers
 	for i := uint16(0); i < m.Header.ANCount; i++ {
 		rr := resourcerecord.ResourceRecord{}
-		n, err := rr.Unmarshal(data[bytesRead:])
+		n, err := rr.UnmarshalFromMessage(data, offset)
 		if err != nil {
 			return 0, fmt.Errorf("error unmarshalling answer: %w", err)
 		}
-		bytesRead += n
+		offset += n
 		m.Answers = append(m.Answers, rr)
 	}
 
 	// Decode authority
 	for i := uint16(0); i < m.Header.NSCount; i++ {
 		rr := resourcerecord.ResourceRecord{}
-		n, err := rr.Unmarshal(data[bytesRead:])
+		n, err := rr.UnmarshalFromMessage(data, offset)
 		if err != nil {
 			return 0, fmt.Errorf("error unmarshalling authority: %w", err)
 		}
-		bytesRead += n
+		offset += n
 		m.Authority = append(m.Authority, rr)
 	}
 
 	// Decode additional
 	for i := uint16(0); i < m.Header.ARCount; i++ {
 		rr := resourcerecord.ResourceRecord{}
-		n, err := rr.Unmarshal(data[bytesRead:])
+		n, err := rr.UnmarshalFromMessage(data, offset)
 		if err != nil {
 			return 0, fmt.Errorf("error unmarshalling additional: %w", err)
 		}
-		bytesRead += n
+		offset += n
 		m.Additional = append(m.Additional, rr)
 	}
 
-	return bytesRead, nil
+	return offset, nil
 }
 
 // IsQuery returns true if the message is a query.

--- a/network/llmnr/message/message_test.go
+++ b/network/llmnr/message/message_test.go
@@ -1,7 +1,9 @@
 package message_test
 
 import (
+	"encoding/hex"
 	"math/rand"
+	"net"
 	"testing"
 	"time"
 
@@ -245,6 +247,133 @@ func TestUnmarshalMultipleRecords(t *testing.T) {
 	}
 	if parsed.Answers[0].Name != "host.local" {
 		t.Errorf("answer name mismatch: got %q", parsed.Answers[0].Name)
+	}
+}
+
+// llmnrLiveResponseHex is a real LLMNR response captured from a Windows Server
+// 2016 host (owner name "TMP-W-2016") replying to a Type A query. This host
+// does not compress the answer NAME (it repeats the full name), so it exercises
+// the uncompressed path end-to-end against genuine traffic.
+//
+//	Header:   ID=0x37c8, Flags=0x8000 (QR), QD=1, AN=1
+//	Question: TMP-W-2016  A IN
+//	Answer:   TMP-W-2016  A IN  TTL=30  RDATA=10.7.0.10
+const llmnrLiveResponseHex = "37c8800000010001000000000a544d502d572d3230313600000100010a544d502d572d3230313600000100010000001e00040a07000a"
+
+// llmnrCompressedResponseHex is a hand-built LLMNR response modelled on the live
+// capture above, but with the answer NAME replaced by a 0xC0 compression pointer
+// (0xC00C) back to the question name at offset 12. It is the known-answer packet
+// for the compression path: the prior code, which fed a sub-slice into the name
+// decoder, resolves this pointer against the wrong origin and produces garbage.
+//
+//	Answer NAME = 0xC0 0x0C -> offset 12 (the question name "TMP-W-2016").
+const llmnrCompressedResponseHex = "37c8800000010001000000000a544d502d572d323031360000010001c00c000100010000001e00040a07000a"
+
+// TestUnmarshalLiveWindowsResponse decodes the real captured Windows LLMNR
+// response and confirms the full message (question + answer RR) is parsed
+// correctly, including the owner name and the A record.
+func TestUnmarshalLiveWindowsResponse(t *testing.T) {
+	data, err := hex.DecodeString(llmnrLiveResponseHex)
+	if err != nil {
+		t.Fatalf("failed to decode fixture: %v", err)
+	}
+
+	msg := message.NewMessage()
+	n, err := msg.Unmarshal(data)
+	if err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if n != len(data) {
+		t.Errorf("Unmarshal read %d bytes, want %d", n, len(data))
+	}
+
+	if !msg.IsResponse() {
+		t.Errorf("expected message to be a response")
+	}
+	if len(msg.Questions) != 1 || msg.Questions[0].Name != "TMP-W-2016" {
+		t.Fatalf("unexpected questions: %+v", msg.Questions)
+	}
+	if len(msg.Answers) != 1 {
+		t.Fatalf("expected 1 answer, got %d", len(msg.Answers))
+	}
+	if msg.Answers[0].Name != "TMP-W-2016" {
+		t.Errorf("answer name = %q; want %q", msg.Answers[0].Name, "TMP-W-2016")
+	}
+	if msg.Answers[0].Type != llmnr_type.TypeA {
+		t.Errorf("answer type = %v; want A", msg.Answers[0].Type)
+	}
+	if got := net.IP(msg.Answers[0].RData).String(); got != "10.7.0.10" {
+		t.Errorf("answer RDATA = %q; want %q", got, "10.7.0.10")
+	}
+}
+
+// TestUnmarshalCompressedAnswerName is the known-answer test for a message whose
+// answer NAME is a 0xC0 compression pointer back to the question name. It must
+// decode to the same owner name and A record as the uncompressed capture.
+func TestUnmarshalCompressedAnswerName(t *testing.T) {
+	data, err := hex.DecodeString(llmnrCompressedResponseHex)
+	if err != nil {
+		t.Fatalf("failed to decode fixture: %v", err)
+	}
+
+	msg := message.NewMessage()
+	n, err := msg.Unmarshal(data)
+	if err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if n != len(data) {
+		t.Errorf("Unmarshal read %d bytes, want %d", n, len(data))
+	}
+
+	if len(msg.Questions) != 1 || msg.Questions[0].Name != "TMP-W-2016" {
+		t.Fatalf("unexpected questions: %+v", msg.Questions)
+	}
+	if len(msg.Answers) != 1 {
+		t.Fatalf("expected 1 answer, got %d", len(msg.Answers))
+	}
+	// The compressed answer NAME must resolve to the question name.
+	if msg.Answers[0].Name != "TMP-W-2016" {
+		t.Errorf("compressed answer name = %q; want %q", msg.Answers[0].Name, "TMP-W-2016")
+	}
+	if msg.Answers[0].Type != llmnr_type.TypeA {
+		t.Errorf("answer type = %v; want A", msg.Answers[0].Type)
+	}
+	if got := net.IP(msg.Answers[0].RData).String(); got != "10.7.0.10" {
+		t.Errorf("answer RDATA = %q; want %q", got, "10.7.0.10")
+	}
+}
+
+// TestUnmarshalPointerLoopMessage ensures a message carrying a malformed
+// compression pointer loop is rejected with an error instead of hanging or
+// panicking.
+func TestUnmarshalPointerLoopMessage(t *testing.T) {
+	// Header (QD=1, AN=0) followed by a question whose name at offset 12 is a
+	// self-referential pointer (0xC0 0x0C -> offset 12), then type A / class IN.
+	data := []byte{
+		0x37, 0xc8, // ID
+		0x00, 0x00, // Flags
+		0x00, 0x01, // QDCount
+		0x00, 0x00, // ANCount
+		0x00, 0x00, // NSCount
+		0x00, 0x00, // ARCount
+		0xC0, 0x0C, // name: self pointer to offset 12
+		0x00, 0x01, // type A
+		0x00, 0x01, // class IN
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		msg := message.NewMessage()
+		if _, err := msg.Unmarshal(data); err == nil {
+			t.Errorf("expected error for pointer loop, got nil")
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("Unmarshal did not terminate on pointer loop")
 	}
 }
 

--- a/network/llmnr/question/question.go
+++ b/network/llmnr/question/question.go
@@ -102,36 +102,52 @@ func (q *Question) Marshal() ([]byte, error) {
 //	    // handle error
 //	}
 func (q *Question) Unmarshal(data []byte) (int, error) {
-	bytesRead := 0
+	return q.UnmarshalFromMessage(data, 0)
+}
+
+// UnmarshalFromMessage decodes a Question located at offset inside the full
+// message buffer. It is used instead of Unmarshal when the question's name may
+// contain 0xC0 compression pointers, so those pointers resolve against the
+// start of the message (RFC 1035 §4.1.4) rather than against a sub-slice.
+//
+// Parameters:
+// - message: The full LLMNR message in wire format.
+// - offset: The absolute offset of the question inside message.
+//
+// Returns:
+//   - The number of bytes consumed from message at offset.
+//   - An error if the decoding fails at any point.
+func (q *Question) UnmarshalFromMessage(message []byte, offset int) (int, error) {
+	start := offset
 
 	// Unmarshal domain name
-	bytesReadDomainName, err := q.Name.Unmarshal(data[bytesRead:])
+	bytesReadDomainName, err := q.Name.UnmarshalFromMessage(message, offset)
 	if err != nil {
 		return 0, fmt.Errorf("error unmarshalling domain name: %w", err)
 	}
-	bytesRead += bytesReadDomainName
+	offset += bytesReadDomainName
 
 	// Unmarshal type
-	if bytesRead+2 > len(data) {
+	if offset+2 > len(message) {
 		return 0, fmt.Errorf("truncated question, missing type")
 	}
-	bytesReadType, err := q.Type.Unmarshal(data[bytesRead : bytesRead+2])
+	bytesReadType, err := q.Type.Unmarshal(message[offset : offset+2])
 	if err != nil {
 		return 0, fmt.Errorf("error unmarshalling type: %w", err)
 	}
-	bytesRead += bytesReadType
+	offset += bytesReadType
 
 	// Unmarshal class
-	if bytesRead+2 > len(data) {
+	if offset+2 > len(message) {
 		return 0, fmt.Errorf("truncated question, missing class")
 	}
-	bytesReadClass, err := q.Class.Unmarshal(data[bytesRead : bytesRead+2])
+	bytesReadClass, err := q.Class.Unmarshal(message[offset : offset+2])
 	if err != nil {
 		return 0, fmt.Errorf("error unmarshalling class: %w", err)
 	}
-	bytesRead += bytesReadClass
+	offset += bytesReadClass
 
-	return bytesRead, nil
+	return offset - start, nil
 }
 
 // Describe prints a detailed description of the Question.

--- a/network/llmnr/resourcerecord/resource_record.go
+++ b/network/llmnr/resourcerecord/resource_record.go
@@ -88,36 +88,53 @@ func (rr *ResourceRecord) Marshal() ([]byte, error) {
 //   - An integer representing the new offset position after decoding.
 //   - An error if the decoding fails at any point, such as if the data is too short or if there is an error decoding the domain name.
 func (rr *ResourceRecord) Unmarshal(data []byte) (int, error) {
-	bytesRead := 0
+	return rr.UnmarshalFromMessage(data, 0)
+}
 
-	bytesReadName, err := rr.Name.Unmarshal(data[bytesRead:])
+// UnmarshalFromMessage decodes a ResourceRecord located at offset inside the
+// full message buffer. It is used instead of Unmarshal when the record's name
+// may contain 0xC0 compression pointers (responders routinely compress the
+// answer NAME to point back at the question), so those pointers resolve against
+// the start of the message (RFC 1035 §4.1.4) rather than against a sub-slice.
+//
+// Parameters:
+// - message: The full LLMNR message in wire format.
+// - offset: The absolute offset of the resource record inside message.
+//
+// Returns:
+//   - The number of bytes consumed from message at offset.
+//   - An error if the decoding fails at any point.
+func (rr *ResourceRecord) UnmarshalFromMessage(message []byte, offset int) (int, error) {
+	start := offset
+
+	bytesReadName, err := rr.Name.UnmarshalFromMessage(message, offset)
 	if err != nil {
 		return 0, fmt.Errorf("error unmarshalling name: %w", err)
 	}
-	bytesRead += bytesReadName
+	offset += bytesReadName
 
-	if bytesRead+10 > len(data) {
+	if offset+10 > len(message) {
 		return 0, fmt.Errorf("truncated resource record")
 	}
 
-	rr.Type = llmnr_type.Type(binary.BigEndian.Uint16(data[bytesRead:]))
-	bytesRead += 2
-	rr.Class = class.Class(binary.BigEndian.Uint16(data[bytesRead:]))
-	bytesRead += 2
-	rr.TTL = binary.BigEndian.Uint32(data[bytesRead:])
-	bytesRead += 4
-	rr.RDLength = binary.BigEndian.Uint16(data[bytesRead:])
-	bytesRead += 2
+	rr.Type = llmnr_type.Type(binary.BigEndian.Uint16(message[offset:]))
+	offset += 2
+	rr.Class = class.Class(binary.BigEndian.Uint16(message[offset:]))
+	offset += 2
+	rr.TTL = binary.BigEndian.Uint32(message[offset:])
+	offset += 4
+	rr.RDLength = binary.BigEndian.Uint16(message[offset:])
+	offset += 2
 
-	if bytesRead+int(rr.RDLength) > len(data) {
+	if offset+int(rr.RDLength) > len(message) {
 		return 0, fmt.Errorf("truncated rdata")
 	}
 
 	rr.RData = make([]byte, rr.RDLength)
-	copy(rr.RData, data[bytesRead:bytesRead+int(rr.RDLength)])
-	bytesRead += int(rr.RDLength)
+	copy(rr.RData, message[offset:offset+int(rr.RDLength)])
+	offset += int(rr.RDLength)
 
-	return bytesRead, nil
+	return offset - start, nil
 }
 
 // IPToRData converts an IP address string to its corresponding RData byte slice representation.


### PR DESCRIPTION
### Linked Issue
`Closes #943`

### Root Cause
DNS/LLMNR name compression uses `0xC0` pointers whose low 14 bits are an offset **from the start of the whole message** (the first octet of the header ID field), per RFC 1035 §4.1.4. The decoder path, however, resolved those pointers against a sub-slice: `DomainName.Unmarshal` was handed `data[bytesRead:]` by `Question`/`ResourceRecord`, which in turn received `data[bytesRead:]` from `Message.Unmarshal`, and it then called `DecodeDomainName(data, 0)`. A pointer value like `0xC00C` (offset 12) was therefore interpreted relative to the answer's own sub-slice rather than the message origin, so any packet that compresses a name (responders routinely compress the answer NAME back to the question) decoded to garbage or errored. The loop guard was also a crude fixed `maxSteps` cap rather than real cycle detection.

### Fix Description
Thread the full message buffer plus an absolute offset through the decode chain:

- Added `UnmarshalFromMessage(message []byte, offset int)` to `DomainName`, `Question`, and `ResourceRecord`. These carry the whole message and the record's absolute offset, so `0xC0` pointers resolve against the message origin.
- `Message.Unmarshal` now tracks a single absolute `offset` into `data` and calls the `FromMessage` variants for every section (questions, answers, authority, additional).
- The existing exported `Unmarshal(data []byte)` signatures are preserved as thin wrappers that delegate to `UnmarshalFromMessage(data, 0)`, keeping backward compatibility for standalone/uncompressed names.
- Replaced the `maxSteps` cap in `DecodeDomainName` with visited-offset pointer-loop protection: a pointer must reference a strictly earlier offset (forward/self references are rejected), and any offset that is revisited is rejected as a cycle. This guarantees termination on malformed input.
- A compression pointer consumes exactly two bytes at the point it appears, regardless of the referenced name's length; `newOffset - offset` gives the bytes consumed in the original stream.

Compression on marshal was left out of scope: `Marshal` continues to emit uncompressed names, which is valid wire output.

### How Verified
- **Live capture:** Sent a real LLMNR Type A query for `TMP-W-2016` to the Windows Server 2016 responder at `10.7.0.10:5355`. The genuine 54-byte response parsed end-to-end with the fixed decoder, yielding question/answer owner name `TMP-W-2016` and A record `10.7.0.10`. That host does not compress the answer NAME (it repeats it), so the exact captured bytes are committed as an uncompressed real-packet KAT (`TestUnmarshalLiveWindowsResponse`).
- **Compression KAT:** A hand-built message modelled on the live capture, but with the answer NAME replaced by a `0xC00C` pointer back to the question name, decodes to the same owner name and A record (`TestUnmarshalCompressedAnswerName`, plus `TestDecodeDomainNameCompressionPointer` at the decoder level). This packet decodes to garbage under the pre-fix sub-slice logic.
- **Loop safety:** `TestDecodeDomainNamePointerLoopRejected` and `TestUnmarshalPointerLoopMessage` feed self/forward/cyclic pointers and assert an error is returned with no hang (guarded by a 2s timeout) and no panic.
- `go build ./...`, `go vet ./network/llmnr/...`, and `go test ./network/llmnr/...` all pass.

### Test Coverage
- **Added:** `TestDecodeDomainNameCompressionPointer`, `TestDecodeDomainNamePointerLoopRejected` (domain_name_test.go); `TestUnmarshalLiveWindowsResponse`, `TestUnmarshalCompressedAnswerName`, `TestUnmarshalPointerLoopMessage` (message_test.go).

### Scope of Change
- **Files changed:** `network/llmnr/domain_name/domain_name.go`, `network/llmnr/question/question.go`, `network/llmnr/resourcerecord/resource_record.go`, `network/llmnr/message/message.go`, and their `_test.go` files.
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Low blast radius: the exported `Unmarshal` signatures are unchanged and continue to work for uncompressed input; the new behavior only affects packets that use compression (previously broken) and malformed pointer loops (previously capped, now rejected). Safe to merge without staged rollout.