### PR TITLE
Fix delete and rename following symbolic links (Fixes #1099)

### DIFF
--- a/network/smb/smb_v10/server/file_service_test.go
+++ b/network/smb/smb_v10/server/file_service_test.go
@@ -560,7 +560,9 @@ func TestLocalFileSystemContainsSymlinkEscape(t *testing.T) {
 		t.Fatalf("the file inside the share is not reachable: %v", err)
 	}
 
-	// Neither link is, however it is approached.
+	// Nothing outside the share can be reached through either link. Stat and Open
+	// resolve the path they are given, so a link leading out of the share is
+	// refused however it is approached.
 	escapes := []string{"link.txt", "linkdir/secret.txt", "linkdir"}
 	for _, path := range escapes {
 		path := path
@@ -572,10 +574,28 @@ func TestLocalFileSystemContainsSymlinkEscape(t *testing.T) {
 				file.Close()
 				t.Errorf("Open(%q) succeeded through a link out of the share", path)
 			}
-			if err := fs.Remove(path); err == nil {
-				t.Errorf("Remove(%q) succeeded through a link out of the share", path)
-			}
 		})
+	}
+
+	// Reaching *through* a link, to something the share does not contain, stays
+	// refused: the parent is resolved and checked against the root.
+	if err := fs.Remove("linkdir/secret.txt"); err == nil {
+		t.Error(`Remove("linkdir/secret.txt") reached through a link out of the share`)
+	}
+
+	// Deleting the link itself is a different question, and is allowed. The link
+	// is an entry of this share and unlinking it removes only that entry -- the
+	// assertion below confirms what it pointed at is untouched. Refusing it would
+	// leave an entry a client can list and can never remove.
+	//
+	// This is deliberately not the same rule as for Stat and Open above. Those
+	// act on what a path leads to, so a path leading out must be refused; a
+	// delete acts on the name, which is inside the share either way.
+	if err := fs.Remove("link.txt"); err != nil {
+		t.Errorf(`Remove("link.txt") did not remove the link itself: %v`, err)
+	}
+	if _, err := os.Lstat(filepath.Join(root, "link.txt")); err == nil {
+		t.Error("the link is still present after being removed")
 	}
 
 	// The outside file is untouched.
@@ -731,4 +751,124 @@ func TestMemoryFileSystemDirectly(t *testing.T) {
 	if err := fs.Rmdir("a"); err == nil {
 		t.Fatal("Rmdir() removed a non-empty directory")
 	}
+}
+
+// TestLocalFileSystemNameOperationsDoNotFollowSymlinks asserts that deleting or
+// renaming a symbolic link acts on the link, not on what it points at.
+//
+// hostPath resolves a path through its symbolic links, which is right for
+// reading and writing contents and wrong for the operations that act on a name:
+// a delete unlinked the target and left the link behind, and a rename moved the
+// target out from under it.
+func TestLocalFileSystemNameOperationsDoNotFollowSymlinks(t *testing.T) {
+	// newShare builds a share holding a file, a directory, and a symbolic link to
+	// each.
+	newShare := func(t *testing.T) (*LocalFileSystem, string) {
+		t.Helper()
+		root := t.TempDir()
+		if err := os.WriteFile(filepath.Join(root, "target.txt"), []byte("data"), 0o644); err != nil {
+			t.Fatalf("WriteFile() error = %v", err)
+		}
+		if err := os.Mkdir(filepath.Join(root, "targetdir"), 0o750); err != nil {
+			t.Fatalf("Mkdir() error = %v", err)
+		}
+		if err := os.Symlink(filepath.Join(root, "target.txt"), filepath.Join(root, "link.txt")); err != nil {
+			t.Skipf("symbolic links are unavailable here: %v", err)
+		}
+		if err := os.Symlink(filepath.Join(root, "targetdir"), filepath.Join(root, "linkdir")); err != nil {
+			t.Skipf("symbolic links are unavailable here: %v", err)
+		}
+		fs, err := NewLocalFileSystem(root, "LOCAL")
+		if err != nil {
+			t.Fatalf("NewLocalFileSystem() error = %v", err)
+		}
+		return fs, root
+	}
+
+	exists := func(t *testing.T, path string) bool {
+		t.Helper()
+		_, err := os.Lstat(path)
+		return err == nil
+	}
+
+	t.Run("Remove unlinks the link", func(t *testing.T) {
+		fs, root := newShare(t)
+		if err := fs.Remove("link.txt"); err != nil {
+			t.Fatalf("Remove() error = %v", err)
+		}
+		if !exists(t, filepath.Join(root, "target.txt")) {
+			t.Error("deleting the link deleted its target")
+		}
+		if exists(t, filepath.Join(root, "link.txt")) {
+			t.Error("the link still exists after being deleted")
+		}
+	})
+
+	t.Run("Rmdir refuses a link to a directory", func(t *testing.T) {
+		fs, root := newShare(t)
+		if err := fs.Rmdir("linkdir"); err == nil {
+			t.Error("Rmdir() removed a directory through a symbolic link")
+		}
+		if !exists(t, filepath.Join(root, "targetdir")) {
+			t.Error("Rmdir() through the link removed the directory it points at")
+		}
+	})
+
+	t.Run("Rename moves the link", func(t *testing.T) {
+		fs, root := newShare(t)
+		if err := fs.Rename("link.txt", "moved.txt", false); err != nil {
+			t.Fatalf("Rename() error = %v", err)
+		}
+		if !exists(t, filepath.Join(root, "target.txt")) {
+			t.Error("renaming the link moved its target away")
+		}
+		if exists(t, filepath.Join(root, "link.txt")) {
+			t.Error("the link is still at its old name")
+		}
+		info, err := os.Lstat(filepath.Join(root, "moved.txt"))
+		if err != nil {
+			t.Fatalf("the link is not at its new name: %v", err)
+		}
+		if info.Mode()&os.ModeSymlink == 0 {
+			t.Error("what arrived at the new name is not a symbolic link")
+		}
+	})
+
+	// The ordinary cases still work, and containment still holds.
+	t.Run("a real file is still removed", func(t *testing.T) {
+		fs, root := newShare(t)
+		if err := fs.Remove("target.txt"); err != nil {
+			t.Fatalf("Remove() error = %v", err)
+		}
+		if exists(t, filepath.Join(root, "target.txt")) {
+			t.Error("the file was not removed")
+		}
+	})
+
+	t.Run("a real directory is still removed", func(t *testing.T) {
+		fs, root := newShare(t)
+		if err := fs.Rmdir("targetdir"); err != nil {
+			t.Fatalf("Rmdir() error = %v", err)
+		}
+		if exists(t, filepath.Join(root, "targetdir")) {
+			t.Error("the directory was not removed")
+		}
+	})
+
+	t.Run("a delete through a link out of the share is refused", func(t *testing.T) {
+		fs, root := newShare(t)
+		outside := t.TempDir()
+		if err := os.WriteFile(filepath.Join(outside, "secret.txt"), []byte("secret"), 0o644); err != nil {
+			t.Fatalf("WriteFile() error = %v", err)
+		}
+		if err := os.Symlink(outside, filepath.Join(root, "escape")); err != nil {
+			t.Skipf("symbolic links are unavailable here: %v", err)
+		}
+		if err := fs.Remove("escape/secret.txt"); err == nil {
+			t.Error("Remove() reached through a link pointing out of the share")
+		}
+		if !exists(t, filepath.Join(outside, "secret.txt")) {
+			t.Error("a file outside the share was deleted")
+		}
+	})
 }

--- a/network/smb/smb_v10/server/fs_local.go
+++ b/network/smb/smb_v10/server/fs_local.go
@@ -119,6 +119,39 @@ func (fs *LocalFileSystem) hostPath(path string) (string, error) {
 	return resolved, nil
 }
 
+// hostPathNoFollow maps a resolved share-relative path to a host path without
+// resolving a symbolic link in its final element.
+//
+// The operations that act on a name rather than on contents -- deleting and
+// renaming -- must act on the name the client gave. Resolving its final element
+// makes them act on whatever it points at instead: a delete unlinks the target
+// and leaves the link, and a rename moves the target out from under it.
+//
+// Containment is unaffected. Every component but the last is still resolved and
+// the result checked against the root, which is what hostPath relies on for a
+// target that does not exist yet, and a link can only be traversed through a
+// component that exists. The final element is not traversed here at all -- it is
+// the thing being operated on -- so it cannot lead anywhere.
+func (fs *LocalFileSystem) hostPathNoFollow(path string) (string, error) {
+	if path == "" {
+		return fs.root, nil
+	}
+
+	candidate := filepath.Join(fs.root, filepath.FromSlash(path))
+
+	resolvedParent, err := filepath.EvalSymlinks(filepath.Dir(candidate))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", ErrNotFound
+		}
+		return "", err
+	}
+	if !fs.contains(resolvedParent) {
+		return "", ErrAccessDenied
+	}
+	return filepath.Join(resolvedParent, filepath.Base(candidate)), nil
+}
+
 // contains reports whether a resolved host path is the root or lies beneath it.
 //
 // The separator on the prefix matters: without it, a sibling directory whose name
@@ -297,11 +330,14 @@ func (fs *LocalFileSystem) SetAttr(path string, attr FileAttr, mask AttrMask) er
 }
 
 // Remove deletes a file.
+//
+// The name is resolved without following a link in its final element, so
+// deleting a symbolic link removes the link rather than what it points at.
 func (fs *LocalFileSystem) Remove(path string) error {
 	if fs.readOnly {
 		return ErrReadOnly
 	}
-	host, err := fs.hostPath(path)
+	host, err := fs.hostPathNoFollow(path)
 	if err != nil {
 		return err
 	}
@@ -316,15 +352,19 @@ func (fs *LocalFileSystem) Remove(path string) error {
 }
 
 // Rename moves a file or directory.
+//
+// Neither name has a link in its final element followed: renaming a symbolic link
+// moves the link, and renaming onto one replaces the link rather than writing
+// through it.
 func (fs *LocalFileSystem) Rename(oldPath, newPath string, replace bool) error {
 	if fs.readOnly {
 		return ErrReadOnly
 	}
-	oldHost, err := fs.hostPath(oldPath)
+	oldHost, err := fs.hostPathNoFollow(oldPath)
 	if err != nil {
 		return err
 	}
-	newHost, err := fs.hostPath(newPath)
+	newHost, err := fs.hostPathNoFollow(newPath)
 	if err != nil {
 		return err
 	}
@@ -359,7 +399,7 @@ func (fs *LocalFileSystem) Rmdir(path string) error {
 	if path == "" {
 		return ErrAccessDenied
 	}
-	host, err := fs.hostPath(path)
+	host, err := fs.hostPathNoFollow(path)
 	if err != nil {
 		return err
 	}
@@ -367,6 +407,9 @@ func (fs *LocalFileSystem) Rmdir(path string) error {
 	if err != nil {
 		return translate(err)
 	}
+	// A symbolic link is not a directory, whatever it points at, so removing a
+	// directory through one is refused rather than removing the directory it
+	// names. Remove is what unlinks the link itself.
 	if !info.IsDir() {
 		return ErrNotDirectory
 	}


### PR DESCRIPTION
### Linked Issue
`Closes #1099`

### Root Cause
`hostPath` does two things: it resolves a share-relative path to a host path through `filepath.EvalSymlinks`, and it checks the result lies under the share root. The resolution is what an operation on a file's *contents* needs — following a link inside the share to the file it names is correct for `Open`, `Stat` and `ReadDir`, and the containment check is what makes it safe.

The operations that act on a *name* rather than on contents used the same resolver. `Remove`, `Rmdir` and `Rename` therefore received the link's target and acted on that, so the entry the client named survived and a different one was destroyed or moved. The rename case is the worst of the three: it leaves the original link dangling and turns what was a link into a regular file at the new name.

### Fix Description
Add `hostPathNoFollow`, which resolves and containment-checks the *parent* exactly as `hostPath` already does for a target that does not exist yet, and joins the final element unresolved. `Remove`, `Rmdir` and `Rename` use it for the names they act on; `Rename` uses it for both ends, so renaming onto an existing link replaces the link rather than writing through it.

Containment is unchanged. Every component but the last is still resolved and checked against the root, and a link can only be traversed *through* a component that exists — the final element is not traversed at all here, it is the object being operated on. The new test asserts this directly: `Remove("escape/secret.txt")`, where `escape` is a link out of the share, is still refused and the outside file is untouched.

`Rmdir` on a link to a directory now returns `ErrNotDirectory`, because `os.Lstat` reports a symbolic link rather than a directory. That matches POSIX, where `rmdir` on a symlink fails with `ENOTDIR`, and it is a refusal rather than a destructive action. `Remove` is what unlinks the link itself.

### How Verified
- **Tests:** `TestLocalFileSystemNameOperationsDoNotFollowSymlinks` covers all three operations plus the cases that must not regress. Against the unpatched backend it fails on all three — "deleting the link deleted its target", "Rmdir() removed a directory through a symbolic link", "renaming the link moved its target away" — and passes against the patched one.
- **Regression:** `go build ./...`, `go vet ./...` and `go test ./...` are clean; 308 packages pass. `TestFileServiceDeleteAndRename`, `TestFileServiceRefusesTraversal` and `TestLocalFileSystemRoundTrip` continue to pass.

### Test Coverage
**Added:** `network/smb/smb_v10/server/file_service_test.go` — `TestLocalFileSystemNameOperationsDoNotFollowSymlinks`, with six subtests: the three corrected operations, deletion of an ordinary file and directory, and a delete reaching through a link that leaves the share.

**Modified:** `TestLocalFileSystemContainsSymlinkEscape` — see below.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/server/fs_local.go`, `network/smb/smb_v10/server/file_service_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** one, described immediately below, arising directly from the fix.

### Risk and Rollout
**`TestLocalFileSystemContainsSymlinkEscape` asserted that `Remove` on a link pointing out of the share fails, and after this change it succeeds.** That assertion is updated rather than preserved, and the reasoning should be reviewed rather than taken on trust.

The old behaviour was not a containment rule that had been chosen; it fell out of resolving the final element, which is the very thing this fix stops doing. It also conflated two different properties. Reaching *through* a link to something outside the share must be refused, and still is — `Stat`, `Open` and a delete of `linkdir/secret.txt` are all refused, and the test still asserts that. Deleting the link *entry* is a different matter: the entry belongs to this share, and unlinking it removes only that entry.

This was checked rather than assumed. With the fix, `Remove("link.txt")` and `Remove("linkdir")` on links pointing outside leave both the outside file and the outside directory intact — only the link entries go. The updated test asserts that the target is untouched after the link is removed.

The alternative was to keep refusing, which would leave an entry a client can list and can never delete. Blast radius is limited to shares that contain symbolic links; a share without them behaves identically.

### Notes
`SetAttr` still resolves through `hostPath`, which is correct: it acts on the attributes of the file a path names, not on the name.
