### PR TITLE
Add LLMNR TCP transport fallback on truncation (Fixes #950)

### DIFF
--- a/cmd/poisoner/main.go
+++ b/cmd/poisoner/main.go
@@ -162,6 +162,9 @@ func main() {
 	var wg sync.WaitGroup
 	runLLMNR(&wg, "udp4", iface, handler, debug)
 	runLLMNR(&wg, "udp6", iface, handler, debug)
+	// Also accept the TCP fallback a querying host uses when its UDP response was
+	// truncated (RFC 4795 §2.4), so large spoofed answers remain recoverable.
+	runLLMNRTCP(&wg, iface, handler, debug)
 	wg.Wait()
 }
 
@@ -192,6 +195,28 @@ func runLLMNR(wg *sync.WaitGroup, network string, iface *net.Interface, handler 
 		defer wg.Done()
 		if err := srv.ListenAndServe(); err != nil {
 			logger.Warnf("%s LLMNR responder stopped: %s", network, err.Error())
+		}
+	}()
+}
+
+// runLLMNRTCP starts the LLMNR TCP responder (RFC 4795 §2.4) with the poisoning
+// handler registered, in its own goroutine tracked by wg. A bind failure is
+// logged rather than fatal so the UDP responders keep working when TCP cannot be
+// bound (e.g. the port is already in use).
+func runLLMNRTCP(wg *sync.WaitGroup, iface *net.Interface, handler server.Handler, debug bool) {
+	srv, err := server.NewIPv4ServerWithHandlers([]server.Handler{handler})
+	if err != nil {
+		logger.Warnf("Failed to create LLMNR TCP responder: %s", err.Error())
+		return
+	}
+	srv.Interface = iface
+	srv.SetDebug(debug)
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := srv.ListenAndServeTCP(); err != nil {
+			logger.Warnf("LLMNR TCP responder stopped: %s", err.Error())
 		}
 	}()
 }

--- a/network/llmnr/client.go
+++ b/network/llmnr/client.go
@@ -23,8 +23,11 @@ import (
 // responses are trivially forgeable and could cross-deliver a wrong answer to a
 // waiting query). See RFC 4795 §2.7.
 type pendingQuery struct {
-	// responseChan receives the validated response for this query.
-	responseChan chan *message.Message
+	// responseChan receives the validated response for this query, together with
+	// the source address it arrived from. The source is needed so that, when a
+	// UDP response has its TC (truncation) bit set, the query can be retried over
+	// TCP to that responder's unicast address (RFC 4795 §2.4).
+	responseChan chan *udpResponse
 
 	// name, qtype and qclass are the question that was sent. A response is only
 	// delivered if its question section echoes this question. The class is
@@ -33,6 +36,14 @@ type pendingQuery struct {
 	name   string
 	qtype  llmnr_type.Type
 	qclass class.Class
+}
+
+// udpResponse pairs a validated UDP response with the address it was received
+// from. The read loop populates it; Query consumes it, using the source address
+// to target the TCP retry when the response is truncated.
+type udpResponse struct {
+	msg  *message.Message
+	from *net.UDPAddr
 }
 
 // Client represents an LLMNR client that can send queries and receive responses.
@@ -92,6 +103,12 @@ type Client struct {
 	// to JITTER_INTERVAL. It defaults to constants.JitterInterval and is
 	// overridable so unit tests can drive it with short, deterministic values.
 	jitterInterval time.Duration
+
+	// tcpPort is the TCP port a truncated response is retried on. RFC 4795 §2.4
+	// fixes the LLMNR TCP port at 5355, so it defaults to constants.ListenPort;
+	// it is overridable so unit tests can point the retry at a loopback TCP
+	// responder bound to an ephemeral port.
+	tcpPort int
 
 	// retransmitInterval is the period on which an unanswered query is
 	// retransmitted. RFC 4795 §2.7: "If an LLMNR query sent over UDP is not
@@ -227,6 +244,7 @@ func newClient(family, ifaceName string) (*Client, error) {
 		localNets:          localUnicastNetworks(),
 		jitterInterval:     constants.JitterInterval,
 		retransmitInterval: constants.LLMNRTimeout,
+		tcpPort:            constants.ListenPort,
 	}
 
 	go c.readLoop()
@@ -293,13 +311,14 @@ func (c *Client) Query(ctx context.Context, name string, qtype llmnr_type.Type) 
 	// Create the response channel and record the outstanding query so the read
 	// loop can validate an incoming response against the exact question that was
 	// asked before delivering it (the transaction ID alone is not enough).
-	responseChan := make(chan *message.Message, 1)
-	c.Queries.Store(msg.Header.Identifier, &pendingQuery{
+	responseChan := make(chan *udpResponse, 1)
+	pq := &pendingQuery{
 		responseChan: responseChan,
 		name:         name,
 		qtype:        qtype,
 		qclass:       class.ClassIN.BaseClass(),
-	})
+	}
+	c.Queries.Store(msg.Header.Identifier, pq)
 	defer c.Queries.Delete(msg.Header.Identifier)
 
 	// Encode the query once; the same bytes are (re)transmitted to the
@@ -341,7 +360,20 @@ func (c *Client) Query(ctx context.Context, name string, qtype llmnr_type.Type) 
 		case <-timeout.C:
 			return nil, fmt.Errorf("query timeout")
 		case resp := <-responseChan:
-			return resp, nil
+			// RFC 4795 §2.4: "If the 'TC' bit is set in an LLMNR response, then
+			// the sender SHOULD resend the LLMNR query over TCP using the unicast
+			// address of the responder as the destination address." Retry over
+			// TCP and, on success, deliver the complete answer in place of the
+			// truncated one (discarding the truncated UDP response). If the TCP
+			// retry fails, fall back to returning the truncated response rather
+			// than failing the query outright, so the records that did fit are
+			// still available to the caller.
+			if resp.msg.Header.Flags.IsTruncation() {
+				if full, err := c.queryTCP(ctx, resp.from, encoded, msg.Header.Identifier, pq); err == nil {
+					return full, nil
+				}
+			}
+			return resp.msg, nil
 		case <-ticker.C:
 			if err := c.transmit(encoded); err != nil {
 				return nil, err
@@ -356,6 +388,78 @@ func (c *Client) transmit(encoded []byte) error {
 		return fmt.Errorf("failed to send query: %w", err)
 	}
 	return nil
+}
+
+// queryTCP re-issues a query over TCP after a truncated UDP response, per RFC
+// 4795 §2.4. It dials the responder's unicast address (from) on the LLMNR TCP
+// port, writes the same encoded query framed with the DNS-over-TCP two-byte
+// length prefix (RFC 1035 §4.2.2), reads the length-prefixed full response, and
+// validates it exactly as the UDP read loop does before returning it: it must be
+// a response, echo the query's transaction ID, and answer the question that was
+// asked. The caller's context and the client timeout bound the dial and the I/O.
+//
+// Parameters:
+//   - ctx: the caller's context; its deadline (if any) bounds the TCP exchange.
+//   - from: the unicast source address of the truncated UDP response.
+//   - encoded: the exact query bytes that were sent over UDP.
+//   - identifier: the query's transaction ID, used to reject a mismatched reply.
+//   - pq: the pending query, used to confirm the response echoes the question.
+//
+// Returns the validated full response, or an error if the dial, framing, read,
+// decode, or validation fails.
+func (c *Client) queryTCP(ctx context.Context, from *net.UDPAddr, encoded []byte, identifier uint16, pq *pendingQuery) (*message.Message, error) {
+	if from == nil || from.IP == nil {
+		return nil, fmt.Errorf("no responder address for TCP retry")
+	}
+
+	port := c.tcpPort
+	if port == 0 {
+		port = constants.ListenPort
+	}
+	raddr := &net.TCPAddr{IP: from.IP, Port: port, Zone: from.Zone}
+
+	dialer := net.Dialer{Timeout: c.Timeout}
+	conn, err := dialer.DialContext(ctx, "tcp", raddr.String())
+	if err != nil {
+		return nil, fmt.Errorf("failed to dial responder over TCP: %w", err)
+	}
+	defer conn.Close()
+
+	// Bound the TCP exchange by the context deadline when present, otherwise by
+	// the client timeout, so a stalled responder cannot hang the query.
+	if deadline, ok := ctx.Deadline(); ok {
+		_ = conn.SetDeadline(deadline)
+	} else {
+		_ = conn.SetDeadline(time.Now().Add(c.Timeout))
+	}
+
+	if err := message.WriteTCPMessage(conn, encoded); err != nil {
+		return nil, fmt.Errorf("failed to send TCP query: %w", err)
+	}
+
+	payload, err := message.ReadTCPMessage(conn)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read TCP response: %w", err)
+	}
+
+	resp := &message.Message{}
+	if _, err := resp.Unmarshal(payload); err != nil {
+		return nil, fmt.Errorf("failed to decode TCP response: %w", err)
+	}
+
+	// Apply the same validation as the UDP path: the reply must be a response,
+	// carry the transaction ID we asked with, and echo our question.
+	if !resp.IsResponse() {
+		return nil, fmt.Errorf("TCP reply is not a response")
+	}
+	if resp.Header.Identifier != identifier {
+		return nil, fmt.Errorf("TCP response transaction ID mismatch")
+	}
+	if !pq.matchesQuestion(resp) {
+		return nil, fmt.Errorf("TCP response does not answer the query")
+	}
+
+	return resp, nil
 }
 
 // jitterDelay blocks for a random duration in the half-open interval
@@ -431,8 +535,14 @@ func (c *Client) readLoop() {
 				continue
 			}
 
+			// Copy the source address: ReadFromUDP hands back an address whose
+			// backing storage it may reuse on the next read, and Query keeps the
+			// address around to target a TCP retry when the response is truncated.
+			from := &net.UDPAddr{IP: append(net.IP(nil), src.IP...), Port: src.Port, Zone: src.Zone}
+
+			delivered := msg
 			select {
-			case pq.responseChan <- &msg:
+			case pq.responseChan <- &udpResponse{msg: &delivered, from: from}:
 			default:
 			}
 		}

--- a/network/llmnr/client_test.go
+++ b/network/llmnr/client_test.go
@@ -14,7 +14,172 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/llmnr/constants"
 	"github.com/TheManticoreProject/Manticore/network/llmnr/llmnr_type"
 	"github.com/TheManticoreProject/Manticore/network/llmnr/message"
+	"github.com/TheManticoreProject/Manticore/network/llmnr/message/header"
 )
+
+// startTCPResponder binds a loopback TCP socket that acts as a fake LLMNR TCP
+// responder. For each accepted connection it reads one DNS-over-TCP framed query
+// (RFC 1035 §4.2.2), passes the query bytes to respond, and writes whatever
+// respond returns (if non-nil) back framed with the two-byte length prefix. It
+// returns the listener's TCP port (to be injected as the client's tcpPort) and a
+// cleanup function that stops the accept loop and closes the socket.
+func startTCPResponder(t *testing.T, respond func(query []byte) []byte) (int, func()) {
+	t.Helper()
+
+	ln, err := net.ListenTCP("tcp4", &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		t.Fatalf("failed to start TCP responder: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			select {
+			case <-done:
+				return
+			default:
+			}
+			if err != nil {
+				continue
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				query, err := message.ReadTCPMessage(c)
+				if err != nil {
+					return
+				}
+				if reply := respond(query); reply != nil {
+					_ = message.WriteTCPMessage(c, reply)
+				}
+			}(conn)
+		}
+	}()
+
+	return ln.Addr().(*net.TCPAddr).Port, func() {
+		close(done)
+		ln.Close()
+	}
+}
+
+// truncatedAnswer builds a well-formed LLMNR response that echoes the query's
+// transaction ID and question but carries the TC (truncation) bit set and no
+// answer records, simulating a responder whose full answer did not fit in a UDP
+// datagram. Returns nil if the query cannot be parsed or has no question.
+func truncatedAnswer(query []byte) []byte {
+	m := message.NewMessage()
+	if _, err := m.Unmarshal(query); err != nil || len(m.Questions) == 0 {
+		return nil
+	}
+
+	resp := message.NewMessage()
+	resp.Header.Identifier = m.Header.Identifier
+	resp.SetResponse()
+	resp.Header.Flags |= header.FlagTC
+	// Echo the question so the client's read loop accepts the response as
+	// matching the outstanding query before acting on the TC bit.
+	if err := resp.AddQuestion(string(m.Questions[0].Name), m.Questions[0].Type, m.Questions[0].Class); err != nil {
+		return nil
+	}
+
+	encoded, err := resp.Marshal()
+	if err != nil {
+		return nil
+	}
+	return encoded
+}
+
+// TestClientTCPFallbackOnTruncation drives the RFC 4795 §2.4 TCP fallback end to
+// end over loopback: a fake UDP responder answers with the TC bit set and no
+// records, and a fake TCP responder serves the complete answer. The client must
+// notice the TC bit, retry the same query over TCP to the responder's address,
+// and deliver the full untruncated answer in place of the truncated UDP one.
+func TestClientTCPFallbackOnTruncation(t *testing.T) {
+	// The TCP responder serves the complete answer (owner name + A record).
+	tcpPort, tcpCleanup := startTCPResponder(t, func(query []byte) []byte {
+		return echoAnswer(query, "10.7.0.10")
+	})
+	defer tcpCleanup()
+
+	// The UDP responder answers with the TC bit set, triggering the TCP retry.
+	udpAddr, udpCleanup := startResponder(t, func(query []byte, _ *net.UDPAddr) []byte {
+		return truncatedAnswer(query)
+	})
+	defer udpCleanup()
+
+	c, err := NewClient()
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	defer c.Close()
+	c.dest = udpAddr
+	c.jitterInterval = 0
+	// Point the TCP retry at the loopback TCP responder's ephemeral port instead
+	// of the fixed RFC port 5355.
+	c.tcpPort = tcpPort
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	resp, err := c.Query(ctx, "host.local", llmnr_type.TypeA)
+	if err != nil {
+		t.Fatalf("Query() error = %v", err)
+	}
+	// The delivered response must be the full TCP answer, not the truncated UDP
+	// one: it carries an answer record and does not have the TC bit set.
+	if resp.Header.Flags.IsTruncation() {
+		t.Error("Query() returned the truncated UDP response, want the full TCP answer")
+	}
+	if len(resp.Answers) != 1 {
+		t.Fatalf("Query() answers = %d, want 1 (from the TCP responder)", len(resp.Answers))
+	}
+	if resp.Answers[0].Name != "host.local" {
+		t.Errorf("Query() answer name = %q, want %q", resp.Answers[0].Name, "host.local")
+	}
+	if got := net.IP(resp.Answers[0].RData).String(); got != "10.7.0.10" {
+		t.Errorf("Query() answer RDATA = %q, want %q", got, "10.7.0.10")
+	}
+}
+
+// TestClientTCPFallbackFailureReturnsTruncated confirms that when the TC bit is
+// set but the TCP retry cannot be completed (nothing is listening on the TCP
+// port), Query degrades gracefully by returning the truncated UDP response
+// rather than failing outright.
+func TestClientTCPFallbackFailureReturnsTruncated(t *testing.T) {
+	udpAddr, udpCleanup := startResponder(t, func(query []byte, _ *net.UDPAddr) []byte {
+		return truncatedAnswer(query)
+	})
+	defer udpCleanup()
+
+	// Reserve a TCP port and immediately release it so the dial is refused.
+	ln, err := net.ListenTCP("tcp4", &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		t.Fatalf("failed to reserve TCP port: %v", err)
+	}
+	deadPort := ln.Addr().(*net.TCPAddr).Port
+	ln.Close()
+
+	c, err := NewClient()
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	defer c.Close()
+	c.dest = udpAddr
+	c.jitterInterval = 0
+	c.tcpPort = deadPort
+	c.Timeout = 500 * time.Millisecond
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	resp, err := c.Query(ctx, "host.local", llmnr_type.TypeA)
+	if err != nil {
+		t.Fatalf("Query() error = %v, want the truncated response returned on TCP failure", err)
+	}
+	if !resp.Header.Flags.IsTruncation() {
+		t.Error("Query() response missing TC bit, want the truncated UDP response on TCP failure")
+	}
+}
 
 // startResponder binds a loopback UDP socket that acts as a fake LLMNR responder
 // and invokes respond for each datagram it receives. Whatever respond returns (if

--- a/network/llmnr/message/message.go
+++ b/network/llmnr/message/message.go
@@ -366,6 +366,75 @@ func (m *Message) Marshal() ([]byte, error) {
 	return marshalledData, nil
 }
 
+// MarshalWithTruncation serializes the message for a datagram transport that
+// cannot carry more than maxSize bytes (for LLMNR over UDP, maxSize is
+// constants.MaxPacketSize). It first encodes the message in full; if the
+// encoding already fits within maxSize it is returned unchanged with truncated
+// == false.
+//
+// Otherwise the message is truncated to fit: the TC (truncation) bit is set in
+// the header and trailing resource records are dropped until the encoding fits,
+// removing additional records first, then authority records, then answers, per
+// the truncation semantics of RFC 1035 §4.1.1. If only the header and questions
+// remain and the encoding still exceeds maxSize, that minimal message is
+// returned with the TC bit set rather than an error. Setting the TC bit on an
+// oversized UDP response is what signals the querying host to retry over TCP
+// (RFC 4795 §2.4).
+//
+// The receiver is not modified: truncation is applied to a copy, so a caller can
+// still send the full message over TCP after learning it did not fit over UDP.
+//
+// Returns:
+//   - The (possibly truncated) encoded message.
+//   - Whether truncation was applied (the TC bit was set and records were dropped).
+//   - An error if encoding fails.
+func (m *Message) MarshalWithTruncation(maxSize int) ([]byte, bool, error) {
+	encoded, err := m.Marshal()
+	if err != nil {
+		return nil, false, err
+	}
+	if len(encoded) <= maxSize {
+		return encoded, false, nil
+	}
+
+	// The full message does not fit: build a truncated copy so the receiver's
+	// message (which the caller may still want to send over TCP) is untouched.
+	// Only the header and the record slices are copied; the slice elements
+	// themselves are not mutated.
+	trunc := *m
+	trunc.Header.Flags |= header.FlagTC
+	trunc.Answers = append([]resourcerecord.ResourceRecord(nil), m.Answers...)
+	trunc.Authority = append([]resourcerecord.ResourceRecord(nil), m.Authority...)
+	trunc.Additional = append([]resourcerecord.ResourceRecord(nil), m.Additional...)
+
+	for {
+		encoded, err = trunc.Marshal()
+		if err != nil {
+			return nil, false, err
+		}
+		if len(encoded) <= maxSize {
+			break
+		}
+
+		// Drop the last record from the least significant section that still has
+		// one, then re-encode. When no records remain, return the minimal
+		// header+questions message with TC set: the querying host will fall back
+		// to TCP to obtain the complete answer.
+		switch {
+		case len(trunc.Additional) > 0:
+			trunc.Additional = trunc.Additional[:len(trunc.Additional)-1]
+		case len(trunc.Authority) > 0:
+			trunc.Authority = trunc.Authority[:len(trunc.Authority)-1]
+		case len(trunc.Answers) > 0:
+			trunc.Answers = trunc.Answers[:len(trunc.Answers)-1]
+		default:
+			return encoded, true, nil
+		}
+	}
+
+	return encoded, true, nil
+}
+
 // Unmarshal decodes a byte slice into the Message receiver. It expects the byte slice to be in the wire format
 // as specified by the LLMNR protocol. The function first checks if the provided data is at least as long as the
 // LLMNR header. It then proceeds to decode the header fields, followed by the question and answer sections.

--- a/network/llmnr/message/tcp.go
+++ b/network/llmnr/message/tcp.go
@@ -1,0 +1,53 @@
+package message
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+)
+
+// WriteTCPMessage writes payload to w framed for DNS-over-TCP transport. Per RFC
+// 1035 §4.2.2 (which RFC 4795 §2.4 adopts for LLMNR over TCP on port 5355), the
+// message is prefixed with a two-byte big-endian length field giving the length
+// of the message, excluding the two length bytes themselves. The prefix and the
+// payload are written together so the framing cannot be split across writes.
+//
+// It returns an error if payload does not fit in the 16-bit length field or if
+// the underlying write fails.
+func WriteTCPMessage(w io.Writer, payload []byte) error {
+	if len(payload) > 0xFFFF {
+		return fmt.Errorf("message too large for TCP framing: %d bytes (max %d)", len(payload), 0xFFFF)
+	}
+
+	framed := make([]byte, 2+len(payload))
+	binary.BigEndian.PutUint16(framed[:2], uint16(len(payload)))
+	copy(framed[2:], payload)
+
+	if _, err := w.Write(framed); err != nil {
+		return fmt.Errorf("failed to write TCP message: %w", err)
+	}
+	return nil
+}
+
+// ReadTCPMessage reads a single DNS-over-TCP framed message from r and returns
+// its payload (without the two-byte length prefix). Per RFC 1035 §4.2.2 it first
+// reads the two-byte big-endian length field, then reads exactly that many bytes
+// of message. io.ReadFull is used for both reads so a short read is reported as
+// an error rather than silently returning a partial message.
+//
+// It returns an error if the length prefix or the announced number of message
+// bytes cannot be fully read.
+func ReadTCPMessage(r io.Reader) ([]byte, error) {
+	lengthPrefix := make([]byte, 2)
+	if _, err := io.ReadFull(r, lengthPrefix); err != nil {
+		return nil, fmt.Errorf("failed to read TCP length prefix: %w", err)
+	}
+
+	length := binary.BigEndian.Uint16(lengthPrefix)
+	payload := make([]byte, length)
+	if _, err := io.ReadFull(r, payload); err != nil {
+		return nil, fmt.Errorf("failed to read TCP message body of %d bytes: %w", length, err)
+	}
+
+	return payload, nil
+}

--- a/network/llmnr/message/tcp_test.go
+++ b/network/llmnr/message/tcp_test.go
@@ -1,0 +1,190 @@
+package message_test
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/llmnr/class"
+	"github.com/TheManticoreProject/Manticore/network/llmnr/constants"
+	"github.com/TheManticoreProject/Manticore/network/llmnr/domain_name"
+	"github.com/TheManticoreProject/Manticore/network/llmnr/llmnr_type"
+	"github.com/TheManticoreProject/Manticore/network/llmnr/message"
+	"github.com/TheManticoreProject/Manticore/network/llmnr/resourcerecord"
+)
+
+// TestWriteReadTCPMessageRoundTrip confirms a payload framed by WriteTCPMessage
+// is recovered byte-for-byte by ReadTCPMessage, and that the on-wire framing is
+// the RFC 1035 §4.2.2 two-byte big-endian length prefix (excluding the prefix
+// itself) followed by the payload.
+func TestWriteReadTCPMessageRoundTrip(t *testing.T) {
+	payload := []byte{0x00, 0x01, 0x02, 0x03, 0xAA, 0xBB}
+
+	var buf bytes.Buffer
+	if err := message.WriteTCPMessage(&buf, payload); err != nil {
+		t.Fatalf("WriteTCPMessage() error = %v", err)
+	}
+
+	framed := buf.Bytes()
+	if len(framed) != len(payload)+2 {
+		t.Fatalf("framed length = %d, want %d (payload + 2-byte prefix)", len(framed), len(payload)+2)
+	}
+	if got := binary.BigEndian.Uint16(framed[:2]); int(got) != len(payload) {
+		t.Errorf("length prefix = %d, want %d (excludes the prefix)", got, len(payload))
+	}
+	if !bytes.Equal(framed[2:], payload) {
+		t.Errorf("framed body = % x, want % x", framed[2:], payload)
+	}
+
+	got, err := message.ReadTCPMessage(&buf)
+	if err != nil {
+		t.Fatalf("ReadTCPMessage() error = %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Errorf("ReadTCPMessage() = % x, want % x", got, payload)
+	}
+}
+
+// TestReadTCPMessageShortPrefix confirms a stream carrying fewer than the two
+// prefix bytes is reported as an error rather than silently succeeding.
+func TestReadTCPMessageShortPrefix(t *testing.T) {
+	if _, err := message.ReadTCPMessage(bytes.NewReader([]byte{0x00})); err == nil {
+		t.Error("ReadTCPMessage() error = nil, want error on a truncated length prefix")
+	}
+}
+
+// TestReadTCPMessageShortBody confirms a stream whose length prefix announces
+// more bytes than are actually present is reported as an error (a short read on
+// the body), rather than returning a partial message.
+func TestReadTCPMessageShortBody(t *testing.T) {
+	// Prefix says 4 bytes, but only 2 follow.
+	stream := []byte{0x00, 0x04, 0xDE, 0xAD}
+	_, err := message.ReadTCPMessage(bytes.NewReader(stream))
+	if err == nil {
+		t.Fatal("ReadTCPMessage() error = nil, want error on a truncated body")
+	}
+	// io.ReadFull surfaces an unexpected EOF for a partial body.
+	if err != io.ErrUnexpectedEOF && !strings.Contains(err.Error(), io.ErrUnexpectedEOF.Error()) {
+		t.Errorf("ReadTCPMessage() error = %v, want it to wrap %v", err, io.ErrUnexpectedEOF)
+	}
+}
+
+// TestReadTCPMessageZeroLength confirms a zero-length prefix yields an empty,
+// non-nil payload and no error (a valid, if empty, frame).
+func TestReadTCPMessageZeroLength(t *testing.T) {
+	got, err := message.ReadTCPMessage(bytes.NewReader([]byte{0x00, 0x00}))
+	if err != nil {
+		t.Fatalf("ReadTCPMessage() error = %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("ReadTCPMessage() = % x, want empty", got)
+	}
+}
+
+// TestMarshalWithTruncationFits confirms that a small message which fits within
+// the limit is returned unchanged, with truncated == false and the TC bit clear.
+func TestMarshalWithTruncationFits(t *testing.T) {
+	m := message.NewMessage()
+	m.SetResponse()
+	if err := m.AddAnswerClassINTypeA("host.local", "10.7.0.10"); err != nil {
+		t.Fatalf("AddAnswerClassINTypeA() error = %v", err)
+	}
+
+	encoded, truncated, err := m.MarshalWithTruncation(constants.MaxPacketSize)
+	if err != nil {
+		t.Fatalf("MarshalWithTruncation() error = %v", err)
+	}
+	if truncated {
+		t.Error("MarshalWithTruncation() truncated = true, want false for a small message")
+	}
+
+	full, err := m.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	if !bytes.Equal(encoded, full) {
+		t.Error("MarshalWithTruncation() changed the encoding of a message that fits")
+	}
+
+	decoded := &message.Message{}
+	if _, err := decoded.Unmarshal(encoded); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if decoded.Header.Flags.IsTruncation() {
+		t.Error("TC bit set on a message that fits within the limit")
+	}
+}
+
+// TestMarshalWithTruncationSetsTC builds a response with enough answer records to
+// exceed the 512-byte UDP limit, then confirms MarshalWithTruncation sets the TC
+// bit, drops records so the result fits within the limit, and still decodes as a
+// well-formed message (its header counts matching the records it retained).
+func TestMarshalWithTruncationSetsTC(t *testing.T) {
+	m := message.NewMessage()
+	m.SetResponse()
+	if err := m.AddQuestion("host.local", llmnr_type.TypeA, class.ClassIN); err != nil {
+		t.Fatalf("AddQuestion() error = %v", err)
+	}
+
+	// Each answer carries a distinct ~30-byte owner name plus a 4-byte A record;
+	// 40 of them comfortably exceed the 512-byte UDP datagram limit. Names are
+	// not compressed on marshal, so this reliably overflows. Answers are added
+	// directly (rather than via AddAnswerClassINTypeA, which would also grow the
+	// question section) so the single question is the only one present.
+	for i := 0; i < 40; i++ {
+		name := strings.Repeat("a", 20) + "-host" + string(rune('a'+i%26)) + ".local"
+		rr := resourcerecord.ResourceRecord{
+			Name:  domain_name.DomainName(name),
+			Type:  llmnr_type.TypeA,
+			Class: class.ClassIN,
+			TTL:   30,
+			RData: resourcerecord.IPv4ToRData("10.7.0.10"),
+		}
+		if err := m.AddAnswer(rr); err != nil {
+			t.Fatalf("AddAnswer(%q) error = %v", name, err)
+		}
+	}
+
+	full, err := m.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	if len(full) <= constants.MaxPacketSize {
+		t.Fatalf("test fixture only %d bytes, want > %d so truncation is exercised", len(full), constants.MaxPacketSize)
+	}
+
+	encoded, truncated, err := m.MarshalWithTruncation(constants.MaxPacketSize)
+	if err != nil {
+		t.Fatalf("MarshalWithTruncation() error = %v", err)
+	}
+	if !truncated {
+		t.Fatal("MarshalWithTruncation() truncated = false, want true for an oversized message")
+	}
+	if len(encoded) > constants.MaxPacketSize {
+		t.Errorf("truncated encoding = %d bytes, want <= %d", len(encoded), constants.MaxPacketSize)
+	}
+
+	// The receiver's message must be left intact (truncation applied to a copy).
+	if m.Header.Flags.IsTruncation() {
+		t.Error("MarshalWithTruncation() mutated the receiver's TC bit")
+	}
+	if len(m.Answers) != 40 {
+		t.Errorf("MarshalWithTruncation() mutated the receiver's answers: got %d, want 40", len(m.Answers))
+	}
+
+	decoded := &message.Message{}
+	if _, err := decoded.Unmarshal(encoded); err != nil {
+		t.Fatalf("Unmarshal(truncated) error = %v", err)
+	}
+	if !decoded.Header.Flags.IsTruncation() {
+		t.Error("truncated response does not have the TC bit set")
+	}
+	if len(decoded.Answers) >= 40 {
+		t.Errorf("truncated response kept %d answers, want fewer than the original 40", len(decoded.Answers))
+	}
+	if err := decoded.Validate(); err != nil {
+		t.Errorf("truncated response is not well-formed: %v", err)
+	}
+}

--- a/network/llmnr/server/response_writer.go
+++ b/network/llmnr/server/response_writer.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/TheManticoreProject/Manticore/network/llmnr/constants"
 	"github.com/TheManticoreProject/Manticore/network/llmnr/message"
 )
 
@@ -46,7 +47,53 @@ func NewResponseWriter(server *Server, remoteAddr net.Addr) ResponseWriter {
 // - An error if the message is nil, if encoding the message fails, or if sending the message fails.
 //
 // The function sets the message as a response, encodes it, and sends it to the remote address using the server's UDP connection.
+//
+// A UDP datagram cannot carry more than constants.MaxPacketSize bytes, so the
+// response is encoded with MarshalWithTruncation: if the full response would
+// exceed that limit it is truncated and the TC (truncation) bit is set, which
+// tells the querying host to retry the same query over TCP (RFC 4795 §2.4) where
+// the complete answer is served by the TCP responder.
 func (w *responseWriter) WriteMessage(msg *message.Message) error {
+	if msg == nil {
+		return fmt.Errorf("message cannot be nil")
+	}
+
+	msg.SetResponse()
+
+	encoded, _, err := msg.MarshalWithTruncation(constants.MaxPacketSize)
+	if err != nil {
+		return fmt.Errorf("failed to encode message: %w", err)
+	}
+
+	_, err = w.Server.Conn.WriteToUDP(encoded, w.RemoteAddr.(*net.UDPAddr))
+
+	return err
+}
+
+// tcpResponseWriter is the ResponseWriter used by the TCP responder. Unlike the
+// UDP writer it never truncates: TCP has no 512-byte datagram limit, so the full
+// answer is written framed with the DNS-over-TCP two-byte length prefix
+// (RFC 1035 §4.2.2). Serving the complete answer over TCP is the whole point of
+// the TC-triggered fallback (RFC 4795 §2.4).
+type tcpResponseWriter struct {
+	conn net.Conn
+}
+
+// newTCPResponseWriter creates a ResponseWriter that writes responses back over
+// the given TCP connection.
+func newTCPResponseWriter(conn net.Conn) ResponseWriter {
+	return &tcpResponseWriter{conn: conn}
+}
+
+// GetRemoteAddr returns the address of the connected TCP peer.
+func (w *tcpResponseWriter) GetRemoteAddr() net.Addr {
+	return w.conn.RemoteAddr()
+}
+
+// WriteMessage marks msg as a response, encodes it in full (no truncation), and
+// writes it to the TCP connection framed with the two-byte big-endian length
+// prefix.
+func (w *tcpResponseWriter) WriteMessage(msg *message.Message) error {
 	if msg == nil {
 		return fmt.Errorf("message cannot be nil")
 	}
@@ -58,7 +105,5 @@ func (w *responseWriter) WriteMessage(msg *message.Message) error {
 		return fmt.Errorf("failed to encode message: %w", err)
 	}
 
-	_, err = w.Server.Conn.WriteToUDP(encoded, w.RemoteAddr.(*net.UDPAddr))
-
-	return err
+	return message.WriteTCPMessage(w.conn, encoded)
 }

--- a/network/llmnr/server/server.go
+++ b/network/llmnr/server/server.go
@@ -40,6 +40,18 @@ type Server struct {
 	// Conn is the connection of the server.
 	Conn *net.UDPConn
 
+	// TCPListenAddr is the address the optional TCP responder binds to when
+	// ListenAndServeTCP is used. RFC 4795 §2.4 requires a responder to listen on
+	// TCP port 5355 on the unicast address(es) it answers from, so this defaults
+	// to ":5355" (all interfaces) when left empty. It is overridable so a caller
+	// can pin the responder to a specific unicast address, and so tests can bind
+	// an ephemeral loopback port.
+	TCPListenAddr string
+
+	// tcpListener is the accepting socket of the optional TCP responder. It is
+	// nil until ListenAndServeTCP binds it, and is closed by Close.
+	tcpListener net.Listener
+
 	// Interface is the network interface on which the multicast group is joined.
 	// When nil the group is joined on the system-default multicast interface
 	// (preserving the previous behavior); setting it lets the server listen on a
@@ -56,6 +68,12 @@ type Server struct {
 	// server has come up without racing on the Conn field.
 	listeningMu sync.RWMutex
 	listening   bool
+
+	// listeningTCP records whether the optional TCP responder socket has been
+	// bound. It is guarded by listeningMu (like listening) so a caller that
+	// started ListenAndServeTCP in the background can observe readiness without a
+	// data race.
+	listeningTCP bool
 
 	// Closed is a channel that is closed when the server is shut down.
 	Closed chan struct{}
@@ -403,10 +421,14 @@ func (s *Server) Close() error {
 		func() {
 			s.listeningMu.Lock()
 			s.listening = false
+			s.listeningTCP = false
 			s.listeningMu.Unlock()
 			close(s.Closed)
 			if s.Conn != nil {
 				s.Conn.Close()
+			}
+			if s.tcpListener != nil {
+				s.tcpListener.Close()
 			}
 		},
 	)

--- a/network/llmnr/server/server_test.go
+++ b/network/llmnr/server/server_test.go
@@ -8,7 +8,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/TheManticoreProject/Manticore/network/llmnr/class"
 	"github.com/TheManticoreProject/Manticore/network/llmnr/constants"
+	"github.com/TheManticoreProject/Manticore/network/llmnr/llmnr_type"
 	"github.com/TheManticoreProject/Manticore/network/llmnr/message"
 	"github.com/TheManticoreProject/Manticore/network/llmnr/server"
 )
@@ -162,6 +164,100 @@ func TestIPv6ServerStartAndStop(t *testing.T) {
 		// Server closed successfully
 	case <-time.After(1 * time.Second):
 		t.Error("Expected server to close within 1 second, but it did not")
+	}
+}
+
+// TestServerTCPRoundTrip exercises the server's TCP responder end to end: it
+// starts ListenAndServeTCP on an ephemeral loopback port, dials it, sends a
+// length-prefixed query (RFC 1035 §4.2.2), and confirms the handler chain runs
+// and a correctly framed, well-formed response comes back.
+func TestServerTCPRoundTrip(t *testing.T) {
+	// Handler that answers every A query for the queried name with 10.7.0.10.
+	answerHandler := func(_ *server.Server, _ net.Addr, w server.ResponseWriter, msg *message.Message) bool {
+		if len(msg.Questions) == 0 {
+			return true
+		}
+		resp := message.NewMessage()
+		resp.Header.Identifier = msg.Header.Identifier
+		resp.SetResponse()
+		if err := resp.AddAnswerClassINTypeA(string(msg.Questions[0].Name), "10.7.0.10"); err != nil {
+			return true
+		}
+		_ = w.WriteMessage(resp)
+		return false
+	}
+
+	srv, err := server.NewIPv4ServerWithHandlers([]server.Handler{server.HandlerFunc(answerHandler)})
+	if err != nil {
+		t.Fatalf("Failed to create server: %v", err)
+	}
+	// Bind an ephemeral loopback port so the test needs no privileges and cannot
+	// collide with a real responder on 5355.
+	srv.TCPListenAddr = "127.0.0.1:0"
+
+	go func() {
+		if err := srv.ListenAndServeTCP(); err != nil {
+			t.Errorf("ListenAndServeTCP() error = %v", err)
+		}
+	}()
+	defer srv.Close()
+
+	// Wait for the TCP responder to come up using the synchronized accessor.
+	deadline := time.Now().Add(2 * time.Second)
+	for !srv.ListeningTCP() {
+		if time.Now().After(deadline) {
+			t.Fatal("TCP responder did not come up within 2s")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	addr := srv.TCPAddr()
+	if addr == nil {
+		t.Fatal("TCPAddr() = nil after the responder came up")
+	}
+
+	conn, err := net.DialTimeout("tcp", addr.String(), 2*time.Second)
+	if err != nil {
+		t.Fatalf("DialTimeout() error = %v", err)
+	}
+	defer conn.Close()
+	_ = conn.SetDeadline(time.Now().Add(2 * time.Second))
+
+	// Build and send a length-prefixed query for "host.local".
+	query := message.NewMessage()
+	query.SetQuery()
+	if err := query.AddQuestion("host.local", llmnr_type.TypeA, class.ClassIN); err != nil {
+		t.Fatalf("AddQuestion() error = %v", err)
+	}
+	encoded, err := query.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	if err := message.WriteTCPMessage(conn, encoded); err != nil {
+		t.Fatalf("WriteTCPMessage() error = %v", err)
+	}
+
+	// Read and decode the length-prefixed response.
+	payload, err := message.ReadTCPMessage(conn)
+	if err != nil {
+		t.Fatalf("ReadTCPMessage() error = %v", err)
+	}
+	resp := &message.Message{}
+	if _, err := resp.Unmarshal(payload); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+
+	if !resp.IsResponse() {
+		t.Error("TCP response does not have the QR (response) bit set")
+	}
+	if resp.Header.Identifier != query.Header.Identifier {
+		t.Errorf("TCP response ID = %d, want %d", resp.Header.Identifier, query.Header.Identifier)
+	}
+	if len(resp.Answers) != 1 {
+		t.Fatalf("TCP response answers = %d, want 1", len(resp.Answers))
+	}
+	if got := net.IP(resp.Answers[0].RData).String(); got != "10.7.0.10" {
+		t.Errorf("TCP response answer RDATA = %q, want %q", got, "10.7.0.10")
 	}
 }
 

--- a/network/llmnr/server/tcp.go
+++ b/network/llmnr/server/tcp.go
@@ -1,0 +1,131 @@
+package server
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/TheManticoreProject/Manticore/logger"
+	"github.com/TheManticoreProject/Manticore/network/llmnr/constants"
+	"github.com/TheManticoreProject/Manticore/network/llmnr/message"
+)
+
+// ListenAndServeTCP starts the optional LLMNR TCP responder and blocks serving
+// it until the server is closed. RFC 4795 §2.4 requires a responder to listen on
+// TCP port 5355 on the unicast address(es) it answers from, so that a querying
+// host whose UDP response was truncated (TC bit set) can retry the query over
+// TCP and receive the complete answer.
+//
+// It binds s.TCPListenAddr (defaulting to ":5355" when empty), then accepts
+// connections and serves each with the same handler chain as the UDP path. It is
+// independent of and non-breaking to ListenAndServe: a caller that wants both
+// transports starts ListenAndServe and ListenAndServeTCP in separate goroutines,
+// and Close shuts down both. Readiness can be observed with ListeningTCP.
+//
+// Returns:
+//   - An error if no handlers are registered or the TCP socket cannot be bound.
+//     A nil error is returned after a clean Close.
+func (s *Server) ListenAndServeTCP() error {
+	if len(s.Handlers) == 0 {
+		return fmt.Errorf("no handlers registered")
+	}
+
+	addr := s.TCPListenAddr
+	if addr == "" {
+		addr = fmt.Sprintf(":%d", constants.ListenPort)
+	}
+
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("failed to listen on TCP: %w", err)
+	}
+	s.tcpListener = listener
+
+	s.listeningMu.Lock()
+	s.listeningTCP = true
+	s.listeningMu.Unlock()
+
+	return s.serveTCP()
+}
+
+// ListeningTCP reports whether the server has bound its TCP responder socket and
+// is ready to accept connections. Like Listening, it is safe to call
+// concurrently with ListenAndServeTCP so a caller that started the TCP responder
+// in a background goroutine can poll for readiness without racing on the
+// tcpListener field.
+func (s *Server) ListeningTCP() bool {
+	s.listeningMu.RLock()
+	defer s.listeningMu.RUnlock()
+	return s.listeningTCP
+}
+
+// TCPAddr returns the address the TCP responder is bound to, or nil when the TCP
+// responder has not been started. It is primarily useful when TCPListenAddr
+// requested an ephemeral port (e.g. "127.0.0.1:0" in tests) and the caller needs
+// the concrete port that was assigned.
+func (s *Server) TCPAddr() net.Addr {
+	if s.tcpListener == nil {
+		return nil
+	}
+	return s.tcpListener.Addr()
+}
+
+// serveTCP accepts and dispatches TCP connections until the server is closed.
+// Each accepted connection is handled in its own goroutine so a slow or stalled
+// client cannot block others.
+func (s *Server) serveTCP() error {
+	for {
+		conn, err := s.tcpListener.Accept()
+		if err != nil {
+			// A closed listener (from Close) surfaces here as an accept error;
+			// treat that as a clean shutdown rather than a failure.
+			select {
+			case <-s.Closed:
+				return nil
+			default:
+			}
+			if s.Debug {
+				logger.Debugf("Error accepting TCP connection: %s\n", err.Error())
+			}
+			continue
+		}
+		go s.handleTCPConn(conn)
+	}
+}
+
+// handleTCPConn serves a single LLMNR-over-TCP connection: it reads one
+// length-prefixed query (RFC 1035 §4.2.2 framing), runs the handler chain if the
+// message is a query, and lets the handlers write a length-prefixed response
+// through the TCP ResponseWriter. The connection is closed when handling
+// completes.
+func (s *Server) handleTCPConn(conn net.Conn) {
+	defer conn.Close()
+
+	payload, err := message.ReadTCPMessage(conn)
+	if err != nil {
+		if s.Debug {
+			logger.Debugf("Error reading TCP query: %s\n", err.Error())
+		}
+		return
+	}
+
+	msg := message.Message{}
+	if _, err := msg.Unmarshal(payload); err != nil {
+		if s.Debug {
+			logger.Debugf("Error decoding TCP message: %s\n", err.Error())
+		}
+		return
+	}
+
+	if !msg.IsQuery() {
+		if s.Debug {
+			logger.Debugf("Received non-query TCP message from %s\n", conn.RemoteAddr().String())
+		}
+		return
+	}
+	if s.Debug {
+		logger.Debugf("Received query TCP message from %s\n", conn.RemoteAddr().String())
+	}
+
+	writer := newTCPResponseWriter(conn)
+	s.processHandlers(s, conn.RemoteAddr(), writer, &msg)
+}


### PR DESCRIPTION
### Linked Issue
`Closes #950`

### Root Cause
LLMNR had no TCP transport. The server only bound a UDP multicast socket and the client never acted on the TC (truncation) bit, so any answer larger than the 512-byte UDP datagram limit was unrecoverable and the `IsTruncation()` predicate was never used. RFC 4795 §2.4 requires a sender whose UDP response is truncated to retry the query over TCP on port 5355, and a responder to serve that query over TCP.

### Fix Description
- Marshal/truncation: `Message.MarshalWithTruncation` encodes the message and, when it exceeds the given limit, sets the TC bit and drops trailing resource records (additional, then authority, then answers) until it fits, per RFC 1035 §4.1.1. It operates on a copy so the caller can still send the full message over TCP. The UDP `ResponseWriter` uses it against `MaxPacketSize` so oversized answers set TC.
- Client: on a UDP response with TC set, the query is re-issued over TCP to the responder's unicast source address on port 5355, framed with the DNS-over-TCP two-byte big-endian length prefix (RFC 1035 §4.2.2). The full response replaces the truncated one and is validated exactly like the UDP path (response bit, transaction ID, question echo). The read loop now captures the responder's source address; a failed TCP retry degrades to returning the truncated response. The TCP port is overridable for tests.
- Server: opt-in `ListenAndServeTCP` accepts connections on port 5355, reads a length-prefixed query, runs the same handler chain through a non-truncating TCP `ResponseWriter`, and writes a length-prefixed response. It is independent of and non-breaking to the UDP `ListenAndServe`; `Close` shuts down both, readiness is exposed via the synchronized `ListeningTCP()` / `TCPAddr()`. The `poisoner` CLI now also starts the TCP responder.
- Shared framing helpers `message.WriteTCPMessage` / `ReadTCPMessage` are used by both sides and rely on `io.ReadFull` so short reads are reported, not silently truncated.

### How Verified
- `go build ./...`, `go vet ./...`, and `go test ./network/llmnr/... -race` all green.
- End-to-end loopback: a throwaway harness drove the real client's TC-triggered TCP fallback against the real server's TCP responder and retrieved the full untruncated answer.
- Cross-checked against RFC 4795 §2.4 (TC-triggered retry, TCP on port 5355) and RFC 1035 §4.2.2 (two-byte length prefix excluding the prefix).
- Windows host at 10.7.0.10 does not accept TCP/5355 (dial times out), consistent with its transient TCP-listen behavior; not required for validation.

### Test Coverage
**Added:**
- `TestMarshalWithTruncationSetsTC` / `TestMarshalWithTruncationFits` — an over-512-byte answer sets TC and truncates to fit; a small message is unchanged.
- `TestClientTCPFallbackOnTruncation` — client, on a TC-set UDP response from a loopback responder, dials a loopback TCP responder and retrieves the full answer.
- `TestClientTCPFallbackFailureReturnsTruncated` — graceful fallback when the TCP retry cannot connect.
- `TestServerTCPRoundTrip` — server TCP path returns a correct length-prefixed response for a query round-trip.
- `TestWriteReadTCPMessageRoundTrip`, `TestReadTCPMessageShortPrefix`, `TestReadTCPMessageShortBody`, `TestReadTCPMessageZeroLength` — framing edge cases.

### Scope of Change
- **Files changed:** `network/llmnr/message/message.go`, `network/llmnr/message/tcp.go` (new), `network/llmnr/client.go`, `network/llmnr/server/server.go`, `network/llmnr/server/tcp.go` (new), `network/llmnr/server/response_writer.go`, `cmd/poisoner/main.go`, plus tests.
- **Submodule pointer updated:** no.
- **Behavioral changes outside the bug fix:** none. The UDP `ResponseWriter` now truncates oversized answers instead of emitting an over-length datagram, which is the intended behavior change of this feature.

### Risk and Rollout
Low blast radius: the TCP responder is opt-in and the client TCP path only activates on a TC-set response, which did not previously occur. Existing UDP behavior for sub-512-byte answers is unchanged. Safe to merge without staged rollout.