### PR TITLE
Fix four RPC interface catalog mappings (Refs #639)

### DIFF
--- a/network/dcerpc/interfaces/catalog/catalog_test.go
+++ b/network/dcerpc/interfaces/catalog/catalog_test.go
@@ -34,6 +34,31 @@ func TestLocalInterfacesPresent(t *testing.T) {
 	}
 }
 
+func TestIssue639DocumentedInterfacesPresent(t *testing.T) {
+	cases := []struct {
+		uuid, name, protocol, service string
+	}{
+		{"0b6edbfa-4a24-4fc6-8a23-942b1eca65d1", "IRPCAsyncNotify", "MS-PAN", "Spooler"},
+		{"ae33069b-a2a8-46ee-a235-ddfd339be281", "IRPCRemoteObject", "MS-PAN", "Spooler"},
+		{"d95afe70-a6d5-4259-822e-2c84da1ddb0d", "WindowsShutdown", "MS-RSP", ""},
+		{"906b0ce0-c70b-1067-b317-00dd010662da", "IXnRemote", "MS-CMPO", ""},
+	}
+	for _, c := range cases {
+		e, ok := Lookup(mustGUID(c.uuid), 1, 0)
+		if !ok {
+			t.Errorf("Lookup(%s v1.0) not found", c.uuid)
+			continue
+		}
+		if e.Name != c.name || e.Protocol != c.protocol || e.Service != c.service {
+			t.Errorf("Lookup(%s v1.0) = (%q/%q/%q), want (%q/%q/%q)",
+				c.uuid, e.Name, e.Protocol, e.Service, c.name, c.protocol, c.service)
+		}
+		if len(e.Pipes) != 0 {
+			t.Errorf("Lookup(%s v1.0).Pipes = %v, want no named pipe for dynamic endpoint", c.uuid, e.Pipes)
+		}
+	}
+}
+
 func TestDefault_BuildsAndIsConsistent(t *testing.T) {
 	db := Default() // panics if the seed table is malformed
 	all := db.All()
@@ -86,11 +111,11 @@ func TestResolveFallback(t *testing.T) {
 }
 
 func TestSearchByFields(t *testing.T) {
-	if got := SearchByExecutable("SPOOLSV.EXE"); len(got) != 2 { // spoolss + IRemoteWinspool, case-insensitive
-		t.Errorf("SearchByExecutable(spoolsv.exe) = %d entries, want 2: %v", len(got), names(got))
+	if got := SearchByExecutable("SPOOLSV.EXE"); len(got) != 4 { // spoolss, IRemoteWinspool, and both MS-PAN interfaces
+		t.Errorf("SearchByExecutable(spoolsv.exe) = %d entries, want 4: %v", len(got), names(got))
 	}
-	if got := SearchByService("Spooler"); len(got) != 2 {
-		t.Errorf("SearchByService(Spooler) = %d, want 2: %v", len(got), names(got))
+	if got := SearchByService("Spooler"); len(got) != 4 {
+		t.Errorf("SearchByService(Spooler) = %d, want 4: %v", len(got), names(got))
 	}
 	if got := SearchByProtocol("MS-EFSR"); len(got) != 2 { // two EFSR interface UUIDs
 		t.Errorf("SearchByProtocol(MS-EFSR) = %d, want 2: %v", len(got), names(got))

--- a/network/dcerpc/interfaces/catalog/data.go
+++ b/network/dcerpc/interfaces/catalog/data.go
@@ -102,6 +102,30 @@ var builtin = []Interface{
 		Executable:  "spoolsv.exe", Service: "Spooler", Protocol: "MS-PAR", Pipes: []string{`\pipe\spoolss`},
 	},
 	{
+		UUID: mustGUID("0b6edbfa-4a24-4fc6-8a23-942b1eca65d1"), Version: v(1, 0),
+		Name: "IRPCAsyncNotify", Title: "Print System Asynchronous Notification Protocol",
+		Description: "Registers print clients and exchanges asynchronous print notifications.",
+		Executable:  "spoolsv.exe", Service: "Spooler", Protocol: "MS-PAN",
+	},
+	{
+		UUID: mustGUID("ae33069b-a2a8-46ee-a235-ddfd339be281"), Version: v(1, 0),
+		Name: "IRPCRemoteObject", Title: "Print System Asynchronous Notification Remote Object",
+		Description: "Creates and destroys remote objects that refer to printers.",
+		Executable:  "spoolsv.exe", Service: "Spooler", Protocol: "MS-PAN",
+	},
+	{
+		UUID: mustGUID("d95afe70-a6d5-4259-822e-2c84da1ddb0d"), Version: v(1, 0),
+		Name: "WindowsShutdown", Title: "Remote Shutdown Protocol (WindowsShutdown)",
+		Description: "Initiates or aborts a remote shutdown through a dynamic RPC-over-TCP endpoint.",
+		Protocol:    "MS-RSP",
+	},
+	{
+		UUID: mustGUID("906b0ce0-c70b-1067-b317-00dd010662da"), Version: v(1, 0),
+		Name: "IXnRemote", Title: "MSDTC Connection Manager: OleTx Transports Protocol",
+		Description: "Establishes peer-to-peer MSDTC partner communication over dynamic RPC endpoints.",
+		Protocol:    "MS-CMPO",
+	},
+	{
 		UUID: mustGUID("12345678-1234-abcd-ef00-01234567cffb"), Version: v(1, 0),
 		Name: "netlogon", Title: "Netlogon Remote Protocol",
 		Description: "Domain authentication; abused via Zerologon.",

--- a/network/dcerpc/interfaces/catalog/integration_test.go
+++ b/network/dcerpc/interfaces/catalog/integration_test.go
@@ -1,0 +1,73 @@
+//go:build integration
+
+package catalog_test
+
+import (
+	"encoding/binary"
+	"os"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/catalog"
+	epm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/functions"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/transport/tcp"
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+	msrpce "github.com/TheManticoreProject/Manticore/windows/protocols/ms-rpce"
+)
+
+func TestIntegration_DocumentedInterfacesResolve(t *testing.T) {
+	host := os.Getenv("DCERPC_TEST_HOST")
+	if host == "" {
+		t.Skip("DCERPC_TEST_HOST not set; skipping live catalog resolution test")
+	}
+
+	rpc := client.NewClient(tcp.New(host, tcp.EndpointMapperPort))
+	if err := rpc.Bind(epm.SyntaxID()); err != nil {
+		t.Fatalf("Bind(endpoint mapper): %v", err)
+	}
+	defer rpc.Close()
+
+	entries, err := functions.Lookup(rpc)
+	if err != nil {
+		t.Fatalf("Lookup(endpoint mapper): %v", err)
+	}
+
+	want := map[string]string{
+		"0b6edbfa-4a24-4fc6-8a23-942b1eca65d1": "IRPCAsyncNotify",
+		"ae33069b-a2a8-46ee-a235-ddfd339be281": "IRPCRemoteObject",
+		"d95afe70-a6d5-4259-822e-2c84da1ddb0d": "WindowsShutdown",
+		"906b0ce0-c70b-1067-b317-00dd010662da": "IXnRemote",
+	}
+	found := make(map[string]bool)
+	for _, endpoint := range entries {
+		tower, err := endpoint.DecodeTower()
+		if err != nil || len(tower.Floors) == 0 {
+			continue
+		}
+		floor := tower.Floors[0]
+		if floor.Protocol() != msrpce.FloorProtoUUID || len(floor.LHS) < 19 || len(floor.RHS) < 2 {
+			continue
+		}
+		var id guid.GUID
+		id.FromRawBytes(floor.LHS[1:17])
+		uuid := id.ToFormatD()
+		name, tracked := want[uuid]
+		if !tracked {
+			continue
+		}
+		major := binary.LittleEndian.Uint16(floor.LHS[17:19])
+		minor := binary.LittleEndian.Uint16(floor.RHS[:2])
+		entry, ok := catalog.Lookup(id, major, minor)
+		if !ok || entry.Name != name {
+			t.Errorf("catalog lookup for live %s v%d.%d = (%q, %v), want %q", uuid, major, minor, entry.Name, ok, name)
+			continue
+		}
+		found[uuid] = true
+		t.Logf("resolved live %s v%d.%d as %s", uuid, major, minor, entry.Name)
+	}
+
+	if !found["d95afe70-a6d5-4259-822e-2c84da1ddb0d"] {
+		t.Error("live endpoint map did not contain the WindowsShutdown interface")
+	}
+}


### PR DESCRIPTION
### Linked Issue

Related #639

### Root Cause

The catalog predates four interface implementations whose UUIDs, versions, names, and transports are now documented by the MS-PAN, MS-RSP, and MS-CMPO specifications. Endpoint enumeration therefore returned raw UUIDs even though authoritative metadata was available.

### Fix Description

Add catalog entries for IRPCAsyncNotify, IRPCRemoteObject, WindowsShutdown, and IXnRemote. The entries record exact version 1.0 identities and protocol names, preserve empty named-pipe metadata for their dynamic endpoints, and attach Spooler process/service metadata only to the two print-server interfaces.

Add a live integration test that enumerates the endpoint mapper over TCP, decodes interface floors, and verifies that observed interfaces resolve through the catalog.

### How Verified

- `go test ./...`
- `go test ./network/dcerpc/interfaces/catalog`
- `DCERPC_TEST_HOST=10.7.0.12 go test -tags integration -v ./network/dcerpc/interfaces/catalog -run '^TestIntegration_DocumentedInterfacesResolve$' -count=1`
- The live Windows Server 2025 endpoint map returned all four UUIDs at version 1.0, and every UUID resolved to its expected catalog name.

### Test Coverage

**Added:**

- `network/dcerpc/interfaces/catalog/catalog_test.go`: `TestIssue639DocumentedInterfacesPresent` verifies exact UUID/version/name/protocol/service metadata and the absence of incorrect named-pipe bindings.
- `network/dcerpc/interfaces/catalog/integration_test.go`: `TestIntegration_DocumentedInterfacesResolve` verifies live endpoint-map results resolve through the catalog.

Existing search tests were updated to include the two additional Spooler-hosted interfaces.

### Scope of Change

- **Files changed:** `network/dcerpc/interfaces/catalog/data.go`, `network/dcerpc/interfaces/catalog/catalog_test.go`, `network/dcerpc/interfaces/catalog/integration_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout

Risk is limited to catalog lookup and search results. Existing UUID mappings are unchanged, and the complete repository test suite passes.

### Notes

This is a partial contribution toward #639. The issue remains open for the 39 UUIDs that still lack authoritative identification.
