### PR TITLE
Fix unterminated SMB_FIND_FILE_NAMES_INFO listings (Fixes #1089)

### DIFF
--- a/network/smb/smb_v10/server/infolevels.go
+++ b/network/smb/smb_v10/server/infolevels.go
@@ -107,8 +107,14 @@ func encodeFindEntries(search *Search, count, budget int, unicode bool) ([]byte,
 	// The last entry's NextEntryOffset is zero, which is how a client knows to
 	// stop walking the buffer. Patching it afterwards is simpler than knowing in
 	// advance which entry will be last, since the budget decides that.
-	if returned > 0 && search.InformationLevel != smbFindFileNamesInfo {
-		zeroLastNextEntryOffset(encoded, search.InformationLevel)
+	//
+	// Every level served here chains this way, SMB_FIND_FILE_NAMES_INFO included:
+	// its entry is NextEntryOffset(4) FileIndex(4) FileNameLength(4) FileName, so
+	// it carries the field at the same place as the others and encodeFindEntry
+	// fills it in the same way. Excluding it left the final entry pointing at the
+	// end of the buffer, and a client walking the chain stepped past it.
+	if returned > 0 {
+		zeroLastNextEntryOffset(encoded)
 	}
 
 	return encoded, returned
@@ -116,7 +122,10 @@ func encodeFindEntries(search *Search, count, budget int, unicode bool) ([]byte,
 
 // zeroLastNextEntryOffset walks the encoded entries and clears the final
 // NextEntryOffset.
-func zeroLastNextEntryOffset(encoded []byte, level uint16) {
+//
+// The walk is the same for every level, since NextEntryOffset is the first field
+// of each of them.
+func zeroLastNextEntryOffset(encoded []byte) {
 	position := 0
 	for position+4 <= len(encoded) {
 		next := int(binary.LittleEndian.Uint32(encoded[position : position+4]))

--- a/network/smb/smb_v10/server/trans2_test.go
+++ b/network/smb/smb_v10/server/trans2_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"encoding/binary"
 	"strings"
 	"testing"
 
@@ -572,4 +573,62 @@ func pad4(value int) string {
 		value /= 10
 	}
 	return string(digits)
+}
+
+// TestFindEntryChainTerminates asserts that the last entry of a batch carries a
+// NextEntryOffset of zero at every level served, so a client walking the chain
+// stops inside the buffer.
+//
+// SMB_FIND_FILE_NAMES_INFO was excluded from the termination pass even though its
+// entry begins with NextEntryOffset like every other level, so its final entry
+// pointed at the end of the buffer and the walk ran off it. The repository's own
+// client reads the entry count rather than walking the chain, which is why the
+// round-trip tests did not show this.
+func TestFindEntryChainTerminates(t *testing.T) {
+	levels := map[string]uint16{
+		"SMB_FIND_FILE_NAMES_INFO":          smbFindFileNamesInfo,
+		"SMB_FIND_FILE_DIRECTORY_INFO":      smbFindFileDirectoryInfo,
+		"SMB_FIND_FILE_FULL_DIRECTORY_INFO": smbFindFileFullDirectoryInfo,
+		"SMB_FIND_FILE_BOTH_DIRECTORY_INFO": smbFindFileBothDirectoryInfo,
+	}
+
+	for name, level := range levels {
+		t.Run(name, func(t *testing.T) {
+			search := &Search{
+				InformationLevel: level,
+				Entries: []DirEntry{
+					{Attr: FileAttr{Name: "alpha.txt"}},
+					{Attr: FileAttr{Name: "beta.txt"}},
+					{Attr: FileAttr{Name: "gamma.txt"}},
+				},
+			}
+
+			encoded, returned := encodeFindEntries(search, 0, 0, true)
+			if returned != 3 {
+				t.Fatalf("encodeFindEntries() returned %d entries, want 3", returned)
+			}
+
+			// Walk the chain the way a client does: each entry says where the
+			// next one starts, and a zero offset ends the listing.
+			position, walked := 0, 0
+			for {
+				if position+4 > len(encoded) {
+					t.Fatalf("the chain left the %d-byte buffer at offset %d", len(encoded), position)
+				}
+				walked++
+				next := int(binary.LittleEndian.Uint32(encoded[position : position+4]))
+				if next == 0 {
+					break
+				}
+				if walked > returned {
+					t.Fatalf("the chain did not terminate after %d entries", returned)
+				}
+				position += next
+			}
+
+			if walked != returned {
+				t.Errorf("the chain holds %d entries, want %d", walked, returned)
+			}
+		})
+	}
 }


### PR DESCRIPTION
### Linked Issue
`Closes #1089`

### Root Cause
Each find level returns its entries as a chain: every entry begins with a `NextEntryOffset` giving the distance to the next one, and the last entry carries zero so the client knows to stop. `encodeFindEntry` builds every entry that way, and `encodeFindEntries` clears the final offset afterwards rather than trying to know in advance which entry the budget will make last.

That final pass was guarded on `search.InformationLevel != smbFindFileNamesInfo`, which treats `SMB_FIND_FILE_NAMES_INFO` as a level without the field. It is not: its entry is `NextEntryOffset(4) FileIndex(4) FileNameLength(4) FileName`, and the encoder writes the offset at L155 exactly as it does for the other three levels. So the last entry kept a non-zero offset pointing at the end of the buffer, and the chain never terminated.

### Fix Description
Remove the exclusion, so the termination pass runs for every level.

`zeroLastNextEntryOffset` loses its `level` parameter in the same change. The parameter was already unused — the walk only ever reads the offset at the head of each entry, which is in the same place at all four levels — and it existed to express a distinction this fix removes. Leaving it would suggest termination still depends on the level.

### How Verified
- **Tests:** `TestFindEntryChainTerminates` encodes a three-entry listing at each of the four levels and walks the chain the way a client does, asserting it terminates inside the buffer and holds exactly the number of entries the response reports. Confirmed to fail against the unpatched encoder at `SMB_FIND_FILE_NAMES_INFO` — "the chain left the 92-byte buffer at offset 92" — and to pass at all four levels against the patched one.
- **Regression:** `go build ./...`, `go vet ./...` and `go test ./...` are clean across the module. `TestDirectoryListing`, `TestDirectoryListingWithPattern`, `TestDirectoryListingInSubdirectory` and `TestDirectoryListingSpansSeveralBatches` continue to pass, so multi-batch enumeration and the other three levels are unaffected.

### Test Coverage
**Added:** `network/smb/smb_v10/server/trans2_test.go` — `TestFindEntryChainTerminates`, covering all four served levels rather than only the broken one, so the termination contract is pinned for each.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/server/infolevels.go`, `network/smb/smb_v10/server/trans2_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
The only bytes that change are the final `NextEntryOffset` of a `SMB_FIND_FILE_NAMES_INFO` batch, which previously pointed out of the buffer. The other three levels already took this path and are byte-identical. Safe to merge without staged rollout.

### Notes
The SMB1 client in this repository reads a listing using the entry count from the response parameters rather than by walking the chain, which is why the existing round-trip coverage over this level was green. The new test walks the chain deliberately, so it exercises what an external client does.
