### PR TITLE
Fix RC4-HMAC GSS MIC checksum to sign unpadded data (Fixes #1022)

### DIFF
--- a/network/kerberos/v5/gssapi/rc4permessage.go
+++ b/network/kerberos/v5/gssapi/rc4permessage.go
@@ -43,18 +43,6 @@ func le32(v uint32) []byte {
 	return b
 }
 
-// rc4MICPad returns the RC4 MIC pad: the data is padded to a 4-byte boundary with
-// the pad length byte (RFC 4757 / MIT behaviour). The pad is folded into the
-// checksum only; it is not transmitted.
-func rc4MICPad(n int) []byte {
-	pad := (4 - (n % 4)) & 3
-	out := make([]byte, pad)
-	for i := range out {
-		out[i] = byte(pad)
-	}
-	return out
-}
-
 // rc4MICSeqBytes builds the 8-byte SND_SEQ field before encryption: the 32-bit
 // sequence number (big-endian) followed by the 4-byte direction indicator (0x00
 // for initiator-sent tokens, 0xff for acceptor-sent tokens).
@@ -130,15 +118,16 @@ func (ctx *SecContext) verifyMICRC4(data, token []byte) error {
 }
 
 // rc4SgnCksum computes the RC4 MIC SGN_CKSUM: HMAC-MD5(Ksign, MD5(LE32(15) |
-// tokenHeader[:8] | data | pad)), truncated to 8 bytes. Ksign is HMAC-MD5(key,
-// "signaturekey\0"). The literal 15 is the MIC "sign" key-usage seed.
+// tokenHeader[:8] | data)), truncated to 8 bytes. Ksign is HMAC-MD5(key,
+// "signaturekey\0"). The literal 15 is the MIC "sign" key-usage seed. Per RFC
+// 4757 §7.2 the checksum is computed over the data as-is: unlike the Wrap token,
+// the MIC token does not pad the signed data.
 func rc4SgnCksum(key, hdr8, data []byte) []byte {
 	ksign := hmacMD5(key, []byte("signaturekey\x00"))
-	buf := make([]byte, 0, 4+8+len(data)+3)
+	buf := make([]byte, 0, 4+8+len(data))
 	buf = append(buf, le32(15)...)
 	buf = append(buf, hdr8...)
 	buf = append(buf, data...)
-	buf = append(buf, rc4MICPad(len(data))...)
 	return hmacMD5(ksign, md5sum(buf))[:8]
 }
 

--- a/network/kerberos/v5/gssapi/rc4permessage_test.go
+++ b/network/kerberos/v5/gssapi/rc4permessage_test.go
@@ -30,6 +30,46 @@ func TestMakeMICRC4KnownAnswer(t *testing.T) {
 	}
 }
 
+// TestRC4MICUnpaddedKnownAnswer pins the RFC 4757 §7.2 RC4-HMAC GSS MIC
+// SGN_CKSUM over messages whose length is NOT a multiple of four. §7.2 signs the
+// data as-is: unlike the Wrap token, the MIC token does not pad the signed data.
+// Each SGN_CKSUM below is the trailing 8 octets of the MIC token — the value of
+// HMAC-MD5(Ksign, MD5(LE32(15) | hdr8 | data))[:8] computed per RFC 4757 §7.2
+// for the fixed RC4 session key. A checksum that folded a 4-byte pad into the
+// MD5 buffer would miss every one of these vectors, so this is the regression
+// guard against re-introducing the pad on the MIC path.
+func TestRC4MICUnpaddedKnownAnswer(t *testing.T) {
+	key, _ := hex.DecodeString("1e9581d2fc64114fbbb0f7ac4502cf2a")
+	ctx := &SecContext{SessionKey: key, SessionEType: rc4HMACEType}
+
+	cases := []struct {
+		data    string
+		sgnCkum string // the trailing 8-octet SGN_CKSUM
+	}{
+		{"A", "fb9d3561dda207b2"},       // len 1, len%4 == 1
+		{"BB", "eb0be530c54313a8"},      // len 2, len%4 == 2
+		{"CCC", "565867a1e3d3b4d4"},     // len 3, len%4 == 3
+		{"DDDDD", "fd2850c069c86363"},   // len 5, len%4 == 1
+		{"EEEEEE", "5c15be411d0ef3f8"},  // len 6, len%4 == 2
+		{"GGGGGGG", "12bbf34046e7e340"}, // len 7, len%4 == 3
+	}
+
+	for _, c := range cases {
+		mic, err := ctx.MakeMIC([]byte(c.data))
+		if err != nil {
+			t.Fatalf("MakeMIC(%q): %v", c.data, err)
+		}
+		if len(mic) != rc4MICTokenLen {
+			t.Fatalf("MIC(%q) length = %d, want %d", c.data, len(mic), rc4MICTokenLen)
+		}
+		got := mic[len(mic)-8:] // SGN_CKSUM is the final 8 octets
+		want, _ := hex.DecodeString(c.sgnCkum)
+		if !bytes.Equal(got, want) {
+			t.Errorf("MIC SGN_CKSUM(%q) = %x, want %x", c.data, got, want)
+		}
+	}
+}
+
 // TestRC4MICRoundTrip confirms an acceptor-direction token verifies, and that a
 // tampered message fails verification.
 func TestRC4MICRoundTrip(t *testing.T) {


### PR DESCRIPTION
### Linked Issue
`Closes #1022`

### Root Cause
The RC4-HMAC per-message MIC token (RFC 4757 §7.2, TOK_ID 01 01) derives its SGN_CKSUM as `HMAC-MD5(Ksign, MD5(LE32(15) | Token.Header | data))`, where the signed `data` is taken exactly as supplied. The implementation instead appended a 4-byte-boundary pad (each byte the pad length) to the MD5 input via a helper `rc4MICPad`, conflating the MIC token with the Wrap token — only the Wrap token (§7.3) pads its sealed region. For any signed message whose length was not a multiple of four, this produced a checksum over `LE32(15) | hdr8 | data | pad` instead of `LE32(15) | hdr8 | data`, i.e. a MIC that does not match the spec. The defect was latent because the real DCE/RPC consumer always signs a 4-aligned padded stub (pad length 0), so the extra term was empty in production.

### Fix Description
Remove the `rc4MICPad(len(data))` term from `rc4SgnCksum` so the MD5 buffer is exactly `LE32(15) | hdr8 | data`, matching RFC 4757 §7.2. The now-unused `rc4MICPad` helper is deleted and the `rc4SgnCksum` doc comment updated to state that the MIC data is unpadded. The Wrap-token pad functions — `rc4WrapPad` (DCE 8-byte) and `rc4WrapPadStandalone` (RFC 1964 1-byte) — are deliberately left untouched; both were previously verified correct on the wire against the DC.

### How Verified
- **Unit / KAT:** added `TestRC4MICUnpaddedKnownAnswer`, a known-answer test over six non-4-aligned messages (lengths 1,2,3,5,6,7) with expected SGN_CKSUM values computed per RFC 4757 §7.2. The KAT **fails** against the pre-fix (4-byte-pad) code — e.g. `MIC("A") = 0bfa7be6800bc73e, want fb9d3561dda207b2` for all six — and **passes** after the fix. The expected vectors were independently reproduced by a from-scratch hand-computation of the §7.2 algorithm (Ksign = HMAC-MD5(Kss, "signaturekey\0"), seed 15, first 8 octets).
- **Spec:** re-confirmed RFC 4757 §7.2 `Sgn_Cksum = MD5((int32)15, Token.Header, data)` — data unpadded.
- **Live PKT_INTEGRITY (no regression):** ran a forced-RC4 (etype 23) DCE/RPC bind at `RPC_C_AUTHN_LEVEL_PKT_INTEGRITY` against the lab DC and drove `ept_lookup`. The DC accepted our request MIC and the client verified the server's response MIC (`status=0x00000000`). The RPC stub is 4-aligned, so the MIC pad was empty either way — confirming the fix does not change and does not break the real consumer.
- `go build ./...`, `go vet ./network/kerberos/v5/gssapi/`, and `go test ./network/kerberos/v5/gssapi/` all green.

### Test Coverage
- **Added:** `TestRC4MICUnpaddedKnownAnswer` in `network/kerberos/v5/gssapi/rc4permessage_test.go`.
- **Existing:** `TestMakeMICRC4KnownAnswer` (4-aligned stub, pad 0), the RC4 MIC/Wrap round-trip and known-answer tests, and replay-enforcement tests remain green. No existing test asserted an old-pad checksum over non-4-aligned data, so none required correction.

### Scope of Change
- **Files changed:** `network/kerberos/v5/gssapi/rc4permessage.go`, `network/kerberos/v5/gssapi/rc4permessage_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local to the RC4-HMAC MIC checksum. The only behavioral change is for MIC tokens over data whose length is not a multiple of four, which now match RFC 4757 §7.2; the 4-aligned DCE/RPC path is byte-identical and was live-validated for no regression. Safe to merge without staged rollout.