### PR TITLE
Fix SetTicks overflowing int64 for large tick values (Fixes #1113)

### DIFF
--- a/windows/keycredentiallink/utils/DateTime.go
+++ b/windows/keycredentiallink/utils/DateTime.go
@@ -26,6 +26,9 @@ type DateTime struct {
 
 const ticksBetween1601AndUnix uint64 = 116444736000000000 // (Unix(1970)-1601) in 100ns ticks
 
+// ticksPerSecond is the number of 100-nanosecond intervals in one second.
+const ticksPerSecond uint64 = 10000000
+
 // NewDateTimeFromTicks initializes a new DateTime instance from a number of ticks.
 //
 // Parameters:
@@ -92,16 +95,18 @@ func (dt DateTime) ToUniversalTime() time.Time {
 // This function updates both the Ticks field and recalculates the corresponding Time field based on the provided ticks.
 func (dt *DateTime) SetTicks(ticks uint64) {
 	dt.ticks = ticks
-	var nsFromUnixEpoch int64
-	if ticks >= ticksBetween1601AndUnix {
-		diffTicks := ticks - ticksBetween1601AndUnix
-		// diffTicks represents duration since Unix epoch in 100ns units; safe to scale to ns for time.Unix
-		nsFromUnixEpoch = int64(diffTicks) * 100
-	} else {
-		diffTicks := ticksBetween1601AndUnix - ticks
-		nsFromUnixEpoch = -int64(diffTicks) * 100
-	}
-	dt.time = time.Unix(0, nsFromUnixEpoch)
+
+	// The epoch offset is applied in whole seconds with the sub-second remainder
+	// carried separately. Scaling the whole tick count to nanoseconds in one
+	// multiplication exhausts the int64 that time.Unix takes after roughly 922
+	// years past 1601, which a 64-bit FILETIME can express more than sixty times
+	// over, so the arithmetic has to stay in seconds to cover the whole range.
+	secondsSince1601 := ticks / ticksPerSecond
+	remainderTicks := ticks % ticksPerSecond
+
+	secondsFromUnixEpoch := int64(secondsSince1601) - int64(ticksBetween1601AndUnix/ticksPerSecond)
+
+	dt.time = time.Unix(secondsFromUnixEpoch, int64(remainderTicks)*100)
 }
 
 // GetTicks returns the number of 100-nanosecond intervals (ticks) stored in the DateTime instance.

--- a/windows/keycredentiallink/utils/DateTime_test.go
+++ b/windows/keycredentiallink/utils/DateTime_test.go
@@ -271,3 +271,64 @@ func TestNewDateTimeFromTime(t *testing.T) {
 		})
 	}
 }
+
+// A 64-bit FILETIME can express dates far beyond what a single scaling to
+// nanoseconds can hold, so large tick counts have to decode to their real date
+// instead of a wrapped one. Before the fix the year-9999 value below decoded to
+// 1816, and the largest signed and unsigned values — 9.2 billion seconds apart —
+// decoded to the same instant.
+func TestDateTime_SetTicks_LargeValues(t *testing.T) {
+	testCases := []struct {
+		name         string
+		ticks        uint64
+		expectedYear int
+	}{
+		{name: "1601 epoch", ticks: 0, expectedYear: 1601},
+		{name: "typical value", ticks: 132918192030000000, expectedYear: 2022},
+		{name: "9999-12-31 (the largest date .NET represents)", ticks: 2650467743999999999, expectedYear: 9999},
+		{name: "maximum signed value", ticks: 0x7FFFFFFFFFFFFFFF, expectedYear: 30828},
+		{name: "maximum unsigned value", ticks: 0xFFFFFFFFFFFFFFFF, expectedYear: 60056},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			dt := utils.DateTime{}
+			dt.SetTicks(tc.ticks)
+
+			if got := dt.GetTime().UTC().Year(); got != tc.expectedYear {
+				t.Errorf("SetTicks(%d) year = %d, want %d (time %s)", tc.ticks, got, tc.expectedYear, dt.GetTime().UTC())
+			}
+
+			if dt.GetTicks() != tc.ticks {
+				t.Errorf("GetTicks() = %d, want %d", dt.GetTicks(), tc.ticks)
+			}
+		})
+	}
+}
+
+// Distinct tick counts must decode to distinct instants; a wrapped multiplication
+// mapped the largest signed and unsigned values onto the same one.
+func TestDateTime_SetTicks_DistinctValuesStayDistinct(t *testing.T) {
+	first := utils.DateTime{}
+	first.SetTicks(0x7FFFFFFFFFFFFFFF)
+
+	second := utils.DateTime{}
+	second.SetTicks(0xFFFFFFFFFFFFFFFF)
+
+	if first.GetTime().Equal(second.GetTime()) {
+		t.Errorf("two tick counts 9.2e18 apart decoded to the same instant: %s", first.GetTime().UTC())
+	}
+}
+
+// The sub-second remainder is carried separately from the whole seconds, so it has
+// to survive the conversion.
+func TestDateTime_SetTicks_SubSecondPrecision(t *testing.T) {
+	// 2022-03-15 12:00:03 UTC plus 1234567 ticks (0.1234567s)
+	dt := utils.DateTime{}
+	dt.SetTicks(132918192030000000 + 1234567)
+
+	expected := time.Date(2022, 3, 15, 12, 0, 3, 123456700, time.UTC)
+	if !dt.GetTime().UTC().Equal(expected) {
+		t.Errorf("GetTime() = %s, want %s", dt.GetTime().UTC(), expected)
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #1113`

### Root Cause
`SetTicks` converted a tick count to a `time.Time` by reducing it to a single nanosecond offset from the Unix epoch — `int64(diffTicks) * 100` — and handing that to `time.Unix(0, ns)`. An `int64` nanosecond offset spans roughly ±292 years around 1970, so the expression can only represent about 922 years of the range a 64-bit FILETIME expresses. Beyond that the multiplication wraps, and the decoded date becomes arbitrary rather than merely imprecise. The comment on the line asserted the scaling was "safe to scale to ns for time.Unix", which held only for the narrow window the existing tests covered.

### Fix Description
The epoch offset is now applied in whole seconds, with the sub-second remainder carried separately into the second argument of `time.Unix`:

```go
secondsSince1601 := ticks / ticksPerSecond
remainderTicks := ticks % ticksPerSecond
secondsFromUnixEpoch := int64(secondsSince1601) - int64(ticksBetween1601AndUnix/ticksPerSecond)
dt.time = time.Unix(secondsFromUnixEpoch, int64(remainderTicks)*100)
```

`time.Unix` takes seconds as an `int64` and internally represents years up to 292277026596, so a seconds-based offset covers the entire 64-bit tick range with no range check and no clamping. The largest possible tick count reduces to 1.8e12 seconds, well inside `int64`, and the remainder is under 1e7 ticks so its scaling to nanoseconds cannot overflow either. A new `ticksPerSecond` constant sits beside the existing `ticksBetween1601AndUnix`.

Saturating at a representable maximum was considered and rejected: it loses the distinction between two out-of-range values and would still need a documented ceiling, whereas the seconds-based arithmetic simply covers the whole range exactly.

### How Verified
Runtime, before and after, over the boundary values:

Before:

```
ticks=9223372036854775807  -> 2185-07-22 01:34:33.709551516 +0200 CEST
ticks=2650467744000000000  -> 1816-03-30 06:05:29.066277376 +0009 LMT
ticks=18446744073709551615 -> 2185-07-22 01:34:33.709551516 +0200 CEST
```

After, the same values decode to years 30828, 10000 and 60056 respectively, and the two extremes no longer collide.

Boundary expectations were cross-checked independently rather than taken from the implementation: `2650467743999999999` is 9999-12-31T23:59:59.999999, which is `DateTime.MaxValue` in .NET's FILETIME representation and the value the new test uses.

`go build ./...` and `go test ./...` are green; the 55 tests in `windows/keycredentiallink/utils` pass, including `TestDateTime_GetTicks_SetTicks/Maximum_value` and `TestBinaryTimeInvolution`, which already exercised this path.

### Test Coverage
**Added** in `windows/keycredentiallink/utils/DateTime_test.go`:
- `TestDateTime_SetTicks_LargeValues` — the 1601 epoch, a typical value, the largest .NET date, and the maximum signed and unsigned tick counts each decode to their real year.
- `TestDateTime_SetTicks_DistinctValuesStayDistinct` — two tick counts 9.2e18 apart no longer decode to the same instant.
- `TestDateTime_SetTicks_SubSecondPrecision` — the remainder carried separately from the whole seconds survives the conversion.

### Scope of Change
- **Files changed:** `windows/keycredentiallink/utils/DateTime.go`, `windows/keycredentiallink/utils/DateTime_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none. Tick counts within the previously working window decode to exactly the same instants.

### Risk and Rollout
Local to `SetTicks`. Values inside the old working range are unchanged; only previously-wrapped values now decode differently, which is the fix. Safe to merge without staged rollout.

### Notes
Same defect class as the already-closed #663. Filed alongside #1111, #1112 and #1114, which touch neighbouring lines in this file; this one lands first because the others build on a correct `SetTicks`.
