### PR TITLE
Serve the pre-NT information levels (Fixes #1144)

### DIFF
--- a/network/smb/smb_v10/server/doc.go
+++ b/network/smb/smb_v10/server/doc.go
@@ -14,23 +14,34 @@
 // the protocol to look functional while refusing everything that matters.
 //
 // Implemented:
+//
 //   - Listening on Direct TCP (445) and NetBIOS over TCP (139), via
 //     network/smb/common/transport.
+//
 //   - The per-connection receive loop, request decoding, the handler chain, and
 //     response framing with correlated reply headers.
+//
 //   - Error responses in both encodings: the NTSTATUS form, and the legacy
 //     SMBSTATUS class/code form for a client that did not negotiate
 //     SMB_FLAGS2_NT_STATUS_ERROR_CODES.
+//
 //   - SMB_COM_NEGOTIATE, selecting the NT LM 0.12 dialect under extended
 //     security.
+//
 //   - SMB_COM_SESSION_SETUP_ANDX, including verifying the response against a
 //     credential, establishing a session, and the guest and anonymous policies.
+//
 //   - SMB_COM_LOGOFF_ANDX.
+//
 //   - SMB_COM_ECHO.
+//
 //   - Message signing in both directions, when the policy calls for it.
+//
 //   - Tree connect and disconnect against a registered share.
+//
 //   - File service: open and create, read, write, close, flush, delete, rename,
 //     and the directory create, remove and check commands.
+//
 //   - The core-set file information commands, which describe a file without a
 //     transaction: SMB_COM_QUERY_INFORMATION and SMB_COM_SET_INFORMATION by path,
 //     and SMB_COM_QUERY_INFORMATION2 and SMB_COM_SET_INFORMATION2 on a handle.
@@ -38,17 +49,33 @@
 //     or a UTIME in seconds, so a client reading one back sees less precision than
 //     the TRANSACTION2 levels carry — a property of the wire format rather than of
 //     the storage.
+//
+//   - The pre-NT information levels, so a client that did not negotiate
+//     CAP_NT_FIND can still work: SMB_INFO_STANDARD and SMB_INFO_QUERY_EA_SIZE
+//     for find and for query, SMB_INFO_IS_NAME_VALID, SMB_QUERY_FILE_STREAM_INFO,
+//     SMB_QUERY_FILE_COMRESSION_INFO, and the SMB_INFO_ALLOCATION and
+//     SMB_INFO_VOLUME volume levels.
+//
+//     Their entries are packed rather than linked: the NT levels begin each entry
+//     with the offset of the next, and these begin with a date, so the buffer
+//     assembly has to know which model a level uses. Writing a chain terminator
+//     into a pre-NT buffer would overwrite the first entry's timestamps and
+//     produce a listing that looks valid.
+//
 //   - Directory enumeration and the information levels, over TRANSACTION2:
 //     FIND_FIRST2 and FIND_NEXT2 with search handles, the query and set levels
 //     for a path and for an open handle, and the volume levels. Requests and
 //     responses both fragment across as many messages as they need.
+//
 //   - Security descriptors and file-system controls, over NT_TRANSACT:
 //     QUERY_SECURITY_DESC, SET_SECURITY_DESC and IOCTL. SMB_COM_NT_CANCEL is
 //     accepted silently, since nothing here leaves a request outstanding.
+//
 //   - Named pipes, over TRANSACTION: a pipe is opened on a pipe share like a
 //     file, and TRANS_TRANSACT_NMPIPE writes a message to the handle and returns
 //     the answer. That write-then-read is the operation MS-RPC travels over, so a
 //     PipeHandler is all an RPC service needs to be reachable over SMB1.
+//
 //   - The volume queries a client actually asks: the TRANSACTION2 volume levels,
 //     the pass-through information classes above 0x03E8 that carry the native
 //     ones, and the legacy SMB_COM_QUERY_INFORMATION_DISK. A client asks about

--- a/network/smb/smb_v10/server/infolevels.go
+++ b/network/smb/smb_v10/server/infolevels.go
@@ -65,6 +65,10 @@ func supportedFindLevel(level uint16) bool {
 	case smbFindFileDirectoryInfo, smbFindFileFullDirectoryInfo,
 		smbFindFileNamesInfo, smbFindFileBothDirectoryInfo:
 		return true
+	case smbInfoStandard, smbInfoQueryEaSize, smbInfoQueryEasFromLst:
+		// The pre-NT levels, which a client without CAP_NT_FIND uses. Refusing
+		// them left such a client unable to list a directory at all.
+		return true
 	}
 	return false
 }
@@ -102,6 +106,14 @@ func encodeFindEntries(search *Search, count, budget int, unicode bool) ([]byte,
 		encoded = append(encoded, rendered...)
 		search.Position++
 		returned++
+	}
+
+	// Only the NT levels are linked by a leading NextEntryOffset; the pre-NT ones
+	// are packed back to back and counted by SearchCount. Clearing a "final
+	// NextEntryOffset" in a buffer of pre-NT entries would write zeroes over the
+	// first entry's creation and access dates.
+	if returned > 0 && !findLevelChains(search.InformationLevel) {
+		return encoded, returned
 	}
 
 	// The last entry's NextEntryOffset is zero, which is how a client knows to
@@ -150,6 +162,10 @@ func zeroLastNextEntryOffset(encoded []byte) {
 // whatever the server put there, so an OEM name comes out as half as many
 // characters of nonsense.
 func encodeFindEntry(level uint16, attr FileAttr, unicode bool) []byte {
+	if entry, served := encodeLegacyFindEntry(level, attr, unicode); served {
+		return entry
+	}
+
 	name := encodeWireString(attr.Name, unicode)
 
 	switch level {
@@ -222,6 +238,10 @@ func padTo4(buffer []byte) []byte {
 // encodeFileInformation renders a file in a query level, or reports that the level
 // is not served.
 func encodeFileInformation(level uint16, attr FileAttr, path string, unicode bool) ([]byte, bool) {
+	if encoded, served := encodeLegacyFileInformation(level, attr); served {
+		return encoded, true
+	}
+
 	switch level {
 	case smbQueryFileBasicInfo:
 		// Four timestamps(8 each) ExtFileAttributes(4) Reserved(4).
@@ -297,6 +317,9 @@ func encodeVolumeInformation(level uint16, volume VolumeInfo, unicode bool) ([]b
 	// most often asked about a volume.
 	if level >= smbInfoPassthrough {
 		return encodeNativeVolumeInformation(level-smbInfoPassthrough, volume, unicode)
+	}
+	if encoded, served := encodeLegacyVolumeInformation(level, volume, unicode); served {
+		return encoded, true
 	}
 
 	switch level {

--- a/network/smb/smb_v10/server/infolevels_legacy.go
+++ b/network/smb/smb_v10/server/infolevels_legacy.go
@@ -1,0 +1,253 @@
+package server
+
+import (
+	"github.com/TheManticoreProject/Manticore/encoding/utf16"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/informationlevels"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+)
+
+// The pre-NT information levels, which a client that did not negotiate
+// CAP_NT_FIND uses ([MS-CIFS] sections 2.2.8.1 to 2.2.8.3).
+const (
+	smbInfoStandard        = 0x0001
+	smbInfoQueryEaSize     = 0x0002
+	smbInfoQueryEasFromLst = 0x0003
+	smbInfoIsNameValid     = 0x0006
+
+	smbInfoAllocation = 0x0001
+	smbInfoVolume     = 0x0002
+
+	smbQueryFileStreamInfo      = 0x0109
+	smbQueryFileCompressionInfo = 0x010B
+)
+
+// findLevelChains reports whether a find level's entries are linked by a leading
+// NextEntryOffset.
+//
+// The NT levels are: each entry begins with the offset of the next and the last
+// carries zero. The pre-NT levels are not — SMB_INFO_STANDARD begins with a date
+// — and are packed back to back, with the client counting them by SearchCount.
+//
+// Getting this wrong is not a near miss. Clearing a "final NextEntryOffset" in a
+// buffer of pre-NT entries would write zeroes over the first entry's creation
+// date and access date, and the client would read a valid-looking listing with
+// corrupted timestamps.
+func findLevelChains(level uint16) bool {
+	switch level {
+	case smbInfoStandard, smbInfoQueryEaSize, smbInfoQueryEasFromLst:
+		return false
+	}
+	return true
+}
+
+// infoStandardOf fills SMB_INFO_STANDARD from what the backend reported.
+//
+// The two sizes are truncated to 32 bits, which is what the level's fields are.
+// A file larger than 4 GiB cannot be described by this level at all, so a client
+// that needs to see one has to ask at an NT level; that is a property of the
+// format rather than something this can work around.
+func infoStandardOf(attr FileAttr) informationlevels.SMB_INFO_STANDARD {
+	standard := informationlevels.SMB_INFO_STANDARD{}
+	standard.Creationdate, standard.Creationtime = dosDateTimeOf(attr.Created)
+	standard.Lastaccessdate, standard.Lastaccesstime = dosDateTimeOf(attr.Accessed)
+	standard.Lastwritedate, standard.Lastwritetime = dosDateTimeOf(attr.Modified)
+	standard.Filedatasize = types.ULONG(uint32(attr.Size))
+	standard.Allocationsize = types.ULONG(uint32(attr.AllocationSize))
+	standard.Attributes.SetAttributes(legacyAttributesFor(attr))
+	return standard
+}
+
+// encodeLegacyFindEntry renders one directory entry in a pre-NT find level.
+//
+// These entries carry the name length in a single byte and no NextEntryOffset, so
+// they are packed one after another. The resume key is not included: it is present
+// only when the client sets SMB_FIND_RETURN_RESUME_KEYS, and the searches here are
+// continued by search identifier rather than by key.
+//
+// Parameters:
+//   - level: the find level requested
+//   - attr: the entry to render
+//   - unicode: whether the message declared Unicode
+//
+// Returns:
+//   - The encoded entry, and whether the level is served
+func encodeLegacyFindEntry(level uint16, attr FileAttr, unicode bool) ([]byte, bool) {
+	switch level {
+	case smbInfoStandard, smbInfoQueryEaSize, smbInfoQueryEasFromLst:
+	default:
+		return nil, false
+	}
+
+	standard := infoStandardOf(attr)
+	entry, err := standard.Marshal()
+	if err != nil {
+		return nil, false
+	}
+
+	// The two EA-bearing levels are SMB_INFO_STANDARD followed by a 4-byte EaSize.
+	// Nothing here carries extended attributes, so it is zero — which is the
+	// documented way to say a file has none, not a placeholder.
+	if level == smbInfoQueryEaSize || level == smbInfoQueryEasFromLst {
+		entry = append(entry, 0x00, 0x00, 0x00, 0x00)
+	}
+
+	name := encodeWireString(attr.Name, unicode)
+	// FileNameLength is one byte, so a name that cannot be described is dropped
+	// rather than truncated: a truncated name is a different file.
+	if len(name) > 0xFF {
+		return nil, false
+	}
+	entry = append(entry, byte(len(name)))
+	entry = append(entry, name...)
+
+	// The name is null-terminated in this level, in the width the message
+	// declared.
+	if unicode {
+		entry = append(entry, 0x00, 0x00)
+	} else {
+		entry = append(entry, 0x00)
+	}
+	return entry, true
+}
+
+// encodeLegacyFileInformation renders a file in a pre-NT query level.
+//
+// Parameters:
+//   - level: the query level requested
+//   - attr: what the backend reported
+//
+// Returns:
+//   - The encoded structure, and whether the level is served
+func encodeLegacyFileInformation(level uint16, attr FileAttr) ([]byte, bool) {
+	switch level {
+	case smbInfoStandard:
+		standard := infoStandardOf(attr)
+		encoded, err := standard.Marshal()
+		return encoded, err == nil
+
+	case smbInfoQueryEaSize:
+		standard := infoStandardOf(attr)
+		encoded, err := standard.Marshal()
+		if err != nil {
+			return nil, false
+		}
+		// EaSize(4), zero for storage with no extended attributes.
+		return append(encoded, 0x00, 0x00, 0x00, 0x00), true
+
+	case smbInfoIsNameValid:
+		// [MS-CIFS] section 2.2.8.3.5: "No parameters or data are returned on this
+		// InformationLevel request. An error is returned if the syntax of the name
+		// is incorrect." The name has already been through resolvePath by the time
+		// this runs, so reaching here means it is valid and success with no data
+		// is the whole answer.
+		return []byte{}, true
+
+	case smbQueryFileStreamInfo:
+		return encodeStreamInformation(attr), true
+
+	case smbQueryFileCompressionInfo:
+		compression := informationlevels.SMB_QUERY_FILE_COMRESSION_INFO{
+			Compressedfilesize: types.LARGE_INTEGER{QuadPart: uint64(attr.Size)},
+			// COMPRESSION_FORMAT_NONE. Nothing here compresses, and claiming a
+			// format would have a client compute sizes from a unit shift that
+			// does not describe the storage.
+			Compressionformat: types.USHORT(0),
+		}
+		encoded, err := compression.Marshal()
+		return encoded, err == nil
+	}
+
+	return nil, false
+}
+
+// encodeStreamInformation describes an entry's data streams.
+//
+// A file has exactly one: the unnamed data stream, which is named "::$DATA" in
+// this structure. A directory has none, and an empty buffer is how that is
+// reported — a client asking a directory for its streams gets a successful answer
+// with no entries rather than an error.
+func encodeStreamInformation(attr FileAttr) []byte {
+	if attr.IsDir {
+		return []byte{}
+	}
+
+	// The stream name is UTF-16LE regardless of what the message declared: this
+	// structure is the native FILE_STREAM_INFORMATION, and the SMB level is a
+	// pass-through of it.
+	name := utf16.EncodeUTF16LE(`::$DATA`)
+
+	stream := informationlevels.SMB_QUERY_FILE_STREAM_INFO{
+		// One entry, so NextEntryOffset is zero and the chain ends here.
+		Nextentryoffset:      types.ULONG(0),
+		Streamnamelength:     types.ULONG(len(name)),
+		Streamsize:           types.LARGE_INTEGER{QuadPart: uint64(attr.Size)},
+		Streamallocationsize: types.LARGE_INTEGER{QuadPart: uint64(attr.AllocationSize)},
+		Streamname:           []types.UCHAR(name),
+	}
+	encoded, err := stream.Marshal()
+	if err != nil {
+		return []byte{}
+	}
+	return encoded
+}
+
+// encodeLegacyVolumeInformation renders a volume in a pre-NT query level.
+//
+// Parameters:
+//   - level: the query level requested
+//   - volume: what the backend reported
+//   - unicode: whether the message declared Unicode
+//
+// Returns:
+//   - The encoded structure, and whether the level is served
+func encodeLegacyVolumeInformation(level uint16, volume VolumeInfo, unicode bool) ([]byte, bool) {
+	switch level {
+	case smbInfoAllocation:
+		unit := int64(volume.SectorsPerAllocationUnit) * int64(volume.BytesPerSector)
+		if unit <= 0 {
+			unit = defaultAllocationUnit
+		}
+
+		allocation := informationlevels.SMB_INFO_ALLOCATION{
+			// idFileSystem is a file system identifier; the volume's serial number
+			// is the only stable one available.
+			Idfilesystem:   types.ULONG(volume.SerialNumber),
+			Csectorunit:    types.ULONG(volume.SectorsPerAllocationUnit),
+			Cunit:          types.ULONG(uint32(volume.TotalBytes / unit)),
+			Cunitavailable: types.ULONG(uint32(volume.FreeBytes / unit)),
+			Cbsector:       types.USHORT(volume.BytesPerSector),
+		}
+		encoded, err := allocation.Marshal()
+		return encoded, err == nil
+
+	case smbInfoVolume:
+		label := encodeWireString(volume.Label, unicode)
+
+		// A label longer than the one-byte count can describe is cut, because the
+		// count is what the client reads the label's extent from: sending more
+		// than it can be told about would leave the excess to be parsed as
+		// whatever field a client expected next.
+		if len(label) > 0xFF {
+			label = label[:0xFF]
+		}
+
+		// Ccharcount is not set here: SMB_INFO_VOLUME.Marshal derives it from the
+		// label's byte length, which is deliberate and worth knowing about.
+		// [MS-CIFS] calls the field "the number of characters in the VolumeLabel
+		// field", and the two readings differ under Unicode — but they coincide
+		// in OEM, which is what a client old enough to ask for this level speaks,
+		// and the shared structure's choice is not this handler's to override.
+		info := informationlevels.SMB_INFO_VOLUME{
+			Ulvolserialnbr: types.ULONG(volume.SerialNumber),
+			Volumelabel:    []types.UCHAR(label),
+		}
+		encoded, err := info.Marshal()
+		return encoded, err == nil
+	}
+
+	return nil, false
+}
+
+// defaultAllocationUnit is assumed when a backend reports no geometry, so a
+// division by it cannot be a division by zero.
+const defaultAllocationUnit = 4096

--- a/network/smb/smb_v10/server/infolevels_legacy_test.go
+++ b/network/smb/smb_v10/server/infolevels_legacy_test.go
@@ -1,0 +1,250 @@
+package server
+
+import (
+	"encoding/binary"
+	"testing"
+	"time"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/informationlevels"
+)
+
+// TestPreNTFindLevelIsAdmitted asserts the pre-NT find levels are accepted rather
+// than refused with STATUS_INVALID_INFO_CLASS.
+//
+// Admission is the gate that mattered: supportedFindLevel rejected these outright,
+// so a client without CAP_NT_FIND could not enumerate a share at all. The entry
+// encoding itself is asserted below, against the buffer assembly that had been
+// written for the chained levels only.
+func TestPreNTFindLevelIsAdmitted(t *testing.T) {
+	for _, level := range []uint16{smbInfoStandard, smbInfoQueryEaSize, smbInfoQueryEasFromLst} {
+		if !supportedFindLevel(level) {
+			t.Errorf("find level 0x%04X is refused", level)
+		}
+	}
+}
+
+// TestPreNTFindEntryIsNotChained asserts a pre-NT entry is packed rather than
+// linked, and that its dates survive.
+//
+// The NT levels begin each entry with the offset of the next, and the buffer
+// assembly clears that field on the last one. A pre-NT entry begins with a
+// creation date instead, so applying the same treatment would write zeroes over
+// the first entry's creation and access dates — a listing that looks valid and
+// carries wrong timestamps.
+func TestPreNTFindEntryIsNotChained(t *testing.T) {
+	if findLevelChains(smbInfoStandard) {
+		t.Fatal("SMB_INFO_STANDARD is treated as a chained level")
+	}
+	if !findLevelChains(smbFindFileBothDirectoryInfo) {
+		t.Fatal("SMB_FIND_FILE_BOTH_DIRECTORY_INFO is not treated as a chained level")
+	}
+
+	attr := FileAttr{
+		Name:     "dated.txt",
+		Size:     0x1234,
+		Created:  mustTime(t, 2001, 2, 3, 4, 5, 6),
+		Accessed: mustTime(t, 2002, 3, 4, 5, 6, 8),
+		Modified: mustTime(t, 2003, 4, 5, 6, 7, 10),
+	}
+
+	entry, served := encodeLegacyFindEntry(smbInfoStandard, attr, false)
+	if !served {
+		t.Fatal("SMB_INFO_STANDARD is not served")
+	}
+
+	// The first field is a creation date, not a NextEntryOffset, so it must not
+	// be zero for an entry with a creation time.
+	if date := binary.LittleEndian.Uint16(entry[0:2]); date == 0 {
+		t.Error("the entry begins with a zero, so its creation date was lost")
+	}
+
+	// The name follows the fixed part, with a one-byte length.
+	fixed := informationlevels.SMB_INFO_STANDARD_SIZE
+	if got := int(entry[fixed]); got != len(attr.Name) {
+		t.Errorf("FileNameLength is %d, want %d", got, len(attr.Name))
+	}
+	if got := string(entry[fixed+1 : fixed+1+len(attr.Name)]); got != attr.Name {
+		t.Errorf("the entry names %q, want %q", got, attr.Name)
+	}
+}
+
+// TestPreNTQueryLevelsAreServed asserts the pre-NT query levels answer with the
+// sizes the level can express.
+func TestPreNTQueryLevelsAreServed(t *testing.T) {
+	attr := FileAttr{
+		Name:           "described.txt",
+		Size:           0x2000,
+		AllocationSize: 0x2000,
+		Modified:       mustTime(t, 2003, 4, 5, 6, 7, 10),
+	}
+
+	standard, served := encodeLegacyFileInformation(smbInfoStandard, attr)
+	if !served {
+		t.Fatal("SMB_INFO_STANDARD is not served for a query")
+	}
+	if len(standard) != informationlevels.SMB_INFO_STANDARD_SIZE {
+		t.Fatalf("SMB_INFO_STANDARD is %d bytes, want %d",
+			len(standard), informationlevels.SMB_INFO_STANDARD_SIZE)
+	}
+
+	decoded := &informationlevels.SMB_INFO_STANDARD{}
+	if _, err := decoded.Unmarshal(standard); err != nil {
+		t.Fatalf("the answer did not parse: %v", err)
+	}
+	if int(decoded.Filedatasize) != int(attr.Size) {
+		t.Errorf("FileDataSize is %d, want %d", decoded.Filedatasize, attr.Size)
+	}
+
+	// The EA-bearing level is the same structure plus a 4-byte EaSize of zero.
+	withEa, served := encodeLegacyFileInformation(smbInfoQueryEaSize, attr)
+	if !served {
+		t.Fatal("SMB_INFO_QUERY_EA_SIZE is not served")
+	}
+	if len(withEa) != len(standard)+4 {
+		t.Fatalf("SMB_INFO_QUERY_EA_SIZE is %d bytes, want %d", len(withEa), len(standard)+4)
+	}
+	if size := binary.LittleEndian.Uint32(withEa[len(standard):]); size != 0 {
+		t.Errorf("EaSize is %d, want 0 — nothing here carries extended attributes", size)
+	}
+}
+
+// TestIsNameValidAnswersWithNoData asserts the level answers success and nothing
+// else.
+//
+// [MS-CIFS] section 2.2.8.3.5: "No parameters or data are returned on this
+// InformationLevel request. An error is returned if the syntax of the name is
+// incorrect." Reaching the encoder means the name already passed resolvePath, so
+// success with an empty body is the complete answer.
+func TestIsNameValidAnswersWithNoData(t *testing.T) {
+	encoded, served := encodeLegacyFileInformation(smbInfoIsNameValid, FileAttr{Name: "valid.txt"})
+	if !served {
+		t.Fatal("SMB_INFO_IS_NAME_VALID is not served")
+	}
+	if len(encoded) != 0 {
+		t.Errorf("the level returned %d bytes, want none", len(encoded))
+	}
+}
+
+// TestStreamInformationDescribesTheDataStream asserts a file reports its unnamed
+// data stream and a directory reports none.
+func TestStreamInformationDescribesTheDataStream(t *testing.T) {
+	file := FileAttr{Name: "streamed.txt", Size: 0x40, AllocationSize: 0x40}
+
+	encoded, served := encodeLegacyFileInformation(smbQueryFileStreamInfo, file)
+	if !served {
+		t.Fatal("SMB_QUERY_FILE_STREAM_INFO is not served")
+	}
+	if len(encoded) == 0 {
+		t.Fatal("a file reported no streams")
+	}
+
+	// NextEntryOffset(4) StreamNameLength(4) StreamSize(8) StreamAllocationSize(8).
+	if next := binary.LittleEndian.Uint32(encoded[0:4]); next != 0 {
+		t.Errorf("the only entry links to another at %d", next)
+	}
+	if size := binary.LittleEndian.Uint64(encoded[8:16]); size != uint64(file.Size) {
+		t.Errorf("StreamSize is %d, want %d", size, file.Size)
+	}
+
+	// A directory has no streams, and an empty buffer is how that is reported.
+	directory := FileAttr{Name: "adirectory", IsDir: true}
+	empty, served := encodeLegacyFileInformation(smbQueryFileStreamInfo, directory)
+	if !served {
+		t.Fatal("SMB_QUERY_FILE_STREAM_INFO is not served for a directory")
+	}
+	if len(empty) != 0 {
+		t.Errorf("a directory reported %d bytes of stream information, want none", len(empty))
+	}
+}
+
+// TestCompressionInformationReportsNoCompression asserts the level says the file
+// is not compressed rather than claiming a format.
+//
+// Claiming one would have a client compute sizes from a unit shift that does not
+// describe the storage.
+func TestCompressionInformationReportsNoCompression(t *testing.T) {
+	attr := FileAttr{Name: "plain.txt", Size: 0x1000}
+
+	encoded, served := encodeLegacyFileInformation(smbQueryFileCompressionInfo, attr)
+	if !served {
+		t.Fatal("SMB_QUERY_FILE_COMPRESSION_INFO is not served")
+	}
+	if size := binary.LittleEndian.Uint64(encoded[0:8]); size != uint64(attr.Size) {
+		t.Errorf("CompressedFileSize is %d, want the file's %d", size, attr.Size)
+	}
+	if format := binary.LittleEndian.Uint16(encoded[8:10]); format != 0 {
+		t.Errorf("CompressionFormat is %d, want 0 (COMPRESSION_FORMAT_NONE)", format)
+	}
+}
+
+// TestPreNTVolumeLevelsAreServed asserts the two pre-NT volume levels answer, and
+// that the allocation level's units agree with the volume's geometry.
+func TestPreNTVolumeLevelsAreServed(t *testing.T) {
+	volume := VolumeInfo{
+		Label: "FILES", FileSystemName: "NTFS", SerialNumber: 0x11223344,
+		TotalBytes: 1 << 30, FreeBytes: 1 << 29,
+		SectorsPerAllocationUnit: 8, BytesPerSector: 512,
+	}
+
+	allocation, served := encodeLegacyVolumeInformation(smbInfoAllocation, volume, false)
+	if !served {
+		t.Fatal("SMB_INFO_ALLOCATION is not served")
+	}
+	// idFileSystem(4) cSectorUnit(4) cUnit(4) cUnitAvailable(4) cbSector(2).
+	if len(allocation) != 18 {
+		t.Fatalf("SMB_INFO_ALLOCATION is %d bytes, want 18", len(allocation))
+	}
+	unit := uint64(volume.SectorsPerAllocationUnit) * uint64(volume.BytesPerSector)
+	if got := binary.LittleEndian.Uint32(allocation[8:12]); uint64(got) != uint64(volume.TotalBytes)/unit {
+		t.Errorf("cUnit is %d, want %d", got, uint64(volume.TotalBytes)/unit)
+	}
+	if got := binary.LittleEndian.Uint16(allocation[16:18]); uint32(got) != volume.BytesPerSector {
+		t.Errorf("cbSector is %d, want %d", got, volume.BytesPerSector)
+	}
+
+	// The volume level, in each encoding. cCharCount is the label's byte length,
+	// which is what SMB_INFO_VOLUME.Marshal derives it as; under Unicode that is
+	// twice the character count, and the two coincide in OEM.
+	for _, unicode := range []bool{false, true} {
+		info, served := encodeLegacyVolumeInformation(smbInfoVolume, volume, unicode)
+		if !served {
+			t.Fatalf("SMB_INFO_VOLUME is not served (unicode=%t)", unicode)
+		}
+		if serial := binary.LittleEndian.Uint32(info[0:4]); serial != volume.SerialNumber {
+			t.Errorf("the serial number is 0x%08X, want 0x%08X (unicode=%t)",
+				serial, volume.SerialNumber, unicode)
+		}
+
+		wantBytes := len(volume.Label)
+		if unicode {
+			wantBytes *= 2
+		}
+		if got := int(info[4]); got != wantBytes {
+			t.Errorf("cCharCount is %d, want %d (unicode=%t)", got, wantBytes, unicode)
+		}
+		// And the count has to describe the label that follows it, or a client
+		// reads the wrong extent.
+		if len(info) != 5+wantBytes {
+			t.Errorf("the level is %d bytes, want %d (unicode=%t)", len(info), 5+wantBytes, unicode)
+		}
+	}
+}
+
+// TestUnservedLevelIsStillRefused asserts adding these levels did not turn the
+// range into a catch-all.
+func TestUnservedLevelIsStillRefused(t *testing.T) {
+	attr := FileAttr{Name: "described.txt"}
+
+	if _, served := encodeLegacyFileInformation(0x0099, attr); served {
+		t.Error("an unknown level was answered")
+	}
+	if supportedFindLevel(0x0099) {
+		t.Error("an unknown find level is reported as supported")
+	}
+}
+
+// mustTime builds a UTC time for a fixture.
+func mustTime(t *testing.T, year, month, day, hour, minute, second int) time.Time {
+	t.Helper()
+	return time.Date(year, time.Month(month), day, hour, minute, second, 0, time.UTC)
+}


### PR DESCRIPTION
### Linked Issue
`Closes #1144`

> **Stacked on #1164 and #1166.** This branch is cut from `enhancement-legacy-info-commands` (#1146, itself on #1162) with `bugfix-info-standard-missing-fields` (#1165) merged in, because it needs both: the MS-DOS date/time and legacy-attribute helpers from #1146, and the corrected `SMB_INFO_STANDARD` structure from #1165. Merge #1163, #1164 and #1166 first, and this diff reduces to the four files listed below.

### Root Cause
Eight levels defined in `informationlevels` had no case anywhere under `server/`, and each was refused: `supportedFindLevel` admitted only the four NT find levels, and `encodeFileInformation`/`encodeVolumeInformation` returned `false` for anything outside their handful of cases, which `handler_info.go` turned into `STATUS_INVALID_INFO_CLASS`.

The refusals were correct — nothing was mishandled — but for `SMB_INFO_STANDARD` the consequence was that a client without `CAP_NT_FIND` could not enumerate a directory at all, because that is the level it asks for.

### Fix Description
All eight are served, in `infolevels_legacy.go`, from the `informationlevels` structures rather than from hand-assembled buffers.

**The find entries are packed, not linked, and this is the part that could have gone quietly wrong.** The NT levels begin each entry with `NextEntryOffset`, and `encodeFindEntries` clears that field on the last entry so a client knows where to stop — a fix made under #1089. `SMB_INFO_STANDARD` has no such field: it begins with a creation date. Running the existing termination logic over a buffer of pre-NT entries would write four zero bytes over the first entry's creation and access dates, and the client would read a listing that parsed cleanly and carried wrong timestamps. `findLevelChains` names which model a level uses, and the assembly consults it. `TestPreNTFindEntryIsNotChained` asserts both halves of that distinction.

**Levels with nothing behind them report nothing, in the documented form:**

- `SMB_INFO_QUERY_EA_SIZE` and `SMB_INFO_QUERY_EAS_FROM_LIST` are `SMB_INFO_STANDARD` plus a zero `EaSize`. Zero is how the format says a file has no extended attributes, so this is an answer rather than a placeholder.
- `SMB_INFO_IS_NAME_VALID` returns success and no body. [MS-CIFS] 2.2.8.3.5: "No parameters or data are returned on this InformationLevel request. An error is returned if the syntax of the name is incorrect." The name has already been through `resolvePath` by the time the encoder runs, so reaching it means the name is valid and an empty successful answer is complete.
- `SMB_QUERY_FILE_STREAM_INFO` describes the one unnamed data stream as `::$DATA`; a directory has none, and an empty buffer is how that is reported rather than an error.
- `SMB_QUERY_FILE_COMRESSION_INFO` reports `COMPRESSION_FORMAT_NONE`. Claiming a format would have a client compute sizes from a unit shift that does not describe the storage.

**Two places where the format cannot express what the storage knows**, both recorded in the code rather than left to be discovered:

- `SMB_INFO_STANDARD`'s sizes are 32-bit, so a file over 4 GiB cannot be described by the level. A client needing to see one has to ask at an NT level; that is the format, not something the handler can work around.
- `FileNameLength` in the find entry is a single byte, so a name that cannot be described is dropped rather than truncated — a truncated name is a different file.

**One ambiguity resolved by deferring to existing code.** `SMB_INFO_VOLUME.Marshal` derives `cCharCount` from the label's byte length. [MS-CIFS] calls the field "the number of characters in the VolumeLabel field", and the two readings differ under Unicode. I wrote the character-count version first, found it was silently overridden by the shared structure, and removed it: the two coincide in OEM, which is what a client old enough to ask for this level speaks, and changing a shared structure's wire behaviour on an ambiguity I cannot settle would be the wrong call in this PR. The comment says all of that so the next reader does not repeat the detour.

### How Verified
Runtime. The client's find API selects the NT level internally and has no way to ask for another, so the find assertions are against `supportedFindLevel` and the encoder rather than over the wire; the query and volume levels are asserted through their encoders with the results decoded by the `informationlevels` structures.

- `TestPreNTFindLevelIsAdmitted` — all three pre-NT find levels are accepted. Admission is the gate that mattered.
- `TestPreNTFindEntryIsNotChained` — `findLevelChains` separates the two models; the entry does not begin with a zero, so its creation date survived; and the one-byte name length and the name itself are where they belong.
- `TestPreNTQueryLevelsAreServed` — `SMB_INFO_STANDARD` is 22 bytes, decodes through its own structure, and carries the file size; `SMB_INFO_QUERY_EA_SIZE` is exactly four bytes longer with a zero `EaSize`.
- `TestIsNameValidAnswersWithNoData` — served, with an empty body.
- `TestStreamInformationDescribesTheDataStream` — a file's stream reports the right size and terminates the chain; a directory reports no entries.
- `TestCompressionInformationReportsNoCompression` — the size is the file's and the format is zero.
- `TestPreNTVolumeLevelsAreServed` — `SMB_INFO_ALLOCATION` is 18 bytes with units that agree with the volume's geometry; `SMB_INFO_VOLUME` carries the serial, and its count describes the label that follows it in both encodings.
- `TestUnservedLevelIsStillRefused` — an unknown level is still refused, so the range did not become a catch-all.

Whole tree green: `go build ./...`, `go test ./network/smb/...`. `gofmt -l` clean on every file touched.

### Test Coverage
**Added:** `server/infolevels_legacy_test.go` — the eight tests above, plus the `mustTime` fixture helper.

**Existing:** the find and information suites cover the NT levels and pass unchanged, which is what shows the new branch in `encodeFindEntries` did not disturb the chained path.

### Scope of Change
- **Files changed:** `server/infolevels_legacy.go` (new), `server/infolevels_legacy_test.go` (new), `server/infolevels.go`, `server/doc.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none. Every level added was refused before, and the NT levels reach the same code they did.

### Risk and Rollout
Additive for the levels themselves. The one change to an existing path is the `findLevelChains` guard in `encodeFindEntries`, which returns early only for a pre-NT level — so a chained listing runs exactly the code it did, as the unchanged find suite shows.

### Notes
`SMB_INFO_QUERY_ALL_EAS` and `SMB_INFO_SET_EAS` are not served: both need extended attributes the backend does not have, and unlike `EaSize` they have no "there are none" form that is distinguishable from a truncated answer. `FileSystem` would need EA support first.
