### PR TITLE
Fix PasswordProperties String and Description ignoring multi-flag values (Fixes #1128)

### DIFF
--- a/network/ldap/ldap_attributes/pwdProperties.go
+++ b/network/ldap/ldap_attributes/pwdProperties.go
@@ -1,5 +1,10 @@
 package ldap_attributes
 
+import (
+	"sort"
+	"strings"
+)
+
 type PasswordProperties uint32
 
 // PasswordProperties
@@ -53,16 +58,63 @@ var PasswordPropertiesDescriptions = map[PasswordProperties]string{
 	PASSWORD_PROPERTY_DOMAIN_REFUSE_PASSWORD_CHANGE:   "Removes the requirement that the machine account password be automatically changed every week. This value should not be used as it can weaken security.",
 }
 
+// String returns the names of the flags set in the value, sorted alphabetically and
+// separated by a pipe ("|").
+//
+// pwdProperties is a bit field and a domain policy routinely sets several flags at
+// once, so each flag is tested with a bitwise AND rather than the whole value being
+// looked up as a single key. A value with no known flag set returns an empty string.
+//
+// Returns:
+//   - A string containing the names of the set flags, separated by a pipe ("|").
 func (pwdProperties PasswordProperties) String() string {
-	if _, ok := PasswordPropertiesMap[pwdProperties]; ok {
-		return PasswordPropertiesMap[pwdProperties]
+	names := []string{}
+	for flag, name := range PasswordPropertiesMap {
+		if pwdProperties&flag != 0 {
+			names = append(names, name)
+		}
 	}
-	return ""
+
+	sort.Strings(names)
+
+	return strings.Join(names, "|")
 }
 
+// Description returns the descriptions of the flags set in the value, one per line.
+//
+// As with String, the value is a bit field, so every set flag is described rather
+// than the whole value being looked up as a single key.
+//
+// Returns:
+//   - A string containing the descriptions of the set flags, separated by newlines.
 func (pwdProperties PasswordProperties) Description() string {
-	if _, ok := PasswordPropertiesDescriptions[pwdProperties]; ok {
-		return PasswordPropertiesDescriptions[pwdProperties]
+	descriptions := []string{}
+	for flag, description := range PasswordPropertiesDescriptions {
+		if pwdProperties&flag != 0 {
+			descriptions = append(descriptions, description)
+		}
 	}
-	return ""
+
+	sort.Strings(descriptions)
+
+	return strings.Join(descriptions, "\n")
+}
+
+// GetFlags returns the flags set in the value, sorted in ascending order.
+//
+// Returns:
+//   - A slice of PasswordProperties values representing the set flags.
+func (pwdProperties PasswordProperties) GetFlags() []PasswordProperties {
+	flags := []PasswordProperties{}
+	for flag := range PasswordPropertiesMap {
+		if pwdProperties&flag != 0 {
+			flags = append(flags, flag)
+		}
+	}
+
+	sort.Slice(flags, func(i, j int) bool {
+		return flags[i] < flags[j]
+	})
+
+	return flags
 }

--- a/network/ldap/ldap_attributes/pwdProperties_test.go
+++ b/network/ldap/ldap_attributes/pwdProperties_test.go
@@ -1,0 +1,115 @@
+package ldap_attributes_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/ldap/ldap_attributes"
+)
+
+// pwdProperties is a bit field, so every flag set in the value has to be named. An
+// exact-match lookup returned an empty string for any value with more than one flag,
+// which is the normal shape of a domain policy.
+func TestPasswordProperties_String(t *testing.T) {
+	testCases := []struct {
+		name     string
+		value    ldap_attributes.PasswordProperties
+		expected string
+	}{
+		{name: "no flags", value: 0x00000000, expected: ""},
+		{name: "single flag", value: 0x00000001, expected: "DOMAIN_PASSWORD_COMPLEX"},
+		{
+			name:     "complex and store cleartext",
+			value:    0x00000011,
+			expected: "DOMAIN_PASSWORD_COMPLEX|DOMAIN_PASSWORD_STORE_CLEARTEXT",
+		},
+		{
+			name:     "complex, lockout admins and store cleartext",
+			value:    0x00000019,
+			expected: "DOMAIN_LOCKOUT_ADMINS|DOMAIN_PASSWORD_COMPLEX|DOMAIN_PASSWORD_STORE_CLEARTEXT",
+		},
+		{
+			name:  "every defined flag",
+			value: 0x0000003F,
+			expected: "DOMAIN_LOCKOUT_ADMINS|DOMAIN_PASSWORD_COMPLEX|DOMAIN_PASSWORD_NO_ANON_CHANGE|" +
+				"DOMAIN_PASSWORD_NO_CLEAR_CHANGE|DOMAIN_PASSWORD_STORE_CLEARTEXT|DOMAIN_REFUSE_PASSWORD_CHANGE",
+		},
+		{name: "only undefined bits", value: 0x00000040, expected: ""},
+		{name: "known flag with an undefined bit", value: 0x00000041, expected: "DOMAIN_PASSWORD_COMPLEX"},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := testCase.value.String(); got != testCase.expected {
+				t.Errorf("PasswordProperties(0x%08x).String() = %q, want %q", uint32(testCase.value), got, testCase.expected)
+			}
+		})
+	}
+}
+
+// Description has the same bit-field shape as String and must describe every set flag.
+func TestPasswordProperties_Description(t *testing.T) {
+	t.Run("single flag", func(t *testing.T) {
+		got := ldap_attributes.PasswordProperties(0x00000001).Description()
+		if !strings.Contains(got, "mix of at least two") {
+			t.Errorf("Description() = %q, want the complexity description", got)
+		}
+		if strings.Contains(got, "\n") {
+			t.Errorf("Description() = %q, want a single line for a single flag", got)
+		}
+	})
+
+	t.Run("two flags", func(t *testing.T) {
+		got := ldap_attributes.PasswordProperties(0x00000011).Description()
+
+		lines := strings.Split(got, "\n")
+		if len(lines) != 2 {
+			t.Fatalf("Description() returned %d lines, want 2:\n%s", len(lines), got)
+		}
+		if !strings.Contains(got, "mix of at least two") {
+			t.Errorf("Description() is missing the complexity description:\n%s", got)
+		}
+		if !strings.Contains(got, "plaintext password for all users") {
+			t.Errorf("Description() is missing the cleartext-storage description:\n%s", got)
+		}
+	})
+
+	t.Run("no flags", func(t *testing.T) {
+		if got := ldap_attributes.PasswordProperties(0).Description(); got != "" {
+			t.Errorf("Description() = %q, want an empty string", got)
+		}
+	})
+}
+
+// GetFlags decomposes the value into the individual flags it carries.
+func TestPasswordProperties_GetFlags(t *testing.T) {
+	flags := ldap_attributes.PasswordProperties(0x00000011).GetFlags()
+
+	expected := []ldap_attributes.PasswordProperties{
+		ldap_attributes.PASSWORD_PROPERTY_DOMAIN_PASSWORD_COMPLEX,
+		ldap_attributes.PASSWORD_PROPERTY_DOMAIN_PASSWORD_STORE_CLEARTEXT,
+	}
+
+	if len(flags) != len(expected) {
+		t.Fatalf("GetFlags() returned %d flags (%v), want %d", len(flags), flags, len(expected))
+	}
+
+	for i := range expected {
+		if flags[i] != expected[i] {
+			t.Errorf("GetFlags()[%d] = 0x%08x, want 0x%08x", i, uint32(flags[i]), uint32(expected[i]))
+		}
+	}
+}
+
+// Every name in the map must be reachable through String() on its own flag.
+func TestPasswordProperties_EveryFlagIsNamed(t *testing.T) {
+	for flag, name := range ldap_attributes.PasswordPropertiesMap {
+		if got := flag.String(); got != name {
+			t.Errorf("PasswordProperties(0x%08x).String() = %q, want %q", uint32(flag), got, name)
+		}
+
+		if flag.Description() == "" {
+			t.Errorf("PasswordProperties(0x%08x) (%s) has no description", uint32(flag), name)
+		}
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #1128`

### Root Cause
`PasswordProperties` is a bit field, but `String()` and `Description()` used the whole value as a map key: `PasswordPropertiesMap[pwdProperties]`. That only hits when the value happens to equal a single flag constant, so any domain policy with two or more flags set missed the map entirely and fell through to the `return ""`.

The failure was invisible because the fallback is the same empty string returned for a zero value and for an unrecognised one — a caller could not tell "no flags", "unknown value" and "several flags" apart. `UserAccountControl.String()` in the same package already had the correct shape, testing each flag with a bitwise AND and joining the names, which is what makes this an inconsistency inside one package rather than an open design question.

### Fix Description
`String()` and `Description()` now iterate their maps and test each flag with `pwdProperties&flag != 0`, exactly as `UserAccountControl.String()` does. `String()` sorts the names and joins them with `|`, matching that method's output format so the two attribute types render consistently. `Description()` sorts and joins with newlines, since the descriptions are full sentences and a pipe-separated line would be unreadable.

A `GetFlags()` method is added alongside, mirroring `UserAccountControl.GetFlags()`, so a caller that needs to act on the individual flags does not have to re-derive them by hand — which is the workaround the broken `String()` forced.

Undefined bits are ignored rather than reported, matching `UserAccountControl`: `0x41` renders as `DOMAIN_PASSWORD_COMPLEX` and drops bit 6. A zero value still returns an empty string.

### How Verified
The new tests were run against the old method bodies to confirm they detect the defect rather than merely restate the new behaviour:

```
PasswordProperties(0x00000011).String() = "", want "DOMAIN_PASSWORD_COMPLEX|DOMAIN_PASSWORD_STORE_CLEARTEXT"
PasswordProperties(0x00000019).String() = "", want "DOMAIN_LOCKOUT_ADMINS|DOMAIN_PASSWORD_COMPLEX|DOMAIN_PASSWORD_STORE_CLEARTEXT"
PasswordProperties(0x0000003f).String() = "", want "DOMAIN_LOCKOUT_ADMINS|DOMAIN_PASSWORD_COMPLEX|DOMAIN_PASSWORD_NO_ANON_CHANGE|DOMAIN_PASSWORD_NO_CLEAR_CHANGE|DOMAIN_PASSWORD_STORE_CLEARTEXT|DOMAIN_REFUSE_PASSWORD_CHANGE"
```

With the fix all 14 subtests pass, and `go build ./...` plus `go test ./...` are green across the repository.

### Test Coverage
**Added** in `network/ldap/ldap_attributes/pwdProperties_test.go`, a new file — the type had no tests at all:
- `TestPasswordProperties_String` — zero, single flag, two flags, three flags, all six flags, undefined bits only, and a known flag combined with an undefined bit.
- `TestPasswordProperties_Description` — a single flag yields one line, two flags yield two lines carrying both descriptions, zero yields an empty string.
- `TestPasswordProperties_GetFlags` — a two-flag value decomposes into exactly those two flags in ascending order.
- `TestPasswordProperties_EveryFlagIsNamed` — every entry in `PasswordPropertiesMap` round-trips through `String()` and has a non-empty description, so a flag added to one map but not the other is caught.

### Scope of Change
- **Files changed:** `network/ldap/ldap_attributes/pwdProperties.go`, `network/ldap/ldap_attributes/pwdProperties_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none. Single-flag values render exactly as before; `GetFlags()` is additive.

### Risk and Rollout
Local to two methods on one type, which has no consumer inside the repository. Output changes only for values that previously rendered as an empty string, which is the fix.
