### PR TITLE
Add LDAP session SPN hostname override for Kerberos binds by IP

### DIFF
--- a/network/ldap/session.go
+++ b/network/ldap/session.go
@@ -54,6 +54,13 @@ type Session struct {
 	// binds (RFC 4752 §3.1). It defaults to no security layer (auth only); use
 	// SetGSSAPISigning / SetGSSAPISealing to request integrity or confidentiality.
 	gssapiLayer byte
+	// spnHostname overrides the hostname used to build the ldap/<host> service
+	// principal name for the Kerberos bind. It is empty by default, in which case
+	// the SPN is built from host. Set it (via SetKerberosSPNHostname) when host is
+	// an IP address: Active Directory registers the SPN under the DC's FQDN, so a
+	// Kerberos bind by IP needs the FQDN here while the TCP connection and the KDC
+	// exchanges still use host.
+	spnHostname string
 	// gssClient retains the GSSAPI client for the lifetime of the session so the
 	// negotiated per-message security context survives past the bind and is torn
 	// down on Close.
@@ -137,6 +144,31 @@ func (s *Session) SetTLSSkipVerify(skip bool) {
 	s.tlsSkipVerify = skip
 }
 
+// SetKerberosSPNHostname sets the hostname used to build the ldap/<host> service
+// principal name for a Kerberos bind, overriding the connection host.
+//
+// Use it when the session connects to a domain controller by IP address: Active
+// Directory registers the ldap SPN under the DC's FQDN, so a Kerberos bind by IP
+// fails with KDC_ERR_S_PRINCIPAL_UNKNOWN unless the SPN is built from the FQDN. The
+// TCP connection and the KDC exchanges continue to use the connection host, so the
+// IP is still what is dialled.
+//
+// Parameters:
+//
+//	hostname (string): The FQDN to use in the SPN, or empty to use the connection host.
+func (s *Session) SetKerberosSPNHostname(hostname string) {
+	s.spnHostname = hostname
+}
+
+// kerberosSPNHostname returns the hostname the ldap SPN is built from: the override
+// when one was set, otherwise the connection host.
+func (s *Session) kerberosSPNHostname() string {
+	if s.spnHostname != "" {
+		return s.spnHostname
+	}
+	return s.host
+}
+
 // Connect establishes a connection to the LDAP server. It supports both regular LDAP and LDAPS connections,
 // and can optionally use Kerberos for authentication.
 //
@@ -195,7 +227,8 @@ func (s *Session) Connect() (bool, error) {
 	if s.usekerberos {
 		// Native (stdlib-only) GSSAPI SASL bind; the DC is both the LDAP server
 		// and the KDC. Realm is the credentials' domain (upper-cased by the client).
-		servicePrincipalName := fmt.Sprintf("ldap/%s", s.host)
+		// The SPN is built from the DC's FQDN when host is an IP (see spnHostname).
+		servicePrincipalName := fmt.Sprintf("ldap/%s", s.kerberosSPNHostname())
 		gssClient, gerr := newNativeGSSAPIClient(s.host, s.credentials.GetDomain(), s.credentials)
 		if gerr != nil {
 			ldapConnection.Close()

--- a/network/ldap/session_spn_test.go
+++ b/network/ldap/session_spn_test.go
@@ -1,0 +1,29 @@
+package ldap
+
+import "testing"
+
+// TestKerberosSPNHostname checks that the ldap SPN is built from the connection
+// host by default and from the override when one is set. The override lets a
+// Kerberos bind reach a DC by IP while naming it by FQDN in the SPN, which is what
+// Active Directory registers.
+func TestKerberosSPNHostname(t *testing.T) {
+	s, err := NewSession("192.168.1.7", 636, nil, true, true)
+	if err != nil {
+		t.Fatalf("NewSession() error = %v", err)
+	}
+
+	if got := s.kerberosSPNHostname(); got != "192.168.1.7" {
+		t.Errorf("default SPN hostname = %q, want the connection host", got)
+	}
+
+	s.SetKerberosSPNHostname("dc1.corp.local")
+	if got := s.kerberosSPNHostname(); got != "dc1.corp.local" {
+		t.Errorf("SPN hostname = %q, want the override", got)
+	}
+
+	// Clearing it falls back to the connection host.
+	s.SetKerberosSPNHostname("")
+	if got := s.kerberosSPNHostname(); got != "192.168.1.7" {
+		t.Errorf("SPN hostname after clear = %q, want the connection host", got)
+	}
+}


### PR DESCRIPTION
### Summary
Add `Session.SetKerberosSPNHostname` so a Kerberos LDAP bind can reach a domain controller by IP while naming it by FQDN in the service principal name.

### Motivation
The Kerberos bind builds its SPN as `ldap/<host>`, where `<host>` is the connection host. When the caller connects to a DC by IP, the SPN becomes `ldap/<ip>`, which Active Directory does not register — the TGS request fails with `KDC_ERR_S_PRINCIPAL_UNKNOWN` (7). AD registers the ldap SPN only under the DC's FQDN, so a Kerberos bind by IP has no way to name the service correctly.

### Change
- New unexported `spnHostname` field on `Session` and a `SetKerberosSPNHostname(hostname string)` setter.
- `Connect` builds the SPN from `kerberosSPNHostname()`, which returns the override when set and the connection host otherwise.
- The TCP connection and the KDC exchanges are unchanged: they still use the connection host, so the IP is still what is dialled and the KDC is still reached by IP. Only the SPN string changes.

This lets a caller pass `--dc-ip 192.168.1.7` for the connection and `--dc-host dc1.corp.local` for the SPN, which is the common way to use Kerberos against a DC that DNS does not resolve locally.

### How Verified
`network/ldap` package tests pass, including a new `TestKerberosSPNHostname` covering the default (connection host), the override, and clearing the override. End-to-end, a downstream tool built against this change authenticates with `-k` against a DC given by IP once the FQDN is supplied for the SPN.

### Test Coverage
**Added** — `TestKerberosSPNHostname` in `network/ldap/session_spn_test.go`.

### Scope of Change
- **Files changed:** `network/ldap/session.go`, `network/ldap/session_spn_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none — the SPN is unchanged when the override is not set.

### Risk and Rollout
Additive and backward-compatible: existing callers that never call `SetKerberosSPNHostname` get exactly the current SPN. Safe to merge without staged rollout.
