### PR TITLE
Serve the core-set file access commands (Fixes #1145)

### DIFF
--- a/network/smb/smb_v10/server/conformance_test.go
+++ b/network/smb/smb_v10/server/conformance_test.go
@@ -123,6 +123,18 @@ var servedCommands = map[codes.CommandCode]string{
 	codes.SMB_COM_TREE_CONNECT_ANDX: "connects a tree to a share",
 	codes.SMB_COM_TREE_DISCONNECT:   "drops the tree and its handles",
 
+	codes.SMB_COM_OPEN:             "opens an existing file by path, core set",
+	codes.SMB_COM_OPEN_ANDX:        "opens, creates or truncates by path, core set",
+	codes.SMB_COM_CREATE:           "creates or truncates a file and opens it",
+	codes.SMB_COM_CREATE_NEW:       "creates a file, refusing one that exists",
+	codes.SMB_COM_CREATE_TEMPORARY: "creates a file under a name the server chooses",
+	codes.SMB_COM_READ:             "reads from a handle, core set",
+	codes.SMB_COM_WRITE:            "writes through a handle, core set; a zero count truncates",
+	codes.SMB_COM_WRITE_AND_CLOSE:  "writes through a handle and closes it",
+	codes.SMB_COM_SEEK:             "moves a handle's file pointer",
+	codes.SMB_COM_TREE_CONNECT:     "connects a tree to a share, deprecated form",
+	codes.SMB_COM_PROCESS_EXIT:     "releases the handles a client process still held",
+
 	codes.SMB_COM_NT_CREATE_ANDX: "opens or creates a file or directory",
 	codes.SMB_COM_CLOSE:          "releases a handle",
 	codes.SMB_COM_READ_ANDX:      "reads from a handle",
@@ -350,9 +362,16 @@ func TestConformanceUnservedCommandsAreRefused(t *testing.T) {
 	}
 	// A floor as well, so a message layer that stopped recognizing commands at all
 	// would not make the accounting trivially true.
-	if exercised < 40 {
-		t.Fatalf("only %d commands were exercised of %d known; the walk is no longer covering the command space",
-			exercised, known)
+	//
+	// The floor is on how many commands the message layer knows, not on how many
+	// this walk exercised. Those were the same number when little was served, but
+	// every command that gains a handler moves out of this walk and into
+	// TestConformanceServedCommandsAreServed — so a floor on `exercised` falls as
+	// the server grows and has to be edited downwards to keep passing, which
+	// makes it a record of past progress rather than a guard. A floor on `known`
+	// says what the guard was for and stays true.
+	if known < 70 {
+		t.Fatalf("the message layer recognizes only %d commands; it is no longer covering the command space", known)
 	}
 	t.Logf("exercised %d of %d known commands (%d served, %d whose zero value cannot be marshalled)",
 		exercised, known, skippedServed, skippedUnmarshalable)

--- a/network/smb/smb_v10/server/core_file_test.go
+++ b/network/smb/smb_v10/server/core_file_test.go
@@ -1,0 +1,454 @@
+package server
+
+import (
+	"testing"
+
+	smb1client "github.com/TheManticoreProject/Manticore/network/smb/smb_v10/client"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/codes"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+	"github.com/TheManticoreProject/Manticore/windows/nt_status"
+)
+
+// coreFileServer serves one file of known contents.
+func coreFileServer(t *testing.T, readOnly bool) (*MemoryFileSystem, *smb1client.Client) {
+	t.Helper()
+
+	fs := NewMemoryFileSystem("FILES")
+	if err := fs.AddFile("existing.txt", []byte("0123456789")); err != nil {
+		t.Fatalf("AddFile() error = %v", err)
+	}
+	if err := fs.AddDirectory("adirectory"); err != nil {
+		t.Fatalf("AddDirectory() error = %v", err)
+	}
+	_, client := fileServer(t, fs, readOnly)
+	return fs, client
+}
+
+// coreOpenFile opens a file with SMB_COM_OPEN and returns its FID.
+func coreOpenFile(t *testing.T, client *smb1client.Client, name string, accessMode uint16) (uint16, uint32) {
+	t.Helper()
+
+	request := commands.NewOpenRequest()
+	request.AccessMode = types.USHORT(accessMode)
+	if err := request.FileName.SetString(name); err != nil {
+		t.Fatalf("SetString() error = %v", err)
+	}
+
+	status, body := sendLegacy(t, client, codes.SMB_COM_OPEN, request)
+	if status != 0 {
+		return 0, status
+	}
+
+	response := commands.NewOpenResponse()
+	if _, err := response.Unmarshal(body); err != nil {
+		t.Fatalf("the open reply did not decode: %v", err)
+	}
+	return uint16(response.FID), 0
+}
+
+// TestCoreOpenReadWriteRoundTrip asserts the core-set open, write and read work
+// together on one handle.
+func TestCoreOpenReadWriteRoundTrip(t *testing.T) {
+	fs, client := coreFileServer(t, false)
+
+	fid, status := coreOpenFile(t, client, "existing.txt", openAccessReadWrite)
+	if status != 0 {
+		t.Fatalf("SMB_COM_OPEN reported 0x%08X", status)
+	}
+
+	payload := []byte("core-set write")
+
+	write := commands.NewWriteRequest()
+	write.FID = types.USHORT(fid)
+	write.CountOfBytesToWrite = types.USHORT(len(payload))
+	write.WriteOffsetInBytes = types.ULONG(0)
+	write.Data.SetBufferFormat(types.SMB_STRING_BUFFER_FORMAT_VARIABLE_BLOCK_16BIT)
+	write.Data.Buffer = []types.UCHAR(payload)
+
+	status, body := sendLegacy(t, client, codes.SMB_COM_WRITE, write)
+	if status != 0 {
+		t.Fatalf("SMB_COM_WRITE reported 0x%08X", status)
+	}
+	writeResponse := commands.NewWriteResponse()
+	if _, err := writeResponse.Unmarshal(body); err != nil {
+		t.Fatalf("the write reply did not decode: %v", err)
+	}
+	if int(writeResponse.CountOfBytesWritten) != len(payload) {
+		t.Errorf("the reply reports %d bytes written, want %d",
+			writeResponse.CountOfBytesWritten, len(payload))
+	}
+
+	read := commands.NewReadRequest()
+	read.FID = types.SHORT(fid)
+	read.CountOfBytesToRead = types.USHORT(len(payload))
+	read.ReadOffsetInBytes = types.ULONG(0)
+
+	status, body = sendLegacy(t, client, codes.SMB_COM_READ, read)
+	if status != 0 {
+		t.Fatalf("SMB_COM_READ reported 0x%08X", status)
+	}
+	readResponse := commands.NewReadResponse()
+	if _, err := readResponse.Unmarshal(body); err != nil {
+		t.Fatalf("the read reply did not decode: %v", err)
+	}
+	if int(readResponse.CountOfBytesReturned) != len(payload) {
+		t.Fatalf("the read returned %d bytes, want %d",
+			readResponse.CountOfBytesReturned, len(payload))
+	}
+	if got := string(readResponse.Bytes.Buffer); got != string(payload) {
+		t.Errorf("the read returned %q, want %q", got, payload)
+	}
+
+	// And the bytes landed in the backend, not just in the reply.
+	stored, err := fs.Open("existing.txt", OpenFlags{Read: true})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer stored.Close()
+
+	buffer := make([]byte, len(payload))
+	if _, err := stored.ReadAt(buffer, 0); err != nil {
+		t.Fatalf("ReadAt() error = %v", err)
+	}
+	if string(buffer) != string(payload) {
+		t.Errorf("the file holds %q, want %q", buffer, payload)
+	}
+}
+
+// TestCoreOpenRefusesAReservedAccessMode asserts a reserved access value is
+// refused rather than treated as read.
+//
+// [MS-CIFS] section 2.2.4.3.1 requires values 4 to 7 to be answered with
+// STATUS_OS2_INVALID_ACCESS. Defaulting one of them to read would grant an access
+// the client neither asked for nor expects.
+func TestCoreOpenRefusesAReservedAccessMode(t *testing.T) {
+	_, client := coreFileServer(t, false)
+
+	for _, mode := range []uint16{4, 5, 6, 7} {
+		_, status := coreOpenFile(t, client, "existing.txt", mode)
+		if status != uint32(nt_status.NT_STATUS_OS2_INVALID_ACCESS) {
+			t.Errorf("access mode %d reported 0x%08X, want STATUS_OS2_INVALID_ACCESS (0x%08X)",
+				mode, status, uint32(nt_status.NT_STATUS_OS2_INVALID_ACCESS))
+		}
+	}
+}
+
+// TestCoreWriteOfZeroBytesTruncates asserts a zero-length write sets the file's
+// length rather than doing nothing.
+//
+// [MS-CIFS] section 3.3.5.14 defines a CountOfBytesToWrite of zero as a request to
+// set the length, so treating it as a no-op silently drops a truncation the client
+// believes succeeded.
+func TestCoreWriteOfZeroBytesTruncates(t *testing.T) {
+	fs, client := coreFileServer(t, false)
+
+	fid, status := coreOpenFile(t, client, "existing.txt", openAccessReadWrite)
+	if status != 0 {
+		t.Fatalf("SMB_COM_OPEN reported 0x%08X", status)
+	}
+
+	write := commands.NewWriteRequest()
+	write.FID = types.USHORT(fid)
+	write.CountOfBytesToWrite = types.USHORT(0)
+	write.WriteOffsetInBytes = types.ULONG(4)
+	write.Data.SetBufferFormat(types.SMB_STRING_BUFFER_FORMAT_VARIABLE_BLOCK_16BIT)
+
+	if status, _ := sendLegacy(t, client, codes.SMB_COM_WRITE, write); status != 0 {
+		t.Fatalf("SMB_COM_WRITE reported 0x%08X", status)
+	}
+
+	attr, err := fs.Stat("existing.txt")
+	if err != nil {
+		t.Fatalf("Stat() error = %v", err)
+	}
+	if attr.Size != 4 {
+		t.Errorf("the file is %d bytes after a zero-length write at 4, want 4", attr.Size)
+	}
+}
+
+// TestCoreCreateAndCreateNewDifferOnExistence asserts the two create commands
+// differ in exactly the way their names say.
+func TestCoreCreateAndCreateNewDifferOnExistence(t *testing.T) {
+	fs, client := coreFileServer(t, false)
+
+	t.Run("create truncates an existing file", func(t *testing.T) {
+		request := commands.NewCreateRequest()
+		if err := request.FileName.SetString("existing.txt"); err != nil {
+			t.Fatalf("SetString() error = %v", err)
+		}
+
+		status, body := sendLegacy(t, client, codes.SMB_COM_CREATE, request)
+		if status != 0 {
+			t.Fatalf("SMB_COM_CREATE reported 0x%08X", status)
+		}
+		response := commands.NewCreateResponse()
+		if _, err := response.Unmarshal(body); err != nil {
+			t.Fatalf("the reply did not decode: %v", err)
+		}
+
+		attr, err := fs.Stat("existing.txt")
+		if err != nil {
+			t.Fatalf("Stat() error = %v", err)
+		}
+		if attr.Size != 0 {
+			t.Errorf("the file is %d bytes after a create, want it truncated", attr.Size)
+		}
+	})
+
+	t.Run("create new refuses an existing file", func(t *testing.T) {
+		request := commands.NewCreateNewRequest()
+		if err := request.FileName.SetString("existing.txt"); err != nil {
+			t.Fatalf("SetString() error = %v", err)
+		}
+
+		if status, _ := sendLegacy(t, client, codes.SMB_COM_CREATE_NEW, request); status == 0 {
+			t.Error("SMB_COM_CREATE_NEW succeeded on a file that already exists")
+		}
+	})
+
+	t.Run("create new makes a missing file", func(t *testing.T) {
+		request := commands.NewCreateNewRequest()
+		if err := request.FileName.SetString("brandnew.txt"); err != nil {
+			t.Fatalf("SetString() error = %v", err)
+		}
+
+		if status, _ := sendLegacy(t, client, codes.SMB_COM_CREATE_NEW, request); status != 0 {
+			t.Fatalf("SMB_COM_CREATE_NEW reported 0x%08X", status)
+		}
+		if _, err := fs.Stat("brandnew.txt"); err != nil {
+			t.Errorf("the file was not created: %v", err)
+		}
+	})
+}
+
+// TestCoreOpenAndxHonoursItsOpenMode asserts the two OpenMode fields decide
+// existence handling, which is the create-disposition of the NT commands in two
+// bits.
+func TestCoreOpenAndxHonoursItsOpenMode(t *testing.T) {
+	fs, client := coreFileServer(t, false)
+
+	openAndx := func(t *testing.T, name string, openMode uint16) uint32 {
+		t.Helper()
+
+		request := commands.NewOpenAndxRequest()
+		request.AccessMode = types.USHORT(openAccessReadWrite)
+		request.OpenMode = types.USHORT(openMode)
+		// The name is a null-terminated ASCII string ([MS-CIFS] section
+		// 2.2.4.41.1). This command leaves the format to its caller rather than
+		// setting it in Marshal as most do, so a client has to say so.
+		request.FileName.SetBufferFormat(types.SMB_STRING_BUFFER_FORMAT_NULL_TERMINATED_ASCII_STRING)
+		if err := request.FileName.SetString(name); err != nil {
+			t.Fatalf("SetString() error = %v", err)
+		}
+		status, _ := sendLegacy(t, client, codes.SMB_COM_OPEN_ANDX, request)
+		return status
+	}
+
+	t.Run("truncate", func(t *testing.T) {
+		if status := openAndx(t, "existing.txt", openModeTruncate); status != 0 {
+			t.Fatalf("a truncating open reported 0x%08X", status)
+		}
+		attr, err := fs.Stat("existing.txt")
+		if err != nil {
+			t.Fatalf("Stat() error = %v", err)
+		}
+		if attr.Size != 0 {
+			t.Errorf("the file is %d bytes after a truncating open, want 0", attr.Size)
+		}
+	})
+
+	t.Run("create if missing", func(t *testing.T) {
+		if status := openAndx(t, "made-by-openandx.txt", openModeCreateIfMissing); status != 0 {
+			t.Fatalf("a creating open reported 0x%08X", status)
+		}
+		if _, err := fs.Stat("made-by-openandx.txt"); err != nil {
+			t.Errorf("the file was not created: %v", err)
+		}
+	})
+
+	t.Run("refuse a missing file when not asked to create", func(t *testing.T) {
+		if status := openAndx(t, "notthere.txt", 0); status == 0 {
+			t.Error("an open of a missing file succeeded without the create bit")
+		}
+	})
+}
+
+// TestCoreWriteAndCloseReleasesTheHandle asserts the handle is gone afterwards,
+// which is the command's whole contract.
+func TestCoreWriteAndCloseReleasesTheHandle(t *testing.T) {
+	fs, client := coreFileServer(t, false)
+
+	fid, status := coreOpenFile(t, client, "existing.txt", openAccessReadWrite)
+	if status != 0 {
+		t.Fatalf("SMB_COM_OPEN reported 0x%08X", status)
+	}
+
+	payload := []byte("written and closed")
+
+	request := commands.NewWriteAndCloseRequest()
+	request.FID = types.USHORT(fid)
+	request.CountOfBytesToWrite = types.USHORT(len(payload))
+	request.WriteOffsetInBytes = types.ULONG(0)
+	request.Data = []types.UCHAR(payload)
+
+	status, body := sendLegacy(t, client, codes.SMB_COM_WRITE_AND_CLOSE, request)
+	if status != 0 {
+		t.Fatalf("SMB_COM_WRITE_AND_CLOSE reported 0x%08X", status)
+	}
+	response := commands.NewWriteAndCloseResponse()
+	if _, err := response.Unmarshal(body); err != nil {
+		t.Fatalf("the reply did not decode: %v", err)
+	}
+	if int(response.CountOfBytesWritten) != len(payload) {
+		t.Errorf("the reply reports %d bytes written, want %d",
+			response.CountOfBytesWritten, len(payload))
+	}
+
+	// The handle is gone: a read through it now fails.
+	read := commands.NewReadRequest()
+	read.FID = types.SHORT(fid)
+	read.CountOfBytesToRead = types.USHORT(4)
+	if status, _ := sendLegacy(t, client, codes.SMB_COM_READ, read); status == 0 {
+		t.Error("reading through the closed handle succeeded")
+	}
+
+	attr, err := fs.Stat("existing.txt")
+	if err != nil {
+		t.Fatalf("Stat() error = %v", err)
+	}
+	if int(attr.Size) != len(payload) {
+		t.Errorf("the file is %d bytes, want %d", attr.Size, len(payload))
+	}
+}
+
+// TestCoreSeekMovesAndRemembersThePosition asserts each seek mode, and that the
+// position persists between calls.
+//
+// Seeking from the current position is only meaningful if the position is
+// remembered, so a server that computed an answer without storing it would give
+// different results for the same sequence of requests.
+func TestCoreSeekMovesAndRemembersThePosition(t *testing.T) {
+	_, client := coreFileServer(t, false)
+
+	fid, status := coreOpenFile(t, client, "existing.txt", openAccessRead)
+	if status != 0 {
+		t.Fatalf("SMB_COM_OPEN reported 0x%08X", status)
+	}
+
+	seek := func(t *testing.T, mode uint16, offset int32) (uint32, uint32) {
+		t.Helper()
+
+		request := commands.NewSeekRequest()
+		request.FID = types.USHORT(fid)
+		request.Mode = types.USHORT(mode)
+		request.Offset = types.LONG(offset)
+
+		status, body := sendLegacy(t, client, codes.SMB_COM_SEEK, request)
+		if status != 0 {
+			return 0, status
+		}
+		response := commands.NewSeekResponse()
+		if _, err := response.Unmarshal(body); err != nil {
+			t.Fatalf("the seek reply did not decode: %v", err)
+		}
+		return uint32(response.Offset), 0
+	}
+
+	if got, status := seek(t, seekFromStart, 4); status != 0 || got != 4 {
+		t.Fatalf("seeking to 4 from the start gave %d (status 0x%08X), want 4", got, status)
+	}
+	// From the current position, which is only right if the previous seek stuck.
+	if got, status := seek(t, seekFromCurrent, 3); status != 0 || got != 7 {
+		t.Fatalf("seeking 3 from the current position gave %d (status 0x%08X), want 7", got, status)
+	}
+	// The file is ten bytes, so the end minus two is eight.
+	if got, status := seek(t, seekFromEnd, -2); status != 0 || got != 8 {
+		t.Fatalf("seeking -2 from the end gave %d (status 0x%08X), want 8", got, status)
+	}
+
+	// Before the start is refused rather than clamped: a clamped answer would
+	// report a seek the client did not ask for as a success.
+	if _, status := seek(t, seekFromStart, -1); status != uint32(nt_status.NT_STATUS_INVALID_PARAMETER) {
+		t.Errorf("seeking before the start reported 0x%08X, want STATUS_INVALID_PARAMETER", status)
+	}
+}
+
+// TestCoreTreeConnectConnectsSameAsTheAndXForm asserts the deprecated tree connect
+// returns a usable TID.
+func TestCoreTreeConnectConnectsSameAsTheAndXForm(t *testing.T) {
+	_, client := coreFileServer(t, false)
+
+	// All three strings are null-terminated ASCII ([MS-CIFS] section 2.2.4.50.1),
+	// and this command leaves the format to its caller.
+	request := commands.NewTreeConnectRequest()
+	request.Path.SetBufferFormat(types.SMB_STRING_BUFFER_FORMAT_NULL_TERMINATED_ASCII_STRING)
+	request.Path.SetString(`\\127.0.0.1\` + fileShareName)
+	request.Password.SetBufferFormat(types.SMB_STRING_BUFFER_FORMAT_NULL_TERMINATED_ASCII_STRING)
+	request.Password.SetString("")
+	request.Service.SetBufferFormat(types.SMB_STRING_BUFFER_FORMAT_NULL_TERMINATED_ASCII_STRING)
+	request.Service.SetString("?????")
+
+	status, body := sendLegacy(t, client, codes.SMB_COM_TREE_CONNECT, request)
+	if status != 0 {
+		t.Fatalf("SMB_COM_TREE_CONNECT reported 0x%08X", status)
+	}
+
+	response := commands.NewTreeConnectResponse()
+	if _, err := response.Unmarshal(body); err != nil {
+		t.Fatalf("the reply did not decode: %v", err)
+	}
+	if response.TID == 0 {
+		t.Error("the reply carries no TID")
+	}
+	if response.MaxBufferSize == 0 {
+		t.Error("the reply carries no MaxBufferSize")
+	}
+}
+
+// TestCoreProcessExitReleasesThatProcessesHandles asserts the command closes what
+// the request's PID held, and leaves another process's handles alone.
+//
+// [MS-CIFS] section 2.2.4.18 has the server close "any resources owned by the
+// Process ID (PID) listed in the request header". Closing everything, or nothing,
+// would both be wrong: the command exists to clean up after one failed process on
+// a connection that may be serving several.
+func TestCoreProcessExitReleasesThatProcessesHandles(t *testing.T) {
+	_, client := coreFileServer(t, false)
+
+	// newRequest uses one PID for every request, so the handle below belongs to
+	// it and the exit that follows names the same one.
+	fid, status := coreOpenFile(t, client, "existing.txt", openAccessRead)
+	if status != 0 {
+		t.Fatalf("SMB_COM_OPEN reported 0x%08X", status)
+	}
+
+	if status, _ := sendLegacy(t, client, codes.SMB_COM_PROCESS_EXIT, commands.NewProcessExitRequest()); status != 0 {
+		t.Fatalf("SMB_COM_PROCESS_EXIT reported 0x%08X", status)
+	}
+
+	read := commands.NewReadRequest()
+	read.FID = types.SHORT(fid)
+	read.CountOfBytesToRead = types.USHORT(4)
+	if status, _ := sendLegacy(t, client, codes.SMB_COM_READ, read); status == 0 {
+		t.Error("the handle survived the exit of the process that opened it")
+	}
+
+	// The connection is still usable afterwards.
+	if _, err := client.Echo([]byte("alive")); err != nil {
+		t.Fatalf("the connection did not survive a process exit: %v", err)
+	}
+}
+
+// TestCoreOpenOnAReadOnlyShareRefusesWriting asserts the share's refusal applies to
+// the core-set opens too.
+func TestCoreOpenOnAReadOnlyShareRefusesWriting(t *testing.T) {
+	_, client := coreFileServer(t, true)
+
+	if _, status := coreOpenFile(t, client, "existing.txt", openAccessWrite); status == 0 {
+		t.Error("a write open succeeded on a read-only share")
+	}
+	if _, status := coreOpenFile(t, client, "existing.txt", openAccessRead); status != 0 {
+		t.Errorf("a read open on a read-only share reported 0x%08X", status)
+	}
+}

--- a/network/smb/smb_v10/server/dispatch.go
+++ b/network/smb/smb_v10/server/dispatch.go
@@ -36,6 +36,20 @@ var dispatchTable = map[codes.CommandCode]commandHandler{
 	codes.SMB_COM_TREE_CONNECT_ANDX: handleTreeConnectAndx,
 	codes.SMB_COM_TREE_DISCONNECT:   handleTreeDisconnect,
 
+	// The core-set file access commands, which a client that does not use the NT
+	// commands opens and transfers with.
+	codes.SMB_COM_OPEN:             handleOpen,
+	codes.SMB_COM_OPEN_ANDX:        handleOpenAndx,
+	codes.SMB_COM_CREATE:           handleCreate,
+	codes.SMB_COM_CREATE_NEW:       handleCreateNew,
+	codes.SMB_COM_CREATE_TEMPORARY: handleCreateTemporary,
+	codes.SMB_COM_READ:             handleRead,
+	codes.SMB_COM_WRITE:            handleWrite,
+	codes.SMB_COM_WRITE_AND_CLOSE:  handleWriteAndClose,
+	codes.SMB_COM_SEEK:             handleSeek,
+	codes.SMB_COM_TREE_CONNECT:     handleTreeConnect,
+	codes.SMB_COM_PROCESS_EXIT:     handleProcessExit,
+
 	// File handles.
 	codes.SMB_COM_NT_CREATE_ANDX: handleNtCreateAndx,
 	codes.SMB_COM_CLOSE:          handleClose,

--- a/network/smb/smb_v10/server/dispatch_test.go
+++ b/network/smb/smb_v10/server/dispatch_test.go
@@ -270,10 +270,15 @@ func TestUnimplementedCommandIsRefused(t *testing.T) {
 	_, addr := serverWithAccount(t, SigningDisabled, nil)
 	session := establishSession(t, addr, captureDomain, captureUsername, capturePassword, false)
 
-	// SMB_COM_SEEK is a recognized command that no handler serves yet.
-	request := newRequest(codes.SMB_COM_SEEK)
+	// SMB_COM_CLOSE_AND_TREE_DISC is recognized and will never be served:
+	// [MS-CIFS] section 2.2.4.45 records it as "reserved but not implemented" and
+	// has servers "return STATUS_NOT_IMPLEMENTED", so it is a durable stand-in
+	// for an unserved command. SMB_COM_SEEK stood here until it was served, at
+	// which point this test failed for a reason that had nothing to do with what
+	// it is checking.
+	request := newRequest(codes.SMB_COM_CLOSE_AND_TREE_DISC)
 	request.Header.UID = session.uid
-	request.AddCommand(commands.NewSeekRequest())
+	request.AddCommand(commands.NewCloseAndTreeDiscRequest())
 	sendRequest(t, session.client, request)
 
 	response, raw := receiveResponse(t, session.client)
@@ -303,11 +308,11 @@ func TestUnimplementedCommandUsesLegacyStatusEncoding(t *testing.T) {
 	_, addr := serverWithAccount(t, SigningDisabled, nil)
 	session := establishSession(t, addr, captureDomain, captureUsername, capturePassword, false)
 
-	request := newRequest(codes.SMB_COM_SEEK)
+	request := newRequest(codes.SMB_COM_CLOSE_AND_TREE_DISC)
 	request.Header.UID = session.uid
 	// Clear the NT-status bit, leaving an old-style client.
 	request.Header.Flags2 &= ^flags2.Flags2(flags2.FLAGS2_NT_STATUS_ERROR_CODES)
-	request.AddCommand(commands.NewSeekRequest())
+	request.AddCommand(commands.NewCloseAndTreeDiscRequest())
 	sendRequest(t, session.client, request)
 
 	response, _ := receiveResponse(t, session.client)

--- a/network/smb/smb_v10/server/doc.go
+++ b/network/smb/smb_v10/server/doc.go
@@ -14,23 +14,51 @@
 // the protocol to look functional while refusing everything that matters.
 //
 // Implemented:
+//
 //   - Listening on Direct TCP (445) and NetBIOS over TCP (139), via
 //     network/smb/common/transport.
+//
 //   - The per-connection receive loop, request decoding, the handler chain, and
 //     response framing with correlated reply headers.
+//
 //   - Error responses in both encodings: the NTSTATUS form, and the legacy
 //     SMBSTATUS class/code form for a client that did not negotiate
 //     SMB_FLAGS2_NT_STATUS_ERROR_CODES.
+//
 //   - SMB_COM_NEGOTIATE, selecting the NT LM 0.12 dialect under extended
 //     security.
+//
 //   - SMB_COM_SESSION_SETUP_ANDX, including verifying the response against a
 //     credential, establishing a session, and the guest and anonymous policies.
+//
 //   - SMB_COM_LOGOFF_ANDX.
+//
 //   - SMB_COM_ECHO.
+//
 //   - Message signing in both directions, when the policy calls for it.
+//
 //   - Tree connect and disconnect against a registered share.
+//
 //   - File service: open and create, read, write, close, flush, delete, rename,
 //     and the directory create, remove and check commands.
+//
+//   - The core-set file access commands, which a client that does not use the NT
+//     commands opens and transfers with: SMB_COM_OPEN, SMB_COM_OPEN_ANDX,
+//     SMB_COM_CREATE, SMB_COM_CREATE_NEW, SMB_COM_CREATE_TEMPORARY,
+//     SMB_COM_READ, SMB_COM_WRITE, SMB_COM_WRITE_AND_CLOSE, SMB_COM_SEEK, the
+//     deprecated SMB_COM_TREE_CONNECT, and SMB_COM_PROCESS_EXIT.
+//
+//     Two of these behave in ways worth knowing. A write of zero bytes sets the
+//     file's length rather than writing nothing, which is what [MS-CIFS] defines
+//     it as. And SMB_COM_PROCESS_EXIT releases the handles held by the PID in the
+//     request header, which is why an open records the PID that made it — the
+//     command exists to clean up after one failed client process on a connection
+//     that may be serving several.
+//
+//     SMB_COM_CLOSE_AND_TREE_DISC stays refused on purpose: [MS-CIFS] section
+//     2.2.4.45 records it as reserved but never implemented and has servers
+//     answer STATUS_NOT_IMPLEMENTED, which is what happens.
+//
 //   - The core-set file information commands, which describe a file without a
 //     transaction: SMB_COM_QUERY_INFORMATION and SMB_COM_SET_INFORMATION by path,
 //     and SMB_COM_QUERY_INFORMATION2 and SMB_COM_SET_INFORMATION2 on a handle.
@@ -38,17 +66,21 @@
 //     or a UTIME in seconds, so a client reading one back sees less precision than
 //     the TRANSACTION2 levels carry — a property of the wire format rather than of
 //     the storage.
+//
 //   - Directory enumeration and the information levels, over TRANSACTION2:
 //     FIND_FIRST2 and FIND_NEXT2 with search handles, the query and set levels
 //     for a path and for an open handle, and the volume levels. Requests and
 //     responses both fragment across as many messages as they need.
+//
 //   - Security descriptors and file-system controls, over NT_TRANSACT:
 //     QUERY_SECURITY_DESC, SET_SECURITY_DESC and IOCTL. SMB_COM_NT_CANCEL is
 //     accepted silently, since nothing here leaves a request outstanding.
+//
 //   - Named pipes, over TRANSACTION: a pipe is opened on a pipe share like a
 //     file, and TRANS_TRANSACT_NMPIPE writes a message to the handle and returns
 //     the answer. That write-then-read is the operation MS-RPC travels over, so a
 //     PipeHandler is all an RPC service needs to be reachable over SMB1.
+//
 //   - The volume queries a client actually asks: the TRANSACTION2 volume levels,
 //     the pass-through information classes above 0x03E8 that carry the native
 //     ones, and the legacy SMB_COM_QUERY_INFORMATION_DISK. A client asks about

--- a/network/smb/smb_v10/server/handler_core_file.go
+++ b/network/smb/smb_v10/server/handler_core_file.go
@@ -1,0 +1,696 @@
+package server
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/TheManticoreProject/Manticore/logger"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+	"github.com/TheManticoreProject/Manticore/windows/nt_status"
+)
+
+// The AccessMode bits of SMB_COM_OPEN ([MS-CIFS] section 2.2.4.3.1).
+const (
+	openAccessModeMask = 0x0007
+
+	openAccessRead      = 0
+	openAccessWrite     = 1
+	openAccessReadWrite = 2
+	openAccessExecute   = 3
+)
+
+// The OpenMode bits of SMB_COM_OPEN_ANDX ([MS-CIFS] section 2.2.4.41.1).
+const (
+	openModeFileExistsMask = 0x0003
+
+	openModeFailIfExists  = 0
+	openModeAppendIfExsts = 1
+	openModeTruncate      = 2
+
+	openModeCreateIfMissing = 0x0010
+)
+
+// The Mode values of SMB_COM_SEEK ([MS-CIFS] section 2.2.4.19.1).
+const (
+	seekFromStart   = 0x0000
+	seekFromCurrent = 0x0001
+	seekFromEnd     = 0x0002
+)
+
+// openResultsCreated is the OpenResults bit an SMB_COM_OPEN_ANDX response sets
+// when the open created the file rather than opening an existing one.
+const openResultsCreated = 0x0001
+
+// coreOpenFlagsFor translates an SMB_COM_OPEN AccessMode into backend flags.
+//
+// The access field is a value rather than a bitmask, so an unrecognised value is
+// refused rather than defaulted: [MS-CIFS] section 2.2.4.3.1 requires values 4 to
+// 7 to be answered with STATUS_OS2_INVALID_ACCESS, and treating one of them as
+// "read" would grant an access the client did not ask for and did not expect.
+//
+// Parameters:
+//   - accessMode: the request's AccessMode field
+//
+// Returns:
+//   - The backend flags, and the status to report if the mode is not usable
+func coreOpenFlagsFor(accessMode uint16) (OpenFlags, nt_status.NT_STATUS) {
+	switch accessMode & openAccessModeMask {
+	case openAccessRead, openAccessExecute:
+		// Execution is read access as far as the storage is concerned: nothing
+		// here runs a file, and refusing the mode would fail an open a client is
+		// entitled to make.
+		return OpenFlags{Read: true, NonDirectory: true}, nt_status.NT_STATUS_SUCCESS
+	case openAccessWrite:
+		return OpenFlags{Write: true, NonDirectory: true}, nt_status.NT_STATUS_SUCCESS
+	case openAccessReadWrite:
+		return OpenFlags{Read: true, Write: true, NonDirectory: true}, nt_status.NT_STATUS_SUCCESS
+	}
+	return OpenFlags{}, nt_status.NT_STATUS_OS2_INVALID_ACCESS
+}
+
+// coreOpen opens a path for one of the core-set commands and registers the handle.
+//
+// It is the shared body of SMB_COM_OPEN, SMB_COM_CREATE, SMB_COM_CREATE_NEW,
+// SMB_COM_CREATE_TEMPORARY and SMB_COM_OPEN_ANDX, which differ in what they say
+// rather than in what they do.
+//
+// Parameters:
+//   - req: the request, for its TID, PID and encoding
+//   - name: the path the client named, before resolution
+//   - flags: what the open needs from the backend
+//
+// Returns:
+//   - The handle, whether the target already existed, and a status
+func (c *Connection) coreOpen(
+	req *message.Message,
+	name string,
+	flags OpenFlags,
+) (*Open, bool, nt_status.NT_STATUS) {
+	tree, status := c.treeFor(req)
+	if status != nt_status.NT_STATUS_SUCCESS {
+		return nil, false, status
+	}
+	if tree.Share.FS == nil {
+		return nil, false, nt_status.NT_STATUS_INVALID_DEVICE_REQUEST
+	}
+
+	path, err := resolvePath(name)
+	if err != nil {
+		logger.Debugf("SMB1 server: %s asked to open %q, which is refused: %v", c.Remote, name, err)
+		return nil, false, nt_status.NT_STATUS_OBJECT_PATH_SYNTAX_BAD
+	}
+
+	// A read-only share refuses a modifying open whatever the client asked for,
+	// checked here rather than left to the backend so a backend cannot forget it.
+	if tree.Share.ReadOnly && (flags.Write || flags.Create || flags.CreateNew || flags.Truncate) {
+		return nil, false, nt_status.NT_STATUS_MEDIA_WRITE_PROTECTED
+	}
+
+	_, statErr := tree.Share.FS.Stat(path)
+	existed := statErr == nil
+
+	file, err := tree.Share.FS.Open(path, flags)
+	if err != nil {
+		logger.Debugf("SMB1 server: %s could not open %q on %q: %v", c.Remote, path, tree.Share.Name, err)
+		return nil, existed, statusForFSError(err)
+	}
+
+	attr, err := file.Stat()
+	if err != nil {
+		file.Close()
+		return nil, existed, statusForFSError(err)
+	}
+
+	fid, err := c.fids.Allocate()
+	if err != nil {
+		file.Close()
+		logger.Warnf("SMB1 server: refusing an open from %s: %v", c.Remote, err)
+		return nil, existed, nt_status.NT_STATUS_TOO_MANY_OPENED_FILES
+	}
+
+	open := &Open{
+		FID:         fid,
+		Tree:        tree,
+		Path:        path,
+		File:        file,
+		IsDirectory: attr.IsDir,
+		Readable:    flags.Read,
+		Writable:    flags.Write && !tree.Share.ReadOnly,
+		// The PID that opened the handle, so SMB_COM_PROCESS_EXIT can close what
+		// a failed process left behind.
+		PID:     req.Header.GetPID(),
+		Created: time.Now().UTC(),
+	}
+	c.addOpen(open)
+
+	logger.Debugf("SMB1 server: %s opened %q on %q as FID 0x%04X (core set)",
+		c.Remote, path, tree.Share.Name, fid)
+	return open, existed, nt_status.NT_STATUS_SUCCESS
+}
+
+// handleOpen answers SMB_COM_OPEN: the core-set open of an existing file.
+//
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/
+func handleOpen(conn *Connection, w ResponseWriter, req *message.Message) nt_status.NT_STATUS {
+	request, ok := req.Command.(*commands.OpenRequest)
+	if !ok {
+		return nt_status.NT_STATUS_INVALID_SMB
+	}
+
+	flags, status := coreOpenFlagsFor(uint16(request.AccessMode))
+	if status != nt_status.NT_STATUS_SUCCESS {
+		return status
+	}
+
+	name := decodeWireString(request.FileName.Buffer, req.Header.Flags2.IsUnicode())
+	open, _, status := conn.coreOpen(req, name, flags)
+	if status != nt_status.NT_STATUS_SUCCESS {
+		return status
+	}
+
+	attr, err := open.File.Stat()
+	if err != nil {
+		return statusForFSError(err)
+	}
+
+	response := commands.NewOpenResponse()
+	response.FID = types.USHORT(open.FID)
+	response.FileAttrs.SetAttributes(legacyAttributesFor(attr))
+	response.LastModified = types.ULONG(utimeOf(attr.Modified))
+	response.FileSize = types.ULONG(uint32(attr.Size))
+	// The granted access is echoed, which is what the client asked for: nothing
+	// here narrows an open the backend accepted.
+	response.AccessMode = request.AccessMode
+
+	return conn.answer(w, response)
+}
+
+// handleOpenAndx answers SMB_COM_OPEN_ANDX, the extended core-set open.
+//
+// Its OpenMode says what to do about existence, which is the create-disposition
+// of the NT commands in two bits ([MS-CIFS] section 2.2.4.41.1): whether to fail,
+// append to or truncate an existing file, and whether to create a missing one.
+//
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/
+func handleOpenAndx(conn *Connection, w ResponseWriter, req *message.Message) nt_status.NT_STATUS {
+	request, ok := req.Command.(*commands.OpenAndxRequest)
+	if !ok {
+		return nt_status.NT_STATUS_INVALID_SMB
+	}
+
+	flags, status := coreOpenFlagsFor(uint16(request.AccessMode))
+	if status != nt_status.NT_STATUS_SUCCESS {
+		return status
+	}
+
+	openMode := uint16(request.OpenMode)
+	if openMode&openModeCreateIfMissing != 0 {
+		flags.Create = true
+	}
+
+	switch openMode & openModeFileExistsMask {
+	case openModeTruncate:
+		flags.Truncate = true
+		// Truncating is a write, whatever access the client named.
+		flags.Write = true
+	case openModeFailIfExists:
+		// Fail if it exists and create if it does not is a create-new; without
+		// the create bit it is a plain open that must find the file, which the
+		// backend already reports.
+		if flags.Create {
+			// Both bits, which is the convention openFlagsFor established: the
+			// backend reads CreateNew as "refuse an existing file" and Create as
+			// "make a missing one", and a create-new needs to say both.
+			flags.CreateNew = true
+		}
+	case openModeAppendIfExsts:
+		// Appending needs write access; the offset is the client's business,
+		// since every core-set write carries one.
+		flags.Write = true
+	}
+
+	name := decodeWireString(request.FileName.Buffer, req.Header.Flags2.IsUnicode())
+	open, existed, status := conn.coreOpen(req, name, flags)
+	if status != nt_status.NT_STATUS_SUCCESS {
+		return status
+	}
+
+	attr, err := open.File.Stat()
+	if err != nil {
+		return statusForFSError(err)
+	}
+
+	response := commands.NewOpenAndxResponse()
+	response.FID = types.USHORT(open.FID)
+	response.FileAttrs = types.SMB_FILE_ATTRIBUTES{Attributes: legacyAttributesFor(attr)}
+	response.LastWriteTime = types.ULONG(utimeOf(attr.Modified))
+	response.FileDataSize = types.ULONG(uint32(attr.Size))
+	response.AccessRights = types.USHORT(request.AccessMode)
+	response.ResourceType = types.USHORT(resourceTypeDisk)
+	if !existed {
+		response.OpenResults = types.USHORT(openResultsCreated)
+	}
+
+	return conn.answer(w, response)
+}
+
+// handleCreate answers SMB_COM_CREATE: create or truncate, then open for writing.
+//
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/
+func handleCreate(conn *Connection, w ResponseWriter, req *message.Message) nt_status.NT_STATUS {
+	request, ok := req.Command.(*commands.CreateRequest)
+	if !ok {
+		return nt_status.NT_STATUS_INVALID_SMB
+	}
+
+	name := decodeWireString(request.FileName.Buffer, req.Header.Flags2.IsUnicode())
+	flags := OpenFlags{Read: true, Write: true, Create: true, Truncate: true, NonDirectory: true}
+
+	open, _, status := conn.coreOpen(req, name, flags)
+	if status != nt_status.NT_STATUS_SUCCESS {
+		return status
+	}
+
+	response := commands.NewCreateResponse()
+	response.FID = types.USHORT(open.FID)
+	return conn.answer(w, response)
+}
+
+// handleCreateNew answers SMB_COM_CREATE_NEW, which differs from SMB_COM_CREATE in
+// refusing a file that already exists rather than truncating it.
+//
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/
+func handleCreateNew(conn *Connection, w ResponseWriter, req *message.Message) nt_status.NT_STATUS {
+	request, ok := req.Command.(*commands.CreateNewRequest)
+	if !ok {
+		return nt_status.NT_STATUS_INVALID_SMB
+	}
+
+	name := decodeWireString(request.FileName.Buffer, req.Header.Flags2.IsUnicode())
+	flags := OpenFlags{Read: true, Write: true, Create: true, CreateNew: true, NonDirectory: true}
+
+	open, _, status := conn.coreOpen(req, name, flags)
+	if status != nt_status.NT_STATUS_SUCCESS {
+		return status
+	}
+
+	// SMB_COM_CREATE_NEW shares the SMB_COM_CREATE response shape.
+	response := commands.NewCreateResponse()
+	response.FID = types.USHORT(open.FID)
+	return conn.answer(w, response)
+}
+
+// handleCreateTemporary answers SMB_COM_CREATE_TEMPORARY: it creates a file with a
+// server-chosen name in the directory the client names, and reports the name it
+// chose.
+//
+// The name has to be one the client can then use, so it is generated inside the
+// named directory and returned share-relative — a name the client could not
+// resolve would make the handle the only way to reach the file and leave it
+// unreachable after a close.
+//
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/
+func handleCreateTemporary(conn *Connection, w ResponseWriter, req *message.Message) nt_status.NT_STATUS {
+	request, ok := req.Command.(*commands.CreateTemporaryRequest)
+	if !ok {
+		return nt_status.NT_STATUS_INVALID_SMB
+	}
+
+	directory := decodeWireString(request.DirectoryName.Buffer, req.Header.Flags2.IsUnicode())
+
+	tree, status := conn.treeFor(req)
+	if status != nt_status.NT_STATUS_SUCCESS {
+		return status
+	}
+	if tree.Share.FS == nil {
+		return nt_status.NT_STATUS_INVALID_DEVICE_REQUEST
+	}
+
+	// A name that does not already exist. The loop is bounded: a directory that
+	// somehow holds every candidate is a refusal rather than an endless search.
+	var chosen string
+	for attempt := 0; attempt < temporaryNameAttempts; attempt++ {
+		candidate, err := temporaryName(directory)
+		if err != nil {
+			return nt_status.NT_STATUS_OBJECT_PATH_SYNTAX_BAD
+		}
+		resolved, err := resolvePath(candidate)
+		if err != nil {
+			return nt_status.NT_STATUS_OBJECT_PATH_SYNTAX_BAD
+		}
+		if _, err := tree.Share.FS.Stat(resolved); err != nil {
+			chosen = candidate
+			break
+		}
+	}
+	if chosen == "" {
+		logger.Warnf("SMB1 server: could not find an unused temporary name in %q for %s", directory, conn.Remote)
+		return nt_status.NT_STATUS_OBJECT_NAME_COLLISION
+	}
+
+	flags := OpenFlags{Read: true, Write: true, Create: true, CreateNew: true, NonDirectory: true}
+	open, _, status := conn.coreOpen(req, chosen, flags)
+	if status != nt_status.NT_STATUS_SUCCESS {
+		return status
+	}
+
+	response := commands.NewCreateTemporaryResponse()
+	response.FID = types.USHORT(open.FID)
+	if err := response.TemporaryFileName.SetString(open.Path); err != nil {
+		return nt_status.NT_STATUS_UNSUCCESSFUL
+	}
+	return conn.answer(w, response)
+}
+
+// handleRead answers SMB_COM_READ: the core-set read, whose count and offset are
+// both 16- and 32-bit respectively, so it cannot address beyond 4 GiB.
+//
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/
+func handleRead(conn *Connection, w ResponseWriter, req *message.Message) nt_status.NT_STATUS {
+	request, ok := req.Command.(*commands.ReadRequest)
+	if !ok {
+		return nt_status.NT_STATUS_INVALID_SMB
+	}
+
+	open, status := conn.openFor(req, uint16(request.FID))
+	if status != nt_status.NT_STATUS_SUCCESS {
+		return status
+	}
+	if !open.Readable {
+		return nt_status.NT_STATUS_ACCESS_DENIED
+	}
+	if open.IsDirectory {
+		return nt_status.NT_STATUS_FILE_IS_A_DIRECTORY
+	}
+
+	length := int(request.CountOfBytesToRead)
+	if limit := int(conn.Server.config.MaxBufferSize) - readResponseOverhead; length > limit {
+		length = limit
+	}
+	if length < 0 {
+		length = 0
+	}
+
+	offset := int64(uint32(request.ReadOffsetInBytes))
+
+	file, status := fileFor(open)
+	if status != nt_status.NT_STATUS_SUCCESS {
+		return status
+	}
+
+	buffer := make([]byte, length)
+	read, err := file.ReadAt(buffer, offset)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return statusForFSError(err)
+	}
+
+	response := commands.NewReadResponse()
+	response.CountOfBytesReturned = types.USHORT(read)
+	// The data block is BufferFormat(0x01) CountOfBytesRead(2) Bytes, per
+	// [MS-CIFS] section 2.2.4.11.2, which is what an SMB_STRING in the
+	// 16-bit variable-block form emits.
+	response.Bytes.SetBufferFormat(types.SMB_STRING_BUFFER_FORMAT_VARIABLE_BLOCK_16BIT)
+	response.Bytes.Buffer = []types.UCHAR(buffer[:read])
+	return conn.answer(w, response)
+}
+
+// handleWrite answers SMB_COM_WRITE.
+//
+// A write of zero bytes truncates the file to the offset, which is the one piece
+// of this command that is not obvious: [MS-CIFS] section 3.3.5.14 defines a
+// CountOfBytesToWrite of zero as a request to set the length rather than as a
+// write of nothing, so treating it as a no-op would silently drop a truncation.
+//
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/
+func handleWrite(conn *Connection, w ResponseWriter, req *message.Message) nt_status.NT_STATUS {
+	request, ok := req.Command.(*commands.WriteRequest)
+	if !ok {
+		return nt_status.NT_STATUS_INVALID_SMB
+	}
+
+	open, status := conn.openFor(req, uint16(request.FID))
+	if status != nt_status.NT_STATUS_SUCCESS {
+		return status
+	}
+
+	written, status := conn.coreWrite(open, int64(uint32(request.WriteOffsetInBytes)),
+		[]byte(request.Data.Buffer), int(request.CountOfBytesToWrite))
+	if status != nt_status.NT_STATUS_SUCCESS {
+		return status
+	}
+
+	response := commands.NewWriteResponse()
+	response.CountOfBytesWritten = types.USHORT(written)
+	return conn.answer(w, response)
+}
+
+// handleWriteAndClose answers SMB_COM_WRITE_AND_CLOSE: a write followed by a
+// close, in one exchange.
+//
+// The close happens even if the write failed, because the client will not send
+// another close for this handle: the command's contract is that the handle is gone
+// afterwards, and leaving it open would leak it.
+//
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/
+func handleWriteAndClose(conn *Connection, w ResponseWriter, req *message.Message) nt_status.NT_STATUS {
+	request, ok := req.Command.(*commands.WriteAndCloseRequest)
+	if !ok {
+		return nt_status.NT_STATUS_INVALID_SMB
+	}
+
+	open, status := conn.openFor(req, uint16(request.FID))
+	if status != nt_status.NT_STATUS_SUCCESS {
+		return status
+	}
+
+	written, writeStatus := conn.coreWrite(open, int64(uint32(request.WriteOffsetInBytes)),
+		[]byte(request.Data), int(request.CountOfBytesToWrite))
+
+	// The handle goes whatever the write did.
+	if err := conn.closeOpen(uint16(request.FID)); err != nil {
+		logger.Debugf("SMB1 server: closing FID 0x%04X for %s reported %v",
+			uint16(request.FID), conn.Remote, err)
+	}
+
+	if writeStatus != nt_status.NT_STATUS_SUCCESS {
+		return writeStatus
+	}
+
+	response := commands.NewWriteAndCloseResponse()
+	response.CountOfBytesWritten = types.USHORT(written)
+	return conn.answer(w, response)
+}
+
+// coreWrite is the shared body of the core-set writes.
+//
+// Parameters:
+//   - open: the handle to write through
+//   - offset: where to write
+//   - data: the bytes that arrived
+//   - declared: how many the request said it carried
+//
+// Returns:
+//   - How many bytes were written, and a status
+func (c *Connection) coreWrite(open *Open, offset int64, data []byte, declared int) (int, nt_status.NT_STATUS) {
+	if !open.Writable {
+		return 0, nt_status.NT_STATUS_ACCESS_DENIED
+	}
+	if open.IsDirectory {
+		return 0, nt_status.NT_STATUS_FILE_IS_A_DIRECTORY
+	}
+	if offset < 0 {
+		return 0, nt_status.NT_STATUS_INVALID_PARAMETER
+	}
+
+	file, status := fileFor(open)
+	if status != nt_status.NT_STATUS_SUCCESS {
+		return 0, status
+	}
+
+	// A count of zero sets the length rather than writing nothing.
+	if declared == 0 {
+		if err := file.Truncate(offset); err != nil {
+			return 0, statusForFSError(err)
+		}
+		return 0, nt_status.NT_STATUS_SUCCESS
+	}
+
+	// Never past what actually arrived: the two disagreeing is a malformed
+	// request, not licence to read past the buffer.
+	if declared < len(data) {
+		data = data[:declared]
+	}
+
+	written, err := file.WriteAt(data, offset)
+	if err != nil {
+		return written, statusForFSError(err)
+	}
+	return written, nt_status.NT_STATUS_SUCCESS
+}
+
+// handleSeek answers SMB_COM_SEEK: it moves the handle's file pointer and reports
+// where it ended up.
+//
+// The pointer is per-handle state that nothing else here consults, because every
+// read and write this server serves carries its own offset. It is kept anyway,
+// because seeking from the current position is only meaningful if the position is
+// remembered between calls — a server that reported an answer without storing it
+// would give a different result for the same sequence of requests.
+//
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/
+func handleSeek(conn *Connection, w ResponseWriter, req *message.Message) nt_status.NT_STATUS {
+	request, ok := req.Command.(*commands.SeekRequest)
+	if !ok {
+		return nt_status.NT_STATUS_INVALID_SMB
+	}
+
+	open, status := conn.openFor(req, uint16(request.FID))
+	if status != nt_status.NT_STATUS_SUCCESS {
+		return status
+	}
+	if open.IsPipe {
+		return nt_status.NT_STATUS_INVALID_DEVICE_REQUEST
+	}
+
+	// Offset is signed: seeking backwards from the end or the current position is
+	// the point of those modes.
+	delta := int64(int32(uint32(request.Offset)))
+
+	var base int64
+	switch uint16(request.Mode) {
+	case seekFromStart:
+		base = 0
+	case seekFromCurrent:
+		base = open.Position
+	case seekFromEnd:
+		file, fileStatus := fileFor(open)
+		if fileStatus != nt_status.NT_STATUS_SUCCESS {
+			return fileStatus
+		}
+		attr, err := file.Stat()
+		if err != nil {
+			return statusForFSError(err)
+		}
+		base = attr.Size
+	default:
+		return nt_status.NT_STATUS_INVALID_PARAMETER
+	}
+
+	position := base + delta
+	if position < 0 {
+		// Seeking before the start of a file is refused rather than clamped: a
+		// clamped answer would tell the client the seek succeeded somewhere it
+		// did not ask for.
+		return nt_status.NT_STATUS_INVALID_PARAMETER
+	}
+
+	open.Position = position
+
+	response := commands.NewSeekResponse()
+	response.Offset = types.ULONG(uint32(position))
+	return conn.answer(w, response)
+}
+
+// handleTreeConnect answers SMB_COM_TREE_CONNECT, the deprecated form of the tree
+// connect.
+//
+// It carries the share path and returns a TID, exactly as the AndX form does, so
+// it shares that handler's share lookup and tree allocation.
+//
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/
+func handleTreeConnect(conn *Connection, w ResponseWriter, req *message.Message) nt_status.NT_STATUS {
+	request, ok := req.Command.(*commands.TreeConnectRequest)
+	if !ok {
+		return nt_status.NT_STATUS_INVALID_SMB
+	}
+
+	unicode := req.Header.Flags2.IsUnicode()
+	tree, status := conn.connectTree(req,
+		decodeWireString(request.Path.Buffer, unicode),
+		decodeOEMString(request.Service.Buffer))
+	if status != nt_status.NT_STATUS_SUCCESS {
+		return status
+	}
+
+	response := commands.NewTreeConnectResponse()
+	response.MaxBufferSize = types.USHORT(conn.Server.config.MaxBufferSize)
+	response.TID = types.USHORT(tree.TID)
+
+	w.SetResponseTID(tree.TID)
+	return conn.answer(w, response)
+}
+
+// handleProcessExit answers SMB_COM_PROCESS_EXIT: it releases what the request's
+// process identifier still holds.
+//
+// [MS-CIFS] section 2.2.4.18: "Upon receiving an SMB_COM_PROCESS_EXIT request, the
+// server MUST close any resources owned by the Process ID (PID) listed in the
+// request header." The command exists to clean up after a client process that died
+// without closing its handles, so the PID recorded on each open is what makes it
+// mean anything.
+//
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/
+func handleProcessExit(conn *Connection, w ResponseWriter, req *message.Message) nt_status.NT_STATUS {
+	if _, ok := req.Command.(*commands.ProcessExitRequest); !ok {
+		return nt_status.NT_STATUS_INVALID_SMB
+	}
+
+	pid := req.Header.GetPID()
+
+	// Collected first: closing a handle mutates the table being walked.
+	doomed := []uint16{}
+	for fid, open := range conn.opens {
+		if open.PID == pid {
+			doomed = append(doomed, fid)
+		}
+	}
+
+	for _, fid := range doomed {
+		if err := conn.closeOpen(fid); err != nil {
+			logger.Debugf("SMB1 server: closing FID 0x%04X for exited PID 0x%08X reported %v", fid, pid, err)
+		}
+	}
+
+	if len(doomed) > 0 {
+		logger.Debugf("SMB1 server: released %d handles held by exited PID 0x%08X for %s",
+			len(doomed), pid, conn.Remote)
+	}
+
+	return conn.answer(w, commands.NewProcessExitResponse())
+}
+
+// temporaryNameAttempts bounds the search for an unused temporary name.
+const temporaryNameAttempts = 32
+
+// temporaryName invents a name inside a directory for SMB_COM_CREATE_TEMPORARY.
+//
+// The name is 8.3-shaped so that it can also be seen through the core-set search
+// commands, which cannot carry a longer one. It is drawn from the system's
+// cryptographic random source rather than from a counter, because a counter shared
+// across connections would need locking and would still collide after a restart.
+//
+// Parameters:
+//   - directory: the share-relative directory the client named
+//
+// Returns:
+//   - A share-relative candidate name, or an error if the directory is not usable
+func temporaryName(directory string) (string, error) {
+	suffix := make([]byte, 4)
+	if _, err := rand.Read(suffix); err != nil {
+		return "", err
+	}
+
+	name := fmt.Sprintf("TMP%s.TMP", strings.ToUpper(hex.EncodeToString(suffix)))
+	trimmed := strings.Trim(strings.ReplaceAll(directory, "\\", "/"), "/")
+	if trimmed == "" {
+		return name, nil
+	}
+	return trimmed + "/" + name, nil
+}

--- a/network/smb/smb_v10/server/handler_tree.go
+++ b/network/smb/smb_v10/server/handler_tree.go
@@ -39,43 +39,15 @@ func handleTreeConnectAndx(conn *Connection, w ResponseWriter, req *message.Mess
 	// negotiates it on the connection but sends its tree connect in OEM, so
 	// taking the connection's setting here decodes the path as garbage.
 	unicode := req.Header.Flags2.IsUnicode()
-	path := decodeWireString(request.Path, unicode)
-	name := shareNameFromPath(path)
-	if name == "" {
-		logger.Debugf("SMB1 server: %s sent a tree connect to %q, which is not a UNC path", conn.Remote, path)
-		return nt_status.NT_STATUS_BAD_NETWORK_NAME
-	}
 
-	share := conn.Server.Share(name)
-	if share == nil {
-		logger.Debugf("SMB1 server: %s asked for share %q, which is not served", conn.Remote, name)
-		return nt_status.NT_STATUS_BAD_NETWORK_NAME
+	tree, status := conn.connectTree(req,
+		decodeWireString(request.Path, unicode),
+		decodeOEMString(request.Service))
+	if status != nt_status.NT_STATUS_SUCCESS {
+		return status
 	}
-
-	// A client may say what kind of resource it expects. Answering a mismatch
-	// here is better than letting it discover the difference through a command
-	// that makes no sense on the resource it actually got.
-	if wanted := ShareType(decodeOEMString(request.Service)); wanted != "" && wanted != ShareTypeAny && wanted != share.Type {
-		logger.Debugf("SMB1 server: %s asked for share %q as %q, but it is %q",
-			conn.Remote, name, wanted, share.Type)
-		return nt_status.NT_STATUS_BAD_DEVICE_TYPE
-	}
-
-	tid, err := conn.tids.Allocate()
-	if err != nil {
-		logger.Warnf("SMB1 server: refusing a tree connect from %s: %v", conn.Remote, err)
-		return nt_status.NT_STATUS_INSUFF_SERVER_RESOURCES
-	}
-
-	tree := &Tree{
-		TID:        tid,
-		Share:      share,
-		SessionUID: session.UID,
-		Created:    time.Now().UTC(),
-	}
-	conn.addTree(tree)
-
-	logger.Debugf("SMB1 server: %s connected share %q as TID 0x%04X", conn.Remote, share.Name, tid)
+	share := tree.Share
+	tid := tree.TID
 
 	response := commands.NewTreeConnectAndxResponse()
 	// The Service string is OEM even when the connection negotiated Unicode,
@@ -93,6 +65,68 @@ func handleTreeConnectAndx(conn *Connection, w ResponseWriter, req *message.Mess
 		logger.Debugf("SMB1 server: failed to answer the tree connect for %s: %v", conn.Remote, err)
 	}
 	return nt_status.NT_STATUS_SUCCESS
+}
+
+// connectTree resolves a UNC path to a registered share and allocates a tree on
+// it.
+//
+// It is shared by SMB_COM_TREE_CONNECT_ANDX and the deprecated
+// SMB_COM_TREE_CONNECT, which differ only in what their responses carry — so
+// sharing this keeps the two from disagreeing about which shares exist or what a
+// client is allowed to connect.
+//
+// Parameters:
+//   - req: the request, for its UID
+//   - path: the UNC path the client sent, already decoded
+//   - service: the resource type the client expects, or empty
+//
+// Returns:
+//   - The tree, or the status that says why there is none
+func (c *Connection) connectTree(req *message.Message, path, service string) (*Tree, nt_status.NT_STATUS) {
+	session := c.Session(uint16(req.Header.UID))
+	if session == nil {
+		// The dispatcher checks this, so reaching here means the tables
+		// disagree; refusing is still the right answer.
+		return nil, nt_status.NT_STATUS_SMB_BAD_UID
+	}
+
+	name := shareNameFromPath(path)
+	if name == "" {
+		logger.Debugf("SMB1 server: %s sent a tree connect to %q, which is not a UNC path", c.Remote, path)
+		return nil, nt_status.NT_STATUS_BAD_NETWORK_NAME
+	}
+
+	share := c.Server.Share(name)
+	if share == nil {
+		logger.Debugf("SMB1 server: %s asked for share %q, which is not served", c.Remote, name)
+		return nil, nt_status.NT_STATUS_BAD_NETWORK_NAME
+	}
+
+	// A client may say what kind of resource it expects. Answering a mismatch
+	// here is better than letting it discover the difference through a command
+	// that makes no sense on the resource it actually got.
+	if wanted := ShareType(service); wanted != "" && wanted != ShareTypeAny && wanted != share.Type {
+		logger.Debugf("SMB1 server: %s asked for share %q as %q, but it is %q",
+			c.Remote, name, wanted, share.Type)
+		return nil, nt_status.NT_STATUS_BAD_DEVICE_TYPE
+	}
+
+	tid, err := c.tids.Allocate()
+	if err != nil {
+		logger.Warnf("SMB1 server: refusing a tree connect from %s: %v", c.Remote, err)
+		return nil, nt_status.NT_STATUS_INSUFF_SERVER_RESOURCES
+	}
+
+	tree := &Tree{
+		TID:        tid,
+		Share:      share,
+		SessionUID: session.UID,
+		Created:    time.Now().UTC(),
+	}
+	c.addTree(tree)
+
+	logger.Debugf("SMB1 server: %s connected share %q as TID 0x%04X", c.Remote, share.Name, tid)
+	return tree, nt_status.NT_STATUS_SUCCESS
 }
 
 // handleTreeDisconnect answers SMB_COM_TREE_DISCONNECT: it drops the tree and

--- a/network/smb/smb_v10/server/session_test.go
+++ b/network/smb/smb_v10/server/session_test.go
@@ -225,8 +225,12 @@ func TestSessionEstablishedWithValidCredential(t *testing.T) {
 	waitFor(t, func() bool { return srv.Connections() == 1 }, "the connection was not registered")
 
 	// The session is usable: a command that requires one is now dispatched
-	// rather than refused.
-	response := sendOnSession(t, session, codes.SMB_COM_TREE_CONNECT_ANDX, commands.NewSeekRequest())
+	// rather than refused by the UID check. SMB_COM_CLOSE_AND_TREE_DISC is
+	// recognized and never served — [MS-CIFS] section 2.2.4.45 has it "reserved
+	// but not implemented" — so reaching STATUS_NOT_IMPLEMENTED means the
+	// dispatch table was consulted, which is the point.
+	response := sendOnSession(t, session, codes.SMB_COM_CLOSE_AND_TREE_DISC,
+		commands.NewCloseAndTreeDiscRequest())
 	if response.Header.Status != uint32(nt_status.NT_STATUS_NOT_IMPLEMENTED) {
 		t.Fatalf("Status = 0x%08X, want NT_STATUS_NOT_IMPLEMENTED on an established session", response.Header.Status)
 	}

--- a/network/smb/smb_v10/server/tree.go
+++ b/network/smb/smb_v10/server/tree.go
@@ -55,6 +55,21 @@ type Open struct {
 	// client deletes something it holds open.
 	DeleteOnClose bool
 
+	// PID is the process identifier that opened the handle.
+	//
+	// It is recorded so SMB_COM_PROCESS_EXIT can release what a client process
+	// still held when it died: [MS-CIFS] section 2.2.4.18 has the server close
+	// "any resources owned by the Process ID (PID) listed in the request header",
+	// and without this the command would have nothing to select on.
+	PID uint32
+
+	// Position is the handle's file pointer, which SMB_COM_SEEK moves.
+	//
+	// Nothing else consults it, because every read and write this server serves
+	// carries its own offset. It is kept because seeking from the current
+	// position is only meaningful if the position persists between calls.
+	Position int64
+
 	// Created is when the handle was opened.
 	Created time.Time
 }


### PR DESCRIPTION
### Linked Issue
`Closes #1145`

> **Stacked on #1164 and #1172.** Cut from main with `enhancement-legacy-info-commands` (#1146, on #1162) and `bugfix-writerequest-data-misplaced` (#1171) merged in: the handlers use the MS-DOS date/time and legacy-attribute helpers from #1146, and `SMB_COM_WRITE` could not be decoded at all until #1171. Merge #1163, #1164 and #1172 first.

### Root Cause
None of the commands had an entry in `dispatchTable`, so each was answered `STATUS_NOT_IMPLEMENTED`. The backend they need was already there — the NT commands use the same `FileSystem` — so this is wiring plus the layouts.

### Fix Description
Eleven commands are served: `SMB_COM_OPEN`, `SMB_COM_OPEN_ANDX`, `SMB_COM_CREATE`, `SMB_COM_CREATE_NEW`, `SMB_COM_CREATE_TEMPORARY`, `SMB_COM_READ`, `SMB_COM_WRITE`, `SMB_COM_WRITE_AND_CLOSE`, `SMB_COM_SEEK`, `SMB_COM_TREE_CONNECT` and `SMB_COM_PROCESS_EXIT`.

**`SMB_COM_CLOSE_AND_TREE_DISC` is deliberately not served**, and this is a correction to the issue rather than an omission. [MS-CIFS] section 2.2.4.45 records it as "reserved but not implemented" and says servers "SHOULD return STATUS_NOT_IMPLEMENTED" — which is exactly what the dispatcher already does. The issue listed it among twelve commands to serve; serving it would have been implementing something the specification tells servers to refuse.

The decisions worth reading:

**A reserved access mode is refused, not defaulted.** `SMB_COM_OPEN`'s `AccessMode` is a value in three bits, not a bitmask, and [MS-CIFS] 2.2.4.3.1 requires values 4 to 7 to be answered `STATUS_OS2_INVALID_ACCESS`. Treating an unrecognised value as "read" would grant access the client neither asked for nor expects. Execution maps to read, because nothing here runs a file and refusing would fail an open a client is entitled to make.

**A write of zero bytes truncates.** [MS-CIFS] 3.3.5.14 defines a `CountOfBytesToWrite` of zero as a request to set the length rather than a write of nothing. Treating it as a no-op silently drops a truncation the client believes succeeded — the kind of failure that shows up later as a file the client thinks is shorter than it is.

**`SMB_COM_PROCESS_EXIT` needed new state to mean anything.** [MS-CIFS] 2.2.4.18 has the server close "any resources owned by the Process ID (PID) listed in the request header", and nothing recorded which PID opened a handle. `Open` gains `PID`, set at open time, and the handler closes the handles matching the request's PID and no others — closing everything, or nothing, would both be wrong on a connection serving several processes.

**`SMB_COM_SEEK` needed a file pointer, and it is honest about being unused elsewhere.** `Open` gains `Position`. Nothing else consults it, because every read and write this server serves carries its own offset — but seeking from the current position is only meaningful if the position persists between calls, so a server that computed an answer without storing it would give different results for the same request sequence. Seeking before the start is refused rather than clamped, because a clamped answer reports a seek the client did not ask for as a success.

**`SMB_COM_CREATE_TEMPORARY` returns a name the client can use again.** The name is generated inside the directory the client named, 8.3-shaped so the core-set search commands can also carry it, drawn from the cryptographic random source rather than a counter (a shared counter would need locking and would still collide after a restart), and checked against the backend before use with a bounded number of attempts.

**`SMB_COM_WRITE_AND_CLOSE` closes even when the write fails.** The command's contract is that the handle is gone afterwards, and the client will not send another close for it, so keeping it open on a failed write would leak it.

`connectTree` is factored out of `handleTreeConnectAndx` and shared with the deprecated form, so the two cannot come to disagree about which shares exist or who may connect. `coreOpen` is likewise shared by the five opens, which differ in what they report rather than in what they do.

### How Verified
Runtime, over the loopback harness, sixteen assertions across ten tests:

- `TestCoreOpenReadWriteRoundTrip` — open, write, read back, and the bytes are confirmed in the backend rather than only in the reply.
- `TestCoreOpenRefusesAReservedAccessMode` — all four reserved values answer `STATUS_OS2_INVALID_ACCESS`.
- `TestCoreWriteOfZeroBytesTruncates` — a zero-length write at offset 4 leaves a 4-byte file.
- `TestCoreCreateAndCreateNewDifferOnExistence` — create truncates an existing file, create-new refuses one and makes a missing one.
- `TestCoreOpenAndxHonoursItsOpenMode` — truncate empties the file, create-if-missing makes it, and a missing file without the create bit is refused.
- `TestCoreWriteAndCloseReleasesTheHandle` — the bytes land and a read through the handle afterwards fails.
- `TestCoreSeekMovesAndRemembersThePosition` — each of the three modes, with the from-current case depending on the previous seek having stuck, and a seek before the start refused.
- `TestCoreTreeConnectConnectsSameAsTheAndXForm` — a usable TID and buffer size.
- `TestCoreProcessExitReleasesThatProcessesHandles` — the handle is gone and the connection survives.
- `TestCoreOpenOnAReadOnlyShareRefusesWriting` — a write open refused, a read open allowed.

Whole tree green: `go build ./...`, `go test ./network/smb/...`. `gofmt -l` clean on every file touched.

### Test Coverage
**Added:** `server/core_file_test.go` — the ten tests above, plus `coreFileServer` and `coreOpenFile`.

**Modified:** `server/conformance_test.go` (eleven commands registered in `servedCommands`, plus the coverage-floor change explained below), and `server/dispatch_test.go` and `server/session_test.go`, explained below.

### Scope of Change
- **Files changed:** `server/handler_core_file.go` (new), `server/core_file_test.go` (new), `server/handler_tree.go`, `server/tree.go`, `server/dispatch.go`, `server/conformance_test.go`, `server/dispatch_test.go`, `server/session_test.go`, `server/doc.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none in the server. Two test changes were forced:

  `TestUnimplementedCommandIsRefused`, `TestUnimplementedCommandUsesLegacyStatusEncoding` and `TestSessionEstablishedWithValidCredential` all used `SMB_COM_SEEK` as their stand-in for "a recognised command with no handler", and serving it broke all three for reasons unrelated to what they check. They now use `SMB_COM_CLOSE_AND_TREE_DISC`, which the specification says will never be served — so the substitution is durable rather than one that has to be revised the next time the server grows.

  `TestConformanceUnservedCommandsAreRefused` asserted `exercised >= 40`; eleven commands moving into the served set took it to 31. The floor now sits on `known >= 70` instead. Its purpose was to catch a message layer that stopped recognising commands, and that is what the new form says; a floor on `exercised` falls as the server grows and becomes a record of past progress. The real invariant in that test — every known command accounted for as exercised, served or unmarshalable — is untouched.

### Risk and Rollout
Additive: every command was refused before, so no existing exchange changes shape. `Open` grows two fields, neither read by an existing path. `connectTree` is a pure extraction — the AndX handler's behaviour is unchanged and its tests pass untouched.

### Notes
Found while writing these tests: `SMB_COM_WRITE` could not be marshalled at all (#1171, fixed and merged into this branch). That is the sixth wire-format defect this work has turned up on paths the server never dispatched, which is the pattern worth noting — the message layer's untested commands are where they live.

`OpenAndxRequest` and `TreeConnectRequest` leave their strings' buffer format to the caller, where most commands set it in `Marshal`. It fails loudly rather than silently, so it is not filed as a bug, but it is an inconsistency a client author will trip over; the tests here set it explicitly with a spec citation.
