### PR TITLE
Add NetBIOS name-resolution client (Fixes #971)

### DIFF
--- a/network/netbios/nbns/broadcast_other.go
+++ b/network/netbios/nbns/broadcast_other.go
@@ -1,0 +1,13 @@
+//go:build !unix
+
+package nbns
+
+import "net"
+
+// enableBroadcast is a no-op on platforms where toggling SO_BROADCAST through a
+// raw socket option is not wired up here. Unicast queries to an NBNS/WINS server
+// are unaffected; only the limited-broadcast (B-node) send depends on the
+// option, and it degrades gracefully rather than failing to build off unix.
+func enableBroadcast(conn *net.UDPConn) error {
+	return nil
+}

--- a/network/netbios/nbns/broadcast_unix.go
+++ b/network/netbios/nbns/broadcast_unix.go
@@ -1,0 +1,28 @@
+//go:build unix
+
+package nbns
+
+import (
+	"net"
+	"syscall"
+)
+
+// enableBroadcast sets the SO_BROADCAST socket option on conn so that datagrams
+// addressed to the IPv4 limited-broadcast address (255.255.255.255) are allowed
+// out. A B-node NAME QUERY REQUEST is sent to that address, and the kernel
+// rejects a broadcast send on a socket that has not opted in via SO_BROADCAST.
+func enableBroadcast(conn *net.UDPConn) error {
+	raw, err := conn.SyscallConn()
+	if err != nil {
+		return err
+	}
+
+	var sockErr error
+	ctrlErr := raw.Control(func(fd uintptr) {
+		sockErr = syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_BROADCAST, 1)
+	})
+	if ctrlErr != nil {
+		return ctrlErr
+	}
+	return sockErr
+}

--- a/network/netbios/nbns/client.go
+++ b/network/netbios/nbns/client.go
@@ -1,0 +1,351 @@
+package nbns
+
+import (
+	"fmt"
+	"math/rand"
+	"net"
+	"time"
+)
+
+// NetBIOS name-resolution client defaults and well-known transport parameters
+// (RFC 1002 4.2.12 / RFC 1001 15.1.1).
+const (
+	// LimitedBroadcastAddr is the IPv4 limited-broadcast address a B-node NAME
+	// QUERY REQUEST is sent to when no NBNS/WINS server is configured. Combined
+	// with DefaultNBNSPort it forms the default destination 255.255.255.255:137.
+	LimitedBroadcastAddr = "255.255.255.255"
+
+	// DefaultClientTimeout bounds how long the client waits for a response to a
+	// single transmission before retransmitting (RFC 1001 15.1.1 models this as
+	// BCAST_REQ_RETRY_TIMEOUT / UCAST_REQ_RETRY_TIMEOUT). One second is a
+	// forgiving value that works for both broadcast and unicast/WINS queries.
+	DefaultClientTimeout = 1 * time.Second
+
+	// DefaultRetransmitCount is how many times an unanswered query is
+	// retransmitted after the first transmission, mirroring the RFC 1001 15.1.1
+	// retry counters (BCAST_REQ_RETRY_COUNT / UCAST_REQ_RETRY_COUNT).
+	DefaultRetransmitCount = 2
+)
+
+// Well-known NetBIOS name suffixes (the 16th byte of a NetBIOS name). The suffix
+// selects the service registered under a name; the same base name is registered
+// several times with different suffixes. These cover the suffixes an outbound
+// resolver most commonly asks for.
+const (
+	SuffixWorkstation       byte = 0x00 // Workstation Service (the computer name)
+	SuffixMessenger         byte = 0x03 // Messenger Service
+	SuffixServer            byte = 0x20 // Server Service (file/print sharing)
+	SuffixDomainMasterBrows byte = 0x1B // Domain Master Browser
+	SuffixDomainControllers byte = 0x1C // Domain Controllers (group)
+	SuffixMasterBrowser     byte = 0x1D // Master Browser
+	SuffixBrowserElections  byte = 0x1E // Browser Service Elections (group)
+)
+
+// Client resolves NetBIOS names to their owner addresses by emitting NAME QUERY
+// REQUEST packets (RFC 1002 4.2.12) and decoding the positive/negative NAME
+// QUERY RESPONSE (RFC 1002 4.2.13). It is the outbound counterpart to the
+// server-side name table in this package and mirrors the resolver shape of the
+// sibling network/llmnr client (a name in, a slice of net.IP out).
+//
+// A Client is a lightweight, stateless value: each Resolve call opens its own
+// short-lived UDP socket, so a single Client is safe to reuse across sequential
+// resolutions.
+type Client struct {
+	// Server is the NBNS/WINS server the query is sent to (P-node/H-node style
+	// unicast). It may be a bare host ("10.0.0.1") or host:port; a missing port
+	// defaults to DefaultNBNSPort (137). When Server is empty the client falls
+	// back to a B-node broadcast to LimitedBroadcastAddr:137.
+	Server string
+
+	// Timeout bounds the wait for a response to each individual transmission.
+	// A zero value is treated as DefaultClientTimeout.
+	Timeout time.Duration
+
+	// Retransmit is the number of times an unanswered query is retransmitted
+	// after the first send. A negative value is treated as zero (a single
+	// transmission).
+	Retransmit int
+
+	// RecursionDesired requests, for a unicast query, that the destination
+	// NBNS/WINS server perform recursive resolution (the RD bit, RFC 1002
+	// 4.2.12). It is meaningful only when querying an actual name server: a
+	// plain end node is not a name server and will not answer a unicast query
+	// with RD set, so this defaults to false and a broadcast query always sets
+	// RD regardless (the RFC B-node NAME QUERY REQUEST sets RD+B).
+	RecursionDesired bool
+}
+
+// NewClient returns a Client that resolves names by B-node broadcast to
+// 255.255.255.255:137, using the default timeout and retransmit count. This is
+// the analogue of llmnr.NewClient for NetBIOS name resolution.
+func NewClient() *Client {
+	return &Client{
+		Timeout:    DefaultClientTimeout,
+		Retransmit: DefaultRetransmitCount,
+	}
+}
+
+// NewClientWithServer returns a Client that unicasts its queries to the given
+// NBNS/WINS server (P-node style) instead of broadcasting. server may be a bare
+// host or host:port; a missing port defaults to 137.
+func NewClientWithServer(server string) *Client {
+	return &Client{
+		Server:     server,
+		Timeout:    DefaultClientTimeout,
+		Retransmit: DefaultRetransmitCount,
+	}
+}
+
+// isBroadcast reports whether this client resolves by limited broadcast (no
+// server configured) rather than by unicast to a name server.
+func (c *Client) isBroadcast() bool {
+	return c.Server == ""
+}
+
+// encodeNameWithSuffix builds the 16-byte NetBIOS name whose first 15 bytes are
+// the space-padded base name and whose 16th byte is the service suffix. This is
+// the on-the-wire layout the first-level codec (NetBIOSName.FirstLevelEncode)
+// expects: it copies exactly 16 bytes, so placing the suffix at index 15 here
+// makes it the 16th encoded octet without the codec's space padding disturbing
+// it.
+func encodeNameWithSuffix(name string, suffix byte) (string, error) {
+	if len(name) > NetBIOSNameLength-1 {
+		return "", fmt.Errorf("name too long: %d bytes (max %d before the suffix)", len(name), NetBIOSNameLength-1)
+	}
+
+	padded := make([]byte, NetBIOSNameLength)
+	copy(padded, name)
+	for i := len(name); i < NetBIOSNameLength-1; i++ {
+		padded[i] = ' '
+	}
+	padded[NetBIOSNameLength-1] = suffix
+
+	return string(padded), nil
+}
+
+// BuildNameQueryRequest assembles a NAME QUERY REQUEST (RFC 1002 4.2.12) for the
+// given base name, 16th-byte suffix, and optional scope. The packet carries a
+// freshly generated transaction ID, a single NB (0x0020) question in class IN,
+// and the header flags appropriate to the client's transport: OPCODE query with
+// the RD (recursion desired) bit set, plus the B (broadcast) bit when the client
+// is broadcasting rather than unicasting to a name server.
+func (c *Client) BuildNameQueryRequest(name string, suffix byte, scope string) (*NBNSPacket, error) {
+	encoded, err := encodeNameWithSuffix(name, suffix)
+	if err != nil {
+		return nil, err
+	}
+
+	// OPCODE is query (0x0000). A broadcast (B-node) NAME QUERY REQUEST sets the
+	// B bit together with RD (RFC 1002 4.2.12). RD (recursion desired) only
+	// makes sense to an actual NBNS/WINS server, and a plain end node will not
+	// answer a unicast query that has RD set, so on the unicast path RD is left
+	// clear unless the caller explicitly opts in via RecursionDesired.
+	flags := OpNameQuery
+	if c.isBroadcast() {
+		flags |= FlagBroadcast | FlagRecursion
+	} else if c.RecursionDesired {
+		flags |= FlagRecursion
+	}
+
+	req := &NBNSPacket{
+		Header: NBNSHeader{
+			TransactionID: uint16(rand.Intn(0x10000)),
+			Flags:         flags,
+			Questions:     1,
+		},
+		Questions: []NBNSQuestion{
+			{
+				Name:  &NetBIOSName{Name: encoded, ScopeID: scope},
+				Type:  QuestionTypeNB,
+				Class: QuestionClassIn,
+			},
+		},
+	}
+
+	return req, nil
+}
+
+// destination returns the UDP address a query is sent to and whether that
+// address requires the socket to be broadcast-enabled. For a unicast client it
+// resolves the configured Server (defaulting the port to 137); otherwise it
+// targets the IPv4 limited-broadcast address on port 137.
+func (c *Client) destination() (*net.UDPAddr, bool, error) {
+	if c.isBroadcast() {
+		return &net.UDPAddr{IP: net.ParseIP(LimitedBroadcastAddr), Port: DefaultNBNSPort}, true, nil
+	}
+
+	// Accept both a bare host and a host:port; default the port to 137 when the
+	// caller supplied only a host.
+	server := c.Server
+	if _, _, err := net.SplitHostPort(server); err != nil {
+		server = net.JoinHostPort(server, fmt.Sprintf("%d", DefaultNBNSPort))
+	}
+
+	addr, err := net.ResolveUDPAddr("udp4", server)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to resolve NBNS server address %q: %w", c.Server, err)
+	}
+	return addr, false, nil
+}
+
+// timeout returns the effective per-transmission timeout, substituting the
+// default for a non-positive configured value.
+func (c *Client) timeout() time.Duration {
+	if c.Timeout <= 0 {
+		return DefaultClientTimeout
+	}
+	return c.Timeout
+}
+
+// retransmits returns the effective retransmit count, clamping a negative
+// configured value to zero (a single transmission).
+func (c *Client) retransmits() int {
+	if c.Retransmit < 0 {
+		return 0
+	}
+	return c.Retransmit
+}
+
+// Resolve resolves a NetBIOS name+suffix to its owner IPv4 address(es) using an
+// empty scope. It is the high-level entry point mirroring llmnr.Client.Resolve:
+// a name in, a slice of net.IP out.
+//
+// A NAME_ERROR (RCODE 0x03) negative response means the name is not registered
+// with the queried responder; this is reported as a not-found result (an empty,
+// non-nil slice and a nil error) rather than an error, matching the LLMNR
+// resolver's no-answer semantics. A genuine failure to obtain any response
+// (every transmission timing out) is returned as an error.
+func (c *Client) Resolve(name string, suffix byte) ([]net.IP, error) {
+	return c.ResolveWithScope(name, suffix, "")
+}
+
+// ResolveWithScope is the scope-aware form of Resolve: it resolves name+suffix
+// within the given NetBIOS scope ID (pass "" for the default empty scope). See
+// Resolve for the return and not-found semantics.
+func (c *Client) ResolveWithScope(name string, suffix byte, scope string) ([]net.IP, error) {
+	req, err := c.BuildNameQueryRequest(name, suffix, scope)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := req.Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal NAME QUERY REQUEST: %w", err)
+	}
+
+	dest, needBroadcast, err := c.destination()
+	if err != nil {
+		return nil, err
+	}
+	if dest.IP == nil {
+		return nil, fmt.Errorf("could not determine a destination address")
+	}
+
+	// A short-lived socket bound to an ephemeral local port; ReadFromUDP then
+	// lets us learn each responder's source address (useful for a broadcast
+	// query, where several hosts may reply).
+	conn, err := net.ListenUDP("udp4", &net.UDPAddr{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to open UDP socket: %w", err)
+	}
+	defer conn.Close()
+
+	// A limited-broadcast send requires the SO_BROADCAST socket option; enabling
+	// it is a no-op on platforms where the option is not wired up.
+	if needBroadcast {
+		if err := enableBroadcast(conn); err != nil {
+			return nil, fmt.Errorf("failed to enable broadcast on UDP socket: %w", err)
+		}
+	}
+
+	// Transmit once, then retransmit up to Retransmit further times if no valid
+	// response is seen within the timeout for each transmission (RFC 1001
+	// 15.1.1 retry model).
+	buf := make([]byte, MaxUDPSize)
+	attempts := c.retransmits() + 1
+	for attempt := 0; attempt < attempts; attempt++ {
+		if _, err := conn.WriteToUDP(data, dest); err != nil {
+			return nil, fmt.Errorf("failed to send NAME QUERY REQUEST: %w", err)
+		}
+
+		deadline := time.Now().Add(c.timeout())
+		if err := conn.SetReadDeadline(deadline); err != nil {
+			return nil, fmt.Errorf("failed to set read deadline: %w", err)
+		}
+
+		// Drain responses until this transmission's deadline. Datagrams that do
+		// not echo our transaction ID or are not responses are ignored (a
+		// broadcast query in particular may draw unrelated traffic).
+		for {
+			n, _, err := conn.ReadFromUDP(buf)
+			if err != nil {
+				if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+					break // deadline reached: fall through to the next retransmission
+				}
+				return nil, fmt.Errorf("failed to read NAME QUERY RESPONSE: %w", err)
+			}
+
+			ips, matched, err := parseNameQueryResponse(buf[:n], req.Header.TransactionID)
+			if err != nil || !matched {
+				continue // not ours (or undecodable): keep waiting for a valid reply
+			}
+			return ips, nil
+		}
+	}
+
+	return nil, fmt.Errorf("no response to NAME QUERY REQUEST for %q (suffix 0x%02x)", name, suffix)
+}
+
+// parseNameQueryResponse decodes a NAME QUERY RESPONSE datagram and, if it is a
+// response to our query, returns the owner IP addresses it carries. matched is
+// true only when the datagram is a response echoing wantTRN; a datagram that is
+// a request, or that carries a different transaction ID, yields matched=false so
+// the caller keeps waiting.
+//
+// A negative response with RCODE NAME_ERROR (0x03) is a valid match with no
+// owners: it returns an empty (non-nil) slice, matched=true, and a nil error,
+// so the caller reports "not found" rather than an error. Any other non-zero
+// RCODE is surfaced as an error.
+func parseNameQueryResponse(data []byte, wantTRN uint16) ([]net.IP, bool, error) {
+	var resp NBNSPacket
+	if _, err := resp.Unmarshal(data); err != nil {
+		return nil, false, err
+	}
+
+	if resp.Header.Flags&FlagResponse == 0 {
+		return nil, false, nil // a request (e.g. our own broadcast echoed back)
+	}
+	if resp.Header.TransactionID != wantTRN {
+		return nil, false, nil // response to some other query
+	}
+
+	// NAME_ERROR is the expected negative answer for an unregistered name: a
+	// definitive not-found, not a failure.
+	switch resp.Header.Flags & RcodeMask {
+	case RcodeSuccess:
+	case RcodeNameError:
+		return []net.IP{}, true, nil
+	default:
+		return nil, true, fmt.Errorf("NAME QUERY RESPONSE returned RCODE 0x%x", resp.Header.Flags&RcodeMask)
+	}
+
+	// Collect every owner address from the NB answer records. A positive
+	// response for a group name carries several ADDR_ENTRY structures in a
+	// single record's RDATA, so walk the RDATA in 6-byte ADDR_ENTRY strides
+	// rather than decoding only the first entry.
+	ips := make([]net.IP, 0)
+	for _, rr := range resp.Answers {
+		if rr.Type != QuestionTypeNB {
+			continue
+		}
+		for off := 0; off+6 <= len(rr.RData); off += 6 {
+			ip, err := ParseIPFromRData(rr.RData[off : off+6])
+			if err != nil {
+				continue
+			}
+			ips = append(ips, ip)
+		}
+	}
+
+	return ips, true, nil
+}

--- a/network/netbios/nbns/client_test.go
+++ b/network/netbios/nbns/client_test.go
@@ -1,0 +1,213 @@
+package nbns
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"net"
+	"testing"
+	"time"
+)
+
+// TestBuildNameQueryRequestWireUnicast asserts the wire layout of a unicast NAME
+// QUERY REQUEST (RFC 1002 4.2.12): the transaction ID is echoed into the header,
+// the flags carry OPCODE query with neither RD nor B set (a plain end node will
+// not answer a unicast query with RD set), QDCOUNT is 1, and the single question
+// is an NB (0x0020) question in class IN whose name decodes back to the base
+// name and 16th-byte suffix that were asked for.
+func TestBuildNameQueryRequestWireUnicast(t *testing.T) {
+	c := NewClientWithServer("10.7.0.10")
+
+	req, err := c.BuildNameQueryRequest("TMP-W-2016", SuffixServer, "")
+	if err != nil {
+		t.Fatalf("BuildNameQueryRequest returned error: %v", err)
+	}
+
+	data, err := req.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal returned error: %v", err)
+	}
+
+	// Header: TRN_ID, flags, and QDCOUNT.
+	if got := binary.BigEndian.Uint16(data[0:2]); got != req.Header.TransactionID {
+		t.Errorf("wire TRN_ID = 0x%04x, want 0x%04x", got, req.Header.TransactionID)
+	}
+	if got := binary.BigEndian.Uint16(data[2:4]); got != OpNameQuery {
+		t.Errorf("unicast flags = 0x%04x, want 0x%04x (OPCODE query, no RD/B)", got, OpNameQuery)
+	}
+	if got := binary.BigEndian.Uint16(data[4:6]); got != 1 {
+		t.Errorf("QDCOUNT = %d, want 1", got)
+	}
+
+	// Question section: type NB (0x0020), class IN (0x0001).
+	q := req.Questions[0]
+	if q.Type != QuestionTypeNB {
+		t.Errorf("question type = 0x%04x, want NB 0x%04x", q.Type, QuestionTypeNB)
+	}
+	if q.Class != QuestionClassIn {
+		t.Errorf("question class = 0x%04x, want IN 0x%04x", q.Class, QuestionClassIn)
+	}
+
+	// The encoded name must carry the base name and the suffix in its 16th byte.
+	if len(q.Name.Name) != NetBIOSNameLength {
+		t.Fatalf("question name length = %d, want %d", len(q.Name.Name), NetBIOSNameLength)
+	}
+	if base := string([]byte(q.Name.Name)[:10]); base != "TMP-W-2016" {
+		t.Errorf("question base name = %q, want %q", base, "TMP-W-2016")
+	}
+	if suffix := q.Name.Name[NetBIOSNameLength-1]; suffix != SuffixServer {
+		t.Errorf("question suffix = 0x%02x, want 0x%02x", suffix, SuffixServer)
+	}
+}
+
+// TestBuildNameQueryRequestWireBroadcast asserts that a broadcast client (no
+// server configured) sets both the RD and B flags, matching the RFC 1002 4.2.12
+// B-node NAME QUERY REQUEST.
+func TestBuildNameQueryRequestWireBroadcast(t *testing.T) {
+	c := NewClient()
+
+	req, err := c.BuildNameQueryRequest("WORKGROUP", SuffixMasterBrowser, "")
+	if err != nil {
+		t.Fatalf("BuildNameQueryRequest returned error: %v", err)
+	}
+
+	want := OpNameQuery | FlagRecursion | FlagBroadcast
+	if req.Header.Flags != want {
+		t.Errorf("broadcast flags = 0x%04x, want 0x%04x (OPCODE query, RD+B)", req.Header.Flags, want)
+	}
+}
+
+// positiveNameQueryResponseKAT is a real POSITIVE NAME QUERY RESPONSE captured
+// from a Windows host (10.7.0.10, name "TMP-W-2016", suffix 0x20). It answers a
+// query with transaction ID 0xc47e and carries two ADDR_ENTRY owner addresses in
+// a single NB record's RDATA (10.7.0.10 and its 169.254.x APIPA address),
+// exercising the multi-entry RDATA walk. Frozen here as a known-answer test.
+const positiveNameQueryResponseKAT = "c47e85000000000100000000204645454e4641434e4648434e44434441444244474341434143414341434143410000200001000493e0000c60000a07000a6000a9fefd4f"
+
+// TestParseNameQueryResponsePositive decodes the frozen positive-response vector
+// and asserts the owner addresses are recovered in order.
+func TestParseNameQueryResponsePositive(t *testing.T) {
+	data, err := hex.DecodeString(positiveNameQueryResponseKAT)
+	if err != nil {
+		t.Fatalf("failed to decode KAT: %v", err)
+	}
+
+	ips, matched, err := parseNameQueryResponse(data, 0xc47e)
+	if err != nil {
+		t.Fatalf("parseNameQueryResponse returned error: %v", err)
+	}
+	if !matched {
+		t.Fatal("parseNameQueryResponse did not match the response to the query")
+	}
+
+	want := []string{"10.7.0.10", "169.254.253.79"}
+	if len(ips) != len(want) {
+		t.Fatalf("parsed %d addresses (%v), want %d", len(ips), ips, len(want))
+	}
+	for i, w := range want {
+		if ips[i].String() != w {
+			t.Errorf("address[%d] = %s, want %s", i, ips[i], w)
+		}
+	}
+}
+
+// TestParseNameQueryResponseTRNMismatch confirms a response carrying a different
+// transaction ID is not accepted as ours.
+func TestParseNameQueryResponseTRNMismatch(t *testing.T) {
+	data, err := hex.DecodeString(positiveNameQueryResponseKAT)
+	if err != nil {
+		t.Fatalf("failed to decode KAT: %v", err)
+	}
+
+	_, matched, err := parseNameQueryResponse(data, 0x0000)
+	if err != nil {
+		t.Fatalf("parseNameQueryResponse returned error: %v", err)
+	}
+	if matched {
+		t.Error("parseNameQueryResponse matched a response with a mismatched transaction ID")
+	}
+}
+
+// TestParseNameQueryResponseNameError checks that a NAME_ERROR (RCODE 0x03)
+// negative response is reported as a definitive not-found: matched, no owners,
+// and no error.
+func TestParseNameQueryResponseNameError(t *testing.T) {
+	// A minimal negative NAME QUERY RESPONSE: R+AA set, RD echoed, RCODE 0x03,
+	// with empty question/answer sections.
+	var hdr [12]byte
+	binary.BigEndian.PutUint16(hdr[0:2], 0x1234)
+	binary.BigEndian.PutUint16(hdr[2:4], FlagResponse|FlagAuthoritative|RcodeNameError)
+
+	ips, matched, err := parseNameQueryResponse(hdr[:], 0x1234)
+	if err != nil {
+		t.Fatalf("parseNameQueryResponse returned error: %v, want nil for NAME_ERROR", err)
+	}
+	if !matched {
+		t.Fatal("parseNameQueryResponse did not match the NAME_ERROR response")
+	}
+	if ips == nil {
+		t.Fatal("parseNameQueryResponse returned a nil slice, want an empty non-nil slice")
+	}
+	if len(ips) != 0 {
+		t.Errorf("parseNameQueryResponse returned %v, want an empty slice", ips)
+	}
+}
+
+// TestResolveAgainstLocalResponder drives the full Resolve path against an
+// in-process UDP responder: the responder echoes the request's transaction ID
+// and answers with an NB record owning 127.0.0.1, and Resolve must return that
+// address.
+func TestResolveAgainstLocalResponder(t *testing.T) {
+	server, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		t.Fatalf("failed to start local responder: %v", err)
+	}
+	defer server.Close()
+
+	go func() {
+		buf := make([]byte, 512)
+		n, from, err := server.ReadFromUDP(buf)
+		if err != nil {
+			return
+		}
+
+		var req NBNSPacket
+		if _, err := req.Unmarshal(buf[:n]); err != nil {
+			return
+		}
+
+		owner := ADDR_ENTRY{Address: binary.BigEndian.Uint32(net.IPv4(127, 0, 0, 1).To4())}
+		resp := &NBNSPacket{
+			Header: NBNSHeader{
+				TransactionID: req.Header.TransactionID,
+				Flags:         FlagResponse | FlagAuthoritative,
+				Answers:       1,
+			},
+			Answers: []NBNSResourceRecord{
+				{
+					Name:     req.Questions[0].Name,
+					Type:     QuestionTypeNB,
+					Class:    QuestionClassIn,
+					TTL:      300,
+					RDLength: owner.Length(),
+					RData:    owner.Marshal(),
+				},
+			},
+		}
+		data, err := resp.Marshal()
+		if err != nil {
+			return
+		}
+		_, _ = server.WriteToUDP(data, from)
+	}()
+
+	c := NewClientWithServer(server.LocalAddr().String())
+	c.Timeout = 2 * time.Second
+
+	ips, err := c.Resolve("TMP-W-2016", SuffixServer)
+	if err != nil {
+		t.Fatalf("Resolve returned error: %v", err)
+	}
+	if len(ips) != 1 || ips[0].String() != "127.0.0.1" {
+		t.Fatalf("Resolve = %v, want [127.0.0.1]", ips)
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #971`

### Summary
Adds an outbound NetBIOS name-resolution client to `network/netbios/nbns` — the counterpart to the package's server-side name table and the analogue of the `network/llmnr` resolver. There was previously no code that emitted an NBNS NAME QUERY to a remote host or WINS server and decoded the reply into addresses.

### What it does
- `Client` with a configurable NBNS/WINS `Server` (empty => UDP limited-broadcast to `255.255.255.255:137`), `Timeout`, `Retransmit` count, and an opt-in `RecursionDesired` flag. Constructors `NewClient()` (broadcast) and `NewClientWithServer(server)` (unicast).
- Builds a NAME QUERY REQUEST (RFC 1002 §4.2.12): OPCODE query, `QDCOUNT=1`, a single NB (`0x0020`) question in class IN, for a base name + 16th-byte suffix (+ optional scope).
- Sends over UDP with timeout + retransmit, matches the transaction ID, and parses the positive/negative NAME QUERY RESPONSE (§4.2.13) into `[]net.IP`.
- High-level `Resolve(name, suffix)` and scope-aware `ResolveWithScope(name, suffix, scope)` mirroring the LLMNR resolver API. `NAME_ERROR` (RCODE `0x03`) is surfaced as not-found (empty non-nil slice, nil error).
- Well-known suffix constants (workstation `0x00`, server `0x20`, master/domain browser, domain controllers, etc.).

### Reused building blocks
Reuses the existing merged codec rather than reinventing it: `NBNSPacket` Marshal/Unmarshal, `NetBIOSName` first-level encoding, and `ADDR_ENTRY`/`ParseIPFromRData`. A positive response's RDATA is walked in 6-byte `ADDR_ENTRY` strides so a group name owning several addresses decodes fully. `SO_BROADCAST` is set through build-tagged helpers (`broadcast_unix.go` / `broadcast_other.go`) mirroring the existing `llmnr` multicast files.

### Flag handling
A broadcast query sets RD+B (the RFC §4.2.12 B-node NAME QUERY REQUEST). A unicast query leaves RD clear by default: a plain end node is not a name server and does not answer a unicast query with RD set (confirmed live — see below). `RecursionDesired` lets a caller opt into RD for a genuine WINS-server query.

### How Verified
- `go build ./...`, `go vet ./network/netbios/...`, `go test ./network/netbios/...` all green.
- Live-validated against a Windows Server 2016 host (`10.7.0.10`, name `TMP-W-2016`). An NBSTAT node-status probe confirmed the host registers `TMP-W-2016` with suffixes `0x00` and `0x20`. `NewClientWithServer("10.7.0.10").Resolve("TMP-W-2016", SuffixServer)` returned `[10.7.0.10 169.254.253.79]` end to end (the same two ADDR_ENTRY owners the host reports); the raw positive response was frozen as a known-answer test.

### Test Coverage
**Added** (`network/netbios/nbns/client_test.go`):
- `TestBuildNameQueryRequestWireUnicast` / `TestBuildNameQueryRequestWireBroadcast` — wire assertion of TRN_ID, flags, QDCOUNT, and the NB/IN question (unicast has no RD/B; broadcast has RD+B).
- `TestParseNameQueryResponsePositive` — parse of a frozen real positive-response vector yielding both owner IPs.
- `TestParseNameQueryResponseNameError` — NAME_ERROR maps to an empty result.
- `TestParseNameQueryResponseTRNMismatch` — a mismatched transaction ID is rejected.
- `TestResolveAgainstLocalResponder` — full `Resolve` round-trip against an in-process UDP responder.

### Scope of Change
- **Files changed:** `network/netbios/nbns/{client.go,broadcast_unix.go,broadcast_other.go,client_test.go}` (all new).
- **Submodule pointer updated:** no.
- **Behavioral changes outside the enhancement:** none.