### PR TITLE
Fix panics on malformed msDS-KeyCredentialLink values (Fixes #1107)

### DIFF
--- a/windows/keycredentiallink/KEYCREDENTIALLINK_BLOB.go
+++ b/windows/keycredentiallink/KEYCREDENTIALLINK_BLOB.go
@@ -48,7 +48,16 @@ func NewKEYCREDENTIALLINK_BLOB(version version.KeyCredentialLinkVersion, entries
 func (k *KEYCREDENTIALLINK_BLOB) Unmarshal(data []byte) (int, error) {
 	bytesRead := 0
 
-	k.Version.Unmarshal(data[bytesRead:4])
+	// The version is a fixed four-byte field, and the entry loop below already
+	// refuses a truncated entry header, so the version needs the same check
+	// rather than slicing a buffer that may be shorter than the field.
+	if len(data) < 4 {
+		return bytesRead, fmt.Errorf("malformed KeyCredentialLink: insufficient bytes for the version (expected at least 4, got %d)", len(data))
+	}
+
+	if _, err := k.Version.Unmarshal(data[bytesRead : bytesRead+4]); err != nil {
+		return bytesRead, fmt.Errorf("failed to unmarshal KeyCredentialLink version: %w", err)
+	}
 	bytesRead += 4
 
 	k.Entries = make([]KEYCREDENTIALLINK_ENTRY, 0)

--- a/windows/keycredentiallink/KEYCREDENTIALLINK_BLOB_test.go
+++ b/windows/keycredentiallink/KEYCREDENTIALLINK_BLOB_test.go
@@ -1,1 +1,52 @@
 package keycredentiallink_test
+
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/windows/keycredentiallink"
+)
+
+// A blob shorter than the four-byte version field is malformed, and the value comes
+// from a directory or a file, so it has to be reported as an error rather than
+// slicing past the end of the buffer.
+func TestKEYCREDENTIALLINK_BLOB_Unmarshal_TruncatedVersion(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+	}{
+		{name: "empty", data: []byte{}},
+		{name: "nil", data: nil},
+		{name: "one byte", data: []byte{0x00}},
+		{name: "three bytes", data: []byte{0x00, 0x02, 0x00}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			blob := keycredentiallink.KEYCREDENTIALLINK_BLOB{}
+
+			if _, err := blob.Unmarshal(test.data); err == nil {
+				t.Errorf("Unmarshal(%d bytes) returned no error, want one", len(test.data))
+			}
+		})
+	}
+}
+
+// A blob carrying only a version parses to zero entries: the version is complete, and
+// the absence of the entries the specification marks mandatory is the caller's to
+// handle, not a parse failure.
+func TestKEYCREDENTIALLINK_BLOB_Unmarshal_VersionOnly(t *testing.T) {
+	blob := keycredentiallink.KEYCREDENTIALLINK_BLOB{}
+
+	bytesRead, err := blob.Unmarshal([]byte{0x00, 0x02, 0x00, 0x00})
+	if err != nil {
+		t.Fatalf("Unmarshal() error = %v, want nil", err)
+	}
+
+	if bytesRead != 4 {
+		t.Errorf("bytesRead = %d, want 4", bytesRead)
+	}
+
+	if len(blob.Entries) != 0 {
+		t.Errorf("len(Entries) = %d, want 0", len(blob.Entries))
+	}
+}

--- a/windows/keycredentiallink/KeyCredentialLink.go
+++ b/windows/keycredentiallink/KeyCredentialLink.go
@@ -285,16 +285,51 @@ func (kc *KeyCredentialLink) Unmarshal(data []byte) (int, error) {
 			}
 
 		case KEYCREDENTIALLINK_ENTRY_IDENTIFIER_KeyApproximateLastLogonTimeStamp:
-			t := utils.ConvertFromBinaryTime(entry.Value, *kc.Source, kc.Version)
-			kc.LastLogonTime = &t
+			t, err := kc.parseBinaryTime(entry.Value)
+			if err != nil {
+				return bytesRead, fmt.Errorf("failed to unmarshal KeyCredentialLink last logon time: %w", err)
+			}
+			kc.LastLogonTime = t
 
 		case KEYCREDENTIALLINK_ENTRY_IDENTIFIER_KeyCreationTime:
-			t := utils.ConvertFromBinaryTime(entry.Value, *kc.Source, kc.Version)
-			kc.CreationTime = &t
+			t, err := kc.parseBinaryTime(entry.Value)
+			if err != nil {
+				return bytesRead, fmt.Errorf("failed to unmarshal KeyCredentialLink creation time: %w", err)
+			}
+			kc.CreationTime = t
 		}
 	}
 
 	return bytesRead, nil
+}
+
+// parseBinaryTime decodes a timestamp entry value into a DateTime.
+//
+// The KeySource entry is optional, and the entries of a blob are not guaranteed
+// to contain one even though it sorts before the timestamp entries, so an absent
+// source is decoded as the zero source instead of being dereferenced. The value
+// itself is a 64-bit integer, so a shorter one is a malformed entry rather than
+// something to decode.
+//
+// Parameters:
+// - value: The raw value of the timestamp entry.
+//
+// Returns:
+// - A pointer to the decoded DateTime object.
+// - An error if the value cannot hold a timestamp.
+func (kc *KeyCredentialLink) parseBinaryTime(value []byte) (*utils.DateTime, error) {
+	if len(value) < 8 {
+		return nil, fmt.Errorf("malformed KeyCredentialLink: insufficient bytes for a timestamp (expected at least 8, got %d)", len(value))
+	}
+
+	keySource := source.KeySource{}
+	if kc.Source != nil {
+		keySource = *kc.Source
+	}
+
+	t := utils.ConvertFromBinaryTime(value, keySource, kc.Version)
+
+	return &t, nil
 }
 
 // CheckIntegrity checks the integrity of the key credential.
@@ -410,6 +445,11 @@ func (kc *KeyCredentialLink) ToKeyCredentialLinkBlob() (*KEYCREDENTIALLINK_BLOB,
 	}
 
 	// Key Material (entry type 0x03) [MANDATORY]
+	// A parsed blob may still lack the entry, so the absence is reported as an
+	// error rather than dereferenced.
+	if kc.KeyMaterial == nil {
+		return nil, fmt.Errorf("cannot build a KeyCredentialLink blob without key material")
+	}
 	keyMaterialBytes, err := kc.KeyMaterial.Marshal()
 	if err != nil {
 		return nil, err
@@ -547,16 +587,34 @@ func (kc *KeyCredentialLink) Describe(indent int) {
 			fmt.Printf("%s │ \x1b[93mKeyHash\x1b[0m: %s (\x1b[91minvalid\x1b[0m)\n", indentPrompt, hex.EncodeToString(kc.KeyHash))
 		}
 	}
-	kc.KeyMaterial.Describe(indent + 1)
+	// Every entry below is described only when the blob carried it: the entries the
+	// specification marks mandatory are not guaranteed to be present in a blob that
+	// was parsed rather than built, so an absent one is reported instead of being
+	// dereferenced.
+	if kc.KeyMaterial != nil {
+		kc.KeyMaterial.Describe(indent + 1)
+	} else {
+		fmt.Printf("%s │ \x1b[93mKeyMaterial\x1b[0m: \x1b[91m<absent>\x1b[0m\n", indentPrompt)
+	}
 	fmt.Printf("%s │ \x1b[93mUsage\x1b[0m: %s\n", indentPrompt, kc.Usage.String())
 	if len(kc.LegacyUsage) != 0 {
 		fmt.Printf("%s │ \x1b[93mLegacyUsage\x1b[0m: %s\n", indentPrompt, kc.LegacyUsage)
 	}
-	fmt.Printf("%s │ \x1b[93mSource\x1b[0m: 0x%02x (%s)\n", indentPrompt, kc.Source.Value, kc.Source.String())
-	fmt.Printf("%s │ \x1b[93mDeviceId\x1b[0m: %s\n", indentPrompt, kc.DeviceId.ToFormatD())
-	kc.CustomKeyInfo.Describe(indent + 1)
-	fmt.Printf("%s │ \x1b[93mLastLogonTime (UTC)\x1b[0m: %s\n", indentPrompt, kc.LastLogonTime.String())
-	fmt.Printf("%s │ \x1b[93mCreationTime (UTC)\x1b[0m: %s\n", indentPrompt, kc.CreationTime.String())
+	if kc.Source != nil {
+		fmt.Printf("%s │ \x1b[93mSource\x1b[0m: 0x%02x (%s)\n", indentPrompt, kc.Source.Value, kc.Source.String())
+	}
+	if kc.DeviceId != nil {
+		fmt.Printf("%s │ \x1b[93mDeviceId\x1b[0m: %s\n", indentPrompt, kc.DeviceId.ToFormatD())
+	}
+	if kc.CustomKeyInfo != nil {
+		kc.CustomKeyInfo.Describe(indent + 1)
+	}
+	if kc.LastLogonTime != nil {
+		fmt.Printf("%s │ \x1b[93mLastLogonTime (UTC)\x1b[0m: %s\n", indentPrompt, kc.LastLogonTime.String())
+	}
+	if kc.CreationTime != nil {
+		fmt.Printf("%s │ \x1b[93mCreationTime (UTC)\x1b[0m: %s\n", indentPrompt, kc.CreationTime.String())
+	}
 	fmt.Printf("%s └───\n", indentPrompt)
 }
 

--- a/windows/keycredentiallink/KeyCredentialLink_test.go
+++ b/windows/keycredentiallink/KeyCredentialLink_test.go
@@ -188,3 +188,96 @@ func TestComputeKeyIdentifier_NoKeyMaterial(t *testing.T) {
 		t.Errorf("ComputeKeyIdentifier() = %q, want an empty string", got)
 	}
 }
+
+// msDS-KeyCredentialLink is read off objects the caller does not control, so a
+// malformed value has to come back as an error from ParseDNWithBinary instead of
+// ending the process. Each value below is well formed as a DN-with-binary and
+// malformed as a blob.
+func TestParseDNWithBinary_MalformedValues(t *testing.T) {
+	tests := []struct {
+		name      string
+		value     string
+		wantError bool
+	}{
+		{
+			// B:4:0000 declares four hexadecimal digits and supplies four, which is two
+			// bytes: too few to hold the four-byte version.
+			name:      "binary shorter than the version",
+			value:     "B:4:0000:CN=PC01,DC=MANTICORE,DC=local",
+			wantError: true,
+		},
+		{
+			// A timestamp entry whose value cannot hold a 64-bit integer.
+			name:      "truncated last logon timestamp",
+			value:     "B:30:000200000100050104000800000000:CN=PC01,DC=MANTICORE,DC=local",
+			wantError: true,
+		},
+		{
+			// A version and nothing else: the entries the specification marks mandatory
+			// are absent, which the caller handles, so this parses.
+			name:      "version only",
+			value:     "B:8:00020000:CN=PC01,DC=MANTICORE,DC=local",
+			wantError: false,
+		},
+		{
+			// A timestamp entry with no KeySource entry before it. The source governs how
+			// the timestamp is decoded and is itself optional, so its absence must not be
+			// dereferenced.
+			name:      "last logon timestamp without a key source",
+			value:     "B:30:000200000800080000000000000000:CN=PC01,DC=MANTICORE,DC=local",
+			wantError: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dnWithBinary := ldap.DNWithBinary{}
+			if _, err := dnWithBinary.Unmarshal([]byte(test.value)); err != nil {
+				t.Fatalf("DNWithBinary.Unmarshal() error = %v, want nil", err)
+			}
+
+			kc := keycredentiallink.KeyCredentialLink{}
+			err := kc.ParseDNWithBinary(dnWithBinary)
+
+			if test.wantError && err == nil {
+				t.Fatalf("ParseDNWithBinary() returned no error, want one")
+			}
+			if !test.wantError && err != nil {
+				t.Fatalf("ParseDNWithBinary() error = %v, want nil", err)
+			}
+
+			if err != nil {
+				return
+			}
+
+			// A value that parses must also describe: the entries it lacks are reported,
+			// not dereferenced.
+			kc.Describe(0)
+		})
+	}
+}
+
+// A blob that omits the mandatory KeyMaterial entry cannot be marshalled back, and
+// the integrity check that goes through the same path has to report a mismatch
+// rather than dereferencing the absent material.
+func TestToKeyCredentialLinkBlob_NoKeyMaterial(t *testing.T) {
+	kc := keycredentiallink.KeyCredentialLink{
+		Version: version.KeyCredentialLinkVersion{Value: version.KeyCredentialLinkVersion_2},
+		KeyHash: []byte{0x01, 0x02, 0x03, 0x04},
+	}
+
+	if _, err := kc.ToKeyCredentialLinkBlob(); err == nil {
+		t.Errorf("ToKeyCredentialLinkBlob() returned no error, want one")
+	}
+
+	if kc.CheckIntegrity() {
+		t.Errorf("CheckIntegrity() = true, want false for a credential without key material")
+	}
+}
+
+// Describe on a zero-valued structure touches every optional field at once.
+func TestDescribe_ZeroValue(t *testing.T) {
+	kc := keycredentiallink.KeyCredentialLink{}
+
+	kc.Describe(0)
+}


### PR DESCRIPTION
### Linked Issue
`Closes #1107`

### Root Cause
`KEYCREDENTIALLINK_BLOB.Unmarshal` sliced the fixed four-byte version field out of the buffer before performing any length check, although the entry loop immediately below it already refused a truncated entry header. A `msDS-KeyCredentialLink` value can be well formed as a DN-with-binary and still carry fewer than four binary bytes — `B:4:0000` declares four hexadecimal digits and supplies four, which is two bytes — so the declared length of the DN-with-binary is no guarantee that the blob can hold a version.

The rest of the package treated the entries the specification marks mandatory as guaranteed to be present, rather than as something a *parsed* blob may lack. A blob is a version followed by whatever entries it happens to carry, so `Describe`, `ToKeyCredentialLinkBlob` and the timestamp decoding in `Unmarshal` each dereferenced fields that stay nil when the corresponding entry is absent: `KeyMaterial` (nil interface), `Source`, `DeviceId`, `CustomKeyInfo`, `LastLogonTime` and `CreationTime`. `Unmarshal` also passed a timestamp entry's value straight to `utils.ConvertFromBinaryTime`, which reads a 64-bit integer off it without checking that eight bytes are there.

### Fix Description
- `KEYCREDENTIALLINK_BLOB.Unmarshal` checks the buffer can hold the four-byte version before slicing it, and now propagates the version's own unmarshalling error instead of discarding it.
- `KeyCredentialLink.Unmarshal` decodes both timestamp entries through a new `parseBinaryTime` helper, which rejects a value shorter than eight bytes and treats an absent `KeySource` entry as the zero source instead of dereferencing `kc.Source`. The `KeySource` entry is optional, so a blob carrying a timestamp without one previously panicked even though it sorts before the timestamp entries.
- `ToKeyCredentialLinkBlob` reports a missing mandatory `KeyMaterial` as an error instead of calling `Marshal` on a nil interface. This also fixes the `CheckIntegrity` path, which reaches the same code and now reports a mismatch rather than panicking.
- `Describe` prints each entry only when the blob carried it, reporting absent key material explicitly as `<absent>` rather than dereferencing it.

Guarding `Describe` alone was rejected: `Describe` is not the only consumer of a parsed blob, and the same absent entries reach `ToKeyCredentialLinkBlob` and `CheckIntegrity`. Refusing at `Unmarshal` any blob that omits a mandatory entry was also rejected — the parser's job is to report what the value contains, and a caller reading the attribute for reconnaissance has a legitimate reason to see a blob the directory holds even when it is incomplete.

### How Verified
Runtime, using the reproduction from the issue plus the further malformed shapes found while confirming it, driven through `ldap.DNWithBinary` + `ParseDNWithBinary` exactly as a caller reading the attribute would:

Before:

```
[short-version]           PANIC: runtime error: slice bounds out of range [:4] with capacity 2
[version-only-describe]   PANIC: runtime error: invalid memory address or nil pointer dereference
[lastlogon-no-source]     PANIC: runtime error: invalid memory address or nil pointer dereference
[keyid-short]             PANIC: runtime error: invalid memory address or nil pointer dereference
[shorttime-with-source]   PANIC: runtime error: index out of range [7] with length 4
```

After:

```
[short-version]           ParseDNWithBinary error: malformed KeyCredentialLink: insufficient bytes for the version (expected at least 4, got 2)
[version-only-describe]   ParseDNWithBinary ok, Describe ok
[lastlogon-no-source]     ParseDNWithBinary ok, Describe ok
[keyid-short]             ParseDNWithBinary ok, Describe ok
[shorttime-with-source]   ParseDNWithBinary error: failed to unmarshal KeyCredentialLink last logon time: malformed KeyCredentialLink: insufficient bytes for a timestamp (expected at least 8, got 4)
```

`go build ./...` and `go test ./...` are green across the repository, and the pre-existing `windows/keycredentiallink` tests — including the round-trip of a real Windows-emitted value in `TestKeyCredential_Unmarshal` — still pass, so well-formed values are unaffected.

### Test Coverage
**Added:**
- `windows/keycredentiallink/KEYCREDENTIALLINK_BLOB_test.go`: `TestKEYCREDENTIALLINK_BLOB_Unmarshal_TruncatedVersion` (nil, empty, one and three bytes all return an error) and `TestKEYCREDENTIALLINK_BLOB_Unmarshal_VersionOnly` (a complete version with no entries parses to zero entries).
- `windows/keycredentiallink/KeyCredentialLink_test.go`: `TestParseDNWithBinary_MalformedValues` (the issue's two values plus a truncated timestamp and a timestamp with no key source; each value that parses is also described), `TestToKeyCredentialLinkBlob_NoKeyMaterial` and `TestDescribe_ZeroValue`.

### Scope of Change
- **Files changed:** `windows/keycredentiallink/KEYCREDENTIALLINK_BLOB.go`, `windows/keycredentiallink/KEYCREDENTIALLINK_BLOB_test.go`, `windows/keycredentiallink/KeyCredentialLink.go`, `windows/keycredentiallink/KeyCredentialLink_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none. `ToKeyCredentialLinkBlob` returning an error where it previously panicked is the fix, not a separate change, and no caller depended on the panic.

### Risk and Rollout
Local to `windows/keycredentiallink`. Every change is a length or nil check on a path that previously crashed, so a well-formed value takes exactly the same path as before; the only new failure mode is an error where the process used to die. Safe to merge without staged rollout.

### Notes
`Describe` of a credential built by `ComposeKeyCredentialLinkForComputer` was also affected: it passes a nil `DeviceId`, which `Describe` dereferenced unconditionally.
