### PR TITLE
Fix FIND_NEXT2 tree ownership check (Fixes #1091)

### DIFF
--- a/network/smb/smb_v10/server/handler_find.go
+++ b/network/smb/smb_v10/server/handler_find.go
@@ -198,8 +198,24 @@ func handleFindNext2(conn *Connection, req *message.Message, reassembly *transac
 		logger.Debugf("SMB1 server: %s continued search 0x%04X, which is not open", conn.Remote, sid)
 		return nil, nil, nt_status.NT_STATUS_INVALID_HANDLE
 	}
-	// The search belongs to the tree it was opened on.
-	if search.Tree.TID != uint16(req.Header.TID) {
+	// The search belongs to the tree it was opened on, and that tree is resolved
+	// the way every other command resolves one: through anyTreeFor, which is the
+	// single place the session that owns a TID is checked. Comparing the TID
+	// against the search's own recorded value instead skipped that check, so a
+	// second session on the connection could continue the first's enumeration.
+	//
+	// The comparison is against the tree object rather than its identifier. A
+	// search outlives a disconnect of the tree it was opened on, and the TID is
+	// released for reuse at that point, so a stale search's recorded TID can come
+	// to match a live tree on an entirely different share. Only the object
+	// identifies the tree the search was actually opened on.
+	tree, status := conn.anyTreeFor(req)
+	if status != nt_status.NT_STATUS_SUCCESS {
+		return nil, nil, status
+	}
+	if search.Tree != tree {
+		logger.Debugf("SMB1 server: %s continued search 0x%04X on TID 0x%04X, which does not hold it",
+			conn.Remote, sid, uint16(req.Header.TID))
 		return nil, nil, nt_status.NT_STATUS_INVALID_HANDLE
 	}
 	// A continuation that changed the shape would be describing a different

--- a/network/smb/smb_v10/server/trans2_test.go
+++ b/network/smb/smb_v10/server/trans2_test.go
@@ -1,11 +1,15 @@
 package server
 
 import (
+	"encoding/binary"
 	"strings"
 	"testing"
 
 	smb1client "github.com/TheManticoreProject/Manticore/network/smb/smb_v10/client"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/codes"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
 	"github.com/TheManticoreProject/Manticore/windows/fileflags"
+	"github.com/TheManticoreProject/Manticore/windows/nt_status"
 )
 
 // namesOf renders a listing's names, so a test asserts on names rather than on
@@ -572,4 +576,97 @@ func pad4(value int) string {
 		value /= 10
 	}
 	return string(digits)
+}
+
+// TestFindNextRefusesAForeignTree asserts a search can only be continued through
+// the tree it was opened on.
+//
+// FIND_NEXT2 compared the request's TID against the value the search had recorded,
+// which skipped anyTreeFor and with it the check that the session owning the TID
+// is the one making the request. It also compared identifiers rather than trees,
+// and a TID is released for reuse when its tree disconnects while the search is
+// not, so a stale search's TID could come to name a live tree on another share.
+func TestFindNextRefusesAForeignTree(t *testing.T) {
+	fs := NewMemoryFileSystem("FILES")
+	if err := fs.AddFile("entry.txt", []byte("x")); err != nil {
+		t.Fatalf("AddFile() error = %v", err)
+	}
+	srv, _ := fileServer(t, fs, false)
+
+	share := &Share{Name: "other", Type: ShareTypeDisk, FS: fs}
+	if err := srv.AddShare(share); err != nil {
+		t.Fatalf("AddShare() error = %v", err)
+	}
+
+	newConnection := func() *Connection {
+		return &Connection{
+			Server:   srv,
+			sessions: map[uint16]*Session{},
+			trees:    map[uint16]*Tree{},
+			tids:     newIdentifierAllocator(16),
+			opens:    map[uint16]*Open{},
+			fids:     newIdentifierAllocator(16),
+			searches: map[uint16]*Search{},
+			sids:     newIdentifierAllocator(16),
+		}
+	}
+
+	// A search opened on one tree, by the session that owns it.
+	conn := newConnection()
+	conn.addSession(&Session{UID: 1})
+	conn.addSession(&Session{UID: 2})
+
+	tid, err := conn.tids.Allocate()
+	if err != nil {
+		t.Fatalf("Allocate() error = %v", err)
+	}
+	tree := &Tree{TID: tid, Share: share, SessionUID: 1}
+	conn.addTree(tree)
+
+	sid, err := conn.sids.Allocate()
+	if err != nil {
+		t.Fatalf("Allocate() error = %v", err)
+	}
+	conn.searches[sid] = &Search{
+		SID:     sid,
+		Tree:    tree,
+		Entries: []DirEntry{{Attr: FileAttr{Name: "entry.txt"}}},
+	}
+
+	continueSearch := func(uid, tid uint16) nt_status.NT_STATUS {
+		t.Helper()
+		parameters := make([]byte, 12)
+		binary.LittleEndian.PutUint16(parameters[0:2], sid)
+		binary.LittleEndian.PutUint16(parameters[2:4], 10)
+		binary.LittleEndian.PutUint16(parameters[4:6], 0) // InformationLevel
+		request := newRequest(codes.SMB_COM_TRANSACTION2)
+		request.Header.UID = types.USHORT(uid)
+		request.Header.TID = types.USHORT(tid)
+		_, _, status := handleFindNext2(conn, request, &transactionReassembly{parameters: parameters})
+		return status
+	}
+
+	// The session that does not own the tree cannot continue the search, even
+	// though it names the right TID.
+	if status := continueSearch(2, tid); status == nt_status.NT_STATUS_SUCCESS {
+		t.Error("a session that does not own the tree continued its search")
+	}
+
+	// Disconnecting the tree frees the TID, and the next tree takes it. The stale
+	// search must not follow the identifier onto the new tree.
+	conn.removeTree(tid)
+	reused, err := conn.tids.Allocate()
+	if err != nil {
+		t.Fatalf("Allocate() error = %v", err)
+	}
+	if reused != tid {
+		t.Skipf("the allocator did not reuse TID 0x%04X, so the reuse case is not exercised", tid)
+	}
+	conn.addTree(&Tree{TID: reused, Share: share, SessionUID: 2})
+
+	if _, stillOpen := conn.searches[sid]; stillOpen {
+		if status := continueSearch(2, reused); status == nt_status.NT_STATUS_SUCCESS {
+			t.Error("a search continued through a TID that had been reallocated to another tree")
+		}
+	}
 }


### PR DESCRIPTION
### Linked Issue
`Closes #1091`

### Root Cause
`anyTreeFor` exists so that resolving a TID and checking the session that owns it happen in one place — as its comment says, "another session's identifier must not reach it, even on the same connection". Every tree-scoped command goes through it.

`handleFindNext2` did not. It resolved the tree by comparing `search.Tree.TID` against the request's TID, which reimplements half of `anyTreeFor` and omits the half that matters: `tree.SessionUID != req.Header.UID`. No session check ran on this path at all.

Comparing identifiers rather than trees introduced a second problem, because the lifetimes of a search and its tree do not coincide. `removeTree` releases the TID for reuse but leaves `Connection.searches` alone, so a search outlives its tree while still holding the old TID value. Once the allocator hands that TID to a new tree — possibly on a different share — the stale search's recorded identifier matches it, and the continuation is answered from the disconnected tree's snapshot.

### Fix Description
Resolve the tree through `anyTreeFor(req)` and compare `search.Tree != tree`.

Going through `anyTreeFor` restores the session-ownership check and brings this handler into line with every other tree-scoped command. Comparing the tree object rather than its identifier makes the check immune to TID reuse: a tree that has been disconnected is a different object from whatever now holds its old TID, so a stale search can never match.

`anyTreeFor` is used rather than `treeFor` because the latter additionally requires a disk share, which is a stronger condition than continuing a search needs and would change the status returned for a case this fix is not about.

The underlying lifetime question — that a search is not released when its tree is disconnected — is left alone here. This change makes such a search unusable, which is the correctness half; the resource half belongs with the rest of the search release rule and is not bundled in.

### How Verified
- **Tests:** `TestFindNextRefusesAForeignTree` covers both halves. It opens a search on a tree owned by UID 1 and asserts a `FIND_NEXT2` from UID 2 naming that TID is refused; it then disconnects the tree, confirms the allocator hands the same TID to a new tree, and asserts the surviving search cannot be continued through it. Confirmed to fail against the unpatched handler on both — "a session that does not own the tree continued its search" and "a search continued through a TID that had been reallocated to another tree" — and to pass against the patched one.
- **Regression:** `go build ./...`, `go vet ./...` and `go test ./...` are clean across the module. `TestDirectoryListingSpansSeveralBatches` exercises the continuation path across many batches and continues to pass, so ordinary enumeration by the owning session is unaffected.

### Test Coverage
**Added:** `network/smb/smb_v10/server/trans2_test.go` — `TestFindNextRefusesAForeignTree`.

The TID-reuse half skips rather than fails if the allocator does not return the same identifier, so the test cannot silently pass for the wrong reason on a different allocation strategy.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/server/handler_find.go`, `network/smb/smb_v10/server/trans2_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
A continuation from the session that owns the tree resolves the same tree object the search recorded and takes the same path as before. The requests whose treatment changes are those from another session, or through a reallocated TID, both of which were previously answered when they should not have been. `anyTreeFor` returns `STATUS_SMB_BAD_TID` where the old code returned `STATUS_INVALID_HANDLE` for a TID that names no tree, which is the status the rest of the server already uses for that condition. Safe to merge without staged rollout.
