### PR TITLE
Replace README roadmap with a color-coded module graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,84 +30,29 @@ go get github.com/TheManticoreProject/Manticore@latest
 
 ## Roadmap
 
-Legend: :white_check_mark: implemented &nbsp;·&nbsp; :construction: partial / in progress &nbsp;·&nbsp; :x: not yet implemented
+Each module is colored by advancement state — 🟢 implemented & tested · 🟠 partial / in progress · 🔴 not yet implemented — where a **parent inherits the worst color of its submodules**. The graph below mirrors the package tree on disk; this shows the top level only.
 
-- **Network**
-  - SMB
-    - SMB 1.0 (CIFS) :white_check_mark:
-    - SMB 2.0 :construction:
-    - SMB 2.1 :x:
-    - SMB 3.0 :x:
-    - SMB 3.0.2 :x:
-    - SMB 3.1.1 :x:
-  - DCE/RPC
-    - Core (PDU, NDR encoding/decoding, EPM) :white_check_mark:
-    - Transports
-      - `ncacn_ip_tcp` :white_check_mark:
-      - `ncacn_np` (named pipes) :white_check_mark:
-      - `ncacn_http` :white_check_mark:
-    - Interfaces
-      - LSARPC (MS-LSAD / MS-LSAT) :white_check_mark:
-      - SAMR (MS-SAMR) :white_check_mark:
-      - SRVSVC (MS-SRVS) :white_check_mark:
-      - SVCCTL (MS-SCMR) :white_check_mark:
-      - DRSUAPI (MS-DRSR) :white_check_mark:
-      - WINREG (MS-RRP) :construction:
-      - EFSRPC (MS-EFSR) :construction:
-      - EPM (endpoint mapper) :construction:
-      - DSAOP (MS-DSSP) :x:
-  - LDAP :construction:
-  - Kerberos v5 :white_check_mark:
-    - AS-REQ / TGS-REQ client (TGT, service tickets, referrals, renew, postdate) :white_check_mark:
-    - PKINIT (RFC 4556) :white_check_mark:
-    - FAST / armoring (RFC 6113), incl. FAST-TGS :white_check_mark:
-    - S4U2self / S4U2proxy (MS-SFU) :white_check_mark:
-    - User-to-user (U2U) :white_check_mark:
-    - AS-REP roasting & Kerberoasting (hashcat / john output) :white_check_mark:
-    - Golden / silver / diamond / sapphire ticket forging :white_check_mark:
-    - UnPAC-the-hash & PAC build / parse :white_check_mark:
-    - keytab / ccache / kirbi credential I/O :white_check_mark:
-    - GSSAPI acceptor, per-message tokens & delegation :white_check_mark:
-  - GSSAPI / SPNEGO (NTLM) :white_check_mark:
-  - LLMNR :white_check_mark:
-  - NetBIOS
-    - NBNS (name service) :white_check_mark:
-    - NBT (NetBIOS over TCP) :construction:
-    - NBF (NetBIOS frames) :x:
-  - DNS :x:
-  - Raw TCP / IP :x:
-- **Cryptography**
-  - MD4 / NT / LM hashes :white_check_mark:
-  - DCC / DCC2 :white_check_mark:
-  - NTLMv1 / NTLMv2 :white_check_mark:
-  - RC4 :white_check_mark:
-  - AES-CTS (RFC 3962) :white_check_mark:
-  - CMAC :white_check_mark:
-  - N-Fold (RFC 3961) :white_check_mark:
-  - PKCS#7 padding :white_check_mark:
-  - GPPP (Group Policy Preferences) :white_check_mark:
-  - UUID (v1–v8) :white_check_mark:
-  - Kerberos crypto (AES-CTS-HMAC-SHA1 RFC 3962, AES-CTS-HMAC-SHA2 RFC 8009, RC4-HMAC RFC 4757) :white_check_mark:
-- **Windows**
-  - Registry
-    - REGF hive parsing (read) :white_check_mark:
-    - REGF hive writing :white_check_mark:
-    - `.reg` file encode/decode :white_check_mark:
-  - Database
-    - ESE / JET Blue reader :white_check_mark:
-    - NTDS.dit offline parsing + secret decryption :white_check_mark:
-  - Active Directory
-    - Replication metadata (`DS_REPL_*`) :white_check_mark:
-    - KeyCredentialLink :white_check_mark:
-    - Service Principal Names (SPN) :white_check_mark:
-  - Security descriptors (via winacl) :white_check_mark:
-  - CNG bcrypt key blobs (RSA / ECC / DSA) :white_check_mark:
-  - MS-DTYP data types :construction:
-  - Filesystem info classes (FSCC) :construction:
-- **Encoding**
-  - ASCII :white_check_mark:
-  - UTF-16LE :white_check_mark:
-  - EBCDIC (cp037, cp500) :white_check_mark:
+```mermaid
+graph LR
+  root["Manticore 🔴"]:::c0
+  n_crypto["crypto 🟠"]:::c1
+  n_encoding["encoding 🟠"]:::c1
+  n_logger["logger 🟢"]:::c2
+  n_network["network 🔴"]:::c0
+  n_utils["utils 🟢"]:::c2
+  n_windows["windows 🟠"]:::c1
+  root --> n_crypto
+  root --> n_encoding
+  root --> n_logger
+  root --> n_network
+  root --> n_utils
+  root --> n_windows
+  classDef c2 fill:#1f8b4c,stroke:#155d33,color:#fff;
+  classDef c1 fill:#d9822b,stroke:#a35d17,color:#fff;
+  classDef c0 fill:#c0392b,stroke:#7d2419,color:#fff;
+```
+
+See **[docs/roadmap.md](docs/roadmap.md)** for the full module-by-module graph covering every package on the filesystem, and [`docs/gen_roadmap_graph.py`](docs/gen_roadmap_graph.py) which regenerates it.
 
 ## Contributing
 

--- a/docs/gen_roadmap_graph.py
+++ b/docs/gen_roadmap_graph.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+import os, re
+
+ROOT = "/home/claude/git_projects/TheManticoreProject/Manticore"
+TOPS = ["crypto", "encoding", "logger", "network", "utils", "windows"]
+EXCLUDE_NAMES = {"docs", "testdata"}  # documentation / test fixtures are not modules
+
+RED, ORANGE, GREEN = 0, 1, 2
+NAME = {RED: "red", ORANGE: "orange", GREEN: "green"}
+
+# Explicit states from the human-curated roadmap (functional completeness).
+# Keyed by repo-relative path; applied to that dir's OWN base color.
+OVERRIDE = {
+    "network/smb/smb_v10": GREEN,
+    "network/smb/smb_v20": ORANGE,
+    "network/smb/smb_v21": RED,
+    "network/smb/smb_v30": RED,
+    "network/smb/smb_v302": RED,
+    "network/smb/smb_v311": RED,
+    "network/ldap": ORANGE,
+    "network/kerberos": GREEN,
+    "network/kerberos/v5": GREEN,
+    "network/gssapi": ORANGE,      # skeleton; real GSSAPI is crypto/spnego + kerberos/v5/gssapi
+    "network/llmnr": GREEN,
+    "network/netbios/nbns": GREEN,
+    "network/netbios/nbdgm": GREEN,
+    "network/netbios/nbt": ORANGE,
+    "network/netbios/nbf": RED,
+    "network/dns": RED,        # 1-file stub (MS-DNSP wire types live under windows/protocols)
+    "network/tcp": RED,        # roadmap: Raw TCP/IP not implemented
+    "network/ip": RED,         # roadmap: Raw TCP/IP not implemented
+    "network/dcerpc/ndr": GREEN,
+    "network/dcerpc/v4": GREEN,
+    "network/dcerpc/v5": GREEN,
+    "network/dcerpc/syntax": GREEN,
+    "windows/ms-dtyp": ORANGE,
+    "windows/filesystem": ORANGE,
+    "windows/filesystem/infoclass": ORANGE,
+}
+
+def own_metrics(d):
+    """non-recursive: (go_loc, test_loc, has_go) for *.go directly in d"""
+    go_loc = 0
+    test_loc = 0
+    has_go = False
+    try:
+        for f in os.listdir(d):
+            p = os.path.join(d, f)
+            if not os.path.isfile(p) or not f.endswith(".go"):
+                continue
+            has_go = True
+            with open(p, "r", errors="ignore") as fh:
+                n = sum(1 for _ in fh)
+            if f.endswith("_test.go"):
+                test_loc += n
+            else:
+                go_loc += n
+    except OSError:
+        pass
+    return go_loc, test_loc, has_go
+
+NEUTRAL = GREEN  # structural dirs defer to their children via worst-color propagation
+
+def metric_color(go_loc, test_loc, has_go, is_leaf):
+    # RED is objective: no production Go code in this dir at all (empty / planned).
+    if go_loc == 0:
+        return RED if is_leaf else NEUTRAL
+    # GREEN: real code (>=30 LOC) exercised by a real test (>=20 LOC) => working & verified.
+    if go_loc >= 30 and test_loc >= 20:
+        return GREEN
+    # ORANGE: minimal/stub code, or code with no real test => partial / unverified.
+    return ORANGE
+
+def base_color(rel, go_loc, test_loc, has_go, is_leaf):
+    if rel in OVERRIDE:
+        return OVERRIDE[rel]
+    return metric_color(go_loc, test_loc, has_go, is_leaf)
+
+# Build directory tree
+dirs = []  # (rel_path, parent_rel_or_None)
+for top in TOPS:
+    abspath = os.path.join(ROOT, top)
+    for cur, subdirs, files in os.walk(abspath):
+        subdirs[:] = [s for s in subdirs if s not in EXCLUDE_NAMES and not s.startswith(".")]
+        rel = os.path.relpath(cur, ROOT)
+        dirs.append(rel)
+
+dirset = set(dirs)
+
+# children map
+def parent_of(rel):
+    p = os.path.dirname(rel)
+    return p if p in dirset else None
+
+children = {rel: [] for rel in dirs}
+for rel in dirs:
+    p = parent_of(rel)
+    if p is not None:
+        children[p].append(rel)
+
+# base colors (needs children to know if a dir is a leaf)
+base = {}
+for rel in dirs:
+    go_loc, test_loc, has_go = own_metrics(os.path.join(ROOT, rel))
+    is_leaf = len(children[rel]) == 0
+    base[rel] = base_color(rel, go_loc, test_loc, has_go, is_leaf)
+
+# propagate worst (min) color bottom-up via memoized recursion
+color = {}
+def resolve(rel):
+    if rel in color:
+        return color[rel]
+    c = base[rel]
+    for ch in children[rel]:
+        c = min(c, resolve(ch))
+    color[rel] = c
+    return c
+for rel in dirs:
+    resolve(rel)
+
+# root node = worst of tops
+root_color = min(color[t] for t in TOPS)
+
+# ---- emit mermaid ----
+def nid(rel):
+    return "n_" + re.sub(r'[^0-9a-zA-Z]', '_', rel)
+
+# Display pruning (colors above already account for the full tree):
+#  - collapse the UUID-keyed DCE/RPC interface registry to a single node
+#  - drop the mechanical structures/ and functions/ NDR partitions
+COLLAPSE = ("network/dcerpc/interfaces",)
+PRUNE_NAMES = {"structures", "functions"}
+
+def emitted(rel):
+    b = os.path.basename(rel)
+    if b in PRUNE_NAMES:
+        return False
+    for c in COLLAPSE:
+        if rel != c and rel.startswith(c + os.sep):
+            return False
+    return True
+
+lines = []
+lines.append("```mermaid")
+lines.append("graph LR")
+DOT = {RED: "\U0001F534", ORANGE: "\U0001F7E0", GREEN: "\U0001F7E2"}
+# root
+lines.append(f'  root["Manticore {DOT[root_color]}"]:::c{root_color}')
+for t in TOPS:
+    lines.append(f'  root --> {nid(t)}')
+
+vis = [rel for rel in sorted(dirs) if emitted(rel)]
+emitted_edges = set()
+for rel in vis:
+    label = os.path.basename(rel)
+    c = color[rel]
+    lines.append(f'  {nid(rel)}["{label} {DOT[c]}"]:::c{c}')
+for rel in vis:
+    p = parent_of(rel)
+    if p is not None and emitted(p):
+        e = (p, rel)
+        if e not in emitted_edges:
+            lines.append(f'  {nid(p)} --> {nid(rel)}')
+            emitted_edges.add(e)
+
+lines.append("  classDef c2 fill:#1f8b4c,stroke:#155d33,color:#fff;")
+lines.append("  classDef c1 fill:#d9822b,stroke:#a35d17,color:#fff;")
+lines.append("  classDef c0 fill:#c0392b,stroke:#7d2419,color:#fff;")
+lines.append("```")
+
+out = "\n".join(lines)
+print(out)
+print("\n---- STATS ----", file=os.sys.stderr)
+from collections import Counter
+cnt = Counter(color[r] for r in vis)
+print("visible nodes:", len(vis)+1, "green:", cnt[GREEN], "orange:", cnt[ORANGE], "red:", cnt[RED], file=os.sys.stderr)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,550 @@
+# Manticore module roadmap
+
+This graph mirrors the package tree on disk (top-level modules → sub-packages) and
+color-codes each module by its advancement state.
+
+**Legend**
+
+| Color | Meaning |
+| :--- | :--- |
+| 🟢 green | Implemented and verified — real code exercised by real tests. |
+| 🟠 orange | Partial / unverified — code present, but minimal (stub) or without meaningful test coverage. |
+| 🔴 red | Not implemented — directory reserved but empty, or explicitly planned-only. |
+
+**Propagation rule:** a parent takes the *worst* color of any of its descendants. If any
+submodule is orange or red, the parent is at best that color. This is why the top-level
+modules and the `Manticore` root read red/orange even though most leaves are green: the
+tree still contains planned-but-empty subsystems (e.g. SMB 2.1+, raw DNS/IP/TCP, NBF).
+
+**How colors are assigned (per directory, from its own `.go` files):**
+- 🔴 red — no production Go code at all (empty leaf / planned).
+- 🟢 green — ≥ 30 lines of production code **and** ≥ 20 lines of test code.
+- 🟠 orange — otherwise (stub-sized code, or code without a real test).
+
+A small set of headline modules carry explicit states from the human-maintained roadmap
+(e.g. SMB versions, LDAP, Kerberos, raw DNS/IP/TCP) that override the metric; the
+`docs/gen_roadmap_graph.py` generator is the source of truth and can regenerate this file.
+The DCE/RPC UUID-keyed interface registry and the mechanical NDR `structures/`/`functions/`
+partitions are collapsed for readability (they still count toward their parent's color).
+
+```mermaid
+graph LR
+  root["Manticore 🔴"]:::c0
+  root --> n_crypto
+  root --> n_encoding
+  root --> n_logger
+  root --> n_network
+  root --> n_utils
+  root --> n_windows
+  n_crypto["crypto 🟠"]:::c1
+  n_crypto_aes["aes 🟢"]:::c2
+  n_crypto_aes_cfb8["cfb8 🟢"]:::c2
+  n_crypto_aes_cts["cts 🟢"]:::c2
+  n_crypto_cmac["cmac 🟢"]:::c2
+  n_crypto_dcc["dcc 🟢"]:::c2
+  n_crypto_dcc2["dcc2 🟢"]:::c2
+  n_crypto_gppp["gppp 🟢"]:::c2
+  n_crypto_lm["lm 🟢"]:::c2
+  n_crypto_md4["md4 🟢"]:::c2
+  n_crypto_nfold["nfold 🟢"]:::c2
+  n_crypto_nt["nt 🟢"]:::c2
+  n_crypto_ntlmv1["ntlmv1 🟢"]:::c2
+  n_crypto_ntlmv2["ntlmv2 🟢"]:::c2
+  n_crypto_pkcs7["pkcs7 🟢"]:::c2
+  n_crypto_rc4["rc4 🟢"]:::c2
+  n_crypto_spnego["spnego 🟠"]:::c1
+  n_crypto_spnego_ntlm["ntlm 🟠"]:::c1
+  n_crypto_spnego_ntlm_avpair["avpair 🟢"]:::c2
+  n_crypto_spnego_ntlm_datafields["datafields 🟢"]:::c2
+  n_crypto_spnego_ntlm_message["message 🟠"]:::c1
+  n_crypto_spnego_ntlm_message_authenticate["authenticate 🟢"]:::c2
+  n_crypto_spnego_ntlm_message_challenge["challenge 🟢"]:::c2
+  n_crypto_spnego_ntlm_message_header["header 🟢"]:::c2
+  n_crypto_spnego_ntlm_message_negotiate["negotiate 🟢"]:::c2
+  n_crypto_spnego_ntlm_message_negotiate_flags["flags 🟢"]:::c2
+  n_crypto_spnego_ntlm_message_types["types 🟢"]:::c2
+  n_crypto_spnego_ntlm_security["security 🟢"]:::c2
+  n_crypto_spnego_ntlm_targetinfo["targetinfo 🟢"]:::c2
+  n_crypto_spnego_ntlm_version["version 🟢"]:::c2
+  n_crypto_uuid["uuid 🟢"]:::c2
+  n_crypto_uuid_uuid_v1["uuid_v1 🟢"]:::c2
+  n_crypto_uuid_uuid_v2["uuid_v2 🟢"]:::c2
+  n_crypto_uuid_uuid_v3["uuid_v3 🟢"]:::c2
+  n_crypto_uuid_uuid_v4["uuid_v4 🟢"]:::c2
+  n_crypto_uuid_uuid_v5["uuid_v5 🟢"]:::c2
+  n_crypto_uuid_uuid_v6["uuid_v6 🟢"]:::c2
+  n_crypto_uuid_uuid_v7["uuid_v7 🟢"]:::c2
+  n_crypto_uuid_uuid_v8["uuid_v8 🟢"]:::c2
+  n_encoding["encoding 🟠"]:::c1
+  n_encoding_ascii["ascii 🟠"]:::c1
+  n_encoding_ebcdic["ebcdic 🟢"]:::c2
+  n_encoding_ebcdic_cp037["cp037 🟢"]:::c2
+  n_encoding_ebcdic_cp500["cp500 🟢"]:::c2
+  n_encoding_utf16["utf16 🟢"]:::c2
+  n_logger["logger 🟢"]:::c2
+  n_network["network 🔴"]:::c0
+  n_network_dcerpc["dcerpc 🟠"]:::c1
+  n_network_dcerpc_interfaces["interfaces 🟠"]:::c1
+  n_network_dcerpc_ms_protocols["ms-protocols 🟢"]:::c2
+  n_network_dcerpc_ms_protocols_ms_drsr["ms-drsr 🟢"]:::c2
+  n_network_dcerpc_ms_protocols_ms_rrp["ms-rrp 🟢"]:::c2
+  n_network_dcerpc_ms_protocols_ms_srvs["ms-srvs 🟢"]:::c2
+  n_network_dcerpc_ms_protocols_msproto["msproto 🟢"]:::c2
+  n_network_dcerpc_ndr["ndr 🟢"]:::c2
+  n_network_dcerpc_syntax["syntax 🟢"]:::c2
+  n_network_dcerpc_v4["v4 🟠"]:::c1
+  n_network_dcerpc_v4_client["client 🟢"]:::c2
+  n_network_dcerpc_v4_epm["epm 🟢"]:::c2
+  n_network_dcerpc_v4_interfaces["interfaces 🟢"]:::c2
+  n_network_dcerpc_v4_interfaces_mgmt["mgmt 🟢"]:::c2
+  n_network_dcerpc_v4_internal["internal 🟢"]:::c2
+  n_network_dcerpc_v4_internal_ndr["ndr 🟢"]:::c2
+  n_network_dcerpc_v4_pdu["pdu 🟢"]:::c2
+  n_network_dcerpc_v4_transport["transport 🟠"]:::c1
+  n_network_dcerpc_v4_transport_udp["udp 🟢"]:::c2
+  n_network_dcerpc_v5["v5 🟠"]:::c1
+  n_network_dcerpc_v5_client["client 🟢"]:::c2
+  n_network_dcerpc_v5_pdu["pdu 🟢"]:::c2
+  n_network_dcerpc_v5_transport["transport 🟠"]:::c1
+  n_network_dcerpc_v5_transport_smb["smb 🟢"]:::c2
+  n_network_dcerpc_v5_transport_smb2["smb2 🟢"]:::c2
+  n_network_dcerpc_v5_transport_tcp["tcp 🟢"]:::c2
+  n_network_dns["dns 🔴"]:::c0
+  n_network_gssapi["gssapi 🟠"]:::c1
+  n_network_gssapi_context["context 🟠"]:::c1
+  n_network_gssapi_status["status 🟢"]:::c2
+  n_network_ip["ip 🔴"]:::c0
+  n_network_kerberos["kerberos 🟠"]:::c1
+  n_network_kerberos_v5["v5 🟠"]:::c1
+  n_network_kerberos_v5_attacks["attacks 🟢"]:::c2
+  n_network_kerberos_v5_credcache["credcache 🟢"]:::c2
+  n_network_kerberos_v5_credcache_ccache["ccache 🟢"]:::c2
+  n_network_kerberos_v5_credcache_keytab["keytab 🟢"]:::c2
+  n_network_kerberos_v5_credcache_kirbi["kirbi 🟢"]:::c2
+  n_network_kerberos_v5_credentials["credentials 🟢"]:::c2
+  n_network_kerberos_v5_crypto["crypto 🟢"]:::c2
+  n_network_kerberos_v5_gssapi["gssapi 🟢"]:::c2
+  n_network_kerberos_v5_iana["iana 🟠"]:::c1
+  n_network_kerberos_v5_messages["messages 🟢"]:::c2
+  n_network_kerberos_v5_mskile["mskile 🟢"]:::c2
+  n_network_kerberos_v5_pac["pac 🟢"]:::c2
+  n_network_kerberos_v5_pkinit["pkinit 🟢"]:::c2
+  n_network_kerberos_v5_sfu["sfu 🟢"]:::c2
+  n_network_ldap["ldap 🟠"]:::c1
+  n_network_ldap_ldap_attributes["ldap_attributes 🟢"]:::c2
+  n_network_ldap_objects["objects 🟠"]:::c1
+  n_network_ldap_schema["schema 🟢"]:::c2
+  n_network_llmnr["llmnr 🟠"]:::c1
+  n_network_llmnr_class["class 🟢"]:::c2
+  n_network_llmnr_constants["constants 🟠"]:::c1
+  n_network_llmnr_domain_name["domain_name 🟢"]:::c2
+  n_network_llmnr_errors["errors 🟠"]:::c1
+  n_network_llmnr_llmnr_type["llmnr_type 🟢"]:::c2
+  n_network_llmnr_message["message 🟢"]:::c2
+  n_network_llmnr_message_header["header 🟢"]:::c2
+  n_network_llmnr_question["question 🟢"]:::c2
+  n_network_llmnr_resourcerecord["resourcerecord 🟢"]:::c2
+  n_network_llmnr_server["server 🟢"]:::c2
+  n_network_netbios["netbios 🔴"]:::c0
+  n_network_netbios_nbdgm["nbdgm 🟢"]:::c2
+  n_network_netbios_nbf["nbf 🔴"]:::c0
+  n_network_netbios_nbns["nbns 🟢"]:::c2
+  n_network_netbios_nbt["nbt 🟠"]:::c1
+  n_network_smb["smb 🔴"]:::c0
+  n_network_smb_client["client 🟢"]:::c2
+  n_network_smb_common["common 🟢"]:::c2
+  n_network_smb_common_transport["transport 🟢"]:::c2
+  n_network_smb_smb_v10["smb_v10 🟠"]:::c1
+  n_network_smb_smb_v10_capabilities["capabilities 🟢"]:::c2
+  n_network_smb_smb_v10_client["client 🟢"]:::c2
+  n_network_smb_smb_v10_dialects["dialects 🟢"]:::c2
+  n_network_smb_smb_v10_errors["errors 🟠"]:::c1
+  n_network_smb_smb_v10_informationlevels["informationlevels 🟢"]:::c2
+  n_network_smb_smb_v10_message["message 🟠"]:::c1
+  n_network_smb_smb_v10_message_commands["commands 🟠"]:::c1
+  n_network_smb_smb_v10_message_commands_andx["andx 🟢"]:::c2
+  n_network_smb_smb_v10_message_commands_codes["codes 🟠"]:::c1
+  n_network_smb_smb_v10_message_commands_command_interface["command_interface 🟢"]:::c2
+  n_network_smb_smb_v10_message_commands_utils["utils 🟢"]:::c2
+  n_network_smb_smb_v10_message_data["data 🟢"]:::c2
+  n_network_smb_smb_v10_message_header["header 🟢"]:::c2
+  n_network_smb_smb_v10_message_header_flags["flags 🟢"]:::c2
+  n_network_smb_smb_v10_message_header_flags2["flags2 🟢"]:::c2
+  n_network_smb_smb_v10_message_parameters["parameters 🟢"]:::c2
+  n_network_smb_smb_v10_message_securityfeatures["securityfeatures 🟢"]:::c2
+  n_network_smb_smb_v10_securitymode["securitymode 🟢"]:::c2
+  n_network_smb_smb_v10_subcommands["subcommands 🟢"]:::c2
+  n_network_smb_smb_v10_types["types 🟢"]:::c2
+  n_network_smb_smb_v20["smb_v20 🟠"]:::c1
+  n_network_smb_smb_v20_capabilities["capabilities 🟢"]:::c2
+  n_network_smb_smb_v20_client["client 🟢"]:::c2
+  n_network_smb_smb_v20_createcontext["createcontext 🟢"]:::c2
+  n_network_smb_smb_v20_dialects["dialects 🟠"]:::c1
+  n_network_smb_smb_v20_message["message 🟠"]:::c1
+  n_network_smb_smb_v20_message_commands["commands 🟠"]:::c1
+  n_network_smb_smb_v20_message_commands_codes["codes 🟢"]:::c2
+  n_network_smb_smb_v20_message_commands_command_interface["command_interface 🟠"]:::c1
+  n_network_smb_smb_v20_message_header["header 🟢"]:::c2
+  n_network_smb_smb_v20_message_header_flags["flags 🟢"]:::c2
+  n_network_smb_smb_v20_securitymode["securitymode 🟢"]:::c2
+  n_network_smb_smb_v20_types["types 🟢"]:::c2
+  n_network_smb_smb_v21["smb_v21 🔴"]:::c0
+  n_network_smb_smb_v30["smb_v30 🔴"]:::c0
+  n_network_smb_smb_v302["smb_v302 🔴"]:::c0
+  n_network_smb_smb_v311["smb_v311 🔴"]:::c0
+  n_network_tcp["tcp 🔴"]:::c0
+  n_utils["utils 🟢"]:::c2
+  n_windows["windows 🟠"]:::c1
+  n_windows_activedirectory["activedirectory 🟢"]:::c2
+  n_windows_activedirectory_replication["replication 🟢"]:::c2
+  n_windows_activedirectory_replication_dsrepl["dsrepl 🟢"]:::c2
+  n_windows_cng["cng 🟠"]:::c1
+  n_windows_cng_bcrypt["bcrypt 🟠"]:::c1
+  n_windows_cng_bcrypt_keys["keys 🟠"]:::c1
+  n_windows_cng_bcrypt_keys_blob["blob 🟢"]:::c2
+  n_windows_cng_bcrypt_keys_headers["headers 🟢"]:::c2
+  n_windows_cng_bcrypt_keys_magic["magic 🟢"]:::c2
+  n_windows_cng_bcrypt_keys_types["types 🟠"]:::c1
+  n_windows_credentials["credentials 🟢"]:::c2
+  n_windows_database["database 🟢"]:::c2
+  n_windows_database_ese["ese 🟢"]:::c2
+  n_windows_database_ntds["ntds 🟢"]:::c2
+  n_windows_fileflags["fileflags 🟠"]:::c1
+  n_windows_filesystem["filesystem 🟠"]:::c1
+  n_windows_filesystem_infoclass["infoclass 🟠"]:::c1
+  n_windows_guid["guid 🟢"]:::c2
+  n_windows_kerberos["kerberos 🟢"]:::c2
+  n_windows_kerberos_serviceprincipalname["serviceprincipalname 🟢"]:::c2
+  n_windows_keycredentiallink["keycredentiallink 🟢"]:::c2
+  n_windows_keycredentiallink_crypto["crypto 🟢"]:::c2
+  n_windows_keycredentiallink_key["key 🟢"]:::c2
+  n_windows_keycredentiallink_key_customkeyinformation["customkeyinformation 🟢"]:::c2
+  n_windows_keycredentiallink_key_material["material 🟢"]:::c2
+  n_windows_keycredentiallink_key_material_fek["fek 🟢"]:::c2
+  n_windows_keycredentiallink_key_material_fek_blob["blob 🟢"]:::c2
+  n_windows_keycredentiallink_key_material_fek_headers["headers 🟢"]:::c2
+  n_windows_keycredentiallink_key_material_fek_magic["magic 🟢"]:::c2
+  n_windows_keycredentiallink_key_source["source 🟢"]:::c2
+  n_windows_keycredentiallink_key_strength["strength 🟢"]:::c2
+  n_windows_keycredentiallink_key_usage["usage 🟢"]:::c2
+  n_windows_keycredentiallink_utils["utils 🟢"]:::c2
+  n_windows_keycredentiallink_version["version 🟢"]:::c2
+  n_windows_ms_dtyp["ms-dtyp 🟠"]:::c1
+  n_windows_nt_status["nt_status 🟢"]:::c2
+  n_windows_protocols["protocols 🟠"]:::c1
+  n_windows_protocols_ms_bpau["ms-bpau 🟠"]:::c1
+  n_windows_protocols_ms_brwsa["ms-brwsa 🟢"]:::c2
+  n_windows_protocols_ms_capr["ms-capr 🟠"]:::c1
+  n_windows_protocols_ms_cmpo["ms-cmpo 🟢"]:::c2
+  n_windows_protocols_ms_cmrp["ms-cmrp 🟢"]:::c2
+  n_windows_protocols_ms_dcom["ms-dcom 🟢"]:::c2
+  n_windows_protocols_ms_dfsnm["ms-dfsnm 🟢"]:::c2
+  n_windows_protocols_ms_dhcpm["ms-dhcpm 🟢"]:::c2
+  n_windows_protocols_ms_dltw["ms-dltw 🟢"]:::c2
+  n_windows_protocols_ms_dnsp["ms-dnsp 🟢"]:::c2
+  n_windows_protocols_ms_drsr["ms-drsr 🟢"]:::c2
+  n_windows_protocols_ms_dssp["ms-dssp 🟢"]:::c2
+  n_windows_protocols_ms_eerr["ms-eerr 🟢"]:::c2
+  n_windows_protocols_ms_efsr["ms-efsr 🟢"]:::c2
+  n_windows_protocols_ms_even["ms-even 🟢"]:::c2
+  n_windows_protocols_ms_even6["ms-even6 🟢"]:::c2
+  n_windows_protocols_ms_fasp["ms-fasp 🟢"]:::c2
+  n_windows_protocols_ms_fax["ms-fax 🟢"]:::c2
+  n_windows_protocols_ms_frs1["ms-frs1 🟠"]:::c1
+  n_windows_protocols_ms_frs2["ms-frs2 🟢"]:::c2
+  n_windows_protocols_ms_fsrvp["ms-fsrvp 🟢"]:::c2
+  n_windows_protocols_ms_irp["ms-irp 🟢"]:::c2
+  n_windows_protocols_ms_lrec["ms-lrec 🟢"]:::c2
+  n_windows_protocols_ms_lsad["ms-lsad 🟢"]:::c2
+  n_windows_protocols_ms_lsat["ms-lsat 🟢"]:::c2
+  n_windows_protocols_ms_mqds["ms-mqds 🟢"]:::c2
+  n_windows_protocols_ms_mqmp["ms-mqmp 🟢"]:::c2
+  n_windows_protocols_ms_mqmq["ms-mqmq 🟢"]:::c2
+  n_windows_protocols_ms_mqmr["ms-mqmr 🟢"]:::c2
+  n_windows_protocols_ms_mqqp["ms-mqqp 🟢"]:::c2
+  n_windows_protocols_ms_mqrr["ms-mqrr 🟢"]:::c2
+  n_windows_protocols_ms_msrp["ms-msrp 🟢"]:::c2
+  n_windows_protocols_ms_nrpc["ms-nrpc 🟢"]:::c2
+  n_windows_protocols_ms_nrpc_crypto["crypto 🟢"]:::c2
+  n_windows_protocols_ms_nrpc_securechannel["securechannel 🟢"]:::c2
+  n_windows_protocols_ms_nspi["ms-nspi 🟢"]:::c2
+  n_windows_protocols_ms_pan["ms-pan 🟢"]:::c2
+  n_windows_protocols_ms_par["ms-par 🟠"]:::c1
+  n_windows_protocols_ms_pcq["ms-pcq 🟠"]:::c1
+  n_windows_protocols_ms_raa["ms-raa 🟢"]:::c2
+  n_windows_protocols_ms_raiw["ms-raiw 🟢"]:::c2
+  n_windows_protocols_ms_rpce["ms-rpce 🟢"]:::c2
+  n_windows_protocols_ms_rpcl["ms-rpcl 🟢"]:::c2
+  n_windows_protocols_ms_rprn["ms-rprn 🟢"]:::c2
+  n_windows_protocols_ms_rrasm["ms-rrasm 🟢"]:::c2
+  n_windows_protocols_ms_rrp["ms-rrp 🟢"]:::c2
+  n_windows_protocols_ms_rsp["ms-rsp 🟠"]:::c1
+  n_windows_protocols_ms_samr["ms-samr 🟢"]:::c2
+  n_windows_protocols_ms_scmr["ms-scmr 🟢"]:::c2
+  n_windows_protocols_ms_srvs["ms-srvs 🟢"]:::c2
+  n_windows_protocols_ms_swn["ms-swn 🟢"]:::c2
+  n_windows_protocols_ms_trp["ms-trp 🟢"]:::c2
+  n_windows_protocols_ms_tsch["ms-tsch 🟢"]:::c2
+  n_windows_protocols_ms_tsgu["ms-tsgu 🟢"]:::c2
+  n_windows_protocols_ms_tsts["ms-tsts 🟢"]:::c2
+  n_windows_protocols_ms_w32t["ms-w32t 🟢"]:::c2
+  n_windows_protocols_ms_wcce["ms-wcce 🟠"]:::c1
+  n_windows_protocols_ms_wkst["ms-wkst 🟢"]:::c2
+  n_windows_registry["registry 🟢"]:::c2
+  n_windows_registry_regf["regf 🟢"]:::c2
+  n_windows_registry_regfile["regfile 🟢"]:::c2
+  n_crypto --> n_crypto_aes
+  n_crypto_aes --> n_crypto_aes_cfb8
+  n_crypto_aes --> n_crypto_aes_cts
+  n_crypto --> n_crypto_cmac
+  n_crypto --> n_crypto_dcc
+  n_crypto --> n_crypto_dcc2
+  n_crypto --> n_crypto_gppp
+  n_crypto --> n_crypto_lm
+  n_crypto --> n_crypto_md4
+  n_crypto --> n_crypto_nfold
+  n_crypto --> n_crypto_nt
+  n_crypto --> n_crypto_ntlmv1
+  n_crypto --> n_crypto_ntlmv2
+  n_crypto --> n_crypto_pkcs7
+  n_crypto --> n_crypto_rc4
+  n_crypto --> n_crypto_spnego
+  n_crypto_spnego --> n_crypto_spnego_ntlm
+  n_crypto_spnego_ntlm --> n_crypto_spnego_ntlm_avpair
+  n_crypto_spnego_ntlm --> n_crypto_spnego_ntlm_datafields
+  n_crypto_spnego_ntlm --> n_crypto_spnego_ntlm_message
+  n_crypto_spnego_ntlm_message --> n_crypto_spnego_ntlm_message_authenticate
+  n_crypto_spnego_ntlm_message --> n_crypto_spnego_ntlm_message_challenge
+  n_crypto_spnego_ntlm_message --> n_crypto_spnego_ntlm_message_header
+  n_crypto_spnego_ntlm_message --> n_crypto_spnego_ntlm_message_negotiate
+  n_crypto_spnego_ntlm_message_negotiate --> n_crypto_spnego_ntlm_message_negotiate_flags
+  n_crypto_spnego_ntlm_message --> n_crypto_spnego_ntlm_message_types
+  n_crypto_spnego_ntlm --> n_crypto_spnego_ntlm_security
+  n_crypto_spnego_ntlm --> n_crypto_spnego_ntlm_targetinfo
+  n_crypto_spnego_ntlm --> n_crypto_spnego_ntlm_version
+  n_crypto --> n_crypto_uuid
+  n_crypto_uuid --> n_crypto_uuid_uuid_v1
+  n_crypto_uuid --> n_crypto_uuid_uuid_v2
+  n_crypto_uuid --> n_crypto_uuid_uuid_v3
+  n_crypto_uuid --> n_crypto_uuid_uuid_v4
+  n_crypto_uuid --> n_crypto_uuid_uuid_v5
+  n_crypto_uuid --> n_crypto_uuid_uuid_v6
+  n_crypto_uuid --> n_crypto_uuid_uuid_v7
+  n_crypto_uuid --> n_crypto_uuid_uuid_v8
+  n_encoding --> n_encoding_ascii
+  n_encoding --> n_encoding_ebcdic
+  n_encoding_ebcdic --> n_encoding_ebcdic_cp037
+  n_encoding_ebcdic --> n_encoding_ebcdic_cp500
+  n_encoding --> n_encoding_utf16
+  n_network --> n_network_dcerpc
+  n_network_dcerpc --> n_network_dcerpc_interfaces
+  n_network_dcerpc --> n_network_dcerpc_ms_protocols
+  n_network_dcerpc_ms_protocols --> n_network_dcerpc_ms_protocols_ms_drsr
+  n_network_dcerpc_ms_protocols --> n_network_dcerpc_ms_protocols_ms_rrp
+  n_network_dcerpc_ms_protocols --> n_network_dcerpc_ms_protocols_ms_srvs
+  n_network_dcerpc_ms_protocols --> n_network_dcerpc_ms_protocols_msproto
+  n_network_dcerpc --> n_network_dcerpc_ndr
+  n_network_dcerpc --> n_network_dcerpc_syntax
+  n_network_dcerpc --> n_network_dcerpc_v4
+  n_network_dcerpc_v4 --> n_network_dcerpc_v4_client
+  n_network_dcerpc_v4 --> n_network_dcerpc_v4_epm
+  n_network_dcerpc_v4 --> n_network_dcerpc_v4_interfaces
+  n_network_dcerpc_v4_interfaces --> n_network_dcerpc_v4_interfaces_mgmt
+  n_network_dcerpc_v4 --> n_network_dcerpc_v4_internal
+  n_network_dcerpc_v4_internal --> n_network_dcerpc_v4_internal_ndr
+  n_network_dcerpc_v4 --> n_network_dcerpc_v4_pdu
+  n_network_dcerpc_v4 --> n_network_dcerpc_v4_transport
+  n_network_dcerpc_v4_transport --> n_network_dcerpc_v4_transport_udp
+  n_network_dcerpc --> n_network_dcerpc_v5
+  n_network_dcerpc_v5 --> n_network_dcerpc_v5_client
+  n_network_dcerpc_v5 --> n_network_dcerpc_v5_pdu
+  n_network_dcerpc_v5 --> n_network_dcerpc_v5_transport
+  n_network_dcerpc_v5_transport --> n_network_dcerpc_v5_transport_smb
+  n_network_dcerpc_v5_transport --> n_network_dcerpc_v5_transport_smb2
+  n_network_dcerpc_v5_transport --> n_network_dcerpc_v5_transport_tcp
+  n_network --> n_network_dns
+  n_network --> n_network_gssapi
+  n_network_gssapi --> n_network_gssapi_context
+  n_network_gssapi --> n_network_gssapi_status
+  n_network --> n_network_ip
+  n_network --> n_network_kerberos
+  n_network_kerberos --> n_network_kerberos_v5
+  n_network_kerberos_v5 --> n_network_kerberos_v5_attacks
+  n_network_kerberos_v5 --> n_network_kerberos_v5_credcache
+  n_network_kerberos_v5_credcache --> n_network_kerberos_v5_credcache_ccache
+  n_network_kerberos_v5_credcache --> n_network_kerberos_v5_credcache_keytab
+  n_network_kerberos_v5_credcache --> n_network_kerberos_v5_credcache_kirbi
+  n_network_kerberos_v5 --> n_network_kerberos_v5_credentials
+  n_network_kerberos_v5 --> n_network_kerberos_v5_crypto
+  n_network_kerberos_v5 --> n_network_kerberos_v5_gssapi
+  n_network_kerberos_v5 --> n_network_kerberos_v5_iana
+  n_network_kerberos_v5 --> n_network_kerberos_v5_messages
+  n_network_kerberos_v5 --> n_network_kerberos_v5_mskile
+  n_network_kerberos_v5 --> n_network_kerberos_v5_pac
+  n_network_kerberos_v5 --> n_network_kerberos_v5_pkinit
+  n_network_kerberos_v5 --> n_network_kerberos_v5_sfu
+  n_network --> n_network_ldap
+  n_network_ldap --> n_network_ldap_ldap_attributes
+  n_network_ldap --> n_network_ldap_objects
+  n_network_ldap --> n_network_ldap_schema
+  n_network --> n_network_llmnr
+  n_network_llmnr --> n_network_llmnr_class
+  n_network_llmnr --> n_network_llmnr_constants
+  n_network_llmnr --> n_network_llmnr_domain_name
+  n_network_llmnr --> n_network_llmnr_errors
+  n_network_llmnr --> n_network_llmnr_llmnr_type
+  n_network_llmnr --> n_network_llmnr_message
+  n_network_llmnr_message --> n_network_llmnr_message_header
+  n_network_llmnr --> n_network_llmnr_question
+  n_network_llmnr --> n_network_llmnr_resourcerecord
+  n_network_llmnr --> n_network_llmnr_server
+  n_network --> n_network_netbios
+  n_network_netbios --> n_network_netbios_nbdgm
+  n_network_netbios --> n_network_netbios_nbf
+  n_network_netbios --> n_network_netbios_nbns
+  n_network_netbios --> n_network_netbios_nbt
+  n_network --> n_network_smb
+  n_network_smb --> n_network_smb_client
+  n_network_smb --> n_network_smb_common
+  n_network_smb_common --> n_network_smb_common_transport
+  n_network_smb --> n_network_smb_smb_v10
+  n_network_smb_smb_v10 --> n_network_smb_smb_v10_capabilities
+  n_network_smb_smb_v10 --> n_network_smb_smb_v10_client
+  n_network_smb_smb_v10 --> n_network_smb_smb_v10_dialects
+  n_network_smb_smb_v10 --> n_network_smb_smb_v10_errors
+  n_network_smb_smb_v10 --> n_network_smb_smb_v10_informationlevels
+  n_network_smb_smb_v10 --> n_network_smb_smb_v10_message
+  n_network_smb_smb_v10_message --> n_network_smb_smb_v10_message_commands
+  n_network_smb_smb_v10_message_commands --> n_network_smb_smb_v10_message_commands_andx
+  n_network_smb_smb_v10_message_commands --> n_network_smb_smb_v10_message_commands_codes
+  n_network_smb_smb_v10_message_commands --> n_network_smb_smb_v10_message_commands_command_interface
+  n_network_smb_smb_v10_message_commands --> n_network_smb_smb_v10_message_commands_utils
+  n_network_smb_smb_v10_message --> n_network_smb_smb_v10_message_data
+  n_network_smb_smb_v10_message --> n_network_smb_smb_v10_message_header
+  n_network_smb_smb_v10_message_header --> n_network_smb_smb_v10_message_header_flags
+  n_network_smb_smb_v10_message_header --> n_network_smb_smb_v10_message_header_flags2
+  n_network_smb_smb_v10_message --> n_network_smb_smb_v10_message_parameters
+  n_network_smb_smb_v10_message --> n_network_smb_smb_v10_message_securityfeatures
+  n_network_smb_smb_v10 --> n_network_smb_smb_v10_securitymode
+  n_network_smb_smb_v10 --> n_network_smb_smb_v10_subcommands
+  n_network_smb_smb_v10 --> n_network_smb_smb_v10_types
+  n_network_smb --> n_network_smb_smb_v20
+  n_network_smb_smb_v20 --> n_network_smb_smb_v20_capabilities
+  n_network_smb_smb_v20 --> n_network_smb_smb_v20_client
+  n_network_smb_smb_v20 --> n_network_smb_smb_v20_createcontext
+  n_network_smb_smb_v20 --> n_network_smb_smb_v20_dialects
+  n_network_smb_smb_v20 --> n_network_smb_smb_v20_message
+  n_network_smb_smb_v20_message --> n_network_smb_smb_v20_message_commands
+  n_network_smb_smb_v20_message_commands --> n_network_smb_smb_v20_message_commands_codes
+  n_network_smb_smb_v20_message_commands --> n_network_smb_smb_v20_message_commands_command_interface
+  n_network_smb_smb_v20_message --> n_network_smb_smb_v20_message_header
+  n_network_smb_smb_v20_message_header --> n_network_smb_smb_v20_message_header_flags
+  n_network_smb_smb_v20 --> n_network_smb_smb_v20_securitymode
+  n_network_smb_smb_v20 --> n_network_smb_smb_v20_types
+  n_network_smb --> n_network_smb_smb_v21
+  n_network_smb --> n_network_smb_smb_v30
+  n_network_smb --> n_network_smb_smb_v302
+  n_network_smb --> n_network_smb_smb_v311
+  n_network --> n_network_tcp
+  n_windows --> n_windows_activedirectory
+  n_windows_activedirectory --> n_windows_activedirectory_replication
+  n_windows_activedirectory_replication --> n_windows_activedirectory_replication_dsrepl
+  n_windows --> n_windows_cng
+  n_windows_cng --> n_windows_cng_bcrypt
+  n_windows_cng_bcrypt --> n_windows_cng_bcrypt_keys
+  n_windows_cng_bcrypt_keys --> n_windows_cng_bcrypt_keys_blob
+  n_windows_cng_bcrypt_keys --> n_windows_cng_bcrypt_keys_headers
+  n_windows_cng_bcrypt_keys --> n_windows_cng_bcrypt_keys_magic
+  n_windows_cng_bcrypt_keys --> n_windows_cng_bcrypt_keys_types
+  n_windows --> n_windows_credentials
+  n_windows --> n_windows_database
+  n_windows_database --> n_windows_database_ese
+  n_windows_database --> n_windows_database_ntds
+  n_windows --> n_windows_fileflags
+  n_windows --> n_windows_filesystem
+  n_windows_filesystem --> n_windows_filesystem_infoclass
+  n_windows --> n_windows_guid
+  n_windows --> n_windows_kerberos
+  n_windows_kerberos --> n_windows_kerberos_serviceprincipalname
+  n_windows --> n_windows_keycredentiallink
+  n_windows_keycredentiallink --> n_windows_keycredentiallink_crypto
+  n_windows_keycredentiallink --> n_windows_keycredentiallink_key
+  n_windows_keycredentiallink_key --> n_windows_keycredentiallink_key_customkeyinformation
+  n_windows_keycredentiallink_key --> n_windows_keycredentiallink_key_material
+  n_windows_keycredentiallink_key_material --> n_windows_keycredentiallink_key_material_fek
+  n_windows_keycredentiallink_key_material_fek --> n_windows_keycredentiallink_key_material_fek_blob
+  n_windows_keycredentiallink_key_material_fek --> n_windows_keycredentiallink_key_material_fek_headers
+  n_windows_keycredentiallink_key_material_fek --> n_windows_keycredentiallink_key_material_fek_magic
+  n_windows_keycredentiallink_key --> n_windows_keycredentiallink_key_source
+  n_windows_keycredentiallink_key --> n_windows_keycredentiallink_key_strength
+  n_windows_keycredentiallink_key --> n_windows_keycredentiallink_key_usage
+  n_windows_keycredentiallink --> n_windows_keycredentiallink_utils
+  n_windows_keycredentiallink --> n_windows_keycredentiallink_version
+  n_windows --> n_windows_ms_dtyp
+  n_windows --> n_windows_nt_status
+  n_windows --> n_windows_protocols
+  n_windows_protocols --> n_windows_protocols_ms_bpau
+  n_windows_protocols --> n_windows_protocols_ms_brwsa
+  n_windows_protocols --> n_windows_protocols_ms_capr
+  n_windows_protocols --> n_windows_protocols_ms_cmpo
+  n_windows_protocols --> n_windows_protocols_ms_cmrp
+  n_windows_protocols --> n_windows_protocols_ms_dcom
+  n_windows_protocols --> n_windows_protocols_ms_dfsnm
+  n_windows_protocols --> n_windows_protocols_ms_dhcpm
+  n_windows_protocols --> n_windows_protocols_ms_dltw
+  n_windows_protocols --> n_windows_protocols_ms_dnsp
+  n_windows_protocols --> n_windows_protocols_ms_drsr
+  n_windows_protocols --> n_windows_protocols_ms_dssp
+  n_windows_protocols --> n_windows_protocols_ms_eerr
+  n_windows_protocols --> n_windows_protocols_ms_efsr
+  n_windows_protocols --> n_windows_protocols_ms_even
+  n_windows_protocols --> n_windows_protocols_ms_even6
+  n_windows_protocols --> n_windows_protocols_ms_fasp
+  n_windows_protocols --> n_windows_protocols_ms_fax
+  n_windows_protocols --> n_windows_protocols_ms_frs1
+  n_windows_protocols --> n_windows_protocols_ms_frs2
+  n_windows_protocols --> n_windows_protocols_ms_fsrvp
+  n_windows_protocols --> n_windows_protocols_ms_irp
+  n_windows_protocols --> n_windows_protocols_ms_lrec
+  n_windows_protocols --> n_windows_protocols_ms_lsad
+  n_windows_protocols --> n_windows_protocols_ms_lsat
+  n_windows_protocols --> n_windows_protocols_ms_mqds
+  n_windows_protocols --> n_windows_protocols_ms_mqmp
+  n_windows_protocols --> n_windows_protocols_ms_mqmq
+  n_windows_protocols --> n_windows_protocols_ms_mqmr
+  n_windows_protocols --> n_windows_protocols_ms_mqqp
+  n_windows_protocols --> n_windows_protocols_ms_mqrr
+  n_windows_protocols --> n_windows_protocols_ms_msrp
+  n_windows_protocols --> n_windows_protocols_ms_nrpc
+  n_windows_protocols_ms_nrpc --> n_windows_protocols_ms_nrpc_crypto
+  n_windows_protocols_ms_nrpc --> n_windows_protocols_ms_nrpc_securechannel
+  n_windows_protocols --> n_windows_protocols_ms_nspi
+  n_windows_protocols --> n_windows_protocols_ms_pan
+  n_windows_protocols --> n_windows_protocols_ms_par
+  n_windows_protocols --> n_windows_protocols_ms_pcq
+  n_windows_protocols --> n_windows_protocols_ms_raa
+  n_windows_protocols --> n_windows_protocols_ms_raiw
+  n_windows_protocols --> n_windows_protocols_ms_rpce
+  n_windows_protocols --> n_windows_protocols_ms_rpcl
+  n_windows_protocols --> n_windows_protocols_ms_rprn
+  n_windows_protocols --> n_windows_protocols_ms_rrasm
+  n_windows_protocols --> n_windows_protocols_ms_rrp
+  n_windows_protocols --> n_windows_protocols_ms_rsp
+  n_windows_protocols --> n_windows_protocols_ms_samr
+  n_windows_protocols --> n_windows_protocols_ms_scmr
+  n_windows_protocols --> n_windows_protocols_ms_srvs
+  n_windows_protocols --> n_windows_protocols_ms_swn
+  n_windows_protocols --> n_windows_protocols_ms_trp
+  n_windows_protocols --> n_windows_protocols_ms_tsch
+  n_windows_protocols --> n_windows_protocols_ms_tsgu
+  n_windows_protocols --> n_windows_protocols_ms_tsts
+  n_windows_protocols --> n_windows_protocols_ms_w32t
+  n_windows_protocols --> n_windows_protocols_ms_wcce
+  n_windows_protocols --> n_windows_protocols_ms_wkst
+  n_windows --> n_windows_registry
+  n_windows_registry --> n_windows_registry_regf
+  n_windows_registry --> n_windows_registry_regfile
+  classDef c2 fill:#1f8b4c,stroke:#155d33,color:#fff;
+  classDef c1 fill:#d9822b,stroke:#a35d17,color:#fff;
+  classDef c0 fill:#c0392b,stroke:#7d2419,color:#fff;
+```


### PR DESCRIPTION
### Summary
Converts the README's textual roadmap into a Mermaid graph that mirrors the package tree on disk, with each module colored by advancement state and a "parent inherits the worst color of its submodules" propagation rule.

### What changed
- **README.md** — the `## Roadmap` bullet list is replaced by a compact top-level Mermaid graph (`Manticore` → `crypto`/`encoding`/`logger`/`network`/`utils`/`windows`) plus a link to the full graph.
- **docs/roadmap.md** — new; the full module-by-module graph (258 nodes) covering every package on the filesystem, with a legend and the exact color criteria.
- **docs/gen_roadmap_graph.py** — new; the generator that walks the tree, colors each directory, and emits the Mermaid. Committed so the graph is reproducible.

### Color model
Per directory, from its own `.go` files:
- 🟢 green — real code (≥30 LOC) exercised by a real test (≥20 LOC).
- 🟠 orange — stub-sized code, or code without a real test.
- 🔴 red — no production Go code at all (empty / planned).

A parent takes the worst color among its descendants. A small set of headline modules (SMB versions, LDAP, Kerberos, raw DNS/IP/TCP, the GSSAPI skeleton) carry explicit states from the previous human-maintained roadmap that override the metric. The DCE/RPC UUID-keyed interface registry and the mechanical NDR `structures/`/`functions/` partitions are collapsed for readability but still count toward their parent's color.

Consequently the top-level modules and the `Manticore` root read red/orange even though most leaves are green: the tree still contains planned-but-empty subsystems (SMB 2.1+/3.x, raw DNS/IP/TCP, NetBIOS NBF).

### How verified
- Structural check: every graph edge references a defined node; fences balanced (258 nodes / 257 edges in the full graph, 7 / 6 in the compact one).
- Render check: the full graph renders via `@mermaid-js/mermaid-cli` to a 454 KB SVG with all nodes present (well under Mermaid's 500-edge cap).
- Colors spot-checked against the codebase (e.g. `windows/registry`, `windows/database/{ese,ntds}`, `crypto/*` green; `network/smb/smb_v21..v311`, `network/{dns,ip,tcp}`, `netbios/nbf` red).

### Scope of Change
- **Files changed:** `README.md`, `docs/roadmap.md` (new), `docs/gen_roadmap_graph.py` (new)
- **Behavioral changes:** none (documentation only)