### PR TITLE
Serve the core-set directory search commands (Fixes #1147)

### DIFF
--- a/network/smb/smb_v10/server/conformance_test.go
+++ b/network/smb/smb_v10/server/conformance_test.go
@@ -142,6 +142,11 @@ var servedCommands = map[codes.CommandCode]string{
 	codes.SMB_COM_QUERY_INFORMATION2: "reports an open handle's timestamps, sizes and attributes",
 	codes.SMB_COM_SET_INFORMATION2:   "sets an open handle's timestamps",
 
+	codes.SMB_COM_SEARCH:      "enumerates a directory in the core-set form",
+	codes.SMB_COM_FIND:        "enumerates a directory in the core-set form, closable",
+	codes.SMB_COM_FIND_UNIQUE: "enumerates one name with no continuation",
+	codes.SMB_COM_FIND_CLOSE:  "closes a core-set search, which holds nothing to release",
+
 	codes.SMB_COM_TRANSACTION2:           "carries the find and information subcommands",
 	codes.SMB_COM_TRANSACTION2_SECONDARY: "continues a fragmented transaction",
 	codes.SMB_COM_FIND_CLOSE2:            "releases a search handle",
@@ -350,9 +355,16 @@ func TestConformanceUnservedCommandsAreRefused(t *testing.T) {
 	}
 	// A floor as well, so a message layer that stopped recognizing commands at all
 	// would not make the accounting trivially true.
-	if exercised < 40 {
-		t.Fatalf("only %d commands were exercised of %d known; the walk is no longer covering the command space",
-			exercised, known)
+	//
+	// The floor is on how many commands the message layer knows, not on how many
+	// this walk exercised. Those were the same number when nothing much was
+	// served, but every command that gains a handler moves out of this walk and
+	// into TestConformanceServedCommandsAreServed — so a floor on `exercised`
+	// falls as the server grows and has to be edited downwards to keep passing,
+	// which makes it a record of past progress rather than a guard. A floor on
+	// `known` says what the guard was for and stays true.
+	if known < 70 {
+		t.Fatalf("the message layer recognizes only %d commands; it is no longer covering the command space", known)
 	}
 	t.Logf("exercised %d of %d known commands (%d served, %d whose zero value cannot be marshalled)",
 		exercised, known, skippedServed, skippedUnmarshalable)

--- a/network/smb/smb_v10/server/dispatch.go
+++ b/network/smb/smb_v10/server/dispatch.go
@@ -60,6 +60,13 @@ var dispatchTable = map[codes.CommandCode]commandHandler{
 	codes.SMB_COM_DELETE_DIRECTORY: handleDeleteDirectory,
 	codes.SMB_COM_CHECK_DIRECTORY:  handleCheckDirectory,
 
+	// The core-set directory search, which a client that does not use
+	// TRANSACTION2 enumerates with.
+	codes.SMB_COM_SEARCH:      handleSearch,
+	codes.SMB_COM_FIND:        handleFind,
+	codes.SMB_COM_FIND_UNIQUE: handleFindUnique,
+	codes.SMB_COM_FIND_CLOSE:  handleFindClose,
+
 	// Transactions, which carry the directory-enumeration and information
 	// subcommands.
 	codes.SMB_COM_TRANSACTION2:           handleTransaction2,

--- a/network/smb/smb_v10/server/doc.go
+++ b/network/smb/smb_v10/server/doc.go
@@ -14,23 +14,34 @@
 // the protocol to look functional while refusing everything that matters.
 //
 // Implemented:
+//
 //   - Listening on Direct TCP (445) and NetBIOS over TCP (139), via
 //     network/smb/common/transport.
+//
 //   - The per-connection receive loop, request decoding, the handler chain, and
 //     response framing with correlated reply headers.
+//
 //   - Error responses in both encodings: the NTSTATUS form, and the legacy
 //     SMBSTATUS class/code form for a client that did not negotiate
 //     SMB_FLAGS2_NT_STATUS_ERROR_CODES.
+//
 //   - SMB_COM_NEGOTIATE, selecting the NT LM 0.12 dialect under extended
 //     security.
+//
 //   - SMB_COM_SESSION_SETUP_ANDX, including verifying the response against a
 //     credential, establishing a session, and the guest and anonymous policies.
+//
 //   - SMB_COM_LOGOFF_ANDX.
+//
 //   - SMB_COM_ECHO.
+//
 //   - Message signing in both directions, when the policy calls for it.
+//
 //   - Tree connect and disconnect against a registered share.
+//
 //   - File service: open and create, read, write, close, flush, delete, rename,
 //     and the directory create, remove and check commands.
+//
 //   - The core-set file information commands, which describe a file without a
 //     transaction: SMB_COM_QUERY_INFORMATION and SMB_COM_SET_INFORMATION by path,
 //     and SMB_COM_QUERY_INFORMATION2 and SMB_COM_SET_INFORMATION2 on a handle.
@@ -38,17 +49,36 @@
 //     or a UTIME in seconds, so a client reading one back sees less precision than
 //     the TRANSACTION2 levels carry — a property of the wire format rather than of
 //     the storage.
+//
+//   - The core-set directory search: SMB_COM_SEARCH, SMB_COM_FIND,
+//     SMB_COM_FIND_UNIQUE and SMB_COM_FIND_CLOSE. These keep no state on the
+//     server — the position travels in the resume key and the directory is read
+//     again each call, which is what a command with no close needs, since a
+//     client that walks away mid-listing would otherwise leak an allocation. The
+//     cost is that the listing is a fresh view rather than a snapshot, so an
+//     entry created or removed between calls may be seen twice or missed;
+//     TRANS2_FIND_FIRST2 is the level that keeps a snapshot.
+//
+//     An entry's name field is a fixed thirteen bytes, so a name that does not
+//     fit an 8.3 field is omitted from these listings. There is no 8.3 alias to
+//     substitute: truncating would name a different file, and inventing an alias
+//     would hand the client a name no subsequent open could resolve. A client
+//     that needs those names has to use TRANS2_FIND_FIRST2.
+//
 //   - Directory enumeration and the information levels, over TRANSACTION2:
 //     FIND_FIRST2 and FIND_NEXT2 with search handles, the query and set levels
 //     for a path and for an open handle, and the volume levels. Requests and
 //     responses both fragment across as many messages as they need.
+//
 //   - Security descriptors and file-system controls, over NT_TRANSACT:
 //     QUERY_SECURITY_DESC, SET_SECURITY_DESC and IOCTL. SMB_COM_NT_CANCEL is
 //     accepted silently, since nothing here leaves a request outstanding.
+//
 //   - Named pipes, over TRANSACTION: a pipe is opened on a pipe share like a
 //     file, and TRANS_TRANSACT_NMPIPE writes a message to the handle and returns
 //     the answer. That write-then-read is the operation MS-RPC travels over, so a
 //     PipeHandler is all an RPC service needs to be reachable over SMB1.
+//
 //   - The volume queries a client actually asks: the TRANSACTION2 volume levels,
 //     the pass-through information classes above 0x03E8 that carry the native
 //     ones, and the legacy SMB_COM_QUERY_INFORMATION_DISK. A client asks about

--- a/network/smb/smb_v10/server/handler_prent_search.go
+++ b/network/smb/smb_v10/server/handler_prent_search.go
@@ -1,0 +1,350 @@
+package server
+
+import (
+	"encoding/binary"
+	"strings"
+
+	"github.com/TheManticoreProject/Manticore/logger"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+	"github.com/TheManticoreProject/Manticore/windows/nt_status"
+)
+
+// preNTSearchMagic marks a resume key as one this server issued.
+//
+// A client hands back a key the server gave it, and the server has to tell its own
+// key from a value a client invented. Without the marker an arbitrary 21 bytes
+// would be read as a position and the search would resume somewhere meaningless.
+var preNTSearchMagic = [4]byte{'M', 'A', 'N', 'T'}
+
+// preNTSearchLimit bounds how many entries one response may carry, whatever the
+// client asked for. Each entry is a fixed 43 bytes, so this is also a bound on the
+// response size.
+const preNTSearchLimit = 512
+
+// handleSearch answers SMB_COM_SEARCH: the core-set directory enumeration.
+//
+// The search keeps no state on the server. The position travels in the resume key,
+// which the client returns with its next request, and the directory is read again
+// each time. That is what the command is shaped for — it has no close, so a search
+// holding server state would leak one allocation per client that walked away
+// mid-listing — and it is what a real server does with it.
+//
+// The cost is that the listing is a fresh view each call rather than a snapshot,
+// so an entry created or removed between calls may be seen twice or missed. The
+// command offers no way to avoid that; TRANS2_FIND_FIRST2, which does keep a
+// snapshot, is the level a client uses when it matters.
+//
+// Wire format: [MS-CIFS] section 2.2.4.58.
+//
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/
+func handleSearch(conn *Connection, w ResponseWriter, req *message.Message) nt_status.NT_STATUS {
+	request, ok := req.Command.(*commands.SearchRequest)
+	if !ok {
+		return nt_status.NT_STATUS_INVALID_SMB
+	}
+
+	entries, next, status := conn.preNTSearch(req,
+		decodeWireString(request.FileName.Buffer, req.Header.Flags2.IsUnicode()),
+		int(request.MaxCount),
+		request.ResumeKeyPresent, request.ResumeKey)
+	if status != nt_status.NT_STATUS_SUCCESS {
+		return status
+	}
+
+	// The response's data block is BufferFormat(0x05) DataLength(2) followed by
+	// the packed entries, which is exactly what an SMB_STRING in variable-block
+	// form emits.
+	packed := []byte{}
+	for index := range entries {
+		entries[index].ResumeKey = preNTResumeKey(next, request.ResumeKey)
+		encoded, err := entries[index].Marshal()
+		if err != nil {
+			logger.Debugf("SMB1 server: failed to encode a search entry for %s: %v", conn.Remote, err)
+			return nt_status.NT_STATUS_UNSUCCESSFUL
+		}
+		packed = append(packed, encoded...)
+	}
+
+	response := commands.NewSearchResponse()
+	response.Count = types.USHORT(len(entries))
+	response.SMB_Directory_Information.SetBufferFormat(types.SMB_STRING_BUFFER_FORMAT_VARIABLE_BLOCK)
+	response.SMB_Directory_Information.Buffer = []types.UCHAR(packed)
+
+	// An empty listing is STATUS_NO_MORE_FILES rather than an empty success:
+	// that is how the command says the walk is finished, and a client given an
+	// empty successful answer asks again forever.
+	if len(entries) == 0 {
+		return nt_status.NT_STATUS_NO_MORE_FILES
+	}
+
+	return conn.answer(w, response)
+}
+
+// handleFind answers SMB_COM_FIND, which carries the same request and response as
+// SMB_COM_SEARCH and differs only in being closable with SMB_COM_FIND_CLOSE.
+//
+// Since the search here holds no server state, the close has nothing to release —
+// see handleFindClose.
+//
+// Wire format: [MS-CIFS] section 2.2.4.59.
+func handleFind(conn *Connection, w ResponseWriter, req *message.Message) nt_status.NT_STATUS {
+	request, ok := req.Command.(*commands.FindRequest)
+	if !ok {
+		return nt_status.NT_STATUS_INVALID_SMB
+	}
+
+	resumeKey, present := preNTResumeKeyFrom(request.ResumeKey.Buffer)
+
+	entries, next, status := conn.preNTSearch(req,
+		decodeWireString(request.FileName.Buffer, req.Header.Flags2.IsUnicode()),
+		int(request.MaxCount), present, resumeKey)
+	if status != nt_status.NT_STATUS_SUCCESS {
+		return status
+	}
+	if len(entries) == 0 {
+		return nt_status.NT_STATUS_NO_MORE_FILES
+	}
+
+	for index := range entries {
+		entries[index].ResumeKey = preNTResumeKey(next, resumeKey)
+	}
+
+	response := commands.NewFindResponse()
+	response.Count = types.USHORT(len(entries))
+	response.DirectoryInformationData = entries
+	return conn.answer(w, response)
+}
+
+// handleFindUnique answers SMB_COM_FIND_UNIQUE: one listing with no continuation.
+//
+// [MS-CIFS] section 2.2.4.60 — the command exists to look up a single name, so no
+// resume key is accepted and none is meaningful in the answer.
+func handleFindUnique(conn *Connection, w ResponseWriter, req *message.Message) nt_status.NT_STATUS {
+	request, ok := req.Command.(*commands.FindUniqueRequest)
+	if !ok {
+		return nt_status.NT_STATUS_INVALID_SMB
+	}
+
+	entries, _, status := conn.preNTSearch(req,
+		decodeWireString(request.FileName.Buffer, req.Header.Flags2.IsUnicode()),
+		int(request.MaxCount), false, types.SMB_RESUME_KEY{})
+	if status != nt_status.NT_STATUS_SUCCESS {
+		return status
+	}
+	if len(entries) == 0 {
+		return nt_status.NT_STATUS_NO_SUCH_FILE
+	}
+
+	response := commands.NewFindUniqueResponse()
+	response.Count = types.USHORT(len(entries))
+	response.DirectoryInformationData = entries
+	return conn.answer(w, response)
+}
+
+// handleFindClose answers SMB_COM_FIND_CLOSE.
+//
+// There is nothing to release: a pre-NT search carries its position in the resume
+// key rather than in a server-side table, so a client that stops asking has
+// already freed everything the search used. Answering success is accurate rather
+// than a stub — a client closing a search it can no longer continue is exactly
+// what the command is for, and reporting an error would make an orderly client
+// look like it had made a mistake.
+//
+// Wire format: [MS-CIFS] section 2.2.4.61.
+func handleFindClose(conn *Connection, w ResponseWriter, req *message.Message) nt_status.NT_STATUS {
+	if _, ok := req.Command.(*commands.FindCloseRequest); !ok {
+		return nt_status.NT_STATUS_INVALID_SMB
+	}
+
+	// The TID still has to name a tree: closing a search on a share the client
+	// does not hold is a protocol error whether or not anything is released.
+	if _, status := conn.treeFor(req); status != nt_status.NT_STATUS_SUCCESS {
+		return status
+	}
+
+	return conn.answer(w, commands.NewFindCloseResponse())
+}
+
+// preNTSearch enumerates a directory for the core-set search commands.
+//
+// Parameters:
+//   - req: the request, for its TID and encoding
+//   - pattern: the search path and wildcard the client sent
+//   - maxCount: how many entries the client will take
+//   - resuming: whether a resume key accompanied the request
+//   - resumeKey: that key
+//
+// Returns:
+//   - The entries, the position to report in their resume keys, and a status
+func (c *Connection) preNTSearch(
+	req *message.Message,
+	pattern string,
+	maxCount int,
+	resuming bool,
+	resumeKey types.SMB_RESUME_KEY,
+) ([]types.SMB_DIRECTORY_INFORMATION, int, nt_status.NT_STATUS) {
+	tree, status := c.treeFor(req)
+	if status != nt_status.NT_STATUS_SUCCESS {
+		return nil, 0, status
+	}
+	if tree.Share.FS == nil {
+		return nil, 0, nt_status.NT_STATUS_INVALID_DEVICE_REQUEST
+	}
+
+	directory, wildcard, err := resolvePathPattern(pattern)
+	if err != nil {
+		logger.Debugf("SMB1 server: %s searched %q, which is refused: %v", c.Remote, pattern, err)
+		return nil, 0, nt_status.NT_STATUS_OBJECT_PATH_SYNTAX_BAD
+	}
+
+	// A path with no wildcard names one entry rather than a directory to walk.
+	// SMB_COM_FIND_UNIQUE exists precisely to look up a single name, and the
+	// other two accept one as well, so reading the named path as a directory
+	// would answer STATUS_NOT_A_DIRECTORY for the command's main use.
+	var found []DirEntry
+	if wildcard == "" {
+		attr, err := tree.Share.FS.Stat(directory)
+		if err != nil {
+			return nil, 0, statusForFSError(err)
+		}
+		// Stat describes the path, and the entry has to name it: the listing
+		// carries base names, not the path the client asked about.
+		attr.Name = baseNameOf(directory)
+		found = []DirEntry{{Attr: attr}}
+	} else {
+		found, err = tree.Share.FS.ReadDir(directory, wildcard)
+		if err != nil {
+			return nil, 0, statusForFSError(err)
+		}
+	}
+
+	// Where to start. A key this server did not issue is refused rather than
+	// guessed at: resuming from a position derived from arbitrary bytes would
+	// return an arbitrary part of the directory and call it a continuation.
+	start := 0
+	if resuming {
+		position, ours := preNTPositionOf(resumeKey)
+		if !ours {
+			logger.Debugf("SMB1 server: %s resumed a search with a key this server did not issue", c.Remote)
+			return nil, 0, nt_status.NT_STATUS_INVALID_PARAMETER
+		}
+		start = position
+	}
+	if start > len(found) {
+		start = len(found)
+	}
+
+	if maxCount <= 0 || maxCount > preNTSearchLimit {
+		maxCount = preNTSearchLimit
+	}
+
+	entries := []types.SMB_DIRECTORY_INFORMATION{}
+	position := start
+	skipped := 0
+
+	for position < len(found) && len(entries) < maxCount {
+		attr := found[position].Attr
+		position++
+
+		// The entry's name field is a fixed 13 bytes: twelve for an 8.3 name and
+		// one for its terminator. A longer name cannot be carried, and this
+		// server has no 8.3 alias to substitute — inventing one would hand the
+		// client a name that no subsequent open could resolve, which is worse
+		// than the file not appearing. Such entries are skipped, and a client
+		// that needs to see them has to use TRANS2_FIND_FIRST2.
+		if !fitsShortNameField(attr.Name) {
+			skipped++
+			continue
+		}
+
+		entry := types.NewSMB_DIRECTORY_INFORMATION()
+		entry.FileAttributes = types.UCHAR(legacyAttributesFor(attr))
+		entry.LastWriteDate, entry.LastWriteTime = dosDateTimeOf(attr.Modified)
+		entry.FileSize = types.ULONG(uint32(attr.Size))
+		entry.FileName = *types.NewOEM_STRINGFromString(attr.Name)
+		entries = append(entries, *entry)
+	}
+
+	if skipped > 0 {
+		logger.Debugf("SMB1 server: omitted %d entries of %q from a core-set search for %s, "+
+			"their names not fitting the 8.3 field", skipped, directory, c.Remote)
+	}
+
+	return entries, position, nt_status.NT_STATUS_SUCCESS
+}
+
+// fitsShortNameField reports whether a name can be carried in an entry's
+// twelve-byte 8.3 name field.
+//
+// The check is on the encoded length rather than on the shape of the name: a
+// name of eight characters and a three-character extension is the intent, but
+// anything that fits and round-trips is serviceable, and anything that does not
+// fit cannot be sent whatever its shape.
+func fitsShortNameField(name string) bool {
+	if len(name) == 0 || len(name) > 12 {
+		return false
+	}
+	// A name with more than one dot, or a dot in the wrong place, still fits the
+	// field and still opens, so it is allowed through. Only a name carrying a
+	// character the field cannot hold is refused.
+	return !strings.ContainsRune(name, 0x00)
+}
+
+// preNTResumeKey builds the resume key an entry reports, carrying the position to
+// continue from.
+//
+// ClientState is echoed from the request: [MS-CIFS] section 2.2.4.58.1 says "The
+// value provided by the client MUST be returned in each ResumeKey provided in the
+// response", so it is the client's to keep and not the server's to use.
+func preNTResumeKey(position int, from types.SMB_RESUME_KEY) types.SMB_RESUME_KEY {
+	key := types.SMB_RESUME_KEY{ClientState: from.ClientState}
+	binary.LittleEndian.PutUint32(key.ServerState[0:4], uint32(position))
+	copy(key.ServerState[4:8], preNTSearchMagic[:])
+	return key
+}
+
+// preNTPositionOf reads the position out of a resume key, and reports whether the
+// key is one this server issued.
+func preNTPositionOf(key types.SMB_RESUME_KEY) (int, bool) {
+	if !equalBytes(key.ServerState[4:8], preNTSearchMagic[:]) {
+		return 0, false
+	}
+	return int(binary.LittleEndian.Uint32(key.ServerState[0:4])), true
+}
+
+// preNTResumeKeyFrom decodes the resume key SMB_COM_FIND carries in its data
+// block, which is modelled as a string rather than as the fixed structure.
+func preNTResumeKeyFrom(raw []types.UCHAR) (types.SMB_RESUME_KEY, bool) {
+	key := types.SMB_RESUME_KEY{}
+	if len(raw) < types.SMB_RESUME_KEY_SIZE {
+		return key, false
+	}
+	if _, err := key.Unmarshal([]byte(raw)); err != nil {
+		return types.SMB_RESUME_KEY{}, false
+	}
+	return key, true
+}
+
+// equalBytes compares two byte slices, avoiding a dependency for one comparison.
+func equalBytes(a []types.UCHAR, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for index := range a {
+		if byte(a[index]) != b[index] {
+			return false
+		}
+	}
+	return true
+}
+
+// baseNameOf returns the final component of a share-relative path, which is the
+// name a listing entry carries.
+func baseNameOf(path string) string {
+	if index := strings.LastIndexAny(path, `/\`); index >= 0 {
+		return path[index+1:]
+	}
+	return path
+}

--- a/network/smb/smb_v10/server/prent_search_test.go
+++ b/network/smb/smb_v10/server/prent_search_test.go
@@ -1,0 +1,325 @@
+package server
+
+import (
+	"encoding/binary"
+	"testing"
+
+	smb1client "github.com/TheManticoreProject/Manticore/network/smb/smb_v10/client"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/codes"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+	"github.com/TheManticoreProject/Manticore/windows/nt_status"
+)
+
+// searchServer serves a directory of short-named files plus one whose name cannot
+// fit the 8.3 field.
+func searchServer(t *testing.T, names ...string) (*MemoryFileSystem, *smb1client.Client) {
+	t.Helper()
+
+	fs := NewMemoryFileSystem("FILES")
+	for _, name := range names {
+		if err := fs.AddFile(name, []byte("x")); err != nil {
+			t.Fatalf("AddFile(%q) error = %v", name, err)
+		}
+	}
+	_, client := fileServer(t, fs, false)
+	return fs, client
+}
+
+// searchEntriesOf decodes the packed entries out of an SMB_COM_SEARCH reply.
+func searchEntriesOf(t *testing.T, body []byte) []types.SMB_DIRECTORY_INFORMATION {
+	t.Helper()
+
+	response := commands.NewSearchResponse()
+	if _, err := response.Unmarshal(body); err != nil {
+		t.Fatalf("the reply did not decode: %v", err)
+	}
+
+	packed := []byte(response.SMB_Directory_Information.Buffer)
+	if len(packed)%types.SMB_DIRECTORY_INFORMATION_SIZE != 0 {
+		t.Fatalf("the entry block is %d bytes, not a whole number of %d-byte entries",
+			len(packed), types.SMB_DIRECTORY_INFORMATION_SIZE)
+	}
+
+	entries := []types.SMB_DIRECTORY_INFORMATION{}
+	for at := 0; at+types.SMB_DIRECTORY_INFORMATION_SIZE <= len(packed); at += types.SMB_DIRECTORY_INFORMATION_SIZE {
+		entry := types.NewSMB_DIRECTORY_INFORMATION()
+		if _, err := entry.Unmarshal(packed[at:]); err != nil {
+			t.Fatalf("entry at %d did not decode: %v", at, err)
+		}
+		entries = append(entries, *entry)
+	}
+
+	if int(response.Count) != len(entries) {
+		t.Errorf("the reply reports %d entries and carries %d", response.Count, len(entries))
+	}
+	return entries
+}
+
+// sendSearch sends an SMB_COM_SEARCH, optionally continuing from a resume key.
+func sendSearch(
+	t *testing.T,
+	client *smb1client.Client,
+	pattern string,
+	maxCount int,
+	resumeKey *types.SMB_RESUME_KEY,
+) (uint32, []byte) {
+	t.Helper()
+
+	request := commands.NewSearchRequest()
+	request.MaxCount = types.USHORT(maxCount)
+	if err := request.FileName.SetString(pattern); err != nil {
+		t.Fatalf("SetString() error = %v", err)
+	}
+	if resumeKey != nil {
+		request.ResumeKey = *resumeKey
+		request.ResumeKeyPresent = true
+	}
+
+	return sendLegacy(t, client, codes.SMB_COM_SEARCH, request)
+}
+
+// TestSearchEnumeratesADirectory asserts the core-set search returns the entries
+// of a directory, packed at the fixed stride.
+func TestSearchEnumeratesADirectory(t *testing.T) {
+	_, client := searchServer(t, "ONE.TXT", "TWO.TXT", "THREE.TXT")
+
+	status, body := sendSearch(t, client, `\*`, 10, nil)
+	if status != 0 {
+		t.Fatalf("the search reported 0x%08X, want success", status)
+	}
+
+	entries := searchEntriesOf(t, body)
+	if len(entries) != 3 {
+		t.Fatalf("the search returned %d entries, want 3", len(entries))
+	}
+
+	found := map[string]bool{}
+	for _, entry := range entries {
+		found[entry.FileName.GetString()] = true
+	}
+	for _, want := range []string{"ONE.TXT", "TWO.TXT", "THREE.TXT"} {
+		if !found[want] {
+			t.Errorf("the listing does not contain %q; it has %v", want, found)
+		}
+	}
+}
+
+// TestSearchResumesFromItsKey asserts a search continues where the previous
+// response left off, and finishes.
+//
+// The position travels in the resume key rather than in a server-side table, so
+// this is the assertion that the key is both issued and honoured — a server that
+// ignored it would restart the listing every call and the client would loop.
+func TestSearchResumesFromItsKey(t *testing.T) {
+	_, client := searchServer(t, "ONE.TXT", "TWO.TXT", "THREE.TXT", "FOUR.TXT")
+
+	// One entry at a time, so every step needs the key.
+	seen := []string{}
+	var key *types.SMB_RESUME_KEY
+
+	for round := 0; round < 8; round++ {
+		status, body := sendSearch(t, client, `\*`, 1, key)
+		if status == uint32(nt_status.NT_STATUS_NO_MORE_FILES) {
+			break
+		}
+		if status != 0 {
+			t.Fatalf("round %d reported 0x%08X", round, status)
+		}
+
+		entries := searchEntriesOf(t, body)
+		if len(entries) != 1 {
+			t.Fatalf("round %d returned %d entries, want 1", round, len(entries))
+		}
+		seen = append(seen, entries[0].FileName.GetString())
+
+		last := entries[len(entries)-1].ResumeKey
+		key = &last
+	}
+
+	if len(seen) != 4 {
+		t.Fatalf("the walk saw %d entries in total, want 4: %v", len(seen), seen)
+	}
+
+	// And no entry was seen twice, which is what a resume key that did not
+	// advance would produce.
+	unique := map[string]bool{}
+	for _, name := range seen {
+		if unique[name] {
+			t.Errorf("%q was returned twice; the resume key is not advancing", name)
+		}
+		unique[name] = true
+	}
+}
+
+// TestSearchRefusesAnInventedResumeKey asserts a key the server did not issue is
+// refused rather than read as a position.
+//
+// Resuming from a position derived from arbitrary bytes would return an arbitrary
+// part of the directory and present it as a continuation.
+func TestSearchRefusesAnInventedResumeKey(t *testing.T) {
+	_, client := searchServer(t, "ONE.TXT")
+
+	invented := types.SMB_RESUME_KEY{Reserved: 0xFF}
+	binary.LittleEndian.PutUint32(invented.ServerState[0:4], 0x41414141)
+
+	status, _ := sendSearch(t, client, `\*`, 10, &invented)
+	if status != uint32(nt_status.NT_STATUS_INVALID_PARAMETER) {
+		t.Errorf("an invented resume key reported 0x%08X, want STATUS_INVALID_PARAMETER (0x%08X)",
+			status, uint32(nt_status.NT_STATUS_INVALID_PARAMETER))
+	}
+}
+
+// TestSearchEchoesTheClientState asserts the client's half of the resume key comes
+// back untouched.
+//
+// [MS-CIFS] section 2.2.4.58.1: "The value provided by the client MUST be returned
+// in each ResumeKey provided in the response." It is the client's state, not the
+// server's, and a client may be keeping its own position in it.
+func TestSearchEchoesTheClientState(t *testing.T) {
+	_, client := searchServer(t, "ONE.TXT", "TWO.TXT")
+
+	// A first call to obtain a key this server issued, then continue with the
+	// client's own bytes written into it.
+	status, body := sendSearch(t, client, `\*`, 1, nil)
+	if status != 0 {
+		t.Fatalf("the first search reported 0x%08X", status)
+	}
+	key := searchEntriesOf(t, body)[0].ResumeKey
+	key.ClientState = [4]types.UCHAR{0xDE, 0xAD, 0xBE, 0xEF}
+
+	status, body = sendSearch(t, client, `\*`, 1, &key)
+	if status != 0 {
+		t.Fatalf("the continued search reported 0x%08X", status)
+	}
+
+	got := searchEntriesOf(t, body)[0].ResumeKey.ClientState
+	if got != [4]types.UCHAR{0xDE, 0xAD, 0xBE, 0xEF} {
+		t.Errorf("ClientState came back as %v, want it echoed unchanged", got)
+	}
+}
+
+// TestSearchOmitsNamesThatDoNotFitTheField asserts a name too long for the 8.3
+// field is left out rather than truncated.
+//
+// The entry's name field is thirteen bytes and this server has no 8.3 alias to
+// substitute. Truncating would name a different file, and inventing an alias would
+// hand the client a name no subsequent open could resolve — so the entry is
+// omitted, and a client that needs it has to use TRANS2_FIND_FIRST2.
+func TestSearchOmitsNamesThatDoNotFitTheField(t *testing.T) {
+	_, client := searchServer(t, "SHORT.TXT", "a-very-long-file-name.txt")
+
+	status, body := sendSearch(t, client, `\*`, 10, nil)
+	if status != 0 {
+		t.Fatalf("the search reported 0x%08X, want success", status)
+	}
+
+	entries := searchEntriesOf(t, body)
+	if len(entries) != 1 {
+		t.Fatalf("the search returned %d entries, want only the short-named one", len(entries))
+	}
+	if got := entries[0].FileName.GetString(); got != "SHORT.TXT" {
+		t.Errorf("the listing names %q, want %q", got, "SHORT.TXT")
+	}
+
+	// The long-named file is still there, and still listable at an NT level.
+	nt, err := client.ListDirectory(`\`)
+	if err != nil {
+		t.Fatalf("listing at an NT level failed: %v", err)
+	}
+	if !containsName(namesOf(nt), "a-very-long-file-name.txt") {
+		t.Error("the long-named file is missing from an NT listing too, so it was not merely omitted")
+	}
+}
+
+// TestSearchOfAnExhaustedDirectoryReportsNoMoreFiles asserts the end of a walk is
+// reported rather than answered with an empty success.
+//
+// A client given an empty successful answer asks again forever.
+func TestSearchOfAnExhaustedDirectoryReportsNoMoreFiles(t *testing.T) {
+	_, client := searchServer(t, "ONE.TXT")
+
+	status, body := sendSearch(t, client, `\*`, 10, nil)
+	if status != 0 {
+		t.Fatalf("the first search reported 0x%08X", status)
+	}
+	key := searchEntriesOf(t, body)[0].ResumeKey
+
+	status, _ = sendSearch(t, client, `\*`, 10, &key)
+	if status != uint32(nt_status.NT_STATUS_NO_MORE_FILES) {
+		t.Errorf("an exhausted search reported 0x%08X, want STATUS_NO_MORE_FILES (0x%08X)",
+			status, uint32(nt_status.NT_STATUS_NO_MORE_FILES))
+	}
+}
+
+// TestFindAndFindUniqueAreServed asserts the other two search commands answer.
+func TestFindAndFindUniqueAreServed(t *testing.T) {
+	_, client := searchServer(t, "ONE.TXT", "TWO.TXT")
+
+	t.Run("find", func(t *testing.T) {
+		request := commands.NewFindRequest()
+		request.MaxCount = types.USHORT(10)
+		if err := request.FileName.SetString(`\*`); err != nil {
+			t.Fatalf("SetString() error = %v", err)
+		}
+
+		status, body := sendLegacy(t, client, codes.SMB_COM_FIND, request)
+		if status != 0 {
+			t.Fatalf("SMB_COM_FIND reported 0x%08X, want success", status)
+		}
+
+		response := commands.NewFindResponse()
+		if _, err := response.Unmarshal(body); err != nil {
+			t.Fatalf("the reply did not decode: %v", err)
+		}
+		if int(response.Count) != 2 || len(response.DirectoryInformationData) != 2 {
+			t.Fatalf("SMB_COM_FIND returned Count=%d with %d entries, want 2",
+				response.Count, len(response.DirectoryInformationData))
+		}
+	})
+
+	t.Run("find unique", func(t *testing.T) {
+		request := commands.NewFindUniqueRequest()
+		request.MaxCount = types.USHORT(10)
+		if err := request.FileName.SetString(`\ONE.TXT`); err != nil {
+			t.Fatalf("SetString() error = %v", err)
+		}
+
+		status, body := sendLegacy(t, client, codes.SMB_COM_FIND_UNIQUE, request)
+		if status != 0 {
+			t.Fatalf("SMB_COM_FIND_UNIQUE reported 0x%08X, want success", status)
+		}
+
+		response := commands.NewFindUniqueResponse()
+		if _, err := response.Unmarshal(body); err != nil {
+			t.Fatalf("the reply did not decode: %v", err)
+		}
+		if int(response.Count) != 1 {
+			t.Fatalf("SMB_COM_FIND_UNIQUE returned %d entries for one name", response.Count)
+		}
+		if got := response.DirectoryInformationData[0].FileName.GetString(); got != "ONE.TXT" {
+			t.Errorf("it names %q, want %q", got, "ONE.TXT")
+		}
+	})
+
+	t.Run("find unique on a missing name", func(t *testing.T) {
+		request := commands.NewFindUniqueRequest()
+		request.MaxCount = types.USHORT(10)
+		if err := request.FileName.SetString(`\NOSUCH.TXT`); err != nil {
+			t.Fatalf("SetString() error = %v", err)
+		}
+
+		status, _ := sendLegacy(t, client, codes.SMB_COM_FIND_UNIQUE, request)
+		if status == 0 {
+			t.Error("SMB_COM_FIND_UNIQUE succeeded for a name that does not exist")
+		}
+	})
+
+	t.Run("find close", func(t *testing.T) {
+		request := commands.NewFindCloseRequest()
+		status, _ := sendLegacy(t, client, codes.SMB_COM_FIND_CLOSE, request)
+		if status != 0 {
+			t.Fatalf("SMB_COM_FIND_CLOSE reported 0x%08X, want success", status)
+		}
+	})
+}


### PR DESCRIPTION
### Linked Issue
`Closes #1147`

> **Stacked on #1169 and #1164.** Cut from `bugfix-directory-information-size` (#1168) with `enhancement-legacy-info-commands` (#1146, on #1162) merged in: the entries these commands return could not be encoded correctly until #1168, and the handlers use the MS-DOS date/time and legacy-attribute helpers from #1146. Merge #1163, #1164 and #1169 first.

### Root Cause
None of the four commands had an entry in `dispatchTable`, so each was answered `STATUS_NOT_IMPLEMENTED`. Together with the unserved `SMB_INFO_STANDARD` find level (#1144), that left a client which does not speak TRANSACTION2 with no way to enumerate a share at all.

### Fix Description
All four are served. Three design decisions carry most of the weight:

**The searches keep no server state.** The position travels in the resume key and the directory is read again on each call. This is what the command's own shape requires rather than a shortcut: `SMB_COM_SEARCH` has no close, so a search holding a server-side table would leak one allocation for every client that started a listing and walked away. `preNTSearchMagic` marks a key as this server's, and a key it did not issue is refused with `STATUS_INVALID_PARAMETER` rather than read as a position — resuming from arbitrary bytes would return an arbitrary slice of the directory and present it as a continuation.

The cost is stated rather than hidden: the listing is a fresh view each call, not a snapshot, so an entry created or removed between calls may be seen twice or missed. The command offers no way to avoid that; `TRANS2_FIND_FIRST2`, which does keep a snapshot, is what a client uses when it matters.

**`ClientState` is echoed untouched.** [MS-CIFS] 2.2.4.58.1: "The value provided by the client MUST be returned in each ResumeKey provided in the response." It is the client's state and may hold the client's own position, so the server writes only its own half.

**Names that do not fit the 8.3 field are omitted, and this is the honest option rather than the convenient one.** The entry's name field is thirteen bytes — twelve plus a terminator — and this server has no 8.3 alias to substitute. The three possibilities were: truncate, which names a different file; synthesise an alias like `LONGFI~1.TXT`, which hands the client a name that no subsequent open could resolve because the alias is not a real name and there is no reverse mapping; or omit the entry. Omission is the only one that does not actively mislead. It is logged, documented, and the test asserts the file is still visible at an NT level so the limitation is scoped to these commands.

Smaller points: a wildcard-free path names one entry and is `Stat`ed rather than read as a directory, which is what `SMB_COM_FIND_UNIQUE` exists for and which the other two also accept; an exhausted walk answers `STATUS_NO_MORE_FILES` rather than an empty success, because a client given an empty successful answer asks again forever; `SMB_COM_FIND_UNIQUE` on a missing name answers `STATUS_NO_SUCH_FILE`; and `SMB_COM_FIND_CLOSE` validates the TID and answers success, which is accurate rather than a stub — there is provably nothing to release, and reporting an error would make an orderly client look mistaken.

### How Verified
Runtime, over the loopback harness, with the packed entry arrays decoded at the fixed 43-byte stride — the same way a client reads them.

- `TestSearchEnumeratesADirectory` — three files come back, packed at a whole number of entries.
- `TestSearchResumesFromItsKey` — a one-entry-at-a-time walk over four files sees all four and none twice. This is the assertion that the key is both issued and honoured; a server ignoring it would restart every call and the client would loop.
- `TestSearchRefusesAnInventedResumeKey` — `STATUS_INVALID_PARAMETER`.
- `TestSearchEchoesTheClientState` — the client's four bytes survive a round trip.
- `TestSearchOmitsNamesThatDoNotFitTheField` — the long-named file is absent from the core-set listing and present in an NT one, so it was omitted rather than lost.
- `TestSearchOfAnExhaustedDirectoryReportsNoMoreFiles` — `STATUS_NO_MORE_FILES`.
- `TestFindAndFindUniqueAreServed` — `SMB_COM_FIND` returns both entries; `SMB_COM_FIND_UNIQUE` returns exactly the one name asked for and fails on a missing one; `SMB_COM_FIND_CLOSE` succeeds.

Whole tree green: `go build ./...`, `go test ./network/smb/...`. `gofmt -l` clean on every file touched.

### Test Coverage
**Added:** `server/prent_search_test.go` — the seven tests above, plus `searchServer`, `searchEntriesOf` (which asserts the block is a whole number of entries and that the reported count matches what it carries) and `sendSearch`.

**Modified:** `server/conformance_test.go` — the four commands registered in `servedCommands`, and one guard changed, explained below.

### Scope of Change
- **Files changed:** `server/handler_prent_search.go` (new), `server/prent_search_test.go` (new), `server/dispatch.go`, `server/conformance_test.go`, `server/doc.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** one, in a test guard rather than in the server. `TestConformanceUnservedCommandsAreRefused` asserted `exercised >= 40`, and serving four more commands moved them out of that walk and took the count to 37. Editing the number down would have made the guard a record of past progress that has to be revised every time the server grows. The guard's purpose is to catch a message layer that stopped recognising commands, so it is now `known >= 70` — which says that directly and stays true as commands become served. The real invariant in that test, that every known command is accounted for as exercised, served or unmarshalable, is untouched.

### Risk and Rollout
Additive: all four commands were refused before, so no existing exchange changes shape. The searches allocate nothing that outlives a request, so there is no new state to leak or exhaust, and `preNTSearchLimit` bounds one response to 512 entries — 22 KiB at the fixed stride — whatever the client asks for.

### Notes
The 8.3 omission above is the one functional gap. Closing it needs either a persistent alias table on the share or an 8.3 generator with a reverse mapping in `resolvePath`, so that a name the server offers is a name it will also open. That is a share-level feature rather than part of serving these commands, and worth its own issue if a client in the interop matrix (#1153) turns out to need it.

`SMB_COM_FIND_NOTIFY_CLOSE` is still unserved: it pairs with the `TRANS2_FIND_NOTIFY_FIRST`/`NEXT` subcommands, which need the out-of-band response path from #1141, so it belongs with #1152 rather than here.
