### PR TITLE
Fix supplemental credential parsing (Fixes #694)

### DIFF
--- a/network/dcerpc/ms-protocols/ms-drsr/integration_test.go
+++ b/network/dcerpc/ms-protocols/ms-drsr/integration_test.go
@@ -3,6 +3,8 @@
 package msdrsr_test
 
 import (
+	"bytes"
+	"encoding/binary"
 	"encoding/hex"
 	"os"
 	"strconv"
@@ -10,6 +12,8 @@ import (
 	"time"
 
 	msdrsr "github.com/TheManticoreProject/Manticore/network/dcerpc/ms-protocols/ms-drsr"
+	kerbcrypto "github.com/TheManticoreProject/Manticore/network/kerberos/v5/crypto"
+	"github.com/TheManticoreProject/Manticore/network/kerberos/v5/iana"
 	"github.com/TheManticoreProject/Manticore/windows/credentials"
 	drsrtypes "github.com/TheManticoreProject/Manticore/windows/protocols/ms-drsr"
 )
@@ -136,6 +140,64 @@ func TestCrackAndReplicate(t *testing.T) {
 	}
 	// secretsdump-style line: sAMAccountName:RID:LMHash:NTHash:::
 	t.Logf("%s:%d:%x:%x:::", s.SAMAccountName, s.RID, s.LMHash, s.NTHash)
+}
+
+// TestSupplementalCredentials live-validates supplemental credential parsing and,
+// when DRSUAPI_TEST_VERIFY_PASSWORD is set to the target account's password, checks the
+// extracted current AES256 key with the RFC 3962 string-to-key implementation.
+func TestSupplementalCredentials(t *testing.T) {
+	host := os.Getenv("DRSUAPI_TEST_HOST")
+	dn := os.Getenv("DRSUAPI_TEST_DN")
+	if host == "" || dn == "" {
+		t.Skip("set DRSUAPI_TEST_HOST and DRSUAPI_TEST_DN to run")
+	}
+	creds, err := credentials.NewCredentials(
+		os.Getenv("DRSUAPI_TEST_DOMAIN"), os.Getenv("DRSUAPI_TEST_USER"),
+		os.Getenv("DRSUAPI_TEST_PASS"), os.Getenv("DRSUAPI_TEST_HASHES"),
+	)
+	if err != nil {
+		t.Fatalf("build credentials: %v", err)
+	}
+	c := msdrsr.New(host, creds)
+	c.SetTimeout(15 * time.Second)
+	if err := c.Connect(); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	defer c.Close()
+
+	account, err := c.DCSyncByDN(dn)
+	if err != nil {
+		t.Fatalf("DCSyncByDN(%q): %v", dn, err)
+	}
+	if len(account.SupplementalCredentials) == 0 {
+		t.Fatal("target has no supplementalCredentials")
+	}
+	if len(account.KerberosKeys) == 0 {
+		t.Fatal("target has no parsed Kerberos keys")
+	}
+	t.Logf("parsed %d Kerberos keys, %d WDigest hashes, cleartext=%v", len(account.KerberosKeys), len(account.WDigestHashes), len(account.CleartextPasswordRaw) != 0)
+
+	password := os.Getenv("DRSUAPI_TEST_VERIFY_PASSWORD")
+	if password == "" {
+		return
+	}
+	for _, key := range account.KerberosKeys {
+		if key.KeyType != iana.ETypeAES256CTSHMACSHA196 || key.Category != msdrsr.KerberosKeyCurrent {
+			continue
+		}
+		var params [4]byte
+		binary.BigEndian.PutUint32(params[:], key.IterationCount)
+		derived, err := kerbcrypto.StringToKey(int(key.KeyType), password, key.Salt, params[:])
+		if err != nil {
+			t.Fatalf("derive AES256 key: %v", err)
+		}
+		if !bytes.Equal(derived, key.Value) {
+			t.Fatalf("extracted AES256 key does not match RFC 3962 derivation")
+		}
+		t.Logf("validated current AES256 key with salt %q and %d iterations", key.Salt, key.IterationCount)
+		return
+	}
+	t.Fatal("target has no current AES256 key")
 }
 
 // TestDomainControllerInfoAndDCSync exercises the Phase 5 workflow: IDL_DRSDomainController

--- a/network/dcerpc/ms-protocols/ms-drsr/secrets.go
+++ b/network/dcerpc/ms-protocols/ms-drsr/secrets.go
@@ -11,8 +11,8 @@ import (
 // AccountSecrets holds the credential material decrypted from one replicated object.
 // NTHash/LMHash are the current 16-byte hashes (valid only when HasNT/HasLM is set);
 // the history slices are previous hashes as the DC returns them. SupplementalCredentials
-// is the transport-decrypted supplementalCredentials blob (Kerberos keys, cleartext, …)
-// left unparsed — decoding it is future work.
+// retains the transport-decrypted source blob; parsed keys, cleartext, and WDigest hashes
+// are exposed in the adjacent fields.
 type AccountSecrets struct {
 	DN             string
 	SAMAccountName string
@@ -26,6 +26,10 @@ type AccountSecrets struct {
 	LMHistory      [][16]byte
 
 	SupplementalCredentials []byte
+	KerberosKeys            []KerberosKey
+	CleartextPassword       string
+	CleartextPasswordRaw    []byte
+	WDigestHashes           [][16]byte
 }
 
 // DecryptSecrets decrypts the secret attributes of every replicated object that carries
@@ -103,6 +107,14 @@ func decryptObjectSecrets(obj ReplicatedObject, prefixTable drsrtypes.SCHEMA_PRE
 			return nil, fmt.Errorf("supplementalCredentials: %w", err)
 		}
 		sec.SupplementalCredentials = blob
+		parsed, err := ParseSupplementalCredentials(blob)
+		if err != nil {
+			return nil, err
+		}
+		sec.KerberosKeys = parsed.KerberosKeys
+		sec.CleartextPassword = parsed.CleartextPassword
+		sec.CleartextPasswordRaw = parsed.CleartextPasswordRaw
+		sec.WDigestHashes = parsed.WDigestHashes
 	}
 	return sec, nil
 }

--- a/network/dcerpc/ms-protocols/ms-drsr/supplemental_credentials.go
+++ b/network/dcerpc/ms-protocols/ms-drsr/supplemental_credentials.go
@@ -1,0 +1,239 @@
+package msdrsr
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+)
+
+const (
+	userPropertiesFixedSize = 110
+	kerberosNewHeaderSize   = 24
+	kerberosNewKeySize      = 24
+	kerberosOldHeaderSize   = 16
+	kerberosOldKeySize      = 20
+)
+
+// KerberosKeyCategory identifies the KERB_STORED_CREDENTIAL[_NEW] array from which a
+// key was extracted.
+type KerberosKeyCategory string
+
+const (
+	KerberosKeyCurrent KerberosKeyCategory = "current"
+	KerberosKeyService KerberosKeyCategory = "service"
+	KerberosKeyOld     KerberosKeyCategory = "old"
+	KerberosKeyOlder   KerberosKeyCategory = "older"
+)
+
+// KerberosKey is one key extracted from Primary:Kerberos or
+// Primary:Kerberos-Newer-Keys. KeyType is the Kerberos encryption type, Value is the raw
+// key, Salt is the default UTF-16 salt, and IterationCount is zero for legacy records.
+type KerberosKey struct {
+	KeyType        uint32
+	Value          []byte
+	Salt           string
+	IterationCount uint32
+	Category       KerberosKeyCategory
+}
+
+// SupplementalCredentialsInfo is the parsed credential material in an MS-SAMR
+// USER_PROPERTIES blob.
+type SupplementalCredentialsInfo struct {
+	KerberosKeys         []KerberosKey
+	CleartextPassword    string
+	CleartextPasswordRaw []byte
+	WDigestHashes        [][16]byte
+}
+
+// ParseSupplementalCredentials parses an MS-SAMR USER_PROPERTIES blob. Unknown
+// properties are ignored; recognized properties are bounds-checked and malformed data
+// is rejected.
+func ParseSupplementalCredentials(blob []byte) (*SupplementalCredentialsInfo, error) {
+	if len(blob) < userPropertiesFixedSize+1 {
+		return nil, fmt.Errorf("supplementalCredentials: USER_PROPERTIES is %d bytes, want at least %d", len(blob), userPropertiesFixedSize+1)
+	}
+	if signature := binary.LittleEndian.Uint16(blob[108:110]); signature != 0x50 {
+		return nil, fmt.Errorf("supplementalCredentials: invalid property signature 0x%x", signature)
+	}
+	propertiesEnd := 12 + int(binary.LittleEndian.Uint32(blob[4:8]))
+	if propertiesEnd < userPropertiesFixedSize || propertiesEnd >= len(blob) {
+		return nil, fmt.Errorf("supplementalCredentials: invalid USER_PROPERTIES length %d", propertiesEnd-12)
+	}
+	info := &SupplementalCredentialsInfo{}
+	if propertiesEnd == userPropertiesFixedSize {
+		return info, nil // PropertyCount is omitted when it is zero.
+	}
+	if propertiesEnd < userPropertiesFixedSize+2 {
+		return nil, fmt.Errorf("supplementalCredentials: USER_PROPERTIES is missing PropertyCount")
+	}
+
+	propertyCount := int(binary.LittleEndian.Uint16(blob[110:112]))
+	offset := 112
+	for i := 0; i < propertyCount; i++ {
+		if propertiesEnd-offset < 6 {
+			return nil, fmt.Errorf("supplementalCredentials: property %d header exceeds USER_PROPERTIES", i)
+		}
+		nameLength := int(binary.LittleEndian.Uint16(blob[offset : offset+2]))
+		valueLength := int(binary.LittleEndian.Uint16(blob[offset+2 : offset+4]))
+		offset += 6
+		if nameLength%2 != 0 || nameLength > propertiesEnd-offset || valueLength > propertiesEnd-offset-nameLength {
+			return nil, fmt.Errorf("supplementalCredentials: property %d has invalid name/value lengths %d/%d", i, nameLength, valueLength)
+		}
+		name := utf16leToString(blob[offset : offset+nameLength])
+		offset += nameLength
+		encodedValue := blob[offset : offset+valueLength]
+		offset += valueLength
+		value := make([]byte, hex.DecodedLen(len(encodedValue)))
+		n, err := hex.Decode(value, encodedValue)
+		if err != nil {
+			return nil, fmt.Errorf("supplementalCredentials: property %q: invalid hexadecimal value: %w", name, err)
+		}
+		value = value[:n]
+
+		switch name {
+		case "Primary:Kerberos-Newer-Keys":
+			keys, err := parseKerberosNew(value)
+			if err != nil {
+				return nil, fmt.Errorf("supplementalCredentials: %s: %w", name, err)
+			}
+			info.KerberosKeys = append(info.KerberosKeys, keys...)
+		case "Primary:Kerberos":
+			keys, err := parseKerberosLegacy(value)
+			if err != nil {
+				return nil, fmt.Errorf("supplementalCredentials: %s: %w", name, err)
+			}
+			info.KerberosKeys = append(info.KerberosKeys, keys...)
+		case "Primary:CLEARTEXT":
+			if len(value)%2 != 0 {
+				return nil, fmt.Errorf("supplementalCredentials: %s: odd UTF-16 byte count %d", name, len(value))
+			}
+			info.CleartextPasswordRaw = append([]byte(nil), value...)
+			info.CleartextPassword = utf16leToString(value)
+		case "Primary:WDigest":
+			hashes, err := parseWDigest(value)
+			if err != nil {
+				return nil, fmt.Errorf("supplementalCredentials: %s: %w", name, err)
+			}
+			info.WDigestHashes = hashes
+		}
+	}
+	if offset != propertiesEnd {
+		return nil, fmt.Errorf("supplementalCredentials: %d unparsed property bytes", propertiesEnd-offset)
+	}
+	return info, nil
+}
+
+func parseKerberosNew(value []byte) ([]KerberosKey, error) {
+	if len(value) < kerberosNewHeaderSize {
+		return nil, fmt.Errorf("KERB_STORED_CREDENTIAL_NEW is %d bytes", len(value))
+	}
+	if revision := binary.LittleEndian.Uint16(value[0:2]); revision != 4 {
+		return nil, fmt.Errorf("invalid revision %d", revision)
+	}
+	counts := [4]int{
+		int(binary.LittleEndian.Uint16(value[4:6])),
+		int(binary.LittleEndian.Uint16(value[6:8])),
+		int(binary.LittleEndian.Uint16(value[8:10])),
+		int(binary.LittleEndian.Uint16(value[10:12])),
+	}
+	total := counts[0] + counts[1] + counts[2] + counts[3]
+	if total > (len(value)-kerberosNewHeaderSize)/kerberosNewKeySize {
+		return nil, fmt.Errorf("%d key records exceed property length", total)
+	}
+	salt, err := parseCredentialSalt(value, binary.LittleEndian.Uint16(value[12:14]), binary.LittleEndian.Uint32(value[16:20]))
+	if err != nil {
+		return nil, err
+	}
+	categories := [...]KerberosKeyCategory{KerberosKeyCurrent, KerberosKeyService, KerberosKeyOld, KerberosKeyOlder}
+	keys := make([]KerberosKey, 0, total)
+	offset := kerberosNewHeaderSize
+	for categoryIndex, count := range counts {
+		for range count {
+			record := value[offset : offset+kerberosNewKeySize]
+			key, err := parseCredentialKey(value, binary.LittleEndian.Uint32(record[12:16]), binary.LittleEndian.Uint32(record[16:20]), binary.LittleEndian.Uint32(record[20:24]))
+			if err != nil {
+				return nil, err
+			}
+			keys = append(keys, KerberosKey{
+				KeyType:        binary.LittleEndian.Uint32(record[12:16]),
+				Value:          key,
+				Salt:           salt,
+				IterationCount: binary.LittleEndian.Uint32(record[8:12]),
+				Category:       categories[categoryIndex],
+			})
+			offset += kerberosNewKeySize
+		}
+	}
+	return keys, nil
+}
+
+func parseKerberosLegacy(value []byte) ([]KerberosKey, error) {
+	if len(value) < kerberosOldHeaderSize {
+		return nil, fmt.Errorf("KERB_STORED_CREDENTIAL is %d bytes", len(value))
+	}
+	if revision := binary.LittleEndian.Uint16(value[0:2]); revision != 3 {
+		return nil, fmt.Errorf("invalid revision %d", revision)
+	}
+	currentCount := int(binary.LittleEndian.Uint16(value[4:6]))
+	oldCount := int(binary.LittleEndian.Uint16(value[6:8]))
+	total := currentCount + oldCount
+	if total > (len(value)-kerberosOldHeaderSize)/kerberosOldKeySize {
+		return nil, fmt.Errorf("%d key records exceed property length", total)
+	}
+	salt, err := parseCredentialSalt(value, binary.LittleEndian.Uint16(value[8:10]), binary.LittleEndian.Uint32(value[12:16]))
+	if err != nil {
+		return nil, err
+	}
+	keys := make([]KerberosKey, 0, total)
+	offset := kerberosOldHeaderSize
+	for i := 0; i < total; i++ {
+		record := value[offset : offset+kerberosOldKeySize]
+		keyType := binary.LittleEndian.Uint32(record[8:12])
+		key, err := parseCredentialKey(value, keyType, binary.LittleEndian.Uint32(record[12:16]), binary.LittleEndian.Uint32(record[16:20]))
+		if err != nil {
+			return nil, err
+		}
+		category := KerberosKeyCurrent
+		if i >= currentCount {
+			category = KerberosKeyOld
+		}
+		keys = append(keys, KerberosKey{KeyType: keyType, Value: key, Salt: salt, Category: category})
+		offset += kerberosOldKeySize
+	}
+	return keys, nil
+}
+
+func parseCredentialSalt(value []byte, length uint16, offset uint32) (string, error) {
+	if length == 0 {
+		return "", nil
+	}
+	if length%2 != 0 || uint64(offset)+uint64(length) > uint64(len(value)) {
+		return "", fmt.Errorf("invalid salt offset/length %d/%d", offset, length)
+	}
+	return utf16leToString(value[int(offset) : int(offset)+int(length)]), nil
+}
+
+func parseCredentialKey(value []byte, keyType, length, offset uint32) ([]byte, error) {
+	if uint64(offset)+uint64(length) > uint64(len(value)) {
+		return nil, fmt.Errorf("key type %d has invalid offset/length %d/%d", keyType, offset, length)
+	}
+	return append([]byte(nil), value[int(offset):int(offset)+int(length)]...), nil
+}
+
+func parseWDigest(value []byte) ([][16]byte, error) {
+	if len(value) < 16 {
+		return nil, fmt.Errorf("WDIGEST_CREDENTIALS is %d bytes", len(value))
+	}
+	if value[2] != 1 {
+		return nil, fmt.Errorf("invalid version %d", value[2])
+	}
+	count := int(value[3])
+	if count != 29 || count > (len(value)-16)/16 {
+		return nil, fmt.Errorf("invalid hash count %d for %d-byte value", count, len(value))
+	}
+	hashes := make([][16]byte, count)
+	for i := range hashes {
+		copy(hashes[i][:], value[16+i*16:16+(i+1)*16])
+	}
+	return hashes, nil
+}

--- a/network/dcerpc/ms-protocols/ms-drsr/supplemental_credentials_test.go
+++ b/network/dcerpc/ms-protocols/ms-drsr/supplemental_credentials_test.go
@@ -1,0 +1,128 @@
+package msdrsr
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/hex"
+	"testing"
+	"unicode/utf16"
+)
+
+func supplementalUTF16(s string) []byte {
+	units := utf16.Encode([]rune(s))
+	out := make([]byte, len(units)*2)
+	for i, unit := range units {
+		binary.LittleEndian.PutUint16(out[i*2:], unit)
+	}
+	return out
+}
+
+func supplementalProperty(name string, value []byte) []byte {
+	nameBytes := supplementalUTF16(name)
+	valueBytes := []byte(hex.EncodeToString(value))
+	out := make([]byte, 6+len(nameBytes)+len(valueBytes))
+	binary.LittleEndian.PutUint16(out[0:2], uint16(len(nameBytes)))
+	binary.LittleEndian.PutUint16(out[2:4], uint16(len(valueBytes)))
+	copy(out[6:], nameBytes)
+	copy(out[6+len(nameBytes):], valueBytes)
+	return out
+}
+
+func supplementalBlob(properties ...[]byte) []byte {
+	out := make([]byte, 112)
+	binary.LittleEndian.PutUint16(out[108:110], 0x50)
+	binary.LittleEndian.PutUint16(out[110:112], uint16(len(properties)))
+	for _, property := range properties {
+		out = append(out, property...)
+	}
+	propertiesEnd := len(out)
+	out = append(out, 0)
+	binary.LittleEndian.PutUint32(out[4:8], uint32(propertiesEnd-12))
+	return out
+}
+
+func kerberosNewValue() ([]byte, []byte, []byte, string) {
+	salt := "LAB.LOCALtest"
+	saltBytes := supplementalUTF16(salt)
+	aes256 := bytes.Repeat([]byte{0x25}, 32)
+	aes128 := bytes.Repeat([]byte{0x18}, 16)
+	value := make([]byte, kerberosNewHeaderSize+2*kerberosNewKeySize)
+	binary.LittleEndian.PutUint16(value[0:2], 4)
+	binary.LittleEndian.PutUint16(value[4:6], 1)
+	binary.LittleEndian.PutUint16(value[8:10], 1)
+	binary.LittleEndian.PutUint16(value[12:14], uint16(len(saltBytes)))
+	binary.LittleEndian.PutUint16(value[14:16], uint16(len(saltBytes)))
+	binary.LittleEndian.PutUint32(value[16:20], uint32(len(value)))
+	binary.LittleEndian.PutUint32(value[20:24], 4096)
+
+	keyOffset := len(value) + len(saltBytes)
+	binary.LittleEndian.PutUint32(value[24+8:24+12], 4096)
+	binary.LittleEndian.PutUint32(value[24+12:24+16], 18)
+	binary.LittleEndian.PutUint32(value[24+16:24+20], uint32(len(aes256)))
+	binary.LittleEndian.PutUint32(value[24+20:24+24], uint32(keyOffset))
+	second := 24 + kerberosNewKeySize
+	binary.LittleEndian.PutUint32(value[second+8:second+12], 4096)
+	binary.LittleEndian.PutUint32(value[second+12:second+16], 17)
+	binary.LittleEndian.PutUint32(value[second+16:second+20], uint32(len(aes128)))
+	binary.LittleEndian.PutUint32(value[second+20:second+24], uint32(keyOffset+len(aes256)))
+	value = append(value, saltBytes...)
+	value = append(value, aes256...)
+	value = append(value, aes128...)
+	return value, aes256, aes128, salt
+}
+
+func TestParseSupplementalCredentials(t *testing.T) {
+	newer, aes256, aes128, salt := kerberosNewValue()
+	cleartext := supplementalUTF16("P@ssw0rd!")
+	wdigest := make([]byte, 16+29*16)
+	wdigest[2], wdigest[3] = 1, 29
+	for i := 0; i < 29; i++ {
+		copy(wdigest[16+i*16:], bytes.Repeat([]byte{byte(i + 1)}, 16))
+	}
+	blob := supplementalBlob(
+		supplementalProperty("Primary:Kerberos-Newer-Keys", newer),
+		supplementalProperty("Primary:CLEARTEXT", cleartext),
+		supplementalProperty("Primary:WDigest", wdigest),
+	)
+
+	info, err := ParseSupplementalCredentials(blob)
+	if err != nil {
+		t.Fatalf("ParseSupplementalCredentials: %v", err)
+	}
+	if len(info.KerberosKeys) != 2 {
+		t.Fatalf("KerberosKeys = %d, want 2", len(info.KerberosKeys))
+	}
+	if key := info.KerberosKeys[0]; key.KeyType != 18 || !bytes.Equal(key.Value, aes256) || key.Salt != salt || key.IterationCount != 4096 || key.Category != KerberosKeyCurrent {
+		t.Errorf("AES256 key = %+v", key)
+	}
+	if key := info.KerberosKeys[1]; key.KeyType != 17 || !bytes.Equal(key.Value, aes128) || key.Category != KerberosKeyOld {
+		t.Errorf("AES128 old key = %+v", key)
+	}
+	if info.CleartextPassword != "P@ssw0rd!" || !bytes.Equal(info.CleartextPasswordRaw, cleartext) {
+		t.Errorf("cleartext = %q (%x)", info.CleartextPassword, info.CleartextPasswordRaw)
+	}
+	if len(info.WDigestHashes) != 29 || info.WDigestHashes[28][0] != 29 {
+		t.Errorf("WDigest hashes = %d", len(info.WDigestHashes))
+	}
+}
+
+func TestParseSupplementalCredentialsRejectsMalformedValues(t *testing.T) {
+	newer, _, _, _ := kerberosNewValue()
+	binary.LittleEndian.PutUint32(newer[24+20:24+24], uint32(len(newer)+1))
+	tests := []struct {
+		name string
+		blob []byte
+	}{
+		{name: "short header", blob: []byte{1, 2, 3}},
+		{name: "bad signature", blob: make([]byte, 111)},
+		{name: "key beyond property", blob: supplementalBlob(supplementalProperty("Primary:Kerberos-Newer-Keys", newer))},
+		{name: "odd cleartext", blob: supplementalBlob(supplementalProperty("Primary:CLEARTEXT", []byte{1}))},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := ParseSupplementalCredentials(tt.blob); err == nil {
+				t.Fatal("expected an error")
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Linked Issue
Closes #694

### Root Cause
The replication path decrypted `supplementalCredentials` only at the transport layer and retained the MS-SAMR `USER_PROPERTIES` blob as opaque bytes. Callers therefore could not access the Kerberos keys, salt and iteration metadata, reversible cleartext value, or WDigest hashes contained in its properties.

### Fix Description
Adds a bounds-checked parser for `USER_PROPERTIES` and recognized property values: `Primary:Kerberos-Newer-Keys`, legacy `Primary:Kerberos`, `Primary:CLEARTEXT`, and `Primary:WDigest`. `AccountSecrets` retains the original blob for compatibility and now exposes typed Kerberos key records (including current/service/history category, salt, and iteration count), cleartext in decoded and raw forms, and WDigest hashes.

The parser validates signatures, length-delimited properties, hexadecimal encoding, structure revisions, record counts, offsets, and key/salt bounds before exposing data.

### How Verified
- Runtime: `go test ./...` passes.
- Runtime: full-NC `TestDCSyncAll` passes against Windows Server 2025, parsing every replicated security principal with supplemental credential data.
- Runtime: `TestSupplementalCredentials` extracted nine Kerberos records for the live Administrator account. Its current AES256 value matched an independent RFC 3962 string-to-key derivation using the extracted salt and 4,096 iteration count.
- Tests: synthetic coverage exercises AES256/AES128 keys, current/history categories, salt, cleartext, all 29 WDigest hashes, and malformed inputs.

### Test Coverage
**Added:** `network/dcerpc/ms-protocols/ms-drsr/supplemental_credentials_test.go` with `TestParseSupplementalCredentials` and `TestParseSupplementalCredentialsRejectsMalformedValues`; integration test `TestSupplementalCredentials` validates live extraction and RFC 3962 derivation.

### Scope of Change
- **Files changed:** `network/dcerpc/ms-protocols/ms-drsr/integration_test.go`, `secrets.go`, `supplemental_credentials.go`, `supplemental_credentials_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
The parser runs only when the replicated attribute is present. Malformed recognized properties now return a descriptive error instead of remaining silently opaque; the original decrypted blob remains available to existing callers.
