### PR TITLE
Add IPv6 multicast querying to the LLMNR client (Fixes #948)

### DIFF
--- a/network/llmnr/client.go
+++ b/network/llmnr/client.go
@@ -129,9 +129,91 @@ type Client struct {
 //	}
 //	fmt.Printf("Received response: %v\n", resp)
 func NewClient() (*Client, error) {
-	conn, err := net.ListenUDP("udp4", &net.UDPAddr{})
+	return newClient("udp4", "")
+}
+
+// NewClientForInterface creates a new LLMNR client bound to a specific address
+// family and (optionally) a specific network interface.
+//
+// It is the entry point for querying over IPv6 multicast, which the default
+// IPv4-only NewClient cannot reach. family selects the socket family and
+// multicast group: "udp4" sends to the IPv4 group 224.0.0.252 (matching
+// NewClient) and "udp6" sends to the IPv6 link-local group FF02::1:3. ifaceName,
+// when non-empty, names the interface the queries are sent out of.
+//
+// An interface is effectively required for "udp6": FF02::1:3 is a link-local
+// (scope 2) multicast address, so the datagram must carry a zone identifying
+// the link it is sent on. On a multi-homed host the interface also overrides the
+// kernel's default multicast egress interface, which is otherwise not
+// necessarily the link carrying the LLMNR traffic of interest. For "udp4" the
+// interface is optional and, when supplied, selects the outgoing multicast
+// interface.
+//
+// The returned client exposes exactly the same Query and resolver API as
+// NewClient; a client created with family "udp6" resolves over IPv6 (e.g.
+// ResolveAAAA leaves over the IPv6 group), while responses are still validated
+// as coming from a plausible on-link/link-local/loopback source.
+//
+// Usage example:
+//
+//	client, err := NewClientForInterface("udp6", "eth0")
+//	if err != nil {
+//	    log.Fatalf("Failed to create client: %v", err)
+//	}
+//	defer client.Close()
+//
+//	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+//	defer cancel()
+//
+//	ips, err := client.ResolveAAAA(ctx, "host")
+//	if err != nil {
+//	    log.Fatalf("Query failed: %v", err)
+//	}
+//	fmt.Printf("Resolved: %v\n", ips)
+func NewClientForInterface(family, ifaceName string) (*Client, error) {
+	return newClient(family, ifaceName)
+}
+
+// newClient is the shared constructor behind NewClient and
+// NewClientForInterface. It binds a UDP socket of the requested family, computes
+// the multicast destination (scoping the link-local IPv6 group with the
+// interface zone), selects the outgoing multicast interface when one was
+// requested, and starts the read loop.
+func newClient(family, ifaceName string) (*Client, error) {
+	switch family {
+	case "udp4", "udp6":
+	default:
+		return nil, fmt.Errorf("unsupported address family %q: want \"udp4\" or \"udp6\"", family)
+	}
+
+	conn, err := net.ListenUDP(family, &net.UDPAddr{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create UDP connection: %w", err)
+	}
+
+	// Resolve the requested interface (if any) so it can both scope the
+	// link-local multicast destination and be selected as the outgoing
+	// multicast interface below.
+	var iface *net.Interface
+	if ifaceName != "" {
+		iface, err = net.InterfaceByName(ifaceName)
+		if err != nil {
+			conn.Close()
+			return nil, fmt.Errorf("failed to look up interface %q: %w", ifaceName, err)
+		}
+	}
+
+	dest := multicastDestination(family, ifaceName)
+
+	// Pin the outgoing multicast interface when one was requested. The
+	// destination Zone already scopes a link-local IPv6 send, but selecting the
+	// interface explicitly is belt-and-braces for IPv6 and the only lever for
+	// IPv4 on a multi-homed host.
+	if iface != nil {
+		if err := setOutgoingMulticastInterface(conn, family, iface); err != nil {
+			conn.Close()
+			return nil, fmt.Errorf("failed to select multicast interface %q: %w", ifaceName, err)
+		}
 	}
 
 	c := &Client{
@@ -139,12 +221,9 @@ func NewClient() (*Client, error) {
 		// Overall budget for a query. Per RFC 4795 §7 the LLMNR timeout is a
 		// protocol constant rather than a user-tunable value, so it defaults to
 		// constants.LLMNRTimeout instead of an arbitrary hardcoded duration.
-		Timeout: constants.LLMNRTimeout,
-		Closed:  make(chan struct{}),
-		dest: &net.UDPAddr{
-			IP:   net.ParseIP(constants.IPv4MulticastAddr),
-			Port: constants.ListenPort,
-		},
+		Timeout:            constants.LLMNRTimeout,
+		Closed:             make(chan struct{}),
+		dest:               dest,
 		localNets:          localUnicastNetworks(),
 		jitterInterval:     constants.JitterInterval,
 		retransmitInterval: constants.LLMNRTimeout,
@@ -153,6 +232,26 @@ func NewClient() (*Client, error) {
 	go c.readLoop()
 
 	return c, nil
+}
+
+// multicastDestination returns the default LLMNR multicast destination for the
+// given address family. For "udp4" it is the IPv4 group 224.0.0.252; for "udp6"
+// it is the IPv6 link-local group FF02::1:3 with its Zone set to ifaceName.
+// FF02::1:3 has link-local (scope 2) reach, so a zone identifying the link is
+// required for the kernel to pick an outgoing interface for the send; leaving it
+// empty yields an unscoped address that a link-local multicast send cannot use.
+func multicastDestination(family, ifaceName string) *net.UDPAddr {
+	if family == "udp6" {
+		return &net.UDPAddr{
+			IP:   net.ParseIP(constants.IPv6MulticastAddr),
+			Port: constants.ListenPort,
+			Zone: ifaceName,
+		}
+	}
+	return &net.UDPAddr{
+		IP:   net.ParseIP(constants.IPv4MulticastAddr),
+		Port: constants.ListenPort,
+	}
 }
 
 // localUnicastNetworks returns the unicast IP networks configured on the host's

--- a/network/llmnr/client_test.go
+++ b/network/llmnr/client_test.go
@@ -114,6 +114,210 @@ func TestNewClient(t *testing.T) {
 	}
 }
 
+// startResponder6 is the IPv6 analogue of startResponder: it binds a udp6
+// loopback socket (::1) acting as a fake LLMNR responder and replies to each
+// datagram with whatever respond returns. It exercises the client's IPv6 send
+// path without touching the real FF02::1:3 multicast group.
+func startResponder6(t *testing.T, respond func(query []byte, from *net.UDPAddr) []byte) (*net.UDPAddr, func()) {
+	t.Helper()
+
+	conn, err := net.ListenUDP("udp6", &net.UDPAddr{IP: net.IPv6loopback})
+	if err != nil {
+		t.Fatalf("failed to start IPv6 responder: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		buf := make([]byte, constants.MaxPacketSize)
+		for {
+			_ = conn.SetReadDeadline(time.Now().Add(50 * time.Millisecond))
+			n, addr, err := conn.ReadFromUDP(buf)
+			select {
+			case <-done:
+				return
+			default:
+			}
+			if err != nil {
+				continue
+			}
+			if reply := respond(append([]byte(nil), buf[:n]...), addr); reply != nil {
+				_, _ = conn.WriteToUDP(reply, addr)
+			}
+		}
+	}()
+
+	return conn.LocalAddr().(*net.UDPAddr), func() {
+		close(done)
+		conn.Close()
+	}
+}
+
+// echoAnswerAAAA builds a well-formed LLMNR response echoing the query's
+// transaction ID and answering the first question with a Type AAAA record
+// pointing at ip. Returns nil if the query cannot be parsed or has no question.
+func echoAnswerAAAA(query []byte, ip string) []byte {
+	m := message.NewMessage()
+	if _, err := m.Unmarshal(query); err != nil {
+		return nil
+	}
+	if len(m.Questions) == 0 {
+		return nil
+	}
+
+	resp := message.NewMessage()
+	resp.Header.Identifier = m.Header.Identifier
+	resp.SetResponse()
+	if err := resp.AddAnswerClassINTypeAAAA(string(m.Questions[0].Name), ip); err != nil {
+		return nil
+	}
+
+	encoded, err := resp.Marshal()
+	if err != nil {
+		return nil
+	}
+	return encoded
+}
+
+// TestMulticastDestination checks the per-family default destination: IPv4 uses
+// the 224.0.0.252 group with no zone, while IPv6 uses the FF02::1:3 link-local
+// group with the interface name appended as the zone (scope), which is required
+// for a link-local multicast send. The zone must surface in the address's string
+// form as "%iface".
+func TestMulticastDestination(t *testing.T) {
+	v4 := multicastDestination("udp4", "")
+	if got := v4.IP.String(); got != constants.IPv4MulticastAddr {
+		t.Errorf("multicastDestination(udp4) IP = %q, want %q", got, constants.IPv4MulticastAddr)
+	}
+	if v4.Port != constants.ListenPort {
+		t.Errorf("multicastDestination(udp4) Port = %d, want %d", v4.Port, constants.ListenPort)
+	}
+	if v4.Zone != "" {
+		t.Errorf("multicastDestination(udp4) Zone = %q, want empty", v4.Zone)
+	}
+
+	v6 := multicastDestination("udp6", "eth0")
+	if !v6.IP.Equal(net.ParseIP(constants.IPv6MulticastAddr)) {
+		t.Errorf("multicastDestination(udp6) IP = %q, want %q", v6.IP, constants.IPv6MulticastAddr)
+	}
+	if v6.Port != constants.ListenPort {
+		t.Errorf("multicastDestination(udp6) Port = %d, want %d", v6.Port, constants.ListenPort)
+	}
+	if v6.Zone != "eth0" {
+		t.Errorf("multicastDestination(udp6) Zone = %q, want %q", v6.Zone, "eth0")
+	}
+	// The zone must appear in the wire/string form so the kernel scopes the send
+	// to the named link (e.g. "[ff02::1:3%eth0]:5355").
+	if got := v6.String(); !strings.Contains(got, "%eth0") {
+		t.Errorf("multicastDestination(udp6) String = %q, want it to contain %q", got, "%eth0")
+	}
+}
+
+// TestNewClientForInterfaceRejectsBadFamily confirms an unsupported address
+// family is rejected rather than silently binding the wrong socket.
+func TestNewClientForInterfaceRejectsBadFamily(t *testing.T) {
+	if _, err := NewClientForInterface("udp7", ""); err == nil {
+		t.Error("NewClientForInterface(udp7) error = nil, want an unsupported-family error")
+	}
+}
+
+// TestNewClientForInterfaceIPv6 constructs an IPv6 client bound to the loopback
+// interface (present on every host, so the test stays offline) and verifies it
+// targets the FF02::1:3 group on the RFC 4795 port with the interface set as the
+// destination zone. This also exercises selecting the outgoing multicast
+// interface, which must not fail construction.
+func TestNewClientForInterfaceIPv6(t *testing.T) {
+	c, err := NewClientForInterface("udp6", "lo")
+	if err != nil {
+		t.Fatalf("NewClientForInterface(udp6, lo) error = %v", err)
+	}
+	defer c.Close()
+
+	if c.Conn == nil {
+		t.Error("NewClientForInterface() Conn is nil")
+	}
+	if c.dest == nil {
+		t.Fatal("NewClientForInterface() dest is nil")
+	}
+	if !c.dest.IP.Equal(net.ParseIP(constants.IPv6MulticastAddr)) {
+		t.Errorf("NewClientForInterface() dest IP = %q, want %q", c.dest.IP, constants.IPv6MulticastAddr)
+	}
+	if c.dest.Port != constants.ListenPort {
+		t.Errorf("NewClientForInterface() dest Port = %d, want %d", c.dest.Port, constants.ListenPort)
+	}
+	if c.dest.Zone != "lo" {
+		t.Errorf("NewClientForInterface() dest Zone = %q, want %q", c.dest.Zone, "lo")
+	}
+}
+
+// TestNewClientForInterfaceUnknownInterface confirms that naming an interface
+// that does not exist fails construction (and does not leak the socket).
+func TestNewClientForInterfaceUnknownInterface(t *testing.T) {
+	if _, err := NewClientForInterface("udp6", "definitely-not-an-iface0"); err == nil {
+		t.Error("NewClientForInterface() error = nil, want an interface-lookup error")
+	}
+}
+
+// TestClientQueryDispatchIPv6 drives a full query through an IPv6 (udp6) client
+// against a ::1 loopback responder, proving the IPv6 send/receive path resolves
+// end to end. The responder answers with an AAAA record and the client's source
+// validation must accept the loopback responder.
+func TestClientQueryDispatchIPv6(t *testing.T) {
+	addr, cleanup := startResponder6(t, func(query []byte, _ *net.UDPAddr) []byte {
+		return echoAnswerAAAA(query, "fe80::1")
+	})
+	defer cleanup()
+
+	c, err := NewClientForInterface("udp6", "")
+	if err != nil {
+		t.Fatalf("NewClientForInterface(udp6) error = %v", err)
+	}
+	defer c.Close()
+	// Direct the query at the loopback responder instead of the FF02::1:3 group.
+	c.dest = addr
+	c.jitterInterval = 0
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	resp, err := c.Query(ctx, "host", llmnr_type.TypeAAAA)
+	if err != nil {
+		t.Fatalf("Query() error = %v", err)
+	}
+	if len(resp.Answers) != 1 {
+		t.Fatalf("Query() answers = %d, want 1", len(resp.Answers))
+	}
+	if got := net.IP(resp.Answers[0].RData).String(); got != "fe80::1" {
+		t.Errorf("Query() answer RDATA = %q, want %q", got, "fe80::1")
+	}
+}
+
+// TestResolveAAAAOverIPv6 exercises the resolver helper over an IPv6 client and
+// the ::1 loopback responder, confirming ResolveAAAA leaves over the udp6 socket
+// and decodes the AAAA answer.
+func TestResolveAAAAOverIPv6(t *testing.T) {
+	addr, cleanup := startResponder6(t, respondWithAnswers(nil, []string{"fe80::1234"}))
+	defer cleanup()
+
+	c, err := NewClientForInterface("udp6", "")
+	if err != nil {
+		t.Fatalf("NewClientForInterface(udp6) error = %v", err)
+	}
+	defer c.Close()
+	c.dest = addr
+	c.jitterInterval = 0
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	ips, err := c.ResolveAAAA(ctx, "host")
+	if err != nil {
+		t.Fatalf("ResolveAAAA() error = %v", err)
+	}
+	if len(ips) != 1 || !containsIP(ips, "fe80::1234") {
+		t.Errorf("ResolveAAAA() = %v, want [fe80::1234]", ipsToStrings(ips))
+	}
+}
+
 // TestClientQueryDispatch drives a full query against a loopback responder and
 // checks that the matching response is dispatched back through Query, including
 // the answered owner name and A record.

--- a/network/llmnr/multicast_other.go
+++ b/network/llmnr/multicast_other.go
@@ -1,0 +1,14 @@
+//go:build !unix
+
+package llmnr
+
+import "net"
+
+// setOutgoingMulticastInterface is a no-op on platforms where selecting the
+// outgoing multicast interface via a raw socket option is not implemented. The
+// link-local IPv6 destination still carries a zone (see multicastDestination),
+// which the kernel uses to scope the send, so interface selection degrades
+// gracefully rather than failing to build off the unix platforms.
+func setOutgoingMulticastInterface(conn *net.UDPConn, family string, iface *net.Interface) error {
+	return nil
+}

--- a/network/llmnr/multicast_unix.go
+++ b/network/llmnr/multicast_unix.go
@@ -1,0 +1,42 @@
+//go:build unix
+
+package llmnr
+
+import (
+	"fmt"
+	"net"
+	"syscall"
+)
+
+// setOutgoingMulticastInterface pins iface as the interface out of which the
+// client's multicast queries are sent. On a multi-homed host the kernel's
+// default multicast egress interface is frequently not the one carrying the
+// link's LLMNR traffic, so binding the outgoing interface explicitly is what
+// makes interface selection effective.
+//
+// For IPv6 the option is IPV6_MULTICAST_IF (an interface index); for IPv4 it is
+// IP_MULTICAST_IF, set via an ip_mreqn carrying the interface index so the
+// interface can be named by index rather than by address. family is the network
+// string the socket was created with ("udp4" or "udp6").
+func setOutgoingMulticastInterface(conn *net.UDPConn, family string, iface *net.Interface) error {
+	raw, err := conn.SyscallConn()
+	if err != nil {
+		return err
+	}
+
+	var sockErr error
+	ctrlErr := raw.Control(func(fd uintptr) {
+		switch family {
+		case "udp6":
+			sockErr = syscall.SetsockoptInt(int(fd), syscall.IPPROTO_IPV6, syscall.IPV6_MULTICAST_IF, iface.Index)
+		case "udp4":
+			sockErr = syscall.SetsockoptIPMreqn(int(fd), syscall.IPPROTO_IP, syscall.IP_MULTICAST_IF, &syscall.IPMreqn{Ifindex: int32(iface.Index)})
+		default:
+			sockErr = fmt.Errorf("unsupported address family %q", family)
+		}
+	})
+	if ctrlErr != nil {
+		return ctrlErr
+	}
+	return sockErr
+}


### PR DESCRIPTION
### Linked Issue
`Closes #948`

### Summary
The LLMNR client could only query over IPv4 multicast. `NewClient` bound `udp4` and always sent to `224.0.0.252`; the `IPv6MulticastAddr` (`FF02::1:3`) constant was used only by the server. This adds IPv6 multicast querying alongside the existing IPv4 path so IPv6-only and dual-stack responders are reached, as RFC 4795 defines LLMNR for both families.

### What changed
A family-aware constructor `NewClientForInterface(family, ifaceName string)` binds either `udp4` or `udp6` and targets the matching multicast group:

- **`udp6`** sends to `FF02::1:3`. Because that group is link-local (scope 2), the destination carries the interface as its zone (`FF02::1:3%<iface>`), which a link-local multicast send requires. The interface is also pinned as the outgoing multicast interface, so on a multi-homed host queries leave on the intended link rather than the kernel's default multicast egress interface.
- **`udp4`** preserves the existing behavior (group `224.0.0.252`), and can optionally pin an outgoing interface too.

The outgoing-interface socket option (`IPV6_MULTICAST_IF` / `IP_MULTICAST_IF`) lives in a `//go:build unix` helper with a `!unix` no-op fallback, so every platform still builds. `NewClient`, `ResolveA`, `ResolveAAAA` and `Resolve` are unchanged and non-breaking: a client created for `udp6` resolves over IPv6 (`ResolveAAAA` leaves over the `FF02::1:3` group), and the existing response validation already accepts link-local IPv6 sources (`fe80::/10`).

### How Verified
- `go build ./...`, `go vet ./network/llmnr/...`, and `go test ./network/llmnr/... -race` all pass.
- Live-validated against a lab Windows Server 2016 (`TMP-W-2016.local`) over IPv6 multicast on the lab interface: `ResolveAAAA("TMP-W-2016")` returned the host's link-local `fe80::a5f1:9f12:767:d759` and `ResolveA` returned `10.7.0.10`, confirming the query egressed on the selected interface and was answered over `FF02::1:3`.
- Setting the outgoing-interface socket options (`IPV6_MULTICAST_IF`, `IP_MULTICAST_IF` via `ip_mreqn`) verified against the running kernel.

### Test Coverage
**Added** (in `network/llmnr/client_test.go`):
- `TestMulticastDestination` - per-family destination; IPv6 zone appended (`%iface` in the string form).
- `TestNewClientForInterfaceRejectsBadFamily` / `TestNewClientForInterfaceUnknownInterface` - family and interface validation.
- `TestNewClientForInterfaceIPv6` - IPv6 client construction targeting `FF02::1:3` with the interface zone and pinned outgoing interface (`lo`, offline).
- `TestClientQueryDispatchIPv6` / `TestResolveAAAAOverIPv6` - full `udp6` `Query`/`ResolveAAAA` round-trips against a `::1` loopback responder.
Existing IPv4 tests continue to pass unchanged.

### Scope of Change
- **Files changed:** `network/llmnr/client.go`, `network/llmnr/client_test.go`, `network/llmnr/multicast_unix.go` (new), `network/llmnr/multicast_other.go` (new)
- **Submodule pointer updated:** no
- **Behavioral changes outside the enhancement:** none

### Risk and Rollout
Low blast radius: the IPv4 default path and all existing APIs are untouched; IPv6 support is opt-in via the new constructor. Safe to merge without staged rollout.