### PR TITLE
Fix LocalRIDs classifying domain-relative RIDs as BUILTIN (Fixes #1130)

### DIFF
--- a/network/ldap/ldap_attributes/RelativeIDs.go
+++ b/network/ldap/ldap_attributes/RelativeIDs.go
@@ -1,7 +1,16 @@
 package ldap_attributes
 
 // Predefined RIDs
+//
+// These are the RIDs whose well-known SID is domain-relative, of the form
+// S-1-5-<domain>-<rid>. The BUILTIN RIDs below, of the form S-1-5-32-<rid>, are a
+// separate list: the distinction is what FindObjectSIDByRID uses to decide which
+// SID to build, and it does not follow the DOMAIN_ALIAS_RID_* naming of the Windows
+// headers — RAS and IAS Servers and the two RODC password replication groups carry
+// alias-style names but are domain groups.
+//
 // Src: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/565a6584-3061-4ede-a531-f5c53826504b
+// Src: https://learn.microsoft.com/en-us/windows-server/identity/ad-ds/manage/understand-security-identifiers
 const (
 	RID_DOMAIN_USER_KRBTGT                                  = 0x000001F6
 	RID_DOMAIN_USER_ADMIN                                   = 0x000001F4
@@ -22,8 +31,11 @@ const (
 	RID_DOMAIN_GROUP_PROTECTED_USERS                        = 0x0000020D
 	RID_DOMAIN_GROUP_KEY_ADMINS                             = 0x0000020E
 	RID_DOMAIN_GROUP_ENTERPRISE_KEY_ADMINS                  = 0x0000020F
+	RID_DOMAIN_GROUP_ALLOWED_RODC_PASSWORD_REPLICATION      = 0x0000023B
 	RID_DOMAIN_GROUP_DENIED_RODC_PASSWORD_REPLICATION       = 0x0000023C
-	RID_DOMAIN_GROUP_ALIAS_CERTSVC_DCOM_ACCESS              = 0x0000023E
+	// S-1-5-<domain>-553, despite the DOMAIN_ALIAS_RID_RAS_SERVERS name in the
+	// Windows headers.
+	RID_DOMAIN_ALIAS_RAS_SERVERS = 0x00000229
 )
 
 var DomainRIDs = []int{
@@ -46,12 +58,20 @@ var DomainRIDs = []int{
 	RID_DOMAIN_GROUP_PROTECTED_USERS,
 	RID_DOMAIN_GROUP_KEY_ADMINS,
 	RID_DOMAIN_GROUP_ENTERPRISE_KEY_ADMINS,
+	RID_DOMAIN_GROUP_ALLOWED_RODC_PASSWORD_REPLICATION,
 	RID_DOMAIN_GROUP_DENIED_RODC_PASSWORD_REPLICATION,
-	RID_DOMAIN_GROUP_ALIAS_CERTSVC_DCOM_ACCESS,
+	RID_DOMAIN_ALIAS_RAS_SERVERS,
 }
 
-// Local RID
+// Local (BUILTIN) RIDs
+//
+// These are the RIDs whose well-known SID is of the form S-1-5-32-<rid>. RIDs whose
+// SID is domain-relative belong in the list above, not here: FindObjectSIDByRID
+// builds S-1-5-32-<rid> for every member of LocalRIDs, so a domain-relative RID
+// listed here is looked up as a SID that cannot exist.
+//
 // Src: https://learn.microsoft.com/en-us/windows/win32/secauthz/well-known-sids
+// Src: https://learn.microsoft.com/en-us/windows-server/identity/ad-ds/manage/understand-security-identifiers
 const (
 	RID_LOCAL_ADMINS                         = 0x00000220
 	RID_LOCAL_USERS                          = 0x00000221
@@ -62,7 +82,6 @@ const (
 	RID_LOCAL_PRINT_OPS                      = 0x00000226
 	RID_LOCAL_BACKUP_OPS                     = 0x00000227
 	RID_LOCAL_REPLICATOR                     = 0x00000228
-	RID_LOCAL_RAS_SERVERS                    = 0x00000229
 	RID_LOCAL_PREW2KCOMPACCESS               = 0x0000022A
 	RID_LOCAL_REMOTE_DESKTOP_USERS           = 0x0000022B
 	RID_LOCAL_NETWORK_CONFIGURATION_OPS      = 0x0000022C
@@ -74,8 +93,6 @@ const (
 	RID_LOCAL_DCOM_USERS                     = 0x00000232
 	RID_LOCAL_IUSERS                         = 0x00000238
 	RID_LOCAL_CRYPTO_OPERATORS               = 0x00000239
-	RID_LOCAL_CACHEABLE_PRINCIPALS_GROUP     = 0x0000023B
-	RID_LOCAL_NON_CACHEABLE_PRINCIPALS_GROUP = 0x0000023C
 	RID_LOCAL_EVENT_LOG_READERS_GROUP        = 0x0000023D
 	RID_LOCAL_CERTSVC_DCOM_ACCESS_GROUP      = 0x0000023E
 	RID_LOCAL_RDS_REMOTE_ACCESS_SERVERS      = 0x0000023F
@@ -99,7 +116,6 @@ var LocalRIDs = []int{
 	RID_LOCAL_PRINT_OPS,
 	RID_LOCAL_BACKUP_OPS,
 	RID_LOCAL_REPLICATOR,
-	RID_LOCAL_RAS_SERVERS,
 	RID_LOCAL_PREW2KCOMPACCESS,
 	RID_LOCAL_REMOTE_DESKTOP_USERS,
 	RID_LOCAL_NETWORK_CONFIGURATION_OPS,
@@ -111,8 +127,6 @@ var LocalRIDs = []int{
 	RID_LOCAL_DCOM_USERS,
 	RID_LOCAL_IUSERS,
 	RID_LOCAL_CRYPTO_OPERATORS,
-	RID_LOCAL_CACHEABLE_PRINCIPALS_GROUP,
-	RID_LOCAL_NON_CACHEABLE_PRINCIPALS_GROUP,
 	RID_LOCAL_EVENT_LOG_READERS_GROUP,
 	RID_LOCAL_CERTSVC_DCOM_ACCESS_GROUP,
 	RID_LOCAL_RDS_REMOTE_ACCESS_SERVERS,

--- a/network/ldap/ldap_attributes/RelativeIDs_test.go
+++ b/network/ldap/ldap_attributes/RelativeIDs_test.go
@@ -1,0 +1,110 @@
+package ldap_attributes_test
+
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/ldap/ldap_attributes"
+)
+
+// The two lists encode whether a RID's well-known SID is BUILTIN (S-1-5-32-<rid>) or
+// domain-relative (S-1-5-<domain>-<rid>), and FindObjectSIDByRID builds the BUILTIN
+// form for every LocalRIDs member. A domain-relative RID in LocalRIDs is therefore
+// looked up as a SID that cannot exist.
+//
+// Src: https://learn.microsoft.com/en-us/windows-server/identity/ad-ds/manage/understand-security-identifiers
+func TestLocalRIDsContainsOnlyBuiltinRIDs(t *testing.T) {
+	// RIDs Microsoft documents as S-1-5-<domain>-<rid> rather than S-1-5-32-<rid>.
+	domainScoped := map[int]string{
+		553: "RAS and IAS Servers",
+		571: "Allowed RODC Password Replication Group",
+		572: "Denied RODC Password Replication Group",
+	}
+
+	for _, rid := range ldap_attributes.LocalRIDs {
+		if name, ok := domainScoped[rid]; ok {
+			t.Errorf("LocalRIDs contains RID %d (0x%03X) %q, whose SID is S-1-5-<domain>-%d, not S-1-5-32-%d",
+				rid, rid, name, rid, rid)
+		}
+	}
+}
+
+// The domain-relative RIDs have to be reachable through DomainRIDs so the domain form
+// of the SID is built for them.
+func TestDomainRIDsContainsTheDomainScopedRIDs(t *testing.T) {
+	expected := map[int]string{
+		ldap_attributes.RID_DOMAIN_ALIAS_RAS_SERVERS:                       "RAS and IAS Servers",
+		ldap_attributes.RID_DOMAIN_GROUP_ALLOWED_RODC_PASSWORD_REPLICATION: "Allowed RODC Password Replication Group",
+		ldap_attributes.RID_DOMAIN_GROUP_DENIED_RODC_PASSWORD_REPLICATION:  "Denied RODC Password Replication Group",
+	}
+
+	present := map[int]bool{}
+	for _, rid := range ldap_attributes.DomainRIDs {
+		present[rid] = true
+	}
+
+	for rid, name := range expected {
+		if !present[rid] {
+			t.Errorf("DomainRIDs is missing RID %d (0x%03X) %q", rid, rid, name)
+		}
+	}
+}
+
+// No RID may appear in both lists: LocalRIDs is scanned first, so a duplicate makes
+// the domain form unreachable.
+func TestRIDListsDoNotOverlap(t *testing.T) {
+	inLocal := map[int]bool{}
+	for _, rid := range ldap_attributes.LocalRIDs {
+		inLocal[rid] = true
+	}
+
+	for _, rid := range ldap_attributes.DomainRIDs {
+		if inLocal[rid] {
+			t.Errorf("RID %d (0x%03X) is in both DomainRIDs and LocalRIDs", rid, rid)
+		}
+	}
+}
+
+// Neither list may contain the same RID twice under two names.
+func TestRIDListsHaveNoInternalDuplicates(t *testing.T) {
+	for _, testCase := range []struct {
+		name string
+		rids []int
+	}{
+		{name: "DomainRIDs", rids: ldap_attributes.DomainRIDs},
+		{name: "LocalRIDs", rids: ldap_attributes.LocalRIDs},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			seen := map[int]bool{}
+			for _, rid := range testCase.rids {
+				if seen[rid] {
+					t.Errorf("%s contains RID %d (0x%03X) more than once", testCase.name, rid, rid)
+				}
+				seen[rid] = true
+			}
+		})
+	}
+}
+
+// The values of the RIDs this fix moved, pinned against Microsoft's table.
+func TestDomainScopedRIDValues(t *testing.T) {
+	testCases := []struct {
+		name     string
+		rid      int
+		expected int
+	}{
+		{name: "RAS and IAS Servers", rid: ldap_attributes.RID_DOMAIN_ALIAS_RAS_SERVERS, expected: 553},
+		{name: "Allowed RODC Password Replication", rid: ldap_attributes.RID_DOMAIN_GROUP_ALLOWED_RODC_PASSWORD_REPLICATION, expected: 571},
+		{name: "Denied RODC Password Replication", rid: ldap_attributes.RID_DOMAIN_GROUP_DENIED_RODC_PASSWORD_REPLICATION, expected: 572},
+		{name: "Certificate Service DCOM Access (BUILTIN)", rid: ldap_attributes.RID_LOCAL_CERTSVC_DCOM_ACCESS_GROUP, expected: 574},
+		{name: "Event Log Readers (BUILTIN)", rid: ldap_attributes.RID_LOCAL_EVENT_LOG_READERS_GROUP, expected: 573},
+		{name: "Cryptographic Operators (BUILTIN)", rid: ldap_attributes.RID_LOCAL_CRYPTO_OPERATORS, expected: 569},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if testCase.rid != testCase.expected {
+				t.Errorf("%s = %d, want %d", testCase.name, testCase.rid, testCase.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #1130`

### Root Cause
`RelativeIDs.go` keeps two lists, and `FindObjectSIDByRID` uses membership of `LocalRIDs` to decide which SID to build: a member gets `S-1-5-32-<rid>`, anything else gets `<domainSID>-<rid>`. The lists therefore encode whether a RID's well-known SID is BUILTIN or domain-relative.

They were populated by following the `DOMAIN_ALIAS_RID_*` versus `DOMAIN_GROUP_RID_*` naming of the Windows headers, and that naming does not track the distinction. Three RIDs carry alias-style names but are domain groups per Microsoft's well-known SID table: RAS and IAS Servers (553), Allowed RODC Password Replication Group (571) and Denied RODC Password Replication Group (572). All three landed in `LocalRIDs`, so a lookup for any of them queried `S-1-5-32-<rid>` — a SID that cannot exist — and `FindObjectSIDByRID` returned an empty string with a nil error, giving the caller no signal that the query was malformed rather than genuinely unmatched.

Two RIDs were additionally defined twice, once in each list under different names. Since `LocalRIDs` is scanned first, the domain form was unreachable for 572.

### Fix Description
The three domain-relative RIDs move to the domain block and into `DomainRIDs`, so `FindObjectSIDByRID` falls through to the domain form for them:

- `RID_LOCAL_RAS_SERVERS` becomes `RID_DOMAIN_ALIAS_RAS_SERVERS` (553). The name keeps "ALIAS" because that is what the Windows header calls it, with a comment recording that the SID is nonetheless domain-relative.
- `RID_LOCAL_CACHEABLE_PRINCIPALS_GROUP` becomes `RID_DOMAIN_GROUP_ALLOWED_RODC_PASSWORD_REPLICATION` (571), named for the group as the directory presents it.
- `RID_LOCAL_NON_CACHEABLE_PRINCIPALS_GROUP` (572) is removed outright — `RID_DOMAIN_GROUP_DENIED_RODC_PASSWORD_REPLICATION` already existed in the domain block with the same value, and that was the duplicate making the domain form unreachable.

The other duplicate is resolved the other way: `RID_DOMAIN_GROUP_ALIAS_CERTSVC_DCOM_ACCESS` (574) is removed, because Certificate Service DCOM Access genuinely is `S-1-5-32-574` and `RID_LOCAL_CERTSVC_DCOM_ACCESS_GROUP` already covers it.

Both `const` blocks gain a comment stating which SID form the list represents and that the header naming does not track it, so the next RID added lands in the right list. `rid.go` needs no change: correcting list membership corrects the query it builds.

### How Verified
The classification comes from Microsoft's well-known SID table, which gives `S-1-5-<domain>-553`, `S-1-5-<domain>-571` and `S-1-5-<domain>-572` for these three, against `S-1-5-32-569` (Cryptographic Operators), `S-1-5-32-573` (Event Log Readers) and `S-1-5-32-574` (Certificate Service DCOM Access) in the same numeric range — the boundary runs through the middle of the range, which is what made this easy to get wrong.

The new tests were run against the old list membership to confirm they detect it:

```
LocalRIDs contains RID 553 (0x229) "RAS and IAS Servers", whose SID is S-1-5-<domain>-553, not S-1-5-32-553
LocalRIDs contains RID 571 (0x23B) "Allowed RODC Password Replication Group", whose SID is S-1-5-<domain>-571, not S-1-5-32-571
LocalRIDs contains RID 572 (0x23C) "Denied RODC Password Replication Group", whose SID is S-1-5-<domain>-572, not S-1-5-32-572
--- FAIL: TestRIDListsDoNotOverlap
```

`go build ./...` and `go test ./...` are green across the repository.

Not verified here: that `FindObjectSIDByRID` now returns these groups against a live domain. That needs a directory to query, and the SID string it builds is asserted only indirectly through list membership.

### Test Coverage
**Added** in `network/ldap/ldap_attributes/RelativeIDs_test.go`, a new file — the RID tables had no tests at all:
- `TestLocalRIDsContainsOnlyBuiltinRIDs` — none of the three domain-relative RIDs appears in `LocalRIDs`.
- `TestDomainRIDsContainsTheDomainScopedRIDs` — all three are reachable through `DomainRIDs`.
- `TestRIDListsDoNotOverlap` — no RID is in both lists, so the `LocalRIDs`-first scan cannot shadow a domain RID.
- `TestRIDListsHaveNoInternalDuplicates` — neither list carries the same RID twice under two names.
- `TestDomainScopedRIDValues` — the six values at the BUILTIN/domain boundary are pinned against Microsoft's table.

### Scope of Change
- **Files changed:** `network/ldap/ldap_attributes/RelativeIDs.go`, `network/ldap/ldap_attributes/RelativeIDs_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none. The other 31 `LocalRIDs` entries and their SID form are untouched.

### Risk and Rollout
Four exported constants change: two renamed, two removed. Nothing in the repository referenced any of them by name — `rid.go` reads only `LocalRIDs`, and `DomainRIDs` has no consumer at all — so the in-repo blast radius is nil, and an out-of-tree caller gets a compile error rather than a silent behaviour change.

### Notes
`DomainRIDs` remains unread by any code in the repository; it is exported, so it is left in place and kept correct rather than removed here.
