### PR TITLE
Fix WriteRequest emitting its data before WordCount (Fixes #1171)

### DIFF
--- a/network/smb/smb_v10/message/commands/WriteRequest.go
+++ b/network/smb/smb_v10/message/commands/WriteRequest.go
@@ -105,12 +105,17 @@ func (c *WriteRequest) Marshal() ([]byte, error) {
 	rawDataContent := []byte{}
 
 	// Marshalling data Data
+	//
+	// This goes into rawDataContent, which becomes the SMB_Data block below. It
+	// once went into marshalledCommand, which is the whole command: that emitted
+	// the payload ahead of WordCount and left the data block empty, so the
+	// message could not be decoded at all.
 	c.Data.SetBufferFormat(types.SMB_STRING_BUFFER_FORMAT_VARIABLE_BLOCK_16BIT)
 	marshalledDataField, err := c.Data.Marshal()
 	if err != nil {
 		return nil, err
 	}
-	marshalledCommand = append(marshalledCommand, marshalledDataField...)
+	rawDataContent = append(rawDataContent, marshalledDataField...)
 
 	// Then marshal the parameters
 	rawParametersContent := []byte{}

--- a/network/smb/smb_v10/message/commands/WriteRequest_wire_test.go
+++ b/network/smb/smb_v10/message/commands/WriteRequest_wire_test.go
@@ -1,0 +1,106 @@
+package commands
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+)
+
+// TestWriteRequestPutsItsDataInTheDataBlock asserts the command marshals as
+// WordCount, the parameter words, ByteCount and then the data — the order
+// [MS-CIFS] section 2.2.4.12.1 gives it.
+//
+// The data field once went into the command buffer rather than the data block,
+// which emitted the payload ahead of WordCount and left the data block empty. The
+// result was not merely mis-sized: a decoder read the leading buffer-format byte
+// as WordCount, so the message could not be parsed at all.
+func TestWriteRequestPutsItsDataInTheDataBlock(t *testing.T) {
+	payload := []byte("bytes to write")
+
+	request := NewWriteRequest()
+	request.FID = types.USHORT(0x0042)
+	request.CountOfBytesToWrite = types.USHORT(len(payload))
+	request.WriteOffsetInBytes = types.ULONG(0x11223344)
+	request.Data.Buffer = []types.UCHAR(payload)
+
+	marshalled, err := request.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+
+	// WordCount is five words: FID(2) CountOfBytesToWrite(2) WriteOffsetInBytes(4)
+	// EstimateOfRemainingBytesToBeWritten(2).
+	const wantWords = 5
+	if got := int(marshalled[0]); got != wantWords {
+		t.Fatalf("the command begins with 0x%02X as WordCount, want %d — the data block is in front of it",
+			marshalled[0], wantWords)
+	}
+
+	if fid := binary.LittleEndian.Uint16(marshalled[1:3]); fid != 0x0042 {
+		t.Errorf("FID is 0x%04X at the first parameter word, want 0x0042", fid)
+	}
+	if offset := binary.LittleEndian.Uint32(marshalled[5:9]); offset != 0x11223344 {
+		t.Errorf("WriteOffsetInBytes is 0x%08X, want 0x11223344", offset)
+	}
+
+	// ByteCount follows the words and has to describe the data block that
+	// follows it: BufferFormat(1) DataLength(2) Data.
+	byteCountAt := 1 + 2*wantWords
+	byteCount := int(binary.LittleEndian.Uint16(marshalled[byteCountAt : byteCountAt+2]))
+	wantByteCount := 1 + 2 + len(payload)
+	if byteCount != wantByteCount {
+		t.Fatalf("ByteCount is %d, want %d — the data block is empty", byteCount, wantByteCount)
+	}
+	if len(marshalled) != byteCountAt+2+wantByteCount {
+		t.Fatalf("the command is %d bytes, want %d", len(marshalled), byteCountAt+2+wantByteCount)
+	}
+
+	block := marshalled[byteCountAt+2:]
+	if block[0] != types.SMB_STRING_BUFFER_FORMAT_VARIABLE_BLOCK_16BIT {
+		t.Errorf("the data block begins with BufferFormat 0x%02X, want 0x01", block[0])
+	}
+	if declared := int(binary.LittleEndian.Uint16(block[1:3])); declared != len(payload) {
+		t.Errorf("the data block declares %d bytes, want %d", declared, len(payload))
+	}
+	if got := string(block[3:]); got != string(payload) {
+		t.Errorf("the data block carries %q, want %q", got, payload)
+	}
+}
+
+// TestWriteRequestRoundTrips asserts the command decodes what it encodes, which it
+// could not while its payload sat in front of the word count.
+func TestWriteRequestRoundTrips(t *testing.T) {
+	payload := []byte("bytes to write")
+
+	request := NewWriteRequest()
+	request.FID = types.USHORT(0x0042)
+	request.CountOfBytesToWrite = types.USHORT(len(payload))
+	request.WriteOffsetInBytes = types.ULONG(0x11223344)
+	request.Data.Buffer = []types.UCHAR(payload)
+
+	marshalled, err := request.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+
+	decoded := NewWriteRequest()
+	if _, err := decoded.Unmarshal(marshalled); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+
+	if decoded.FID != request.FID {
+		t.Errorf("FID round-tripped to 0x%04X, want 0x%04X", decoded.FID, request.FID)
+	}
+	if decoded.CountOfBytesToWrite != request.CountOfBytesToWrite {
+		t.Errorf("CountOfBytesToWrite round-tripped to %d, want %d",
+			decoded.CountOfBytesToWrite, request.CountOfBytesToWrite)
+	}
+	if decoded.WriteOffsetInBytes != request.WriteOffsetInBytes {
+		t.Errorf("WriteOffsetInBytes round-tripped to 0x%08X, want 0x%08X",
+			decoded.WriteOffsetInBytes, request.WriteOffsetInBytes)
+	}
+	if got := string(decoded.Data.Buffer); got != string(payload) {
+		t.Errorf("the data round-tripped to %q, want %q", got, payload)
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #1171`

### Root Cause
One wrong destination variable. `Marshal` prepares `rawDataContent` to become the SMB_Data block, marshals the data field into `marshalledDataField`, and then appended it to `marshalledCommand` — the whole command — instead of to `rawDataContent`.

Two things followed. `rawDataContent` was still empty when it reached `GetData().Add(...)`, so the data block went out with `ByteCount` 0 and no bytes; and because the parameter block is appended to `marshalledCommand` *after* that point, the payload ended up ahead of `WordCount`. The emitted layout was `BufferFormat(1) DataLength(2) Data WordCount(1) Words ByteCount(2)`.

That is not a mis-sized message but an unparseable one: a decoder reads the first byte as `WordCount` and gets the buffer-format byte `0x01`, so it expects one parameter word and everything after it is misaligned. The server answers `STATUS_INVALID_SMB` and logs `data too short to unmarshal SMB parameters`.

Every other command in the package appends to `rawDataContent` at this point, and the comment two lines above — "First marshal the data and then the parameters" — describes what was intended.

### Fix Description
The data field is appended to `rawDataContent`. A comment records what the wrong buffer did, because the two variable names are similar enough that the next reader could make the same substitution.

### How Verified
Runtime, with new tests. Before the fix `TestWriteRequestPutsItsDataInTheDataBlock` fails on its first assertion — the command begins with `0x01` where `WordCount` belongs — and `TestWriteRequestRoundTrips` fails to decode at all.

- `TestWriteRequestPutsItsDataInTheDataBlock` walks the emitted bytes in order: `WordCount` is 5, `FID` and `WriteOffsetInBytes` are at their parameter offsets, `ByteCount` describes the block that follows it, the total length matches, and the block is `BufferFormat(0x01) DataLength(2) Data` carrying the payload. Checking `ByteCount` against the block it precedes is the assertion that catches an empty data block, which is the other half of this defect.
- `TestWriteRequestRoundTrips` decodes the command back and compares the FID, count, offset and payload.

Whole tree green: `go build ./...`, `go test ./network/smb/...`. `gofmt -l` clean on both files.

### Test Coverage
**Added:** `message/commands/WriteRequest_wire_test.go` — the two tests above. The command had no marshalling test, which is why a defect this complete survived.

### Scope of Change
- **Files changed:** `message/commands/WriteRequest.go`, `message/commands/WriteRequest_wire_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Low. `SMB_COM_WRITE` has no server handler and no client caller today, so nothing was producing these messages — the defect was total but unreached. Any consumer added from here gets a correct message.

### Notes
Prerequisite for #1145, which serves `SMB_COM_WRITE`; the handler could not have received a decodable request. Found by writing the handler's test first, which is what turned a latent total failure into a visible one.

`WriteAndCloseRequest` carries its data as a plain byte slice rather than through an `SMB_STRING` and is unaffected. Worth a look while nearby: the other commands whose data fields go through this same pattern have no marshalling test either, and this one was wrong for what looks like a copy-paste substitution.
