### PR TITLE
Fix second session re-keying a signing connection (Fixes #1087)

### DIFF
--- a/network/smb/smb_v10/server/handler_session.go
+++ b/network/smb/smb_v10/server/handler_session.go
@@ -181,7 +181,16 @@ func (c *Connection) finishAuthentication(
 		return status
 	}
 
-	if armSigning {
+	// Signing belongs to the connection rather than to a session: one key and one
+	// sequence carry every session on it. So it is armed once, by the first
+	// exchange that can, and a later session setup leaves it alone.
+	//
+	// Re-keying here would strand every session already established. The
+	// connection's sequence would restart at two while the client is far past it,
+	// and the key would change under sessions that never asked for a new one, so
+	// the next request any of them sent would fail verification and the connection
+	// would be dropped.
+	if armSigning && !c.SigningActive {
 		// Signing is activated by this exchange rather than checked on it. The
 		// AUTHENTICATE request's own signature is not verified, and [MS-SMB]
 		// section 3.3.5.3 does not ask for it to be: it says only that once the key
@@ -202,6 +211,9 @@ func (c *Connection) finishAuthentication(
 
 		logger.Debugf("SMB1 server: signing armed for %s on UID 0x%04X", c.Remote, uid)
 	}
+	// On a connection that is already signing, this response needs no signature
+	// applied here: handleFrame verified the request against the connection's key
+	// and armed the writer with the response sequence that follows it.
 
 	response := c.newSessionSetupResponse()
 	if session.IsGuest {

--- a/network/smb/smb_v10/server/session_test.go
+++ b/network/smb/smb_v10/server/session_test.go
@@ -833,3 +833,103 @@ func TestClientEstablishesSignedSession(t *testing.T) {
 		}
 	}
 }
+
+// TestSecondSessionKeepsTheConnectionSigning asserts a second session set up on a
+// connection that is already signing does not re-key it.
+//
+// Signing belongs to the connection: one key and one sequence carry every session
+// on it. Arming it again for a second logon reset both, so the first session's
+// next request was verified against a key it never used at a sequence the client
+// had long passed, and the connection was dropped.
+//
+// TestSeveralSessionsOnOneConnection covers two sessions on one connection but
+// runs with SigningDisabled, which is why this case needs its own test.
+func TestSecondSessionKeepsTheConnectionSigning(t *testing.T) {
+	const secondUsername, secondPassword = "bob", "bobs-password"
+
+	_, addr := serverWithAccount(t, SigningRequired, func(c *Config) {
+		c.Authenticator = StaticAccounts(
+			Account{Domain: captureDomain, Username: captureUsername, NTHash: nt.NTHash(capturePassword)},
+			Account{Domain: captureDomain, Username: secondUsername, NTHash: nt.NTHash(secondPassword)},
+		)
+	})
+
+	session := establishSession(t, addr, captureDomain, captureUsername, capturePassword, true)
+	if !session.signing {
+		t.Fatal("signing was not armed on the first session")
+	}
+	keyBefore := append([]byte(nil), session.key...)
+
+	// The first session works before the second logon. sendOnSession verifies the
+	// response signature and advances the sequence, so a failure here is already a
+	// signing failure.
+	echo := commands.NewEchoRequest()
+	echo.EchoCount = 1
+	echo.Data = []byte("before")
+	if response := sendOnSession(t, session, codes.SMB_COM_ECHO, echo); response.Header.Status != 0 {
+		t.Fatalf("the echo before the second logon answered 0x%08X, want success", response.Header.Status)
+	}
+
+	// A second logon for another account, on the same connection. Both legs are
+	// signed with the connection's key at the connection's sequence, because that
+	// is what a signing connection requires of every request on it.
+	auth := spnego.NewAuthContext(spnego.AuthTypeNTLM, captureDomain, secondUsername, secondPassword, "CLIENT01", true)
+	version := ntlmversion.DefaultVersion()
+	negotiateToken, err := auth.CreateNegotiateToken(testClientNegotiateFlags, &version)
+	if err != nil {
+		t.Fatalf("CreateNegotiateToken() error = %v", err)
+	}
+
+	first := sendSessionSetupSigned(t, session.client, negotiateToken, 0, true, session.key, session.sequence)
+	if first.Header.Status != uint32(nt_status.NT_STATUS_MORE_PROCESSING_REQUIRED) {
+		t.Fatalf("the second session's challenge leg answered 0x%08X, want NT_STATUS_MORE_PROCESSING_REQUIRED",
+			first.Header.Status)
+	}
+	session.sequence = signing.NextRequestSequenceNumber(session.sequence)
+
+	challengeResponse, ok := first.Command.(*commands.SessionSetupAndxResponse)
+	if !ok {
+		t.Fatalf("the second session's challenge leg command is %T", first.Command)
+	}
+	authenticateToken, err := auth.CreateAuthenticateTokenFromChallengeToken([]byte(challengeResponse.SecurityBlob))
+	if err != nil {
+		t.Fatalf("CreateAuthenticateTokenFromChallengeToken() error = %v", err)
+	}
+
+	second := sendSessionSetupSigned(t, session.client, authenticateToken, first.Header.UID, true,
+		session.key, session.sequence)
+	if second.Header.Status != 0 {
+		t.Fatalf("the second session setup answered 0x%08X, want success", second.Header.Status)
+	}
+	secondUID := second.Header.UID
+	if secondUID == session.uid {
+		t.Fatalf("both sessions were assigned UID 0x%04X", uint16(secondUID))
+	}
+	session.sequence = signing.NextRequestSequenceNumber(session.sequence)
+
+	// The connection's key is untouched, so the first session carries on.
+	if !bytes.Equal(session.key, keyBefore) {
+		t.Fatal("the test's own key changed, which it must not")
+	}
+	echo = commands.NewEchoRequest()
+	echo.EchoCount = 1
+	echo.Data = []byte("after")
+	if response := sendOnSession(t, session, codes.SMB_COM_ECHO, echo); response.Header.Status != 0 {
+		t.Fatalf("the echo after the second logon answered 0x%08X, want success", response.Header.Status)
+	}
+
+	// And so does the second session, on the same key and sequence.
+	onSecond := &authSession{
+		client:   session.client,
+		uid:      secondUID,
+		key:      session.key,
+		signing:  true,
+		sequence: session.sequence,
+	}
+	echo = commands.NewEchoRequest()
+	echo.EchoCount = 1
+	echo.Data = []byte("second session")
+	if response := sendOnSession(t, onSecond, codes.SMB_COM_ECHO, echo); response.Header.Status != 0 {
+		t.Fatalf("an echo on the second session answered 0x%08X, want success", response.Header.Status)
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #1087`

### Root Cause
`Connection` carries one `SigningKey` and one `ExpectedRequestSequenceNumber`, and `handleFrame` verifies every request on the connection against them. Signing is therefore a property of the connection, shared by every session on it.

The arming block in `finishAuthentication` was written as though it were a property of the session being established. Its only condition was `armSigning`, which `signingDecision` returns for any session that can sign under the policy — including the second, third and every subsequent one. So a second logon re-ran the bootstrap: it replaced the key with the new session's and reset the sequence to two, while the client was far past that and still using the original key. The next request from any earlier session failed verification and the connection was dropped.

The `w.SignResponse` call in the same block compounded it. For a request arriving on an already-signing connection, `handleFrame` has already armed the writer with the connection's key and the response sequence matching the request it verified. Calling `SignResponse` again overwrote that with the new session's key at sequence one, so the second setup's own response was unverifiable by the client that sent it.

### Fix Description
Arm signing only when `!c.SigningActive` — that is, only for the first exchange on the connection that arms it. The bootstrap inside the block is unchanged, so a connection that is not yet signing behaves exactly as before.

On a connection that is already signing there is nothing left for this exchange to do, and in particular no `SignResponse` call: `handleFrame` verified the request against the connection's key and armed the response with the sequence that follows it, which is the correct signature for this response. A comment records that, because the absence of a call is otherwise the kind of thing a later reader adds back.

The narrower fix was chosen deliberately over enforcing "arm only on the very first session setup". The confirmed defect is re-keying a connection that is *already signing*; refusing to arm on a later session when the first one did not sign would change behaviour under `SigningEnabled` beyond the bug, and is a separate question.

### How Verified
- **Tests:** `TestSecondSessionKeepsTheConnectionSigning` establishes a signed session, exchanges an echo, performs a full two-leg session setup for a second account on the same connection with every request signed at the connection's key and sequence, then asserts that both the first and the second session still exchange signed echoes.
- **Runtime:** against the unpatched server the test fails at the first echo after the second logon with `failed to read Direct TCP header: EOF`, and the server log shows the cause directly — `signing armed ... on UID 0x0001`, `signing armed ... on UID 0x0002`, then `dropping connection: request failed signature verification at sequence 2`. Against the patched server the log shows a single `signing armed` line, both accounts authenticate, and no connection is dropped.
- **Regression:** `go build ./...`, `go vet ./...` and `go test ./...` are clean across the module. `TestSignedExchangeRoundTrips`, `TestUnsignedRequestOnSigningConnectionIsDropped`, `TestTamperedSignatureIsDropped`, `TestReplayedSequenceNumberIsDropped`, `TestGuestIsRefusedWhenSigningIsRequired` and `TestSeveralSessionsOnOneConnection` all continue to pass, so first-session arming and the refusal paths are unaffected.

### Test Coverage
**Added:** `network/smb/smb_v10/server/session_test.go` — `TestSecondSessionKeepsTheConnectionSigning`.

It asserts the second setup succeeds, that the two sessions get distinct UIDs, and that both work afterwards on the connection's original key and sequence. The existing `TestSeveralSessionsOnOneConnection` covers two sessions on one connection but runs under `SigningDisabled`, which is exactly why this defect was not caught.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/server/handler_session.go`, `network/smb/smb_v10/server/session_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
The change adds one condition to a block whose body is otherwise untouched. A connection establishing its first signing session takes the same path as before; the only behaviour that changes is on a connection that is already signing, where the previous behaviour was to drop it. Safe to merge without staged rollout.

### Notes
Live validation against a Windows client with two sessions on one connection is worth doing, since the interop history on this server has turned up wire-level differences that in-repo round-trips do not show. The behaviour this restores — one key and one sequence for the life of the connection — is what such a client expects.
