### PR TITLE
Add high-level LLMNR resolver API (Fixes #947)

### DIFF
--- a/network/llmnr/llmnr.go
+++ b/network/llmnr/llmnr.go
@@ -1,1 +1,167 @@
+// Package llmnr implements a Link-Local Multicast Name Resolution (LLMNR)
+// client and the message types defined by RFC 4795. LLMNR reuses the DNS
+// message format (RFC 1035) to resolve single-label, link-local names over the
+// multicast group 224.0.0.252 (or FF02::1:3) on UDP/TCP port 5355.
+//
+// The Client type (see client.go) exposes the low-level Query primitive, which
+// sends a single question and returns the raw *message.Message it was answered
+// with. This file layers the high-level resolver API most callers actually
+// want on top of it: Resolve, ResolveA and ResolveAAAA turn a name into a slice
+// of net.IP, and LookupRecords returns the typed resource records answering a
+// name for a given type. Each helper reuses the typed RDATA accessors on
+// resourcerecord.ResourceRecord (AsA/AsAAAA/…) to decode answers rather than
+// walking the wire format by hand.
+//
+// No-answer semantics: when a responder replies but its answer section carries
+// no record matching the queried name and type, the resolver helpers return an
+// empty (non-nil) slice and a nil error, i.e. "resolved to nothing" is not an
+// error. A genuine failure to obtain any response (the query timing out because
+// no host on the link owns the name, or the caller's context being cancelled)
+// is surfaced as the error returned by Client.Query.
+//
+// Usage example:
+//
+//	client, err := llmnr.NewClient()
+//	if err != nil {
+//	    log.Fatalf("failed to create client: %v", err)
+//	}
+//	defer client.Close()
+//
+//	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+//	defer cancel()
+//
+//	ips, err := client.Resolve(ctx, "wpad")
+//	if err != nil {
+//	    log.Fatalf("resolve failed: %v", err)
+//	}
+//	for _, ip := range ips {
+//	    fmt.Println(ip)
+//	}
 package llmnr
+
+import (
+	"context"
+	"net"
+	"strings"
+
+	"github.com/TheManticoreProject/Manticore/network/llmnr/llmnr_type"
+	"github.com/TheManticoreProject/Manticore/network/llmnr/resourcerecord"
+)
+
+// LookupRecords sends an LLMNR query for name and qtype and returns the answer
+// records that actually answer it: only records whose owner name matches name
+// (compared case-insensitively, as DNS names are case-insensitive) and whose
+// type equals qtype are returned. This filtering discards any unrelated records
+// a responder may have bundled into the answer section.
+//
+// The returned slice is always non-nil; a response that carries no matching
+// record yields an empty slice and a nil error (see the package-level no-answer
+// semantics). An error is returned only when the underlying query fails to
+// obtain a response (timeout or context cancellation).
+func (c *Client) LookupRecords(ctx context.Context, name string, qtype llmnr_type.Type) ([]resourcerecord.ResourceRecord, error) {
+	resp, err := c.Query(ctx, name, qtype)
+	if err != nil {
+		return nil, err
+	}
+
+	records := make([]resourcerecord.ResourceRecord, 0, len(resp.Answers))
+	for _, rr := range resp.Answers {
+		if rr.Type != qtype {
+			continue
+		}
+		if !strings.EqualFold(string(rr.Name), name) {
+			continue
+		}
+		records = append(records, rr)
+	}
+	return records, nil
+}
+
+// ResolveA resolves name to its IPv4 addresses by issuing a Type A LLMNR query
+// and decoding every matching A answer with resourcerecord.AsA. The returned
+// slice is always non-nil and holds one net.IP per A record answering name (an
+// empty slice when the responder returned none). An error is returned only when
+// the query itself fails (timeout or context cancellation); a malformed A record
+// is skipped rather than failing the whole resolution.
+func (c *Client) ResolveA(ctx context.Context, name string) ([]net.IP, error) {
+	records, err := c.LookupRecords(ctx, name, llmnr_type.TypeA)
+	if err != nil {
+		return nil, err
+	}
+
+	ips := make([]net.IP, 0, len(records))
+	for i := range records {
+		ip, err := records[i].AsA()
+		if err != nil {
+			continue
+		}
+		ips = append(ips, ip)
+	}
+	return ips, nil
+}
+
+// ResolveAAAA resolves name to its IPv6 addresses by issuing a Type AAAA LLMNR
+// query and decoding every matching AAAA answer with resourcerecord.AsAAAA. The
+// returned slice is always non-nil and holds one net.IP per AAAA record
+// answering name (an empty slice when the responder returned none). An error is
+// returned only when the query itself fails (timeout or context cancellation); a
+// malformed AAAA record is skipped rather than failing the whole resolution.
+func (c *Client) ResolveAAAA(ctx context.Context, name string) ([]net.IP, error) {
+	records, err := c.LookupRecords(ctx, name, llmnr_type.TypeAAAA)
+	if err != nil {
+		return nil, err
+	}
+
+	ips := make([]net.IP, 0, len(records))
+	for i := range records {
+		ip, err := records[i].AsAAAA()
+		if err != nil {
+			continue
+		}
+		ips = append(ips, ip)
+	}
+	return ips, nil
+}
+
+// Resolve resolves name to all of its IPv4 and IPv6 addresses by issuing both a
+// Type A and a Type AAAA query concurrently and concatenating their results
+// (A addresses first, then AAAA). The two queries run in parallel so the
+// combined lookup is not slower than a single one.
+//
+// Because a host commonly owns only one address family, Resolve is deliberately
+// lenient: it returns the addresses from whichever query succeeded and only
+// propagates an error when both queries failed, in which case the A query's
+// error is returned. The returned slice is always non-nil; it is empty when the
+// name resolved to no addresses at all.
+func (c *Client) Resolve(ctx context.Context, name string) ([]net.IP, error) {
+	type result struct {
+		ips []net.IP
+		err error
+	}
+
+	aChan := make(chan result, 1)
+	aaaaChan := make(chan result, 1)
+
+	go func() {
+		ips, err := c.ResolveA(ctx, name)
+		aChan <- result{ips: ips, err: err}
+	}()
+	go func() {
+		ips, err := c.ResolveAAAA(ctx, name)
+		aaaaChan <- result{ips: ips, err: err}
+	}()
+
+	a := <-aChan
+	aaaa := <-aaaaChan
+
+	// Only fail when neither address family could be obtained; a host owning
+	// just A (or just AAAA) records must still resolve successfully.
+	if a.err != nil && aaaa.err != nil {
+		return nil, a.err
+	}
+
+	ips := make([]net.IP, 0, len(a.ips)+len(aaaa.ips))
+	ips = append(ips, a.ips...)
+	ips = append(ips, aaaa.ips...)
+	return ips, nil
+}

--- a/network/llmnr/resolver_test.go
+++ b/network/llmnr/resolver_test.go
@@ -1,0 +1,244 @@
+package llmnr
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/TheManticoreProject/Manticore/network/llmnr/message"
+)
+
+// newTestClient returns a client whose destination is addr and whose jitter is
+// disabled, so resolver tests drive the loopback responder deterministically and
+// without any pre-send delay.
+func newTestClient(t *testing.T, addr *net.UDPAddr) *Client {
+	t.Helper()
+
+	c, err := NewClient()
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	c.dest = addr
+	c.jitterInterval = 0
+	return c
+}
+
+// respondWithAnswers builds a responder that echoes the query's transaction ID
+// and question and answers it with the supplied A and AAAA addresses, so a
+// single responder can serve ResolveA, ResolveAAAA and Resolve.
+func respondWithAnswers(aIPs []string, aaaaIPs []string) func(query []byte, from *net.UDPAddr) []byte {
+	return func(query []byte, _ *net.UDPAddr) []byte {
+		m := message.NewMessage()
+		if _, err := m.Unmarshal(query); err != nil || len(m.Questions) == 0 {
+			return nil
+		}
+		name := string(m.Questions[0].Name)
+
+		resp := message.NewMessage()
+		resp.Header.Identifier = m.Header.Identifier
+		resp.SetResponse()
+
+		// Echo the exact question that was asked so the client's response
+		// validation accepts the reply for the pending query.
+		if err := resp.AddQuestion(name, m.Questions[0].Type, m.Questions[0].Class); err != nil {
+			return nil
+		}
+		for _, ip := range aIPs {
+			if err := resp.AddAnswerClassINTypeA(name, ip); err != nil {
+				return nil
+			}
+		}
+		for _, ip := range aaaaIPs {
+			if err := resp.AddAnswerClassINTypeAAAA(name, ip); err != nil {
+				return nil
+			}
+		}
+
+		encoded, err := resp.Marshal()
+		if err != nil {
+			return nil
+		}
+		return encoded
+	}
+}
+
+// ipsToStrings renders a slice of net.IP as strings for assertions.
+func ipsToStrings(ips []net.IP) []string {
+	out := make([]string, 0, len(ips))
+	for _, ip := range ips {
+		out = append(out, ip.String())
+	}
+	return out
+}
+
+// containsIP reports whether want (an IP string) appears in got.
+func containsIP(got []net.IP, want string) bool {
+	for _, ip := range got {
+		if ip.String() == want {
+			return true
+		}
+	}
+	return false
+}
+
+// TestResolveAReturnsIPv4 checks that ResolveA collects every A answer into the
+// returned []net.IP.
+func TestResolveAReturnsIPv4(t *testing.T) {
+	addr, cleanup := startResponder(t, respondWithAnswers([]string{"10.7.0.10", "10.7.0.11"}, nil))
+	defer cleanup()
+
+	c := newTestClient(t, addr)
+	defer c.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	ips, err := c.ResolveA(ctx, "host.local")
+	if err != nil {
+		t.Fatalf("ResolveA() error = %v", err)
+	}
+	if len(ips) != 2 {
+		t.Fatalf("ResolveA() returned %d IPs (%v), want 2", len(ips), ipsToStrings(ips))
+	}
+	if !containsIP(ips, "10.7.0.10") || !containsIP(ips, "10.7.0.11") {
+		t.Errorf("ResolveA() = %v, want to contain 10.7.0.10 and 10.7.0.11", ipsToStrings(ips))
+	}
+}
+
+// TestResolveAAAAReturnsIPv6 checks that ResolveAAAA collects AAAA answers.
+func TestResolveAAAAReturnsIPv6(t *testing.T) {
+	addr, cleanup := startResponder(t, respondWithAnswers(nil, []string{"fe80::1"}))
+	defer cleanup()
+
+	c := newTestClient(t, addr)
+	defer c.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	ips, err := c.ResolveAAAA(ctx, "host.local")
+	if err != nil {
+		t.Fatalf("ResolveAAAA() error = %v", err)
+	}
+	if len(ips) != 1 {
+		t.Fatalf("ResolveAAAA() returned %d IPs (%v), want 1", len(ips), ipsToStrings(ips))
+	}
+	if !containsIP(ips, "fe80::1") {
+		t.Errorf("ResolveAAAA() = %v, want to contain fe80::1", ipsToStrings(ips))
+	}
+}
+
+// TestResolveReturnsBothFamilies checks that Resolve concatenates the A and AAAA
+// results from the two concurrent queries.
+func TestResolveReturnsBothFamilies(t *testing.T) {
+	addr, cleanup := startResponder(t, respondWithAnswers([]string{"10.7.0.10"}, []string{"fe80::1"}))
+	defer cleanup()
+
+	c := newTestClient(t, addr)
+	defer c.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	ips, err := c.Resolve(ctx, "host.local")
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if len(ips) != 2 {
+		t.Fatalf("Resolve() returned %d IPs (%v), want 2", len(ips), ipsToStrings(ips))
+	}
+	if !containsIP(ips, "10.7.0.10") || !containsIP(ips, "fe80::1") {
+		t.Errorf("Resolve() = %v, want to contain 10.7.0.10 and fe80::1", ipsToStrings(ips))
+	}
+}
+
+// TestResolveAFiltersMismatchedName verifies that answers whose owner name does
+// not match the queried name are filtered out, so a responder that pads the
+// answer section with an unrelated A record cannot leak into the result.
+func TestResolveAFiltersMismatchedName(t *testing.T) {
+	addr, cleanup := startResponder(t, func(query []byte, _ *net.UDPAddr) []byte {
+		m := message.NewMessage()
+		if _, err := m.Unmarshal(query); err != nil || len(m.Questions) == 0 {
+			return nil
+		}
+		name := string(m.Questions[0].Name)
+
+		resp := message.NewMessage()
+		resp.Header.Identifier = m.Header.Identifier
+		resp.SetResponse()
+		if err := resp.AddQuestion(name, m.Questions[0].Type, m.Questions[0].Class); err != nil {
+			return nil
+		}
+		// The requested name resolves to 10.7.0.10; an unrelated name is also
+		// present and must be discarded by the resolver's name filter.
+		if err := resp.AddAnswerClassINTypeA(name, "10.7.0.10"); err != nil {
+			return nil
+		}
+		if err := resp.AddAnswerClassINTypeA("other.local", "10.7.0.99"); err != nil {
+			return nil
+		}
+		encoded, err := resp.Marshal()
+		if err != nil {
+			return nil
+		}
+		return encoded
+	})
+	defer cleanup()
+
+	c := newTestClient(t, addr)
+	defer c.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	ips, err := c.ResolveA(ctx, "host.local")
+	if err != nil {
+		t.Fatalf("ResolveA() error = %v", err)
+	}
+	if len(ips) != 1 || !containsIP(ips, "10.7.0.10") {
+		t.Errorf("ResolveA() = %v, want exactly [10.7.0.10]", ipsToStrings(ips))
+	}
+}
+
+// TestResolveANoAnswerReturnsEmpty verifies the documented no-answer semantics:
+// a response that echoes the question but carries no matching record yields an
+// empty, non-nil slice and a nil error rather than an error.
+func TestResolveANoAnswerReturnsEmpty(t *testing.T) {
+	addr, cleanup := startResponder(t, func(query []byte, _ *net.UDPAddr) []byte {
+		m := message.NewMessage()
+		if _, err := m.Unmarshal(query); err != nil || len(m.Questions) == 0 {
+			return nil
+		}
+		resp := message.NewMessage()
+		resp.Header.Identifier = m.Header.Identifier
+		resp.SetResponse()
+		// Echo the question but supply no answers at all.
+		if err := resp.AddQuestion(string(m.Questions[0].Name), m.Questions[0].Type, m.Questions[0].Class); err != nil {
+			return nil
+		}
+		encoded, err := resp.Marshal()
+		if err != nil {
+			return nil
+		}
+		return encoded
+	})
+	defer cleanup()
+
+	c := newTestClient(t, addr)
+	defer c.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	ips, err := c.ResolveA(ctx, "host.local")
+	if err != nil {
+		t.Fatalf("ResolveA() error = %v, want nil for a no-answer response", err)
+	}
+	if ips == nil {
+		t.Fatal("ResolveA() returned a nil slice, want empty non-nil slice")
+	}
+	if len(ips) != 0 {
+		t.Errorf("ResolveA() = %v, want an empty slice", ipsToStrings(ips))
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #947`

### Motivation
`Client.Query` returned a raw `*message.Message`, forcing every caller to walk the answer section by hand, and `network/llmnr/llmnr.go` was an empty package stub. This adds the ergonomic `Resolve(name) -> []net.IP` entry point the package was missing, giving the client side a usable public surface parallel to the server.

### Change Description
Adds resolver helpers on `Client`, layered on the existing `Query` and the typed RDATA accessors:

- `LookupRecords(ctx, name, qtype)` — issues a query and returns the answer records matching the queried name (case-insensitively) and type.
- `ResolveA(ctx, name) ([]net.IP, error)` — collects all A answers via `ResourceRecord.AsA`.
- `ResolveAAAA(ctx, name) ([]net.IP, error)` — collects all AAAA answers via `ResourceRecord.AsAAAA`.
- `Resolve(ctx, name) ([]net.IP, error)` — runs the A and AAAA queries concurrently and returns their combined addresses; fails only when both families fail (a host commonly owns just one).

The empty `llmnr.go` is populated with these methods, a package doc comment documenting the no-answer semantics, and a usage example.

**No-answer semantics:** a response that carries no matching record yields an empty, non-nil slice and a nil error; only a failure to obtain any response (timeout / context cancellation) is surfaced as an error.

### How Verified
- `go build ./...`, `go vet ./network/llmnr/...` clean; `go test ./network/llmnr/ -race` green (a pre-existing, unrelated race in the `network/llmnr/server` subpackage is not touched by this change).
- Unit tests using the loopback-responder harness assert `ResolveA`/`ResolveAAAA`/`Resolve` return the right IPs, that mismatched-name answers are filtered out, and the empty-slice no-answer behavior.
- Live-validated against a lab LLMNR responder (domain TMP-W-2016.local): `ResolveA("TMP-W-2016")` returned `[10.7.0.10]`, `ResolveAAAA` returned the host's link-local address, and `Resolve` returned both.

Type codes cross-checked against RFC 4795 (LLMNR reuses the RFC 1035 DNS message format): A = 1 (RFC 1035 §3.4.1), AAAA = 28 (RFC 3596).

### Test Coverage
**Added:** `network/llmnr/resolver_test.go` — `TestResolveAReturnsIPv4`, `TestResolveAAAAReturnsIPv6`, `TestResolveReturnsBothFamilies`, `TestResolveAFiltersMismatchedName`, `TestResolveANoAnswerReturnsEmpty`.

### Scope of Change
- **Files changed:** `network/llmnr/llmnr.go`, `network/llmnr/resolver_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none