### PR TITLE
Add a server-side listener to the SMB transport layer (Refs #1068)

### DIFF
--- a/network/netbios/nbns/name.go
+++ b/network/netbios/nbns/name.go
@@ -150,6 +150,79 @@ func EncodeSessionServiceName(name string, suffix byte) ([]byte, error) {
 	return encoded, nil
 }
 
+// DecodeSessionServiceName decodes one second-level-encoded NetBIOS name as it
+// appears in a SESSION REQUEST (RFC 1002 4.3.2), the inverse of
+// EncodeSessionServiceName: a 0x20 length byte, EncodedNameLength encoded bytes,
+// then the label sequence terminating the name — a bare 0x00 for the default
+// scope, or one or more length-prefixed scope labels followed by 0x00.
+//
+// It returns the name with its trailing space padding removed, the one-byte
+// service suffix that occupied the 16th position, and the total number of bytes
+// consumed, so a caller can decode the CALLED name and then the CALLING name
+// that follows it.
+//
+// Parameters:
+//   - b: the buffer positioned at the start of the encoded name
+//
+// Returns:
+//   - name: the decoded name, trailing padding removed
+//   - suffix: the one-byte service suffix
+//   - n: the number of bytes consumed from b
+//   - err: non-nil if the encoding is malformed
+func DecodeSessionServiceName(b []byte) (name string, suffix byte, n int, err error) {
+	// The shortest well-formed name is the length byte, the encoded name and a
+	// single 0x00 label terminator.
+	if len(b) < 1+EncodedNameLength+1 {
+		return "", 0, 0, fmt.Errorf("truncated session-service name: need at least %d bytes, got %d", 1+EncodedNameLength+1, len(b))
+	}
+	if b[0] != EncodedNameLength {
+		return "", 0, 0, fmt.Errorf("invalid session-service name length byte: expected 0x%02X, got 0x%02X", EncodedNameLength, b[0])
+	}
+
+	// First-level decoding: each pair of characters in the range 'A'..'P' encodes
+	// the high and low half-byte of one name byte.
+	decoded := make([]byte, NetBIOSNameLength)
+	for i := 0; i < NetBIOSNameLength; i++ {
+		high := b[1+i*2] - ASCII_A
+		low := b[1+i*2+1] - ASCII_A
+		if high > 0x0F || low > 0x0F {
+			return "", 0, 0, fmt.Errorf("invalid encoding character at offset %d", 1+i*2)
+		}
+		decoded[i] = (high << 4) | low
+	}
+
+	n = 1 + EncodedNameLength
+
+	// Walk the remaining labels. The default scope is a single 0x00 terminator;
+	// a scoped name carries length-prefixed labels before it. Bounding each
+	// label by the DNS 63-byte limit keeps a malformed buffer from being read as
+	// one enormous label.
+	for {
+		if n >= len(b) {
+			return "", 0, 0, fmt.Errorf("session-service name is not terminated")
+		}
+		labelLength := int(b[n])
+		n++
+		if labelLength == 0 {
+			break
+		}
+		if labelLength > 63 {
+			return "", 0, 0, fmt.Errorf("invalid scope label length %d at offset %d", labelLength, n-1)
+		}
+		if n+labelLength > len(b) {
+			return "", 0, 0, fmt.Errorf("truncated scope label at offset %d", n-1)
+		}
+		n += labelLength
+	}
+
+	// The 16th byte is the service suffix; the preceding 15 are the name, padded
+	// with spaces on the wire.
+	suffix = decoded[NetBIOSNameLength-1]
+	name = string(bytes.TrimRight(decoded[:NetBIOSNameLength-1], " "))
+
+	return name, suffix, n, nil
+}
+
 // FirstLevelDecode decodes a first level encoded NetBIOS name
 func FirstLevelDecode(encoded string) (*NetBIOSName, error) {
 	parts := strings.SplitN(encoded, ".", 2)

--- a/network/netbios/nbns/name_test.go
+++ b/network/netbios/nbns/name_test.go
@@ -215,3 +215,155 @@ func TestEncodeSessionServiceName(t *testing.T) {
 		t.Fatal("EncodeSessionServiceName() should reject names longer than 15 characters")
 	}
 }
+
+// TestDecodeSessionServiceName asserts the exact wire decoding of a
+// second-level-encoded session-service name, including the RFC 1001 known
+// answer, the suffix split and the byte count consumed.
+func TestDecodeSessionServiceName(t *testing.T) {
+	// The "*SMBSERVER" / 0x20 encoding from TestEncodeSessionServiceName.
+	encoded := append(append([]byte{0x20}, []byte("CKFDENECFDEFFCFGEFFCCACACACACACA")...), 0x00)
+
+	name, suffix, n, err := DecodeSessionServiceName(encoded)
+	if err != nil {
+		t.Fatalf("DecodeSessionServiceName() error = %v", err)
+	}
+	if name != "*SMBSERVER" {
+		t.Fatalf("name = %q, want %q", name, "*SMBSERVER")
+	}
+	if suffix != 0x20 {
+		t.Fatalf("suffix = 0x%02X, want 0x20", suffix)
+	}
+	if n != 34 {
+		t.Fatalf("consumed = %d, want 34", n)
+	}
+
+	// Trailing bytes must be left untouched: a SESSION REQUEST carries the
+	// CALLING name immediately after the CALLED name, so the caller decodes the
+	// second name from encoded[n:].
+	twoNames := append(append([]byte{}, encoded...), encoded...)
+	_, _, first, err := DecodeSessionServiceName(twoNames)
+	if err != nil {
+		t.Fatalf("DecodeSessionServiceName() on a two-name buffer error = %v", err)
+	}
+	second, secondSuffix, _, err := DecodeSessionServiceName(twoNames[first:])
+	if err != nil {
+		t.Fatalf("DecodeSessionServiceName() on the second name error = %v", err)
+	}
+	if second != "*SMBSERVER" || secondSuffix != 0x20 {
+		t.Fatalf("second name = %q/0x%02X, want *SMBSERVER/0x20", second, secondSuffix)
+	}
+}
+
+// TestDecodeSessionServiceNameRoundTrip asserts DecodeSessionServiceName is the
+// exact inverse of EncodeSessionServiceName across name lengths and suffixes,
+// including the space padding the encoder applies.
+func TestDecodeSessionServiceNameRoundTrip(t *testing.T) {
+	cases := []struct {
+		name   string
+		suffix byte
+	}{
+		{"A", 0x00},
+		{"CLIENT", 0x00},
+		{"FILESERVER01", 0x20},
+		{"*SMBSERVER", 0x20},
+		{"WORKSTATION1234", 0x03}, // exactly 15 characters, the maximum
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			encoded, err := EncodeSessionServiceName(tc.name, tc.suffix)
+			if err != nil {
+				t.Fatalf("EncodeSessionServiceName() error = %v", err)
+			}
+			got, suffix, n, err := DecodeSessionServiceName(encoded)
+			if err != nil {
+				t.Fatalf("DecodeSessionServiceName() error = %v", err)
+			}
+			if got != tc.name {
+				t.Fatalf("name = %q, want %q", got, tc.name)
+			}
+			if suffix != tc.suffix {
+				t.Fatalf("suffix = 0x%02X, want 0x%02X", suffix, tc.suffix)
+			}
+			if n != len(encoded) {
+				t.Fatalf("consumed = %d, want %d", n, len(encoded))
+			}
+		})
+	}
+}
+
+// TestDecodeSessionServiceNameScoped asserts a name carrying scope labels is
+// decoded and that the consumed count covers the whole label sequence, so a
+// following name is still found at the right offset.
+func TestDecodeSessionServiceNameScoped(t *testing.T) {
+	base, err := EncodeSessionServiceName("SERVER", 0x20)
+	if err != nil {
+		t.Fatalf("EncodeSessionServiceName() error = %v", err)
+	}
+	// Replace the bare 0x00 terminator with two scope labels ("EXAMPLE.COM")
+	// followed by the terminator.
+	scoped := append([]byte{}, base[:len(base)-1]...)
+	scoped = append(scoped, 7)
+	scoped = append(scoped, []byte("EXAMPLE")...)
+	scoped = append(scoped, 3)
+	scoped = append(scoped, []byte("COM")...)
+	scoped = append(scoped, 0x00)
+
+	name, suffix, n, err := DecodeSessionServiceName(scoped)
+	if err != nil {
+		t.Fatalf("DecodeSessionServiceName() on a scoped name error = %v", err)
+	}
+	if name != "SERVER" || suffix != 0x20 {
+		t.Fatalf("name = %q/0x%02X, want SERVER/0x20", name, suffix)
+	}
+	if n != len(scoped) {
+		t.Fatalf("consumed = %d, want %d", n, len(scoped))
+	}
+}
+
+// TestDecodeSessionServiceNameErrors asserts each malformed encoding is rejected
+// rather than producing a garbage name or reading out of bounds.
+func TestDecodeSessionServiceNameErrors(t *testing.T) {
+	valid, err := EncodeSessionServiceName("SERVER", 0x20)
+	if err != nil {
+		t.Fatalf("EncodeSessionServiceName() error = %v", err)
+	}
+
+	// A length byte other than 0x20.
+	badLength := append([]byte{}, valid...)
+	badLength[0] = 0x10
+
+	// An encoding character outside the 'A'..'P' half-byte alphabet.
+	badChar := append([]byte{}, valid...)
+	badChar[1] = 'Z'
+
+	// No label terminator at all.
+	unterminated := append([]byte{}, valid[:len(valid)-1]...)
+
+	// A scope label whose length runs past the end of the buffer.
+	truncatedLabel := append(append([]byte{}, valid[:len(valid)-1]...), 40, 'A', 'B')
+
+	// A scope label longer than the 63-byte DNS limit.
+	oversizeLabel := append(append([]byte{}, valid[:len(valid)-1]...), 64)
+
+	cases := []struct {
+		name  string
+		input []byte
+	}{
+		{"empty", nil},
+		{"truncated", valid[:20]},
+		{"bad length byte", badLength},
+		{"bad encoding character", badChar},
+		{"unterminated", unterminated},
+		{"truncated scope label", truncatedLabel},
+		{"oversize scope label", oversizeLabel},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if _, _, _, err := DecodeSessionServiceName(tc.input); err == nil {
+				t.Fatalf("DecodeSessionServiceName(% x) should fail", tc.input)
+			}
+		})
+	}
+}

--- a/network/netbios/nbt/nbt.go
+++ b/network/netbios/nbt/nbt.go
@@ -61,6 +61,19 @@ func NewNBTTransport() *NBTTransport {
 	}
 }
 
+// NewNBTTransportFromConn wraps an already-established connection — typically one
+// returned by net.Listener.Accept — as a NetBIOS over TCP transport. Connect MUST
+// NOT be called on the result; the accept-side handshake is performed by
+// AcceptSession instead of by Connect.
+func NewNBTTransportFromConn(conn net.Conn) *NBTTransport {
+	return &NBTTransport{
+		conn:        conn,
+		handshake:   true,
+		calledName:  DefaultCalledName,
+		callingName: defaultCallingName(),
+	}
+}
+
 // SetHandshakeEnabled controls whether Connect performs the RFC 1002
 // session-establishment handshake. Disable it to talk to a modern server that
 // accepts SESSION MESSAGEs on port 139 without a prior SESSION REQUEST.
@@ -209,6 +222,102 @@ func (n *NBTTransport) EstablishSession(calledName, callingName string) error {
 			return fmt.Errorf("unexpected NetBIOS session response type 0x%02X (%s)", messageType, netbios.SESSION_MESSAGE_TYPE(messageType))
 		}
 	}
+}
+
+// AcceptSession completes the RFC 1002 4.3 session-establishment handshake on an
+// accepted connection, the server-side counterpart of EstablishSession: it reads
+// the SESSION REQUEST (0x81), decodes the CALLED and CALLING names it carries,
+// and answers either a POSITIVE SESSION RESPONSE (0x82) or a NEGATIVE SESSION
+// RESPONSE (0x83).
+//
+// The CALLED name is accepted when acceptedNames is empty (any name is served),
+// when it matches one of acceptedNames case-insensitively, or when it is a
+// wildcard such as the "*SMBSERVER" convention that clients use before they know
+// a host's real machine name. A name that matches none of these is refused with
+// NEGATIVE_SESSION_NOT_LISTENING_ON_CALLED_NAME, mirroring what EstablishSession
+// expects to receive and retry against.
+//
+// Parameters:
+//   - acceptedNames: the CALLED names this endpoint answers to; empty accepts any
+//
+// Returns:
+//   - called: the CALLED name the client asked for
+//   - calling: the CALLING name the client identified itself with
+//   - err: non-nil if the handshake did not complete, in which case the caller
+//     should close the connection
+func (n *NBTTransport) AcceptSession(acceptedNames []string) (called, calling string, err error) {
+	if !n.IsConnected() {
+		return "", "", fmt.Errorf("not connected")
+	}
+
+	messageType, body, err := n.readFrame()
+	if err != nil {
+		return "", "", fmt.Errorf("failed to read SESSION REQUEST: %v", err)
+	}
+	if netbios.SESSION_MESSAGE_TYPE(messageType) != netbios.SESSION_REQUEST {
+		return "", "", fmt.Errorf("unexpected NetBIOS session message type 0x%02X (%s), expected SESSION REQUEST", messageType, netbios.SESSION_MESSAGE_TYPE(messageType))
+	}
+
+	// RFC 1002 4.3.2: the body is the CALLED name followed by the CALLING name,
+	// each second-level encoded. A malformed name is answered with an
+	// unspecified-error NEGATIVE response rather than silently dropped, so the
+	// client fails with a protocol error instead of a read timeout.
+	calledName, calledSuffix, consumed, err := nbns.DecodeSessionServiceName(body)
+	if err != nil {
+		n.sendNegativeSessionResponse(netbios.NEGATIVE_SESSION_UNSPECIFIED_ERROR)
+		return "", "", fmt.Errorf("failed to decode CALLED name: %v", err)
+	}
+	callingName, _, _, err := nbns.DecodeSessionServiceName(body[consumed:])
+	if err != nil {
+		n.sendNegativeSessionResponse(netbios.NEGATIVE_SESSION_UNSPECIFIED_ERROR)
+		return "", "", fmt.Errorf("failed to decode CALLING name: %v", err)
+	}
+
+	// The CALLED name of an SMB session request carries the server-service
+	// suffix; anything else is addressed to a different NetBIOS service.
+	if calledSuffix != NetBIOSSuffixServer {
+		n.sendNegativeSessionResponse(netbios.NEGATIVE_SESSION_CALLED_NAME_NOT_PRESENT)
+		return "", "", fmt.Errorf("CALLED name %q has service suffix 0x%02X, expected the server service 0x%02X", calledName, calledSuffix, NetBIOSSuffixServer)
+	}
+
+	if !calledNameAccepted(calledName, acceptedNames) {
+		n.sendNegativeSessionResponse(netbios.NEGATIVE_SESSION_NOT_LISTENING_ON_CALLED_NAME)
+		return "", "", fmt.Errorf("not listening on CALLED name %q", calledName)
+	}
+
+	// RFC 1002 4.3.3: a POSITIVE SESSION RESPONSE is a bare header with a zero
+	// LENGTH and no body.
+	positive := []byte{byte(netbios.SESSION_POSITIVE_RESPONSE), 0x00, 0x00, 0x00}
+	if _, err := n.conn.Write(positive); err != nil {
+		return "", "", fmt.Errorf("failed to send POSITIVE SESSION RESPONSE: %v", err)
+	}
+
+	return calledName, callingName, nil
+}
+
+// sendNegativeSessionResponse answers a SESSION REQUEST with a NEGATIVE SESSION
+// RESPONSE (RFC 1002 4.3.4): a header with LENGTH 1 followed by the one-byte
+// error code. A write failure is discarded because the caller is already
+// abandoning the connection on every path that reaches here.
+func (n *NBTTransport) sendNegativeSessionResponse(code netbios.NEGATIVE_SESSION_ERROR) {
+	//nolint:errcheck // the connection is being abandoned regardless
+	n.conn.Write([]byte{byte(netbios.SESSION_NEGATIVE_RESPONSE), 0x00, 0x00, 0x01, byte(code)})
+}
+
+// calledNameAccepted reports whether a SESSION REQUEST addressed to calledName
+// should be served. An empty acceptedNames list serves any name; a wildcard
+// called name is always served, because a client that does not know the host's
+// machine name has no better option than the "*SMBSERVER" convention.
+func calledNameAccepted(calledName string, acceptedNames []string) bool {
+	if len(acceptedNames) == 0 || isWildcardCalledName(calledName) {
+		return true
+	}
+	for _, accepted := range acceptedNames {
+		if strings.EqualFold(strings.TrimSpace(accepted), calledName) {
+			return true
+		}
+	}
+	return false
 }
 
 // isWildcardCalledName reports whether name is a wildcard called name (e.g. the

--- a/network/netbios/nbt/nbt_test.go
+++ b/network/netbios/nbt/nbt_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/TheManticoreProject/Manticore/network/netbios/nbns"
 	"github.com/TheManticoreProject/Manticore/network/netbios/nbt"
 )
 
@@ -463,4 +464,285 @@ func TestNBTTransport_ReceiveTimesOutOnSilentServer(t *testing.T) {
 	if elapsed > 5*time.Second {
 		t.Fatalf("NBTTransport.Receive() took %v to fail, want a bounded timeout", elapsed)
 	}
+}
+
+// acceptSessionResult carries the outcome of a server-side AcceptSession run
+// back to the test goroutine.
+type acceptSessionResult struct {
+	transport *nbt.NBTTransport
+	called    string
+	calling   string
+	err       error
+}
+
+// serveAcceptSession listens on an ephemeral port and runs AcceptSession on the
+// first connection it accepts, delivering the outcome on the returned channel.
+// It is the server-side counterpart of the connectedPair helper above.
+func serveAcceptSession(t *testing.T, acceptedNames []string) (*net.TCPAddr, <-chan acceptSessionResult, func()) {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start test server: %v", err)
+	}
+
+	ch := make(chan acceptSessionResult, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			ch <- acceptSessionResult{err: err}
+			return
+		}
+		tr := nbt.NewNBTTransportFromConn(conn)
+		tr.SetTimeout(5 * time.Second)
+		called, calling, err := tr.AcceptSession(acceptedNames)
+		ch <- acceptSessionResult{transport: tr, called: called, calling: calling, err: err}
+	}()
+
+	return ln.Addr().(*net.TCPAddr), ch, func() { ln.Close() }
+}
+
+// TestNBTTransport_AcceptSessionPositive verifies the accept side completes the
+// handshake against the client side of the same implementation, and that the
+// resulting transports carry SESSION MESSAGEs in both directions.
+func TestNBTTransport_AcceptSessionPositive(t *testing.T) {
+	addr, results, cleanup := serveAcceptSession(t, []string{"FILESERVER"})
+	defer cleanup()
+
+	client := nbt.NewNBTTransport()
+	client.SetCalledName("FILESERVER")
+	client.SetCallingName("TESTCLIENT")
+	client.SetTimeout(5 * time.Second)
+	if err := client.Connect(addr.IP, addr.Port); err != nil {
+		t.Fatalf("client Connect() error = %v", err)
+	}
+	defer client.Close()
+
+	got := <-results
+	if got.err != nil {
+		t.Fatalf("AcceptSession() error = %v", got.err)
+	}
+	defer got.transport.Close()
+
+	if got.called != "FILESERVER" {
+		t.Fatalf("called name = %q, want %q", got.called, "FILESERVER")
+	}
+	if got.calling != "TESTCLIENT" {
+		t.Fatalf("calling name = %q, want %q", got.calling, "TESTCLIENT")
+	}
+
+	// The session is established, so both ends must now frame SESSION MESSAGEs
+	// for each other.
+	payload := []byte{0xFF, 'S', 'M', 'B', 0x72}
+	if _, err := client.Send(payload); err != nil {
+		t.Fatalf("client Send() error = %v", err)
+	}
+	received, err := got.transport.Receive()
+	if err != nil {
+		t.Fatalf("server Receive() error = %v", err)
+	}
+	if !bytes.Equal(received, payload) {
+		t.Fatalf("server received % x, want % x", received, payload)
+	}
+
+	reply := []byte{0xFF, 'S', 'M', 'B', 0x72, 0x00}
+	if _, err := got.transport.Send(reply); err != nil {
+		t.Fatalf("server Send() error = %v", err)
+	}
+	back, err := client.Receive()
+	if err != nil {
+		t.Fatalf("client Receive() error = %v", err)
+	}
+	if !bytes.Equal(back, reply) {
+		t.Fatalf("client received % x, want % x", back, reply)
+	}
+}
+
+// TestNBTTransport_AcceptSessionWildcard verifies the "*SMBSERVER" convention is
+// answered even when it is not in the accepted-name list, and that an empty list
+// answers to any name.
+func TestNBTTransport_AcceptSessionWildcard(t *testing.T) {
+	cases := []struct {
+		name          string
+		acceptedNames []string
+		calledName    string
+	}{
+		{"wildcard against a named endpoint", []string{"FILESERVER"}, "*SMBSERVER"},
+		{"any name against an empty list", nil, "SOMEOTHERHOST"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			addr, results, cleanup := serveAcceptSession(t, tc.acceptedNames)
+			defer cleanup()
+
+			client := nbt.NewNBTTransport()
+			client.SetCalledName(tc.calledName)
+			client.SetTimeout(5 * time.Second)
+			if err := client.Connect(addr.IP, addr.Port); err != nil {
+				t.Fatalf("client Connect() to %q error = %v", tc.calledName, err)
+			}
+			defer client.Close()
+
+			got := <-results
+			if got.err != nil {
+				t.Fatalf("AcceptSession() error = %v", got.err)
+			}
+			got.transport.Close()
+			if got.called != tc.calledName {
+				t.Fatalf("called name = %q, want %q", got.called, tc.calledName)
+			}
+		})
+	}
+}
+
+// TestNBTTransport_AcceptSessionRefusesUnknownName verifies a CALLED name the
+// endpoint does not serve is refused with a NEGATIVE SESSION RESPONSE carrying
+// NEGATIVE_SESSION_NOT_LISTENING_ON_CALLED_NAME (0x80), which is what the client
+// side surfaces as an error.
+func TestNBTTransport_AcceptSessionRefusesUnknownName(t *testing.T) {
+	addr, results, cleanup := serveAcceptSession(t, []string{"FILESERVER"})
+	defer cleanup()
+
+	// Drive the client at the raw byte level so the response can be inspected
+	// exactly, rather than through Connect's fallback logic.
+	conn, err := net.DialTCP("tcp", nil, addr)
+	if err != nil {
+		t.Fatalf("dial error = %v", err)
+	}
+	defer conn.Close()
+
+	request := sessionRequestBytes(t, "OTHERHOST", 0x20, "TESTCLIENT", 0x00)
+	if _, err := conn.Write(request); err != nil {
+		t.Fatalf("write SESSION REQUEST error = %v", err)
+	}
+
+	response := make([]byte, 5)
+	if _, err := io.ReadFull(conn, response); err != nil {
+		t.Fatalf("read SESSION RESPONSE error = %v", err)
+	}
+	want := []byte{0x83, 0x00, 0x00, 0x01, 0x80}
+	if !bytes.Equal(response, want) {
+		t.Fatalf("response = % x, want % x", response, want)
+	}
+
+	got := <-results
+	if got.err == nil {
+		t.Fatal("AcceptSession() should reject a CALLED name the endpoint does not serve")
+	}
+	if !strings.Contains(got.err.Error(), "OTHERHOST") {
+		t.Fatalf("error %q does not name the refused CALLED name", got.err.Error())
+	}
+}
+
+// TestNBTTransport_AcceptSessionRejectsWrongSuffix verifies a CALLED name
+// addressed to a service other than the server service (0x20) is refused with
+// NEGATIVE_SESSION_CALLED_NAME_NOT_PRESENT (0x82).
+func TestNBTTransport_AcceptSessionRejectsWrongSuffix(t *testing.T) {
+	addr, results, cleanup := serveAcceptSession(t, nil)
+	defer cleanup()
+
+	conn, err := net.DialTCP("tcp", nil, addr)
+	if err != nil {
+		t.Fatalf("dial error = %v", err)
+	}
+	defer conn.Close()
+
+	// Suffix 0x00 is the workstation service, not the server service.
+	request := sessionRequestBytes(t, "FILESERVER", 0x00, "TESTCLIENT", 0x00)
+	if _, err := conn.Write(request); err != nil {
+		t.Fatalf("write SESSION REQUEST error = %v", err)
+	}
+
+	response := make([]byte, 5)
+	if _, err := io.ReadFull(conn, response); err != nil {
+		t.Fatalf("read SESSION RESPONSE error = %v", err)
+	}
+	want := []byte{0x83, 0x00, 0x00, 0x01, 0x82}
+	if !bytes.Equal(response, want) {
+		t.Fatalf("response = % x, want % x", response, want)
+	}
+
+	if got := <-results; got.err == nil {
+		t.Fatal("AcceptSession() should reject a non-server service suffix")
+	}
+}
+
+// TestNBTTransport_AcceptSessionRejectsMalformed verifies the accept side refuses
+// a frame that is not a SESSION REQUEST, and refuses a SESSION REQUEST whose
+// names are malformed, without hanging or panicking.
+func TestNBTTransport_AcceptSessionRejectsMalformed(t *testing.T) {
+	cases := []struct {
+		name  string
+		frame []byte
+	}{
+		// A SESSION MESSAGE (0x00) where a SESSION REQUEST is required.
+		{"wrong message type", []byte{0x00, 0x00, 0x00, 0x02, 0xFF, 0x53}},
+		// A SESSION REQUEST with an empty body.
+		{"empty body", []byte{0x81, 0x00, 0x00, 0x00}},
+		// A SESSION REQUEST whose CALLED name has a bad length byte.
+		{"bad called name", append([]byte{0x81, 0x00, 0x00, 0x22, 0x10}, bytes.Repeat([]byte{'A'}, 33)...)},
+		// A well-formed CALLED name with no CALLING name following it.
+		{"missing calling name", func() []byte {
+			called := sessionServiceNameBytes(0x20)
+			frame := []byte{0x81, 0x00, 0x00, byte(len(called))}
+			return append(frame, called...)
+		}()},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			addr, results, cleanup := serveAcceptSession(t, nil)
+			defer cleanup()
+
+			conn, err := net.DialTCP("tcp", nil, addr)
+			if err != nil {
+				t.Fatalf("dial error = %v", err)
+			}
+			defer conn.Close()
+
+			if _, err := conn.Write(tc.frame); err != nil {
+				t.Fatalf("write error = %v", err)
+			}
+
+			got := <-results
+			if got.err == nil {
+				if got.transport != nil {
+					got.transport.Close()
+				}
+				t.Fatalf("AcceptSession() should reject %s", tc.name)
+			}
+		})
+	}
+}
+
+// sessionRequestBytes builds a SESSION REQUEST frame carrying the given CALLED
+// and CALLING names with explicit service suffixes, so a test can address a
+// service other than the one the client-side helpers assume.
+func sessionRequestBytes(t *testing.T, calledName string, calledSuffix byte, callingName string, callingSuffix byte) []byte {
+	t.Helper()
+
+	called, err := nbns.EncodeSessionServiceName(calledName, calledSuffix)
+	if err != nil {
+		t.Fatalf("EncodeSessionServiceName(%q) error = %v", calledName, err)
+	}
+	calling, err := nbns.EncodeSessionServiceName(callingName, callingSuffix)
+	if err != nil {
+		t.Fatalf("EncodeSessionServiceName(%q) error = %v", callingName, err)
+	}
+
+	length := len(called) + len(calling)
+	frame := []byte{0x81, 0x00, byte((length >> 8) & 0xFF), byte(length & 0xFF)}
+	frame = append(frame, called...)
+	return append(frame, calling...)
+}
+
+// sessionServiceNameBytes returns one encoded session-service name for use in
+// hand-built frames.
+func sessionServiceNameBytes(suffix byte) []byte {
+	encoded, err := nbns.EncodeSessionServiceName("FILESERVER", suffix)
+	if err != nil {
+		panic(err)
+	}
+	return encoded
 }

--- a/network/smb/common/transport/listener.go
+++ b/network/smb/common/transport/listener.go
@@ -1,0 +1,157 @@
+package transport
+
+import (
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/TheManticoreProject/Manticore/logger"
+	"github.com/TheManticoreProject/Manticore/network/netbios/nbt"
+	"github.com/TheManticoreProject/Manticore/network/tcp"
+)
+
+// Default SMB listening ports: 445 carries SMB directly over TCP, while 139
+// carries it inside a NetBIOS session (RFC 1002).
+const (
+	DefaultDirectTCPPort = "445"
+	DefaultNBTPort       = "139"
+)
+
+// Listener is the accept side of the SMB transport layer, the counterpart of
+// Transport's Connect. Accept yields a Transport that is already connected and
+// whose transport-level handshake, if the transport has one, is already
+// complete, so a server above it can treat both transports identically.
+type Listener interface {
+	// Accept blocks until a client connects and returns it as a Transport
+	// together with its remote address. A connection whose transport-level
+	// handshake fails is discarded rather than returned, so Accept only ever
+	// yields a Transport ready to carry SMB messages.
+	Accept() (Transport, net.Addr, error)
+
+	// Close stops listening. It does not close the connections already handed
+	// out by Accept; those are owned by their callers.
+	Close() error
+
+	// Addr returns the address the listener is bound to, which is how a caller
+	// discovers the port when it asked for port 0.
+	Addr() net.Addr
+}
+
+// ListenTCP listens for Direct TCP SMB connections on addr. An addr with no port
+// (including the empty string) is bound on DefaultDirectTCPPort.
+//
+// Parameters:
+//   - addr: the address to bind, e.g. "0.0.0.0:445", ":445", "" or "127.0.0.1:0"
+//
+// Returns:
+//   - A Listener yielding Direct TCP transports
+//   - An error if the address cannot be bound
+func ListenTCP(addr string) (Listener, error) {
+	ln, err := net.Listen("tcp", withDefaultPort(addr, DefaultDirectTCPPort))
+	if err != nil {
+		return nil, fmt.Errorf("failed to listen for Direct TCP SMB connections: %v", err)
+	}
+	return &tcpListener{listener: ln}, nil
+}
+
+// ListenNBT listens for NetBIOS-over-TCP SMB connections on addr, completing the
+// RFC 1002 4.3 session handshake on each accepted connection before returning it.
+// An addr with no port (including the empty string) is bound on DefaultNBTPort.
+//
+// acceptedNames are the CALLED NetBIOS names this endpoint answers to; an empty
+// list answers to any name, and the "*SMBSERVER" wildcard is always answered.
+//
+// Parameters:
+//   - addr: the address to bind, e.g. "0.0.0.0:139", ":139", "" or "127.0.0.1:0"
+//   - acceptedNames: the CALLED names to serve, or nil to serve any
+//
+// Returns:
+//   - A Listener yielding NetBIOS over TCP transports
+//   - An error if the address cannot be bound
+func ListenNBT(addr string, acceptedNames []string) (Listener, error) {
+	ln, err := net.Listen("tcp", withDefaultPort(addr, DefaultNBTPort))
+	if err != nil {
+		return nil, fmt.Errorf("failed to listen for NetBIOS over TCP SMB connections: %v", err)
+	}
+	names := make([]string, len(acceptedNames))
+	copy(names, acceptedNames)
+	return &nbtListener{listener: ln, acceptedNames: names}, nil
+}
+
+// withDefaultPort appends defaultPort to addr when addr does not already carry
+// one, so callers can pass a bare host or an empty string.
+func withDefaultPort(addr, defaultPort string) string {
+	if addr == "" {
+		return ":" + defaultPort
+	}
+	if _, _, err := net.SplitHostPort(addr); err == nil {
+		return addr
+	}
+	// An IPv6 literal has to be bracketed before a port can be appended to it.
+	if strings.Count(addr, ":") > 1 && !strings.HasPrefix(addr, "[") {
+		return "[" + addr + "]:" + defaultPort
+	}
+	return addr + ":" + defaultPort
+}
+
+// tcpListener adapts a net.Listener into a Listener yielding Direct TCP
+// transports. Direct TCP has no transport-level handshake, so an accepted
+// connection is usable immediately.
+type tcpListener struct {
+	listener net.Listener
+}
+
+func (l *tcpListener) Accept() (Transport, net.Addr, error) {
+	conn, err := l.listener.Accept()
+	if err != nil {
+		return nil, nil, err
+	}
+	return tcp.NewTCPTransportFromConn(conn), conn.RemoteAddr(), nil
+}
+
+func (l *tcpListener) Close() error { return l.listener.Close() }
+
+func (l *tcpListener) Addr() net.Addr { return l.listener.Addr() }
+
+// nbtListener adapts a net.Listener into a Listener yielding NetBIOS over TCP
+// transports, performing the session handshake on each connection as it arrives.
+type nbtListener struct {
+	listener      net.Listener
+	acceptedNames []string
+}
+
+// Accept accepts connections until one completes the NetBIOS session handshake.
+// A connection whose handshake fails is logged and closed rather than surfaced
+// as an error: a client addressing the wrong CALLED name, or speaking something
+// other than the session service, must not take the listener down. The loop ends
+// when the underlying listener itself fails, which is also how Close unblocks it.
+func (l *nbtListener) Accept() (Transport, net.Addr, error) {
+	for {
+		conn, err := l.listener.Accept()
+		if err != nil {
+			return nil, nil, err
+		}
+
+		remote := conn.RemoteAddr()
+		nbtTransport := nbt.NewNBTTransportFromConn(conn)
+		called, calling, err := nbtTransport.AcceptSession(l.acceptedNames)
+		if err != nil {
+			logger.Debugf("NetBIOS session handshake with %s failed: %v", remote, err)
+			nbtTransport.Close()
+			continue
+		}
+
+		logger.Debugf("NetBIOS session established with %s (called %q, calling %q)", remote, called, calling)
+		return nbtTransport, remote, nil
+	}
+}
+
+func (l *nbtListener) Close() error { return l.listener.Close() }
+
+func (l *nbtListener) Addr() net.Addr { return l.listener.Addr() }
+
+// Compile-time assurance that both listeners satisfy the Listener contract.
+var (
+	_ Listener = (*tcpListener)(nil)
+	_ Listener = (*nbtListener)(nil)
+)

--- a/network/smb/common/transport/listener_test.go
+++ b/network/smb/common/transport/listener_test.go
@@ -1,0 +1,247 @@
+package transport_test
+
+import (
+	"bytes"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/TheManticoreProject/Manticore/network/netbios/nbt"
+	"github.com/TheManticoreProject/Manticore/network/smb/common/transport"
+	"github.com/TheManticoreProject/Manticore/network/tcp"
+)
+
+// acceptResult carries the outcome of a Listener.Accept run back to the test
+// goroutine.
+type acceptResult struct {
+	transport transport.Transport
+	remote    net.Addr
+	err       error
+}
+
+// acceptOnce runs Accept in the background and delivers its outcome, so a test
+// can drive the client side on the main goroutine.
+func acceptOnce(l transport.Listener) <-chan acceptResult {
+	ch := make(chan acceptResult, 1)
+	go func() {
+		tr, remote, err := l.Accept()
+		ch <- acceptResult{tr, remote, err}
+	}()
+	return ch
+}
+
+// exchange asserts a bidirectional SMB-message round trip over an established
+// client/server transport pair, which is the contract a Listener promises: the
+// transport it returns is ready to carry SMB messages in both directions.
+func exchange(t *testing.T, client, server transport.Transport) {
+	t.Helper()
+
+	request := []byte{0xFF, 'S', 'M', 'B', 0x72, 0x00, 0x00, 0x00}
+	if _, err := client.Send(request); err != nil {
+		t.Fatalf("client Send() error = %v", err)
+	}
+	got, err := server.Receive()
+	if err != nil {
+		t.Fatalf("server Receive() error = %v", err)
+	}
+	if !bytes.Equal(got, request) {
+		t.Fatalf("server received % x, want % x", got, request)
+	}
+
+	response := []byte{0xFF, 'S', 'M', 'B', 0x72, 0x01}
+	if _, err := server.Send(response); err != nil {
+		t.Fatalf("server Send() error = %v", err)
+	}
+	back, err := client.Receive()
+	if err != nil {
+		t.Fatalf("client Receive() error = %v", err)
+	}
+	if !bytes.Equal(back, response) {
+		t.Fatalf("client received % x, want % x", back, response)
+	}
+}
+
+// TestListenTCPRoundTrip verifies a Direct TCP listener hands back a connected
+// transport that round-trips SMB messages with the client-side transport.
+func TestListenTCPRoundTrip(t *testing.T) {
+	listener, err := transport.ListenTCP("127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("ListenTCP() error = %v", err)
+	}
+	defer listener.Close()
+
+	results := acceptOnce(listener)
+
+	addr := listener.Addr().(*net.TCPAddr)
+	client := tcp.NewTCPTransport()
+	client.SetTimeout(5 * time.Second)
+	if err := client.Connect(addr.IP, addr.Port); err != nil {
+		t.Fatalf("client Connect() error = %v", err)
+	}
+	defer client.Close()
+
+	got := <-results
+	if got.err != nil {
+		t.Fatalf("Accept() error = %v", got.err)
+	}
+	defer got.transport.Close()
+
+	if !got.transport.IsConnected() {
+		t.Fatal("Accept() returned a transport that reports itself disconnected")
+	}
+	if got.remote == nil {
+		t.Fatal("Accept() returned a nil remote address")
+	}
+	got.transport.SetTimeout(5 * time.Second)
+
+	exchange(t, client, got.transport)
+}
+
+// TestListenNBTRoundTrip verifies an NBT listener completes the RFC 1002 session
+// handshake before returning, so the transport it hands back is immediately
+// usable for SMB messages.
+func TestListenNBTRoundTrip(t *testing.T) {
+	listener, err := transport.ListenNBT("127.0.0.1:0", []string{"FILESERVER"})
+	if err != nil {
+		t.Fatalf("ListenNBT() error = %v", err)
+	}
+	defer listener.Close()
+
+	results := acceptOnce(listener)
+
+	addr := listener.Addr().(*net.TCPAddr)
+	client := nbt.NewNBTTransport()
+	client.SetCalledName("FILESERVER")
+	client.SetCallingName("TESTCLIENT")
+	client.SetTimeout(5 * time.Second)
+	if err := client.Connect(addr.IP, addr.Port); err != nil {
+		t.Fatalf("client Connect() error = %v", err)
+	}
+	defer client.Close()
+
+	got := <-results
+	if got.err != nil {
+		t.Fatalf("Accept() error = %v", got.err)
+	}
+	defer got.transport.Close()
+	got.transport.SetTimeout(5 * time.Second)
+
+	exchange(t, client, got.transport)
+}
+
+// TestListenNBTSkipsFailedHandshake verifies a connection that fails the NetBIOS
+// handshake is discarded rather than surfaced from Accept, so one bad client
+// cannot take the listener down: the next well-formed client is still served.
+func TestListenNBTSkipsFailedHandshake(t *testing.T) {
+	listener, err := transport.ListenNBT("127.0.0.1:0", []string{"FILESERVER"})
+	if err != nil {
+		t.Fatalf("ListenNBT() error = %v", err)
+	}
+	defer listener.Close()
+
+	results := acceptOnce(listener)
+	addr := listener.Addr().(*net.TCPAddr)
+
+	// A client asking for a CALLED name this endpoint does not serve is refused
+	// during the handshake. Connect fails, and Accept must still be waiting.
+	refused := nbt.NewNBTTransport()
+	refused.SetCalledName("OTHERHOST")
+	refused.SetTimeout(5 * time.Second)
+	if err := refused.Connect(addr.IP, addr.Port); err == nil {
+		refused.Close()
+		t.Fatal("Connect() with an unserved CALLED name should fail")
+	}
+
+	select {
+	case got := <-results:
+		if got.transport != nil {
+			got.transport.Close()
+		}
+		t.Fatalf("Accept() returned after a failed handshake (err = %v), it should keep waiting", got.err)
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	// A well-formed client is still served on the same listener.
+	client := nbt.NewNBTTransport()
+	client.SetCalledName("FILESERVER")
+	client.SetTimeout(5 * time.Second)
+	if err := client.Connect(addr.IP, addr.Port); err != nil {
+		t.Fatalf("client Connect() after a failed handshake error = %v", err)
+	}
+	defer client.Close()
+
+	got := <-results
+	if got.err != nil {
+		t.Fatalf("Accept() error = %v", got.err)
+	}
+	defer got.transport.Close()
+	got.transport.SetTimeout(5 * time.Second)
+
+	exchange(t, client, got.transport)
+}
+
+// TestListenerCloseUnblocksAccept verifies Close makes a blocked Accept return an
+// error, which is how a server's accept loop terminates.
+func TestListenerCloseUnblocksAccept(t *testing.T) {
+	listeners := map[string]func() (transport.Listener, error){
+		"tcp": func() (transport.Listener, error) { return transport.ListenTCP("127.0.0.1:0") },
+		"nbt": func() (transport.Listener, error) { return transport.ListenNBT("127.0.0.1:0", nil) },
+	}
+	for name, newListener := range listeners {
+		newListener := newListener
+		t.Run(name, func(t *testing.T) {
+			listener, err := newListener()
+			if err != nil {
+				t.Fatalf("listen error = %v", err)
+			}
+
+			results := acceptOnce(listener)
+			if err := listener.Close(); err != nil {
+				t.Fatalf("Close() error = %v", err)
+			}
+
+			select {
+			case got := <-results:
+				if got.err == nil {
+					got.transport.Close()
+					t.Fatal("Accept() should fail once the listener is closed")
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatal("Accept() did not return after Close()")
+			}
+		})
+	}
+}
+
+// TestListenDefaultPorts verifies an address with no port is bound on the
+// dialect's default SMB port. Binding 445 and 139 needs privileges the test
+// environment may not have, so an inability to bind is skipped rather than
+// failed; what matters is that a successful bind lands on the right port.
+func TestListenDefaultPorts(t *testing.T) {
+	cases := []struct {
+		name string
+		open func(string) (transport.Listener, error)
+		port string
+	}{
+		{"tcp", transport.ListenTCP, transport.DefaultDirectTCPPort},
+		{"nbt", func(addr string) (transport.Listener, error) { return transport.ListenNBT(addr, nil) }, transport.DefaultNBTPort},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			listener, err := tc.open("127.0.0.1")
+			if err != nil {
+				t.Skipf("cannot bind the default port %s: %v", tc.port, err)
+			}
+			defer listener.Close()
+
+			_, port, err := net.SplitHostPort(listener.Addr().String())
+			if err != nil {
+				t.Fatalf("SplitHostPort(%q) error = %v", listener.Addr().String(), err)
+			}
+			if port != tc.port {
+				t.Fatalf("bound port = %s, want the default %s", port, tc.port)
+			}
+		})
+	}
+}

--- a/network/tcp/tcp.go
+++ b/network/tcp/tcp.go
@@ -25,6 +25,15 @@ func NewTCPTransport() *TCPTransport {
 	return &TCPTransport{}
 }
 
+// NewTCPTransportFromConn wraps an already-established connection — typically one
+// returned by net.Listener.Accept — as a Direct TCP transport, so the server side
+// of a connection uses the same framing as the client side. Connect MUST NOT be
+// called on the result: the transport is connected from the outset, and calling
+// Connect would dial a second connection and leak conn.
+func NewTCPTransportFromConn(conn net.Conn) *TCPTransport {
+	return &TCPTransport{conn: conn}
+}
+
 // Connect establishes a Direct TCP connection
 func (t *TCPTransport) Connect(ipaddr net.IP, port int) error {
 	// Default SMB port is 445 if not specified


### PR DESCRIPTION
### Summary

Commit 1 of 12 for #1068. The SMB transport layer had only a client side: `Transport` exposes `Connect`, and neither implementation could be built from an accepted connection, so nothing in the tree could listen for SMB. `grep -rl 'net.Listen|\.Accept()'` matched `netbios/nbns`, `netbios/nbdgm` and `llmnr/server`, and nothing under `network/smb/`.

This adds the accept side, keeping both transports interchangeable above it so the server layers in later commits do not care which one a connection arrived on.

### Changes

- **`tcp.NewTCPTransportFromConn`** and **`nbt.NewNBTTransportFromConn`** adopt an already-established connection, so the server side reuses the existing framing, `MaxDirectTCPPayloadSize` limit and read-deadline handling rather than duplicating them.
- **`nbns.DecodeSessionServiceName`** decodes a second-level-encoded NetBIOS name — the inverse of the existing `EncodeSessionServiceName`. It returns the number of bytes consumed so a caller can decode the CALLED name and then the CALLING name that follows it, and it walks scope labels rather than assuming the default scope, bounding each by the 63-byte limit.
- **`nbt.AcceptSession`** completes the RFC 1002 §4.3 handshake on an accepted connection, the counterpart of `EstablishSession`. A CALLED name addressed to a service other than the server service (0x20) and a name the endpoint does not serve are refused separately, and a wildcard CALLED name such as the `*SMBSERVER` convention is always served — mirroring what `EstablishSession` expects to receive and retry against.
- **`transport.Listener`**, with `ListenTCP` and `ListenNBT`, yields a `Transport` whose transport-level handshake (where the transport has one) is already complete. A connection that fails the NetBIOS handshake is logged and discarded inside `Accept` rather than surfaced as an error, so one bad client cannot take the listener down. An address with no port binds the dialect default: 445 for Direct TCP, 139 for NetBIOS.

No existing behaviour changes: the additions are new symbols, and the client-side paths are untouched.

### Wire format

Cross-checked against RFC 1002 §4.3:

| Packet | TYPE | FLAGS | LENGTH | Trailer |
|---|---|---|---|---|
| SESSION REQUEST (§4.3.2) | 0x81 | 0x00 | variable | CALLED name, then CALLING name |
| POSITIVE SESSION RESPONSE (§4.3.3) | 0x82 | 0x00 | 0x0000 | none |
| NEGATIVE SESSION RESPONSE (§4.3.4) | 0x83 | 0x00 | 0x0001 | 1-byte ERROR_CODE |

The error codes emitted (`0x80` not listening on called name, `0x82` called name not present, `0x8F` unspecified) are the existing `netbios.NEGATIVE_SESSION_*` constants.

### Testing

`go build ./...`, `go vet ./...` and `go test ./...` are green across the repository.

New tests:

- **Name codec** — round trip across name lengths, suffixes and a scoped name; the RFC 1001 `*SMBSERVER` known answer; the two-names-in-one-buffer case the SESSION REQUEST needs; and rejection of a bad length byte, a bad encoding character, an unterminated name, a truncated scope label and an oversize scope label.
- **Handshake** — completes against the client side of the same implementation, with an SMB-message exchange in both directions afterwards to prove the session is usable; the wildcard and any-name policies; and refusal of an unserved CALLED name, a wrong service suffix, a wrong message type, an empty body, a malformed CALLED name and a missing CALLING name — asserting the exact response bytes where a response is sent.
- **Listeners** — a bidirectional SMB-message round trip for each; that a failed NetBIOS handshake leaves the listener still serving the next client; that `Close` unblocks a blocked `Accept`; and that a portless address lands on the default port.

### Notes

The remaining eleven commits for #1068 build on this: the server skeleton and dispatch loop come next.