### PR TITLE
Fix RSA private key exported with world-readable file permissions (Fixes #1036)

### DIFF
--- a/windows/keycredentiallink/crypto/X509Certificate2.go
+++ b/windows/keycredentiallink/crypto/X509Certificate2.go
@@ -18,6 +18,16 @@ import (
 	"github.com/TheManticoreProject/Manticore/windows/cng/bcrypt/keys/magic"
 )
 
+const (
+	// privateKeyFileMode is the mode of a file holding private key material. Only
+	// the owner may read or write it.
+	privateKeyFileMode = 0o600
+
+	// privateKeyDirMode is the mode of a directory created to hold private key
+	// material. Only the owner may traverse or list it.
+	privateKeyDirMode = 0o700
+)
+
 // X509Certificate represents an X.509 certificate along with its associated RSA private key and public key material.
 //
 // Fields:
@@ -203,6 +213,11 @@ func (x *X509Certificate) ExportRSAPublicKeyBCrypt() (*keys.BCRYPT_RSA_PUBLIC_KE
 
 // ExportRSAPrivateKeyPEM exports the private key to a PEM file.
 //
+// The file is created with mode 0600 and a directory created to hold it with mode
+// 0700, so that the private key is only readable by its owner. An existing file at
+// pathToFile is narrowed to 0600 as well, since os.OpenFile leaves the mode of an
+// already existing file untouched.
+//
 // Parameters:
 // - pathToFile: A string representing the path to the file where the private key will be exported.
 //
@@ -212,17 +227,21 @@ func (x *X509Certificate) ExportRSAPrivateKeyPEM(pathToFile string) error {
 	if len(pathToFile) != 0 {
 		dir := filepath.Dir(pathToFile)
 		if _, err := os.Stat(dir); os.IsNotExist(err) {
-			if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+			if err := os.MkdirAll(dir, privateKeyDirMode); err != nil {
 				return err
 			}
 		}
 	}
 
-	keyOut, err := os.Create(pathToFile)
+	keyOut, err := os.OpenFile(pathToFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, privateKeyFileMode)
 	if err != nil {
 		return err
 	}
 	defer keyOut.Close()
+
+	if err := keyOut.Chmod(privateKeyFileMode); err != nil {
+		return err
+	}
 
 	privateKey, err := x.GetRSAPrivateKey()
 	if err != nil {

--- a/windows/keycredentiallink/crypto/X509Certificate2_test.go
+++ b/windows/keycredentiallink/crypto/X509Certificate2_test.go
@@ -1,0 +1,104 @@
+package crypto
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// newTestCertificate builds a small certificate for the export tests. 1024 bits
+// keeps key generation fast; the tests only exercise file handling.
+func newTestCertificate(t *testing.T) *X509Certificate {
+	t.Helper()
+
+	notBefore := time.Now()
+	cert, err := NewX509Certificate("TESTUSER$", 1024, notBefore, notBefore.Add(24*time.Hour))
+	if err != nil {
+		t.Fatalf("NewX509Certificate() error = %v", err)
+	}
+	return cert
+}
+
+func TestExportRSAPrivateKeyPEMUsesRestrictivePermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX file modes are not enforced on Windows")
+	}
+
+	cert := newTestCertificate(t)
+
+	// A nested path so that the directory is created by the export itself.
+	dir := filepath.Join(t.TempDir(), "keys", "nested")
+	path := filepath.Join(dir, "private.pem")
+
+	if err := cert.ExportRSAPrivateKeyPEM(path); err != nil {
+		t.Fatalf("ExportRSAPrivateKeyPEM() error = %v", err)
+	}
+
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("os.Stat(%q) error = %v", path, err)
+	}
+	if got := fi.Mode().Perm(); got != privateKeyFileMode {
+		t.Errorf("private key file mode = %04o, want %04o", got, privateKeyFileMode)
+	}
+
+	di, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("os.Stat(%q) error = %v", dir, err)
+	}
+	if got := di.Mode().Perm(); got != privateKeyDirMode {
+		t.Errorf("private key directory mode = %04o, want %04o", got, privateKeyDirMode)
+	}
+}
+
+func TestExportRSAPrivateKeyPEMNarrowsExistingFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX file modes are not enforced on Windows")
+	}
+
+	cert := newTestCertificate(t)
+	path := filepath.Join(t.TempDir(), "private.pem")
+
+	// O_CREATE does not change the mode of a file that already exists, so an
+	// export over a world-readable file has to narrow it explicitly.
+	if err := os.WriteFile(path, []byte("stale"), 0o666); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+	if err := os.Chmod(path, 0o666); err != nil {
+		t.Fatalf("os.Chmod() error = %v", err)
+	}
+
+	if err := cert.ExportRSAPrivateKeyPEM(path); err != nil {
+		t.Fatalf("ExportRSAPrivateKeyPEM() error = %v", err)
+	}
+
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("os.Stat(%q) error = %v", path, err)
+	}
+	if got := fi.Mode().Perm(); got != privateKeyFileMode {
+		t.Errorf("private key file mode = %04o, want %04o", got, privateKeyFileMode)
+	}
+}
+
+func TestExportRSAPrivateKeyPEMWritesParsablePEM(t *testing.T) {
+	cert := newTestCertificate(t)
+	path := filepath.Join(t.TempDir(), "private.pem")
+
+	if err := cert.ExportRSAPrivateKeyPEM(path); err != nil {
+		t.Fatalf("ExportRSAPrivateKeyPEM() error = %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("os.ReadFile(%q) error = %v", path, err)
+	}
+	if len(data) == 0 {
+		t.Fatal("exported private key is empty")
+	}
+	if want := "-----BEGIN RSA PRIVATE KEY-----"; string(data[:len(want)]) != want {
+		t.Errorf("exported private key does not start with %q", want)
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #1036`

### Root Cause
`ExportRSAPrivateKeyPEM` created its output with `os.Create`, which hardcodes mode `0666`, and created the parent directory with `os.ModePerm` (`0777`). Both are masked by the process umask, but a umask is a ceiling and not a guarantee: with the default `0002` the private key landed at `0664` and the directory at `0775`, and with the other common `0022` the key landed at `0644`. There is no umask value that makes `os.Create` correct for secret material.

The permissive mode was inherited from the public key export path directly above it, where a world-readable file is harmless. That shape was reused for the private key without narrowing it, so the function that writes the one genuinely secret artifact in the package used the most permissive mode in it.

### Fix Description
Introduces two named constants, `privateKeyFileMode` (`0600`) and `privateKeyDirMode` (`0700`), and uses them in `ExportRSAPrivateKeyPEM`:

- `os.Create` is replaced with `os.OpenFile(..., os.O_WRONLY|os.O_CREATE|os.O_TRUNC, privateKeyFileMode)`, keeping the truncate-or-create semantics while requesting `0600`.
- An explicit `keyOut.Chmod(privateKeyFileMode)` follows the open, because `O_CREATE` does not alter the mode of a file that already exists — without it, exporting over a pre-existing world-readable file left it world-readable.
- `os.MkdirAll` uses `privateKeyDirMode` when it creates the directory.

`ExportRSAPublicKeyPEM` is deliberately left untouched: a public key is not secret, and narrowing it would be an unrelated change. The directory mode is only applied when this function creates the directory; a pre-existing directory is not chmod'ed, because `pathToFile` can point into a caller-chosen location such as the working directory or a home directory, and silently tightening that would be destructive.

### How Verified
Runtime, by reverting only the two behavioral lines while keeping the constants so the new tests still compile.

Before the fix:

```
--- FAIL: TestExportRSAPrivateKeyPEMUsesRestrictivePermissions
    X509Certificate2_test.go:44: private key file mode = 0664, want 0600
    X509Certificate2_test.go:52: private key directory mode = 0775, want 0700
--- FAIL: TestExportRSAPrivateKeyPEMNarrowsExistingFile
    X509Certificate2_test.go:82: private key file mode = 0666, want 0600
```

After the fix:

```
ok  	github.com/TheManticoreProject/Manticore/windows/keycredentiallink/crypto	0.060s
```

`go build ./...`, `go vet ./windows/keycredentiallink/crypto/` and `gofmt -l` are all clean.

### Test Coverage
**Added** — `windows/keycredentiallink/crypto/X509Certificate2_test.go`:

- `TestExportRSAPrivateKeyPEMUsesRestrictivePermissions` — asserts the exported key file is `0600` and a directory created by the export is `0700`.
- `TestExportRSAPrivateKeyPEMNarrowsExistingFile` — pre-creates the target at `0666` and asserts the export narrows it to `0600`, covering the `O_CREATE` gap.
- `TestExportRSAPrivateKeyPEMWritesParsablePEM` — asserts the export still produces a non-empty `RSA PRIVATE KEY` PEM block, so the permission change did not break the output.

The two mode tests skip on Windows, where POSIX modes are not enforced.

### Scope of Change
- **Files changed:** `windows/keycredentiallink/crypto/X509Certificate2.go`, `windows/keycredentiallink/crypto/X509Certificate2_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local to one function. The only behavioral change for existing callers is that exported private keys and newly created key directories are no longer readable by other local users, and an export over an existing file now narrows that file's mode. A caller that relied on group-readable exported keys would be affected; that reliance is the vulnerability being fixed. Safe to merge without staged rollout.
