### PR TITLE
Adopt the ticket's principal in the LDAP GSSAPI bind

### DIFF
--- a/network/ldap/kerberos_gssapi.go
+++ b/network/ldap/kerberos_gssapi.go
@@ -103,6 +103,14 @@ func newNativeGSSAPIClient(kdc, realm string, creds *credentials.Credentials) (*
 		return nil, fmt.Errorf("ldap gssapi: no usable secret: set a password, NT hash, AES key, keytab, ccache or kirbi")
 	}
 
+	// Adopt the client name and realm the client ended up with. For pass-the-ticket
+	// the principal is carried by the loaded ticket, not passed in, so the incoming
+	// user (and possibly realm) is empty; using the ticket's values keeps the AP-REQ
+	// authenticator consistent with the ticket. For the secret paths these are the
+	// values already supplied, so this is a no-op.
+	user = kc.Username()
+	realm = kc.Realm()
+
 	return &nativeGSSAPIClient{kc: kc, realm: strings.ToUpper(realm), user: user, desiredLayer: saslLayerNone}, nil
 }
 

--- a/network/ldap/kerberos_gssapi_ticket_test.go
+++ b/network/ldap/kerberos_gssapi_ticket_test.go
@@ -67,18 +67,32 @@ func forgeTGTFiles(t *testing.T) (ccachePath, kirbiPath string) {
 func TestNewNativeGSSAPIClientLoadsTicket(t *testing.T) {
 	ccachePath, kirbiPath := forgeTGTFiles(t)
 
+	// The forged TGT is for Administrator@CORP.LOCAL; the bridge must adopt that
+	// principal from the ticket even though no username is passed in, so the AP-REQ
+	// authenticator matches the ticket.
+	check := func(t *testing.T, gss *nativeGSSAPIClient) {
+		t.Helper()
+		if gss == nil {
+			t.Fatal("newNativeGSSAPIClient returned nil client")
+		}
+		if gss.user != "Administrator" {
+			t.Errorf("adopted user = %q, want %q", gss.user, "Administrator")
+		}
+		if gss.realm != "CORP.LOCAL" {
+			t.Errorf("adopted realm = %q, want %q", gss.realm, "CORP.LOCAL")
+		}
+	}
+
 	t.Run("ccache", func(t *testing.T) {
 		creds := &credentials.Credentials{}
 		if err := creds.SetCCache(ccachePath); err != nil {
 			t.Fatalf("SetCCache: %v", err)
 		}
-		gss, err := newNativeGSSAPIClient("10.0.0.1", "CORP.LOCAL", creds)
+		gss, err := newNativeGSSAPIClient("10.0.0.1", "", creds)
 		if err != nil {
 			t.Fatalf("newNativeGSSAPIClient with ccache: %v", err)
 		}
-		if gss == nil {
-			t.Fatal("newNativeGSSAPIClient returned nil client")
-		}
+		check(t, gss)
 	})
 
 	t.Run("kirbi", func(t *testing.T) {
@@ -86,13 +100,11 @@ func TestNewNativeGSSAPIClientLoadsTicket(t *testing.T) {
 		if err := creds.SetKirbi(kirbiPath); err != nil {
 			t.Fatalf("SetKirbi: %v", err)
 		}
-		gss, err := newNativeGSSAPIClient("10.0.0.1", "CORP.LOCAL", creds)
+		gss, err := newNativeGSSAPIClient("10.0.0.1", "", creds)
 		if err != nil {
 			t.Fatalf("newNativeGSSAPIClient with kirbi: %v", err)
 		}
-		if gss == nil {
-			t.Fatal("newNativeGSSAPIClient returned nil client")
-		}
+		check(t, gss)
 	})
 }
 


### PR DESCRIPTION
## What

Follow-up to #1048. `newNativeGSSAPIClient` captured the client name and realm from the incoming `Credentials` **before** acquiring the TGT and baked them into the AP-REQ authenticator. For the pass-the-ticket paths (`ccache` / `.kirbi`) the principal is carried by the loaded ticket, not passed in, so the client name was empty and the bind failed.

## Fix

After the secret/ticket switch, adopt the name and realm the client ended up with (`kc.Username()` / `kc.Realm()`), which the ccache/kirbi loaders set from the ticket. For the secret paths these equal the supplied values, so it is a no-op there.

## Tests

- The bridge ticket test now passes an empty username and asserts the forged ticket's principal (`Administrator@CORP.LOCAL`) is adopted.
- Existing secret-path bridge tests (keytab/AES/hash/password preference) still pass, confirming no regression.
- Validated end-to-end against a live DC: `list`, `enroll`, `describe`, `flush` all succeed over both `--ticket-ccache` and `--ticket-kirbi` with no username supplied.

Fixes #1049