### PR TITLE
Implement Kerberos ticket postdating (Fixes #998)

### DIFF
--- a/network/kerberos/v5/client.go
+++ b/network/kerberos/v5/client.go
@@ -49,6 +49,13 @@ type KerberosClient struct {
 	// ticket's session-key etype). nil requests AES256, AES128, then RC4.
 	stETypes []int
 
+	// postdateFrom, when non-zero, requests a postdated TGT: GetTGT sends the
+	// AS-REQ with the allow-postdate and postdated KDC options and a from time
+	// set to this (future) start time (RFC 4120 §3.3). The KDC — if it permits
+	// postdating — returns an INVALID (and POSTDATED) TGT that a later Validate
+	// call activates. Configured via WithPostdate.
+	postdateFrom time.Time
+
 	// preloadedTGS holds service tickets supplied out-of-band (a forged silver
 	// ticket, or a captured service ticket) keyed by normalized SPN. When GetTGS
 	// is asked for one of these SPNs it returns the preloaded ticket instead of
@@ -365,27 +372,7 @@ func (c *KerberosClient) HasTGT() bool { return c.hasTGT }
 // EncASRepPart per RFC 4120 §3.1.3).
 func (c *KerberosClient) sendASReq(pa_data []messages.PAData) ([]byte, int, error) {
 	nonce := randomNonce()
-	req := &messages.ASReq{
-		PVNO:    messages.KerberosV5,
-		MsgType: messages.MsgTypeASReq,
-		PAData:  pa_data,
-		ReqBody: messages.KDCReqBody{
-			KDCOptions: kdcOptionsForASReq(),
-			CName: messages.PrincipalName{
-				NameType:   messages.NameTypePrincipal,
-				NameString: []string{c.username},
-			},
-			Realm: c.realm,
-			SName: messages.PrincipalName{
-				NameType:   messages.NameTypeSRVInst,
-				NameString: []string{"krbtgt", c.realm},
-			},
-			Till:  c.now().Add(24 * time.Hour),
-			Nonce: nonce,
-			EType: c.cred.SupportedETypes(),
-		},
-	}
-
+	req := c.buildASReq(pa_data, nonce)
 	req_bytes, err := req.Marshal()
 	if err != nil {
 		return nil, 0, fmt.Errorf("kerberos: marshal AS-REQ: %w", err)
@@ -395,6 +382,46 @@ func (c *KerberosClient) sendASReq(pa_data []messages.PAData) ([]byte, int, erro
 		return nil, 0, err
 	}
 	return resp, nonce, nil
+}
+
+// buildASReq constructs the AS-REQ for the given PA-DATA and nonce. It is
+// factored out of sendASReq so the request shape — in particular the postdating
+// options and from time — can be verified without a live KDC (see
+// postdate_test.go).
+//
+// An ordinary request omits from (its zero value drops the optional tag) and
+// asks for a 24h endtime. A postdated request (WithPostdate) carries the future
+// start time in from and derives the endtime from it, alongside the
+// allow-postdate/postdated options set by asReqKDCOptions (RFC 4120 §3.3).
+func (c *KerberosClient) buildASReq(pa_data []messages.PAData, nonce int) *messages.ASReq {
+	var from time.Time
+	till := c.now().Add(24 * time.Hour)
+	if !c.postdateFrom.IsZero() {
+		from = c.postdateFrom
+		till = c.postdateFrom.Add(24 * time.Hour)
+	}
+
+	return &messages.ASReq{
+		PVNO:    messages.KerberosV5,
+		MsgType: messages.MsgTypeASReq,
+		PAData:  pa_data,
+		ReqBody: messages.KDCReqBody{
+			KDCOptions: c.asReqKDCOptions(),
+			CName: messages.PrincipalName{
+				NameType:   messages.NameTypePrincipal,
+				NameString: []string{c.username},
+			},
+			Realm: c.realm,
+			SName: messages.PrincipalName{
+				NameType:   messages.NameTypeSRVInst,
+				NameString: []string{"krbtgt", c.realm},
+			},
+			From:  from,
+			Till:  till,
+			Nonce: nonce,
+			EType: c.cred.SupportedETypes(),
+		},
+	}
 }
 
 // sendToRealm discovers the KDC endpoints serving realm (explicit config, custom
@@ -627,6 +654,8 @@ func (c *KerberosClient) buildAPReqWith(tgt messages.Ticket, tgtRaw, sessionKey 
 const (
 	kdcOptionForwardable    = iana.KDCOptionForwardable    // byte 0, 0x40
 	kdcOptionProxiable      = iana.KDCOptionProxiable      // byte 0, 0x10
+	kdcOptionAllowPostdate  = iana.KDCOptionAllowPostdate  // byte 0, 0x04 (RFC 4120 §3.3 postdating)
+	kdcOptionPostdated      = iana.KDCOptionPostdated      // byte 0, 0x02 (RFC 4120 §3.3 postdating)
 	kdcOptionRenewable      = iana.KDCOptionRenewable      // byte 1, 0x80
 	kdcOptionCanonicalize   = iana.KDCOptionCanonicalize   // byte 1, 0x01 (RFC 6806)
 	kdcOptionCNameInAddlTkt = iana.KDCOptionCNameInAddlTkt // byte 1, 0x02 (MS-SFU S4U2Proxy)

--- a/network/kerberos/v5/messages/constants.go
+++ b/network/kerberos/v5/messages/constants.go
@@ -59,6 +59,9 @@ const (
 	TicketFlagForwarded   = iana.TicketFlagForwarded
 	TicketFlagProxiable   = iana.TicketFlagProxiable
 	TicketFlagProxy       = iana.TicketFlagProxy
+	TicketFlagMayPostdate = iana.TicketFlagMayPostdate
+	TicketFlagPostdated   = iana.TicketFlagPostdated
+	TicketFlagInvalid     = iana.TicketFlagInvalid
 	TicketFlagPreAuthent  = iana.TicketFlagPreAuthent
 	TicketFlagInitial     = iana.TicketFlagInitial
 	TicketFlagRenewable   = iana.TicketFlagRenewable

--- a/network/kerberos/v5/postdate.go
+++ b/network/kerberos/v5/postdate.go
@@ -1,0 +1,75 @@
+package kerberos
+
+import (
+	"encoding/asn1"
+	"time"
+
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/iana"
+)
+
+// WithPostdate configures GetTGT to request a postdated Ticket Granting Ticket
+// with the given (future) start time (RFC 4120 §3.3). The AS-REQ is sent with
+// the allow-postdate and postdated KDC options and a from field carrying start;
+// its endtime is derived from start (a 24h window). The KDC — if postdating is
+// permitted by policy — returns a TGT flagged POSTDATED and INVALID whose start
+// time lies in the future. Call Validate once that start time is reached (or
+// where the KDC allows, immediately) to clear the INVALID flag and turn it into
+// a usable TGT.
+//
+// Many production KDCs (default Active Directory policy included) disable
+// postdating, in which case GetTGT surfaces the KDC's policy error
+// (e.g. KDC_ERR_POLICY / KDC_ERR_CANNOT_POSTDATE).
+//
+// Returns the client to allow fluent chaining. Passing the zero time clears the
+// request, restoring an ordinary immediate-start TGT.
+func (c *KerberosClient) WithPostdate(start time.Time) *KerberosClient {
+	c.postdateFrom = start.UTC()
+	return c
+}
+
+// asReqKDCOptions returns the KDCOptions BitString for the AS-REQ. When a
+// postdated TGT has been requested (WithPostdate) it adds the allow-postdate and
+// postdated bits to the usual forwardable/proxiable/renewable set: postdated
+// tells the KDC to honor the future from time (issuing the ticket INVALID until
+// validated), and allow-postdate marks the ticket MAY-POSTDATE so it may itself
+// authorize further postdated tickets (RFC 4120 §3.3). Otherwise it returns the
+// standard AS-REQ options.
+func (c *KerberosClient) asReqKDCOptions() asn1.BitString {
+	if c.postdateFrom.IsZero() {
+		return kdcOptionsForASReq()
+	}
+	return encodeKDCOptions(
+		kdcOptionForwardable,
+		kdcOptionProxiable,
+		kdcOptionRenewable,
+		kdcOptionAllowPostdate,
+		kdcOptionPostdated,
+	)
+}
+
+// TGTFlags returns the ticket-flags BitString of the currently held TGT (the
+// decrypted AS-REP/TGS-REP enc-part flags). It is the zero BitString before
+// GetTGT succeeds. See TGTMayPostdate / TGTPostdated / TGTInvalid for the
+// postdating-relevant decodes.
+func (c *KerberosClient) TGTFlags() asn1.BitString {
+	return c.tgtEnc.Flags
+}
+
+// TGTMayPostdate reports whether the held TGT carries the MAY-POSTDATE flag,
+// i.e. it is authorized to obtain postdated tickets (RFC 4120 §2.4).
+func (c *KerberosClient) TGTMayPostdate() bool {
+	return c.tgtEnc.Flags.At(iana.TicketFlagMayPostdate) == 1
+}
+
+// TGTPostdated reports whether the held TGT carries the POSTDATED flag, i.e. it
+// was issued with a start time in the future (RFC 4120 §2.4).
+func (c *KerberosClient) TGTPostdated() bool {
+	return c.tgtEnc.Flags.At(iana.TicketFlagPostdated) == 1
+}
+
+// TGTInvalid reports whether the held TGT carries the INVALID flag. A postdated
+// ticket is issued INVALID and must be turned valid by a VALIDATE exchange (see
+// Validate) once its start time is reached (RFC 4120 §2.4, §3.3.3).
+func (c *KerberosClient) TGTInvalid() bool {
+	return c.tgtEnc.Flags.At(iana.TicketFlagInvalid) == 1
+}

--- a/network/kerberos/v5/postdate_test.go
+++ b/network/kerberos/v5/postdate_test.go
@@ -1,0 +1,163 @@
+package kerberos
+
+import (
+	"bytes"
+	"encoding/asn1"
+	"testing"
+	"time"
+
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/messages"
+)
+
+// asReqBody parses a marshaled AS-REQ down to its [4] KDC-REQ-BODY.
+func asReqBody(t *testing.T, wire []byte) asn1.RawValue {
+	t.Helper()
+	var app asn1.RawValue
+	if _, err := asn1.Unmarshal(wire, &app); err != nil {
+		t.Fatal(err)
+	}
+	if app.Class != asn1.ClassApplication || app.Tag != messages.MsgTypeASReq {
+		t.Fatalf("outer tag: class=%d tag=%d", app.Class, app.Tag)
+	}
+	return seqChild(t, app.Bytes, asn1.ClassContextSpecific, 4)
+}
+
+// TestAsReqKDCOptionsPostdate verifies the exact wire bits of the postdated
+// AS-REQ options: forwardable + proxiable + renewable plus allow-postdate
+// (bit 5 -> byte 0 0x04) and postdated (bit 6 -> byte 0 0x02). Without a
+// postdate request, the standard AS-REQ options are used.
+func TestAsReqKDCOptionsPostdate(t *testing.T) {
+	c := NewClient("svc", "corp.local", "10.0.0.1").WithPassword("x")
+
+	// No postdate configured: standard AS-REQ options.
+	if got := c.asReqKDCOptions(); !bytes.Equal(got.Bytes, kdcOptionsForASReq().Bytes) {
+		t.Errorf("non-postdated options: got %x, want %x", got.Bytes, kdcOptionsForASReq().Bytes)
+	}
+
+	// Postdated: forwardable (0x40) + proxiable (0x10) + allow-postdate (0x04)
+	// + postdated (0x02) in byte 0 => 0x56; renewable (0x80) in byte 1.
+	c.WithPostdate(time.Date(2027, 1, 2, 15, 4, 5, 0, time.UTC))
+	want := []byte{0x56, 0x80, 0x00, 0x00}
+	got := c.asReqKDCOptions()
+	if got.BitLength != 32 {
+		t.Errorf("BitLength: got %d, want 32", got.BitLength)
+	}
+	if !bytes.Equal(got.Bytes, want) {
+		t.Errorf("Bytes: got %x, want %x", got.Bytes, want)
+	}
+}
+
+// TestPostdateASReqShape verifies a postdated AS-REQ sets the allow-postdate
+// (bit 5) and postdated (bit 6) options, carries the requested future start
+// time in from [4], and derives its endtime till [5] from that start time
+// (RFC 4120 §3.3).
+func TestPostdateASReqShape(t *testing.T) {
+	start := time.Date(2027, 1, 2, 15, 4, 5, 0, time.UTC)
+	c := NewClient("svc", "corp.local", "10.0.0.1").WithPassword("x").WithPostdate(start)
+
+	req := c.buildASReq(nil, 4242)
+	wire, err := req.Marshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	body := asReqBody(t, wire)
+
+	// KDCOptions [0]: allow-postdate (bit 5) and postdated (bit 6) set; renew
+	// (bit 30) and validate (bit 31) clear.
+	optElem := seqChild(t, body.Bytes, asn1.ClassContextSpecific, 0)
+	var flags asn1.BitString
+	if _, err := asn1.Unmarshal(optElem.Bytes, &flags); err != nil {
+		t.Fatalf("parse KDCOptions: %v", err)
+	}
+	if flags.At(kdcOptionAllowPostdate) != 1 {
+		t.Errorf("allow-postdate (bit 5) not set; bytes=% X", flags.Bytes)
+	}
+	if flags.At(kdcOptionPostdated) != 1 {
+		t.Errorf("postdated (bit 6) not set; bytes=% X", flags.Bytes)
+	}
+	if flags.At(kdcOptionRenew) != 0 || flags.At(kdcOptionValidate) != 0 {
+		t.Errorf("renew/validate unexpectedly set; bytes=% X", flags.Bytes)
+	}
+
+	// from [4] must equal the requested start time.
+	fromElem := seqChild(t, body.Bytes, asn1.ClassContextSpecific, 4)
+	var from time.Time
+	if _, err := asn1.Unmarshal(fromElem.Bytes, &from); err != nil {
+		t.Fatalf("parse from: %v", err)
+	}
+	if !from.Equal(start) {
+		t.Errorf("from: got %s, want %s", from, start)
+	}
+
+	// till [5] must be the endtime derived from the start time (start + 24h).
+	tillElem := seqChild(t, body.Bytes, asn1.ClassContextSpecific, 5)
+	var till time.Time
+	if _, err := asn1.Unmarshal(tillElem.Bytes, &till); err != nil {
+		t.Fatalf("parse till: %v", err)
+	}
+	if !till.Equal(start.Add(24 * time.Hour)) {
+		t.Errorf("till: got %s, want %s", till, start.Add(24*time.Hour))
+	}
+}
+
+// TestNonPostdatedASReqOmitsFrom verifies that an ordinary (non-postdated)
+// AS-REQ omits the optional from [4] field entirely.
+func TestNonPostdatedASReqOmitsFrom(t *testing.T) {
+	c := NewClient("svc", "corp.local", "10.0.0.1").WithPassword("x")
+	wire, err := c.buildASReq(nil, 4242).Marshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	body := asReqBody(t, wire)
+
+	// Iterate the body: no [4] element must be present.
+	var seq asn1.RawValue
+	if _, err := asn1.Unmarshal(body.Bytes, &seq); err == nil {
+		rest := seq.Bytes
+		for len(rest) > 0 {
+			var e asn1.RawValue
+			r, err := asn1.Unmarshal(rest, &e)
+			if err != nil {
+				t.Fatalf("iterate body: %v", err)
+			}
+			if e.Class == asn1.ClassContextSpecific && e.Tag == 4 {
+				t.Fatalf("from [4] must be absent from a non-postdated AS-REQ")
+			}
+			rest = r
+		}
+	}
+}
+
+// TestPostdateFlagsDecode verifies the ticket-flag accessors decode a crafted
+// postdated reply: a TGT carrying MAY-POSTDATE (bit 5), POSTDATED (bit 6) and
+// INVALID (bit 7), as a KDC returns for a postdated request (RFC 4120 §3.3.3).
+func TestPostdateFlagsDecode(t *testing.T) {
+	c := NewClient("svc", "corp.local", "10.0.0.1").WithPassword("x")
+	c.tgtEnc = messages.EncASRepPart{
+		Flags: messages.NewKerberosFlags(
+			messages.TicketFlagMayPostdate,
+			messages.TicketFlagPostdated,
+			messages.TicketFlagInvalid,
+		),
+	}
+
+	// may-postdate (0x04) + postdated (0x02) + invalid (0x01) all in byte 0.
+	if want := byte(0x07); c.tgtEnc.Flags.Bytes[0] != want {
+		t.Errorf("flags byte 0: got %#x, want %#x", c.tgtEnc.Flags.Bytes[0], want)
+	}
+	if !c.TGTMayPostdate() {
+		t.Error("TGTMayPostdate: got false, want true")
+	}
+	if !c.TGTPostdated() {
+		t.Error("TGTPostdated: got false, want true")
+	}
+	if !c.TGTInvalid() {
+		t.Error("TGTInvalid: got false, want true")
+	}
+
+	// A plain TGT (no postdating flags) must report all three false.
+	c.tgtEnc.Flags = messages.NewKerberosFlags(messages.TicketFlagForwardable, messages.TicketFlagRenewable)
+	if c.TGTMayPostdate() || c.TGTPostdated() || c.TGTInvalid() {
+		t.Error("plain TGT reported a postdating flag")
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #998`

### Root Cause
Ticket postdating (RFC 4120 §3.3) was entirely absent. The ALLOW-POSTDATE / POSTDATED KDC options and the MAY-POSTDATE / POSTDATED / INVALID ticket flags were defined in `iana/constants.go` but unused, and `KDCReqBody.From` — the field carrying a ticket's requested future start time — was never populated, so a postdated TGT could not be requested.

### Fix Description
- `WithPostdate(start)` configures `GetTGT` to send the AS-REQ with the allow-postdate (bit 5) and postdated (bit 6) KDC options, populate `KDCReqBody.From` with the requested future start time, and derive `Till` from it. The KDC returns a POSTDATED, INVALID TGT that the existing `Validate()` VALIDATE exchange (`renew.go`) activates once its start time is reached — reusing that path rather than adding a second one.
- AS-REQ construction is factored into `buildASReq(pa_data, nonce)` (mirroring `buildRenewalTGSReq`) so the postdating request shape can be verified offline. `asReqKDCOptions()` adds the postdating bits only when a postdate is requested.
- `TGTFlags` / `TGTMayPostdate` / `TGTPostdated` / `TGTInvalid` accessors decode the postdating-relevant flags on the held TGT.
- The may-postdate / postdated / invalid ticket-flag aliases are added to the `messages` package.

### How Verified
- `go build ./...`, `go vet ./...`, `go test ./network/kerberos/...` all green.
- Live probe against a Windows Server 2016 KDC: the production `WithPostdate().GetTGT()` path is rejected with **KDC_ERR_POLICY (code 12)** — Active Directory disables postdating by default. A raw wire dump of the equivalent AS-REQ confirms the request is correctly formed: `KDCOptions = 56 80 00 00` with allow-postdate(5)=1, postdated(6)=1 (plus forwardable/proxiable/renewable), and `from [4]` carrying the future GeneralizedTime. The client path and the raw request receive the identical verdict, confirming the rejection is server policy, not a client encoding bug. This matches the issue's acceptance criteria (postdated+validated ticket, or a documented policy rejection of a correctly-formed request).

### Test Coverage
- **Added:** `network/kerberos/v5/postdate_test.go` — `TestAsReqKDCOptionsPostdate` (byte-level option bits), `TestPostdateASReqShape` (options + `from` + `till` on the marshaled AS-REQ), `TestNonPostdatedASReqOmitsFrom` (optional `from` omitted otherwise), `TestPostdateFlagsDecode` (MAY-POSTDATE/POSTDATED/INVALID decode from a crafted reply).

### Scope of Change
- **Files changed:** `network/kerberos/v5/client.go`, `network/kerberos/v5/postdate.go` (new), `network/kerberos/v5/postdate_test.go` (new), `network/kerberos/v5/messages/constants.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local to the Kerberos v5 client. Non-postdated requests are unchanged (`asReqKDCOptions` falls through to the existing options and `from` stays omitted); postdating is opt-in via `WithPostdate`. Safe to merge.