### PR TITLE
Fix directory open creating on a read-only share (Fixes #1085)

### DIFF
--- a/network/smb/smb_v10/server/file_service_test.go
+++ b/network/smb/smb_v10/server/file_service_test.go
@@ -732,3 +732,84 @@ func TestMemoryFileSystemDirectly(t *testing.T) {
 		t.Fatal("Rmdir() removed a non-empty directory")
 	}
 }
+
+// TestLocalFileSystemDirectoryOpenDoesNotCreate asserts that an open-existing-only
+// request for a directory that is not there is refused, and creates nothing.
+//
+// FILE_OPEN with FILE_DIRECTORY_FILE produces OpenFlags with Directory set and
+// Create clear. The backend's create-a-directory branch is reached whenever the
+// target is absent, so without a check on Create it answered a request to find a
+// directory by making one. On a read-only share it made one anyway: the read-only
+// guards test Write, Create, CreateNew and Truncate, and such a request sets none
+// of them.
+func TestLocalFileSystemDirectoryOpenDoesNotCreate(t *testing.T) {
+	for _, readOnly := range []bool{false, true} {
+		name := "writable share"
+		if readOnly {
+			name = "read-only share"
+		}
+
+		t.Run(name, func(t *testing.T) {
+			root := t.TempDir()
+			fs, err := NewLocalFileSystem(root, "LOCAL")
+			if err != nil {
+				t.Fatalf("NewLocalFileSystem() error = %v", err)
+			}
+			fs.SetReadOnly(readOnly)
+			_, client := fileServer(t, fs, readOnly)
+
+			fid, err := client.OpenFile("absent", fileflags.GENERIC_READ, fileflags.FILE_SHARE_READ,
+				fileflags.FILE_OPEN, fileflags.FILE_DIRECTORY_FILE)
+			if err == nil {
+				client.CloseFile(fid)
+				t.Error("OpenFile() with FILE_OPEN succeeded for a directory that does not exist")
+			}
+			if _, statErr := os.Stat(filepath.Join(root, "absent")); statErr == nil {
+				t.Error("the directory was created by a request that only asked to open one")
+			}
+		})
+	}
+}
+
+// TestLocalFileSystemDirectoryCreateStillWorks asserts the guard above did not
+// cost the dispositions that legitimately create a directory.
+func TestLocalFileSystemDirectoryCreateStillWorks(t *testing.T) {
+	dispositions := map[string]uint32{
+		"FILE_CREATE":  fileflags.FILE_CREATE,
+		"FILE_OPEN_IF": fileflags.FILE_OPEN_IF,
+	}
+
+	for name, disposition := range dispositions {
+		t.Run(name, func(t *testing.T) {
+			root := t.TempDir()
+			fs, err := NewLocalFileSystem(root, "LOCAL")
+			if err != nil {
+				t.Fatalf("NewLocalFileSystem() error = %v", err)
+			}
+			_, client := fileServer(t, fs, false)
+
+			fid, err := client.OpenFile("made", fileflags.GENERIC_READ, fileflags.FILE_SHARE_READ,
+				disposition, fileflags.FILE_DIRECTORY_FILE)
+			if err != nil {
+				t.Fatalf("OpenFile() with %s error = %v", name, err)
+			}
+			client.CloseFile(fid)
+
+			info, statErr := os.Stat(filepath.Join(root, "made"))
+			if statErr != nil {
+				t.Fatalf("the directory was not created: %v", statErr)
+			}
+			if !info.IsDir() {
+				t.Error("what was created is not a directory")
+			}
+
+			// And opening it again with FILE_OPEN now finds it.
+			reopened, err := client.OpenFile("made", fileflags.GENERIC_READ, fileflags.FILE_SHARE_READ,
+				fileflags.FILE_OPEN, fileflags.FILE_DIRECTORY_FILE)
+			if err != nil {
+				t.Fatalf("OpenFile() with FILE_OPEN on the existing directory error = %v", err)
+			}
+			client.CloseFile(reopened)
+		})
+	}
+}

--- a/network/smb/smb_v10/server/fs_local.go
+++ b/network/smb/smb_v10/server/fs_local.go
@@ -218,6 +218,18 @@ func (fs *LocalFileSystem) Open(path string, flags OpenFlags) (File, error) {
 	}
 
 	if flags.Directory {
+		// Reaching here means the target does not exist: an existing directory
+		// returned a handle above, and an existing file was refused there. So this
+		// branch creates one, and may only be taken when the disposition asked for
+		// a create.
+		//
+		// Without that condition an open-existing-only request created the
+		// directory it was meant to find, and did so on a read-only share as well:
+		// the read-only guards above test Write, Create, CreateNew and Truncate,
+		// none of which a bare FILE_OPEN with FILE_DIRECTORY_FILE sets.
+		if !flags.Create {
+			return nil, ErrNotFound
+		}
 		if err := os.Mkdir(host, 0o750); err != nil {
 			return nil, translate(err)
 		}


### PR DESCRIPTION
### Linked Issue
`Closes #1085`

### Root Cause
`openFlagsFor` translates a create request into backend flags: the disposition decides what happens about existence, and `CreateOptions` decides what the target must be. `FILE_OPEN` means "must exist" and so sets no flag at all, while `FILE_DIRECTORY_FILE` sets `flags.Directory`. The two are independent, and `LocalFileSystem.Open` only ever consulted the second.

The branch at L220 is reached exactly when the target is absent — an existing directory returns a handle at L199, and an existing file is refused at L201 — and its only condition was `flags.Directory`. So it could not tell an open from a create, and answered a request to find a directory by making one.

The read-only bypass follows from the same gap rather than being a separate defect. Both guards — the backend's at L181 and the share's at `handler_file.go:189` — test `Write || Create || CreateNew || Truncate`. A directory-only open sets none of those, so it passed both and then created a directory on a share configured read-only.

### Fix Description
Take the create-a-directory branch only when `flags.Create` is set, and return `ErrNotFound` otherwise.

That one condition fixes both halves. The refusal is the correct answer for `FILE_OPEN` on its own, and because creating a directory now requires `Create`, the existing read-only guards catch it — the guard at L181 already tests `Create`, so no change is needed there. Adding `flags.Directory` to those guards was rejected as the alternative: it would refuse opening an *existing* directory on a read-only share, which must keep working.

This also brings the two backends into line. `MemoryFileSystem.Open` at `fs_mem.go:184` already refuses `!exists && !flags.Create`, and the file path in this same function already got the equivalent from `os.OpenFile` without `O_CREATE`; only the directory branch was missing it.

### How Verified
- **Tests:** `TestLocalFileSystemDirectoryOpenDoesNotCreate` drives a real `NT_CREATE_ANDX` over the protocol with `FILE_OPEN` + `FILE_DIRECTORY_FILE` against a `LocalFileSystem`, on a writable and a read-only share, and asserts both that the open is refused and that nothing appeared on disk. Confirmed to fail against the unpatched backend on both shares — "OpenFile() with FILE_OPEN succeeded for a directory that does not exist" and "the directory was created by a request that only asked to open one" — and to pass against the patched one.
- **Runtime:** the refusal now reaches the client as `STATUS_OBJECT_NAME_NOT_FOUND`, logged as `could not open "absent" on "files": no such file or directory`.
- **Regression:** `go build ./...`, `go vet ./...` and `go test ./...` are clean across the module. `TestFileServiceDirectoryOperations`, `TestFileServiceReadOnlyShare` and `TestLocalFileSystemRoundTrip` continue to pass.

### Test Coverage
**Added:** both in `network/smb/smb_v10/server/file_service_test.go`.
- `TestLocalFileSystemDirectoryOpenDoesNotCreate` — the bug, on a writable and a read-only share.
- `TestLocalFileSystemDirectoryCreateStillWorks` — `FILE_CREATE` and `FILE_OPEN_IF` still create a directory, and `FILE_OPEN` finds it afterwards. This guards the obvious way to get the fix wrong, which is to refuse the dispositions that legitimately create.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/server/fs_local.go`, `network/smb/smb_v10/server/file_service_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
The change adds one condition on a branch that is only reachable when the target does not exist. Every disposition that legitimately creates a directory sets `Create`, so the dispositions that worked before still work; the only requests whose treatment changes are those that asked to open a directory that is not there. Safe to merge without staged rollout.

### Notes
`TestFileServiceReadOnlyShare` covers the read-only share against `MemoryFileSystem`, which does not have this defect. That is why the existing suite was green — the new tests use `LocalFileSystem` deliberately.
