### PR TITLE
Fix transaction completion counting overlapping fragments (Fixes #1097)

### DIFF
--- a/network/smb/smb_v10/server/handler_trans2.go
+++ b/network/smb/smb_v10/server/handler_trans2.go
@@ -64,10 +64,11 @@ type transactionReassembly struct {
 	parameters []byte
 	data       []byte
 
-	// parametersSeen and dataSeen count the bytes placed so far, so completion is
-	// known without scanning for gaps.
-	parametersSeen int
-	dataSeen       int
+	// parametersSeen and dataSeen record which parts of each block have arrived,
+	// so completion means every byte was written rather than merely that enough
+	// bytes were sent.
+	parametersSeen coverage
+	dataSeen       coverage
 
 	// maxParameterCount and maxDataCount are what the client said it can receive
 	// back, which bounds the response.
@@ -87,7 +88,69 @@ type transactionReassembly struct {
 
 // complete reports whether every declared byte has arrived.
 func (r *transactionReassembly) complete() bool {
-	return r.parametersSeen >= len(r.parameters) && r.dataSeen >= len(r.data)
+	return r.parametersSeen.covers(len(r.parameters)) && r.dataSeen.covers(len(r.data))
+}
+
+// coverage records which parts of a block have been written, as a sorted list of
+// disjoint half-open ranges.
+//
+// Counting bytes instead is not enough. A client may send its fragments at any
+// displacement it likes, so the same run can arrive twice: a counter reaches the
+// declared total while part of the block was never written, and the transaction
+// then runs against a buffer whose gaps are still zero. Recording what arrived
+// rather than how much makes a hole impossible to miss.
+//
+// A transaction carries few fragments, so the list stays short and a linear merge
+// is the right shape for it.
+type coverage struct {
+	ranges []span
+}
+
+// span is a half-open range of a block, [start, end).
+type span struct {
+	start int
+	end   int
+}
+
+// add records that [start, start+length) has been written, merging the range into
+// any it meets or overlaps.
+func (c *coverage) add(start, length int) {
+	if length <= 0 {
+		return
+	}
+	added := span{start: start, end: start + length}
+
+	merged := make([]span, 0, len(c.ranges)+1)
+	for _, existing := range c.ranges {
+		switch {
+		case existing.end < added.start:
+			// Entirely before the new range, and cannot touch what follows.
+			merged = append(merged, existing)
+		case existing.start > added.end:
+			// Entirely after it. Everything from here on is too, so the new
+			// range is settled and the rest is copied below.
+			merged = append(merged, added)
+			added = existing
+		default:
+			// They meet or overlap, so they become one.
+			if existing.start < added.start {
+				added.start = existing.start
+			}
+			if existing.end > added.end {
+				added.end = existing.end
+			}
+		}
+	}
+	c.ranges = append(merged, added)
+}
+
+// covers reports whether every byte of a block of the given total length has been
+// written. A block of no bytes is covered by definition.
+func (c *coverage) covers(total int) bool {
+	if total == 0 {
+		return true
+	}
+	return len(c.ranges) == 1 && c.ranges[0].start <= 0 && c.ranges[0].end >= total
 }
 
 // place copies a fragment into the blocks at its declared displacement.
@@ -106,8 +169,8 @@ func (r *transactionReassembly) place(
 	if err := placeFragment(r.data, data, dataDisplacement, "data"); err != nil {
 		return err
 	}
-	r.parametersSeen += len(parameters)
-	r.dataSeen += len(data)
+	r.parametersSeen.add(parameterDisplacement, len(parameters))
+	r.dataSeen.add(dataDisplacement, len(data))
 	return nil
 }
 

--- a/network/smb/smb_v10/server/trans2_test.go
+++ b/network/smb/smb_v10/server/trans2_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 
@@ -572,4 +573,110 @@ func pad4(value int) string {
 		value /= 10
 	}
 	return string(digits)
+}
+
+// TestTransactionCoverageTracksRanges covers the range bookkeeping directly,
+// including the arrival orders a byte counter cannot tell apart.
+func TestTransactionCoverageTracksRanges(t *testing.T) {
+	tests := []struct {
+		name     string
+		total    int
+		fragment []span
+		covered  bool
+	}{
+		{name: "empty block", total: 0, covered: true},
+		{name: "one whole run", total: 40, fragment: []span{{0, 40}}, covered: true},
+		{name: "two runs in order", total: 40, fragment: []span{{0, 20}, {20, 40}}, covered: true},
+		{name: "two runs reversed", total: 40, fragment: []span{{20, 40}, {0, 20}}, covered: true},
+		{name: "three runs shuffled", total: 60, fragment: []span{{40, 60}, {0, 20}, {20, 40}}, covered: true},
+		{name: "overlapping runs", total: 40, fragment: []span{{0, 25}, {15, 40}}, covered: true},
+		{name: "run repeated", total: 40, fragment: []span{{0, 10}, {0, 10}, {0, 10}, {0, 10}}, covered: false},
+		{name: "hole in the middle", total: 40, fragment: []span{{0, 10}, {30, 40}}, covered: false},
+		{name: "short of the end", total: 40, fragment: []span{{0, 39}}, covered: false},
+		{name: "starts late", total: 40, fragment: []span{{1, 40}}, covered: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var tracked coverage
+			for _, run := range test.fragment {
+				tracked.add(run.start, run.end-run.start)
+			}
+			if covered := tracked.covers(test.total); covered != test.covered {
+				t.Errorf("covers(%d) = %t, want %t (ranges %v)", test.total, covered, test.covered, tracked.ranges)
+			}
+		})
+	}
+}
+
+// TestTransactionIsNotCompletedByRepeatedFragments asserts a transaction is
+// completed by every byte arriving, not by enough bytes arriving.
+//
+// Reassembly counted the bytes placed, so a client could re-send one fragment
+// until the counter reached the declared total. The transaction then ran against
+// a buffer most of which had never been written, with the gaps left as zeroes.
+func TestTransactionIsNotCompletedByRepeatedFragments(t *testing.T) {
+	reassembly := &transactionReassembly{
+		family:     "TRANSACTION2",
+		parameters: make([]byte, 0),
+		data:       make([]byte, 40),
+	}
+
+	fragment := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+	for i := 0; i < 4; i++ {
+		if err := reassembly.place(nil, 0, fragment, 0); err != nil {
+			t.Fatalf("place() on copy %d error = %v", i, err)
+		}
+		if reassembly.complete() {
+			t.Fatalf("the transaction reported complete after %d copies of one fragment", i+1)
+		}
+	}
+
+	// The rest of the block still has to arrive, and then it is complete.
+	if err := reassembly.place(nil, 0, make([]byte, 30), 10); err != nil {
+		t.Fatalf("place() of the remainder error = %v", err)
+	}
+	if !reassembly.complete() {
+		t.Error("the transaction is not complete although every byte has arrived")
+	}
+}
+
+// TestTransactionCompletesOutOfOrder asserts fragments that arrive at
+// displacements out of order still complete the transaction, since the
+// displacement is what says where they belong.
+func TestTransactionCompletesOutOfOrder(t *testing.T) {
+	reassembly := &transactionReassembly{
+		family:     "TRANSACTION2",
+		parameters: make([]byte, 8),
+		data:       make([]byte, 30),
+	}
+
+	if err := reassembly.place([]byte{5, 6, 7, 8}, 4, []byte{3, 3, 3, 3, 3, 3, 3, 3, 3, 3}, 20); err != nil {
+		t.Fatalf("place() of the tail error = %v", err)
+	}
+	if reassembly.complete() {
+		t.Fatal("the transaction is complete although the head has not arrived")
+	}
+	if err := reassembly.place([]byte{1, 2, 3, 4}, 0, []byte{2, 2, 2, 2, 2, 2, 2, 2, 2, 2}, 10); err != nil {
+		t.Fatalf("place() of the middle error = %v", err)
+	}
+	if reassembly.complete() {
+		t.Fatal("the transaction is complete although the first data run has not arrived")
+	}
+	if err := reassembly.place(nil, 0, []byte{1, 1, 1, 1, 1, 1, 1, 1, 1, 1}, 0); err != nil {
+		t.Fatalf("place() of the head error = %v", err)
+	}
+	if !reassembly.complete() {
+		t.Fatal("the transaction is not complete although every byte has arrived")
+	}
+
+	if !bytes.Equal(reassembly.parameters, []byte{1, 2, 3, 4, 5, 6, 7, 8}) {
+		t.Errorf("parameters = %v", reassembly.parameters)
+	}
+	for index, value := range reassembly.data {
+		want := byte(index/10 + 1)
+		if value != want {
+			t.Fatalf("data[%d] = %d, want %d", index, value, want)
+		}
+	}
 }


### PR DESCRIPTION
### Linked Issue
`Closes #1097`

### Root Cause
A transaction's parameter and data blocks are sized from the totals the primary message declares, and secondary messages fill them in at whatever displacement each one names. `placeFragment` checks that a run lands inside its block, which is why nothing was ever written out of bounds.

What was missing is the other half: knowing that the block was *filled*. Completion was tracked as `parametersSeen += len(parameters)`, a running count in which the displacement plays no part. Two different fragment sequences that send the same number of bytes are indistinguishable to it — one that tiles the block, and one that writes the same ten bytes four times. The comment on the fields stated the assumption plainly, that completion could be "known without scanning for gaps", and that holds only if fragments never overlap. Nothing in the protocol or the code requires that.

So a client could re-send one run until the counter reached the declared total and have the transaction dispatched against a buffer that was still mostly zeroes. Skipping a range instead of repeating one produced the same result.

### Fix Description
Replace the two counters with a `coverage` value per block, recording which parts have arrived as a sorted list of disjoint half-open ranges. `add` merges a new run into any range it meets or overlaps; `covers` reports completion only when a single range spans the whole block from zero.

`complete()` becomes `parametersSeen.covers(len(r.parameters)) && dataSeen.covers(len(r.data))`, so a hole anywhere keeps the transaction open rather than dispatching it.

Fragments may still arrive at any displacement and in any order, which is what the protocol allows and what the existing `TestTransaction2FragmentPlacement` covers. The alternative considered and rejected was to require each fragment to continue where the last left off, which would have made the accounting trivial but refused out-of-order delivery the protocol permits.

A transaction carries few fragments, so the list stays short and a linear merge is the right shape. The memory is proportional to the number of distinct runs, not to the block size, so nothing scales with the 1 MB NT_TRANSACT ceiling.

### How Verified
- **Tests:** `TestTransactionCoverageTracksRanges` drives the range bookkeeping through ten cases, including in-order, reversed, shuffled and overlapping arrivals, a repeated run, a hole in the middle, a block one byte short, and one that starts late. `TestTransactionIsNotCompletedByRepeatedFragments` reproduces the reported case and then confirms the transaction does complete once the remaining 30 bytes arrive. `TestTransactionCompletesOutOfOrder` sends three fragments back to front across both blocks and asserts both the completion point and the assembled bytes.
- **Runtime:** the old behaviour was confirmed against the unpatched reassembly — four copies of one 10-byte fragment reported complete with "30 of 40 bytes never written".
- **Fuzzing:** `FuzzServerFrame` ran 3.5M executions over the patched server with no failures, which exercises the reassembly through the real frame path.
- **Regression:** `go build ./...`, `go vet ./...` and `go test ./...` are clean across the module. `TestTransaction2FragmentPlacement`, which covers in-order and out-of-order assembly and the four inconsistent-fragment refusals, continues to pass unchanged.

### Test Coverage
**Added:** all in `network/smb/smb_v10/server/trans2_test.go` — `TestTransactionCoverageTracksRanges`, `TestTransactionIsNotCompletedByRepeatedFragments`, `TestTransactionCompletesOutOfOrder`.

The first tests `coverage` directly because the merge is the part with edge cases; the other two test it through `transactionReassembly`, so the wiring is covered as well as the bookkeeping.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/server/handler_trans2.go`, `network/smb/smb_v10/server/trans2_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
A client whose fragments tile its blocks — every real one — reaches completion at exactly the same message as before. What changes is that a sequence leaving a hole no longer completes: such a transaction now stays open until the missing bytes arrive, and is discarded by the existing 30-second reassembly timeout if they never do. That is the intended outcome, and it replaces dispatching a half-written buffer. Safe to merge without staged rollout.
