### PR TITLE
Add LDAP search variants that carry controls (Fixes #1104)

### DIFF
--- a/network/ldap/query.go
+++ b/network/ldap/query.go
@@ -29,6 +29,35 @@ import (
 // If the search is successful, it returns the search results. If an error occurs, it logs a warning
 // and returns an empty slice.
 func (ldapSession *Session) Query(searchBase string, query string, attributes []string, scope int) ([]*ldap.Entry, error) {
+	return ldapSession.QueryWithControls(searchBase, query, attributes, scope, nil)
+}
+
+// QueryWithControls performs an LDAP search operation with the given LDAP controls
+// attached to the search request.
+//
+// Some searches cannot be expressed by the search request alone. Reading
+// nTSecurityDescriptor is the common case: without the LDAP_SERVER_SD_FLAGS_OID
+// control (1.2.840.113556.1.4.801, MS-ADTS 3.1.1.3.4.1.11) naming the parts of the
+// descriptor to return, a domain controller tries to include the SACL, and a client
+// that does not hold SE_SECURITY_NAME gets the attribute back empty rather than an
+// error. See ControlMicrosoftSDFlags in security_descriptors.go.
+//
+// Parameters:
+//   - searchBase: A string representing the base DN (Distinguished Name) from which the search should start.
+//     Special values "defaultNamingContext", "configurationNamingContext", and "schemaNamingContext"
+//     will be replaced with the corresponding values from the root DSE.
+//   - query: A string representing the LDAP search filter.
+//   - attributes: A slice of strings specifying the attributes to retrieve from the search results.
+//   - scope: An integer representing the scope of the search. Valid values are:
+//   - ScopeBaseObject: Search only the base object.
+//   - ScopeSingleLevel: Search one level under the base object.
+//   - ScopeWholeSubtree: Search the entire subtree under the base object.
+//   - controls: The LDAP controls to attach to the search request. A nil or empty slice
+//     sends the search without any control, which is what Query does.
+//
+// Returns:
+// - A slice of pointers to ldap.Entry objects representing the search results.
+func (ldapSession *Session) QueryWithControls(searchBase string, query string, attributes []string, scope int, controls []ldap.Control) ([]*ldap.Entry, error) {
 	// Parsing parameters
 	if len(searchBase) == 0 {
 		searchBase = "defaultNamingContext"
@@ -76,7 +105,7 @@ func (ldapSession *Session) Query(searchBase string, query string, attributes []
 		// Attributes to retrieve
 		attributes,
 		// Controls
-		nil,
+		controls,
 	)
 
 	// Perform LDAP search
@@ -193,6 +222,31 @@ func (ldapSession *Session) QuerySingleLevel(searchBase string, query string, at
 //   - The function logs warnings if the search fails or if no entries are found.
 func (ldapSession *Session) QueryWholeSubtree(searchBase string, query string, attributes []string) ([]*ldap.Entry, error) {
 	entries, err := ldapSession.Query(searchBase, query, attributes, ldap.ScopeWholeSubtree)
+	if err != nil {
+		return nil, fmt.Errorf("error querying LDAP: %w", err)
+	}
+	return entries, nil
+}
+
+// QueryWholeSubtreeWithControls performs an LDAP query with a scope of Whole Subtree,
+// with the given LDAP controls attached to the search request.
+//
+// This is the subtree form of QueryWithControls, and exists because the searches that
+// need a control are usually the ones that sweep a whole naming context: reading the
+// security descriptor of every object of a domain needs LDAP_SERVER_SD_FLAGS_OID on a
+// subtree search, and doing it one base object at a time is one round trip per object.
+//
+// Parameters:
+//   - searchBase (string): The base DN (Distinguished Name) from which the search should start.
+//   - query (string): The LDAP query to be executed.
+//   - attributes ([]string): The list of attributes to retrieve for each entry.
+//   - controls ([]ldap.Control): The LDAP controls to attach to the search request.
+//
+// Returns:
+//   - []*ldap.Entry: A slice of LDAP entries that match the query within the whole subtree.
+//   - error: An error if the search fails, nil otherwise.
+func (ldapSession *Session) QueryWholeSubtreeWithControls(searchBase string, query string, attributes []string, controls []ldap.Control) ([]*ldap.Entry, error) {
+	entries, err := ldapSession.QueryWithControls(searchBase, query, attributes, ldap.ScopeWholeSubtree, controls)
 	if err != nil {
 		return nil, fmt.Errorf("error querying LDAP: %w", err)
 	}

--- a/network/ldap/security_descriptors.go
+++ b/network/ldap/security_descriptors.go
@@ -7,6 +7,27 @@ import (
 	"github.com/go-ldap/ldap/v3"
 )
 
+// Security Information constants for NT Security Descriptor flags, as carried in the
+// LDAP_SERVER_SD_FLAGS_OID control value.
+//
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/3888c2b7-35b9-45b7-afeb-b772aa932dd0
+//
+// SACL_SECURITY_INFORMATION is the one to think about before requesting: reading a
+// SACL needs the SE_SECURITY_NAME privilege, and a domain controller answers a client
+// that lacks it with the nTSecurityDescriptor attribute absent from the entry rather
+// than with an error. A caller that only needs the owner, the group and the DACL
+// should ask for exactly those, which is what SECURITY_INFORMATION_DEFAULT is.
+const (
+	OWNER_SECURITY_INFORMATION = 0x1 // Owner identifier of the object
+	GROUP_SECURITY_INFORMATION = 0x2 // Primary group identifier
+	DACL_SECURITY_INFORMATION  = 0x4 // Discretionary access control list (DACL) of the object
+	SACL_SECURITY_INFORMATION  = 0x8 // System access control list (SACL) of the object
+
+	// SECURITY_INFORMATION_DEFAULT is the everything-but-the-SACL set, which is what
+	// an unprivileged read of a security descriptor has to ask for.
+	SECURITY_INFORMATION_DEFAULT = OWNER_SECURITY_INFORMATION | GROUP_SECURITY_INFORMATION | DACL_SECURITY_INFORMATION
+)
+
 type ControlMicrosoftSDFlags struct {
 	Criticality  bool
 	ControlValue int32
@@ -54,17 +75,9 @@ func NewControlMicrosoftSDFlags() *ControlMicrosoftSDFlags {
 func (s *Session) GetNtSecurityDescriptorOf(distinguishedName string) (string, error) {
 	// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/3888c2b7-35b9-45b7-afeb-b772aa932dd0
 
-	// Security Information constants for NT Security Descriptor flags
-	const (
-		OWNER_SECURITY_INFORMATION = 0x1 // Owner identifier of the object
-		GROUP_SECURITY_INFORMATION = 0x2 // Primary group identifier
-		DACL_SECURITY_INFORMATION  = 0x4 // Discretionary access control list (DACL) of the object
-		SACL_SECURITY_INFORMATION  = 0x8 // System access control list (SACL) of the object
-	)
-
 	control := &ControlMicrosoftSDFlags{
 		Criticality:  false,
-		ControlValue: int32(OWNER_SECURITY_INFORMATION | GROUP_SECURITY_INFORMATION | DACL_SECURITY_INFORMATION),
+		ControlValue: int32(SECURITY_INFORMATION_DEFAULT),
 	}
 
 	searchRequest := ldap.NewSearchRequest(

--- a/network/ldap/security_descriptors_test.go
+++ b/network/ldap/security_descriptors_test.go
@@ -1,0 +1,86 @@
+package ldap
+
+import (
+	"testing"
+
+	ber "github.com/go-asn1-ber/asn1-ber"
+)
+
+// TestSecurityInformationDefaultExcludesSACL pins the value an unprivileged read has
+// to ask for. Letting SACL_SECURITY_INFORMATION into this set makes a domain
+// controller return the nTSecurityDescriptor attribute empty, with no error, for every
+// client that does not hold SE_SECURITY_NAME.
+func TestSecurityInformationDefaultExcludesSACL(t *testing.T) {
+	if SECURITY_INFORMATION_DEFAULT != 0x7 {
+		t.Errorf("SECURITY_INFORMATION_DEFAULT = 0x%x, want 0x7", SECURITY_INFORMATION_DEFAULT)
+	}
+	if SECURITY_INFORMATION_DEFAULT&SACL_SECURITY_INFORMATION != 0 {
+		t.Error("SECURITY_INFORMATION_DEFAULT must not request the SACL")
+	}
+}
+
+// TestControlMicrosoftSDFlagsGetControlType checks the OID the control is sent under.
+func TestControlMicrosoftSDFlagsGetControlType(t *testing.T) {
+	control := NewControlMicrosoftSDFlags()
+	if got, want := control.GetControlType(), "1.2.840.113556.1.4.801"; got != want {
+		t.Errorf("GetControlType() = %q, want %q", got, want)
+	}
+}
+
+// TestControlMicrosoftSDFlagsEncode walks the encoded control and checks that the OID
+// and the flags value are where a server expects to read them: a SEQUENCE holding the
+// control OID and an OCTET STRING wrapping a SEQUENCE with a single INTEGER.
+func TestControlMicrosoftSDFlagsEncode(t *testing.T) {
+	testCases := []struct {
+		name         string
+		criticality  bool
+		controlValue int32
+		wantChildren int
+	}{
+		{"default flags, not critical", false, SECURITY_INFORMATION_DEFAULT, 2},
+		{"with SACL, not critical", false, SECURITY_INFORMATION_DEFAULT | SACL_SECURITY_INFORMATION, 2},
+		{"default flags, critical", true, SECURITY_INFORMATION_DEFAULT, 3},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			control := &ControlMicrosoftSDFlags{Criticality: testCase.criticality, ControlValue: testCase.controlValue}
+			packet := control.Encode()
+
+			if len(packet.Children) != testCase.wantChildren {
+				t.Fatalf("encoded control has %d children, want %d", len(packet.Children), testCase.wantChildren)
+			}
+
+			oid, ok := packet.Children[0].Value.(string)
+			if !ok {
+				t.Fatalf("first child is %T, want the control OID as a string", packet.Children[0].Value)
+			}
+			if oid != "1.2.840.113556.1.4.801" {
+				t.Errorf("encoded OID = %q, want %q", oid, "1.2.840.113556.1.4.801")
+			}
+
+			// The control value is the last child whatever the criticality, since the
+			// criticality boolean is only emitted when it is true.
+			value := packet.Children[len(packet.Children)-1]
+			if len(value.Children) != 1 {
+				t.Fatalf("control value has %d children, want 1 SDFlags sequence", len(value.Children))
+			}
+			flags := value.Children[0]
+			if len(flags.Children) != 1 {
+				t.Fatalf("SDFlags sequence has %d children, want 1 integer", len(flags.Children))
+			}
+			if flags.Children[0].Tag != ber.TagInteger {
+				t.Errorf("SDFlags child tag = %d, want TagInteger (%d)", flags.Children[0].Tag, ber.TagInteger)
+			}
+			// ber.NewInteger stores the value it was handed, so this is the int32 the
+			// control carries rather than a widened int64.
+			got, ok := flags.Children[0].Value.(int32)
+			if !ok {
+				t.Fatalf("SDFlags value is %T, want int32", flags.Children[0].Value)
+			}
+			if got != testCase.controlValue {
+				t.Errorf("SDFlags value = %d, want %d", got, testCase.controlValue)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Linked Issue

`Closes #1104`

### Root Cause

`Query()` was written with the control list of its `ldap.NewSearchRequest` call fixed
at `nil`, and the five scope wrappers (`QueryBaseObject`, `QuerySingleLevel`,
`QueryWholeSubtree`, `QueryChildren`, `QueryAllNamingContexts`) were then built on top
of that signature. Nothing in the package carries a control through to the wire, and
because `Session.connection` is unexported a caller cannot go around the package and
build its own search either. The result is that an entire class of LDAP search - any
search whose meaning is set by a control - cannot be expressed through this API.

`nTSecurityDescriptor` is where that bites hardest. Per MS-ADTS 3.1.1.3.4.1.11 the read
is scoped by `LDAP_SERVER_SD_FLAGS_OID`; without it a domain controller attempts to
include the SACL, and a client that does not hold `SE_SECURITY_NAME` gets the attribute
back absent from the entry rather than an error. `GetNtSecurityDescriptorOf` already
knows this and sends `OWNER | GROUP | DACL`, but it is a `ScopeBaseObject` read of a
single DN, so reading the descriptor of every object of a naming context costs one
round trip per object.

### Fix Description

`QueryWithControls` takes the control list and holds the body `Query` used to have.
`Query` becomes a one-line delegation passing `nil`, so its behaviour is unchanged by
construction rather than by inspection, and none of its call sites move - which matters,
since `Query` and its wrappers have 25 call sites inside this repository and many more
across the sibling tool repositories. `QueryWholeSubtreeWithControls` is added beside
`QueryWholeSubtree` because the subtree sweep is the shape that actually needs a
control.

The four `*_SECURITY_INFORMATION` values move from inside the body of
`GetNtSecurityDescriptorOf` to package level, so a caller building its own SD flags
control does not have to redeclare them, and `SECURITY_INFORMATION_DEFAULT` names the
everything-but-the-SACL set that an unprivileged read has to ask for.
`GetNtSecurityDescriptorOf` now uses that constant and sends exactly the value it sent
before.

An additive variant was chosen over changing the signature of `Query` (which would
touch every call site in every repository) and over a session-level
`SetSearchControls([]ldap.Control)`. The latter would reach all five wrappers without
new functions, but it makes controls sticky and invisible at the call site: a control
set once for one search would silently ride along on every later search of that
session. For something that changes what the server returns, an explicit parameter is
the safer shape.

### How Verified

- `go build ./network/ldap/`, `go vet ./network/ldap/` and `gofmt -l network/ldap/` are
  all clean.
- `go test ./network/ldap/` passes.
- Static: `Query` at `network/ldap/query.go:31` now contains a single `return`
  delegating with `nil`, and the request built at
  `network/ldap/query.go:88-107` is otherwise byte-for-byte the code that ran before,
  so a caller of `Query` sends the same search it always did.
- The control value is unchanged for the one existing sender:
  `SECURITY_INFORMATION_DEFAULT` is asserted to be `0x7` by
  `TestSecurityInformationDefaultExcludesSACL`, which is the value
  `GetNtSecurityDescriptorOf` inlined before this change.
- Downstream: the new subtree variant is what `manticore-aclmonitor` reads security
  descriptors with, and it builds and runs against this branch.

### Test Coverage

**Added:** `network/ldap/security_descriptors_test.go`

- `TestSecurityInformationDefaultExcludesSACL` - pins `SECURITY_INFORMATION_DEFAULT` to
  `0x7` and asserts it does not carry `SACL_SECURITY_INFORMATION`. Letting the SACL into
  that set would make a domain controller return the `nTSecurityDescriptor` attribute
  empty, with no error, for every client without `SE_SECURITY_NAME` - a silent failure
  worth a regression test.
- `TestControlMicrosoftSDFlagsGetControlType` - checks the OID the control is sent under.
- `TestControlMicrosoftSDFlagsEncode` - walks the encoded control and checks the OID and
  the flags integer are where a server reads them, across three cases (default flags,
  with the SACL, and with criticality set, which changes the child count).

The search functions themselves need a bound connection and are not unit-testable here;
the delegation that keeps `Query` unchanged is verified statically, as described above.

### Scope of Change

- **Files changed:** `network/ldap/query.go`, `network/ldap/security_descriptors.go`, `network/ldap/security_descriptors_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout

Low blast radius. Existing callers reach the same code through one added call frame with
`nil` controls, and the only behavioural surface that could regress is `Query`, which is
now defined in terms of the new function rather than duplicated. Safe to merge without a
staged rollout.

### Notes

Related to #1103, which reports the other half of the same constraint: `SearchWithPaging`
is called with a hardcoded page size of 1000 that no caller can change, for the same
underlying reason. That is a separate fix and is not touched here. Note that
`QueryWithControls` still goes through `SearchWithPaging`, which appends its own
paged-results control to whatever the caller passed - the behaviour a caller wants here,
but it does mean this cannot be used to send a search with no control at all.
