### PR TITLE
Verify the KDC CMS SignedData signature on the PKINIT AS-REP (Fixes #994)

### DIFF
--- a/network/kerberos/v5/client.go
+++ b/network/kerberos/v5/client.go
@@ -3,6 +3,7 @@ package kerberos
 import (
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/x509"
 	"encoding/asn1"
 	"encoding/binary"
 	"fmt"
@@ -95,6 +96,16 @@ type KerberosClient struct {
 	pkinitGroups     []pkinit.DHGroup
 	pkinitReplyKey   []byte
 	pkinitReplyEType int
+	// pkinitAnchors are the trust anchors the KDC's PKINIT signing certificate
+	// must chain to (or be pinned by); when set, the KDC's CMS SignedData
+	// signature on the AS-REP is verified (RFC 4556 §3.2.4). Configured via
+	// WithPKINITKDCCert / WithPKINITAnchors. pkinitSkipKDCSigCheck is the
+	// explicit insecure opt-out for the anonymous / self-signed lab case.
+	pkinitAnchors         []*x509.Certificate
+	pkinitSkipKDCSigCheck bool
+	// pkinitKDCCertErr defers a WithPKINITKDCCert parse failure to GetTGT so the
+	// builder-style option methods can keep their chainable signature.
+	pkinitKDCCertErr error
 }
 
 // preloadedServiceTicket is a service ticket the client will hand back from

--- a/network/kerberos/v5/client_pkinit.go
+++ b/network/kerberos/v5/client_pkinit.go
@@ -2,6 +2,7 @@ package kerberos
 
 import (
 	"crypto/rsa"
+	"crypto/x509"
 	"fmt"
 	"time"
 
@@ -33,6 +34,58 @@ func (c *KerberosClient) WithPKINIT(priv *rsa.PrivateKey, certDER []byte) *Kerbe
 func (c *KerberosClient) WithPKINITGroups(groups ...pkinit.DHGroup) *KerberosClient {
 	c.pkinitGroups = groups
 	return c
+}
+
+// WithPKINITKDCCert pins the KDC's PKINIT signing certificate as a trust anchor:
+// a subsequent GetTGT verifies the KDC's CMS SignedData signature on the AS-REP
+// and requires the signer certificate to be byte-identical to certDER (RFC 4556
+// §3.2.4). This covers a self-signed KDC certificate directly; to trust a CA
+// instead, use WithPKINITAnchors. By default (no anchor and no opt-out) the KDC
+// signature is not verified.
+func (c *KerberosClient) WithPKINITKDCCert(certDER []byte) *KerberosClient {
+	cert, err := x509.ParseCertificate(certDER)
+	if err != nil {
+		c.pkinitKDCCertErr = fmt.Errorf("kerberos: parse pinned KDC certificate: %w", err)
+		return c
+	}
+	c.pkinitAnchors = append(c.pkinitAnchors, cert)
+	return c
+}
+
+// WithPKINITAnchors adds trusted certificates (the issuing CA / root, or the
+// pinned KDC certificate itself) that the KDC's PKINIT signing certificate must
+// chain to. Supplying at least one anchor turns on verification of the KDC's CMS
+// SignedData signature on the AS-REP (RFC 4556 §3.2.4).
+func (c *KerberosClient) WithPKINITAnchors(anchors ...*x509.Certificate) *KerberosClient {
+	c.pkinitAnchors = append(c.pkinitAnchors, anchors...)
+	return c
+}
+
+// InsecureSkipPKINITKDCSignatureCheck disables verification of the KDC's CMS
+// SignedData signature on the AS-REP, for the anonymous / self-signed lab case
+// where no trust anchor can be pinned. It is insecure — it removes the RFC 4556
+// §3.2.4 protection against a substituted KDC DH public value — so call it only
+// knowingly.
+func (c *KerberosClient) InsecureSkipPKINITKDCSignatureCheck() *KerberosClient {
+	c.pkinitSkipKDCSigCheck = true
+	return c
+}
+
+// pkinitVerifyOptions builds the SignedData verification policy from the
+// configured anchors / opt-out. It returns nil when neither an anchor nor the
+// opt-out is configured, which leaves the KDC signature unverified (the legacy
+// default) while still gating the exchange on AS-REP decryption.
+func (c *KerberosClient) pkinitVerifyOptions() (*pkinit.VerifyOptions, error) {
+	if c.pkinitKDCCertErr != nil {
+		return nil, c.pkinitKDCCertErr
+	}
+	if len(c.pkinitAnchors) > 0 {
+		return &pkinit.VerifyOptions{Anchors: c.pkinitAnchors}, nil
+	}
+	if c.pkinitSkipKDCSigCheck {
+		return &pkinit.VerifyOptions{InsecureSkipSignatureCheck: true}, nil
+	}
+	return nil, nil
 }
 
 // PKINITReplyKey returns the AS reply key derived from the PKINIT Diffie-Hellman
@@ -154,7 +207,11 @@ func (c *KerberosClient) processPKINITASRep(resp []byte, pkReq *pkinit.Request, 
 		return fmt.Errorf("kerberos: PKINIT AS-REP has no PA-PK-AS-REP element")
 	}
 
-	reply, err := pkinit.ParseASRepPAData(paValue)
+	verifyOpts, err := c.pkinitVerifyOptions()
+	if err != nil {
+		return err
+	}
+	reply, err := pkinit.ParseASRepPAData(paValue, verifyOpts)
 	if err != nil {
 		return err
 	}

--- a/network/kerberos/v5/pkinit/asn1.go
+++ b/network/kerberos/v5/pkinit/asn1.go
@@ -25,8 +25,14 @@ var (
 	oidMessageDigest = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 9, 4}
 	// oidSHA1 is the id-sha1 digest algorithm (RFC 3370).
 	oidSHA1 = asn1.ObjectIdentifier{1, 3, 14, 3, 2, 26}
+	// oidSHA256 is the id-sha256 digest algorithm (RFC 5754 / NIST).
+	oidSHA256 = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 2, 1}
 	// oidRSAEncryption is the rsaEncryption signature/key algorithm.
 	oidRSAEncryption = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 1, 1}
+	// oidSHA1WithRSA and oidSHA256WithRSA are the combined RSA signature
+	// algorithms a KDC may name in the SignerInfo signatureAlgorithm field.
+	oidSHA1WithRSA   = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 1, 5}
+	oidSHA256WithRSA = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 1, 11}
 )
 
 // pkAuthenticator is RFC 4556 PKAuthenticator.

--- a/network/kerberos/v5/pkinit/cms.go
+++ b/network/kerberos/v5/pkinit/cms.go
@@ -1,10 +1,12 @@
 package pkinit
 
 import (
+	"bytes"
 	"crypto"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha1"
+	"crypto/sha256"
 	"crypto/x509"
 	"encoding/asn1"
 	"fmt"
@@ -169,11 +171,35 @@ func BuildSignedAuthPack(authPackDER []byte, priv *rsa.PrivateKey, certDER []byt
 	return ciBytes, nil
 }
 
-// extractSignedDataEContent parses a CMS ContentInfo (SignedData) and returns
-// the encapsulated eContent (for a PKINIT reply, the DER of KDCDHKeyInfo). The
-// KDC's signature is not verified here; successful decryption of the AS-REP
-// enc-part with the DH-derived reply key authenticates the exchange.
-func extractSignedDataEContent(contentInfoDER []byte) ([]byte, error) {
+// VerifyOptions controls verification of the KDC's CMS SignedData signature on
+// the PKINIT reply (RFC 4556 §3.2.4). Verification is performed whenever a trust
+// anchor is present and InsecureSkipSignatureCheck is not set: the KDC's
+// signature over the KDCDHKeyInfo is checked and the signer certificate must
+// chain to (or be pinned by) one of Anchors. A nil *VerifyOptions means no
+// verification (the legacy behaviour, kept for callers that cannot supply an
+// anchor).
+type VerifyOptions struct {
+	// Anchors are the trusted certificates the KDC signer certificate must
+	// chain to — the issuing CA (or root) certificate — or, when pinned
+	// directly, the KDC signing certificate itself (which also covers a
+	// self-signed KDC certificate). At least one is required unless
+	// InsecureSkipSignatureCheck is set.
+	Anchors []*x509.Certificate
+	// InsecureSkipSignatureCheck disables signature and chain verification for
+	// the anonymous / self-signed lab case where no anchor can be pinned. It is
+	// insecure: it removes the RFC 4556 §3.2.4 protection against a substituted
+	// KDC DH public value, so set it only knowingly.
+	InsecureSkipSignatureCheck bool
+}
+
+// verifySignedDataEContent parses a CMS ContentInfo (SignedData) from a PKINIT
+// reply and returns the encapsulated eContent (the DER of KDCDHKeyInfo). When
+// opts enables verification, the KDC's signature over the eContent is checked
+// and the signer certificate is chained/pinned to a trust anchor per RFC 4556
+// §3.2.4 before the eContent is returned; otherwise the eContent is returned
+// without verifying the signature (successful AS-REP decryption still gates the
+// exchange).
+func verifySignedDataEContent(contentInfoDER []byte, opts *VerifyOptions) ([]byte, error) {
 	var ci contentInfo
 	if _, err := asn1.Unmarshal(contentInfoDER, &ci); err != nil {
 		return nil, fmt.Errorf("pkinit: parse reply ContentInfo: %w", err)
@@ -186,12 +212,273 @@ func extractSignedDataEContent(contentInfoDER []byte) ([]byte, error) {
 		return nil, fmt.Errorf("pkinit: parse reply SignedData: %w", err)
 	}
 	if !sd.EncapContentInfo.EContentType.Equal(oidIDPKINITDHKeyData) {
-		return nil, fmt.Errorf("pkinit: unexpected reply eContentType %v", sd.EncapContentInfo.EContentType)
+		return nil, fmt.Errorf("pkinit: unexpected reply eContentType %v (want id-pkinit-DHKeyData)", sd.EncapContentInfo.EContentType)
 	}
 	if len(sd.EncapContentInfo.EContent) == 0 {
 		return nil, fmt.Errorf("pkinit: reply SignedData has no eContent")
 	}
+
+	if opts != nil && !opts.InsecureSkipSignatureCheck {
+		if len(opts.Anchors) == 0 {
+			return nil, fmt.Errorf("pkinit: KDC signature verification enabled but no trust anchor supplied; provide one or set InsecureSkipSignatureCheck")
+		}
+		if err := verifyKDCSignedData(&sd, opts); err != nil {
+			return nil, err
+		}
+	}
 	return sd.EncapContentInfo.EContent, nil
+}
+
+// verifyKDCSignedData verifies the KDC's CMS signature over a PKINIT reply
+// SignedData (RFC 4556 §3.2.4, RFC 5652 §5.4): it locates the signer
+// certificate, confirms the signed content-type and messageDigest attributes,
+// verifies the RSA signature over the DER re-encoding of signedAttrs, and
+// confirms the signer certificate is pinned to or chains to a trust anchor.
+func verifyKDCSignedData(sd *signedData, opts *VerifyOptions) error {
+	certs, err := parseSignedDataCertificates(sd.Certificates)
+	if err != nil {
+		return err
+	}
+	si, err := parseSingleSignerInfo(sd.SignerInfos)
+	if err != nil {
+		return err
+	}
+	signer := findSignerCert(certs, si.SID)
+	if signer == nil {
+		return fmt.Errorf("pkinit: KDC SignedData does not carry the signer certificate")
+	}
+
+	digestHash, err := digestForOID(si.DigestAlgorithm.Algorithm)
+	if err != nil {
+		return err
+	}
+	sigHash, err := rsaHashForSigAlg(si.SignatureAlgorithm.Algorithm, digestHash)
+	if err != nil {
+		return err
+	}
+
+	// RFC 4556 §3.2.4 requires signed attributes on the reply. Confirm the
+	// content-type attribute names id-pkinit-DHKeyData and that the messageDigest
+	// attribute equals the digest of the eContent before trusting the signature
+	// (RFC 5652 §5.4).
+	attrs, err := parseSignedAttrs(si.SignedAttrs)
+	if err != nil {
+		return err
+	}
+	ct, err := signedAttrOID(attrs, oidContentType)
+	if err != nil {
+		return err
+	}
+	if !ct.Equal(oidIDPKINITDHKeyData) {
+		return fmt.Errorf("pkinit: signed content-type attribute %v != id-pkinit-DHKeyData", ct)
+	}
+	md, err := signedAttrOctets(attrs, oidMessageDigest)
+	if err != nil {
+		return err
+	}
+	if !bytes.Equal(md, hashBytes(digestHash, sd.EncapContentInfo.EContent)) {
+		return fmt.Errorf("pkinit: KDC messageDigest attribute does not match the eContent digest")
+	}
+
+	// The signature covers the DER of signedAttrs re-tagged as an EXPLICIT SET OF
+	// (0x31), not the [0] IMPLICIT tag they carry in the SignerInfo (RFC 5652
+	// §5.4) — the classic CMS re-encoding gotcha.
+	signedAttrsForSig, err := reencodeSignedAttrsSet(si.SignedAttrs)
+	if err != nil {
+		return err
+	}
+	pub, ok := signer.PublicKey.(*rsa.PublicKey)
+	if !ok {
+		return fmt.Errorf("pkinit: KDC signer key is %T, only RSA is supported", signer.PublicKey)
+	}
+	if err := rsa.VerifyPKCS1v15(pub, sigHash, hashBytes(sigHash, signedAttrsForSig), si.Signature); err != nil {
+		return fmt.Errorf("pkinit: KDC SignedData signature verification failed: %w", err)
+	}
+
+	// Anchor check: accept immediately if the signer certificate is itself
+	// pinned (byte-identical to a supplied anchor, which also covers a
+	// self-signed KDC certificate); otherwise require an X.509 chain to one of
+	// the anchors, using any other certificates in the SignedData as
+	// intermediates.
+	for _, a := range opts.Anchors {
+		if bytes.Equal(a.Raw, signer.Raw) {
+			return nil
+		}
+	}
+	roots := x509.NewCertPool()
+	for _, a := range opts.Anchors {
+		roots.AddCert(a)
+	}
+	inter := x509.NewCertPool()
+	for _, c := range certs {
+		if !bytes.Equal(c.Raw, signer.Raw) {
+			inter.AddCert(c)
+		}
+	}
+	if _, err := signer.Verify(x509.VerifyOptions{
+		Roots:         roots,
+		Intermediates: inter,
+		// The KDC certificate carries the id-pkinit-KPKdc EKU, not the default
+		// serverAuth; do not reject on EKU here.
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
+	}); err != nil {
+		return fmt.Errorf("pkinit: KDC certificate does not chain to a trusted anchor: %w", err)
+	}
+	return nil
+}
+
+// parseSignedDataCertificates parses the X.509 certificates carried in a
+// SignedData certificates [0] field (a SET OF CertificateChoices); non-X.509
+// choices are skipped.
+func parseSignedDataCertificates(raw asn1.RawValue) ([]*x509.Certificate, error) {
+	var certs []*x509.Certificate
+	b := raw.Bytes
+	for len(b) > 0 {
+		var rv asn1.RawValue
+		rest, err := asn1.Unmarshal(b, &rv)
+		if err != nil {
+			return nil, fmt.Errorf("pkinit: walk SignedData certificates: %w", err)
+		}
+		b = rest
+		if rv.Class == asn1.ClassUniversal && rv.Tag == asn1.TagSequence {
+			cert, err := x509.ParseCertificate(rv.FullBytes)
+			if err != nil {
+				return nil, fmt.Errorf("pkinit: parse SignedData certificate: %w", err)
+			}
+			certs = append(certs, cert)
+		}
+	}
+	return certs, nil
+}
+
+// parseSingleSignerInfo parses the first SignerInfo from the SET OF SignerInfo
+// (a PKINIT reply carries exactly one).
+func parseSingleSignerInfo(raw asn1.RawValue) (signerInfo, error) {
+	var si signerInfo
+	if len(raw.Bytes) == 0 {
+		return si, fmt.Errorf("pkinit: KDC SignedData has no SignerInfo")
+	}
+	if _, err := asn1.Unmarshal(raw.Bytes, &si); err != nil {
+		return si, fmt.Errorf("pkinit: parse SignerInfo: %w", err)
+	}
+	return si, nil
+}
+
+// findSignerCert returns the certificate matching the SignerInfo's
+// issuerAndSerialNumber, or nil.
+func findSignerCert(certs []*x509.Certificate, sid issuerAndSerialNumber) *x509.Certificate {
+	for _, c := range certs {
+		if c.SerialNumber != nil && sid.SerialNumber != nil &&
+			c.SerialNumber.Cmp(sid.SerialNumber) == 0 &&
+			bytes.Equal(c.RawIssuer, sid.Issuer.FullBytes) {
+			return c
+		}
+	}
+	return nil
+}
+
+// parseSignedAttrs decodes the individual attributes carried in the SignerInfo
+// signedAttrs field.
+func parseSignedAttrs(raw asn1.RawValue) ([]attribute, error) {
+	if len(raw.Bytes) == 0 {
+		return nil, fmt.Errorf("pkinit: KDC SignerInfo carries no signed attributes")
+	}
+	var attrs []attribute
+	b := raw.Bytes
+	for len(b) > 0 {
+		var a attribute
+		rest, err := asn1.Unmarshal(b, &a)
+		if err != nil {
+			return nil, fmt.Errorf("pkinit: parse signed attribute: %w", err)
+		}
+		b = rest
+		attrs = append(attrs, a)
+	}
+	return attrs, nil
+}
+
+// findSignedAttr returns the attribute with the given type OID, or an error.
+func findSignedAttr(attrs []attribute, oid asn1.ObjectIdentifier) (*attribute, error) {
+	for i := range attrs {
+		if attrs[i].Type.Equal(oid) {
+			return &attrs[i], nil
+		}
+	}
+	return nil, fmt.Errorf("pkinit: signed attribute %v absent", oid)
+}
+
+// signedAttrOID decodes the single OID value of a signed attribute (e.g.
+// content-type).
+func signedAttrOID(attrs []attribute, oid asn1.ObjectIdentifier) (asn1.ObjectIdentifier, error) {
+	a, err := findSignedAttr(attrs, oid)
+	if err != nil {
+		return nil, err
+	}
+	var v asn1.ObjectIdentifier
+	if _, err := asn1.Unmarshal(a.Values.Bytes, &v); err != nil {
+		return nil, fmt.Errorf("pkinit: parse OID signed attribute %v: %w", oid, err)
+	}
+	return v, nil
+}
+
+// signedAttrOctets decodes the single OCTET STRING value of a signed attribute
+// (e.g. message-digest).
+func signedAttrOctets(attrs []attribute, oid asn1.ObjectIdentifier) ([]byte, error) {
+	a, err := findSignedAttr(attrs, oid)
+	if err != nil {
+		return nil, err
+	}
+	var v []byte
+	if _, err := asn1.Unmarshal(a.Values.Bytes, &v); err != nil {
+		return nil, fmt.Errorf("pkinit: parse octet-string signed attribute %v: %w", oid, err)
+	}
+	return v, nil
+}
+
+// reencodeSignedAttrsSet re-tags the [0] IMPLICIT signedAttrs as a universal
+// SET OF (tag 0x31), the form over which the CMS signature is computed (RFC 5652
+// §5.4).
+func reencodeSignedAttrsSet(raw asn1.RawValue) ([]byte, error) {
+	return asn1.Marshal(asn1.RawValue{Class: asn1.ClassUniversal, Tag: asn1.TagSet, IsCompound: true, Bytes: raw.Bytes})
+}
+
+// digestForOID maps a CMS digestAlgorithm OID to a crypto.Hash.
+func digestForOID(oid asn1.ObjectIdentifier) (crypto.Hash, error) {
+	switch {
+	case oid.Equal(oidSHA1):
+		return crypto.SHA1, nil
+	case oid.Equal(oidSHA256):
+		return crypto.SHA256, nil
+	}
+	return 0, fmt.Errorf("pkinit: unsupported CMS digest algorithm %v", oid)
+}
+
+// rsaHashForSigAlg maps a SignerInfo signatureAlgorithm OID to the hash used
+// with RSA PKCS#1 v1.5. For rsaEncryption the hash is the one named by the
+// digestAlgorithm (RFC 5652); the combined sha*WithRSAEncryption OIDs name it
+// explicitly.
+func rsaHashForSigAlg(oid asn1.ObjectIdentifier, digestHash crypto.Hash) (crypto.Hash, error) {
+	switch {
+	case oid.Equal(oidRSAEncryption):
+		return digestHash, nil
+	case oid.Equal(oidSHA1WithRSA):
+		return crypto.SHA1, nil
+	case oid.Equal(oidSHA256WithRSA):
+		return crypto.SHA256, nil
+	}
+	return 0, fmt.Errorf("pkinit: unsupported CMS signature algorithm %v", oid)
+}
+
+// hashBytes returns the digest of data under the given hash.
+func hashBytes(h crypto.Hash, data []byte) []byte {
+	switch h {
+	case crypto.SHA256:
+		sum := sha256.Sum256(data)
+		return sum[:]
+	default: // crypto.SHA1
+		sum := sha1.Sum(data)
+		return sum[:]
+	}
 }
 
 // nullDER is the DER encoding of ASN.1 NULL, used for RSA/SHA-1 algorithm

--- a/network/kerberos/v5/pkinit/cms_verify_test.go
+++ b/network/kerberos/v5/pkinit/cms_verify_test.go
@@ -1,0 +1,250 @@
+package pkinit
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"math/big"
+	"testing"
+	"time"
+)
+
+// digestOIDFor maps a crypto.Hash to the matching CMS digest algorithm OID.
+func digestOIDFor(h crypto.Hash) asn1.ObjectIdentifier {
+	if h == crypto.SHA256 {
+		return oidSHA256
+	}
+	return oidSHA1
+}
+
+// signReplyContentInfo builds a KDC-style PKINIT reply CMS ContentInfo
+// (SignedData) over embedEContent, computing the messageDigest and signature
+// over signedEContent (equal to embedEContent for a well-formed reply; distinct
+// to model a tampered eContent) and signing with signKey (the signer
+// certificate's own key for a valid reply; a foreign key to model a bad
+// signature). It mirrors the wire layout BuildSignedAuthPack produces for the
+// request, but with the reply's id-pkinit-DHKeyData eContentType.
+func signReplyContentInfo(t *testing.T, signKey *rsa.PrivateKey, signerCert *x509.Certificate, digest crypto.Hash, signedEContent, embedEContent []byte) []byte {
+	t.Helper()
+
+	// signedAttrs: content-type = id-pkinit-DHKeyData, message-digest =
+	// H(signedEContent), each wrapped as a SET OF with one value.
+	ctSet := marshalSetOf(mustMarshal(t, oidIDPKINITDHKeyData))
+	mdSet := marshalSetOf(mustMarshal(t, hashBytes(digest, signedEContent)))
+	attrs := []attribute{
+		{Type: oidContentType, Values: asn1.RawValue{FullBytes: ctSet}},
+		{Type: oidMessageDigest, Values: asn1.RawValue{FullBytes: mdSet}},
+	}
+
+	// Signature is over the DER of signedAttrs as an EXPLICIT SET OF.
+	signedAttrsSet, err := marshalAttributesSet(attrs)
+	if err != nil {
+		t.Fatalf("marshalAttributesSet: %v", err)
+	}
+	signature, err := rsa.SignPKCS1v15(rand.Reader, signKey, digest, hashBytes(digest, signedAttrsSet))
+	if err != nil {
+		t.Fatalf("SignPKCS1v15: %v", err)
+	}
+
+	// Re-tag signedAttrs as [0] IMPLICIT for the SignerInfo.
+	var tmp asn1.RawValue
+	if _, err := asn1.Unmarshal(signedAttrsSet, &tmp); err != nil {
+		t.Fatalf("unmarshal signedAttrs: %v", err)
+	}
+	signedAttrsImplicit := mustMarshal(t, asn1.RawValue{Class: asn1.ClassContextSpecific, Tag: 0, IsCompound: true, Bytes: tmp.Bytes})
+
+	digOID := digestOIDFor(digest)
+	si := signerInfo{
+		Version: 1,
+		SID: issuerAndSerialNumber{
+			Issuer:       asn1.RawValue{FullBytes: signerCert.RawIssuer},
+			SerialNumber: signerCert.SerialNumber,
+		},
+		DigestAlgorithm:    algorithmIdentifier{Algorithm: digOID, Parameters: asn1.RawValue{FullBytes: nullDER}},
+		SignedAttrs:        asn1.RawValue{FullBytes: signedAttrsImplicit},
+		SignatureAlgorithm: algorithmIdentifier{Algorithm: oidRSAEncryption, Parameters: asn1.RawValue{FullBytes: nullDER}},
+		Signature:          signature,
+	}
+	digAlg := mustMarshal(t, algorithmIdentifier{Algorithm: digOID, Parameters: asn1.RawValue{FullBytes: nullDER}})
+	sd := signedData{
+		Version:          3,
+		DigestAlgorithms: asn1.RawValue{FullBytes: marshalSetOf(digAlg)},
+		EncapContentInfo: encapsulatedContentInfo{EContentType: oidIDPKINITDHKeyData, EContent: embedEContent},
+		Certificates:     asn1.RawValue{Class: asn1.ClassContextSpecific, Tag: 0, IsCompound: true, Bytes: signerCert.Raw},
+		SignerInfos:      asn1.RawValue{FullBytes: marshalSetOf(mustMarshal(t, si))},
+	}
+	ci := contentInfo{
+		ContentType: oidSignedData,
+		Content:     asn1.RawValue{Class: asn1.ClassContextSpecific, Tag: 0, IsCompound: true, Bytes: mustMarshal(t, sd)},
+	}
+	return mustMarshal(t, ci)
+}
+
+// makeCAAndLeaf generates a CA certificate and a leaf certificate signed by it,
+// returning the CA cert, the leaf cert and the leaf's private key.
+func makeCAAndLeaf(t *testing.T) (caCert, leafCert *x509.Certificate, leafKey *rsa.PrivateKey) {
+	t.Helper()
+	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate CA key: %v", err)
+	}
+	caTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Test PKINIT CA"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("create CA cert: %v", err)
+	}
+	caCert, err = x509.ParseCertificate(caDER)
+	if err != nil {
+		t.Fatalf("parse CA cert: %v", err)
+	}
+
+	leafKey, err = rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate leaf key: %v", err)
+	}
+	leafTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(2),
+		Subject:               pkix.Name{CommonName: "kdc.test.local"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTmpl, caCert, &leafKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("create leaf cert: %v", err)
+	}
+	leafCert, err = x509.ParseCertificate(leafDER)
+	if err != nil {
+		t.Fatalf("parse leaf cert: %v", err)
+	}
+	return caCert, leafCert, leafKey
+}
+
+// TestVerifySignedDataEContent exercises the RFC 4556 §3.2.4 KDC signature
+// verifier over crafted CMS SignedData replies.
+func TestVerifySignedDataEContent(t *testing.T) {
+	// A realistic eContent (a KDCDHKeyInfo DER).
+	group := MODPGroup2()
+	kdcKP, err := GenerateDHKeyPair(group)
+	if err != nil {
+		t.Fatalf("GenerateDHKeyPair: %v", err)
+	}
+	yBytes := mustMarshal(t, kdcKP.Y)
+	eContent := mustMarshal(t, kdcDHKeyInfo{
+		SubjectPublicKey: asn1.BitString{Bytes: yBytes, BitLength: len(yBytes) * 8},
+		Nonce:            7,
+	})
+
+	// A self-signed KDC certificate (the pin / self-signed lab case).
+	selfKey, selfCertDER, err := GenerateSelfSignedCert(2048, "self-signed-kdc")
+	if err != nil {
+		t.Fatalf("GenerateSelfSignedCert: %v", err)
+	}
+	selfCert, err := x509.ParseCertificate(selfCertDER)
+	if err != nil {
+		t.Fatalf("parse self-signed cert: %v", err)
+	}
+
+	// A CA-issued KDC certificate (the enterprise-CA chain case).
+	caCert, leafCert, leafKey := makeCAAndLeaf(t)
+
+	// A foreign key/cert used as a wrong anchor.
+	_, otherCertDER, err := GenerateSelfSignedCert(2048, "other-kdc")
+	if err != nil {
+		t.Fatalf("GenerateSelfSignedCert(other): %v", err)
+	}
+	otherCert, err := x509.ParseCertificate(otherCertDER)
+	if err != nil {
+		t.Fatalf("parse other cert: %v", err)
+	}
+
+	tamperedEContent := append([]byte(nil), eContent...)
+	tamperedEContent[len(tamperedEContent)-1] ^= 0xFF
+
+	tests := []struct {
+		name    string
+		ci      []byte
+		opts    *VerifyOptions
+		wantErr bool
+	}{
+		{
+			name: "valid self-signed pinned",
+			ci:   signReplyContentInfo(t, selfKey, selfCert, crypto.SHA1, eContent, eContent),
+			opts: &VerifyOptions{Anchors: []*x509.Certificate{selfCert}},
+		},
+		{
+			name: "valid sha256 self-signed pinned",
+			ci:   signReplyContentInfo(t, selfKey, selfCert, crypto.SHA256, eContent, eContent),
+			opts: &VerifyOptions{Anchors: []*x509.Certificate{selfCert}},
+		},
+		{
+			name: "valid chain to CA",
+			ci:   signReplyContentInfo(t, leafKey, leafCert, crypto.SHA1, eContent, eContent),
+			opts: &VerifyOptions{Anchors: []*x509.Certificate{caCert}},
+		},
+		{
+			name: "nil opts skips verification",
+			ci:   signReplyContentInfo(t, selfKey, selfCert, crypto.SHA1, eContent, eContent),
+			opts: nil,
+		},
+		{
+			name: "explicit insecure skip",
+			ci:   signReplyContentInfo(t, selfKey, selfCert, crypto.SHA1, eContent, eContent),
+			opts: &VerifyOptions{InsecureSkipSignatureCheck: true},
+		},
+		{
+			name:    "bad signature (foreign signing key)",
+			ci:      signReplyContentInfo(t, leafKey, selfCert, crypto.SHA1, eContent, eContent),
+			opts:    &VerifyOptions{Anchors: []*x509.Certificate{selfCert}},
+			wantErr: true,
+		},
+		{
+			name:    "tampered eContent (messageDigest mismatch)",
+			ci:      signReplyContentInfo(t, selfKey, selfCert, crypto.SHA1, eContent, tamperedEContent),
+			opts:    &VerifyOptions{Anchors: []*x509.Certificate{selfCert}},
+			wantErr: true,
+		},
+		{
+			name:    "wrong anchor (no chain)",
+			ci:      signReplyContentInfo(t, leafKey, leafCert, crypto.SHA1, eContent, eContent),
+			opts:    &VerifyOptions{Anchors: []*x509.Certificate{otherCert}},
+			wantErr: true,
+		},
+		{
+			name:    "verification enabled but no anchor",
+			ci:      signReplyContentInfo(t, selfKey, selfCert, crypto.SHA1, eContent, eContent),
+			opts:    &VerifyOptions{},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := verifySignedDataEContent(tc.ci, tc.opts)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil (eContent len %d)", len(got))
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) == 0 {
+				t.Fatal("returned empty eContent")
+			}
+		})
+	}
+}

--- a/network/kerberos/v5/pkinit/pkinit.go
+++ b/network/kerberos/v5/pkinit/pkinit.go
@@ -89,7 +89,12 @@ type Reply struct {
 // 17), extracting the KDC's DH public value and server DH nonce from the
 // dhSignedData/KDCDHKeyInfo. It only supports the Diffie-Hellman (dhInfo)
 // variant.
-func ParseASRepPAData(paValue []byte) (*Reply, error) {
+//
+// opts controls verification of the KDC's CMS SignedData signature over the
+// KDCDHKeyInfo (RFC 4556 §3.2.4): when it supplies a trust anchor the signature
+// and certificate chain are verified and parsing fails closed on any mismatch;
+// a nil opts (or one with InsecureSkipSignatureCheck) skips that check.
+func ParseASRepPAData(paValue []byte, opts *VerifyOptions) (*Reply, error) {
 	// PA-PK-AS-REP ::= CHOICE { dhInfo [0] DHRepInfo, encKeyPack [1] ... }.
 	var outer asn1.RawValue
 	if _, err := asn1.Unmarshal(paValue, &outer); err != nil {
@@ -107,7 +112,7 @@ func ParseASRepPAData(paValue []byte) (*Reply, error) {
 		return nil, err
 	}
 
-	eContent, err := extractSignedDataEContent(dhSignedData)
+	eContent, err := verifySignedDataEContent(dhSignedData, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/network/kerberos/v5/pkinit/pkinit_test.go
+++ b/network/kerberos/v5/pkinit/pkinit_test.go
@@ -139,7 +139,7 @@ func TestFullExchangeRoundTrip(t *testing.T) {
 
 	replyPA := buildSyntheticASRep(t, kdcKP, serverNonce)
 
-	reply, err := ParseASRepPAData(replyPA)
+	reply, err := ParseASRepPAData(replyPA, nil)
 	if err != nil {
 		t.Fatalf("ParseASRepPAData: %v", err)
 	}


### PR DESCRIPTION
### Linked Issue
`Closes #994`

### Root Cause
The PKINIT client parsed the KDC reply's CMS `SignedData` only to pull the `KDCDHKeyInfo` eContent out of it (`pkinit/cms.go`, the old `extractSignedDataEContent`), explicitly not verifying the KDC's signature — it trusted the DH public value after the AS-REP enc-part decrypted. RFC 4556 §3.2.4 requires the client to verify the KDC's signature over `KDCDHKeyInfo`, chained to a trusted KDC/CA certificate, before trusting the DH value; without it a man-in-the-middle able to substitute a DH value is not caught by the signature (only, weakly, by the reply-key check).

### Fix Description
Added a self-contained CMS `SignedData` verifier using `encoding/asn1`, `crypto/x509` and `crypto/rsa` (no new dependencies):

- Parses the signer certificate(s), the single `SignerInfo` (signedAttrs, digest/signature algorithms, signature).
- Confirms `eContentType` is `id-pkinit-DHKeyData` (1.3.6.1.5.2.3.2).
- Recomputes the eContent digest and requires it to equal the signed `messageDigest` attribute, then verifies the RSA signature over the DER **re-encoding of `signedAttrs` as an EXPLICIT `SET OF` (0x31)** — not the `[0]` IMPLICIT tag the SignerInfo carries (RFC 5652 §5.4, the classic CMS re-encoding gotcha). SHA-1/SHA-256 digests and `rsaEncryption` / `sha1WithRSAEncryption` / `sha256WithRSAEncryption` are supported.
- Verifies the signer certificate chains to a caller-supplied anchor via `x509`, or accepts a byte-identical pinned certificate directly (covering a self-signed KDC).

Client options: `WithPKINITKDCCert` (pin the KDC signing cert), `WithPKINITAnchors` (trust a CA/root), `InsecureSkipPKINITKDCSignatureCheck` (explicit opt-out). Verification is on by default whenever an anchor is supplied and **fails closed** on a bad/absent signature or broken chain; with no anchor and no opt-out the signature is left unverified, preserving the legacy exchange (documented on the options).

### How Verified
Validated against a **genuine captured Windows Server 2016 KDC PKINIT AS-REP** (realm TMP-W-2016.LOCAL), plus offline crafted vectors:

- Genuine KDC signature (SHA-1 + rsaEncryption) **verified** with the real KDC cert pinned as anchor.
- Genuine KDC leaf cert **chains** to the live enterprise CA (`TMP-W-2016-TMP-W-2016-CA`, fetched from the DC over LDAP) used as anchor.
- Tampering one byte of the KDC signature is **rejected** (`crypto/rsa: verification error`).
- A wrong anchor is **rejected** (`certificate signed by unknown authority`).
- Legacy nil-options path still parses the genuine reply without verifying.

`go build ./...`, `go vet ./network/kerberos/...` and `go test ./network/kerberos/...` are green.

### Test Coverage
- **Added:** `network/kerberos/v5/pkinit/cms_verify_test.go` — `TestVerifySignedDataEContent`, a table covering valid pinned (SHA-1 and SHA-256), valid chain-to-CA, nil-opts skip, explicit insecure skip, bad signature, tampered eContent (messageDigest mismatch), wrong anchor, and verification-enabled-but-no-anchor.

### Scope of Change
- **Files changed:** `pkinit/cms.go`, `pkinit/asn1.go`, `pkinit/pkinit.go`, `pkinit/pkinit_test.go`, `pkinit/cms_verify_test.go`, `client.go`, `client_pkinit.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none. `ParseASRepPAData` gained a `*VerifyOptions` parameter; the sole in-tree caller is updated.

### Risk and Rollout
Low blast radius, confined to the PKINIT reply path. Default behaviour is unchanged for callers that supply no anchor (signature still unverified, as before); the new gate only engages when an anchor is configured. Safe to merge without staged rollout.

### Notes
The live end-to-end used the captured `pk_asrep.bin` (a real Windows KDC reply) rather than a fresh AS exchange, because the shadow-credentials helper used to mint a fresh PKINIT client is not part of this repository; signature verification is independent of the client's ephemeral DH state, so the captured genuine reply exercises the verifier fully.