### PR TITLE
Derive the KeyID in NewKeyCredentialLink (Fixes #1053)

### DIFF
--- a/windows/keycredentiallink/KeyCredentialLink.go
+++ b/windows/keycredentiallink/KeyCredentialLink.go
@@ -20,7 +20,9 @@ import (
 //
 // Fields:
 // - Version: A KeyCredentialLinkVersion object representing the version of the key credential.
-// - Identifier: A string representing the unique identifier of the key credential.
+// - Identifier: A string representing the unique identifier (KeyID) of the key
+// credential. When empty, it is derived from the key material as MS-ADTS 2.2.20
+// requires; supply one only to reproduce a specific credential.
 // - KeyHash: A byte slice containing the hash of the key material.
 // - KeyMaterial: A KeyMaterial object representing the key material of the key credential.
 // - Usage: A KeyUsage object representing the usage of the key credential.
@@ -130,9 +132,38 @@ func NewKeyCredentialLink(
 
 	kc.Source.Value = source.KeySource_AD
 
+	// MS-ADTS 2.2.20 defines the KeyID entry as the SHA-256 of the KeyMaterial
+	// entry's value, and the KDC matches a key presented during PKINIT against it.
+	// A caller that does not supply one gets it derived rather than left empty, so
+	// the rule lives with the structure instead of with every caller.
+	if len(kc.Identifier) == 0 {
+		kc.Identifier = kc.ComputeKeyIdentifier()
+	}
+
 	kc.KeyHash = kc.ComputeKeyHash()
 
 	return kc
+}
+
+// ComputeKeyIdentifier returns the KeyID for this credential's key material.
+//
+// The KeyID is the SHA-256 of the marshalled key material, encoded as the credential's
+// version requires: hexadecimal for versions 0 and 1, base64 for version 2.
+//
+// Returns:
+//
+// - The KeyID, or an empty string when there is no key material or it cannot be marshalled.
+func (kc *KeyCredentialLink) ComputeKeyIdentifier() string {
+	if kc.KeyMaterial == nil {
+		return ""
+	}
+
+	rawKeyMaterial, err := kc.KeyMaterial.Marshal()
+	if err != nil {
+		return ""
+	}
+
+	return utils.ComputeKeyIdentifier(rawKeyMaterial, kc.Version)
 }
 
 // ParseDNWithBinary parses the provided DNWithBinary object into the KeyCredentialLink structure.

--- a/windows/keycredentiallink/KeyCredentialLink_test.go
+++ b/windows/keycredentiallink/KeyCredentialLink_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/windows/cng/bcrypt/keys/magic"
 	"github.com/TheManticoreProject/Manticore/windows/guid"
 	"github.com/TheManticoreProject/Manticore/windows/keycredentiallink"
+	"github.com/TheManticoreProject/Manticore/windows/keycredentiallink/utils"
 	"github.com/TheManticoreProject/Manticore/windows/keycredentiallink/version"
 )
 
@@ -81,5 +82,109 @@ func TestKeyCredential_Unmarshal_PreservesVersion(t *testing.T) {
 
 	if parsed.Version.Value != version.KeyCredentialLinkVersion_2 {
 		t.Errorf("Version.Value = 0x%x, want 0x%x", parsed.Version.Value, version.KeyCredentialLinkVersion_2)
+	}
+}
+
+// testKeyMaterial builds a BCRYPT_RSA_PUBLIC_KEY with a deterministic modulus, so the
+// derived KeyID is stable across runs.
+func testKeyMaterial(modulusByte byte) *keys.BCRYPT_RSA_PUBLIC_KEY {
+	exponent := []byte{0x01, 0x00, 0x01}
+	modulus := make([]byte, 256)
+	for i := range modulus {
+		modulus[i] = modulusByte
+	}
+
+	return &keys.BCRYPT_RSA_PUBLIC_KEY{
+		Magic: magic.BCRYPT_KEY_BLOB{Magic: magic.BCRYPT_RSAPUBLIC_MAGIC},
+		Header: headers.BCRYPT_RSA_KEY_BLOB{
+			BitLength:   uint32(len(modulus) * 8),
+			CbPublicExp: uint32(len(exponent)),
+			CbModulus:   uint32(len(modulus)),
+		},
+		Content: blob.BCRYPT_RSA_PUBLIC_BLOB{
+			PublicExponent: exponent,
+			Modulus:        modulus,
+		},
+	}
+}
+
+// An empty identifier has to be filled in with the KeyID the key material requires.
+// The KDC looks a PKINIT key up by that hash, so a credential built without one would
+// otherwise carry an empty KeyID and never match the account.
+func TestNewKeyCredentialLink_DerivesIdentifierWhenEmpty(t *testing.T) {
+	keyMaterial := testKeyMaterial(0xAB)
+	now := utils.NewDateTimeFromTicks(0)
+
+	for _, kcv := range []uint32{
+		version.KeyCredentialLinkVersion_0,
+		version.KeyCredentialLinkVersion_1,
+		version.KeyCredentialLinkVersion_2,
+	} {
+		kc := keycredentiallink.NewKeyCredentialLink(
+			version.KeyCredentialLinkVersion{Value: kcv},
+			"",
+			keyMaterial,
+			guid.NewGUID(),
+			&now,
+			&now,
+		)
+
+		rawKeyMaterial, err := keyMaterial.Marshal()
+		if err != nil {
+			t.Fatalf("Marshal() error = %v", err)
+		}
+		want := utils.ComputeKeyIdentifier(rawKeyMaterial, version.KeyCredentialLinkVersion{Value: kcv})
+
+		if kc.Identifier == "" {
+			t.Errorf("version %v: Identifier is empty, want the derived KeyID", kcv)
+		}
+		if kc.Identifier != want {
+			t.Errorf("version %v: Identifier = %s, want %s", kcv, kc.Identifier, want)
+		}
+	}
+}
+
+// A caller that supplies an identifier is reproducing a specific credential, so the
+// value has to survive untouched.
+func TestNewKeyCredentialLink_KeepsExplicitIdentifier(t *testing.T) {
+	const explicit = "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8="
+	now := utils.NewDateTimeFromTicks(0)
+
+	kc := keycredentiallink.NewKeyCredentialLink(
+		version.KeyCredentialLinkVersion{Value: version.KeyCredentialLinkVersion_2},
+		explicit,
+		testKeyMaterial(0xCD),
+		guid.NewGUID(),
+		&now,
+		&now,
+	)
+
+	if kc.Identifier != explicit {
+		t.Errorf("Identifier = %s, want the supplied %s", kc.Identifier, explicit)
+	}
+}
+
+// Different key material has to yield a different KeyID, otherwise the KDC could not
+// tell two credentials apart.
+func TestComputeKeyIdentifier_DistinguishesKeys(t *testing.T) {
+	now := utils.NewDateTimeFromTicks(0)
+	kcv := version.KeyCredentialLinkVersion{Value: version.KeyCredentialLinkVersion_2}
+
+	first := keycredentiallink.NewKeyCredentialLink(kcv, "", testKeyMaterial(0x01), guid.NewGUID(), &now, &now)
+	second := keycredentiallink.NewKeyCredentialLink(kcv, "", testKeyMaterial(0x02), guid.NewGUID(), &now, &now)
+
+	if first.Identifier == second.Identifier {
+		t.Errorf("two different keys produced the same KeyID: %s", first.Identifier)
+	}
+}
+
+// Key material that cannot be marshalled, or is absent, must not panic.
+func TestComputeKeyIdentifier_NoKeyMaterial(t *testing.T) {
+	kc := keycredentiallink.KeyCredentialLink{
+		Version: version.KeyCredentialLinkVersion{Value: version.KeyCredentialLinkVersion_2},
+	}
+
+	if got := kc.ComputeKeyIdentifier(); got != "" {
+		t.Errorf("ComputeKeyIdentifier() = %q, want an empty string", got)
 	}
 }


### PR DESCRIPTION
### Linked Issue
`Closes #1053`

### Root Cause
`NewKeyCredentialLink` treats the KeyID as caller-supplied data. It derives `KeyHash` itself (L133) but assigns `Identifier` straight from the argument (L116), and nothing else in the constructor writes that field. An empty argument therefore produces a credential with an empty KeyID entry, which MS-ADTS 2.2.20 does not permit — the entry is defined as the SHA-256 of the KeyMaterial entry's value, and the KDC matches a key presented during PKINIT against it.

The derivation was already implemented in the same package, as `utils.ComputeKeyIdentifier`, but only reachable from `ComposeKeyCredentialLinkForComputer`. So the rule existed in the library while every caller of the constructor still had to know it and repeat it, with no signal when they got it wrong.

### Fix Description
Add a `ComputeKeyIdentifier()` method on `KeyCredentialLink` that marshals the key material and hands it to `utils.ComputeKeyIdentifier` with the credential's version, and call it from the constructor when no identifier is supplied.

The method deliberately mirrors the existing `ComputeKeyHash()`: same receiver, no error return, empty result when the key material is absent or cannot be marshalled. That keeps the constructor's signature unchanged, so this is source-compatible for every existing caller.

An explicitly supplied identifier is still stored untouched. Reproducing a specific credential keeps working, and `ComposeKeyCredentialLinkForComputer` is intentionally left alone: it computes its KeyID from the caller's exact `keyValue` bytes, which are not guaranteed to round-trip identically through `UnmarshalKeyMaterial` + `Marshal` when the input carries trailing data, so switching it to the derived path could change its output.

### How Verified

Unit tests, plus an end-to-end check with a real consumer against a live Windows Server 2025 domain controller.

Building `manticore-keycredentials` against this branch with its own KeyID derivation removed — so the identifier reaching the constructor is empty and only the library can fill it in — produces a spec-correct credential:

```
[0x01] KeyID: caac567c7b71e7b7beed3db7375a6ef10505a6c763e350a720f97db682e3d770
check KeyID == sha256(KeyMaterial): True
```

and PKINIT with the matching certificate reaches `KDC_ERR_ETYPE_NOSUPP`, i.e. past identity mapping. Before, a credential built this way carried an empty KeyID. (The residual `ETYPE_NOSUPP` is environmental — that lab has no AD CS, so the KDC holds no certificate to sign a PKINIT reply.)

Full suite: 306 packages pass, 0 failures. `go build ./...` clean. `gofmt` reports only `windows/cng/bcrypt/keys/BCRYPT_RSA_PUBLIC_KEY.go` and `windows/cng/bcrypt/keys/types/blob_type.go`, both already unformatted on `main` and untouched here.

### Test Coverage
**Added:** four tests in `windows/keycredentiallink/KeyCredentialLink_test.go`:
- `TestNewKeyCredentialLink_DerivesIdentifierWhenEmpty` — across v0, v1 and v2, an empty identifier is filled in with `ComputeKeyIdentifier` of the marshalled key material, which also pins the version-dependent encoding (hex for v0/v1, base64 for v2).
- `TestNewKeyCredentialLink_KeepsExplicitIdentifier` — a supplied identifier survives untouched.
- `TestComputeKeyIdentifier_DistinguishesKeys` — different key material yields different KeyIDs.
- `TestComputeKeyIdentifier_NoKeyMaterial` — absent key material returns empty rather than panicking.

The first fails against the previous behaviour.

### Scope of Change
- **Files changed:** `windows/keycredentiallink/KeyCredentialLink.go`, `windows/keycredentiallink/KeyCredentialLink_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none. Callers passing an explicit identifier are unaffected; the only behaviour that changes is the previously-broken empty case.

### Risk and Rollout
Low. No signature change, no change for any caller that already supplied an identifier, and the new path only replaces a value that was invalid. Safe to merge without staged rollout.

### Notes
Worth being precise about the scope: this makes the correct KeyID the default and removes the reason a caller would invent its own, but it does not police an explicitly supplied value. A caller that deliberately passes a wrong identifier still gets it stored, which is what the downstream bug did. Rejecting an explicit identifier that disagrees with the key material would close that too, but it would also break any legitimate use of the parameter, so it is left out here.

Downstream, `manticore-keycredentials` currently derives the KeyID itself via `utils.ComputeKeyIdentifier`. Once this lands and is released, that call can go away and the tool can simply pass an empty identifier.
