### PR TITLE
Implement 17-bit NBT SESSION MESSAGE length framing (Fixes #968)

### DIFF
--- a/network/netbios/nbt/nbt.go
+++ b/network/netbios/nbt/nbt.go
@@ -70,13 +70,21 @@ func (n *NBTTransport) Send(data []byte) (int, error) {
 		return 0, fmt.Errorf("not connected")
 	}
 
+	// RFC 1002 4.3.1: the session header is TYPE(8) | FLAGS(8) | LENGTH(16).
+	// Bit 0 of the FLAGS byte (E) is the length-extension bit and acts as the
+	// high-order 17th bit of LENGTH, so the payload may range from 0 to 131071.
+	length := len(data)
+	if length > 0x1FFFF {
+		return 0, fmt.Errorf("NetBIOS session message too large: %d bytes (max %d)", length, 0x1FFFF)
+	}
+
 	// Create NetBIOS header
 	header := []byte{}
 	// Set message type to Session Message (0x00)
 	header = append(header, byte(netbios.SESSION_MESSAGE))
-	// Set length in big-endian format
-	length := len(data)
-	header = append(header, 0x00)
+	// Set the FLAGS byte: bit 0 carries the 17th (high-order) length bit
+	header = append(header, byte((length>>16)&0x01))
+	// Set the low 16 bits of the length in big-endian format
 	header = append(header, byte((length>>8)&0xFF))
 	header = append(header, byte(length&0xFF))
 
@@ -108,9 +116,11 @@ func (n *NBTTransport) Receive() ([]byte, error) {
 		return nil, fmt.Errorf("failed to read NetBIOS header: %v", err)
 	}
 
-	// Parse message type and length
+	// Parse message type and length. RFC 1002 4.3.1: bit 0 of the FLAGS byte
+	// (header[1]) is the length-extension bit, forming the 17th (high-order)
+	// bit of the LENGTH field carried in header[2..3].
 	messageType := header[0]
-	length := (int(header[2]) << 8) | int(header[3])
+	length := (int(header[1]&0x01) << 16) | (int(header[2]) << 8) | int(header[3])
 
 	// Verify message type is Session Message (0x00)
 	if messageType != 0x00 {

--- a/network/netbios/nbt/nbt_test.go
+++ b/network/netbios/nbt/nbt_test.go
@@ -1,12 +1,204 @@
 package nbt_test
 
 import (
+	"bytes"
+	"io"
 	"net"
 	"testing"
 	"time"
 
 	"github.com/TheManticoreProject/Manticore/network/netbios/nbt"
 )
+
+// connectedPair returns a connected NBTTransport together with the raw
+// server-side connection it is talking to, so tests can inspect or produce
+// exact wire bytes. The returned cleanup closes both ends and the listener.
+func connectedPair(t *testing.T) (*nbt.NBTTransport, net.Conn, func()) {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start test server: %v", err)
+	}
+
+	type accepted struct {
+		conn net.Conn
+		err  error
+	}
+	ch := make(chan accepted, 1)
+	go func() {
+		c, err := ln.Accept()
+		ch <- accepted{c, err}
+	}()
+
+	addr := ln.Addr().(*net.TCPAddr)
+	tr := nbt.NewNBTTransport()
+	tr.SetTimeout(5 * time.Second)
+	if err := tr.Connect(addr.IP, addr.Port); err != nil {
+		ln.Close()
+		t.Fatalf("NBTTransport.Connect() error = %v", err)
+	}
+
+	a := <-ch
+	if a.err != nil {
+		tr.Close()
+		ln.Close()
+		t.Fatalf("failed to accept connection: %v", a.err)
+	}
+
+	cleanup := func() {
+		tr.Close()
+		if a.conn != nil {
+			a.conn.Close()
+		}
+		ln.Close()
+	}
+	return tr, a.conn, cleanup
+}
+
+// TestNBTTransport_SendFramesSub64K asserts the exact wire bytes emitted for a
+// payload below 65536 bytes: the FLAGS byte (header[1]) is 0x00 and LENGTH is
+// carried in the low 16 bits.
+func TestNBTTransport_SendFramesSub64K(t *testing.T) {
+	tr, srv, cleanup := connectedPair(t)
+	defer cleanup()
+
+	payload := []byte("test")
+	if _, err := tr.Send(payload); err != nil {
+		t.Fatalf("NBTTransport.Send() error = %v", err)
+	}
+
+	got := make([]byte, 4+len(payload))
+	if _, err := io.ReadFull(srv, got); err != nil {
+		t.Fatalf("failed to read framed message: %v", err)
+	}
+
+	want := []byte{0x00, 0x00, 0x00, 0x04, 't', 'e', 's', 't'}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("framed bytes = % x, want % x", got, want)
+	}
+}
+
+// TestNBTTransport_SendFramesOver64K asserts that a payload larger than 65535
+// bytes sets the length-extension bit (header[1] & 0x01) and encodes the 17th
+// length bit correctly alongside the low 16 bits.
+func TestNBTTransport_SendFramesOver64K(t *testing.T) {
+	tr, srv, cleanup := connectedPair(t)
+	defer cleanup()
+
+	// 0x1ABCD == 109517 bytes: high bit set, low bytes 0xAB and 0xCD.
+	const n = 0x1ABCD
+	payload := make([]byte, n)
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := tr.Send(payload)
+		errCh <- err
+	}()
+
+	header := make([]byte, 4)
+	if _, err := io.ReadFull(srv, header); err != nil {
+		t.Fatalf("failed to read framed header: %v", err)
+	}
+	want := []byte{0x00, 0x01, 0xAB, 0xCD}
+	if !bytes.Equal(header, want) {
+		t.Fatalf("framed header = % x, want % x", header, want)
+	}
+	if _, err := io.CopyN(io.Discard, srv, n); err != nil {
+		t.Fatalf("failed to drain payload: %v", err)
+	}
+	if err := <-errCh; err != nil {
+		t.Fatalf("NBTTransport.Send() error = %v", err)
+	}
+}
+
+// TestNBTTransport_SendRejectsTooLarge verifies that a payload exceeding the
+// 17-bit maximum (131071 bytes) is rejected instead of being mis-framed.
+func TestNBTTransport_SendRejectsTooLarge(t *testing.T) {
+	tr, srv, cleanup := connectedPair(t)
+	defer cleanup()
+
+	// Keep draining so a (mistaken) write cannot block the test.
+	go io.Copy(io.Discard, srv)
+
+	payload := make([]byte, 0x1FFFF+1)
+	if _, err := tr.Send(payload); err == nil {
+		t.Fatal("NBTTransport.Send() should reject payloads larger than 131071 bytes")
+	}
+}
+
+// TestNBTTransport_ReceiveParsesExtensionBit feeds fixed wire vectors into
+// Receive and checks that the extension bit in header[1] is combined as the
+// 17th length bit, for both the sub-64K and over-64K cases.
+func TestNBTTransport_ReceiveParsesExtensionBit(t *testing.T) {
+	tests := []struct {
+		name   string
+		header []byte
+		length int
+	}{
+		{name: "sub-64K", header: []byte{0x00, 0x00, 0x00, 0x04}, length: 4},
+		{name: "over-64K", header: []byte{0x00, 0x01, 0x00, 0x02}, length: (1 << 16) | 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tr, srv, cleanup := connectedPair(t)
+			defer cleanup()
+
+			go func() {
+				srv.Write(tt.header)
+				srv.Write(make([]byte, tt.length))
+			}()
+
+			got, err := tr.Receive()
+			if err != nil {
+				t.Fatalf("NBTTransport.Receive() error = %v", err)
+			}
+			if len(got) != tt.length {
+				t.Fatalf("Receive() returned %d bytes, want %d", len(got), tt.length)
+			}
+		})
+	}
+}
+
+// TestNBTTransport_SendReceiveRoundTrip proves the framing round-trips: the
+// bytes produced by Send are echoed back and parsed by Receive into the exact
+// original payload, for both the sub-64K and over-64K length paths.
+func TestNBTTransport_SendReceiveRoundTrip(t *testing.T) {
+	tests := []struct {
+		name   string
+		length int
+	}{
+		{name: "sub-64K", length: 512},
+		{name: "over-64K", length: 65538},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tr, srv, cleanup := connectedPair(t)
+			defer cleanup()
+
+			payload := make([]byte, tt.length)
+			for i := range payload {
+				payload[i] = byte(i)
+			}
+
+			// Echo whatever bytes Send produces straight back to the transport.
+			go io.Copy(srv, srv)
+
+			if _, err := tr.Send(payload); err != nil {
+				t.Fatalf("NBTTransport.Send() error = %v", err)
+			}
+			got, err := tr.Receive()
+			if err != nil {
+				t.Fatalf("NBTTransport.Receive() error = %v", err)
+			}
+			if !bytes.Equal(got, payload) {
+				t.Fatalf("round-trip payload mismatch: got %d bytes, want %d", len(got), len(payload))
+			}
+		})
+	}
+}
 
 func TestNBTTransport_Connect(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
### Linked Issue
`Closes #968`

### Root Cause
The NBT session-message framing implemented only a 16-bit length and ignored the length-extension flag. RFC 1002 4.3.1 defines the session header as `TYPE(8) | FLAGS(8) | LENGTH(16)`, where bit 0 of the FLAGS byte (E) acts as an additional high-order bit of LENGTH, giving a 17-bit length (max 131071). The send path hardcoded `header[1]=0x00` and encoded only 16 length bits; the receive path computed `length = header[2]<<8 | header[3]` and never consulted `header[1]`. Payloads larger than 65535 bytes were therefore mis-framed and an inbound frame using the extension bit was truncated, desynchronizing the stream.

### Fix Description
- Send: encode the 17th length bit into the FLAGS byte (`header[1] = (length>>16)&0x01`, which is `0x00` for sub-64K payloads), encode the low 16 bits in `header[2..3]`, and reject payloads larger than `0x1FFFF` (131071) with an error.
- Receive: compute `length = (int(header[1]&0x01) << 16) | (int(header[2]) << 8) | int(header[3])`.
- The existing SESSION_MESSAGE (0x00) type check and behavior are preserved.

### How Verified
- `go build ./...`, `go vet ./network/netbios/...`, and `go test ./network/netbios/...` all pass; `gofmt` clean.
- Live-validated against a Windows Server 2016 host: a full SMB2 NEGOTIATE was driven over the NBT (port 139) transport through the modified framing, negotiating dialect 0x0311. The sub-64K send path (`header[1]=0x00`) was unaffected and the receive path parsed the real server response header, confirming no regression.

### Test Coverage
**Added** in `network/netbios/nbt/nbt_test.go`:
- `TestNBTTransport_SendFramesSub64K` — asserts exact wire bytes for a sub-64K payload (`header[1]==0x00`).
- `TestNBTTransport_SendFramesOver64K` — asserts the extension bit and 17th length bit for a 109517-byte payload (`header == 00 01 AB CD`).
- `TestNBTTransport_SendRejectsTooLarge` — payload > 131071 bytes is rejected.
- `TestNBTTransport_ReceiveParsesExtensionBit` — fixed receive vectors for sub-64K and over-64K.
- `TestNBTTransport_SendReceiveRoundTrip` — send->parse round-trip for both length paths.

### Scope of Change
- **Files changed:** `network/netbios/nbt/nbt.go`, `network/netbios/nbt/nbt_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none