### PR TITLE
Serve the remaining TRANSACTION2 and NT_TRANSACT subcommands (Fixes #1149)

### DIFF
--- a/network/smb/smb_v10/server/conformance_test.go
+++ b/network/smb/smb_v10/server/conformance_test.go
@@ -177,6 +177,8 @@ var servedNtTransactFunctions = map[subcommands.NtTransactSubcommand]string{
 	subcommands.NT_TRANSACT_QUERY_SECURITY_DESC: "returns a share's security descriptor",
 	subcommands.NT_TRANSACT_SET_SECURITY_DESC:   "applies one, if the share can store it",
 	subcommands.NT_TRANSACT_IOCTL:               "carries the file-system control codes",
+	subcommands.NT_TRANSACT_CREATE:              "opens or creates a file through a transaction",
+	subcommands.NT_TRANSACT_RENAME:              "reserved and never implemented; refused with the mandated status",
 }
 
 // servedFsctlCodes are the file-system control codes NT_TRANSACT_IOCTL answers.
@@ -239,6 +241,9 @@ var servedTrans2Subcommands = map[subcommands.Transaction2Subcommand]string{
 	subcommands.TRANS2_SET_PATH_INFORMATION:   "changes a path",
 	subcommands.TRANS2_SET_FILE_INFORMATION:   "changes an open handle",
 	subcommands.TRANS2_QUERY_FS_INFORMATION:   "describes the volume",
+	subcommands.TRANS2_OPEN2:                  "opens or creates a file through a transaction",
+	subcommands.TRANS2_CREATE_DIRECTORY:       "creates a directory",
+	subcommands.TRANS2_SET_FS_INFORMATION:     "reserved and never implemented; refused with the mandated status",
 }
 
 // TestConformanceServedTrans2SubcommandsAreServed asserts the subcommand table and

--- a/network/smb/smb_v10/server/doc.go
+++ b/network/smb/smb_v10/server/doc.go
@@ -103,10 +103,21 @@
 // asked for. Both are architectural additions, and half of either would be worse
 // than the honest refusal.
 //
-// NT_TRANSACT_CREATE and NT_TRANSACT_RENAME are also absent by choice: they
-// duplicate SMB_COM_NT_CREATE_ANDX and SMB_COM_RENAME, which are served. The
-// quota subcommands are absent because nothing here tracks a quota, and a number
-// invented for them is a number a client would believe.
+// NT_TRANSACT_CREATE and TRANS2_OPEN2 are served, as are TRANS2_CREATE_DIRECTORY
+// and the extended attributes those two can carry — except that the attributes
+// themselves are not stored, and the responses report a length of zero, which is
+// how the format says a file has none.
+//
+// TRANS2_SET_FS_INFORMATION and NT_TRANSACT_RENAME are reserved and were never
+// implemented, and each is refused with the status its own section names rather
+// than with the tables' generic STATUS_NOT_IMPLEMENTED: [MS-CIFS] 2.2.6.5 requires
+// STATUS_SMB_NO_SUPPORT for the first and 2.2.7.5 requires STATUS_SMB_BAD_COMMAND
+// for the second.
+//
+// The quota subcommands are absent because nothing here tracks a quota, and a
+// number invented for them is a number a client would believe. TRANS2_FSCTL,
+// TRANS2_IOCTL2 and TRANS2_SESSION_SETUP are reserved and take the generic
+// refusal, which is what their sections require.
 //
 // # Shares
 //

--- a/network/smb/smb_v10/server/handler_core_file.go
+++ b/network/smb/smb_v10/server/handler_core_file.go
@@ -75,6 +75,43 @@ func coreOpenFlagsFor(accessMode uint16) (OpenFlags, nt_status.NT_STATUS) {
 	return OpenFlags{}, nt_status.NT_STATUS_OS2_INVALID_ACCESS
 }
 
+// applyOpenMode folds an OpenMode field into backend flags.
+//
+// OpenMode is the create-disposition of the NT commands expressed in two bits
+// ([MS-CIFS] section 2.2.4.41.1): what to do about a file that exists, and
+// whether to create one that does not. It is shared by SMB_COM_OPEN_ANDX and
+// TRANS2_OPEN2, which carry the same field.
+//
+// Parameters:
+//   - flags: the flags to fold into, already carrying the access mode
+//   - openMode: the request's OpenMode field
+func applyOpenMode(flags *OpenFlags, openMode uint16) {
+	if openMode&openModeCreateIfMissing != 0 {
+		flags.Create = true
+	}
+
+	switch openMode & openModeFileExistsMask {
+	case openModeTruncate:
+		flags.Truncate = true
+		// Truncating is a write, whatever access the client named.
+		flags.Write = true
+	case openModeFailIfExists:
+		// Fail if it exists and create if it does not is a create-new; without
+		// the create bit it is a plain open that must find the file, which the
+		// backend already reports.
+		if flags.Create {
+			// Both bits, which is the convention openFlagsFor established: the
+			// backend reads CreateNew as "refuse an existing file" and Create as
+			// "make a missing one", and a create-new needs to say both.
+			flags.CreateNew = true
+		}
+	case openModeAppendIfExsts:
+		// Appending needs write access; the offset is the client's business,
+		// since every core-set write carries one.
+		flags.Write = true
+	}
+}
+
 // coreOpen opens a path for one of the core-set commands and registers the handle.
 //
 // It is the shared body of SMB_COM_OPEN, SMB_COM_CREATE, SMB_COM_CREATE_NEW,
@@ -210,31 +247,7 @@ func handleOpenAndx(conn *Connection, w ResponseWriter, req *message.Message) nt
 		return status
 	}
 
-	openMode := uint16(request.OpenMode)
-	if openMode&openModeCreateIfMissing != 0 {
-		flags.Create = true
-	}
-
-	switch openMode & openModeFileExistsMask {
-	case openModeTruncate:
-		flags.Truncate = true
-		// Truncating is a write, whatever access the client named.
-		flags.Write = true
-	case openModeFailIfExists:
-		// Fail if it exists and create if it does not is a create-new; without
-		// the create bit it is a plain open that must find the file, which the
-		// backend already reports.
-		if flags.Create {
-			// Both bits, which is the convention openFlagsFor established: the
-			// backend reads CreateNew as "refuse an existing file" and Create as
-			// "make a missing one", and a create-new needs to say both.
-			flags.CreateNew = true
-		}
-	case openModeAppendIfExsts:
-		// Appending needs write access; the offset is the client's business,
-		// since every core-set write carries one.
-		flags.Write = true
-	}
+	applyOpenMode(&flags, uint16(request.OpenMode))
 
 	name := decodeWireString(request.FileName.Buffer, req.Header.Flags2.IsUnicode())
 	open, existed, status := conn.coreOpen(req, name, flags)

--- a/network/smb/smb_v10/server/handler_nttransact.go
+++ b/network/smb/smb_v10/server/handler_nttransact.go
@@ -140,14 +140,21 @@ type ntTransactHandler func(*Connection, *message.Message, *transactionReassembl
 
 // ntTransactHandlers maps a function code to its handler.
 //
-// NT_TRANSACT_CREATE, RENAME and the quota subcommands are absent deliberately.
-// Create and rename duplicate commands that already exist in their own right, and
-// nothing here tracks a quota, so answering them would mean inventing a number a
-// client would then believe.
+// The quota subcommands are absent deliberately: nothing here tracks a quota, so
+// answering them would mean inventing a number a client would then believe.
+//
+// NT_TRANSACT_NOTIFY_CHANGE is absent because it needs a reply sent after the
+// request that asked for it has been answered.
 var ntTransactHandlers = map[subcommands.NtTransactSubcommand]ntTransactHandler{
 	subcommands.NT_TRANSACT_QUERY_SECURITY_DESC: handleQuerySecurityDescriptor,
 	subcommands.NT_TRANSACT_SET_SECURITY_DESC:   handleSetSecurityDescriptor,
 	subcommands.NT_TRANSACT_IOCTL:               handleNtTransactIoctl,
+	subcommands.NT_TRANSACT_CREATE:              handleNtTransactCreate,
+
+	// Reserved and never implemented, with a status of its own: [MS-CIFS]
+	// section 2.2.7.5 requires STATUS_SMB_BAD_COMMAND rather than the table's
+	// default of STATUS_NOT_IMPLEMENTED.
+	subcommands.NT_TRANSACT_RENAME: handleNtTransactRename,
 }
 
 // sendNtTransactResponse sends an NT_TRANSACT result, splitting it across as many

--- a/network/smb/smb_v10/server/handler_remaining_subcommands.go
+++ b/network/smb/smb_v10/server/handler_remaining_subcommands.go
@@ -1,0 +1,265 @@
+package server
+
+import (
+	"encoding/binary"
+
+	"github.com/TheManticoreProject/Manticore/logger"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+	"github.com/TheManticoreProject/Manticore/windows/nt_status"
+)
+
+// handleOpen2 answers TRANS2_OPEN2: the TRANSACTION2 open, whose AccessMode and
+// OpenMode are the same fields SMB_COM_OPEN_ANDX carries.
+//
+// Request parameters, per [MS-CIFS] section 2.2.6.1.1: Flags(2) AccessMode(2)
+// Reserved1(2) FileAttributes(2) CreationTime(4) OpenMode(2) AllocationSize(4)
+// Reserved[5](10) FileName(variable).
+//
+// The extended attributes a client may send in the data block are not applied:
+// nothing here stores them, and the response reports an EA length of zero, which
+// is how the format says a file has none. Accepting them silently would tell the
+// client they had been kept.
+//
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/
+func handleOpen2(
+	conn *Connection,
+	req *message.Message,
+	reassembly *transactionReassembly,
+) ([]byte, []byte, nt_status.NT_STATUS) {
+	const fixed = 2 + 2 + 2 + 2 + 4 + 2 + 4 + 10
+
+	if len(reassembly.parameters) < fixed {
+		return nil, nil, nt_status.NT_STATUS_INVALID_PARAMETER
+	}
+
+	accessMode := binary.LittleEndian.Uint16(reassembly.parameters[2:4])
+	openMode := binary.LittleEndian.Uint16(reassembly.parameters[12:14])
+	name := decodeWireString([]types.UCHAR(reassembly.parameters[fixed:]), req.Header.Flags2.IsUnicode())
+
+	flags, status := coreOpenFlagsFor(accessMode)
+	if status != nt_status.NT_STATUS_SUCCESS {
+		return nil, nil, status
+	}
+	applyOpenMode(&flags, openMode)
+
+	open, existed, status := conn.coreOpen(req, name, flags)
+	if status != nt_status.NT_STATUS_SUCCESS {
+		return nil, nil, status
+	}
+
+	attr, err := open.File.Stat()
+	if err != nil {
+		return nil, nil, statusForFSError(err)
+	}
+
+	// Response parameters, per [MS-CIFS] section 2.2.6.1.2: FID(2)
+	// FileAttributes(2) CreationTime(4) FileDataSize(4) AccessMode(2)
+	// ResourceType(2) NMPipeStatus(2) ActionTaken(2) Reserved(4)
+	// ExtendedAttributeErrorOffset(2) ExtendedAttributeLength(4).
+	parameters := make([]byte, 30)
+	binary.LittleEndian.PutUint16(parameters[0:2], open.FID)
+	binary.LittleEndian.PutUint16(parameters[2:4], legacyAttributesFor(attr))
+	binary.LittleEndian.PutUint32(parameters[4:8], utimeOf(attr.Created))
+	binary.LittleEndian.PutUint32(parameters[8:12], uint32(attr.Size))
+	binary.LittleEndian.PutUint16(parameters[12:14], accessMode)
+	binary.LittleEndian.PutUint16(parameters[14:16], resourceTypeDisk)
+	binary.LittleEndian.PutUint16(parameters[18:20], open2ActionTaken(existed))
+
+	return parameters, nil, nt_status.NT_STATUS_SUCCESS
+}
+
+// The ActionTaken values of a TRANS2_OPEN2 response ([MS-CIFS] section 2.2.6.1.2).
+const (
+	open2ActionOpened    = 0x0001
+	open2ActionCreated   = 0x0002
+	open2ActionTruncated = 0x0003
+)
+
+// open2ActionTaken reports what the open did, which is the only way a client can
+// tell a file it created from one it found.
+func open2ActionTaken(existed bool) uint16 {
+	if existed {
+		return open2ActionOpened
+	}
+	return open2ActionCreated
+}
+
+// handleTrans2CreateDirectory answers TRANS2_CREATE_DIRECTORY.
+//
+// [MS-CIFS] section 2.2.6.14: "The directory MUST NOT exist. If the directory does
+// exist, the request MUST fail and the server MUST return
+// STATUS_OBJECT_NAME_COLLISION." The backend's Mkdir already reports that, so the
+// status comes from there rather than from a separate check.
+//
+// Request parameters: Reserved(4) DirectoryName(variable).
+//
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/
+func handleTrans2CreateDirectory(
+	conn *Connection,
+	req *message.Message,
+	reassembly *transactionReassembly,
+) ([]byte, []byte, nt_status.NT_STATUS) {
+	const fixed = 4
+
+	if len(reassembly.parameters) < fixed {
+		return nil, nil, nt_status.NT_STATUS_INVALID_PARAMETER
+	}
+
+	tree, status := conn.treeFor(req)
+	if status != nt_status.NT_STATUS_SUCCESS {
+		return nil, nil, status
+	}
+	if tree.Share.FS == nil {
+		return nil, nil, nt_status.NT_STATUS_INVALID_DEVICE_REQUEST
+	}
+	if tree.Share.ReadOnly {
+		return nil, nil, nt_status.NT_STATUS_MEDIA_WRITE_PROTECTED
+	}
+
+	name := decodeWireString([]types.UCHAR(reassembly.parameters[fixed:]), req.Header.Flags2.IsUnicode())
+	path, err := resolvePath(name)
+	if err != nil {
+		return nil, nil, nt_status.NT_STATUS_OBJECT_PATH_SYNTAX_BAD
+	}
+
+	if err := tree.Share.FS.Mkdir(path); err != nil {
+		logger.Debugf("SMB1 server: %s created directory %q, which failed: %v", conn.Remote, path, err)
+		return nil, nil, statusForFSError(err)
+	}
+
+	// Response parameters are a 2-byte EaErrorOffset, which is zero because no
+	// extended attributes were applied.
+	return make([]byte, 2), nil, nt_status.NT_STATUS_SUCCESS
+}
+
+// handleTrans2SetFsInformation answers TRANS2_SET_FS_INFORMATION with the status
+// the specification mandates for it.
+//
+// [MS-CIFS] section 2.2.6.5: the subcommand "is reserved but not implemented" and
+// "Servers receiving requests with this command code MUST return
+// STATUS_SMB_NO_SUPPORT (ERRSRV/ERRnosupport)". It is handled explicitly rather
+// than left to fall through to STATUS_NOT_IMPLEMENTED because the specification
+// names a different status for it than for its neighbours.
+//
+// STATUS_SMB_NO_SUPPORT has no constant in windows/nt_status, so the closest
+// available is used: NT_STATUS_NOT_SUPPORTED, which carries the same meaning and
+// maps to a not-supported legacy code. Nothing sends this subcommand — it is
+// reserved — so the difference is a conformance detail rather than a live one.
+func handleTrans2SetFsInformation(
+	conn *Connection,
+	_ *message.Message,
+	_ *transactionReassembly,
+) ([]byte, []byte, nt_status.NT_STATUS) {
+	logger.Debugf("SMB1 server: %s sent TRANS2_SET_FS_INFORMATION, which is reserved and refused", conn.Remote)
+	return nil, nil, nt_status.NT_STATUS_NOT_SUPPORTED
+}
+
+// handleNtTransactCreate answers NT_TRANSACT_CREATE, the NT_TRANSACT open.
+//
+// It is the same open as SMB_COM_NT_CREATE_ANDX with the parameters in a
+// transaction rather than in the command words, so it shares openFlagsFor and the
+// same read-only enforcement.
+//
+// Request parameters, per [MS-CIFS] section 2.2.7.1.1: Flags(4)
+// RootDirectoryFID(4) DesiredAccess(4) AllocationSize(8) ExtFileAttributes(4)
+// ShareAccess(4) CreateDisposition(4) CreateOptions(4) SecurityDescriptorLength(4)
+// EALength(4) NameLength(4) ImpersonationLevel(4) SecurityFlags(1) Name(NameLength).
+//
+// The security descriptor and extended attributes a client may send in the data
+// block are not applied: a descriptor is answered through the NT_TRANSACT security
+// subcommands by a share that has a provider, and applying one here would let a
+// create set access this server cannot then honour.
+//
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/
+func handleNtTransactCreate(
+	conn *Connection,
+	req *message.Message,
+	reassembly *transactionReassembly,
+) ([]byte, []byte, nt_status.NT_STATUS) {
+	const fixed = 4 + 4 + 4 + 8 + 4 + 4 + 4 + 4 + 4 + 4 + 4 + 4 + 1
+
+	if len(reassembly.parameters) < fixed {
+		return nil, nil, nt_status.NT_STATUS_INVALID_PARAMETER
+	}
+
+	rootDirectoryFID := binary.LittleEndian.Uint32(reassembly.parameters[4:8])
+	desiredAccess := binary.LittleEndian.Uint32(reassembly.parameters[8:12])
+	createDisposition := binary.LittleEndian.Uint32(reassembly.parameters[28:32])
+	createOptions := binary.LittleEndian.Uint32(reassembly.parameters[32:36])
+	nameLength := int(binary.LittleEndian.Uint32(reassembly.parameters[40:44]))
+
+	// RootDirectoryFID names a directory handle the name is relative to. Nothing
+	// here can resolve one, and treating the name as share-relative instead would
+	// open a different file and report success.
+	if rootDirectoryFID != 0 {
+		logger.Debugf("SMB1 server: %s created relative to FID 0x%08X, which is refused",
+			conn.Remote, rootDirectoryFID)
+		return nil, nil, nt_status.NT_STATUS_NOT_SUPPORTED
+	}
+
+	if nameLength < 0 || fixed+nameLength > len(reassembly.parameters) {
+		return nil, nil, nt_status.NT_STATUS_INVALID_PARAMETER
+	}
+	name := decodeWireString([]types.UCHAR(reassembly.parameters[fixed:fixed+nameLength]),
+		req.Header.Flags2.IsUnicode())
+
+	flags, status := openFlagsFor(desiredAccess, createDisposition, createOptions)
+	if status != nt_status.NT_STATUS_SUCCESS {
+		return nil, nil, status
+	}
+
+	open, existed, status := conn.coreOpen(req, name, flags)
+	if status != nt_status.NT_STATUS_SUCCESS {
+		return nil, nil, status
+	}
+	open.DeleteOnClose = createOptions&fileDeleteOnClose != 0
+
+	attr, err := open.File.Stat()
+	if err != nil {
+		return nil, nil, statusForFSError(err)
+	}
+
+	// Response parameters are 69 bytes, per [MS-CIFS] section 2.2.7.1.2.
+	parameters := make([]byte, 69)
+	// OpLockLevel stays zero: no oplock is granted, and claiming one the server
+	// cannot break would have the client cache on a promise nothing keeps.
+	binary.LittleEndian.PutUint16(parameters[2:4], open.FID)
+	binary.LittleEndian.PutUint32(parameters[4:8], createActionFor(existed, flags))
+	binary.LittleEndian.PutUint64(parameters[12:20], filetimeOf(attr.Created))
+	binary.LittleEndian.PutUint64(parameters[20:28], filetimeOf(attr.Accessed))
+	binary.LittleEndian.PutUint64(parameters[28:36], filetimeOf(attr.Modified))
+	binary.LittleEndian.PutUint64(parameters[36:44], filetimeOf(attr.Changed))
+	binary.LittleEndian.PutUint32(parameters[44:48], attributesFor(attr))
+	binary.LittleEndian.PutUint64(parameters[48:56], uint64(attr.AllocationSize))
+	binary.LittleEndian.PutUint64(parameters[56:64], uint64(attr.Size))
+	binary.LittleEndian.PutUint16(parameters[64:66], resourceTypeDisk)
+	if attr.IsDir {
+		parameters[68] = 1
+	}
+
+	return parameters, nil, nt_status.NT_STATUS_SUCCESS
+}
+
+// handleNtTransactRename answers NT_TRANSACT_RENAME with the status the
+// specification mandates.
+//
+// [MS-CIFS] section 2.2.7.5: the subcommand "was reserved but not implemented" and
+// "Servers receiving requests with this subcommand code MUST return
+// STATUS_SMB_BAD_COMMAND (ERRSRV/ERRbadcmd)".
+//
+// It is handled explicitly rather than left to fall through, because the fall
+// through answers STATUS_NOT_IMPLEMENTED and the specification names a different
+// status here. Renaming through NT_TRANSACT was never a real operation, and
+// SMB_COM_NT_RENAME is the command that does it.
+func handleNtTransactRename(
+	conn *Connection,
+	_ *message.Message,
+	_ *transactionReassembly,
+) ([]byte, []byte, nt_status.NT_STATUS) {
+	logger.Debugf("SMB1 server: %s sent NT_TRANSACT_RENAME, which is reserved and refused", conn.Remote)
+	return nil, nil, nt_status.NT_STATUS_SMB_BAD_COMMAND
+}
+
+// fileDeleteOnClose is the CreateOptions bit that marks a handle for deletion.
+const fileDeleteOnClose = 0x00001000

--- a/network/smb/smb_v10/server/handler_trans2.go
+++ b/network/smb/smb_v10/server/handler_trans2.go
@@ -320,6 +320,13 @@ var trans2Handlers = map[subcommands.Transaction2Subcommand]trans2Handler{
 	subcommands.TRANS2_SET_PATH_INFORMATION:   handleSetPathInformation,
 	subcommands.TRANS2_SET_FILE_INFORMATION:   handleSetFileInformation,
 	subcommands.TRANS2_QUERY_FS_INFORMATION:   handleQueryFsInformation,
+	subcommands.TRANS2_OPEN2:                  handleOpen2,
+	subcommands.TRANS2_CREATE_DIRECTORY:       handleTrans2CreateDirectory,
+
+	// Reserved and never implemented, but with a status of its own rather than
+	// the table's default: [MS-CIFS] section 2.2.6.5 requires
+	// STATUS_SMB_NO_SUPPORT for this one specifically.
+	subcommands.TRANS2_SET_FS_INFORMATION: handleTrans2SetFsInformation,
 }
 
 // sendTransaction2Response sends a transaction result, splitting it across as many

--- a/network/smb/smb_v10/server/nttransact_test.go
+++ b/network/smb/smb_v10/server/nttransact_test.go
@@ -599,9 +599,11 @@ func TestNtTransactUnimplementedFunctions(t *testing.T) {
 	fs := NewMemoryFileSystem("FILES")
 	_, client := fileServer(t, fs, false)
 
+	// NT_TRANSACT_CREATE is served, and NT_TRANSACT_RENAME is refused with
+	// STATUS_SMB_BAD_COMMAND rather than STATUS_NOT_IMPLEMENTED because
+	// [MS-CIFS] section 2.2.7.5 names that status for it; both are asserted
+	// elsewhere. What is left here is the set that answers the generic refusal.
 	unimplemented := []subcommands.NtTransactSubcommand{
-		subcommands.NT_TRANSACT_CREATE,
-		subcommands.NT_TRANSACT_RENAME,
 		subcommands.NT_TRANSACT_NOTIFY_CHANGE,
 		subcommands.NT_TRANSACT_QUERY_QUOTA,
 		subcommands.NT_TRANSACT_SET_QUOTA,

--- a/network/smb/smb_v10/server/remaining_subcommands_test.go
+++ b/network/smb/smb_v10/server/remaining_subcommands_test.go
@@ -1,0 +1,352 @@
+package server
+
+import (
+	"encoding/binary"
+	"testing"
+
+	smb1client "github.com/TheManticoreProject/Manticore/network/smb/smb_v10/client"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/codes"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header/flags2"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/subcommands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+	"github.com/TheManticoreProject/Manticore/windows/nt_status"
+)
+
+// open2Parameters builds a TRANS2_OPEN2 request's parameter block.
+//
+// Flags(2) AccessMode(2) Reserved1(2) FileAttributes(2) CreationTime(4)
+// OpenMode(2) AllocationSize(4) Reserved[5](10) FileName(variable), per [MS-CIFS]
+// section 2.2.6.1.1.
+func open2Parameters(accessMode, openMode uint16, name string) []byte {
+	parameters := make([]byte, 28)
+	binary.LittleEndian.PutUint16(parameters[2:4], accessMode)
+	binary.LittleEndian.PutUint16(parameters[12:14], openMode)
+	return append(parameters, append([]byte(name), 0x00)...)
+}
+
+// TestTrans2Open2OpensAndCreates asserts the transaction open honours its
+// OpenMode, and reports which of the two it did.
+//
+// ActionTaken is the only way a client can tell a file it created from one it
+// found, so reporting it wrongly would have a client overwrite something it
+// believed it had just made.
+func TestTrans2Open2OpensAndCreates(t *testing.T) {
+	fs := NewMemoryFileSystem("FILES")
+	if err := fs.AddFile("existing.txt", []byte("0123456789")); err != nil {
+		t.Fatalf("AddFile() error = %v", err)
+	}
+	_, client := fileServer(t, fs, false)
+
+	t.Run("opens an existing file", func(t *testing.T) {
+		parameters, _, status := sendTrans2(t, client, subcommands.TRANS2_OPEN2,
+			open2Parameters(openAccessReadWrite, 0, "existing.txt"), nil)
+		if status != 0 {
+			t.Fatalf("TRANS2_OPEN2 reported 0x%08X, want success", status)
+		}
+		if len(parameters) < 20 {
+			t.Fatalf("the reply carries %d parameter bytes, want at least 20", len(parameters))
+		}
+		if fid := binary.LittleEndian.Uint16(parameters[0:2]); fid == 0 {
+			t.Error("the reply carries no FID")
+		}
+		if size := binary.LittleEndian.Uint32(parameters[8:12]); size != 10 {
+			t.Errorf("FileDataSize is %d, want 10", size)
+		}
+		if action := binary.LittleEndian.Uint16(parameters[18:20]); action != open2ActionOpened {
+			t.Errorf("ActionTaken is %d, want %d (opened)", action, open2ActionOpened)
+		}
+	})
+
+	t.Run("creates a missing file", func(t *testing.T) {
+		parameters, _, status := sendTrans2(t, client, subcommands.TRANS2_OPEN2,
+			open2Parameters(openAccessReadWrite, openModeCreateIfMissing, "created.txt"), nil)
+		if status != 0 {
+			t.Fatalf("TRANS2_OPEN2 reported 0x%08X, want success", status)
+		}
+		if action := binary.LittleEndian.Uint16(parameters[18:20]); action != open2ActionCreated {
+			t.Errorf("ActionTaken is %d, want %d (created)", action, open2ActionCreated)
+		}
+		if _, err := fs.Stat("created.txt"); err != nil {
+			t.Errorf("the file was not created: %v", err)
+		}
+	})
+
+	t.Run("truncates when asked", func(t *testing.T) {
+		if _, _, status := sendTrans2(t, client, subcommands.TRANS2_OPEN2,
+			open2Parameters(openAccessReadWrite, openModeTruncate, "existing.txt"), nil); status != 0 {
+			t.Fatalf("TRANS2_OPEN2 reported 0x%08X", status)
+		}
+		attr, err := fs.Stat("existing.txt")
+		if err != nil {
+			t.Fatalf("Stat() error = %v", err)
+		}
+		if attr.Size != 0 {
+			t.Errorf("the file is %d bytes after a truncating open, want 0", attr.Size)
+		}
+	})
+
+	t.Run("refuses a missing file when not asked to create", func(t *testing.T) {
+		if _, _, status := sendTrans2(t, client, subcommands.TRANS2_OPEN2,
+			open2Parameters(openAccessRead, 0, "notthere.txt"), nil); status == 0 {
+			t.Error("an open of a missing file succeeded without the create bit")
+		}
+	})
+}
+
+// TestTrans2CreateDirectoryMakesOneAndRefusesADuplicate asserts the subcommand
+// creates a directory and refuses one that exists.
+//
+// [MS-CIFS] section 2.2.6.14: "The directory MUST NOT exist. If the directory does
+// exist, the request MUST fail and the server MUST return
+// STATUS_OBJECT_NAME_COLLISION."
+func TestTrans2CreateDirectoryMakesOneAndRefusesADuplicate(t *testing.T) {
+	fs := NewMemoryFileSystem("FILES")
+	_, client := fileServer(t, fs, false)
+
+	parameters := append(make([]byte, 4), append([]byte("newdirectory"), 0x00)...)
+
+	if _, _, status := sendTrans2(t, client, subcommands.TRANS2_CREATE_DIRECTORY, parameters, nil); status != 0 {
+		t.Fatalf("TRANS2_CREATE_DIRECTORY reported 0x%08X, want success", status)
+	}
+	attr, err := fs.Stat("newdirectory")
+	if err != nil {
+		t.Fatalf("the directory was not created: %v", err)
+	}
+	if !attr.IsDir {
+		t.Error("what was created is not a directory")
+	}
+
+	_, _, status := sendTrans2(t, client, subcommands.TRANS2_CREATE_DIRECTORY, parameters, nil)
+	if status != uint32(nt_status.NT_STATUS_OBJECT_NAME_COLLISION) {
+		t.Errorf("creating it twice reported 0x%08X, want STATUS_OBJECT_NAME_COLLISION (0x%08X)",
+			status, uint32(nt_status.NT_STATUS_OBJECT_NAME_COLLISION))
+	}
+}
+
+// TestTrans2CreateDirectoryOnAReadOnlyShareIsRefused asserts the share's refusal
+// applies.
+func TestTrans2CreateDirectoryOnAReadOnlyShareIsRefused(t *testing.T) {
+	fs := NewMemoryFileSystem("FILES")
+	_, client := fileServer(t, fs, true)
+
+	parameters := append(make([]byte, 4), append([]byte("newdirectory"), 0x00)...)
+	if _, _, status := sendTrans2(t, client, subcommands.TRANS2_CREATE_DIRECTORY, parameters, nil); status == 0 {
+		t.Error("a directory was created on a read-only share")
+	}
+}
+
+// TestNtTransactCreateOpensThroughATransaction asserts the NT_TRANSACT open works
+// and reports the file it opened.
+func TestNtTransactCreateOpensThroughATransaction(t *testing.T) {
+	fs := NewMemoryFileSystem("FILES")
+	if err := fs.AddFile("existing.txt", []byte("0123456789")); err != nil {
+		t.Fatalf("AddFile() error = %v", err)
+	}
+	_, client := fileServer(t, fs, false)
+
+	// Flags(4) RootDirectoryFID(4) DesiredAccess(4) AllocationSize(8)
+	// ExtFileAttributes(4) ShareAccess(4) CreateDisposition(4) CreateOptions(4)
+	// SecurityDescriptorLength(4) EALength(4) NameLength(4)
+	// ImpersonationLevel(4) SecurityFlags(1), then the name.
+	name := "existing.txt"
+	parameters := make([]byte, 53)
+	binary.LittleEndian.PutUint32(parameters[8:12], 0x00120089)  // DesiredAccess: read
+	binary.LittleEndian.PutUint32(parameters[28:32], 0x00000001) // FILE_OPEN
+	binary.LittleEndian.PutUint32(parameters[32:36], 0x00000040) // FILE_NON_DIRECTORY_FILE
+	binary.LittleEndian.PutUint32(parameters[40:44], uint32(len(name)))
+	parameters = append(parameters, []byte(name)...)
+
+	got, _, status := sendNtTransactWithParameters(t, client, subcommands.NT_TRANSACT_CREATE, parameters)
+	if status != 0 {
+		t.Fatalf("NT_TRANSACT_CREATE reported 0x%08X, want success", status)
+	}
+	if len(got) != 69 {
+		t.Fatalf("the reply carries %d parameter bytes, want the 69 of [MS-CIFS] 2.2.7.1.2", len(got))
+	}
+	if fid := binary.LittleEndian.Uint16(got[2:4]); fid == 0 {
+		t.Error("the reply carries no FID")
+	}
+	if size := binary.LittleEndian.Uint64(got[56:64]); size != 10 {
+		t.Errorf("EndOfFile is %d, want 10", size)
+	}
+	if got[0] != 0 {
+		t.Errorf("OpLockLevel is %d, want 0 — no oplock is granted", got[0])
+	}
+}
+
+// TestNtTransactCreateRefusesARelativeRoot asserts a create relative to a
+// directory handle is refused rather than resolved against the share root.
+//
+// Treating the name as share-relative instead would open a different file and
+// report success.
+func TestNtTransactCreateRefusesARelativeRoot(t *testing.T) {
+	fs := NewMemoryFileSystem("FILES")
+	_, client := fileServer(t, fs, false)
+
+	name := "somewhere.txt"
+	parameters := make([]byte, 53)
+	binary.LittleEndian.PutUint32(parameters[4:8], 0x1234) // RootDirectoryFID
+	binary.LittleEndian.PutUint32(parameters[40:44], uint32(len(name)))
+	parameters = append(parameters, []byte(name)...)
+
+	_, _, status := sendNtTransactWithParameters(t, client, subcommands.NT_TRANSACT_CREATE, parameters)
+	if status != uint32(nt_status.NT_STATUS_NOT_SUPPORTED) {
+		t.Errorf("a create relative to a handle reported 0x%08X, want STATUS_NOT_SUPPORTED", status)
+	}
+}
+
+// TestReservedSubcommandsUseTheirMandatedStatus asserts the two reserved
+// subcommands answer with the status the specification names for each, rather than
+// the generic refusal.
+//
+// [MS-CIFS] section 2.2.6.5 requires STATUS_SMB_NO_SUPPORT for
+// TRANS2_SET_FS_INFORMATION, and section 2.2.7.5 requires STATUS_SMB_BAD_COMMAND
+// for NT_TRANSACT_RENAME. Both differ from the STATUS_NOT_IMPLEMENTED their
+// neighbours get, which is why each is handled rather than left to fall through.
+func TestReservedSubcommandsUseTheirMandatedStatus(t *testing.T) {
+	fs := NewMemoryFileSystem("FILES")
+	_, client := fileServer(t, fs, false)
+
+	t.Run("TRANS2_SET_FS_INFORMATION", func(t *testing.T) {
+		// STATUS_SMB_NO_SUPPORT has no constant in windows/nt_status, so the
+		// closest available is used; what matters here is that it is not the
+		// generic STATUS_NOT_IMPLEMENTED.
+		_, _, status := sendTrans2(t, client, subcommands.TRANS2_SET_FS_INFORMATION, make([]byte, 4), nil)
+		if status != uint32(nt_status.NT_STATUS_NOT_SUPPORTED) {
+			t.Errorf("it reported 0x%08X, want STATUS_NOT_SUPPORTED (0x%08X)",
+				status, uint32(nt_status.NT_STATUS_NOT_SUPPORTED))
+		}
+		if status == uint32(nt_status.NT_STATUS_NOT_IMPLEMENTED) {
+			t.Error("it fell through to the table's generic refusal")
+		}
+	})
+
+	t.Run("NT_TRANSACT_RENAME", func(t *testing.T) {
+		_, _, status := sendNtTransactWithParameters(t, client, subcommands.NT_TRANSACT_RENAME, make([]byte, 4))
+		if status != uint32(nt_status.NT_STATUS_SMB_BAD_COMMAND) {
+			t.Errorf("it reported 0x%08X, want STATUS_SMB_BAD_COMMAND (0x%08X)",
+				status, uint32(nt_status.NT_STATUS_SMB_BAD_COMMAND))
+		}
+	})
+}
+
+// sendTrans2 sends a TRANSACTION2 and returns the parameter block, the data block
+// and the status.
+//
+// The existing sendNtTransact returns only a status, and these subcommands answer
+// in their parameter block, so the reply has to come back whole.
+func sendTrans2(
+	t *testing.T,
+	client *smb1client.Client,
+	subcommand subcommands.Transaction2Subcommand,
+	parameters, data []byte,
+) ([]byte, []byte, uint32) {
+	t.Helper()
+
+	request := newRequest(codes.SMB_COM_TRANSACTION2)
+	request.Header.UID = client.Session.SessionUID
+	request.Header.TID = client.Session.TreeID
+	// The names in these parameter blocks are ASCII, so the message must not
+	// declare Unicode.
+	request.Header.Flags2 &^= flags2.Flags2(flags2.FLAGS2_UNICODE)
+
+	transaction := commands.NewTransaction2Request()
+	transaction.Setup = []types.USHORT{types.USHORT(subcommand)}
+	transaction.SetupCount = types.UCHAR(1)
+	transaction.MaxParameterCount = 1024
+	transaction.MaxDataCount = 4096
+	transaction.TotalParameterCount = types.USHORT(len(parameters))
+	transaction.ParameterCount = types.USHORT(len(parameters))
+	transaction.Trans2_Parameters = parameters
+	transaction.TotalDataCount = types.USHORT(len(data))
+	transaction.DataCount = types.USHORT(len(data))
+	transaction.Trans2_Data = data
+	request.AddCommand(transaction)
+
+	marshalled, err := request.Marshal()
+	if err != nil {
+		t.Fatalf("failed to marshal the transaction: %v", err)
+	}
+	if _, err := client.Transport.Send(marshalled); err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+	raw, err := client.Transport.Receive()
+	if err != nil {
+		t.Fatalf("Receive() error = %v", err)
+	}
+	if len(raw) < 9 {
+		t.Fatalf("the reply is %d bytes", len(raw))
+	}
+
+	status := binary.LittleEndian.Uint32(raw[5:9])
+	if status != 0 {
+		return nil, nil, status
+	}
+
+	response := message.NewMessage()
+	if err := response.Unmarshal(raw); err != nil {
+		t.Fatalf("the reply did not decode: %v", err)
+	}
+	decoded, ok := response.Command.(*commands.Transaction2Response)
+	if !ok {
+		t.Fatalf("the reply carries %T", response.Command)
+	}
+	return []byte(decoded.Trans2_Parameters), []byte(decoded.Trans2_Data), 0
+}
+
+// sendNtTransactWithParameters is sendNtTransact with the reply's parameter block
+// returned, which is where these subcommands answer.
+func sendNtTransactWithParameters(
+	t *testing.T,
+	client *smb1client.Client,
+	function subcommands.NtTransactSubcommand,
+	parameters []byte,
+) ([]byte, []byte, uint32) {
+	t.Helper()
+
+	request := newRequest(codes.SMB_COM_NT_TRANSACT)
+	request.Header.UID = client.Session.SessionUID
+	request.Header.TID = client.Session.TreeID
+	request.Header.Flags2 &^= flags2.Flags2(flags2.FLAGS2_UNICODE)
+
+	transaction := commands.NewNtTransactRequest()
+	transaction.Function = types.USHORT(function)
+	transaction.MaxParameterCount = 1024
+	transaction.MaxDataCount = 4096
+	transaction.TotalParameterCount = types.ULONG(len(parameters))
+	transaction.ParameterCount = types.ULONG(len(parameters))
+	transaction.NT_Trans_Parameters = parameters
+	request.AddCommand(transaction)
+
+	marshalled, err := request.Marshal()
+	if err != nil {
+		t.Fatalf("failed to marshal the transaction: %v", err)
+	}
+	if _, err := client.Transport.Send(marshalled); err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+	raw, err := client.Transport.Receive()
+	if err != nil {
+		t.Fatalf("Receive() error = %v", err)
+	}
+	if len(raw) < 9 {
+		t.Fatalf("the reply is %d bytes", len(raw))
+	}
+
+	status := binary.LittleEndian.Uint32(raw[5:9])
+	if status != 0 {
+		return nil, nil, status
+	}
+
+	response := message.NewMessage()
+	if err := response.Unmarshal(raw); err != nil {
+		t.Fatalf("the reply did not decode: %v", err)
+	}
+	decoded, ok := response.Command.(*commands.NtTransactResponse)
+	if !ok {
+		t.Fatalf("the reply carries %T", response.Command)
+	}
+	return []byte(decoded.Parameters), []byte(decoded.Data), 0
+}


### PR DESCRIPTION
### Linked Issue
`Closes #1149`

> **Stacked on #1173.** Cut from main with `enhancement-core-file-commands` (#1145, which carries #1146/#1162/#1171) merged in: `TRANS2_OPEN2` carries the same `OpenMode` field as `SMB_COM_OPEN_ANDX` and shares `applyOpenMode` and `coreOpen` with it. Merge #1163, #1164, #1172 and #1173 first.

### Root Cause
The unserved subcommands had no entry in `trans2Handlers` or `ntTransactHandlers`, so each fell through to `STATUS_NOT_IMPLEMENTED`.

### Fix Description
**Three are served**, and **two are refused with a status the specification names specifically** — which is the part of this issue that turned out to matter more than the count.

Served:

- `TRANS2_OPEN2` — the transaction open, reusing `applyOpenMode` and `coreOpen` from #1145, since it carries the same `AccessMode` and `OpenMode` fields as `SMB_COM_OPEN_ANDX`. `ActionTaken` reports whether the file was opened or created, which is the only way a client can tell a file it made from one it found; getting it wrong would have a client overwrite something it believed it had just created.
- `TRANS2_CREATE_DIRECTORY` — backed by `Mkdir`, which already produces the `STATUS_OBJECT_NAME_COLLISION` that [MS-CIFS] 2.2.6.14 requires for a directory that exists.
- `NT_TRANSACT_CREATE` — the same open as `SMB_COM_NT_CREATE_ANDX` with its parameters in a transaction, sharing `openFlagsFor`. A non-zero `RootDirectoryFID` is refused rather than resolved against the share root, because treating the name as share-relative would open a different file and report success. The 69-byte response is the layout of [MS-CIFS] 2.2.7.1.2, with `OpLockLevel` zero — claiming an oplock the server cannot break would have the client cache on a promise nothing keeps.

**Two corrections to the issue I filed.** It listed `NT_TRANSACT_RENAME` among the subcommands to serve, and grouped `TRANS2_SET_FS_INFORMATION` with the ones to "refuse with the status [MS-CIFS] specifies" without saying which. Reading the sections:

- `NT_TRANSACT_RENAME` "was reserved but not implemented", and servers "MUST return STATUS_SMB_BAD_COMMAND" (2.2.7.5). Serving it would have implemented something the specification says to refuse.
- `TRANS2_SET_FS_INFORMATION` "is reserved but not implemented", and servers "MUST return STATUS_SMB_NO_SUPPORT" (2.2.6.5).

Both differ from the `STATUS_NOT_IMPLEMENTED` their neighbours get, so both are handled explicitly rather than left to fall through — a table entry whose only job is to answer with a different status is still the right way to say so.

One honest gap: `STATUS_SMB_NO_SUPPORT` has no constant in `windows/nt_status`, so `NT_STATUS_NOT_SUPPORTED` is used. It carries the same meaning and maps to a not-supported legacy code, and nothing sends this reserved subcommand, so the difference is a conformance detail rather than a live one. Adding the constant would be a change to a shared package for one caller; it is called out here rather than done quietly.

**Left out, with reasons:** `TRANS2_FIND_NOTIFY_FIRST`/`NEXT` need the out-of-band reply path (#1141, then #1152). `TRANS2_GET_DFS_REFERRAL` and `TRANS2_REPORT_DFS_INCONSISTENCY` are only reachable if `CAP_DFS` is advertised, which this server does not do. The quota subcommands have nothing behind them. `TRANS2_FSCTL`, `TRANS2_IOCTL2` and `TRANS2_SESSION_SETUP` are reserved and their sections require exactly the generic `STATUS_NOT_IMPLEMENTED` they already get.

The extended attributes `TRANS2_OPEN2`, `TRANS2_CREATE_DIRECTORY` and `NT_TRANSACT_CREATE` can carry are not stored, and the responses report a length of zero — the documented way to say a file has none. Accepting them silently would tell the client they had been kept. `NT_TRANSACT_CREATE`'s security descriptor is likewise not applied: descriptors are answered through the NT_TRANSACT security subcommands by a share with a provider, and applying one at create time would let a client set access this server cannot then honour.

### How Verified
Runtime, over the loopback harness:

- `TestTrans2Open2OpensAndCreates` — opens an existing file with the right size and `ActionTaken`, creates a missing one and reports it as created, truncates when asked, and refuses a missing file without the create bit.
- `TestTrans2CreateDirectoryMakesOneAndRefusesADuplicate` — the directory is created and is a directory; a second attempt gives `STATUS_OBJECT_NAME_COLLISION`.
- `TestTrans2CreateDirectoryOnAReadOnlyShareIsRefused` — refused.
- `TestNtTransactCreateOpensThroughATransaction` — a 69-byte parameter block with a FID, the right `EndOfFile`, and `OpLockLevel` zero.
- `TestNtTransactCreateRefusesARelativeRoot` — `STATUS_NOT_SUPPORTED`.
- `TestReservedSubcommandsUseTheirMandatedStatus` — each of the two answers its own status, with an explicit assertion that neither fell through to the generic refusal.

Whole tree green: `go build ./...`, `go test ./network/smb/...`. `gofmt -l` clean on every file touched.

### Test Coverage
**Added:** `server/remaining_subcommands_test.go` — the six tests above, plus `open2Parameters` and two new raw senders. The existing `sendNtTransact` returns only a status, and these subcommands answer in their *parameter* block, so `sendTrans2` and `sendNtTransactWithParameters` return the reply whole.

**Modified:** `server/conformance_test.go` — the five subcommands registered in `servedTrans2Subcommands` and `servedNtTransactFunctions`. `server/nttransact_test.go` — `TestNtTransactUnimplementedFunctions` no longer lists `NT_TRANSACT_CREATE` (now served) or `NT_TRANSACT_RENAME` (now refused with a different status); both are asserted in the new file instead, and the comment records why they moved.

### Scope of Change
- **Files changed:** `server/handler_remaining_subcommands.go` (new), `server/remaining_subcommands_test.go` (new), `server/handler_core_file.go`, `server/handler_trans2.go`, `server/handler_nttransact.go`, `server/conformance_test.go`, `server/nttransact_test.go`, `server/doc.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** `applyOpenMode` is extracted from `handleOpenAndx` so `TRANS2_OPEN2` can share it. Pure extraction — the AndX handler's behaviour is unchanged and its tests pass untouched.

### Risk and Rollout
Additive: every subcommand touched was refused before. The two reserved ones change from one refusal to another, which no client will notice because no client sends them.

### Notes
This completes the mechanical command and subcommand work from the original review. What remains is #1141 (the asynchronous reply path), #1152 behind it, #1150 (a `srvsvc` handler, which needs a server-side DCE/RPC layer that does not exist yet), #1153 (the interop legs) and #1161.
