### PR TITLE
Fix NTLMv2Response so it can carry a NetNTLMv2 response (Refs #1068)

### DIFF
--- a/crypto/ntlmv1/ntlmv1_response.go
+++ b/crypto/ntlmv1/ntlmv1_response.go
@@ -6,6 +6,12 @@ import (
 	"strings"
 )
 
+// HashcatMode is the hashcat hash-mode number for a NetNTLMv1 response, so a
+// caller writing captured material to a file can label it correctly. It is a
+// different mode from a NetNTLMv2 response, which hashcat expects in a different
+// field layout (see crypto/ntlmv2.HashcatMode).
+const HashcatMode = 5500
+
 type NTLMv1Response struct {
 	Username string // Username for authentication
 	Domain   string // Domain name

--- a/crypto/ntlmv1/ntlmv1_response_test.go
+++ b/crypto/ntlmv1/ntlmv1_response_test.go
@@ -1,6 +1,8 @@
 package ntlmv1
 
 import (
+	"encoding/hex"
+	"strings"
 	"testing"
 )
 
@@ -112,5 +114,67 @@ func TestNTLMv1ResponseEqual(t *testing.T) {
 	other.SetServerChallenge([8]byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff})
 	if resp.Equal(other) {
 		t.Error("Equal() returned true for different responses")
+	}
+}
+
+// TestNTLMv1HashcatStringMatchesPublishedExample asserts the renderer reproduces
+// the published hashcat mode-5500 example hash, pinning the field order.
+//
+// NetNTLMv1 and NetNTLMv2 use different layouts, and confusing them is easy: mode
+// 5500 puts the server challenge LAST, after the LM and NT responses, whereas
+// mode 5600 puts it BEFORE the NTProofStr and blob. This guards the v1 side of
+// that distinction; crypto/ntlmv2 guards the other.
+//
+// Source: https://hashcat.net/wiki/doku.php?id=example_hashes
+func TestNTLMv1HashcatStringMatchesPublishedExample(t *testing.T) {
+	const (
+		username        = "u4-netntlm"
+		domain          = "kNS"
+		lmResponse      = "338d08f8e26de93300000000000000000000000000000000"
+		ntResponse      = "9526fb8c23a90751cdd619b6cea564742e1e4bf33006ba41"
+		serverChallenge = "cb8086049ec4736c"
+		exampleHash     = username + "::" + domain + ":" + lmResponse + ":" + ntResponse + ":" + serverChallenge
+	)
+
+	mustDecode := func(s string) []byte {
+		b, err := hex.DecodeString(s)
+		if err != nil {
+			t.Fatalf("bad hex %q: %v", s, err)
+		}
+		return b
+	}
+
+	var challenge [8]byte
+	var lm, nt [24]byte
+	copy(challenge[:], mustDecode(serverChallenge))
+	copy(lm[:], mustDecode(lmResponse))
+	copy(nt[:], mustDecode(ntResponse))
+
+	response := NewNTLMv1Response(username, domain, challenge, lm, nt)
+
+	got, err := response.HashcatString()
+	if err != nil {
+		t.Fatalf("HashcatString() error = %v", err)
+	}
+	// The renderer uppercases hex; hashcat parses it case-insensitively.
+	if !strings.EqualFold(got, exampleHash) {
+		t.Fatalf("HashcatString() =\n  %s\nwant (any case)\n  %s", got, exampleHash)
+	}
+
+	// The server challenge is the last field for mode 5500, not the first.
+	fields := strings.Split(got, ":")
+	if len(fields) != 6 {
+		t.Fatalf("line has %d colon-separated fields, want 6: %q", len(fields), got)
+	}
+	if !strings.EqualFold(fields[5], serverChallenge) {
+		t.Fatalf("last field = %q, want the server challenge %q", fields[5], serverChallenge)
+	}
+}
+
+// TestNTLMv1HashcatModeIsNetNTLMv1 guards the mode number a caller labels
+// captured material with.
+func TestNTLMv1HashcatModeIsNetNTLMv1(t *testing.T) {
+	if HashcatMode != 5500 {
+		t.Fatalf("HashcatMode = %d, want 5500 for NetNTLMv1", HashcatMode)
 	}
 }

--- a/crypto/ntlmv2/ntlmv2_response.go
+++ b/crypto/ntlmv2/ntlmv2_response.go
@@ -6,55 +6,137 @@ import (
 	"strings"
 )
 
+// HashcatMode is the hashcat hash-mode number for a NetNTLMv2 response, so a
+// caller writing captured material to a file can label it correctly.
+const HashcatMode = 5600
+
+// NTProofStrLength is the length in bytes of the NTProofStr that prefixes an
+// NTLMv2 NtChallengeResponse. It is the HMAC-MD5 taken over the server challenge
+// concatenated with the blob that follows it ([MS-NLMP] 3.3.2).
+const NTProofStrLength = 16
+
+// LmChallengeResponseLength is the length in bytes of an LMv2 response: a
+// 16-byte HMAC-MD5 followed by the 8-byte client challenge. Unlike the NT
+// response it is fixed-size, and it is all zeroes when the server's TargetInfo
+// carried a timestamp.
+const LmChallengeResponseLength = 24
+
+// NTLMv2Response is a NetNTLMv2 authentication: the identity that was claimed,
+// the server challenge it answered, and the responses it carried.
+//
+// NtChallengeResponse is variable-length by construction —
+// NTProofStr(16) || blob(variable), exactly what
+// NTLMv2Ctx.ComputeNTChallengeResponse produces — where the blob holds the
+// response type, a timestamp, the client challenge and the server's TargetInfo
+// AV_PAIR list. In practice it runs from roughly 44 bytes to a few hundred, so it
+// cannot be held in a fixed-size array.
+//
+// An NtChallengeResponse of exactly 24 bytes is an NTLMv1 response rather than an
+// NTLMv2 one, and belongs in crypto/ntlmv1.NTLMv1Response, which renders the
+// different layout hashcat expects for it.
 type NTLMv2Response struct {
 	Username string // Username for authentication
 	Domain   string // Domain name
 
-	ServerChallenge     [8]byte  // 8-byte challenge from server
-	LmChallengeResponse [24]byte // 24-byte LM challenge response
-	NtChallengeResponse [24]byte // 24-byte NT challenge response
+	ServerChallenge     [8]byte  // 8-byte challenge from the server
+	LmChallengeResponse [24]byte // 24-byte LMv2 challenge response
+	NtChallengeResponse []byte   // NTProofStr(16) || blob(variable)
 }
 
-// NewNTLMv2Response creates a new NTLMv2 response
+// NewNTLMv2Response creates a new NTLMv2 response.
 //
 // Parameters:
 //   - username: The username
 //   - domain: The domain name
 //   - serverChallenge: The 8-byte server challenge
-//   - lmChallengeResponse: The 24-byte LM challenge response
-func NewNTLMv2Response(username, domain string, serverChallenge [8]byte, lmChallengeResponse [24]byte, ntChallengeResponse [24]byte) *NTLMv2Response {
+//   - lmChallengeResponse: The 24-byte LMv2 challenge response
+//   - ntChallengeResponse: The NT challenge response, NTProofStr(16) || blob
+//
+// Returns:
+//   - A pointer to the new NTLMv2Response
+func NewNTLMv2Response(username, domain string, serverChallenge [8]byte, lmChallengeResponse [24]byte, ntChallengeResponse []byte) *NTLMv2Response {
+	// Copy the response so a caller reusing its buffer cannot mutate what was
+	// captured here.
+	nt := make([]byte, len(ntChallengeResponse))
+	copy(nt, ntChallengeResponse)
+
 	return &NTLMv2Response{
 		Username:            username,
 		Domain:              domain,
 		ServerChallenge:     serverChallenge,
 		LmChallengeResponse: lmChallengeResponse,
-		NtChallengeResponse: ntChallengeResponse,
+		NtChallengeResponse: nt,
 	}
 }
 
-// HashcatString converts the NTLMv2 response to a Hashcat string
+// NTProofStr returns the 16-byte NTProofStr prefix of the NT challenge response,
+// or nil when the response is too short to carry one.
 //
 // Returns:
-//   - The Hashcat string
-//   - An error if the conversion fails
+//   - The NTProofStr, or nil
+func (r *NTLMv2Response) NTProofStr() []byte {
+	if len(r.NtChallengeResponse) < NTProofStrLength {
+		return nil
+	}
+	return r.NtChallengeResponse[:NTProofStrLength]
+}
+
+// Blob returns the variable-length blob that follows the NTProofStr in the NT
+// challenge response, or nil when the response is too short to carry one. The
+// blob is what the NTProofStr is computed over, together with the server
+// challenge, so cracking needs both.
+//
+// Returns:
+//   - The blob, or nil
+func (r *NTLMv2Response) Blob() []byte {
+	if len(r.NtChallengeResponse) <= NTProofStrLength {
+		return nil
+	}
+	return r.NtChallengeResponse[NTProofStrLength:]
+}
+
+// HashcatString renders the response in the format hashcat mode 5600 expects:
+//
+//	username::domain:serverchallenge:ntproofstr:blob
+//
+// The hex is uppercased for consistency with the rest of this repository;
+// hashcat parses hex case-insensitively.
+//
+// Returns:
+//   - The hashcat string
+//   - An error if the NT challenge response cannot form a mode-5600 line
 func (r *NTLMv2Response) HashcatString() (string, error) {
+	ntProofStr := r.NTProofStr()
+	if ntProofStr == nil {
+		return "", fmt.Errorf("NT challenge response is %d bytes, too short to carry the %d-byte NTProofStr",
+			len(r.NtChallengeResponse), NTProofStrLength)
+	}
+
+	blob := r.Blob()
+	if len(blob) == 0 {
+		// A response that is exactly the NTProofStr has no blob, and a mode-5600
+		// line with an empty final field is not crackable. Report that rather
+		// than emitting a malformed line.
+		return "", fmt.Errorf("NT challenge response carries no blob after the NTProofStr")
+	}
+
 	hashcatString := fmt.Sprintf(
 		"%s::%s:%s:%s:%s",
 		r.Username,
 		r.Domain,
 		strings.ToUpper(hex.EncodeToString(r.ServerChallenge[:])),
-		strings.ToUpper(hex.EncodeToString(r.LmChallengeResponse[:])),
-		strings.ToUpper(hex.EncodeToString(r.NtChallengeResponse[:])),
+		strings.ToUpper(hex.EncodeToString(ntProofStr)),
+		strings.ToUpper(hex.EncodeToString(blob)),
 	)
 
 	return hashcatString, nil
 }
 
-// String returns the NTLMv2 response as a string
+// String returns the NTLMv2 response in hashcat mode 5600 form, or the empty
+// string when it cannot be rendered.
 //
 // Returns:
-//   - The NTLMv2 response as a string
-//   - An error if the conversion fails
+//   - The hashcat string, or ""
 func (r *NTLMv2Response) String() string {
 	hashcatString, err := r.HashcatString()
 	if err != nil {

--- a/crypto/ntlmv2/ntlmv2_response_test.go
+++ b/crypto/ntlmv2/ntlmv2_response_test.go
@@ -1,0 +1,285 @@
+package ntlmv2
+
+import (
+	"bytes"
+	"encoding/hex"
+	"strings"
+	"testing"
+)
+
+// mustDecodeHex decodes a hex literal in a test, failing rather than returning.
+func mustDecodeHex(t *testing.T, s string) []byte {
+	t.Helper()
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		t.Fatalf("bad hex %q: %v", s, err)
+	}
+	return b
+}
+
+// The published hashcat example hash for mode 5600, split into its fields. It is
+// the authoritative statement of the layout, so reproducing it exactly is the
+// strongest available check that the renderer is right.
+//
+// Source: https://hashcat.net/wiki/doku.php?id=example_hashes
+const (
+	exampleUsername        = "admin"
+	exampleDomain          = "N46iSNekpT"
+	exampleServerChallenge = "08ca45b7d7ea58ee"
+	exampleNTProofStr      = "88dcbe4446168966a153a0064958dac6"
+	exampleBlob            = "5c7830315c7830310000000000000b45c67103d07d7b95acd12ffa11230e0000000052920b85f78d013c31cdb3b92f5d765c783030"
+	exampleHash            = exampleUsername + "::" + exampleDomain + ":" + exampleServerChallenge + ":" + exampleNTProofStr + ":" + exampleBlob
+)
+
+// TestHashcatStringMatchesPublishedExample asserts the renderer reproduces the
+// published mode-5600 example hash byte for byte, which pins both the field
+// order and the field contents.
+//
+// The previous implementation emitted the server challenge followed by the LM and
+// NT responses, which is neither the mode-5600 layout nor the mode-5500 one, so
+// nothing it produced for an NTLMv2 capture was crackable.
+func TestHashcatStringMatchesPublishedExample(t *testing.T) {
+	var serverChallenge [8]byte
+	copy(serverChallenge[:], mustDecodeHex(t, exampleServerChallenge))
+
+	ntChallengeResponse := append(mustDecodeHex(t, exampleNTProofStr), mustDecodeHex(t, exampleBlob)...)
+
+	response := NewNTLMv2Response(exampleUsername, exampleDomain, serverChallenge, [24]byte{}, ntChallengeResponse)
+
+	got, err := response.HashcatString()
+	if err != nil {
+		t.Fatalf("HashcatString() error = %v", err)
+	}
+	// The renderer uppercases hex; hashcat parses it case-insensitively, so the
+	// comparison is too.
+	if !strings.EqualFold(got, exampleHash) {
+		t.Fatalf("HashcatString() =\n  %s\nwant (any case)\n  %s", got, exampleHash)
+	}
+}
+
+// TestHashcatStringFieldLayout asserts the rendered line has exactly the fields
+// mode 5600 defines, in order, with the lengths each one is fixed at.
+func TestHashcatStringFieldLayout(t *testing.T) {
+	var serverChallenge [8]byte
+	copy(serverChallenge[:], mustDecodeHex(t, exampleServerChallenge))
+	ntChallengeResponse := append(mustDecodeHex(t, exampleNTProofStr), mustDecodeHex(t, exampleBlob)...)
+
+	response := NewNTLMv2Response("user", "DOMAIN", serverChallenge, [24]byte{}, ntChallengeResponse)
+	line, err := response.HashcatString()
+	if err != nil {
+		t.Fatalf("HashcatString() error = %v", err)
+	}
+
+	fields := strings.Split(line, ":")
+	if len(fields) != 6 {
+		t.Fatalf("line has %d colon-separated fields, want 6 (the second is empty): %q", len(fields), line)
+	}
+	if fields[0] != "user" {
+		t.Fatalf("field 1 (username) = %q", fields[0])
+	}
+	if fields[1] != "" {
+		t.Fatalf("field 2 should be empty, got %q", fields[1])
+	}
+	if fields[2] != "DOMAIN" {
+		t.Fatalf("field 3 (domain) = %q", fields[2])
+	}
+	if len(fields[3]) != 16 {
+		t.Fatalf("field 4 (server challenge) is %d hex chars, want 16 (8 bytes): %q", len(fields[3]), fields[3])
+	}
+	if len(fields[4]) != NTProofStrLength*2 {
+		t.Fatalf("field 5 (NTProofStr) is %d hex chars, want %d (%d bytes): %q",
+			len(fields[4]), NTProofStrLength*2, NTProofStrLength, fields[4])
+	}
+	if len(fields[5]) != len(exampleBlob) {
+		t.Fatalf("field 6 (blob) is %d hex chars, want %d", len(fields[5]), len(exampleBlob))
+	}
+}
+
+// TestHashcatStringFromComputedResponse renders a response computed by this
+// package from the official [MS-NLMP] 4.2.4 worked example, tying the renderer to
+// the spec vector rather than only to a hand-assembled line.
+func TestHashcatStringFromComputedResponse(t *testing.T) {
+	var serverChallenge, clientChallenge [8]byte
+	copy(serverChallenge[:], mustDecodeHex(t, "0123456789abcdef"))
+	copy(clientChallenge[:], mustDecodeHex(t, "aaaaaaaaaaaaaaaa"))
+
+	ctx, err := NewNTLMv2CtxWithPassword("Domain", "User", "Password", serverChallenge, clientChallenge)
+	if err != nil {
+		t.Fatalf("NewNTLMv2CtxWithPassword() error = %v", err)
+	}
+
+	// [MS-NLMP] 4.2.4.1.3 ServerName, as used by the existing vectors test.
+	targetInfo := mustDecodeHex(t, "02000c0044006f006d00610069006e0001000c005300650072007600650072000000000000000000")
+	ntChallengeResponse, ntProofStr, err := ctx.ComputeNTChallengeResponse(make([]byte, 8), targetInfo)
+	if err != nil {
+		t.Fatalf("ComputeNTChallengeResponse() error = %v", err)
+	}
+
+	response := NewNTLMv2Response("User", "Domain", serverChallenge, [24]byte{}, ntChallengeResponse)
+
+	// The NTProofStr the accessor reports must be the one the computation
+	// produced, and the one [MS-NLMP] 4.2.4.2.2 publishes.
+	if !bytes.Equal(response.NTProofStr(), ntProofStr) {
+		t.Fatalf("NTProofStr() = %x, want %x", response.NTProofStr(), ntProofStr)
+	}
+	if got := hex.EncodeToString(response.NTProofStr()); got != "68cd0ab851e51c96aabc927bebef6a1c" {
+		t.Fatalf("NTProofStr() = %s, want the MS-NLMP 4.2.4 value 68cd0ab851e51c96aabc927bebef6a1c", got)
+	}
+
+	line, err := response.HashcatString()
+	if err != nil {
+		t.Fatalf("HashcatString() error = %v", err)
+	}
+	fields := strings.Split(line, ":")
+	if len(fields) != 6 {
+		t.Fatalf("line has %d fields, want 6: %q", len(fields), line)
+	}
+	if !strings.EqualFold(fields[3], "0123456789abcdef") {
+		t.Fatalf("server challenge field = %q, want the vector's 0123456789abcdef", fields[3])
+	}
+	if !strings.EqualFold(fields[4], "68cd0ab851e51c96aabc927bebef6a1c") {
+		t.Fatalf("NTProofStr field = %q, want 68cd0ab851e51c96aabc927bebef6a1c", fields[4])
+	}
+	// Reassembling fields 5 and 6 must give back the whole NT response.
+	reassembled := mustDecodeHex(t, fields[4]+fields[5])
+	if !bytes.Equal(reassembled, ntChallengeResponse) {
+		t.Fatalf("NTProofStr||blob does not reassemble to the NT challenge response")
+	}
+}
+
+// TestVariableLengthResponseIsPreserved asserts a realistic NT challenge response
+// is held whole. The field was a fixed [24]byte, which could not represent one at
+// all: a real response is the 16-byte NTProofStr plus a blob that is itself at
+// least 28 bytes before the TargetInfo is appended.
+func TestVariableLengthResponseIsPreserved(t *testing.T) {
+	ntChallengeResponse := append(mustDecodeHex(t, exampleNTProofStr), mustDecodeHex(t, exampleBlob)...)
+	if len(ntChallengeResponse) <= 24 {
+		t.Fatalf("the test vector is only %d bytes, so it does not exercise the variable length", len(ntChallengeResponse))
+	}
+
+	response := NewNTLMv2Response("user", "DOMAIN", [8]byte{}, [24]byte{}, ntChallengeResponse)
+
+	if len(response.NtChallengeResponse) != len(ntChallengeResponse) {
+		t.Fatalf("stored response is %d bytes, want %d", len(response.NtChallengeResponse), len(ntChallengeResponse))
+	}
+	if !bytes.Equal(response.NtChallengeResponse, ntChallengeResponse) {
+		t.Fatal("stored response does not match what was supplied")
+	}
+	if got := len(response.NTProofStr()); got != NTProofStrLength {
+		t.Fatalf("NTProofStr() is %d bytes, want %d", got, NTProofStrLength)
+	}
+	if got, want := len(response.Blob()), len(ntChallengeResponse)-NTProofStrLength; got != want {
+		t.Fatalf("Blob() is %d bytes, want %d", got, want)
+	}
+	if !bytes.Equal(response.Blob(), mustDecodeHex(t, exampleBlob)) {
+		t.Fatal("Blob() does not match the blob that was supplied")
+	}
+}
+
+// TestConstructorCopiesResponse asserts the constructor does not alias the
+// caller's slice, so a caller reusing a receive buffer cannot silently rewrite a
+// response that has already been recorded.
+func TestConstructorCopiesResponse(t *testing.T) {
+	ntChallengeResponse := append(mustDecodeHex(t, exampleNTProofStr), mustDecodeHex(t, exampleBlob)...)
+	original := append([]byte(nil), ntChallengeResponse...)
+
+	response := NewNTLMv2Response("user", "DOMAIN", [8]byte{}, [24]byte{}, ntChallengeResponse)
+
+	// Scribble over the caller's buffer.
+	for i := range ntChallengeResponse {
+		ntChallengeResponse[i] = 0xAA
+	}
+
+	if !bytes.Equal(response.NtChallengeResponse, original) {
+		t.Fatal("mutating the caller's slice changed the stored response")
+	}
+}
+
+// TestHashcatStringRejectsUnrenderableResponses asserts a response that cannot
+// form a mode-5600 line is reported as an error rather than producing a malformed
+// line or slicing past the end of the buffer.
+func TestHashcatStringRejectsUnrenderableResponses(t *testing.T) {
+	cases := []struct {
+		name                string
+		ntChallengeResponse []byte
+	}{
+		{"nil", nil},
+		{"empty", []byte{}},
+		{"one byte short of the NTProofStr", make([]byte, NTProofStrLength-1)},
+		{"exactly the NTProofStr, no blob", make([]byte, NTProofStrLength)},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			response := NewNTLMv2Response("user", "DOMAIN", [8]byte{}, [24]byte{}, tc.ntChallengeResponse)
+
+			line, err := response.HashcatString()
+			if err == nil {
+				t.Fatalf("HashcatString() returned %q, want an error", line)
+			}
+			if line != "" {
+				t.Fatalf("HashcatString() returned %q alongside an error, want the empty string", line)
+			}
+			if got := response.String(); got != "" {
+				t.Fatalf("String() = %q, want the empty string when the line cannot be rendered", got)
+			}
+		})
+	}
+}
+
+// TestAccessorsOnShortResponse asserts the accessors report absence rather than
+// panicking on a response too short to carry what is asked for.
+func TestAccessorsOnShortResponse(t *testing.T) {
+	short := NewNTLMv2Response("user", "DOMAIN", [8]byte{}, [24]byte{}, make([]byte, NTProofStrLength-1))
+	if got := short.NTProofStr(); got != nil {
+		t.Fatalf("NTProofStr() = %x on a short response, want nil", got)
+	}
+	if got := short.Blob(); got != nil {
+		t.Fatalf("Blob() = %x on a short response, want nil", got)
+	}
+
+	exact := NewNTLMv2Response("user", "DOMAIN", [8]byte{}, [24]byte{}, make([]byte, NTProofStrLength))
+	if got := exact.NTProofStr(); len(got) != NTProofStrLength {
+		t.Fatalf("NTProofStr() is %d bytes on an exact-length response, want %d", len(got), NTProofStrLength)
+	}
+	if got := exact.Blob(); got != nil {
+		t.Fatalf("Blob() = %x when there is nothing after the NTProofStr, want nil", got)
+	}
+}
+
+// TestStringRendersTheHashcatLine asserts String is the hashcat line when one can
+// be rendered, which is what makes the type printable straight into an output
+// file.
+func TestStringRendersTheHashcatLine(t *testing.T) {
+	var serverChallenge [8]byte
+	copy(serverChallenge[:], mustDecodeHex(t, exampleServerChallenge))
+	ntChallengeResponse := append(mustDecodeHex(t, exampleNTProofStr), mustDecodeHex(t, exampleBlob)...)
+
+	response := NewNTLMv2Response(exampleUsername, exampleDomain, serverChallenge, [24]byte{}, ntChallengeResponse)
+
+	line, err := response.HashcatString()
+	if err != nil {
+		t.Fatalf("HashcatString() error = %v", err)
+	}
+	if got := response.String(); got != line {
+		t.Fatalf("String() = %q, want the hashcat line %q", got, line)
+	}
+}
+
+// TestHashcatModeIsNetNTLMv2 guards the mode number a caller labels captured
+// material with. A NetNTLMv2 response written under mode 5500 is unusable.
+func TestHashcatModeIsNetNTLMv2(t *testing.T) {
+	if HashcatMode != 5600 {
+		t.Fatalf("HashcatMode = %d, want 5600 for NetNTLMv2", HashcatMode)
+	}
+}
+
+// TestLengthConstants guards the two fixed lengths the layout depends on.
+func TestLengthConstants(t *testing.T) {
+	if NTProofStrLength != 16 {
+		t.Fatalf("NTProofStrLength = %d, want 16", NTProofStrLength)
+	}
+	if LmChallengeResponseLength != 24 {
+		t.Fatalf("LmChallengeResponseLength = %d, want 24", LmChallengeResponseLength)
+	}
+}


### PR DESCRIPTION
### Summary

Commit 3 of 12 for #1068. **Independent of the other commits** — it touches only `crypto/ntlmv1` and `crypto/ntlmv2`, so it targets `main` directly and can merge in any order relative to #1069 and #1070.

`NTLMv2Response.NtChallengeResponse` was a fixed `[24]byte`, but an NTLMv2 NT challenge response is `NTProofStr(16) || blob(variable)` — exactly what `NTLMv2Ctx.ComputeNTChallengeResponse` in this same package returns, where the blob carries the response type, a timestamp, the client challenge and the server's TargetInfo. A real response runs from roughly 44 bytes to a few hundred, so the field could not represent one at all.

`HashcatString` compounded it by emitting the server challenge followed by the LM and NT responses. That is **neither** the mode-5600 layout NetNTLMv2 uses **nor** the mode-5500 layout NetNTLMv1 uses, so nothing the type produced for an NTLMv2 capture was crackable.

### The two layouts

Verified against the published example hashes:

| Mode | Layout |
|---|---|
| 5500 (NetNTLMv1) | `user::domain:LM:NT:`**`challenge`** — challenge **last** |
| 5600 (NetNTLMv2) | `user::domain:`**`challenge`**`:NTProofStr:blob` — challenge **before** the proof |

The old v2 renderer produced `user::domain:challenge:LM:NT` — the challenge in the v2 position, the trailing fields in the v1 sense.

### Changes

- `NtChallengeResponse` becomes `[]byte`, and the constructor **copies** it, so a caller reusing a receive buffer cannot rewrite a response already recorded.
- `NTProofStr()` and `Blob()` split the response, reporting absence rather than slicing past the end of a short buffer.
- `HashcatString` emits the mode-5600 layout, and returns an error for a response that cannot form one rather than emitting a malformed line.
- `HashcatMode` records the mode number in **each** package (5500 / 5600), so a caller writing captured material to a file labels it correctly instead of hardcoding a number at the call site.

Nothing outside these two packages referenced the types, so the signature change breaks no caller.

`crypto/ntlmv1` needed **no correction**: it already put the challenge last, and `ntlmv1_ctx_test.go` already asserted that layout against a computed expectation. Added alongside it are a pin to the published mode-5500 example and a guard on the new constant — the v1/v2 layouts differing in exactly this way is where the original defect came from, so both sides are now pinned to the published references.

### Testing

`go build ./...`, `go vet ./...` and `go test ./...` green across the repository.

- **Reproduces the published mode-5600 example hash byte for byte**, which pins both field order and field contents.
- **Renders a response computed from the official [MS-NLMP] 4.2.4 worked example** and checks the NTProofStr field against the published `68cd0ab851e51c96aabc927bebef6a1c`, with NTProofStr and blob reassembling to the whole response.
- Field count and the fixed field widths (16 hex chars of challenge, 32 of NTProofStr).
- A realistic variable-length response is preserved whole — the case the old fixed array could not represent.
- The constructor does not alias the caller's slice.
- Rejects a nil, empty, one-byte-short, and exactly-the-NTProofStr response, with `String()` returning empty rather than a malformed line.
- The v1 side: the published mode-5500 example, asserting the challenge is the last field.

### Notes

This is a prerequisite for the credential-capture handler in commit 5: capture is the reason the type exists, and until this fix the captured material was unusable.