### PR TITLE
Fix LOCKING_ANDX ranges ignoring the LARGE_FILES format bit (Fixes #1156)

### DIFF
--- a/network/smb/smb_v10/message/commands/LockingAndxRequest.go
+++ b/network/smb/smb_v10/message/commands/LockingAndxRequest.go
@@ -14,6 +14,14 @@ import (
 
 // LockingAndxRequest
 // Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/b5c6eae7-976b-4444-b52e-c76c68c861ad
+// LockingAndxLargeFiles is the TypeOfLock bit that selects the wire format of the
+// Locks and Unlocks arrays: set, they are 20-byte LOCKING_ANDX_RANGE64 entries;
+// clear, they are 10-byte LOCKING_ANDX_RANGE32 entries ([MS-CIFS] 2.2.4.32.1).
+//
+// Both are held in memory as LOCKING_ANDX_RANGE64, which is the wider of the two,
+// so a caller works with one shape and this bit decides only what goes on the wire.
+const LockingAndxLargeFiles = 0x10
+
 type LockingAndxRequest struct {
 	command_interface.Command
 
@@ -135,20 +143,21 @@ func (c *LockingAndxRequest) Marshal() ([]byte, error) {
 	// the data will be stored in the parameters
 	rawDataContent := []byte{}
 
-	// Marshal Unlocks
-	for _, unlock := range c.Unlocks {
-		unlockBytes, err := unlock.Marshal()
+	// Marshal Unlocks and Locks in whichever range format TypeOfLock declares.
+	largeFiles := c.UsesLargeFileRanges()
+
+	for index, unlock := range c.Unlocks {
+		unlockBytes, err := marshalLockingRange(unlock, largeFiles)
 		if err != nil {
-			return nil, fmt.Errorf("error marshalling unlock: %v", err)
+			return nil, fmt.Errorf("error marshalling unlock %d: %v", index, err)
 		}
 		rawDataContent = append(rawDataContent, unlockBytes...)
 	}
 
-	// Marshal Locks
-	for _, lock := range c.Locks {
-		lockBytes, err := lock.Marshal()
+	for index, lock := range c.Locks {
+		lockBytes, err := marshalLockingRange(lock, largeFiles)
 		if err != nil {
-			return nil, fmt.Errorf("error marshalling lock: %v", err)
+			return nil, fmt.Errorf("error marshalling lock %d: %v", index, err)
 		}
 		rawDataContent = append(rawDataContent, lockBytes...)
 	}
@@ -289,29 +298,24 @@ func (c *LockingAndxRequest) Unmarshal(rawData []byte) (int, error) {
 	// Then unmarshal the data
 	offset = 0
 
-	// Unmarshal Unlocks
+	// Unmarshal Unlocks and Locks from whichever range format TypeOfLock declares.
+	// Reading the wrong one does not fail cleanly: the two differ in width, so a
+	// 32-bit array read as 64-bit yields ranges assembled from adjacent entries.
+	largeFiles := c.UsesLargeFileRanges()
+
 	for i := 0; i < int(c.NumberOfRequestedUnlocks); i++ {
-		if len(rawDataContent) < offset+20 {
-			return offset, fmt.Errorf("rawDataContent too short for Unlocks[%d]", i)
-		}
-		unlock := types.LOCKING_ANDX_RANGE64{}
-		bytesRead, err := unlock.Unmarshal(rawDataContent[offset : offset+20])
+		unlock, bytesRead, err := unmarshalLockingRange(rawDataContent[offset:], largeFiles)
 		if err != nil {
-			return offset, fmt.Errorf("error unmarshalling unlock: %v", err)
+			return offset, fmt.Errorf("error unmarshalling unlock %d: %v", i, err)
 		}
 		c.Unlocks = append(c.Unlocks, unlock)
 		offset += bytesRead
 	}
 
-	// Unmarshal Locks
 	for i := 0; i < int(c.NumberOfRequestedLocks); i++ {
-		if len(rawDataContent) < offset+20 {
-			return offset, fmt.Errorf("rawDataContent too short for Locks[%d]", i)
-		}
-		lock := types.LOCKING_ANDX_RANGE64{}
-		bytesRead, err := lock.Unmarshal(rawDataContent[offset : offset+20])
+		lock, bytesRead, err := unmarshalLockingRange(rawDataContent[offset:], largeFiles)
 		if err != nil {
-			return offset, fmt.Errorf("error unmarshalling lock: %v", err)
+			return offset, fmt.Errorf("error unmarshalling lock %d: %v", i, err)
 		}
 		c.Locks = append(c.Locks, lock)
 		offset += bytesRead
@@ -319,3 +323,96 @@ func (c *LockingAndxRequest) Unmarshal(rawData []byte) (int, error) {
 
 	return offset, nil
 }
+
+// UsesLargeFileRanges reports whether this request's Locks and Unlocks arrays are
+// in the 64-bit LOCKING_ANDX_RANGE64 wire format, which the LARGE_FILES bit of
+// TypeOfLock selects.
+//
+// Returns:
+//   - true when the arrays are 20-byte 64-bit entries, false for 10-byte 32-bit ones
+func (c *LockingAndxRequest) UsesLargeFileRanges() bool {
+	return uint8(c.TypeOfLock)&LockingAndxLargeFiles != 0
+}
+
+// marshalLockingRange emits one byte range in the requested wire format.
+//
+// A range whose offset or length needs more than 32 bits cannot be expressed in
+// the 32-bit format. That is refused rather than truncated: a truncated offset
+// names a different part of the file, so the lock would be taken somewhere the
+// caller did not ask for and the caller would be told it succeeded.
+//
+// Parameters:
+//   - lockingRange: the range to emit, held in the wider of the two forms
+//   - largeFiles: whether to emit the 64-bit form
+//
+// Returns:
+//   - The marshalled range, or an error
+func marshalLockingRange(lockingRange types.LOCKING_ANDX_RANGE64, largeFiles bool) ([]byte, error) {
+	if largeFiles {
+		return lockingRange.Marshal()
+	}
+
+	if lockingRange.ByteOffsetHigh != 0 || lockingRange.LengthInBytesHigh != 0 {
+		return nil, fmt.Errorf(
+			"range at offset 0x%08X%08X for 0x%08X%08X bytes does not fit the 32-bit format; set the LARGE_FILES bit of TypeOfLock",
+			uint32(lockingRange.ByteOffsetHigh), uint32(lockingRange.ByteOffsetLow),
+			uint32(lockingRange.LengthInBytesHigh), uint32(lockingRange.LengthInBytesLow))
+	}
+
+	narrow := types.LOCKING_ANDX_RANGE32{
+		PID:           lockingRange.PID,
+		ByteOffset:    lockingRange.ByteOffsetLow,
+		LengthInBytes: lockingRange.LengthInBytesLow,
+	}
+	return narrow.Marshal()
+}
+
+// unmarshalLockingRange reads one byte range in the given wire format and returns
+// it in the wider of the two forms, so a caller has one shape to work with.
+//
+// Parameters:
+//   - data: the bytes at the start of the range
+//   - largeFiles: whether the range is in the 64-bit form
+//
+// Returns:
+//   - The range, the number of bytes it occupied, or an error
+func unmarshalLockingRange(data []byte, largeFiles bool) (types.LOCKING_ANDX_RANGE64, int, error) {
+	if largeFiles {
+		wide := types.LOCKING_ANDX_RANGE64{}
+		if len(data) < lockingRange64Size {
+			return wide, 0, fmt.Errorf("data too short for a 64-bit range: got %d bytes, need %d",
+				len(data), lockingRange64Size)
+		}
+		bytesRead, err := wide.Unmarshal(data[:lockingRange64Size])
+		return wide, bytesRead, err
+	}
+
+	narrow := types.LOCKING_ANDX_RANGE32{}
+	if len(data) < lockingRange32Size {
+		return types.LOCKING_ANDX_RANGE64{}, 0, fmt.Errorf(
+			"data too short for a 32-bit range: got %d bytes, need %d", len(data), lockingRange32Size)
+	}
+	bytesRead, err := narrow.Unmarshal(data[:lockingRange32Size])
+	if err != nil {
+		return types.LOCKING_ANDX_RANGE64{}, 0, err
+	}
+
+	// Widened, not reinterpreted: the 32-bit form has no high words, so they are
+	// zero rather than unknown.
+	return types.LOCKING_ANDX_RANGE64{
+		PID:               narrow.PID,
+		Pad:               0,
+		ByteOffsetHigh:    0,
+		ByteOffsetLow:     narrow.ByteOffset,
+		LengthInBytesHigh: 0,
+		LengthInBytesLow:  narrow.LengthInBytes,
+	}, bytesRead, nil
+}
+
+// The two range formats' sizes on the wire, from [MS-CIFS] 2.2.4.32.1:
+// LOCKING_ANDX_RANGE32 is PID(2) ByteOffset(4) LengthInBytes(4), and
+// LOCKING_ANDX_RANGE64 is PID(2) Pad(2) then four 4-byte words.
+const (
+	lockingRange32Size = 10
+	lockingRange64Size = 20
+)

--- a/network/smb/smb_v10/message/commands/LockingAndxRequest_ranges_test.go
+++ b/network/smb/smb_v10/message/commands/LockingAndxRequest_ranges_test.go
@@ -1,0 +1,167 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+)
+
+// lockingRoundTrip marshals a request and decodes it back, returning the decoded
+// copy. The AndX block and framing come along for free, which is what a real
+// request carries.
+func lockingRoundTrip(t *testing.T, request *LockingAndxRequest) *LockingAndxRequest {
+	t.Helper()
+
+	marshalled, err := request.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+
+	decoded := NewLockingAndxRequest()
+	if _, err := decoded.Unmarshal(marshalled); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	return decoded
+}
+
+// TestLockingAndxRangesRoundTripInBothFormats asserts a lock range survives a
+// round trip in each of the two wire formats, and that each format occupies the
+// width [MS-CIFS] 2.2.4.32.1 gives it.
+//
+// The width is the whole point: the formats are 10 and 20 bytes, so decoding an
+// array in the wrong one does not fail cleanly — it assembles ranges out of
+// adjacent entries and locks somewhere the client never asked for.
+func TestLockingAndxRangesRoundTripInBothFormats(t *testing.T) {
+	for _, testCase := range []struct {
+		name       string
+		typeOfLock uint8
+		entrySize  int
+	}{
+		{name: "32-bit ranges", typeOfLock: 0x00, entrySize: 10},
+		{name: "64-bit ranges", typeOfLock: LockingAndxLargeFiles, entrySize: 20},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			request := NewLockingAndxRequest()
+			request.FID = types.USHORT(0x0042)
+			request.TypeOfLock = types.UCHAR(testCase.typeOfLock)
+			request.Timeout = types.ULONG(0)
+
+			locks := []types.LOCKING_ANDX_RANGE64{
+				{PID: 0x1111, ByteOffsetLow: 0x00001000, LengthInBytesLow: 0x00000200},
+				{PID: 0x2222, ByteOffsetLow: 0xFFFFFFF0, LengthInBytesLow: 0x00000010},
+			}
+			unlocks := []types.LOCKING_ANDX_RANGE64{
+				{PID: 0x3333, ByteOffsetLow: 0x00000040, LengthInBytesLow: 0x00000004},
+			}
+
+			request.Locks = locks
+			request.NumberOfRequestedLocks = types.USHORT(len(locks))
+			request.Unlocks = unlocks
+			request.NumberOfRequestedUnlocks = types.USHORT(len(unlocks))
+
+			marshalled, err := request.Marshal()
+			if err != nil {
+				t.Fatalf("Marshal() error = %v", err)
+			}
+
+			// WordCount(1) + 8 words + ByteCount(2), then the arrays.
+			wantData := testCase.entrySize * (len(locks) + len(unlocks))
+			gotData := len(marshalled) - (1 + 2*8 + 2)
+			if gotData != wantData {
+				t.Fatalf("the arrays occupy %d bytes, want %d (%d entries of %d)",
+					gotData, wantData, len(locks)+len(unlocks), testCase.entrySize)
+			}
+
+			decoded := NewLockingAndxRequest()
+			if _, err := decoded.Unmarshal(marshalled); err != nil {
+				t.Fatalf("Unmarshal() error = %v", err)
+			}
+
+			if got := len(decoded.Locks); got != len(locks) {
+				t.Fatalf("decoded %d locks, want %d", got, len(locks))
+			}
+			if got := len(decoded.Unlocks); got != len(unlocks) {
+				t.Fatalf("decoded %d unlocks, want %d", got, len(unlocks))
+			}
+
+			for index, want := range locks {
+				got := decoded.Locks[index]
+				if got.PID != want.PID || got.ByteOffsetLow != want.ByteOffsetLow ||
+					got.LengthInBytesLow != want.LengthInBytesLow ||
+					got.ByteOffsetHigh != want.ByteOffsetHigh ||
+					got.LengthInBytesHigh != want.LengthInBytesHigh {
+					t.Errorf("lock %d round-tripped to %+v, want %+v", index, got, want)
+				}
+			}
+			for index, want := range unlocks {
+				got := decoded.Unlocks[index]
+				if got.PID != want.PID || got.ByteOffsetLow != want.ByteOffsetLow ||
+					got.LengthInBytesLow != want.LengthInBytesLow {
+					t.Errorf("unlock %d round-tripped to %+v, want %+v", index, got, want)
+				}
+			}
+		})
+	}
+}
+
+// TestLockingAndxLargeRangeNeedsTheLargeFilesBit asserts a range that does not fit
+// in 32 bits is refused rather than truncated when the 32-bit format is declared.
+//
+// Truncating would name a different part of the file and report success, which is
+// worse than refusing: the caller would believe it holds a lock it does not.
+func TestLockingAndxLargeRangeNeedsTheLargeFilesBit(t *testing.T) {
+	request := NewLockingAndxRequest()
+	request.FID = types.USHORT(0x0042)
+	request.TypeOfLock = types.UCHAR(0x00)
+	request.Locks = []types.LOCKING_ANDX_RANGE64{
+		{PID: 0x1111, ByteOffsetHigh: 0x00000001, ByteOffsetLow: 0x00000000, LengthInBytesLow: 0x10},
+	}
+	request.NumberOfRequestedLocks = types.USHORT(1)
+
+	if _, err := request.Marshal(); err == nil {
+		t.Fatal("a range past 4 GiB marshalled into the 32-bit format, want an error")
+	}
+
+	// With the bit set the same range is expressible. A fresh request is built
+	// rather than the previous one reused: Marshal appends to a command's
+	// parameter and data blocks, so marshalling one twice does not produce the
+	// same bytes twice.
+	wide := NewLockingAndxRequest()
+	wide.FID = types.USHORT(0x0042)
+	wide.TypeOfLock = types.UCHAR(LockingAndxLargeFiles)
+	wide.Locks = []types.LOCKING_ANDX_RANGE64{
+		{PID: 0x1111, ByteOffsetHigh: 0x00000001, ByteOffsetLow: 0x00000000, LengthInBytesLow: 0x10},
+	}
+	wide.NumberOfRequestedLocks = types.USHORT(1)
+
+	decoded := lockingRoundTrip(t, wide)
+	if got := len(decoded.Locks); got != 1 {
+		t.Fatalf("decoded %d locks, want 1", got)
+	}
+	if got := decoded.Locks[0].ByteOffsetHigh; got != 0x00000001 {
+		t.Errorf("the high offset word round-tripped to 0x%08X, want 0x00000001", uint32(got))
+	}
+}
+
+// TestLockingAndxTruncatedRangeArrayIsRefused asserts an array shorter than the
+// count claims is reported rather than read past.
+func TestLockingAndxTruncatedRangeArrayIsRefused(t *testing.T) {
+	request := NewLockingAndxRequest()
+	request.FID = types.USHORT(0x0042)
+	request.TypeOfLock = types.UCHAR(0x00)
+	request.Locks = []types.LOCKING_ANDX_RANGE64{
+		{PID: 0x1111, ByteOffsetLow: 0x10, LengthInBytesLow: 0x10},
+	}
+	// One entry is sent, two are claimed.
+	request.NumberOfRequestedLocks = types.USHORT(2)
+
+	marshalled, err := request.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+
+	decoded := NewLockingAndxRequest()
+	if _, err := decoded.Unmarshal(marshalled); err == nil {
+		t.Fatal("a request claiming more ranges than it carries decoded, want an error")
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #1156`

### Root Cause
[MS-CIFS] 2.2.4.32.1 gives the `Locks` and `Unlocks` arrays two wire formats and one bit that selects between them: `LOCKING_ANDX_RANGE32` is 10 bytes, `LOCKING_ANDX_RANGE64` is 20, and the `LARGE_FILES` (0x10) bit of `TypeOfLock` says which is on the wire.

The struct declared both fields as `[]types.LOCKING_ANDX_RANGE64`, and that choice of field type quietly became the decoder: both `Unmarshal` loops constructed a `LOCKING_ANDX_RANGE64` and advanced by its width, and `Marshal` emitted the same. Nothing in the file read the selecting bit — it appeared only in the doc comment describing the rule the code did not implement. `types.LOCKING_ANDX_RANGE32` existed and was referenced nowhere outside its own file, so the 32-bit path had been modelled and never wired in.

The failure mode is not a clean one. Because the widths differ, a 32-bit array decoded as 64-bit does not simply come out wrong per field — each decoded range is assembled from bytes belonging to two adjacent entries, so the offsets and lengths are unrelated to anything the client sent.

### Fix Description
The wire format is now chosen by the bit, in both directions, while the in-memory representation stays `LOCKING_ANDX_RANGE64` for both.

Keeping one in-memory shape is deliberate: `LOCKING_ANDX_RANGE64` is the wider of the two and loses nothing, so a caller — the server's lock handler in particular — works with a single type and never branches on the format. Exposing two slice types, or a union, would push the wire's accident into every consumer.

- `UsesLargeFileRanges` reads the bit, and `LockingAndxLargeFiles` names it. Both are exported so the handler that serves this command can name the same bit rather than redefine it.
- `unmarshalLockingRange` reads whichever form is declared and widens the 32-bit one. The high words are set to zero rather than left untouched, because in the 32-bit form they are genuinely absent, not unknown.
- `marshalLockingRange` narrows to the 32-bit form when the bit is clear, and **refuses** a range whose offset or length needs more than 32 bits. Truncating would name a different part of the file and report success, leaving the caller believing it holds a lock it does not — the same class of silent wrongness the bug itself is.
- Both decode paths now bounds-check against the width they are actually reading, so a request claiming more ranges than it carries is reported instead of read past.

### How Verified
Runtime, with new tests:

- `TestLockingAndxRangesRoundTripInBothFormats` — the same three ranges round-trip under each format, and the test asserts the arrays occupy exactly `10 × n` and `20 × n` bytes on the wire. The width assertion is the one that matters: before the fix the 32-bit case emitted 20-byte entries, so the message did not match what `TypeOfLock` declared, and any correct peer would have misread it.
- `TestLockingAndxLargeRangeNeedsTheLargeFilesBit` — a range past 4 GiB is refused under the 32-bit format and expressible once the bit is set.
- `TestLockingAndxTruncatedRangeArrayIsRefused` — a request claiming two ranges while carrying one fails to decode.

Whole tree green: `go build ./...`, `go test ./network/smb/...`. `gofmt -l` clean on both files.

### Test Coverage
**Added:** `message/commands/LockingAndxRequest_ranges_test.go` — `TestLockingAndxRangesRoundTripInBothFormats`, `TestLockingAndxLargeRangeNeedsTheLargeFilesBit`, `TestLockingAndxTruncatedRangeArrayIsRefused`, plus the `lockingRoundTrip` helper.

### Scope of Change
- **Files changed:** `message/commands/LockingAndxRequest.go`, `message/commands/LockingAndxRequest_ranges_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Low. The defect is currently latent — the only in-repo producer is `client/locking.go`, which always sets `LARGE_FILES`, and that path is unchanged by this PR because the 64-bit branch is what it already exercised. Nothing decodes this command yet, so there is no consumer to regress. Safe to merge without staged rollout.

### Notes
Prerequisite for #1142, which serves `SMB_COM_LOCKING_ANDX` and needs both formats decoded correctly before it can act on a range.

Worth recording for whoever touches this file next: a command's `Marshal` appends to its own parameter and data blocks, so marshalling the same command twice does not produce the same bytes twice. The tests build a fresh request per marshal for that reason.
