### PR TITLE
Implement the GSSAPI acceptor path AcceptSecContext (Fixes #1000)

### DIFF
--- a/network/kerberos/v5/gssapi/acceptor.go
+++ b/network/kerberos/v5/gssapi/acceptor.go
@@ -1,0 +1,450 @@
+package gssapi
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/md5"
+	"crypto/rand"
+	"encoding/asn1"
+	"encoding/binary"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/credcache/keytab"
+	kerbcrypto "github.com/TheManticoreProject/Manticore/network/kerberos/v5/crypto"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/messages"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/pac"
+)
+
+// The GSS-API acceptor path (RFC 4121 §4.1 / RFC 4120 §3.2). It is the service
+// side of context establishment: it consumes the initiator's KRB_AP_REQ GSS
+// token, decrypts the ticket with the service long-term key, validates the
+// enclosed authenticator (client identity, clock skew, replay, channel
+// bindings), adopts a per-message base key, and — when the initiator asked for
+// mutual authentication — emits the KRB_AP_REP GSS token that proves the service
+// holds the ticket session key. The resulting SecContext drives the same
+// per-message MIC/Wrap layer as the initiator, with the acceptor direction set.
+
+// adTypeIfRelevant / adTypeWin2KPAC are the authorization-data types wrapping the
+// PAC inside a Windows ticket (AD-IF-RELEVANT[1] { AD-WIN2K-PAC[128] }).
+const (
+	adTypeIfRelevant = 1
+	adTypeWin2KPAC   = 128
+)
+
+// DefaultClockSkew is the maximum difference the acceptor tolerates between the
+// authenticator timestamp and its own clock (RFC 4120 §5.3.2 recommends five
+// minutes).
+const DefaultClockSkew = 5 * time.Minute
+
+// ServiceKey is one candidate long-term key the acceptor can try when decrypting
+// the ticket enc-part (key usage 2). It is the explicit-key alternative to a
+// keytab.
+type ServiceKey struct {
+	// EType is the key's Kerberos encryption type (see iana.EType*).
+	EType int
+	// Key is the raw long-term key bytes.
+	Key []byte
+}
+
+// ReplayCache is a minimal in-memory authenticator replay cache (RFC 4120
+// §3.2.3): it remembers the (client, ctime, cusec) tuple of every AP-REQ
+// authenticator seen within the clock-skew window and rejects a repeat. It is
+// safe for concurrent use; a single cache should be shared across all
+// AcceptSecContext calls for one service so replays are caught across contexts.
+type ReplayCache struct {
+	mu      sync.Mutex
+	entries map[string]time.Time // tuple -> expiry (ctime + skew)
+}
+
+// NewReplayCache returns an empty replay cache ready for use.
+func NewReplayCache() *ReplayCache {
+	return &ReplayCache{entries: make(map[string]time.Time)}
+}
+
+// seenBefore records the authenticator tuple and reports whether it was already
+// present (a replay). Expired tuples are pruned as a side effect so the cache
+// does not grow without bound. now is the acceptor's current time.
+func (rc *ReplayCache) seenBefore(tuple string, expiry, now time.Time) bool {
+	rc.mu.Lock()
+	defer rc.mu.Unlock()
+	if rc.entries == nil {
+		rc.entries = make(map[string]time.Time)
+	}
+	for k, exp := range rc.entries {
+		if now.After(exp) {
+			delete(rc.entries, k)
+		}
+	}
+	if _, ok := rc.entries[tuple]; ok {
+		return true
+	}
+	rc.entries[tuple] = expiry
+	return false
+}
+
+// AcceptOptions configures AcceptSecContext.
+type AcceptOptions struct {
+	// Keytab supplies candidate service long-term keys (the preferred source):
+	// every key whose enctype matches the ticket enc-part is tried at key usage 2.
+	Keytab *keytab.Keytab
+	// Keys supplies explicit candidate service keys when no keytab is available.
+	// They are tried after the keytab keys.
+	Keys []ServiceKey
+	// ChannelBindings, when non-nil, are the acceptor's channel bindings: the
+	// authenticator's 0x8003 Bnd field must equal MD5(ChannelBindings) or the
+	// AP-REQ is rejected (GSS_C_BAD_BINDINGS). When nil the initiator's channel
+	// bindings are not verified (RFC 4121 §4.1.1 permits the acceptor to ignore
+	// them).
+	ChannelBindings []byte
+	// ClockSkew is the maximum tolerated difference between the authenticator
+	// timestamp and the acceptor clock. Zero selects DefaultClockSkew.
+	ClockSkew time.Duration
+	// ReplayCache detects replayed authenticators. When nil a fresh single-use
+	// cache is created, giving no cross-call replay protection; callers accepting
+	// more than one context should pass a shared cache.
+	ReplayCache *ReplayCache
+	// MintSubkey makes the acceptor generate its own sub-session key, return it in
+	// the AP-REP (setting the AcceptorSubkey per-message flag), and key per-message
+	// tokens with it. Requires mutual authentication so the initiator learns the
+	// key. When false the authenticator subkey (if any) or the ticket session key
+	// keys the per-message tokens.
+	MintSubkey bool
+	// Now overrides the acceptor's notion of the current time (for testing). Zero
+	// uses time.Now().
+	Now time.Time
+	// DisableReplayDetection turns off the per-message receive-side replay window
+	// (see InitOptions); replay detection is on by default.
+	DisableReplayDetection bool
+	// EnforceSequence additionally rejects per-message tokens delivered out of
+	// order (see InitOptions); off by default.
+	EnforceSequence bool
+}
+
+// AcceptSecContext consumes an initiator's KRB_AP_REQ GSS token and establishes
+// the acceptor (service) side of the context. It parses the InitialContextToken
+// wrapper and the AP-REQ, decrypts the ticket enc-part with a service long-term
+// key (key usage 2, trying keytab and explicit keys), decrypts and validates the
+// authenticator with the ticket session key (key usage 11), enforces client
+// identity, clock skew, replay and — when requested — channel bindings, and
+// adopts a per-message base key. When the AP-REQ set the mutual-required option
+// it returns the KRB_AP_REP GSS token (echoing ctime/cusec, key usage 12); the
+// output token is nil otherwise.
+//
+// The returned SecContext exposes the authenticated client identity
+// (ClientPrincipal), the extracted PAC (PAC), the negotiated session key
+// (SessionKey / SessionEType) and the validated authenticator (Authenticator),
+// and drives the per-message MIC/Wrap layer as the acceptor.
+func AcceptSecContext(token []byte, opts AcceptOptions) (outputToken []byte, ctx *SecContext, err error) {
+	tokID, krbMsg, err := UnwrapToken(token)
+	if err != nil {
+		return nil, nil, err
+	}
+	if tokID != TokIDAPReq {
+		return nil, nil, fmt.Errorf("gssapi: expected AP-REQ token (01 00), got %02x %02x", tokID[0], tokID[1])
+	}
+
+	var apReq messages.APReq
+	if _, err := apReq.Unmarshal(krbMsg); err != nil {
+		return nil, nil, fmt.Errorf("gssapi: parse AP-REQ: %w", err)
+	}
+
+	// Decrypt the ticket enc-part with a service long-term key (key usage 2) and
+	// recover the session key the KDC sealed inside it.
+	encTkt, err := decryptTicket(&apReq.Ticket, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	sessionKey := encTkt.Key.KeyValue
+	sessionEType := encTkt.Key.KeyType
+
+	// Decrypt the authenticator with the ticket session key (key usage 11).
+	authPlain, err := kerbcrypto.Decrypt(sessionEType, sessionKey, kerbcrypto.KeyUsageAPReqAuthen, apReq.Authenticator.Cipher)
+	if err != nil {
+		return nil, nil, fmt.Errorf("gssapi: decrypt authenticator: %w", err)
+	}
+	var auth messages.Authenticator
+	if _, err := auth.Unmarshal(authPlain); err != nil {
+		return nil, nil, fmt.Errorf("gssapi: parse authenticator: %w", err)
+	}
+
+	// RFC 4120 §3.2.3: the authenticator's client name/realm must match the
+	// ticket's, binding the presenter to the principal the KDC named.
+	if !principalsEqual(auth.CName, encTkt.CName) || auth.CRealm != encTkt.CRealm {
+		return nil, nil, fmt.Errorf("gssapi: authenticator client %s@%s does not match ticket client %s@%s",
+			principalString(auth.CName), auth.CRealm, principalString(encTkt.CName), encTkt.CRealm)
+	}
+
+	// Clock-skew check against the authenticator timestamp (RFC 4120 §3.2.3).
+	now := opts.Now
+	if now.IsZero() {
+		now = time.Now()
+	}
+	now = now.UTC()
+	skew := opts.ClockSkew
+	if skew <= 0 {
+		skew = DefaultClockSkew
+	}
+	delta := now.Sub(auth.CTime.UTC())
+	if delta < 0 {
+		delta = -delta
+	}
+	if delta > skew {
+		return nil, nil, fmt.Errorf("gssapi: authenticator clock skew too large (%s > %s)", delta, skew)
+	}
+
+	// Replay check: reject a repeated (client, ctime, cusec) tuple within the skew
+	// window (RFC 4120 §3.2.3).
+	rc := opts.ReplayCache
+	if rc == nil {
+		rc = NewReplayCache()
+	}
+	tuple := fmt.Sprintf("%s@%s|%d|%d", principalString(auth.CName), auth.CRealm, auth.CTime.UTC().Unix(), auth.CUSec)
+	if rc.seenBefore(tuple, auth.CTime.UTC().Add(skew), now) {
+		return nil, nil, fmt.Errorf("gssapi: replayed authenticator (client %s@%s, ctime %s)", principalString(auth.CName), auth.CRealm, auth.CTime.UTC())
+	}
+
+	// Validate the 0x8003 GSS checksum: parse the context flags, and — when the
+	// acceptor supplied channel bindings — verify the Bnd field matches
+	// (RFC 4121 §4.1.1).
+	if err := validateGSSChecksum(&auth, opts.ChannelBindings); err != nil {
+		return nil, nil, err
+	}
+
+	ctx = &SecContext{
+		SessionKey:    sessionKey,
+		SessionEType:  sessionEType,
+		isAcceptor:    true,
+		clientName:    auth.CName,
+		clientRealm:   auth.CRealm,
+		authenticator: func() *messages.Authenticator { a := auth; return &a }(),
+		pacBytes:      extractWin2KPAC(encTkt.AuthorizationData),
+		ctime:         auth.CTime.UTC().Truncate(time.Second),
+		cusec:         auth.CUSec,
+		recvWindow: seqWindow{
+			replayDetect: !opts.DisableReplayDetection,
+			sequence:     opts.EnforceSequence,
+		},
+	}
+
+	// Adopt the per-message base key. An acceptor-minted subkey (returned in the
+	// AP-REP) wins and sets the AcceptorSubkey flag; otherwise the authenticator
+	// subkey (if present) keys per-message tokens without the flag; otherwise the
+	// ticket session key does.
+	var apRepSubkey *messages.EncryptionKey
+	switch {
+	case opts.MintSubkey:
+		keyLen := kerbcrypto.KeyLen(sessionEType)
+		if keyLen <= 0 {
+			return nil, nil, fmt.Errorf("gssapi: cannot mint subkey for etype %d", sessionEType)
+		}
+		sub := make([]byte, keyLen)
+		if _, err := rand.Read(sub); err != nil {
+			return nil, nil, err
+		}
+		ctx.SubKey = sub
+		ctx.SubKeyEType = sessionEType
+		ctx.acceptorSubkey = true
+		apRepSubkey = &messages.EncryptionKey{KeyType: sessionEType, KeyValue: sub}
+	case auth.SubKey != nil:
+		ctx.SubKey = auth.SubKey.KeyValue
+		ctx.SubKeyEType = auth.SubKey.KeyType
+	}
+
+	// The initiator's authenticator sequence number seeds this side's receive
+	// window origin implicitly (the window seeds itself on the first token). The
+	// acceptor's own per-message send sequence starts from the number it announces
+	// in the AP-REP, mirroring the initiator seeding its send sequence from the
+	// authenticator.
+	if !mutualRequired(apReq.APOptions) {
+		return nil, ctx, nil
+	}
+
+	acceptorSeq, err := randomSeq()
+	if err != nil {
+		return nil, nil, err
+	}
+	ctx.acceptorSeq = acceptorSeq
+	ctx.sendSeq = uint64(acceptorSeq)
+
+	enc := messages.EncAPRepPart{
+		CTime:     auth.CTime.UTC(),
+		CUSec:     auth.CUSec,
+		SubKey:    apRepSubkey,
+		SeqNumber: acceptorSeq,
+	}
+	encBytes, err := enc.Marshal()
+	if err != nil {
+		return nil, nil, fmt.Errorf("gssapi: marshal EncAPRepPart: %w", err)
+	}
+	cipher, err := kerbcrypto.Encrypt(sessionEType, sessionKey, kerbcrypto.KeyUsageAPRepEncPart, encBytes)
+	if err != nil {
+		return nil, nil, fmt.Errorf("gssapi: encrypt EncAPRepPart: %w", err)
+	}
+	apRep := messages.APRep{
+		PVNO:    messages.KerberosV5,
+		MsgType: messages.MsgTypeAPRep,
+		EncPart: messages.EncryptedData{EType: sessionEType, Cipher: cipher},
+	}
+	apRepBytes, err := apRep.Marshal()
+	if err != nil {
+		return nil, nil, fmt.Errorf("gssapi: marshal AP-REP: %w", err)
+	}
+	outputToken, err = WrapToken(TokIDAPRep, apRepBytes)
+	if err != nil {
+		return nil, nil, err
+	}
+	return outputToken, ctx, nil
+}
+
+// decryptTicket recovers the EncTicketPart from a ticket by trying each candidate
+// service key whose enctype matches the ticket enc-part at key usage 2. Keys come
+// from the keytab first, then the explicit key list.
+func decryptTicket(tkt *messages.Ticket, opts AcceptOptions) (*messages.EncTicketPart, error) {
+	etype := tkt.EncPart.EType
+	var candidates []ServiceKey
+	if opts.Keytab != nil {
+		for _, e := range opts.Keytab.Find("", etype, -1) {
+			candidates = append(candidates, ServiceKey{EType: int(e.EType), Key: e.Key})
+		}
+	}
+	for _, k := range opts.Keys {
+		if k.EType == etype {
+			candidates = append(candidates, k)
+		}
+	}
+	if len(candidates) == 0 {
+		return nil, fmt.Errorf("gssapi: no service key for ticket enctype %d", etype)
+	}
+	var lastErr error
+	for _, c := range candidates {
+		plain, err := kerbcrypto.Decrypt(c.EType, c.Key, kerbcrypto.KeyUsageKDCRepTicket, tkt.EncPart.Cipher)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		var enc messages.EncTicketPart
+		if _, err := enc.Unmarshal(plain); err != nil {
+			lastErr = err
+			continue
+		}
+		return &enc, nil
+	}
+	return nil, fmt.Errorf("gssapi: no service key could decrypt the ticket (enctype %d): %w", etype, lastErr)
+}
+
+// validateGSSChecksum verifies the authenticator carries a 0x8003 GSS checksum
+// and, when the acceptor supplied channel bindings, that the checksum's Bnd field
+// matches MD5(channelBindings) (RFC 4121 §4.1.1).
+func validateGSSChecksum(auth *messages.Authenticator, channelBindings []byte) error {
+	if auth.Cksum == nil {
+		return fmt.Errorf("gssapi: AP-REQ authenticator has no checksum")
+	}
+	if auth.Cksum.CKSumType != ChecksumTypeGSSAPI {
+		return fmt.Errorf("gssapi: authenticator checksum type %d is not the GSS 0x8003 type", auth.Cksum.CKSumType)
+	}
+	if len(auth.Cksum.Checksum) < gss8003MinLen {
+		return fmt.Errorf("gssapi: 0x8003 checksum too short (%d bytes)", len(auth.Cksum.Checksum))
+	}
+	if len(channelBindings) > 0 {
+		want := md5.Sum(channelBindings)
+		if !hmac.Equal(auth.Cksum.Checksum[4:20], want[:]) {
+			return fmt.Errorf("gssapi: channel-binding mismatch (GSS_C_BAD_BINDINGS)")
+		}
+	}
+	return nil
+}
+
+// mutualRequired reports whether the AP-options set mutual-required (bit 2, i.e.
+// byte 0 / 0x20).
+func mutualRequired(apOptions asn1.BitString) bool {
+	return len(apOptions.Bytes) > 0 && apOptions.Bytes[0]&0x20 != 0
+}
+
+// randomSeq returns a random non-negative 31-bit sequence number, matching the
+// initiator's authenticator sequence generation.
+func randomSeq() (int, error) {
+	var buf [4]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return 0, err
+	}
+	return int(binary.BigEndian.Uint32(buf[:]) & 0x7fffffff), nil
+}
+
+// principalsEqual reports whether two principal names have the same name string
+// components (the name-type is not compared, matching MIT's krb5_principal_compare
+// default which treats an enterprise/principal name-type difference as equal when
+// the components match).
+func principalsEqual(a, b messages.PrincipalName) bool {
+	if len(a.NameString) != len(b.NameString) {
+		return false
+	}
+	for i := range a.NameString {
+		if a.NameString[i] != b.NameString[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// principalString renders a principal name as "comp1/comp2" for diagnostics.
+func principalString(p messages.PrincipalName) string {
+	var b bytes.Buffer
+	for i, c := range p.NameString {
+		if i > 0 {
+			b.WriteByte('/')
+		}
+		b.WriteString(c)
+	}
+	return b.String()
+}
+
+// extractWin2KPAC walks the ticket authorization-data for the AD-IF-RELEVANT
+// wrapped AD-WIN2K-PAC element and returns the raw PAC bytes, or nil when absent.
+func extractWin2KPAC(ad []messages.AuthorizationData) []byte {
+	for _, e := range ad {
+		if e.ADType != adTypeIfRelevant {
+			continue
+		}
+		var inner []messages.AuthorizationData
+		if _, err := asn1.Unmarshal(e.ADData, &inner); err != nil {
+			continue
+		}
+		for _, ie := range inner {
+			if ie.ADType == adTypeWin2KPAC {
+				return ie.ADData
+			}
+		}
+	}
+	return nil
+}
+
+// ClientPrincipal returns the authenticated client's principal name and realm,
+// taken from the validated AP-REQ authenticator (acceptor side). It is empty on
+// an initiator context.
+func (ctx *SecContext) ClientPrincipal() (messages.PrincipalName, string) {
+	return ctx.clientName, ctx.clientRealm
+}
+
+// Authenticator returns the decrypted, validated AP-REQ authenticator (acceptor
+// side), or nil on an initiator context. It lets a caller inspect the 0x8003
+// checksum, e.g. via ExtractDelegatedCred for an unconstrained-delegation
+// KRB-CRED.
+func (ctx *SecContext) Authenticator() *messages.Authenticator { return ctx.authenticator }
+
+// HasPAC reports whether the decrypted ticket carried a PAC (acceptor side).
+func (ctx *SecContext) HasPAC() bool { return len(ctx.pacBytes) > 0 }
+
+// PACBytes returns the raw AD-WIN2K-PAC bytes extracted from the decrypted ticket
+// (acceptor side), or nil when the ticket carried no PAC.
+func (ctx *SecContext) PACBytes() []byte { return ctx.pacBytes }
+
+// PAC parses and returns the PAC extracted from the decrypted ticket (acceptor
+// side). It returns (nil, nil) when the ticket carried no PAC.
+func (ctx *SecContext) PAC() (*pac.PAC, error) {
+	if len(ctx.pacBytes) == 0 {
+		return nil, nil
+	}
+	return pac.Parse(ctx.pacBytes)
+}

--- a/network/kerberos/v5/gssapi/acceptor_test.go
+++ b/network/kerberos/v5/gssapi/acceptor_test.go
@@ -1,0 +1,448 @@
+package gssapi
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/asn1"
+	"testing"
+	"time"
+
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/credcache/keytab"
+	kerbcrypto "github.com/TheManticoreProject/Manticore/network/kerberos/v5/crypto"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/iana"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/messages"
+)
+
+// serviceTicket builds a synthetic service ticket for cifs/host@REALM whose
+// enc-part is sealed under serviceKey (key usage 2), carrying sessionKey as the
+// ticket session key and issued to clientName@clientRealm. When pacBytes is
+// non-nil it is wrapped as an AD-IF-RELEVANT → AD-WIN2K-PAC element, exactly as a
+// KDC would. It returns the raw APPLICATION[1] ticket bytes.
+func serviceTicket(t *testing.T, etype int, serviceKey, sessionKey []byte, clientName messages.PrincipalName, clientRealm string, pacBytes []byte) []byte {
+	t.Helper()
+	now := time.Now().UTC()
+	var ad []messages.AuthorizationData
+	if pacBytes != nil {
+		inner, err := asn1.Marshal([]messages.AuthorizationData{{ADType: adTypeWin2KPAC, ADData: pacBytes}})
+		if err != nil {
+			t.Fatalf("marshal inner AD: %v", err)
+		}
+		ad = []messages.AuthorizationData{{ADType: adTypeIfRelevant, ADData: inner}}
+	}
+	encPart := messages.EncTicketPart{
+		Flags:             asn1.BitString{Bytes: []byte{0x40, 0, 0, 0}, BitLength: 32},
+		Key:               messages.EncryptionKey{KeyType: etype, KeyValue: sessionKey},
+		CRealm:            clientRealm,
+		CName:             clientName,
+		AuthTime:          now,
+		EndTime:           now.Add(8 * time.Hour),
+		AuthorizationData: ad,
+	}
+	plain, err := encPart.Marshal()
+	if err != nil {
+		t.Fatalf("marshal EncTicketPart: %v", err)
+	}
+	cipher, err := kerbcrypto.Encrypt(etype, serviceKey, kerbcrypto.KeyUsageKDCRepTicket, plain)
+	if err != nil {
+		t.Fatalf("encrypt ticket enc-part: %v", err)
+	}
+	tkt := messages.Ticket{
+		TktVno:  messages.KerberosV5,
+		Realm:   clientRealm,
+		SName:   messages.PrincipalName{NameType: iana.NameTypeSRVInst, NameString: []string{"cifs", "host.corp.local"}},
+		EncPart: messages.EncryptedData{EType: etype, Cipher: cipher},
+	}
+	raw, err := tkt.Marshal()
+	if err != nil {
+		t.Fatalf("marshal ticket: %v", err)
+	}
+	return raw
+}
+
+func randKey(t *testing.T, n int) []byte {
+	t.Helper()
+	k := make([]byte, n)
+	if _, err := rand.Read(k); err != nil {
+		t.Fatal(err)
+	}
+	return k
+}
+
+// exerciseBothDirections drives per-message MIC and Wrap tokens in both
+// directions across an established initiator/acceptor pair.
+func exerciseBothDirections(t *testing.T, ictx, actx *SecContext) {
+	t.Helper()
+
+	// Initiator -> acceptor MIC.
+	msg := []byte("hello from the initiator")
+	mic, err := ictx.MakeMIC(msg)
+	if err != nil {
+		t.Fatalf("initiator MakeMIC: %v", err)
+	}
+	if err := actx.VerifyMIC(msg, mic); err != nil {
+		t.Fatalf("acceptor VerifyMIC (initiator MIC): %v", err)
+	}
+
+	// Acceptor -> initiator MIC.
+	msg2 := []byte("hello from the acceptor")
+	mic2, err := actx.MakeMIC(msg2)
+	if err != nil {
+		t.Fatalf("acceptor MakeMIC: %v", err)
+	}
+	if err := ictx.VerifyMIC(msg2, mic2); err != nil {
+		t.Fatalf("initiator VerifyMIC (acceptor MIC): %v", err)
+	}
+
+	// Initiator -> acceptor Wrap (sealed).
+	secret := []byte("confidential initiator payload")
+	wrapped, err := ictx.Wrap(secret, true)
+	if err != nil {
+		t.Fatalf("initiator Wrap: %v", err)
+	}
+	got, sealed, err := actx.Unwrap(wrapped)
+	if err != nil {
+		t.Fatalf("acceptor Unwrap: %v", err)
+	}
+	if !sealed || !bytes.Equal(got, secret) {
+		t.Fatalf("acceptor Unwrap = %q sealed=%v, want %q sealed=true", got, sealed, secret)
+	}
+
+	// Acceptor -> initiator Wrap (sealed).
+	secret2 := []byte("confidential acceptor payload")
+	wrapped2, err := actx.Wrap(secret2, true)
+	if err != nil {
+		t.Fatalf("acceptor Wrap: %v", err)
+	}
+	got2, sealed2, err := ictx.Unwrap(wrapped2)
+	if err != nil {
+		t.Fatalf("initiator Unwrap: %v", err)
+	}
+	if !sealed2 || !bytes.Equal(got2, secret2) {
+		t.Fatalf("initiator Unwrap = %q sealed=%v, want %q sealed=true", got2, sealed2, secret2)
+	}
+}
+
+// loopback runs InitSecContext -> AcceptSecContext for the given options and
+// returns both contexts and the AP-REP output token.
+func loopback(t *testing.T, etype int, initOpts InitOptions, acceptOpts AcceptOptions) (ictx, actx *SecContext, apRep []byte) {
+	t.Helper()
+	token, ictx, err := InitSecContext(initOpts)
+	if err != nil {
+		t.Fatalf("InitSecContext: %v", err)
+	}
+	apRep, actx, err = AcceptSecContext(token, acceptOpts)
+	if err != nil {
+		t.Fatalf("AcceptSecContext: %v", err)
+	}
+	return ictx, actx, apRep
+}
+
+func TestAcceptSecContextLoopbackMutual(t *testing.T) {
+	const etype = iana.ETypeAES256CTSHMACSHA196
+	serviceKey := randKey(t, 32)
+	sessionKey := randKey(t, 32)
+	client := messages.PrincipalName{NameType: iana.NameTypePrincipal, NameString: []string{"alice"}}
+	ticketRaw := serviceTicket(t, etype, serviceKey, sessionKey, client, "CORP.LOCAL", nil)
+
+	ictx, actx, apRep := loopback(t, etype,
+		InitOptions{
+			TicketRaw: ticketRaw, SessionKey: sessionKey, SessionEType: etype,
+			ClientName: client, ClientRealm: "CORP.LOCAL",
+			Flags: GSSIntegFlag | GSSConfFlag, Mutual: true,
+		},
+		AcceptOptions{Keys: []ServiceKey{{EType: etype, Key: serviceKey}}},
+	)
+
+	// The acceptor recovered the client identity and session key.
+	name, realm := actx.ClientPrincipal()
+	if realm != "CORP.LOCAL" || len(name.NameString) != 1 || name.NameString[0] != "alice" {
+		t.Errorf("ClientPrincipal = %v@%s, want alice@CORP.LOCAL", name.NameString, realm)
+	}
+	if !bytes.Equal(actx.SessionKey, sessionKey) {
+		t.Error("acceptor session key does not match the ticket session key")
+	}
+	if actx.Authenticator() == nil {
+		t.Error("acceptor did not retain the authenticator")
+	}
+
+	// Mutual authentication: the initiator accepts the acceptor's AP-REP.
+	if len(apRep) == 0 {
+		t.Fatal("expected an AP-REP output token for mutual authentication")
+	}
+	if err := ictx.AcceptAPRep(apRep); err != nil {
+		t.Fatalf("initiator AcceptAPRep: %v", err)
+	}
+
+	exerciseBothDirections(t, ictx, actx)
+}
+
+func TestAcceptSecContextLoopbackViaKeytab(t *testing.T) {
+	const etype = iana.ETypeAES256CTSHMACSHA196
+	serviceKey := randKey(t, 32)
+	sessionKey := randKey(t, 32)
+	client := messages.PrincipalName{NameType: iana.NameTypePrincipal, NameString: []string{"bob"}}
+	ticketRaw := serviceTicket(t, etype, serviceKey, sessionKey, client, "CORP.LOCAL", nil)
+
+	kt := keytab.New()
+	kt.Add(keytab.Principal{Realm: "CORP.LOCAL", Components: []string{"cifs", "host.corp.local"}}, etype, serviceKey, 3)
+
+	ictx, actx, apRep := loopback(t, etype,
+		InitOptions{
+			TicketRaw: ticketRaw, SessionKey: sessionKey, SessionEType: etype,
+			ClientName: client, ClientRealm: "CORP.LOCAL", Mutual: true,
+		},
+		AcceptOptions{Keytab: kt},
+	)
+	if err := ictx.AcceptAPRep(apRep); err != nil {
+		t.Fatalf("initiator AcceptAPRep: %v", err)
+	}
+	exerciseBothDirections(t, ictx, actx)
+}
+
+func TestAcceptSecContextRC4BothDirections(t *testing.T) {
+	const etype = iana.ETypeRC4HMAC
+	serviceKey := randKey(t, 16)
+	sessionKey := randKey(t, 16)
+	client := messages.PrincipalName{NameType: iana.NameTypePrincipal, NameString: []string{"carol"}}
+	ticketRaw := serviceTicket(t, etype, serviceKey, sessionKey, client, "CORP.LOCAL", nil)
+
+	ictx, actx, apRep := loopback(t, etype,
+		InitOptions{
+			TicketRaw: ticketRaw, SessionKey: sessionKey, SessionEType: etype,
+			ClientName: client, ClientRealm: "CORP.LOCAL", Mutual: true,
+		},
+		AcceptOptions{Keys: []ServiceKey{{EType: etype, Key: serviceKey}}},
+	)
+	if err := ictx.AcceptAPRep(apRep); err != nil {
+		t.Fatalf("initiator AcceptAPRep: %v", err)
+	}
+	exerciseBothDirections(t, ictx, actx)
+}
+
+func TestAcceptSecContextMintSubkey(t *testing.T) {
+	const etype = iana.ETypeAES256CTSHMACSHA196
+	serviceKey := randKey(t, 32)
+	sessionKey := randKey(t, 32)
+	client := messages.PrincipalName{NameType: iana.NameTypePrincipal, NameString: []string{"dan"}}
+	ticketRaw := serviceTicket(t, etype, serviceKey, sessionKey, client, "CORP.LOCAL", nil)
+
+	ictx, actx, apRep := loopback(t, etype,
+		InitOptions{
+			TicketRaw: ticketRaw, SessionKey: sessionKey, SessionEType: etype,
+			ClientName: client, ClientRealm: "CORP.LOCAL", Mutual: true,
+		},
+		AcceptOptions{Keys: []ServiceKey{{EType: etype, Key: serviceKey}}, MintSubkey: true},
+	)
+	// The acceptor keys per-message tokens with its minted subkey; the initiator
+	// must adopt it from the AP-REP before per-message tokens agree.
+	if err := ictx.AcceptAPRep(apRep); err != nil {
+		t.Fatalf("initiator AcceptAPRep: %v", err)
+	}
+	if len(actx.SubKey) == 0 || !bytes.Equal(actx.SubKey, ictx.SubKey) {
+		t.Fatal("initiator did not adopt the acceptor subkey")
+	}
+	exerciseBothDirections(t, ictx, actx)
+}
+
+func TestAcceptSecContextAuthenticatorSubkey(t *testing.T) {
+	const etype = iana.ETypeAES256CTSHMACSHA196
+	serviceKey := randKey(t, 32)
+	sessionKey := randKey(t, 32)
+	subKey := randKey(t, 32)
+	client := messages.PrincipalName{NameType: iana.NameTypePrincipal, NameString: []string{"erin"}}
+	ticketRaw := serviceTicket(t, etype, serviceKey, sessionKey, client, "CORP.LOCAL", nil)
+
+	ictx, actx, apRep := loopback(t, etype,
+		InitOptions{
+			TicketRaw: ticketRaw, SessionKey: sessionKey, SessionEType: etype,
+			ClientName: client, ClientRealm: "CORP.LOCAL", Mutual: true,
+			SubKey: subKey, SubKeyEType: etype,
+		},
+		AcceptOptions{Keys: []ServiceKey{{EType: etype, Key: serviceKey}}},
+	)
+	if !bytes.Equal(actx.SubKey, subKey) {
+		t.Fatal("acceptor did not adopt the authenticator subkey")
+	}
+	if err := ictx.AcceptAPRep(apRep); err != nil {
+		t.Fatalf("initiator AcceptAPRep: %v", err)
+	}
+	exerciseBothDirections(t, ictx, actx)
+}
+
+func TestAcceptSecContextNoMutualNoAPRep(t *testing.T) {
+	const etype = iana.ETypeAES256CTSHMACSHA196
+	serviceKey := randKey(t, 32)
+	sessionKey := randKey(t, 32)
+	client := messages.PrincipalName{NameType: iana.NameTypePrincipal, NameString: []string{"frank"}}
+	ticketRaw := serviceTicket(t, etype, serviceKey, sessionKey, client, "CORP.LOCAL", nil)
+
+	token, _, err := InitSecContext(InitOptions{
+		TicketRaw: ticketRaw, SessionKey: sessionKey, SessionEType: etype,
+		ClientName: client, ClientRealm: "CORP.LOCAL", Mutual: false,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	apRep, actx, err := AcceptSecContext(token, AcceptOptions{Keys: []ServiceKey{{EType: etype, Key: serviceKey}}})
+	if err != nil {
+		t.Fatalf("AcceptSecContext: %v", err)
+	}
+	if apRep != nil {
+		t.Error("no AP-REP expected when mutual authentication was not requested")
+	}
+	if actx == nil {
+		t.Fatal("expected a SecContext even without mutual authentication")
+	}
+}
+
+func TestAcceptSecContextPACExtraction(t *testing.T) {
+	const etype = iana.ETypeAES256CTSHMACSHA196
+	serviceKey := randKey(t, 32)
+	sessionKey := randKey(t, 32)
+	client := messages.PrincipalName{NameType: iana.NameTypePrincipal, NameString: []string{"grace"}}
+	pacBytes := []byte{0xDE, 0xAD, 0xBE, 0xEF, 0x01, 0x02, 0x03, 0x04}
+	ticketRaw := serviceTicket(t, etype, serviceKey, sessionKey, client, "CORP.LOCAL", pacBytes)
+
+	token, _, err := InitSecContext(InitOptions{
+		TicketRaw: ticketRaw, SessionKey: sessionKey, SessionEType: etype,
+		ClientName: client, ClientRealm: "CORP.LOCAL",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, actx, err := AcceptSecContext(token, AcceptOptions{Keys: []ServiceKey{{EType: etype, Key: serviceKey}}})
+	if err != nil {
+		t.Fatalf("AcceptSecContext: %v", err)
+	}
+	if !actx.HasPAC() {
+		t.Fatal("expected the acceptor to extract a PAC")
+	}
+	if !bytes.Equal(actx.PACBytes(), pacBytes) {
+		t.Errorf("PACBytes = % X, want % X", actx.PACBytes(), pacBytes)
+	}
+}
+
+func TestAcceptSecContextChannelBindings(t *testing.T) {
+	const etype = iana.ETypeAES256CTSHMACSHA196
+	serviceKey := randKey(t, 32)
+	sessionKey := randKey(t, 32)
+	client := messages.PrincipalName{NameType: iana.NameTypePrincipal, NameString: []string{"heidi"}}
+	ticketRaw := serviceTicket(t, etype, serviceKey, sessionKey, client, "CORP.LOCAL", nil)
+
+	cb := GSSChannelBindings([]byte("tls-server-end-point:abcd"))
+	token, _, err := InitSecContext(InitOptions{
+		TicketRaw: ticketRaw, SessionKey: sessionKey, SessionEType: etype,
+		ClientName: client, ClientRealm: "CORP.LOCAL", ChannelBindings: cb,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Matching channel bindings pass.
+	if _, _, err := AcceptSecContext(token, AcceptOptions{
+		Keys: []ServiceKey{{EType: etype, Key: serviceKey}}, ChannelBindings: cb,
+	}); err != nil {
+		t.Fatalf("matching channel bindings rejected: %v", err)
+	}
+
+	// Mismatched channel bindings fail (tampered checksum Bnd field).
+	if _, _, err := AcceptSecContext(token, AcceptOptions{
+		Keys:            []ServiceKey{{EType: etype, Key: serviceKey}},
+		ChannelBindings: GSSChannelBindings([]byte("tls-server-end-point:WRONG")),
+	}); err == nil {
+		t.Error("expected channel-binding mismatch to be rejected")
+	}
+}
+
+func TestAcceptSecContextWrongServiceKey(t *testing.T) {
+	const etype = iana.ETypeAES256CTSHMACSHA196
+	serviceKey := randKey(t, 32)
+	sessionKey := randKey(t, 32)
+	client := messages.PrincipalName{NameType: iana.NameTypePrincipal, NameString: []string{"ivan"}}
+	ticketRaw := serviceTicket(t, etype, serviceKey, sessionKey, client, "CORP.LOCAL", nil)
+
+	token, _, err := InitSecContext(InitOptions{
+		TicketRaw: ticketRaw, SessionKey: sessionKey, SessionEType: etype,
+		ClientName: client, ClientRealm: "CORP.LOCAL",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	wrong := randKey(t, 32)
+	if _, _, err := AcceptSecContext(token, AcceptOptions{Keys: []ServiceKey{{EType: etype, Key: wrong}}}); err == nil {
+		t.Error("expected AcceptSecContext to fail with the wrong service key")
+	}
+}
+
+func TestAcceptSecContextReplay(t *testing.T) {
+	const etype = iana.ETypeAES256CTSHMACSHA196
+	serviceKey := randKey(t, 32)
+	sessionKey := randKey(t, 32)
+	client := messages.PrincipalName{NameType: iana.NameTypePrincipal, NameString: []string{"judy"}}
+	ticketRaw := serviceTicket(t, etype, serviceKey, sessionKey, client, "CORP.LOCAL", nil)
+
+	token, _, err := InitSecContext(InitOptions{
+		TicketRaw: ticketRaw, SessionKey: sessionKey, SessionEType: etype,
+		ClientName: client, ClientRealm: "CORP.LOCAL",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rc := NewReplayCache()
+	opts := AcceptOptions{Keys: []ServiceKey{{EType: etype, Key: serviceKey}}, ReplayCache: rc}
+
+	if _, _, err := AcceptSecContext(token, opts); err != nil {
+		t.Fatalf("first AcceptSecContext: %v", err)
+	}
+	// The same authenticator replayed against the shared cache must be rejected.
+	if _, _, err := AcceptSecContext(token, opts); err == nil {
+		t.Error("expected a replayed authenticator to be rejected")
+	}
+}
+
+func TestAcceptSecContextClockSkew(t *testing.T) {
+	const etype = iana.ETypeAES256CTSHMACSHA196
+	serviceKey := randKey(t, 32)
+	sessionKey := randKey(t, 32)
+	client := messages.PrincipalName{NameType: iana.NameTypePrincipal, NameString: []string{"kate"}}
+	ticketRaw := serviceTicket(t, etype, serviceKey, sessionKey, client, "CORP.LOCAL", nil)
+
+	token, _, err := InitSecContext(InitOptions{
+		TicketRaw: ticketRaw, SessionKey: sessionKey, SessionEType: etype,
+		ClientName: client, ClientRealm: "CORP.LOCAL",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The acceptor's clock is an hour ahead of the authenticator: skew rejected.
+	skewed := AcceptOptions{
+		Keys: []ServiceKey{{EType: etype, Key: serviceKey}},
+		Now:  time.Now().UTC().Add(time.Hour),
+	}
+	if _, _, err := AcceptSecContext(token, skewed); err == nil {
+		t.Error("expected an out-of-skew authenticator to be rejected")
+	}
+}
+
+func TestAcceptSecContextTamperedAuthenticator(t *testing.T) {
+	const etype = iana.ETypeAES256CTSHMACSHA196
+	serviceKey := randKey(t, 32)
+	sessionKey := randKey(t, 32)
+	client := messages.PrincipalName{NameType: iana.NameTypePrincipal, NameString: []string{"leo"}}
+	ticketRaw := serviceTicket(t, etype, serviceKey, sessionKey, client, "CORP.LOCAL", nil)
+
+	token, _, err := InitSecContext(InitOptions{
+		TicketRaw: ticketRaw, SessionKey: sessionKey, SessionEType: etype,
+		ClientName: client, ClientRealm: "CORP.LOCAL",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Flip a byte late in the token (inside the encrypted authenticator): the
+	// integrity check on the authenticator must fail.
+	tampered := append([]byte(nil), token...)
+	tampered[len(tampered)-5] ^= 0xff
+	if _, _, err := AcceptSecContext(tampered, AcceptOptions{Keys: []ServiceKey{{EType: etype, Key: serviceKey}}}); err == nil {
+		t.Error("expected a tampered authenticator to be rejected")
+	}
+}

--- a/network/kerberos/v5/gssapi/gssapi.go
+++ b/network/kerberos/v5/gssapi/gssapi.go
@@ -145,6 +145,23 @@ type SecContext struct {
 	// acceptorSeq is the sequence number the acceptor placed in its AP-REP. The
 	// DCE-style third-leg AP-REP must echo it (krb5_rd_rep_dce checks it).
 	acceptorSeq int
+	// isAcceptor records that this context is the acceptor (service) side rather
+	// than the initiator. It flips the per-message direction: the acceptor signs /
+	// seals with the acceptor key usages and sets the SentByAcceptor flag, and
+	// verifies the initiator's tokens with the initiator usages (RFC 4121 §2).
+	isAcceptor bool
+	// clientName / clientRealm identify the authenticated client, taken from the
+	// AP-REQ authenticator (and cross-checked against the ticket) on the acceptor
+	// side. AcceptSecContext populates them; ClientPrincipal exposes them.
+	clientName  messages.PrincipalName
+	clientRealm string
+	// authenticator is the decrypted AP-REQ authenticator the acceptor validated,
+	// retained so callers can inspect the 0x8003 checksum (e.g. ExtractDelegatedCred
+	// for an unconstrained-delegation KRB-CRED).
+	authenticator *messages.Authenticator
+	// pacBytes is the raw AD-WIN2K-PAC extracted from the decrypted ticket on the
+	// acceptor side, or nil when the ticket carried no PAC. PAC() parses it.
+	pacBytes []byte
 	// recvWindow enforces the receive-side replay / sequencing check on incoming
 	// per-message tokens (RFC 4121 §4.2.6 / RFC 2743 §1.2.1.1). It seeds itself
 	// from the first authenticated token; a zero-value SecContext (no flags set)

--- a/network/kerberos/v5/gssapi/permessage.go
+++ b/network/kerberos/v5/gssapi/permessage.go
@@ -43,8 +43,10 @@ func (ctx *SecContext) baseKey() ([]byte, int) {
 	return ctx.SessionKey, ctx.SessionEType
 }
 
-// initiatorFlags is the Flags byte for tokens this (initiator) context sends.
-func (ctx *SecContext) initiatorFlags(sealed bool) byte {
+// sendFlags is the Flags byte for tokens this context sends. It sets
+// SentByAcceptor when the context is the acceptor side, so per-message tokens
+// are tagged with the direction the peer expects (RFC 4121 §4.2.2).
+func (ctx *SecContext) sendFlags(sealed bool) byte {
 	var f byte
 	if ctx.acceptorSubkey {
 		f |= flagAcceptorSubkey
@@ -52,7 +54,55 @@ func (ctx *SecContext) initiatorFlags(sealed bool) byte {
 	if sealed {
 		f |= flagSealed
 	}
-	return f // SentByAcceptor stays 0 (we are the initiator)
+	if ctx.isAcceptor {
+		f |= flagSentByAcceptor
+	}
+	return f
+}
+
+// The four key usages of RFC 4121 §2 are direction-scoped: the initiator signs /
+// seals with the initiator usages and the acceptor with the acceptor usages, and
+// each side verifies its peer's tokens with the peer's usages. These helpers pick
+// the right usage for the context's own role so the same per-message code drives
+// both an initiator and an acceptor SecContext.
+func (ctx *SecContext) sendSignUsage() int {
+	if ctx.isAcceptor {
+		return kgUsageAcceptorSign
+	}
+	return kgUsageInitiatorSign
+}
+
+func (ctx *SecContext) sendSealUsage() int {
+	if ctx.isAcceptor {
+		return kgUsageAcceptorSeal
+	}
+	return kgUsageInitiatorSeal
+}
+
+func (ctx *SecContext) recvSignUsage() int {
+	if ctx.isAcceptor {
+		return kgUsageInitiatorSign
+	}
+	return kgUsageAcceptorSign
+}
+
+func (ctx *SecContext) recvSealUsage() int {
+	if ctx.isAcceptor {
+		return kgUsageInitiatorSeal
+	}
+	return kgUsageAcceptorSeal
+}
+
+// checkRecvDirection rejects a per-message token whose SentByAcceptor flag does
+// not match the peer's role: an initiator only accepts acceptor-sent tokens and
+// an acceptor only accepts initiator-sent ones. This prevents a context's own
+// tokens from being reflected back at it.
+func (ctx *SecContext) checkRecvDirection(flags byte) error {
+	sentByAcceptor := flags&flagSentByAcceptor != 0
+	if sentByAcceptor == ctx.isAcceptor {
+		return fmt.Errorf("gssapi: per-message token has the wrong direction (SentByAcceptor=%v)", sentByAcceptor)
+	}
+	return nil
 }
 
 func (ctx *SecContext) nextSendSeq() uint64 {
@@ -318,14 +368,14 @@ func (ctx *SecContext) sealAES(data []byte, seq uint64) (sealed, token []byte, e
 
 	// The header used inside the encrypted plaintext carries EC with RRC=0
 	// (RFC 4121 §4.2.4: the checksum/encryption is computed with RRC zeroed).
-	hdr := wrapHeader(ctx.initiatorFlags(true), seq)
+	hdr := wrapHeader(ctx.sendFlags(true), seq)
 	binary.BigEndian.PutUint16(hdr[4:6], uint16(ec))
 
 	plain := make([]byte, 0, len(data)+ec+16)
 	plain = append(plain, data...)
 	plain = append(plain, make([]byte, ec)...)
 	plain = append(plain, hdr...)
-	cipher, err := kerbcrypto.Encrypt(etype, key, kgUsageInitiatorSeal, plain)
+	cipher, err := kerbcrypto.Encrypt(etype, key, ctx.sendSealUsage(), plain)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -355,8 +405,8 @@ func (ctx *SecContext) unsealAES(sealed, token []byte) ([]byte, error) {
 	if token[0] != tokIDWrap[0] || token[1] != tokIDWrap[1] {
 		return nil, fmt.Errorf("gssapi: not a Wrap token (tok_id %02x %02x)", token[0], token[1])
 	}
-	if token[2]&flagSentByAcceptor == 0 {
-		return nil, fmt.Errorf("gssapi: Wrap token not marked as sent by acceptor")
+	if err := ctx.checkRecvDirection(token[2]); err != nil {
+		return nil, err
 	}
 	if token[2]&flagSealed == 0 {
 		return nil, fmt.Errorf("gssapi: Wrap token is not sealed")
@@ -369,7 +419,7 @@ func (ctx *SecContext) unsealAES(sealed, token []byte) ([]byte, error) {
 	// the in-place sealed stub) and undo the right-rotation.
 	rotated := append(append([]byte{}, token[16:]...), sealed...)
 	cipher := rotateLeft(rotated, rrc+ec)
-	plain, err := kerbcrypto.Decrypt(etype, key, kgUsageAcceptorSeal, cipher)
+	plain, err := kerbcrypto.Decrypt(etype, key, ctx.recvSealUsage(), cipher)
 	if err != nil {
 		return nil, fmt.Errorf("gssapi: decrypt AES Wrap token: %w", err)
 	}
@@ -396,8 +446,8 @@ func (ctx *SecContext) MakeMIC(data []byte) ([]byte, error) {
 	if !ok {
 		return nil, fmt.Errorf("gssapi: no checksum for etype %d", etype)
 	}
-	hdr := micHeader(ctx.initiatorFlags(false), ctx.nextSendSeq())
-	sum, err := kerbcrypto.GetChecksum(ct, key, kgUsageInitiatorSign, append(append([]byte{}, data...), hdr...))
+	hdr := micHeader(ctx.sendFlags(false), ctx.nextSendSeq())
+	sum, err := kerbcrypto.GetChecksum(ct, key, ctx.sendSignUsage(), append(append([]byte{}, data...), hdr...))
 	if err != nil {
 		return nil, err
 	}
@@ -415,8 +465,8 @@ func (ctx *SecContext) VerifyMIC(data, token []byte) error {
 	if token[0] != tokIDMIC[0] || token[1] != tokIDMIC[1] {
 		return fmt.Errorf("gssapi: not a MIC token")
 	}
-	if token[2]&flagSentByAcceptor == 0 {
-		return fmt.Errorf("gssapi: MIC token not marked as sent by acceptor")
+	if err := ctx.checkRecvDirection(token[2]); err != nil {
+		return err
 	}
 	key, etype := ctx.baseKey()
 	ct, ok := kerbcrypto.ChecksumTypeForEType(etype)
@@ -425,7 +475,7 @@ func (ctx *SecContext) VerifyMIC(data, token []byte) error {
 	}
 	hdr := token[:16]
 	got := token[16:]
-	want, err := kerbcrypto.GetChecksum(ct, key, kgUsageAcceptorSign, append(append([]byte{}, data...), hdr...))
+	want, err := kerbcrypto.GetChecksum(ct, key, ctx.recvSignUsage(), append(append([]byte{}, data...), hdr...))
 	if err != nil {
 		return err
 	}
@@ -441,11 +491,11 @@ func (ctx *SecContext) VerifyMIC(data, token []byte) error {
 // otherwise integrity only. EC and RRC are 0 (no filler, no rotation).
 func (ctx *SecContext) Wrap(data []byte, seal bool) ([]byte, error) {
 	key, etype := ctx.baseKey()
-	hdr := wrapHeader(ctx.initiatorFlags(seal), ctx.nextSendSeq())
+	hdr := wrapHeader(ctx.sendFlags(seal), ctx.nextSendSeq())
 
 	if seal {
 		pt := append(append([]byte{}, data...), hdr...)
-		ct, err := kerbcrypto.Encrypt(etype, key, kgUsageInitiatorSeal, pt)
+		ct, err := kerbcrypto.Encrypt(etype, key, ctx.sendSealUsage(), pt)
 		if err != nil {
 			return nil, err
 		}
@@ -458,7 +508,7 @@ func (ctx *SecContext) Wrap(data []byte, seal bool) ([]byte, error) {
 	}
 	// RFC 4121 §4.2.4: the checksum is computed over data | header with EC and
 	// RRC zeroed. hdr already has EC=RRC=0 here.
-	sum, err := kerbcrypto.GetChecksum(ct, key, kgUsageInitiatorSeal, append(append([]byte{}, data...), hdr...))
+	sum, err := kerbcrypto.GetChecksum(ct, key, ctx.sendSealUsage(), append(append([]byte{}, data...), hdr...))
 	if err != nil {
 		return nil, err
 	}
@@ -482,8 +532,8 @@ func (ctx *SecContext) Unwrap(token []byte) (data []byte, sealed bool, err error
 		return nil, false, fmt.Errorf("gssapi: not a Wrap token")
 	}
 	flags := token[2]
-	if flags&flagSentByAcceptor == 0 {
-		return nil, false, fmt.Errorf("gssapi: Wrap token not marked as sent by acceptor")
+	if err := ctx.checkRecvDirection(flags); err != nil {
+		return nil, false, err
 	}
 	sealed = flags&flagSealed != 0
 	ec := int(binary.BigEndian.Uint16(token[4:6]))
@@ -494,7 +544,7 @@ func (ctx *SecContext) Unwrap(token []byte) (data []byte, sealed bool, err error
 	key, etype := ctx.baseKey()
 
 	if sealed {
-		pt, err := kerbcrypto.Decrypt(etype, key, kgUsageAcceptorSeal, body)
+		pt, err := kerbcrypto.Decrypt(etype, key, ctx.recvSealUsage(), body)
 		if err != nil {
 			return nil, false, fmt.Errorf("gssapi: decrypt Wrap token: %w", err)
 		}
@@ -526,7 +576,7 @@ func (ctx *SecContext) Unwrap(token []byte) (data []byte, sealed bool, err error
 	// The checksum is over data | header with EC and RRC zeroed.
 	zhdr := append([]byte{}, hdr...)
 	zhdr[4], zhdr[5], zhdr[6], zhdr[7] = 0, 0, 0, 0
-	want, err := kerbcrypto.GetChecksum(ct, key, kgUsageAcceptorSeal, append(append([]byte{}, payload...), zhdr...))
+	want, err := kerbcrypto.GetChecksum(ct, key, ctx.recvSealUsage(), append(append([]byte{}, payload...), zhdr...))
 	if err != nil {
 		return nil, false, err
 	}

--- a/network/kerberos/v5/gssapi/rc4permessage.go
+++ b/network/kerberos/v5/gssapi/rc4permessage.go
@@ -71,12 +71,22 @@ func rc4MICSeqBytes(seq uint64, initiator bool) []byte {
 	return b
 }
 
+// recvDirByte is the SND_SEQ direction indicator the peer sets on tokens this
+// context receives (RFC 4757): 0xff when the peer is the acceptor (this context
+// is the initiator) and 0x00 when the peer is the initiator.
+func (ctx *SecContext) recvDirByte() byte {
+	if ctx.isAcceptor {
+		return 0x00
+	}
+	return 0xff
+}
+
 // makeMICRC4 produces an RC4-HMAC GSS MIC token over data with the given sequence
-// number, as the initiator (RFC 4757 §7.3).
+// number, in the direction of this context's role (RFC 4757 §7.3).
 func (ctx *SecContext) makeMICRC4(data []byte, seq uint64) []byte {
 	key, _ := ctx.baseKey()
 	hdr8 := []byte{0x01, 0x01, 0x11, 0x00, 0xff, 0xff, 0xff, 0xff}
-	seqBytes := rc4MICSeqBytes(seq, true)
+	seqBytes := rc4MICSeqBytes(seq, !ctx.isAcceptor)
 	cksum := rc4SgnCksum(key, hdr8, data)
 	encSeq := rc4Encrypt(rc4SeqKey(key, cksum), seqBytes)
 
@@ -112,8 +122,8 @@ func (ctx *SecContext) verifyMICRC4(data, token []byte) error {
 	}
 	// Decrypt SND_SEQ and confirm the acceptor direction indicator.
 	seq := rc4Encrypt(rc4SeqKey(key, got), encSeq)
-	if seq[4] != 0xff {
-		return fmt.Errorf("gssapi: RC4 MIC not marked as sent by acceptor")
+	if seq[4] != ctx.recvDirByte() {
+		return fmt.Errorf("gssapi: RC4 MIC has the wrong direction indicator")
 	}
 	// The token is authentic and acceptor-directed; enforce replay/sequence.
 	return ctx.recvWindow.check(uint64(binary.BigEndian.Uint32(seq[:4])))
@@ -236,7 +246,7 @@ func (ctx *SecContext) sealRC4WithConfounder(data []byte, seq uint64, confounder
 	payload = append(payload, pad...)
 
 	cksum := rc4WrapSgnCksum(key, hdr8, confounder, payload)
-	encSeq := rc4Encrypt(rc4SeqKey(key, cksum), rc4MICSeqBytes(seq, true))
+	encSeq := rc4Encrypt(rc4SeqKey(key, cksum), rc4MICSeqBytes(seq, !ctx.isAcceptor))
 
 	kcrypt := rc4WrapCryptKey(key, seq)
 	plain := make([]byte, 0, 8+len(payload))
@@ -276,8 +286,8 @@ func (ctx *SecContext) unsealRC4(sealed, token []byte) ([]byte, error) {
 	key, _ := ctx.baseKey()
 	// Recover SND_SEQ; the acceptor direction indicator must be 0xff.
 	seqBytes := rc4Encrypt(rc4SeqKey(key, cksum), encSeq)
-	if seqBytes[4] != 0xff {
-		return nil, fmt.Errorf("gssapi: RC4 Wrap not marked as sent by acceptor")
+	if seqBytes[4] != ctx.recvDirByte() {
+		return nil, fmt.Errorf("gssapi: RC4 Wrap has the wrong direction indicator")
 	}
 	seq := uint64(binary.BigEndian.Uint32(seqBytes[:4]))
 


### PR DESCRIPTION
### Linked Issue
`Closes #1000`

### Summary
Adds the service side of Kerberos GSS-API context establishment. The GSS layer (`network/kerberos/v5/gssapi`) was initiator-only (`InitSecContext`); this adds `AcceptSecContext`, the acceptor that consumes an initiator's `KRB_AP_REQ` GSS token, decrypts and validates it against a service key, and emits the mutual-auth `KRB_AP_REP`.

### What it does
- Parses the GSS `InitialContextToken` wrapper (OID + TOK_ID `01 00`) and the AP-REQ.
- Decrypts the ticket enc-part with a service long-term key (**key usage 2**), sourced from a `credcache/keytab` keytab or explicit keys, trying candidates by enctype; recovers the session key.
- Decrypts the authenticator with the session key (**key usage 11**) and validates it: authenticator client name/realm must match the ticket (RFC 4120 §3.2.3), timestamp within clock skew (default 5 min), and a minimal in-memory replay cache rejects a repeated `(client, ctime, cusec)` tuple.
- When the acceptor supplies channel bindings, verifies the `0x8003` checksum `Bnd` field against `MD5(bindings)` (RFC 4121 §4.1.1).
- Adopts a per-message base key: an acceptor-minted subkey (returned in the AP-REP, sets the `AcceptorSubkey` flag), else the authenticator subkey, else the ticket session key.
- When mutual-required is set, emits the `KRB_AP_REP` GSS token (`EncAPRepPart` echoing ctime/cusec, **key usage 12**).
- Exposes the authenticated identity: `ClientPrincipal()`, `PAC()`/`PACBytes()`/`HasPAC()`, `Authenticator()` (for delegated-credential extraction), and the negotiated `SessionKey`.

The per-message MIC/Wrap layer (`permessage.go`, `rc4permessage.go`) is made direction-aware so one `SecContext` drives either role, using the acceptor key usages and `SentByAcceptor` flag on the acceptor side.

### Key usages verified
RFC 4120: ticket enc-part = 2, AP-REQ authenticator = 11, AP-REP enc-part = 12. RFC 4121 §4.1: `0x8003` checksum flags/channel bindings.

### How verified
- **Offline unit tests** (`acceptor_test.go`): `InitSecContext` → `AcceptSecContext` loopback via explicit keys and via a keytab, mutual AP-REP round-trip, per-message MIC + Wrap in **both directions** for AES256 and RC4; minted-subkey and authenticator-subkey adoption; PAC extraction. Negatives: wrong service key, replayed authenticator, clock skew, tampered authenticator, channel-binding mismatch — all rejected.
- **Live against a real KDC**: requested a genuine KDC-issued service ticket for a disposable service account whose key we hold, built the AP-REQ via `InitSecContext`, and drove it through `AcceptSecContext`. The acceptor decrypted the real ticket, validated the authenticator, extracted the client principal `Administrator@REALM` and the real PAC (5 buffers, UserName="Administrator", RID=500), the mutual AP-REP round-tripped, and per-message MIC + Wrap succeeded in both directions. The disposable account was deleted afterward.
- `go build ./...`, `go vet ./network/kerberos/...`, and `go test ./network/kerberos/...` are green.