### PR TITLE
Extract the SMB1 message-signing primitives (Refs #1068)

### DIFF
--- a/network/smb/smb_v10/client/session.go
+++ b/network/smb/smb_v10/client/session.go
@@ -13,6 +13,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/codes"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header/flags"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header/flags2"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/signing"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
 	"github.com/TheManticoreProject/Manticore/windows/credentials"
 	"github.com/TheManticoreProject/Manticore/windows/nt_status"
@@ -361,7 +362,7 @@ func (s *Session) SessionSetup() error {
 	if signingRequired {
 		s.Client.Connection.SigningSessionKey = signingKey
 		s.Client.Connection.IsSigningActive = true
-		signSMBMessage(signingKey, marshalledStep2, 0)
+		signing.Sign(signingKey, marshalledStep2, 0)
 	}
 
 	// Send the message
@@ -414,12 +415,12 @@ func (s *Session) SessionSetup() error {
 	// arming the per-message sequence counter for subsequent requests.
 	s.SessionKey = signingKey
 	if s.Client.Connection.IsSigningActive {
-		if !verifySMBSignature(signingKey, rawAuthResponse, 1) {
+		if !signing.Verify(signingKey, rawAuthResponse, 1) {
 			return fmt.Errorf("session setup response failed SMB signature verification")
 		}
 		// The AUTHENTICATE request used sequence 0 and its response sequence 1, so the
 		// next outbound request uses sequence 2.
-		s.Client.Connection.ClientNextSendSequenceNumber = 2
+		s.Client.Connection.ClientNextSendSequenceNumber = signing.NextRequestSequenceNumber(0)
 	}
 
 	return nil

--- a/network/smb/smb_v10/client/signing.go
+++ b/network/smb/smb_v10/client/signing.go
@@ -1,10 +1,9 @@
 package client
 
 import (
-	"crypto/hmac"
-	"crypto/md5"
-	"encoding/binary"
 	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/signing"
 )
 
 // Server signing policy states, recorded in Server.SigningState after negotiation.
@@ -14,80 +13,23 @@ const (
 	SigningStateRequired = "required"
 )
 
-// securitySignatureOffset is the byte offset, from the start of the SMB header, of
-// the 8-byte SecurityFeatures field that carries the message signature:
-// Protocol(4) + Command(1) + Status(4) + Flags(1) + Flags2(2) + PIDHigh(2) = 14.
-const securitySignatureOffset = 14
-
-// securitySignatureSize is the size, in bytes, of the SecuritySignature field.
-const securitySignatureSize = 8
-
-// computeSMBSignature computes the 8-byte SMB v1 message signature for a fully
-// marshalled SMB message, per [MS-CIFS] 3.1.5.1. The signature is the first 8 bytes
-// of MD5(MACKey || SMBMessage), where the message's SecuritySignature field has
-// first been set to the 32-bit sequence number (little-endian) followed by four
-// zero bytes. The input slice is not modified.
-func computeSMBSignature(macKey, message []byte, sequenceNumber uint32) [securitySignatureSize]byte {
-	// Work on a copy so the caller's buffer is untouched while we substitute the
-	// sequence number into the signature field for the digest computation.
-	buf := make([]byte, len(message))
-	copy(buf, message)
-
-	if len(buf) >= securitySignatureOffset+securitySignatureSize {
-		binary.LittleEndian.PutUint32(buf[securitySignatureOffset:securitySignatureOffset+4], sequenceNumber)
-		for i := securitySignatureOffset + 4; i < securitySignatureOffset+securitySignatureSize; i++ {
-			buf[i] = 0x00
-		}
-	}
-
-	h := md5.New()
-	h.Write(macKey)
-	h.Write(buf)
-	digest := h.Sum(nil)
-
-	var signature [securitySignatureSize]byte
-	copy(signature[:], digest[:securitySignatureSize])
-	return signature
-}
-
-// signSMBMessage computes the SMB v1 signature for the marshalled message and
-// writes it into the message's SecuritySignature field in place.
-func signSMBMessage(macKey, message []byte, sequenceNumber uint32) {
-	if len(message) < securitySignatureOffset+securitySignatureSize {
-		return
-	}
-	signature := computeSMBSignature(macKey, message, sequenceNumber)
-	copy(message[securitySignatureOffset:securitySignatureOffset+securitySignatureSize], signature[:])
-}
-
-// verifySMBSignature reports whether the marshalled message carries a valid SMB v1
-// signature for the given MAC key and expected sequence number. The comparison is
-// constant-time.
-func verifySMBSignature(macKey, message []byte, sequenceNumber uint32) bool {
-	if len(message) < securitySignatureOffset+securitySignatureSize {
-		return false
-	}
-	received := make([]byte, securitySignatureSize)
-	copy(received, message[securitySignatureOffset:securitySignatureOffset+securitySignatureSize])
-
-	expected := computeSMBSignature(macKey, message, sequenceNumber)
-	return hmac.Equal(received, expected[:])
-}
-
 // signOutgoing signs a marshalled request in place when signing is active for the
 // connection, consuming the next send sequence number. It returns the sequence
-// number expected on the matching response and whether the message was signed. When
-// signing is inactive it leaves the message untouched and returns (0, false).
+// number expected on the matching response and whether the message was signed.
+// When signing is inactive it leaves the message untouched and returns (0, false).
 func (c *Client) signOutgoing(marshalled []byte) (uint32, bool) {
 	if c.Connection == nil || !c.Connection.IsSigningActive {
 		return 0, false
 	}
+
 	sequenceNumber := c.Connection.ClientNextSendSequenceNumber
-	signSMBMessage(c.Connection.SigningSessionKey, marshalled, sequenceNumber)
-	// The response carries the next sequence number; advance past both the request
-	// and its response for the following exchange.
-	c.Connection.ClientNextSendSequenceNumber += 2
-	return sequenceNumber + 1, true
+	signing.Sign(c.Connection.SigningSessionKey, marshalled, sequenceNumber)
+
+	// The request and its response consume one sequence number each, so the
+	// following request skips past both.
+	c.Connection.ClientNextSendSequenceNumber = signing.NextRequestSequenceNumber(sequenceNumber)
+
+	return signing.ResponseSequenceNumber(sequenceNumber), true
 }
 
 // verifyIncoming validates the signature of a received response against the given
@@ -97,7 +39,7 @@ func (c *Client) verifyIncoming(raw []byte, responseSequenceNumber uint32) error
 	if c.Connection == nil || !c.Connection.IsSigningActive {
 		return nil
 	}
-	if !verifySMBSignature(c.Connection.SigningSessionKey, raw, responseSequenceNumber) {
+	if !signing.Verify(c.Connection.SigningSessionKey, raw, responseSequenceNumber) {
 		return fmt.Errorf("invalid SMB message signature on response (expected sequence %d)", responseSequenceNumber)
 	}
 	return nil

--- a/network/smb/smb_v10/client/signing_test.go
+++ b/network/smb/smb_v10/client/signing_test.go
@@ -2,125 +2,26 @@ package client
 
 import (
 	"bytes"
-	"crypto/md5"
-	"encoding/binary"
 	"testing"
 
-	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header"
-	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/securityfeatures"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/signing"
 )
 
-// TestSecuritySignatureOffsetMatchesHeader guards the securitySignatureOffset
-// constant against drift in the SMB header layout: a marshalled header MUST carry
-// its 8-byte SecurityFeatures field exactly at securitySignatureOffset.
-func TestSecuritySignatureOffsetMatchesHeader(t *testing.T) {
-	h := header.NewHeader()
-	sig := securityfeatures.NewSecurityFeaturesSecuritySignature()
-	sig.SetSecuritySignature([8]byte{0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA})
-	h.SecurityFeatures = sig
-
-	raw, err := h.Marshal()
-	if err != nil {
-		t.Fatalf("header Marshal failed: %v", err)
-	}
-	if len(raw) != header.SMB_HEADER_SIZE {
-		t.Fatalf("header is %d bytes, want %d", len(raw), header.SMB_HEADER_SIZE)
-	}
-	want := bytes.Repeat([]byte{0xAA}, securitySignatureSize)
-	if !bytes.Equal(raw[securitySignatureOffset:securitySignatureOffset+securitySignatureSize], want) {
-		t.Errorf("SecurityFeatures not at offset %d: bytes there = % x", securitySignatureOffset, raw[securitySignatureOffset:securitySignatureOffset+securitySignatureSize])
-	}
-}
+// The signature algorithm itself is covered in the signing package; these tests
+// cover the client's use of it: which sequence number is consumed, when signing
+// applies at all, and what the connection state looks like afterwards.
 
 // makeMessage returns a deterministic pseudo-message of the given length whose
-// SecurityFeatures field (bytes 14..22) starts zeroed, as a freshly marshalled SMB
-// message would.
+// SecurityFeatures field starts zeroed, as a freshly marshalled SMB message would.
 func makeMessage(n int) []byte {
 	msg := make([]byte, n)
 	for i := range msg {
 		msg[i] = byte(i)
 	}
-	for i := securitySignatureOffset; i < securitySignatureOffset+securitySignatureSize && i < n; i++ {
+	for i := signing.SecuritySignatureOffset; i < signing.SecuritySignatureOffset+signing.SecuritySignatureSize && i < n; i++ {
 		msg[i] = 0
 	}
 	return msg
-}
-
-// TestComputeSMBSignatureMatchesFormula pins the signature algorithm: the 8-byte
-// signature MUST equal the first 8 bytes of MD5(MACKey || message), with the
-// message's signature field set to the little-endian sequence number followed by
-// four zero bytes. The independent computation here guards the field offset, the
-// sequence-number placement, the endianness, and the digest input order.
-func TestComputeSMBSignatureMatchesFormula(t *testing.T) {
-	key := []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
-	msg := makeMessage(64)
-	const seq = uint32(0x04030201)
-
-	// Independent reference computation.
-	ref := make([]byte, len(msg))
-	copy(ref, msg)
-	binary.LittleEndian.PutUint32(ref[securitySignatureOffset:securitySignatureOffset+4], seq)
-	for i := securitySignatureOffset + 4; i < securitySignatureOffset+8; i++ {
-		ref[i] = 0
-	}
-	sum := md5.Sum(append(append([]byte{}, key...), ref...))
-	var want [8]byte
-	copy(want[:], sum[:8])
-
-	got := computeSMBSignature(key, msg, seq)
-	if got != want {
-		t.Errorf("signature = % x, want % x", got, want)
-	}
-
-	// The input message must not have been modified.
-	if msg[securitySignatureOffset] != 0 {
-		t.Error("computeSMBSignature modified the caller's buffer")
-	}
-}
-
-// TestSignAndVerifyRoundTrip verifies a signed message validates with the same key
-// and sequence number, and that the signature is written at the right offset.
-func TestSignAndVerifyRoundTrip(t *testing.T) {
-	key := bytes.Repeat([]byte{0xAB}, 16)
-	msg := makeMessage(48)
-	const seq = uint32(7)
-
-	signSMBMessage(key, msg, seq)
-
-	if !verifySMBSignature(key, msg, seq) {
-		t.Fatal("verifySMBSignature failed on a freshly signed message")
-	}
-	// The signature must have been written into the SecurityFeatures field.
-	if bytes.Equal(msg[securitySignatureOffset:securitySignatureOffset+8], make([]byte, 8)) {
-		t.Error("signature field is still zero after signing")
-	}
-}
-
-// TestVerifyRejectsTamperingAndWrongSequence verifies that signature validation
-// fails on a modified body or a mismatched sequence number.
-func TestVerifyRejectsTamperingAndWrongSequence(t *testing.T) {
-	key := bytes.Repeat([]byte{0x5A}, 16)
-	const seq = uint32(2)
-
-	msg := makeMessage(48)
-	signSMBMessage(key, msg, seq)
-
-	// Wrong sequence number.
-	if verifySMBSignature(key, msg, seq+1) {
-		t.Error("verification passed with the wrong sequence number")
-	}
-
-	// Tampered payload (a byte outside the signature field).
-	tampered := append([]byte{}, msg...)
-	tampered[40] ^= 0xFF
-	if verifySMBSignature(key, tampered, seq) {
-		t.Error("verification passed on a tampered message")
-	}
-
-	// Wrong key.
-	if verifySMBSignature(bytes.Repeat([]byte{0x00}, 16), msg, seq) {
-		t.Error("verification passed with the wrong key")
-	}
 }
 
 // TestSignOutgoingInactiveIsNoOp verifies that when signing is inactive the message
@@ -165,13 +66,13 @@ func TestSignOutgoingActiveAdvancesSequence(t *testing.T) {
 		t.Errorf("expected next send sequence 4, got %d", c.Connection.ClientNextSendSequenceNumber)
 	}
 	// The request was signed with sequence 2.
-	if !verifySMBSignature(key, msg, 2) {
+	if !signing.Verify(key, msg, 2) {
 		t.Error("signed message does not validate at the consumed sequence number")
 	}
 
 	// verifyIncoming should accept a response signed at the returned sequence number.
 	resp := makeMessage(48)
-	signSMBMessage(key, resp, respSeq)
+	signing.Sign(key, resp, respSeq)
 	if err := c.verifyIncoming(resp, respSeq); err != nil {
 		t.Errorf("verifyIncoming rejected a valid response: %v", err)
 	}
@@ -179,5 +80,49 @@ func TestSignOutgoingActiveAdvancesSequence(t *testing.T) {
 	resp[30] ^= 0xFF
 	if err := c.verifyIncoming(resp, respSeq); err == nil {
 		t.Error("verifyIncoming accepted a tampered response")
+	}
+}
+
+// TestSignOutgoingHandlesNilConnection asserts a client with no connection is a
+// no-op rather than a nil dereference, since the guard is what every send path
+// relies on before signing is ever armed.
+func TestSignOutgoingHandlesNilConnection(t *testing.T) {
+	c := &Client{}
+	msg := makeMessage(48)
+
+	if respSeq, signed := c.signOutgoing(msg); signed || respSeq != 0 {
+		t.Errorf("expected (0, false) with no connection, got (%d, %v)", respSeq, signed)
+	}
+	if err := c.verifyIncoming(msg, 0); err != nil {
+		t.Errorf("verifyIncoming with no connection should be a no-op, got %v", err)
+	}
+}
+
+// TestSignOutgoingConsumesSuccessiveNumbers asserts consecutive requests on one
+// connection take successive even numbers, and each expects the odd one above.
+func TestSignOutgoingConsumesSuccessiveNumbers(t *testing.T) {
+	key := bytes.Repeat([]byte{0x42}, 16)
+	c := &Client{Connection: &Connection{
+		IsSigningActive:   true,
+		SigningSessionKey: key,
+		// Signing is armed by the AUTHENTICATE exchange, which consumes 0 and 1.
+		ClientNextSendSequenceNumber: 2,
+	}}
+
+	for expected := uint32(2); expected <= 8; expected += 2 {
+		msg := makeMessage(48)
+		respSeq, signed := c.signOutgoing(msg)
+		if !signed {
+			t.Fatalf("request at %d was not signed", expected)
+		}
+		if !signing.Verify(key, msg, expected) {
+			t.Fatalf("request was not signed at %d", expected)
+		}
+		if respSeq != expected+1 {
+			t.Fatalf("expected response sequence %d, got %d", expected+1, respSeq)
+		}
+	}
+	if c.Connection.ClientNextSendSequenceNumber != 10 {
+		t.Fatalf("next send sequence = %d, want 10", c.Connection.ClientNextSendSequenceNumber)
 	}
 }

--- a/network/smb/smb_v10/signing/signing.go
+++ b/network/smb/smb_v10/signing/signing.go
@@ -1,0 +1,149 @@
+// Package signing implements SMB 1.0 message signing.
+//
+// The primitives are direction-agnostic, because signing is symmetric: each side
+// signs what it sends and verifies what it receives with the same key and the
+// same digest. Only the sequence numbers differ, and which of them a party uses
+// is the one thing that distinguishes a client from a server here.
+//
+// # The MAC key
+//
+// The key is the ExportedSessionKey derived from the authentication exchange,
+// used as-is. [MS-CIFS] 3.1.5.1 also defines a MACKey of SessionKey ||
+// NTLMResponse for the paths that do not derive a session key, but neither side
+// of this implementation takes such a path: extended session security is required
+// precisely so a key exists to sign with.
+//
+// # Sequence numbers
+//
+// Signing is bootstrapped by the authentication exchange and then advances in
+// pairs. A request carries an even sequence number and the response to it carries
+// the odd number above, so the AUTHENTICATE request is signed at 0, its response
+// at 1, and the next request at 2.
+//
+// A client therefore consumes a number when it sends and expects the next one
+// back; a server verifies at the number it expects and signs its reply at the one
+// above. ResponseSequenceNumber and NextRequestSequenceNumber name the two steps
+// so both sides derive them the same way rather than each spelling out an
+// increment.
+//
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/59ec6b57-7e1b-4a0e-bbdf-1a4f4e0e1d75
+package signing
+
+import (
+	"crypto/hmac"
+	"crypto/md5"
+	"encoding/binary"
+)
+
+// SecuritySignatureOffset is the byte offset, from the start of the SMB header, of
+// the 8-byte SecurityFeatures field that carries the signature:
+// Protocol(4) + Command(1) + Status(4) + Flags(1) + Flags2(2) + PIDHigh(2) = 14.
+const SecuritySignatureOffset = 14
+
+// SecuritySignatureSize is the size, in bytes, of the SecuritySignature field.
+const SecuritySignatureSize = 8
+
+// Signature is an SMB 1.0 message signature.
+type Signature = [SecuritySignatureSize]byte
+
+// Compute returns the signature for a fully marshalled SMB message.
+//
+// The signature is the first 8 bytes of MD5(MACKey || message), where the
+// message's SecuritySignature field has first been replaced by the 32-bit
+// sequence number in little-endian order followed by four zero bytes. The input
+// slice is not modified.
+//
+// Parameters:
+//   - macKey: the MAC key, which is the exported session key
+//   - message: the marshalled SMB message, header included
+//   - sequenceNumber: the sequence number this message is signed at
+//
+// Returns:
+//   - The signature
+func Compute(macKey, message []byte, sequenceNumber uint32) Signature {
+	// Work on a copy so the caller's buffer is untouched while the sequence
+	// number stands in for the signature during the digest.
+	buffer := make([]byte, len(message))
+	copy(buffer, message)
+
+	if len(buffer) >= SecuritySignatureOffset+SecuritySignatureSize {
+		binary.LittleEndian.PutUint32(buffer[SecuritySignatureOffset:SecuritySignatureOffset+4], sequenceNumber)
+		for i := SecuritySignatureOffset + 4; i < SecuritySignatureOffset+SecuritySignatureSize; i++ {
+			buffer[i] = 0x00
+		}
+	}
+
+	digest := md5.New()
+	digest.Write(macKey)
+	digest.Write(buffer)
+	sum := digest.Sum(nil)
+
+	var signature Signature
+	copy(signature[:], sum[:SecuritySignatureSize])
+	return signature
+}
+
+// Sign computes the signature for a marshalled message and writes it into the
+// message's SecuritySignature field in place.
+//
+// A message too short to carry a signature is left alone: there is no field to
+// write into, and the caller's own framing will have already rejected it.
+//
+// Parameters:
+//   - macKey: the MAC key
+//   - message: the marshalled SMB message, modified in place
+//   - sequenceNumber: the sequence number to sign at
+func Sign(macKey, message []byte, sequenceNumber uint32) {
+	if len(message) < SecuritySignatureOffset+SecuritySignatureSize {
+		return
+	}
+	signature := Compute(macKey, message, sequenceNumber)
+	copy(message[SecuritySignatureOffset:SecuritySignatureOffset+SecuritySignatureSize], signature[:])
+}
+
+// Verify reports whether a marshalled message carries a valid signature for the
+// given key and sequence number. The comparison is constant-time.
+//
+// Parameters:
+//   - macKey: the MAC key
+//   - message: the marshalled SMB message as received
+//   - sequenceNumber: the sequence number the message is expected to be signed at
+//
+// Returns:
+//   - true when the signature is valid
+func Verify(macKey, message []byte, sequenceNumber uint32) bool {
+	if len(message) < SecuritySignatureOffset+SecuritySignatureSize {
+		return false
+	}
+
+	received := make([]byte, SecuritySignatureSize)
+	copy(received, message[SecuritySignatureOffset:SecuritySignatureOffset+SecuritySignatureSize])
+
+	expected := Compute(macKey, message, sequenceNumber)
+	return hmac.Equal(received, expected[:])
+}
+
+// ResponseSequenceNumber returns the sequence number the response to a request
+// must carry, given the number the request was signed at.
+//
+// Parameters:
+//   - requestSequenceNumber: the number the request was signed at
+//
+// Returns:
+//   - The number its response is signed at
+func ResponseSequenceNumber(requestSequenceNumber uint32) uint32 {
+	return requestSequenceNumber + 1
+}
+
+// NextRequestSequenceNumber returns the sequence number the following request
+// must carry, given the number the current one was signed at. A request and its
+// response consume one number each, so the next request skips both.
+//
+// Parameters:
+//   - requestSequenceNumber: the number the current request was signed at
+//
+// Returns:
+//   - The number the next request is signed at
+func NextRequestSequenceNumber(requestSequenceNumber uint32) uint32 {
+	return requestSequenceNumber + 2
+}

--- a/network/smb/smb_v10/signing/signing_test.go
+++ b/network/smb/smb_v10/signing/signing_test.go
@@ -1,0 +1,206 @@
+package signing
+
+import (
+	"bytes"
+	"crypto/md5"
+	"encoding/binary"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/securityfeatures"
+)
+
+// TestSecuritySignatureOffsetMatchesHeader guards SecuritySignatureOffset against
+// drift in the SMB header layout: a marshalled header MUST carry its 8-byte
+// SecurityFeatures field exactly there.
+func TestSecuritySignatureOffsetMatchesHeader(t *testing.T) {
+	h := header.NewHeader()
+	sig := securityfeatures.NewSecurityFeaturesSecuritySignature()
+	sig.SetSecuritySignature([8]byte{0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA})
+	h.SecurityFeatures = sig
+
+	raw, err := h.Marshal()
+	if err != nil {
+		t.Fatalf("header Marshal failed: %v", err)
+	}
+	if len(raw) != header.SMB_HEADER_SIZE {
+		t.Fatalf("header is %d bytes, want %d", len(raw), header.SMB_HEADER_SIZE)
+	}
+	want := bytes.Repeat([]byte{0xAA}, SecuritySignatureSize)
+	if !bytes.Equal(raw[SecuritySignatureOffset:SecuritySignatureOffset+SecuritySignatureSize], want) {
+		t.Errorf("SecurityFeatures not at offset %d: bytes there = % x",
+			SecuritySignatureOffset, raw[SecuritySignatureOffset:SecuritySignatureOffset+SecuritySignatureSize])
+	}
+}
+
+// makeMessage returns a deterministic pseudo-message of the given length whose
+// SecurityFeatures field starts zeroed, as a freshly marshalled SMB message would.
+func makeMessage(n int) []byte {
+	msg := make([]byte, n)
+	for i := range msg {
+		msg[i] = byte(i)
+	}
+	for i := SecuritySignatureOffset; i < SecuritySignatureOffset+SecuritySignatureSize && i < n; i++ {
+		msg[i] = 0
+	}
+	return msg
+}
+
+// TestComputeMatchesFormula pins the algorithm: the signature MUST equal the first
+// 8 bytes of MD5(MACKey || message), with the message's signature field set to the
+// little-endian sequence number followed by four zero bytes. The independent
+// computation here guards the field offset, the sequence-number placement, the
+// endianness and the digest input order.
+func TestComputeMatchesFormula(t *testing.T) {
+	key := []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
+	msg := makeMessage(64)
+	const seq = uint32(0x04030201)
+
+	// Independent reference computation.
+	ref := make([]byte, len(msg))
+	copy(ref, msg)
+	binary.LittleEndian.PutUint32(ref[SecuritySignatureOffset:SecuritySignatureOffset+4], seq)
+	for i := SecuritySignatureOffset + 4; i < SecuritySignatureOffset+8; i++ {
+		ref[i] = 0
+	}
+	sum := md5.Sum(append(append([]byte{}, key...), ref...))
+	var want Signature
+	copy(want[:], sum[:8])
+
+	got := Compute(key, msg, seq)
+	if got != want {
+		t.Errorf("signature = % x, want % x", got, want)
+	}
+
+	// The input message must not have been modified.
+	if msg[SecuritySignatureOffset] != 0 {
+		t.Error("Compute modified the caller's buffer")
+	}
+}
+
+// TestSignAndVerifyRoundTrip verifies a signed message validates with the same key
+// and sequence number, and that the signature is written at the right offset.
+func TestSignAndVerifyRoundTrip(t *testing.T) {
+	key := bytes.Repeat([]byte{0xAB}, 16)
+	msg := makeMessage(48)
+	const seq = uint32(7)
+
+	Sign(key, msg, seq)
+
+	if !Verify(key, msg, seq) {
+		t.Fatal("Verify failed on a freshly signed message")
+	}
+	// The signature must have been written into the SecurityFeatures field.
+	if bytes.Equal(msg[SecuritySignatureOffset:SecuritySignatureOffset+8], make([]byte, 8)) {
+		t.Error("signature field is still zero after signing")
+	}
+}
+
+// TestVerifyRejectsTamperingAndWrongSequence verifies that validation fails on a
+// modified body, a mismatched sequence number, or the wrong key.
+func TestVerifyRejectsTamperingAndWrongSequence(t *testing.T) {
+	key := bytes.Repeat([]byte{0x5A}, 16)
+	const seq = uint32(2)
+
+	msg := makeMessage(48)
+	Sign(key, msg, seq)
+
+	if Verify(key, msg, seq+1) {
+		t.Error("verification passed with the wrong sequence number")
+	}
+
+	tampered := append([]byte{}, msg...)
+	tampered[40] ^= 0xFF
+	if Verify(key, tampered, seq) {
+		t.Error("verification passed on a tampered message")
+	}
+
+	if Verify(bytes.Repeat([]byte{0x00}, 16), msg, seq) {
+		t.Error("verification passed with the wrong key")
+	}
+}
+
+// TestShortMessages asserts a message too short to carry a signature is handled
+// rather than indexed into. A signing implementation is reachable from the network
+// on the server side, so a short frame must not panic.
+func TestShortMessages(t *testing.T) {
+	key := bytes.Repeat([]byte{0x11}, 16)
+
+	for length := 0; length < SecuritySignatureOffset+SecuritySignatureSize; length++ {
+		short := make([]byte, length)
+
+		// Sign leaves it alone: there is no field to write into.
+		before := append([]byte{}, short...)
+		Sign(key, short, 1)
+		if !bytes.Equal(short, before) {
+			t.Fatalf("Sign modified a %d-byte message that cannot carry a signature", length)
+		}
+
+		// Verify reports failure rather than reading past the end.
+		if Verify(key, short, 1) {
+			t.Fatalf("Verify accepted a %d-byte message", length)
+		}
+
+		// Compute must not panic, and must not read past the end.
+		Compute(key, short, 1)
+	}
+}
+
+// TestSequenceNumberRule pins the pairing rule both sides depend on: a request
+// takes a number, its response the one above, and the next request skips both.
+// Getting this wrong in one direction produces signatures the other side rejects.
+func TestSequenceNumberRule(t *testing.T) {
+	// The AUTHENTICATE request is signed at 0, so its response is at 1 and the
+	// first request after it is at 2.
+	if got := ResponseSequenceNumber(0); got != 1 {
+		t.Errorf("ResponseSequenceNumber(0) = %d, want 1", got)
+	}
+	if got := NextRequestSequenceNumber(0); got != 2 {
+		t.Errorf("NextRequestSequenceNumber(0) = %d, want 2", got)
+	}
+
+	// Requests stay even and responses odd as the exchange advances.
+	sequence := uint32(0)
+	for exchange := 0; exchange < 8; exchange++ {
+		if sequence%2 != 0 {
+			t.Fatalf("request %d is signed at %d, which is not even", exchange, sequence)
+		}
+		if response := ResponseSequenceNumber(sequence); response%2 == 0 {
+			t.Fatalf("response %d is signed at %d, which is not odd", exchange, response)
+		}
+		sequence = NextRequestSequenceNumber(sequence)
+	}
+	if sequence != 16 {
+		t.Fatalf("after 8 exchanges the sequence is %d, want 16", sequence)
+	}
+}
+
+// TestSignVerifyAcrossSides asserts the primitives are usable in both directions:
+// what one party signs at a sequence number, the other verifies at the same one.
+// That symmetry is why the package is direction-agnostic.
+func TestSignVerifyAcrossSides(t *testing.T) {
+	key := bytes.Repeat([]byte{0x7E}, 16)
+
+	// A request signed by the sending side.
+	request := makeMessage(64)
+	requestSequence := uint32(4)
+	Sign(key, request, requestSequence)
+
+	// The receiving side verifies at the number it expects.
+	if !Verify(key, request, requestSequence) {
+		t.Fatal("the receiving side rejected a validly signed request")
+	}
+
+	// It then signs its reply at the number above, which the original sender
+	// verifies at the value it was told to expect.
+	response := makeMessage(48)
+	responseSequence := ResponseSequenceNumber(requestSequence)
+	Sign(key, response, responseSequence)
+	if !Verify(key, response, responseSequence) {
+		t.Fatal("the requesting side rejected a validly signed response")
+	}
+	// And the response must not verify at the request's number.
+	if Verify(key, response, requestSequence) {
+		t.Fatal("the response verified at the request's sequence number")
+	}
+}


### PR DESCRIPTION
### Summary

Commit 6 of 12 for #1068. **Independent of the other commits** — it touches only `network/smb/smb_v10/client` and adds a new package, so it targets `main` and can merge in any order.

Signing is symmetric: each side signs what it sends and verifies what it receives with the same key and the same digest, and only the sequence numbers differ. The primitives were unexported inside the client package, so a server could not reach them and would have had to carry a second copy of the algorithm — the kind of duplicate that stays correct only until one side is touched.

### Changes

- **`network/smb/smb_v10/signing`** exports `Compute`, `Sign` and `Verify`, plus `SecuritySignatureOffset` / `SecuritySignatureSize`. Direction-agnostic, because the algorithm is.
- The client keeps `signOutgoing` / `verifyIncoming` — those are about its own sequence-number bookkeeping, not about the algorithm — and now delegate.
- **The sequence-number rule moves with the primitives**, because it is the one thing the two sides must agree on and the easiest to get wrong in a mirror implementation. A request takes an even number and its response the odd number above: the AUTHENTICATE request is signed at 0, its response at 1, the next request at 2. `ResponseSequenceNumber` and `NextRequestSequenceNumber` name those steps so neither side spells out a bare increment — the client now uses both, in place of the `+= 2` and the literal `2` it had in `session.go`.

The package doc records what the MAC key actually is, since it is not what [MS-CIFS] 3.1.5.1 describes first: **the exported session key used as-is**, not the `SessionKey || NTLMResponse` construction. That form belongs to the paths that derive no session key, and neither side takes one — extended session security is required precisely so a key exists to sign with. (My original plan sketch had this wrong and said a derivation helper was needed; there isn't one.)

### No behaviour changes

`go build ./...`, `go vet ./...` and `go test ./...` green across the repository. The existing client-level tests pass unchanged, which is the main evidence the move is faithful.

The algorithm tests move to the new package, where `TestComputeMatchesFormula` still recomputes `MD5(MACKey || message)` directly with `crypto/md5` rather than through the code under test — so the field offset, the sequence-number placement, the endianness and the digest input order stay pinned independently rather than self-referentially.

Added in the new package:

- **short messages** — `Sign` leaves them alone and `Verify` refuses rather than indexing past the end, for every length below the minimum. This matters now in a way it did not before: a server feeds these primitives straight from the network.
- **the sequence pairing across eight exchanges**, asserting requests stay even and responses odd.
- **a two-sided exchange**: what one party signs the other verifies at the same number, and a response does *not* verify at its request's number.

The client keeps the tests about its own use of the primitives, plus a nil-connection case — the guard every send path relies on before signing is armed.

### Notes

This is the last small item before commit 7 (verified sessions with signing armed in both directions), which is where the server side of these primitives gets its first caller.