### PR TITLE
Fix MSPKIEnrollmentFlag String reporting multi-flag values as unknown (Fixes #1129)

### DIFF
--- a/network/ldap/ldap_attributes/msPKI-Enrollment-Flag.go
+++ b/network/ldap/ldap_attributes/msPKI-Enrollment-Flag.go
@@ -1,6 +1,10 @@
 package ldap_attributes
 
-import "fmt"
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
 
 type MSPKIEnrollmentFlag uint32
 
@@ -122,10 +126,57 @@ var MSPKIEnrollmentFlagMap = map[MSPKIEnrollmentFlag]string{
 	MSPKI_ENROLLMENT_FLAG_NO_SECURITY_EXTENSION:                                         "No Security Extension",
 }
 
-// String returns the string representation of the enrollment flag
+// String returns the names of the flags set in the value, sorted alphabetically and
+// separated by a pipe ("|").
+//
+// msPKI-Enrollment-Flag is a bit field and a certificate template almost always sets
+// several flags at once, so each flag is tested with a bitwise AND rather than the
+// whole value being looked up as a single key. Any bits left over that the map does
+// not name are reported as a single trailing UnknownEnrollmentFlag entry, so an
+// unrecognised flag is still visible instead of hiding the recognised ones.
+//
+// A value with no bits set returns an empty string.
+//
+// Returns:
+//   - A string containing the names of the set flags, separated by a pipe ("|").
 func (flag MSPKIEnrollmentFlag) String() string {
-	if val, ok := MSPKIEnrollmentFlagMap[flag]; ok {
-		return val
+	names := []string{}
+	known := MSPKIEnrollmentFlag(0)
+
+	for candidate, name := range MSPKIEnrollmentFlagMap {
+		known |= candidate
+
+		if flag&candidate != 0 {
+			names = append(names, name)
+		}
 	}
-	return fmt.Sprintf("UnknownEnrollmentFlag(%d)", flag)
+
+	sort.Strings(names)
+
+	if residue := flag & ^known; residue != 0 {
+		names = append(names, fmt.Sprintf("UnknownEnrollmentFlag(0x%08x)", uint32(residue)))
+	}
+
+	return strings.Join(names, "|")
+}
+
+// GetFlags returns the flags set in the value, sorted in ascending order.
+//
+// Bits the map does not name are not returned; use String to see those.
+//
+// Returns:
+//   - A slice of MSPKIEnrollmentFlag values representing the set flags.
+func (flag MSPKIEnrollmentFlag) GetFlags() []MSPKIEnrollmentFlag {
+	flags := []MSPKIEnrollmentFlag{}
+	for candidate := range MSPKIEnrollmentFlagMap {
+		if flag&candidate != 0 {
+			flags = append(flags, candidate)
+		}
+	}
+
+	sort.Slice(flags, func(i, j int) bool {
+		return flags[i] < flags[j]
+	})
+
+	return flags
 }

--- a/network/ldap/ldap_attributes/msPKI-Enrollment-Flag_test.go
+++ b/network/ldap/ldap_attributes/msPKI-Enrollment-Flag_test.go
@@ -1,0 +1,101 @@
+package ldap_attributes_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/ldap/ldap_attributes"
+)
+
+// msPKI-Enrollment-Flag is a bit field and a certificate template almost always sets
+// several flags at once. An exact-match lookup reported those ordinary values as
+// UnknownEnrollmentFlag(<decimal>) even though every flag in them is named.
+func TestMSPKIEnrollmentFlag_String(t *testing.T) {
+	testCases := []struct {
+		name     string
+		value    ldap_attributes.MSPKIEnrollmentFlag
+		expected string
+	}{
+		{name: "no flags", value: 0x00000000, expected: ""},
+		{name: "single flag", value: 0x00000020, expected: "Auto Enrollment"},
+		{
+			name:     "auto enrollment and publish to DS",
+			value:    0x00000028,
+			expected: "Auto Enrollment|Publish to DS",
+		},
+		{
+			name:     "no security extension alone",
+			value:    0x00080000,
+			expected: "No Security Extension",
+		},
+		{
+			// PUBLISH_TO_DS | AUTO_ENROLLMENT | USER_INTERACTION_REQUIRED |
+			// ISSUANCE_POLICIES_FROM_REQUEST. Note 0x80 and 0x200 are not assigned by
+			// MS-CRTD, so a realistic value skips them.
+			name:  "a realistic template flag set",
+			value: 0x00020128,
+			expected: "Auto Enrollment|Issuance Policies From Request|Publish to DS|" +
+				"User Interaction Required",
+		},
+		{
+			name:     "unnamed bit alone",
+			value:    0x80000000,
+			expected: "UnknownEnrollmentFlag(0x80000000)",
+		},
+		{
+			name:     "named flag combined with an unnamed bit",
+			value:    0x80000020,
+			expected: "Auto Enrollment|UnknownEnrollmentFlag(0x80000000)",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := testCase.value.String(); got != testCase.expected {
+				t.Errorf("MSPKIEnrollmentFlag(0x%08x).String() = %q, want %q", uint32(testCase.value), got, testCase.expected)
+			}
+		})
+	}
+}
+
+// An unrecognised bit must not hide the flags that are recognised.
+func TestMSPKIEnrollmentFlag_UnknownBitDoesNotHideKnownFlags(t *testing.T) {
+	got := ldap_attributes.MSPKIEnrollmentFlag(0x00000028 | 0x40000000).String()
+
+	if !strings.Contains(got, "Auto Enrollment") || !strings.Contains(got, "Publish to DS") {
+		t.Errorf("String() = %q, want it to still name the recognised flags", got)
+	}
+
+	if !strings.Contains(got, "UnknownEnrollmentFlag(0x40000000)") {
+		t.Errorf("String() = %q, want it to report the unrecognised bit", got)
+	}
+}
+
+// GetFlags decomposes the value into the individual named flags it carries.
+func TestMSPKIEnrollmentFlag_GetFlags(t *testing.T) {
+	flags := ldap_attributes.MSPKIEnrollmentFlag(0x00000028).GetFlags()
+
+	expected := []ldap_attributes.MSPKIEnrollmentFlag{
+		ldap_attributes.MSPKI_ENROLLMENT_FLAG_PUBLISH_TO_DS,
+		ldap_attributes.MSPKI_ENROLLMENT_FLAG_AUTO_ENROLLMENT,
+	}
+
+	if len(flags) != len(expected) {
+		t.Fatalf("GetFlags() returned %d flags (%v), want %d", len(flags), flags, len(expected))
+	}
+
+	for i := range expected {
+		if flags[i] != expected[i] {
+			t.Errorf("GetFlags()[%d] = 0x%08x, want 0x%08x", i, uint32(flags[i]), uint32(expected[i]))
+		}
+	}
+}
+
+// Every name in the map must be reachable through String() on its own flag.
+func TestMSPKIEnrollmentFlag_EveryFlagIsNamed(t *testing.T) {
+	for flag, name := range ldap_attributes.MSPKIEnrollmentFlagMap {
+		if got := flag.String(); got != name {
+			t.Errorf("MSPKIEnrollmentFlag(0x%08x).String() = %q, want %q", uint32(flag), got, name)
+		}
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #1129`

### Root Cause
`MSPKIEnrollmentFlag` is a bit field, but `String()` used the whole value as a map key: `MSPKIEnrollmentFlagMap[flag]`. That only hits when the value equals a single flag constant, so any template with two or more flags set fell through to `UnknownEnrollmentFlag(<decimal>)` even though every flag in the value was named in the map.

Since a certificate template almost always carries several flags, the method reported "unknown" for the normal case and a name only for the rare single-flag one. `UserAccountControl.String()` in the same package already had the correct shape, so this was an inconsistency within one package rather than an open design question.

### Fix Description
`String()` now iterates the map, tests each flag with `flag&candidate != 0`, sorts the names and joins them with `|`, matching `UserAccountControl.String()` and the `PasswordProperties.String()` fixed in #1128.

The unknown-flag diagnostic is kept rather than dropped: the method accumulates the union of the named flags and, if the value carries bits outside that union, appends a single trailing `UnknownEnrollmentFlag(0x%08x)` entry. So an unrecognised bit is still surfaced instead of hiding the recognised ones, and it is now reported in hexadecimal with the residue isolated rather than as the decimal of the whole value. A value with no bits set returns an empty string, consistent with the other two types.

A `GetFlags()` method is added alongside, mirroring the same method on `UserAccountControl` and `PasswordProperties`.

### How Verified
The new tests were run against the old `String()` body to confirm they detect the defect:

```
MSPKIEnrollmentFlag(0x00000000).String() = "UnknownEnrollmentFlag(0)", want ""
MSPKIEnrollmentFlag(0x00000028).String() = "UnknownEnrollmentFlag(40)", want "Auto Enrollment|Publish to DS"
```

With the fix all subtests pass, and `go build ./...` plus `go test ./...` are green across the repository.

Writing the tests also turned up that bits `0x80` and `0x200` are not assigned by MS-CRTD — the flags run `0x40` then `0x100`, and `0x100` then `0x400`. A first draft of the "realistic template" case used `0x000200A8`, which includes `0x80`, and the new `String()` correctly reported that bit as `UnknownEnrollmentFlag(0x00000080)`. The test value was corrected to `0x00020128`, whose bits are all assigned, and a comment records why. The constant table itself matches the specification; nothing in it needed changing.

### Test Coverage
**Added** in `network/ldap/ldap_attributes/msPKI-Enrollment-Flag_test.go`, a new file — the type had no tests at all:
- `TestMSPKIEnrollmentFlag_String` — zero, single flag, two flags, a four-flag realistic template value, an unnamed bit alone, and a named flag combined with an unnamed bit.
- `TestMSPKIEnrollmentFlag_UnknownBitDoesNotHideKnownFlags` — an unrecognised bit is reported without suppressing the recognised names.
- `TestMSPKIEnrollmentFlag_GetFlags` — a two-flag value decomposes into exactly those two flags in ascending order.
- `TestMSPKIEnrollmentFlag_EveryFlagIsNamed` — every entry in `MSPKIEnrollmentFlagMap` round-trips through `String()`, so a flag added to the constants but not the map is caught.

### Scope of Change
- **Files changed:** `network/ldap/ldap_attributes/msPKI-Enrollment-Flag.go`, `network/ldap/ldap_attributes/msPKI-Enrollment-Flag_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none for values that previously resolved. Single-flag values render exactly as before. Two deliberate changes accompany the fix: a zero value now returns `""` instead of `UnknownEnrollmentFlag(0)`, and an unrecognised bit is reported in hexadecimal with only the residue rather than the decimal of the whole value.

### Risk and Rollout
Local to one method on one type, which has no consumer inside the repository. Output changes only for values that previously rendered as unknown, which is the fix.
