### PR TITLE
Fix remaining DRSUAPI read opnums (Fixes #696)

### DIFF
--- a/network/dcerpc/ms-protocols/ms-drsr/integration_test.go
+++ b/network/dcerpc/ms-protocols/ms-drsr/integration_test.go
@@ -3,7 +3,7 @@
 package msdrsr_test
 
 import (
-	"encoding/hex"
+	"bytes"
 	"os"
 	"strconv"
 	"testing"
@@ -378,15 +378,67 @@ func TestReadOpnums2(t *testing.T) {
 		t.Logf("GetNT4ChangeLog: ntstatus=0x%x logLen=%d restartLen=%d", cl.ActualNTStatus, len(cl.Log), len(cl.Restart))
 	}
 
-	adminSID, _ := hex.DecodeString("010500000000000515000000fdca06a7cba8d22c3eae86ecf4010000")
-	if groups, err := c.GetMemberships([][]byte{adminSID}, drsrtypes.RevMembGetGroupsForUser, nc); err != nil {
+	admin, err := c.DCSyncByDN(acct)
+	if err != nil {
+		t.Fatalf("DCSyncByDN(%s): %v", acct, err)
+	}
+	if len(admin.SID) == 0 {
+		t.Fatalf("DCSyncByDN(%s): object has no SID", acct)
+	}
+	if groups, err := c.GetMemberships([][]byte{admin.SID}, drsrtypes.RevMembGetGroupsForUser, nc); err != nil {
 		t.Fatalf("GetMemberships: %v", err)
 	} else {
 		t.Logf("GetMemberships: %d group(s)", len(groups))
+		for _, group := range groups {
+			if group.Attribute == 0 {
+				t.Errorf("GetMemberships group %q has no requested attributes", group.DN)
+			}
+		}
 	}
-	if groups, err := c.GetMemberships2([][][]byte{{adminSID}}, drsrtypes.RevMembGetGroupsForUser, nc); err != nil {
+	if groups, err := c.GetMemberships2([][][]byte{{admin.SID}}, drsrtypes.RevMembGetGroupsForUser, nc); err != nil {
 		t.Fatalf("GetMemberships2: %v", err)
 	} else {
 		t.Logf("GetMemberships2: %d group(s)", len(groups))
+		for _, group := range groups {
+			if group.Attribute == 0 {
+				t.Errorf("GetMemberships2 group %q has no requested attributes", group.DN)
+			}
+		}
+	}
+
+	replication, err := c.ReplicateNC(nc)
+	if err != nil {
+		t.Fatalf("ReplicateNC(%s): %v", nc, err)
+	}
+	if len(replication.Objects) == 0 || replication.Reply == nil || replication.Reply.PUpToDateVecSrc == nil {
+		t.Fatal("ReplicateNC returned no objects or up-to-date vector")
+	}
+	startGUID := replication.Objects[0].GUID
+	for _, object := range replication.Objects[1:] {
+		if bytes.Compare(object.GUID.ToBytes(), startGUID.ToBytes()) < 0 {
+			startGUID = object.GUID
+		}
+	}
+	vectorV2 := replication.Reply.PUpToDateVecSrc
+	vectorV1 := &drsrtypes.UPTODATE_VECTOR_V1_EXT{
+		DwVersion:   1,
+		CNumCursors: vectorV2.CNumCursors,
+		RgCursors:   make([]drsrtypes.UPTODATE_CURSOR_V1, len(vectorV2.RgCursors)),
+	}
+	for i, cursor := range vectorV2.RgCursors {
+		vectorV1.RgCursors[i] = drsrtypes.UPTODATE_CURSOR_V1{
+			UuidDsa:           cursor.UuidDsa,
+			UsnHighPropUpdate: cursor.UsnHighPropUpdate,
+		}
+	}
+	existence, err := c.GetObjectExistence(nc, startGUID, 1, vectorV1, [16]byte{})
+	if err != nil {
+		t.Fatalf("GetObjectExistence: %v", err)
+	}
+	t.Logf("GetObjectExistence: digestMatches=%v GUIDs=%d", existence.DigestMatches, len(existence.GUIDs))
+	if existence.DigestMatches || len(existence.GUIDs) != 1 {
+		t.Errorf("GetObjectExistence = matches %v, %d GUIDs; want false, 1", existence.DigestMatches, len(existence.GUIDs))
+	} else if existence.GUIDs[0] != startGUID {
+		t.Errorf("GetObjectExistence GUID = %s, want %s", existence.GUIDs[0].ToFormatD(), startGUID.ToFormatD())
 	}
 }

--- a/network/dcerpc/ms-protocols/ms-drsr/memberships.go
+++ b/network/dcerpc/ms-protocols/ms-drsr/memberships.go
@@ -22,12 +22,6 @@ type MembershipGroup struct {
 // (opnum 9). opType selects which memberships to compute (e.g.
 // drsrtypes.RevMembGetGroupsForUser). limitingDomainNC, if non-empty, bounds the search
 // to that domain NC. It is read-only.
-//
-// NOTE: in lab testing against a fresh Windows Server 2016 DC this consistently returned
-// an empty set for accounts that do have group memberships, regardless of SID/GUID/DN
-// addressing or operation type. The request marshals and the reply parses correctly, so
-// the empty result is the server's response, not a client defect; the exact conditions
-// under which a DC returns data here are not yet established.
 func (c *Client) GetMemberships(sids [][]byte, opType drsrtypes.REVERSE_MEMBERSHIP_OPERATION_TYPE, limitingDomainNC string) ([]MembershipGroup, error) {
 	if !c.bound {
 		return nil, fmt.Errorf("msdrsr: not connected")
@@ -41,7 +35,7 @@ func (c *Client) GetMemberships(sids [][]byte, opType drsrtypes.REVERSE_MEMBERSH
 
 // GetMemberships2 issues a batch of reverse-membership requests in one call via
 // IDL_DRSGetMemberships2 (opnum 21), one request per SID set, returning the groups from
-// each reply concatenated. See GetMemberships for the lab-result caveat.
+// each reply concatenated.
 func (c *Client) GetMemberships2(sidSets [][][]byte, opType drsrtypes.REVERSE_MEMBERSHIP_OPERATION_TYPE, limitingDomainNC string) ([]MembershipGroup, error) {
 	if !c.bound {
 		return nil, fmt.Errorf("msdrsr: not connected")
@@ -72,9 +66,14 @@ func (c *Client) buildRevMembReq(sids [][]byte, opType drsrtypes.REVERSE_MEMBERS
 		d := drsrtypes.NewDSNameFromSID(sid)
 		names[i] = &d
 	}
+	return c.buildRevMembReqFromNames(names, opType, limitingDomainNC)
+}
+
+func (c *Client) buildRevMembReqFromNames(names []*drsrtypes.DSNAME, opType drsrtypes.REVERSE_MEMBERSHIP_OPERATION_TYPE, limitingDomainNC string) drsrtypes.DRS_MSG_REVMEMB_REQ_V1 {
 	v1 := drsrtypes.DRS_MSG_REVMEMB_REQ_V1{
-		CDsNames:      ndr.DWORD(len(sids)),
+		CDsNames:      ndr.DWORD(len(names)),
 		PpDsNames:     names,
+		DwFlags:       drsrtypes.DRS_REVMEMB_FLAG_GET_ATTRIBUTES,
 		OperationType: opType,
 	}
 	if limitingDomainNC != "" {

--- a/network/dcerpc/ms-protocols/ms-drsr/object_existence.go
+++ b/network/dcerpc/ms-protocols/ms-drsr/object_existence.go
@@ -1,0 +1,78 @@
+package msdrsr
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/e3514235-4b06-11d1-ab04-00c04fc2dcd2/4.0/functions"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+	drsrtypes "github.com/TheManticoreProject/Manticore/windows/protocols/ms-drsr"
+)
+
+// ObjectExistenceResult reports whether the server's digest matches the supplied digest.
+// When it does not match, GUIDs contains the server's object sequence for the requested
+// range after applying the supplied up-to-date vector.
+type ObjectExistenceResult struct {
+	DigestMatches bool
+	GUIDs         []guid.GUID
+}
+
+// GetObjectExistence calls IDL_DRSGetObjectExistence (opnum 23) for a range in a naming
+// context. start must identify the first object in the client's sequence and count is the
+// maximum number of objects in that sequence. upToDateVector is the merged client/server
+// replication state used to exclude objects that have not reached both replicas. The
+// digest is the MD5 digest of the client's GUID sequence; a mismatch makes the server
+// return its sequence for reconciliation.
+func (c *Client) GetObjectExistence(ncDN string, start guid.GUID, count uint32, upToDateVector *drsrtypes.UPTODATE_VECTOR_V1_EXT, digest [16]byte) (*ObjectExistenceResult, error) {
+	if !c.bound {
+		return nil, fmt.Errorf("msdrsr: not connected")
+	}
+	if ncDN == "" {
+		return nil, fmt.Errorf("msdrsr: GetObjectExistence: naming context is empty")
+	}
+	startUUID := drsrtypes.UUIDFromGUID(start)
+	if startUUID.IsZero() {
+		return nil, fmt.Errorf("msdrsr: GetObjectExistence: start GUID is zero")
+	}
+	if count == 0 {
+		return nil, fmt.Errorf("msdrsr: GetObjectExistence: count is zero")
+	}
+	if upToDateVector == nil {
+		return nil, fmt.Errorf("msdrsr: GetObjectExistence: up-to-date vector is nil")
+	}
+	if upToDateVector.DwVersion != 1 {
+		return nil, fmt.Errorf("msdrsr: GetObjectExistence: up-to-date vector version is %d, want 1", upToDateVector.DwVersion)
+	}
+	if int(upToDateVector.CNumCursors) != len(upToDateVector.RgCursors) {
+		return nil, fmt.Errorf("msdrsr: GetObjectExistence: up-to-date vector count is %d, have %d cursors", upToDateVector.CNumCursors, len(upToDateVector.RgCursors))
+	}
+	for i := 1; i < len(upToDateVector.RgCursors); i++ {
+		if bytes.Compare(upToDateVector.RgCursors[i-1].UuidDsa.Octets[:], upToDateVector.RgCursors[i].UuidDsa.Octets[:]) > 0 {
+			return nil, fmt.Errorf("msdrsr: GetObjectExistence: up-to-date vector cursors are not sorted by invocation GUID")
+		}
+	}
+
+	nc := drsrtypes.NewDSNameFromDN(ncDN)
+	msgIn := drsrtypes.DRS_MSG_EXISTREQ{
+		Tag: 1,
+		V1: drsrtypes.DRS_MSG_EXISTREQ_V1{
+			GuidStart:            startUUID,
+			CGuids:               ndr.DWORD(count),
+			PNC:                  &nc,
+			PUpToDateVecCommonV1: upToDateVector,
+			Md5Digest:            digest,
+		},
+	}
+	_, msgOut, err := functions.IDL_DRSGetObjectExistence(c.rpc, c.handle, 1, msgIn)
+	if err != nil {
+		return nil, fmt.Errorf("msdrsr: GetObjectExistence: %w", err)
+	}
+
+	result := &ObjectExistenceResult{DigestMatches: msgOut.V1.DwStatusFlags&1 != 0}
+	result.GUIDs = make([]guid.GUID, 0, len(msgOut.V1.RgGuids))
+	for _, objectGUID := range msgOut.V1.RgGuids {
+		result.GUIDs = append(result.GUIDs, objectGUID.GUID())
+	}
+	return result, nil
+}

--- a/network/dcerpc/ms-protocols/ms-drsr/read_opnums_test.go
+++ b/network/dcerpc/ms-protocols/ms-drsr/read_opnums_test.go
@@ -1,0 +1,57 @@
+package msdrsr
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+	drsrtypes "github.com/TheManticoreProject/Manticore/windows/protocols/ms-drsr"
+)
+
+func TestBuildRevMembReqRequestsAttributes(t *testing.T) {
+	sid := sidWithRID(500)
+	req := (&Client{}).buildRevMembReq([][]byte{sid}, drsrtypes.RevMembGetGroupsForUser, "DC=lab,DC=local")
+	if req.DwFlags != drsrtypes.DRS_REVMEMB_FLAG_GET_ATTRIBUTES {
+		t.Fatalf("DwFlags = 0x%x, want DRS_REVMEMB_FLAG_GET_ATTRIBUTES", req.DwFlags)
+	}
+	if len(req.PpDsNames) != 1 || req.PpDsNames[0] == nil {
+		t.Fatalf("PpDsNames = %#v, want one name", req.PpDsNames)
+	}
+	if got := req.PpDsNames[0].Sid.Data[:req.PpDsNames[0].SidLen]; string(got) != string(sid) {
+		t.Errorf("request SID = %x, want %x", got, sid)
+	}
+}
+
+func TestGetObjectExistenceRejectsInvalidVector(t *testing.T) {
+	c := &Client{bound: true}
+	start := guid.GUID{A: 1}
+	tests := []struct {
+		name   string
+		vector *drsrtypes.UPTODATE_VECTOR_V1_EXT
+		want   string
+	}{
+		{name: "nil", want: "vector is nil"},
+		{name: "wrong version", vector: &drsrtypes.UPTODATE_VECTOR_V1_EXT{DwVersion: 2}, want: "version is 2"},
+		{name: "wrong count", vector: &drsrtypes.UPTODATE_VECTOR_V1_EXT{DwVersion: 1, CNumCursors: 1}, want: "have 0 cursors"},
+		{
+			name: "unsorted",
+			vector: &drsrtypes.UPTODATE_VECTOR_V1_EXT{
+				DwVersion:   1,
+				CNumCursors: 2,
+				RgCursors: []drsrtypes.UPTODATE_CURSOR_V1{
+					{UuidDsa: drsrtypes.UUID{Octets: [16]byte{2}}},
+					{UuidDsa: drsrtypes.UUID{Octets: [16]byte{1}}},
+				},
+			},
+			want: "not sorted",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := c.GetObjectExistence("DC=lab,DC=local", start, 1, tt.vector, [16]byte{})
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %v, want containing %q", err, tt.want)
+			}
+		})
+	}
+}

--- a/network/dcerpc/ms-protocols/ms-drsr/secrets.go
+++ b/network/dcerpc/ms-protocols/ms-drsr/secrets.go
@@ -16,6 +16,7 @@ import (
 type AccountSecrets struct {
 	DN             string
 	SAMAccountName string
+	SID            []byte
 	RID            uint32
 	NTHash         [16]byte
 	LMHash         [16]byte
@@ -59,6 +60,9 @@ func (c *Client) DecryptSecrets(res *ReplicationResult) ([]*AccountSecrets, erro
 // decryptObjectSecrets extracts and decrypts the secret attributes of a single object.
 func decryptObjectSecrets(obj ReplicatedObject, prefixTable drsrtypes.SCHEMA_PREFIX_TABLE, sessionKey []byte, rid uint32) (*AccountSecrets, error) {
 	sec := &AccountSecrets{DN: obj.DN, RID: rid}
+	if sid := firstValue(findAttr(obj, prefixTable, oidObjectSid)); sid != nil {
+		sec.SID = append([]byte(nil), sid...)
+	}
 
 	// isDeleted is a 4-byte LE boolean: TRUE = 0x01000000
 	if v := firstValue(findAttr(obj, prefixTable, oidIsDeleted)); v != nil && len(v) >= 4 && v[0] != 0 {

--- a/network/dcerpc/ms-protocols/ms-drsr/secrets_test.go
+++ b/network/dcerpc/ms-protocols/ms-drsr/secrets_test.go
@@ -61,4 +61,7 @@ func TestDecryptObjectSecrets(t *testing.T) {
 	if sec.RID != 500 {
 		t.Errorf("RID = %d, want 500", sec.RID)
 	}
+	if got, want := hex.EncodeToString(sec.SID), hex.EncodeToString(obj.Attributes[0].Values[0]); got != want {
+		t.Errorf("SID = %s, want %s", got, want)
+	}
 }

--- a/windows/protocols/ms-drsr/constants.go
+++ b/windows/protocols/ms-drsr/constants.go
@@ -18,6 +18,10 @@ const (
 	DS_DNS_DOMAIN_NAME         uint32 = 12
 )
 
+// DRS_REVMEMB_FLAG_GET_ATTRIBUTES requests the SE_GROUP attributes associated with
+// each group returned by IDL_DRSGetMemberships ([MS-DRSR] 4.1.7.2.1).
+const DRS_REVMEMB_FLAG_GET_ATTRIBUTES uint32 = 0x00000001
+
 // DS_NAME_ERROR is the per-item status in DS_NAME_RESULT_ITEMW.Status
 // ([MS-DRSR] 4.1.4.1.2). DS_NAME_NO_ERROR (0) means the item resolved.
 const (


### PR DESCRIPTION
### Linked Issue
Closes #696

### Root Cause
The read-opnum work stopped short of a usable `IDL_DRSGetObjectExistence` wrapper because the earlier probe omitted the nonzero sequence start and non-null, versioned up-to-date vector required by the server. The membership integration test also embedded a SID from another domain, and membership requests did not set the documented flag for the group attributes projected by `MembershipGroup.Attribute`.

### Fix Description
Adds a validated `GetObjectExistence` client method and friendly result, rejecting invalid range/vector inputs before issuing RPC. Updates reverse-membership requests to ask for group attributes, retains each replicated account's binary SID for follow-on calls, and makes the integration test derive the target SID and object-existence inputs from the live domain.

### How Verified
- Runtime: `go test ./...` passes.
- Runtime: `go test -tags=integration ./network/dcerpc/ms-protocols/ms-drsr -run '^TestReadOpnums2$' -v -count=1 -timeout=2m` passes against Windows Server 2025. `GetObjectExistence` returned a digest mismatch and the expected one-GUID server sequence; membership opnums returned successful, parseable replies using the live Administrator SID.
- Tests: validation covers membership flags/SID encoding and malformed object-existence vectors.

### Test Coverage
**Added:** `network/dcerpc/ms-protocols/ms-drsr/read_opnums_test.go` tests `TestBuildRevMembReqRequestsAttributes` and `TestGetObjectExistenceRejectsInvalidVector`; `TestReadOpnums2` now covers the live object-existence call and domain-derived membership inputs. `TestDecryptObjectSecrets` verifies the projected binary SID.

### Scope of Change
- **Files changed:** `network/dcerpc/ms-protocols/ms-drsr/integration_test.go`, `memberships.go`, `object_existence.go`, `read_opnums_test.go`, `secrets.go`, `secrets_test.go`; `windows/protocols/ms-drsr/constants.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
The change is local to read-only client helpers. Existing membership callers now receive documented group attributes when the server returns groups; object-existence callers must provide a valid merged version-1 up-to-date vector.
