### PR TITLE
Fix a named-pipe answer larger than the client buffer being unreadable (Fixes #1139)

### DIFF
--- a/network/smb/smb_v10/server/doc.go
+++ b/network/smb/smb_v10/server/doc.go
@@ -41,7 +41,9 @@
 //   - Named pipes, over TRANSACTION: a pipe is opened on a pipe share like a
 //     file, and TRANS_TRANSACT_NMPIPE writes a message to the handle and returns
 //     the answer. That write-then-read is the operation MS-RPC travels over, so a
-//     PipeHandler is all an RPC service needs to be reachable over SMB1.
+//     PipeHandler is all an RPC service needs to be reachable over SMB1. An answer
+//     too large for one response is collected with TRANS_READ_NMPIPE,
+//     TRANS_PEEK_NMPIPE or SMB_COM_READ_ANDX on the same handle.
 //   - The volume queries a client actually asks: the TRANSACTION2 volume levels,
 //     the pass-through information classes above 0x03E8 that carry the native
 //     ones, and the legacy SMB_COM_QUERY_INFORMATION_DISK. A client asks about
@@ -106,6 +108,19 @@
 // STATUS_BUFFER_OVERFLOW, which is what tells the client to read again. Reporting
 // plain success would leave an RPC client parsing a truncated response as a whole
 // one.
+//
+// The part that did not fit is kept on the handle, and reading again is how the
+// client collects it: SMB_COM_READ_ANDX on the pipe FID, TRANS_READ_NMPIPE, or
+// TRANS_PEEK_NMPIPE to size the read first. A read once the answer is exhausted
+// returns no data rather than an error, because a client reads a pipe only after
+// being told more remains, so an empty read is the end of the answer rather than a
+// failure. Writing a pipe handle with SMB_COM_WRITE_ANDX is still refused: a
+// handler answers a transaction rather than accepting a stream, so there is
+// nowhere for the write to go.
+//
+// The handler is asked for the whole answer rather than for the part that fits,
+// bounded by maxPipeAnswerSize, because only the server knows how the client will
+// read the rest.
 //
 // # Character encoding
 //

--- a/network/smb/smb_v10/server/handler_file.go
+++ b/network/smb/smb_v10/server/handler_file.go
@@ -353,6 +353,14 @@ func handleReadAndx(conn *Connection, w ResponseWriter, req *message.Message) nt
 		length = 0
 	}
 
+	// A pipe handle is a stream of the answer a transaction produced, not a file:
+	// there is nothing at an offset, and reading is how a client collects an
+	// answer that did not fit in one response. An RPC client does exactly this
+	// after STATUS_BUFFER_OVERFLOW, so refusing it strands the conversation.
+	if open.IsPipe {
+		return conn.readPipeHandle(w, open, length)
+	}
+
 	file, status := fileFor(open)
 	if status != nt_status.NT_STATUS_SUCCESS {
 		return status
@@ -379,6 +387,41 @@ func handleReadAndx(conn *Connection, w ResponseWriter, req *message.Message) nt
 // 32-byte header, the parameter words and the byte count. Reserving it keeps a
 // full-size read inside the negotiated buffer.
 const readResponseOverhead = 64
+
+// readPipeHandle answers SMB_COM_READ_ANDX against a pipe handle, from the answer
+// buffered on it.
+//
+// The request's offset is ignored, because a pipe has no addressable content: the
+// buffer is consumed from the front, which is what makes repeated reads collect
+// successive parts of one answer.
+//
+// A read with nothing buffered returns no data rather than an error. A client
+// reads a pipe only after being told more remains, so an empty read means the
+// answer is finished, and reporting an error for it would turn a completed
+// exchange into a failed one.
+//
+// Parameters:
+//   - w: where the response is written
+//   - open: the pipe handle being read
+//   - length: the most bytes the response may carry
+//
+// Returns:
+//   - The status to report, which is success once the response is sent
+func (c *Connection) readPipeHandle(w ResponseWriter, open *Open, length int) nt_status.NT_STATUS {
+	chunk, moreRemains := open.drainPipeOutput(length)
+
+	logger.Debugf("SMB1 server: read %d bytes of pipe %q for %s, more remains=%t",
+		len(chunk), open.Path, c.Remote, moreRemains)
+
+	response := commands.NewReadAndxResponse()
+	response.Data = chunk
+	response.DataLength = types.USHORT(len(chunk))
+
+	if err := w.WriteResponse(response); err != nil {
+		logger.Debugf("SMB1 server: failed to answer the pipe read for %s: %v", c.Remote, err)
+	}
+	return nt_status.NT_STATUS_SUCCESS
+}
 
 // handleWriteAndx answers SMB_COM_WRITE_ANDX.
 func handleWriteAndx(conn *Connection, w ResponseWriter, req *message.Message) nt_status.NT_STATUS {
@@ -492,9 +535,10 @@ func handleFlush(conn *Connection, w ResponseWriter, req *message.Message) nt_st
 func fileFor(open *Open) (File, nt_status.NT_STATUS) {
 	switch {
 	case open.IsPipe:
-		// The pipe handler serves a transacted exchange rather than a stream. A
-		// client that reads or writes a pipe handle directly is told so, rather
-		// than given an empty read it would take for an answer.
+		// A pipe handle has a handler behind it rather than a file. Reading one is
+		// served by readPipeHandle before reaching here; writing one is a request
+		// the handler has no way to receive, since a handler answers a transaction
+		// rather than accepting a stream, so it is refused.
 		return nil, nt_status.NT_STATUS_NOT_SUPPORTED
 	case open.File == nil:
 		// What a read or a write on a directory is answered with.

--- a/network/smb/smb_v10/server/handler_pipe.go
+++ b/network/smb/smb_v10/server/handler_pipe.go
@@ -33,7 +33,10 @@ type PipeHandler interface {
 	OpenPipe(name string) error
 
 	// Transact writes a message to a pipe and returns the answer. maxOutput is
-	// the largest answer the client can receive; a handler that would exceed it
+	// the largest answer the server will take in one exchange, which is
+	// maxPipeAnswerSize rather than the client's buffer: fitting the answer to
+	// the client is the server's job, because only the server knows how the
+	// client will read the rest. A handler whose answer would exceed maxOutput
 	// should return what fits and report that more remains.
 	Transact(name string, input []byte, maxOutput int) (output []byte, moreRemains bool, err error)
 
@@ -163,6 +166,12 @@ func (c *Connection) runTransaction(w ResponseWriter, req *message.Message, reas
 	case subcommands.TRANS_TRANSACT_NMPIPE:
 		return c.transactNamedPipe(w, req, tree, reassembly)
 
+	case subcommands.TRANS_READ_NMPIPE:
+		return c.readNamedPipe(w, reassembly)
+
+	case subcommands.TRANS_PEEK_NMPIPE:
+		return c.peekNamedPipe(w, reassembly)
+
 	case subcommands.TRANS_WAIT_NMPIPE:
 		// The pipe is available as soon as the handler knows the name, so waiting
 		// for it succeeds immediately rather than blocking on nothing.
@@ -189,6 +198,172 @@ func (c *Connection) runTransaction(w ResponseWriter, req *message.Message, reas
 	return nt_status.NT_STATUS_NOT_IMPLEMENTED
 }
 
+// maxPipeAnswerSize bounds the answer the server will take from a handler in one
+// exchange, and so bounds what one handle may hold undelivered.
+//
+// It is not the client's buffer: the client's buffer bounds one response, and an
+// answer larger than that is delivered across several reads. It is a ceiling on
+// buffering, because the client chooses when to read and a handler that produced
+// a very large answer would otherwise pin that memory until the handle closed.
+const maxPipeAnswerSize = 64 * 1024
+
+// namedPipeStateConnectionOk is the NamedPipeState a peek reports for a pipe whose
+// handler is present and answering ([MS-CIFS] section 2.2.5.5.2).
+const namedPipeStateConnectionOk = 0x0003
+
+// peekParametersSize is the size of a peek response's Trans_Parameters:
+// ReadDataAvailable(2) MessageBytesLength(2) NamedPipeState(2), per [MS-CIFS]
+// section 2.2.5.5.2.
+const peekParametersSize = 6
+
+// pipeReadBudget is how many bytes a pipe response may carry, from the client's
+// MaxDataCount. A client that named no limit gets the largest a transaction can
+// describe.
+//
+// Parameters:
+//   - maxDataCount: the MaxDataCount the client sent
+//
+// Returns:
+//   - The number of bytes the response may carry
+func pipeReadBudget(maxDataCount int) int {
+	if maxDataCount <= 0 || maxDataCount > maxTrans2Payload {
+		return maxTrans2Payload
+	}
+	return maxDataCount
+}
+
+// pipeOpenFrom resolves the pipe handle a transaction acts on from its setup
+// words.
+//
+// [MS-CIFS] sections 3.3.5.57.6, 3.3.5.57.7 and 3.3.5.57.9 all identify the pipe
+// by the FID in Setup[1], so this is the one place that reads it.
+//
+// Parameters:
+//   - reassembly: the assembled transaction
+//
+// Returns:
+//   - The open handle, or the status that says why there is none
+func (c *Connection) pipeOpenFrom(reassembly *transactionReassembly) (*Open, nt_status.NT_STATUS) {
+	if len(reassembly.setup) < 2 {
+		logger.Debugf("SMB1 server: %s sent pipe operation 0x%04X with no FID in its setup words",
+			c.Remote, reassembly.subcommand)
+		return nil, nt_status.NT_STATUS_INVALID_PARAMETER
+	}
+
+	fid := uint16(reassembly.setup[1])
+	open := c.Open(fid)
+	switch {
+	case open == nil:
+		logger.Debugf("SMB1 server: %s sent a pipe operation on FID 0x%04X, which is not open", c.Remote, fid)
+		return nil, nt_status.NT_STATUS_SMB_BAD_FID
+	case !open.IsPipe:
+		logger.Debugf("SMB1 server: %s sent a pipe operation on FID 0x%04X, which is a file", c.Remote, fid)
+		return nil, nt_status.NT_STATUS_INVALID_HANDLE
+	}
+	return open, nt_status.NT_STATUS_SUCCESS
+}
+
+// readNamedPipe answers TRANS_READ_NMPIPE: it returns the next part of the answer
+// buffered on a pipe handle.
+//
+// This is one of the two ways a client collects an answer that did not fit in the
+// transaction that produced it; SMB_COM_READ_ANDX on the same handle is the other.
+//
+// A read with nothing buffered answers with no data rather than blocking. The
+// specification has a blocking pipe wait "indefinitely for data to become
+// available" ([MS-CIFS] section 3.3.5.57.9), but a handler here answers a
+// transaction rather than producing data on its own, so there is nothing for a
+// wait to become available from, and blocking would hold the connection forever.
+//
+// Wire format: [MS-CIFS] section 2.2.5.8.2. Server behaviour: section 3.3.5.57.9.
+//
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/
+func (c *Connection) readNamedPipe(w ResponseWriter, reassembly *transactionReassembly) nt_status.NT_STATUS {
+	open, status := c.pipeOpenFrom(reassembly)
+	if status != nt_status.NT_STATUS_SUCCESS {
+		return status
+	}
+
+	chunk, moreRemains := open.drainPipeOutput(pipeReadBudget(reassembly.maxDataCount))
+
+	// [MS-CIFS] section 3.3.5.57.9: on either success or STATUS_BUFFER_OVERFLOW
+	// the server MUST construct a TRANS_READ_NMPIPE Response, so the status
+	// travels with the data.
+	answer := nt_status.NT_STATUS_SUCCESS
+	if moreRemains {
+		answer = nt_status.NT_STATUS_BUFFER_OVERFLOW
+	}
+
+	logger.Debugf("SMB1 server: read %d bytes of pipe %q for %s, more remains=%t",
+		len(chunk), open.Path, c.Remote, moreRemains)
+
+	if err := c.sendTransactionResponse(w, reassembly, nil, chunk, answer); err != nil {
+		logger.Debugf("SMB1 server: failed to answer the pipe read for %s: %v", c.Remote, err)
+	}
+	return nt_status.NT_STATUS_SUCCESS
+}
+
+// peekNamedPipe answers TRANS_PEEK_NMPIPE: it returns the front of the answer
+// buffered on a pipe handle without consuming it, plus how much is there.
+//
+// A client peeks to size a read before making it, so the counts matter as much as
+// the data.
+//
+// Wire format: [MS-CIFS] section 2.2.5.5.2. Server behaviour: section 3.3.5.57.6.
+//
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/
+func (c *Connection) peekNamedPipe(w ResponseWriter, reassembly *transactionReassembly) nt_status.NT_STATUS {
+	open, status := c.pipeOpenFrom(reassembly)
+	if status != nt_status.NT_STATUS_SUCCESS {
+		return status
+	}
+
+	// The client's budget covers the parameters as well as the data, and the
+	// parameters go out in the first message, so the peeked chunk has to leave
+	// room for them. Peeking the full budget instead would push the tail of the
+	// chunk into a second message and leave ReadDataAvailable and
+	// MessageBytesLength describing bytes this response did not carry — the two
+	// counts a client sizes its next read from.
+	budget := pipeReadBudget(reassembly.maxDataCount) - peekParametersSize
+	if budget < 0 {
+		budget = 0
+	}
+	chunk, available := open.peekPipeOutput(budget)
+
+	// MessageBytesLength is what is left of the peeked message after what is
+	// being returned.
+	parameters := make([]byte, peekParametersSize)
+	binary.LittleEndian.PutUint16(parameters[0:2], clampToUint16(available))
+	binary.LittleEndian.PutUint16(parameters[2:4], clampToUint16(available-len(chunk)))
+	binary.LittleEndian.PutUint16(parameters[4:6], namedPipeStateConnectionOk)
+
+	answer := nt_status.NT_STATUS_SUCCESS
+	if available > len(chunk) {
+		answer = nt_status.NT_STATUS_BUFFER_OVERFLOW
+	}
+
+	logger.Debugf("SMB1 server: peeked %d of %d buffered bytes of pipe %q for %s",
+		len(chunk), available, open.Path, c.Remote)
+
+	if err := c.sendTransactionResponse(w, reassembly, parameters, chunk, answer); err != nil {
+		logger.Debugf("SMB1 server: failed to answer the pipe peek for %s: %v", c.Remote, err)
+	}
+	return nt_status.NT_STATUS_SUCCESS
+}
+
+// clampToUint16 fits a length into the 16-bit field that describes it, saturating
+// rather than wrapping: a count that wrapped would describe less data than is
+// there and stop a client reading the rest.
+func clampToUint16(value int) uint16 {
+	if value < 0 {
+		return 0
+	}
+	if value > 0xFFFF {
+		return 0xFFFF
+	}
+	return uint16(value)
+}
+
 // pipeStateMessageMode is the NMPIPE_STATE a query reports: message-type pipe,
 // message-mode reads, blocking, unlimited instances ([MS-CIFS] 2.2.7.2).
 const pipeStateMessageMode = 0x0500
@@ -210,21 +385,14 @@ func (c *Connection) transactNamedPipe(
 	// which is Setup[1] behind the subcommand. So the handle the client opened is
 	// what names the pipe, and the request's Name field is boilerplate — the
 	// subcommand sets it to "\PIPE\", which names nothing on its own.
+	var open *Open
 	name := ""
 	if len(reassembly.setup) >= 2 {
-		open := c.Open(uint16(reassembly.setup[1]))
-		switch {
-		case open == nil:
-			logger.Debugf("SMB1 server: %s sent a pipe transaction on FID 0x%04X, which is not open",
-				c.Remote, uint16(reassembly.setup[1]))
-			return nt_status.NT_STATUS_SMB_BAD_FID
-		case !open.IsPipe:
-			logger.Debugf("SMB1 server: %s sent a pipe transaction on FID 0x%04X, which is a file",
-				c.Remote, uint16(reassembly.setup[1]))
-			return nt_status.NT_STATUS_INVALID_HANDLE
-		default:
-			name = open.Path
+		resolved, status := c.pipeOpenFrom(reassembly)
+		if status != nt_status.NT_STATUS_SUCCESS {
+			return status
 		}
+		open, name = resolved, resolved.Path
 	}
 	// A client that sent no FID may still have named the pipe outright. That is
 	// not what the subcommand specifies, but answering it costs nothing and a
@@ -237,15 +405,34 @@ func (c *Connection) transactNamedPipe(
 		return nt_status.NT_STATUS_OBJECT_NAME_NOT_FOUND
 	}
 
-	budget := reassembly.maxDataCount
-	if budget <= 0 || budget > maxTrans2Payload {
-		budget = maxTrans2Payload
-	}
-
-	output, moreRemains, err := tree.Share.Pipes.Transact(name, reassembly.data, budget)
+	// The handler is asked for the whole answer, not for the part that fits: the
+	// client's buffer bounds what one response may carry, not what the pipe
+	// produced, and the difference is what gets buffered for the client to read.
+	output, moreRemains, err := tree.Share.Pipes.Transact(name, reassembly.data, maxPipeAnswerSize)
 	if err != nil {
 		logger.Debugf("SMB1 server: pipe %q refused a transaction from %s: %v", name, c.Remote, err)
 		return statusForPipeError(err)
+	}
+
+	// Cut the answer to what the client said it could receive, and keep the rest
+	// on the handle. Keeping it is what makes STATUS_BUFFER_OVERFLOW below an
+	// instruction the client can act on: discarding it would leave the client
+	// reading for data that no longer exists.
+	deliver := output
+	if budget := pipeReadBudget(reassembly.maxDataCount); len(deliver) > budget {
+		deliver = output[:budget]
+	}
+	remainder := output[len(deliver):]
+	if len(remainder) > 0 {
+		if open == nil {
+			// No FID was sent, so there is no handle to hold the rest on and no
+			// handle for the client to read it from either. The answer is cut and
+			// the overflow reported, which is all this case can honestly do.
+			logger.Debugf("SMB1 server: %s transacted pipe %q without a FID, so %d undelivered bytes are dropped",
+				c.Remote, name, len(remainder))
+		} else {
+			open.pipeOutput = append(open.pipeOutput, remainder...)
+		}
 	}
 
 	// What the client is told about a truncated answer is the whole difference
@@ -254,12 +441,12 @@ func (c *Connection) transactNamedPipe(
 	// TRANS_TRANSACT_NMPIPE Response" — the status travels alongside the data
 	// rather than instead of it, and it is what tells the client to read again.
 	status := nt_status.NT_STATUS_SUCCESS
-	if moreRemains {
+	if moreRemains || len(remainder) > 0 {
 		status = nt_status.NT_STATUS_BUFFER_OVERFLOW
 		logger.Debugf("SMB1 server: pipe %q has more to return to %s", name, c.Remote)
 	}
 
-	if err := c.sendTransactionResponse(w, reassembly, nil, output, status); err != nil {
+	if err := c.sendTransactionResponse(w, reassembly, nil, deliver, status); err != nil {
 		logger.Debugf("SMB1 server: failed to answer the pipe transaction for %s: %v", c.Remote, err)
 	}
 	// The response has been sent, status included, so the dispatcher must not send

--- a/network/smb/smb_v10/server/nttransact_test.go
+++ b/network/smb/smb_v10/server/nttransact_test.go
@@ -178,6 +178,21 @@ func sendTransaction(
 	parameters, data []byte,
 ) (*commands.TransactionResponse, uint32) {
 	t.Helper()
+	return sendTransactionWithLimit(t, client, setup, name, parameters, data, 4096)
+}
+
+// sendTransactionWithLimit is sendTransaction with the client's MaxDataCount
+// under the test's control, which is what decides whether an answer fits in one
+// response or has to be collected across several.
+func sendTransactionWithLimit(
+	t *testing.T,
+	client *smb1client.Client,
+	setup []types.USHORT,
+	name string,
+	parameters, data []byte,
+	maxDataCount types.USHORT,
+) (*commands.TransactionResponse, uint32) {
+	t.Helper()
 
 	request := newRequest(codes.SMB_COM_TRANSACTION)
 	request.Header.UID = client.Session.SessionUID
@@ -189,7 +204,7 @@ func sendTransaction(
 	transaction.Setup = setup
 	transaction.SetupCount = types.UCHAR(len(setup))
 	transaction.MaxParameterCount = 1024
-	transaction.MaxDataCount = 4096
+	transaction.MaxDataCount = maxDataCount
 	if err := transaction.Name.SetString(name); err != nil {
 		t.Fatalf("Name.SetString() error = %v", err)
 	}
@@ -783,4 +798,223 @@ func sendNtTransact(
 		t.Fatalf("the response is %d bytes", len(raw))
 	}
 	return binary.LittleEndian.Uint32(raw[5:9])
+}
+
+// oversizedAnswerPipe is a PipeHandler whose answer is a fixed, known block larger
+// than a client's buffer, which is the shape an RPC response has when it does not
+// fit in the transaction that asked for it.
+type oversizedAnswerPipe struct {
+	name   string
+	answer []byte
+}
+
+func (p *oversizedAnswerPipe) OpenPipe(name string) error {
+	if !strings.EqualFold(name, p.name) {
+		return fmt.Errorf("pipe %q not found", name)
+	}
+	return nil
+}
+
+func (p *oversizedAnswerPipe) Transact(name string, input []byte, maxOutput int) ([]byte, bool, error) {
+	if !strings.EqualFold(name, p.name) {
+		return nil, false, fmt.Errorf("pipe %q not found", name)
+	}
+	if len(p.answer) > maxOutput {
+		return p.answer[:maxOutput], true, nil
+	}
+	// The whole answer is handed over: cutting it to the client's buffer is the
+	// server's job, and asserting that is the point of these tests.
+	return p.answer, false, nil
+}
+
+func (p *oversizedAnswerPipe) ClosePipe(string) error { return nil }
+
+// countingAnswer is a block whose every byte identifies its own position, so a
+// reassembled answer that is right in length but wrong in order still fails.
+func countingAnswer(length int) []byte {
+	answer := make([]byte, length)
+	for index := range answer {
+		answer[index] = byte(index % 251)
+	}
+	return answer
+}
+
+// TestNamedPipeOversizedAnswerIsDrainedByReadAndx asserts that an answer larger
+// than the client's buffer is delivered in full: the transaction returns what fits
+// and reports STATUS_BUFFER_OVERFLOW, and SMB_COM_READ_ANDX on the same handle
+// collects the rest.
+//
+// This is the path an RPC client takes, and the whole answer having to arrive is
+// the point: a response cut short is one an RPC client parses as a complete
+// message of the wrong length.
+func TestNamedPipeOversizedAnswerIsDrainedByReadAndx(t *testing.T) {
+	const budget = 64
+	answer := countingAnswer(305)
+
+	_, client := pipeServer(t, &oversizedAnswerPipe{name: "srvsvc", answer: answer})
+
+	fid, err := openPipeHandle(t, client, `\PIPE\srvsvc`)
+	if err != nil {
+		t.Fatalf("opening the pipe failed: %v", err)
+	}
+
+	setup := []types.USHORT{types.USHORT(subcommands.TRANS_TRANSACT_NMPIPE), types.USHORT(fid)}
+	response, status := sendTransactionWithLimit(t, client, setup, `\PIPE\`, nil, []byte("bind"), budget)
+	if status != uint32(nt_status.NT_STATUS_BUFFER_OVERFLOW) {
+		t.Fatalf("the transaction reported 0x%08X, want STATUS_BUFFER_OVERFLOW (0x%08X)",
+			status, uint32(nt_status.NT_STATUS_BUFFER_OVERFLOW))
+	}
+	if response == nil {
+		t.Fatal("no response accompanied the overflow status")
+	}
+	if len(response.Trans_Data) != budget {
+		t.Fatalf("the transaction carried %d bytes, want the %d the client's buffer allows",
+			len(response.Trans_Data), budget)
+	}
+
+	// ReadFile reads until a read comes back empty, which is how the end of the
+	// answer is signalled.
+	rest, err := client.ReadFile(fid, 0, 4096)
+	if err != nil {
+		t.Fatalf("reading the rest of the answer failed: %v", err)
+	}
+
+	collected := append([]byte(response.Trans_Data), rest...)
+	if !bytes.Equal(collected, answer) {
+		t.Fatalf("the answer reassembled to %d bytes, want the %d the handler produced (equal=%t)",
+			len(collected), len(answer), bytes.Equal(collected, answer))
+	}
+
+	// Once drained, a further read is empty rather than an error or a repeat.
+	trailing, err := client.ReadFile(fid, 0, 64)
+	if err != nil {
+		t.Fatalf("reading a drained pipe failed: %v", err)
+	}
+	if len(trailing) != 0 {
+		t.Fatalf("reading a drained pipe returned %d bytes, want none", len(trailing))
+	}
+}
+
+// TestNamedPipeOversizedAnswerIsDrainedByTransReadNmpipe asserts the same
+// completion through TRANS_READ_NMPIPE, which is the other way a client collects
+// the rest of an answer.
+func TestNamedPipeOversizedAnswerIsDrainedByTransReadNmpipe(t *testing.T) {
+	const budget = 100
+	answer := countingAnswer(512)
+
+	_, client := pipeServer(t, &oversizedAnswerPipe{name: "srvsvc", answer: answer})
+
+	fid, err := openPipeHandle(t, client, `\PIPE\srvsvc`)
+	if err != nil {
+		t.Fatalf("opening the pipe failed: %v", err)
+	}
+
+	setup := []types.USHORT{types.USHORT(subcommands.TRANS_TRANSACT_NMPIPE), types.USHORT(fid)}
+	response, status := sendTransactionWithLimit(t, client, setup, `\PIPE\`, nil, []byte("bind"), budget)
+	if status != uint32(nt_status.NT_STATUS_BUFFER_OVERFLOW) {
+		t.Fatalf("the transaction reported 0x%08X, want STATUS_BUFFER_OVERFLOW", status)
+	}
+
+	collected := []byte(response.Trans_Data)
+	readSetup := []types.USHORT{types.USHORT(subcommands.TRANS_READ_NMPIPE), types.USHORT(fid)}
+
+	// Bounded so a server that never drains the buffer fails the test rather than
+	// looping in it.
+	for round := 0; round < 16; round++ {
+		read, readStatus := sendTransactionWithLimit(t, client, readSetup, `\PIPE\`, nil, nil, budget)
+		if readStatus != 0 && readStatus != uint32(nt_status.NT_STATUS_BUFFER_OVERFLOW) {
+			t.Fatalf("round %d of TRANS_READ_NMPIPE reported 0x%08X", round, readStatus)
+		}
+		if read == nil {
+			t.Fatalf("round %d of TRANS_READ_NMPIPE returned no response", round)
+		}
+		if len(read.Trans_Data) > budget {
+			t.Fatalf("round %d returned %d bytes, more than the %d requested",
+				round, len(read.Trans_Data), budget)
+		}
+		collected = append(collected, read.Trans_Data...)
+
+		// Success rather than overflow is the server saying the answer is finished.
+		if readStatus == 0 {
+			break
+		}
+	}
+
+	if !bytes.Equal(collected, answer) {
+		t.Fatalf("the answer reassembled to %d bytes, want the %d the handler produced",
+			len(collected), len(answer))
+	}
+}
+
+// TestNamedPipePeekReportsAndPreservesTheAnswer asserts TRANS_PEEK_NMPIPE returns
+// the front of the buffered answer without consuming it, and describes how much is
+// there — which is what a client peeks in order to size the read it makes next.
+func TestNamedPipePeekReportsAndPreservesTheAnswer(t *testing.T) {
+	const budget = 32
+	answer := countingAnswer(200)
+
+	_, client := pipeServer(t, &oversizedAnswerPipe{name: "srvsvc", answer: answer})
+
+	fid, err := openPipeHandle(t, client, `\PIPE\srvsvc`)
+	if err != nil {
+		t.Fatalf("opening the pipe failed: %v", err)
+	}
+
+	setup := []types.USHORT{types.USHORT(subcommands.TRANS_TRANSACT_NMPIPE), types.USHORT(fid)}
+	response, status := sendTransactionWithLimit(t, client, setup, `\PIPE\`, nil, []byte("bind"), budget)
+	if status != uint32(nt_status.NT_STATUS_BUFFER_OVERFLOW) {
+		t.Fatalf("the transaction reported 0x%08X, want STATUS_BUFFER_OVERFLOW", status)
+	}
+	buffered := len(answer) - len(response.Trans_Data)
+
+	peekSetup := []types.USHORT{types.USHORT(subcommands.TRANS_PEEK_NMPIPE), types.USHORT(fid)}
+
+	// Peeking twice must produce the same answer both times: that is what makes it
+	// a peek rather than a read.
+	var firstPeek []byte
+	for attempt := 0; attempt < 2; attempt++ {
+		peek, peekStatus := sendTransactionWithLimit(t, client, peekSetup, `\PIPE\`, nil, nil, budget)
+		if peekStatus != uint32(nt_status.NT_STATUS_BUFFER_OVERFLOW) {
+			t.Fatalf("peek %d reported 0x%08X, want STATUS_BUFFER_OVERFLOW while data remains",
+				attempt, peekStatus)
+		}
+		if len(peek.Trans_Parameters) != 6 {
+			t.Fatalf("peek %d returned %d parameter bytes, want the 6 of [MS-CIFS] 2.2.5.5.2",
+				attempt, len(peek.Trans_Parameters))
+		}
+
+		parameters := []byte(peek.Trans_Parameters)
+		// These are Fatalf rather than Errorf deliberately: the transport is
+		// synchronous, so continuing to a second request after a wrong answer
+		// deadlocks instead of reporting.
+		if available := binary.LittleEndian.Uint16(parameters[0:2]); int(available) != buffered {
+			t.Fatalf("peek %d reports %d bytes available, want %d", attempt, available, buffered)
+		}
+		if left := binary.LittleEndian.Uint16(parameters[2:4]); int(left) != buffered-len(peek.Trans_Data) {
+			t.Fatalf("peek %d reports %d bytes left in the message, want %d",
+				attempt, left, buffered-len(peek.Trans_Data))
+		}
+		if state := binary.LittleEndian.Uint16(parameters[4:6]); state != namedPipeStateConnectionOk {
+			t.Fatalf("peek %d reports pipe state 0x%04X, want 0x%04X",
+				attempt, state, namedPipeStateConnectionOk)
+		}
+
+		if attempt == 0 {
+			firstPeek = append([]byte(nil), peek.Trans_Data...)
+			continue
+		}
+		if !bytes.Equal(firstPeek, peek.Trans_Data) {
+			t.Fatalf("the second peek returned different data, so the first consumed the buffer")
+		}
+	}
+
+	// And the answer is still whole afterwards.
+	rest, err := client.ReadFile(fid, 0, 4096)
+	if err != nil {
+		t.Fatalf("reading after peeking failed: %v", err)
+	}
+	collected := append([]byte(response.Trans_Data), rest...)
+	if !bytes.Equal(collected, answer) {
+		t.Fatalf("after peeking the answer reassembled to %d bytes, want %d", len(collected), len(answer))
+	}
 }

--- a/network/smb/smb_v10/server/tree.go
+++ b/network/smb/smb_v10/server/tree.go
@@ -51,6 +51,16 @@ type Open struct {
 	Readable bool
 	Writable bool
 
+	// pipeOutput is the part of a pipe answer that has not been delivered yet.
+	//
+	// A transaction returns only as much as the client's buffer takes, and the
+	// rest has to live somewhere until the client reads it: the client is told
+	// more remains, and reading again is how it collects it. The handle is the
+	// right owner because [MS-CIFS] section 3.3.5.57.9 identifies the pipe a read
+	// acts on by its FID, and because closing the handle is what makes an
+	// undrained answer collectable.
+	pipeOutput []byte
+
 	// DeleteOnClose removes the file when the handle closes, which is how a
 	// client deletes something it holds open.
 	DeleteOnClose bool
@@ -72,6 +82,48 @@ func (c *Connection) Open(fid uint16) *Open {
 }
 
 // addTree records a connected tree.
+// drainPipeOutput removes up to limit bytes of the answer buffered on a pipe
+// handle and reports whether any is left after it.
+//
+// The bytes are returned with the capacity clipped, so a caller that appends to
+// the returned slice cannot write into what is still buffered.
+//
+// Parameters:
+//   - limit: the most bytes to remove
+//
+// Returns:
+//   - The bytes removed, and whether more remain buffered
+func (o *Open) drainPipeOutput(limit int) ([]byte, bool) {
+	if limit < 0 {
+		limit = 0
+	}
+	if limit > len(o.pipeOutput) {
+		limit = len(o.pipeOutput)
+	}
+
+	chunk := o.pipeOutput[:limit:limit]
+	o.pipeOutput = o.pipeOutput[limit:]
+	return chunk, len(o.pipeOutput) > 0
+}
+
+// peekPipeOutput returns up to limit bytes of the answer buffered on a pipe
+// handle without removing any of it, along with how much is buffered in total.
+//
+// Parameters:
+//   - limit: the most bytes to return
+//
+// Returns:
+//   - The bytes at the front of the buffer, and the total buffered length
+func (o *Open) peekPipeOutput(limit int) ([]byte, int) {
+	if limit < 0 {
+		limit = 0
+	}
+	if limit > len(o.pipeOutput) {
+		limit = len(o.pipeOutput)
+	}
+	return o.pipeOutput[:limit:limit], len(o.pipeOutput)
+}
+
 func (c *Connection) addTree(tree *Tree) {
 	c.trees[tree.TID] = tree
 }

--- a/network/smb/smb_v10/server/unicode_wire_test.go
+++ b/network/smb/smb_v10/server/unicode_wire_test.go
@@ -324,13 +324,19 @@ func TestFindPatternAcceptsAnExactName(t *testing.T) {
 	}
 }
 
-// TestFileCommandsOnAPipeHandleAreRefused asserts a read or a write through a pipe
-// handle is answered rather than crashing.
+// TestFileCommandsOnAPipeHandle asserts a read through a pipe handle is served and
+// a write through one is refused, and that neither crashes the connection.
 //
-// A pipe handle has no file behind it. An RPC client reads one directly when its
-// transaction did not return a whole response, which reached an unguarded
-// dereference and took the connection down.
-func TestFileCommandsOnAPipeHandleAreRefused(t *testing.T) {
+// An RPC client reads a pipe handle directly when its transaction did not return a
+// whole response, so the read has to work: it is how the rest of the answer is
+// collected. Reading with nothing buffered is not an error — it means the answer
+// is finished. Writing has nowhere to go, because a handler answers a transaction
+// rather than accepting a stream.
+//
+// A pipe handle has no file behind it, and reaching one through a file command
+// once found an unguarded dereference that took the connection down, so the
+// survival assertion below stays.
+func TestFileCommandsOnAPipeHandle(t *testing.T) {
 	pipes := newEchoPipe("srvsvc")
 	_, client := pipeServer(t, pipes)
 
@@ -339,8 +345,12 @@ func TestFileCommandsOnAPipeHandleAreRefused(t *testing.T) {
 		t.Fatalf("opening the pipe failed: %v", err)
 	}
 
-	if _, err := client.ReadFile(fid, 0, 16); err == nil {
-		t.Error("reading a pipe handle as a file succeeded")
+	data, err := client.ReadFile(fid, 0, 16)
+	if err != nil {
+		t.Errorf("reading a pipe handle with nothing buffered failed: %v", err)
+	}
+	if len(data) != 0 {
+		t.Errorf("reading a pipe handle with nothing buffered returned %q, want no data", data)
 	}
 	if _, err := client.WriteFile(fid, 0, []byte("x")); err == nil {
 		t.Error("writing a pipe handle as a file succeeded")


### PR DESCRIPTION
### Linked Issue
`Closes #1139`

### Root Cause
Pipe output was modelled as a value returned by one transaction rather than as a stream held on the open handle. `PipeHandler.Transact` was given the client's `MaxDataCount` as its `maxOutput` and asked to return only what fit, so the part that did not fit never reached the server at all — there was nothing to keep, and no field on `Open` to keep it in.

The server nonetheless reported `STATUS_BUFFER_OVERFLOW`, which [MS-CIFS] 3.3.5.57.7 defines as "here is what fits, ask again". Every way of asking again was then refused: `fileFor` returned `STATUS_NOT_SUPPORTED` for any handle with `IsPipe` set, so `SMB_COM_READ_ANDX` could not read the handle, and `TRANS_READ_NMPIPE` and `TRANS_PEEK_NMPIPE` were absent from the subcommand switch. The result was an instruction the client could not act on, and an MS-RPC response larger than the client's buffer was unrecoverable.

### Fix Description
Pipe output becomes a stream on the handle.

- `Open` gains `pipeOutput`, the part of an answer not yet delivered, with `drainPipeOutput` and `peekPipeOutput` accessors. Both clip the capacity of what they return so a caller appending to it cannot write into what is still buffered.
- `transactNamedPipe` now asks the handler for the whole answer, bounded by the new `maxPipeAnswerSize` (64 KiB) rather than by the client's buffer, cuts the response to what the client said it could receive, and keeps the rest on the handle. `STATUS_BUFFER_OVERFLOW` is reported when either the handler or the server has more to give.
- `SMB_COM_READ_ANDX` on a pipe handle is served by the new `readPipeHandle`, consuming from the front of the buffer and ignoring the request's offset, since a pipe has no addressable content.
- `TRANS_READ_NMPIPE` and `TRANS_PEEK_NMPIPE` are served, in the layouts of [MS-CIFS] 2.2.5.8.2 and 2.2.5.5.2 respectively — the read response carries no `Trans_Parameters`, the peek response carries `ReadDataAvailable`, `MessageBytesLength` and `NamedPipeState`.
- The FID resolution the three subcommands share is factored into `pipeOpenFrom`, which keeps `transactNamedPipe`'s existing statuses unchanged.

The `Transact` signature is unchanged; only the documented meaning of `maxOutput` moves from "the largest answer the client can receive" to "the largest answer the server will take in one exchange", because fitting the answer to the client is the server's job — only the server knows how the client will read the rest. There are no `PipeHandler` implementations in the repository outside tests, so nothing else depended on the old reading.

`SMB_COM_WRITE_ANDX` on a pipe handle stays refused, and `TRANS_WRITE_NMPIPE` and `TRANS_CALL_NMPIPE` stay unserved: those issue a *request* by writing rather than collecting an *answer*, which is a separate capability from the one this issue describes.

Two alternatives were rejected. Having the server pass a large `maxOutput` and leave the handler to hold the remainder would have put the buffer behind an interface that has no way to be read from. Adding a `ReadPipe` method to `PipeHandler` would have made every handler implement stream bookkeeping that is identical for all of them and that the server is better placed to do.

The peek path needed one subtlety: the client's `MaxDataCount` budget covers `Trans_Parameters` as well as `Trans_Data`, and the parameters ship in the first message, so peeking the full budget pushed the tail of the chunk into a second message and left `ReadDataAvailable` and `MessageBytesLength` describing bytes that response had not carried. The peeked chunk therefore reserves `peekParametersSize` out of the budget, which keeps the counts truthful and the response unfragmented.

### How Verified
Runtime, over the loopback harness:

- `TestNamedPipeOversizedAnswerIsDrainedByReadAndx` — a 305-byte answer against a 64-byte client buffer. Before: the transaction returned 64 bytes with `STATUS_BUFFER_OVERFLOW` and `client.ReadFile` on the FID failed, so 241 bytes were unrecoverable. After: the answer reassembles byte-for-byte and a further read returns empty.
- `TestNamedPipeOversizedAnswerIsDrainedByTransReadNmpipe` — a 512-byte answer collected in 100-byte `TRANS_READ_NMPIPE` rounds, with the loop bounded so a server that never drains fails rather than spins.
- `TestNamedPipePeekReportsAndPreservesTheAnswer` — peeking twice returns identical data, the three parameter fields match what is buffered, and the answer is still whole afterwards.

Each answer is a position-encoding byte pattern, so a reassembly that is right in length but wrong in order still fails.

Full package suite green: `go test ./network/smb/...`. `go build ./...`, `go vet ./network/smb/...` and `gofmt -l` clean.

### Test Coverage
**Added:**
- `nttransact_test.go`: `TestNamedPipeOversizedAnswerIsDrainedByReadAndx`, `TestNamedPipeOversizedAnswerIsDrainedByTransReadNmpipe`, `TestNamedPipePeekReportsAndPreservesTheAnswer`, plus the `oversizedAnswerPipe` handler and the `countingAnswer` pattern helper.
- `sendTransaction` is refactored into `sendTransactionWithLimit` so a test controls the client's `MaxDataCount`, which is what decides whether an answer fits in one response.

**Modified:** `unicode_wire_test.go`: `TestFileCommandsOnAPipeHandleAreRefused` becomes `TestFileCommandsOnAPipeHandle`. Its assertion that reading a pipe handle fails was asserting this bug; it now asserts the read is served and the write still refused. The connection-survival assertion it was originally written for is kept — reaching a pipe handle through a file command once found an unguarded dereference.

### Scope of Change
- **Files changed:** `server/tree.go`, `server/handler_pipe.go`, `server/handler_file.go`, `server/doc.go`, `server/nttransact_test.go`, `server/unicode_wire_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local to the SMB1 server's pipe path. The only behaviour that changes for an existing caller is that a read on a pipe handle now succeeds instead of returning `STATUS_NOT_SUPPORTED`, which is the fix. `maxPipeAnswerSize` bounds per-handle buffering so a handler with a very large answer cannot pin unbounded memory until the handle closes. Safe to merge without staged rollout.

### Notes
Follow-up work already filed separately: `TRANS_WRITE_NMPIPE` and `TRANS_CALL_NMPIPE` under #1149, and a shipped `PipeHandler` for `srvsvc` under #1150 — the latter is what would exercise this path against a real RPC client rather than a synthetic answer.
