### PR TITLE
Add a srvsvc and wkssvc PipeHandler so an IPC$ share is browsable (Fixes #1150)

### DIFF
--- a/network/dcerpc/v5/rpcserver/doc.go
+++ b/network/dcerpc/v5/rpcserver/doc.go
@@ -1,0 +1,52 @@
+// Package rpcserver answers connection-oriented DCE/RPC calls.
+//
+// It is the server side of what network/dcerpc/v5/client sends: it reads a bind or
+// a request PDU, hands the request's stub to a registered Service, and frames the
+// reply. It knows nothing about how the bytes arrived, so the same Dispatcher
+// serves an interface over an SMB named pipe, over TCP, or over anything else that
+// can hand it one PDU and take one back.
+//
+// # What a Service is
+//
+// A Service is one RPC interface: an abstract syntax that identifies it, and a
+// Call that runs one opnum against a request stub and returns a response stub. The
+// NDR marshalling of those stubs is the Service's business — network/dcerpc/ndr
+// does it, and the structures in windows/protocols/... describe the parameters —
+// so a Service is the interface's methods and nothing else.
+//
+// # What this does not do
+//
+// RPC-level authentication is refused rather than half-implemented. A bind
+// carrying an authentication verifier is answered with a bind_nak, because
+// completing one means an NTLM or Kerberos exchange over auth3 PDUs and a
+// per-context security context to verify and seal every later request against.
+// Over an SMB named pipe the pipe is already authenticated by the SMB session, so
+// the common case needs none; a caller that needs RPC-level auth is better served
+// by that being absent than by a bind that succeeds and then cannot verify
+// anything.
+//
+// A request arriving in fragments is refused with a fault rather than
+// reassembled. Reassembly needs per-call state keyed by call id, and the request
+// stubs of the interfaces served here — an information level and a couple of
+// counts — do not approach a fragment's worth of bytes. Replies are fragmented,
+// which is the direction that matters: a share enumeration easily exceeds one
+// fragment.
+//
+// A Dispatcher serves one endpoint, and a request is dispatched to the single
+// interface that endpoint serves rather than by the presentation context the
+// request names. A transport that cannot tell two opens of an endpoint apart —
+// an SMB named pipe reached through a PipeHandler is one — cannot hold the
+// per-bind context table that dispatching by context id would need, so an
+// endpoint registered with more than one interface faults a request instead of
+// guessing. One interface per endpoint is how \srvsvc and \wkssvc are used.
+//
+// Only the NDR (little-endian, version 2) transfer syntax is accepted. NDR64 is
+// declined at bind time rather than accepted and then misencoded, which is the
+// only useful answer when the encoder in use speaks one of the two.
+//
+// References:
+//   - [C706] DCE 1.1 RPC, chapter 12 (connection-oriented protocol):
+//     https://pubs.opengroup.org/onlinepubs/9629399/
+//   - [MS-RPCE] Remote Procedure Call Protocol Extensions:
+//     https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/290c38b1-92fe-4229-91e6-4fc376ea09c4
+package rpcserver

--- a/network/dcerpc/v5/rpcserver/rpcserver.go
+++ b/network/dcerpc/v5/rpcserver/rpcserver.go
@@ -1,0 +1,444 @@
+package rpcserver
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/TheManticoreProject/Manticore/logger"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/pdu"
+)
+
+// Service is one RPC interface a Dispatcher can answer for.
+type Service interface {
+	// AbstractSyntax identifies the interface and its version, which is what a
+	// bind names and what a Dispatcher matches against.
+	AbstractSyntax() syntax.SyntaxID
+
+	// Call runs one method and returns its response stub.
+	//
+	// The returned error is turned into a fault: ErrUnknownOpnum becomes
+	// nca_s_op_rng_error and ErrBadStub becomes nca_s_fault_ndr, so a Service can
+	// report those two without knowing the fault codes. Anything else becomes
+	// nca_s_proto_error.
+	//
+	// A method that fails at the protocol's own level — an unsupported
+	// information level, say — is not an error here: it returns a stub carrying
+	// the protocol's status code, because that is a successful call reporting a
+	// failure and a client parses it as one.
+	Call(opnum uint16, stub []byte) ([]byte, error)
+}
+
+// ErrUnknownOpnum reports a method the Service does not implement.
+var ErrUnknownOpnum = errors.New("unknown opnum")
+
+// ErrBadStub reports a request stub the Service could not decode.
+var ErrBadStub = errors.New("request stub could not be decoded")
+
+// DefaultMaxFragment is the reply fragment size used when a client's bind named
+// none, or named one too small to carry a PDU header.
+//
+// 4280 is what Windows offers and what every client is prepared for.
+const DefaultMaxFragment = 4280
+
+// minFragmentStub is the smallest stub a fragment may carry. A fragment size that
+// left no room for stub bytes would make progress impossible, so a client asking
+// for one is given DefaultMaxFragment instead.
+const minFragmentStub = 8
+
+// Dispatcher answers RPC PDUs for a set of interfaces.
+//
+// One Dispatcher serves one endpoint — one named pipe, say — and is safe for
+// concurrent use. It keeps no per-call state; the negotiated fragment size is the
+// only thing a bind changes, and it is guarded, because a transport that cannot
+// tell two opens of an endpoint apart delivers both clients' PDUs to one
+// Dispatcher and may do so from two goroutines at once.
+type Dispatcher struct {
+	// services are the interfaces this endpoint answers for. Written once by New
+	// and only read afterwards.
+	services []Service
+
+	// mutex guards maxFragment.
+	mutex sync.Mutex
+
+	// maxFragment is the largest reply fragment any client of this endpoint has
+	// said it can receive.
+	//
+	// It is the smallest such value seen, not the latest: without per-open state
+	// one size has to serve every client, and a fragment smaller than a client's
+	// maximum is always acceptable to it while a larger one is not. So a client
+	// asking for less shrinks the endpoint's fragments for everyone rather than
+	// risking a reply another client cannot take.
+	maxFragment uint16
+}
+
+// New builds a Dispatcher for a set of interfaces.
+//
+// Parameters:
+//   - services: the interfaces this endpoint answers for
+//
+// Returns:
+//   - The dispatcher
+func New(services ...Service) *Dispatcher {
+	return &Dispatcher{services: services, maxFragment: DefaultMaxFragment}
+}
+
+// Handle answers one received PDU and returns the reply.
+//
+// The reply may be several PDUs concatenated: a response larger than the client's
+// fragment size is split, and the caller writes the whole thing back as one
+// stream. That is what a byte-stream transport such as a named pipe wants — the
+// client reads fragments off the pipe until it sees one with PFC_LAST_FRAG.
+//
+// Parameters:
+//   - request: one complete received PDU
+//
+// Returns:
+//   - The reply PDUs to send back, and an error only when no reply can be framed
+func (d *Dispatcher) Handle(request []byte) ([]byte, error) {
+	header, err := pdu.PeekHeader(request)
+	if err != nil {
+		return nil, fmt.Errorf("not a DCE/RPC PDU: %w", err)
+	}
+
+	switch header.PacketType {
+	case pdu.PacketTypeBind, pdu.PacketTypeAlterContext:
+		return d.handleBind(request, header)
+
+	case pdu.PacketTypeRequest:
+		return d.handleRequest(request, header)
+
+	default:
+		// A packet type this endpoint does not answer for. A fault is a reply the
+		// client can act on; silence would leave it waiting.
+		logger.Debugf("rpcserver: refusing packet type %s", header.PacketType)
+		return d.fault(header.CallID, 0, pdu.NCASProtoError)
+	}
+}
+
+// handleBind answers a bind or an alter_context.
+//
+// The two are answered the same way: alter_context re-negotiates presentation
+// contexts on an existing association, and with no authentication to renegotiate
+// there is nothing that makes it differ from a bind here.
+func (d *Dispatcher) handleBind(request []byte, header *pdu.Header) ([]byte, error) {
+	// An alter_context PDU is wire-identical to a bind but for the packet type at
+	// offset 2 of the common header, and Bind.Unmarshal refuses anything else.
+	// Rewriting the type on a copy is how the client sends one; this is the same
+	// move on the receiving side, and the copy leaves the caller's buffer alone.
+	body := request
+	if header.PacketType == pdu.PacketTypeAlterContext {
+		body = make([]byte, len(request))
+		copy(body, request)
+		body[2] = byte(pdu.PacketTypeBind)
+	}
+
+	bind := &pdu.Bind{}
+	if _, err := bind.Unmarshal(body); err != nil {
+		logger.Debugf("rpcserver: a bind PDU would not decode: %v", err)
+		return d.bindNak(header.CallID, bindNakProtocolVersionNotSupported)
+	}
+
+	// An authenticated bind is refused rather than half-answered. See the package
+	// documentation: completing one needs a security context this does not keep,
+	// and a bind that succeeded without one would leave every later request
+	// unverifiable.
+	if header.AuthLength > 0 || len(bind.AuthValue) > 0 {
+		logger.Debugf("rpcserver: refusing an authenticated bind (%d bytes of verifier)", header.AuthLength)
+		return d.bindNak(header.CallID, bindNakAuthenticationTypeNotRecognized)
+	}
+
+	if len(bind.ContextList) == 0 {
+		return d.bindNak(header.CallID, bindNakReasonNotSpecified)
+	}
+
+	// Each context the client offered gets a result, in order: [C706] 12.6.4.4
+	// pairs them positionally with the contexts of the request.
+	ndrSyntax := syntax.NDRTransferSyntax()
+	results := make([]pdu.PresentationResult, 0, len(bind.ContextList))
+	accepted := 0
+
+	for _, context := range bind.ContextList {
+		service := d.serviceFor(context.AbstractSyntax)
+		if service == nil {
+			results = append(results, pdu.PresentationResult{
+				Result: contextResultProviderRejection,
+				Reason: contextReasonAbstractSyntaxNotSupported,
+			})
+			continue
+		}
+
+		if !offersSyntax(context.TransferSyntaxes, ndrSyntax) {
+			// NDR64 or nothing recognisable. Declining here is the only useful
+			// answer: accepting and then encoding NDR would produce a reply the
+			// client decodes as the wrong shape.
+			results = append(results, pdu.PresentationResult{
+				Result: contextResultProviderRejection,
+				Reason: contextReasonTransferSyntaxesNotSupported,
+			})
+			continue
+		}
+
+		results = append(results, pdu.PresentationResult{
+			Result:         contextResultAcceptance,
+			TransferSyntax: ndrSyntax,
+		})
+		accepted++
+	}
+
+	if accepted == 0 {
+		logger.Debugf("rpcserver: no presentation context in the bind could be accepted")
+		return d.bindNak(header.CallID, bindNakReasonNotSpecified)
+	}
+
+	negotiated := d.observeFragment(bind.MaxRecvFrag)
+
+	ack := &pdu.BindAck{
+		Header:      pdu.NewHeader(pdu.PacketTypeBindAck, pdu.PFCFirstFrag|pdu.PFCLastFrag, header.CallID),
+		MaxXmitFrag: negotiated,
+		MaxRecvFrag: negotiated,
+		// The association group is the client's when it named one, and 0x1234
+		// otherwise; the value is opaque and only has to be non-zero and stable.
+		AssocGroupID: assocGroup(bind.AssocGroupID),
+		// The secondary address is the endpoint the association continues on.
+		// Over a named pipe there is no second port to name, and an empty string
+		// is what a pipe endpoint reports.
+		SecondaryAddress: "",
+		Results:          results,
+	}
+	encoded, err := ack.Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal the bind_ack: %w", err)
+	}
+
+	// BindAck.Marshal forces PTYPE=bind_ack, and an alter_context_resp is
+	// wire-identical to it but for the packet type, so the answer to an
+	// alter_context is relabelled the same way the request was read.
+	if header.PacketType == pdu.PacketTypeAlterContext {
+		encoded[2] = byte(pdu.PacketTypeAlterContextResp)
+	}
+	return encoded, nil
+}
+
+// handleRequest answers a request PDU by calling the interface it names.
+func (d *Dispatcher) handleRequest(request []byte, header *pdu.Header) ([]byte, error) {
+	incoming := &pdu.Request{}
+	if _, err := incoming.Unmarshal(request); err != nil {
+		logger.Debugf("rpcserver: a request PDU would not decode: %v", err)
+		return d.fault(header.CallID, 0, pdu.NCASProtoError)
+	}
+
+	// A request arriving in fragments is refused rather than half-assembled.
+	// Reassembly needs per-call state keyed by call ID, and a partial stub handed
+	// to a Service would be decoded as a whole one.
+	if !header.PacketFlags.Has(pdu.PFCFirstFrag) || !header.PacketFlags.Has(pdu.PFCLastFrag) {
+		logger.Debugf("rpcserver: refusing a fragmented request (flags %s)", header.PacketFlags)
+		return d.fault(header.CallID, incoming.ContextID, pdu.NCASProtoError)
+	}
+
+	// The endpoint decides the interface. A Dispatcher serves one endpoint, and
+	// the context identifier a request carries was assigned by a bind this
+	// Dispatcher may not have seen — a transport that cannot tell two opens apart
+	// cannot keep per-bind state — so a single-interface endpoint dispatches by
+	// what it serves rather than by what the client numbered it.
+	service := d.only()
+	if service == nil {
+		logger.Debugf("rpcserver: request on an endpoint serving %d interfaces, which needs a bind context",
+			len(d.services))
+		return d.fault(header.CallID, incoming.ContextID, pdu.NCASUnkIf)
+	}
+
+	stub, err := service.Call(incoming.Opnum, incoming.Stub)
+	if err != nil {
+		status := pdu.NCASProtoError
+		switch {
+		case errors.Is(err, ErrUnknownOpnum):
+			status = pdu.NCASOpRngError
+		case errors.Is(err, ErrBadStub):
+			status = pdu.NCASFaultNDR
+		}
+		logger.Debugf("rpcserver: opnum %d failed (%v), answering %s",
+			incoming.Opnum, err, pdu.FaultStatus(status))
+		return d.fault(header.CallID, incoming.ContextID, status)
+	}
+
+	return d.response(header.CallID, incoming.ContextID, stub)
+}
+
+// response frames a response stub, splitting it across fragments if it exceeds
+// what the client said it can receive.
+func (d *Dispatcher) response(callID uint32, contextID uint16, stub []byte) ([]byte, error) {
+	budget := int(d.fragment()) - pdu.HeaderSize - responseBodyOverhead
+	if budget < minFragmentStub {
+		budget = DefaultMaxFragment - pdu.HeaderSize - responseBodyOverhead
+	}
+	// Fragments are kept to a multiple of eight so a stub's own alignment is not
+	// disturbed by where a fragment happens to end.
+	budget -= budget % 8
+
+	out := []byte{}
+	for first, sent := true, 0; first || sent < len(stub); first = false {
+		chunk := len(stub) - sent
+		if chunk > budget {
+			chunk = budget
+		}
+
+		flags := pdu.PFCFlags(0)
+		if first {
+			flags |= pdu.PFCFirstFrag
+		}
+		if sent+chunk >= len(stub) {
+			flags |= pdu.PFCLastFrag
+		}
+
+		reply := &pdu.Response{
+			Header:    pdu.NewHeader(pdu.PacketTypeResponse, flags, callID),
+			ContextID: contextID,
+			// AllocHint on the first fragment tells the client the whole size, so
+			// it can allocate once rather than growing per fragment.
+			AllocHint: uint32(len(stub) - sent),
+			Stub:      stub[sent : sent+chunk],
+		}
+		encoded, err := reply.Marshal()
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal a response fragment: %w", err)
+		}
+		out = append(out, encoded...)
+		sent += chunk
+	}
+	return out, nil
+}
+
+// responseBodyOverhead is the fixed part of a response PDU behind its header:
+// alloc_hint(4) p_cont_id(2) cancel_count(1) reserved(1).
+const responseBodyOverhead = 8
+
+// fault frames a fault PDU.
+func (d *Dispatcher) fault(callID uint32, contextID uint16, status uint32) ([]byte, error) {
+	f := &pdu.Fault{
+		Header:    pdu.NewHeader(pdu.PacketTypeFault, pdu.PFCFirstFrag|pdu.PFCLastFrag, callID),
+		ContextID: contextID,
+		Status:    status,
+	}
+	encoded, err := f.Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal a fault: %w", err)
+	}
+	return encoded, nil
+}
+
+// bindNak frames a bind_nak carrying a reject reason.
+func (d *Dispatcher) bindNak(callID uint32, reason uint16) ([]byte, error) {
+	nak := &pdu.BindNak{
+		Header:       pdu.NewHeader(pdu.PacketTypeBindNak, pdu.PFCFirstFrag|pdu.PFCLastFrag, callID),
+		RejectReason: reason,
+		// The versions this endpoint speaks, which is what a client uses to
+		// decide whether to retry differently.
+		Versions: []pdu.ProtocolVersion{{Major: 5, Minor: 0}},
+	}
+	encoded, err := nak.Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal a bind_nak: %w", err)
+	}
+	return encoded, nil
+}
+
+// serviceFor finds the interface a bind's abstract syntax names.
+func (d *Dispatcher) serviceFor(abstract syntax.SyntaxID) Service {
+	for _, service := range d.services {
+		if service.AbstractSyntax().Equal(abstract) {
+			return service
+		}
+	}
+	return nil
+}
+
+// only returns the single interface this endpoint serves, or nil when it serves
+// more than one and a request cannot be attributed without bind state.
+func (d *Dispatcher) only() Service {
+	if len(d.services) == 1 {
+		return d.services[0]
+	}
+	return nil
+}
+
+// offersSyntax reports whether a list of transfer syntaxes includes one.
+func offersSyntax(offered []syntax.SyntaxID, wanted syntax.SyntaxID) bool {
+	for _, candidate := range offered {
+		if candidate.Equal(wanted) {
+			return true
+		}
+	}
+	return false
+}
+
+// observeFragment records what a binding client can receive and returns the size
+// the endpoint will use for it.
+//
+// Parameters:
+//   - requested: the client's max_recv_frag
+//
+// Returns:
+//   - The fragment size the endpoint will send at
+func (d *Dispatcher) observeFragment(requested uint16) uint16 {
+	usable := negotiatedFragment(requested)
+
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+	if usable < d.maxFragment {
+		d.maxFragment = usable
+	}
+	return d.maxFragment
+}
+
+// fragment returns the size replies are fragmented at.
+func (d *Dispatcher) fragment() uint16 {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+	return d.maxFragment
+}
+
+// negotiatedFragment bounds the client's requested fragment size.
+//
+// A client asking for less than a PDU header plus a usable stub is asking for
+// something no reply fits in, so it is given the default instead: it is a client
+// that filled the field in wrongly rather than one with a tiny buffer.
+func negotiatedFragment(requested uint16) uint16 {
+	if int(requested) < pdu.HeaderSize+responseBodyOverhead+minFragmentStub {
+		return DefaultMaxFragment
+	}
+	return requested
+}
+
+// assocGroup echoes the client's association group, or invents one when it asked
+// the server to.
+//
+// A client sends zero to mean "give me a group"; the value is opaque and only has
+// to be non-zero, since this endpoint keeps no per-group state to look up.
+func assocGroup(requested uint32) uint32 {
+	if requested == 0 {
+		return defaultAssocGroup
+	}
+	return requested
+}
+
+// defaultAssocGroup is the association group handed out when a client asks for
+// one.
+const defaultAssocGroup = 0x00001234
+
+// The bind_nak reject reasons ([C706] 12.6.4.5).
+const (
+	bindNakReasonNotSpecified              uint16 = 0
+	bindNakProtocolVersionNotSupported     uint16 = 4
+	bindNakAuthenticationTypeNotRecognized uint16 = 8
+)
+
+// The presentation context results and rejection reasons ([C706] 12.6.4.4).
+const (
+	contextResultAcceptance        uint16 = 0
+	contextResultProviderRejection uint16 = 2
+
+	contextReasonAbstractSyntaxNotSupported   uint16 = 1
+	contextReasonTransferSyntaxesNotSupported uint16 = 2
+)

--- a/network/dcerpc/v5/rpcserver/rpcserver_test.go
+++ b/network/dcerpc/v5/rpcserver/rpcserver_test.go
@@ -1,0 +1,638 @@
+package rpcserver
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/pdu"
+	"github.com/TheManticoreProject/Manticore/windows/guid"
+)
+
+// testSyntax is an interface identifier used only here. It is not any real
+// interface's, so a test cannot pass by accident against a registered one.
+func testSyntax() syntax.SyntaxID {
+	return syntax.SyntaxID{
+		UUID:         guid.GUID{A: 0x11112222, B: 0x3333, C: 0x4444, D: 0x5555, E: 0x666677778888},
+		MajorVersion: 2,
+		MinorVersion: 1,
+	}
+}
+
+// otherSyntax is a second identifier, for the interface a Dispatcher does not
+// serve.
+func otherSyntax() syntax.SyntaxID {
+	return syntax.SyntaxID{
+		UUID:         guid.GUID{A: 0x99990000, B: 0xaaaa, C: 0xbbbb, D: 0xcccc, E: 0xddddeeeeffff},
+		MajorVersion: 1,
+		MinorVersion: 0,
+	}
+}
+
+// stubService answers one opnum with a fixed stub and reports the errors a
+// Service is allowed to report for the others.
+type stubService struct {
+	answer []byte
+
+	// calls counts the calls made, to check that a refused PDU never reaches the
+	// interface.
+	mutex sync.Mutex
+	calls int
+}
+
+func (s *stubService) AbstractSyntax() syntax.SyntaxID { return testSyntax() }
+
+func (s *stubService) Call(opnum uint16, stub []byte) ([]byte, error) {
+	s.mutex.Lock()
+	s.calls++
+	s.mutex.Unlock()
+
+	switch opnum {
+	case 0:
+		return s.answer, nil
+	case 1:
+		return nil, ErrBadStub
+	case 2:
+		return nil, errors.New("something else went wrong")
+	default:
+		return nil, ErrUnknownOpnum
+	}
+}
+
+func (s *stubService) callCount() int {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	return s.calls
+}
+
+// bindRequest builds a bind PDU offering one context per abstract syntax given,
+// each offering NDR20.
+func bindRequest(t *testing.T, callID uint32, maxRecvFrag uint16, abstracts ...syntax.SyntaxID) []byte {
+	t.Helper()
+
+	contexts := make([]pdu.ContextElement, 0, len(abstracts))
+	for i, abstract := range abstracts {
+		contexts = append(contexts, pdu.ContextElement{
+			ContextID:        uint16(i),
+			AbstractSyntax:   abstract,
+			TransferSyntaxes: []syntax.SyntaxID{syntax.NDRTransferSyntax()},
+		})
+	}
+
+	bind := &pdu.Bind{
+		Header:      pdu.NewHeader(pdu.PacketTypeBind, pdu.PFCFirstFrag|pdu.PFCLastFrag, callID),
+		MaxXmitFrag: maxRecvFrag,
+		MaxRecvFrag: maxRecvFrag,
+		ContextList: contexts,
+	}
+	encoded, err := bind.Marshal()
+	if err != nil {
+		t.Fatalf("failed to marshal the bind: %v", err)
+	}
+	return encoded
+}
+
+// callRequest builds a complete, unfragmented request PDU.
+func callRequest(t *testing.T, callID uint32, opnum uint16, stub []byte) []byte {
+	t.Helper()
+
+	request := &pdu.Request{
+		Header: pdu.NewHeader(pdu.PacketTypeRequest, pdu.PFCFirstFrag|pdu.PFCLastFrag, callID),
+		Opnum:  opnum,
+		Stub:   stub,
+	}
+	encoded, err := request.Marshal()
+	if err != nil {
+		t.Fatalf("failed to marshal the request: %v", err)
+	}
+	return encoded
+}
+
+// splitPDUs walks a reply that may hold several PDUs back to back, as a byte
+// stream transport delivers them, and returns each one.
+func splitPDUs(t *testing.T, stream []byte) [][]byte {
+	t.Helper()
+
+	pdus := [][]byte{}
+	for offset := 0; offset < len(stream); {
+		header, err := pdu.PeekHeader(stream[offset:])
+		if err != nil {
+			t.Fatalf("failed to read the header of the PDU at offset %d: %v", offset, err)
+		}
+		length := int(header.FragLength)
+		if length < pdu.HeaderSize || offset+length > len(stream) {
+			t.Fatalf("PDU at offset %d claims a length of %d, which does not fit in the %d bytes remaining",
+				offset, length, len(stream)-offset)
+		}
+		pdus = append(pdus, stream[offset:offset+length])
+		offset += length
+	}
+	return pdus
+}
+
+func TestBindAcceptsTheServedInterface(t *testing.T) {
+	dispatcher := New(&stubService{})
+
+	reply, err := dispatcher.Handle(bindRequest(t, 7, 4280, testSyntax()))
+	if err != nil {
+		t.Fatalf("Handle returned an error for a well-formed bind: %v", err)
+	}
+
+	ack := &pdu.BindAck{}
+	if _, err := ack.Unmarshal(reply); err != nil {
+		t.Fatalf("the reply is not a bind_ack: %v", err)
+	}
+	if ack.Header.CallID != 7 {
+		t.Errorf("the bind_ack carries call id %d, want the request's 7", ack.Header.CallID)
+	}
+	if !ack.Header.PacketFlags.Has(pdu.PFCFirstFrag) || !ack.Header.PacketFlags.Has(pdu.PFCLastFrag) {
+		t.Errorf("the bind_ack is flagged %s, want both PFC_FIRST_FRAG and PFC_LAST_FRAG", ack.Header.PacketFlags)
+	}
+	if len(ack.Results) != 1 {
+		t.Fatalf("the bind_ack carries %d results, want one per offered context (1)", len(ack.Results))
+	}
+	if ack.Results[0].Result != pdu.ResultAcceptance {
+		t.Errorf("the context was answered with result %d, want acceptance (%d)",
+			ack.Results[0].Result, pdu.ResultAcceptance)
+	}
+	if !ack.Results[0].TransferSyntax.Equal(syntax.NDRTransferSyntax()) {
+		t.Errorf("the accepted transfer syntax is %v, want NDR20", ack.Results[0].TransferSyntax)
+	}
+	if ack.AssocGroupID == 0 {
+		t.Error("the bind_ack reports association group 0, but a client that asked for one needs a non-zero group")
+	}
+	if !ack.Accepted() {
+		t.Error("BindAck.Accepted reports the bind was not accepted")
+	}
+}
+
+func TestBindRejectsTheContextNamingAnotherInterfaceAndKeepsTheServedOne(t *testing.T) {
+	dispatcher := New(&stubService{})
+
+	// Two contexts, the second naming an interface this endpoint does not serve.
+	// Both get a result, positionally, per [C706] 12.6.4.4.
+	reply, err := dispatcher.Handle(bindRequest(t, 1, 4280, testSyntax(), otherSyntax()))
+	if err != nil {
+		t.Fatalf("Handle returned an error: %v", err)
+	}
+
+	ack := &pdu.BindAck{}
+	if _, err := ack.Unmarshal(reply); err != nil {
+		t.Fatalf("the reply is not a bind_ack: %v", err)
+	}
+	if len(ack.Results) != 2 {
+		t.Fatalf("the bind_ack carries %d results, want one per offered context (2)", len(ack.Results))
+	}
+	if ack.Results[0].Result != pdu.ResultAcceptance {
+		t.Errorf("the first context was answered with result %d, want acceptance", ack.Results[0].Result)
+	}
+	if ack.Results[1].Result != pdu.ResultProviderRejection {
+		t.Errorf("the second context was answered with result %d, want provider rejection (%d)",
+			ack.Results[1].Result, pdu.ResultProviderRejection)
+	}
+	if ack.Results[1].Reason != pdu.ReasonAbstractSyntaxNotSupported {
+		t.Errorf("the second context was rejected for reason %d, want abstract syntax not supported (%d)",
+			ack.Results[1].Reason, pdu.ReasonAbstractSyntaxNotSupported)
+	}
+}
+
+func TestBindNamingOnlyAnotherInterfaceIsRefused(t *testing.T) {
+	dispatcher := New(&stubService{})
+
+	reply, err := dispatcher.Handle(bindRequest(t, 2, 4280, otherSyntax()))
+	if err != nil {
+		t.Fatalf("Handle returned an error: %v", err)
+	}
+
+	nak := &pdu.BindNak{}
+	if _, err := nak.Unmarshal(reply); err != nil {
+		t.Fatalf("a bind naming no served interface was not answered with a bind_nak: %v", err)
+	}
+	if nak.Header.CallID != 2 {
+		t.Errorf("the bind_nak carries call id %d, want the request's 2", nak.Header.CallID)
+	}
+	if len(nak.Versions) == 0 {
+		t.Error("the bind_nak names no protocol version, so a client cannot tell what to retry with")
+	}
+}
+
+func TestBindOfferingOnlyNDR64IsRefused(t *testing.T) {
+	dispatcher := New(&stubService{})
+
+	// NDR64 ([MS-RPCE] 2.2.4.4). Accepting it and then encoding NDR20 would hand
+	// the client a reply it decodes as the wrong shape.
+	ndr64 := syntax.SyntaxID{
+		UUID:         guid.GUID{A: 0x71710533, B: 0xbeba, C: 0x4937, D: 0x8319, E: 0xb5dbef9ccc36},
+		MajorVersion: 1,
+		MinorVersion: 0,
+	}
+
+	bind := &pdu.Bind{
+		Header:      pdu.NewHeader(pdu.PacketTypeBind, pdu.PFCFirstFrag|pdu.PFCLastFrag, 3),
+		MaxXmitFrag: 4280,
+		MaxRecvFrag: 4280,
+		ContextList: []pdu.ContextElement{{
+			ContextID:        0,
+			AbstractSyntax:   testSyntax(),
+			TransferSyntaxes: []syntax.SyntaxID{ndr64},
+		}},
+	}
+	encoded, err := bind.Marshal()
+	if err != nil {
+		t.Fatalf("failed to marshal the bind: %v", err)
+	}
+
+	reply, err := dispatcher.Handle(encoded)
+	if err != nil {
+		t.Fatalf("Handle returned an error: %v", err)
+	}
+	nak := &pdu.BindNak{}
+	if _, err := nak.Unmarshal(reply); err != nil {
+		t.Fatalf("a bind offering only NDR64 was not answered with a bind_nak: %v", err)
+	}
+}
+
+func TestAuthenticatedBindIsRefused(t *testing.T) {
+	dispatcher := New(&stubService{})
+
+	bind := &pdu.Bind{
+		Header:      pdu.NewHeader(pdu.PacketTypeBind, pdu.PFCFirstFrag|pdu.PFCLastFrag, 4),
+		MaxXmitFrag: 4280,
+		MaxRecvFrag: 4280,
+		ContextList: []pdu.ContextElement{{
+			ContextID:        0,
+			AbstractSyntax:   testSyntax(),
+			TransferSyntaxes: []syntax.SyntaxID{syntax.NDRTransferSyntax()},
+		}},
+		SecTrailer: pdu.SecTrailer{AuthType: 10, AuthLevel: 6},
+		AuthValue:  []byte("NTLMSSP\x00 a negotiate token"),
+	}
+	encoded, err := bind.Marshal()
+	if err != nil {
+		t.Fatalf("failed to marshal the bind: %v", err)
+	}
+
+	reply, err := dispatcher.Handle(encoded)
+	if err != nil {
+		t.Fatalf("Handle returned an error: %v", err)
+	}
+
+	nak := &pdu.BindNak{}
+	if _, err := nak.Unmarshal(reply); err != nil {
+		t.Fatalf("an authenticated bind was not answered with a bind_nak: %v", err)
+	}
+	if nak.RejectReason != bindNakAuthenticationTypeNotRecognized {
+		t.Errorf("the bind_nak reports reason %d, want authentication type not recognized (%d)",
+			nak.RejectReason, bindNakAuthenticationTypeNotRecognized)
+	}
+}
+
+func TestAlterContextIsAnsweredWithAnAlterContextResponse(t *testing.T) {
+	dispatcher := New(&stubService{})
+
+	bind := &pdu.Bind{
+		Header:      pdu.NewHeader(pdu.PacketTypeBind, pdu.PFCFirstFrag|pdu.PFCLastFrag, 5),
+		MaxXmitFrag: 4280,
+		MaxRecvFrag: 4280,
+		ContextList: []pdu.ContextElement{{
+			ContextID:        1,
+			AbstractSyntax:   testSyntax(),
+			TransferSyntaxes: []syntax.SyntaxID{syntax.NDRTransferSyntax()},
+		}},
+	}
+	encoded, err := bind.Marshal()
+	if err != nil {
+		t.Fatalf("failed to marshal the bind: %v", err)
+	}
+	// Rewrite the packet type in place: Bind.Marshal forces PacketTypeBind, and
+	// an alter_context has the same body.
+	encoded[2] = byte(pdu.PacketTypeAlterContext)
+
+	reply, err := dispatcher.Handle(encoded)
+	if err != nil {
+		t.Fatalf("Handle returned an error: %v", err)
+	}
+
+	header, err := pdu.PeekHeader(reply)
+	if err != nil {
+		t.Fatalf("failed to read the reply header: %v", err)
+	}
+	if header.PacketType != pdu.PacketTypeAlterContextResp {
+		t.Errorf("an alter_context was answered with %s, want %s",
+			header.PacketType, pdu.PacketTypeAlterContextResp)
+	}
+}
+
+func TestRequestReturnsTheInterfacesStub(t *testing.T) {
+	service := &stubService{answer: []byte("0123456789abcdef")}
+	dispatcher := New(service)
+
+	if _, err := dispatcher.Handle(bindRequest(t, 1, 4280, testSyntax())); err != nil {
+		t.Fatalf("the bind failed: %v", err)
+	}
+
+	reply, err := dispatcher.Handle(callRequest(t, 9, 0, []byte("in")))
+	if err != nil {
+		t.Fatalf("Handle returned an error for a well-formed request: %v", err)
+	}
+
+	response := &pdu.Response{}
+	if _, err := response.Unmarshal(reply); err != nil {
+		t.Fatalf("the reply is not a response: %v", err)
+	}
+	if response.Header.CallID != 9 {
+		t.Errorf("the response carries call id %d, want the request's 9", response.Header.CallID)
+	}
+	if !bytes.Equal(response.Stub, service.answer) {
+		t.Errorf("the response carries stub % x, want the interface's % x", response.Stub, service.answer)
+	}
+	if response.AllocHint != uint32(len(service.answer)) {
+		t.Errorf("the response's alloc_hint is %d, want the stub length %d",
+			response.AllocHint, len(service.answer))
+	}
+}
+
+func TestRequestFaultStatuses(t *testing.T) {
+	cases := []struct {
+		name   string
+		opnum  uint16
+		status uint32
+	}{
+		{"an opnum the interface does not implement", 42, pdu.NCASOpRngError},
+		{"a stub the interface cannot decode", 1, pdu.NCASFaultNDR},
+		{"any other failure in the interface", 2, pdu.NCASProtoError},
+	}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			dispatcher := New(&stubService{})
+
+			reply, err := dispatcher.Handle(callRequest(t, 1, test.opnum, nil))
+			if err != nil {
+				t.Fatalf("Handle returned an error instead of framing a fault: %v", err)
+			}
+
+			fault := &pdu.Fault{}
+			if _, err := fault.Unmarshal(reply); err != nil {
+				t.Fatalf("the reply is not a fault: %v", err)
+			}
+			if fault.Status != test.status {
+				t.Errorf("the fault reports %s, want %s",
+					pdu.FaultStatus(fault.Status), pdu.FaultStatus(test.status))
+			}
+		})
+	}
+}
+
+func TestFragmentedRequestIsRefusedWithoutReachingTheInterface(t *testing.T) {
+	service := &stubService{answer: []byte("unreachable")}
+	dispatcher := New(service)
+
+	// PFC_FIRST_FRAG without PFC_LAST_FRAG: the first fragment of a request whose
+	// stub is incomplete. Handing it to the interface would decode a fragment as
+	// a whole stub.
+	request := &pdu.Request{
+		Header: pdu.NewHeader(pdu.PacketTypeRequest, pdu.PFCFirstFrag, 1),
+		Opnum:  0,
+		Stub:   []byte("half a st"),
+	}
+	encoded, err := request.Marshal()
+	if err != nil {
+		t.Fatalf("failed to marshal the request: %v", err)
+	}
+
+	reply, err := dispatcher.Handle(encoded)
+	if err != nil {
+		t.Fatalf("Handle returned an error instead of framing a fault: %v", err)
+	}
+
+	fault := &pdu.Fault{}
+	if _, err := fault.Unmarshal(reply); err != nil {
+		t.Fatalf("a fragmented request was not answered with a fault: %v", err)
+	}
+	if fault.Status != pdu.NCASProtoError {
+		t.Errorf("the fault reports %s, want %s", pdu.FaultStatus(fault.Status), pdu.FaultStatus(pdu.NCASProtoError))
+	}
+	if service.callCount() != 0 {
+		t.Errorf("the interface was called %d times for a fragmented request, want 0", service.callCount())
+	}
+}
+
+func TestUnexpectedPacketTypeIsFaulted(t *testing.T) {
+	dispatcher := New(&stubService{})
+
+	// An auth3 PDU, which only an authenticated association uses and which this
+	// endpoint never negotiates.
+	auth3 := &pdu.Auth3{
+		Header:     pdu.NewHeader(pdu.PacketTypeAuth3, pdu.PFCFirstFrag|pdu.PFCLastFrag, 11),
+		SecTrailer: pdu.SecTrailer{AuthType: 10, AuthLevel: 6},
+		AuthValue:  []byte("a token"),
+	}
+	encoded, err := auth3.Marshal()
+	if err != nil {
+		t.Fatalf("failed to marshal the auth3: %v", err)
+	}
+
+	reply, err := dispatcher.Handle(encoded)
+	if err != nil {
+		t.Fatalf("Handle returned an error instead of framing a fault: %v", err)
+	}
+
+	fault := &pdu.Fault{}
+	if _, err := fault.Unmarshal(reply); err != nil {
+		t.Fatalf("an auth3 was not answered with a fault: %v", err)
+	}
+	if fault.Header.CallID != 11 {
+		t.Errorf("the fault carries call id %d, want the request's 11", fault.Header.CallID)
+	}
+}
+
+func TestSomethingThatIsNotAPDUIsRejected(t *testing.T) {
+	dispatcher := New(&stubService{})
+
+	if _, err := dispatcher.Handle([]byte("not a PDU")); err == nil {
+		t.Error("Handle accepted nine bytes that are not a PDU")
+	}
+}
+
+func TestLargeResponseIsFragmentedAndReassembles(t *testing.T) {
+	// A stub several times the fragment size, with a recognisable pattern so a
+	// reassembly that loses or duplicates a chunk shows up as a mismatch rather
+	// than as the right length of the wrong bytes.
+	answer := make([]byte, 3*DefaultMaxFragment+37)
+	for i := range answer {
+		answer[i] = byte(i * 7)
+	}
+
+	service := &stubService{answer: answer}
+	dispatcher := New(service)
+	if _, err := dispatcher.Handle(bindRequest(t, 1, 4280, testSyntax())); err != nil {
+		t.Fatalf("the bind failed: %v", err)
+	}
+
+	reply, err := dispatcher.Handle(callRequest(t, 2, 0, nil))
+	if err != nil {
+		t.Fatalf("Handle returned an error: %v", err)
+	}
+
+	fragments := splitPDUs(t, reply)
+	if len(fragments) < 4 {
+		t.Fatalf("a %d-byte stub was sent in %d fragments at a %d-byte fragment size, want at least 4",
+			len(answer), len(fragments), DefaultMaxFragment)
+	}
+
+	reassembled := []byte{}
+	for i, fragment := range fragments {
+		response := &pdu.Response{}
+		if _, err := response.Unmarshal(fragment); err != nil {
+			t.Fatalf("fragment %d is not a response: %v", i, err)
+		}
+		if len(fragment) > DefaultMaxFragment {
+			t.Errorf("fragment %d is %d bytes, past the %d-byte fragment size the bind agreed",
+				i, len(fragment), DefaultMaxFragment)
+		}
+
+		first := response.Header.PacketFlags.Has(pdu.PFCFirstFrag)
+		last := response.Header.PacketFlags.Has(pdu.PFCLastFrag)
+		if want := i == 0; first != want {
+			t.Errorf("fragment %d has PFC_FIRST_FRAG %v, want %v", i, first, want)
+		}
+		if want := i == len(fragments)-1; last != want {
+			t.Errorf("fragment %d has PFC_LAST_FRAG %v, want %v", i, last, want)
+		}
+		if want := uint32(len(answer) - len(reassembled)); response.AllocHint != want {
+			t.Errorf("fragment %d reports alloc_hint %d, want the %d bytes still to come",
+				i, response.AllocHint, want)
+		}
+		if !last && len(response.Stub)%8 != 0 {
+			t.Errorf("fragment %d carries %d stub bytes, which is not a multiple of 8 and so moves the alignment of what follows",
+				i, len(response.Stub))
+		}
+		reassembled = append(reassembled, response.Stub...)
+	}
+
+	if !bytes.Equal(reassembled, answer) {
+		t.Errorf("the reassembled stub is %d bytes and does not match the %d the interface returned",
+			len(reassembled), len(answer))
+	}
+}
+
+func TestASmallerFragmentSizeIsHonouredForEveryClientOfTheEndpoint(t *testing.T) {
+	answer := make([]byte, 4096)
+	service := &stubService{answer: answer}
+	dispatcher := New(service)
+
+	// One client says it can only take 1024-byte fragments. The endpoint cannot
+	// tell two opens apart, so that bound has to apply to the whole endpoint: a
+	// fragment smaller than a client's maximum is always acceptable, a larger one
+	// is not.
+	if _, err := dispatcher.Handle(bindRequest(t, 1, 1024, testSyntax())); err != nil {
+		t.Fatalf("the first bind failed: %v", err)
+	}
+	if _, err := dispatcher.Handle(bindRequest(t, 2, 4280, testSyntax())); err != nil {
+		t.Fatalf("the second bind failed: %v", err)
+	}
+
+	reply, err := dispatcher.Handle(callRequest(t, 3, 0, nil))
+	if err != nil {
+		t.Fatalf("Handle returned an error: %v", err)
+	}
+
+	for i, fragment := range splitPDUs(t, reply) {
+		if len(fragment) > 1024 {
+			t.Errorf("fragment %d is %d bytes, past the 1024 the smaller client asked for", i, len(fragment))
+		}
+	}
+}
+
+func TestAnAbsurdFragmentSizeFallsBackToTheDefault(t *testing.T) {
+	dispatcher := New(&stubService{answer: make([]byte, 8192)})
+
+	// A max_recv_frag of 4 leaves no room for a PDU header, let alone a stub. It
+	// is a client that filled the field in wrongly, and answering at that size
+	// would make progress impossible.
+	reply, err := dispatcher.Handle(bindRequest(t, 1, 4, testSyntax()))
+	if err != nil {
+		t.Fatalf("the bind failed: %v", err)
+	}
+
+	ack := &pdu.BindAck{}
+	if _, err := ack.Unmarshal(reply); err != nil {
+		t.Fatalf("the reply is not a bind_ack: %v", err)
+	}
+	if ack.MaxRecvFrag != DefaultMaxFragment {
+		t.Errorf("the bind_ack agreed a fragment size of %d, want the default %d", ack.MaxRecvFrag, DefaultMaxFragment)
+	}
+}
+
+func TestMultiInterfaceEndpointRefusesARequest(t *testing.T) {
+	// Two interfaces on one endpoint. A request names its context by an
+	// identifier assigned in a bind, and without per-open state there is no
+	// table to look it up in, so the request cannot be attributed.
+	other := &secondService{}
+	dispatcher := New(&stubService{answer: []byte("x")}, other)
+
+	reply, err := dispatcher.Handle(callRequest(t, 1, 0, nil))
+	if err != nil {
+		t.Fatalf("Handle returned an error instead of framing a fault: %v", err)
+	}
+
+	fault := &pdu.Fault{}
+	if _, err := fault.Unmarshal(reply); err != nil {
+		t.Fatalf("the reply is not a fault: %v", err)
+	}
+	if fault.Status != pdu.NCASUnkIf {
+		t.Errorf("the fault reports %s, want %s", pdu.FaultStatus(fault.Status), pdu.FaultStatus(pdu.NCASUnkIf))
+	}
+}
+
+// secondService is a second interface, used to build an endpoint that serves
+// more than one.
+type secondService struct{}
+
+func (s *secondService) AbstractSyntax() syntax.SyntaxID { return otherSyntax() }
+func (s *secondService) Call(opnum uint16, stub []byte) ([]byte, error) {
+	return nil, ErrUnknownOpnum
+}
+
+func TestConcurrentClientsOfOneEndpoint(t *testing.T) {
+	// One Dispatcher serves every open of its endpoint, and the SMB server calls
+	// a pipe handler on the goroutine of whichever connection is asking. Binds
+	// and requests therefore overlap, which is what this checks under -race.
+	dispatcher := New(&stubService{answer: make([]byte, 2048)})
+
+	var waiting sync.WaitGroup
+	for client := 0; client < 8; client++ {
+		waiting.Add(1)
+		go func(client int) {
+			defer waiting.Done()
+			for round := 0; round < 20; round++ {
+				callID := uint32(client*100 + round)
+				if _, err := dispatcher.Handle(bindRequest(t, callID, uint16(1024+client*64), testSyntax())); err != nil {
+					t.Errorf("client %d: the bind failed: %v", client, err)
+					return
+				}
+				if _, err := dispatcher.Handle(callRequest(t, callID, 0, nil)); err != nil {
+					t.Errorf("client %d: the request failed: %v", client, err)
+					return
+				}
+			}
+		}(client)
+	}
+	waiting.Wait()
+}
+
+func TestErrorsAreDistinguishable(t *testing.T) {
+	// A Service reports the two conditions the Dispatcher maps to specific faults
+	// by wrapping these sentinels, so wrapping has to survive errors.Is.
+	wrapped := fmt.Errorf("decoding the parameters: %w", ErrBadStub)
+	if !errors.Is(wrapped, ErrBadStub) {
+		t.Error("a wrapped ErrBadStub is not recognised by errors.Is")
+	}
+	if errors.Is(wrapped, ErrUnknownOpnum) {
+		t.Error("a wrapped ErrBadStub is mistaken for ErrUnknownOpnum")
+	}
+}

--- a/network/smb/smb_v10/server/doc.go
+++ b/network/smb/smb_v10/server/doc.go
@@ -315,6 +315,11 @@
 // bounded by maxPipeAnswerSize, because only the server knows how the client will
 // read the rest.
 //
+// Package rpcpipe, in the subdirectory of the same name, is a PipeHandler that
+// answers the srvsvc and wkssvc RPC interfaces, which is what a client calls to
+// list a host's shares and to identify it. A caller that wants a browsable server
+// registers an IPC$ share carrying one rather than writing DCE/RPC by hand.
+//
 // # Character encoding
 //
 // Unicode is a per-message property, not a per-connection one: SMB_FLAGS2_UNICODE

--- a/network/smb/smb_v10/server/rpcpipe/doc.go
+++ b/network/smb/smb_v10/server/rpcpipe/doc.go
@@ -1,0 +1,48 @@
+// Package rpcpipe makes an SMB1 IPC$ share answer RPC calls.
+//
+// It supplies the PipeHandler that network/smb/smb_v10/server defines but does
+// not implement: register an IPC$ share, give it a Handler, and a client that
+// opens \srvsvc or \wkssvc on it reaches a working RPC endpoint. Without it a
+// caller has to write DCE/RPC framing and NDR by hand before a server is
+// browsable.
+//
+//	srv, err := server.NewServer(server.Config{})
+//	srv.AddShare(&server.Share{Name: "PUBLIC", FS: fs, Comment: "Public files"})
+//	srv.AddShare(&server.Share{
+//	    Name:  "IPC$",
+//	    Type:  server.ShareTypeNamedPipe,
+//	    Pipes: rpcpipe.ForServer(srv, rpcpipe.Options{ServerName: "MANTICORE"}),
+//	})
+//
+// It is a package of its own rather than part of the server. The server has no
+// reason to know about DCE/RPC, and a caller who only serves files should not
+// have an RPC stack linked in; the dependency runs from here to the server and
+// never back.
+//
+// # What is served
+//
+// srvsvc NetrShareEnum at information levels 0 and 1, which is the call a client
+// makes to list shares — "net view", "smbclient -L" and Explorer's network
+// browser all arrive through it — and wkssvc NetrWkstaGetInfo at levels 100 and
+// 101, which is what a client asks to identify the host.
+//
+// The shares reported are the server's own when the Handler was built with
+// ForServer, read on each call, so a share added with AddShare afterwards appears
+// in the next enumeration. A caller that wants to report something else supplies
+// Options.Shares instead.
+//
+// Any other opnum faults with nca_s_op_rng_error. Any other information level
+// answers ERROR_INVALID_LEVEL, which is a successful call reporting a refusal
+// rather than a fault, and is what makes a client fall back to a level that is
+// served.
+//
+// # One interface per pipe
+//
+// A pipe here carries exactly one interface: \srvsvc is srvsvc and \wkssvc is
+// wkssvc. That is how both are used, and it is also the only arrangement this can
+// serve — the PipeHandler contract names a pipe by name and not by open handle,
+// so a handler cannot tell two clients of one pipe apart and cannot hold the
+// per-open bind state that a pipe carrying several interfaces would need. A bind
+// is still checked against the interface the pipe carries, and one naming a
+// different interface is refused with a bind_nak.
+package rpcpipe

--- a/network/smb/smb_v10/server/rpcpipe/rpcpipe.go
+++ b/network/smb/smb_v10/server/rpcpipe/rpcpipe.go
@@ -1,0 +1,251 @@
+package rpcpipe
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/TheManticoreProject/Manticore/logger"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/rpcserver"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/server"
+)
+
+// ShareEntry is one share as an enumeration reports it.
+//
+// It is this package's own shape rather than the SMB server's, so a caller can
+// serve a share list that has nothing to do with a running server — a test, or a
+// host whose shares live elsewhere — and the services below depend on a list and
+// not on where the list came from.
+type ShareEntry struct {
+	// Name is the share name a client connects to.
+	Name string
+
+	// Comment is the remark reported beside it.
+	Comment string
+
+	// Type is what the share is, as an STYPE_* value.
+	Type uint32
+}
+
+// Options configures a Handler.
+type Options struct {
+	// ServerName is the host name wkssvc reports. A client displays it.
+	ServerName string
+
+	// DomainName is the workgroup or domain wkssvc reports.
+	DomainName string
+
+	// VersionMajor and VersionMinor are the operating system version wkssvc
+	// reports. Both zero reports 6.1, the version of Windows 7 and Server
+	// 2008 R2, because a client displays the number and one of zero reads as
+	// missing rather than as a version.
+	VersionMajor uint32
+	VersionMinor uint32
+
+	// Shares supplies the shares an enumeration reports, called afresh on each
+	// call so a share added later appears without the handler being told.
+	//
+	// Nil reports an empty list, which is what an endpoint with no share source
+	// should say rather than failing.
+	Shares func() []ShareEntry
+}
+
+// defaultVersionMajor and defaultVersionMinor are the version reported when the
+// caller names none. See Options.VersionMajor.
+const (
+	defaultVersionMajor = 6
+	defaultVersionMinor = 1
+)
+
+// Handler must satisfy the server's pipe contract, which is the whole point of
+// the package: a mismatch is a compile error here rather than a share that
+// refuses every pipe at run time.
+var _ server.PipeHandler = (*Handler)(nil)
+
+// Handler answers RPC calls on the pipes of an IPC$ share.
+//
+// It satisfies the PipeHandler interface of network/smb/smb_v10/server, so a
+// share carrying one serves srvsvc and wkssvc:
+//
+//	srv.AddShare(&server.Share{
+//	    Name:  "IPC$",
+//	    Type:  server.ShareTypeNamedPipe,
+//	    Pipes: rpcpipe.ForServer(srv, rpcpipe.Options{ServerName: "MANTICORE"}),
+//	})
+//
+// A Handler is safe for concurrent use, which it has to be: one is reachable from
+// every connection the server accepts.
+type Handler struct {
+	// endpoints maps a normalised pipe name to the dispatcher answering it. It is
+	// written once by New and only read afterwards.
+	endpoints map[string]*rpcserver.Dispatcher
+
+	// mutex guards opened, the count of opens outstanding per pipe.
+	mutex  sync.Mutex
+	opened map[string]int
+}
+
+// New builds a Handler serving srvsvc and wkssvc.
+//
+// Parameters:
+//   - options: the names to report and where to read shares from
+//
+// Returns:
+//   - The handler
+func New(options Options) *Handler {
+	shares := options.Shares
+	if shares == nil {
+		shares = func() []ShareEntry { return nil }
+	}
+
+	versionMajor, versionMinor := options.VersionMajor, options.VersionMinor
+	if versionMajor == 0 && versionMinor == 0 {
+		versionMajor, versionMinor = defaultVersionMajor, defaultVersionMinor
+	}
+
+	return &Handler{
+		endpoints: map[string]*rpcserver.Dispatcher{
+			"srvsvc": rpcserver.New(&srvsvcService{shares: shares}),
+			"wkssvc": rpcserver.New(&wkssvcService{
+				serverName:   options.ServerName,
+				domainName:   options.DomainName,
+				versionMajor: versionMajor,
+				versionMinor: versionMinor,
+			}),
+		},
+		opened: map[string]int{},
+	}
+}
+
+// ForServer builds a Handler whose share enumeration reports a server's own
+// shares.
+//
+// It fills Options.Shares from the server, leaving anything the caller already
+// set in place, so a share registered with AddShare appears in an enumeration
+// without being described twice.
+//
+// Parameters:
+//   - srv: the server whose shares an enumeration should report
+//   - options: the rest of the configuration
+//
+// Returns:
+//   - The handler
+func ForServer(srv *server.Server, options Options) *Handler {
+	if srv != nil && options.Shares == nil {
+		options.Shares = func() []ShareEntry { return sharesOf(srv) }
+	}
+	return New(options)
+}
+
+// sharesOf converts a server's registered shares into enumeration entries.
+func sharesOf(srv *server.Server) []ShareEntry {
+	registered := srv.Shares()
+	entries := make([]ShareEntry, 0, len(registered))
+	for _, share := range registered {
+		if share == nil {
+			continue
+		}
+		entries = append(entries, ShareEntry{
+			Name:    share.Name,
+			Comment: share.Comment,
+			Type:    ShareTypeOf(share.Name, share.Type),
+		})
+	}
+	return entries
+}
+
+// OpenPipe reports whether a pipe exists under this handler.
+func (h *Handler) OpenPipe(name string) error {
+	endpoint := normalisePipeName(name)
+	if _, served := h.endpoints[endpoint]; !served {
+		return fmt.Errorf("pipe %q is not served", name)
+	}
+
+	h.mutex.Lock()
+	h.opened[endpoint]++
+	h.mutex.Unlock()
+
+	logger.Debugf("rpcpipe: opened %q", endpoint)
+	return nil
+}
+
+// Transact answers one RPC exchange on a pipe.
+//
+// Parameters:
+//   - name: the pipe, without its leading separator or "PIPE" element
+//   - input: the request PDU the client wrote
+//   - maxOutput: the largest answer the caller will take in one exchange
+//
+// Returns:
+//   - The reply PDUs, whether more of the answer remains, and an error only when
+//     the pipe is not served or the request is not a PDU at all
+func (h *Handler) Transact(name string, input []byte, maxOutput int) ([]byte, bool, error) {
+	endpoint := normalisePipeName(name)
+	dispatcher, served := h.endpoints[endpoint]
+	if !served {
+		return nil, false, fmt.Errorf("pipe %q is not served", name)
+	}
+
+	reply, err := dispatcher.Handle(input)
+	if err != nil {
+		return nil, false, fmt.Errorf("pipe %q: %w", endpoint, err)
+	}
+
+	// An answer past the caller's ceiling is cut and reported as incomplete,
+	// which is the contract: the caller tells the client more remains and the
+	// client reads the rest off the handle.
+	if maxOutput > 0 && len(reply) > maxOutput {
+		logger.Debugf("rpcpipe: %q answered with %d bytes, cut to the %d the caller allows",
+			endpoint, len(reply), maxOutput)
+		return reply[:maxOutput], true, nil
+	}
+
+	logger.Debugf("rpcpipe: %q answered %d request bytes with %d", endpoint, len(input), len(reply))
+	return reply, false, nil
+}
+
+// ClosePipe releases what OpenPipe recorded.
+func (h *Handler) ClosePipe(name string) error {
+	endpoint := normalisePipeName(name)
+
+	h.mutex.Lock()
+	if h.opened[endpoint] > 0 {
+		h.opened[endpoint]--
+	}
+	h.mutex.Unlock()
+	return nil
+}
+
+// Pipes returns the pipe names this handler serves, sorted for a stable listing.
+func (h *Handler) Pipes() []string {
+	names := make([]string, 0, len(h.endpoints))
+	for name := range h.endpoints {
+		names = append(names, name)
+	}
+	sortStrings(names)
+	return names
+}
+
+// sortStrings sorts in place. It is an insertion sort because the slice holds two
+// elements and a dependency on sort for that would be noise.
+func sortStrings(values []string) {
+	for i := 1; i < len(values); i++ {
+		for j := i; j > 0 && values[j] < values[j-1]; j-- {
+			values[j], values[j-1] = values[j-1], values[j]
+		}
+	}
+}
+
+// normalisePipeName reduces the forms a client names a pipe in to the endpoint
+// name.
+//
+// The SMB server already strips the leading separator and the PIPE element, but
+// a caller may hand over any of the forms a client sends, and the comparison is
+// case-insensitive because pipe names are.
+func normalisePipeName(name string) string {
+	trimmed := strings.Trim(strings.ReplaceAll(name, `\`, "/"), "/")
+	if upper := strings.ToUpper(trimmed); strings.HasPrefix(upper, "PIPE/") {
+		trimmed = trimmed[len("PIPE/"):]
+	}
+	return strings.ToLower(strings.Trim(trimmed, "/"))
+}

--- a/network/smb/smb_v10/server/rpcpipe/rpcpipe_test.go
+++ b/network/smb/smb_v10/server/rpcpipe/rpcpipe_test.go
@@ -1,0 +1,858 @@
+package rpcpipe
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	srvsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0"
+	srvsvcfunctions "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions"
+	wkssvcfunctions "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/6bffd098-a112-3610-9833-46c3f87e345a/1.0/functions"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/pdu"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/server"
+	mssrvs "github.com/TheManticoreProject/Manticore/windows/protocols/ms-srvs"
+)
+
+// maxPipeAnswer is the ceiling the SMB server passes to Transact. It is not
+// exported by the server, so it is repeated here; a test that used a different
+// value would not be exercising the path a real client takes.
+const maxPipeAnswer = 64 * 1024
+
+// pipeInvoker drives a Handler the way a client does: it marshals a call's
+// parameters, frames a request PDU, hands it to Transact, reassembles the reply
+// fragments and decodes the response stub.
+//
+// It satisfies ndr.Invoker, so the interfaces' own client stubs run against it
+// unchanged. That is the point of testing through it: the client declares the
+// parameter sets privately, and a server that disagreed with them about the wire
+// would fail here rather than only against a real client.
+type pipeInvoker struct {
+	t       *testing.T
+	handler *Handler
+	pipe    string
+	callID  uint32
+}
+
+// bind performs the association's bind and returns the bind_ack.
+func (p *pipeInvoker) bind(abstract syntax.SyntaxID) *pdu.BindAck {
+	p.t.Helper()
+
+	p.callID++
+	bind := &pdu.Bind{
+		Header:      pdu.NewHeader(pdu.PacketTypeBind, pdu.PFCFirstFrag|pdu.PFCLastFrag, p.callID),
+		MaxXmitFrag: 4280,
+		MaxRecvFrag: 4280,
+		ContextList: []pdu.ContextElement{{
+			ContextID:        0,
+			AbstractSyntax:   abstract,
+			TransferSyntaxes: []syntax.SyntaxID{syntax.NDRTransferSyntax()},
+		}},
+	}
+	request, err := bind.Marshal()
+	if err != nil {
+		p.t.Fatalf("failed to marshal the bind: %v", err)
+	}
+
+	reply, more, err := p.handler.Transact(p.pipe, request, maxPipeAnswer)
+	if err != nil {
+		p.t.Fatalf("Transact refused the bind on %q: %v", p.pipe, err)
+	}
+	if more {
+		p.t.Fatalf("a bind_ack of %d bytes was reported as incomplete", len(reply))
+	}
+
+	header, err := pdu.PeekHeader(reply)
+	if err != nil {
+		p.t.Fatalf("the bind reply is not a PDU: %v", err)
+	}
+	if header.PacketType != pdu.PacketTypeBindAck {
+		p.t.Fatalf("the bind on %q was answered with %s, want bind_ack", p.pipe, header.PacketType)
+	}
+
+	ack := &pdu.BindAck{}
+	if _, err := ack.Unmarshal(reply); err != nil {
+		p.t.Fatalf("failed to decode the bind_ack: %v", err)
+	}
+	return ack
+}
+
+// Invoke runs one call over the pipe.
+func (p *pipeInvoker) Invoke(in ndr.Call, out any) error {
+	stub, err := ndr.Request(in)
+	if err != nil {
+		return fmt.Errorf("marshal the request stub: %w", err)
+	}
+
+	p.callID++
+	request := &pdu.Request{
+		Header: pdu.NewHeader(pdu.PacketTypeRequest, pdu.PFCFirstFrag|pdu.PFCLastFrag, p.callID),
+		Opnum:  in.Opnum(),
+		Stub:   stub,
+	}
+	framed, err := request.Marshal()
+	if err != nil {
+		return fmt.Errorf("marshal the request PDU: %w", err)
+	}
+
+	reply, more, err := p.handler.Transact(p.pipe, framed, maxPipeAnswer)
+	if err != nil {
+		return fmt.Errorf("transact on %q: %w", p.pipe, err)
+	}
+	if more {
+		return fmt.Errorf("the answer was cut at %d bytes, which this test's ceiling should not do", len(reply))
+	}
+
+	answer, err := reassemble(reply)
+	if err != nil {
+		return err
+	}
+	if err := ndr.Unmarshal(answer, out); err != nil {
+		return fmt.Errorf("unmarshal the response stub: %w", err)
+	}
+	return nil
+}
+
+// reassemble joins the response fragments of a reply, and reports a fault as an
+// error naming its status.
+func reassemble(stream []byte) ([]byte, error) {
+	stub := []byte{}
+
+	for offset := 0; offset < len(stream); {
+		header, err := pdu.PeekHeader(stream[offset:])
+		if err != nil {
+			return nil, fmt.Errorf("the PDU at offset %d has no readable header: %w", offset, err)
+		}
+		length := int(header.FragLength)
+		if length < pdu.HeaderSize || offset+length > len(stream) {
+			return nil, fmt.Errorf("the PDU at offset %d claims %d bytes, past the %d remaining",
+				offset, length, len(stream)-offset)
+		}
+		fragment := stream[offset : offset+length]
+		offset += length
+
+		switch header.PacketType {
+		case pdu.PacketTypeResponse:
+			response := &pdu.Response{}
+			if _, err := response.Unmarshal(fragment); err != nil {
+				return nil, fmt.Errorf("failed to decode a response fragment: %w", err)
+			}
+			stub = append(stub, response.Stub...)
+
+		case pdu.PacketTypeFault:
+			fault := &pdu.Fault{}
+			if _, err := fault.Unmarshal(fragment); err != nil {
+				return nil, fmt.Errorf("failed to decode a fault: %w", err)
+			}
+			return nil, fmt.Errorf("the call faulted with %s", pdu.FaultStatus(fault.Status))
+
+		default:
+			return nil, fmt.Errorf("the reply carries a %s PDU", header.PacketType)
+		}
+	}
+
+	return stub, nil
+}
+
+// testHandler builds a Handler over a fixed share list.
+func testHandler(shares ...ShareEntry) *Handler {
+	return New(Options{
+		ServerName: "MANTICORE",
+		DomainName: "WORKGROUP",
+		Shares:     func() []ShareEntry { return shares },
+	})
+}
+
+// sampleShares is a share list with the shapes that matter: an ordinary disk
+// share with a remark, an administrative share, a printer, and one with no
+// remark at all.
+func sampleShares() []ShareEntry {
+	return []ShareEntry{
+		{Name: "PUBLIC", Comment: "Public files", Type: STYPE_DISKTREE},
+		{Name: "IPC$", Comment: "Remote IPC", Type: STYPE_IPC | STYPE_SPECIAL},
+		{Name: "PRINTER", Comment: "The printer", Type: STYPE_PRINTQ},
+		{Name: "SCRATCH", Type: STYPE_DISKTREE},
+	}
+}
+
+func TestHandlerSatisfiesThePipeContract(t *testing.T) {
+	// The compile-time assertion in the package covers the method set; this
+	// checks the behaviour the server relies on: a pipe it serves opens, one it
+	// does not is refused rather than silently accepted.
+	handler := testHandler()
+
+	for _, name := range []string{"srvsvc", "wkssvc", `\PIPE\srvsvc`, "PIPE/wkssvc", "SrvSvc"} {
+		if err := handler.OpenPipe(name); err != nil {
+			t.Errorf("OpenPipe(%q) failed: %v", name, err)
+			continue
+		}
+		if err := handler.ClosePipe(name); err != nil {
+			t.Errorf("ClosePipe(%q) failed: %v", name, err)
+		}
+	}
+
+	for _, name := range []string{"lsarpc", "samr", "", "srvsvc2"} {
+		if err := handler.OpenPipe(name); err == nil {
+			t.Errorf("OpenPipe(%q) succeeded for a pipe this handler does not serve", name)
+		}
+	}
+}
+
+func TestPipesServed(t *testing.T) {
+	got := testHandler().Pipes()
+	want := []string{"srvsvc", "wkssvc"}
+
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("Pipes reports %v, want %v", got, want)
+	}
+}
+
+func TestTransactOnAnUnservedPipeFails(t *testing.T) {
+	handler := testHandler()
+
+	if _, _, err := handler.Transact("lsarpc", []byte{0}, maxPipeAnswer); err == nil {
+		t.Error("Transact answered on a pipe the handler does not serve")
+	}
+}
+
+func TestBindOnEachPipeNamesItsOwnInterface(t *testing.T) {
+	handler := testHandler(sampleShares()...)
+
+	// The srvsvc pipe accepts srvsvc and refuses wkssvc, and the other way
+	// round. That is the whole of what one-interface-per-pipe means, and it is
+	// what a client relies on to discover it opened the wrong pipe.
+	cases := []struct {
+		pipe     string
+		abstract syntax.SyntaxID
+		accepted bool
+	}{
+		{"srvsvc", srvsvcSyntax(), true},
+		{"srvsvc", wkssvcSyntax(), false},
+		{"wkssvc", wkssvcSyntax(), true},
+		{"wkssvc", srvsvcSyntax(), false},
+	}
+
+	for _, test := range cases {
+		name := fmt.Sprintf("%s pipe binding %s", test.pipe, test.abstract.UUID.ToFormatD())
+		t.Run(name, func(t *testing.T) {
+			bind := &pdu.Bind{
+				Header:      pdu.NewHeader(pdu.PacketTypeBind, pdu.PFCFirstFrag|pdu.PFCLastFrag, 1),
+				MaxXmitFrag: 4280,
+				MaxRecvFrag: 4280,
+				ContextList: []pdu.ContextElement{{
+					AbstractSyntax:   test.abstract,
+					TransferSyntaxes: []syntax.SyntaxID{syntax.NDRTransferSyntax()},
+				}},
+			}
+			request, err := bind.Marshal()
+			if err != nil {
+				t.Fatalf("failed to marshal the bind: %v", err)
+			}
+
+			reply, _, err := handler.Transact(test.pipe, request, maxPipeAnswer)
+			if err != nil {
+				t.Fatalf("Transact failed: %v", err)
+			}
+			header, err := pdu.PeekHeader(reply)
+			if err != nil {
+				t.Fatalf("the reply is not a PDU: %v", err)
+			}
+
+			want := pdu.PacketTypeBindNak
+			if test.accepted {
+				want = pdu.PacketTypeBindAck
+			}
+			if header.PacketType != want {
+				t.Errorf("the bind was answered with %s, want %s", header.PacketType, want)
+			}
+		})
+	}
+}
+
+func srvsvcSyntax() syntax.SyntaxID { return srvsvc.SyntaxID() }
+
+func wkssvcSyntax() syntax.SyntaxID {
+	return (&wkssvcService{}).AbstractSyntax()
+}
+
+func TestNetrShareEnumLevel1ReportsEveryShare(t *testing.T) {
+	shares := sampleShares()
+	handler := testHandler(shares...)
+
+	rpc := &pipeInvoker{t: t, handler: handler, pipe: "srvsvc"}
+	rpc.bind(srvsvcSyntax())
+
+	info, total, resume, err := srvsvcfunctions.NetrShareEnum(rpc, "",
+		mssrvs.SHARE_ENUM_STRUCT{Level: 1, ShareInfo: mssrvs.SHARE_ENUM_UNION{Tag: 1}},
+		maxPreferredLength, nil)
+	if err != nil {
+		t.Fatalf("NetrShareEnum at level 1 failed: %v", err)
+	}
+
+	if int(total) != len(shares) {
+		t.Errorf("TotalEntries is %d, want the %d shares registered", total, len(shares))
+	}
+	if resume != nil {
+		t.Errorf("a resume handle of %d came back for a call that sent none", *resume)
+	}
+	if info.Level != 1 || info.ShareInfo.Tag != 1 {
+		t.Errorf("the answer reports level %d and union tag %d, want 1 and 1", info.Level, info.ShareInfo.Tag)
+	}
+
+	container := info.ShareInfo.Level1
+	if container == nil {
+		t.Fatal("the level 1 container is a null pointer, so no shares came back")
+	}
+	if int(container.EntriesRead) != len(shares) || len(container.Buffer) != len(shares) {
+		t.Fatalf("the container reports %d entries and carries %d, want %d of each",
+			container.EntriesRead, len(container.Buffer), len(shares))
+	}
+
+	for i, want := range shares {
+		got := container.Buffer[i]
+		if string(got.Shi1Netname) != want.Name {
+			t.Errorf("entry %d is named %q, want %q", i, got.Shi1Netname, want.Name)
+		}
+		if uint32(got.Shi1Type) != want.Type {
+			t.Errorf("entry %d (%s) has type 0x%08X, want 0x%08X", i, want.Name, got.Shi1Type, want.Type)
+		}
+		if string(got.Shi1Remark) != want.Comment {
+			t.Errorf("entry %d (%s) has remark %q, want %q", i, want.Name, got.Shi1Remark, want.Comment)
+		}
+	}
+}
+
+func TestNetrShareEnumLevel0ReportsNamesOnly(t *testing.T) {
+	shares := sampleShares()
+	rpc := &pipeInvoker{t: t, handler: testHandler(shares...), pipe: "srvsvc"}
+	rpc.bind(srvsvcSyntax())
+
+	info, total, _, err := srvsvcfunctions.NetrShareEnum(rpc, "",
+		mssrvs.SHARE_ENUM_STRUCT{Level: 0, ShareInfo: mssrvs.SHARE_ENUM_UNION{Tag: 0}},
+		maxPreferredLength, nil)
+	if err != nil {
+		t.Fatalf("NetrShareEnum at level 0 failed: %v", err)
+	}
+	if int(total) != len(shares) {
+		t.Errorf("TotalEntries is %d, want %d", total, len(shares))
+	}
+
+	container := info.ShareInfo.Level0
+	if container == nil {
+		t.Fatal("the level 0 container is a null pointer")
+	}
+	if info.ShareInfo.Level1 != nil {
+		t.Error("the level 1 container is also set, so the union carries two arms")
+	}
+	if len(container.Buffer) != len(shares) {
+		t.Fatalf("the container carries %d entries, want %d", len(container.Buffer), len(shares))
+	}
+	for i, want := range shares {
+		if string(container.Buffer[i].Shi0Netname) != want.Name {
+			t.Errorf("entry %d is named %q, want %q", i, container.Buffer[i].Shi0Netname, want.Name)
+		}
+	}
+}
+
+func TestNetrShareEnumOnAnEmptyServer(t *testing.T) {
+	// A server with no shares answers an empty list, not a failure: that is how
+	// a client learns there is nothing to browse.
+	rpc := &pipeInvoker{t: t, handler: testHandler(), pipe: "srvsvc"}
+	rpc.bind(srvsvcSyntax())
+
+	info, total, _, err := srvsvcfunctions.NetrShareEnum(rpc, "",
+		mssrvs.SHARE_ENUM_STRUCT{Level: 1, ShareInfo: mssrvs.SHARE_ENUM_UNION{Tag: 1}},
+		maxPreferredLength, nil)
+	if err != nil {
+		t.Fatalf("NetrShareEnum on a server with no shares failed: %v", err)
+	}
+	if total != 0 {
+		t.Errorf("TotalEntries is %d, want 0", total)
+	}
+	if info.ShareInfo.Level1 == nil {
+		t.Fatal("the level 1 container is a null pointer, want an empty one")
+	}
+	if len(info.ShareInfo.Level1.Buffer) != 0 {
+		t.Errorf("the container carries %d entries, want none", len(info.ShareInfo.Level1.Buffer))
+	}
+}
+
+func TestNetrShareEnumWithNoShareSourceReportsNone(t *testing.T) {
+	// Options.Shares left nil. Reporting nothing is the honest answer for an
+	// endpoint with no share source, and a nil call would panic on the
+	// connection's goroutine.
+	rpc := &pipeInvoker{t: t, handler: New(Options{}), pipe: "srvsvc"}
+	rpc.bind(srvsvcSyntax())
+
+	_, total, _, err := srvsvcfunctions.NetrShareEnum(rpc, "",
+		mssrvs.SHARE_ENUM_STRUCT{Level: 1, ShareInfo: mssrvs.SHARE_ENUM_UNION{Tag: 1}},
+		maxPreferredLength, nil)
+	if err != nil {
+		t.Fatalf("NetrShareEnum with no share source failed: %v", err)
+	}
+	if total != 0 {
+		t.Errorf("TotalEntries is %d, want 0", total)
+	}
+}
+
+func TestNetrShareEnumRefusesAnUnservedLevel(t *testing.T) {
+	rpc := &pipeInvoker{t: t, handler: testHandler(sampleShares()...), pipe: "srvsvc"}
+	rpc.bind(srvsvcSyntax())
+
+	// Level 2 has a union arm this does not fill, and level 99 has none at all.
+	// Both are a successful call reporting ERROR_INVALID_LEVEL, which is what
+	// makes a client fall back rather than give up.
+	for _, level := range []ndr.DWORD{2, 502, 99} {
+		t.Run(fmt.Sprintf("level %d", level), func(t *testing.T) {
+			_, _, _, err := srvsvcfunctions.NetrShareEnum(rpc, "",
+				mssrvs.SHARE_ENUM_STRUCT{Level: level, ShareInfo: mssrvs.SHARE_ENUM_UNION{Tag: level}},
+				maxPreferredLength, nil)
+			if err == nil {
+				t.Fatalf("level %d was answered as if it were served", level)
+			}
+			if !strings.Contains(err.Error(), "ERROR_INVALID_LEVEL") {
+				t.Errorf("level %d failed with %v, want ERROR_INVALID_LEVEL", level, err)
+			}
+		})
+	}
+}
+
+func TestNetrShareEnumUnknownOpnumFaults(t *testing.T) {
+	handler := testHandler(sampleShares()...)
+
+	// NetrShareAdd, opnum 14, which this does not implement.
+	request := &pdu.Request{
+		Header: pdu.NewHeader(pdu.PacketTypeRequest, pdu.PFCFirstFrag|pdu.PFCLastFrag, 1),
+		Opnum:  srvsvc.OpnumNetrShareAdd,
+		Stub:   make([]byte, 16),
+	}
+	framed, err := request.Marshal()
+	if err != nil {
+		t.Fatalf("failed to marshal the request: %v", err)
+	}
+
+	reply, _, err := handler.Transact("srvsvc", framed, maxPipeAnswer)
+	if err != nil {
+		t.Fatalf("Transact failed: %v", err)
+	}
+	if _, err := reassemble(reply); err == nil {
+		t.Fatal("an opnum the interface does not implement was answered with a response")
+	} else if !strings.Contains(err.Error(), "nca_s_op_rng_error") {
+		t.Errorf("the call failed with %v, want a fault of nca_s_op_rng_error", err)
+	}
+}
+
+func TestNetrShareEnumUndecodableStubFaults(t *testing.T) {
+	handler := testHandler(sampleShares()...)
+
+	// Three bytes where a SHARE_ENUM_STRUCT and three more parameters belong.
+	request := &pdu.Request{
+		Header: pdu.NewHeader(pdu.PacketTypeRequest, pdu.PFCFirstFrag|pdu.PFCLastFrag, 1),
+		Opnum:  srvsvc.OpnumNetrShareEnum,
+		Stub:   []byte{1, 2, 3},
+	}
+	framed, err := request.Marshal()
+	if err != nil {
+		t.Fatalf("failed to marshal the request: %v", err)
+	}
+
+	reply, _, err := handler.Transact("srvsvc", framed, maxPipeAnswer)
+	if err != nil {
+		t.Fatalf("Transact failed: %v", err)
+	}
+	if _, err := reassemble(reply); err == nil {
+		t.Fatal("a stub that cannot be decoded was answered with a response")
+	} else if !strings.Contains(err.Error(), "nca_s_fault_ndr") {
+		t.Errorf("the call failed with %v, want a fault of nca_s_fault_ndr", err)
+	}
+}
+
+func TestNetrShareEnumResumesWhereItStopped(t *testing.T) {
+	// A budget too small for the whole list makes the enumeration report part of
+	// it with ERROR_MORE_DATA and a resume handle, which the client sends back to
+	// continue. Walking it to the end has to yield every share exactly once.
+	shares := sampleShares()
+	rpc := &pipeInvoker{t: t, handler: testHandler(shares...), pipe: "srvsvc"}
+	rpc.bind(srvsvcSyntax())
+
+	handle := ndr.DWORD(0)
+	seen := []string{}
+
+	for round := 0; round < len(shares)+2; round++ {
+		info, total, resume, err := srvsvcfunctions.NetrShareEnum(rpc, "",
+			mssrvs.SHARE_ENUM_STRUCT{Level: 1, ShareInfo: mssrvs.SHARE_ENUM_UNION{Tag: 1}},
+			48, &handle)
+		if err != nil {
+			t.Fatalf("round %d failed: %v", round, err)
+		}
+		if resume == nil {
+			t.Fatalf("round %d came back with no resume handle for a call that sent one", round)
+		}
+
+		container := info.ShareInfo.Level1
+		if container == nil {
+			t.Fatalf("round %d came back with a null container", round)
+		}
+		if len(container.Buffer) == 0 {
+			t.Fatalf("round %d reported no entries, so the enumeration cannot advance", round)
+		}
+		for _, entry := range container.Buffer {
+			seen = append(seen, string(entry.Shi1Netname))
+		}
+
+		if *resume == 0 {
+			// The enumeration finished: the last answer carried the remainder.
+			if int(total) != len(container.Buffer) {
+				t.Errorf("the final round reports %d entries remaining but carried %d",
+					total, len(container.Buffer))
+			}
+			break
+		}
+		handle = *resume
+	}
+
+	if want := []string{"PUBLIC", "IPC$", "PRINTER", "SCRATCH"}; strings.Join(seen, ",") != strings.Join(want, ",") {
+		t.Errorf("walking the enumeration saw %v, want %v exactly once each", seen, want)
+	}
+}
+
+func TestNetrShareEnumResumeHandlePastTheEndFinishes(t *testing.T) {
+	// A share removed between two calls can leave a handle past the end. The
+	// enumeration is over, and saying so is what lets the client stop.
+	rpc := &pipeInvoker{t: t, handler: testHandler(sampleShares()...), pipe: "srvsvc"}
+	rpc.bind(srvsvcSyntax())
+
+	handle := ndr.DWORD(9999)
+	info, total, resume, err := srvsvcfunctions.NetrShareEnum(rpc, "",
+		mssrvs.SHARE_ENUM_STRUCT{Level: 1, ShareInfo: mssrvs.SHARE_ENUM_UNION{Tag: 1}},
+		maxPreferredLength, &handle)
+	if err != nil {
+		t.Fatalf("a resume handle past the end failed: %v", err)
+	}
+	if total != 0 {
+		t.Errorf("TotalEntries is %d, want 0 from a handle past the end", total)
+	}
+	if resume == nil || *resume != 0 {
+		t.Errorf("the resume handle came back as %v, want 0 to end the enumeration", resume)
+	}
+	if info.ShareInfo.Level1 == nil || len(info.ShareInfo.Level1.Buffer) != 0 {
+		t.Error("the answer carries entries for a handle past the end")
+	}
+}
+
+func TestNetrShareEnumFragmentsALongList(t *testing.T) {
+	// A share list well past one fragment, so the reply is several response PDUs
+	// that the client reassembles. Reporting the whole list in one exchange is
+	// what MAX_PREFERRED_LENGTH asks for, so the fragmentation is the server's
+	// problem and not the client's.
+	shares := make([]ShareEntry, 0, 200)
+	for i := 0; i < 200; i++ {
+		shares = append(shares, ShareEntry{
+			Name:    fmt.Sprintf("SHARE%03d", i),
+			Comment: fmt.Sprintf("share number %d, with a remark long enough to matter", i),
+			Type:    STYPE_DISKTREE,
+		})
+	}
+
+	handler := testHandler(shares...)
+	rpc := &pipeInvoker{t: t, handler: handler, pipe: "srvsvc"}
+	rpc.bind(srvsvcSyntax())
+
+	info, total, _, err := srvsvcfunctions.NetrShareEnum(rpc, "",
+		mssrvs.SHARE_ENUM_STRUCT{Level: 1, ShareInfo: mssrvs.SHARE_ENUM_UNION{Tag: 1}},
+		maxPreferredLength, nil)
+	if err != nil {
+		t.Fatalf("NetrShareEnum over a long list failed: %v", err)
+	}
+	if int(total) != len(shares) {
+		t.Errorf("TotalEntries is %d, want %d", total, len(shares))
+	}
+
+	container := info.ShareInfo.Level1
+	if container == nil {
+		t.Fatal("the container is a null pointer")
+	}
+	if len(container.Buffer) != len(shares) {
+		t.Fatalf("the container carries %d entries, want %d", len(container.Buffer), len(shares))
+	}
+	for i, want := range shares {
+		if string(container.Buffer[i].Shi1Netname) != want.Name {
+			t.Fatalf("entry %d is named %q, want %q — the fragments did not reassemble in order",
+				i, container.Buffer[i].Shi1Netname, want.Name)
+		}
+	}
+}
+
+func TestNetrWkstaGetInfoLevel100(t *testing.T) {
+	rpc := &pipeInvoker{t: t, handler: testHandler(), pipe: "wkssvc"}
+	rpc.bind(wkssvcSyntax())
+
+	info, err := wkssvcfunctions.NetrWkstaGetInfo(rpc, nil, 100)
+	if err != nil {
+		t.Fatalf("NetrWkstaGetInfo at level 100 failed: %v", err)
+	}
+	if info.Tag != 100 {
+		t.Errorf("the union tag is %d, want 100", info.Tag)
+	}
+
+	level := info.WkstaInfo100
+	if level == nil {
+		t.Fatal("the level 100 arm is a null pointer")
+	}
+	if level.Wki100_platform_id != platformIDNT {
+		t.Errorf("the platform id is %d, want PLATFORM_ID_NT (%d)", level.Wki100_platform_id, platformIDNT)
+	}
+	if level.Wki100_computername == nil || string(*level.Wki100_computername) != "MANTICORE" {
+		t.Errorf("the computer name is %v, want MANTICORE", level.Wki100_computername)
+	}
+	if level.Wki100_langroup == nil || string(*level.Wki100_langroup) != "WORKGROUP" {
+		t.Errorf("the workgroup is %v, want WORKGROUP", level.Wki100_langroup)
+	}
+	if level.Wki100_ver_major != defaultVersionMajor || level.Wki100_ver_minor != defaultVersionMinor {
+		t.Errorf("the version is %d.%d, want the default %d.%d",
+			level.Wki100_ver_major, level.Wki100_ver_minor, defaultVersionMajor, defaultVersionMinor)
+	}
+}
+
+func TestNetrWkstaGetInfoLevel101(t *testing.T) {
+	handler := New(Options{ServerName: "HOST", DomainName: "LAB", VersionMajor: 10, VersionMinor: 0})
+	rpc := &pipeInvoker{t: t, handler: handler, pipe: "wkssvc"}
+	rpc.bind(wkssvcSyntax())
+
+	info, err := wkssvcfunctions.NetrWkstaGetInfo(rpc, nil, 101)
+	if err != nil {
+		t.Fatalf("NetrWkstaGetInfo at level 101 failed: %v", err)
+	}
+
+	level := info.WkstaInfo101
+	if level == nil {
+		t.Fatal("the level 101 arm is a null pointer")
+	}
+	if info.WkstaInfo100 != nil {
+		t.Error("the level 100 arm is also set, so the union carries two arms")
+	}
+	if level.Wki101_computername == nil || string(*level.Wki101_computername) != "HOST" {
+		t.Errorf("the computer name is %v, want HOST", level.Wki101_computername)
+	}
+	if level.Wki101_ver_major != 10 || level.Wki101_ver_minor != 0 {
+		t.Errorf("the version is %d.%d, want the configured 10.0", level.Wki101_ver_major, level.Wki101_ver_minor)
+	}
+	// The LAN root is a Windows redirector path, which this host has none of.
+	// A null pointer says so; an empty string would claim it has one that is
+	// nameless.
+	if level.Wki101_lanroot != nil {
+		t.Errorf("the LAN root is %q, want a null pointer", *level.Wki101_lanroot)
+	}
+}
+
+func TestNetrWkstaGetInfoWithNoNamesConfigured(t *testing.T) {
+	rpc := &pipeInvoker{t: t, handler: New(Options{}), pipe: "wkssvc"}
+	rpc.bind(wkssvcSyntax())
+
+	info, err := wkssvcfunctions.NetrWkstaGetInfo(rpc, nil, 100)
+	if err != nil {
+		t.Fatalf("NetrWkstaGetInfo failed: %v", err)
+	}
+	if info.WkstaInfo100 == nil {
+		t.Fatal("the level 100 arm is a null pointer")
+	}
+	if info.WkstaInfo100.Wki100_computername != nil {
+		t.Errorf("the computer name is %q, want a null pointer when none is configured",
+			*info.WkstaInfo100.Wki100_computername)
+	}
+}
+
+func TestNetrWkstaGetInfoRefusesAnUnservedLevel(t *testing.T) {
+	rpc := &pipeInvoker{t: t, handler: testHandler(), pipe: "wkssvc"}
+	rpc.bind(wkssvcSyntax())
+
+	for _, level := range []ndr.DWORD{102, 502, 1013, 0} {
+		t.Run(fmt.Sprintf("level %d", level), func(t *testing.T) {
+			_, err := wkssvcfunctions.NetrWkstaGetInfo(rpc, nil, level)
+			if err == nil {
+				t.Fatalf("level %d was answered as if it were served", level)
+			}
+			if !strings.Contains(err.Error(), "ERROR_INVALID_LEVEL") {
+				t.Errorf("level %d failed with %v, want ERROR_INVALID_LEVEL", level, err)
+			}
+		})
+	}
+}
+
+func TestForServerReportsTheServersOwnShares(t *testing.T) {
+	srv, err := server.NewServer(server.Config{})
+	if err != nil {
+		t.Fatalf("failed to build a server: %v", err)
+	}
+
+	pipes := ForServer(srv, Options{ServerName: "MANTICORE"})
+	if err := srv.AddShare(&server.Share{
+		Name:  "IPC$",
+		Type:  server.ShareTypeNamedPipe,
+		Pipes: pipes,
+	}); err != nil {
+		t.Fatalf("failed to add IPC$: %v", err)
+	}
+	if err := srv.AddShare(&server.Share{
+		Name:    "PUBLIC",
+		Type:    server.ShareTypeDisk,
+		Comment: "Public files",
+		FS:      server.NewMemoryFileSystem(""),
+	}); err != nil {
+		t.Fatalf("failed to add PUBLIC: %v", err)
+	}
+
+	rpc := &pipeInvoker{t: t, handler: pipes, pipe: "srvsvc"}
+	rpc.bind(srvsvcSyntax())
+
+	info, _, _, err := srvsvcfunctions.NetrShareEnum(rpc, "",
+		mssrvs.SHARE_ENUM_STRUCT{Level: 1, ShareInfo: mssrvs.SHARE_ENUM_UNION{Tag: 1}},
+		maxPreferredLength, nil)
+	if err != nil {
+		t.Fatalf("NetrShareEnum failed: %v", err)
+	}
+	container := info.ShareInfo.Level1
+	if container == nil {
+		t.Fatal("the container is a null pointer")
+	}
+
+	// Shares come out of a map, so the order is not fixed; what matters is that
+	// both are there with the right type.
+	types := map[string]uint32{}
+	remarks := map[string]string{}
+	for _, entry := range container.Buffer {
+		types[string(entry.Shi1Netname)] = uint32(entry.Shi1Type)
+		remarks[string(entry.Shi1Netname)] = string(entry.Shi1Remark)
+	}
+
+	if got, want := types["IPC$"], STYPE_IPC|STYPE_SPECIAL; got != want {
+		t.Errorf("IPC$ is reported as type 0x%08X, want 0x%08X", got, want)
+	}
+	if got, want := types["PUBLIC"], STYPE_DISKTREE; got != want {
+		t.Errorf("PUBLIC is reported as type 0x%08X, want 0x%08X", got, want)
+	}
+	if got := remarks["PUBLIC"]; got != "Public files" {
+		t.Errorf("PUBLIC's remark is %q, want %q", got, "Public files")
+	}
+
+	// A share added after the handler was built appears in the next enumeration,
+	// because the share list is read on each call.
+	if err := srv.AddShare(&server.Share{
+		Name: "LATER",
+		Type: server.ShareTypeDisk,
+		FS:   server.NewMemoryFileSystem(""),
+	}); err != nil {
+		t.Fatalf("failed to add LATER: %v", err)
+	}
+
+	info, _, _, err = srvsvcfunctions.NetrShareEnum(rpc, "",
+		mssrvs.SHARE_ENUM_STRUCT{Level: 1, ShareInfo: mssrvs.SHARE_ENUM_UNION{Tag: 1}},
+		maxPreferredLength, nil)
+	if err != nil {
+		t.Fatalf("the second NetrShareEnum failed: %v", err)
+	}
+	found := false
+	for _, entry := range info.ShareInfo.Level1.Buffer {
+		if string(entry.Shi1Netname) == "LATER" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("a share added after the handler was built does not appear in an enumeration")
+	}
+}
+
+func TestForServerWithoutAServerReportsNoShares(t *testing.T) {
+	rpc := &pipeInvoker{t: t, handler: ForServer(nil, Options{}), pipe: "srvsvc"}
+	rpc.bind(srvsvcSyntax())
+
+	_, total, _, err := srvsvcfunctions.NetrShareEnum(rpc, "",
+		mssrvs.SHARE_ENUM_STRUCT{Level: 1, ShareInfo: mssrvs.SHARE_ENUM_UNION{Tag: 1}},
+		maxPreferredLength, nil)
+	if err != nil {
+		t.Fatalf("NetrShareEnum failed: %v", err)
+	}
+	if total != 0 {
+		t.Errorf("TotalEntries is %d, want 0", total)
+	}
+}
+
+func TestShareTypeOf(t *testing.T) {
+	cases := []struct {
+		name      string
+		shareType server.ShareType
+		want      uint32
+	}{
+		{"PUBLIC", server.ShareTypeDisk, STYPE_DISKTREE},
+		{"C$", server.ShareTypeDisk, STYPE_DISKTREE | STYPE_SPECIAL},
+		{"IPC$", server.ShareTypeNamedPipe, STYPE_IPC | STYPE_SPECIAL},
+		{"PRINT", server.ShareTypePrinter, STYPE_PRINTQ},
+		{"PRINT$", server.ShareTypePrinter, STYPE_PRINTQ | STYPE_SPECIAL},
+		{"ODD", server.ShareTypeAny, STYPE_DISKTREE},
+	}
+
+	for _, test := range cases {
+		if got := ShareTypeOf(test.name, test.shareType); got != test.want {
+			t.Errorf("ShareTypeOf(%q, %q) is 0x%08X, want 0x%08X", test.name, test.shareType, got, test.want)
+		}
+		if got := ShareTypeOf(test.name, test.shareType) & STYPE_MASK; got > STYPE_IPC {
+			t.Errorf("ShareTypeOf(%q, %q) masks to kind %d, which is not a share kind",
+				test.name, test.shareType, got)
+		}
+	}
+}
+
+func TestConcurrentClientsOfOnePipe(t *testing.T) {
+	// The SMB server calls a pipe handler on the goroutine of whichever
+	// connection is asking, and one handler serves every connection. Under -race
+	// this is what proves the handler can be shared.
+	handler := testHandler(sampleShares()...)
+
+	var waiting sync.WaitGroup
+	for client := 0; client < 8; client++ {
+		waiting.Add(1)
+		go func(client int) {
+			defer waiting.Done()
+
+			pipe := "srvsvc"
+			if client%2 == 1 {
+				pipe = "wkssvc"
+			}
+			if err := handler.OpenPipe(pipe); err != nil {
+				t.Errorf("client %d: OpenPipe failed: %v", client, err)
+				return
+			}
+			defer func() {
+				if err := handler.ClosePipe(pipe); err != nil {
+					t.Errorf("client %d: ClosePipe failed: %v", client, err)
+				}
+			}()
+
+			rpc := &pipeInvoker{t: t, handler: handler, pipe: pipe, callID: uint32(client) * 1000}
+			if pipe == "srvsvc" {
+				rpc.bind(srvsvcSyntax())
+			} else {
+				rpc.bind(wkssvcSyntax())
+			}
+
+			for round := 0; round < 10; round++ {
+				if pipe == "srvsvc" {
+					if _, _, _, err := srvsvcfunctions.NetrShareEnum(rpc, "",
+						mssrvs.SHARE_ENUM_STRUCT{Level: 1, ShareInfo: mssrvs.SHARE_ENUM_UNION{Tag: 1}},
+						maxPreferredLength, nil); err != nil {
+						t.Errorf("client %d round %d: NetrShareEnum failed: %v", client, round, err)
+						return
+					}
+					continue
+				}
+				if _, err := wkssvcfunctions.NetrWkstaGetInfo(rpc, nil, 100); err != nil {
+					t.Errorf("client %d round %d: NetrWkstaGetInfo failed: %v", client, round, err)
+					return
+				}
+			}
+		}(client)
+	}
+	waiting.Wait()
+}

--- a/network/smb/smb_v10/server/rpcpipe/sharetype.go
+++ b/network/smb/smb_v10/server/rpcpipe/sharetype.go
@@ -1,0 +1,65 @@
+package rpcpipe
+
+import (
+	"strings"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/server"
+)
+
+// Share types reported by a share enumeration ([MS-SRVS] 2.2.2.4).
+//
+// The low byte names the kind of resource and the high bits carry flags, which is
+// why STYPE_MASK exists: a client reads the kind by masking, so a share that is
+// both a disk tree and administrative reports 0x80000000 and not some third kind.
+const (
+	// STYPE_DISKTREE is a disk directory tree.
+	STYPE_DISKTREE uint32 = 0x00000000
+
+	// STYPE_PRINTQ is a print queue.
+	STYPE_PRINTQ uint32 = 0x00000001
+
+	// STYPE_DEVICE is a communication device.
+	STYPE_DEVICE uint32 = 0x00000002
+
+	// STYPE_IPC is an interprocess communication share, which is what IPC$ is.
+	STYPE_IPC uint32 = 0x00000003
+
+	// STYPE_MASK selects the resource kind out of a share type.
+	STYPE_MASK uint32 = 0x000000FF
+
+	// STYPE_TEMPORARY marks a share that is not persisted.
+	STYPE_TEMPORARY uint32 = 0x40000000
+
+	// STYPE_SPECIAL marks an administrative share: one whose name ends in "$"
+	// and which a client hides from an ordinary listing.
+	STYPE_SPECIAL uint32 = 0x80000000
+)
+
+// ShareTypeOf reports the STYPE_* value for a server share.
+//
+// The flag bits are part of the answer and not a decoration: a client decides
+// whether to show a share in a browse listing from STYPE_SPECIAL, so reporting
+// IPC$ or C$ without it makes an administrative share look like an ordinary one.
+//
+// Parameters:
+//   - name: the share name, which decides whether it is administrative
+//   - shareType: the share's Service string
+//
+// Returns:
+//   - The share type an enumeration should report
+func ShareTypeOf(name string, shareType server.ShareType) uint32 {
+	reported := STYPE_DISKTREE
+	switch shareType {
+	case server.ShareTypeNamedPipe:
+		reported = STYPE_IPC
+	case server.ShareTypePrinter:
+		reported = STYPE_PRINTQ
+	}
+
+	// A name ending in "$" is administrative by convention, which is the only
+	// thing that marks one: SMB carries no separate flag for it.
+	if strings.HasSuffix(name, "$") {
+		reported |= STYPE_SPECIAL
+	}
+	return reported
+}

--- a/network/smb/smb_v10/server/rpcpipe/srvsvc.go
+++ b/network/smb/smb_v10/server/rpcpipe/srvsvc.go
@@ -1,0 +1,224 @@
+package rpcpipe
+
+import (
+	"github.com/TheManticoreProject/Manticore/logger"
+	srvsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/rpcserver"
+	mssrvs "github.com/TheManticoreProject/Manticore/windows/protocols/ms-srvs"
+)
+
+// srvsvcService answers the srvsvc interface ([MS-SRVS]).
+//
+// It serves NetrShareEnum and nothing else, because that is the method a client
+// calls to list shares — "net view", "smbclient -L" and Explorer's network
+// browser all reach a host through it. Every other opnum faults with
+// nca_s_op_rng_error, which is what a client expects from a server that does not
+// implement a method.
+type srvsvcService struct {
+	// shares supplies the shares to report, called afresh on each enumeration.
+	shares func() []ShareEntry
+}
+
+// netrShareEnumRequest is the [in] parameter set of NetrShareEnum.
+//
+// It mirrors the client-side declaration in the interface's functions package,
+// which is unexported there. The NDR tags are what matter and they are identical:
+// the two have to agree on the wire or nothing decodes.
+type netrShareEnumRequest struct {
+	ServerName            *ndr.WSTR `ndr:"unique"`
+	InfoStruct            mssrvs.SHARE_ENUM_STRUCT
+	PreferedMaximumLength ndr.DWORD
+	ResumeHandle          *ndr.DWORD `ndr:"unique"`
+}
+
+// netrShareEnumResponse is the [out] parameter set and return value of
+// NetrShareEnum.
+type netrShareEnumResponse struct {
+	InfoStruct   mssrvs.SHARE_ENUM_STRUCT
+	TotalEntries ndr.DWORD
+	ResumeHandle *ndr.DWORD `ndr:"unique"`
+	Status       ndr.DWORD  `ndr:"retval"`
+}
+
+// maxPreferredLength is MAX_PREFERRED_LENGTH, the value a client sends to mean
+// "no limit, send everything" ([MS-SRVS] 2.2.2.1). It is what every ordinary
+// share listing sends.
+const maxPreferredLength = 0xFFFFFFFF
+
+// AbstractSyntax identifies the srvsvc interface, version 3.0.
+func (s *srvsvcService) AbstractSyntax() syntax.SyntaxID {
+	return srvsvc.SyntaxID()
+}
+
+// Call runs one srvsvc method.
+func (s *srvsvcService) Call(opnum uint16, stub []byte) ([]byte, error) {
+	if opnum != srvsvc.OpnumNetrShareEnum {
+		return nil, rpcserver.ErrUnknownOpnum
+	}
+	return s.netrShareEnum(stub)
+}
+
+// netrShareEnum answers NetrShareEnum, opnum 15 ([MS-SRVS] 3.1.4.8).
+//
+// Levels 0 and 1 are served. A level the union knows but this does not — 2, 501,
+// 502 and 503, which describe a share's path, permissions and use counts — is
+// answered with ERROR_INVALID_LEVEL rather than a fault, because an unsupported
+// information level is a successful call reporting a refusal and a client falls
+// back to a lower level when it sees one.
+func (s *srvsvcService) netrShareEnum(stub []byte) ([]byte, error) {
+	var request netrShareEnumRequest
+	if err := ndr.Unmarshal(stub, &request); err != nil {
+		logger.Debugf("rpcpipe: srvsvc NetrShareEnum stub would not decode: %v", err)
+		return nil, rpcserver.ErrBadStub
+	}
+
+	level := uint32(request.InfoStruct.Level)
+	if level != 0 && level != 1 {
+		logger.Debugf("rpcpipe: srvsvc NetrShareEnum asked for level %d, which is not served", level)
+		return ndr.Marshal(&netrShareEnumResponse{
+			InfoStruct: mssrvs.SHARE_ENUM_STRUCT{
+				Level:     ndr.DWORD(level),
+				ShareInfo: mssrvs.SHARE_ENUM_UNION{Tag: ndr.DWORD(level)},
+			},
+			ResumeHandle: echoResumeHandle(request.ResumeHandle, 0),
+			Status:       ndr.DWORD(srvsvc.ERROR_INVALID_LEVEL),
+		})
+	}
+
+	// A resume handle past the end is not an error: the enumeration has simply
+	// finished, and answering an empty list is how a client learns that.
+	all := s.shares()
+	from := 0
+	if request.ResumeHandle != nil {
+		from = int(uint32(*request.ResumeHandle))
+	}
+	if from < 0 || from > len(all) {
+		from = len(all)
+	}
+	remaining := all[from:]
+
+	// The client's budget is a preference, not a limit on the wire: it asks for
+	// an answer of about that size and takes a resume handle for the rest.
+	// MAX_PREFERRED_LENGTH waives it, which is what an ordinary listing sends.
+	sent := remaining
+	truncated := false
+	if budget := uint32(request.PreferedMaximumLength); budget != maxPreferredLength {
+		sent, truncated = fitEntries(remaining, level, budget)
+	}
+
+	response := &netrShareEnumResponse{
+		InfoStruct:   shareEnumStruct(level, sent),
+		TotalEntries: ndr.DWORD(len(remaining)),
+		Status:       ndr.DWORD(srvsvc.NERR_Success),
+	}
+	if truncated {
+		// ERROR_MORE_DATA with a resume handle is how the enumeration continues.
+		// The handle is an index into the share list, so a share added or removed
+		// between two calls shifts what a resumed enumeration sees; SMB offers no
+		// way to hold an enumeration open across calls, so an index is the whole
+		// of what a resume handle can be.
+		response.Status = ndr.DWORD(srvsvc.ERROR_MORE_DATA)
+		response.ResumeHandle = echoResumeHandle(request.ResumeHandle, uint32(from+len(sent)))
+	} else {
+		response.ResumeHandle = echoResumeHandle(request.ResumeHandle, 0)
+	}
+
+	logger.Debugf("rpcpipe: srvsvc NetrShareEnum level %d reported %d of %d shares from %d",
+		level, len(sent), len(remaining), from)
+	return ndr.Marshal(response)
+}
+
+// shareEnumStruct builds the level's container around a set of entries.
+func shareEnumStruct(level uint32, entries []ShareEntry) mssrvs.SHARE_ENUM_STRUCT {
+	info := mssrvs.SHARE_ENUM_UNION{Tag: ndr.DWORD(level)}
+
+	switch level {
+	case 0:
+		buffer := make([]mssrvs.SHARE_INFO_0, 0, len(entries))
+		for _, entry := range entries {
+			buffer = append(buffer, mssrvs.SHARE_INFO_0{Shi0Netname: ndr.WSTR(entry.Name)})
+		}
+		info.Level0 = &mssrvs.SHARE_INFO_0_CONTAINER{
+			EntriesRead: ndr.DWORD(len(buffer)),
+			Buffer:      buffer,
+		}
+	case 1:
+		buffer := make([]mssrvs.SHARE_INFO_1, 0, len(entries))
+		for _, entry := range entries {
+			buffer = append(buffer, mssrvs.SHARE_INFO_1{
+				Shi1Netname: ndr.WSTR(entry.Name),
+				Shi1Type:    ndr.DWORD(entry.Type),
+				Shi1Remark:  ndr.WSTR(entry.Comment),
+			})
+		}
+		info.Level1 = &mssrvs.SHARE_INFO_1_CONTAINER{
+			EntriesRead: ndr.DWORD(len(buffer)),
+			Buffer:      buffer,
+		}
+	}
+
+	return mssrvs.SHARE_ENUM_STRUCT{Level: ndr.DWORD(level), ShareInfo: info}
+}
+
+// fitEntries returns the longest prefix of entries whose reported size stays
+// within budget, and whether anything was left out.
+//
+// At least one entry is always returned when there is one to return: a budget
+// too small for a single share would otherwise make the enumeration unable to
+// advance, and the client would ask again for the same nothing forever.
+func fitEntries(entries []ShareEntry, level uint32, budget uint32) ([]ShareEntry, bool) {
+	used := uint32(0)
+	for i, entry := range entries {
+		size := entrySize(entry, level)
+		if i > 0 && used+size > budget {
+			return entries[:i], true
+		}
+		used += size
+	}
+	return entries, false
+}
+
+// entrySize is the number of bytes an entry contributes to an enumeration.
+//
+// It counts the entry's own NDR representation: the fixed part of the level's
+// structure, plus the conformant-varying wide strings its members point at. The
+// container's own header is not counted, since the budget the client sends
+// describes the entries it wants.
+func entrySize(entry ShareEntry, level uint32) uint32 {
+	switch level {
+	case 0:
+		// A referent identifier for the name.
+		return 4 + wideStringSize(entry.Name)
+	default:
+		// Referent identifiers for the name and the remark, and the type between
+		// them.
+		return 12 + wideStringSize(entry.Name) + wideStringSize(entry.Comment)
+	}
+}
+
+// wideStringSize is the wire size of a [string] wchar_t* referent under NDR20:
+// the maximum count, offset and actual count, then the characters and the
+// terminator, padded to the next four-byte boundary.
+func wideStringSize(value string) uint32 {
+	characters := uint32(len([]rune(value)) + 1)
+	body := 2 * characters
+	if remainder := body % 4; remainder != 0 {
+		body += 4 - remainder
+	}
+	return 12 + body
+}
+
+// echoResumeHandle returns a resume handle carrying value when the client sent
+// one, and nil when it did not.
+//
+// A client that passed no handle is not asking to resume, and answering with one
+// would be describing a continuation it never requested.
+func echoResumeHandle(requested *ndr.DWORD, value uint32) *ndr.DWORD {
+	if requested == nil {
+		return nil
+	}
+	handle := ndr.DWORD(value)
+	return &handle
+}

--- a/network/smb/smb_v10/server/rpcpipe/wkssvc.go
+++ b/network/smb/smb_v10/server/rpcpipe/wkssvc.go
@@ -1,0 +1,124 @@
+package rpcpipe
+
+import (
+	"github.com/TheManticoreProject/Manticore/logger"
+	wkssvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/6bffd098-a112-3610-9833-46c3f87e345a/1.0"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/rpcserver"
+	mswkst "github.com/TheManticoreProject/Manticore/windows/protocols/ms-wkst"
+)
+
+// wkssvcService answers the wkssvc interface ([MS-WKST]).
+//
+// It serves NetrWkstaGetInfo and nothing else, because that is the method a
+// client calls to identify a host: it is how a browser learns the computer name
+// and the workgroup to file the host under. Every other opnum faults with
+// nca_s_op_rng_error.
+type wkssvcService struct {
+	// serverName and domainName are what the workstation reports itself as.
+	serverName string
+	domainName string
+
+	// versionMajor and versionMinor are the operating system version reported.
+	versionMajor uint32
+	versionMinor uint32
+}
+
+// netrWkstaGetInfoRequest is the [in] parameter set of NetrWkstaGetInfo.
+//
+// It mirrors the client-side declaration in the interface's functions package,
+// which is unexported there.
+type netrWkstaGetInfoRequest struct {
+	ServerName *ndr.WSTR `ndr:"unique"`
+	Level      ndr.DWORD
+}
+
+// netrWkstaGetInfoResponse is the [out] parameter and return value of
+// NetrWkstaGetInfo.
+type netrWkstaGetInfoResponse struct {
+	WkstaInfo mswkst.WKSTA_INFO
+	Status    ndr.DWORD `ndr:"retval"`
+}
+
+// platformIDNT is PLATFORM_ID_NT, the platform identifier every current host
+// reports ([MS-WKST] 2.2.5.1). The older DOS, OS/2 and OSF values describe
+// systems no client still expects to meet.
+const platformIDNT = 500
+
+// AbstractSyntax identifies the wkssvc interface, version 1.0.
+func (s *wkssvcService) AbstractSyntax() syntax.SyntaxID {
+	return wkssvc.SyntaxID()
+}
+
+// Call runs one wkssvc method.
+func (s *wkssvcService) Call(opnum uint16, stub []byte) ([]byte, error) {
+	if opnum != wkssvc.OpnumNetrWkstaGetInfo {
+		return nil, rpcserver.ErrUnknownOpnum
+	}
+	return s.netrWkstaGetInfo(stub)
+}
+
+// netrWkstaGetInfo answers NetrWkstaGetInfo, opnum 0 ([MS-WKST] 3.2.4.1).
+//
+// Levels 100 and 101 are served. Level 100 is what an unprivileged caller gets
+// and what a browser asks for; level 101 adds the LAN root, a path that has no
+// meaning on a host that is not running the Windows redirector, and is reported
+// as empty rather than invented.
+//
+// Every other level — 102 and the 502 and 1013-and-above configuration levels —
+// is answered with ERROR_INVALID_LEVEL. Those describe a workstation's logged-on
+// user count and redirector tuning, which this server has no equivalent of, and
+// reporting zeroes for them would be describing a machine that does not exist.
+func (s *wkssvcService) netrWkstaGetInfo(stub []byte) ([]byte, error) {
+	var request netrWkstaGetInfoRequest
+	if err := ndr.Unmarshal(stub, &request); err != nil {
+		logger.Debugf("rpcpipe: wkssvc NetrWkstaGetInfo stub would not decode: %v", err)
+		return nil, rpcserver.ErrBadStub
+	}
+
+	level := uint32(request.Level)
+	response := &netrWkstaGetInfoResponse{
+		WkstaInfo: mswkst.WKSTA_INFO{Tag: ndr.DWORD(level)},
+		Status:    ndr.DWORD(wkssvc.StatusSuccess),
+	}
+
+	switch level {
+	case 100:
+		response.WkstaInfo.WkstaInfo100 = &mswkst.WKSTA_INFO_100{
+			Wki100_platform_id:  platformIDNT,
+			Wki100_computername: optionalWideString(s.serverName),
+			Wki100_langroup:     optionalWideString(s.domainName),
+			Wki100_ver_major:    ndr.DWORD(s.versionMajor),
+			Wki100_ver_minor:    ndr.DWORD(s.versionMinor),
+		}
+	case 101:
+		response.WkstaInfo.WkstaInfo101 = &mswkst.WKSTA_INFO_101{
+			Wki101_platform_id:  platformIDNT,
+			Wki101_computername: optionalWideString(s.serverName),
+			Wki101_langroup:     optionalWideString(s.domainName),
+			Wki101_ver_major:    ndr.DWORD(s.versionMajor),
+			Wki101_ver_minor:    ndr.DWORD(s.versionMinor),
+			Wki101_lanroot:      nil,
+		}
+	default:
+		logger.Debugf("rpcpipe: wkssvc NetrWkstaGetInfo asked for level %d, which is not served", level)
+		response.Status = ndr.DWORD(wkssvc.ErrorInvalidLevel)
+	}
+
+	return ndr.Marshal(response)
+}
+
+// optionalWideString returns a pointer to a wide string, or nil for the empty
+// one.
+//
+// A name the server does not have is a null pointer and not an empty string: the
+// field is [unique], so null is the representation for "not set", and a client
+// that gets an empty string displays an empty name instead of falling back.
+func optionalWideString(value string) *ndr.WSTR {
+	if value == "" {
+		return nil
+	}
+	wide := ndr.WSTR(value)
+	return &wide
+}


### PR DESCRIPTION
### Linked Issue
`Closes #1150`

### Root Cause
`PipeHandler` was an interface with no implementation. `grep -rn "PipeHandler" network/smb/smb_v10/` returned only the declaration in `handler_pipe.go`, the `Share.Pipes` field, and documentation references. The server's own docs said "a `PipeHandler` is all an RPC service needs to be reachable over SMB1", which was accurate and was also the whole gap: nothing in the tree provided one.

Behind that sat a second gap. `network/dcerpc/` was entirely client-side — `interfaces`, `ms-protocols`, `ndr`, `syntax`, `v4`, `v5/client` — with no bind acceptor and no request dispatcher, so the interface definitions under `network/dcerpc/interfaces/` could be called but not served. A caller who wanted a browsable server had to decode DCE/RPC PDUs, dispatch opnums and encode NDR by hand.

### Fix Description
Two packages, split along the dependency they must not share.

`network/dcerpc/v5/rpcserver` is the server side of what `network/dcerpc/v5/client` sends, and knows nothing about how the bytes arrived. A `Service` is one RPC interface: `AbstractSyntax()` identifying it and `Call(opnum, stub)` running one method. `Dispatcher.Handle` takes one PDU and returns the reply:

- bind and alter_context produce one `PresentationResult` per offered context, positionally per [C706] 12.6.4.4, accepting a context only when its abstract syntax names a registered `Service` and it offers NDR20. NDR64-only and unknown-interface contexts are rejected individually; a bind with nothing acceptable gets a bind_nak.
- An authenticated bind is refused with a bind_nak rather than half-answered. Completing one needs an auth3 exchange and a per-context security context to verify and seal every later request; over an SMB named pipe the pipe is already authenticated by the SMB session.
- request PDUs are dispatched to the interface the endpoint serves, and the reply is fragmented to the size the bind agreed, each fragment's stub kept to a multiple of 8 so a stub's own alignment is not disturbed by where a fragment ends. `ErrUnknownOpnum` and `ErrBadStub` map to `nca_s_op_rng_error` and `nca_s_fault_ndr`; anything else is `nca_s_proto_error`.
- A fragmented *request* is faulted rather than reassembled: reassembly needs per-call state keyed by call id, and the request stubs of these interfaces are an information level and a couple of counts.

`network/smb/smb_v10/server/rpcpipe` is the `PipeHandler`. It maps `\srvsvc` and `\wkssvc` to `Dispatcher`s and serves:

- srvsvc `NetrShareEnum` (opnum 15, [MS-SRVS] 3.1.4.8) at levels 0 and 1, honouring `MAX_PREFERRED_LENGTH`, byte budgets with `ERROR_MORE_DATA` and a resume handle, and answering `ERROR_INVALID_LEVEL` for the levels it does not fill.
- wkssvc `NetrWkstaGetInfo` (opnum 0, [MS-WKST] 3.2.4.1) at levels 100 and 101.
- `STYPE_*` ([MS-SRVS] 2.2.2.4), which did not exist anywhere in the tree, and `ShareTypeOf`, so `IPC$` and `C$` are reported with `STYPE_SPECIAL` — that flag is what a client uses to decide whether to show a share in a browse listing.

`rpcpipe.ForServer(srv, opts)` reads the server's own share table on each call, so a share registered with `AddShare` after the handler was built appears in the next enumeration. The dependency runs from `rpcpipe` to the server and never back: the server gains no DCE/RPC dependency, and a caller who only serves files links no RPC stack.

Two things a reviewer should look at as deliberate choices rather than omissions:

**One interface per pipe.** `PipeHandler` identifies a pipe by name, not by open handle, so a handler cannot tell two clients of one pipe apart and cannot hold per-open bind state. A `Dispatcher` therefore dispatches a request to the single interface its endpoint serves rather than by the presentation context id the request carries, and an endpoint registered with more than one interface faults a request instead of guessing. That is exactly how `\srvsvc` and `\wkssvc` are used. Extending `PipeHandler` to carry a per-open handle is filed separately as #1178.

**The endpoint's fragment size is the smallest any client has asked for.** For the same reason — one `Dispatcher` serves every open of its endpoint — one fragment size has to serve every client. A fragment smaller than a client's `max_recv_frag` is always acceptable to it and a larger one is not, so a client asking for less shrinks the endpoint's fragments for everyone rather than risking a reply another client cannot take. `Dispatcher.maxFragment` is guarded by a mutex, because the SMB server calls a pipe handler on the goroutine of whichever connection is asking.

### How Verified
**Tests:** `go test -race ./network/dcerpc/v5/rpcserver/ ./network/smb/smb_v10/server/rpcpipe/` — 39 tests (53 including subtests), all passing.

The `rpcpipe` tests drive the handler through `pipeInvoker`, an `ndr.Invoker` that marshals a call's parameters, frames a request PDU, calls `Transact` with the same 64 KiB ceiling the SMB server passes, reassembles the response fragments and decodes the stub. That means the interfaces' own client stubs — `srvsvcfunctions.NetrShareEnum`, `wkssvcfunctions.NetrWkstaGetInfo` — run against the server unchanged. Those packages declare their parameter sets unexported, so the server had to mirror them; testing through the client's own stubs is what proves the two agree about the wire rather than agreeing with each other.

**Runtime:** `go build ./...`, `go vet ./network/smb/... ./network/dcerpc/...` and `go test ./network/smb/... ./network/dcerpc/...` are clean.

Two defects were found and fixed while writing the tests:

- `Bind.Unmarshal` refuses a PDU whose packet type is not `bind`, and `BindAck.Marshal` forces `bind_ack`, so every alter_context was answered with a bind_nak. `TestAlterContextIsAnsweredWithAnAlterContextResponse` caught it. Fixed by relabelling the packet type on a copy on the way in and on the encoded reply on the way out — the same move `v5/client/auth.go:254` already makes when it *sends* an alter_context, for the same reason.
- `Dispatcher.maxFragment` was written on every bind with no lock, on the assumption that a bind and a request on one endpoint are ordered by the transport. That is false: one handler serves every connection, and `PipeHandler` is documented as callable concurrently for different connections. `TestConcurrentClientsOfOneEndpoint` and `TestConcurrentClientsOfOnePipe` fail under `-race` without the fix.

### Test Coverage
**Added.**

`network/dcerpc/v5/rpcserver/rpcserver_test.go`:
- `TestBindAcceptsTheServedInterface`, `TestBindRejectsTheContextNamingAnotherInterfaceAndKeepsTheServedOne` (both contexts answered, positionally), `TestBindNamingOnlyAnotherInterfaceIsRefused`, `TestBindOfferingOnlyNDR64IsRefused`, `TestAuthenticatedBindIsRefused`, `TestAlterContextIsAnsweredWithAnAlterContextResponse`
- `TestRequestReturnsTheInterfacesStub`, `TestRequestFaultStatuses` (the three fault mappings), `TestFragmentedRequestIsRefusedWithoutReachingTheInterface`, `TestUnexpectedPacketTypeIsFaulted`, `TestSomethingThatIsNotAPDUIsRejected`, `TestMultiInterfaceEndpointRefusesARequest`
- `TestLargeResponseIsFragmentedAndReassembles` asserts the flags, per-fragment `alloc_hint`, the 8-byte stub multiples and byte-exact reassembly of a 12877-byte stub; `TestASmallerFragmentSizeIsHonouredForEveryClientOfTheEndpoint`; `TestAnAbsurdFragmentSizeFallsBackToTheDefault`; `TestConcurrentClientsOfOneEndpoint`; `TestErrorsAreDistinguishable`

`network/smb/smb_v10/server/rpcpipe/rpcpipe_test.go`:
- `TestHandlerSatisfiesThePipeContract` (every form a client names a pipe in, and the pipes that are not served), `TestPipesServed`, `TestTransactOnAnUnservedPipeFails`, `TestBindOnEachPipeNamesItsOwnInterface` (each pipe accepts its own interface and refuses the other's)
- `TestNetrShareEnumLevel1ReportsEveryShare` (name, type and remark of each), `TestNetrShareEnumLevel0ReportsNamesOnly` (and that only one union arm is set), `TestNetrShareEnumOnAnEmptyServer`, `TestNetrShareEnumWithNoShareSourceReportsNone`, `TestNetrShareEnumRefusesAnUnservedLevel`, `TestNetrShareEnumUnknownOpnumFaults`, `TestNetrShareEnumUndecodableStubFaults`
- `TestNetrShareEnumResumesWhereItStopped` walks a 48-byte budget to the end and asserts every share is seen exactly once in order; `TestNetrShareEnumResumeHandlePastTheEndFinishes`; `TestNetrShareEnumFragmentsALongList` enumerates 200 shares across many fragments and checks all 200 come back in order
- `TestNetrWkstaGetInfoLevel100`, `TestNetrWkstaGetInfoLevel101` (including that the LAN root is a null pointer, not an empty string), `TestNetrWkstaGetInfoWithNoNamesConfigured`, `TestNetrWkstaGetInfoRefusesAnUnservedLevel`
- `TestForServerReportsTheServersOwnShares` (types, remarks, and a share added after the handler was built), `TestForServerWithoutAServerReportsNoShares`, `TestShareTypeOf`, `TestConcurrentClientsOfOnePipe`

### Scope of Change
- **Files changed:** `network/dcerpc/v5/rpcserver/{doc.go,rpcserver.go,rpcserver_test.go}` (new), `network/smb/smb_v10/server/rpcpipe/{doc.go,rpcpipe.go,sharetype.go,srvsvc.go,wkssvc.go,rpcpipe_test.go}` (new), `network/smb/smb_v10/server/doc.go` (a paragraph in the named-pipes section pointing at `rpcpipe`)
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none. Both packages are new, and the only edit to existing code is a documentation paragraph.

### Risk and Rollout
The blast radius is limited to callers that opt in. Nothing existing imports either package, and a server that registers no IPC$ share behaves exactly as before. Safe to merge without staged rollout.

### Notes
Scope is what #1150 asked for: `NetrShareEnum` and `NetrWkstaGetInfo`. Other opnums a client sometimes tries — srvsvc `NetrShareGetInfo` (16) and `NetrServerGetInfo` (21) — fault with `nca_s_op_rng_error`, which is the correct answer from a server that does not implement them, and can be added without touching the dispatcher.

Follow-up filed: #1178, extending `PipeHandler` to carry a per-open handle so a pipe can serve several interfaces and hold per-bind state. Neither `\srvsvc` nor `\wkssvc` needs it.
