### PR TITLE
Enumerate directories and serve the information levels (Refs #1068)

### DIFF
--- a/network/smb/smb_v10/server/conformance_test.go
+++ b/network/smb/smb_v10/server/conformance_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/codes"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header/flags2"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/subcommands"
 	"github.com/TheManticoreProject/Manticore/network/tcp"
 	"github.com/TheManticoreProject/Manticore/windows/credentials"
 	"github.com/TheManticoreProject/Manticore/windows/nt_status"
@@ -133,6 +134,39 @@ var servedCommands = map[codes.CommandCode]string{
 	codes.SMB_COM_CREATE_DIRECTORY: "creates a directory",
 	codes.SMB_COM_DELETE_DIRECTORY: "removes an empty directory",
 	codes.SMB_COM_CHECK_DIRECTORY:  "reports whether a path is a directory",
+
+	codes.SMB_COM_TRANSACTION2:           "carries the find and information subcommands",
+	codes.SMB_COM_TRANSACTION2_SECONDARY: "continues a fragmented transaction",
+	codes.SMB_COM_FIND_CLOSE2:            "releases a search handle",
+}
+
+// servedTrans2Subcommands are the TRANSACTION2 subcommands the server answers.
+// The same discipline as servedCommands: a subcommand gaining a handler has to
+// gain a row, and the cross-check below fails if the two drift.
+var servedTrans2Subcommands = map[subcommands.Transaction2Subcommand]string{
+	subcommands.TRANS2_FIND_FIRST2:            "opens a directory enumeration",
+	subcommands.TRANS2_FIND_NEXT2:             "continues one",
+	subcommands.TRANS2_QUERY_PATH_INFORMATION: "describes a path",
+	subcommands.TRANS2_QUERY_FILE_INFORMATION: "describes an open handle",
+	subcommands.TRANS2_SET_PATH_INFORMATION:   "changes a path",
+	subcommands.TRANS2_SET_FILE_INFORMATION:   "changes an open handle",
+	subcommands.TRANS2_QUERY_FS_INFORMATION:   "describes the volume",
+}
+
+// TestConformanceServedTrans2SubcommandsAreServed asserts the subcommand table and
+// the handler table agree, in both directions.
+func TestConformanceServedTrans2SubcommandsAreServed(t *testing.T) {
+	for subcommand := range servedTrans2Subcommands {
+		if _, ok := trans2Handlers[subcommand]; !ok {
+			t.Errorf("TRANSACTION2 subcommand 0x%04X is listed as served but has no handler", uint16(subcommand))
+		}
+	}
+	for subcommand := range trans2Handlers {
+		if _, ok := servedTrans2Subcommands[subcommand]; !ok {
+			t.Errorf("TRANSACTION2 subcommand 0x%04X has a handler but is not listed; add it with a note on what it does",
+				uint16(subcommand))
+		}
+	}
 }
 
 // TestConformanceServedCommandsAreServed asserts every command in the served set
@@ -264,6 +298,16 @@ func TestConformanceClientAPI(t *testing.T) {
 			t.Run("TreeConnect to an unserved share", func(t *testing.T) {
 				if err := client.TreeConnect("nosuchshare"); err == nil {
 					t.Fatal("TreeConnect() succeeded for a share that is not served")
+				}
+			})
+
+			t.Run("ListDirectory", func(t *testing.T) {
+				// No share is registered on the conformance server, so a listing
+				// has nowhere to run: what is asserted is that it is refused
+				// rather than crashing, since the file-service tests cover the
+				// working path against a share.
+				if _, err := client.ListEntries("\\*"); err == nil {
+					t.Fatal("ListEntries() succeeded with no tree connected")
 				}
 			})
 

--- a/network/smb/smb_v10/server/connection.go
+++ b/network/smb/smb_v10/server/connection.go
@@ -87,6 +87,17 @@ type Connection struct {
 	// goroutine owns the connection.
 	currentRequestFrame []byte
 
+	// trans2 is the TRANSACTION2 being received across several messages, or nil
+	// when none is. One at a time: a client completes a transaction before
+	// starting another, and holding several would let it pin memory by opening
+	// many and finishing none.
+	trans2 *trans2Reassembly
+
+	// searches are the directory enumerations in progress, by search identifier,
+	// and sids allocates those identifiers.
+	searches map[uint16]*Search
+	sids     *identifierAllocator
+
 	// pendingAuth holds the authentication exchanges part-way through, keyed by
 	// the UID assigned when the challenge was issued.
 	//
@@ -109,6 +120,8 @@ func newConnection(srv *Server, t transport.Transport, remote net.Addr) *Connect
 		tids:        newIdentifierAllocator(srv.config.MaxTreesPerConnection),
 		opens:       make(map[uint16]*Open),
 		fids:        newIdentifierAllocator(srv.config.MaxOpensPerConnection),
+		searches:    make(map[uint16]*Search),
+		sids:        newIdentifierAllocator(srv.config.MaxSearchesPerConnection),
 		pendingAuth: make(map[uint16]*spnego.AcceptContext),
 	}
 }

--- a/network/smb/smb_v10/server/dispatch.go
+++ b/network/smb/smb_v10/server/dispatch.go
@@ -49,6 +49,12 @@ var dispatchTable = map[codes.CommandCode]commandHandler{
 	codes.SMB_COM_CREATE_DIRECTORY: handleCreateDirectory,
 	codes.SMB_COM_DELETE_DIRECTORY: handleDeleteDirectory,
 	codes.SMB_COM_CHECK_DIRECTORY:  handleCheckDirectory,
+
+	// Transactions, which carry the directory-enumeration and information
+	// subcommands.
+	codes.SMB_COM_TRANSACTION2:           handleTransaction2,
+	codes.SMB_COM_TRANSACTION2_SECONDARY: handleTransaction2Secondary,
+	codes.SMB_COM_FIND_CLOSE2:            handleFindClose2,
 }
 
 // sessionlessCommands are the commands a client may send before it holds a

--- a/network/smb/smb_v10/server/doc.go
+++ b/network/smb/smb_v10/server/doc.go
@@ -31,13 +31,14 @@
 //   - Tree connect and disconnect against a registered share.
 //   - File service: open and create, read, write, close, flush, delete, rename,
 //     and the directory create, remove and check commands.
+//   - Directory enumeration and the information levels, over TRANSACTION2:
+//     FIND_FIRST2 and FIND_NEXT2 with search handles, the query and set levels
+//     for a path and for an open handle, and the volume levels. Requests and
+//     responses both fragment across as many messages as they need.
 //
-// Not yet implemented, and answered with STATUS_NOT_IMPLEMENTED: directory
-// enumeration (the TRANSACTION2 FIND subcommands), the query and set information
-// commands, byte-range locking, seek, the legacy SMB_COM_OPEN_ANDX, the
-// NT_TRANSACT subcommands, named pipes, and batched AndX chains beyond their
-// first command. A client can open and read a file by name but cannot yet list a
-// directory or ask about a file without opening it.
+// Not yet implemented, and answered with STATUS_NOT_IMPLEMENTED: byte-range
+// locking, seek, the legacy SMB_COM_OPEN_ANDX, the NT_TRANSACT subcommands,
+// named pipes, and batched AndX chains beyond their first command.
 //
 // # Shares
 //

--- a/network/smb/smb_v10/server/fuzz_test.go
+++ b/network/smb/smb_v10/server/fuzz_test.go
@@ -86,6 +86,26 @@ func FuzzServerFrame(f *testing.F) {
 		flags2.Flags2(flags2.FLAGS2_SECURITY_SIGNATURE),
 		[]byte{0x01, 0x01, 0x00, 0x00, 0x00}))
 
+	// A TRANSACTION2 whose declared totals exceed what it carries, which is what
+	// the reassembly arithmetic has to refuse rather than allocate for, and a
+	// secondary message with no transaction in progress.
+	f.Add(rawFrame(codes.SMB_COM_TRANSACTION2, flags.Flags(0),
+		flags2.Flags2(flags2.FLAGS2_NT_STATUS_ERROR_CODES),
+		append([]byte{0x0F}, make([]byte, 15*2+2)...)))
+	f.Add(rawFrame(codes.SMB_COM_TRANSACTION2_SECONDARY, flags.Flags(0),
+		flags2.Flags2(flags2.FLAGS2_NT_STATUS_ERROR_CODES),
+		append([]byte{0x09}, make([]byte, 9*2+2)...)))
+
+	// The file commands, each carrying a client-controlled length or offset.
+	for _, command := range []codes.CommandCode{
+		codes.SMB_COM_NT_CREATE_ANDX, codes.SMB_COM_READ_ANDX, codes.SMB_COM_WRITE_ANDX,
+		codes.SMB_COM_TREE_CONNECT_ANDX, codes.SMB_COM_DELETE, codes.SMB_COM_RENAME,
+	} {
+		f.Add(rawFrame(command, flags.Flags(0),
+			flags2.Flags2(flags2.FLAGS2_NT_STATUS_ERROR_CODES),
+			append([]byte{0x0C}, make([]byte, 12*2+2)...)))
+	}
+
 	f.Fuzz(func(t *testing.T, raw []byte) {
 		srv, err := NewServer(Config{})
 		if err != nil {

--- a/network/smb/smb_v10/server/handler_find.go
+++ b/network/smb/smb_v10/server/handler_find.go
@@ -1,0 +1,260 @@
+package server
+
+import (
+	"encoding/binary"
+	"time"
+
+	"github.com/TheManticoreProject/Manticore/logger"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/windows/nt_status"
+)
+
+// Search flags a client sends on a FIND ([MS-CIFS] 2.2.6.2.1).
+const (
+	// findClose closes the search once this response is sent.
+	findClose = 0x0001
+	// findCloseIfEndOfSearch closes it when the enumeration finishes.
+	findCloseIfEndOfSearch = 0x0002
+	// findContinueFromLast resumes from the server's own cursor rather than from
+	// a resume key the client supplies.
+	findContinueFromLast = 0x0008
+)
+
+// Search is a directory enumeration in progress.
+//
+// The whole listing is taken once, when the search opens, and then handed out in
+// batches. Re-reading the directory on each continuation would be worse than it
+// sounds: entries appearing or vanishing between batches would make the cursor
+// mean something different each time, so a client could see an entry twice or miss
+// one entirely. A snapshot is stale but coherent, which is the trade a client
+// enumerating a directory expects.
+type Search struct {
+	// SID is the identifier the client sends to continue the search.
+	SID uint16
+
+	// Tree is the tree the search runs on, and Directory the resolved directory
+	// being listed.
+	Tree      *Tree
+	Directory string
+
+	// Pattern is what names are matched against.
+	Pattern string
+
+	// InformationLevel is the shape the entries are returned in, fixed when the
+	// search opens: a continuation that asked for a different one would be
+	// describing a different enumeration.
+	InformationLevel uint16
+
+	// Entries is the snapshot, and Position how far through it the client has
+	// been taken.
+	Entries  []DirEntry
+	Position int
+
+	Created time.Time
+}
+
+// exhausted reports whether every entry has been handed out.
+func (s *Search) exhausted() bool {
+	return s.Position >= len(s.Entries)
+}
+
+// Search returns the enumeration a SID names, or nil when it names none.
+func (c *Connection) Search(sid uint16) *Search {
+	return c.searches[sid]
+}
+
+// closeSearch drops an enumeration and releases its identifier.
+func (c *Connection) closeSearch(sid uint16) bool {
+	if _, ok := c.searches[sid]; !ok {
+		return false
+	}
+	delete(c.searches, sid)
+	c.sids.Release(sid)
+	return true
+}
+
+// handleFindFirst2 answers TRANS2_FIND_FIRST2: it opens an enumeration and returns
+// its first batch.
+//
+// Request parameters: SearchAttributes(2) SearchCount(2) Flags(2)
+// InformationLevel(2) SearchStorageType(4) FileName(variable).
+func handleFindFirst2(conn *Connection, req *message.Message, reassembly *trans2Reassembly) ([]byte, []byte, nt_status.NT_STATUS) {
+	parameters := reassembly.parameters
+	if len(parameters) < 12 {
+		return nil, nil, nt_status.NT_STATUS_INVALID_PARAMETER
+	}
+
+	tree, status := conn.treeFor(req)
+	if status != nt_status.NT_STATUS_SUCCESS {
+		return nil, nil, status
+	}
+
+	searchCount := int(binary.LittleEndian.Uint16(parameters[2:4]))
+	flags := binary.LittleEndian.Uint16(parameters[4:6])
+	informationLevel := binary.LittleEndian.Uint16(parameters[6:8])
+	requested := trimTerminator(string(parameters[12:]))
+
+	if !supportedFindLevel(informationLevel) {
+		logger.Debugf("SMB1 server: %s asked for find information level 0x%04X, which is not served",
+			conn.Remote, informationLevel)
+		return nil, nil, nt_status.NT_STATUS_INVALID_INFO_CLASS
+	}
+
+	directory, pattern, err := resolvePathPattern(requested)
+	if err != nil {
+		logger.Debugf("SMB1 server: %s asked to enumerate %q, which is refused: %v", conn.Remote, requested, err)
+		return nil, nil, nt_status.NT_STATUS_OBJECT_PATH_SYNTAX_BAD
+	}
+
+	entries, err := tree.Share.FS.ReadDir(directory, pattern)
+	if err != nil {
+		return nil, nil, statusForFSError(err)
+	}
+
+	// "." and ".." are what a client expects at the head of a listing, and some
+	// clients rely on them to recognise a directory. They are synthesised rather
+	// than expected from a backend, since a backend has no reason to invent them.
+	entries = append(dotEntries(tree, directory), entries...)
+
+	sid, err := conn.sids.Allocate()
+	if err != nil {
+		logger.Warnf("SMB1 server: refusing a search from %s: %v", conn.Remote, err)
+		return nil, nil, nt_status.NT_STATUS_OS2_NO_MORE_SIDS
+	}
+
+	search := &Search{
+		SID:              sid,
+		Tree:             tree,
+		Directory:        directory,
+		Pattern:          pattern,
+		InformationLevel: informationLevel,
+		Entries:          entries,
+		Created:          time.Now().UTC(),
+	}
+
+	data, returned := encodeFindEntries(search, searchCount, reassembly.maxDataCount)
+	endOfSearch := search.exhausted()
+
+	// The search is kept only while there is more to hand out, and only if the
+	// client did not ask for it to be closed.
+	keep := !endOfSearch && flags&findClose == 0
+	if endOfSearch && flags&findCloseIfEndOfSearch != 0 {
+		keep = false
+	}
+	if keep {
+		conn.searches[sid] = search
+	} else {
+		conn.sids.Release(sid)
+	}
+
+	logger.Debugf("SMB1 server: %s enumerated %q on %q: %d entries, end=%t, sid=0x%04X",
+		conn.Remote, directory, tree.Share.Name, returned, endOfSearch, sid)
+
+	// Response parameters: SID(2) SearchCount(2) EndOfSearch(2) EaErrorOffset(2)
+	// LastNameOffset(2).
+	responseParameters := make([]byte, 10)
+	binary.LittleEndian.PutUint16(responseParameters[0:2], sid)
+	binary.LittleEndian.PutUint16(responseParameters[2:4], uint16(returned))
+	binary.LittleEndian.PutUint16(responseParameters[4:6], boolToUint16(endOfSearch))
+
+	return responseParameters, data, nt_status.NT_STATUS_SUCCESS
+}
+
+// handleFindNext2 answers TRANS2_FIND_NEXT2: it hands out the next batch of an
+// enumeration already open.
+//
+// Request parameters: SID(2) SearchCount(2) InformationLevel(2) ResumeKey(4)
+// Flags(2) FileName(variable).
+func handleFindNext2(conn *Connection, req *message.Message, reassembly *trans2Reassembly) ([]byte, []byte, nt_status.NT_STATUS) {
+	parameters := reassembly.parameters
+	if len(parameters) < 12 {
+		return nil, nil, nt_status.NT_STATUS_INVALID_PARAMETER
+	}
+
+	sid := binary.LittleEndian.Uint16(parameters[0:2])
+	searchCount := int(binary.LittleEndian.Uint16(parameters[2:4]))
+	informationLevel := binary.LittleEndian.Uint16(parameters[4:6])
+	flags := binary.LittleEndian.Uint16(parameters[10:12])
+
+	search := conn.Search(sid)
+	if search == nil {
+		logger.Debugf("SMB1 server: %s continued search 0x%04X, which is not open", conn.Remote, sid)
+		return nil, nil, nt_status.NT_STATUS_INVALID_HANDLE
+	}
+	// The search belongs to the tree it was opened on.
+	if search.Tree.TID != uint16(req.Header.TID) {
+		return nil, nil, nt_status.NT_STATUS_INVALID_HANDLE
+	}
+	// A continuation that changed the shape would be describing a different
+	// enumeration, so it is refused rather than quietly honoured.
+	if informationLevel != search.InformationLevel {
+		logger.Debugf("SMB1 server: %s continued search 0x%04X at level 0x%04X, opened at 0x%04X",
+			conn.Remote, sid, informationLevel, search.InformationLevel)
+		return nil, nil, nt_status.NT_STATUS_INVALID_INFO_CLASS
+	}
+
+	data, returned := encodeFindEntries(search, searchCount, reassembly.maxDataCount)
+	endOfSearch := search.exhausted()
+
+	if flags&findClose != 0 || (endOfSearch && flags&findCloseIfEndOfSearch != 0) {
+		conn.closeSearch(sid)
+	}
+
+	// Response parameters: SearchCount(2) EndOfSearch(2) EaErrorOffset(2)
+	// LastNameOffset(2). No SID: the client already has it.
+	responseParameters := make([]byte, 8)
+	binary.LittleEndian.PutUint16(responseParameters[0:2], uint16(returned))
+	binary.LittleEndian.PutUint16(responseParameters[2:4], boolToUint16(endOfSearch))
+
+	return responseParameters, data, nt_status.NT_STATUS_SUCCESS
+}
+
+// handleFindClose2 answers SMB_COM_FIND_CLOSE2: it releases a search handle.
+func handleFindClose2(conn *Connection, w ResponseWriter, req *message.Message) nt_status.NT_STATUS {
+	request, ok := req.Command.(*commands.FindClose2Request)
+	if !ok {
+		return nt_status.NT_STATUS_INVALID_SMB
+	}
+
+	if !conn.closeSearch(uint16(request.SearchHandle)) {
+		return nt_status.NT_STATUS_INVALID_HANDLE
+	}
+
+	return conn.answer(w, commands.NewFindClose2Response())
+}
+
+// dotEntries synthesises the "." and ".." entries at the head of a listing. ".."
+// is omitted at the share root, where there is no parent within the share to
+// name.
+func dotEntries(tree *Tree, directory string) []DirEntry {
+	self, err := tree.Share.FS.Stat(directory)
+	if err != nil {
+		// A directory that cannot be described still lists; the timestamps are
+		// the only thing lost.
+		self = FileAttr{IsDir: true}
+	}
+
+	self.Name = "."
+	entries := []DirEntry{{Attr: self}}
+
+	if directory == "" {
+		return entries
+	}
+
+	parent, _ := splitPath(directory)
+	up, err := tree.Share.FS.Stat(parent)
+	if err != nil {
+		up = FileAttr{IsDir: true}
+	}
+	up.Name = ".."
+	return append(entries, DirEntry{Attr: up})
+}
+
+// boolToUint16 renders a flag as the 16-bit value the wire carries.
+func boolToUint16(value bool) uint16 {
+	if value {
+		return 1
+	}
+	return 0
+}

--- a/network/smb/smb_v10/server/handler_info.go
+++ b/network/smb/smb_v10/server/handler_info.go
@@ -1,0 +1,194 @@
+package server
+
+import (
+	"encoding/binary"
+
+	"github.com/TheManticoreProject/Manticore/logger"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message"
+	"github.com/TheManticoreProject/Manticore/windows/nt_status"
+)
+
+// handleQueryPathInformation answers TRANS2_QUERY_PATH_INFORMATION: it describes a
+// path without opening it, which is how a client inspects a file it does not
+// intend to read.
+//
+// Request parameters: InformationLevel(2) Reserved(4) FileName(variable).
+func handleQueryPathInformation(conn *Connection, req *message.Message, reassembly *trans2Reassembly) ([]byte, []byte, nt_status.NT_STATUS) {
+	parameters := reassembly.parameters
+	if len(parameters) < 6 {
+		return nil, nil, nt_status.NT_STATUS_INVALID_PARAMETER
+	}
+
+	tree, status := conn.treeFor(req)
+	if status != nt_status.NT_STATUS_SUCCESS {
+		return nil, nil, status
+	}
+
+	level := binary.LittleEndian.Uint16(parameters[0:2])
+	requested := trimTerminator(string(parameters[6:]))
+
+	path, err := resolvePath(requested)
+	if err != nil {
+		logger.Debugf("SMB1 server: %s asked about %q, which is refused: %v", conn.Remote, requested, err)
+		return nil, nil, nt_status.NT_STATUS_OBJECT_PATH_SYNTAX_BAD
+	}
+
+	attr, err := tree.Share.FS.Stat(path)
+	if err != nil {
+		return nil, nil, statusForFSError(err)
+	}
+
+	data, served := encodeFileInformation(level, attr, path)
+	if !served {
+		logger.Debugf("SMB1 server: %s asked for file information level 0x%04X, which is not served",
+			conn.Remote, level)
+		return nil, nil, nt_status.NT_STATUS_INVALID_INFO_CLASS
+	}
+
+	// The response parameters carry an EaErrorOffset, which is zero when no
+	// extended attribute was involved.
+	return make([]byte, 2), data, nt_status.NT_STATUS_SUCCESS
+}
+
+// handleQueryFileInformation answers TRANS2_QUERY_FILE_INFORMATION: the same, for
+// a path a client already holds open.
+//
+// Request parameters: FID(2) InformationLevel(2).
+func handleQueryFileInformation(conn *Connection, req *message.Message, reassembly *trans2Reassembly) ([]byte, []byte, nt_status.NT_STATUS) {
+	parameters := reassembly.parameters
+	if len(parameters) < 4 {
+		return nil, nil, nt_status.NT_STATUS_INVALID_PARAMETER
+	}
+
+	fid := binary.LittleEndian.Uint16(parameters[0:2])
+	level := binary.LittleEndian.Uint16(parameters[2:4])
+
+	open, status := conn.openFor(req, fid)
+	if status != nt_status.NT_STATUS_SUCCESS {
+		return nil, nil, status
+	}
+
+	// Asking the handle rather than the path: the two can differ if the file was
+	// renamed underneath, and the handle is what the client is talking about.
+	attr, err := open.File.Stat()
+	if err != nil {
+		return nil, nil, statusForFSError(err)
+	}
+
+	data, served := encodeFileInformation(level, attr, open.Path)
+	if !served {
+		return nil, nil, nt_status.NT_STATUS_INVALID_INFO_CLASS
+	}
+
+	return make([]byte, 2), data, nt_status.NT_STATUS_SUCCESS
+}
+
+// handleSetPathInformation answers TRANS2_SET_PATH_INFORMATION.
+//
+// Request parameters: InformationLevel(2) Reserved(4) FileName(variable).
+func handleSetPathInformation(conn *Connection, req *message.Message, reassembly *trans2Reassembly) ([]byte, []byte, nt_status.NT_STATUS) {
+	parameters := reassembly.parameters
+	if len(parameters) < 6 {
+		return nil, nil, nt_status.NT_STATUS_INVALID_PARAMETER
+	}
+
+	tree, status := conn.writableTreeFor(req)
+	if status != nt_status.NT_STATUS_SUCCESS {
+		return nil, nil, status
+	}
+
+	level := binary.LittleEndian.Uint16(parameters[0:2])
+	requested := trimTerminator(string(parameters[6:]))
+
+	path, err := resolvePath(requested)
+	if err != nil {
+		return nil, nil, nt_status.NT_STATUS_OBJECT_PATH_SYNTAX_BAD
+	}
+	if path == "" {
+		return nil, nil, nt_status.NT_STATUS_ACCESS_DENIED
+	}
+
+	// A path-based set has no handle, so the levels that are properties of a
+	// handle rather than of a file cannot be applied through it.
+	served, err := applyFileInformation(tree.Share.FS, path, level, reassembly.data, nil)
+	if !served {
+		return nil, nil, nt_status.NT_STATUS_INVALID_INFO_CLASS
+	}
+	if err != nil {
+		return nil, nil, statusForFSError(err)
+	}
+
+	return make([]byte, 2), nil, nt_status.NT_STATUS_SUCCESS
+}
+
+// handleSetFileInformation answers TRANS2_SET_FILE_INFORMATION.
+//
+// Request parameters: FID(2) InformationLevel(2) Reserved(2).
+func handleSetFileInformation(conn *Connection, req *message.Message, reassembly *trans2Reassembly) ([]byte, []byte, nt_status.NT_STATUS) {
+	parameters := reassembly.parameters
+	if len(parameters) < 4 {
+		return nil, nil, nt_status.NT_STATUS_INVALID_PARAMETER
+	}
+
+	fid := binary.LittleEndian.Uint16(parameters[0:2])
+	level := binary.LittleEndian.Uint16(parameters[2:4])
+
+	open, status := conn.openFor(req, fid)
+	if status != nt_status.NT_STATUS_SUCCESS {
+		return nil, nil, status
+	}
+	if open.Tree.Share.ReadOnly {
+		return nil, nil, nt_status.NT_STATUS_MEDIA_WRITE_PROTECTED
+	}
+	if !open.Writable {
+		return nil, nil, nt_status.NT_STATUS_ACCESS_DENIED
+	}
+
+	served, err := applyFileInformation(open.Tree.Share.FS, open.Path, level, reassembly.data, open)
+	if !served {
+		return nil, nil, nt_status.NT_STATUS_INVALID_INFO_CLASS
+	}
+	if err != nil {
+		return nil, nil, statusForFSError(err)
+	}
+
+	return make([]byte, 2), nil, nt_status.NT_STATUS_SUCCESS
+}
+
+// handleQueryFsInformation answers TRANS2_QUERY_FS_INFORMATION: it describes the
+// volume behind the share.
+//
+// Request parameters: InformationLevel(2).
+func handleQueryFsInformation(conn *Connection, req *message.Message, reassembly *trans2Reassembly) ([]byte, []byte, nt_status.NT_STATUS) {
+	parameters := reassembly.parameters
+	if len(parameters) < 2 {
+		return nil, nil, nt_status.NT_STATUS_INVALID_PARAMETER
+	}
+
+	tree, status := conn.treeFor(req)
+	if status != nt_status.NT_STATUS_SUCCESS {
+		return nil, nil, status
+	}
+
+	level := binary.LittleEndian.Uint16(parameters[0:2])
+
+	volume, err := tree.Share.FS.VolumeInfo()
+	if err != nil {
+		return nil, nil, statusForFSError(err)
+	}
+	// A share reports its own name as the label when the backend has none, which
+	// is what a client displays.
+	if volume.Label == "" {
+		volume.Label = tree.Share.Name
+	}
+
+	data, served := encodeVolumeInformation(level, volume)
+	if !served {
+		logger.Debugf("SMB1 server: %s asked for volume information level 0x%04X, which is not served",
+			conn.Remote, level)
+		return nil, nil, nt_status.NT_STATUS_INVALID_INFO_CLASS
+	}
+
+	// A volume query returns no response parameters.
+	return nil, data, nt_status.NT_STATUS_SUCCESS
+}

--- a/network/smb/smb_v10/server/handler_trans2.go
+++ b/network/smb/smb_v10/server/handler_trans2.go
@@ -1,0 +1,331 @@
+package server
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/TheManticoreProject/Manticore/logger"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/subcommands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+	"github.com/TheManticoreProject/Manticore/windows/nt_status"
+)
+
+// TRANSACTION2 carries a subcommand whose parameter and data blocks may be larger
+// than one SMB message. Both directions therefore fragment: a request arrives as a
+// primary message and then as many secondary messages as it needs, and a response
+// goes back the same way.
+//
+// The two halves are separate problems. Reassembly has to tolerate fragments
+// arriving with displacements it did not choose, and must not let a client claim a
+// total it never sends. Fragmentation has to fit each response inside what the
+// client said it could receive. What they share is the offset arithmetic, which is
+// the part that is easy to get wrong and impossible to get away with: a client
+// reads the blocks at the offsets the response declares.
+
+const (
+	// trans2ResponseWordCount is the fixed word count of a TRANSACTION2 response
+	// carrying no setup words, which none of the subcommands here return.
+	trans2ResponseWordCount = 10
+
+	// maxTrans2Payload bounds a reassembled request. The totals are 16-bit, so a
+	// client cannot legitimately exceed this, and refusing beyond it keeps a
+	// claimed total from becoming an allocation.
+	maxTrans2Payload = 0xFFFF
+
+	// trans2ReassemblyTimeout bounds how long a half-delivered transaction is
+	// held. A client that starts one and stops would otherwise pin the memory for
+	// as long as the connection lasts.
+	trans2ReassemblyTimeout = 30 * time.Second
+)
+
+// trans2Reassembly is a transaction being received across several messages.
+type trans2Reassembly struct {
+	subcommand uint16
+
+	// parameters and data are the blocks being filled in, sized to the totals the
+	// primary message declared.
+	parameters []byte
+	data       []byte
+
+	// parametersSeen and dataSeen count the bytes placed so far, so completion is
+	// known without scanning for gaps.
+	parametersSeen int
+	dataSeen       int
+
+	// maxParameterCount and maxDataCount are what the client said it can receive
+	// back, which bounds the response.
+	maxParameterCount int
+	maxDataCount      int
+
+	started time.Time
+}
+
+// complete reports whether every declared byte has arrived.
+func (r *trans2Reassembly) complete() bool {
+	return r.parametersSeen >= len(r.parameters) && r.dataSeen >= len(r.data)
+}
+
+// place copies a fragment into the blocks at its declared displacement.
+//
+// A displacement or length that would write outside the declared total is refused
+// rather than clamped: it means the client's own arithmetic disagrees with itself,
+// and guessing which half to believe would let a fragment land somewhere it was
+// not meant to.
+func (r *trans2Reassembly) place(
+	parameters []byte, parameterDisplacement int,
+	data []byte, dataDisplacement int,
+) error {
+	if err := placeFragment(r.parameters, parameters, parameterDisplacement, "parameter"); err != nil {
+		return err
+	}
+	if err := placeFragment(r.data, data, dataDisplacement, "data"); err != nil {
+		return err
+	}
+	r.parametersSeen += len(parameters)
+	r.dataSeen += len(data)
+	return nil
+}
+
+// placeFragment copies a run into a block at a displacement, refusing anything
+// that would fall outside it.
+func placeFragment(block, run []byte, displacement int, what string) error {
+	if len(run) == 0 {
+		return nil
+	}
+	if displacement < 0 || displacement > len(block) {
+		return fmt.Errorf("%s displacement %d is outside the declared %d-byte block", what, displacement, len(block))
+	}
+	if displacement+len(run) > len(block) {
+		return fmt.Errorf("%s fragment of %d bytes at displacement %d overruns the declared %d-byte block",
+			what, len(run), displacement, len(block))
+	}
+	copy(block[displacement:], run)
+	return nil
+}
+
+// handleTransaction2 answers SMB_COM_TRANSACTION2: the primary message of a
+// transaction.
+func handleTransaction2(conn *Connection, w ResponseWriter, req *message.Message) nt_status.NT_STATUS {
+	request, ok := req.Command.(*commands.Transaction2Request)
+	if !ok {
+		return nt_status.NT_STATUS_INVALID_SMB
+	}
+
+	if len(request.Setup) < 1 {
+		logger.Debugf("SMB1 server: %s sent a TRANSACTION2 with no subcommand", conn.Remote)
+		return nt_status.NT_STATUS_INVALID_PARAMETER
+	}
+	subcommand := uint16(request.Setup[0])
+
+	totalParameters := int(request.TotalParameterCount)
+	totalData := int(request.TotalDataCount)
+	if totalParameters > maxTrans2Payload || totalData > maxTrans2Payload {
+		return nt_status.NT_STATUS_INVALID_PARAMETER
+	}
+
+	reassembly := &trans2Reassembly{
+		subcommand:        subcommand,
+		parameters:        make([]byte, totalParameters),
+		data:              make([]byte, totalData),
+		maxParameterCount: int(request.MaxParameterCount),
+		maxDataCount:      int(request.MaxDataCount),
+		started:           time.Now(),
+	}
+
+	// The primary message carries no displacement fields: it is by definition the
+	// first fragment, so both blocks start at zero.
+	if err := reassembly.place(
+		[]byte(request.Trans2_Parameters), 0,
+		[]byte(request.Trans2_Data), 0,
+	); err != nil {
+		logger.Debugf("SMB1 server: %s sent an inconsistent TRANSACTION2: %v", conn.Remote, err)
+		return nt_status.NT_STATUS_INVALID_PARAMETER
+	}
+
+	// The common case is a transaction that fits in one message.
+	if reassembly.complete() {
+		return conn.runTransaction2(w, req, reassembly)
+	}
+
+	// More is coming. Only one transaction is tracked at a time: [MS-CIFS] has a
+	// client complete one before starting another, and holding several would let a
+	// client pin memory by opening many and finishing none.
+	conn.trans2 = reassembly
+	logger.Debugf("SMB1 server: %s began a fragmented TRANSACTION2 (subcommand 0x%04X, %d+%d bytes)",
+		conn.Remote, subcommand, totalParameters, totalData)
+
+	// A primary message that does not complete the transaction gets no response:
+	// the client sends the rest before expecting one.
+	return nt_status.NT_STATUS_SUCCESS
+}
+
+// handleTransaction2Secondary answers SMB_COM_TRANSACTION2_SECONDARY: a
+// continuation of a transaction already begun.
+func handleTransaction2Secondary(conn *Connection, w ResponseWriter, req *message.Message) nt_status.NT_STATUS {
+	request, ok := req.Command.(*commands.Transaction2SecondaryRequest)
+	if !ok {
+		return nt_status.NT_STATUS_INVALID_SMB
+	}
+
+	reassembly := conn.trans2
+	if reassembly == nil {
+		logger.Debugf("SMB1 server: %s sent a TRANSACTION2_SECONDARY with no transaction in progress", conn.Remote)
+		return nt_status.NT_STATUS_INVALID_SMB
+	}
+	if time.Since(reassembly.started) > trans2ReassemblyTimeout {
+		conn.trans2 = nil
+		logger.Debugf("SMB1 server: %s continued a TRANSACTION2 that had timed out", conn.Remote)
+		return nt_status.NT_STATUS_IO_TIMEOUT
+	}
+
+	if err := reassembly.place(
+		[]byte(request.Trans2_Parameters), int(request.ParameterDisplacement),
+		[]byte(request.Trans2_Data), int(request.DataDisplacement),
+	); err != nil {
+		conn.trans2 = nil
+		logger.Debugf("SMB1 server: %s sent an inconsistent TRANSACTION2_SECONDARY: %v", conn.Remote, err)
+		return nt_status.NT_STATUS_INVALID_PARAMETER
+	}
+
+	if !reassembly.complete() {
+		return nt_status.NT_STATUS_SUCCESS
+	}
+
+	conn.trans2 = nil
+	return conn.runTransaction2(w, req, reassembly)
+}
+
+// runTransaction2 dispatches a fully assembled transaction to its subcommand and
+// sends the result back, fragmenting the response if it does not fit.
+func (c *Connection) runTransaction2(w ResponseWriter, req *message.Message, reassembly *trans2Reassembly) nt_status.NT_STATUS {
+	handler, ok := trans2Handlers[subcommands.Transaction2Subcommand(reassembly.subcommand)]
+	if !ok {
+		logger.Debugf("SMB1 server: %s sent unimplemented TRANSACTION2 subcommand 0x%04X",
+			c.Remote, reassembly.subcommand)
+		return nt_status.NT_STATUS_NOT_IMPLEMENTED
+	}
+
+	parameters, data, status := handler(c, req, reassembly)
+	if status != nt_status.NT_STATUS_SUCCESS {
+		return status
+	}
+
+	if err := c.sendTransaction2Response(w, reassembly, parameters, data); err != nil {
+		logger.Debugf("SMB1 server: failed to answer the transaction for %s: %v", c.Remote, err)
+	}
+	return nt_status.NT_STATUS_SUCCESS
+}
+
+// trans2Handler answers one TRANSACTION2 subcommand, returning the parameter and
+// data blocks to send back.
+type trans2Handler func(*Connection, *message.Message, *trans2Reassembly) (parameters, data []byte, status nt_status.NT_STATUS)
+
+// trans2Handlers maps a subcommand to its handler. A subcommand with no entry is
+// answered with STATUS_NOT_IMPLEMENTED, which for the DFS and OS/2-era
+// subcommands is the permanent answer rather than a placeholder.
+var trans2Handlers = map[subcommands.Transaction2Subcommand]trans2Handler{
+	subcommands.TRANS2_FIND_FIRST2:            handleFindFirst2,
+	subcommands.TRANS2_FIND_NEXT2:             handleFindNext2,
+	subcommands.TRANS2_QUERY_PATH_INFORMATION: handleQueryPathInformation,
+	subcommands.TRANS2_QUERY_FILE_INFORMATION: handleQueryFileInformation,
+	subcommands.TRANS2_SET_PATH_INFORMATION:   handleSetPathInformation,
+	subcommands.TRANS2_SET_FILE_INFORMATION:   handleSetFileInformation,
+	subcommands.TRANS2_QUERY_FS_INFORMATION:   handleQueryFsInformation,
+}
+
+// sendTransaction2Response sends a transaction result, splitting it across as many
+// messages as it needs.
+//
+// Each message declares the running totals and its own displacement, so the client
+// can place the fragments however they arrive. The offsets are absolute from the
+// start of the SMB header, which is what the client reads them as.
+func (c *Connection) sendTransaction2Response(
+	w ResponseWriter,
+	reassembly *trans2Reassembly,
+	parameters, data []byte,
+) error {
+	// What the client said it can receive bounds each message, and so does the
+	// buffer the connection negotiated: a response larger than either could not be
+	// read at the far end.
+	budget := int(c.Server.config.MaxBufferSize) - trans2ResponseOverhead
+	if budget <= 0 {
+		return fmt.Errorf("the negotiated buffer of %d bytes leaves no room for a transaction response",
+			c.Server.config.MaxBufferSize)
+	}
+	if reassembly.maxDataCount > 0 && reassembly.maxDataCount < budget {
+		budget = reassembly.maxDataCount
+	}
+
+	// Parameters go first and are not split away from their transaction: every
+	// subcommand here returns a handful of bytes, so a parameter block that did
+	// not fit would mean the buffer is too small to talk at all.
+	if len(parameters) > budget {
+		return fmt.Errorf("the response parameters are %d bytes, over the %d-byte budget", len(parameters), budget)
+	}
+
+	sentData := 0
+	for first := true; first || sentData < len(data); first = false {
+		chunkBudget := budget
+		parameterChunk := []byte{}
+		if first {
+			parameterChunk = parameters
+			chunkBudget -= len(parameters)
+		}
+
+		remaining := len(data) - sentData
+		chunk := remaining
+		if chunk > chunkBudget {
+			chunk = chunkBudget
+		}
+		if chunk < 0 {
+			chunk = 0
+		}
+
+		response := commands.NewTransaction2Response()
+		response.TotalParameterCount = types.USHORT(len(parameters))
+		response.TotalDataCount = types.USHORT(len(data))
+		response.SetupCount = types.UCHAR(0)
+		response.Setup = []types.USHORT{}
+
+		response.ParameterCount = types.USHORT(len(parameterChunk))
+		response.ParameterDisplacement = types.USHORT(0)
+		response.DataCount = types.USHORT(chunk)
+		response.DataDisplacement = types.USHORT(sentData)
+
+		// The offsets: the parameter block starts after the fixed part, padded to
+		// a 4-byte boundary, and the data block after the parameters, padded
+		// again.
+		preParameters := header.SMB_HEADER_SIZE + 1 + 2*trans2ResponseWordCount + 2
+		pad1 := (4 - (preParameters % 4)) % 4
+		parameterOffset := preParameters + pad1
+		response.Pad1 = make([]types.UCHAR, pad1)
+		response.ParameterOffset = types.USHORT(parameterOffset)
+		response.Trans2_Parameters = []types.UCHAR(parameterChunk)
+
+		afterParameters := parameterOffset + len(parameterChunk)
+		pad2 := (4 - (afterParameters % 4)) % 4
+		response.Pad2 = make([]types.UCHAR, pad2)
+		response.DataOffset = types.USHORT(afterParameters + pad2)
+		response.Trans2_Data = []types.UCHAR(data[sentData : sentData+chunk])
+
+		if err := w.WriteResponse(response); err != nil {
+			return err
+		}
+
+		sentData += chunk
+		// A response with nothing left to send is finished, even if the loop
+		// condition would run again on a zero-length chunk.
+		if chunk == 0 && !first {
+			break
+		}
+	}
+
+	return nil
+}
+
+// trans2ResponseOverhead is the space a transaction response needs beyond its
+// blocks: the header, the parameter words, the byte count and the two pads.
+const trans2ResponseOverhead = 96

--- a/network/smb/smb_v10/server/infolevels.go
+++ b/network/smb/smb_v10/server/infolevels.go
@@ -1,0 +1,398 @@
+package server
+
+import (
+	"encoding/binary"
+	"time"
+
+	"github.com/TheManticoreProject/Manticore/windows/fileflags"
+)
+
+// Information levels are the shapes a client can ask for a file, a directory
+// listing or a volume to be described in. Each is a fixed wire layout, so the
+// encoders below build the bytes directly rather than through a struct: what
+// matters is the offsets, and writing them out makes the offsets the thing being
+// reviewed.
+//
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/f0a5ba31-1d84-4bcb-a0f1-6e4f0e3b30f6
+const (
+	// Find information levels.
+	smbFindFileDirectoryInfo     = 0x0101
+	smbFindFileFullDirectoryInfo = 0x0102
+	smbFindFileNamesInfo         = 0x0103
+	smbFindFileBothDirectoryInfo = 0x0104
+
+	// Query file information levels.
+	smbQueryFileBasicInfo    = 0x0101
+	smbQueryFileStandardInfo = 0x0102
+	smbQueryFileEAInfo       = 0x0103
+	smbQueryFileNameInfo     = 0x0104
+	smbQueryFileAllInfo      = 0x0107
+	smbQueryFileAltNameInfo  = 0x0108
+
+	// Set file information levels.
+	smbSetFileBasicInfo       = 0x0101
+	smbSetFileDispositionInfo = 0x0102
+	smbSetFileAllocationInfo  = 0x0103
+	smbSetFileEndOfFileInfo   = 0x0104
+
+	// Query file-system information levels.
+	smbQueryFsVolumeInfo    = 0x0102
+	smbQueryFsSizeInfo      = 0x0103
+	smbQueryFsDeviceInfo    = 0x0104
+	smbQueryFsAttributeInfo = 0x0105
+)
+
+// bothDirectoryInfoFixedSize is the fixed part of an
+// SMB_FIND_FILE_BOTH_DIRECTORY_INFO entry, before its variable-length name.
+const bothDirectoryInfoFixedSize = 94
+
+// filetimeOf renders a time as the 64-bit Windows FILETIME the wire carries. A
+// zero time renders as zero rather than as the year 1601, which is what a client
+// displays for a converted zero.
+func filetimeOf(when time.Time) uint64 {
+	if when.IsZero() {
+		return 0
+	}
+	const unixEpochIn100ns = 116444736000000000
+	return uint64(when.UTC().UnixNano()/100 + unixEpochIn100ns)
+}
+
+// supportedFindLevel reports whether a directory listing can be returned in a
+// level. Refusing an unsupported level is better than returning the nearest one:
+// a client parses what it asked for, so a different shape is read as corruption.
+func supportedFindLevel(level uint16) bool {
+	switch level {
+	case smbFindFileDirectoryInfo, smbFindFileFullDirectoryInfo,
+		smbFindFileNamesInfo, smbFindFileBothDirectoryInfo:
+		return true
+	}
+	return false
+}
+
+// encodeFindEntries takes up to count entries from a search and renders them,
+// stopping early if the next entry would not fit in the client's budget.
+//
+// Stopping short is not a failure: the search keeps its position, and the client
+// asks again. What must not happen is a truncated entry, which a client would
+// parse as a corrupt one.
+//
+// Returns:
+//   - The encoded entries
+//   - How many were encoded, which the response reports as its count
+func encodeFindEntries(search *Search, count, budget int) ([]byte, int) {
+	if count <= 0 {
+		count = len(search.Entries)
+	}
+	if budget <= 0 {
+		budget = maxTrans2Payload
+	}
+
+	encoded := []byte{}
+	returned := 0
+
+	for returned < count && !search.exhausted() {
+		entry := search.Entries[search.Position]
+		rendered := encodeFindEntry(search.InformationLevel, entry.Attr)
+
+		// The entry must fit whole.
+		if len(encoded)+len(rendered) > budget {
+			break
+		}
+
+		encoded = append(encoded, rendered...)
+		search.Position++
+		returned++
+	}
+
+	// The last entry's NextEntryOffset is zero, which is how a client knows to
+	// stop walking the buffer. Patching it afterwards is simpler than knowing in
+	// advance which entry will be last, since the budget decides that.
+	if returned > 0 && search.InformationLevel != smbFindFileNamesInfo {
+		zeroLastNextEntryOffset(encoded, search.InformationLevel)
+	}
+
+	return encoded, returned
+}
+
+// zeroLastNextEntryOffset walks the encoded entries and clears the final
+// NextEntryOffset.
+func zeroLastNextEntryOffset(encoded []byte, level uint16) {
+	position := 0
+	for position+4 <= len(encoded) {
+		next := int(binary.LittleEndian.Uint32(encoded[position : position+4]))
+		if next == 0 || position+next > len(encoded) {
+			// Already terminated, or the walk would leave the buffer.
+			binary.LittleEndian.PutUint32(encoded[position:position+4], 0)
+			return
+		}
+		if position+next == len(encoded) {
+			binary.LittleEndian.PutUint32(encoded[position:position+4], 0)
+			return
+		}
+		position += next
+	}
+}
+
+// encodeFindEntry renders one directory entry in the requested level.
+//
+// Names are written as OEM bytes. That is what this repository's client reads them
+// as, and the FIND request itself carries its pattern in OEM, so the two agree.
+func encodeFindEntry(level uint16, attr FileAttr) []byte {
+	name := []byte(attr.Name)
+
+	switch level {
+	case smbFindFileNamesInfo:
+		// NextEntryOffset(4) FileIndex(4) FileNameLength(4) FileName(variable).
+		entry := make([]byte, 12)
+		binary.LittleEndian.PutUint32(entry[8:12], uint32(len(name)))
+		entry = append(entry, name...)
+		entry = padTo4(entry)
+		binary.LittleEndian.PutUint32(entry[0:4], uint32(len(entry)))
+		return entry
+
+	case smbFindFileDirectoryInfo:
+		// The fixed part is the first 64 bytes of the both-directory layout,
+		// without the EA size or the short name.
+		entry := make([]byte, 64)
+		writeDirectoryInfoCommon(entry, attr, len(name))
+		entry = append(entry, name...)
+		entry = padTo4(entry)
+		binary.LittleEndian.PutUint32(entry[0:4], uint32(len(entry)))
+		return entry
+
+	case smbFindFileFullDirectoryInfo:
+		// As above, plus a 4-byte EA size.
+		entry := make([]byte, 68)
+		writeDirectoryInfoCommon(entry, attr, len(name))
+		entry = append(entry, name...)
+		entry = padTo4(entry)
+		binary.LittleEndian.PutUint32(entry[0:4], uint32(len(entry)))
+		return entry
+
+	default:
+		// SMB_FIND_FILE_BOTH_DIRECTORY_INFO, which is what a Windows client asks
+		// for and what this repository's client parses.
+		entry := make([]byte, bothDirectoryInfoFixedSize)
+		writeDirectoryInfoCommon(entry, attr, len(name))
+		// ShortNameLength(1) at 68, Reserved(1) at 69, ShortName(24) at 70. The
+		// short name is left empty: this server has no 8.3 alias to report, and a
+		// client uses the long name when the short one is absent.
+		entry = append(entry, name...)
+		entry = padTo4(entry)
+		binary.LittleEndian.PutUint32(entry[0:4], uint32(len(entry)))
+		return entry
+	}
+}
+
+// writeDirectoryInfoCommon fills the part every directory-info level shares:
+// NextEntryOffset(4) FileIndex(4) four timestamps(8 each) EndOfFile(8)
+// AllocationSize(8) ExtFileAttributes(4) FileNameLength(4).
+func writeDirectoryInfoCommon(entry []byte, attr FileAttr, nameLength int) {
+	binary.LittleEndian.PutUint64(entry[8:16], filetimeOf(attr.Created))
+	binary.LittleEndian.PutUint64(entry[16:24], filetimeOf(attr.Accessed))
+	binary.LittleEndian.PutUint64(entry[24:32], filetimeOf(attr.Modified))
+	binary.LittleEndian.PutUint64(entry[32:40], filetimeOf(attr.Changed))
+	binary.LittleEndian.PutUint64(entry[40:48], uint64(attr.Size))
+	binary.LittleEndian.PutUint64(entry[48:56], uint64(attr.AllocationSize))
+	binary.LittleEndian.PutUint32(entry[56:60], attributesFor(attr))
+	binary.LittleEndian.PutUint32(entry[60:64], uint32(nameLength))
+}
+
+// padTo4 rounds a buffer up to a 4-byte boundary, which each entry is aligned to
+// so the next one starts aligned.
+func padTo4(buffer []byte) []byte {
+	if remainder := len(buffer) % 4; remainder != 0 {
+		buffer = append(buffer, make([]byte, 4-remainder)...)
+	}
+	return buffer
+}
+
+// encodeFileInformation renders a file in a query level, or reports that the level
+// is not served.
+func encodeFileInformation(level uint16, attr FileAttr, path string) ([]byte, bool) {
+	switch level {
+	case smbQueryFileBasicInfo:
+		// Four timestamps(8 each) ExtFileAttributes(4) Reserved(4).
+		info := make([]byte, 40)
+		binary.LittleEndian.PutUint64(info[0:8], filetimeOf(attr.Created))
+		binary.LittleEndian.PutUint64(info[8:16], filetimeOf(attr.Accessed))
+		binary.LittleEndian.PutUint64(info[16:24], filetimeOf(attr.Modified))
+		binary.LittleEndian.PutUint64(info[24:32], filetimeOf(attr.Changed))
+		binary.LittleEndian.PutUint32(info[32:36], attributesFor(attr))
+		return info, true
+
+	case smbQueryFileStandardInfo:
+		// AllocationSize(8) EndOfFile(8) NumberOfLinks(4) DeletePending(1)
+		// Directory(1) Reserved(2).
+		info := make([]byte, 24)
+		binary.LittleEndian.PutUint64(info[0:8], uint64(attr.AllocationSize))
+		binary.LittleEndian.PutUint64(info[8:16], uint64(attr.Size))
+		binary.LittleEndian.PutUint32(info[16:20], 1)
+		if attr.IsDir {
+			info[21] = 1
+		}
+		return info, true
+
+	case smbQueryFileEAInfo:
+		// EaSize(4). Nothing here carries extended attributes, so it is zero.
+		return make([]byte, 4), true
+
+	case smbQueryFileNameInfo, smbQueryFileAltNameInfo:
+		// FileNameLength(4) FileName(variable).
+		name := []byte(pathForClient(path))
+		info := make([]byte, 4)
+		binary.LittleEndian.PutUint32(info[0:4], uint32(len(name)))
+		return append(info, name...), true
+
+	case smbQueryFileAllInfo:
+		// The basic and standard blocks together, then EaSize and the name.
+		info := make([]byte, 0, 104)
+		basic, _ := encodeFileInformation(smbQueryFileBasicInfo, attr, path)
+		standard, _ := encodeFileInformation(smbQueryFileStandardInfo, attr, path)
+		info = append(info, basic...)
+		info = append(info, standard...)
+		info = append(info, make([]byte, 4)...) // EaSize
+		name := []byte(pathForClient(path))
+		lengthField := make([]byte, 4)
+		binary.LittleEndian.PutUint32(lengthField, uint32(len(name)))
+		info = append(info, lengthField...)
+		return append(info, name...), true
+	}
+
+	return nil, false
+}
+
+// pathForClient renders a resolved path back in the form a client sent it:
+// backslash separated and rooted.
+func pathForClient(path string) string {
+	rendered := "\\"
+	for i := 0; i < len(path); i++ {
+		if path[i] == '/' {
+			rendered += "\\"
+			continue
+		}
+		rendered += string(path[i])
+	}
+	return rendered
+}
+
+// encodeVolumeInformation renders a volume in a query level, or reports that the
+// level is not served.
+func encodeVolumeInformation(level uint16, volume VolumeInfo) ([]byte, bool) {
+	switch level {
+	case smbQueryFsVolumeInfo:
+		// VolumeCreationTime(8) SerialNumber(4) VolumeLabelSize(4) Reserved(2)
+		// VolumeLabel(variable).
+		label := []byte(volume.Label)
+		info := make([]byte, 18)
+		binary.LittleEndian.PutUint32(info[8:12], volume.SerialNumber)
+		binary.LittleEndian.PutUint32(info[12:16], uint32(len(label)))
+		return append(info, label...), true
+
+	case smbQueryFsSizeInfo:
+		// TotalAllocationUnits(8) TotalFreeAllocationUnits(8)
+		// SectorsPerAllocationUnit(4) BytesPerSector(4).
+		unit := int64(volume.SectorsPerAllocationUnit) * int64(volume.BytesPerSector)
+		if unit <= 0 {
+			unit = 4096
+		}
+		info := make([]byte, 24)
+		binary.LittleEndian.PutUint64(info[0:8], uint64(volume.TotalBytes/unit))
+		binary.LittleEndian.PutUint64(info[8:16], uint64(volume.FreeBytes/unit))
+		binary.LittleEndian.PutUint32(info[16:20], volume.SectorsPerAllocationUnit)
+		binary.LittleEndian.PutUint32(info[20:24], volume.BytesPerSector)
+		return info, true
+
+	case smbQueryFsDeviceInfo:
+		// DeviceType(4) DeviceCharacteristics(4). FILE_DEVICE_DISK with no
+		// special characteristics.
+		info := make([]byte, 8)
+		binary.LittleEndian.PutUint32(info[0:4], 0x00000007)
+		return info, true
+
+	case smbQueryFsAttributeInfo:
+		// FileSystemAttributes(4) MaxFileNameLengthInBytes(4)
+		// LengthOfFileSystemName(4) FileSystemName(variable).
+		//
+		// Only case-preserving names are claimed. Claiming a capability the
+		// storage does not have — unicode-on-disk, compression, quotas — is worse
+		// than claiming none, because a client then uses it.
+		name := []byte(volume.FileSystemName)
+		info := make([]byte, 12)
+		binary.LittleEndian.PutUint32(info[0:4], 0x00000002) // FILE_CASE_PRESERVED_NAMES
+		binary.LittleEndian.PutUint32(info[4:8], MaxPathComponentLength)
+		binary.LittleEndian.PutUint32(info[8:12], uint32(len(name)))
+		return append(info, name...), true
+	}
+
+	return nil, false
+}
+
+// applyFileInformation applies a set level to a path, reporting whether the level
+// is served and what the backend made of it.
+func applyFileInformation(fs FileSystem, path string, level uint16, data []byte, open *Open) (bool, error) {
+	switch level {
+	case smbSetFileBasicInfo:
+		if len(data) < 36 {
+			return true, ErrAccessDenied
+		}
+		attr := FileAttr{
+			Created:  timeFromFiletime(binary.LittleEndian.Uint64(data[0:8])),
+			Accessed: timeFromFiletime(binary.LittleEndian.Uint64(data[8:16])),
+			Modified: timeFromFiletime(binary.LittleEndian.Uint64(data[16:24])),
+			Changed:  timeFromFiletime(binary.LittleEndian.Uint64(data[24:32])),
+			ReadOnly: binary.LittleEndian.Uint32(data[32:36])&fileflags.FILE_ATTRIBUTE_READONLY != 0,
+		}
+		// A zero timestamp means "leave this one alone", so the mask selects only
+		// the ones the client actually supplied.
+		mask := AttrMask{
+			ReadOnly: true,
+			Created:  !attr.Created.IsZero(),
+			Accessed: !attr.Accessed.IsZero(),
+			Modified: !attr.Modified.IsZero(),
+			Changed:  !attr.Changed.IsZero(),
+		}
+		return true, fs.SetAttr(path, attr, mask)
+
+	case smbSetFileDispositionInfo:
+		if len(data) < 1 {
+			return true, ErrAccessDenied
+		}
+		// Delete-on-close is a property of the handle, not of the file, so it is
+		// recorded rather than acted on now.
+		if open == nil {
+			return true, ErrAccessDenied
+		}
+		open.DeleteOnClose = data[0] != 0
+		return true, nil
+
+	case smbSetFileEndOfFileInfo, smbSetFileAllocationInfo:
+		if len(data) < 8 {
+			return true, ErrAccessDenied
+		}
+		size := int64(binary.LittleEndian.Uint64(data[0:8]))
+		if size < 0 {
+			return true, ErrAccessDenied
+		}
+		// The allocation level asks for space to be reserved rather than for the
+		// length to change, and nothing here distinguishes the two, so only the
+		// end-of-file level resizes.
+		if level == smbSetFileAllocationInfo {
+			return true, nil
+		}
+		return true, fs.SetAttr(path, FileAttr{Size: size}, AttrMask{Size: true})
+	}
+
+	return false, nil
+}
+
+// timeFromFiletime converts a Windows FILETIME to a time. Zero and the
+// leave-alone sentinel both render as the zero time, which the mask above reads as
+// "not supplied".
+func timeFromFiletime(filetime uint64) time.Time {
+	const unixEpochIn100ns = 116444736000000000
+	if filetime == 0 || filetime == 0xFFFFFFFFFFFFFFFF || filetime < unixEpochIn100ns {
+		return time.Time{}
+	}
+	return time.Unix(0, int64(filetime-unixEpochIn100ns)*100).UTC()
+}

--- a/network/smb/smb_v10/server/server.go
+++ b/network/smb/smb_v10/server/server.go
@@ -78,6 +78,7 @@ type Config struct {
 	MaxSessionsPerConnection int
 	MaxTreesPerConnection    int
 	MaxOpensPerConnection    int
+	MaxSearchesPerConnection int
 
 	// Timeout bounds each read on a connection, so a client that opens a socket
 	// and says nothing does not hold a goroutine forever. Zero means no bound.
@@ -112,6 +113,7 @@ const (
 	DefaultMaxSessionsPerConnection = 64
 	DefaultMaxTreesPerConnection    = 64
 	DefaultMaxOpensPerConnection    = 1024
+	DefaultMaxSearchesPerConnection = 128
 )
 
 // SigningPolicy selects a server's stance on SMB message signing.
@@ -241,10 +243,14 @@ func NewServer(config Config) (*Server, error) {
 	if config.MaxOpensPerConnection == 0 {
 		config.MaxOpensPerConnection = DefaultMaxOpensPerConnection
 	}
+	if config.MaxSearchesPerConnection == 0 {
+		config.MaxSearchesPerConnection = DefaultMaxSearchesPerConnection
+	}
 	for name, limit := range map[string]int{
 		"MaxSessionsPerConnection": config.MaxSessionsPerConnection,
 		"MaxTreesPerConnection":    config.MaxTreesPerConnection,
 		"MaxOpensPerConnection":    config.MaxOpensPerConnection,
+		"MaxSearchesPerConnection": config.MaxSearchesPerConnection,
 	} {
 		if limit < 0 {
 			return nil, fmt.Errorf("%s cannot be negative (got %d)", name, limit)

--- a/network/smb/smb_v10/server/trans2_test.go
+++ b/network/smb/smb_v10/server/trans2_test.go
@@ -1,0 +1,575 @@
+package server
+
+import (
+	"strings"
+	"testing"
+
+	smb1client "github.com/TheManticoreProject/Manticore/network/smb/smb_v10/client"
+	"github.com/TheManticoreProject/Manticore/windows/fileflags"
+)
+
+// namesOf renders a listing's names, so a test asserts on names rather than on
+// whole entries.
+func namesOf(entries []smb1client.Entry) []string {
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		names = append(names, entry.LongName)
+	}
+	return names
+}
+
+// TestDirectoryListing is the milestone this phase exists for: the SMB1 client in
+// this repository lists a directory on the server.
+func TestDirectoryListing(t *testing.T) {
+	fs := NewMemoryFileSystem("FILES")
+	for _, name := range []string{"alpha.txt", "beta.txt", "gamma.log"} {
+		if err := fs.AddFile(name, []byte(name)); err != nil {
+			t.Fatalf("AddFile(%q) error = %v", name, err)
+		}
+	}
+	if err := fs.AddDirectory("subdir"); err != nil {
+		t.Fatalf("AddDirectory() error = %v", err)
+	}
+	_, client := fileServer(t, fs, false)
+
+	entries, err := client.ListDirectory("\\")
+	if err != nil {
+		t.Fatalf("ListDirectory() error = %v", err)
+	}
+
+	names := namesOf(entries)
+	for _, want := range []string{".", "..", "alpha.txt", "beta.txt", "gamma.log", "subdir"} {
+		found := false
+		for _, name := range names {
+			if name == want {
+				found = true
+				break
+			}
+		}
+		// ".." is absent at the share root, which has no parent within the share.
+		if want == ".." {
+			continue
+		}
+		if !found {
+			t.Errorf("the listing is missing %q; it holds %v", want, names)
+		}
+	}
+
+	// The directory is reported as one, and the files are not.
+	for _, entry := range entries {
+		switch entry.LongName {
+		case "subdir", ".":
+			if !entry.IsDirectory {
+				t.Errorf("%q is not reported as a directory", entry.LongName)
+			}
+		case "alpha.txt":
+			if entry.IsDirectory {
+				t.Error("alpha.txt is reported as a directory")
+			}
+			if entry.Size != uint64(len("alpha.txt")) {
+				t.Errorf("alpha.txt is reported as %d bytes, want %d", entry.Size, len("alpha.txt"))
+			}
+		}
+	}
+}
+
+// TestDirectoryListingWithPattern asserts a wildcard filters the listing, and that
+// a pattern matching nothing yields nothing rather than failing.
+func TestDirectoryListingWithPattern(t *testing.T) {
+	fs := NewMemoryFileSystem("FILES")
+	for _, name := range []string{"one.txt", "two.txt", "three.log"} {
+		if err := fs.AddFile(name, []byte("x")); err != nil {
+			t.Fatalf("AddFile(%q) error = %v", name, err)
+		}
+	}
+	_, client := fileServer(t, fs, false)
+
+	entries, err := client.ListEntries("\\*.txt")
+	if err != nil {
+		t.Fatalf("ListEntries() error = %v", err)
+	}
+	names := namesOf(entries)
+
+	// The dot entries are always present; the filter applies to the rest.
+	for _, name := range names {
+		if name == "." || name == ".." {
+			continue
+		}
+		if !strings.HasSuffix(name, ".txt") {
+			t.Errorf("the listing holds %q, which does not match *.txt", name)
+		}
+	}
+	if !containsName(names, "one.txt") || !containsName(names, "two.txt") {
+		t.Errorf("the listing is missing a match: %v", names)
+	}
+	if containsName(names, "three.log") {
+		t.Errorf("the listing holds a non-match: %v", names)
+	}
+
+	// A pattern matching nothing still lists the dot entries and does not fail.
+	entries, err = client.ListEntries("\\*.nothing")
+	if err != nil {
+		t.Fatalf("ListEntries() with a non-matching pattern error = %v", err)
+	}
+	for _, entry := range entries {
+		if entry.LongName != "." && entry.LongName != ".." {
+			t.Errorf("a non-matching pattern returned %q", entry.LongName)
+		}
+	}
+}
+
+// TestDirectoryListingInSubdirectory asserts a listing of something other than the
+// share root works, and that ".." appears there.
+func TestDirectoryListingInSubdirectory(t *testing.T) {
+	fs := NewMemoryFileSystem("FILES")
+	if err := fs.AddFile("dir/nested.txt", []byte("nested")); err != nil {
+		t.Fatalf("AddFile() error = %v", err)
+	}
+	_, client := fileServer(t, fs, false)
+
+	entries, err := client.ListDirectory("\\dir")
+	if err != nil {
+		t.Fatalf("ListDirectory() error = %v", err)
+	}
+	names := namesOf(entries)
+
+	if !containsName(names, "nested.txt") {
+		t.Errorf("the listing is missing nested.txt: %v", names)
+	}
+	// A directory below the root has a parent to name.
+	if !containsName(names, "..") {
+		t.Errorf("the listing of a subdirectory has no %q entry: %v", "..", names)
+	}
+}
+
+// TestDirectoryListingSpansSeveralBatches asserts an enumeration larger than one
+// response is handed out across continuations, and that every entry arrives exactly
+// once.
+//
+// This is what the search state exists for: the client asks again with the handle
+// it was given, and the server picks up where it left off.
+func TestDirectoryListingSpansSeveralBatches(t *testing.T) {
+	fs := NewMemoryFileSystem("FILES")
+
+	// Enough entries, with long enough names, that the listing cannot fit in one
+	// response.
+	const count = 500
+	expected := map[string]bool{}
+	for i := 0; i < count; i++ {
+		name := "a-file-with-a-reasonably-long-name-" + pad4(i) + ".txt"
+		if err := fs.AddFile(name, []byte("x")); err != nil {
+			t.Fatalf("AddFile() error = %v", err)
+		}
+		expected[name] = false
+	}
+
+	_, client := fileServer(t, fs, false)
+
+	entries, err := client.ListDirectory("\\")
+	if err != nil {
+		t.Fatalf("ListDirectory() error = %v", err)
+	}
+
+	// Prove the enumeration actually spanned batches rather than happening to fit.
+	// Each entry is the 94-byte fixed part plus a name of about 45 bytes, so one
+	// response's budget holds on the order of a hundred: a complete listing of 500
+	// cannot have arrived in one.
+	perBatch := (int(DefaultMaxBufferSize) - trans2ResponseOverhead) / (bothDirectoryInfoFixedSize + 48)
+	if len(entries) <= perBatch {
+		t.Fatalf("the listing returned %d entries, which could have fitted in one response of about %d; "+
+			"the continuation path was not exercised", len(entries), perBatch)
+	}
+
+	for _, entry := range entries {
+		if entry.LongName == "." || entry.LongName == ".." {
+			continue
+		}
+		seen, known := expected[entry.LongName]
+		if !known {
+			t.Fatalf("the listing holds %q, which was never created", entry.LongName)
+		}
+		if seen {
+			t.Fatalf("the listing holds %q twice", entry.LongName)
+		}
+		expected[entry.LongName] = true
+	}
+
+	missing := 0
+	for name, seen := range expected {
+		if !seen {
+			if missing < 3 {
+				t.Errorf("the listing is missing %q", name)
+			}
+			missing++
+		}
+	}
+	if missing > 0 {
+		t.Fatalf("%d of %d entries are missing from the listing", missing, count)
+	}
+}
+
+// TestSearchHandleLifecycle asserts a search handle is released, and that a
+// continuation or a close on a handle that is not open is refused.
+func TestSearchHandleLifecycle(t *testing.T) {
+	fs := NewMemoryFileSystem("FILES")
+	for i := 0; i < 200; i++ {
+		if err := fs.AddFile("entry-"+pad4(i)+".txt", []byte("x")); err != nil {
+			t.Fatalf("AddFile() error = %v", err)
+		}
+	}
+	srv, client := fileServer(t, fs, false)
+
+	// A full enumeration opens a handle and closes it on the way out.
+	if _, err := client.ListDirectory("\\"); err != nil {
+		t.Fatalf("ListDirectory() error = %v", err)
+	}
+
+	waitFor(t, func() bool {
+		for _, conn := range srv.liveConnections() {
+			if len(conn.searches) != 0 {
+				return false
+			}
+		}
+		return true
+	}, "the server still holds a search handle after the enumeration finished")
+
+	// Several enumerations in a row do not leak handles either.
+	for i := 0; i < 5; i++ {
+		if _, err := client.ListDirectory("\\"); err != nil {
+			t.Fatalf("ListDirectory() on pass %d error = %v", i, err)
+		}
+	}
+	waitFor(t, func() bool {
+		for _, conn := range srv.liveConnections() {
+			if len(conn.searches) != 0 {
+				return false
+			}
+		}
+		return true
+	}, "the server leaked search handles across repeated enumerations")
+}
+
+// TestQueryPathInformation asserts the path-based query levels, which are how a
+// client inspects a file it does not open.
+func TestQueryPathInformation(t *testing.T) {
+	fs := NewMemoryFileSystem("FILES")
+	contents := []byte("twenty-four characters..")
+	if err := fs.AddFile("described.txt", contents); err != nil {
+		t.Fatalf("AddFile() error = %v", err)
+	}
+	if err := fs.AddDirectory("adir"); err != nil {
+		t.Fatalf("AddDirectory() error = %v", err)
+	}
+	_, client := fileServer(t, fs, false)
+
+	basic, err := client.GetFileBasicInfo("described.txt")
+	if err != nil {
+		t.Fatalf("GetFileBasicInfo() error = %v", err)
+	}
+	if basic.Extfileattributes == 0 {
+		t.Error("the basic information reports no attributes at all")
+	}
+
+	standard, err := client.GetFileStandardInfo("described.txt")
+	if err != nil {
+		t.Fatalf("GetFileStandardInfo() error = %v", err)
+	}
+	if standard.Endoffile.QuadPart != uint64(len(contents)) {
+		t.Errorf("the standard information reports %d bytes, want %d", standard.Endoffile.QuadPart, len(contents))
+	}
+	if standard.Directory != 0 {
+		t.Error("a file is reported as a directory")
+	}
+
+	// A directory is reported as one.
+	directoryInfo, err := client.GetFileStandardInfo("adir")
+	if err != nil {
+		t.Fatalf("GetFileStandardInfo() on a directory error = %v", err)
+	}
+	if directoryInfo.Directory == 0 {
+		t.Error("a directory is not reported as one")
+	}
+
+	// A path that does not exist is refused.
+	if _, err := client.GetFileBasicInfo("missing.txt"); err == nil {
+		t.Error("GetFileBasicInfo() succeeded for a path that does not exist")
+	}
+
+	// A level that is not served is refused rather than answered with the nearest
+	// one, since a client parses what it asked for.
+	if _, err := client.QueryPathInformation("described.txt", 0x0999); err == nil {
+		t.Error("QueryPathInformation() succeeded for an unserved information level")
+	}
+}
+
+// TestQueryFileInformation asserts the handle-based query levels.
+func TestQueryFileInformation(t *testing.T) {
+	fs := NewMemoryFileSystem("FILES")
+	if err := fs.AddFile("open.txt", []byte("0123456789")); err != nil {
+		t.Fatalf("AddFile() error = %v", err)
+	}
+	_, client := fileServer(t, fs, false)
+
+	fid, err := client.OpenFile("open.txt", fileflags.GENERIC_READ, fileflags.FILE_SHARE_READ,
+		fileflags.FILE_OPEN, fileflags.FILE_NON_DIRECTORY_FILE)
+	if err != nil {
+		t.Fatalf("OpenFile() error = %v", err)
+	}
+	defer client.CloseFile(fid)
+
+	data, err := client.QueryFileInformation(fid, smb1client.InfoLevelQueryFileStandard)
+	if err != nil {
+		t.Fatalf("QueryFileInformation() error = %v", err)
+	}
+	if len(data) < 24 {
+		t.Fatalf("the standard information is %d bytes, want at least 24", len(data))
+	}
+
+	// A handle that is not open is refused.
+	if _, err := client.QueryFileInformation(0x7FFF, smb1client.InfoLevelQueryFileStandard); err == nil {
+		t.Error("QueryFileInformation() succeeded on a handle that was never issued")
+	}
+}
+
+// TestQueryFsInformation asserts the volume query levels, which a client uses to
+// report free space and the file-system name.
+func TestQueryFsInformation(t *testing.T) {
+	fs := NewMemoryFileSystem("VOLUME")
+	_, client := fileServer(t, fs, false)
+
+	size, err := client.GetFsSizeInfo()
+	if err != nil {
+		t.Fatalf("GetFsSizeInfo() error = %v", err)
+	}
+	if size.Bytespersector == 0 || size.Sectorsperallocationunit == 0 {
+		t.Error("the size information reports a zero allocation geometry")
+	}
+	if size.Totalallocationunits.QuadPart == 0 {
+		t.Error("the size information reports no capacity at all")
+	}
+
+	attribute, err := client.GetFsAttributeInfo()
+	if err != nil {
+		t.Fatalf("GetFsAttributeInfo() error = %v", err)
+	}
+	if attribute.Maxfilenamelengthinbytes == 0 {
+		t.Error("the attribute information reports a zero maximum name length")
+	}
+
+	// An unserved level is refused.
+	if _, err := client.QueryFsInformation(0x0999); err == nil {
+		t.Error("QueryFsInformation() succeeded for an unserved information level")
+	}
+}
+
+// TestSetFileInformation asserts the set levels: resizing a file, and marking one
+// for deletion on close.
+func TestSetFileInformation(t *testing.T) {
+	fs := NewMemoryFileSystem("FILES")
+	if err := fs.AddFile("resized.txt", []byte("0123456789")); err != nil {
+		t.Fatalf("AddFile() error = %v", err)
+	}
+	if err := fs.AddFile("doomed.txt", []byte("x")); err != nil {
+		t.Fatalf("AddFile() error = %v", err)
+	}
+	_, client := fileServer(t, fs, false)
+
+	// Resize through a handle.
+	fid, err := client.OpenFile("resized.txt",
+		fileflags.GENERIC_READ|fileflags.GENERIC_WRITE, fileflags.FILE_SHARE_READ,
+		fileflags.FILE_OPEN, fileflags.FILE_NON_DIRECTORY_FILE)
+	if err != nil {
+		t.Fatalf("OpenFile() error = %v", err)
+	}
+	if err := client.SetFileEndOfFile(fid, 4); err != nil {
+		t.Fatalf("SetFileEndOfFile() error = %v", err)
+	}
+	if err := client.CloseFile(fid); err != nil {
+		t.Fatalf("CloseFile() error = %v", err)
+	}
+	attr, err := fs.Stat("resized.txt")
+	if err != nil {
+		t.Fatalf("Stat() error = %v", err)
+	}
+	if attr.Size != 4 {
+		t.Fatalf("the file is %d bytes after being resized to 4", attr.Size)
+	}
+
+	// Delete-on-close is a property of the handle, and takes effect when it
+	// closes rather than when it is set.
+	doomed, err := client.OpenFile("doomed.txt",
+		fileflags.GENERIC_READ|fileflags.GENERIC_WRITE, fileflags.FILE_SHARE_READ,
+		fileflags.FILE_OPEN, fileflags.FILE_NON_DIRECTORY_FILE)
+	if err != nil {
+		t.Fatalf("OpenFile() error = %v", err)
+	}
+	if err := client.SetFileDeleteOnClose(doomed, true); err != nil {
+		t.Fatalf("SetFileDeleteOnClose() error = %v", err)
+	}
+	if _, err := fs.Stat("doomed.txt"); err != nil {
+		t.Fatal("the file was deleted when delete-on-close was set rather than when the handle closed")
+	}
+	if err := client.CloseFile(doomed); err != nil {
+		t.Fatalf("CloseFile() error = %v", err)
+	}
+	if _, err := fs.Stat("doomed.txt"); err == nil {
+		t.Fatal("the file survived a close with delete-on-close set")
+	}
+}
+
+// TestTransaction2RefusesTraversal asserts the containment boundary holds through
+// the transaction subcommands too, which take a path like any other command.
+func TestTransaction2RefusesTraversal(t *testing.T) {
+	fs := NewMemoryFileSystem("FILES")
+	if err := fs.AddFile("inside.txt", []byte("in")); err != nil {
+		t.Fatalf("AddFile() error = %v", err)
+	}
+	_, client := fileServer(t, fs, false)
+
+	escapes := []string{
+		"..\\*",
+		"..\\..\\etc\\*",
+		"C:\\windows\\*",
+		"\\dir\\..\\..\\*",
+	}
+	for _, pattern := range escapes {
+		pattern := pattern
+		t.Run("list "+pattern, func(t *testing.T) {
+			if entries, err := client.ListEntries(pattern); err == nil {
+				t.Fatalf("ListEntries(%q) succeeded and returned %d entries", pattern, len(entries))
+			}
+		})
+	}
+
+	for _, path := range []string{"..\\outside.txt", "C:\\windows\\win.ini", "inside.txt:stream"} {
+		path := path
+		t.Run("query "+path, func(t *testing.T) {
+			if _, err := client.GetFileBasicInfo(path); err == nil {
+				t.Fatalf("GetFileBasicInfo(%q) succeeded", path)
+			}
+		})
+	}
+}
+
+// TestSetPathInformationOnReadOnlyShare asserts a read-only share refuses the set
+// levels, since they modify.
+func TestSetPathInformationOnReadOnlyShare(t *testing.T) {
+	fs := NewMemoryFileSystem("FILES")
+	if err := fs.AddFile("guarded.txt", []byte("0123456789")); err != nil {
+		t.Fatalf("AddFile() error = %v", err)
+	}
+	_, client := fileServer(t, fs, true)
+
+	// Reading about the file is fine.
+	if _, err := client.GetFileStandardInfo("guarded.txt"); err != nil {
+		t.Fatalf("GetFileStandardInfo() on a read-only share error = %v", err)
+	}
+
+	// Changing it is not.
+	if err := client.SetPathInformation("guarded.txt", smb1client.InfoLevelSetFileEndOfFile,
+		make([]byte, 8)); err == nil {
+		t.Fatal("SetPathInformation() succeeded on a read-only share")
+	}
+
+	attr, err := fs.Stat("guarded.txt")
+	if err != nil {
+		t.Fatalf("Stat() error = %v", err)
+	}
+	if attr.Size != 10 {
+		t.Fatalf("the file is %d bytes, so the refused change still landed", attr.Size)
+	}
+}
+
+// TestTransaction2FragmentPlacement covers the reassembly arithmetic directly,
+// including the inconsistencies it has to refuse. A fragment landing in the wrong
+// place would corrupt a request in a way that is very hard to see from the outside.
+func TestTransaction2FragmentPlacement(t *testing.T) {
+	newReassembly := func(parameters, data int) *trans2Reassembly {
+		return &trans2Reassembly{
+			parameters: make([]byte, parameters),
+			data:       make([]byte, data),
+		}
+	}
+
+	t.Run("fragments assemble in order", func(t *testing.T) {
+		r := newReassembly(6, 0)
+		if err := r.place([]byte{1, 2, 3}, 0, nil, 0); err != nil {
+			t.Fatalf("place() error = %v", err)
+		}
+		if r.complete() {
+			t.Fatal("the transaction reports complete with half its parameters")
+		}
+		if err := r.place([]byte{4, 5, 6}, 3, nil, 0); err != nil {
+			t.Fatalf("place() error = %v", err)
+		}
+		if !r.complete() {
+			t.Fatal("the transaction does not report complete")
+		}
+		for i, want := range []byte{1, 2, 3, 4, 5, 6} {
+			if r.parameters[i] != want {
+				t.Fatalf("parameters = %v, want 1..6", r.parameters)
+			}
+		}
+	})
+
+	t.Run("fragments assemble out of order", func(t *testing.T) {
+		r := newReassembly(4, 0)
+		if err := r.place([]byte{3, 4}, 2, nil, 0); err != nil {
+			t.Fatalf("place() error = %v", err)
+		}
+		if err := r.place([]byte{1, 2}, 0, nil, 0); err != nil {
+			t.Fatalf("place() error = %v", err)
+		}
+		if !r.complete() {
+			t.Fatal("the transaction does not report complete")
+		}
+		for i, want := range []byte{1, 2, 3, 4} {
+			if r.parameters[i] != want {
+				t.Fatalf("parameters = %v, want 1..4", r.parameters)
+			}
+		}
+	})
+
+	t.Run("inconsistent fragments are refused", func(t *testing.T) {
+		cases := []struct {
+			name         string
+			blockSize    int
+			run          []byte
+			displacement int
+		}{
+			{"displacement past the block", 4, []byte{1}, 5},
+			{"negative displacement", 4, []byte{1}, -1},
+			{"run overruns the block", 4, []byte{1, 2, 3}, 2},
+			{"run larger than the whole block", 2, []byte{1, 2, 3, 4}, 0},
+		}
+		for _, tc := range cases {
+			tc := tc
+			t.Run(tc.name, func(t *testing.T) {
+				r := newReassembly(tc.blockSize, 0)
+				if err := r.place(tc.run, tc.displacement, nil, 0); err == nil {
+					t.Fatal("place() accepted an inconsistent fragment")
+				}
+			})
+		}
+	})
+}
+
+// containsName reports whether a listing holds a name.
+func containsName(names []string, want string) bool {
+	for _, name := range names {
+		if name == want {
+			return true
+		}
+	}
+	return false
+}
+
+// pad4 renders an index as four digits, so generated names sort predictably.
+func pad4(value int) string {
+	digits := []byte{'0', '0', '0', '0'}
+	for i := 3; i >= 0 && value > 0; i-- {
+		digits[i] = byte('0' + value%10)
+		value /= 10
+	}
+	return string(digits)
+}


### PR DESCRIPTION
### Summary

Commit 10 of 12 for #1068. **Stacked on #1077.** A client could open and read a file by name; it can now list a directory and ask about a file without opening it.

### TRANSACTION2 fragments in both directions

A request arrives as a primary message plus as many secondary messages as it needs, and a response goes back the same way. The two halves are separate problems:

- **Reassembly** tolerates fragments arriving at displacements it did not choose, and **refuses rather than clamps** a claim that disagrees with itself. A displacement or length outside the declared block means the client's own arithmetic is inconsistent, and guessing which half to believe would let a fragment land somewhere it was not meant to.
- **Fragmentation** fits each response inside *both* what the client said it can receive and what the connection negotiated — a response larger than either could not be read at the far end.

A half-delivered transaction is held for a bounded time, and only one at a time, so a client cannot pin memory by opening many and finishing none.

### The enumeration snapshot — a deliberate trade

`FIND_FIRST2` takes the listing **once** and hands it out in batches. Re-reading the directory per batch would be worse than it sounds: entries appearing or vanishing between batches would make the cursor mean something different each time, so a client could see an entry twice or miss one entirely. A snapshot is stale but coherent, which is what a client enumerating a directory expects.

An entry is never split across responses — a truncated one reads as corrupt — so a batch stops short and the client asks again. `.` and `..` are synthesised, since a backend has no reason to invent them, and `..` is omitted at the share root where there is no parent *within the share* to name.

Two things are refused rather than accommodated: a continuation that changes the information level (it would be describing a different enumeration), and an unserved level in either direction. Returning the nearest shape would be read as corruption, because a client parses what it asked for.

### Information levels

Written out as offsets rather than through structs, because the offsets are what matters and writing them out makes them the thing being reviewed. Names go out as OEM — what this repository's client reads them as, and what the FIND request carries its pattern in, so the two agree.

The volume attribute level claims **only** case-preserved names. Claiming a capability the storage does not have (unicode-on-disk, compression, quotas) is worse than claiming none, because a client then uses it.

### Testing

`go build ./...`, `go vet ./...` and `go test ./...` green. `FuzzServerFrame` ran **8.5M executions clean**.

The suite drives the client's own `ListDirectory` / `ListEntries`. The multi-batch test is worth calling out: it asserts every one of 500 entries arrives **exactly once** *and* that the listing could not have fitted in a single response —

```go
perBatch := (int(DefaultMaxBufferSize) - trans2ResponseOverhead) / (bothDirectoryInfoFixedSize + 48)
if len(entries) <= perBatch { t.Fatalf("...the continuation path was not exercised") }
```

so the continuation path is *known* to have run rather than assumed. That guard is the difference between testing fragmentation and hoping for it.

Also: a listing with its dot entries and directory flags; a wildcard filter; a listing below the share root; search handles released after one enumeration and across repeated ones; the query levels for a path, a handle and a volume; resizing through a handle; delete-on-close taking effect at close rather than when set; a read-only share refusing the set levels; traversal refused through the transaction subcommands too; and the reassembly arithmetic directly — in order, out of order, and four shapes of inconsistency.

The conformance suite gains a **second table** for the TRANSACTION2 subcommands, cross-checked against the handler map in both directions like the command table.

### Still not implemented

Byte-range locking, seek, the legacy `SMB_COM_OPEN_ANDX`, the NT_TRANSACT subcommands, named pipes, and batched AndX chains beyond their first command. The package doc says so.