### PR TITLE
Fix KerberosTime Marshal paths to normalize to UTC (Fixes #1016)

### DIFF
--- a/network/kerberos/v5/messages/authenticator.go
+++ b/network/kerberos/v5/messages/authenticator.go
@@ -88,7 +88,7 @@ func (a *Authenticator) Marshal() ([]byte, error) {
 		CRealm:    realmExplicit(1, a.CRealm),
 		CName:     MarshalPrincipalName(a.CName),
 		CUSec:     a.CUSec,
-		CTime:     a.CTime,
+		CTime:     normalizeTime(a.CTime),
 		SeqNumber: a.SeqNumber,
 	}
 	if a.Cksum != nil {

--- a/network/kerberos/v5/messages/kdcreqbody.go
+++ b/network/kerberos/v5/messages/kdcreqbody.go
@@ -44,19 +44,26 @@ func marshalKDCReqBody(b KDCReqBody) kdcReqBodyMarshal {
 	if len(b.CName.NameString) > 0 {
 		cname = MarshalPrincipalName(b.CName)
 	}
-	return kdcReqBodyMarshal{
+	m := kdcReqBodyMarshal{
 		KDCOptions:  b.KDCOptions,
 		CName:       cname,
 		Realm:       realmExplicit(2, b.Realm),
 		SName:       MarshalPrincipalName(b.SName),
-		From:        b.From,
-		Till:        b.Till,
-		RTime:       b.RTime,
+		Till:        normalizeTime(b.Till),
 		Nonce:       b.Nonce,
 		EType:       b.EType,
 		Addresses:   b.Addresses,
 		EncAuthData: b.EncAuthData,
 	}
+	// From and RTime are optional: only normalize (and thus emit) them when set,
+	// so a zero value stays the struct zero and the optional tag omits the field.
+	if !b.From.IsZero() {
+		m.From = normalizeTime(b.From)
+	}
+	if !b.RTime.IsZero() {
+		m.RTime = normalizeTime(b.RTime)
+	}
+	return m
 }
 
 // encodeKDCReqBodyForTGS marshals a KDC-REQ-BODY and, when the body carries

--- a/network/kerberos/v5/messages/kerberostime_utc_test.go
+++ b/network/kerberos/v5/messages/kerberostime_utc_test.go
@@ -1,0 +1,140 @@
+package messages
+
+import (
+	"bytes"
+	"testing"
+	"time"
+)
+
+// collectGeneralizedTimes walks a DER blob and returns the content octets of
+// every GeneralizedTime (universal tag 24, 0x18) primitive it contains. It
+// recurses into constructed values so explicitly-tagged timestamps are found.
+func collectGeneralizedTimes(der []byte) [][]byte {
+	var out [][]byte
+	i := 0
+	for i < len(der) {
+		tag := der[i]
+		i++
+		if i >= len(der) {
+			break
+		}
+		// Decode the (possibly long-form) length.
+		l := int(der[i])
+		i++
+		if l&0x80 != 0 {
+			n := l & 0x7f
+			l = 0
+			for k := 0; k < n && i < len(der); k++ {
+				l = l<<8 | int(der[i])
+				i++
+			}
+		}
+		if i+l > len(der) {
+			break
+		}
+		content := der[i : i+l]
+		if tag&0x20 != 0 { // constructed: recurse into the content
+			out = append(out, collectGeneralizedTimes(content)...)
+		} else if tag&0x1f == 0x18 && tag&0xc0 == 0x00 { // universal primitive GeneralizedTime
+			out = append(out, content)
+		}
+		i += l
+	}
+	return out
+}
+
+// assertUTCTimes fails unless every GeneralizedTime in der ends with 'Z' and
+// carries no numeric zone offset ('+'/'-'), i.e. the DER form RFC 4120 mandates.
+func assertUTCTimes(t *testing.T, der []byte, want int) {
+	t.Helper()
+	times := collectGeneralizedTimes(der)
+	if len(times) != want {
+		t.Fatalf("expected %d GeneralizedTime value(s), found %d: %q", want, len(times), times)
+	}
+	for _, tv := range times {
+		if len(tv) == 0 || tv[len(tv)-1] != 'Z' {
+			t.Errorf("GeneralizedTime %q does not end with UTC 'Z'", tv)
+		}
+		if bytes.ContainsAny(tv, "+-") {
+			t.Errorf("GeneralizedTime %q carries a numeric zone offset", tv)
+		}
+	}
+}
+
+// TestAuthenticatorMarshalNormalizesCTime confirms a non-UTC CTime is emitted as
+// a UTC GeneralizedTime (trailing 'Z', no numeric offset).
+func TestAuthenticatorMarshalNormalizesCTime(t *testing.T) {
+	loc := time.FixedZone("X", -5*3600)
+	a := &Authenticator{
+		AVno:   KerberosV5,
+		CRealm: "CORP.LOCAL",
+		CName:  cliName(),
+		CUSec:  42,
+		CTime:  time.Date(2026, 7, 10, 12, 0, 0, 0, loc),
+	}
+	wire, err := a.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	assertUTCTimes(t, wire, 1)
+}
+
+// TestKDCReqBodyMarshalNormalizesTill confirms a non-UTC Till is emitted in UTC
+// and that an omitted optional From/RTime stays absent from the wire form.
+func TestKDCReqBodyMarshalNormalizesTill(t *testing.T) {
+	loc := time.FixedZone("X", -5*3600)
+	body := KDCReqBody{
+		KDCOptions: NewKerberosFlags(1, 3, 8),
+		CName:      cliName(),
+		Realm:      "CORP.LOCAL",
+		SName:      tgtSName(),
+		Till:       time.Date(2026, 7, 10, 12, 0, 0, 0, loc),
+		Nonce:      0x2A2A2A2A,
+		EType:      []int{ETypeAES256CTSHMACSHA196},
+	}
+	wire, err := EncodeKDCReqBody(body)
+	if err != nil {
+		t.Fatalf("EncodeKDCReqBody: %v", err)
+	}
+	// From and RTime are left zero, so only Till must appear.
+	assertUTCTimes(t, wire, 1)
+}
+
+// TestKDCReqBodyMarshalNormalizesAllTimes confirms that when From, Till and RTime
+// are all set in a non-UTC location, all three are emitted in UTC form.
+func TestKDCReqBodyMarshalNormalizesAllTimes(t *testing.T) {
+	loc := time.FixedZone("X", -5*3600)
+	tv := time.Date(2026, 7, 10, 12, 0, 0, 0, loc)
+	body := KDCReqBody{
+		KDCOptions: NewKerberosFlags(1, 3, 8),
+		CName:      cliName(),
+		Realm:      "CORP.LOCAL",
+		SName:      tgtSName(),
+		From:       tv,
+		Till:       tv,
+		RTime:      tv,
+		Nonce:      0x2A2A2A2A,
+		EType:      []int{ETypeAES256CTSHMACSHA196},
+	}
+	wire, err := EncodeKDCReqBody(body)
+	if err != nil {
+		t.Fatalf("EncodeKDCReqBody: %v", err)
+	}
+	assertUTCTimes(t, wire, 3)
+}
+
+// TestPAEncTSEncMarshalNormalizesTimestamp confirms a non-UTC PATimestamp is
+// emitted in UTC form and that Marshal does not mutate the receiver's field.
+func TestPAEncTSEncMarshalNormalizesTimestamp(t *testing.T) {
+	loc := time.FixedZone("X", -5*3600)
+	orig := time.Date(2026, 7, 10, 12, 0, 0, 0, loc)
+	p := &PAEncTSEnc{PATimestamp: orig, PAUSec: 42}
+	wire, err := p.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	assertUTCTimes(t, wire, 1)
+	if !p.PATimestamp.Equal(orig) || p.PATimestamp.Location() != loc {
+		t.Errorf("Marshal mutated receiver PATimestamp: %v", p.PATimestamp)
+	}
+}

--- a/network/kerberos/v5/messages/padata.go
+++ b/network/kerberos/v5/messages/padata.go
@@ -17,7 +17,11 @@ type PAEncTSEnc struct {
 
 // Marshal encodes PAEncTSEnc as a plain ASN.1 SEQUENCE (no APPLICATION wrapper).
 func (p *PAEncTSEnc) Marshal() ([]byte, error) {
-	return asn1.Marshal(*p)
+	// Normalize the timestamp to UTC in a local copy so the receiver's field is
+	// left untouched while the wire form still carries the mandatory "Z" zone.
+	m := *p
+	m.PATimestamp = normalizeTime(p.PATimestamp)
+	return asn1.Marshal(m)
 }
 
 // Unmarshal decodes PAEncTSEnc from a plain ASN.1 SEQUENCE.


### PR DESCRIPTION
### Linked Issue
`Closes #1016`

### Root Cause
Three Marshal paths in `network/kerberos/v5/messages` emitted their KerberosTime values raw, without the UTC normalization that every other Marshal in the package applies through the `normalizeTime` helper: `Authenticator.Marshal` (CTime), `marshalKDCReqBody` (From/Till/RTime) and `PAEncTSEnc.Marshal` (PATimestamp). RFC 4120 §5.2.3 requires a KerberosTime to be a GeneralizedTime in UTC with the `Z` designator and no fractional seconds. Go's `encoding/asn1` GeneralizedTime encoder honors a non-UTC `time.Time` location by writing a numeric zone offset (e.g. `20260710120000-0500`) rather than the mandatory `Z` form, which is an invalid DER encoding a KDC rejects. The defect was latent because the client normally sources its timestamps in UTC, so it only surfaces when a non-UTC `time.Time` reaches these paths.

### Fix Description
Apply `normalizeTime` (`t.UTC().Truncate(time.Second)`) at the three sites, mirroring the existing call sites (`encreppart.go`, `encticketpart.go`, `aprep.go`, `krbcred.go`, `fast.go`):
- `authenticator.go`: `CTime` normalized unconditionally (required field).
- `kdcreqbody.go`: `Till` normalized unconditionally; optional `From`/`RTime` normalized only when non-zero so an omitted optional stays absent from the wire (same `IsZero()` guard used in `encticketpart.go`).
- `padata.go`: `PATimestamp` normalized into a local copy of the receiver so the caller's field is not mutated.

### How Verified
- **Tests:** added `kerberostime_utc_test.go` with a DER walker that collects every GeneralizedTime primitive and asserts each ends in `Z` and carries no `+`/`-` offset. Cases: `Authenticator` CTime, `KDCReqBody` Till (also asserting omitted From/RTime stay absent — exactly one time on the wire), all-three KDCReqBody times, and `PAEncTSEnc` PATimestamp (also asserting the receiver is not mutated), all built with `time.FixedZone("X", -5*3600)`. The Marshal tests FAIL before the fix (emit `20260710120000-0500`) and PASS after.
- **Build/vet/test:** `go build ./...`, `go vet ./network/kerberos/v5/messages/`, and `go test ./network/kerberos/v5/messages/` all green.
- **Live (no-regression):** ran a throwaway harness against the lab DC (10.7.0.10, realm TMP-W-2016.LOCAL, Administrator) that does GetTGT by password (AS-REQ: KDCReqBody Till + PA-ENC-TIMESTAMP) then GetTGS for `ldap/tmp-w-2016.tmp-w-2016.local` (TGS-REQ Authenticator) — both succeeded (service ticket, etype 18). Since the client sources UTC internally there is no live injection point for a non-UTC time, so this live run is the no-regression check and the unit test is the authoritative proof of the fix.

### Test Coverage
- **Added:** `network/kerberos/v5/messages/kerberostime_utc_test.go` — `TestAuthenticatorMarshalNormalizesCTime`, `TestKDCReqBodyMarshalNormalizesTill`, `TestKDCReqBodyMarshalNormalizesAllTimes`, `TestPAEncTSEncMarshalNormalizesTimestamp`.

### Scope of Change
- **Files changed:** `network/kerberos/v5/messages/authenticator.go`, `network/kerberos/v5/messages/kdcreqbody.go`, `network/kerberos/v5/messages/padata.go`, `network/kerberos/v5/messages/kerberostime_utc_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local and low blast radius: the change only forces UTC on timestamps that must already be UTC per RFC 4120; UTC inputs (the normal case) are unaffected. Safe to merge without staged rollout.