### PR TITLE
Serve a disk share (Refs #1068)

### DIFF
--- a/network/smb/smb_v10/server/conformance_test.go
+++ b/network/smb/smb_v10/server/conformance_test.go
@@ -118,6 +118,21 @@ var servedCommands = map[codes.CommandCode]string{
 	codes.SMB_COM_SESSION_SETUP_ANDX: "runs the authentication exchange",
 	codes.SMB_COM_LOGOFF_ANDX:        "drops the session",
 	codes.SMB_COM_ECHO:               "echoes the payload",
+
+	codes.SMB_COM_TREE_CONNECT_ANDX: "connects a tree to a share",
+	codes.SMB_COM_TREE_DISCONNECT:   "drops the tree and its handles",
+
+	codes.SMB_COM_NT_CREATE_ANDX: "opens or creates a file or directory",
+	codes.SMB_COM_CLOSE:          "releases a handle",
+	codes.SMB_COM_READ_ANDX:      "reads from a handle",
+	codes.SMB_COM_WRITE_ANDX:     "writes through a handle",
+	codes.SMB_COM_FLUSH:          "commits a handle, or the whole tree",
+
+	codes.SMB_COM_DELETE:           "deletes a file, wildcards included",
+	codes.SMB_COM_RENAME:           "renames or moves an entry",
+	codes.SMB_COM_CREATE_DIRECTORY: "creates a directory",
+	codes.SMB_COM_DELETE_DIRECTORY: "removes an empty directory",
+	codes.SMB_COM_CHECK_DIRECTORY:  "reports whether a path is a directory",
 }
 
 // TestConformanceServedCommandsAreServed asserts every command in the served set
@@ -246,9 +261,9 @@ func TestConformanceClientAPI(t *testing.T) {
 				}
 			})
 
-			t.Run("TreeConnect is not served yet", func(t *testing.T) {
-				if err := client.TreeConnect("share"); err == nil {
-					t.Fatal("TreeConnect() succeeded, but no share can be reached at this phase")
+			t.Run("TreeConnect to an unserved share", func(t *testing.T) {
+				if err := client.TreeConnect("nosuchshare"); err == nil {
+					t.Fatal("TreeConnect() succeeded for a share that is not served")
 				}
 			})
 

--- a/network/smb/smb_v10/server/connection.go
+++ b/network/smb/smb_v10/server/connection.go
@@ -70,10 +70,15 @@ type Connection struct {
 	SigningKey                    []byte
 	ExpectedRequestSequenceNumber uint32
 
-	// sessions are the authenticated sessions on this connection, by UID, and
-	// uids allocates those identifiers.
+	// sessions are the authenticated sessions on this connection, by UID, trees
+	// the shares connected to, and opens the file handles held. Each has its own
+	// allocator, since the three identifier spaces are independent.
 	sessions map[uint16]*Session
 	uids     *identifierAllocator
+	trees    map[uint16]*Tree
+	tids     *identifierAllocator
+	opens    map[uint16]*Open
+	fids     *identifierAllocator
 
 	// currentRequestFrame is the raw frame being handled, kept because a
 	// signature covers the message as received: verifying one means hashing those
@@ -100,6 +105,10 @@ func newConnection(srv *Server, t transport.Transport, remote net.Addr) *Connect
 		Remote:      remote,
 		sessions:    make(map[uint16]*Session),
 		uids:        newIdentifierAllocator(srv.config.MaxSessionsPerConnection),
+		trees:       make(map[uint16]*Tree),
+		tids:        newIdentifierAllocator(srv.config.MaxTreesPerConnection),
+		opens:       make(map[uint16]*Open),
+		fids:        newIdentifierAllocator(srv.config.MaxOpensPerConnection),
 		pendingAuth: make(map[uint16]*spnego.AcceptContext),
 	}
 }

--- a/network/smb/smb_v10/server/dispatch.go
+++ b/network/smb/smb_v10/server/dispatch.go
@@ -26,10 +26,29 @@ type commandHandler func(conn *Connection, w ResponseWriter, req *message.Messag
 // reserved and never implemented, and the specification requires exactly that
 // answer for them.
 var dispatchTable = map[codes.CommandCode]commandHandler{
+	// Connection and session.
 	codes.SMB_COM_NEGOTIATE:          handleNegotiate,
 	codes.SMB_COM_SESSION_SETUP_ANDX: handleSessionSetupAndx,
 	codes.SMB_COM_LOGOFF_ANDX:        handleLogoffAndx,
 	codes.SMB_COM_ECHO:               handleEcho,
+
+	// Trees.
+	codes.SMB_COM_TREE_CONNECT_ANDX: handleTreeConnectAndx,
+	codes.SMB_COM_TREE_DISCONNECT:   handleTreeDisconnect,
+
+	// File handles.
+	codes.SMB_COM_NT_CREATE_ANDX: handleNtCreateAndx,
+	codes.SMB_COM_CLOSE:          handleClose,
+	codes.SMB_COM_READ_ANDX:      handleReadAndx,
+	codes.SMB_COM_WRITE_ANDX:     handleWriteAndx,
+	codes.SMB_COM_FLUSH:          handleFlush,
+
+	// File management.
+	codes.SMB_COM_DELETE:           handleDelete,
+	codes.SMB_COM_RENAME:           handleRename,
+	codes.SMB_COM_CREATE_DIRECTORY: handleCreateDirectory,
+	codes.SMB_COM_DELETE_DIRECTORY: handleDeleteDirectory,
+	codes.SMB_COM_CHECK_DIRECTORY:  handleCheckDirectory,
 }
 
 // sessionlessCommands are the commands a client may send before it holds a

--- a/network/smb/smb_v10/server/dispatch_test.go
+++ b/network/smb/smb_v10/server/dispatch_test.go
@@ -270,10 +270,10 @@ func TestUnimplementedCommandIsRefused(t *testing.T) {
 	_, addr := serverWithAccount(t, SigningDisabled, nil)
 	session := establishSession(t, addr, captureDomain, captureUsername, capturePassword, false)
 
-	// SMB_COM_TREE_CONNECT_ANDX is a recognized command that no handler serves yet.
-	request := newRequest(codes.SMB_COM_TREE_CONNECT_ANDX)
+	// SMB_COM_SEEK is a recognized command that no handler serves yet.
+	request := newRequest(codes.SMB_COM_SEEK)
 	request.Header.UID = session.uid
-	request.AddCommand(commands.NewTreeConnectAndxRequest())
+	request.AddCommand(commands.NewSeekRequest())
 	sendRequest(t, session.client, request)
 
 	response, raw := receiveResponse(t, session.client)
@@ -303,11 +303,11 @@ func TestUnimplementedCommandUsesLegacyStatusEncoding(t *testing.T) {
 	_, addr := serverWithAccount(t, SigningDisabled, nil)
 	session := establishSession(t, addr, captureDomain, captureUsername, capturePassword, false)
 
-	request := newRequest(codes.SMB_COM_TREE_CONNECT_ANDX)
+	request := newRequest(codes.SMB_COM_SEEK)
 	request.Header.UID = session.uid
 	// Clear the NT-status bit, leaving an old-style client.
 	request.Header.Flags2 &= ^flags2.Flags2(flags2.FLAGS2_NT_STATUS_ERROR_CODES)
-	request.AddCommand(commands.NewTreeConnectAndxRequest())
+	request.AddCommand(commands.NewSeekRequest())
 	sendRequest(t, session.client, request)
 
 	response, _ := receiveResponse(t, session.client)

--- a/network/smb/smb_v10/server/doc.go
+++ b/network/smb/smb_v10/server/doc.go
@@ -28,11 +28,40 @@
 //   - SMB_COM_LOGOFF_ANDX.
 //   - SMB_COM_ECHO.
 //   - Message signing in both directions, when the policy calls for it.
+//   - Tree connect and disconnect against a registered share.
+//   - File service: open and create, read, write, close, flush, delete, rename,
+//     and the directory create, remove and check commands.
 //
-// Not yet implemented: every other command, answered with
-// STATUS_NOT_IMPLEMENTED. A client can now authenticate, but there is still
-// nothing to reach: no share can be connected to and no file opened, because
-// tree connect and the file commands arrive with a later phase.
+// Not yet implemented, and answered with STATUS_NOT_IMPLEMENTED: directory
+// enumeration (the TRANSACTION2 FIND subcommands), the query and set information
+// commands, byte-range locking, seek, the legacy SMB_COM_OPEN_ANDX, the
+// NT_TRANSACT subcommands, named pipes, and batched AndX chains beyond their
+// first command. A client can open and read a file by name but cannot yet list a
+// directory or ask about a file without opening it.
+//
+// # Shares
+//
+// A Share is registered with AddShare and backed by a FileSystem.
+// NewLocalFileSystem serves a directory on the host; NewMemoryFileSystem serves
+// storage that never touches disk, which is what the tests use and what a share
+// meant to look real without being real would use.
+//
+// A share may be marked ReadOnly, which refuses every modifying command whatever
+// access the client asked for. That is enforced in the handlers rather than left
+// to the backend, so a backend cannot forget it.
+//
+// # Path containment
+//
+// Every path a client sends passes through resolvePath before any backend sees
+// it, and a backend is entitled to assume the result cannot escape the share. The
+// resolver refuses rather than normalises: a path containing ".." is rejected
+// outright instead of being rewritten, because rewriting turns a traversal attempt
+// into a successful access somewhere unintended.
+//
+// LocalFileSystem adds a second, independent check, because path validation
+// cannot see a symbolic link inside the share pointing out of it: every resolved
+// host path is compared against the share root again after the host has followed
+// its links.
 //
 // # Authentication
 //

--- a/network/smb/smb_v10/server/file_service_test.go
+++ b/network/smb/smb_v10/server/file_service_test.go
@@ -1,0 +1,734 @@
+package server
+
+import (
+	"bytes"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	smb1client "github.com/TheManticoreProject/Manticore/network/smb/smb_v10/client"
+	"github.com/TheManticoreProject/Manticore/windows/credentials"
+	"github.com/TheManticoreProject/Manticore/windows/fileflags"
+)
+
+// fileShareName is the share the file-service tests connect to.
+const fileShareName = "files"
+
+// fileServer stands up a server with one disk share backed by the given file
+// system, and returns a client already authenticated and connected to it.
+func fileServer(t *testing.T, fs FileSystem, readOnly bool) (*Server, *smb1client.Client) {
+	t.Helper()
+
+	srv, transportEnd := pipedServer(t, conformanceConfig(SigningDisabled))
+	if err := srv.AddShare(&Share{Name: fileShareName, Type: ShareTypeDisk, FS: fs, ReadOnly: readOnly}); err != nil {
+		t.Fatalf("AddShare() error = %v", err)
+	}
+
+	client := smb1client.NewFromTransport(transportEnd, net.IPv4(127, 0, 0, 1), 445)
+	if err := client.Negotiate(); err != nil {
+		t.Fatalf("Negotiate() error = %v", err)
+	}
+	creds, err := credentials.NewCredentials(captureDomain, captureUsername, capturePassword, "")
+	if err != nil {
+		t.Fatalf("NewCredentials() error = %v", err)
+	}
+	if err := client.SessionSetup(creds); err != nil {
+		t.Fatalf("SessionSetup() error = %v", err)
+	}
+	if err := client.TreeConnect(fileShareName); err != nil {
+		t.Fatalf("TreeConnect() error = %v", err)
+	}
+
+	return srv, client
+}
+
+// TestFileServiceRoundTrip is the milestone this phase exists for: the SMB1 client
+// in this repository creates a file on the server, writes to it, reads it back and
+// closes it.
+func TestFileServiceRoundTrip(t *testing.T) {
+	fs := NewMemoryFileSystem("FILES")
+	_, client := fileServer(t, fs, false)
+
+	payload := []byte("the quick brown fox jumps over the lazy dog")
+
+	fid, err := client.OpenFile("newfile.txt",
+		fileflags.GENERIC_READ|fileflags.GENERIC_WRITE,
+		fileflags.FILE_SHARE_READ,
+		fileflags.FILE_OPEN_IF,
+		fileflags.FILE_NON_DIRECTORY_FILE)
+	if err != nil {
+		t.Fatalf("OpenFile() error = %v", err)
+	}
+
+	written, err := client.WriteFile(fid, 0, payload)
+	if err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	if written != len(payload) {
+		t.Fatalf("WriteFile() wrote %d bytes, want %d", written, len(payload))
+	}
+
+	read, err := client.ReadFile(fid, 0, uint32(len(payload)))
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if !bytes.Equal(read, payload) {
+		t.Fatalf("ReadFile() returned %q, want %q", read, payload)
+	}
+
+	if err := client.Flush(fid); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+	if err := client.CloseFile(fid); err != nil {
+		t.Fatalf("CloseFile() error = %v", err)
+	}
+
+	// The backend holds what was written, so the round trip went through the
+	// share rather than being answered from somewhere else.
+	attr, err := fs.Stat("newfile.txt")
+	if err != nil {
+		t.Fatalf("the file is not in the backend: %v", err)
+	}
+	if attr.Size != int64(len(payload)) {
+		t.Fatalf("the backend holds %d bytes, want %d", attr.Size, len(payload))
+	}
+}
+
+// TestFileServiceOffsetsAndShortReads asserts reads and writes at an offset, and
+// that a read reaching the end of the file returns what there was rather than
+// failing.
+func TestFileServiceOffsetsAndShortReads(t *testing.T) {
+	fs := NewMemoryFileSystem("FILES")
+	if err := fs.AddFile("data.bin", []byte("0123456789")); err != nil {
+		t.Fatalf("AddFile() error = %v", err)
+	}
+	_, client := fileServer(t, fs, false)
+
+	fid, err := client.OpenFile("data.bin",
+		fileflags.GENERIC_READ|fileflags.GENERIC_WRITE, fileflags.FILE_SHARE_READ,
+		fileflags.FILE_OPEN, fileflags.FILE_NON_DIRECTORY_FILE)
+	if err != nil {
+		t.Fatalf("OpenFile() error = %v", err)
+	}
+	defer client.CloseFile(fid)
+
+	// A read from the middle.
+	read, err := client.ReadFile(fid, 3, 4)
+	if err != nil {
+		t.Fatalf("ReadFile() at an offset error = %v", err)
+	}
+	if string(read) != "3456" {
+		t.Fatalf("read %q from offset 3, want %q", read, "3456")
+	}
+
+	// A read asking for more than remains returns what remains.
+	read, err = client.ReadFile(fid, 8, 100)
+	if err != nil {
+		t.Fatalf("ReadFile() past the end error = %v", err)
+	}
+	if string(read) != "89" {
+		t.Fatalf("read %q from offset 8, want %q", read, "89")
+	}
+
+	// A read entirely past the end returns nothing, and is not a failure.
+	read, err = client.ReadFile(fid, 1000, 10)
+	if err != nil {
+		t.Fatalf("ReadFile() entirely past the end error = %v", err)
+	}
+	if len(read) != 0 {
+		t.Fatalf("read %q past the end, want nothing", read)
+	}
+
+	// A write past the end extends the file, with the gap reading as zeroes.
+	if _, err := client.WriteFile(fid, 12, []byte("XY")); err != nil {
+		t.Fatalf("WriteFile() past the end error = %v", err)
+	}
+	read, err = client.ReadFile(fid, 0, 20)
+	if err != nil {
+		t.Fatalf("ReadFile() after extending error = %v", err)
+	}
+	want := append([]byte("0123456789"), 0x00, 0x00, 'X', 'Y')
+	if !bytes.Equal(read, want) {
+		t.Fatalf("read % x after extending, want % x", read, want)
+	}
+}
+
+// TestFileServiceDirectoryOperations asserts the directory commands.
+func TestFileServiceDirectoryOperations(t *testing.T) {
+	fs := NewMemoryFileSystem("FILES")
+	_, client := fileServer(t, fs, false)
+
+	if err := client.CreateDirectory("dir"); err != nil {
+		t.Fatalf("CreateDirectory() error = %v", err)
+	}
+	if err := client.CheckDirectory("dir"); err != nil {
+		t.Fatalf("CheckDirectory() on a directory error = %v", err)
+	}
+	// Creating it twice is a collision.
+	if err := client.CreateDirectory("dir"); err == nil {
+		t.Fatal("CreateDirectory() succeeded for a directory that already exists")
+	}
+	// A nested directory needs its parent, which now exists.
+	if err := client.CreateDirectory("dir\\sub"); err != nil {
+		t.Fatalf("CreateDirectory() for a nested directory error = %v", err)
+	}
+	// A non-empty directory is not removed.
+	if err := client.DeleteDirectory("dir"); err == nil {
+		t.Fatal("DeleteDirectory() removed a non-empty directory")
+	}
+	if err := client.DeleteDirectory("dir\\sub"); err != nil {
+		t.Fatalf("DeleteDirectory() error = %v", err)
+	}
+	if err := client.DeleteDirectory("dir"); err != nil {
+		t.Fatalf("DeleteDirectory() on the now-empty directory error = %v", err)
+	}
+	// And it is gone.
+	if err := client.CheckDirectory("dir"); err == nil {
+		t.Fatal("CheckDirectory() succeeded for a removed directory")
+	}
+
+	// CheckDirectory must distinguish a file from a directory, since a client
+	// walks a path with it before opening anything.
+	if err := fs.AddFile("afile.txt", []byte("x")); err != nil {
+		t.Fatalf("AddFile() error = %v", err)
+	}
+	if err := client.CheckDirectory("afile.txt"); err == nil {
+		t.Fatal("CheckDirectory() reported a file as a directory")
+	}
+}
+
+// TestFileServiceDeleteAndRename asserts deletion including wildcards, and that
+// rename refuses to overwrite.
+func TestFileServiceDeleteAndRename(t *testing.T) {
+	fs := NewMemoryFileSystem("FILES")
+	for _, name := range []string{"a.txt", "b.txt", "c.log", "keep.txt"} {
+		if err := fs.AddFile(name, []byte(name)); err != nil {
+			t.Fatalf("AddFile(%q) error = %v", name, err)
+		}
+	}
+	if err := fs.AddDirectory("adir"); err != nil {
+		t.Fatalf("AddDirectory() error = %v", err)
+	}
+	_, client := fileServer(t, fs, false)
+
+	// One named file.
+	if err := client.DeleteFile("a.txt"); err != nil {
+		t.Fatalf("DeleteFile() error = %v", err)
+	}
+	if _, err := fs.Stat("a.txt"); err == nil {
+		t.Fatal("the file is still in the backend")
+	}
+
+	// A wildcard deletes the matches and leaves the rest, and never takes a
+	// directory with it.
+	if err := client.DeleteFile("*.txt"); err != nil {
+		t.Fatalf("DeleteFile() with a wildcard error = %v", err)
+	}
+	if _, err := fs.Stat("b.txt"); err == nil {
+		t.Fatal("b.txt survived a matching wildcard")
+	}
+	if _, err := fs.Stat("keep.txt"); err == nil {
+		t.Fatal("keep.txt survived a matching wildcard")
+	}
+	if _, err := fs.Stat("c.log"); err != nil {
+		t.Fatal("c.log was deleted by a pattern that does not match it")
+	}
+	if _, err := fs.Stat("adir"); err != nil {
+		t.Fatal("a directory was deleted by SMB_COM_DELETE")
+	}
+
+	// A pattern matching nothing is a failure, not a no-op.
+	if err := client.DeleteFile("*.nothing"); err == nil {
+		t.Fatal("DeleteFile() succeeded for a pattern that matched nothing")
+	}
+
+	// Rename, then a rename onto something that exists.
+	if err := client.RenameFile("c.log", "renamed.log"); err != nil {
+		t.Fatalf("RenameFile() error = %v", err)
+	}
+	if _, err := fs.Stat("renamed.log"); err != nil {
+		t.Fatalf("the renamed file is not in the backend: %v", err)
+	}
+	if err := fs.AddFile("occupied.log", []byte("x")); err != nil {
+		t.Fatalf("AddFile() error = %v", err)
+	}
+	if err := client.RenameFile("renamed.log", "occupied.log"); err == nil {
+		t.Fatal("RenameFile() overwrote an existing file")
+	}
+}
+
+// TestFileServiceRefusesTraversal asserts the containment boundary holds through
+// the whole stack, not just in the resolver's own tests: a client asking for a
+// path outside the share is refused at every command that takes one.
+func TestFileServiceRefusesTraversal(t *testing.T) {
+	fs := NewMemoryFileSystem("FILES")
+	if err := fs.AddFile("inside.txt", []byte("in")); err != nil {
+		t.Fatalf("AddFile() error = %v", err)
+	}
+	_, client := fileServer(t, fs, false)
+
+	escapes := []string{
+		"..\\outside.txt",
+		"..\\..\\etc\\passwd",
+		"dir\\..\\..\\outside.txt",
+		"C:\\windows\\win.ini",
+		"\\\\other\\share\\file",
+		"inside.txt:stream",
+		"NUL",
+	}
+
+	// An embedded NUL is deliberately absent from this list. The field carrying a
+	// path is NUL-terminated, so SMB_STRING.Unmarshal stops at the first one and
+	// the server never sees the remainder: opening "inside.txt" is the correct
+	// reading of a wire message that says "inside.txt\x00.png". The resolver is
+	// still tested against an embedded NUL directly, for the field formats that
+	// can carry one.
+
+	for _, path := range escapes {
+		path := path
+		t.Run(path, func(t *testing.T) {
+			if fid, err := client.OpenFile(path, fileflags.GENERIC_READ, fileflags.FILE_SHARE_READ,
+				fileflags.FILE_OPEN, fileflags.FILE_NON_DIRECTORY_FILE); err == nil {
+				client.CloseFile(fid)
+				t.Fatalf("OpenFile(%q) succeeded", path)
+			}
+			if err := client.DeleteFile(path); err == nil {
+				t.Fatalf("DeleteFile(%q) succeeded", path)
+			}
+			if err := client.CreateDirectory(path); err == nil {
+				t.Fatalf("CreateDirectory(%q) succeeded", path)
+			}
+			if err := client.CheckDirectory(path); err == nil {
+				t.Fatalf("CheckDirectory(%q) succeeded", path)
+			}
+			if err := client.RenameFile("inside.txt", path); err == nil {
+				t.Fatalf("RenameFile() to %q succeeded", path)
+			}
+			if err := client.RenameFile(path, "moved.txt"); err == nil {
+				t.Fatalf("RenameFile() from %q succeeded", path)
+			}
+		})
+	}
+
+	// Nothing above reached the backend.
+	if _, err := fs.Stat("inside.txt"); err != nil {
+		t.Fatal("the file inside the share was disturbed")
+	}
+}
+
+// TestFileServiceReadOnlyShare asserts a read-only share refuses every modifying
+// command whatever access the client asks for, and still serves reads.
+func TestFileServiceReadOnlyShare(t *testing.T) {
+	fs := NewMemoryFileSystem("FILES")
+	if err := fs.AddFile("readable.txt", []byte("contents")); err != nil {
+		t.Fatalf("AddFile() error = %v", err)
+	}
+	_, client := fileServer(t, fs, true)
+
+	// Reading works.
+	fid, err := client.OpenFile("readable.txt", fileflags.GENERIC_READ, fileflags.FILE_SHARE_READ,
+		fileflags.FILE_OPEN, fileflags.FILE_NON_DIRECTORY_FILE)
+	if err != nil {
+		t.Fatalf("OpenFile() for reading on a read-only share error = %v", err)
+	}
+	read, err := client.ReadFile(fid, 0, 8)
+	if err != nil {
+		t.Fatalf("ReadFile() on a read-only share error = %v", err)
+	}
+	if string(read) != "contents" {
+		t.Fatalf("read %q, want %q", read, "contents")
+	}
+	client.CloseFile(fid)
+
+	// Everything that modifies is refused.
+	if writeFid, err := client.OpenFile("readable.txt", fileflags.GENERIC_WRITE, fileflags.FILE_SHARE_READ,
+		fileflags.FILE_OPEN, fileflags.FILE_NON_DIRECTORY_FILE); err == nil {
+		client.CloseFile(writeFid)
+		t.Fatal("OpenFile() for writing succeeded on a read-only share")
+	}
+	if newFid, err := client.OpenFile("created.txt", fileflags.GENERIC_READ, fileflags.FILE_SHARE_READ,
+		fileflags.FILE_CREATE, fileflags.FILE_NON_DIRECTORY_FILE); err == nil {
+		client.CloseFile(newFid)
+		t.Fatal("OpenFile() with FILE_CREATE succeeded on a read-only share")
+	}
+	if err := client.DeleteFile("readable.txt"); err == nil {
+		t.Fatal("DeleteFile() succeeded on a read-only share")
+	}
+	if err := client.CreateDirectory("dir"); err == nil {
+		t.Fatal("CreateDirectory() succeeded on a read-only share")
+	}
+	if err := client.RenameFile("readable.txt", "other.txt"); err == nil {
+		t.Fatal("RenameFile() succeeded on a read-only share")
+	}
+
+	// And the backend is untouched.
+	if _, err := fs.Stat("readable.txt"); err != nil {
+		t.Fatal("the file was removed from a read-only share")
+	}
+}
+
+// TestFileServiceHandleScoping asserts a handle can only be used on the tree that
+// produced it, and stops working once closed.
+func TestFileServiceHandleScoping(t *testing.T) {
+	fs := NewMemoryFileSystem("FILES")
+	if err := fs.AddFile("scoped.txt", []byte("data")); err != nil {
+		t.Fatalf("AddFile() error = %v", err)
+	}
+	_, client := fileServer(t, fs, false)
+
+	fid, err := client.OpenFile("scoped.txt", fileflags.GENERIC_READ, fileflags.FILE_SHARE_READ,
+		fileflags.FILE_OPEN, fileflags.FILE_NON_DIRECTORY_FILE)
+	if err != nil {
+		t.Fatalf("OpenFile() error = %v", err)
+	}
+	if err := client.CloseFile(fid); err != nil {
+		t.Fatalf("CloseFile() error = %v", err)
+	}
+
+	// A closed handle no longer works.
+	if _, err := client.ReadFile(fid, 0, 4); err == nil {
+		t.Fatal("ReadFile() succeeded on a closed handle")
+	}
+	if err := client.CloseFile(fid); err == nil {
+		t.Fatal("CloseFile() succeeded twice on one handle")
+	}
+
+	// A handle that was never issued does not work either.
+	if _, err := client.ReadFile(0x7FFF, 0, 4); err == nil {
+		t.Fatal("ReadFile() succeeded on a handle that was never issued")
+	}
+}
+
+// TestFileServiceAccessIsEnforcedPerHandle asserts a handle opened for reading
+// cannot be written through, so the access granted at open time actually governs.
+func TestFileServiceAccessIsEnforcedPerHandle(t *testing.T) {
+	fs := NewMemoryFileSystem("FILES")
+	if err := fs.AddFile("guarded.txt", []byte("original")); err != nil {
+		t.Fatalf("AddFile() error = %v", err)
+	}
+	_, client := fileServer(t, fs, false)
+
+	fid, err := client.OpenFile("guarded.txt", fileflags.GENERIC_READ, fileflags.FILE_SHARE_READ,
+		fileflags.FILE_OPEN, fileflags.FILE_NON_DIRECTORY_FILE)
+	if err != nil {
+		t.Fatalf("OpenFile() error = %v", err)
+	}
+	defer client.CloseFile(fid)
+
+	if _, err := client.WriteFile(fid, 0, []byte("overwritten")); err == nil {
+		t.Fatal("WriteFile() succeeded through a read-only handle")
+	}
+
+	attr, err := fs.Stat("guarded.txt")
+	if err != nil {
+		t.Fatalf("Stat() error = %v", err)
+	}
+	if attr.Size != int64(len("original")) {
+		t.Fatalf("the file is %d bytes, so the refused write still landed", attr.Size)
+	}
+}
+
+// TestFileServiceTreeDisconnectClosesHandles asserts disconnecting a tree releases
+// what was opened on it, rather than leaving handles nothing can reach.
+func TestFileServiceTreeDisconnectClosesHandles(t *testing.T) {
+	fs := NewMemoryFileSystem("FILES")
+	if err := fs.AddFile("held.txt", []byte("data")); err != nil {
+		t.Fatalf("AddFile() error = %v", err)
+	}
+	srv, client := fileServer(t, fs, false)
+
+	fid, err := client.OpenFile("held.txt", fileflags.GENERIC_READ, fileflags.FILE_SHARE_READ,
+		fileflags.FILE_OPEN, fileflags.FILE_NON_DIRECTORY_FILE)
+	if err != nil {
+		t.Fatalf("OpenFile() error = %v", err)
+	}
+
+	if err := client.TreeDisconnect(); err != nil {
+		t.Fatalf("TreeDisconnect() error = %v", err)
+	}
+
+	// The handle went with the tree.
+	if _, err := client.ReadFile(fid, 0, 4); err == nil {
+		t.Fatal("ReadFile() succeeded after the tree was disconnected")
+	}
+
+	// And the server is holding nothing.
+	waitFor(t, func() bool {
+		for _, conn := range srv.liveConnections() {
+			if len(conn.opens) != 0 || len(conn.trees) != 0 {
+				return false
+			}
+		}
+		return true
+	}, "the server still holds trees or handles after a tree disconnect")
+}
+
+// TestFileServiceUnknownShareIsRefused asserts a tree connect to a share that is
+// not served is refused, and that a served share of the wrong kind is too.
+func TestFileServiceUnknownShareIsRefused(t *testing.T) {
+	fs := NewMemoryFileSystem("FILES")
+	srv, transportEnd := pipedServer(t, conformanceConfig(SigningDisabled))
+	if err := srv.AddShare(&Share{Name: fileShareName, Type: ShareTypeDisk, FS: fs}); err != nil {
+		t.Fatalf("AddShare() error = %v", err)
+	}
+
+	client := smb1client.NewFromTransport(transportEnd, net.IPv4(127, 0, 0, 1), 445)
+	if err := client.Negotiate(); err != nil {
+		t.Fatalf("Negotiate() error = %v", err)
+	}
+	creds, _ := credentials.NewCredentials(captureDomain, captureUsername, capturePassword, "")
+	if err := client.SessionSetup(creds); err != nil {
+		t.Fatalf("SessionSetup() error = %v", err)
+	}
+
+	if err := client.TreeConnect("nosuchshare"); err == nil {
+		t.Fatal("TreeConnect() succeeded for a share that is not served")
+	}
+	// The name is matched case-insensitively, as Windows does.
+	if err := client.TreeConnect(strings.ToUpper(fileShareName)); err != nil {
+		t.Fatalf("TreeConnect() with a differently-cased name error = %v", err)
+	}
+}
+
+// TestAddShareValidation asserts a share that could not be served is refused when
+// it is registered rather than when a client reaches it.
+func TestAddShareValidation(t *testing.T) {
+	srv, err := NewServer(conformanceConfig(SigningDisabled))
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	if err := srv.AddShare(nil); err == nil {
+		t.Fatal("AddShare(nil) succeeded")
+	}
+	if err := srv.AddShare(&Share{Name: ""}); err == nil {
+		t.Fatal("AddShare() accepted a share with no name")
+	}
+	if err := srv.AddShare(&Share{Name: "bad\\name", FS: NewMemoryFileSystem("X")}); err == nil {
+		t.Fatal("AddShare() accepted a name containing a separator")
+	}
+	if err := srv.AddShare(&Share{Name: "disk", Type: ShareTypeDisk}); err == nil {
+		t.Fatal("AddShare() accepted a disk share with no file system")
+	}
+
+	if err := srv.AddShare(&Share{Name: "good", FS: NewMemoryFileSystem("X")}); err != nil {
+		t.Fatalf("AddShare() on a valid share error = %v", err)
+	}
+	// A duplicate, including one differing only in case, is refused.
+	if err := srv.AddShare(&Share{Name: "GOOD", FS: NewMemoryFileSystem("X")}); err == nil {
+		t.Fatal("AddShare() accepted a duplicate name")
+	}
+	if srv.Share("good") == nil || srv.Share("GOOD") == nil {
+		t.Fatal("Share() does not find the registered share case-insensitively")
+	}
+	if len(srv.Shares()) != 1 {
+		t.Fatalf("Shares() reports %d shares, want 1", len(srv.Shares()))
+	}
+}
+
+// TestLocalFileSystemContainsSymlinkEscape asserts the second containment
+// mechanism: a symbolic link inside the share pointing out of it is refused, which
+// no amount of path checking could catch.
+func TestLocalFileSystemContainsSymlinkEscape(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(outside, "secret.txt"), []byte("secret"), 0o600); err != nil {
+		t.Fatalf("failed to write the outside file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "inside.txt"), []byte("inside"), 0o600); err != nil {
+		t.Fatalf("failed to write the inside file: %v", err)
+	}
+
+	// A link to a file outside, and a link to the whole directory outside.
+	if err := os.Symlink(filepath.Join(outside, "secret.txt"), filepath.Join(root, "link.txt")); err != nil {
+		t.Skipf("symlinks are not available here: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(root, "linkdir")); err != nil {
+		t.Skipf("symlinks are not available here: %v", err)
+	}
+
+	fs, err := NewLocalFileSystem(root, "LOCAL")
+	if err != nil {
+		t.Fatalf("NewLocalFileSystem() error = %v", err)
+	}
+
+	// The file inside is reachable.
+	if _, err := fs.Stat("inside.txt"); err != nil {
+		t.Fatalf("the file inside the share is not reachable: %v", err)
+	}
+
+	// Neither link is, however it is approached.
+	escapes := []string{"link.txt", "linkdir/secret.txt", "linkdir"}
+	for _, path := range escapes {
+		path := path
+		t.Run(path, func(t *testing.T) {
+			if _, err := fs.Stat(path); err == nil {
+				t.Errorf("Stat(%q) succeeded through a link out of the share", path)
+			}
+			if file, err := fs.Open(path, OpenFlags{Read: true}); err == nil {
+				file.Close()
+				t.Errorf("Open(%q) succeeded through a link out of the share", path)
+			}
+			if err := fs.Remove(path); err == nil {
+				t.Errorf("Remove(%q) succeeded through a link out of the share", path)
+			}
+		})
+	}
+
+	// The outside file is untouched.
+	if _, err := os.Stat(filepath.Join(outside, "secret.txt")); err != nil {
+		t.Fatal("the file outside the share was disturbed")
+	}
+
+	// A listing does not advertise what cannot be opened.
+	entries, err := fs.ReadDir("", "")
+	if err != nil {
+		t.Fatalf("ReadDir() error = %v", err)
+	}
+	for _, entry := range entries {
+		if entry.Attr.Name == "link.txt" || entry.Attr.Name == "linkdir" {
+			// Listing a link is acceptable only if opening it is refused, which
+			// the assertions above establish. What must not happen is the
+			// contents leaking.
+			continue
+		}
+	}
+}
+
+// TestLocalFileSystemRoundTrip asserts the os-backed backend does the same things
+// the in-memory one does, since a share can be served by either.
+func TestLocalFileSystemRoundTrip(t *testing.T) {
+	root := t.TempDir()
+	fs, err := NewLocalFileSystem(root, "LOCAL")
+	if err != nil {
+		t.Fatalf("NewLocalFileSystem() error = %v", err)
+	}
+	_, client := fileServer(t, fs, false)
+
+	payload := []byte("written through the protocol")
+
+	fid, err := client.OpenFile("ondisk.txt",
+		fileflags.GENERIC_READ|fileflags.GENERIC_WRITE, fileflags.FILE_SHARE_READ,
+		fileflags.FILE_OPEN_IF, fileflags.FILE_NON_DIRECTORY_FILE)
+	if err != nil {
+		t.Fatalf("OpenFile() error = %v", err)
+	}
+	if _, err := client.WriteFile(fid, 0, payload); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	if err := client.CloseFile(fid); err != nil {
+		t.Fatalf("CloseFile() error = %v", err)
+	}
+
+	// It is on the host's disk, where it was asked to be.
+	onDisk, err := os.ReadFile(filepath.Join(root, "ondisk.txt"))
+	if err != nil {
+		t.Fatalf("the file is not on disk: %v", err)
+	}
+	if !bytes.Equal(onDisk, payload) {
+		t.Fatalf("the file on disk holds %q, want %q", onDisk, payload)
+	}
+
+	// And the directory commands reach the host too.
+	if err := client.CreateDirectory("subdir"); err != nil {
+		t.Fatalf("CreateDirectory() error = %v", err)
+	}
+	if info, err := os.Stat(filepath.Join(root, "subdir")); err != nil || !info.IsDir() {
+		t.Fatalf("the directory is not on disk: %v", err)
+	}
+	if err := client.DeleteFile("ondisk.txt"); err != nil {
+		t.Fatalf("DeleteFile() error = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "ondisk.txt")); err == nil {
+		t.Fatal("the file is still on disk after a delete")
+	}
+}
+
+// TestMemoryFileSystemDirectly covers the in-memory backend's own behaviour,
+// including the cases the protocol handlers above do not reach.
+func TestMemoryFileSystemDirectly(t *testing.T) {
+	fs := NewMemoryFileSystem("MEM")
+
+	// A create needs its parent to exist.
+	if _, err := fs.Open("missing/file.txt", OpenFlags{Create: true, Write: true}); err == nil {
+		t.Fatal("Open() created a file under a directory that does not exist")
+	}
+
+	// Seeding builds the tree.
+	if err := fs.AddFile("a/b/c.txt", []byte("deep")); err != nil {
+		t.Fatalf("AddFile() error = %v", err)
+	}
+	for _, path := range []string{"a", "a/b", "a/b/c.txt"} {
+		if _, err := fs.Stat(path); err != nil {
+			t.Fatalf("Stat(%q) after seeding error = %v", path, err)
+		}
+	}
+
+	// Renaming a directory takes what is beneath it.
+	if err := fs.Rename("a/b", "a/moved", false); err != nil {
+		t.Fatalf("Rename() error = %v", err)
+	}
+	if _, err := fs.Stat("a/moved/c.txt"); err != nil {
+		t.Fatalf("the nested file did not move with its directory: %v", err)
+	}
+	if _, err := fs.Stat("a/b/c.txt"); err == nil {
+		t.Fatal("the nested file is still reachable at its old path")
+	}
+
+	// A listing reports immediate children only, in a stable order.
+	if err := fs.AddFile("a/second.txt", []byte("x")); err != nil {
+		t.Fatalf("AddFile() error = %v", err)
+	}
+	entries, err := fs.ReadDir("a", "")
+	if err != nil {
+		t.Fatalf("ReadDir() error = %v", err)
+	}
+	names := []string{}
+	for _, entry := range entries {
+		names = append(names, entry.Attr.Name)
+	}
+	if strings.Join(names, ",") != "moved,second.txt" {
+		t.Fatalf("ReadDir() reported %v, want the immediate children in order", names)
+	}
+
+	// A pattern filters.
+	entries, err = fs.ReadDir("a", "*.txt")
+	if err != nil {
+		t.Fatalf("ReadDir() with a pattern error = %v", err)
+	}
+	if len(entries) != 1 || entries[0].Attr.Name != "second.txt" {
+		t.Fatalf("ReadDir() with a pattern reported %d entries", len(entries))
+	}
+
+	// Truncation both ways.
+	file, err := fs.Open("a/second.txt", OpenFlags{Read: true, Write: true})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	if _, err := file.WriteAt([]byte("0123456789"), 0); err != nil {
+		t.Fatalf("WriteAt() error = %v", err)
+	}
+	if err := file.Truncate(4); err != nil {
+		t.Fatalf("Truncate() error = %v", err)
+	}
+	buffer := make([]byte, 10)
+	read, err := file.ReadAt(buffer, 0)
+	if err != nil {
+		t.Fatalf("ReadAt() error = %v", err)
+	}
+	if string(buffer[:read]) != "0123" {
+		t.Fatalf("after truncating to 4 the file holds %q", buffer[:read])
+	}
+	file.Close()
+
+	// Rmdir refuses the root and a non-empty directory.
+	if err := fs.Rmdir(""); err == nil {
+		t.Fatal("Rmdir() removed the share root")
+	}
+	if err := fs.Rmdir("a"); err == nil {
+		t.Fatal("Rmdir() removed a non-empty directory")
+	}
+}

--- a/network/smb/smb_v10/server/fs_local.go
+++ b/network/smb/smb_v10/server/fs_local.go
@@ -1,0 +1,506 @@
+package server
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// LocalFileSystem is a FileSystem backed by a directory on the host.
+//
+// The share is rooted at that directory and nothing above it is reachable. Two
+// separate mechanisms keep that true, because either alone is insufficient:
+// resolvePath refuses a path that could climb out, and every resolved path is
+// checked against the root again after the host has followed any symbolic links
+// in it. The first stops a traversal spelled in the request; the second stops one
+// planted in the file system itself, which no amount of path checking can see.
+type LocalFileSystem struct {
+	// root is the absolute, symlink-resolved directory the share is rooted at.
+	root string
+
+	// label is the volume label reported to a client.
+	label string
+
+	// readOnly refuses every modifying operation at the backend, independently of
+	// the share's own flag, so a caller can hand out a genuinely read-only
+	// backend.
+	readOnly bool
+}
+
+// NewLocalFileSystem roots a file system at a directory on the host.
+//
+// The directory is resolved through any symbolic links at construction, so the
+// containment checks compare like with like afterwards.
+//
+// Parameters:
+//   - root: the directory to serve
+//   - label: the volume label reported to a client
+//
+// Returns:
+//   - The file system
+//   - An error if the directory is unusable
+func NewLocalFileSystem(root, label string) (*LocalFileSystem, error) {
+	absolute, err := filepath.Abs(root)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve %q: %v", root, err)
+	}
+	// Resolve the root's own symlinks once, so a later comparison is against the
+	// real directory rather than a link to it.
+	resolved, err := filepath.EvalSymlinks(absolute)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve %q: %v", absolute, err)
+	}
+	info, err := os.Stat(resolved)
+	if err != nil {
+		return nil, fmt.Errorf("failed to stat %q: %v", resolved, err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("%q is not a directory", resolved)
+	}
+
+	return &LocalFileSystem{root: resolved, label: label}, nil
+}
+
+// SetReadOnly refuses every modifying operation at the backend.
+func (fs *LocalFileSystem) SetReadOnly(readOnly bool) {
+	fs.readOnly = readOnly
+}
+
+// Root returns the directory the share is rooted at.
+func (fs *LocalFileSystem) Root() string {
+	return fs.root
+}
+
+// hostPath maps a resolved share-relative path to a host path, and refuses one
+// that leaves the root.
+//
+// This is the second containment mechanism. resolvePath has already refused
+// anything that spells an escape, but it cannot see a symbolic link inside the
+// share pointing out of it: the path "public/link/secret" is perfectly well
+// formed. So the host path is resolved through its links and compared against the
+// root before it is used.
+//
+// A path that does not exist yet cannot be resolved through links, so its parent
+// is checked instead — which is what a create needs, and is sufficient, because a
+// link can only be traversed through a component that exists.
+func (fs *LocalFileSystem) hostPath(path string) (string, error) {
+	// filepath.Join cleans the result, but the input is already known to hold no
+	// ".." element, so cleaning cannot move it upwards.
+	candidate := filepath.Join(fs.root, filepath.FromSlash(path))
+
+	resolved, err := filepath.EvalSymlinks(candidate)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return "", err
+		}
+		// The target does not exist. Its parent must, and must be inside the
+		// root; the final element cannot itself be a traversed link, because it
+		// is not there to be one.
+		parent := filepath.Dir(candidate)
+		resolvedParent, parentErr := filepath.EvalSymlinks(parent)
+		if parentErr != nil {
+			// The parent does not exist either, so nothing can be created here.
+			return "", ErrNotFound
+		}
+		if !fs.contains(resolvedParent) {
+			return "", ErrAccessDenied
+		}
+		return filepath.Join(resolvedParent, filepath.Base(candidate)), nil
+	}
+
+	if !fs.contains(resolved) {
+		return "", ErrAccessDenied
+	}
+	return resolved, nil
+}
+
+// contains reports whether a resolved host path is the root or lies beneath it.
+//
+// The separator on the prefix matters: without it, a sibling directory whose name
+// merely starts with the root's name would compare as inside it.
+func (fs *LocalFileSystem) contains(resolved string) bool {
+	if resolved == fs.root {
+		return true
+	}
+	return strings.HasPrefix(resolved, fs.root+string(os.PathSeparator))
+}
+
+// translate maps a host error onto the sentinel the server understands.
+func translate(err error) error {
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, os.ErrNotExist):
+		return ErrNotFound
+	case errors.Is(err, os.ErrExist):
+		return ErrExists
+	case errors.Is(err, os.ErrPermission):
+		return ErrAccessDenied
+	}
+	// A few conditions have no portable errors.Is target.
+	text := err.Error()
+	switch {
+	case strings.Contains(text, "directory not empty"):
+		return ErrNotEmpty
+	case strings.Contains(text, "not a directory"):
+		return ErrNotDirectory
+	case strings.Contains(text, "is a directory"):
+		return ErrIsDirectory
+	}
+	return err
+}
+
+// attrOf renders a host entry.
+func attrOf(name string, info os.FileInfo) FileAttr {
+	modified := info.ModTime().UTC()
+	return FileAttr{
+		Name:  name,
+		IsDir: info.IsDir(),
+		Size:  info.Size(),
+		// The host does not report an allocation size portably, so it is the
+		// length rounded up to a 512-byte boundary, which is what a client uses
+		// it for.
+		AllocationSize: (info.Size() + 511) / 512 * 512,
+		ReadOnly:       info.Mode().Perm()&0o200 == 0,
+		// Only one timestamp is portable, so it stands for all four rather than
+		// reporting a zero a client would render as the year 1601.
+		Created:  modified,
+		Accessed: modified,
+		Modified: modified,
+		Changed:  modified,
+	}
+}
+
+// Open opens or creates a file.
+func (fs *LocalFileSystem) Open(path string, flags OpenFlags) (File, error) {
+	if fs.readOnly && (flags.Write || flags.Create || flags.CreateNew || flags.Truncate) {
+		return nil, ErrReadOnly
+	}
+
+	host, err := fs.hostPath(path)
+	if err != nil {
+		return nil, err
+	}
+
+	// A directory is opened for metadata only: the host refuses to open one for
+	// reading on some platforms, and SMB only ever uses such a handle to query.
+	if info, statErr := os.Stat(host); statErr == nil && info.IsDir() {
+		if flags.NonDirectory {
+			return nil, ErrIsDirectory
+		}
+		if flags.CreateNew {
+			return nil, ErrExists
+		}
+		return &localFile{path: host, directory: true}, nil
+	} else if statErr == nil && flags.Directory {
+		return nil, ErrNotDirectory
+	}
+
+	mode := os.O_RDONLY
+	switch {
+	case flags.Read && flags.Write:
+		mode = os.O_RDWR
+	case flags.Write:
+		mode = os.O_RDWR
+	}
+	if flags.CreateNew {
+		mode |= os.O_CREATE | os.O_EXCL
+	} else if flags.Create {
+		mode |= os.O_CREATE
+	}
+	if flags.Truncate {
+		mode |= os.O_TRUNC
+	}
+
+	if flags.Directory {
+		if err := os.Mkdir(host, 0o750); err != nil {
+			return nil, translate(err)
+		}
+		return &localFile{path: host, directory: true}, nil
+	}
+
+	file, err := os.OpenFile(host, mode, 0o640)
+	if err != nil {
+		return nil, translate(err)
+	}
+	return &localFile{file: file, path: host}, nil
+}
+
+// Stat describes a path.
+func (fs *LocalFileSystem) Stat(path string) (FileAttr, error) {
+	host, err := fs.hostPath(path)
+	if err != nil {
+		return FileAttr{}, err
+	}
+	info, err := os.Stat(host)
+	if err != nil {
+		return FileAttr{}, translate(err)
+	}
+	_, name := splitPath(path)
+	if name == "" {
+		name = fs.label
+	}
+	return attrOf(name, info), nil
+}
+
+// SetAttr applies the selected fields.
+func (fs *LocalFileSystem) SetAttr(path string, attr FileAttr, mask AttrMask) error {
+	if fs.readOnly {
+		return ErrReadOnly
+	}
+	host, err := fs.hostPath(path)
+	if err != nil {
+		return err
+	}
+
+	if mask.Size {
+		if err := os.Truncate(host, attr.Size); err != nil {
+			return translate(err)
+		}
+	}
+	if mask.ReadOnly {
+		info, err := os.Stat(host)
+		if err != nil {
+			return translate(err)
+		}
+		perm := info.Mode().Perm()
+		if attr.ReadOnly {
+			perm &= ^os.FileMode(0o222)
+		} else {
+			perm |= 0o200
+		}
+		if err := os.Chmod(host, perm); err != nil {
+			return translate(err)
+		}
+	}
+	// The host carries only an access and a modification time, so the two SMB
+	// timestamps that map onto them are applied and the others ignored rather
+	// than faked.
+	if mask.Accessed || mask.Modified {
+		accessed, modified := attr.Accessed, attr.Modified
+		if !mask.Accessed || accessed.IsZero() {
+			accessed = time.Now()
+		}
+		if !mask.Modified || modified.IsZero() {
+			modified = time.Now()
+		}
+		if err := os.Chtimes(host, accessed, modified); err != nil {
+			return translate(err)
+		}
+	}
+	return nil
+}
+
+// Remove deletes a file.
+func (fs *LocalFileSystem) Remove(path string) error {
+	if fs.readOnly {
+		return ErrReadOnly
+	}
+	host, err := fs.hostPath(path)
+	if err != nil {
+		return err
+	}
+	info, err := os.Lstat(host)
+	if err != nil {
+		return translate(err)
+	}
+	if info.IsDir() {
+		return ErrIsDirectory
+	}
+	return translate(os.Remove(host))
+}
+
+// Rename moves a file or directory.
+func (fs *LocalFileSystem) Rename(oldPath, newPath string, replace bool) error {
+	if fs.readOnly {
+		return ErrReadOnly
+	}
+	oldHost, err := fs.hostPath(oldPath)
+	if err != nil {
+		return err
+	}
+	newHost, err := fs.hostPath(newPath)
+	if err != nil {
+		return err
+	}
+	if !replace {
+		if _, err := os.Lstat(newHost); err == nil {
+			return ErrExists
+		}
+	}
+	return translate(os.Rename(oldHost, newHost))
+}
+
+// Mkdir creates a directory.
+func (fs *LocalFileSystem) Mkdir(path string) error {
+	if fs.readOnly {
+		return ErrReadOnly
+	}
+	host, err := fs.hostPath(path)
+	if err != nil {
+		return err
+	}
+	if _, err := os.Lstat(host); err == nil {
+		return ErrExists
+	}
+	return translate(os.Mkdir(host, 0o750))
+}
+
+// Rmdir removes an empty directory.
+func (fs *LocalFileSystem) Rmdir(path string) error {
+	if fs.readOnly {
+		return ErrReadOnly
+	}
+	if path == "" {
+		return ErrAccessDenied
+	}
+	host, err := fs.hostPath(path)
+	if err != nil {
+		return err
+	}
+	info, err := os.Lstat(host)
+	if err != nil {
+		return translate(err)
+	}
+	if !info.IsDir() {
+		return ErrNotDirectory
+	}
+	return translate(os.Remove(host))
+}
+
+// ReadDir lists the entries of a directory that match pattern.
+func (fs *LocalFileSystem) ReadDir(path, pattern string) ([]DirEntry, error) {
+	host, err := fs.hostPath(path)
+	if err != nil {
+		return nil, err
+	}
+	info, err := os.Stat(host)
+	if err != nil {
+		return nil, translate(err)
+	}
+	if !info.IsDir() {
+		return nil, ErrNotDirectory
+	}
+
+	held, err := os.ReadDir(host)
+	if err != nil {
+		return nil, translate(err)
+	}
+
+	listed := []DirEntry{}
+	for _, entry := range held {
+		if !matchPattern(pattern, entry.Name()) {
+			continue
+		}
+		// A name the resolver would refuse is not listed either: a client that
+		// saw it could not then open it, and it may be a link out of the share.
+		if _, err := resolvePath(joinPath(path, entry.Name())); err != nil {
+			continue
+		}
+		entryInfo, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		listed = append(listed, DirEntry{Attr: attrOf(entry.Name(), entryInfo)})
+	}
+
+	sort.Slice(listed, func(i, j int) bool { return listed[i].Attr.Name < listed[j].Attr.Name })
+	return listed, nil
+}
+
+// VolumeInfo describes the storage.
+func (fs *LocalFileSystem) VolumeInfo() (VolumeInfo, error) {
+	return VolumeInfo{
+		Label:          fs.label,
+		FileSystemName: "NTFS",
+		// Derived from the root so it is stable across restarts, which is what a
+		// client caches it for.
+		SerialNumber:             serialNumberOf(fs.root),
+		SectorsPerAllocationUnit: 8,
+		BytesPerSector:           512,
+	}, nil
+}
+
+// serialNumberOf derives a stable volume serial from a path.
+func serialNumberOf(path string) uint32 {
+	// FNV-1a, inline to avoid pulling in a hash for four lines.
+	const offset, prime = uint32(2166136261), uint32(16777619)
+	sum := offset
+	for i := 0; i < len(path); i++ {
+		sum ^= uint32(path[i])
+		sum *= prime
+	}
+	return sum
+}
+
+// localFile is an open handle onto a host file. A directory handle carries no
+// file, because SMB only ever uses one to query metadata.
+type localFile struct {
+	file      *os.File
+	path      string
+	directory bool
+}
+
+func (f *localFile) ReadAt(p []byte, off int64) (int, error) {
+	if f.directory {
+		return 0, ErrIsDirectory
+	}
+	read, err := f.file.ReadAt(p, off)
+	// A short read at the end of the file is not a failure: SMB reports the short
+	// count, so only a read that got nothing is an end-of-file.
+	if err == io.EOF && read > 0 {
+		return read, nil
+	}
+	if err != nil && err != io.EOF {
+		return read, translate(err)
+	}
+	return read, err
+}
+
+func (f *localFile) WriteAt(p []byte, off int64) (int, error) {
+	if f.directory {
+		return 0, ErrIsDirectory
+	}
+	written, err := f.file.WriteAt(p, off)
+	return written, translate(err)
+}
+
+func (f *localFile) Truncate(size int64) error {
+	if f.directory {
+		return ErrIsDirectory
+	}
+	return translate(f.file.Truncate(size))
+}
+
+func (f *localFile) Sync() error {
+	if f.directory {
+		return nil
+	}
+	return translate(f.file.Sync())
+}
+
+func (f *localFile) Stat() (FileAttr, error) {
+	info, err := os.Stat(f.path)
+	if err != nil {
+		return FileAttr{}, translate(err)
+	}
+	return attrOf(filepath.Base(f.path), info), nil
+}
+
+func (f *localFile) Close() error {
+	if f.file == nil {
+		return nil
+	}
+	return translate(f.file.Close())
+}
+
+// Compile-time assurance that the backend satisfies the contracts.
+var (
+	_ FileSystem = (*LocalFileSystem)(nil)
+	_ File       = (*localFile)(nil)
+)

--- a/network/smb/smb_v10/server/fs_mem.go
+++ b/network/smb/smb_v10/server/fs_mem.go
@@ -1,0 +1,562 @@
+package server
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// MemoryFileSystem is a FileSystem held entirely in memory.
+//
+// It exists for two reasons. Tests get a backend with no disk and no cleanup, so
+// a file-service test is about the protocol rather than about a temporary
+// directory. And a caller can serve a share that touches no storage at all —
+// useful when the point is to look like a file server rather than to be one.
+//
+// It is safe for concurrent use.
+type MemoryFileSystem struct {
+	mutex sync.RWMutex
+
+	// entries holds every file and directory by its resolved path. The share root
+	// is the empty path and is always present.
+	entries map[string]*memoryEntry
+
+	// volume describes the storage reported to a client.
+	volume VolumeInfo
+}
+
+// memoryEntry is one file or directory.
+type memoryEntry struct {
+	name  string
+	isDir bool
+	data  []byte
+
+	readOnly bool
+	created  time.Time
+	accessed time.Time
+	modified time.Time
+	changed  time.Time
+}
+
+// NewMemoryFileSystem creates an empty in-memory file system.
+//
+// Parameters:
+//   - label: the volume label reported to a client
+//
+// Returns:
+//   - The file system, containing only its root
+func NewMemoryFileSystem(label string) *MemoryFileSystem {
+	now := time.Now().UTC()
+	return &MemoryFileSystem{
+		entries: map[string]*memoryEntry{
+			"": {name: "", isDir: true, created: now, accessed: now, modified: now, changed: now},
+		},
+		volume: VolumeInfo{
+			Label:                    label,
+			FileSystemName:           "NTFS",
+			SerialNumber:             0x4D454D30,
+			TotalBytes:               1 << 30,
+			FreeBytes:                1 << 30,
+			SectorsPerAllocationUnit: 8,
+			BytesPerSector:           512,
+		},
+	}
+}
+
+// AddFile seeds a file, creating the directories above it. It is for a caller
+// setting up a share before serving it, and for tests.
+//
+// Parameters:
+//   - path: the share-relative path, slash separated
+//   - contents: the file's contents
+//
+// Returns:
+//   - An error if the path is unusable
+func (fs *MemoryFileSystem) AddFile(path string, contents []byte) error {
+	resolved, err := resolvePath(path)
+	if err != nil {
+		return err
+	}
+	if resolved == "" {
+		return fmt.Errorf("cannot add a file at the share root")
+	}
+
+	fs.mutex.Lock()
+	defer fs.mutex.Unlock()
+
+	if err := fs.ensureParents(resolved); err != nil {
+		return err
+	}
+
+	now := time.Now().UTC()
+	_, name := splitPath(resolved)
+	stored := make([]byte, len(contents))
+	copy(stored, contents)
+	fs.entries[resolved] = &memoryEntry{
+		name: name, data: stored,
+		created: now, accessed: now, modified: now, changed: now,
+	}
+	return nil
+}
+
+// AddDirectory seeds a directory, creating the directories above it.
+func (fs *MemoryFileSystem) AddDirectory(path string) error {
+	resolved, err := resolvePath(path)
+	if err != nil {
+		return err
+	}
+	if resolved == "" {
+		return nil
+	}
+
+	fs.mutex.Lock()
+	defer fs.mutex.Unlock()
+
+	if err := fs.ensureParents(resolved); err != nil {
+		return err
+	}
+	return fs.makeDirectory(resolved)
+}
+
+// ensureParents creates every missing directory above a path. The caller holds
+// the lock.
+func (fs *MemoryFileSystem) ensureParents(path string) error {
+	parent, _ := splitPath(path)
+	if parent == "" {
+		return nil
+	}
+
+	built := ""
+	for _, element := range strings.Split(parent, "/") {
+		built = joinPath(built, element)
+		if existing, ok := fs.entries[built]; ok {
+			if !existing.isDir {
+				return fmt.Errorf("%q is a file, so it cannot hold %q: %w", built, path, ErrNotDirectory)
+			}
+			continue
+		}
+		if err := fs.makeDirectory(built); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// makeDirectory records a directory. The caller holds the lock.
+func (fs *MemoryFileSystem) makeDirectory(path string) error {
+	now := time.Now().UTC()
+	_, name := splitPath(path)
+	fs.entries[path] = &memoryEntry{
+		name: name, isDir: true,
+		created: now, accessed: now, modified: now, changed: now,
+	}
+	return nil
+}
+
+// attrOf renders an entry. The caller holds the lock.
+func (e *memoryEntry) attr() FileAttr {
+	return FileAttr{
+		Name:           e.name,
+		IsDir:          e.isDir,
+		Size:           int64(len(e.data)),
+		AllocationSize: int64(len(e.data)),
+		ReadOnly:       e.readOnly,
+		Created:        e.created,
+		Accessed:       e.accessed,
+		Modified:       e.modified,
+		Changed:        e.changed,
+	}
+}
+
+// Open opens or creates a file.
+func (fs *MemoryFileSystem) Open(path string, flags OpenFlags) (File, error) {
+	fs.mutex.Lock()
+	defer fs.mutex.Unlock()
+
+	entry, exists := fs.entries[path]
+
+	switch {
+	case exists && flags.CreateNew:
+		return nil, ErrExists
+	case !exists && !flags.Create:
+		return nil, ErrNotFound
+	}
+
+	if exists {
+		if entry.isDir && flags.NonDirectory {
+			return nil, ErrIsDirectory
+		}
+		if !entry.isDir && flags.Directory {
+			return nil, ErrNotDirectory
+		}
+		if flags.Write && entry.readOnly {
+			return nil, ErrReadOnly
+		}
+		if flags.Truncate && !entry.isDir {
+			entry.data = nil
+			entry.modified = time.Now().UTC()
+		}
+		return &memoryFile{fs: fs, path: path}, nil
+	}
+
+	// Creating. The parent has to exist: a create does not build a tree.
+	parent, name := splitPath(path)
+	if parent != "" {
+		holder, ok := fs.entries[parent]
+		if !ok {
+			return nil, ErrNotFound
+		}
+		if !holder.isDir {
+			return nil, ErrNotDirectory
+		}
+	}
+
+	now := time.Now().UTC()
+	fs.entries[path] = &memoryEntry{
+		name: name, isDir: flags.Directory,
+		created: now, accessed: now, modified: now, changed: now,
+	}
+	return &memoryFile{fs: fs, path: path}, nil
+}
+
+// Stat describes a path.
+func (fs *MemoryFileSystem) Stat(path string) (FileAttr, error) {
+	fs.mutex.RLock()
+	defer fs.mutex.RUnlock()
+
+	entry, ok := fs.entries[path]
+	if !ok {
+		return FileAttr{}, ErrNotFound
+	}
+	return entry.attr(), nil
+}
+
+// SetAttr applies the selected fields.
+func (fs *MemoryFileSystem) SetAttr(path string, attr FileAttr, mask AttrMask) error {
+	fs.mutex.Lock()
+	defer fs.mutex.Unlock()
+
+	entry, ok := fs.entries[path]
+	if !ok {
+		return ErrNotFound
+	}
+
+	if mask.Size && !entry.isDir {
+		fs.resize(entry, attr.Size)
+	}
+	if mask.ReadOnly {
+		entry.readOnly = attr.ReadOnly
+	}
+	if mask.Created {
+		entry.created = attr.Created
+	}
+	if mask.Accessed {
+		entry.accessed = attr.Accessed
+	}
+	if mask.Modified {
+		entry.modified = attr.Modified
+	}
+	if mask.Changed {
+		entry.changed = attr.Changed
+	}
+	return nil
+}
+
+// resize grows or shrinks an entry's contents. The caller holds the lock.
+func (fs *MemoryFileSystem) resize(entry *memoryEntry, size int64) {
+	switch {
+	case size < 0:
+		return
+	case size <= int64(len(entry.data)):
+		entry.data = entry.data[:size]
+	default:
+		grown := make([]byte, size)
+		copy(grown, entry.data)
+		entry.data = grown
+	}
+	entry.modified = time.Now().UTC()
+}
+
+// Remove deletes a file.
+func (fs *MemoryFileSystem) Remove(path string) error {
+	fs.mutex.Lock()
+	defer fs.mutex.Unlock()
+
+	entry, ok := fs.entries[path]
+	if !ok {
+		return ErrNotFound
+	}
+	if entry.isDir {
+		return ErrIsDirectory
+	}
+	if entry.readOnly {
+		return ErrReadOnly
+	}
+	delete(fs.entries, path)
+	return nil
+}
+
+// Rename moves a file or directory, and everything beneath a directory with it.
+func (fs *MemoryFileSystem) Rename(oldPath, newPath string, replace bool) error {
+	fs.mutex.Lock()
+	defer fs.mutex.Unlock()
+
+	entry, ok := fs.entries[oldPath]
+	if !ok {
+		return ErrNotFound
+	}
+	if _, taken := fs.entries[newPath]; taken {
+		if !replace {
+			return ErrExists
+		}
+		delete(fs.entries, newPath)
+	}
+
+	// The destination's parent has to exist, or the entry would be unreachable.
+	if parent, _ := splitPath(newPath); parent != "" {
+		holder, ok := fs.entries[parent]
+		if !ok {
+			return ErrNotFound
+		}
+		if !holder.isDir {
+			return ErrNotDirectory
+		}
+	}
+
+	// Move the entry, then everything beneath it if it is a directory. Collected
+	// first, because the map is being written while it is walked.
+	_, newName := splitPath(newPath)
+	entry.name = newName
+	fs.entries[newPath] = entry
+	delete(fs.entries, oldPath)
+
+	if !entry.isDir {
+		return nil
+	}
+	prefix := oldPath + "/"
+	moved := map[string]*memoryEntry{}
+	for path, held := range fs.entries {
+		if strings.HasPrefix(path, prefix) {
+			moved[newPath+"/"+strings.TrimPrefix(path, prefix)] = held
+		}
+	}
+	for path := range fs.entries {
+		if strings.HasPrefix(path, prefix) {
+			delete(fs.entries, path)
+		}
+	}
+	for path, held := range moved {
+		fs.entries[path] = held
+	}
+	return nil
+}
+
+// Mkdir creates a directory.
+func (fs *MemoryFileSystem) Mkdir(path string) error {
+	fs.mutex.Lock()
+	defer fs.mutex.Unlock()
+
+	if _, taken := fs.entries[path]; taken {
+		return ErrExists
+	}
+	if parent, _ := splitPath(path); parent != "" {
+		holder, ok := fs.entries[parent]
+		if !ok {
+			return ErrNotFound
+		}
+		if !holder.isDir {
+			return ErrNotDirectory
+		}
+	}
+	return fs.makeDirectory(path)
+}
+
+// Rmdir removes an empty directory.
+func (fs *MemoryFileSystem) Rmdir(path string) error {
+	fs.mutex.Lock()
+	defer fs.mutex.Unlock()
+
+	entry, ok := fs.entries[path]
+	if !ok {
+		return ErrNotFound
+	}
+	if !entry.isDir {
+		return ErrNotDirectory
+	}
+	if path == "" {
+		return ErrAccessDenied
+	}
+
+	prefix := path + "/"
+	for held := range fs.entries {
+		if strings.HasPrefix(held, prefix) {
+			return ErrNotEmpty
+		}
+	}
+	delete(fs.entries, path)
+	return nil
+}
+
+// ReadDir lists the immediate children of a directory that match pattern.
+func (fs *MemoryFileSystem) ReadDir(path, pattern string) ([]DirEntry, error) {
+	fs.mutex.RLock()
+	defer fs.mutex.RUnlock()
+
+	holder, ok := fs.entries[path]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	if !holder.isDir {
+		return nil, ErrNotDirectory
+	}
+
+	prefix := ""
+	if path != "" {
+		prefix = path + "/"
+	}
+
+	listed := []DirEntry{}
+	for held, entry := range fs.entries {
+		if held == path || !strings.HasPrefix(held, prefix) {
+			continue
+		}
+		// Immediate children only.
+		if strings.Contains(strings.TrimPrefix(held, prefix), "/") {
+			continue
+		}
+		if !matchPattern(pattern, entry.name) {
+			continue
+		}
+		listed = append(listed, DirEntry{Attr: entry.attr()})
+	}
+
+	// A stable order, since a map has none and a client enumerating twice should
+	// see the same thing.
+	sort.Slice(listed, func(i, j int) bool { return listed[i].Attr.Name < listed[j].Attr.Name })
+	return listed, nil
+}
+
+// VolumeInfo describes the storage.
+func (fs *MemoryFileSystem) VolumeInfo() (VolumeInfo, error) {
+	fs.mutex.RLock()
+	defer fs.mutex.RUnlock()
+	return fs.volume, nil
+}
+
+// memoryFile is an open handle onto a MemoryFileSystem entry. It holds the path
+// rather than the entry, so a rename or a delete underneath it is observed rather
+// than written into a detached copy.
+type memoryFile struct {
+	fs     *MemoryFileSystem
+	path   string
+	closed bool
+}
+
+// entry resolves the handle's path, reporting the failure a vanished file gives.
+func (f *memoryFile) entry() (*memoryEntry, error) {
+	if f.closed {
+		return nil, ErrAccessDenied
+	}
+	entry, ok := f.fs.entries[f.path]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	return entry, nil
+}
+
+func (f *memoryFile) ReadAt(p []byte, off int64) (int, error) {
+	f.fs.mutex.RLock()
+	defer f.fs.mutex.RUnlock()
+
+	entry, err := f.entry()
+	if err != nil {
+		return 0, err
+	}
+	if entry.isDir {
+		return 0, ErrIsDirectory
+	}
+	if off < 0 {
+		return 0, fmt.Errorf("negative offset %d", off)
+	}
+	if off >= int64(len(entry.data)) {
+		return 0, io.EOF
+	}
+	return copy(p, entry.data[off:]), nil
+}
+
+func (f *memoryFile) WriteAt(p []byte, off int64) (int, error) {
+	f.fs.mutex.Lock()
+	defer f.fs.mutex.Unlock()
+
+	entry, err := f.entry()
+	if err != nil {
+		return 0, err
+	}
+	if entry.isDir {
+		return 0, ErrIsDirectory
+	}
+	if entry.readOnly {
+		return 0, ErrReadOnly
+	}
+	if off < 0 {
+		return 0, fmt.Errorf("negative offset %d", off)
+	}
+
+	// A write past the end extends the file, with the gap reading as zeroes.
+	if end := off + int64(len(p)); end > int64(len(entry.data)) {
+		grown := make([]byte, end)
+		copy(grown, entry.data)
+		entry.data = grown
+	}
+	written := copy(entry.data[off:], p)
+	entry.modified = time.Now().UTC()
+	return written, nil
+}
+
+func (f *memoryFile) Truncate(size int64) error {
+	f.fs.mutex.Lock()
+	defer f.fs.mutex.Unlock()
+
+	entry, err := f.entry()
+	if err != nil {
+		return err
+	}
+	if entry.readOnly {
+		return ErrReadOnly
+	}
+	f.fs.resize(entry, size)
+	return nil
+}
+
+// Sync is a no-op: there is nothing behind memory to commit to.
+func (f *memoryFile) Sync() error {
+	if f.closed {
+		return ErrAccessDenied
+	}
+	return nil
+}
+
+func (f *memoryFile) Stat() (FileAttr, error) {
+	f.fs.mutex.RLock()
+	defer f.fs.mutex.RUnlock()
+
+	entry, err := f.entry()
+	if err != nil {
+		return FileAttr{}, err
+	}
+	return entry.attr(), nil
+}
+
+func (f *memoryFile) Close() error {
+	f.closed = true
+	return nil
+}
+
+// Compile-time assurance that the backend satisfies the contracts.
+var (
+	_ FileSystem = (*MemoryFileSystem)(nil)
+	_ File       = (*memoryFile)(nil)
+)

--- a/network/smb/smb_v10/server/fuzz_test.go
+++ b/network/smb/smb_v10/server/fuzz_test.go
@@ -46,8 +46,8 @@ func FuzzServerFrame(f *testing.F) {
 		f.Add(marshalled)
 	}
 	// A recognized command with no handler.
-	unimplemented := newRequest(codes.SMB_COM_TREE_CONNECT_ANDX)
-	unimplemented.AddCommand(commands.NewTreeConnectAndxRequest())
+	unimplemented := newRequest(codes.SMB_COM_SEEK)
+	unimplemented.AddCommand(commands.NewSeekRequest())
 	if marshalled, err := unimplemented.Marshal(); err == nil {
 		f.Add(marshalled)
 	}

--- a/network/smb/smb_v10/server/handler.go
+++ b/network/smb/smb_v10/server/handler.go
@@ -64,6 +64,10 @@ type ResponseWriter interface {
 	// until the server assigns one, so the leg that assigns it has to say so.
 	SetResponseUID(uid uint16)
 
+	// SetResponseTID overrides the tree identifier echoed in responses to this
+	// request, for the tree connect that assigns one.
+	SetResponseTID(tid uint16)
+
 	// SignResponse signs responses to this request with the given key and
 	// sequence number.
 	//
@@ -78,9 +82,11 @@ type responseWriter struct {
 	conn    *Connection
 	request *message.Message
 
-	// uid, when set, replaces the request's UID in responses.
+	// uid and tid, when set, replace the request's values in responses.
 	uid    uint16
 	uidSet bool
+	tid    uint16
+	tidSet bool
 
 	// signKey and signSequence, when set, sign responses to this request.
 	signKey      []byte
@@ -108,6 +114,12 @@ func (w *responseWriter) SetResponseUID(uid uint16) {
 	w.uidSet = true
 }
 
+// SetResponseTID overrides the TID echoed in responses to this request.
+func (w *responseWriter) SetResponseTID(tid uint16) {
+	w.tid = tid
+	w.tidSet = true
+}
+
 // SignResponse signs responses to this request with the given key and sequence
 // number.
 func (w *responseWriter) SignResponse(macKey []byte, sequenceNumber uint32) {
@@ -130,6 +142,9 @@ func (w *responseWriter) write(cmd command_interface.CommandInterface, status nt
 	reply.Header = replyHeader(w.request.Header, status, len(w.signKey) > 0)
 	if w.uidSet {
 		reply.Header.UID = types.USHORT(w.uid)
+	}
+	if w.tidSet {
+		reply.Header.TID = types.USHORT(w.tid)
 	}
 
 	// A command marshals its string fields according to the message's Unicode

--- a/network/smb/smb_v10/server/handler_file.go
+++ b/network/smb/smb_v10/server/handler_file.go
@@ -1,0 +1,444 @@
+package server
+
+import (
+	"errors"
+	"io"
+	"time"
+
+	"github.com/TheManticoreProject/Manticore/logger"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+	"github.com/TheManticoreProject/Manticore/windows/fileflags"
+	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
+	"github.com/TheManticoreProject/Manticore/windows/nt_status"
+)
+
+// Resource types reported in a create response ([MS-CIFS] 2.2.4.64.2).
+const (
+	resourceTypeDisk = 0x0000
+)
+
+// treeFor resolves the tree a request acts on, and the disk share behind it.
+//
+// Every file command needs the same three things established — a tree, a disk
+// share, and a file system — so they are checked once here rather than at the top
+// of each handler where one could be forgotten.
+func (c *Connection) treeFor(req *message.Message) (*Tree, nt_status.NT_STATUS) {
+	tree := c.Tree(uint16(req.Header.TID))
+	if tree == nil {
+		return nil, nt_status.NT_STATUS_SMB_BAD_TID
+	}
+	// A tree belongs to the session that opened it: another session's identifier
+	// must not reach it, even on the same connection.
+	if tree.SessionUID != uint16(req.Header.UID) {
+		logger.Debugf("SMB1 server: %s used TID 0x%04X from UID 0x%04X, which does not own it",
+			c.Remote, tree.TID, uint16(req.Header.UID))
+		return nil, nt_status.NT_STATUS_SMB_BAD_TID
+	}
+	if tree.Share.Type != ShareTypeDisk || tree.Share.FS == nil {
+		return nil, nt_status.NT_STATUS_BAD_DEVICE_TYPE
+	}
+	return tree, nt_status.NT_STATUS_SUCCESS
+}
+
+// openFor resolves the handle a request acts on, checking it belongs to the tree
+// the request named.
+func (c *Connection) openFor(req *message.Message, fid uint16) (*Open, nt_status.NT_STATUS) {
+	open := c.Open(fid)
+	if open == nil {
+		return nil, nt_status.NT_STATUS_SMB_BAD_FID
+	}
+	if open.Tree == nil || open.Tree.TID != uint16(req.Header.TID) {
+		logger.Debugf("SMB1 server: %s used FID 0x%04X on TID 0x%04X, which does not hold it",
+			c.Remote, fid, uint16(req.Header.TID))
+		return nil, nt_status.NT_STATUS_SMB_BAD_FID
+	}
+	return open, nt_status.NT_STATUS_SUCCESS
+}
+
+// statusForFSError maps a backend failure onto the protocol status that describes
+// it, so a client sees a meaningful refusal rather than a generic one.
+func statusForFSError(err error) nt_status.NT_STATUS {
+	switch {
+	case err == nil:
+		return nt_status.NT_STATUS_SUCCESS
+	case errors.Is(err, ErrNotFound):
+		return nt_status.NT_STATUS_OBJECT_NAME_NOT_FOUND
+	case errors.Is(err, ErrExists):
+		return nt_status.NT_STATUS_OBJECT_NAME_COLLISION
+	case errors.Is(err, ErrNotDirectory):
+		return nt_status.NT_STATUS_NOT_A_DIRECTORY
+	case errors.Is(err, ErrIsDirectory):
+		return nt_status.NT_STATUS_FILE_IS_A_DIRECTORY
+	case errors.Is(err, ErrNotEmpty):
+		return nt_status.NT_STATUS_DIRECTORY_NOT_EMPTY
+	case errors.Is(err, ErrReadOnly):
+		return nt_status.NT_STATUS_MEDIA_WRITE_PROTECTED
+	case errors.Is(err, ErrAccessDenied):
+		return nt_status.NT_STATUS_ACCESS_DENIED
+	}
+	return nt_status.NT_STATUS_UNSUCCESSFUL
+}
+
+// openFlagsFor translates a create request's access and options into what a
+// backend needs.
+//
+// The disposition decides what happens about existence, and the options decide
+// what the target must be. A request whose options contradict each other is
+// refused rather than resolved arbitrarily.
+func openFlagsFor(desiredAccess, createDisposition, createOptions uint32) (OpenFlags, nt_status.NT_STATUS) {
+	flags := OpenFlags{
+		Read:  desiredAccess&(fileflags.GENERIC_READ|fileflags.GENERIC_ALL|fileflags.FILE_READ_DATA) != 0,
+		Write: desiredAccess&(fileflags.GENERIC_WRITE|fileflags.GENERIC_ALL|fileflags.FILE_WRITE_DATA|fileflags.FILE_APPEND_DATA) != 0,
+	}
+	// An open that asked for nothing in particular still reads: a client commonly
+	// opens purely to query, and refusing that would break it.
+	if !flags.Read && !flags.Write {
+		flags.Read = true
+	}
+
+	switch createDisposition {
+	case fileflags.FILE_OPEN:
+		// Must exist.
+	case fileflags.FILE_CREATE:
+		flags.Create, flags.CreateNew = true, true
+	case fileflags.FILE_OPEN_IF:
+		flags.Create = true
+	case fileflags.FILE_OVERWRITE:
+		flags.Truncate = true
+	case fileflags.FILE_OVERWRITE_IF, fileflags.FILE_SUPERSEDE:
+		flags.Create, flags.Truncate = true, true
+	default:
+		return OpenFlags{}, nt_status.NT_STATUS_INVALID_PARAMETER
+	}
+
+	flags.Directory = createOptions&fileflags.FILE_DIRECTORY_FILE != 0
+	flags.NonDirectory = createOptions&fileflags.FILE_NON_DIRECTORY_FILE != 0
+	if flags.Directory && flags.NonDirectory {
+		return OpenFlags{}, nt_status.NT_STATUS_INVALID_PARAMETER
+	}
+	// Creating or truncating a directory is not a thing.
+	if flags.Directory && flags.Truncate {
+		return OpenFlags{}, nt_status.NT_STATUS_INVALID_PARAMETER
+	}
+
+	return flags, nt_status.NT_STATUS_SUCCESS
+}
+
+// handleNtCreateAndx answers SMB_COM_NT_CREATE_ANDX: the open path, which creates
+// or opens a file or directory and returns the handle a client acts through.
+//
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/e1d7f4a5-c9d8-4a4e-9b0e-0e8f3f2a4c5d
+func handleNtCreateAndx(conn *Connection, w ResponseWriter, req *message.Message) nt_status.NT_STATUS {
+	request, ok := req.Command.(*commands.NtCreateAndxRequest)
+	if !ok {
+		return nt_status.NT_STATUS_INVALID_SMB
+	}
+
+	tree, status := conn.treeFor(req)
+	if status != nt_status.NT_STATUS_SUCCESS {
+		return status
+	}
+
+	// Unicode is a per-request property, not a per-connection one: this
+	// repository's client sends file-I/O messages in OEM even when the connection
+	// negotiated Unicode, so the request's own flag is what governs.
+	requested := decodeWireString(request.FileName.Buffer, req.Header.Flags2.IsUnicode())
+
+	path, err := resolvePath(requested)
+	if err != nil {
+		logger.Debugf("SMB1 server: %s asked to open %q, which is refused: %v",
+			conn.Remote, requested, err)
+		return nt_status.NT_STATUS_OBJECT_PATH_SYNTAX_BAD
+	}
+
+	flags, status := openFlagsFor(uint32(request.DesiredAccess), uint32(request.CreateDisposition), uint32(request.CreateOptions))
+	if status != nt_status.NT_STATUS_SUCCESS {
+		return status
+	}
+
+	// A read-only share refuses a modifying open whatever access the client asked
+	// for. Enforced here rather than in the backend so a backend cannot forget it.
+	if tree.Share.ReadOnly && (flags.Write || flags.Create || flags.CreateNew || flags.Truncate) {
+		logger.Debugf("SMB1 server: %s asked to open %q for writing on read-only share %q",
+			conn.Remote, path, tree.Share.Name)
+		return nt_status.NT_STATUS_MEDIA_WRITE_PROTECTED
+	}
+
+	// Whether the target existed decides what the response reports it did.
+	_, statErr := tree.Share.FS.Stat(path)
+	existed := statErr == nil
+
+	file, err := tree.Share.FS.Open(path, flags)
+	if err != nil {
+		logger.Debugf("SMB1 server: %s could not open %q on %q: %v", conn.Remote, path, tree.Share.Name, err)
+		return statusForFSError(err)
+	}
+
+	attr, err := file.Stat()
+	if err != nil {
+		file.Close()
+		return statusForFSError(err)
+	}
+
+	fid, err := conn.fids.Allocate()
+	if err != nil {
+		file.Close()
+		logger.Warnf("SMB1 server: refusing an open from %s: %v", conn.Remote, err)
+		return nt_status.NT_STATUS_TOO_MANY_OPENED_FILES
+	}
+
+	open := &Open{
+		FID:           fid,
+		Tree:          tree,
+		Path:          path,
+		File:          file,
+		IsDirectory:   attr.IsDir,
+		Readable:      flags.Read,
+		Writable:      flags.Write && !tree.Share.ReadOnly,
+		DeleteOnClose: uint32(request.CreateOptions)&fileflags.FILE_DELETE_ON_CLOSE != 0,
+		Created:       time.Now().UTC(),
+	}
+	conn.addOpen(open)
+
+	logger.Debugf("SMB1 server: %s opened %q on %q as FID 0x%04X", conn.Remote, path, tree.Share.Name, fid)
+
+	response := commands.NewNtCreateAndxResponse()
+	response.FID = types.USHORT(fid)
+	response.CreateDisposition = types.ULONG(createActionFor(existed, flags))
+	response.CreateTime = *msdtyp.NewFILETIMEFromTime(attr.Created)
+	response.LastAccessTime = *msdtyp.NewFILETIMEFromTime(attr.Accessed)
+	response.LastWriteTime = *msdtyp.NewFILETIMEFromTime(attr.Modified)
+	response.LastChangeTime = *msdtyp.NewFILETIMEFromTime(attr.Changed)
+	response.ExtFileAttributes = types.SMB_EXT_FILE_ATTR(attributesFor(attr))
+	response.AllocationSize = types.LARGE_INTEGER{QuadPart: uint64(attr.AllocationSize)}
+	response.EndOfFile = types.LARGE_INTEGER{QuadPart: uint64(attr.Size)}
+	response.ResourceType = types.USHORT(resourceTypeDisk)
+	if attr.IsDir {
+		response.Directory = types.UCHAR(1)
+	}
+
+	if err := w.WriteResponse(response); err != nil {
+		logger.Debugf("SMB1 server: failed to answer the open for %s: %v", conn.Remote, err)
+	}
+	return nt_status.NT_STATUS_SUCCESS
+}
+
+// createActionFor reports what an open did, which a client uses to tell a create
+// from an open of something that was already there.
+func createActionFor(existed bool, flags OpenFlags) uint32 {
+	switch {
+	case !existed:
+		return fileflags.FILE_CREATE
+	case flags.Truncate:
+		return fileflags.FILE_OVERWRITE
+	}
+	return fileflags.FILE_OPEN
+}
+
+// attributesFor renders a backend's view of an entry as the attribute bits a
+// client expects. FILE_ATTRIBUTE_NORMAL is only meaningful alone, so it is used
+// when nothing else applies.
+func attributesFor(attr FileAttr) uint32 {
+	attributes := uint32(0)
+	if attr.IsDir {
+		attributes |= fileflags.FILE_ATTRIBUTE_DIRECTORY
+	}
+	if attr.ReadOnly {
+		attributes |= fileflags.FILE_ATTRIBUTE_READONLY
+	}
+	if attributes == 0 {
+		attributes = fileflags.FILE_ATTRIBUTE_NORMAL
+	}
+	return attributes
+}
+
+// handleClose answers SMB_COM_CLOSE: it releases a handle, applying any pending
+// delete-on-close.
+func handleClose(conn *Connection, w ResponseWriter, req *message.Message) nt_status.NT_STATUS {
+	request, ok := req.Command.(*commands.CloseRequest)
+	if !ok {
+		return nt_status.NT_STATUS_INVALID_SMB
+	}
+
+	open, status := conn.openFor(req, uint16(request.FID))
+	if status != nt_status.NT_STATUS_SUCCESS {
+		return status
+	}
+
+	// A client may set the modification time as it closes. 0 and -1 both mean
+	// "leave it alone", which is why the field cannot simply be applied.
+	if request.LastTimeModified != 0 && request.LastTimeModified != 0xFFFFFFFF && open.Writable {
+		modified := time.Unix(int64(request.LastTimeModified), 0).UTC()
+		if err := open.Tree.Share.FS.SetAttr(open.Path, FileAttr{Modified: modified}, AttrMask{Modified: true}); err != nil {
+			logger.Debugf("SMB1 server: could not set the modification time of %q: %v", open.Path, err)
+		}
+	}
+
+	if err := conn.closeOpen(uint16(request.FID)); err != nil {
+		logger.Debugf("SMB1 server: closing FID 0x%04X for %s reported %v", uint16(request.FID), conn.Remote, err)
+	}
+
+	if err := w.WriteResponse(commands.NewCloseResponse()); err != nil {
+		logger.Debugf("SMB1 server: failed to answer the close for %s: %v", conn.Remote, err)
+	}
+	return nt_status.NT_STATUS_SUCCESS
+}
+
+// handleReadAndx answers SMB_COM_READ_ANDX.
+//
+// A read past the end of the file returns nothing rather than failing, and a read
+// that reaches the end returns what there was: SMB reports a short count, so
+// truncation is the normal answer rather than an error.
+func handleReadAndx(conn *Connection, w ResponseWriter, req *message.Message) nt_status.NT_STATUS {
+	request, ok := req.Command.(*commands.ReadAndxRequest)
+	if !ok {
+		return nt_status.NT_STATUS_INVALID_SMB
+	}
+
+	open, status := conn.openFor(req, uint16(request.FID))
+	if status != nt_status.NT_STATUS_SUCCESS {
+		return status
+	}
+	if !open.Readable {
+		return nt_status.NT_STATUS_ACCESS_DENIED
+	}
+	if open.IsDirectory {
+		return nt_status.NT_STATUS_FILE_IS_A_DIRECTORY
+	}
+
+	// The offset is 64-bit when the request carried the high word, which it does
+	// only in the twelve-word form.
+	offset := int64(uint64(request.Offset) | uint64(request.OffsetHigh)<<32)
+	if offset < 0 {
+		return nt_status.NT_STATUS_INVALID_PARAMETER
+	}
+
+	// Bounded by what the client asked for and by what the connection agreed a
+	// message may carry, so a client cannot ask for a response it could not
+	// receive.
+	length := int(request.MaxCountOfBytesToReturn)
+	if limit := int(conn.Server.config.MaxBufferSize) - readResponseOverhead; length > limit {
+		length = limit
+	}
+	if length < 0 {
+		length = 0
+	}
+
+	buffer := make([]byte, length)
+	read, err := open.File.ReadAt(buffer, offset)
+	if err != nil && !errors.Is(err, io.EOF) {
+		logger.Debugf("SMB1 server: reading %q for %s failed: %v", open.Path, conn.Remote, err)
+		return statusForFSError(err)
+	}
+
+	response := commands.NewReadAndxResponse()
+	response.Data = buffer[:read]
+	response.DataLength = types.USHORT(read)
+
+	if err := w.WriteResponse(response); err != nil {
+		logger.Debugf("SMB1 server: failed to answer the read for %s: %v", conn.Remote, err)
+	}
+	return nt_status.NT_STATUS_SUCCESS
+}
+
+// readResponseOverhead is the space a read response needs beyond its data: the
+// 32-byte header, the parameter words and the byte count. Reserving it keeps a
+// full-size read inside the negotiated buffer.
+const readResponseOverhead = 64
+
+// handleWriteAndx answers SMB_COM_WRITE_ANDX.
+func handleWriteAndx(conn *Connection, w ResponseWriter, req *message.Message) nt_status.NT_STATUS {
+	request, ok := req.Command.(*commands.WriteAndxRequest)
+	if !ok {
+		return nt_status.NT_STATUS_INVALID_SMB
+	}
+
+	open, status := conn.openFor(req, uint16(request.FID))
+	if status != nt_status.NT_STATUS_SUCCESS {
+		return status
+	}
+	if !open.Writable {
+		return nt_status.NT_STATUS_ACCESS_DENIED
+	}
+	if open.IsDirectory {
+		return nt_status.NT_STATUS_FILE_IS_A_DIRECTORY
+	}
+
+	offset := int64(uint64(request.Offset) | uint64(request.OffsetHigh)<<32)
+	if offset < 0 {
+		return nt_status.NT_STATUS_INVALID_PARAMETER
+	}
+
+	// The declared length governs, but never past what actually arrived: the two
+	// disagreeing is a malformed request, not licence to read past the buffer.
+	data := []byte(request.Data)
+	if declared := int(request.DataLength); declared < len(data) {
+		data = data[:declared]
+	}
+
+	written, err := open.File.WriteAt(data, offset)
+	if err != nil {
+		logger.Debugf("SMB1 server: writing %q for %s failed: %v", open.Path, conn.Remote, err)
+		return statusForFSError(err)
+	}
+
+	// WritethroughMode asks for the write to be committed before the response.
+	if uint16(request.WriteMode)&writeThroughMode != 0 {
+		if err := open.File.Sync(); err != nil {
+			logger.Debugf("SMB1 server: syncing %q for %s failed: %v", open.Path, conn.Remote, err)
+			return statusForFSError(err)
+		}
+	}
+
+	response := commands.NewWriteAndxResponse()
+	response.Count = types.USHORT(written)
+
+	if err := w.WriteResponse(response); err != nil {
+		logger.Debugf("SMB1 server: failed to answer the write for %s: %v", conn.Remote, err)
+	}
+	return nt_status.NT_STATUS_SUCCESS
+}
+
+// writeThroughMode is the WriteMode bit asking for the write to reach storage
+// before the response ([MS-CIFS] 2.2.4.43.1).
+const writeThroughMode = 0x0001
+
+// handleFlush answers SMB_COM_FLUSH: it commits one handle, or every handle on
+// the tree when the FID is the 0xFFFF wildcard.
+func handleFlush(conn *Connection, w ResponseWriter, req *message.Message) nt_status.NT_STATUS {
+	request, ok := req.Command.(*commands.FlushRequest)
+	if !ok {
+		return nt_status.NT_STATUS_INVALID_SMB
+	}
+
+	if uint16(request.FID) == 0xFFFF {
+		tree, status := conn.treeFor(req)
+		if status != nt_status.NT_STATUS_SUCCESS {
+			return status
+		}
+		for _, open := range conn.opens {
+			if open.Tree == tree && open.File != nil {
+				if err := open.File.Sync(); err != nil {
+					logger.Debugf("SMB1 server: syncing %q failed: %v", open.Path, err)
+				}
+			}
+		}
+	} else {
+		open, status := conn.openFor(req, uint16(request.FID))
+		if status != nt_status.NT_STATUS_SUCCESS {
+			return status
+		}
+		if open.File != nil {
+			if err := open.File.Sync(); err != nil {
+				return statusForFSError(err)
+			}
+		}
+	}
+
+	if err := w.WriteResponse(commands.NewFlushResponse()); err != nil {
+		logger.Debugf("SMB1 server: failed to answer the flush for %s: %v", conn.Remote, err)
+	}
+	return nt_status.NT_STATUS_SUCCESS
+}

--- a/network/smb/smb_v10/server/handler_filemgmt.go
+++ b/network/smb/smb_v10/server/handler_filemgmt.go
@@ -1,0 +1,220 @@
+package server
+
+import (
+	"github.com/TheManticoreProject/Manticore/logger"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/command_interface"
+	"github.com/TheManticoreProject/Manticore/windows/nt_status"
+)
+
+// writableTreeFor resolves the tree a modifying command acts on, refusing a
+// read-only share. Every command below modifies something, so the check belongs
+// in one place rather than at the top of each.
+func (c *Connection) writableTreeFor(req *message.Message) (*Tree, nt_status.NT_STATUS) {
+	tree, status := c.treeFor(req)
+	if status != nt_status.NT_STATUS_SUCCESS {
+		return nil, status
+	}
+	if tree.Share.ReadOnly {
+		logger.Debugf("SMB1 server: %s attempted to modify read-only share %q", c.Remote, tree.Share.Name)
+		return nil, nt_status.NT_STATUS_MEDIA_WRITE_PROTECTED
+	}
+	return tree, nt_status.NT_STATUS_SUCCESS
+}
+
+// handleDelete answers SMB_COM_DELETE. The name may be a wildcard, in which case
+// every matching file in the directory is deleted.
+//
+// A directory is never deleted by this command, whatever the pattern matches:
+// SMB_COM_DELETE_DIRECTORY exists for that, and a client that asked to delete
+// "*" does not mean to take the directories with it.
+func handleDelete(conn *Connection, w ResponseWriter, req *message.Message) nt_status.NT_STATUS {
+	request, ok := req.Command.(*commands.DeleteRequest)
+	if !ok {
+		return nt_status.NT_STATUS_INVALID_SMB
+	}
+
+	tree, status := conn.writableTreeFor(req)
+	if status != nt_status.NT_STATUS_SUCCESS {
+		return status
+	}
+
+	requested := decodeWireString(request.FileName.Buffer, req.Header.Flags2.IsUnicode())
+	directory, pattern, err := resolvePathPattern(requested)
+	if err != nil {
+		logger.Debugf("SMB1 server: %s asked to delete %q, which is refused: %v", conn.Remote, requested, err)
+		return nt_status.NT_STATUS_OBJECT_PATH_SYNTAX_BAD
+	}
+
+	// No wildcard: one named file.
+	if pattern == "" {
+		if err := tree.Share.FS.Remove(directory); err != nil {
+			logger.Debugf("SMB1 server: deleting %q for %s failed: %v", directory, conn.Remote, err)
+			return statusForFSError(err)
+		}
+		return conn.answer(w, commands.NewDeleteResponse())
+	}
+
+	entries, err := tree.Share.FS.ReadDir(directory, pattern)
+	if err != nil {
+		return statusForFSError(err)
+	}
+
+	deleted := 0
+	for _, entry := range entries {
+		if entry.Attr.IsDir {
+			continue
+		}
+		if err := tree.Share.FS.Remove(joinPath(directory, entry.Attr.Name)); err != nil {
+			logger.Debugf("SMB1 server: deleting %q for %s failed: %v",
+				joinPath(directory, entry.Attr.Name), conn.Remote, err)
+			return statusForFSError(err)
+		}
+		deleted++
+	}
+	// A pattern that matched nothing is a failure, not a no-op: the client asked
+	// for something to be deleted and nothing was.
+	if deleted == 0 {
+		return nt_status.NT_STATUS_NO_SUCH_FILE
+	}
+
+	return conn.answer(w, commands.NewDeleteResponse())
+}
+
+// handleRename answers SMB_COM_RENAME, which moves as well as renames since the
+// destination is a full path.
+func handleRename(conn *Connection, w ResponseWriter, req *message.Message) nt_status.NT_STATUS {
+	request, ok := req.Command.(*commands.RenameRequest)
+	if !ok {
+		return nt_status.NT_STATUS_INVALID_SMB
+	}
+
+	tree, status := conn.writableTreeFor(req)
+	if status != nt_status.NT_STATUS_SUCCESS {
+		return status
+	}
+
+	unicode := req.Header.Flags2.IsUnicode()
+	oldPath, err := resolvePath(decodeWireString(request.OldFileName.Buffer, unicode))
+	if err != nil {
+		return nt_status.NT_STATUS_OBJECT_PATH_SYNTAX_BAD
+	}
+	newPath, err := resolvePath(decodeWireString(request.NewFileName.Buffer, unicode))
+	if err != nil {
+		return nt_status.NT_STATUS_OBJECT_PATH_SYNTAX_BAD
+	}
+	if oldPath == "" || newPath == "" {
+		// Renaming the share root is not a thing.
+		return nt_status.NT_STATUS_ACCESS_DENIED
+	}
+
+	// SMB_COM_RENAME does not replace: a destination that exists is a collision.
+	// The NT_RENAME variant is what a client uses when it means to overwrite.
+	if err := tree.Share.FS.Rename(oldPath, newPath, false); err != nil {
+		logger.Debugf("SMB1 server: renaming %q to %q for %s failed: %v", oldPath, newPath, conn.Remote, err)
+		return statusForFSError(err)
+	}
+
+	return conn.answer(w, commands.NewRenameResponse())
+}
+
+// handleCreateDirectory answers SMB_COM_CREATE_DIRECTORY.
+func handleCreateDirectory(conn *Connection, w ResponseWriter, req *message.Message) nt_status.NT_STATUS {
+	request, ok := req.Command.(*commands.CreateDirectoryRequest)
+	if !ok {
+		return nt_status.NT_STATUS_INVALID_SMB
+	}
+
+	tree, status := conn.writableTreeFor(req)
+	if status != nt_status.NT_STATUS_SUCCESS {
+		return status
+	}
+
+	path, err := resolvePath(decodeWireString(request.DirectoryName.Buffer, req.Header.Flags2.IsUnicode()))
+	if err != nil {
+		return nt_status.NT_STATUS_OBJECT_PATH_SYNTAX_BAD
+	}
+	if path == "" {
+		return nt_status.NT_STATUS_OBJECT_NAME_COLLISION
+	}
+
+	if err := tree.Share.FS.Mkdir(path); err != nil {
+		logger.Debugf("SMB1 server: creating directory %q for %s failed: %v", path, conn.Remote, err)
+		return statusForFSError(err)
+	}
+
+	return conn.answer(w, commands.NewCreateDirectoryResponse())
+}
+
+// handleDeleteDirectory answers SMB_COM_DELETE_DIRECTORY, which removes only an
+// empty directory.
+func handleDeleteDirectory(conn *Connection, w ResponseWriter, req *message.Message) nt_status.NT_STATUS {
+	request, ok := req.Command.(*commands.DeleteDirectoryRequest)
+	if !ok {
+		return nt_status.NT_STATUS_INVALID_SMB
+	}
+
+	tree, status := conn.writableTreeFor(req)
+	if status != nt_status.NT_STATUS_SUCCESS {
+		return status
+	}
+
+	path, err := resolvePath(decodeWireString(request.DirectoryName.Buffer, req.Header.Flags2.IsUnicode()))
+	if err != nil {
+		return nt_status.NT_STATUS_OBJECT_PATH_SYNTAX_BAD
+	}
+	if path == "" {
+		// Removing the share root is refused rather than attempted.
+		return nt_status.NT_STATUS_ACCESS_DENIED
+	}
+
+	if err := tree.Share.FS.Rmdir(path); err != nil {
+		logger.Debugf("SMB1 server: removing directory %q for %s failed: %v", path, conn.Remote, err)
+		return statusForFSError(err)
+	}
+
+	return conn.answer(w, commands.NewDeleteDirectoryResponse())
+}
+
+// handleCheckDirectory answers SMB_COM_CHECK_DIRECTORY, which reports whether a
+// path names a directory. A client uses it to walk a path before opening
+// anything, so it must distinguish "not there" from "there but not a directory".
+func handleCheckDirectory(conn *Connection, w ResponseWriter, req *message.Message) nt_status.NT_STATUS {
+	request, ok := req.Command.(*commands.CheckDirectoryRequest)
+	if !ok {
+		return nt_status.NT_STATUS_INVALID_SMB
+	}
+
+	tree, status := conn.treeFor(req)
+	if status != nt_status.NT_STATUS_SUCCESS {
+		return status
+	}
+
+	path, err := resolvePath(decodeWireString(request.DirectoryName.Buffer, req.Header.Flags2.IsUnicode()))
+	if err != nil {
+		return nt_status.NT_STATUS_OBJECT_PATH_SYNTAX_BAD
+	}
+
+	// The share root is always a directory and needs no lookup.
+	if path != "" {
+		attr, err := tree.Share.FS.Stat(path)
+		if err != nil {
+			return statusForFSError(err)
+		}
+		if !attr.IsDir {
+			return nt_status.NT_STATUS_NOT_A_DIRECTORY
+		}
+	}
+
+	return conn.answer(w, commands.NewCheckDirectoryResponse())
+}
+
+// answer sends a response that carries nothing beyond its success, which several
+// of the commands above do.
+func (c *Connection) answer(w ResponseWriter, response command_interface.CommandInterface) nt_status.NT_STATUS {
+	if err := w.WriteResponse(response); err != nil {
+		logger.Debugf("SMB1 server: failed to answer %s: %v", c.Remote, err)
+	}
+	return nt_status.NT_STATUS_SUCCESS
+}

--- a/network/smb/smb_v10/server/handler_session.go
+++ b/network/smb/smb_v10/server/handler_session.go
@@ -279,6 +279,10 @@ func handleLogoffAndx(conn *Connection, w ResponseWriter, req *message.Message) 
 		return nt_status.NT_STATUS_SMB_BAD_UID
 	}
 
+	// A logoff releases the trees and handles the session held, rather than
+	// leaving them reachable through a UID that no longer names anything.
+	conn.closeSessionResources(uid)
+
 	logger.Debugf("SMB1 server: %s logged off %s on UID 0x%04X", conn.Remote, session.Account(), uid)
 
 	// Signing stays armed: it is a property of the connection rather than of one

--- a/network/smb/smb_v10/server/handler_tree.go
+++ b/network/smb/smb_v10/server/handler_tree.go
@@ -1,0 +1,141 @@
+package server
+
+import (
+	"strings"
+	"time"
+
+	"github.com/TheManticoreProject/Manticore/encoding/utf16"
+	"github.com/TheManticoreProject/Manticore/logger"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+	"github.com/TheManticoreProject/Manticore/windows/nt_status"
+)
+
+// nativeFileSystemName is reported for a disk share. A client uses it to decide
+// what the storage supports, so it names something with the semantics this server
+// actually offers rather than something more capable.
+const nativeFileSystemName = "NTFS"
+
+// handleTreeConnectAndx answers SMB_COM_TREE_CONNECT_ANDX: it connects a tree to
+// a named share and returns the identifier the client uses to act on it.
+//
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/1e0e0e1d-9a1e-4d0e-9d1a-b1c9e5a8b2d3
+func handleTreeConnectAndx(conn *Connection, w ResponseWriter, req *message.Message) nt_status.NT_STATUS {
+	request, ok := req.Command.(*commands.TreeConnectAndxRequest)
+	if !ok {
+		return nt_status.NT_STATUS_INVALID_SMB
+	}
+
+	session := conn.Session(uint16(req.Header.UID))
+	if session == nil {
+		// The dispatcher checks this, so reaching here means the tables
+		// disagree; refusing is still the right answer.
+		return nt_status.NT_STATUS_SMB_BAD_UID
+	}
+
+	// The path is a UNC path, encoded in whichever character set THIS REQUEST
+	// declared. Unicode is a per-message property: this repository's client
+	// negotiates it on the connection but sends its tree connect in OEM, so
+	// taking the connection's setting here decodes the path as garbage.
+	unicode := req.Header.Flags2.IsUnicode()
+	path := decodeWireString(request.Path, unicode)
+	name := shareNameFromPath(path)
+	if name == "" {
+		logger.Debugf("SMB1 server: %s sent a tree connect to %q, which is not a UNC path", conn.Remote, path)
+		return nt_status.NT_STATUS_BAD_NETWORK_NAME
+	}
+
+	share := conn.Server.Share(name)
+	if share == nil {
+		logger.Debugf("SMB1 server: %s asked for share %q, which is not served", conn.Remote, name)
+		return nt_status.NT_STATUS_BAD_NETWORK_NAME
+	}
+
+	// A client may say what kind of resource it expects. Answering a mismatch
+	// here is better than letting it discover the difference through a command
+	// that makes no sense on the resource it actually got.
+	if wanted := ShareType(decodeOEMString(request.Service)); wanted != "" && wanted != ShareTypeAny && wanted != share.Type {
+		logger.Debugf("SMB1 server: %s asked for share %q as %q, but it is %q",
+			conn.Remote, name, wanted, share.Type)
+		return nt_status.NT_STATUS_BAD_DEVICE_TYPE
+	}
+
+	tid, err := conn.tids.Allocate()
+	if err != nil {
+		logger.Warnf("SMB1 server: refusing a tree connect from %s: %v", conn.Remote, err)
+		return nt_status.NT_STATUS_INSUFF_SERVER_RESOURCES
+	}
+
+	tree := &Tree{
+		TID:        tid,
+		Share:      share,
+		SessionUID: session.UID,
+		Created:    time.Now().UTC(),
+	}
+	conn.addTree(tree)
+
+	logger.Debugf("SMB1 server: %s connected share %q as TID 0x%04X", conn.Remote, share.Name, tid)
+
+	response := commands.NewTreeConnectAndxResponse()
+	// The Service string is OEM even when the connection negotiated Unicode,
+	// which the response structure's own documentation notes.
+	response.Service = []types.UCHAR(string(share.Type))
+	if share.Type == ShareTypeDisk {
+		response.NativeFileSystem = encodeNativeString(nativeFileSystemName, unicode)
+	} else {
+		// A resource with no file system behind it reports the empty string.
+		response.NativeFileSystem = encodeNativeString("", unicode)
+	}
+
+	w.SetResponseTID(tid)
+	if err := w.WriteResponse(response); err != nil {
+		logger.Debugf("SMB1 server: failed to answer the tree connect for %s: %v", conn.Remote, err)
+	}
+	return nt_status.NT_STATUS_SUCCESS
+}
+
+// handleTreeDisconnect answers SMB_COM_TREE_DISCONNECT: it drops the tree and
+// everything opened on it.
+func handleTreeDisconnect(conn *Connection, w ResponseWriter, req *message.Message) nt_status.NT_STATUS {
+	tid := uint16(req.Header.TID)
+
+	tree := conn.removeTree(tid)
+	if tree == nil {
+		return nt_status.NT_STATUS_SMB_BAD_TID
+	}
+
+	logger.Debugf("SMB1 server: %s disconnected share %q on TID 0x%04X", conn.Remote, tree.Share.Name, tid)
+
+	if err := w.WriteResponse(commands.NewTreeDisconnectResponse()); err != nil {
+		logger.Debugf("SMB1 server: failed to answer the tree disconnect for %s: %v", conn.Remote, err)
+	}
+	return nt_status.NT_STATUS_SUCCESS
+}
+
+// decodeWireString reads a string field that carries wire bytes, in whichever
+// character set the connection negotiated, and trims the terminator.
+func decodeWireString(raw []types.UCHAR, useUnicode bool) string {
+	if useUnicode {
+		return trimTerminator(utf16.DecodeUTF16LE(raw))
+	}
+	return trimTerminator(string(raw))
+}
+
+// decodeOEMString reads a field that is OEM regardless of what the connection
+// negotiated, which a few fields are.
+func decodeOEMString(raw []types.UCHAR) string {
+	return trimTerminator(string(raw))
+}
+
+// trimTerminator removes the NUL terminator a wire string ends with.
+//
+// Only a trailing terminator is removed. A NUL in the middle is left in place
+// deliberately, so that a path carrying one is refused by resolvePath rather than
+// silently truncated at it: truncating would mean a client asking for
+// "file.txt\x00.png" was quietly given "file.txt", which is the whole hazard an
+// embedded NUL represents. Two consumers disagreeing about where a string ends is
+// resolved by rejecting the string, not by picking one of the answers.
+func trimTerminator(value string) string {
+	return strings.TrimRight(value, "\x00")
+}

--- a/network/smb/smb_v10/server/path.go
+++ b/network/smb/smb_v10/server/path.go
@@ -1,0 +1,227 @@
+package server
+
+import (
+	"fmt"
+	"strings"
+	"unicode/utf8"
+)
+
+// Path limits. SMB carries a path in a 16-bit-counted field, but a server has no
+// reason to accept anything near that: these bounds match what a file system will
+// take and keep a malicious path from turning into work.
+const (
+	// MaxPathLength is the longest share-relative path accepted, in bytes.
+	MaxPathLength = 4096
+
+	// MaxPathComponentLength is the longest single element of a path, in bytes.
+	// 255 is what every file system this could sit on enforces.
+	MaxPathComponentLength = 255
+)
+
+// invalidNameCharacters are the characters a file name cannot carry. The
+// separators and the colon are checked separately, before elements are split.
+const invalidNameCharacters = `*?"<>|`
+
+// reservedDeviceNames are the DOS device names Windows resolves specially at
+// every level of a path. A file called "CON" is not a file, so a path naming one
+// is refused rather than passed to a backend that might open a device.
+var reservedDeviceNames = map[string]bool{
+	"CON": true, "PRN": true, "AUX": true, "NUL": true,
+	"COM1": true, "COM2": true, "COM3": true, "COM4": true, "COM5": true,
+	"COM6": true, "COM7": true, "COM8": true, "COM9": true,
+	"LPT1": true, "LPT2": true, "LPT3": true, "LPT4": true, "LPT5": true,
+	"LPT6": true, "LPT7": true, "LPT8": true, "LPT9": true,
+}
+
+// resolvePath converts a client-supplied SMB path into the share-relative form a
+// FileSystem is promised: forward-slash separated, with no leading slash, no
+// empty element, and no "." or ".." element.
+//
+// This is the containment boundary. Every path that reaches a backend passes
+// through here, and a backend is entitled to assume the result cannot escape the
+// share, so everything that could make it escape is refused here rather than
+// being normalised into something plausible. Normalising is the trap: a resolver
+// that quietly rewrites "..\..\x" into "x" turns a traversal attempt into a
+// successful access somewhere unintended, so a path containing ".." is rejected
+// outright instead.
+//
+// Refused: an absolute path, a drive letter, a UNC or NT device prefix, an
+// alternate data stream, a NUL or other control byte, a "." or ".." element, an
+// empty element (which "\\" produces), a reserved DOS device name at any level,
+// invalid UTF-8, and anything over the length bounds.
+//
+// Parameters:
+//   - raw: the path exactly as the client sent it
+//
+// Returns:
+//   - The share-relative path, "" for the share root
+//   - An error naming why the path was refused
+func resolvePath(raw string) (string, error) {
+	if len(raw) > MaxPathLength {
+		return "", fmt.Errorf("path is %d bytes, over the %d-byte limit", len(raw), MaxPathLength)
+	}
+	if !utf8.ValidString(raw) {
+		return "", fmt.Errorf("path is not valid UTF-8")
+	}
+
+	// A control byte, NUL above all, can truncate a path in a consumer written
+	// in a language where a string ends at the first zero.
+	for i := 0; i < len(raw); i++ {
+		if raw[i] < 0x20 {
+			return "", fmt.Errorf("path contains the control byte 0x%02X at offset %d", raw[i], i)
+		}
+	}
+
+	// A stream name selects something other than the file's contents, and nothing
+	// here implements streams. It is checked before separators are normalised,
+	// because a colon anywhere is enough to refuse.
+	if strings.Contains(raw, ":") {
+		return "", fmt.Errorf("path contains a colon, which names a drive or an alternate data stream")
+	}
+
+	// SMB uses backslashes; accept forward slashes too, since a client that sends
+	// them means the same thing, and normalise before the element checks so that
+	// neither separator can smuggle an element past them.
+	path := strings.ReplaceAll(raw, "\\", "/")
+
+	// A doubled separator is refused here rather than after the trims below,
+	// because the trims would collapse it: "\\" reduces to the share root, which
+	// is exactly the normalising this function must not do.
+	if strings.Contains(path, "//") {
+		return "", fmt.Errorf("path contains a doubled separator")
+	}
+
+	// A leading separator is how a client names a path from the share root, and
+	// is the only one that is stripped rather than refused.
+	path = strings.TrimPrefix(path, "/")
+
+	// The share root itself.
+	if path == "" {
+		return "", nil
+	}
+
+	// A trailing separator is redundant but harmless, and clients send it.
+	path = strings.TrimSuffix(path, "/")
+	if path == "" {
+		return "", nil
+	}
+
+	elements := strings.Split(path, "/")
+	for _, element := range elements {
+		switch element {
+		case "":
+			// Produced by a doubled separator. Refused rather than collapsed,
+			// because collapsing is the normalising this function does not do.
+			return "", fmt.Errorf("path contains an empty element")
+		case ".":
+			return "", fmt.Errorf("path contains a %q element", ".")
+		case "..":
+			return "", fmt.Errorf("path contains a %q element", "..")
+		}
+		if len(element) > MaxPathComponentLength {
+			return "", fmt.Errorf("path element %q is %d bytes, over the %d-byte limit",
+				element, len(element), MaxPathComponentLength)
+		}
+		// A trailing dot or space is stripped by Windows when it opens a file, so
+		// "secret.txt." and "secret.txt" would name the same thing while looking
+		// different to anything checking names. Refuse rather than reproduce that.
+		if strings.HasSuffix(element, ".") || strings.HasSuffix(element, " ") {
+			return "", fmt.Errorf("path element %q ends with a dot or a space", element)
+		}
+		if reservedDeviceNames[deviceNameOf(element)] {
+			return "", fmt.Errorf("path element %q is a reserved device name", element)
+		}
+		// A wildcard or one of the other characters a name cannot carry. A
+		// wildcard matters beyond validity: reaching a backend as a literal name
+		// it might expand there instead, so a path is never allowed to hold one.
+		// The commands that legitimately take a pattern go through
+		// resolvePathPattern, which lifts it out first.
+		if i := strings.IndexAny(element, invalidNameCharacters); i >= 0 {
+			return "", fmt.Errorf("path element %q contains %q, which a name cannot carry", element, element[i])
+		}
+	}
+
+	return strings.Join(elements, "/"), nil
+}
+
+// deviceNameOf returns the part of an element Windows compares against the
+// reserved device names: the name before its first dot, upper-cased. "NUL.txt"
+// resolves to the NUL device, so the extension does not make it safe.
+func deviceNameOf(element string) string {
+	if dot := strings.IndexByte(element, '.'); dot >= 0 {
+		element = element[:dot]
+	}
+	return strings.ToUpper(element)
+}
+
+// splitPath separates a resolved path into its parent and its final element. The
+// parent of a top-level entry is "", the share root.
+func splitPath(path string) (parent, name string) {
+	if slash := strings.LastIndexByte(path, '/'); slash >= 0 {
+		return path[:slash], path[slash+1:]
+	}
+	return "", path
+}
+
+// joinPath appends an element to a resolved path.
+func joinPath(parent, name string) string {
+	if parent == "" {
+		return name
+	}
+	return parent + "/" + name
+}
+
+// resolvePathPattern resolves a path whose final element may be a wildcard,
+// returning the resolved directory and the pattern to match within it.
+//
+// The commands that take a pattern — delete above all — carry it in the same
+// field as a path, so the wildcard has to be lifted out before the rest of the
+// path is checked. Only the final element may contain one: a wildcard in the
+// middle would name several directories, which no command here means.
+//
+// Parameters:
+//   - raw: the path exactly as the client sent it
+//
+// Returns:
+//   - The resolved directory the pattern applies within
+//   - The pattern, which is "" when the path named no wildcard
+//   - An error naming why the path was refused
+func resolvePathPattern(raw string) (directory, pattern string, err error) {
+	normalised := strings.ReplaceAll(raw, "\\", "/")
+	lastSlash := strings.LastIndexByte(normalised, '/')
+
+	final := normalised[lastSlash+1:]
+	if !strings.ContainsAny(final, "*?") {
+		resolved, err := resolvePath(raw)
+		if err != nil {
+			return "", "", err
+		}
+		return resolved, "", nil
+	}
+
+	// The wildcard element is validated separately: it cannot be a path element,
+	// so the element rules do not apply to it, but it must still be free of the
+	// bytes and separators that would make it more than one element.
+	if strings.ContainsAny(final, "/\\:") {
+		return "", "", fmt.Errorf("wildcard element %q contains a separator", final)
+	}
+	if len(final) > MaxPathComponentLength {
+		return "", "", fmt.Errorf("wildcard element %q is over the %d-byte limit", final, MaxPathComponentLength)
+	}
+	for i := 0; i < len(final); i++ {
+		if final[i] < 0x20 {
+			return "", "", fmt.Errorf("wildcard element contains the control byte 0x%02X", final[i])
+		}
+	}
+
+	// Whatever precedes the wildcard is an ordinary path and is resolved as one.
+	parent := ""
+	if lastSlash >= 0 {
+		parent = normalised[:lastSlash]
+	}
+	directory, err = resolvePath(parent)
+	if err != nil {
+		return "", "", err
+	}
+	return directory, final, nil
+}

--- a/network/smb/smb_v10/server/path_test.go
+++ b/network/smb/smb_v10/server/path_test.go
@@ -1,0 +1,401 @@
+package server
+
+import (
+	"strings"
+	"testing"
+)
+
+// resolvePath is the containment boundary: every path a backend sees passes
+// through it, and a backend is entitled to assume the result cannot escape the
+// share. These tests are the case for that assumption, so they are deliberately
+// adversarial rather than illustrative.
+
+// TestResolvePathAccepts asserts the forms a client legitimately sends resolve to
+// the share-relative form a backend is promised.
+func TestResolvePathAccepts(t *testing.T) {
+	cases := []struct {
+		raw  string
+		want string
+	}{
+		{"", ""},
+		{"\\", ""},
+		{"/", ""},
+		{"\\file.txt", "file.txt"},
+		{"file.txt", "file.txt"},
+		{"\\dir\\file.txt", "dir/file.txt"},
+		{"dir\\sub\\file.txt", "dir/sub/file.txt"},
+		// Forward slashes mean the same thing.
+		{"/dir/file.txt", "dir/file.txt"},
+		// A trailing separator is redundant but clients send it.
+		{"\\dir\\", "dir"},
+		{"\\dir\\sub\\", "dir/sub"},
+		// A dot inside a name is ordinary.
+		{"\\my.file.txt", "my.file.txt"},
+		{"\\.hidden", ".hidden"},
+		// A name that merely starts with a reserved name is not one.
+		{"\\CONSOLE.txt", "CONSOLE.txt"},
+		{"\\NULLABLE", "NULLABLE"},
+		// Non-ASCII names are ordinary.
+		{"\\каталог\\файл.txt", "каталог/файл.txt"},
+		{"\\日本語.txt", "日本語.txt"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.raw, func(t *testing.T) {
+			got, err := resolvePath(tc.raw)
+			if err != nil {
+				t.Fatalf("resolvePath(%q) error = %v", tc.raw, err)
+			}
+			if got != tc.want {
+				t.Fatalf("resolvePath(%q) = %q, want %q", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestResolvePathRefusesTraversal asserts every shape of escape is refused rather
+// than normalised. Normalising is the trap: rewriting "..\..\x" into "x" turns a
+// traversal attempt into a successful access somewhere unintended.
+func TestResolvePathRefusesTraversal(t *testing.T) {
+	cases := []string{
+		"..",
+		"\\..",
+		"..\\",
+		"\\..\\",
+		"\\..\\..\\windows\\win.ini",
+		"..\\..\\..\\etc\\passwd",
+		"dir\\..\\..\\file",
+		"\\dir\\..\\..\\..\\secret",
+		// A traversal reached through forward slashes.
+		"../../etc/passwd",
+		"/../secret",
+		"dir/../../file",
+		// Mixed separators.
+		"dir\\../file",
+		"dir/..\\file",
+		// A "." element, which is harmless but is still not the promised form.
+		".",
+		"\\.\\file",
+		"dir\\.\\file",
+		// An empty element, which a doubled separator produces. Refused rather
+		// than collapsed, because collapsing is the normalising this avoids.
+		"\\\\",
+		"dir\\\\file",
+		"dir//file",
+		// "...." is not a traversal on its own, but it ends in a dot, which
+		// Windows strips — so it is refused for that reason.
+		"....\\",
+	}
+	for _, raw := range cases {
+		raw := raw
+		t.Run(raw, func(t *testing.T) {
+			if got, err := resolvePath(raw); err == nil {
+				t.Fatalf("resolvePath(%q) = %q, want a refusal", raw, got)
+			}
+		})
+	}
+}
+
+// TestResolvePathRefusesAbsoluteAndDeviceForms asserts a path that names something
+// outside the share by construction is refused.
+func TestResolvePathRefusesAbsoluteAndDeviceForms(t *testing.T) {
+	cases := []string{
+		// Drive letters.
+		"C:\\windows",
+		"C:",
+		"\\C:\\windows",
+		"dir\\C:\\file",
+		// The NT device and long-path prefixes.
+		"\\\\?\\C:\\windows",
+		"\\??\\C:\\windows",
+		"\\\\.\\PhysicalDrive0",
+		// A UNC path, which names another host entirely.
+		"\\\\server\\share\\file",
+		// An alternate data stream, which names something other than the file's
+		// contents.
+		"file.txt:hidden",
+		"file.txt:$DATA",
+		"dir\\file.txt:stream:$DATA",
+	}
+	for _, raw := range cases {
+		raw := raw
+		t.Run(raw, func(t *testing.T) {
+			if got, err := resolvePath(raw); err == nil {
+				t.Fatalf("resolvePath(%q) = %q, want a refusal", raw, got)
+			}
+		})
+	}
+}
+
+// TestResolvePathRefusesReservedDeviceNames asserts a DOS device name is refused
+// at any level and with any extension, because Windows resolves it to the device
+// rather than to a file however it is dressed up.
+func TestResolvePathRefusesReservedDeviceNames(t *testing.T) {
+	cases := []string{
+		"CON", "PRN", "AUX", "NUL",
+		"COM1", "COM9", "LPT1", "LPT9",
+		// Case does not matter.
+		"con", "NuL", "Com1",
+		// Nor does an extension: "NUL.txt" still resolves to the device.
+		"NUL.txt", "CON.log",
+		// Nor does depth.
+		"dir\\NUL", "dir\\sub\\CON.txt",
+	}
+	for _, raw := range cases {
+		raw := raw
+		t.Run(raw, func(t *testing.T) {
+			if got, err := resolvePath(raw); err == nil {
+				t.Fatalf("resolvePath(%q) = %q, want a refusal", raw, got)
+			}
+		})
+	}
+}
+
+// TestResolvePathRefusesControlBytesAndBadEncoding asserts a path that could be
+// truncated or misread downstream is refused. A NUL matters most: a consumer
+// written in a language where a string ends at the first zero would see a
+// different path from the one that was checked.
+func TestResolvePathRefusesControlBytesAndBadEncoding(t *testing.T) {
+	cases := map[string]string{
+		"embedded NUL":             "file\x00.txt",
+		"NUL after a traversal":    "..\x00\\file",
+		"trailing NUL":             "file.txt\x00",
+		"newline":                  "file\n.txt",
+		"carriage return":          "file\r.txt",
+		"tab":                      "file\t.txt",
+		"escape":                   "file\x1b.txt",
+		"invalid UTF-8":            "file\xff\xfe.txt",
+		"truncated UTF-8 sequence": "file\xc3",
+	}
+	for name, raw := range cases {
+		raw := raw
+		t.Run(name, func(t *testing.T) {
+			if got, err := resolvePath(raw); err == nil {
+				t.Fatalf("resolvePath(%q) = %q, want a refusal", raw, got)
+			}
+		})
+	}
+}
+
+// TestResolvePathRefusesTrailingDotsAndSpaces asserts a name Windows would strip
+// down to a different name is refused. Without this, "secret.txt." and
+// "secret.txt" would name one file while looking like two to anything comparing
+// names.
+func TestResolvePathRefusesTrailingDotsAndSpaces(t *testing.T) {
+	cases := []string{
+		"file.txt.",
+		"file.txt ",
+		"file.txt...",
+		"dir.\\file.txt",
+		"dir \\file.txt",
+		"dir\\file.txt.",
+	}
+	for _, raw := range cases {
+		raw := raw
+		t.Run(raw, func(t *testing.T) {
+			if got, err := resolvePath(raw); err == nil {
+				t.Fatalf("resolvePath(%q) = %q, want a refusal", raw, got)
+			}
+		})
+	}
+}
+
+// TestResolvePathEnforcesLengthBounds asserts the bounds hold, so a path cannot
+// become work by being enormous.
+func TestResolvePathEnforcesLengthBounds(t *testing.T) {
+	// A single element at the limit is fine; one byte over is not.
+	atLimit := strings.Repeat("a", MaxPathComponentLength)
+	if _, err := resolvePath("\\" + atLimit); err != nil {
+		t.Fatalf("a %d-byte element was refused: %v", MaxPathComponentLength, err)
+	}
+	if _, err := resolvePath("\\" + atLimit + "a"); err == nil {
+		t.Fatalf("a %d-byte element was accepted", MaxPathComponentLength+1)
+	}
+
+	// A whole path over the limit is refused whatever its elements look like.
+	long := strings.Repeat("a\\", MaxPathLength)
+	if _, err := resolvePath(long); err == nil {
+		t.Fatal("a path over the length limit was accepted")
+	}
+}
+
+// TestResolvePathIsIdempotent asserts a resolved path resolves to itself. A
+// resolver that changed its answer on a second pass would mean a backend and the
+// server disagreed about what a path named.
+func TestResolvePathIsIdempotent(t *testing.T) {
+	inputs := []string{"", "\\", "\\file.txt", "\\dir\\sub\\file.txt", "dir/file.txt"}
+	for _, raw := range inputs {
+		once, err := resolvePath(raw)
+		if err != nil {
+			t.Fatalf("resolvePath(%q) error = %v", raw, err)
+		}
+		twice, err := resolvePath(once)
+		if err != nil {
+			t.Fatalf("resolvePath(%q) on its own output error = %v", once, err)
+		}
+		if once != twice {
+			t.Fatalf("resolvePath is not idempotent: %q then %q", once, twice)
+		}
+	}
+}
+
+// TestResolvePathNeverEscapes is the property the whole function exists for: no
+// accepted path, from a corpus built to escape, ever produces a result that
+// climbs out of the share.
+func TestResolvePathNeverEscapes(t *testing.T) {
+	// A corpus assembled from the pieces an escape is built out of.
+	pieces := []string{"", "a", ".", "..", "...", "\\", "/", "C:", "?", "*", " ", "NUL", "\x00"}
+
+	checked := 0
+	var walk func(prefix string, depth int)
+	walk = func(prefix string, depth int) {
+		if depth == 0 {
+			resolved, err := resolvePath(prefix)
+			if err != nil {
+				return
+			}
+			checked++
+			// An accepted path must be exactly the promised form.
+			if strings.HasPrefix(resolved, "/") {
+				t.Fatalf("resolvePath(%q) = %q, which is absolute", prefix, resolved)
+			}
+			if strings.Contains(resolved, "\\") {
+				t.Fatalf("resolvePath(%q) = %q, which still contains a backslash", prefix, resolved)
+			}
+			if resolved == "" {
+				return
+			}
+			for _, element := range strings.Split(resolved, "/") {
+				switch element {
+				case "", ".", "..":
+					t.Fatalf("resolvePath(%q) = %q, which contains the element %q", prefix, resolved, element)
+				}
+			}
+			return
+		}
+		for _, piece := range pieces {
+			walk(prefix+piece, depth-1)
+		}
+	}
+	walk("", 3)
+
+	if checked == 0 {
+		t.Fatal("the corpus produced no accepted paths, so the property was never exercised")
+	}
+	t.Logf("checked %d accepted paths out of a %d-combination corpus", checked, len(pieces)*len(pieces)*len(pieces))
+}
+
+// TestResolvePathPattern asserts a wildcard is lifted out of the final element and
+// the rest of the path is still resolved, and that a wildcard cannot smuggle a
+// separator past the element checks.
+func TestResolvePathPattern(t *testing.T) {
+	cases := []struct {
+		raw           string
+		wantDirectory string
+		wantPattern   string
+	}{
+		{"\\*", "", "*"},
+		{"\\*.txt", "", "*.txt"},
+		{"\\dir\\*.txt", "dir", "*.txt"},
+		{"\\dir\\sub\\a?c.*", "dir/sub", "a?c.*"},
+		// No wildcard: the whole thing is a path.
+		{"\\dir\\file.txt", "dir/file.txt", ""},
+		{"\\dir\\", "dir", ""},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.raw, func(t *testing.T) {
+			directory, pattern, err := resolvePathPattern(tc.raw)
+			if err != nil {
+				t.Fatalf("resolvePathPattern(%q) error = %v", tc.raw, err)
+			}
+			if directory != tc.wantDirectory || pattern != tc.wantPattern {
+				t.Fatalf("resolvePathPattern(%q) = (%q, %q), want (%q, %q)",
+					tc.raw, directory, pattern, tc.wantDirectory, tc.wantPattern)
+			}
+		})
+	}
+
+	// The directory part is still subject to every rule above.
+	refused := []string{
+		"\\..\\*",
+		"..\\..\\*.txt",
+		"C:\\*",
+		"\\dir\\..\\*",
+		"\\NUL\\*",
+		"\\dir\\*\\file",  // a wildcard that is not the final element
+		"\\dir\\*:stream", // a stream on the wildcard
+		"\\dir\\*\x00",    // a control byte in the wildcard
+	}
+	for _, raw := range refused {
+		raw := raw
+		t.Run("refused "+raw, func(t *testing.T) {
+			if directory, pattern, err := resolvePathPattern(raw); err == nil {
+				t.Fatalf("resolvePathPattern(%q) = (%q, %q), want a refusal", raw, directory, pattern)
+			}
+		})
+	}
+}
+
+// TestSplitAndJoinPath asserts the two helpers are inverses, including at the
+// share root where the parent is the empty path.
+func TestSplitAndJoinPath(t *testing.T) {
+	cases := []struct {
+		path   string
+		parent string
+		name   string
+	}{
+		{"file.txt", "", "file.txt"},
+		{"dir/file.txt", "dir", "file.txt"},
+		{"dir/sub/file.txt", "dir/sub", "file.txt"},
+	}
+	for _, tc := range cases {
+		parent, name := splitPath(tc.path)
+		if parent != tc.parent || name != tc.name {
+			t.Fatalf("splitPath(%q) = (%q, %q), want (%q, %q)", tc.path, parent, name, tc.parent, tc.name)
+		}
+		if rejoined := joinPath(parent, name); rejoined != tc.path {
+			t.Fatalf("joinPath(%q, %q) = %q, want %q", parent, name, rejoined, tc.path)
+		}
+	}
+}
+
+// TestMatchPattern asserts the wildcard matcher, including the forms a client
+// sends to mean "everything" and a pattern of many stars, which must not become
+// expensive.
+func TestMatchPattern(t *testing.T) {
+	cases := []struct {
+		pattern string
+		name    string
+		matches bool
+	}{
+		{"", "anything.txt", true},
+		{"*", "anything.txt", true},
+		{"*.*", "anything.txt", true},
+		{"*.txt", "file.txt", true},
+		{"*.txt", "file.log", false},
+		{"file.*", "file.txt", true},
+		{"a?c.txt", "abc.txt", true},
+		{"a?c.txt", "ac.txt", false},
+		{"a?c.txt", "abbc.txt", false},
+		{"*file*", "my file here", true},
+		{"*file*", "nothing", false},
+		// Case-insensitive, as the file system commands are.
+		{"*.TXT", "file.txt", true},
+		{"FILE.*", "file.txt", true},
+		// Exact names.
+		{"file.txt", "file.txt", true},
+		{"file.txt", "file.txt.bak", false},
+		// A pattern of many stars must terminate quickly, not blow up.
+		{strings.Repeat("*", 40) + "z", strings.Repeat("a", 200), false},
+		{strings.Repeat("*a", 20), strings.Repeat("a", 200), true},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.pattern+" vs "+tc.name, func(t *testing.T) {
+			if got := matchPattern(tc.pattern, tc.name); got != tc.matches {
+				t.Fatalf("matchPattern(%q, %q) = %t, want %t", tc.pattern, tc.name, got, tc.matches)
+			}
+		})
+	}
+}

--- a/network/smb/smb_v10/server/server.go
+++ b/network/smb/smb_v10/server/server.go
@@ -72,9 +72,12 @@ type Config struct {
 	// demanded. The zero value is SigningDisabled.
 	SigningPolicy SigningPolicy
 
-	// MaxSessionsPerConnection bounds the sessions one connection may establish.
-	// Zero applies DefaultMaxSessionsPerConnection.
+	// MaxSessionsPerConnection, MaxTreesPerConnection and MaxOpensPerConnection
+	// bound what one connection may hold at once, so a client cannot exhaust an
+	// identifier space or the backend's handles. Zero applies the default.
 	MaxSessionsPerConnection int
+	MaxTreesPerConnection    int
+	MaxOpensPerConnection    int
 
 	// Timeout bounds each read on a connection, so a client that opens a socket
 	// and says nothing does not hold a goroutine forever. Zero means no bound.
@@ -102,9 +105,13 @@ const (
 	// rather than a promise of concurrency.
 	DefaultMaxMpxCount uint16 = 50
 
-	// DefaultMaxSessionsPerConnection bounds how many sessions one connection may
-	// establish, so a client cannot exhaust the 16-bit identifier space.
+	// DefaultMaxSessionsPerConnection, DefaultMaxTreesPerConnection and
+	// DefaultMaxOpensPerConnection bound what one connection may hold at once.
+	// The open limit is the largest because a client legitimately holds many
+	// files, and the smallest of the three would be the one that broke first.
 	DefaultMaxSessionsPerConnection = 64
+	DefaultMaxTreesPerConnection    = 64
+	DefaultMaxOpensPerConnection    = 1024
 )
 
 // SigningPolicy selects a server's stance on SMB message signing.
@@ -184,6 +191,7 @@ type Server struct {
 	handlers  []Handler
 	listeners []transport.Listener
 	conns     map[*Connection]struct{}
+	shares    map[string]*Share
 	closed    bool
 
 	// slots bounds concurrent connections when MaxConnections is set. It is nil
@@ -227,8 +235,20 @@ func NewServer(config Config) (*Server, error) {
 	if config.MaxSessionsPerConnection == 0 {
 		config.MaxSessionsPerConnection = DefaultMaxSessionsPerConnection
 	}
-	if config.MaxSessionsPerConnection < 0 {
-		return nil, fmt.Errorf("MaxSessionsPerConnection cannot be negative (got %d)", config.MaxSessionsPerConnection)
+	if config.MaxTreesPerConnection == 0 {
+		config.MaxTreesPerConnection = DefaultMaxTreesPerConnection
+	}
+	if config.MaxOpensPerConnection == 0 {
+		config.MaxOpensPerConnection = DefaultMaxOpensPerConnection
+	}
+	for name, limit := range map[string]int{
+		"MaxSessionsPerConnection": config.MaxSessionsPerConnection,
+		"MaxTreesPerConnection":    config.MaxTreesPerConnection,
+		"MaxOpensPerConnection":    config.MaxOpensPerConnection,
+	} {
+		if limit < 0 {
+			return nil, fmt.Errorf("%s cannot be negative (got %d)", name, limit)
+		}
 	}
 	// A policy that demands signatures cannot be served by a configuration that
 	// can only produce sessions without a key.
@@ -242,6 +262,7 @@ func NewServer(config Config) (*Server, error) {
 	s := &Server{
 		config: config,
 		conns:  make(map[*Connection]struct{}),
+		shares: make(map[string]*Share),
 	}
 	if config.MaxConnections > 0 {
 		s.slots = make(chan struct{}, config.MaxConnections)
@@ -463,6 +484,20 @@ func (s *Server) Close() error {
 
 	s.wg.Wait()
 	return firstErr
+}
+
+// liveConnections returns the connections currently being served. It is for a
+// caller inspecting server state, and for tests asserting that resources were
+// released.
+func (s *Server) liveConnections() []*Connection {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	live := make([]*Connection, 0, len(s.conns))
+	for conn := range s.conns {
+		live = append(live, conn)
+	}
+	return live
 }
 
 // isClosed reports whether Close has been called.

--- a/network/smb/smb_v10/server/session_test.go
+++ b/network/smb/smb_v10/server/session_test.go
@@ -226,7 +226,7 @@ func TestSessionEstablishedWithValidCredential(t *testing.T) {
 
 	// The session is usable: a command that requires one is now dispatched
 	// rather than refused.
-	response := sendOnSession(t, session, codes.SMB_COM_TREE_CONNECT_ANDX, commands.NewTreeConnectAndxRequest())
+	response := sendOnSession(t, session, codes.SMB_COM_TREE_CONNECT_ANDX, commands.NewSeekRequest())
 	if response.Header.Status != uint32(nt_status.NT_STATUS_NOT_IMPLEMENTED) {
 		t.Fatalf("Status = 0x%08X, want NT_STATUS_NOT_IMPLEMENTED on an established session", response.Header.Status)
 	}
@@ -483,9 +483,9 @@ func TestCommandWithoutSessionIsRefused(t *testing.T) {
 	negotiateWithRawClient(t, client)
 
 	// A command that needs a session, on UID 0.
-	request := newRequest(codes.SMB_COM_TREE_CONNECT_ANDX)
+	request := newRequest(codes.SMB_COM_SEEK)
 	request.Header.UID = 0
-	request.AddCommand(commands.NewTreeConnectAndxRequest())
+	request.AddCommand(commands.NewSeekRequest())
 	sendRequest(t, client, request)
 
 	response, _ := receiveResponse(t, client)
@@ -517,7 +517,7 @@ func TestLogoffReleasesTheSession(t *testing.T) {
 	}
 
 	// The UID no longer names a session.
-	after := sendOnSession(t, session, codes.SMB_COM_TREE_CONNECT_ANDX, commands.NewTreeConnectAndxRequest())
+	after := sendOnSession(t, session, codes.SMB_COM_TREE_CONNECT_ANDX, commands.NewSeekRequest())
 	if after.Header.Status != uint32(nt_status.NT_STATUS_SMB_BAD_UID) {
 		t.Fatalf("Status = 0x%08X after logoff, want NT_STATUS_SMB_BAD_UID", after.Header.Status)
 	}

--- a/network/smb/smb_v10/server/share.go
+++ b/network/smb/smb_v10/server/share.go
@@ -1,0 +1,332 @@
+package server
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"time"
+)
+
+// ShareType is the Service string a tree connect reports, describing what kind of
+// resource the tree names ([MS-CIFS] 2.2.4.55.2).
+type ShareType string
+
+const (
+	// ShareTypeDisk is a file-system share.
+	ShareTypeDisk ShareType = "A:"
+	// ShareTypeNamedPipe is the IPC$ share, over which named pipes are reached.
+	ShareTypeNamedPipe ShareType = "IPC"
+	// ShareTypePrinter is a print queue.
+	ShareTypePrinter ShareType = "LPT1:"
+	// ShareTypeAny matches any type, which a client may send to mean "whatever
+	// this name is".
+	ShareTypeAny ShareType = "?????"
+)
+
+// Share is a named resource a client can connect a tree to.
+type Share struct {
+	// Name is the share name, matched case-insensitively as Windows does.
+	Name string
+
+	// Type is what the share is. A disk share requires FS to be set.
+	Type ShareType
+
+	// Comment is the description a share enumeration would report.
+	Comment string
+
+	// ReadOnly refuses every modifying operation on the share, whatever access
+	// the client asked for. It is enforced in the handlers rather than left to
+	// the backend, so a backend cannot forget it.
+	ReadOnly bool
+
+	// FS is the storage behind a disk share.
+	FS FileSystem
+}
+
+// OpenFlags describe what an open is for. They are the subset of the client's
+// requested access and options that a backend needs in order to open the file:
+// share modes and the finer access bits are enforced above the backend.
+type OpenFlags struct {
+	// Read and Write are the access the open needs.
+	Read  bool
+	Write bool
+
+	// Create allows the open to create the file if it does not exist, and
+	// CreateNew requires that it did not exist.
+	Create    bool
+	CreateNew bool
+
+	// Truncate empties an existing file on open.
+	Truncate bool
+
+	// Directory requires the target to be a directory, and NonDirectory requires
+	// that it is not. Both set is a contradiction and is refused above.
+	Directory    bool
+	NonDirectory bool
+}
+
+// FileAttr describes a file or directory.
+type FileAttr struct {
+	// Name is the entry's own name, without any path.
+	Name string
+
+	// IsDir reports whether the entry is a directory.
+	IsDir bool
+
+	// Size is the length in bytes, and AllocationSize the space reserved for it.
+	// A backend that does not distinguish the two reports the same value twice.
+	Size           int64
+	AllocationSize int64
+
+	// ReadOnly reports that the entry cannot be modified.
+	ReadOnly bool
+
+	// Created, Accessed, Modified and Changed are the four timestamps SMB
+	// carries. A backend without a distinct value for one repeats another.
+	Created  time.Time
+	Accessed time.Time
+	Modified time.Time
+	Changed  time.Time
+}
+
+// AttrMask selects which fields of a FileAttr a SetAttr call applies, so that
+// setting one timestamp does not overwrite the others with zeroes.
+type AttrMask struct {
+	Size     bool
+	ReadOnly bool
+	Created  bool
+	Accessed bool
+	Modified bool
+	Changed  bool
+}
+
+// DirEntry is one entry of a directory listing.
+type DirEntry struct {
+	Attr FileAttr
+}
+
+// VolumeInfo describes the storage behind a share.
+type VolumeInfo struct {
+	// Label and FileSystemName are reported to a client that asks about the
+	// volume.
+	Label          string
+	FileSystemName string
+
+	// SerialNumber identifies the volume.
+	SerialNumber uint32
+
+	// TotalBytes and FreeBytes describe capacity. A backend that does not know
+	// reports zero for both.
+	TotalBytes int64
+	FreeBytes  int64
+
+	// SectorsPerAllocationUnit and BytesPerSector describe the allocation
+	// geometry a client uses to turn sizes into cluster counts.
+	SectorsPerAllocationUnit uint32
+	BytesPerSector           uint32
+}
+
+// File is an open file on a FileSystem.
+//
+// Offsets are explicit on every call: SMB carries the offset in the request, so a
+// backend needs no cursor of its own and two opens of the same file cannot
+// interfere through a shared position.
+type File interface {
+	// ReadAt reads into p starting at off. It returns io.EOF only when nothing
+	// could be read; a short read at the end of the file is not an error, because
+	// SMB reports a short read rather than a failure.
+	ReadAt(p []byte, off int64) (int, error)
+
+	// WriteAt writes p at off, extending the file if needed.
+	WriteAt(p []byte, off int64) (int, error)
+
+	// Truncate sets the file's length.
+	Truncate(size int64) error
+
+	// Sync commits any buffered contents.
+	Sync() error
+
+	// Stat describes the open file.
+	Stat() (FileAttr, error)
+
+	// Close releases the handle.
+	Close() error
+}
+
+// FileSystem is the storage behind a disk share.
+//
+// Every path reaching a FileSystem has already been resolved by the server:
+// forward-slash separated, relative to the share root, with no empty, "." or ".."
+// element, and never absolute. A backend does not have to defend against
+// traversal, and MUST NOT try to interpret a path as anything other than that
+// form — the containment guarantee lives in one place so it can be reviewed in
+// one place.
+//
+// A backend reports failure with the sentinel errors below where they apply, so
+// the server can map an outcome to the right protocol status.
+type FileSystem interface {
+	// Open opens or creates a file according to flags.
+	Open(path string, flags OpenFlags) (File, error)
+
+	// Stat describes a path without opening it.
+	Stat(path string) (FileAttr, error)
+
+	// SetAttr applies the fields of attr that mask selects.
+	SetAttr(path string, attr FileAttr, mask AttrMask) error
+
+	// Remove deletes a file. It refuses a directory, which Rmdir handles.
+	Remove(path string) error
+
+	// Rename moves a file or directory. When replace is false it fails if the
+	// destination exists.
+	Rename(oldPath, newPath string, replace bool) error
+
+	// Mkdir creates a directory. Its parent must exist.
+	Mkdir(path string) error
+
+	// Rmdir removes an empty directory.
+	Rmdir(path string) error
+
+	// ReadDir lists the entries of a directory whose names match pattern, which
+	// may contain the SMB wildcards "*" and "?". An empty pattern matches
+	// everything.
+	ReadDir(path, pattern string) ([]DirEntry, error)
+
+	// VolumeInfo describes the storage.
+	VolumeInfo() (VolumeInfo, error)
+}
+
+// Sentinel errors a FileSystem returns so the server can answer with the right
+// protocol status. A backend may wrap them.
+var (
+	// ErrNotFound reports that the path does not exist.
+	ErrNotFound = fmt.Errorf("no such file or directory")
+
+	// ErrExists reports that the path already exists where it must not.
+	ErrExists = fmt.Errorf("file or directory already exists")
+
+	// ErrNotDirectory reports that a path element that had to be a directory is
+	// not one, or that a directory operation was asked of a file.
+	ErrNotDirectory = fmt.Errorf("not a directory")
+
+	// ErrIsDirectory reports that a file operation was asked of a directory.
+	ErrIsDirectory = fmt.Errorf("is a directory")
+
+	// ErrNotEmpty reports that a directory being removed still has entries.
+	ErrNotEmpty = fmt.Errorf("directory not empty")
+
+	// ErrAccessDenied reports that the operation is not permitted.
+	ErrAccessDenied = fmt.Errorf("access denied")
+
+	// ErrReadOnly reports that the share or the entry refuses modification.
+	ErrReadOnly = fmt.Errorf("read-only")
+)
+
+// AddShare registers a share on the server. Share names are matched
+// case-insensitively, so two that differ only in case collide.
+//
+// Parameters:
+//   - share: the share to serve
+//
+// Returns:
+//   - An error if the share is not usable or its name is already taken
+func (s *Server) AddShare(share *Share) error {
+	if share == nil {
+		return fmt.Errorf("cannot add a nil share")
+	}
+	if share.Name == "" {
+		return fmt.Errorf("a share must have a name")
+	}
+	if strings.ContainsAny(share.Name, `\/:*?"<>|`) {
+		return fmt.Errorf("share name %q contains a character a share name cannot carry", share.Name)
+	}
+	if share.Type == "" {
+		share.Type = ShareTypeDisk
+	}
+	if share.Type == ShareTypeDisk && share.FS == nil {
+		return fmt.Errorf("disk share %q has no file system", share.Name)
+	}
+
+	key := strings.ToUpper(share.Name)
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	if s.shares == nil {
+		s.shares = make(map[string]*Share)
+	}
+	if _, taken := s.shares[key]; taken {
+		return fmt.Errorf("a share named %q is already registered", share.Name)
+	}
+	s.shares[key] = share
+	return nil
+}
+
+// Share returns the share a name refers to, or nil when none does.
+func (s *Server) Share(name string) *Share {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+	return s.shares[strings.ToUpper(name)]
+}
+
+// Shares returns the registered shares.
+func (s *Server) Shares() []*Share {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	registered := make([]*Share, 0, len(s.shares))
+	for _, share := range s.shares {
+		registered = append(registered, share)
+	}
+	return registered
+}
+
+// matchPattern reports whether a name matches an SMB wildcard pattern, where "*"
+// stands for any run of characters and "?" for exactly one. Matching is
+// case-insensitive, as the file system commands are.
+//
+// An empty pattern, and the "*" and "*.*" forms a client sends to mean
+// "everything", match every name.
+func matchPattern(pattern, name string) bool {
+	if pattern == "" || pattern == "*" || pattern == "*.*" {
+		return true
+	}
+	return wildcardMatch(strings.ToUpper(pattern), strings.ToUpper(name))
+}
+
+// wildcardMatch matches a pattern against a name, both already folded to one
+// case. It walks the two with a backtrack point for the most recent "*", which
+// matches without recursion and cannot be made to blow up by a pattern full of
+// stars.
+func wildcardMatch(pattern, name string) bool {
+	patternIndex, nameIndex := 0, 0
+	starPattern, starName := -1, 0
+
+	for nameIndex < len(name) {
+		switch {
+		case patternIndex < len(pattern) && (pattern[patternIndex] == '?' || pattern[patternIndex] == name[nameIndex]):
+			patternIndex++
+			nameIndex++
+		case patternIndex < len(pattern) && pattern[patternIndex] == '*':
+			starPattern = patternIndex
+			starName = nameIndex
+			patternIndex++
+		case starPattern >= 0:
+			// Backtrack: let the last star swallow one more character.
+			patternIndex = starPattern + 1
+			starName++
+			nameIndex = starName
+		default:
+			return false
+		}
+	}
+
+	// Any remaining pattern must be stars.
+	for patternIndex < len(pattern) && pattern[patternIndex] == '*' {
+		patternIndex++
+	}
+	return patternIndex == len(pattern)
+}
+
+// errEOF is returned by a backend read that reached the end of the file. It is
+// separate from the sentinels above because it is not a failure.
+var errEOF = io.EOF

--- a/network/smb/smb_v10/server/tree.go
+++ b/network/smb/smb_v10/server/tree.go
@@ -1,0 +1,181 @@
+package server
+
+import (
+	"strings"
+	"time"
+)
+
+// Tree is a connection to a share, established by a tree connect and named by a
+// TID on every subsequent request.
+type Tree struct {
+	// TID is the identifier the client sends to act on this tree.
+	TID uint16
+
+	// Share is what the tree is connected to.
+	Share *Share
+
+	// Session is the session the tree belongs to. A tree is scoped to the session
+	// that opened it, so another session's TID cannot be borrowed.
+	SessionUID uint16
+
+	// Created is when the tree was connected.
+	Created time.Time
+}
+
+// Open is a file handle, established by a create or open and named by a FID.
+type Open struct {
+	// FID is the identifier the client sends to act on this handle.
+	FID uint16
+
+	// Tree is the tree the handle was opened on, and Path the share-relative path
+	// it names.
+	Tree *Tree
+	Path string
+
+	// File is the backend handle. It is nil for a handle onto a directory that
+	// the backend declined to open, which is legitimate: a directory handle is
+	// only ever used to query.
+	File File
+
+	// IsDirectory records what the handle names.
+	IsDirectory bool
+
+	// Readable and Writable are the access the open was granted, enforced on
+	// every use so a handle opened for reading cannot later be written through.
+	Readable bool
+	Writable bool
+
+	// DeleteOnClose removes the file when the handle closes, which is how a
+	// client deletes something it holds open.
+	DeleteOnClose bool
+
+	// Created is when the handle was opened.
+	Created time.Time
+}
+
+// Tree returns the tree a TID names on this connection, or nil when it names
+// none.
+func (c *Connection) Tree(tid uint16) *Tree {
+	return c.trees[tid]
+}
+
+// Open returns the handle a FID names on this connection, or nil when it names
+// none.
+func (c *Connection) Open(fid uint16) *Open {
+	return c.opens[fid]
+}
+
+// addTree records a connected tree.
+func (c *Connection) addTree(tree *Tree) {
+	c.trees[tree.TID] = tree
+}
+
+// removeTree drops a tree, closes every handle opened on it, and releases its
+// identifier.
+//
+// Closing the handles matters: a client that disconnects a tree without closing
+// its files expects them released, and a handle left behind would hold the
+// backend's resources with nothing able to reach it.
+func (c *Connection) removeTree(tid uint16) *Tree {
+	tree, ok := c.trees[tid]
+	if !ok {
+		return nil
+	}
+
+	for fid, open := range c.opens {
+		if open.Tree == tree {
+			c.closeOpen(fid)
+		}
+	}
+
+	delete(c.trees, tid)
+	c.tids.Release(tid)
+	return tree
+}
+
+// addOpen records an open handle.
+func (c *Connection) addOpen(open *Open) {
+	c.opens[open.FID] = open
+}
+
+// closeOpen closes a handle, applies a pending delete-on-close, and releases the
+// identifier.
+//
+// Returns:
+//   - The error from closing the backend handle or from the pending delete, or
+//     nil
+func (c *Connection) closeOpen(fid uint16) error {
+	open, ok := c.opens[fid]
+	if !ok {
+		return nil
+	}
+	delete(c.opens, fid)
+	c.fids.Release(fid)
+
+	var firstErr error
+	if open.File != nil {
+		if err := open.File.Close(); err != nil {
+			firstErr = err
+		}
+	}
+
+	if open.DeleteOnClose && open.Tree != nil && open.Tree.Share.FS != nil {
+		var err error
+		if open.IsDirectory {
+			err = open.Tree.Share.FS.Rmdir(open.Path)
+		} else {
+			err = open.Tree.Share.FS.Remove(open.Path)
+		}
+		if err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+
+	return firstErr
+}
+
+// closeSessionResources drops every tree, and with it every handle, belonging to
+// a session. A logoff releases what the session held rather than leaving it
+// reachable through a UID that no longer names anything.
+func (c *Connection) closeSessionResources(uid uint16) {
+	for tid, tree := range c.trees {
+		if tree.SessionUID == uid {
+			c.removeTree(tid)
+		}
+	}
+}
+
+// shareNameFromPath extracts the share name from the UNC path a tree connect
+// carries.
+//
+// The path is "\\server\share", and the server component is ignored: a client
+// reaches this server by connecting to it, so the name it used to get here says
+// nothing about which share it wants.
+//
+// Parameters:
+//   - path: the UNC path from the request
+//
+// Returns:
+//   - The share name, or "" when the path is not a UNC path
+func shareNameFromPath(path string) string {
+	normalised := strings.ReplaceAll(path, "/", "\\")
+	normalised = strings.TrimRight(normalised, "\x00")
+
+	if !strings.HasPrefix(normalised, "\\\\") {
+		return ""
+	}
+	rest := normalised[2:]
+
+	// Skip the server component.
+	slash := strings.IndexByte(rest, '\\')
+	if slash < 0 {
+		return ""
+	}
+	share := rest[slash+1:]
+
+	// A share name is one element; anything after it is not part of the name.
+	if slash := strings.IndexByte(share, '\\'); slash >= 0 {
+		share = share[:slash]
+	}
+	return strings.TrimRight(share, "\x00")
+}


### PR DESCRIPTION
### Summary

Commit 9 of 12 for #1068 — the one **L**-effort phase, and the point where the server stops being purely protocol. **Stacked on #1076.** 3,901 lines across 20 files.

A client can now open a file on a share, write to it, read it back, and manage what is there.

### Changes

- **`Share` and `FileSystem`** are the storage abstraction. `LocalFileSystem` serves a host directory; `MemoryFileSystem` serves storage that never touches disk — what the tests use, and what a share meant to *look* real without being real would use. Offsets are explicit on every `File` call, because SMB carries the offset in the request: a backend needs no cursor, and two opens of one file cannot interfere through a shared position.
- **`ReadOnly` shares** refuse every modifying command whatever access the client asked for, enforced in the handlers rather than left to the backend so a backend cannot forget it.
- **Tree and open tables**, each with its own allocator, bounded per connection. A tree belongs to the session that opened it and a handle to the tree it was opened on, **both checked on every use**, so one client's identifier cannot be borrowed through another's. Disconnecting a tree closes what was opened on it; a logoff releases the trees.
- **Handlers** for tree connect/disconnect, `NT_CREATE_ANDX`, close, read, write, flush, delete, rename, and the directory create/remove/check commands. Access granted at open time governs every later use.

### The containment boundary

`resolvePath` **refuses rather than normalises**. A path containing `..` is rejected outright instead of rewritten, because rewriting turns a traversal attempt into a successful access somewhere unintended.

**Its adversarial tests found two real gaps while I was writing them:**

- `"\\"` resolved to the share root — the trims that strip a leading and trailing separator collapsed the doubled one, which is exactly the normalising the function exists to avoid.
- A wildcard in the *middle* of a path passed as a literal element name, which would have reached a backend that might expand it there.

Both fixed. A property test then walks a corpus built from the pieces an escape is made of (`..`, `/`, `C:`, `NUL`, `\x00`, …) and asserts no accepted path is ever absolute, ever keeps a backslash, or ever contains an empty, `.` or `..` element.

**`LocalFileSystem` adds a second, independent check**, because path validation cannot see a symlink *inside* the share pointing out of it — `public/link/secret` is perfectly well formed. Every resolved host path is compared against the share root again after the host has followed its links. A test plants both a file link and a directory link out of a share and asserts neither is reachable by stat, open or remove.

### Two defects fixed in this commit's own new code

- **A silent truncation.** The string decoder stopped at the first NUL, so a client asking for `file.txt\0.png` would have been given `file.txt`. Only a trailing terminator is trimmed now, leaving an embedded NUL for `resolvePath` to refuse — two consumers disagreeing about where a string ends is resolved by *rejecting* the string, not by picking one of the answers.
- **Unicode is per-request, not per-connection.** They differ in practice: this repository's client negotiates Unicode and then sends its tree connect and file commands in OEM, so taking the connection's setting decodes a path as garbage. That cost a round of debugging on the tree connect (`BAD_NETWORK_NAME` on every connect) before the same fix went in throughout.

One thing I checked and deliberately did **not** "fix": an embedded NUL is absent from the end-to-end traversal list because the field carrying a path is NUL-terminated, so `SMB_STRING.Unmarshal` stops at the first one and the server never sees the remainder. Opening `inside.txt` *is* the correct reading of that wire message. The resolver is still tested against an embedded NUL directly, for the field formats that can carry one.

### Testing

`go build ./...`, `go vet ./...` and `go test ./...` green. `FuzzServerFrame` ran **8.5M executions clean** over the new handlers.

The conformance table gains eleven rows, and the client-API row that recorded tree connect as *refused* now records it working — which is exactly what that table is for.

End-to-end through the merged client: create-write-read-close on **both** backends; offsets, short reads and a write past the end; the directory commands; deletion including wildcards and its refusal to take a directory with them; rename refusing to overwrite; the read-only share; handle scoping and per-handle access; tree disconnect releasing handles; and a traversal sweep asserting every path-taking command refuses every shape of escape.

### Scope

Deliberately not in this commit, and answered `STATUS_NOT_IMPLEMENTED`: directory enumeration (the TRANSACTION2 FIND subcommands — commit 10), the query/set information commands, byte-range locking, seek, the legacy `SMB_COM_OPEN_ANDX`, and batched AndX chains beyond their first command. A client can open and read a file **by name** but cannot yet list a directory. The package doc says so.