### PR TITLE
Serve NT_TRANSACT and named pipes (Refs #1068)

### DIFF
--- a/network/smb/smb_v10/message/commands/TransactionRequest.go
+++ b/network/smb/smb_v10/message/commands/TransactionRequest.go
@@ -259,12 +259,16 @@ func (c *TransactionRequest) Marshal() ([]byte, error) {
 	// the data will be stored in the parameters
 	rawDataContent := []byte{}
 
-	// Marshalling data Name
-	bytesStream, err := c.Name.Marshal()
-	if err != nil {
-		return nil, err
-	}
-	rawDataContent = append(rawDataContent, bytesStream...)
+	// Marshalling data Name.
+	//
+	// Per [MS-CIFS] section 2.2.4.33.1 the Name is "a null-terminated array of
+	// OEM characters", or of 16-bit Unicode characters when SMB_FLAGS2_UNICODE is
+	// set, and it "MUST be the first field in this section". There is no
+	// buffer-format byte: marshalling it through SMB_STRING would prepend a
+	// spurious 0x04, which a server reads as the first character of the name. The
+	// same is done for SMB_COM_NT_CREATE_ANDX's FileName, for the same reason.
+	rawDataContent = append(rawDataContent, []byte(c.Name.Buffer)...)
+	rawDataContent = append(rawDataContent, nameTerminator(c.IsUnicode())...)
 
 	// Marshalling data Pad1
 	rawDataContent = append(rawDataContent, c.Pad1...)
@@ -532,12 +536,12 @@ func (c *TransactionRequest) Unmarshal(rawData []byte) (int, error) {
 	// Then unmarshal the data
 	offset = 0
 
-	// Unmarshalling data Name
-	bytesRead, err = c.Name.Unmarshal(rawDataContent[offset:])
-	if err != nil {
-		return offset, err
-	}
-	offset += bytesRead
+	// Unmarshalling data Name: a raw null-terminated string with no SMB_STRING
+	// buffer-format byte (mirrors Marshal above).
+	nameBytes, nameSize := readTerminatedName(rawDataContent[offset:], c.IsUnicode())
+	c.Name.Buffer = []types.UCHAR(nameBytes)
+	c.Name.Length = types.USHORT(len(nameBytes))
+	offset += nameSize
 
 	// Unmarshalling data Pad1, Trans_Parameters, Pad2, Trans_Data.
 	//

--- a/network/smb/smb_v10/message/commands/terminated_name.go
+++ b/network/smb/smb_v10/message/commands/terminated_name.go
@@ -1,0 +1,49 @@
+package commands
+
+// Helpers for the string fields that a command carries raw in its data block.
+//
+// [MS-CIFS] describes several such fields — SMB_COM_TRANSACTION's Name, and
+// SMB_COM_NT_CREATE_ANDX's FileName among them — as a null-terminated array of
+// OEM characters, or of 16-bit Unicode characters when SMB_FLAGS2_UNICODE is set
+// in the request's Flags2. None of them carries an SMB_STRING buffer-format byte:
+// the commands that do carry one declare it as a separate field. Reading such a
+// field through SMB_STRING treats the name's first character as a format code,
+// which fails outright for a name beginning with a backslash.
+//
+// The width of the terminator follows the encoding, so both helpers take it.
+
+// nameTerminator returns the terminator that ends a raw name field.
+func nameTerminator(unicode bool) []byte {
+	if unicode {
+		return []byte{0x00, 0x00}
+	}
+	return []byte{0x00}
+}
+
+// readTerminatedName reads a raw name from the start of a data block and returns
+// the name's bytes together with the number of bytes it occupied, terminator
+// included.
+//
+// A name that runs to the end of the block without a terminator is returned
+// whole: the block is bounded by ByteCount, so there is nothing to overrun, and
+// refusing the message outright would be harsher than the field warrants.
+func readTerminatedName(data []byte, unicode bool) (name []byte, size int) {
+	if !unicode {
+		for index := 0; index < len(data); index++ {
+			if data[index] == 0x00 {
+				return data[:index], index + 1
+			}
+		}
+		return data, len(data)
+	}
+
+	// A UTF-16 name ends at the first pair of zero bytes on an even offset. An odd
+	// offset cannot end it: the low half of one character and the high half of the
+	// next can both be zero without the string having ended.
+	for index := 0; index+1 < len(data); index += 2 {
+		if data[index] == 0x00 && data[index+1] == 0x00 {
+			return data[:index], index + 2
+		}
+	}
+	return data, len(data)
+}

--- a/network/smb/smb_v10/message/commands/transaction_name_test.go
+++ b/network/smb/smb_v10/message/commands/transaction_name_test.go
@@ -1,0 +1,149 @@
+package commands_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/encoding/utf16"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+)
+
+// The Name field of an SMB_COM_TRANSACTION request is, per [MS-CIFS] section
+// 2.2.4.33.1, "a null-terminated array of OEM characters" — or of 16-bit Unicode
+// characters when SMB_FLAGS2_UNICODE is set — and "MUST be the first field in this
+// section". It carries no SMB_STRING buffer-format byte.
+//
+// These tests pin that down in both directions, because getting it wrong is
+// invisible in a round trip that shares the mistake: a marshaller that prepends a
+// format byte and an unmarshaller that consumes one agree with each other and
+// disagree with every real client.
+
+// TestTransactionNameCarriesNoBufferFormatByte asserts the marshalled data block
+// begins with the name itself.
+func TestTransactionNameCarriesNoBufferFormatByte(t *testing.T) {
+	request := commands.NewTransactionRequest()
+	if err := request.Name.SetString(`\PIPE\srvsvc`); err != nil {
+		t.Fatalf("Name.SetString() error = %v", err)
+	}
+	request.Setup = []types.USHORT{0x0026, 0x0001}
+	request.SetupCount = types.UCHAR(2)
+
+	marshalled, err := request.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+
+	// The data block is WordCount(1) + 2*WordCount words + ByteCount(2), then the
+	// bytes. WordCount is 14 plus the setup words.
+	wordCount := int(marshalled[0])
+	if want := 14 + len(request.Setup); wordCount != want {
+		t.Fatalf("WordCount = %d, want %d", wordCount, want)
+	}
+	dataStart := 1 + 2*wordCount + 2
+	if dataStart >= len(marshalled) {
+		t.Fatalf("the message is %d bytes, too short to hold a data block", len(marshalled))
+	}
+
+	block := marshalled[dataStart:]
+	if !bytes.HasPrefix(block, []byte(`\PIPE\srvsvc`+"\x00")) {
+		t.Fatalf("the data block begins % x, want the name at its start with no format byte", block[:min(8, len(block))])
+	}
+	// Spelled out, because this is the exact byte the bug added: 0x04 is
+	// SMB_STRING's null-terminated-ASCII format code.
+	if block[0] == 0x04 {
+		t.Fatal("the data block begins with an SMB_STRING buffer-format byte, which the wire format has no room for")
+	}
+}
+
+// TestTransactionNameRoundTrips asserts a name survives marshal and unmarshal in
+// both encodings, terminator width included.
+func TestTransactionNameRoundTrips(t *testing.T) {
+	cases := []struct {
+		name    string
+		unicode bool
+		value   string
+	}{
+		{"OEM pipe path", false, `\PIPE\srvsvc`},
+		{"OEM bare prefix", false, `\PIPE\`},
+		{"OEM empty", false, ""},
+		{"Unicode pipe path", true, `\PIPE\srvsvc`},
+		{"Unicode empty", true, ""},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			request := commands.NewTransactionRequest()
+			request.SetUnicode(tc.unicode)
+			if tc.unicode {
+				request.Name.Buffer = []types.UCHAR(utf16.EncodeUTF16LE(tc.value))
+			} else {
+				request.Name.Buffer = []types.UCHAR(tc.value)
+			}
+			request.Name.Length = types.USHORT(len(request.Name.Buffer))
+			request.Trans_Data = []types.UCHAR("payload")
+			request.TotalDataCount = types.USHORT(len(request.Trans_Data))
+			request.DataCount = types.USHORT(len(request.Trans_Data))
+
+			marshalled, err := request.Marshal()
+			if err != nil {
+				t.Fatalf("Marshal() error = %v", err)
+			}
+
+			decoded := commands.NewTransactionRequest()
+			decoded.Init()
+			decoded.SetUnicode(tc.unicode)
+			if _, err := decoded.Unmarshal(marshalled); err != nil {
+				t.Fatalf("Unmarshal() error = %v", err)
+			}
+
+			got := string(decoded.Name.Buffer)
+			if tc.unicode {
+				got = utf16.DecodeUTF16LE(decoded.Name.Buffer)
+			}
+			if got != tc.value {
+				t.Fatalf("the name round-tripped to %q, want %q", got, tc.value)
+			}
+			if string(decoded.Trans_Data) != "payload" {
+				t.Fatalf("the data round-tripped to %q, want \"payload\"", decoded.Trans_Data)
+			}
+		})
+	}
+}
+
+// TestTransactionNameFromTheWire asserts a name as a real client sends it decodes,
+// which is the case the buffer-format byte broke: a name beginning with a
+// backslash was read as a format code of 0x5C and refused outright.
+func TestTransactionNameFromTheWire(t *testing.T) {
+	// Built by hand rather than by this package's own marshaller, so the
+	// assertion is against the wire format and not against a shared assumption.
+	name := []byte(`\PIPE\LANMAN` + "\x00")
+	setup := []byte{0x26, 0x00, 0x01, 0x00}
+	words := make([]byte, 28)
+	// SetupCount at word 14, byte offset 26.
+	words[26] = 0x02
+
+	message := []byte{}
+	message = append(message, byte(14+2))
+	message = append(message, words...)
+	message = append(message, setup...)
+	message = append(message, byte(len(name)), 0x00)
+	message = append(message, name...)
+
+	decoded := commands.NewTransactionRequest()
+	decoded.Init()
+	read, err := decoded.Unmarshal(message)
+	if err != nil {
+		t.Fatalf("a request as a client sends it did not decode: %v", err)
+	}
+	if read == 0 {
+		t.Fatal("Unmarshal reported reading nothing")
+	}
+	if got := string(decoded.Name.Buffer); got != `\PIPE\LANMAN` {
+		t.Fatalf("the name decoded as %q, want %q", got, `\PIPE\LANMAN`)
+	}
+	if decoded.SetupCount != 2 || len(decoded.Setup) != 2 || decoded.Setup[0] != 0x0026 {
+		t.Fatalf("the setup words decoded as %v (count %d), want [0x0026 0x0001]", decoded.Setup, decoded.SetupCount)
+	}
+}

--- a/network/smb/smb_v10/server/conformance_test.go
+++ b/network/smb/smb_v10/server/conformance_test.go
@@ -138,6 +138,75 @@ var servedCommands = map[codes.CommandCode]string{
 	codes.SMB_COM_TRANSACTION2:           "carries the find and information subcommands",
 	codes.SMB_COM_TRANSACTION2_SECONDARY: "continues a fragmented transaction",
 	codes.SMB_COM_FIND_CLOSE2:            "releases a search handle",
+
+	codes.SMB_COM_TRANSACTION:           "carries the named-pipe subcommands",
+	codes.SMB_COM_TRANSACTION_SECONDARY: "continues a fragmented pipe transaction",
+
+	codes.SMB_COM_NT_TRANSACT:           "carries the security-descriptor and control subcommands",
+	codes.SMB_COM_NT_TRANSACT_SECONDARY: "continues a fragmented NT_TRANSACT",
+	codes.SMB_COM_NT_CANCEL:             "accepts a cancel, which has nothing to cancel",
+}
+
+// servedNtTransactFunctions are the NT_TRANSACT functions the server answers.
+//
+// The absences are deliberate and are asserted, not merely omitted:
+// NT_TRANSACT_CREATE and NT_TRANSACT_RENAME duplicate commands that exist in
+// their own right, the quota functions have nothing to report a quota from, and
+// NOTIFY_CHANGE needs a watching file system and a concurrent write path that
+// neither the FileSystem interface nor the connection has.
+var servedNtTransactFunctions = map[subcommands.NtTransactSubcommand]string{
+	subcommands.NT_TRANSACT_QUERY_SECURITY_DESC: "returns a share's security descriptor",
+	subcommands.NT_TRANSACT_SET_SECURITY_DESC:   "applies one, if the share can store it",
+	subcommands.NT_TRANSACT_IOCTL:               "carries the file-system control codes",
+}
+
+// servedFsctlCodes are the file-system control codes NT_TRANSACT_IOCTL answers.
+var servedFsctlCodes = map[uint32]string{
+	fsctlGetCompression:  "reports that nothing is compressed",
+	fsctlIsPathnameValid: "asks the path resolver whether a name is usable",
+}
+
+// servedPipeSubcommands are the TRANSACTION subcommands the server answers.
+//
+// TRANS_TRANSACT_NMPIPE is the one that matters: it is the write-then-read that
+// MS-RPC travels over. The others exist because an RPC client asks them on its
+// way in.
+var servedPipeSubcommands = map[subcommands.TransactionSubcommand]string{
+	subcommands.TRANS_TRANSACT_NMPIPE:    "writes a message to a pipe and returns the answer",
+	subcommands.TRANS_WAIT_NMPIPE:        "reports a pipe available",
+	subcommands.TRANS_QUERY_NMPIPE_STATE: "reports a message-mode pipe",
+	subcommands.TRANS_SET_NMPIPE_STATE:   "accepts the state a client sets",
+}
+
+// TestConformanceServedNtTransactFunctionsAreServed asserts the NT_TRANSACT table
+// and the handler table agree, in both directions.
+func TestConformanceServedNtTransactFunctionsAreServed(t *testing.T) {
+	for function := range servedNtTransactFunctions {
+		if _, ok := ntTransactHandlers[function]; !ok {
+			t.Errorf("NT_TRANSACT function 0x%04X is listed as served but has no handler", uint16(function))
+		}
+	}
+	for function := range ntTransactHandlers {
+		if _, ok := servedNtTransactFunctions[function]; !ok {
+			t.Errorf("NT_TRANSACT function 0x%04X has a handler but is not listed; add it with a note on what it does",
+				uint16(function))
+		}
+	}
+}
+
+// TestConformanceServedFsctlCodesAreServed asserts the control-code table and the
+// handler table agree, in both directions.
+func TestConformanceServedFsctlCodesAreServed(t *testing.T) {
+	for code := range servedFsctlCodes {
+		if _, ok := fsctlHandlers[code]; !ok {
+			t.Errorf("FSCTL 0x%08X is listed as served but has no handler", code)
+		}
+	}
+	for code := range fsctlHandlers {
+		if _, ok := servedFsctlCodes[code]; !ok {
+			t.Errorf("FSCTL 0x%08X has a handler but is not listed; add it with a note on what it does", code)
+		}
+	}
 }
 
 // servedTrans2Subcommands are the TRANSACTION2 subcommands the server answers.
@@ -203,13 +272,17 @@ func TestConformanceUnservedCommandsAreRefused(t *testing.T) {
 	// while asserting nothing.
 	exercised := 0
 	skippedUnmarshalable := 0
+	known := 0
+	skippedServed := 0
 
 	for value := 0; value <= 0xFF; value++ {
 		command := codes.CommandCode(value)
-		if _, served := servedCommands[command]; served {
+		if !isKnownCommand(command) {
 			continue
 		}
-		if !isKnownCommand(command) {
+		known++
+		if _, served := servedCommands[command]; served {
+			skippedServed++
 			continue
 		}
 
@@ -259,14 +332,23 @@ func TestConformanceUnservedCommandsAreRefused(t *testing.T) {
 		}
 	}
 
-	// The message layer knows well over a hundred commands, so a walk that
-	// exercised only a handful means the loop stopped covering the space.
-	if exercised < 50 {
-		t.Fatalf("only %d commands were exercised (%d skipped as unmarshalable); the walk is no longer covering the command space",
-			exercised, skippedUnmarshalable)
+	// Every command the message layer knows was either exercised here, skipped as
+	// served, or skipped as unmarshalable. Accounting for all of them is what
+	// makes this a walk of the command space rather than of whatever the loop
+	// happened to reach — and unlike a fixed floor it stays true as later phases
+	// move commands into the served set.
+	if accounted := exercised + skippedServed + skippedUnmarshalable; accounted != known {
+		t.Fatalf("accounted for %d of %d known commands (%d exercised, %d served, %d unmarshalable); the walk is skipping commands silently",
+			accounted, known, exercised, skippedServed, skippedUnmarshalable)
 	}
-	t.Logf("exercised %d unserved commands, skipped %d whose zero value cannot be marshalled",
-		exercised, skippedUnmarshalable)
+	// A floor as well, so a message layer that stopped recognizing commands at all
+	// would not make the accounting trivially true.
+	if exercised < 40 {
+		t.Fatalf("only %d commands were exercised of %d known; the walk is no longer covering the command space",
+			exercised, known)
+	}
+	t.Logf("exercised %d of %d known commands (%d served, %d whose zero value cannot be marshalled)",
+		exercised, known, skippedServed, skippedUnmarshalable)
 }
 
 // TestConformanceClientAPI walks the client's entry points against the server and

--- a/network/smb/smb_v10/server/connection.go
+++ b/network/smb/smb_v10/server/connection.go
@@ -91,7 +91,7 @@ type Connection struct {
 	// when none is. One at a time: a client completes a transaction before
 	// starting another, and holding several would let it pin memory by opening
 	// many and finishing none.
-	trans2 *trans2Reassembly
+	transaction *transactionReassembly
 
 	// searches are the directory enumerations in progress, by search identifier,
 	// and sids allocates those identifiers.

--- a/network/smb/smb_v10/server/dispatch.go
+++ b/network/smb/smb_v10/server/dispatch.go
@@ -55,6 +55,16 @@ var dispatchTable = map[codes.CommandCode]commandHandler{
 	codes.SMB_COM_TRANSACTION2:           handleTransaction2,
 	codes.SMB_COM_TRANSACTION2_SECONDARY: handleTransaction2Secondary,
 	codes.SMB_COM_FIND_CLOSE2:            handleFindClose2,
+
+	// NT_TRANSACT, which carries the security-descriptor and control
+	// subcommands.
+	codes.SMB_COM_NT_TRANSACT:           handleNtTransact,
+	codes.SMB_COM_NT_TRANSACT_SECONDARY: handleNtTransactSecondary,
+	codes.SMB_COM_NT_CANCEL:             handleNtCancel,
+
+	// TRANSACTION, which carries the named-pipe operations.
+	codes.SMB_COM_TRANSACTION:           handleTransaction,
+	codes.SMB_COM_TRANSACTION_SECONDARY: handleTransactionSecondary,
 }
 
 // sessionlessCommands are the commands a client may send before it holds a

--- a/network/smb/smb_v10/server/doc.go
+++ b/network/smb/smb_v10/server/doc.go
@@ -35,10 +35,34 @@
 //     FIND_FIRST2 and FIND_NEXT2 with search handles, the query and set levels
 //     for a path and for an open handle, and the volume levels. Requests and
 //     responses both fragment across as many messages as they need.
+//   - Security descriptors and file-system controls, over NT_TRANSACT:
+//     QUERY_SECURITY_DESC, SET_SECURITY_DESC and IOCTL. SMB_COM_NT_CANCEL is
+//     accepted silently, since nothing here leaves a request outstanding.
+//   - Named pipes, over TRANSACTION: a pipe is opened on a pipe share like a
+//     file, and TRANS_TRANSACT_NMPIPE writes a message to the handle and returns
+//     the answer. That write-then-read is the operation MS-RPC travels over, so a
+//     PipeHandler is all an RPC service needs to be reachable over SMB1.
+//
+// All three transaction families share one reassembly, since they are the same
+// shape at different field widths: totals, a per-message count and a
+// displacement, with the subcommand selected by a setup word, a Function field or
+// a name.
 //
 // Not yet implemented, and answered with STATUS_NOT_IMPLEMENTED: byte-range
-// locking, seek, the legacy SMB_COM_OPEN_ANDX, the NT_TRANSACT subcommands,
-// named pipes, and batched AndX chains beyond their first command.
+// locking, seek, the legacy SMB_COM_OPEN_ANDX, and batched AndX chains beyond
+// their first command.
+//
+// NT_TRANSACT_NOTIFY_CHANGE is deliberately absent rather than pending. It needs
+// two things this package does not have: a FileSystem that can be watched, and a
+// connection whose write path can be used from outside the request that is being
+// served — a notification is answered when the change happens, not when it is
+// asked for. Both are architectural additions, and half of either would be worse
+// than the honest refusal.
+//
+// NT_TRANSACT_CREATE and NT_TRANSACT_RENAME are also absent by choice: they
+// duplicate SMB_COM_NT_CREATE_ANDX and SMB_COM_RENAME, which are served. The
+// quota subcommands are absent because nothing here tracks a quota, and a number
+// invented for them is a number a client would believe.
 //
 // # Shares
 //
@@ -50,6 +74,33 @@
 // A share may be marked ReadOnly, which refuses every modifying command whatever
 // access the client asked for. That is enforced in the handlers rather than left
 // to the backend, so a backend cannot forget it.
+//
+// # Security descriptors
+//
+// A Share may carry a SecurityProvider, which answers the NT_TRANSACT security
+// subcommands. NewReflectiveSecurityProvider derives a descriptor from the
+// share's own configuration: a read-only share does not describe write access,
+// because it does not grant any. That is the point of deriving one rather than
+// returning a fixed descriptor — a client uses a descriptor to predict what it
+// will be allowed to do, so one that disagreed with the handlers would make the
+// client wrong. For the same reason it refuses a change instead of accepting one
+// it has nowhere to store.
+//
+// A share with no provider answers STATUS_NOT_SUPPORTED rather than inventing a
+// descriptor.
+//
+// # Named pipes
+//
+// A Share of type ShareTypeNamedPipe carries a PipeHandler instead of a
+// FileSystem. A client opens a pipe on it with SMB_COM_NT_CREATE_ANDX and then
+// transacts on the handle: [MS-CIFS] identifies the pipe a transaction acts on by
+// the FID in the request's setup words, not by the name the request carries, so
+// the handle is what matters and the name is boilerplate.
+//
+// An answer larger than the client's buffer is cut to fit and reported with
+// STATUS_BUFFER_OVERFLOW, which is what tells the client to read again. Reporting
+// plain success would leave an RPC client parsing a truncated response as a whole
+// one.
 //
 // # Path containment
 //

--- a/network/smb/smb_v10/server/fuzz_test.go
+++ b/network/smb/smb_v10/server/fuzz_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"io"
 	"net"
 	"testing"
@@ -105,6 +106,44 @@ func FuzzServerFrame(f *testing.F) {
 			flags2.Flags2(flags2.FLAGS2_NT_STATUS_ERROR_CODES),
 			append([]byte{0x0C}, make([]byte, 12*2+2)...)))
 	}
+
+	// The NT_TRANSACT family, whose counts are 32-bit: a declared total is an
+	// allocation, so the bound on it is reachable from the first frame a client
+	// sends. WordCount 19 selects the primary form, 18 the secondary.
+	f.Add(rawFrame(codes.SMB_COM_NT_TRANSACT, flags.Flags(0),
+		flags2.Flags2(flags2.FLAGS2_NT_STATUS_ERROR_CODES),
+		append([]byte{0x13}, make([]byte, 19*2+2)...)))
+	// The same, with every count field set to 0xFFFFFFFF.
+	f.Add(rawFrame(codes.SMB_COM_NT_TRANSACT, flags.Flags(0),
+		flags2.Flags2(flags2.FLAGS2_NT_STATUS_ERROR_CODES),
+		append([]byte{0x13}, bytes.Repeat([]byte{0xFF}, 19*2+2)...)))
+	f.Add(rawFrame(codes.SMB_COM_NT_TRANSACT_SECONDARY, flags.Flags(0),
+		flags2.Flags2(flags2.FLAGS2_NT_STATUS_ERROR_CODES),
+		append([]byte{0x12}, make([]byte, 18*2+2)...)))
+	f.Add(rawFrame(codes.SMB_COM_NT_CANCEL, flags.Flags(0),
+		flags2.Flags2(flags2.FLAGS2_NT_STATUS_ERROR_CODES), []byte{0x00, 0x00, 0x00}))
+
+	// The TRANSACTION family, whose data block begins with a name the decoder has
+	// to find the end of. A block with no terminator at all is the case that a
+	// scan without a bound would run off.
+	f.Add(rawFrame(codes.SMB_COM_TRANSACTION, flags.Flags(0),
+		flags2.Flags2(flags2.FLAGS2_NT_STATUS_ERROR_CODES),
+		append([]byte{0x0E}, make([]byte, 14*2+2)...)))
+	transactionWithName := append([]byte{0x10}, make([]byte, 16*2)...)
+	// SetupCount at word 14 (byte offset 1+28), then two setup words, then a
+	// ByteCount naming a block of unterminated name bytes.
+	transactionWithName[1+26] = 0x02
+	transactionWithName = append(transactionWithName, 0x0C, 0x00)
+	transactionWithName = append(transactionWithName, []byte(`\PIPE\srvsvc`)...)
+	f.Add(rawFrame(codes.SMB_COM_TRANSACTION, flags.Flags(0),
+		flags2.Flags2(flags2.FLAGS2_NT_STATUS_ERROR_CODES), transactionWithName))
+	// The same declared as Unicode, where the terminator is two bytes wide and an
+	// odd-length block cannot hold one.
+	f.Add(rawFrame(codes.SMB_COM_TRANSACTION, flags.Flags(0),
+		flags2.Flags2(flags2.FLAGS2_NT_STATUS_ERROR_CODES|flags2.FLAGS2_UNICODE), transactionWithName))
+	f.Add(rawFrame(codes.SMB_COM_TRANSACTION_SECONDARY, flags.Flags(0),
+		flags2.Flags2(flags2.FLAGS2_NT_STATUS_ERROR_CODES),
+		append([]byte{0x08}, make([]byte, 8*2+2)...)))
 
 	f.Fuzz(func(t *testing.T, raw []byte) {
 		srv, err := NewServer(Config{})

--- a/network/smb/smb_v10/server/handler_file.go
+++ b/network/smb/smb_v10/server/handler_file.go
@@ -25,6 +25,23 @@ const (
 // share, and a file system — so they are checked once here rather than at the top
 // of each handler where one could be forgotten.
 func (c *Connection) treeFor(req *message.Message) (*Tree, nt_status.NT_STATUS) {
+	tree, status := c.anyTreeFor(req)
+	if status != nt_status.NT_STATUS_SUCCESS {
+		return nil, status
+	}
+	if tree.Share.Type != ShareTypeDisk || tree.Share.FS == nil {
+		return nil, nt_status.NT_STATUS_BAD_DEVICE_TYPE
+	}
+	return tree, nt_status.NT_STATUS_SUCCESS
+}
+
+// anyTreeFor resolves the tree a request names, whatever kind of share it is.
+//
+// Only the commands that serve more than one kind of share use this — an open,
+// which reaches a file on a disk share and a pipe on a pipe share. Everything
+// else goes through treeFor and gets the disk check for free, which is what keeps
+// a file-system handler from being reached with a nil FS.
+func (c *Connection) anyTreeFor(req *message.Message) (*Tree, nt_status.NT_STATUS) {
 	tree := c.Tree(uint16(req.Header.TID))
 	if tree == nil {
 		return nil, nt_status.NT_STATUS_SMB_BAD_TID
@@ -35,9 +52,6 @@ func (c *Connection) treeFor(req *message.Message) (*Tree, nt_status.NT_STATUS) 
 		logger.Debugf("SMB1 server: %s used TID 0x%04X from UID 0x%04X, which does not own it",
 			c.Remote, tree.TID, uint16(req.Header.UID))
 		return nil, nt_status.NT_STATUS_SMB_BAD_TID
-	}
-	if tree.Share.Type != ShareTypeDisk || tree.Share.FS == nil {
-		return nil, nt_status.NT_STATUS_BAD_DEVICE_TYPE
 	}
 	return tree, nt_status.NT_STATUS_SUCCESS
 }
@@ -136,7 +150,9 @@ func handleNtCreateAndx(conn *Connection, w ResponseWriter, req *message.Message
 		return nt_status.NT_STATUS_INVALID_SMB
 	}
 
-	tree, status := conn.treeFor(req)
+	// An open is the one command that serves both kinds of share, so it resolves
+	// the tree without the disk check and applies its own.
+	tree, status := conn.anyTreeFor(req)
 	if status != nt_status.NT_STATUS_SUCCESS {
 		return status
 	}
@@ -145,6 +161,16 @@ func handleNtCreateAndx(conn *Connection, w ResponseWriter, req *message.Message
 	// repository's client sends file-I/O messages in OEM even when the connection
 	// negotiated Unicode, so the request's own flag is what governs.
 	requested := decodeWireString(request.FileName.Buffer, req.Header.Flags2.IsUnicode())
+
+	// A pipe share has no file system behind it, so it takes a different path
+	// entirely: what a client opens there is a pipe, and the handle it gets back
+	// is what a later transaction names.
+	if tree.Share.Type == ShareTypeNamedPipe {
+		return conn.openPipe(w, tree, requested)
+	}
+	if tree.Share.Type != ShareTypeDisk || tree.Share.FS == nil {
+		return nt_status.NT_STATUS_BAD_DEVICE_TYPE
+	}
 
 	path, err := resolvePath(requested)
 	if err != nil {
@@ -269,7 +295,8 @@ func handleClose(conn *Connection, w ResponseWriter, req *message.Message) nt_st
 
 	// A client may set the modification time as it closes. 0 and -1 both mean
 	// "leave it alone", which is why the field cannot simply be applied.
-	if request.LastTimeModified != 0 && request.LastTimeModified != 0xFFFFFFFF && open.Writable {
+	if request.LastTimeModified != 0 && request.LastTimeModified != 0xFFFFFFFF && open.Writable &&
+		open.Tree != nil && open.Tree.Share.FS != nil {
 		modified := time.Unix(int64(request.LastTimeModified), 0).UTC()
 		if err := open.Tree.Share.FS.SetAttr(open.Path, FileAttr{Modified: modified}, AttrMask{Modified: true}); err != nil {
 			logger.Debugf("SMB1 server: could not set the modification time of %q: %v", open.Path, err)

--- a/network/smb/smb_v10/server/handler_find.go
+++ b/network/smb/smb_v10/server/handler_find.go
@@ -79,7 +79,7 @@ func (c *Connection) closeSearch(sid uint16) bool {
 //
 // Request parameters: SearchAttributes(2) SearchCount(2) Flags(2)
 // InformationLevel(2) SearchStorageType(4) FileName(variable).
-func handleFindFirst2(conn *Connection, req *message.Message, reassembly *trans2Reassembly) ([]byte, []byte, nt_status.NT_STATUS) {
+func handleFindFirst2(conn *Connection, req *message.Message, reassembly *transactionReassembly) ([]byte, []byte, nt_status.NT_STATUS) {
 	parameters := reassembly.parameters
 	if len(parameters) < 12 {
 		return nil, nil, nt_status.NT_STATUS_INVALID_PARAMETER
@@ -166,7 +166,7 @@ func handleFindFirst2(conn *Connection, req *message.Message, reassembly *trans2
 //
 // Request parameters: SID(2) SearchCount(2) InformationLevel(2) ResumeKey(4)
 // Flags(2) FileName(variable).
-func handleFindNext2(conn *Connection, req *message.Message, reassembly *trans2Reassembly) ([]byte, []byte, nt_status.NT_STATUS) {
+func handleFindNext2(conn *Connection, req *message.Message, reassembly *transactionReassembly) ([]byte, []byte, nt_status.NT_STATUS) {
 	parameters := reassembly.parameters
 	if len(parameters) < 12 {
 		return nil, nil, nt_status.NT_STATUS_INVALID_PARAMETER

--- a/network/smb/smb_v10/server/handler_info.go
+++ b/network/smb/smb_v10/server/handler_info.go
@@ -13,7 +13,7 @@ import (
 // intend to read.
 //
 // Request parameters: InformationLevel(2) Reserved(4) FileName(variable).
-func handleQueryPathInformation(conn *Connection, req *message.Message, reassembly *trans2Reassembly) ([]byte, []byte, nt_status.NT_STATUS) {
+func handleQueryPathInformation(conn *Connection, req *message.Message, reassembly *transactionReassembly) ([]byte, []byte, nt_status.NT_STATUS) {
 	parameters := reassembly.parameters
 	if len(parameters) < 6 {
 		return nil, nil, nt_status.NT_STATUS_INVALID_PARAMETER
@@ -54,7 +54,7 @@ func handleQueryPathInformation(conn *Connection, req *message.Message, reassemb
 // a path a client already holds open.
 //
 // Request parameters: FID(2) InformationLevel(2).
-func handleQueryFileInformation(conn *Connection, req *message.Message, reassembly *trans2Reassembly) ([]byte, []byte, nt_status.NT_STATUS) {
+func handleQueryFileInformation(conn *Connection, req *message.Message, reassembly *transactionReassembly) ([]byte, []byte, nt_status.NT_STATUS) {
 	parameters := reassembly.parameters
 	if len(parameters) < 4 {
 		return nil, nil, nt_status.NT_STATUS_INVALID_PARAMETER
@@ -86,7 +86,7 @@ func handleQueryFileInformation(conn *Connection, req *message.Message, reassemb
 // handleSetPathInformation answers TRANS2_SET_PATH_INFORMATION.
 //
 // Request parameters: InformationLevel(2) Reserved(4) FileName(variable).
-func handleSetPathInformation(conn *Connection, req *message.Message, reassembly *trans2Reassembly) ([]byte, []byte, nt_status.NT_STATUS) {
+func handleSetPathInformation(conn *Connection, req *message.Message, reassembly *transactionReassembly) ([]byte, []byte, nt_status.NT_STATUS) {
 	parameters := reassembly.parameters
 	if len(parameters) < 6 {
 		return nil, nil, nt_status.NT_STATUS_INVALID_PARAMETER
@@ -124,7 +124,7 @@ func handleSetPathInformation(conn *Connection, req *message.Message, reassembly
 // handleSetFileInformation answers TRANS2_SET_FILE_INFORMATION.
 //
 // Request parameters: FID(2) InformationLevel(2) Reserved(2).
-func handleSetFileInformation(conn *Connection, req *message.Message, reassembly *trans2Reassembly) ([]byte, []byte, nt_status.NT_STATUS) {
+func handleSetFileInformation(conn *Connection, req *message.Message, reassembly *transactionReassembly) ([]byte, []byte, nt_status.NT_STATUS) {
 	parameters := reassembly.parameters
 	if len(parameters) < 4 {
 		return nil, nil, nt_status.NT_STATUS_INVALID_PARAMETER
@@ -159,7 +159,7 @@ func handleSetFileInformation(conn *Connection, req *message.Message, reassembly
 // volume behind the share.
 //
 // Request parameters: InformationLevel(2).
-func handleQueryFsInformation(conn *Connection, req *message.Message, reassembly *trans2Reassembly) ([]byte, []byte, nt_status.NT_STATUS) {
+func handleQueryFsInformation(conn *Connection, req *message.Message, reassembly *transactionReassembly) ([]byte, []byte, nt_status.NT_STATUS) {
 	parameters := reassembly.parameters
 	if len(parameters) < 2 {
 		return nil, nil, nt_status.NT_STATUS_INVALID_PARAMETER

--- a/network/smb/smb_v10/server/handler_nttransact.go
+++ b/network/smb/smb_v10/server/handler_nttransact.go
@@ -1,0 +1,379 @@
+package server
+
+import (
+	"encoding/binary"
+	"fmt"
+	"time"
+
+	"github.com/TheManticoreProject/Manticore/logger"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/subcommands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+	"github.com/TheManticoreProject/Manticore/windows/nt_status"
+)
+
+// ntTransactResponseWordCount is the fixed word count of an NT_TRANSACT response
+// carrying no setup words, which none of the subcommands here return.
+const ntTransactResponseWordCount = 18
+
+// ntTransactResponseOverhead is the space an NT_TRANSACT response needs beyond its
+// blocks. Its fixed part is larger than TRANSACTION2's, because its counts are
+// 32-bit.
+const ntTransactResponseOverhead = 128
+
+// handleNtTransact answers SMB_COM_NT_TRANSACT: the primary message of an
+// NT_TRANSACT.
+//
+// The family is the same shape as TRANSACTION2 with wider fields, so the
+// reassembly is shared and only the extraction differs. The subcommand travels in
+// its own Function field rather than in a setup word.
+func handleNtTransact(conn *Connection, w ResponseWriter, req *message.Message) nt_status.NT_STATUS {
+	request, ok := req.Command.(*commands.NtTransactRequest)
+	if !ok {
+		return nt_status.NT_STATUS_INVALID_SMB
+	}
+
+	totalParameters := int(request.TotalParameterCount)
+	totalData := int(request.TotalDataCount)
+	// The counts are 32-bit here, so the bound matters more than it did for
+	// TRANSACTION2: a claimed total is an allocation.
+	if totalParameters < 0 || totalData < 0 ||
+		totalParameters > maxNtTransactPayload || totalData > maxNtTransactPayload {
+		logger.Debugf("SMB1 server: %s declared an NT_TRANSACT of %d+%d bytes, over the limit",
+			conn.Remote, totalParameters, totalData)
+		return nt_status.NT_STATUS_INVALID_PARAMETER
+	}
+
+	reassembly := &transactionReassembly{
+		family:            "NT_TRANSACT",
+		subcommand:        uint16(request.Function),
+		parameters:        make([]byte, totalParameters),
+		data:              make([]byte, totalData),
+		maxParameterCount: int(request.MaxParameterCount),
+		maxDataCount:      int(request.MaxDataCount),
+		setup:             request.Setup,
+		started:           time.Now(),
+	}
+
+	if err := reassembly.place(
+		[]byte(request.NT_Trans_Parameters), 0,
+		[]byte(request.NT_Trans_Data), 0,
+	); err != nil {
+		logger.Debugf("SMB1 server: %s sent an inconsistent NT_TRANSACT: %v", conn.Remote, err)
+		return nt_status.NT_STATUS_INVALID_PARAMETER
+	}
+
+	if reassembly.complete() {
+		return conn.runNtTransact(w, req, reassembly)
+	}
+
+	conn.transaction = reassembly
+	logger.Debugf("SMB1 server: %s began a fragmented NT_TRANSACT (function 0x%04X, %d+%d bytes)",
+		conn.Remote, reassembly.subcommand, totalParameters, totalData)
+	return nt_status.NT_STATUS_SUCCESS
+}
+
+// maxNtTransactPayload bounds a reassembled NT_TRANSACT. Its counts are 32-bit, so
+// unlike TRANSACTION2 there is no natural ceiling and one has to be imposed:
+// without it a client could declare four gigabytes and have it allocated.
+const maxNtTransactPayload = 1 << 20
+
+// handleNtTransactSecondary answers SMB_COM_NT_TRANSACT_SECONDARY.
+func handleNtTransactSecondary(conn *Connection, w ResponseWriter, req *message.Message) nt_status.NT_STATUS {
+	request, ok := req.Command.(*commands.NtTransactSecondaryRequest)
+	if !ok {
+		return nt_status.NT_STATUS_INVALID_SMB
+	}
+
+	reassembly := conn.transaction
+	if reassembly == nil || reassembly.family != "NT_TRANSACT" {
+		logger.Debugf("SMB1 server: %s sent an NT_TRANSACT_SECONDARY with no matching transaction in progress",
+			conn.Remote)
+		return nt_status.NT_STATUS_INVALID_SMB
+	}
+	if time.Since(reassembly.started) > transactionReassemblyTimeout {
+		conn.transaction = nil
+		return nt_status.NT_STATUS_IO_TIMEOUT
+	}
+
+	if err := reassembly.place(
+		[]byte(request.NT_Trans_Parameters), int(request.ParameterDisplacement),
+		[]byte(request.NT_Trans_Data), int(request.DataDisplacement),
+	); err != nil {
+		conn.transaction = nil
+		logger.Debugf("SMB1 server: %s sent an inconsistent NT_TRANSACT_SECONDARY: %v", conn.Remote, err)
+		return nt_status.NT_STATUS_INVALID_PARAMETER
+	}
+
+	if !reassembly.complete() {
+		return nt_status.NT_STATUS_SUCCESS
+	}
+
+	conn.transaction = nil
+	return conn.runNtTransact(w, req, reassembly)
+}
+
+// runNtTransact dispatches an assembled NT_TRANSACT to its subcommand.
+func (c *Connection) runNtTransact(w ResponseWriter, req *message.Message, reassembly *transactionReassembly) nt_status.NT_STATUS {
+	handler, ok := ntTransactHandlers[subcommands.NtTransactSubcommand(reassembly.subcommand)]
+	if !ok {
+		logger.Debugf("SMB1 server: %s sent unimplemented NT_TRANSACT function 0x%04X",
+			c.Remote, reassembly.subcommand)
+		return nt_status.NT_STATUS_NOT_IMPLEMENTED
+	}
+
+	parameters, data, status := handler(c, req, reassembly)
+	if status != nt_status.NT_STATUS_SUCCESS {
+		return status
+	}
+
+	if err := c.sendNtTransactResponse(w, reassembly, parameters, data); err != nil {
+		logger.Debugf("SMB1 server: failed to answer the NT_TRANSACT for %s: %v", c.Remote, err)
+	}
+	return nt_status.NT_STATUS_SUCCESS
+}
+
+// ntTransactHandler answers one NT_TRANSACT subcommand.
+type ntTransactHandler func(*Connection, *message.Message, *transactionReassembly) (parameters, data []byte, status nt_status.NT_STATUS)
+
+// ntTransactHandlers maps a function code to its handler.
+//
+// NT_TRANSACT_CREATE, RENAME and the quota subcommands are absent deliberately.
+// Create and rename duplicate commands that already exist in their own right, and
+// nothing here tracks a quota, so answering them would mean inventing a number a
+// client would then believe.
+var ntTransactHandlers = map[subcommands.NtTransactSubcommand]ntTransactHandler{
+	subcommands.NT_TRANSACT_QUERY_SECURITY_DESC: handleQuerySecurityDescriptor,
+	subcommands.NT_TRANSACT_SET_SECURITY_DESC:   handleSetSecurityDescriptor,
+	subcommands.NT_TRANSACT_IOCTL:               handleNtTransactIoctl,
+}
+
+// sendNtTransactResponse sends an NT_TRANSACT result, splitting it across as many
+// messages as it needs.
+func (c *Connection) sendNtTransactResponse(
+	w ResponseWriter,
+	reassembly *transactionReassembly,
+	parameters, data []byte,
+) error {
+	budget := int(c.Server.config.MaxBufferSize) - ntTransactResponseOverhead
+	if budget <= 0 {
+		return fmt.Errorf("the negotiated buffer of %d bytes leaves no room for an NT_TRANSACT response",
+			c.Server.config.MaxBufferSize)
+	}
+	if reassembly.maxDataCount > 0 && reassembly.maxDataCount < budget {
+		budget = reassembly.maxDataCount
+	}
+	if len(parameters) > budget {
+		return fmt.Errorf("the response parameters are %d bytes, over the %d-byte budget", len(parameters), budget)
+	}
+
+	sentData := 0
+	for first := true; first || sentData < len(data); first = false {
+		chunkBudget := budget
+		parameterChunk := []byte{}
+		if first {
+			parameterChunk = parameters
+			chunkBudget -= len(parameters)
+		}
+
+		chunk := len(data) - sentData
+		if chunk > chunkBudget {
+			chunk = chunkBudget
+		}
+		if chunk < 0 {
+			chunk = 0
+		}
+
+		response := commands.NewNtTransactResponse()
+		response.TotalParameterCount = types.ULONG(len(parameters))
+		response.TotalDataCount = types.ULONG(len(data))
+		response.SetupCount = types.UCHAR(0)
+		response.Setup = []types.USHORT{}
+
+		response.ParameterCount = types.ULONG(len(parameterChunk))
+		response.ParameterDisplacement = types.ULONG(0)
+		response.DataCount = types.ULONG(chunk)
+		response.DataDisplacement = types.ULONG(sentData)
+
+		preParameters := header.SMB_HEADER_SIZE + 1 + 2*ntTransactResponseWordCount + 2
+		pad1 := (4 - (preParameters % 4)) % 4
+		parameterOffset := preParameters + pad1
+		response.Pad1 = make([]types.UCHAR, pad1)
+		response.ParameterOffset = types.ULONG(parameterOffset)
+		response.Parameters = []types.UCHAR(parameterChunk)
+
+		afterParameters := parameterOffset + len(parameterChunk)
+		pad2 := (4 - (afterParameters % 4)) % 4
+		response.Pad2 = make([]types.UCHAR, pad2)
+		response.DataOffset = types.ULONG(afterParameters + pad2)
+		response.Data = []types.UCHAR(data[sentData : sentData+chunk])
+
+		if err := w.WriteResponse(response); err != nil {
+			return err
+		}
+
+		sentData += chunk
+		if chunk == 0 && !first {
+			break
+		}
+	}
+
+	return nil
+}
+
+// handleQuerySecurityDescriptor answers NT_TRANSACT_QUERY_SECURITY_DESC.
+//
+// Request parameters: FID(2) Reserved(2) SecurityInformation(4).
+func handleQuerySecurityDescriptor(conn *Connection, req *message.Message, reassembly *transactionReassembly) ([]byte, []byte, nt_status.NT_STATUS) {
+	parameters := reassembly.parameters
+	if len(parameters) < 8 {
+		return nil, nil, nt_status.NT_STATUS_INVALID_PARAMETER
+	}
+
+	fid := binary.LittleEndian.Uint16(parameters[0:2])
+	information := SecurityInformation(binary.LittleEndian.Uint32(parameters[4:8]))
+
+	open, status := conn.openFor(req, fid)
+	if status != nt_status.NT_STATUS_SUCCESS {
+		return nil, nil, status
+	}
+
+	provider := open.Tree.Share.Security
+	if provider == nil {
+		// Saying so is better than inventing a descriptor: a client that receives
+		// one believes it describes the access the server enforces.
+		logger.Debugf("SMB1 server: %s asked for a security descriptor on share %q, which has no security model",
+			conn.Remote, open.Tree.Share.Name)
+		return nil, nil, nt_status.NT_STATUS_NOT_SUPPORTED
+	}
+
+	descriptor, err := provider.SecurityDescriptor(open.Path, information)
+	if err != nil {
+		return nil, nil, statusForFSError(err)
+	}
+
+	// Response parameters: the length of the descriptor. A client that asked for
+	// less than it takes uses this to size a second request.
+	responseParameters := make([]byte, 4)
+	binary.LittleEndian.PutUint32(responseParameters, uint32(len(descriptor)))
+
+	// A client whose buffer is too small is told the size and given no data,
+	// rather than a truncated descriptor it would parse as corrupt.
+	if reassembly.maxDataCount > 0 && len(descriptor) > reassembly.maxDataCount {
+		return responseParameters, nil, nt_status.NT_STATUS_BUFFER_TOO_SMALL
+	}
+
+	return responseParameters, descriptor, nt_status.NT_STATUS_SUCCESS
+}
+
+// handleSetSecurityDescriptor answers NT_TRANSACT_SET_SECURITY_DESC.
+//
+// Request parameters: FID(2) Reserved(2) SecurityInformation(4).
+func handleSetSecurityDescriptor(conn *Connection, req *message.Message, reassembly *transactionReassembly) ([]byte, []byte, nt_status.NT_STATUS) {
+	parameters := reassembly.parameters
+	if len(parameters) < 8 {
+		return nil, nil, nt_status.NT_STATUS_INVALID_PARAMETER
+	}
+
+	fid := binary.LittleEndian.Uint16(parameters[0:2])
+	information := SecurityInformation(binary.LittleEndian.Uint32(parameters[4:8]))
+
+	open, status := conn.openFor(req, fid)
+	if status != nt_status.NT_STATUS_SUCCESS {
+		return nil, nil, status
+	}
+	if open.Tree.Share.ReadOnly {
+		return nil, nil, nt_status.NT_STATUS_MEDIA_WRITE_PROTECTED
+	}
+
+	provider := open.Tree.Share.Security
+	if provider == nil {
+		return nil, nil, nt_status.NT_STATUS_NOT_SUPPORTED
+	}
+
+	if err := provider.SetSecurityDescriptor(open.Path, information, reassembly.data); err != nil {
+		return nil, nil, statusForFSError(err)
+	}
+
+	return nil, nil, nt_status.NT_STATUS_SUCCESS
+}
+
+// handleNtTransactIoctl answers NT_TRANSACT_IOCTL.
+//
+// The setup words carry FunctionCode(4) FID(2) IsFsctl(1) IsFlags(1).
+func handleNtTransactIoctl(conn *Connection, req *message.Message, reassembly *transactionReassembly) ([]byte, []byte, nt_status.NT_STATUS) {
+	if len(reassembly.setup) < 4 {
+		return nil, nil, nt_status.NT_STATUS_INVALID_PARAMETER
+	}
+
+	// The function code spans two setup words, low half first.
+	functionCode := uint32(reassembly.setup[0]) | uint32(reassembly.setup[1])<<16
+	fid := uint16(reassembly.setup[2])
+
+	open, status := conn.openFor(req, fid)
+	if status != nt_status.NT_STATUS_SUCCESS {
+		return nil, nil, status
+	}
+
+	handler, ok := fsctlHandlers[functionCode]
+	if !ok {
+		logger.Debugf("SMB1 server: %s asked for FSCTL 0x%08X, which is not served", conn.Remote, functionCode)
+		// The status a client expects for a control code the device does not
+		// implement, which it treats as "this feature is absent" rather than as a
+		// failure of the request.
+		return nil, nil, nt_status.NT_STATUS_INVALID_DEVICE_REQUEST
+	}
+
+	data, status := handler(conn, open, reassembly.data)
+	return nil, data, status
+}
+
+// fsctlHandler answers one file-system control code.
+type fsctlHandler func(*Connection, *Open, []byte) ([]byte, nt_status.NT_STATUS)
+
+// File-system control codes. Only codes whose answer the server can give
+// truthfully are served: a control that reported a capability the storage does not
+// have would be worse than one that is absent, because a client would use it.
+const (
+	// fsctlGetCompression reports a file's compression state.
+	fsctlGetCompression = 0x0009003C
+	// fsctlIsPathnameValid reports whether a name is usable on the volume.
+	fsctlIsPathnameValid = 0x0009002C
+)
+
+var fsctlHandlers = map[uint32]fsctlHandler{
+	fsctlGetCompression:  fsctlHandleGetCompression,
+	fsctlIsPathnameValid: fsctlHandleIsPathnameValid,
+}
+
+// fsctlHandleGetCompression reports that a file is not compressed, which is true
+// of everything either backend stores.
+func fsctlHandleGetCompression(conn *Connection, open *Open, input []byte) ([]byte, nt_status.NT_STATUS) {
+	// COMPRESSION_FORMAT_NONE.
+	return make([]byte, 2), nt_status.NT_STATUS_SUCCESS
+}
+
+// fsctlHandleIsPathnameValid reports whether a name would be accepted, which is
+// exactly what the path resolver decides — so the answer is the resolver's, rather
+// than a second opinion that could disagree with it.
+func fsctlHandleIsPathnameValid(conn *Connection, open *Open, input []byte) ([]byte, nt_status.NT_STATUS) {
+	if _, err := resolvePath(trimTerminator(string(input))); err != nil {
+		return nil, nt_status.NT_STATUS_OBJECT_NAME_INVALID
+	}
+	return nil, nt_status.NT_STATUS_SUCCESS
+}
+
+// handleNtCancel answers SMB_COM_NT_CANCEL, which asks the server to abandon a
+// request still outstanding.
+//
+// Nothing here leaves a request outstanding: every command is answered before the
+// next is read from the connection. So there is never anything to cancel, and the
+// command is accepted silently — which is what it is defined to do, since a cancel
+// carries no response of its own.
+func handleNtCancel(conn *Connection, w ResponseWriter, req *message.Message) nt_status.NT_STATUS {
+	logger.Debugf("SMB1 server: %s cancelled PID 0x%08X MID 0x%04X, which has nothing outstanding",
+		conn.Remote, req.Header.GetPID(), uint16(req.Header.MID))
+	return nt_status.NT_STATUS_SUCCESS
+}

--- a/network/smb/smb_v10/server/handler_pipe.go
+++ b/network/smb/smb_v10/server/handler_pipe.go
@@ -1,0 +1,443 @@
+package server
+
+import (
+	"encoding/binary"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/TheManticoreProject/Manticore/logger"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/subcommands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+	"github.com/TheManticoreProject/Manticore/windows/fileflags"
+	"github.com/TheManticoreProject/Manticore/windows/nt_status"
+)
+
+// PipeHandler serves the named pipes on an IPC share.
+//
+// A pipe is request-response: a client writes a message and reads the answer,
+// which is how MS-RPC travels over SMB. Transact is the operation that does both
+// in one exchange and the one every RPC client uses, so a handler that implements
+// only that is a complete one for the purpose.
+//
+// A handler is called on the goroutine serving the connection, so an
+// implementation that blocks holds that client up. It may be called concurrently
+// for different connections.
+type PipeHandler interface {
+	// OpenPipe reports whether a pipe exists under this handler, and prepares
+	// whatever per-open state it needs. The name has no leading separator and no
+	// "PIPE" prefix: "srvsvc", not "\\PIPE\\srvsvc".
+	OpenPipe(name string) error
+
+	// Transact writes a message to a pipe and returns the answer. maxOutput is
+	// the largest answer the client can receive; a handler that would exceed it
+	// should return what fits and report that more remains.
+	Transact(name string, input []byte, maxOutput int) (output []byte, moreRemains bool, err error)
+
+	// ClosePipe releases whatever OpenPipe prepared.
+	ClosePipe(name string) error
+}
+
+// pipeNameOf extracts a pipe's name from the path a client opened.
+//
+// A client reaches a pipe by opening "\PIPE\srvsvc" on IPC$, or sometimes
+// "\srvsvc", and the name is matched case-insensitively as Windows does. The
+// leading separator and the "PIPE" element are stripped so a handler sees the name
+// alone.
+func pipeNameOf(path string) string {
+	trimmed := strings.Trim(strings.ReplaceAll(path, "\\", "/"), "/")
+	if upper := strings.ToUpper(trimmed); strings.HasPrefix(upper, "PIPE/") {
+		trimmed = trimmed[len("PIPE/"):]
+	} else if upper == "PIPE" {
+		return ""
+	}
+	return strings.Trim(trimmed, "/")
+}
+
+// handleTransaction answers SMB_COM_TRANSACTION, the family that carries the named
+// pipe operations.
+//
+// Unlike the other two families the subcommand travels in a setup word AND the
+// request names the pipe in its Name field, so both are needed to know what is
+// being asked of what.
+func handleTransaction(conn *Connection, w ResponseWriter, req *message.Message) nt_status.NT_STATUS {
+	request, ok := req.Command.(*commands.TransactionRequest)
+	if !ok {
+		return nt_status.NT_STATUS_INVALID_SMB
+	}
+
+	if len(request.Setup) < 1 {
+		return nt_status.NT_STATUS_INVALID_PARAMETER
+	}
+
+	totalParameters := int(request.TotalParameterCount)
+	totalData := int(request.TotalDataCount)
+	if totalParameters > maxTrans2Payload || totalData > maxTrans2Payload {
+		return nt_status.NT_STATUS_INVALID_PARAMETER
+	}
+
+	reassembly := &transactionReassembly{
+		family:            "TRANSACTION",
+		subcommand:        uint16(request.Setup[0]),
+		parameters:        make([]byte, totalParameters),
+		data:              make([]byte, totalData),
+		maxParameterCount: int(request.MaxParameterCount),
+		maxDataCount:      int(request.MaxDataCount),
+		setup:             request.Setup,
+		// The Name is OEM or UTF-16 according to the request's own flag, as every
+		// other name-carrying field is.
+		name:    decodeWireString(request.Name.Buffer, req.Header.Flags2.IsUnicode()),
+		started: time.Now(),
+	}
+
+	if err := reassembly.place(
+		[]byte(request.Trans_Parameters), 0,
+		[]byte(request.Trans_Data), 0,
+	); err != nil {
+		logger.Debugf("SMB1 server: %s sent an inconsistent TRANSACTION: %v", conn.Remote, err)
+		return nt_status.NT_STATUS_INVALID_PARAMETER
+	}
+
+	if reassembly.complete() {
+		return conn.runTransaction(w, req, reassembly)
+	}
+
+	conn.transaction = reassembly
+	return nt_status.NT_STATUS_SUCCESS
+}
+
+// handleTransactionSecondary answers SMB_COM_TRANSACTION_SECONDARY.
+func handleTransactionSecondary(conn *Connection, w ResponseWriter, req *message.Message) nt_status.NT_STATUS {
+	request, ok := req.Command.(*commands.TransactionSecondaryRequest)
+	if !ok {
+		return nt_status.NT_STATUS_INVALID_SMB
+	}
+
+	reassembly := conn.transaction
+	if reassembly == nil || reassembly.family != "TRANSACTION" {
+		return nt_status.NT_STATUS_INVALID_SMB
+	}
+	if time.Since(reassembly.started) > transactionReassemblyTimeout {
+		conn.transaction = nil
+		return nt_status.NT_STATUS_IO_TIMEOUT
+	}
+
+	// TransactionSecondaryRequest names its blocks Trans2_* even though it belongs
+	// to the TRANSACTION family rather than to TRANSACTION2. The names are
+	// misleading but the fields are the right ones.
+	if err := reassembly.place(
+		[]byte(request.Trans2_Parameters), int(request.ParameterDisplacement),
+		[]byte(request.Trans2_Data), int(request.DataDisplacement),
+	); err != nil {
+		conn.transaction = nil
+		return nt_status.NT_STATUS_INVALID_PARAMETER
+	}
+
+	if !reassembly.complete() {
+		return nt_status.NT_STATUS_SUCCESS
+	}
+
+	conn.transaction = nil
+	return conn.runTransaction(w, req, reassembly)
+}
+
+// runTransaction dispatches an assembled TRANSACTION to its pipe operation.
+func (c *Connection) runTransaction(w ResponseWriter, req *message.Message, reassembly *transactionReassembly) nt_status.NT_STATUS {
+	tree := c.Tree(uint16(req.Header.TID))
+	if tree == nil {
+		return nt_status.NT_STATUS_SMB_BAD_TID
+	}
+	if tree.Share.Type != ShareTypeNamedPipe {
+		logger.Debugf("SMB1 server: %s sent a pipe transaction on share %q, which is a %q share",
+			c.Remote, tree.Share.Name, tree.Share.Type)
+		return nt_status.NT_STATUS_BAD_DEVICE_TYPE
+	}
+	if tree.Share.Pipes == nil {
+		return nt_status.NT_STATUS_NOT_SUPPORTED
+	}
+
+	switch subcommands.TransactionSubcommand(reassembly.subcommand) {
+	case subcommands.TRANS_TRANSACT_NMPIPE:
+		return c.transactNamedPipe(w, req, tree, reassembly)
+
+	case subcommands.TRANS_WAIT_NMPIPE:
+		// The pipe is available as soon as the handler knows the name, so waiting
+		// for it succeeds immediately rather than blocking on nothing.
+		name := pipeNameOf(reassembly.name)
+		if err := tree.Share.Pipes.OpenPipe(name); err != nil {
+			return nt_status.NT_STATUS_OBJECT_NAME_NOT_FOUND
+		}
+		return c.answerTransaction(w, reassembly, nil, nil)
+
+	case subcommands.TRANS_QUERY_NMPIPE_STATE:
+		// A message-mode, blocking, client-end pipe with unlimited instances,
+		// which is what an RPC client expects to find.
+		state := make([]byte, 2)
+		binary.LittleEndian.PutUint16(state, pipeStateMessageMode)
+		return c.answerTransaction(w, reassembly, state, nil)
+
+	case subcommands.TRANS_SET_NMPIPE_STATE:
+		// Accepted and ignored: the only state a client sets is blocking mode and
+		// read mode, and both are already what this reports.
+		return c.answerTransaction(w, reassembly, nil, nil)
+	}
+
+	logger.Debugf("SMB1 server: %s sent unimplemented pipe operation 0x%04X", c.Remote, reassembly.subcommand)
+	return nt_status.NT_STATUS_NOT_IMPLEMENTED
+}
+
+// pipeStateMessageMode is the NMPIPE_STATE a query reports: message-type pipe,
+// message-mode reads, blocking, unlimited instances ([MS-CIFS] 2.2.7.2).
+const pipeStateMessageMode = 0x0500
+
+// transactNamedPipe answers TRANS_TRANSACT_NMPIPE: it writes the request's data to
+// a pipe and returns the answer as the response data.
+//
+// This is the operation MS-RPC travels over, so it is the one that matters: an RPC
+// bind and every call after it is a write-then-read on one pipe, which this does
+// in a single exchange.
+func (c *Connection) transactNamedPipe(
+	w ResponseWriter,
+	req *message.Message,
+	tree *Tree,
+	reassembly *transactionReassembly,
+) nt_status.NT_STATUS {
+	// [MS-CIFS] section 3.3.5.57.7 is explicit about which pipe is acted on: the
+	// one "identified by the SMB_Parameters.Words.Setup.FID field of the request",
+	// which is Setup[1] behind the subcommand. So the handle the client opened is
+	// what names the pipe, and the request's Name field is boilerplate — the
+	// subcommand sets it to "\PIPE\", which names nothing on its own.
+	name := ""
+	if len(reassembly.setup) >= 2 {
+		open := c.Open(uint16(reassembly.setup[1]))
+		switch {
+		case open == nil:
+			logger.Debugf("SMB1 server: %s sent a pipe transaction on FID 0x%04X, which is not open",
+				c.Remote, uint16(reassembly.setup[1]))
+			return nt_status.NT_STATUS_SMB_BAD_FID
+		case !open.IsPipe:
+			logger.Debugf("SMB1 server: %s sent a pipe transaction on FID 0x%04X, which is a file",
+				c.Remote, uint16(reassembly.setup[1]))
+			return nt_status.NT_STATUS_INVALID_HANDLE
+		default:
+			name = open.Path
+		}
+	}
+	// A client that sent no FID may still have named the pipe outright. That is
+	// not what the subcommand specifies, but answering it costs nothing and a
+	// client that does it has said unambiguously what it means.
+	if name == "" {
+		name = pipeNameOf(reassembly.name)
+	}
+	if name == "" {
+		logger.Debugf("SMB1 server: %s sent a pipe transaction naming no pipe", c.Remote)
+		return nt_status.NT_STATUS_OBJECT_NAME_NOT_FOUND
+	}
+
+	budget := reassembly.maxDataCount
+	if budget <= 0 || budget > maxTrans2Payload {
+		budget = maxTrans2Payload
+	}
+
+	output, moreRemains, err := tree.Share.Pipes.Transact(name, reassembly.data, budget)
+	if err != nil {
+		logger.Debugf("SMB1 server: pipe %q refused a transaction from %s: %v", name, c.Remote, err)
+		return statusForPipeError(err)
+	}
+
+	// What the client is told about a truncated answer is the whole difference
+	// between a working RPC conversation and a stuck one. [MS-CIFS] section
+	// 3.3.5.57.7: on STATUS_BUFFER_OVERFLOW the server still "MUST construct a
+	// TRANS_TRANSACT_NMPIPE Response" — the status travels alongside the data
+	// rather than instead of it, and it is what tells the client to read again.
+	status := nt_status.NT_STATUS_SUCCESS
+	if moreRemains {
+		status = nt_status.NT_STATUS_BUFFER_OVERFLOW
+		logger.Debugf("SMB1 server: pipe %q has more to return to %s", name, c.Remote)
+	}
+
+	if err := c.sendTransactionResponse(w, reassembly, nil, output, status); err != nil {
+		logger.Debugf("SMB1 server: failed to answer the pipe transaction for %s: %v", c.Remote, err)
+	}
+	// The response has been sent, status included, so the dispatcher must not send
+	// an error response on top of it.
+	return nt_status.NT_STATUS_SUCCESS
+}
+
+// statusForPipeError maps a handler's failure onto the status a client expects.
+func statusForPipeError(err error) nt_status.NT_STATUS {
+	switch {
+	case err == nil:
+		return nt_status.NT_STATUS_SUCCESS
+	case strings.Contains(err.Error(), "not found"):
+		return nt_status.NT_STATUS_OBJECT_NAME_NOT_FOUND
+	}
+	return nt_status.NT_STATUS_UNSUCCESSFUL
+}
+
+// answerTransaction sends a transaction result and reports success, for the
+// branches whose only failure would be a connection already going away.
+func (c *Connection) answerTransaction(w ResponseWriter, reassembly *transactionReassembly, parameters, data []byte) nt_status.NT_STATUS {
+	if err := c.sendTransactionResponse(w, reassembly, parameters, data, nt_status.NT_STATUS_SUCCESS); err != nil {
+		logger.Debugf("SMB1 server: failed to answer the pipe transaction for %s: %v", c.Remote, err)
+	}
+	return nt_status.NT_STATUS_SUCCESS
+}
+
+// sendTransactionResponse sends a TRANSACTION result, splitting it across as many
+// messages as it needs.
+// The status is carried on the response itself rather than in place of it, which
+// STATUS_BUFFER_OVERFLOW requires: it means "here is what fits, ask again".
+func (c *Connection) sendTransactionResponse(
+	w ResponseWriter,
+	reassembly *transactionReassembly,
+	parameters, data []byte,
+	status nt_status.NT_STATUS,
+) error {
+	const wordCount = 10
+
+	budget := int(c.Server.config.MaxBufferSize) - trans2ResponseOverhead
+	if budget <= 0 {
+		return fmt.Errorf("the negotiated buffer leaves no room for a transaction response")
+	}
+	if reassembly.maxDataCount > 0 && reassembly.maxDataCount < budget {
+		budget = reassembly.maxDataCount
+	}
+	if len(parameters) > budget {
+		return fmt.Errorf("the response parameters are %d bytes, over the %d-byte budget", len(parameters), budget)
+	}
+
+	sentData := 0
+	for first := true; first || sentData < len(data); first = false {
+		chunkBudget := budget
+		parameterChunk := []byte{}
+		if first {
+			parameterChunk = parameters
+			chunkBudget -= len(parameters)
+		}
+
+		chunk := len(data) - sentData
+		if chunk > chunkBudget {
+			chunk = chunkBudget
+		}
+		if chunk < 0 {
+			chunk = 0
+		}
+
+		response := commands.NewTransactionResponse()
+		response.TotalParameterCount = types.USHORT(len(parameters))
+		response.TotalDataCount = types.USHORT(len(data))
+		response.SetupCount = types.UCHAR(0)
+		response.Setup = []types.USHORT{}
+		response.ParameterCount = types.USHORT(len(parameterChunk))
+		response.ParameterDisplacement = types.USHORT(0)
+		response.DataCount = types.USHORT(chunk)
+		response.DataDisplacement = types.USHORT(sentData)
+
+		preParameters := header.SMB_HEADER_SIZE + 1 + 2*wordCount + 2
+		pad1 := (4 - (preParameters % 4)) % 4
+		parameterOffset := preParameters + pad1
+		response.Pad1 = make([]types.UCHAR, pad1)
+		response.ParameterOffset = types.USHORT(parameterOffset)
+		response.Trans_Parameters = []types.UCHAR(parameterChunk)
+
+		afterParameters := parameterOffset + len(parameterChunk)
+		pad2 := (4 - (afterParameters % 4)) % 4
+		response.Pad2 = make([]types.UCHAR, pad2)
+		response.DataOffset = types.USHORT(afterParameters + pad2)
+		response.Trans_Data = []types.UCHAR(data[sentData : sentData+chunk])
+
+		var err error
+		if status == nt_status.NT_STATUS_SUCCESS {
+			err = w.WriteResponse(response)
+		} else {
+			err = w.WriteResponseWithStatus(response, status)
+		}
+		if err != nil {
+			return err
+		}
+
+		sentData += chunk
+		if chunk == 0 && !first {
+			break
+		}
+	}
+
+	return nil
+}
+
+// openPipe answers an NT_CREATE_ANDX against a pipe share.
+//
+// The handle it returns is the point of the exchange: [MS-CIFS] section 3.3.5.57.7
+// identifies the pipe a transaction acts on by the FID in the request's setup
+// words, so a client has to open the pipe before it can transact on it. This is
+// the first half of every MS-RPC conversation over SMB1.
+func (c *Connection) openPipe(w ResponseWriter, tree *Tree, requested string) nt_status.NT_STATUS {
+	if tree.Share.Pipes == nil {
+		logger.Debugf("SMB1 server: %s asked to open a pipe on share %q, which serves none",
+			c.Remote, tree.Share.Name)
+		return nt_status.NT_STATUS_NOT_SUPPORTED
+	}
+
+	name := pipeNameOf(requested)
+	if name == "" {
+		return nt_status.NT_STATUS_OBJECT_NAME_INVALID
+	}
+
+	if err := tree.Share.Pipes.OpenPipe(name); err != nil {
+		logger.Debugf("SMB1 server: %s could not open pipe %q: %v", c.Remote, name, err)
+		return statusForPipeError(err)
+	}
+
+	fid, err := c.fids.Allocate()
+	if err != nil {
+		// The handler prepared state for a handle that will not exist, so give it
+		// back rather than leaking it for the life of the connection.
+		if closeErr := tree.Share.Pipes.ClosePipe(name); closeErr != nil {
+			logger.Debugf("SMB1 server: releasing pipe %q after a failed open reported %v", name, closeErr)
+		}
+		logger.Warnf("SMB1 server: refusing a pipe open from %s: %v", c.Remote, err)
+		return nt_status.NT_STATUS_TOO_MANY_OPENED_FILES
+	}
+
+	open := &Open{
+		FID:  fid,
+		Tree: tree,
+		// The name is stored as the handler sees it, since that is what every
+		// later call passes back to the handler.
+		Path:     name,
+		IsPipe:   true,
+		Readable: true,
+		Writable: true,
+		Created:  time.Now().UTC(),
+	}
+	c.addOpen(open)
+
+	logger.Debugf("SMB1 server: %s opened pipe %q on %q as FID 0x%04X", c.Remote, name, tree.Share.Name, fid)
+
+	response := commands.NewNtCreateAndxResponse()
+	response.FID = types.USHORT(fid)
+	response.CreateDisposition = types.ULONG(fileflags.FILE_OPEN)
+	// A message-mode pipe, which is the only kind a transacted exchange may run
+	// against ([MS-CIFS] section 2.2.5.6).
+	response.ResourceType = types.USHORT(resourceTypeMessageModePipe)
+	response.NMPipeStatus = types.SMB_NMPIPE_STATUS{
+		// ICount is the instance count; Flags carries the high half of the 16-bit
+		// status, which is where the read-mode and pipe-type fields live.
+		ICount: uint8(pipeStateMessageMode & 0xFF),
+		Flags:  uint8(pipeStateMessageMode >> 8),
+	}
+	response.ExtFileAttributes = types.SMB_EXT_FILE_ATTR(fileflags.FILE_ATTRIBUTE_NORMAL)
+
+	if err := w.WriteResponse(response); err != nil {
+		logger.Debugf("SMB1 server: failed to answer the pipe open for %s: %v", c.Remote, err)
+	}
+	return nt_status.NT_STATUS_SUCCESS
+}
+
+// resourceTypeMessageModePipe is the ResourceType an open reports for a pipe that
+// carries messages rather than a byte stream ([MS-CIFS] section 2.2.4.64.2).
+const resourceTypeMessageModePipe = 0x0002

--- a/network/smb/smb_v10/server/handler_trans2.go
+++ b/network/smb/smb_v10/server/handler_trans2.go
@@ -35,14 +35,28 @@ const (
 	// claimed total from becoming an allocation.
 	maxTrans2Payload = 0xFFFF
 
-	// trans2ReassemblyTimeout bounds how long a half-delivered transaction is
+	// transactionReassemblyTimeout bounds how long a half-delivered transaction is
 	// held. A client that starts one and stops would otherwise pin the memory for
 	// as long as the connection lasts.
-	trans2ReassemblyTimeout = 30 * time.Second
+	transactionReassemblyTimeout = 30 * time.Second
 )
 
-// trans2Reassembly is a transaction being received across several messages.
-type trans2Reassembly struct {
+// transactionReassembly is a transaction being received across several messages.
+//
+// All three transaction families — TRANSACTION, TRANSACTION2 and NT_TRANSACT —
+// carry the same shape: running totals, a per-message count, and a displacement
+// saying where the message's bytes belong. They differ only in the width of those
+// fields and in how the subcommand is named. So the reassembly is shared and each
+// family's handler extracts the fields, which keeps the arithmetic that is easy to
+// get wrong in one place.
+type transactionReassembly struct {
+	// family names which transaction this is, for the log line that reports a
+	// malformed one.
+	family string
+
+	// subcommand is the selector the family carries: a setup word for
+	// TRANSACTION2, a function code for NT_TRANSACT, a pipe operation for
+	// TRANSACTION.
 	subcommand uint16
 
 	// parameters and data are the blocks being filled in, sized to the totals the
@@ -60,11 +74,19 @@ type trans2Reassembly struct {
 	maxParameterCount int
 	maxDataCount      int
 
+	// setup holds the family's setup words, which some subcommands carry their
+	// arguments in rather than in the parameter block.
+	setup []types.USHORT
+
+	// name is the resource a TRANSACTION names, which is how a client says which
+	// pipe it is talking to. The other two families carry no name.
+	name string
+
 	started time.Time
 }
 
 // complete reports whether every declared byte has arrived.
-func (r *trans2Reassembly) complete() bool {
+func (r *transactionReassembly) complete() bool {
 	return r.parametersSeen >= len(r.parameters) && r.dataSeen >= len(r.data)
 }
 
@@ -74,7 +96,7 @@ func (r *trans2Reassembly) complete() bool {
 // rather than clamped: it means the client's own arithmetic disagrees with itself,
 // and guessing which half to believe would let a fragment land somewhere it was
 // not meant to.
-func (r *trans2Reassembly) place(
+func (r *transactionReassembly) place(
 	parameters []byte, parameterDisplacement int,
 	data []byte, dataDisplacement int,
 ) error {
@@ -126,7 +148,8 @@ func handleTransaction2(conn *Connection, w ResponseWriter, req *message.Message
 		return nt_status.NT_STATUS_INVALID_PARAMETER
 	}
 
-	reassembly := &trans2Reassembly{
+	reassembly := &transactionReassembly{
+		family:            "TRANSACTION2",
 		subcommand:        subcommand,
 		parameters:        make([]byte, totalParameters),
 		data:              make([]byte, totalData),
@@ -153,7 +176,7 @@ func handleTransaction2(conn *Connection, w ResponseWriter, req *message.Message
 	// More is coming. Only one transaction is tracked at a time: [MS-CIFS] has a
 	// client complete one before starting another, and holding several would let a
 	// client pin memory by opening many and finishing none.
-	conn.trans2 = reassembly
+	conn.transaction = reassembly
 	logger.Debugf("SMB1 server: %s began a fragmented TRANSACTION2 (subcommand 0x%04X, %d+%d bytes)",
 		conn.Remote, subcommand, totalParameters, totalData)
 
@@ -170,13 +193,13 @@ func handleTransaction2Secondary(conn *Connection, w ResponseWriter, req *messag
 		return nt_status.NT_STATUS_INVALID_SMB
 	}
 
-	reassembly := conn.trans2
+	reassembly := conn.transaction
 	if reassembly == nil {
 		logger.Debugf("SMB1 server: %s sent a TRANSACTION2_SECONDARY with no transaction in progress", conn.Remote)
 		return nt_status.NT_STATUS_INVALID_SMB
 	}
-	if time.Since(reassembly.started) > trans2ReassemblyTimeout {
-		conn.trans2 = nil
+	if time.Since(reassembly.started) > transactionReassemblyTimeout {
+		conn.transaction = nil
 		logger.Debugf("SMB1 server: %s continued a TRANSACTION2 that had timed out", conn.Remote)
 		return nt_status.NT_STATUS_IO_TIMEOUT
 	}
@@ -185,7 +208,7 @@ func handleTransaction2Secondary(conn *Connection, w ResponseWriter, req *messag
 		[]byte(request.Trans2_Parameters), int(request.ParameterDisplacement),
 		[]byte(request.Trans2_Data), int(request.DataDisplacement),
 	); err != nil {
-		conn.trans2 = nil
+		conn.transaction = nil
 		logger.Debugf("SMB1 server: %s sent an inconsistent TRANSACTION2_SECONDARY: %v", conn.Remote, err)
 		return nt_status.NT_STATUS_INVALID_PARAMETER
 	}
@@ -194,13 +217,13 @@ func handleTransaction2Secondary(conn *Connection, w ResponseWriter, req *messag
 		return nt_status.NT_STATUS_SUCCESS
 	}
 
-	conn.trans2 = nil
+	conn.transaction = nil
 	return conn.runTransaction2(w, req, reassembly)
 }
 
 // runTransaction2 dispatches a fully assembled transaction to its subcommand and
 // sends the result back, fragmenting the response if it does not fit.
-func (c *Connection) runTransaction2(w ResponseWriter, req *message.Message, reassembly *trans2Reassembly) nt_status.NT_STATUS {
+func (c *Connection) runTransaction2(w ResponseWriter, req *message.Message, reassembly *transactionReassembly) nt_status.NT_STATUS {
 	handler, ok := trans2Handlers[subcommands.Transaction2Subcommand(reassembly.subcommand)]
 	if !ok {
 		logger.Debugf("SMB1 server: %s sent unimplemented TRANSACTION2 subcommand 0x%04X",
@@ -221,7 +244,7 @@ func (c *Connection) runTransaction2(w ResponseWriter, req *message.Message, rea
 
 // trans2Handler answers one TRANSACTION2 subcommand, returning the parameter and
 // data blocks to send back.
-type trans2Handler func(*Connection, *message.Message, *trans2Reassembly) (parameters, data []byte, status nt_status.NT_STATUS)
+type trans2Handler func(*Connection, *message.Message, *transactionReassembly) (parameters, data []byte, status nt_status.NT_STATUS)
 
 // trans2Handlers maps a subcommand to its handler. A subcommand with no entry is
 // answered with STATUS_NOT_IMPLEMENTED, which for the DFS and OS/2-era
@@ -244,7 +267,7 @@ var trans2Handlers = map[subcommands.Transaction2Subcommand]trans2Handler{
 // start of the SMB header, which is what the client reads them as.
 func (c *Connection) sendTransaction2Response(
 	w ResponseWriter,
-	reassembly *trans2Reassembly,
+	reassembly *transactionReassembly,
 	parameters, data []byte,
 ) error {
 	// What the client said it can receive bounds each message, and so does the

--- a/network/smb/smb_v10/server/nttransact_test.go
+++ b/network/smb/smb_v10/server/nttransact_test.go
@@ -1,0 +1,786 @@
+package server
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+
+	smb1client "github.com/TheManticoreProject/Manticore/network/smb/smb_v10/client"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/codes"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header/flags2"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/subcommands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+	"github.com/TheManticoreProject/Manticore/windows/credentials"
+	"github.com/TheManticoreProject/Manticore/windows/fileflags"
+	"github.com/TheManticoreProject/Manticore/windows/nt_status"
+	"github.com/TheManticoreProject/winacl/securitydescriptor"
+)
+
+// echoPipe is a PipeHandler that returns whatever is written to it, which is the
+// smallest handler that exercises the whole path a request-response pipe takes.
+type echoPipe struct {
+	mutex sync.Mutex
+
+	// names are the pipes this handler serves; anything else is unknown.
+	names map[string]bool
+
+	// opened and closed record the calls, so a test can assert the lifecycle.
+	opened []string
+	closed []string
+
+	// prefix is prepended to every answer, so a test can tell the handler's
+	// output from its input.
+	prefix string
+
+	// truncateAt, when positive, caps an answer and reports that more remains.
+	truncateAt int
+}
+
+func newEchoPipe(names ...string) *echoPipe {
+	served := map[string]bool{}
+	for _, name := range names {
+		served[strings.ToLower(name)] = true
+	}
+	return &echoPipe{names: served, prefix: "echo:"}
+}
+
+func (p *echoPipe) OpenPipe(name string) error {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+	if !p.names[strings.ToLower(name)] {
+		return fmt.Errorf("pipe %q not found", name)
+	}
+	p.opened = append(p.opened, name)
+	return nil
+}
+
+func (p *echoPipe) Transact(name string, input []byte, maxOutput int) ([]byte, bool, error) {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+	if !p.names[strings.ToLower(name)] {
+		return nil, false, fmt.Errorf("pipe %q not found", name)
+	}
+
+	answer := append([]byte(p.prefix), input...)
+	if p.truncateAt > 0 && len(answer) > p.truncateAt {
+		return answer[:p.truncateAt], true, nil
+	}
+	if len(answer) > maxOutput {
+		return answer[:maxOutput], true, nil
+	}
+	return answer, false, nil
+}
+
+func (p *echoPipe) ClosePipe(name string) error {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+	p.closed = append(p.closed, name)
+	return nil
+}
+
+// openedNames and closedNames report the lifecycle calls the handler saw.
+func (p *echoPipe) openedNames() []string {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+	return append([]string(nil), p.opened...)
+}
+
+func (p *echoPipe) closedNames() []string {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+	return append([]string(nil), p.closed...)
+}
+
+// pipeServer stands up a server with an IPC share served by the given handler, and
+// returns a client connected to it.
+func pipeServer(t *testing.T, pipes PipeHandler) (*Server, *smb1client.Client) {
+	t.Helper()
+
+	srv, transportEnd := pipedServer(t, conformanceConfig(SigningDisabled))
+	if err := srv.AddShare(&Share{Name: "IPC$", Type: ShareTypeNamedPipe, Pipes: pipes}); err != nil {
+		t.Fatalf("AddShare() error = %v", err)
+	}
+
+	client := smb1client.NewFromTransport(transportEnd, net.IPv4(127, 0, 0, 1), 445)
+	if err := client.Negotiate(); err != nil {
+		t.Fatalf("Negotiate() error = %v", err)
+	}
+	creds, err := credentials.NewCredentials(captureDomain, captureUsername, capturePassword, "")
+	if err != nil {
+		t.Fatalf("NewCredentials() error = %v", err)
+	}
+	if err := client.SessionSetup(creds); err != nil {
+		t.Fatalf("SessionSetup() error = %v", err)
+	}
+	if err := client.TreeConnect("IPC$"); err != nil {
+		t.Fatalf("TreeConnect() error = %v", err)
+	}
+
+	return srv, client
+}
+
+// openPipeHandle opens a pipe over SMB and returns the FID the server assigned.
+//
+// This is the first half of the exchange the phase exists for: the FID is what a
+// transaction names, per [MS-CIFS] section 3.3.5.57.7.
+func openPipeHandle(t *testing.T, client *smb1client.Client, pipeName string) (smb1client.FID, error) {
+	t.Helper()
+
+	fid, err := client.OpenFile(pipeName, fileflags.GENERIC_READ|fileflags.GENERIC_WRITE,
+		fileflags.FILE_SHARE_READ|fileflags.FILE_SHARE_WRITE,
+		fileflags.FILE_OPEN, fileflags.FILE_NON_DIRECTORY_FILE)
+	if err != nil {
+		return 0, err
+	}
+	return fid, nil
+}
+
+// transactPipe sends a TRANS_TRANSACT_NMPIPE against an open pipe handle and
+// returns the response's data block and status.
+//
+// The pipe is named by the FID in Setup[1]; the Name field carries "\PIPE\" as
+// the subcommand specifies, which is exactly what a real client sends.
+func transactPipe(t *testing.T, client *smb1client.Client, fid smb1client.FID, payload []byte) ([]byte, uint32) {
+	t.Helper()
+	return transactPipeNamed(t, client, fid, `\PIPE\`, payload)
+}
+
+// transactPipeNamed is transactPipe with control over the Name field, so a test
+// can send a request that names the pipe rather than passing a handle.
+func transactPipeNamed(t *testing.T, client *smb1client.Client, fid smb1client.FID, name string, payload []byte) ([]byte, uint32) {
+	t.Helper()
+
+	setup := []types.USHORT{types.USHORT(subcommands.TRANS_TRANSACT_NMPIPE)}
+	if fid != 0 {
+		setup = append(setup, types.USHORT(fid))
+	}
+
+	response, status := sendTransaction(t, client, setup, name, nil, payload)
+	if status != 0 {
+		return nil, status
+	}
+	return []byte(response.Trans_Data), 0
+}
+
+// sendTransaction sends one SMB_COM_TRANSACTION and returns the decoded response,
+// or the status it was refused with.
+func sendTransaction(
+	t *testing.T,
+	client *smb1client.Client,
+	setup []types.USHORT,
+	name string,
+	parameters, data []byte,
+) (*commands.TransactionResponse, uint32) {
+	t.Helper()
+
+	request := newRequest(codes.SMB_COM_TRANSACTION)
+	request.Header.UID = client.Session.SessionUID
+	request.Header.TID = client.Session.TreeID
+	// The name is sent OEM, so the server must read it that way.
+	request.Header.Flags2 &^= flags2.Flags2(flags2.FLAGS2_UNICODE)
+
+	transaction := commands.NewTransactionRequest()
+	transaction.Setup = setup
+	transaction.SetupCount = types.UCHAR(len(setup))
+	transaction.MaxParameterCount = 1024
+	transaction.MaxDataCount = 4096
+	if err := transaction.Name.SetString(name); err != nil {
+		t.Fatalf("Name.SetString() error = %v", err)
+	}
+	transaction.TotalParameterCount = types.USHORT(len(parameters))
+	transaction.ParameterCount = types.USHORT(len(parameters))
+	transaction.Trans_Parameters = parameters
+	transaction.TotalDataCount = types.USHORT(len(data))
+	transaction.DataCount = types.USHORT(len(data))
+	transaction.Trans_Data = data
+	request.AddCommand(transaction)
+
+	marshalled, err := request.Marshal()
+	if err != nil {
+		t.Fatalf("failed to marshal the transaction: %v", err)
+	}
+	if _, err := client.Transport.Send(marshalled); err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+
+	raw, err := client.Transport.Receive()
+	if err != nil {
+		t.Fatalf("Receive() error = %v", err)
+	}
+	response := message.NewMessage()
+	if err := response.Unmarshal(raw); err != nil {
+		t.Fatalf("failed to decode the response: %v", err)
+	}
+	if response.Header.Status != 0 && response.Header.Status != uint32(nt_status.NT_STATUS_BUFFER_OVERFLOW) {
+		return nil, response.Header.Status
+	}
+
+	transactionResponse, ok := response.Command.(*commands.TransactionResponse)
+	if !ok {
+		t.Fatalf("response command is %T", response.Command)
+	}
+	return transactionResponse, response.Header.Status
+}
+
+// TestNamedPipeTransact is what this phase exists for: a request-response pipe
+// reached over SMB, which is the path MS-RPC travels.
+//
+// It is the whole exchange, in the order a real client performs it: open the pipe
+// on IPC$, transact on the handle, close it.
+func TestNamedPipeTransact(t *testing.T) {
+	pipes := newEchoPipe("srvsvc", "lsarpc")
+	_, client := pipeServer(t, pipes)
+
+	fid, err := openPipeHandle(t, client, `\PIPE\srvsvc`)
+	if err != nil {
+		t.Fatalf("opening the pipe failed: %v", err)
+	}
+
+	payload := []byte("an rpc bind would go here")
+	answer, status := transactPipe(t, client, fid, payload)
+	if status != 0 {
+		t.Fatalf("the pipe transaction answered 0x%08X, want success", status)
+	}
+
+	want := append([]byte("echo:"), payload...)
+	if !bytes.Equal(answer, want) {
+		t.Fatalf("the pipe returned %q, want %q", answer, want)
+	}
+
+	if err := client.CloseFile(fid); err != nil {
+		t.Fatalf("closing the pipe failed: %v", err)
+	}
+
+	// The handler's lifecycle calls are what prove the handle was a pipe handle
+	// and not something the file path happened to accept.
+	if got := pipes.openedNames(); len(got) != 1 || got[0] != "srvsvc" {
+		t.Errorf("the handler was asked to open %v, want [srvsvc]", got)
+	}
+	if got := pipes.closedNames(); len(got) != 1 || got[0] != "srvsvc" {
+		t.Errorf("the handler was asked to close %v, want [srvsvc]", got)
+	}
+}
+
+// TestNamedPipeNameForms asserts the forms a client names a pipe in all reach the
+// same handler, since clients differ in how much of the path they send.
+func TestNamedPipeNameForms(t *testing.T) {
+	for _, form := range []string{`\PIPE\srvsvc`, `\pipe\srvsvc`, `\srvsvc`, "srvsvc", "/PIPE/srvsvc"} {
+		form := form
+		t.Run(form, func(t *testing.T) {
+			pipes := newEchoPipe("srvsvc")
+			_, client := pipeServer(t, pipes)
+
+			fid, err := openPipeHandle(t, client, form)
+			if err != nil {
+				t.Fatalf("naming the pipe %q failed to open: %v", form, err)
+			}
+			answer, status := transactPipe(t, client, fid, []byte("x"))
+			if status != 0 {
+				t.Fatalf("naming the pipe %q answered 0x%08X", form, status)
+			}
+			if !bytes.Equal(answer, []byte("echo:x")) {
+				t.Fatalf("naming the pipe %q returned %q", form, answer)
+			}
+		})
+	}
+}
+
+// TestNamedPipeUnknownIsRefused asserts a pipe the handler does not serve is
+// refused, and that a share with no handler refuses every pipe operation.
+func TestNamedPipeUnknownIsRefused(t *testing.T) {
+	t.Run("unknown pipe", func(t *testing.T) {
+		_, client := pipeServer(t, newEchoPipe("srvsvc"))
+		if _, err := openPipeHandle(t, client, `\PIPE\nosuchpipe`); err == nil {
+			t.Fatal("a pipe the handler does not serve was opened")
+		}
+	})
+
+	t.Run("share with no handler", func(t *testing.T) {
+		srv, transportEnd := pipedServer(t, conformanceConfig(SigningDisabled))
+		if err := srv.AddShare(&Share{Name: "IPC$", Type: ShareTypeNamedPipe}); err != nil {
+			t.Fatalf("AddShare() error = %v", err)
+		}
+		client := smb1client.NewFromTransport(transportEnd, net.IPv4(127, 0, 0, 1), 445)
+		if err := client.Negotiate(); err != nil {
+			t.Fatalf("Negotiate() error = %v", err)
+		}
+		creds, _ := credentials.NewCredentials(captureDomain, captureUsername, capturePassword, "")
+		if err := client.SessionSetup(creds); err != nil {
+			t.Fatalf("SessionSetup() error = %v", err)
+		}
+		if err := client.TreeConnect("IPC$"); err != nil {
+			t.Fatalf("TreeConnect() error = %v", err)
+		}
+		if _, err := openPipeHandle(t, client, `\PIPE\srvsvc`); err == nil {
+			t.Fatal("a share with no pipe handler opened a pipe")
+		}
+	})
+}
+
+// TestNamedPipeTransactRequiresAPipeHandle asserts a transaction on something that
+// is not an open pipe is refused rather than guessed at.
+//
+// The FID is what identifies the pipe, so a request that carries the wrong one
+// must fail: answering it from the Name field instead would let a client act on a
+// pipe it never opened.
+func TestNamedPipeTransactRequiresAPipeHandle(t *testing.T) {
+	t.Run("a FID that is not open", func(t *testing.T) {
+		_, client := pipeServer(t, newEchoPipe("srvsvc"))
+		if _, status := transactPipe(t, client, 0x0999, []byte("x")); status == 0 {
+			t.Fatal("a transaction on an unopened FID was answered")
+		}
+	})
+
+	t.Run("a FID that is a file", func(t *testing.T) {
+		fs := NewMemoryFileSystem("FILES")
+		if err := fs.AddFile("notapipe.txt", []byte("x")); err != nil {
+			t.Fatalf("AddFile() error = %v", err)
+		}
+		srv, transportEnd := pipedServer(t, conformanceConfig(SigningDisabled))
+		if err := srv.AddShare(&Share{Name: fileShareName, Type: ShareTypeDisk, FS: fs}); err != nil {
+			t.Fatalf("AddShare() error = %v", err)
+		}
+		if err := srv.AddShare(&Share{Name: "IPC$", Type: ShareTypeNamedPipe, Pipes: newEchoPipe("srvsvc")}); err != nil {
+			t.Fatalf("AddShare() error = %v", err)
+		}
+
+		client := smb1client.NewFromTransport(transportEnd, net.IPv4(127, 0, 0, 1), 445)
+		if err := client.Negotiate(); err != nil {
+			t.Fatalf("Negotiate() error = %v", err)
+		}
+		creds, _ := credentials.NewCredentials(captureDomain, captureUsername, capturePassword, "")
+		if err := client.SessionSetup(creds); err != nil {
+			t.Fatalf("SessionSetup() error = %v", err)
+		}
+		if err := client.TreeConnect(fileShareName); err != nil {
+			t.Fatalf("TreeConnect() error = %v", err)
+		}
+		fileFID, err := client.OpenFile("notapipe.txt", fileflags.GENERIC_READ, fileflags.FILE_SHARE_READ,
+			fileflags.FILE_OPEN, fileflags.FILE_NON_DIRECTORY_FILE)
+		if err != nil {
+			t.Fatalf("OpenFile() error = %v", err)
+		}
+		fileTID := client.Session.TreeID
+
+		// Move onto the pipe share, but hand the transaction the file's handle.
+		if err := client.TreeConnect("IPC$"); err != nil {
+			t.Fatalf("TreeConnect(IPC$) error = %v", err)
+		}
+		if client.Session.TreeID == fileTID {
+			t.Fatal("the second tree connect returned the same TID")
+		}
+		if _, status := transactPipe(t, client, fileFID, []byte("x")); status == 0 {
+			t.Fatal("a transaction on a file handle was answered as a pipe")
+		}
+	})
+}
+
+// TestNamedPipeOnDiskShareIsRefused asserts a pipe operation on a disk share is
+// refused, rather than being attempted against a file system.
+func TestNamedPipeOnDiskShareIsRefused(t *testing.T) {
+	fs := NewMemoryFileSystem("FILES")
+	_, client := fileServer(t, fs, false)
+
+	if _, status := transactPipeNamed(t, client, 0, `\PIPE\srvsvc`, []byte("x")); status == 0 {
+		t.Fatal("a pipe transaction on a disk share was answered")
+	}
+}
+
+// TestNamedPipeTruncatedAnswer asserts an answer larger than the client's budget is
+// cut to fit AND reported with STATUS_BUFFER_OVERFLOW.
+//
+// The status is the assertion that matters. [MS-CIFS] section 3.3.5.57.7 requires
+// the response to be constructed on overflow as well as on success, and the
+// overflow status is the only thing telling the client its answer is incomplete —
+// reporting plain success would leave an RPC client parsing a truncated response
+// as a whole one.
+func TestNamedPipeTruncatedAnswer(t *testing.T) {
+	pipes := newEchoPipe("srvsvc")
+	pipes.truncateAt = 8
+	_, client := pipeServer(t, pipes)
+
+	fid, err := openPipeHandle(t, client, `\PIPE\srvsvc`)
+	if err != nil {
+		t.Fatalf("opening the pipe failed: %v", err)
+	}
+
+	setup := []types.USHORT{types.USHORT(subcommands.TRANS_TRANSACT_NMPIPE), types.USHORT(fid)}
+	response, status := sendTransaction(t, client, setup, `\PIPE\`, nil, bytes.Repeat([]byte("A"), 64))
+	if status != uint32(nt_status.NT_STATUS_BUFFER_OVERFLOW) {
+		t.Fatalf("a truncated answer reported 0x%08X, want STATUS_BUFFER_OVERFLOW (0x%08X)",
+			status, uint32(nt_status.NT_STATUS_BUFFER_OVERFLOW))
+	}
+	if response == nil {
+		t.Fatal("no response accompanied the overflow status")
+	}
+	if len(response.Trans_Data) != 8 {
+		t.Fatalf("the answer is %d bytes, want the 8 the handler capped it at", len(response.Trans_Data))
+	}
+}
+
+// TestPipeStateQuery asserts a state query is answered, and that it reports a
+// message-mode pipe.
+//
+// The mode is not cosmetic: [MS-CIFS] section 3.3.5.57.7 requires a transacted
+// exchange to be refused on a pipe that is not message mode, so a server that
+// reported byte mode here would be contradicting the transactions it goes on to
+// answer.
+func TestPipeStateQuery(t *testing.T) {
+	_, client := pipeServer(t, newEchoPipe("srvsvc"))
+
+	fid, err := openPipeHandle(t, client, `\PIPE\srvsvc`)
+	if err != nil {
+		t.Fatalf("opening the pipe failed: %v", err)
+	}
+
+	setup := []types.USHORT{types.USHORT(subcommands.TRANS_QUERY_NMPIPE_STATE), types.USHORT(fid)}
+	response, status := sendTransaction(t, client, setup, `\PIPE\`, nil, nil)
+	if status != 0 {
+		t.Fatalf("the state query answered 0x%08X", status)
+	}
+	if len(response.Trans_Parameters) < 2 {
+		t.Fatalf("the state query returned %d parameter bytes, want 2", len(response.Trans_Parameters))
+	}
+
+	state := binary.LittleEndian.Uint16([]byte(response.Trans_Parameters))
+	if state != pipeStateMessageMode {
+		t.Fatalf("the reported pipe state is 0x%04X, want 0x%04X", state, pipeStateMessageMode)
+	}
+	// The bits, spelled out: read mode and pipe type both message.
+	if readMode := (state >> 8) & 0x03; readMode != uint16(types.SMB_NMPIPE_STATUS_READ_MODE_MESSAGE) {
+		t.Errorf("the reported read mode is %d, want message mode", readMode)
+	}
+}
+
+// TestSecurityDescriptorQuery asserts a descriptor is returned and that it parses
+// back through winacl into what the provider meant, which is what a client will do
+// with it.
+func TestSecurityDescriptorQuery(t *testing.T) {
+	fs := NewMemoryFileSystem("FILES")
+	if err := fs.AddFile("described.txt", []byte("x")); err != nil {
+		t.Fatalf("AddFile() error = %v", err)
+	}
+
+	srv, transportEnd := pipedServer(t, conformanceConfig(SigningDisabled))
+	if err := srv.AddShare(&Share{
+		Name: fileShareName, Type: ShareTypeDisk, FS: fs,
+		Security: NewReflectiveSecurityProvider(false),
+	}); err != nil {
+		t.Fatalf("AddShare() error = %v", err)
+	}
+
+	client := smb1client.NewFromTransport(transportEnd, net.IPv4(127, 0, 0, 1), 445)
+	if err := client.Negotiate(); err != nil {
+		t.Fatalf("Negotiate() error = %v", err)
+	}
+	creds, _ := credentials.NewCredentials(captureDomain, captureUsername, capturePassword, "")
+	if err := client.SessionSetup(creds); err != nil {
+		t.Fatalf("SessionSetup() error = %v", err)
+	}
+	if err := client.TreeConnect(fileShareName); err != nil {
+		t.Fatalf("TreeConnect() error = %v", err)
+	}
+
+	fid, err := client.OpenFile("described.txt", fileflags.GENERIC_READ, fileflags.FILE_SHARE_READ,
+		fileflags.FILE_OPEN, fileflags.FILE_NON_DIRECTORY_FILE)
+	if err != nil {
+		t.Fatalf("OpenFile() error = %v", err)
+	}
+	defer client.CloseFile(fid)
+
+	descriptor, status := querySecurityDescriptor(t, client, uint16(fid),
+		OwnerSecurityInformation|GroupSecurityInformation|DaclSecurityInformation)
+	if status != 0 {
+		t.Fatalf("the security-descriptor query answered 0x%08X", status)
+	}
+	if len(descriptor) == 0 {
+		t.Fatal("the query returned an empty descriptor")
+	}
+
+	// The proof: winacl parses back what the provider built.
+	parsed := &securitydescriptor.NtSecurityDescriptor{}
+	if _, err := parsed.Unmarshal(descriptor); err != nil {
+		t.Fatalf("the descriptor does not parse: %v", err)
+	}
+	if parsed.Owner == nil || parsed.Owner.SID.ToString() != sidLocalSystem {
+		t.Errorf("the owner is %v, want %s", parsed.Owner, sidLocalSystem)
+	}
+	if parsed.DACL == nil || len(parsed.DACL.Entries) != 1 {
+		t.Fatalf("the DACL has %v entries, want 1", parsed.DACL)
+	}
+	entry := parsed.DACL.Entries[0]
+	if entry.Identity.SID.ToString() != sidAuthenticatedUsers {
+		t.Errorf("the DACL grants %s, want %s", entry.Identity.SID.ToString(), sidAuthenticatedUsers)
+	}
+	// A writable share describes write access, because that is what it enforces.
+	if entry.Mask.RawValue&accessWrite == 0 {
+		t.Errorf("the DACL mask is 0x%08X, which does not include write on a writable share", entry.Mask.RawValue)
+	}
+}
+
+// TestSecurityDescriptorReflectsReadOnly asserts the descriptor describes what the
+// server actually enforces: a read-only share does not advertise write access.
+//
+// That is the whole justification for deriving a descriptor rather than refusing:
+// a client uses one to predict what it will be allowed to do, so a descriptor that
+// disagreed with the handlers would make the client wrong.
+func TestSecurityDescriptorReflectsReadOnly(t *testing.T) {
+	for _, readOnly := range []bool{false, true} {
+		readOnly := readOnly
+		t.Run(fmt.Sprintf("readOnly=%t", readOnly), func(t *testing.T) {
+			provider := NewReflectiveSecurityProvider(readOnly)
+			descriptor, err := provider.SecurityDescriptor("anything", DaclSecurityInformation)
+			if err != nil {
+				t.Fatalf("SecurityDescriptor() error = %v", err)
+			}
+
+			parsed := &securitydescriptor.NtSecurityDescriptor{}
+			if _, err := parsed.Unmarshal(descriptor); err != nil {
+				t.Fatalf("the descriptor does not parse: %v", err)
+			}
+			if parsed.DACL == nil || len(parsed.DACL.Entries) != 1 {
+				t.Fatal("the descriptor has no single-entry DACL")
+			}
+
+			mask := parsed.DACL.Entries[0].Mask.RawValue
+			if mask&accessRead == 0 {
+				t.Error("the descriptor does not describe read access, which every share grants")
+			}
+			if readOnly && mask&accessWrite != 0 {
+				t.Error("a read-only share's descriptor describes write access")
+			}
+			if !readOnly && mask&accessWrite == 0 {
+				t.Error("a writable share's descriptor does not describe write access")
+			}
+		})
+	}
+}
+
+// TestSecurityDescriptorWithoutProviderIsRefused asserts a share with no security
+// model says so rather than inventing a descriptor.
+func TestSecurityDescriptorWithoutProviderIsRefused(t *testing.T) {
+	fs := NewMemoryFileSystem("FILES")
+	if err := fs.AddFile("plain.txt", []byte("x")); err != nil {
+		t.Fatalf("AddFile() error = %v", err)
+	}
+	_, client := fileServer(t, fs, false)
+
+	fid, err := client.OpenFile("plain.txt", fileflags.GENERIC_READ, fileflags.FILE_SHARE_READ,
+		fileflags.FILE_OPEN, fileflags.FILE_NON_DIRECTORY_FILE)
+	if err != nil {
+		t.Fatalf("OpenFile() error = %v", err)
+	}
+	defer client.CloseFile(fid)
+
+	if _, status := querySecurityDescriptor(t, client, uint16(fid), DaclSecurityInformation); status == 0 {
+		t.Fatal("a share with no security provider returned a descriptor")
+	}
+}
+
+// TestReflectiveProviderRefusesSet asserts the derived provider refuses a change
+// rather than accepting one it could not store: a client that believed it had
+// applied a descriptor would be wrong about what the server enforces.
+func TestReflectiveProviderRefusesSet(t *testing.T) {
+	provider := NewReflectiveSecurityProvider(false)
+	if err := provider.SetSecurityDescriptor("anything", DaclSecurityInformation, []byte{0x01}); err == nil {
+		t.Fatal("the derived provider accepted a descriptor change")
+	}
+}
+
+// TestNtTransactUnimplementedFunctions asserts the NT_TRANSACT functions this
+// server does not serve are refused, rather than answered with something invented.
+func TestNtTransactUnimplementedFunctions(t *testing.T) {
+	fs := NewMemoryFileSystem("FILES")
+	_, client := fileServer(t, fs, false)
+
+	unimplemented := []subcommands.NtTransactSubcommand{
+		subcommands.NT_TRANSACT_CREATE,
+		subcommands.NT_TRANSACT_RENAME,
+		subcommands.NT_TRANSACT_NOTIFY_CHANGE,
+		subcommands.NT_TRANSACT_QUERY_QUOTA,
+		subcommands.NT_TRANSACT_SET_QUOTA,
+	}
+	for _, function := range unimplemented {
+		function := function
+		t.Run(fmt.Sprintf("0x%04X", uint16(function)), func(t *testing.T) {
+			status := sendNtTransact(t, client, function, nil, nil, nil)
+			if status != uint32(nt_status.NT_STATUS_NOT_IMPLEMENTED) {
+				t.Fatalf("function 0x%04X answered 0x%08X, want NT_STATUS_NOT_IMPLEMENTED",
+					uint16(function), status)
+			}
+		})
+	}
+}
+
+// TestNtTransactRejectsOversizeTotals asserts a declared total beyond the limit is
+// refused rather than allocated. The NT_TRANSACT counts are 32-bit, so unlike
+// TRANSACTION2 there is no natural ceiling and a client could otherwise ask for
+// gigabytes.
+func TestNtTransactRejectsOversizeTotals(t *testing.T) {
+	fs := NewMemoryFileSystem("FILES")
+	_, client := fileServer(t, fs, false)
+
+	request := newRequest(codes.SMB_COM_NT_TRANSACT)
+	request.Header.UID = client.Session.SessionUID
+	request.Header.TID = client.Session.TreeID
+
+	transaction := commands.NewNtTransactRequest()
+	transaction.Function = types.USHORT(subcommands.NT_TRANSACT_IOCTL)
+	transaction.SetupCount = types.UCHAR(0)
+	transaction.Setup = []types.USHORT{}
+	// Far beyond the imposed limit.
+	transaction.TotalDataCount = types.ULONG(1 << 28)
+	request.AddCommand(transaction)
+
+	marshalled, err := request.Marshal()
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+	if _, err := client.Transport.Send(marshalled); err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+	raw, err := client.Transport.Receive()
+	if err != nil {
+		t.Fatalf("Receive() error = %v", err)
+	}
+	status := binary.LittleEndian.Uint32(raw[5:9])
+	if status != uint32(nt_status.NT_STATUS_INVALID_PARAMETER) {
+		t.Fatalf("an oversize NT_TRANSACT answered 0x%08X, want NT_STATUS_INVALID_PARAMETER", status)
+	}
+}
+
+// TestNtCancelIsAcceptedSilently asserts a cancel produces no response at all and
+// leaves the connection usable.
+//
+// The silence is the assertion: a client that received a response to a cancel
+// would read it as the answer to whatever it sends next, and every exchange after
+// that would be off by one. The following echo is what proves the connection is
+// still in step.
+func TestNtCancelIsAcceptedSilently(t *testing.T) {
+	fs := NewMemoryFileSystem("FILES")
+	_, client := fileServer(t, fs, false)
+
+	request := newRequest(codes.SMB_COM_NT_CANCEL)
+	request.Header.UID = client.Session.SessionUID
+	request.Header.TID = client.Session.TreeID
+	request.AddCommand(commands.NewNtCancelRequest())
+
+	marshalled, err := request.Marshal()
+	if err != nil {
+		t.Fatalf("failed to marshal the cancel: %v", err)
+	}
+	if _, err := client.Transport.Send(marshalled); err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+
+	// If the cancel had been answered, this echo would read that answer instead of
+	// its own and the payload would not match.
+	payload := []byte("still in step")
+	echoed, err := client.Echo(payload)
+	if err != nil {
+		t.Fatalf("the connection is unusable after a cancel: %v", err)
+	}
+	if !bytes.Equal(echoed, payload) {
+		t.Fatalf("the echo returned %q, want %q: the cancel was answered", echoed, payload)
+	}
+}
+
+// querySecurityDescriptor sends an NT_TRANSACT_QUERY_SECURITY_DESC and returns the
+// descriptor and status.
+func querySecurityDescriptor(t *testing.T, client *smb1client.Client, fid uint16, information SecurityInformation) ([]byte, uint32) {
+	t.Helper()
+
+	parameters := make([]byte, 8)
+	binary.LittleEndian.PutUint16(parameters[0:2], fid)
+	binary.LittleEndian.PutUint32(parameters[4:8], uint32(information))
+
+	request := newRequest(codes.SMB_COM_NT_TRANSACT)
+	request.Header.UID = client.Session.SessionUID
+	request.Header.TID = client.Session.TreeID
+
+	transaction := commands.NewNtTransactRequest()
+	transaction.Function = types.USHORT(subcommands.NT_TRANSACT_QUERY_SECURITY_DESC)
+	transaction.SetupCount = types.UCHAR(0)
+	transaction.Setup = []types.USHORT{}
+	transaction.MaxParameterCount = 1024
+	transaction.MaxDataCount = 8192
+	transaction.TotalParameterCount = types.ULONG(len(parameters))
+	transaction.ParameterCount = types.ULONG(len(parameters))
+	transaction.NT_Trans_Parameters = parameters
+	request.AddCommand(transaction)
+
+	marshalled, err := request.Marshal()
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+	if _, err := client.Transport.Send(marshalled); err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+	raw, err := client.Transport.Receive()
+	if err != nil {
+		t.Fatalf("Receive() error = %v", err)
+	}
+	response := message.NewMessage()
+	if err := response.Unmarshal(raw); err != nil {
+		t.Fatalf("failed to decode: %v", err)
+	}
+	if response.Header.Status != 0 {
+		return nil, response.Header.Status
+	}
+	ntResponse, ok := response.Command.(*commands.NtTransactResponse)
+	if !ok {
+		t.Fatalf("response command is %T", response.Command)
+	}
+	return []byte(ntResponse.Data), 0
+}
+
+// sendNtTransact sends an NT_TRANSACT and returns the status it was answered with.
+func sendNtTransact(
+	t *testing.T,
+	client *smb1client.Client,
+	function subcommands.NtTransactSubcommand,
+	setup []types.USHORT,
+	parameters, data []byte,
+) uint32 {
+	t.Helper()
+
+	request := newRequest(codes.SMB_COM_NT_TRANSACT)
+	request.Header.UID = client.Session.SessionUID
+	request.Header.TID = client.Session.TreeID
+
+	transaction := commands.NewNtTransactRequest()
+	transaction.Function = types.USHORT(function)
+	transaction.Setup = setup
+	transaction.SetupCount = types.UCHAR(len(setup))
+	transaction.MaxParameterCount = 1024
+	transaction.MaxDataCount = 4096
+	transaction.TotalParameterCount = types.ULONG(len(parameters))
+	transaction.ParameterCount = types.ULONG(len(parameters))
+	transaction.NT_Trans_Parameters = parameters
+	transaction.TotalDataCount = types.ULONG(len(data))
+	transaction.DataCount = types.ULONG(len(data))
+	transaction.NT_Trans_Data = data
+	request.AddCommand(transaction)
+
+	marshalled, err := request.Marshal()
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+	if _, err := client.Transport.Send(marshalled); err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+	raw, err := client.Transport.Receive()
+	if err != nil {
+		t.Fatalf("Receive() error = %v", err)
+	}
+	if len(raw) < 9 {
+		t.Fatalf("the response is %d bytes", len(raw))
+	}
+	return binary.LittleEndian.Uint32(raw[5:9])
+}

--- a/network/smb/smb_v10/server/security.go
+++ b/network/smb/smb_v10/server/security.go
@@ -1,0 +1,207 @@
+package server
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/winacl/ace"
+	aceflags "github.com/TheManticoreProject/winacl/ace/aceflags"
+	acetype "github.com/TheManticoreProject/winacl/ace/acetype"
+	aceheader "github.com/TheManticoreProject/winacl/ace/header"
+	acemask "github.com/TheManticoreProject/winacl/ace/mask"
+	"github.com/TheManticoreProject/winacl/acl"
+	aclrevision "github.com/TheManticoreProject/winacl/acl/revision"
+	"github.com/TheManticoreProject/winacl/identity"
+	"github.com/TheManticoreProject/winacl/securitydescriptor"
+	sdcontrol "github.com/TheManticoreProject/winacl/securitydescriptor/control"
+	"github.com/TheManticoreProject/winacl/sid"
+)
+
+// SecurityInformation selects which parts of a security descriptor a query or a set
+// applies to. The values are the SECURITY_INFORMATION bits from [MS-DTYP] 2.4.7.
+type SecurityInformation uint32
+
+const (
+	// OwnerSecurityInformation selects the owner.
+	OwnerSecurityInformation SecurityInformation = 0x00000001
+	// GroupSecurityInformation selects the primary group.
+	GroupSecurityInformation SecurityInformation = 0x00000002
+	// DaclSecurityInformation selects the discretionary ACL.
+	DaclSecurityInformation SecurityInformation = 0x00000004
+	// SaclSecurityInformation selects the system ACL.
+	SaclSecurityInformation SecurityInformation = 0x00000008
+)
+
+// SecurityProvider supplies the security descriptors for a share.
+//
+// A share without one refuses the security-descriptor subcommands with
+// STATUS_NOT_SUPPORTED, which is the honest answer: a client that receives a
+// descriptor believes it describes the access the server enforces, so inventing one
+// is worse than admitting there is no model to describe.
+type SecurityProvider interface {
+	// SecurityDescriptor returns the self-relative descriptor for a path, with
+	// only the parts information selects populated.
+	SecurityDescriptor(path string, information SecurityInformation) ([]byte, error)
+
+	// SetSecurityDescriptor applies a descriptor to a path.
+	SetSecurityDescriptor(path string, information SecurityInformation, descriptor []byte) error
+}
+
+// Well-known SIDs used by the reflective provider below.
+const (
+	// sidAuthenticatedUsers is S-1-5-11, every identity that authenticated.
+	sidAuthenticatedUsers = "S-1-5-11"
+	// sidLocalSystem is S-1-5-18, which owns what the server itself created.
+	sidLocalSystem = "S-1-5-18"
+	// sidAdministrators is S-1-5-32-544, the local administrators group.
+	sidAdministrators = "S-1-5-32-544"
+)
+
+// Access-mask values used in the descriptor built below.
+const (
+	// accessRead is what reading needs: the data, the extended attributes and the
+	// attributes, plus READ_CONTROL and SYNCHRONIZE, which every open carries.
+	accessRead uint32 = 0x00120089
+	// accessWrite is the rights writing adds on top. It holds no bit that
+	// accessRead holds, so a mask can be tested for one without matching the
+	// other — which a combined constant could not be, since both would carry
+	// READ_CONTROL and SYNCHRONIZE.
+	accessWrite uint32 = 0x00000116
+)
+
+// ReflectiveSecurityProvider describes the access the server actually enforces,
+// rather than an access-control model it does not have.
+//
+// The descriptor it returns says: authenticated users may read, and may also write
+// unless the share is read-only. That is exactly the rule the handlers apply, so
+// the descriptor is truthful — which matters because a client uses a descriptor to
+// predict what it will be allowed to do, and a descriptor describing rights the
+// server does not honour, or withholding ones it does, makes the client wrong in
+// one direction or the other.
+//
+// It is deliberately not a stand-in for real per-file ACLs. A caller with a real
+// model implements SecurityProvider itself.
+type ReflectiveSecurityProvider struct {
+	// readOnly mirrors the share's own flag, which is what decides whether write
+	// access is described.
+	readOnly bool
+}
+
+// NewReflectiveSecurityProvider creates a provider describing a share whose
+// read-only state is given.
+//
+// Parameters:
+//   - readOnly: whether the share refuses modification
+//
+// Returns:
+//   - The provider
+func NewReflectiveSecurityProvider(readOnly bool) *ReflectiveSecurityProvider {
+	return &ReflectiveSecurityProvider{readOnly: readOnly}
+}
+
+// SecurityDescriptor builds the descriptor for a path.
+//
+// The path does not affect the answer: the server's access rule is per share, not
+// per file, and pretending otherwise by varying the descriptor would suggest a
+// granularity that does not exist.
+func (p *ReflectiveSecurityProvider) SecurityDescriptor(path string, information SecurityInformation) ([]byte, error) {
+	descriptor := &securitydescriptor.NtSecurityDescriptor{}
+	descriptor.Header.Revision = 1
+	// SE_DACL_PRESENT plus SE_SELF_RELATIVE: the form a client asks for, where
+	// every component is reached by an offset from the start rather than by a
+	// pointer.
+	descriptor.Header.Control = sdcontrol.NtSecurityDescriptorControl{
+		RawValue: sdcontrol.NT_SECURITY_DESCRIPTOR_CONTROL_DP |
+			sdcontrol.NT_SECURITY_DESCRIPTOR_CONTROL_SR,
+	}
+
+	if information&OwnerSecurityInformation != 0 {
+		owner, err := identityFor(sidLocalSystem)
+		if err != nil {
+			return nil, err
+		}
+		descriptor.Owner = owner
+	}
+	if information&GroupSecurityInformation != 0 {
+		group, err := identityFor(sidAdministrators)
+		if err != nil {
+			return nil, err
+		}
+		descriptor.Group = group
+	}
+
+	if information&DaclSecurityInformation != 0 {
+		mask := accessRead
+		if !p.readOnly {
+			mask |= accessWrite
+		}
+		entry, err := allowEntry(sidAuthenticatedUsers, mask)
+		if err != nil {
+			return nil, err
+		}
+		entries := []ace.AccessControlEntry{*entry}
+		descriptor.DACL = &acl.DiscretionaryAccessControlList{
+			Header: acl.DiscretionaryAccessControlListHeader{
+				// ACL_REVISION, the revision for an ACL holding no
+				// object-specific ACEs.
+				Revision: aclrevision.AccessControlListRevision{Value: 2},
+				// The marshaller derives AclSize from what it writes but takes
+				// AceCount as given, so a count left at zero produces an ACL
+				// whose entries every parser skips.
+				AceCount: uint16(len(entries)),
+			},
+			Entries: entries,
+		}
+	}
+
+	// A SACL is never produced: nothing here audits, so an empty one would claim
+	// auditing is configured and a populated one would be a fabrication.
+
+	marshalled, err := descriptor.Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal the security descriptor: %v", err)
+	}
+	return marshalled, nil
+}
+
+// SetSecurityDescriptor refuses every change.
+//
+// The descriptor this provider returns is derived from the share's configuration,
+// so there is nowhere to store a different one. Accepting a change and then
+// continuing to report the derived descriptor would be worse than refusing: a
+// client would believe it had applied something it had not.
+func (p *ReflectiveSecurityProvider) SetSecurityDescriptor(path string, information SecurityInformation, descriptor []byte) error {
+	return fmt.Errorf("this share's security descriptor is derived from its configuration: %w", ErrAccessDenied)
+}
+
+// identityFor builds an identity from a SID string.
+func identityFor(value string) (*identity.Identity, error) {
+	parsed := &sid.SID{}
+	if err := parsed.FromString(value); err != nil {
+		return nil, fmt.Errorf("failed to parse the SID %q: %v", value, err)
+	}
+	return &identity.Identity{SID: *parsed}, nil
+}
+
+// allowEntry builds an access-allowed ACE granting a mask to a SID.
+func allowEntry(value string, mask uint32) (*ace.AccessControlEntry, error) {
+	holder, err := identityFor(value)
+	if err != nil {
+		return nil, err
+	}
+
+	entry := &ace.AccessControlEntry{
+		Header: aceheader.AccessControlEntryHeader{
+			Type:  acetype.AccessControlEntryType{Value: acetype.ACE_TYPE_ACCESS_ALLOWED},
+			Flags: aceflags.AccessControlEntryFlag{RawValue: aceflags.ACE_FLAG_NONE},
+		},
+		Mask:     acemask.AccessControlMask{RawValue: mask},
+		Identity: *holder,
+	}
+	// The header size is the fixed part plus the SID, which the marshaller reads
+	// rather than deriving, so it has to be right or the entry is unparseable.
+	entry.Header.Size = uint16(4 + 4 + holder.SID.RawBytesSize)
+	return entry, nil
+}
+
+// Compile-time assurance that the provider satisfies the contract.
+var _ SecurityProvider = (*ReflectiveSecurityProvider)(nil)

--- a/network/smb/smb_v10/server/share.go
+++ b/network/smb/smb_v10/server/share.go
@@ -41,6 +41,15 @@ type Share struct {
 
 	// FS is the storage behind a disk share.
 	FS FileSystem
+
+	// Security supplies the share's security descriptors. Nil refuses the
+	// security-descriptor subcommands, which is the honest answer for a share
+	// with no access-control model to describe.
+	Security SecurityProvider
+
+	// Pipes serves the named pipes on an IPC share. Nil refuses every pipe
+	// operation.
+	Pipes PipeHandler
 }
 
 // OpenFlags describe what an open is for. They are the subset of the client's

--- a/network/smb/smb_v10/server/trans2_test.go
+++ b/network/smb/smb_v10/server/trans2_test.go
@@ -484,8 +484,8 @@ func TestSetPathInformationOnReadOnlyShare(t *testing.T) {
 // including the inconsistencies it has to refuse. A fragment landing in the wrong
 // place would corrupt a request in a way that is very hard to see from the outside.
 func TestTransaction2FragmentPlacement(t *testing.T) {
-	newReassembly := func(parameters, data int) *trans2Reassembly {
-		return &trans2Reassembly{
+	newReassembly := func(parameters, data int) *transactionReassembly {
+		return &transactionReassembly{
 			parameters: make([]byte, parameters),
 			data:       make([]byte, data),
 		}

--- a/network/smb/smb_v10/server/tree.go
+++ b/network/smb/smb_v10/server/tree.go
@@ -40,6 +40,12 @@ type Open struct {
 	// IsDirectory records what the handle names.
 	IsDirectory bool
 
+	// IsPipe records that the handle names a named pipe rather than a file, so
+	// Path is a pipe name and there is no backend file behind it. A pipe handle
+	// is what a transaction acts on: [MS-CIFS] section 3.3.5.57.7 identifies the
+	// pipe by the FID in the request's setup words, not by the name it carries.
+	IsPipe bool
+
 	// Readable and Writable are the access the open was granted, enforced on
 	// every use so a handle opened for reading cannot later be written through.
 	Readable bool
@@ -115,6 +121,14 @@ func (c *Connection) closeOpen(fid uint16) error {
 	var firstErr error
 	if open.File != nil {
 		if err := open.File.Close(); err != nil {
+			firstErr = err
+		}
+	}
+
+	// A pipe handle has no backend file; what it holds is whatever the handler
+	// prepared when the pipe was opened, so closing it is the handler's business.
+	if open.IsPipe && open.Tree != nil && open.Tree.Share.Pipes != nil {
+		if err := open.Tree.Share.Pipes.ClosePipe(open.Path); err != nil && firstErr == nil {
 			firstErr = err
 		}
 	}


### PR DESCRIPTION
Eleventh commit toward an SMB 1.0 server (#1068), stacked on #1078.

TRANSACTION2 carried the file and directory subcommands. This adds the other two transaction families: **NT_TRANSACT** (security descriptors, file-system controls) and **TRANSACTION** (named pipes).

### One reassembly, three families

All three are the same shape at different field widths — totals, a per-message count, a displacement — differing only in how the subcommand is selected: a setup word for TRANSACTION, a `Function` field for NT_TRANSACT, a name alongside the setup word for the pipe operations. The reassembly built for TRANSACTION2 is generalised rather than copied twice.

The NT_TRANSACT counts are 32-bit, which needs a bound the 16-bit family did not: there a declared total was capped by the field, here it is an allocation, so a total beyond the limit is refused before anything is allocated for it.

### Named pipes are the point

`TRANS_TRANSACT_NMPIPE` writes a message to a pipe and returns the answer in one exchange — which is what MS-RPC over SMB is: a bind and every call after it. A `Share` of the pipe type carries a `PipeHandler` instead of a `FileSystem`, so an RPC service becomes reachable over SMB1 by implementing three methods.

A pipe is opened like a file and then transacted on **by handle**: [MS-CIFS] 3.3.5.57.7 identifies the pipe by the FID in the setup words, not by the name the request carries. A request naming a FID that is not an open pipe is refused rather than resolved from the name — reading the name instead would let a client act on a pipe it never opened.

An answer larger than the client's buffer is cut to fit and reported with `STATUS_BUFFER_OVERFLOW`. That status is the whole difference between an RPC conversation that continues and one that stalls: plain success would leave the client parsing a truncated response as a complete one.

### Security descriptors are derived, not stored

A read-only share does not describe write access, because it does not grant any. A client uses a descriptor to predict what it will be allowed to do, so one that disagreed with the handlers would make the client wrong. For the same reason a change is refused rather than accepted with nowhere to store it, and a share with no provider says so instead of inventing a descriptor. Only control codes whose answer can be given truthfully are served, and `IS_PATHNAME_VALID` answers from the path resolver itself rather than forming a second opinion that could disagree with it.

### Three groups absent by choice

The conformance tables assert the absence rather than leaving it implied:

- **NT_TRANSACT_CREATE / RENAME** duplicate commands already served.
- **The quota subcommands** have nothing to report a quota from.
- **NOTIFY_CHANGE** needs a file system that can be watched and a connection writable from outside the request being served — a notification is answered when the change *happens*, not when it is asked for. Neither exists here, and half of either would be worse than the refusal.

### Five wire fixes, all in decoders that had no caller until now

This is the sixth phase in a row to surface latent defects on the request side, for the same structural reason: a client marshals requests and unmarshals responses, so a request *decoder* is only exercised once a server exists.

1. **`SMB_COM_TRANSACTION`'s `Name` carried a spurious buffer-format byte.** It was modelled as an `SMB_STRING`, which prepends one. [MS-CIFS] 2.2.4.33.1 gives the field as a bare null-terminated array of OEM or Unicode characters that "MUST be the first field in this section" — there is no format byte. **Every pipe transaction from a real client failed to decode**: the leading backslash of the name was read as a format code of `0x5C` and refused. Marshal and Unmarshal now agree with the wire and with each other, terminator width following the encoding, mirroring the same fix already made for `NT_CREATE_ANDX`'s `FileName`. A marshaller and an unmarshaller that share a mistake round-trip perfectly, so the test builds a request **by hand** and asserts the data block begins with the name.
2. **An open resolved its tree through the disk-share check**, so opening a pipe answered `STATUS_BAD_DEVICE_TYPE`. It is the one command serving both kinds of share, so it now resolves the tree without that check and applies its own; every other handler keeps the check, which is what stops a file-system handler being reached with no file system behind it.
3. **Closing a handle read the share's file system** to apply a modification time, which a pipe share does not have.
4. **The derived descriptor left the ACL's `AceCount` at zero.** The marshaller derives `AclSize` from what it writes but takes `AceCount` as given, so the descriptor parsed as having an *empty* ACL — a permissive reading of a descriptor meant to describe a restriction.
5. **The read and write access masks shared `READ_CONTROL` and `SYNCHRONIZE`**, so a test for write access matched a read-only descriptor. They are disjoint now, which is what makes the read-only assertion mean anything.

### Validation

Tests drive the whole exchange in the order a client performs it: open the pipe on IPC$, transact on the handle, close it, and assert the handler saw the matching lifecycle calls rather than the file path having quietly accepted the name. Alongside those: the pipe-name forms a client may send, an unknown pipe and a handler-less share refused, a transaction on an unopened FID and on a file handle both refused, a truncated answer carrying `STATUS_BUFFER_OVERFLOW` *with* its data, the state query reporting message mode in the bits a client reads, and a cancel proved silent by an echo that follows it and still matches.

Descriptors are parsed back through winacl's own unmarshaller rather than compared as bytes, since that is what a client does with one, and the read-only and writable cases are asserted to differ.

The conformance suite gains three tables — NT_TRANSACT functions, control codes, pipe subcommands — each cross-checked against its handler map in both directions. Its command-space walk no longer guards itself with a fixed floor that every phase has to edit: it now accounts for every command the message layer knows as exercised, served, or unmarshalable, which stays true as later phases move commands into the served set.

The fuzz corpus gains the NT_TRANSACT counts at `0xFFFFFFFF`, both secondary messages with no transaction in progress, a cancel, and a TRANSACTION whose data block holds an unterminated name in each encoding — the case a terminator scan without a bound would run off. **10.9M executions, no crashers.**

Every wire detail relied on was checked against [MS-CIFS] 2.2.4.33.1 (the TRANSACTION request layout), 2.2.5.6 (TRANS_TRANSACT_NMPIPE) and 3.3.5.57.7 (receiving one).

`go build`, `go vet`, `gofmt` and the full `go test ./...` are green.

### Not validated

Interop against a real Windows client, Samba `smbclient` or `mount.cifs` has **not** been run — no such client is reachable from this environment. That is commit 12's scope, and it is flagged there rather than claimed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
