### PR TITLE
Serve NT_TRANSACT_NOTIFY_CHANGE with a watchable FileSystem (Refs #1152)

### DIFF
--- a/network/smb/smb_v10/server/conformance_test.go
+++ b/network/smb/smb_v10/server/conformance_test.go
@@ -160,6 +160,7 @@ var servedNtTransactFunctions = map[subcommands.NtTransactSubcommand]string{
 	subcommands.NT_TRANSACT_QUERY_SECURITY_DESC: "returns a share's security descriptor",
 	subcommands.NT_TRANSACT_SET_SECURITY_DESC:   "applies one, if the share can store it",
 	subcommands.NT_TRANSACT_IOCTL:               "carries the file-system control codes",
+	subcommands.NT_TRANSACT_NOTIFY_CHANGE:       "answers when a watched directory changes",
 }
 
 // servedFsctlCodes are the file-system control codes NT_TRANSACT_IOCTL answers.
@@ -183,7 +184,18 @@ var servedPipeSubcommands = map[subcommands.TransactionSubcommand]string{
 // TestConformanceServedNtTransactFunctionsAreServed asserts the NT_TRANSACT table
 // and the handler table agree, in both directions.
 func TestConformanceServedNtTransactFunctionsAreServed(t *testing.T) {
+	// NT_TRANSACT_NOTIFY_CHANGE is dispatched before the table rather than from
+	// it: it answers through the deferred response path, so it has nothing to
+	// hand back to runNtTransact and cannot have the table's handler shape. It is
+	// still listed as served, because it is.
+	dispatchedOutsideTheTable := map[subcommands.NtTransactSubcommand]bool{
+		subcommands.NT_TRANSACT_NOTIFY_CHANGE: true,
+	}
+
 	for function := range servedNtTransactFunctions {
+		if dispatchedOutsideTheTable[function] {
+			continue
+		}
 		if _, ok := ntTransactHandlers[function]; !ok {
 			t.Errorf("NT_TRANSACT function 0x%04X is listed as served but has no handler", uint16(function))
 		}

--- a/network/smb/smb_v10/server/doc.go
+++ b/network/smb/smb_v10/server/doc.go
@@ -57,10 +57,26 @@
 // locking, seek, the legacy SMB_COM_OPEN_ANDX, and batched AndX chains beyond
 // their first command.
 //
-// NT_TRANSACT_NOTIFY_CHANGE is still absent, but only one of the two things it
-// needs is now missing. A reply can be sent from outside the request that asked
-// for it — see "Deferred answers" below — so what is left is a FileSystem that can
-// be watched.
+// NT_TRANSACT_NOTIFY_CHANGE is served, through the deferred answers described
+// below and a FileSystem that implements Watcher. It is single-shot, as the
+// protocol defines it: the client reissues it to hear about the next change.
+//
+// A change that will not fit in the client's buffer is answered with
+// STATUS_NOTIFY_ENUM_DIR and no data, which tells the client to list the directory
+// again. That is a complete answer rather than a failure, and it is what makes a
+// small client buffer safe to honour instead of something to work around.
+//
+// MemoryFileSystem reports changes as it makes them. LocalFileSystem polls,
+// because asking the host to report changes portably needs a per-platform
+// notification API and this package is standard library only: the interval is
+// LocalWatchInterval, and a change that leaves an entry's name, size and
+// modification time alone is not visible to it. That is a property of polling
+// rather than something the interval can fix, and it is why the poll is documented
+// where a caller will see it.
+//
+// Oplocks are still never granted. Breaking one means sending a message the client
+// did not ask for, and Connection.SendUnsolicited refuses to do that on a signing
+// connection for the reason given below.
 //
 // # Deferred answers
 //

--- a/network/smb/smb_v10/server/fs_mem.go
+++ b/network/smb/smb_v10/server/fs_mem.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/TheManticoreProject/Manticore/windows/filesystem"
 )
 
 // MemoryFileSystem is a FileSystem held entirely in memory.
@@ -26,6 +28,15 @@ type MemoryFileSystem struct {
 
 	// volume describes the storage reported to a client.
 	volume VolumeInfo
+
+	// watches are the change notifications registered on this file system, for
+	// NT_TRANSACT_NOTIFY_CHANGE.
+	//
+	// A publish happens while a mutation still holds the lock above. That is
+	// deliberate: the registry has its own lock and its sends never block, so the
+	// order is always this lock then the registry's, and there is no inversion to
+	// deadlock on.
+	watches watchRegistry
 }
 
 // memoryEntry is one file or directory.
@@ -99,6 +110,11 @@ func (fs *MemoryFileSystem) AddFile(path string, contents []byte) error {
 		name: name, data: stored,
 		created: now, accessed: now, modified: now, changed: now,
 	}
+	// Published like any other addition. This is a setup helper, but a caller
+	// that adds a file to a share a client is already watching has changed the
+	// share, and a watch that heard about a create through Open but not through
+	// here would be reporting on how the file arrived rather than on the file.
+	fs.watches.publish(resolved, changeAdded)
 	return nil
 }
 
@@ -153,6 +169,7 @@ func (fs *MemoryFileSystem) makeDirectory(path string) error {
 		name: name, isDir: true,
 		created: now, accessed: now, modified: now, changed: now,
 	}
+	fs.watches.publish(path, changeAdded)
 	return nil
 }
 
@@ -202,7 +219,9 @@ func (fs *MemoryFileSystem) Open(path string, flags OpenFlags) (File, error) {
 		return &memoryFile{fs: fs, path: path}, nil
 	}
 
-	// Creating. The parent has to exist: a create does not build a tree.
+	// Creating: published below, once the entry is in place.
+	//
+	// The parent has to exist: a create does not build a tree.
 	parent, name := splitPath(path)
 	if parent != "" {
 		holder, ok := fs.entries[parent]
@@ -219,6 +238,7 @@ func (fs *MemoryFileSystem) Open(path string, flags OpenFlags) (File, error) {
 		name: name, isDir: flags.Directory,
 		created: now, accessed: now, modified: now, changed: now,
 	}
+	fs.watches.publish(path, changeAdded)
 	return &memoryFile{fs: fs, path: path}, nil
 }
 
@@ -262,6 +282,7 @@ func (fs *MemoryFileSystem) SetAttr(path string, attr FileAttr, mask AttrMask) e
 	if mask.Changed {
 		entry.changed = attr.Changed
 	}
+	fs.watches.publish(path, changeModified)
 	return nil
 }
 
@@ -296,6 +317,7 @@ func (fs *MemoryFileSystem) Remove(path string) error {
 		return ErrReadOnly
 	}
 	delete(fs.entries, path)
+	fs.watches.publish(path, changeRemoved)
 	return nil
 }
 
@@ -332,6 +354,11 @@ func (fs *MemoryFileSystem) Rename(oldPath, newPath string, replace bool) error 
 	entry.name = newName
 	fs.entries[newPath] = entry
 	delete(fs.entries, oldPath)
+
+	// A rename is two notifications, and the pair is what tells a client the
+	// entry moved rather than that one vanished and an unrelated one appeared.
+	fs.watches.publish(oldPath, uint32(filesystem.FileActionRenamedOldName))
+	fs.watches.publish(newPath, uint32(filesystem.FileActionRenamedNewName))
 
 	if !entry.isDir {
 		return nil
@@ -371,6 +398,7 @@ func (fs *MemoryFileSystem) Mkdir(path string) error {
 			return ErrNotDirectory
 		}
 	}
+	// makeDirectory publishes the addition, so nothing more is needed here.
 	return fs.makeDirectory(path)
 }
 
@@ -397,6 +425,7 @@ func (fs *MemoryFileSystem) Rmdir(path string) error {
 		}
 	}
 	delete(fs.entries, path)
+	fs.watches.publish(path, changeRemoved)
 	return nil
 }
 
@@ -513,6 +542,7 @@ func (f *memoryFile) WriteAt(p []byte, off int64) (int, error) {
 	}
 	written := copy(entry.data[off:], p)
 	entry.modified = time.Now().UTC()
+	f.fs.watches.publish(f.path, changeModified)
 	return written, nil
 }
 

--- a/network/smb/smb_v10/server/handler_notify.go
+++ b/network/smb/smb_v10/server/handler_notify.go
@@ -1,0 +1,263 @@
+package server
+
+import (
+	"encoding/binary"
+
+	"github.com/TheManticoreProject/Manticore/encoding/utf16"
+	"github.com/TheManticoreProject/Manticore/logger"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/codes"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/command_interface"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header"
+	"github.com/TheManticoreProject/Manticore/windows/filesystem"
+	"github.com/TheManticoreProject/Manticore/windows/nt_status"
+)
+
+// handleNotifyChange answers NT_TRANSACT_NOTIFY_CHANGE: it tells the client when
+// the directory a handle names is modified.
+//
+// The command is answered when the change happens rather than when it is asked
+// for, which is what it needed the deferred response path for. It is single-shot:
+// [MS-CIFS] section 2.2.7.4 has the client reissue it to watch for more.
+//
+// Setup words: CompletionFilter(4) FID(2) WatchTree(1) Reserved(1).
+//
+// Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/
+func handleNotifyChange(
+	conn *Connection,
+	w ResponseWriter,
+	req *message.Message,
+	reassembly *transactionReassembly,
+) nt_status.NT_STATUS {
+	// The setup arrives as words; the filter spans the first two.
+	if len(reassembly.setup) < 4 {
+		return nt_status.NT_STATUS_INVALID_PARAMETER
+	}
+
+	completionFilter := uint32(reassembly.setup[0]) | uint32(reassembly.setup[1])<<16
+	fid := uint16(reassembly.setup[2])
+	watchTree := uint16(reassembly.setup[3])&0x00FF != 0
+
+	open, status := conn.openFor(req, fid)
+	if status != nt_status.NT_STATUS_SUCCESS {
+		return status
+	}
+
+	// "A directory file MUST be opened before this command can be used." A handle
+	// on a file has no entries to report changes to.
+	if !open.IsDirectory {
+		logger.Debugf("SMB1 server: %s watched FID 0x%04X, which is not a directory", conn.Remote, fid)
+		return nt_status.NT_STATUS_NOT_A_DIRECTORY
+	}
+	if open.Tree == nil || open.Tree.Share.FS == nil {
+		return nt_status.NT_STATUS_INVALID_DEVICE_REQUEST
+	}
+
+	watcher, ok := open.Tree.Share.FS.(Watcher)
+	if !ok {
+		// A backend that cannot be watched says so. Answering success and never
+		// notifying would leave the client waiting for a change it would never
+		// hear about, which is worse than a refusal it can act on.
+		logger.Debugf("SMB1 server: %s watched %q on share %q, which cannot be watched",
+			conn.Remote, open.Path, open.Tree.Share.Name)
+		return nt_status.NT_STATUS_NOT_SUPPORTED
+	}
+
+	changes, stop, err := watcher.Watch(open.Path, watchTree)
+	if err != nil {
+		return statusForFSError(err)
+	}
+
+	// Everything the answer needs is captured now: the responder is the only part
+	// of the connection safe to touch from the goroutine below, and the handle
+	// and share tables belong to the receive loop.
+	responder := w.Defer()
+	budget := reassembly.maxParameterCount
+
+	go func() {
+		defer stop()
+		defer responder.Done()
+
+		waitForChange(conn, responder, changes, completionFilter, budget)
+	}()
+
+	// The handler has answered by deferring; the response comes from above.
+	return nt_status.NT_STATUS_SUCCESS
+}
+
+// waitForChange blocks until something the filter admits happens, the request is
+// cancelled, or the watch ends, and answers accordingly.
+//
+// Parameters:
+//   - conn: the connection, for logging
+//   - responder: the deferred answer to complete
+//   - changes: the watch's notifications
+//   - completionFilter: the changes the client asked about
+//   - budget: how many bytes of notification the client will take
+func waitForChange(
+	conn *Connection,
+	responder AsyncResponder,
+	changes <-chan ChangeNotification,
+	completionFilter uint32,
+	budget int,
+) {
+	for {
+		select {
+		case <-responder.Cancelled():
+			// The client withdrew the request, or the connection went away.
+			// Either way there is nobody to answer.
+			logger.Debugf("SMB1 server: a directory watch for %s was cancelled", conn.Remote)
+			return
+
+		case change, open := <-changes:
+			if !open {
+				// The watch ended without a change — the backend stopped
+				// watching. Reported rather than left hanging.
+				if err := responder.RespondWithError(nt_status.NT_STATUS_NOTIFY_CLEANUP); err != nil {
+					logger.Debugf("SMB1 server: failed to end a watch for %s: %v", conn.Remote, err)
+				}
+				return
+			}
+
+			if !changeAdmittedBy(change, completionFilter) {
+				continue
+			}
+
+			logger.Debugf("SMB1 server: telling %s that %q changed (action %d)",
+				conn.Remote, change.Name, change.Action)
+			answerChange(conn, responder, change, budget)
+			return
+		}
+	}
+}
+
+// answerChange sends the notification, or tells the client to re-enumerate when it
+// will not fit.
+//
+// [MS-CIFS] section 2.2.7.4: "If too many files [...] have changed since the last
+// time that the command was issued, then zero bytes are returned and
+// STATUS_NOTIFY_ENUM_DIR [...] is returned in the Status field". A client handles
+// that by listing the directory again, so it is a complete answer rather than a
+// failure — which is what makes a small client buffer safe to honour rather than
+// something to work around.
+func answerChange(conn *Connection, responder AsyncResponder, change ChangeNotification, budget int) {
+	encoded := encodeNotifyInformation(change)
+
+	if budget > 0 && len(encoded) > budget {
+		if err := responder.RespondWithError(nt_status.NT_STATUS_NOTIFY_ENUM_DIR); err != nil {
+			logger.Debugf("SMB1 server: failed to tell %s to re-enumerate: %v", conn.Remote, err)
+		}
+		return
+	}
+
+	response := newNotifyChangeResponse(encoded)
+	if err := responder.Respond(response); err != nil {
+		logger.Debugf("SMB1 server: failed to send a change notification to %s: %v", conn.Remote, err)
+	}
+}
+
+// encodeNotifyInformation renders one change as a FILE_NOTIFY_INFORMATION record.
+//
+// NextEntryOffset(4) Action(4) FileNameLength(4) FileName(variable), per [MS-FSCC]
+// section 2.7.1. One record, so NextEntryOffset is zero and the chain ends here.
+//
+// The name is UTF-16LE regardless of what the message declared: this is a native
+// structure, and its own definition fixes the encoding.
+func encodeNotifyInformation(change ChangeNotification) []byte {
+	name := utf16.EncodeUTF16LE(change.Name)
+
+	record := make([]byte, 12, 12+len(name))
+	binary.LittleEndian.PutUint32(record[4:8], change.Action)
+	binary.LittleEndian.PutUint32(record[8:12], uint32(len(name)))
+	return append(record, name...)
+}
+
+// changeAdmittedBy reports whether the client asked about a change of this kind.
+//
+// A filter of zero admits everything: a client that asked to be told about nothing
+// in particular is asking to be told about anything, and refusing to notify it
+// would leave it waiting forever.
+func changeAdmittedBy(change ChangeNotification, completionFilter uint32) bool {
+	if completionFilter == 0 {
+		return true
+	}
+	return completionFilter&filterForAction(change.Action) != 0
+}
+
+// filterForAction maps a change to the CompletionFilter bits a client would have
+// set to ask about it.
+//
+// The mapping is deliberately generous: an addition or a removal is a name change
+// for a file and for a directory both, because this server does not record which
+// of the two an entry that has just disappeared was. Erring towards notifying is
+// the safer direction — a client told about a change it did not ask for
+// re-enumerates and finds nothing, while one not told about a change it did ask
+// for waits forever.
+func filterForAction(action uint32) uint32 {
+	switch action {
+	case changeAdded, changeRemoved,
+		uint32(filesystem.FileActionRenamedOldName), uint32(filesystem.FileActionRenamedNewName):
+		return filesystem.FILE_NOTIFY_CHANGE_FILE_NAME | filesystem.FILE_NOTIFY_CHANGE_DIR_NAME
+	case changeModified:
+		return filesystem.FILE_NOTIFY_CHANGE_SIZE |
+			filesystem.FILE_NOTIFY_CHANGE_LAST_WRITE |
+			filesystem.FILE_NOTIFY_CHANGE_ATTRIBUTES
+	}
+	return 0
+}
+
+// newNotifyChangeResponse builds the NT_TRANSACT response carrying a change.
+//
+// The notification travels in the parameter block: [MS-CIFS] section 2.2.7.4 says
+// "The TotalParameterCount field of the server response indicates the number of
+// bytes that are being returned", and MaxDataCount is required to be zero, so
+// there is no data block to put it in.
+func newNotifyChangeResponse(parameters []byte) *ntTransactParametersResponse {
+	return &ntTransactParametersResponse{parameters: parameters}
+}
+
+// ntTransactParametersResponse is an NT_TRANSACT response whose whole payload is
+// its parameter block.
+//
+// The deferred responder sends a command rather than a transaction, so the
+// framing an immediate transaction would get from sendNtTransactResponse is done
+// here instead — for one small record it is a fixed layout rather than a
+// fragmentation problem.
+type ntTransactParametersResponse struct {
+	command_interface.Command
+	parameters []byte
+}
+
+// Marshal emits the NT_TRANSACT response words with the parameter block behind
+// them.
+func (r *ntTransactParametersResponse) Marshal() ([]byte, error) {
+	const wordCount = 18
+
+	// WordCount(1) Reserved1(3) TotalParameterCount(4) TotalDataCount(4)
+	// ParameterCount(4) ParameterOffset(4) ParameterDisplacement(4) DataCount(4)
+	// DataOffset(4) DataDisplacement(4) SetupCount(1) then ByteCount(2).
+	head := make([]byte, 1+2*wordCount+1)
+	head[0] = wordCount
+
+	words := head[1 : len(head)-1]
+	binary.LittleEndian.PutUint32(words[3:7], uint32(len(r.parameters)))   // TotalParameterCount
+	binary.LittleEndian.PutUint32(words[11:15], uint32(len(r.parameters))) // ParameterCount
+
+	// ParameterOffset is measured from the start of the SMB header.
+	parameterOffset := header.SMB_HEADER_SIZE + len(head) + 2
+	binary.LittleEndian.PutUint32(words[15:19], uint32(parameterOffset))
+
+	byteCount := make([]byte, 2)
+	binary.LittleEndian.PutUint16(byteCount, uint16(len(r.parameters)))
+
+	// SetupCount is the last word's low byte and stays zero: no setup words come back.
+	out := append([]byte{}, head...)
+	out = append(out, byteCount...)
+	out = append(out, r.parameters...)
+	return out, nil
+}
+
+// GetCommandCode reports the command this response answers.
+func (r *ntTransactParametersResponse) GetCommandCode() codes.CommandCode {
+	return codes.SMB_COM_NT_TRANSACT
+}

--- a/network/smb/smb_v10/server/handler_nttransact.go
+++ b/network/smb/smb_v10/server/handler_nttransact.go
@@ -117,6 +117,13 @@ func handleNtTransactSecondary(conn *Connection, w ResponseWriter, req *message.
 
 // runNtTransact dispatches an assembled NT_TRANSACT to its subcommand.
 func (c *Connection) runNtTransact(w ResponseWriter, req *message.Message, reassembly *transactionReassembly) nt_status.NT_STATUS {
+	// NOTIFY_CHANGE answers later rather than returning a block now, so it is
+	// dispatched before the table: a handler that defers has nothing to give
+	// runNtTransact to send.
+	if subcommands.NtTransactSubcommand(reassembly.subcommand) == subcommands.NT_TRANSACT_NOTIFY_CHANGE {
+		return handleNotifyChange(c, w, req, reassembly)
+	}
+
 	handler, ok := ntTransactHandlers[subcommands.NtTransactSubcommand(reassembly.subcommand)]
 	if !ok {
 		logger.Debugf("SMB1 server: %s sent unimplemented NT_TRANSACT function 0x%04X",

--- a/network/smb/smb_v10/server/notify_test.go
+++ b/network/smb/smb_v10/server/notify_test.go
@@ -1,0 +1,328 @@
+package server
+
+import (
+	"encoding/binary"
+	"testing"
+	"time"
+
+	smb1client "github.com/TheManticoreProject/Manticore/network/smb/smb_v10/client"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/codes"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+	"github.com/TheManticoreProject/Manticore/windows/fileflags"
+	"github.com/TheManticoreProject/Manticore/windows/filesystem"
+	"github.com/TheManticoreProject/Manticore/windows/nt_status"
+)
+
+// notifyReply is what a watch's answer carried.
+type notifyReply struct {
+	status  uint32
+	records []filesystem.FileNotifyInformation
+}
+
+// watchDirectory opens a directory handle and sends NT_TRANSACT_NOTIFY_CHANGE on
+// it, returning a channel that receives the answer whenever it arrives.
+//
+// The reply is read on a goroutine because the whole point of the command is that
+// it is answered later: reading inline would block the test before it could make
+// the change it wants to be told about.
+func watchDirectory(
+	t *testing.T,
+	client *smb1client.Client,
+	path string,
+	completionFilter uint32,
+	watchTree bool,
+	maxParameterCount uint32,
+) <-chan notifyReply {
+	t.Helper()
+
+	fid, err := client.OpenFile(path,
+		fileflags.GENERIC_READ, fileflags.FILE_SHARE_READ|fileflags.FILE_SHARE_WRITE,
+		fileflags.FILE_OPEN, fileflags.FILE_DIRECTORY_FILE)
+	if err != nil {
+		t.Fatalf("opening %q as a directory failed: %v", path, err)
+	}
+
+	tree := uint16(0)
+	if watchTree {
+		tree = 1
+	}
+	setup := []types.USHORT{
+		types.USHORT(completionFilter & 0xFFFF),
+		types.USHORT(completionFilter >> 16),
+		types.USHORT(fid),
+		types.USHORT(tree),
+	}
+
+	request := newRequest(codes.SMB_COM_NT_TRANSACT)
+	request.Header.UID = client.Session.SessionUID
+	request.Header.TID = client.Session.TreeID
+
+	transaction := commands.NewNtTransactRequest()
+	transaction.Function = types.USHORT(4) // NT_TRANSACT_NOTIFY_CHANGE
+	transaction.Setup = setup
+	transaction.SetupCount = types.UCHAR(len(setup))
+	transaction.MaxParameterCount = types.ULONG(maxParameterCount)
+	transaction.MaxDataCount = types.ULONG(0)
+	request.AddCommand(transaction)
+
+	marshalled, err := request.Marshal()
+	if err != nil {
+		t.Fatalf("failed to marshal the watch: %v", err)
+	}
+	if _, err := client.Transport.Send(marshalled); err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+
+	replies := make(chan notifyReply, 1)
+	go func() {
+		raw, err := client.Transport.Receive()
+		if err != nil {
+			replies <- notifyReply{status: 0xFFFFFFFF}
+			return
+		}
+		if len(raw) < 9 {
+			replies <- notifyReply{status: 0xFFFFFFFE}
+			return
+		}
+
+		reply := notifyReply{status: binary.LittleEndian.Uint32(raw[5:9])}
+		if reply.status == 0 {
+			reply.records = notifyRecordsOf(raw)
+		}
+		replies <- reply
+	}()
+	return replies
+}
+
+// notifyRecordsOf pulls the FILE_NOTIFY_INFORMATION records out of a reply, using
+// the offsets the reply itself declares.
+//
+// They are parsed with windows/filesystem's own reader rather than by hand, so a
+// layout this server got wrong fails here instead of agreeing with itself.
+func notifyRecordsOf(raw []byte) []filesystem.FileNotifyInformation {
+	// WordCount(1) then the response words; ParameterCount is the fourth 4-byte
+	// word after the 3 reserved bytes, and ParameterOffset the fifth.
+	words := raw[header.SMB_HEADER_SIZE+1:]
+	if len(words) < 19 {
+		return nil
+	}
+	count := int(binary.LittleEndian.Uint32(words[11:15]))
+	offset := int(binary.LittleEndian.Uint32(words[15:19]))
+
+	if count == 0 || offset+count > len(raw) {
+		return nil
+	}
+	return filesystem.ParseFileNotifyInformation(raw[offset : offset+count])
+}
+
+// notifyServer serves a share with a directory to watch.
+func notifyServer(t *testing.T) (*MemoryFileSystem, *smb1client.Client) {
+	t.Helper()
+
+	fs := NewMemoryFileSystem("FILES")
+	if err := fs.AddDirectory("watched"); err != nil {
+		t.Fatalf("AddDirectory() error = %v", err)
+	}
+	_, client := fileServer(t, fs, false)
+	return fs, client
+}
+
+// TestNotifyChangeAnswersWhenSomethingIsCreated asserts a watch is answered when
+// an entry appears, with the name and action of the change.
+//
+// This is the command the deferred response path was built for: it is asked before
+// there is anything to say and answered when there is.
+func TestNotifyChangeAnswersWhenSomethingIsCreated(t *testing.T) {
+	fs, client := notifyServer(t)
+
+	replies := watchDirectory(t, client, "watched", 0, false, 4096)
+
+	// The change is made through the backend rather than over the wire, because
+	// the connection is occupied waiting for the answer.
+	waitFor(t, func() bool { return fs.watches.count() == 1 }, "the watch was not registered")
+	if err := fs.AddFile(`watched/appeared.txt`, []byte("x")); err != nil {
+		t.Fatalf("AddFile() error = %v", err)
+	}
+
+	select {
+	case reply := <-replies:
+		if reply.status != 0 {
+			t.Fatalf("the watch reported 0x%08X, want success", reply.status)
+		}
+		if len(reply.records) != 1 {
+			t.Fatalf("the answer carries %d records, want 1", len(reply.records))
+		}
+		if got := reply.records[0].FileName; got != "appeared.txt" {
+			t.Errorf("the change names %q, want %q", got, "appeared.txt")
+		}
+		if reply.records[0].Action != filesystem.FileActionAdded {
+			t.Errorf("the action is %v, want added", reply.records[0].Action)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("the watch was never answered")
+	}
+}
+
+// TestNotifyChangeTellsTheClientToReEnumerateWhenItWillNotFit asserts a client
+// whose buffer is too small is told to list the directory again.
+//
+// [MS-CIFS] section 2.2.7.4: too much to return means "zero bytes are returned and
+// STATUS_NOTIFY_ENUM_DIR [...] is returned in the Status field". A client handles
+// that by re-enumerating, so honouring a small buffer is a complete answer rather
+// than a failure — and truncating a record instead would give the client a name
+// that is not a name.
+func TestNotifyChangeTellsTheClientToReEnumerateWhenItWillNotFit(t *testing.T) {
+	fs, client := notifyServer(t)
+
+	// Four bytes cannot hold even the fixed part of one record.
+	replies := watchDirectory(t, client, "watched", 0, false, 4)
+
+	waitFor(t, func() bool { return fs.watches.count() == 1 }, "the watch was not registered")
+	if err := fs.AddFile(`watched/appeared.txt`, []byte("x")); err != nil {
+		t.Fatalf("AddFile() error = %v", err)
+	}
+
+	select {
+	case reply := <-replies:
+		if reply.status != uint32(nt_status.NT_STATUS_NOTIFY_ENUM_DIR) {
+			t.Errorf("a watch with a 4-byte buffer reported 0x%08X, want STATUS_NOTIFY_ENUM_DIR (0x%08X)",
+				reply.status, uint32(nt_status.NT_STATUS_NOTIFY_ENUM_DIR))
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("the watch was never answered")
+	}
+}
+
+// TestNotifyChangeHonoursItsCompletionFilter asserts a change the client did not
+// ask about does not answer the watch, and one it did asks does.
+func TestNotifyChangeHonoursItsCompletionFilter(t *testing.T) {
+	fs, client := notifyServer(t)
+
+	// Asking only about size changes: a new name must not answer this.
+	replies := watchDirectory(t, client, "watched", filesystem.FILE_NOTIFY_CHANGE_SIZE, false, 4096)
+
+	waitFor(t, func() bool { return fs.watches.count() == 1 }, "the watch was not registered")
+	if err := fs.AddFile(`watched/appeared.txt`, []byte("x")); err != nil {
+		t.Fatalf("AddFile() error = %v", err)
+	}
+
+	select {
+	case reply := <-replies:
+		t.Fatalf("a name change answered a size-only watch, with status 0x%08X", reply.status)
+	case <-time.After(300 * time.Millisecond):
+		// Correct: the filter excluded it.
+	}
+
+	// A modification is what the filter admits.
+	if err := fs.SetAttr(`watched/appeared.txt`, FileAttr{ReadOnly: true}, AttrMask{ReadOnly: true}); err != nil {
+		t.Fatalf("SetAttr() error = %v", err)
+	}
+
+	select {
+	case reply := <-replies:
+		if reply.status != 0 {
+			t.Fatalf("the watch reported 0x%08X, want success", reply.status)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("a change the filter admits did not answer the watch")
+	}
+}
+
+// TestNotifyChangeOnANonDirectoryIsRefused asserts the handle has to name a
+// directory.
+//
+// [MS-CIFS] section 2.2.7.4: "A directory file MUST be opened before this command
+// can be used." A handle on a file has no entries whose changes could be reported.
+func TestNotifyChangeOnANonDirectoryIsRefused(t *testing.T) {
+	fs := NewMemoryFileSystem("FILES")
+	if err := fs.AddFile("afile.txt", []byte("x")); err != nil {
+		t.Fatalf("AddFile() error = %v", err)
+	}
+	_, client := fileServer(t, fs, false)
+
+	fid, err := client.OpenFile("afile.txt",
+		fileflags.GENERIC_READ, fileflags.FILE_SHARE_READ,
+		fileflags.FILE_OPEN, fileflags.FILE_NON_DIRECTORY_FILE)
+	if err != nil {
+		t.Fatalf("opening the file failed: %v", err)
+	}
+
+	setup := []types.USHORT{0, 0, types.USHORT(fid), 0}
+	status := sendNtTransact(t, client, 4, setup, nil, nil)
+	if status != uint32(nt_status.NT_STATUS_NOT_A_DIRECTORY) {
+		t.Errorf("watching a file reported 0x%08X, want STATUS_NOT_A_DIRECTORY (0x%08X)",
+			status, uint32(nt_status.NT_STATUS_NOT_A_DIRECTORY))
+	}
+}
+
+// TestNotifyChangeOnAnUnwatchableBackendIsRefused asserts a share whose backend
+// cannot be watched says so.
+//
+// Answering success and never notifying would leave the client waiting for a
+// change it would never hear about — a worse outcome than a refusal it can act on.
+func TestNotifyChangeOnAnUnwatchableBackendIsRefused(t *testing.T) {
+	fs := &unwatchableFileSystem{MemoryFileSystem: NewMemoryFileSystem("FILES")}
+	if err := fs.AddDirectory("watched"); err != nil {
+		t.Fatalf("AddDirectory() error = %v", err)
+	}
+	_, client := fileServer(t, fs, false)
+
+	fid, err := client.OpenFile("watched",
+		fileflags.GENERIC_READ, fileflags.FILE_SHARE_READ,
+		fileflags.FILE_OPEN, fileflags.FILE_DIRECTORY_FILE)
+	if err != nil {
+		t.Fatalf("opening the directory failed: %v", err)
+	}
+
+	setup := []types.USHORT{0, 0, types.USHORT(fid), 0}
+	status := sendNtTransact(t, client, 4, setup, nil, nil)
+	if status != uint32(nt_status.NT_STATUS_NOT_SUPPORTED) {
+		t.Errorf("watching an unwatchable share reported 0x%08X, want STATUS_NOT_SUPPORTED", status)
+	}
+}
+
+// unwatchableFileSystem is a MemoryFileSystem with Watch hidden, standing in for a
+// caller's backend that cannot report changes.
+type unwatchableFileSystem struct {
+	*MemoryFileSystem
+
+	// Watch shadows the embedded method, so the type does not satisfy Watcher.
+	Watch struct{}
+}
+
+// TestNotifyChangeStopsWatchingWhenCancelled asserts a cancelled watch releases
+// the backend watch rather than leaving it running for the life of the share.
+func TestNotifyChangeStopsWatchingWhenCancelled(t *testing.T) {
+	fs, client := notifyServer(t)
+
+	replies := watchDirectory(t, client, "watched", 0, false, 4096)
+	waitFor(t, func() bool { return fs.watches.count() == 1 }, "the watch was not registered")
+
+	// The cancel names the watch's own PID and MID, which newRequest fixes.
+	request := newRequest(codes.SMB_COM_NT_CANCEL)
+	request.Header.UID = client.Session.SessionUID
+	request.AddCommand(commands.NewNtCancelRequest())
+
+	marshalled, err := request.Marshal()
+	if err != nil {
+		t.Fatalf("failed to marshal the cancel: %v", err)
+	}
+	if _, err := client.Transport.Send(marshalled); err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+
+	// The backend watch goes when the request is cancelled, which is what keeps a
+	// client that walks away from leaking one per abandoned watch.
+	waitFor(t, func() bool { return fs.watches.count() == 0 },
+		"the backend watch outlived the cancelled request")
+
+	// And nothing was sent for it, so the reply stream stays in step: an echo
+	// afterwards gets its own answer.
+	select {
+	case reply := <-replies:
+		t.Fatalf("a cancelled watch was answered anyway, with status 0x%08X", reply.status)
+	case <-time.After(300 * time.Millisecond):
+	}
+}

--- a/network/smb/smb_v10/server/nttransact_test.go
+++ b/network/smb/smb_v10/server/nttransact_test.go
@@ -599,10 +599,12 @@ func TestNtTransactUnimplementedFunctions(t *testing.T) {
 	fs := NewMemoryFileSystem("FILES")
 	_, client := fileServer(t, fs, false)
 
+	// NT_TRANSACT_NOTIFY_CHANGE is served now, through the deferred response
+	// path, and is asserted in notify_test.go. What is left here is the set that
+	// answers the generic refusal.
 	unimplemented := []subcommands.NtTransactSubcommand{
 		subcommands.NT_TRANSACT_CREATE,
 		subcommands.NT_TRANSACT_RENAME,
-		subcommands.NT_TRANSACT_NOTIFY_CHANGE,
 		subcommands.NT_TRANSACT_QUERY_QUOTA,
 		subcommands.NT_TRANSACT_SET_QUOTA,
 	}

--- a/network/smb/smb_v10/server/share.go
+++ b/network/smb/smb_v10/server/share.go
@@ -205,6 +205,45 @@ type FileSystem interface {
 	VolumeInfo() (VolumeInfo, error)
 }
 
+// ChangeNotification is one change a Watcher reports.
+type ChangeNotification struct {
+	// Action is what happened, as an [MS-FSCC] FILE_ACTION_* value.
+	Action uint32
+
+	// Name is the entry that changed, relative to the watched directory and
+	// separated by backslashes, which is how FILE_NOTIFY_INFORMATION carries it.
+	Name string
+}
+
+// Watcher is implemented by a FileSystem that can report changes under a
+// directory.
+//
+// Like Linker it is a separate interface rather than a method on FileSystem, so
+// that adding it does not break a backend outside this repository: one that cannot
+// be watched simply does not implement it, and NT_TRANSACT_NOTIFY_CHANGE is
+// refused for its shares.
+type Watcher interface {
+	// Watch begins watching a directory and returns a channel of changes and a
+	// function that stops the watch.
+	//
+	// The channel is buffered and lossy by design: a watch that fell behind and
+	// blocked would hold up whatever made the change. A caller that misses a
+	// notification is expected to re-enumerate, which is exactly what the
+	// protocol tells a client to do when more changed than would fit in a
+	// response.
+	//
+	// The stop function must be called, and is safe to call more than once.
+	//
+	// Parameters:
+	//   - path: the share-relative directory to watch, empty for the share root
+	//   - recursive: whether to report changes below the directory as well
+	//
+	// Returns:
+	//   - A channel of changes, a stop function, and an error if the path cannot
+	//     be watched
+	Watch(path string, recursive bool) (<-chan ChangeNotification, func(), error)
+}
+
 // Sentinel errors a FileSystem returns so the server can answer with the right
 // protocol status. A backend may wrap them.
 var (

--- a/network/smb/smb_v10/server/watch_local.go
+++ b/network/smb/smb_v10/server/watch_local.go
@@ -1,0 +1,159 @@
+package server
+
+import (
+	"sync"
+	"time"
+
+	"github.com/TheManticoreProject/Manticore/logger"
+)
+
+// LocalWatchInterval is how often a watch on a LocalFileSystem re-reads the
+// directory it is watching.
+//
+// The host is not asked to report changes: doing that portably means a per-platform
+// notification API, and this package is pure standard library by design. So a
+// watch polls, and the interval is the latency a client sees between a change and
+// its notification.
+//
+// It is a package variable rather than a constant so a test can shorten it. A
+// caller has no reason to.
+var LocalWatchInterval = 500 * time.Millisecond
+
+// localWatch is one polling watch on a LocalFileSystem.
+type localWatch struct {
+	fs        *LocalFileSystem
+	path      string
+	recursive bool
+
+	changes chan ChangeNotification
+	done    chan struct{}
+	once    sync.Once
+}
+
+// Watch begins watching a directory of the local file system.
+//
+// The watch compares successive listings rather than being told what changed, so
+// it reports what it can see afterwards: an entry that appeared, one that
+// disappeared, and one whose size or modification time moved. A change that leaves
+// all three the same — a write that replaces a byte without changing the length,
+// within the same timestamp granularity — is not visible to it, and that is a
+// property of polling rather than something the interval can fix.
+//
+// Parameters:
+//   - path: the share-relative directory to watch
+//   - recursive: whether to report changes below it
+//
+// Returns:
+//   - A channel of changes, a stop function, and an error if the path cannot be
+//     watched
+func (fs *LocalFileSystem) Watch(path string, recursive bool) (<-chan ChangeNotification, func(), error) {
+	attr, err := fs.Stat(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	if !attr.IsDir {
+		return nil, nil, ErrNotDirectory
+	}
+
+	watch := &localWatch{
+		fs:        fs,
+		path:      path,
+		recursive: recursive,
+		changes:   make(chan ChangeNotification, memoryWatchBuffer),
+		done:      make(chan struct{}),
+	}
+
+	go watch.poll()
+
+	stop := func() {
+		watch.once.Do(func() { close(watch.done) })
+	}
+	return watch.changes, stop, nil
+}
+
+// snapshot is what a poll remembers about one entry, which is everything it can
+// compare.
+type snapshot struct {
+	size     int64
+	modified time.Time
+	isDir    bool
+}
+
+// poll re-reads the directory until it is stopped, reporting what changed between
+// readings.
+func (w *localWatch) poll() {
+	defer close(w.changes)
+
+	previous := w.read()
+
+	ticker := time.NewTicker(LocalWatchInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-w.done:
+			return
+		case <-ticker.C:
+		}
+
+		current := w.read()
+		w.report(previous, current)
+		previous = current
+	}
+}
+
+// read takes a snapshot of the watched directory.
+func (w *localWatch) read() map[string]snapshot {
+	taken := map[string]snapshot{}
+
+	entries, err := w.fs.ReadDir(w.path, "")
+	if err != nil {
+		// A directory that has gone away stops producing changes rather than
+		// reporting every entry as removed: the client's handle on it is what
+		// will fail next, and inventing a storm of removals here would be worse
+		// than silence.
+		logger.Debugf("SMB1 server: a watch on %q could not read it: %v", w.path, err)
+		return taken
+	}
+
+	for _, entry := range entries {
+		taken[entry.Attr.Name] = snapshot{
+			size:     entry.Attr.Size,
+			modified: entry.Attr.Modified,
+			isDir:    entry.Attr.IsDir,
+		}
+	}
+	return taken
+}
+
+// report sends a notification for each difference between two snapshots.
+func (w *localWatch) report(previous, current map[string]snapshot) {
+	for name, now := range current {
+		before, existed := previous[name]
+		switch {
+		case !existed:
+			w.send(name, changeAdded)
+		case now.size != before.size || !now.modified.Equal(before.modified):
+			w.send(name, changeModified)
+		}
+	}
+
+	for name := range previous {
+		if _, present := current[name]; !present {
+			w.send(name, changeRemoved)
+		}
+	}
+}
+
+// send delivers one notification, dropping it if the reader has fallen behind.
+//
+// Dropping is the right failure: a client that misses a notification
+// re-enumerates, which is what the protocol tells it to do when more changed than
+// fits in a response, so nothing is lost that the client cannot recover.
+func (w *localWatch) send(name string, action uint32) {
+	select {
+	case w.changes <- ChangeNotification{Action: action, Name: name}:
+	case <-w.done:
+	default:
+	}
+}

--- a/network/smb/smb_v10/server/watch_mem.go
+++ b/network/smb/smb_v10/server/watch_mem.go
@@ -1,0 +1,156 @@
+package server
+
+import (
+	"strings"
+	"sync"
+
+	"github.com/TheManticoreProject/Manticore/windows/filesystem"
+)
+
+// memoryWatch is one registered watch on a MemoryFileSystem.
+type memoryWatch struct {
+	// path is the directory being watched, share-relative, and recursive says
+	// whether entries below it count.
+	path      string
+	recursive bool
+
+	// changes carries the notifications. It is buffered, and a send that would
+	// block is dropped: a watch that fell behind must not hold up the operation
+	// that made the change.
+	changes chan ChangeNotification
+}
+
+// memoryWatchBuffer is how many notifications a watch holds before it starts
+// dropping them.
+//
+// A client that misses one re-enumerates, which is what the protocol tells it to
+// do when more changed than fits in a response, so a bounded buffer loses nothing
+// a client cannot recover.
+const memoryWatchBuffer = 64
+
+// watchRegistry holds the watches on a file system and publishes to them.
+//
+// It is a separate type so that both backends share the fan-out and the dropping
+// rule rather than each implementing it.
+type watchRegistry struct {
+	mutex   sync.Mutex
+	watches map[*memoryWatch]struct{}
+}
+
+// add registers a watch and returns it with the function that removes it.
+func (r *watchRegistry) add(path string, recursive bool) (<-chan ChangeNotification, func(), error) {
+	watch := &memoryWatch{
+		path:      strings.Trim(path, "/"),
+		recursive: recursive,
+		changes:   make(chan ChangeNotification, memoryWatchBuffer),
+	}
+
+	r.mutex.Lock()
+	if r.watches == nil {
+		r.watches = make(map[*memoryWatch]struct{})
+	}
+	r.watches[watch] = struct{}{}
+	r.mutex.Unlock()
+
+	var once sync.Once
+	stop := func() {
+		once.Do(func() {
+			r.mutex.Lock()
+			delete(r.watches, watch)
+			r.mutex.Unlock()
+			close(watch.changes)
+		})
+	}
+	return watch.changes, stop, nil
+}
+
+// publish tells every interested watch that a path changed.
+//
+// Parameters:
+//   - path: the share-relative path that changed
+//   - action: the FILE_ACTION_* value describing what happened
+func (r *watchRegistry) publish(path string, action uint32) {
+	r.mutex.Lock()
+	interested := make([]*memoryWatch, 0, len(r.watches))
+	for watch := range r.watches {
+		if watch.covers(path) {
+			interested = append(interested, watch)
+		}
+	}
+	r.mutex.Unlock()
+
+	for _, watch := range interested {
+		notification := ChangeNotification{
+			Action: action,
+			Name:   watch.relative(path),
+		}
+		// Non-blocking: a full buffer drops the notification rather than
+		// stalling the operation that made the change.
+		select {
+		case watch.changes <- notification:
+		default:
+		}
+	}
+}
+
+// covers reports whether a changed path is one this watch reports.
+//
+// A non-recursive watch reports only its immediate children, which is what
+// WatchTree being clear means: a change two levels down is not a change to the
+// directory the client asked about.
+func (w *memoryWatch) covers(path string) bool {
+	relative := w.relative(path)
+	if relative == "" {
+		return false
+	}
+	if w.recursive {
+		return true
+	}
+	return !strings.Contains(relative, "/")
+}
+
+// relative renders a changed path relative to the watched directory, in the
+// backslash-separated form FILE_NOTIFY_INFORMATION carries.
+func (w *memoryWatch) relative(path string) string {
+	trimmed := strings.Trim(path, "/")
+	if w.path == "" {
+		return strings.ReplaceAll(trimmed, "/", `\`)
+	}
+	if !strings.HasPrefix(trimmed, w.path+"/") {
+		return ""
+	}
+	return strings.ReplaceAll(strings.TrimPrefix(trimmed, w.path+"/"), "/", `\`)
+}
+
+// Watch begins watching a directory of the memory file system.
+//
+// The directory has to exist and be a directory: watching something that is not
+// there would report changes to a path the client cannot enumerate.
+func (fs *MemoryFileSystem) Watch(path string, recursive bool) (<-chan ChangeNotification, func(), error) {
+	if path != "" {
+		attr, err := fs.Stat(path)
+		if err != nil {
+			return nil, nil, err
+		}
+		if !attr.IsDir {
+			return nil, nil, ErrNotDirectory
+		}
+	}
+	return fs.watches.add(path, recursive)
+}
+
+// The FILE_ACTION_* values a change carries, named from windows/filesystem so the
+// two agree.
+var (
+	changeAdded    = uint32(filesystem.FileActionAdded)
+	changeRemoved  = uint32(filesystem.FileActionRemoved)
+	changeModified = uint32(filesystem.FileActionModified)
+)
+
+// count reports how many watches are registered, for the tests and for a caller
+// that wants to report on a share.
+func (r *watchRegistry) count() int {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	return len(r.watches)
+}


### PR DESCRIPTION
### Linked Issue
Refs #1152 — this delivers the change-notification half. The oplock half stays open, for the reason at the bottom.

> **Stacked on #1176.** Cut from `enhancement-async-response-path` (#1141), which is what makes an answer sendable after the request that asked for it has returned. Merge #1176 first.

### Root Cause
`NT_TRANSACT_NOTIFY_CHANGE` needed two things the package did not have: a reply sent from outside the request that asked for it, and a `FileSystem` that could be watched. #1141 supplied the first. This supplies the second and serves the command.

### Fix Description
**`Watcher` is an optional interface, like `Linker`.** A backend that cannot report changes simply does not implement it, and the command is refused for its shares — answering success and never notifying would leave a client waiting for something it would never hear about, which is worse than a refusal it can act on. Adding a method to `FileSystem` would have broken every backend outside this repository.

**`MemoryFileSystem` reports changes as it makes them**, published from inside the lock that made the mutation. That is deliberate: the registry has its own lock and its sends never block, so the order is always the file system's lock then the registry's and there is no inversion to deadlock on. An earlier attempt published from a `defer`, which would have read the entry map *after* the mutex unlocked — a data race that the `-race` run below is there to keep out.

`AddFile` and `AddDirectory` publish too. They are setup helpers, but a caller adding a file to a share a client is already watching has changed the share, and a watch that heard about a create through `Open` but not through here would be reporting on how a file arrived rather than on the file.

**`LocalFileSystem` polls**, and the documentation says so where a caller will see it. Asking the host to report changes portably needs a per-platform notification API, and this package is standard library only by design. The consequence is stated rather than buried: `LocalWatchInterval` is the latency a client sees, and a change that leaves an entry's name, size and modification time alone — a write replacing a byte within the same timestamp granularity — is invisible to a differ. That is a property of polling, not something a shorter interval fixes.

**Notifications are dropped rather than blocking.** Both watchers use a bounded buffer and a non-blocking send. A watch that fell behind and blocked would hold up whatever made the change, and a client that misses a notification re-enumerates — which is exactly what the protocol tells it to do when more changed than fits in a response. So nothing is lost that the client cannot recover.

**A change that will not fit is answered with `STATUS_NOTIFY_ENUM_DIR` and no data.** [MS-CIFS] 2.2.7.4: too much to return means "zero bytes are returned and STATUS_NOTIFY_ENUM_DIR [...] is returned in the Status field". A client handles that by listing the directory again, so it is a complete answer rather than a failure — and it is what makes honouring a small client buffer correct instead of something to work around. Truncating a record instead would hand the client a name that is not a name.

**The completion filter is honoured generously.** A change the client did not ask about does not answer the watch. The mapping from action to filter bits errs towards notifying — an addition counts as both a file-name and a directory-name change, because this server does not record which of the two a vanished entry was. A client told about a change it did not ask for re-enumerates and finds nothing; one not told about a change it did ask for waits forever.

The handler captures everything it needs at `Defer` time and touches only the responder afterwards, which is the rule `AsyncResponder` documents. A cancelled watch releases the backend watch, so a client that walks away does not leak one per abandoned request.

### How Verified
Runtime, over the loopback harness. The reply is read on a goroutine because the command is answered later — reading inline would block the test before it could make the change it wants to be told about. The `FILE_NOTIFY_INFORMATION` records are parsed with `windows/filesystem`'s own reader rather than by hand, so a layout this server got wrong fails here instead of agreeing with itself.

- `TestNotifyChangeAnswersWhenSomethingIsCreated` — the watch is answered with the name and the added action.
- `TestNotifyChangeTellsTheClientToReEnumerateWhenItWillNotFit` — a four-byte buffer gets `STATUS_NOTIFY_ENUM_DIR`.
- `TestNotifyChangeHonoursItsCompletionFilter` — a name change does not answer a size-only watch, and a modification does.
- `TestNotifyChangeOnANonDirectoryIsRefused` — `STATUS_NOT_A_DIRECTORY`.
- `TestNotifyChangeOnAnUnwatchableBackendIsRefused` — `STATUS_NOT_SUPPORTED`, with a fixture that shadows the embedded `Watch` method.
- `TestNotifyChangeStopsWatchingWhenCancelled` — the backend watch count returns to zero and nothing is sent for the cancelled request, so the reply stream stays in step.

**`go test -race` passes** on the notify, deferral and cancellation tests together. That is the check that matters: a watcher publishing from one goroutine while the receive loop serves another is exactly the shape a race hides in, and it is how the `defer`-based publish above was caught.

Whole tree green: `go build ./...`, `go test ./network/smb/...`. `gofmt -l` clean on every file touched.

### Test Coverage
**Added:** `server/notify_test.go` — the six tests above, plus `watchDirectory`, `notifyRecordsOf` (which reads the reply's own declared offsets rather than assuming them) and the `unwatchableFileSystem` fixture.

**Modified:** `server/conformance_test.go` — `NT_TRANSACT_NOTIFY_CHANGE` registered as served, and `TestConformanceServedNtTransactFunctionsAreServed` taught that it is dispatched before the handler table rather than from it, because a handler that defers has nothing to hand back to `runNtTransact`. `server/nttransact_test.go` — it leaves the unimplemented list.

### Scope of Change
- **Files changed:** `server/watch_mem.go` (new), `server/watch_local.go` (new), `server/handler_notify.go` (new), `server/notify_test.go` (new), `server/share.go`, `server/fs_mem.go`, `server/handler_nttransact.go`, `server/conformance_test.go`, `server/nttransact_test.go`, `server/doc.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** `MemoryFileSystem` now publishes on mutation. Nothing consumes those publishes unless a watch is registered, and with none registered a publish is one uncontended lock and a map iteration over an empty map.

### Risk and Rollout
The new work happens only when a client watches something. A share with no watch pays a publish that finds nothing; `LocalFileSystem` starts no goroutine until `Watch` is called, and stops it when the watch does.

The one thing to watch in review is the lock ordering described above — file system lock then registry lock, never the reverse — because it is the kind of invariant that a later change to `MemoryFileSystem` could break without any test noticing except under `-race`.

### Notes
**The oplock half of #1152 is not done, and should not be closed by this.** Granting a level II oplock means being able to break it, which means sending a message the client did not ask for, and `Connection.SendUnsolicited` refuses that on a signing connection: a signed message consumes a number from the sequence the two sides keep in step, and one with no request behind it has none reserved. Guessing wrong desynchronises signing for the whole connection. Settling it needs a capture from a real client, which is what the interop legs in #1153 would provide — so the two are worth doing together.

`CAP_LEVEL_II_OPLOCKS` therefore stays unadvertised, and `NT_CREATE_ANDX` and `NT_TRANSACT_CREATE` keep reporting oplock level 0.
