### PR TITLE
Fix DateTime.Unmarshal leaving the time at its zero value (Fixes #1115)

### DIFF
--- a/windows/keycredentiallink/utils/DateTime.go
+++ b/windows/keycredentiallink/utils/DateTime.go
@@ -205,6 +205,10 @@ func (dt *DateTime) Unmarshal(data []byte) error {
 	if len(data) != 8 {
 		return fmt.Errorf("invalid data length: %d", len(data))
 	}
-	dt.ticks = binary.LittleEndian.Uint64(data)
+	// Routed through SetTicks so the derived time field is recomputed with the tick
+	// count: assigning dt.ticks alone leaves the two fields describing different
+	// instants, and every other mutator in this file maintains the pair.
+	dt.SetTicks(binary.LittleEndian.Uint64(data))
+
 	return nil
 }

--- a/windows/keycredentiallink/utils/DateTime_test.go
+++ b/windows/keycredentiallink/utils/DateTime_test.go
@@ -376,3 +376,31 @@ func TestDateTime_SetTicksAndSetTimeAgreeOnZone(t *testing.T) {
 		t.Errorf("SetTicks gave %q, SetTime gave %q for the same instant", viaTicks.String(), viaTime.String())
 	}
 }
+
+// Unmarshal has to leave the DateTime in the same state as SetTicks with the same
+// tick count: assigning only the ticks left the time accessors reporting the zero
+// time for a perfectly valid timestamp.
+func TestDateTime_Unmarshal_SetsTheTime(t *testing.T) {
+	data := []byte{0x80, 0xa3, 0x22, 0x34, 0x64, 0x38, 0xd8, 0x01} // 2022-03-15 12:00:03 UTC
+
+	dt := utils.DateTime{}
+	if err := dt.Unmarshal(data); err != nil {
+		t.Fatalf("Unmarshal() error = %v, want nil", err)
+	}
+
+	expected := time.Date(2022, 3, 15, 12, 0, 3, 0, time.UTC)
+	if !dt.GetTime().UTC().Equal(expected) {
+		t.Errorf("GetTime() = %s, want %s", dt.GetTime().UTC(), expected)
+	}
+
+	if dt.GetTicks() != 132918192030000000 {
+		t.Errorf("GetTicks() = %d, want 132918192030000000", dt.GetTicks())
+	}
+
+	// The two fields must describe the same instant, whichever mutator was used.
+	viaSetTicks := utils.DateTime{}
+	viaSetTicks.SetTicks(dt.GetTicks())
+	if !dt.GetTime().Equal(viaSetTicks.GetTime()) {
+		t.Errorf("Unmarshal gave time %s, SetTicks gave %s for the same ticks", dt.GetTime(), viaSetTicks.GetTime())
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #1115`

### Root Cause
`DateTime` carries a derived pair: the tick count and the `time.Time` it denotes. Every mutator in the file maintains both — `SetTicks` writes both, `SetTime` writes both, `NewDateTimeFromTicks` writes both — except `Unmarshal`, which assigned `dt.ticks` directly and left `dt.time` at its zero value. A value populated by `Unmarshal` therefore reported the correct ticks and the year 1 through `GetTime()`, `String()` and `ToUniversalTime()`.

The existing tests at `DateTime_test.go:99` and `:113` call `Unmarshal` and assert only on the returned error and on `GetTicks()`, so nothing exercised the field the function forgot to set.

### Fix Description
`Unmarshal` now routes the decoded value through `SetTicks`, which is the single place the derived time is computed:

```go
dt.SetTicks(binary.LittleEndian.Uint64(data))
```

Assigning both fields inline in `Unmarshal` was rejected: it would duplicate the epoch arithmetic that `SetTicks` already owns, which is exactly how the two got out of step.

### How Verified
Runtime, on the FILETIME the package's test data uses for 2022-03-15 12:00:03 UTC.

Before:

```
after Unmarshal: ticks=132918192030000000 String()="0001-01-01 00:00:00 +0000 UTC"
```

After:

```
after Unmarshal: ticks=132918192030000000 String()="2022-03-15 12:00:03 +0000 UTC"
```

`go build ./...` and `go test ./...` are green, including the existing `TestDateTime_Unmarshal` subtests.

### Test Coverage
**Added** in `windows/keycredentiallink/utils/DateTime_test.go`: `TestDateTime_Unmarshal_SetsTheTime` — asserts the decoded time, the decoded ticks, and that the instant matches what `SetTicks` produces from the same tick count.

### Scope of Change
- **Files changed:** `windows/keycredentiallink/utils/DateTime.go`, `windows/keycredentiallink/utils/DateTime_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none. The tick count decoded is identical; only the previously-unset time field is now populated.

### Risk and Rollout
Local to `Unmarshal`, which has no caller inside the repository — the blob parse path uses `ConvertFromBinaryTime`. Nothing can regress from a field that was previously left at its zero value now holding the right one.
