### PR TITLE
Fix ConvertToBinaryTime encoding Unix nanoseconds instead of FILETIME ticks (Fixes #1112)

### DIFF
--- a/windows/keycredentiallink/utils/utils.go
+++ b/windows/keycredentiallink/utils/utils.go
@@ -121,25 +121,29 @@ func ConvertFromBinaryTime(rawBinaryTime []byte, ksrc source.KeySource, kcv vers
 // - A byte slice containing the binary representation of the time in little-endian format.
 //
 // Note:
-// The function currently treats all versions and sources the same way, converting the time
-// directly to a Unix time in nanoseconds and then encoding it in little-endian format.
+// The function currently treats all versions and sources the same way, encoding the time as a
+// count of 100-nanosecond intervals since 1601-01-01 00:00:00 UTC in little-endian format,
+// which is the representation ConvertFromBinaryTime decodes.
 func ConvertToBinaryTime(date time.Time, ksrc source.KeySource, kcv version.KeyCredentialLinkVersion) []byte {
-	timeStamp := date.UnixNano()
+	// The field holds ticks since 1601, not nanoseconds since 1970. Deriving them
+	// through NewDateTimeFromTime keeps this function the exact inverse of
+	// ConvertFromBinaryTime instead of an encoder for a different representation.
+	timeStamp := NewDateTimeFromTime(date).ToTicks()
 
 	switch kcv.Value {
 	case version.KeyCredentialLinkVersion_0, version.KeyCredentialLinkVersion_1:
-		return binary.LittleEndian.AppendUint64(nil, uint64(timeStamp))
+		return binary.LittleEndian.AppendUint64(nil, timeStamp)
 	case version.KeyCredentialLinkVersion_2:
 		if ksrc.Value == source.KeySource_AD {
-			return binary.LittleEndian.AppendUint64(nil, uint64(timeStamp))
+			return binary.LittleEndian.AppendUint64(nil, timeStamp)
 		} else {
-			return binary.LittleEndian.AppendUint64(nil, uint64(timeStamp))
+			return binary.LittleEndian.AppendUint64(nil, timeStamp)
 		}
 	default:
 		if ksrc.Value == source.KeySource_AD {
-			return binary.LittleEndian.AppendUint64(nil, uint64(timeStamp))
+			return binary.LittleEndian.AppendUint64(nil, timeStamp)
 		} else {
-			return binary.LittleEndian.AppendUint64(nil, uint64(timeStamp))
+			return binary.LittleEndian.AppendUint64(nil, timeStamp)
 		}
 	}
 }

--- a/windows/keycredentiallink/utils/utils_test.go
+++ b/windows/keycredentiallink/utils/utils_test.go
@@ -3,6 +3,7 @@ package utils_test
 import (
 	"bytes"
 	"encoding/base64"
+	"encoding/hex"
 	"testing"
 	"time"
 
@@ -93,32 +94,31 @@ func TestConvertFromBinaryTime(t *testing.T) {
 	}
 }
 
+// The encoder has to emit the FILETIME the field holds. This test previously called
+// only ConvertFromBinaryTime despite its name, which is why the encoder emitting
+// Unix nanoseconds went unnoticed.
 func TestConvertToBinaryTime(t *testing.T) {
-	// Create test timestamp (2022-03-15 12:00:03 UTC)
-	testTimeBytes := []byte{0x80, 0xa3, 0x22, 0x34, 0x64, 0x38, 0xd8, 0x01}
+	// 2022-03-15 12:00:03 UTC, and the bytes Windows writes for it.
 	testTimeStruct := time.Date(2022, 3, 15, 12, 0, 3, 0, time.UTC)
+	testTimeBytes := []byte{0x80, 0xa3, 0x22, 0x34, 0x64, 0x38, 0xd8, 0x01}
 
 	testCases := []struct {
 		name    string
-		input   []byte
 		source  source.KeySource
 		version version.KeyCredentialLinkVersion
 	}{
 		{
 			name:    "Version 0 AD source",
-			input:   testTimeBytes,
 			source:  source.KeySource{Value: source.KeySource_AD},
 			version: version.KeyCredentialLinkVersion{Value: version.KeyCredentialLinkVersion_0},
 		},
 		{
 			name:    "Version 1 AD source",
-			input:   testTimeBytes,
 			source:  source.KeySource{Value: source.KeySource_AD},
 			version: version.KeyCredentialLinkVersion{Value: version.KeyCredentialLinkVersion_1},
 		},
 		{
 			name:    "Version 2 AD source",
-			input:   testTimeBytes,
 			source:  source.KeySource{Value: source.KeySource_AD},
 			version: version.KeyCredentialLinkVersion{Value: version.KeyCredentialLinkVersion_2},
 		},
@@ -126,9 +126,17 @@ func TestConvertToBinaryTime(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			converted := utils.ConvertFromBinaryTime(tc.input, tc.source, tc.version)
-			if !converted.GetTime().Equal(testTimeStruct) {
-				t.Errorf("Time conversion mismatch. \n | Expected '%v'\n | utils.ConvertToBinaryTime(_) = %v\n | final decoded time '%v'", testTimeStruct, tc.input, converted.GetTime())
+			encoded := utils.ConvertToBinaryTime(testTimeStruct, tc.source, tc.version)
+
+			if !bytes.Equal(encoded, testTimeBytes) {
+				t.Errorf("ConvertToBinaryTime() = %s, want %s (the FILETIME Windows writes)",
+					hex.EncodeToString(encoded), hex.EncodeToString(testTimeBytes))
+			}
+
+			// The two functions are named as inverses and have to behave as such.
+			decoded := utils.ConvertFromBinaryTime(encoded, tc.source, tc.version)
+			if !decoded.GetTime().Equal(testTimeStruct) {
+				t.Errorf("round-trip gave %v, want %v", decoded.GetTime(), testTimeStruct)
 			}
 		})
 	}


### PR DESCRIPTION
### Linked Issue
`Closes #1112`

### Root Cause
`ConvertToBinaryTime` was written against `time.Time.UnixNano()` — nanoseconds since 1970 — while the field it encodes holds a FILETIME, a count of 100-nanosecond intervals since 1601, which is what its counterpart `ConvertFromBinaryTime` decodes. Neither the unit nor the epoch matched, so the two functions were inverses by name only: a value encoded and decoded by this package came back 122 years later than it went in.

The defect survived because it had no test. `TestConvertToBinaryTime` never called `ConvertToBinaryTime`: its body only exercised `ConvertFromBinaryTime` on hardcoded bytes, so the encoder had no coverage at all despite a test named after it.

### Fix Description
The encoder now derives the tick count the same way the rest of the package does, through `NewDateTimeFromTime`, which owns the epoch arithmetic:

```go
timeStamp := NewDateTimeFromTime(date).ToTicks()
```

and the five return sites emit that value directly rather than casting a signed nanosecond count. Computing the ticks inline was rejected — that arithmetic already exists in `SetTime` and duplicating it is how the file's two conversion paths drifted apart in the first place.

`TestConvertToBinaryTime` is rewritten to actually call the function under test, since leaving it as it was would let a corrected encoder go untested again.

### How Verified
Runtime, against the FILETIME Windows writes for the test instant.

Before, from the rewritten test run against the unfixed encoder:

```
ConvertToBinaryTime() = 00de1d11198cdc16, want 80a322346438d801 (the FILETIME Windows writes)
round-trip gave 6821-03-26 00:05:00 +0000 UTC, want 2022-03-15 12:00:03 +0000 UTC
```

After, `ConvertToBinaryTime` emits `80a322346438d801` — byte-identical to the Windows value already used as test data in this file — and the round trip returns 2022-03-15 12:00:03 UTC.

(The round trip lands in 6821 rather than the 2144 seen when this was first reported: #1113 has since corrected `SetTicks`, so the Unix-nanosecond value the encoder emitted is now decoded at its true FILETIME magnitude instead of a wrapped one. The encoder's output is unchanged; only the decoder reporting it improved.)

`go build ./...` and `go test ./...` are green.

### Test Coverage
**Added / modified** in `windows/keycredentiallink/utils/utils_test.go`: `TestConvertToBinaryTime` now calls `ConvertToBinaryTime`, asserts the output is byte-equal to the Windows FILETIME for that instant, and asserts the round trip through `ConvertFromBinaryTime` returns the original time — for each of the three versions the switch distinguishes.

### Scope of Change
- **Files changed:** `windows/keycredentiallink/utils/utils.go`, `windows/keycredentiallink/utils/utils_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none.

### Risk and Rollout
The function has no caller inside the repository — the write path goes through `DateTime.Marshal()`, which was already correct — so nothing in the current codebase changes behaviour. The change matters for the next caller that reaches for it by name.

### Notes
Depends on #1113 and #1114 for the decode side. The `switch` in both `Convert*BinaryTime` functions has five arms with identical bodies; that redundancy is untouched here, being a readability matter rather than a defect.
