### PR TITLE
Fix NTLM AUTHENTICATE bounds on 32-bit targets (Fixes #1095)

### DIFF
--- a/crypto/spnego/ntlm/message/authenticate/authenticate.go
+++ b/crypto/spnego/ntlm/message/authenticate/authenticate.go
@@ -484,14 +484,14 @@ const MICLength = 16
 // no payload and its offset is not meaningful, so it is skipped.
 //
 // It is only valid once the field descriptors have been read.
-func (msg *AuthenticateMessage) payloadStart() int {
-	start := 0
+func (msg *AuthenticateMessage) payloadStart() uint64 {
+	start := uint64(0)
 	consider := func(length uint16, offset uint32) {
 		if length == 0 {
 			return
 		}
-		if start == 0 || int(offset) < start {
-			start = int(offset)
+		if start == 0 || uint64(offset) < start {
+			start = uint64(offset)
 		}
 	}
 	consider(msg.LmChallengeResponseFields.Len, msg.LmChallengeResponseFields.BufferOffset)
@@ -619,57 +619,78 @@ func (msg *AuthenticateMessage) Unmarshal(data []byte) (int, error) {
 	// nothing to verify and a tampered MIC was indistinguishable from a correct
 	// one.
 	if payloadStart := msg.payloadStart(); payloadStart >= 80 {
-		micOffset := payloadStart - MICLength
-		if micOffset < 64 || payloadStart > len(data) {
+		if payloadStart > uint64(len(data)) {
 			return 0, fmt.Errorf("data too short to read MIC in AuthenticateMessage")
 		}
-		copy(msg.MIC[:], data[micOffset:payloadStart])
+		// payloadStart is at least 80, so the MIC begins at 64 or beyond and the
+		// subtraction cannot reach back into the fixed part.
+		micOffset := int(payloadStart) - MICLength
+		copy(msg.MIC[:], data[micOffset:int(payloadStart)])
 		msg.NeedsMIC = true
 		msg.MICOffset = micOffset
 	}
 
-	// Read payload section
+	// Read payload section.
+	//
+	// The bounds are computed in 64-bit. BufferOffset is a 32-bit field taken
+	// straight off the wire, and int is 32 bits on a 32-bit host -- which this
+	// builds and tests for -- so int(BufferOffset) turns a large offset into a
+	// negative index, which passes an upper-bound check and then panics in the
+	// slice expression. uint64 cannot overflow for a uint32 offset plus a uint16
+	// length and cannot go negative, whatever the width of int.
 
 	// LM response
-	if int(msg.LmChallengeResponseFields.BufferOffset)+int(msg.LmChallengeResponseFields.Len) > len(data) {
+	lmChallengeResponseStart := uint64(msg.LmChallengeResponseFields.BufferOffset)
+	lmChallengeResponseEnd := lmChallengeResponseStart + uint64(msg.LmChallengeResponseFields.Len)
+	if lmChallengeResponseEnd > uint64(len(data)) {
 		return 0, fmt.Errorf("data too short to read LmChallengeResponse in payload section in AuthenticateMessage")
 	}
-	msg.LmChallengeResponse = data[int(msg.LmChallengeResponseFields.BufferOffset) : int(msg.LmChallengeResponseFields.BufferOffset)+int(msg.LmChallengeResponseFields.Len)]
+	msg.LmChallengeResponse = data[lmChallengeResponseStart:lmChallengeResponseEnd]
 	totalBytesRead += int(msg.LmChallengeResponseFields.Len)
 
 	// NT response
-	if int(msg.NtChallengeResponseFields.BufferOffset)+int(msg.NtChallengeResponseFields.Len) > len(data) {
+	ntChallengeResponseStart := uint64(msg.NtChallengeResponseFields.BufferOffset)
+	ntChallengeResponseEnd := ntChallengeResponseStart + uint64(msg.NtChallengeResponseFields.Len)
+	if ntChallengeResponseEnd > uint64(len(data)) {
 		return 0, fmt.Errorf("data too short to read NtChallengeResponse in payload section in AuthenticateMessage")
 	}
-	msg.NtChallengeResponse = data[int(msg.NtChallengeResponseFields.BufferOffset) : int(msg.NtChallengeResponseFields.BufferOffset)+int(msg.NtChallengeResponseFields.Len)]
+	msg.NtChallengeResponse = data[ntChallengeResponseStart:ntChallengeResponseEnd]
 	totalBytesRead += int(msg.NtChallengeResponseFields.Len)
 
 	// Domain name
-	if int(msg.DomainNameFields.BufferOffset)+int(msg.DomainNameFields.Len) > len(data) {
+	domainNameStart := uint64(msg.DomainNameFields.BufferOffset)
+	domainNameEnd := domainNameStart + uint64(msg.DomainNameFields.Len)
+	if domainNameEnd > uint64(len(data)) {
 		return 0, fmt.Errorf("data too short to read DomainName in payload section in AuthenticateMessage")
 	}
-	msg.DomainName = data[int(msg.DomainNameFields.BufferOffset) : int(msg.DomainNameFields.BufferOffset)+int(msg.DomainNameFields.Len)]
+	msg.DomainName = data[domainNameStart:domainNameEnd]
 	totalBytesRead += int(msg.DomainNameFields.Len)
 
 	// User name
-	if int(msg.UserNameFields.BufferOffset)+int(msg.UserNameFields.Len) > len(data) {
+	userNameStart := uint64(msg.UserNameFields.BufferOffset)
+	userNameEnd := userNameStart + uint64(msg.UserNameFields.Len)
+	if userNameEnd > uint64(len(data)) {
 		return 0, fmt.Errorf("data too short to read UserName in payload section in AuthenticateMessage")
 	}
-	msg.UserName = data[int(msg.UserNameFields.BufferOffset) : int(msg.UserNameFields.BufferOffset)+int(msg.UserNameFields.Len)]
+	msg.UserName = data[userNameStart:userNameEnd]
 	totalBytesRead += int(msg.UserNameFields.Len)
 
 	// Workstation
-	if int(msg.WorkstationFields.BufferOffset)+int(msg.WorkstationFields.Len) > len(data) {
+	workstationStart := uint64(msg.WorkstationFields.BufferOffset)
+	workstationEnd := workstationStart + uint64(msg.WorkstationFields.Len)
+	if workstationEnd > uint64(len(data)) {
 		return 0, fmt.Errorf("data too short to read Workstation in payload section in AuthenticateMessage")
 	}
-	msg.Workstation = data[int(msg.WorkstationFields.BufferOffset) : int(msg.WorkstationFields.BufferOffset)+int(msg.WorkstationFields.Len)]
+	msg.Workstation = data[workstationStart:workstationEnd]
 	totalBytesRead += int(msg.WorkstationFields.Len)
 
 	// Encrypted random session key
-	if int(msg.EncryptedRandomSessionKeyFields.BufferOffset)+int(msg.EncryptedRandomSessionKeyFields.Len) > len(data) {
+	encryptedRandomSessionKeyStart := uint64(msg.EncryptedRandomSessionKeyFields.BufferOffset)
+	encryptedRandomSessionKeyEnd := encryptedRandomSessionKeyStart + uint64(msg.EncryptedRandomSessionKeyFields.Len)
+	if encryptedRandomSessionKeyEnd > uint64(len(data)) {
 		return 0, fmt.Errorf("data too short to read EncryptedRandomSessionKey in payload section in AuthenticateMessage")
 	}
-	msg.EncryptedRandomSessionKey = data[int(msg.EncryptedRandomSessionKeyFields.BufferOffset) : int(msg.EncryptedRandomSessionKeyFields.BufferOffset)+int(msg.EncryptedRandomSessionKeyFields.Len)]
+	msg.EncryptedRandomSessionKey = data[encryptedRandomSessionKeyStart:encryptedRandomSessionKeyEnd]
 	totalBytesRead += int(msg.EncryptedRandomSessionKeyFields.Len)
 
 	return totalBytesRead, nil

--- a/crypto/spnego/ntlm/message/authenticate/authenticate_test.go
+++ b/crypto/spnego/ntlm/message/authenticate/authenticate_test.go
@@ -2,6 +2,7 @@ package authenticate_test
 
 import (
 	"bytes"
+	"encoding/binary"
 	"testing"
 
 	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/message/authenticate"
@@ -130,5 +131,50 @@ func TestMarshalUnmarshal(t *testing.T) {
 		t.Error("EncryptedRandomSessionKeyFields mismatch")
 		t.Errorf("Expected : %v", authMsg.EncryptedRandomSessionKeyFields)
 		t.Errorf("Actual   : %v", unmarshaledMsg.EncryptedRandomSessionKeyFields)
+	}
+}
+
+// TestAuthenticateMessagePayloadOffsetOverflow asserts that a payload
+// BufferOffset near the top of the 32-bit range is refused rather than becoming a
+// negative index that passes the bounds check and panics in the slice expression.
+//
+// The check was written as int(BufferOffset)+int(Len) > len(data). int is 64 bits
+// on the hosts this is usually run on, where that is correct; it is 32 bits on the
+// 386 targets this project also builds and tests, where int(0xFFFFFFFF) is -1 and
+// the comparison passes for an offset nowhere near the buffer.
+func TestAuthenticateMessagePayloadOffsetOverflow(t *testing.T) {
+	// The fixed part of an AUTHENTICATE is 88 bytes at minimum: signature and
+	// type (12), six field descriptors (48), NegotiateFlags (4), Version (8).
+	// Each subtest sets one descriptor's Len and drives its offset to the top of
+	// the range, leaving the others empty so only the field under test is read.
+	descriptors := map[string]int{
+		"LmChallengeResponse":       12,
+		"NtChallengeResponse":       20,
+		"DomainName":                28,
+		"UserName":                  36,
+		"Workstation":               44,
+		"EncryptedRandomSessionKey": 52,
+	}
+
+	for name, at := range descriptors {
+		t.Run(name, func(t *testing.T) {
+			message := make([]byte, 96)
+			copy(message, []byte{'N', 'T', 'L', 'M', 'S', 'S', 'P', 0})
+			binary.LittleEndian.PutUint32(message[8:12], 3)
+			binary.LittleEndian.PutUint16(message[at:at+2], 8)   // Len
+			binary.LittleEndian.PutUint16(message[at+2:at+4], 8) // MaxLen
+			binary.LittleEndian.PutUint32(message[at+4:at+8], 0xFFFFFFFF)
+
+			defer func() {
+				if recovered := recover(); recovered != nil {
+					t.Fatalf("Unmarshal() panicked instead of returning an error: %v", recovered)
+				}
+			}()
+
+			parsed := &authenticate.AuthenticateMessage{}
+			if _, err := parsed.Unmarshal(message); err == nil {
+				t.Error("Unmarshal() accepted a payload offset outside the message")
+			}
+		})
 	}
 }


### PR DESCRIPTION
### Linked Issue
`Closes #1095`

### Root Cause
`BufferOffset` is a `uint32` read straight off the wire and `Len` a `uint16`. The payload checks added them as `int`, whose width is platform-dependent: 64 bits on amd64, where the sum is exact and the guard is correct, and 32 bits on 386, where `int(uint32(0xFFFFFFFF))` is -1. The comparison is upper-bound only, so a negative start satisfies it, and the slice expression that follows panics.

`payloadStart()` made the same conversion. It returned -1 for such an offset, which is below the `>= 80` gate for the MIC, so the MIC block was skipped and control reached the payload blocks rather than being stopped earlier.

This is the same defect as #1081 in a different disguise. There the arithmetic was `uint32`, which wraps on every architecture; here it is `int`, which is only wrong where `int` is 32 bits. That is why `authenticate.go` looked correct when #1081 was fixed and was deferred at the time — it was correct on the architecture it was tested on.

### Fix Description
Compute each payload's start and end as `uint64` locals and compare the end against `uint64(len(data))`. A `uint32` offset plus a `uint16` length cannot overflow 64 bits and cannot go negative, so the guard holds regardless of host word size. This is the form already applied to `challenge.go` and `negotiate.go`, so all three parsers now check bounds the same way.

`payloadStart()` returns `uint64` for the same reason. Its single caller compares against `uint64(len(data))` before narrowing, and the `micOffset < 64` arm is dropped as redundant: the enclosing `payloadStart >= 80` already guarantees `payloadStart - MICLength >= 64`, which the old arm re-checked.

### How Verified
- **Tests:** `TestAuthenticateMessagePayloadOffsetOverflow` drives each of the six payload descriptors to `BufferOffset = 0xFFFFFFFF` in turn. Against the unpatched parser it fails on `GOARCH=386` for all six with `panic: runtime error: slice bounds out of range [-1:]`, and passes on amd64 — reproducing the platform dependence exactly. Against the patched parser it passes on both.
- **Runtime:** `go build ./...` succeeds under `GOARCH=386` as well as natively.
- **Regression:** `go build ./...`, `go vet ./...` and `go test ./...` are clean on amd64, and `go test ./crypto/... ./network/smb/...` is clean under `GOARCH=386`. The existing round-trip and MIC coverage in `authenticate_test.go` continues to pass, so well-formed messages, including those carrying a MIC, are unaffected.

### Test Coverage
**Added:** `crypto/spnego/ntlm/message/authenticate/authenticate_test.go` — `TestAuthenticateMessagePayloadOffsetOverflow`, one subtest per payload descriptor.

The test is architecture-independent: it asserts the message is rejected without panicking, which was already true on amd64 and is now true on 386. Its value is as a guard on the 386 CI leg, which is where it fails without this change.

### Scope of Change
- **Files changed:** `crypto/spnego/ntlm/message/authenticate/authenticate.go`, `crypto/spnego/ntlm/message/authenticate/authenticate_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
On 64-bit hosts the arithmetic was already exact, so every message parses to the same values and the change is a no-op in behaviour there. On 32-bit hosts the inputs whose treatment changes are exactly those that previously panicked. Safe to merge without staged rollout.

### Notes
Found while confirming that the CI matrix covers 386, after #1081 deferred this file on the grounds that its `int` arithmetic was safe. It is safe on amd64 and not on 386, and the workflow at `.github/workflows/unit_tests.yaml` builds both — so the deferral was wrong and this closes the family.
