### PR TITLE
Add client-level export of service tickets to kirbi and ccache (Fixes #990)

### DIFF
--- a/network/kerberos/v5/client.go
+++ b/network/kerberos/v5/client.go
@@ -53,6 +53,13 @@ type KerberosClient struct {
 	// contacting the KDC — enabling silver-ticket use with no TGT.
 	preloadedTGS map[string]preloadedServiceTicket
 
+	// serviceTickets caches service tickets the client has obtained (via GetTGS)
+	// or been given (LoadServiceTicket), keyed by normalized SPN, together with
+	// the enc-part metadata (session key, flags, times, sname/srealm) needed to
+	// re-serialize them. It is the source ExportServiceTicketKirbi/CCache read
+	// from — the harvest→save half of pass-the-ticket (see export.go).
+	serviceTickets map[string]cachedServiceTicket
+
 	// realmKDCs maps an (uppercased) realm to the KDC host to contact when the
 	// cross-realm referral chase reaches that realm. Populated via WithRealmKDC.
 	realmKDCs map[string]string
@@ -96,6 +103,14 @@ type preloadedServiceTicket struct {
 	ticketRaw    []byte
 	sessionKey   []byte
 	sessionEType int
+}
+
+// cachedServiceTicket is a service ticket retained for export: the raw
+// APPLICATION[1] ticket bytes plus the KrbCredInfo (session key, flags, times,
+// sname/srealm) describing it, ready to feed the .kirbi / ccache marshalers.
+type cachedServiceTicket struct {
+	ticketRaw []byte
+	credInfo  messages.KrbCredInfo
 }
 
 // PreferRC4ServiceTicket makes GetTGS request an RC4-HMAC service ticket (RC4

--- a/network/kerberos/v5/export.go
+++ b/network/kerberos/v5/export.go
@@ -4,6 +4,8 @@ import (
 	"encoding/asn1"
 	"encoding/binary"
 	"fmt"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/credcache/ccache"
@@ -75,6 +77,129 @@ func (c *KerberosClient) ExportTGTCCache() (*ccache.CCache, error) {
 			Ticket:      c.tgtTicketRaw,
 		}},
 	}, nil
+}
+
+// cacheServiceTicket records a service ticket (raw APPLICATION[1] bytes plus the
+// enc-part it was issued with) under its SPN so ExportServiceTicketKirbi/CCache
+// can serialize it later. It is called on every successful GetTGS and by
+// LoadServiceTicket. The client principal is this client's identity (the
+// principal the ticket was issued to).
+func (c *KerberosClient) cacheServiceTicket(ticketRaw []byte, enc messages.EncTGSRepPart) {
+	if len(enc.SName.NameString) == 0 {
+		return
+	}
+	if c.serviceTickets == nil {
+		c.serviceTickets = make(map[string]cachedServiceTicket)
+	}
+	spn := strings.Join(enc.SName.NameString, "/")
+	c.serviceTickets[normalizeSPN(spn)] = cachedServiceTicket{
+		ticketRaw: ticketRaw,
+		credInfo: messages.KrbCredInfo{
+			Key:       enc.Key,
+			PRealm:    c.realm,
+			PName:     messages.PrincipalName{NameType: messages.NameTypePrincipal, NameString: []string{c.username}},
+			Flags:     enc.Flags,
+			AuthTime:  enc.AuthTime,
+			StartTime: enc.StartTime,
+			EndTime:   enc.EndTime,
+			RenewTill: enc.RenewTill,
+			SRealm:    enc.SRealm,
+			SName:     enc.SName,
+		},
+	}
+}
+
+// serviceTicketFor returns the cached service ticket for spn: an exact normalized
+// "service/host" match first, then a match on the service principal name (so a
+// bare "cifs" or a differently spelled host component still resolves). It errors
+// if no service ticket for spn has been obtained.
+func (c *KerberosClient) serviceTicketFor(spn string) (cachedServiceTicket, error) {
+	if ct, ok := c.serviceTickets[normalizeSPN(spn)]; ok {
+		return ct, nil
+	}
+	for _, ct := range c.serviceTickets {
+		if snameMatchesSPN(ct.credInfo.SName, spn) {
+			return ct, nil
+		}
+	}
+	return cachedServiceTicket{}, fmt.Errorf("kerberos: no service ticket for SPN %q: call GetTGS first", spn)
+}
+
+// ExportServiceTicketKirbi returns the cached service ticket for spn as .kirbi
+// (DER KRB-CRED) bytes, the service-ticket counterpart of ExportTGTKirbi. The
+// ticket must have been obtained via GetTGS (or wired in via LoadServiceTicket)
+// beforehand.
+func (c *KerberosClient) ExportServiceTicketKirbi(spn string) ([]byte, error) {
+	ct, err := c.serviceTicketFor(spn)
+	if err != nil {
+		return nil, err
+	}
+	cred, err := kirbi.New(ct.ticketRaw, ct.credInfo)
+	if err != nil {
+		return nil, err
+	}
+	return kirbi.Bytes(cred)
+}
+
+// ExportServiceTicketCCache returns the cached service ticket for spn as an MIT
+// ccache (v4) holding a single credential, the service-ticket counterpart of
+// ExportTGTCCache. The ticket must have been obtained via GetTGS (or wired in via
+// LoadServiceTicket) beforehand.
+func (c *KerberosClient) ExportServiceTicketCCache(spn string) ([]byte, error) {
+	ct, err := c.serviceTicketFor(spn)
+	if err != nil {
+		return nil, err
+	}
+	info := ct.credInfo
+	client := ccache.Principal{
+		NameType:   uint32(info.PName.NameType),
+		Realm:      info.PRealm,
+		Components: append([]string(nil), info.PName.NameString...),
+	}
+	server := ccache.Principal{
+		NameType:   uint32(info.SName.NameType),
+		Realm:      info.SRealm,
+		Components: append([]string(nil), info.SName.NameString...),
+	}
+	start := info.StartTime
+	if start.IsZero() {
+		start = info.AuthTime
+	}
+	cc := &ccache.CCache{
+		DefaultPrincipal: client,
+		Credentials: []ccache.Credential{{
+			Client:      client,
+			Server:      server,
+			Key:         ccache.Keyblock{EType: uint16(info.Key.KeyType), KeyValue: info.Key.KeyValue},
+			AuthTime:    unixU32(info.AuthTime),
+			StartTime:   unixU32(start),
+			EndTime:     unixU32(info.EndTime),
+			RenewTill:   unixU32(info.RenewTill),
+			TicketFlags: flagsToUint32(info.Flags),
+			Ticket:      ct.ticketRaw,
+		}},
+	}
+	return cc.Marshal()
+}
+
+// ExportServiceTicketKirbiToFile writes the cached service ticket for spn to path
+// in .kirbi (DER KRB-CRED) form, mode 0600.
+func (c *KerberosClient) ExportServiceTicketKirbiToFile(spn, path string) error {
+	blob, err := c.ExportServiceTicketKirbi(spn)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, blob, 0o600)
+}
+
+// ExportServiceTicketCCacheToFile writes the cached service ticket for spn to path
+// in MIT ccache (v4) form, mode 0600.
+func (c *KerberosClient) ExportServiceTicketCCacheToFile(spn, path string) error {
+	blob, err := c.ExportServiceTicketCCache(spn)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, blob, 0o600)
 }
 
 // unixU32 returns t as Unix seconds in a uint32, or 0 for the zero time (rather

--- a/network/kerberos/v5/export_test.go
+++ b/network/kerberos/v5/export_test.go
@@ -2,6 +2,7 @@ package kerberos
 
 import (
 	"bytes"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -95,6 +96,131 @@ func TestExportTGTCCache(t *testing.T) {
 	}
 	if !bytes.Equal(cr.Ticket, c.tgtTicketRaw) {
 		t.Errorf("ticket bytes not preserved")
+	}
+}
+
+// cachedServiceTicketClient returns a client with a single cifs/host service
+// ticket cached (as GetTGS would after a successful TGS-REP), so the
+// service-ticket export path can be exercised without a live KDC.
+func cachedServiceTicketClient(t *testing.T) (*KerberosClient, messages.EncTGSRepPart, []byte) {
+	t.Helper()
+	sname := messages.PrincipalName{NameType: messages.NameTypeSRVInst, NameString: []string{"cifs", "host.corp.local"}}
+	tkt := messages.Ticket{
+		TktVno:  messages.KerberosV5,
+		Realm:   "CORP.LOCAL",
+		SName:   sname,
+		EncPart: messages.EncryptedData{EType: messages.ETypeAES256CTSHMACSHA196, Cipher: bytes.Repeat([]byte{0xCD}, 32)},
+	}
+	raw, err := tkt.Marshal()
+	if err != nil {
+		t.Fatalf("Ticket.Marshal: %v", err)
+	}
+	enc := messages.EncTGSRepPart{
+		Key:       messages.EncryptionKey{KeyType: messages.ETypeAES256CTSHMACSHA196, KeyValue: bytes.Repeat([]byte{0x22}, 32)},
+		Flags:     messages.NewKerberosFlags(messages.TicketFlagForwardable, messages.TicketFlagRenewable),
+		AuthTime:  time.Date(2026, 7, 9, 10, 0, 0, 0, time.UTC),
+		StartTime: time.Date(2026, 7, 9, 10, 0, 0, 0, time.UTC),
+		EndTime:   time.Date(2026, 7, 9, 20, 0, 0, 0, time.UTC),
+		RenewTill: time.Date(2026, 7, 16, 10, 0, 0, 0, time.UTC),
+		SRealm:    "CORP.LOCAL",
+		SName:     sname,
+	}
+	c := NewClient("alice", "corp.local", "10.0.0.1").WithPassword("x")
+	c.cacheServiceTicket(raw, enc)
+	return c, enc, raw
+}
+
+func TestExportServiceTicketKirbi(t *testing.T) {
+	c, enc, raw := cachedServiceTicketClient(t)
+	blob, err := c.ExportServiceTicketKirbi("cifs/host.corp.local")
+	if err != nil {
+		t.Fatalf("ExportServiceTicketKirbi: %v", err)
+	}
+	st, err := LoadServiceTicketFromKirbiBytes(blob, "cifs/host.corp.local")
+	if err != nil {
+		t.Fatalf("LoadServiceTicketFromKirbiBytes: %v", err)
+	}
+	if !bytes.Equal(st.TicketRaw, raw) {
+		t.Errorf("service ticket raw bytes not preserved")
+	}
+	if !bytes.Equal(st.SessionKey, enc.Key.KeyValue) {
+		t.Errorf("session key mismatch")
+	}
+	if st.SessionEType != enc.Key.KeyType {
+		t.Errorf("session etype: got %d, want %d", st.SessionEType, enc.Key.KeyType)
+	}
+	if st.SName.NameString[0] != "cifs" || st.SRealm != "CORP.LOCAL" {
+		t.Errorf("sname/srealm wrong: %v %q", st.SName.NameString, st.SRealm)
+	}
+	if st.Client.NameString[0] != "alice" || st.CRealm != "CORP.LOCAL" {
+		t.Errorf("client principal wrong: %v %q", st.Client.NameString, st.CRealm)
+	}
+}
+
+func TestExportServiceTicketCCache(t *testing.T) {
+	c, enc, raw := cachedServiceTicketClient(t)
+	blob, err := c.ExportServiceTicketCCache("cifs/host.corp.local")
+	if err != nil {
+		t.Fatalf("ExportServiceTicketCCache: %v", err)
+	}
+	st, err := LoadServiceTicketFromCCacheBytes(blob, "cifs/host.corp.local")
+	if err != nil {
+		t.Fatalf("LoadServiceTicketFromCCacheBytes: %v", err)
+	}
+	if !bytes.Equal(st.TicketRaw, raw) {
+		t.Errorf("service ticket raw bytes not preserved")
+	}
+	if !bytes.Equal(st.SessionKey, enc.Key.KeyValue) {
+		t.Errorf("session key mismatch")
+	}
+	if st.SName.NameString[1] != "host.corp.local" || st.SRealm != "CORP.LOCAL" {
+		t.Errorf("sname/srealm wrong: %v %q", st.SName.NameString, st.SRealm)
+	}
+	// The ccache credential carries the times/flags; confirm they survive.
+	cc, err := ccache.Unmarshal(blob)
+	if err != nil {
+		t.Fatalf("ccache.Unmarshal: %v", err)
+	}
+	cr := cc.Credentials[0]
+	if uint32(enc.EndTime.Unix()) != cr.EndTime || uint32(enc.RenewTill.Unix()) != cr.RenewTill {
+		t.Errorf("times not preserved: end %d renew %d", cr.EndTime, cr.RenewTill)
+	}
+	if cr.TicketFlags != flagsToUint32(enc.Flags) {
+		t.Errorf("flags not preserved: %08x vs %08x", cr.TicketFlags, flagsToUint32(enc.Flags))
+	}
+}
+
+func TestExportServiceTicketToFile(t *testing.T) {
+	c, _, raw := cachedServiceTicketClient(t)
+	dir := t.TempDir()
+	kpath := filepath.Join(dir, "svc.kirbi")
+	cpath := filepath.Join(dir, "svc.ccache")
+	if err := c.ExportServiceTicketKirbiToFile("cifs/host.corp.local", kpath); err != nil {
+		t.Fatalf("ExportServiceTicketKirbiToFile: %v", err)
+	}
+	if err := c.ExportServiceTicketCCacheToFile("cifs/host.corp.local", cpath); err != nil {
+		t.Fatalf("ExportServiceTicketCCacheToFile: %v", err)
+	}
+	kst, err := LoadServiceTicketFromKirbiFile(kpath, "cifs/host.corp.local")
+	if err != nil {
+		t.Fatalf("LoadServiceTicketFromKirbiFile: %v", err)
+	}
+	cst, err := LoadServiceTicketFromCCacheFile(cpath, "cifs/host.corp.local")
+	if err != nil {
+		t.Fatalf("LoadServiceTicketFromCCacheFile: %v", err)
+	}
+	if !bytes.Equal(kst.TicketRaw, raw) || !bytes.Equal(cst.TicketRaw, raw) {
+		t.Errorf("ticket bytes not preserved through file round-trip")
+	}
+}
+
+func TestExportServiceTicketRequiresCached(t *testing.T) {
+	c := NewClient("alice", "corp.local", "10.0.0.1").WithPassword("x")
+	if _, err := c.ExportServiceTicketKirbi("cifs/host.corp.local"); err == nil {
+		t.Error("expected error exporting an uncached service ticket (kirbi)")
+	}
+	if _, err := c.ExportServiceTicketCCache("cifs/host.corp.local"); err == nil {
+		t.Error("expected error exporting an uncached service ticket (ccache)")
 	}
 }
 

--- a/network/kerberos/v5/import.go
+++ b/network/kerberos/v5/import.go
@@ -204,6 +204,14 @@ func (c *KerberosClient) LoadServiceTicket(st *ServiceTicket) error {
 		sessionKey:   st.SessionKey,
 		sessionEType: st.SessionEType,
 	}
+	// Also retain it for export (harvest→save): a captured/forged ticket wired in
+	// here can be written back out via ExportServiceTicketKirbi/CCache. The
+	// ServiceTicket carries no flags/times, so those stay zero.
+	c.cacheServiceTicket(st.TicketRaw, messages.EncTGSRepPart{
+		Key:    messages.EncryptionKey{KeyType: st.SessionEType, KeyValue: st.SessionKey},
+		SRealm: st.SRealm,
+		SName:  st.SName,
+	})
 	return nil
 }
 

--- a/network/kerberos/v5/referral.go
+++ b/network/kerberos/v5/referral.go
@@ -117,7 +117,9 @@ func (c *KerberosClient) chaseServiceTicket(sname messages.PrincipalName, includ
 
 		nextRealm, isReferral := referralTargetRealm(rep, sname)
 		if !isReferral {
-			// The requested service ticket was issued — done.
+			// The requested service ticket was issued — cache it (for export) and
+			// return it.
+			c.cacheServiceTicket(rep.TicketRaw, *encRep)
 			return rep.Ticket, rep.TicketRaw, encRep.Key.KeyValue, encRep.Key.KeyType, nil
 		}
 


### PR DESCRIPTION
### Linked Issue
`Closes #990`

### Summary
Adds client-level export of SERVICE tickets to `.kirbi` and MIT ccache, symmetric with the existing TGT export. Service tickets could previously be imported (`LoadServiceTicketFrom*`) but never exported, leaving the harvest→save half of the pass-the-ticket / silver-ticket workflow incomplete.

### What changed
- `client.go`: added a `serviceTickets` cache (keyed by normalized SPN) holding each obtained ticket's raw APPLICATION[1] bytes plus a `KrbCredInfo` (session key, flags, times, sname/srealm).
- `referral.go`: `chaseServiceTicket` now caches the ticket on a successful TGS-REP.
- `import.go`: `LoadServiceTicket` also records the ticket in the cache so captured/forged tickets can be re-exported.
- `export.go`: added `ExportServiceTicketKirbi(spn) ([]byte, error)`, `ExportServiceTicketCCache(spn) ([]byte, error)` and `...ToFile` wrappers, reusing the `credcache/kirbi` and `credcache/ccache` marshalers with no new wire structures. SPN lookup matches on the exact normalized `service/host` key first, then on the service principal name.

### Design notes
The `KrbCredInfo` (RFC 4120 §5.8.1) and ccache credential field layouts match the existing TGT export path and were cross-checked against RFC 4120 and the MIT ccache credential format documentation, so output round-trips through the existing import path and external ccache readers.

### How Verified
- `go build ./...`, `go vet ./network/kerberos/...`, `go test ./network/kerberos/...` all green.
- New offline unit tests (`TestExportServiceTicket{Kirbi,CCache,ToFile,RequiresCached}`) export a synthetic cached service ticket and re-import it via `LoadServiceTicketFrom*`, asserting ticket bytes, session key/etype, sname/srealm, client principal, times and flags round-trip for both formats and the ToFile wrappers.
- Live-validated against a Windows Server 2016 DC: `GetTGT` (password) → `GetTGS cifs/<dc-fqdn>` → `ExportServiceTicketCCacheToFile` + `ExportServiceTicketKirbiToFile` → re-imported each into a fresh, TGT-less client via `LoadServiceTicketFromCCacheFile` / `FromKirbiFile` → `SessionSetupKerberosWithClient` + `TreeConnect IPC$` succeeded end-to-end for both kirbi and ccache (signed SMB2 session established).