### PR TITLE
Validate LLMNR client responses by question section and source address (Fixes #945)

### DIFF
--- a/network/llmnr/client.go
+++ b/network/llmnr/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"strings"
 	"sync"
 	"time"
 
@@ -12,6 +13,26 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/llmnr/llmnr_type"
 	"github.com/TheManticoreProject/Manticore/network/llmnr/message"
 )
+
+// pendingQuery holds the state the read loop needs to validate and deliver a
+// response for a single outstanding query. Alongside the delivery channel it
+// records the question that was asked (name/type/class) so that an incoming
+// response can be checked against it: matching on the 16-bit transaction ID
+// alone is insufficient (the ID space is small and the query is multicast, so
+// responses are trivially forgeable and could cross-deliver a wrong answer to a
+// waiting query). See RFC 4795 §2.7.
+type pendingQuery struct {
+	// responseChan receives the validated response for this query.
+	responseChan chan *message.Message
+
+	// name, qtype and qclass are the question that was sent. A response is only
+	// delivered if its question section echoes this question. The class is
+	// stored with the QU (Unicast-Preferred) bit cleared so the comparison is
+	// robust: responders (notably Windows) do not necessarily echo that bit.
+	name   string
+	qtype  llmnr_type.Type
+	qclass class.Class
+}
 
 // Client represents an LLMNR client that can send queries and receive responses.
 //
@@ -55,6 +76,14 @@ type Client struct {
 	// the LLMNR IPv4 multicast group and is overridable so queries can be
 	// directed at a specific responder (e.g. for testing or unicast probing).
 	dest *net.UDPAddr
+
+	// localNets holds the IP networks configured on the host's interfaces at
+	// the time the client was created. The read loop uses them to decide
+	// whether a response's source address is a plausible LLMNR responder: LLMNR
+	// is a link-local protocol, so a legitimate response must come from an
+	// on-link (same-subnet) unicast address, a link-local address, or loopback
+	// (the last covers unit tests that use a 127.0.0.1 responder).
+	localNets []*net.IPNet
 }
 
 // NewClient creates a new LLMNR client with a UDP connection.
@@ -96,11 +125,31 @@ func NewClient() (*Client, error) {
 			IP:   net.ParseIP(constants.IPv4MulticastAddr),
 			Port: constants.ListenPort,
 		},
+		localNets: localUnicastNetworks(),
 	}
 
 	go c.readLoop()
 
 	return c, nil
+}
+
+// localUnicastNetworks returns the unicast IP networks configured on the host's
+// interfaces. It is best-effort: on error it returns nil, in which case the
+// on-link source check simply does not match and validation falls back to the
+// loopback and link-local checks.
+func localUnicastNetworks() []*net.IPNet {
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return nil
+	}
+
+	nets := make([]*net.IPNet, 0, len(addrs))
+	for _, addr := range addrs {
+		if ipNet, ok := addr.(*net.IPNet); ok {
+			nets = append(nets, ipNet)
+		}
+	}
+	return nets
 }
 
 // Close closes the client connection
@@ -120,9 +169,16 @@ func (c *Client) Query(ctx context.Context, name string, qtype llmnr_type.Type) 
 		return nil, fmt.Errorf("failed to add question: %w", err)
 	}
 
-	// Create response channel
+	// Create the response channel and record the outstanding query so the read
+	// loop can validate an incoming response against the exact question that was
+	// asked before delivering it (the transaction ID alone is not enough).
 	responseChan := make(chan *message.Message, 1)
-	c.Queries.Store(msg.Header.Identifier, responseChan)
+	c.Queries.Store(msg.Header.Identifier, &pendingQuery{
+		responseChan: responseChan,
+		name:         name,
+		qtype:        qtype,
+		qclass:       class.ClassIN.BaseClass(),
+	})
 	defer c.Queries.Delete(msg.Header.Identifier)
 
 	// Send query to the configured destination (the LLMNR multicast group by
@@ -154,8 +210,14 @@ func (c *Client) readLoop() {
 		case <-c.Closed:
 			return
 		default:
-			n, _, err := c.Conn.ReadFromUDP(buffer)
+			n, src, err := c.Conn.ReadFromUDP(buffer)
 			if err != nil {
+				continue
+			}
+
+			// Drop datagrams whose source address is not a plausible LLMNR
+			// responder before spending any effort parsing them.
+			if !c.isPlausibleResponder(src) {
 				continue
 			}
 
@@ -169,14 +231,77 @@ func (c *Client) readLoop() {
 				continue
 			}
 
-			// Find the matching query
-			if ch, ok := c.Queries.Load(msg.Header.Identifier); ok {
-				responseChan := ch.(chan *message.Message)
-				select {
-				case responseChan <- &msg:
-				default:
-				}
+			// Find the matching outstanding query by transaction ID, then
+			// confirm the response's question section echoes the question we
+			// asked before delivering it. This rejects responses that merely
+			// guessed (or collided on) the 16-bit ID.
+			ch, ok := c.Queries.Load(msg.Header.Identifier)
+			if !ok {
+				continue
+			}
+			pq := ch.(*pendingQuery)
+			if !pq.matchesQuestion(&msg) {
+				continue
+			}
+
+			select {
+			case pq.responseChan <- &msg:
+			default:
 			}
 		}
 	}
+}
+
+// isPlausibleResponder reports whether src is an acceptable source for an LLMNR
+// response. LLMNR is a link-local protocol, so a legitimate unicast response
+// must originate from an on-link (same-subnet) address, a link-local address,
+// or loopback (which covers the loopback responder used by the unit tests). A
+// multicast or unspecified source is never a valid responder.
+func (c *Client) isPlausibleResponder(src *net.UDPAddr) bool {
+	if src == nil || src.IP == nil {
+		return false
+	}
+	ip := src.IP
+
+	if ip.IsUnspecified() || ip.IsMulticast() {
+		return false
+	}
+
+	// Loopback covers the in-process test responder (127.0.0.1); link-local
+	// addresses (169.254.0.0/16, fe80::/10) are on the local link by definition.
+	if ip.IsLoopback() || ip.IsLinkLocalUnicast() {
+		return true
+	}
+
+	// Otherwise the source must be on-link, i.e. fall inside one of the
+	// networks configured on this host's interfaces (e.g. a responder on the
+	// same /24 as us). This accepts genuine LAN responders while rejecting
+	// off-link/routed sources.
+	for _, n := range c.localNets {
+		if n.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// matchesQuestion reports whether the response resp answers the question this
+// query asked. The name is compared case-insensitively (DNS names are
+// case-insensitive) and the type must match exactly. The class is compared with
+// the QU (Unicast-Preferred) bit cleared, because responders do not necessarily
+// echo that bit. A response with no matching question is rejected.
+func (pq *pendingQuery) matchesQuestion(resp *message.Message) bool {
+	for _, q := range resp.Questions {
+		if !strings.EqualFold(string(q.Name), pq.name) {
+			continue
+		}
+		if q.Type != pq.qtype {
+			continue
+		}
+		if q.Class.BaseClass() != pq.qclass {
+			continue
+		}
+		return true
+	}
+	return false
 }

--- a/network/llmnr/client_test.go
+++ b/network/llmnr/client_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"net"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -377,6 +378,175 @@ func TestClientReadLoopFiltersUnknownID(t *testing.T) {
 	_, err = c.Query(context.Background(), "host.local", llmnr_type.TypeA)
 	if err == nil || err.Error() != "query timeout" {
 		t.Errorf("Query() error = %v, want %q (unknown ID must be dropped)", err, "query timeout")
+	}
+}
+
+// TestClientReadLoopFiltersMismatchedQuestion verifies that a response bearing a
+// matching transaction ID but a question section that does not correspond to the
+// outstanding query is rejected, so an attacker who guesses (or collides on) the
+// 16-bit ID cannot inject an answer for a name the client never asked about. The
+// responder echoes the query ID but answers a different owner name, so Query must
+// time out.
+func TestClientReadLoopFiltersMismatchedQuestion(t *testing.T) {
+	addr, cleanup := startResponder(t, func(query []byte, _ *net.UDPAddr) []byte {
+		m := message.NewMessage()
+		if _, err := m.Unmarshal(query); err != nil {
+			return nil
+		}
+		// Same transaction ID, but answer a name the client did not query.
+		resp := message.NewMessage()
+		resp.Header.Identifier = m.Header.Identifier
+		resp.SetResponse()
+		if err := resp.AddAnswerClassINTypeA("attacker.local", "10.7.0.66"); err != nil {
+			return nil
+		}
+		encoded, err := resp.Marshal()
+		if err != nil {
+			return nil
+		}
+		return encoded
+	})
+	defer cleanup()
+
+	c, err := NewClient()
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	defer c.Close()
+	c.dest = addr
+	c.Timeout = 200 * time.Millisecond
+
+	_, err = c.Query(context.Background(), "host.local", llmnr_type.TypeA)
+	if err == nil || err.Error() != "query timeout" {
+		t.Errorf("Query() error = %v, want %q (mismatched question must be rejected)", err, "query timeout")
+	}
+}
+
+// TestClientReadLoopFiltersMismatchedType verifies that a response whose question
+// echoes the queried name but with a different record type is rejected, so a Type
+// AAAA answer cannot satisfy a pending Type A query sharing the same ID.
+func TestClientReadLoopFiltersMismatchedType(t *testing.T) {
+	addr, cleanup := startResponder(t, func(query []byte, _ *net.UDPAddr) []byte {
+		m := message.NewMessage()
+		if _, err := m.Unmarshal(query); err != nil {
+			return nil
+		}
+		// Same ID and name, but answer with a Type AAAA record instead of A.
+		resp := message.NewMessage()
+		resp.Header.Identifier = m.Header.Identifier
+		resp.SetResponse()
+		if err := resp.AddAnswerClassINTypeAAAA("host.local", "fe80::1"); err != nil {
+			return nil
+		}
+		encoded, err := resp.Marshal()
+		if err != nil {
+			return nil
+		}
+		return encoded
+	})
+	defer cleanup()
+
+	c, err := NewClient()
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	defer c.Close()
+	c.dest = addr
+	c.Timeout = 200 * time.Millisecond
+
+	_, err = c.Query(context.Background(), "host.local", llmnr_type.TypeA)
+	if err == nil || err.Error() != "query timeout" {
+		t.Errorf("Query() error = %v, want %q (mismatched question type must be rejected)", err, "query timeout")
+	}
+}
+
+// TestClientReadLoopMatchesQuestionCaseInsensitively confirms a genuine response
+// is still delivered when the echoed question name differs only in letter case
+// from the query, since DNS names are case-insensitive. A responder that would
+// upper-case the name (as some implementations do) must not be rejected.
+func TestClientReadLoopMatchesQuestionCaseInsensitively(t *testing.T) {
+	addr, cleanup := startResponder(t, func(query []byte, _ *net.UDPAddr) []byte {
+		m := message.NewMessage()
+		if _, err := m.Unmarshal(query); err != nil || len(m.Questions) == 0 {
+			return nil
+		}
+		// Answer using an upper-cased owner name to exercise case-insensitive
+		// matching against the lower-case query name.
+		resp := message.NewMessage()
+		resp.Header.Identifier = m.Header.Identifier
+		resp.SetResponse()
+		if err := resp.AddAnswerClassINTypeA(strings.ToUpper(string(m.Questions[0].Name)), "10.7.0.10"); err != nil {
+			return nil
+		}
+		encoded, err := resp.Marshal()
+		if err != nil {
+			return nil
+		}
+		return encoded
+	})
+	defer cleanup()
+
+	c, err := NewClient()
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	defer c.Close()
+	c.dest = addr
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	resp, err := c.Query(ctx, "host.local", llmnr_type.TypeA)
+	if err != nil {
+		t.Fatalf("Query() error = %v (case-insensitive question must match)", err)
+	}
+	if len(resp.Answers) != 1 {
+		t.Fatalf("Query() answers = %d, want 1", len(resp.Answers))
+	}
+	if got := net.IP(resp.Answers[0].RData).String(); got != "10.7.0.10" {
+		t.Errorf("Query() answer RDATA = %q, want %q", got, "10.7.0.10")
+	}
+}
+
+// TestClientIsPlausibleResponder exercises the source-address sanity check
+// directly: loopback and link-local sources are accepted, multicast/unspecified
+// sources are rejected, and an off-link routed source is rejected while an
+// on-link source (inside a configured interface network) is accepted.
+func TestClientIsPlausibleResponder(t *testing.T) {
+	c, err := NewClient()
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	defer c.Close()
+
+	// Constrain localNets to a known network so the on-link case is deterministic.
+	_, onLink, err := net.ParseCIDR("10.7.0.0/24")
+	if err != nil {
+		t.Fatalf("ParseCIDR() error = %v", err)
+	}
+	c.localNets = []*net.IPNet{onLink}
+
+	cases := []struct {
+		name string
+		ip   net.IP
+		want bool
+	}{
+		{"loopback", net.IPv4(127, 0, 0, 1), true},
+		{"link-local", net.IPv4(169, 254, 1, 2), true},
+		{"on-link unicast", net.IPv4(10, 7, 0, 10), true},
+		{"off-link unicast", net.IPv4(8, 8, 8, 8), false},
+		{"multicast", net.ParseIP(constants.IPv4MulticastAddr), false},
+		{"unspecified", net.IPv4zero, false},
+		{"nil", nil, false},
+	}
+	for _, tc := range cases {
+		var src *net.UDPAddr
+		if tc.ip != nil {
+			src = &net.UDPAddr{IP: tc.ip, Port: constants.ListenPort}
+		}
+		if got := c.isPlausibleResponder(src); got != tc.want {
+			t.Errorf("isPlausibleResponder(%s) = %v, want %v", tc.name, got, tc.want)
+		}
 	}
 }
 


### PR DESCRIPTION
### Linked Issue
Closes #945

### Root Cause
The LLMNR client correlated responses to outstanding queries using only the 16-bit transaction ID stored in a `sync.Map`. The read loop discarded the datagram source address (`n, _, err := ReadFromUDP`) and never inspected the response's question section. Because the ID space is only 16 bits and queries are sent to a multicast group, any host on (or off) the link could forge a response that matched a pending ID, and an ID collision between two concurrent queries could cross-deliver the wrong answer.

### Fix Description
Each outstanding query now records the question it asked (name, type, class) alongside its delivery channel via a small `pendingQuery` struct keyed by transaction ID. The read loop performs two additional checks before delivering a response:

- Source-address sanity: the datagram source must be loopback, link-local, or on-link (contained in one of the host's interface networks, captured at client creation). Multicast/unspecified sources are rejected. LLMNR is a link-local protocol, so an off-link routed source is never a valid responder.
- Question-section match: the response must echo the asked question. The owner name is compared case-insensitively (DNS names are case-insensitive) and the type must match exactly. The class is compared with the QU (Unicast-Preferred) bit cleared, because responders (notably Windows) do not necessarily echo that bit — matching the full class verbatim would over-reject genuine replies.

Concurrent-query correctness (the ID→channel map) and `Close` semantics are unchanged.

### How Verified
- `go build ./...`, `go vet ./network/llmnr/`, and `go test ./network/llmnr/ -race` all pass.
- Live-validated against a Windows Server 2016 LLMNR responder on the link: a real multicast query for `TMP-W-2016` type A returned a reply from the on-link host that passed both checks (question echoed `TMP-W-2016`/A/IN, source on-link) and resolved to A=10.7.0.10. A synthetic response bearing a matching ID but a mismatched question name was correctly rejected.

### Test Coverage
**Added** (reusing the loopback-responder harness):
- `TestClientReadLoopFiltersMismatchedQuestion` — matching ID, wrong owner name is rejected.
- `TestClientReadLoopFiltersMismatchedType` — matching ID and name, wrong record type is rejected.
- `TestClientReadLoopMatchesQuestionCaseInsensitively` — an upper-cased echoed name still matches and is delivered.
- `TestClientIsPlausibleResponder` — table test for loopback/link-local/on-link accepted; off-link/multicast/unspecified/nil rejected.

Existing `TestClientReadLoopFiltersUnknownID` (mismatched ID rejected) and `TestClientQueryDispatch` / `TestClientQueryMatchesRealCapture` (valid response delivered) continue to pass.

### Scope of Change
- **Files changed:** `network/llmnr/client.go`, `network/llmnr/client_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local to the LLMNR client read/dispatch path. The source check is deliberately permissive (loopback + link-local + on-link) so it does not regress genuine LAN or loopback usage; safe to merge without staged rollout.