### PR TITLE
Fix negative SMB2 negotiate context offset (Fixes #1082)

### DIFF
--- a/network/smb/smb_v20/message/commands/NegotiateContext.go
+++ b/network/smb/smb_v20/message/commands/NegotiateContext.go
@@ -101,6 +101,15 @@ func marshalNegotiateContexts(bodyOffset int, contexts []*NegotiateContext) ([]b
 // header). Each context is 8-byte aligned relative to the header.
 func parseNegotiateContexts(data []byte, headerRelativeOffset int, count int) ([]*NegotiateContext, error) {
 	contexts := make([]*NegotiateContext, 0, count)
+	// The offset is header-relative and the data begins at the body, so the header
+	// size is subtracted to reach an index into data. An offset that points inside
+	// or before the header would make that index negative, and the bounds checks
+	// below are upper-bound comparisons that a negative index satisfies -- so it
+	// is refused here rather than allowed to reach a slice expression.
+	if headerRelativeOffset < header.SMB2_HEADER_SIZE {
+		return nil, fmt.Errorf("negotiate context offset %d is inside the %d-byte SMB2 header",
+			headerRelativeOffset, header.SMB2_HEADER_SIZE)
+	}
 	off := headerRelativeOffset - header.SMB2_HEADER_SIZE
 	for i := 0; i < count; i++ {
 		// Align to 8 relative to the header.

--- a/network/smb/smb_v20/message/commands/commands_test.go
+++ b/network/smb/smb_v20/message/commands/commands_test.go
@@ -236,3 +236,58 @@ func TestLogoffAndTreeDisconnect_RoundTrip(t *testing.T) {
 		}
 	}
 }
+
+// TestNegotiateContextOffsetInsideHeader asserts that a NegotiateContextOffset
+// pointing inside or before the 64-byte SMB2 header is refused rather than
+// producing a negative index into the message body.
+//
+// The offset is header-relative and the body begins after the header, so the
+// parser subtracts the header size to index the body. The bounds checks that
+// follow are upper-bound comparisons, which a negative index satisfies, so
+// without an explicit lower bound the slice expression panics.
+func TestNegotiateContextOffsetInsideHeader(t *testing.T) {
+	// A NEGOTIATE response body with one announced context, an empty security
+	// buffer, and a context offset short of the header.
+	response := make([]byte, 64)
+	binary.LittleEndian.PutUint16(response[0:2], commands.NegotiateResponseStructureSize)
+	binary.LittleEndian.PutUint16(response[6:8], 1)   // NegotiateContextCount
+	binary.LittleEndian.PutUint16(response[56:58], 0) // SecurityBufferOffset
+	binary.LittleEndian.PutUint16(response[58:60], 0) // SecurityBufferLength
+
+	// A request body of the same shape. Its context offset sits at 28:32.
+	request := make([]byte, 36)
+	binary.LittleEndian.PutUint16(request[0:2], commands.NegotiateRequestStructureSize)
+	binary.LittleEndian.PutUint16(request[2:4], 1) // DialectCount
+	binary.LittleEndian.PutUint16(request[32:34], 1)
+	binary.LittleEndian.PutUint16(request[34:36], uint16(dialects.SMB2_DIALECT_3_1_1))
+
+	// Offset 0 is not included: it is the encoding for "no contexts", which both
+	// parsers skip before any arithmetic.
+	offsets := map[string]uint32{
+		"one byte in":      1,
+		"mid header":       50,
+		"last header byte": 63,
+	}
+
+	for name, offset := range offsets {
+		t.Run(name, func(t *testing.T) {
+			defer func() {
+				if recovered := recover(); recovered != nil {
+					t.Fatalf("Unmarshal() panicked instead of returning an error: %v", recovered)
+				}
+			}()
+
+			binary.LittleEndian.PutUint32(response[60:64], offset)
+			var decodedResponse commands.NegotiateResponse
+			if _, err := decodedResponse.Unmarshal(response); err == nil {
+				t.Errorf("NegotiateResponse.Unmarshal() accepted a context offset of %d", offset)
+			}
+
+			binary.LittleEndian.PutUint32(request[28:32], offset)
+			var decodedRequest commands.NegotiateRequest
+			if _, err := decodedRequest.Unmarshal(request); err == nil {
+				t.Errorf("NegotiateRequest.Unmarshal() accepted a context offset of %d", offset)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #1082`

### Root Cause
`NegotiateContextOffset` is measured from the start of the SMB2 header, while the `data` slice `parseNegotiateContexts` walks begins at the message body. The function bridged the two by subtracting the header size at L104 and then relied on the per-context bounds checks to keep the index inside the buffer.

Those checks are upper-bound comparisons only — `off+8 > len(data)` and `off+dataLen > len(data)`. A negative `off` satisfies both, so nothing rejected an offset that pointed inside or before the header. The implicit assumption was that a peer places its contexts after the header, which holds for a well-formed message and not for a hostile one.

### Fix Description
Reject `headerRelativeOffset < SMB2_HEADER_SIZE` before the subtraction, so `off` is non-negative by construction and the existing upper-bound checks are sufficient on their own.

The guard is placed in `parseNegotiateContexts` rather than at either call site because both callers share the defect: `NegotiateResponse.go:147` parses an offset supplied by the server, and `NegotiateRequest.go:132` one supplied by the client. Fixing the shared parser covers both and leaves no second copy to drift.

Offset 0 is not affected. Both callers test `NegotiateContextOffset != 0` before calling, so the "no contexts" encoding never reaches this function.

### How Verified
- **Tests:** `TestNegotiateContextOffsetInsideHeader` exercises offsets 1, 50 and 63 against both `NegotiateResponse.Unmarshal` and `NegotiateRequest.Unmarshal`. Confirmed to fail against the unpatched parser with `panic: runtime error: slice bounds out of range [:-54]` and `[:-6]`, and to pass against the patched one.
- **Static:** with the guard at L104, `off` starts at `headerRelativeOffset - 64 >= 0`. The alignment step at L108 only increases it, and each subsequent advance adds a non-negative `dataLen`, so every index into `data` in the loop is non-negative and already checked against `len(data)`.
- **Regression:** `go build ./...`, `go vet ./...` and `go test ./...` are clean across the module. `TestNegotiateRequest_RoundTrip` and `TestNegotiateResponse_RoundTrip` continue to pass, so well-formed messages with contexts at legal offsets are unaffected.

### Test Coverage
**Added:** `network/smb/smb_v20/message/commands/commands_test.go` — `TestNegotiateContextOffsetInsideHeader`, covering both the request and response paths and asserting an error rather than a panic.

### Scope of Change
- **Files changed:** `network/smb/smb_v20/message/commands/NegotiateContext.go`, `network/smb/smb_v20/message/commands/commands_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
The change adds one lower-bound check on a path that previously panicked for exactly the inputs it now rejects. No message that parsed successfully before parses differently. Safe to merge without staged rollout.

### Notes
`gofmt` reports `network/smb/smb_v20/message/commands/Create_test.go` as unformatted. That predates this branch and is untouched here.
