### PR TITLE
Implement HandlerDescribePacketJson JSON packet describer (Fixes #952)

### DIFF
--- a/network/llmnr/server/custom_handlers.go
+++ b/network/llmnr/server/custom_handlers.go
@@ -1,11 +1,15 @@
 package server
 
 import (
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"net"
 
 	"github.com/TheManticoreProject/Manticore/logger"
+	"github.com/TheManticoreProject/Manticore/network/llmnr/llmnr_type"
 	"github.com/TheManticoreProject/Manticore/network/llmnr/message"
+	"github.com/TheManticoreProject/Manticore/network/llmnr/resourcerecord"
 )
 
 // HandlerDescribePacket logs detailed information about an LLMNR packet received by the
@@ -122,8 +126,215 @@ func HandlerDescribePacket(server *Server, remoteAddr net.Addr, writer ResponseW
 // - writer: A ResponseWriter to send responses back to the client.
 // - message: The LLMNR message received from the client.
 //
-// The function logs the details of the LLMNR message in JSON format.
+// The function marshals the decoded message into an indented JSON document (see
+// MessageToJson) and logs it via the same logger used by HandlerDescribePacket.
+// Like its sibling it always returns false so that packet processing continues
+// with the next handler.
 func HandlerDescribePacketJson(server *Server, remoteAddr net.Addr, writer ResponseWriter, message *message.Message) bool {
 
+	data, err := MessageToJson(remoteAddr, message)
+	if err != nil {
+		logger.Infof("Failed to render LLMNR packet from [%s] as JSON: %s", remoteAddr.String(), err)
+		return false
+	}
+
+	logger.Info(string(data))
+
 	return false
+}
+
+// jsonPacket is the JSON-shaped view of an LLMNR message as received from a
+// remote peer. It intentionally exposes only the decoded protocol fields (never
+// the wire-internal bookkeeping carried by the underlying structs) so the
+// rendered document stays stable and human-readable.
+type jsonPacket struct {
+	RemoteAddr string               `json:"remote_addr"`
+	Header     jsonHeader           `json:"header"`
+	Questions  []jsonQuestion       `json:"questions"`
+	Answers    []jsonResourceRecord `json:"answers"`
+	Authority  []jsonResourceRecord `json:"authority"`
+	Additional []jsonResourceRecord `json:"additional"`
+}
+
+// jsonHeader is the JSON-shaped view of the LLMNR header, exposing both the raw
+// section counts and the individually decoded flag bits (QR/Opcode/C/TC/T/Z/RCODE
+// per RFC 4795 §2.1.1).
+type jsonHeader struct {
+	ID      uint16    `json:"id"`
+	Flags   jsonFlags `json:"flags"`
+	QDCount uint16    `json:"qd_count"`
+	ANCount uint16    `json:"an_count"`
+	NSCount uint16    `json:"ns_count"`
+	ARCount uint16    `json:"ar_count"`
+}
+
+// jsonFlags is the JSON-shaped view of the 16-bit LLMNR flags word, exposing the
+// raw value alongside each decoded field.
+type jsonFlags struct {
+	Raw    uint16 `json:"raw"`
+	QR     bool   `json:"qr"`
+	Opcode uint8  `json:"opcode"`
+	C      bool   `json:"c"`
+	TC     bool   `json:"tc"`
+	T      bool   `json:"t"`
+	Z      uint8  `json:"z"`
+	RCODE  uint8  `json:"rcode"`
+}
+
+// jsonQuestion is the JSON-shaped view of a question section entry.
+type jsonQuestion struct {
+	Name      string `json:"name"`
+	Type      string `json:"type"`
+	TypeCode  uint16 `json:"type_code"`
+	Class     string `json:"class"`
+	ClassCode uint16 `json:"class_code"`
+}
+
+// jsonResourceRecord is the JSON-shaped view of a resource record. RData holds a
+// typed representation of the RDATA when the record type is recognized (via the
+// As* accessors), and RDataHex always carries the raw RDATA bytes as a hex
+// string so that unmodeled types (or records whose typed decode fails) remain
+// fully represented.
+type jsonResourceRecord struct {
+	Name      string      `json:"name"`
+	Type      string      `json:"type"`
+	TypeCode  uint16      `json:"type_code"`
+	Class     string      `json:"class"`
+	ClassCode uint16      `json:"class_code"`
+	TTL       uint32      `json:"ttl"`
+	RDLength  uint16      `json:"rdlength"`
+	RData     interface{} `json:"rdata,omitempty"`
+	RDataHex  string      `json:"rdata_hex"`
+}
+
+// jsonSRV is the JSON-shaped view of an SRV record's typed RDATA (RFC 2782).
+type jsonSRV struct {
+	Priority uint16 `json:"priority"`
+	Weight   uint16 `json:"weight"`
+	Port     uint16 `json:"port"`
+	Target   string `json:"target"`
+}
+
+// MessageToJson builds an indented JSON representation of a decoded LLMNR
+// message. It renders the header (including the individually decoded flag bits
+// and the section counts), the questions (name/type/class), and the answer,
+// authority and additional resource records (name/type/class/ttl plus typed
+// RDATA where the record type is recognized). The raw RDATA bytes are always
+// included as a hex string so that unmodeled record types stay fully
+// represented. The build is robust: a record whose typed decode errors simply
+// falls back to its raw bytes and never panics.
+//
+// Parameters:
+// - remoteAddr: The address of the remote peer that sent the message.
+// - msg: The decoded LLMNR message to render.
+//
+// Returns:
+// - The indented JSON document.
+// - An error if JSON marshalling fails.
+func MessageToJson(remoteAddr net.Addr, msg *message.Message) ([]byte, error) {
+	packet := jsonPacket{
+		Header: jsonHeader{
+			ID: msg.Header.Identifier,
+			Flags: jsonFlags{
+				Raw:    uint16(msg.Header.Flags),
+				QR:     msg.Header.Flags.IsResponse(),
+				Opcode: msg.Header.Flags.Opcode(),
+				C:      msg.Header.Flags.IsConflict(),
+				TC:     msg.Header.Flags.IsTruncation(),
+				T:      msg.Header.Flags.IsTentative(),
+				Z:      msg.Header.Flags.Z(),
+				RCODE:  msg.Header.Flags.RCODE(),
+			},
+			QDCount: msg.Header.QDCount,
+			ANCount: msg.Header.ANCount,
+			NSCount: msg.Header.NSCount,
+			ARCount: msg.Header.ARCount,
+		},
+		Questions:  make([]jsonQuestion, 0, len(msg.Questions)),
+		Answers:    make([]jsonResourceRecord, 0, len(msg.Answers)),
+		Authority:  make([]jsonResourceRecord, 0, len(msg.Authority)),
+		Additional: make([]jsonResourceRecord, 0, len(msg.Additional)),
+	}
+
+	if remoteAddr != nil {
+		packet.RemoteAddr = remoteAddr.String()
+	}
+
+	for _, q := range msg.Questions {
+		packet.Questions = append(packet.Questions, jsonQuestion{
+			Name:      string(q.Name),
+			Type:      q.Type.String(),
+			TypeCode:  uint16(q.Type),
+			Class:     q.Class.String(),
+			ClassCode: uint16(q.Class),
+		})
+	}
+
+	for i := range msg.Answers {
+		packet.Answers = append(packet.Answers, resourceRecordToJson(&msg.Answers[i]))
+	}
+	for i := range msg.Authority {
+		packet.Authority = append(packet.Authority, resourceRecordToJson(&msg.Authority[i]))
+	}
+	for i := range msg.Additional {
+		packet.Additional = append(packet.Additional, resourceRecordToJson(&msg.Additional[i]))
+	}
+
+	return json.MarshalIndent(packet, "", "  ")
+}
+
+// resourceRecordToJson builds the JSON-shaped view of a single resource record,
+// decoding a typed RDATA value for the record types recognized by the As*
+// accessors and always retaining the raw RDATA bytes as a hex string. A typed
+// decode that errors is not fatal: the typed value is simply left out and only
+// the raw bytes are reported.
+func resourceRecordToJson(rr *resourcerecord.ResourceRecord) jsonResourceRecord {
+	record := jsonResourceRecord{
+		Name:      string(rr.Name),
+		Type:      rr.Type.String(),
+		TypeCode:  uint16(rr.Type),
+		Class:     rr.Class.String(),
+		ClassCode: uint16(rr.Class),
+		TTL:       rr.TTL,
+		RDLength:  rr.RDLength,
+		RDataHex:  hex.EncodeToString(rr.RData),
+	}
+
+	switch rr.Type {
+	case llmnr_type.TypeA:
+		if ip, err := rr.AsA(); err == nil {
+			record.RData = ip.String()
+		}
+	case llmnr_type.TypeAAAA:
+		if ip, err := rr.AsAAAA(); err == nil {
+			record.RData = ip.String()
+		}
+	case llmnr_type.TypePTR:
+		if name, err := rr.AsPTR(); err == nil {
+			record.RData = name
+		}
+	case llmnr_type.TypeCNAME:
+		if name, err := rr.AsCNAME(); err == nil {
+			record.RData = name
+		}
+	case llmnr_type.TypeNS:
+		if name, err := rr.AsNS(); err == nil {
+			record.RData = name
+		}
+	case llmnr_type.TypeTXT:
+		if strs, err := rr.AsTXT(); err == nil {
+			record.RData = strs
+		}
+	case llmnr_type.TypeSRV:
+		if priority, weight, port, target, err := rr.AsSRV(); err == nil {
+			record.RData = jsonSRV{
+				Priority: priority,
+				Weight:   weight,
+				Port:     port,
+				Target:   target,
+			}
+		}
+	}
+
+	return record
 }

--- a/network/llmnr/server/custom_handlers_test.go
+++ b/network/llmnr/server/custom_handlers_test.go
@@ -1,0 +1,114 @@
+package server_test
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/llmnr/class"
+	"github.com/TheManticoreProject/Manticore/network/llmnr/llmnr_type"
+	"github.com/TheManticoreProject/Manticore/network/llmnr/message"
+	"github.com/TheManticoreProject/Manticore/network/llmnr/server"
+)
+
+// llmnrLiveResponseHex is the real LLMNR Type A response captured from the
+// Windows Server 2016 lab host (owner name "TMP-W-2016", A=10.7.0.10). It is the
+// same fixture exercised by the message package tests and is used here to
+// confirm MessageToJson renders genuine traffic correctly.
+//
+//	Header:   ID=0x37c8, Flags=0x8000 (QR), QD=1, AN=1
+//	Question: TMP-W-2016  A IN
+//	Answer:   TMP-W-2016  A IN  TTL=30  RDATA=10.7.0.10
+const llmnrLiveResponseHex = "37c8800000010001000000000a544d502d572d3230313600000100010a544d502d572d3230313600000100010000001e00040a07000a"
+
+// TestMessageToJsonShape asserts the JSON shape produced by MessageToJson for a
+// query and for a response carrying an A answer. The produced JSON is unmarshalled
+// back into a generic map and the key fields (ID, QR, question name/type and the
+// answer name/type/A-address) are asserted.
+func TestMessageToJsonShape(t *testing.T) {
+	// Build a simple Type A query for "printer.local".
+	query := message.NewMessage()
+	query.Header.Identifier = 0x1234
+	if err := query.AddQuestion("printer.local", llmnr_type.TypeA, class.ClassIN); err != nil {
+		t.Fatalf("AddQuestion failed: %v", err)
+	}
+
+	data, err := server.MessageToJson(nil, query)
+	if err != nil {
+		t.Fatalf("MessageToJson(query) failed: %v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("query JSON is not valid: %v\n%s", err, data)
+	}
+
+	header := decoded["header"].(map[string]interface{})
+	if id := header["id"].(float64); uint16(id) != 0x1234 {
+		t.Errorf("query header.id = %v, want %d", id, 0x1234)
+	}
+	flags := header["flags"].(map[string]interface{})
+	if qr := flags["qr"].(bool); qr {
+		t.Errorf("query flags.qr = true, want false (a query has QR clear)")
+	}
+
+	questions := decoded["questions"].([]interface{})
+	if len(questions) != 1 {
+		t.Fatalf("query questions = %d, want 1", len(questions))
+	}
+	q0 := questions[0].(map[string]interface{})
+	if name := q0["name"].(string); name != "printer.local" {
+		t.Errorf("query question name = %q, want %q", name, "printer.local")
+	}
+	if typ := q0["type"].(string); typ != llmnr_type.TypeA.String() {
+		t.Errorf("query question type = %q, want %q", typ, llmnr_type.TypeA.String())
+	}
+
+	// Decode the real captured response and render it.
+	raw, err := hex.DecodeString(llmnrLiveResponseHex)
+	if err != nil {
+		t.Fatalf("failed to decode fixture: %v", err)
+	}
+	resp := message.NewMessage()
+	if _, err := resp.Unmarshal(raw); err != nil {
+		t.Fatalf("Unmarshal(fixture) failed: %v", err)
+	}
+
+	data, err = server.MessageToJson(nil, resp)
+	if err != nil {
+		t.Fatalf("MessageToJson(response) failed: %v", err)
+	}
+
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("response JSON is not valid: %v\n%s", err, data)
+	}
+
+	header = decoded["header"].(map[string]interface{})
+	if id := header["id"].(float64); uint16(id) != 0x37c8 {
+		t.Errorf("response header.id = %v, want %#x", id, 0x37c8)
+	}
+	flags = header["flags"].(map[string]interface{})
+	if qr := flags["qr"].(bool); !qr {
+		t.Errorf("response flags.qr = false, want true (a response has QR set)")
+	}
+
+	answers := decoded["answers"].([]interface{})
+	if len(answers) != 1 {
+		t.Fatalf("response answers = %d, want 1", len(answers))
+	}
+	a0 := answers[0].(map[string]interface{})
+	if name := a0["name"].(string); name != "TMP-W-2016" {
+		t.Errorf("response answer name = %q, want %q", name, "TMP-W-2016")
+	}
+	if typ := a0["type"].(string); typ != llmnr_type.TypeA.String() {
+		t.Errorf("response answer type = %q, want %q", typ, llmnr_type.TypeA.String())
+	}
+	// The A record's typed RDATA must be the dotted-quad address.
+	if addr, ok := a0["rdata"].(string); !ok || addr != "10.7.0.10" {
+		t.Errorf("response answer rdata = %v, want %q", a0["rdata"], "10.7.0.10")
+	}
+	// The raw RDATA hex must always be present.
+	if hexData, ok := a0["rdata_hex"].(string); !ok || hexData != "0a07000a" {
+		t.Errorf("response answer rdata_hex = %v, want %q", a0["rdata_hex"], "0a07000a")
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #952`

### Root Cause
`HandlerDescribePacketJson` in `network/llmnr/server/custom_handlers.go` was declared with an empty body that only returned `false`, so the JSON packet describer produced no output at all. The typed-RDATA accessors (`As*`, #959) and the decoded header flag bits (#954) that make a useful JSON rendering possible existed but were never wired into a handler.

### Fix Description
The handler now marshals the decoded LLMNR message into an indented JSON document and logs it through the same project logger used by the sibling `HandlerDescribePacket`, returning the same `false` continue value so packet processing is unaffected.

The JSON construction is factored into an exported, testable helper `MessageToJson(remoteAddr, msg)` returning `([]byte, error)`. It renders:
- Header: ID, the section counts, and the individually decoded flag bits (QR/Opcode/C/TC/T/Z/RCODE per RFC 4795 §2.1.1) plus the raw flags word.
- Questions: name / type (name + numeric code) / class (name + numeric code).
- Answers, Authority and Additional resource records: name / type / class / ttl / rdlength, a typed RDATA value decoded via the `As*` accessors where the record type is recognized (A, AAAA, PTR, CNAME, NS, TXT, SRV), and the raw RDATA bytes as a hex string.

Small JSON-shaped structs are defined so the rendered document exposes only decoded protocol fields and never leaks wire-internal bookkeeping. The build is robust: a record whose typed decode errors simply omits the typed value and keeps the raw hex bytes, never panicking.

### How Verified
- `go build ./...`, `go vet ./...`, and `go test ./network/llmnr/... -race` all pass.
- Added a unit test (`TestMessageToJsonShape`) that renders a Type A query and the committed real-packet capture (owner `TMP-W-2016`, A=10.7.0.10), unmarshals the produced JSON, and asserts the header ID, the QR bit (false for the query, true for the response), the question name/type, and the answer name/type/A-address plus raw `rdata_hex`.
- Fed the same real-packet fixture through `MessageToJson` in a throwaway harness and confirmed valid indented JSON reflecting owner `TMP-W-2016` and A=10.7.0.10 with QR=true and ID=0x37c8.

### Test Coverage
- **Added:** `network/llmnr/server/custom_handlers_test.go` — `TestMessageToJsonShape`.

### Scope of Change
- **Files changed:** `network/llmnr/server/custom_handlers.go`, `network/llmnr/server/custom_handlers_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none