### PR TITLE
Fix SMB_INFO_STANDARD omitting its size and attribute fields (Fixes #1165)

### DIFF
--- a/network/smb/smb_v10/informationlevels/SMB_INFO_STANDARD.go
+++ b/network/smb/smb_v10/informationlevels/SMB_INFO_STANDARD.go
@@ -1,6 +1,7 @@
 package informationlevels
 
 import (
+	"encoding/binary"
 	"fmt"
 
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
@@ -25,7 +26,26 @@ type SMB_INFO_STANDARD struct {
 	// LastWriteTime: (2 bytes): This field contains the time when data was last
 	// written to the file.
 	Lastwritetime types.SMB_TIME_DOS
+	// FileDataSize: (4 bytes): This field contains the file size.
+	//
+	// [MS-CIFS] describes this as the size "in filesystem allocation units" and
+	// AllocationSize as "the size of the filesystem allocation unit, in bytes",
+	// but every implementation puts a byte count in both, and the neighbouring
+	// SMB_QUERY_FILE_STANDARD_INFO says bytes outright for the same quantities. A
+	// client reads bytes, so bytes is what belongs here.
+	Filedatasize types.ULONG
+	// AllocationSize: (4 bytes): This field contains the allocated size of the
+	// file, in bytes. See the note on FileDataSize about the specification's
+	// wording.
+	Allocationsize types.ULONG
+	// Attributes: (2 bytes): This field contains the file attributes.
+	Attributes types.SMB_FILE_ATTRIBUTES
 }
+
+// SMB_INFO_STANDARD_SIZE is the size of the structure on the wire: six 2-byte
+// date and time fields, two 4-byte sizes and a 2-byte attribute word, per
+// [MS-CIFS] section 2.2.8.3.1.
+const SMB_INFO_STANDARD_SIZE = 22
 
 // marshaler is the common 2-byte (de)serialization interface implemented by
 // SMB_DATE and SMB_TIME_DOS.
@@ -34,7 +54,8 @@ type infoStandardField interface {
 	Unmarshal([]byte) (int, error)
 }
 
-// Marshal serializes the SMB_INFO_STANDARD into a byte slice (12 bytes).
+// Marshal serializes the SMB_INFO_STANDARD into a byte slice
+// (SMB_INFO_STANDARD_SIZE bytes).
 //
 // Returns:
 // - A byte slice containing the marshalled information level structure
@@ -56,6 +77,18 @@ func (s *SMB_INFO_STANDARD) Marshal() ([]byte, error) {
 		marshalled_struct = append(marshalled_struct, b...)
 	}
 
+	// Then the two sizes and the attribute word.
+	sizes := make([]byte, 8)
+	binary.LittleEndian.PutUint32(sizes[0:4], uint32(s.Filedatasize))
+	binary.LittleEndian.PutUint32(sizes[4:8], uint32(s.Allocationsize))
+	marshalled_struct = append(marshalled_struct, sizes...)
+
+	attributes, err := s.Attributes.Marshal()
+	if err != nil {
+		return nil, err
+	}
+	marshalled_struct = append(marshalled_struct, attributes...)
+
 	return marshalled_struct, nil
 }
 
@@ -68,9 +101,9 @@ func (s *SMB_INFO_STANDARD) Marshal() ([]byte, error) {
 // - The number of bytes consumed
 // - An error if unmarshalling any component fails or if the data format is invalid
 func (s *SMB_INFO_STANDARD) Unmarshal(data []byte) (int, error) {
-	// Six 2-byte DOS date/time fields = 12 bytes.
-	if len(data) < 12 {
-		return 0, fmt.Errorf("data too short for SMB_INFO_STANDARD (need 12 bytes, have %d)", len(data))
+	if len(data) < SMB_INFO_STANDARD_SIZE {
+		return 0, fmt.Errorf("data too short for SMB_INFO_STANDARD (need %d bytes, have %d)",
+			SMB_INFO_STANDARD_SIZE, len(data))
 	}
 
 	fields := []infoStandardField{
@@ -86,6 +119,17 @@ func (s *SMB_INFO_STANDARD) Unmarshal(data []byte) (int, error) {
 		}
 		offset += n
 	}
+
+	s.Filedatasize = types.ULONG(binary.LittleEndian.Uint32(data[offset : offset+4]))
+	offset += 4
+	s.Allocationsize = types.ULONG(binary.LittleEndian.Uint32(data[offset : offset+4]))
+	offset += 4
+
+	read, err := s.Attributes.Unmarshal(data[offset:])
+	if err != nil {
+		return offset, err
+	}
+	offset += read
 
 	return offset, nil
 }

--- a/network/smb/smb_v10/informationlevels/legacy_ea_info_test.go
+++ b/network/smb/smb_v10/informationlevels/legacy_ea_info_test.go
@@ -15,8 +15,15 @@ func dosTime(h, m, twoSec uint8) types.SMB_TIME_DOS {
 	return types.SMB_TIME_DOS{Hours: h, Minutes: m, TwoSeconds: twoSec}
 }
 
-// TestInfoStandardRoundTrip verifies SMB_INFO_STANDARD is 12 bytes (six 2-byte DOS
-// date/time fields) and round-trips, confirming the 2-byte SMB_TIME_DOS layout.
+// TestInfoStandardRoundTrip verifies SMB_INFO_STANDARD is the 22 bytes [MS-CIFS]
+// section 2.2.8.3.1 specifies — six 2-byte DOS date and time fields, two 4-byte
+// sizes and a 2-byte attribute word — and that it round-trips.
+//
+// The size assertion previously read 12, which was the six date and time fields
+// alone: the three trailing fields were missing from the structure, so a client
+// reading the level found no size and no attributes. The neighbouring
+// SMB_INFO_QUERY_EA_SIZE is defined as this structure plus EaSize and always
+// carried all three, which is what showed the two disagreed.
 func TestInfoStandardRoundTrip(t *testing.T) {
 	in := &informationlevels.SMB_INFO_STANDARD{
 		Creationdate:   dosDate(2021, 6, 15),
@@ -25,20 +32,37 @@ func TestInfoStandardRoundTrip(t *testing.T) {
 		Lastaccesstime: dosTime(1, 2, 3),
 		Lastwritedate:  dosDate(2023, 12, 31),
 		Lastwritetime:  dosTime(23, 59, 29),
+		Filedatasize:   0x1000,
+		Allocationsize: 0x200,
 	}
+	in.Attributes.SetAttributes(0x0020)
+
 	raw, err := in.Marshal()
 	if err != nil {
 		t.Fatalf("Marshal: %v", err)
 	}
-	if len(raw) != 12 {
-		t.Fatalf("expected 12 bytes, got %d", len(raw))
+	if len(raw) != informationlevels.SMB_INFO_STANDARD_SIZE {
+		t.Fatalf("expected %d bytes, got %d", informationlevels.SMB_INFO_STANDARD_SIZE, len(raw))
 	}
 	out := &informationlevels.SMB_INFO_STANDARD{}
-	if n, err := out.Unmarshal(raw); err != nil || n != 12 {
+	n, err := out.Unmarshal(raw)
+	if err != nil || n != informationlevels.SMB_INFO_STANDARD_SIZE {
 		t.Fatalf("Unmarshal: n=%d err=%v", n, err)
 	}
 	if *out != *in {
 		t.Errorf("mismatch:\n in  %+v\n out %+v", in, out)
+	}
+
+	// The level is a prefix of SMB_INFO_QUERY_EA_SIZE, which is that structure
+	// plus a 4-byte EaSize, so their sizes have to differ by exactly that.
+	eaSize := &informationlevels.SMB_INFO_QUERY_EA_SIZE{}
+	withEa, err := eaSize.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal SMB_INFO_QUERY_EA_SIZE: %v", err)
+	}
+	if len(withEa)-len(raw) != 4 {
+		t.Errorf("SMB_INFO_QUERY_EA_SIZE is %d bytes and SMB_INFO_STANDARD %d; they must differ by the 4-byte EaSize",
+			len(withEa), len(raw))
 	}
 }
 


### PR DESCRIPTION
### Linked Issue
`Closes #1165`

### Root Cause
The structure was modelled from the prose at the top of [MS-CIFS] section 2.2.8.3.1 — which lists "Creation, access, and last write timestamps", "File size" and "File attributes" — but only the timestamps made it into the fields. `FileDataSize`, `AllocationSize` and `Attributes` were dropped, and `Marshal`/`Unmarshal` were written to match the six fields that were there rather than the nine the field table specifies. `Unmarshal`'s own comment stated the wrong size as a fact: "Six 2-byte DOS date/time fields = 12 bytes".

The package contradicted itself, which is what makes this certain rather than a reading of the spec. `SMB_INFO_QUERY_EA_SIZE` sits beside it and carries all six timestamps *plus* `Filedatasize`, `Allocationsize`, `Attributes` and `Easize`. Section 2.2.8.3.2 defines that level as "the SMB_INFO_STANDARD data along with the size of a file's extended attributes", so by the package's own modelling `SMB_INFO_STANDARD` had to contain the three fields it was missing.

### Fix Description
The three fields are added, `Marshal` writes them after the timestamps, and `Unmarshal` reads them back. `SMB_INFO_STANDARD_SIZE` names the 22-byte total so the size lives in one place instead of being restated in a guard.

One judgement call, recorded in the code rather than left silent. [MS-CIFS] describes `FileDataSize` as the size "in filesystem allocation units" and `AllocationSize` as "the size of the filesystem allocation unit, in bytes". Taken literally that is not what any implementation does, and it disagrees with the neighbouring `SMB_QUERY_FILE_STANDARD_INFO`, which gives the same two quantities in bytes. A client reads bytes, so both fields carry bytes and the comment says why it departs from the wording.

### How Verified
Runtime. `TestInfoStandardRoundTrip` already existed and asserted `len(raw) != 12` — it had encoded the defect, so it failed immediately on the corrected structure with "expected 12 bytes, got 22". It is now the spec size, and extended two ways:

- The three new fields are populated and compared after a round trip, so they are exercised rather than merely present.
- A new assertion compares the marshalled size against `SMB_INFO_QUERY_EA_SIZE`'s and requires them to differ by exactly the 4-byte `EaSize`. That is the invariant the two levels' definitions impose on each other, and it is what would have caught the original omission — it holds only if both structures agree about what `SMB_INFO_STANDARD` contains.

Whole tree green: `go build ./...`, `go test ./network/smb/...`. `gofmt -l` clean on both files.

### Test Coverage
**Modified:** `informationlevels/legacy_ea_info_test.go` — `TestInfoStandardRoundTrip` corrected to the spec size, extended over the new fields, and given the cross-check against `SMB_INFO_QUERY_EA_SIZE`.

### Scope of Change
- **Files changed:** `informationlevels/SMB_INFO_STANDARD.go`, `informationlevels/legacy_ea_info_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Low. The defect is latent: the level has no server handler and no client caller, so nothing constructs the structure today and there is no wire behaviour in use to change. The structure grows by ten bytes and gains three fields; nothing outside its own methods and the test referenced it.

### Notes
Prerequisite for #1144, which serves this level for both find and query — the handler could not have produced a correct structure. `SMB_INFO_STANDARD` is the level a client without `CAP_NT_FIND` uses for directory enumeration, so the fields it was missing were the size and attributes of every file in a listing.

The same modelling mistake is worth looking for in the other `informationlevels` structures; the cross-check assertion added here is the cheap form of that audit for this pair.
