### PR TITLE
Fix NTLM payload bounds overflow (Fixes #1081)

### DIFF
--- a/crypto/spnego/ntlm/message/challenge/challenge.go
+++ b/crypto/spnego/ntlm/message/challenge/challenge.go
@@ -199,17 +199,27 @@ func (msg *ChallengeMessage) Unmarshal(data []byte) (int, error) {
 
 	// Read payload section
 
+	// The payload bounds are computed in 64-bit. BufferOffset is a 32-bit field
+	// taken straight off the wire, so adding Len to it in 32-bit arithmetic wraps:
+	// an offset of 0xFFFFFFFF produces a sum that compares as inside the buffer,
+	// and the slice expression below then panics. uint64 cannot overflow for a
+	// uint32 offset plus a uint16 length, whatever the width of int on the host.
+
 	// Target name
-	if msg.TargetNameFields.BufferOffset+uint32(msg.TargetNameFields.Len) > uint32(len(data)) {
+	targetNameStart := uint64(msg.TargetNameFields.BufferOffset)
+	targetNameEnd := targetNameStart + uint64(msg.TargetNameFields.Len)
+	if targetNameEnd > uint64(len(data)) {
 		return 0, fmt.Errorf("data too short to read TargetName in payload section in ChallengeMessage")
 	}
-	msg.TargetName = data[msg.TargetNameFields.BufferOffset : msg.TargetNameFields.BufferOffset+uint32(msg.TargetNameFields.Len)]
+	msg.TargetName = data[targetNameStart:targetNameEnd]
 
 	// Target info
-	if msg.TargetInfoFields.BufferOffset+uint32(msg.TargetInfoFields.Len) > uint32(len(data)) {
+	targetInfoStart := uint64(msg.TargetInfoFields.BufferOffset)
+	targetInfoEnd := targetInfoStart + uint64(msg.TargetInfoFields.Len)
+	if targetInfoEnd > uint64(len(data)) {
 		return 0, fmt.Errorf("data too short to read TargetInfo in payload section in ChallengeMessage")
 	}
-	msg.TargetInfo = data[msg.TargetInfoFields.BufferOffset : msg.TargetInfoFields.BufferOffset+uint32(msg.TargetInfoFields.Len)]
+	msg.TargetInfo = data[targetInfoStart:targetInfoEnd]
 
 	return totalBytesRead, nil
 }

--- a/crypto/spnego/ntlm/message/challenge/challenge_test.go
+++ b/crypto/spnego/ntlm/message/challenge/challenge_test.go
@@ -2,6 +2,7 @@ package challenge_test
 
 import (
 	"bytes"
+	"encoding/binary"
 	"encoding/hex"
 	"testing"
 
@@ -122,6 +123,57 @@ func TestChallengeMessageMarshalUnmarshal(t *testing.T) {
 						t.Error("Version mismatch")
 					}
 				}
+			}
+		})
+	}
+}
+
+// TestChallengeMessagePayloadOffsetOverflow asserts that a TargetName or
+// TargetInfo BufferOffset near the top of the 32-bit range is refused rather than
+// wrapping past the bounds check and panicking in the slice expression.
+//
+// BufferOffset is a 32-bit wire field and Len a 16-bit one, so computing the end
+// of the payload as BufferOffset+Len in uint32 overflows: 0xFFFFFFFF plus a small
+// length compares as inside the buffer.
+func TestChallengeMessagePayloadOffsetOverflow(t *testing.T) {
+	// The fixed part of a CHALLENGE: signature and type (12), TargetNameFields
+	// (8), NegotiateFlags (4), ServerChallenge (8), Reserved (8),
+	// TargetInfoFields (8), Version (8).
+	build := func(targetNameOffset, targetInfoOffset uint32) []byte {
+		message := make([]byte, 60)
+		copy(message, []byte{'N', 'T', 'L', 'M', 'S', 'S', 'P', 0})
+		binary.LittleEndian.PutUint32(message[8:12], 2)
+
+		binary.LittleEndian.PutUint16(message[12:14], 8) // TargetName Len
+		binary.LittleEndian.PutUint16(message[14:16], 8) // TargetName MaxLen
+		binary.LittleEndian.PutUint32(message[16:20], targetNameOffset)
+
+		binary.LittleEndian.PutUint16(message[40:42], 8) // TargetInfo Len
+		binary.LittleEndian.PutUint16(message[42:44], 8) // TargetInfo MaxLen
+		binary.LittleEndian.PutUint32(message[44:48], targetInfoOffset)
+
+		return message
+	}
+
+	tests := []struct {
+		name    string
+		message []byte
+	}{
+		{name: "TargetName offset overflows", message: build(0xFFFFFFFF, 52)},
+		{name: "TargetInfo offset overflows", message: build(52, 0xFFFFFFFF)},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			defer func() {
+				if recovered := recover(); recovered != nil {
+					t.Fatalf("Unmarshal() panicked instead of returning an error: %v", recovered)
+				}
+			}()
+
+			parsed := &challenge.ChallengeMessage{}
+			if _, err := parsed.Unmarshal(test.message); err == nil {
+				t.Error("Unmarshal() accepted a payload offset outside the message")
 			}
 		})
 	}

--- a/crypto/spnego/ntlm/message/negotiate/negotiate.go
+++ b/crypto/spnego/ntlm/message/negotiate/negotiate.go
@@ -246,20 +246,30 @@ func (msg *NegotiateMessage) Unmarshal(data []byte) (int, error) {
 
 	// Read payload section
 
+	// The payload bounds are computed in 64-bit. BufferOffset is a 32-bit field
+	// taken straight off the wire, so adding Len to it in 32-bit arithmetic wraps:
+	// an offset of 0xFFFFFFFF produces a sum that compares as inside the buffer,
+	// and the slice expression below then panics. uint64 cannot overflow for a
+	// uint32 offset plus a uint16 length, whatever the width of int on the host.
+
 	// Domain name
 	if msg.DomainNameFields.Len != 0 {
-		if msg.DomainNameFields.BufferOffset+uint32(msg.DomainNameFields.Len) > uint32(len(data)) {
+		domainStart := uint64(msg.DomainNameFields.BufferOffset)
+		domainEnd := domainStart + uint64(msg.DomainNameFields.Len)
+		if domainEnd > uint64(len(data)) {
 			return 0, fmt.Errorf("data too short to read DomainName in payload section in NegotiateMessage")
 		}
-		msg.DomainName = data[msg.DomainNameFields.BufferOffset : msg.DomainNameFields.BufferOffset+uint32(msg.DomainNameFields.Len)]
+		msg.DomainName = data[domainStart:domainEnd]
 	}
 
 	// Workstation
 	if msg.WorkstationFields.Len != 0 {
-		if msg.WorkstationFields.BufferOffset+uint32(msg.WorkstationFields.Len) > uint32(len(data)) {
+		workstationStart := uint64(msg.WorkstationFields.BufferOffset)
+		workstationEnd := workstationStart + uint64(msg.WorkstationFields.Len)
+		if workstationEnd > uint64(len(data)) {
 			return 0, fmt.Errorf("data too short to read Workstation in payload section in NegotiateMessage")
 		}
-		msg.Workstation = data[msg.WorkstationFields.BufferOffset : msg.WorkstationFields.BufferOffset+uint32(msg.WorkstationFields.Len)]
+		msg.Workstation = data[workstationStart:workstationEnd]
 	}
 
 	return totalBytesRead, nil

--- a/crypto/spnego/ntlm/message/negotiate/negotiate_test.go
+++ b/crypto/spnego/ntlm/message/negotiate/negotiate_test.go
@@ -2,6 +2,7 @@ package negotiate_test
 
 import (
 	"bytes"
+	"encoding/binary"
 	"encoding/hex"
 	"testing"
 
@@ -118,5 +119,56 @@ func TestUnmarshallRealData(t *testing.T) {
 	_, err = msg.Unmarshal(bytesBlob)
 	if err != nil {
 		t.Fatalf("failed to unmarshal: %v", err)
+	}
+}
+
+// TestNegotiateMessagePayloadOffsetOverflow asserts that a DomainName or
+// Workstation BufferOffset near the top of the 32-bit range is refused rather
+// than wrapping past the bounds check and panicking in the slice expression.
+//
+// BufferOffset is a 32-bit wire field and Len a 16-bit one, so computing the end
+// of the payload as BufferOffset+Len in uint32 overflows: 0xFFFFFFFF plus a small
+// length compares as inside the buffer.
+func TestNegotiateMessagePayloadOffsetOverflow(t *testing.T) {
+	// The fixed part of a NEGOTIATE: signature and type (12), NegotiateFlags (4),
+	// DomainNameFields (8), WorkstationFields (8), Version (8).
+	build := func(domainOffset, workstationOffset uint32) []byte {
+		message := make([]byte, 40)
+		copy(message, []byte{'N', 'T', 'L', 'M', 'S', 'S', 'P', 0})
+		binary.LittleEndian.PutUint32(message[8:12], 1)
+		binary.LittleEndian.PutUint32(message[12:16], 0)
+
+		binary.LittleEndian.PutUint16(message[16:18], 8) // DomainName Len
+		binary.LittleEndian.PutUint16(message[18:20], 8) // DomainName MaxLen
+		binary.LittleEndian.PutUint32(message[20:24], domainOffset)
+
+		binary.LittleEndian.PutUint16(message[24:26], 8) // Workstation Len
+		binary.LittleEndian.PutUint16(message[26:28], 8) // Workstation MaxLen
+		binary.LittleEndian.PutUint32(message[28:32], workstationOffset)
+
+		return message
+	}
+
+	tests := []struct {
+		name    string
+		message []byte
+	}{
+		{name: "DomainName offset overflows", message: build(0xFFFFFFFF, 32)},
+		{name: "Workstation offset overflows", message: build(32, 0xFFFFFFFF)},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			defer func() {
+				if recovered := recover(); recovered != nil {
+					t.Fatalf("Unmarshal() panicked instead of returning an error: %v", recovered)
+				}
+			}()
+
+			parsed := &negotiate.NegotiateMessage{}
+			if _, err := parsed.Unmarshal(test.message); err == nil {
+				t.Error("Unmarshal() accepted a payload offset outside the message")
+			}
+		})
 	}
 }


### PR DESCRIPTION
### Linked Issue
`Closes #1081`

### Root Cause
`datafields.DataFields` declares `BufferOffset` as `uint32` and `Len` as `uint16`, both read directly off the wire. The CHALLENGE and NEGOTIATE parsers checked each payload with `BufferOffset+uint32(Len) > uint32(len(data))`, which performs the addition in 32-bit arithmetic. For an offset near the top of the range the sum wraps to a small number, so the comparison is made against a wrapped value rather than the real end of the payload. The guard then passes for an offset that is nowhere near the buffer, and the slice expression on the next line panics.

`authenticate.go` already performed the equivalent checks with `int(...)+int(...)`, which does not overflow on a 64-bit platform. These two parsers were never brought into line with it, so the defect survived in four places: TargetName and TargetInfo in CHALLENGE, DomainName and Workstation in NEGOTIATE.

### Fix Description
Each payload's start and end are computed as `uint64` locals and the end is compared against `uint64(len(data))` before the slice is taken. A `uint32` offset plus a `uint16` length cannot overflow 64 bits, so the comparison is always made against the true end offset.

`uint64` was chosen over the `int` form used in `authenticate.go` because `int` is 32 bits on a 32-bit host, where `int(uint32(0xFFFFFFFF))` is -1 and the same class of defect reappears as a negative index. `uint64` is correct regardless of host word size.

The error strings, the surrounding `Len != 0` guards in NEGOTIATE, and the parse order are unchanged, so a well-formed message parses exactly as before.

### How Verified
- **Tests:** `TestChallengeMessagePayloadOffsetOverflow` and `TestNegotiateMessagePayloadOffsetOverflow`, each covering both payload fields of its message. Both were confirmed to fail against the unpatched parsers, with `panic: runtime error: slice bounds out of range [4294967295:7]` at `challenge.go:206` and `negotiate.go:254`, and to pass against the patched ones.
- **Runtime:** the inputs that originally produced these panics under fuzzing are now rejected with the existing "data too short to read ..." errors.
- **Regression:** `go build ./...`, `go vet ./...` and `go test ./...` are clean across the module. The existing round-trip tests (`TestChallengeMessageMarshalUnmarshal`, `TestMarshalUnmarshal`, `TestUnmarshallRealData`) continue to pass, so well-formed messages are unaffected.

### Test Coverage
**Added:**
- `crypto/spnego/ntlm/message/challenge/challenge_test.go` — `TestChallengeMessagePayloadOffsetOverflow`
- `crypto/spnego/ntlm/message/negotiate/negotiate_test.go` — `TestNegotiateMessagePayloadOffsetOverflow`

Each asserts that a `BufferOffset` of `0xFFFFFFFF` is rejected with an error, and fails the test if `Unmarshal` panics instead.

### Scope of Change
- **Files changed:** `crypto/spnego/ntlm/message/challenge/challenge.go`, `crypto/spnego/ntlm/message/challenge/challenge_test.go`, `crypto/spnego/ntlm/message/negotiate/negotiate.go`, `crypto/spnego/ntlm/message/negotiate/negotiate_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
The change is confined to four bounds comparisons and the slice expressions they guard. A message that parsed before still parses to the same values, since the only inputs whose treatment changes are those whose 32-bit sum wrapped — all of which previously panicked. Safe to merge without staged rollout.

### Notes
The equivalent checks in `crypto/spnego/ntlm/message/authenticate/authenticate.go` use `int` arithmetic. That is safe on the 64-bit platforms this builds for, and the parser does not panic on the inputs that crash the other two, so it is left alone here rather than bundled into this fix. Aligning it on the `uint64` form for 32-bit correctness is worth a separate change.

The NTLM header parser at `crypto/spnego/ntlm/message/header/header.go:43` validates neither the `NTLMSSP\0` signature nor that `MessageType` matches the message being parsed — the fuzz input that first surfaced this panic was not an NTLM message at all. That is a separate defect and is not addressed here.
