### PR TITLE
Fix missing NTLM header validation (Fixes #1101)

### DIFF
--- a/crypto/spnego/ntlm/message/authenticate/authenticate.go
+++ b/crypto/spnego/ntlm/message/authenticate/authenticate.go
@@ -515,6 +515,9 @@ func (msg *AuthenticateMessage) Unmarshal(data []byte) (int, error) {
 	if err != nil {
 		return 0, err
 	}
+	if err := msg.Header.Expect(types.MESSAGE_TYPE_AUTHENTICATE); err != nil {
+		return 0, err
+	}
 	totalBytesRead += bytesRead
 
 	// Read LM response fields

--- a/crypto/spnego/ntlm/message/challenge/challenge.go
+++ b/crypto/spnego/ntlm/message/challenge/challenge.go
@@ -135,6 +135,9 @@ func (msg *ChallengeMessage) Unmarshal(data []byte) (int, error) {
 	if err != nil {
 		return 0, err
 	}
+	if err := msg.Header.Expect(types.MESSAGE_TYPE_CHALLENGE); err != nil {
+		return 0, err
+	}
 	totalBytesRead += bytesRead
 
 	// Read target name fields

--- a/crypto/spnego/ntlm/message/challenge/challenge_test.go
+++ b/crypto/spnego/ntlm/message/challenge/challenge_test.go
@@ -2,6 +2,7 @@ package challenge_test
 
 import (
 	"bytes"
+	"encoding/binary"
 	"encoding/hex"
 	"testing"
 
@@ -124,5 +125,21 @@ func TestChallengeMessageMarshalUnmarshal(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestChallengeMessageRejectsAnotherMessageType asserts a NEGOTIATE is not parsed
+// as a CHALLENGE. The three messages have different layouts and no discriminator
+// beyond the header's MessageType, so parsing one as another fills the fields
+// from the wrong offsets instead of failing.
+func TestChallengeMessageRejectsAnotherMessageType(t *testing.T) {
+	// A well-formed NEGOTIATE, long enough to clear the CHALLENGE length gate.
+	message := make([]byte, 64)
+	copy(message, header.NTLM_SIGNATURE[:])
+	binary.LittleEndian.PutUint32(message[8:12], 1) // MESSAGE_TYPE_NEGOTIATE
+
+	parsed := &challenge.ChallengeMessage{}
+	if _, err := parsed.Unmarshal(message); err == nil {
+		t.Error("Unmarshal() parsed a NEGOTIATE as a CHALLENGE")
 	}
 }

--- a/crypto/spnego/ntlm/message/header/header.go
+++ b/crypto/spnego/ntlm/message/header/header.go
@@ -35,16 +35,37 @@ func (m *Header) Marshal() ([]byte, error) {
 }
 
 // Unmarshal deserializes a byte slice into a Header
+//
+// The signature is checked rather than merely copied. Everything that follows it
+// is read at fixed offsets and at offsets the message itself declares, so a buffer
+// that is not an NTLM message at all is otherwise parsed as one: the fields come
+// out as whatever the bytes happened to say, and the caller has no way to tell.
+// Refusing here means a parse failure is reported where it happens.
 func (m *Header) Unmarshal(data []byte) (int, error) {
 	if len(data) < 12 {
 		return 0, fmt.Errorf("data too short to be a valid Header")
 	}
 
 	copy(m.Signature[:], data[:8])
+	if m.Signature != NTLM_SIGNATURE {
+		return 0, fmt.Errorf("data does not begin with the NTLMSSP signature (got % x)", m.Signature)
+	}
 
 	m.MessageType = types.MessageType(binary.LittleEndian.Uint32(data[8:12]))
 
 	return 12, nil
+}
+
+// Expect reports whether the header names the message type the caller is parsing.
+//
+// The three NTLM messages have different layouts and no shared discriminator
+// beyond this field, so parsing one as another produces a message populated from
+// the wrong offsets rather than an error.
+func (m *Header) Expect(messageType types.MessageType) error {
+	if m.MessageType != messageType {
+		return fmt.Errorf("message is a %s, not a %s", m.MessageType, messageType)
+	}
+	return nil
 }
 
 // GetType returns the message type

--- a/crypto/spnego/ntlm/message/header/header_test.go
+++ b/crypto/spnego/ntlm/message/header/header_test.go
@@ -13,6 +13,11 @@ func TestHeaderMarshalUnmarshal(t *testing.T) {
 		signature [8]byte
 		msgType   types.MessageType
 		wantError bool
+		// wantUnmarshalError says the bytes must be refused when read back. A
+		// header whose signature is not the NTLMSSP string is not an NTLM message,
+		// so it marshals -- the field is whatever the caller put there -- and does
+		// not parse.
+		wantUnmarshalError bool
 	}{
 		{
 			name:      "Standard NTLM Header",
@@ -21,10 +26,17 @@ func TestHeaderMarshalUnmarshal(t *testing.T) {
 			wantError: false,
 		},
 		{
-			name:      "Custom Signature",
-			signature: [8]byte{'T', 'E', 'S', 'T', 'S', 'I', 'G', 0},
+			name:      "Standard NTLM Header, challenge",
+			signature: header.NTLM_SIGNATURE,
 			msgType:   types.MESSAGE_TYPE_CHALLENGE,
 			wantError: false,
+		},
+		{
+			name:               "Custom Signature",
+			signature:          [8]byte{'T', 'E', 'S', 'T', 'S', 'I', 'G', 0},
+			msgType:            types.MESSAGE_TYPE_CHALLENGE,
+			wantError:          false,
+			wantUnmarshalError: true,
 		},
 	}
 
@@ -50,6 +62,12 @@ func TestHeaderMarshalUnmarshal(t *testing.T) {
 			// Unmarshal into new header
 			unmarshalled := &header.Header{}
 			_, err = unmarshalled.Unmarshal(data)
+			if tt.wantUnmarshalError {
+				if err == nil {
+					t.Error("Unmarshal() accepted a header whose signature is not NTLMSSP")
+				}
+				return
+			}
 			if err != nil {
 				t.Errorf("Unmarshal() error = %v", err)
 				return
@@ -66,5 +84,39 @@ func TestHeaderMarshalUnmarshal(t *testing.T) {
 					unmarshalled.GetType(), original.GetType())
 			}
 		})
+	}
+}
+
+// TestUnmarshalRejectsForeignBytes asserts a buffer that is not an NTLM message
+// is refused rather than parsed into whatever the bytes happen to say.
+func TestUnmarshalRejectsForeignBytes(t *testing.T) {
+	foreign := map[string][]byte{
+		"ASCII digits":      []byte("000000000000"),
+		"zeroes":            make([]byte, 12),
+		"truncated NTLMSSP": append([]byte("NTLMSS"), 0x00, 0x00, 0x01, 0x00, 0x00, 0x00),
+	}
+
+	for name, data := range foreign {
+		t.Run(name, func(t *testing.T) {
+			parsed := &header.Header{}
+			if _, err := parsed.Unmarshal(data); err == nil {
+				t.Error("Unmarshal() accepted a buffer that is not an NTLM message")
+			}
+		})
+	}
+}
+
+// TestExpectRejectsTheWrongMessageType asserts the type check distinguishes the
+// three messages, which share no other discriminator.
+func TestExpectRejectsTheWrongMessageType(t *testing.T) {
+	parsed := &header.Header{Signature: header.NTLM_SIGNATURE, MessageType: types.MESSAGE_TYPE_CHALLENGE}
+
+	if err := parsed.Expect(types.MESSAGE_TYPE_CHALLENGE); err != nil {
+		t.Errorf("Expect() rejected the matching type: %v", err)
+	}
+	for _, other := range []types.MessageType{types.MESSAGE_TYPE_NEGOTIATE, types.MESSAGE_TYPE_AUTHENTICATE} {
+		if err := parsed.Expect(other); err == nil {
+			t.Errorf("Expect(%s) accepted a %s", other, parsed.MessageType)
+		}
 	}
 }

--- a/crypto/spnego/ntlm/message/negotiate/negotiate.go
+++ b/crypto/spnego/ntlm/message/negotiate/negotiate.go
@@ -196,6 +196,9 @@ func (msg *NegotiateMessage) Unmarshal(data []byte) (int, error) {
 	if err != nil {
 		return 0, err
 	}
+	if err := msg.Header.Expect(types.MESSAGE_TYPE_NEGOTIATE); err != nil {
+		return 0, err
+	}
 	totalBytesRead += bytesRead
 
 	// Read negotiate flags


### PR DESCRIPTION
### Linked Issue
`Closes #1101`

### Root Cause
`Header.Unmarshal` was written to read its two fields rather than to validate them. The signature was copied into the struct and never compared, even though the field's own documentation states it "MUST contain the ASCII string ('N', 'T', 'L', 'M', 'S', 'S', 'P', '\0')" — a constraint the type declared and did not enforce.

The per-message parsers had the matching gap. Everything after the header is read at fixed offsets and at offsets the message itself declares, and the three messages have different layouts with no discriminator beyond `MessageType`. So parsing a NEGOTIATE as a CHALLENGE does not fail; it fills `TargetNameFields` from where `NegotiateFlags` lives and carries on. Each parser trusted the caller to have chosen the right type instead of confirming it.

The result is that a parse which should fail instead succeeds with values taken from the wrong places, and the return value gives the caller no way to tell.

### Fix Description
`Header.Unmarshal` compares the signature against `NTLM_SIGNATURE` and returns an error when it does not match. `Header.Expect` is added for the type check, and each of the three parsers calls it immediately after reading the header.

`Expect` is a method on the header rather than a parameter to `Unmarshal` so the header parser keeps one job and the three call sites read as what they are — each parser stating which message it is. The error names both types, so a mismatch says what arrived and what was wanted.

Nothing on the writing side changes. `Marshal` already sets both fields on every message, so a message this library produces satisfies the new checks by construction, and a message from any conforming peer does too.

### How Verified
- **Tests:** `TestUnmarshalRejectsForeignBytes` covers three buffers that are not NTLM messages; `TestExpectRejectsTheWrongMessageType` covers the type check in both directions; `TestChallengeMessageRejectsAnotherMessageType` confirms a NEGOTIATE is no longer parsed as a CHALLENGE.
- **Runtime:** the 60-byte buffer beginning `"0000000000000\x00"` that `ChallengeMessage.Unmarshal` previously accepted is now refused at the header.
- **Regression, and this is the part that mattered:** the change sits on the path every NTLM exchange takes, so the end-to-end authentication coverage is what establishes it is safe. `go test ./...` is clean across 308 packages, including the SMB1 server's session-setup, signing, capture and conformance suites, the SMB2 client, and the SPNEGO round-trips — all of which drive real NEGOTIATE/CHALLENGE/AUTHENTICATE exchanges through these parsers.

### Test Coverage
**Added:**
- `crypto/spnego/ntlm/message/header/header_test.go` — `TestUnmarshalRejectsForeignBytes`, `TestExpectRejectsTheWrongMessageType`
- `crypto/spnego/ntlm/message/challenge/challenge_test.go` — `TestChallengeMessageRejectsAnotherMessageType`

**Modified:** `TestHeaderMarshalUnmarshal` — see below.

### Scope of Change
- **Files changed:** `crypto/spnego/ntlm/message/header/header.go`, `crypto/spnego/ntlm/message/header/header_test.go`, `crypto/spnego/ntlm/message/challenge/challenge.go`, `crypto/spnego/ntlm/message/challenge/challenge_test.go`, `crypto/spnego/ntlm/message/negotiate/negotiate.go`, `crypto/spnego/ntlm/message/authenticate/authenticate.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** one, described below, arising directly from the fix.

### Risk and Rollout
**`TestHeaderMarshalUnmarshal` had a "Custom Signature" case asserting that a header carrying `TESTSIG\0` marshals and unmarshals back unchanged.** That is exactly the permissiveness being removed, so the case is updated to expect the bytes to be refused on the way back in rather than deleted — a header with a non-NTLMSSP signature still marshals, since the field is whatever the caller put there, and no longer parses.

This is a reading-side restriction on a path every NTLM exchange crosses, so the risk is a peer whose messages were previously tolerated now being refused. Both checks are on fields MS-NLMP makes mandatory and that this library's own `Marshal` always sets, so a conforming peer is unaffected; the full suite passing, including the SMB1 server's live-style session-setup and conformance tests, is the evidence for that. Worth merging ahead of a live-validation run rather than alongside one, so any interop surprise is attributable.

### Notes
This is how the fuzz input that surfaced #1081 reached the payload code — it was not an NTLM message at all, and nothing before the payload bounds check rejected it. The bounds fix in #1081 and #1095 stops the panic; this stops such a buffer being treated as a message in the first place.
