### PR TITLE
Fix an absent KeyUsage entry reading as a declared AdminKey usage (Fixes #1110)

### DIFF
--- a/windows/keycredentiallink/KeyCredentialLink.go
+++ b/windows/keycredentiallink/KeyCredentialLink.go
@@ -25,7 +25,7 @@ import (
 // requires; supply one only to reproduce a specific credential.
 // - KeyHash: A byte slice containing the hash of the key material.
 // - KeyMaterial: A KeyMaterial object representing the key material of the key credential.
-// - Usage: A KeyUsage object representing the usage of the key credential.
+// - Usage: A KeyUsage object representing the usage of the key credential, or nil when the blob carried no KeyUsage entry.
 // - LegacyUsage: A string representing the legacy usage of the key credential.
 // - Source: A KeySource object representing the source of the key credential.
 // - LastLogonTime: A DateTime object representing the last logon time associated with the key credential.
@@ -54,8 +54,11 @@ type KeyCredentialLink struct {
 	// This field is MANDATORY.
 	KeyMaterial bcrypt.KeyMaterial
 	// A KeyUsage object representing the usage of the key credential.
-	// This field is MANDATORY.
-	Usage usage.KeyUsage
+	// This field is MANDATORY, but a blob that was parsed rather than built may
+	// still lack the entry, so it is held as a pointer: KeyUsage_AdminKey is 0,
+	// which collides with the zero value of the struct, and a nil pointer is the
+	// only way to tell an absent entry from a declared admin key.
+	Usage *usage.KeyUsage
 	// A string representing the legacy usage of the key credential.
 	// This field is OPTIONAL.
 	LegacyUsage string
@@ -118,7 +121,7 @@ func NewKeyCredentialLink(
 		Identifier:  identifier,
 		KeyHash:     []byte{},
 		KeyMaterial: keyMaterial,
-		Usage:       usage.KeyUsage{Value: usage.KeyUsage_NGC},
+		Usage:       &usage.KeyUsage{Value: usage.KeyUsage_NGC},
 		LegacyUsage: "",
 		Source:      &source.KeySource{},
 		CustomKeyInfo: &customkeyinformation.CustomKeyInformation{
@@ -251,6 +254,9 @@ func (kc *KeyCredentialLink) Unmarshal(data []byte) (int, error) {
 		case KEYCREDENTIALLINK_ENTRY_IDENTIFIER_KeyUsage:
 			if len(entry.Value) == 1 {
 				// This is apparently a V2 structure (single byte enum).
+				if kc.Usage == nil {
+					kc.Usage = &usage.KeyUsage{}
+				}
 				_, err := kc.Usage.Unmarshal(entry.Value)
 				if err != nil {
 					return bytesRead, fmt.Errorf("failed to unmarshal KeyCredentialLink usage: %w", err)
@@ -462,18 +468,24 @@ func (kc *KeyCredentialLink) ToKeyCredentialLinkBlob() (*KEYCREDENTIALLINK_BLOB,
 	)
 
 	// Key Usage (entry type 0x04) [MANDATORY]
-	usageBytes, err := kc.Usage.Marshal()
-	if err != nil {
-		return nil, err
+	// Written only when the credential carries one. Emitting it unconditionally
+	// declared KeyUsage_AdminKey for a blob that never held the entry, and a
+	// legacy blob — which carries its usage as the string in LegacyUsage below —
+	// ended up with two entries under this identifier.
+	if kc.Usage != nil {
+		usageBytes, err := kc.Usage.Marshal()
+		if err != nil {
+			return nil, err
+		}
+		blob.Entries = append(
+			blob.Entries,
+			KEYCREDENTIALLINK_ENTRY{
+				Identifier: KEYCREDENTIALLINK_ENTRY_IDENTIFIER_KeyUsage,
+				Value:      usageBytes,
+				Length:     uint16(len(usageBytes)),
+			},
+		)
 	}
-	blob.Entries = append(
-		blob.Entries,
-		KEYCREDENTIALLINK_ENTRY{
-			Identifier: KEYCREDENTIALLINK_ENTRY_IDENTIFIER_KeyUsage,
-			Value:      usageBytes,
-			Length:     uint16(len(usageBytes)),
-		},
-	)
 
 	// Legacy Key Usage (entry type 0x04) [OPTIONAL]
 	if len(kc.LegacyUsage) > 0 {
@@ -594,7 +606,11 @@ func (kc *KeyCredentialLink) Describe(indent int) {
 	} else {
 		fmt.Printf("%s │ \x1b[93mKeyMaterial\x1b[0m: \x1b[91m<absent>\x1b[0m\n", indentPrompt)
 	}
-	fmt.Printf("%s │ \x1b[93mUsage\x1b[0m: %s\n", indentPrompt, kc.Usage.String())
+	if kc.Usage != nil {
+		fmt.Printf("%s │ \x1b[93mUsage\x1b[0m: %s\n", indentPrompt, kc.Usage.String())
+	} else if len(kc.LegacyUsage) == 0 {
+		fmt.Printf("%s │ \x1b[93mUsage\x1b[0m: \x1b[91m<absent>\x1b[0m\n", indentPrompt)
+	}
 	if len(kc.LegacyUsage) != 0 {
 		fmt.Printf("%s │ \x1b[93mLegacyUsage\x1b[0m: %s\n", indentPrompt, kc.LegacyUsage)
 	}

--- a/windows/keycredentiallink/KeyCredentialLink_test.go
+++ b/windows/keycredentiallink/KeyCredentialLink_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/windows/cng/bcrypt/keys/magic"
 	"github.com/TheManticoreProject/Manticore/windows/guid"
 	"github.com/TheManticoreProject/Manticore/windows/keycredentiallink"
+	"github.com/TheManticoreProject/Manticore/windows/keycredentiallink/key/usage"
 	"github.com/TheManticoreProject/Manticore/windows/keycredentiallink/utils"
 	"github.com/TheManticoreProject/Manticore/windows/keycredentiallink/version"
 )
@@ -280,4 +281,122 @@ func TestDescribe_ZeroValue(t *testing.T) {
 	kc := keycredentiallink.KeyCredentialLink{}
 
 	kc.Describe(0)
+}
+
+// KeyUsage_AdminKey is 0, which is also the zero value of the KeyUsage struct, so a
+// blob carrying no KeyUsage entry used to be indistinguishable from one declaring an
+// admin (PIN-reset) key — both when described and when marshalled back out.
+func TestKeyUsage_AbsentEntryIsNotAdminKey(t *testing.T) {
+	// A version plus a single KeyID entry: no KeyUsage entry at all.
+	dnWithBinary := ldap.DNWithBinary{}
+	if _, err := dnWithBinary.Unmarshal([]byte("B:18:00020000020001aabb:CN=PC01,DC=MANTICORE,DC=local")); err != nil {
+		t.Fatalf("DNWithBinary.Unmarshal() error = %v, want nil", err)
+	}
+
+	kc := keycredentiallink.KeyCredentialLink{}
+	if err := kc.ParseDNWithBinary(dnWithBinary); err != nil {
+		t.Fatalf("ParseDNWithBinary() error = %v, want nil", err)
+	}
+
+	if kc.Usage != nil {
+		t.Errorf("Usage = %v, want nil for a blob that carried no KeyUsage entry", kc.Usage)
+	}
+
+	// And it must describe without claiming a usage.
+	kc.Describe(0)
+}
+
+// The absence must not be written back out as a declared usage. Marshalling needs
+// key material, which the blob above does not carry, so this covers the same absent
+// Usage on a credential that can be marshalled.
+func TestKeyUsage_AbsentEntryIsNotMarshalled(t *testing.T) {
+	kc := keycredentiallink.KeyCredentialLink{
+		Version:     version.KeyCredentialLinkVersion{Value: version.KeyCredentialLinkVersion_2},
+		KeyMaterial: testKeyMaterial(0x01),
+	}
+
+	if kc.Usage != nil {
+		t.Fatalf("Usage = %v, want nil", kc.Usage)
+	}
+
+	blob, err := kc.ToKeyCredentialLinkBlob()
+	if err != nil {
+		t.Fatalf("ToKeyCredentialLinkBlob() error = %v, want nil", err)
+	}
+
+	for _, entry := range blob.Entries {
+		if entry.Identifier == keycredentiallink.KEYCREDENTIALLINK_ENTRY_IDENTIFIER_KeyUsage {
+			t.Errorf("blob carries a KeyUsage entry with value %v, want none", entry.Value)
+		}
+	}
+}
+
+// A blob that does declare a usage keeps it, so the fix does not turn every usage
+// into an absence.
+func TestKeyUsage_DeclaredAdminKeyIsPreserved(t *testing.T) {
+	// version 0x200 + KeyUsage entry (identifier 0x04) whose single byte is 0x00.
+	dnWithBinary := ldap.DNWithBinary{}
+	if _, err := dnWithBinary.Unmarshal([]byte("B:16:0002000001000400:CN=PC01,DC=MANTICORE,DC=local")); err != nil {
+		t.Fatalf("DNWithBinary.Unmarshal() error = %v, want nil", err)
+	}
+
+	kc := keycredentiallink.KeyCredentialLink{}
+	if err := kc.ParseDNWithBinary(dnWithBinary); err != nil {
+		t.Fatalf("ParseDNWithBinary() error = %v, want nil", err)
+	}
+
+	if kc.Usage == nil {
+		t.Fatalf("Usage = nil, want a declared AdminKey usage")
+	}
+
+	if kc.Usage.Value != usage.KeyUsage_AdminKey {
+		t.Errorf("Usage.Value = 0x%02x, want 0x%02x (AdminKey)", kc.Usage.Value, usage.KeyUsage_AdminKey)
+	}
+}
+
+// A legacy blob carries its usage as a string in the same entry identifier. Emitting
+// the binary entry unconditionally gave such a blob two entries under identifier
+// 0x04: a fabricated AdminKey plus the legacy string.
+func TestKeyUsage_LegacyUsageDoesNotGainASecondEntry(t *testing.T) {
+	kc := keycredentiallink.KeyCredentialLink{
+		Version:     version.KeyCredentialLinkVersion{Value: version.KeyCredentialLinkVersion_2},
+		KeyMaterial: testKeyMaterial(0x01),
+		LegacyUsage: "NGC",
+	}
+
+	blob, err := kc.ToKeyCredentialLinkBlob()
+	if err != nil {
+		t.Fatalf("ToKeyCredentialLinkBlob() error = %v, want nil", err)
+	}
+
+	usageEntries := make([][]byte, 0)
+	for _, entry := range blob.Entries {
+		if entry.Identifier == keycredentiallink.KEYCREDENTIALLINK_ENTRY_IDENTIFIER_KeyUsage {
+			usageEntries = append(usageEntries, entry.Value)
+		}
+	}
+
+	if len(usageEntries) != 1 {
+		t.Errorf("blob carries %d KeyUsage entries (%v), want exactly 1 (the legacy string)", len(usageEntries), usageEntries)
+	}
+
+	if len(usageEntries) == 1 && string(usageEntries[0]) != "NGC" {
+		t.Errorf("KeyUsage entry = %q, want %q", usageEntries[0], "NGC")
+	}
+}
+
+// A credential built by the constructor still declares NGC.
+func TestKeyUsage_ConstructorSetsNGC(t *testing.T) {
+	now := utils.NewDateTimeFromTicks(0)
+	kcv := version.KeyCredentialLinkVersion{Value: version.KeyCredentialLinkVersion_2}
+
+	kc := keycredentiallink.NewKeyCredentialLink(kcv, "", testKeyMaterial(0x01), guid.NewGUID(), &now, &now)
+
+	if kc.Usage == nil {
+		t.Fatalf("Usage = nil, want NGC")
+	}
+
+	if kc.Usage.Value != usage.KeyUsage_NGC {
+		t.Errorf("Usage.Value = 0x%02x, want 0x%02x (NGC)", kc.Usage.Value, usage.KeyUsage_NGC)
+	}
 }


### PR DESCRIPTION
### Linked Issue
`Closes #1110`

### Root Cause
`KeyUsage.Value` is a bare `uint8` and `KeyUsage_AdminKey` is `0`, so the enum's first member collides with the field's zero value. `KeyCredentialLink` held `Usage` by value, which left the structure with no representation for "the blob carried no KeyUsage entry" — every other entry whose absence is possible (`Source`, `CustomKeyInfo`, `DeviceId`, `LastLogonTime`, `CreationTime`) is already a pointer for exactly this reason; `Usage` was the one that was not.

`Unmarshal` only touches `Usage` inside the `KEYCREDENTIALLINK_ENTRY_IDENTIFIER_KeyUsage` case, so a blob without the entry left it at its zero value, and both readers of the field took that at face value: `Describe` reported `AdminKey`, and `ToKeyCredentialLinkBlob` appended an explicit `KeyUsage = 0x00` entry unconditionally.

That second half also produced a malformed blob for legacy credentials. A legacy blob carries its usage as a string, which `Unmarshal` puts in `LegacyUsage` while leaving `Usage` untouched; re-marshalling then emitted *two* entries under identifier `0x04` — a fabricated `AdminKey` plus the legacy string. `ComputeKeyHash` hashes the entries `ToKeyCredentialLinkBlob` builds, so the fabricated entry was covered by the hash as well.

### Fix Description
`Usage` becomes `*usage.KeyUsage`, matching how the structure already models every other optional-in-practice entry:

- `Unmarshal` allocates on demand inside the `KeyUsage` case, mirroring the existing `Source` and `CustomKeyInfo` cases.
- `ToKeyCredentialLinkBlob` writes the entry only when `kc.Usage != nil`, which also stops a legacy credential from gaining a second `0x04` entry.
- `Describe` prints the usage when present, and `<absent>` when neither `Usage` nor `LegacyUsage` is — so a legacy credential still shows its usage on the `LegacyUsage` line rather than being reported as absent twice.
- `NewKeyCredentialLink` sets `&usage.KeyUsage{Value: usage.KeyUsage_NGC}`, so a credential built by the constructor declares NGC exactly as before.

A presence flag on `KeyUsage` was considered and rejected: it would put the same information in a second place and would not match the surrounding fields, which a reader of this struct already has to understand as pointers-mean-optional.

Returning an error from `ToKeyCredentialLinkBlob` when the mandatory entry is missing — as it does for absent key material — was also rejected. The issue asks for the entry not to be written, and erroring would make legacy blobs unmarshallable, since their usage lives in `LegacyUsage` and `Usage` is legitimately nil for them.

### How Verified
The recorded run in the issue, on a blob of a version plus a single `KeyID` entry:

```
blob carried no KeyUsage entry -> Usage.Value=0x00 String()="AdminKey" RawBytesSize=0
```

`RawBytesSize=0` shows nothing was ever unmarshalled into the struct, while `Value` and `String()` could not express it. After the fix `kc.Usage` is `nil` for that blob and `Describe` prints:

```
 │ Usage: <absent>
```

where it previously printed ` │ Usage: AdminKey`.

The new tests cannot be run against the unfixed code — the fix is a type change, so they fail to compile there (`invalid operation: kc.Usage != nil (mismatched types usage.KeyUsage and untyped nil)`). Their assertions are therefore stated against the recorded before-behaviour above rather than a re-run.

`go build ./...` and `go test ./...` are green across the repository.

### Test Coverage
**Added** in `windows/keycredentiallink/KeyCredentialLink_test.go`:
- `TestKeyUsage_AbsentEntryIsNotAdminKey` — a blob with no `KeyUsage` entry parses to a nil `Usage` and describes without claiming one.
- `TestKeyUsage_AbsentEntryIsNotMarshalled` — a credential with a nil `Usage` produces a blob carrying no `KeyUsage` entry.
- `TestKeyUsage_DeclaredAdminKeyIsPreserved` — a blob that *does* declare `AdminKey` (a `0x04` entry whose byte is `0x00`) still parses to that usage, so the fix does not turn a real admin key into an absence.
- `TestKeyUsage_LegacyUsageDoesNotGainASecondEntry` — a legacy credential marshals to exactly one `0x04` entry, holding the legacy string.
- `TestKeyUsage_ConstructorSetsNGC` — `NewKeyCredentialLink` still declares NGC.

### Scope of Change
- **Files changed:** `windows/keycredentiallink/KeyCredentialLink.go`, `windows/keycredentiallink/KeyCredentialLink_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none. Blobs that declare a usage parse, describe and marshal exactly as before, and the constructor's output is unchanged.

### Risk and Rollout
Breaking change to an exported struct field: `Usage` is now `*usage.KeyUsage`. Every in-repo reader is updated in this commit and the build is green, so the blast radius inside the repository is nil; an out-of-tree caller gets a compile error rather than a silent behaviour change, which is the safe failure mode. Blobs written after this change no longer carry a `KeyUsage` entry when the credential has none — previously they carried one declaring an admin key, which was never true of the source value.

### Notes
Last of the batch filed after the `windows/keycredentiallink` review (#1109, #1111–#1117 are merged). The `KeyUsage_AdminKey`-is-zero collision itself is left in place: it is what MS-ADTS defines, and the fix is to make absence representable in the structure that holds it rather than to renumber the enum.
