### PR TITLE
Add the NTLM acceptor side to SPNEGO (Refs #1068)

### DIFF
--- a/crypto/ntlmv2/verify.go
+++ b/crypto/ntlmv2/verify.go
@@ -1,0 +1,68 @@
+package ntlmv2
+
+import (
+	"crypto/hmac"
+	"crypto/md5"
+)
+
+// VerifyNTChallengeResponse reports whether an NTLMv2 NT challenge response was
+// produced by a party holding responseKeyNT.
+//
+// It is the acceptor-side counterpart of ComputeNTChallengeResponse. The two
+// cannot share an implementation: the computing side builds the blob itself from
+// a timestamp and a TargetInfo, whereas a verifier is handed a blob the client
+// chose and must recompute the proof over exactly those bytes. Reconstructing the
+// blob instead would reject every legitimate client whose blob differs in any
+// detail from the one this implementation would have built.
+//
+//	NTProofStr = HMAC_MD5(ResponseKeyNT, ServerChallenge || blob)
+//
+// where the response is NTProofStr(16) || blob(variable) ([MS-NLMP] 3.3.2). The
+// comparison is constant-time.
+//
+// Parameters:
+//   - responseKeyNT: the NTOWFv2 for the claimed identity, as computed by
+//     NewNTLMv2CtxWithNTHash
+//   - serverChallenge: the 8-byte challenge the response answers
+//   - ntChallengeResponse: the response as received, NTProofStr(16) || blob
+//
+// Returns:
+//   - true when the response verifies against responseKeyNT
+func VerifyNTChallengeResponse(responseKeyNT []byte, serverChallenge [8]byte, ntChallengeResponse []byte) bool {
+	// A response with no blob cannot be verified: there is nothing for the proof
+	// to have been taken over, and an empty-blob proof is not something any
+	// client produces.
+	if len(responseKeyNT) == 0 || len(ntChallengeResponse) <= NTProofStrLength {
+		return false
+	}
+
+	ntProofStr := ntChallengeResponse[:NTProofStrLength]
+	blob := ntChallengeResponse[NTProofStrLength:]
+
+	mac := hmac.New(md5.New, responseKeyNT)
+	mac.Write(serverChallenge[:])
+	mac.Write(blob)
+
+	return hmac.Equal(ntProofStr, mac.Sum(nil))
+}
+
+// SessionBaseKeyFromResponse derives the SessionBaseKey for a verified NTLMv2
+// response: HMAC_MD5(ResponseKeyNT, NTProofStr) ([MS-NLMP] 3.3.2). It is the
+// acceptor's route to the key material, taking the NTProofStr from the response
+// as received rather than from a computation of its own.
+//
+// Parameters:
+//   - responseKeyNT: the NTOWFv2 for the claimed identity
+//   - ntChallengeResponse: the response as received, NTProofStr(16) || blob
+//
+// Returns:
+//   - The 16-byte SessionBaseKey, or nil if the response carries no NTProofStr
+func SessionBaseKeyFromResponse(responseKeyNT []byte, ntChallengeResponse []byte) []byte {
+	if len(responseKeyNT) == 0 || len(ntChallengeResponse) < NTProofStrLength {
+		return nil
+	}
+
+	mac := hmac.New(md5.New, responseKeyNT)
+	mac.Write(ntChallengeResponse[:NTProofStrLength])
+	return mac.Sum(nil)
+}

--- a/crypto/ntlmv2/verify_test.go
+++ b/crypto/ntlmv2/verify_test.go
@@ -1,0 +1,147 @@
+package ntlmv2
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+)
+
+// msnlmpVector returns the [MS-NLMP] 4.2.4 worked example: the context, the full
+// NT challenge response and its NTProofStr.
+func msnlmpVector(t *testing.T) (*NTLMv2Ctx, []byte, []byte) {
+	t.Helper()
+
+	decode := func(s string) []byte {
+		b, err := hex.DecodeString(s)
+		if err != nil {
+			t.Fatalf("bad hex %q: %v", s, err)
+		}
+		return b
+	}
+
+	var serverChallenge, clientChallenge [8]byte
+	copy(serverChallenge[:], decode("0123456789abcdef"))
+	copy(clientChallenge[:], decode("aaaaaaaaaaaaaaaa"))
+
+	ctx, err := NewNTLMv2CtxWithPassword("Domain", "User", "Password", serverChallenge, clientChallenge)
+	if err != nil {
+		t.Fatalf("NewNTLMv2CtxWithPassword() error = %v", err)
+	}
+
+	targetInfo := decode("02000c0044006f006d00610069006e0001000c005300650072007600650072000000000000000000")
+	ntResponse, ntProofStr, err := ctx.ComputeNTChallengeResponse(make([]byte, 8), targetInfo)
+	if err != nil {
+		t.Fatalf("ComputeNTChallengeResponse() error = %v", err)
+	}
+
+	return ctx, ntResponse, ntProofStr
+}
+
+// TestVerifyNTChallengeResponseAcceptsTheSpecVector asserts a response computed
+// from the [MS-NLMP] 4.2.4 worked example verifies, tying the acceptor-side check
+// to the same published vector the computing side is checked against.
+func TestVerifyNTChallengeResponseAcceptsTheSpecVector(t *testing.T) {
+	ctx, ntResponse, ntProofStr := msnlmpVector(t)
+
+	// Guard the vector itself, so a failure below is about verification rather
+	// than about the response having changed.
+	if got := hex.EncodeToString(ntProofStr); got != "68cd0ab851e51c96aabc927bebef6a1c" {
+		t.Fatalf("NTProofStr = %s, want the MS-NLMP 4.2.4 value 68cd0ab851e51c96aabc927bebef6a1c", got)
+	}
+
+	if !VerifyNTChallengeResponse(ctx.ResponseKeyNT[:], ctx.ServerChallenge, ntResponse) {
+		t.Fatal("VerifyNTChallengeResponse() rejected the response computed from the spec vector")
+	}
+}
+
+// TestVerifyNTChallengeResponseRejects asserts every way a response can be wrong
+// is rejected. The verifier is what stands between an acceptor and an attacker who
+// does not hold the credential, so a false accept is the worst outcome available.
+func TestVerifyNTChallengeResponseRejects(t *testing.T) {
+	ctx, ntResponse, _ := msnlmpVector(t)
+	key := ctx.ResponseKeyNT[:]
+
+	t.Run("wrong response key", func(t *testing.T) {
+		wrong := append([]byte(nil), key...)
+		wrong[0] ^= 0x01
+		if VerifyNTChallengeResponse(wrong, ctx.ServerChallenge, ntResponse) {
+			t.Fatal("accepted a response under the wrong response key")
+		}
+	})
+
+	t.Run("wrong server challenge", func(t *testing.T) {
+		other := ctx.ServerChallenge
+		other[0] ^= 0x01
+		if VerifyNTChallengeResponse(key, other, ntResponse) {
+			t.Fatal("accepted a response against a different challenge, so a captured response could be replayed")
+		}
+	})
+
+	t.Run("tampered NTProofStr", func(t *testing.T) {
+		tampered := append([]byte(nil), ntResponse...)
+		tampered[0] ^= 0x01
+		if VerifyNTChallengeResponse(key, ctx.ServerChallenge, tampered) {
+			t.Fatal("accepted a response with a modified NTProofStr")
+		}
+	})
+
+	t.Run("tampered blob", func(t *testing.T) {
+		// A modified blob must invalidate the proof: the blob carries the
+		// timestamp and the TargetInfo, so accepting a changed one would let a
+		// client rewrite what it committed to.
+		tampered := append([]byte(nil), ntResponse...)
+		tampered[len(tampered)-1] ^= 0x01
+		if VerifyNTChallengeResponse(key, ctx.ServerChallenge, tampered) {
+			t.Fatal("accepted a response with a modified blob")
+		}
+	})
+
+	t.Run("degenerate inputs", func(t *testing.T) {
+		cases := []struct {
+			name       string
+			key        []byte
+			ntResponse []byte
+		}{
+			{"nil key", nil, ntResponse},
+			{"empty key", []byte{}, ntResponse},
+			{"nil response", key, nil},
+			{"response with no blob", key, ntResponse[:NTProofStrLength]},
+			{"response shorter than the NTProofStr", key, ntResponse[:NTProofStrLength-1]},
+		}
+		for _, tc := range cases {
+			tc := tc
+			t.Run(tc.name, func(t *testing.T) {
+				if VerifyNTChallengeResponse(tc.key, ctx.ServerChallenge, tc.ntResponse) {
+					t.Fatal("accepted a degenerate input")
+				}
+			})
+		}
+	})
+}
+
+// TestSessionBaseKeyFromResponse asserts the acceptor's route to the
+// SessionBaseKey agrees with the computing side's. The two start from different
+// places — one from a response as received, the other from a proof it computed —
+// so a disagreement would leave the two ends of an exchange with different keys.
+func TestSessionBaseKeyFromResponse(t *testing.T) {
+	ctx, ntResponse, ntProofStr := msnlmpVector(t)
+
+	fromResponse := SessionBaseKeyFromResponse(ctx.ResponseKeyNT[:], ntResponse)
+	fromComputation := ctx.ComputeSessionBaseKey(ntProofStr)
+
+	if !bytes.Equal(fromResponse, fromComputation) {
+		t.Fatalf("SessionBaseKeyFromResponse = %x, ComputeSessionBaseKey = %x", fromResponse, fromComputation)
+	}
+	// The [MS-NLMP] 4.2.4.2.2 published SessionBaseKey.
+	if got := hex.EncodeToString(fromResponse); got != "8de40ccadbc14a82f15cb0ad0de95ca3" {
+		t.Fatalf("SessionBaseKey = %s, want the MS-NLMP 4.2.4 value 8de40ccadbc14a82f15cb0ad0de95ca3", got)
+	}
+
+	// Degenerate inputs report absence rather than a short or wrong key.
+	if got := SessionBaseKeyFromResponse(nil, ntResponse); got != nil {
+		t.Fatalf("SessionBaseKeyFromResponse() with no key = %x, want nil", got)
+	}
+	if got := SessionBaseKeyFromResponse(ctx.ResponseKeyNT[:], ntResponse[:NTProofStrLength-1]); got != nil {
+		t.Fatalf("SessionBaseKeyFromResponse() with a short response = %x, want nil", got)
+	}
+}

--- a/crypto/spnego/acceptor.go
+++ b/crypto/spnego/acceptor.go
@@ -1,0 +1,455 @@
+package spnego
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/crypto/ntlmv1"
+	"github.com/TheManticoreProject/Manticore/crypto/ntlmv2"
+	"github.com/TheManticoreProject/Manticore/crypto/rc4"
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/message/authenticate"
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/message/challenge"
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/message/header"
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/message/negotiate"
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/message/negotiate/flags"
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/message/types"
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/version"
+	"github.com/TheManticoreProject/Manticore/encoding/utf16"
+)
+
+// Verification outcomes reported by AcceptContext.Verify. They are distinguished
+// because a caller acts differently on each: a capture-only acceptor expects
+// ErrCaptureOnly on every exchange, whereas a serving acceptor treats an unknown
+// identity and a wrong password the same way on the wire but wants them apart in
+// its logs.
+var (
+	// ErrCaptureOnly reports that the AUTHENTICATE was recorded but not verified,
+	// because no CredentialLookup is configured. The captured material is
+	// available regardless; this is the expected outcome for an acceptor whose
+	// purpose is to harvest responses rather than to serve.
+	ErrCaptureOnly = errors.New("spnego: authenticate recorded but not verified, no credential lookup configured")
+
+	// ErrNoAuthenticate reports that Verify was called before an AUTHENTICATE was
+	// accepted.
+	ErrNoAuthenticate = errors.New("spnego: no AUTHENTICATE message has been accepted")
+
+	// ErrUnknownIdentity reports that CredentialLookup had no credential for the
+	// identity the client claimed.
+	ErrUnknownIdentity = errors.New("spnego: no credential for the claimed identity")
+
+	// ErrBadResponse reports that the NT challenge response did not verify
+	// against the credential, which is what a wrong password looks like.
+	ErrBadResponse = errors.New("spnego: NT challenge response did not verify")
+
+	// ErrBadMIC reports that the NT challenge response verified but the message
+	// integrity code did not, meaning the exchange was tampered with in flight.
+	ErrBadMIC = errors.New("spnego: AUTHENTICATE message integrity code did not verify")
+)
+
+// AcceptContext is the acceptor side of an NTLM authentication carried over
+// SPNEGO: the counterpart of AuthContext, which initiates one.
+//
+// The exchange is two calls. AcceptNegotiateToken consumes the client's
+// NEGOTIATE and returns the CHALLENGE to send back. AcceptAuthenticateToken
+// consumes the client's AUTHENTICATE and records it. Verification is a separate
+// step, so an acceptor that only wants to harvest responses never has to hold a
+// credential, while one that serves calls Verify to decide.
+//
+// A context handles one exchange and is not safe for concurrent use.
+type AcceptContext struct {
+	// TargetName is the name advertised in the CHALLENGE. Leaving it empty omits
+	// it, which a client is entitled to refuse.
+	TargetName string
+
+	// TargetType declares whether TargetName names a domain or a server.
+	TargetType challenge.TargetType
+
+	// TargetInfo is the AV_PAIR list advertised in the CHALLENGE, as built by
+	// targetinfo.BuildServerTargetInfo. A client folds these bytes into its
+	// NTLMv2 blob, so they are covered by the response and cannot be changed
+	// after the CHALLENGE is sent.
+	//
+	// Supplying an MsvAvTimestamp here obliges the client to carry a MIC, which
+	// Verify then checks; omit it if the acceptor would rather not require one.
+	TargetInfo []byte
+
+	// ServerChallenge is the 8-byte nonce. The zero value means generate one from
+	// the system's cryptographic random source when the CHALLENGE is built, which
+	// is what an acceptor should normally do: a predictable or reused challenge
+	// lets a captured response be replayed.
+	ServerChallenge [8]byte
+
+	// Version is advertised in the CHALLENGE. Nil omits it.
+	Version *version.Version
+
+	// CredentialLookup resolves a claimed identity to the account's NT hash.
+	// Returning false means the identity is unknown.
+	//
+	// Nil makes the acceptor capture-only: Verify records nothing further and
+	// reports ErrCaptureOnly. Holding NT hashes rather than passwords is
+	// deliberate — the hash is all that verification needs.
+	CredentialLookup func(domain, username string) (ntHash [16]byte, ok bool)
+
+	// Negotiate and NegotiateMessageBytes hold the client's NEGOTIATE, the
+	// latter because the MIC is computed over the raw message.
+	Negotiate             *negotiate.NegotiateMessage
+	NegotiateMessageBytes []byte
+
+	// Challenge and ChallengeMessageBytes hold the CHALLENGE that was issued,
+	// for the same reason.
+	Challenge             *challenge.ChallengeMessage
+	ChallengeMessageBytes []byte
+
+	// Authenticate and AuthenticateMessageBytes hold the client's AUTHENTICATE.
+	Authenticate             *authenticate.AuthenticateMessage
+	AuthenticateMessageBytes []byte
+
+	// SessionKey is the ExportedSessionKey, set by a successful Verify. It is the
+	// key a consumer uses for message signing and sealing. It stays nil until
+	// verification succeeds, because deriving it requires the credential.
+	SessionKey []byte
+
+	// Verified records whether Verify has succeeded.
+	Verified bool
+}
+
+// NewAcceptContext creates an acceptor advertising the given identity.
+//
+// Parameters:
+//   - targetName: the name to advertise in the CHALLENGE
+//   - targetType: whether targetName names a domain or a server
+//   - targetInfo: the AV_PAIR list to advertise, or nil
+//
+// Returns:
+//   - The acceptor context
+func NewAcceptContext(targetName string, targetType challenge.TargetType, targetInfo []byte) *AcceptContext {
+	return &AcceptContext{
+		TargetName: targetName,
+		TargetType: targetType,
+		TargetInfo: targetInfo,
+	}
+}
+
+// AcceptNegotiateToken consumes the client's NEGOTIATE token and returns the
+// SPNEGO token carrying the CHALLENGE to send back.
+//
+// The returned bytes are framed exactly as CreateAuthenticateTokenFromChallengeToken
+// expects to receive them: a SecurityBlob wrapping a NegTokenResp whose negState
+// is accept-incomplete and whose supportedMech is the NTLM OID.
+//
+// Parameters:
+//   - token: the client's NEGOTIATE, as a SPNEGO token or a bare NTLMSSP message
+//
+// Returns:
+//   - The SPNEGO token carrying the CHALLENGE
+//   - An error if the client's token cannot be answered
+func (ctx *AcceptContext) AcceptNegotiateToken(token []byte) ([]byte, error) {
+	inner, err := extractNTLMMessage(token)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract the NTLM NEGOTIATE message: %v", err)
+	}
+	if err := expectMessageType(inner, types.MESSAGE_TYPE_NEGOTIATE); err != nil {
+		return nil, err
+	}
+
+	negotiateMessage := &negotiate.NegotiateMessage{}
+	if _, err := negotiateMessage.Unmarshal(inner); err != nil {
+		return nil, fmt.Errorf("failed to parse the NTLM NEGOTIATE message: %v", err)
+	}
+	ctx.Negotiate = negotiateMessage
+	// The MIC is computed over the raw message, so keep the bytes as received
+	// rather than a re-marshalling of them.
+	ctx.NegotiateMessageBytes = append([]byte(nil), inner...)
+
+	// A zero challenge means one was not supplied, so generate one. Reusing a
+	// challenge across exchanges would let a response captured from one be
+	// replayed into another.
+	if ctx.ServerChallenge == ([8]byte{}) {
+		generated, err := challenge.NewServerChallenge()
+		if err != nil {
+			return nil, err
+		}
+		ctx.ServerChallenge = generated
+	}
+
+	challengeMessage, err := challenge.CreateChallengeMessage(
+		negotiateMessage, ctx.ServerChallenge, ctx.TargetName, ctx.TargetType, ctx.TargetInfo, ctx.Version)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build the NTLM CHALLENGE message: %v", err)
+	}
+
+	challengeBytes, err := challengeMessage.Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal the NTLM CHALLENGE message: %v", err)
+	}
+	ctx.Challenge = challengeMessage
+	ctx.ChallengeMessageBytes = challengeBytes
+
+	// The CHALLENGE is a continuation token: a NegTokenResp naming the mechanism
+	// and reporting that more messages are expected, wrapped in a SecurityBlob.
+	negTokenResp := NewNegTokenResp(NegStateAcceptIncomplete, NtlmOID, challengeBytes)
+	marshalledNegTokenResp, err := negTokenResp.Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal the NegTokenResp: %v", err)
+	}
+
+	securityBlob := SecurityBlob{Data: marshalledNegTokenResp}
+	marshalledSecurityBlob, err := securityBlob.Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal the SecurityBlob: %v", err)
+	}
+
+	return marshalledSecurityBlob, nil
+}
+
+// AcceptAuthenticateToken consumes the client's AUTHENTICATE token and records
+// it, without verifying anything.
+//
+// Recording and verifying are separate so that a failure to authenticate does not
+// lose the response: the material is captured whether or not a credential exists
+// to check it against. Call Verify afterwards to decide whether to honour it.
+//
+// Parameters:
+//   - token: the client's AUTHENTICATE, as a SPNEGO token or a bare NTLMSSP message
+//
+// Returns:
+//   - An error if the token cannot be parsed
+func (ctx *AcceptContext) AcceptAuthenticateToken(token []byte) error {
+	if ctx.Challenge == nil {
+		return fmt.Errorf("cannot accept an AUTHENTICATE before a CHALLENGE has been issued")
+	}
+
+	inner, err := extractNTLMMessage(token)
+	if err != nil {
+		return fmt.Errorf("failed to extract the NTLM AUTHENTICATE message: %v", err)
+	}
+	if err := expectMessageType(inner, types.MESSAGE_TYPE_AUTHENTICATE); err != nil {
+		return err
+	}
+
+	authenticateMessage := &authenticate.AuthenticateMessage{}
+	if _, err := authenticateMessage.Unmarshal(inner); err != nil {
+		return fmt.Errorf("failed to parse the NTLM AUTHENTICATE message: %v", err)
+	}
+
+	ctx.Authenticate = authenticateMessage
+	ctx.AuthenticateMessageBytes = append([]byte(nil), inner...)
+
+	return nil
+}
+
+// Verify checks the recorded AUTHENTICATE against the credential for the identity
+// it claimed, and on success derives the ExportedSessionKey.
+//
+// It reports ErrCaptureOnly when no CredentialLookup is configured,
+// ErrUnknownIdentity when the lookup has no credential, ErrBadResponse when the
+// NT response does not verify, and ErrBadMIC when the response verifies but the
+// message integrity code does not.
+//
+// Returns:
+//   - nil when the authentication is genuine, with SessionKey populated
+func (ctx *AcceptContext) Verify() error {
+	if ctx.Authenticate == nil {
+		return ErrNoAuthenticate
+	}
+	if ctx.CredentialLookup == nil {
+		return ErrCaptureOnly
+	}
+
+	domain, username, _ := ctx.Identity()
+
+	ntHash, ok := ctx.CredentialLookup(domain, username)
+	if !ok {
+		return ErrUnknownIdentity
+	}
+
+	// The identity folded into NTOWFv2 must be the one the client sent, byte for
+	// byte: NTLMv2 uppercases only the username and takes the domain as-is, so a
+	// normalized domain here would recompute a different key and reject every
+	// client whose domain was not already upper-case.
+	//
+	// The client challenge is not part of verification — it reaches the verifier
+	// inside the blob, which is hashed as received — so a zero value is passed.
+	v2, err := ntlmv2.NewNTLMv2CtxWithNTHash(domain, username, ntHash, ctx.ServerChallenge, [8]byte{})
+	if err != nil {
+		return fmt.Errorf("failed to derive the response key: %v", err)
+	}
+
+	ntResponse := ctx.Authenticate.NtChallengeResponse
+	if !ntlmv2.VerifyNTChallengeResponse(v2.ResponseKeyNT[:], ctx.ServerChallenge, ntResponse) {
+		return ErrBadResponse
+	}
+
+	sessionKey, err := ctx.exportedSessionKey(v2.ResponseKeyNT[:], ntResponse)
+	if err != nil {
+		return err
+	}
+
+	// A client that carries a MIC has committed to the whole exchange, so a
+	// mismatch means the NEGOTIATE or CHALLENGE was altered in flight even though
+	// the response itself is genuine.
+	if ctx.Authenticate.NeedsMIC {
+		if !ctx.Authenticate.VerifyMIC(sessionKey, ctx.NegotiateMessageBytes, ctx.ChallengeMessageBytes, ctx.AuthenticateMessageBytes) {
+			return ErrBadMIC
+		}
+	}
+
+	ctx.SessionKey = sessionKey
+	ctx.Verified = true
+
+	return nil
+}
+
+// exportedSessionKey derives the ExportedSessionKey for a verified response.
+//
+// For NTLMv2 the KeyExchangeKey is the SessionBaseKey ([MS-NLMP] 3.4.5.1). When
+// the client negotiated NTLMSSP_NEGOTIATE_KEY_EXCH it chose its own session key,
+// sealed it under the KeyExchangeKey with RC4 and sent it in the AUTHENTICATE, so
+// the acceptor has to unseal it ([MS-NLMP] 3.1.5.1.2); otherwise the two keys are
+// the same.
+func (ctx *AcceptContext) exportedSessionKey(responseKeyNT, ntResponse []byte) ([]byte, error) {
+	keyExchangeKey := ntlmv2.SessionBaseKeyFromResponse(responseKeyNT, ntResponse)
+	if len(keyExchangeKey) == 0 {
+		return nil, fmt.Errorf("failed to derive the session base key from the NT challenge response")
+	}
+
+	if !ctx.Authenticate.NegotiateFlags.HasFlag(flags.NTLMSSP_NEGOTIATE_KEY_EXCH) {
+		return keyExchangeKey, nil
+	}
+
+	encrypted := ctx.Authenticate.EncryptedRandomSessionKey
+	if len(encrypted) != 16 {
+		return nil, fmt.Errorf("client negotiated key exchange but sent a %d-byte EncryptedRandomSessionKey, want 16", len(encrypted))
+	}
+
+	cipher, err := rc4.NewRC4WithKey(keyExchangeKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialise RC4 for the key exchange: %v", err)
+	}
+	exported := make([]byte, len(encrypted))
+	cipher.XORKeyStream(exported, encrypted)
+
+	return exported, nil
+}
+
+// Identity reports the domain, username and workstation the client claimed in its
+// AUTHENTICATE, decoded according to the character set the exchange negotiated.
+//
+// The values are what the client asserted, not anything verified: they are
+// meaningful for a capture record before Verify runs, and remain unvalidated
+// input until it succeeds.
+//
+// Returns:
+//   - The claimed domain, username and workstation, empty if no AUTHENTICATE
+//     has been accepted
+func (ctx *AcceptContext) Identity() (domain, username, workstation string) {
+	if ctx.Authenticate == nil {
+		return "", "", ""
+	}
+
+	decode := func(b []byte) string {
+		if ctx.Authenticate.NegotiateFlags.HasFlag(flags.NTLMSSP_NEGOTIATE_UNICODE) {
+			return utf16.DecodeUTF16LE(b)
+		}
+		return string(b)
+	}
+
+	return decode(ctx.Authenticate.DomainName),
+		decode(ctx.Authenticate.UserName),
+		decode(ctx.Authenticate.Workstation)
+}
+
+// CapturedResponse renders the recorded AUTHENTICATE as a crackable response.
+//
+// Exactly one of the two is returned, chosen by the length of the NT challenge
+// response: 24 bytes is an NTLMv1 response, anything longer is NTLMv2. A response
+// that is neither yields two nils, as does a context with no AUTHENTICATE.
+//
+// Returns:
+//   - The NTLMv1 response, or nil
+//   - The NTLMv2 response, or nil
+func (ctx *AcceptContext) CapturedResponse() (*ntlmv1.NTLMv1Response, *ntlmv2.NTLMv2Response) {
+	if ctx.Authenticate == nil {
+		return nil, nil
+	}
+
+	domain, username, _ := ctx.Identity()
+	ntResponse := ctx.Authenticate.NtChallengeResponse
+
+	var lmResponse [24]byte
+	copy(lmResponse[:], ctx.Authenticate.LmChallengeResponse)
+
+	switch {
+	case len(ntResponse) == 24:
+		var nt [24]byte
+		copy(nt[:], ntResponse)
+		return ntlmv1.NewNTLMv1Response(username, domain, ctx.ServerChallenge, lmResponse, nt), nil
+
+	case len(ntResponse) > 24:
+		return nil, ntlmv2.NewNTLMv2Response(username, domain, ctx.ServerChallenge, lmResponse, ntResponse)
+	}
+
+	return nil, nil
+}
+
+// GetSessionKey returns the ExportedSessionKey derived by a successful Verify, or
+// nil if verification has not succeeded.
+//
+// Returns:
+//   - The session key, or nil
+func (ctx *AcceptContext) GetSessionKey() []byte {
+	return ctx.SessionKey
+}
+
+// extractNTLMMessage pulls the NTLMSSP message out of whatever framing a client
+// used. Three shapes appear in practice: a bare NTLMSSP message, a continuation
+// token (a SecurityBlob wrapping a NegTokenResp), and an initial token (a
+// GSS-wrapped NegTokenInit).
+func extractNTLMMessage(token []byte) ([]byte, error) {
+	if len(token) == 0 {
+		return nil, errors.New("token is empty")
+	}
+
+	// A bare NTLMSSP message needs no unwrapping.
+	if bytes.HasPrefix(token, header.NTLM_SIGNATURE[:]) {
+		return token, nil
+	}
+
+	// A continuation token: SecurityBlob wrapping a NegTokenResp.
+	blob := &SecurityBlob{}
+	if _, err := blob.Unmarshal(token); err == nil {
+		resp := NegTokenResp{}
+		if _, err := resp.Unmarshal(blob.Data); err == nil && len(resp.ResponseToken) > 0 {
+			return resp.ResponseToken, nil
+		}
+	}
+
+	// An initial token: GSS-wrapped NegTokenInit, or a GSS-wrapped NegTokenResp.
+	if inner, err := ExtractNTLMToken(token); err == nil {
+		return inner, nil
+	}
+
+	return nil, errors.New("no NTLM message found in the token")
+}
+
+// expectMessageType checks the NTLMSSP signature and message type before a
+// message is parsed, so a client cannot have one message type decoded as another.
+func expectMessageType(message []byte, want types.MessageType) error {
+	if len(message) < 12 {
+		return fmt.Errorf("NTLM message is %d bytes, too short to carry a header", len(message))
+	}
+	if !bytes.Equal(message[:8], header.NTLM_SIGNATURE[:]) {
+		return fmt.Errorf("NTLM message does not carry the NTLMSSP signature")
+	}
+
+	messageHeader := &header.Header{}
+	if _, err := messageHeader.Unmarshal(message); err != nil {
+		return fmt.Errorf("failed to parse the NTLM message header: %v", err)
+	}
+	if messageHeader.MessageType != want {
+		return fmt.Errorf("NTLM message type is %d, want %d", messageHeader.MessageType, want)
+	}
+
+	return nil
+}

--- a/crypto/spnego/acceptor_test.go
+++ b/crypto/spnego/acceptor_test.go
@@ -1,0 +1,610 @@
+package spnego
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/md5"
+	"encoding/hex"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/crypto/nt"
+	"github.com/TheManticoreProject/Manticore/crypto/ntlmv2"
+	"github.com/TheManticoreProject/Manticore/crypto/rc4"
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/avpair"
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/message/authenticate"
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/message/challenge"
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/message/negotiate/flags"
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/targetinfo"
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/version"
+)
+
+// The identity used throughout. The domain is deliberately mixed-case: NTLMv2
+// folds the domain into NTOWFv2 exactly as sent, so a verifier that normalizes it
+// rejects every client whose domain is not already upper-case.
+const (
+	testDomain      = "Lab.Example.Local"
+	testUsername    = "alice"
+	testPassword    = "Passw0rd!"
+	testWorkstation = "CLIENT01"
+)
+
+// clientNegotiateFlags are the options the initiator in this repository offers.
+const clientNegotiateFlags = flags.NTLMSSP_NEGOTIATE_UNICODE |
+	flags.NTLMSSP_NEGOTIATE_NTLM |
+	flags.NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY |
+	flags.NTLMSSP_NEGOTIATE_SIGN |
+	flags.NTLMSSP_NEGOTIATE_ALWAYS_SIGN |
+	flags.NTLMSSP_NEGOTIATE_128 |
+	flags.NTLMSSP_NEGOTIATE_56 |
+	flags.NTLMSSP_REQUEST_TARGET |
+	flags.NTLMSSP_NEGOTIATE_TARGET_INFO |
+	flags.NTLMSSP_NEGOTIATE_VERSION
+
+// serverTargetInfo builds the TargetInfo an acceptor advertises. The timestamp is
+// omitted by default so the initiator is not obliged to carry a MIC.
+func serverTargetInfo(t *testing.T, timestamp []byte) []byte {
+	t.Helper()
+	info, err := targetinfo.BuildServerTargetInfo("SERVER01", "LAB", "server01.lab.example.local", "lab.example.local", timestamp)
+	if err != nil {
+		t.Fatalf("BuildServerTargetInfo() error = %v", err)
+	}
+	return info
+}
+
+// lookupFor returns a CredentialLookup that answers for one identity, recording
+// what it was asked so a test can assert the acceptor passed the claimed identity
+// through unchanged.
+func lookupFor(domain, username, password string, asked *[2]string) func(string, string) ([16]byte, bool) {
+	return func(gotDomain, gotUsername string) ([16]byte, bool) {
+		if asked != nil {
+			*asked = [2]string{gotDomain, gotUsername}
+		}
+		if !strings.EqualFold(gotUsername, username) || gotDomain != domain {
+			return [16]byte{}, false
+		}
+		return nt.NTHash(password), true
+	}
+}
+
+// runExchange drives the initiator in this repository against the acceptor and
+// returns both, so a test can compare what the two derived.
+func runExchange(t *testing.T, ctx *AcceptContext) *AuthContext {
+	t.Helper()
+
+	client := NewAuthContext(AuthTypeNTLM, testDomain, testUsername, testPassword, testWorkstation, true)
+	v := version.DefaultVersion()
+
+	negotiateToken, err := client.CreateNegotiateToken(clientNegotiateFlags, &v)
+	if err != nil {
+		t.Fatalf("client CreateNegotiateToken() error = %v", err)
+	}
+
+	challengeToken, err := ctx.AcceptNegotiateToken(negotiateToken)
+	if err != nil {
+		t.Fatalf("AcceptNegotiateToken() error = %v", err)
+	}
+
+	authenticateToken, err := client.CreateAuthenticateTokenFromChallengeToken(challengeToken)
+	if err != nil {
+		t.Fatalf("client CreateAuthenticateTokenFromChallengeToken() error = %v", err)
+	}
+
+	if err := ctx.AcceptAuthenticateToken(authenticateToken); err != nil {
+		t.Fatalf("AcceptAuthenticateToken() error = %v", err)
+	}
+
+	return client
+}
+
+// TestAcceptorAgreesWithInitiator drives the initiator in this repository against
+// the acceptor end to end and asserts both sides derive the identical session key.
+// Agreeing on the key is the whole point: it is what a consumer signs and seals
+// with, so a mismatch would break every message after authentication.
+func TestAcceptorAgreesWithInitiator(t *testing.T) {
+	var asked [2]string
+	ctx := NewAcceptContext("LAB", challenge.TargetTypeDomain, serverTargetInfo(t, nil))
+	ctx.CredentialLookup = lookupFor(testDomain, testUsername, testPassword, &asked)
+	v := version.DefaultVersion()
+	ctx.Version = &v
+
+	client := runExchange(t, ctx)
+
+	if err := ctx.Verify(); err != nil {
+		t.Fatalf("Verify() error = %v", err)
+	}
+	if !ctx.Verified {
+		t.Fatal("Verify() succeeded but Verified is false")
+	}
+
+	clientKey := client.GetSessionKey()
+	if len(clientKey) == 0 {
+		t.Fatal("the initiator derived no session key, so there is nothing to compare")
+	}
+	if !bytes.Equal(ctx.GetSessionKey(), clientKey) {
+		t.Fatalf("session keys differ:\n  acceptor %s\n  initiator %s",
+			hex.EncodeToString(ctx.GetSessionKey()), hex.EncodeToString(clientKey))
+	}
+
+	// The identity passed to the lookup must be exactly what the client claimed,
+	// with the domain's case intact.
+	if asked[0] != testDomain {
+		t.Fatalf("lookup was asked for domain %q, want %q", asked[0], testDomain)
+	}
+	if asked[1] != testUsername {
+		t.Fatalf("lookup was asked for username %q, want %q", asked[1], testUsername)
+	}
+}
+
+// TestAcceptorIdentityAndCapture asserts the claimed identity is decoded and the
+// response is rendered as crackable NetNTLMv2 material, which is what an acceptor
+// that only harvests responses needs.
+func TestAcceptorIdentityAndCapture(t *testing.T) {
+	ctx := NewAcceptContext("LAB", challenge.TargetTypeDomain, serverTargetInfo(t, nil))
+	runExchange(t, ctx)
+
+	domain, username, workstation := ctx.Identity()
+	if domain != testDomain {
+		t.Fatalf("domain = %q, want %q", domain, testDomain)
+	}
+	if username != testUsername {
+		t.Fatalf("username = %q, want %q", username, testUsername)
+	}
+	if !strings.EqualFold(workstation, testWorkstation) {
+		t.Fatalf("workstation = %q, want %q", workstation, testWorkstation)
+	}
+
+	v1, v2 := ctx.CapturedResponse()
+	if v1 != nil {
+		t.Fatalf("an NTLMv2 exchange yielded an NTLMv1 response: %v", v1)
+	}
+	if v2 == nil {
+		t.Fatal("CapturedResponse() returned no NTLMv2 response")
+	}
+
+	line, err := v2.HashcatString()
+	if err != nil {
+		t.Fatalf("HashcatString() error = %v", err)
+	}
+	fields := strings.Split(line, ":")
+	if len(fields) != 6 {
+		t.Fatalf("hashcat line has %d fields, want 6: %q", len(fields), line)
+	}
+	// The captured challenge must be the one the acceptor issued.
+	if !strings.EqualFold(fields[3], hex.EncodeToString(ctx.ServerChallenge[:])) {
+		t.Fatalf("captured challenge = %q, want %x", fields[3], ctx.ServerChallenge)
+	}
+	// The NTProofStr must be the first 16 bytes of what the client sent.
+	wantProof := hex.EncodeToString(ctx.Authenticate.NtChallengeResponse[:16])
+	if !strings.EqualFold(fields[4], wantProof) {
+		t.Fatalf("captured NTProofStr = %q, want %s", fields[4], wantProof)
+	}
+}
+
+// TestAcceptorCaptureOnly asserts an acceptor with no credential records the
+// response and says so, rather than failing in a way that loses it.
+func TestAcceptorCaptureOnly(t *testing.T) {
+	ctx := NewAcceptContext("LAB", challenge.TargetTypeDomain, serverTargetInfo(t, nil))
+	runExchange(t, ctx)
+
+	err := ctx.Verify()
+	if !errors.Is(err, ErrCaptureOnly) {
+		t.Fatalf("Verify() error = %v, want ErrCaptureOnly", err)
+	}
+	if ctx.Verified {
+		t.Fatal("Verified is set although nothing was verified")
+	}
+	if ctx.GetSessionKey() != nil {
+		t.Fatal("a session key was derived without a credential")
+	}
+	// The capture survives the unverified outcome.
+	if _, v2 := ctx.CapturedResponse(); v2 == nil {
+		t.Fatal("the response was lost when verification could not run")
+	}
+}
+
+// TestAcceptorRejectsWrongCredential asserts a response that does not match the
+// credential is refused, and separately that an identity with no credential is
+// distinguished from one with the wrong password.
+func TestAcceptorRejectsWrongCredential(t *testing.T) {
+	t.Run("wrong password", func(t *testing.T) {
+		ctx := NewAcceptContext("LAB", challenge.TargetTypeDomain, serverTargetInfo(t, nil))
+		ctx.CredentialLookup = lookupFor(testDomain, testUsername, "not-the-password", nil)
+		runExchange(t, ctx)
+
+		if err := ctx.Verify(); !errors.Is(err, ErrBadResponse) {
+			t.Fatalf("Verify() error = %v, want ErrBadResponse", err)
+		}
+		if ctx.GetSessionKey() != nil {
+			t.Fatal("a session key was derived from a response that did not verify")
+		}
+	})
+
+	t.Run("unknown identity", func(t *testing.T) {
+		ctx := NewAcceptContext("LAB", challenge.TargetTypeDomain, serverTargetInfo(t, nil))
+		ctx.CredentialLookup = lookupFor(testDomain, "someone-else", testPassword, nil)
+		runExchange(t, ctx)
+
+		if err := ctx.Verify(); !errors.Is(err, ErrUnknownIdentity) {
+			t.Fatalf("Verify() error = %v, want ErrUnknownIdentity", err)
+		}
+	})
+
+	t.Run("tampered NT response", func(t *testing.T) {
+		ctx := NewAcceptContext("LAB", challenge.TargetTypeDomain, serverTargetInfo(t, nil))
+		ctx.CredentialLookup = lookupFor(testDomain, testUsername, testPassword, nil)
+		runExchange(t, ctx)
+
+		// Flip a bit in the NTProofStr.
+		ctx.Authenticate.NtChallengeResponse[0] ^= 0x01
+		if err := ctx.Verify(); !errors.Is(err, ErrBadResponse) {
+			t.Fatalf("Verify() error = %v, want ErrBadResponse", err)
+		}
+	})
+}
+
+// TestAcceptorVerifiesMIC asserts a client that commits to the exchange with a MIC
+// is checked, and that a tampered MIC is refused even though the NT response
+// itself is genuine.
+//
+// The initiator in this repository does not emit a MIC, so the AUTHENTICATE is
+// built directly here to exercise the path.
+func TestAcceptorVerifiesMIC(t *testing.T) {
+	build := func(t *testing.T, tamper bool) (*AcceptContext, error) {
+		t.Helper()
+
+		// A TargetInfo carrying a timestamp is what obliges a client to send a MIC.
+		timestamp := make([]byte, 8)
+		for i := range timestamp {
+			timestamp[i] = byte(i + 1)
+		}
+		ctx := NewAcceptContext("LAB", challenge.TargetTypeDomain, serverTargetInfo(t, timestamp))
+		ctx.CredentialLookup = lookupFor(testDomain, testUsername, testPassword, nil)
+
+		client := NewAuthContext(AuthTypeNTLM, testDomain, testUsername, testPassword, testWorkstation, true)
+		v := version.DefaultVersion()
+		negotiateToken, err := client.CreateNegotiateToken(clientNegotiateFlags, &v)
+		if err != nil {
+			t.Fatalf("CreateNegotiateToken() error = %v", err)
+		}
+		if _, err := ctx.AcceptNegotiateToken(negotiateToken); err != nil {
+			t.Fatalf("AcceptNegotiateToken() error = %v", err)
+		}
+
+		// Build an AUTHENTICATE that carries a MIC over this exchange.
+		message, err := authenticate.CreateAuthenticateMessage(ctx.Challenge, testUsername, testPassword, testDomain, testWorkstation)
+		if err != nil {
+			t.Fatalf("CreateAuthenticateMessage() error = %v", err)
+		}
+		message.NeedsMIC = true
+		if err := message.ComputeMIC(ctx.NegotiateMessageBytes, ctx.ChallengeMessageBytes); err != nil {
+			t.Fatalf("ComputeMIC() error = %v", err)
+		}
+		raw, err := message.Marshal()
+		if err != nil {
+			t.Fatalf("Marshal() error = %v", err)
+		}
+		if tamper {
+			// Locate the MIC field by parsing the message back, then flip a bit
+			// inside it, leaving the NT response intact.
+			parsed := &authenticate.AuthenticateMessage{}
+			if _, err := parsed.Unmarshal(raw); err != nil {
+				t.Fatalf("Unmarshal() error = %v", err)
+			}
+			if !parsed.NeedsMIC || parsed.MICOffset == 0 {
+				t.Fatal("could not locate the MIC field in the marshalled message")
+			}
+			raw[parsed.MICOffset] ^= 0x01
+		}
+
+		if err := ctx.AcceptAuthenticateToken(raw); err != nil {
+			t.Fatalf("AcceptAuthenticateToken() error = %v", err)
+		}
+		if !ctx.Authenticate.NeedsMIC {
+			t.Fatal("the accepted AUTHENTICATE does not report a MIC, so Unmarshal did not read one")
+		}
+		return ctx, ctx.Verify()
+	}
+
+	t.Run("valid MIC", func(t *testing.T) {
+		ctx, err := build(t, false)
+		if err != nil {
+			t.Fatalf("Verify() error = %v", err)
+		}
+		if len(ctx.GetSessionKey()) == 0 {
+			t.Fatal("no session key after a successful verification")
+		}
+	})
+
+	t.Run("tampered MIC", func(t *testing.T) {
+		_, err := build(t, true)
+		if !errors.Is(err, ErrBadMIC) {
+			t.Fatalf("Verify() error = %v, want ErrBadMIC", err)
+		}
+	})
+}
+
+// TestAcceptorKeyExchange asserts the acceptor unseals a client-chosen session key
+// when NTLMSSP_NEGOTIATE_KEY_EXCH was negotiated. A Windows client requests key
+// exchange, so this is the path that matters in the field even though the
+// initiator in this repository does not use it.
+func TestAcceptorKeyExchange(t *testing.T) {
+	ctx := NewAcceptContext("LAB", challenge.TargetTypeDomain, serverTargetInfo(t, nil))
+	ctx.CredentialLookup = lookupFor(testDomain, testUsername, testPassword, nil)
+	runExchange(t, ctx)
+
+	// Recompute the KeyExchangeKey the way the acceptor will, then seal a chosen
+	// session key under it exactly as a client does.
+	ntHash := nt.NTHash(testPassword)
+	v2, err := ntlmv2.NewNTLMv2CtxWithNTHash(testDomain, testUsername, ntHash, ctx.ServerChallenge, [8]byte{})
+	if err != nil {
+		t.Fatalf("NewNTLMv2CtxWithNTHash() error = %v", err)
+	}
+	keyExchangeKey := ntlmv2.SessionBaseKeyFromResponse(v2.ResponseKeyNT[:], ctx.Authenticate.NtChallengeResponse)
+	if len(keyExchangeKey) != 16 {
+		t.Fatalf("KeyExchangeKey is %d bytes, want 16", len(keyExchangeKey))
+	}
+
+	chosenKey := []byte("0123456789abcdef")
+	cipher, err := rc4.NewRC4WithKey(keyExchangeKey)
+	if err != nil {
+		t.Fatalf("NewRC4WithKey() error = %v", err)
+	}
+	sealed := make([]byte, len(chosenKey))
+	cipher.XORKeyStream(sealed, chosenKey)
+
+	ctx.Authenticate.NegotiateFlags |= flags.NTLMSSP_NEGOTIATE_KEY_EXCH
+	ctx.Authenticate.EncryptedRandomSessionKey = sealed
+
+	if err := ctx.Verify(); err != nil {
+		t.Fatalf("Verify() error = %v", err)
+	}
+	if !bytes.Equal(ctx.GetSessionKey(), chosenKey) {
+		t.Fatalf("unsealed session key = %x, want %x", ctx.GetSessionKey(), chosenKey)
+	}
+
+	// A malformed sealed key is refused rather than producing a short key.
+	ctx.Verified = false
+	ctx.SessionKey = nil
+	ctx.Authenticate.EncryptedRandomSessionKey = []byte{0x01, 0x02}
+	if err := ctx.Verify(); err == nil {
+		t.Fatal("Verify() accepted a truncated EncryptedRandomSessionKey")
+	}
+}
+
+// TestAcceptorChallengeFlags asserts the CHALLENGE advertises the intersection of
+// what the client offered with what the acceptor supports, and asserts the bits an
+// acceptor must set for a real client to continue.
+func TestAcceptorChallengeFlags(t *testing.T) {
+	ctx := NewAcceptContext("LAB", challenge.TargetTypeDomain, serverTargetInfo(t, nil))
+	v := version.DefaultVersion()
+	ctx.Version = &v
+	runExchange(t, ctx)
+
+	got := ctx.Challenge.NegotiateFlags
+
+	// TargetInfo was supplied, so both bits that announce it must be set or a
+	// Windows client abandons the exchange.
+	if !got.HasFlag(flags.NTLMSSP_NEGOTIATE_TARGET_INFO) {
+		t.Error("CHALLENGE does not set NTLMSSP_NEGOTIATE_TARGET_INFO although TargetInfo was supplied")
+	}
+	if !got.HasFlag(flags.NTLMSSP_REQUEST_TARGET) {
+		t.Error("CHALLENGE does not set NTLMSSP_REQUEST_TARGET although a TargetName was supplied")
+	}
+	// The client asked to sign, so the acceptor must agree to it.
+	if !got.HasFlag(flags.NTLMSSP_NEGOTIATE_SIGN) {
+		t.Error("CHALLENGE does not echo NTLMSSP_NEGOTIATE_SIGN")
+	}
+	if !got.HasFlag(flags.NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY) {
+		t.Error("CHALLENGE does not set NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY")
+	}
+	// A target type describes the TargetName.
+	if !got.HasFlag(flags.NTLMSSP_TARGET_TYPE_DOMAIN) {
+		t.Error("CHALLENGE does not set NTLMSSP_TARGET_TYPE_DOMAIN")
+	}
+	// Unicode was offered, so OEM must not also be asserted.
+	if !got.HasFlag(flags.NTLMSSP_NEGOTIATE_UNICODE) {
+		t.Error("CHALLENGE does not set NTLMSSP_NEGOTIATE_UNICODE")
+	}
+	if got.HasFlag(flags.NTLMSSP_NEGOTIATE_OEM) {
+		t.Error("CHALLENGE sets both NTLMSSP_NEGOTIATE_UNICODE and NTLMSSP_NEGOTIATE_OEM")
+	}
+	// A bit the client never offered must not appear.
+	if got.HasFlag(flags.NTLMSSP_NEGOTIATE_DATAGRAM) {
+		t.Error("CHALLENGE asserts NTLMSSP_NEGOTIATE_DATAGRAM, which the client did not offer")
+	}
+	// The advertised TargetInfo must be exactly what was configured.
+	if !bytes.Equal(ctx.Challenge.TargetInfo, ctx.TargetInfo) {
+		t.Error("CHALLENGE TargetInfo differs from what was configured")
+	}
+}
+
+// TestAcceptorGeneratesAChallenge asserts a challenge is generated when none was
+// supplied, and that two exchanges do not reuse one. A predictable or repeated
+// challenge lets a captured response be replayed.
+func TestAcceptorGeneratesAChallenge(t *testing.T) {
+	seen := map[string]bool{}
+	for i := 0; i < 8; i++ {
+		ctx := NewAcceptContext("LAB", challenge.TargetTypeDomain, serverTargetInfo(t, nil))
+		runExchange(t, ctx)
+
+		if ctx.ServerChallenge == ([8]byte{}) {
+			t.Fatal("no challenge was generated")
+		}
+		key := hex.EncodeToString(ctx.ServerChallenge[:])
+		if seen[key] {
+			t.Fatalf("challenge %s was issued twice", key)
+		}
+		seen[key] = true
+	}
+}
+
+// TestAcceptorHonoursSuppliedChallenge asserts an explicitly configured challenge
+// is used unchanged, which is what makes an exchange reproducible in a test or
+// against a recorded capture.
+func TestAcceptorHonoursSuppliedChallenge(t *testing.T) {
+	want := [8]byte{0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef}
+	ctx := NewAcceptContext("LAB", challenge.TargetTypeDomain, serverTargetInfo(t, nil))
+	ctx.ServerChallenge = want
+	runExchange(t, ctx)
+
+	if ctx.ServerChallenge != want {
+		t.Fatalf("challenge = %x, want %x", ctx.ServerChallenge, want)
+	}
+	if ctx.Challenge.ServerChallenge != want {
+		t.Fatalf("CHALLENGE carries %x, want %x", ctx.Challenge.ServerChallenge, want)
+	}
+}
+
+// TestAcceptorRejectsMalformedTokens asserts each way a token can be wrong is
+// refused rather than parsed as something else.
+func TestAcceptorRejectsMalformedTokens(t *testing.T) {
+	t.Run("negotiate leg", func(t *testing.T) {
+		cases := []struct {
+			name  string
+			token []byte
+		}{
+			{"empty", nil},
+			{"not a token", []byte{0x01, 0x02, 0x03}},
+			{"truncated NTLMSSP", []byte("NTLMSSP\x00")},
+			{"wrong message type", authenticateShapedToken(t)},
+		}
+		for _, tc := range cases {
+			tc := tc
+			t.Run(tc.name, func(t *testing.T) {
+				ctx := NewAcceptContext("LAB", challenge.TargetTypeDomain, nil)
+				if _, err := ctx.AcceptNegotiateToken(tc.token); err == nil {
+					t.Fatal("AcceptNegotiateToken() should fail")
+				}
+			})
+		}
+	})
+
+	t.Run("authenticate before challenge", func(t *testing.T) {
+		ctx := NewAcceptContext("LAB", challenge.TargetTypeDomain, nil)
+		if err := ctx.AcceptAuthenticateToken(authenticateShapedToken(t)); err == nil {
+			t.Fatal("AcceptAuthenticateToken() should refuse to run before a CHALLENGE was issued")
+		}
+	})
+
+	t.Run("verify before authenticate", func(t *testing.T) {
+		ctx := NewAcceptContext("LAB", challenge.TargetTypeDomain, nil)
+		if err := ctx.Verify(); !errors.Is(err, ErrNoAuthenticate) {
+			t.Fatalf("Verify() error = %v, want ErrNoAuthenticate", err)
+		}
+	})
+}
+
+// TestAcceptorRejectsClientWithNoCharacterSet asserts a client offering neither
+// Unicode nor OEM is refused, since there is no encoding both sides could agree
+// on for the identity.
+func TestAcceptorRejectsClientWithNoCharacterSet(t *testing.T) {
+	client := NewAuthContext(AuthTypeNTLM, testDomain, testUsername, testPassword, testWorkstation, false)
+	negotiateToken, err := client.CreateNegotiateToken(flags.NTLMSSP_NEGOTIATE_NTLM, nil)
+	if err != nil {
+		t.Fatalf("CreateNegotiateToken() error = %v", err)
+	}
+
+	ctx := NewAcceptContext("LAB", challenge.TargetTypeDomain, serverTargetInfo(t, nil))
+	if _, err := ctx.AcceptNegotiateToken(negotiateToken); err == nil {
+		t.Fatal("AcceptNegotiateToken() accepted a client offering no character set")
+	}
+}
+
+// TestSessionBaseKeyMatchesComputed asserts the acceptor's route to the
+// SessionBaseKey agrees with the computing side's, since the two derive it from
+// different starting points.
+func TestSessionBaseKeyMatchesComputed(t *testing.T) {
+	ctx := NewAcceptContext("LAB", challenge.TargetTypeDomain, serverTargetInfo(t, nil))
+	runExchange(t, ctx)
+
+	ntHash := nt.NTHash(testPassword)
+	v2, err := ntlmv2.NewNTLMv2CtxWithNTHash(testDomain, testUsername, ntHash, ctx.ServerChallenge, [8]byte{})
+	if err != nil {
+		t.Fatalf("NewNTLMv2CtxWithNTHash() error = %v", err)
+	}
+
+	ntResponse := ctx.Authenticate.NtChallengeResponse
+	fromResponse := ntlmv2.SessionBaseKeyFromResponse(v2.ResponseKeyNT[:], ntResponse)
+	fromComputation := v2.ComputeSessionBaseKey(ntResponse[:16])
+
+	if !bytes.Equal(fromResponse, fromComputation) {
+		t.Fatalf("SessionBaseKeyFromResponse = %x, ComputeSessionBaseKey = %x", fromResponse, fromComputation)
+	}
+
+	// And the same value, derived independently here.
+	mac := hmac.New(md5.New, v2.ResponseKeyNT[:])
+	mac.Write(ntResponse[:16])
+	if !bytes.Equal(fromResponse, mac.Sum(nil)) {
+		t.Fatal("SessionBaseKeyFromResponse does not match HMAC_MD5(ResponseKeyNT, NTProofStr)")
+	}
+}
+
+// TestTargetInfoBuild asserts the TargetInfo builder produces a list the parser in
+// this package reads back, terminated as the wire format requires.
+func TestTargetInfoBuild(t *testing.T) {
+	info := serverTargetInfo(t, []byte{1, 2, 3, 4, 5, 6, 7, 8})
+
+	pairs, err := targetinfo.ParseTargetInfo(info)
+	if err != nil {
+		t.Fatalf("ParseTargetInfo() error = %v", err)
+	}
+	for _, id := range []avpair.AvId{
+		avpair.MsvAvNbDomainName,
+		avpair.MsvAvNbComputerName,
+		avpair.MsvAvDnsDomainName,
+		avpair.MsvAvDnsComputerName,
+		avpair.MsvAvTimestamp,
+	} {
+		if _, ok := pairs[id]; !ok {
+			t.Errorf("TargetInfo is missing %s", id)
+		}
+	}
+	if !targetinfo.HasTimestamp(info) {
+		t.Error("HasTimestamp() is false although a timestamp was supplied")
+	}
+	// The list ends with the EOL terminator: AvId 0, AvLen 0.
+	if len(info) < 4 || !bytes.Equal(info[len(info)-4:], []byte{0x00, 0x00, 0x00, 0x00}) {
+		t.Errorf("TargetInfo does not end with the MsvAvEOL terminator: % x", info)
+	}
+
+	// An omitted name is not advertised as an empty pair.
+	sparse, err := targetinfo.BuildServerTargetInfo("SERVER01", "", "", "", nil)
+	if err != nil {
+		t.Fatalf("BuildServerTargetInfo() error = %v", err)
+	}
+	sparsePairs, err := targetinfo.ParseTargetInfo(sparse)
+	if err != nil {
+		t.Fatalf("ParseTargetInfo() error = %v", err)
+	}
+	if len(sparsePairs) != 1 {
+		t.Fatalf("a single supplied name produced %d pairs, want 1", len(sparsePairs))
+	}
+
+	// A timestamp of the wrong width is refused rather than truncated.
+	if _, err := targetinfo.BuildServerTargetInfo("S", "", "", "", []byte{1, 2, 3}); err == nil {
+		t.Error("BuildServerTargetInfo() accepted a 3-byte timestamp")
+	}
+}
+
+// authenticateShapedToken returns a bare, well-formed AUTHENTICATE message, used
+// where a test needs a token of the wrong type for the leg being exercised.
+func authenticateShapedToken(t *testing.T) []byte {
+	t.Helper()
+
+	message := &authenticate.AuthenticateMessage{}
+	message.NegotiateFlags = flags.NTLMSSP_NEGOTIATE_UNICODE
+	message.DomainName = []byte{}
+	message.UserName = []byte{}
+	message.Workstation = []byte{}
+	message.LmChallengeResponse = []byte{}
+	message.NtChallengeResponse = []byte{}
+	message.EncryptedRandomSessionKey = []byte{}
+
+	raw, err := message.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	return raw
+}

--- a/crypto/spnego/ntlm/message/authenticate/authenticate.go
+++ b/crypto/spnego/ntlm/message/authenticate/authenticate.go
@@ -58,6 +58,13 @@ type AuthenticateMessage struct {
 	// the NtChallengeResponse also carry MsvAvFlags with the MIC-present bit.
 	NeedsMIC bool
 
+	// MICOffset is the byte offset the MIC was read from, set by Unmarshal when a
+	// MIC was present. A verifier needs it to zero the field in the bytes as
+	// received: re-marshalling to recompute the digest would only reproduce the
+	// original if this implementation encodes the message identically to whoever
+	// sent it, which is not something a verifier can assume.
+	MICOffset int
+
 	// Payload section
 
 	// LmChallengeResponse (16 bytes): A payload containing LmChallengeResponse data.
@@ -275,6 +282,51 @@ func (msg *AuthenticateMessage) ComputeMIC(negotiateMessage, challengeMessage []
 	return nil
 }
 
+// VerifyMIC reports whether the message integrity code carried by the message
+// verifies against an exported session key, the acceptor-side counterpart of
+// ComputeMIC.
+//
+// The digest is taken over the message as received, with only the 16 MIC bytes
+// zeroed, rather than over a re-marshalling of the parsed fields: the MIC covers
+// the sender's exact encoding, and any difference in how this implementation
+// would lay the message out would produce a mismatch that looks identical to a
+// forged MIC.
+//
+//	MIC = HMAC_MD5(ExportedSessionKey, NEGOTIATE || CHALLENGE || AUTHENTICATE)
+//
+// The comparison is constant-time.
+//
+// Parameters:
+//   - exportedSessionKey: the key derived from the verified NT response
+//   - negotiateMessage: the raw NEGOTIATE_MESSAGE of this exchange
+//   - challengeMessage: the raw CHALLENGE_MESSAGE of this exchange
+//   - rawAuthenticate: this message exactly as received
+//
+// Returns:
+//   - true when the MIC verifies
+func (msg *AuthenticateMessage) VerifyMIC(exportedSessionKey, negotiateMessage, challengeMessage, rawAuthenticate []byte) bool {
+	if len(exportedSessionKey) == 0 || !msg.NeedsMIC {
+		return false
+	}
+	if msg.MICOffset <= 0 || msg.MICOffset+MICLength > len(rawAuthenticate) {
+		return false
+	}
+
+	// Zero the MIC field in a copy, so the caller's buffer is untouched.
+	zeroed := make([]byte, len(rawAuthenticate))
+	copy(zeroed, rawAuthenticate)
+	for i := msg.MICOffset; i < msg.MICOffset+MICLength; i++ {
+		zeroed[i] = 0x00
+	}
+
+	mac := hmac.New(md5.New, exportedSessionKey)
+	mac.Write(negotiateMessage)
+	mac.Write(challengeMessage)
+	mac.Write(zeroed)
+
+	return hmac.Equal(msg.MIC[:], mac.Sum(nil))
+}
+
 // Marshal serializes the AuthenticateMessage into a byte slice
 func (msg *AuthenticateMessage) Marshal() ([]byte, error) {
 	// Offset, in bytes, from the start of the AUTHENTICATE_MESSAGE to the payload.
@@ -423,6 +475,34 @@ func (msg *AuthenticateMessage) Marshal() ([]byte, error) {
 }
 
 // Unmarshal deserializes a byte slice into an AuthenticateMessage
+// MICLength is the length in bytes of the AUTHENTICATE_MESSAGE message integrity
+// code.
+const MICLength = 16
+
+// payloadStart returns the lowest buffer offset among the payload fields, which
+// is where the fixed part of the message ends. A field with a zero length carries
+// no payload and its offset is not meaningful, so it is skipped.
+//
+// It is only valid once the field descriptors have been read.
+func (msg *AuthenticateMessage) payloadStart() int {
+	start := 0
+	consider := func(length uint16, offset uint32) {
+		if length == 0 {
+			return
+		}
+		if start == 0 || int(offset) < start {
+			start = int(offset)
+		}
+	}
+	consider(msg.LmChallengeResponseFields.Len, msg.LmChallengeResponseFields.BufferOffset)
+	consider(msg.NtChallengeResponseFields.Len, msg.NtChallengeResponseFields.BufferOffset)
+	consider(msg.DomainNameFields.Len, msg.DomainNameFields.BufferOffset)
+	consider(msg.UserNameFields.Len, msg.UserNameFields.BufferOffset)
+	consider(msg.WorkstationFields.Len, msg.WorkstationFields.BufferOffset)
+	consider(msg.EncryptedRandomSessionKeyFields.Len, msg.EncryptedRandomSessionKeyFields.BufferOffset)
+	return start
+}
+
 func (msg *AuthenticateMessage) Unmarshal(data []byte) (int, error) {
 	totalBytesRead := 0
 
@@ -521,6 +601,31 @@ func (msg *AuthenticateMessage) Unmarshal(data []byte) (int, error) {
 		msg.Version = nil
 		// Read 8 bytes of zeros
 		totalBytesRead += 8
+	}
+
+	// Read the MIC when one is present.
+	//
+	// The MIC is not self-describing: nothing in the fixed header announces it. It
+	// occupies the 16 bytes immediately before the payload, so it is located from
+	// where the payload starts rather than from the cursor above. That matters,
+	// because two layouts appear in the wild and they put the payload in different
+	// places: [MS-NLMP] treats Version as always present (payload at 72 without a
+	// MIC, 88 with one), while this implementation's Marshal omits Version when
+	// NTLMSSP_NEGOTIATE_VERSION is clear (payload at 64, or 80 with a MIC).
+	// Deriving the offset from the payload handles both, and a MIC is present in
+	// either layout exactly when the payload starts at 80 or beyond.
+	//
+	// Without this the MIC a client sent was silently discarded, so an acceptor had
+	// nothing to verify and a tampered MIC was indistinguishable from a correct
+	// one.
+	if payloadStart := msg.payloadStart(); payloadStart >= 80 {
+		micOffset := payloadStart - MICLength
+		if micOffset < 64 || payloadStart > len(data) {
+			return 0, fmt.Errorf("data too short to read MIC in AuthenticateMessage")
+		}
+		copy(msg.MIC[:], data[micOffset:payloadStart])
+		msg.NeedsMIC = true
+		msg.MICOffset = micOffset
 	}
 
 	// Read payload section

--- a/crypto/spnego/ntlm/message/challenge/create.go
+++ b/crypto/spnego/ntlm/message/challenge/create.go
@@ -1,0 +1,159 @@
+package challenge
+
+import (
+	"crypto/rand"
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/message/header"
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/message/negotiate"
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/message/negotiate/flags"
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/message/types"
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/version"
+	"github.com/TheManticoreProject/Manticore/encoding/utf16"
+)
+
+// acceptorSupportedFlags are the options this implementation will agree to when a
+// client offers them. The CHALLENGE advertises the intersection of the client's
+// offer with this set, per [MS-NLMP] 3.2.5.1.1, so a client cannot select
+// something the acceptor does not implement, and the acceptor does not assert
+// something the client did not ask for.
+const acceptorSupportedFlags = flags.NTLMSSP_NEGOTIATE_UNICODE |
+	flags.NTLMSSP_NEGOTIATE_OEM |
+	flags.NTLMSSP_REQUEST_TARGET |
+	flags.NTLMSSP_NEGOTIATE_SIGN |
+	flags.NTLMSSP_NEGOTIATE_SEAL |
+	flags.NTLMSSP_NEGOTIATE_NTLM |
+	flags.NTLMSSP_NEGOTIATE_ALWAYS_SIGN |
+	flags.NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY |
+	flags.NTLMSSP_NEGOTIATE_TARGET_INFO |
+	flags.NTLMSSP_NEGOTIATE_KEY_EXCH |
+	flags.NTLMSSP_NEGOTIATE_128 |
+	flags.NTLMSSP_NEGOTIATE_56
+
+// TargetType selects which target-type bit the CHALLENGE asserts, describing what
+// the TargetName names.
+type TargetType int
+
+const (
+	// TargetTypeDomain declares the TargetName to be a domain name.
+	TargetTypeDomain TargetType = iota
+	// TargetTypeServer declares the TargetName to be a server name.
+	TargetTypeServer
+	// TargetTypeNone asserts neither bit.
+	TargetTypeNone
+)
+
+// NewServerChallenge returns a fresh 8-byte challenge from the system's
+// cryptographic random source.
+//
+// The challenge is the only thing standing between a captured response and an
+// offline replay, so it must be unpredictable and must not be reused across
+// exchanges.
+//
+// Returns:
+//   - The challenge
+//   - An error if the random source fails
+func NewServerChallenge() ([8]byte, error) {
+	var challenge [8]byte
+	if _, err := rand.Read(challenge[:]); err != nil {
+		return challenge, fmt.Errorf("failed to generate a server challenge: %v", err)
+	}
+	return challenge, nil
+}
+
+// CreateChallengeMessage builds the CHALLENGE_MESSAGE answering a client's
+// NEGOTIATE_MESSAGE, the acceptor-side counterpart of CreateNegotiateMessage.
+//
+// The negotiated flags are the intersection of what the client offered with what
+// this implementation supports, with three adjustments the specification requires
+// of an acceptor:
+//
+//   - Unicode wins over OEM when the client offered both, because every string in
+//     the exchange is then UTF-16LE and mixing the two is what produces an
+//     identity that fails to verify.
+//   - REQUEST_TARGET and NEGOTIATE_TARGET_INFO are asserted whenever a TargetName
+//     or TargetInfo is supplied. A Windows client abandons the exchange when it
+//     receives TargetInfo that the flags do not announce.
+//   - NEGOTIATE_VERSION is asserted only when a Version is supplied, since the
+//     field is otherwise required to be zero.
+//
+// Parameters:
+//   - neg: the client's NEGOTIATE_MESSAGE
+//   - serverChallenge: the 8-byte challenge to issue
+//   - targetName: the name to advertise, or "" to omit it
+//   - targetType: which target-type bit to assert
+//   - targetInfo: the AV_PAIR list to advertise, or nil to omit it
+//   - v: the version to advertise, or nil to omit it
+//
+// Returns:
+//   - The CHALLENGE_MESSAGE
+//   - An error if the client's offer cannot be answered
+func CreateChallengeMessage(
+	neg *negotiate.NegotiateMessage,
+	serverChallenge [8]byte,
+	targetName string,
+	targetType TargetType,
+	targetInfo []byte,
+	v *version.Version,
+) (*ChallengeMessage, error) {
+	if neg == nil {
+		return nil, fmt.Errorf("cannot answer a nil NEGOTIATE message")
+	}
+
+	negotiated := neg.NegotiateFlags & acceptorSupportedFlags
+
+	// A client that offers neither character set has offered nothing this
+	// implementation can speak, and there is no sane default: picking one would
+	// mean encoding the identity differently from how the client folded it into
+	// its response.
+	if negotiated&(flags.NTLMSSP_NEGOTIATE_UNICODE|flags.NTLMSSP_NEGOTIATE_OEM) == 0 {
+		return nil, fmt.Errorf("client offered neither NTLMSSP_NEGOTIATE_UNICODE nor NTLMSSP_NEGOTIATE_OEM")
+	}
+	// Exactly one character set is negotiated, and Unicode is preferred.
+	if negotiated.HasFlag(flags.NTLMSSP_NEGOTIATE_UNICODE) {
+		negotiated &= ^flags.NTLMSSP_NEGOTIATE_OEM
+	}
+
+	msg := &ChallengeMessage{
+		Header: header.Header{
+			Signature:   header.NTLM_SIGNATURE,
+			MessageType: types.MESSAGE_TYPE_CHALLENGE,
+		},
+		ServerChallenge: serverChallenge,
+	}
+
+	if targetName != "" {
+		if negotiated.HasFlag(flags.NTLMSSP_NEGOTIATE_UNICODE) {
+			msg.TargetName = utf16.EncodeUTF16LE(targetName)
+		} else {
+			msg.TargetName = []byte(targetName)
+		}
+		negotiated |= flags.NTLMSSP_REQUEST_TARGET
+
+		switch targetType {
+		case TargetTypeDomain:
+			negotiated |= flags.NTLMSSP_TARGET_TYPE_DOMAIN
+		case TargetTypeServer:
+			negotiated |= flags.NTLMSSP_TARGET_TYPE_SERVER
+		}
+	}
+
+	if len(targetInfo) > 0 {
+		msg.TargetInfo = targetInfo
+		negotiated |= flags.NTLMSSP_NEGOTIATE_TARGET_INFO
+		// TargetInfo is only meaningful alongside extended session security, and
+		// a client that sends a v2 response expects the bit set.
+		negotiated |= flags.NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY
+	}
+
+	if v != nil {
+		msg.Version = v
+		negotiated |= flags.NTLMSSP_NEGOTIATE_VERSION
+	} else {
+		negotiated &= ^flags.NTLMSSP_NEGOTIATE_VERSION
+	}
+
+	msg.NegotiateFlags = negotiated
+
+	return msg, nil
+}

--- a/crypto/spnego/ntlm/targetinfo/build.go
+++ b/crypto/spnego/ntlm/targetinfo/build.go
@@ -1,0 +1,118 @@
+package targetinfo
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/avpair"
+	"github.com/TheManticoreProject/Manticore/encoding/utf16"
+)
+
+// MaxTargetInfoLength is the largest TargetInfo that can be advertised. The
+// CHALLENGE_MESSAGE carries its length in a 16-bit field, so a longer list
+// cannot be described on the wire.
+const MaxTargetInfoLength = 0xFFFF
+
+// Build marshals an AV_PAIR list into the TargetInfo form a CHALLENGE_MESSAGE
+// carries, appending the MsvAvEOL terminator that ends the list.
+//
+// This package could previously only parse TargetInfo. An acceptor has to compose
+// one: the pairs it advertises are what the client folds into its NTLMv2 blob, so
+// they end up covered by the NTProofStr and cannot be added after the fact.
+//
+// Each pair's AvLen is taken from its value rather than from the AvLen field, so
+// a caller cannot produce a list whose declared lengths disagree with its
+// contents. A caller-supplied MsvAvEOL is ignored, since the terminator is
+// appended here.
+//
+// Parameters:
+//   - pairs: the AV_PAIRs to advertise, in order
+//
+// Returns:
+//   - The marshalled TargetInfo, EOL-terminated
+//   - An error if the list cannot be described on the wire
+func Build(pairs []avpair.AvPair) ([]byte, error) {
+	marshalled := []byte{}
+
+	for i := range pairs {
+		if pairs[i].AvID == avpair.MsvAvEOL {
+			// The terminator is appended below; one supplied mid-list would
+			// truncate the list for every reader.
+			continue
+		}
+		if len(pairs[i].AvData) > 0xFFFF {
+			return nil, fmt.Errorf("AV_PAIR %s value is %d bytes, which does not fit the 16-bit AvLen field",
+				pairs[i].AvID, len(pairs[i].AvData))
+		}
+
+		// Take the length from the value so the two cannot disagree.
+		pair := avpair.AvPair{
+			AvID:   pairs[i].AvID,
+			AvLen:  uint16(len(pairs[i].AvData)),
+			AvData: pairs[i].AvData,
+		}
+		encoded, err := pair.Marshal()
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal AV_PAIR %s: %v", pair.AvID, err)
+		}
+		marshalled = append(marshalled, encoded...)
+	}
+
+	// MsvAvEOL terminates the list and carries no value.
+	terminator := avpair.AvPair{AvID: avpair.MsvAvEOL, AvLen: 0, AvData: nil}
+	encoded, err := terminator.Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal the MsvAvEOL terminator: %v", err)
+	}
+	marshalled = append(marshalled, encoded...)
+
+	if len(marshalled) > MaxTargetInfoLength {
+		return nil, fmt.Errorf("TargetInfo is %d bytes, which does not fit the 16-bit length field", len(marshalled))
+	}
+
+	return marshalled, nil
+}
+
+// BuildServerTargetInfo composes the TargetInfo an acceptor advertises: the
+// NetBIOS and DNS computer and domain names, and a timestamp.
+//
+// The names are encoded UTF-16LE, which is how they appear on the wire. A name
+// left empty is omitted rather than advertised as a zero-length pair. The
+// timestamp is included only when non-empty; when it is present a client is
+// required to carry a MIC in its AUTHENTICATE ([MS-NLMP] 3.1.5.1.2), so an
+// acceptor that supplies one must be prepared to verify it.
+//
+// Parameters:
+//   - netBIOSComputerName: the server's NetBIOS computer name
+//   - netBIOSDomainName: the server's NetBIOS domain name
+//   - dnsComputerName: the server's fully qualified computer name
+//   - dnsDomainName: the server's fully qualified domain name
+//   - timestamp: an 8-byte Windows FILETIME, or nil to omit it
+//
+// Returns:
+//   - The marshalled TargetInfo, EOL-terminated
+//   - An error if the list cannot be described on the wire
+func BuildServerTargetInfo(netBIOSComputerName, netBIOSDomainName, dnsComputerName, dnsDomainName string, timestamp []byte) ([]byte, error) {
+	pairs := []avpair.AvPair{}
+
+	appendName := func(id avpair.AvId, name string) {
+		if name == "" {
+			return
+		}
+		pairs = append(pairs, avpair.AvPair{AvID: id, AvData: utf16.EncodeUTF16LE(name)})
+	}
+
+	// The order matches what a Windows server sends.
+	appendName(avpair.MsvAvNbDomainName, netBIOSDomainName)
+	appendName(avpair.MsvAvNbComputerName, netBIOSComputerName)
+	appendName(avpair.MsvAvDnsDomainName, dnsDomainName)
+	appendName(avpair.MsvAvDnsComputerName, dnsComputerName)
+
+	if len(timestamp) > 0 {
+		if len(timestamp) != 8 {
+			return nil, fmt.Errorf("MsvAvTimestamp must be an 8-byte FILETIME, got %d bytes", len(timestamp))
+		}
+		pairs = append(pairs, avpair.AvPair{AvID: avpair.MsvAvTimestamp, AvData: timestamp})
+	}
+
+	return Build(pairs)
+}


### PR DESCRIPTION
### Summary

Commit 4 of 12 for #1068. **Stacked on #1071** — it needs the variable-length response type from that PR, so it targets that branch and this diff shows only the acceptor commit.

`crypto/spnego` could only *initiate* an authentication: it built a NEGOTIATE and answered a CHALLENGE, but nothing generated a CHALLENGE from a received NEGOTIATE and nothing verified an AUTHENTICATE. Every primitive underneath was already present and symmetric — all three NTLM messages marshal *and* unmarshal, and `crypto/ntlmv2` has `NTOWFv2`, `ComputeSessionBaseKey` and the rest — so this is the missing half of the package rather than new cryptography.

### `AcceptContext`

Mirrors `AuthContext`. Two calls drive the exchange, and **verification is a third, separate step**:

- `AcceptNegotiateToken` → returns the CHALLENGE, framed exactly as `CreateAuthenticateTokenFromChallengeToken` expects it (a `SecurityBlob` wrapping a `NegTokenResp` with negState accept-incomplete and the NTLM mech OID).
- `AcceptAuthenticateToken` → records the AUTHENTICATE, verifying nothing.
- `Verify` → reports `ErrCaptureOnly`, `ErrUnknownIdentity`, `ErrBadResponse` or `ErrBadMIC`.

Splitting record from verify is what lets an acceptor whose purpose is harvesting responses run without ever holding a credential, and means a failed authentication doesn't lose the material. `CapturedResponse` renders what was recorded as NetNTLMv1 or NetNTLMv2, choosing by response length.

### Three pieces missing underneath

- **`targetinfo.Build`** / **`BuildServerTargetInfo`** — the package could only *parse* TargetInfo. An acceptor has to compose it, because a client folds those bytes into its NTLMv2 blob where they become covered by the NTProofStr and can no longer be changed.
- **`challenge.CreateChallengeMessage`** — advertises the intersection of the client's offer with what this implementation supports, per [MS-NLMP] 3.2.5.1.1. Prefers Unicode over OEM, asserts `REQUEST_TARGET` / `NEGOTIATE_TARGET_INFO` whenever a name or list is supplied (a Windows client abandons the exchange otherwise), and **refuses a client offering neither character set** rather than guessing — guessing would encode the identity differently from how the client folded it. `NewServerChallenge` draws a nonce from the system random source.
- **`ntlmv2.VerifyNTChallengeResponse`** — recomputes the NTProofStr over the blob **as received**. It deliberately cannot share an implementation with `ComputeNTChallengeResponse`: the computing side builds the blob itself, while a verifier must hash the bytes the client chose, or it rejects every legitimate client whose blob differs in any detail from the one we'd have built. `SessionBaseKeyFromResponse` is the acceptor's route to the key material.

Key exchange is handled: for NTLMv2 the KeyExchangeKey is the SessionBaseKey, and a client that negotiated `NTLMSSP_NEGOTIATE_KEY_EXCH` sealed its own session key under it, so the acceptor unseals it. The initiator here doesn't request key exchange — a Windows client does.

### Gap found: the MIC was never parsed

`AuthenticateMessage.Unmarshal` stepped from the Version field straight to the payload, so **a MIC a client sent was silently discarded** — an acceptor had nothing to verify, and a tampered MIC was indistinguishable from a correct one. It now reads the MIC, records `MICOffset`, and `VerifyMIC` checks it over the message as received with only those 16 bytes zeroed. Re-marshalling to recompute the digest would only reproduce the original if this implementation encoded the message identically to whoever sent it, which a verifier cannot assume.

**A pre-existing asymmetry surfaced while doing this**, and is deliberately left alone: `Marshal` omits the Version field when `NTLMSSP_NEGOTIATE_VERSION` is clear, while `Unmarshal` always advances 8 bytes for it. Existing round-trips survive because the payload is read by absolute `BufferOffset`, so the cursor drift is invisible. Rather than pick a side — each direction is deliberate, and the live-validated Windows interop depends on `Marshal`'s behaviour — the MIC is located from where the payload starts, which is correct for both layouts ([MS-NLMP]: payload at 72/88; here: 64/80).

### Testing

`go build ./...`, `go vet ./...` and `go test ./...` green across the repository.

The central test **drives the initiator in this repository against the new acceptor end to end and asserts both derive the identical session key** — that agreement is the whole point, since it's what a consumer signs and seals with. The claimed identity is asserted to reach the credential lookup with its domain case intact (the mixed-case domain is deliberate: NTLMv2 folds the domain in as-sent).

Beyond that: the capture-only path keeps the response; a wrong password, an unknown identity and a tampered NT response are each distinguished; a MIC is verified and a tampered one refused; a client-chosen session key is unsealed and a truncated one refused; the CHALLENGE advertises the bits a real client requires and none the client didn't offer; a generated challenge is never reused across eight exchanges and a supplied one is honoured; malformed and wrong-type tokens are refused on both legs. The verification primitive has its own known-answer tests against the [MS-NLMP] 4.2.4 vector — including that a response does **not** verify against a different challenge, which is what stops a captured response being replayed.

### Notes

This is the last prerequisite before the credential-capture server (commit 5), which needs only the CHALLENGE-generation half of this.

Merging: targets `enhancement-netntlmv2-response`. Merge #1071 first, and avoid `--delete-branch` on it while this is stacked.