### PR TITLE
Fix Kerberos key destruction (Fixes #1061)

### DIFF
--- a/network/kerberos/v5/client.go
+++ b/network/kerberos/v5/client.go
@@ -348,13 +348,50 @@ func (c *KerberosClient) GetTGS(spn string, includePAC bool) (messages.Ticket, [
 
 // Destroy zeroes out key material held by the client.
 func (c *KerberosClient) Destroy() {
-	for i := range c.sessionKey {
-		c.sessionKey[i] = 0
+	zero := func(key []byte) {
+		for i := range key {
+			key[i] = 0
+		}
 	}
+
+	zero(c.sessionKey)
+	zero(c.tgtEnc.Key.KeyValue)
 	c.sessionKey = nil
+	c.sessionEType = 0
+	c.tgtTicket = messages.Ticket{}
+	c.tgtTicketRaw = nil
+	c.tgtEnc = messages.EncASRepPart{}
+
+	zero(c.pkinitReplyKey)
+	c.pkinitReplyKey = nil
+	c.pkinitReplyEType = 0
+	c.pkinitPriv = nil
+	c.pkinitCert = nil
+	c.pkinitGroups = nil
+	c.pkinitAnchors = nil
+	c.pkinitSkipKDCSigCheck = false
+	c.pkinitKDCCertErr = nil
+
+	if c.fast != nil {
+		zero(c.fast.sessionKey)
+	}
+	c.fast = nil
+
+	for name, ticket := range c.preloadedTGS {
+		zero(ticket.sessionKey)
+		delete(c.preloadedTGS, name)
+	}
+	c.preloadedTGS = nil
+	for name, ticket := range c.serviceTickets {
+		zero(ticket.credInfo.Key.KeyValue)
+		delete(c.serviceTickets, name)
+	}
+	c.serviceTickets = nil
+
 	if c.cred != nil {
 		c.cred.Destroy()
 	}
+	c.cred = nil
 	c.hasTGT = false
 }
 

--- a/network/kerberos/v5/destroy_test.go
+++ b/network/kerberos/v5/destroy_test.go
@@ -1,0 +1,76 @@
+package kerberos
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/messages"
+)
+
+func allZero(b []byte) bool {
+	return bytes.Equal(b, make([]byte, len(b)))
+}
+
+func TestDestroyClearsAllKerberosMaterial(t *testing.T) {
+	src := fakeServiceTicketClient(t)
+	blob, err := src.ExportTGTKirbi()
+	if err != nil {
+		t.Fatal(err)
+	}
+	st, err := LoadServiceTicketFromKirbiBytes(blob, "cifs/host.corp.local")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c := NewClient("", "", "10.0.0.1")
+	if err := c.LoadServiceTicket(st); err != nil {
+		t.Fatal(err)
+	}
+	c.pkinitReplyKey = bytes.Repeat([]byte{0x31}, 32)
+	c.pkinitReplyEType = messages.ETypeAES256CTSHMACSHA196
+	armorInput := bytes.Repeat([]byte{0x42}, 32)
+	c.WithFASTArmor("", "", messages.Ticket{}, nil, armorInput, messages.ETypeAES256CTSHMACSHA196)
+
+	preloadedKey := c.preloadedTGS[normalizeSPN("cifs/host.corp.local")].sessionKey
+	cachedKey := c.serviceTickets[normalizeSPN("cifs/host.corp.local")].credInfo.Key.KeyValue
+	pkinitKey := c.pkinitReplyKey
+	armorKey := c.fast.sessionKey
+
+	if _, _, _, _, err := c.GetTGS("cifs/host.corp.local", true); err != nil {
+		t.Fatalf("precondition: loaded service ticket is unusable: %v", err)
+	}
+	if _, err := c.ExportServiceTicketKirbi("cifs/host.corp.local"); err != nil {
+		t.Fatalf("precondition: cached service ticket is not exportable: %v", err)
+	}
+
+	c.Destroy()
+
+	for name, key := range map[string][]byte{
+		"preloaded service key": preloadedKey,
+		"cached service key":    cachedKey,
+		"PKINIT reply key":      pkinitKey,
+		"FAST armor key":        armorKey,
+	} {
+		if !allZero(key) {
+			t.Errorf("%s was not zeroed: %x", name, key)
+		}
+	}
+	if c.cred != nil || c.hasTGT || c.fast != nil || c.preloadedTGS != nil || c.serviceTickets != nil {
+		t.Fatalf("Destroy retained authentication state: %+v", c)
+	}
+	if key, etype := c.PKINITReplyKey(); key != nil || etype != 0 {
+		t.Errorf("PKINITReplyKey after Destroy = (%x, %d)", key, etype)
+	}
+	if allZero(st.SessionKey) {
+		t.Error("Destroy zeroed the caller-owned service-ticket key")
+	}
+	if allZero(armorInput) {
+		t.Error("Destroy zeroed the caller-owned FAST armor key")
+	}
+	if _, _, _, _, err := c.GetTGS("cifs/host.corp.local", true); err == nil {
+		t.Error("GetTGS returned a preloaded ticket after Destroy")
+	}
+	if _, err := c.ExportServiceTicketKirbi("cifs/host.corp.local"); err == nil {
+		t.Error("ExportServiceTicketKirbi succeeded after Destroy")
+	}
+}

--- a/network/kerberos/v5/export.go
+++ b/network/kerberos/v5/export.go
@@ -92,8 +92,9 @@ func (c *KerberosClient) cacheServiceTicket(ticketRaw []byte, enc messages.EncTG
 		c.serviceTickets = make(map[string]cachedServiceTicket)
 	}
 	spn := strings.Join(enc.SName.NameString, "/")
+	enc.Key.KeyValue = append([]byte(nil), enc.Key.KeyValue...)
 	c.serviceTickets[normalizeSPN(spn)] = cachedServiceTicket{
-		ticketRaw: ticketRaw,
+		ticketRaw: append([]byte(nil), ticketRaw...),
 		credInfo: messages.KrbCredInfo{
 			Key:       enc.Key,
 			PRealm:    c.realm,

--- a/network/kerberos/v5/fast.go
+++ b/network/kerberos/v5/fast.go
@@ -52,7 +52,7 @@ func (c *KerberosClient) WithFASTArmor(cname, realm string, ticket messages.Tick
 		realm:        realm,
 		ticket:       ticket,
 		ticketRaw:    ticketRaw,
-		sessionKey:   sessionKey,
+		sessionKey:   append([]byte(nil), sessionKey...),
 		sessionEType: sessionEType,
 	}
 	return c

--- a/network/kerberos/v5/import.go
+++ b/network/kerberos/v5/import.go
@@ -187,6 +187,7 @@ func (c *KerberosClient) LoadServiceTicket(st *ServiceTicket) error {
 	if c.preloadedTGS == nil {
 		c.preloadedTGS = make(map[string]preloadedServiceTicket)
 	}
+	sessionKey := append([]byte(nil), st.SessionKey...)
 	// Adopt the ticket's client identity when the client has none, so the AP-REQ
 	// authenticator's cname/crealm match the ticket (else the service rejects with
 	// KRB_AP_ERR_BADMATCH). A client created with only a KDC host thus becomes
@@ -201,14 +202,14 @@ func (c *KerberosClient) LoadServiceTicket(st *ServiceTicket) error {
 	c.preloadedTGS[normalizeSPN(spn)] = preloadedServiceTicket{
 		ticket:       st.Ticket,
 		ticketRaw:    st.TicketRaw,
-		sessionKey:   st.SessionKey,
+		sessionKey:   sessionKey,
 		sessionEType: st.SessionEType,
 	}
 	// Also retain it for export (harvest→save): a captured/forged ticket wired in
 	// here can be written back out via ExportServiceTicketKirbi/CCache. The
 	// ServiceTicket carries no flags/times, so those stay zero.
 	c.cacheServiceTicket(st.TicketRaw, messages.EncTGSRepPart{
-		Key:    messages.EncryptionKey{KeyType: st.SessionEType, KeyValue: st.SessionKey},
+		Key:    messages.EncryptionKey{KeyType: st.SessionEType, KeyValue: sessionKey},
 		SRealm: st.SRealm,
 		SName:  st.SName,
 	})
@@ -272,9 +273,11 @@ func (c *KerberosClient) applyTGT(ticketRaw []byte, info messages.KrbCredInfo) e
 		c.username = info.PName.NameString[0]
 	}
 
+	sessionKey := append([]byte(nil), info.Key.KeyValue...)
+	info.Key.KeyValue = sessionKey
 	c.tgtTicket = tkt
-	c.tgtTicketRaw = ticketRaw
-	c.sessionKey = info.Key.KeyValue
+	c.tgtTicketRaw = append([]byte(nil), ticketRaw...)
+	c.sessionKey = sessionKey
 	c.sessionEType = info.Key.KeyType
 	// Reconstruct the AS-REP enc-part so re-export (tgtCredInfo) and downstream
 	// consumers see the same times/flags/service name the ticket was issued with.


### PR DESCRIPTION
### Linked Issue
Closes #1061

### Root Cause
`KerberosClient.Destroy()` predated the PKINIT reply-key, FAST armor, preloaded service-ticket, and export-cache fields. Those additions retained session keys and usable tickets without extending the destruction path.

Several ingestion paths also retained caller-owned key slices directly. Zeroing those slices during destruction would unexpectedly corrupt the caller's service-ticket or armor object, so the client did not have clear ownership of all key buffers it needed to erase.

### Fix Description
`Destroy()` now zeroes and removes TGT, PKINIT reply-key, FAST armor, preloaded service-ticket, cached service-ticket, and long-term credential state. It resets the associated enctype, ticket, PKINIT configuration, and cache fields, making subsequent ticket retrieval or export fail.

TGT import, service-ticket loading/caching, and FAST armor configuration now copy key buffers on ingestion. This gives the client ownership of the material it destroys while preserving caller-owned buffers.

### How Verified
**Tests:** `go test ./...`, `go test -race ./network/kerberos/v5/...`, and `go vet ./network/kerberos/v5/...` pass.

**Static:** the destruction path now covers every key-bearing `KerberosClient` field and clears both ticket maps before returning.

### Test Coverage
**Added:** `network/kerberos/v5/destroy_test.go`, `TestDestroyClearsAllKerberosMaterial`, verifies that preloaded service, cached service, PKINIT reply, and FAST armor keys are zeroed; all authentication state is removed; `GetTGS` and service-ticket export fail after destruction; and caller-owned input keys remain intact.

### Scope of Change
- **Files changed:** `network/kerberos/v5/client.go`, `network/kerberos/v5/destroy_test.go`, `network/kerberos/v5/export.go`, `network/kerberos/v5/fast.go`, `network/kerberos/v5/import.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
The change is limited to client teardown and ownership copies at key-ingestion boundaries. It is safe to merge without staged rollout; callers that invoke `Destroy()` will no longer be able to reuse that client, which is the documented contract.
