### PR TITLE
Fix QueryInformation2Response using an 8-byte alias for 2-byte time fields (Fixes #1162)

### DIFF
--- a/network/smb/smb_v10/message/commands/QueryInformation2Response.go
+++ b/network/smb/smb_v10/message/commands/QueryInformation2Response.go
@@ -23,19 +23,19 @@ type QueryInformation2Response struct {
 	CreateDate types.SMB_DATE
 
 	// CreateTime (2 bytes): This field is the time on CreateDate when the file was created.
-	CreationTime types.SMB_TIME
+	CreationTime types.SMB_TIME_DOS
 
 	// LastAccessDate (2 bytes): This field is the date when the file was last accessed.
 	LastAccessDate types.SMB_DATE
 
 	// LastAccessTime (2 bytes): This field is the time on LastAccessDate when the file was last accessed.
-	LastAccessTime types.SMB_TIME
+	LastAccessTime types.SMB_TIME_DOS
 
 	// LastWriteDate (2 bytes): This field is the date when data was last written to the file.
 	LastWriteDate types.SMB_DATE
 
 	// LastWriteTime (2 bytes): This field is the time on LastWriteDate when data was last written to the file.
-	LastWriteTime types.SMB_TIME
+	LastWriteTime types.SMB_TIME_DOS
 
 	// FileDataSize (4 bytes): This field contains the number of bytes in the file, in bytes. Because this size
 	// is limited to 32 bits, this command is inappropriate for files whose size is too large.
@@ -58,11 +58,11 @@ func NewQueryInformation2Response() *QueryInformation2Response {
 		// Parameters
 
 		CreateDate:         types.SMB_DATE{},
-		CreationTime:       types.SMB_TIME{},
+		CreationTime:       types.SMB_TIME_DOS{},
 		LastAccessDate:     types.SMB_DATE{},
-		LastAccessTime:     types.SMB_TIME{},
+		LastAccessTime:     types.SMB_TIME_DOS{},
 		LastWriteDate:      types.SMB_DATE{},
-		LastWriteTime:      types.SMB_TIME{},
+		LastWriteTime:      types.SMB_TIME_DOS{},
 		FileDataSize:       types.ULONG(0),
 		FileAllocationSize: types.ULONG(0),
 		FileAttributes:     types.SMB_FILE_ATTRIBUTES{},

--- a/network/smb/smb_v10/message/commands/QueryInformation2Response_wire_test.go
+++ b/network/smb/smb_v10/message/commands/QueryInformation2Response_wire_test.go
@@ -1,0 +1,89 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+)
+
+// TestQueryInformation2ResponseParameterBlockIsElevenWords asserts the response
+// occupies the parameter block [MS-CIFS] section 2.2.4.35.2 gives it.
+//
+// WordCount is 11: CreateDate(2) CreationTime(2) LastAccessDate(2)
+// LastAccessTime(2) LastWriteDate(2) LastWriteTime(2) FileDataSize(4)
+// FileAllocationSize(4) FileAttributes(2), which is 22 bytes. A time field of the
+// wrong width does not fail loudly — it pushes every field behind it out of place,
+// so the length is the assertion that catches it.
+func TestQueryInformation2ResponseParameterBlockIsElevenWords(t *testing.T) {
+	response := NewQueryInformation2Response()
+	response.CreateDate = *types.NewSMB_DATEFromDate(2001, 2, 3)
+	response.CreationTime = *types.NewSMB_TIME_DOSFromTime(4, 5, 6)
+	response.LastAccessDate = *types.NewSMB_DATEFromDate(2002, 3, 4)
+	response.LastAccessTime = *types.NewSMB_TIME_DOSFromTime(7, 8, 10)
+	response.LastWriteDate = *types.NewSMB_DATEFromDate(2003, 4, 5)
+	response.LastWriteTime = *types.NewSMB_TIME_DOSFromTime(11, 12, 14)
+	response.FileDataSize = types.ULONG(0x11223344)
+	response.FileAllocationSize = types.ULONG(0x55667788)
+
+	marshalled, err := response.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+
+	// WordCount(1) + Words + ByteCount(2).
+	const wantWords = 11
+	if got := int(marshalled[0]); got != wantWords {
+		t.Errorf("WordCount is %d, want %d", got, wantWords)
+	}
+	if want := 1 + 2*wantWords + 2; len(marshalled) != want {
+		t.Fatalf("the command is %d bytes, want %d", len(marshalled), want)
+	}
+}
+
+// TestQueryInformation2ResponseRoundTrips asserts the response decodes what it
+// encodes.
+//
+// It could not before: each time field marshalled eight bytes and was handed a
+// two-byte window on the way back, so Unmarshal failed on its own output.
+func TestQueryInformation2ResponseRoundTrips(t *testing.T) {
+	response := NewQueryInformation2Response()
+	response.CreateDate = *types.NewSMB_DATEFromDate(2001, 2, 3)
+	response.CreationTime = *types.NewSMB_TIME_DOSFromTime(4, 5, 6)
+	response.LastAccessDate = *types.NewSMB_DATEFromDate(2002, 3, 4)
+	response.LastAccessTime = *types.NewSMB_TIME_DOSFromTime(7, 8, 10)
+	response.LastWriteDate = *types.NewSMB_DATEFromDate(2003, 4, 5)
+	response.LastWriteTime = *types.NewSMB_TIME_DOSFromTime(11, 12, 14)
+	response.FileDataSize = types.ULONG(0x11223344)
+	response.FileAllocationSize = types.ULONG(0x55667788)
+
+	marshalled, err := response.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+
+	decoded := NewQueryInformation2Response()
+	if _, err := decoded.Unmarshal(marshalled); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+
+	if decoded.FileDataSize != response.FileDataSize {
+		t.Errorf("FileDataSize round-tripped to 0x%08X, want 0x%08X",
+			uint32(decoded.FileDataSize), uint32(response.FileDataSize))
+	}
+	if decoded.FileAllocationSize != response.FileAllocationSize {
+		t.Errorf("FileAllocationSize round-tripped to 0x%08X, want 0x%08X",
+			uint32(decoded.FileAllocationSize), uint32(response.FileAllocationSize))
+	}
+	if decoded.LastWriteTime != response.LastWriteTime {
+		t.Errorf("LastWriteTime round-tripped to %+v, want %+v",
+			decoded.LastWriteTime, response.LastWriteTime)
+	}
+	if decoded.LastWriteDate != response.LastWriteDate {
+		t.Errorf("LastWriteDate round-tripped to %+v, want %+v",
+			decoded.LastWriteDate, response.LastWriteDate)
+	}
+	if decoded.CreationTime != response.CreationTime {
+		t.Errorf("CreationTime round-tripped to %+v, want %+v",
+			decoded.CreationTime, response.CreationTime)
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #1162`

### Root Cause
`types.SMB_TIME` is declared `type SMB_TIME = msdtyp.FILETIME`. Those are two different types with the same name in two different specifications: [MS-DTYP]'s `FILETIME` is an 8-byte 100-nanosecond count, while [MS-CIFS]'s `SMB_TIME` is a 2-byte packed MS-DOS time of day.

`QueryInformation2Response` used that alias for its three time-of-day fields, so `Marshal` wrote 8 bytes each and produced a 40-byte parameter block where [MS-CIFS] 2.2.4.35.2 specifies 22. `Unmarshal` had been written to the specification and handed each field a 2-byte window, which an 8-byte `FILETIME` rejects — so the structure could not decode its own output.

The correct type already existed, and its own documentation names this defect: `types/SMB_TIME_DOS.go:12` reads "The 8-byte FILETIME-backed types.SMB_TIME alias is unsuitable for these fields because the wire format mandates exactly 2 bytes per SMB_TIME." `SetInformation2Request` was migrated to it; this response was missed. So this is the second half of a fix that was already started.

### Fix Description
The three time-of-day fields become `types.SMB_TIME_DOS`.

That is the whole change. `Marshal` and `Unmarshal` call `Marshal()`/`Unmarshal()` on the field generically, so correcting the declared type corrects both directions at once — the 2-byte type produces a 2-byte field and accepts the 2-byte window `Unmarshal` was already passing it.

The field documentation needed no change: the comments already read "(2 bytes)". They had been right all along and only the type disagreed with them, which is why the defect survived review.

`types.SMB_TIME` itself is left alone. Retargeting the alias would be the tidier-looking fix, but it is shared with `client_structures.go`, where `SystemTime` is genuinely a `FILETIME` from a negotiate response, so changing the alias would break a correct user in order to fix an incorrect one. Naming the right type at each use site is what `SMB_TIME_DOS` was added for.

### How Verified
Runtime, with new tests:

- `TestQueryInformation2ResponseParameterBlockIsElevenWords` — `WordCount` is 11 and the command is `1 + 22 + 2` bytes. Before the fix the parameter block was 40 bytes, so this fails loudly on the exact defect. The length is the assertion that matters, because a time field of the wrong width does not fail visibly — it pushes every field behind it out of place, and a client reads plausible-looking rubbish.
- `TestQueryInformation2ResponseRoundTrips` — the response decodes what it encodes, checking both a time and a date field and both 32-bit sizes. Before the fix `Unmarshal` failed outright on its own output.

Whole tree green: `go build ./...`, `go test ./network/smb/...`. `gofmt -l` clean on both files.

### Test Coverage
**Added:** `message/commands/QueryInformation2Response_wire_test.go` — the two tests above.

### Scope of Change
- **Files changed:** `message/commands/QueryInformation2Response.go`, `message/commands/QueryInformation2Response_wire_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Effectively none. The defect is latent: `SMB_COM_QUERY_INFORMATION2` has no server handler and no client caller, so nothing in the repository constructs this response today. There is no caller to migrate and no wire behaviour in use to change.

### Notes
Prerequisite for serving `SMB_COM_QUERY_INFORMATION2` under #1146, which is what turned this up — the handler could not have produced a correct response.

Worth a look while nearby: `types.SMB_TIME` remains an alias for `FILETIME`, which is a trap for the next person who reaches for the [MS-CIFS] name and gets the [MS-DTYP] type. Renaming it to something that says `FILETIME`, and keeping `SMB_TIME` for the 2-byte form, would remove the footgun; that is a wider rename than this fix should carry.
