### PR TITLE
Serve large reads and writes above the negotiated buffer (Fixes #1151)

### DIFF
--- a/network/smb/smb_v10/message/commands/ReadAndxResponse.go
+++ b/network/smb/smb_v10/message/commands/ReadAndxResponse.go
@@ -15,7 +15,8 @@ import (
 
 // readAndxResponseParameterWords is the fixed number of 2-byte parameter words in
 // an SMB_COM_READ_ANDX response: the 2-word AndX block plus Available,
-// DataCompactionMode, Reserved1, DataLength, DataOffset, and the 5-word Reserved2.
+// DataCompactionMode, Reserved1, DataLength, DataOffset, DataLengthHigh, and the
+// 4-word Reserved2.
 const readAndxResponseParameterWords = 12
 
 // readAndxResponseDataOffset is the offset, in bytes from the start of the SMB
@@ -50,10 +51,21 @@ type ReadAndxResponse struct {
 	// DataOffset (2 bytes): The offset in bytes from the header of the read data.
 	DataOffset types.USHORT
 
-	// Reserved2 (10 bytes): Reserved. All entries MUST be 0x0000. The last 5 words are
+	// DataLengthHigh (2 bytes): The high 16 bits of the number of bytes returned,
+	// which is how a read of more than 0xFFFF bytes describes its length.
+	//
+	// [MS-CIFS] section 2.2.4.42.2 has this as the first word of a 5-word
+	// Reserved2; [MS-SMB] section 2.2.4.2.2 extends "the first two bytes of the
+	// SMB_Parameters.Words.Reserved2[] field [...] for use as the new
+	// DataLengthHigh field", leaving four reserved words behind it. Naming it
+	// here rather than writing into Reserved2[0] keeps a server that answers a
+	// large read from looking like it is filling in a reserved field.
+	DataLengthHigh types.USHORT
+
+	// Reserved2 (8 bytes): Reserved. All entries MUST be 0x0000. These words are
 	// reserved in order to make the SMB_COM_READ_ANDX Response the same size as the
 	// SMB_COM_WRITE_ANDX Response.
-	Reserved2 [5]types.USHORT
+	Reserved2 [4]types.USHORT
 
 	// Data
 
@@ -161,6 +173,11 @@ func (c *ReadAndxResponse) Marshal() ([]byte, error) {
 	binary.LittleEndian.PutUint16(buf2, uint16(c.DataOffset))
 	rawParametersContent = append(rawParametersContent, buf2...)
 
+	// Marshalling parameter DataLengthHigh
+	buf2 = make([]byte, 2)
+	binary.LittleEndian.PutUint16(buf2, uint16(c.DataLengthHigh))
+	rawParametersContent = append(rawParametersContent, buf2...)
+
 	// Marshalling parameter Reserved2
 	for _, reserved := range c.Reserved2 {
 		buf2 = make([]byte, 2)
@@ -263,6 +280,13 @@ func (c *ReadAndxResponse) Unmarshal(rawData []byte) (int, error) {
 		return offset, fmt.Errorf("rawParametersContent too short for DataOffset")
 	}
 	c.DataOffset = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
+	offset += 2
+
+	// Unmarshalling parameter DataLengthHigh
+	if len(rawParametersContent) < offset+2 {
+		return offset, fmt.Errorf("rawParametersContent too short for DataLengthHigh")
+	}
+	c.DataLengthHigh = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
 	offset += 2
 
 	// Unmarshalling parameter Reserved2

--- a/network/smb/smb_v10/message/commands/WriteAndxRequest.go
+++ b/network/smb/smb_v10/message/commands/WriteAndxRequest.go
@@ -215,6 +215,19 @@ func (c *WriteAndxRequest) Marshal() ([]byte, error) {
 	return marshalledCommand, nil
 }
 
+// DataLengthHigh is the high 16 bits of the write's length.
+//
+// [MS-SMB] section 2.2.4.3.1 allocates the CIFS Reserved field for it under
+// CAP_LARGE_WRITEX. The field keeps its CIFS name on the struct because that is
+// what it is called when the capability is not in force, and this accessor names
+// what it means when it is.
+//
+// Returns:
+//   - The high 16 bits of the number of data bytes the request carries
+func (c *WriteAndxRequest) DataLengthHigh() types.USHORT {
+	return c.Reserved
+}
+
 // Unmarshal unmarshals a byte array into the command structure
 //
 // Parameters:
@@ -334,11 +347,21 @@ func (c *WriteAndxRequest) Unmarshal(rawData []byte) (int, error) {
 	offset++
 
 	// Unmarshalling data Data
-	if len(rawDataContent) < offset+int(c.DataLength) {
-		return offset, fmt.Errorf("rawDataContent too short for Data")
+	//
+	// The length spans two fields. [MS-SMB] section 2.2.4.3.1 allocates the CIFS
+	// Reserved field as DataLengthHigh, which is the only way a write above
+	// 0xFFFF bytes can describe itself, and [MS-CIFS] section 2.2.4.43.1 requires
+	// Reserved to be zero, so a non-zero value is a length rather than a client
+	// leaving a field dirty. Reading DataLength alone would silently truncate
+	// every large write to its low word: the server would write 4464 of 70000
+	// bytes and report success.
+	declared := int(c.DataLengthHigh())<<16 | int(c.DataLength)
+	if len(rawDataContent) < offset+declared {
+		return offset, fmt.Errorf("rawDataContent too short for Data: need %d bytes from %d, have %d",
+			declared, offset, len(rawDataContent))
 	}
-	c.Data = rawDataContent[offset : offset+int(c.DataLength)]
-	offset += int(c.DataLength)
+	c.Data = rawDataContent[offset : offset+declared]
+	offset += declared
 
 	return offset, nil
 }

--- a/network/smb/smb_v10/message/commands/WriteAndxResponse.go
+++ b/network/smb/smb_v10/message/commands/WriteAndxResponse.go
@@ -28,8 +28,17 @@ type WriteAndxResponse struct {
 	// field MUST be set to 0xFFFF.
 	Available types.USHORT
 
-	// Reserved (4 bytes): This field MUST be 0x00000000.
-	Reserved types.ULONG
+	// CountHigh (2 bytes): The high 16 bits of the number of bytes written, which
+	// is how a write of more than 0xFFFF bytes reports what it wrote.
+	//
+	// [MS-CIFS] section 2.2.4.43.2 has this as part of a 4-byte Reserved;
+	// [MS-SMB] section 2.2.4.3.2 allocates "the first two bytes of the
+	// SMB_Parameters.Words.Reserved field for use as the CountHigh field",
+	// leaving two reserved bytes behind it.
+	CountHigh types.USHORT
+
+	// Reserved (2 bytes): This field MUST be 0x0000.
+	Reserved types.USHORT
 }
 
 // NewWriteAndxResponse creates a new WriteAndxResponse structure
@@ -41,7 +50,8 @@ func NewWriteAndxResponse() *WriteAndxResponse {
 		// Parameters
 		Count:     types.USHORT(0),
 		Available: types.USHORT(0),
-		Reserved:  types.ULONG(0),
+		CountHigh: types.USHORT(0),
+		Reserved:  types.USHORT(0),
 	}
 
 	c.Command.SetCommandCode(codes.SMB_COM_WRITE_ANDX)
@@ -103,7 +113,8 @@ func (c *WriteAndxResponse) Marshal() ([]byte, error) {
 
 	// Marshalling parameter Reserved
 	buf4 := make([]byte, 4)
-	binary.LittleEndian.PutUint32(buf4, uint32(c.Reserved))
+	binary.LittleEndian.PutUint16(buf4[0:2], uint16(c.CountHigh))
+	binary.LittleEndian.PutUint16(buf4[2:4], uint16(c.Reserved))
 	rawParametersContent = append(rawParametersContent, buf4...)
 
 	// Marshalling parameters
@@ -186,7 +197,8 @@ func (c *WriteAndxResponse) Unmarshal(rawData []byte) (int, error) {
 	if len(rawParametersContent) < offset+4 {
 		return offset, fmt.Errorf("rawParametersContent too short for Reserved")
 	}
-	c.Reserved = types.ULONG(binary.LittleEndian.Uint32(rawParametersContent[offset : offset+4]))
+	c.CountHigh = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset : offset+2]))
+	c.Reserved = types.USHORT(binary.LittleEndian.Uint16(rawParametersContent[offset+2 : offset+4]))
 	offset += 4
 
 	// Then unmarshal the data

--- a/network/smb/smb_v10/server/doc.go
+++ b/network/smb/smb_v10/server/doc.go
@@ -48,6 +48,16 @@
 //     free space after a listing whether or not anything wanted it, so leaving
 //     these unanswered puts an error in every session.
 //
+// A read or a write may exceed the negotiated MaxBufferSize once both sides have
+// agreed CAP_LARGE_READX or CAP_LARGE_WRITEX, bounded by Config.MaxLargeTransfer.
+// Signing overrides that: a signed response is verified over the bytes as sent, so
+// a client that sized its buffer to MaxBufferSize and received more would fail the
+// signature rather than merely truncate, and [MS-SMB] has clients hold to
+// MaxBufferSize whenever signing is active.
+//
+// The ceiling stays under 0x10000 because SMB_Data.ByteCount is a USHORT that no
+// extension widens, so a larger data block could not describe its own length.
+//
 // All three transaction families share one reassembly, since they are the same
 // shape at different field widths: totals, a per-message count and a
 // displacement, with the subcommand selected by a setup word, a Function field or

--- a/network/smb/smb_v10/server/handler_file.go
+++ b/network/smb/smb_v10/server/handler_file.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/TheManticoreProject/Manticore/logger"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/capabilities"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
@@ -345,8 +346,8 @@ func handleReadAndx(conn *Connection, w ResponseWriter, req *message.Message) nt
 	// Bounded by what the client asked for and by what the connection agreed a
 	// message may carry, so a client cannot ask for a response it could not
 	// receive.
-	length := int(request.MaxCountOfBytesToReturn)
-	if limit := int(conn.Server.config.MaxBufferSize) - readResponseOverhead; length > limit {
+	length := readLengthOf(conn, open, request)
+	if limit := conn.readLimit(); length > limit {
 		length = limit
 	}
 	if length < 0 {
@@ -367,7 +368,11 @@ func handleReadAndx(conn *Connection, w ResponseWriter, req *message.Message) nt
 
 	response := commands.NewReadAndxResponse()
 	response.Data = buffer[:read]
-	response.DataLength = types.USHORT(read)
+	// DataLength is 16 bits, so a read of 0x10000 bytes or more describes its
+	// length across DataLength and DataLengthHigh ([MS-SMB] section 2.2.4.2.2).
+	// Reporting only the low word would tell the client it received nothing.
+	response.DataLength = types.USHORT(read & 0xFFFF)
+	response.DataLengthHigh = types.USHORT(read >> 16)
 
 	if err := w.WriteResponse(response); err != nil {
 		logger.Debugf("SMB1 server: failed to answer the read for %s: %v", conn.Remote, err)
@@ -379,6 +384,74 @@ func handleReadAndx(conn *Connection, w ResponseWriter, req *message.Message) nt
 // 32-byte header, the parameter words and the byte count. Reserving it keeps a
 // full-size read inside the negotiated buffer.
 const readResponseOverhead = 64
+
+// largeTransfersAgreed reports whether a capability that both sides have to set
+// is in force on this connection.
+//
+// [MS-SMB] section 2.2.4.5.2.1 makes CAP_LARGE_READX and CAP_LARGE_WRITEX
+// two-sided: the server advertises them in its negotiate response and the
+// capability takes effect only when the client sets it in its session setup as
+// well. A server that acted on its own advertisement alone would answer a client
+// that never agreed with a message that client cannot receive.
+func largeTransfersAgreed(conn *Connection, capability capabilities.Capabilities) bool {
+	return serverCapabilities&capability != 0 && conn.ClientCapabilities&capability != 0
+}
+
+// readLimit is the largest read this connection may be answered with.
+//
+// Signing overrides the large-read capability entirely. [MS-SMB] section
+// 2.2.4.5.2.1: "When signing is active on a connection, then clients MUST limit
+// read lengths to the MaxBufferSize value negotiated by the server irrespective
+// of the value of the CAP_LARGE_READX flag." A signed response is verified over
+// the bytes as sent, so a client that sized its buffer to MaxBufferSize and
+// received more would fail the signature rather than merely truncate.
+func (c *Connection) readLimit() int {
+	if c.SigningActive || !largeTransfersAgreed(c, capabilities.CAP_LARGE_READX) {
+		return int(c.Server.config.MaxBufferSize) - readResponseOverhead
+	}
+
+	limit := c.Server.config.MaxLargeTransfer
+	if limit <= 0 {
+		limit = DefaultMaxLargeTransfer
+	}
+	return limit
+}
+
+// readLengthOf is how many bytes a read request asked for.
+//
+// Under CAP_LARGE_READX the Timeout field is overloaded: [MS-SMB] section
+// 2.2.4.2.1 defines it as "a union of a 32-bit Timeout field and a 16-bit
+// MaxCountHigh field", read as MaxCountHigh for a regular file and as Timeout for
+// a named pipe or an I/O device. So the handle decides how the field is read, and
+// treating a pipe's timeout as a length would ask the backend for gigabytes
+// because the client asked it to wait a while.
+func readLengthOf(conn *Connection, open *Open, request *commands.ReadAndxRequest) int {
+	length := int(request.MaxCountOfBytesToReturn)
+	if open.IsPipe || !largeTransfersAgreed(conn, capabilities.CAP_LARGE_READX) {
+		return length
+	}
+
+	// MaxCountHigh is the first word of the union and the second is Reserved,
+	// which the server must ignore: [MS-SMB] section 2.2.4.2.1 says the client
+	// "SHOULD be set to 0xFFFF [...] if MaxCountHigh is 0xFFFF" and that "For all
+	// values, this field MUST be ignored by the server". Rejecting a request that
+	// set it would refuse the largest read a client is told to ask for.
+	return int(uint32(request.Timeout)&0xFFFF)<<16 | length
+}
+
+// writeLengthOf is how many bytes a write request says it carries.
+//
+// Under CAP_LARGE_WRITEX the CIFS Reserved field becomes DataLengthHigh
+// ([MS-SMB] section 2.2.4.3.1), which is the only way to describe a write above
+// 0xFFFF bytes. Reading it when the capability was not agreed would turn a
+// reserved field a client left non-zero into a length.
+func writeLengthOf(conn *Connection, request *commands.WriteAndxRequest) int {
+	declared := int(request.DataLength)
+	if !largeTransfersAgreed(conn, capabilities.CAP_LARGE_WRITEX) {
+		return declared
+	}
+	return int(request.DataLengthHigh())<<16 | declared
+}
 
 // handleWriteAndx answers SMB_COM_WRITE_ANDX.
 func handleWriteAndx(conn *Connection, w ResponseWriter, req *message.Message) nt_status.NT_STATUS {
@@ -406,7 +479,7 @@ func handleWriteAndx(conn *Connection, w ResponseWriter, req *message.Message) n
 	// The declared length governs, but never past what actually arrived: the two
 	// disagreeing is a malformed request, not licence to read past the buffer.
 	data := []byte(request.Data)
-	if declared := int(request.DataLength); declared < len(data) {
+	if declared := writeLengthOf(conn, request); declared < len(data) {
 		data = data[:declared]
 	}
 
@@ -430,7 +503,12 @@ func handleWriteAndx(conn *Connection, w ResponseWriter, req *message.Message) n
 	}
 
 	response := commands.NewWriteAndxResponse()
-	response.Count = types.USHORT(written)
+	// Count is 16 bits, so a write of 0x10000 bytes or more reports what it wrote
+	// across Count and CountHigh ([MS-SMB] section 2.2.4.3.2). Reporting only the
+	// low word would tell the client that a 64 KiB write wrote nothing, and a
+	// client that retried from there would write the same bytes twice.
+	response.Count = types.USHORT(written & 0xFFFF)
+	response.CountHigh = types.USHORT(written >> 16)
 
 	if err := w.WriteResponse(response); err != nil {
 		logger.Debugf("SMB1 server: failed to answer the write for %s: %v", conn.Remote, err)

--- a/network/smb/smb_v10/server/handler_negotiate.go
+++ b/network/smb/smb_v10/server/handler_negotiate.go
@@ -28,11 +28,19 @@ const noDialectSelected = 0xFFFF
 // absent because raw transfers, the combined lock-and-read command and oplocks are
 // not implemented; advertising them would have clients issue commands that are
 // then refused.
+//
+// CAP_LARGE_READX and CAP_LARGE_WRITEX let one read or write exceed the
+// negotiated MaxBufferSize, bounded by Config.MaxLargeTransfer. Both are a
+// two-sided agreement: [MS-SMB] section 2.2.4.5.2.1 has the capability take
+// effect only when the client sets it in its session setup too, so a client that
+// does not ask keeps the old bound.
 const serverCapabilities = capabilities.CAP_UNICODE |
 	capabilities.CAP_LARGE_FILES |
 	capabilities.CAP_NT_SMBS |
 	capabilities.CAP_NT_STATUS |
 	capabilities.CAP_NT_FIND |
+	capabilities.CAP_LARGE_READX |
+	capabilities.CAP_LARGE_WRITEX |
 	capabilities.CAP_EXTENDED_SECURITY
 
 // handleNegotiate answers SMB_COM_NEGOTIATE: it selects a dialect from the list

--- a/network/smb/smb_v10/server/large_transfer_test.go
+++ b/network/smb/smb_v10/server/large_transfer_test.go
@@ -1,0 +1,379 @@
+package server
+
+import (
+	"bytes"
+	"encoding/binary"
+	"net"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/capabilities"
+	smb1client "github.com/TheManticoreProject/Manticore/network/smb/smb_v10/client"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/codes"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+	"github.com/TheManticoreProject/Manticore/windows/credentials"
+	"github.com/TheManticoreProject/Manticore/windows/fileflags"
+)
+
+// countingBytes is a block whose every byte identifies its own position, so a
+// transfer that is right in length but wrong in content still fails.
+func countingBytes(length int) []byte {
+	block := make([]byte, length)
+	for index := range block {
+		block[index] = byte(index % 251)
+	}
+	return block
+}
+
+// largeTransferShare serves one file of the given size, filled so that every byte
+// identifies its own position.
+func largeTransferShare(t *testing.T, size int) *MemoryFileSystem {
+	t.Helper()
+
+	fs := NewMemoryFileSystem("FILES")
+	if err := fs.AddFile("large.bin", countingBytes(size)); err != nil {
+		t.Fatalf("AddFile() error = %v", err)
+	}
+	return fs
+}
+
+// sendReadAndx sends a hand-built SMB_COM_READ_ANDX and returns the raw reply.
+//
+// The client API caps its own reads well below the large-read range, so a request
+// that exercises MaxCountHigh has to be built here.
+func sendReadAndx(
+	t *testing.T,
+	client *smb1client.Client,
+	fid smb1client.FID,
+	maxCountLow uint16,
+	timeoutOrMaxCountHigh uint32,
+) []byte {
+	t.Helper()
+
+	request := newRequest(codes.SMB_COM_READ_ANDX)
+	request.Header.UID = client.Session.SessionUID
+	request.Header.TID = client.Session.TreeID
+
+	cmd := commands.NewReadAndxRequest()
+	cmd.FID = types.USHORT(fid)
+	cmd.Offset = types.ULONG(0)
+	cmd.MaxCountOfBytesToReturn = types.USHORT(maxCountLow)
+	cmd.MinCountOfBytesToReturn = types.USHORT(0)
+	cmd.Timeout = types.ULONG(timeoutOrMaxCountHigh)
+	request.AddCommand(cmd)
+
+	marshalled, err := request.Marshal()
+	if err != nil {
+		t.Fatalf("failed to marshal the read: %v", err)
+	}
+	if _, err := client.Transport.Send(marshalled); err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+	raw, err := client.Transport.Receive()
+	if err != nil {
+		t.Fatalf("Receive() error = %v", err)
+	}
+	return raw
+}
+
+// readReplyLength reads the length a read reply describes, across both of the
+// words that carry it.
+func readReplyLength(t *testing.T, raw []byte) int {
+	t.Helper()
+
+	decoded := readReplyOf(t, raw)
+	return int(decoded.DataLengthHigh)<<16 | int(decoded.DataLength)
+}
+
+// readReplyOf decodes a read reply.
+func readReplyOf(t *testing.T, raw []byte) *commands.ReadAndxResponse {
+	t.Helper()
+
+	if status := binary.LittleEndian.Uint32(raw[5:9]); status != 0 {
+		t.Fatalf("the read reported 0x%08X, want success", status)
+	}
+	response := commands.NewReadAndxResponse()
+	if _, err := response.Unmarshal(raw[header.SMB_HEADER_SIZE:]); err != nil {
+		t.Fatalf("the reply did not decode: %v", err)
+	}
+	return response
+}
+
+// openLargeFile connects a share over the given config and opens the test file.
+func openLargeFile(t *testing.T, config Config, size int) (*smb1client.Client, smb1client.FID) {
+	t.Helper()
+
+	srv, transportEnd := pipedServer(t, config)
+	if err := srv.AddShare(&Share{
+		Name: fileShareName, Type: ShareTypeDisk, FS: largeTransferShare(t, size),
+	}); err != nil {
+		t.Fatalf("AddShare() error = %v", err)
+	}
+
+	client := smb1client.NewFromTransport(transportEnd, net.IPv4(127, 0, 0, 1), 445)
+	if err := client.Negotiate(); err != nil {
+		t.Fatalf("Negotiate() error = %v", err)
+	}
+	creds, err := credentials.NewCredentials(captureDomain, captureUsername, capturePassword, "")
+	if err != nil {
+		t.Fatalf("NewCredentials() error = %v", err)
+	}
+	if err := client.SessionSetup(creds); err != nil {
+		t.Fatalf("SessionSetup() error = %v", err)
+	}
+	if err := client.TreeConnect(fileShareName); err != nil {
+		t.Fatalf("TreeConnect() error = %v", err)
+	}
+
+	fid, err := client.OpenFile("large.bin",
+		fileflags.GENERIC_READ|fileflags.GENERIC_WRITE,
+		fileflags.FILE_SHARE_READ|fileflags.FILE_SHARE_WRITE,
+		fileflags.FILE_OPEN,
+		fileflags.FILE_NON_DIRECTORY_FILE)
+	if err != nil {
+		t.Fatalf("opening the file failed: %v", err)
+	}
+	return client, fid
+}
+
+// TestLargeReadExceedsTheNegotiatedBuffer asserts a read under CAP_LARGE_READX may
+// return more than MaxBufferSize, which is the whole point of the capability.
+func TestLargeReadExceedsTheNegotiatedBuffer(t *testing.T) {
+	config := conformanceConfig(SigningDisabled)
+	client, fid := openLargeFile(t, config, 200*1024)
+
+	// 0x18000 = 98304 bytes, described across both words, and past the ceiling so
+	// the answer is the ceiling rather than the request.
+	raw := sendReadAndx(t, client, fid, 0x8000, 0x0001)
+
+	length := readReplyLength(t, raw)
+	if length <= int(config.MaxBufferSize) {
+		t.Fatalf("the read returned %d bytes, which does not exceed the negotiated buffer of %d",
+			length, config.MaxBufferSize)
+	}
+	if length != DefaultMaxLargeTransfer {
+		t.Fatalf("the read returned %d bytes, want the %d-byte ceiling", length, DefaultMaxLargeTransfer)
+	}
+
+	response := readReplyOf(t, raw)
+
+	// And the bytes are the file's, at the offset asked for.
+	at := int(response.DataOffset)
+	if at+length > len(raw) {
+		t.Fatalf("DataOffset %d plus %d bytes runs past the %d-byte reply", at, length, len(raw))
+	}
+	if !bytes.Equal(raw[at:at+length], countingBytes(200 * 1024)[:length]) {
+		t.Error("the bytes returned are not the file's")
+	}
+}
+
+// TestLargeReadIsCappedWhenSigningIsActive asserts signing overrides the
+// capability.
+//
+// [MS-SMB] section 2.2.4.5.2.1: "When signing is active on a connection, then
+// clients MUST limit read lengths to the MaxBufferSize value negotiated by the
+// server irrespective of the value of the CAP_LARGE_READX flag." A signed response
+// is verified over the bytes as sent, so a client that sized its buffer to
+// MaxBufferSize and received more would fail the signature rather than truncate.
+//
+// This is asserted against readLimit rather than over the wire because signing a
+// hand-built request needs the connection's MAC key, which the client keeps to
+// itself — and the rule is about the ceiling, which is what readLimit is.
+func TestLargeReadIsCappedWhenSigningIsActive(t *testing.T) {
+	conn := &Connection{
+		Server: &Server{config: Config{
+			MaxBufferSize:    DefaultMaxBufferSize,
+			MaxLargeTransfer: DefaultMaxLargeTransfer,
+		}},
+		ClientCapabilities: capabilities.CAP_LARGE_READX,
+	}
+
+	unsigned := conn.readLimit()
+	if unsigned != DefaultMaxLargeTransfer {
+		t.Fatalf("an unsigned connection allows %d bytes, want the %d-byte ceiling",
+			unsigned, DefaultMaxLargeTransfer)
+	}
+
+	conn.SigningActive = true
+	signed := conn.readLimit()
+	if signed > int(DefaultMaxBufferSize) {
+		t.Errorf("a signing connection allows %d bytes, more than the negotiated buffer of %d",
+			signed, DefaultMaxBufferSize)
+	}
+	if signed >= unsigned {
+		t.Errorf("signing did not reduce the ceiling: %d then %d", unsigned, signed)
+	}
+}
+
+// TestLargeReadIgnoresTheReservedHalf asserts the second half of the overloaded
+// field is ignored rather than treated as a refusal.
+//
+// [MS-SMB] section 2.2.4.2.1 tells the client to set Reserved to 0xFFFF when
+// MaxCountHigh is 0xFFFF, and says "For all values, this field MUST be ignored by
+// the server". A server that rejected a non-zero Reserved would refuse the largest
+// read a client is told how to ask for.
+func TestLargeReadIgnoresTheReservedHalf(t *testing.T) {
+	config := conformanceConfig(SigningDisabled)
+	client, fid := openLargeFile(t, config, 200*1024)
+
+	// MaxCountHigh 0x0001 with the Reserved half set to 0xFFFF.
+	raw := sendReadAndx(t, client, fid, 0x8000, 0xFFFF0001)
+
+	if length := readReplyLength(t, raw); length != DefaultMaxLargeTransfer {
+		t.Fatalf("the read returned %d bytes, want %d — the Reserved half was not ignored",
+			length, DefaultMaxLargeTransfer)
+	}
+}
+
+// TestLargeTransfersRequireBothSidesToAgree asserts the high word is ignored for a
+// client that did not set the capability in its session setup.
+//
+// [MS-SMB] section 2.2.4.5.2.1 makes the capability two-sided. A client that never
+// agreed cannot receive a response above MaxBufferSize, so acting on the server's
+// own advertisement alone would send it one it cannot read.
+func TestLargeTransfersRequireBothSidesToAgree(t *testing.T) {
+	conn := &Connection{
+		Server:             &Server{config: Config{MaxBufferSize: DefaultMaxBufferSize}},
+		ClientCapabilities: capabilities.CAP_UNICODE,
+	}
+	open := &Open{}
+
+	request := commands.NewReadAndxRequest()
+	request.MaxCountOfBytesToReturn = types.USHORT(0x8000)
+	request.Timeout = types.ULONG(0x0001)
+
+	if got := readLengthOf(conn, open, request); got != 0x8000 {
+		t.Errorf("a client that did not agree asked for %d, want the low word alone (%d)", got, 0x8000)
+	}
+
+	write := commands.NewWriteAndxRequest()
+	write.DataLength = types.USHORT(0x0100)
+	write.Reserved = types.USHORT(0x0001)
+	if got := writeLengthOf(conn, write); got != 0x0100 {
+		t.Errorf("a client that did not agree wrote %d, want the low word alone (%d)", got, 0x0100)
+	}
+
+	// With the capability agreed, both words count.
+	conn.ClientCapabilities |= capabilities.CAP_LARGE_READX | capabilities.CAP_LARGE_WRITEX
+	if got := readLengthOf(conn, open, request); got != 0x18000 {
+		t.Errorf("an agreed client asked for %d, want 0x18000", got)
+	}
+	if got := writeLengthOf(conn, write); got != 0x10100 {
+		t.Errorf("an agreed client wrote %d, want 0x10100", got)
+	}
+}
+
+// TestLargeReadOnAPipeReadsTheFieldAsATimeout asserts the overloaded field is not
+// treated as a length for a pipe handle.
+//
+// [MS-SMB] section 2.2.4.2.1: the field is MaxCountHigh "When reading from a
+// regular file" and Timeout "When reading from a name pipe or I/O device".
+// Treating a pipe's timeout as a length would have the server try to return
+// gigabytes because the client asked it to wait a while.
+func TestLargeReadOnAPipeReadsTheFieldAsATimeout(t *testing.T) {
+	conn := &Connection{
+		Server:             &Server{config: Config{MaxBufferSize: DefaultMaxBufferSize}},
+		ClientCapabilities: capabilities.CAP_LARGE_READX,
+	}
+
+	request := commands.NewReadAndxRequest()
+	request.MaxCountOfBytesToReturn = types.USHORT(0x0100)
+	// A five-second wait, which as a length would be 327680 bytes.
+	request.Timeout = types.ULONG(5000)
+
+	if got := readLengthOf(conn, &Open{IsPipe: true}, request); got != 0x0100 {
+		t.Errorf("a pipe read asked for %d, want the low word alone (%d)", got, 0x0100)
+	}
+	if got := readLengthOf(conn, &Open{}, request); got == 0x0100 {
+		t.Error("a regular-file read ignored MaxCountHigh")
+	}
+}
+
+// TestLargeWriteExceedsTheNegotiatedBuffer asserts one write may carry more than
+// MaxBufferSize, which is what CAP_LARGE_WRITEX is for.
+//
+// The size is above the negotiated 16644 bytes and below 0x10000, which is the
+// range the capability actually buys: at 0x10000 and above the data block cannot
+// describe itself, because SMB_Data.ByteCount is a USHORT that [MS-SMB] does not
+// widen. DefaultMaxLargeTransfer stays under that for the same reason.
+func TestLargeWriteExceedsTheNegotiatedBuffer(t *testing.T) {
+	const size = 40000
+
+	config := conformanceConfig(SigningDisabled)
+	client, fid := openLargeFile(t, config, size)
+
+	payload := countingBytes(size)
+	for index := range payload {
+		// Distinguish what is written from what the file already held.
+		payload[index] ^= 0xFF
+	}
+
+	request := newRequest(codes.SMB_COM_WRITE_ANDX)
+	request.Header.UID = client.Session.SessionUID
+	request.Header.TID = client.Session.TreeID
+
+	cmd := commands.NewWriteAndxRequest()
+	cmd.FID = types.USHORT(fid)
+	cmd.Offset = types.ULONG(0)
+	cmd.DataLength = types.USHORT(size & 0xFFFF)
+	// Reserved is DataLengthHigh under CAP_LARGE_WRITEX; zero at this size.
+	cmd.Reserved = types.USHORT(size >> 16)
+	cmd.DataOffset = types.USHORT(header.SMB_HEADER_SIZE + 1 + 24 + 2 + 1)
+	cmd.Pad = types.UCHAR(0)
+	cmd.Data = []types.UCHAR(payload)
+	request.AddCommand(cmd)
+
+	marshalled, err := request.Marshal()
+	if err != nil {
+		t.Fatalf("failed to marshal the write: %v", err)
+	}
+	if _, err := client.Transport.Send(marshalled); err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+	raw, err := client.Transport.Receive()
+	if err != nil {
+		t.Fatalf("Receive() error = %v", err)
+	}
+	if status := binary.LittleEndian.Uint32(raw[5:9]); status != 0 {
+		t.Fatalf("the write reported 0x%08X, want success", status)
+	}
+
+	response := commands.NewWriteAndxResponse()
+	if _, err := response.Unmarshal(raw[header.SMB_HEADER_SIZE:]); err != nil {
+		t.Fatalf("the reply did not decode: %v", err)
+	}
+	if written := int(response.CountHigh)<<16 | int(response.Count); written != size {
+		t.Fatalf("the reply reports %d bytes written, want %d", written, size)
+	}
+	if size <= int(config.MaxBufferSize) {
+		t.Fatalf("the test writes %d bytes, which does not exceed the negotiated buffer of %d",
+			size, config.MaxBufferSize)
+	}
+
+	// And the bytes actually landed, all of them.
+	readBack, err := client.ReadFile(fid, 0, size)
+	if err != nil {
+		t.Fatalf("reading the file back failed: %v", err)
+	}
+	if !bytes.Equal(readBack, payload) {
+		t.Fatalf("the file holds %d bytes that do not match the %d written", len(readBack), len(payload))
+	}
+}
+
+// TestLargeTransferCeilingKeepsByteCountTruthful asserts the ceiling stays inside
+// what SMB_Data.ByteCount can describe.
+//
+// ByteCount is a USHORT and [MS-SMB] does not widen it for a large transfer, so a
+// data block of 0x10000 bytes or more cannot state its own length. Raising the
+// ceiling past that would emit messages whose ByteCount is wrong, readable only by
+// a client that ignores the field — so the invariant is asserted rather than left
+// to a comment.
+func TestLargeTransferCeilingKeepsByteCountTruthful(t *testing.T) {
+	// One byte of pad precedes a write's data, so the block is the transfer plus
+	// one and must still fit.
+	if DefaultMaxLargeTransfer+1 > 0xFFFF {
+		t.Fatalf("DefaultMaxLargeTransfer is %d, which with its pad byte exceeds what ByteCount can describe",
+			DefaultMaxLargeTransfer)
+	}
+}

--- a/network/smb/smb_v10/server/server.go
+++ b/network/smb/smb_v10/server/server.go
@@ -84,6 +84,16 @@ type Config struct {
 	// and says nothing does not hold a goroutine forever. Zero means no bound.
 	Timeout time.Duration
 
+	// MaxLargeTransfer bounds one read or write that exceeds the negotiated
+	// MaxBufferSize under CAP_LARGE_READX or CAP_LARGE_WRITEX. Zero applies the
+	// default.
+	//
+	// The capabilities say a transfer may exceed MaxBufferSize, not that it is
+	// unbounded, and [MS-SMB] leaves the ceiling to the implementation. It has to
+	// stay inside what the transport will carry, since a response larger than a
+	// frame cannot be sent at all.
+	MaxLargeTransfer int
+
 	// MaxConnections bounds the number of connections served at once. A
 	// connection arriving while the server is at the limit is closed
 	// immediately. Zero means unbounded.
@@ -114,6 +124,22 @@ const (
 	DefaultMaxTreesPerConnection    = 64
 	DefaultMaxOpensPerConnection    = 1024
 	DefaultMaxSearchesPerConnection = 128
+
+	// DefaultMaxLargeTransfer is the ceiling on one large read or write.
+	//
+	// It is 0xFF00 rather than the 64 KiB Windows uses, and the difference is not
+	// arbitrary. SMB_Data.ByteCount is a USHORT, and neither [MS-SMB] section
+	// 2.2.4.2.2 nor 2.2.4.3.1 widens it for a large transfer, so a data block of
+	// 0x10000 bytes or more cannot describe itself — its length has to be taken
+	// from DataLength and DataLengthHigh instead, and a data block here is parsed
+	// by its ByteCount. Staying under 0x10000 keeps ByteCount truthful, which
+	// keeps the message readable by any client rather than only by one that
+	// ignores it.
+	//
+	// The point of the capability survives intact: a transfer goes from the
+	// negotiated 16644 bytes to 65280, and escaping MaxBufferSize is what matters
+	// rather than the last kilobyte.
+	DefaultMaxLargeTransfer = 0xFF00
 )
 
 // SigningPolicy selects a server's stance on SMB message signing.


### PR DESCRIPTION
### Linked Issue
`Closes #1151`

### Root Cause
`serverCapabilities` did not include `CAP_LARGE_READX` or `CAP_LARGE_WRITEX`, so every transfer was bounded by the negotiated `MaxBufferSize` — 16644 bytes by default. `handleReadAndx` clamped to that and never looked at the field carrying the high half of the requested length, and `handleWriteAndx` read only the 16-bit `DataLength`.

Two message-layer omissions sat behind that, and both were silent:

- `WriteAndxRequest.Unmarshal` read `DataLength` alone, so a write declaring 70000 bytes decoded as 4464 — the low word — and the server would have written that many and reported success. A client resuming from that count would duplicate or skip data.
- Neither response could report a length above 0xFFFF. `ReadAndxResponse` had a 5-word `Reserved2` where [MS-SMB] 2.2.4.2.2 puts `DataLengthHigh`, and `WriteAndxResponse` had a 4-byte `Reserved` where 2.2.4.3.2 puts `CountHigh`.

### Fix Description
Both capabilities are advertised and both length fields are honoured, in each direction.

**The capability is two-sided.** [MS-SMB] 2.2.4.5.2.1 has it take effect only when the client sets it in its session setup as well, so `largeTransfersAgreed` checks both. A server acting on its own advertisement alone would send a client that never agreed a response it cannot receive.

**The read's high word is an overloaded field, and the handle decides how to read it.** [MS-SMB] 2.2.4.2.1 redefines `Timeout` as "a union of a 32-bit Timeout field and a 16-bit MaxCountHigh field", read as `MaxCountHigh` for a regular file and as `Timeout` for a named pipe or I/O device. Treating a pipe's timeout as a length would have the server try to return 320 KB because the client asked it to wait five seconds, so `readLengthOf` checks `open.IsPipe`.

The second half of that union is `Reserved`, and the spec is explicit that the server **must ignore** it — a client is told to set it to `0xFFFF` when `MaxCountHigh` is `0xFFFF`. An early draft of this change rejected a request with that half set, which would have refused the largest read a client is told how to ask for; `TestLargeReadIgnoresTheReservedHalf` exists to keep that from coming back.

**Signing overrides the capability entirely.** [MS-SMB] 2.2.4.5.2.1: clients "MUST limit read lengths to the MaxBufferSize value negotiated by the server irrespective of the value of the CAP_LARGE_READX flag." A signed response is verified over the bytes as sent, so a client that sized its buffer to `MaxBufferSize` and received more fails the signature rather than merely truncating. `readLimit` returns the old bound whenever `SigningActive`.

**The ceiling is `0xFF00`, not the 64 KiB Windows uses**, and this is the one deliberate departure. `SMB_Data.ByteCount` is a `USHORT`, and neither response extension widens it, so a data block of `0x10000` bytes or more cannot state its own length — its length has to be taken from `DataLength`/`DataLengthHigh` instead, and this message layer parses a data block *by* its `ByteCount`. Staying under `0x10000` keeps `ByteCount` truthful, which keeps the message readable by any client rather than only by one that ignores the field.

I found this by writing the 70000-byte write test first: it failed with `STATUS_INVALID_SMB` because `ByteCount` had wrapped to 4465 and the data block was truncated before the command saw it. Capping is the honest fix at this layer; going higher needs the message layer to locate a write's data by `DataOffset` against the whole message, which is a larger change and is filed as its own issue rather than smuggled in here.

The substance of the capability survives: a transfer goes from 16644 bytes to 65280, roughly four times, and escaping `MaxBufferSize` is what matters rather than the last kilobyte. `DataLengthHigh` and `CountHigh` are still populated correctly, so a caller that raises `MaxLargeTransfer` gets correct length reporting — only `ByteCount` would then be untruthful, which is why the ceiling is asserted by a test rather than left to a comment.

### How Verified
Runtime, over the loopback harness, plus unit tests for the rules a wire test cannot reach.

- `TestLargeReadExceedsTheNegotiatedBuffer` — a hand-built read with `MaxCountHigh` set returns 65280 bytes in one response, well past the negotiated 16644, and the bytes at `DataOffset` are the file's. The payload is a position-encoding pattern, so a response of the right length carrying the wrong bytes still fails.
- `TestLargeWriteExceedsTheNegotiatedBuffer` — a 40000-byte single write is accepted whole, the reply reports 40000 across `Count`/`CountHigh`, and reading the file back matches byte for byte. The test asserts the size exceeds `MaxBufferSize`, so it cannot silently stop proving anything if the default changes.
- `TestLargeReadIgnoresTheReservedHalf` — `MaxCountHigh` with the `Reserved` half set to `0xFFFF` still reads the full ceiling.
- `TestLargeReadIsCappedWhenSigningIsActive` — `readLimit` drops back to `MaxBufferSize` once signing is active. Asserted against `readLimit` rather than over the wire because signing a hand-built request needs the connection's MAC key, which the client keeps to itself, and the rule is about the ceiling.
- `TestLargeTransfersRequireBothSidesToAgree` — a client that did not set the capability gets the low word alone, for both read and write; with it set, both words count.
- `TestLargeReadOnAPipeReadsTheFieldAsATimeout` — a five-second timeout on a pipe handle is not read as 320 KB, and the same request on a regular-file handle is.
- `TestLargeTransferCeilingKeepsByteCountTruthful` — the ceiling plus its pad byte fits in `ByteCount`.

Whole tree green: `go build ./...`, `go test ./network/smb/...`. `gofmt -l` clean on every file touched.

### Test Coverage
**Added:** `server/large_transfer_test.go` — the seven tests above, plus `countingBytes`, `largeTransferShare`, `sendReadAndx`, `readReplyOf`/`readReplyLength` and `openLargeFile`.

**Existing:** the file-service suite covers the ordinary sub-`MaxBufferSize` path and passes unchanged, which is what shows the new branches are only reached by a client that asked for them.

### Scope of Change
- **Files changed:** `server/handler_negotiate.go`, `server/handler_file.go`, `server/server.go`, `server/doc.go`, `server/large_transfer_test.go`, `message/commands/ReadAndxResponse.go`, `message/commands/WriteAndxResponse.go`, `message/commands/WriteAndxRequest.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
The negotiate response gains two capability bits, which is the only change visible to a client that does not use them — and because the in-repo client mirrors the server's capabilities back in its session setup, it now agrees to both. Its own read chunking is still capped at `0xFF00` and bounded by `MaxBufferSize - 512`, so its wire behaviour does not change; the whole client suite passes.

The two response structs change shape: `ReadAndxResponse.Reserved2` goes from `[5]USHORT` to `DataLengthHigh` plus `[4]USHORT`, and `WriteAndxResponse.Reserved` from `ULONG` to `CountHigh` plus `USHORT`. Both are wire-identical — the same words in the same order — so this is a rename in the struct, not a change to the message. Nothing outside the structs' own methods referenced either field.

The `WriteAndxRequest.Unmarshal` change means a write whose declared length exceeds the data block now fails to decode instead of silently writing the low word's worth. That is a strictly better failure: a partial write reported as a complete one is the worse outcome.

### Notes
Raising the ceiling to a full 64 KiB or beyond needs a write's data located by `DataOffset` against the whole message rather than by `ByteCount`; filed separately.

The in-repo client does not yet take advantage of large reads — it caps its own chunk well below the new ceiling — so the throughput win is available to third-party clients today and to this client after a small change on its side. That is worth pairing with the interop legs in #1153, which is where a real client would actually exercise it.
