### PR TITLE
Fix NewDateTimeFromTicks computing the current tick count from an int64 overflow (Fixes #1111)

### DIFF
--- a/windows/keycredentiallink/utils/DateTime.go
+++ b/windows/keycredentiallink/utils/DateTime.go
@@ -50,11 +50,13 @@ func NewDateTimeFromTicks(ticks uint64) DateTime {
 		// that can be before a caller-captured timestamp taken immediately
 		// before invoking this function (due to 100ns truncation flooring).
 		now := time.Now().UTC()
-		epoch1601 := time.Date(1601, 1, 1, 0, 0, 0, 0, time.UTC)
-		// Use signed arithmetic to correctly support times before 1970.
-		nsSince1601 := now.UnixNano() - epoch1601.UnixNano()
+		// The offset is added from the ticksBetween1601AndUnix constant rather than
+		// derived by subtracting the UnixNano() of 1601, which is undefined: 1601 is
+		// 11.6e18 nanoseconds before the Unix epoch, past the int64 that UnixNano()
+		// returns, so that subtraction operated on a wrapped value and produced a
+		// tick count roughly 137 times too large.
 		dt.time = now
-		dt.ticks = uint64(nsSince1601 / 100)
+		dt.ticks = ticksBetween1601AndUnix + uint64(now.UnixNano()/100)
 	} else {
 		dt.SetTicks(ticks)
 	}

--- a/windows/keycredentiallink/utils/DateTime_test.go
+++ b/windows/keycredentiallink/utils/DateTime_test.go
@@ -404,3 +404,37 @@ func TestDateTime_Unmarshal_SetsTheTime(t *testing.T) {
 		t.Errorf("Unmarshal gave time %s, SetTicks gave %s for the same ticks", dt.GetTime(), viaSetTicks.GetTime())
 	}
 }
+
+// The current-time branch must produce the same tick count SetTime derives for that
+// instant. It used to subtract the UnixNano() of 1601, which is undefined, and the
+// resulting ticks were written into blobs as an invalid FILETIME.
+func TestNewDateTimeFromTicks_NowBranchTicksMatchSetTime(t *testing.T) {
+	dt := utils.NewDateTimeFromTicks(0)
+
+	viaSetTime := utils.NewDateTimeFromTime(dt.GetTime())
+
+	// SetTime truncates to 100ns, so allow the single tick that truncation can drop.
+	diff := int64(dt.GetTicks()) - int64(viaSetTime.GetTicks())
+	if diff < 0 || diff > 1 {
+		t.Errorf("now-branch ticks = %d, SetTime ticks = %d (difference %d, want 0 or 1)",
+			dt.GetTicks(), viaSetTime.GetTicks(), diff)
+	}
+
+	if dt.GetTicks() > 1<<63-1 {
+		t.Errorf("ticks = %d exceeds the int64 range, which indicates an overflowed conversion", dt.GetTicks())
+	}
+}
+
+// The tick count the branch produces has to round-trip as a FILETIME, since
+// ToKeyCredentialLinkBlob writes it into the blob's timestamp entries verbatim.
+func TestNewDateTimeFromTicks_NowBranchRoundTripsAsFiletime(t *testing.T) {
+	dt := utils.NewDateTimeFromTicks(0)
+
+	readBack := utils.DateTime{}
+	readBack.SetTicks(dt.GetTicks())
+
+	if delta := readBack.GetTime().Sub(dt.GetTime()); delta > time.Microsecond || delta < -time.Microsecond {
+		t.Errorf("a FILETIME reader sees %s for a value written at %s (off by %s)",
+			readBack.GetTime().UTC(), dt.GetTime().UTC(), delta)
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #1111`

### Root Cause
The `ticks == 0` branch of `NewDateTimeFromTicks` derived the tick count by subtracting one epoch's `UnixNano()` from another: `now.UnixNano() - epoch1601.UnixNano()`. `time.Time.UnixNano()` is documented as undefined outside 1678–2262, and 1601-01-01 is 11644473600000000000 nanoseconds before the Unix epoch against an `int64` limit of 9223372036854775807. The subtraction therefore operated on a wrapped value, and the branch produced a tick count roughly 137 times too large — one that does not even fit in an `int64`.

`SetTime` performs the same conversion correctly a few lines below by *adding* the `ticksBetween1601AndUnix` constant, so the file already contained the right way to do it. The branch reached for `time.Time` arithmetic instead of the constant, and the constant exists precisely because that arithmetic does not work at this epoch.

The error was invisible in practice because `SetTicks` overflowed in the inverse direction, so a value written by this branch and read back through the same package returned approximately the original wall-clock time. Only a consumer treating the field as a real FILETIME — that is, anything outside this package — saw the corruption. It also survived in the tests because `TestNewDateTimeFromTime` computes its own expected value with the same overflowing expression, and the two wraps cancel exactly.

### Fix Description
The branch now derives the ticks from the constant, matching `SetTime`:

```go
dt.time = now
dt.ticks = ticksBetween1601AndUnix + uint64(now.UnixNano()/100)
```

`dt.time` is still assigned the untruncated `now`, preserving the documented intent of the original comment — a caller who captures a timestamp immediately before the call must not get back a value that precedes it — which routing the whole branch through `SetTime` would have broken by truncating to 100ns.

### How Verified
Runtime, before and after.

Before:

```
time                 : 2026-09-07 08:56:03.16529824 +0000 UTC
ticks via now-branch : 18396609082604109083
ticks via SetTime    : 134332449631652982
exceeds int64 max    : true
```

After, the two tick counts agree to within the single tick that `SetTime`'s 100ns truncation can drop, and the value is inside the `int64` range.

The wire consequence, which is the reason this is the highest-severity of the batch — `ComposeKeyCredentialLinkForComputer` builds both blob timestamps with `NewDateTimeFromTicks(0)` and `ToKeyCredentialLinkBlob` writes them with `DateTime.Marshal()`:

```
before: blob timestamp entry bytes = af3062de7de24dff   (high byte 0xff)
after : blob timestamp entry bytes = 67a1e9f6a93edd01   (high byte 0x01, as every valid modern FILETIME has)
```

(The two runs are at different instants, so the low bytes differ; the high byte is the tell.)

The new tests spell the impact out when run against the unfixed code, decoding the emitted tick count the way an external reader would:

```
a FILETIME reader sees 59897-07-14 15:20:57.3438673 +0000 UTC
for a value written at 2026-09-07 09:19:20.098257315 +0000 UTC (off by 2562047h47m16s)
now-branch ticks = 18396609096573438134, SetTime ticks = 134332463600982033
```

After the fix the same reader sees the instant the value was written at, and the bytes emitted are byte-identical to what `SetTime` derives for it.

`go build ./...` and `go test ./...` are green, including `TestNewDateTime/with_zero_ticks_should_set_current_time`, which asserts the branch still returns the current instant.

### Test Coverage
**Added** in `windows/keycredentiallink/utils/DateTime_test.go`:
- `TestNewDateTimeFromTicks_NowBranchTicksMatchSetTime` — the branch's tick count matches what `SetTime` derives for the same instant, and does not exceed the `int64` range.
- `TestNewDateTimeFromTicks_NowBranchRoundTripsAsFiletime` — reading the produced tick count back as a FILETIME yields the instant it was written at, which is what an external reader of `msDS-KeyCredentialLink` does.

### Scope of Change
- **Files changed:** `windows/keycredentiallink/utils/DateTime.go`, `windows/keycredentiallink/utils/DateTime_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none. The instant returned is unchanged; only the tick count derived from it is corrected.

### Risk and Rollout
Local to one branch of one constructor. Blobs written after this change carry a valid FILETIME where they previously carried a wrapped one, so a credential written by an older build and read by a newer one shows the old bogus timestamp — the timestamps are informational and are not part of the KeyID or of the authentication path, so this does not affect whether an existing credential works.

### Notes
`SetTime` at the same file has the same `UnixNano()` range limitation for a caller-supplied date before 1678; that is not reachable from any current caller and is left alone here. `TestNewDateTimeFromTime`'s expected-value computation still uses the overflowing expression; it produces the correct number through two cancelling wraps, and the `ticksFromTime` helper already in that file is the correct way to compute it.
