### PR TITLE
Wire up dead NBNS server behaviors: NODE STATUS, WACK, challenge, redirect, conflict demand (Fixes #975)

### DIFF
--- a/network/netbios/nbns/challenge.go
+++ b/network/netbios/nbns/challenge.go
@@ -116,7 +116,7 @@ func (c *NameChallenger) ChallengeOwnership(name string, owner net.IP) (bool, er
 // DefendName actively defends a name against challenges
 func (c *NameChallenger) DefendName(packet *NBNSPacket, response *NBNSPacket) {
 	// Only defend against queries
-	if packet.Header.Flags&0xF000 != OpNameQuery {
+	if packet.Header.Flags&OpcodeMask != OpNameQuery {
 		return
 	}
 

--- a/network/netbios/nbns/handlers.go
+++ b/network/netbios/nbns/handlers.go
@@ -2,12 +2,37 @@ package nbns
 
 import (
 	"encoding/binary"
+	"net"
 	"time"
+)
+
+const (
+	// DefaultWACKWait is the time-to-wait (in seconds) advertised in a WAIT FOR
+	// ACKNOWLEDGEMENT (WACK) RESPONSE while the server runs a name challenge
+	// before answering a registration (RFC 1002 4.2.16). It comfortably covers
+	// the challenger's retry budget (ChallengeRetries * ChallengeTimeout).
+	DefaultWACKWait = 8 * time.Second
 )
 
 // PacketHandler provides common packet handling methods for both TCP and UDP servers
 type PacketHandler struct {
 	nbns *NetBIOSNameServer
+
+	// nodeStatusEnabled gates the NODE STATUS responder. It is off by default so
+	// an NBSTAT (0x0021) query falls through to the historical behaviour; a
+	// server opts in through EnableNodeStatus.
+	nodeStatusEnabled bool
+	// nodeStatusMAC is the adapter unit id reported in the STATISTICS block of a
+	// NODE STATUS RESPONSE. It may be nil, in which case the UNIT_ID is zeroed.
+	nodeStatusMAC net.HardwareAddr
+
+	// challenger, when non-nil, defends an owned unique name against a
+	// conflicting registration by challenging the current owner (RFC 1002
+	// 4.2.10). Nil by default, so registrations behave exactly as before.
+	challenger *NameChallenger
+	// redirect, when non-nil, may turn a NAME QUERY into a REDIRECT NAME QUERY
+	// RESPONSE for a configured scope (RFC 1002 4.2.14). Nil by default.
+	redirect *RedirectManager
 }
 
 // NewPacketHandler creates a new packet handler instance
@@ -15,6 +40,60 @@ func NewPacketHandler(nbns *NetBIOSNameServer) *PacketHandler {
 	return &PacketHandler{
 		nbns: nbns,
 	}
+}
+
+// EnableNodeStatus turns on the NODE STATUS responder and sets the adapter MAC
+// reported as the STATISTICS UNIT_ID. A nil or non-6-byte mac reports a zeroed
+// UNIT_ID.
+func (h *PacketHandler) EnableNodeStatus(mac net.HardwareAddr) {
+	h.nodeStatusEnabled = true
+	h.nodeStatusMAC = mac
+}
+
+// SetChallenger installs (or, with nil, removes) the name challenger used to
+// defend owned unique names on a conflicting registration.
+func (h *PacketHandler) SetChallenger(c *NameChallenger) { h.challenger = c }
+
+// SetRedirectManager installs (or, with nil, removes) the redirect manager
+// consulted on the name-query path.
+func (h *PacketHandler) SetRedirectManager(r *RedirectManager) { h.redirect = r }
+
+// isNodeStatusQuery reports whether request is a NODE STATUS REQUEST: an OPCODE
+// query (0x0000, the same opcode as a name query) whose first question asks for
+// the NBSTAT (0x0021) type (RFC 1002 4.2.17). Node status is distinguished from
+// a name query only by that question type.
+func (h *PacketHandler) isNodeStatusQuery(request *NBNSPacket) bool {
+	return request.Header.Flags&OpcodeMask == OpNameQuery &&
+		len(request.Questions) > 0 &&
+		request.Questions[0].Type == QuestionTypeNBSTAT
+}
+
+// handleNodeStatus answers a NODE STATUS REQUEST with the local name table (RFC
+// 1002 4.2.18): a single NBSTAT answer record whose RDATA lists every registered
+// name as a NODE_NAME entry (with NAME_FLAGS reflecting group/active/conflict)
+// followed by the STATISTICS block carrying the configured adapter MAC. The
+// answer echoes the request's question name (the reserved "*" wildcard), which
+// the label-sequence marshaller encodes directly.
+func (h *PacketHandler) handleNodeStatus(request *NBNSPacket, response *NBNSPacket) {
+	response.Header.Flags = FlagResponse | FlagAuthoritative
+
+	var name *NetBIOSName
+	if len(request.Questions) > 0 {
+		name = request.Questions[0].Name
+	} else {
+		name = &NetBIOSName{Name: "*"}
+	}
+
+	rdata := buildNodeStatusRData(h.nbns.NameTable(), h.nodeStatusMAC)
+	response.Answers = append(response.Answers, NBNSResourceRecord{
+		Name:     name,
+		Type:     QuestionTypeNBSTAT,
+		Class:    QuestionClassIn,
+		TTL:      0,
+		RDLength: uint16(len(rdata)),
+		RData:    rdata,
+	})
+	response.Header.Answers = uint16(len(response.Answers))
 }
 
 // handleNameQuery processes a name query request
@@ -115,5 +194,155 @@ func (h *PacketHandler) handleRefresh(request *NBNSPacket, response *NBNSPacket)
 			response.Header.Flags |= RcodeServerError
 			return
 		}
+	}
+}
+
+// handleNameQueryWithRedirect answers a name query, first giving a configured
+// redirect manager the chance to turn it into a REDIRECT NAME QUERY RESPONSE
+// (RFC 1002 4.2.14) for a matching scope. When no redirect applies (or none is
+// configured) it falls back to the authoritative name-table lookup.
+func (h *PacketHandler) handleNameQueryWithRedirect(request *NBNSPacket, response *NBNSPacket) {
+	if h.redirect != nil && h.redirect.HandleRedirect(request, response) {
+		return
+	}
+	h.handleNameQuery(request, response)
+}
+
+// handleRegistrationWithChallenge processes a name registration when a name
+// challenger is configured. Each proposed name is first registered optimistically;
+// on a conflict with an already-owned name the server defers the decision per RFC
+// 1002 4.2.10: it asks the transport to emit a WACK (so the requestor waits
+// longer) through sendWACK, then challenges the current owner(s). If any owner
+// still defends the name the registration is refused with RCODE CFT_ERR;
+// otherwise the stale record is released and the new registration is accepted.
+// sendWACK may be nil when the transport cannot emit an intermediate datagram, in
+// which case the WACK is skipped but the challenge still runs.
+func (h *PacketHandler) handleRegistrationWithChallenge(request *NBNSPacket, response *NBNSPacket, sendWACK func(*NBNSPacket)) {
+	for _, rr := range request.Answers {
+		var entry ADDR_ENTRY
+		if err := entry.Unmarshal(rr.RData); err != nil {
+			response.Header.Flags |= RcodeFormatError
+			return
+		}
+		ip := entry.IP()
+		ttl := time.Duration(rr.TTL) * time.Second
+
+		// The unique/group distinction is carried by the RR NB_FLAGS G bit.
+		nameType := Unique
+		if entry.Flags&NBFlagGroup != 0 {
+			nameType = Group
+		}
+
+		if err := h.nbns.RegisterName(rr.Name.Name, rr.Name.ScopeID, nameType, ip, ttl); err == nil {
+			continue // no conflict: registered directly
+		}
+
+		// Conflict with an existing owner: tell the requestor to wait, then
+		// challenge the current owner(s) before deciding.
+		if sendWACK != nil {
+			sendWACK(buildWACK(request, DefaultWACKWait))
+		}
+
+		owners, _, _, qerr := h.nbns.QueryName(rr.Name.Name, rr.Name.ScopeID)
+		if qerr != nil {
+			// The record disappeared between the failed registration and the
+			// lookup; try once more to claim the now-free name.
+			if err := h.nbns.RegisterName(rr.Name.Name, rr.Name.ScopeID, nameType, ip, ttl); err != nil {
+				response.Header.Flags |= RcodeConflict
+				return
+			}
+			continue
+		}
+
+		defended := false
+		for _, owner := range owners {
+			if ok, _ := h.challenger.ChallengeOwnership(rr.Name.Name, owner); ok {
+				defended = true
+				break
+			}
+		}
+
+		if defended {
+			// A current owner still answers: refuse the registration.
+			response.Header.Flags |= RcodeConflict
+			return
+		}
+
+		// No owner defended the name: release the stale record(s) and let the
+		// new node take ownership.
+		for _, owner := range owners {
+			_ = h.nbns.ReleaseName(rr.Name.Name, rr.Name.ScopeID, owner)
+		}
+		if err := h.nbns.RegisterName(rr.Name.Name, rr.Name.ScopeID, nameType, ip, ttl); err != nil {
+			response.Header.Flags |= RcodeConflict
+			return
+		}
+	}
+}
+
+// buildWACK constructs a WAIT FOR ACKNOWLEDGEMENT (WACK) RESPONSE (RFC 1002
+// 4.2.16) echoing request's transaction ID and name. The TTL is the number of
+// seconds the requestor should wait for the pending operation to complete, and
+// the 2-byte RDATA carries the OPCODE and NM_FLAGS of the request (its header
+// flags with the response bit and RCODE cleared) so the requestor can correlate
+// the wait with its outstanding request.
+func buildWACK(request *NBNSPacket, wait time.Duration) *NBNSPacket {
+	name := &NetBIOSName{}
+	switch {
+	case len(request.Answers) > 0:
+		name = request.Answers[0].Name
+	case len(request.Questions) > 0:
+		name = request.Questions[0].Name
+	}
+
+	rdata := make([]byte, 2)
+	binary.BigEndian.PutUint16(rdata, request.Header.Flags&^FlagResponse&^RcodeMask)
+
+	return &NBNSPacket{
+		Header: NBNSHeader{
+			TransactionID: request.Header.TransactionID,
+			Flags:         FlagResponse | OpWACK | FlagAuthoritative,
+			Answers:       1,
+		},
+		Answers: []NBNSResourceRecord{{
+			Name:     name,
+			Type:     0x0020, // RR_TYPE NULL, per the RFC 1002 4.2.16 WACK diagram
+			Class:    QuestionClassIn,
+			TTL:      uint32(wait.Seconds()),
+			RDLength: uint16(len(rdata)),
+			RData:    rdata,
+		}},
+	}
+}
+
+// buildNameConflictDemand constructs a NAME CONFLICT DEMAND (RFC 1002 4.2.15): a
+// registration-opcode response carrying RCODE CFT_ERR that tells owner the unique
+// name is claimed by more than one node. It is byte-identical to a NEGATIVE NAME
+// REGISTRATION RESPONSE with RCODE = CFT_ERR, so the single NB answer record
+// carries the owner's ADDR_ENTRY. It returns nil when owner has no IPv4 address
+// to place in the ADDR_ENTRY.
+func buildNameConflictDemand(name *NetBIOSName, owner net.IP) *NBNSPacket {
+	v4 := owner.To4()
+	if v4 == nil {
+		return nil
+	}
+	entry := ADDR_ENTRY{Address: binary.BigEndian.Uint32(v4)}
+
+	return &NBNSPacket{
+		Header: NBNSHeader{
+			TransactionID: generateTransactionID(),
+			// R=1, OPCODE=registration, AA|RD|RA set, RCODE=CFT_ERR
+			// (RFC 1002 4.2.15 packet diagram).
+			Flags:   FlagResponse | OpConflict | FlagAuthoritative | FlagRecursion | FlagRecursionAvailable | RcodeConflict,
+			Answers: 1,
+		},
+		Answers: []NBNSResourceRecord{{
+			Name:     name,
+			Type:     QuestionTypeNB,
+			Class:    QuestionClassIn,
+			TTL:      0,
+			RDLength: uint16(entry.Length()),
+			RData:    entry.Marshal(),
+		}},
 	}
 }

--- a/network/netbios/nbns/nbtns.go
+++ b/network/netbios/nbns/nbtns.go
@@ -21,6 +21,13 @@ type NetBIOSNameServer struct {
 	cleanupInterval time.Duration
 	cleanupQuit     chan struct{}
 	cleanupDone     chan struct{}
+
+	// conflictDemandSender, when non-nil, transmits a NAME CONFLICT DEMAND (RFC
+	// 1002 4.2.15) to a conflicting name's owner as part of MarkNameConflict.
+	// It is left nil by default so a plain name server only flips local state,
+	// preserving the historical behaviour; a transport wires it in to actually
+	// put the demand on the wire.
+	conflictDemandSender func(packet *NBNSPacket, owner net.IP) error
 }
 
 // NewNetBIOSNameServer creates a new NetBIOS Name Server instance.
@@ -220,21 +227,100 @@ func (n *NetBIOSNameServer) RefreshName(name string, scopeID string, owner net.I
 	return nil
 }
 
-// MarkNameConflict marks a name as being in conflict
-func (n *NetBIOSNameServer) MarkNameConflict(name string, scopeID string) error {
+// SetConflictDemandSender installs the transport callback MarkNameConflict uses
+// to emit a NAME CONFLICT DEMAND to a conflicting name's owner. Passing nil (the
+// default) restores the local-only behaviour in which MarkNameConflict merely
+// flips the record's status.
+func (n *NetBIOSNameServer) SetConflictDemandSender(send func(packet *NBNSPacket, owner net.IP) error) {
 	n.mu.Lock()
 	defer n.mu.Unlock()
+	n.conflictDemandSender = send
+}
+
+// MarkNameConflict marks a name as being in conflict and, when a conflict-demand
+// sender has been installed, emits a NAME CONFLICT DEMAND (RFC 1002 4.2.15) to
+// every current owner of the name so the offending node learns its registration
+// is disputed. The demand is built once per owner from the record's scope-aware
+// name and the owner's address; a send failure is not fatal to marking the
+// conflict, matching the best-effort nature of a broadcast/unicast demand.
+func (n *NetBIOSNameServer) MarkNameConflict(name string, scopeID string) error {
+	n.mu.Lock()
 
 	name = normalizeName(name)
 	key := nameKey(name, scopeID)
 
 	record, exists := n.names[key]
 	if !exists {
+		n.mu.Unlock()
 		return fmt.Errorf("name not found: %s", name)
 	}
 
 	record.Status = Conflict
+
+	// Snapshot the sender and owners under the lock, then emit outside it so a
+	// blocking transport send cannot stall other name-table operations.
+	send := n.conflictDemandSender
+	var owners []net.IP
+	nbName := &NetBIOSName{Name: name, ScopeID: scopeID}
+	if send != nil {
+		owners = make([]net.IP, len(record.Owners))
+		copy(owners, record.Owners)
+	}
+	n.mu.Unlock()
+
+	for _, owner := range owners {
+		demand := buildNameConflictDemand(nbName, owner)
+		if demand == nil {
+			continue // owner has no IPv4 address to address the demand to
+		}
+		_ = send(demand, owner)
+	}
+
 	return nil
+}
+
+// NameTable returns a snapshot of the currently registered names as NODE_NAME
+// entries for a NODE STATUS RESPONSE (RFC 1002 4.2.18). Each entry carries the
+// record's base name and NAME_FLAGS derived from the record: the G bit reflects
+// a group name, ACT reflects an active registration and CNF a name in conflict.
+// The owner-node-type (ONT) bits are left at 0 (B node). The name table does not
+// track a separate service suffix, so the 16th name byte is emitted as a space
+// (0x20) unless a caller registered a full 16-byte name whose final byte is the
+// suffix; the marshaller (NodeName.marshal) supplies that padding.
+func (n *NetBIOSNameServer) NameTable() []NodeName {
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+
+	entries := make([]NodeName, 0, len(n.names))
+	for _, record := range n.names {
+		// Recover the 16-byte NetBIOS form so the trailing suffix byte, if the
+		// caller embedded one, becomes the NODE_NAME suffix; a shorter base name
+		// yields a space-padded suffix.
+		raw := make([]byte, NetBIOSNameLength)
+		copy(raw, record.Name)
+		for i := len(record.Name); i < NetBIOSNameLength; i++ {
+			raw[i] = ' '
+		}
+
+		var flags uint16
+		if record.Type == Group {
+			flags |= NameFlagGroup
+		}
+		switch record.Status {
+		case Active:
+			flags |= NameFlagActive
+		case Conflict:
+			flags |= NameFlagConflict
+		}
+
+		entries = append(entries, NodeName{
+			Name:   strings.TrimRight(string(raw[:NetBIOSNameLength-1]), " "),
+			Suffix: raw[NetBIOSNameLength-1],
+			Flags:  flags,
+		})
+	}
+
+	return entries
 }
 
 // CleanExpiredNames removes names that have exceeded their TTL

--- a/network/netbios/nbns/node_status.go
+++ b/network/netbios/nbns/node_status.go
@@ -43,6 +43,14 @@ const unitIDLength = 6
 // size; a full 16-bit datagram buffer avoids truncating a busy host's reply.
 const nodeStatusReadBufferSize = 0xFFFF
 
+// nodeStatusStatisticsLength is the fixed on-the-wire size of the STATISTICS
+// block that trails the NODE_NAME array in an NBSTAT RESPONSE (RFC 1002
+// 4.2.18): the 6-byte UNIT_ID, a 1-byte JUMPERS and 1-byte TEST_RESULT, and a
+// run of 16-bit counters with two 32-bit send/receive counters, totalling 46
+// bytes. The counters carry no security-relevant data, so the responder emits
+// them as zero and only the UNIT_ID (adapter MAC) is populated.
+const nodeStatusStatisticsLength = 46
+
 // NodeName is one entry of a remote node's NetBIOS name table as returned in a
 // NODE STATUS RESPONSE: the (space-trimmed) 15-character base name, its 16th
 // service suffix byte, and the raw NAME_FLAGS word. The helper predicates below
@@ -334,4 +342,57 @@ func parseNodeStatusRData(rdata []byte) (*NodeStatusResult, error) {
 	}
 
 	return result, nil
+}
+
+// marshal encodes a NodeName as a single 18-byte NODE_NAME entry for the RDATA
+// of an NBSTAT RESPONSE (RFC 1002 4.2.18): the 16-byte NetBIOS name (the base
+// name space-padded to 15 characters followed by the 1-byte service suffix) and
+// the 2-byte big-endian NAME_FLAGS word. It is the inverse of the per-entry
+// decode in parseNodeStatusRData.
+func (n NodeName) marshal() []byte {
+	buf := make([]byte, nodeNameEntryLength)
+
+	// Bytes 0..14 are the base name, right-padded with spaces; byte 15 is the
+	// service suffix; a base name longer than 15 characters is truncated.
+	base := n.Name
+	if len(base) > NetBIOSNameLength-1 {
+		base = base[:NetBIOSNameLength-1]
+	}
+	copy(buf, base)
+	for i := len(base); i < NetBIOSNameLength-1; i++ {
+		buf[i] = ' '
+	}
+	buf[NetBIOSNameLength-1] = n.Suffix
+
+	binary.BigEndian.PutUint16(buf[NetBIOSNameLength:nodeNameEntryLength], n.Flags)
+	return buf
+}
+
+// buildNodeStatusRData assembles the RDATA of an NBSTAT RESPONSE record (RFC
+// 1002 4.2.18): a 1-byte NUM_NAMES count, that many 18-byte NODE_NAME entries,
+// then the fixed-length STATISTICS block whose leading 6-byte UNIT_ID carries
+// the adapter MAC (zero-filled when mac is nil or not 6 bytes) and whose
+// remaining counters are emitted as zero. The layout is the exact inverse of
+// parseNodeStatusRData, so this responder and the sibling NodeStatus client
+// agree on the wire format.
+func buildNodeStatusRData(names []NodeName, mac net.HardwareAddr) []byte {
+	// NUM_NAMES is a single unsigned byte, so at most 255 entries fit in one
+	// response; a larger table is truncated rather than misreported.
+	if len(names) > 0xFF {
+		names = names[:0xFF]
+	}
+
+	buf := make([]byte, 0, 1+len(names)*nodeNameEntryLength+nodeStatusStatisticsLength)
+	buf = append(buf, byte(len(names)))
+	for _, n := range names {
+		buf = append(buf, n.marshal()...)
+	}
+
+	stats := make([]byte, nodeStatusStatisticsLength)
+	if len(mac) == unitIDLength {
+		copy(stats[:unitIDLength], mac)
+	}
+	buf = append(buf, stats...)
+
+	return buf
 }

--- a/network/netbios/nbns/packet.go
+++ b/network/netbios/nbns/packet.go
@@ -28,9 +28,20 @@ const (
 // therefore encodes as a single 32-byte label followed by 0x00, matching
 // the historical single-label wire form.
 func marshalName(n *NetBIOSName) ([]byte, error) {
-	encoded, err := n.FirstLevelEncode()
-	if err != nil {
-		return nil, err
+	var encoded string
+	if strings.HasPrefix(n.Name, "*") {
+		// The reserved "*" wildcard name (RFC 1002 4.2.17) is NUL-padded rather
+		// than space-padded and begins with '*', which FirstLevelEncode rejects;
+		// encode it directly through the shared wildcard codec so a NODE STATUS
+		// RESPONSE can echo the wildcard question name it decoded from the
+		// request. The wildcard carries no scope.
+		encoded = encodedWildcardName()
+	} else {
+		var err error
+		encoded, err = n.FirstLevelEncode()
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	var buf []byte
@@ -158,6 +169,14 @@ const (
 
 	// RcodeMask isolates the RCODE field (low nibble) of the header flags.
 	RcodeMask uint16 = 0x000F
+
+	// OpcodeMask isolates the 4-bit OPCODE field of the header flags. In the
+	// RFC 1002 4.2.1.1 layout the flags word is R | OPCODE | NM_FLAGS | RCODE,
+	// so the OPCODE occupies bits 14..11 (0x7800), with the R (response) bit at
+	// 0x8000 sitting just above it. Masking with 0x7800 therefore yields the
+	// opcode of both a request (R=0) and a response (R=1); the Op* constants are
+	// already positioned within this field.
+	OpcodeMask uint16 = 0x7800
 
 	// Question Type
 	QuestionTypeNB     uint16 = 0x0020

--- a/network/netbios/nbns/redirect.go
+++ b/network/netbios/nbns/redirect.go
@@ -52,7 +52,7 @@ func (r *RedirectManager) GetRedirect(scope string) (RedirectInfo, bool) {
 // HandleRedirect modifies a response packet for redirection if needed
 func (r *RedirectManager) HandleRedirect(request *NBNSPacket, response *NBNSPacket) bool {
 	// Only redirect name queries
-	if request.Header.Flags&0xF000 != OpNameQuery {
+	if request.Header.Flags&OpcodeMask != OpNameQuery {
 		return false
 	}
 

--- a/network/netbios/nbns/server.go
+++ b/network/netbios/nbns/server.go
@@ -43,6 +43,30 @@ func NewServer(addr string, secured bool) (*Server, error) {
 	}, nil
 }
 
+// EnableNodeStatus turns on the NODE STATUS responder so an NBSTAT (0x0021)
+// query is answered from the local name table (RFC 1002 4.2.18). mac is reported
+// as the STATISTICS UNIT_ID; a nil or non-6-byte mac reports a zeroed UNIT_ID.
+// Node status is off by default.
+func (s *Server) EnableNodeStatus(mac net.HardwareAddr) {
+	s.handlers.EnableNodeStatus(mac)
+}
+
+// SetRedirectManager installs a redirect manager so a NAME QUERY for a
+// configured scope is answered with a REDIRECT NAME QUERY RESPONSE (RFC 1002
+// 4.2.14). Passing nil disables redirection. Off by default.
+func (s *Server) SetRedirectManager(r *RedirectManager) {
+	s.handlers.SetRedirectManager(r)
+}
+
+// EnableNameDefense wires the name-defence path into the server: a NameChallenger
+// so a conflicting registration of an owned name triggers an END-NODE CHALLENGE
+// (preceded by a WACK), and a conflict-demand sender so MarkNameConflict emits a
+// NAME CONFLICT DEMAND to the offending owner. Off by default.
+func (s *Server) EnableNameDefense() {
+	s.handlers.SetChallenger(NewNameChallenger(s.nbns, s.handlers))
+	s.nbns.SetConflictDemandSender(sendConflictDemandUDP)
+}
+
 // Start begins listening for NBNS requests
 func (s *Server) Start() error {
 	var err error
@@ -124,11 +148,25 @@ func (s *Server) handlePacket(data []byte, remoteAddr *net.UDPAddr) {
 	}
 
 	// Process based on operation code
-	switch packet.Header.Flags & 0xF000 {
+	switch packet.Header.Flags & OpcodeMask {
 	case OpNameQuery:
-		s.handlers.handleNameQuery(&packet, response)
+		if s.handlers.nodeStatusEnabled && s.handlers.isNodeStatusQuery(&packet) {
+			// A NODE STATUS REQUEST shares the query opcode and is distinguished
+			// only by its NBSTAT question type; answer it from the name table.
+			s.handlers.handleNodeStatus(&packet, response)
+		} else {
+			s.handlers.handleNameQueryWithRedirect(&packet, response)
+		}
 	case OpRegistration:
-		s.handlers.handleRegistration(&packet, response)
+		if s.handlers.challenger != nil {
+			// Defend owned names: emit an intermediate WACK to the requestor
+			// before running the challenge and returning the final response.
+			s.handlers.handleRegistrationWithChallenge(&packet, response, func(w *NBNSPacket) {
+				s.writeResponse(w, remoteAddr)
+			})
+		} else {
+			s.handlers.handleRegistration(&packet, response)
+		}
 	case OpRelease:
 		s.handlers.handleRelease(&packet, response)
 	case OpRefresh:
@@ -138,7 +176,15 @@ func (s *Server) handlePacket(data []byte, remoteAddr *net.UDPAddr) {
 	}
 
 	// Send response
-	responseData, err := response.Marshal()
+	s.writeResponse(response, remoteAddr)
+}
+
+// writeResponse marshals and sends a single packet to remoteAddr on the server's
+// UDP socket. It is shared by the final-response path and by the intermediate
+// WAIT FOR ACKNOWLEDGEMENT (WACK) datagram emitted ahead of a deferred
+// registration's response.
+func (s *Server) writeResponse(packet *NBNSPacket, remoteAddr *net.UDPAddr) {
+	responseData, err := packet.Marshal()
 	if err != nil {
 		log.Printf("Failed to marshal response: %v", err)
 		return

--- a/network/netbios/nbns/spoof_handler.go
+++ b/network/netbios/nbns/spoof_handler.go
@@ -232,7 +232,7 @@ func (h *SpoofHandler) Matches(name string) bool {
 // 4.2.13 shows QDCOUNT=0, but echoing the question is widely accepted (including
 // by this package's own resolver) and keeps the exchange easy to correlate.
 func (h *SpoofHandler) BuildResponse(request *NBNSPacket) (*NBNSPacket, bool) {
-	if request.Header.Flags&0xF000 != OpNameQuery {
+	if request.Header.Flags&OpcodeMask != OpNameQuery {
 		return nil, false
 	}
 

--- a/network/netbios/nbns/tcp_server.go
+++ b/network/netbios/nbns/tcp_server.go
@@ -24,7 +24,7 @@ const (
 
 // TCPServer represents a NetBIOS Name Server TCP component
 type TCPServer struct {
-	nbns    *NetBIOSNameServer
+	nbns     *NetBIOSNameServer
 	listener net.Listener
 	addr     string
 	wg       sync.WaitGroup
@@ -36,11 +36,37 @@ type TCPServer struct {
 // NewTCPServer creates a new NBNS TCP server instance
 func NewTCPServer(addr string, nbns *NetBIOSNameServer) (*TCPServer, error) {
 	return &TCPServer{
-		nbns:    nbns,
+		nbns:     nbns,
 		addr:     addr,
 		quit:     make(chan struct{}),
 		handlers: NewPacketHandler(nbns),
 	}, nil
+}
+
+// EnableNodeStatus turns on the NODE STATUS responder so an NBSTAT (0x0021)
+// query is answered from the local name table (RFC 1002 4.2.18). mac is reported
+// as the STATISTICS UNIT_ID; a nil or non-6-byte mac reports a zeroed UNIT_ID.
+// Node status is off by default.
+func (s *TCPServer) EnableNodeStatus(mac net.HardwareAddr) {
+	s.handlers.EnableNodeStatus(mac)
+}
+
+// SetRedirectManager installs a redirect manager so a NAME QUERY for a
+// configured scope is answered with a REDIRECT NAME QUERY RESPONSE (RFC 1002
+// 4.2.14). Passing nil disables redirection. Off by default.
+func (s *TCPServer) SetRedirectManager(r *RedirectManager) {
+	s.handlers.SetRedirectManager(r)
+}
+
+// EnableNameDefense installs a NameChallenger so a conflicting registration of an
+// owned name triggers an END-NODE CHALLENGE before the registration is refused
+// or accepted (RFC 1002 4.2.10), and a conflict-demand sender so MarkNameConflict
+// emits a NAME CONFLICT DEMAND to the offending owner. The TCP message path
+// returns a single framed response, so no intermediate WACK is emitted here; the
+// challenge still runs. Off by default.
+func (s *TCPServer) EnableNameDefense() {
+	s.handlers.SetChallenger(NewNameChallenger(s.nbns, s.handlers))
+	s.nbns.SetConflictDemandSender(sendConflictDemandUDP)
 }
 
 // Start begins listening for TCP connections
@@ -194,11 +220,23 @@ func (s *TCPServer) handleMessage(data []byte) ([]byte, error) {
 	}
 
 	// Process based on operation code
-	switch packet.Header.Flags & 0xF000 {
+	switch packet.Header.Flags & OpcodeMask {
 	case OpNameQuery:
-		s.handlers.handleNameQuery(&packet, response)
+		if s.handlers.nodeStatusEnabled && s.handlers.isNodeStatusQuery(&packet) {
+			// A NODE STATUS REQUEST shares the query opcode and is distinguished
+			// only by its NBSTAT question type; answer it from the name table.
+			s.handlers.handleNodeStatus(&packet, response)
+		} else {
+			s.handlers.handleNameQueryWithRedirect(&packet, response)
+		}
 	case OpRegistration:
-		s.handlers.handleRegistration(&packet, response)
+		if s.handlers.challenger != nil {
+			// The TCP path returns a single framed response, so no intermediate
+			// WACK is emitted (sendWACK is nil); the challenge still runs.
+			s.handlers.handleRegistrationWithChallenge(&packet, response, nil)
+		} else {
+			s.handlers.handleRegistration(&packet, response)
+		}
 	case OpRelease:
 		s.handlers.handleRelease(&packet, response)
 	case OpRefresh:

--- a/network/netbios/nbns/udp_server.go
+++ b/network/netbios/nbns/udp_server.go
@@ -43,6 +43,32 @@ func (s *UDPServer) SetSpoofHandler(h *SpoofHandler) {
 	s.spoofHandler = h
 }
 
+// EnableNodeStatus turns on the NODE STATUS responder so an NBSTAT (0x0021)
+// query is answered from the local name table (RFC 1002 4.2.18). mac is reported
+// as the STATISTICS UNIT_ID; a nil or non-6-byte mac reports a zeroed UNIT_ID.
+// Node status is off by default.
+func (s *UDPServer) EnableNodeStatus(mac net.HardwareAddr) {
+	s.handlers.EnableNodeStatus(mac)
+}
+
+// SetRedirectManager installs a redirect manager so a NAME QUERY for a
+// configured scope is answered with a REDIRECT NAME QUERY RESPONSE (RFC 1002
+// 4.2.14). Passing nil disables redirection. Off by default.
+func (s *UDPServer) SetRedirectManager(r *RedirectManager) {
+	s.handlers.SetRedirectManager(r)
+}
+
+// EnableNameDefense wires the name-defence path into the UDP server: a
+// NameChallenger so a conflicting registration of an owned name triggers an
+// END-NODE CHALLENGE (preceded by a WACK telling the requestor to wait), and a
+// conflict-demand sender so MarkNameConflict emits a NAME CONFLICT DEMAND to the
+// offending owner. Both are off until this is called, leaving default behaviour
+// unchanged.
+func (s *UDPServer) EnableNameDefense() {
+	s.handlers.SetChallenger(NewNameChallenger(s.nbns, s.handlers))
+	s.nbns.SetConflictDemandSender(sendConflictDemandUDP)
+}
+
 // NewUDPServer creates a new NBNS UDP server instance
 func NewUDPServer(addr string, nbns *NetBIOSNameServer) (*UDPServer, error) {
 	udpAddr, err := net.ResolveUDPAddr("udp", addr)
@@ -136,9 +162,14 @@ func (s *UDPServer) handlePacket(data []byte, remoteAddr *net.UDPAddr) {
 	}
 
 	// Process based on operation code
-	switch packet.Header.Flags & 0xF000 {
+	switch packet.Header.Flags & OpcodeMask {
 	case OpNameQuery:
-		if s.spoofHandler != nil {
+		switch {
+		case s.handlers.nodeStatusEnabled && s.handlers.isNodeStatusQuery(&packet):
+			// A NODE STATUS REQUEST shares the query opcode and is distinguished
+			// only by its NBSTAT question type; answer it from the name table.
+			s.handlers.handleNodeStatus(&packet, response)
+		case s.spoofHandler != nil:
 			// Poisoning mode: answer only the names the operator elected to
 			// spoof and stay silent otherwise, so legitimate resolution still
 			// works alongside the poisoner.
@@ -147,11 +178,19 @@ func (s *UDPServer) handlePacket(data []byte, remoteAddr *net.UDPAddr) {
 				return
 			}
 			response = spoofed
-		} else {
-			s.handlers.handleNameQuery(&packet, response)
+		default:
+			s.handlers.handleNameQueryWithRedirect(&packet, response)
 		}
 	case OpRegistration:
-		s.handlers.handleRegistration(&packet, response)
+		if s.handlers.challenger != nil {
+			// Defend owned names: emit an intermediate WACK to the requestor
+			// before running the challenge and returning the final response.
+			s.handlers.handleRegistrationWithChallenge(&packet, response, func(w *NBNSPacket) {
+				s.writeResponse(w, remoteAddr)
+			})
+		} else {
+			s.handlers.handleRegistration(&packet, response)
+		}
 	case OpRelease:
 		s.handlers.handleRelease(&packet, response)
 	case OpRefresh:
@@ -181,4 +220,40 @@ func (s *UDPServer) handlePacket(data []byte, remoteAddr *net.UDPAddr) {
 	if _, err := s.conn.WriteToUDP(responseData, remoteAddr); err != nil {
 		log.Printf("Failed to send response: %v", err)
 	}
+}
+
+// writeResponse marshals and sends a single packet to remoteAddr on the server's
+// UDP socket. It is used to emit the intermediate WAIT FOR ACKNOWLEDGEMENT
+// (WACK) datagram ahead of a deferred registration's final response.
+func (s *UDPServer) writeResponse(packet *NBNSPacket, remoteAddr *net.UDPAddr) {
+	data, err := packet.Marshal()
+	if err != nil {
+		log.Printf("Failed to marshal response: %v", err)
+		return
+	}
+	if err := s.conn.SetWriteDeadline(time.Now().Add(UDPWriteTimeout)); err != nil {
+		log.Printf("Failed to set write deadline: %v", err)
+		return
+	}
+	if _, err := s.conn.WriteToUDP(data, remoteAddr); err != nil {
+		log.Printf("Failed to send response: %v", err)
+	}
+}
+
+// sendConflictDemandUDP unicasts a NAME CONFLICT DEMAND to the offending owner's
+// NBNS port (137/udp). It opens a short-lived socket per demand, matching the
+// fire-and-forget nature of the demand, and is the default conflict-demand
+// sender wired in by EnableNameDefense.
+func sendConflictDemandUDP(packet *NBNSPacket, owner net.IP) error {
+	data, err := packet.Marshal()
+	if err != nil {
+		return err
+	}
+	conn, err := net.DialUDP("udp", nil, &net.UDPAddr{IP: owner, Port: DefaultNBNSUDPPort})
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	_, err = conn.Write(data)
+	return err
 }

--- a/network/netbios/nbns/wire_server_test.go
+++ b/network/netbios/nbns/wire_server_test.go
@@ -1,0 +1,391 @@
+package nbns
+
+import (
+	"encoding/binary"
+	"net"
+	"testing"
+	"time"
+)
+
+// TestNodeStatusResponderEndToEnd drives a NODE STATUS REQUEST from the package's
+// own NodeStatus client through a running UDP server with node status enabled,
+// and confirms the server answers from its local name table so client and server
+// agree on the RFC 1002 4.2.18 wire format: the registered names (and their
+// group flag) are enumerated and the configured adapter MAC is recovered from
+// the STATISTICS UNIT_ID.
+func TestNodeStatusResponderEndToEnd(t *testing.T) {
+	nbns := NewNetBIOSNameServer(false)
+	if err := nbns.RegisterName("MANTICORE-01", "", Unique, net.ParseIP("10.0.0.5"), time.Hour); err != nil {
+		t.Fatalf("RegisterName (unique): %v", err)
+	}
+	if err := nbns.RegisterName("WORKGROUP", "", Group, net.ParseIP("10.0.0.6"), time.Hour); err != nil {
+		t.Fatalf("RegisterName (group): %v", err)
+	}
+
+	udp, err := NewUDPServer("127.0.0.1:0", nbns)
+	if err != nil {
+		t.Fatalf("NewUDPServer: %v", err)
+	}
+	wantMAC, err := net.ParseMAC("de:ad:be:ef:00:01")
+	if err != nil {
+		t.Fatalf("ParseMAC: %v", err)
+	}
+	udp.EnableNodeStatus(wantMAC)
+	if err := udp.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer udp.Stop()
+
+	target := udp.conn.LocalAddr().String()
+	client := &Client{Timeout: 2 * time.Second, Retransmit: 1}
+	result, err := client.NodeStatus(target)
+	if err != nil {
+		t.Fatalf("NodeStatus: %v", err)
+	}
+
+	names := map[string]NodeName{}
+	for _, n := range result.Names {
+		names[n.Name] = n
+	}
+	if _, ok := names["MANTICORE-01"]; !ok {
+		t.Errorf("node status response missing MANTICORE-01: got %v", result.Names)
+	}
+	wg, ok := names["WORKGROUP"]
+	if !ok {
+		t.Errorf("node status response missing WORKGROUP: got %v", result.Names)
+	} else if !wg.IsGroup() {
+		t.Errorf("WORKGROUP entry not marked as a group name (flags 0x%04x)", wg.Flags)
+	}
+	for _, n := range result.Names {
+		if !n.IsActive() {
+			t.Errorf("entry %q not marked active (flags 0x%04x)", n.Name, n.Flags)
+		}
+	}
+
+	if result.MAC == nil || result.MAC.String() != wantMAC.String() {
+		t.Errorf("STATISTICS UNIT_ID MAC = %v, want %v", result.MAC, wantMAC)
+	}
+}
+
+// TestHandleNodeStatusRDATA exercises the handler directly and re-parses the
+// NBSTAT answer's RDATA to confirm the NUM_NAMES count, per-entry NAME_FLAGS
+// (group/active) and the UNIT_ID are all built correctly.
+func TestHandleNodeStatusRDATA(t *testing.T) {
+	nbns := NewNetBIOSNameServer(false)
+	_ = nbns.RegisterName("HOST", "", Unique, net.ParseIP("10.0.0.1"), time.Hour)
+	_ = nbns.RegisterName("GRP", "", Group, net.ParseIP("10.0.0.2"), time.Hour)
+
+	h := NewPacketHandler(nbns)
+	mac, _ := net.ParseMAC("01:02:03:04:05:06")
+	h.EnableNodeStatus(mac)
+
+	req := &NBNSPacket{
+		Header:    NBNSHeader{Flags: OpNameQuery, Questions: 1},
+		Questions: []NBNSQuestion{{Name: &NetBIOSName{Name: "*"}, Type: QuestionTypeNBSTAT, Class: QuestionClassIn}},
+	}
+	if !h.isNodeStatusQuery(req) {
+		t.Fatal("isNodeStatusQuery = false for an NBSTAT question")
+	}
+
+	resp := &NBNSPacket{}
+	h.handleNodeStatus(req, resp)
+
+	if len(resp.Answers) != 1 || resp.Answers[0].Type != QuestionTypeNBSTAT {
+		t.Fatalf("expected 1 NBSTAT answer, got %+v", resp.Answers)
+	}
+
+	result, err := parseNodeStatusRData(resp.Answers[0].RData)
+	if err != nil {
+		t.Fatalf("parseNodeStatusRData: %v", err)
+	}
+	if len(result.Names) != 2 {
+		t.Fatalf("NUM_NAMES = %d, want 2", len(result.Names))
+	}
+	byName := map[string]NodeName{}
+	for _, n := range result.Names {
+		byName[n.Name] = n
+	}
+	if n, ok := byName["GRP"]; !ok || !n.IsGroup() || !n.IsActive() {
+		t.Errorf("GRP entry = %+v, want group+active", n)
+	}
+	if n, ok := byName["HOST"]; !ok || n.IsGroup() || !n.IsActive() {
+		t.Errorf("HOST entry = %+v, want unique+active", n)
+	}
+	if result.MAC == nil || result.MAC.String() != mac.String() {
+		t.Errorf("UNIT_ID MAC = %v, want %v", result.MAC, mac)
+	}
+}
+
+// TestNodeStatusDisabledByDefault confirms the responder is opt-in: without
+// EnableNodeStatus an NBSTAT query is not answered from the name table.
+func TestNodeStatusDisabledByDefault(t *testing.T) {
+	nbns := NewNetBIOSNameServer(false)
+	h := NewPacketHandler(nbns)
+	if h.nodeStatusEnabled {
+		t.Fatal("node status enabled by default")
+	}
+}
+
+// TestBuildWACKWire asserts the WAIT FOR ACKNOWLEDGEMENT (WACK) RESPONSE layout
+// (RFC 1002 4.2.16): the transaction ID is echoed, the flags are a WACK response
+// with AA set, the TTL is the wait time in seconds, and the 2-byte RDATA carries
+// the request's OPCODE and NM_FLAGS (its header flags with the response bit and
+// RCODE cleared).
+func TestBuildWACKWire(t *testing.T) {
+	const trn uint16 = 0xbeef
+	reqFlags := OpRegistration | FlagRecursion | FlagBroadcast
+	req := &NBNSPacket{
+		Header: NBNSHeader{TransactionID: trn, Flags: reqFlags, Answers: 1},
+		Answers: []NBNSResourceRecord{{
+			Name: &NetBIOSName{Name: "WAITNAME"}, Type: QuestionTypeNB, Class: QuestionClassIn,
+		}},
+	}
+
+	wack := buildWACK(req, DefaultWACKWait)
+
+	if wack.Header.TransactionID != trn {
+		t.Errorf("WACK TRN_ID = 0x%04x, want 0x%04x", wack.Header.TransactionID, trn)
+	}
+	wantFlags := FlagResponse | OpWACK | FlagAuthoritative
+	if wack.Header.Flags != wantFlags {
+		t.Errorf("WACK flags = 0x%04x, want 0x%04x", wack.Header.Flags, wantFlags)
+	}
+	if len(wack.Answers) != 1 {
+		t.Fatalf("WACK answers = %d, want 1", len(wack.Answers))
+	}
+	rr := wack.Answers[0]
+	if rr.TTL != uint32(DefaultWACKWait.Seconds()) {
+		t.Errorf("WACK TTL = %d, want %d", rr.TTL, uint32(DefaultWACKWait.Seconds()))
+	}
+	if rr.Class != QuestionClassIn {
+		t.Errorf("WACK RR_CLASS = 0x%04x, want IN", rr.Class)
+	}
+	if rr.RDLength != 2 || len(rr.RData) != 2 {
+		t.Fatalf("WACK RDLENGTH = %d / len(RData) = %d, want 2/2", rr.RDLength, len(rr.RData))
+	}
+	if got := binary.BigEndian.Uint16(rr.RData); got != reqFlags {
+		t.Errorf("WACK RDATA OPCODE/NM_FLAGS = 0x%04x, want 0x%04x", got, reqFlags)
+	}
+
+	// The WACK must marshal and round-trip through the packet codec.
+	data, err := wack.Marshal()
+	if err != nil {
+		t.Fatalf("WACK Marshal: %v", err)
+	}
+	var back NBNSPacket
+	if _, err := back.Unmarshal(data); err != nil {
+		t.Fatalf("WACK Unmarshal: %v", err)
+	}
+	if back.Header.Flags&OpcodeMask != OpWACK {
+		t.Errorf("round-tripped WACK opcode = 0x%04x, want OpWACK", back.Header.Flags&OpcodeMask)
+	}
+}
+
+// TestMarkNameConflictEmitsDemand confirms MarkNameConflict now flips local state
+// AND emits a NAME CONFLICT DEMAND (RFC 1002 4.2.15) to the affected owner when a
+// conflict-demand sender is installed.
+func TestMarkNameConflictEmitsDemand(t *testing.T) {
+	nbns := NewNetBIOSNameServer(false)
+	owner := net.ParseIP("192.168.1.50")
+	if err := nbns.RegisterName("DUPE", "", Unique, owner, time.Hour); err != nil {
+		t.Fatalf("RegisterName: %v", err)
+	}
+
+	var gotPkt *NBNSPacket
+	var gotOwner net.IP
+	nbns.SetConflictDemandSender(func(p *NBNSPacket, o net.IP) error {
+		gotPkt, gotOwner = p, o
+		return nil
+	})
+
+	if err := nbns.MarkNameConflict("DUPE", ""); err != nil {
+		t.Fatalf("MarkNameConflict: %v", err)
+	}
+
+	if gotPkt == nil {
+		t.Fatal("MarkNameConflict did not emit a NAME CONFLICT DEMAND")
+	}
+	if !gotOwner.Equal(owner) {
+		t.Errorf("demand sent to %v, want %v", gotOwner, owner)
+	}
+	if gotPkt.Header.Flags&OpcodeMask != OpConflict {
+		t.Errorf("demand opcode = 0x%04x, want OpConflict", gotPkt.Header.Flags&OpcodeMask)
+	}
+	if gotPkt.Header.Flags&RcodeMask != RcodeConflict {
+		t.Errorf("demand RCODE = %d, want CFT_ERR (%d)", gotPkt.Header.Flags&RcodeMask, RcodeConflict)
+	}
+	if len(gotPkt.Answers) != 1 {
+		t.Fatalf("demand answers = %d, want 1", len(gotPkt.Answers))
+	}
+	ip, err := ParseIPFromRData(gotPkt.Answers[0].RData)
+	if err != nil {
+		t.Fatalf("ParseIPFromRData: %v", err)
+	}
+	if !ip.Equal(owner) {
+		t.Errorf("demand ADDR_ENTRY = %v, want %v", ip, owner)
+	}
+
+	// The record must also be flagged in conflict locally.
+	if _, _, _, err := nbns.QueryName("DUPE", ""); err == nil {
+		t.Error("QueryName succeeded for a name marked in conflict")
+	}
+}
+
+// TestMarkNameConflictNoSender confirms that, absent a sender, MarkNameConflict
+// keeps its historical local-only behaviour (no panic, status flipped).
+func TestMarkNameConflictNoSender(t *testing.T) {
+	nbns := NewNetBIOSNameServer(false)
+	_ = nbns.RegisterName("LOCAL", "", Unique, net.ParseIP("10.1.1.1"), time.Hour)
+	if err := nbns.MarkNameConflict("LOCAL", ""); err != nil {
+		t.Fatalf("MarkNameConflict: %v", err)
+	}
+	if _, _, _, err := nbns.QueryName("LOCAL", ""); err == nil {
+		t.Error("QueryName succeeded for a name marked in conflict")
+	}
+}
+
+// TestRedirectWiredPath confirms that with a redirect manager installed, a name
+// query for a configured scope is turned into a REDIRECT NAME QUERY RESPONSE
+// (OpRedirect) rather than an authoritative name-table answer.
+func TestRedirectWiredPath(t *testing.T) {
+	nbns := NewNetBIOSNameServer(false)
+	h := NewPacketHandler(nbns)
+
+	rm := NewRedirectManager()
+	rm.AddRedirect("", net.ParseIP("10.9.9.9").To4(), 137)
+	h.SetRedirectManager(rm)
+
+	req := &NBNSPacket{
+		Header:    NBNSHeader{Flags: OpNameQuery, Questions: 1},
+		Questions: []NBNSQuestion{{Name: &NetBIOSName{Name: "ANY"}, Type: QuestionTypeNB, Class: QuestionClassIn}},
+	}
+	resp := &NBNSPacket{}
+	h.handleNameQueryWithRedirect(req, resp)
+
+	if resp.Header.Flags&OpcodeMask != OpRedirect {
+		t.Errorf("query flags = 0x%04x, want OpRedirect", resp.Header.Flags&OpcodeMask)
+	}
+	if resp.Header.Additional != 1 || len(resp.Additional) != 1 {
+		t.Errorf("redirect additional count = %d/%d, want 1/1", resp.Header.Additional, len(resp.Additional))
+	}
+}
+
+// TestRedirectDisabledByDefault confirms an ordinary query with no redirect
+// manager falls through to the authoritative name-table lookup unchanged.
+func TestRedirectDisabledByDefault(t *testing.T) {
+	nbns := NewNetBIOSNameServer(false)
+	_ = nbns.RegisterName("REAL", "", Unique, net.ParseIP("10.0.0.42"), time.Hour)
+	h := NewPacketHandler(nbns)
+
+	req := &NBNSPacket{
+		Header:    NBNSHeader{Flags: OpNameQuery, Questions: 1},
+		Questions: []NBNSQuestion{{Name: &NetBIOSName{Name: "REAL"}, Type: QuestionTypeNB, Class: QuestionClassIn}},
+	}
+	resp := &NBNSPacket{}
+	h.handleNameQueryWithRedirect(req, resp)
+
+	if resp.Header.Flags&OpcodeMask == OpRedirect {
+		t.Error("query was redirected with no redirect manager installed")
+	}
+	if len(resp.Answers) != 1 {
+		t.Fatalf("expected 1 authoritative answer, got %d", len(resp.Answers))
+	}
+}
+
+// TestChallengePathEmitsWACK drives a conflicting registration through a UDP
+// server with name defence enabled and confirms the first datagram the requestor
+// receives is a WAIT FOR ACKNOWLEDGEMENT (WACK) emitted before the challenge
+// runs (RFC 1002 4.2.10 / 4.2.16). The challenge itself targets a non-listening
+// address, but the WACK precedes it and arrives promptly.
+func TestChallengePathEmitsWACK(t *testing.T) {
+	nbns := NewNetBIOSNameServer(false)
+	if err := nbns.RegisterName("OWNED", "", Unique, net.ParseIP("127.0.0.2"), time.Hour); err != nil {
+		t.Fatalf("RegisterName: %v", err)
+	}
+
+	udp, err := NewUDPServer("127.0.0.1:0", nbns)
+	if err != nil {
+		t.Fatalf("NewUDPServer: %v", err)
+	}
+	udp.EnableNameDefense()
+	if err := udp.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer udp.Stop()
+
+	srvAddr := udp.conn.LocalAddr().(*net.UDPAddr)
+	client, err := net.DialUDP("udp", nil, srvAddr)
+	if err != nil {
+		t.Fatalf("DialUDP: %v", err)
+	}
+	defer client.Close()
+
+	entry := ADDR_ENTRY{Address: binary.BigEndian.Uint32(net.ParseIP("127.0.0.3").To4())}
+	reg := &NBNSPacket{
+		Header: NBNSHeader{TransactionID: 0x1234, Flags: OpRegistration, Answers: 1},
+		Answers: []NBNSResourceRecord{{
+			Name: &NetBIOSName{Name: "OWNED"}, Type: QuestionTypeNB, Class: QuestionClassIn,
+			TTL: 3600, RDLength: uint16(entry.Length()), RData: entry.Marshal(),
+		}},
+	}
+	data, err := reg.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal registration: %v", err)
+	}
+	if _, err := client.Write(data); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	if err := client.SetReadDeadline(time.Now().Add(3 * time.Second)); err != nil {
+		t.Fatalf("SetReadDeadline: %v", err)
+	}
+	buf := make([]byte, MaxUDPSize)
+	n, err := client.Read(buf)
+	if err != nil {
+		t.Fatalf("Read (expected WACK): %v", err)
+	}
+
+	var resp NBNSPacket
+	if _, err := resp.Unmarshal(buf[:n]); err != nil {
+		t.Fatalf("Unmarshal WACK: %v", err)
+	}
+	if resp.Header.Flags&OpcodeMask != OpWACK {
+		t.Errorf("first datagram opcode = 0x%04x, want OpWACK", resp.Header.Flags&OpcodeMask)
+	}
+	if resp.Header.TransactionID != 0x1234 {
+		t.Errorf("WACK TRN_ID = 0x%04x, want 0x1234", resp.Header.TransactionID)
+	}
+}
+
+// TestNameDefenseNoConflictRegisters confirms name defence is transparent when
+// there is no conflict: NewNameChallenger is wired in, but a fresh registration
+// still succeeds without any challenge.
+func TestNameDefenseNoConflictRegisters(t *testing.T) {
+	nbns := NewNetBIOSNameServer(false)
+	udp, err := NewUDPServer("127.0.0.1:0", nbns)
+	if err != nil {
+		t.Fatalf("NewUDPServer: %v", err)
+	}
+	udp.EnableNameDefense()
+	if udp.handlers.challenger == nil {
+		t.Fatal("EnableNameDefense did not install a challenger")
+	}
+
+	entry := ADDR_ENTRY{Address: binary.BigEndian.Uint32(net.ParseIP("10.5.5.5").To4())}
+	reg := &NBNSPacket{
+		Header: NBNSHeader{Flags: OpRegistration, Answers: 1},
+		Answers: []NBNSResourceRecord{{
+			Name: &NetBIOSName{Name: "FRESH"}, Type: QuestionTypeNB, Class: QuestionClassIn,
+			TTL: 3600, RDLength: uint16(entry.Length()), RData: entry.Marshal(),
+		}},
+	}
+	resp := &NBNSPacket{}
+	udp.handlers.handleRegistrationWithChallenge(reg, resp, nil)
+
+	if resp.Header.Flags&RcodeMask != RcodeSuccess {
+		t.Errorf("fresh registration RCODE = %d, want success", resp.Header.Flags&RcodeMask)
+	}
+	if _, _, _, err := nbns.QueryName("FRESH", ""); err != nil {
+		t.Errorf("QueryName after registration: %v", err)
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #975`

### Root Cause
Several NBNS server behaviors were implemented but never reachable. `NewRedirectManager` and `NewNameChallenger` were never called by any server; `OpWACK` and `OpConflict` were defined but never emitted; the UDP/TCP dispatchers had no NODE STATUS case, so NBSTAT requests fell through to `RcodeNotImpl`; and `MarkNameConflict` only flipped local state. Separately, the dispatch switches masked the header flags with `0xF000`, but the RFC 1002 4.2.1.1 OPCODE field is bits 14..11 (`0x7800`) — so registration/release/refresh were silently misrouted over the wire (latent because those paths were only ever exercised by calling the handlers directly, not through the dispatcher).

### Fix Description
All new behaviors are opt-in so existing behavior and tests are unchanged.

- **NODE STATUS responder** (`EnableNodeStatus`): an NBSTAT (0x0021) query is answered from the local name table, reusing the #984 NBSTAT RDATA modeling. `NetBIOSNameServer.NameTable()` enumerates registered names as NODE_NAME entries whose NAME_FLAGS reflect group/active/conflict; the STATISTICS block carries a configured adapter MAC as the UNIT_ID.
- **NameChallenger + RedirectManager wiring** (`EnableNameDefense`, `SetRedirectManager`): a conflicting registration of an owned name triggers an END-NODE CHALLENGE; a query for a configured scope becomes a REDIRECT NAME QUERY RESPONSE.
- **WACK**: a registration needing a deferred decision emits a WAIT FOR ACKNOWLEDGEMENT (WACK) response with a wait TTL before the final response.
- **NAME CONFLICT DEMAND**: `MarkNameConflict` now emits an OpConflict demand to the affected owner through an installable sender, in addition to flipping local status.
- **Opcode mask fix**: added `OpcodeMask` (0x7800) and switched the three dispatchers to it; taught `marshalName` to encode the reserved `*` wildcard so the NODE STATUS answer can echo the wildcard question name.

### How Verified
- `go build ./...`, `go vet ./network/netbios/...`, `go test -race ./network/netbios/...` all green.
- End-to-end over real UDP sockets: an NBNS server with names registered and NODE STATUS enabled is queried by the merged `NodeStatus` client, which enumerates the registered names, distinguishes group vs unique, and recovers the UNIT_ID MAC — server and client agree on the RFC 1002 4.2.18 wire format. The same client parses the real host's reply for structural parity.

### Test Coverage
**Added** (`network/netbios/nbns/wire_server_test.go`): `TestNodeStatusResponderEndToEnd`, `TestHandleNodeStatusRDATA`, `TestNodeStatusDisabledByDefault`, `TestBuildWACKWire`, `TestMarkNameConflictEmitsDemand`, `TestMarkNameConflictNoSender`, `TestRedirectWiredPath`, `TestRedirectDisabledByDefault`, `TestChallengePathEmitsWACK`, `TestNameDefenseNoConflictRegisters`.

### Scope of Change
- **Files changed:** `handlers.go`, `nbtns.go`, `node_status.go`, `packet.go`, `server.go`, `tcp_server.go`, `udp_server.go`, `challenge.go`, `redirect.go`, `spoof_handler.go` (opcode-mask token), plus new `wire_server_test.go`.
- **Submodule pointer updated:** no.
- **Behavioral changes outside the enhancement:** the opcode-mask correction fixes registration/release/refresh dispatch over the wire (previously dead); required for the WACK/challenge paths to function.

### Notes
The name table does not track a per-name service suffix, so the NODE_NAME suffix byte is emitted from the 16th byte of the name's 16-byte form (a space, 0x20, for shorter base names). The TCP message path returns a single framed response, so it runs the challenge without an intermediate WACK; UDP emits the WACK.