### PR TITLE
Support pass-the-ticket (ccache/.kirbi) for the LDAP GSSAPI bind

### DIFF
--- a/network/ldap/kerberos_gssapi.go
+++ b/network/ldap/kerberos_gssapi.go
@@ -59,31 +59,50 @@ func newNativeGSSAPIClient(kdc, realm string, creds *credentials.Credentials) (*
 	user := creds.GetUsername()
 	kc := kerberos.NewClient(user, realm, kdc)
 
-	// Ordered strongest first: a keytab can carry AES keys for several etypes, an
-	// AES key beats the RC4 key an NT hash provides, and a password is the weakest
-	// because it still has to be string-to-key'd into one.
+	// A ccache or .kirbi already carries a TGT (pass-the-ticket): load it and skip
+	// the AS exchange. Otherwise derive a TGT from a secret, ordered strongest
+	// first: a keytab can carry AES keys for several etypes, an AES key beats the
+	// RC4 key an NT hash provides, and a password is the weakest because it still
+	// has to be string-to-key'd into one.
 	switch {
+	case creds.CanUseCCache():
+		if err := kc.LoadTGTFromCCacheFile(creds.GetCCache()); err != nil {
+			return nil, fmt.Errorf("ldap gssapi: ccache: %w", err)
+		}
+	case creds.CanUseKirbi():
+		if err := kc.LoadTGTFromKirbiFile(creds.GetKirbi()); err != nil {
+			return nil, fmt.Errorf("ldap gssapi: kirbi: %w", err)
+		}
 	case creds.CanUseKeytab():
 		if err := kc.WithKeytabFile(creds.GetKeytab()); err != nil {
 			return nil, fmt.Errorf("ldap gssapi: keytab: %w", err)
+		}
+		if err := kc.GetTGT(); err != nil {
+			return nil, fmt.Errorf("ldap gssapi: GetTGT: %w", err)
 		}
 	case creds.CanUseAESKey():
 		if err := kc.WithAESKey(creds.GetAESKey()); err != nil {
 			return nil, fmt.Errorf("ldap gssapi: AES key: %w", err)
 		}
+		if err := kc.GetTGT(); err != nil {
+			return nil, fmt.Errorf("ldap gssapi: GetTGT: %w", err)
+		}
 	case creds.CanPassTheHash():
 		if err := kc.WithNTHash(creds.GetNTHash()); err != nil {
 			return nil, fmt.Errorf("ldap gssapi: NT hash: %w", err)
 		}
+		if err := kc.GetTGT(); err != nil {
+			return nil, fmt.Errorf("ldap gssapi: GetTGT: %w", err)
+		}
 	case creds.GetPassword() != "":
 		kc.WithPassword(creds.GetPassword())
+		if err := kc.GetTGT(); err != nil {
+			return nil, fmt.Errorf("ldap gssapi: GetTGT: %w", err)
+		}
 	default:
-		return nil, fmt.Errorf("ldap gssapi: no usable secret: set a password, NT hash, AES key or keytab")
+		return nil, fmt.Errorf("ldap gssapi: no usable secret: set a password, NT hash, AES key, keytab, ccache or kirbi")
 	}
 
-	if err := kc.GetTGT(); err != nil {
-		return nil, fmt.Errorf("ldap gssapi: GetTGT: %w", err)
-	}
 	return &nativeGSSAPIClient{kc: kc, realm: strings.ToUpper(realm), user: user, desiredLayer: saslLayerNone}, nil
 }
 

--- a/network/ldap/kerberos_gssapi_ticket_test.go
+++ b/network/ldap/kerberos_gssapi_ticket_test.go
@@ -1,0 +1,115 @@
+package ldap
+
+import (
+	"crypto/rand"
+	"os"
+	"path/filepath"
+	"testing"
+
+	kerberos "github.com/TheManticoreProject/Manticore/network/kerberos/v5"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/messages"
+	"github.com/TheManticoreProject/Manticore/windows/credentials"
+)
+
+// forgeTGTFiles produces a ccache file and a .kirbi file holding a usable TGT, so
+// the ticket-based bridge paths can be tested without a KDC.
+func forgeTGTFiles(t *testing.T) (ccachePath, kirbiPath string) {
+	t.Helper()
+
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		t.Fatalf("rand.Read: %v", err)
+	}
+
+	ft, err := kerberos.ForgeGolden(kerberos.ForgeOptions{
+		Realm:     "CORP.LOCAL",
+		Username:  "Administrator",
+		DomainSID: "S-1-5-21-1-2-3",
+		UserRID:   500,
+		Key:       key,
+		KeyEType:  messages.ETypeAES256CTSHMACSHA196,
+	})
+	if err != nil {
+		t.Fatalf("ForgeGolden: %v", err)
+	}
+
+	kirbiBytes, err := ft.KirbiBytes()
+	if err != nil {
+		t.Fatalf("KirbiBytes: %v", err)
+	}
+
+	dir := t.TempDir()
+	kirbiPath = filepath.Join(dir, "tgt.kirbi")
+	if err := os.WriteFile(kirbiPath, kirbiBytes, 0o600); err != nil {
+		t.Fatalf("write kirbi: %v", err)
+	}
+
+	// Round-trip the forged TGT through a client to serialize it as a ccache.
+	kc := kerberos.NewClient("", "", "10.0.0.1")
+	if err := kc.LoadTGTFromKirbiBytes(kirbiBytes); err != nil {
+		t.Fatalf("LoadTGTFromKirbiBytes: %v", err)
+	}
+	cc, err := kc.ExportTGTCCache()
+	if err != nil {
+		t.Fatalf("ExportTGTCCache: %v", err)
+	}
+	ccachePath = filepath.Join(dir, "krb5cc")
+	if err := cc.Save(ccachePath); err != nil {
+		t.Fatalf("ccache.Save: %v", err)
+	}
+	return ccachePath, kirbiPath
+}
+
+// TestNewNativeGSSAPIClientLoadsTicket checks that a ccache or .kirbi credential
+// makes the bridge load the TGT it carries, without an AS exchange. The KDC host is
+// unreachable on purpose: if the bridge tried to acquire a TGT it would fail, so a
+// nil error proves the ticket was used instead.
+func TestNewNativeGSSAPIClientLoadsTicket(t *testing.T) {
+	ccachePath, kirbiPath := forgeTGTFiles(t)
+
+	t.Run("ccache", func(t *testing.T) {
+		creds := &credentials.Credentials{}
+		if err := creds.SetCCache(ccachePath); err != nil {
+			t.Fatalf("SetCCache: %v", err)
+		}
+		gss, err := newNativeGSSAPIClient("10.0.0.1", "CORP.LOCAL", creds)
+		if err != nil {
+			t.Fatalf("newNativeGSSAPIClient with ccache: %v", err)
+		}
+		if gss == nil {
+			t.Fatal("newNativeGSSAPIClient returned nil client")
+		}
+	})
+
+	t.Run("kirbi", func(t *testing.T) {
+		creds := &credentials.Credentials{}
+		if err := creds.SetKirbi(kirbiPath); err != nil {
+			t.Fatalf("SetKirbi: %v", err)
+		}
+		gss, err := newNativeGSSAPIClient("10.0.0.1", "CORP.LOCAL", creds)
+		if err != nil {
+			t.Fatalf("newNativeGSSAPIClient with kirbi: %v", err)
+		}
+		if gss == nil {
+			t.Fatal("newNativeGSSAPIClient returned nil client")
+		}
+	})
+}
+
+// TestNewNativeGSSAPIClientRejectsBadTicket confirms an unreadable ccache surfaces
+// as a ccache error, proving the branch routes to the ticket loader rather than a
+// secret path.
+func TestNewNativeGSSAPIClientRejectsBadTicket(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "krb5cc")
+	if err := os.WriteFile(path, []byte("not a ccache"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	creds := &credentials.Credentials{}
+	if err := creds.SetCCache(path); err != nil {
+		t.Fatalf("SetCCache: %v", err)
+	}
+	_, err := newNativeGSSAPIClient("10.0.0.1", "CORP.LOCAL", creds)
+	if err == nil {
+		t.Fatal("newNativeGSSAPIClient with a garbage ccache error = nil, want an error")
+	}
+}

--- a/windows/credentials/credentials.go
+++ b/windows/credentials/credentials.go
@@ -25,6 +25,14 @@ type Credentials struct {
 	// Keytab is the path to a Kerberos keytab file holding the principal's keys.
 	// Set it with SetKeytab.
 	Keytab string
+
+	// CCache is the path to a Kerberos credential cache (FILE format) holding a
+	// TGT to authenticate with (pass-the-ticket). Set it with SetCCache.
+	CCache string
+
+	// Kirbi is the path to a .kirbi (DER KRB-CRED) file holding a TGT to
+	// authenticate with (pass-the-ticket). Set it with SetKirbi.
+	Kirbi string
 }
 
 // NewCredentials creates a new Credentials object.
@@ -103,6 +111,19 @@ func (c *Credentials) CanUseKeytab() bool {
 	return c.Keytab != "" && c.Username != ""
 }
 
+// CanUseCCache returns true if the credentials point at a Kerberos credential
+// cache to authenticate from. Unlike the secret-based methods it does not require a
+// username: the principal is carried by the ticket in the cache.
+func (c *Credentials) CanUseCCache() bool {
+	return c.CCache != ""
+}
+
+// CanUseKirbi returns true if the credentials point at a .kirbi ticket to
+// authenticate from. Like CanUseCCache it does not require a username.
+func (c *Credentials) CanUseKirbi() bool {
+	return c.Kirbi != ""
+}
+
 // Setters
 
 // SetAESKey sets the hex-encoded Kerberos AES key, after checking that it decodes
@@ -157,6 +178,54 @@ func (c *Credentials) SetKeytab(path string) error {
 	return nil
 }
 
+// SetCCache sets the path to a Kerberos credential cache, after checking that the
+// file exists and is readable.
+//
+// Parameters:
+//
+//	path (string): The path to the ccache file.
+//
+// Returns:
+//
+//	An error if the file cannot be opened, nil otherwise.
+func (c *Credentials) SetCCache(path string) error {
+	trimmed := strings.TrimSpace(path)
+
+	handle, err := os.Open(trimmed)
+	if err != nil {
+		return fmt.Errorf("cannot read ccache: %w", err)
+	}
+	defer handle.Close()
+
+	c.CCache = trimmed
+
+	return nil
+}
+
+// SetKirbi sets the path to a .kirbi ticket file, after checking that the file
+// exists and is readable.
+//
+// Parameters:
+//
+//	path (string): The path to the .kirbi file.
+//
+// Returns:
+//
+//	An error if the file cannot be opened, nil otherwise.
+func (c *Credentials) SetKirbi(path string) error {
+	trimmed := strings.TrimSpace(path)
+
+	handle, err := os.Open(trimmed)
+	if err != nil {
+		return fmt.Errorf("cannot read kirbi: %w", err)
+	}
+	defer handle.Close()
+
+	c.Kirbi = trimmed
+
+	return nil
+}
+
 // Getters
 
 func (c *Credentials) GetLMHash() string {
@@ -185,4 +254,12 @@ func (c *Credentials) GetAESKey() string {
 
 func (c *Credentials) GetKeytab() string {
 	return c.Keytab
+}
+
+func (c *Credentials) GetCCache() string {
+	return c.CCache
+}
+
+func (c *Credentials) GetKirbi() string {
+	return c.Kirbi
 }

--- a/windows/credentials/credentials_test.go
+++ b/windows/credentials/credentials_test.go
@@ -217,3 +217,68 @@ func TestSetKeytabRejectsMissingFile(t *testing.T) {
 		t.Error("CanUseKeytab() = true after a rejected path")
 	}
 }
+
+func TestSetCCache(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "krb5cc")
+	if err := os.WriteFile(path, []byte("ticket cache bytes"), 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	// The principal comes from the ticket, so no username is required.
+	c := &credentials.Credentials{}
+	if c.CanUseCCache() {
+		t.Error("CanUseCCache() = true before a ccache is set")
+	}
+	if err := c.SetCCache(path); err != nil {
+		t.Fatalf("SetCCache(%q) error = %v", path, err)
+	}
+	if got := c.GetCCache(); got != path {
+		t.Errorf("GetCCache() = %q, want %q", got, path)
+	}
+	if !c.CanUseCCache() {
+		t.Error("CanUseCCache() = false after a readable ccache is set")
+	}
+}
+
+func TestSetCCacheRejectsMissingFile(t *testing.T) {
+	c := &credentials.Credentials{}
+	if err := c.SetCCache(filepath.Join(t.TempDir(), "absent")); err == nil {
+		t.Fatal("SetCCache() with a missing file error = nil, want an error")
+	}
+	if c.GetCCache() != "" {
+		t.Errorf("CCache = %q after a rejected path, want it left empty", c.GetCCache())
+	}
+	if c.CanUseCCache() {
+		t.Error("CanUseCCache() = true after a rejected path")
+	}
+}
+
+func TestSetKirbi(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tgt.kirbi")
+	if err := os.WriteFile(path, []byte("kirbi bytes"), 0o600); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	c := &credentials.Credentials{}
+	if err := c.SetKirbi(path); err != nil {
+		t.Fatalf("SetKirbi(%q) error = %v", path, err)
+	}
+	if got := c.GetKirbi(); got != path {
+		t.Errorf("GetKirbi() = %q, want %q", got, path)
+	}
+	if !c.CanUseKirbi() {
+		t.Error("CanUseKirbi() = false after a readable kirbi is set")
+	}
+}
+
+func TestSetKirbiRejectsMissingFile(t *testing.T) {
+	c := &credentials.Credentials{}
+	if err := c.SetKirbi(filepath.Join(t.TempDir(), "absent")); err == nil {
+		t.Fatal("SetKirbi() with a missing file error = nil, want an error")
+	}
+	if c.CanUseKirbi() {
+		t.Error("CanUseKirbi() = true after a rejected path")
+	}
+}


### PR DESCRIPTION
## What

Adds pass-the-ticket support to the native Kerberos LDAP GSSAPI bind: authenticate from an existing TGT in a credential cache or a `.kirbi` file, instead of only deriving one from a secret.

## Changes

- `windows/credentials.Credentials`: new `CCache` / `Kirbi` fields with `SetCCache`/`SetKirbi` (validate the file is readable, like `SetKeytab`), `GetCCache`/`GetKirbi`, and `CanUseCCache`/`CanUseKirbi`. The ticket helpers deliberately do **not** require a username — the principal is carried by the ticket.
- `network/ldap.newNativeGSSAPIClient`: when a ccache or kirbi is set, load the TGT via `LoadTGTFromCCacheFile` / `LoadTGTFromKirbiFile` and skip the AS exchange (`GetTGT`). The secret paths (keytab, AES key, NT hash, password) are unchanged.

## Tests

- `windows/credentials`: `SetCCache`/`SetKirbi` accept a readable file and reject a missing one; `CanUseCCache`/`CanUseKirbi` reflect the state.
- `network/ldap`: forge a golden TGT, materialize it as both a ccache and a `.kirbi`, and assert `newNativeGSSAPIClient` loads it **without contacting a KDC** (the KDC host is unreachable on purpose); a garbage ccache surfaces as a ccache error, proving the routing.

`go build ./...`, `go vet`, and the affected package tests pass.

Fixes #1047