### PR TITLE
Add certificate PEM export and implement ExportPFX (Fixes #1037)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,4 +16,5 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	golang.org/x/net v0.46.0 // indirect
 	golang.org/x/sys v0.37.0 // indirect
+	software.sslmate.com/src/go-pkcs12 v0.7.3 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -42,3 +42,5 @@ golang.org/x/term v0.36.0 h1:zMPR+aF8gfksFprF/Nc/rd1wRS1EI6nDBGyWAvDzx2Q=
 golang.org/x/term v0.36.0/go.mod h1:Qu394IJq6V6dCBRgwqshf3mPF85AqzYEzofzRdZkWss=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+software.sslmate.com/src/go-pkcs12 v0.7.3 h1:JBQD3FDqYjTeyDAeZQklj2ar88ykBLtALloPJHyAauU=
+software.sslmate.com/src/go-pkcs12 v0.7.3/go.mod h1:Qiz0EyvDRJjjxGyUQa2cCNZn/wMyzrRJ/qcDXOQazLI=

--- a/windows/keycredentiallink/crypto/X509Certificate2.go
+++ b/windows/keycredentiallink/crypto/X509Certificate2.go
@@ -16,6 +16,8 @@ import (
 	"github.com/TheManticoreProject/Manticore/windows/cng/bcrypt/keys/blob"
 	"github.com/TheManticoreProject/Manticore/windows/cng/bcrypt/keys/headers"
 	"github.com/TheManticoreProject/Manticore/windows/cng/bcrypt/keys/magic"
+
+	"software.sslmate.com/src/go-pkcs12"
 )
 
 const (
@@ -117,7 +119,55 @@ func NewX509Certificate(subject string, keySize int, notBefore, notAfter time.Ti
 
 // Export ====================================================================================
 
+// ExportCertificatePEM exports the certificate to a PEM file.
+//
+// This is the counterpart of ExportRSAPrivateKeyPEM: together the two files are
+// what PKINIT implementations expect when they take a certificate and its private
+// key as separate PEM inputs. The directory is created with privateKeyDirMode
+// because it is the same directory the private key is written to.
+//
+// Parameters:
+// - pathToFile: A string representing the path to the file where the certificate will be exported.
+//
+// Returns:
+// - An error if the export fails, otherwise nil.
+func (x *X509Certificate) ExportCertificatePEM(pathToFile string) error {
+	certificate, err := x.GetCertificate()
+	if err != nil {
+		return fmt.Errorf("error getting certificate from crypto.X509Certificate: %s", err)
+	}
+
+	if len(pathToFile) != 0 {
+		dir := filepath.Dir(pathToFile)
+		if _, err := os.Stat(dir); os.IsNotExist(err) {
+			if err := os.MkdirAll(dir, privateKeyDirMode); err != nil {
+				return err
+			}
+		}
+	}
+
+	certOut, err := os.Create(pathToFile)
+	if err != nil {
+		return err
+	}
+	defer certOut.Close()
+
+	if err := pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: certificate.Raw}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // ExportPFX exports the certificate and private key to a PFX file with the specified password.
+//
+// The PFX is encoded with the modern algorithm set (AES-256-CBC and SHA-256 for
+// both encryption and the integrity MAC), which is what current OpenSSL, .NET and
+// Python implementations read. The legacy RC2 and DES encodings are deliberately
+// not used, as modern OpenSSL rejects them by default.
+//
+// The PFX embeds the private key, so the file is written with privateKeyFileMode
+// and a directory created to hold it with privateKeyDirMode.
 //
 // Parameters:
 // - pathToFile: A string representing the path to the file where the PFX will be exported.
@@ -126,7 +176,47 @@ func NewX509Certificate(subject string, keySize int, notBefore, notAfter time.Ti
 // Returns:
 // - An error if the export fails, otherwise nil.
 func (x *X509Certificate) ExportPFX(pathToFile, password string) error {
-	return fmt.Errorf("ExportPFX not implemented")
+	privateKey, err := x.GetRSAPrivateKey()
+	if err != nil {
+		return fmt.Errorf("error getting RSA private key from crypto.X509Certificate: %s", err)
+	}
+
+	certificate, err := x.GetCertificate()
+	if err != nil {
+		return fmt.Errorf("error getting certificate from crypto.X509Certificate: %s", err)
+	}
+
+	pfxData, err := pkcs12.Modern.Encode(privateKey, certificate, nil, password)
+	if err != nil {
+		return fmt.Errorf("error encoding PFX: %s", err)
+	}
+
+	if len(pathToFile) != 0 {
+		dir := filepath.Dir(pathToFile)
+		if _, err := os.Stat(dir); os.IsNotExist(err) {
+			if err := os.MkdirAll(dir, privateKeyDirMode); err != nil {
+				return err
+			}
+		}
+	}
+
+	pfxOut, err := os.OpenFile(pathToFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, privateKeyFileMode)
+	if err != nil {
+		return err
+	}
+	defer pfxOut.Close()
+
+	// O_CREATE leaves the mode of an already existing file untouched, so narrow it
+	// explicitly before the key material is written.
+	if err := pfxOut.Chmod(privateKeyFileMode); err != nil {
+		return err
+	}
+
+	if _, err := pfxOut.Write(pfxData); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // ExportRSAPublicKeyPEM exports the public key to a PEM file.

--- a/windows/keycredentiallink/crypto/X509Certificate2_test.go
+++ b/windows/keycredentiallink/crypto/X509Certificate2_test.go
@@ -1,11 +1,16 @@
 package crypto
 
 import (
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
 	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
 	"time"
+
+	"software.sslmate.com/src/go-pkcs12"
 )
 
 // newTestCertificate builds a small certificate for the export tests. 1024 bits
@@ -100,5 +105,134 @@ func TestExportRSAPrivateKeyPEMWritesParsablePEM(t *testing.T) {
 	}
 	if want := "-----BEGIN RSA PRIVATE KEY-----"; string(data[:len(want)]) != want {
 		t.Errorf("exported private key does not start with %q", want)
+	}
+}
+
+func TestExportCertificatePEMWritesParsableCertificate(t *testing.T) {
+	cert := newTestCertificate(t)
+	path := filepath.Join(t.TempDir(), "cert.pem")
+
+	if err := cert.ExportCertificatePEM(path); err != nil {
+		t.Fatalf("ExportCertificatePEM() error = %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("os.ReadFile(%q) error = %v", path, err)
+	}
+
+	block, rest := pem.Decode(data)
+	if block == nil {
+		t.Fatal("exported certificate is not a PEM block")
+	}
+	if block.Type != "CERTIFICATE" {
+		t.Errorf("PEM block type = %q, want %q", block.Type, "CERTIFICATE")
+	}
+	if len(rest) != 0 {
+		t.Errorf("unexpected trailing data after PEM block: %d bytes", len(rest))
+	}
+
+	parsed, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("x509.ParseCertificate() error = %v", err)
+	}
+
+	original, err := cert.GetCertificate()
+	if err != nil {
+		t.Fatalf("GetCertificate() error = %v", err)
+	}
+	if parsed.SerialNumber.Cmp(original.SerialNumber) != 0 {
+		t.Errorf("serial number = %v, want %v", parsed.SerialNumber, original.SerialNumber)
+	}
+	if parsed.Subject.CommonName != "TESTUSER$" {
+		t.Errorf("subject CN = %q, want %q", parsed.Subject.CommonName, "TESTUSER$")
+	}
+}
+
+func TestExportPFXRoundTrips(t *testing.T) {
+	cert := newTestCertificate(t)
+	path := filepath.Join(t.TempDir(), "keys", "bundle.pfx")
+	const password = "Passw0rd!"
+
+	if err := cert.ExportPFX(path, password); err != nil {
+		t.Fatalf("ExportPFX() error = %v", err)
+	}
+
+	pfxData, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("os.ReadFile(%q) error = %v", path, err)
+	}
+
+	decodedKey, decodedCert, err := pkcs12.Decode(pfxData, password)
+	if err != nil {
+		t.Fatalf("pkcs12.Decode() error = %v", err)
+	}
+
+	original, err := cert.GetCertificate()
+	if err != nil {
+		t.Fatalf("GetCertificate() error = %v", err)
+	}
+	if decodedCert.SerialNumber.Cmp(original.SerialNumber) != 0 {
+		t.Errorf("decoded serial number = %v, want %v", decodedCert.SerialNumber, original.SerialNumber)
+	}
+
+	originalKey, err := cert.GetRSAPrivateKey()
+	if err != nil {
+		t.Fatalf("GetRSAPrivateKey() error = %v", err)
+	}
+	rsaKey, ok := decodedKey.(*rsa.PrivateKey)
+	if !ok {
+		t.Fatalf("decoded private key type = %T, want *rsa.PrivateKey", decodedKey)
+	}
+	if !rsaKey.Equal(originalKey) {
+		t.Error("decoded private key does not match the certificate's private key")
+	}
+}
+
+func TestExportPFXRejectsWrongPassword(t *testing.T) {
+	cert := newTestCertificate(t)
+	path := filepath.Join(t.TempDir(), "bundle.pfx")
+
+	if err := cert.ExportPFX(path, "correct-horse"); err != nil {
+		t.Fatalf("ExportPFX() error = %v", err)
+	}
+
+	pfxData, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("os.ReadFile(%q) error = %v", path, err)
+	}
+
+	if _, _, err := pkcs12.Decode(pfxData, "wrong-password"); err == nil {
+		t.Error("pkcs12.Decode() with a wrong password succeeded, want error")
+	}
+}
+
+func TestExportPFXUsesRestrictivePermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX file modes are not enforced on Windows")
+	}
+
+	cert := newTestCertificate(t)
+	dir := filepath.Join(t.TempDir(), "keys")
+	path := filepath.Join(dir, "bundle.pfx")
+
+	if err := cert.ExportPFX(path, "Passw0rd!"); err != nil {
+		t.Fatalf("ExportPFX() error = %v", err)
+	}
+
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("os.Stat(%q) error = %v", path, err)
+	}
+	if got := fi.Mode().Perm(); got != privateKeyFileMode {
+		t.Errorf("PFX file mode = %04o, want %04o", got, privateKeyFileMode)
+	}
+
+	di, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("os.Stat(%q) error = %v", dir, err)
+	}
+	if got := di.Mode().Perm(); got != privateKeyDirMode {
+		t.Errorf("PFX directory mode = %04o, want %04o", got, privateKeyDirMode)
 	}
 }


### PR DESCRIPTION
### Linked Issue
`Closes #1037`

### Root Cause
The export surface of `X509Certificate` was built out for key material only. `ExportRSAPublicKeyPEM` and `ExportRSAPrivateKeyPEM` write the two halves of the RSA key, but the certificate held in `x.certificate` since L104 was never serialised by any exported method, so its DER was unreachable from outside the package. `ExportPFX` was left as a placeholder returning `ExportPFX not implemented`, while the struct godoc at L42 continued to advertise it as a supported method.

The result is that a caller could generate a key credential certificate and retrieve its private key, but never the certificate itself — and PKINIT needs the certificate, which a public-key PEM cannot substitute for.

### Fix Description
Adds `ExportCertificatePEM` and implements `ExportPFX`.

`ExportCertificatePEM` writes `x.certificate.Raw` as a `CERTIFICATE` PEM block. It is the counterpart of `ExportRSAPrivateKeyPEM`, so the two together give the cert-plus-key PEM pair that PKINIT implementations take as separate inputs.

`ExportPFX` encodes the certificate and its private key with `pkcs12.Modern.Encode`. `Modern` is AES-256-CBC with SHA-256 for both encryption and the integrity MAC. The `LegacyRC2` and `LegacyDES` encoders were rejected: OpenSSL 3 refuses RC2 by default, so a legacy-encoded PFX would be unreadable by the most common consumer.

This adds one dependency, `software.sslmate.com/src/go-pkcs12`. Its only requirement is `golang.org/x/crypto`, which is already a direct dependency of this module, so the module graph grows by exactly one entry. Implementing PKCS#12 natively was considered and rejected for this change: it is several hundred lines of ASN.1 container code plus RFC 7292 key derivation, and hand-rolled crypto containers carry a real risk of silent interop bugs.

Because the PFX embeds the private key, it is written with `privateKeyFileMode` and its directory with `privateKeyDirMode`, including the explicit `Chmod` needed because `O_CREATE` leaves an existing file's mode untouched. `ExportCertificatePEM` uses `os.Create` for the file — a certificate is not secret — but still creates the directory with `privateKeyDirMode`, since it is the same directory the private key is written into.

### How Verified
Runtime, in three layers.

Unit tests, all passing:

```
ok  	github.com/TheManticoreProject/Manticore/windows/keycredentiallink/crypto	0.211s
```

External interop against OpenSSL 3.0.13, which is the check that matters for PKINIT consumers — the round-trip test alone would only prove the library reads its own output:

```
$ openssl pkcs12 -in out.pfx -passin pass:'Passw0rd!' -nokeys -clcerts -noenc | openssl x509 -noout -subject -dates
subject=CN = INTEROP$
notBefore=Jul 31 14:56:25 2026 GMT
notAfter=Aug  1 14:56:25 2026 GMT

$ openssl pkcs12 -in out.pfx -passin pass:'Passw0rd!' -nocerts -noenc | openssl rsa -noout -check
RSA key ok

$ openssl pkcs12 -in out.pfx -passin pass:'wrong' -nokeys -noenc
Mac verify error
```

And that the exported PEM pair is a valid PKINIT pair, by comparing moduli:

```
$ openssl x509 -in out.cert.pem -noout -modulus == openssl rsa -in out.key.pem -noout -modulus
MATCH

$ stat -c '%a %n' out.pfx out.key.pem out.cert.pem
600 out.pfx
600 out.key.pem
664 out.cert.pem
```

`go build ./...`, `go vet` and `gofmt -l` are clean.

### Test Coverage
**Added** — in `windows/keycredentiallink/crypto/X509Certificate2_test.go`:

- `TestExportCertificatePEMWritesParsableCertificate` — asserts a single `CERTIFICATE` block with no trailing data, that it re-parses via `x509.ParseCertificate`, and that the serial number and subject CN match the original.
- `TestExportPFXRoundTrips` — decodes the written PFX and asserts both the certificate serial number and, via `rsa.PrivateKey.Equal`, the private key match the originals.
- `TestExportPFXRejectsWrongPassword` — asserts decoding with a wrong password fails, so the password is actually applied.
- `TestExportPFXUsesRestrictivePermissions` — asserts the PFX file is `0600` and its directory `0700`.

### Scope of Change
- **Files changed:** `go.mod`, `go.sum`, `windows/keycredentiallink/crypto/X509Certificate2.go`, `windows/keycredentiallink/crypto/X509Certificate2_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
`ExportCertificatePEM` is new, so nothing can regress through it. `ExportPFX` previously failed unconditionally, so every existing call site is currently on an error path; the only way this changes behavior is by making those calls succeed. The new dependency is single-purpose and adds no transitive modules beyond one already present. Safe to merge without staged rollout.

### Notes
This branch is based on `bugfix-private-key-file-permissions` (#1039), because `ExportPFX` writes private key material and needs the `privateKeyFileMode` and `privateKeyDirMode` constants that #1039 introduces. Merge #1039 first and the diff here reduces to the export work alone. Happy to rebase onto `main` instead if you would rather land them in the other order.

`ExportRSAPublicKeyDER` at L179 remains a stub; it is unrelated to certificate export and is left for a separate change.
