### PR TITLE
Add AES key and keytab support to Credentials and the LDAP Kerberos bind (Fixes #1038)

### DIFF
--- a/network/ldap/kerberos_gssapi.go
+++ b/network/ldap/kerberos_gssapi.go
@@ -58,13 +58,29 @@ type nativeGSSAPIClient struct {
 func newNativeGSSAPIClient(kdc, realm string, creds *credentials.Credentials) (*nativeGSSAPIClient, error) {
 	user := creds.GetUsername()
 	kc := kerberos.NewClient(user, realm, kdc)
-	if creds.CanPassTheHash() {
+
+	// Ordered strongest first: a keytab can carry AES keys for several etypes, an
+	// AES key beats the RC4 key an NT hash provides, and a password is the weakest
+	// because it still has to be string-to-key'd into one.
+	switch {
+	case creds.CanUseKeytab():
+		if err := kc.WithKeytabFile(creds.GetKeytab()); err != nil {
+			return nil, fmt.Errorf("ldap gssapi: keytab: %w", err)
+		}
+	case creds.CanUseAESKey():
+		if err := kc.WithAESKey(creds.GetAESKey()); err != nil {
+			return nil, fmt.Errorf("ldap gssapi: AES key: %w", err)
+		}
+	case creds.CanPassTheHash():
 		if err := kc.WithNTHash(creds.GetNTHash()); err != nil {
 			return nil, fmt.Errorf("ldap gssapi: NT hash: %w", err)
 		}
-	} else {
+	case creds.GetPassword() != "":
 		kc.WithPassword(creds.GetPassword())
+	default:
+		return nil, fmt.Errorf("ldap gssapi: no usable secret: set a password, NT hash, AES key or keytab")
 	}
+
 	if err := kc.GetTGT(); err != nil {
 		return nil, fmt.Errorf("ldap gssapi: GetTGT: %w", err)
 	}

--- a/network/ldap/kerberos_gssapi_test.go
+++ b/network/ldap/kerberos_gssapi_test.go
@@ -4,7 +4,11 @@ import (
 	"bytes"
 	"crypto/x509"
 	"encoding/binary"
+	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/TheManticoreProject/Manticore/windows/credentials"
 )
 
 // serverOffer builds an RFC 4752 §3.1 server security-layer offer: the supported
@@ -131,5 +135,65 @@ func TestCertificateHashAlgorithmSelection(t *testing.T) {
 		if got := len(certificateHash(cert)); got != c.length {
 			t.Errorf("%v: hash length = %d, want %d", c.alg, got, c.length)
 		}
+	}
+}
+
+// The secret-selection tests below reach newNativeGSSAPIClient without a KDC. Each
+// case is arranged so the chosen branch fails inside its own With* call, which
+// happens before GetTGT is reached, so the returned error identifies which secret
+// was picked. That makes the precedence order observable without a live KDC.
+
+func TestNewNativeGSSAPIClientRequiresASecret(t *testing.T) {
+	creds, err := credentials.NewCredentials("MANTICORE.LOCAL", "user", "", "")
+	if err != nil {
+		t.Fatalf("NewCredentials() error = %v", err)
+	}
+
+	_, err = newNativeGSSAPIClient("dc.manticore.local", "MANTICORE.LOCAL", creds)
+	if err == nil {
+		t.Fatal("newNativeGSSAPIClient() with no secret error = nil, want an error")
+	}
+	if !strings.Contains(err.Error(), "no usable secret") {
+		t.Errorf("error = %q, want it to mention %q", err, "no usable secret")
+	}
+}
+
+func TestNewNativeGSSAPIClientPrefersKeytabOverEverything(t *testing.T) {
+	creds, err := credentials.NewCredentials("MANTICORE.LOCAL", "user", "password", strings.Repeat("a", 32))
+	if err != nil {
+		t.Fatalf("NewCredentials() error = %v", err)
+	}
+	// Assigned directly rather than through SetKeytab, which would reject a path
+	// that does not exist. A keytab that fails to load still proves it was chosen.
+	creds.Keytab = filepath.Join(t.TempDir(), "absent.keytab")
+	creds.AESKey = strings.Repeat("bb", 32)
+
+	_, err = newNativeGSSAPIClient("dc.manticore.local", "MANTICORE.LOCAL", creds)
+	if err == nil {
+		t.Fatal("newNativeGSSAPIClient() error = nil, want the keytab load to fail")
+	}
+	if !strings.Contains(err.Error(), "keytab") {
+		t.Errorf("error = %q, want it to mention %q", err, "keytab")
+	}
+}
+
+func TestNewNativeGSSAPIClientPrefersAESKeyOverHashAndPassword(t *testing.T) {
+	creds, err := credentials.NewCredentials("MANTICORE.LOCAL", "user", "password", strings.Repeat("a", 32))
+	if err != nil {
+		t.Fatalf("NewCredentials() error = %v", err)
+	}
+	if !creds.CanPassTheHash() {
+		t.Fatal("CanPassTheHash() = false, the NT hash fixture is wrong")
+	}
+	// A malformed key assigned directly, so WithAESKey rejects it and the error
+	// shows the AES branch ran ahead of the NT hash and password branches.
+	creds.AESKey = "not-hex"
+
+	_, err = newNativeGSSAPIClient("dc.manticore.local", "MANTICORE.LOCAL", creds)
+	if err == nil {
+		t.Fatal("newNativeGSSAPIClient() error = nil, want the AES key to be rejected")
+	}
+	if !strings.Contains(err.Error(), "AES key") {
+		t.Errorf("error = %q, want it to mention %q", err, "AES key")
 	}
 }

--- a/windows/credentials/credentials.go
+++ b/windows/credentials/credentials.go
@@ -1,7 +1,10 @@
 package credentials
 
 import (
+	"encoding/hex"
 	"errors"
+	"fmt"
+	"os"
 	"regexp"
 	"strings"
 )
@@ -13,6 +16,15 @@ type Credentials struct {
 
 	LMHash string
 	NTHash string
+
+	// AESKey is a hex-encoded Kerberos AES key, 32 hex characters for
+	// aes128-cts-hmac-sha1-96 or 64 for aes256-cts-hmac-sha1-96. Set it with
+	// SetAESKey, which validates the encoding and length.
+	AESKey string
+
+	// Keytab is the path to a Kerberos keytab file holding the principal's keys.
+	// Set it with SetKeytab.
+	Keytab string
 }
 
 // NewCredentials creates a new Credentials object.
@@ -79,6 +91,72 @@ func (c *Credentials) CanPassTheHash() bool {
 	return c.NTHash != "" && c.Username != ""
 }
 
+// CanUseAESKey returns true if the credentials hold a Kerberos AES key usable for
+// authentication.
+func (c *Credentials) CanUseAESKey() bool {
+	return c.AESKey != "" && c.Username != ""
+}
+
+// CanUseKeytab returns true if the credentials hold a Kerberos keytab usable for
+// authentication.
+func (c *Credentials) CanUseKeytab() bool {
+	return c.Keytab != "" && c.Username != ""
+}
+
+// Setters
+
+// SetAESKey sets the hex-encoded Kerberos AES key, after checking that it decodes
+// and is a valid AES key length. Validating here means a malformed key is reported
+// when the credentials are built, rather than as a KDC failure later.
+//
+// Parameters:
+//
+//	hexKey (string): The hex-encoded AES key, 32 or 64 hex characters.
+//
+// Returns:
+//
+//	An error if the key is not valid hex or is not 16 or 32 bytes, nil otherwise.
+func (c *Credentials) SetAESKey(hexKey string) error {
+	trimmed := strings.TrimSpace(hexKey)
+
+	raw, err := hex.DecodeString(trimmed)
+	if err != nil {
+		return fmt.Errorf("invalid hex AES key: %w", err)
+	}
+
+	if len(raw) != 16 && len(raw) != 32 {
+		return fmt.Errorf("AES key must be 16 or 32 bytes (32 or 64 hex characters), got %d", len(raw))
+	}
+
+	c.AESKey = trimmed
+
+	return nil
+}
+
+// SetKeytab sets the path to a Kerberos keytab file, after checking that the file
+// exists and is readable.
+//
+// Parameters:
+//
+//	path (string): The path to the keytab file.
+//
+// Returns:
+//
+//	An error if the file cannot be opened, nil otherwise.
+func (c *Credentials) SetKeytab(path string) error {
+	trimmed := strings.TrimSpace(path)
+
+	handle, err := os.Open(trimmed)
+	if err != nil {
+		return fmt.Errorf("cannot read keytab: %w", err)
+	}
+	defer handle.Close()
+
+	c.Keytab = trimmed
+
+	return nil
+}
+
 // Getters
 
 func (c *Credentials) GetLMHash() string {
@@ -99,4 +177,12 @@ func (c *Credentials) GetUsername() string {
 
 func (c *Credentials) GetPassword() string {
 	return c.Password
+}
+
+func (c *Credentials) GetAESKey() string {
+	return c.AESKey
+}
+
+func (c *Credentials) GetKeytab() string {
+	return c.Keytab
 }

--- a/windows/credentials/credentials_test.go
+++ b/windows/credentials/credentials_test.go
@@ -1,6 +1,9 @@
 package credentials_test
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/TheManticoreProject/Manticore/windows/credentials"
@@ -116,5 +119,101 @@ func TestParseLMNTHashes(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestSetAESKey(t *testing.T) {
+	// 32 hex characters is a 16-byte aes128 key, 64 a 32-byte aes256 key.
+	aes128 := strings.Repeat("ab", 16)
+	aes256 := strings.Repeat("cd", 32)
+
+	tests := []struct {
+		name    string
+		hexKey  string
+		wantErr bool
+		want    string
+	}{
+		{name: "aes128", hexKey: aes128, want: aes128},
+		{name: "aes256", hexKey: aes256, want: aes256},
+		{name: "surrounding whitespace is trimmed", hexKey: "  " + aes256 + "\n", want: aes256},
+		{name: "uppercase hex", hexKey: strings.ToUpper(aes256), want: strings.ToUpper(aes256)},
+		{name: "not hex", hexKey: strings.Repeat("zz", 32), wantErr: true},
+		{name: "odd length", hexKey: strings.Repeat("a", 63), wantErr: true},
+		{name: "too short", hexKey: strings.Repeat("ab", 8), wantErr: true},
+		{name: "too long", hexKey: strings.Repeat("ab", 48), wantErr: true},
+		{name: "empty", hexKey: "", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &credentials.Credentials{Username: "user"}
+			err := c.SetAESKey(tt.hexKey)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("SetAESKey(%q) error = nil, want an error", tt.hexKey)
+				}
+				if c.GetAESKey() != "" {
+					t.Errorf("AESKey = %q after a rejected key, want it left empty", c.GetAESKey())
+				}
+				if c.CanUseAESKey() {
+					t.Error("CanUseAESKey() = true after a rejected key")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("SetAESKey(%q) error = %v", tt.hexKey, err)
+			}
+			if got := c.GetAESKey(); got != tt.want {
+				t.Errorf("GetAESKey() = %q, want %q", got, tt.want)
+			}
+			if !c.CanUseAESKey() {
+				t.Error("CanUseAESKey() = false, want true")
+			}
+		})
+	}
+}
+
+func TestCanUseAESKeyRequiresUsername(t *testing.T) {
+	c := &credentials.Credentials{}
+	if err := c.SetAESKey(strings.Repeat("ab", 32)); err != nil {
+		t.Fatalf("SetAESKey() error = %v", err)
+	}
+	if c.CanUseAESKey() {
+		t.Error("CanUseAESKey() = true with no username, want false")
+	}
+}
+
+func TestSetKeytab(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "user.keytab")
+	if err := os.WriteFile(path, []byte("not a real keytab"), 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	c := &credentials.Credentials{Username: "user"}
+	if err := c.SetKeytab(path); err != nil {
+		t.Fatalf("SetKeytab(%q) error = %v", path, err)
+	}
+	if got := c.GetKeytab(); got != path {
+		t.Errorf("GetKeytab() = %q, want %q", got, path)
+	}
+	if !c.CanUseKeytab() {
+		t.Error("CanUseKeytab() = false, want true")
+	}
+}
+
+func TestSetKeytabRejectsMissingFile(t *testing.T) {
+	c := &credentials.Credentials{Username: "user"}
+	missing := filepath.Join(t.TempDir(), "absent.keytab")
+
+	if err := c.SetKeytab(missing); err == nil {
+		t.Fatal("SetKeytab() with a missing file error = nil, want an error")
+	}
+	if c.GetKeytab() != "" {
+		t.Errorf("Keytab = %q after a rejected path, want it left empty", c.GetKeytab())
+	}
+	if c.CanUseKeytab() {
+		t.Error("CanUseKeytab() = true after a rejected path")
 	}
 }


### PR DESCRIPTION
### Linked Issue
`Closes #1038`

### Root Cause
`credentials.Credentials` predates the native Kerberos client. When gokrb5 was replaced, the new `KerberosClient` gained `WithAESKey` (`network/kerberos/v5/client.go` L194) and `WithKeytabFile` (`network/kerberos/v5/keytab.go` L87), but neither the credential struct nor the LDAP bridge that feeds it were extended. `Credentials` carried only a password and LM/NT hashes, so an AES key or keytab held by a caller had nowhere to live, and `newNativeGSSAPIClient` had no way to pass one on.

The bridge also had no "no secret" case. Its `if creds.CanPassTheHash() { ... } else { kc.WithPassword(...) }` fell through to the password branch unconditionally, so a `Credentials` with neither password nor hash was configured with an empty password and failed at `GetTGT()` against the KDC rather than reporting locally that nothing usable was supplied.

### Fix Description
Adds `AESKey` and `Keytab` to `Credentials`, with `SetAESKey` and `SetKeytab` setters that validate up front, matching getters, and `CanUseAESKey`/`CanUseKeytab` predicates in the style of the existing `CanPassTheHash`.

`SetAESKey` hex-decodes and requires 16 or 32 bytes, so a malformed key is rejected where it is supplied rather than surfacing as a KDC failure much later. `SetKeytab` opens the file so an unreadable path fails immediately. Both trim surrounding whitespace, which matters when a key is pasted from tool output, and both leave the field untouched when they reject the input so a failed set cannot half-configure the credentials.

`newNativeGSSAPIClient` becomes an explicit switch, ordered strongest secret first: keytab, AES key, NT hash, password. A keytab can carry AES keys for several etypes; an AES key beats the RC4 key an NT hash yields; a password is weakest since it still has to be string-to-key'd. The final `default` returns `no usable secret: set a password, NT hash, AES key or keytab` instead of attempting an empty-password TGT.

### How Verified
Runtime. New tests pass:

```
--- PASS: TestSetAESKey (0.00s)
    --- PASS: TestSetAESKey/aes128
    --- PASS: TestSetAESKey/aes256
    --- PASS: TestSetAESKey/surrounding_whitespace_is_trimmed
    --- PASS: TestSetAESKey/uppercase_hex
    --- PASS: TestSetAESKey/not_hex
    --- PASS: TestSetAESKey/odd_length
    --- PASS: TestSetAESKey/too_short
    --- PASS: TestSetAESKey/too_long
    --- PASS: TestSetAESKey/empty
--- PASS: TestCanUseAESKeyRequiresUsername (0.00s)
--- PASS: TestSetKeytab (0.00s)
--- PASS: TestSetKeytabRejectsMissingFile (0.00s)
--- PASS: TestNewNativeGSSAPIClientRequiresASecret (0.00s)
--- PASS: TestNewNativeGSSAPIClientPrefersKeytabOverEverything (0.00s)
--- PASS: TestNewNativeGSSAPIClientPrefersAESKeyOverHashAndPassword (0.00s)
```

Surrounding packages stay green:

```
ok  	github.com/TheManticoreProject/Manticore/windows/credentials
ok  	github.com/TheManticoreProject/Manticore/network/ldap	0.056s
ok  	github.com/TheManticoreProject/Manticore/network/kerberos/v5	1.209s
ok  	github.com/TheManticoreProject/Manticore/network/kerberos/v5/credcache/keytab
ok  	github.com/TheManticoreProject/Manticore/network/kerberos/v5/credentials
ok  	github.com/TheManticoreProject/Manticore/network/kerberos/v5/gssapi
```

`go build ./...` and `go vet ./...` are clean, and all four changed files are `gofmt` clean. (`gofmt -l .` reports 25 files repo-wide, unchanged from `origin/main` and none of them touched here.)

### Test Coverage
**Added.**

`windows/credentials/credentials_test.go`:
- `TestSetAESKey` — a nine-case table over aes128, aes256, whitespace, uppercase hex, non-hex, odd length, too short, too long and empty, asserting the field is left empty and `CanUseAESKey` stays false on every rejection.
- `TestCanUseAESKeyRequiresUsername` — a valid key with no username does not count as usable.
- `TestSetKeytab` / `TestSetKeytabRejectsMissingFile` — accepts a readable file, rejects a missing path without recording it.

`network/ldap/kerberos_gssapi_test.go`:
- `TestNewNativeGSSAPIClientRequiresASecret` — asserts the new `no usable secret` error.
- `TestNewNativeGSSAPIClientPrefersKeytabOverEverything` and `TestNewNativeGSSAPIClientPrefersAESKeyOverHashAndPassword` — make the precedence order observable without a KDC by arranging for the preferred branch to fail inside its own `With*` call, which runs before `GetTGT`, so the error names the secret that was chosen.

### Scope of Change
- **Files changed:** `windows/credentials/credentials.go`, `windows/credentials/credentials_test.go`, `network/ldap/kerberos_gssapi.go`, `network/ldap/kerberos_gssapi_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
`NewCredentials` keeps its signature, and the new fields default to empty, so every existing caller takes exactly the branches it took before: NT hash if present, otherwise password. The one changed outcome for existing callers is that a `Credentials` with neither password nor hash now fails locally with a clear message instead of making a doomed empty-password request to the KDC. Safe to merge without staged rollout.

### Notes
`Credentials.AESKey` and `Credentials.Keytab` are exported for consistency with the existing fields, but callers should prefer the setters so the validation runs. The two precedence tests assign them directly on purpose, to construct the invalid states the setters exist to prevent.
