### PR TITLE
Fix GSSAPI Wrap/Unwrap to dispatch RC4-HMAC tokens (Fixes #1015)

### DIFF
--- a/network/kerberos/v5/gssapi/permessage.go
+++ b/network/kerberos/v5/gssapi/permessage.go
@@ -500,11 +500,16 @@ func (ctx *SecContext) VerifyMIC(data, token []byte) error {
 	return ctx.recvWindow.check(binary.BigEndian.Uint64(hdr[8:16]))
 }
 
-// Wrap produces a Wrap token over data as the context initiator (RFC 4121
-// §4.2.6.2). With seal=true the token provides confidentiality+integrity;
-// otherwise integrity only. EC and RRC are 0 (no filler, no rotation).
+// Wrap produces a Wrap token over data as the context initiator. For RC4-HMAC it
+// is the contiguous RFC 4757 §7.4 token (tok_id 02 01); otherwise the RFC 4121
+// §4.2.6.2 CFX token (tok_id 05 04). With seal=true the token provides
+// confidentiality+integrity; otherwise integrity only. For the CFX path EC and
+// RRC are 0 (no filler, no rotation).
 func (ctx *SecContext) Wrap(data []byte, seal bool) ([]byte, error) {
 	key, etype := ctx.baseKey()
+	if etype == rc4HMACEType {
+		return ctx.wrapRC4(data, ctx.nextSendSeq(), seal)
+	}
 	hdr := wrapHeader(ctx.sendFlags(seal), ctx.nextSendSeq())
 
 	if seal {
@@ -537,8 +542,12 @@ func (ctx *SecContext) Wrap(data []byte, seal bool) ([]byte, error) {
 }
 
 // Unwrap decodes a Wrap token received from the acceptor, returning the
-// plaintext data and whether it was sealed (confidential).
+// plaintext data and whether it was sealed (confidential). For RC4-HMAC it parses
+// the RFC 4757 §7.4 token (tok_id 02 01), otherwise the RFC 4121 CFX token.
 func (ctx *SecContext) Unwrap(token []byte) (data []byte, sealed bool, err error) {
+	if _, etype := ctx.baseKey(); etype == rc4HMACEType {
+		return ctx.unwrapRC4(token)
+	}
 	if len(token) < 16 {
 		return nil, false, fmt.Errorf("gssapi: Wrap token too short")
 	}

--- a/network/kerberos/v5/gssapi/rc4permessage.go
+++ b/network/kerberos/v5/gssapi/rc4permessage.go
@@ -263,6 +263,140 @@ func (ctx *SecContext) sealRC4WithConfounder(data []byte, seq uint64, confounder
 	return enc[8:], token
 }
 
+// rc4WrapPadStandalone builds the RFC 1964 §1.2.2.3 self-describing pad the
+// standalone (non-DCE) RC4-HMAC GSS_Wrap token uses. The arcfour profile has a
+// cipher blocksize of 1 (RC4 is a stream cipher), so "pad to the next multiple
+// of the blocksize, appending between 1 and blocksize bytes" collapses to a
+// single octet of value 0x01, appended unconditionally. This is what Windows /
+// MIT emit and expect on the wire (verified live: an AD SASL security-layer
+// offer of n data octets arrives with exactly one 0x01 pad byte). Unlike the
+// DCE rc4WrapPad (which pads the sealed stub to 8 because RPC signals the true
+// length out of band), a standalone token has no external length, so the pad is
+// always present and self-describing for the receiver to strip.
+func rc4WrapPadStandalone() []byte {
+	return []byte{0x01}
+}
+
+// wrapRC4 produces a single contiguous RFC 4757 §7.4 GSS_Wrap token over data as
+// this context's role, with the given sequence number. Unlike sealRC4 (which
+// splits the sealed stub out for DCE in-place sealing), the whole token —
+// {GSS InitialContextToken framing | TOK_ID 02 01 | SGN_ALG | SEAL_ALG | Filler |
+// SND_SEQ | SGN_CKSUM | (optionally sealed) confounder | data | pad} — is
+// returned contiguously, as a peer's GSS_Unwrap expects. With seal=true the
+// confounder and data are RC4-encrypted (SEAL_ALG 10 00); with seal=false the
+// token provides integrity only (SEAL_ALG ff ff, "none") and the confounder and
+// data travel in clear.
+func (ctx *SecContext) wrapRC4(data []byte, seq uint64, seal bool) ([]byte, error) {
+	confounder := make([]byte, 8)
+	if _, err := rand.Read(confounder); err != nil {
+		return nil, err
+	}
+	inner := ctx.wrapRC4Inner(data, seq, confounder, seal)
+	// RFC 1964 §1.2 wraps every RC4/DES per-message token in the OID-prefixed
+	// GSS framing (the RFC 4121 CFX tokens dropped it). WrapToken encodes the DER
+	// length, so tokens longer than the fixed 45-byte DCE form frame correctly.
+	return WrapToken([2]byte{inner[0], inner[1]}, inner[2:])
+}
+
+// wrapRC4Inner builds the bare (un-framed) RFC 4757 §7.4 GSS_Wrap token with a
+// caller-supplied confounder: the 32-byte header followed by the confounder and
+// the padded data, sealed together when seal is set. It is the deterministic core
+// of wrapRC4 (which supplies a random confounder and adds the GSS framing) and is
+// driven directly by known-answer tests.
+func (ctx *SecContext) wrapRC4Inner(data []byte, seq uint64, confounder []byte, seal bool) []byte {
+	key, _ := ctx.baseKey()
+	// TOK_ID 02 01, SGN_ALG 11 00 (HMAC), SEAL_ALG 10 00 (RC4) or ff ff (none),
+	// Filler ff ff.
+	hdr8 := []byte{0x02, 0x01, 0x11, 0x00, 0x10, 0x00, 0xff, 0xff}
+	if !seal {
+		hdr8[4], hdr8[5] = 0xff, 0xff
+	}
+
+	pad := rc4WrapPadStandalone()
+	payload := make([]byte, 0, len(data)+len(pad))
+	payload = append(payload, data...)
+	payload = append(payload, pad...)
+
+	cksum := rc4WrapSgnCksum(key, hdr8, confounder, payload)
+	encSeq := rc4Encrypt(rc4SeqKey(key, cksum), rc4MICSeqBytes(seq, !ctx.isAcceptor))
+
+	region := make([]byte, 0, len(confounder)+len(payload))
+	region = append(region, confounder...)
+	region = append(region, payload...)
+	if seal {
+		region = rc4Encrypt(rc4WrapCryptKey(key, seq), region)
+	}
+
+	token := make([]byte, 0, 8+8+8+len(region))
+	token = append(token, hdr8...)
+	token = append(token, encSeq...)
+	token = append(token, cksum...)
+	token = append(token, region...)
+	return token
+}
+
+// unwrapRC4 parses and verifies a single contiguous RFC 4757 §7.4 GSS_Wrap token
+// received from the peer, returning the recovered plaintext and whether it was
+// sealed (confidential). It is the standalone counterpart of unsealRC4 (which
+// takes the sealed stub and the token separately for DCE): here the confounder
+// and data ride inside the one token and the self-describing pad is stripped.
+func (ctx *SecContext) unwrapRC4(token []byte) (data []byte, sealed bool, err error) {
+	// Strip the GSS InitialContextToken framing (RFC 1964 §1.2) if present,
+	// tolerating a multi-byte DER length; UnwrapToken also verifies the mech OID.
+	inner := token
+	if len(token) > 0 && token[0] == 0x60 {
+		tokID, rest, uerr := UnwrapToken(token)
+		if uerr != nil {
+			return nil, false, uerr
+		}
+		inner = append([]byte{tokID[0], tokID[1]}, rest...)
+	}
+	if len(inner) < 32 {
+		return nil, false, fmt.Errorf("gssapi: RC4 Wrap token too short")
+	}
+	if inner[0] != 0x02 || inner[1] != 0x01 {
+		return nil, false, fmt.Errorf("gssapi: not an RC4 Wrap token (TOK_ID %02x %02x)", inner[0], inner[1])
+	}
+	hdr8 := inner[:8]
+	encSeq := inner[8:16]
+	cksum := inner[16:24]
+	region := inner[24:]
+	// SEAL_ALG ff ff means "none" (integrity only); anything else is confidential.
+	sealed = !(hdr8[4] == 0xff && hdr8[5] == 0xff)
+
+	key, _ := ctx.baseKey()
+	// Recover SND_SEQ and confirm the peer's direction indicator.
+	seqBytes := rc4Encrypt(rc4SeqKey(key, cksum), encSeq)
+	if seqBytes[4] != ctx.recvDirByte() {
+		return nil, false, fmt.Errorf("gssapi: RC4 Wrap has the wrong direction indicator")
+	}
+	seq := uint64(binary.BigEndian.Uint32(seqBytes[:4]))
+
+	if sealed {
+		region = rc4Encrypt(rc4WrapCryptKey(key, seq), region)
+	}
+	confounder := region[:8]
+	payload := region[8:]
+
+	want := rc4WrapSgnCksum(key, hdr8, confounder, payload)
+	if !hmac.Equal(cksum, want) {
+		return nil, false, fmt.Errorf("gssapi: RC4 Wrap verification failed")
+	}
+	// Strip the self-describing RFC 1964 pad (1..8 octets, each the pad length).
+	if len(payload) == 0 {
+		return nil, false, fmt.Errorf("gssapi: RC4 Wrap payload missing pad")
+	}
+	pad := int(payload[len(payload)-1])
+	if pad < 1 || pad > 8 || pad > len(payload) {
+		return nil, false, fmt.Errorf("gssapi: RC4 Wrap invalid pad length %d", pad)
+	}
+	// The token is authentic and correctly directed; enforce replay/sequence.
+	if err := ctx.recvWindow.check(seq); err != nil {
+		return nil, false, err
+	}
+	return payload[:len(payload)-pad], sealed, nil
+}
+
 // unsealRC4 decrypts and verifies an RC4-HMAC GSS Wrap token received from the
 // acceptor. sealed is the on-wire (encrypted) stub; token is the auth_value. It
 // returns the recovered plaintext (data plus any GSS pad, which the caller

--- a/network/kerberos/v5/gssapi/rc4permessage_test.go
+++ b/network/kerberos/v5/gssapi/rc4permessage_test.go
@@ -1,6 +1,7 @@
 package gssapi
 
 import (
+	"bytes"
 	"encoding/hex"
 	"testing"
 )
@@ -132,6 +133,130 @@ func (ctx *SecContext) sealRC4Acceptor(data []byte, seq uint64) (sealed, token [
 	token = append(token, cksum...)
 	token = append(token, enc[:8]...)
 	return enc[8:], token
+}
+
+// TestRC4WrapDispatchesRC4Token confirms the generic Wrap/Unwrap API emits and
+// parses the RFC 4757 §7.4 RC4-HMAC token (TOK_ID 02 01) — not the RFC 4121 CFX
+// token (05 04) — for an RC4-HMAC context, and that a sealed token round-trips
+// its plaintext through a peer (acceptor) context. This is the regression guard
+// for the missing RC4 dispatch in Wrap/Unwrap.
+func TestRC4WrapDispatchesRC4Token(t *testing.T) {
+	key, _ := hex.DecodeString("0123456789abcdef0123456789abcdef")
+	data := []byte("confidential payload over rc4-hmac gssapi") // 41 bytes -> pad-to-8
+
+	init := &SecContext{SessionKey: key, SessionEType: rc4HMACEType}
+	peer := &SecContext{SessionKey: key, SessionEType: rc4HMACEType, isAcceptor: true}
+
+	tok, err := init.Wrap(data, true)
+	if err != nil {
+		t.Fatalf("Wrap(seal): %v", err)
+	}
+	// The token is GSS-framed (RFC 1964); the RC4 TOK_ID follows the OID header.
+	if tok[0] != 0x60 {
+		t.Fatalf("RC4 Wrap token missing GSS framing (first byte %02x)", tok[0])
+	}
+	tokID, rest, err := UnwrapToken(tok)
+	if err != nil {
+		t.Fatalf("UnwrapToken: %v", err)
+	}
+	if tokID != [2]byte{0x02, 0x01} {
+		t.Errorf("RC4 Wrap TOK_ID = %02x %02x, want 02 01", tokID[0], tokID[1])
+	}
+	if tokID == [2]byte{0x05, 0x04} {
+		t.Error("RC4 context must not emit a CFX (05 04) Wrap token")
+	}
+	// SEAL_ALG (rest[2:4], i.e. inner bytes 4..5) must be RC4 (10 00) when sealed.
+	if rest[2] != 0x10 || rest[3] != 0x00 {
+		t.Errorf("sealed RC4 Wrap SEAL_ALG = %02x %02x, want 10 00", rest[2], rest[3])
+	}
+	if bytes.Contains(tok, data) {
+		t.Error("sealed RC4 Wrap token leaks plaintext")
+	}
+
+	got, sealed, err := peer.Unwrap(tok)
+	if err != nil {
+		t.Fatalf("Unwrap(seal): %v", err)
+	}
+	if !sealed {
+		t.Error("Unwrap reported a sealed RC4 token as not sealed")
+	}
+	if !bytes.Equal(got, data) {
+		t.Errorf("sealed round-trip plaintext = %q, want %q", got, data)
+	}
+}
+
+// TestRC4WrapIntegrityOnlyRoundTrip confirms the integrity-only (seal=false)
+// generic Wrap on an RC4-HMAC context emits an RFC 4757 token with SEAL_ALG
+// "none" (ff ff) carrying the data in clear, and that a peer context recovers it.
+func TestRC4WrapIntegrityOnlyRoundTrip(t *testing.T) {
+	key, _ := hex.DecodeString("fedcba9876543210fedcba9876543210")
+	data := []byte("integrity-only rc4 gssapi buffer!!") // exercises the pad-to-8
+
+	init := &SecContext{SessionKey: key, SessionEType: rc4HMACEType}
+	peer := &SecContext{SessionKey: key, SessionEType: rc4HMACEType, isAcceptor: true}
+
+	tok, err := init.Wrap(data, false)
+	if err != nil {
+		t.Fatalf("Wrap(integrity): %v", err)
+	}
+	tokID, rest, err := UnwrapToken(tok)
+	if err != nil {
+		t.Fatalf("UnwrapToken: %v", err)
+	}
+	if tokID != [2]byte{0x02, 0x01} {
+		t.Errorf("RC4 Wrap TOK_ID = %02x %02x, want 02 01", tokID[0], tokID[1])
+	}
+	// SEAL_ALG must be "none" (ff ff) and the data must travel in clear.
+	if rest[2] != 0xff || rest[3] != 0xff {
+		t.Errorf("integrity-only SEAL_ALG = %02x %02x, want ff ff", rest[2], rest[3])
+	}
+	if !bytes.Contains(tok, data) {
+		t.Error("integrity-only RC4 Wrap token must carry data in clear")
+	}
+
+	got, sealed, err := peer.Unwrap(tok)
+	if err != nil {
+		t.Fatalf("Unwrap(integrity): %v", err)
+	}
+	if sealed {
+		t.Error("integrity-only token reported as sealed")
+	}
+	if !bytes.Equal(got, data) {
+		t.Errorf("integrity round-trip plaintext = %q, want %q", got, data)
+	}
+
+	// Tampering with the payload must fail the integrity check.
+	bad := append([]byte{}, tok...)
+	bad[len(bad)-1] ^= 0xff
+	if _, _, err := peer.Unwrap(bad); err == nil {
+		t.Error("expected integrity failure on tampered RC4 Wrap token")
+	}
+}
+
+// TestRC4WrapAlignedPadding checks a Wrap round-trip for 8-aligned data. The
+// arcfour profile has a cipher blocksize of 1, so the RFC 1964 self-describing
+// pad is a single 0x01 octet regardless of length and the receiver can always
+// strip it with no external length signal.
+func TestRC4WrapAlignedPadding(t *testing.T) {
+	key, _ := hex.DecodeString("00112233445566778899aabbccddeeff")
+	data := []byte("sixteen bytes!!!") // exactly 16 bytes (8-aligned)
+
+	init := &SecContext{SessionKey: key, SessionEType: rc4HMACEType}
+	peer := &SecContext{SessionKey: key, SessionEType: rc4HMACEType, isAcceptor: true}
+
+	for _, seal := range []bool{true, false} {
+		tok, err := init.Wrap(data, seal)
+		if err != nil {
+			t.Fatalf("Wrap(seal=%v): %v", seal, err)
+		}
+		got, _, err := peer.Unwrap(tok)
+		if err != nil {
+			t.Fatalf("Unwrap(seal=%v): %v", seal, err)
+		}
+		if !bytes.Equal(got, data) {
+			t.Errorf("seal=%v round-trip = %q, want %q", seal, got, data)
+		}
+	}
 }
 
 // makeMICRC4Acceptor builds an acceptor-direction RC4 MIC (test helper for


### PR DESCRIPTION
### Linked Issue
`Closes #1015`

### Root Cause
Every sibling per-message routine — `Seal`/`Unseal`/`MakeMIC`/`VerifyMIC` — begins with an `if etype == rc4HMACEType { ... }` dispatch, but `Wrap()`/`Unwrap()` were written only for the RFC 4121 CFX (`05 04`) token and never got that branch. On a context whose base key is RC4-HMAC (etype 23) they still built/parsed a CFX token, so the generic GSS_Wrap/GSS_Unwrap API produced a token a conformant peer rejects and could not parse an inbound RFC 4757 `02 01` token. The regression surface is any peer that negotiates an RC4-HMAC session key (e.g. LDAP GSS-SPNEGO SASL sign/seal against an AD peer that selects RC4).

### Fix Description
`Wrap`/`Unwrap` now dispatch to a new standalone RC4-HMAC path when the base-key etype is RC4-HMAC, mirroring the sibling routines; the CFX path is untouched for every other etype (and the #1014 sealed-header-authentication fix is preserved).

The new `wrapRC4` emits a single contiguous RFC 4757 §7.4 GSS_Wrap token — GSS InitialContextToken framing, then `TOK_ID 02 01 | SGN_ALG 11 00 | SEAL_ALG (10 00 seal / ff ff none) | Filler ff ff | SND_SEQ | SGN_CKSUM | (optionally sealed) confounder | data | pad`. `unwrapRC4` parses that token (tolerating a multi-byte DER length), verifies the SGN_CKSUM, decrypts the confounder+data when SEAL_ALG is not "none", strips the self-describing pad, and enforces the replay/sequence window. It reuses the existing RC4 keying/checksum/sequence helpers rather than duplicating them; only the padding differs from the DCE `sealRC4` path (arcfour blocksize is 1, so a standalone token carries a single `0x01` pad octet), and the GSS framing is produced with a DER length so tokens larger than the fixed 45-byte DCE form frame correctly.

### How Verified
- Live against the lab DC (KDC/LDAP 10.7.0.10, realm TMP-W-2016.LOCAL): an RC4-HMAC session key was forced for the `ldap/` service ticket (the DC issues etype 23), and the full RFC 4752 SASL GSSAPI bind + `namingContexts` read + subtree user search were driven over **both** the integrity (`sign`) and confidentiality (`seal`) security layers. Both round-tripped end-to-end (6 user accounts), exercising the production `Wrap`/`Unwrap` RC4 path — including large multi-KB tokens with multi-byte DER lengths. The real AD SASL security-layer offer was parsed by `unwrapRC4` (confirming wire-format compatibility, including the single-octet arcfour pad). The temporary RC4-forcing hook used to drive this was reverted; it is not part of the diff.
- AES no-regression: the same `sign`/`seal` LDAP search harness ran on the default (AES256) session key and passed, proving the CFX path is unchanged.
- `go build ./...`, `go vet ./network/kerberos/v5/gssapi/`, and `go test ./network/kerberos/v5/gssapi/ ./network/ldap/` all pass.

### Test Coverage
**Added** (`network/kerberos/v5/gssapi/rc4permessage_test.go`):
- `TestRC4WrapDispatchesRC4Token` — an RC4 context's `Wrap(pt, true)` emits a `02 01` (not `05 04`) token with SEAL_ALG `10 00`, does not leak plaintext, and round-trips through a peer `Unwrap`.
- `TestRC4WrapIntegrityOnlyRoundTrip` — `Wrap(pt, false)` emits SEAL_ALG `ff ff` carrying data in clear, round-trips integrity-only, and fails on tamper.
- `TestRC4WrapAlignedPadding` — round-trip for 8-aligned data (arcfour single-octet pad).
Existing RC4 known-answer vectors (`TestSealRC4KnownAnswer`, `TestMakeMICRC4KnownAnswer`) remain green.

### Scope of Change
- **Files changed:** `network/kerberos/v5/gssapi/permessage.go`, `network/kerberos/v5/gssapi/rc4permessage.go`, `network/kerberos/v5/gssapi/rc4permessage_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local to the GSS-API per-message layer. Non-RC4 (AES CFX) contexts hit an early etype check and take the identical pre-existing code path, so the dominant AES case is unaffected; safe to merge.