### PR TITLE
Dedupe KDCOptions bit constants onto the iana registry (Fixes #991)

### DIFF
--- a/network/kerberos/v5/client.go
+++ b/network/kerberos/v5/client.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/credentials"
 	kerbcrypto "github.com/TheManticoreProject/Manticore/network/kerberos/v5/crypto"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/iana"
 	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/messages"
 	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/pkinit"
 )
@@ -605,18 +606,23 @@ func (c *KerberosClient) buildAPReqWith(tgt messages.Ticket, tgtRaw, sessionKey 
 	return ap_req.Marshal()
 }
 
-// Bit positions for KDCOptions (RFC 4120 Section 5.4.1, RFC 6806 for canonicalize).
-// Bit 0 is the MSB; bit N sits in byte N/8 at position 7-(N%8).
+// Package-local aliases of the KDCOptions bit positions defined in the iana
+// package (RFC 4120 §5.4.1, RFC 6806 for canonicalize, MS-SFU for
+// cname-in-additional-ticket). The iana registry is the single source of truth
+// for these bit values; the aliases let the option-encoding helpers and their
+// byte-pinning tests refer to the flags tersely without re-declaring — and so
+// silently drifting from — the values. Bit 0 is the MSB; bit N sits in byte
+// N/8 at position 7-(N%8).
 const (
-	kdcOptionForwardable    = 1  // byte 0, 0x40
-	kdcOptionProxiable      = 3  // byte 0, 0x10
-	kdcOptionRenewable      = 8  // byte 1, 0x80
-	kdcOptionCanonicalize   = 15 // byte 1, 0x01 (RFC 6806)
-	kdcOptionCNameInAddlTkt = 14 // byte 1, 0x02 (MS-SFU S4U2Proxy)
-	kdcOptionRenewableOK    = 27 // byte 3, 0x10
-	kdcOptionEncTktInSKey   = 28 // byte 3, 0x08 (user-to-user)
-	kdcOptionRenew          = 30 // byte 3, 0x02 (RFC 4120 §3.3.3 renewal)
-	kdcOptionValidate       = 31 // byte 3, 0x01 (RFC 4120 §3.3.3 validation)
+	kdcOptionForwardable    = iana.KDCOptionForwardable    // byte 0, 0x40
+	kdcOptionProxiable      = iana.KDCOptionProxiable      // byte 0, 0x10
+	kdcOptionRenewable      = iana.KDCOptionRenewable      // byte 1, 0x80
+	kdcOptionCanonicalize   = iana.KDCOptionCanonicalize   // byte 1, 0x01 (RFC 6806)
+	kdcOptionCNameInAddlTkt = iana.KDCOptionCNameInAddlTkt // byte 1, 0x02 (MS-SFU S4U2Proxy)
+	kdcOptionRenewableOK    = iana.KDCOptionRenewableOK    // byte 3, 0x10
+	kdcOptionEncTktInSKey   = iana.KDCOptionEncTktInSKey   // byte 3, 0x08 (user-to-user)
+	kdcOptionRenew          = iana.KDCOptionRenew          // byte 3, 0x02 (RFC 4120 §3.3.3 renewal)
+	kdcOptionValidate       = iana.KDCOptionValidate       // byte 3, 0x01 (RFC 4120 §3.3.3 validation)
 )
 
 // encodeKDCOptions packs a list of bit positions into a 32-bit BitString

--- a/network/kerberos/v5/iana/constants.go
+++ b/network/kerberos/v5/iana/constants.go
@@ -183,6 +183,7 @@ const (
 	KDCOptionAllowPostdate     = 5  // allow-postdate
 	KDCOptionPostdated         = 6  // postdated
 	KDCOptionRenewable         = 8  // renewable
+	KDCOptionCNameInAddlTkt    = 14 // cname-in-additional-ticket (MS-SFU S4U2Proxy; RFC 4120 leaves bit 14 unused)
 	KDCOptionCanonicalize      = 15 // canonicalize (RFC 6806)
 	KDCOptionDisableTransitChk = 26 // disable-transited-check
 	KDCOptionRenewableOK       = 27 // renewable-ok


### PR DESCRIPTION
### Linked Issue
`Closes #991`

### Summary
The Kerberos v5 client (`network/kerberos/v5/client.go`) declared its own private `kdcOption*` bit constants with hardcoded values, duplicating the `KDCOption*` set already defined in `network/kerberos/v5/iana/constants.go`. The two copies of the same wire bit positions could silently drift, and the iana copy was entirely unused.

### Root Cause
KDCOptions bit positions were defined in two places — the iana registry and a private const block in the client — with no linkage between them, so an edit to one would not be reflected in the other.

### Fix Description
- Redefined the client-local `kdcOption*` constants as aliases of the `iana.KDCOption*` constants, making the iana registry the single source of truth. Drift is now impossible and the previously-unused iana constants are referenced.
- Added the one bit the client used that iana lacked: `KDCOptionCNameInAddlTkt` (bit 14, MS-SFU S4U2Proxy; RFC 4120 leaves bit 14 unused).

The local names are retained (as aliases) so the byte-pinning regression guard `kdcoptions_test.go` stays unchanged. Every aliased value equals its former literal, verified against RFC 4120 §5.4.1 (forwardable=1, proxiable=3, renewable=8, canonicalize=15, renewable-ok=27, enc-tkt-in-skey=28, renew=30, validate=31), so the encoded KDCOptions bytes are byte-identical on the wire.

### How Verified
- `go build ./...`, `go vet ./network/kerberos/...` clean.
- `go test ./network/kerberos/...` green, including the unchanged `kdcoptions_test.go` byte-pinning guard (`TestEncodeKDCOptionsBitLayout`, `TestKDCOptionsForASReq`, `TestKDCOptionsForTGSReq`).
- Live: `GetTGT` (password) + `GetTGS` for `cifs/tmp-w-2016.tmp-w-2016.local` against a Windows Server 2016 KDC both succeed, confirming the option encoding is unchanged on the wire.