### PR TITLE
Fix AES-SHA2 Kerberos authentication (Fixes #1059)

### DIFF
--- a/network/kerberos/v5/client.go
+++ b/network/kerberos/v5/client.go
@@ -46,7 +46,8 @@ type KerberosClient struct {
 	hasTGT       bool
 
 	// stETypes overrides the etype list requested in the TGS-REQ (the service
-	// ticket's session-key etype). nil requests AES256, AES128, then RC4.
+	// ticket's session-key etype). nil requests all supported AES profiles,
+	// strongest first, then RC4.
 	stETypes []int
 
 	// postdateFrom, when non-zero, requests a postdated TGT: GetTGT sends the
@@ -147,6 +148,8 @@ func (c *KerberosClient) serviceTicketETypes() []int {
 		return c.stETypes
 	}
 	return []int{
+		messages.ETypeAES256CTSHMACSHA384,
+		messages.ETypeAES128CTSHMACSHA256,
 		messages.ETypeAES256CTSHMACSHA196,
 		messages.ETypeAES128CTSHMACSHA196,
 		messages.ETypeRC4HMAC,
@@ -193,6 +196,18 @@ func (c *KerberosClient) WithNTHash(hexHash string) error {
 // (16 bytes -> AES128, 32 bytes -> AES256).
 func (c *KerberosClient) WithAESKey(hexKey string) error {
 	cred, err := credentials.NewWithHexAESKey(c.username, c.realm, hexKey)
+	if err != nil {
+		return err
+	}
+	c.cred = cred
+	return nil
+}
+
+// WithAESKeyForEType configures a pass-the-key credential for an explicit
+// AES-SHA1 or AES-SHA2 enctype. The explicit enctype is required for AES-SHA2
+// because its key lengths are the same as the corresponding AES-SHA1 profiles.
+func (c *KerberosClient) WithAESKeyForEType(hexKey string, etype int) error {
+	cred, err := credentials.NewWithHexAESKeyForEType(c.username, c.realm, etype, hexKey)
 	if err != nil {
 		return err
 	}
@@ -256,13 +271,19 @@ func (c *KerberosClient) GetTGT() error {
 	}
 
 	// Start with the strongest etype the credential can satisfy and the AD
-	// default salt. The KDC corrects both via PREAUTH_REQUIRED if needed.
-	etype := c.cred.SupportedETypes()[0]
+	// default salt. The KDC corrects both via PREAUTH_REQUIRED if needed. Some
+	// Windows Server 2025 KDCs reject a PA-ENC-TIMESTAMP using a supported but
+	// disabled AES-SHA2 profile with KDC_ERR_ETYPE_NOSUPP, so walk the
+	// credential's preference list until the KDC accepts one.
+	etypes := c.cred.SupportedETypes()
+	if len(etypes) == 0 {
+		return fmt.Errorf("kerberos: credential supports no encryption types")
+	}
 	salt := c.cred.DefaultSalt()
 
-	// At most two attempts: the second only ever follows a KRB_AP_ERR_SKEW, after
-	// the clock offset has been applied (RFC 4120 Section 5.9.1).
-	for attempt := 0; attempt < 2; attempt++ {
+	skewRetried := false
+	for i := 0; i < len(etypes); {
+		etype := etypes[i]
 		resp, nonce, err := c.sendASReqWithPreauth(etype, salt, nil)
 		if err != nil {
 			return err
@@ -271,6 +292,9 @@ func (c *KerberosClient) GetTGT() error {
 		var krb_err messages.KRBError
 		if _, parse_err := krb_err.Unmarshal(resp); parse_err == nil {
 			switch krb_err.ErrorCode {
+			case iana.ErrETypeNoSupp:
+				i++
+				continue
 			case messages.ErrPreauthRequired, messages.ErrPreauthFailed:
 				// PREAUTH_REQUIRED means the KDC wants pre-auth with the etype/salt
 				// from its ETYPE-INFO2. PREAUTH_FAILED means our optimistic guess was
@@ -283,7 +307,8 @@ func (c *KerberosClient) GetTGT() error {
 				etype, salt, s2k_params := c.pickETypeFromError(krb_err)
 				return c.doASReqWithPreauth(etype, salt, s2k_params)
 			case messages.ErrSkew:
-				if attempt == 0 && c.applyClockSkew(krb_err) {
+				if !skewRetried && c.applyClockSkew(krb_err) {
+					skewRetried = true
 					continue // retry with the KDC-aligned clock
 				}
 				return fmt.Errorf("kerberos: KDC clock skew too great (error %d): %s", krb_err.ErrorCode, krb_err.EText)
@@ -294,7 +319,7 @@ func (c *KerberosClient) GetTGT() error {
 
 		return c.processASRep(resp, etype, salt, nil, nonce)
 	}
-	return fmt.Errorf("kerberos: GetTGT: clock-skew retry exhausted")
+	return fmt.Errorf("kerberos: KDC does not support any credential encryption type")
 }
 
 // pacRequestPA returns a PA-PAC-REQUEST PAData element with include-pac = TRUE.

--- a/network/kerberos/v5/client_test.go
+++ b/network/kerberos/v5/client_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/asn1"
 	"encoding/hex"
+	"reflect"
 	"testing"
 	"time"
 
@@ -51,6 +52,31 @@ func buildASRep(t *testing.T, etype int, key []byte, nonce int, sessionKey []byt
 		t.Fatalf("ASRep.Marshal: %v", err)
 	}
 	return wire
+}
+
+func TestServiceTicketETypesIncludeAESSHA2(t *testing.T) {
+	got := NewClient("alice", "corp.local", "10.0.0.1").serviceTicketETypes()
+	want := []int{
+		messages.ETypeAES256CTSHMACSHA384,
+		messages.ETypeAES128CTSHMACSHA256,
+		messages.ETypeAES256CTSHMACSHA196,
+		messages.ETypeAES128CTSHMACSHA196,
+		messages.ETypeRC4HMAC,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("serviceTicketETypes = %v, want %v", got, want)
+	}
+}
+
+func TestWithAESKeyForEType(t *testing.T) {
+	key := bytes.Repeat([]byte{0x42}, 32)
+	c := NewClient("alice", "corp.local", "10.0.0.1")
+	if err := c.WithAESKeyForEType(hex.EncodeToString(key), messages.ETypeAES256CTSHMACSHA384); err != nil {
+		t.Fatal(err)
+	}
+	if got := c.cred.SupportedETypes(); len(got) != 1 || got[0] != messages.ETypeAES256CTSHMACSHA384 {
+		t.Fatalf("credential etypes = %v, want [20]", got)
+	}
 }
 
 // TestProcessASRepSuccess drives processASRep with a hand-built AS-REP encrypted

--- a/network/kerberos/v5/credentials/credentials.go
+++ b/network/kerberos/v5/credentials/credentials.go
@@ -24,7 +24,7 @@ const (
 	// SecretNTHash is the NT hash (MD4 of the UTF-16LE password), which is
 	// exactly the RC4-HMAC (etype 23) key — the basis of overpass-the-hash.
 	SecretNTHash
-	// SecretAESKey is a precomputed AES key for one specific etype (17 or 18),
+	// SecretAESKey is a precomputed AES key for one specific etype (17-20),
 	// the basis of pass-the-key.
 	SecretAESKey
 )
@@ -38,7 +38,7 @@ type Credential struct {
 	password string
 	ntHash   []byte // 16 bytes, when kind == SecretNTHash
 	aesKey   []byte // 16 or 32 bytes, when kind == SecretAESKey
-	aesEtype int    // 17 or 18, when kind == SecretAESKey
+	aesEtype int    // 17, 18, 19, or 20, when kind == SecretAESKey
 }
 
 // NewWithPassword creates a password-based credential. The realm is upper-cased.
@@ -82,17 +82,17 @@ func NewWithHexNTHash(username, realm, hexHash string) (*Credential, error) {
 }
 
 // NewWithAESKey creates a pass-the-key credential from a raw AES key. etype must
-// be 17 (AES128, 16-byte key) or 18 (AES256, 32-byte key) and match the key
-// length. The key is copied.
+// be one of the AES-SHA1 or AES-SHA2 profiles (17-20) and match the profile's
+// 16- or 32-byte key length. The key is copied.
 func NewWithAESKey(username, realm string, etype int, key []byte) (*Credential, error) {
 	var want int
 	switch etype {
-	case iana.ETypeAES128CTSHMACSHA196:
+	case iana.ETypeAES128CTSHMACSHA196, iana.ETypeAES128CTSHMACSHA256:
 		want = 16
-	case iana.ETypeAES256CTSHMACSHA196:
+	case iana.ETypeAES256CTSHMACSHA196, iana.ETypeAES256CTSHMACSHA384:
 		want = 32
 	default:
-		return nil, fmt.Errorf("credentials: AES key etype must be 17 or 18, got %d", etype)
+		return nil, fmt.Errorf("credentials: AES key etype must be 17, 18, 19, or 20, got %d", etype)
 	}
 	if len(key) != want {
 		return nil, fmt.Errorf("credentials: etype %d requires a %d-byte key, got %d", etype, want, len(key))
@@ -123,6 +123,18 @@ func NewWithHexAESKey(username, realm, hexKey string) (*Credential, error) {
 	default:
 		return nil, fmt.Errorf("credentials: AES key must be 16 or 32 bytes, got %d", len(raw))
 	}
+}
+
+// NewWithHexAESKeyForEType creates a pass-the-key credential for an explicit
+// AES-SHA1 or AES-SHA2 enctype. Unlike NewWithHexAESKey, it does not infer the
+// profile from the key length because the SHA1 and SHA2 variants use identical
+// key sizes.
+func NewWithHexAESKeyForEType(username, realm string, etype int, hexKey string) (*Credential, error) {
+	raw, err := hex.DecodeString(strings.TrimSpace(hexKey))
+	if err != nil {
+		return nil, fmt.Errorf("credentials: invalid hex AES key: %w", err)
+	}
+	return NewWithAESKey(username, realm, etype, raw)
 }
 
 // Username returns the principal's account name.
@@ -182,6 +194,8 @@ func (c *Credential) SupportedETypes() []int {
 	switch c.kind {
 	case SecretPassword:
 		return []int{
+			iana.ETypeAES256CTSHMACSHA384,
+			iana.ETypeAES128CTSHMACSHA256,
 			iana.ETypeAES256CTSHMACSHA196,
 			iana.ETypeAES128CTSHMACSHA196,
 			iana.ETypeRC4HMAC,

--- a/network/kerberos/v5/credentials/credentials_test.go
+++ b/network/kerberos/v5/credentials/credentials_test.go
@@ -3,6 +3,7 @@ package credentials
 import (
 	"bytes"
 	"encoding/hex"
+	"reflect"
 	"testing"
 
 	"github.com/TheManticoreProject/Manticore/crypto/nt"
@@ -32,6 +33,20 @@ func TestPasswordDerivesAES(t *testing.T) {
 	}
 	if len(k) != 32 {
 		t.Errorf("AES256 key length = %d, want 32", len(k))
+	}
+}
+
+func TestPasswordAdvertisesAESSHA2(t *testing.T) {
+	c := NewWithPassword("alice", "CORP.LOCAL", "password")
+	want := []int{
+		iana.ETypeAES256CTSHMACSHA384,
+		iana.ETypeAES128CTSHMACSHA256,
+		iana.ETypeAES256CTSHMACSHA196,
+		iana.ETypeAES128CTSHMACSHA196,
+		iana.ETypeRC4HMAC,
+	}
+	if got := c.SupportedETypes(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("SupportedETypes = %v, want %v", got, want)
 	}
 }
 
@@ -95,6 +110,29 @@ func TestPassTheKey(t *testing.T) {
 	}
 	if _, err := ck.Key(iana.ETypeRC4HMAC, "", nil); err == nil {
 		t.Error("expected error: AES key cannot serve RC4")
+	}
+}
+
+func TestPassTheKeyAESSHA2(t *testing.T) {
+	for _, tc := range []struct {
+		etype int
+		size  int
+	}{
+		{iana.ETypeAES128CTSHMACSHA256, 16},
+		{iana.ETypeAES256CTSHMACSHA384, 32},
+	} {
+		key := bytes.Repeat([]byte{byte(tc.etype)}, tc.size)
+		c, err := NewWithHexAESKeyForEType("svc", "CORP.LOCAL", tc.etype, hex.EncodeToString(key))
+		if err != nil {
+			t.Fatalf("etype %d: %v", tc.etype, err)
+		}
+		got, err := c.Key(tc.etype, "", nil)
+		if err != nil {
+			t.Fatalf("etype %d Key: %v", tc.etype, err)
+		}
+		if !bytes.Equal(got, key) {
+			t.Errorf("etype %d key mismatch", tc.etype)
+		}
 	}
 }
 

--- a/network/kerberos/v5/fast_test.go
+++ b/network/kerberos/v5/fast_test.go
@@ -123,8 +123,8 @@ func TestFASTASReqBody(t *testing.T) {
 	if body.Nonce != 0x2233 {
 		t.Errorf("nonce = %d, want 0x2233", body.Nonce)
 	}
-	if len(body.EType) == 0 || body.EType[0] != messages.ETypeAES256CTSHMACSHA196 {
-		t.Errorf("etype list = %v, want AES256 first", body.EType)
+	if len(body.EType) == 0 || body.EType[0] != messages.ETypeAES256CTSHMACSHA384 {
+		t.Errorf("etype list = %v, want AES256-SHA2 first", body.EType)
 	}
 	for _, bit := range []int{kdcOptionForwardable, kdcOptionProxiable, kdcOptionRenewable} {
 		if body.KDCOptions.At(bit) != 1 {

--- a/network/kerberos/v5/keytab.go
+++ b/network/kerberos/v5/keytab.go
@@ -12,23 +12,23 @@ import (
 //
 // A keytab stores an account's long-term keys, so it lets a client authenticate
 // non-interactively — no password. These methods select a key from a keytab and
-// wire it into the client as an AES pass-the-key (etype 17/18) or, for RC4, an
+// wire it into the client as an AES pass-the-key (etype 17-20) or, for RC4, an
 // overpass-the-hash NT-hash credential, exactly as WithAESKey / WithNTHash would.
 // GetTGT / GetTGS then run unchanged.
 
 // credentialFromKeytabEntry converts a selected keytab entry into a long-term
 // credential for username@realm. AES128/AES256 keys become pass-the-key
 // credentials; the RC4-HMAC key is the NT hash, so it becomes an
-// overpass-the-hash credential. Other enctypes (DES, AES-SHA2) are not supported
-// by the credentials layer.
+// overpass-the-hash credential. Other enctypes such as DES are not supported.
 func credentialFromKeytabEntry(e *keytab.Entry, username, realm string) (*credentials.Credential, error) {
 	switch int(e.EType) {
-	case iana.ETypeAES128CTSHMACSHA196, iana.ETypeAES256CTSHMACSHA196:
+	case iana.ETypeAES128CTSHMACSHA196, iana.ETypeAES256CTSHMACSHA196,
+		iana.ETypeAES128CTSHMACSHA256, iana.ETypeAES256CTSHMACSHA384:
 		return credentials.NewWithAESKey(username, realm, int(e.EType), e.Key)
 	case iana.ETypeRC4HMAC:
 		return credentials.NewWithNTHash(username, realm, e.Key)
 	default:
-		return nil, fmt.Errorf("kerberos: keytab enctype %d is not usable for authentication (need AES128/AES256/RC4)", e.EType)
+		return nil, fmt.Errorf("kerberos: keytab enctype %d is not usable for authentication (need AES or RC4)", e.EType)
 	}
 }
 

--- a/network/kerberos/v5/keytab_test.go
+++ b/network/kerberos/v5/keytab_test.go
@@ -88,11 +88,31 @@ func TestWithKeytabForcesEType(t *testing.T) {
 	}
 }
 
-// TestWithKeytabRejectsUnsupportedEType confirms an entry whose only key is an
-// AES-SHA2 (or DES) enctype — which the credentials layer cannot key for
-// authentication — is rejected rather than silently accepted.
+// TestWithKeytabAcceptsAESSHA2 confirms AES-SHA2 keytab entries can be used as
+// explicitly typed pass-the-key credentials.
+func TestWithKeytabAcceptsAESSHA2(t *testing.T) {
+	for _, tc := range []struct {
+		etype int
+		size  int
+	}{
+		{iana.ETypeAES128CTSHMACSHA256, 16},
+		{iana.ETypeAES256CTSHMACSHA384, 32},
+	} {
+		data := keytabBytes(t, map[int][]byte{tc.etype: bytes.Repeat([]byte{0x44}, tc.size)})
+		c := NewClient("alice", "corp.local", "10.0.0.1")
+		if err := c.WithKeytabBytes(data); err != nil {
+			t.Fatalf("etype %d: WithKeytabBytes: %v", tc.etype, err)
+		}
+		if got := c.cred.SupportedETypes(); len(got) != 1 || got[0] != tc.etype {
+			t.Errorf("etype %d: selected credential etypes = %v", tc.etype, got)
+		}
+	}
+}
+
+// TestWithKeytabRejectsUnsupportedEType confirms a DES entry, which the
+// credentials layer cannot key for authentication, is rejected.
 func TestWithKeytabRejectsUnsupportedEType(t *testing.T) {
-	for _, etype := range []int{iana.ETypeAES256CTSHMACSHA384, iana.ETypeDESCBCMD5} {
+	for _, etype := range []int{iana.ETypeDESCBCMD5} {
 		data := keytabBytes(t, map[int][]byte{etype: bytes.Repeat([]byte{0x44}, 32)})
 		c := NewClient("alice", "corp.local", "10.0.0.1")
 		if err := c.WithKeytabBytes(data); err == nil {


### PR DESCRIPTION
### Linked Issue
Closes #1059

### Root Cause
AES-SHA2 support had been added to the crypto, PKINIT, checksum, and GSS layers without extending the ordinary credential and negotiation paths. The password and TGS preference lists still contained only AES-SHA1 and RC4, while raw AES credentials and keytab conversion explicitly rejected enctypes 19 and 20.

Windows Server 2025 can expose these profiles selectively. A KDC with them disabled rejects a pre-authentication timestamp using enctype 19 or 20, so adding them without an enctype fallback would regress existing domains.

### Fix Description
Password and service-ticket negotiation now prefer AES256-SHA2 and AES128-SHA2 before the existing AES-SHA1 and RC4 fallbacks. TGT acquisition advances through the credential's supported enctype list when the KDC returns `KDC_ERR_ETYPE_NOSUPP`.

Raw credential and keytab paths now accept enctypes 19 and 20. `NewWithHexAESKeyForEType` and `WithAESKeyForEType` provide explicit profile selection because AES-SHA1 and AES-SHA2 use the same key lengths; the existing length-inferred APIs retain their previous AES-SHA1 behavior.

### How Verified
**Tests:** `go test ./...`, `go test -race ./network/kerberos/v5/...`, and `go vet ./network/kerberos/v5/...` pass.

**Runtime:** Live tests against Windows Server 2025 verified that the controller rejects AES-SHA2 because the optional profiles are disabled, the client falls back to AES-SHA1, and TGT acquisition, TGS acquisition, U2U PAC decoding, and kirbi/ccache pass-the-ticket round trips all succeed.

### Test Coverage
**Added:**
- `network/kerberos/v5/client_test.go`: `TestServiceTicketETypesIncludeAESSHA2`, `TestWithAESKeyForEType`
- `network/kerberos/v5/credentials/credentials_test.go`: `TestPasswordAdvertisesAESSHA2`, `TestPassTheKeyAESSHA2`
- `network/kerberos/v5/keytab_test.go`: `TestWithKeytabAcceptsAESSHA2`
- Existing FAST request coverage now asserts the AES256-SHA2 preference.

### Scope of Change
- **Files changed:** `network/kerberos/v5/client.go`, `network/kerberos/v5/client_test.go`, `network/kerberos/v5/credentials/credentials.go`, `network/kerberos/v5/credentials/credentials_test.go`, `network/kerberos/v5/fast_test.go`, `network/kerberos/v5/keytab.go`, `network/kerberos/v5/keytab_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
The change affects Kerberos enctype preference and fallback only. It is safe to merge without staged rollout because unsupported profiles fall back on the KDC's explicit error, and the full live workflow remains interoperable with a controller where AES-SHA2 is disabled.

### Notes
Windows Server 2025 and later support enctypes 19 and 20, with both disabled by default: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-kile/1163bb03-7035-433e-b5a4-802247262d18
