### PR TITLE
Fix HOMEDIR_REQUIRED and PARTIAL_SECRETS_ACCOUNT userAccountControl bits (Fixes #1106)

### DIFF
--- a/network/ldap/ldap_attributes/UserAccountControl.go
+++ b/network/ldap/ldap_attributes/UserAccountControl.go
@@ -8,12 +8,21 @@ import (
 type UserAccountControl uint32
 
 // UserAccountControl
+//
+// The bit values are those of [MS-ADTS] 2.2.16 userAccountControl Bits, which is
+// the authoritative table; the reserved names below sit on the bits it marks
+// "X: Unused. Must be zero and ignored." SCRIPT (0x1), TEMP_DUPLICATE_ACCOUNT
+// (0x100) and MNS_LOGON_ACCOUNT (0x20000) are among that set for MS-ADTS but are
+// defined by ADS_USER_FLAG_ENUM, so they are kept under their ADSI names.
+//
+// Src: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/dd302fd1-0aa7-406b-ad91-2a6b35738557
+// Src: https://learn.microsoft.com/en-us/windows/win32/api/iads/ne-iads-ads_user_flag_enum
 // Src: https://learn.microsoft.com/en-us/troubleshoot/windows-server/active-directory/useraccountcontrol-manipulate-account-properties
 const (
 	UAF_SCRIPT                         UserAccountControl = 1       // 1
 	UAF_ACCOUNT_DISABLED               UserAccountControl = 1 << 1  // 2
-	UAF_HOMEDIR_REQUIRED               UserAccountControl = 1 << 2  // 4
-	UAF_RESERVED_03                    UserAccountControl = 1 << 3  // 8
+	UAF_RESERVED_02                    UserAccountControl = 1 << 2  // 4
+	UAF_HOMEDIR_REQUIRED               UserAccountControl = 1 << 3  // 8
 	UAF_LOCKOUT                        UserAccountControl = 1 << 4  // 16
 	UAF_PASSWD_NOTREQD                 UserAccountControl = 1 << 5  // 32
 	UAF_PASSWD_CANT_CHANGE             UserAccountControl = 1 << 6  // 64
@@ -35,9 +44,9 @@ const (
 	UAF_DONT_REQ_PREAUTH               UserAccountControl = 1 << 22 // 4194304
 	UAF_PASSWORD_EXPIRED               UserAccountControl = 1 << 23 // 8388608
 	UAF_TRUSTED_TO_AUTH_FOR_DELEGATION UserAccountControl = 1 << 24 // 16777216
-	UAF_RESERVED_25                    UserAccountControl = 1 << 25 // 33554432
-	UAF_RESERVED_26                    UserAccountControl = 1 << 26 // 67108864
-	UAF_PARTIAL_SECRETS_ACCOUNT        UserAccountControl = 1 << 27 // 134217728
+	UAF_NO_AUTH_DATA_REQUIRED          UserAccountControl = 1 << 25 // 33554432
+	UAF_PARTIAL_SECRETS_ACCOUNT        UserAccountControl = 1 << 26 // 67108864
+	UAF_RESERVED_27                    UserAccountControl = 1 << 27 // 134217728
 	UAF_RESERVED_28                    UserAccountControl = 1 << 28 // 268435456
 	UAF_RESERVED_29                    UserAccountControl = 1 << 29 // 536870912
 	UAF_RESERVED_30                    UserAccountControl = 1 << 30 // 1073741824
@@ -66,6 +75,7 @@ var UserAccountControlMap = map[UserAccountControl]string{
 	UAF_DONT_REQ_PREAUTH:               "DONT_REQ_PREAUTH",
 	UAF_PASSWORD_EXPIRED:               "PASSWORD_EXPIRED",
 	UAF_TRUSTED_TO_AUTH_FOR_DELEGATION: "TRUSTED_TO_AUTH_FOR_DELEGATION",
+	UAF_NO_AUTH_DATA_REQUIRED:          "NO_AUTH_DATA_REQUIRED",
 	UAF_PARTIAL_SECRETS_ACCOUNT:        "PARTIAL_SECRETS_ACCOUNT",
 }
 

--- a/network/ldap/ldap_attributes/UserAccountControl_test.go
+++ b/network/ldap/ldap_attributes/UserAccountControl_test.go
@@ -46,3 +46,127 @@ func TestUserAccountControlToString(t *testing.T) {
 		})
 	}
 }
+
+// Each constant is pinned against the literal value from [MS-ADTS] 2.2.16, not
+// against UserAccountControlMap. The pre-existing tests above assert a constant
+// against a map keyed by that same constant, so they hold for whatever value the
+// constant happens to carry — which is why HOMEDIR_REQUIRED sitting on 0x00000004
+// and PARTIAL_SECRETS_ACCOUNT on 0x08000000 went unnoticed.
+//
+// Src: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/dd302fd1-0aa7-406b-ad91-2a6b35738557
+func TestUserAccountControlSpecValues(t *testing.T) {
+	testCases := []struct {
+		name     string
+		flag     ldap_attributes.UserAccountControl
+		expected uint32
+	}{
+		{name: "SCRIPT", flag: ldap_attributes.UAF_SCRIPT, expected: 0x00000001},
+		{name: "ACCOUNT_DISABLED", flag: ldap_attributes.UAF_ACCOUNT_DISABLED, expected: 0x00000002},
+		{name: "HOMEDIR_REQUIRED", flag: ldap_attributes.UAF_HOMEDIR_REQUIRED, expected: 0x00000008},
+		{name: "LOCKOUT", flag: ldap_attributes.UAF_LOCKOUT, expected: 0x00000010},
+		{name: "PASSWD_NOTREQD", flag: ldap_attributes.UAF_PASSWD_NOTREQD, expected: 0x00000020},
+		{name: "PASSWD_CANT_CHANGE", flag: ldap_attributes.UAF_PASSWD_CANT_CHANGE, expected: 0x00000040},
+		{name: "ENCRYPTED_TEXT_PWD_ALLOWED", flag: ldap_attributes.UAF_ENCRYPTED_TEXT_PWD_ALLOWED, expected: 0x00000080},
+		{name: "TEMP_DUPLICATE_ACCOUNT", flag: ldap_attributes.UAF_TEMP_DUPLICATE_ACCOUNT, expected: 0x00000100},
+		{name: "NORMAL_ACCOUNT", flag: ldap_attributes.UAF_NORMAL_ACCOUNT, expected: 0x00000200},
+		{name: "INTERDOMAIN_TRUST_ACCOUNT", flag: ldap_attributes.UAF_INTERDOMAIN_TRUST_ACCOUNT, expected: 0x00000800},
+		{name: "WORKSTATION_TRUST_ACCOUNT", flag: ldap_attributes.UAF_WORKSTATION_TRUST_ACCOUNT, expected: 0x00001000},
+		{name: "SERVER_TRUST_ACCOUNT", flag: ldap_attributes.UAF_SERVER_TRUST_ACCOUNT, expected: 0x00002000},
+		{name: "DONT_EXPIRE_PASSWORD", flag: ldap_attributes.UAF_DONT_EXPIRE_PASSWORD, expected: 0x00010000},
+		{name: "MNS_LOGON_ACCOUNT", flag: ldap_attributes.UAF_MNS_LOGON_ACCOUNT, expected: 0x00020000},
+		{name: "SMARTCARD_REQUIRED", flag: ldap_attributes.UAF_SMARTCARD_REQUIRED, expected: 0x00040000},
+		{name: "TRUSTED_FOR_DELEGATION", flag: ldap_attributes.UAF_TRUSTED_FOR_DELEGATION, expected: 0x00080000},
+		{name: "NOT_DELEGATED", flag: ldap_attributes.UAF_NOT_DELEGATED, expected: 0x00100000},
+		{name: "USE_DES_KEY_ONLY", flag: ldap_attributes.UAF_USE_DES_KEY_ONLY, expected: 0x00200000},
+		{name: "DONT_REQ_PREAUTH", flag: ldap_attributes.UAF_DONT_REQ_PREAUTH, expected: 0x00400000},
+		{name: "PASSWORD_EXPIRED", flag: ldap_attributes.UAF_PASSWORD_EXPIRED, expected: 0x00800000},
+		{name: "TRUSTED_TO_AUTH_FOR_DELEGATION", flag: ldap_attributes.UAF_TRUSTED_TO_AUTH_FOR_DELEGATION, expected: 0x01000000},
+		{name: "NO_AUTH_DATA_REQUIRED", flag: ldap_attributes.UAF_NO_AUTH_DATA_REQUIRED, expected: 0x02000000},
+		{name: "PARTIAL_SECRETS_ACCOUNT", flag: ldap_attributes.UAF_PARTIAL_SECRETS_ACCOUNT, expected: 0x04000000},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if uint32(testCase.flag) != testCase.expected {
+				t.Errorf("%s = 0x%08x (%d), want 0x%08x (%d)",
+					testCase.name, uint32(testCase.flag), testCase.flag, testCase.expected, testCase.expected)
+			}
+		})
+	}
+}
+
+// The bits MS-ADTS marks "X: Unused. Must be zero and ignored." must carry a
+// reserved name and must not appear in the map, so String() never reports a flag
+// for a bit the specification does not assign.
+func TestUserAccountControlReservedBits(t *testing.T) {
+	reserved := map[string]ldap_attributes.UserAccountControl{
+		"bit 2":  ldap_attributes.UAF_RESERVED_02,
+		"bit 10": ldap_attributes.UAF_RESERVED_10,
+		"bit 14": ldap_attributes.UAF_RESERVED_14,
+		"bit 15": ldap_attributes.UAF_RESERVED_15,
+		"bit 27": ldap_attributes.UAF_RESERVED_27,
+		"bit 28": ldap_attributes.UAF_RESERVED_28,
+		"bit 29": ldap_attributes.UAF_RESERVED_29,
+		"bit 30": ldap_attributes.UAF_RESERVED_30,
+		"bit 31": ldap_attributes.UAF_RESERVED_31,
+	}
+
+	expectedValues := map[string]uint32{
+		"bit 2":  0x00000004,
+		"bit 10": 0x00000400,
+		"bit 14": 0x00004000,
+		"bit 15": 0x00008000,
+		"bit 27": 0x08000000,
+		"bit 28": 0x10000000,
+		"bit 29": 0x20000000,
+		"bit 30": 0x40000000,
+		"bit 31": 0x80000000,
+	}
+
+	for name, flag := range reserved {
+		t.Run(name, func(t *testing.T) {
+			if uint32(flag) != expectedValues[name] {
+				t.Errorf("%s = 0x%08x, want 0x%08x", name, uint32(flag), expectedValues[name])
+			}
+
+			if _, ok := ldap_attributes.UserAccountControlMap[flag]; ok {
+				t.Errorf("%s (0x%08x) is named in UserAccountControlMap, want absent", name, uint32(flag))
+			}
+
+			if got := flag.String(); got != "" {
+				t.Errorf("%s.String() = %q, want an empty string", name, got)
+			}
+		})
+	}
+}
+
+// The RODC filter of GetAllReadOnlyDomainControllers renders this constant into a
+// bitwise-AND matching rule, so its decimal form is what goes on the wire.
+func TestPartialSecretsAccountFilterValue(t *testing.T) {
+	if got := uint32(ldap_attributes.UAF_PARTIAL_SECRETS_ACCOUNT); got != 67108864 {
+		t.Errorf("PARTIAL_SECRETS_ACCOUNT = %d, want 67108864 — the LDAP filter would read "+
+			"(userAccountControl:1.2.840.113556.1.4.803:=%d)", got, got)
+	}
+}
+
+// An account carrying the real HOMEDIR_REQUIRED bit must report it, and one carrying
+// the unassigned neighbouring bit must report nothing.
+func TestHomedirRequiredBitIsReported(t *testing.T) {
+	if got := ldap_attributes.UserAccountControl(0x00000008).String(); got != "HOMEDIR_REQUIRED" {
+		t.Errorf("UserAccountControl(0x00000008).String() = %q, want %q", got, "HOMEDIR_REQUIRED")
+	}
+
+	if got := ldap_attributes.UserAccountControl(0x00000004).String(); got != "" {
+		t.Errorf("UserAccountControl(0x00000004).String() = %q, want an empty string", got)
+	}
+}
+
+// A real RODC computer account: WORKSTATION_TRUST_ACCOUNT plus PARTIAL_SECRETS_ACCOUNT,
+// which MS-ADTS requires to be set together.
+func TestReadOnlyDomainControllerAccountFlags(t *testing.T) {
+	rodc := ldap_attributes.UserAccountControl(0x04000000 | 0x00001000)
+
+	if got, want := rodc.String(), "PARTIAL_SECRETS_ACCOUNT|WORKSTATION_TRUST_ACCOUNT"; got != want {
+		t.Errorf("String() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #1106`

### Root Cause
The `userAccountControl` table was transcribed by walking `1 << n` down a list of flag names, which only stays aligned if every unassigned bit in between is accounted for. Two runs slipped:

- Bit 2 (`0x00000004`) is unassigned in the specification, but the list gave it `HOMEDIR_REQUIRED` and pushed the reserved name onto bit 3 — which is where `HOMEDIR_REQUIRED` actually lives. The run self-corrected immediately at bit 4, because `LOCKOUT = 0x10` is well known.
- Bits 25 and 26 both carry documented flags (`NO_AUTH_DATA_REQUIRED` and `PARTIAL_SECRETS_ACCOUNT`), but both were recorded as reserved, pushing `PARTIAL_SECRETS_ACCOUNT` onto bit 27 — which the specification marks unused.

Because `UserAccountControlMap` is keyed by the same constants the tests assert against, `UserAccountControl_test.go` held for whatever value each constant happened to carry. `TestUserAccountControlToString` asserting `UAF_HOMEDIR_REQUIRED.String() == "HOMEDIR_REQUIRED"` is true for any bit that constant names, so nothing in the suite pinned the table to the specification.

### Fix Description
Five entries in the `const` block move onto the bits [MS-ADTS] 2.2.16 assigns them:

| Constant | Was | Now |
|---|---|---|
| `UAF_RESERVED_02` (new name) | — | `0x00000004` |
| `UAF_HOMEDIR_REQUIRED` | `0x00000004` | `0x00000008` |
| `UAF_NO_AUTH_DATA_REQUIRED` (new name, was `UAF_RESERVED_25`) | — | `0x02000000` |
| `UAF_PARTIAL_SECRETS_ACCOUNT` | `0x08000000` | `0x04000000` |
| `UAF_RESERVED_27` (was `UAF_PARTIAL_SECRETS_ACCOUNT`) | — | `0x08000000` |

`UAF_NO_AUTH_DATA_REQUIRED` is added to `UserAccountControlMap` so `String()` and `GetFlags()` report it. `UAF_RESERVED_03`, `UAF_RESERVED_25` and `UAF_RESERVED_26` are gone, since those bits are all assigned; no code referenced them.

`GetAllReadOnlyDomainControllers` needs no change — it renders the constant into its filter, so correcting the constant corrects the query.

The header comment now cites MS-ADTS as the authoritative table alongside the KB article that was there, and records why `SCRIPT` (`0x1`), `TEMP_DUPLICATE_ACCOUNT` (`0x100`) and `MNS_LOGON_ACCOUNT` (`0x20000`) keep their names even though MS-ADTS marks those bits unused: `ADS_USER_FLAG_ENUM` defines all three, and they were already correct here.

### How Verified
Every value was cross-checked against three Microsoft sources before changing anything, and all three agree:

- [\[MS-ADTS\] 2.2.16 userAccountControl Bits](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/dd302fd1-0aa7-406b-ad91-2a6b35738557) — the authoritative table. `HR (ADS_UF_HOMEDIR_REQUIRED, 0x00000008)`, `NA (ADS_UF_NO_AUTH_DATA_REQUIRED, 0x02000000)`, `PS (ADS_UF_PARTIAL_SECRETS_ACCOUNT, 0x04000000)`. Its bit row is presented big-endian, so position 28 is bit 3 (`HR`) and position 5 is bit 26 (`PS`); positions 0–4 — `0x08000000` and above — are all `X: Unused. Must be zero and ignored.`, as is position 29, which is bit 2.
- [ADS_USER_FLAG_ENUM (iads.h)](https://learn.microsoft.com/en-us/windows/win32/api/iads/ne-iads-ads_user_flag_enum) — `ADS_UF_HOMEDIR_REQUIRED = 0x8`, and `0x4` absent from the enumeration entirely.
- [UserAccountControl property flags (KB 305144)](https://learn.microsoft.com/en-us/troubleshoot/windows-server/active-directory/useraccountcontrol-manipulate-account-properties) — `HOMEDIR_REQUIRED 0x0008 / 8` and `PARTIAL_SECRETS_ACCOUNT 0x04000000 / 67108864`.

That review also confirmed the other 18 flags and the remaining reserved bits (10, 14, 15, 28–31) were already correct, so the diff is limited to the five entries above.

The new tests were then run against the old bit values to confirm they catch the defect rather than merely restating it:

```
HOMEDIR_REQUIRED = 0x00000004 (4), want 0x00000008 (8)
PARTIAL_SECRETS_ACCOUNT = 0x08000000 (134217728), want 0x04000000 (67108864)
bit 2 (0x00000004) is named in UserAccountControlMap, want absent
bit 2.String() = "HOMEDIR_REQUIRED", want an empty string
bit 27 (0x08000000) is named in UserAccountControlMap, want absent
bit 27.String() = "PARTIAL_SECRETS_ACCOUNT", want an empty string
```

`go build ./...`, `go vet ./network/ldap/...` and `go test ./...` are green across the repository, including the pre-existing `TestUserAccountControlToString` and `TestUserAccountControlGetFlags`.

The RODC filter now renders as

```
(&(objectClass=computer)(userAccountControl:1.2.840.113556.1.4.803:=67108864)(dnsHostname=*))
```

which is asserted by `TestPartialSecretsAccountFilterValue`. Verifying it returns RODCs against a live domain needs a domain that has one and is not covered here.

### Test Coverage
**Added** in `network/ldap/ldap_attributes/UserAccountControl_test.go`:
- `TestUserAccountControlSpecValues` — pins all 23 named flags to the literal hexadecimal value from MS-ADTS, independently of `UserAccountControlMap`. This is the check that was missing and that catches any future transcription slip.
- `TestUserAccountControlReservedBits` — the nine unassigned bits carry their documented value, are absent from the map, and render as an empty string.
- `TestPartialSecretsAccountFilterValue` — the constant's decimal form is 67108864, which is what the RODC LDAP filter puts on the wire.
- `TestHomedirRequiredBitIsReported` — `0x00000008` reports `HOMEDIR_REQUIRED` and `0x00000004` reports nothing.
- `TestReadOnlyDomainControllerAccountFlags` — a real RODC account value (`PARTIAL_SECRETS_ACCOUNT | WORKSTATION_TRUST_ACCOUNT`, which MS-ADTS requires to be set together) renders both flags.

### Scope of Change
- **Files changed:** `network/ldap/ldap_attributes/UserAccountControl.go`, `network/ldap/ldap_attributes/UserAccountControl_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none. The 18 flags that were already correct are untouched, and `String()`/`GetFlags()` gain `NO_AUTH_DATA_REQUIRED` only because the bit is now named.

### Risk and Rollout
Three exported constants are renamed (`UAF_RESERVED_03`, `UAF_RESERVED_25`, `UAF_RESERVED_26`) and two change value. Nothing in the repository referenced the renamed ones, and the only consumer of a changed value is the RODC filter, which is the bug. An out-of-tree caller of a renamed constant gets a compile error; one that hardcoded a comparison against `UAF_HOMEDIR_REQUIRED` or `UAF_PARTIAL_SECRETS_ACCOUNT` starts getting the right answer.

### Notes
`GetAllReadOnlyDomainControllers` previously returned an empty map rather than an error against any domain, so a caller had no signal that the filter was wrong. No change to that behaviour is included here; an empty result is now genuinely "no RODCs".
