### PR TITLE
Fix Kerberoast doc example to use the account name for the AES salt (Fixes #1026)

### DIFF
--- a/network/kerberos/v5/kerberoast.go
+++ b/network/kerberos/v5/kerberoast.go
@@ -4,7 +4,13 @@ package kerberos
 // obtained for a target SPN. The service ticket's enc-part is encrypted with the
 // service account's long-term key, so it can be cracked offline to recover that
 // account's password. Format it for a cracker with
-// attacks.FormatTGSHash(spn, result.Realm, spn, result.EType, result.Cipher).
+// attacks.FormatTGSHash(account, result.Realm, result.SPN, result.EType, result.Cipher),
+// where account is the service account's sAMAccountName. The account is the
+// AES string-to-key salt input (UPPER(realm)+account), so passing the SPN there
+// produces the wrong salt and an uncrackable AES hash; it is not carried on the
+// result and must be resolved separately (e.g. the account owning the SPN in the
+// directory). For RC4 (etype 23) the account field is not used in the salt, so any
+// placeholder cracks, but supplying the real sAMAccountName keeps both etypes correct.
 type KerberoastResult struct {
 	// SPN is the service principal name that was roasted.
 	SPN string


### PR DESCRIPTION
### Linked Issue
`Closes #1026`

### Root Cause
The `KerberoastResult` doc comment conflated the SPN with the service account name, instructing callers to pass the SPN as the `account` argument to `attacks.FormatTGSHash(account, realm, spn, …)`. `FormatTGSHash`'s AES branch derives the string-to-key salt as `UPPER(realm)+account` (`attacks/john.go:36`), so the SPN-as-account example built the salt from the SPN. The mistake was invisible for RC4 (etype 23 does not salt on the account) and only broke AES (etype 17/18) service tickets.

### Fix Description
Documentation-only change to the `KerberoastResult` comment: the example now passes the service account's sAMAccountName as `account` and `result.SPN` as the SPN, and explains that (a) the account is the AES salt input so the SPN must not be used there, (b) the account is not carried on the result and must be resolved separately (e.g. the account owning the SPN in the directory), and (c) RC4 does not use the account in its salt. No code behavior changes; `FormatTGSHash` was already correct when given the true account name.

### How Verified
- **Static:** `FormatTGSHash` signature (`attacks/hashcat.go:75`) and the AES salt `aesSalt(account, realm) = ToUpper(realm)+account` (`attacks/john.go:36`) confirm the account argument is the salt input; the corrected example supplies the sAMAccountName there.
- **Runtime:** `go build ./network/kerberos/...`, `go vet`, and `go test ./network/kerberos/v5/attacks/` all pass. The AES Kerberoast salt behavior the corrected guidance relies on was live-crack-validated in the AS-REP/Kerberoast formatter work (issue #1024 / PR #1025).

### Test Coverage
- **Existing:** the `attacks` package tests already cover `FormatTGSHash`/`FormatTGSHashJohn` for RC4 and AES with the correct account name; no behavior changed, so no new test is applicable to a doc-only fix.

### Scope of Change
- **Files changed:** `network/kerberos/v5/kerberoast.go` (comment only)
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none
