### PR TITLE
Fix SetTicks storing a local-zone time instead of UTC (Fixes #1114)

### DIFF
--- a/windows/keycredentiallink/utils/DateTime.go
+++ b/windows/keycredentiallink/utils/DateTime.go
@@ -106,7 +106,11 @@ func (dt *DateTime) SetTicks(ticks uint64) {
 
 	secondsFromUnixEpoch := int64(secondsSince1601) - int64(ticksBetween1601AndUnix/ticksPerSecond)
 
-	dt.time = time.Unix(secondsFromUnixEpoch, int64(remainderTicks)*100)
+	// The result is normalised to UTC to match SetTime, which stores a UTC value:
+	// time.Unix returns a Time in the machine's local zone, which would otherwise
+	// make the zone of a DateTime depend on how it was populated, and Describe
+	// prints these values under a label that says UTC.
+	dt.time = time.Unix(secondsFromUnixEpoch, int64(remainderTicks)*100).UTC()
 }
 
 // GetTicks returns the number of 100-nanosecond intervals (ticks) stored in the DateTime instance.

--- a/windows/keycredentiallink/utils/DateTime_test.go
+++ b/windows/keycredentiallink/utils/DateTime_test.go
@@ -332,3 +332,47 @@ func TestDateTime_SetTicks_SubSecondPrecision(t *testing.T) {
 		t.Errorf("GetTime() = %s, want %s", dt.GetTime().UTC(), expected)
 	}
 }
+
+// withNonUTCLocalZone points time.Local at a fixed offset for the duration of a
+// test. The defect these tests cover is invisible on a UTC host — which is what CI
+// runs — because the local zone and UTC then coincide, so the zone has to be pinned
+// for the assertions to mean anything.
+func withNonUTCLocalZone(t *testing.T) {
+	t.Helper()
+
+	original := time.Local
+	time.Local = time.FixedZone("TEST", 2*60*60)
+	t.Cleanup(func() { time.Local = original })
+}
+
+// A DateTime must report the same zone however it was populated: SetTime stores a
+// UTC value, and time.Unix inside SetTicks returns a local-zone one, so a decoded
+// timestamp used to print with the collector's offset under Describe's "(UTC)" label.
+func TestDateTime_SetTicks_StoresUTC(t *testing.T) {
+	withNonUTCLocalZone(t)
+
+	dt := utils.DateTime{}
+	dt.SetTicks(132918192030000000) // 2022-03-15 12:00:03 UTC
+
+	if zone, offset := dt.GetTime().Zone(); offset != 0 {
+		t.Errorf("SetTicks stored zone %s with offset %d, want UTC (offset 0)", zone, offset)
+	}
+
+	if got, want := dt.String(), "2022-03-15 12:00:03 +0000 UTC"; got != want {
+		t.Errorf("String() = %q, want %q", got, want)
+	}
+}
+
+// SetTicks and SetTime must agree on the zone for the same instant.
+func TestDateTime_SetTicksAndSetTimeAgreeOnZone(t *testing.T) {
+	withNonUTCLocalZone(t)
+
+	viaTicks := utils.DateTime{}
+	viaTicks.SetTicks(132918192030000000)
+
+	viaTime := utils.NewDateTimeFromTime(viaTicks.GetTime())
+
+	if viaTicks.String() != viaTime.String() {
+		t.Errorf("SetTicks gave %q, SetTime gave %q for the same instant", viaTicks.String(), viaTime.String())
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #1114`

### Root Cause
`SetTicks` built its `time.Time` with `time.Unix`, which is documented to return a value in the machine's local location, and stored it without normalising. `SetTime`, the other mutator that derives the pair, normalises with `t.UTC()` before storing. The zone of a `DateTime` therefore depended on which mutator had populated it, and `String()` formats whatever zone the stored value happens to carry.

Nothing in the package's tests could see this: they compare instants with `time.Time.Equal`, which ignores the zone, and CI runs in UTC where the local zone and UTC coincide. The defect is only visible to a caller running off-UTC — which is every operator collecting from a workstation in a non-UTC timezone.

### Fix Description
`SetTicks` now normalises the value it stores:

```go
dt.time = time.Unix(secondsFromUnixEpoch, int64(remainderTicks)*100).UTC()
```

This makes the two mutators agree, and makes `Describe`'s `LastLogonTime (UTC)` and `CreationTime (UTC)` labels truthful, since they print `String()` on the value the decode path produced.

Changing `String()` to format `dt.time.UTC()` instead was considered and rejected: it would hide the inconsistency at one call site while leaving `GetTime()` returning a local-zone value to every other caller. Normalising at the point of storage fixes it for all of them, and `ToUniversalTime()` keeps working as before.

### How Verified
Runtime, on a host in `Europe/Paris`, decoding the FILETIME the package's own test data uses for 2022-03-15 12:00:03 UTC.

Before:

```
decoded via SetTicks: 2022-03-15 13:00:03 +0100 CET
built   via SetTime : 2022-03-15 12:00:03 +0000 UTC
```

After, both print `2022-03-15 12:00:03 +0000 UTC`.

`go build ./...` and `go test ./...` are green.

The new tests pin `time.Local` to a fixed non-UTC offset for their duration, because the defect is invisible on a UTC host — which is what CI runs — and would otherwise pass unfixed there. Verified both ways under `TZ=UTC`: without the fix they fail with `SetTicks stored zone TEST with offset 7200, want UTC (offset 0)` and `String() = "2022-03-15 14:00:03 +0200 TEST"`; with the fix they pass. The existing tests compare instants with `Equal` and cannot detect a zone difference at all.

### Test Coverage
**Added** in `windows/keycredentiallink/utils/DateTime_test.go`:
- `TestDateTime_SetTicks_StoresUTC` — asserts the stored zone offset is 0 and that `String()` renders the expected UTC text.
- `TestDateTime_SetTicksAndSetTimeAgreeOnZone` — the two mutators produce the same rendering for the same instant.

### Scope of Change
- **Files changed:** `windows/keycredentiallink/utils/DateTime.go`, `windows/keycredentiallink/utils/DateTime_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none. The instant represented is unchanged; only the zone attached to it is normalised, and every existing comparison uses `Equal`, which is zone-independent.

### Risk and Rollout
One call to `.UTC()`. A caller that relied on `GetTime()` returning local time would see UTC instead, which is the documented intent of the field and what the other mutator already did. Safe to merge without staged rollout.

### Notes
Builds on #1113, which rewrote the arithmetic on this same line.
