### PR TITLE
Fix batched AndX commands after the first being discarded (Fixes #1140)

### DIFF
--- a/network/smb/smb_v10/message/andx_chain_test.go
+++ b/network/smb/smb_v10/message/andx_chain_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/codes"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header/flags"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
 )
 
 // TestUnmarshalFollowsAndXChain verifies that Message.Unmarshal decodes every
@@ -134,5 +135,132 @@ func TestUnmarshalRejectsCyclicAndXChain(t *testing.T) {
 	out := message.NewMessage()
 	if err := out.Unmarshal(full); err == nil {
 		t.Fatal("Unmarshal should reject a cyclic AndX chain, got nil error")
+	}
+}
+
+// TestMarshalWritesAndXChain asserts Message.Marshal emits a batched message for a
+// chain built with AddCommand: each AndX block naming the command that follows it
+// and the offset it begins at, and the last one terminating the chain.
+//
+// The assembled bytes are then decoded back, because a chain that marshals into
+// something Unmarshal cannot follow is the failure this is guarding against.
+func TestMarshalWritesAndXChain(t *testing.T) {
+	// The length of the first command's block, from a message of its own. A fresh
+	// command is used because Marshal appends to a command's parameter and data
+	// blocks, so marshalling one twice does not produce the same bytes twice.
+	sizing := message.NewMessage()
+	sizing.Header.SetFlags(flags.FLAGS_REPLY)
+	sizing.AddCommand(commands.NewSessionSetupAndxResponse())
+	sized, err := sizing.Marshal()
+	if err != nil {
+		t.Fatalf("failed to marshal the sizing message: %v", err)
+	}
+	firstBlockLength := len(sized) - header.SMB_HEADER_SIZE
+
+	batched := message.NewMessage()
+	batched.Header.SetFlags(flags.FLAGS_REPLY)
+	batched.AddCommand(commands.NewSessionSetupAndxResponse())
+	batched.AddCommand(commands.NewTreeConnectAndxResponse())
+
+	raw, err := batched.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal returned error: %v", err)
+	}
+
+	// The header's command code is the first command's, per [MS-CIFS] 2.2.3.4.
+	if got := codes.CommandCode(raw[4]); got != codes.SMB_COM_SESSION_SETUP_ANDX {
+		t.Errorf("the header names command 0x%02X, want SMB_COM_SESSION_SETUP_ANDX", uint8(got))
+	}
+
+	// The first command's AndX block: AndXCommand(1) AndXReserved(1)
+	// AndXOffset(2), immediately after its WordCount.
+	andxAt := header.SMB_HEADER_SIZE + 1
+	if got := codes.CommandCode(raw[andxAt]); got != codes.SMB_COM_TREE_CONNECT_ANDX {
+		t.Errorf("AndXCommand is 0x%02X, want SMB_COM_TREE_CONNECT_ANDX", uint8(got))
+	}
+	if raw[andxAt+1] != 0x00 {
+		t.Errorf("AndXReserved is 0x%02X, want 0x00", raw[andxAt+1])
+	}
+
+	wantOffset := header.SMB_HEADER_SIZE + firstBlockLength
+	gotOffset := int(binary.LittleEndian.Uint16(raw[andxAt+2 : andxAt+4]))
+	if gotOffset != wantOffset {
+		t.Fatalf("AndXOffset is %d, want %d (the header plus the first command's %d bytes)",
+			gotOffset, wantOffset, firstBlockLength)
+	}
+
+	// The second command terminates the chain.
+	secondAndxAt := gotOffset + 1
+	if got := codes.CommandCode(raw[secondAndxAt]); got != codes.SMB_COM_NO_ANDX_COMMAND {
+		t.Errorf("the last command names 0x%02X as its follow-on, want SMB_COM_NO_ANDX_COMMAND", uint8(got))
+	}
+	if got := binary.LittleEndian.Uint16(raw[secondAndxAt+2 : secondAndxAt+4]); got != 0 {
+		t.Errorf("the last command's AndXOffset is %d, want 0", got)
+	}
+
+	// And the whole thing decodes back into the chain it was built from.
+	out := message.NewMessage()
+	if err := out.Unmarshal(raw); err != nil {
+		t.Fatalf("the marshalled chain did not decode: %v", err)
+	}
+	if got := out.Command.GetChainLength(); got != 2 {
+		t.Fatalf("the decoded chain is %d commands, want 2", got)
+	}
+	if _, ok := out.Command.(*commands.SessionSetupAndxResponse); !ok {
+		t.Errorf("the first decoded command is %T, want *SessionSetupAndxResponse", out.Command)
+	}
+	if _, ok := out.Command.GetNextCommand().(*commands.TreeConnectAndxResponse); !ok {
+		t.Errorf("the second decoded command is %T, want *TreeConnectAndxResponse",
+			out.Command.GetNextCommand())
+	}
+}
+
+// TestMarshalRejectsFollowingANonAndXCommand asserts a chain whose non-final
+// command is not an AndX command is refused rather than emitted.
+//
+// A non-AndX command has no AndX block, so there is nowhere to record what follows
+// it: [MS-CIFS] 2.2.3.4 makes such a command the end of a chain. Emitting the
+// follow-on anyway would put a block pair in the message that no client could find.
+func TestMarshalRejectsFollowingANonAndXCommand(t *testing.T) {
+	msg := message.NewMessage()
+	msg.Header.SetFlags(flags.FLAGS_REPLY)
+	msg.AddCommand(commands.NewNegotiateResponse())
+	msg.AddCommand(commands.NewTreeConnectAndxResponse())
+
+	if _, err := msg.Marshal(); err == nil {
+		t.Fatal("marshalling a chain behind a non-AndX command succeeded, want an error")
+	}
+}
+
+// TestMarshalPositionsChainedReadOffsets asserts a read response batched behind
+// another command reports a DataOffset that points at its data.
+//
+// DataOffset is measured from the start of the SMB header, so a response that
+// assumed it sat at the front of the message would send the client to bytes
+// belonging to the command ahead of it.
+func TestMarshalPositionsChainedReadOffsets(t *testing.T) {
+	payload := []byte("the bytes the client asked to read")
+
+	read := commands.NewReadAndxResponse()
+	read.Data = []types.UCHAR(payload)
+	read.DataLength = types.USHORT(len(payload))
+
+	batched := message.NewMessage()
+	batched.Header.SetFlags(flags.FLAGS_REPLY)
+	batched.AddCommand(commands.NewTreeConnectAndxResponse())
+	batched.AddCommand(read)
+
+	raw, err := batched.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal returned error: %v", err)
+	}
+
+	offset := int(read.DataOffset)
+	if offset+len(payload) > len(raw) {
+		t.Fatalf("DataOffset %d plus %d bytes runs past the %d-byte message",
+			offset, len(payload), len(raw))
+	}
+	if got := raw[offset : offset+len(payload)]; string(got) != string(payload) {
+		t.Fatalf("DataOffset %d points at %q, want %q", offset, got, payload)
 	}
 }

--- a/network/smb/smb_v10/message/commands/ReadAndxResponse.go
+++ b/network/smb/smb_v10/message/commands/ReadAndxResponse.go
@@ -61,6 +61,22 @@ type ReadAndxResponse struct {
 	// located at DataOffset (measured from the start of the SMB header) and are
 	// DataLength bytes long.
 	Data []types.UCHAR
+
+	// chainOffset is how far past the SMB header this response begins, which is
+	// non-zero only when it is batched behind another command. DataOffset is
+	// measured from the header, so it has to include everything ahead of this
+	// response or the client reads its data from the wrong place.
+	chainOffset int
+}
+
+// SetChainOffset records where this response begins, so DataOffset describes where
+// the data actually is when the response is batched behind another command.
+//
+// Parameters:
+//   - offset: bytes between the end of the SMB header and the start of this
+//     response
+func (c *ReadAndxResponse) SetChainOffset(offset int) {
+	c.chainOffset = offset
 }
 
 // NewReadAndxResponse creates a new ReadAndxResponse structure
@@ -128,7 +144,7 @@ func (c *ReadAndxResponse) Marshal() ([]byte, error) {
 	// and advertise its length and its absolute offset from the start of the SMB
 	// header so the parameter fields below carry the matching values.
 	c.DataLength = types.USHORT(len(c.Data))
-	c.DataOffset = types.USHORT(readAndxResponseDataOffset)
+	c.DataOffset = types.USHORT(readAndxResponseDataOffset + c.chainOffset)
 
 	rawDataContent := []byte{}
 	rawDataContent = append(rawDataContent, c.Data...)

--- a/network/smb/smb_v10/message/commands/command_interface/command_interface.go
+++ b/network/smb/smb_v10/message/commands/command_interface/command_interface.go
@@ -66,6 +66,19 @@ type CommandInterface interface {
 	IsUnicode() bool
 }
 
+// ChainPositioned is implemented by a command whose wire format carries an offset
+// measured from the start of the SMB header rather than from the command itself.
+//
+// Such a command is only correct at the front of a message: batched second or
+// later, its own offsets have to account for everything ahead of it.
+// Message.Marshal tells each command where it begins before marshalling it, so a
+// command that needs the number has it, and one that does not is unaffected.
+type ChainPositioned interface {
+	// SetChainOffset records how far past the end of the SMB header this command
+	// begins. Zero means it is the first command in the message.
+	SetChainOffset(offset int)
+}
+
 // Command is a struct that implements the CommandInterface
 type Command struct {
 	// Command code
@@ -201,14 +214,14 @@ func (c *Command) SetData(data *data.Data) {
 // Returns:
 //   - CommandInterface: The next command in the chain
 func (c *Command) GetNextCommand() CommandInterface {
-	// A chained command is present only when an AndX block has been recorded.
-	// (The guard cannot also call c.IsAndX(): from this embedded base method that
-	// call resolves to the base IsAndX, not the concrete command's override, so it
-	// would always be false and hide a linked command.)
-	if c.AndX != nil {
-		return c.NextCommand
-	}
-	return nil
+	// Whatever is linked is returned, with no test for an AndX block.
+	//
+	// Gating this on c.AndX != nil looks like it identifies an AndX command, but
+	// it does not: the block is recorded when a chain is parsed and absent when a
+	// chain is built, so the gate hid a command that had been linked deliberately
+	// and made every walker stop at the first one. Whether a command may be
+	// followed at all is an AndX question, and Message.Marshal asks it there.
+	return c.NextCommand
 }
 
 // SetNextCommand sets the next command in the chain

--- a/network/smb/smb_v10/message/message.go
+++ b/network/smb/smb_v10/message/message.go
@@ -56,28 +56,98 @@ func (m *Message) AddCommand(command command_interface.CommandInterface) {
 // - A byte slice containing the marshalled message
 // - An error if marshalling any component fails
 func (m *Message) Marshal() ([]byte, error) {
-	marshalled_message := []byte{}
-
 	// Marshal the header
 	marshalled_header, err := m.Header.Marshal()
 	if err != nil {
 		return nil, err
 	}
-	marshalled_message = append(marshalled_message, marshalled_header...)
 
 	// Check if there is a command to marshal
-	if m.Command != nil {
-		marshalled_command, err := m.Command.Marshal()
+	if m.Command == nil {
+		return nil, fmt.Errorf("no command added to message")
+	}
+
+	// Marshal every command in the chain, in order.
+	//
+	// Each one is marshalled exactly once: a command's Marshal appends to its own
+	// parameter and data blocks, so marshalling it twice would emit those fields
+	// twice. The AndX offsets are therefore patched into the marshalled bytes
+	// below rather than filled in and re-marshalled.
+	chain := []command_interface.CommandInterface{}
+	blocks := [][]byte{}
+	written := 0
+	for command := m.Command; command != nil; command = command.GetNextCommand() {
+		if command.GetNextCommand() != nil && !command.IsAndX() {
+			return nil, fmt.Errorf(
+				"command 0x%02X is followed in an AndX chain but is not an AndX command",
+				uint8(command.GetCommandCode()))
+		}
+
+		// A command that describes its own fields by an offset from the SMB header
+		// needs to know how far into the message it sits. Batched second or later,
+		// a response that assumed the front of the message points its client at
+		// the wrong bytes.
+		if positioned, ok := command.(command_interface.ChainPositioned); ok {
+			positioned.SetChainOffset(written)
+		}
+
+		block, err := command.Marshal()
 		if err != nil {
 			return nil, err
 		}
-		marshalled_message = append(marshalled_message, marshalled_command...)
-	} else {
-		return nil, fmt.Errorf("no command added to message")
+		if command.IsAndX() && len(block) < andxBlockEnd {
+			return nil, fmt.Errorf(
+				"AndX command 0x%02X marshalled to %d bytes, too few to hold its AndX block",
+				uint8(command.GetCommandCode()), len(block))
+		}
+
+		chain = append(chain, command)
+		blocks = append(blocks, block)
+		written += len(block)
+	}
+
+	// AndXOffset is measured from the start of the SMB header, so where a command
+	// begins is known only once everything ahead of it has been marshalled. Walk
+	// the blocks accumulating that position and patch each command's AndX block
+	// with the command code and the offset of the one that follows it.
+	position := len(marshalled_header)
+	for index, block := range blocks {
+		if index > 0 && chain[index-1].IsAndX() {
+			previous := blocks[index-1]
+			previous[andxCommandOffset] = uint8(chain[index].GetCommandCode())
+			previous[andxReservedOffset] = 0x00
+			binary.LittleEndian.PutUint16(previous[andxOffsetField:andxBlockEnd], uint16(position))
+		}
+		position += len(block)
+	}
+
+	// The chain is terminated explicitly. A command's own Marshal writes the
+	// terminator when it was given no AndX block, but a command that was linked
+	// and then turned out to be last would otherwise name a successor that is not
+	// there, which a client would follow off the end of the message.
+	if last := len(blocks) - 1; last >= 0 && chain[last].IsAndX() {
+		blocks[last][andxCommandOffset] = uint8(codes.SMB_COM_NO_ANDX_COMMAND)
+		blocks[last][andxReservedOffset] = 0x00
+		binary.LittleEndian.PutUint16(blocks[last][andxOffsetField:andxBlockEnd], 0)
+	}
+
+	marshalled_message := append([]byte{}, marshalled_header...)
+	for _, block := range blocks {
+		marshalled_message = append(marshalled_message, block...)
 	}
 
 	return marshalled_message, nil
 }
+
+// The AndX block sits at the start of an AndX command's parameter words, which
+// follow the one-byte WordCount: AndXCommand(1) AndXReserved(1) AndXOffset(2).
+// Message.Unmarshal reads the same positions when it follows a chain.
+const (
+	andxCommandOffset  = 1
+	andxReservedOffset = 2
+	andxOffsetField    = 3
+	andxBlockEnd       = 5
+)
 
 // Unmarshal deserializes a byte slice into the Message structure.
 //

--- a/network/smb/smb_v10/server/andx_chain_test.go
+++ b/network/smb/smb_v10/server/andx_chain_test.go
@@ -1,0 +1,368 @@
+package server
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	smb1client "github.com/TheManticoreProject/Manticore/network/smb/smb_v10/client"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/codes"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/command_interface"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header/flags2"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+	"github.com/TheManticoreProject/Manticore/windows/fileflags"
+	"github.com/TheManticoreProject/Manticore/windows/nt_status"
+)
+
+// writeAndxRequestDataOffset is where a WriteAndx request's data block begins
+// when the command is first in the message, measured from the start of the SMB
+// header: header + WordCount(1) + 12 parameter words + ByteCount(2) + Pad(1).
+//
+// The server locates the data by walking the data block rather than by trusting
+// this field, so a chained write does not depend on it — but a request that
+// misdescribed itself would still be a wrong request, so the tests send the right
+// value.
+const writeAndxRequestDataOffset = header.SMB_HEADER_SIZE + 1 + 24 + 2 + 1
+
+// sendChain sends a batched request carrying every command given, in order, and
+// returns the raw reply.
+//
+// The reply is returned raw rather than decoded because an error response in a
+// chain is a WordCount 0 block, which the response structure for that command code
+// cannot decode. A client reads the header status before parsing a body for
+// exactly that reason, so a test asserting the error case has to work the same way.
+func sendChain(t *testing.T, client *smb1client.Client, chain ...command_interface.CommandInterface) []byte {
+	t.Helper()
+
+	if len(chain) == 0 {
+		t.Fatal("sendChain needs at least one command")
+	}
+
+	request := newRequest(chain[0].GetCommandCode())
+	request.Header.UID = client.Session.SessionUID
+	request.Header.TID = client.Session.TreeID
+	for _, cmd := range chain {
+		request.AddCommand(cmd)
+	}
+	// AddCommand takes the header code from the first command, which newRequest
+	// already set; setting it again keeps the two from drifting apart.
+	request.Header.Command = chain[0].GetCommandCode()
+
+	marshalled, err := request.Marshal()
+	if err != nil {
+		t.Fatalf("failed to marshal the batched request: %v", err)
+	}
+	if _, err := client.Transport.Send(marshalled); err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+
+	raw, err := client.Transport.Receive()
+	if err != nil {
+		t.Fatalf("Receive() error = %v", err)
+	}
+	if len(raw) < header.SMB_HEADER_SIZE {
+		t.Fatalf("the reply is %d bytes, shorter than an SMB header", len(raw))
+	}
+	return raw
+}
+
+// replyStatus reads the status out of a raw reply's header.
+func replyStatus(raw []byte) uint32 {
+	return binary.LittleEndian.Uint32(raw[5:9])
+}
+
+// chainBlockAt describes the AndX linkage of the command block starting at
+// position, which is WordCount(1) then AndXCommand(1) AndXReserved(1)
+// AndXOffset(2).
+func chainBlockAt(t *testing.T, raw []byte, position int) (wordCount int, follows codes.CommandCode, next int) {
+	t.Helper()
+	if position+5 > len(raw) {
+		t.Fatalf("a command block at %d does not fit in the %d-byte reply", position, len(raw))
+	}
+	return int(raw[position]),
+		codes.CommandCode(raw[position+1]),
+		int(binary.LittleEndian.Uint16(raw[position+3 : position+5]))
+}
+
+// TestBatchedChainExecutesEveryCommand asserts every command of a batch runs and
+// that every answer comes back in one message.
+//
+// A write batched with a close is the shape a client uses to finish with a file in
+// one round trip. Before chains were executed the close was decoded and dropped,
+// so the write landed, the handle leaked, and the client was told the batch had
+// completed.
+func TestBatchedChainExecutesEveryCommand(t *testing.T) {
+	fs := NewMemoryFileSystem("FILES")
+	if err := fs.AddFile("batched.txt", []byte("")); err != nil {
+		t.Fatalf("AddFile() error = %v", err)
+	}
+	_, client := fileServer(t, fs, false)
+
+	fid, err := client.OpenFile("batched.txt",
+		fileflags.GENERIC_READ|fileflags.GENERIC_WRITE,
+		fileflags.FILE_SHARE_READ,
+		fileflags.FILE_OPEN_IF,
+		fileflags.FILE_NON_DIRECTORY_FILE)
+	if err != nil {
+		t.Fatalf("opening the file failed: %v", err)
+	}
+
+	payload := []byte("written as one half of a batch")
+
+	write := commands.NewWriteAndxRequest()
+	write.FID = types.USHORT(fid)
+	write.Offset = types.ULONG(0)
+	write.DataLength = types.USHORT(len(payload))
+	write.DataOffset = types.USHORT(writeAndxRequestDataOffset)
+	write.Data = []types.UCHAR(payload)
+
+	closeCmd := commands.NewCloseRequest()
+	closeCmd.FID = types.USHORT(fid)
+
+	raw := sendChain(t, client, write, closeCmd)
+
+	if status := replyStatus(raw); status != 0 {
+		t.Fatalf("the batch reported 0x%08X, want success", status)
+	}
+	if got := codes.CommandCode(raw[4]); got != codes.SMB_COM_WRITE_ANDX {
+		t.Errorf("the reply header names 0x%02X, want SMB_COM_WRITE_ANDX", uint8(got))
+	}
+
+	// The write response links to a close response.
+	_, follows, next := chainBlockAt(t, raw, header.SMB_HEADER_SIZE)
+	if follows != codes.SMB_COM_CLOSE {
+		t.Fatalf("the write response names 0x%02X as its follow-on, want SMB_COM_CLOSE", uint8(follows))
+	}
+	if next <= header.SMB_HEADER_SIZE || next >= len(raw) {
+		t.Fatalf("the close response is at %d, outside the %d-byte reply", next, len(raw))
+	}
+	// A close response is WordCount 0, ByteCount 0.
+	if wordCount := int(raw[next]); wordCount != 0 {
+		t.Errorf("the close response has WordCount %d, want 0", wordCount)
+	}
+
+	// The close actually happened, so the handle is gone. This is checked before
+	// reopening the file: the identifier allocator reuses a released FID, so a
+	// reopen can hand back the same number and make a stale handle look live.
+	if err := client.CloseFile(fid); err == nil {
+		t.Error("closing the batched handle a second time succeeded, so the batched close was dropped")
+	}
+
+	// And the write actually happened.
+	reopened, err := client.OpenFile("batched.txt",
+		fileflags.GENERIC_READ,
+		fileflags.FILE_SHARE_READ,
+		fileflags.FILE_OPEN,
+		fileflags.FILE_NON_DIRECTORY_FILE)
+	if err != nil {
+		t.Fatalf("reopening the file failed: %v", err)
+	}
+	defer client.CloseFile(reopened)
+
+	contents, err := client.ReadFile(reopened, 0, uint32(len(payload)))
+	if err != nil {
+		t.Fatalf("reading the file back failed: %v", err)
+	}
+	if !bytes.Equal(contents, payload) {
+		t.Errorf("the file holds %q, want %q", contents, payload)
+	}
+}
+
+// TestBatchedChainStopsAtTheFirstFailure asserts a failing command ends the chain
+// and that the answers produced before it are still returned.
+//
+// [MS-CIFS] section 3.3.4.1: "processing of the AndX request chain terminates with
+// the request that generated the error. The error response MUST be the last
+// response in the returned AndX chain."
+func TestBatchedChainStopsAtTheFirstFailure(t *testing.T) {
+	payload := []byte("readable")
+
+	fs := NewMemoryFileSystem("FILES")
+	if err := fs.AddFile("readable.txt", payload); err != nil {
+		t.Fatalf("AddFile() error = %v", err)
+	}
+	_, client := fileServer(t, fs, false)
+
+	fid, err := client.OpenFile("readable.txt",
+		fileflags.GENERIC_READ,
+		fileflags.FILE_SHARE_READ,
+		fileflags.FILE_OPEN,
+		fileflags.FILE_NON_DIRECTORY_FILE)
+	if err != nil {
+		t.Fatalf("opening the file failed: %v", err)
+	}
+	defer client.CloseFile(fid)
+
+	good := commands.NewReadAndxRequest()
+	good.FID = types.USHORT(fid)
+	good.MaxCountOfBytesToReturn = types.USHORT(len(payload))
+
+	// A FID the connection never handed out.
+	bad := commands.NewReadAndxRequest()
+	bad.FID = types.USHORT(0xBEEF)
+	bad.MaxCountOfBytesToReturn = types.USHORT(16)
+
+	third := commands.NewReadAndxRequest()
+	third.FID = types.USHORT(fid)
+	third.MaxCountOfBytesToReturn = types.USHORT(len(payload))
+
+	raw := sendChain(t, client, good, bad, third)
+
+	if status := replyStatus(raw); status != uint32(nt_status.NT_STATUS_SMB_BAD_FID) {
+		t.Fatalf("the batch reported 0x%08X, want STATUS_SMB_BAD_FID (0x%08X)",
+			status, uint32(nt_status.NT_STATUS_SMB_BAD_FID))
+	}
+
+	// The first read answered, and links to the error response.
+	wordCount, follows, next := chainBlockAt(t, raw, header.SMB_HEADER_SIZE)
+	if wordCount == 0 {
+		t.Fatal("the first read produced an error response, so the chain never got to the failing command")
+	}
+	if follows != codes.SMB_COM_READ_ANDX {
+		t.Fatalf("the first response names 0x%02X as its follow-on, want SMB_COM_READ_ANDX", uint8(follows))
+	}
+
+	// The error response is a WordCount 0, ByteCount 0 block, and it is the last
+	// thing in the message: the third command must not have run.
+	if next+3 > len(raw) {
+		t.Fatalf("the error response at %d does not fit in the %d-byte reply", next, len(raw))
+	}
+	if got := raw[next : next+3]; !bytes.Equal(got, []byte{0x00, 0x00, 0x00}) {
+		t.Fatalf("the block at %d is % x, want an error response of 00 00 00", next, got)
+	}
+	if next+3 != len(raw) {
+		t.Fatalf("the reply has %d bytes after the error response, want none — a command after the failure ran",
+			len(raw)-(next+3))
+	}
+}
+
+// TestBatchedChainSeesIdentifiersAssignedWithinIt asserts a command batched behind
+// a tree connect acts on the tree the tree connect just created.
+//
+// The client cannot know the TID when it builds the batch — the server has not
+// assigned one yet — so it sends whatever it has and the server has to substitute
+// what it allocated. SMB_COM_CHECK_DIRECTORY is one of the commands [MS-CIFS]
+// section 2.2.4.55 documents as following a tree connect.
+func TestBatchedChainSeesIdentifiersAssignedWithinIt(t *testing.T) {
+	fs := NewMemoryFileSystem("FILES")
+	if err := fs.AddDirectory("adirectory"); err != nil {
+		t.Fatalf("AddDirectory() error = %v", err)
+	}
+	_, client := fileServer(t, fs, false)
+
+	connect := commands.NewTreeConnectAndxRequest()
+	connect.Password = []types.UCHAR{}
+	connect.PasswordLength = types.USHORT(0)
+	connect.Path = []types.UCHAR("\\\\127.0.0.1\\" + fileShareName + "\x00")
+	connect.Service = []types.UCHAR("?????\x00")
+
+	check := commands.NewCheckDirectoryRequest()
+	if err := check.DirectoryName.SetString("adirectory"); err != nil {
+		t.Fatalf("SetString() error = %v", err)
+	}
+
+	// A TID the server never issued, so an answer of success can only come from
+	// the tree the batch itself connected.
+	request := newRequest(codes.SMB_COM_TREE_CONNECT_ANDX)
+	request.Header.UID = client.Session.SessionUID
+	request.Header.TID = 0xFFFE
+	// Both names above are ASCII, and a name is read in the encoding the message
+	// declares, so the message must not declare Unicode.
+	request.Header.Flags2 &^= flags2.Flags2(flags2.FLAGS2_UNICODE)
+	request.AddCommand(connect)
+	request.AddCommand(check)
+	request.Header.Command = codes.SMB_COM_TREE_CONNECT_ANDX
+
+	marshalled, err := request.Marshal()
+	if err != nil {
+		t.Fatalf("failed to marshal the batched request: %v", err)
+	}
+	if _, err := client.Transport.Send(marshalled); err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+	raw, err := client.Transport.Receive()
+	if err != nil {
+		t.Fatalf("Receive() error = %v", err)
+	}
+
+	if status := replyStatus(raw); status != 0 {
+		t.Fatalf("the batch reported 0x%08X, want success — the chained command did not see the new tree", status)
+	}
+
+	_, follows, next := chainBlockAt(t, raw, header.SMB_HEADER_SIZE)
+	if follows != codes.SMB_COM_CHECK_DIRECTORY {
+		t.Fatalf("the tree connect response names 0x%02X as its follow-on, want SMB_COM_CHECK_DIRECTORY",
+			uint8(follows))
+	}
+	if next == 0 || next >= len(raw) {
+		t.Fatalf("the chained response is at %d, outside the %d-byte reply", next, len(raw))
+	}
+
+	// The reply's TID is the one the server allocated, and it is not the invented
+	// one the request carried.
+	if tid := binary.LittleEndian.Uint16(raw[28:30]); tid == 0xFFFE {
+		t.Errorf("the reply echoes the invented TID 0x%04X rather than the one it allocated", tid)
+	}
+}
+
+// TestUnbatchedAndXRequestTerminatesItsChain asserts a single AndX command still
+// answers with a terminated one-command chain, so a request that was never batched
+// is unaffected by chain support.
+func TestUnbatchedAndXRequestTerminatesItsChain(t *testing.T) {
+	payload := []byte("unbatched")
+
+	fs := NewMemoryFileSystem("FILES")
+	if err := fs.AddFile("single.txt", payload); err != nil {
+		t.Fatalf("AddFile() error = %v", err)
+	}
+	_, client := fileServer(t, fs, false)
+
+	fid, err := client.OpenFile("single.txt",
+		fileflags.GENERIC_READ,
+		fileflags.FILE_SHARE_READ,
+		fileflags.FILE_OPEN,
+		fileflags.FILE_NON_DIRECTORY_FILE)
+	if err != nil {
+		t.Fatalf("opening the file failed: %v", err)
+	}
+	defer client.CloseFile(fid)
+
+	read := commands.NewReadAndxRequest()
+	read.FID = types.USHORT(fid)
+	read.MaxCountOfBytesToReturn = types.USHORT(len(payload))
+
+	raw := sendChain(t, client, read)
+
+	if status := replyStatus(raw); status != 0 {
+		t.Fatalf("the read reported 0x%08X, want success", status)
+	}
+
+	_, follows, next := chainBlockAt(t, raw, header.SMB_HEADER_SIZE)
+	if follows != codes.SMB_COM_NO_ANDX_COMMAND {
+		t.Errorf("a lone response names 0x%02X as its follow-on, want SMB_COM_NO_ANDX_COMMAND", uint8(follows))
+	}
+	if next != 0 {
+		t.Errorf("a lone response has AndXOffset %d, want 0", next)
+	}
+
+	// And the data is where the response says it is, which is the property a
+	// chained response has to preserve too.
+	decoded := message.NewMessage()
+	if err := decoded.Unmarshal(raw); err != nil {
+		t.Fatalf("the reply did not decode: %v", err)
+	}
+	response, ok := decoded.Command.(*commands.ReadAndxResponse)
+	if !ok {
+		t.Fatalf("the reply carries %T, want *ReadAndxResponse", decoded.Command)
+	}
+	at := int(response.DataOffset)
+	if at+len(payload) > len(raw) {
+		t.Fatalf("DataOffset %d plus %d bytes runs past the %d-byte reply", at, len(payload), len(raw))
+	}
+	if got := raw[at : at+len(payload)]; !bytes.Equal(got, payload) {
+		t.Errorf("DataOffset %d points at %q, want %q", at, got, payload)
+	}
+}

--- a/network/smb/smb_v10/server/dispatch.go
+++ b/network/smb/smb_v10/server/dispatch.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"errors"
+
 	"github.com/TheManticoreProject/Manticore/logger"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
@@ -9,6 +11,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header/flags"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header/flags2"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
 	"github.com/TheManticoreProject/Manticore/windows/nt_status"
 )
 
@@ -163,32 +166,132 @@ func isKnownCommand(command codes.CommandCode) bool {
 
 // dispatch runs the built-in handler for a decoded request, or answers with the
 // status that says why it could not.
+//
+// A batched request is run as a chain: every command in it executes, in order,
+// and all the answers travel back in one message.
 func (s *Server) dispatch(conn *Connection, w ResponseWriter, req *message.Message) {
-	// A command that acts within a session must name one that exists. Checking
-	// here rather than in each handler means a command added later cannot forget
-	// to.
-	if !sessionlessCommands[req.Header.Command] {
-		if conn.Session(uint16(req.Header.UID)) == nil {
-			logger.Debugf("SMB1 server: %s sent command 0x%02X on UID 0x%04X, which names no session",
-				conn.Remote, uint8(req.Header.Command), uint16(req.Header.UID))
-			s.writeError(conn, w, nt_status.NT_STATUS_SMB_BAD_UID)
-			return
-		}
-	}
-
-	handler, ok := dispatchTable[req.Header.Command]
-	if !ok {
-		logger.Debugf("SMB1 server: %s sent unimplemented command 0x%02X (%s)",
-			conn.Remote, uint8(req.Header.Command), req.Header.Command)
-		s.writeError(conn, w, nt_status.NT_STATUS_NOT_IMPLEMENTED)
+	// A batch is only a batch if a second command is actually linked, and only the
+	// concrete writer can collect a chain — a caller-supplied ResponseWriter has
+	// no way to. A chain reaching a writer that cannot collect one is answered
+	// command by command, which is what happened to every batch before chains
+	// were executed at all.
+	writer, collectable := w.(*responseWriter)
+	if collectable && req.Command != nil && req.Command.GetNextCommand() != nil {
+		s.dispatchChain(conn, writer, req)
 		return
 	}
 
-	if status := handler(conn, w, req); status != nt_status.NT_STATUS_SUCCESS {
-		logger.Debugf("SMB1 server: command 0x%02X from %s failed with %s",
-			uint8(req.Header.Command), conn.Remote, statusName(status))
+	if status := s.runCommand(conn, w, req, req.Header.Command); status != nt_status.NT_STATUS_SUCCESS {
 		s.writeError(conn, w, status)
 	}
+}
+
+// dispatchChain runs every command of a batched request and answers with one
+// message carrying every response.
+//
+// [MS-CIFS] section 3.3.4.1: "If the client request is part of an AndX chain,
+// processing of the AndX request chain terminates with the request that generated
+// the error. The error response MUST be the last response in the returned AndX
+// chain." So a failure stops the chain, the answers already produced are still
+// returned, and the error response closes it.
+func (s *Server) dispatchChain(conn *Connection, writer *responseWriter, req *message.Message) {
+	writer.beginChain()
+
+	for command := req.Command; command != nil; command = command.GetNextCommand() {
+		code := command.GetCommandCode()
+
+		// Each command in the chain sees the identifiers as they stand when it
+		// runs, not as the client sent them. That is what makes a session setup
+		// batched with a tree connect work: the client sent UID 0 because it had
+		// no session yet, and the setup assigned one that the tree connect has to
+		// act on.
+		view := &message.Message{Header: req.Header, Command: command}
+		if writer.uidSet || writer.tidSet {
+			amended := *req.Header
+			if writer.uidSet {
+				amended.UID = types.USHORT(writer.uid)
+			}
+			if writer.tidSet {
+				amended.TID = types.USHORT(writer.tid)
+			}
+			view.Header = &amended
+		}
+
+		status := s.runCommand(conn, writer, view, code)
+		if status != nt_status.NT_STATUS_SUCCESS {
+			// The error response terminates the chain and carries the status.
+			if err := writer.WriteResponseWithStatus(newErrorResponse(code), status); err != nil {
+				logger.Debugf("SMB1 server: failed to collect the chain error for %s: %v", conn.Remote, err)
+			}
+			break
+		}
+
+		// A response written with a status of its own ends the chain too. An
+		// interim status such as STATUS_MORE_PROCESSING_REQUIRED describes the
+		// message, and a message carries one status, so nothing after it could be
+		// reported.
+		if writer.chainStatus != nt_status.NT_STATUS_SUCCESS {
+			logger.Debugf("SMB1 server: chain from %s stops after 0x%02X, which reported %s",
+				conn.Remote, uint8(code), statusName(writer.chainStatus))
+			break
+		}
+	}
+
+	if err := writer.flushChain(); err != nil {
+		if errors.Is(err, errChainTooLarge) {
+			logger.Debugf("SMB1 server: the batched answer for %s does not fit the negotiated buffer", conn.Remote)
+			s.writeError(conn, writer, nt_status.NT_STATUS_INSUFF_SERVER_RESOURCES)
+			return
+		}
+		logger.Debugf("SMB1 server: failed to answer the batch from %s: %v", conn.Remote, err)
+	}
+}
+
+// runCommand applies the session requirement and the dispatch table to one
+// command, and returns the status to report for it.
+//
+// It is shared by the single-command and the batched paths so a command cannot
+// behave differently depending on whether it arrived on its own.
+//
+// Parameters:
+//   - conn: the connection being served
+//   - w: where the command writes its response
+//   - req: the request as this command should see it
+//   - code: the command being run, which for a chained command is not the
+//     header's
+//
+// Returns:
+//   - NT_STATUS_SUCCESS once the command has answered, or the status to report
+func (s *Server) runCommand(
+	conn *Connection,
+	w ResponseWriter,
+	req *message.Message,
+	code codes.CommandCode,
+) nt_status.NT_STATUS {
+	// A command that acts within a session must name one that exists. Checking
+	// here rather than in each handler means a command added later cannot forget
+	// to.
+	if !sessionlessCommands[code] {
+		if conn.Session(uint16(req.Header.UID)) == nil {
+			logger.Debugf("SMB1 server: %s sent command 0x%02X on UID 0x%04X, which names no session",
+				conn.Remote, uint8(code), uint16(req.Header.UID))
+			return nt_status.NT_STATUS_SMB_BAD_UID
+		}
+	}
+
+	handler, ok := dispatchTable[code]
+	if !ok {
+		logger.Debugf("SMB1 server: %s sent unimplemented command 0x%02X (%s)",
+			conn.Remote, uint8(code), code)
+		return nt_status.NT_STATUS_NOT_IMPLEMENTED
+	}
+
+	status := handler(conn, w, req)
+	if status != nt_status.NT_STATUS_SUCCESS {
+		logger.Debugf("SMB1 server: command 0x%02X from %s failed with %s",
+			uint8(code), conn.Remote, statusName(status))
+	}
+	return status
 }
 
 // writeError sends an error response and logs a write failure, which is only

--- a/network/smb/smb_v10/server/doc.go
+++ b/network/smb/smb_v10/server/doc.go
@@ -53,9 +53,15 @@
 // displacement, with the subcommand selected by a setup word, a Function field or
 // a name.
 //
+//   - Batched ("AndX") requests: every command in a chain runs, in order, and all
+//     the answers return in one message. A command sees the identifiers as they
+//     stand when it runs rather than as the client sent them, which is what makes
+//     a session setup batched with a tree connect work — the client had no UID to
+//     send. A failure ends the chain and the error response closes it, per
+//     [MS-CIFS] 3.3.4.1, so the answers already produced still come back.
+//
 // Not yet implemented, and answered with STATUS_NOT_IMPLEMENTED: byte-range
-// locking, seek, the legacy SMB_COM_OPEN_ANDX, and batched AndX chains beyond
-// their first command.
+// locking, seek, and the legacy SMB_COM_OPEN_ANDX.
 //
 // NT_TRANSACT_NOTIFY_CHANGE is deliberately absent rather than pending. It needs
 // two things this package does not have: a FileSystem that can be watched, and a

--- a/network/smb/smb_v10/server/handler.go
+++ b/network/smb/smb_v10/server/handler.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"errors"
 	"fmt"
 	"net"
 
@@ -91,6 +92,18 @@ type responseWriter struct {
 	// signKey and signSequence, when set, sign responses to this request.
 	signKey      []byte
 	signSequence uint32
+
+	// chaining collects responses instead of sending them, for a batched request
+	// whose answers all travel in one message. A handler is unaware of it: it
+	// writes its response as it always does, and the dispatcher decides whether
+	// that response leaves on its own or as one link of a chain.
+	chaining  bool
+	collected []command_interface.CommandInterface
+
+	// chainStatus is the status the assembled chain reports. A chain carries one
+	// header and so one status: it stays success until a command reports
+	// otherwise, and that command's status is the message's.
+	chainStatus nt_status.NT_STATUS
 }
 
 // RemoteAddr returns the address of the client being answered.
@@ -133,9 +146,20 @@ func (w *responseWriter) WriteError(status nt_status.NT_STATUS) error {
 }
 
 // write builds the reply, marshals it and frames it on the transport.
+//
+// While a chain is being collected the response is kept instead of sent, and the
+// whole chain is framed once by flushChain.
 func (w *responseWriter) write(cmd command_interface.CommandInterface, status nt_status.NT_STATUS) error {
 	if cmd == nil {
 		return fmt.Errorf("cannot write a response with no command")
+	}
+
+	if w.chaining {
+		w.collected = append(w.collected, cmd)
+		if status != nt_status.NT_STATUS_SUCCESS && w.chainStatus == nt_status.NT_STATUS_SUCCESS {
+			w.chainStatus = status
+		}
+		return nil
 	}
 
 	reply := message.NewMessage()
@@ -173,6 +197,86 @@ func (w *responseWriter) write(cmd command_interface.CommandInterface, status nt
 	}
 	return nil
 }
+
+// beginChain puts the writer into chain mode, so responses are collected rather
+// than sent.
+func (w *responseWriter) beginChain() {
+	w.chaining = true
+	w.collected = nil
+	w.chainStatus = nt_status.NT_STATUS_SUCCESS
+}
+
+// flushChain leaves chain mode and sends everything collected as one message.
+//
+// The responses go out in the order they were produced. Message.Marshal writes
+// each AndX block — the code of the command that follows and the offset it begins
+// at — and terminates the chain, and it refuses a chain in which a non-AndX
+// response is followed by another, which is the rule that ends a chain in
+// [MS-CIFS] section 2.2.3.4. The header carries the first command's code and the
+// chain's status.
+//
+// Returns:
+//   - The error from framing the message, or nil
+func (w *responseWriter) flushChain() error {
+	collected := w.collected
+	status := w.chainStatus
+
+	w.chaining = false
+	w.collected = nil
+	w.chainStatus = nt_status.NT_STATUS_SUCCESS
+
+	if len(collected) == 0 {
+		// Every command in the chain produced no response, which is legitimate:
+		// SMB_COM_ECHO with a count of zero is defined that way. Nothing to send.
+		return nil
+	}
+
+	reply := message.NewMessage()
+	reply.Header = replyHeader(w.request.Header, status, len(w.signKey) > 0)
+	if w.uidSet {
+		reply.Header.UID = types.USHORT(w.uid)
+	}
+	if w.tidSet {
+		reply.Header.TID = types.USHORT(w.tid)
+	}
+
+	for _, cmd := range collected {
+		cmd.SetUnicode(w.request.Header.Flags2.IsUnicode())
+		reply.AddCommand(cmd)
+	}
+
+	// AddCommand takes the header's command code from the first command it is
+	// given, and the reply must echo the request's code regardless.
+	reply.Header.Command = w.request.Header.Command
+
+	marshalled, err := reply.Marshal()
+	if err != nil {
+		return fmt.Errorf("failed to marshal the response chain: %v", err)
+	}
+
+	// [MS-CIFS] section 2.2.3.4: the total size of a batched message MUST NOT
+	// exceed the negotiated MaxBufferSize. A chain that does cannot be trimmed
+	// after the fact — the commands have already run — so it is refused rather
+	// than sent as a message the client cannot receive.
+	if limit := int(w.conn.Server.config.MaxBufferSize); limit > 0 && len(marshalled) > limit {
+		return errChainTooLarge
+	}
+
+	// Signing happens after marshalling and over the whole message, because the
+	// signature occupies a field inside the header it covers.
+	if len(w.signKey) > 0 {
+		signing.Sign(w.signKey, marshalled, w.signSequence)
+	}
+
+	if _, err := w.conn.Transport.Send(marshalled); err != nil {
+		return fmt.Errorf("failed to send the response chain: %v", err)
+	}
+	return nil
+}
+
+// errChainTooLarge reports a batched response that does not fit in the negotiated
+// buffer, which the dispatcher answers with a status rather than a partial chain.
+var errChainTooLarge = errors.New("the batched response exceeds the negotiated buffer size")
 
 // Compile-time assurance that responseWriter satisfies the contract.
 var _ ResponseWriter = (*responseWriter)(nil)


### PR DESCRIPTION
### Linked Issue
`Closes #1140`

### Root Cause
Chain execution was deferred when the dispatcher was written and never added, and the failure was silent in both directions.

On the request side, `Message.Unmarshal` decodes the whole chain and links it onto the message, but `Server.dispatch` looked up exactly one handler from `dispatchTable` keyed on `req.Header.Command` and called it once. Nothing under `server/` ever asked a command what followed it.

On the response side there was no way to emit a chain even had the commands run: `Message.Marshal` wrote `m.Command` and stopped, and every AndX response's own `Marshal` writes `SMB_COM_NO_ANDX_COMMAND` into its AndX block when it was given none. So a client that batched two commands received a well-formed single response that declared the chain terminated — the second command had been decoded, linked, and dropped, and the client was told the batch had completed.

A third defect sat behind those two. `Command.GetNextCommand` returned the linked command only `if c.AndX != nil`. That block is recorded when a chain is *parsed* and absent when a chain is *built*, so the gate hid every command that had been linked deliberately and would have made any walker stop at the first one.

### Fix Description
**Message layer.** `Message.Marshal` walks the chain, marshalling each command once and then patching the AndX blocks in the produced bytes: each predecessor gets the command code of its successor and the offset the successor begins at, measured from the start of the SMB header. The last AndX command is terminated explicitly.

Patching bytes rather than filling in the fields and re-marshalling is deliberate, and not a shortcut: a command's `Marshal` *appends* to its own parameter and data blocks (`GetParameters().AddWord`, `GetData().Add`), so marshalling one twice does not produce the same bytes twice. Marshalling once and patching is the only correct order.

`Marshal` also refuses a chain whose non-final command is not an AndX command. Such a command has no AndX block, so there is nowhere to record what follows it, and [MS-CIFS] 2.2.3.4 makes it the end of a chain — emitting the follow-on anyway would put a block pair in the message that no client could find. That single check replaces the need for the caller to validate anything.

`Command.GetNextCommand` now returns whatever is linked. Whether a command *may* be followed is an AndX question, and it is asked in `Marshal`, where refusing is possible.

**Chained offsets.** `ReadAndxResponse.DataOffset` is measured from the start of the SMB header, and was a constant computed for a response sitting at the front of a message. Batched second, it pointed the client at bytes belonging to the command ahead of it. `Marshal` now tells each command where it begins, through a new optional `ChainPositioned` interface, before marshalling it; `ReadAndxResponse` is the one currently-served response that needs the number. This is the class of silent wrongness the issue is about, so it is fixed here rather than filed on.

**Server.** `responseWriter` gains a chain mode: `write` collects responses instead of framing them, and `flushChain` emits everything collected as one message with one header. Handlers are untouched and unaware — a handler writes its response exactly as before, and the dispatcher decides whether that response leaves alone or as one link.

`Server.dispatch` runs a chain when a second command is actually linked, and the per-command work (session requirement, table lookup, handler call) is factored into `runCommand` so a command cannot behave differently depending on whether it arrived batched.

Two details the chain needs:

- **Identifiers assigned mid-chain.** A command sees the identifiers as they stand when it runs, not as the client sent them. This is what makes the batch a Windows client actually sends work: `SESSION_SETUP_ANDX` + `TREE_CONNECT_ANDX` arrives with UID 0, because the client has no session yet, and the tree connect has to act on the UID the setup just assigned. The loop amends the header view from `SetResponseUID`/`SetResponseTID` for the commands that follow.
- **Failure.** [MS-CIFS] 3.3.4.1: processing terminates with the request that generated the error and the error response is the last response in the returned chain. A failing command appends a `WordCount 0`/`ByteCount 0` error response, carrying the failing command's code, and the loop stops — the answers already produced still come back. A response written with an interim status of its own (`STATUS_MORE_PROCESSING_REQUIRED`) ends the chain too, because one message carries one status.

A chain whose assembled answer exceeds the negotiated `MaxBufferSize` is refused with `STATUS_INSUFF_SERVER_RESOURCES` rather than sent. [MS-CIFS] 2.2.3.4 forbids exceeding it, and by the time the size is known the commands have run, so the message cannot be trimmed. A cooperative client does not produce one; refusing is better than framing a message the client cannot receive.

Follow-on command lists ([MS-CIFS] 2.2.3.4.1) are not enforced. Being permissive about which command follows which costs nothing here and refusing a legal-but-unlisted batch would be an interop regression.

### How Verified
Runtime, over the loopback harness and at the message layer.

Server, in `server/andx_chain_test.go`:
- `TestBatchedChainExecutesEveryCommand` — `WRITE_ANDX` + `CLOSE`. Before: the write landed, the close was dropped, the handle leaked and the client was told the batch completed. After: the reply carries a write response linked to a close response, the file holds the payload, and the handle is gone. The handle check runs *before* the file is reopened, because the identifier allocator reuses a released FID and a reopen can hand back the same number.
- `TestBatchedChainStopsAtTheFirstFailure` — `READ_ANDX`(valid) + `READ_ANDX`(unknown FID) + `READ_ANDX`(valid). Asserts the header reports `STATUS_SMB_BAD_FID`, the first read still answered, the error response is `00 00 00`, and there is nothing after it — the third command must not have run.
- `TestBatchedChainSeesIdentifiersAssignedWithinIt` — `TREE_CONNECT_ANDX` + `CHECK_DIRECTORY` (a documented follow-on, [MS-CIFS] 2.2.4.55) sent with an invented TID, so success can only come from the tree the batch itself connected.
- `TestUnbatchedAndXRequestTerminatesItsChain` — a lone `READ_ANDX` still answers with a terminated one-command chain whose `DataOffset` points at its data.

Message layer, in `message/andx_chain_test.go`:
- `TestMarshalWritesAndXChain` — asserts the header names the first command, the first AndX block names the second and the offset it begins at, the last terminates with `SMB_COM_NO_ANDX_COMMAND` and offset 0, and the bytes decode back into the chain they were built from.
- `TestMarshalRejectsFollowingANonAndXCommand` — a follow-on behind a `NegotiateResponse` is refused.
- `TestMarshalPositionsChainedReadOffsets` — a read response batched behind a tree connect reports a `DataOffset` that indexes its own payload in the assembled message.

The error-case tests assert on raw bytes rather than decoding, because an error response in a chain is a `WordCount 0` block that the response structure for that command code cannot decode — a client reads the header status before parsing a body for the same reason.

Whole tree green: `go build ./...`, `go vet ./network/smb/...`, `go test ./network/smb/...`. `gofmt -l` reports nothing for any file this PR touches.

### Test Coverage
**Added:**
- `server/andx_chain_test.go` (new): `TestBatchedChainExecutesEveryCommand`, `TestBatchedChainStopsAtTheFirstFailure`, `TestBatchedChainSeesIdentifiersAssignedWithinIt`, `TestUnbatchedAndXRequestTerminatesItsChain`, plus the `sendChain` helper and the raw-reply accessors.
- `message/andx_chain_test.go`: `TestMarshalWritesAndXChain`, `TestMarshalRejectsFollowingANonAndXCommand`, `TestMarshalPositionsChainedReadOffsets`.

**Existing:** the whole server conformance and file-service suite covers the single-command path and passes unchanged, which is what shows chain support did not disturb it. `TestUnmarshalFollowsAndXChain` and `TestUnmarshalNonAndXLeavesNoChain` still pass with `GetNextCommand`'s gate removed.

### Scope of Change
- **Files changed:** `message/message.go`, `message/commands/command_interface/command_interface.go`, `message/commands/ReadAndxResponse.go`, `server/dispatch.go`, `server/handler.go`, `server/doc.go`, `message/andx_chain_test.go`, `server/andx_chain_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
This touches the message layer, which the SMB1 client shares, so the blast radius is wider than a server-only change. It is bounded by construction: with one command in a message, `Marshal` marshals it, patches nothing, and emits exactly the bytes it did before, and `GetNextCommand` returns nil for an unlinked command as it did before. The client builds only single-command messages, so its wire output is unchanged, and the client suite passes.

The behaviour that changes for a client talking to this server is that a batch it sent is now answered in full instead of half-answered — which is the fix.

### Notes
`TRANS2_*`/`NT_TRANSACT` responses set their `ParameterOffset` and `DataOffset` for the front of a message as well. They are not AndX commands, so they can only ever be last in a chain, and a chain ending in a transaction is exotic enough that no client in the interop matrix sends one; `ChainPositioned` is the hook for it if one turns up.

The `SESSION_SETUP_ANDX` + `TREE_CONNECT_ANDX` batch is covered for the mechanism it needs (an identifier assigned mid-chain, asserted through the tree-connect case) but not end to end, because the in-repo client performs the authentication exchange internally and cannot batch onto its final leg. Driving that batch belongs to the Windows-client leg of the interop matrix, filed as #1153.
