### PR TITLE
Fix ConvertFromBinaryTime panicking on a short buffer (Fixes #1117)

### DIFF
--- a/windows/keycredentiallink/KeyCredentialLink.go
+++ b/windows/keycredentiallink/KeyCredentialLink.go
@@ -307,9 +307,8 @@ func (kc *KeyCredentialLink) Unmarshal(data []byte) (int, error) {
 //
 // The KeySource entry is optional, and the entries of a blob are not guaranteed
 // to contain one even though it sorts before the timestamp entries, so an absent
-// source is decoded as the zero source instead of being dereferenced. The value
-// itself is a 64-bit integer, so a shorter one is a malformed entry rather than
-// something to decode.
+// source is decoded as the zero source instead of being dereferenced. A value too
+// short to hold a timestamp is reported by ConvertFromBinaryTime itself.
 //
 // Parameters:
 // - value: The raw value of the timestamp entry.
@@ -318,16 +317,15 @@ func (kc *KeyCredentialLink) Unmarshal(data []byte) (int, error) {
 // - A pointer to the decoded DateTime object.
 // - An error if the value cannot hold a timestamp.
 func (kc *KeyCredentialLink) parseBinaryTime(value []byte) (*utils.DateTime, error) {
-	if len(value) < 8 {
-		return nil, fmt.Errorf("malformed KeyCredentialLink: insufficient bytes for a timestamp (expected at least 8, got %d)", len(value))
-	}
-
 	keySource := source.KeySource{}
 	if kc.Source != nil {
 		keySource = *kc.Source
 	}
 
-	t := utils.ConvertFromBinaryTime(value, keySource, kc.Version)
+	t, err := utils.ConvertFromBinaryTime(value, keySource, kc.Version)
+	if err != nil {
+		return nil, fmt.Errorf("malformed KeyCredentialLink: %w", err)
+	}
 
 	return &t, nil
 }

--- a/windows/keycredentiallink/utils/utils.go
+++ b/windows/keycredentiallink/utils/utils.go
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/hex"
+	"fmt"
 	"strings"
 	"time"
 )
@@ -80,32 +81,40 @@ func ConvertFromBinaryIdentifier(keyIdentifier []byte, kcv version.KeyCredential
 // - version: The version of the KeyCredentialLink, which can affect the interpretation of the time.
 //
 // Returns:
-// - A time.Time object representing the converted time.
+// - A DateTime object representing the converted time.
+// - An error if the buffer cannot hold a 64-bit timestamp.
 //
 // Note:
 // The function currently treats all versions and sources the same way, decoding the binary
 // timestamp as a count of 100-nanosecond intervals since 1601-01-01 00:00:00 UTC.
 //
 // Src : https://github.com/microsoft/referencesource/blob/master/mscorlib/system/datetime.cs
-func ConvertFromBinaryTime(rawBinaryTime []byte, ksrc source.KeySource, kcv version.KeyCredentialLinkVersion) DateTime {
+func ConvertFromBinaryTime(rawBinaryTime []byte, ksrc source.KeySource, kcv version.KeyCredentialLinkVersion) (DateTime, error) {
+	// The value comes from a KEYCREDENTIALLINK_ENTRY whose length is whatever the
+	// entry declared, so a blob can parse into an entry too short to hold the
+	// field. Reading it unchecked indexes past the end of the slice.
+	if len(rawBinaryTime) < 8 {
+		return DateTime{}, fmt.Errorf("insufficient bytes for a timestamp (expected at least 8, got %d)", len(rawBinaryTime))
+	}
+
 	timeStamp := binary.LittleEndian.Uint64(rawBinaryTime)
 
 	switch kcv.Value {
 	case version.KeyCredentialLinkVersion_0, version.KeyCredentialLinkVersion_1:
-		return dateTimeFromWireTicks(timeStamp)
+		return dateTimeFromWireTicks(timeStamp), nil
 	case version.KeyCredentialLinkVersion_2:
 		if ksrc.Value == source.KeySource_AD {
-			return dateTimeFromWireTicks(timeStamp)
+			return dateTimeFromWireTicks(timeStamp), nil
 		} else {
 			// This is not fully supported right now, you may encounter issues.
-			return dateTimeFromWireTicks(timeStamp)
+			return dateTimeFromWireTicks(timeStamp), nil
 		}
 	default:
 		if ksrc.Value == source.KeySource_AD {
-			return dateTimeFromWireTicks(timeStamp)
+			return dateTimeFromWireTicks(timeStamp), nil
 		} else {
 			// This is not fully supported right now, you may encounter issues.
-			return dateTimeFromWireTicks(timeStamp)
+			return dateTimeFromWireTicks(timeStamp), nil
 		}
 	}
 }

--- a/windows/keycredentiallink/utils/utils_test.go
+++ b/windows/keycredentiallink/utils/utils_test.go
@@ -86,7 +86,10 @@ func TestConvertFromBinaryTime(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result := utils.ConvertFromBinaryTime(tc.input, tc.source, tc.version)
+			result, err := utils.ConvertFromBinaryTime(tc.input, tc.source, tc.version)
+			if err != nil {
+				t.Fatalf("ConvertFromBinaryTime() error = %v, want nil", err)
+			}
 			if !result.GetTime().Equal(tc.expected) {
 				t.Errorf("Expected %v, got %v", tc.expected, result.GetTime())
 			}
@@ -134,7 +137,10 @@ func TestConvertToBinaryTime(t *testing.T) {
 			}
 
 			// The two functions are named as inverses and have to behave as such.
-			decoded := utils.ConvertFromBinaryTime(encoded, tc.source, tc.version)
+			decoded, err := utils.ConvertFromBinaryTime(encoded, tc.source, tc.version)
+			if err != nil {
+				t.Fatalf("ConvertFromBinaryTime() error = %v, want nil", err)
+			}
 			if !decoded.GetTime().Equal(testTimeStruct) {
 				t.Errorf("round-trip gave %v, want %v", decoded.GetTime(), testTimeStruct)
 			}
@@ -215,7 +221,10 @@ func TestBinaryTimeInvolution(t *testing.T) {
 			}
 
 			// Convert binary back to time
-			result := utils.ConvertFromBinaryTime(binary, tc.source, tc.version)
+			result, err := utils.ConvertFromBinaryTime(binary, tc.source, tc.version)
+			if err != nil {
+				t.Fatalf("Failed to decode time: %v", err)
+			}
 
 			// Check if the final time matches the original
 			if !result.GetTime().Equal(dt.GetTime()) {
@@ -249,7 +258,10 @@ func TestConvertFromBinaryTime_ZeroIsTheEpochNotNow(t *testing.T) {
 		{Value: version.KeyCredentialLinkVersion_1},
 		{Value: version.KeyCredentialLinkVersion_2},
 	} {
-		decoded := utils.ConvertFromBinaryTime(raw, source.KeySource{Value: source.KeySource_AD}, kcv)
+		decoded, err := utils.ConvertFromBinaryTime(raw, source.KeySource{Value: source.KeySource_AD}, kcv)
+		if err != nil {
+			t.Fatalf("ConvertFromBinaryTime() error = %v, want nil", err)
+		}
 
 		expected := time.Date(1601, 1, 1, 0, 0, 0, 0, time.UTC)
 		if !decoded.GetTime().UTC().Equal(expected) {
@@ -276,4 +288,42 @@ func TestNewDateTimeFromTicks_ZeroStillMeansNow(t *testing.T) {
 	if dt.GetTime().Before(before) || dt.GetTime().After(after) {
 		t.Errorf("NewDateTimeFromTicks(0) = %s, want an instant between %s and %s", dt.GetTime(), before, after)
 	}
+}
+
+// The value of a timestamp entry is as long as the entry declared, so a blob can
+// parse into one too short to hold the field. Reading it used to index past the end
+// of the slice and panic.
+func TestConvertFromBinaryTime_ShortBuffer(t *testing.T) {
+	adSrc := source.KeySource{Value: source.KeySource_AD}
+	kcv := version.KeyCredentialLinkVersion{Value: version.KeyCredentialLinkVersion_2}
+
+	for _, test := range []struct {
+		name string
+		data []byte
+	}{
+		{name: "nil", data: nil},
+		{name: "empty", data: []byte{}},
+		{name: "one byte", data: []byte{0x01}},
+		{name: "seven bytes", data: []byte{1, 2, 3, 4, 5, 6, 7}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := utils.ConvertFromBinaryTime(test.data, adSrc, kcv); err == nil {
+				t.Errorf("ConvertFromBinaryTime(%d bytes) returned no error, want one", len(test.data))
+			}
+		})
+	}
+
+	t.Run("eight bytes still decodes", func(t *testing.T) {
+		data := []byte{0x80, 0xa3, 0x22, 0x34, 0x64, 0x38, 0xd8, 0x01}
+
+		decoded, err := utils.ConvertFromBinaryTime(data, adSrc, kcv)
+		if err != nil {
+			t.Fatalf("ConvertFromBinaryTime() error = %v, want nil", err)
+		}
+
+		expected := time.Date(2022, 3, 15, 12, 0, 3, 0, time.UTC)
+		if !decoded.GetTime().Equal(expected) {
+			t.Errorf("decoded %s, want %s", decoded.GetTime(), expected)
+		}
+	})
 }


### PR DESCRIPTION
### Linked Issue
`Closes #1117`

### Root Cause
`ConvertFromBinaryTime` read its 64-bit field with `binary.LittleEndian.Uint64`, which indexes the eighth byte unconditionally, and had no length check. Its input is a `KEYCREDENTIALLINK_ENTRY.Value`, whose length is whatever the entry's `Length` field declared, so a blob can legitimately parse into a timestamp entry whose value is shorter than the field — and the exported function had no way to say so, since it returned a bare `DateTime`.

The reachable form of this was fixed at the call site in #1107 by checking the length in `KeyCredentialLink.parseBinaryTime` before calling. That guard protected the package's own path but left the exported function itself unsafe for any other caller, and put the check in the wrong place: the function that reads the field is the one that knows how many bytes it needs.

### Fix Description
`ConvertFromBinaryTime` now returns `(DateTime, error)` and reports a short buffer itself:

```go
if len(rawBinaryTime) < 8 {
	return DateTime{}, fmt.Errorf("insufficient bytes for a timestamp (expected at least 8, got %d)", len(rawBinaryTime))
}
```

`KeyCredentialLink.parseBinaryTime` drops its own length check and wraps the returned error instead, so the message a caller sees is unchanged in substance and the check lives in exactly one place.

This is a breaking change to an exported signature, which is why the guard was placed at the call site in #1107 rather than here. It is the correct fix: the alternative — returning a zero `DateTime` for malformed input — would trade a panic for a silently wrong timestamp, which is worse for a value read off a directory object.

### How Verified
Runtime.

Before:

```go
utils.ConvertFromBinaryTime([]byte{1, 2, 3, 4}, adSrc, kcv2)
// panic: runtime error: index out of range [7] with length 4
```

After, the same call returns `insufficient bytes for a timestamp (expected at least 8, got 4)`.

End to end through the blob parser, the message a caller sees is unchanged from #1107:

```
ParseDNWithBinary error: malformed KeyCredentialLink: insufficient bytes for a timestamp (expected at least 8, got 4)
```

`go build ./...` and `go test ./...` are green, including `TestParseDNWithBinary_MalformedValues/truncated_last_logon_timestamp` from #1107, which asserts that path still returns an error.

### Test Coverage
**Added** in `windows/keycredentiallink/utils/utils_test.go`: `TestConvertFromBinaryTime_ShortBuffer` — nil, empty and seven-byte buffers each return an error rather than panicking, and an eight-byte buffer still decodes.

**Existing:** `TestParseDNWithBinary_MalformedValues` in `windows/keycredentiallink/KeyCredentialLink_test.go` covers the call site, and `TestBinaryTimeInvolution` plus `TestConvertFromBinaryTime` cover the success path with the new signature.

### Scope of Change
- **Files changed:** `windows/keycredentiallink/utils/utils.go`, `windows/keycredentiallink/utils/utils_test.go`, `windows/keycredentiallink/KeyCredentialLink.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none. The signature change is the fix; the only in-repo caller is updated in the same commit and its observable error message is unchanged.

### Risk and Rollout
Breaking change to one exported function. Every in-repo caller is updated in this commit and the build is green, so the blast radius inside the repository is nil; an out-of-tree caller gets a compile error rather than silently wrong behaviour, which is the safe failure mode.
