### PR TITLE
Refuse a modify request that selects no operation (Fixes #1055)

### DIFF
--- a/network/ldap/modify.go
+++ b/network/ldap/modify.go
@@ -254,7 +254,27 @@ func (ldapSession *Session) OverwriteAttributeValue(distinguishedName string, at
 //     for specific attributes.
 //   - Ensure that the LDAP connection is properly established before calling this function.
 func (ldapSession *Session) Modify(modifyRequest *ModifyRequest) error {
-	return ldapSession.connection.Modify(buildModifyRequest(modifyRequest))
+	m := buildModifyRequest(modifyRequest)
+
+	// An Action only selects an operation when one of its value lists asks for one, so
+	// a request can arrive here with nothing to do at all: no attributes, or attributes
+	// whose value lists are all unset. The usual cause is a nil ReplaceValues where an
+	// empty one was meant, since only the latter clears an attribute.
+	//
+	// Such a request cannot have any effect, and sending it spends a round trip to be
+	// told so in terms that describe neither the cause nor the fix: Active Directory
+	// answers "Unwilling To Perform ... Error in attribute conversion operation", which
+	// reads like a value encoding problem. Refuse it here, and say what is missing.
+	if len(m.Changes) == 0 {
+		return fmt.Errorf(
+			"modify request for '%s' carries no changes: none of its %d action(s) selected an operation "+
+				"(AddValues, DelValues and IncrementValues need at least one value; ReplaceValues has to be "+
+				"non-nil, and an empty one clears the attribute)",
+			modifyRequest.DistinguishedName, len(modifyRequest.Attributes),
+		)
+	}
+
+	return ldapSession.connection.Modify(m)
 }
 
 // buildModifyRequest translates a Manticore ModifyRequest into the go-ldap

--- a/network/ldap/modify_test.go
+++ b/network/ldap/modify_test.go
@@ -1,6 +1,7 @@
 package ldap
 
 import (
+	"strings"
 	"testing"
 
 	goldapv3 "github.com/go-ldap/ldap/v3"
@@ -87,5 +88,67 @@ func TestBuildModifyRequestOperationSelection(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// A request that selects no operation at all cannot change anything, and sending it
+// spends a round trip to come back as a generic "Unwilling To Perform" that describes
+// neither the cause nor the fix. Modify has to refuse it before the wire.
+//
+// The guard returns before the connection is used, so a zero-valued Session is enough
+// here: reaching the connection on any of these inputs would panic instead.
+func TestModifyRejectsRequestWithNoChanges(t *testing.T) {
+	cases := []struct {
+		name       string
+		attributes []*Action
+	}{
+		{name: "nil attributes", attributes: nil},
+		{name: "empty attributes", attributes: []*Action{}},
+		{name: "action with every value list unset", attributes: []*Action{{Attribute: "description"}}},
+		{name: "empty AddValues", attributes: []*Action{{Attribute: "description", AddValues: []string{}}}},
+		{name: "empty DelValues", attributes: []*Action{{Attribute: "description", DelValues: []string{}}}},
+		{name: "empty IncrementValues", attributes: []*Action{{Attribute: "description", IncrementValues: []string{}}}},
+		{name: "several unset actions", attributes: []*Action{{Attribute: "description"}, {Attribute: "displayName"}}},
+	}
+
+	session := &Session{}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			err := session.Modify(&ModifyRequest{
+				DistinguishedName: "cn=obj,dc=example,dc=com",
+				Attributes:        tt.attributes,
+			})
+			if err == nil {
+				t.Fatal("error = nil, want a refusal")
+			}
+			if !strings.Contains(err.Error(), "no changes") {
+				t.Errorf("error = %q, want it to say the request carries no changes", err)
+			}
+			if !strings.Contains(err.Error(), "cn=obj,dc=example,dc=com") {
+				t.Errorf("error = %q, want it to name the target", err)
+			}
+		})
+	}
+}
+
+// The guard is about the request as a whole, not the individual actions: an action
+// that selects nothing alongside one that does must still reach the wire.
+func TestBuildModifyRequestKeepsRealChangeBesideNoOpAction(t *testing.T) {
+	mr := &ModifyRequest{
+		DistinguishedName: "cn=obj,dc=example,dc=com",
+		Attributes: []*Action{
+			{Attribute: "description", ReplaceValues: []string{"value"}},
+			{Attribute: "displayName"},
+		},
+	}
+
+	m := buildModifyRequest(mr)
+
+	if len(m.Changes) != 1 {
+		t.Fatalf("Changes = %d; want 1 (the real change survives, the no-op adds nothing)", len(m.Changes))
+	}
+	if m.Changes[0].Operation != goldapv3.ReplaceAttribute {
+		t.Errorf("Operation = %d; want ReplaceAttribute", m.Changes[0].Operation)
 	}
 }


### PR DESCRIPTION
### Linked Issue
`Closes #1055`

### Root Cause
`buildModifyRequest` appends a `Change` only when one of an action's value lists selects an operation. Nothing checks whether the loop produced anything, so `Modify` hands the connection a request with an empty change set whenever every action is unset — or when there are no actions at all.

Such a request cannot have any effect, but it is still sent. Active Directory answers `Unwilling To Perform ... Error in attribute conversion operation`, which points at value encoding and says nothing about the real problem, so the caller is left debugging the values they did supply rather than the operation they did not.

The trap became easier to hit with #1051: `ReplaceValues` now distinguishes nil (selects nothing) from empty (clears the attribute). A keep-list built by appending into a zero-valued struct field stays nil when nothing is appended, which is exactly the shape that yields a silently empty request.

### Fix Description
Check the built request in `Modify` and return early when it carries no changes, with an error naming the target and stating what an action needs in order to select an operation.

The check is deliberately on the request as a whole rather than per action: an action that selects nothing alongside one that does is legitimate, and still reaches the wire unchanged.

Refusing rather than treating an empty request as a silent success is the point of the change. The motivating case downstream was a `remove` that planned to delete a value and then issued a request that did nothing; a silent success would have let it report "Removed 1 value(s)" while removing nothing, which is worse than the confusing error it actually got.

### How Verified

Against a live Windows Server 2025 domain controller, all seven ways to produce an empty change set, before and after.

Before — identical for every case, target unchanged:

```
LDAP Result Code 53 "Unwilling To Perform": 00000057: LdapErr: DSID-0C091336,
comment: Error in attribute conversion operation, data 0, v65f4
```

After — refused before the wire, naming the target and the cause:

```
modify request for 'CN=KCPC01,CN=Computers,DC=TMP-W-2025,DC=local' carries no changes:
none of its 1 action(s) selected an operation (AddValues, DelValues and IncrementValues
need at least one value; ReplaceValues has to be non-nil, and an empty one clears the
attribute)
```

Regressions on the same DC, through a consumer built against this branch:
- A request mixing a real change with a no-op action still succeeds.
- Full write lifecycle unaffected: `enroll`, `attach`, `remove` of an object's last value, and `flush` all behave exactly as before.

Full suite: 306 packages ok, 0 failing. `go vet` and `gofmt` clean on the touched package.

### Test Coverage
**Added:** two tests in `network/ldap/modify_test.go`:
- `TestModifyRejectsRequestWithNoChanges` — seven subtests covering nil attributes, an empty attributes slice, an action with every value list unset, empty `AddValues`, empty `DelValues`, empty `IncrementValues`, and several unset actions. Each asserts an error that says the request carries no changes and names the target. The guard returns before the connection is used, so a zero-valued `Session` suffices — reaching the connection would panic instead, which is itself proof the check fires first.
- `TestBuildModifyRequestKeepsRealChangeBesideNoOpAction` — pins that a no-op action alongside a real one leaves exactly one change, so the guard cannot start swallowing valid requests.

### Scope of Change
- **Files changed:** `network/ldap/modify.go`, `network/ldap/modify_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Very low against Active Directory: an empty request is rejected there today, so no call that currently succeeds changes behaviour — only which layer reports the failure, and how usefully.

The one caveat worth stating: RFC 4511 permits an empty modification list, and a directory that accepts it as a no-op would previously have returned success where this now returns an error. That is the intended trade — a caller that assembled an empty request almost always has a bug, and the downstream case shows what silence costs.
