### PR TITLE
Fix Kerberos pre-auth failing for accounts whose salt is not realm+username (Fixes #1044)

### DIFF
--- a/network/kerberos/v5/client.go
+++ b/network/kerberos/v5/client.go
@@ -271,9 +271,15 @@ func (c *KerberosClient) GetTGT() error {
 		var krb_err messages.KRBError
 		if _, parse_err := krb_err.Unmarshal(resp); parse_err == nil {
 			switch krb_err.ErrorCode {
-			case messages.ErrPreauthRequired:
-				// The KDC wants a different etype/salt; retry with the corrected
-				// values (that path applies its own skew retry).
+			case messages.ErrPreauthRequired, messages.ErrPreauthFailed:
+				// PREAUTH_REQUIRED means the KDC wants pre-auth with the etype/salt
+				// from its ETYPE-INFO2. PREAUTH_FAILED means our optimistic guess was
+				// wrong; the same ETYPE-INFO2 is carried in that error too, and it
+				// names the salt the account actually uses. Accounts whose salt is not
+				// realm+username (renamed domains, pre-created accounts) fail the
+				// optimistic attempt and only succeed via this correction. Retry once
+				// with the KDC-provided values (that path applies its own skew retry
+				// and does not loop on a repeated failure).
 				etype, salt, s2k_params := c.pickETypeFromError(krb_err)
 				return c.doASReqWithPreauth(etype, salt, s2k_params)
 			case messages.ErrSkew:

--- a/network/kerberos/v5/client_test.go
+++ b/network/kerberos/v5/client_test.go
@@ -215,3 +215,39 @@ func TestParseSPN(t *testing.T) {
 		}
 	}
 }
+
+// TestPreauthFailedCarriesCorrectedSalt covers the KDC_ERR_PREAUTH_FAILED (24)
+// case: when an account's Kerberos salt is not realm+username (a renamed domain or
+// a pre-created account), the optimistic pre-auth is rejected with error 24, and
+// that error carries the salt the account actually uses. GetTGT retries error 24
+// like error 25, so the salt used for the retry must come from the error's
+// ETYPE-INFO2, not from the default realm+username guess.
+func TestPreauthFailedCarriesCorrectedSalt(t *testing.T) {
+	if messages.ErrPreauthFailed != 24 {
+		t.Fatalf("ErrPreauthFailed = %d, want 24", messages.ErrPreauthFailed)
+	}
+
+	c := NewClient("Administrator", "TMP-W-2025.local", "10.0.0.1").WithPassword("Passw0rd!")
+
+	// The account was created under an original machine name, so AD salts with that
+	// name and not with the DNS realm.
+	const kdcSalt = "WIN-UK5B7SSQIUDAdministrator"
+	if c.cred.DefaultSalt() == kdcSalt {
+		t.Fatal("test precondition: KDC salt must differ from the default realm+username salt")
+	}
+
+	info := messages.ETypeInfo2{{EType: messages.ETypeAES256CTSHMACSHA196, Salt: kdcSalt}}
+	infoDER, err := info.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	krbErr := messages.KRBError{ErrorCode: messages.ErrPreauthFailed, EData: infoDER}
+
+	etype, salt, _ := c.pickETypeFromError(krbErr)
+	if etype != messages.ETypeAES256CTSHMACSHA196 {
+		t.Errorf("etype = %d, want AES256", etype)
+	}
+	if salt != kdcSalt {
+		t.Errorf("salt = %q, want the KDC-advertised %q", salt, kdcSalt)
+	}
+}

--- a/network/kerberos/v5/messages/constants.go
+++ b/network/kerberos/v5/messages/constants.go
@@ -47,6 +47,7 @@ const (
 	ErrNone              = iana.ErrNone
 	ErrCPrincipalUnknown = iana.ErrCPrincipalUnknown
 	ErrSPrincipalUnknown = iana.ErrSPrincipalUnknown
+	ErrPreauthFailed     = iana.ErrPreauthFailed
 	ErrPreauthRequired   = iana.ErrPreauthRequired
 	ErrSkew              = iana.ErrSkew
 	ErrResponseTooBig    = iana.ErrResponseTooBig


### PR DESCRIPTION
### Linked Issue
`Closes #1044`

### Root Cause
`GetTGT` sends an optimistic PA-ENC-TIMESTAMP salted with `realm+username` and only retries on `KDC_ERR_PREAUTH_REQUIRED` (25). An account whose real salt is not `realm+username` — which happens whenever a domain was renamed, or an account predates a rename — makes the KDC reject the optimistic timestamp with `KDC_ERR_PREAUTH_FAILED` (24). That error already carries the correct salt in its ETYPE-INFO2, but error 24 fell into the `default` branch, so GetTGT returned instead of retrying with the salt the KDC just handed it.

### Fix Description
`GetTGT` now treats `ErrPreauthFailed` the same as `ErrPreauthRequired`: it extracts the etype, salt and s2k-params from the error's ETYPE-INFO2 via the existing `pickETypeFromError`, and retries once through `doASReqWithPreauth`. That retry path already handles its own clock-skew retry and does not loop on a repeated failure, so a genuinely wrong password still terminates after one corrected attempt rather than spinning.

A `messages.ErrPreauthFailed` alias for `iana.ErrPreauthFailed` (24) is added, matching the existing `ErrPreauthRequired` alias.

### How Verified
Runtime, against a renamed-domain DC where the built-in Administrator is salted with the domain's original machine name (`WIN-UK5B7SSQIUDAdministrator`) rather than the DNS realm.

Before: `-k` authentication fails at TGT acquisition with `kerberos: KDC error 24`.
After: the TGT is acquired (the exchange proceeds past pre-auth to the TGS stage).

Unit test added and passing; the full `network/kerberos/v5` package suite is green.

### Test Coverage
**Added** — `TestPreauthFailedCarriesCorrectedSalt` in `network/kerberos/v5/client_test.go`: asserts `ErrPreauthFailed == 24`, and that `pickETypeFromError`, given a `KRBError` with error code 24 and an ETYPE-INFO2 salt that differs from `realm+username`, returns the KDC-advertised salt — the value the corrected retry depends on.

The switch-branch wiring itself (that error 24 now routes into the retry) is exercised live in the scenario above; the package has no mock-KDC transport for a pure unit test of the full round-trip, so the salt-selection mechanism the fix relies on is what is unit-tested.

### Scope of Change
- **Files changed:** `network/kerberos/v5/client.go`, `network/kerberos/v5/messages/constants.go`, `network/kerberos/v5/client_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
The only behavioral change is that an AS-REQ which previously failed with error 24 is retried once using the KDC's own ETYPE-INFO2. Accounts that already worked (salt == realm+username) are unaffected: their optimistic attempt still succeeds and never reaches the new branch. A wrong password now costs one extra round-trip before failing, which is negligible. Safe to merge without staged rollout.

### Notes
A separate limitation surfaced during the same test and is *not* addressed here: with `-k` and the DC given by IP, the service-ticket request uses the SPN `ldap/<ip>`, which AD does not register, yielding `KDC_ERR_S_PRINCIPAL_UNKNOWN` (7). Kerberos service tickets are keyed by hostname, so the DC has to be named by FQDN. That is a downstream/CLI concern rather than a bug in this client.
