### PR TITLE
Fix DomainFunctionalityLevel.IsSupported omitting the 2003 Interim level (Fixes #1132)

### DIFF
--- a/network/ldap/ldap_attributes/domain_functionnality_level.go
+++ b/network/ldap/ldap_attributes/domain_functionnality_level.go
@@ -40,9 +40,19 @@ func (v DomainFunctionalityLevel) String() string {
 	}
 }
 
-// IsSupported returns true if the domain functionality level is supported by the current version of Windows
+// IsSupported returns true if the value is a domain functionality level this package
+// recognises, that is one named by DomainFunctionalityLevelToWindowsVersion.
+//
+// The check consults that table rather than restating its contents as a chain of
+// equality comparisons, which is how the two came to disagree: the comparison chain
+// listed eight of the nine defined levels and omitted 2003 Interim.
+//
+// Returns:
+//   - true if the level is one this package defines, false otherwise.
 func (v DomainFunctionalityLevel) IsSupported() bool {
-	return v == DOMAIN_FUNCTIONALITY_LEVEL_2000 || v == DOMAIN_FUNCTIONALITY_LEVEL_2003 || v == DOMAIN_FUNCTIONALITY_LEVEL_2008 || v == DOMAIN_FUNCTIONALITY_LEVEL_2008_R2 || v == DOMAIN_FUNCTIONALITY_LEVEL_2012 || v == DOMAIN_FUNCTIONALITY_LEVEL_2012_R2 || v == DOMAIN_FUNCTIONALITY_LEVEL_2016 || v == DOMAIN_FUNCTIONALITY_LEVEL_2025
+	_, exists := DomainFunctionalityLevelToWindowsVersion[v]
+
+	return exists
 }
 
 // Equal returns true if the domain functionality level is equal to the specified level

--- a/network/ldap/ldap_attributes/domain_functionnality_level_test.go
+++ b/network/ldap/ldap_attributes/domain_functionnality_level_test.go
@@ -1,0 +1,92 @@
+package ldap_attributes_test
+
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/ldap/ldap_attributes"
+)
+
+// IsSupported must agree with the table of defined levels. It used to restate that
+// table as a chain of equality comparisons and omitted 2003 Interim, so level 1 was
+// the only defined level reporting false.
+func TestDomainFunctionalityLevel_IsSupportedMatchesTheTable(t *testing.T) {
+	for level, name := range ldap_attributes.DomainFunctionalityLevelToWindowsVersion {
+		if !level.IsSupported() {
+			t.Errorf("level %d (%s) is named by the table but IsSupported() = false", level, name)
+		}
+	}
+}
+
+// Every defined level, checked explicitly so a level dropped from the table is caught
+// rather than silently skipped by the loop above.
+func TestDomainFunctionalityLevel_EveryDefinedLevel(t *testing.T) {
+	testCases := []struct {
+		name  string
+		level ldap_attributes.DomainFunctionalityLevel
+	}{
+		{name: "2000", level: ldap_attributes.DOMAIN_FUNCTIONALITY_LEVEL_2000},
+		{name: "2003 Interim", level: ldap_attributes.DOMAIN_FUNCTIONALITY_LEVEL_2003_INTERIM},
+		{name: "2003", level: ldap_attributes.DOMAIN_FUNCTIONALITY_LEVEL_2003},
+		{name: "2008", level: ldap_attributes.DOMAIN_FUNCTIONALITY_LEVEL_2008},
+		{name: "2008 R2", level: ldap_attributes.DOMAIN_FUNCTIONALITY_LEVEL_2008_R2},
+		{name: "2012", level: ldap_attributes.DOMAIN_FUNCTIONALITY_LEVEL_2012},
+		{name: "2012 R2", level: ldap_attributes.DOMAIN_FUNCTIONALITY_LEVEL_2012_R2},
+		{name: "2016", level: ldap_attributes.DOMAIN_FUNCTIONALITY_LEVEL_2016},
+		{name: "2025", level: ldap_attributes.DOMAIN_FUNCTIONALITY_LEVEL_2025},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if !testCase.level.IsSupported() {
+				t.Errorf("DOMAIN_FUNCTIONALITY_LEVEL_%s (%d).IsSupported() = false, want true", testCase.name, testCase.level)
+			}
+
+			if got := testCase.level.String(); got == "" {
+				t.Errorf("level %d has an empty String()", testCase.level)
+			}
+		})
+	}
+}
+
+// Values the package does not define must report false and render as unknown.
+func TestDomainFunctionalityLevel_UndefinedLevels(t *testing.T) {
+	for _, level := range []ldap_attributes.DomainFunctionalityLevel{8, 9, 11, 255} {
+		t.Run(ldap_attributes.DomainFunctionalityLevel(level).String(), func(t *testing.T) {
+			if level.IsSupported() {
+				t.Errorf("level %d.IsSupported() = true, want false", level)
+			}
+
+			if got, want := level.String(), "UNKNOWN"; len(got) < len(want) || got[:len(want)] != want {
+				t.Errorf("level %d.String() = %q, want it to start with %q", level, got, want)
+			}
+		})
+	}
+}
+
+// The 2003 Interim level, which is what the omission affected.
+func TestDomainFunctionalityLevel_2003InterimIsSupported(t *testing.T) {
+	level := ldap_attributes.DOMAIN_FUNCTIONALITY_LEVEL_2003_INTERIM
+
+	if level != 1 {
+		t.Fatalf("DOMAIN_FUNCTIONALITY_LEVEL_2003_INTERIM = %d, want 1", level)
+	}
+
+	if !level.IsSupported() {
+		t.Errorf("IsSupported() = false for 2003 Interim, which String() names %q", level.String())
+	}
+}
+
+// Ordering is used by the comparison helpers on Domain, so it has to be monotonic.
+func TestDomainFunctionalityLevel_Ordering(t *testing.T) {
+	if !ldap_attributes.DOMAIN_FUNCTIONALITY_LEVEL_2003.Less(ldap_attributes.DOMAIN_FUNCTIONALITY_LEVEL_2016) {
+		t.Error("2003 should be less than 2016")
+	}
+
+	if ldap_attributes.DOMAIN_FUNCTIONALITY_LEVEL_2025.Less(ldap_attributes.DOMAIN_FUNCTIONALITY_LEVEL_2016) {
+		t.Error("2025 should not be less than 2016")
+	}
+
+	if !ldap_attributes.DOMAIN_FUNCTIONALITY_LEVEL_2016.Equal(ldap_attributes.DOMAIN_FUNCTIONALITY_LEVEL_2016) {
+		t.Error("2016 should equal itself")
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #1132`

### Root Cause
`IsSupported()` restated the contents of `DomainFunctionalityLevelToWindowsVersion` as a chain of eight `||` equality comparisons instead of consulting it. A hand-written list that duplicates a table has to be edited in step with it, and it was not: the chain covered eight of the nine defined levels and omitted `DOMAIN_FUNCTIONALITY_LEVEL_2003_INTERIM`, so level 1 was the only defined level reporting `false` while `String()` named it "Windows Server 2003 Interim".

### Fix Description
The method now consults the table it was duplicating:

```go
func (v DomainFunctionalityLevel) IsSupported() bool {
	_, exists := DomainFunctionalityLevelToWindowsVersion[v]

	return exists
}
```

There is now one source of truth, so the two cannot drift again — a level added to or removed from the table changes `IsSupported()` with it.

The doc comment is corrected as part of the fix. It said "supported by the current version of Windows", which did not describe the old behaviour either: level 0 is Windows 2000 and reported `true`. It now says what the method actually answers — whether the value is a level this package recognises — since a caller reading the old comment would draw the wrong conclusion from a `true` result.

Adding `DOMAIN_FUNCTIONALITY_LEVEL_2003_INTERIM` to the existing chain was rejected: it would fix this instance and leave the duplication that caused it.

### How Verified
Runtime, before and after. Before, across every value from 0 to 10:

```
level=0  String()="Windows 2000"                 IsSupported()=true
level=1  String()="Windows Server 2003 Interim"  IsSupported()=false
level=2  String()="Windows Server 2003"          IsSupported()=true
...
level=10 String()="Windows Server 2025"          IsSupported()=true
```

The new tests run against the old method report:

```
level 1 (Windows Server 2003 Interim) is named by the table but IsSupported() = false
DOMAIN_FUNCTIONALITY_LEVEL_2003 Interim (1).IsSupported() = false, want true
```

After the fix every defined level reports `true`, undefined values 8, 9, 11 and 255 report `false` and render as `UNKNOWN (n)`, and `go build ./...`, `go vet ./network/ldap/...` and `go test ./...` are green across the repository.

### Test Coverage
**Added** in `network/ldap/ldap_attributes/domain_functionnality_level_test.go`, a new file — the type had no tests at all:
- `TestDomainFunctionalityLevel_IsSupportedMatchesTheTable` — iterates the table and asserts every named level is supported, so the two can never disagree again regardless of which levels the table holds.
- `TestDomainFunctionalityLevel_EveryDefinedLevel` — each of the nine levels named explicitly, so a level dropped from the table is caught rather than silently skipped by the loop above.
- `TestDomainFunctionalityLevel_UndefinedLevels` — 8, 9, 11 and 255 are unsupported and render as `UNKNOWN`.
- `TestDomainFunctionalityLevel_2003InterimIsSupported` — the specific level the omission affected, pinned at value 1.
- `TestDomainFunctionalityLevel_Ordering` — `Less` and `Equal`, which the `Domain` comparison helpers in `network/ldap/objects` depend on.

### Scope of Change
- **Files changed:** `network/ldap/ldap_attributes/domain_functionnality_level.go`, `network/ldap/ldap_attributes/domain_functionnality_level_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none. Level 1 changes from `false` to `true`; every other value returns what it did before.

### Risk and Rollout
One method body. Its only behaviour change is for level 1, and no caller in the repository invokes `IsSupported()` — `network/ldap/objects/domain.go` uses the `Less`, `Equal` and `Greater` comparisons instead.

### Notes
Out of scope here, and not filed as issues since neither is a defect: `String()` wraps its result in a redundant `fmt.Sprintf("%s", name)`, and `DOMAIN_FUNCTIONALITY_LEVEL_2025 = 10` could not be confirmed against a primary source — the MS-ADTS tables for both domain and forest functional levels stop at `DS_BEHAVIOR_WIN2016 = 7`, and the AD DS functional levels article names the Windows Server 2025 level without giving its integer. The value is left as it is rather than changed on a guess.
