### PR TITLE
Fix KeyCredentialLink.Unmarshal dropping the version (Fixes #1042)

### DIFF
--- a/windows/keycredentiallink/KeyCredentialLink.go
+++ b/windows/keycredentiallink/KeyCredentialLink.go
@@ -196,6 +196,11 @@ func (kc *KeyCredentialLink) Unmarshal(data []byte) (int, error) {
 		return bytesRead, err
 	}
 
+	// The version governs how the entries below are interpreted (identifier form,
+	// timestamp encoding), so it has to be carried over from the parsed blob before
+	// the entries are processed, not left at its zero value.
+	kc.Version = blob.Version
+
 	for _, entry := range blob.Entries {
 		// Process the entry data based on its type.
 		switch entry.Identifier {

--- a/windows/keycredentiallink/KeyCredentialLink_test.go
+++ b/windows/keycredentiallink/KeyCredentialLink_test.go
@@ -4,7 +4,13 @@ import (
 	"testing"
 
 	"github.com/TheManticoreProject/Manticore/network/ldap"
+	"github.com/TheManticoreProject/Manticore/windows/cng/bcrypt/keys"
+	"github.com/TheManticoreProject/Manticore/windows/cng/bcrypt/keys/blob"
+	"github.com/TheManticoreProject/Manticore/windows/cng/bcrypt/keys/headers"
+	"github.com/TheManticoreProject/Manticore/windows/cng/bcrypt/keys/magic"
+	"github.com/TheManticoreProject/Manticore/windows/guid"
 	"github.com/TheManticoreProject/Manticore/windows/keycredentiallink"
+	"github.com/TheManticoreProject/Manticore/windows/keycredentiallink/version"
 )
 
 func TestKeyCredential_Unmarshal(t *testing.T) {
@@ -42,5 +48,38 @@ func TestKeyCredential_Unmarshal(t *testing.T) {
 				return
 			}
 		})
+	}
+}
+
+// TestKeyCredential_Unmarshal_PreservesVersion checks that Unmarshal carries the
+// blob version onto the KeyCredentialLink. The version was previously left at its
+// zero value, so a v2 credential round-tripped as v0 and the version-dependent
+// entry parsing ran with the wrong version.
+func TestKeyCredential_Unmarshal_PreservesVersion(t *testing.T) {
+	built := keycredentiallink.NewKeyCredentialLink(
+		version.KeyCredentialLinkVersion{Value: version.KeyCredentialLinkVersion_2},
+		"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+		&keys.BCRYPT_RSA_PUBLIC_KEY{
+			Magic:   magic.BCRYPT_KEY_BLOB{Magic: magic.BCRYPT_RSAPUBLIC_MAGIC},
+			Header:  headers.BCRYPT_RSA_KEY_BLOB{BitLength: 16, CbPublicExp: 3, CbModulus: 2},
+			Content: blob.BCRYPT_RSA_PUBLIC_BLOB{PublicExponent: []byte{0x01, 0x00, 0x01}, Modulus: []byte{0x00, 0x01}},
+		},
+		guid.NewGUID(),
+		nil,
+		nil,
+	)
+
+	raw, err := built.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+
+	parsed := keycredentiallink.KeyCredentialLink{}
+	if _, err := parsed.Unmarshal(raw); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+
+	if parsed.Version.Value != version.KeyCredentialLinkVersion_2 {
+		t.Errorf("Version.Value = 0x%x, want 0x%x", parsed.Version.Value, version.KeyCredentialLinkVersion_2)
 	}
 }


### PR DESCRIPTION
### Linked Issue
`Closes #1042`

### Root Cause
`KeyCredentialLink.Unmarshal` parses the blob (which reads the version correctly into `blob.Version`) and copies `blob.Entries` onto the credential, but never copies `blob.Version` onto `kc.Version`. The field is left at its zero value, so a v2 credential reads back as v0. `Marshal` does the mirror assignment (`blob.Version = kc.Version`); `Unmarshal` was missing the reverse.

This is more than a display issue: the entry loop right below passes `kc.Version` into `utils.ConvertFromBinaryIdentifier`, `utils.ConvertFromBinaryTime` and `CustomKeyInfo.Unmarshal`, so those version-dependent conversions run against v0 for an actual v2 credential.

### Fix Description
Assign `kc.Version = blob.Version` immediately after the blob is unmarshalled and before the entry loop, so the version is set when the entries are interpreted. One line, no signature or behavioural change beyond the corrected version.

### How Verified
Runtime. A new test builds a v2 credential, marshals it, unmarshals it, and asserts the version survives. It fails on the current code and passes with the fix:

```
# before
--- FAIL: TestKeyCredential_Unmarshal_PreservesVersion
    KeyCredentialLink_test.go:83: Version.Value = 0x0, want 0x200

# after
ok  	github.com/TheManticoreProject/Manticore/windows/keycredentiallink
```

`go build ./...` and the `windows/keycredentiallink/...` tests are green.

### Test Coverage
**Added** — `TestKeyCredential_Unmarshal_PreservesVersion` in `windows/keycredentiallink/KeyCredentialLink_test.go`: builds a v2 credential, round-trips it through Marshal/Unmarshal, and asserts `Version.Value == KeyCredentialLinkVersion_2`.

### Scope of Change
- **Files changed:** `windows/keycredentiallink/KeyCredentialLink.go`, `windows/keycredentiallink/KeyCredentialLink_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
The version now reflects what is on the wire, so consumers that read `kc.Version` after `Unmarshal` (for display or version-gated parsing) get the correct value. A consumer that somehow depended on the version always being v0 would change, but that reliance would itself be the bug. Safe to merge without staged rollout.

### Notes
Found while testing a downstream tool (`manticore-keycredentials describe`) against a live domain controller: v2 credentials created by the tool were read back and reported as `KeyCredentialLink_v0`.
