### PR TITLE
Fix Modify dropping an empty DelValues that should remove an attribute (Fixes #1057)

### DIFF
--- a/network/ldap/modify.go
+++ b/network/ldap/modify.go
@@ -258,8 +258,9 @@ func (ldapSession *Session) Modify(modifyRequest *ModifyRequest) error {
 
 	// An Action only selects an operation when one of its value lists asks for one, so
 	// a request can arrive here with nothing to do at all: no attributes, or attributes
-	// whose value lists are all unset. The usual cause is a nil ReplaceValues where an
-	// empty one was meant, since only the latter clears an attribute.
+	// whose value lists are all unset. The usual cause is a nil DelValues or
+	// ReplaceValues where an empty one was meant, since only the latter removes an
+	// attribute's values.
 	//
 	// Such a request cannot have any effect, and sending it spends a round trip to be
 	// told so in terms that describe neither the cause nor the fix: Active Directory
@@ -268,8 +269,8 @@ func (ldapSession *Session) Modify(modifyRequest *ModifyRequest) error {
 	if len(m.Changes) == 0 {
 		return fmt.Errorf(
 			"modify request for '%s' carries no changes: none of its %d action(s) selected an operation "+
-				"(AddValues, DelValues and IncrementValues need at least one value; ReplaceValues has to be "+
-				"non-nil, and an empty one clears the attribute)",
+				"(AddValues and IncrementValues need at least one value; DelValues and ReplaceValues have to "+
+				"be non-nil, and an empty one removes the attribute's values)",
 			modifyRequest.DistinguishedName, len(modifyRequest.Attributes),
 		)
 	}
@@ -302,8 +303,11 @@ func buildModifyRequest(modifyRequest *ModifyRequest) *goldapv3.ModifyRequest {
 			// add a value that already exists in the entry.
 			// Source: https://ldap.com/the-ldap-modify-operation/
 			m.Add(attribute.Attribute, attribute.AddValues)
-		} else if len(attribute.DelValues) > 0 {
+		} else if attribute.DelValues != nil {
 			// Delete the values from the attribute
+			// An empty (non-nil) DelValues is meaningful and must still emit a Delete: as
+			// described below, a delete carrying no values removes the whole attribute. A
+			// nil DelValues selects nothing.
 			// If the modification type is "delete" and there is an attribute description without any values,
 			// then all values for the specified attribute will be removed from the entry. Under normal circumstances,
 			// a modify operation cannot be used with the delete modification type to remove an attribute that does

--- a/network/ldap/modify_test.go
+++ b/network/ldap/modify_test.go
@@ -106,7 +106,7 @@ func TestModifyRejectsRequestWithNoChanges(t *testing.T) {
 		{name: "empty attributes", attributes: []*Action{}},
 		{name: "action with every value list unset", attributes: []*Action{{Attribute: "description"}}},
 		{name: "empty AddValues", attributes: []*Action{{Attribute: "description", AddValues: []string{}}}},
-		{name: "empty DelValues", attributes: []*Action{{Attribute: "description", DelValues: []string{}}}},
+		{name: "nil DelValues", attributes: []*Action{{Attribute: "description", DelValues: nil}}},
 		{name: "empty IncrementValues", attributes: []*Action{{Attribute: "description", IncrementValues: []string{}}}},
 		{name: "several unset actions", attributes: []*Action{{Attribute: "description"}, {Attribute: "displayName"}}},
 	}
@@ -150,5 +150,68 @@ func TestBuildModifyRequestKeepsRealChangeBesideNoOpAction(t *testing.T) {
 	}
 	if m.Changes[0].Operation != goldapv3.ReplaceAttribute {
 		t.Errorf("Operation = %d; want ReplaceAttribute", m.Changes[0].Operation)
+	}
+}
+
+// TestBuildModifyRequestEmptyDeleteRemovesAttribute is the regression test for an
+// empty (non-nil) DelValues: a delete carrying no values removes the whole attribute,
+// so it must still emit a Delete change. Previously the value-count guard dropped it,
+// leaving the request with nothing to do.
+func TestBuildModifyRequestEmptyDeleteRemovesAttribute(t *testing.T) {
+	mr := &ModifyRequest{
+		DistinguishedName: "cn=obj,dc=example,dc=com",
+		Attributes:        []*Action{{Attribute: "description", DelValues: []string{}}},
+	}
+
+	m := buildModifyRequest(mr)
+
+	if len(m.Changes) != 1 {
+		t.Fatalf("Changes = %d; want 1 (an empty delete removes the attribute)", len(m.Changes))
+	}
+	if m.Changes[0].Operation != goldapv3.DeleteAttribute {
+		t.Errorf("Operation = %d; want DeleteAttribute", m.Changes[0].Operation)
+	}
+	if got := m.Changes[0].Modification.Type; got != "description" {
+		t.Errorf("attribute = %q; want \"description\"", got)
+	}
+	if got := len(m.Changes[0].Modification.Vals); got != 0 {
+		t.Errorf("values = %d; want 0", got)
+	}
+}
+
+// The counterpart: an unset DelValues asks for nothing and must stay a no-op, so the
+// nil/empty distinction means the same thing for Delete as it does for Replace.
+func TestBuildModifyRequestNilDeleteIsNoOp(t *testing.T) {
+	mr := &ModifyRequest{
+		DistinguishedName: "cn=obj,dc=example,dc=com",
+		Attributes:        []*Action{{Attribute: "description", DelValues: nil}},
+	}
+
+	m := buildModifyRequest(mr)
+
+	if len(m.Changes) != 0 {
+		t.Fatalf("Changes = %d; want 0 (an unset DelValues must not emit an operation)", len(m.Changes))
+	}
+}
+
+// An add carrying no values is invalid per RFC 4511, so unlike Delete and Replace the
+// Add branch stays value-counted. Increment likewise needs exactly one value.
+func TestBuildModifyRequestEmptyAddAndIncrementStayNoOps(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		action *Action
+	}{
+		{name: "empty AddValues", action: &Action{Attribute: "description", AddValues: []string{}}},
+		{name: "empty IncrementValues", action: &Action{Attribute: "description", IncrementValues: []string{}}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			m := buildModifyRequest(&ModifyRequest{
+				DistinguishedName: "cn=obj,dc=example,dc=com",
+				Attributes:        []*Action{tt.action},
+			})
+			if len(m.Changes) != 0 {
+				t.Fatalf("Changes = %d; want 0", len(m.Changes))
+			}
+		})
 	}
 }


### PR DESCRIPTION
### Linked Issue
`Closes #1057`

### Root Cause
The Delete branch of `buildModifyRequest` selected on `len(attribute.DelValues) > 0`, so an explicit empty slice fell through to the next branch and no Delete change was produced. A delete carrying no values removes every value of the attribute — the comment sitting directly below that guard says exactly that — so the documented form of the operation could not be issued.

This is the same defect #1051 identified for `ReplaceValues`, and the same reasoning applies: a value count cannot distinguish "unset" from "explicitly remove everything". #1052 converted the Replace branch to a nil check and left Delete as it was.

### Fix Description
Select on `attribute.DelValues != nil`, matching Replace. An empty list removes the attribute's values; an unset one asks for nothing.

`AddValues` and `IncrementValues` stay value-counted, deliberately. Per the comments in the same function, an add "must [have] an attribute description and a set of values" and an increment needs "exactly one value", so an empty list is meaningless for both rather than significant. Only Delete and Replace have the "empty means all" semantics.

Two consequences handled here:
- The refusal message added in #1055 grouped `DelValues` with the operations needing at least one value, which this makes wrong. It now names `DelValues` alongside `ReplaceValues`.
- The `empty DelValues` subtest of `TestModifyRejectsRequestWithNoChanges` described a way to build an empty request; it becomes a real Delete, so that case moves to a nil `DelValues`.

### How Verified

Against a live Windows Server 2025 DC, on an object holding one `msDS-KeyCredentialLink` value.

Active Directory honours a valueless delete — established first with an independent client (ldap3), so the target behaviour was not assumed:

```
values before: 1
delete-with-no-values -> True success
values after:  0
```

Through `Session.Modify`, before this change the same intent produced no operation at all and (since #1055) was refused client-side. After:

```
empty DelValues  -> OK (no error)     1 value -> 0
nil   DelValues  -> refused, unchanged (1 value -> 1)
```

with the corrected message:

```
modify request for 'CN=KCPC01,...' carries no changes: none of its 1 action(s) selected an
operation (AddValues and IncrementValues need at least one value; DelValues and ReplaceValues
have to be non-nil, and an empty one removes the attribute's values)
```

Regressions through a consumer built against this branch: `enroll`, `remove` of an object's last value (which issues a populated `DelValues`) and `flush` all behave exactly as before. Full suite: 306 packages ok, 0 failing; `gofmt` and `go vet` clean on the touched package.

### Test Coverage
**Added:** three tests in `network/ldap/modify_test.go`:
- `TestBuildModifyRequestEmptyDeleteRemovesAttribute` — an empty `DelValues` emits one `DeleteAttribute` change, naming the right attribute and carrying no values.
- `TestBuildModifyRequestNilDeleteIsNoOp` — the counterpart, so the nil/empty distinction means the same for Delete as for Replace.
- `TestBuildModifyRequestEmptyAddAndIncrementStayNoOps` — pins that Add and Increment are deliberately *not* given the same treatment, so this asymmetry is intentional rather than the next thing someone "fixes".

**Updated:** `TestModifyRejectsRequestWithNoChanges` — the `empty DelValues` case becomes `nil DelValues`.

The first fails against the previous behaviour.

### Scope of Change
- **Files changed:** `network/ldap/modify.go`, `network/ldap/modify_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Low. An empty `DelValues` previously produced no operation, so nothing that currently works changes; it either contributed nothing to a larger request or made the request empty and (since #1055) refused. The one case worth naming: an action setting *both* an empty `DelValues` and a populated `ReplaceValues` previously fell through to the Replace and now takes the Delete. Setting two operations on one action was always ambiguous — the branch chain has only ever applied one — and the precedence order is unchanged.
