### PR TITLE
Add typed RDATA encode/decode for common LLMNR record types (Fixes #949)

### DIFF
--- a/network/llmnr/resourcerecord/rdata.go
+++ b/network/llmnr/resourcerecord/rdata.go
@@ -1,0 +1,183 @@
+package resourcerecord
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net"
+
+	"github.com/TheManticoreProject/Manticore/network/llmnr/domain_name"
+	"github.com/TheManticoreProject/Manticore/network/llmnr/llmnr_type"
+)
+
+// This file implements typed encode/decode of the RDATA field for the resource
+// record types commonly seen over LLMNR/DNS: A, AAAA, PTR, CNAME, NS, TXT and
+// SRV. The wire formats follow RFC 1035 §3.3 (A/CNAME/NS/PTR/TXT) and RFC 2782
+// (SRV). RDATA for unmodeled types is left as the opaque RData byte slice.
+//
+// Name-bearing RDATA (PTR/CNAME/NS and the SRV target) may contain 0xC0
+// compression pointers whose 14-bit offset is measured from the start of the
+// enclosing message (RFC 1035 §4.1.4). The typed decoders below therefore
+// resolve names through the message context captured by UnmarshalFromMessage
+// (rr.message / rr.rdataOffset) rather than against the RData sub-slice, which
+// would resolve those pointers against the wrong origin.
+
+// decodeName decodes a single domain name that begins at rdataInternalOffset
+// bytes into this record's RData. When the record was decoded from a full
+// message (via UnmarshalFromMessage) the name is resolved against the message
+// origin so that compression pointers work; otherwise it falls back to decoding
+// from the RData bytes alone, which only succeeds for uncompressed names.
+func (rr *ResourceRecord) decodeName(rdataInternalOffset int) (string, error) {
+	if rdataInternalOffset > len(rr.RData) {
+		return "", fmt.Errorf("rdata too short for name at offset %d", rdataInternalOffset)
+	}
+
+	if rr.message != nil {
+		name, _, err := domain_name.DecodeDomainName(rr.message, rr.rdataOffset+rdataInternalOffset)
+		if err != nil {
+			return "", err
+		}
+		return name, nil
+	}
+
+	name, _, err := domain_name.DecodeDomainName(rr.RData, rdataInternalOffset)
+	if err != nil {
+		return "", err
+	}
+	return name, nil
+}
+
+// AsA returns the IPv4 address carried by an A record. It errors if the record
+// is not an A record or if RDATA is not exactly four octets (RFC 1035 §3.4.1).
+func (rr *ResourceRecord) AsA() (net.IP, error) {
+	if rr.Type != llmnr_type.TypeA {
+		return nil, fmt.Errorf("record type is %s, not A", rr.Type.String())
+	}
+	if len(rr.RData) != net.IPv4len {
+		return nil, fmt.Errorf("A rdata length is %d, want %d", len(rr.RData), net.IPv4len)
+	}
+	ip := make(net.IP, net.IPv4len)
+	copy(ip, rr.RData)
+	return ip, nil
+}
+
+// AsAAAA returns the IPv6 address carried by an AAAA record. It errors if the
+// record is not an AAAA record or if RDATA is not exactly sixteen octets
+// (RFC 3596 §2.2).
+func (rr *ResourceRecord) AsAAAA() (net.IP, error) {
+	if rr.Type != llmnr_type.TypeAAAA {
+		return nil, fmt.Errorf("record type is %s, not AAAA", rr.Type.String())
+	}
+	if len(rr.RData) != net.IPv6len {
+		return nil, fmt.Errorf("AAAA rdata length is %d, want %d", len(rr.RData), net.IPv6len)
+	}
+	ip := make(net.IP, net.IPv6len)
+	copy(ip, rr.RData)
+	return ip, nil
+}
+
+// AsPTR returns the domain name carried by a PTR record (RFC 1035 §3.3.12).
+func (rr *ResourceRecord) AsPTR() (string, error) {
+	if rr.Type != llmnr_type.TypePTR {
+		return "", fmt.Errorf("record type is %s, not PTR", rr.Type.String())
+	}
+	return rr.decodeName(0)
+}
+
+// AsCNAME returns the canonical name carried by a CNAME record (RFC 1035 §3.3.1).
+func (rr *ResourceRecord) AsCNAME() (string, error) {
+	if rr.Type != llmnr_type.TypeCNAME {
+		return "", fmt.Errorf("record type is %s, not CNAME", rr.Type.String())
+	}
+	return rr.decodeName(0)
+}
+
+// AsNS returns the name server carried by an NS record (RFC 1035 §3.3.11).
+func (rr *ResourceRecord) AsNS() (string, error) {
+	if rr.Type != llmnr_type.TypeNS {
+		return "", fmt.Errorf("record type is %s, not NS", rr.Type.String())
+	}
+	return rr.decodeName(0)
+}
+
+// AsTXT returns the character-strings carried by a TXT record. TXT RDATA is one
+// or more <character-string>s, each a single length octet followed by that many
+// bytes (RFC 1035 §3.3.14 and §3.3).
+func (rr *ResourceRecord) AsTXT() ([]string, error) {
+	if rr.Type != llmnr_type.TypeTXT {
+		return nil, fmt.Errorf("record type is %s, not TXT", rr.Type.String())
+	}
+
+	strs := []string{}
+	offset := 0
+	for offset < len(rr.RData) {
+		length := int(rr.RData[offset])
+		offset++
+		if offset+length > len(rr.RData) {
+			return nil, fmt.Errorf("truncated txt character-string")
+		}
+		strs = append(strs, string(rr.RData[offset:offset+length]))
+		offset += length
+	}
+	return strs, nil
+}
+
+// AsSRV returns the priority, weight, port and target of an SRV record. SRV
+// RDATA is three big-endian uint16s (priority, weight, port) followed by the
+// target domain name (RFC 2782). The target may in principle contain a
+// compression pointer, which is resolved against the message origin.
+func (rr *ResourceRecord) AsSRV() (priority uint16, weight uint16, port uint16, target string, err error) {
+	if rr.Type != llmnr_type.TypeSRV {
+		return 0, 0, 0, "", fmt.Errorf("record type is %s, not SRV", rr.Type.String())
+	}
+	if len(rr.RData) < 6 {
+		return 0, 0, 0, "", fmt.Errorf("srv rdata length is %d, want at least 6", len(rr.RData))
+	}
+
+	priority = binary.BigEndian.Uint16(rr.RData[0:2])
+	weight = binary.BigEndian.Uint16(rr.RData[2:4])
+	port = binary.BigEndian.Uint16(rr.RData[4:6])
+
+	target, err = rr.decodeName(6)
+	if err != nil {
+		return 0, 0, 0, "", err
+	}
+	return priority, weight, port, target, nil
+}
+
+// NameToRData encodes a single domain name as RDATA for a name-bearing record
+// (PTR/CNAME/NS). The name is emitted uncompressed; compression-on-write is a
+// separate concern and Marshal recomputes RDLENGTH from the resulting bytes.
+func NameToRData(name string) ([]byte, error) {
+	return domain_name.EncodeDomainName(name)
+}
+
+// TXTToRData encodes one or more character-strings as TXT RDATA (RFC 1035
+// §3.3.14). Each string is emitted as a single length octet followed by its
+// bytes; a string longer than 255 bytes cannot be represented and is rejected.
+func TXTToRData(strs []string) ([]byte, error) {
+	data := []byte{}
+	for _, s := range strs {
+		if len(s) > 255 {
+			return nil, fmt.Errorf("txt character-string too long: %d bytes, max 255", len(s))
+		}
+		data = append(data, byte(len(s)))
+		data = append(data, []byte(s)...)
+	}
+	return data, nil
+}
+
+// SRVToRData encodes an SRV record's RDATA (RFC 2782): the priority, weight and
+// port as big-endian uint16s followed by the uncompressed target name.
+func SRVToRData(priority uint16, weight uint16, port uint16, target string) ([]byte, error) {
+	data := make([]byte, 6)
+	binary.BigEndian.PutUint16(data[0:2], priority)
+	binary.BigEndian.PutUint16(data[2:4], weight)
+	binary.BigEndian.PutUint16(data[4:6], port)
+
+	nameBuf, err := domain_name.EncodeDomainName(target)
+	if err != nil {
+		return nil, err
+	}
+	data = append(data, nameBuf...)
+	return data, nil
+}

--- a/network/llmnr/resourcerecord/rdata_test.go
+++ b/network/llmnr/resourcerecord/rdata_test.go
@@ -1,0 +1,286 @@
+package resourcerecord_test
+
+import (
+	"bytes"
+	"net"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/llmnr/class"
+	"github.com/TheManticoreProject/Manticore/network/llmnr/domain_name"
+	"github.com/TheManticoreProject/Manticore/network/llmnr/llmnr_type"
+	"github.com/TheManticoreProject/Manticore/network/llmnr/resourcerecord"
+)
+
+// buildRecord marshals a ResourceRecord and unmarshals it back through the
+// message-relative path, returning the decoded record. The record is placed at
+// a non-zero offset inside a synthetic buffer so that any accidental use of a
+// sub-slice origin (rather than the message origin) for RDATA name decoding
+// would surface as a wrong result.
+func buildRecord(t *testing.T, name string, rtype llmnr_type.Type, rdata []byte) resourcerecord.ResourceRecord {
+	t.Helper()
+
+	rr := resourcerecord.ResourceRecord{
+		Name:  domain_name.DomainName(name),
+		Type:  rtype,
+		Class: class.ClassIN,
+		TTL:   30,
+		RData: rdata,
+	}
+	wire, err := rr.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	var decoded resourcerecord.ResourceRecord
+	n, err := decoded.Unmarshal(wire)
+	if err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if n != len(wire) {
+		t.Fatalf("consumed %d bytes, want %d", n, len(wire))
+	}
+	return decoded
+}
+
+func TestAsARoundTrip(t *testing.T) {
+	rdata := resourcerecord.IPv4ToRData("10.7.0.10")
+	rr := resourcerecord.ResourceRecord{Type: llmnr_type.TypeA, RData: rdata}
+
+	ip, err := rr.AsA()
+	if err != nil {
+		t.Fatalf("AsA failed: %v", err)
+	}
+	if !ip.Equal(net.ParseIP("10.7.0.10")) {
+		t.Errorf("AsA = %v, want 10.7.0.10", ip)
+	}
+
+	// Wrong type must be rejected.
+	rr.Type = llmnr_type.TypeAAAA
+	if _, err := rr.AsA(); err == nil {
+		t.Errorf("AsA on non-A record should error")
+	}
+
+	// Wrong length must be rejected.
+	rr = resourcerecord.ResourceRecord{Type: llmnr_type.TypeA, RData: []byte{1, 2, 3}}
+	if _, err := rr.AsA(); err == nil {
+		t.Errorf("AsA with 3-byte rdata should error")
+	}
+}
+
+func TestAsAAAARoundTrip(t *testing.T) {
+	rdata := resourcerecord.IPv6ToRData("2001:db8::1")
+	rr := resourcerecord.ResourceRecord{Type: llmnr_type.TypeAAAA, RData: rdata}
+
+	ip, err := rr.AsAAAA()
+	if err != nil {
+		t.Fatalf("AsAAAA failed: %v", err)
+	}
+	if !ip.Equal(net.ParseIP("2001:db8::1")) {
+		t.Errorf("AsAAAA = %v, want 2001:db8::1", ip)
+	}
+
+	rr = resourcerecord.ResourceRecord{Type: llmnr_type.TypeAAAA, RData: []byte{1, 2, 3}}
+	if _, err := rr.AsAAAA(); err == nil {
+		t.Errorf("AsAAAA with short rdata should error")
+	}
+}
+
+func TestAsPTRRoundTrip(t *testing.T) {
+	rdata, err := resourcerecord.NameToRData("host.example.com")
+	if err != nil {
+		t.Fatalf("NameToRData failed: %v", err)
+	}
+	rr := buildRecord(t, "10.0.0.1.in-addr.arpa", llmnr_type.TypePTR, rdata)
+
+	name, err := rr.AsPTR()
+	if err != nil {
+		t.Fatalf("AsPTR failed: %v", err)
+	}
+	if name != "host.example.com" {
+		t.Errorf("AsPTR = %q, want %q", name, "host.example.com")
+	}
+}
+
+func TestAsCNAMERoundTrip(t *testing.T) {
+	rdata, err := resourcerecord.NameToRData("canonical.example.com")
+	if err != nil {
+		t.Fatalf("NameToRData failed: %v", err)
+	}
+	rr := buildRecord(t, "alias.example.com", llmnr_type.TypeCNAME, rdata)
+
+	name, err := rr.AsCNAME()
+	if err != nil {
+		t.Fatalf("AsCNAME failed: %v", err)
+	}
+	if name != "canonical.example.com" {
+		t.Errorf("AsCNAME = %q, want %q", name, "canonical.example.com")
+	}
+}
+
+func TestAsNSRoundTrip(t *testing.T) {
+	rdata, err := resourcerecord.NameToRData("ns1.example.com")
+	if err != nil {
+		t.Fatalf("NameToRData failed: %v", err)
+	}
+	rr := buildRecord(t, "example.com", llmnr_type.TypeNS, rdata)
+
+	name, err := rr.AsNS()
+	if err != nil {
+		t.Fatalf("AsNS failed: %v", err)
+	}
+	if name != "ns1.example.com" {
+		t.Errorf("AsNS = %q, want %q", name, "ns1.example.com")
+	}
+}
+
+func TestAsTXTRoundTrip(t *testing.T) {
+	want := []string{"hello", "v=spf1 -all"}
+	rdata, err := resourcerecord.TXTToRData(want)
+	if err != nil {
+		t.Fatalf("TXTToRData failed: %v", err)
+	}
+	rr := buildRecord(t, "txt.example.com", llmnr_type.TypeTXT, rdata)
+
+	got, err := rr.AsTXT()
+	if err != nil {
+		t.Fatalf("AsTXT failed: %v", err)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("AsTXT returned %d strings, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("AsTXT[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+
+	// A character-string longer than 255 bytes cannot be encoded.
+	if _, err := resourcerecord.TXTToRData([]string{string(make([]byte, 256))}); err == nil {
+		t.Errorf("TXTToRData with 256-byte string should error")
+	}
+}
+
+func TestAsSRVRoundTrip(t *testing.T) {
+	rdata, err := resourcerecord.SRVToRData(10, 20, 389, "dc.example.com")
+	if err != nil {
+		t.Fatalf("SRVToRData failed: %v", err)
+	}
+	rr := buildRecord(t, "_ldap._tcp.example.com", llmnr_type.TypeSRV, rdata)
+
+	prio, weight, port, target, err := rr.AsSRV()
+	if err != nil {
+		t.Fatalf("AsSRV failed: %v", err)
+	}
+	if prio != 10 || weight != 20 || port != 389 {
+		t.Errorf("AsSRV numbers = (%d,%d,%d), want (10,20,389)", prio, weight, port)
+	}
+	if target != "dc.example.com" {
+		t.Errorf("AsSRV target = %q, want %q", target, "dc.example.com")
+	}
+}
+
+// TestAsPTRCompressedPointer decodes a hand-built PTR record whose PTRDNAME is a
+// 0xC0 compression pointer referencing a name earlier in the message. It must be
+// resolved through the message-relative path (RFC 1035 §4.1.4). The record is
+// decoded via UnmarshalFromMessage at its true offset inside the full buffer.
+func TestAsPTRCompressedPointer(t *testing.T) {
+	// Lay out a message: at offset 0 sits the target name "host.example.com".
+	// A PTR record later in the buffer points its PTRDNAME back to offset 0.
+	target := []byte{
+		4, 'h', 'o', 's', 't',
+		7, 'e', 'x', 'a', 'm', 'p', 'l', 'e',
+		3, 'c', 'o', 'm',
+		0,
+	}
+	msg := append([]byte{}, target...) // target name occupies offsets [0, len(target))
+	rrOffset := len(msg)
+
+	// Record NAME: a single label "1" then root, to keep it simple.
+	msg = append(msg, 1, '1', 0)
+	// TYPE = PTR (12), CLASS = IN (1), TTL = 30
+	msg = append(msg, 0x00, 0x0c, 0x00, 0x01, 0x00, 0x00, 0x00, 0x1e)
+	// RDLENGTH = 2 (a bare compression pointer)
+	msg = append(msg, 0x00, 0x02)
+	// RDATA: 0xC000 -> pointer to offset 0
+	msg = append(msg, 0xc0, 0x00)
+
+	var rr resourcerecord.ResourceRecord
+	n, err := rr.UnmarshalFromMessage(msg, rrOffset)
+	if err != nil {
+		t.Fatalf("UnmarshalFromMessage failed: %v", err)
+	}
+	if rrOffset+n != len(msg) {
+		t.Fatalf("consumed to %d, want %d", rrOffset+n, len(msg))
+	}
+
+	name, err := rr.AsPTR()
+	if err != nil {
+		t.Fatalf("AsPTR failed: %v", err)
+	}
+	if name != "host.example.com" {
+		t.Errorf("AsPTR (compressed) = %q, want %q", name, "host.example.com")
+	}
+}
+
+// TestAsSRVCompressedTarget decodes a hand-built SRV record whose target is a
+// compression pointer, exercising the same message-relative name resolution for
+// the name that follows the SRV priority/weight/port header.
+func TestAsSRVCompressedTarget(t *testing.T) {
+	target := []byte{
+		2, 'd', 'c',
+		7, 'e', 'x', 'a', 'm', 'p', 'l', 'e',
+		3, 'c', 'o', 'm',
+		0,
+	}
+	msg := append([]byte{}, target...)
+	rrOffset := len(msg)
+
+	msg = append(msg, 1, 's', 0) // record NAME
+	// TYPE = SRV (33), CLASS = IN (1), TTL = 30
+	msg = append(msg, 0x00, 0x21, 0x00, 0x01, 0x00, 0x00, 0x00, 0x1e)
+	// RDLENGTH = 8 (priority + weight + port + 2-byte pointer)
+	msg = append(msg, 0x00, 0x08)
+	// priority=1, weight=2, port=88, target -> pointer to offset 0
+	msg = append(msg, 0x00, 0x01, 0x00, 0x02, 0x00, 0x58, 0xc0, 0x00)
+
+	var rr resourcerecord.ResourceRecord
+	if _, err := rr.UnmarshalFromMessage(msg, rrOffset); err != nil {
+		t.Fatalf("UnmarshalFromMessage failed: %v", err)
+	}
+
+	prio, weight, port, tgt, err := rr.AsSRV()
+	if err != nil {
+		t.Fatalf("AsSRV failed: %v", err)
+	}
+	if prio != 1 || weight != 2 || port != 88 {
+		t.Errorf("AsSRV numbers = (%d,%d,%d), want (1,2,88)", prio, weight, port)
+	}
+	if tgt != "dc.example.com" {
+		t.Errorf("AsSRV target (compressed) = %q, want %q", tgt, "dc.example.com")
+	}
+}
+
+// TestAsAWireSample decodes a hand-built A record and asserts parse-back to the
+// right net.IP.
+func TestAsAWireSample(t *testing.T) {
+	// NAME "x" root, TYPE A, CLASS IN, TTL 30, RDLENGTH 4, RDATA 10.7.0.10
+	msg := []byte{
+		1, 'x', 0,
+		0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x1e,
+		0x00, 0x04, 10, 7, 0, 10,
+	}
+	var rr resourcerecord.ResourceRecord
+	if _, err := rr.Unmarshal(msg); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	ip, err := rr.AsA()
+	if err != nil {
+		t.Fatalf("AsA failed: %v", err)
+	}
+	if !ip.Equal(net.IPv4(10, 7, 0, 10)) {
+		t.Errorf("AsA = %v, want 10.7.0.10", ip)
+	}
+	if !bytes.Equal(ip.To4(), []byte{10, 7, 0, 10}) {
+		t.Errorf("AsA bytes = %v, want [10 7 0 10]", ip.To4())
+	}
+}

--- a/network/llmnr/resourcerecord/resource_record.go
+++ b/network/llmnr/resourcerecord/resource_record.go
@@ -35,6 +35,16 @@ type ResourceRecord struct {
 
 	// The resource data, which contains the actual information associated with the domain name (e.g., an IP address).
 	RData []byte `json:"rdata"`
+
+	// message and rdataOffset retain the context needed to resolve 0xC0
+	// compression pointers embedded inside name-bearing RDATA (PTR/CNAME/NS/SRV).
+	// They are populated by UnmarshalFromMessage: message is the full LLMNR
+	// message buffer and rdataOffset is the absolute offset of RData within it.
+	// When a record is built by hand (rather than decoded from a message) these
+	// stay zero-valued and the typed accessors fall back to decoding names from
+	// RData alone, which resolves correctly only for uncompressed names.
+	message     []byte
+	rdataOffset int
 }
 
 // Marshal converts a ResourceRecord into a byte slice using the LLMNR protocol's wire format.
@@ -129,6 +139,12 @@ func (rr *ResourceRecord) UnmarshalFromMessage(message []byte, offset int) (int,
 	if offset+int(rr.RDLength) > len(message) {
 		return 0, fmt.Errorf("truncated rdata")
 	}
+
+	// Retain the message context so that name-bearing RDATA (PTR/CNAME/NS/SRV)
+	// can resolve compression pointers relative to the start of the message
+	// (RFC 1035 §4.1.4) via the typed accessors below.
+	rr.message = message
+	rr.rdataOffset = offset
 
 	rr.RData = make([]byte, rr.RDLength)
 	copy(rr.RData, message[offset:offset+int(rr.RDLength)])


### PR DESCRIPTION
### Linked Issue
`Closes #949`

### Root Cause
`ResourceRecord.RData` was carried as an opaque `[]byte` for every record type, and the only typed helpers (`IPv4ToRData`/`IPv6ToRData`) were one-directional string-to-bytes encoders. There was no way to parse a decoded response's RDATA back into a usable value, and no support at all for the name-bearing record types (PTR/CNAME/NS/SRV) whose RDATA can contain 0xC0 compression pointers that must be resolved against the start of the enclosing message (RFC 1035 §4.1.4).

### Fix Description
Adds typed RDATA encoders and accessors for the record types commonly seen over LLMNR/DNS:

- `AsA`/`AsAAAA` parse the fixed-length address RDATA back to `net.IP` (and reject wrong length/type).
- `AsPTR`/`AsCNAME`/`AsNS` decode a single domain name from RDATA.
- `AsTXT` splits the one-or-more length-prefixed character-strings (RFC 1035 §3.3.14).
- `AsSRV` returns priority/weight/port + target (RFC 2782).
- `NameToRData`/`TXTToRData`/`SRVToRData` are the matching encoders.

Name-bearing RDATA is decoded through the existing message-relative domain-name decoder. `UnmarshalFromMessage` now retains the full message buffer and the absolute RData offset on the record, so the accessors resolve compression pointers against the message origin rather than an RData sub-slice (avoiding the previously-fixed sub-slice bug). Accessors are keyed off the RR TYPE and error on mismatch; raw `RData` stays available and unmodeled types keep the opaque `[]byte` fallback. `Marshal` continues to recompute RDLENGTH from the encoded RData.

### How Verified
- Unit KATs (`go test ./network/llmnr/... -race`) green: encode->decode round-trips for A/AAAA/PTR/CNAME/NS/TXT/SRV, plus hand-built wire samples for a PTR and an SRV whose target is a `0xC0` compression pointer decoded via the message-relative path, and A/AAAA parse-back to the expected `net.IP`.
- `go build ./...` and `go vet ./network/llmnr/...` clean.
- Live-validated against a real LLMNR responder (10.7.0.10, forcing multicast egress to the correct interface): an A query returned `AsA() -> 10.7.0.10`; an AAAA query returned `AsAAAA() -> fe80::a5f1:9f12:767:d759`; and a reverse PTR query returned `AsPTR() -> "TMP-W-2016"`, decoded through the message-relative name path.

### Test Coverage
**Added:** `network/llmnr/resourcerecord/rdata_test.go` — `TestAsARoundTrip`, `TestAsAAAARoundTrip`, `TestAsPTRRoundTrip`, `TestAsCNAMERoundTrip`, `TestAsNSRoundTrip`, `TestAsTXTRoundTrip`, `TestAsSRVRoundTrip`, `TestAsPTRCompressedPointer`, `TestAsSRVCompressedTarget`, `TestAsAWireSample`.

### Scope of Change
- **Files changed:** `network/llmnr/resourcerecord/rdata.go` (new), `network/llmnr/resourcerecord/rdata_test.go` (new), `network/llmnr/resourcerecord/resource_record.go` (retain message context in `UnmarshalFromMessage`).
- **Submodule pointer updated:** no.
- **Behavioral changes outside the bug fix:** none.

### Risk and Rollout
Low blast radius: additive accessors/encoders plus two unexported fields on `ResourceRecord`; the wire encode/decode path is unchanged apart from recording the message context. Safe to merge without staged rollout.
