### PR TITLE
Fix a zero timestamp entry decoding to the current time (Fixes #1109)

### DIFF
--- a/windows/keycredentiallink/utils/DateTime.go
+++ b/windows/keycredentiallink/utils/DateTime.go
@@ -64,6 +64,24 @@ func NewDateTimeFromTicks(ticks uint64) DateTime {
 	return dt
 }
 
+// dateTimeFromWireTicks builds a DateTime from a tick count read off the wire.
+//
+// Unlike NewDateTimeFromTicks, a zero tick count is decoded as the epoch it
+// denotes, 1601-01-01, rather than being overloaded to mean the current time: a
+// zero timestamp entry is a well-formed value a blob can legitimately carry, and
+// decoding it must not consult the clock.
+//
+// Parameters:
+// - ticks: A uint64 value representing the number of 100-nanosecond intervals since 1601-01-01 00:00:00 UTC.
+//
+// Returns:
+// - A DateTime object for the given tick count.
+func dateTimeFromWireTicks(ticks uint64) DateTime {
+	dt := DateTime{}
+	dt.SetTicks(ticks)
+	return dt
+}
+
 // NewDateTimeFromTime initializes a new DateTime instance from a time.Time object.
 //
 // Parameters:

--- a/windows/keycredentiallink/utils/utils.go
+++ b/windows/keycredentiallink/utils/utils.go
@@ -83,8 +83,8 @@ func ConvertFromBinaryIdentifier(keyIdentifier []byte, kcv version.KeyCredential
 // - A time.Time object representing the converted time.
 //
 // Note:
-// The function currently treats all versions and sources the same way, converting the binary
-// timestamp directly to a Unix time in nanoseconds.
+// The function currently treats all versions and sources the same way, decoding the binary
+// timestamp as a count of 100-nanosecond intervals since 1601-01-01 00:00:00 UTC.
 //
 // Src : https://github.com/microsoft/referencesource/blob/master/mscorlib/system/datetime.cs
 func ConvertFromBinaryTime(rawBinaryTime []byte, ksrc source.KeySource, kcv version.KeyCredentialLinkVersion) DateTime {
@@ -92,20 +92,20 @@ func ConvertFromBinaryTime(rawBinaryTime []byte, ksrc source.KeySource, kcv vers
 
 	switch kcv.Value {
 	case version.KeyCredentialLinkVersion_0, version.KeyCredentialLinkVersion_1:
-		return NewDateTimeFromTicks(uint64(timeStamp))
+		return dateTimeFromWireTicks(timeStamp)
 	case version.KeyCredentialLinkVersion_2:
 		if ksrc.Value == source.KeySource_AD {
-			return NewDateTimeFromTicks(uint64(timeStamp))
+			return dateTimeFromWireTicks(timeStamp)
 		} else {
 			// This is not fully supported right now, you may encounter issues.
-			return NewDateTimeFromTicks(uint64(timeStamp))
+			return dateTimeFromWireTicks(timeStamp)
 		}
 	default:
 		if ksrc.Value == source.KeySource_AD {
-			return NewDateTimeFromTicks(uint64(timeStamp))
+			return dateTimeFromWireTicks(timeStamp)
 		} else {
 			// This is not fully supported right now, you may encounter issues.
-			return NewDateTimeFromTicks(uint64(timeStamp))
+			return dateTimeFromWireTicks(timeStamp)
 		}
 	}
 }

--- a/windows/keycredentiallink/utils/utils_test.go
+++ b/windows/keycredentiallink/utils/utils_test.go
@@ -228,3 +228,44 @@ func TestBinaryTimeInvolution(t *testing.T) {
 		})
 	}
 }
+
+// A timestamp entry of eight zero bytes is a well-formed FILETIME denoting
+// 1601-01-01, so decoding it must not consult the clock. It used to come back as
+// the moment of the call, because the decoder went through NewDateTimeFromTicks,
+// whose zero argument is overloaded to mean "now".
+func TestConvertFromBinaryTime_ZeroIsTheEpochNotNow(t *testing.T) {
+	raw := make([]byte, 8)
+
+	for _, kcv := range []version.KeyCredentialLinkVersion{
+		{Value: version.KeyCredentialLinkVersion_0},
+		{Value: version.KeyCredentialLinkVersion_1},
+		{Value: version.KeyCredentialLinkVersion_2},
+	} {
+		decoded := utils.ConvertFromBinaryTime(raw, source.KeySource{Value: source.KeySource_AD}, kcv)
+
+		expected := time.Date(1601, 1, 1, 0, 0, 0, 0, time.UTC)
+		if !decoded.GetTime().UTC().Equal(expected) {
+			t.Errorf("version %d: decoded %s, want %s", kcv.Value, decoded.GetTime().UTC(), expected)
+		}
+
+		if decoded.GetTicks() != 0 {
+			t.Errorf("version %d: ticks = %d, want 0", kcv.Value, decoded.GetTicks())
+		}
+
+		if delta := time.Since(decoded.GetTime()); delta < time.Minute {
+			t.Errorf("version %d: decoded a value %s from now, which means the clock was consulted", kcv.Value, delta)
+		}
+	}
+}
+
+// The constructor keeps its documented overload: callers that build a credential
+// pass zero to mean the current time, and that must stay separate from decoding.
+func TestNewDateTimeFromTicks_ZeroStillMeansNow(t *testing.T) {
+	before := time.Now()
+	dt := utils.NewDateTimeFromTicks(0)
+	after := time.Now()
+
+	if dt.GetTime().Before(before) || dt.GetTime().After(after) {
+		t.Errorf("NewDateTimeFromTicks(0) = %s, want an instant between %s and %s", dt.GetTime(), before, after)
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #1109`

### Root Cause
`NewDateTimeFromTicks` overloads a zero argument to mean "the current time". That is a documented and deliberate constructor convenience — `ComposeKeyCredentialLinkForComputer` relies on it to mean "now" — but every branch of `ConvertFromBinaryTime` used that same constructor to decode a value read off the wire, where zero is a legitimate encoding: a FILETIME of zero denotes 1601-01-01, and an unset timestamp entry carries exactly that.

The decoder therefore could not distinguish a blob recording no timestamp from a caller asking for the clock, and reported a timestamp the directory does not hold — with the fabricated value being the time of collection, which looks plausible to whoever reads the output.

### Fix Description
Decoding no longer goes through the overloaded constructor. A new unexported `dateTimeFromWireTicks` builds a `DateTime` from a tick count with no special case, by calling `SetTicks`:

```go
func dateTimeFromWireTicks(ticks uint64) DateTime {
	dt := DateTime{}
	dt.SetTicks(ticks)
	return dt
}
```

and the five call sites in `ConvertFromBinaryTime` use it. A zero timestamp now decodes to 1601-01-01, the epoch it denotes.

`NewDateTimeFromTicks` keeps its overload: it is exported, documented, tested, and its constructor callers depend on it. Removing the overload instead would have been the larger change and would have broken `ComposeKeyCredentialLinkForComputer`'s use of it. Separating the decode path from the constructor is what the defect actually calls for — a decoder must never consult the clock.

The stale note on `ConvertFromBinaryTime` claiming it converts "directly to a Unix time in nanoseconds" is corrected to say what it decodes, since that wording described neither the old behaviour nor the new.

### How Verified
Runtime, on a timestamp entry of eight zero bytes.

Before:

```
ConvertFromBinaryTime(00*8) -> 2026-09-07 08:49:26.427098785 +0000 UTC
```

After:

```
ConvertFromBinaryTime(00*8) -> 1601-01-01 00:00:00 +0000 UTC
```

`go build ./...` and `go test ./...` are green, including `TestNewDateTime/with_zero_ticks_should_set_current_time`, which asserts the constructor's overload is untouched, and `TestBinaryTimeInvolution`, which round-trips through this function.

### Test Coverage
**Added** in `windows/keycredentiallink/utils/utils_test.go`: `TestConvertFromBinaryTime_ZeroIsTheEpochNotNow` — a zero timestamp decodes to 1601-01-01 and to zero ticks, and is not within a minute of the current time. Also asserts `NewDateTimeFromTicks(0)` still returns the current instant, so the split between the two behaviours stays deliberate rather than drifting.

### Scope of Change
- **Files changed:** `windows/keycredentiallink/utils/utils.go`, `windows/keycredentiallink/utils/DateTime.go`, `windows/keycredentiallink/utils/utils_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none. Non-zero timestamps decode exactly as before, and the exported constructor's behaviour is unchanged.

### Risk and Rollout
A blob carrying a zero timestamp now describes as 1601-01-01 instead of the collection time. That is the correction; any consumer that treated the old value as real was reading a fabricated one.

### Notes
Depends on #1113 and #1114 for `SetTicks` to decode the full tick range in UTC.
