### PR TITLE
Implement NetBIOS Datagram Service transport (Fixes #976)

### DIFF
--- a/network/netbios/nbdgm/broadcast_other.go
+++ b/network/netbios/nbdgm/broadcast_other.go
@@ -1,0 +1,13 @@
+//go:build !unix
+
+package nbdgm
+
+import "net"
+
+// enableBroadcast is a no-op on platforms where toggling SO_BROADCAST through a
+// raw socket option is not wired up here. Unicast (DIRECT) datagrams are
+// unaffected; only the limited-broadcast send depends on the option, and it
+// degrades gracefully rather than failing to build off unix.
+func enableBroadcast(conn *net.UDPConn) error {
+	return nil
+}

--- a/network/netbios/nbdgm/broadcast_unix.go
+++ b/network/netbios/nbdgm/broadcast_unix.go
@@ -1,0 +1,28 @@
+//go:build unix
+
+package nbdgm
+
+import (
+	"net"
+	"syscall"
+)
+
+// enableBroadcast sets the SO_BROADCAST socket option on conn so that datagrams
+// addressed to the IPv4 limited-broadcast address (255.255.255.255) are allowed
+// out. A BROADCAST datagram is sent to that address, and the kernel rejects a
+// broadcast send on a socket that has not opted in via SO_BROADCAST.
+func enableBroadcast(conn *net.UDPConn) error {
+	raw, err := conn.SyscallConn()
+	if err != nil {
+		return err
+	}
+
+	var sockErr error
+	ctrlErr := raw.Control(func(fd uintptr) {
+		sockErr = syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_BROADCAST, 1)
+	})
+	if ctrlErr != nil {
+		return ctrlErr
+	}
+	return sockErr
+}

--- a/network/netbios/nbdgm/datagram.go
+++ b/network/netbios/nbdgm/datagram.go
@@ -1,0 +1,358 @@
+// Package nbdgm implements the NetBIOS Datagram Service (RFC 1002 4.4, UDP
+// port 138): the datagram header codec, the DIRECT_UNIQUE / DIRECT_GROUP /
+// BROADCAST datagrams, the DATAGRAM ERROR packet, the DATAGRAM QUERY REQUEST
+// and POSITIVE / NEGATIVE DATAGRAM QUERY RESPONSE packets, and FIRST/MORE
+// fragmentation and reassembly of the USER_DATA payload.
+//
+// This is the connectionless transport that the Browser protocol and mailslots
+// ride on top of; only the datagram transport layer lives here. The NetBIOS
+// name encoding for the SOURCE_NAME / DESTINATION_NAME fields is reused from
+// the sibling name-service package (network/netbios/nbns).
+package nbdgm
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/TheManticoreProject/Manticore/network/netbios/nbns"
+)
+
+// DefaultDatagramPort is the well-known UDP port of the NetBIOS Datagram
+// Service (RFC 1002 4.4 / RFC 1001 5.4). All datagrams are exchanged on it.
+const DefaultDatagramPort = 138
+
+// Datagram MSG_TYPE values (RFC 1002 4.4.1). The message type is the first byte
+// of every datagram and selects both the semantics and the trailer layout.
+const (
+	MsgTypeDirectUnique          uint8 = 0x10 // DIRECT_UNIQUE DATAGRAM
+	MsgTypeDirectGroup           uint8 = 0x11 // DIRECT_GROUP DATAGRAM
+	MsgTypeBroadcast             uint8 = 0x12 // BROADCAST DATAGRAM
+	MsgTypeError                 uint8 = 0x13 // DATAGRAM ERROR
+	MsgTypeQueryRequest          uint8 = 0x14 // DATAGRAM QUERY REQUEST
+	MsgTypePositiveQueryResponse uint8 = 0x15 // DATAGRAM POSITIVE QUERY RESPONSE
+	MsgTypeNegativeQueryResponse uint8 = 0x16 // DATAGRAM NEGATIVE QUERY RESPONSE
+)
+
+// FLAGS field bit layout (RFC 1002 4.4.1). The one-byte FLAGS field is drawn in
+// the RFC as
+//
+//	  0   1   2   3   4   5   6   7
+//	+---+---+---+---+---+---+---+---+
+//	| 0 | 0 | 0 | 0 |  SNT  | F | M |
+//	+---+---+---+---+---+---+---+---+
+//
+// where bit 0 is the most-significant bit. In terms of the numeric byte value
+// M (MORE) is therefore the least-significant bit (0x01), F (FIRST) is 0x02,
+// and SNT (source end-node type) occupies bits 2-3 (mask 0x0C).
+const (
+	FlagMore  uint8 = 0x01 // M: set when more fragments of this datagram follow
+	FlagFirst uint8 = 0x02 // F: set on the first (or only) fragment of a datagram
+
+	sntShift = 2
+	sntMask  = 0x0C // SNT occupies the two bits above F
+)
+
+// SNT source end-node type values carried in the FLAGS field (RFC 1002 4.4.1).
+const (
+	NodeTypeB    uint8 = 0x00 // B node (broadcast)
+	NodeTypeP    uint8 = 0x01 // P node (point-to-point)
+	NodeTypeM    uint8 = 0x02 // M node (mixed)
+	NodeTypeNBDD uint8 = 0x03 // NetBIOS Datagram Distribution server
+)
+
+// DATAGRAM ERROR ERROR_CODE values (RFC 1002 4.4.2).
+const (
+	ErrorDestinationNameNotPresent uint8 = 0x82 // DESTINATION NAME NOT PRESENT
+	ErrorInvalidSourceNameFormat   uint8 = 0x83 // INVALID SOURCE NAME FORMAT
+	ErrorInvalidDestNameFormat     uint8 = 0x84 // INVALID DESTINATION NAME FORMAT
+)
+
+// baseHeaderLen is the size of the header common to every datagram: MSG_TYPE(1)
+// + FLAGS(1) + DGM_ID(2) + SOURCE_IP(4) + SOURCE_PORT(2). The DIRECT/BROADCAST
+// datagrams extend it with DGM_LENGTH(2) + PACKET_OFFSET(2).
+const (
+	baseHeaderLen   = 10
+	directHeaderLen = 14
+)
+
+// Name is a NetBIOS name as carried in a datagram SOURCE_NAME or
+// DESTINATION_NAME field: the up-to-15-character base name, the one-byte
+// service suffix (the 16th byte of the padded NetBIOS name), and an optional
+// scope. On the wire it is the RFC 1002 4.2.1.2 second-level encoding.
+type Name struct {
+	Name   string // base name, up to 15 characters (may be the "*" wildcard)
+	Suffix byte   // service suffix (16th byte of the padded NetBIOS name)
+	Scope  string // optional NetBIOS scope ID, dot-separated ("" for the default)
+}
+
+// encode builds the on-the-wire form of the name: the 0x20 length byte, the
+// 32-byte first-level encoding of the 16-byte (15 chars + suffix) name, any
+// dot-separated scope labels, and a 0x00 terminator. The first-level half-byte
+// encoding is reused from the name-service codec (nbns.EncodeSessionServiceName)
+// so the datagram and name services agree on the wire form.
+func (n Name) encode() ([]byte, error) {
+	// EncodeSessionServiceName returns exactly [0x20][32 encoded bytes][0x00];
+	// that is the datagram name form for the default (empty) scope.
+	base, err := nbns.EncodeSessionServiceName(n.Name, n.Suffix)
+	if err != nil {
+		return nil, err
+	}
+	if n.Scope == "" {
+		return base, nil
+	}
+
+	// With a scope, drop the trailing 0x00 root label and append the scope
+	// labels before a fresh terminator.
+	out := make([]byte, 0, len(base)+len(n.Scope)+8)
+	out = append(out, base[:len(base)-1]...)
+	for _, label := range strings.Split(n.Scope, ".") {
+		if len(label) == 0 || len(label) > 63 {
+			return nil, fmt.Errorf("invalid scope label %q", label)
+		}
+		out = append(out, byte(len(label)))
+		out = append(out, label...)
+	}
+	out = append(out, 0x00)
+	return out, nil
+}
+
+// decodeName decodes a datagram name at offset in data and returns the name and
+// the number of bytes it consumed. It mirrors the second-level encoding: a
+// 0x20 length byte, the 32 first-level-encoded characters (half-byte pairs, each
+// character being the nibble plus 'A'), and a 0x00-terminated scope label
+// sequence. The suffix byte is preserved (unlike nbns.FirstLevelDecode, which
+// trims it when it is a space).
+func decodeName(data []byte, offset int) (Name, int, error) {
+	pos := offset
+	if pos >= len(data) {
+		return Name{}, 0, fmt.Errorf("truncated name: no length byte")
+	}
+
+	l := int(data[pos])
+	pos++
+	if l != nbns.EncodedNameLength {
+		return Name{}, 0, fmt.Errorf("unexpected first label length %d (want %d)", l, nbns.EncodedNameLength)
+	}
+	if pos+l > len(data) {
+		return Name{}, 0, fmt.Errorf("truncated name label")
+	}
+
+	// Decode the 32 printable characters back into the 16-byte NetBIOS name.
+	encoded := data[pos : pos+l]
+	pos += l
+	decoded := make([]byte, nbns.NetBIOSNameLength)
+	for i := 0; i < nbns.NetBIOSNameLength; i++ {
+		high := encoded[i*2] - 'A'
+		low := encoded[i*2+1] - 'A'
+		if high > 0x0F || low > 0x0F {
+			return Name{}, 0, fmt.Errorf("invalid name encoding character")
+		}
+		decoded[i] = (high << 4) | low
+	}
+
+	// Read the scope label sequence up to the 0x00 root label.
+	var scope []string
+	for {
+		if pos >= len(data) {
+			return Name{}, 0, fmt.Errorf("truncated name: missing scope terminator")
+		}
+		sl := int(data[pos])
+		pos++
+		if sl == 0 {
+			break
+		}
+		if pos+sl > len(data) {
+			return Name{}, 0, fmt.Errorf("truncated scope label")
+		}
+		scope = append(scope, string(data[pos:pos+sl]))
+		pos += sl
+	}
+
+	return Name{
+		Name:   strings.TrimRight(string(decoded[:nbns.NetBIOSNameLength-1]), " "),
+		Suffix: decoded[nbns.NetBIOSNameLength-1],
+		Scope:  strings.Join(scope, "."),
+	}, pos - offset, nil
+}
+
+// Datagram is a decoded NetBIOS datagram. Which trailer fields are meaningful
+// depends on MsgType: the DIRECT/BROADCAST types carry DgmLength, PacketOffset,
+// SourceName, DestinationName and UserData; DATAGRAM ERROR carries ErrorCode;
+// the query request/response types carry only DestinationName.
+type Datagram struct {
+	MsgType    uint8
+	Flags      uint8
+	DgmID      uint16
+	SourceIP   net.IP
+	SourcePort uint16
+
+	// DIRECT_UNIQUE / DIRECT_GROUP / BROADCAST fields.
+	DgmLength       uint16 // length of the trailer (names + user data) in this packet
+	PacketOffset    uint16 // offset of this fragment's USER_DATA in the reassembled datagram
+	SourceName      Name
+	DestinationName Name
+	UserData        []byte
+
+	// DATAGRAM ERROR field.
+	ErrorCode uint8
+}
+
+// NodeType returns the SNT source end-node type encoded in the FLAGS field.
+func (d *Datagram) NodeType() uint8 { return (d.Flags & sntMask) >> sntShift }
+
+// SetNodeType sets the SNT source end-node type bits of the FLAGS field.
+func (d *Datagram) SetNodeType(nt uint8) {
+	d.Flags = (d.Flags &^ sntMask) | ((nt << sntShift) & sntMask)
+}
+
+// IsFirst reports whether the FIRST (F) flag is set.
+func (d *Datagram) IsFirst() bool { return d.Flags&FlagFirst != 0 }
+
+// HasMore reports whether the MORE (M) flag is set, i.e. further fragments of
+// this datagram follow.
+func (d *Datagram) HasMore() bool { return d.Flags&FlagMore != 0 }
+
+// isDirect reports whether the message type is one of the DIRECT/BROADCAST
+// datagrams, which carry the extended (14-byte) header and a name+user-data
+// trailer.
+func isDirect(msgType uint8) bool {
+	return msgType == MsgTypeDirectUnique ||
+		msgType == MsgTypeDirectGroup ||
+		msgType == MsgTypeBroadcast
+}
+
+// isQuery reports whether the message type is a DATAGRAM QUERY REQUEST or a
+// POSITIVE/NEGATIVE DATAGRAM QUERY RESPONSE, all of which carry only a
+// DESTINATION_NAME after the base header.
+func isQuery(msgType uint8) bool {
+	return msgType == MsgTypeQueryRequest ||
+		msgType == MsgTypePositiveQueryResponse ||
+		msgType == MsgTypeNegativeQueryResponse
+}
+
+// Marshal serialises the datagram to its RFC 1002 4.4 wire form. For the
+// DIRECT/BROADCAST types the DGM_LENGTH field is computed as the length of the
+// emitted trailer (names, when the FIRST flag is set, plus USER_DATA), matching
+// how a receiver validates it; the caller-supplied DgmLength is ignored.
+func (d *Datagram) Marshal() ([]byte, error) {
+	ip := d.SourceIP.To4()
+	if ip == nil {
+		return nil, fmt.Errorf("SOURCE_IP must be an IPv4 address, got %v", d.SourceIP)
+	}
+
+	buf := make([]byte, baseHeaderLen)
+	buf[0] = d.MsgType
+	buf[1] = d.Flags
+	binary.BigEndian.PutUint16(buf[2:4], d.DgmID)
+	copy(buf[4:8], ip)
+	binary.BigEndian.PutUint16(buf[8:10], d.SourcePort)
+
+	switch {
+	case isDirect(d.MsgType):
+		// The trailer holds the two names (only on the FIRST fragment) followed
+		// by this packet's USER_DATA. A non-first fragment repeats neither name.
+		var trailer []byte
+		if d.IsFirst() {
+			src, err := d.SourceName.encode()
+			if err != nil {
+				return nil, fmt.Errorf("encoding SOURCE_NAME: %w", err)
+			}
+			dst, err := d.DestinationName.encode()
+			if err != nil {
+				return nil, fmt.Errorf("encoding DESTINATION_NAME: %w", err)
+			}
+			trailer = append(trailer, src...)
+			trailer = append(trailer, dst...)
+		}
+		trailer = append(trailer, d.UserData...)
+
+		ext := make([]byte, 4)
+		binary.BigEndian.PutUint16(ext[0:2], uint16(len(trailer)))
+		binary.BigEndian.PutUint16(ext[2:4], d.PacketOffset)
+		buf = append(buf, ext...)
+		buf = append(buf, trailer...)
+
+	case d.MsgType == MsgTypeError:
+		buf = append(buf, d.ErrorCode)
+
+	case isQuery(d.MsgType):
+		dst, err := d.DestinationName.encode()
+		if err != nil {
+			return nil, fmt.Errorf("encoding DESTINATION_NAME: %w", err)
+		}
+		buf = append(buf, dst...)
+
+	default:
+		return nil, fmt.Errorf("unknown datagram MSG_TYPE 0x%02x", d.MsgType)
+	}
+
+	return buf, nil
+}
+
+// Unmarshal parses a datagram from data and returns the number of bytes
+// consumed. It never panics on short or malformed input, reporting an error
+// instead. For a DIRECT/BROADCAST datagram only the DGM_LENGTH trailer bytes
+// are consumed, so trailing padding in an oversized buffer is ignored.
+func (d *Datagram) Unmarshal(data []byte) (int, error) {
+	if len(data) < baseHeaderLen {
+		return 0, fmt.Errorf("datagram too short: need %d header bytes, got %d", baseHeaderLen, len(data))
+	}
+
+	d.MsgType = data[0]
+	d.Flags = data[1]
+	d.DgmID = binary.BigEndian.Uint16(data[2:4])
+	d.SourceIP = net.IP(append([]byte(nil), data[4:8]...))
+	d.SourcePort = binary.BigEndian.Uint16(data[8:10])
+
+	switch {
+	case isDirect(d.MsgType):
+		if len(data) < directHeaderLen {
+			return 0, fmt.Errorf("DIRECT datagram too short: need %d header bytes, got %d", directHeaderLen, len(data))
+		}
+		d.DgmLength = binary.BigEndian.Uint16(data[10:12])
+		d.PacketOffset = binary.BigEndian.Uint16(data[12:14])
+
+		trailer := data[directHeaderLen:]
+		if int(d.DgmLength) > len(trailer) {
+			return 0, fmt.Errorf("DGM_LENGTH %d exceeds %d available trailer bytes", d.DgmLength, len(trailer))
+		}
+		trailer = trailer[:d.DgmLength]
+
+		if d.IsFirst() {
+			src, n1, err := decodeName(trailer, 0)
+			if err != nil {
+				return 0, fmt.Errorf("decoding SOURCE_NAME: %w", err)
+			}
+			dst, n2, err := decodeName(trailer, n1)
+			if err != nil {
+				return 0, fmt.Errorf("decoding DESTINATION_NAME: %w", err)
+			}
+			d.SourceName = src
+			d.DestinationName = dst
+			d.UserData = append([]byte(nil), trailer[n1+n2:]...)
+		} else {
+			d.UserData = append([]byte(nil), trailer...)
+		}
+		return directHeaderLen + int(d.DgmLength), nil
+
+	case d.MsgType == MsgTypeError:
+		if len(data) < baseHeaderLen+1 {
+			return 0, fmt.Errorf("DATAGRAM ERROR too short: need %d bytes, got %d", baseHeaderLen+1, len(data))
+		}
+		d.ErrorCode = data[baseHeaderLen]
+		return baseHeaderLen + 1, nil
+
+	case isQuery(d.MsgType):
+		dst, n, err := decodeName(data, baseHeaderLen)
+		if err != nil {
+			return 0, fmt.Errorf("decoding DESTINATION_NAME: %w", err)
+		}
+		d.DestinationName = dst
+		return baseHeaderLen + n, nil
+
+	default:
+		return 0, fmt.Errorf("unknown datagram MSG_TYPE 0x%02x", d.MsgType)
+	}
+}

--- a/network/netbios/nbdgm/datagram_test.go
+++ b/network/netbios/nbdgm/datagram_test.go
@@ -1,0 +1,256 @@
+package nbdgm
+
+import (
+	"bytes"
+	"encoding/binary"
+	"net"
+	"testing"
+)
+
+// sampleHeader returns the header fields shared by the round-trip tests so each
+// test can assert the exact wire offsets against known values.
+func sampleHeader() (dgmID uint16, ip net.IP, port uint16) {
+	return 0xBEEF, net.IPv4(10, 7, 0, 20), 138
+}
+
+func TestDirectUniqueRoundTrip(t *testing.T) {
+	dgmID, ip, port := sampleHeader()
+	d := &Datagram{
+		MsgType:         MsgTypeDirectUnique,
+		Flags:           FlagFirst | ((NodeTypeM << sntShift) & sntMask),
+		DgmID:           dgmID,
+		SourceIP:        ip,
+		SourcePort:      port,
+		SourceName:      Name{Name: "SENDER", Suffix: 0x00},
+		DestinationName: Name{Name: "TARGET", Suffix: 0x20},
+		UserData:        []byte("hello datagram"),
+	}
+
+	wire, err := d.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	// Assert the fixed header field offsets on the wire.
+	if wire[0] != MsgTypeDirectUnique {
+		t.Errorf("MSG_TYPE = 0x%02x, want 0x%02x", wire[0], MsgTypeDirectUnique)
+	}
+	if wire[1] != FlagFirst|((NodeTypeM<<sntShift)&sntMask) {
+		t.Errorf("FLAGS = 0x%02x, want 0x%02x", wire[1], FlagFirst|((NodeTypeM<<sntShift)&sntMask))
+	}
+	if got := binary.BigEndian.Uint16(wire[2:4]); got != dgmID {
+		t.Errorf("DGM_ID = 0x%04x, want 0x%04x", got, dgmID)
+	}
+	if !bytes.Equal(wire[4:8], ip.To4()) {
+		t.Errorf("SOURCE_IP = %v, want %v", net.IP(wire[4:8]), ip.To4())
+	}
+	if got := binary.BigEndian.Uint16(wire[8:10]); got != port {
+		t.Errorf("SOURCE_PORT = %d, want %d", got, port)
+	}
+	// DGM_LENGTH must equal the trailer length; PACKET_OFFSET is 0.
+	trailerLen := len(wire) - directHeaderLen
+	if got := binary.BigEndian.Uint16(wire[10:12]); int(got) != trailerLen {
+		t.Errorf("DGM_LENGTH = %d, want %d", got, trailerLen)
+	}
+	if got := binary.BigEndian.Uint16(wire[12:14]); got != 0 {
+		t.Errorf("PACKET_OFFSET = %d, want 0", got)
+	}
+	// Each encoded name is 34 bytes (0x20 + 32 + 0x00) for the default scope.
+	if wire[directHeaderLen] != 0x20 {
+		t.Errorf("SOURCE_NAME length byte = 0x%02x, want 0x20", wire[directHeaderLen])
+	}
+
+	var got Datagram
+	n, err := got.Unmarshal(wire)
+	if err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if n != len(wire) {
+		t.Errorf("Unmarshal consumed %d bytes, want %d", n, len(wire))
+	}
+	if got.MsgType != d.MsgType || got.DgmID != d.DgmID || got.SourcePort != d.SourcePort {
+		t.Errorf("header mismatch: %+v", got)
+	}
+	if got.NodeType() != NodeTypeM {
+		t.Errorf("NodeType = %d, want %d", got.NodeType(), NodeTypeM)
+	}
+	if !got.SourceIP.Equal(ip) {
+		t.Errorf("SOURCE_IP = %v, want %v", got.SourceIP, ip)
+	}
+	if got.SourceName.Name != "SENDER" || got.SourceName.Suffix != 0x00 {
+		t.Errorf("SOURCE_NAME = %+v", got.SourceName)
+	}
+	if got.DestinationName.Name != "TARGET" || got.DestinationName.Suffix != 0x20 {
+		t.Errorf("DESTINATION_NAME = %+v", got.DestinationName)
+	}
+	if !bytes.Equal(got.UserData, d.UserData) {
+		t.Errorf("USER_DATA = %q, want %q", got.UserData, d.UserData)
+	}
+}
+
+func TestDirectGroupAndBroadcastRoundTrip(t *testing.T) {
+	for _, mt := range []uint8{MsgTypeDirectGroup, MsgTypeBroadcast} {
+		d := &Datagram{
+			MsgType:         mt,
+			Flags:           FlagFirst,
+			DgmID:           0x0102,
+			SourceIP:        net.IPv4(192, 168, 1, 5),
+			SourcePort:      138,
+			SourceName:      Name{Name: "WK", Suffix: 0x00},
+			DestinationName: Name{Name: "WORKGROUP", Suffix: 0x1D},
+			UserData:        []byte{0x01, 0x02, 0x03},
+		}
+		wire, err := d.Marshal()
+		if err != nil {
+			t.Fatalf("Marshal(0x%02x): %v", mt, err)
+		}
+		if wire[0] != mt {
+			t.Errorf("MSG_TYPE = 0x%02x, want 0x%02x", wire[0], mt)
+		}
+		var got Datagram
+		if _, err := got.Unmarshal(wire); err != nil {
+			t.Fatalf("Unmarshal(0x%02x): %v", mt, err)
+		}
+		if got.DestinationName.Name != "WORKGROUP" || got.DestinationName.Suffix != 0x1D {
+			t.Errorf("DESTINATION_NAME = %+v", got.DestinationName)
+		}
+		if !bytes.Equal(got.UserData, d.UserData) {
+			t.Errorf("USER_DATA = %v", got.UserData)
+		}
+	}
+}
+
+func TestDatagramErrorRoundTrip(t *testing.T) {
+	d := &Datagram{
+		MsgType:    MsgTypeError,
+		Flags:      FlagFirst,
+		DgmID:      0x2211,
+		SourceIP:   net.IPv4(10, 0, 0, 1),
+		SourcePort: 138,
+		ErrorCode:  ErrorDestinationNameNotPresent,
+	}
+	wire, err := d.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if len(wire) != baseHeaderLen+1 {
+		t.Fatalf("DATAGRAM ERROR length = %d, want %d", len(wire), baseHeaderLen+1)
+	}
+	if wire[0] != MsgTypeError {
+		t.Errorf("MSG_TYPE = 0x%02x, want 0x%02x", wire[0], MsgTypeError)
+	}
+	if wire[baseHeaderLen] != ErrorDestinationNameNotPresent {
+		t.Errorf("ERROR_CODE = 0x%02x, want 0x%02x", wire[baseHeaderLen], ErrorDestinationNameNotPresent)
+	}
+
+	var got Datagram
+	n, err := got.Unmarshal(wire)
+	if err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if n != baseHeaderLen+1 {
+		t.Errorf("consumed %d bytes, want %d", n, baseHeaderLen+1)
+	}
+	if got.ErrorCode != ErrorDestinationNameNotPresent {
+		t.Errorf("ERROR_CODE = 0x%02x", got.ErrorCode)
+	}
+}
+
+func TestQueryRequestAndResponsesRoundTrip(t *testing.T) {
+	for _, mt := range []uint8{MsgTypeQueryRequest, MsgTypePositiveQueryResponse, MsgTypeNegativeQueryResponse} {
+		d := &Datagram{
+			MsgType:         mt,
+			Flags:           FlagFirst,
+			DgmID:           0x00FF,
+			SourceIP:        net.IPv4(172, 16, 0, 9),
+			SourcePort:      138,
+			DestinationName: Name{Name: "HOST", Suffix: 0x00},
+		}
+		wire, err := d.Marshal()
+		if err != nil {
+			t.Fatalf("Marshal(0x%02x): %v", mt, err)
+		}
+		if wire[0] != mt {
+			t.Errorf("MSG_TYPE = 0x%02x, want 0x%02x", wire[0], mt)
+		}
+		// Base header (10) + a default-scope name (34 bytes).
+		if len(wire) != baseHeaderLen+34 {
+			t.Errorf("length = %d, want %d", len(wire), baseHeaderLen+34)
+		}
+		var got Datagram
+		n, err := got.Unmarshal(wire)
+		if err != nil {
+			t.Fatalf("Unmarshal(0x%02x): %v", mt, err)
+		}
+		if n != len(wire) {
+			t.Errorf("consumed %d, want %d", n, len(wire))
+		}
+		if got.DestinationName.Name != "HOST" {
+			t.Errorf("DESTINATION_NAME = %+v", got.DestinationName)
+		}
+	}
+}
+
+func TestNameWithScopeRoundTrip(t *testing.T) {
+	n := Name{Name: "SRV", Suffix: 0x20, Scope: "example.com"}
+	wire, err := n.encode()
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	got, consumed, err := decodeName(wire, 0)
+	if err != nil {
+		t.Fatalf("decodeName: %v", err)
+	}
+	if consumed != len(wire) {
+		t.Errorf("consumed %d, want %d", consumed, len(wire))
+	}
+	if got.Name != "SRV" || got.Suffix != 0x20 || got.Scope != "example.com" {
+		t.Errorf("decoded name = %+v", got)
+	}
+}
+
+func TestUnmarshalRejectsMalformedInput(t *testing.T) {
+	cases := map[string][]byte{
+		"empty":                     {},
+		"short base header":         {0x10, 0x02, 0x00},
+		"direct missing ext header": {MsgTypeDirectUnique, FlagFirst, 0, 1, 10, 0, 0, 1, 0, 138, 0},
+		"dgm_length overruns": func() []byte {
+			b := make([]byte, directHeaderLen)
+			b[0] = MsgTypeDirectUnique
+			b[1] = FlagFirst
+			binary.BigEndian.PutUint16(b[10:12], 999) // claims 999 trailer bytes, none present
+			return b
+		}(),
+		"error too short": {MsgTypeError, FlagFirst, 0, 1, 10, 0, 0, 1, 0, 138},
+		"query truncated name": func() []byte {
+			b := make([]byte, baseHeaderLen+1)
+			b[0] = MsgTypeQueryRequest
+			b[baseHeaderLen] = 0x20 // promises 32 name bytes that are absent
+			return b
+		}(),
+		"unknown msg type": {0x7F, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+	}
+
+	for name, data := range cases {
+		t.Run(name, func(t *testing.T) {
+			var d Datagram
+			// Must return an error, never panic.
+			if _, err := d.Unmarshal(data); err == nil {
+				t.Errorf("Unmarshal(%v) = nil error, want error", data)
+			}
+		})
+	}
+}
+
+func TestMarshalRejectsIPv6Source(t *testing.T) {
+	d := &Datagram{
+		MsgType:         MsgTypeDirectUnique,
+		Flags:           FlagFirst,
+		SourceIP:        net.ParseIP("fe80::1"),
+		DestinationName: Name{Name: "X"},
+		SourceName:      Name{Name: "Y"},
+	}
+	if _, err := d.Marshal(); err == nil {
+		t.Error("Marshal with IPv6 SOURCE_IP = nil error, want error")
+	}
+}

--- a/network/netbios/nbdgm/listener.go
+++ b/network/netbios/nbdgm/listener.go
@@ -1,0 +1,146 @@
+package nbdgm
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"sync"
+	"time"
+)
+
+// Listener socket timeouts and buffer size. MaxUDPSize is the RFC 1001 minimum
+// reassembly buffer, the largest single UDP datagram a conforming datagram
+// service must accept; larger logical datagrams arrive fragmented.
+const (
+	UDPReadTimeout = 5 * time.Second
+	MaxUDPSize     = 576
+)
+
+// DatagramHandler is invoked for each fully received datagram. For the
+// DIRECT/BROADCAST types the datagram is delivered only once fully reassembled,
+// with the complete USER_DATA and decoded SOURCE_NAME/DESTINATION_NAME; the
+// query request/response and error types are delivered as they arrive. source
+// is the sender's UDP address.
+type DatagramHandler func(source *net.UDPAddr, d *Datagram)
+
+// Listener receives NetBIOS datagrams on a UDP socket (port 138 by default),
+// reassembles fragmented DIRECT/BROADCAST datagrams, and hands each complete
+// datagram to a callback. It mirrors the nbns UDP server: Start spawns a serve
+// goroutine and Stop shuts it down. A Listener is the inbound counterpart to
+// Sender.
+type Listener struct {
+	addr    *net.UDPAddr
+	conn    *net.UDPConn
+	handler DatagramHandler
+	reasm   *Reassembler
+	wg      sync.WaitGroup
+	quit    chan struct{}
+}
+
+// NewListener creates a datagram Listener bound to addr (e.g. ":138" or
+// "127.0.0.1:0" for an ephemeral port) that delivers received datagrams to
+// handler.
+func NewListener(addr string, handler DatagramHandler) (*Listener, error) {
+	udpAddr, err := net.ResolveUDPAddr("udp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve address: %w", err)
+	}
+	return &Listener{
+		addr:    udpAddr,
+		handler: handler,
+		reasm:   NewReassembler(),
+		quit:    make(chan struct{}),
+	}, nil
+}
+
+// Start begins listening for datagrams.
+func (l *Listener) Start() error {
+	conn, err := net.ListenUDP("udp", l.addr)
+	if err != nil {
+		return fmt.Errorf("failed to start datagram listener: %w", err)
+	}
+	l.conn = conn
+	l.wg.Add(1)
+	go l.serve()
+	return nil
+}
+
+// LocalAddr returns the address the listener is bound to, useful when it was
+// started on an ephemeral port ("...:0").
+func (l *Listener) LocalAddr() *net.UDPAddr {
+	if l.conn == nil {
+		return l.addr
+	}
+	return l.conn.LocalAddr().(*net.UDPAddr)
+}
+
+// Stop gracefully shuts down the listener.
+func (l *Listener) Stop() {
+	close(l.quit)
+	if l.conn != nil {
+		l.conn.Close()
+	}
+	l.wg.Wait()
+}
+
+// serve reads and dispatches inbound datagrams until Stop is called.
+func (l *Listener) serve() {
+	defer l.wg.Done()
+
+	buf := make([]byte, MaxUDPSize)
+	for {
+		select {
+		case <-l.quit:
+			return
+		default:
+			if err := l.conn.SetReadDeadline(time.Now().Add(UDPReadTimeout)); err != nil {
+				log.Printf("nbdgm: failed to set read deadline: %v", err)
+				continue
+			}
+
+			n, remoteAddr, err := l.conn.ReadFromUDP(buf)
+			if err != nil {
+				if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+					continue
+				}
+				// A read that fails because Stop closed the socket is an
+				// expected part of shutdown, not an error to report.
+				select {
+				case <-l.quit:
+					return
+				default:
+				}
+				log.Printf("nbdgm: failed to read datagram: %v", err)
+				continue
+			}
+
+			l.handlePacket(append([]byte(nil), buf[:n]...), remoteAddr)
+		}
+	}
+}
+
+// handlePacket parses one received UDP payload and dispatches it, reassembling
+// fragmented DIRECT/BROADCAST datagrams via the Reassembler.
+func (l *Listener) handlePacket(data []byte, remoteAddr *net.UDPAddr) {
+	var d Datagram
+	if _, err := d.Unmarshal(data); err != nil {
+		log.Printf("nbdgm: failed to parse datagram from %s: %v", remoteAddr, err)
+		return
+	}
+
+	if isDirect(d.MsgType) {
+		assembled, done, err := l.reasm.Add(remoteAddr.String(), &d)
+		if err != nil {
+			log.Printf("nbdgm: reassembly error from %s: %v", remoteAddr, err)
+			return
+		}
+		if !done {
+			return
+		}
+		l.handler(remoteAddr, assembled)
+		return
+	}
+
+	// ERROR and query request/response datagrams are complete in one packet.
+	l.handler(remoteAddr, &d)
+}

--- a/network/netbios/nbdgm/listener_test.go
+++ b/network/netbios/nbdgm/listener_test.go
@@ -1,0 +1,173 @@
+package nbdgm
+
+import (
+	"bytes"
+	"net"
+	"testing"
+	"time"
+)
+
+// TestSenderListenerRoundTrip proves the datagram transport end to end over
+// real UDP sockets: a Listener on an ephemeral loopback port receives a
+// DIRECT_UNIQUE datagram sent by a Sender, and the exact USER_DATA and decoded
+// SOURCE_NAME/DESTINATION_NAME are recovered.
+func TestSenderListenerRoundTrip(t *testing.T) {
+	received := make(chan *Datagram, 1)
+	l, err := NewListener("127.0.0.1:0", func(_ *net.UDPAddr, d *Datagram) {
+		received <- d
+	})
+	if err != nil {
+		t.Fatalf("NewListener: %v", err)
+	}
+	if err := l.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer l.Stop()
+
+	dest := l.LocalAddr().String()
+
+	s := &Sender{
+		SourceName: Name{Name: "SENDER", Suffix: 0x00},
+		SourceIP:   net.IPv4(127, 0, 0, 1),
+		SourcePort: 138,
+		NodeType:   NodeTypeB,
+	}
+	payload := []byte("the quick brown fox")
+	if err := s.SendDirectUnique(dest, Name{Name: "TARGET", Suffix: 0x20}, payload); err != nil {
+		t.Fatalf("SendDirectUnique: %v", err)
+	}
+
+	select {
+	case d := <-received:
+		if !bytes.Equal(d.UserData, payload) {
+			t.Errorf("USER_DATA = %q, want %q", d.UserData, payload)
+		}
+		if d.SourceName.Name != "SENDER" {
+			t.Errorf("SOURCE_NAME = %q, want SENDER", d.SourceName.Name)
+		}
+		if d.DestinationName.Name != "TARGET" || d.DestinationName.Suffix != 0x20 {
+			t.Errorf("DESTINATION_NAME = %+v", d.DestinationName)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for datagram")
+	}
+}
+
+// TestSenderListenerFragmentedRoundTrip proves fragmentation end to end: a
+// USER_DATA payload larger than a single UDP datagram is fragmented by the
+// Sender, delivered over loopback, and reassembled byte-for-byte by the
+// Listener before the callback fires exactly once.
+func TestSenderListenerFragmentedRoundTrip(t *testing.T) {
+	received := make(chan *Datagram, 4)
+	l, err := NewListener("127.0.0.1:0", func(_ *net.UDPAddr, d *Datagram) {
+		received <- d
+	})
+	if err != nil {
+		t.Fatalf("NewListener: %v", err)
+	}
+	if err := l.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer l.Stop()
+
+	dest := l.LocalAddr().String()
+
+	s := &Sender{
+		SourceName:      Name{Name: "SENDER", Suffix: 0x00},
+		SourceIP:        net.IPv4(127, 0, 0, 1),
+		SourcePort:      138,
+		NodeType:        NodeTypeM,
+		MaxFragmentSize: 200, // force several fragments
+	}
+
+	// A distinctive, position-dependent payload so a reordering or offset bug
+	// would corrupt the reassembly.
+	var payload []byte
+	for i := 0; i < 1000; i++ {
+		payload = append(payload, byte(i%251))
+	}
+
+	dst := Name{Name: "TARGET", Suffix: 0x20}
+	frags, err := s.Fragment(MsgTypeDirectUnique, dst, payload)
+	if err != nil {
+		t.Fatalf("Fragment: %v", err)
+	}
+	if len(frags) < 4 {
+		t.Fatalf("expected the payload to fragment into >=4 packets, got %d", len(frags))
+	}
+
+	if err := s.SendDirectUnique(dest, dst, payload); err != nil {
+		t.Fatalf("SendDirectUnique: %v", err)
+	}
+
+	select {
+	case d := <-received:
+		if !bytes.Equal(d.UserData, payload) {
+			t.Errorf("reassembled USER_DATA mismatch: got %d bytes, want %d", len(d.UserData), len(payload))
+		}
+		if d.NodeType() != NodeTypeM {
+			t.Errorf("NodeType = %d, want %d", d.NodeType(), NodeTypeM)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for reassembled datagram")
+	}
+
+	// The callback must fire exactly once for one logical datagram, even though
+	// it arrived as several UDP packets.
+	select {
+	case <-received:
+		t.Fatal("callback fired more than once for a single datagram")
+	case <-time.After(150 * time.Millisecond):
+	}
+}
+
+// TestListenerDeliversQueryRequest confirms a non-fragmenting datagram type
+// (DATAGRAM QUERY REQUEST) is delivered as a single packet with its
+// DESTINATION_NAME decoded.
+func TestListenerDeliversQueryRequest(t *testing.T) {
+	received := make(chan *Datagram, 1)
+	l, err := NewListener("127.0.0.1:0", func(_ *net.UDPAddr, d *Datagram) {
+		received <- d
+	})
+	if err != nil {
+		t.Fatalf("NewListener: %v", err)
+	}
+	if err := l.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer l.Stop()
+
+	d := &Datagram{
+		MsgType:         MsgTypeQueryRequest,
+		Flags:           FlagFirst,
+		DgmID:           0x4242,
+		SourceIP:        net.IPv4(127, 0, 0, 1),
+		SourcePort:      138,
+		DestinationName: Name{Name: "WORKGROUP", Suffix: 0x1D},
+	}
+	wire, err := d.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	conn, err := net.DialUDP("udp", nil, l.LocalAddr())
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer conn.Close()
+	if _, err := conn.Write(wire); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	select {
+	case got := <-received:
+		if got.MsgType != MsgTypeQueryRequest {
+			t.Errorf("MSG_TYPE = 0x%02x", got.MsgType)
+		}
+		if got.DestinationName.Name != "WORKGROUP" || got.DestinationName.Suffix != 0x1D {
+			t.Errorf("DESTINATION_NAME = %+v", got.DestinationName)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for query request")
+	}
+}

--- a/network/netbios/nbdgm/reassembly.go
+++ b/network/netbios/nbdgm/reassembly.go
@@ -1,0 +1,189 @@
+package nbdgm
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+// Reassembly bounds. The datagram service fragments a datagram whose names plus
+// USER_DATA do not fit in a single UDP packet (RFC 1002 4.4.1); a receiver
+// reassembles the pieces keyed by (source, DGM_ID). These constants bound the
+// memory and lifetime of the reassembly state so a hostile or lossy sender
+// cannot exhaust memory with partial datagrams.
+const (
+	// MaxUserDataSize caps the reassembled USER_DATA of a single datagram. A
+	// DGM_ID whose fragments would exceed it is dropped.
+	MaxUserDataSize = 65535
+
+	// DefaultReassemblyTimeout is how long an incomplete datagram is retained
+	// before its fragments are discarded.
+	DefaultReassemblyTimeout = 30 * time.Second
+
+	// DefaultMaxPending bounds the number of distinct in-progress datagrams held
+	// at once. Once reached, a new datagram is only admitted after expired
+	// entries are evicted.
+	DefaultMaxPending = 1024
+)
+
+// reassemblyKey identifies an in-progress datagram by its source (address
+// string) and DGM_ID, the pair the RFC uses to associate fragments.
+type reassemblyKey struct {
+	source string
+	dgmID  uint16
+}
+
+// partial accumulates the fragments of one datagram. USER_DATA is written into
+// buf at each fragment's PACKET_OFFSET; covered tracks which bytes have arrived
+// so gaps can be detected, and total becomes known once the last (MORE clear)
+// fragment is seen.
+type partial struct {
+	msgType  uint8
+	nodeType uint8
+	src      Name
+	dst      Name
+	haveHdr  bool // true once the FIRST fragment (carrying the names) has arrived
+
+	buf     []byte
+	covered []bool
+	filled  int // count of covered bytes
+	total   int // final length once known, else -1
+	created time.Time
+}
+
+// Reassembler reassembles fragmented NetBIOS datagrams. It is safe for
+// concurrent use; a single Reassembler is shared by a Listener across the
+// goroutines that handle inbound packets.
+type Reassembler struct {
+	mu      sync.Mutex
+	pending map[reassemblyKey]*partial
+	timeout time.Duration
+}
+
+// NewReassembler returns a Reassembler using the default timeout.
+func NewReassembler() *Reassembler {
+	return &Reassembler{
+		pending: make(map[reassemblyKey]*partial),
+		timeout: DefaultReassemblyTimeout,
+	}
+}
+
+// SetTimeout overrides the retention time for incomplete datagrams. A
+// non-positive value restores the default.
+func (r *Reassembler) SetTimeout(d time.Duration) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if d <= 0 {
+		d = DefaultReassemblyTimeout
+	}
+	r.timeout = d
+}
+
+// Add feeds one received DIRECT/BROADCAST datagram fragment into the
+// reassembler. source identifies the sender (typically its "ip:port"). When the
+// datagram is complete it returns the fully reassembled Datagram and done=true;
+// otherwise it returns done=false and retains the fragment. A datagram that is
+// both FIRST and not MORE is complete in a single packet and is returned
+// directly without any retained state.
+func (r *Reassembler) Add(source string, d *Datagram) (assembled *Datagram, done bool, err error) {
+	if !isDirect(d.MsgType) {
+		return nil, false, fmt.Errorf("reassembly only applies to DIRECT/BROADCAST datagrams, got MSG_TYPE 0x%02x", d.MsgType)
+	}
+
+	// Fast path: an unfragmented datagram (FIRST set, MORE clear) needs no
+	// state and is returned as-is.
+	if d.IsFirst() && !d.HasMore() {
+		return d, true, nil
+	}
+
+	end := int(d.PacketOffset) + len(d.UserData)
+	if end > MaxUserDataSize {
+		return nil, false, fmt.Errorf("fragment exceeds maximum USER_DATA size (%d > %d)", end, MaxUserDataSize)
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.evictExpiredLocked()
+
+	key := reassemblyKey{source: source, dgmID: d.DgmID}
+	p := r.pending[key]
+	if p == nil {
+		if len(r.pending) >= DefaultMaxPending {
+			return nil, false, fmt.Errorf("too many pending reassemblies (%d)", len(r.pending))
+		}
+		p = &partial{total: -1, created: time.Now()}
+		r.pending[key] = p
+	}
+
+	// The FIRST fragment carries the source and destination names and the
+	// message type used for the assembled datagram.
+	if d.IsFirst() {
+		p.haveHdr = true
+		p.msgType = d.MsgType
+		p.nodeType = d.NodeType()
+		p.src = d.SourceName
+		p.dst = d.DestinationName
+	}
+
+	if err := p.write(int(d.PacketOffset), d.UserData); err != nil {
+		delete(r.pending, key)
+		return nil, false, err
+	}
+
+	// The last fragment (MORE clear) fixes the total USER_DATA length.
+	if !d.HasMore() {
+		p.total = end
+	}
+
+	if p.total < 0 || p.filled < p.total || !p.haveHdr {
+		return nil, false, nil
+	}
+
+	// Complete: hand back a synthesised datagram carrying the whole USER_DATA.
+	delete(r.pending, key)
+	return &Datagram{
+		MsgType:         p.msgType,
+		Flags:           FlagFirst | ((p.nodeType << sntShift) & sntMask),
+		DgmID:           d.DgmID,
+		SourceIP:        d.SourceIP,
+		SourcePort:      d.SourcePort,
+		SourceName:      p.src,
+		DestinationName: p.dst,
+		UserData:        p.buf[:p.total],
+	}, true, nil
+}
+
+// write copies a fragment's USER_DATA into the partial buffer at offset,
+// growing the buffer as needed and marking the newly covered bytes. Overlapping
+// re-transmissions are tolerated (previously covered bytes are not recounted).
+func (p *partial) write(offset int, data []byte) error {
+	end := offset + len(data)
+	if end > len(p.buf) {
+		grown := make([]byte, end)
+		copy(grown, p.buf)
+		p.buf = grown
+		coveredGrown := make([]bool, end)
+		copy(coveredGrown, p.covered)
+		p.covered = coveredGrown
+	}
+	copy(p.buf[offset:end], data)
+	for i := offset; i < end; i++ {
+		if !p.covered[i] {
+			p.covered[i] = true
+			p.filled++
+		}
+	}
+	return nil
+}
+
+// evictExpiredLocked removes reassembly state older than the timeout. The caller
+// must hold r.mu.
+func (r *Reassembler) evictExpiredLocked() {
+	now := time.Now()
+	for key, p := range r.pending {
+		if now.Sub(p.created) > r.timeout {
+			delete(r.pending, key)
+		}
+	}
+}

--- a/network/netbios/nbdgm/reassembly_test.go
+++ b/network/netbios/nbdgm/reassembly_test.go
@@ -1,0 +1,185 @@
+package nbdgm
+
+import (
+	"bytes"
+	"net"
+	"testing"
+	"time"
+)
+
+// buildFragments produces the wire fragments for a DIRECT_UNIQUE datagram whose
+// USER_DATA is split into three pieces by a small MaxFragmentSize, exercising
+// the FIRST/MORE + PACKET_OFFSET path.
+func buildFragments(t *testing.T, userData []byte) ([][]byte, *Sender, Name) {
+	t.Helper()
+	s := &Sender{
+		SourceName:      Name{Name: "SENDER", Suffix: 0x00},
+		SourceIP:        net.IPv4(10, 7, 0, 20),
+		SourcePort:      138,
+		NodeType:        NodeTypeB,
+		MaxFragmentSize: 128, // small enough to force multiple fragments
+	}
+	dst := Name{Name: "TARGET", Suffix: 0x20}
+	frags, err := s.Fragment(MsgTypeDirectUnique, dst, userData)
+	if err != nil {
+		t.Fatalf("Fragment: %v", err)
+	}
+	if len(frags) < 3 {
+		t.Fatalf("expected at least 3 fragments, got %d", len(frags))
+	}
+	return frags, s, dst
+}
+
+func TestReassemblyThreeFragments(t *testing.T) {
+	// A payload larger than a single 128-byte fragment can hold.
+	userData := bytes.Repeat([]byte("ABCDEFGHIJ"), 30) // 300 bytes
+	frags, _, _ := buildFragments(t, userData)
+
+	// Verify the fragment flags: FIRST only on the first, MORE on all but last.
+	for i, frag := range frags {
+		var d Datagram
+		if _, err := d.Unmarshal(frag); err != nil {
+			t.Fatalf("Unmarshal fragment %d: %v", i, err)
+		}
+		wantFirst := i == 0
+		if d.IsFirst() != wantFirst {
+			t.Errorf("fragment %d FIRST = %v, want %v", i, d.IsFirst(), wantFirst)
+		}
+		wantMore := i != len(frags)-1
+		if d.HasMore() != wantMore {
+			t.Errorf("fragment %d MORE = %v, want %v", i, d.HasMore(), wantMore)
+		}
+	}
+
+	r := NewReassembler()
+	src := "10.7.0.20:138"
+	var assembled *Datagram
+	for i, frag := range frags {
+		var d Datagram
+		if _, err := d.Unmarshal(frag); err != nil {
+			t.Fatalf("Unmarshal fragment %d: %v", i, err)
+		}
+		a, done, err := r.Add(src, &d)
+		if err != nil {
+			t.Fatalf("Add fragment %d: %v", i, err)
+		}
+		if done != (i == len(frags)-1) {
+			t.Fatalf("fragment %d done = %v, want %v", i, done, i == len(frags)-1)
+		}
+		if done {
+			assembled = a
+		}
+	}
+
+	if assembled == nil {
+		t.Fatal("reassembly never completed")
+	}
+	if !bytes.Equal(assembled.UserData, userData) {
+		t.Errorf("reassembled USER_DATA mismatch: got %d bytes, want %d", len(assembled.UserData), len(userData))
+	}
+	if assembled.SourceName.Name != "SENDER" || assembled.DestinationName.Name != "TARGET" {
+		t.Errorf("reassembled names = src %+v dst %+v", assembled.SourceName, assembled.DestinationName)
+	}
+	if assembled.DestinationName.Suffix != 0x20 {
+		t.Errorf("reassembled DESTINATION_NAME suffix = 0x%02x, want 0x20", assembled.DestinationName.Suffix)
+	}
+}
+
+func TestReassemblyOutOfOrder(t *testing.T) {
+	userData := bytes.Repeat([]byte("0123456789"), 30)
+	frags, _, _ := buildFragments(t, userData)
+
+	// Feed the fragments in reverse order; reassembly by PACKET_OFFSET must
+	// still reconstruct the original payload.
+	r := NewReassembler()
+	src := "10.7.0.20:138"
+	var assembled *Datagram
+	for i := len(frags) - 1; i >= 0; i-- {
+		var d Datagram
+		if _, err := d.Unmarshal(frags[i]); err != nil {
+			t.Fatalf("Unmarshal: %v", err)
+		}
+		a, done, err := r.Add(src, &d)
+		if err != nil {
+			t.Fatalf("Add: %v", err)
+		}
+		if done {
+			assembled = a
+		}
+	}
+	if assembled == nil {
+		t.Fatal("out-of-order reassembly never completed")
+	}
+	if !bytes.Equal(assembled.UserData, userData) {
+		t.Error("out-of-order reassembled USER_DATA mismatch")
+	}
+}
+
+func TestReassemblyUnfragmentedFastPath(t *testing.T) {
+	d := &Datagram{
+		MsgType:         MsgTypeDirectUnique,
+		Flags:           FlagFirst, // FIRST set, MORE clear => complete in one packet
+		SourceIP:        net.IPv4(10, 0, 0, 1),
+		SourceName:      Name{Name: "A"},
+		DestinationName: Name{Name: "B"},
+		UserData:        []byte("single"),
+	}
+	r := NewReassembler()
+	a, done, err := r.Add("10.0.0.1:138", d)
+	if err != nil || !done {
+		t.Fatalf("fast path: done=%v err=%v", done, err)
+	}
+	if !bytes.Equal(a.UserData, []byte("single")) {
+		t.Errorf("USER_DATA = %q", a.UserData)
+	}
+}
+
+func TestReassemblyTimeoutEviction(t *testing.T) {
+	r := NewReassembler()
+	r.SetTimeout(1 * time.Millisecond)
+
+	// A first fragment that expects more, left incomplete.
+	d := &Datagram{
+		MsgType:         MsgTypeDirectUnique,
+		Flags:           FlagFirst | FlagMore,
+		DgmID:           0x1234,
+		SourceIP:        net.IPv4(10, 0, 0, 2),
+		SourceName:      Name{Name: "A"},
+		DestinationName: Name{Name: "B"},
+		UserData:        []byte("part"),
+	}
+	if _, done, err := r.Add("10.0.0.2:138", d); err != nil || done {
+		t.Fatalf("first fragment: done=%v err=%v", done, err)
+	}
+
+	time.Sleep(5 * time.Millisecond)
+
+	// Any subsequent Add triggers eviction of the expired entry; a new first
+	// fragment for the same key starts fresh (no stale bytes leak in).
+	r.mu.Lock()
+	before := len(r.pending)
+	r.mu.Unlock()
+	if before != 1 {
+		t.Fatalf("expected 1 pending entry, got %d", before)
+	}
+
+	// Trigger eviction via a fragment for a different key.
+	other := &Datagram{
+		MsgType:         MsgTypeDirectUnique,
+		Flags:           FlagFirst | FlagMore,
+		DgmID:           0x9999,
+		SourceIP:        net.IPv4(10, 0, 0, 3),
+		SourceName:      Name{Name: "C"},
+		DestinationName: Name{Name: "D"},
+		UserData:        []byte("x"),
+	}
+	if _, _, err := r.Add("10.0.0.3:138", other); err != nil {
+		t.Fatalf("Add other: %v", err)
+	}
+	r.mu.Lock()
+	_, expiredStillThere := r.pending[reassemblyKey{source: "10.0.0.2:138", dgmID: 0x1234}]
+	r.mu.Unlock()
+	if expiredStillThere {
+		t.Error("expired reassembly entry was not evicted")
+	}
+}

--- a/network/netbios/nbdgm/sender.go
+++ b/network/netbios/nbdgm/sender.go
@@ -1,0 +1,206 @@
+package nbdgm
+
+import (
+	"fmt"
+	"math/rand"
+	"net"
+)
+
+// LimitedBroadcastAddr is the IPv4 limited-broadcast address a BROADCAST
+// datagram is sent to (RFC 1002 5.4). With DefaultDatagramPort it forms the
+// destination 255.255.255.255:138.
+const LimitedBroadcastAddr = "255.255.255.255"
+
+// DefaultMaxFragmentSize is the maximum size of a single outbound UDP datagram
+// (header plus trailer) when the sender fragments an oversized USER_DATA. It is
+// the RFC 1001 minimum reassembly buffer size (576), which every conforming
+// receiver must accept.
+const DefaultMaxFragmentSize = 576
+
+// Sender emits NetBIOS datagrams. It carries the source identity stamped into
+// every datagram's header (SOURCE_NAME, SOURCE_IP, SOURCE_PORT and the SNT
+// node type) and fragments a USER_DATA payload too large for a single UDP
+// datagram. A Sender is a lightweight value: each send opens its own
+// short-lived UDP socket, so one Sender is safe to reuse across sequential
+// sends.
+type Sender struct {
+	// SourceName is the sending application's NetBIOS name, carried as the
+	// SOURCE_NAME of DIRECT/BROADCAST datagrams.
+	SourceName Name
+
+	// SourceIP and SourcePort populate the datagram header's SOURCE_IP and
+	// SOURCE_PORT. SourceIP must be an IPv4 address. SourcePort is typically
+	// DefaultDatagramPort.
+	SourceIP   net.IP
+	SourcePort uint16
+
+	// NodeType is the SNT source end-node type stamped into the FLAGS field
+	// (NodeTypeB by default).
+	NodeType uint8
+
+	// MaxFragmentSize bounds the size of each emitted UDP datagram. A
+	// non-positive value uses DefaultMaxFragmentSize.
+	MaxFragmentSize int
+}
+
+// maxFragment returns the effective per-packet size limit.
+func (s *Sender) maxFragment() int {
+	if s.MaxFragmentSize <= 0 {
+		return DefaultMaxFragmentSize
+	}
+	return s.MaxFragmentSize
+}
+
+// SendDirectUnique sends a DIRECT_UNIQUE datagram carrying userData to dest,
+// which may be a bare host or host:port (the port defaults to 138). userData is
+// fragmented across as many UDP datagrams as needed.
+func (s *Sender) SendDirectUnique(dest string, destName Name, userData []byte) error {
+	return s.sendDirect(MsgTypeDirectUnique, dest, destName, userData, false)
+}
+
+// SendDirectGroup sends a DIRECT_GROUP datagram carrying userData to dest (see
+// SendDirectUnique for the dest and fragmentation semantics).
+func (s *Sender) SendDirectGroup(dest string, destName Name, userData []byte) error {
+	return s.sendDirect(MsgTypeDirectGroup, dest, destName, userData, false)
+}
+
+// SendBroadcast sends a BROADCAST datagram carrying userData to the IPv4
+// limited-broadcast address on port 138. userData is fragmented as needed.
+func (s *Sender) SendBroadcast(destName Name, userData []byte) error {
+	dest := net.JoinHostPort(LimitedBroadcastAddr, fmt.Sprintf("%d", DefaultDatagramPort))
+	return s.sendDirect(MsgTypeBroadcast, dest, destName, userData, true)
+}
+
+// sendDirect builds, fragments and transmits a DIRECT/BROADCAST datagram.
+func (s *Sender) sendDirect(msgType uint8, dest string, destName Name, userData []byte, broadcast bool) error {
+	if s.SourceIP.To4() == nil {
+		return fmt.Errorf("Sender.SourceIP must be an IPv4 address, got %v", s.SourceIP)
+	}
+
+	addr, err := resolveDest(dest)
+	if err != nil {
+		return err
+	}
+
+	fragments, err := s.Fragment(msgType, destName, userData)
+	if err != nil {
+		return err
+	}
+
+	conn, err := net.ListenUDP("udp4", &net.UDPAddr{})
+	if err != nil {
+		return fmt.Errorf("failed to open UDP socket: %w", err)
+	}
+	defer conn.Close()
+
+	if broadcast {
+		if err := enableBroadcast(conn); err != nil {
+			return fmt.Errorf("failed to enable broadcast on UDP socket: %w", err)
+		}
+	}
+
+	for i, frag := range fragments {
+		if _, err := conn.WriteToUDP(frag, addr); err != nil {
+			return fmt.Errorf("failed to send datagram fragment %d/%d: %w", i+1, len(fragments), err)
+		}
+	}
+	return nil
+}
+
+// Fragment builds the wire-form UDP payloads for a DIRECT/BROADCAST datagram,
+// splitting userData across as many packets as the per-packet size limit
+// requires. The first fragment carries SOURCE_NAME and DESTINATION_NAME and the
+// FIRST flag; every fragment but the last sets the MORE flag; PACKET_OFFSET on
+// each fragment is the byte offset of its USER_DATA within the whole payload.
+// All fragments share one freshly generated DGM_ID.
+func (s *Sender) Fragment(msgType uint8, destName Name, userData []byte) ([][]byte, error) {
+	if !isDirect(msgType) {
+		return nil, fmt.Errorf("Fragment: MSG_TYPE 0x%02x is not a DIRECT/BROADCAST datagram", msgType)
+	}
+
+	// Compute the USER_DATA capacity of the first packet (which also carries the
+	// two names) and of the subsequent name-free packets.
+	src, err := s.SourceName.encode()
+	if err != nil {
+		return nil, fmt.Errorf("encoding SOURCE_NAME: %w", err)
+	}
+	dst, err := destName.encode()
+	if err != nil {
+		return nil, fmt.Errorf("encoding DESTINATION_NAME: %w", err)
+	}
+
+	limit := s.maxFragment()
+	firstCap := limit - directHeaderLen - len(src) - len(dst)
+	restCap := limit - directHeaderLen
+	if firstCap <= 0 || restCap <= 0 {
+		return nil, fmt.Errorf("MaxFragmentSize %d too small for datagram header and names", limit)
+	}
+
+	dgmID := uint16(rand.Intn(0x10000))
+	flagsBase := (s.NodeType << sntShift) & sntMask
+
+	var fragments [][]byte
+	offset := 0
+	first := true
+	for {
+		chunkCap := restCap
+		if first {
+			chunkCap = firstCap
+		}
+
+		end := offset + chunkCap
+		if end > len(userData) {
+			end = len(userData)
+		}
+		chunk := userData[offset:end]
+
+		flags := flagsBase
+		if first {
+			flags |= FlagFirst
+		}
+		if end < len(userData) {
+			flags |= FlagMore
+		}
+
+		d := &Datagram{
+			MsgType:      msgType,
+			Flags:        flags,
+			DgmID:        dgmID,
+			SourceIP:     s.SourceIP,
+			SourcePort:   s.SourcePort,
+			PacketOffset: uint16(offset),
+			UserData:     chunk,
+		}
+		if first {
+			d.SourceName = s.SourceName
+			d.DestinationName = destName
+		}
+
+		wire, err := d.Marshal()
+		if err != nil {
+			return nil, err
+		}
+		fragments = append(fragments, wire)
+
+		offset = end
+		first = false
+		if offset >= len(userData) {
+			break
+		}
+	}
+
+	return fragments, nil
+}
+
+// resolveDest resolves a datagram destination, accepting a bare host or a
+// host:port pair and defaulting the port to 138.
+func resolveDest(dest string) (*net.UDPAddr, error) {
+	if _, _, err := net.SplitHostPort(dest); err != nil {
+		dest = net.JoinHostPort(dest, fmt.Sprintf("%d", DefaultDatagramPort))
+	}
+	addr, err := net.ResolveUDPAddr("udp4", dest)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve datagram destination %q: %w", dest, err)
+	}
+	return addr, nil
+}


### PR DESCRIPTION
### Linked Issue
`Closes #976`

### Summary
Implements the NetBIOS Datagram Service (RFC 1002 4.4, UDP port 138), which was entirely absent. A new subpackage `network/netbios/nbdgm` provides the datagram header codec, all seven datagram message types, and FIRST/MORE fragmentation and reassembly. Only the datagram transport layer is in scope; the Browser/mailslot payloads that ride on top are not.

### Fix Description
- **datagram.go** — Header codec and `Datagram` type with `Marshal`/`Unmarshal` for every MSG_TYPE:
  - DIRECT_UNIQUE (`0x10`), DIRECT_GROUP (`0x11`), BROADCAST (`0x12`) carry the 14-byte header (MSG_TYPE, FLAGS, DGM_ID, SOURCE_IP, SOURCE_PORT, DGM_LENGTH, PACKET_OFFSET) followed by SOURCE_NAME + DESTINATION_NAME + USER_DATA.
  - DATAGRAM ERROR (`0x13`) carries ERROR_CODE; DATAGRAM QUERY REQUEST (`0x14`) and POSITIVE/NEGATIVE QUERY RESPONSE (`0x15`/`0x16`) carry a DESTINATION_NAME.
  - FLAGS bit layout per RFC 1002 4.4.1: MORE = `0x01`, FIRST = `0x02`, SNT (source node type) = bits 2-3.
  - The 34-byte second-level SOURCE_NAME/DESTINATION_NAME encoding reuses the merged `nbns` name codec.
- **reassembly.go** — A `Reassembler` keyed by (source, DGM_ID) that rebuilds USER_DATA from FIRST/MORE + PACKET_OFFSET fragments, with bounds on reassembled size, pending-entry count, and a retention timeout to cap memory.
- **sender.go** — A `Sender` that builds and, when USER_DATA exceeds a UDP datagram, fragments DIRECT_UNIQUE/DIRECT_GROUP/BROADCAST datagrams (names only on the FIRST fragment, PACKET_OFFSET advancing per fragment) and transmits them.
- **listener.go** — A UDP listener on :138 mirroring the `nbns` UDP server pattern that parses inbound datagrams, reassembles fragments, and delivers assembled USER_DATA and decoded names to a callback.

### How Verified
`go build ./...`, `go vet ./network/netbios/...`, and `go test -race ./network/netbios/...` all pass. The datagram-service field order and sizes, the `0x10`-`0x16` MSG_TYPE values, and the FLAGS bit layout (MORE=bit0, FIRST=bit1, SNT=bits2-3) were cross-checked against RFC 1002 4.4.

End-to-end transport is proven over real UDP loopback sockets: a `Listener` on an ephemeral 127.0.0.1 port receives a DIRECT_UNIQUE datagram from a `Sender` and recovers the exact USER_DATA and decoded SOURCE_NAME/DESTINATION_NAME; a second test sends a 1000-byte payload that the sender fragments into several UDP packets, which the listener reassembles byte-for-byte before firing the callback exactly once.

### Test Coverage
**Added:**
- `datagram_test.go` — fixed-wire-vector build/parse round-trips for every MSG_TYPE with header field offsets asserted; scope-name round-trip; malformed/short-input rejection (no panic); IPv6-source rejection.
- `reassembly_test.go` — 3-fragment in-order and out-of-order reassembly, unfragmented fast path, timeout eviction.
- `listener_test.go` — sender-to-listener round-trip over real UDP sockets (single datagram and fragmented payload), and single-packet query-request delivery.

### Scope of Change
- **Files changed:** `network/netbios/nbdgm/{datagram,reassembly,sender,listener,broadcast_unix,broadcast_other}.go` and their `_test.go` files (new subpackage).
- **Submodule pointer updated:** no
- **Behavioral changes outside the new package:** none

### Risk and Rollout
Additive: a brand-new subpackage with no existing callers, so blast radius is limited to code that opts in. Safe to merge without staged rollout.