### PR TITLE
Fix AS-REP hashcat formatter to reject unsupported AES etypes (Fixes #1024)

### DIFF
--- a/network/kerberos/v5/attacks/hashcat.go
+++ b/network/kerberos/v5/attacks/hashcat.go
@@ -55,16 +55,27 @@ func splitCipher(etype int, cipher []byte) (cksum, edata []byte, err error) {
 }
 
 // FormatASREPHash formats an AS-REP encrypted part as a hashcat AS-REP-roast
-// hash. RC4 (etype 23) yields the mode-18200 form
-// "$krb5asrep$23$user@realm:<checksum>$<edata>"; AES enctypes use the analogous
-// "$krb5asrep$<etype>$user@realm:<checksum>$<edata>".
+// hash. Only RC4 (etype 23) is supported: it yields the mode-18200 form
+// "$krb5asrep$23$user@realm:<checksum>$<edata>".
+//
+// hashcat has NO AS-REP mode for AES enctypes — mode 18200 is RC4/etype-23 only,
+// and the AES Kerberos modes cover TGS-REP (19600/19700), Pre-Auth (19800/19900)
+// and the KDC database (28800/28900), not AS-REP. Emitting an "$krb5asrep$17/18$"
+// string is therefore uncrackable (hashcat rejects it with a token-length error),
+// so this function returns an error for any non-RC4 etype. Use
+// FormatASREPHashJohn (John the Ripper), which does support AES AS-REP roasting.
 func FormatASREPHash(username, realm string, etype int, cipher []byte) (string, error) {
+	if etype != iana.ETypeRC4HMAC {
+		return "", fmt.Errorf("attacks: hashcat has no AS-REP mode for etype %d; "+
+			"hashcat AS-REP roasting supports only RC4 (etype 23, mode 18200) — "+
+			"format AES AS-REP hashes with FormatASREPHashJohn (John the Ripper) instead", etype)
+	}
 	cksum, edata, err := splitCipher(etype, cipher)
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("$krb5asrep$%d$%s@%s:%s$%s",
-		etype, username, realm, hex.EncodeToString(cksum), hex.EncodeToString(edata)), nil
+	return fmt.Sprintf("$krb5asrep$23$%s@%s:%s$%s",
+		username, realm, hex.EncodeToString(cksum), hex.EncodeToString(edata)), nil
 }
 
 // FormatTGSHash formats a service ticket's encrypted part as a hashcat

--- a/network/kerberos/v5/attacks/hashcat_test.go
+++ b/network/kerberos/v5/attacks/hashcat_test.go
@@ -50,6 +50,27 @@ func TestFormatASREPHashRC4(t *testing.T) {
 	}
 }
 
+// TestFormatASREPHashRejectsAES verifies that FormatASREPHash refuses every AES
+// enctype: hashcat has no AS-REP mode for AES (mode 18200 is RC4/etype-23 only),
+// so an "$krb5asrep$17/18/19/20$" string would be uncrackable. AES AS-REP hashes
+// must go through FormatASREPHashJohn instead.
+func TestFormatASREPHashRejectsAES(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		etype int
+	}{
+		{"aes128-sha1", iana.ETypeAES128CTSHMACSHA196},
+		{"aes256-sha1", iana.ETypeAES256CTSHMACSHA196},
+		{"aes256-sha2", iana.ETypeAES256CTSHMACSHA384},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := FormatASREPHash("user", "domain.com", tc.etype, make([]byte, 64)); err == nil {
+				t.Errorf("expected error for AES etype %d, got nil", tc.etype)
+			}
+		})
+	}
+}
+
 func lastTwoFields(s string) (secondLast, last string) {
 	f := strings.Split(s, "$")
 	return f[len(f)-2], f[len(f)-1]


### PR DESCRIPTION
### Linked Issue
`Closes #1024`

### Root Cause
`FormatASREPHash` treated AES enctypes as an "analogous" case to RC4 and emitted `$krb5asrep$<etype>$user@realm:<checksum>$<edata>` for etypes 17/18/19/20. That was based on a false assumption: hashcat's AS-REP-roast mode (18200) is RC4/etype-23 only. hashcat has no AS-REP mode for AES — its AES Kerberos modes cover TGS-REP (19600/19700), Pre-Auth (19800/19900) and the KDC database (28800/28900), none of which parse an AS-REP colon-string. So the AES output the function produced was silently uncrackable: hashcat rejects it outright with a "Token length exception".

### Fix Description
`FormatASREPHash` now returns a clear error for any etype other than RC4 (`iana.ETypeRC4HMAC`), stating that hashcat AS-REP roasting supports only RC4 (etype 23, mode 18200) and that AES AS-REP hashes should be formatted with `FormatASREPHashJohn` (John the Ripper), which already handles them correctly. The RC4 path is unchanged and still emits the exact mode-18200 form `$krb5asrep$23$user@realm:<checksum>$<edata>`. The doc comment was corrected to state the AES-unsupported fact and point to the John formatter. `FormatTGSHash` (hashcat DOES support AES TGS via 19600/19700), `FormatASREPHashJohn`, and `FormatTGSHashJohn` are untouched.

### How Verified
Cross-checked against hashcat documentation/issues that mode 18200 is etype-23 only and that no AES AS-REP mode exists. Live crack demonstration against a lab DC (realm TMP-W-2016.LOCAL) using local hashcat v6.2.6 and a from-source John Jumbo build, all recovering the known password `Autumn2026!`:

- **RC4 → hashcat -m 18200:** a genuine RC4 AS-REP enc-part (a real AES-roasted `EncASRepPart`, decrypted with the account password and re-encrypted under the RC4 key) formatted with `FormatASREPHash` → hashcat status **Cracked**, recovered `Autumn2026!`.
- **AES → hashcat -m 18200 (old behavior):** the pre-fix `$krb5asrep$18$user@realm:<cksum>$<edata>` colon-string built from a live AES (etype 18) AS-REP → hashcat **"Token length exception", "No hashes loaded"** — confirming why the old output was broken.
- **AES → John `--format=krb5asrep`:** the same live AES enc-part formatted with `FormatASREPHashJohn` → John (krb5asrep, etype 18) **cracked**, recovered `Autumn2026!`. This is the correct AES AS-REP route.

`go build ./...`, `go vet ./network/kerberos/v5/attacks/`, and `go test ./network/kerberos/v5/attacks/` are green.

### Test Coverage
- **Added:** `TestFormatASREPHashRejectsAES` (in `hashcat_test.go`) asserts `FormatASREPHash` returns an error for `ETypeAES128CTSHMACSHA196`, `ETypeAES256CTSHMACSHA196`, and an AES-SHA2 etype.
- **Existing:** `TestFormatASREPHashRC4` still asserts the exact mode-18200 RC4 string; all `FormatASREPHashJohn` tests (including the John AES `tests[]` vector) remain green and unchanged.

### Scope of Change
- **Files changed:** `network/kerberos/v5/attacks/hashcat.go`, `network/kerberos/v5/attacks/hashcat_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local, self-contained change to one formatter. The only behavioral change is that AES etypes now error instead of returning an uncrackable string; there are no in-tree callers of `FormatASREPHash`. Safe to merge without staged rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)