### PR TITLE
Fix Kerberos message header validation (Fixes #1063)

### DIFF
--- a/network/kerberos/v5/messages/aprep.go
+++ b/network/kerberos/v5/messages/aprep.go
@@ -49,6 +49,9 @@ func (r *APRep) Unmarshal(data []byte) (int, error) {
 	if _, err := asn1.Unmarshal(inner_bytes, &inner); err != nil {
 		return 0, fmt.Errorf("aprep inner unmarshal: %w", err)
 	}
+	if err := validateMessageHeader("aprep", inner.PVNO, inner.MsgType, MsgTypeAPRep); err != nil {
+		return 0, err
+	}
 	r.PVNO = inner.PVNO
 	r.MsgType = inner.MsgType
 	r.EncPart = inner.EncPart

--- a/network/kerberos/v5/messages/apreq.go
+++ b/network/kerberos/v5/messages/apreq.go
@@ -88,6 +88,9 @@ func (r *APReq) Unmarshal(data []byte) (int, error) {
 	if _, err := asn1.Unmarshal(inner_bytes, &inner); err != nil {
 		return 0, fmt.Errorf("apreq inner unmarshal: %w", err)
 	}
+	if err := validateMessageHeader("apreq", inner.PVNO, inner.MsgType, MsgTypeAPReq); err != nil {
+		return 0, err
+	}
 
 	r.PVNO = inner.PVNO
 	r.MsgType = inner.MsgType

--- a/network/kerberos/v5/messages/asrep.go
+++ b/network/kerberos/v5/messages/asrep.go
@@ -92,6 +92,9 @@ func (r *ASRep) Unmarshal(data []byte) (int, error) {
 	if _, err := asn1.Unmarshal(inner_bytes, &inner); err != nil {
 		return 0, fmt.Errorf("asrep inner unmarshal: %w", err)
 	}
+	if err := validateMessageHeader("asrep", inner.PVNO, inner.MsgType, MsgTypeASRep); err != nil {
+		return 0, err
+	}
 
 	r.PVNO = inner.PVNO
 	r.MsgType = inner.MsgType

--- a/network/kerberos/v5/messages/asreq.go
+++ b/network/kerberos/v5/messages/asreq.go
@@ -69,6 +69,9 @@ func (r *ASReq) Unmarshal(data []byte) (int, error) {
 	if _, err := asn1.Unmarshal(inner_bytes, &inner); err != nil {
 		return 0, fmt.Errorf("asreq inner unmarshal: %w", err)
 	}
+	if err := validateMessageHeader("asreq", inner.PVNO, inner.MsgType, MsgTypeASReq); err != nil {
+		return 0, err
+	}
 
 	r.PVNO = inner.PVNO
 	r.MsgType = inner.MsgType

--- a/network/kerberos/v5/messages/authenticator.go
+++ b/network/kerberos/v5/messages/authenticator.go
@@ -117,6 +117,9 @@ func (a *Authenticator) Unmarshal(data []byte) (int, error) {
 	if _, err := asn1.Unmarshal(inner_bytes, &inner); err != nil {
 		return 0, fmt.Errorf("authenticator inner unmarshal: %w", err)
 	}
+	if err := validateKerberosVersion("authenticator", inner.AVno); err != nil {
+		return 0, err
+	}
 
 	a.AVno = inner.AVno
 	a.CRealm = inner.CRealm

--- a/network/kerberos/v5/messages/header_validation_test.go
+++ b/network/kerberos/v5/messages/header_validation_test.go
@@ -1,0 +1,100 @@
+package messages
+
+import (
+	"bytes"
+	"testing"
+	"time"
+)
+
+type messageMarshaler interface {
+	Marshal() ([]byte, error)
+}
+
+func marshalHeaderTestMessage(t *testing.T, m messageMarshaler) []byte {
+	t.Helper()
+	wire, err := m.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return wire
+}
+
+func replaceExplicitInteger(t *testing.T, wire []byte, tag, old, replacement byte) []byte {
+	t.Helper()
+	out := append([]byte(nil), wire...)
+	pattern := []byte{tag, 0x03, 0x02, 0x01, old}
+	i := bytes.Index(out, pattern)
+	if i < 0 {
+		t.Fatalf("explicit integer %x=%d not found in %x", tag, old, wire)
+	}
+	out[i+len(pattern)-1] = replacement
+	return out
+}
+
+func TestUnmarshalRejectsInvalidKerberosHeaders(t *testing.T) {
+	now := time.Date(2026, 8, 19, 12, 0, 0, 0, time.UTC)
+	principal := PrincipalName{NameType: NameTypePrincipal, NameString: []string{"alice"}}
+	service := PrincipalName{NameType: NameTypeSRVInst, NameString: []string{"krbtgt", "CORP.LOCAL"}}
+	enc := EncryptedData{EType: ETypeAES256CTSHMACSHA196, Cipher: []byte{1, 2, 3}}
+	ticket := Ticket{TktVno: KerberosV5, Realm: "CORP.LOCAL", SName: service, EncPart: enc}
+	body := KDCReqBody{
+		KDCOptions: NewKerberosFlags(),
+		CName:      principal,
+		Realm:      "CORP.LOCAL",
+		SName:      service,
+		Till:       now.Add(time.Hour),
+		Nonce:      1,
+		EType:      []int{ETypeAES256CTSHMACSHA196},
+	}
+
+	tests := []struct {
+		name    string
+		wire    []byte
+		pvnoTag byte
+		msgTag  byte
+		msgType byte
+		decode  func([]byte) error
+	}{
+		{"ASReq", marshalHeaderTestMessage(t, &ASReq{ReqBody: body}), 0xa1, 0xa2, MsgTypeASReq, func(b []byte) error { var v ASReq; _, err := v.Unmarshal(b); return err }},
+		{"TGSReq", marshalHeaderTestMessage(t, &TGSReq{ReqBody: body}), 0xa1, 0xa2, MsgTypeTGSReq, func(b []byte) error { var v TGSReq; _, err := v.Unmarshal(b); return err }},
+		{"ASRep", marshalHeaderTestMessage(t, &ASRep{CRealm: "CORP.LOCAL", CName: principal, Ticket: ticket, EncPart: enc}), 0xa0, 0xa1, MsgTypeASRep, func(b []byte) error { var v ASRep; _, err := v.Unmarshal(b); return err }},
+		{"TGSRep", marshalHeaderTestMessage(t, &TGSRep{CRealm: "CORP.LOCAL", CName: principal, Ticket: ticket, EncPart: enc}), 0xa0, 0xa1, MsgTypeTGSRep, func(b []byte) error { var v TGSRep; _, err := v.Unmarshal(b); return err }},
+		{"APReq", marshalHeaderTestMessage(t, &APReq{Ticket: ticket, Authenticator: enc}), 0xa0, 0xa1, MsgTypeAPReq, func(b []byte) error { var v APReq; _, err := v.Unmarshal(b); return err }},
+		{"APRep", marshalHeaderTestMessage(t, &APRep{EncPart: enc}), 0xa0, 0xa1, MsgTypeAPRep, func(b []byte) error { var v APRep; _, err := v.Unmarshal(b); return err }},
+		{"KRBError", marshalHeaderTestMessage(t, &KRBError{STime: now, Realm: "CORP.LOCAL", SName: service}), 0xa0, 0xa1, MsgTypeError, func(b []byte) error { var v KRBError; _, err := v.Unmarshal(b); return err }},
+		{"KRBCred", marshalHeaderTestMessage(t, &KRBCred{Tickets: []Ticket{ticket}, EncPart: enc}), 0xa0, 0xa1, MsgTypeKRBCred, func(b []byte) error { var v KRBCred; _, err := v.Unmarshal(b); return err }},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name+"/version", func(t *testing.T) {
+			if err := tc.decode(replaceExplicitInteger(t, tc.wire, tc.pvnoTag, KerberosV5, 4)); err == nil {
+				t.Fatal("accepted an invalid protocol version")
+			}
+		})
+		t.Run(tc.name+"/message-type", func(t *testing.T) {
+			if err := tc.decode(replaceExplicitInteger(t, tc.wire, tc.msgTag, tc.msgType, 1)); err == nil {
+				t.Fatal("accepted an inconsistent message type")
+			}
+		})
+	}
+
+	t.Run("Ticket/version", func(t *testing.T) {
+		wire := marshalHeaderTestMessage(t, &ticket)
+		var decoded Ticket
+		if _, err := decoded.Unmarshal(replaceExplicitInteger(t, wire, 0xa0, KerberosV5, 4)); err == nil {
+			t.Fatal("accepted an invalid ticket version")
+		}
+	})
+
+	t.Run("Authenticator/version", func(t *testing.T) {
+		wire := marshalHeaderTestMessage(t, &Authenticator{
+			CRealm: "CORP.LOCAL",
+			CName:  principal,
+			CTime:  now,
+		})
+		var decoded Authenticator
+		if _, err := decoded.Unmarshal(replaceExplicitInteger(t, wire, 0xa0, KerberosV5, 4)); err == nil {
+			t.Fatal("accepted an invalid authenticator version")
+		}
+	})
+}

--- a/network/kerberos/v5/messages/krbcred.go
+++ b/network/kerberos/v5/messages/krbcred.go
@@ -326,6 +326,9 @@ func (c *KRBCred) Unmarshal(data []byte) (int, error) {
 	if _, err := asn1.Unmarshal(inner_bytes, &inner); err != nil {
 		return 0, fmt.Errorf("krbcred inner unmarshal: %w", err)
 	}
+	if err := validateMessageHeader("krbcred", inner.PVNO, inner.MsgType, MsgTypeKRBCred); err != nil {
+		return 0, err
+	}
 	c.PVNO = inner.PVNO
 	c.MsgType = inner.MsgType
 	c.EncPart = inner.EncPart

--- a/network/kerberos/v5/messages/krberror.go
+++ b/network/kerberos/v5/messages/krberror.go
@@ -102,6 +102,9 @@ func (e *KRBError) Unmarshal(data []byte) (int, error) {
 	if _, err := asn1.Unmarshal(inner_bytes, &inner); err != nil {
 		return 0, fmt.Errorf("krberror inner unmarshal: %w", err)
 	}
+	if err := validateMessageHeader("krberror", inner.PVNO, inner.MsgType, MsgTypeError); err != nil {
+		return 0, err
+	}
 
 	e.PVNO = inner.PVNO
 	e.MsgType = inner.MsgType

--- a/network/kerberos/v5/messages/tgsrep.go
+++ b/network/kerberos/v5/messages/tgsrep.go
@@ -74,6 +74,9 @@ func (r *TGSRep) Unmarshal(data []byte) (int, error) {
 	if _, err := asn1.Unmarshal(inner_bytes, &inner); err != nil {
 		return 0, fmt.Errorf("tgsrep inner unmarshal: %w", err)
 	}
+	if err := validateMessageHeader("tgsrep", inner.PVNO, inner.MsgType, MsgTypeTGSRep); err != nil {
+		return 0, err
+	}
 
 	r.PVNO = inner.PVNO
 	r.MsgType = inner.MsgType

--- a/network/kerberos/v5/messages/tgsreq.go
+++ b/network/kerberos/v5/messages/tgsreq.go
@@ -75,6 +75,9 @@ func (r *TGSReq) Unmarshal(data []byte) (int, error) {
 	if _, err := asn1.Unmarshal(inner_bytes, &inner); err != nil {
 		return 0, fmt.Errorf("tgsreq inner unmarshal: %w", err)
 	}
+	if err := validateMessageHeader("tgsreq", inner.PVNO, inner.MsgType, MsgTypeTGSReq); err != nil {
+		return 0, err
+	}
 
 	r.PVNO = inner.PVNO
 	r.MsgType = inner.MsgType

--- a/network/kerberos/v5/messages/ticket.go
+++ b/network/kerberos/v5/messages/ticket.go
@@ -66,6 +66,9 @@ func (t *Ticket) Unmarshal(data []byte) (int, error) {
 	if _, err := asn1.Unmarshal(inner_bytes, &inner); err != nil {
 		return 0, err
 	}
+	if err := validateKerberosVersion("ticket", inner.TktVno); err != nil {
+		return 0, err
+	}
 
 	t.TktVno = inner.TktVno
 	t.Realm = inner.Realm

--- a/network/kerberos/v5/messages/types.go
+++ b/network/kerberos/v5/messages/types.go
@@ -2,8 +2,26 @@ package messages
 
 import (
 	"encoding/asn1"
+	"fmt"
 	"time"
 )
+
+func validateKerberosVersion(message string, version int) error {
+	if version != KerberosV5 {
+		return fmt.Errorf("%s: invalid protocol version %d (want %d)", message, version, KerberosV5)
+	}
+	return nil
+}
+
+func validateMessageHeader(message string, version, msgType, wantMsgType int) error {
+	if err := validateKerberosVersion(message, version); err != nil {
+		return err
+	}
+	if msgType != wantMsgType {
+		return fmt.Errorf("%s: invalid message type %d (want %d)", message, msgType, wantMsgType)
+	}
+	return nil
+}
 
 // NewKerberosFlags builds a KerberosFlags/KDCOptions/APOptions/TicketFlags
 // BIT STRING from the given set bit positions. Per RFC 4120 Section 5.2.8 a


### PR DESCRIPTION
### Linked Issue
Closes #1063

### Root Cause
The decoders validated each outer ASN.1 application tag but accepted the embedded protocol-version and message-type fields without checking that they matched the concrete message being decoded. A payload could therefore identify itself as one Kerberos message in the outer tag and another in the mandatory inner header.

Tickets and authenticators had the same gap for their mandatory version fields.

### Fix Description
Add shared protocol-version and message-header validation helpers and invoke them immediately after decoding the inner ASN.1 structure. All concrete request, reply, error, credential, ticket, and authenticator decoders now reject inconsistent mandatory headers before copying fields into the destination object.

### How Verified
**Tests:** `go test ./...`, `go test -race ./network/kerberos/v5/...`, and `go vet ./network/kerberos/v5/...` pass.

**Runtime:** Live tests against Windows Server 2025 verified TGT acquisition, TGS acquisition, U2U PAC decoding, and kirbi/ccache round trips through the hardened decoders.

### Test Coverage
**Added:** `network/kerberos/v5/messages/header_validation_test.go`: `TestUnmarshalRejectsInvalidKerberosHeaders` mutates valid encodings and verifies rejection of invalid protocol versions and inconsistent message types across AS-REQ, TGS-REQ, AS-REP, TGS-REP, AP-REQ, AP-REP, KRB-ERROR, KRB-CRED, Ticket, and Authenticator.

### Scope of Change
- **Files changed:** `network/kerberos/v5/messages/aprep.go`, `network/kerberos/v5/messages/apreq.go`, `network/kerberos/v5/messages/asrep.go`, `network/kerberos/v5/messages/asreq.go`, `network/kerberos/v5/messages/authenticator.go`, `network/kerberos/v5/messages/header_validation_test.go`, `network/kerberos/v5/messages/krbcred.go`, `network/kerberos/v5/messages/krberror.go`, `network/kerberos/v5/messages/tgsrep.go`, `network/kerberos/v5/messages/tgsreq.go`, `network/kerberos/v5/messages/ticket.go`, `network/kerberos/v5/messages/types.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
The change is local to message decoding and only rejects payloads that violate mandatory header invariants. It is safe to merge without staged rollout.

### Notes
The protocol message definitions require version 5 and fixed message-type values: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-kile/9cb019ad-9ee3-48ca-b054-e525b350fa27
