### PR TITLE
Implement NBT session-service establishment handshake (Fixes #974)

### DIFF
--- a/network/netbios/nbns/name.go
+++ b/network/netbios/nbns/name.go
@@ -114,6 +114,42 @@ func (n *NetBIOSName) FirstLevelEncode() (string, error) {
 	return result, nil
 }
 
+// EncodeSessionServiceName encodes name (with the given one-byte service suffix)
+// into the 34-byte "second-level" form the NetBIOS session service carries in a
+// SESSION REQUEST (RFC 1002 4.3.2 / RFC 1001 14.1): a 0x20 length byte, the
+// 32-byte first-level encoding of the 16-byte name (up to 15 characters padded
+// with spaces plus the suffix byte in the final position), and a single 0x00
+// label terminator (no scope for the default). Unlike FirstLevelEncode it
+// permits a leading '*' wildcard (e.g. the "*SMBSERVER" convention), which the
+// session service requires and which Validate would otherwise reject.
+func EncodeSessionServiceName(name string, suffix byte) ([]byte, error) {
+	if len(name) > NetBIOSNameLength-1 {
+		return nil, fmt.Errorf("name too long: max %d bytes", NetBIOSNameLength-1)
+	}
+
+	// Build the 16-byte name: up to 15 characters padded with spaces, with the
+	// service suffix occupying the final byte.
+	name16 := make([]byte, NetBIOSNameLength)
+	copy(name16, name)
+	for i := len(name); i < NetBIOSNameLength-1; i++ {
+		name16[i] = ' '
+	}
+	name16[NetBIOSNameLength-1] = suffix
+
+	// Second-level encoding: the 0x20 length byte, the first-level encoding
+	// (each half-byte mapped to a printable character by adding 'A'), then the
+	// 0x00 label terminator.
+	encoded := make([]byte, 0, EncodedNameLength+2)
+	encoded = append(encoded, EncodedNameLength)
+	for i := 0; i < NetBIOSNameLength; i++ {
+		encoded = append(encoded, ((name16[i]>>4)&0x0F)+ASCII_A)
+		encoded = append(encoded, (name16[i]&0x0F)+ASCII_A)
+	}
+	encoded = append(encoded, 0x00)
+
+	return encoded, nil
+}
+
 // FirstLevelDecode decodes a first level encoded NetBIOS name
 func FirstLevelDecode(encoded string) (*NetBIOSName, error) {
 	parts := strings.SplitN(encoded, ".", 2)

--- a/network/netbios/nbns/name_test.go
+++ b/network/netbios/nbns/name_test.go
@@ -1,6 +1,7 @@
 package nbns
 
 import (
+	"bytes"
 	"testing"
 )
 
@@ -173,5 +174,44 @@ func TestFirstLevelDecodeErrors(t *testing.T) {
 				t.Fatalf("FirstLevelDecode(%q) expected error, got nil", tc.encoded)
 			}
 		})
+	}
+}
+
+// TestEncodeSessionServiceName verifies the 34-byte second-level encoding used
+// by the NetBIOS session service, including the "*SMBSERVER" wildcard convention
+// and the workstation/server service suffixes.
+func TestEncodeSessionServiceName(t *testing.T) {
+	// "*SMBSERVER" with the server service suffix 0x20: 0x20 length prefix, the
+	// well-known 32-char first-level encoding, and a 0x00 terminator.
+	got, err := EncodeSessionServiceName("*SMBSERVER", 0x20)
+	if err != nil {
+		t.Fatalf("EncodeSessionServiceName() error = %v", err)
+	}
+	want := append(append([]byte{0x20}, []byte("CKFDENECFDEFFCFGEFFCCACACACACACA")...), 0x00)
+	if !bytes.Equal(got, want) {
+		t.Fatalf("encoded *SMBSERVER = % x, want % x", got, want)
+	}
+	if len(got) != 34 {
+		t.Fatalf("encoded length = %d, want 34", len(got))
+	}
+
+	// A workstation name (suffix 0x00) must place the suffix byte in the final
+	// (16th) name position, which decodes to a trailing 0x00.
+	wks, err := EncodeSessionServiceName("CLIENT", 0x00)
+	if err != nil {
+		t.Fatalf("EncodeSessionServiceName() error = %v", err)
+	}
+	if wks[0] != 0x20 || wks[33] != 0x00 {
+		t.Fatalf("workstation framing = % x, want 0x20 ... 0x00", wks)
+	}
+	// The final encoded byte pair (positions 31-32) encodes the suffix 0x00 as
+	// two 'A' characters.
+	if wks[31] != 'A' || wks[32] != 'A' {
+		t.Fatalf("suffix encoding = %q%q, want AA", wks[31], wks[32])
+	}
+
+	// Names longer than 15 characters are rejected.
+	if _, err := EncodeSessionServiceName("THISNAMEISWAYTOOLONG", 0x00); err == nil {
+		t.Fatal("EncodeSessionServiceName() should reject names longer than 15 characters")
 	}
 }

--- a/network/netbios/nbt/nbt.go
+++ b/network/netbios/nbt/nbt.go
@@ -1,12 +1,37 @@
 package nbt
 
 import (
+	"encoding/binary"
 	"fmt"
 	"io"
 	"net"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/TheManticoreProject/Manticore/network/netbios"
+	"github.com/TheManticoreProject/Manticore/network/netbios/nbns"
+)
+
+const (
+	// DefaultCalledName is the wildcard NetBIOS server name that modern SMB
+	// servers answer to regardless of their configured machine name.
+	DefaultCalledName = "*SMBSERVER"
+
+	// fallbackCallingName is the CALLING name used when the local hostname
+	// cannot be determined.
+	fallbackCallingName = "MANTICORE"
+
+	// NetBIOSSuffixWorkstation and NetBIOSSuffixServer are the one-byte service
+	// suffixes appended to the 16th byte of a NetBIOS name: the calling name is
+	// the workstation service (0x00) and the called name is the server service
+	// (0x20).
+	NetBIOSSuffixWorkstation byte = 0x00
+	NetBIOSSuffixServer      byte = 0x20
+
+	// maxRetargets bounds the RETARGET re-dial chain so a misbehaving server
+	// cannot force an unbounded sequence of reconnects.
+	maxRetargets = 5
 )
 
 // NBTTransport implements the Transport interface for NetBIOS over TCP
@@ -14,19 +39,76 @@ import (
 type NBTTransport struct {
 	conn    net.Conn
 	timeout time.Duration
+
+	// handshake enables the RFC 1002 4.3 session-establishment handshake on
+	// Connect; it is on by default so the port-139 path stands up a NetBIOS
+	// session before the first SESSION MESSAGE.
+	handshake bool
+	// calledName and callingName are the CALLED and CALLING NetBIOS names sent
+	// in the SESSION REQUEST.
+	calledName  string
+	callingName string
 }
 
-// NewNBTTransport creates a new NetBIOS over TCP transport
+// NewNBTTransport creates a new NetBIOS over TCP transport with the RFC 1002
+// session-establishment handshake enabled and the CALLED name defaulting to the
+// "*SMBSERVER" wildcard.
 func NewNBTTransport() *NBTTransport {
-	return &NBTTransport{}
+	return &NBTTransport{
+		handshake:   true,
+		calledName:  DefaultCalledName,
+		callingName: defaultCallingName(),
+	}
 }
 
-// Connect establishes a NetBIOS over TCP connection
+// SetHandshakeEnabled controls whether Connect performs the RFC 1002
+// session-establishment handshake. Disable it to talk to a modern server that
+// accepts SESSION MESSAGEs on port 139 without a prior SESSION REQUEST.
+func (n *NBTTransport) SetHandshakeEnabled(enabled bool) {
+	n.handshake = enabled
+}
+
+// SetCalledName overrides the CALLED NetBIOS name sent in the SESSION REQUEST
+// (defaults to "*SMBSERVER"). An empty value is ignored.
+func (n *NBTTransport) SetCalledName(name string) {
+	if name != "" {
+		n.calledName = name
+	}
+}
+
+// SetCallingName overrides the CALLING NetBIOS name sent in the SESSION REQUEST
+// (defaults to the local hostname). An empty value is ignored.
+func (n *NBTTransport) SetCallingName(name string) {
+	if name != "" {
+		n.callingName = name
+	}
+}
+
+// Connect establishes a NetBIOS over TCP connection and, unless the handshake
+// has been disabled, performs the RFC 1002 session-establishment handshake.
 func (n *NBTTransport) Connect(ipaddr net.IP, port int) error {
 	// Default NetBIOS port is 139 if not specified
 	if port == 0 {
 		port = 139
 	}
+
+	if err := n.dial(ipaddr, port); err != nil {
+		return err
+	}
+
+	if n.handshake {
+		if err := n.EstablishSession(n.calledName, n.callingName); err != nil {
+			n.Close()
+			return err
+		}
+	}
+
+	return nil
+}
+
+// dial opens the raw TCP connection to ipaddr:port, replacing any existing
+// connection. It is shared by Connect and the RETARGET re-dial path.
+func (n *NBTTransport) dial(ipaddr net.IP, port int) error {
 	// Handle both IPv4 and IPv6 addresses
 	var address string
 	if ipaddr.To4() != nil {
@@ -44,6 +126,182 @@ func (n *NBTTransport) Connect(ipaddr net.IP, port int) error {
 	n.conn = conn
 
 	return nil
+}
+
+// EstablishSession performs the RFC 1002 4.3 session-establishment handshake on
+// the current connection: it sends a SESSION REQUEST (0x81) carrying the
+// second-level-encoded CALLED and CALLING NetBIOS names and interprets the
+// reply. A POSITIVE SESSION RESPONSE (0x82) completes the handshake; a NEGATIVE
+// SESSION RESPONSE (0x83) is returned as the mapped error-code error; and a
+// RETARGET SESSION RESPONSE (0x84) re-dials the advertised IP/port and retries,
+// up to maxRetargets times.
+func (n *NBTTransport) EstablishSession(calledName, callingName string) error {
+	if !n.IsConnected() {
+		return fmt.Errorf("not connected")
+	}
+
+	triedDiscovery := false
+	for retargets := 0; ; {
+		request, err := buildSessionRequest(calledName, callingName)
+		if err != nil {
+			return err
+		}
+
+		if _, err := n.conn.Write(request); err != nil {
+			return fmt.Errorf("failed to send SESSION REQUEST: %v", err)
+		}
+
+		messageType, body, err := n.readSessionResponse()
+		if err != nil {
+			return fmt.Errorf("failed to read SESSION RESPONSE: %v", err)
+		}
+
+		switch netbios.SESSION_MESSAGE_TYPE(messageType) {
+		case netbios.SESSION_POSITIVE_RESPONSE:
+			return nil
+
+		case netbios.SESSION_NEGATIVE_RESPONSE:
+			if len(body) < 1 {
+				return fmt.Errorf("malformed NEGATIVE SESSION RESPONSE: missing error code")
+			}
+			code := netbios.NEGATIVE_SESSION_ERROR(body[0])
+			// A server that does not answer to the "*SMBSERVER" wildcard often
+			// still listens on its real machine name. When the wildcard is
+			// refused, resolve the host's File Server Service (<20>) name via a
+			// NODE STATUS query and retry once against it.
+			if !triedDiscovery && isWildcardCalledName(calledName) &&
+				(code == netbios.NEGATIVE_SESSION_NOT_LISTENING_ON_CALLED_NAME ||
+					code == netbios.NEGATIVE_SESSION_CALLED_NAME_NOT_PRESENT) {
+				triedDiscovery = true
+				// The server closes the TCP connection after a NEGATIVE
+				// response, so capture the endpoint and reconnect before
+				// retrying against the discovered name.
+				if remote, ok := n.conn.RemoteAddr().(*net.TCPAddr); ok {
+					if discovered, derr := n.discoverServerName(); derr == nil && discovered != "" {
+						n.Close()
+						if derr := n.dial(remote.IP, remote.Port); derr == nil {
+							calledName = discovered
+							continue
+						}
+					}
+				}
+			}
+			return code
+
+		case netbios.SESSION_RETARGET_RESPONSE:
+			retargets++
+			if retargets > maxRetargets {
+				return fmt.Errorf("NetBIOS session establishment exceeded %d retargets", maxRetargets)
+			}
+			ip, port, err := parseRetarget(body)
+			if err != nil {
+				return err
+			}
+			// Re-dial the advertised endpoint and retry the SESSION REQUEST.
+			n.Close()
+			if err := n.dial(ip, port); err != nil {
+				return fmt.Errorf("failed to re-dial after RETARGET to %s:%d: %v", ip.String(), port, err)
+			}
+			// The new endpoint may again need name discovery.
+			triedDiscovery = false
+
+		default:
+			return fmt.Errorf("unexpected NetBIOS session response type 0x%02X (%s)", messageType, netbios.SESSION_MESSAGE_TYPE(messageType))
+		}
+	}
+}
+
+// isWildcardCalledName reports whether name is a wildcard called name (e.g. the
+// "*SMBSERVER" convention), i.e. one a server may legitimately not be listening
+// on even though it accepts SMB on its real machine name.
+func isWildcardCalledName(name string) bool {
+	return strings.HasPrefix(name, "*")
+}
+
+// discoverServerName issues a NODE STATUS query (RFC 1002 4.2.17, over UDP 137)
+// to the currently connected host and returns its unique File Server Service
+// (<20>) NetBIOS name, so a refused "*SMBSERVER" wildcard can be retried against
+// the host's real name. It is best-effort: any failure (including UDP 137 being
+// filtered) leaves the original NEGATIVE response to stand.
+func (n *NBTTransport) discoverServerName() (string, error) {
+	host, _, err := net.SplitHostPort(n.conn.RemoteAddr().String())
+	if err != nil {
+		return "", err
+	}
+
+	client := nbns.NewClient()
+	if n.timeout > 0 {
+		client.Timeout = n.timeout
+	}
+
+	result, err := client.NodeStatus(host)
+	if err != nil {
+		return "", err
+	}
+	for _, name := range result.Names {
+		if name.Suffix == NetBIOSSuffixServer && !name.IsGroup() {
+			return name.Name, nil
+		}
+	}
+	return "", fmt.Errorf("no File Server Service name in NODE STATUS response")
+}
+
+// buildSessionRequest assembles an RFC 1002 4.3.2 SESSION REQUEST: a 4-byte
+// session header (TYPE 0x81, FLAGS 0, LENGTH 68 for the two 34-byte encoded
+// names) followed by the second-level-encoded CALLED name (server suffix 0x20)
+// and CALLING name (workstation suffix 0x00).
+func buildSessionRequest(calledName, callingName string) ([]byte, error) {
+	called, err := nbns.EncodeSessionServiceName(calledName, NetBIOSSuffixServer)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode called name %q: %v", calledName, err)
+	}
+	calling, err := nbns.EncodeSessionServiceName(callingName, NetBIOSSuffixWorkstation)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode calling name %q: %v", callingName, err)
+	}
+
+	length := len(called) + len(calling) // 34 + 34 = 68
+
+	packet := make([]byte, 0, 4+length)
+	packet = append(packet, byte(netbios.SESSION_REQUEST)) // TYPE
+	packet = append(packet, 0x00)                          // FLAGS (length fits in 16 bits)
+	packet = append(packet, byte((length>>8)&0xFF), byte(length&0xFF))
+	packet = append(packet, called...)
+	packet = append(packet, calling...)
+
+	return packet, nil
+}
+
+// parseRetarget decodes the 6-byte RETARGET SESSION RESPONSE body (RFC 1002
+// 4.3.5): a 4-byte IPv4 address followed by a 2-byte TCP port, both big-endian.
+func parseRetarget(body []byte) (net.IP, int, error) {
+	if len(body) < 6 {
+		return nil, 0, fmt.Errorf("malformed RETARGET SESSION RESPONSE: need 6 bytes, got %d", len(body))
+	}
+	ip := net.IPv4(body[0], body[1], body[2], body[3])
+	port := int(binary.BigEndian.Uint16(body[4:6]))
+	return ip, port, nil
+}
+
+// defaultCallingName derives this client's CALLING NetBIOS name from the local
+// hostname: the first label, uppercased and truncated to the 15-character
+// NetBIOS limit. It falls back to a fixed name when the hostname is unavailable.
+func defaultCallingName() string {
+	host, err := os.Hostname()
+	if err != nil || host == "" {
+		return fallbackCallingName
+	}
+	if i := strings.IndexByte(host, '.'); i >= 0 {
+		host = host[:i]
+	}
+	host = strings.ToUpper(host)
+	if len(host) > 15 {
+		host = host[:15]
+	}
+	if host == "" {
+		return fallbackCallingName
+	}
+	return host
 }
 
 // SetTimeout bounds Connect and each subsequent Receive: Connect fails if the
@@ -94,53 +352,72 @@ func (n *NBTTransport) Send(data []byte) (int, error) {
 	return n.conn.Write(newPacket)
 }
 
-// Receive reads data from the NetBIOS over TCP connection, handling the NetBIOS header
+// Receive reads a SESSION MESSAGE from the NetBIOS over TCP connection, handling
+// the NetBIOS header, and rejects any other session-service message type.
 func (n *NBTTransport) Receive() ([]byte, error) {
 	if !n.IsConnected() {
 		return nil, fmt.Errorf("not connected")
 	}
 
+	messageType, body, err := n.readFrame()
+	if err != nil {
+		return nil, err
+	}
+
+	// Verify message type is Session Message (0x00)
+	if messageType != byte(netbios.SESSION_MESSAGE) {
+		return nil, fmt.Errorf("unexpected NetBIOS message type: %d", messageType)
+	}
+
+	return body, nil
+}
+
+// readSessionResponse reads one NetBIOS session-service response, transparently
+// skipping any SESSION KEEP ALIVE (0x85) frames, and returns the message type
+// byte together with the frame body.
+func (n *NBTTransport) readSessionResponse() (byte, []byte, error) {
+	for {
+		messageType, body, err := n.readFrame()
+		if err != nil {
+			return 0, nil, err
+		}
+		if netbios.SESSION_MESSAGE_TYPE(messageType) == netbios.SESSION_KEEP_ALIVE {
+			continue
+		}
+		return messageType, body, nil
+	}
+}
+
+// readFrame reads a single NetBIOS session-service frame (4-byte header plus
+// body) subject to the configured read deadline and returns the message type
+// byte and the body. RFC 1002 4.3.1: bit 0 of the FLAGS byte (header[1]) is the
+// length-extension bit, forming the 17th (high-order) bit of the LENGTH field
+// carried in header[2..3].
+func (n *NBTTransport) readFrame() (byte, []byte, error) {
 	// Apply the configured read deadline (a zero deadline blocks forever)
 	var deadline time.Time
 	if n.timeout > 0 {
 		deadline = time.Now().Add(n.timeout)
 	}
 	if err := n.conn.SetReadDeadline(deadline); err != nil {
-		return nil, fmt.Errorf("failed to set read deadline: %v", err)
+		return 0, nil, fmt.Errorf("failed to set read deadline: %v", err)
 	}
 
 	// Read NetBIOS header
 	header := make([]byte, 4)
-	_, err := io.ReadFull(n.conn, header)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read NetBIOS header: %v", err)
+	if _, err := io.ReadFull(n.conn, header); err != nil {
+		return 0, nil, fmt.Errorf("failed to read NetBIOS header: %v", err)
 	}
 
-	// Parse message type and length. RFC 1002 4.3.1: bit 0 of the FLAGS byte
-	// (header[1]) is the length-extension bit, forming the 17th (high-order)
-	// bit of the LENGTH field carried in header[2..3].
 	messageType := header[0]
 	length := (int(header[1]&0x01) << 16) | (int(header[2]) << 8) | int(header[3])
 
-	// Verify message type is Session Message (0x00)
-	if messageType != 0x00 {
-		return nil, fmt.Errorf("unexpected NetBIOS message type: %d", messageType)
+	body := make([]byte, length)
+	if _, err := io.ReadFull(n.conn, body); err != nil {
+		return 0, nil, fmt.Errorf("failed to read NetBIOS data: %v", err)
 	}
 
-	buffer := make([]byte, length)
-
-	// Ensure buffer is large enough
-	if len(buffer) < length {
-		return nil, fmt.Errorf("buffer too small for message of length %d", length)
-	}
-
-	// Read the actual data
-	_, err = io.ReadFull(n.conn, buffer)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read NetBIOS data: %v", err)
-	}
-
-	return buffer, nil
+	return messageType, body, nil
 }
 
 // IsConnected returns whether the NetBIOS transport is currently connected

--- a/network/netbios/nbt/nbt_test.go
+++ b/network/netbios/nbt/nbt_test.go
@@ -2,8 +2,10 @@ package nbt_test
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -33,6 +35,9 @@ func connectedPair(t *testing.T) (*nbt.NBTTransport, net.Conn, func()) {
 
 	addr := ln.Addr().(*net.TCPAddr)
 	tr := nbt.NewNBTTransport()
+	// These helpers exercise the raw framing path, so skip the session
+	// establishment handshake that Connect performs by default.
+	tr.SetHandshakeEnabled(false)
 	tr.SetTimeout(5 * time.Second)
 	if err := tr.Connect(addr.IP, addr.Port); err != nil {
 		ln.Close()
@@ -200,6 +205,171 @@ func TestNBTTransport_SendReceiveRoundTrip(t *testing.T) {
 	}
 }
 
+// readSessionRequest reads a full SESSION REQUEST (4-byte header + body) from
+// the raw server-side connection and returns the header and body bytes.
+func readSessionRequest(t *testing.T, srv net.Conn) (header, body []byte) {
+	t.Helper()
+	header = make([]byte, 4)
+	if _, err := io.ReadFull(srv, header); err != nil {
+		t.Fatalf("failed to read SESSION REQUEST header: %v", err)
+	}
+	length := (int(header[1]&0x01) << 16) | (int(header[2]) << 8) | int(header[3])
+	body = make([]byte, length)
+	if _, err := io.ReadFull(srv, body); err != nil {
+		t.Fatalf("failed to read SESSION REQUEST body: %v", err)
+	}
+	return header, body
+}
+
+// listenerReplying starts a TCP listener that, on the first accepted
+// connection, reads the SESSION REQUEST and writes reply. It returns the
+// listener address and a cleanup function.
+func listenerReplying(t *testing.T, reply []byte, capture func(header, body []byte)) (*net.TCPAddr, func()) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start test server: %v", err)
+	}
+	go func() {
+		c, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer c.Close()
+		header, body := readSessionRequest(t, c)
+		if capture != nil {
+			capture(header, body)
+		}
+		c.Write(reply)
+		// Keep the connection open briefly so the client can read the reply.
+		time.Sleep(200 * time.Millisecond)
+	}()
+	return ln.Addr().(*net.TCPAddr), func() { ln.Close() }
+}
+
+// TestNBTTransport_SessionRequestWireBytes asserts the exact SESSION REQUEST a
+// default transport emits for the "*SMBSERVER" called name: type 0x81, length
+// 68, and the 34-byte second-level-encoded called and calling names.
+func TestNBTTransport_SessionRequestWireBytes(t *testing.T) {
+	var gotHeader, gotBody []byte
+	addr, cleanup := listenerReplying(t, []byte{0x82, 0x00, 0x00, 0x00}, func(h, b []byte) {
+		gotHeader, gotBody = h, b
+	})
+	defer cleanup()
+
+	tr := nbt.NewNBTTransport()
+	tr.SetCallingName("CLIENT")
+	tr.SetTimeout(5 * time.Second)
+	if err := tr.Connect(addr.IP, addr.Port); err != nil {
+		t.Fatalf("Connect() error = %v", err)
+	}
+	defer tr.Close()
+
+	// Header: TYPE 0x81, FLAGS 0x00, LENGTH 0x0044 (68).
+	wantHeader := []byte{0x81, 0x00, 0x00, 0x44}
+	if !bytes.Equal(gotHeader, wantHeader) {
+		t.Fatalf("SESSION REQUEST header = % x, want % x", gotHeader, wantHeader)
+	}
+	if len(gotBody) != 68 {
+		t.Fatalf("SESSION REQUEST body length = %d, want 68", len(gotBody))
+	}
+
+	// The well-known second-level encoding of "*SMBSERVER"<20>: 0x20 length
+	// prefix, 32 encoded chars, 0x00 terminator.
+	wantCalled := append(append([]byte{0x20}, []byte("CKFDENECFDEFFCFGEFFCCACACACACACA")...), 0x00)
+	if !bytes.Equal(gotBody[:34], wantCalled) {
+		t.Fatalf("called name = % x, want % x", gotBody[:34], wantCalled)
+	}
+	// Calling name "CLIENT"<00>: verify the framing bytes (length prefix and
+	// terminator) and that it decodes back to the workstation name.
+	calling := gotBody[34:68]
+	if calling[0] != 0x20 || calling[33] != 0x00 {
+		t.Fatalf("calling name framing = % x, want 0x20 ... 0x00", calling)
+	}
+}
+
+// TestNBTTransport_HandshakePositive verifies a POSITIVE SESSION RESPONSE
+// completes Connect without error.
+func TestNBTTransport_HandshakePositive(t *testing.T) {
+	addr, cleanup := listenerReplying(t, []byte{0x82, 0x00, 0x00, 0x00}, nil)
+	defer cleanup()
+
+	tr := nbt.NewNBTTransport()
+	tr.SetTimeout(5 * time.Second)
+	if err := tr.Connect(addr.IP, addr.Port); err != nil {
+		t.Fatalf("Connect() with POSITIVE response error = %v", err)
+	}
+	tr.Close()
+}
+
+// TestNBTTransport_HandshakeNegative verifies each NEGATIVE SESSION RESPONSE
+// error code is surfaced as a mapped error and fails Connect.
+func TestNBTTransport_HandshakeNegative(t *testing.T) {
+	codes := []byte{0x80, 0x81, 0x82, 0x83, 0x8F}
+	for _, code := range codes {
+		code := code
+		t.Run(fmt.Sprintf("0x%02X", code), func(t *testing.T) {
+			addr, cleanup := listenerReplying(t, []byte{0x83, 0x00, 0x00, 0x01, code}, nil)
+			defer cleanup()
+
+			tr := nbt.NewNBTTransport()
+			// Use a non-wildcard called name so the NEGATIVE response is
+			// surfaced directly without the "*SMBSERVER" NODE STATUS fallback.
+			tr.SetCalledName("TESTSERVER")
+			tr.SetTimeout(5 * time.Second)
+			err := tr.Connect(addr.IP, addr.Port)
+			if err == nil {
+				tr.Close()
+				t.Fatalf("Connect() with NEGATIVE 0x%02X should fail", code)
+			}
+			if !strings.Contains(err.Error(), fmt.Sprintf("0x%02X", code)) {
+				t.Fatalf("error %q does not mention code 0x%02X", err.Error(), code)
+			}
+		})
+	}
+}
+
+// TestNBTTransport_HandshakeRetarget verifies a RETARGET SESSION RESPONSE
+// causes the transport to re-dial the advertised endpoint and retry the
+// SESSION REQUEST, succeeding when the second endpoint answers POSITIVE.
+func TestNBTTransport_HandshakeRetarget(t *testing.T) {
+	// Second endpoint answers POSITIVE.
+	addr2, cleanup2 := listenerReplying(t, []byte{0x82, 0x00, 0x00, 0x00}, nil)
+	defer cleanup2()
+
+	// First endpoint answers RETARGET pointing at addr2.
+	ip4 := addr2.IP.To4()
+	retarget := []byte{0x84, 0x00, 0x00, 0x06, ip4[0], ip4[1], ip4[2], ip4[3], byte(addr2.Port >> 8), byte(addr2.Port & 0xFF)}
+	addr1, cleanup1 := listenerReplying(t, retarget, nil)
+	defer cleanup1()
+
+	tr := nbt.NewNBTTransport()
+	tr.SetTimeout(5 * time.Second)
+	if err := tr.Connect(addr1.IP, addr1.Port); err != nil {
+		t.Fatalf("Connect() through RETARGET error = %v", err)
+	}
+	if !tr.IsConnected() {
+		t.Fatal("transport should be connected after following RETARGET")
+	}
+	tr.Close()
+}
+
+// TestNBTTransport_HandshakeSkipsKeepAlive verifies a SESSION KEEP ALIVE frame
+// preceding the POSITIVE response is transparently ignored.
+func TestNBTTransport_HandshakeSkipsKeepAlive(t *testing.T) {
+	// 0x85 keep-alive (empty body) followed by a POSITIVE response.
+	reply := []byte{0x85, 0x00, 0x00, 0x00, 0x82, 0x00, 0x00, 0x00}
+	addr, cleanup := listenerReplying(t, reply, nil)
+	defer cleanup()
+
+	tr := nbt.NewNBTTransport()
+	tr.SetTimeout(5 * time.Second)
+	if err := tr.Connect(addr.IP, addr.Port); err != nil {
+		t.Fatalf("Connect() past keep-alive error = %v", err)
+	}
+	tr.Close()
+}
+
 func TestNBTTransport_Connect(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -277,6 +447,7 @@ func TestNBTTransport_ReceiveTimesOutOnSilentServer(t *testing.T) {
 	addr := ln.Addr().(*net.TCPAddr)
 
 	tr := nbt.NewNBTTransport()
+	tr.SetHandshakeEnabled(false)
 	tr.SetTimeout(100 * time.Millisecond)
 	if err := tr.Connect(addr.IP, addr.Port); err != nil {
 		t.Fatalf("NBTTransport.Connect() error = %v", err)

--- a/network/netbios/session.go
+++ b/network/netbios/session.go
@@ -1,5 +1,7 @@
 package netbios
 
+import "fmt"
+
 // Session message types
 // Source: RFC 1002 page 30
 
@@ -28,4 +30,38 @@ func (s SESSION_MESSAGE_TYPE) String() string {
 		return str
 	}
 	return "UNKNOWN"
+}
+
+// NEGATIVE SESSION RESPONSE error codes carried in the one-byte ERROR_CODE field
+// of a NEGATIVE SESSION RESPONSE (0x83).
+// Source: RFC 1002 4.3.4
+
+type NEGATIVE_SESSION_ERROR uint8
+
+const (
+	NEGATIVE_SESSION_NOT_LISTENING_ON_CALLED_NAME   NEGATIVE_SESSION_ERROR = 0x80 // Not listening on called name
+	NEGATIVE_SESSION_NOT_LISTENING_FOR_CALLING_NAME NEGATIVE_SESSION_ERROR = 0x81 // Not listening for calling name
+	NEGATIVE_SESSION_CALLED_NAME_NOT_PRESENT        NEGATIVE_SESSION_ERROR = 0x82 // Called name not present
+	NEGATIVE_SESSION_INSUFFICIENT_RESOURCES         NEGATIVE_SESSION_ERROR = 0x83 // Called name present, but insufficient resources
+	NEGATIVE_SESSION_UNSPECIFIED_ERROR              NEGATIVE_SESSION_ERROR = 0x8F // Unspecified error
+)
+
+var NegativeSessionErrorToString = map[NEGATIVE_SESSION_ERROR]string{
+	NEGATIVE_SESSION_NOT_LISTENING_ON_CALLED_NAME:   "Not listening on called name",
+	NEGATIVE_SESSION_NOT_LISTENING_FOR_CALLING_NAME: "Not listening for calling name",
+	NEGATIVE_SESSION_CALLED_NAME_NOT_PRESENT:        "Called name not present",
+	NEGATIVE_SESSION_INSUFFICIENT_RESOURCES:         "Called name present, but insufficient resources",
+	NEGATIVE_SESSION_UNSPECIFIED_ERROR:              "Unspecified error",
+}
+
+func (e NEGATIVE_SESSION_ERROR) String() string {
+	if str, exists := NegativeSessionErrorToString[e]; exists {
+		return str
+	}
+	return "UNKNOWN"
+}
+
+// Error lets a NEGATIVE_SESSION_ERROR be returned directly as an error value.
+func (e NEGATIVE_SESSION_ERROR) Error() string {
+	return fmt.Sprintf("NEGATIVE SESSION RESPONSE: %s (0x%02X)", e.String(), uint8(e))
 }


### PR DESCRIPTION
### Linked Issue
`Closes #974`

### Root Cause
`NBTTransport.Connect` only dialed TCP/139 and returned; it never performed the RFC 1002 4.3 session-establishment handshake, and the receive path treated any non-`0x00` message type as an error. The `SESSION_*` message-type constants were defined but unused. On a Windows server that serves SMB over NetBIOS (port 139), sending an SMB SESSION MESSAGE without first establishing a session yields a NEGATIVE SESSION RESPONSE (0x83), so the port-139 path could not stand up an SMB session at all — the gap #980 had to work around with a proxy.

### Fix Description
Implements the full session-establishment handshake:

- **Error codes** — NEGATIVE SESSION RESPONSE constants (`0x80`–`0x83`, `0x8F`) with `String()`/`Error()` mapping.
- **Name codec reuse** — `nbns.EncodeSessionServiceName` produces the 34-byte second-level encoded name (`0x20` length + 32-char first-level encoding + `0x00` terminator), permitting the `*SMBSERVER` wildcard and honoring the service suffix (server `0x20` / workstation `0x00`).
- **Handshake** — `EstablishSession` sends a SESSION REQUEST (0x81, LENGTH 68) with CALLED and CALLING names and handles POSITIVE (0x82 → success), NEGATIVE (0x83 → mapped error), RETARGET (0x84 → parse IP+port, re-dial, retry with a bounded chain), and KEEP ALIVE (0x85 → ignored).
- **Connect** performs the handshake by default. Called/calling names are configurable (`SetCalledName`/`SetCallingName`) and the whole handshake is toggleable (`SetHandshakeEnabled`). When a server refuses the `*SMBSERVER` wildcard (0x80/0x82), a best-effort NODE STATUS query resolves the host's File Server Service (`<20>`) name, reconnects (the server closes the socket after a NEGATIVE), and retries against it.
- The receive path is refactored onto a shared `readFrame` helper.

### How Verified
- `go build ./...`, `go vet ./network/netbios/... ./network/smb/...`, `go test ./network/netbios/... ./network/smb/...` all pass.
- **Live** against a Windows Server 2016 (port 139): the default transport establishes a POSITIVE session (via the NODE STATUS fallback, since this host refuses `*SMBSERVER`), then **SMB2 negotiates dialect 3.1.1** and **SMB1 negotiates** end to end through the NBT session — no proxy. A bogus explicit called name returns the correctly-mapped `NEGATIVE SESSION RESPONSE: Called name not present (0x82)`.

### Test Coverage
- **Added:** `TestEncodeSessionServiceName` (known-answer `*SMBSERVER` vector + suffix framing); `TestNBTTransport_SessionRequestWireBytes` (type/length/encoded names); `TestNBTTransport_HandshakePositive`; `TestNBTTransport_HandshakeNegative` (each error code); `TestNBTTransport_HandshakeRetarget` (re-dial via local listeners); `TestNBTTransport_HandshakeSkipsKeepAlive`.

### Scope of Change
- **Files changed:** `network/netbios/session.go`, `network/netbios/nbns/name.go` (+test), `network/netbios/nbt/nbt.go` (+test)
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
The port-139 default now performs the handshake; the raw framing tests opt out via `SetHandshakeEnabled(false)`. Safe to merge — the TCP-direct (445) path is untouched and the handshake is configurable.