### PR TITLE
Extend FAST armoring to the TGS exchange (Fixes #996)

### DIFF
--- a/network/kerberos/v5/fast_tgs.go
+++ b/network/kerberos/v5/fast_tgs.go
@@ -1,0 +1,323 @@
+package kerberos
+
+import (
+	"crypto/rand"
+	"encoding/asn1"
+	"encoding/binary"
+	"fmt"
+	"time"
+
+	kerbcrypto "github.com/TheManticoreProject/Manticore/network/kerberos/v5/crypto"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/messages"
+)
+
+// This file extends RFC 6113 FAST (Kerberos armoring) to the TGS exchange, as a
+// companion to the AS-exchange path in fast.go.
+//
+// The TGS armor is not a separate FX_FAST_ARMOR_AP_REQUEST. RFC 6113 §5.4.2
+// specifies that when the ticket presented in the PA-TGS-REQ authenticator is a
+// TGT, the client omits the KrbFastArmoredReq armor field entirely and instead
+// places a subkey in that PA-TGS-REQ authenticator. The armor key is then
+// computed exactly as for FX_FAST_ARMOR_AP_REQUEST (RFC 6113 §5.4.1.1) —
+// KRB-FX-CF2(subkey, ticket-session-key, "subkeyarmor", "ticketarmor") — but the
+// "ticket" is the TGT being presented in the TGS-REQ and the subkey is the one
+// in its AP-REQ authenticator.
+//
+// Two further TGS-specific rules distinguish this from the AS path:
+//   - the req-checksum (key usage 50) is computed over the AP-REQ in the
+//     PA-TGS-REQ padata, not over the outer KDC-REQ-BODY (RFC 6113 §5.4.2); and
+//   - the KDC MUST return a strengthen-key in the TGS reply, so the reply key is
+//     always KRB-FX-CF2(strengthen-key, subkey, "strengthenkey", "replykey")
+//     and the reply enc-part is keyed by the sub-session key (usage 9)
+//     (RFC 6113 §5.4.3).
+
+// fastTGSContext carries the per-request FAST state a TGS reply needs to be
+// unwrapped: the armor key (to decrypt the KrbFastResponse), the authenticator
+// subkey (the base reply key the strengthen-key is combined with), and the inner
+// request nonce the reply must echo.
+type fastTGSContext struct {
+	armorKey    []byte
+	armorEType  int
+	subkey      []byte
+	subkeyEType int
+	nonce       int
+}
+
+// buildTGSAPReqWithSubkey builds the PA-TGS-REQ AP-REQ that presents tgt, with
+// the given subkey placed in the authenticator (RFC 6113 §5.4.2 requires the
+// subkey for TGS armoring). The authenticator is encrypted with the TGT session
+// key under key usage 7 (the PA-TGS-REQ authenticator usage).
+func (c *KerberosClient) buildTGSAPReqWithSubkey(tgt messages.Ticket, tgtRaw, sessionKey []byte, sessionEType int, subkey []byte) ([]byte, error) {
+	now := c.now()
+
+	var seqBuf [4]byte
+	if _, err := rand.Read(seqBuf[:]); err != nil {
+		return nil, err
+	}
+	seqNum := int(binary.BigEndian.Uint32(seqBuf[:]) & 0x7fffffff)
+
+	auth := &messages.Authenticator{
+		AVno:      messages.KerberosV5,
+		CRealm:    c.realm,
+		CName:     messages.PrincipalName{NameType: messages.NameTypePrincipal, NameString: []string{c.username}},
+		CUSec:     now.Nanosecond() / 1000,
+		CTime:     now,
+		SubKey:    &messages.EncryptionKey{KeyType: sessionEType, KeyValue: subkey},
+		SeqNumber: seqNum,
+	}
+	authBytes, err := auth.Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("marshal TGS Authenticator: %w", err)
+	}
+	encAuth, err := kerbcrypto.Encrypt(sessionEType, sessionKey, kerbcrypto.KeyUsageTGSReqPAAPReqAuthen, authBytes)
+	if err != nil {
+		return nil, fmt.Errorf("encrypt TGS Authenticator: %w", err)
+	}
+
+	apReq := &messages.APReq{
+		PVNO:      messages.KerberosV5,
+		MsgType:   messages.MsgTypeAPReq,
+		APOptions: asn1.BitString{Bytes: []byte{0x00, 0x00, 0x00, 0x00}, BitLength: 32},
+		Ticket:    tgt,
+		TicketRaw: tgtRaw,
+		Authenticator: messages.EncryptedData{
+			EType:  sessionEType,
+			Cipher: encAuth,
+		},
+	}
+	return apReq.Marshal()
+}
+
+// tgsReqBody builds the KDC-REQ-BODY for a service-ticket request toward sname in
+// bodyRealm. It mirrors the body assembled by the non-FAST tgsExchange so the
+// armored (inner) request the KDC honors is identical in shape.
+func (c *KerberosClient) tgsReqBody(bodyRealm string, sname messages.PrincipalName, nonce int) messages.KDCReqBody {
+	return messages.KDCReqBody{
+		KDCOptions: kdcOptionsForTGSReq(),
+		Realm:      bodyRealm,
+		SName:      sname,
+		Till:       c.now().Add(24 * time.Hour),
+		Nonce:      nonce,
+		EType:      c.serviceTicketETypes(),
+	}
+}
+
+// buildFASTTGSReq assembles a FAST-armored TGS-REQ for sname at the current hop,
+// presenting tgt as both the ticket-granting ticket and (per RFC 6113 §5.4.2) the
+// FAST armor. It returns the marshaled request and the fastTGSContext the reply
+// processor needs. cookie, when non-nil, is echoed as PA-FX-COOKIE in the armored
+// (inner) padata.
+func (c *KerberosClient) buildFASTTGSReq(
+	bodyRealm string,
+	sname messages.PrincipalName,
+	includePAC bool,
+	tgt messages.Ticket, tgtRaw, sessionKey []byte, sessionEType int,
+	cookie *messages.PAData,
+) ([]byte, *fastTGSContext, error) {
+
+	// A fresh subkey carried in the PA-TGS-REQ authenticator; combined with the
+	// TGT session key it yields the armor key (RFC 6113 §5.4.1.1 / §5.4.2). Both
+	// inputs share the TGT session etype, so the armor key adopts that etype.
+	subkey := make([]byte, kerbcrypto.KeyLen(sessionEType))
+	if _, err := rand.Read(subkey); err != nil {
+		return nil, nil, fmt.Errorf("kerberos: FAST TGS subkey: %w", err)
+	}
+	armorKey, armorEType, err := kerbcrypto.KRBFXCF2(
+		subkey, sessionEType,
+		sessionKey, sessionEType,
+		fastPepperSubkeyArmor, fastPepperTicketArmor)
+	if err != nil {
+		return nil, nil, fmt.Errorf("kerberos: derive FAST TGS armor key: %w", err)
+	}
+
+	// The AP-REQ carrying the subkey. It goes verbatim into the outer PA-TGS-REQ
+	// and is also the object the req-checksum covers (RFC 6113 §5.4.2).
+	apReqBytes, err := c.buildTGSAPReqWithSubkey(tgt, tgtRaw, sessionKey, sessionEType, subkey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("kerberos: build FAST TGS AP-REQ: %w", err)
+	}
+
+	// Inner (armor-protected) padata + body. PA-PAC-REQUEST rides inside the armor,
+	// as does the FX-COOKIE to echo when the KDC handed one back. The KDC uses this
+	// inner req-body in preference to the outer, unprotected one.
+	pacBool := byte(0xff)
+	if !includePAC {
+		pacBool = 0x00
+	}
+	innerPAData := []messages.PAData{
+		{PADataType: messages.PAPACRequest, PADataValue: []byte{0x30, 0x05, 0xa0, 0x03, 0x01, 0x01, pacBool}},
+	}
+	if cookie != nil {
+		innerPAData = append(innerPAData, *cookie)
+	}
+	nonce := randomNonce()
+	innerBody := c.tgsReqBody(bodyRealm, sname, nonce)
+
+	fastReq := &messages.KrbFastReq{
+		FastOptions: messages.NewKerberosFlags(),
+		PAData:      innerPAData,
+		ReqBody:     innerBody,
+	}
+	fastReqBytes, err := fastReq.Marshal()
+	if err != nil {
+		return nil, nil, fmt.Errorf("kerberos: marshal KrbFastReq (TGS): %w", err)
+	}
+	encFastReq, err := kerbcrypto.Encrypt(armorEType, armorKey, kerbcrypto.KeyUsageFASTEnc, fastReqBytes)
+	if err != nil {
+		return nil, nil, fmt.Errorf("kerberos: encrypt KrbFastReq (TGS): %w", err)
+	}
+
+	// req-checksum: a keyed checksum over the AP-REQ, computed with the armor key
+	// (RFC 6113 §5.4.2, key usage 50). The TGS case checksums the AP-REQ, not the
+	// KDC-REQ-BODY as the AS case does.
+	cksumType, ok := kerbcrypto.ChecksumTypeForEType(armorEType)
+	if !ok {
+		return nil, nil, fmt.Errorf("kerberos: no checksum type for armor etype %d", armorEType)
+	}
+	cksum, err := kerbcrypto.GetChecksum(cksumType, armorKey, kerbcrypto.KeyUsageFASTReqChksum, apReqBytes)
+	if err != nil {
+		return nil, nil, fmt.Errorf("kerberos: FAST TGS req-checksum: %w", err)
+	}
+
+	// No armor field for the TGS case (RFC 6113 §5.4.2): the armor is the TGT
+	// itself, presented in the PA-TGS-REQ AP-REQ.
+	armoredReq := &messages.KrbFastArmoredReq{
+		ReqChecksum: messages.Checksum{CKSumType: cksumType, Checksum: cksum},
+		EncFastReq:  messages.EncryptedData{EType: armorEType, Cipher: encFastReq},
+	}
+	fastValue, err := messages.MarshalPAFXFastRequest(armoredReq)
+	if err != nil {
+		return nil, nil, fmt.Errorf("kerberos: marshal PA-FX-FAST (TGS): %w", err)
+	}
+
+	// The outer TGS-REQ carries the PA-TGS-REQ (so the KDC can locate the armor
+	// ticket) and PA-FX-FAST. Its body is present but ignored in favor of the
+	// armored inner body, so it uses its own throwaway nonce.
+	tgsReq := &messages.TGSReq{
+		PVNO:    messages.KerberosV5,
+		MsgType: messages.MsgTypeTGSReq,
+		PAData: []messages.PAData{
+			{PADataType: messages.PATGSReq, PADataValue: apReqBytes},
+			{PADataType: messages.PAFXFast, PADataValue: fastValue},
+		},
+		ReqBody: c.tgsReqBody(bodyRealm, sname, randomNonce()),
+	}
+	reqBytes, err := tgsReq.Marshal()
+	if err != nil {
+		return nil, nil, fmt.Errorf("kerberos: marshal FAST TGS-REQ: %w", err)
+	}
+
+	ctx := &fastTGSContext{
+		armorKey:    armorKey,
+		armorEType:  armorEType,
+		subkey:      subkey,
+		subkeyEType: sessionEType,
+		nonce:       nonce,
+	}
+	return reqBytes, ctx, nil
+}
+
+// processFASTTGSRep parses a FAST-armored TGS reply. On a TGS-REP it decrypts the
+// KrbFastResponse with the armor key (usage 52), derives the strengthened reply
+// key (RFC 6113 §5.4.3 mandates strengthen-key for TGS) from the authenticator
+// subkey, decrypts the TGS-REP enc-part with it (usage 9, the sub-session key),
+// and returns the parsed ticket and enc-part. A KRB-ERROR is returned as
+// *messages.KRBError (with a nil error) so the caller can react to a recoverable
+// code; any FAST-armored inner error is preferred and an FX-COOKIE to echo on a
+// retry is surfaced.
+func (c *KerberosClient) processFASTTGSRep(resp []byte, ctx *fastTGSContext) (*messages.TGSRep, *messages.EncTGSRepPart, *messages.KRBError, *messages.PAData, error) {
+	var krbErr messages.KRBError
+	if _, parseErr := krbErr.Unmarshal(resp); parseErr == nil {
+		innerErr, cookie, _ := c.parseFASTError(krbErr, ctx.armorKey, ctx.armorEType)
+		effective := krbErr
+		if innerErr != nil {
+			effective = *innerErr
+		}
+		return nil, nil, &effective, cookie, nil
+	}
+
+	var tgsRep messages.TGSRep
+	if _, err := tgsRep.Unmarshal(resp); err != nil {
+		return nil, nil, nil, nil, fmt.Errorf("kerberos: parse FAST TGS-REP: %w", err)
+	}
+
+	fastResp, err := c.decryptFASTReply(tgsRep.PAData, ctx.armorKey, ctx.armorEType)
+	if err != nil {
+		return nil, nil, nil, nil, fmt.Errorf("kerberos: decrypt FAST TGS reply: %w", err)
+	}
+	if fastResp.Nonce != ctx.nonce {
+		return nil, nil, nil, nil, fmt.Errorf("kerberos: FAST TGS response nonce mismatch: got %d, want %d", fastResp.Nonce, ctx.nonce)
+	}
+
+	// The base reply key is the authenticator sub-session key; the KDC MUST
+	// strengthen it for TGS (RFC 6113 §5.4.3). The strengthened key replaces the
+	// key value but not the usage: a subkey was sent, so the enc-part is keyed by
+	// the sub-session key (usage 9).
+	replyKey := ctx.subkey
+	replyEType := ctx.subkeyEType
+	if fastResp.StrengthenKey != nil {
+		sk := fastResp.StrengthenKey
+		replyKey, replyEType, err = kerbcrypto.KRBFXCF2(
+			sk.KeyValue, sk.KeyType, ctx.subkey, ctx.subkeyEType,
+			fastPepperStrengthenKey, fastPepperReplyKey)
+		if err != nil {
+			return nil, nil, nil, nil, fmt.Errorf("kerberos: strengthen TGS reply key: %w", err)
+		}
+	}
+
+	encPlain, err := kerbcrypto.Decrypt(replyEType, replyKey, kerbcrypto.KeyUsageTGSRepEncSubSessionKey, tgsRep.EncPart.Cipher)
+	if err != nil {
+		return nil, nil, nil, nil, fmt.Errorf("kerberos: decrypt FAST TGS-REP enc-part: %w", err)
+	}
+	var encRep messages.EncTGSRepPart
+	if _, err := encRep.Unmarshal(encPlain); err != nil {
+		return nil, nil, nil, nil, fmt.Errorf("kerberos: parse EncTGSRepPart: %w", err)
+	}
+	if encRep.Nonce != ctx.nonce {
+		return nil, nil, nil, nil, fmt.Errorf("kerberos: FAST TGS-REP nonce mismatch: got %d, want %d", encRep.Nonce, ctx.nonce)
+	}
+	return &tgsRep, &encRep, nil, nil, nil
+}
+
+// tgsExchangeFAST performs a single FAST-armored TGS-REQ/REP round-trip against
+// the given KDC endpoints, presenting tgt as both the ticket-granting ticket and
+// the FAST armor. It mirrors the return contract of the non-FAST tgsExchange: a
+// KRB-ERROR is returned as *messages.KRBError (nil error) so the chase loop can
+// react to WRONG_REALM / KRB_AP_ERR_SKEW. A single FX-COOKIE handed back inside a
+// FAST-armored error is echoed on one retry (RFC 6113 §5.4.4.3).
+func (c *KerberosClient) tgsExchangeFAST(
+	bodyRealm string,
+	endpoints []kdcEndpoint,
+	sname messages.PrincipalName,
+	includePAC bool,
+	tgt messages.Ticket, tgtRaw, sessionKey []byte, sessionEType int,
+) (*messages.TGSRep, *messages.EncTGSRepPart, *messages.KRBError, error) {
+
+	var cookie *messages.PAData
+	for attempt := 0; attempt < 2; attempt++ {
+		reqBytes, ctx, err := c.buildFASTTGSReq(bodyRealm, sname, includePAC, tgt, tgtRaw, sessionKey, sessionEType, cookie)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		resp, err := kdcSendEndpoints(c.resolver, endpoints, reqBytes)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+
+		rep, encRep, krbErr, newCookie, err := c.processFASTTGSRep(resp, ctx)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		if krbErr != nil {
+			// A cookie handed back on the first attempt is echoed once; any other
+			// error (WRONG_REALM, SKEW, hard failure) is handed to the chase loop.
+			if newCookie != nil && cookie == nil && attempt == 0 {
+				cookie = newCookie
+				continue
+			}
+			return nil, nil, krbErr, nil
+		}
+		return rep, encRep, nil, nil
+	}
+	return nil, nil, nil, fmt.Errorf("kerberos: FAST TGS: retry budget exhausted")
+}

--- a/network/kerberos/v5/fast_tgs_test.go
+++ b/network/kerberos/v5/fast_tgs_test.go
@@ -1,0 +1,244 @@
+package kerberos
+
+import (
+	"bytes"
+	"encoding/asn1"
+	"testing"
+
+	kerbcrypto "github.com/TheManticoreProject/Manticore/network/kerberos/v5/crypto"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/messages"
+)
+
+// fastTGSClient returns a client holding a usable (hand-built) TGT with a known
+// AES256 session key and FAST enabled, so the TGS-exchange FAST assembly helpers
+// can run without a KDC. The TGT session key doubles as the armor "ticket"
+// session key per RFC 6113 §5.4.2.
+func fastTGSClient(t *testing.T, sessionKey []byte, sessionEType int) *KerberosClient {
+	t.Helper()
+	tkt := messages.Ticket{
+		TktVno:  messages.KerberosV5,
+		Realm:   testRealm,
+		SName:   messages.PrincipalName{NameType: messages.NameTypeSRVInst, NameString: []string{"krbtgt", testRealm}},
+		EncPart: messages.EncryptedData{EType: sessionEType, Cipher: bytes.Repeat([]byte{0x7a}, 32)},
+	}
+	raw, err := tkt.Marshal()
+	if err != nil {
+		t.Fatalf("Ticket.Marshal: %v", err)
+	}
+	c := NewClient("alice", testRealm, "10.0.0.1").WithPassword("Passw0rd!")
+	c.tgtTicket = tkt
+	c.tgtTicketRaw = raw
+	c.sessionKey = sessionKey
+	c.sessionEType = sessionEType
+	c.hasTGT = true
+	// Enabling FAST via a self-armor is only what flips GetTGS onto the FAST path;
+	// the TGS armor itself is the client's own TGT (set above), not this field.
+	c.WithFASTArmor(c.username, c.realm, tkt, raw, sessionKey, sessionEType)
+	return c
+}
+
+// parseFASTTGSReq decodes a FAST-armored TGS-REQ, returning the parsed outer
+// request, the AP-REQ bytes carried in the PA-TGS-REQ, and the KrbFastArmoredReq
+// unwrapped from PA-FX-FAST.
+func parseFASTTGSReq(t *testing.T, reqBytes []byte) (messages.TGSReq, []byte, messages.KrbFastArmoredReq) {
+	t.Helper()
+	var tgsReq messages.TGSReq
+	if _, err := tgsReq.Unmarshal(reqBytes); err != nil {
+		t.Fatalf("parse FAST TGS-REQ: %v", err)
+	}
+
+	var apReqBytes, fastValue []byte
+	for _, pa := range tgsReq.PAData {
+		switch pa.PADataType {
+		case messages.PATGSReq:
+			apReqBytes = pa.PADataValue
+		case messages.PAFXFast:
+			fastValue = pa.PADataValue
+		}
+	}
+	if apReqBytes == nil {
+		t.Fatal("FAST TGS-REQ missing PA-TGS-REQ")
+	}
+	if fastValue == nil {
+		t.Fatal("FAST TGS-REQ missing PA-FX-FAST")
+	}
+
+	// PA-FX-FAST-REQUEST is a CHOICE: [0] EXPLICIT KrbFastArmoredReq.
+	var choice asn1.RawValue
+	if _, err := asn1.Unmarshal(fastValue, &choice); err != nil {
+		t.Fatalf("parse PA-FX-FAST CHOICE: %v", err)
+	}
+	if choice.Class != asn1.ClassContextSpecific || choice.Tag != 0 {
+		t.Fatalf("PA-FX-FAST alternative class=%d tag=%d, want context [0]", choice.Class, choice.Tag)
+	}
+	var armored messages.KrbFastArmoredReq
+	if _, err := armored.Unmarshal(choice.Bytes); err != nil {
+		t.Fatalf("parse KrbFastArmoredReq: %v", err)
+	}
+	return tgsReq, apReqBytes, armored
+}
+
+// TestBuildFASTTGSReqStructure verifies the wire shape of a FAST-armored TGS-REQ:
+// the outer request carries both PA-TGS-REQ and PA-FX-FAST, and the armored
+// request omits the armor field (RFC 6113 §5.4.2: the armor is the TGT itself).
+func TestBuildFASTTGSReqStructure(t *testing.T) {
+	sessionKey := bytes.Repeat([]byte{0x24}, kerbcrypto.KeyLen(messages.ETypeAES256CTSHMACSHA196))
+	c := fastTGSClient(t, sessionKey, messages.ETypeAES256CTSHMACSHA196)
+	sname := messages.PrincipalName{NameType: messages.NameTypeSRVInst, NameString: []string{"cifs", "host.corp.local"}}
+
+	reqBytes, ctx, err := c.buildFASTTGSReq(testRealm, sname, true, c.tgtTicket, c.tgtTicketRaw, c.sessionKey, c.sessionEType, nil)
+	if err != nil {
+		t.Fatalf("buildFASTTGSReq: %v", err)
+	}
+
+	_, apReqBytes, armored := parseFASTTGSReq(t, reqBytes)
+
+	if armored.Armor != nil {
+		t.Errorf("TGS KrbFastArmoredReq must omit the armor field, got %+v", armored.Armor)
+	}
+	if len(apReqBytes) == 0 {
+		t.Fatal("PA-TGS-REQ carried no AP-REQ bytes")
+	}
+	if len(armored.EncFastReq.Cipher) == 0 {
+		t.Fatal("enc-fast-req is empty")
+	}
+	if ctx.armorEType != c.sessionEType {
+		t.Errorf("armor etype = %d, want TGT session etype %d", ctx.armorEType, c.sessionEType)
+	}
+	if len(ctx.subkey) != kerbcrypto.KeyLen(c.sessionEType) {
+		t.Errorf("subkey length = %d, want %d", len(ctx.subkey), kerbcrypto.KeyLen(c.sessionEType))
+	}
+}
+
+// TestFASTTGSArmorKeyFromAuthenticatorSubkey is the crux of the TGS FAST rule
+// (RFC 6113 §5.4.1.1 / §5.4.2): the armor key MUST be derived from the subkey in
+// the PA-TGS-REQ authenticator combined with the TGT session key via KRB-FX-CF2
+// under the "subkeyarmor"/"ticketarmor" peppers. It recovers the subkey from the
+// AP-REQ authenticator (decrypting with the TGT session key at key usage 7) and
+// reproduces the armor key the builder returned.
+func TestFASTTGSArmorKeyFromAuthenticatorSubkey(t *testing.T) {
+	sessionKey := bytes.Repeat([]byte{0x51}, kerbcrypto.KeyLen(messages.ETypeAES256CTSHMACSHA196))
+	c := fastTGSClient(t, sessionKey, messages.ETypeAES256CTSHMACSHA196)
+	sname := messages.PrincipalName{NameType: messages.NameTypeSRVInst, NameString: []string{"cifs", "host.corp.local"}}
+
+	reqBytes, ctx, err := c.buildFASTTGSReq(testRealm, sname, true, c.tgtTicket, c.tgtTicketRaw, c.sessionKey, c.sessionEType, nil)
+	if err != nil {
+		t.Fatalf("buildFASTTGSReq: %v", err)
+	}
+	_, apReqBytes, armored := parseFASTTGSReq(t, reqBytes)
+
+	// Recover the authenticator subkey (encrypted under the TGT session key, key
+	// usage 7 — the PA-TGS-REQ authenticator usage).
+	var apReq messages.APReq
+	if _, err := apReq.Unmarshal(apReqBytes); err != nil {
+		t.Fatalf("parse AP-REQ: %v", err)
+	}
+	authBytes, err := kerbcrypto.Decrypt(c.sessionEType, c.sessionKey, kerbcrypto.KeyUsageTGSReqPAAPReqAuthen, apReq.Authenticator.Cipher)
+	if err != nil {
+		t.Fatalf("decrypt TGS authenticator: %v", err)
+	}
+	var auth messages.Authenticator
+	if _, err := auth.Unmarshal(authBytes); err != nil {
+		t.Fatalf("parse TGS authenticator: %v", err)
+	}
+	if auth.SubKey == nil {
+		t.Fatal("PA-TGS-REQ authenticator carries no subkey (required for TGS FAST)")
+	}
+	if !bytes.Equal(auth.SubKey.KeyValue, ctx.subkey) {
+		t.Errorf("authenticator subkey %x != builder subkey %x", auth.SubKey.KeyValue, ctx.subkey)
+	}
+
+	// The armor key must equal KRB-FX-CF2(subkey, TGT-session-key, peppers).
+	wantArmor, wantEType, err := kerbcrypto.KRBFXCF2(
+		auth.SubKey.KeyValue, auth.SubKey.KeyType,
+		c.sessionKey, c.sessionEType,
+		fastPepperSubkeyArmor, fastPepperTicketArmor)
+	if err != nil {
+		t.Fatalf("KRBFXCF2: %v", err)
+	}
+	if !bytes.Equal(wantArmor, ctx.armorKey) || wantEType != ctx.armorEType {
+		t.Errorf("armor key mismatch: got %x/%d, want %x/%d", ctx.armorKey, ctx.armorEType, wantArmor, wantEType)
+	}
+
+	// The req-checksum MUST be a keyed checksum over the AP-REQ (not the
+	// KDC-REQ-BODY) computed with the armor key at key usage 50.
+	if !kerbcrypto.VerifyChecksum(armored.ReqChecksum.CKSumType, ctx.armorKey, kerbcrypto.KeyUsageFASTReqChksum, apReqBytes, armored.ReqChecksum.Checksum) {
+		t.Error("req-checksum does not verify over the AP-REQ with the armor key")
+	}
+}
+
+// TestFASTTGSReqRoundTrip round-trips the armored KrbFastReq: decrypting
+// enc-fast-req with the armor key (key usage 51) must recover the inner request
+// with the requested SPN and the inner nonce the reply is expected to echo.
+func TestFASTTGSReqRoundTrip(t *testing.T) {
+	sessionKey := bytes.Repeat([]byte{0x66}, kerbcrypto.KeyLen(messages.ETypeAES256CTSHMACSHA196))
+	c := fastTGSClient(t, sessionKey, messages.ETypeAES256CTSHMACSHA196)
+	sname := messages.PrincipalName{NameType: messages.NameTypeSRVInst, NameString: []string{"cifs", "host.corp.local"}}
+
+	reqBytes, ctx, err := c.buildFASTTGSReq(testRealm, sname, true, c.tgtTicket, c.tgtTicketRaw, c.sessionKey, c.sessionEType, nil)
+	if err != nil {
+		t.Fatalf("buildFASTTGSReq: %v", err)
+	}
+	_, _, armored := parseFASTTGSReq(t, reqBytes)
+
+	plain, err := kerbcrypto.Decrypt(armored.EncFastReq.EType, ctx.armorKey, kerbcrypto.KeyUsageFASTEnc, armored.EncFastReq.Cipher)
+	if err != nil {
+		t.Fatalf("decrypt enc-fast-req: %v", err)
+	}
+	var fastReq messages.KrbFastReq
+	if _, err := fastReq.Unmarshal(plain); err != nil {
+		t.Fatalf("parse KrbFastReq: %v", err)
+	}
+	if !principalNameEqualFold(fastReq.ReqBody.SName, sname) {
+		t.Errorf("inner SName = %+v, want %+v", fastReq.ReqBody.SName, sname)
+	}
+	if fastReq.ReqBody.Realm != testRealm {
+		t.Errorf("inner realm = %q, want %q", fastReq.ReqBody.Realm, testRealm)
+	}
+	if fastReq.ReqBody.Nonce != ctx.nonce {
+		t.Errorf("inner nonce = %d, want ctx.nonce %d", fastReq.ReqBody.Nonce, ctx.nonce)
+	}
+	// The armored (inner) padata must carry PA-PAC-REQUEST.
+	var sawPAC bool
+	for _, pa := range fastReq.PAData {
+		if pa.PADataType == messages.PAPACRequest {
+			sawPAC = true
+		}
+	}
+	if !sawPAC {
+		t.Error("inner padata missing PA-PAC-REQUEST")
+	}
+}
+
+// TestFASTTGSCookieEchoed confirms an FX-COOKIE handed to the builder is placed
+// in the armored (inner) padata (RFC 6113 §5.4.4.3 replay cookie echo).
+func TestFASTTGSCookieEchoed(t *testing.T) {
+	sessionKey := bytes.Repeat([]byte{0x77}, kerbcrypto.KeyLen(messages.ETypeAES256CTSHMACSHA196))
+	c := fastTGSClient(t, sessionKey, messages.ETypeAES256CTSHMACSHA196)
+	sname := messages.PrincipalName{NameType: messages.NameTypeSRVInst, NameString: []string{"cifs", "host.corp.local"}}
+	cookie := &messages.PAData{PADataType: messages.PAFXCookie, PADataValue: []byte("opaque-cookie")}
+
+	reqBytes, ctx, err := c.buildFASTTGSReq(testRealm, sname, true, c.tgtTicket, c.tgtTicketRaw, c.sessionKey, c.sessionEType, cookie)
+	if err != nil {
+		t.Fatalf("buildFASTTGSReq: %v", err)
+	}
+	_, _, armored := parseFASTTGSReq(t, reqBytes)
+
+	plain, err := kerbcrypto.Decrypt(armored.EncFastReq.EType, ctx.armorKey, kerbcrypto.KeyUsageFASTEnc, armored.EncFastReq.Cipher)
+	if err != nil {
+		t.Fatalf("decrypt enc-fast-req: %v", err)
+	}
+	var fastReq messages.KrbFastReq
+	if _, err := fastReq.Unmarshal(plain); err != nil {
+		t.Fatalf("parse KrbFastReq: %v", err)
+	}
+	var sawCookie bool
+	for _, pa := range fastReq.PAData {
+		if pa.PADataType == messages.PAFXCookie && bytes.Equal(pa.PADataValue, cookie.PADataValue) {
+			sawCookie = true
+		}
+	}
+	if !sawCookie {
+		t.Error("inner padata did not echo the FX-COOKIE")
+	}
+}

--- a/network/kerberos/v5/live_integration_test.go
+++ b/network/kerberos/v5/live_integration_test.go
@@ -371,6 +371,40 @@ func TestLiveKerberos_FAST(t *testing.T) {
 	t.Logf("[ok] FAST-armored TGT acquired for %s", c.Username())
 }
 
+// TestLiveKerberos_FAST_GetTGS exercises RFC 6113 FAST armoring on the TGS
+// exchange: a FAST-enabled client acquires its TGT over an armored AS-REQ, then
+// requests a service ticket for KRB5_TEST_SPN over an armored TGS-REQ (the TGT is
+// its own armor; the armor key is derived from the subkey in the PA-TGS-REQ
+// authenticator). Skipped unless KRB5_TEST_FAST and KRB5_TEST_SPN are set.
+func TestLiveKerberos_FAST_GetTGS(t *testing.T) {
+	e := requireKrbEnv(t)
+	if os.Getenv("KRB5_TEST_FAST") == "" {
+		t.Skip("set KRB5_TEST_FAST=1 to run the FAST-armored TGS-REQ test (requires KDC armoring support)")
+	}
+	if e.SPN == "" {
+		t.Skip("set KRB5_TEST_SPN to a service principal name to run the FAST GetTGS test")
+	}
+
+	armor := e.newClient()
+	if err := armor.GetTGT(); err != nil {
+		t.Fatalf("armor GetTGT: %v", err)
+	}
+	c := e.newClient().WithFASTArmorFromClient(armor)
+	if err := c.GetTGT(); err != nil {
+		t.Fatalf("GetTGT(FAST): %v", err)
+	}
+
+	ticket, ticketRaw, key, keyEType, err := c.GetTGS(e.SPN, true)
+	if err != nil {
+		t.Fatalf("FAST GetTGS(%q): %v", e.SPN, err)
+	}
+	if len(ticketRaw) == 0 || len(key) == 0 {
+		t.Fatalf("FAST GetTGS(%q) returned empty ticket/key", e.SPN)
+	}
+	t.Logf("[ok] FAST-armored service ticket for %s (sname=%v, session etype=%d)",
+		e.SPN, ticket.SName.NameString, keyEType)
+}
+
 // TestLiveKerberos_Renew acquires a renewable TGT and renews it.
 func TestLiveKerberos_Renew(t *testing.T) {
 	e := requireKrbEnv(t)

--- a/network/kerberos/v5/referral.go
+++ b/network/kerberos/v5/referral.go
@@ -159,6 +159,13 @@ func (c *KerberosClient) tgsExchange(
 	tgt messages.Ticket, tgtRaw, sessionKey []byte, sessionEType int,
 ) (*messages.TGSRep, *messages.EncTGSRepPart, *messages.KRBError, error) {
 
+	// When FAST (RFC 6113 Kerberos armoring) is enabled, armor the exchange with
+	// the TGT being presented at this hop (see fast_tgs.go). The armor is the TGT
+	// itself; no separate armor AP-REQ is used for the TGS case.
+	if c.fast != nil {
+		return c.tgsExchangeFAST(bodyRealm, endpoints, sname, includePAC, tgt, tgtRaw, sessionKey, sessionEType)
+	}
+
 	apReqBytes, err := c.buildAPReqWith(tgt, tgtRaw, sessionKey, sessionEType)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("kerberos: build AP-REQ: %w", err)


### PR DESCRIPTION
## Summary
Extends RFC 6113 FAST (Kerberos armoring) from the AS exchange to the **TGS exchange**, so service tickets can be requested against a realm/DC that requires FAST (armored) for TGS, and FAST-protected reply/error data on TGS is consumed.

## What changed
- New `network/kerberos/v5/fast_tgs.go` implements the TGS-exchange FAST path:
  - Per RFC 6113 §5.4.1.1 / §5.4.2, the TGS armor is the TGT itself — the `KrbFastArmoredReq` **armor field is omitted** and a subkey is placed in the PA-TGS-REQ authenticator.
  - Armor key = `KRB-FX-CF2(subkey, TGT-session-key, "subkeyarmor", "ticketarmor")`.
  - `req-checksum` (key usage 50) is computed over the **AP-REQ** in the PA-TGS-REQ (the TGS rule), not over the KDC-REQ-BODY.
  - `KrbFastReq` is encrypted under the armor key (key usage 51); the outer TGS-REQ carries `PA-TGS-REQ` + `PA-FX-FAST`.
  - On the reply, the strengthen-key (mandatory for TGS, §5.4.3) is combined with the authenticator subkey to derive the reply key; the TGS-REP enc-part is decrypted at key usage 9 (sub-session key).
  - An FX-COOKIE handed back in a FAST-armored error is echoed on one retry.
- `referral.go`: `tgsExchange` routes through the armored path when FAST is enabled, so `GetTGS` and cross-realm referral chasing are both covered behind the existing FAST option. The `messages/fast.go` wire layer is reused unchanged.

## Testing
- `go build ./...`, `go vet ./...`, `go test ./network/kerberos/...` all green.
- New offline unit tests (`fast_tgs_test.go`): assert the PA-FX-FAST-REQUEST structure (no armor field), that the armor key derives from the authenticator subkey + TGT key via KRB-FX-CF2, that the req-checksum verifies over the AP-REQ, and round-trip the KrbFastReq encrypt/decrypt.
- Live-validated against a Windows Server 2016 DC advertising FAST/armoring: a FAST-armored `GetTGS` returns a usable AES256 service ticket, and a wire capture confirmed the outgoing TGS-REQ carried padata-types `[1 136]` (PA-TGS-REQ + PA-FX-FAST-REQUEST) with the reply processed through the FAST response path.