### PR TITLE
Encode NetBIOS scope names as RFC 1002 label sequences and decode 0xC0 pointers (Fixes #970)

### DIFF
--- a/network/netbios/nbns/packet.go
+++ b/network/netbios/nbns/packet.go
@@ -3,7 +3,128 @@ package nbns
 import (
 	"encoding/binary"
 	"fmt"
+	"strings"
 )
+
+// Label sequence encoding limits (RFC 1002 4.2.1.2 / RFC 1035 4.1.4).
+const (
+	// maxLabelLength is the largest label a single length octet can describe;
+	// the top two bits are reserved as compression/escape flags.
+	maxLabelLength = 0x3F // 63
+	// labelPointerFlag marks a length octet whose top two bits are 0b11,
+	// indicating a 14-bit message-relative compression pointer follows.
+	labelPointerFlag = 0xC0
+	// labelFlagMask isolates the two most-significant bits of a length octet.
+	labelFlagMask = 0xC0
+	// maxNamePointers bounds the number of compression pointers a single name
+	// may follow, guarding against pointer loops and malicious chains.
+	maxNamePointers = 128
+)
+
+// marshalName encodes a NetBIOS name as an RFC 1002 4.2.1.2 label sequence:
+// the first label is the 32-byte first-level-encoded name, each scope
+// component is a further length-prefixed label, and the sequence is
+// terminated by a zero-length (0x00) root label. A name with no scope
+// therefore encodes as a single 32-byte label followed by 0x00, matching
+// the historical single-label wire form.
+func marshalName(n *NetBIOSName) ([]byte, error) {
+	encoded, err := n.FirstLevelEncode()
+	if err != nil {
+		return nil, err
+	}
+
+	var buf []byte
+	for _, label := range strings.Split(encoded, ".") {
+		if len(label) > maxLabelLength {
+			return nil, fmt.Errorf("label too long: %d bytes (max %d)", len(label), maxLabelLength)
+		}
+		buf = append(buf, byte(len(label)))
+		buf = append(buf, label...)
+	}
+	buf = append(buf, 0x00) // root label / terminator
+
+	return buf, nil
+}
+
+// unmarshalName decodes an RFC 1002 4.2.1.2 label sequence starting at offset
+// in data, following any RFC 1035 4.1.4 compression pointers (length octet
+// with the top two bits set to 0b11, carrying a 14-bit message-relative
+// offset). It returns the decoded name and the number of bytes consumed at
+// the ORIGINAL offset: a name that begins with a pointer consumes exactly the
+// two pointer octets regardless of how far the pointer chain reaches.
+func unmarshalName(data []byte, offset int) (*NetBIOSName, int, error) {
+	var labels []string
+
+	pos := offset
+	consumed := 0     // bytes consumed at the original call site
+	followed := false // true once a pointer has been followed (stops advancing consumed)
+	pointers := 0
+
+	for {
+		if pos >= len(data) {
+			return nil, 0, fmt.Errorf("truncated name")
+		}
+
+		b := data[pos]
+
+		if b&labelFlagMask == labelPointerFlag {
+			// Compression pointer: a two-octet, 14-bit message-relative offset.
+			if pos+1 >= len(data) {
+				return nil, 0, fmt.Errorf("truncated compression pointer")
+			}
+			if !followed {
+				consumed += 2
+			}
+
+			pointers++
+			if pointers > maxNamePointers {
+				return nil, 0, fmt.Errorf("too many compression pointers (possible loop)")
+			}
+
+			target := (int(b&0x3F) << 8) | int(data[pos+1])
+			if target >= len(data) {
+				return nil, 0, fmt.Errorf("compression pointer out of range: %d", target)
+			}
+
+			pos = target
+			followed = true
+			continue
+		}
+
+		if b&labelFlagMask != 0 {
+			return nil, 0, fmt.Errorf("invalid label length flags: 0x%02x", b)
+		}
+
+		length := int(b)
+		if !followed {
+			consumed++
+		}
+		pos++
+
+		if length == 0 {
+			break // root label terminates the sequence
+		}
+
+		if pos+length > len(data) {
+			return nil, 0, fmt.Errorf("truncated label")
+		}
+
+		labels = append(labels, string(data[pos:pos+length]))
+		if !followed {
+			consumed += length
+		}
+		pos += length
+	}
+
+	// Reassemble the first-level name and scope components ("name.scope...")
+	// so FirstLevelDecode can split the encoded name from the scope ID.
+	name, err := FirstLevelDecode(strings.Join(labels, "."))
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to decode name: %v", err)
+	}
+
+	return name, consumed, nil
+}
 
 // Constants for packet types and flags
 const (
@@ -96,15 +217,13 @@ func (p *NBNSPacket) Marshal() ([]byte, error) {
 
 	// Marshal questions
 	for _, q := range p.Questions {
-		encoded, err := q.Name.FirstLevelEncode()
+		encoded, err := marshalName(q.Name)
 		if err != nil {
 			return nil, fmt.Errorf("failed to encode question name: %v", err)
 		}
 
-		// Add name length and name
-		buf = append(buf, byte(len(encoded)))
-		buf = append(buf, []byte(encoded)...)
-		buf = append(buf, byte(0x00)) // null terminator
+		// Add the name as an RFC 1002 4.2.1.2 label sequence
+		buf = append(buf, encoded...)
 
 		// Add type and class
 		buf = binary.BigEndian.AppendUint16(buf, q.Type)
@@ -114,15 +233,13 @@ func (p *NBNSPacket) Marshal() ([]byte, error) {
 	// Marshal resource records (answers, authority, additional)
 	for _, section := range [][]NBNSResourceRecord{p.Answers, p.Authority, p.Additional} {
 		for _, rr := range section {
-			encoded, err := rr.Name.FirstLevelEncode()
+			encoded, err := marshalName(rr.Name)
 			if err != nil {
 				return nil, fmt.Errorf("failed to encode resource record name: %v", err)
 			}
 
-			// Add name length and name
-			buf = append(buf, byte(len(encoded)))
-			buf = append(buf, []byte(encoded)...)
-			buf = append(buf, byte(0x00))
+			// Add the name as an RFC 1002 4.2.1.2 label sequence
+			buf = append(buf, encoded...)
 
 			// Add type, class, TTL, and RDATA length
 			buf = binary.BigEndian.AppendUint16(buf, rr.Type)
@@ -160,18 +277,11 @@ func (p *NBNSPacket) Unmarshal(data []byte) (int, error) {
 			return 0, fmt.Errorf("truncated packet")
 		}
 
-		nameLen := int(data[offset])
-		offset++
-
-		if offset+nameLen > len(data) {
-			return 0, fmt.Errorf("truncated name")
-		}
-
-		name, err := FirstLevelDecode(string(data[offset : offset+nameLen]))
+		name, consumed, err := unmarshalName(data, offset)
 		if err != nil {
-			return 0, fmt.Errorf("failed to decode name: %v", err)
+			return 0, fmt.Errorf("failed to decode question name: %v", err)
 		}
-		offset += nameLen + 1 // null terminator
+		offset += consumed
 
 		if offset+4 > len(data) {
 			return 0, fmt.Errorf("truncated question")
@@ -196,18 +306,11 @@ func (p *NBNSPacket) Unmarshal(data []byte) (int, error) {
 				return nil, fmt.Errorf("truncated packet")
 			}
 
-			nameLen := int(data[offset])
-			offset++
-
-			if offset+nameLen > len(data) {
-				return nil, fmt.Errorf("truncated name")
-			}
-
-			name, err := FirstLevelDecode(string(data[offset : offset+nameLen]))
+			name, consumed, err := unmarshalName(data, offset)
 			if err != nil {
-				return nil, fmt.Errorf("failed to decode name: %v", err)
+				return nil, fmt.Errorf("failed to decode resource record name: %v", err)
 			}
-			offset += nameLen + 1 // +1 for null terminator
+			offset += consumed
 
 			if offset+10 > len(data) {
 				return nil, fmt.Errorf("truncated resource record")

--- a/network/netbios/nbns/packet_test.go
+++ b/network/netbios/nbns/packet_test.go
@@ -227,6 +227,170 @@ func TestNBNSPacketUnmarshalErrors(t *testing.T) {
 	}
 }
 
+// TestNBNSPacketScopedNameRoundTrip marshals a NAME QUERY REQUEST whose
+// question name carries a multi-component scope ID and asserts the name and
+// scope survive the RFC 1002 4.2.1.2 label-sequence round-trip.
+func TestNBNSPacketScopedNameRoundTrip(t *testing.T) {
+	req := &NBNSPacket{
+		Header: NBNSHeader{
+			TransactionID: 0x2222,
+			Flags:         OpNameQuery | FlagRecursion,
+			Questions:     1,
+		},
+		Questions: []NBNSQuestion{
+			{
+				Name:  &NetBIOSName{Name: "NAME", ScopeID: "SCOPE.COM"},
+				Type:  QuestionTypeNB,
+				Class: QuestionClassIn,
+			},
+		},
+	}
+
+	data, err := req.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal returned error: %v", err)
+	}
+
+	// The name must encode as length-prefixed labels: 0x20 + 32-byte encoded
+	// name, then 0x05 "SCOPE", 0x03 "COM", terminated by 0x00.
+	if data[12] != 0x20 {
+		t.Fatalf("first label length = 0x%02x, want 0x20", data[12])
+	}
+	if got := data[12+1+32]; got != 0x05 {
+		t.Errorf("scope label length = 0x%02x, want 0x05 (SCOPE)", got)
+	}
+
+	var got NBNSPacket
+	consumed, err := got.Unmarshal(data)
+	if err != nil {
+		t.Fatalf("Unmarshal returned error: %v", err)
+	}
+	if consumed != len(data) {
+		t.Fatalf("Unmarshal consumed %d bytes, want %d", consumed, len(data))
+	}
+	if len(got.Questions) != 1 {
+		t.Fatalf("decoded %d questions, want 1", len(got.Questions))
+	}
+
+	q := got.Questions[0]
+	if q.Name == nil || q.Name.Name != "NAME" {
+		t.Errorf("question name = %+v, want NAME", q.Name)
+	}
+	if q.Name.ScopeID != "SCOPE.COM" {
+		t.Errorf("question scope = %q, want %q", q.Name.ScopeID, "SCOPE.COM")
+	}
+}
+
+// TestNBNSPacketCompressionPointer hand-builds a response whose single answer
+// name is a 0xC0 compression pointer back to the question name (as real
+// Windows NBNS replies commonly emit) and asserts the pointer-decode path
+// resolves it to the correct name and consumes exactly two octets for it.
+func TestNBNSPacketCompressionPointer(t *testing.T) {
+	// Encode the question name into a label sequence at a known offset.
+	qName := &NetBIOSName{Name: "FRED"}
+	encodedName, err := marshalName(qName)
+	if err != nil {
+		t.Fatalf("marshalName returned error: %v", err)
+	}
+
+	entry := ADDR_ENTRY{Address: ipToUint32(t, "192.168.1.50")}
+	rdata := entry.Marshal()
+
+	var b []byte
+	// Header: 1 question, 1 answer, response flag.
+	hdr := make([]byte, 12)
+	binaryPutUint16(hdr[0:2], 0x4444)
+	binaryPutUint16(hdr[2:4], FlagResponse|OpNameQuery)
+	binaryPutUint16(hdr[4:6], 1) // Questions
+	binaryPutUint16(hdr[6:8], 1) // Answers
+	b = append(b, hdr...)
+
+	// Question section: name (offset 12) + type + class.
+	questionNameOffset := len(b)
+	b = append(b, encodedName...)
+	b = binaryAppendUint16(b, QuestionTypeNB)
+	b = binaryAppendUint16(b, QuestionClassIn)
+
+	// Answer section: name is a compression pointer to the question name.
+	answerNameOffset := len(b)
+	b = append(b, byte(labelPointerFlag|(questionNameOffset>>8)), byte(questionNameOffset&0xFF))
+	b = binaryAppendUint16(b, QuestionTypeNB)     // type
+	b = binaryAppendUint16(b, QuestionClassIn)    // class
+	b = append(b, 0x00, 0x00, 0x01, 0x2c)         // TTL = 300
+	b = binaryAppendUint16(b, uint16(len(rdata))) // RDLength
+	b = append(b, rdata...)
+
+	var got NBNSPacket
+	consumed, err := got.Unmarshal(b)
+	if err != nil {
+		t.Fatalf("Unmarshal returned error: %v", err)
+	}
+	if consumed != len(b) {
+		t.Fatalf("Unmarshal consumed %d bytes, want %d", consumed, len(b))
+	}
+	if len(got.Answers) != 1 {
+		t.Fatalf("decoded %d answers, want 1", len(got.Answers))
+	}
+	if got.Answers[0].Name == nil || got.Answers[0].Name.Name != "FRED" {
+		t.Errorf("answer name via pointer = %+v, want FRED", got.Answers[0].Name)
+	}
+
+	// The pointer itself must consume exactly two octets at the answer name.
+	name, n, err := unmarshalName(b, answerNameOffset)
+	if err != nil {
+		t.Fatalf("unmarshalName(pointer) returned error: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("pointer consumed %d bytes, want 2", n)
+	}
+	if name.Name != "FRED" {
+		t.Errorf("pointer decoded name = %q, want FRED", name.Name)
+	}
+}
+
+// TestNBNSNameUnmarshalPointerErrors asserts that malformed compression
+// pointers (self-referential loops and out-of-range targets) return an error
+// instead of looping forever.
+func TestNBNSNameUnmarshalPointerErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+	}{
+		// Pointer at offset 0 targeting offset 0: an immediate self-loop.
+		{"self-loop", []byte{labelPointerFlag, 0x00}},
+		// Two pointers referencing each other: 0->2 and 2->0.
+		{"mutual-loop", []byte{labelPointerFlag, 0x02, labelPointerFlag, 0x00}},
+		// Pointer targeting an offset past the end of the buffer.
+		{"out-of-range", []byte{labelPointerFlag, 0x7f}},
+		// Pointer flag with no second octet.
+		{"truncated-pointer", []byte{labelPointerFlag}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("unmarshalName panicked on %s: %v", tc.name, r)
+				}
+			}()
+			if _, _, err := unmarshalName(tc.data, 0); err == nil {
+				t.Fatalf("unmarshalName(%s) expected error, got nil", tc.name)
+			}
+		})
+	}
+}
+
+// binaryPutUint16 and binaryAppendUint16 are tiny big-endian helpers used by
+// the hand-built compression-pointer test buffer.
+func binaryPutUint16(b []byte, v uint16) {
+	b[0] = byte(v >> 8)
+	b[1] = byte(v)
+}
+
+func binaryAppendUint16(b []byte, v uint16) []byte {
+	return append(b, byte(v>>8), byte(v))
+}
+
 // ipToUint32 converts a dotted-quad IPv4 string into the big-endian uint32
 // used by ADDR_ENTRY.Address.
 func ipToUint32(t *testing.T, s string) uint32 {


### PR DESCRIPTION
### Linked Issue
`Closes #970`

### Root Cause
The second-level NetBIOS name representation did not follow RFC 1002 4.2.1.2. On marshal the code wrote a single length byte equal to the length of the entire `"32chars.scope"` string followed by one `0x00`, so scope components were not individually length-prefixed. On unmarshal it read exactly one length-prefixed label and assumed the terminator, with no loop over multiple labels and no handling of RFC 1035 4.1.4 `0xC0` compression pointers. The codec therefore only round-tripped within Manticore and would misparse genuine on-wire replies.

### Fix Description
Two helpers were added in `packet.go` and wired into `Marshal`/`Unmarshal`:

- `marshalName` encodes the 32-byte first-level name as the first label, then each scope component as its own length-prefixed label, terminated by a `0x00` root label. A name with no scope still encodes as `0x20` + 32 bytes + `0x00`, identical to the previous single-label wire form, so backward compatibility with the existing round-trip tests is preserved.
- `unmarshalName` decodes the label sequence in a loop. A length octet with the top two bits set to `0b11` is treated as a 14-bit message-relative compression pointer (`((b&0x3F)<<8)|next`) and followed, with guards against pointer loops (bounded jump count) and out-of-range / truncated targets. It returns the number of bytes consumed at the original offset, so a leading pointer consumes exactly two octets at the call site.

Public function signatures (`FirstLevelEncode`/`FirstLevelDecode`) are unchanged; callers were not modified.

### How Verified
- `go build ./...`, `go vet ./network/netbios/...`, `go test ./network/netbios/...` all green; the #981 round-trip tests still pass.
- Added tests: a scoped `NAME.SCOPE.COM` round-trip through the label sequence; a hand-built buffer whose answer name is a `0xC0` pointer decoding to the correct name and consuming exactly 2 octets; and pointer self-loop / mutual-loop / out-of-range / truncated cases that must error without looping.
- Live-validated against a Windows Server 2016 host (10.7.0.10:137/udp): a 193-byte NODE STATUS reply and a 68-byte NAME QUERY reply (decoding to `TMP-W-2016`) both unmarshalled with full byte consumption. This host echoes full uncompressed label sequences rather than `0xC0` pointers, so the pointer-decode path is validated by the hand-built known-answer test; the live traffic confirms the label-sequence decoder against genuine wire data.

### Test Coverage
`TestNBNSPacketScopedNameRoundTrip`, `TestNBNSPacketCompressionPointer`, `TestNBNSNameUnmarshalPointerErrors`.