### PR TITLE
Serve SMB_COM_NT_RENAME with a backend link primitive (Fixes #1148)

### DIFF
--- a/network/smb/smb_v10/server/conformance_test.go
+++ b/network/smb/smb_v10/server/conformance_test.go
@@ -134,6 +134,7 @@ var servedCommands = map[codes.CommandCode]string{
 	codes.SMB_COM_CREATE_DIRECTORY: "creates a directory",
 	codes.SMB_COM_DELETE_DIRECTORY: "removes an empty directory",
 	codes.SMB_COM_CHECK_DIRECTORY:  "reports whether a path is a directory",
+	codes.SMB_COM_NT_RENAME:        "renames an entry, or gives it a second name",
 
 	codes.SMB_COM_QUERY_INFORMATION_DISK: "reports the volume's capacity in the legacy fields",
 
@@ -350,9 +351,15 @@ func TestConformanceUnservedCommandsAreRefused(t *testing.T) {
 	}
 	// A floor as well, so a message layer that stopped recognizing commands at all
 	// would not make the accounting trivially true.
-	if exercised < 40 {
-		t.Fatalf("only %d commands were exercised of %d known; the walk is no longer covering the command space",
-			exercised, known)
+	//
+	// The floor is on how many commands the message layer knows, not on how many
+	// this walk exercised. Every command that gains a handler moves out of this
+	// walk and into TestConformanceServedCommandsAreServed, so a floor on
+	// `exercised` falls as the server grows and has to be edited downwards to
+	// keep passing — a record of past progress rather than a guard. A floor on
+	// `known` says what the guard was for and stays true.
+	if known < 70 {
+		t.Fatalf("the message layer recognizes only %d commands; it is no longer covering the command space", known)
 	}
 	t.Logf("exercised %d of %d known commands (%d served, %d whose zero value cannot be marshalled)",
 		exercised, known, skippedServed, skippedUnmarshalable)

--- a/network/smb/smb_v10/server/dispatch.go
+++ b/network/smb/smb_v10/server/dispatch.go
@@ -59,6 +59,7 @@ var dispatchTable = map[codes.CommandCode]commandHandler{
 	codes.SMB_COM_CREATE_DIRECTORY: handleCreateDirectory,
 	codes.SMB_COM_DELETE_DIRECTORY: handleDeleteDirectory,
 	codes.SMB_COM_CHECK_DIRECTORY:  handleCheckDirectory,
+	codes.SMB_COM_NT_RENAME:        handleNtRename,
 
 	// Transactions, which carry the directory-enumeration and information
 	// subcommands.

--- a/network/smb/smb_v10/server/doc.go
+++ b/network/smb/smb_v10/server/doc.go
@@ -14,23 +14,46 @@
 // the protocol to look functional while refusing everything that matters.
 //
 // Implemented:
+//
 //   - Listening on Direct TCP (445) and NetBIOS over TCP (139), via
 //     network/smb/common/transport.
+//
 //   - The per-connection receive loop, request decoding, the handler chain, and
 //     response framing with correlated reply headers.
+//
 //   - Error responses in both encodings: the NTSTATUS form, and the legacy
 //     SMBSTATUS class/code form for a client that did not negotiate
 //     SMB_FLAGS2_NT_STATUS_ERROR_CODES.
+//
 //   - SMB_COM_NEGOTIATE, selecting the NT LM 0.12 dialect under extended
 //     security.
+//
 //   - SMB_COM_SESSION_SETUP_ANDX, including verifying the response against a
 //     credential, establishing a session, and the guest and anonymous policies.
+//
 //   - SMB_COM_LOGOFF_ANDX.
+//
 //   - SMB_COM_ECHO.
+//
 //   - Message signing in both directions, when the policy calls for it.
+//
 //   - Tree connect and disconnect against a registered share.
+//
 //   - File service: open and create, read, write, close, flush, delete, rename,
 //     and the directory create, remove and check commands.
+//
+//   - SMB_COM_NT_RENAME, which renames an entry at SMB_NT_RENAME_RENAME_FILE and
+//     gives it a second name at SMB_NT_RENAME_SET_LINK_INFO. Linking needs a
+//     backend that implements Linker; one that does not is answered
+//     STATUS_NOT_SUPPORTED rather than given a copy, because a copy is a second
+//     file and not a second name, and the two diverge as soon as either is
+//     written.
+//
+//     SMB_COM_COPY and SMB_COM_MOVE stay refused: [MS-CIFS] sections 2.2.4.37
+//     and 2.2.4.38 record both as obsolete in the NT LAN Manager dialect — the
+//     only dialect this server speaks — and have servers answer
+//     STATUS_NOT_IMPLEMENTED, which is what happens.
+//
 //   - The core-set file information commands, which describe a file without a
 //     transaction: SMB_COM_QUERY_INFORMATION and SMB_COM_SET_INFORMATION by path,
 //     and SMB_COM_QUERY_INFORMATION2 and SMB_COM_SET_INFORMATION2 on a handle.
@@ -38,17 +61,21 @@
 //     or a UTIME in seconds, so a client reading one back sees less precision than
 //     the TRANSACTION2 levels carry — a property of the wire format rather than of
 //     the storage.
+//
 //   - Directory enumeration and the information levels, over TRANSACTION2:
 //     FIND_FIRST2 and FIND_NEXT2 with search handles, the query and set levels
 //     for a path and for an open handle, and the volume levels. Requests and
 //     responses both fragment across as many messages as they need.
+//
 //   - Security descriptors and file-system controls, over NT_TRANSACT:
 //     QUERY_SECURITY_DESC, SET_SECURITY_DESC and IOCTL. SMB_COM_NT_CANCEL is
 //     accepted silently, since nothing here leaves a request outstanding.
+//
 //   - Named pipes, over TRANSACTION: a pipe is opened on a pipe share like a
 //     file, and TRANS_TRANSACT_NMPIPE writes a message to the handle and returns
 //     the answer. That write-then-read is the operation MS-RPC travels over, so a
 //     PipeHandler is all an RPC service needs to be reachable over SMB1.
+//
 //   - The volume queries a client actually asks: the TRANSACTION2 volume levels,
 //     the pass-through information classes above 0x03E8 that carry the native
 //     ones, and the legacy SMB_COM_QUERY_INFORMATION_DISK. A client asks about
@@ -77,6 +104,11 @@
 // invented for them is a number a client would believe.
 //
 // # Shares
+//
+// A FileSystem may also implement Linker, which lets SMB_COM_NT_RENAME give a
+// file a second name. It is a separate interface so that adding it does not break
+// a backend outside this repository: one that cannot link simply does not
+// implement it.
 //
 // A Share is registered with AddShare and backed by a FileSystem.
 // NewLocalFileSystem serves a directory on the host; NewMemoryFileSystem serves

--- a/network/smb/smb_v10/server/fs_local.go
+++ b/network/smb/smb_v10/server/fs_local.go
@@ -276,6 +276,48 @@ func (fs *LocalFileSystem) Open(path string, flags OpenFlags) (File, error) {
 	return &localFile{file: file, path: host}, nil
 }
 
+// Link gives an existing file a second name.
+//
+// Both paths go through hostPathNoFollow, so neither the source nor the target
+// can be placed outside the share by way of a symbolic link — the same rule the
+// name operations follow, and for the same reason: a link is created by name, and
+// a name that resolves through a link out of the share would put a file where the
+// share does not reach.
+//
+// Parameters:
+//   - existing: the file to link to, share-relative
+//   - target: the new name, share-relative
+//
+// Returns:
+//   - An error if either path is unusable or the host refuses the link
+func (fs *LocalFileSystem) Link(existing, target string) error {
+	if fs.readOnly {
+		return ErrReadOnly
+	}
+
+	source, err := fs.hostPathNoFollow(existing)
+	if err != nil {
+		return err
+	}
+	destination, err := fs.hostPathNoFollow(target)
+	if err != nil {
+		return err
+	}
+
+	info, err := os.Lstat(source)
+	if err != nil {
+		return translate(err)
+	}
+	if info.IsDir() {
+		return ErrIsDirectory
+	}
+
+	if err := os.Link(source, destination); err != nil {
+		return translate(err)
+	}
+	return nil
+}
+
 // Stat describes a path.
 func (fs *LocalFileSystem) Stat(path string) (FileAttr, error) {
 	host, err := fs.hostPath(path)

--- a/network/smb/smb_v10/server/fs_mem.go
+++ b/network/smb/smb_v10/server/fs_mem.go
@@ -222,6 +222,50 @@ func (fs *MemoryFileSystem) Open(path string, flags OpenFlags) (File, error) {
 	return &memoryFile{fs: fs, path: path}, nil
 }
 
+// Link gives an existing entry a second name.
+//
+// The two names share one *memoryEntry, which is what makes this a link rather
+// than a copy: a write through either name is visible through both, and removing
+// one leaves the other working.
+//
+// Parameters:
+//   - existing: the entry to link to
+//   - target: the new name
+//
+// Returns:
+//   - An error if either path is unusable
+func (fs *MemoryFileSystem) Link(existing, target string) error {
+	fs.mutex.Lock()
+	defer fs.mutex.Unlock()
+
+	entry, present := fs.entries[existing]
+	if !present {
+		return ErrNotFound
+	}
+	if entry.isDir {
+		return ErrIsDirectory
+	}
+	if _, taken := fs.entries[target]; taken {
+		return ErrExists
+	}
+
+	// The parent has to exist, as it does for a create: a link does not build a
+	// tree.
+	parent, _ := splitPath(target)
+	if parent != "" {
+		holder, ok := fs.entries[parent]
+		if !ok {
+			return ErrNotFound
+		}
+		if !holder.isDir {
+			return ErrNotDirectory
+		}
+	}
+
+	fs.entries[target] = entry
+	return nil
+}
+
 // Stat describes a path.
 func (fs *MemoryFileSystem) Stat(path string) (FileAttr, error) {
 	fs.mutex.RLock()

--- a/network/smb/smb_v10/server/handler_nt_rename.go
+++ b/network/smb/smb_v10/server/handler_nt_rename.go
@@ -1,0 +1,134 @@
+package server
+
+import (
+	"strings"
+
+	"github.com/TheManticoreProject/Manticore/logger"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/windows/nt_status"
+)
+
+// The InformationLevel values of SMB_COM_NT_RENAME ([MS-CIFS] section 2.2.4.66.1).
+const (
+	smbNtRenameSetLinkInfo = 0x0103
+	smbNtRenameRenameFile  = 0x0104
+)
+
+// handleNtRename answers SMB_COM_NT_RENAME, which renames a file or gives it a
+// second name depending on its information level.
+//
+// [MS-CIFS] section 3.3.5.51 defines three outcomes, and all three are here: at
+// SMB_NT_RENAME_RENAME_FILE the request "is treated as if it is an SMB_COM_RENAME
+// Request"; at SMB_NT_RENAME_SET_LINK_INFO "the original file MUST NOT be renamed.
+// Instead, the server MUST attempt to create a hard link"; and any other level
+// "SHOULD fail the request with STATUS_INVALID_SMB".
+//
+// That last clause is why the default below is INVALID_SMB rather than
+// INVALID_PARAMETER or NOT_SUPPORTED: the specification names the status, and a
+// client distinguishing "I asked for something unsupported" from "I asked for
+// something that is not a level" would be misled by either alternative.
+//
+// Wire format: [MS-CIFS] section 2.2.4.66.
+//
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/
+func handleNtRename(conn *Connection, w ResponseWriter, req *message.Message) nt_status.NT_STATUS {
+	request, ok := req.Command.(*commands.NtRenameRequest)
+	if !ok {
+		return nt_status.NT_STATUS_INVALID_SMB
+	}
+
+	tree, status := conn.treeFor(req)
+	if status != nt_status.NT_STATUS_SUCCESS {
+		return status
+	}
+	if tree.Share.FS == nil {
+		return nt_status.NT_STATUS_INVALID_DEVICE_REQUEST
+	}
+	if tree.Share.ReadOnly {
+		return nt_status.NT_STATUS_MEDIA_WRITE_PROTECTED
+	}
+
+	unicode := req.Header.Flags2.IsUnicode()
+	oldName := decodeWireString(request.OldFileName.Buffer, unicode)
+	newName := decodeWireString(request.NewFileName.Buffer, unicode)
+
+	// "OldFileName MUST NOT contain wildcard characters; otherwise, the server
+	// MUST return an error response with a Status of
+	// STATUS_OBJECT_PATH_SYNTAX_BAD." Unlike SMB_COM_RENAME, which takes a
+	// pattern, this command acts on exactly one named file.
+	if strings.ContainsAny(oldName, "*?") {
+		logger.Debugf("SMB1 server: %s sent an NT rename of %q, which carries a wildcard", conn.Remote, oldName)
+		return nt_status.NT_STATUS_OBJECT_PATH_SYNTAX_BAD
+	}
+
+	source, err := resolvePath(oldName)
+	if err != nil {
+		return nt_status.NT_STATUS_OBJECT_PATH_SYNTAX_BAD
+	}
+	target, err := resolvePath(newName)
+	if err != nil {
+		return nt_status.NT_STATUS_OBJECT_PATH_SYNTAX_BAD
+	}
+
+	// The source has to exist and match the search attributes, which is what the
+	// specification checks before looking at the level.
+	attr, err := tree.Share.FS.Stat(source)
+	if err != nil {
+		return statusForFSError(err)
+	}
+	if !matchesSearchAttributes(attr, request.SearchAttributes.GetAttributes()) {
+		logger.Debugf("SMB1 server: %s renamed %q, which does not match the search attributes 0x%04X",
+			conn.Remote, source, request.SearchAttributes.GetAttributes())
+		return nt_status.NT_STATUS_NO_SUCH_FILE
+	}
+
+	switch uint16(request.InformationLevel) {
+	case smbNtRenameRenameFile:
+		// Treated as SMB_COM_RENAME: the target must not already exist, which is
+		// what a rename with replace=false gives.
+		if err := tree.Share.FS.Rename(source, target, false); err != nil {
+			logger.Debugf("SMB1 server: %s renamed %q to %q, which failed: %v",
+				conn.Remote, source, target, err)
+			return statusForFSError(err)
+		}
+		logger.Debugf("SMB1 server: %s renamed %q to %q", conn.Remote, source, target)
+
+	case smbNtRenameSetLinkInfo:
+		linker, ok := tree.Share.FS.(Linker)
+		if !ok {
+			// A backend that cannot link says so, rather than the server
+			// substituting a copy: a copy is a second file, not a second name,
+			// and the two diverge as soon as either is written.
+			logger.Debugf("SMB1 server: %s asked to link %q, which share %q cannot do",
+				conn.Remote, source, tree.Share.Name)
+			return nt_status.NT_STATUS_NOT_SUPPORTED
+		}
+		if err := linker.Link(source, target); err != nil {
+			logger.Debugf("SMB1 server: %s linked %q to %q, which failed: %v",
+				conn.Remote, source, target, err)
+			return statusForFSError(err)
+		}
+		logger.Debugf("SMB1 server: %s linked %q as %q", conn.Remote, source, target)
+
+	default:
+		logger.Debugf("SMB1 server: %s sent an NT rename at level 0x%04X, which is not a level",
+			conn.Remote, uint16(request.InformationLevel))
+		return nt_status.NT_STATUS_INVALID_SMB
+	}
+
+	return conn.answer(w, commands.NewNtRenameResponse())
+}
+
+// matchesSearchAttributes reports whether an entry is one the request's
+// SearchAttributes admit.
+//
+// The field is inclusive rather than exclusive: a directory is matched only when
+// the directory bit is set, and a plain file always matches. That is what makes
+// SearchAttributes able to say "rename this only if it is a file".
+func matchesSearchAttributes(attr FileAttr, searchAttributes uint16) bool {
+	if attr.IsDir {
+		return searchAttributes&smbFileAttributeDirectory != 0
+	}
+	return true
+}

--- a/network/smb/smb_v10/server/nt_rename_test.go
+++ b/network/smb/smb_v10/server/nt_rename_test.go
@@ -1,0 +1,262 @@
+package server
+
+import (
+	"testing"
+
+	smb1client "github.com/TheManticoreProject/Manticore/network/smb/smb_v10/client"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/codes"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+	"github.com/TheManticoreProject/Manticore/windows/nt_status"
+)
+
+// sendNtRename sends an SMB_COM_NT_RENAME at the given information level.
+func sendNtRename(
+	t *testing.T,
+	client *smb1client.Client,
+	level uint16,
+	oldName, newName string,
+	searchAttributes uint16,
+) uint32 {
+	t.Helper()
+
+	request := commands.NewNtRenameRequest()
+	request.InformationLevel = types.USHORT(level)
+	request.SearchAttributes.SetAttributes(searchAttributes)
+	request.OldFileName.SetBufferFormat(types.SMB_STRING_BUFFER_FORMAT_NULL_TERMINATED_ASCII_STRING)
+	if err := request.OldFileName.SetString(oldName); err != nil {
+		t.Fatalf("SetString() error = %v", err)
+	}
+	request.NewFileName.SetBufferFormat(types.SMB_STRING_BUFFER_FORMAT_NULL_TERMINATED_ASCII_STRING)
+	if err := request.NewFileName.SetString(newName); err != nil {
+		t.Fatalf("SetString() error = %v", err)
+	}
+
+	status, _ := sendLegacy(t, client, codes.SMB_COM_NT_RENAME, request)
+	return status
+}
+
+// renameServer serves one file and one directory.
+func renameServer(t *testing.T, readOnly bool) (*MemoryFileSystem, *smb1client.Client) {
+	t.Helper()
+
+	fs := NewMemoryFileSystem("FILES")
+	if err := fs.AddFile("before.txt", []byte("contents")); err != nil {
+		t.Fatalf("AddFile() error = %v", err)
+	}
+	if err := fs.AddDirectory("adirectory"); err != nil {
+		t.Fatalf("AddDirectory() error = %v", err)
+	}
+	_, client := fileServer(t, fs, readOnly)
+	return fs, client
+}
+
+// TestNtRenameRenamesAtTheRenameLevel asserts the rename level moves the entry.
+func TestNtRenameRenamesAtTheRenameLevel(t *testing.T) {
+	fs, client := renameServer(t, false)
+
+	if status := sendNtRename(t, client, smbNtRenameRenameFile, "before.txt", "after.txt", 0); status != 0 {
+		t.Fatalf("the rename reported 0x%08X, want success", status)
+	}
+
+	if _, err := fs.Stat("after.txt"); err != nil {
+		t.Errorf("the file is not at its new name: %v", err)
+	}
+	if _, err := fs.Stat("before.txt"); err == nil {
+		t.Error("the file is still at its old name")
+	}
+}
+
+// TestNtRenameLinksAtTheLinkLevel asserts the link level gives the file a second
+// name and leaves the first in place.
+//
+// [MS-CIFS] section 3.3.5.51: "the original file MUST NOT be renamed. Instead, the
+// server MUST attempt to create a hard link at the target". A server that renamed
+// here would lose the original name and report success.
+func TestNtRenameLinksAtTheLinkLevel(t *testing.T) {
+	fs, client := renameServer(t, false)
+
+	if status := sendNtRename(t, client, smbNtRenameSetLinkInfo, "before.txt", "alias.txt", 0); status != 0 {
+		t.Fatalf("the link reported 0x%08X, want success", status)
+	}
+
+	// Both names resolve.
+	if _, err := fs.Stat("before.txt"); err != nil {
+		t.Errorf("the original name is gone, so this was a rename rather than a link: %v", err)
+	}
+	if _, err := fs.Stat("alias.txt"); err != nil {
+		t.Errorf("the new name does not resolve: %v", err)
+	}
+
+	// And they are the same file, not two copies: a write through one is visible
+	// through the other, which is the whole difference between a link and a copy.
+	file, err := fs.Open("alias.txt", OpenFlags{Read: true, Write: true})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	if _, err := file.WriteAt([]byte("CHANGED!"), 0); err != nil {
+		t.Fatalf("WriteAt() error = %v", err)
+	}
+	file.Close()
+
+	original, err := fs.Open("before.txt", OpenFlags{Read: true})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer original.Close()
+
+	buffer := make([]byte, 8)
+	if _, err := original.ReadAt(buffer, 0); err != nil {
+		t.Fatalf("ReadAt() error = %v", err)
+	}
+	if string(buffer) != "CHANGED!" {
+		t.Errorf("the original name holds %q, want the write made through the link", buffer)
+	}
+}
+
+// TestNtRenameLinkRefusesATakenName asserts a link onto an existing name fails.
+func TestNtRenameLinkRefusesATakenName(t *testing.T) {
+	fs, client := renameServer(t, false)
+	if err := fs.AddFile("taken.txt", []byte("x")); err != nil {
+		t.Fatalf("AddFile() error = %v", err)
+	}
+
+	if status := sendNtRename(t, client, smbNtRenameSetLinkInfo, "before.txt", "taken.txt", 0); status == 0 {
+		t.Error("a link onto an existing name succeeded")
+	}
+}
+
+// TestNtRenameLinkOnABackendThatCannotLinkIsRefused asserts a share whose backend
+// does not implement Linker says so rather than approximating.
+//
+// A copy would be a second file rather than a second name, and the two diverge as
+// soon as either is written — so reporting success for one would be worse than
+// refusing.
+func TestNtRenameLinkOnABackendThatCannotLinkIsRefused(t *testing.T) {
+	fs := &unlinkableFileSystem{MemoryFileSystem: NewMemoryFileSystem("FILES")}
+	if err := fs.AddFile("before.txt", []byte("contents")); err != nil {
+		t.Fatalf("AddFile() error = %v", err)
+	}
+	_, client := fileServer(t, fs, false)
+
+	status := sendNtRename(t, client, smbNtRenameSetLinkInfo, "before.txt", "alias.txt", 0)
+	if status != uint32(nt_status.NT_STATUS_NOT_SUPPORTED) {
+		t.Errorf("a backend that cannot link reported 0x%08X, want STATUS_NOT_SUPPORTED (0x%08X)",
+			status, uint32(nt_status.NT_STATUS_NOT_SUPPORTED))
+	}
+
+	// A rename on the same share still works, so the refusal is about linking
+	// rather than about the share.
+	if status := sendNtRename(t, client, smbNtRenameRenameFile, "before.txt", "after.txt", 0); status != 0 {
+		t.Errorf("a rename on the same share reported 0x%08X", status)
+	}
+}
+
+// unlinkableFileSystem is a MemoryFileSystem with Link hidden, standing in for a
+// caller's backend that cannot create one.
+//
+// The embedded type's Link would otherwise satisfy Linker, so it is shadowed by a
+// field rather than overridden — a method cannot be removed in Go, and this is the
+// least surprising way to express "does not implement it".
+type unlinkableFileSystem struct {
+	*MemoryFileSystem
+
+	// Link shadows the embedded method, so the type does not satisfy Linker.
+	Link struct{}
+}
+
+// TestNtRenameRefusesAWildcardSource asserts the source name may not be a pattern.
+//
+// [MS-CIFS] section 3.3.5.51: "OldFileName MUST NOT contain wildcard characters;
+// otherwise, the server MUST return an error response with a Status of
+// STATUS_OBJECT_PATH_SYNTAX_BAD." Unlike SMB_COM_RENAME, this command acts on one
+// named file, so a pattern is a malformed request rather than a match set.
+func TestNtRenameRefusesAWildcardSource(t *testing.T) {
+	_, client := renameServer(t, false)
+
+	for _, pattern := range []string{"*.txt", "befor?.txt"} {
+		status := sendNtRename(t, client, smbNtRenameRenameFile, pattern, "after.txt", 0)
+		if status != uint32(nt_status.NT_STATUS_OBJECT_PATH_SYNTAX_BAD) {
+			t.Errorf("a wildcard source %q reported 0x%08X, want STATUS_OBJECT_PATH_SYNTAX_BAD (0x%08X)",
+				pattern, status, uint32(nt_status.NT_STATUS_OBJECT_PATH_SYNTAX_BAD))
+		}
+	}
+}
+
+// TestNtRenameRefusesAnUnknownLevel asserts a level that is neither of the two is
+// refused with the status the specification names.
+//
+// [MS-CIFS] section 3.3.5.51 says STATUS_INVALID_SMB specifically, and a client
+// distinguishing "unsupported" from "not a level" would be misled by
+// STATUS_NOT_SUPPORTED or STATUS_INVALID_PARAMETER.
+func TestNtRenameRefusesAnUnknownLevel(t *testing.T) {
+	_, client := renameServer(t, false)
+
+	status := sendNtRename(t, client, 0x0199, "before.txt", "after.txt", 0)
+	if status != uint32(nt_status.NT_STATUS_INVALID_SMB) {
+		t.Errorf("an unknown level reported 0x%08X, want STATUS_INVALID_SMB (0x%08X)",
+			status, uint32(nt_status.NT_STATUS_INVALID_SMB))
+	}
+}
+
+// TestNtRenameHonoursSearchAttributes asserts a directory is only matched when the
+// request's search attributes admit one.
+func TestNtRenameHonoursSearchAttributes(t *testing.T) {
+	_, client := renameServer(t, false)
+
+	// Without the directory bit, a directory is not a match.
+	status := sendNtRename(t, client, smbNtRenameRenameFile, "adirectory", "renamed", 0)
+	if status != uint32(nt_status.NT_STATUS_NO_SUCH_FILE) {
+		t.Errorf("renaming a directory without the directory attribute reported 0x%08X, want STATUS_NO_SUCH_FILE",
+			status)
+	}
+
+	// With it, the rename proceeds.
+	if status := sendNtRename(t, client, smbNtRenameRenameFile, "adirectory", "renamed",
+		smbFileAttributeDirectory); status != 0 {
+		t.Errorf("renaming a directory with the directory attribute reported 0x%08X", status)
+	}
+}
+
+// TestNtRenameOnAReadOnlyShareIsRefused asserts the share's refusal applies.
+func TestNtRenameOnAReadOnlyShareIsRefused(t *testing.T) {
+	_, client := renameServer(t, true)
+
+	if status := sendNtRename(t, client, smbNtRenameRenameFile, "before.txt", "after.txt", 0); status == 0 {
+		t.Error("a rename succeeded on a read-only share")
+	}
+}
+
+// TestObsoleteNameCommandsStayRefused asserts SMB_COM_COPY and SMB_COM_MOVE are
+// still answered STATUS_NOT_IMPLEMENTED.
+//
+// They were rendered obsolete in the NT LAN Manager dialect — the only dialect this
+// server speaks — and [MS-CIFS] sections 2.2.4.37 and 2.2.4.38 say servers
+// receiving them "SHOULD return STATUS_NOT_IMPLEMENTED". Serving them would be
+// implementing something the specification tells servers to refuse, so this test
+// pins the refusal rather than leaving it to look like an oversight.
+func TestObsoleteNameCommandsStayRefused(t *testing.T) {
+	_, client := renameServer(t, false)
+
+	for _, testCase := range []struct {
+		name    string
+		command codes.CommandCode
+	}{
+		{name: "SMB_COM_COPY", command: codes.SMB_COM_COPY},
+		{name: "SMB_COM_MOVE", command: codes.SMB_COM_MOVE},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			var status uint32
+			switch testCase.command {
+			case codes.SMB_COM_COPY:
+				status, _ = sendLegacy(t, client, codes.SMB_COM_COPY, commands.NewCopyRequest())
+			case codes.SMB_COM_MOVE:
+				status, _ = sendLegacy(t, client, codes.SMB_COM_MOVE, commands.NewMoveRequest())
+			}
+			if status != uint32(nt_status.NT_STATUS_NOT_IMPLEMENTED) {
+				t.Errorf("%s reported 0x%08X, want STATUS_NOT_IMPLEMENTED (0x%08X)",
+					testCase.name, status, uint32(nt_status.NT_STATUS_NOT_IMPLEMENTED))
+			}
+		})
+	}
+}

--- a/network/smb/smb_v10/server/share.go
+++ b/network/smb/smb_v10/server/share.go
@@ -205,6 +205,25 @@ type FileSystem interface {
 	VolumeInfo() (VolumeInfo, error)
 }
 
+// Linker is implemented by a FileSystem that can give an existing file a second
+// name.
+//
+// It is a separate interface rather than a method on FileSystem so that adding it
+// does not break a backend outside this repository: a FileSystem that cannot link
+// simply does not implement it, and the server answers STATUS_NOT_SUPPORTED. A
+// hard link is also the one operation here with no sensible approximation —
+// copying the bytes instead would produce a second file rather than a second name,
+// and the two diverge the moment either is written.
+type Linker interface {
+	// Link gives the file at existing a second name at target.
+	//
+	// It fails with ErrExists if target is taken, and with ErrNotFound if
+	// existing is not there. Linking a directory is refused with
+	// ErrIsDirectory: a directory hard link is not something the protocol asks
+	// for and not something most storage allows.
+	Link(existing, target string) error
+}
+
 // Sentinel errors a FileSystem returns so the server can answer with the right
 // protocol status. A backend may wrap them.
 var (


### PR DESCRIPTION
### Linked Issue
`Closes #1148`

> **Stacked on #1164.** Cut from main with `enhancement-legacy-info-commands` (#1146, on #1162) merged in, for the `SMB_FILE_ATTRIBUTES` constants the search-attribute check uses. Merge #1163 and #1164 first.

### Root Cause
`SMB_COM_NT_RENAME` had no entry in `dispatchTable`, so it was answered `STATUS_NOT_IMPLEMENTED`, and `FileSystem` had no way to create a hard link — which is half of what the command does.

### Fix Description
**`SMB_COM_COPY` and `SMB_COM_MOVE` are deliberately left refused, and this corrects the issue I filed.** The issue said they "perform the operation within the share, per [MS-CIFS] 2.2.4.44 and 2.2.4.43". Both the section numbers and the conclusion were wrong: those sections are `SMB_COM_WRITE_ANDX` and `SMB_COM_NEW_FILE_SIZE`, and the real sections — 2.2.4.37 and 2.2.4.38 — say both commands were "rendered obsolete in the NT LAN Manager dialect" and that servers receiving them "SHOULD return STATUS_NOT_IMPLEMENTED". NT LM 0.12 is the only dialect this server speaks, so refusing them is correct and serving them would have implemented something the specification tells servers not to. Their request structures in the message layer are empty, which is consistent with that.

`TestObsoleteNameCommandsStayRefused` pins the refusal so it reads as a decision rather than an oversight.

**`SMB_COM_NT_RENAME` is served at both of its levels**, per [MS-CIFS] 3.3.5.51:

- `SMB_NT_RENAME_RENAME_FILE` is "treated as if it is an SMB_COM_RENAME Request", so it renames with replace disabled.
- `SMB_NT_RENAME_SET_LINK_INFO` — "the original file MUST NOT be renamed. Instead, the server MUST attempt to create a hard link at the target". A server that renamed here would lose the original name and report success.
- Any other level fails with `STATUS_INVALID_SMB`, which is the status the specification names. `STATUS_NOT_SUPPORTED` or `STATUS_INVALID_PARAMETER` would read to a client as "unsupported level" rather than "not a level", so the specific status matters.
- The source may not be a pattern: `STATUS_OBJECT_PATH_SYNTAX_BAD` for a wildcard, because unlike `SMB_COM_RENAME` this command acts on exactly one named file.
- `SearchAttributes` gates the match, so a request can say "rename this only if it is a file".

**Linking needed a new backend primitive, added as `Linker` rather than as a `FileSystem` method.** That choice is deliberate: widening `FileSystem` would break every backend outside this repository, while an optional interface lets one that cannot link simply not implement it. A backend that does not is answered `STATUS_NOT_SUPPORTED` and *not* given a copy — a copy is a second file rather than a second name, and the two diverge the moment either is written, so silently substituting one would be worse than refusing.

`MemoryFileSystem.Link` points two paths at one `*memoryEntry`, which gives real link semantics: a write through either name is visible through the other. `LocalFileSystem.Link` uses `os.Link` with both paths through `hostPathNoFollow`, so neither source nor target can be placed outside the share by way of a symbolic link — the same rule the other name operations follow, and for the same reason.

### How Verified
Runtime, over the loopback harness:

- `TestNtRenameRenamesAtTheRenameLevel` — the entry moves.
- `TestNtRenameLinksAtTheLinkLevel` — both names resolve afterwards, and a write through the new name is read back through the old one. That last assertion is the one that distinguishes a link from a copy, which is the whole point of the level.
- `TestNtRenameLinkRefusesATakenName` — refused.
- `TestNtRenameLinkOnABackendThatCannotLinkIsRefused` — `STATUS_NOT_SUPPORTED`, and a rename on the same share still works, so the refusal is about linking and not about the share. The fixture shadows the embedded `Link` method with a field, because a Go method cannot be removed and that is the least surprising way to express "does not implement it".
- `TestNtRenameRefusesAWildcardSource` — both `*` and `?` give `STATUS_OBJECT_PATH_SYNTAX_BAD`.
- `TestNtRenameRefusesAnUnknownLevel` — `STATUS_INVALID_SMB` specifically.
- `TestNtRenameHonoursSearchAttributes` — a directory is refused without the directory bit and renamed with it.
- `TestNtRenameOnAReadOnlyShareIsRefused` — refused.
- `TestObsoleteNameCommandsStayRefused` — `SMB_COM_COPY` and `SMB_COM_MOVE` both answer `STATUS_NOT_IMPLEMENTED`.

Whole tree green: `go build ./...`, `go test ./network/smb/...`. `gofmt -l` clean on every file touched.

### Test Coverage
**Added:** `server/nt_rename_test.go` — the nine tests above, plus `sendNtRename`, `renameServer` and the `unlinkableFileSystem` fixture.

**Modified:** `server/conformance_test.go` — `SMB_COM_NT_RENAME` registered in `servedCommands`, and the coverage floor moved from `exercised >= 40` to `known >= 70` for the reason given in #1173: a floor on how many commands this walk exercises falls every time the server serves one more, so it becomes a record of past progress rather than a guard.

### Scope of Change
- **Files changed:** `server/handler_nt_rename.go` (new), `server/nt_rename_test.go` (new), `server/share.go`, `server/fs_mem.go`, `server/fs_local.go`, `server/dispatch.go`, `server/conformance_test.go`, `server/doc.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none. `Linker` is additive and both in-tree backends gain a method nothing else calls.

### Risk and Rollout
Additive. `SMB_COM_NT_RENAME` was refused before, and `Linker` is reached only through it. `LocalFileSystem.Link` is the one path that touches the host, and it validates both names the same way the existing rename and delete do — a defect there would be a containment escape, which is why the paths go through `hostPathNoFollow` rather than `hostPath`.

### Notes
This closes the last of the mechanical command batches apart from #1149. What remains on the original review are the two architectural items (#1141, then #1152), the `srvsvc` handler (#1150), and the interop legs (#1153).
