### PR TITLE
Fix GSSAPI sealed Wrap replay window to use authenticated sequence number (Fixes #1014)

### DIFF
--- a/network/kerberos/v5/gssapi/permessage.go
+++ b/network/kerberos/v5/gssapi/permessage.go
@@ -427,8 +427,22 @@ func (ctx *SecContext) unsealAES(sealed, token []byte) ([]byte, error) {
 	if len(plain) < 16+ec {
 		return nil, fmt.Errorf("gssapi: AES Wrap plaintext too short")
 	}
+	// RFC 4121 §4.2.6.2: the 16-octet header recovered from the decrypted
+	// plaintext is authenticated (it rides inside the ciphertext), whereas the
+	// transmitted token header travels in clear and is not under the checksum.
+	// Compare the two before trusting the token, and drive the replay/sequence
+	// window from the AUTHENTICATED sequence number rather than the transmitted
+	// one. The only field that legitimately differs is RRC: §4.2.4 zeroes it in
+	// the encrypted copy while the transmitted header carries the real
+	// right-rotation count, so normalise RRC (bytes [6:8]) before comparing.
+	recovered := plain[len(plain)-16:]
+	transmitted := append([]byte{}, token[:16]...)
+	transmitted[6], transmitted[7] = 0, 0
+	if !hmac.Equal(recovered, transmitted) {
+		return nil, fmt.Errorf("gssapi: Wrap token header mismatch")
+	}
 	// The token decrypted cleanly and is acceptor-directed; enforce replay/sequence.
-	if err := ctx.recvWindow.check(binary.BigEndian.Uint64(token[8:16])); err != nil {
+	if err := ctx.recvWindow.check(binary.BigEndian.Uint64(recovered[8:16])); err != nil {
 		return nil, err
 	}
 	return plain[:len(plain)-16-ec], nil
@@ -552,7 +566,18 @@ func (ctx *SecContext) Unwrap(token []byte) (data []byte, sealed bool, err error
 		if len(pt) < 16+ec {
 			return nil, false, fmt.Errorf("gssapi: Wrap plaintext too short")
 		}
-		if err := ctx.recvWindow.check(binary.BigEndian.Uint64(hdr[8:16])); err != nil {
+		// Compare the authenticated header recovered from the plaintext against
+		// the transmitted header (RFC 4121 §4.2.6.2) and drive the replay/sequence
+		// window from the AUTHENTICATED sequence number, not the unauthenticated
+		// transmitted one. Only RRC legitimately differs (§4.2.4 zeroes it in the
+		// encrypted copy), so normalise RRC (bytes [6:8]) before comparing.
+		recovered := pt[len(pt)-16:]
+		transmitted := append([]byte{}, hdr...)
+		transmitted[6], transmitted[7] = 0, 0
+		if !hmac.Equal(recovered, transmitted) {
+			return nil, false, fmt.Errorf("gssapi: Wrap token header mismatch")
+		}
+		if err := ctx.recvWindow.check(binary.BigEndian.Uint64(recovered[8:16])); err != nil {
 			return nil, false, err
 		}
 		return pt[:len(pt)-16-ec], true, nil

--- a/network/kerberos/v5/gssapi/permessage_test.go
+++ b/network/kerberos/v5/gssapi/permessage_test.go
@@ -306,6 +306,93 @@ func TestUnsealDCERejectsUnsealed(t *testing.T) {
 	}
 }
 
+// TestSealedWrapAuthenticatesTransmittedSeq is a regression test for the
+// per-message replay-window authentication fix. For a sealed CFX Wrap token the
+// receiver must drive the replay/sequence window from the sequence number in
+// the AUTHENTICATED header copy recovered from the ciphertext (RFC 4121
+// §4.2.6.2), not from the unauthenticated transmitted header. A legitimate
+// round-trip must still be accepted, but flipping the transmitted sequence bytes
+// must be rejected rather than silently accepted (which previously poisoned the
+// window with an attacker-chosen sequence number).
+func TestSealedWrapAuthenticatesTransmittedSeq(t *testing.T) {
+	key := bytes.Repeat([]byte{0x42}, 32)
+	etype := iana.ETypeAES256CTSHMACSHA196
+	const bogusSeq = uint64(0xdeadbeef)
+
+	// DCE Seal -> Unseal path (acceptor seals, initiator unseals).
+	t.Run("DCE", func(t *testing.T) {
+		acc := newTestContext(42)
+		acc.isAcceptor = true
+		acc.acceptorSubkey = true
+		acc.SessionKey, acc.SubKey, acc.SubKeyEType = key, key, etype
+		data := []byte("confidential-dce-stub")
+
+		sealedStub, tok, err := acc.Seal(data)
+		if err != nil {
+			t.Fatalf("Seal: %v", err)
+		}
+
+		// A fresh initiator context with the replay window enabled.
+		newInit := func() *SecContext {
+			c := newTestContext(1)
+			c.acceptorSubkey = true
+			c.SessionKey, c.SubKey, c.SubKeyEType = key, key, etype
+			c.recvWindow.replayDetect = true
+			return c
+		}
+
+		got, err := newInit().Unseal(sealedStub, tok)
+		if err != nil {
+			t.Fatalf("Unseal rejected a legitimate sealed token: %v", err)
+		}
+		if !bytes.Equal(got, data) {
+			t.Fatalf("Unseal data = %q, want %q", got, data)
+		}
+
+		// Flip the transmitted sequence number: the authenticated header copy
+		// still carries the real value, so the token must now be rejected.
+		bad := append([]byte{}, tok...)
+		binary.BigEndian.PutUint64(bad[8:16], bogusSeq)
+		if _, err := newInit().Unseal(sealedStub, bad); err == nil {
+			t.Error("Unseal accepted a token with a tampered transmitted sequence number")
+		}
+	})
+
+	// Wrap(seal=true) -> Unwrap path (acceptor wraps, initiator unwraps).
+	t.Run("Wrap", func(t *testing.T) {
+		acc := newTestContext(42)
+		acc.isAcceptor = true
+		acc.SessionKey, acc.SessionEType = key, etype
+		data := []byte("confidential-wrap-payload")
+
+		tok, err := acc.Wrap(data, true)
+		if err != nil {
+			t.Fatalf("Wrap: %v", err)
+		}
+
+		newInit := func() *SecContext {
+			c := newTestContext(1)
+			c.SessionKey, c.SessionEType = key, etype
+			c.recvWindow.replayDetect = true
+			return c
+		}
+
+		got, sealed, err := newInit().Unwrap(tok)
+		if err != nil || !sealed {
+			t.Fatalf("Unwrap rejected a legitimate sealed token: %v (sealed=%v)", err, sealed)
+		}
+		if !bytes.Equal(got, data) {
+			t.Fatalf("Unwrap data = %q, want %q", got, data)
+		}
+
+		bad := append([]byte{}, tok...)
+		binary.BigEndian.PutUint64(bad[8:16], bogusSeq)
+		if _, _, err := newInit().Unwrap(bad); err == nil {
+			t.Error("Unwrap accepted a sealed token with a tampered transmitted sequence number")
+		}
+	})
+}
+
 func TestUnwrapRotation(t *testing.T) {
 	ctx := newTestContext(1)
 	data := []byte("rotated-sealed-data-payload")


### PR DESCRIPTION
### Linked Issue
`Closes #1014`

### Root Cause
For an RFC 4121 §4.2.6.2 CFX sealed Wrap token, the 16-octet header is transmitted in clear at the front of the token *and* carried a second time inside the encrypted plaintext (`data | filler(ec) | header(16)`), where it is under the checksum/encryption. Only that embedded copy is authenticated. The unwrap paths (`unsealAES()` and the sealed branch of `Unwrap()`) fed the replay/sequence window from the transmitted header (`token[8:16]` / `hdr[8:16]`) and threw the decrypted header copy away without comparing it. The transmitted sequence number is therefore attacker-mutable: a man-in-the-middle who cannot forge the ciphertext can still flip the cleartext sequence bytes; decryption still succeeds and the correct plaintext is returned, but the window records the attacker-chosen sequence number.

### Fix Description
`unsealAES()` and the sealed branch of `Unwrap()` now extract the authenticated header copy from the tail of the decrypted plaintext (`plain[len(plain)-16:]` / `pt[len(pt)-16:]`), compare it against the transmitted header, and drive `recvWindow.check(...)` from the authenticated sequence number (`recovered[8:16]`). Per RFC 4121 §4.2.4 the encrypted header copy carries `RRC = 0` while the transmitted header carries the real right-rotation count, so the RRC field (bytes `[6:8]`) is normalised to zero before a constant-time `hmac.Equal` comparison; every other field — TOK_ID, Flags, Filler, EC and critically the sequence number — must match, otherwise the token is rejected with `gssapi: Wrap token header mismatch`. This matches the header-comparison requirement of §4.2.6.2 and leaves the legitimate path (including real Windows-emitted tokens, which zero RRC in the encrypted copy) unchanged.

### How Verified
- **Unit tests:** `go test ./network/kerberos/v5/gssapi/` green. New test `TestSealedWrapAuthenticatesTransmittedSeq` (subtests `DCE` and `Wrap`) round-trips `Seal→Unseal` and `Wrap(seal=true)→Unwrap` with the replay window enabled, then flips the transmitted sequence bytes and asserts rejection. Confirmed the test **fails** against the pre-fix logic (both paths silently accept the tampered token) and **passes** after the fix.
- **Build/vet:** `go build ./...` and `go vet ./network/kerberos/v5/gssapi/` clean.
- **Live:** a real LDAP GSS-SPNEGO bind with the confidentiality (seal) security layer against a Windows Server 2016 DC, followed by a `namingContexts` read and a subtree user search (all wrapped PDUs), round-trips OK both before and after the change — proving the header-equality check accepts legitimate Windows Wrap tokens.

### Test Coverage
- **Added:** `network/kerberos/v5/gssapi/permessage_test.go` — `TestSealedWrapAuthenticatesTransmittedSeq` (`DCE` + `Wrap` subtests).

### Scope of Change
- **Files changed:** `network/kerberos/v5/gssapi/permessage.go`, `network/kerberos/v5/gssapi/permessage_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local to the two sealed-Wrap unwrap paths; the only new behaviour is rejecting tokens whose transmitted header disagrees with the authenticated copy on any field other than RRC. The sealed LDAP round-trip against a live DC confirms no regression on the legitimate path. Safe to merge without staged rollout.