### PR TITLE
Harden LLMNR responder: checked UDPAddr assertion, Handlers sync, wired error sentinels (Fixes #953)

### DIFF
--- a/network/llmnr/domain_name/domain_name.go
+++ b/network/llmnr/domain_name/domain_name.go
@@ -99,7 +99,7 @@ func EncodeDomainName(name string) ([]byte, error) {
 // point it appears), and an error if decoding fails.
 func DecodeDomainName(data []byte, offset int) (string, int, error) {
 	if offset < 0 || offset >= len(data) {
-		return "", offset, fmt.Errorf("offset out of bounds")
+		return "", offset, fmt.Errorf("offset out of bounds: %w", errors.ErrInvalidDomainName)
 	}
 
 	originalOffset := offset
@@ -116,7 +116,7 @@ func DecodeDomainName(data []byte, offset int) (string, int, error) {
 
 	for {
 		if offset >= len(data) {
-			return "", originalOffset, fmt.Errorf("truncated name")
+			return "", originalOffset, fmt.Errorf("truncated name: %w", errors.ErrInvalidDomainName)
 		}
 
 		length := int(data[offset])
@@ -126,7 +126,7 @@ func DecodeDomainName(data []byte, offset int) (string, int, error) {
 		if length&constants.LabelPointer == constants.LabelPointer {
 			// Need one more byte for the pointer
 			if offset+1 >= len(data) {
-				return "", originalOffset, fmt.Errorf("truncated pointer")
+				return "", originalOffset, fmt.Errorf("truncated pointer: %w", errors.ErrInvalidDomainName)
 			}
 			ptr := int(binary.BigEndian.Uint16(data[offset:]) & 0x3FFF)
 			if !jumped {
@@ -138,10 +138,10 @@ func DecodeDomainName(data []byte, offset int) (string, int, error) {
 			// it must point strictly backwards. Forward and self references are
 			// rejected per RFC guidance and to guarantee decoding terminates.
 			if ptr >= offset {
-				return "", originalOffset, fmt.Errorf("invalid pointer: not a backward reference")
+				return "", originalOffset, fmt.Errorf("invalid pointer: not a backward reference: %w", errors.ErrInvalidDomainName)
 			}
 			if _, seen := visited[ptr]; seen {
-				return "", originalOffset, fmt.Errorf("invalid pointer: cycle detected")
+				return "", originalOffset, fmt.Errorf("invalid pointer: cycle detected: %w", errors.ErrInvalidDomainName)
 			}
 			visited[offset] = struct{}{}
 			// Follow the pointer
@@ -151,7 +151,7 @@ func DecodeDomainName(data []byte, offset int) (string, int, error) {
 		}
 
 		if _, seen := visited[offset]; seen {
-			return "", originalOffset, fmt.Errorf("invalid name: cycle detected")
+			return "", originalOffset, fmt.Errorf("invalid name: cycle detected: %w", errors.ErrInvalidDomainName)
 		}
 		visited[offset] = struct{}{}
 
@@ -166,7 +166,7 @@ func DecodeDomainName(data []byte, offset int) (string, int, error) {
 		// Regular label
 		offset++
 		if offset+length > len(data) {
-			return "", originalOffset, fmt.Errorf("truncated label")
+			return "", originalOffset, fmt.Errorf("truncated label: %w", errors.ErrInvalidDomainName)
 		}
 		label := string(data[offset : offset+length])
 		labels = append(labels, label)

--- a/network/llmnr/errors/errors.go
+++ b/network/llmnr/errors/errors.go
@@ -2,17 +2,23 @@ package errors
 
 import "errors"
 
-// Common errors
+// Common errors.
+//
+// These sentinels are wrapped with %w by the parsers so callers can classify a
+// decode failure with errors.Is (e.g. errors.Is(err, ErrInvalidHeader)) without
+// matching on error strings. Each layer wraps its own sentinel: the message
+// parser wraps the section-level sentinels (ErrInvalidAnswer/Authority/Additional)
+// around the ErrInvalidResourceRecord returned by the record parser, so a section
+// failure matches both its section sentinel and ErrInvalidResourceRecord.
 var (
-	ErrInvalidDomainName         = errors.New("invalid domain name")
-	ErrInvalidMessage            = errors.New("invalid message format")
-	ErrInvalidHeader             = errors.New("invalid header format")
-	ErrInvalidQuestion           = errors.New("invalid question format")
-	ErrInvalidAnswer             = errors.New("invalid answer format")
-	ErrInvalidAuthority          = errors.New("invalid authority format")
-	ErrInvalidAdditional         = errors.New("invalid additional format")
-	ErrInvalidResourceRecord     = errors.New("invalid resource record format")
-	ErrInvalidResourceRecordType = errors.New("invalid resource record type")
-	ErrNameTooLong               = errors.New("domain name too long")
-	ErrLabelTooLong              = errors.New("label too long")
+	ErrInvalidDomainName     = errors.New("invalid domain name")
+	ErrInvalidMessage        = errors.New("invalid message format")
+	ErrInvalidHeader         = errors.New("invalid header format")
+	ErrInvalidQuestion       = errors.New("invalid question format")
+	ErrInvalidAnswer         = errors.New("invalid answer format")
+	ErrInvalidAuthority      = errors.New("invalid authority format")
+	ErrInvalidAdditional     = errors.New("invalid additional format")
+	ErrInvalidResourceRecord = errors.New("invalid resource record format")
+	ErrNameTooLong           = errors.New("domain name too long")
+	ErrLabelTooLong          = errors.New("label too long")
 )

--- a/network/llmnr/errors/errors_test.go
+++ b/network/llmnr/errors/errors_test.go
@@ -21,7 +21,6 @@ func TestSentinelMessages(t *testing.T) {
 		{errors.ErrInvalidAuthority, "invalid authority format"},
 		{errors.ErrInvalidAdditional, "invalid additional format"},
 		{errors.ErrInvalidResourceRecord, "invalid resource record format"},
-		{errors.ErrInvalidResourceRecordType, "invalid resource record type"},
 		{errors.ErrNameTooLong, "domain name too long"},
 		{errors.ErrLabelTooLong, "label too long"},
 	}
@@ -49,7 +48,6 @@ func TestSentinelIdentity(t *testing.T) {
 		errors.ErrInvalidAuthority,
 		errors.ErrInvalidAdditional,
 		errors.ErrInvalidResourceRecord,
-		errors.ErrInvalidResourceRecordType,
 		errors.ErrNameTooLong,
 		errors.ErrLabelTooLong,
 	}

--- a/network/llmnr/message/header/header.go
+++ b/network/llmnr/message/header/header.go
@@ -4,6 +4,8 @@ import (
 	"encoding/binary"
 	"fmt"
 	"strings"
+
+	"github.com/TheManticoreProject/Manticore/network/llmnr/errors"
 )
 
 // Size of LLMNR message header in bytes
@@ -70,7 +72,7 @@ func (h *Header) Marshal() ([]byte, error) {
 // It returns an error if the input slice is not exactly 12 bytes.
 func (h *Header) Unmarshal(data []byte) (int, error) {
 	if len(data) != 12 {
-		return 0, fmt.Errorf("invalid length: got %d bytes, want 12 bytes", len(data))
+		return 0, fmt.Errorf("invalid length: got %d bytes, want 12 bytes: %w", len(data), errors.ErrInvalidHeader)
 	}
 
 	bytesRead := 0
@@ -79,7 +81,7 @@ func (h *Header) Unmarshal(data []byte) (int, error) {
 
 	bytesReadFlags, err := h.Flags.Unmarshal(data[bytesRead : bytesRead+2])
 	if err != nil {
-		return 0, fmt.Errorf("failed to unmarshal flags: %w", err)
+		return 0, fmt.Errorf("failed to unmarshal flags: %w: %w", err, errors.ErrInvalidHeader)
 	}
 	bytesRead += bytesReadFlags
 

--- a/network/llmnr/message/message.go
+++ b/network/llmnr/message/message.go
@@ -448,7 +448,7 @@ func (m *Message) MarshalWithTruncation(maxSize int) ([]byte, bool, error) {
 //     decoding the question or answer sections.
 func (m *Message) Unmarshal(data []byte) (int, error) {
 	if len(data) < header.HeaderSize {
-		return 0, fmt.Errorf("message too short")
+		return 0, fmt.Errorf("message too short: %w", errors.ErrInvalidMessage)
 	}
 
 	// Unmarshal header. From here on we track an absolute offset into data so
@@ -478,7 +478,7 @@ func (m *Message) Unmarshal(data []byte) (int, error) {
 		rr := resourcerecord.ResourceRecord{}
 		n, err := rr.UnmarshalFromMessage(data, offset)
 		if err != nil {
-			return 0, fmt.Errorf("error unmarshalling answer: %w", err)
+			return 0, fmt.Errorf("error unmarshalling answer: %w: %w", err, errors.ErrInvalidAnswer)
 		}
 		offset += n
 		m.Answers = append(m.Answers, rr)
@@ -489,7 +489,7 @@ func (m *Message) Unmarshal(data []byte) (int, error) {
 		rr := resourcerecord.ResourceRecord{}
 		n, err := rr.UnmarshalFromMessage(data, offset)
 		if err != nil {
-			return 0, fmt.Errorf("error unmarshalling authority: %w", err)
+			return 0, fmt.Errorf("error unmarshalling authority: %w: %w", err, errors.ErrInvalidAuthority)
 		}
 		offset += n
 		m.Authority = append(m.Authority, rr)
@@ -500,7 +500,7 @@ func (m *Message) Unmarshal(data []byte) (int, error) {
 		rr := resourcerecord.ResourceRecord{}
 		n, err := rr.UnmarshalFromMessage(data, offset)
 		if err != nil {
-			return 0, fmt.Errorf("error unmarshalling additional: %w", err)
+			return 0, fmt.Errorf("error unmarshalling additional: %w: %w", err, errors.ErrInvalidAdditional)
 		}
 		offset += n
 		m.Additional = append(m.Additional, rr)

--- a/network/llmnr/message/message_test.go
+++ b/network/llmnr/message/message_test.go
@@ -2,6 +2,7 @@ package message_test
 
 import (
 	"encoding/hex"
+	stderrors "errors"
 	"math/rand"
 	"net"
 	"testing"
@@ -441,5 +442,84 @@ func TestValidateChecksAuthorityAndAdditional(t *testing.T) {
 	msgAdd.Header.ARCount = 1
 	if err := msgAdd.Validate(); err != errors.ErrLabelTooLong {
 		t.Errorf("Validate() returned %v for invalid Additional name, want %v", err, errors.ErrLabelTooLong)
+	}
+}
+
+// TestUnmarshalWrapsSentinels verifies that Unmarshal wraps the errors package
+// sentinels with %w so callers can classify a malformed packet with errors.Is
+// rather than matching on error strings. Each case feeds a deliberately
+// malformed buffer and asserts the sentinel(s) it should surface.
+func TestUnmarshalWrapsSentinels(t *testing.T) {
+	cases := []struct {
+		name string
+		data []byte
+		want []error
+	}{
+		{
+			// Fewer than the 12 header bytes: the top-level message is invalid.
+			name: "short buffer",
+			data: []byte{0x00, 0x00, 0x00, 0x00, 0x00},
+			want: []error{errors.ErrInvalidMessage},
+		},
+		{
+			// QDCount=1 but the question name is not followed by type/class.
+			name: "truncated question",
+			data: []byte{
+				0x00, 0x00, // ID
+				0x00, 0x00, // Flags (query)
+				0x00, 0x01, // QDCount = 1
+				0x00, 0x00, // ANCount
+				0x00, 0x00, // NSCount
+				0x00, 0x00, // ARCount
+				0x01, 'a', 0x00, // name "a." then end of buffer
+			},
+			want: []error{errors.ErrInvalidQuestion},
+		},
+		{
+			// QDCount=1 with a forward compression pointer in the name, which is
+			// rejected as an invalid domain name (and bubbles up as an invalid
+			// question).
+			name: "invalid name pointer",
+			data: []byte{
+				0x00, 0x00, // ID
+				0x00, 0x00, // Flags (query)
+				0x00, 0x01, // QDCount = 1
+				0x00, 0x00, // ANCount
+				0x00, 0x00, // NSCount
+				0x00, 0x00, // ARCount
+				0xC0, 0xFF, // pointer to offset 255 (forward reference)
+			},
+			want: []error{errors.ErrInvalidDomainName, errors.ErrInvalidQuestion},
+		},
+		{
+			// ANCount=1 with a root-labelled answer whose fixed fields are cut off:
+			// the record is invalid, surfaced through the answer section.
+			name: "truncated answer",
+			data: []byte{
+				0x00, 0x00, // ID
+				0x00, 0x00, // Flags (query)
+				0x00, 0x00, // QDCount
+				0x00, 0x01, // ANCount = 1
+				0x00, 0x00, // NSCount
+				0x00, 0x00, // ARCount
+				0x00, // root name, then no type/class/ttl/rdlength
+			},
+			want: []error{errors.ErrInvalidAnswer, errors.ErrInvalidResourceRecord},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			msg := message.Message{}
+			_, err := msg.Unmarshal(c.data)
+			if err == nil {
+				t.Fatalf("Unmarshal(%s) error = nil, want error", c.name)
+			}
+			for _, want := range c.want {
+				if !stderrors.Is(err, want) {
+					t.Errorf("Unmarshal(%s) error = %v, want errors.Is match for %v", c.name, err, want)
+				}
+			}
+		})
 	}
 }

--- a/network/llmnr/question/question.go
+++ b/network/llmnr/question/question.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/TheManticoreProject/Manticore/network/llmnr/class"
 	"github.com/TheManticoreProject/Manticore/network/llmnr/domain_name"
+	"github.com/TheManticoreProject/Manticore/network/llmnr/errors"
 	"github.com/TheManticoreProject/Manticore/network/llmnr/llmnr_type"
 )
 
@@ -123,27 +124,27 @@ func (q *Question) UnmarshalFromMessage(message []byte, offset int) (int, error)
 	// Unmarshal domain name
 	bytesReadDomainName, err := q.Name.UnmarshalFromMessage(message, offset)
 	if err != nil {
-		return 0, fmt.Errorf("error unmarshalling domain name: %w", err)
+		return 0, fmt.Errorf("error unmarshalling domain name: %w: %w", err, errors.ErrInvalidQuestion)
 	}
 	offset += bytesReadDomainName
 
 	// Unmarshal type
 	if offset+2 > len(message) {
-		return 0, fmt.Errorf("truncated question, missing type")
+		return 0, fmt.Errorf("truncated question, missing type: %w", errors.ErrInvalidQuestion)
 	}
 	bytesReadType, err := q.Type.Unmarshal(message[offset : offset+2])
 	if err != nil {
-		return 0, fmt.Errorf("error unmarshalling type: %w", err)
+		return 0, fmt.Errorf("error unmarshalling type: %w: %w", err, errors.ErrInvalidQuestion)
 	}
 	offset += bytesReadType
 
 	// Unmarshal class
 	if offset+2 > len(message) {
-		return 0, fmt.Errorf("truncated question, missing class")
+		return 0, fmt.Errorf("truncated question, missing class: %w", errors.ErrInvalidQuestion)
 	}
 	bytesReadClass, err := q.Class.Unmarshal(message[offset : offset+2])
 	if err != nil {
-		return 0, fmt.Errorf("error unmarshalling class: %w", err)
+		return 0, fmt.Errorf("error unmarshalling class: %w: %w", err, errors.ErrInvalidQuestion)
 	}
 	offset += bytesReadClass
 

--- a/network/llmnr/resourcerecord/resource_record.go
+++ b/network/llmnr/resourcerecord/resource_record.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/TheManticoreProject/Manticore/network/llmnr/class"
 	"github.com/TheManticoreProject/Manticore/network/llmnr/domain_name"
+	"github.com/TheManticoreProject/Manticore/network/llmnr/errors"
 	"github.com/TheManticoreProject/Manticore/network/llmnr/llmnr_type"
 )
 
@@ -119,12 +120,12 @@ func (rr *ResourceRecord) UnmarshalFromMessage(message []byte, offset int) (int,
 
 	bytesReadName, err := rr.Name.UnmarshalFromMessage(message, offset)
 	if err != nil {
-		return 0, fmt.Errorf("error unmarshalling name: %w", err)
+		return 0, fmt.Errorf("error unmarshalling name: %w: %w", err, errors.ErrInvalidResourceRecord)
 	}
 	offset += bytesReadName
 
 	if offset+10 > len(message) {
-		return 0, fmt.Errorf("truncated resource record")
+		return 0, fmt.Errorf("truncated resource record: %w", errors.ErrInvalidResourceRecord)
 	}
 
 	rr.Type = llmnr_type.Type(binary.BigEndian.Uint16(message[offset:]))
@@ -137,7 +138,7 @@ func (rr *ResourceRecord) UnmarshalFromMessage(message []byte, offset int) (int,
 	offset += 2
 
 	if offset+int(rr.RDLength) > len(message) {
-		return 0, fmt.Errorf("truncated rdata")
+		return 0, fmt.Errorf("truncated rdata: %w", errors.ErrInvalidResourceRecord)
 	}
 
 	// Retain the message context so that name-bearing RDATA (PTR/CNAME/NS/SRV)

--- a/network/llmnr/server/handler.go
+++ b/network/llmnr/server/handler.go
@@ -55,5 +55,7 @@ func (f HandlerFunc) Run(server *Server, remoteAddr net.Addr, writer ResponseWri
 // This function is typically called before starting the server to ensure that all necessary
 // handlers are in place to process incoming queries.
 func (s *Server) RegisterHandler(handler Handler) {
+	s.handlersMu.Lock()
+	defer s.handlersMu.Unlock()
 	s.Handlers = append(s.Handlers, handler)
 }

--- a/network/llmnr/server/response_writer.go
+++ b/network/llmnr/server/response_writer.go
@@ -65,7 +65,15 @@ func (w *responseWriter) WriteMessage(msg *message.Message) error {
 		return fmt.Errorf("failed to encode message: %w", err)
 	}
 
-	_, err = w.Server.Conn.WriteToUDP(encoded, w.RemoteAddr.(*net.UDPAddr))
+	// The UDP responder can only reply over its net.UDPConn, so the remote
+	// address must be a *net.UDPAddr. Assert with the comma-ok form and return a
+	// descriptive error rather than risk a panic on an unexpected address type.
+	udpAddr, ok := w.RemoteAddr.(*net.UDPAddr)
+	if !ok {
+		return fmt.Errorf("cannot write UDP response: remote address is %T, want *net.UDPAddr", w.RemoteAddr)
+	}
+
+	_, err = w.Server.Conn.WriteToUDP(encoded, udpAddr)
 
 	return err
 }

--- a/network/llmnr/server/robustness_test.go
+++ b/network/llmnr/server/robustness_test.go
@@ -1,0 +1,77 @@
+package server
+
+import (
+	"net"
+	"sync"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/llmnr/message"
+)
+
+// TestRegisterHandlerConcurrentWithDispatchNoRace exercises RegisterHandler
+// (which appends to Handlers under the write lock) concurrently with the
+// per-packet dispatch path (which reads a snapshot under the read lock). Run
+// under -race it proves the two paths no longer race on the Handlers slice.
+func TestRegisterHandlerConcurrentWithDispatchNoRace(t *testing.T) {
+	s := &Server{Closed: make(chan struct{})}
+
+	// A no-op handler that keeps the chain going; it never touches the writer,
+	// so a nil ResponseWriter is fine for the purposes of this race test.
+	noop := HandlerFunc(func(*Server, net.Addr, ResponseWriter, *message.Message) bool {
+		return true
+	})
+
+	const registrars = 32
+	const dispatchers = 32
+	const iterations = 200
+
+	remote := &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 5355}
+	msg := message.NewMessage()
+
+	var wg sync.WaitGroup
+
+	// Writers: keep appending handlers.
+	for i := 0; i < registrars; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				s.RegisterHandler(noop)
+			}
+		}()
+	}
+
+	// Readers: keep dispatching, which snapshots the Handlers slice under lock.
+	for i := 0; i < dispatchers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				s.processHandlers(s, remote, nil, msg)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// Every registration must have landed exactly once.
+	if got := len(s.snapshotHandlers()); got != registrars*iterations {
+		t.Errorf("registered handler count = %d, want %d", got, registrars*iterations)
+	}
+}
+
+// TestWriteMessageNonUDPAddrReturnsError verifies the UDP ResponseWriter returns
+// a descriptive error (instead of panicking) when its remote address is not a
+// *net.UDPAddr, which is the checked-assertion hardening this test guards.
+func TestWriteMessageNonUDPAddrReturnsError(t *testing.T) {
+	// A non-UDP remote address; the assertion must fail cleanly rather than panic.
+	w := &responseWriter{
+		Server:     &Server{},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 5355},
+	}
+
+	err := w.WriteMessage(message.NewMessage())
+	if err == nil {
+		t.Fatal("WriteMessage() error = nil, want an error for a non-*net.UDPAddr remote address")
+	}
+}

--- a/network/llmnr/server/server.go
+++ b/network/llmnr/server/server.go
@@ -26,7 +26,16 @@ import (
 //   - Debug: A boolean flag indicating whether debug mode is enabled.
 type Server struct {
 	// Handlers is a slice of Handler interfaces that process incoming LLMNR messages.
+	// It is guarded by handlersMu: RegisterHandler appends under the write lock
+	// while the per-packet dispatch path reads a snapshot under the read lock, so
+	// a handler may be registered concurrently with Serve without a data race.
 	Handlers []Handler
+
+	// handlersMu guards the Handlers slice. It is deliberately separate from
+	// listeningMu (which guards the listening/listeningTCP readiness flags) so the
+	// two unrelated concerns never contend, and it is never held while a handler
+	// runs: the read path copies the slice under the lock and iterates the copy.
+	handlersMu sync.RWMutex
 
 	// Known networks are "tcp", "tcp4" (IPv4-only), "tcp6" (IPv6-only),
 	// "udp", "udp4" (IPv4-only), "udp6" (IPv6-only), "ip", "ip4"
@@ -353,7 +362,7 @@ func (s *Server) SetDebug(debug bool) {
 //	    log.Fatalf("Server encountered an error: %v", err)
 //	}
 func (s *Server) ListenAndServe() error {
-	if len(s.Handlers) == 0 {
+	if len(s.snapshotHandlers()) == 0 {
 		return fmt.Errorf("no handlers registered")
 	}
 
@@ -533,10 +542,25 @@ func (s *Server) Serve() error {
 //
 // This function is typically called internally by the Server when a new LLMNR query is received.
 func (s *Server) processHandlers(server *Server, remoteAddr net.Addr, writer ResponseWriter, message *message.Message) {
-	for _, handler := range s.Handlers {
+	// Iterate a snapshot taken under the read lock rather than ranging over
+	// s.Handlers directly: this keeps RegisterHandler safe to call concurrently
+	// with dispatch, and avoids holding the lock while a handler runs.
+	for _, handler := range s.snapshotHandlers() {
 		continueProcessing := handler.Run(server, remoteAddr, writer, message)
 		if !continueProcessing {
 			break
 		}
 	}
+}
+
+// snapshotHandlers returns a copy of the registered handlers taken under the
+// read lock. Callers iterate the returned slice so that RegisterHandler can
+// append concurrently (under the write lock) without racing the dispatch path,
+// and so no lock is held while a handler runs.
+func (s *Server) snapshotHandlers() []Handler {
+	s.handlersMu.RLock()
+	defer s.handlersMu.RUnlock()
+	handlers := make([]Handler, len(s.Handlers))
+	copy(handlers, s.Handlers)
+	return handlers
 }

--- a/network/llmnr/server/tcp.go
+++ b/network/llmnr/server/tcp.go
@@ -25,7 +25,7 @@ import (
 //   - An error if no handlers are registered or the TCP socket cannot be bound.
 //     A nil error is returned after a clean Close.
 func (s *Server) ListenAndServeTCP() error {
-	if len(s.Handlers) == 0 {
+	if len(s.snapshotHandlers()) == 0 {
 		return fmt.Errorf("no handlers registered")
 	}
 


### PR DESCRIPTION
### Linked Issue
`Closes #953`

### Root Cause
The LLMNR server/message layer carried three latent robustness defects. (1) `responseWriter.WriteMessage` performed an unchecked `w.RemoteAddr.(*net.UDPAddr)` type assertion; any code path that constructed a writer with a non-UDP `net.Addr` would panic the serving goroutine. (2) The `Handlers` slice was appended to by `RegisterHandler` while being read from per-packet dispatch goroutines with no synchronization, a data race. (3) The `errors` package defined classification sentinels that no parser ever returned, so callers could only match on error strings.

### Fix Description
- **Checked assertion:** `WriteMessage` now uses the comma-ok form and returns a descriptive error (`remote address is %T, want *net.UDPAddr`) instead of panicking. The TCP writer added for the TCP responder needs no equivalent change: it writes through `conn.RemoteAddr()`/`WriteTCPMessage` with no type assertion.
- **Handlers synchronization:** a dedicated `handlersMu sync.RWMutex` guards the slice. It is intentionally separate from the pre-existing `listeningMu` (which guards the `Listening()`/`ListeningTCP()` readiness flags) so the two unrelated concerns never contend and no second lock conflicts with the existing one. `RegisterHandler` appends under the write lock; dispatch and the startup handler-count checks read a snapshot via `snapshotHandlers()` under the read lock, and the snapshot is iterated so no lock is held while a handler runs.
- **Error sentinels:** the applicable sentinels are wired through the header/question/resource-record/domain-name/message parsers with `%w` (including double-`%w` so a section failure matches both its section sentinel and the underlying record/name sentinel), making `errors.Is` work. The truly dead `ErrInvalidResourceRecordType` is removed, since no parser can apply it without changing the responder's deliberately permissive record-type handling.

### How Verified
- `go build ./...` and `go vet ./network/llmnr/...` clean.
- `go test ./network/llmnr/... -race` green across the whole tree, including the server package.
- Live UDP round-trip over interface `enp0s8` against the multicast group: a server with a spoof handler answered a real `wpad` A query with the configured address, confirming no behavioral regression through the modified writer and dispatch paths.

### Test Coverage
- **Added:**
  - `server.TestRegisterHandlerConcurrentWithDispatchNoRace` — spins registrar and dispatcher goroutines concurrently; clean under `-race`.
  - `server.TestWriteMessageNonUDPAddrReturnsError` — `WriteMessage` with a `*net.TCPAddr` remote returns an error instead of panicking.
  - `message.TestUnmarshalWrapsSentinels` — `errors.Is` matches `ErrInvalidMessage`, `ErrInvalidQuestion`, `ErrInvalidDomainName`, and `ErrInvalidAnswer`/`ErrInvalidResourceRecord` for malformed packets.
- **Existing:** `errors` sentinel tests updated for the removed sentinel; existing server TCP round-trip and message round-trip tests continue to pass.

### Scope of Change
- **Files changed:** `network/llmnr/server/{response_writer,server,handler,tcp}.go`, `network/llmnr/errors/errors.go`, `network/llmnr/{message/message,message/header/header,question/question,resourcerecord/resource_record,domain_name/domain_name}.go`, plus tests (`server/robustness_test.go`, `errors/errors_test.go`, `message/message_test.go`).
- **Submodule pointer updated:** no.
- **Behavioral changes outside the bug fix:** none.

### Risk and Rollout
Local to the LLMNR package. Error message text for some parse failures now includes the wrapped sentinel suffix; no test matches on those exact strings. Safe to merge without staged rollout.