### PR TITLE
Fix NBNS RA/group flag bits and RCODE match (Fixes #967)

### DIFF
--- a/network/netbios/nbns/challenge.go
+++ b/network/netbios/nbns/challenge.go
@@ -91,8 +91,10 @@ func (c *NameChallenger) ChallengeOwnership(name string, owner net.IP) (bool, er
 			continue
 		}
 
-		// Check if name is still owned
-		if response.Header.Flags&RcodeNameError != 0 {
+		// Check if name is still owned. RCODE is the low nibble of the header
+		// flags, so compare it rather than masking (a bitmask test would also
+		// match RCODE 1 and 2).
+		if response.Header.Flags&RcodeMask == RcodeNameError {
 			return false, nil
 		}
 
@@ -129,15 +131,19 @@ func (c *NameChallenger) DefendName(packet *NBNSPacket, response *NBNSPacket) {
 
 		// Create defense response
 		response.Header.Flags = FlagResponse | FlagAuthoritative
+
+		// The Group (G) bit lives in the resource record's NB_FLAGS, not in the
+		// header (RFC 1002 4.2.1.3).
+		var nbFlags uint16
 		if nameType == Group {
-			response.Header.Flags |= 0x0080 // Group name bit
+			nbFlags |= NBFlagGroup
 		}
 
 		// Add resource records for all owners
 		for _, ip := range owners {
 			owner := ADDR_ENTRY{
 				Address: binary.BigEndian.Uint32(ip.To4()),
-				Flags:   0x0000,
+				Flags:   nbFlags,
 			}
 			rr := NBNSResourceRecord{
 				Name:     q.Name,

--- a/network/netbios/nbns/handlers.go
+++ b/network/netbios/nbns/handlers.go
@@ -28,11 +28,18 @@ func (h *PacketHandler) handleNameQuery(request *NBNSPacket, response *NBNSPacke
 
 		ttlSeconds := uint32(ttl.Seconds())
 
+		// The Group (G) bit lives in the resource record's NB_FLAGS, not in the
+		// header (RFC 1002 4.2.1.3).
+		var nbFlags uint16
+		if nameType == Group {
+			nbFlags |= NBFlagGroup
+		}
+
 		// Create resource record for each owner
 		for _, ip := range owners {
 			owner := ADDR_ENTRY{
 				Address: binary.BigEndian.Uint32(ip.To4()),
-				Flags:   0x0000,
+				Flags:   nbFlags,
 			}
 			rr := NBNSResourceRecord{
 				Name:     q.Name,
@@ -46,29 +53,27 @@ func (h *PacketHandler) handleNameQuery(request *NBNSPacket, response *NBNSPacke
 		}
 
 		response.Header.Answers = uint16(len(response.Answers))
-
-		// Set group bit if this is a group name
-		if nameType == Group {
-			response.Header.Flags |= 0x0080 // Group name bit
-		}
 	}
 }
 
 // handleRegistration processes a name registration request
 func (h *PacketHandler) handleRegistration(request *NBNSPacket, response *NBNSPacket) {
 	for _, rr := range request.Answers {
-		ip, err := ParseIPFromRData(rr.RData)
-		if err != nil {
+		var entry ADDR_ENTRY
+		if err := entry.Unmarshal(rr.RData); err != nil {
 			response.Header.Flags |= RcodeFormatError
 			return
 		}
+		ip := entry.IP()
 
+		// The unique/group distinction is carried by the Group (G) bit of the
+		// resource record's NB_FLAGS, not by the header (RFC 1002 4.2.1.3).
 		nameType := Unique
-		if request.Header.Flags&0x0080 != 0 {
+		if entry.Flags&NBFlagGroup != 0 {
 			nameType = Group
 		}
 
-		err = h.nbns.RegisterName(
+		err := h.nbns.RegisterName(
 			rr.Name.Name,
 			rr.Name.ScopeID,
 			nameType,

--- a/network/netbios/nbns/name.go
+++ b/network/netbios/nbns/name.go
@@ -49,6 +49,13 @@ type ADDR_ENTRY struct {
 	Address uint32
 }
 
+// NB_FLAGS bits carried in the ADDR_ENTRY.Flags field of an NB resource record
+// (RFC 1002 4.2.1.3: G | ONT | RESERVED). The Group (G) bit is the most
+// significant bit of the 16-bit NB_FLAGS field, distinct from the header flags.
+const (
+	NBFlagGroup uint16 = 0x8000 // G: set for a group name, clear for a unique name
+)
+
 // Constants for name encoding
 const (
 	NetBIOSNameLength = 16 // NetBIOS names are exactly 16 bytes

--- a/network/netbios/nbns/nbtns_test.go
+++ b/network/netbios/nbns/nbtns_test.go
@@ -102,3 +102,94 @@ func TestNBNSIntegration(t *testing.T) {
 		}
 	})
 }
+
+// TestFlagBitLayout asserts the corrected NBNS header flag and RR NB_FLAGS bit
+// layout per RFC 1002 4.2.1.1 and 4.2.1.3.
+func TestFlagBitLayout(t *testing.T) {
+	// RA (recursion available) is header bit 8 == 0x0080; it is not a group bit.
+	if FlagRecursionAvailable != 0x0080 {
+		t.Errorf("FlagRecursionAvailable: got 0x%04X, want 0x0080", FlagRecursionAvailable)
+	}
+	// The Group (G) bit is the MSB of the 16-bit RR NB_FLAGS field.
+	if NBFlagGroup != 0x8000 {
+		t.Errorf("NBFlagGroup: got 0x%04X, want 0x8000", NBFlagGroup)
+	}
+	if RcodeMask != 0x000F {
+		t.Errorf("RcodeMask: got 0x%04X, want 0x000F", RcodeMask)
+	}
+}
+
+// TestRcodeNameErrorMatch ensures the RCODE comparison classifies only RCODE 3
+// as NAME_ERROR and does not falsely match RCODE 1 (FMT_ERR) or 2 (SRV_ERR).
+func TestRcodeNameErrorMatch(t *testing.T) {
+	isNameError := func(flags uint16) bool {
+		return flags&RcodeMask == RcodeNameError
+	}
+	// Response with unrelated high bits set plus the RCODE nibble.
+	base := FlagResponse | FlagAuthoritative | FlagRecursionAvailable
+	for rcode := uint16(0); rcode <= 0x0007; rcode++ {
+		got := isNameError(base | rcode)
+		want := rcode == RcodeNameError
+		if got != want {
+			t.Errorf("RCODE %d: isNameError=%v, want %v", rcode, got, want)
+		}
+	}
+}
+
+// TestGroupBitInResourceRecord verifies a group name query response carries the
+// Group bit in the RR NB_FLAGS (0x8000) and leaves the header RA bit (0x0080)
+// clear, and that a group registration is read from the RR NB_FLAGS.
+func TestGroupBitInResourceRecord(t *testing.T) {
+	nbns := NewNetBIOSNameServer(false)
+	h := NewPacketHandler(nbns)
+
+	name := "GRPNAME"
+	ip := net.ParseIP("192.168.1.10")
+	if err := nbns.RegisterName(name, "", Group, ip, time.Hour); err != nil {
+		t.Fatalf("RegisterName: %v", err)
+	}
+
+	request := &NBNSPacket{
+		Header:    NBNSHeader{Flags: OpNameQuery, Questions: 1},
+		Questions: []NBNSQuestion{{Name: &NetBIOSName{Name: name}, Type: QuestionTypeNB, Class: QuestionClassIn}},
+	}
+	response := &NBNSPacket{}
+	h.handleNameQuery(request, response)
+
+	if len(response.Answers) != 1 {
+		t.Fatalf("expected 1 answer, got %d", len(response.Answers))
+	}
+	var entry ADDR_ENTRY
+	if err := entry.Unmarshal(response.Answers[0].RData); err != nil {
+		t.Fatalf("Unmarshal ADDR_ENTRY: %v", err)
+	}
+	if entry.Flags&NBFlagGroup == 0 {
+		t.Errorf("group query answer: G bit not set in RR NB_FLAGS (0x%04X)", entry.Flags)
+	}
+	if response.Header.Flags&0x0080 != 0 {
+		t.Errorf("group query answer: header 0x0080 (RA) bit must not be used as a group bit (flags=0x%04X)", response.Header.Flags)
+	}
+
+	// Registration: the G bit in the RR NB_FLAGS drives the unique/group type.
+	nbns2 := NewNetBIOSNameServer(false)
+	h2 := NewPacketHandler(nbns2)
+	groupEntry := ADDR_ENTRY{Flags: NBFlagGroup, Address: 0xC0A8010B}
+	regReq := &NBNSPacket{
+		Header: NBNSHeader{Flags: OpRegistration}, // header 0x0080 intentionally clear
+		Answers: []NBNSResourceRecord{{
+			Name:     &NetBIOSName{Name: "REGGRP"},
+			Type:     QuestionTypeNB,
+			Class:    QuestionClassIn,
+			RDLength: 6,
+			RData:    groupEntry.Marshal(),
+		}},
+	}
+	h2.handleRegistration(regReq, &NBNSPacket{})
+	_, nameType, _, err := nbns2.QueryName("REGGRP", "")
+	if err != nil {
+		t.Fatalf("QueryName after registration: %v", err)
+	}
+	if nameType != Group {
+		t.Errorf("registration name type: got %v, want Group", nameType)
+	}
+}

--- a/network/netbios/nbns/packet.go
+++ b/network/netbios/nbns/packet.go
@@ -27,12 +27,16 @@ const (
 	RcodeActive      uint16 = 0x0006
 	RcodeConflict    uint16 = 0x0007
 
-	// Flags
-	FlagResponse      uint16 = 0x8000
-	FlagAuthoritative uint16 = 0x0400
-	FlagTruncated     uint16 = 0x0200
-	FlagRecursion     uint16 = 0x0100
-	FlagBroadcast     uint16 = 0x0010
+	// Header NM_FLAGS (RFC 1002 4.2.1.1: R | OPCODE | AA TC RD RA 0 0 B | RCODE)
+	FlagResponse           uint16 = 0x8000 // R:  response
+	FlagAuthoritative      uint16 = 0x0400 // AA: authoritative answer
+	FlagTruncated          uint16 = 0x0200 // TC: truncated
+	FlagRecursion          uint16 = 0x0100 // RD: recursion desired
+	FlagRecursionAvailable uint16 = 0x0080 // RA: recursion available
+	FlagBroadcast          uint16 = 0x0010 // B:  broadcast/multicast
+
+	// RcodeMask isolates the RCODE field (low nibble) of the header flags.
+	RcodeMask uint16 = 0x000F
 
 	// Question Type
 	QuestionTypeNB     uint16 = 0x0020


### PR DESCRIPTION
### Linked Issue
`Closes #967`

### Root Cause
The NBNS code conflated the header NM_FLAGS with the resource-record NB_FLAGS. Per RFC 1002 4.2.1.1 the header second word is `R | OPCODE | AA TC RD RA 0 0 B | RCODE`, so `0x0080` is the RA (recursion available) bit — not a group indicator. The Group (G) name flag is the most significant bit (`0x8000`) of the 16-bit NB_FLAGS field carried in each ADDR_ENTRY (RFC 1002 4.2.1.3). The code set/read `0x0080` in the header as a "group name" bit, and there was no RA constant. Separately, the challenger tested ownership with `flags & RcodeNameError`, a bitmask test that is also true for RCODE 1 (FMT_ERR) and 2 (SRV_ERR) because those share bits with RCODE 3 — RCODE is the low nibble and must be compared, not masked.

### Fix Description
- Added `FlagRecursionAvailable = 0x0080` (RA) to the header NM_FLAG block and documented the full flag word against RFC 1002 4.2.1.1.
- Added `NBFlagGroup = 0x8000` next to `ADDR_ENTRY` and a `RcodeMask = 0x000F` helper.
- Name-query response and name-defense paths now set the G bit in each record's NB_FLAGS instead of the header; registration reads the unique/group distinction from the record NB_FLAGS (unmarshalling the full `ADDR_ENTRY`) rather than the header `0x0080`.
- The challenger now classifies NAME_ERROR with `flags & RcodeMask == RcodeNameError`.

### How Verified
- `go build ./... && go vet ./network/netbios/... && go test ./network/netbios/...` all green.
- Live-validated against a Windows Server 2016 host (TMP-W-2016) by sending a real NAME QUERY built with the corrected encoder to `:137/udp`: the host answered, header flags decoded sanely (R=1, AA=1, RA=0, RCODE=0), the masked NAME_ERROR test was correctly false, and the record NB_FLAGS (0x6000, G=0 → unique) was read from the resource record rather than the header — no RA/group confusion.

### Test Coverage
- **Added:** `TestFlagBitLayout` (asserts RA=0x0080, NBFlagGroup=0x8000, RcodeMask=0x000F), `TestRcodeNameErrorMatch` (RCODE 1/2 are not NAME_ERROR, RCODE 3 is), and `TestGroupBitInResourceRecord` (group query response sets G in the RR NB_FLAGS and leaves header 0x0080 clear; group registration is read from the RR NB_FLAGS).

### Scope of Change
- **Files changed:** `network/netbios/nbns/{packet,name,handlers,challenge}.go`, `network/netbios/nbns/nbtns_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none