### PR TITLE
Fix LDAP Modify dropping an empty Replace that should clear an attribute (Fixes #1051)

### DIFF
--- a/network/ldap/modify.go
+++ b/network/ldap/modify.go
@@ -254,6 +254,20 @@ func (ldapSession *Session) OverwriteAttributeValue(distinguishedName string, at
 //     for specific attributes.
 //   - Ensure that the LDAP connection is properly established before calling this function.
 func (ldapSession *Session) Modify(modifyRequest *ModifyRequest) error {
+	return ldapSession.connection.Modify(buildModifyRequest(modifyRequest))
+}
+
+// buildModifyRequest translates a Manticore ModifyRequest into the go-ldap
+// ModifyRequest that is sent on the wire.
+//
+// It is kept separate from Modify so the per-attribute operation selection can be
+// exercised without a live LDAP connection. Each Action's operation is chosen by
+// which value list it carries. A Replace is emitted whenever ReplaceValues is
+// non-nil, including an explicit empty slice: per LDAP semantics a replace with no
+// values clears the attribute, so an empty ReplaceValues must still produce a
+// Replace change rather than being dropped. An unset (nil) ReplaceValues carries no
+// operation.
+func buildModifyRequest(modifyRequest *ModifyRequest) *goldapv3.ModifyRequest {
 	// Create a new modify request
 	m := goldapv3.NewModifyRequest(modifyRequest.DistinguishedName, modifyRequest.Controls)
 
@@ -279,7 +293,7 @@ func (ldapSession *Session) Modify(modifyRequest *ModifyRequest) error {
 			// operation cannot be used to delete an attribute value that does not already exist in the entry.
 			// Source: https://ldap.com/the-ldap-modify-operation/
 			m.Delete(attribute.Attribute, attribute.DelValues)
-		} else if len(attribute.ReplaceValues) > 0 {
+		} else if attribute.ReplaceValues != nil {
 			// Replace the content of the attribute with the new values
 			// If the modification type is "replace" and there is an attribute description without any values,
 			// then all values for the specified attribute will be removed from the entry. If the specified attribute
@@ -301,7 +315,7 @@ func (ldapSession *Session) Modify(modifyRequest *ModifyRequest) error {
 		}
 	}
 
-	return ldapSession.connection.Modify(m)
+	return m
 }
 
 // AddStringToAttributeList adds a string to an attribute list

--- a/network/ldap/modify_test.go
+++ b/network/ldap/modify_test.go
@@ -1,0 +1,91 @@
+package ldap
+
+import (
+	"testing"
+
+	goldapv3 "github.com/go-ldap/ldap/v3"
+)
+
+// TestBuildModifyRequestEmptyReplaceClearsAttribute is the regression test for an
+// empty (non-nil) ReplaceValues: it must still emit a Replace change with no values,
+// which is how an attribute is cleared. Previously the value-count guard dropped it,
+// producing an empty modify request the directory rejects.
+func TestBuildModifyRequestEmptyReplaceClearsAttribute(t *testing.T) {
+	mr := &ModifyRequest{
+		DistinguishedName: "cn=obj,dc=example,dc=com",
+		Attributes: []*Action{
+			{Attribute: "msDS-KeyCredentialLink", ReplaceValues: []string{}},
+		},
+	}
+
+	m := buildModifyRequest(mr)
+
+	if len(m.Changes) != 1 {
+		t.Fatalf("Changes = %d; want 1 (empty replace must clear the attribute, not be dropped)", len(m.Changes))
+	}
+	change := m.Changes[0]
+	if change.Operation != goldapv3.ReplaceAttribute {
+		t.Errorf("Operation = %d; want ReplaceAttribute (%d)", change.Operation, goldapv3.ReplaceAttribute)
+	}
+	if change.Modification.Type != "msDS-KeyCredentialLink" {
+		t.Errorf("Type = %q; want %q", change.Modification.Type, "msDS-KeyCredentialLink")
+	}
+	if len(change.Modification.Vals) != 0 {
+		t.Errorf("Vals = %v; want empty", change.Modification.Vals)
+	}
+}
+
+// TestBuildModifyRequestNilReplaceIsNoOp confirms that an unset (nil) ReplaceValues
+// with no other values emits no change, so the fix does not turn an unset action
+// into an accidental attribute clear.
+func TestBuildModifyRequestNilReplaceIsNoOp(t *testing.T) {
+	mr := &ModifyRequest{
+		DistinguishedName: "cn=obj,dc=example,dc=com",
+		Attributes:        []*Action{{Attribute: "description"}},
+	}
+
+	m := buildModifyRequest(mr)
+
+	if len(m.Changes) != 0 {
+		t.Fatalf("Changes = %d; want 0 (an unset action must not emit an operation)", len(m.Changes))
+	}
+}
+
+// TestBuildModifyRequestOperationSelection checks that a populated value list still
+// maps to its matching operation.
+func TestBuildModifyRequestOperationSelection(t *testing.T) {
+	cases := []struct {
+		name     string
+		action   *Action
+		wantOp   uint
+		wantVals []string
+	}{
+		{"add", &Action{Attribute: "member", AddValues: []string{"a"}}, goldapv3.AddAttribute, []string{"a"}},
+		{"delete", &Action{Attribute: "member", DelValues: []string{"b"}}, goldapv3.DeleteAttribute, []string{"b"}},
+		{"replace", &Action{Attribute: "member", ReplaceValues: []string{"c", "d"}}, goldapv3.ReplaceAttribute, []string{"c", "d"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := buildModifyRequest(&ModifyRequest{
+				DistinguishedName: "cn=obj,dc=example,dc=com",
+				Attributes:        []*Action{tc.action},
+			})
+			if len(m.Changes) != 1 {
+				t.Fatalf("Changes = %d; want 1", len(m.Changes))
+			}
+			change := m.Changes[0]
+			if change.Operation != tc.wantOp {
+				t.Errorf("Operation = %d; want %d", change.Operation, tc.wantOp)
+			}
+			if len(change.Modification.Vals) != len(tc.wantVals) {
+				t.Fatalf("Vals = %v; want %v", change.Modification.Vals, tc.wantVals)
+			}
+			for i, v := range tc.wantVals {
+				if change.Modification.Vals[i] != v {
+					t.Errorf("Vals[%d] = %q; want %q", i, change.Modification.Vals[i], v)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #1051`

### Root Cause
`Session.Modify` builds the wire request by selecting a per-attribute operation from the length of each value list (`len(AddValues) > 0`, `len(DelValues) > 0`, `len(ReplaceValues) > 0`, `len(IncrementValues) > 0`). This conflates two distinct states of `ReplaceValues`: unset (nil) and explicitly empty. Under LDAP semantics a Replace with no values clears the attribute, so an empty `ReplaceValues` is a meaningful request — but the `len > 0` guard dropped it, emitting no change. When the empty Replace was the only action, the resulting modify request had zero changes and Active Directory rejected it with `LDAP Result Code 53 "Unwilling To Perform"`. The function's own doc comment already promised that an empty replace clears the attribute, so the code contradicted its documented contract. `FlushAttributeValues` had to bypass `Modify` and call go-ldap directly for exactly this reason.

### Fix Description
Emit a Replace whenever `ReplaceValues` is non-nil, using `attribute.ReplaceValues != nil` in place of the length check. An explicit empty (non-nil) slice now clears the attribute, while an unset (nil) list still carries no operation, preserving the existing no-op behavior for actions that do not touch Replace. The `Add`, `Delete`, and `Increment` branches are unchanged. The request-building loop was extracted verbatim into a package-level `buildModifyRequest` helper (behavior-preserving) so the operation selection can be tested without a live LDAP connection; `Modify` now calls it and sends the result.

### How Verified
- **Tests:** added `network/ldap/modify_test.go`. `TestBuildModifyRequestEmptyReplaceClearsAttribute` asserts an empty `ReplaceValues` produces exactly one `ReplaceAttribute` change with zero values; it fails against the previous guard (`Changes = 0; want 1`) and passes with the fix. `TestBuildModifyRequestNilReplaceIsNoOp` asserts an unset action emits no change. `TestBuildModifyRequestOperationSelection` covers add/delete/replace mapping.
- **Static:** the corrected `buildModifyRequest` matches the semantics documented in the surrounding comment (empty replace clears the attribute).
- **Equivalence:** the fix makes `Modify` emit the same go-ldap call (`m.Replace(attr, []string{})`) that `FlushAttributeValues` already uses successfully against Active Directory.
- `go build ./...` and `go test ./network/ldap/` pass.

### Test Coverage
- **Added:** `network/ldap/modify_test.go` — `TestBuildModifyRequestEmptyReplaceClearsAttribute`, `TestBuildModifyRequestNilReplaceIsNoOp`, `TestBuildModifyRequestOperationSelection`.

### Scope of Change
- **Files changed:** `network/ldap/modify.go`, `network/ldap/modify_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Low blast radius. The only behavioral change is that an explicitly empty (non-nil) `ReplaceValues` now clears the attribute instead of being silently dropped, which is the documented and expected behavior; unset (nil) actions and all non-empty operations are unchanged. Safe to merge without staged rollout.
