### PR TITLE
Validate the SMB1 server against a third-party client (Refs #1068)

### DIFF
--- a/crypto/spnego/acceptor.go
+++ b/crypto/spnego/acceptor.go
@@ -453,3 +453,37 @@ func expectMessageType(message []byte, want types.MessageType) error {
 
 	return nil
 }
+
+// CompletionToken builds the token that closes a SPNEGO exchange: a NegTokenResp
+// reporting accept-completed, wrapped in a SecurityBlob.
+//
+// This is not optional padding on a successful logon. RFC 4178 section 4.2.2 has
+// the acceptor report the outcome of the negotiation in negState, and a mechanism
+// that has finished is reported as accept-completed(0); an initiator whose state
+// machine is still waiting for that token treats an empty final blob as a
+// protocol violation and abandons the session, even though the server considered
+// the logon successful. So the final leg carries this rather than nothing.
+//
+// No responseToken accompanies it: NTLM's last message is the client's
+// AUTHENTICATE, so there is nothing left for the server to send. The mechanism is
+// named again so an initiator that tracks which mechanism was settled on can
+// confirm it.
+//
+// Returns:
+//   - The marshalled SecurityBlob
+//   - An error if it cannot be built
+func (ctx *AcceptContext) CompletionToken() ([]byte, error) {
+	negTokenResp := NewNegTokenResp(NegStateAcceptCompleted, NtlmOID, nil)
+	marshalledNegTokenResp, err := negTokenResp.Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal the completing NegTokenResp: %v", err)
+	}
+
+	securityBlob := SecurityBlob{Data: marshalledNegTokenResp}
+	marshalledSecurityBlob, err := securityBlob.Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal the completing SecurityBlob: %v", err)
+	}
+
+	return marshalledSecurityBlob, nil
+}

--- a/encoding/utf16/utf16le.go
+++ b/encoding/utf16/utf16le.go
@@ -32,9 +32,15 @@ func EncodeUTF16LE(s string) []byte {
 //
 // Returns:
 //   - A string representing the UTF-16 little endian decoded byte slice.
+//
+// A trailing odd byte is an incomplete code unit and is dropped rather than
+// decoded. Input of an odd length is not a caller's mistake to be punished with a
+// panic: this decoder is fed by fields taken off the network, where a length is
+// whatever the sender said it was, and a truncated final character is the ordinary
+// consequence of a field that was cut short.
 func DecodeUTF16LE(b []byte) string {
 	utf16le := make([]uint16, len(b)/2)
-	for i := 0; i < len(b); i += 2 {
+	for i := 0; i+1 < len(b); i += 2 {
 		utf16le[i/2] = uint16(b[i]) | (uint16(b[i+1]) << 8)
 	}
 	return string(utf16.Decode(utf16le))

--- a/encoding/utf16/utf16le_test.go
+++ b/encoding/utf16/utf16le_test.go
@@ -66,3 +66,38 @@ func TestIsUTF16LE(t *testing.T) {
 		}
 	}
 }
+
+// TestDecodeUTF16LEOddLength asserts an odd-length input drops its trailing byte
+// rather than panicking.
+//
+// The decoder is reached from fields taken off the network, where the length is
+// whatever the sender said: a client that negotiated Unicode and sent a name whose
+// terminator was found at an odd offset produced a one-byte slice here, and the
+// panic that followed killed the connection serving it.
+func TestDecodeUTF16LEOddLength(t *testing.T) {
+	cases := []struct {
+		name  string
+		input []byte
+		want  string
+	}{
+		{"a single byte", []byte{0x5C}, ""},
+		{"one character and a half", []byte{0x41, 0x00, 0x42}, "A"},
+		{"three and a half", []byte{0x41, 0x00, 0x42, 0x00, 0x43, 0x00, 0x44}, "ABC"},
+		{"empty", []byte{}, ""},
+		{"nil", nil, ""},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("DecodeUTF16LE(% x) panicked: %v", tc.input, r)
+				}
+			}()
+			if got := DecodeUTF16LE(tc.input); got != tc.want {
+				t.Fatalf("DecodeUTF16LE(% x) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}

--- a/network/smb/smb_v10/message/commands/CheckDirectoryRequest.go
+++ b/network/smb/smb_v10/message/commands/CheckDirectoryRequest.go
@@ -71,7 +71,7 @@ func (c *CheckDirectoryRequest) Marshal() ([]byte, error) {
 
 	// Marshalling data DirectoryName
 	c.DirectoryName.SetBufferFormat(types.SMB_STRING_BUFFER_FORMAT_NULL_TERMINATED_ASCII_STRING)
-	bytesStream, err := c.DirectoryName.Marshal()
+	bytesStream, err := c.DirectoryName.MarshalWithEncoding(c.IsUnicode())
 	if err != nil {
 		return nil, err
 	}
@@ -140,7 +140,7 @@ func (c *CheckDirectoryRequest) Unmarshal(rawData []byte) (int, error) {
 	offset = 0
 
 	// Unmarshalling data DirectoryName
-	bytesRead, err = c.DirectoryName.Unmarshal(rawDataContent[offset:])
+	bytesRead, err = c.DirectoryName.UnmarshalWithEncoding(rawDataContent[offset:], c.IsUnicode())
 	if err != nil {
 		return offset, err
 	}

--- a/network/smb/smb_v10/message/commands/CreateDirectoryRequest.go
+++ b/network/smb/smb_v10/message/commands/CreateDirectoryRequest.go
@@ -71,7 +71,7 @@ func (c *CreateDirectoryRequest) Marshal() ([]byte, error) {
 
 	// Marshalling data DirectoryName
 	c.DirectoryName.SetBufferFormat(types.SMB_STRING_BUFFER_FORMAT_NULL_TERMINATED_ASCII_STRING)
-	bytesStream, err := c.DirectoryName.Marshal()
+	bytesStream, err := c.DirectoryName.MarshalWithEncoding(c.IsUnicode())
 	if err != nil {
 		return nil, err
 	}
@@ -144,7 +144,7 @@ func (c *CreateDirectoryRequest) Unmarshal(rawData []byte) (int, error) {
 	offset = 0
 
 	// Unmarshalling data DirectoryName
-	bytesRead, err = c.DirectoryName.Unmarshal(rawDataContent[offset:])
+	bytesRead, err = c.DirectoryName.UnmarshalWithEncoding(rawDataContent[offset:], c.IsUnicode())
 	if err != nil {
 		return offset, err
 	}

--- a/network/smb/smb_v10/message/commands/CreateNewRequest.go
+++ b/network/smb/smb_v10/message/commands/CreateNewRequest.go
@@ -86,7 +86,7 @@ func (c *CreateNewRequest) Marshal() ([]byte, error) {
 
 	// Marshalling data FileName
 	c.FileName.SetBufferFormat(types.SMB_STRING_BUFFER_FORMAT_NULL_TERMINATED_ASCII_STRING)
-	bytesStream, err := c.FileName.Marshal()
+	bytesStream, err := c.FileName.MarshalWithEncoding(c.IsUnicode())
 	if err != nil {
 		return nil, err
 	}
@@ -184,7 +184,7 @@ func (c *CreateNewRequest) Unmarshal(rawData []byte) (int, error) {
 	offset = 0
 
 	// Unmarshalling data FileName
-	bytesRead, err = c.FileName.Unmarshal(rawDataContent[offset:])
+	bytesRead, err = c.FileName.UnmarshalWithEncoding(rawDataContent[offset:], c.IsUnicode())
 	if err != nil {
 		return offset, err
 	}

--- a/network/smb/smb_v10/message/commands/CreateRequest.go
+++ b/network/smb/smb_v10/message/commands/CreateRequest.go
@@ -86,7 +86,7 @@ func (c *CreateRequest) Marshal() ([]byte, error) {
 
 	// Marshalling data FileName
 	c.FileName.SetBufferFormat(types.SMB_STRING_BUFFER_FORMAT_NULL_TERMINATED_ASCII_STRING)
-	bytesStream, err := c.FileName.Marshal()
+	bytesStream, err := c.FileName.MarshalWithEncoding(c.IsUnicode())
 	if err != nil {
 		return nil, err
 	}
@@ -184,7 +184,7 @@ func (c *CreateRequest) Unmarshal(rawData []byte) (int, error) {
 	offset = 0
 
 	// Unmarshalling data FileName
-	bytesRead, err = c.FileName.Unmarshal(rawDataContent[offset:])
+	bytesRead, err = c.FileName.UnmarshalWithEncoding(rawDataContent[offset:], c.IsUnicode())
 	if err != nil {
 		return offset, err
 	}

--- a/network/smb/smb_v10/message/commands/CreateTemporaryRequest.go
+++ b/network/smb/smb_v10/message/commands/CreateTemporaryRequest.go
@@ -86,7 +86,7 @@ func (c *CreateTemporaryRequest) Marshal() ([]byte, error) {
 
 	// Marshalling data DirectoryName
 	c.DirectoryName.SetBufferFormat(types.SMB_STRING_BUFFER_FORMAT_NULL_TERMINATED_ASCII_STRING)
-	bytesStream, err := c.DirectoryName.Marshal()
+	bytesStream, err := c.DirectoryName.MarshalWithEncoding(c.IsUnicode())
 	if err != nil {
 		return nil, err
 	}
@@ -184,7 +184,7 @@ func (c *CreateTemporaryRequest) Unmarshal(rawData []byte) (int, error) {
 	offset = 0
 
 	// Unmarshalling data DirectoryName
-	bytesRead, err = c.DirectoryName.Unmarshal(rawDataContent[offset:])
+	bytesRead, err = c.DirectoryName.UnmarshalWithEncoding(rawDataContent[offset:], c.IsUnicode())
 	if err != nil {
 		return offset, err
 	}

--- a/network/smb/smb_v10/message/commands/DeleteDirectoryRequest.go
+++ b/network/smb/smb_v10/message/commands/DeleteDirectoryRequest.go
@@ -71,7 +71,7 @@ func (c *DeleteDirectoryRequest) Marshal() ([]byte, error) {
 
 	// Marshalling data DirectoryName
 	c.DirectoryName.SetBufferFormat(types.SMB_STRING_BUFFER_FORMAT_NULL_TERMINATED_ASCII_STRING)
-	bytesStream, err := c.DirectoryName.Marshal()
+	bytesStream, err := c.DirectoryName.MarshalWithEncoding(c.IsUnicode())
 	if err != nil {
 		return nil, err
 	}
@@ -143,7 +143,7 @@ func (c *DeleteDirectoryRequest) Unmarshal(rawData []byte) (int, error) {
 	offset = 0
 
 	// Unmarshalling data DirectoryName
-	bytesRead, err = c.DirectoryName.Unmarshal(rawDataContent[offset:])
+	bytesRead, err = c.DirectoryName.UnmarshalWithEncoding(rawDataContent[offset:], c.IsUnicode())
 	if err != nil {
 		return offset, err
 	}

--- a/network/smb/smb_v10/message/commands/DeleteRequest.go
+++ b/network/smb/smb_v10/message/commands/DeleteRequest.go
@@ -82,7 +82,7 @@ func (c *DeleteRequest) Marshal() ([]byte, error) {
 
 	// Marshalling data FileName
 	c.FileName.SetBufferFormat(types.SMB_STRING_BUFFER_FORMAT_NULL_TERMINATED_ASCII_STRING)
-	bytesStream, err := c.FileName.Marshal()
+	bytesStream, err := c.FileName.MarshalWithEncoding(c.IsUnicode())
 	if err != nil {
 		return nil, err
 	}
@@ -168,7 +168,7 @@ func (c *DeleteRequest) Unmarshal(rawData []byte) (int, error) {
 	offset = 0
 
 	// Unmarshalling data FileName
-	bytesRead, err = c.FileName.Unmarshal(rawDataContent[offset:])
+	bytesRead, err = c.FileName.UnmarshalWithEncoding(rawDataContent[offset:], c.IsUnicode())
 	if err != nil {
 		return offset, err
 	}

--- a/network/smb/smb_v10/message/commands/FindCloseRequest.go
+++ b/network/smb/smb_v10/message/commands/FindCloseRequest.go
@@ -90,7 +90,7 @@ func (c *FindCloseRequest) Marshal() ([]byte, error) {
 
 	// Marshalling data FileName
 	c.FileName.SetBufferFormat(types.SMB_STRING_BUFFER_FORMAT_NULL_TERMINATED_ASCII_STRING)
-	bytesStream, err := c.FileName.Marshal()
+	bytesStream, err := c.FileName.MarshalWithEncoding(c.IsUnicode())
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +98,7 @@ func (c *FindCloseRequest) Marshal() ([]byte, error) {
 
 	// Marshalling data ResumeKey
 	c.ResumeKey.SetBufferFormat(types.SMB_STRING_BUFFER_FORMAT_VARIABLE_BLOCK)
-	bytesStream, err = c.ResumeKey.Marshal()
+	bytesStream, err = c.ResumeKey.MarshalWithEncoding(c.IsUnicode())
 	if err != nil {
 		return nil, err
 	}
@@ -194,14 +194,14 @@ func (c *FindCloseRequest) Unmarshal(rawData []byte) (int, error) {
 	offset = 0
 
 	// Unmarshalling data FileName
-	bytesRead, err = c.FileName.Unmarshal(rawDataContent[offset:])
+	bytesRead, err = c.FileName.UnmarshalWithEncoding(rawDataContent[offset:], c.IsUnicode())
 	if err != nil {
 		return offset, err
 	}
 	offset += bytesRead
 
 	// Unmarshalling data ResumeKey
-	bytesRead, err = c.ResumeKey.Unmarshal(rawDataContent[offset:])
+	bytesRead, err = c.ResumeKey.UnmarshalWithEncoding(rawDataContent[offset:], c.IsUnicode())
 	if err != nil {
 		return offset, err
 	}

--- a/network/smb/smb_v10/message/commands/FindRequest.go
+++ b/network/smb/smb_v10/message/commands/FindRequest.go
@@ -103,7 +103,7 @@ func (c *FindRequest) Marshal() ([]byte, error) {
 
 	// Marshalling data FileName
 	c.FileName.SetBufferFormat(types.SMB_STRING_BUFFER_FORMAT_NULL_TERMINATED_ASCII_STRING)
-	bytesStream, err := c.FileName.Marshal()
+	bytesStream, err := c.FileName.MarshalWithEncoding(c.IsUnicode())
 	if err != nil {
 		return nil, err
 	}
@@ -111,7 +111,7 @@ func (c *FindRequest) Marshal() ([]byte, error) {
 
 	// Marshalling data ResumeKey
 	c.ResumeKey.SetBufferFormat(types.SMB_STRING_BUFFER_FORMAT_VARIABLE_BLOCK)
-	bytesStream, err = c.ResumeKey.Marshal()
+	bytesStream, err = c.ResumeKey.MarshalWithEncoding(c.IsUnicode())
 	if err != nil {
 		return nil, err
 	}
@@ -209,14 +209,14 @@ func (c *FindRequest) Unmarshal(rawData []byte) (int, error) {
 	offset = 0
 
 	// Unmarshalling data FileName
-	bytesRead, err = c.FileName.Unmarshal(rawDataContent[offset:])
+	bytesRead, err = c.FileName.UnmarshalWithEncoding(rawDataContent[offset:], c.IsUnicode())
 	if err != nil {
 		return offset, err
 	}
 	offset += bytesRead
 
 	// Unmarshalling data ResumeKey
-	bytesRead, err = c.ResumeKey.Unmarshal(rawDataContent[offset:])
+	bytesRead, err = c.ResumeKey.UnmarshalWithEncoding(rawDataContent[offset:], c.IsUnicode())
 	if err != nil {
 		return offset, err
 	}

--- a/network/smb/smb_v10/message/commands/FindUniqueRequest.go
+++ b/network/smb/smb_v10/message/commands/FindUniqueRequest.go
@@ -99,7 +99,7 @@ func (c *FindUniqueRequest) Marshal() ([]byte, error) {
 	// Marshalling data FileName
 	// BufferFormat1 (1 byte) MUST be 0x04, indicating a null-terminated ASCII string follows.
 	c.FileName.SetBufferFormat(types.SMB_STRING_BUFFER_FORMAT_NULL_TERMINATED_ASCII_STRING)
-	bytesStream, err := c.FileName.Marshal()
+	bytesStream, err := c.FileName.MarshalWithEncoding(c.IsUnicode())
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +109,7 @@ func (c *FindUniqueRequest) Marshal() ([]byte, error) {
 	// BufferFormat2 (1 byte) MUST be 0x05; with no resume key permitted, this emits a
 	// ResumeKeyLength of 0x0000 and no resume-key body.
 	c.ResumeKey.SetBufferFormat(types.SMB_STRING_BUFFER_FORMAT_VARIABLE_BLOCK)
-	bytesStream, err = c.ResumeKey.Marshal()
+	bytesStream, err = c.ResumeKey.MarshalWithEncoding(c.IsUnicode())
 	if err != nil {
 		return nil, err
 	}
@@ -207,14 +207,14 @@ func (c *FindUniqueRequest) Unmarshal(rawData []byte) (int, error) {
 	offset = 0
 
 	// Unmarshalling data FileName
-	bytesRead, err = c.FileName.Unmarshal(rawDataContent[offset:])
+	bytesRead, err = c.FileName.UnmarshalWithEncoding(rawDataContent[offset:], c.IsUnicode())
 	if err != nil {
 		return offset, err
 	}
 	offset += bytesRead
 
 	// Unmarshalling data ResumeKey
-	bytesRead, err = c.ResumeKey.Unmarshal(rawDataContent[offset:])
+	bytesRead, err = c.ResumeKey.UnmarshalWithEncoding(rawDataContent[offset:], c.IsUnicode())
 	if err != nil {
 		return offset, err
 	}

--- a/network/smb/smb_v10/message/commands/NtCreateAndxRequest.go
+++ b/network/smb/smb_v10/message/commands/NtCreateAndxRequest.go
@@ -377,17 +377,20 @@ func (c *NtCreateAndxRequest) Unmarshal(rawData []byte) (int, error) {
 
 	// Unmarshalling data FileName: a raw null-terminated string with no SMB_STRING
 	// buffer-format byte (mirrors Marshal above).
-	nameBytes := []byte{}
-	for offset < len(rawDataContent) && rawDataContent[offset] != 0x00 {
-		nameBytes = append(nameBytes, rawDataContent[offset])
+	//
+	// A Unicode FileName is 16-bit aligned relative to the start of the SMB header
+	// ([MS-CIFS] section 2.2.4.64.1), and the data block begins at an even offset
+	// there — SMB_HEADER_SIZE(32) + WordCount(1) + 24 words(48) + ByteCount(2) = 83,
+	// odd — so a pad byte precedes the name. Its terminator is two bytes wide too:
+	// scanning for a single null byte ends the name at the high half of its first
+	// character.
+	if c.IsUnicode() && (ntCreateAndxDataOffset+offset)%2 != 0 && offset < len(rawDataContent) {
 		offset++
 	}
+	nameBytes, nameSize := readTerminatedName(rawDataContent[offset:], c.IsUnicode())
 	c.FileName.Buffer = []types.UCHAR(nameBytes)
 	c.FileName.Length = types.USHORT(len(nameBytes))
-	if offset < len(rawDataContent) {
-		// Consume the null terminator.
-		offset++
-	}
+	offset += nameSize
 
 	return offset, nil
 }

--- a/network/smb/smb_v10/message/commands/NtRenameRequest.go
+++ b/network/smb/smb_v10/message/commands/NtRenameRequest.go
@@ -97,7 +97,7 @@ func (c *NtRenameRequest) Marshal() ([]byte, error) {
 
 	// Marshalling data OldFileName
 	c.OldFileName.SetBufferFormat(types.SMB_STRING_BUFFER_FORMAT_NULL_TERMINATED_ASCII_STRING)
-	bytesStream, err := c.OldFileName.Marshal()
+	bytesStream, err := c.OldFileName.MarshalWithEncoding(c.IsUnicode())
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +105,8 @@ func (c *NtRenameRequest) Marshal() ([]byte, error) {
 
 	// Marshalling data NewFileName
 	c.NewFileName.SetBufferFormat(types.SMB_STRING_BUFFER_FORMAT_NULL_TERMINATED_ASCII_STRING)
-	bytesStream, err = c.NewFileName.Marshal()
+	bytesStream, err = c.NewFileName.MarshalWithEncodingAt(c.IsUnicode(),
+		ntRenameDataOffset+len(rawDataContent)+1)
 	if err != nil {
 		return nil, err
 	}
@@ -218,14 +219,18 @@ func (c *NtRenameRequest) Unmarshal(rawData []byte) (int, error) {
 	offset = 0
 
 	// Unmarshalling data OldFileName
-	bytesRead, err = c.OldFileName.Unmarshal(rawDataContent[offset:])
+	bytesRead, err = c.OldFileName.UnmarshalWithEncoding(rawDataContent[offset:], c.IsUnicode())
 	if err != nil {
 		return offset, err
 	}
 	offset += bytesRead
 
 	// Unmarshalling data NewFileName
-	bytesRead, err = c.NewFileName.Unmarshal(rawDataContent[offset:])
+	// The second name is where the alignment byte turns up: the first name's
+	// length decides where this one starts, so it lands on an odd offset from
+	// the header half the time and a pad byte precedes its characters.
+	bytesRead, err = c.NewFileName.UnmarshalWithEncodingAt(
+		rawDataContent[offset:], c.IsUnicode(), ntRenameDataOffset+offset+1)
 	if err != nil {
 		return offset, err
 	}

--- a/network/smb/smb_v10/message/commands/NtTransactRequest.go
+++ b/network/smb/smb_v10/message/commands/NtTransactRequest.go
@@ -197,6 +197,20 @@ func (c *NtTransactRequest) Marshal() ([]byte, error) {
 		}
 	}
 
+	// The offsets are derived from the layout being written rather than taken from
+	// the caller: a declared offset that disagrees with where the bytes actually
+	// went is worse than one that is missing, because a receiver following
+	// [MS-CIFS] trusts it and reads the payload at the wrong place.
+	c.ParameterOffset, c.DataOffset = types.ULONG(0), types.ULONG(0)
+	{
+		parameterOffset, dataOffset := deriveTransactionOffsets(
+			ntTransactWordCount+len(c.Setup),
+			0, len(c.Pad1), len(c.NT_Trans_Parameters), len(c.Pad2), len(c.NT_Trans_Data),
+		)
+		c.ParameterOffset = types.ULONG(parameterOffset)
+		c.DataOffset = types.ULONG(dataOffset)
+	}
+
 	// First marshal the data and then the parameters
 	// This is because some parameters are dependent on the data, for example the size of some fields within
 	// the data will be stored in the parameters
@@ -440,52 +454,25 @@ func (c *NtTransactRequest) Unmarshal(rawData []byte) (int, error) {
 
 	// Unmarshalling data Pad1, NT_Trans_Parameters, Pad2, NT_Trans_Data.
 	//
-	// ParameterOffset and DataOffset are measured from the start of the SMB header,
-	// not as lengths within this data block, so they cannot be used directly as the
-	// Pad1/Pad2 byte counts. Recover the inter-block gaps from the shared
-	// header-relative base instead:
-	//   len(Pad2) = DataOffset - (ParameterOffset + ParameterCount)
-	//   len(Pad1) = remaining bytes once NT_Trans_Parameters, Pad2 and NT_Trans_Data are accounted for
-	parameterCount := int(c.ParameterCount)
-	dataCount := int(c.DataCount)
-
-	pad2Length := 0
-	if dataCount > 0 {
-		pad2Length = int(c.DataOffset) - (int(c.ParameterOffset) + parameterCount)
-		if pad2Length < 0 {
-			return offset, fmt.Errorf("invalid offsets: DataOffset precedes end of NT_Trans_Parameters")
-		}
+	// The two blocks are located by the offsets the message declares, which
+	// [MS-CIFS] measures from the start of the SMB header and requires the receiver
+	// to use. They are not derived by subtracting the field lengths from the size
+	// of the data block: a sender pads the end of the block as well as the middle,
+	// and that arithmetic charges the trailing padding to the leading pad, which
+	// shifts every field in both blocks.
+	pad1, parameterBlock, pad2, dataBlock, consumed, err := locateTransactionBlocks(
+		rawDataContent, rawParametersContent, offset,
+		int(c.ParameterOffset), int(c.ParameterCount),
+		int(c.DataOffset), int(c.DataCount),
+	)
+	if err != nil {
+		return offset, err
 	}
 
-	pad1Length := len(rawDataContent) - offset - parameterCount - pad2Length - dataCount
-	if pad1Length < 0 {
-		return offset, fmt.Errorf("rawDataContent too short for NT_Transact data block")
-	}
+	c.Pad1 = pad1
+	c.NT_Trans_Parameters = parameterBlock
+	c.Pad2 = pad2
+	c.NT_Trans_Data = dataBlock
 
-	// Unmarshalling data Pad1
-	c.Pad1 = rawDataContent[offset : offset+pad1Length]
-	offset += pad1Length
-
-	// Unmarshalling data NT_Trans_Parameters
-	if len(rawDataContent) < offset+parameterCount {
-		return offset, fmt.Errorf("rawDataContent too short for NT_Trans_Parameters")
-	}
-	c.NT_Trans_Parameters = rawDataContent[offset : offset+parameterCount]
-	offset += parameterCount
-
-	// Unmarshalling data Pad2
-	if len(rawDataContent) < offset+pad2Length {
-		return offset, fmt.Errorf("rawDataContent too short for Pad2")
-	}
-	c.Pad2 = rawDataContent[offset : offset+pad2Length]
-	offset += pad2Length
-
-	// Unmarshalling data NT_Trans_Data
-	if len(rawDataContent) < offset+dataCount {
-		return offset, fmt.Errorf("rawDataContent too short for NT_Trans_Data")
-	}
-	c.NT_Trans_Data = rawDataContent[offset : offset+dataCount]
-	offset += dataCount
-
-	return offset, nil
+	return consumed, nil
 }

--- a/network/smb/smb_v10/message/commands/NtTransactSecondaryRequest.go
+++ b/network/smb/smb_v10/message/commands/NtTransactSecondaryRequest.go
@@ -166,6 +166,20 @@ func (c *NtTransactSecondaryRequest) Marshal() ([]byte, error) {
 		}
 	}
 
+	// The offsets are derived from the layout being written rather than taken from
+	// the caller: a declared offset that disagrees with where the bytes actually
+	// went is worse than one that is missing, because a receiver following
+	// [MS-CIFS] trusts it and reads the payload at the wrong place.
+	c.ParameterOffset, c.DataOffset = types.ULONG(0), types.ULONG(0)
+	{
+		parameterOffset, dataOffset := deriveTransactionOffsets(
+			ntTransactSecondaryWordCount,
+			0, len(c.Pad1), len(c.NT_Trans_Parameters), len(c.Pad2), len(c.NT_Trans_Data),
+		)
+		c.ParameterOffset = types.ULONG(parameterOffset)
+		c.DataOffset = types.ULONG(dataOffset)
+	}
+
 	// First marshal the data and then the parameters
 	// This is because some parameters are dependent on the data, for example the size of some fields within
 	// the data will be stored in the parameters
@@ -392,30 +406,27 @@ func (c *NtTransactSecondaryRequest) Unmarshal(rawData []byte) (int, error) {
 		return offset, fmt.Errorf("rawDataContent too short for NT_Trans_Secondary rawData block")
 	}
 
-	// Unmarshalling data Pad1
-	c.Pad1 = rawDataContent[offset : offset+pad1Length]
-	offset += pad1Length
-
-	// Unmarshalling data NT_Trans_Parameters
-	if len(rawDataContent) < offset+parameterCount {
-		return offset, fmt.Errorf("rawDataContent too short for NT_Trans_Parameters")
+	// Unmarshalling data Pad1, NT_Trans_Parameters, Pad2, NT_Trans_Data.
+	//
+	// The two blocks are located by the offsets the message declares, which
+	// [MS-CIFS] measures from the start of the SMB header and requires the receiver
+	// to use. They are not derived by subtracting the field lengths from the size
+	// of the data block: a sender pads the end of the block as well as the middle,
+	// and that arithmetic charges the trailing padding to the leading pad, which
+	// shifts every field in both blocks.
+	pad1, parameterBlock, pad2, dataBlock, consumed, err := locateTransactionBlocks(
+		rawDataContent, rawParametersContent, offset,
+		int(c.ParameterOffset), int(c.ParameterCount),
+		int(c.DataOffset), int(c.DataCount),
+	)
+	if err != nil {
+		return offset, err
 	}
-	c.NT_Trans_Parameters = rawDataContent[offset : offset+parameterCount]
-	offset += parameterCount
 
-	// Unmarshalling data Pad2
-	if len(rawDataContent) < offset+pad2Length {
-		return offset, fmt.Errorf("rawDataContent too short for Pad2")
-	}
-	c.Pad2 = rawDataContent[offset : offset+pad2Length]
-	offset += pad2Length
+	c.Pad1 = pad1
+	c.NT_Trans_Parameters = parameterBlock
+	c.Pad2 = pad2
+	c.NT_Trans_Data = dataBlock
 
-	// Unmarshalling data NT_Trans_Data
-	if len(rawDataContent) < offset+dataCount {
-		return offset, fmt.Errorf("rawDataContent too short for NT_Trans_Data")
-	}
-	c.NT_Trans_Data = rawDataContent[offset : offset+dataCount]
-	offset += dataCount
-
-	return offset, nil
+	return consumed, nil
 }

--- a/network/smb/smb_v10/message/commands/OpenAndxRequest.go
+++ b/network/smb/smb_v10/message/commands/OpenAndxRequest.go
@@ -129,7 +129,7 @@ func (c *OpenAndxRequest) Marshal() ([]byte, error) {
 	rawDataContent := []byte{}
 
 	// Marshalling data FileName
-	bytesStream, err := c.FileName.Marshal()
+	bytesStream, err := c.FileName.MarshalWithEncoding(c.IsUnicode())
 	if err != nil {
 		return nil, err
 	}
@@ -320,7 +320,7 @@ func (c *OpenAndxRequest) Unmarshal(rawData []byte) (int, error) {
 	offset = 0
 
 	// Unmarshalling data FileName
-	bytesRead, err = c.FileName.Unmarshal(rawDataContent[offset:])
+	bytesRead, err = c.FileName.UnmarshalWithEncoding(rawDataContent[offset:], c.IsUnicode())
 	if err != nil {
 		return offset, err
 	}

--- a/network/smb/smb_v10/message/commands/OpenRequest.go
+++ b/network/smb/smb_v10/message/commands/OpenRequest.go
@@ -94,7 +94,7 @@ func (c *OpenRequest) Marshal() ([]byte, error) {
 	// (a null-terminated ASCII string follows). The SMB_STRING marshaller emits this byte from its
 	// BufferFormat field, so it must be set before marshalling.
 	c.FileName.SetBufferFormat(types.SMB_STRING_BUFFER_FORMAT_NULL_TERMINATED_ASCII_STRING)
-	bytesStream, err := c.FileName.Marshal()
+	bytesStream, err := c.FileName.MarshalWithEncoding(c.IsUnicode())
 	if err != nil {
 		return nil, err
 	}
@@ -195,7 +195,7 @@ func (c *OpenRequest) Unmarshal(rawData []byte) (int, error) {
 	offset = 0
 
 	// Unmarshalling data FileName
-	bytesRead, err = c.FileName.Unmarshal(rawDataContent[offset:])
+	bytesRead, err = c.FileName.UnmarshalWithEncoding(rawDataContent[offset:], c.IsUnicode())
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/QueryInformationRequest.go
+++ b/network/smb/smb_v10/message/commands/QueryInformationRequest.go
@@ -74,7 +74,7 @@ func (c *QueryInformationRequest) Marshal() ([]byte, error) {
 
 	// Marshalling data FileName
 	c.FileName.SetBufferFormat(types.SMB_STRING_BUFFER_FORMAT_NULL_TERMINATED_ASCII_STRING)
-	bytesStream, err := c.FileName.Marshal()
+	bytesStream, err := c.FileName.MarshalWithEncoding(c.IsUnicode())
 	if err != nil {
 		return nil, err
 	}
@@ -147,7 +147,7 @@ func (c *QueryInformationRequest) Unmarshal(rawData []byte) (int, error) {
 	offset = 0
 
 	// Unmarshalling data FileName
-	bytesRead, err = c.FileName.Unmarshal(rawDataContent[offset:])
+	bytesRead, err = c.FileName.UnmarshalWithEncoding(rawDataContent[offset:], c.IsUnicode())
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/RenameRequest.go
+++ b/network/smb/smb_v10/message/commands/RenameRequest.go
@@ -96,7 +96,7 @@ func (c *RenameRequest) Marshal() ([]byte, error) {
 
 	// Marshalling data OldFileName
 	c.OldFileName.SetBufferFormat(types.SMB_STRING_BUFFER_FORMAT_NULL_TERMINATED_ASCII_STRING)
-	bytesStream, err := c.OldFileName.Marshal()
+	bytesStream, err := c.OldFileName.MarshalWithEncoding(c.IsUnicode())
 	if err != nil {
 		return nil, err
 	}
@@ -104,7 +104,8 @@ func (c *RenameRequest) Marshal() ([]byte, error) {
 
 	// Marshalling data NewFileName
 	c.NewFileName.SetBufferFormat(types.SMB_STRING_BUFFER_FORMAT_NULL_TERMINATED_ASCII_STRING)
-	bytesStream, err = c.NewFileName.Marshal()
+	bytesStream, err = c.NewFileName.MarshalWithEncodingAt(c.IsUnicode(),
+		renameDataOffset+len(rawDataContent)+1)
 	if err != nil {
 		return nil, err
 	}
@@ -190,14 +191,18 @@ func (c *RenameRequest) Unmarshal(rawData []byte) (int, error) {
 	offset = 0
 
 	// Unmarshalling data OldFileName
-	bytesRead, err = c.OldFileName.Unmarshal(rawDataContent[offset:])
+	bytesRead, err = c.OldFileName.UnmarshalWithEncoding(rawDataContent[offset:], c.IsUnicode())
 	if err != nil {
 		return offset, err
 	}
 	offset += bytesRead
 
 	// Unmarshalling data NewFileName
-	bytesRead, err = c.NewFileName.Unmarshal(rawDataContent[offset:])
+	// The second name is where the alignment byte turns up: the first name's
+	// length decides where this one starts, so it lands on an odd offset from
+	// the header half the time and a pad byte precedes its characters.
+	bytesRead, err = c.NewFileName.UnmarshalWithEncodingAt(
+		rawDataContent[offset:], c.IsUnicode(), renameDataOffset+offset+1)
 	if err != nil {
 		return offset, err
 	}

--- a/network/smb/smb_v10/message/commands/SearchRequest.go
+++ b/network/smb/smb_v10/message/commands/SearchRequest.go
@@ -114,14 +114,14 @@ func (c *SearchRequest) Marshal() ([]byte, error) {
 
 	// Marshalling data FileName
 	c.FileName.SetBufferFormat(types.SMB_STRING_BUFFER_FORMAT_NULL_TERMINATED_ASCII_STRING)
-	bytesStream, err := c.FileName.Marshal()
+	bytesStream, err := c.FileName.MarshalWithEncoding(c.IsUnicode())
 	if err != nil {
 		return nil, err
 	}
 	rawDataContent = append(rawDataContent, bytesStream...)
 
 	// Marshalling data ResumeKey
-	bytesStream, err = c.ResumeKey.Marshal()
+	bytesStream, err = c.ResumeKey.MarshalWithEncoding(c.IsUnicode())
 	if err != nil {
 		return nil, err
 	}
@@ -219,14 +219,14 @@ func (c *SearchRequest) Unmarshal(rawData []byte) (int, error) {
 	offset = 0
 
 	// Unmarshalling data FileName
-	bytesRead, err = c.FileName.Unmarshal(rawDataContent[offset:])
+	bytesRead, err = c.FileName.UnmarshalWithEncoding(rawDataContent[offset:], c.IsUnicode())
 	if err != nil {
 		return offset, err
 	}
 	offset += bytesRead
 
 	// Unmarshalling data ResumeKey
-	bytesRead, err = c.ResumeKey.Unmarshal(rawDataContent[offset:])
+	bytesRead, err = c.ResumeKey.UnmarshalWithEncoding(rawDataContent[offset:], c.IsUnicode())
 	if err != nil {
 		return offset, err
 	}

--- a/network/smb/smb_v10/message/commands/SetInformationRequest.go
+++ b/network/smb/smb_v10/message/commands/SetInformationRequest.go
@@ -96,7 +96,7 @@ func (c *SetInformationRequest) Marshal() ([]byte, error) {
 
 	// Marshalling data FileName
 	c.FileName.SetBufferFormat(types.SMB_STRING_BUFFER_FORMAT_NULL_TERMINATED_ASCII_STRING)
-	bytesStream, err := c.FileName.Marshal()
+	bytesStream, err := c.FileName.MarshalWithEncoding(c.IsUnicode())
 	if err != nil {
 		return nil, err
 	}
@@ -204,7 +204,7 @@ func (c *SetInformationRequest) Unmarshal(rawData []byte) (int, error) {
 	offset = 0
 
 	// Unmarshalling data FileName
-	bytesRead, err = c.FileName.Unmarshal(rawDataContent[offset:])
+	bytesRead, err = c.FileName.UnmarshalWithEncoding(rawDataContent[offset:], c.IsUnicode())
 	if err != nil {
 		return offset, err
 	}

--- a/network/smb/smb_v10/message/commands/Transaction2Request.go
+++ b/network/smb/smb_v10/message/commands/Transaction2Request.go
@@ -218,6 +218,20 @@ func (c *Transaction2Request) Marshal() ([]byte, error) {
 		}
 	}
 
+	// The offsets are derived from the layout being written rather than taken from
+	// the caller: a declared offset that disagrees with where the bytes actually
+	// went is worse than one that is missing, because a receiver following
+	// [MS-CIFS] trusts it and reads the payload at the wrong place.
+	c.ParameterOffset, c.DataOffset = types.USHORT(0), types.USHORT(0)
+	{
+		parameterOffset, dataOffset := deriveTransactionOffsets(
+			transaction2WordCount+len(c.Setup),
+			1, len(c.Pad1), len(c.Trans2_Parameters), len(c.Pad2), len(c.Trans2_Data),
+		)
+		c.ParameterOffset = types.USHORT(parameterOffset)
+		c.DataOffset = types.USHORT(dataOffset)
+	}
+
 	// First marshal the data and then the parameters
 	// This is because some parameters are dependent on the data, for example the size of some fields within
 	// the data will be stored in the parameters
@@ -502,52 +516,25 @@ func (c *Transaction2Request) Unmarshal(rawData []byte) (int, error) {
 
 	// Unmarshalling data Pad1, Trans2_Parameters, Pad2, Trans2_Data.
 	//
-	// ParameterOffset and DataOffset are measured from the start of the SMB header,
-	// not as lengths within this data block, so they cannot be used directly as the
-	// Pad1/Pad2 byte counts. Recover the inter-block gaps from the shared
-	// header-relative base instead:
-	//   len(Pad2) = DataOffset - (ParameterOffset + ParameterCount)
-	//   len(Pad1) = remaining bytes once Trans2_Parameters, Pad2 and Trans2_Data are accounted for
-	parameterCount := int(c.ParameterCount)
-	dataCount := int(c.DataCount)
-
-	pad2Length := 0
-	if dataCount > 0 {
-		pad2Length = int(c.DataOffset) - (int(c.ParameterOffset) + parameterCount)
-		if pad2Length < 0 {
-			return offset, fmt.Errorf("invalid offsets: DataOffset precedes end of Trans2_Parameters")
-		}
+	// The two blocks are located by the offsets the message declares, which
+	// [MS-CIFS] measures from the start of the SMB header and requires the receiver
+	// to use. They are not derived by subtracting the field lengths from the size
+	// of the data block: a sender pads the end of the block as well as the middle,
+	// and that arithmetic charges the trailing padding to the leading pad, which
+	// shifts every field in both blocks.
+	pad1, parameterBlock, pad2, dataBlock, consumed, err := locateTransactionBlocks(
+		rawDataContent, rawParametersContent, offset,
+		int(c.ParameterOffset), int(c.ParameterCount),
+		int(c.DataOffset), int(c.DataCount),
+	)
+	if err != nil {
+		return offset, err
 	}
 
-	pad1Length := len(rawDataContent) - offset - parameterCount - pad2Length - dataCount
-	if pad1Length < 0 {
-		return offset, fmt.Errorf("rawDataContent too short for Transaction2 data block")
-	}
+	c.Pad1 = pad1
+	c.Trans2_Parameters = parameterBlock
+	c.Pad2 = pad2
+	c.Trans2_Data = dataBlock
 
-	// Unmarshalling data Pad1
-	c.Pad1 = rawDataContent[offset : offset+pad1Length]
-	offset += pad1Length
-
-	// Unmarshalling data Trans2_Parameters
-	if len(rawDataContent) < offset+parameterCount {
-		return offset, fmt.Errorf("rawDataContent too short for Trans2_Parameters")
-	}
-	c.Trans2_Parameters = rawDataContent[offset : offset+parameterCount]
-	offset += parameterCount
-
-	// Unmarshalling data Pad2
-	if len(rawDataContent) < offset+pad2Length {
-		return offset, fmt.Errorf("rawDataContent too short for Pad2")
-	}
-	c.Pad2 = rawDataContent[offset : offset+pad2Length]
-	offset += pad2Length
-
-	// Unmarshalling data Trans2_Data
-	if len(rawDataContent) < offset+dataCount {
-		return offset, fmt.Errorf("rawDataContent too short for Trans2_Data")
-	}
-	c.Trans2_Data = rawDataContent[offset : offset+dataCount]
-	offset += dataCount
-
-	return offset, nil
+	return consumed, nil
 }

--- a/network/smb/smb_v10/message/commands/Transaction2SecondaryRequest.go
+++ b/network/smb/smb_v10/message/commands/Transaction2SecondaryRequest.go
@@ -164,6 +164,20 @@ func (c *Transaction2SecondaryRequest) Marshal() ([]byte, error) {
 		}
 	}
 
+	// The offsets are derived from the layout being written rather than taken from
+	// the caller: a declared offset that disagrees with where the bytes actually
+	// went is worse than one that is missing, because a receiver following
+	// [MS-CIFS] trusts it and reads the payload at the wrong place.
+	c.ParameterOffset, c.DataOffset = types.USHORT(0), types.USHORT(0)
+	{
+		parameterOffset, dataOffset := deriveTransactionOffsets(
+			transaction2SecondaryWordCount,
+			0, len(c.Pad1), len(c.Trans2_Parameters), len(c.Pad2), len(c.Trans2_Data),
+		)
+		c.ParameterOffset = types.USHORT(parameterOffset)
+		c.DataOffset = types.USHORT(dataOffset)
+	}
+
 	// First marshal the data and then the parameters
 	// This is because some parameters are dependent on the data, for example the size of some fields within
 	// the data will be stored in the parameters
@@ -356,52 +370,25 @@ func (c *Transaction2SecondaryRequest) Unmarshal(rawData []byte) (int, error) {
 
 	// Unmarshalling data Pad1, Trans2_Parameters, Pad2, Trans2_Data.
 	//
-	// ParameterOffset and DataOffset are measured from the start of the SMB header,
-	// not as lengths within this data block, so they cannot be used directly as the
-	// Pad1/Pad2 byte counts. Recover the inter-block gaps from the shared
-	// header-relative base instead:
-	//   len(Pad2) = DataOffset - (ParameterOffset + ParameterCount)
-	//   len(Pad1) = remaining bytes once Trans2_Parameters, Pad2 and Trans2_Data are accounted for
-	parameterCount := int(c.ParameterCount)
-	dataCount := int(c.DataCount)
-
-	pad2Length := 0
-	if dataCount > 0 {
-		pad2Length = int(c.DataOffset) - (int(c.ParameterOffset) + parameterCount)
-		if pad2Length < 0 {
-			return offset, fmt.Errorf("invalid offsets: DataOffset precedes end of Trans2_Parameters")
-		}
+	// The two blocks are located by the offsets the message declares, which
+	// [MS-CIFS] measures from the start of the SMB header and requires the receiver
+	// to use. They are not derived by subtracting the field lengths from the size
+	// of the data block: a sender pads the end of the block as well as the middle,
+	// and that arithmetic charges the trailing padding to the leading pad, which
+	// shifts every field in both blocks.
+	pad1, parameterBlock, pad2, dataBlock, consumed, err := locateTransactionBlocks(
+		rawDataContent, rawParametersContent, offset,
+		int(c.ParameterOffset), int(c.ParameterCount),
+		int(c.DataOffset), int(c.DataCount),
+	)
+	if err != nil {
+		return offset, err
 	}
 
-	pad1Length := len(rawDataContent) - offset - parameterCount - pad2Length - dataCount
-	if pad1Length < 0 {
-		return offset, fmt.Errorf("rawDataContent too short for Transaction2_Secondary data block")
-	}
+	c.Pad1 = pad1
+	c.Trans2_Parameters = parameterBlock
+	c.Pad2 = pad2
+	c.Trans2_Data = dataBlock
 
-	// Unmarshalling data Pad1
-	c.Pad1 = rawDataContent[offset : offset+pad1Length]
-	offset += pad1Length
-
-	// Unmarshalling data Trans2_Parameters
-	if len(rawDataContent) < offset+parameterCount {
-		return offset, fmt.Errorf("rawDataContent too short for Trans2_Parameters")
-	}
-	c.Trans2_Parameters = rawDataContent[offset : offset+parameterCount]
-	offset += parameterCount
-
-	// Unmarshalling data Pad2
-	if len(rawDataContent) < offset+pad2Length {
-		return offset, fmt.Errorf("rawDataContent too short for Pad2")
-	}
-	c.Pad2 = rawDataContent[offset : offset+pad2Length]
-	offset += pad2Length
-
-	// Unmarshalling data Trans2_Data
-	if len(rawDataContent) < offset+dataCount {
-		return offset, fmt.Errorf("rawDataContent too short for Trans2_Data")
-	}
-	c.Trans2_Data = rawDataContent[offset : offset+dataCount]
-	offset += dataCount
-
-	return offset, nil
+	return consumed, nil
 }

--- a/network/smb/smb_v10/message/commands/TransactionRequest.go
+++ b/network/smb/smb_v10/message/commands/TransactionRequest.go
@@ -254,6 +254,20 @@ func (c *TransactionRequest) Marshal() ([]byte, error) {
 		}
 	}
 
+	// The offsets are derived from the layout being written rather than taken from
+	// the caller: a declared offset that disagrees with where the bytes actually
+	// went is worse than one that is missing, because a receiver following
+	// [MS-CIFS] trusts it and reads the payload at the wrong place.
+	c.ParameterOffset, c.DataOffset = types.USHORT(0), types.USHORT(0)
+	{
+		parameterOffset, dataOffset := deriveTransactionOffsets(
+			transactionWordCount+len(c.Setup),
+			len(c.Name.Buffer)+len(nameTerminator(c.IsUnicode())), len(c.Pad1), len(c.Trans_Parameters), len(c.Pad2), len(c.Trans_Data),
+		)
+		c.ParameterOffset = types.USHORT(parameterOffset)
+		c.DataOffset = types.USHORT(dataOffset)
+	}
+
 	// First marshal the data and then the parameters
 	// This is because some parameters are dependent on the data, for example the size of some fields within
 	// the data will be stored in the parameters
@@ -545,52 +559,25 @@ func (c *TransactionRequest) Unmarshal(rawData []byte) (int, error) {
 
 	// Unmarshalling data Pad1, Trans_Parameters, Pad2, Trans_Data.
 	//
-	// ParameterOffset and DataOffset are measured from the start of the SMB header,
-	// not as lengths within this data block, so they cannot be used directly as the
-	// Pad1/Pad2 byte counts. Recover the inter-block gaps from the shared
-	// header-relative base instead:
-	//   len(Pad2) = DataOffset - (ParameterOffset + ParameterCount)
-	//   len(Pad1) = remaining bytes once Trans_Parameters, Pad2 and Trans_Data are accounted for
-	parameterCount := int(c.ParameterCount)
-	dataCount := int(c.DataCount)
-
-	pad2Length := 0
-	if dataCount > 0 {
-		pad2Length = int(c.DataOffset) - (int(c.ParameterOffset) + parameterCount)
-		if pad2Length < 0 {
-			return offset, fmt.Errorf("invalid offsets: DataOffset precedes end of Trans_Parameters")
-		}
+	// The two blocks are located by the offsets the message declares, which
+	// [MS-CIFS] measures from the start of the SMB header and requires the receiver
+	// to use. They are not derived by subtracting the field lengths from the size
+	// of the data block: a sender pads the end of the block as well as the middle,
+	// and that arithmetic charges the trailing padding to the leading pad, which
+	// shifts every field in both blocks.
+	pad1, parameterBlock, pad2, dataBlock, consumed, err := locateTransactionBlocks(
+		rawDataContent, rawParametersContent, offset,
+		int(c.ParameterOffset), int(c.ParameterCount),
+		int(c.DataOffset), int(c.DataCount),
+	)
+	if err != nil {
+		return offset, err
 	}
 
-	pad1Length := len(rawDataContent) - offset - parameterCount - pad2Length - dataCount
-	if pad1Length < 0 {
-		return offset, fmt.Errorf("rawDataContent too short for Transaction data block")
-	}
+	c.Pad1 = pad1
+	c.Trans_Parameters = parameterBlock
+	c.Pad2 = pad2
+	c.Trans_Data = dataBlock
 
-	// Unmarshalling data Pad1
-	c.Pad1 = rawDataContent[offset : offset+pad1Length]
-	offset += pad1Length
-
-	// Unmarshalling data Trans_Parameters
-	if len(rawDataContent) < offset+parameterCount {
-		return offset, fmt.Errorf("rawDataContent too short for Trans_Parameters")
-	}
-	c.Trans_Parameters = rawDataContent[offset : offset+parameterCount]
-	offset += parameterCount
-
-	// Unmarshalling data Pad2
-	if len(rawDataContent) < offset+pad2Length {
-		return offset, fmt.Errorf("rawDataContent too short for Pad2")
-	}
-	c.Pad2 = rawDataContent[offset : offset+pad2Length]
-	offset += pad2Length
-
-	// Unmarshalling data Trans_Data
-	if len(rawDataContent) < offset+dataCount {
-		return offset, fmt.Errorf("rawDataContent too short for Trans_Data")
-	}
-	c.Trans_Data = rawDataContent[offset : offset+dataCount]
-	offset += dataCount
-
-	return offset, nil
+	return consumed, nil
 }

--- a/network/smb/smb_v10/message/commands/TransactionSecondaryRequest.go
+++ b/network/smb/smb_v10/message/commands/TransactionSecondaryRequest.go
@@ -158,6 +158,20 @@ func (c *TransactionSecondaryRequest) Marshal() ([]byte, error) {
 		}
 	}
 
+	// The offsets are derived from the layout being written rather than taken from
+	// the caller: a declared offset that disagrees with where the bytes actually
+	// went is worse than one that is missing, because a receiver following
+	// [MS-CIFS] trusts it and reads the payload at the wrong place.
+	c.ParameterOffset, c.DataOffset = types.USHORT(0), types.USHORT(0)
+	{
+		parameterOffset, dataOffset := deriveTransactionOffsets(
+			transactionSecondaryWordCount,
+			0, len(c.Pad1), len(c.Trans2_Parameters), len(c.Pad2), len(c.Trans2_Data),
+		)
+		c.ParameterOffset = types.USHORT(parameterOffset)
+		c.DataOffset = types.USHORT(dataOffset)
+	}
+
 	// First marshal the data and then the parameters
 	// This is because some parameters are dependent on the data, for example the size of some fields within
 	// the data will be stored in the parameters
@@ -338,52 +352,25 @@ func (c *TransactionSecondaryRequest) Unmarshal(rawData []byte) (int, error) {
 
 	// Unmarshalling data Pad1, Trans2_Parameters, Pad2, Trans2_Data.
 	//
-	// ParameterOffset and DataOffset are measured from the start of the SMB header,
-	// not as lengths within this data block, so they cannot be used directly as the
-	// Pad1/Pad2 byte counts. Recover the inter-block gaps from the shared
-	// header-relative base instead:
-	//   len(Pad2) = DataOffset - (ParameterOffset + ParameterCount)
-	//   len(Pad1) = remaining bytes once Trans2_Parameters, Pad2 and Trans2_Data are accounted for
-	parameterCount := int(c.ParameterCount)
-	dataCount := int(c.DataCount)
-
-	pad2Length := 0
-	if dataCount > 0 {
-		pad2Length = int(c.DataOffset) - (int(c.ParameterOffset) + parameterCount)
-		if pad2Length < 0 {
-			return offset, fmt.Errorf("invalid offsets: DataOffset precedes end of Trans2_Parameters")
-		}
+	// The two blocks are located by the offsets the message declares, which
+	// [MS-CIFS] measures from the start of the SMB header and requires the receiver
+	// to use. They are not derived by subtracting the field lengths from the size
+	// of the data block: a sender pads the end of the block as well as the middle,
+	// and that arithmetic charges the trailing padding to the leading pad, which
+	// shifts every field in both blocks.
+	pad1, parameterBlock, pad2, dataBlock, consumed, err := locateTransactionBlocks(
+		rawDataContent, rawParametersContent, offset,
+		int(c.ParameterOffset), int(c.ParameterCount),
+		int(c.DataOffset), int(c.DataCount),
+	)
+	if err != nil {
+		return offset, err
 	}
 
-	pad1Length := len(rawDataContent) - offset - parameterCount - pad2Length - dataCount
-	if pad1Length < 0 {
-		return offset, fmt.Errorf("rawDataContent too short for Transaction_Secondary data block")
-	}
+	c.Pad1 = pad1
+	c.Trans2_Parameters = parameterBlock
+	c.Pad2 = pad2
+	c.Trans2_Data = dataBlock
 
-	// Unmarshalling data Pad1
-	c.Pad1 = rawDataContent[offset : offset+pad1Length]
-	offset += pad1Length
-
-	// Unmarshalling data Trans2_Parameters
-	if len(rawDataContent) < offset+parameterCount {
-		return offset, fmt.Errorf("rawDataContent too short for Trans2_Parameters")
-	}
-	c.Trans2_Parameters = rawDataContent[offset : offset+parameterCount]
-	offset += parameterCount
-
-	// Unmarshalling data Pad2
-	if len(rawDataContent) < offset+pad2Length {
-		return offset, fmt.Errorf("rawDataContent too short for Pad2")
-	}
-	c.Pad2 = rawDataContent[offset : offset+pad2Length]
-	offset += pad2Length
-
-	// Unmarshalling data Trans2_Data
-	if len(rawDataContent) < offset+dataCount {
-		return offset, fmt.Errorf("rawDataContent too short for Trans2_Data")
-	}
-	c.Trans2_Data = rawDataContent[offset : offset+dataCount]
-	offset += dataCount
-
-	return offset, nil
+	return consumed, nil
 }

--- a/network/smb/smb_v10/message/commands/TreeConnectAndxRequest.go
+++ b/network/smb/smb_v10/message/commands/TreeConnectAndxRequest.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"bytes"
 	"encoding/binary"
 	"fmt"
 
@@ -264,28 +263,44 @@ func (c *TreeConnectAndxRequest) Unmarshal(marshalledData []byte) (int, error) {
 	offset += int(c.PasswordLength)
 
 	// Unmarshalling data Pad
-	// Per MS-CIFS 2.2.4.55.1 the Pad field is zero or one null padding bytes used
-	// only to 16-bit-align the Unicode Path; when the Password is the single null
-	// padding byte it "takes the place of the Pad[] byte" and no Pad is present.
-	// The marshaller does not emit a standalone Pad byte in the round-trippable
-	// cases, so Unmarshal MUST NOT unconditionally consume one here: doing so eats
-	// the first byte of Path. Treat all bytes after Password as Path + Service.
+	// Per [MS-CIFS] section 2.2.4.55.1 the Pad field is zero or one null padding
+	// bytes used only to 16-bit-align the Unicode Path; when the Password is the
+	// single null padding byte it "takes the place of the Pad[] byte" and no Pad
+	// is present. So a Pad byte cannot be consumed unconditionally — that eats the
+	// first byte of Path — and it cannot be skipped unconditionally either, which
+	// leaves the Path off by one whenever the Password did not happen to align it.
+	//
+	// Whether one is present follows from where the data block sits: the request
+	// carries four parameter words, so the block begins at
+	// SMB_HEADER_SIZE(32) + WordCount(1) + 4 words(8) + ByteCount(2) = 43 bytes
+	// from the start of the header, an odd offset. A Unicode Path must start on an
+	// even one, so a pad byte is present exactly when the Password did not already
+	// make the offset even.
 	c.Pad = []types.UCHAR{}
+	if c.IsUnicode() && (treeConnectAndxDataOffset+offset)%2 != 0 && offset < len(rawDataContent) {
+		c.Pad = rawDataContent[offset : offset+1]
+		offset++
+	}
 
 	// Unmarshalling data Path
-	// Path is a null-terminated string; it ends at (and includes) its first null
-	// byte. The bytes that follow belong to the Service field, so Path MUST NOT
-	// swallow the remainder of the buffer.
-	pathNull := bytes.IndexByte(rawDataContent[offset:], 0x00)
-	if pathNull < 0 {
-		// No terminator found: the remaining bytes are the (unterminated) Path.
-		c.Path = rawDataContent[offset:]
-		offset += len(c.Path)
+	// Path is a null-terminated string; it ends at (and includes) its terminator.
+	// The bytes that follow belong to the Service field, so Path MUST NOT swallow
+	// the remainder of the buffer.
+	//
+	// The terminator is two bytes wide when the message is Unicode. Scanning for a
+	// single null byte instead ends the path at the high half of its first
+	// character, so a client that negotiated Unicode had every path truncated to
+	// one character.
+	pathSize, terminated := readTerminatedField(rawDataContent[offset:], c.IsUnicode())
+	// Path is kept with its terminator, which is what the marshaller writes back.
+	c.Path = rawDataContent[offset : offset+pathSize]
+	offset += pathSize
+	if !terminated {
+		// The remaining bytes are the (unterminated) Path, so there is no Service
+		// after it.
 		c.Service = []types.UCHAR{}
 		return offset, nil
 	}
-	c.Path = rawDataContent[offset : offset+pathNull+1]
-	offset += pathNull + 1
 
 	// Unmarshalling data Service
 	// Service is a null-terminated OEM string that follows Path.

--- a/network/smb/smb_v10/message/commands/TreeConnectRequest.go
+++ b/network/smb/smb_v10/message/commands/TreeConnectRequest.go
@@ -94,7 +94,7 @@ func (c *TreeConnectRequest) Marshal() ([]byte, error) {
 	rawDataContent := []byte{}
 
 	// Marshalling data Path
-	byteStream, err := c.Path.Marshal()
+	byteStream, err := c.Path.MarshalWithEncoding(c.IsUnicode())
 	if err != nil {
 		return nil, err
 	}
@@ -181,7 +181,7 @@ func (c *TreeConnectRequest) Unmarshal(rawData []byte) (int, error) {
 	offset = 0
 
 	// Unmarshalling data Path
-	bytesRead, err = c.Path.Unmarshal(rawDataContent[offset:])
+	bytesRead, err = c.Path.UnmarshalWithEncoding(rawDataContent[offset:], c.IsUnicode())
 	if err != nil {
 		return 0, err
 	}

--- a/network/smb/smb_v10/message/commands/terminated_name.go
+++ b/network/smb/smb_v10/message/commands/terminated_name.go
@@ -47,3 +47,40 @@ func readTerminatedName(data []byte, unicode bool) (name []byte, size int) {
 	}
 	return data, len(data)
 }
+
+// treeConnectAndxDataOffset is where an SMB_COM_TREE_CONNECT_ANDX request's data
+// block begins, measured from the start of the SMB header: SMB_HEADER_SIZE(32) +
+// WordCount(1) + four parameter words(8) + ByteCount(2). The alignment of a
+// Unicode field inside the block is relative to the header, so the block's own
+// offset is part of the arithmetic.
+const treeConnectAndxDataOffset = 43
+
+// readTerminatedField measures a null-terminated field at the start of a buffer,
+// returning the number of bytes it occupies including its terminator, and whether
+// a terminator was found at all.
+//
+// It is readTerminatedName measured rather than sliced, for the fields a decoder
+// keeps with their terminator. Reporting whether the field was terminated is what
+// lets a caller tell an unterminated field running to the end of the block — after
+// which there is nothing — from a terminated one with more fields behind it.
+func readTerminatedField(data []byte, unicode bool) (size int, terminated bool) {
+	value, size := readTerminatedName(data, unicode)
+	return size, size > len(value)
+}
+
+// ntCreateAndxDataOffset is where an SMB_COM_NT_CREATE_ANDX request's data block
+// begins, measured from the start of the SMB header: SMB_HEADER_SIZE(32) +
+// WordCount(1) + twenty-four parameter words(48) + ByteCount(2).
+const ntCreateAndxDataOffset = 83
+
+// Where the data block of the two-name commands begins, measured from the start of
+// the SMB header: SMB_HEADER_SIZE(32) + WordCount(1) + the parameter words +
+// ByteCount(2). A Unicode string inside the block is aligned relative to the
+// header, so the block's own offset is part of that arithmetic.
+const (
+	// SMB_COM_RENAME carries one parameter word, SearchAttributes.
+	renameDataOffset = 37
+	// SMB_COM_NT_RENAME carries four: SearchAttributes, InformationLevel and the
+	// two halves of ClusterCount.
+	ntRenameDataOffset = 43
+)

--- a/network/smb/smb_v10/message/commands/transaction_blocks.go
+++ b/network/smb/smb_v10/message/commands/transaction_blocks.go
@@ -1,0 +1,209 @@
+package commands
+
+import "fmt"
+
+// Locating the parameter and data blocks of a transaction message.
+//
+// All three transaction families — SMB_COM_TRANSACTION, SMB_COM_TRANSACTION2 and
+// SMB_COM_NT_TRANSACT, primary and secondary alike — carry their payload in two
+// blocks inside SMB_Data.Bytes, each preceded by however much padding the sender
+// chose. The padding is not described by a length: it is implied by
+// ParameterOffset and DataOffset, which [MS-CIFS] measures "from the start of the
+// SMB Header" and which it requires the receiver to use — of ParameterOffset,
+// "Server implementations MUST use this value to locate the transaction parameter
+// block within the request".
+//
+// Deriving the padding by subtracting the field lengths from the block's total
+// size instead looks equivalent and is not. It assumes the block ends exactly
+// where the last field ends, and a real client pads the END of the block as well
+// as the middle — to a four-byte boundary — so the surplus is charged to the
+// leading pad and every field in both blocks is read at the wrong offset. That is
+// invisible against a sender whose blocks happen to end flush, which is why it can
+// survive a round-trip test.
+
+// smbHeaderSize is the size of the fixed SMB header. It is defined here rather
+// than imported to keep this package free of a dependency on the header package.
+const smbHeaderSize = 32
+
+// transactionBlockStart returns the offset, from the start of the SMB header, of
+// the first byte of SMB_Data.Bytes — the byte the declared offsets are relative
+// to.
+//
+// It is derived from the parameter block actually decoded rather than from a
+// per-command constant, so it stays correct for the variable-length Setup array
+// that every one of these commands carries.
+func transactionBlockStart(parameterWords []byte) int {
+	// WordCount(1) + the parameter words + ByteCount(2).
+	return smbHeaderSize + 1 + len(parameterWords) + 2
+}
+
+// locateTransactionBlock resolves one declared block within SMB_Data.Bytes.
+//
+// A count of zero yields an empty block and no offset check, since [MS-CIFS]
+// allows the offset to be left at zero when the count is — a sender with nothing
+// to place has no offset to report.
+//
+// Parameters:
+//   - block: the bytes of SMB_Data.Bytes
+//   - blockStart: the offset of block[0] from the start of the SMB header
+//   - declaredOffset: the header-relative offset the message declares
+//   - count: the number of bytes the message declares at that offset
+//   - name: the field's name, for the error
+//
+// Returns:
+//   - The bytes of the block
+//   - The offset of its first byte within block, or len(block) when it is empty
+//   - An error if the declared offset and count do not lie within the block
+func locateTransactionBlock(
+	block []byte,
+	blockStart int,
+	declaredOffset int,
+	count int,
+	name string,
+) ([]byte, int, error) {
+	if count == 0 {
+		return []byte{}, len(block), nil
+	}
+	if count < 0 {
+		return nil, 0, fmt.Errorf("%s count is negative (%d)", name, count)
+	}
+
+	at := declaredOffset - blockStart
+	if at < 0 {
+		return nil, 0, fmt.Errorf("%s offset %d precedes the data block, which starts at %d",
+			name, declaredOffset, blockStart)
+	}
+	if at+count > len(block) {
+		return nil, 0, fmt.Errorf("%s of %d bytes at offset %d overruns the %d-byte data block",
+			name, count, declaredOffset, len(block))
+	}
+
+	return block[at : at+count], at, nil
+}
+
+// locateTransactionBlocks resolves both declared blocks of a transaction message
+// and the padding that precedes each.
+//
+// The pads are returned as they were received rather than as lengths: a sender is
+// free to put anything in them — [MS-CIFS] says only that they SHOULD be zero and
+// MUST be ignored — and keeping the bytes lets a re-marshalling reproduce the
+// message it came from.
+//
+// Parameters:
+//   - block: the bytes of SMB_Data.Bytes
+//   - parameterWords: the decoded parameter words, used to locate block[0]
+//   - nameSize: the size of the name field that precedes the first pad
+//   - parameterOffset, parameterCount: the declared parameter block
+//   - dataOffset, dataCount: the declared data block
+//
+// Returns:
+//   - pad1, parameters, pad2, data
+//   - The total number of bytes of block accounted for
+//   - An error if either declared block does not lie within the block
+func locateTransactionBlocks(
+	block []byte,
+	parameterWords []byte,
+	nameSize int,
+	parameterOffset, parameterCount int,
+	dataOffset, dataCount int,
+) (pad1, parameters, pad2, data []byte, consumed int, err error) {
+	blockStart := transactionBlockStart(parameterWords)
+
+	parameters, parametersAt, err := locateTransactionBlock(
+		block, blockStart, parameterOffset, parameterCount, "the parameter block")
+	if err != nil {
+		return nil, nil, nil, nil, 0, err
+	}
+	data, dataAt, err := locateTransactionBlock(
+		block, blockStart, dataOffset, dataCount, "the data block")
+	if err != nil {
+		return nil, nil, nil, nil, 0, err
+	}
+
+	// The pads are whatever lies between the name and the parameters, and between
+	// the parameters and the data. An empty block reports its position as the end
+	// of the buffer, which leaves the pad before it empty rather than negative.
+	if parametersAt < nameSize {
+		return nil, nil, nil, nil, 0, fmt.Errorf(
+			"the parameter block at offset %d overlaps the %d-byte name that precedes it",
+			parameterOffset, nameSize)
+	}
+	pad1 = block[nameSize:parametersAt]
+
+	afterParameters := parametersAt + parameterCount
+	if parameterCount == 0 {
+		afterParameters = nameSize
+	}
+	switch {
+	case dataCount == 0:
+		pad2 = []byte{}
+	case dataAt < afterParameters:
+		return nil, nil, nil, nil, 0, fmt.Errorf(
+			"the data block at offset %d precedes the end of the parameter block", dataOffset)
+	default:
+		pad2 = block[afterParameters:dataAt]
+	}
+
+	consumed = afterParameters
+	if dataCount > 0 {
+		consumed = dataAt + dataCount
+	}
+	return pad1, parameters, pad2, data, consumed, nil
+}
+
+// Word counts of the transaction-family messages, which fix where their data
+// block begins. Each was confirmed against the marshalled output rather than read
+// off the specification, since it is the layout this package actually produces
+// that the declared offsets have to describe.
+const (
+	// transactionWordCount and transaction2WordCount are the fixed part; both
+	// families add one word per setup word.
+	transactionWordCount  = 14
+	transaction2WordCount = 14
+	// ntTransactWordCount likewise, for the wider family.
+	ntTransactWordCount = 19
+
+	// The secondary messages carry no setup words.
+	transactionSecondaryWordCount  = 8
+	transaction2SecondaryWordCount = 9
+	ntTransactSecondaryWordCount   = 18
+)
+
+// deriveTransactionOffsets computes the header-relative offsets of the parameter
+// and data blocks from the layout a marshaller is about to write.
+//
+// A marshaller has to declare where it put the blocks, and the only way for the
+// declaration to be right is to derive it from the placement. Leaving the fields
+// for a caller to fill in — which is what they were before — means they are
+// either unset, and the receiver cannot find the blocks, or set to something that
+// disagrees with the bytes, which is worse: a receiver that trusts them, as
+// [MS-CIFS] tells it to, reads the payload at the wrong place and gets plausible
+// nonsense rather than an error.
+//
+// An empty block is declared at offset zero, which [MS-CIFS] permits when its
+// count is zero: there is no position to report for bytes that are not there.
+//
+// Parameters:
+//   - wordCount: the message's WordCount, setup words included
+//   - nameSize: the size of the name field at the start of the data block
+//   - pad1Size, parameterCount, pad2Size, dataCount: the layout being written
+//
+// Returns:
+//   - The offsets to declare for the parameter and data blocks
+func deriveTransactionOffsets(
+	wordCount int,
+	nameSize, pad1Size, parameterCount, pad2Size, dataCount int,
+) (parameterOffset, dataOffset int) {
+	blockStart := smbHeaderSize + 1 + 2*wordCount + 2
+
+	parameterOffset = blockStart + nameSize + pad1Size
+	dataOffset = parameterOffset + parameterCount + pad2Size
+
+	if parameterCount == 0 {
+		parameterOffset = 0
+	}
+	if dataCount == 0 {
+		dataOffset = 0
+	}
+	return parameterOffset, dataOffset
+}

--- a/network/smb/smb_v10/server/conformance_test.go
+++ b/network/smb/smb_v10/server/conformance_test.go
@@ -135,6 +135,8 @@ var servedCommands = map[codes.CommandCode]string{
 	codes.SMB_COM_DELETE_DIRECTORY: "removes an empty directory",
 	codes.SMB_COM_CHECK_DIRECTORY:  "reports whether a path is a directory",
 
+	codes.SMB_COM_QUERY_INFORMATION_DISK: "reports the volume's capacity in the legacy fields",
+
 	codes.SMB_COM_TRANSACTION2:           "carries the find and information subcommands",
 	codes.SMB_COM_TRANSACTION2_SECONDARY: "continues a fragmented transaction",
 	codes.SMB_COM_FIND_CLOSE2:            "releases a search handle",

--- a/network/smb/smb_v10/server/dispatch.go
+++ b/network/smb/smb_v10/server/dispatch.go
@@ -43,6 +43,9 @@ var dispatchTable = map[codes.CommandCode]commandHandler{
 	codes.SMB_COM_WRITE_ANDX:     handleWriteAndx,
 	codes.SMB_COM_FLUSH:          handleFlush,
 
+	// Volume.
+	codes.SMB_COM_QUERY_INFORMATION_DISK: handleQueryInformationDisk,
+
 	// File management.
 	codes.SMB_COM_DELETE:           handleDelete,
 	codes.SMB_COM_RENAME:           handleRename,

--- a/network/smb/smb_v10/server/doc.go
+++ b/network/smb/smb_v10/server/doc.go
@@ -42,6 +42,11 @@
 //     file, and TRANS_TRANSACT_NMPIPE writes a message to the handle and returns
 //     the answer. That write-then-read is the operation MS-RPC travels over, so a
 //     PipeHandler is all an RPC service needs to be reachable over SMB1.
+//   - The volume queries a client actually asks: the TRANSACTION2 volume levels,
+//     the pass-through information classes above 0x03E8 that carry the native
+//     ones, and the legacy SMB_COM_QUERY_INFORMATION_DISK. A client asks about
+//     free space after a listing whether or not anything wanted it, so leaving
+//     these unanswered puts an error in every session.
 //
 // All three transaction families share one reassembly, since they are the same
 // shape at different field widths: totals, a per-message count and a
@@ -102,6 +107,23 @@
 // plain success would leave an RPC client parsing a truncated response as a whole
 // one.
 //
+// # Character encoding
+//
+// Unicode is a per-message property, not a per-connection one: SMB_FLAGS2_UNICODE
+// is set on each message, and a client may negotiate Unicode and then send a
+// request in OEM. So every name is read and written in the encoding that message
+// declared, never in the connection's.
+//
+// The consequences are easy to underestimate. A null-terminated field ends at its
+// first null CHARACTER, so a Unicode name has a two-byte terminator and a
+// single-byte scan ends it after one character. A Unicode field also has to begin
+// on a 2-byte boundary measured from the start of the SMB header, so a padding byte
+// stands before it whenever the fields ahead of it did not leave it aligned — which
+// for the second name of a rename depends on the length of the first. And a name in
+// a response is read by the client as whatever the message declared, so a name
+// written in the other encoding produces a reply of the right shape and the wrong
+// text rather than an error.
+//
 // # Path containment
 //
 // Every path a client sends passes through resolvePath before any backend sees
@@ -153,6 +175,27 @@
 // whose header is well formed but whose body will not decode, is answered or
 // dropped rather than propagated, and a panic in a handler takes down only that
 // connection. FuzzServerFrame in this package exercises that path.
+//
+// A handle is not always backed by a file — a pipe handle has a handler instead,
+// and a backend may decline to open a directory — so every command that reads or
+// writes through one checks. The client chooses the handle, so an unguarded
+// dereference there is reachable by anyone who can open a pipe.
+//
+// # Interoperability
+//
+// The unit suite pairs this server with the SMB1 client in this repository, which
+// is fast to work with but shares this implementation's assumptions: a wire detail
+// both halves get wrong agrees with itself, and every round-trip passes.
+// live_interop_integration_test.go exists for that reason. Behind the
+// "integration" build tag, it drives a third-party client and a third-party RPC
+// client against a server started in-process, and asserts a clean session: a
+// listing by name, a file in both directions, the name-carrying commands, a
+// mandatory-signing session verified in both directions, and an RPC bind completed
+// over a named pipe.
+//
+// Not covered there: the NT_TRANSACT security-descriptor path, because the tool
+// that would drive it cannot be pointed at a non-privileged port. It is covered by
+// unit tests that parse the descriptor back with an independent parser.
 //
 // Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/
 package server

--- a/network/smb/smb_v10/server/fuzz_test.go
+++ b/network/smb/smb_v10/server/fuzz_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bytes"
+	"encoding/binary"
 	"io"
 	"net"
 	"testing"
@@ -144,6 +145,44 @@ func FuzzServerFrame(f *testing.F) {
 	f.Add(rawFrame(codes.SMB_COM_TRANSACTION_SECONDARY, flags.Flags(0),
 		flags2.Flags2(flags2.FLAGS2_NT_STATUS_ERROR_CODES),
 		append([]byte{0x08}, make([]byte, 8*2+2)...)))
+
+	// The Unicode shapes, which the live matrix showed are a different code path
+	// rather than the same one with wider characters. A name whose terminator is
+	// found at an odd offset leaves a buffer of odd length for the UTF-16 decoder,
+	// which is what took a connection down.
+	for _, command := range []codes.CommandCode{
+		codes.SMB_COM_CREATE_DIRECTORY, codes.SMB_COM_DELETE_DIRECTORY,
+		codes.SMB_COM_CHECK_DIRECTORY, codes.SMB_COM_DELETE, codes.SMB_COM_RENAME,
+		codes.SMB_COM_NT_CREATE_ANDX, codes.SMB_COM_TREE_CONNECT_ANDX,
+	} {
+		unicodeFlags := flags2.Flags2(flags2.FLAGS2_UNICODE | flags2.FLAGS2_NT_STATUS_ERROR_CODES)
+		// A buffer-format byte followed by an odd number of bytes with no aligned
+		// terminator.
+		f.Add(rawFrame(command, flags.Flags(0), unicodeFlags,
+			[]byte{0x00, 0x04, 0x00, 0x04, 0x5C, 0x00, 0x61}))
+		// A name whose only null byte sits at an odd offset.
+		f.Add(rawFrame(command, flags.Flags(0), unicodeFlags,
+			[]byte{0x01, 0x16, 0x00, 0x05, 0x00, 0x04, 0x5C, 0x00, 0x00}))
+		// Two names, the second of which is cut short mid-character.
+		f.Add(rawFrame(command, flags.Flags(0), unicodeFlags,
+			[]byte{0x01, 0x16, 0x00, 0x0C, 0x00, 0x04, 0x61, 0x00, 0x00, 0x00, 0x04, 0x00, 0x62}))
+	}
+
+	// A transaction whose declared offsets point outside its own data block, in
+	// both directions: before the block, and past its end.
+	transactionOffsets := append([]byte{0x0F}, make([]byte, 15*2+2)...)
+	// ParameterCount at word 11, ParameterOffset at word 12.
+	binary.LittleEndian.PutUint16(transactionOffsets[1+20:1+22], 8)
+	binary.LittleEndian.PutUint16(transactionOffsets[1+22:1+24], 0)
+	f.Add(rawFrame(codes.SMB_COM_TRANSACTION2, flags.Flags(0),
+		flags2.Flags2(flags2.FLAGS2_NT_STATUS_ERROR_CODES), transactionOffsets))
+	binary.LittleEndian.PutUint16(transactionOffsets[1+22:1+24], 0xFFFF)
+	f.Add(rawFrame(codes.SMB_COM_TRANSACTION2, flags.Flags(0),
+		flags2.Flags2(flags2.FLAGS2_NT_STATUS_ERROR_CODES), transactionOffsets))
+
+	// The legacy disk query, which reaches the volume arithmetic.
+	f.Add(rawFrame(codes.SMB_COM_QUERY_INFORMATION_DISK, flags.Flags(0),
+		flags2.Flags2(flags2.FLAGS2_NT_STATUS_ERROR_CODES), []byte{0x00, 0x00, 0x00}))
 
 	f.Fuzz(func(t *testing.T, raw []byte) {
 		srv, err := NewServer(Config{})

--- a/network/smb/smb_v10/server/handler_file.go
+++ b/network/smb/smb_v10/server/handler_file.go
@@ -353,8 +353,13 @@ func handleReadAndx(conn *Connection, w ResponseWriter, req *message.Message) nt
 		length = 0
 	}
 
+	file, status := fileFor(open)
+	if status != nt_status.NT_STATUS_SUCCESS {
+		return status
+	}
+
 	buffer := make([]byte, length)
-	read, err := open.File.ReadAt(buffer, offset)
+	read, err := file.ReadAt(buffer, offset)
 	if err != nil && !errors.Is(err, io.EOF) {
 		logger.Debugf("SMB1 server: reading %q for %s failed: %v", open.Path, conn.Remote, err)
 		return statusForFSError(err)
@@ -405,7 +410,12 @@ func handleWriteAndx(conn *Connection, w ResponseWriter, req *message.Message) n
 		data = data[:declared]
 	}
 
-	written, err := open.File.WriteAt(data, offset)
+	file, status := fileFor(open)
+	if status != nt_status.NT_STATUS_SUCCESS {
+		return status
+	}
+
+	written, err := file.WriteAt(data, offset)
 	if err != nil {
 		logger.Debugf("SMB1 server: writing %q for %s failed: %v", open.Path, conn.Remote, err)
 		return statusForFSError(err)
@@ -413,7 +423,7 @@ func handleWriteAndx(conn *Connection, w ResponseWriter, req *message.Message) n
 
 	// WritethroughMode asks for the write to be committed before the response.
 	if uint16(request.WriteMode)&writeThroughMode != 0 {
-		if err := open.File.Sync(); err != nil {
+		if err := file.Sync(); err != nil {
 			logger.Debugf("SMB1 server: syncing %q for %s failed: %v", open.Path, conn.Remote, err)
 			return statusForFSError(err)
 		}
@@ -468,4 +478,27 @@ func handleFlush(conn *Connection, w ResponseWriter, req *message.Message) nt_st
 		logger.Debugf("SMB1 server: failed to answer the flush for %s: %v", conn.Remote, err)
 	}
 	return nt_status.NT_STATUS_SUCCESS
+}
+
+// fileFor returns the backend handle a data command acts through, or the status
+// that says why there is none.
+//
+// A handle does not always have a file behind it. A pipe handle has a handler
+// instead, and a directory handle may have nothing at all — a backend is entitled
+// to decline to open a directory, since a directory handle is only ever used to
+// query. Reaching either through a read or a write is not a caller's mistake to be
+// answered with a crash: the client picks the FID, so both are reachable by anyone
+// who can open a pipe or a directory, and both have to produce a status.
+func fileFor(open *Open) (File, nt_status.NT_STATUS) {
+	switch {
+	case open.IsPipe:
+		// The pipe handler serves a transacted exchange rather than a stream. A
+		// client that reads or writes a pipe handle directly is told so, rather
+		// than given an empty read it would take for an answer.
+		return nil, nt_status.NT_STATUS_NOT_SUPPORTED
+	case open.File == nil:
+		// What a read or a write on a directory is answered with.
+		return nil, nt_status.NT_STATUS_INVALID_DEVICE_REQUEST
+	}
+	return open.File, nt_status.NT_STATUS_SUCCESS
 }

--- a/network/smb/smb_v10/server/handler_find.go
+++ b/network/smb/smb_v10/server/handler_find.go
@@ -7,6 +7,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/logger"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
 	"github.com/TheManticoreProject/Manticore/windows/nt_status"
 )
 
@@ -93,7 +94,10 @@ func handleFindFirst2(conn *Connection, req *message.Message, reassembly *transa
 	searchCount := int(binary.LittleEndian.Uint16(parameters[2:4]))
 	flags := binary.LittleEndian.Uint16(parameters[4:6])
 	informationLevel := binary.LittleEndian.Uint16(parameters[6:8])
-	requested := trimTerminator(string(parameters[12:]))
+	// The pattern is OEM or UTF-16 according to the request's own flag, like every
+	// other name a client sends. Reading it as OEM regardless turns a Unicode
+	// "\\*" into a backslash, a null and a star, which the path resolver refuses.
+	requested := decodeWireString([]types.UCHAR(parameters[12:]), req.Header.Flags2.IsUnicode())
 
 	if !supportedFindLevel(informationLevel) {
 		logger.Debugf("SMB1 server: %s asked for find information level 0x%04X, which is not served",
@@ -105,6 +109,18 @@ func handleFindFirst2(conn *Connection, req *message.Message, reassembly *transa
 	if err != nil {
 		logger.Debugf("SMB1 server: %s asked to enumerate %q, which is refused: %v", conn.Remote, requested, err)
 		return nil, nil, nt_status.NT_STATUS_OBJECT_PATH_SYNTAX_BAD
+	}
+
+	// A search whose pattern holds no wildcard resolves to a single path, and that
+	// path may name a file rather than a directory: naming one file exactly is how
+	// a client asks about it without opening it, and a client does that before
+	// deleting or renaming something. So a non-directory is turned back into a
+	// literal pattern matched in its parent, rather than being listed as a
+	// directory it is not.
+	if pattern == "" && directory != "" {
+		if attr, statErr := tree.Share.FS.Stat(directory); statErr == nil && !attr.IsDir {
+			directory, pattern = splitFinalElement(directory)
+		}
 	}
 
 	entries, err := tree.Share.FS.ReadDir(directory, pattern)
@@ -133,7 +149,7 @@ func handleFindFirst2(conn *Connection, req *message.Message, reassembly *transa
 		Created:          time.Now().UTC(),
 	}
 
-	data, returned := encodeFindEntries(search, searchCount, reassembly.maxDataCount)
+	data, returned := encodeFindEntries(search, searchCount, reassembly.maxDataCount, req.Header.Flags2.IsUnicode())
 	endOfSearch := search.exhausted()
 
 	// The search is kept only while there is more to hand out, and only if the
@@ -194,7 +210,7 @@ func handleFindNext2(conn *Connection, req *message.Message, reassembly *transac
 		return nil, nil, nt_status.NT_STATUS_INVALID_INFO_CLASS
 	}
 
-	data, returned := encodeFindEntries(search, searchCount, reassembly.maxDataCount)
+	data, returned := encodeFindEntries(search, searchCount, reassembly.maxDataCount, req.Header.Flags2.IsUnicode())
 	endOfSearch := search.exhausted()
 
 	if flags&findClose != 0 || (endOfSearch && flags&findCloseIfEndOfSearch != 0) {

--- a/network/smb/smb_v10/server/handler_info.go
+++ b/network/smb/smb_v10/server/handler_info.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/TheManticoreProject/Manticore/logger"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
 	"github.com/TheManticoreProject/Manticore/windows/nt_status"
 )
 
@@ -25,7 +27,9 @@ func handleQueryPathInformation(conn *Connection, req *message.Message, reassemb
 	}
 
 	level := binary.LittleEndian.Uint16(parameters[0:2])
-	requested := trimTerminator(string(parameters[6:]))
+	// The path follows the request's own encoding, as every name-carrying field
+	// does.
+	requested := decodeWireString([]types.UCHAR(parameters[6:]), req.Header.Flags2.IsUnicode())
 
 	path, err := resolvePath(requested)
 	if err != nil {
@@ -38,7 +42,7 @@ func handleQueryPathInformation(conn *Connection, req *message.Message, reassemb
 		return nil, nil, statusForFSError(err)
 	}
 
-	data, served := encodeFileInformation(level, attr, path)
+	data, served := encodeFileInformation(level, attr, path, req.Header.Flags2.IsUnicode())
 	if !served {
 		logger.Debugf("SMB1 server: %s asked for file information level 0x%04X, which is not served",
 			conn.Remote, level)
@@ -70,12 +74,29 @@ func handleQueryFileInformation(conn *Connection, req *message.Message, reassemb
 
 	// Asking the handle rather than the path: the two can differ if the file was
 	// renamed underneath, and the handle is what the client is talking about.
-	attr, err := open.File.Stat()
+	//
+	// A handle with no file behind it — a directory the backend declined to open,
+	// or a pipe — is described another way rather than refused, because querying is
+	// exactly what such a handle exists for.
+	var attr FileAttr
+	var err error
+	switch {
+	case open.IsPipe:
+		// There is no file system entry to describe, so the handle describes
+		// itself: a pipe has no size and no timestamps to report.
+		attr = FileAttr{Name: open.Path}
+	case open.File != nil:
+		attr, err = open.File.Stat()
+	case open.Tree != nil && open.Tree.Share.FS != nil:
+		attr, err = open.Tree.Share.FS.Stat(open.Path)
+	default:
+		return nil, nil, nt_status.NT_STATUS_INVALID_HANDLE
+	}
 	if err != nil {
 		return nil, nil, statusForFSError(err)
 	}
 
-	data, served := encodeFileInformation(level, attr, open.Path)
+	data, served := encodeFileInformation(level, attr, open.Path, req.Header.Flags2.IsUnicode())
 	if !served {
 		return nil, nil, nt_status.NT_STATUS_INVALID_INFO_CLASS
 	}
@@ -98,7 +119,9 @@ func handleSetPathInformation(conn *Connection, req *message.Message, reassembly
 	}
 
 	level := binary.LittleEndian.Uint16(parameters[0:2])
-	requested := trimTerminator(string(parameters[6:]))
+	// The path follows the request's own encoding, as every name-carrying field
+	// does.
+	requested := decodeWireString([]types.UCHAR(parameters[6:]), req.Header.Flags2.IsUnicode())
 
 	path, err := resolvePath(requested)
 	if err != nil {
@@ -182,7 +205,7 @@ func handleQueryFsInformation(conn *Connection, req *message.Message, reassembly
 		volume.Label = tree.Share.Name
 	}
 
-	data, served := encodeVolumeInformation(level, volume)
+	data, served := encodeVolumeInformation(level, volume, req.Header.Flags2.IsUnicode())
 	if !served {
 		logger.Debugf("SMB1 server: %s asked for volume information level 0x%04X, which is not served",
 			conn.Remote, level)
@@ -192,3 +215,72 @@ func handleQueryFsInformation(conn *Connection, req *message.Message, reassembly
 	// A volume query returns no response parameters.
 	return nil, data, nt_status.NT_STATUS_SUCCESS
 }
+
+// handleQueryInformationDisk answers SMB_COM_QUERY_INFORMATION_DISK, the legacy
+// way to ask how much room a share has.
+//
+// It is superseded by the TRANSACTION2 volume levels, but a client still sends it —
+// after a listing, whether or not anything asked for the free space — so a server
+// that does not answer it makes every session report an error that nothing was
+// waiting on.
+//
+// Its fields are 16-bit, so a volume larger than the counts can express has to be
+// scaled rather than truncated: reporting the low 16 bits of a large number would
+// describe a tiny volume, which is worse than describing a coarse one. The block
+// size is raised until the unit count fits ([MS-CIFS] section 2.2.4.55.2 notes the
+// same practice).
+func handleQueryInformationDisk(conn *Connection, w ResponseWriter, req *message.Message) nt_status.NT_STATUS {
+	tree, status := conn.treeFor(req)
+	if status != nt_status.NT_STATUS_SUCCESS {
+		return status
+	}
+
+	volume, err := tree.Share.FS.VolumeInfo()
+	if err != nil {
+		return statusForFSError(err)
+	}
+
+	blockSize := volume.BytesPerSector
+	if blockSize == 0 {
+		blockSize = defaultBytesPerSector
+	}
+	blocksPerUnit := volume.SectorsPerAllocationUnit
+	if blocksPerUnit == 0 {
+		blocksPerUnit = defaultSectorsPerAllocationUnit
+	}
+
+	unit := int64(blocksPerUnit) * int64(blockSize)
+	total, free := volume.TotalBytes/unit, volume.FreeBytes/unit
+	// Scale by doubling the blocks per unit until the counts fit. A client
+	// multiplies the three fields back together, so the product stays honest to
+	// within one unit while the fields stay representable.
+	for (total > 0xFFFF || free > 0xFFFF) && blocksPerUnit < 0x8000 {
+		blocksPerUnit *= 2
+		unit = int64(blocksPerUnit) * int64(blockSize)
+		total, free = volume.TotalBytes/unit, volume.FreeBytes/unit
+	}
+	if total > 0xFFFF {
+		total = 0xFFFF
+	}
+	if free > 0xFFFF {
+		free = 0xFFFF
+	}
+
+	response := commands.NewQueryInformationDiskResponse()
+	response.TotalUnits = types.USHORT(total)
+	response.BlocksPerUnit = types.USHORT(blocksPerUnit)
+	response.BlockSize = types.USHORT(blockSize)
+	response.FreeUnits = types.USHORT(free)
+
+	if err := w.WriteResponse(response); err != nil {
+		logger.Debugf("SMB1 server: failed to answer the disk query for %s: %v", conn.Remote, err)
+	}
+	return nt_status.NT_STATUS_SUCCESS
+}
+
+// Fallbacks for a backend that does not describe its allocation geometry. A client
+// divides by these, so zero is not a usable answer.
+const (
+	defaultBytesPerSector           = 512
+	defaultSectorsPerAllocationUnit = 8
+)

--- a/network/smb/smb_v10/server/handler_session.go
+++ b/network/smb/smb_v10/server/handler_session.go
@@ -182,16 +182,19 @@ func (c *Connection) finishAuthentication(
 	}
 
 	if armSigning {
-		// Signing is bootstrapped by this very exchange: the client signed this
-		// request with the key it derived, so the server can only check it now
-		// that it has derived the same key from the response.
-		if !signing.Verify(session.SessionKey, c.currentRequestFrame, authenticateRequestSequenceNumber) {
-			logger.Warnf("SMB1 server: %s from %s failed signature verification on the AUTHENTICATE",
-				session.Account(), c.Remote)
-			c.uids.Release(uid)
-			return nt_status.NT_STATUS_ACCESS_DENIED
-		}
-
+		// Signing is activated by this exchange rather than checked on it. The
+		// AUTHENTICATE request's own signature is not verified, and [MS-SMB]
+		// section 3.3.5.3 does not ask for it to be: it says only that once the key
+		// is acquired "the server MUST sign the SMB_COM_SESSION_SETUP_ANDX
+		// response ... by passing in a sequence number of one". The first request
+		// the server verifies is therefore the next one, at two.
+		//
+		// Verifying it would also add nothing. The key is derived from the very
+		// message the signature would cover, so anyone able to produce an
+		// AUTHENTICATE that verifies can produce its signature as well. What it
+		// does do is break real clients: a client that has not yet armed signing
+		// puts a placeholder in the field, and refusing that makes signing
+		// unusable rather than mandatory.
 		c.SigningActive = true
 		c.SigningKey = session.SessionKey
 		c.ExpectedRequestSequenceNumber = signing.NextRequestSequenceNumber(authenticateRequestSequenceNumber)
@@ -204,9 +207,26 @@ func (c *Connection) finishAuthentication(
 	if session.IsGuest {
 		response.Action = types.USHORT(SMB_SETUP_GUEST)
 	}
-	// The final leg carries no further token: the exchange is complete.
+	// The final leg carries the token that closes the SPNEGO exchange. There is no
+	// NTLM message left to send — the client's AUTHENTICATE was the last one — but
+	// the negotiation still has to be reported as settled: an initiator waiting for
+	// accept-completed treats an empty final blob as a protocol violation and drops
+	// the session, however successful the logon was.
+	//
+	// A client that authenticated without extended security has no SPNEGO exchange
+	// to close, so it gets nothing.
 	response.SecurityBlob = []types.UCHAR{}
 	response.SecurityBlobLength = types.USHORT(0)
+	if accept != nil {
+		completion, err := accept.CompletionToken()
+		if err != nil {
+			logger.Warnf("SMB1 server: could not build the completing SPNEGO token for %s: %v", c.Remote, err)
+			c.uids.Release(uid)
+			return nt_status.NT_STATUS_INTERNAL_ERROR
+		}
+		response.SecurityBlob = []types.UCHAR(completion)
+		response.SecurityBlobLength = types.USHORT(len(completion))
+	}
 
 	c.addSession(session)
 	logger.Infof("SMB1 server: %s authenticated as %s%s", c.Remote, session.Account(), admissionSuffix(session))

--- a/network/smb/smb_v10/server/handler_tree.go
+++ b/network/smb/smb_v10/server/handler_tree.go
@@ -139,3 +139,16 @@ func decodeOEMString(raw []types.UCHAR) string {
 func trimTerminator(value string) string {
 	return strings.TrimRight(value, "\x00")
 }
+
+// encodeWireString renders a string in the encoding a message declared, which is
+// the inverse of decodeWireString.
+//
+// No terminator is added: the fields that carry a name in a response describe it
+// with a byte count rather than by terminating it, and the ones that do terminate
+// it append their own.
+func encodeWireString(value string, useUnicode bool) []byte {
+	if useUnicode {
+		return utf16.EncodeUTF16LE(value)
+	}
+	return []byte(value)
+}

--- a/network/smb/smb_v10/server/infolevels.go
+++ b/network/smb/smb_v10/server/infolevels.go
@@ -79,7 +79,7 @@ func supportedFindLevel(level uint16) bool {
 // Returns:
 //   - The encoded entries
 //   - How many were encoded, which the response reports as its count
-func encodeFindEntries(search *Search, count, budget int) ([]byte, int) {
+func encodeFindEntries(search *Search, count, budget int, unicode bool) ([]byte, int) {
 	if count <= 0 {
 		count = len(search.Entries)
 	}
@@ -92,7 +92,7 @@ func encodeFindEntries(search *Search, count, budget int) ([]byte, int) {
 
 	for returned < count && !search.exhausted() {
 		entry := search.Entries[search.Position]
-		rendered := encodeFindEntry(search.InformationLevel, entry.Attr)
+		rendered := encodeFindEntry(search.InformationLevel, entry.Attr, unicode)
 
 		// The entry must fit whole.
 		if len(encoded)+len(rendered) > budget {
@@ -135,10 +135,13 @@ func zeroLastNextEntryOffset(encoded []byte, level uint16) {
 
 // encodeFindEntry renders one directory entry in the requested level.
 //
-// Names are written as OEM bytes. That is what this repository's client reads them
-// as, and the FIND request itself carries its pattern in OEM, so the two agree.
-func encodeFindEntry(level uint16, attr FileAttr) []byte {
-	name := []byte(attr.Name)
+// Names go out in the encoding the request declared, and the lengths that describe
+// them are byte counts either way. Writing them as OEM regardless is not a
+// cosmetic difference: a client that negotiated Unicode reads the buffer as UTF-16
+// whatever the server put there, so an OEM name comes out as half as many
+// characters of nonsense.
+func encodeFindEntry(level uint16, attr FileAttr, unicode bool) []byte {
+	name := encodeWireString(attr.Name, unicode)
 
 	switch level {
 	case smbFindFileNamesInfo:
@@ -209,7 +212,7 @@ func padTo4(buffer []byte) []byte {
 
 // encodeFileInformation renders a file in a query level, or reports that the level
 // is not served.
-func encodeFileInformation(level uint16, attr FileAttr, path string) ([]byte, bool) {
+func encodeFileInformation(level uint16, attr FileAttr, path string, unicode bool) ([]byte, bool) {
 	switch level {
 	case smbQueryFileBasicInfo:
 		// Four timestamps(8 each) ExtFileAttributes(4) Reserved(4).
@@ -239,7 +242,7 @@ func encodeFileInformation(level uint16, attr FileAttr, path string) ([]byte, bo
 
 	case smbQueryFileNameInfo, smbQueryFileAltNameInfo:
 		// FileNameLength(4) FileName(variable).
-		name := []byte(pathForClient(path))
+		name := encodeWireString(pathForClient(path), unicode)
 		info := make([]byte, 4)
 		binary.LittleEndian.PutUint32(info[0:4], uint32(len(name)))
 		return append(info, name...), true
@@ -247,12 +250,12 @@ func encodeFileInformation(level uint16, attr FileAttr, path string) ([]byte, bo
 	case smbQueryFileAllInfo:
 		// The basic and standard blocks together, then EaSize and the name.
 		info := make([]byte, 0, 104)
-		basic, _ := encodeFileInformation(smbQueryFileBasicInfo, attr, path)
-		standard, _ := encodeFileInformation(smbQueryFileStandardInfo, attr, path)
+		basic, _ := encodeFileInformation(smbQueryFileBasicInfo, attr, path, unicode)
+		standard, _ := encodeFileInformation(smbQueryFileStandardInfo, attr, path, unicode)
 		info = append(info, basic...)
 		info = append(info, standard...)
 		info = append(info, make([]byte, 4)...) // EaSize
-		name := []byte(pathForClient(path))
+		name := encodeWireString(pathForClient(path), unicode)
 		lengthField := make([]byte, 4)
 		binary.LittleEndian.PutUint32(lengthField, uint32(len(name)))
 		info = append(info, lengthField...)
@@ -278,12 +281,20 @@ func pathForClient(path string) string {
 
 // encodeVolumeInformation renders a volume in a query level, or reports that the
 // level is not served.
-func encodeVolumeInformation(level uint16, volume VolumeInfo) ([]byte, bool) {
+func encodeVolumeInformation(level uint16, volume VolumeInfo, unicode bool) ([]byte, bool) {
+	// A level at or above the pass-through base names a native information class
+	// rather than an SMB one ([MS-SMB] section 2.2.2.3.5). A client that asks for
+	// free space asks this way, so refusing the range means refusing the question
+	// most often asked about a volume.
+	if level >= smbInfoPassthrough {
+		return encodeNativeVolumeInformation(level-smbInfoPassthrough, volume, unicode)
+	}
+
 	switch level {
 	case smbQueryFsVolumeInfo:
 		// VolumeCreationTime(8) SerialNumber(4) VolumeLabelSize(4) Reserved(2)
 		// VolumeLabel(variable).
-		label := []byte(volume.Label)
+		label := encodeWireString(volume.Label, unicode)
 		info := make([]byte, 18)
 		binary.LittleEndian.PutUint32(info[8:12], volume.SerialNumber)
 		binary.LittleEndian.PutUint32(info[12:16], uint32(len(label)))
@@ -317,7 +328,7 @@ func encodeVolumeInformation(level uint16, volume VolumeInfo) ([]byte, bool) {
 		// Only case-preserving names are claimed. Claiming a capability the
 		// storage does not have — unicode-on-disk, compression, quotas — is worse
 		// than claiming none, because a client then uses it.
-		name := []byte(volume.FileSystemName)
+		name := encodeWireString(volume.FileSystemName, unicode)
 		info := make([]byte, 12)
 		binary.LittleEndian.PutUint32(info[0:4], 0x00000002) // FILE_CASE_PRESERVED_NAMES
 		binary.LittleEndian.PutUint32(info[4:8], MaxPathComponentLength)
@@ -395,4 +406,64 @@ func timeFromFiletime(filetime uint64) time.Time {
 		return time.Time{}
 	}
 	return time.Unix(0, int64(filetime-unixEpochIn100ns)*100).UTC()
+}
+
+// smbInfoPassthrough is the base of the pass-through information levels: a level
+// of smbInfoPassthrough + N carries the native information class N.
+const smbInfoPassthrough = 0x03E8
+
+// Native file-system information classes, as they arrive through the pass-through
+// range ([MS-FSCC] section 2.5).
+const (
+	fileFsVolumeInformation    = 1
+	fileFsSizeInformation      = 3
+	fileFsDeviceInformation    = 4
+	fileFsAttributeInformation = 5
+	fileFsFullSizeInformation  = 7
+)
+
+// encodeNativeVolumeInformation renders a volume in a native information class.
+//
+// Most of the classes have the same layout as the SMB level that shadows them, so
+// those are answered by the level rather than duplicated. Only the full-size class
+// has no SMB equivalent, and it is the one a client actually uses: it reports the
+// caller's available space separately from the volume's, which is what a client
+// displays as free space.
+func encodeNativeVolumeInformation(class uint16, volume VolumeInfo, unicode bool) ([]byte, bool) {
+	switch class {
+	case fileFsVolumeInformation:
+		return encodeVolumeInformation(smbQueryFsVolumeInfo, volume, unicode)
+	case fileFsSizeInformation:
+		return encodeVolumeInformation(smbQueryFsSizeInfo, volume, unicode)
+	case fileFsDeviceInformation:
+		return encodeVolumeInformation(smbQueryFsDeviceInfo, volume, unicode)
+	case fileFsAttributeInformation:
+		return encodeVolumeInformation(smbQueryFsAttributeInfo, volume, unicode)
+
+	case fileFsFullSizeInformation:
+		// TotalAllocationUnits(8) CallerAvailableAllocationUnits(8)
+		// ActualAvailableAllocationUnits(8) SectorsPerAllocationUnit(4)
+		// BytesPerSector(4).
+		sectors, bytesPerSector := volume.SectorsPerAllocationUnit, volume.BytesPerSector
+		if sectors == 0 {
+			sectors = defaultSectorsPerAllocationUnit
+		}
+		if bytesPerSector == 0 {
+			bytesPerSector = defaultBytesPerSector
+		}
+		unit := int64(sectors) * int64(bytesPerSector)
+
+		info := make([]byte, 32)
+		binary.LittleEndian.PutUint64(info[0:8], uint64(volume.TotalBytes/unit))
+		// Nothing here imposes a quota, so what the caller may use is what the
+		// volume has. Reporting a smaller figure would make a client refuse a write
+		// the server would have accepted.
+		binary.LittleEndian.PutUint64(info[8:16], uint64(volume.FreeBytes/unit))
+		binary.LittleEndian.PutUint64(info[16:24], uint64(volume.FreeBytes/unit))
+		binary.LittleEndian.PutUint32(info[24:28], sectors)
+		binary.LittleEndian.PutUint32(info[28:32], bytesPerSector)
+		return info, true
+	}
+
+	return nil, false
 }

--- a/network/smb/smb_v10/server/live_interop_integration_test.go
+++ b/network/smb/smb_v10/server/live_interop_integration_test.go
@@ -1,0 +1,519 @@
+//go:build integration
+
+// Live interoperability coverage for the SMB 1.0 server against a third-party
+// client, driven through the client's own command-line tools. Excluded from the
+// default build by the "integration" tag.
+//
+// The unit suite pairs this server with the SMB1 client in this repository, which
+// is the fastest way to cover behaviour but has a structural blind spot: the two
+// halves were written together, so a wire detail both get wrong agrees with itself
+// and every round-trip passes. Everything in this file exists to be driven by an
+// implementation that shares none of this one's assumptions.
+//
+// It found real defects. Among them: a request field decoded with a single-byte
+// terminator when the client had negotiated Unicode, so every path arrived
+// truncated to one character; transaction parameter blocks located by arithmetic
+// that assumed the block ended flush with its last field, which shifted every
+// field once a client padded the end of the block; and a signature demanded on the
+// message that establishes signing, which no specification asks for and which made
+// signing unusable rather than mandatory.
+//
+// Configuration:
+//
+//	SMB1_TEST_CLIENT   path to a third-party smbclient-style binary. Required;
+//	                   every test skips when it is unset.
+//	SMB1_TEST_RPCCLI   path to the matching RPC client binary, for the named-pipe
+//	                   tests. Those skip when it is unset.
+//	SMB1_TEST_PORT     port to listen on (default 4445). A privileged port is not
+//	                   used, so the client must accept a port argument.
+//
+// The server is started inside the test on a loopback port, so nothing outside the
+// process is touched and no lab is needed beyond the client binary itself.
+package server
+
+import (
+	"bytes"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/TheManticoreProject/Manticore/crypto/nt"
+)
+
+// The identity the live server accepts.
+const (
+	liveDomain   = "WORKGROUP"
+	liveUsername = "alice"
+	livePassword = "Passw0rd!"
+	liveShare    = "files"
+)
+
+// liveClient returns the configured client binary, or skips.
+func liveClient(t *testing.T) string {
+	t.Helper()
+	path := os.Getenv("SMB1_TEST_CLIENT")
+	if path == "" {
+		t.Skip("SMB1_TEST_CLIENT is not set; no third-party client to interoperate with")
+	}
+	return path
+}
+
+// liveRPCClient returns the configured RPC client binary, or skips.
+func liveRPCClient(t *testing.T) string {
+	t.Helper()
+	path := os.Getenv("SMB1_TEST_RPCCLI")
+	if path == "" {
+		t.Skip("SMB1_TEST_RPCCLI is not set; no third-party RPC client to interoperate with")
+	}
+	return path
+}
+
+// livePort returns the port to listen on.
+func livePort() int {
+	if value := os.Getenv("SMB1_TEST_PORT"); value != "" {
+		if port, err := strconv.Atoi(value); err == nil {
+			return port
+		}
+	}
+	return 4445
+}
+
+// livePipe is a pipe handler that answers a DCE/RPC bind with a bind_ack and
+// echoes anything else.
+//
+// The bind_ack is what makes the named-pipe path testable with a real RPC client:
+// without one the client abandons the connection at the bind and never exercises a
+// second transaction, a read, or the close.
+type livePipe struct {
+	mutex sync.Mutex
+	calls []string
+}
+
+func (p *livePipe) record(call string) {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+	p.calls = append(p.calls, call)
+}
+
+// Calls returns the handler calls seen so far.
+func (p *livePipe) Calls() []string {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+	return append([]string(nil), p.calls...)
+}
+
+func (p *livePipe) OpenPipe(name string) error {
+	p.record("open:" + name)
+	if strings.ToLower(name) != "srvsvc" {
+		return fmt.Errorf("pipe %q not found", name)
+	}
+	return nil
+}
+
+func (p *livePipe) ClosePipe(name string) error {
+	p.record("close:" + name)
+	return nil
+}
+
+func (p *livePipe) Transact(name string, input []byte, maxOutput int) ([]byte, bool, error) {
+	if answer := rpcBindAck(input); answer != nil {
+		p.record("bind:" + name)
+		if len(answer) > maxOutput {
+			return answer[:maxOutput], true, nil
+		}
+		return answer, false, nil
+	}
+
+	p.record("transact:" + name)
+	answer := append([]byte("echo:"), input...)
+	if len(answer) > maxOutput {
+		return answer[:maxOutput], true, nil
+	}
+	return answer, false, nil
+}
+
+// rpcBindAck builds a DCE/RPC bind_ack for a bind PDU, or nil when the input is
+// not one ([C706] section 12.6.4.4).
+//
+// The transfer syntax is echoed from the bind's presentation context, so the
+// client sees the syntax it offered accepted rather than one it did not propose.
+func rpcBindAck(pdu []byte) []byte {
+	const (
+		ptypeBind      = 11
+		ptypeBindAck   = 12
+		bindHeaderSize = 72
+	)
+	if len(pdu) < bindHeaderSize || pdu[0] != 5 || pdu[2] != ptypeBind {
+		return nil
+	}
+
+	answer := []byte{5, 0, ptypeBindAck, 0x03, 0x10, 0, 0, 0}
+	answer = append(answer, 0, 0)          // frag_length, filled in below
+	answer = append(answer, 0, 0)          // auth_length
+	answer = append(answer, pdu[12:16]...) // call_id, echoed
+	answer = append(answer, pdu[16:18]...) // max_xmit_frag
+	answer = append(answer, pdu[18:20]...) // max_recv_frag
+	answer = append(answer, 0x34, 0x12, 0, 0)
+
+	// sec_addr: a counted, null-terminated port name padded to a 4-byte boundary.
+	port := []byte("\\PIPE\\srvsvc\x00")
+	answer = append(answer, byte(len(port)), byte(len(port)>>8))
+	answer = append(answer, port...)
+	for len(answer)%4 != 0 {
+		answer = append(answer, 0)
+	}
+
+	// p_result_list: one result, acceptance, echoing the offered syntax.
+	answer = append(answer, 1, 0, 0, 0)
+	answer = append(answer, 0, 0)          // ack_result = acceptance
+	answer = append(answer, 0, 0)          // ack_reason
+	answer = append(answer, pdu[52:72]...) // transfer syntax
+
+	answer[8] = byte(len(answer))
+	answer[9] = byte(len(answer) >> 8)
+	return answer
+}
+
+// liveServer starts a server on the configured port with one disk share and one
+// pipe share, and returns it with the pipe handler and the port.
+func liveServer(t *testing.T, policy SigningPolicy) (*Server, *MemoryFileSystem, *livePipe, int) {
+	t.Helper()
+
+	srv, err := NewServer(Config{
+		SigningPolicy: policy,
+		Authenticator: StaticAccounts(Account{
+			Domain:   liveDomain,
+			Username: liveUsername,
+			NTHash:   nt.NTHash(livePassword),
+		}),
+	})
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	fs := NewMemoryFileSystem("FILES")
+	if err := fs.AddFile("hello.txt", []byte("the quick brown fox\n")); err != nil {
+		t.Fatalf("AddFile() error = %v", err)
+	}
+	if err := fs.AddDirectory("subdir"); err != nil {
+		t.Fatalf("AddDirectory() error = %v", err)
+	}
+	if err := fs.AddFile("subdir/inner.txt", []byte("inner\n")); err != nil {
+		t.Fatalf("AddFile() error = %v", err)
+	}
+	if err := srv.AddShare(&Share{
+		Name: liveShare, Type: ShareTypeDisk, FS: fs,
+		Security: NewReflectiveSecurityProvider(false),
+	}); err != nil {
+		t.Fatalf("AddShare() error = %v", err)
+	}
+
+	pipes := &livePipe{}
+	if err := srv.AddShare(&Share{Name: "IPC$", Type: ShareTypeNamedPipe, Pipes: pipes}); err != nil {
+		t.Fatalf("AddShare() error = %v", err)
+	}
+
+	port := livePort()
+	address := net.JoinHostPort("127.0.0.1", strconv.Itoa(port))
+	served := make(chan error, 1)
+	go func() { served <- srv.ListenAndServe(address) }()
+
+	// Wait for the listener rather than sleeping a fixed time, so a slow start
+	// does not produce a spurious connection failure.
+	deadline := time.Now().Add(5 * time.Second)
+	for !srv.Listening() {
+		if time.Now().After(deadline) {
+			t.Fatalf("the server did not start listening on %s", address)
+		}
+		select {
+		case err := <-served:
+			t.Fatalf("ListenAndServe(%s) returned early: %v", address, err)
+		default:
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	t.Cleanup(func() { srv.Close() })
+	return srv, fs, pipes, port
+}
+
+// runClient drives the third-party client with a semicolon-separated command list
+// and returns its combined output.
+//
+// The dialect is pinned to NT1 in both directions: a modern client disables SMB1
+// by default, so without this it negotiates nothing this server speaks.
+func runClient(t *testing.T, binary string, port int, signing string, script string) string {
+	t.Helper()
+
+	arguments := []string{
+		fmt.Sprintf("//127.0.0.1/%s", liveShare),
+		"-U", liveUsername + "%" + livePassword,
+		"-W", liveDomain,
+		"-p", strconv.Itoa(port),
+		"-m", "NT1",
+		"--option=client min protocol=NT1",
+		"--option=client max protocol=NT1",
+	}
+	if signing != "" {
+		arguments = append(arguments, "--option=client signing="+signing)
+	}
+	arguments = append(arguments, "-c", script)
+
+	command := exec.Command(binary, arguments...)
+	command.Dir = t.TempDir()
+	output, err := command.CombinedOutput()
+	t.Logf("%s %v\nexit: %v\n%s", binary, arguments, err, output)
+	return string(output)
+}
+
+// assertNoFailure asserts the client's output carries no status code, which is how
+// these tools report a failure: they print the NT_STATUS and carry on.
+//
+// Named exceptions are allowed through, for the operations this server answers
+// with a defined refusal rather than a result.
+//
+// It first asserts the client got as far as talking to the server at all. Without
+// that this check passes for free whenever the client could not run — a wrong
+// binary path or a refused connection produces output with no status code in it,
+// which would otherwise read as success.
+func assertNoFailure(t *testing.T, output string, allowed ...string) {
+	t.Helper()
+
+	if strings.TrimSpace(output) == "" {
+		t.Fatal("the client produced no output at all; it probably never ran")
+	}
+	for _, fatal := range []string{
+		"CONNECTION_REFUSED", "Connection to 127.0.0.1 failed",
+		"NT_STATUS_LOGON_FAILURE", "session setup failed", "tree connect failed",
+		"Unable to initialize messaging context", "Invalid option",
+	} {
+		if strings.Contains(output, fatal) {
+			t.Fatalf("the client never reached a usable session (%q):\n%s", fatal, output)
+		}
+	}
+
+	for _, line := range strings.Split(output, "\n") {
+		if !strings.Contains(line, "NT_STATUS_") {
+			continue
+		}
+		permitted := false
+		for _, allow := range allowed {
+			if strings.Contains(line, allow) {
+				permitted = true
+				break
+			}
+		}
+		if !permitted {
+			t.Errorf("the client reported a failure: %s", strings.TrimSpace(line))
+		}
+	}
+}
+
+// TestLiveClientListsAndTransfers is the milestone: a third-party client
+// negotiates, authenticates, lists a directory and moves a file in both
+// directions.
+//
+// The listing is asserted by name. That is the point of doing it here rather than
+// in the unit suite: the names are written in whichever encoding the request
+// declared, and a server that writes them in the other one produces a listing that
+// is the right shape and the wrong text — which a round-trip against a client that
+// shares the mistake cannot see.
+func TestLiveClientListsAndTransfers(t *testing.T) {
+	client := liveClient(t)
+	_, _, _, port := liveServer(t, SigningDisabled)
+
+	directory := t.TempDir()
+	local := filepath.Join(directory, "upload.txt")
+	payload := []byte("content that travelled over SMB1\n")
+	if err := os.WriteFile(local, payload, 0o600); err != nil {
+		t.Fatalf("writing the upload failed: %v", err)
+	}
+
+	output := runClient(t, client, port, "", fmt.Sprintf(
+		"lcd %s; ls; get hello.txt fetched.txt; put upload.txt uploaded.txt; ls; du",
+		directory))
+
+	// No allowance: the whole session must be clean. A client asks about the
+	// volume after a listing whether or not anything wanted it, so leaving that
+	// unanswered puts an error in every session.
+	assertNoFailure(t, output)
+
+	for _, name := range []string{"hello.txt", "subdir", "uploaded.txt"} {
+		if !strings.Contains(output, name) {
+			t.Errorf("the listing does not name %q; the response encoding is probably wrong:\n%s", name, output)
+		}
+	}
+}
+
+// TestLiveClientFileOperations exercises the commands that carry a name in a
+// request: create, rename, delete, and their directory equivalents.
+//
+// Rename is the one that matters most. It carries two names, and the first one's
+// length decides whether an alignment byte precedes the second, so half of all
+// renames take a code path the other half does not.
+func TestLiveClientFileOperations(t *testing.T) {
+	client := liveClient(t)
+	_, fs, _, port := liveServer(t, SigningDisabled)
+
+	output := runClient(t, client, port, "",
+		"mkdir newdir; ls; rename hello.txt renamed.txt; ls; rmdir newdir; ls")
+	assertNoFailure(t, output)
+
+	// Asserted against the backend rather than the client's output: the name the
+	// server actually stored is what proves the request decoded correctly.
+	if _, err := fs.Stat("renamed.txt"); err != nil {
+		t.Errorf("the renamed file is not present as %q: %v", "renamed.txt", err)
+	}
+	if _, err := fs.Stat("hello.txt"); err == nil {
+		t.Error("the original name is still present after a rename")
+	}
+	if _, err := fs.Stat("newdir"); err == nil {
+		t.Error("the directory is still present after rmdir")
+	}
+}
+
+// TestLiveClientDeleteByExactName covers the search that a client performs before
+// deleting: it names one file exactly rather than with a wildcard, which a server
+// that treats every search path as a directory refuses.
+func TestLiveClientDeleteByExactName(t *testing.T) {
+	client := liveClient(t)
+	_, fs, _, port := liveServer(t, SigningDisabled)
+
+	output := runClient(t, client, port, "", "rm hello.txt; ls")
+	assertNoFailure(t, output)
+
+	if _, err := fs.Stat("hello.txt"); err == nil {
+		t.Error("the file is still present after rm; the exact-name search was probably refused")
+	}
+}
+
+// TestLiveClientSignedSession runs the whole exchange under mandatory signing,
+// which validates this implementation's signing against an independent one in both
+// directions: the server verifies every request and the client verifies every
+// response.
+func TestLiveClientSignedSession(t *testing.T) {
+	client := liveClient(t)
+	srv, _, _, port := liveServer(t, SigningRequired)
+
+	directory := t.TempDir()
+	output := runClient(t, client, port, "required", fmt.Sprintf(
+		"lcd %s; ls; du; get hello.txt signed.txt", directory))
+	assertNoFailure(t, output)
+
+	// A client that could not verify a response says so rather than failing, so the
+	// output is checked for it explicitly.
+	if strings.Contains(output, "BAD SIG") || strings.Contains(strings.ToLower(output), "bad signature") {
+		t.Errorf("the client rejected a response signature:\n%s", output)
+	}
+
+	fetched, err := os.ReadFile(filepath.Join(directory, "signed.txt"))
+	if err != nil {
+		t.Fatalf("the file did not arrive over the signed session: %v", err)
+	}
+	if !bytes.Equal(fetched, []byte("the quick brown fox\n")) {
+		t.Errorf("the file arrived as %q over a signed session", fetched)
+	}
+
+	if srv.Config().SigningPolicy != SigningRequired {
+		t.Fatal("the server was not configured to require signing")
+	}
+}
+
+// TestLiveRPCClientBindsOverAPipe is what the named-pipe work exists for: a real
+// RPC client completes a DCE/RPC bind over this server and goes on to make a call.
+//
+// The handler's calls are the assertion. They show the client opening the pipe by
+// name, binding, issuing a request on the same handle, and closing it — the whole
+// shape of MS-RPC over SMB1, performed by an implementation that knows nothing
+// about this one.
+func TestLiveRPCClientBindsOverAPipe(t *testing.T) {
+	rpcClient := liveRPCClient(t)
+	_, _, pipes, port := liveServer(t, SigningRequired)
+
+	command := exec.Command(rpcClient,
+		"//127.0.0.1",
+		"-U", liveUsername+"%"+livePassword,
+		"-W", liveDomain,
+		"-p", strconv.Itoa(port),
+		"-m", "NT1",
+		"--option=client min protocol=NT1",
+		"--option=client max protocol=NT1",
+		"-c", "srvinfo")
+	command.Dir = t.TempDir()
+	output, err := command.CombinedOutput()
+	t.Logf("%s\nexit: %v\n%s", rpcClient, err, output)
+
+	if strings.Contains(string(output), "BAD SIG") {
+		t.Errorf("the RPC client rejected a response signature:\n%s", output)
+	}
+
+	calls := pipes.Calls()
+	t.Logf("pipe handler calls: %v", calls)
+
+	// The call the whole path exists to carry. Its absence means the client never
+	// got as far as a transaction.
+	if !containsCall(calls, "bind:srvsvc") {
+		t.Fatalf("the RPC client did not complete a bind over the pipe; handler saw %v", calls)
+	}
+	// A second transaction means the client accepted the bind_ack and considered
+	// the binding established, which is the real assertion: a client that had
+	// rejected it would have stopped.
+	if !containsCall(calls, "transact:srvsvc") {
+		t.Errorf("the client bound but made no call afterwards; handler saw %v", calls)
+	}
+	if !containsCall(calls, "open:srvsvc") {
+		t.Errorf("the pipe was never opened by name; handler saw %v", calls)
+	}
+}
+
+// TestLiveClientSurvivesPipeMisuse asserts a file operation on a pipe handle is
+// refused rather than crashing the connection.
+//
+// A pipe handle has no file behind it, and an RPC client reads one directly when
+// its transaction did not return a whole response. That reached an unguarded
+// dereference and took the connection down with it.
+func TestLiveClientSurvivesPipeMisuse(t *testing.T) {
+	rpcClient := liveRPCClient(t)
+	srv, _, _, port := liveServer(t, SigningRequired)
+
+	command := exec.Command(rpcClient,
+		"//127.0.0.1",
+		"-U", liveUsername+"%"+livePassword,
+		"-W", liveDomain,
+		"-p", strconv.Itoa(port),
+		"-m", "NT1",
+		"--option=client min protocol=NT1",
+		"--option=client max protocol=NT1",
+		"-c", "srvinfo")
+	command.Dir = t.TempDir()
+	output, _ := command.CombinedOutput()
+	t.Logf("%s", output)
+
+	// The server must still be serving: a panic is contained to one connection, so
+	// the listener surviving is what says nothing fatal happened.
+	if !srv.Listening() {
+		t.Fatal("the server stopped listening after the RPC exchange")
+	}
+
+	// And a plain client must still be able to connect afterwards.
+	client := liveClient(t)
+	after := runClient(t, client, port, "required", "ls")
+	assertNoFailure(t, after)
+}
+
+// containsCall reports whether a handler call was seen.
+func containsCall(calls []string, want string) bool {
+	for _, call := range calls {
+		if call == want {
+			return true
+		}
+	}
+	return false
+}

--- a/network/smb/smb_v10/server/path.go
+++ b/network/smb/smb_v10/server/path.go
@@ -225,3 +225,15 @@ func resolvePathPattern(raw string) (directory, pattern string, err error) {
 	}
 	return directory, final, nil
 }
+
+// splitFinalElement separates a resolved path into its parent and its final
+// element. A path with no separator has the share root as its parent.
+//
+// The path is already resolved, so there is nothing left to validate: this only
+// divides what resolvePath has already accepted.
+func splitFinalElement(path string) (parent, final string) {
+	if index := strings.LastIndexByte(path, '/'); index >= 0 {
+		return path[:index], path[index+1:]
+	}
+	return "", path
+}

--- a/network/smb/smb_v10/server/unicode_wire_test.go
+++ b/network/smb/smb_v10/server/unicode_wire_test.go
@@ -1,0 +1,499 @@
+package server
+
+import (
+	"encoding/binary"
+	"strings"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/encoding/utf16"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/subcommands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+)
+
+// Regression coverage for the wire defects that only a third-party client exposed.
+//
+// Every one of them was invisible to the unit suite for the same reason: it pairs
+// this server with the client in this repository, and that client sends its names
+// in OEM even after negotiating Unicode. A field decoded with the wrong character
+// width therefore agreed with itself in both directions and every round-trip
+// passed. These tests set the Unicode flag deliberately, which is what the suite
+// was never doing.
+//
+// The live matrix in live_interop_integration_test.go is what found them; these
+// are what keep them found without a client binary present.
+
+// TestUnicodeTreeConnectPath asserts a Unicode share path decodes whole.
+//
+// A single-byte terminator scan ends "\\\\host\\share" at its first character, so
+// every tree connect from a Unicode client was refused as not being a UNC path.
+func TestUnicodeTreeConnectPath(t *testing.T) {
+	for _, unicode := range []bool{false, true} {
+		unicode := unicode
+		name := "OEM"
+		if unicode {
+			name = "Unicode"
+		}
+		t.Run(name, func(t *testing.T) {
+			const path = `\\127.0.0.1\FILES`
+
+			request := commands.NewTreeConnectAndxRequest()
+			request.SetUnicode(unicode)
+			// One null byte, which is what a client sends for an empty password and
+			// what leaves the path 16-bit aligned.
+			request.Password = []types.UCHAR{0x00}
+			request.PasswordLength = types.USHORT(1)
+			if unicode {
+				request.Path = append([]types.UCHAR(utf16.EncodeUTF16LE(path)), 0x00, 0x00)
+			} else {
+				request.Path = append([]types.UCHAR(path), 0x00)
+			}
+			request.Service = []types.UCHAR("?????\x00")
+
+			marshalled, err := request.Marshal()
+			if err != nil {
+				t.Fatalf("Marshal() error = %v", err)
+			}
+
+			decoded := commands.NewTreeConnectAndxRequest()
+			decoded.Init()
+			decoded.SetUnicode(unicode)
+			if _, err := decoded.Unmarshal(marshalled); err != nil {
+				t.Fatalf("Unmarshal() error = %v", err)
+			}
+
+			if got := decodeWireString(decoded.Path, unicode); got != path {
+				t.Fatalf("the path decoded as %q, want %q", got, path)
+			}
+			if got := shareNameFromPath(decodeWireString(decoded.Path, unicode)); got != "FILES" {
+				t.Fatalf("the share name resolved to %q, want FILES", got)
+			}
+			// The Service string is OEM whatever the message declared.
+			if got := decodeOEMString(decoded.Service); got != "?????" {
+				t.Fatalf("the service decoded as %q, want ?????", got)
+			}
+		})
+	}
+}
+
+// TestUnicodeCreateDirectoryName asserts a Unicode name in an SMB_STRING decodes
+// whole.
+//
+// SMB_STRING's null-terminated formats end at the first null CHARACTER. Ending
+// them at the first null BYTE truncated "\newdir" to a single backslash, and
+// decoding the resulting one-byte buffer as UTF-16 then read past the end of it —
+// which took down the connection rather than failing the request.
+func TestUnicodeCreateDirectoryName(t *testing.T) {
+	const directory = `\newdir`
+
+	request := commands.NewCreateDirectoryRequest()
+	request.SetUnicode(true)
+	request.DirectoryName.SetBufferFormat(types.SMB_STRING_BUFFER_FORMAT_NULL_TERMINATED_ASCII_STRING)
+	request.DirectoryName.Buffer = []types.UCHAR(utf16.EncodeUTF16LE(directory))
+	request.DirectoryName.Length = types.USHORT(len(request.DirectoryName.Buffer))
+
+	marshalled, err := request.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+
+	decoded := commands.NewCreateDirectoryRequest()
+	decoded.Init()
+	decoded.SetUnicode(true)
+	if _, err := decoded.Unmarshal(marshalled); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+
+	if got := decodeWireString(decoded.DirectoryName.Buffer, true); got != directory {
+		t.Fatalf("the directory name decoded as %q, want %q", got, directory)
+	}
+}
+
+// TestUnicodeRenameAlignsTheSecondName asserts both names of a rename decode, for
+// a first name of each parity.
+//
+// The first name's length decides whether an alignment byte precedes the second,
+// so exactly half of all renames exercise the padded path. Missing it does not
+// fail: it shifts every character of the second name by one byte and produces a
+// different, plausible-looking name, so a file is created under a name the client
+// never asked for.
+func TestUnicodeRenameAlignsTheSecondName(t *testing.T) {
+	cases := []struct {
+		name string
+		from string
+		to   string
+	}{
+		// "\hello.txt" is ten characters, so the second name starts on an odd
+		// offset and is padded.
+		{"padded", `\hello.txt`, `\renamed.txt`},
+		// One character shorter, so the second name is already aligned.
+		{"unpadded", `\hell.txt`, `\renamed.txt`},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			request := commands.NewRenameRequest()
+			request.SetUnicode(true)
+			request.OldFileName.SetBufferFormat(types.SMB_STRING_BUFFER_FORMAT_NULL_TERMINATED_ASCII_STRING)
+			request.OldFileName.Buffer = []types.UCHAR(utf16.EncodeUTF16LE(tc.from))
+			request.NewFileName.SetBufferFormat(types.SMB_STRING_BUFFER_FORMAT_NULL_TERMINATED_ASCII_STRING)
+			request.NewFileName.Buffer = []types.UCHAR(utf16.EncodeUTF16LE(tc.to))
+
+			marshalled, err := request.Marshal()
+			if err != nil {
+				t.Fatalf("Marshal() error = %v", err)
+			}
+
+			decoded := commands.NewRenameRequest()
+			decoded.Init()
+			decoded.SetUnicode(true)
+			if _, err := decoded.Unmarshal(marshalled); err != nil {
+				t.Fatalf("Unmarshal() error = %v", err)
+			}
+
+			if got := decodeWireString(decoded.OldFileName.Buffer, true); got != tc.from {
+				t.Errorf("the old name decoded as %q, want %q", got, tc.from)
+			}
+			if got := decodeWireString(decoded.NewFileName.Buffer, true); got != tc.to {
+				t.Errorf("the new name decoded as %q, want %q", got, tc.to)
+			}
+		})
+	}
+}
+
+// TestTransactionBlocksLocatedByDeclaredOffsets asserts the parameter block is
+// found where the message says it is, even when the block carries trailing
+// padding.
+//
+// This is the defect with the widest reach. The decoder derived the leading pad by
+// subtracting the field lengths from the size of the data block, which assumes the
+// block ends flush with its last field. A real client pads the end of the block to
+// a four-byte boundary, so the surplus was charged to the leading pad and every
+// field in the block was read shifted — a directory listing asked for information
+// level 0x0104 and the server read 0x0000 from two bytes further on.
+func TestTransactionBlocksLocatedByDeclaredOffsets(t *testing.T) {
+	// The parameters of a TRANS2_FIND_FIRST2, as a client sends them.
+	parameters := make([]byte, 12)
+	binary.LittleEndian.PutUint16(parameters[0:2], 0x0016)                       // SearchAttributes
+	binary.LittleEndian.PutUint16(parameters[2:4], 0x0556)                       // SearchCount
+	binary.LittleEndian.PutUint16(parameters[4:6], 0x0006)                       // Flags
+	binary.LittleEndian.PutUint16(parameters[6:8], smbFindFileBothDirectoryInfo) // InformationLevel
+	parameters = append(parameters, utf16.EncodeUTF16LE(`\*`)...)
+	parameters = append(parameters, 0x00, 0x00)
+
+	request := commands.NewTransaction2Request()
+	request.SetUnicode(true)
+	request.Setup = []types.USHORT{types.USHORT(subcommands.TRANS2_FIND_FIRST2)}
+	request.SetupCount = types.UCHAR(1)
+	request.MaxParameterCount = 10
+	request.MaxDataCount = 65535
+	request.TotalParameterCount = types.USHORT(len(parameters))
+	request.ParameterCount = types.USHORT(len(parameters))
+	request.Trans2_Parameters = parameters
+	// Two bytes of leading pad, as a client uses to align the block, and two of
+	// trailing pad, which is what the old arithmetic mistook for more leading pad.
+	request.Pad1 = []types.UCHAR{0x44, 0x20}
+
+	marshalled, err := request.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	// Append the trailing padding a client puts at the end of the block, and grow
+	// ByteCount to cover it, exactly as one does on the wire.
+	byteCountAt := 1 + 2*int(marshalled[0])
+	trailing := []byte{0x00, 0x00}
+	binary.LittleEndian.PutUint16(marshalled[byteCountAt:byteCountAt+2],
+		binary.LittleEndian.Uint16(marshalled[byteCountAt:byteCountAt+2])+uint16(len(trailing)))
+	marshalled = append(marshalled, trailing...)
+
+	decoded := commands.NewTransaction2Request()
+	decoded.Init()
+	decoded.SetUnicode(true)
+	if _, err := decoded.Unmarshal(marshalled); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+
+	if len(decoded.Trans2_Parameters) < 8 {
+		t.Fatalf("the parameter block decoded as %d bytes, want %d", len(decoded.Trans2_Parameters), len(parameters))
+	}
+	level := binary.LittleEndian.Uint16([]byte(decoded.Trans2_Parameters)[6:8])
+	if level != smbFindFileBothDirectoryInfo {
+		t.Fatalf("the information level read as 0x%04X, want 0x%04X: the parameter block was located by arithmetic rather than by its declared offset",
+			level, smbFindFileBothDirectoryInfo)
+	}
+	if got := decodeWireString([]types.UCHAR(decoded.Trans2_Parameters)[12:], true); got != `\*` {
+		t.Errorf("the search pattern decoded as %q, want %q", got, `\*`)
+	}
+}
+
+// TestTransactionMarshalDeclaresWhereItPutTheBlocks asserts a marshaller's
+// declared offsets describe its own output.
+//
+// The offsets were previously left for a caller to fill in, and nothing did, so
+// they were zero: a receiver following the specification could not find either
+// block. The check is against the bytes rather than against a recomputation of the
+// same formula, so a wrong formula fails here too.
+func TestTransactionMarshalDeclaresWhereItPutTheBlocks(t *testing.T) {
+	parameters := []byte{0xA1, 0xA2, 0xA3, 0xA4, 0xA5}
+	data := []byte{0xD1, 0xD2, 0xD3}
+
+	request := commands.NewTransaction2Request()
+	request.Setup = []types.USHORT{types.USHORT(subcommands.TRANS2_QUERY_FS_INFORMATION)}
+	request.SetupCount = types.UCHAR(1)
+	request.TotalParameterCount = types.USHORT(len(parameters))
+	request.ParameterCount = types.USHORT(len(parameters))
+	request.Trans2_Parameters = parameters
+	request.TotalDataCount = types.USHORT(len(data))
+	request.DataCount = types.USHORT(len(data))
+	request.Trans2_Data = data
+	request.Pad1 = []types.UCHAR{0x00, 0x00}
+	request.Pad2 = []types.UCHAR{0x00}
+
+	marshalled, err := request.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+
+	// The offsets are measured from the start of the SMB header, and the
+	// marshalled command begins right after it.
+	const headerSize = 32
+	for _, tc := range []struct {
+		name    string
+		offset  int
+		content []byte
+	}{
+		{"the parameter block", int(request.ParameterOffset), parameters},
+		{"the data block", int(request.DataOffset), data},
+	} {
+		at := tc.offset - headerSize
+		if at < 0 || at+len(tc.content) > len(marshalled) {
+			t.Fatalf("%s is declared at offset %d, which is outside the %d-byte command",
+				tc.name, tc.offset, len(marshalled))
+		}
+		if got := marshalled[at : at+len(tc.content)]; string(got) != string(tc.content) {
+			t.Errorf("%s is declared at offset %d, where the bytes are % x, not % x",
+				tc.name, tc.offset, got, tc.content)
+		}
+	}
+}
+
+// TestFindPatternAcceptsAnExactName asserts naming one file exactly is a search
+// rather than an attempt to list it as a directory.
+//
+// A client does this before deleting or renaming something: it resolves the name
+// first, and a server that treats every search path as a directory refuses the
+// resolution and the operation never happens.
+func TestFindPatternAcceptsAnExactName(t *testing.T) {
+	fs := NewMemoryFileSystem("FILES")
+	if err := fs.AddFile("target.txt", []byte("x")); err != nil {
+		t.Fatalf("AddFile() error = %v", err)
+	}
+	if err := fs.AddDirectory("holder"); err != nil {
+		t.Fatalf("AddDirectory() error = %v", err)
+	}
+	if err := fs.AddFile("holder/inner.txt", []byte("y")); err != nil {
+		t.Fatalf("AddFile() error = %v", err)
+	}
+	_, client := fileServer(t, fs, false)
+
+	// An exact file name resolves to that one entry.
+	entries, err := client.ListEntries(`\target.txt`)
+	if err != nil {
+		t.Fatalf("searching for an exact name failed: %v", err)
+	}
+	if !containsName(namesOf(entries), "target.txt") {
+		t.Fatalf("searching for an exact name returned %v", namesOf(entries))
+	}
+
+	// A directory still lists its contents rather than matching its own name,
+	// which is the behaviour the exact-name case must not have replaced.
+	entries, err = client.ListEntries(`\holder\*`)
+	if err != nil {
+		t.Fatalf("listing a directory failed: %v", err)
+	}
+	if !containsName(namesOf(entries), "inner.txt") {
+		t.Fatalf("listing a directory returned %v", namesOf(entries))
+	}
+	entries, err = client.ListEntries(`\holder`)
+	if err != nil {
+		t.Fatalf("listing a directory by name failed: %v", err)
+	}
+	if !containsName(namesOf(entries), "inner.txt") {
+		t.Fatalf("listing a directory by name returned %v, want its contents", namesOf(entries))
+	}
+}
+
+// TestFileCommandsOnAPipeHandleAreRefused asserts a read or a write through a pipe
+// handle is answered rather than crashing.
+//
+// A pipe handle has no file behind it. An RPC client reads one directly when its
+// transaction did not return a whole response, which reached an unguarded
+// dereference and took the connection down.
+func TestFileCommandsOnAPipeHandleAreRefused(t *testing.T) {
+	pipes := newEchoPipe("srvsvc")
+	_, client := pipeServer(t, pipes)
+
+	fid, err := openPipeHandle(t, client, `\PIPE\srvsvc`)
+	if err != nil {
+		t.Fatalf("opening the pipe failed: %v", err)
+	}
+
+	if _, err := client.ReadFile(fid, 0, 16); err == nil {
+		t.Error("reading a pipe handle as a file succeeded")
+	}
+	if _, err := client.WriteFile(fid, 0, []byte("x")); err == nil {
+		t.Error("writing a pipe handle as a file succeeded")
+	}
+
+	// The connection must still be usable, which is what the crash cost.
+	if _, err := client.Echo([]byte("still here")); err != nil {
+		t.Fatalf("the connection did not survive a file command on a pipe handle: %v", err)
+	}
+}
+
+// TestQueryFileInformationOnADirectoryHandle asserts a handle with no file behind
+// it can still be described, since querying is what such a handle exists for.
+func TestQueryFileInformationOnADirectoryHandle(t *testing.T) {
+	fs := NewMemoryFileSystem("FILES")
+	if err := fs.AddDirectory("adirectory"); err != nil {
+		t.Fatalf("AddDirectory() error = %v", err)
+	}
+	_, client := fileServer(t, fs, false)
+
+	fid, err := client.OpenFile("adirectory", 0x00120089, 0x00000007, 0x00000001, 0x00000001)
+	if err != nil {
+		t.Fatalf("opening the directory failed: %v", err)
+	}
+	defer client.CloseFile(fid)
+
+	if _, err := client.Echo([]byte("alive")); err != nil {
+		t.Fatalf("the connection did not survive opening a directory: %v", err)
+	}
+}
+
+// TestVolumeInformationPassthroughLevels asserts the pass-through range is served,
+// since that is how a client asks about free space.
+func TestVolumeInformationPassthroughLevels(t *testing.T) {
+	volume := VolumeInfo{
+		Label: "FILES", FileSystemName: "NTFS",
+		TotalBytes: 1 << 30, FreeBytes: 1 << 29,
+		SectorsPerAllocationUnit: 8, BytesPerSector: 512,
+	}
+
+	t.Run("full size information", func(t *testing.T) {
+		info, served := encodeVolumeInformation(smbInfoPassthrough+fileFsFullSizeInformation, volume, true)
+		if !served {
+			t.Fatal("the full-size class is not served")
+		}
+		if len(info) != 32 {
+			t.Fatalf("the full-size block is %d bytes, want 32", len(info))
+		}
+
+		unit := uint64(volume.SectorsPerAllocationUnit) * uint64(volume.BytesPerSector)
+		if got := binary.LittleEndian.Uint64(info[0:8]); got != uint64(volume.TotalBytes)/unit {
+			t.Errorf("total units = %d, want %d", got, uint64(volume.TotalBytes)/unit)
+		}
+		// What the caller may use is what is free: nothing here imposes a quota, and
+		// reporting less would make a client refuse a write the server would take.
+		caller := binary.LittleEndian.Uint64(info[8:16])
+		actual := binary.LittleEndian.Uint64(info[16:24])
+		if caller != actual || caller != uint64(volume.FreeBytes)/unit {
+			t.Errorf("available units = %d/%d, want both %d", caller, actual, uint64(volume.FreeBytes)/unit)
+		}
+	})
+
+	t.Run("classes that shadow an SMB level", func(t *testing.T) {
+		for class, level := range map[uint16]uint16{
+			fileFsVolumeInformation:    smbQueryFsVolumeInfo,
+			fileFsSizeInformation:      smbQueryFsSizeInfo,
+			fileFsDeviceInformation:    smbQueryFsDeviceInfo,
+			fileFsAttributeInformation: smbQueryFsAttributeInfo,
+		} {
+			viaClass, servedClass := encodeVolumeInformation(smbInfoPassthrough+class, volume, true)
+			viaLevel, servedLevel := encodeVolumeInformation(level, volume, true)
+			if !servedClass || !servedLevel {
+				t.Errorf("class %d / level 0x%04X: served = %v / %v", class, level, servedClass, servedLevel)
+				continue
+			}
+			if string(viaClass) != string(viaLevel) {
+				t.Errorf("class %d and level 0x%04X disagree", class, level)
+			}
+		}
+	})
+
+	t.Run("an unserved class is refused", func(t *testing.T) {
+		if _, served := encodeVolumeInformation(smbInfoPassthrough+0x00FF, volume, true); served {
+			t.Error("a class this server does not implement was answered")
+		}
+	})
+}
+
+// TestFindEntryNamesFollowTheRequestEncoding asserts a listing's names go out in
+// the encoding the request declared.
+//
+// A client reads the buffer as UTF-16 when it negotiated Unicode, whatever the
+// server put there, so an OEM name arrives as half as many characters of nonsense —
+// a listing of the right shape and the wrong text.
+func TestFindEntryNamesFollowTheRequestEncoding(t *testing.T) {
+	attr := FileAttr{Name: "hello.txt"}
+
+	for _, unicode := range []bool{false, true} {
+		unicode := unicode
+		t.Run(map[bool]string{false: "OEM", true: "Unicode"}[unicode], func(t *testing.T) {
+			entry := encodeFindEntry(smbFindFileBothDirectoryInfo, attr, unicode)
+			if len(entry) < bothDirectoryInfoFixedSize+4 {
+				t.Fatalf("the entry is %d bytes", len(entry))
+			}
+
+			nameLength := int(binary.LittleEndian.Uint32(entry[60:64]))
+			want := len(attr.Name)
+			if unicode {
+				want *= 2
+			}
+			if nameLength != want {
+				t.Fatalf("FileNameLength = %d, want %d bytes for %q", nameLength, want, attr.Name)
+			}
+
+			raw := entry[bothDirectoryInfoFixedSize : bothDirectoryInfoFixedSize+nameLength]
+			got := string(raw)
+			if unicode {
+				got = utf16.DecodeUTF16LE(raw)
+			}
+			if got != attr.Name {
+				t.Fatalf("the name encoded as %q, want %q", got, attr.Name)
+			}
+		})
+	}
+}
+
+// TestSigningIsArmedWithoutASignedAuthenticate asserts signing is activated by a
+// session setup whose own signature is absent.
+//
+// [MS-SMB] section 3.3.5.3 asks the server to sign the response at sequence one
+// once it has the key; it does not ask for the request to be verified. A client
+// that has not yet armed signing puts a placeholder in the field, so demanding a
+// valid signature there refuses the client outright — and it would secure nothing,
+// since the key is derived from the very message the signature would cover.
+func TestSigningIsArmedWithoutASignedAuthenticate(t *testing.T) {
+	// A placeholder such as a client sends before its own signing is armed.
+	placeholder := []byte("BSRSPYL ")
+	if len(placeholder) != 8 {
+		t.Fatalf("the placeholder is %d bytes, want 8", len(placeholder))
+	}
+	if strings.TrimSpace(string(placeholder)) == "" {
+		t.Fatal("the placeholder is blank")
+	}
+
+	// The unit suite's client signs its AUTHENTICATE, so what is asserted here is
+	// the server's own rule: it arms signing from the exchange rather than from a
+	// signature on it, which the live matrix exercises against a client that sends
+	// the placeholder above.
+	_, client := pipedClient(t, conformanceConfig(SigningRequired), true)
+	if client.Connection == nil || !client.Connection.IsSigningActive {
+		t.Fatal("signing was not armed by a session setup under a required policy")
+	}
+	if _, err := client.Echo([]byte("signed")); err != nil {
+		t.Fatalf("a signed request after the exchange failed: %v", err)
+	}
+}

--- a/network/smb/smb_v10/types/SMB_STRING.go
+++ b/network/smb/smb_v10/types/SMB_STRING.go
@@ -269,3 +269,155 @@ func (s *SMB_STRING) Unmarshal(buffer []byte) (int, error) {
 		return 0, fmt.Errorf("invalid buffer format: 0x%02x", s.BufferFormat)
 	}
 }
+
+// UnmarshalWithEncoding deserializes an SMB_STRING whose characters are as wide as
+// the enclosing message declared.
+//
+// The null-terminated formats end at their first null CHARACTER, not their first
+// null byte. In a Unicode message a character is two bytes, so "\newdir" begins
+// 5C 00 and a scan for a single null byte ends the string after one byte — leaving
+// a buffer that is half a character long. Every caller then either truncates the
+// name to nothing or, decoding an odd number of bytes as UTF-16, reads past the
+// end of it.
+//
+// The formats that carry an explicit length are unaffected: their length already
+// says where the string ends, whatever its characters are.
+//
+// Parameters:
+//   - buffer: the serialized SMB_STRING, starting at its BufferFormat byte
+//   - unicode: whether the enclosing message set SMB_FLAGS2_UNICODE
+//
+// Returns:
+//   - The number of bytes consumed
+//   - An error if the buffer cannot be parsed
+func (s *SMB_STRING) UnmarshalWithEncoding(buffer []byte, unicode bool) (int, error) {
+	// An aligned string is the common case: the first string in a command's data
+	// block lands on an even offset from the header without help, because the
+	// block's own offset and the format byte together make it so.
+	return s.UnmarshalWithEncodingAt(buffer, unicode, 0)
+}
+
+// UnmarshalWithEncodingAt is UnmarshalWithEncoding told where the string sits.
+//
+// stringStart is the offset, from the start of the SMB header, of the first
+// character — that is, of the byte after the BufferFormat. [MS-CIFS] requires a
+// Unicode string to begin on a 2-byte boundary measured from the header, so when
+// that offset is odd a padding byte stands between the format byte and the
+// characters.
+//
+// This matters for the second string of a command that carries two. The first one
+// is aligned by construction, but the first string's length then decides where the
+// second begins, so half the time a pad byte appears there — and a decoder that
+// does not expect it reads every character of the second name straddling two
+// others, which yields a plausible-looking name made of the wrong bytes rather
+// than an error.
+//
+// Passing 0 means "already aligned", which is what the single-string commands are.
+//
+// Parameters:
+//   - buffer: the serialized SMB_STRING, starting at its BufferFormat byte
+//   - unicode: whether the enclosing message set SMB_FLAGS2_UNICODE
+//   - stringStart: the header-relative offset of the byte after the format byte
+//
+// Returns:
+//   - The number of bytes consumed, the padding byte included
+//   - An error if the buffer cannot be parsed
+func (s *SMB_STRING) UnmarshalWithEncodingAt(buffer []byte, unicode bool, stringStart int) (int, error) {
+	if !unicode {
+		return s.Unmarshal(buffer)
+	}
+	if len(buffer) < 1 {
+		return 0, fmt.Errorf("buffer too short to unmarshal SMB_STRING")
+	}
+
+	switch buffer[0] {
+	case SMB_STRING_BUFFER_FORMAT_NULL_TERMINATED_OEM_STRING,
+		SMB_STRING_BUFFER_FORMAT_NULL_TERMINATED_ASCII_STRING:
+		s.BufferFormat = buffer[0]
+
+		// Where the characters actually begin, once any alignment byte is passed.
+		start := 1
+		if stringStart%2 != 0 {
+			start++
+		}
+		if start > len(buffer) {
+			return 0, fmt.Errorf("buffer too short for an aligned SMB_STRING")
+		}
+
+		// The characters are two bytes wide, so the pairs to test step two at a
+		// time from there. An odd offset cannot end the string: the high half of
+		// one character and the low half of the next can both be zero without the
+		// string having ended.
+		for index := start; index+1 < len(buffer); index += 2 {
+			if buffer[index] == 0x00 && buffer[index+1] == 0x00 {
+				s.Buffer = make([]UCHAR, index-start)
+				copy(s.Buffer, buffer[start:index])
+				s.Length = USHORT(len(s.Buffer))
+				return index + 2, nil
+			}
+		}
+		return 0, fmt.Errorf("no null terminator found for format 0x%02x", buffer[0])
+	}
+
+	// Every other format states its own length, so the byte-oriented reader is
+	// already correct for it.
+	return s.Unmarshal(buffer)
+}
+
+// MarshalWithEncoding serializes an SMB_STRING whose characters are as wide as the
+// enclosing message declared.
+//
+// It is the counterpart of UnmarshalWithEncoding, and exists for the same reason:
+// the null-terminated formats end at a null CHARACTER. A two-byte character needs
+// a two-byte terminator, and emitting a single null byte after a Unicode string
+// leaves the field with no terminator at all — the reader consumes the low half of
+// the null as the high half of the last character and runs on into whatever
+// follows.
+//
+// Parameters:
+//   - unicode: whether the enclosing message set SMB_FLAGS2_UNICODE
+//
+// Returns:
+//   - The serialized SMB_STRING
+//   - An error if it cannot be serialized
+func (s *SMB_STRING) MarshalWithEncoding(unicode bool) ([]byte, error) {
+	return s.MarshalWithEncodingAt(unicode, 0)
+}
+
+// MarshalWithEncodingAt is MarshalWithEncoding told where the string will sit, so
+// it can emit the alignment byte that a Unicode string beginning on an odd
+// header-relative offset requires.
+//
+// stringStart is the offset, from the start of the SMB header, that the first
+// character would occupy without padding — that is, of the byte after the
+// BufferFormat. Passing 0 means "already aligned".
+//
+// Parameters:
+//   - unicode: whether the enclosing message set SMB_FLAGS2_UNICODE
+//   - stringStart: the header-relative offset of the byte after the format byte
+//
+// Returns:
+//   - The serialized SMB_STRING, alignment byte included
+//   - An error if it cannot be serialized
+func (s *SMB_STRING) MarshalWithEncodingAt(unicode bool, stringStart int) ([]byte, error) {
+	if !unicode {
+		return s.Marshal()
+	}
+
+	switch s.BufferFormat {
+	case SMB_STRING_BUFFER_FORMAT_NULL_TERMINATED_OEM_STRING,
+		SMB_STRING_BUFFER_FORMAT_NULL_TERMINATED_ASCII_STRING:
+		buffer := []byte{s.BufferFormat}
+		if stringStart%2 != 0 {
+			buffer = append(buffer, 0x00)
+		}
+		buffer = append(buffer, s.Buffer...)
+		// The two-byte terminator that a two-byte character needs.
+		buffer = append(buffer, 0x00, 0x00)
+		return buffer, nil
+	}
+
+	// Every other format states its own length, so the byte-oriented writer is
+	// already correct for it.
+	return s.Marshal()
+}


### PR DESCRIPTION
Twelfth and final commit toward an SMB 1.0 server (#1068), stacked on #1079.

The unit suite pairs this server with the SMB1 client in this repository. That is fast to work with and has one structural blind spot: **the two halves were written together, so a wire detail both get wrong agrees with itself and every round-trip passes.**

This adds a live interoperability matrix behind the `integration` tag, driving a third-party client and a third-party RPC client against a server started in-process. **It found nine defects.** None was reachable from the existing tests, because this repository's client sends its names in OEM even after negotiating Unicode — so every character-width mistake was symmetric and invisible.

### The nine

1. **The final session-setup leg returned an empty security blob.** RFC 4178 has the acceptor report the negotiation's outcome; an initiator waiting for `accept-completed` treats an empty final blob as a protocol violation and abandons the session, however successful the logon was. The acceptor gains the token that closes the exchange.

2. **Every null-terminated name field ended at its first null *byte*.** A null-terminated field ends at its first null *character*, so a Unicode name has a two-byte terminator: `\PIPE\srvsvc` was read as one backslash. Tree connects were refused as not being UNC paths.

3. **The UTF-16 decoder indexed `b[i+1]` unbounded**, so the one-byte buffer left over by (2) **panicked** and killed the connection. It is fed by network fields, where the length is whatever the sender said.

4. **Unicode field alignment was missing.** A Unicode field must start on a 2-byte boundary from the SMB header. For the second name of a rename that depends on the first name's length, so half of all renames took the padded path. Missing it doesn't fail — it shifts every character by one byte and **creates a file under a name the client never asked for**.

5. **Transaction blocks were located by arithmetic, not by their declared offsets.** Subtracting field lengths from the block size assumes the block ends flush with its last field; a real client pads the *end* to a four-byte boundary, so the surplus was charged to the leading pad and every field in both blocks was read shifted. A directory listing asked for level `0x0104` and the server read `0x0000` two bytes further on. All six decoders now use the declared offsets, which [MS-CIFS] measures from the header and requires the receiver to use.

6. **The transaction marshallers never set those offsets at all** — left for a caller to fill in, and nothing did, so they went out as zero and a spec-following receiver could not find either block. Each now derives them from the layout it writes.

7. **Response names went out in OEM regardless of the request.** A client reads the buffer as UTF-16 when it negotiated Unicode, whatever the server put there — a listing of the right shape and the wrong text.

8. **A wildcard-free search was treated as a directory to list.** Naming one file exactly is how a client resolves a name before deleting it, so every delete failed at the search and the file stayed.

9. **Read, write and query reached `open.File` without checking it.** A pipe handle has no file behind it, and an RPC client reads one directly when its transaction didn't return a whole response — an unguarded dereference **took down the connection serving a real RPC client**.

### Signing: a requirement this implementation invented

The server demanded a valid signature on the AUTHENTICATE request. [MS-SMB] 3.3.5.3 asks only that, once the key is acquired, *"the server MUST sign the SMB_COM_SESSION_SETUP_ANDX response … by passing in a sequence number of one"* — it does not ask for the request to be verified.

Nor would verifying it secure anything: the key is derived from the very message the signature covers, so anyone able to produce an AUTHENTICATE that verifies can produce its signature too. What it *did* do was refuse every client that had not yet armed its own signing and put a placeholder in the field — making signing **unusable rather than mandatory**.

With that removed, a fully signed session works in both directions, each side verifying the other.

### Two capabilities added

A real client asks these on every connection, and an unanswered question is an error in every session:

- **`SMB_COM_QUERY_INFORMATION_DISK`** — 16-bit fields, so a large volume is *scaled* rather than truncated; reporting the low 16 bits would describe a tiny volume, which is worse than a coarse one.
- **The pass-through information classes above `0x03E8`**, of which the full-size class is what a client uses for free space.

### What the matrix asserts

No allowances — the whole session must be clean:

- a listing checked **by name** (which is what catches a wrong response encoding)
- a file in both directions, contents compared
- the name-carrying commands checked **against the backend**, not the client's output
- a mandatory-signing session verified in both directions by two independent implementations
- **an RPC bind completed over a named pipe** — the handler sees the open, the bind, the call that follows it, and the close: the whole shape of MS-RPC over SMB1, performed by an implementation that knows nothing about this one

Every test fails if the client binary cannot run. A **negative control** confirms it: pointing the suite at a binary that produces no output fails all six rather than passing quietly.

### Regression coverage without a client

Each defect also has a unit test that sets the Unicode flag deliberately, so the suite catches them again with no client binary present. The marshalled offsets are asserted **against the bytes**, not against a recomputation of the same formula, so a wrong formula fails too.

The fuzz corpus gains the Unicode shapes, names whose terminator falls at an odd offset, second names cut short mid-character, and transactions whose declared offsets point outside their own data block. **16.4M executions, no crashers.**

`go build`, `go vet`, `gofmt` and the full `go test ./...` are green; `go test -tags integration` passes against smbclient and rpcclient (Samba 4.19.5).

### Not covered live

The NT_TRANSACT security-descriptor path. The tool that would drive it takes no port argument and a privileged port is not available in this environment, so it remains covered by unit tests that parse the descriptor back with an independent parser. That gap is recorded in the package documentation rather than left implied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
