### PR TITLE
Fix ConvertToBinaryIdentifier rewriting base64 padding (Fixes #1116)

### DIFF
--- a/windows/keycredentiallink/utils/utils.go
+++ b/windows/keycredentiallink/utils/utils.go
@@ -41,10 +41,33 @@ func ConvertToBinaryIdentifier(keyIdentifier string, kcv version.KeyCredentialLi
 	case version.KeyCredentialLinkVersion_0, version.KeyCredentialLinkVersion_1:
 		return hex.DecodeString(keyIdentifier)
 	case version.KeyCredentialLinkVersion_2:
-		return base64.StdEncoding.DecodeString(strings.TrimRight(keyIdentifier, "=") + "=")
+		return decodeBase64Identifier(keyIdentifier)
 	default:
-		return base64.StdEncoding.DecodeString(strings.TrimRight(keyIdentifier, "=") + "=")
+		return decodeBase64Identifier(keyIdentifier)
 	}
+}
+
+// decodeBase64Identifier decodes a base64 key identifier, accepting both the padded
+// form ConvertFromBinaryIdentifier produces and an unpadded one.
+//
+// The padding is left as it is rather than rewritten. Base64 uses two padding
+// characters when the encoded length is 1 mod 3, one when it is 2 mod 3 and none
+// otherwise, so stripping the padding and appending a fixed single '=' only ever
+// produced a decodable string for the 2-mod-3 case and corrupted the length of
+// every other one.
+//
+// Parameters:
+// - keyIdentifier: A string containing the base64 representation of the key identifier.
+//
+// Returns:
+// - A byte slice containing the decoded key identifier.
+// - An error if the string is not valid base64.
+func decodeBase64Identifier(keyIdentifier string) ([]byte, error) {
+	if strings.HasSuffix(keyIdentifier, "=") {
+		return base64.StdEncoding.DecodeString(keyIdentifier)
+	}
+
+	return base64.RawStdEncoding.DecodeString(keyIdentifier)
 }
 
 // ConvertFromBinaryIdentifier converts a binary key identifier to its string representation.

--- a/windows/keycredentiallink/utils/utils_test.go
+++ b/windows/keycredentiallink/utils/utils_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/hex"
+	"strings"
 	"testing"
 	"time"
 
@@ -326,4 +327,58 @@ func TestConvertFromBinaryTime_ShortBuffer(t *testing.T) {
 			t.Errorf("decoded %s, want %s", decoded.GetTime(), expected)
 		}
 	})
+}
+
+// Base64 padding is one or two characters depending on the encoded length, so an
+// identifier of any length has to survive the round trip. Rewriting the padding with
+// a fixed single '=' only ever worked for lengths that are 2 mod 3 — which is what a
+// 32-byte SHA-256 hash happens to be, hiding the defect on the normal path.
+func TestConvertToBinaryIdentifier_RoundTripsEveryLength(t *testing.T) {
+	for _, kcv := range []version.KeyCredentialLinkVersion{
+		{Value: version.KeyCredentialLinkVersion_0},
+		{Value: version.KeyCredentialLinkVersion_1},
+		{Value: version.KeyCredentialLinkVersion_2},
+	} {
+		for size := 1; size <= 40; size++ {
+			raw := make([]byte, size)
+			for i := range raw {
+				raw[i] = byte(i)
+			}
+
+			encoded := utils.ConvertFromBinaryIdentifier(raw, kcv)
+
+			decoded, err := utils.ConvertToBinaryIdentifier(encoded, kcv)
+			if err != nil {
+				t.Errorf("version %d, %d bytes (%d mod 3): ConvertToBinaryIdentifier(%q) error = %v",
+					kcv.Value, size, size%3, encoded, err)
+				continue
+			}
+
+			if !bytes.Equal(decoded, raw) {
+				t.Errorf("version %d, %d bytes: round trip gave %d bytes, want the original %d",
+					kcv.Value, size, len(decoded), size)
+			}
+		}
+	}
+}
+
+// An identifier whose padding has been stripped still decodes, which is what the
+// original padding rewrite was reaching for.
+func TestConvertToBinaryIdentifier_AcceptsUnpaddedInput(t *testing.T) {
+	kcv := version.KeyCredentialLinkVersion{Value: version.KeyCredentialLinkVersion_2}
+	raw := make([]byte, 32)
+	for i := range raw {
+		raw[i] = byte(i)
+	}
+
+	unpadded := strings.TrimRight(utils.ConvertFromBinaryIdentifier(raw, kcv), "=")
+
+	decoded, err := utils.ConvertToBinaryIdentifier(unpadded, kcv)
+	if err != nil {
+		t.Fatalf("ConvertToBinaryIdentifier(%q) error = %v, want nil", unpadded, err)
+	}
+
+	if !bytes.Equal(decoded, raw) {
+		t.Errorf("decoded %d bytes, want the original 32", len(decoded))
+	}
 }


### PR DESCRIPTION
### Linked Issue
`Closes #1116`

### Root Cause
`ConvertToBinaryIdentifier` rewrote the base64 padding of its input: `strings.TrimRight(keyIdentifier, "=") + "="` stripped every padding character and appended exactly one. Base64 padding is not a fixed single character — it is two when the encoded length is 1 mod 3, one when it is 2 mod 3, and none otherwise — so the expression left a two-pad encoding one character short and an unpadded encoding one character too long. Only the 2-mod-3 case survived.

A SHA-256 hash is 32 bytes, which is 2 mod 3, so `ComputeKeyIdentifier` output happens to fall in the one length class that works. That is why the defect stayed invisible on the normal path while the function silently rejected every other identifier length, including the output of its own inverse.

### Fix Description
The padding is no longer rewritten. A new unexported `decodeBase64Identifier` picks the encoding that matches the input as given:

```go
if strings.HasSuffix(keyIdentifier, "=") {
	return base64.StdEncoding.DecodeString(keyIdentifier)
}

return base64.RawStdEncoding.DecodeString(keyIdentifier)
```

This accepts the correctly padded form `ConvertFromBinaryIdentifier` produces, whatever its length, and still tolerates an unpadded identifier — which is what the original `TrimRight` was presumably reaching for. Using `base64.StdEncoding` unconditionally was rejected because it rejects unpadded input, which would be a new failure for anyone passing a stripped identifier.

### How Verified
Runtime, round-tripping identifiers of each length class through the package's own pair of converters.

Before:

```
30 bytes (0 mod 3) : ERROR: illegal base64 data at input byte 40
31 bytes (1 mod 3) : ERROR: illegal base64 data at input byte 43
32 bytes (2 mod 3) : round-trip OK
33 bytes (0 mod 3) : ERROR: illegal base64 data at input byte 44
34 bytes (1 mod 3) : ERROR: illegal base64 data at input byte 47
```

After, all five round-trip and return the original bytes.

The new length sweep run against the unfixed function reports 27 failing lengths out of the 40 it covers, for example:

```
version 512, 1 bytes (1 mod 3): ConvertToBinaryIdentifier("AA==") error = illegal base64 data at input byte 3
version 512, 3 bytes (0 mod 3): ConvertToBinaryIdentifier("AAEC") error = illegal base64 data at input byte 4
version 512, 4 bytes (1 mod 3): ConvertToBinaryIdentifier("AAECAw==") error = illegal base64 data at input byte 7
```

With the fix all 40 lengths pass for each of the three versions.

`go build ./...` and `go test ./...` are green, including `TestConvertFromBinaryIdentifier`.

### Test Coverage
**Added** in `windows/keycredentiallink/utils/utils_test.go`:
- `TestConvertToBinaryIdentifier_RoundTripsEveryLength` — identifiers of 1 to 40 bytes survive the round trip through `ConvertFromBinaryIdentifier` and back, byte for byte, for versions 0, 1 and 2.
- `TestConvertToBinaryIdentifier_AcceptsUnpaddedInput` — an identifier with its padding stripped still decodes.

### Scope of Change
- **Files changed:** `windows/keycredentiallink/utils/utils.go`, `windows/keycredentiallink/utils/utils_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none. The 32-byte case that previously worked decodes to the same bytes.

### Risk and Rollout
Local to one function. It accepts strictly more inputs than before and returns the same result for the inputs it already accepted, so no existing call can regress.
