### PR TITLE
Add offline unit tests for Kerberos client orchestration (Fixes #993)

### DIFF
--- a/network/kerberos/v5/client_pkinit_test.go
+++ b/network/kerberos/v5/client_pkinit_test.go
@@ -1,0 +1,273 @@
+package kerberos
+
+import (
+	"bytes"
+	"encoding/asn1"
+	"math/big"
+	"testing"
+	"time"
+
+	kerbcrypto "github.com/TheManticoreProject/Manticore/network/kerberos/v5/crypto"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/messages"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/pkinit"
+)
+
+// CMS OIDs used to hand-build a synthetic PKINIT KDC reply (RFC 5652 / RFC 4556).
+var (
+	testOIDSignedData        = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 7, 2}
+	testOIDIDPKINITDHKeyData = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 2, 3, 2}
+)
+
+// derRaw marshals a single ASN.1 element with the given class/tag/compound flag.
+func derRaw(t *testing.T, class, tag int, compound bool, content []byte) []byte {
+	t.Helper()
+	b, err := asn1.Marshal(asn1.RawValue{Class: class, Tag: tag, IsCompound: compound, Bytes: content})
+	if err != nil {
+		t.Fatalf("marshal raw (class %d tag %d): %v", class, tag, err)
+	}
+	return b
+}
+
+// derMarshal marshals any value, failing the test on error.
+func derMarshal(t *testing.T, v interface{}) []byte {
+	t.Helper()
+	b, err := asn1.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal %T: %v", v, err)
+	}
+	return b
+}
+
+// synthPKINITReplyPA constructs the PA-PK-AS-REP (dhInfo variant) a Windows KDC
+// emits, carrying the KDC's DH public value inside a minimal CMS SignedData whose
+// eContent is a KDCDHKeyInfo. The parser does not verify the KDC signature, so no
+// real signer is needed. The layout mirrors the pkinit package's own test harness.
+func synthPKINITReplyPA(t *testing.T, kdcY *big.Int, serverNonce []byte) []byte {
+	t.Helper()
+
+	// KDCDHKeyInfo ::= SEQUENCE { subjectPublicKey [0] BIT STRING, nonce [1] INTEGER }
+	yDER := derMarshal(t, kdcY)
+	yBitString := derMarshal(t, asn1.BitString{Bytes: yDER, BitLength: len(yDER) * 8})
+	subjPub := derRaw(t, asn1.ClassContextSpecific, 0, true, yBitString)
+	nonceField := derRaw(t, asn1.ClassContextSpecific, 1, true, derMarshal(t, 7))
+	infoDER := derRaw(t, asn1.ClassUniversal, asn1.TagSequence, true, append(subjPub, nonceField...))
+
+	// EncapsulatedContentInfo ::= SEQUENCE { eContentType OID, eContent [0] OCTET STRING }
+	eContentField := derRaw(t, asn1.ClassContextSpecific, 0, true, derMarshal(t, infoDER))
+	encap := derRaw(t, asn1.ClassUniversal, asn1.TagSequence, true,
+		append(derMarshal(t, testOIDIDPKINITDHKeyData), eContentField...))
+
+	// SignedData ::= SEQUENCE { version, digestAlgorithms SET, encapContentInfo, signerInfos SET }
+	emptySet := derRaw(t, asn1.ClassUniversal, asn1.TagSet, true, nil)
+	var sdParts []byte
+	sdParts = append(sdParts, derMarshal(t, 3)...)
+	sdParts = append(sdParts, emptySet...)
+	sdParts = append(sdParts, encap...)
+	sdParts = append(sdParts, emptySet...)
+	sdDER := derRaw(t, asn1.ClassUniversal, asn1.TagSequence, true, sdParts)
+
+	// ContentInfo ::= SEQUENCE { contentType OID, content [0] SignedData }. The
+	// parser captures the [0] element as a RawValue and reads its .Bytes as the
+	// SignedData DER, so a single [0] wrapping the SignedData is what it expects.
+	contentField := derRaw(t, asn1.ClassContextSpecific, 0, true, sdDER)
+	ciDER := derRaw(t, asn1.ClassUniversal, asn1.TagSequence, true,
+		append(derMarshal(t, testOIDSignedData), contentField...))
+
+	// DHRepInfo: dhSignedData [0] IMPLICIT OCTET STRING || serverDHNonce [1].
+	dhSigned := derRaw(t, asn1.ClassContextSpecific, 0, false, ciDER)
+	srvNonce := derRaw(t, asn1.ClassContextSpecific, 1, false, serverNonce)
+
+	// dhInfo [0] wrapping the DHRepInfo fields.
+	return derRaw(t, asn1.ClassContextSpecific, 0, true, append(dhSigned, srvNonce...))
+}
+
+// buildPKINITASRep assembles an AS-REP whose enc-part (EncASRepPart with the given
+// nonce and session key) is encrypted under replyKey/replyEType, carrying the
+// supplied PA-PK-AS-REP so processPKINITASRep can derive the reply key and decrypt.
+func buildPKINITASRep(t *testing.T, replyEType int, replyKey []byte, nonce int, sessionKey, paValue []byte) []byte {
+	t.Helper()
+	enc := &messages.EncASRepPart{
+		Key:      messages.EncryptionKey{KeyType: messages.ETypeAES256CTSHMACSHA196, KeyValue: sessionKey},
+		Nonce:    nonce,
+		Flags:    messages.NewKerberosFlags(messages.TicketFlagForwardable, messages.TicketFlagInitial),
+		AuthTime: time.Date(2026, 7, 11, 10, 0, 0, 0, time.UTC),
+		EndTime:  time.Date(2026, 7, 11, 20, 0, 0, 0, time.UTC),
+		SRealm:   testRealm,
+		SName:    messages.PrincipalName{NameType: messages.NameTypeSRVInst, NameString: []string{"krbtgt", testRealm}},
+	}
+	plain, err := enc.Marshal()
+	if err != nil {
+		t.Fatalf("EncASRepPart.Marshal: %v", err)
+	}
+	cipher, err := kerbcrypto.Encrypt(replyEType, replyKey, kerbcrypto.KeyUsageASRepEncPart, plain)
+	if err != nil {
+		t.Fatalf("encrypt enc-part: %v", err)
+	}
+	rep := &messages.ASRep{
+		PVNO:    messages.KerberosV5,
+		MsgType: messages.MsgTypeASRep,
+		CRealm:  testRealm,
+		CName:   messages.PrincipalName{NameType: messages.NameTypePrincipal, NameString: []string{"alice"}},
+		PAData:  []messages.PAData{{PADataType: messages.PAPKASRep, PADataValue: paValue}},
+		Ticket: messages.Ticket{
+			TktVno:  messages.KerberosV5,
+			Realm:   testRealm,
+			SName:   messages.PrincipalName{NameType: messages.NameTypeSRVInst, NameString: []string{"krbtgt", testRealm}},
+			EncPart: messages.EncryptedData{EType: replyEType, Cipher: bytes.Repeat([]byte{0x5a}, 32)},
+		},
+		EncPart: messages.EncryptedData{EType: replyEType, Cipher: cipher},
+	}
+	wire, err := rep.Marshal()
+	if err != nil {
+		t.Fatalf("ASRep.Marshal: %v", err)
+	}
+	return wire
+}
+
+// pkinitExchange sets up a matched client request / KDC reply pair: it builds a
+// real client PKINIT request, derives the shared reply key on the KDC side, and
+// returns the client, its request, the synthetic PA-PK-AS-REP, and the AES256
+// reply key both sides agree on.
+func pkinitExchange(t *testing.T) (c *KerberosClient, pkReq *pkinit.Request, paValue, replyKey []byte) {
+	t.Helper()
+	group := pkinit.MODPGroup2()
+	priv, certDER, err := pkinit.GenerateSelfSignedCert(2048, "unit-test")
+	if err != nil {
+		t.Fatalf("GenerateSelfSignedCert: %v", err)
+	}
+	_, pkReq, err = pkinit.BuildASReqPAData([]byte("req-body"), priv, certDER, group, 0x11223344, time.Now())
+	if err != nil {
+		t.Fatalf("BuildASReqPAData: %v", err)
+	}
+
+	kdcKP, err := pkinit.GenerateDHKeyPair(group)
+	if err != nil {
+		t.Fatalf("KDC GenerateDHKeyPair: %v", err)
+	}
+	serverNonce := bytes.Repeat([]byte{0x5A}, pkinit.DHNonceLen)
+	paValue = synthPKINITReplyPA(t, kdcKP.Y, serverNonce)
+
+	// KDC-side derivation of the reply key (must equal the client's candidate[0]).
+	shared, err := kdcKP.SharedSecret(pkReq.KeyPair.Y)
+	if err != nil {
+		t.Fatalf("KDC SharedSecret: %v", err)
+	}
+	keyMaterial := append(append(append([]byte{}, shared...), pkReq.ClientDHNonce...), serverNonce...)
+	replyKey = pkinit.OctetString2Key(keyMaterial, kerbcrypto.KeyLen(messages.ETypeAES256CTSHMACSHA196))
+
+	c = NewClient("alice", "corp.local", "")
+	return c, pkReq, paValue, replyKey
+}
+
+// TestProcessPKINITASRepSuccess drives the PKINIT AS-REP processing end to end
+// with a synthetic KDC reply: the DH reply key is reconstructed, the AS-REP
+// enc-part decrypts, and the TGT plus the reply key (needed for UnPAC-the-hash)
+// are stored on the client.
+func TestProcessPKINITASRepSuccess(t *testing.T) {
+	c, pkReq, paValue, replyKey := pkinitExchange(t)
+	const nonce = 0x11223344
+	sessionKey := bytes.Repeat([]byte{0x42}, 32)
+	wire := buildPKINITASRep(t, messages.ETypeAES256CTSHMACSHA196, replyKey, nonce, sessionKey, paValue)
+
+	if err := c.processPKINITASRep(wire, pkReq, nonce); err != nil {
+		t.Fatalf("processPKINITASRep: %v", err)
+	}
+	if !c.hasTGT {
+		t.Fatal("hasTGT not set after a successful PKINIT AS-REP")
+	}
+	if !bytes.Equal(c.sessionKey, sessionKey) {
+		t.Errorf("session key mismatch: %x", c.sessionKey)
+	}
+	key, etype := c.PKINITReplyKey()
+	if !bytes.Equal(key, replyKey) || etype != messages.ETypeAES256CTSHMACSHA196 {
+		t.Errorf("PKINITReplyKey = (%x, %d), want (%x, AES256)", key, etype, replyKey)
+	}
+}
+
+// TestProcessPKINITASRepRejectsBadEType confirms an AS-REP whose reply-key etype
+// is unsupported (KeyLen 0) is rejected before any decryption.
+func TestProcessPKINITASRepRejectsBadEType(t *testing.T) {
+	c, pkReq, paValue, replyKey := pkinitExchange(t)
+	// A parseable reply, but the enc-part advertises an unusable reply-key etype.
+	wire := buildPKINITASRep(t, messages.ETypeAES256CTSHMACSHA196, replyKey, 1, bytes.Repeat([]byte{0x42}, 32), paValue)
+	var rep messages.ASRep
+	if _, err := rep.Unmarshal(wire); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	rep.EncPart.EType = 0 // no key length -> rejected
+	bad, err := rep.Marshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := c.processPKINITASRep(bad, pkReq, 1); err == nil {
+		t.Fatal("expected an error for an unsupported reply-key etype")
+	}
+	if c.hasTGT {
+		t.Error("hasTGT must not be set on a rejected AS-REP")
+	}
+}
+
+// TestProcessPKINITASRepNonceMismatch confirms an enc-part whose nonce differs
+// from the request nonce is rejected (no candidate key decrypts to a matching
+// nonce), and no TGT is stored.
+func TestProcessPKINITASRepNonceMismatch(t *testing.T) {
+	c, pkReq, paValue, replyKey := pkinitExchange(t)
+	wire := buildPKINITASRep(t, messages.ETypeAES256CTSHMACSHA196, replyKey, 999, bytes.Repeat([]byte{0x42}, 32), paValue)
+	if err := c.processPKINITASRep(wire, pkReq, 12345); err == nil {
+		t.Fatal("expected a nonce-mismatch rejection")
+	}
+	if c.hasTGT {
+		t.Error("hasTGT must not be set on a nonce mismatch")
+	}
+}
+
+// TestProcessPKINITASRepNoPAData confirms an AS-REP lacking a PA-PK-AS-REP element
+// is rejected (the KDC did not return its DH contribution).
+func TestProcessPKINITASRepNoPAData(t *testing.T) {
+	c, pkReq, _, replyKey := pkinitExchange(t)
+	// Reply with an unrelated padata type only.
+	wire := buildPKINITASRep(t, messages.ETypeAES256CTSHMACSHA196, replyKey, 1, bytes.Repeat([]byte{0x42}, 32), nil)
+	var rep messages.ASRep
+	if _, err := rep.Unmarshal(wire); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	rep.PAData = []messages.PAData{pacRequestPA()} // no PA-PK-AS-REP
+	stripped, err := rep.Marshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := c.processPKINITASRep(stripped, pkReq, 1); err == nil {
+		t.Fatal("expected an error when the AS-REP has no PA-PK-AS-REP element")
+	}
+}
+
+// TestWithPKINITConfiguration covers the PKINIT configuration accessors: WithPKINIT
+// records the key/cert and installs the default DH groups, pkinitConfigured
+// reflects that, WithPKINITGroups overrides the group list, and the reply key is
+// empty until a successful exchange.
+func TestWithPKINITConfiguration(t *testing.T) {
+	priv, certDER, err := pkinit.GenerateSelfSignedCert(2048, "config-test")
+	if err != nil {
+		t.Fatalf("GenerateSelfSignedCert: %v", err)
+	}
+
+	c := NewClient("alice", "corp.local", "10.0.0.1")
+	if c.pkinitConfigured() {
+		t.Error("pkinitConfigured should be false before WithPKINIT")
+	}
+	c.WithPKINIT(priv, certDER)
+	if !c.pkinitConfigured() {
+		t.Fatal("pkinitConfigured should be true after WithPKINIT")
+	}
+	if len(c.pkinitGroups) != 2 {
+		t.Errorf("default PKINIT groups = %d, want 2 (MODP14, MODP2)", len(c.pkinitGroups))
+	}
+	if key, etype := c.PKINITReplyKey(); key != nil || etype != 0 {
+		t.Errorf("PKINITReplyKey should be empty before a successful exchange, got (%x, %d)", key, etype)
+	}
+
+	c.WithPKINITGroups(pkinit.MODPGroup2())
+	if len(c.pkinitGroups) != 1 {
+		t.Errorf("WithPKINITGroups override = %d groups, want 1", len(c.pkinitGroups))
+	}
+}

--- a/network/kerberos/v5/fast_test.go
+++ b/network/kerberos/v5/fast_test.go
@@ -1,0 +1,159 @@
+package kerberos
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+
+	kerbcrypto "github.com/TheManticoreProject/Manticore/network/kerberos/v5/crypto"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/messages"
+)
+
+// fastArmoredClient returns a client with a FAST armor TGT configured (a dummy
+// ticket plus a known AES256 armor session key) and a password credential, so
+// the FAST assembly helpers can run without a KDC.
+func fastArmoredClient(t *testing.T, armorKey []byte, armorEType int) *KerberosClient {
+	t.Helper()
+	tkt := messages.Ticket{
+		TktVno:  messages.KerberosV5,
+		Realm:   testRealm,
+		SName:   messages.PrincipalName{NameType: messages.NameTypeSRVInst, NameString: []string{"krbtgt", testRealm}},
+		EncPart: messages.EncryptedData{EType: armorEType, Cipher: bytes.Repeat([]byte{0x7a}, 32)},
+	}
+	raw, err := tkt.Marshal()
+	if err != nil {
+		t.Fatalf("Ticket.Marshal: %v", err)
+	}
+	c := NewClient("alice", "corp.local", "10.0.0.1").WithPassword("Passw0rd!")
+	c.WithFASTArmor("armor$", testRealm, tkt, raw, armorKey, armorEType)
+	return c
+}
+
+// TestFASTArmorKeyDerivation pins the FAST armor-key derivation: fast.go combines
+// a fresh subkey with the armor TGT session key via KRB-FX-CF2 under the RFC 6113
+// "subkeyarmor"/"ticketarmor" peppers. This confirms fast.go's pepper constants
+// match the RFC and reproduce the crypto package's known-answer value.
+func TestFASTArmorKeyDerivation(t *testing.T) {
+	if fastPepperSubkeyArmor != "subkeyarmor" || fastPepperTicketArmor != "ticketarmor" {
+		t.Fatalf("armor peppers drifted: %q / %q", fastPepperSubkeyArmor, fastPepperTicketArmor)
+	}
+	// Same inputs as the crypto KAT "aes256-subkeyarmor" (prf_test.go).
+	subkey, _ := hex.DecodeString("0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20")
+	armorSession, _ := hex.DecodeString("2122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f40")
+	want, _ := hex.DecodeString("18b1ecfa39a1bf373bcbc098aae658fe35082a00d7d6660e6cb6fd6138404d21")
+
+	got, etype, err := kerbcrypto.KRBFXCF2(
+		subkey, messages.ETypeAES256CTSHMACSHA196,
+		armorSession, messages.ETypeAES256CTSHMACSHA196,
+		fastPepperSubkeyArmor, fastPepperTicketArmor)
+	if err != nil {
+		t.Fatalf("KRBFXCF2: %v", err)
+	}
+	if etype != messages.ETypeAES256CTSHMACSHA196 {
+		t.Errorf("armor key etype = %d, want AES256", etype)
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("armor key = %x, want %x", got, want)
+	}
+}
+
+// TestBuildArmorAPReq confirms the FX_FAST_ARMOR_AP_REQUEST assembly: the AP-REQ
+// carries the armor TGT verbatim, and its authenticator (decryptable with the
+// armor session key at key usage 11) carries the subkey the KDC needs to
+// reconstruct the armor key, keyed to the armor principal.
+func TestBuildArmorAPReq(t *testing.T) {
+	armorKey := bytes.Repeat([]byte{0x33}, 32)
+	c := fastArmoredClient(t, armorKey, messages.ETypeAES256CTSHMACSHA196)
+
+	subkey := bytes.Repeat([]byte{0x5c}, kerbcrypto.KeyLen(messages.ETypeAES256CTSHMACSHA196))
+	apReqBytes, err := c.buildArmorAPReq(subkey)
+	if err != nil {
+		t.Fatalf("buildArmorAPReq: %v", err)
+	}
+
+	var apReq messages.APReq
+	if _, err := apReq.Unmarshal(apReqBytes); err != nil {
+		t.Fatalf("parse armor AP-REQ: %v", err)
+	}
+	if !bytes.Equal(apReq.TicketRaw, c.fast.ticketRaw) {
+		t.Error("armor AP-REQ does not carry the armor TGT verbatim")
+	}
+
+	authBytes, err := kerbcrypto.Decrypt(messages.ETypeAES256CTSHMACSHA196, armorKey, kerbcrypto.KeyUsageAPReqAuthen, apReq.Authenticator.Cipher)
+	if err != nil {
+		t.Fatalf("decrypt armor authenticator: %v", err)
+	}
+	var auth messages.Authenticator
+	if _, err := auth.Unmarshal(authBytes); err != nil {
+		t.Fatalf("parse armor authenticator: %v", err)
+	}
+	if auth.SubKey == nil || !bytes.Equal(auth.SubKey.KeyValue, subkey) {
+		t.Errorf("armor authenticator subkey mismatch: %+v", auth.SubKey)
+	}
+	if auth.CRealm != testRealm || len(auth.CName.NameString) != 1 || auth.CName.NameString[0] != "armor$" {
+		t.Errorf("armor authenticator principal = %q/%+v, want %s/armor$", auth.CRealm, auth.CName, testRealm)
+	}
+}
+
+// TestBuildArmorAPReqRejectsBadEType covers the error path: an unsupported armor
+// session etype fails encryption of the authenticator.
+func TestBuildArmorAPReqRejectsBadEType(t *testing.T) {
+	c := fastArmoredClient(t, bytes.Repeat([]byte{0x33}, 32), 9999) // bogus etype
+	if _, err := c.buildArmorAPReq(bytes.Repeat([]byte{0x5c}, 32)); err == nil {
+		t.Fatal("expected buildArmorAPReq to fail for an unsupported armor etype")
+	}
+}
+
+// TestFASTASReqBody verifies the inner AS-REQ body FAST wraps: it requests a TGT
+// (krbtgt/REALM) for the client, carries the credential's etype list, and sets
+// the forwardable/proxiable/renewable options a real AD client sends.
+func TestFASTASReqBody(t *testing.T) {
+	c := fastArmoredClient(t, bytes.Repeat([]byte{0x33}, 32), messages.ETypeAES256CTSHMACSHA196)
+	body := c.asReqBody(0x2233)
+
+	if len(body.CName.NameString) != 1 || body.CName.NameString[0] != "alice" {
+		t.Errorf("cname = %+v, want alice", body.CName)
+	}
+	if body.Realm != testRealm {
+		t.Errorf("realm = %q, want %q", body.Realm, testRealm)
+	}
+	if len(body.SName.NameString) != 2 || body.SName.NameString[0] != "krbtgt" || body.SName.NameString[1] != testRealm {
+		t.Errorf("sname = %+v, want krbtgt/%s", body.SName, testRealm)
+	}
+	if body.Nonce != 0x2233 {
+		t.Errorf("nonce = %d, want 0x2233", body.Nonce)
+	}
+	if len(body.EType) == 0 || body.EType[0] != messages.ETypeAES256CTSHMACSHA196 {
+		t.Errorf("etype list = %v, want AES256 first", body.EType)
+	}
+	for _, bit := range []int{kdcOptionForwardable, kdcOptionProxiable, kdcOptionRenewable} {
+		if body.KDCOptions.At(bit) != 1 {
+			t.Errorf("AS-REQ option bit %d not set", bit)
+		}
+	}
+}
+
+// TestFASTEnabledAndSelfArmor covers the FAST configuration accessors:
+// FASTEnabled tracks whether an armor TGT is set, and WithFASTArmorFromClient
+// copies another client's TGT state as the armor (the self-armor pattern).
+func TestFASTEnabledAndSelfArmor(t *testing.T) {
+	plain := NewClient("alice", "corp.local", "10.0.0.1").WithPassword("x")
+	if plain.FASTEnabled() {
+		t.Error("FASTEnabled should be false before an armor is configured")
+	}
+
+	armorClient := fakeTGTClient(t) // a client holding a usable TGT
+	plain.WithFASTArmorFromClient(armorClient)
+	if !plain.FASTEnabled() {
+		t.Fatal("FASTEnabled should be true after WithFASTArmorFromClient")
+	}
+	if plain.fast.cname != armorClient.username || plain.fast.realm != armorClient.realm {
+		t.Errorf("self-armor identity = %q@%q, want %q@%q", plain.fast.cname, plain.fast.realm, armorClient.username, armorClient.realm)
+	}
+	if !bytes.Equal(plain.fast.sessionKey, armorClient.sessionKey) || plain.fast.sessionEType != armorClient.sessionEType {
+		t.Error("self-armor did not adopt the armor client's session key/etype")
+	}
+	if !bytes.Equal(plain.fast.ticketRaw, armorClient.tgtTicketRaw) {
+		t.Error("self-armor did not adopt the armor client's raw TGT")
+	}
+}

--- a/network/kerberos/v5/keytab_test.go
+++ b/network/kerberos/v5/keytab_test.go
@@ -1,0 +1,112 @@
+package kerberos
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/credcache/keytab"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/iana"
+)
+
+// keytabBytes marshals a keytab holding the given (etype, key) entries for
+// alice@CORP.LOCAL, all at the same kvno so selection turns on enctype strength
+// rather than key version.
+func keytabBytes(t *testing.T, entries map[int][]byte) []byte {
+	t.Helper()
+	kt := keytab.New()
+	princ := keytab.Principal{
+		NameType:   iana.NameTypePrincipal,
+		Realm:      testRealm,
+		Components: []string{"alice"},
+	}
+	for etype, key := range entries {
+		kt.Add(princ, etype, key, 1)
+	}
+	data, err := kt.Marshal()
+	if err != nil {
+		t.Fatalf("keytab.Marshal: %v", err)
+	}
+	return data
+}
+
+// TestWithKeytabBytesPrefersAES256 confirms WithKeytabBytes selects the strongest
+// usable enctype (AES256 > AES128 > RC4) and configures the client credential
+// with it.
+func TestWithKeytabBytesPrefersAES256(t *testing.T) {
+	data := keytabBytes(t, map[int][]byte{
+		iana.ETypeRC4HMAC:             bytes.Repeat([]byte{0x11}, 16),
+		iana.ETypeAES128CTSHMACSHA196: bytes.Repeat([]byte{0x22}, 16),
+		iana.ETypeAES256CTSHMACSHA196: bytes.Repeat([]byte{0x33}, 32),
+	})
+
+	c := NewClient("alice", "corp.local", "10.0.0.1")
+	if err := c.WithKeytabBytes(data); err != nil {
+		t.Fatalf("WithKeytabBytes: %v", err)
+	}
+	et := c.cred.SupportedETypes()
+	if len(et) != 1 || et[0] != iana.ETypeAES256CTSHMACSHA196 {
+		t.Errorf("selected credential etypes = %v, want [AES256]", et)
+	}
+}
+
+// TestWithKeytabBytesFallsBackToRC4 confirms that when no AES key is present the
+// RC4-HMAC key is adopted as an overpass-the-hash (NT-hash) credential.
+func TestWithKeytabBytesFallsBackToRC4(t *testing.T) {
+	data := keytabBytes(t, map[int][]byte{
+		iana.ETypeRC4HMAC: bytes.Repeat([]byte{0x11}, 16),
+	})
+
+	c := NewClient("alice", "corp.local", "10.0.0.1")
+	if err := c.WithKeytabBytes(data); err != nil {
+		t.Fatalf("WithKeytabBytes: %v", err)
+	}
+	et := c.cred.SupportedETypes()
+	if len(et) != 1 || et[0] != iana.ETypeRC4HMAC {
+		t.Errorf("selected credential etypes = %v, want [RC4]", et)
+	}
+}
+
+// TestWithKeytabForcesEType confirms an explicit etype overrides the
+// strongest-first preference (WithKeytab with etype > 0).
+func TestWithKeytabForcesEType(t *testing.T) {
+	data := keytabBytes(t, map[int][]byte{
+		iana.ETypeAES256CTSHMACSHA196: bytes.Repeat([]byte{0x33}, 32),
+		iana.ETypeAES128CTSHMACSHA196: bytes.Repeat([]byte{0x22}, 16),
+	})
+	kt, err := keytab.Unmarshal(data)
+	if err != nil {
+		t.Fatalf("keytab.Unmarshal: %v", err)
+	}
+
+	c := NewClient("alice", "corp.local", "10.0.0.1")
+	if err := c.WithKeytab(kt, iana.ETypeAES128CTSHMACSHA196); err != nil {
+		t.Fatalf("WithKeytab(AES128): %v", err)
+	}
+	et := c.cred.SupportedETypes()
+	if len(et) != 1 || et[0] != iana.ETypeAES128CTSHMACSHA196 {
+		t.Errorf("forced credential etypes = %v, want [AES128]", et)
+	}
+}
+
+// TestWithKeytabRejectsUnsupportedEType confirms an entry whose only key is an
+// AES-SHA2 (or DES) enctype — which the credentials layer cannot key for
+// authentication — is rejected rather than silently accepted.
+func TestWithKeytabRejectsUnsupportedEType(t *testing.T) {
+	for _, etype := range []int{iana.ETypeAES256CTSHMACSHA384, iana.ETypeDESCBCMD5} {
+		data := keytabBytes(t, map[int][]byte{etype: bytes.Repeat([]byte{0x44}, 32)})
+		c := NewClient("alice", "corp.local", "10.0.0.1")
+		if err := c.WithKeytabBytes(data); err == nil {
+			t.Errorf("etype %d: expected WithKeytabBytes to reject an unusable enctype", etype)
+		}
+	}
+}
+
+// TestWithKeytabNoMatch confirms a keytab with no entry for the client principal
+// is reported as an error.
+func TestWithKeytabNoMatch(t *testing.T) {
+	data := keytabBytes(t, map[int][]byte{iana.ETypeAES256CTSHMACSHA196: bytes.Repeat([]byte{0x33}, 32)})
+	c := NewClient("bob", "corp.local", "10.0.0.1") // keytab holds alice, not bob
+	if err := c.WithKeytabBytes(data); err == nil {
+		t.Fatal("expected an error selecting a keytab entry for a non-present principal")
+	}
+}

--- a/network/kerberos/v5/spnego_mechanism_test.go
+++ b/network/kerberos/v5/spnego_mechanism_test.go
@@ -1,0 +1,178 @@
+package kerberos
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+	"time"
+
+	kerbcrypto "github.com/TheManticoreProject/Manticore/network/kerberos/v5/crypto"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/gssapi"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/messages"
+)
+
+// silverArmedClient forges a silver service ticket for spn (signed with an RC4
+// service key) and preloads it into a fresh client, so the SPNEGO mechanism can
+// build an AP-REQ with neither a TGT nor a KDC — exactly the silver-ticket
+// pass-the-ticket path. It returns the client and the ticket session key/etype
+// the acceptor would key against.
+func silverArmedClient(t *testing.T, spn string) (*KerberosClient, []byte, int) {
+	t.Helper()
+	sessionKey := bytes.Repeat([]byte{0x42}, 32)
+	ft, err := ForgeSilver(ForgeOptions{
+		Realm:           testRealm,
+		Username:        "Administrator",
+		DomainSID:       testDomainSID,
+		UserRID:         500,
+		LogonDomainName: "CORP",
+		Key:             bytes.Repeat([]byte{0xCD}, 16), // service RC4 NT hash
+		KeyEType:        messages.ETypeRC4HMAC,
+		SessionKey:      sessionKey,
+		SessionEType:    messages.ETypeAES256CTSHMACSHA196,
+	}, spn)
+	if err != nil {
+		t.Fatalf("ForgeSilver: %v", err)
+	}
+	c := NewClient("Administrator", "corp.local", "") // no KDC host: must not be contacted
+	if err := c.LoadForgedServiceTicket(ft); err != nil {
+		t.Fatalf("LoadForgedServiceTicket: %v", err)
+	}
+	return c, ft.SessionKey, ft.SessionEType
+}
+
+// TestSPNEGOInitTokenBuildsAPReq drives InitToken over a preloaded silver ticket
+// and confirms the emitted SPNEGO mechToken is a well-formed KRB_AP_REQ: the
+// GSS-wrapped AP-REQ carries the ticket verbatim, mutual-required is set, and the
+// authenticator (decryptable with the ticket session key at key usage 11) holds
+// the 0x8003 GSS checksum with the mutual flag and names the client.
+func TestSPNEGOInitTokenBuildsAPReq(t *testing.T) {
+	const spn = "cifs/host.corp.local"
+	c, sessionKey, sessionEType := silverArmedClient(t, spn)
+
+	m := NewSPNEGOMechanism(c, spn)
+	token, err := m.InitToken()
+	if err != nil {
+		t.Fatalf("InitToken: %v", err)
+	}
+
+	tokID, apReqBytes, err := gssapi.UnwrapToken(token)
+	if err != nil {
+		t.Fatalf("UnwrapToken: %v", err)
+	}
+	if tokID != gssapi.TokIDAPReq {
+		t.Fatalf("TOK_ID = %02x %02x, want AP-REQ (01 00)", tokID[0], tokID[1])
+	}
+
+	var apReq messages.APReq
+	if _, err := apReq.Unmarshal(apReqBytes); err != nil {
+		t.Fatalf("parse AP-REQ: %v", err)
+	}
+	// mutual-required (AP-options bit 2 -> byte 0, 0x20) must be set.
+	if apReq.APOptions.Bytes[0]&0x20 == 0 {
+		t.Errorf("mutual-required AP option not set: % X", apReq.APOptions.Bytes)
+	}
+	if apReq.Authenticator.EType != sessionEType {
+		t.Errorf("authenticator etype = %d, want session etype %d", apReq.Authenticator.EType, sessionEType)
+	}
+
+	authBytes, err := kerbcrypto.Decrypt(sessionEType, sessionKey, kerbcrypto.KeyUsageAPReqAuthen, apReq.Authenticator.Cipher)
+	if err != nil {
+		t.Fatalf("decrypt authenticator: %v", err)
+	}
+	var auth messages.Authenticator
+	if _, err := auth.Unmarshal(authBytes); err != nil {
+		t.Fatalf("parse authenticator: %v", err)
+	}
+	if auth.Cksum == nil || auth.Cksum.CKSumType != gssapi.ChecksumTypeGSSAPI {
+		t.Fatalf("authenticator checksum type = %v, want 0x8003", auth.Cksum)
+	}
+	if len(auth.Cksum.Checksum) != 24 {
+		t.Fatalf("0x8003 checksum length = %d, want 24", len(auth.Cksum.Checksum))
+	}
+	if flags := binary.LittleEndian.Uint32(auth.Cksum.Checksum[20:]); flags&gssapi.GSSMutualFlag == 0 {
+		t.Errorf("checksum flags 0x%x missing mutual bit", flags)
+	}
+	if len(auth.CName.NameString) != 1 || auth.CName.NameString[0] != "Administrator" {
+		t.Errorf("authenticator cname = %+v, want Administrator", auth.CName)
+	}
+}
+
+// TestSPNEGOSessionKeyReturnsSubkey confirms SessionKey exposes the negotiated
+// initiator subkey after InitToken (used to sign/seal SMB and RPC traffic), and
+// returns nil before a context exists.
+func TestSPNEGOSessionKeyReturnsSubkey(t *testing.T) {
+	const spn = "cifs/host.corp.local"
+	c, _, sessionEType := silverArmedClient(t, spn)
+
+	m := NewSPNEGOMechanism(c, spn)
+	if m.SessionKey() != nil {
+		t.Error("SessionKey should be nil before InitToken establishes a context")
+	}
+	if _, err := m.InitToken(); err != nil {
+		t.Fatalf("InitToken: %v", err)
+	}
+	key := m.SessionKey()
+	if len(key) != kerbcrypto.KeyLen(sessionEType) {
+		t.Fatalf("SessionKey length = %d, want %d", len(key), kerbcrypto.KeyLen(sessionEType))
+	}
+	// InitToken asserts an initiator subkey, so SessionKey returns it (not the
+	// bare ticket session key).
+	if m.ctx == nil || !bytes.Equal(key, m.ctx.SubKey) {
+		t.Error("SessionKey should return the negotiated context subkey")
+	}
+}
+
+// TestSPNEGOInitTokenNoCredential covers the error path: with no TGT, no
+// preloaded ticket, and no credential, InitToken fails while acquiring a TGT
+// rather than contacting the network.
+func TestSPNEGOInitTokenNoCredential(t *testing.T) {
+	c := NewClient("bob", "corp.local", "") // no credential, no ticket
+	m := NewSPNEGOMechanism(c, "cifs/host.corp.local")
+	if _, err := m.InitToken(); err == nil {
+		t.Fatal("expected InitToken to fail without a credential or preloaded ticket")
+	}
+}
+
+// TestSPNEGOAcceptResponseToken exercises the AcceptResponseToken paths that do
+// not require a live acceptor: an empty token is a no-op, a token with no
+// established context is rejected, and a GSS-wrapped KRB-ERROR is surfaced with
+// its error code.
+func TestSPNEGOAcceptResponseToken(t *testing.T) {
+	const spn = "cifs/host.corp.local"
+
+	// Empty token is a no-op even before a context exists.
+	m := NewSPNEGOMechanism(NewClient("bob", "corp.local", ""), spn)
+	if err := m.AcceptResponseToken(nil); err != nil {
+		t.Errorf("empty token should be a no-op, got %v", err)
+	}
+
+	// A non-empty token with no established context is rejected.
+	if err := m.AcceptResponseToken([]byte{0x01, 0x02}); err == nil {
+		t.Error("expected error with no established context")
+	}
+
+	// With a context established, a GSS-wrapped KRB-ERROR must be surfaced.
+	c, _, _ := silverArmedClient(t, spn)
+	m2 := NewSPNEGOMechanism(c, spn)
+	if _, err := m2.InitToken(); err != nil {
+		t.Fatalf("InitToken: %v", err)
+	}
+	krbErr := &messages.KRBError{
+		STime:     time.Date(2026, 7, 11, 12, 0, 0, 0, time.UTC),
+		ErrorCode: messages.ErrSkew,
+		Realm:     testRealm,
+		SName:     messages.PrincipalName{NameType: messages.NameTypeSRVInst, NameString: []string{"cifs", "host.corp.local"}},
+		EText:     "clock skew too great",
+	}
+	krbErrBytes, err := krbErr.Marshal()
+	if err != nil {
+		t.Fatalf("KRBError.Marshal: %v", err)
+	}
+	errToken, err := gssapi.WrapToken(gssapi.TokIDError, krbErrBytes)
+	if err != nil {
+		t.Fatalf("WrapToken: %v", err)
+	}
+	if err := m2.AcceptResponseToken(errToken); err == nil {
+		t.Error("expected AcceptResponseToken to surface a server KRB-ERROR")
+	}
+}

--- a/network/kerberos/v5/unpac_test.go
+++ b/network/kerberos/v5/unpac_test.go
@@ -1,0 +1,137 @@
+package kerberos
+
+import (
+	"bytes"
+	"encoding/asn1"
+	"encoding/binary"
+	"testing"
+
+	kerbcrypto "github.com/TheManticoreProject/Manticore/network/kerberos/v5/crypto"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/messages"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/pac"
+)
+
+// TestUnPACTheHashGuards covers the pre-conditions UnPACTheHash enforces before
+// any network exchange: a TGT is required, and a PKINIT reply key must be
+// present (the technique only applies after a certificate logon).
+func TestUnPACTheHashGuards(t *testing.T) {
+	// No TGT at all.
+	c := NewClient("alice", "corp.local", "10.0.0.1").WithPassword("x")
+	if _, _, err := c.UnPACTheHash(); err == nil {
+		t.Error("expected error without a TGT")
+	}
+
+	// A TGT but no PKINIT reply key (a password/hash logon, not certificate).
+	c2 := fakeTGTClient(t)
+	if _, _, err := c2.UnPACTheHash(); err == nil {
+		t.Error("expected error without a PKINIT reply key")
+	}
+}
+
+// TestExtractWin2KPAC checks the AD-IF-RELEVANT → AD-WIN2K-PAC walk: the PAC
+// bytes are recovered from a well-formed wrapper and nil is returned when the
+// wrapper or the inner AD-WIN2K-PAC element is absent.
+func TestExtractWin2KPAC(t *testing.T) {
+	pacBytes := []byte{0xDE, 0xAD, 0xBE, 0xEF}
+	inner, err := asn1.Marshal([]messages.AuthorizationData{
+		{ADType: adTypeWin2KPAC, ADData: pacBytes},
+	})
+	if err != nil {
+		t.Fatalf("marshal inner AD: %v", err)
+	}
+	ad := []messages.AuthorizationData{{ADType: adTypeIfRelevant, ADData: inner}}
+	if got := extractWin2KPAC(ad); !bytes.Equal(got, pacBytes) {
+		t.Errorf("extractWin2KPAC = % X, want % X", got, pacBytes)
+	}
+
+	// A non-IF-RELEVANT element is ignored.
+	if got := extractWin2KPAC([]messages.AuthorizationData{{ADType: 99, ADData: inner}}); got != nil {
+		t.Errorf("expected nil for a non-IF-RELEVANT element, got % X", got)
+	}
+
+	// IF-RELEVANT without an AD-WIN2K-PAC element yields nil.
+	other, err := asn1.Marshal([]messages.AuthorizationData{{ADType: 42, ADData: []byte{0x01}}})
+	if err != nil {
+		t.Fatalf("marshal other AD: %v", err)
+	}
+	if got := extractWin2KPAC([]messages.AuthorizationData{{ADType: adTypeIfRelevant, ADData: other}}); got != nil {
+		t.Errorf("expected nil without AD-WIN2K-PAC, got % X", got)
+	}
+}
+
+// TestPACCredentialInfoRecoversNTHash exercises the credential-recovery half of
+// UnPACTheHash (everything after the user-to-user ticket is decrypted): a PAC
+// carrying a PAC_CREDENTIAL_INFO encrypted under the PKINIT reply key is parsed,
+// decrypted, and the embedded NTLM_SUPPLEMENTAL_CREDENTIAL NT hash is recovered.
+// The network user-to-user step itself is not reachable offline.
+func TestPACCredentialInfoRecoversNTHash(t *testing.T) {
+	replyKey := bytes.Repeat([]byte{0x24}, 32) // AES256 reply key
+	replyEType := messages.ETypeAES256CTSHMACSHA196
+	wantNT := bytes.Repeat([]byte{0xAB}, 16)
+	wantLM := bytes.Repeat([]byte{0xCD}, 16)
+
+	// PAC_CREDENTIAL_DATA: NDR type-serialization framing, then the trailing
+	// NTLM_SUPPLEMENTAL_CREDENTIAL as a conformant array (MaximumCount=40).
+	ntlm := make([]byte, 40)
+	binary.LittleEndian.PutUint32(ntlm[0:], 0) // Version
+	binary.LittleEndian.PutUint32(ntlm[4:], 0x1|0x2)
+	copy(ntlm[8:], wantLM)
+	copy(ntlm[24:], wantNT)
+	var credData []byte
+	credData = append(credData, bytes.Repeat([]byte{0x00}, 48)...)
+	count := make([]byte, 4)
+	binary.LittleEndian.PutUint32(count, 40)
+	credData = append(credData, count...)
+	credData = append(credData, ntlm...)
+
+	// Encrypt PAC_CREDENTIAL_DATA with the reply key (key usage KERB_NON_KERB_SALT).
+	enc, err := kerbcrypto.Encrypt(replyEType, replyKey, kerbcrypto.KeyUsageKerbNonKerbSalt, credData)
+	if err != nil {
+		t.Fatalf("encrypt PAC_CREDENTIAL_DATA: %v", err)
+	}
+
+	// PAC_CREDENTIAL_INFO: Version(0), EncryptionType, SerializedData(ciphertext).
+	ci := make([]byte, 8)
+	binary.LittleEndian.PutUint32(ci[0:], 0)
+	binary.LittleEndian.PutUint32(ci[4:], uint32(replyEType))
+	ci = append(ci, enc...)
+
+	p := &pac.PAC{Version: 0, Buffers: []pac.Buffer{{Type: pac.BufferCredentials, Data: ci}}}
+	pacBytes, err := p.Marshal()
+	if err != nil {
+		t.Fatalf("PAC.Marshal: %v", err)
+	}
+
+	// Drive the same parse/decrypt chain UnPACTheHash runs on the U2U ticket's PAC.
+	parsed, err := pac.Parse(pacBytes)
+	if err != nil {
+		t.Fatalf("pac.Parse: %v", err)
+	}
+	buf, ok := parsed.Buffer(pac.BufferCredentials)
+	if !ok {
+		t.Fatal("PAC has no PAC_CREDENTIAL_INFO buffer")
+	}
+	info, err := pac.ParseCredentialInfo(buf.Data)
+	if err != nil {
+		t.Fatalf("ParseCredentialInfo: %v", err)
+	}
+	plain, err := info.DecryptCredentialData(replyKey)
+	if err != nil {
+		t.Fatalf("DecryptCredentialData: %v", err)
+	}
+	ntlmCred, err := pac.ParseNTLMSupplementalCredential(plain)
+	if err != nil {
+		t.Fatalf("ParseNTLMSupplementalCredential: %v", err)
+	}
+	if !bytes.Equal(ntlmCred.NTHash, wantNT) {
+		t.Errorf("recovered NT hash = %x, want %x", ntlmCred.NTHash, wantNT)
+	}
+	if !bytes.Equal(ntlmCred.LMHash, wantLM) {
+		t.Errorf("recovered LM hash = %x, want %x", ntlmCred.LMHash, wantLM)
+	}
+
+	// A wrong reply key must fail decryption (integrity check).
+	if _, err := info.DecryptCredentialData(bytes.Repeat([]byte{0x99}, 32)); err == nil {
+		t.Error("expected decryption failure with a wrong reply key")
+	}
+}


### PR DESCRIPTION
## Summary

Adds strictly offline, white-box unit tests for the five top-level Kerberos client orchestration files under `network/kerberos/v5/` that previously had no dedicated coverage (`fast.go`, `client_pkinit.go`, `keytab.go`, `spnego_mechanism.go`, `unpac.go`). Closes #993.

These files were exercised only indirectly or by the live integration suite (which needs a domain controller). The new tests exercise the real shipped logic with synthetic/crafted inputs and the existing message/PAC/keytab builders — no network, no `//go:build integration` tags.

## What changed (tests only; no production code touched)

- **`spnego_mechanism_test.go`** — `InitToken` over a preloaded silver ticket produces a well-formed GSS/AP-REQ (unwrapped and its authenticator decrypted with the ticket session key at usage 11; mutual flag + 0x8003 checksum + client name asserted); `SessionKey` returns the negotiated initiator subkey; `AcceptResponseToken` covers the empty-token no-op, the no-context rejection, and a GSS-wrapped KRB-ERROR surfaced to the caller. Error path: `InitToken` with no credential/ticket fails before any network call.
- **`fast_test.go`** — pins the KRB-FX-CF2 armor-key derivation to the crypto package's known-answer value (confirming fast.go's RFC 6113 `subkeyarmor`/`ticketarmor` pepper constants), verifies the `FX_FAST_ARMOR_AP_REQUEST` assembly (subkey carried, TGT verbatim, armor principal) and the inner AS-REQ body, plus the self-armor accessors and an encryption error path.
- **`client_pkinit_test.go`** — drives `processPKINITASRep` end to end with a hand-built synthetic PKINIT KDC reply whose DH public value yields the same reply key both sides derive, then asserts the TGT and reply key are stored; also covers the unsupported reply-key etype rejection, the nonce mismatch, the missing-`PA-PK-AS-REP` path, and the `WithPKINIT`/`WithPKINITGroups`/`PKINITReplyKey` accessors.
- **`keytab_test.go`** — `WithKeytabBytes` enctype selection (AES256 > AES128 > RC4), RC4 overpass-the-hash fallback, forced-etype override, and rejection of AES-SHA2/DES entries and non-present principals, using synthetic keytab bytes.
- **`unpac_test.go`** — the TGT and PKINIT-reply-key guards, the `AD-IF-RELEVANT -> AD-WIN2K-PAC` walk (`extractWin2KPAC`), and the `PAC_CREDENTIAL_INFO -> NT/LM hash` recovery chain against a synthetic PAC encrypted under a reply key (plus a wrong-key decryption failure).

## How validated

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./network/kerberos/...` — all green (22 new tests pass)

Offline only; no live DC needed (per the issue, that is the gate). No shipped code changed and no test was weakened to pass.

## Seams not coverable offline (left to the integration suite)

- `AcceptResponseToken`'s **mutual-auth success branch**: a matching AP-REP must echo the `gssapi.SecContext`'s wall-clock `ctime`/`cusec`, which are unexported and captured inside `InitSecContext`, so a valid AP-REP cannot be crafted from package `kerberos`. The AP-REP verification itself is already covered by `gssapi`'s `TestAcceptAPRepMutualAuth`.
- `UnPACTheHash`'s **user-to-user KDC round-trip** (`GetTGSU2U -> sendToRealm`): there is no transport-injection seam. The credential-recovery half it performs after that hop is covered directly.