### PR TITLE
Fix search handle release rule (Fixes #1093)

### DIFF
--- a/network/smb/smb_v10/server/handler_find.go
+++ b/network/smb/smb_v10/server/handler_find.go
@@ -152,9 +152,15 @@ func handleFindFirst2(conn *Connection, req *message.Message, reassembly *transa
 	data, returned := encodeFindEntries(search, searchCount, reassembly.maxDataCount, req.Header.Flags2.IsUnicode())
 	endOfSearch := search.exhausted()
 
-	// The search is kept only while there is more to hand out, and only if the
-	// client did not ask for it to be closed.
-	keep := !endOfSearch && flags&findClose == 0
+	// The search is kept unless the client asked for it to be closed: with
+	// findClose after this response, or with findCloseIfEndOfSearch once the
+	// enumeration has finished.
+	//
+	// Reaching the end is not itself a reason to drop it. A client that set
+	// neither flag is expected to release the handle with FIND_CLOSE2, and
+	// releasing it here made that call fail -- and made the identifier available
+	// for reuse while the client still believed it held one.
+	keep := flags&findClose == 0
 	if endOfSearch && flags&findCloseIfEndOfSearch != 0 {
 		keep = false
 	}

--- a/network/smb/smb_v10/server/trans2_test.go
+++ b/network/smb/smb_v10/server/trans2_test.go
@@ -1,11 +1,16 @@
 package server
 
 import (
+	"encoding/binary"
 	"strings"
 	"testing"
 
 	smb1client "github.com/TheManticoreProject/Manticore/network/smb/smb_v10/client"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/codes"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header/flags2"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
 	"github.com/TheManticoreProject/Manticore/windows/fileflags"
+	"github.com/TheManticoreProject/Manticore/windows/nt_status"
 )
 
 // namesOf renders a listing's names, so a test asserts on names rather than on
@@ -572,4 +577,154 @@ func pad4(value int) string {
 		value /= 10
 	}
 	return string(digits)
+}
+
+// TestSearchIsKeptUntilTheClientClosesIt asserts a search that has handed out
+// every entry stays open when the client asked for neither close flag, so the
+// FIND_CLOSE2 that client is expected to send resolves.
+//
+// Releasing it at end-of-search made FIND_CLOSE2 fail with STATUS_INVALID_HANDLE
+// and returned the identifier to the allocator while the client still believed it
+// held one. The SMB1 client in this repository sends Flags of zero and then calls
+// FIND_CLOSE2, which is exactly the case that was broken.
+func TestSearchIsKeptUntilTheClientClosesIt(t *testing.T) {
+	fs := NewMemoryFileSystem("FILES")
+	if err := fs.AddFile("only.txt", []byte("x")); err != nil {
+		t.Fatalf("AddFile() error = %v", err)
+	}
+	srv, _ := fileServer(t, fs, false)
+
+	conn, tid := searchFixture(t, srv, fs)
+
+	// A listing small enough to finish in one response, with no close flag set.
+	sid, status := openSearch(t, conn, tid, 0)
+	if status != nt_status.NT_STATUS_SUCCESS {
+		t.Fatalf("TRANS2_FIND_FIRST2 answered %s", statusName(status))
+	}
+	if conn.Search(sid) == nil {
+		t.Fatal("the search was released although the client asked for neither close flag")
+	}
+
+	// FIND_CLOSE2 is what releases it, and it succeeds.
+	if !conn.closeSearch(sid) {
+		t.Fatal("closeSearch() reported the handle was not open")
+	}
+	if conn.Search(sid) != nil {
+		t.Fatal("the search is still open after being closed")
+	}
+}
+
+// TestSearchIsReleasedWhenTheClientAsks asserts the two close flags still do what
+// they say, so keeping the search above did not cost the releases that were right.
+func TestSearchIsReleasedWhenTheClientAsks(t *testing.T) {
+	fs := NewMemoryFileSystem("FILES")
+	if err := fs.AddFile("only.txt", []byte("x")); err != nil {
+		t.Fatalf("AddFile() error = %v", err)
+	}
+	srv, _ := fileServer(t, fs, false)
+
+	for name, flags := range map[string]uint16{
+		"findClose":              findClose,
+		"findCloseIfEndOfSearch": findCloseIfEndOfSearch,
+	} {
+		t.Run(name, func(t *testing.T) {
+			conn, tid := searchFixture(t, srv, fs)
+			sid, status := openSearch(t, conn, tid, flags)
+			if status != nt_status.NT_STATUS_SUCCESS {
+				t.Fatalf("TRANS2_FIND_FIRST2 answered %s", statusName(status))
+			}
+			if conn.Search(sid) != nil {
+				t.Errorf("the search is still open although the client set %s", name)
+			}
+		})
+	}
+}
+
+// TestTreeDisconnectReleasesItsSearches asserts an enumeration is released with
+// the tree it was opened on, rather than holding its snapshot and its identifier
+// for the life of the connection.
+func TestTreeDisconnectReleasesItsSearches(t *testing.T) {
+	fs := NewMemoryFileSystem("FILES")
+	if err := fs.AddFile("only.txt", []byte("x")); err != nil {
+		t.Fatalf("AddFile() error = %v", err)
+	}
+	srv, _ := fileServer(t, fs, false)
+
+	conn, tid := searchFixture(t, srv, fs)
+	sid, status := openSearch(t, conn, tid, 0)
+	if status != nt_status.NT_STATUS_SUCCESS {
+		t.Fatalf("TRANS2_FIND_FIRST2 answered %s", statusName(status))
+	}
+	if conn.Search(sid) == nil {
+		t.Fatal("the search was not opened")
+	}
+
+	conn.removeTree(tid)
+
+	if conn.Search(sid) != nil {
+		t.Error("the search outlived the tree it was opened on")
+	}
+	// The identifier is back, so a long-lived connection that connects and
+	// disconnects trees does not exhaust the search space.
+	if reused, err := conn.sids.Allocate(); err != nil {
+		t.Errorf("the search identifier was not released: %v", err)
+	} else if reused != sid {
+		t.Errorf("Allocate() returned 0x%04X, want the released 0x%04X", reused, sid)
+	}
+}
+
+// searchFixture builds a connection with one session and one tree on the share
+// backed by fs, ready for a search to be opened on it.
+func searchFixture(t *testing.T, srv *Server, fs FileSystem) (*Connection, uint16) {
+	t.Helper()
+
+	conn := &Connection{
+		Server:   srv,
+		sessions: map[uint16]*Session{},
+		trees:    map[uint16]*Tree{},
+		tids:     newIdentifierAllocator(16),
+		opens:    map[uint16]*Open{},
+		fids:     newIdentifierAllocator(16),
+		searches: map[uint16]*Search{},
+		sids:     newIdentifierAllocator(16),
+	}
+	conn.addSession(&Session{UID: 1})
+
+	tid, err := conn.tids.Allocate()
+	if err != nil {
+		t.Fatalf("Allocate() error = %v", err)
+	}
+	conn.addTree(&Tree{
+		TID:        tid,
+		Share:      &Share{Name: "files", Type: ShareTypeDisk, FS: fs},
+		SessionUID: 1,
+	})
+	return conn, tid
+}
+
+// openSearch issues a TRANS2_FIND_FIRST2 for everything in the share root and
+// returns the identifier the response reports.
+func openSearch(t *testing.T, conn *Connection, tid, flags uint16) (uint16, nt_status.NT_STATUS) {
+	t.Helper()
+
+	// SearchAttributes(2) SearchCount(2) Flags(2) InformationLevel(2)
+	// SearchStorageType(4) FileName(variable).
+	pattern := encodeWireString("\\*", true)
+	parameters := make([]byte, 12, 12+len(pattern))
+	binary.LittleEndian.PutUint16(parameters[2:4], 100)
+	binary.LittleEndian.PutUint16(parameters[4:6], flags)
+	binary.LittleEndian.PutUint16(parameters[6:8], smbFindFileBothDirectoryInfo)
+	parameters = append(parameters, pattern...)
+
+	request := newRequest(codes.SMB_COM_TRANSACTION2)
+	request.Header.UID = types.USHORT(1)
+	request.Header.TID = types.USHORT(tid)
+	request.Header.Flags2 |= flags2.FLAGS2_UNICODE
+
+	responseParameters, _, status := handleFindFirst2(conn, request,
+		&transactionReassembly{parameters: parameters, maxDataCount: 0xFFFF})
+	if status != nt_status.NT_STATUS_SUCCESS {
+		return 0, status
+	}
+	return binary.LittleEndian.Uint16(responseParameters[0:2]), status
 }

--- a/network/smb/smb_v10/server/tree.go
+++ b/network/smb/smb_v10/server/tree.go
@@ -76,12 +76,12 @@ func (c *Connection) addTree(tree *Tree) {
 	c.trees[tree.TID] = tree
 }
 
-// removeTree drops a tree, closes every handle opened on it, and releases its
-// identifier.
+// removeTree drops a tree, closes every handle and enumeration opened on it, and
+// releases its identifier.
 //
-// Closing the handles matters: a client that disconnects a tree without closing
-// its files expects them released, and a handle left behind would hold the
-// backend's resources with nothing able to reach it.
+// Closing them matters: a client that disconnects a tree without closing its
+// files expects them released, and anything left behind would hold the backend's
+// resources with nothing able to reach it.
 func (c *Connection) removeTree(tid uint16) *Tree {
 	tree, ok := c.trees[tid]
 	if !ok {
@@ -91,6 +91,17 @@ func (c *Connection) removeTree(tid uint16) *Tree {
 	for fid, open := range c.opens {
 		if open.Tree == tree {
 			c.closeOpen(fid)
+		}
+	}
+
+	// The enumerations opened on the tree go with it, for the same reason its
+	// handles do: a search names a directory on this tree, so once the tree is
+	// gone there is nothing for it to continue against. Leaving them behind held
+	// their snapshots for the life of the connection and kept identifiers
+	// allocated that no client could still use.
+	for sid, search := range c.searches {
+		if search.Tree == tree {
+			c.closeSearch(sid)
 		}
 	}
 


### PR DESCRIPTION
### Linked Issue
`Closes #1093`

### Root Cause
When a search is released is the client's decision, expressed by two flags: `findClose` releases it after this response, and `findCloseIfEndOfSearch` releases it once the enumeration has finished. A client that sets neither keeps the handle and releases it with `FIND_CLOSE2`.

`keep` folded a third condition into that rule — `!endOfSearch` — which makes reaching the end sufficient to release on its own. That is the same condition `findCloseIfEndOfSearch` already expresses, so setting the flag or not made no difference, and a client that deliberately did not set it had its handle taken away anyway. Its subsequent `FIND_CLOSE2` was then refused with `STATUS_INVALID_HANDLE`, and the identifier had already gone back to the allocator to be handed to a different search.

`removeTree` had the opposite omission. It was written to release everything a tree holds, and accounts for open file handles, but enumerations were never added to it. A search holds a `*Tree` and a snapshot of a directory on it, so once the tree is gone nothing can reach it and nothing releases it until the connection closes.

Both are the same rule getting the lifetime wrong: released when the client had not asked, and not released when the thing it refers to had gone.

### Fix Description
`keep` becomes `flags&findClose == 0`, with the `findCloseIfEndOfSearch` case unchanged below it. Reaching the end no longer releases anything by itself, so both flags now mean what they say and a client that sets neither keeps its handle until it closes it.

`removeTree` gains a loop over `Connection.searches` releasing those opened on the tree, alongside the existing loop over `Connection.opens`. It goes through `closeSearch`, so the identifier is returned to the allocator rather than merely dropped from the map.

The two changes belong together. Keeping searches open for longer is only safe if they are released when their tree goes away — without the second half, the first would let a connection that repeatedly connects and disconnects trees accumulate unreachable searches until `MaxSearchesPerConnection` is exhausted and `FIND_FIRST2` starts failing with `STATUS_OS2_NO_MORE_SIDS` for the life of the connection.

### How Verified
- **Tests:** each half was confirmed to fail with only the other applied. Without the `handler_find.go` change, `TestSearchIsKeptUntilTheClientClosesIt` fails with "the search was released although the client asked for neither close flag". Without the `tree.go` change, `TestTreeDisconnectReleasesItsSearches` fails with "the search outlived the tree it was opened on" and the allocator returns 0x0002 instead of the released 0x0001.
- **Runtime:** `TestSearchHandleLifecycle` continues to pass unchanged. It asserts `Connection.searches` is empty after a full enumeration, and it now reaches that state through the client's own `FIND_CLOSE2` rather than through the early release — which is the interaction the fix restores.
- **Regression:** `go build ./...`, `go vet ./...` and `go test ./...` are clean across the module. `TestDirectoryListing`, `TestDirectoryListingWithPattern` and `TestDirectoryListingSpansSeveralBatches` continue to pass.

### Test Coverage
**Added:** all in `network/smb/smb_v10/server/trans2_test.go`.
- `TestSearchIsKeptUntilTheClientClosesIt` — a finished search with no close flag stays open, and `FIND_CLOSE2` releases it.
- `TestSearchIsReleasedWhenTheClientAsks` — both close flags still release, so keeping the search did not cost the releases that were correct.
- `TestTreeDisconnectReleasesItsSearches` — the search and its identifier go with the tree.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/server/handler_find.go`, `network/smb/smb_v10/server/tree.go`, `network/smb/smb_v10/server/trans2_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Searches now live longer in the common case, so the ceiling that matters is `MaxSessionsPerConnection`'s counterpart for searches, which is already enforced by the allocator and now has the tree-disconnect release feeding it. A client that sets a close flag, and a client that sends `FIND_CLOSE2`, both end in the same state as before. Safe to merge without staged rollout.

### Notes
`#1091` changes the same handler file in `handleFindNext2`; the two touch different functions and do not overlap. That fix is what makes a search surviving its tree unusable rather than merely unreachable — this one stops it surviving at all.
