### PR TITLE
Add a session-configurable LDAP paged-search page size (Fixes #1103)

### DIFF
--- a/network/ldap/pagesize_test.go
+++ b/network/ldap/pagesize_test.go
@@ -1,0 +1,225 @@
+package ldap
+
+import (
+	"net"
+	"testing"
+
+	ber "github.com/go-asn1-ber/asn1-ber"
+	"github.com/go-ldap/ldap/v3"
+)
+
+// pagingRecorder is a minimal LDAP server that answers every SearchRequest with an
+// empty SearchResultDone and records the page size carried by the paged-results
+// control (1.2.840.113556.1.4.319) the client attached to it. It exists to observe
+// what the session actually puts on the wire, which is the only place the page size
+// is visible from outside the package.
+type pagingRecorder struct {
+	listener  net.Listener
+	pageSizes []uint32
+	unpaged   []bool
+	done      chan struct{}
+}
+
+func newPagingRecorder(t *testing.T) *pagingRecorder {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %s", err)
+	}
+
+	recorder := &pagingRecorder{listener: listener, done: make(chan struct{})}
+	go recorder.serve()
+
+	return recorder
+}
+
+func (r *pagingRecorder) serve() {
+	defer close(r.done)
+
+	conn, err := r.listener.Accept()
+	if err != nil {
+		return
+	}
+	defer conn.Close()
+
+	for {
+		packet, err := ber.ReadPacket(conn)
+		if err != nil {
+			return
+		}
+		if len(packet.Children) < 2 {
+			return
+		}
+
+		messageID, ok := packet.Children[0].Value.(int64)
+		if !ok {
+			return
+		}
+
+		switch packet.Children[1].Tag {
+		case ldap.ApplicationSearchRequest:
+			pageSize, paged := uint32(0), false
+			if len(packet.Children) > 2 {
+				for _, controlPacket := range packet.Children[2].Children {
+					control, err := ldap.DecodeControl(controlPacket)
+					if err != nil {
+						continue
+					}
+					if pagingControl, ok := control.(*ldap.ControlPaging); ok {
+						pageSize, paged = pagingControl.PagingSize, true
+					}
+				}
+			}
+			r.pageSizes = append(r.pageSizes, pageSize)
+			r.unpaged = append(r.unpaged, !paged)
+			conn.Write(ldapResultDone(messageID, ldap.ApplicationSearchResultDone))
+		case ldap.ApplicationUnbindRequest:
+			return
+		default:
+			conn.Write(ldapResultDone(messageID, ldap.ApplicationBindResponse))
+		}
+	}
+}
+
+// ldapResultDone builds an LDAPMessage carrying a success result for the given
+// application response tag.
+func ldapResultDone(messageID int64, applicationTag ber.Tag) []byte {
+	message := ber.Encode(ber.ClassUniversal, ber.TypeConstructed, ber.TagSequence, nil, "LDAP Response")
+	message.AppendChild(ber.NewInteger(ber.ClassUniversal, ber.TypePrimitive, ber.TagInteger, messageID, "MessageID"))
+
+	response := ber.Encode(ber.ClassApplication, ber.TypeConstructed, applicationTag, nil, "Response")
+	response.AppendChild(ber.NewInteger(ber.ClassUniversal, ber.TypePrimitive, ber.TagEnumerated, 0, "resultCode"))
+	response.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, "", "matchedDN"))
+	response.AppendChild(ber.NewString(ber.ClassUniversal, ber.TypePrimitive, ber.TagOctetString, "", "diagnosticMessage"))
+	message.AppendChild(response)
+
+	return message.Bytes()
+}
+
+// recordPageSizes runs search against a session connected to a recording server and
+// returns the page sizes the searches asked for, in order.
+func recordPageSizes(t *testing.T, search func(session *Session)) ([]uint32, []bool) {
+	t.Helper()
+
+	recorder := newPagingRecorder(t)
+	defer recorder.listener.Close()
+
+	conn, err := net.Dial("tcp", recorder.listener.Addr().String())
+	if err != nil {
+		t.Fatalf("failed to dial the recording server: %s", err)
+	}
+
+	connection := ldap.NewConn(conn, false)
+	connection.Start()
+
+	session := &Session{connection: connection}
+	search(session)
+
+	connection.Close()
+	<-recorder.done
+
+	return recorder.pageSizes, recorder.unpaged
+}
+
+// TestQueryPageSizeDefault checks that a session which was never told otherwise
+// pages at DefaultPageSize.
+func TestQueryPageSizeDefault(t *testing.T) {
+	pageSizes, unpaged := recordPageSizes(t, func(session *Session) {
+		if _, err := session.Query("DC=example,DC=com", "(objectClass=*)", []string{"cn"}, ldap.ScopeWholeSubtree); err != nil {
+			t.Errorf("Query returned an error: %s", err)
+		}
+	})
+
+	if len(pageSizes) != 1 {
+		t.Fatalf("expected 1 search, got %d", len(pageSizes))
+	}
+	if unpaged[0] {
+		t.Fatalf("expected the search to carry a paged-results control")
+	}
+	if pageSizes[0] != DefaultPageSize {
+		t.Fatalf("expected a page size of %d, got %d", DefaultPageSize, pageSizes[0])
+	}
+}
+
+// TestQueryPageSizeSet checks that SetPageSize is what reaches the wire, for Query
+// and for the scope wrappers built on it.
+func TestQueryPageSizeSet(t *testing.T) {
+	pageSizes, unpaged := recordPageSizes(t, func(session *Session) {
+		session.SetPageSize(42)
+
+		if _, err := session.Query("DC=example,DC=com", "(objectClass=*)", []string{"cn"}, ldap.ScopeWholeSubtree); err != nil {
+			t.Errorf("Query returned an error: %s", err)
+		}
+		if _, err := session.QueryWholeSubtree("DC=example,DC=com", "(objectClass=*)", []string{"cn"}); err != nil {
+			t.Errorf("QueryWholeSubtree returned an error: %s", err)
+		}
+	})
+
+	if len(pageSizes) != 2 {
+		t.Fatalf("expected 2 searches, got %d", len(pageSizes))
+	}
+	for i, pageSize := range pageSizes {
+		if unpaged[i] {
+			t.Fatalf("expected search %d to carry a paged-results control", i)
+		}
+		if pageSize != 42 {
+			t.Fatalf("expected search %d to ask for a page size of 42, got %d", i, pageSize)
+		}
+	}
+}
+
+// TestQueryPageSizeZeroIsDefault checks that zero means unset rather than a page
+// size of zero, so a session literal and an explicit SetPageSize(0) both page at
+// DefaultPageSize.
+func TestQueryPageSizeZeroIsDefault(t *testing.T) {
+	pageSizes, _ := recordPageSizes(t, func(session *Session) {
+		session.SetPageSize(0)
+
+		if _, err := session.Query("DC=example,DC=com", "(objectClass=*)", []string{"cn"}, ldap.ScopeWholeSubtree); err != nil {
+			t.Errorf("Query returned an error: %s", err)
+		}
+	})
+
+	if len(pageSizes) != 1 || pageSizes[0] != DefaultPageSize {
+		t.Fatalf("expected a page size of %d, got %v", DefaultPageSize, pageSizes)
+	}
+}
+
+// TestSecurityDescriptorPageSizeSet checks that GetNtSecurityDescriptorOf, the
+// second call site that used to hardcode the page size, honours the session setting
+// too.
+func TestSecurityDescriptorPageSizeSet(t *testing.T) {
+	pageSizes, _ := recordPageSizes(t, func(session *Session) {
+		session.SetPageSize(7)
+
+		// The recording server returns no entries, so this reports "no entry
+		// returned"; the page size it asked for is what is under test.
+		session.GetNtSecurityDescriptorOf("DC=example,DC=com")
+	})
+
+	if len(pageSizes) != 1 || pageSizes[0] != 7 {
+		t.Fatalf("expected a page size of 7, got %v", pageSizes)
+	}
+}
+
+// TestGetPageSize checks the accessor against both a session built by NewSession
+// and a zero-value session literal.
+func TestGetPageSize(t *testing.T) {
+	session, err := NewSession("ldap.example.com", 389, nil, false, false)
+	if err != nil {
+		t.Fatalf("failed to create the session: %s", err)
+	}
+	if session.GetPageSize() != DefaultPageSize {
+		t.Fatalf("expected NewSession to default to %d, got %d", DefaultPageSize, session.GetPageSize())
+	}
+
+	session.SetPageSize(500)
+	if session.GetPageSize() != 500 {
+		t.Fatalf("expected 500, got %d", session.GetPageSize())
+	}
+
+	if (&Session{}).GetPageSize() != DefaultPageSize {
+		t.Fatalf("expected a zero-value session to report %d, got %d", DefaultPageSize, (&Session{}).GetPageSize())
+	}
+}

--- a/network/ldap/query.go
+++ b/network/ldap/query.go
@@ -109,7 +109,7 @@ func (ldapSession *Session) QueryWithControls(searchBase string, query string, a
 	)
 
 	// Perform LDAP search
-	searchResult, err := ldapSession.connection.SearchWithPaging(searchRequest, 1000)
+	searchResult, err := ldapSession.connection.SearchWithPaging(searchRequest, ldapSession.GetPageSize())
 	if err != nil {
 		return nil, fmt.Errorf("error searching LDAP: %w", err)
 	}

--- a/network/ldap/security_descriptors.go
+++ b/network/ldap/security_descriptors.go
@@ -92,7 +92,7 @@ func (s *Session) GetNtSecurityDescriptorOf(distinguishedName string) (string, e
 		[]ldap.Control{control},
 	)
 
-	searchResult, err := s.connection.SearchWithPaging(searchRequest, 1000)
+	searchResult, err := s.connection.SearchWithPaging(searchRequest, s.GetPageSize())
 	if err != nil {
 		return "", fmt.Errorf("error searching for nTSecurityDescriptor: %w", err)
 	}

--- a/network/ldap/session.go
+++ b/network/ldap/session.go
@@ -65,7 +65,21 @@ type Session struct {
 	// negotiated per-message security context survives past the bind and is torn
 	// down on Close.
 	gssClient *nativeGSSAPIClient
+	// pageSize is the number of entries a paged search asks the server for per
+	// page. It defaults to DefaultPageSize; use SetPageSize to change it. Zero
+	// means unset and selects DefaultPageSize, so a Session built as a literal
+	// rather than through NewSession still pages.
+	pageSize uint32
 }
+
+// DefaultPageSize is the page size a session requests for a paged search unless
+// SetPageSize says otherwise.
+//
+// It matches MaxPageSize in the default Active Directory query policy
+// (CN=Default Query Policy,CN=Query-Policies,CN=Directory Service,CN=Windows NT,
+// CN=Services,<configurationNamingContext>), which is the ceiling a domain
+// controller applies to a paged search out of the box.
+const DefaultPageSize uint32 = 1000
 
 // NewSession creates a new LDAP session with the provided configuration and credentials.
 //
@@ -112,6 +126,8 @@ func NewSession(host string, port int, credentials *credentials.Credentials, use
 	// Preserve the historical default of an auth-only GSSAPI bind (no ongoing
 	// sign/seal); callers opt into a security layer explicitly.
 	s.gssapiLayer = saslLayerNone
+	// Preserve the historical page size every paged search used to hardcode.
+	s.pageSize = DefaultPageSize
 
 	return s, nil
 }
@@ -142,6 +158,34 @@ func (s *Session) SetGSSAPISealing() {
 // This must be called before Connect to take effect.
 func (s *Session) SetTLSSkipVerify(skip bool) {
 	s.tlsSkipVerify = skip
+}
+
+// SetPageSize sets how many entries a paged search asks the server for per page.
+//
+// The server caps this at its own limit (MaxPageSize in the Active Directory query
+// policy, 1000 by default), so a larger value is not an error, it is simply not
+// honoured. A smaller one costs more round-trips and returns the first entries
+// sooner.
+//
+// It applies to every subsequent paged search made through the session: Query and
+// its scope wrappers, QueryWithControls, and GetNtSecurityDescriptorOf. It may be
+// called at any time, before or after Connect.
+//
+// Parameters:
+//
+//	pageSize (uint32): The number of entries per page. Zero means unset and
+//	  selects DefaultPageSize.
+func (s *Session) SetPageSize(pageSize uint32) {
+	s.pageSize = pageSize
+}
+
+// GetPageSize returns the page size a paged search on this session requests, which
+// is DefaultPageSize unless SetPageSize set another one.
+func (s *Session) GetPageSize() uint32 {
+	if s.pageSize == 0 {
+		return DefaultPageSize
+	}
+	return s.pageSize
 }
 
 // SetKerberosSPNHostname sets the hostname used to build the ldap/<host> service


### PR DESCRIPTION
### Linked Issue

`Closes #1103`

### Root Cause

`network/ldap` was written with the Active Directory default in mind and never made
that default a decision a caller could take part in. The page size was a bare `1000`
at each of the two `SearchWithPaging` call sites — `QueryWithControls()` in
`query.go` and `GetNtSecurityDescriptorOf()` in `security_descriptors.go` — rather
than a constant or a session setting. Because `Session.connection` is unexported,
there was no way around the library either: a tool could not drop down to the
`*ldap.Conn` and issue its own search. The result is that `MaxPageSize` in the
server's query policy, which is administrator-settable, was answered by the client
with a fixed guess, and duplicated at that.

### Fix Description

Additive, as the issue requires: `Query` and its five wrappers have 25 call sites in
Manticore and 129 across the sibling tools, so no signature changes.

- `DefaultPageSize uint32 = 1000` — the default now has a single named home.
- `pageSize` field on `Session`, defaulted to `DefaultPageSize` in `NewSession`.
- `SetPageSize(uint32)` / `GetPageSize()`, matching the existing option setters
  (`SetTLSSkipVerify`, `SetGSSAPISigning`, `SetGSSAPISealing`,
  `SetKerberosSPNHostname`). One setting covers `Query`, all five scope wrappers,
  `QueryWithControls` and `GetNtSecurityDescriptorOf`.
- Both call sites now read `GetPageSize()`.

A page size of `0` means unset and selects `DefaultPageSize` — the second of the two
readings the issue put forward. `GetPageSize()` resolves it in the accessor rather
than only in `NewSession`, so a `Session` built as a struct literal (the form several
doc comments in the package use) pages at 1000 instead of sending a paged-results
control with a size of zero.

Unpaged search — `Conn.Search` with no `1.2.840.113556.1.4.319` control — is
deliberately **not** part of this PR. It carries truncation semantics that need
deciding (Active Directory answers a search past `MaxPageSize` with the entries it
did return plus `LDAP_SIZELIMIT_EXCEEDED`), and that behaviour has not been checked
against a live domain controller. It should be a separate change on its own setting,
not an overload of the value `0`.

### How Verified

**Runtime.** The page size is only observable on the wire, so verification runs the
session against a minimal in-process LDAP server that decodes the paged-results
control off each `SearchRequest` and answers with an empty `SearchResultDone`.

Before the change, on the same harness:

```
page sizes seen on the wire: [1000] (unpaged: [false])
```

for every session, with no API able to alter it. After the change, `SetPageSize(42)`
puts `42` on the wire for `Query` and for `QueryWholeSubtree`, `SetPageSize(7)` puts
`7` on the wire for `GetNtSecurityDescriptorOf`, and an untouched session still sends
`1000`.

```
$ go test -race ./network/ldap/
ok      github.com/TheManticoreProject/Manticore/network/ldap   1.067s
```

`go build ./...`, `go vet ./network/ldap/` and `gofmt -l` are clean.

### Test Coverage

**Added:** `network/ldap/pagesize_test.go`

- `TestQueryPageSizeDefault` — an untouched session sends `DefaultPageSize` and does
  carry a paged-results control.
- `TestQueryPageSizeSet` — `SetPageSize(42)` reaches the wire for both `Query` and
  the `QueryWholeSubtree` wrapper.
- `TestQueryPageSizeZeroIsDefault` — `SetPageSize(0)` sends `DefaultPageSize`.
- `TestSecurityDescriptorPageSizeSet` — the second former call site,
  `GetNtSecurityDescriptorOf`, honours the session setting.
- `TestGetPageSize` — accessor behaviour for a `NewSession` session, after a set, and
  for a zero-value `Session` literal.

The tests assert on decoded wire bytes rather than on the field, so they would have
caught the hardcoded literal.

### Scope of Change

- **Files changed:** `network/ldap/session.go`, `network/ldap/query.go`,
  `network/ldap/security_descriptors.go`, `network/ldap/pagesize_test.go` (new)
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout

The default is unchanged and no signature moves, so every existing caller in
Manticore and in the sibling tool repositories keeps sending exactly the bytes it
sent before. The only new behaviour is reached by calling `SetPageSize`. Safe to
merge directly.

### Notes

This unblocks the `-s / --page-size` flag in `manticore-ldapmonitor`, which the issue
names as the motivating case.