### PR TITLE
Add an asynchronous response path for replies sent outside a request (Fixes #1141)

### DIFF
--- a/network/smb/smb_v10/server/async.go
+++ b/network/smb/smb_v10/server/async.go
@@ -1,0 +1,378 @@
+package server
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/TheManticoreProject/Manticore/logger"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/command_interface"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header/flags"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header/flags2"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/signing"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+	"github.com/TheManticoreProject/Manticore/windows/nt_status"
+)
+
+// AsyncResponder answers a request after the handler that received it has
+// returned.
+//
+// It exists for the commands whose answer is not ready when they are asked:
+// NT_TRANSACT_NOTIFY_CHANGE is answered when a directory changes, and a byte-range
+// lock that offers to wait is answered when the range comes free. A handler takes
+// one with ResponseWriter.Defer, returns success without writing, and completes
+// the exchange from wherever the answer arrives.
+//
+// # What a responder may touch
+//
+// A responder is safe to use from any goroutine, and it is the only part of the
+// connection that is. Everything else on a Connection — the open, tree, session
+// and search tables — belongs to the goroutine running the receive loop and has no
+// locking, so a responder must capture what it needs at Defer time rather than
+// reading those tables when it fires.
+//
+// That constraint is the reason this is a narrow interface rather than a handle on
+// the connection: what a deferred answer needs is a way to send bytes, and giving
+// it anything more would invite a data race that no test on one goroutine would
+// find.
+//
+// # Cancellation
+//
+// Cancelled closes when the client sends SMB_COM_NT_CANCEL for the request, or
+// when the connection goes away. A responder that never fires must still be
+// released with Done, or the connection keeps a record of it until it closes.
+type AsyncResponder interface {
+	// Respond sends a successful response and releases the responder.
+	Respond(cmd command_interface.CommandInterface) error
+
+	// RespondWithStatus sends a response carrying a status and releases the
+	// responder.
+	RespondWithStatus(cmd command_interface.CommandInterface, status nt_status.NT_STATUS) error
+
+	// RespondWithError sends a payload-less error response and releases the
+	// responder.
+	RespondWithError(status nt_status.NT_STATUS) error
+
+	// Cancelled is closed when the request is cancelled or the connection ends.
+	// It never carries a value; a receive on it means stop.
+	Cancelled() <-chan struct{}
+
+	// Done releases the responder without answering. Calling it after a Respond
+	// is harmless, so it is safe in a defer.
+	Done()
+}
+
+// ErrResponderDone reports a responder used after it has answered or been
+// released. It is a programming error rather than a protocol one: a request has
+// one response, and sending a second would leave a reply on the connection that
+// no request accounts for.
+var ErrResponderDone = errors.New("the asynchronous responder has already been released")
+
+// ErrUnsolicitedWhileSigning reports an attempt to send a server-initiated message
+// on a signing connection.
+//
+// A signed message consumes a sequence number from the pair the two sides keep in
+// step, and a message the client never asked for has no request whose number it
+// can use. Getting that wrong desynchronises signing for the rest of the
+// connection, and every subsequent request fails verification — so it is refused
+// here rather than guessed at, until the numbering can be checked against a
+// reference capture.
+var ErrUnsolicitedWhileSigning = errors.New("cannot send a server-initiated message on a signing connection")
+
+// asyncResponder is the AsyncResponder bound to one deferred request.
+type asyncResponder struct {
+	conn *Connection
+
+	// request is the header being answered, kept so the reply can echo the
+	// identifiers the client correlates on.
+	request *header.Header
+
+	// signKey and signSequence are the signing state reserved for this request's
+	// response, captured at Defer time. They are the response's own numbers, so a
+	// deferred answer signs exactly as an immediate one would.
+	signKey      []byte
+	signSequence uint32
+
+	// uid and tid override the request's, for a handler that assigned one.
+	uid    uint16
+	uidSet bool
+	tid    uint16
+	tidSet bool
+
+	// cancelled is closed by the receive loop on NT_CANCEL or on shutdown.
+	cancelled chan struct{}
+
+	// once guards the release, so a double answer is reported rather than sent.
+	once     sync.Once
+	released bool
+	mutex    sync.Mutex
+}
+
+// Respond sends a successful response.
+func (r *asyncResponder) Respond(cmd command_interface.CommandInterface) error {
+	return r.RespondWithStatus(cmd, nt_status.NT_STATUS_SUCCESS)
+}
+
+// RespondWithStatus sends a response carrying a status.
+func (r *asyncResponder) RespondWithStatus(
+	cmd command_interface.CommandInterface,
+	status nt_status.NT_STATUS,
+) error {
+	if cmd == nil {
+		return fmt.Errorf("cannot answer with no command")
+	}
+
+	r.mutex.Lock()
+	if r.released {
+		r.mutex.Unlock()
+		return ErrResponderDone
+	}
+	r.released = true
+	r.mutex.Unlock()
+
+	defer r.conn.releaseResponder(r)
+
+	reply := message.NewMessage()
+	reply.Header = replyHeader(r.request, status, len(r.signKey) > 0)
+	if r.uidSet {
+		reply.Header.UID = types.USHORT(r.uid)
+	}
+	if r.tidSet {
+		reply.Header.TID = types.USHORT(r.tid)
+	}
+
+	cmd.SetUnicode(r.request.Flags2.IsUnicode())
+	reply.AddCommand(cmd)
+	reply.Header.Command = r.request.Command
+
+	return r.conn.frame(reply, r.signKey, r.signSequence)
+}
+
+// RespondWithError sends a payload-less error response.
+func (r *asyncResponder) RespondWithError(status nt_status.NT_STATUS) error {
+	return r.RespondWithStatus(newErrorResponse(r.request.Command), status)
+}
+
+// Cancelled reports when the request no longer needs an answer.
+func (r *asyncResponder) Cancelled() <-chan struct{} {
+	return r.cancelled
+}
+
+// Done releases the responder without answering.
+func (r *asyncResponder) Done() {
+	r.mutex.Lock()
+	already := r.released
+	r.released = true
+	r.mutex.Unlock()
+
+	if !already {
+		r.conn.releaseResponder(r)
+	}
+}
+
+// cancel closes the responder's cancellation channel, once.
+func (r *asyncResponder) cancel() {
+	r.once.Do(func() { close(r.cancelled) })
+}
+
+// Compile-time assurance that asyncResponder satisfies the contract.
+var _ AsyncResponder = (*asyncResponder)(nil)
+
+// frame marshals, signs and sends one message, serialised against every other
+// write on the connection.
+//
+// Every path that puts bytes on the transport goes through here — the immediate
+// responses, the deferred ones and the server-initiated ones — because the
+// transport is not safe for concurrent use and a deferred answer runs on a
+// goroutine the receive loop knows nothing about.
+//
+// Parameters:
+//   - reply: the message to send
+//   - signKey: the MAC key, or nil for an unsigned message
+//   - signSequence: the sequence number to sign at
+//
+// Returns:
+//   - The error from marshalling or sending
+func (c *Connection) frame(reply *message.Message, signKey []byte, signSequence uint32) error {
+	marshalled, err := reply.Marshal()
+	if err != nil {
+		return fmt.Errorf("failed to marshal the response: %v", err)
+	}
+
+	// The lock covers signing as well as sending: a signature is written into the
+	// buffer being sent, so two goroutines signing and sending independently could
+	// interleave a partial write.
+	c.writeMutex.Lock()
+	defer c.writeMutex.Unlock()
+
+	if len(signKey) > 0 {
+		signing.Sign(signKey, marshalled, signSequence)
+	}
+
+	if _, err := c.Transport.Send(marshalled); err != nil {
+		return fmt.Errorf("failed to send the response: %v", err)
+	}
+	return nil
+}
+
+// defer_ registers a deferred answer for the request being handled.
+//
+// The signing state is captured now rather than when the answer fires, because it
+// belongs to this request: the sequence number the response signs at was reserved
+// when the request arrived, and a later answer signs at the same number an
+// immediate one would have.
+func (c *Connection) deferResponse(
+	request *header.Header,
+	signKey []byte,
+	signSequence uint32,
+	uid uint16, uidSet bool,
+	tid uint16, tidSet bool,
+) AsyncResponder {
+	responder := &asyncResponder{
+		conn:         c,
+		request:      request,
+		signKey:      signKey,
+		signSequence: signSequence,
+		uid:          uid,
+		uidSet:       uidSet,
+		tid:          tid,
+		tidSet:       tidSet,
+		cancelled:    make(chan struct{}),
+	}
+
+	c.responderMutex.Lock()
+	if c.responders == nil {
+		c.responders = make(map[*asyncResponder]struct{})
+	}
+	c.responders[responder] = struct{}{}
+	outstanding := len(c.responders)
+	c.responderMutex.Unlock()
+
+	logger.Debugf("SMB1 server: %s deferred command 0x%02X MID 0x%04X, %d outstanding",
+		c.Remote, uint8(request.Command), uint16(request.MID), outstanding)
+	return responder
+}
+
+// releaseResponder forgets a responder that has answered or been released.
+func (c *Connection) releaseResponder(responder *asyncResponder) {
+	c.responderMutex.Lock()
+	delete(c.responders, responder)
+	c.responderMutex.Unlock()
+}
+
+// cancelResponders closes the cancellation channel of every deferred request
+// matching a PID and MID, and reports how many it found.
+//
+// SMB_COM_NT_CANCEL names the request to cancel by the PID and MID in its own
+// header, which is how a client refers to something it has not had an answer for.
+func (c *Connection) cancelResponders(pid uint32, mid uint16) int {
+	c.responderMutex.Lock()
+	matching := []*asyncResponder{}
+	for responder := range c.responders {
+		if responder.request.GetPID() == pid && uint16(responder.request.MID) == mid {
+			matching = append(matching, responder)
+		}
+	}
+	c.responderMutex.Unlock()
+
+	// Cancelled outside the lock: a responder that reacts immediately will call
+	// back in to release itself.
+	for _, responder := range matching {
+		responder.cancel()
+	}
+	return len(matching)
+}
+
+// cancelAllResponders cancels every deferred request, which is what closing the
+// connection does.
+//
+// A deferred answer that is still waiting has nowhere to send its reply once the
+// transport is gone, so it is told to stop rather than left to fail on a write.
+func (c *Connection) cancelAllResponders() {
+	c.responderMutex.Lock()
+	matching := make([]*asyncResponder, 0, len(c.responders))
+	for responder := range c.responders {
+		matching = append(matching, responder)
+	}
+	c.responderMutex.Unlock()
+
+	for _, responder := range matching {
+		responder.cancel()
+	}
+}
+
+// OutstandingResponses reports how many deferred answers this connection is
+// waiting to send, for a caller that wants to report on it and for the tests.
+func (c *Connection) OutstandingResponses() int {
+	c.responderMutex.Lock()
+	defer c.responderMutex.Unlock()
+	return len(c.responders)
+}
+
+// SendUnsolicited sends a message the client did not ask for.
+//
+// This is the one place in the protocol where the server sends a request rather
+// than a response: [MS-CIFS] section 2.2.4.32.1 has the server send
+// SMB_COM_LOCKING_ANDX with SMB_FLAGS_REPLY clear to break an oplock. The message
+// carries a fresh MID, because there is no request to correlate it with.
+//
+// It is refused on a signing connection. A signed message consumes a sequence
+// number from the pair the two sides keep in step, and a message with no request
+// behind it has no number reserved for it; a wrong guess desynchronises signing
+// for the rest of the connection and every later request fails verification.
+// Refusing is better than a guess that cannot be checked here against a real
+// client.
+//
+// Parameters:
+//   - cmd: the command to send
+//   - uid, tid, mid: the identifiers to carry
+//
+// Returns:
+//   - ErrUnsolicitedWhileSigning on a signing connection, or the send error
+func (c *Connection) SendUnsolicited(
+	cmd command_interface.CommandInterface,
+	uid, tid, mid uint16,
+) error {
+	if cmd == nil {
+		return fmt.Errorf("cannot send no command")
+	}
+	if c.SigningActive {
+		return ErrUnsolicitedWhileSigning
+	}
+
+	request := message.NewMessage()
+	request.Header.Command = cmd.GetCommandCode()
+	// SMB_FLAGS_REPLY stays clear: this is a request, and a client reads that bit
+	// to decide which decoder to run.
+	request.Header.Flags = flags.Flags(0)
+	request.Header.Flags2 = c.negotiatedFlags2()
+	request.Header.UID = types.USHORT(uid)
+	request.Header.TID = types.USHORT(tid)
+	request.Header.MID = types.USHORT(mid)
+
+	cmd.SetUnicode(c.UseUnicode)
+	request.AddCommand(cmd)
+	request.Header.Command = cmd.GetCommandCode()
+
+	logger.Debugf("SMB1 server: sending unsolicited command 0x%02X to %s",
+		uint8(cmd.GetCommandCode()), c.Remote)
+	return c.frame(request, nil, 0)
+}
+
+// negotiatedFlags2 rebuilds the SMB_FLAGS2 bits a server-initiated message
+// carries, from what the connection agreed.
+//
+// A response mirrors them from the request it answers; an unsolicited message has
+// no request to mirror, so they come from the connection instead.
+func (c *Connection) negotiatedFlags2() flags2.Flags2 {
+	var bits flags2.Flags2
+	if c.UseUnicode {
+		bits |= flags2.Flags2(flags2.FLAGS2_UNICODE)
+	}
+	if c.UseNTStatus {
+		bits |= flags2.Flags2(flags2.FLAGS2_NT_STATUS_ERROR_CODES)
+	}
+	return bits
+}

--- a/network/smb/smb_v10/server/async.go
+++ b/network/smb/smb_v10/server/async.go
@@ -200,7 +200,24 @@ func (c *Connection) frame(reply *message.Message, signKey []byte, signSequence 
 	if err != nil {
 		return fmt.Errorf("failed to marshal the response: %v", err)
 	}
+	return c.send(marshalled, signKey, signSequence)
+}
 
+// send signs and writes one already-marshalled message, serialised against every
+// other write on the connection.
+//
+// It is separate from frame because a batched response has to know its own size
+// before it is sent — [MS-CIFS] section 2.2.3.4 caps a batch at the negotiated
+// buffer — so that path marshals first and sends through here.
+//
+// Parameters:
+//   - marshalled: the message as it will go on the wire
+//   - signKey: the MAC key, or nil for an unsigned message
+//   - signSequence: the sequence number to sign at
+//
+// Returns:
+//   - The error from sending
+func (c *Connection) send(marshalled []byte, signKey []byte, signSequence uint32) error {
 	// The lock covers signing as well as sending: a signature is written into the
 	// buffer being sent, so two goroutines signing and sending independently could
 	// interleave a partial write.

--- a/network/smb/smb_v10/server/async_test.go
+++ b/network/smb/smb_v10/server/async_test.go
@@ -1,0 +1,257 @@
+package server
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+	"time"
+
+	smb1client "github.com/TheManticoreProject/Manticore/network/smb/smb_v10/client"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/codes"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+	"github.com/TheManticoreProject/Manticore/windows/nt_status"
+)
+
+// deferringHandler is a Handler that defers every ECHO it sees and answers it
+// from another goroutine when told to.
+//
+// ECHO is used because it needs no session, no share and no handle, so the test
+// exercises the deferral machinery and nothing else.
+type deferringHandler struct {
+	// deferred receives what the test needs about each intercepted request, so
+	// the test drives the answer rather than racing it.
+	deferred chan deferredRequest
+}
+
+// deferredRequest is what the handler saw, published so the test can build a
+// cancel that names the same request rather than guessing the client's
+// identifiers.
+type deferredRequest struct {
+	responder  AsyncResponder
+	connection *Connection
+	pid        uint32
+	mid        uint16
+}
+
+func (h *deferringHandler) Run(srv *Server, conn *Connection, w ResponseWriter, req *message.Message) bool {
+	if req.Header.Command != codes.SMB_COM_ECHO {
+		return false
+	}
+	h.deferred <- deferredRequest{
+		responder:  w.Defer(),
+		connection: conn,
+		pid:        req.Header.GetPID(),
+		mid:        uint16(req.Header.MID),
+	}
+	// Handled: the responder owns the answer now, and writing one here as well
+	// would put two replies on the connection for one request.
+	return true
+}
+
+// deferringServer starts a server with a deferring handler registered.
+func deferringServer(t *testing.T) (*Server, *smb1client.Client, *deferringHandler) {
+	t.Helper()
+
+	// The client is fully authenticated first: SMB_COM_ECHO needs no session to
+	// be dispatched, but the client refuses to send one without having
+	// established the connection, and a failure there would look like a handler
+	// that never fired.
+	srv, client := pipedClient(t, conformanceConfig(SigningDisabled), true)
+
+	// Registered after the exchange, so nothing in it is intercepted.
+	handler := &deferringHandler{deferred: make(chan deferredRequest, 4)}
+	srv.RegisterHandler(handler)
+
+	return srv, client, handler
+}
+
+// TestDeferredAnswerReachesTheClient asserts a response sent after the handler
+// returned arrives, and carries the identifiers of the request it answers.
+//
+// Correlation is the whole point: a client matches a reply to a request by MID, so
+// a deferred answer that lost it would be read against the wrong request.
+func TestDeferredAnswerReachesTheClient(t *testing.T) {
+	_, client, handler := deferringServer(t)
+
+	payload := []byte("answered later")
+
+	// Sent from a goroutine, because the client's Echo blocks until the answer
+	// arrives and the answer is this test's job to produce.
+	type echoResult struct {
+		data []byte
+		err  error
+	}
+	results := make(chan echoResult, 1)
+	go func() {
+		data, err := client.Echo(payload)
+		results <- echoResult{data: data, err: err}
+	}()
+
+	var deferred deferredRequest
+	select {
+	case deferred = <-handler.deferred:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the handler never deferred the request")
+	}
+	responder := deferred.responder
+
+	response := commands.NewEchoResponse()
+	response.SequenceNumber = types.USHORT(1)
+	response.Data = []types.UCHAR(payload)
+	if err := responder.Respond(response); err != nil {
+		t.Fatalf("Respond() error = %v", err)
+	}
+
+	select {
+	case result := <-results:
+		if result.err != nil {
+			t.Fatalf("the client did not receive the deferred answer: %v", result.err)
+		}
+		if !bytes.Equal(result.data, payload) {
+			t.Errorf("the deferred answer carried %q, want %q", result.data, payload)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("the deferred answer never reached the client")
+	}
+}
+
+// TestDeferredAnswerIsTrackedUntilItFires asserts the connection knows what it
+// still owes, and forgets it once answered.
+//
+// A responder that is never released would keep the connection remembering it for
+// as long as the connection lives, so the accounting is what makes a leak visible.
+func TestDeferredAnswerIsTrackedUntilItFires(t *testing.T) {
+	_, client, handler := deferringServer(t)
+
+	go client.Echo([]byte("tracked"))
+
+	deferred := <-handler.deferred
+	responder, conn := deferred.responder, deferred.connection
+	waitFor(t, func() bool { return conn.OutstandingResponses() == 1 },
+		"the deferred request was not recorded as outstanding")
+
+	response := commands.NewEchoResponse()
+	response.SequenceNumber = types.USHORT(1)
+	response.Data = []types.UCHAR("tracked")
+	if err := responder.Respond(response); err != nil {
+		t.Fatalf("Respond() error = %v", err)
+	}
+
+	waitFor(t, func() bool { return conn.OutstandingResponses() == 0 },
+		"the deferred request was not released after answering")
+}
+
+// TestDeferredAnswerRefusesASecondSend asserts a responder answers once.
+//
+// A request has one response, and a second would leave a reply on the connection
+// that no request accounts for — after which the client reads every later
+// response against the wrong request.
+func TestDeferredAnswerRefusesASecondSend(t *testing.T) {
+	_, client, handler := deferringServer(t)
+
+	go client.Echo([]byte("once"))
+	responder := (<-handler.deferred).responder
+
+	response := commands.NewEchoResponse()
+	response.SequenceNumber = types.USHORT(1)
+	response.Data = []types.UCHAR("once")
+	if err := responder.Respond(response); err != nil {
+		t.Fatalf("the first Respond() failed: %v", err)
+	}
+
+	second := commands.NewEchoResponse()
+	second.SequenceNumber = types.USHORT(1)
+	second.Data = []types.UCHAR("twice")
+	if err := responder.Respond(second); err == nil {
+		t.Error("a second Respond() succeeded, so two replies went out for one request")
+	}
+
+	// Done after answering is harmless, so it is safe in a defer.
+	responder.Done()
+}
+
+// TestNtCancelCancelsAnOutstandingRequest asserts SMB_COM_NT_CANCEL reaches the
+// deferred request it names.
+//
+// The command was previously accepted and ignored, which was only correct because
+// nothing could be outstanding. Now that something can be, it has to arrive.
+func TestNtCancelCancelsAnOutstandingRequest(t *testing.T) {
+	_, client, handler := deferringServer(t)
+
+	go client.Echo([]byte("cancel me"))
+	deferred := <-handler.deferred
+	responder := deferred.responder
+
+	// The cancel has to name the same PID and MID the deferred request carried,
+	// which the handler published rather than the test guessing at the client's
+	// numbering.
+	request := newRequest(codes.SMB_COM_NT_CANCEL)
+	// The cancel needs the session's UID: SMB_COM_NT_CANCEL is not one of the
+	// commands that may arrive without a session, so the dispatcher refuses it
+	// before the handler sees it otherwise.
+	request.Header.UID = client.Session.SessionUID
+	request.Header.SetPID(deferred.pid)
+	request.Header.MID = types.USHORT(deferred.mid)
+	request.AddCommand(commands.NewNtCancelRequest())
+
+	marshalled, err := request.Marshal()
+	if err != nil {
+		t.Fatalf("failed to marshal the cancel: %v", err)
+	}
+	if _, err := client.Transport.Send(marshalled); err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+
+	select {
+	case <-responder.Cancelled():
+	case <-time.After(5 * time.Second):
+		t.Fatal("the cancel never reached the deferred request")
+	}
+
+	// The request still has to be released, and answering a cancelled request is
+	// the responder's choice: here it reports the cancellation.
+	if err := responder.RespondWithError(nt_status.NT_STATUS_CANCELLED); err != nil {
+		t.Fatalf("RespondWithError() error = %v", err)
+	}
+}
+
+// TestClosingTheConnectionCancelsWhatItOwes asserts a deferred answer is told to
+// stop when the connection goes away, rather than discovering it on a failed write.
+func TestClosingTheConnectionCancelsWhatItOwes(t *testing.T) {
+	srv, client, handler := deferringServer(t)
+
+	go client.Echo([]byte("abandoned"))
+	responder := (<-handler.deferred).responder
+
+	if err := srv.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	select {
+	case <-responder.Cancelled():
+	case <-time.After(5 * time.Second):
+		t.Fatal("closing the connection did not cancel the deferred request")
+	}
+}
+
+// TestUnsolicitedSendIsRefusedWhileSigning asserts a server-initiated message is
+// refused on a signing connection rather than sent with a guessed sequence number.
+//
+// A signed message consumes a number from the pair the two sides keep in step, and
+// one with no request behind it has none reserved. A wrong guess desynchronises
+// signing for the rest of the connection and every later request fails
+// verification — a failure mode far worse than a refused oplock break.
+func TestUnsolicitedSendIsRefusedWhileSigning(t *testing.T) {
+	conn := &Connection{SigningActive: true}
+
+	err := conn.SendUnsolicited(commands.NewLockingAndxRequest(), 1, 1, 1)
+	if err == nil {
+		t.Fatal("an unsolicited send succeeded on a signing connection")
+	}
+	if !errors.Is(err, ErrUnsolicitedWhileSigning) {
+		t.Errorf("the refusal is %v, want ErrUnsolicitedWhileSigning", err)
+	}
+}

--- a/network/smb/smb_v10/server/connection.go
+++ b/network/smb/smb_v10/server/connection.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"net"
+	"sync"
 
 	"github.com/TheManticoreProject/Manticore/crypto/spnego"
 	"github.com/TheManticoreProject/Manticore/logger"
@@ -98,6 +99,23 @@ type Connection struct {
 	searches map[uint16]*Search
 	sids     *identifierAllocator
 
+	// writeMutex serialises every write to the transport.
+	//
+	// The receive loop is not the only writer any more: a deferred answer sends
+	// from whatever goroutine produced it. The transport is not safe for
+	// concurrent use, and signing writes a signature into the buffer being sent,
+	// so both happen under this lock.
+	writeMutex sync.Mutex
+
+	// responders are the deferred answers this connection still owes, and
+	// responderMutex guards them.
+	//
+	// They are the one piece of per-connection state reachable from another
+	// goroutine, which is why they have a lock and the rest of the tables here do
+	// not.
+	responderMutex sync.Mutex
+	responders     map[*asyncResponder]struct{}
+
 	// pendingAuth holds the authentication exchanges part-way through, keyed by
 	// the UID assigned when the challenge was issued.
 	//
@@ -157,6 +175,11 @@ func (c *Connection) serve() {
 		}
 	}()
 	defer c.Close()
+
+	// A deferred answer still waiting has nowhere to send its reply once the
+	// transport is gone, so every outstanding request is told to stop rather
+	// than left to discover it on a failed write.
+	defer c.cancelAllResponders()
 
 	logger.Debugf("SMB1 server: serving %s", c.Remote)
 

--- a/network/smb/smb_v10/server/doc.go
+++ b/network/smb/smb_v10/server/doc.go
@@ -57,12 +57,40 @@
 // locking, seek, the legacy SMB_COM_OPEN_ANDX, and batched AndX chains beyond
 // their first command.
 //
-// NT_TRANSACT_NOTIFY_CHANGE is deliberately absent rather than pending. It needs
-// two things this package does not have: a FileSystem that can be watched, and a
-// connection whose write path can be used from outside the request that is being
-// served — a notification is answered when the change happens, not when it is
-// asked for. Both are architectural additions, and half of either would be worse
-// than the honest refusal.
+// NT_TRANSACT_NOTIFY_CHANGE is still absent, but only one of the two things it
+// needs is now missing. A reply can be sent from outside the request that asked
+// for it — see "Deferred answers" below — so what is left is a FileSystem that can
+// be watched.
+//
+// # Deferred answers
+//
+// A handler that cannot answer yet takes an AsyncResponder from
+// ResponseWriter.Defer, returns success without writing, and completes the
+// exchange from wherever the answer arrives. The responder is safe to use from any
+// goroutine and is the only part of a Connection that is: the open, tree, session
+// and search tables belong to the receive loop and have no locking, so a responder
+// captures what it needs when it is taken rather than reading them when it fires.
+//
+// That constraint is why AsyncResponder is a narrow interface rather than a handle
+// on the connection. What a deferred answer needs is a way to send bytes; giving
+// it more would invite a data race that no test running on one goroutine would
+// find.
+//
+// Deferral is also what makes the receive loop concurrent without a worker pool: a
+// handler that defers returns at once, so the loop goes back to reading while the
+// answer is still owed. SMB_COM_NT_CANCEL cancels a deferred request by the PID
+// and MID it names, and closing the connection cancels everything outstanding — a
+// deferred answer with nowhere to send its reply is told to stop rather than left
+// to discover it on a failed write.
+//
+// A server-initiated message — the oplock break of [MS-CIFS] 2.2.4.32.1, the one
+// place the server sends a request — goes out through Connection.SendUnsolicited.
+// It is refused on a signing connection: a signed message consumes a number from
+// the sequence the two sides keep in step, and a message with no request behind it
+// has none reserved for it. A wrong guess desynchronises signing for the rest of
+// the connection and every later request fails verification, so it is refused
+// rather than guessed at until the numbering can be checked against a reference
+// capture.
 //
 // NT_TRANSACT_CREATE and NT_TRANSACT_RENAME are also absent by choice: they
 // duplicate SMB_COM_NT_CREATE_ANDX and SMB_COM_RENAME, which are served. The

--- a/network/smb/smb_v10/server/handler.go
+++ b/network/smb/smb_v10/server/handler.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/command_interface"
-	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/signing"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
 	"github.com/TheManticoreProject/Manticore/windows/nt_status"
 )
@@ -75,6 +74,14 @@ type ResponseWriter interface {
 	// exchange that establishes signing has to arm it itself, because the key
 	// does not exist until that exchange has been verified.
 	SignResponse(macKey []byte, sequenceNumber uint32)
+
+	// Defer takes an AsyncResponder for this request and returns it, so the
+	// handler can answer after it has returned.
+	//
+	// A handler that defers must return NT_STATUS_SUCCESS without writing a
+	// response, or the client receives two. The responder must be released with
+	// Done if it never answers.
+	Defer() AsyncResponder
 }
 
 // responseWriter is the ResponseWriter bound to one request on one connection.
@@ -132,6 +139,20 @@ func (w *responseWriter) WriteError(status nt_status.NT_STATUS) error {
 	return w.write(newErrorResponse(w.request.Header.Command), status)
 }
 
+// Defer takes an AsyncResponder for the request being handled.
+//
+// The signing state passes to the responder as it stands now: the sequence number
+// this response will sign at was reserved when the request arrived, so a deferred
+// answer signs at exactly the number an immediate one would have.
+func (w *responseWriter) Defer() AsyncResponder {
+	return w.conn.deferResponse(
+		w.request.Header,
+		w.signKey, w.signSequence,
+		w.uid, w.uidSet,
+		w.tid, w.tidSet,
+	)
+}
+
 // write builds the reply, marshals it and frames it on the transport.
 func (w *responseWriter) write(cmd command_interface.CommandInterface, status nt_status.NT_STATUS) error {
 	if cmd == nil {
@@ -157,21 +178,10 @@ func (w *responseWriter) write(cmd command_interface.CommandInterface, status nt
 	// returning a mismatched command cannot desynchronize the client.
 	reply.Header.Command = w.request.Header.Command
 
-	marshalled, err := reply.Marshal()
-	if err != nil {
-		return fmt.Errorf("failed to marshal the response: %v", err)
-	}
-
-	// Signing happens after marshalling and over the whole message, because the
-	// signature occupies a field inside the header it covers.
-	if len(w.signKey) > 0 {
-		signing.Sign(w.signKey, marshalled, w.signSequence)
-	}
-
-	if _, err := w.conn.Transport.Send(marshalled); err != nil {
-		return fmt.Errorf("failed to send the response: %v", err)
-	}
-	return nil
+	// Framed through the connection so that this write and a deferred answer's
+	// cannot interleave: signing writes into the buffer being sent, so the two
+	// have to be serialised together rather than each locking on its own.
+	return w.conn.frame(reply, w.signKey, w.signSequence)
 }
 
 // Compile-time assurance that responseWriter satisfies the contract.

--- a/network/smb/smb_v10/server/handler.go
+++ b/network/smb/smb_v10/server/handler.go
@@ -259,6 +259,8 @@ func (w *responseWriter) flushChain() error {
 	// given, and the reply must echo the request's code regardless.
 	reply.Header.Command = w.request.Header.Command
 
+	// The size has to be known before sending, so the chain is marshalled here
+	// and framed below rather than handed straight to Connection.frame.
 	marshalled, err := reply.Marshal()
 	if err != nil {
 		return fmt.Errorf("failed to marshal the response chain: %v", err)
@@ -272,16 +274,10 @@ func (w *responseWriter) flushChain() error {
 		return errChainTooLarge
 	}
 
-	// Signing happens after marshalling and over the whole message, because the
-	// signature occupies a field inside the header it covers.
-	if len(w.signKey) > 0 {
-		signing.Sign(w.signKey, marshalled, w.signSequence)
-	}
-
-	if _, err := w.conn.Transport.Send(marshalled); err != nil {
-		return fmt.Errorf("failed to send the response chain: %v", err)
-	}
-	return nil
+	// Signed and sent through the connection, like every other write: signing
+	// puts a signature inside the buffer being sent, so the two have to happen
+	// under one lock or a deferred answer's write could interleave with this one.
+	return w.conn.send(marshalled, w.signKey, w.signSequence)
 }
 
 // errChainTooLarge reports a batched response that does not fit in the negotiated

--- a/network/smb/smb_v10/server/handler_nttransact.go
+++ b/network/smb/smb_v10/server/handler_nttransact.go
@@ -373,7 +373,18 @@ func fsctlHandleIsPathnameValid(conn *Connection, open *Open, input []byte) ([]b
 // command is accepted silently — which is what it is defined to do, since a cancel
 // carries no response of its own.
 func handleNtCancel(conn *Connection, w ResponseWriter, req *message.Message) nt_status.NT_STATUS {
-	logger.Debugf("SMB1 server: %s cancelled PID 0x%08X MID 0x%04X, which has nothing outstanding",
-		conn.Remote, req.Header.GetPID(), uint16(req.Header.MID))
+	pid := req.Header.GetPID()
+	mid := uint16(req.Header.MID)
+
+	// The command names the request to cancel by the PID and MID in its own
+	// header, which is how a client refers to something it has had no answer for.
+	cancelled := conn.cancelResponders(pid, mid)
+
+	logger.Debugf("SMB1 server: %s cancelled PID 0x%08X MID 0x%04X, matching %d outstanding request(s)",
+		conn.Remote, pid, mid, cancelled)
+
+	// SMB_COM_NT_CANCEL is answered with silence whether or not it matched: the
+	// cancelled request produces the response, and a reply to the cancel itself
+	// would leave an extra message on the connection.
 	return nt_status.NT_STATUS_SUCCESS
 }


### PR DESCRIPTION
### Linked Issue
`Closes #1141`

### Root Cause
`ResponseWriter` was created per request inside `Connection.handleFrame` and went out of scope when the handler returned, and the connection goroutine was occupied by the request it was serving. There was no writer that outlived a request and none that was safe to use from another goroutine, so any command whose answer arrives later could not be implemented at all — which is why `NT_TRANSACT_NOTIFY_CHANGE` was documented as absent, why no oplock could be granted, and why `SMB_COM_NT_CANCEL` was accepted and ignored.

### Fix Description
A handler that cannot answer yet takes an `AsyncResponder` from `ResponseWriter.Defer`, returns success without writing, and completes the exchange from wherever the answer arrives.

**Deferral is what makes the receive loop concurrent, and no worker pool was needed.** A handler that defers returns immediately, so the loop goes straight back to reading while the answer is still owed. That is the whole mechanism: the alternative — running handlers on their own goroutines — would have exposed the open, tree, session and search tables, which have no locking because a single goroutine owns them.

**The responder is deliberately a narrow interface rather than a handle on the connection.** It is the only part of a `Connection` safe to use from another goroutine, so it must capture what it needs at `Defer` time rather than reading those tables when it fires. Giving a deferred answer anything more than a way to send bytes would invite a data race that no test running on one goroutine would find — so the type does not offer it. That constraint is stated in the interface's own documentation, because it is the thing a caller has to know.

**Every write now goes through `Connection.frame`, under one mutex.** The immediate responses, the deferred ones and the server-initiated ones all use it. Two reasons it has to be one lock covering signing *and* sending rather than two: the transport is not safe for concurrent use, and signing writes a signature into the buffer being sent, so a lock released between the two would let a partial write interleave.

**Signing works for deferred replies, and is refused for unsolicited ones.** A deferred reply signs at the sequence number reserved for that request's response, captured at `Defer` time — so a late answer signs at exactly the number an immediate one would have, and nothing about the numbering changes.

A server-initiated message is different, and this is where I stopped rather than guessed. `Connection.SendUnsolicited` sends the oplock break of [MS-CIFS] 2.2.4.32.1 — the one place in the protocol where the server sends a request — with `SMB_FLAGS_REPLY` clear and a fresh MID. On a signing connection it returns `ErrUnsolicitedWhileSigning`. A signed message consumes a number from the sequence the two sides keep in step, and a message with no request behind it has none reserved; a wrong guess desynchronises signing for the whole connection and every later request fails verification. That failure is far worse than a refused oplock break, and I have no reference capture here to check the numbering against, so the refusal is explicit and documented rather than a plausible guess.

**`SMB_COM_NT_CANCEL` becomes real.** It cancels the deferred requests matching the PID and MID in its own header — how a client refers to something it has had no answer for — and is itself answered with silence, because the cancelled request produces the response and a reply to the cancel would leave an extra message on the connection. Closing the connection cancels everything outstanding, so a deferred answer with nowhere to send its reply is told to stop rather than left to fail on a write.

A responder answers once: a second `Respond` returns `ErrResponderDone` rather than putting a reply on the connection that no request accounts for, after which a client would read every later response against the wrong request. `Done` is idempotent and safe in a `defer`.

### How Verified
Runtime, over the loopback harness, with a test handler that defers every `SMB_COM_ECHO` and publishes the responder so the test drives the answer rather than racing it:

- `TestDeferredAnswerReachesTheClient` — a reply sent after the handler returned arrives and carries the right payload. Correlation is the point: a client matches a reply to a request by MID.
- `TestDeferredAnswerIsTrackedUntilItFires` — the connection reports one outstanding answer, then none after it fires. The accounting is what makes a leaked responder visible.
- `TestDeferredAnswerRefusesASecondSend` — the second `Respond` fails.
- `TestNtCancelCancelsAnOutstandingRequest` — a cancel naming the deferred request's PID and MID closes its `Cancelled` channel. The identifiers come from the handler rather than from a guess at the client's numbering.
- `TestClosingTheConnectionCancelsWhatItOwes` — closing the server cancels the outstanding request.
- `TestUnsolicitedSendIsRefusedWhileSigning` — `ErrUnsolicitedWhileSigning`.

**`go test -race` passes on the deferral tests**, which is the check that matters for this change: the whole point is a second goroutine writing to a connection, and the tests exercise the deferred write, the tracking map and the cancellation concurrently with the receive loop.

Whole tree green: `go build ./...`, `go test ./network/smb/...`. `gofmt -l` clean on every file touched.

### Test Coverage
**Added:** `server/async_test.go` — the six tests above, plus the `deferringHandler` fixture and the `deferredRequest` it publishes.

**Existing:** the whole conformance and file-service suite covers the immediate path, which now runs through `Connection.frame` as well, so those passing unchanged is what shows the shared write path did not disturb it.

### Scope of Change
- **Files changed:** `server/async.go` (new), `server/async_test.go` (new), `server/handler.go`, `server/connection.go`, `server/handler_nttransact.go`, `server/doc.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** `SMB_COM_NT_CANCEL` now cancels rather than being ignored — which is the issue's substance, not a side effect. `responseWriter.write` sends through `Connection.frame` instead of framing itself; the bytes and the signing are identical, and the whole existing suite passes on it.

### Risk and Rollout
This adds a lock on the write path that every response now takes. It is uncontended on a connection with nothing deferred, which is every connection until a handler uses `Defer`, so the ordinary path pays one uncontended mutex per response.

`ResponseWriter` gains a method, so a caller outside this repository that implements the interface itself would need to add it. That is a real break for such a caller, and worth knowing about: the interface exists so a caller can intercept requests, and most do so with the concrete writer they are handed rather than by implementing it.

Nothing yet calls `Defer` in the server itself — this is the foundation for #1152, and the tests are its only consumer. That is deliberate: landing the mechanism separately keeps the change reviewable, and the tests exercise it as a caller would.

### Notes
`Config.MaxLockWait` (from #1158) exists because a blocking lock had to bound its wait rather than hold the connection. With deferral available, a blocked `SMB_COM_LOCKING_ANDX` could defer instead and wait as long as the client asked, which is worth revisiting now that the mechanism exists.

The remaining half of #1152 is a watchable `FileSystem`. Oplock breaks additionally need the unsolicited-while-signing question settled, which needs a capture from a real client — pairing it with the interop legs in #1153 is the way to get one.
