### PR TITLE
Serve SMB_COM_LOCKING_ANDX with enforced byte-range locks (Fixes #1142)

### DIFF
--- a/network/smb/smb_v10/message/commands/LockingAndxRequest.go
+++ b/network/smb/smb_v10/message/commands/LockingAndxRequest.go
@@ -14,13 +14,23 @@ import (
 
 // LockingAndxRequest
 // Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/b5c6eae7-976b-4444-b52e-c76c68c861ad
-// LockingAndxLargeFiles is the TypeOfLock bit that selects the wire format of the
-// Locks and Unlocks arrays: set, they are 20-byte LOCKING_ANDX_RANGE64 entries;
-// clear, they are 10-byte LOCKING_ANDX_RANGE32 entries ([MS-CIFS] 2.2.4.32.1).
+// The TypeOfLock bits of an SMB_COM_LOCKING_ANDX request ([MS-CIFS] 2.2.4.32.1).
 //
-// Both are held in memory as LOCKING_ANDX_RANGE64, which is the wider of the two,
-// so a caller works with one shape and this bit decides only what goes on the wire.
-const LockingAndxLargeFiles = 0x10
+// LockingAndxLargeFiles selects the wire format of the Locks and Unlocks arrays:
+// set, they are 20-byte LOCKING_ANDX_RANGE64 entries; clear, they are 10-byte
+// LOCKING_ANDX_RANGE32 entries. Both are held in memory as LOCKING_ANDX_RANGE64,
+// which is the wider of the two, so a caller works with one shape and this bit
+// decides only what goes on the wire.
+//
+// An exclusive read-and-write lock is the absence of LockingAndxSharedLock rather
+// than a bit of its own, which is why READ_WRITE_LOCK is documented as 0x00.
+const (
+	LockingAndxSharedLock     = 0x01
+	LockingAndxOplockRelease  = 0x02
+	LockingAndxChangeLockType = 0x04
+	LockingAndxCancelLock     = 0x08
+	LockingAndxLargeFiles     = 0x10
+)
 
 type LockingAndxRequest struct {
 	command_interface.Command

--- a/network/smb/smb_v10/server/conformance_test.go
+++ b/network/smb/smb_v10/server/conformance_test.go
@@ -128,6 +128,7 @@ var servedCommands = map[codes.CommandCode]string{
 	codes.SMB_COM_READ_ANDX:      "reads from a handle",
 	codes.SMB_COM_WRITE_ANDX:     "writes through a handle",
 	codes.SMB_COM_FLUSH:          "commits a handle, or the whole tree",
+	codes.SMB_COM_LOCKING_ANDX:   "acquires and releases byte-range locks",
 
 	codes.SMB_COM_DELETE:           "deletes a file, wildcards included",
 	codes.SMB_COM_RENAME:           "renames or moves an entry",

--- a/network/smb/smb_v10/server/dispatch.go
+++ b/network/smb/smb_v10/server/dispatch.go
@@ -42,6 +42,7 @@ var dispatchTable = map[codes.CommandCode]commandHandler{
 	codes.SMB_COM_READ_ANDX:      handleReadAndx,
 	codes.SMB_COM_WRITE_ANDX:     handleWriteAndx,
 	codes.SMB_COM_FLUSH:          handleFlush,
+	codes.SMB_COM_LOCKING_ANDX:   handleLockingAndx,
 
 	// Volume.
 	codes.SMB_COM_QUERY_INFORMATION_DISK: handleQueryInformationDisk,

--- a/network/smb/smb_v10/server/doc.go
+++ b/network/smb/smb_v10/server/doc.go
@@ -53,9 +53,16 @@
 // displacement, with the subcommand selected by a setup word, a Function field or
 // a name.
 //
-// Not yet implemented, and answered with STATUS_NOT_IMPLEMENTED: byte-range
-// locking, seek, the legacy SMB_COM_OPEN_ANDX, and batched AndX chains beyond
-// their first command.
+//   - Byte-range locking, over SMB_COM_LOCKING_ANDX: locks and unlocks in one
+//     atomic request, in both range formats, exclusive and shared. Overlapping
+//     locks are refused, an unlock of a range the handle does not hold is
+//     refused, and closing a handle releases what it held. The locks are
+//     enforced: a read or a write through another handle onto an exclusively
+//     locked range is refused, and a shared lock refuses only writes. A request
+//     that offers to wait waits, bounded by Config.MaxLockWait.
+//
+// Not yet implemented, and answered with STATUS_NOT_IMPLEMENTED: seek and the
+// legacy SMB_COM_OPEN_ANDX.
 //
 // NT_TRANSACT_NOTIFY_CHANGE is deliberately absent rather than pending. It needs
 // two things this package does not have: a FileSystem that can be watched, and a
@@ -93,6 +100,25 @@
 //
 // A share with no provider answers STATUS_NOT_SUPPORTED rather than inventing a
 // descriptor.
+//
+// # Byte-range locks
+//
+// Locks are held by the server, in a table on the Share, rather than delegated to
+// the FileSystem. That is deliberate. SMB lock semantics are not the host's: a
+// lock is held on a FID and excludes every other FID onto the same file, whoever
+// opened it, and a MemoryFileSystem has no host locks to delegate to while a
+// LocalFileSystem's would carry the platform's rules rather than the protocol's.
+// Holding them here means every backend gets the same, correct semantics and none
+// of them can forget to.
+//
+// The table belongs to the Share because a lock is a statement about a file, and
+// the handles it has to exclude are on other connections as much as on the one
+// that took it.
+//
+// A blocked request waits by polling, and Config.MaxLockWait bounds how long. A
+// client may ask to wait forever, and the connection serves nothing else while it
+// does, so an unbounded wait would let a client stall itself with no way out — the
+// cancel it would send arrives behind the request it wanted to cancel.
 //
 // # Named pipes
 //

--- a/network/smb/smb_v10/server/handler_file.go
+++ b/network/smb/smb_v10/server/handler_file.go
@@ -353,6 +353,12 @@ func handleReadAndx(conn *Connection, w ResponseWriter, req *message.Message) nt
 		length = 0
 	}
 
+	if status := lockedAgainst(open, uint64(offset), uint64(length), false); status != nt_status.NT_STATUS_SUCCESS {
+		logger.Debugf("SMB1 server: %s read %d bytes of %q at %d, which another handle has locked",
+			conn.Remote, length, open.Path, offset)
+		return status
+	}
+
 	file, status := fileFor(open)
 	if status != nt_status.NT_STATUS_SUCCESS {
 		return status
@@ -379,6 +385,32 @@ func handleReadAndx(conn *Connection, w ResponseWriter, req *message.Message) nt
 // 32-byte header, the parameter words and the byte count. Reserving it keeps a
 // full-size read inside the negotiated buffer.
 const readResponseOverhead = 64
+
+// lockedAgainst reports whether a byte-range lock held by another handle refuses
+// this access.
+//
+// A lock is only worth granting if it is honoured, so every read and write goes
+// through here. The owning handle is never refused by its own lock; an exclusive
+// lock refuses everyone else both ways, and a shared lock refuses only writes
+// ([MS-CIFS] section 3.3.5.30).
+//
+// Parameters:
+//   - open: the handle doing the access
+//   - offset, length: the range being accessed
+//   - writing: whether the access is a write
+//
+// Returns:
+//   - NT_STATUS_SUCCESS when the access may proceed, otherwise the status to
+//     report
+func lockedAgainst(open *Open, offset, length uint64, writing bool) nt_status.NT_STATUS {
+	if open == nil || open.Tree == nil || open.Tree.Share == nil || open.Tree.Share.locks == nil {
+		return nt_status.NT_STATUS_SUCCESS
+	}
+	if open.Tree.Share.locks.Blocks(open.Path, open, offset, length, writing) {
+		return nt_status.NT_STATUS_FILE_LOCK_CONFLICT
+	}
+	return nt_status.NT_STATUS_SUCCESS
+}
 
 // handleWriteAndx answers SMB_COM_WRITE_ANDX.
 func handleWriteAndx(conn *Connection, w ResponseWriter, req *message.Message) nt_status.NT_STATUS {
@@ -408,6 +440,12 @@ func handleWriteAndx(conn *Connection, w ResponseWriter, req *message.Message) n
 	data := []byte(request.Data)
 	if declared := int(request.DataLength); declared < len(data) {
 		data = data[:declared]
+	}
+
+	if status := lockedAgainst(open, uint64(offset), uint64(len(data)), true); status != nt_status.NT_STATUS_SUCCESS {
+		logger.Debugf("SMB1 server: %s wrote %d bytes of %q at %d, which another handle has locked",
+			conn.Remote, len(data), open.Path, offset)
+		return status
 	}
 
 	file, status := fileFor(open)

--- a/network/smb/smb_v10/server/handler_lock.go
+++ b/network/smb/smb_v10/server/handler_lock.go
@@ -1,0 +1,182 @@
+package server
+
+import (
+	"time"
+
+	"github.com/TheManticoreProject/Manticore/logger"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+	"github.com/TheManticoreProject/Manticore/windows/nt_status"
+)
+
+// lockingRange names the wire range type the message layer decodes into, so the
+// widening below reads as what it is.
+type lockingRange = types.LOCKING_ANDX_RANGE64
+
+// lockWaitInterval is how often a blocked lock request retries.
+//
+// The server answers one request per connection at a time, so a wait holds this
+// client and nothing else. Polling is used rather than waking on release because
+// the thing being waited for may be released by another connection, another share
+// or a closing handle, and a poll is correct for all of them without a
+// notification path that would have to reach each one.
+const lockWaitInterval = 10 * time.Millisecond
+
+// handleLockingAndx answers SMB_COM_LOCKING_ANDX: it releases and acquires
+// byte-range locks on an open handle.
+//
+// [MS-CIFS] section 3.3.5.30 processes the request in three parts, all of which
+// are executed: the unlocks, then the locks, then an OpLock release if the
+// OPLOCK_RELEASE bit is set. The first two are one atomic step — a failure in
+// either leaves the file's lock state untouched.
+//
+// Wire format: [MS-CIFS] section 2.2.4.32.
+//
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/
+func handleLockingAndx(conn *Connection, w ResponseWriter, req *message.Message) nt_status.NT_STATUS {
+	request, ok := req.Command.(*commands.LockingAndxRequest)
+	if !ok {
+		return nt_status.NT_STATUS_INVALID_SMB
+	}
+
+	open, status := conn.openFor(req, uint16(request.FID))
+	if status != nt_status.NT_STATUS_SUCCESS {
+		return status
+	}
+
+	typeOfLock := uint8(request.TypeOfLock)
+
+	// A change of lock type has to be atomic or refused, and nothing here can
+	// swap a lock's type without releasing it first. [MS-CIFS] section 2.2.4.32.1:
+	// "If the server cannot do this in an atomic fashion, the server MUST reject
+	// this request".
+	if typeOfLock&commands.LockingAndxChangeLockType != 0 {
+		logger.Debugf("SMB1 server: %s asked to change a lock's type on FID 0x%04X, which is refused",
+			conn.Remote, uint16(request.FID))
+		return nt_status.NT_STATUS_NOT_SUPPORTED
+	}
+
+	// Cancelling an outstanding lock request has nothing to cancel: a request
+	// that is waiting is waiting on this connection's own goroutine, so no other
+	// request from this client can arrive while it does. Answering success is
+	// therefore accurate rather than a stub — there is provably no outstanding
+	// request to cancel.
+	if typeOfLock&commands.LockingAndxCancelLock != 0 {
+		logger.Debugf("SMB1 server: %s cancelled lock requests on FID 0x%04X, of which none were outstanding",
+			conn.Remote, uint16(request.FID))
+		return answerLocking(conn, w)
+	}
+
+	unlocks := lockRangesOf(request.Unlocks)
+	locks := lockRangesOf(request.Locks)
+	shared := typeOfLock&commands.LockingAndxSharedLock != 0
+
+	// An OpLock Break Request carries no ranges, and [MS-CIFS] section 3.3.5.30
+	// is explicit that it is answered with silence: "If NumberOfRequestedUnlocks
+	// and NumberOfRequestedLocks are both zero (0x0000) [...] the server MUST NOT
+	// send an SMB_COM_LOCKING_ANDX Response". No OpLock is ever granted here, so
+	// there is none to release, and the same section says that is not an error.
+	if len(unlocks) == 0 && len(locks) == 0 {
+		logger.Debugf("SMB1 server: %s sent a lock request with no ranges on FID 0x%04X, which is answered with silence",
+			conn.Remote, uint16(request.FID))
+		return nt_status.NT_STATUS_SUCCESS
+	}
+
+	locksTable := open.Tree.Share.locks
+	if locksTable == nil {
+		// A share registered without a table cannot track a lock, and granting
+		// one it could not enforce would be worse than refusing.
+		return nt_status.NT_STATUS_NOT_SUPPORTED
+	}
+
+	deadline, waits := lockDeadline(conn, uint32(request.Timeout))
+	for {
+		switch outcome := locksTable.Apply(open, unlocks, locks, shared); outcome {
+		case lockOutcomeGranted:
+			logger.Debugf("SMB1 server: %s locked %d and unlocked %d ranges of %q",
+				conn.Remote, len(locks), len(unlocks), open.Path)
+			return answerLocking(conn, w)
+
+		case lockOutcomeNotLocked:
+			// Waiting cannot make a range that is not held become held, so this
+			// fails immediately however long the client offered to wait.
+			logger.Debugf("SMB1 server: %s asked to unlock a range of %q it does not hold",
+				conn.Remote, open.Path)
+			return nt_status.NT_STATUS_RANGE_NOT_LOCKED
+
+		default:
+			if !waits || !time.Now().Before(deadline) {
+				logger.Debugf("SMB1 server: %s could not lock a range of %q, which is already locked",
+					conn.Remote, open.Path)
+				return nt_status.NT_STATUS_LOCK_NOT_GRANTED
+			}
+		}
+
+		time.Sleep(lockWaitInterval)
+	}
+}
+
+// answerLocking sends the response, which carries nothing but success.
+func answerLocking(conn *Connection, w ResponseWriter) nt_status.NT_STATUS {
+	if err := w.WriteResponse(commands.NewLockingAndxResponse()); err != nil {
+		logger.Debugf("SMB1 server: failed to answer the lock request for %s: %v", conn.Remote, err)
+	}
+	return nt_status.NT_STATUS_SUCCESS
+}
+
+// lockDeadline turns a request's Timeout into a deadline.
+//
+// [MS-CIFS] section 2.2.4.32.1: zero fails immediately, 0xFFFFFFFF waits forever,
+// and anything else is a number of milliseconds. Waiting forever is bounded by
+// Config.MaxLockWait, because the connection serves nothing else while it waits —
+// an unbounded wait would be a client's own denial of service, and the client
+// cannot cancel it either, since the cancel would arrive behind the request it
+// wanted to cancel.
+//
+// Parameters:
+//   - conn: the connection, for its configured ceiling
+//   - timeout: the request's Timeout field
+//
+// Returns:
+//   - The deadline, and whether the request waits at all
+func lockDeadline(conn *Connection, timeout uint32) (time.Time, bool) {
+	if timeout == 0 {
+		return time.Time{}, false
+	}
+
+	ceiling := conn.Server.config.MaxLockWait
+	if ceiling <= 0 {
+		ceiling = DefaultMaxLockWait
+	}
+
+	wait := ceiling
+	if timeout != lockTimeoutForever {
+		if requested := time.Duration(timeout) * time.Millisecond; requested < ceiling {
+			wait = requested
+		}
+	}
+	return time.Now().Add(wait), true
+}
+
+// lockTimeoutForever is the Timeout value that asks the server to wait as long as
+// it takes ([MS-CIFS] section 2.2.4.32.1).
+const lockTimeoutForever = 0xFFFFFFFF
+
+// lockRangesOf widens the message layer's range entries into the form the lock
+// table works with.
+//
+// The message layer hands over LOCKING_ANDX_RANGE64 whichever format was on the
+// wire, so the two halves of the 64-bit offset and length are recombined here and
+// the 32-bit case arrives with its high words already zero.
+func lockRangesOf(entries []lockingRange) []lockRange {
+	ranges := make([]lockRange, 0, len(entries))
+	for _, entry := range entries {
+		ranges = append(ranges, lockRange{
+			Offset: uint64(entry.ByteOffsetHigh)<<32 | uint64(entry.ByteOffsetLow),
+			Length: uint64(entry.LengthInBytesHigh)<<32 | uint64(entry.LengthInBytesLow),
+			PID:    uint32(entry.PID),
+		})
+	}
+	return ranges
+}

--- a/network/smb/smb_v10/server/locking_test.go
+++ b/network/smb/smb_v10/server/locking_test.go
@@ -1,0 +1,381 @@
+package server
+
+import (
+	"encoding/binary"
+	"testing"
+
+	smb1client "github.com/TheManticoreProject/Manticore/network/smb/smb_v10/client"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/codes"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+	"github.com/TheManticoreProject/Manticore/windows/fileflags"
+	"github.com/TheManticoreProject/Manticore/windows/nt_status"
+)
+
+// lockableServer serves one file and returns a client with two handles open on
+// it, which is what the cross-handle rules need: a lock is held on a FID, and what
+// it excludes is every other FID onto the same file.
+func lockableServer(t *testing.T, contents string) (*smb1client.Client, smb1client.FID, smb1client.FID) {
+	t.Helper()
+
+	fs := NewMemoryFileSystem("FILES")
+	if err := fs.AddFile("locked.txt", []byte(contents)); err != nil {
+		t.Fatalf("AddFile() error = %v", err)
+	}
+	_, client := fileServer(t, fs, false)
+
+	open := func(what string) smb1client.FID {
+		fid, err := client.OpenFile("locked.txt",
+			fileflags.GENERIC_READ|fileflags.GENERIC_WRITE,
+			fileflags.FILE_SHARE_READ|fileflags.FILE_SHARE_WRITE,
+			fileflags.FILE_OPEN,
+			fileflags.FILE_NON_DIRECTORY_FILE)
+		if err != nil {
+			t.Fatalf("opening the %s handle failed: %v", what, err)
+		}
+		return fid
+	}
+
+	return client, open("first"), open("second")
+}
+
+// sendLockingRequest sends a hand-built SMB_COM_LOCKING_ANDX and returns the raw
+// reply, so a test can send more ranges than the client API does and can look at
+// what came back rather than only whether it failed.
+func sendLockingRequest(
+	t *testing.T,
+	client *smb1client.Client,
+	fid smb1client.FID,
+	typeOfLock uint8,
+	timeout uint32,
+	unlocks, locks []types.LOCKING_ANDX_RANGE64,
+) []byte {
+	t.Helper()
+
+	request := newRequest(codes.SMB_COM_LOCKING_ANDX)
+	request.Header.UID = client.Session.SessionUID
+	request.Header.TID = client.Session.TreeID
+
+	cmd := commands.NewLockingAndxRequest()
+	cmd.FID = types.USHORT(fid)
+	cmd.TypeOfLock = types.UCHAR(typeOfLock)
+	cmd.Timeout = types.ULONG(timeout)
+	cmd.Unlocks = unlocks
+	cmd.NumberOfRequestedUnlocks = types.USHORT(len(unlocks))
+	cmd.Locks = locks
+	cmd.NumberOfRequestedLocks = types.USHORT(len(locks))
+	request.AddCommand(cmd)
+
+	marshalled, err := request.Marshal()
+	if err != nil {
+		t.Fatalf("failed to marshal the lock request: %v", err)
+	}
+	if _, err := client.Transport.Send(marshalled); err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+
+	raw, err := client.Transport.Receive()
+	if err != nil {
+		t.Fatalf("Receive() error = %v", err)
+	}
+	return raw
+}
+
+// wideRange builds a 64-bit lock range.
+func wideRange(pid uint16, offset, length uint64) types.LOCKING_ANDX_RANGE64 {
+	return types.LOCKING_ANDX_RANGE64{
+		PID:               types.USHORT(pid),
+		ByteOffsetHigh:    types.ULONG(offset >> 32),
+		ByteOffsetLow:     types.ULONG(offset),
+		LengthInBytesHigh: types.ULONG(length >> 32),
+		LengthInBytesLow:  types.ULONG(length),
+	}
+}
+
+// TestByteRangeLockIsGrantedAndReleased asserts a lock is granted, that the range
+// is then unavailable to another handle, and that releasing it makes it available
+// again.
+func TestByteRangeLockIsGrantedAndReleased(t *testing.T) {
+	client, first, second := lockableServer(t, "0123456789abcdef")
+
+	if err := client.LockFile(first, 0, 8, true); err != nil {
+		t.Fatalf("locking [0,8) failed: %v", err)
+	}
+
+	// Held, so the other handle cannot have it.
+	if err := client.LockFile(second, 0, 8, true); err == nil {
+		t.Fatal("a second handle locked a range the first holds")
+	}
+
+	if err := client.UnlockFile(first, 0, 8); err != nil {
+		t.Fatalf("unlocking [0,8) failed: %v", err)
+	}
+
+	// Released, so it is available.
+	if err := client.LockFile(second, 0, 8, true); err != nil {
+		t.Fatalf("locking [0,8) after it was released failed: %v", err)
+	}
+}
+
+// TestOverlappingLockIsRefusedAndAdjacentOneIsNot asserts the overlap rule, and
+// that it really is an overlap rule rather than a whole-file one.
+//
+// [MS-CIFS] section 3.3.5.30: "Overlapping locks are not allowed."
+func TestOverlappingLockIsRefusedAndAdjacentOneIsNot(t *testing.T) {
+	client, first, second := lockableServer(t, "0123456789abcdef")
+
+	if err := client.LockFile(first, 4, 8, true); err != nil {
+		t.Fatalf("locking [4,12) failed: %v", err)
+	}
+
+	for _, overlapping := range []struct {
+		name           string
+		offset, length uint64
+	}{
+		{name: "same range", offset: 4, length: 8},
+		{name: "straddles the front", offset: 0, length: 8},
+		{name: "straddles the back", offset: 8, length: 8},
+		{name: "inside", offset: 6, length: 2},
+		{name: "encloses", offset: 0, length: 16},
+	} {
+		t.Run(overlapping.name, func(t *testing.T) {
+			if err := client.LockFile(second, overlapping.offset, overlapping.length, true); err == nil {
+				t.Errorf("locking [%d,%d) succeeded while [4,12) is held",
+					overlapping.offset, overlapping.offset+overlapping.length)
+			}
+		})
+	}
+
+	// Adjacent ranges touch but do not overlap, so both are available.
+	if err := client.LockFile(second, 0, 4, true); err != nil {
+		t.Errorf("locking [0,4), which ends where the held range begins, failed: %v", err)
+	}
+	if err := client.LockFile(second, 12, 4, true); err != nil {
+		t.Errorf("locking [12,16), which begins where the held range ends, failed: %v", err)
+	}
+}
+
+// TestExclusiveLockRefusesAnotherHandlesAccess asserts an exclusive lock is
+// enforced against reads and writes through another handle, and not against the
+// handle that holds it.
+//
+// A lock nothing honours is decoration; this is the assertion that makes the
+// feature real.
+func TestExclusiveLockRefusesAnotherHandlesAccess(t *testing.T) {
+	client, first, second := lockableServer(t, "0123456789abcdef")
+
+	if err := client.LockFile(first, 0, 8, true); err != nil {
+		t.Fatalf("locking [0,8) failed: %v", err)
+	}
+
+	if _, err := client.ReadFile(second, 0, 8); err == nil {
+		t.Error("another handle read a range under an exclusive lock")
+	}
+	if _, err := client.WriteFile(second, 0, []byte("XXXXXXXX")); err == nil {
+		t.Error("another handle wrote a range under an exclusive lock")
+	}
+
+	// Beyond the lock, the other handle is unaffected.
+	if _, err := client.ReadFile(second, 8, 8); err != nil {
+		t.Errorf("another handle could not read outside the locked range: %v", err)
+	}
+
+	// The owning handle is never refused by its own lock.
+	if _, err := client.ReadFile(first, 0, 8); err != nil {
+		t.Errorf("the owning handle could not read its own locked range: %v", err)
+	}
+	if _, err := client.WriteFile(first, 0, []byte("ABCDEFGH")); err != nil {
+		t.Errorf("the owning handle could not write its own locked range: %v", err)
+	}
+}
+
+// TestSharedLockRefusesWritesOnly asserts a shared read-only lock lets another
+// handle read the range and refuses only its writes.
+//
+// [MS-CIFS] section 3.3.5.30: "If the lock is a shared read lock, other FIDs
+// indicating a separate Open of the same file MUST be denied write access to the
+// same bytes."
+func TestSharedLockRefusesWritesOnly(t *testing.T) {
+	client, first, second := lockableServer(t, "0123456789abcdef")
+
+	if err := client.LockFile(first, 0, 8, false); err != nil {
+		t.Fatalf("taking a shared lock on [0,8) failed: %v", err)
+	}
+
+	if _, err := client.ReadFile(second, 0, 8); err != nil {
+		t.Errorf("another handle could not read a range under a shared lock: %v", err)
+	}
+	if _, err := client.WriteFile(second, 0, []byte("XXXXXXXX")); err == nil {
+		t.Error("another handle wrote a range under a shared lock")
+	}
+}
+
+// TestUnlockingARangeNotHeldIsRefused asserts a release of something not held is
+// reported rather than ignored.
+//
+// [MS-CIFS] section 3.3.5.30 names the status: "If the PID in the unlock request
+// does not match Server.Open.Locks in the Open, the server MUST send an error
+// response message with status set to STATUS_RANGE_NOT_LOCKED".
+func TestUnlockingARangeNotHeldIsRefused(t *testing.T) {
+	client, first, second := lockableServer(t, "0123456789abcdef")
+
+	// Never locked at all.
+	raw := sendLockingRequest(t, client, first, commands.LockingAndxLargeFiles, 0,
+		[]types.LOCKING_ANDX_RANGE64{wideRange(0x1234, 0, 8)}, nil)
+	if status := binary.LittleEndian.Uint32(raw[5:9]); status != uint32(nt_status.NT_STATUS_RANGE_NOT_LOCKED) {
+		t.Errorf("unlocking a range never held reported 0x%08X, want STATUS_RANGE_NOT_LOCKED (0x%08X)",
+			status, uint32(nt_status.NT_STATUS_RANGE_NOT_LOCKED))
+	}
+
+	// Held, but by the other handle.
+	if err := client.LockFile(first, 0, 8, true); err != nil {
+		t.Fatalf("locking [0,8) failed: %v", err)
+	}
+	if err := client.UnlockFile(second, 0, 8); err == nil {
+		t.Error("a handle released a lock held by another handle")
+	}
+}
+
+// TestClosingAHandleReleasesItsLocks asserts a closed handle leaves nothing
+// locked.
+//
+// A lock owned by a handle that no longer exists could never be released, so the
+// range would stay locked for as long as the share did.
+func TestClosingAHandleReleasesItsLocks(t *testing.T) {
+	client, first, second := lockableServer(t, "0123456789abcdef")
+
+	if err := client.LockFile(first, 0, 16, true); err != nil {
+		t.Fatalf("locking [0,16) failed: %v", err)
+	}
+	if err := client.CloseFile(first); err != nil {
+		t.Fatalf("closing the holding handle failed: %v", err)
+	}
+
+	if err := client.LockFile(second, 0, 16, true); err != nil {
+		t.Fatalf("the range was still locked after its holder closed: %v", err)
+	}
+	if _, err := client.ReadFile(second, 0, 16); err != nil {
+		t.Errorf("reading after the holder closed failed: %v", err)
+	}
+}
+
+// TestLockRequestIsAtomic asserts a request whose second range conflicts grants
+// neither range.
+//
+// [MS-CIFS] section 3.3.5.30: "This client request is atomic. If any of the lock
+// ranges times out because the area to be locked is already locked, or the
+// lock/unlock request otherwise fails, the lock state of the file MUST NOT be
+// changed."
+func TestLockRequestIsAtomic(t *testing.T) {
+	client, first, second := lockableServer(t, "0123456789abcdef")
+
+	// The second handle holds [8,12), so the pair below cannot be granted whole.
+	if err := client.LockFile(second, 8, 4, true); err != nil {
+		t.Fatalf("locking [8,12) failed: %v", err)
+	}
+
+	raw := sendLockingRequest(t, client, first, commands.LockingAndxLargeFiles, 0, nil,
+		[]types.LOCKING_ANDX_RANGE64{
+			wideRange(0x1234, 0, 4),
+			wideRange(0x1234, 8, 4),
+		})
+	if status := binary.LittleEndian.Uint32(raw[5:9]); status != uint32(nt_status.NT_STATUS_LOCK_NOT_GRANTED) {
+		t.Fatalf("the request reported 0x%08X, want STATUS_LOCK_NOT_GRANTED (0x%08X)",
+			status, uint32(nt_status.NT_STATUS_LOCK_NOT_GRANTED))
+	}
+
+	// [0,4) must not have been granted on the way to the failure, so the other
+	// handle can still take it.
+	if err := client.LockFile(second, 0, 4, true); err != nil {
+		t.Errorf("[0,4) was left locked by a request that failed: %v", err)
+	}
+}
+
+// TestLockRequestWithNoRangesIsAnsweredWithSilence asserts a request carrying no
+// ranges gets no response at all.
+//
+// That is an OpLock Break Request, and [MS-CIFS] section 3.3.5.30 is explicit:
+// "If NumberOfRequestedUnlocks and NumberOfRequestedLocks are both zero (0x0000)
+// [...] the server MUST NOT send an SMB_COM_LOCKING_ANDX Response". A server that
+// answered anyway would leave one unread reply on the connection and every
+// subsequent response would be read against the wrong request.
+func TestLockRequestWithNoRangesIsAnsweredWithSilence(t *testing.T) {
+	client, first, _ := lockableServer(t, "0123456789abcdef")
+
+	request := newRequest(codes.SMB_COM_LOCKING_ANDX)
+	request.Header.UID = client.Session.SessionUID
+	request.Header.TID = client.Session.TreeID
+
+	cmd := commands.NewLockingAndxRequest()
+	cmd.FID = types.USHORT(first)
+	cmd.TypeOfLock = types.UCHAR(commands.LockingAndxLargeFiles | commands.LockingAndxOplockRelease)
+	request.AddCommand(cmd)
+
+	marshalled, err := request.Marshal()
+	if err != nil {
+		t.Fatalf("failed to marshal the lock request: %v", err)
+	}
+	if _, err := client.Transport.Send(marshalled); err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+
+	// Nothing may be read for that request, so the next thing on the connection
+	// has to be the answer to what is sent next. An echo is used because its
+	// response is unmistakable.
+	echoed, err := client.Echo([]byte("after the break acknowledgement"))
+	if err != nil {
+		t.Fatalf("the connection did not survive a break acknowledgement: %v", err)
+	}
+	if string(echoed) != "after the break acknowledgement" {
+		t.Fatalf("the echo returned %q, so the reply stream is out of step — the lock request was answered",
+			echoed)
+	}
+}
+
+// TestChangingALockTypeIsRefused asserts the atomic lock-type change is refused
+// rather than approximated.
+//
+// [MS-CIFS] section 2.2.4.32.1: "If the server cannot do this in an atomic
+// fashion, the server MUST reject this request". Releasing and re-taking the lock
+// would open a window in which the range is unlocked, which is exactly what the
+// client asked to avoid.
+func TestChangingALockTypeIsRefused(t *testing.T) {
+	client, first, _ := lockableServer(t, "0123456789abcdef")
+
+	if err := client.LockFile(first, 0, 8, false); err != nil {
+		t.Fatalf("taking a shared lock failed: %v", err)
+	}
+
+	raw := sendLockingRequest(t, client, first,
+		commands.LockingAndxLargeFiles|commands.LockingAndxChangeLockType, 0, nil,
+		[]types.LOCKING_ANDX_RANGE64{wideRange(0x1234, 0, 8)})
+	if status := binary.LittleEndian.Uint32(raw[5:9]); status != uint32(nt_status.NT_STATUS_NOT_SUPPORTED) {
+		t.Errorf("a lock-type change reported 0x%08X, want STATUS_NOT_SUPPORTED (0x%08X)",
+			status, uint32(nt_status.NT_STATUS_NOT_SUPPORTED))
+	}
+}
+
+// TestBlockedLockWaitsAndThenFails asserts a request that offers to wait is
+// refused once its timeout runs out, and that the wait is bounded by the timeout
+// rather than by the server's ceiling.
+func TestBlockedLockWaitsAndThenFails(t *testing.T) {
+	client, first, second := lockableServer(t, "0123456789abcdef")
+
+	if err := client.LockFile(first, 0, 8, true); err != nil {
+		t.Fatalf("locking [0,8) failed: %v", err)
+	}
+
+	// 50 ms, so the wait is observable but the test is not slow.
+	raw := sendLockingRequest(t, client, second, commands.LockingAndxLargeFiles, 50, nil,
+		[]types.LOCKING_ANDX_RANGE64{wideRange(0x4321, 0, 8)})
+	if status := binary.LittleEndian.Uint32(raw[5:9]); status != uint32(nt_status.NT_STATUS_LOCK_NOT_GRANTED) {
+		t.Errorf("a lock that waited reported 0x%08X, want STATUS_LOCK_NOT_GRANTED (0x%08X)",
+			status, uint32(nt_status.NT_STATUS_LOCK_NOT_GRANTED))
+	}
+
+	// The connection is still usable after the wait.
+	if _, err := client.Echo([]byte("still here")); err != nil {
+		t.Errorf("the connection did not survive a lock wait: %v", err)
+	}
+
+}

--- a/network/smb/smb_v10/server/locks.go
+++ b/network/smb/smb_v10/server/locks.go
@@ -1,0 +1,262 @@
+package server
+
+import (
+	"math"
+	"sync"
+)
+
+// byteRangeLock is one byte-range lock granted on a file.
+//
+// The owning handle is part of the identity, not just bookkeeping: [MS-CIFS]
+// section 3.3.5.30 holds a lock "based upon the FID used to create the lock", so
+// which handle took it decides who may read and write the bytes underneath it.
+type byteRangeLock struct {
+	// Offset and Length describe the range. A range may extend past the end of
+	// the file, and locking one does not extend the file.
+	Offset uint64
+	Length uint64
+
+	// PID is the process identifier from the range entry. Only this PID may
+	// release the lock.
+	PID uint32
+
+	// Shared records a shared read-only lock rather than an exclusive one, which
+	// changes what other handles are refused rather than whether the lock
+	// overlaps.
+	Shared bool
+
+	// owner is the handle the lock was taken on.
+	owner *Open
+}
+
+// end returns the first offset past the lock, saturating rather than wrapping so
+// a range described as running to the end of the address space still compares
+// correctly.
+func (l byteRangeLock) end() uint64 {
+	end := l.Offset + l.Length
+	if end < l.Offset {
+		return math.MaxUint64
+	}
+	return end
+}
+
+// overlaps reports whether this lock covers any byte of the given range.
+//
+// A zero-length range covers nothing and so overlaps nothing, which is what makes
+// a zero-length lock legal and inert.
+func (l byteRangeLock) overlaps(offset, length uint64) bool {
+	if l.Length == 0 || length == 0 {
+		return false
+	}
+	end := offset + length
+	if end < offset {
+		end = math.MaxUint64
+	}
+	return l.Offset < end && offset < l.end()
+}
+
+// lockTable holds the byte-range locks granted on the files of one share.
+//
+// It belongs to the share rather than to a connection because a lock is a
+// statement about a file, and the handles it has to exclude are on other
+// connections as much as this one. That makes it shared state, so every path
+// through it takes the mutex.
+type lockTable struct {
+	mutex sync.Mutex
+
+	// granted maps a share-relative path to the locks held on that file. A path
+	// with no locks carries no entry, so an unlocked file costs nothing.
+	granted map[string][]byteRangeLock
+}
+
+// newLockTable builds an empty table.
+func newLockTable() *lockTable {
+	return &lockTable{granted: make(map[string][]byteRangeLock)}
+}
+
+// lockRange is one entry of a request's Locks or Unlocks array, in the widened
+// form the message layer hands over.
+type lockRange struct {
+	Offset uint64
+	Length uint64
+	PID    uint32
+}
+
+// Apply releases and then acquires ranges on one file, as one atomic step.
+//
+// [MS-CIFS] section 3.3.5.30: "This client request is atomic. If any of the lock
+// ranges times out because the area to be locked is already locked, or the
+// lock/unlock request otherwise fails, the lock state of the file MUST NOT be
+// changed." So the whole result is computed against a copy and committed only if
+// every part of it succeeded.
+//
+// The order is the specification's: unlocks first, then locks, both of which are
+// executed.
+//
+// Parameters:
+//   - open: the handle the request arrived on
+//   - unlocks: ranges to release
+//   - locks: ranges to acquire
+//   - shared: whether the acquired locks are shared read-only locks
+//
+// Returns:
+//   - lockOutcome saying whether it succeeded and, if not, why
+func (t *lockTable) Apply(open *Open, unlocks, locks []lockRange, shared bool) lockOutcome {
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+
+	path := open.Path
+
+	// A copy, so a failure half-way leaves the table as it was.
+	working := make([]byteRangeLock, len(t.granted[path]))
+	copy(working, t.granted[path])
+
+	for _, unlock := range unlocks {
+		index := findLock(working, open, unlock)
+		if index < 0 {
+			// [MS-CIFS] section 3.3.5.30: a range the requesting PID did not lock
+			// is STATUS_RANGE_NOT_LOCKED, and that includes a range locked by
+			// another PID.
+			return lockOutcomeNotLocked
+		}
+		working = append(working[:index], working[index+1:]...)
+	}
+
+	for _, lock := range locks {
+		// "Overlapping locks are not allowed" and locking "SHOULD fail with
+		// STATUS_LOCK_NOT_GRANTED if any subranges or overlapping ranges are
+		// locked, even if they are currently locked by the PID requesting the new
+		// lock". So there is no same-owner exemption here: any overlap refuses.
+		for _, held := range working {
+			if held.overlaps(lock.Offset, lock.Length) {
+				return lockOutcomeConflict
+			}
+		}
+		working = append(working, byteRangeLock{
+			Offset: lock.Offset,
+			Length: lock.Length,
+			PID:    lock.PID,
+			Shared: shared,
+			owner:  open,
+		})
+	}
+
+	if len(working) == 0 {
+		delete(t.granted, path)
+	} else {
+		t.granted[path] = working
+	}
+	return lockOutcomeGranted
+}
+
+// lockOutcome is why an Apply succeeded or failed, kept separate from a status so
+// the caller can decide whether waiting could change the answer.
+type lockOutcome int
+
+const (
+	// lockOutcomeGranted means the whole request was applied.
+	lockOutcomeGranted lockOutcome = iota
+
+	// lockOutcomeConflict means a range asked for is already locked. Waiting may
+	// change this, so it is the outcome a timeout retries on.
+	lockOutcomeConflict
+
+	// lockOutcomeNotLocked means a range asked to be released is not held by the
+	// requesting handle and PID. Waiting cannot change this.
+	lockOutcomeNotLocked
+)
+
+// findLock locates a lock matching a range exactly, held on the given handle by
+// the range's PID, and returns its index or -1.
+//
+// The match is exact rather than by containment: a lock is released as a unit, and
+// splitting one to satisfy a partial unlock would leave the client holding
+// something it never asked for.
+func findLock(held []byteRangeLock, open *Open, wanted lockRange) int {
+	for index, lock := range held {
+		if lock.owner == open && lock.PID == wanted.PID &&
+			lock.Offset == wanted.Offset && lock.Length == wanted.Length {
+			return index
+		}
+	}
+	return -1
+}
+
+// Blocks reports whether a lock held by some other handle stops this one reading
+// or writing a range.
+//
+// [MS-CIFS] section 3.3.5.30: "any process (PID) using the FID specified in the
+// creation of the lock has access to the locked bytes. If the lock is an exclusive
+// lock, other FIDs indicating a separate Open of the same file MUST be denied
+// access to the same bytes. If the lock is a shared read lock, other FIDs
+// indicating a separate Open of the same file MUST be denied write access to the
+// same bytes."
+//
+// So the owning handle is never blocked by its own lock, an exclusive lock blocks
+// both directions for everyone else, and a shared lock blocks only writes.
+//
+// Parameters:
+//   - path: the share-relative path being accessed
+//   - open: the handle doing the access
+//   - offset, length: the range being accessed
+//   - writing: whether the access is a write
+//
+// Returns:
+//   - true when the access must be refused
+func (t *lockTable) Blocks(path string, open *Open, offset, length uint64, writing bool) bool {
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+
+	for _, held := range t.granted[path] {
+		if held.owner == open {
+			continue
+		}
+		if !held.overlaps(offset, length) {
+			continue
+		}
+		if writing || !held.Shared {
+			return true
+		}
+	}
+	return false
+}
+
+// ReleaseAll drops every lock held on a handle, which is what closing it does.
+//
+// [MS-CIFS] section 2.2.4.32.1: "Closing a file with locks still in force causes
+// the locks to be released in a nondeterministic order." Releasing them all at
+// once satisfies that and leaves no lock owned by a handle that no longer exists —
+// which would otherwise be a lock nothing could ever release.
+func (t *lockTable) ReleaseAll(open *Open) {
+	if open == nil {
+		return
+	}
+
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+
+	held, present := t.granted[open.Path]
+	if !present {
+		return
+	}
+
+	kept := held[:0]
+	for _, lock := range held {
+		if lock.owner != open {
+			kept = append(kept, lock)
+		}
+	}
+	if len(kept) == 0 {
+		delete(t.granted, open.Path)
+		return
+	}
+	t.granted[open.Path] = kept
+}
+
+// HeldOn returns how many locks are held on a path, for tests and for a caller
+// that wants to report on a share.
+func (t *lockTable) HeldOn(path string) int {
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+	return len(t.granted[path])
+}

--- a/network/smb/smb_v10/server/server.go
+++ b/network/smb/smb_v10/server/server.go
@@ -84,6 +84,15 @@ type Config struct {
 	// and says nothing does not hold a goroutine forever. Zero means no bound.
 	Timeout time.Duration
 
+	// MaxLockWait bounds how long a blocked SMB_COM_LOCKING_ANDX request waits
+	// for a range to become free. Zero applies the default.
+	//
+	// A client may ask to wait forever, and the connection serves nothing else
+	// while it does, so an unbounded wait would let a client stall itself with no
+	// way back — the cancel it would send arrives behind the request it wanted to
+	// cancel. The ceiling turns that into a refusal the client can act on.
+	MaxLockWait time.Duration
+
 	// MaxConnections bounds the number of connections served at once. A
 	// connection arriving while the server is at the limit is closed
 	// immediately. Zero means unbounded.
@@ -114,6 +123,12 @@ const (
 	DefaultMaxTreesPerConnection    = 64
 	DefaultMaxOpensPerConnection    = 1024
 	DefaultMaxSearchesPerConnection = 128
+
+	// DefaultMaxLockWait is how long a blocked lock request waits before it is
+	// refused. It is long enough for a lock held across a short read or write to
+	// be released, and short enough that a client that asked to wait forever gets
+	// an answer.
+	DefaultMaxLockWait = 30 * time.Second
 )
 
 // SigningPolicy selects a server's stance on SMB message signing.

--- a/network/smb/smb_v10/server/share.go
+++ b/network/smb/smb_v10/server/share.go
@@ -50,6 +50,13 @@ type Share struct {
 	// Pipes serves the named pipes on an IPC share. Nil refuses every pipe
 	// operation.
 	Pipes PipeHandler
+
+	// locks holds the byte-range locks granted on this share's files.
+	//
+	// It belongs to the share because a lock is a statement about a file and the
+	// handles it excludes may be on other connections. AddShare creates it, so a
+	// share reached through the server always has one.
+	locks *lockTable
 }
 
 // OpenFlags describe what an open is for. They are the subset of the client's
@@ -254,6 +261,12 @@ func (s *Server) AddShare(share *Share) error {
 	}
 	if share.Type == ShareTypeDisk && share.FS == nil {
 		return fmt.Errorf("disk share %q has no file system", share.Name)
+	}
+
+	// Every share gets a lock table, so a handler never has to ask whether the
+	// share it was given can hold a lock.
+	if share.locks == nil {
+		share.locks = newLockTable()
 	}
 
 	key := strings.ToUpper(share.Name)

--- a/network/smb/smb_v10/server/tree.go
+++ b/network/smb/smb_v10/server/tree.go
@@ -129,6 +129,15 @@ func (c *Connection) closeOpen(fid uint16) error {
 	delete(c.opens, fid)
 	c.fids.Release(fid)
 
+	// Locks go first, and unconditionally. [MS-CIFS] section 2.2.4.32.1: "Closing
+	// a file with locks still in force causes the locks to be released". A lock
+	// left behind here would be owned by a handle that no longer exists, so
+	// nothing could ever release it and the range would stay locked for the life
+	// of the share.
+	if open.Tree != nil && open.Tree.Share != nil && open.Tree.Share.locks != nil {
+		open.Tree.Share.locks.ReleaseAll(open)
+	}
+
 	var firstErr error
 	if open.File != nil {
 		if err := open.File.Close(); err != nil {


### PR DESCRIPTION
### Linked Issue
`Closes #1142`

> **Stacked on #1157.** This branch is cut from `bugfix-locking-range-format`, because serving the command requires decoding both range formats correctly, which is what #1156 fixes. Merge #1157 first; the diff shown here will then reduce to this change alone.

### Root Cause
`SMB_COM_LOCKING_ANDX` was never added to `dispatchTable`, so every lock request was answered `STATUS_NOT_IMPLEMENTED`, and there was no lock state anywhere in the server to add it to. The asymmetry was already visible in-tree: `client/locking.go` sends the command and the server could not answer it.

### Fix Description
The command is served, and the locks it grants are enforced.

**Where the locks live.** In a `lockTable` on the `Share`, not delegated to `FileSystem`. The issue suggested adding lock primitives to the backend interface; that is the wrong seam and this PR deliberately diverges from it:

- SMB lock semantics are not the host's. A lock is held on a FID and excludes every *other* FID onto the same file, whoever opened it — that is a protocol rule, not a filesystem one.
- `MemoryFileSystem` has no host locks to delegate to, and `LocalFileSystem`'s would carry the platform's rules rather than the protocol's. Two backends would then behave differently for the same wire request.
- Holding them in the server means every backend gets the same correct semantics and none can forget to implement them.

The table belongs to the share rather than the connection because a lock is a statement about a file, and the handles it must exclude are on other connections as much as on the one that took it. That makes it shared state, so every path through it takes a mutex. `AddShare` creates one for every share, so a handler never has to ask whether the share it was handed can hold a lock.

**Semantics**, all from [MS-CIFS] 3.3.5.30, which is unusually explicit:

- Unlocks are processed first, then locks, and both are executed.
- The request is atomic: the whole result is computed against a copy of the file's lock list and committed only if every part succeeded, so a failure leaves the lock state untouched.
- "Overlapping locks are not allowed [...] even if they are currently locked by the PID requesting the new lock" — so there is **no** same-owner exemption when *taking* a lock. Any overlap refuses with `STATUS_LOCK_NOT_GRANTED`.
- A release must match an existing lock exactly, on the same handle and PID. Anything else is `STATUS_RANGE_NOT_LOCKED`, which the section names directly. The match is exact rather than by containment: splitting a lock to satisfy a partial unlock would leave the client holding something it never asked for.
- Closing a handle releases its locks, unconditionally and before anything else in `closeOpen`. A lock owned by a handle that no longer exists could never be released, so the range would stay locked for the life of the share.
- Zero-length ranges are legal and inert — they overlap nothing.
- Offsets past end-of-file are lockable and do not extend the file.

**Enforcement.** Every `READ_ANDX` and `WRITE_ANDX` passes through `lockedAgainst` before the backend is touched. The owning handle is never refused by its own lock; an exclusive lock refuses every other handle both ways; a shared lock refuses only writes. This is the half that makes the feature real — a lock nothing honours is decoration — and the rules are quoted from the same section.

**Waiting.** `Timeout` 0 fails immediately, `0xFFFFFFFF` asks to wait forever, anything else is milliseconds. A blocked request polls at 10 ms. Polling is used rather than waking on release because the range may be freed by another connection, another handle or a closing handle, and a poll is correct for all of them without a notification path that would have to reach each one.

Waiting forever is bounded by the new `Config.MaxLockWait` (default 30 s), and this is a deliberate departure from the literal wire contract. The server answers one request per connection at a time, so an unbounded wait would let a client stall itself with no way out — the `CANCEL_LOCK` it would send arrives *behind* the request it wants to cancel. The ceiling converts a hang into a refusal the client can act on. An unbounded wait becomes safe once #1141 lands; until then this is the honest behaviour.

**Bits handled rather than ignored:**

- `CHANGE_LOCKTYPE` is refused with `STATUS_NOT_SUPPORTED`. [MS-CIFS] 2.2.4.32.1 requires an atomic type change or a rejection; releasing and re-taking would open a window in which the range is unlocked, which is exactly what the client asked to avoid.
- `CANCEL_LOCK` answers success. This is accurate rather than a stub: a waiting request occupies this connection's own goroutine, so no other request from this client can arrive while one waits — there is provably nothing outstanding to cancel.
- `OPLOCK_RELEASE` with no ranges is answered **with silence**. The same section: "If NumberOfRequestedUnlocks and NumberOfRequestedLocks are both zero (0x0000) [...] the server MUST NOT send an SMB_COM_LOCKING_ANDX Response". No oplock is ever granted here so there is none to release, and the section says that is not an error. Answering anyway would leave an unread reply on the connection and every subsequent response would be read against the wrong request.

### How Verified
Runtime, over the loopback harness. Fourteen assertions across ten tests:

- `TestByteRangeLockIsGrantedAndReleased` — granted, unavailable to a second handle, available again after release.
- `TestOverlappingLockIsRefusedAndAdjacentOneIsNot` — five overlap shapes (identical, straddling each end, enclosed, enclosing) all refused; the two *adjacent* ranges that touch without overlapping are both granted. The adjacent cases are what show this is an overlap rule and not a whole-file one.
- `TestExclusiveLockRefusesAnotherHandlesAccess` — another handle's read and write are refused inside the range and permitted outside it; the owning handle reads and writes its own locked range.
- `TestSharedLockRefusesWritesOnly` — another handle reads, and is refused the write.
- `TestUnlockingARangeNotHeldIsRefused` — `STATUS_RANGE_NOT_LOCKED` for a range never locked, and for one held by a different handle.
- `TestClosingAHandleReleasesItsLocks` — the range is lockable and readable once its holder closes.
- `TestLockRequestIsAtomic` — a two-range request whose second range conflicts leaves the first ungranted, proved by another handle then taking it.
- `TestLockRequestWithNoRangesIsAnsweredWithSilence` — nothing is read for the request, and a following echo returns its own payload, which is what shows the reply stream did not go out of step.
- `TestChangingALockTypeIsRefused` — `STATUS_NOT_SUPPORTED`.
- `TestBlockedLockWaitsAndThenFails` — a 50 ms wait ends in `STATUS_LOCK_NOT_GRANTED` and the connection is still usable afterwards.

The conformance suite's `servedCommands` registry required the new command to be declared with a note on what it does, which is what caught it during development — `TestConformanceServedCommandsAreServed` and `TestConformanceUnservedCommandsAreRefused` both failed until it was registered.

Whole tree green: `go build ./...`, `go test ./network/smb/...`. `gofmt -l` clean on every file touched.

### Test Coverage
**Added:** `server/locking_test.go` — the ten tests above, plus the `lockableServer` fixture (two handles on one file, which is what the cross-handle rules need), the `sendLockingRequest` raw-request helper (the client API sends one range; atomicity needs two), and `wideRange`.

**Modified:** `server/conformance_test.go` — `SMB_COM_LOCKING_ANDX` registered in `servedCommands`.

### Scope of Change
- **Files changed:** `server/locks.go` (new), `server/handler_lock.go` (new), `server/locking_test.go` (new), `server/share.go`, `server/server.go`, `server/dispatch.go`, `server/tree.go`, `server/handler_file.go`, `server/doc.go`, `server/conformance_test.go`, `message/commands/LockingAndxRequest.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none. The `LockingAndxRequest.go` change adds the remaining `TypeOfLock` bit constants next to the one #1156 introduced, so the handler names the same bits rather than redefining them.

### Risk and Rollout
Reads and writes now consult the lock table on every call, which is a map lookup on a share with no locks and a short slice walk otherwise. The behaviour changes only for a client that takes a lock — before this, none could.

The one thing to watch is enforcement against a client that took a lock and did not expect it to be honoured, since previously locks could not exist. That is the intended change, and it matches what any real SMB server does.

### Notes
Oplocks are still never granted and `CAP_LEVEL_II_OPLOCKS` is still not advertised; the `OPLOCK_RELEASE` path above is only the acknowledgement side, handled because it shares this command. Granting oplocks needs an unsolicited break notification, filed as #1152 behind #1141.

`Config.MaxLockWait`'s existence is a consequence of the synchronous request loop and should be revisited when #1141 lands.
