### PR TITLE
Add NBNS wire round-trip and RFC 1001 name-encoding KAT tests (Fixes #969)

### DIFF
--- a/network/netbios/nbns/name_test.go
+++ b/network/netbios/nbns/name_test.go
@@ -1,0 +1,177 @@
+package nbns
+
+import (
+	"testing"
+)
+
+// TestFirstLevelEncodeRFC1001KAT is the canonical known-answer test from
+// RFC 1001 section 4.1: the 16-byte NetBIOS name "FRED" padded to 16 bytes
+// with spaces (0x20) first-level encodes to "EGFCEFEECACACACACACACACACACACACA".
+// Each nibble is split high-then-low and offset by ASCII 'A' (0x41); a space
+// byte (0x20) therefore encodes to the pair "CA".
+func TestFirstLevelEncodeRFC1001KAT(t *testing.T) {
+	const want = "EGFCEFEECACACACACACACACACACACACA"
+
+	n := &NetBIOSName{Name: "FRED"}
+	got, err := n.FirstLevelEncode()
+	if err != nil {
+		t.Fatalf("FirstLevelEncode returned error: %v", err)
+	}
+	if got != want {
+		t.Fatalf("FirstLevelEncode(%q) = %q, want %q", n.Name, got, want)
+	}
+	if len(got) != EncodedNameLength {
+		t.Fatalf("encoded length = %d, want %d", len(got), EncodedNameLength)
+	}
+}
+
+// TestFirstLevelDecodeRFC1001KAT is the inverse of the RFC 1001 4.1 example:
+// decoding "EGFCEFEECACACACACACACACACACACACA" yields "FRED" (trailing space
+// padding trimmed).
+func TestFirstLevelDecodeRFC1001KAT(t *testing.T) {
+	const encoded = "EGFCEFEECACACACACACACACACACACACA"
+
+	nb, err := FirstLevelDecode(encoded)
+	if err != nil {
+		t.Fatalf("FirstLevelDecode returned error: %v", err)
+	}
+	if nb.Name != "FRED" {
+		t.Fatalf("FirstLevelDecode(%q).Name = %q, want %q", encoded, nb.Name, "FRED")
+	}
+	if nb.ScopeID != "" {
+		t.Fatalf("FirstLevelDecode(%q).ScopeID = %q, want empty", encoded, nb.ScopeID)
+	}
+}
+
+// TestFirstLevelEncodeWithScopeID checks that a scope identifier is appended
+// as an RFC 1001 4.1 domain suffix ("<encoded>.<scope>").
+func TestFirstLevelEncodeWithScopeID(t *testing.T) {
+	const want = "EGFCEFEECACACACACACACACACACACACA.NETBIOS.COM"
+
+	n := &NetBIOSName{Name: "FRED", ScopeID: "NETBIOS.COM"}
+	got, err := n.FirstLevelEncode()
+	if err != nil {
+		t.Fatalf("FirstLevelEncode returned error: %v", err)
+	}
+	if got != want {
+		t.Fatalf("FirstLevelEncode with scope = %q, want %q", got, want)
+	}
+
+	nb, err := FirstLevelDecode(got)
+	if err != nil {
+		t.Fatalf("FirstLevelDecode returned error: %v", err)
+	}
+	if nb.Name != "FRED" {
+		t.Fatalf("round-trip Name = %q, want %q", nb.Name, "FRED")
+	}
+	if nb.ScopeID != "NETBIOS.COM" {
+		t.Fatalf("round-trip ScopeID = %q, want %q", nb.ScopeID, "NETBIOS.COM")
+	}
+}
+
+// TestFirstLevelEncodeSuffixByte verifies that a name whose 16th byte carries
+// a NetBIOS suffix (service identifier) survives encode/decode. Here the name
+// occupies 15 bytes and the 16th byte is the workstation-service suffix 0x00.
+// The trailing 0x00 encodes to "AA" and, unlike a space, is NOT trimmed on
+// decode, so the decoded name retains the embedded suffix byte.
+func TestFirstLevelEncodeSuffixByte(t *testing.T) {
+	// 15-char base + a single explicit suffix byte in position 16.
+	base := "WORKSTATION1234"
+	name := base + string([]byte{0x00})
+
+	n := &NetBIOSName{Name: name}
+	encoded, err := n.FirstLevelEncode()
+	if err != nil {
+		t.Fatalf("FirstLevelEncode returned error: %v", err)
+	}
+	if len(encoded) != EncodedNameLength {
+		t.Fatalf("encoded length = %d, want %d", len(encoded), EncodedNameLength)
+	}
+	// 0x00 -> high nibble 0 ('A'), low nibble 0 ('A').
+	if last := encoded[len(encoded)-2:]; last != "AA" {
+		t.Fatalf("suffix byte encoding = %q, want %q", last, "AA")
+	}
+
+	nb, err := FirstLevelDecode(encoded)
+	if err != nil {
+		t.Fatalf("FirstLevelDecode returned error: %v", err)
+	}
+	if nb.Name != name {
+		t.Fatalf("round-trip Name = %q (% x), want %q (% x)", nb.Name, nb.Name, name, name)
+	}
+}
+
+// TestFirstLevelRoundTripFuzz encodes then decodes a handful of names and
+// asserts the space-trimmed value is recovered. Names shorter than 16 bytes
+// are padded with spaces on encode and trimmed on decode, so the recovered
+// value equals the original with trailing spaces removed.
+func TestFirstLevelRoundTripFuzz(t *testing.T) {
+	names := []string{
+		"A",
+		"FRED",
+		"WORKSTATION",
+		"SIXTEENCHARLONG!", // exactly 16 bytes
+		"HOST-01",
+		"*SMBSERVER",
+	}
+
+	for _, name := range names {
+		// "*SMBSERVER" starts with '*', which Validate rejects; skip it as
+		// an encode input but keep it documented as an invalid case below.
+		if name == "*SMBSERVER" {
+			n := &NetBIOSName{Name: name}
+			if _, err := n.FirstLevelEncode(); err == nil {
+				t.Errorf("FirstLevelEncode(%q) expected error (name cannot start with *)", name)
+			}
+			continue
+		}
+
+		n := &NetBIOSName{Name: name}
+		encoded, err := n.FirstLevelEncode()
+		if err != nil {
+			t.Errorf("FirstLevelEncode(%q) error: %v", name, err)
+			continue
+		}
+
+		nb, err := FirstLevelDecode(encoded)
+		if err != nil {
+			t.Errorf("FirstLevelDecode(%q) error: %v", encoded, err)
+			continue
+		}
+
+		if nb.Name != name {
+			t.Errorf("round-trip %q -> %q -> %q", name, encoded, nb.Name)
+		}
+	}
+}
+
+// TestFirstLevelEncodeTooLong ensures a name exceeding 16 bytes is rejected.
+func TestFirstLevelEncodeTooLong(t *testing.T) {
+	n := &NetBIOSName{Name: "THISNAMEISWAYTOOLONG"}
+	if _, err := n.FirstLevelEncode(); err == nil {
+		t.Fatalf("FirstLevelEncode expected error for over-long name")
+	}
+}
+
+// TestFirstLevelDecodeErrors covers malformed encoded inputs: wrong length and
+// characters outside the RFC 1001 'A'..'P' half-ASCII alphabet.
+func TestFirstLevelDecodeErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		encoded string
+	}{
+		{"too short", "EGFC"},
+		{"too long", "EGFCEFEECACACACACACACACACACACACAA"},
+		{"empty", ""},
+		{"out of range char", "EGFCEFEECACACACACACACACACACACAC0"}, // '0' < 'A'
+		{"high char", "ZGFCEFEECACACACACACACACACACACACA"},         // 'Z'-'A' = 25 > 0x0F
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := FirstLevelDecode(tc.encoded); err == nil {
+				t.Fatalf("FirstLevelDecode(%q) expected error, got nil", tc.encoded)
+			}
+		})
+	}
+}

--- a/network/netbios/nbns/packet_test.go
+++ b/network/netbios/nbns/packet_test.go
@@ -1,0 +1,239 @@
+package nbns
+
+import (
+	"net"
+	"testing"
+)
+
+// TestNBNSPacketNameQueryRequestRoundTrip marshals a NAME QUERY REQUEST and
+// unmarshals it back, asserting the header fields, flags/counts, and the
+// question section survive the wire round-trip.
+func TestNBNSPacketNameQueryRequestRoundTrip(t *testing.T) {
+	req := &NBNSPacket{
+		Header: NBNSHeader{
+			TransactionID: 0x1234,
+			Flags:         OpNameQuery | FlagRecursion | FlagBroadcast,
+			Questions:     1,
+		},
+		Questions: []NBNSQuestion{
+			{
+				Name:  &NetBIOSName{Name: "FRED"},
+				Type:  QuestionTypeNB,
+				Class: QuestionClassIn,
+			},
+		},
+	}
+
+	data, err := req.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal returned error: %v", err)
+	}
+
+	var got NBNSPacket
+	consumed, err := got.Unmarshal(data)
+	if err != nil {
+		t.Fatalf("Unmarshal returned error: %v", err)
+	}
+	if consumed != len(data) {
+		t.Fatalf("Unmarshal consumed %d bytes, want %d", consumed, len(data))
+	}
+
+	if got.Header.TransactionID != req.Header.TransactionID {
+		t.Errorf("TransactionID = 0x%04x, want 0x%04x", got.Header.TransactionID, req.Header.TransactionID)
+	}
+	if got.Header.Flags != req.Header.Flags {
+		t.Errorf("Flags = 0x%04x, want 0x%04x", got.Header.Flags, req.Header.Flags)
+	}
+	if got.Header.Flags&FlagResponse != 0 {
+		t.Errorf("request should not have the response flag set: 0x%04x", got.Header.Flags)
+	}
+	if got.Header.Questions != 1 {
+		t.Errorf("Questions = %d, want 1", got.Header.Questions)
+	}
+	if len(got.Questions) != 1 {
+		t.Fatalf("decoded %d questions, want 1", len(got.Questions))
+	}
+
+	q := got.Questions[0]
+	if q.Name == nil || q.Name.Name != "FRED" {
+		t.Errorf("question name = %+v, want FRED", q.Name)
+	}
+	if q.Type != QuestionTypeNB {
+		t.Errorf("question type = 0x%04x, want 0x%04x", q.Type, QuestionTypeNB)
+	}
+	if q.Class != QuestionClassIn {
+		t.Errorf("question class = 0x%04x, want 0x%04x", q.Class, QuestionClassIn)
+	}
+}
+
+// TestNBNSPacketNameQueryResponseRoundTrip marshals a POSITIVE NAME QUERY
+// RESPONSE carrying an NB answer resource record whose RDATA is an ADDR_ENTRY
+// (NB_FLAGS + IPv4 address), then unmarshals it and asserts the flags, counts
+// and decoded IP address survive.
+func TestNBNSPacketNameQueryResponseRoundTrip(t *testing.T) {
+	const wantIP = "192.168.1.50"
+
+	entry := ADDR_ENTRY{
+		Flags:   0x0000, // unique name, B-node owner
+		Address: ipToUint32(t, wantIP),
+	}
+	rdata := entry.Marshal()
+
+	resp := &NBNSPacket{
+		Header: NBNSHeader{
+			TransactionID: 0xBEEF,
+			Flags:         FlagResponse | OpNameQuery | FlagAuthoritative | FlagRecursion | FlagRecursionAvailable,
+			Answers:       1,
+		},
+		Answers: []NBNSResourceRecord{
+			{
+				Name:     &NetBIOSName{Name: "FRED"},
+				Type:     QuestionTypeNB,
+				Class:    QuestionClassIn,
+				TTL:      300,
+				RDLength: uint16(len(rdata)),
+				RData:    rdata,
+			},
+		},
+	}
+
+	data, err := resp.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal returned error: %v", err)
+	}
+
+	var got NBNSPacket
+	if _, err := got.Unmarshal(data); err != nil {
+		t.Fatalf("Unmarshal returned error: %v", err)
+	}
+
+	if got.Header.Flags&FlagResponse == 0 {
+		t.Errorf("response flag not set: 0x%04x", got.Header.Flags)
+	}
+	if got.Header.Flags&FlagAuthoritative == 0 {
+		t.Errorf("authoritative flag not set: 0x%04x", got.Header.Flags)
+	}
+	if got.Header.Flags != resp.Header.Flags {
+		t.Errorf("Flags = 0x%04x, want 0x%04x", got.Header.Flags, resp.Header.Flags)
+	}
+	if got.Header.Answers != 1 {
+		t.Errorf("Answers = %d, want 1", got.Header.Answers)
+	}
+	if len(got.Answers) != 1 {
+		t.Fatalf("decoded %d answers, want 1", len(got.Answers))
+	}
+
+	rr := got.Answers[0]
+	if rr.Name == nil || rr.Name.Name != "FRED" {
+		t.Errorf("answer name = %+v, want FRED", rr.Name)
+	}
+	if rr.Type != QuestionTypeNB {
+		t.Errorf("answer type = 0x%04x, want 0x%04x", rr.Type, QuestionTypeNB)
+	}
+	if rr.TTL != 300 {
+		t.Errorf("answer TTL = %d, want 300", rr.TTL)
+	}
+
+	ip, err := ParseIPFromRData(rr.RData)
+	if err != nil {
+		t.Fatalf("ParseIPFromRData returned error: %v", err)
+	}
+	if !ip.Equal(net.ParseIP(wantIP)) {
+		t.Errorf("decoded IP = %v, want %v", ip, wantIP)
+	}
+}
+
+// TestNBNSPacketGroupFlag confirms the NB_FLAGS Group bit in an ADDR_ENTRY
+// round-trips through the RR RDATA.
+func TestNBNSPacketGroupFlag(t *testing.T) {
+	entry := ADDR_ENTRY{
+		Flags:   NBFlagGroup,
+		Address: ipToUint32(t, "10.0.0.1"),
+	}
+	rdata := entry.Marshal()
+
+	var decoded ADDR_ENTRY
+	if err := decoded.Unmarshal(rdata); err != nil {
+		t.Fatalf("ADDR_ENTRY.Unmarshal returned error: %v", err)
+	}
+	if decoded.Flags&NBFlagGroup == 0 {
+		t.Errorf("group flag lost: 0x%04x", decoded.Flags)
+	}
+	if !decoded.IP().Equal(net.ParseIP("10.0.0.1")) {
+		t.Errorf("decoded IP = %v, want 10.0.0.1", decoded.IP())
+	}
+}
+
+// TestNBNSPacketUnmarshalErrors asserts that malformed or truncated inputs
+// return an error rather than panicking.
+func TestNBNSPacketUnmarshalErrors(t *testing.T) {
+	// A valid response we can truncate at various points.
+	entry := ADDR_ENTRY{Address: ipToUint32(t, "192.168.1.50")}
+	rdata := entry.Marshal()
+	valid := &NBNSPacket{
+		Header: NBNSHeader{
+			TransactionID: 1,
+			Flags:         FlagResponse | OpNameQuery,
+			Answers:       1,
+		},
+		Answers: []NBNSResourceRecord{
+			{
+				Name:     &NetBIOSName{Name: "FRED"},
+				Type:     QuestionTypeNB,
+				Class:    QuestionClassIn,
+				TTL:      300,
+				RDLength: uint16(len(rdata)),
+				RData:    rdata,
+			},
+		},
+	}
+	full, err := valid.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal returned error: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		data []byte
+	}{
+		{"empty", []byte{}},
+		{"short header", []byte{0x00, 0x01, 0x02}},
+		{"header only, claims 1 question", func() []byte {
+			b := make([]byte, 12)
+			b[5] = 0x01 // Questions = 1, but no question bytes follow
+			return b
+		}()},
+		{"header only, claims 1 answer", func() []byte {
+			b := make([]byte, 12)
+			b[7] = 0x01 // Answers = 1, but no RR bytes follow
+			return b
+		}()},
+		{"truncated mid-rdata", full[:len(full)-2]},
+		{"truncated mid-record", full[:20]},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var p NBNSPacket
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("Unmarshal panicked on %s: %v", tc.name, r)
+				}
+			}()
+			if _, err := p.Unmarshal(tc.data); err == nil {
+				t.Fatalf("Unmarshal(%s) expected error, got nil", tc.name)
+			}
+		})
+	}
+}
+
+// ipToUint32 converts a dotted-quad IPv4 string into the big-endian uint32
+// used by ADDR_ENTRY.Address.
+func ipToUint32(t *testing.T, s string) uint32 {
+	t.Helper()
+	ip := net.ParseIP(s).To4()
+	if ip == nil {
+		t.Fatalf("invalid IPv4 address %q", s)
+	}
+	return uint32(ip[0])<<24 | uint32(ip[1])<<16 | uint32(ip[2])<<8 | uint32(ip[3])
+}


### PR DESCRIPTION
### Linked Issue
`Closes #969`

### Summary
Adds direct, byte-exact tests for the NBNS wire codec (`network/netbios/nbns/packet.go`) and NetBIOS first-level name encoding (`network/netbios/nbns/name.go`), which previously had no direct coverage.

### Test Description
- **`name_test.go`**
  - RFC 1001 §4.1 known-answer test: the 16-byte name `"FRED"` padded with spaces first-level encodes to `EGFCEFEECACACACACACACACACACACACA` (each nibble split high-then-low, offset by ASCII `A`; space `0x20` -> `CA`), plus the decode inverse.
  - Scope-ID suffix (`<encoded>.NETBIOS.COM`) round-trip.
  - A non-space suffix byte (`0x00`) that survives decode (only trailing spaces are trimmed).
  - Round-trip coverage over several names, over-long-name rejection, and malformed decode inputs (wrong length, characters outside the `A`..`P` half-ASCII alphabet).
- **`packet_test.go`**
  - `Marshal`->`Unmarshal` round-trips for a NAME QUERY REQUEST and a positive NAME QUERY RESPONSE carrying an NB answer RR (`ADDR_ENTRY`: NB_FLAGS + IPv4), asserting header flags/counts and the decoded IP survive.
  - NB group-flag (`NBFlagGroup`) round-trip through RR RDATA.
  - Malformed/short-buffer inputs return an error rather than panicking (empty, short header, count/body mismatch, mid-record and mid-RDATA truncation).

### How Verified
- `go build ./...`, `go vet ./network/netbios/...` clean.
- `go test ./network/netbios/... -run 'Name|Packet|NBNS' -v` all pass.
- The KAT matches the RFC 1001 §4.1 published value `EGFCEFEECACACACACACACACACACACACA` (cross-checked against the RFC text).
- Real-wire sanity check: a NAME QUERY built by this codec was sent to a live Windows 2016 NBNS host on 137/udp; the 68-byte response `Unmarshal`ed cleanly (echoed transaction ID, response+authoritative flags, one NB answer RR). Read-only, no server state changed.

### Test Coverage
- **Added:** `network/netbios/nbns/name_test.go`, `network/netbios/nbns/packet_test.go`.

### Scope of Change
- **Files changed:** `network/netbios/nbns/name_test.go`, `network/netbios/nbns/packet_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the tests:** none (test-only; no production code modified)
