### PR TITLE
Add built-in SPN service class recognition and HOST substitution (Fixes #1028)

### DIFF
--- a/windows/kerberos/serviceprincipalname/builtin.go
+++ b/windows/kerberos/serviceprincipalname/builtin.go
@@ -1,0 +1,122 @@
+package serviceprincipalname
+
+import (
+	"sort"
+	"strings"
+)
+
+// HostServiceClass is the special "HOST" service class. A HOST SPN registered on
+// a computer account implicitly substitutes for every built-in service class SPN
+// (see BuiltInServiceClasses): unless a built-in SPN is explicitly registered on
+// another object, a client requesting it is satisfied by the computer's HOST SPN.
+// HOST itself is not one of the built-in service classes; it is the class that
+// stands in for them.
+const HostServiceClass = "HOST"
+
+// builtInServiceClasses is the set of service class names that Active Directory
+// recognizes as built-in SPNs for computer accounts. The names are stored
+// lowercased; SPNs are not case sensitive, so all lookups fold case.
+//
+// Source (verbatim list): https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/setspn
+// ("The built-in SPNs that are recognized for computer accounts are:").
+var builtInServiceClasses = map[string]struct{}{
+	"alerter":          {},
+	"appmgmt":          {},
+	"browser":          {},
+	"cifs":             {},
+	"cisvc":            {},
+	"clipsrv":          {},
+	"dcom":             {},
+	"dhcp":             {},
+	"dmserver":         {},
+	"dns":              {},
+	"dnscache":         {},
+	"eventlog":         {},
+	"eventsystem":      {},
+	"fax":              {},
+	"http":             {},
+	"ias":              {},
+	"iisadmin":         {},
+	"mcsvc":            {},
+	"messenger":        {},
+	"msiserver":        {},
+	"netdde":           {},
+	"netddedsm":        {},
+	"netlogon":         {},
+	"netman":           {},
+	"nmagent":          {},
+	"oakley":           {},
+	"plugplay":         {},
+	"policyagent":      {},
+	"protectedstorage": {},
+	"rasman":           {},
+	"remoteaccess":     {},
+	"replicator":       {},
+	"rpc":              {},
+	"rpclocator":       {},
+	"rpcss":            {},
+	"rsvp":             {},
+	"samss":            {},
+	"scardsvr":         {},
+	"scesrv":           {},
+	"schedule":         {},
+	"scm":              {},
+	"seclogon":         {},
+	"snmp":             {},
+	"spooler":          {},
+	"tapisrv":          {},
+	"time":             {},
+	"trksvr":           {},
+	"trkwks":           {},
+	"ups":              {},
+	"w3svc":            {},
+	"wins":             {},
+	"www":              {},
+}
+
+// BuiltInServiceClasses returns the built-in SPN service class names recognized
+// for computer accounts, lowercased and sorted. The returned slice is a fresh
+// copy the caller may modify. HOST is not included (see HostServiceClass).
+func BuiltInServiceClasses() []string {
+	out := make([]string, 0, len(builtInServiceClasses))
+	for class := range builtInServiceClasses {
+		out = append(out, class)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// IsBuiltInServiceClass reports whether class is one of the built-in SPN service
+// classes recognized for computer accounts. The comparison is case-insensitive.
+func IsBuiltInServiceClass(class string) bool {
+	_, ok := builtInServiceClasses[strings.ToLower(class)]
+	return ok
+}
+
+// IsBuiltInServiceClass reports whether the SPN's service class is one of the
+// built-in service classes recognized for computer accounts (case-insensitive).
+func (s *ServicePrincipalName) IsBuiltInServiceClass() bool {
+	if s == nil {
+		return false
+	}
+	return IsBuiltInServiceClass(s.ServiceClass)
+}
+
+// IsHostServiceClass reports whether the SPN's service class is the special
+// "HOST" class (case-insensitive).
+func (s *ServicePrincipalName) IsHostServiceClass() bool {
+	if s == nil {
+		return false
+	}
+	return strings.EqualFold(s.ServiceClass, HostServiceClass)
+}
+
+// CoveredByHostSPN reports whether a HOST SPN on the same computer account would
+// implicitly satisfy a request for this SPN. This is true exactly when the
+// service class is a built-in one: per the setspn documentation, a computer's
+// HOST SPN substitutes for any built-in service class SPN that is not explicitly
+// registered on another object. It does not account for such explicit
+// registrations, which are not knowable from the SPN string alone.
+func (s *ServicePrincipalName) CoveredByHostSPN() bool {
+	return s.IsBuiltInServiceClass()
+}

--- a/windows/kerberos/serviceprincipalname/builtin_test.go
+++ b/windows/kerberos/serviceprincipalname/builtin_test.go
@@ -1,0 +1,102 @@
+package serviceprincipalname
+
+import "testing"
+
+// builtInList is the verbatim built-in SPN list from the setspn documentation
+// (https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/setspn),
+// used as an independent known-answer check against the package's own set.
+var builtInList = []string{
+	"alerter", "appmgmt", "browser", "cifs", "cisvc", "clipsrv",
+	"dcom", "dhcp", "dmserver", "dns", "dnscache", "eventlog",
+	"eventsystem", "fax", "http", "ias", "iisadmin", "mcsvc",
+	"messenger", "msiserver", "netdde", "netddedsm", "netlogon", "netman",
+	"nmagent", "oakley", "plugplay", "policyagent", "protectedstorage", "rasman",
+	"remoteaccess", "replicator", "rpc", "rpclocator", "rpcss", "rsvp",
+	"samss", "scardsvr", "scesrv", "schedule", "scm", "seclogon",
+	"snmp", "spooler", "tapisrv", "time", "trksvr", "trkwks",
+	"ups", "w3svc", "wins", "www",
+}
+
+func TestBuiltInServiceClassesMatchesDoc(t *testing.T) {
+	got := BuiltInServiceClasses()
+	if len(got) != len(builtInList) {
+		t.Fatalf("BuiltInServiceClasses len = %d, want %d", len(got), len(builtInList))
+	}
+	// BuiltInServiceClasses is documented to return a sorted slice; builtInList is
+	// already sorted, so compare element-wise.
+	for i := range builtInList {
+		if got[i] != builtInList[i] {
+			t.Errorf("BuiltInServiceClasses[%d] = %q, want %q", i, got[i], builtInList[i])
+		}
+	}
+}
+
+func TestIsBuiltInServiceClass(t *testing.T) {
+	for _, class := range builtInList {
+		if !IsBuiltInServiceClass(class) {
+			t.Errorf("IsBuiltInServiceClass(%q) = false, want true", class)
+		}
+		// SPNs are not case sensitive: uppercase must match too.
+		up := ""
+		for _, r := range class {
+			if r >= 'a' && r <= 'z' {
+				r -= 'a' - 'A'
+			}
+			up += string(r)
+		}
+		if !IsBuiltInServiceClass(up) {
+			t.Errorf("IsBuiltInServiceClass(%q) = false, want true (case-insensitive)", up)
+		}
+	}
+
+	for _, class := range []string{"HOST", "host", "MSSQLSvc", "ldap", "", "htttp"} {
+		if IsBuiltInServiceClass(class) {
+			t.Errorf("IsBuiltInServiceClass(%q) = true, want false", class)
+		}
+	}
+}
+
+func TestHostIsNotBuiltIn(t *testing.T) {
+	// HOST is the substituting class, not itself a built-in service class.
+	if IsBuiltInServiceClass(HostServiceClass) {
+		t.Errorf("IsBuiltInServiceClass(%q) = true, want false", HostServiceClass)
+	}
+}
+
+func TestSPNBuiltInMethods(t *testing.T) {
+	tests := []struct {
+		spn     string
+		builtIn bool
+		host    bool
+		covered bool
+	}{
+		{"cifs/server.corp.local", true, false, true},
+		{"HTTP/web.corp.local", true, false, true}, // case-insensitive
+		{"HOST/server.corp.local", false, true, false},
+		{"host/server.corp.local", false, true, false},
+		{"MSSQLSvc/db.corp.local:1433", false, false, false},
+		{"ldap/dc.corp.local/corp.local", false, false, false},
+	}
+	for _, tt := range tests {
+		s, err := FromString(tt.spn)
+		if err != nil {
+			t.Fatalf("FromString(%q): %v", tt.spn, err)
+		}
+		if got := s.IsBuiltInServiceClass(); got != tt.builtIn {
+			t.Errorf("%q IsBuiltInServiceClass = %v, want %v", tt.spn, got, tt.builtIn)
+		}
+		if got := s.IsHostServiceClass(); got != tt.host {
+			t.Errorf("%q IsHostServiceClass = %v, want %v", tt.spn, got, tt.host)
+		}
+		if got := s.CoveredByHostSPN(); got != tt.covered {
+			t.Errorf("%q CoveredByHostSPN = %v, want %v", tt.spn, got, tt.covered)
+		}
+	}
+}
+
+func TestNilSPNBuiltInMethods(t *testing.T) {
+	var s *ServicePrincipalName
+	if s.IsBuiltInServiceClass() || s.IsHostServiceClass() || s.CoveredByHostSPN() {
+		t.Error("nil SPN methods should all report false")
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #1028`

### Summary
Adds built-in SPN service class awareness to `windows/kerberos/serviceprincipalname`, which previously understood SPN syntax but not which service classes Active Directory recognizes as built-in for computer accounts.

### What's added
- `builtInServiceClasses` — the 52 documented built-in service class names, stored lowercased.
- `BuiltInServiceClasses() []string` — a sorted copy of the list.
- `IsBuiltInServiceClass(class string) bool` — case-insensitive membership test (package function).
- `HostServiceClass` const (`"HOST"`) — the class whose SPN substitutes for the built-in classes; deliberately not itself in the set.
- Methods on `ServicePrincipalName`: `IsBuiltInServiceClass()`, `IsHostServiceClass()`, `CoveredByHostSPN()` (true iff the service class is built-in — a computer's HOST SPN substitutes for any built-in class SPN not explicitly registered elsewhere). All are nil-safe.

### How Verified
- The list was extracted verbatim from the setspn documentation and programmatically de-duplicated to 52 entries; the test `TestBuiltInServiceClassesMatchesDoc` pins the package set against an independent verbatim copy of that list.
- `go vet` and `go test ./windows/kerberos/serviceprincipalname/` pass, including the pre-existing parser/validator tests and the new built-in tests (case-insensitivity, HOST-is-not-built-in, per-SPN methods, nil receiver).

### Test Coverage
- **Added:** `builtin_test.go` — `TestBuiltInServiceClassesMatchesDoc`, `TestIsBuiltInServiceClass`, `TestHostIsNotBuiltIn`, `TestSPNBuiltInMethods`, `TestNilSPNBuiltInMethods`.

### Scope of Change
- **Files changed:** `windows/kerberos/serviceprincipalname/builtin.go` (new), `windows/kerberos/serviceprincipalname/builtin_test.go` (new)
- **Submodule pointer updated:** no
- **Behavioral changes outside the addition:** none (existing types/functions unchanged)

### References
- https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/setspn
