### PR TITLE
Fix ccache reader to reject negative lengths (Fixes #1017)

### DIFF
--- a/network/kerberos/v5/credcache/ccache/ccache.go
+++ b/network/kerberos/v5/credcache/ccache/ccache.go
@@ -172,7 +172,7 @@ type reader struct {
 }
 
 func (r *reader) need(n int) error {
-	if r.pos+n > len(r.b) {
+	if n < 0 || r.pos+n > len(r.b) {
 		return fmt.Errorf("ccache: truncated: need %d bytes at offset %d of %d", n, r.pos, len(r.b))
 	}
 	return nil

--- a/network/kerberos/v5/credcache/ccache/ccache_test.go
+++ b/network/kerberos/v5/credcache/ccache/ccache_test.go
@@ -106,6 +106,34 @@ func TestCCacheRejectsWrongVersion(t *testing.T) {
 	}
 }
 
+// TestCCacheRejectsHugeLength ensures a hostile variable-length field with a
+// declared length that overflows the remaining buffer is rejected with a clean
+// error instead of panicking in make([]byte, n). The 0x80000000 length also
+// covers the negative-int path of need(): on a 32-bit build int(n) is negative,
+// which the n < 0 guard rejects (mirroring the keytab reader); on a 64-bit build
+// it is a large positive value caught by the pos+n > len(b) bounds check.
+func TestCCacheRejectsHugeLength(t *testing.T) {
+	// version 4 (05 04), empty header (00 00), then a principal whose realm
+	// data field claims a length of 0x80000000 bytes.
+	crafted := []byte{
+		0x05, 0x04, // version 4
+		0x00, 0x00, // header length 0
+		0x00, 0x00, 0x00, 0x01, // principal name-type
+		0x00, 0x00, 0x00, 0x00, // component count 0
+		0x80, 0x00, 0x00, 0x00, // realm length 0x80000000 (hostile)
+	}
+	if _, err := Unmarshal(crafted); err == nil {
+		t.Fatal("expected error for oversized length field, got nil")
+	}
+
+	// A plainly-too-large length that exceeds the buffer on any platform must
+	// likewise return an error rather than reading out of bounds.
+	crafted[12], crafted[13], crafted[14], crafted[15] = 0x00, 0x00, 0xFF, 0xFF
+	if _, err := Unmarshal(crafted); err == nil {
+		t.Fatal("expected error for length exceeding buffer, got nil")
+	}
+}
+
 func TestCCacheEmptyHeaderNoDelta(t *testing.T) {
 	cc := &CCache{DefaultPrincipal: Principal{NameType: 1, Realm: "R", Components: []string{"u"}}}
 	b, err := cc.Marshal()


### PR DESCRIPTION
### Linked Issue
`Closes #1017`

### Root Cause
The ccache byte reader (`network/kerberos/v5/credcache/ccache/ccache.go`) reads variable-length fields as MIT "counted octet strings": a 32-bit big-endian length prefix followed by that many value bytes. Its `need(n int)` bounds check only tested `r.pos+n > len(r.b)`, omitting the `n < 0` guard that its keytab-reader sibling (`keytab.go:275`) already has. Because the declared length is a `uint32`, a crafted value greater than 2^31 becomes a negative `int(n)` on a 32-bit build. A negative `n` slips past the upper-bound check (`r.pos+n` is smaller than `len(r.b)`), then reaches `make([]byte, n)` in `data()`, which panics with `makeslice: len out of range` — a parse-time denial of service on untrusted ccache input.

### Fix Description
Add the `n < 0` guard to `need()`, before the existing upper-bound check, exactly mirroring the keytab reader's guard and error idiom. A hostile length is now rejected with a clean `ccache: truncated: ...` error on every platform: on 64-bit `int(n)` is a large positive value caught by the bounds check; on 32-bit the negative `int(n)` is caught by the new guard. All callers of `need`/`data` already propagate the returned error, so no other change is required.

### How Verified
- `go build ./...`, `go vet ./network/kerberos/v5/credcache/...`, and `go test ./network/kerberos/v5/credcache/...` all pass.
- New unit test `TestCCacheRejectsHugeLength` feeds `Unmarshal` a crafted v4 ccache whose realm length field is `0x80000000` (and a second case exceeding the buffer) and asserts a graceful error rather than a panic.
- No regression: real ccache files (`.private/kerberos/{tgt,l,opth}.ccache`) still parse correctly via a gitignored harness — principal `Administrator@TMP-W-2016.LOCAL`, `krbtgt` TGT, etypes 18/23.
- Cross-checked the MIT ccache format doc: variable-length fields use a 32-bit length prefix (counted octet string), so a hostile length is representable.

### Test Coverage
- **Added:** `TestCCacheRejectsHugeLength` in `network/kerberos/v5/credcache/ccache/ccache_test.go`. Existing round-trip / save-load / version tests remain green.

### Scope of Change
- **Files changed:** `network/kerberos/v5/credcache/ccache/ccache.go`, `network/kerberos/v5/credcache/ccache/ccache_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Minimal, local blast radius: one added guard on a rejection path. Legitimate ccache files are unaffected (verified against real captures); safe to merge without staged rollout.