### PR TITLE
Serve the pass-through information classes for files (Fixes #1143)

### DIFF
--- a/network/smb/smb_v10/server/doc.go
+++ b/network/smb/smb_v10/server/doc.go
@@ -14,39 +14,65 @@
 // the protocol to look functional while refusing everything that matters.
 //
 // Implemented:
+//
 //   - Listening on Direct TCP (445) and NetBIOS over TCP (139), via
 //     network/smb/common/transport.
+//
 //   - The per-connection receive loop, request decoding, the handler chain, and
 //     response framing with correlated reply headers.
+//
 //   - Error responses in both encodings: the NTSTATUS form, and the legacy
 //     SMBSTATUS class/code form for a client that did not negotiate
 //     SMB_FLAGS2_NT_STATUS_ERROR_CODES.
+//
 //   - SMB_COM_NEGOTIATE, selecting the NT LM 0.12 dialect under extended
 //     security.
+//
 //   - SMB_COM_SESSION_SETUP_ANDX, including verifying the response against a
 //     credential, establishing a session, and the guest and anonymous policies.
+//
 //   - SMB_COM_LOGOFF_ANDX.
+//
 //   - SMB_COM_ECHO.
+//
 //   - Message signing in both directions, when the policy calls for it.
+//
 //   - Tree connect and disconnect against a registered share.
+//
 //   - File service: open and create, read, write, close, flush, delete, rename,
 //     and the directory create, remove and check commands.
+//
 //   - Directory enumeration and the information levels, over TRANSACTION2:
 //     FIND_FIRST2 and FIND_NEXT2 with search handles, the query and set levels
 //     for a path and for an open handle, and the volume levels. Requests and
 //     responses both fragment across as many messages as they need.
+//
 //   - Security descriptors and file-system controls, over NT_TRANSACT:
 //     QUERY_SECURITY_DESC, SET_SECURITY_DESC and IOCTL. SMB_COM_NT_CANCEL is
 //     accepted silently, since nothing here leaves a request outstanding.
+//
 //   - Named pipes, over TRANSACTION: a pipe is opened on a pipe share like a
 //     file, and TRANS_TRANSACT_NMPIPE writes a message to the handle and returns
 //     the answer. That write-then-read is the operation MS-RPC travels over, so a
 //     PipeHandler is all an RPC service needs to be reachable over SMB1.
+//
 //   - The volume queries a client actually asks: the TRANSACTION2 volume levels,
 //     the pass-through information classes above 0x03E8 that carry the native
 //     ones, and the legacy SMB_COM_QUERY_INFORMATION_DISK. A client asks about
 //     free space after a listing whether or not anything wanted it, so leaving
 //     these unanswered puts an error in every session.
+//
+//   - The pass-through information classes for files, in both directions: the
+//     basic, standard, internal, EA, access, position, name, alternate-name,
+//     network-open and all classes for a query, and the basic, disposition,
+//     allocation, end-of-file and rename classes for a set. Those structures come
+//     from windows/filesystem rather than being assembled here, so their layouts
+//     are the ones the rest of the repository agrees on.
+//
+//     A pass-through structure's strings are UTF-16LE whatever the message
+//     declared, which is the one place in this package where a name's encoding
+//     does not follow SMB_FLAGS2_UNICODE: an SMB level carries an SMB string, but
+//     a pass-through level carries the [MS-FSCC] structure verbatim.
 //
 // All three transaction families share one reassembly, since they are the same
 // shape at different field widths: totals, a per-message count and a

--- a/network/smb/smb_v10/server/handler_negotiate.go
+++ b/network/smb/smb_v10/server/handler_negotiate.go
@@ -28,11 +28,18 @@ const noDialectSelected = 0xFFFF
 // absent because raw transfers, the combined lock-and-read command and oplocks are
 // not implemented; advertising them would have clients issue commands that are
 // then refused.
+//
+// CAP_INFOLEVEL_PASSTHROUGH is advertised because the pass-through information
+// range is served for both files and volumes. A client may ask in that range
+// without being told it can, so advertising it changes nothing about what is
+// answered — but a client that checks first would otherwise take the long way
+// round to information the server already has.
 const serverCapabilities = capabilities.CAP_UNICODE |
 	capabilities.CAP_LARGE_FILES |
 	capabilities.CAP_NT_SMBS |
 	capabilities.CAP_NT_STATUS |
 	capabilities.CAP_NT_FIND |
+	capabilities.CAP_INFOLEVEL_PASSTHROUGH |
 	capabilities.CAP_EXTENDED_SECURITY
 
 // handleNegotiate answers SMB_COM_NEGOTIATE: it selects a dialect from the list

--- a/network/smb/smb_v10/server/infolevels.go
+++ b/network/smb/smb_v10/server/infolevels.go
@@ -222,6 +222,14 @@ func padTo4(buffer []byte) []byte {
 // encodeFileInformation renders a file in a query level, or reports that the level
 // is not served.
 func encodeFileInformation(level uint16, attr FileAttr, path string, unicode bool) ([]byte, bool) {
+	// A level at or above the pass-through base names a native information class
+	// rather than an SMB one ([MS-SMB] section 2.2.2.3.5), exactly as the volume
+	// levels already do. A Windows client asks for several of its file
+	// information this way, so refusing the range refuses the questions it asks.
+	if level >= smbInfoPassthrough {
+		return encodeNativeFileInformation(level-smbInfoPassthrough, attr, path)
+	}
+
 	switch level {
 	case smbQueryFileBasicInfo:
 		// Four timestamps(8 each) ExtFileAttributes(4) Reserved(4).
@@ -351,6 +359,10 @@ func encodeVolumeInformation(level uint16, volume VolumeInfo, unicode bool) ([]b
 // applyFileInformation applies a set level to a path, reporting whether the level
 // is served and what the backend made of it.
 func applyFileInformation(fs FileSystem, path string, level uint16, data []byte, open *Open) (bool, error) {
+	if level >= smbInfoPassthrough {
+		return applyNativeFileInformation(fs, path, level-smbInfoPassthrough, data, open)
+	}
+
 	switch level {
 	case smbSetFileBasicInfo:
 		if len(data) < 36 {

--- a/network/smb/smb_v10/server/infolevels_native.go
+++ b/network/smb/smb_v10/server/infolevels_native.go
@@ -1,0 +1,275 @@
+package server
+
+import (
+	"encoding/binary"
+
+	"github.com/TheManticoreProject/Manticore/encoding/utf16"
+	"github.com/TheManticoreProject/Manticore/windows/filesystem"
+	"github.com/TheManticoreProject/Manticore/windows/filesystem/infoclass"
+)
+
+// The pass-through information classes are native structures, so their strings
+// are UTF-16LE whatever encoding the message declared.
+//
+// This is the one place in the server where a name's encoding does not follow
+// SMB_FLAGS2_UNICODE: an SMB information level carries an SMB string, but a
+// pass-through level carries the [MS-FSCC] structure verbatim, and that structure
+// is defined in UTF-16LE. Reading the message's flag here would produce an OEM
+// name inside a native structure, which a client parses as UTF-16 regardless.
+func nativeName(value string) []byte {
+	return utf16.EncodeUTF16LE(value)
+}
+
+// encodeNativeFileInformation renders a file in a native FILE_INFORMATION_CLASS,
+// for a query in the pass-through range.
+//
+// The structures come from windows/filesystem rather than being assembled here,
+// so the layouts are the ones the rest of the repository already agrees on and
+// already tests.
+//
+// Parameters:
+//   - class: the native information class, with the pass-through base removed
+//   - attr: what the backend reported about the file
+//   - path: the share-relative path, for the classes that name the file
+//
+// Returns:
+//   - The encoded structure, and whether the class is served
+func encodeNativeFileInformation(class uint16, attr FileAttr, path string) ([]byte, bool) {
+	switch infoclass.FileInformationClass(class) {
+	case infoclass.FileBasicInformation:
+		basic := nativeBasicInformation(attr)
+		encoded, err := basic.Marshal()
+		return encoded, err == nil
+
+	case infoclass.FileStandardInformation:
+		standard := nativeStandardInformation(attr)
+		encoded, err := standard.Marshal()
+		return encoded, err == nil
+
+	case infoclass.FileInternalInformation:
+		// IndexNumber(8). A client uses it to tell whether two names are the same
+		// file. Nothing here keeps a file index, and inventing one would let a
+		// client conclude that two unrelated files are hard links to each other,
+		// so it is reported as zero — the value for storage with no index.
+		return make([]byte, 8), true
+
+	case infoclass.FileEaInformation:
+		// EaSize(4). Nothing here carries extended attributes.
+		return make([]byte, 4), true
+
+	case infoclass.FileAccessInformation:
+		// AccessFlags(4), which is what the open was granted.
+		information := make([]byte, 4)
+		binary.LittleEndian.PutUint32(information, nativeAccessFlags(attr))
+		return information, true
+
+	case infoclass.FilePositionInformation:
+		// CurrentByteOffset(8). The server keeps no file pointer — every read and
+		// write carries its own offset — so the position is the start.
+		return make([]byte, 8), true
+
+	case infoclass.FileNameInformation, infoclass.FileAlternateNameInformation:
+		// FileNameLength(4) FileName(variable). The alternate name is the 8.3
+		// alias, and there is none here, so the long name answers both: a client
+		// falls back to the long name when no alias is offered.
+		name := nativeName(nativePath(path))
+		information := make([]byte, 4, 4+len(name))
+		binary.LittleEndian.PutUint32(information, uint32(len(name)))
+		return append(information, name...), true
+
+	case infoclass.FileNetworkOpenInformation:
+		open := filesystem.FileNetworkOpenInformation{
+			CreationTime:   filetimeOf(attr.Created),
+			LastAccessTime: filetimeOf(attr.Accessed),
+			LastWriteTime:  filetimeOf(attr.Modified),
+			ChangeTime:     filetimeOf(attr.Changed),
+			AllocationSize: attr.AllocationSize,
+			EndOfFile:      attr.Size,
+			FileAttributes: attributesFor(attr),
+		}
+		encoded, err := open.Marshal()
+		return encoded, err == nil
+
+	case infoclass.FileAllInformation:
+		all := filesystem.FileAllInformation{
+			Basic:    nativeBasicInformation(attr),
+			Standard: nativeStandardInformation(attr),
+			EaSize:   0,
+			// AccessFlags, Mode and AlignmentRequirement describe the open rather
+			// than the file. Mode is zero because no write-through or
+			// synchronous-IO mode is in force, and the alignment requirement is
+			// byte alignment, which is what storage with no device constraint has.
+			AccessFlags:          nativeAccessFlags(attr),
+			CurrentByteOffset:    0,
+			Mode:                 0,
+			AlignmentRequirement: 0,
+			FileName:             nativePath(path),
+		}
+		encoded, err := all.Marshal()
+		return encoded, err == nil
+	}
+
+	return nil, false
+}
+
+// nativeBasicInformation fills FILE_BASIC_INFORMATION from what the backend
+// reported.
+func nativeBasicInformation(attr FileAttr) filesystem.FileBasicInformation {
+	return filesystem.FileBasicInformation{
+		CreationTime:   filetimeOf(attr.Created),
+		LastAccessTime: filetimeOf(attr.Accessed),
+		LastWriteTime:  filetimeOf(attr.Modified),
+		ChangeTime:     filetimeOf(attr.Changed),
+		FileAttributes: attributesFor(attr),
+	}
+}
+
+// nativeStandardInformation fills FILE_STANDARD_INFORMATION.
+//
+// NumberOfLinks is one because nothing here creates a hard link, so every file has
+// exactly the one name it is reached by.
+func nativeStandardInformation(attr FileAttr) filesystem.FileStandardInformation {
+	return filesystem.FileStandardInformation{
+		AllocationSize: attr.AllocationSize,
+		EndOfFile:      attr.Size,
+		NumberOfLinks:  1,
+		DeletePending:  false,
+		Directory:      attr.IsDir,
+	}
+}
+
+// nativeAccessFlags reports the access a client has to an entry, as the
+// FILE_ACCESS_INFORMATION mask.
+//
+// A read-only entry does not describe write access, for the same reason the
+// reflective security provider does not: a client uses this to predict what it
+// will be allowed to do, so a mask that disagreed with the handlers would make the
+// client wrong.
+func nativeAccessFlags(attr FileAttr) uint32 {
+	access := uint32(fileflagsGenericRead)
+	if !attr.ReadOnly {
+		access |= fileflagsGenericWrite
+	}
+	return access
+}
+
+// nativePath renders a share-relative path the way a native structure names one:
+// separated by backslashes and rooted, which is what FILE_NAME_INFORMATION
+// carries.
+func nativePath(path string) string {
+	if path == "" {
+		return `\`
+	}
+	rooted := path
+	if rooted[0] != '\\' {
+		rooted = `\` + rooted
+	}
+	return rooted
+}
+
+// applyNativeFileInformation applies a native FILE_INFORMATION_CLASS to a path,
+// for a set in the pass-through range.
+//
+// Parameters:
+//   - fs: the backend to apply it through
+//   - path: the share-relative path being changed
+//   - class: the native information class, with the pass-through base removed
+//   - data: the structure the client sent
+//   - open: the handle the set arrived on, or nil for a set by path
+//
+// Returns:
+//   - Whether the class is served, and what the backend made of it
+func applyNativeFileInformation(
+	fs FileSystem,
+	path string,
+	class uint16,
+	data []byte,
+	open *Open,
+) (bool, error) {
+	switch infoclass.FileInformationClass(class) {
+	case infoclass.FileBasicInformation:
+		basic := filesystem.FileBasicInformation{}
+		if err := basic.Unmarshal(data); err != nil {
+			return true, ErrAccessDenied
+		}
+		attr := FileAttr{
+			Created:  timeFromFiletime(basic.CreationTime),
+			Accessed: timeFromFiletime(basic.LastAccessTime),
+			Modified: timeFromFiletime(basic.LastWriteTime),
+			Changed:  timeFromFiletime(basic.ChangeTime),
+			ReadOnly: basic.FileAttributes&fileAttributeReadOnly != 0,
+		}
+		// A zero timestamp means "leave this one alone", which is the same rule
+		// the SMB-level basic set follows.
+		mask := AttrMask{
+			ReadOnly: true,
+			Created:  !attr.Created.IsZero(),
+			Accessed: !attr.Accessed.IsZero(),
+			Modified: !attr.Modified.IsZero(),
+			Changed:  !attr.Changed.IsZero(),
+		}
+		return true, fs.SetAttr(path, attr, mask)
+
+	case infoclass.FileDispositionInformation:
+		disposition := filesystem.FileDispositionInformation{}
+		if err := disposition.Unmarshal(data); err != nil {
+			return true, ErrAccessDenied
+		}
+		// Delete-on-close is a property of the handle, so a set by path has
+		// nowhere to record it.
+		if open == nil {
+			return true, ErrAccessDenied
+		}
+		open.DeleteOnClose = disposition.DeletePending
+		return true, nil
+
+	case infoclass.FileEndOfFileInformation:
+		endOfFile := filesystem.FileEndOfFileInformation{}
+		if err := endOfFile.Unmarshal(data); err != nil {
+			return true, ErrAccessDenied
+		}
+		if endOfFile.EndOfFile < 0 {
+			return true, ErrAccessDenied
+		}
+		return true, fs.SetAttr(path, FileAttr{Size: endOfFile.EndOfFile}, AttrMask{Size: true})
+
+	case infoclass.FileAllocationInformation:
+		// Reserving space is not changing the length, and nothing here
+		// distinguishes the two, so the request is accepted and the length left
+		// alone — the same answer the SMB-level allocation set gives.
+		if len(data) < 8 {
+			return true, ErrAccessDenied
+		}
+		return true, nil
+
+	case infoclass.FileRenameInformation:
+		rename := filesystem.FileRenameInformation{}
+		if err := rename.Unmarshal(data); err != nil {
+			return true, ErrAccessDenied
+		}
+		// RootDirectory names a directory handle the new name is relative to.
+		// Nothing here can resolve one, and treating a relative name as if it
+		// were share-relative would rename the file somewhere the client did not
+		// ask for, so it is refused instead.
+		if rename.RootDirectory != 0 {
+			return true, ErrAccessDenied
+		}
+
+		target, err := resolvePath(rename.FileName)
+		if err != nil {
+			return true, ErrAccessDenied
+		}
+		return true, fs.Rename(path, target, rename.ReplaceIfExists)
+	}
+
+	return false, nil
+}
+
+// fileAttributeReadOnly, fileflagsGenericRead and fileflagsGenericWrite are the
+// bits the native structures above use, named here so this file does not depend
+// on the SMB-level constants for values that belong to [MS-FSCC].
+const (
+	fileAttributeReadOnly = 0x00000001
+	fileflagsGenericRead  = 0x00000001
+	fileflagsGenericWrite = 0x00000002
+)

--- a/network/smb/smb_v10/server/infolevels_native_test.go
+++ b/network/smb/smb_v10/server/infolevels_native_test.go
@@ -1,0 +1,322 @@
+package server
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/TheManticoreProject/Manticore/encoding/utf16"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/capabilities"
+	smb1client "github.com/TheManticoreProject/Manticore/network/smb/smb_v10/client"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+	"github.com/TheManticoreProject/Manticore/windows/fileflags"
+	"github.com/TheManticoreProject/Manticore/windows/filesystem"
+	"github.com/TheManticoreProject/Manticore/windows/filesystem/infoclass"
+)
+
+// passthroughLevel is the SMB information level that carries a native
+// information class ([MS-SMB] section 2.2.2.3.5).
+func passthroughLevel(class infoclass.FileInformationClass) uint16 {
+	return smbInfoPassthrough + uint16(class)
+}
+
+// passthroughServer serves one file of known contents and returns a connected
+// client with a handle on it.
+func passthroughServer(t *testing.T, name, contents string) (*smb1client.Client, smb1client.FID) {
+	t.Helper()
+
+	fs := NewMemoryFileSystem("FILES")
+	if err := fs.AddFile(name, []byte(contents)); err != nil {
+		t.Fatalf("AddFile() error = %v", err)
+	}
+	_, client := fileServer(t, fs, false)
+
+	fid, err := client.OpenFile(name,
+		fileflags.GENERIC_READ|fileflags.GENERIC_WRITE,
+		fileflags.FILE_SHARE_READ|fileflags.FILE_SHARE_WRITE,
+		fileflags.FILE_OPEN,
+		fileflags.FILE_NON_DIRECTORY_FILE)
+	if err != nil {
+		t.Fatalf("opening %q failed: %v", name, err)
+	}
+	return client, fid
+}
+
+// TestPassthroughQueryClassesAreServed asserts each served native query class
+// comes back and parses with the repository's own [MS-FSCC] structures.
+//
+// Parsing the answer back with windows/filesystem rather than with assertions on
+// raw offsets is deliberate: those structures are what the SMB2 client and the
+// rest of the repository already agree on, so a layout this server got wrong
+// fails here rather than agreeing with itself.
+func TestPassthroughQueryClassesAreServed(t *testing.T) {
+	const contents = "0123456789abcdef"
+	client, fid := passthroughServer(t, "described.txt", contents)
+
+	t.Run("basic information", func(t *testing.T) {
+		raw, err := client.QueryFileInformation(fid, passthroughLevel(infoclass.FileBasicInformation))
+		if err != nil {
+			t.Fatalf("querying FileBasicInformation failed: %v", err)
+		}
+		basic := filesystem.FileBasicInformation{}
+		if err := basic.Unmarshal(raw); err != nil {
+			t.Fatalf("the answer did not parse as FILE_BASIC_INFORMATION: %v", err)
+		}
+		if basic.LastWriteTime == 0 {
+			t.Error("the reported last-write time is zero")
+		}
+		if basic.FileAttributes == 0 {
+			t.Error("the reported attributes are zero, so the file describes nothing")
+		}
+	})
+
+	t.Run("standard information", func(t *testing.T) {
+		raw, err := client.QueryFileInformation(fid, passthroughLevel(infoclass.FileStandardInformation))
+		if err != nil {
+			t.Fatalf("querying FileStandardInformation failed: %v", err)
+		}
+		standard := filesystem.FileStandardInformation{}
+		if err := standard.Unmarshal(raw); err != nil {
+			t.Fatalf("the answer did not parse as FILE_STANDARD_INFORMATION: %v", err)
+		}
+		if standard.EndOfFile != int64(len(contents)) {
+			t.Errorf("EndOfFile is %d, want %d", standard.EndOfFile, len(contents))
+		}
+		if standard.Directory {
+			t.Error("a file is reported as a directory")
+		}
+		if standard.NumberOfLinks != 1 {
+			t.Errorf("NumberOfLinks is %d, want 1", standard.NumberOfLinks)
+		}
+	})
+
+	t.Run("network open information", func(t *testing.T) {
+		raw, err := client.QueryFileInformation(fid, passthroughLevel(infoclass.FileNetworkOpenInformation))
+		if err != nil {
+			t.Fatalf("querying FileNetworkOpenInformation failed: %v", err)
+		}
+		open := filesystem.FileNetworkOpenInformation{}
+		if err := open.Unmarshal(raw); err != nil {
+			t.Fatalf("the answer did not parse as FILE_NETWORK_OPEN_INFORMATION: %v", err)
+		}
+		if open.EndOfFile != int64(len(contents)) {
+			t.Errorf("EndOfFile is %d, want %d", open.EndOfFile, len(contents))
+		}
+	})
+
+	t.Run("all information", func(t *testing.T) {
+		raw, err := client.QueryFileInformation(fid, passthroughLevel(infoclass.FileAllInformation))
+		if err != nil {
+			t.Fatalf("querying FileAllInformation failed: %v", err)
+		}
+		all := filesystem.FileAllInformation{}
+		if err := all.Unmarshal(raw); err != nil {
+			t.Fatalf("the answer did not parse as FILE_ALL_INFORMATION: %v", err)
+		}
+		if all.Standard.EndOfFile != int64(len(contents)) {
+			t.Errorf("EndOfFile is %d, want %d", all.Standard.EndOfFile, len(contents))
+		}
+		if !strings.EqualFold(all.FileName, `\described.txt`) {
+			t.Errorf("FileName is %q, want %q", all.FileName, `\described.txt`)
+		}
+	})
+
+	t.Run("name information carries UTF-16 whatever the message declared", func(t *testing.T) {
+		raw, err := client.QueryFileInformation(fid, passthroughLevel(infoclass.FileNameInformation))
+		if err != nil {
+			t.Fatalf("querying FileNameInformation failed: %v", err)
+		}
+		if len(raw) < 4 {
+			t.Fatalf("the answer is %d bytes, too short for FileNameLength", len(raw))
+		}
+		// FileNameLength(4) FileName(variable). A native structure's strings are
+		// UTF-16LE regardless of SMB_FLAGS2_UNICODE, so decoding it that way is
+		// the assertion.
+		name := utf16.DecodeUTF16LE([]types.UCHAR(raw[4:]))
+		if !strings.EqualFold(name, `\described.txt`) {
+			t.Errorf("the name decoded as %q, want %q — a native name is UTF-16LE", name, `\described.txt`)
+		}
+	})
+
+	t.Run("classes with nothing behind them are still answered", func(t *testing.T) {
+		for _, class := range []infoclass.FileInformationClass{
+			infoclass.FileInternalInformation,
+			infoclass.FileEaInformation,
+			infoclass.FileAccessInformation,
+			infoclass.FilePositionInformation,
+			infoclass.FileAlternateNameInformation,
+		} {
+			if _, err := client.QueryFileInformation(fid, passthroughLevel(class)); err != nil {
+				t.Errorf("querying class %d failed: %v", class, err)
+			}
+		}
+	})
+}
+
+// TestPassthroughUnservedClassIsRefused asserts a class in the range that the
+// server does not serve is refused rather than answered with something else.
+func TestPassthroughUnservedClassIsRefused(t *testing.T) {
+	client, fid := passthroughServer(t, "described.txt", "x")
+
+	// 12 is FileNamesInformation, which describes a directory enumeration rather
+	// than one file and is not served here.
+	if _, err := client.QueryFileInformation(fid, passthroughLevel(infoclass.FileNamesInformation)); err == nil {
+		t.Error("an unserved pass-through class was answered")
+	}
+}
+
+// TestPassthroughSetEndOfFileResizes asserts the pass-through set classes act,
+// rather than being accepted and dropped.
+func TestPassthroughSetEndOfFileResizes(t *testing.T) {
+	client, fid := passthroughServer(t, "resized.txt", "0123456789abcdef")
+
+	endOfFile := filesystem.FileEndOfFileInformation{EndOfFile: 4}
+	encoded, err := endOfFile.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+
+	if err := client.SetFileInformation(fid, passthroughLevel(infoclass.FileEndOfFileInformation), encoded); err != nil {
+		t.Fatalf("setting FileEndOfFileInformation failed: %v", err)
+	}
+
+	raw, err := client.QueryFileInformation(fid, passthroughLevel(infoclass.FileStandardInformation))
+	if err != nil {
+		t.Fatalf("querying the size back failed: %v", err)
+	}
+	standard := filesystem.FileStandardInformation{}
+	if err := standard.Unmarshal(raw); err != nil {
+		t.Fatalf("the answer did not parse: %v", err)
+	}
+	if standard.EndOfFile != 4 {
+		t.Errorf("the file is %d bytes after being truncated to 4", standard.EndOfFile)
+	}
+}
+
+// TestPassthroughSetBasicInformationAppliesTimes asserts a native basic set is
+// applied, and that a zero timestamp leaves that one alone.
+func TestPassthroughSetBasicInformationAppliesTimes(t *testing.T) {
+	client, fid := passthroughServer(t, "stamped.txt", "x")
+
+	before, err := client.QueryFileInformation(fid, passthroughLevel(infoclass.FileBasicInformation))
+	if err != nil {
+		t.Fatalf("querying the times first failed: %v", err)
+	}
+	original := filesystem.FileBasicInformation{}
+	if err := original.Unmarshal(before); err != nil {
+		t.Fatalf("the answer did not parse: %v", err)
+	}
+
+	// Only the write time is supplied; the rest are zero and so must not move.
+	wanted := time.Date(2001, 2, 3, 4, 5, 6, 0, time.UTC)
+	basic := filesystem.FileBasicInformation{LastWriteTime: filetimeOf(wanted)}
+	encoded, err := basic.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	if err := client.SetFileInformation(fid, passthroughLevel(infoclass.FileBasicInformation), encoded); err != nil {
+		t.Fatalf("setting FileBasicInformation failed: %v", err)
+	}
+
+	after, err := client.QueryFileInformation(fid, passthroughLevel(infoclass.FileBasicInformation))
+	if err != nil {
+		t.Fatalf("querying the times back failed: %v", err)
+	}
+	applied := filesystem.FileBasicInformation{}
+	if err := applied.Unmarshal(after); err != nil {
+		t.Fatalf("the answer did not parse: %v", err)
+	}
+
+	if applied.LastWriteTime != filetimeOf(wanted) {
+		t.Errorf("the write time is %d, want %d", applied.LastWriteTime, filetimeOf(wanted))
+	}
+	if applied.CreationTime != original.CreationTime {
+		t.Errorf("the creation time moved to %d from %d, but none was supplied",
+			applied.CreationTime, original.CreationTime)
+	}
+}
+
+// TestPassthroughRenameMovesTheEntry asserts a rename through the pass-through
+// class works, which is how a Windows client renames a file.
+func TestPassthroughRenameMovesTheEntry(t *testing.T) {
+	fs := NewMemoryFileSystem("FILES")
+	if err := fs.AddFile("before.txt", []byte("contents")); err != nil {
+		t.Fatalf("AddFile() error = %v", err)
+	}
+	_, client := fileServer(t, fs, false)
+
+	rename := filesystem.FileRenameInformation{FileName: `after.txt`}
+	encoded, err := rename.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+
+	if err := client.SetPathInformation("before.txt",
+		passthroughLevel(infoclass.FileRenameInformation), encoded); err != nil {
+		t.Fatalf("renaming through the pass-through class failed: %v", err)
+	}
+
+	if _, err := fs.Stat("after.txt"); err != nil {
+		t.Errorf("the file is not at its new name: %v", err)
+	}
+	if _, err := fs.Stat("before.txt"); err == nil {
+		t.Error("the file is still at its old name")
+	}
+}
+
+// TestPassthroughRenameRefusesARelativeRoot asserts a rename whose new name is
+// relative to a directory handle is refused rather than misapplied.
+//
+// RootDirectory names an open directory the new name is relative to. Nothing here
+// can resolve one, and treating the name as share-relative instead would move the
+// file somewhere the client did not ask for and report success.
+func TestPassthroughRenameRefusesARelativeRoot(t *testing.T) {
+	fs := NewMemoryFileSystem("FILES")
+	if err := fs.AddFile("before.txt", []byte("contents")); err != nil {
+		t.Fatalf("AddFile() error = %v", err)
+	}
+	_, client := fileServer(t, fs, false)
+
+	rename := filesystem.FileRenameInformation{RootDirectory: 0x1234, FileName: `after.txt`}
+	encoded, err := rename.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+
+	if err := client.SetPathInformation("before.txt",
+		passthroughLevel(infoclass.FileRenameInformation), encoded); err == nil {
+		t.Fatal("a rename relative to a directory handle was accepted")
+	}
+	if _, err := fs.Stat("before.txt"); err != nil {
+		t.Errorf("the refused rename moved the file anyway: %v", err)
+	}
+}
+
+// TestPassthroughRenameRefusesEscapingTheShare asserts the new name goes through
+// the same path resolution every other name does.
+func TestPassthroughRenameRefusesEscapingTheShare(t *testing.T) {
+	fs := NewMemoryFileSystem("FILES")
+	if err := fs.AddFile("before.txt", []byte("contents")); err != nil {
+		t.Fatalf("AddFile() error = %v", err)
+	}
+	_, client := fileServer(t, fs, false)
+
+	rename := filesystem.FileRenameInformation{FileName: `..\escaped.txt`}
+	encoded, err := rename.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+
+	if err := client.SetPathInformation("before.txt",
+		passthroughLevel(infoclass.FileRenameInformation), encoded); err == nil {
+		t.Fatal("a rename out of the share was accepted")
+	}
+}
+
+// TestPassthroughCapabilityIsAdvertised asserts the server says it serves the
+// range it serves.
+func TestPassthroughCapabilityIsAdvertised(t *testing.T) {
+	if serverCapabilities&capabilities.CAP_INFOLEVEL_PASSTHROUGH == 0 {
+		t.Error("CAP_INFOLEVEL_PASSTHROUGH is not advertised, but the pass-through range is served")
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #1143`

### Root Cause
The pass-through range was implemented for one of the three places it appears and not the other two. `encodeVolumeInformation` branched on `level >= smbInfoPassthrough` and mapped the level onto a native `FS_INFORMATION_CLASS`; `encodeFileInformation` and `applyFileInformation` had no such branch and returned `false` for anything outside their handful of SMB levels, which `handler_info.go` turned into `STATUS_INVALID_INFO_CLASS`.

The asymmetry was not a decision, it was an omission — the volume side was added because a client asking for free space made it unavoidable, and the file side was never revisited. `CAP_INFOLEVEL_PASSTHROUGH` was not advertised either, so the half that did work was not announced.

### Fix Description
Both file paths now route the range, and the structures come from `windows/filesystem` rather than being assembled here.

That reuse is the main design decision. The repository already models the [MS-FSCC] structures — `FileBasicInformation`, `FileStandardInformation`, `FileAllInformation`, `FileNetworkOpenInformation`, `FileEndOfFileInformation`, `FileDispositionInformation`, `FileRenameInformation` — with their own `Marshal`/`Unmarshal` and their own tests, and the SMB2 client already speaks them. Hand-rolling the layouts in this package would have created a second opinion about the same wire format, and the two would drift.

**Query** (`encodeNativeFileInformation`): basic, standard, internal, EA, access, position, name, alternate-name, network-open and all.

Three of those report nothing rather than something invented, and the reason matters in each case:

- `FileInternalInformation`'s IndexNumber is zero. A client uses it to decide whether two names are the same file; nothing here keeps a file index, and a fabricated one would let a client conclude that two unrelated files are hard links to each other.
- `FileAlternateNameInformation` returns the long name. There is no 8.3 alias, and a client falls back to the long name when none is offered.
- `FilePositionInformation` reports offset zero. The server keeps no file pointer — every read and write carries its own offset — so there is no position to report.

`FileAccessInformation` and `FileAllInformation`'s access mask describe a read-only entry without write access, for the same reason `NewReflectiveSecurityProvider` does: a client uses this to predict what it will be allowed to do, so a mask that disagreed with the handlers would make the client wrong.

**Set** (`applyNativeFileInformation`): basic, disposition, allocation, end-of-file and rename. Basic keeps the existing "a zero timestamp means leave this one alone" rule; allocation is accepted without resizing, which is the same answer the SMB-level allocation set already gives, because reserving space is not changing the length and nothing here distinguishes the two.

Rename is the one with teeth, because it is how a Windows client renames a file. Two things it refuses rather than approximates:

- A non-zero `RootDirectory` names an open directory the new name is relative to. Nothing here can resolve one, and treating the name as share-relative instead would move the file somewhere the client did not ask for *and report success*.
- The new name goes through `resolvePath` like every other name, so a rename cannot escape the share.

**Encoding.** A pass-through structure's strings are UTF-16LE whatever the message declared. This is the one place in the package where a name's encoding does not follow `SMB_FLAGS2_UNICODE`, and it is worth stating plainly: an SMB information level carries an SMB string, but a pass-through level carries the [MS-FSCC] structure verbatim, and that structure is defined in UTF-16LE. Reading the message's flag here would put an OEM name inside a native structure, which a client parses as UTF-16 regardless — producing a reply of the right shape and the wrong text.

**Scope line.** `FileStreamInformation` and `FileCompressionInformation` are not served here. They have no constant in `windows/filesystem/infoclass` and no structure in the repository, so serving them would mean introducing layouts this PR has no independent parser to check against. Their SMB-level equivalents are part of #1144, which is where they belong.

### How Verified
Runtime, over the loopback harness, with every answer parsed back by the `windows/filesystem` structures rather than by assertions on raw offsets. That is the point: those structures are what the SMB2 client and the rest of the repository already agree on, so a layout this server got wrong fails here instead of agreeing with itself.

- `TestPassthroughQueryClassesAreServed` — basic, standard, network-open and all classes parse and carry the right size and name; the name class is decoded as UTF-16LE explicitly, which is the assertion that the native-encoding rule is followed; and the five classes with nothing behind them are still answered rather than refused.
- `TestPassthroughUnservedClassIsRefused` — `FileNamesInformation` (a directory-enumeration class) is refused, so the range is not a catch-all.
- `TestPassthroughSetEndOfFileResizes` — a truncation to 4 bytes is applied and read back, so the set acts rather than being accepted and dropped.
- `TestPassthroughSetBasicInformationAppliesTimes` — the supplied write time is applied and the unsupplied creation time does not move.
- `TestPassthroughRenameMovesTheEntry` — the file is at its new name and gone from the old one.
- `TestPassthroughRenameRefusesARelativeRoot` — refused, and the file did not move.
- `TestPassthroughRenameRefusesEscapingTheShare` — `..\escaped.txt` refused.
- `TestPassthroughCapabilityIsAdvertised` — the server says it serves the range it serves.

Whole tree green: `go build ./...`, `go test ./network/smb/...`. `gofmt -l` clean on every file touched.

### Test Coverage
**Added:** `server/infolevels_native_test.go` — the eight tests above, plus the `passthroughLevel` and `passthroughServer` helpers.

### Scope of Change
- **Files changed:** `server/infolevels_native.go` (new), `server/infolevels_native_test.go` (new), `server/infolevels.go`, `server/handler_negotiate.go`, `server/doc.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none. Levels below `SMB_INFO_PASSTHROUGH` take exactly the path they did before; the new branch is reached only by a level that was previously refused.

### Risk and Rollout
Low, and additive. Every level this touches was answered `STATUS_INVALID_INFO_CLASS` before, so no existing exchange changes shape.

The one visible change to negotiation is the new `CAP_INFOLEVEL_PASSTHROUGH` bit. It is a statement about what the server already does in this PR, not a new promise: a client may ask in the range without being told it can, so advertising it changes what a client *tries*, not what it *gets*.

### Notes
`FileStreamInformation` and `FileCompressionInformation` are left to #1144 as above. Hard links via `FileLinkInformation` need a backend primitive that `FileSystem` does not have; that is #1148's `SMB_COM_NT_RENAME` set-link work, and this PR does not claim the class.
