### PR TITLE
Give a pipe handler a session per open so RPC state belongs to a client (Fixes #1178)

### DIFF
--- a/network/dcerpc/v5/rpcserver/doc.go
+++ b/network/dcerpc/v5/rpcserver/doc.go
@@ -6,6 +6,22 @@
 // serves an interface over an SMB named pipe, over TCP, or over anything else that
 // can hand it one PDU and take one back.
 //
+// # Dispatchers and associations
+//
+// A Dispatcher is the set of interfaces an endpoint answers for, and holds nothing
+// that belongs to a client. Dispatcher.Open starts an Association, which is one
+// client's conversation with the endpoint and holds what a bind establishes: which
+// interface each presentation context names, and the largest fragment that client
+// will accept. Association.Handle is what answers a PDU.
+//
+// The split is what the transport dictates. A caller knows what one client is —
+// one open of a named pipe, one TCP connection — and the Dispatcher does not, so
+// the caller opens an association per client and the endpoint's interface table is
+// shared between them. A bind and the requests after it therefore land on the same
+// association, which is what makes them one conversation; a request naming a
+// context its association never negotiated is faulted with
+// nca_s_fault_context_mismatch rather than guessed at.
+//
 // # What a Service is
 //
 // A Service is one RPC interface: an abstract syntax that identifies it, and a
@@ -31,14 +47,6 @@
 // counts — do not approach a fragment's worth of bytes. Replies are fragmented,
 // which is the direction that matters: a share enumeration easily exceeds one
 // fragment.
-//
-// A Dispatcher serves one endpoint, and a request is dispatched to the single
-// interface that endpoint serves rather than by the presentation context the
-// request names. A transport that cannot tell two opens of an endpoint apart —
-// an SMB named pipe reached through a PipeHandler is one — cannot hold the
-// per-bind context table that dispatching by context id would need, so an
-// endpoint registered with more than one interface faults a request instead of
-// guessing. One interface per endpoint is how \srvsvc and \wkssvc are used.
 //
 // Only the NDR (little-endian, version 2) transfer syntax is accepted. NDR64 is
 // declined at bind time rather than accepted and then misencoded, which is the

--- a/network/dcerpc/v5/rpcserver/rpcserver.go
+++ b/network/dcerpc/v5/rpcserver/rpcserver.go
@@ -36,8 +36,8 @@ var ErrUnknownOpnum = errors.New("unknown opnum")
 // ErrBadStub reports a request stub the Service could not decode.
 var ErrBadStub = errors.New("request stub could not be decoded")
 
-// DefaultMaxFragment is the reply fragment size used when a client's bind named
-// none, or named one too small to carry a PDU header.
+// DefaultMaxFragment is the reply fragment size used before a bind has named
+// one, and when a bind names one too small to carry a PDU.
 //
 // 4280 is what Windows offers and what every client is prepared for.
 const DefaultMaxFragment = 4280
@@ -47,30 +47,23 @@ const DefaultMaxFragment = 4280
 // for one is given DefaultMaxFragment instead.
 const minFragmentStub = 8
 
-// Dispatcher answers RPC PDUs for a set of interfaces.
+// responseBodyOverhead is the fixed part of a response PDU behind its header:
+// alloc_hint(4) p_cont_id(2) cancel_count(1) reserved(1).
+const responseBodyOverhead = 8
+
+// defaultAssocGroup is the association group handed out when a client asks for
+// one.
+const defaultAssocGroup = 0x00001234
+
+// Dispatcher is the set of interfaces an endpoint answers for.
 //
-// One Dispatcher serves one endpoint — one named pipe, say — and is safe for
-// concurrent use. It keeps no per-call state; the negotiated fragment size is the
-// only thing a bind changes, and it is guarded, because a transport that cannot
-// tell two opens of an endpoint apart delivers both clients' PDUs to one
-// Dispatcher and may do so from two goroutines at once.
+// It holds no per-call and no per-client state, so one Dispatcher serves every
+// client of its endpoint and is safe for concurrent use. What a bind establishes
+// belongs to an Association, which Open returns one of.
 type Dispatcher struct {
 	// services are the interfaces this endpoint answers for. Written once by New
 	// and only read afterwards.
 	services []Service
-
-	// mutex guards maxFragment.
-	mutex sync.Mutex
-
-	// maxFragment is the largest reply fragment any client of this endpoint has
-	// said it can receive.
-	//
-	// It is the smallest such value seen, not the latest: without per-open state
-	// one size has to serve every client, and a fragment smaller than a client's
-	// maximum is always acceptable to it while a larger one is not. So a client
-	// asking for less shrinks the endpoint's fragments for everyone rather than
-	// risking a reply another client cannot take.
-	maxFragment uint16
 }
 
 // New builds a Dispatcher for a set of interfaces.
@@ -81,7 +74,56 @@ type Dispatcher struct {
 // Returns:
 //   - The dispatcher
 func New(services ...Service) *Dispatcher {
-	return &Dispatcher{services: services, maxFragment: DefaultMaxFragment}
+	return &Dispatcher{services: services}
+}
+
+// Services returns the interfaces this endpoint answers for.
+func (d *Dispatcher) Services() []Service {
+	return append([]Service(nil), d.services...)
+}
+
+// Open starts an association: one client's conversation with this endpoint.
+//
+// Every transport that carries RPC has something an association corresponds to —
+// one open of a named pipe, one TCP connection — and the caller is what knows
+// which. A caller that handed PDUs straight to the Dispatcher would have nowhere
+// to keep what a bind negotiated.
+//
+// Returns:
+//   - A new association, with no presentation context bound yet
+func (d *Dispatcher) Open() *Association {
+	return &Association{
+		dispatcher:  d,
+		contexts:    map[uint16]Service{},
+		maxFragment: DefaultMaxFragment,
+	}
+}
+
+// Association is one client's conversation with an endpoint.
+//
+// It holds what a bind establishes and the requests after it are interpreted
+// against: which interface each presentation context names, and the largest
+// fragment this client will accept. Two clients of one endpoint have separate
+// associations and negotiate separately.
+//
+// An association is guarded, so a transport that lets a client have several calls
+// in flight cannot corrupt the context table with a bind arriving beside a
+// request.
+type Association struct {
+	// dispatcher is the endpoint this association is with.
+	dispatcher *Dispatcher
+
+	// mutex guards contexts and maxFragment.
+	mutex sync.Mutex
+
+	// contexts maps a presentation context identifier to the interface the
+	// client bound it to. It is what makes a request's p_cont_id meaningful:
+	// [C706] 12.6.4.9 has a request name its interface by the context it was
+	// negotiated under, not by the interface's own identifier.
+	contexts map[uint16]Service
+
+	// maxFragment is the largest reply fragment this client said it can receive.
+	maxFragment uint16
 }
 
 // Handle answers one received PDU and returns the reply.
@@ -96,7 +138,7 @@ func New(services ...Service) *Dispatcher {
 //
 // Returns:
 //   - The reply PDUs to send back, and an error only when no reply can be framed
-func (d *Dispatcher) Handle(request []byte) ([]byte, error) {
+func (a *Association) Handle(request []byte) ([]byte, error) {
 	header, err := pdu.PeekHeader(request)
 	if err != nil {
 		return nil, fmt.Errorf("not a DCE/RPC PDU: %w", err)
@@ -104,31 +146,33 @@ func (d *Dispatcher) Handle(request []byte) ([]byte, error) {
 
 	switch header.PacketType {
 	case pdu.PacketTypeBind, pdu.PacketTypeAlterContext:
-		return d.handleBind(request, header)
+		return a.handleBind(request, header)
 
 	case pdu.PacketTypeRequest:
-		return d.handleRequest(request, header)
+		return a.handleRequest(request, header)
 
 	default:
 		// A packet type this endpoint does not answer for. A fault is a reply the
 		// client can act on; silence would leave it waiting.
 		logger.Debugf("rpcserver: refusing packet type %s", header.PacketType)
-		return d.fault(header.CallID, 0, pdu.NCASProtoError)
+		return a.fault(header.CallID, 0, pdu.NCASProtoError)
 	}
 }
 
 // handleBind answers a bind or an alter_context.
 //
-// The two are answered the same way: alter_context re-negotiates presentation
-// contexts on an existing association, and with no authentication to renegotiate
-// there is nothing that makes it differ from a bind here.
-func (d *Dispatcher) handleBind(request []byte, header *pdu.Header) ([]byte, error) {
+// The difference between the two is what happens to the contexts already bound:
+// a bind starts the association's context table afresh, and an alter_context adds
+// to it ([C706] 12.6.3.3, which has alter_context "negotiate a new presentation
+// context ... on an existing association").
+func (a *Association) handleBind(request []byte, header *pdu.Header) ([]byte, error) {
 	// An alter_context PDU is wire-identical to a bind but for the packet type at
 	// offset 2 of the common header, and Bind.Unmarshal refuses anything else.
 	// Rewriting the type on a copy is how the client sends one; this is the same
 	// move on the receiving side, and the copy leaves the caller's buffer alone.
+	altering := header.PacketType == pdu.PacketTypeAlterContext
 	body := request
-	if header.PacketType == pdu.PacketTypeAlterContext {
+	if altering {
 		body = make([]byte, len(request))
 		copy(body, request)
 		body[2] = byte(pdu.PacketTypeBind)
@@ -137,7 +181,7 @@ func (d *Dispatcher) handleBind(request []byte, header *pdu.Header) ([]byte, err
 	bind := &pdu.Bind{}
 	if _, err := bind.Unmarshal(body); err != nil {
 		logger.Debugf("rpcserver: a bind PDU would not decode: %v", err)
-		return d.bindNak(header.CallID, bindNakProtocolVersionNotSupported)
+		return a.bindNak(header.CallID, bindNakProtocolVersionNotSupported)
 	}
 
 	// An authenticated bind is refused rather than half-answered. See the package
@@ -146,21 +190,21 @@ func (d *Dispatcher) handleBind(request []byte, header *pdu.Header) ([]byte, err
 	// unverifiable.
 	if header.AuthLength > 0 || len(bind.AuthValue) > 0 {
 		logger.Debugf("rpcserver: refusing an authenticated bind (%d bytes of verifier)", header.AuthLength)
-		return d.bindNak(header.CallID, bindNakAuthenticationTypeNotRecognized)
+		return a.bindNak(header.CallID, bindNakAuthenticationTypeNotRecognized)
 	}
 
 	if len(bind.ContextList) == 0 {
-		return d.bindNak(header.CallID, bindNakReasonNotSpecified)
+		return a.bindNak(header.CallID, bindNakReasonNotSpecified)
 	}
 
 	// Each context the client offered gets a result, in order: [C706] 12.6.4.4
 	// pairs them positionally with the contexts of the request.
 	ndrSyntax := syntax.NDRTransferSyntax()
 	results := make([]pdu.PresentationResult, 0, len(bind.ContextList))
-	accepted := 0
+	bound := map[uint16]Service{}
 
 	for _, context := range bind.ContextList {
-		service := d.serviceFor(context.AbstractSyntax)
+		service := a.dispatcher.serviceFor(context.AbstractSyntax)
 		if service == nil {
 			results = append(results, pdu.PresentationResult{
 				Result: contextResultProviderRejection,
@@ -184,15 +228,15 @@ func (d *Dispatcher) handleBind(request []byte, header *pdu.Header) ([]byte, err
 			Result:         contextResultAcceptance,
 			TransferSyntax: ndrSyntax,
 		})
-		accepted++
+		bound[context.ContextID] = service
 	}
 
-	if accepted == 0 {
+	if len(bound) == 0 {
 		logger.Debugf("rpcserver: no presentation context in the bind could be accepted")
-		return d.bindNak(header.CallID, bindNakReasonNotSpecified)
+		return a.bindNak(header.CallID, bindNakReasonNotSpecified)
 	}
 
-	negotiated := d.observeFragment(bind.MaxRecvFrag)
+	negotiated := a.negotiate(bound, bind.MaxRecvFrag, altering)
 
 	ack := &pdu.BindAck{
 		Header:      pdu.NewHeader(pdu.PacketTypeBindAck, pdu.PFCFirstFrag|pdu.PFCLastFrag, header.CallID),
@@ -207,6 +251,7 @@ func (d *Dispatcher) handleBind(request []byte, header *pdu.Header) ([]byte, err
 		SecondaryAddress: "",
 		Results:          results,
 	}
+
 	encoded, err := ack.Marshal()
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal the bind_ack: %w", err)
@@ -215,18 +260,19 @@ func (d *Dispatcher) handleBind(request []byte, header *pdu.Header) ([]byte, err
 	// BindAck.Marshal forces PTYPE=bind_ack, and an alter_context_resp is
 	// wire-identical to it but for the packet type, so the answer to an
 	// alter_context is relabelled the same way the request was read.
-	if header.PacketType == pdu.PacketTypeAlterContext {
+	if altering {
 		encoded[2] = byte(pdu.PacketTypeAlterContextResp)
 	}
 	return encoded, nil
 }
 
-// handleRequest answers a request PDU by calling the interface it names.
-func (d *Dispatcher) handleRequest(request []byte, header *pdu.Header) ([]byte, error) {
+// handleRequest answers a request PDU by calling the interface its presentation
+// context names.
+func (a *Association) handleRequest(request []byte, header *pdu.Header) ([]byte, error) {
 	incoming := &pdu.Request{}
 	if _, err := incoming.Unmarshal(request); err != nil {
 		logger.Debugf("rpcserver: a request PDU would not decode: %v", err)
-		return d.fault(header.CallID, 0, pdu.NCASProtoError)
+		return a.fault(header.CallID, 0, pdu.NCASProtoError)
 	}
 
 	// A request arriving in fragments is refused rather than half-assembled.
@@ -234,19 +280,17 @@ func (d *Dispatcher) handleRequest(request []byte, header *pdu.Header) ([]byte, 
 	// to a Service would be decoded as a whole one.
 	if !header.PacketFlags.Has(pdu.PFCFirstFrag) || !header.PacketFlags.Has(pdu.PFCLastFrag) {
 		logger.Debugf("rpcserver: refusing a fragmented request (flags %s)", header.PacketFlags)
-		return d.fault(header.CallID, incoming.ContextID, pdu.NCASProtoError)
+		return a.fault(header.CallID, incoming.ContextID, pdu.NCASProtoError)
 	}
 
-	// The endpoint decides the interface. A Dispatcher serves one endpoint, and
-	// the context identifier a request carries was assigned by a bind this
-	// Dispatcher may not have seen — a transport that cannot tell two opens apart
-	// cannot keep per-bind state — so a single-interface endpoint dispatches by
-	// what it serves rather than by what the client numbered it.
-	service := d.only()
+	// The context the request names is what says which interface it is for, so a
+	// context this association never negotiated cannot be answered. That is a
+	// request before a bind, or one carrying a context the bind rejected.
+	service := a.serviceForContext(incoming.ContextID)
 	if service == nil {
-		logger.Debugf("rpcserver: request on an endpoint serving %d interfaces, which needs a bind context",
-			len(d.services))
-		return d.fault(header.CallID, incoming.ContextID, pdu.NCASUnkIf)
+		logger.Debugf("rpcserver: request on presentation context %d, which this association has not bound",
+			incoming.ContextID)
+		return a.fault(header.CallID, incoming.ContextID, pdu.NCASFaultContextMismatch)
 	}
 
 	stub, err := service.Call(incoming.Opnum, incoming.Stub)
@@ -260,16 +304,16 @@ func (d *Dispatcher) handleRequest(request []byte, header *pdu.Header) ([]byte, 
 		}
 		logger.Debugf("rpcserver: opnum %d failed (%v), answering %s",
 			incoming.Opnum, err, pdu.FaultStatus(status))
-		return d.fault(header.CallID, incoming.ContextID, status)
+		return a.fault(header.CallID, incoming.ContextID, status)
 	}
 
-	return d.response(header.CallID, incoming.ContextID, stub)
+	return a.response(header.CallID, incoming.ContextID, stub)
 }
 
 // response frames a response stub, splitting it across fragments if it exceeds
 // what the client said it can receive.
-func (d *Dispatcher) response(callID uint32, contextID uint16, stub []byte) ([]byte, error) {
-	budget := int(d.fragment()) - pdu.HeaderSize - responseBodyOverhead
+func (a *Association) response(callID uint32, contextID uint16, stub []byte) ([]byte, error) {
+	budget := int(a.fragment()) - pdu.HeaderSize - responseBodyOverhead
 	if budget < minFragmentStub {
 		budget = DefaultMaxFragment - pdu.HeaderSize - responseBodyOverhead
 	}
@@ -310,12 +354,8 @@ func (d *Dispatcher) response(callID uint32, contextID uint16, stub []byte) ([]b
 	return out, nil
 }
 
-// responseBodyOverhead is the fixed part of a response PDU behind its header:
-// alloc_hint(4) p_cont_id(2) cancel_count(1) reserved(1).
-const responseBodyOverhead = 8
-
 // fault frames a fault PDU.
-func (d *Dispatcher) fault(callID uint32, contextID uint16, status uint32) ([]byte, error) {
+func (a *Association) fault(callID uint32, contextID uint16, status uint32) ([]byte, error) {
 	f := &pdu.Fault{
 		Header:    pdu.NewHeader(pdu.PacketTypeFault, pdu.PFCFirstFrag|pdu.PFCLastFrag, callID),
 		ContextID: contextID,
@@ -329,7 +369,7 @@ func (d *Dispatcher) fault(callID uint32, contextID uint16, status uint32) ([]by
 }
 
 // bindNak frames a bind_nak carrying a reject reason.
-func (d *Dispatcher) bindNak(callID uint32, reason uint16) ([]byte, error) {
+func (a *Association) bindNak(callID uint32, reason uint16) ([]byte, error) {
 	nak := &pdu.BindNak{
 		Header:       pdu.NewHeader(pdu.PacketTypeBindNak, pdu.PFCFirstFrag|pdu.PFCLastFrag, callID),
 		RejectReason: reason,
@@ -344,21 +384,59 @@ func (d *Dispatcher) bindNak(callID uint32, reason uint16) ([]byte, error) {
 	return encoded, nil
 }
 
+// negotiate records what a bind established and returns the fragment size the
+// association will send at.
+//
+// Parameters:
+//   - bound: the contexts the bind accepted, by context identifier
+//   - requested: the client's max_recv_frag
+//   - altering: true for an alter_context, which adds to what is bound rather
+//     than replacing it
+//
+// Returns:
+//   - The fragment size replies will be framed at
+func (a *Association) negotiate(bound map[uint16]Service, requested uint16, altering bool) uint16 {
+	a.mutex.Lock()
+	defer a.mutex.Unlock()
+
+	if !altering {
+		a.contexts = map[uint16]Service{}
+	}
+	for id, service := range bound {
+		a.contexts[id] = service
+	}
+	a.maxFragment = negotiatedFragment(requested)
+	return a.maxFragment
+}
+
+// serviceForContext returns the interface a presentation context names, or nil
+// when this association has not bound that context.
+func (a *Association) serviceForContext(contextID uint16) Service {
+	a.mutex.Lock()
+	defer a.mutex.Unlock()
+	return a.contexts[contextID]
+}
+
+// fragment returns the size replies are framed at.
+func (a *Association) fragment() uint16 {
+	a.mutex.Lock()
+	defer a.mutex.Unlock()
+	return a.maxFragment
+}
+
+// Bound reports how many presentation contexts this association has negotiated.
+func (a *Association) Bound() int {
+	a.mutex.Lock()
+	defer a.mutex.Unlock()
+	return len(a.contexts)
+}
+
 // serviceFor finds the interface a bind's abstract syntax names.
 func (d *Dispatcher) serviceFor(abstract syntax.SyntaxID) Service {
 	for _, service := range d.services {
 		if service.AbstractSyntax().Equal(abstract) {
 			return service
 		}
-	}
-	return nil
-}
-
-// only returns the single interface this endpoint serves, or nil when it serves
-// more than one and a request cannot be attributed without bind state.
-func (d *Dispatcher) only() Service {
-	if len(d.services) == 1 {
-		return d.services[0]
 	}
 	return nil
 }
@@ -371,32 +449,6 @@ func offersSyntax(offered []syntax.SyntaxID, wanted syntax.SyntaxID) bool {
 		}
 	}
 	return false
-}
-
-// observeFragment records what a binding client can receive and returns the size
-// the endpoint will use for it.
-//
-// Parameters:
-//   - requested: the client's max_recv_frag
-//
-// Returns:
-//   - The fragment size the endpoint will send at
-func (d *Dispatcher) observeFragment(requested uint16) uint16 {
-	usable := negotiatedFragment(requested)
-
-	d.mutex.Lock()
-	defer d.mutex.Unlock()
-	if usable < d.maxFragment {
-		d.maxFragment = usable
-	}
-	return d.maxFragment
-}
-
-// fragment returns the size replies are fragmented at.
-func (d *Dispatcher) fragment() uint16 {
-	d.mutex.Lock()
-	defer d.mutex.Unlock()
-	return d.maxFragment
 }
 
 // negotiatedFragment bounds the client's requested fragment size.
@@ -422,10 +474,6 @@ func assocGroup(requested uint32) uint32 {
 	}
 	return requested
 }
-
-// defaultAssocGroup is the association group handed out when a client asks for
-// one.
-const defaultAssocGroup = 0x00001234
 
 // The bind_nak reject reasons ([C706] 12.6.4.5).
 const (

--- a/network/dcerpc/v5/rpcserver/rpcserver_test.go
+++ b/network/dcerpc/v5/rpcserver/rpcserver_test.go
@@ -134,9 +134,10 @@ func splitPDUs(t *testing.T, stream []byte) [][]byte {
 }
 
 func TestBindAcceptsTheServedInterface(t *testing.T) {
-	dispatcher := New(&stubService{})
+	endpoint := New(&stubService{})
+	association := endpoint.Open()
 
-	reply, err := dispatcher.Handle(bindRequest(t, 7, 4280, testSyntax()))
+	reply, err := association.Handle(bindRequest(t, 7, 4280, testSyntax()))
 	if err != nil {
 		t.Fatalf("Handle returned an error for a well-formed bind: %v", err)
 	}
@@ -170,11 +171,12 @@ func TestBindAcceptsTheServedInterface(t *testing.T) {
 }
 
 func TestBindRejectsTheContextNamingAnotherInterfaceAndKeepsTheServedOne(t *testing.T) {
-	dispatcher := New(&stubService{})
+	endpoint := New(&stubService{})
+	association := endpoint.Open()
 
 	// Two contexts, the second naming an interface this endpoint does not serve.
 	// Both get a result, positionally, per [C706] 12.6.4.4.
-	reply, err := dispatcher.Handle(bindRequest(t, 1, 4280, testSyntax(), otherSyntax()))
+	reply, err := association.Handle(bindRequest(t, 1, 4280, testSyntax(), otherSyntax()))
 	if err != nil {
 		t.Fatalf("Handle returned an error: %v", err)
 	}
@@ -200,9 +202,10 @@ func TestBindRejectsTheContextNamingAnotherInterfaceAndKeepsTheServedOne(t *test
 }
 
 func TestBindNamingOnlyAnotherInterfaceIsRefused(t *testing.T) {
-	dispatcher := New(&stubService{})
+	endpoint := New(&stubService{})
+	association := endpoint.Open()
 
-	reply, err := dispatcher.Handle(bindRequest(t, 2, 4280, otherSyntax()))
+	reply, err := association.Handle(bindRequest(t, 2, 4280, otherSyntax()))
 	if err != nil {
 		t.Fatalf("Handle returned an error: %v", err)
 	}
@@ -220,7 +223,8 @@ func TestBindNamingOnlyAnotherInterfaceIsRefused(t *testing.T) {
 }
 
 func TestBindOfferingOnlyNDR64IsRefused(t *testing.T) {
-	dispatcher := New(&stubService{})
+	endpoint := New(&stubService{})
+	association := endpoint.Open()
 
 	// NDR64 ([MS-RPCE] 2.2.4.4). Accepting it and then encoding NDR20 would hand
 	// the client a reply it decodes as the wrong shape.
@@ -245,7 +249,7 @@ func TestBindOfferingOnlyNDR64IsRefused(t *testing.T) {
 		t.Fatalf("failed to marshal the bind: %v", err)
 	}
 
-	reply, err := dispatcher.Handle(encoded)
+	reply, err := association.Handle(encoded)
 	if err != nil {
 		t.Fatalf("Handle returned an error: %v", err)
 	}
@@ -256,7 +260,8 @@ func TestBindOfferingOnlyNDR64IsRefused(t *testing.T) {
 }
 
 func TestAuthenticatedBindIsRefused(t *testing.T) {
-	dispatcher := New(&stubService{})
+	endpoint := New(&stubService{})
+	association := endpoint.Open()
 
 	bind := &pdu.Bind{
 		Header:      pdu.NewHeader(pdu.PacketTypeBind, pdu.PFCFirstFrag|pdu.PFCLastFrag, 4),
@@ -275,7 +280,7 @@ func TestAuthenticatedBindIsRefused(t *testing.T) {
 		t.Fatalf("failed to marshal the bind: %v", err)
 	}
 
-	reply, err := dispatcher.Handle(encoded)
+	reply, err := association.Handle(encoded)
 	if err != nil {
 		t.Fatalf("Handle returned an error: %v", err)
 	}
@@ -291,7 +296,8 @@ func TestAuthenticatedBindIsRefused(t *testing.T) {
 }
 
 func TestAlterContextIsAnsweredWithAnAlterContextResponse(t *testing.T) {
-	dispatcher := New(&stubService{})
+	endpoint := New(&stubService{})
+	association := endpoint.Open()
 
 	bind := &pdu.Bind{
 		Header:      pdu.NewHeader(pdu.PacketTypeBind, pdu.PFCFirstFrag|pdu.PFCLastFrag, 5),
@@ -311,7 +317,7 @@ func TestAlterContextIsAnsweredWithAnAlterContextResponse(t *testing.T) {
 	// an alter_context has the same body.
 	encoded[2] = byte(pdu.PacketTypeAlterContext)
 
-	reply, err := dispatcher.Handle(encoded)
+	reply, err := association.Handle(encoded)
 	if err != nil {
 		t.Fatalf("Handle returned an error: %v", err)
 	}
@@ -328,13 +334,14 @@ func TestAlterContextIsAnsweredWithAnAlterContextResponse(t *testing.T) {
 
 func TestRequestReturnsTheInterfacesStub(t *testing.T) {
 	service := &stubService{answer: []byte("0123456789abcdef")}
-	dispatcher := New(service)
+	endpoint := New(service)
+	association := endpoint.Open()
 
-	if _, err := dispatcher.Handle(bindRequest(t, 1, 4280, testSyntax())); err != nil {
+	if _, err := association.Handle(bindRequest(t, 1, 4280, testSyntax())); err != nil {
 		t.Fatalf("the bind failed: %v", err)
 	}
 
-	reply, err := dispatcher.Handle(callRequest(t, 9, 0, []byte("in")))
+	reply, err := association.Handle(callRequest(t, 9, 0, []byte("in")))
 	if err != nil {
 		t.Fatalf("Handle returned an error for a well-formed request: %v", err)
 	}
@@ -368,9 +375,13 @@ func TestRequestFaultStatuses(t *testing.T) {
 
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
-			dispatcher := New(&stubService{})
+			endpoint := New(&stubService{})
+			association := endpoint.Open()
+			if _, err := association.Handle(bindRequest(t, 1, 4280, testSyntax())); err != nil {
+				t.Fatalf("the bind failed: %v", err)
+			}
 
-			reply, err := dispatcher.Handle(callRequest(t, 1, test.opnum, nil))
+			reply, err := association.Handle(callRequest(t, 1, test.opnum, nil))
 			if err != nil {
 				t.Fatalf("Handle returned an error instead of framing a fault: %v", err)
 			}
@@ -389,7 +400,11 @@ func TestRequestFaultStatuses(t *testing.T) {
 
 func TestFragmentedRequestIsRefusedWithoutReachingTheInterface(t *testing.T) {
 	service := &stubService{answer: []byte("unreachable")}
-	dispatcher := New(service)
+	endpoint := New(service)
+	association := endpoint.Open()
+	if _, err := association.Handle(bindRequest(t, 1, 4280, testSyntax())); err != nil {
+		t.Fatalf("the bind failed: %v", err)
+	}
 
 	// PFC_FIRST_FRAG without PFC_LAST_FRAG: the first fragment of a request whose
 	// stub is incomplete. Handing it to the interface would decode a fragment as
@@ -404,7 +419,7 @@ func TestFragmentedRequestIsRefusedWithoutReachingTheInterface(t *testing.T) {
 		t.Fatalf("failed to marshal the request: %v", err)
 	}
 
-	reply, err := dispatcher.Handle(encoded)
+	reply, err := association.Handle(encoded)
 	if err != nil {
 		t.Fatalf("Handle returned an error instead of framing a fault: %v", err)
 	}
@@ -422,7 +437,8 @@ func TestFragmentedRequestIsRefusedWithoutReachingTheInterface(t *testing.T) {
 }
 
 func TestUnexpectedPacketTypeIsFaulted(t *testing.T) {
-	dispatcher := New(&stubService{})
+	endpoint := New(&stubService{})
+	association := endpoint.Open()
 
 	// An auth3 PDU, which only an authenticated association uses and which this
 	// endpoint never negotiates.
@@ -436,7 +452,7 @@ func TestUnexpectedPacketTypeIsFaulted(t *testing.T) {
 		t.Fatalf("failed to marshal the auth3: %v", err)
 	}
 
-	reply, err := dispatcher.Handle(encoded)
+	reply, err := association.Handle(encoded)
 	if err != nil {
 		t.Fatalf("Handle returned an error instead of framing a fault: %v", err)
 	}
@@ -451,9 +467,10 @@ func TestUnexpectedPacketTypeIsFaulted(t *testing.T) {
 }
 
 func TestSomethingThatIsNotAPDUIsRejected(t *testing.T) {
-	dispatcher := New(&stubService{})
+	endpoint := New(&stubService{})
+	association := endpoint.Open()
 
-	if _, err := dispatcher.Handle([]byte("not a PDU")); err == nil {
+	if _, err := association.Handle([]byte("not a PDU")); err == nil {
 		t.Error("Handle accepted nine bytes that are not a PDU")
 	}
 }
@@ -468,12 +485,13 @@ func TestLargeResponseIsFragmentedAndReassembles(t *testing.T) {
 	}
 
 	service := &stubService{answer: answer}
-	dispatcher := New(service)
-	if _, err := dispatcher.Handle(bindRequest(t, 1, 4280, testSyntax())); err != nil {
+	endpoint := New(service)
+	association := endpoint.Open()
+	if _, err := association.Handle(bindRequest(t, 1, 4280, testSyntax())); err != nil {
 		t.Fatalf("the bind failed: %v", err)
 	}
 
-	reply, err := dispatcher.Handle(callRequest(t, 2, 0, nil))
+	reply, err := association.Handle(callRequest(t, 2, 0, nil))
 	if err != nil {
 		t.Fatalf("Handle returned an error: %v", err)
 	}
@@ -520,41 +538,61 @@ func TestLargeResponseIsFragmentedAndReassembles(t *testing.T) {
 	}
 }
 
-func TestASmallerFragmentSizeIsHonouredForEveryClientOfTheEndpoint(t *testing.T) {
-	answer := make([]byte, 4096)
-	service := &stubService{answer: answer}
-	dispatcher := New(service)
+func TestEachAssociationNegotiatesItsOwnFragmentSize(t *testing.T) {
+	// Two clients of one endpoint, one with a small receive buffer and one with
+	// the usual size. Each is answered at the size it asked for: what a bind
+	// negotiates belongs to the association, so neither client's buffer bounds
+	// the other's replies.
+	endpoint := New(&stubService{answer: make([]byte, 4096)})
 
-	// One client says it can only take 1024-byte fragments. The endpoint cannot
-	// tell two opens apart, so that bound has to apply to the whole endpoint: a
-	// fragment smaller than a client's maximum is always acceptable, a larger one
-	// is not.
-	if _, err := dispatcher.Handle(bindRequest(t, 1, 1024, testSyntax())); err != nil {
-		t.Fatalf("the first bind failed: %v", err)
+	small := endpoint.Open()
+	if _, err := small.Handle(bindRequest(t, 1, 1024, testSyntax())); err != nil {
+		t.Fatalf("the small client's bind failed: %v", err)
 	}
-	if _, err := dispatcher.Handle(bindRequest(t, 2, 4280, testSyntax())); err != nil {
-		t.Fatalf("the second bind failed: %v", err)
+	large := endpoint.Open()
+	if _, err := large.Handle(bindRequest(t, 2, 4280, testSyntax())); err != nil {
+		t.Fatalf("the large client's bind failed: %v", err)
 	}
 
-	reply, err := dispatcher.Handle(callRequest(t, 3, 0, nil))
+	smallReply, err := small.Handle(callRequest(t, 3, 0, nil))
 	if err != nil {
-		t.Fatalf("Handle returned an error: %v", err)
+		t.Fatalf("the small client's request failed: %v", err)
+	}
+	largeReply, err := large.Handle(callRequest(t, 4, 0, nil))
+	if err != nil {
+		t.Fatalf("the large client's request failed: %v", err)
 	}
 
-	for i, fragment := range splitPDUs(t, reply) {
+	smallFragments := splitPDUs(t, smallReply)
+	for i, fragment := range smallFragments {
 		if len(fragment) > 1024 {
-			t.Errorf("fragment %d is %d bytes, past the 1024 the smaller client asked for", i, len(fragment))
+			t.Errorf("the small client's fragment %d is %d bytes, past the 1024 it asked for", i, len(fragment))
 		}
+	}
+
+	largeFragments := splitPDUs(t, largeReply)
+	for i, fragment := range largeFragments {
+		if len(fragment) > 4280 {
+			t.Errorf("the large client's fragment %d is %d bytes, past the 4280 it asked for", i, len(fragment))
+		}
+	}
+
+	// The point of the test: the small client's bind did not shrink the large
+	// client's replies.
+	if len(largeFragments) >= len(smallFragments) {
+		t.Errorf("the large client's reply came in %d fragments and the small client's in %d, so the two are not negotiating separately",
+			len(largeFragments), len(smallFragments))
 	}
 }
 
 func TestAnAbsurdFragmentSizeFallsBackToTheDefault(t *testing.T) {
-	dispatcher := New(&stubService{answer: make([]byte, 8192)})
+	endpoint := New(&stubService{answer: make([]byte, 8192)})
+	association := endpoint.Open()
 
 	// A max_recv_frag of 4 leaves no room for a PDU header, let alone a stub. It
 	// is a client that filled the field in wrongly, and answering at that size
 	// would make progress impossible.
-	reply, err := dispatcher.Handle(bindRequest(t, 1, 4, testSyntax()))
+	reply, err := association.Handle(bindRequest(t, 1, 4, testSyntax()))
 	if err != nil {
 		t.Fatalf("the bind failed: %v", err)
 	}
@@ -568,59 +606,296 @@ func TestAnAbsurdFragmentSizeFallsBackToTheDefault(t *testing.T) {
 	}
 }
 
-func TestMultiInterfaceEndpointRefusesARequest(t *testing.T) {
-	// Two interfaces on one endpoint. A request names its context by an
-	// identifier assigned in a bind, and without per-open state there is no
-	// table to look it up in, so the request cannot be attributed.
-	other := &secondService{}
-	dispatcher := New(&stubService{answer: []byte("x")}, other)
+func TestMultiInterfaceEndpointDispatchesByPresentationContext(t *testing.T) {
+	// Two interfaces on one endpoint, bound in one bind under two context ids.
+	// Which interface answers a request is decided by the context it names, so
+	// both are reachable over the same association and neither is guessed at.
+	first := &stubService{answer: []byte("from the first")}
+	second := &secondService{answer: []byte("from the second")}
+	endpoint := New(first, second)
+	association := endpoint.Open()
 
-	reply, err := dispatcher.Handle(callRequest(t, 1, 0, nil))
+	reply, err := association.Handle(bindRequest(t, 1, 4280, testSyntax(), otherSyntax()))
+	if err != nil {
+		t.Fatalf("the bind failed: %v", err)
+	}
+	ack := &pdu.BindAck{}
+	if _, err := ack.Unmarshal(reply); err != nil {
+		t.Fatalf("the reply is not a bind_ack: %v", err)
+	}
+	for i, result := range ack.Results {
+		if result.Result != pdu.ResultAcceptance {
+			t.Fatalf("context %d was answered with result %d, want acceptance", i, result.Result)
+		}
+	}
+	if got := association.Bound(); got != 2 {
+		t.Fatalf("the association reports %d bound contexts, want 2", got)
+	}
+
+	// bindRequest numbers the contexts by their position, so context 0 is the
+	// first interface and context 1 the second.
+	for contextID, want := range map[uint16][]byte{0: first.answer, 1: second.answer} {
+		request := &pdu.Request{
+			Header:    pdu.NewHeader(pdu.PacketTypeRequest, pdu.PFCFirstFrag|pdu.PFCLastFrag, 2),
+			ContextID: contextID,
+			Opnum:     0,
+		}
+		encoded, err := request.Marshal()
+		if err != nil {
+			t.Fatalf("failed to marshal the request on context %d: %v", contextID, err)
+		}
+
+		reply, err := association.Handle(encoded)
+		if err != nil {
+			t.Fatalf("the request on context %d failed: %v", contextID, err)
+		}
+		response := &pdu.Response{}
+		if _, err := response.Unmarshal(reply); err != nil {
+			t.Fatalf("the reply on context %d is not a response: %v", contextID, err)
+		}
+		if !bytes.Equal(response.Stub, want) {
+			t.Errorf("context %d was answered by the wrong interface: stub %q, want %q",
+				contextID, response.Stub, want)
+		}
+		if response.ContextID != contextID {
+			t.Errorf("the response to context %d carries context %d", contextID, response.ContextID)
+		}
+	}
+}
+
+func TestRequestBeforeABindIsFaulted(t *testing.T) {
+	// A request names its interface by a presentation context, and a context is
+	// only meaningful once a bind has negotiated it. Answering one anyway would
+	// mean guessing which interface the client meant.
+	service := &stubService{answer: []byte("unreachable")}
+	endpoint := New(service)
+	association := endpoint.Open()
+
+	if got := association.Bound(); got != 0 {
+		t.Errorf("a fresh association reports %d bound contexts, want 0", got)
+	}
+
+	reply, err := association.Handle(callRequest(t, 1, 0, nil))
 	if err != nil {
 		t.Fatalf("Handle returned an error instead of framing a fault: %v", err)
 	}
-
 	fault := &pdu.Fault{}
 	if _, err := fault.Unmarshal(reply); err != nil {
 		t.Fatalf("the reply is not a fault: %v", err)
 	}
-	if fault.Status != pdu.NCASUnkIf {
-		t.Errorf("the fault reports %s, want %s", pdu.FaultStatus(fault.Status), pdu.FaultStatus(pdu.NCASUnkIf))
+	if fault.Status != pdu.NCASFaultContextMismatch {
+		t.Errorf("the fault reports %s, want %s",
+			pdu.FaultStatus(fault.Status), pdu.FaultStatus(pdu.NCASFaultContextMismatch))
+	}
+	if service.callCount() != 0 {
+		t.Errorf("the interface was called %d times before a bind, want 0", service.callCount())
+	}
+}
+
+func TestRequestOnAContextTheBindRejectedIsFaulted(t *testing.T) {
+	// The bind offers two contexts and only the first is accepted, so a request
+	// on the second names a context that was refused.
+	endpoint := New(&stubService{answer: []byte("x")})
+	association := endpoint.Open()
+
+	if _, err := association.Handle(bindRequest(t, 1, 4280, testSyntax(), otherSyntax())); err != nil {
+		t.Fatalf("the bind failed: %v", err)
+	}
+	if got := association.Bound(); got != 1 {
+		t.Fatalf("the association reports %d bound contexts, want only the accepted one", got)
+	}
+
+	request := &pdu.Request{
+		Header:    pdu.NewHeader(pdu.PacketTypeRequest, pdu.PFCFirstFrag|pdu.PFCLastFrag, 2),
+		ContextID: 1,
+		Opnum:     0,
+	}
+	encoded, err := request.Marshal()
+	if err != nil {
+		t.Fatalf("failed to marshal the request: %v", err)
+	}
+
+	reply, err := association.Handle(encoded)
+	if err != nil {
+		t.Fatalf("Handle returned an error instead of framing a fault: %v", err)
+	}
+	fault := &pdu.Fault{}
+	if _, err := fault.Unmarshal(reply); err != nil {
+		t.Fatalf("the reply is not a fault: %v", err)
+	}
+	if fault.Status != pdu.NCASFaultContextMismatch {
+		t.Errorf("the fault reports %s, want %s",
+			pdu.FaultStatus(fault.Status), pdu.FaultStatus(pdu.NCASFaultContextMismatch))
+	}
+}
+
+func TestAlterContextAddsToWhatIsBoundAndABindReplacesIt(t *testing.T) {
+	// [C706] 12.6.3.3: alter_context negotiates a new presentation context on an
+	// existing association, so what was bound stays bound. A bind starts the
+	// association's context table again.
+	first := &stubService{answer: []byte("from the first")}
+	second := &secondService{answer: []byte("from the second")}
+	endpoint := New(first, second)
+	association := endpoint.Open()
+
+	if _, err := association.Handle(bindRequest(t, 1, 4280, testSyntax())); err != nil {
+		t.Fatalf("the bind failed: %v", err)
+	}
+	if got := association.Bound(); got != 1 {
+		t.Fatalf("after the bind the association reports %d bound contexts, want 1", got)
+	}
+
+	// An alter_context naming the second interface, under context id 1.
+	alter := &pdu.Bind{
+		Header:      pdu.NewHeader(pdu.PacketTypeBind, pdu.PFCFirstFrag|pdu.PFCLastFrag, 2),
+		MaxXmitFrag: 4280,
+		MaxRecvFrag: 4280,
+		ContextList: []pdu.ContextElement{{
+			ContextID:        1,
+			AbstractSyntax:   otherSyntax(),
+			TransferSyntaxes: []syntax.SyntaxID{syntax.NDRTransferSyntax()},
+		}},
+	}
+	encoded, err := alter.Marshal()
+	if err != nil {
+		t.Fatalf("failed to marshal the alter_context: %v", err)
+	}
+	encoded[2] = byte(pdu.PacketTypeAlterContext)
+
+	if _, err := association.Handle(encoded); err != nil {
+		t.Fatalf("the alter_context failed: %v", err)
+	}
+	if got := association.Bound(); got != 2 {
+		t.Errorf("after the alter_context the association reports %d bound contexts, want 2 — the first was dropped",
+			got)
+	}
+
+	// A fresh bind naming only the second interface leaves that one context.
+	rebind := bindRequest(t, 3, 4280, otherSyntax())
+	if _, err := association.Handle(rebind); err != nil {
+		t.Fatalf("the second bind failed: %v", err)
+	}
+	if got := association.Bound(); got != 1 {
+		t.Errorf("after a second bind the association reports %d bound contexts, want 1", got)
+	}
+}
+
+func TestTwoAssociationsOfOneEndpointBindIndependently(t *testing.T) {
+	// The endpoint's interfaces are shared; what a bind establishes is not. One
+	// client binding must not make the other client's requests answerable, which
+	// is the whole reason an association exists.
+	endpoint := New(&stubService{answer: []byte("answer")})
+
+	bound := endpoint.Open()
+	if _, err := bound.Handle(bindRequest(t, 1, 4280, testSyntax())); err != nil {
+		t.Fatalf("the bind failed: %v", err)
+	}
+	unbound := endpoint.Open()
+
+	if got := unbound.Bound(); got != 0 {
+		t.Errorf("the second association reports %d bound contexts after the first one bound, want 0", got)
+	}
+
+	reply, err := unbound.Handle(callRequest(t, 2, 0, nil))
+	if err != nil {
+		t.Fatalf("Handle returned an error instead of framing a fault: %v", err)
+	}
+	fault := &pdu.Fault{}
+	if _, err := fault.Unmarshal(reply); err != nil {
+		t.Fatalf("the second association's request was answered rather than faulted: %v", err)
+	}
+	if fault.Status != pdu.NCASFaultContextMismatch {
+		t.Errorf("the fault reports %s, want %s",
+			pdu.FaultStatus(fault.Status), pdu.FaultStatus(pdu.NCASFaultContextMismatch))
+	}
+
+	// The association that did bind still works.
+	if _, err := bound.Handle(callRequest(t, 3, 0, nil)); err != nil {
+		t.Fatalf("the bound association's request failed: %v", err)
+	}
+}
+
+func TestServicesReportsTheEndpointsInterfaces(t *testing.T) {
+	endpoint := New(&stubService{}, &secondService{})
+
+	services := endpoint.Services()
+	if len(services) != 2 {
+		t.Fatalf("Services reports %d interfaces, want 2", len(services))
+	}
+	// The slice is a copy, so a caller cannot reach into the endpoint's own.
+	services[0] = nil
+	if again := endpoint.Services(); again[0] == nil {
+		t.Error("Services handed out the endpoint's own slice, so a caller can empty it")
 	}
 }
 
 // secondService is a second interface, used to build an endpoint that serves
 // more than one.
-type secondService struct{}
+type secondService struct {
+	answer []byte
+}
 
 func (s *secondService) AbstractSyntax() syntax.SyntaxID { return otherSyntax() }
 func (s *secondService) Call(opnum uint16, stub []byte) ([]byte, error) {
-	return nil, ErrUnknownOpnum
+	if opnum != 0 {
+		return nil, ErrUnknownOpnum
+	}
+	return s.answer, nil
 }
 
 func TestConcurrentClientsOfOneEndpoint(t *testing.T) {
-	// One Dispatcher serves every open of its endpoint, and the SMB server calls
-	// a pipe handler on the goroutine of whichever connection is asking. Binds
-	// and requests therefore overlap, which is what this checks under -race.
-	dispatcher := New(&stubService{answer: make([]byte, 2048)})
+	// One Dispatcher serves every client of its endpoint, and the SMB server
+	// calls a pipe handler on the goroutine of whichever connection is asking.
+	// Each client has its own association; the endpoint's interface table is
+	// shared, which is what this checks under -race.
+	endpoint := New(&stubService{answer: make([]byte, 2048)})
 
 	var waiting sync.WaitGroup
 	for client := 0; client < 8; client++ {
 		waiting.Add(1)
 		go func(client int) {
 			defer waiting.Done()
+
+			association := endpoint.Open()
 			for round := 0; round < 20; round++ {
 				callID := uint32(client*100 + round)
-				if _, err := dispatcher.Handle(bindRequest(t, callID, uint16(1024+client*64), testSyntax())); err != nil {
+				if _, err := association.Handle(bindRequest(t, callID, uint16(1024+client*64), testSyntax())); err != nil {
 					t.Errorf("client %d: the bind failed: %v", client, err)
 					return
 				}
-				if _, err := dispatcher.Handle(callRequest(t, callID, 0, nil)); err != nil {
+				if _, err := association.Handle(callRequest(t, callID, 0, nil)); err != nil {
 					t.Errorf("client %d: the request failed: %v", client, err)
 					return
 				}
 			}
 		}(client)
+	}
+	waiting.Wait()
+}
+
+func TestOneAssociationUsedFromSeveralGoroutines(t *testing.T) {
+	// A transport that let a client have several calls in flight would use one
+	// association from several goroutines. The server does not, but the guard is
+	// what makes that a supported thing to do rather than a corrupted context
+	// table, and this is what checks it under -race.
+	endpoint := New(&stubService{answer: make([]byte, 512)})
+	association := endpoint.Open()
+	if _, err := association.Handle(bindRequest(t, 1, 4280, testSyntax())); err != nil {
+		t.Fatalf("the bind failed: %v", err)
+	}
+
+	var waiting sync.WaitGroup
+	for caller := 0; caller < 8; caller++ {
+		waiting.Add(1)
+		go func(caller int) {
+			defer waiting.Done()
+			for round := 0; round < 20; round++ {
+				if _, err := association.Handle(callRequest(t, uint32(caller*100+round), 0, nil)); err != nil {
+					t.Errorf("caller %d: the request failed: %v", caller, err)
+					return
+				}
+			}
+		}(caller)
 	}
 	waiting.Wait()
 }

--- a/network/smb/smb_v10/server/doc.go
+++ b/network/smb/smb_v10/server/doc.go
@@ -297,6 +297,13 @@
 // the FID in the request's setup words, not by the name the request carries, so
 // the handle is what matters and the name is boilerplate.
 //
+// The handle is what the handler sees too. OpenPipe returns a PipeSession, the
+// Open keeps it, and every transaction on that handle runs against it, so a
+// handler can hold state belonging to one client's open rather than to the pipe.
+// An RPC endpoint needs precisely that: a bind establishes the presentation
+// contexts and the fragment size the requests after it are read against, and two
+// clients of one pipe bind separately. Closing the handle closes the session.
+//
 // An answer larger than the client's buffer is cut to fit and reported with
 // STATUS_BUFFER_OVERFLOW, which is what tells the client to read again. Reporting
 // plain success would leave an RPC client parsing a truncated response as a whole

--- a/network/smb/smb_v10/server/handler_pipe.go
+++ b/network/smb/smb_v10/server/handler_pipe.go
@@ -19,29 +19,47 @@ import (
 // PipeHandler serves the named pipes on an IPC share.
 //
 // A pipe is request-response: a client writes a message and reads the answer,
-// which is how MS-RPC travels over SMB. Transact is the operation that does both
-// in one exchange and the one every RPC client uses, so a handler that implements
-// only that is a complete one for the purpose.
+// which is how MS-RPC travels over SMB. A handler's job is to say which pipes
+// exist and to open one; everything the client does afterwards happens on the
+// PipeSession the open returns.
 //
 // A handler is called on the goroutine serving the connection, so an
-// implementation that blocks holds that client up. It may be called concurrently
-// for different connections.
+// implementation that blocks holds that client up. One handler serves every
+// connection to its share, so OpenPipe may be called concurrently.
 type PipeHandler interface {
-	// OpenPipe reports whether a pipe exists under this handler, and prepares
-	// whatever per-open state it needs. The name has no leading separator and no
+	// OpenPipe opens one instance of a pipe and returns the session the
+	// instance's later calls run on. The name has no leading separator and no
 	// "PIPE" prefix: "srvsvc", not "\\PIPE\\srvsvc".
-	OpenPipe(name string) error
+	//
+	// A pipe this handler does not serve is refused with an error: one whose
+	// message contains "not found" is reported to the client as
+	// STATUS_OBJECT_NAME_NOT_FOUND, and anything else as STATUS_UNSUCCESSFUL.
+	OpenPipe(name string) (PipeSession, error)
+}
 
-	// Transact writes a message to a pipe and returns the answer. maxOutput is
-	// the largest answer the server will take in one exchange, which is
-	// maxPipeAnswerSize rather than the client's buffer: fitting the answer to
-	// the client is the server's job, because only the server knows how the
-	// client will read the rest. A handler whose answer would exceed maxOutput
-	// should return what fits and report that more remains.
-	Transact(name string, input []byte, maxOutput int) (output []byte, moreRemains bool, err error)
+// PipeSession is one open of a named pipe: the handle side of a PipeHandler.
+//
+// It exists so that a handler can hold state belonging to one client's open of a
+// pipe rather than to the pipe itself. An RPC endpoint needs exactly that: a bind
+// establishes the presentation contexts and the fragment size that the requests
+// following it are interpreted against, two clients of one pipe bind separately,
+// and a handler keyed only by pipe name has nowhere to keep either.
+//
+// A session belongs to one open on one connection, and the server never uses one
+// from two goroutines at once.
+type PipeSession interface {
+	// Transact writes a message to the pipe and returns the answer.
+	//
+	// maxOutput is the largest answer the server will take in one exchange, which
+	// is maxPipeAnswerSize rather than the client's buffer: fitting the answer to
+	// the client is the server's job, because only the server knows how the client
+	// will read the rest. A session whose answer would exceed maxOutput should
+	// return what fits and report that more remains.
+	Transact(input []byte, maxOutput int) (output []byte, moreRemains bool, err error)
 
-	// ClosePipe releases whatever OpenPipe prepared.
-	ClosePipe(name string) error
+	// Close releases whatever the open prepared. The server calls it once, when
+	// the handle closes.
+	Close() error
 }
 
 // pipeNameOf extracts a pipe's name from the path a client opened.
@@ -173,11 +191,17 @@ func (c *Connection) runTransaction(w ResponseWriter, req *message.Message, reas
 		return c.peekNamedPipe(w, reassembly)
 
 	case subcommands.TRANS_WAIT_NMPIPE:
-		// The pipe is available as soon as the handler knows the name, so waiting
-		// for it succeeds immediately rather than blocking on nothing.
+		// The pipe is available as soon as the handler will open it, so waiting
+		// for it succeeds immediately rather than blocking on nothing. The
+		// session is released at once: the wait asks whether an instance can be
+		// had, not for one to keep.
 		name := pipeNameOf(reassembly.name)
-		if err := tree.Share.Pipes.OpenPipe(name); err != nil {
+		session, err := tree.Share.Pipes.OpenPipe(name)
+		if err != nil {
 			return nt_status.NT_STATUS_OBJECT_NAME_NOT_FOUND
+		}
+		if err := session.Close(); err != nil {
+			logger.Debugf("SMB1 server: releasing pipe %q after a wait reported %v", name, err)
 		}
 		return c.answerTransaction(w, reassembly, nil, nil)
 
@@ -405,10 +429,31 @@ func (c *Connection) transactNamedPipe(
 		return nt_status.NT_STATUS_OBJECT_NAME_NOT_FOUND
 	}
 
-	// The handler is asked for the whole answer, not for the part that fits: the
+	// The transaction runs on the handle's own session, which is what makes a
+	// bind and the requests after it one conversation. A client that sent no FID
+	// gets a session of its own for this one exchange, since there is no handle
+	// to have opened one on; an interface that needs a bind will refuse such a
+	// request, which is the honest outcome rather than a silent misdispatch.
+	session := open.pipeSession()
+	if session == nil {
+		transient, err := tree.Share.Pipes.OpenPipe(name)
+		if err != nil {
+			logger.Debugf("SMB1 server: %s transacted pipe %q without a FID and it would not open: %v",
+				c.Remote, name, err)
+			return statusForPipeError(err)
+		}
+		defer func() {
+			if err := transient.Close(); err != nil {
+				logger.Debugf("SMB1 server: releasing the transient session on pipe %q reported %v", name, err)
+			}
+		}()
+		session = transient
+	}
+
+	// The session is asked for the whole answer, not for the part that fits: the
 	// client's buffer bounds what one response may carry, not what the pipe
 	// produced, and the difference is what gets buffered for the client to read.
-	output, moreRemains, err := tree.Share.Pipes.Transact(name, reassembly.data, maxPipeAnswerSize)
+	output, moreRemains, err := session.Transact(reassembly.data, maxPipeAnswerSize)
 	if err != nil {
 		logger.Debugf("SMB1 server: pipe %q refused a transaction from %s: %v", name, c.Remote, err)
 		return statusForPipeError(err)
@@ -574,16 +619,17 @@ func (c *Connection) openPipe(w ResponseWriter, tree *Tree, requested string) nt
 		return nt_status.NT_STATUS_OBJECT_NAME_INVALID
 	}
 
-	if err := tree.Share.Pipes.OpenPipe(name); err != nil {
+	session, err := tree.Share.Pipes.OpenPipe(name)
+	if err != nil {
 		logger.Debugf("SMB1 server: %s could not open pipe %q: %v", c.Remote, name, err)
 		return statusForPipeError(err)
 	}
 
 	fid, err := c.fids.Allocate()
 	if err != nil {
-		// The handler prepared state for a handle that will not exist, so give it
-		// back rather than leaking it for the life of the connection.
-		if closeErr := tree.Share.Pipes.ClosePipe(name); closeErr != nil {
+		// The handler opened an instance for a handle that will not exist, so
+		// give it back rather than leaking it for the life of the connection.
+		if closeErr := session.Close(); closeErr != nil {
 			logger.Debugf("SMB1 server: releasing pipe %q after a failed open reported %v", name, closeErr)
 		}
 		logger.Warnf("SMB1 server: refusing a pipe open from %s: %v", c.Remote, err)
@@ -593,10 +639,11 @@ func (c *Connection) openPipe(w ResponseWriter, tree *Tree, requested string) nt
 	open := &Open{
 		FID:  fid,
 		Tree: tree,
-		// The name is stored as the handler sees it, since that is what every
-		// later call passes back to the handler.
+		// The name is stored as the handler sees it, for the log lines and the
+		// error messages that name the pipe a client is acting on.
 		Path:     name,
 		IsPipe:   true,
+		Pipe:     session,
 		Readable: true,
 		Writable: true,
 		Created:  time.Now().UTC(),

--- a/network/smb/smb_v10/server/live_interop_integration_test.go
+++ b/network/smb/smb_v10/server/live_interop_integration_test.go
@@ -109,20 +109,27 @@ func (p *livePipe) Calls() []string {
 	return append([]string(nil), p.calls...)
 }
 
-func (p *livePipe) OpenPipe(name string) error {
+func (p *livePipe) OpenPipe(name string) (PipeSession, error) {
 	p.record("open:" + name)
 	if strings.ToLower(name) != "srvsvc" {
-		return fmt.Errorf("pipe %q not found", name)
+		return nil, fmt.Errorf("pipe %q not found", name)
 	}
+	return &livePipeSession{handler: p, name: name}, nil
+}
+
+// livePipeSession is one open of a livePipe.
+type livePipeSession struct {
+	handler *livePipe
+	name    string
+}
+
+func (s *livePipeSession) Close() error {
+	s.handler.record("close:" + s.name)
 	return nil
 }
 
-func (p *livePipe) ClosePipe(name string) error {
-	p.record("close:" + name)
-	return nil
-}
-
-func (p *livePipe) Transact(name string, input []byte, maxOutput int) ([]byte, bool, error) {
+func (s *livePipeSession) Transact(input []byte, maxOutput int) ([]byte, bool, error) {
+	p, name := s.handler, s.name
 	if answer := rpcBindAck(input); answer != nil {
 		p.record("bind:" + name)
 		if len(answer) > maxOutput {

--- a/network/smb/smb_v10/server/nttransact_test.go
+++ b/network/smb/smb_v10/server/nttransact_test.go
@@ -24,6 +24,9 @@ import (
 
 // echoPipe is a PipeHandler that returns whatever is written to it, which is the
 // smallest handler that exercises the whole path a request-response pipe takes.
+//
+// It records the sessions it hands out so a test can assert that each open gets
+// its own and that closing a handle closes it.
 type echoPipe struct {
 	mutex sync.Mutex
 
@@ -33,6 +36,9 @@ type echoPipe struct {
 	// opened and closed record the calls, so a test can assert the lifecycle.
 	opened []string
 	closed []string
+
+	// sessions are the opens handed out, newest last.
+	sessions []*echoPipeSession
 
 	// prefix is prepended to every answer, so a test can tell the handler's
 	// output from its input.
@@ -50,22 +56,53 @@ func newEchoPipe(names ...string) *echoPipe {
 	return &echoPipe{names: served, prefix: "echo:"}
 }
 
-func (p *echoPipe) OpenPipe(name string) error {
+func (p *echoPipe) OpenPipe(name string) (PipeSession, error) {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 	if !p.names[strings.ToLower(name)] {
-		return fmt.Errorf("pipe %q not found", name)
+		return nil, fmt.Errorf("pipe %q not found", name)
 	}
 	p.opened = append(p.opened, name)
-	return nil
+
+	session := &echoPipeSession{handler: p, name: name}
+	p.sessions = append(p.sessions, session)
+	return session, nil
 }
 
-func (p *echoPipe) Transact(name string, input []byte, maxOutput int) ([]byte, bool, error) {
+// sessionCount reports how many sessions the handler has handed out, and
+// sessionAt returns one of them.
+func (p *echoPipe) sessionCount() int {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
-	if !p.names[strings.ToLower(name)] {
-		return nil, false, fmt.Errorf("pipe %q not found", name)
+	return len(p.sessions)
+}
+
+func (p *echoPipe) sessionAt(index int) *echoPipeSession {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+	return p.sessions[index]
+}
+
+// echoPipeSession is one open of an echoPipe.
+type echoPipeSession struct {
+	handler *echoPipe
+	name    string
+
+	// transacts counts the exchanges on this open, so a test can tell that two
+	// handles are two conversations.
+	transacts int
+	closed    bool
+}
+
+func (s *echoPipeSession) Transact(input []byte, maxOutput int) ([]byte, bool, error) {
+	p := s.handler
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	if s.closed {
+		return nil, false, fmt.Errorf("pipe %q: the session is closed", s.name)
 	}
+	s.transacts++
 
 	answer := append([]byte(p.prefix), input...)
 	if p.truncateAt > 0 && len(answer) > p.truncateAt {
@@ -77,10 +114,26 @@ func (p *echoPipe) Transact(name string, input []byte, maxOutput int) ([]byte, b
 	return answer, false, nil
 }
 
-func (p *echoPipe) ClosePipe(name string) error {
+// transactCount and isClosed read the session's state under the handler's lock,
+// since the goroutine serving the connection is what wrote it.
+func (s *echoPipeSession) transactCount() int {
+	s.handler.mutex.Lock()
+	defer s.handler.mutex.Unlock()
+	return s.transacts
+}
+
+func (s *echoPipeSession) isClosed() bool {
+	s.handler.mutex.Lock()
+	defer s.handler.mutex.Unlock()
+	return s.closed
+}
+
+func (s *echoPipeSession) Close() error {
+	p := s.handler
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
-	p.closed = append(p.closed, name)
+	s.closed = true
+	p.closed = append(p.closed, s.name)
 	return nil
 }
 
@@ -279,6 +332,81 @@ func TestNamedPipeTransact(t *testing.T) {
 	}
 	if got := pipes.closedNames(); len(got) != 1 || got[0] != "srvsvc" {
 		t.Errorf("the handler was asked to close %v, want [srvsvc]", got)
+	}
+}
+
+// TestNamedPipeEachHandleGetsItsOwnSession asserts that two opens of one pipe are
+// two conversations: each handle carries its own session, a transaction runs on
+// the session of the handle it names, and closing one handle closes only that
+// one.
+//
+// This is what an RPC endpoint depends on. A bind establishes the presentation
+// contexts and fragment size the requests after it are read against, so two
+// clients sharing a session would read each other's negotiation.
+func TestNamedPipeEachHandleGetsItsOwnSession(t *testing.T) {
+	pipes := newEchoPipe("srvsvc")
+	_, client := pipeServer(t, pipes)
+
+	first, err := openPipeHandle(t, client, `\PIPE\srvsvc`)
+	if err != nil {
+		t.Fatalf("opening the first handle failed: %v", err)
+	}
+	second, err := openPipeHandle(t, client, `\PIPE\srvsvc`)
+	if err != nil {
+		t.Fatalf("opening the second handle failed: %v", err)
+	}
+	if first == second {
+		t.Fatalf("both opens returned FID 0x%04X", first)
+	}
+
+	if got := pipes.sessionCount(); got != 2 {
+		t.Fatalf("two opens of one pipe produced %d sessions, want 2", got)
+	}
+	firstSession, secondSession := pipes.sessionAt(0), pipes.sessionAt(1)
+
+	// Two transactions on the first handle and one on the second, so the counts
+	// tell the sessions apart rather than merely proving both work.
+	for _, payload := range []string{"one", "two"} {
+		if _, status := transactPipe(t, client, first, []byte(payload)); status != 0 {
+			t.Fatalf("the transaction on the first handle answered 0x%08X", status)
+		}
+	}
+	if _, status := transactPipe(t, client, second, []byte("three")); status != 0 {
+		t.Fatalf("the transaction on the second handle answered 0x%08X", status)
+	}
+
+	if got := firstSession.transactCount(); got != 2 {
+		t.Errorf("the first handle's session saw %d transactions, want 2", got)
+	}
+	if got := secondSession.transactCount(); got != 1 {
+		t.Errorf("the second handle's session saw %d transactions, want 1", got)
+	}
+
+	// Closing one handle closes its session and leaves the other's alone, which
+	// is what lets a client keep a bound handle open while it closes another.
+	if err := client.CloseFile(first); err != nil {
+		t.Fatalf("closing the first handle failed: %v", err)
+	}
+	if !firstSession.isClosed() {
+		t.Error("closing the first handle did not close its session")
+	}
+	if secondSession.isClosed() {
+		t.Error("closing the first handle closed the second handle's session")
+	}
+
+	// The surviving handle still works.
+	if _, status := transactPipe(t, client, second, []byte("four")); status != 0 {
+		t.Errorf("the transaction on the surviving handle answered 0x%08X", status)
+	}
+	if got := secondSession.transactCount(); got != 2 {
+		t.Errorf("the surviving handle's session saw %d transactions, want 2", got)
+	}
+
+	if err := client.CloseFile(second); err != nil {
+		t.Fatalf("closing the second handle failed: %v", err)
+	}
+	if !secondSession.isClosed() {
+		t.Error("closing the second handle did not close its session")
 	}
 }
 
@@ -811,26 +939,28 @@ type oversizedAnswerPipe struct {
 	answer []byte
 }
 
-func (p *oversizedAnswerPipe) OpenPipe(name string) error {
+func (p *oversizedAnswerPipe) OpenPipe(name string) (PipeSession, error) {
 	if !strings.EqualFold(name, p.name) {
-		return fmt.Errorf("pipe %q not found", name)
+		return nil, fmt.Errorf("pipe %q not found", name)
 	}
-	return nil
+	return &oversizedAnswerSession{answer: p.answer}, nil
 }
 
-func (p *oversizedAnswerPipe) Transact(name string, input []byte, maxOutput int) ([]byte, bool, error) {
-	if !strings.EqualFold(name, p.name) {
-		return nil, false, fmt.Errorf("pipe %q not found", name)
-	}
-	if len(p.answer) > maxOutput {
-		return p.answer[:maxOutput], true, nil
+// oversizedAnswerSession is one open of an oversizedAnswerPipe.
+type oversizedAnswerSession struct {
+	answer []byte
+}
+
+func (s *oversizedAnswerSession) Transact(input []byte, maxOutput int) ([]byte, bool, error) {
+	if len(s.answer) > maxOutput {
+		return s.answer[:maxOutput], true, nil
 	}
 	// The whole answer is handed over: cutting it to the client's buffer is the
 	// server's job, and asserting that is the point of these tests.
-	return p.answer, false, nil
+	return s.answer, false, nil
 }
 
-func (p *oversizedAnswerPipe) ClosePipe(string) error { return nil }
+func (s *oversizedAnswerSession) Close() error { return nil }
 
 // countingAnswer is a block whose every byte identifies its own position, so a
 // reassembled answer that is right in length but wrong in order still fails.

--- a/network/smb/smb_v10/server/rpcpipe/doc.go
+++ b/network/smb/smb_v10/server/rpcpipe/doc.go
@@ -6,6 +6,9 @@
 // caller has to write DCE/RPC framing and NDR by hand before a server is
 // browsable.
 //
+// Each open of a pipe gets its own Session, so what one client's bind negotiates
+// belongs to that client.
+//
 //	srv, err := server.NewServer(server.Config{})
 //	srv.AddShare(&server.Share{Name: "PUBLIC", FS: fs, Comment: "Public files"})
 //	srv.AddShare(&server.Share{
@@ -36,13 +39,20 @@
 // rather than a fault, and is what makes a client fall back to a level that is
 // served.
 //
-// # One interface per pipe
+// # Pipes, opens and interfaces
 //
-// A pipe here carries exactly one interface: \srvsvc is srvsvc and \wkssvc is
-// wkssvc. That is how both are used, and it is also the only arrangement this can
-// serve — the PipeHandler contract names a pipe by name and not by open handle,
-// so a handler cannot tell two clients of one pipe apart and cannot hold the
-// per-open bind state that a pipe carrying several interfaces would need. A bind
-// is still checked against the interface the pipe carries, and one naming a
-// different interface is refused with a bind_nak.
+// OpenPipe returns a Session, and the session is where a client's RPC state
+// lives: its bind establishes the presentation contexts and the reply fragment
+// size that its later requests are read against. Two clients of \srvsvc get two
+// sessions and negotiate separately, so neither can see or disturb what the other
+// agreed.
+//
+// \srvsvc carries srvsvc and \wkssvc carries wkssvc, which is how Windows serves
+// them, and a bind naming an interface its pipe does not carry is refused with a
+// bind_nak. That is a property of these two pipes rather than a limit: a pipe may
+// carry several interfaces, and Options.Services adds interfaces to a built-in
+// pipe or adds a pipe of its own, so a caller can serve its own interface over
+// IPC$ without writing a PipeHandler. A request is dispatched by the presentation
+// context its bind negotiated, so which interface answers is what the client
+// asked for and never a guess.
 package rpcpipe

--- a/network/smb/smb_v10/server/rpcpipe/rpcpipe.go
+++ b/network/smb/smb_v10/server/rpcpipe/rpcpipe.go
@@ -48,6 +48,15 @@ type Options struct {
 	// Nil reports an empty list, which is what an endpoint with no share source
 	// should say rather than failing.
 	Shares func() []ShareEntry
+
+	// Services are further RPC interfaces to serve, keyed by pipe name.
+	//
+	// A name that is one of the built-in pipes adds its interfaces to that pipe,
+	// and any other name adds a pipe. A pipe may carry several interfaces: a bind
+	// picks one of them and the requests after it are dispatched by the
+	// presentation context it negotiated, so a caller can serve its own interface
+	// over IPC$ without writing a PipeHandler.
+	Services map[string][]rpcserver.Service
 }
 
 // defaultVersionMajor and defaultVersionMinor are the version reported when the
@@ -57,10 +66,13 @@ const (
 	defaultVersionMinor = 1
 )
 
-// Handler must satisfy the server's pipe contract, which is the whole point of
-// the package: a mismatch is a compile error here rather than a share that
-// refuses every pipe at run time.
-var _ server.PipeHandler = (*Handler)(nil)
+// Handler and Session must satisfy the server's pipe contract, which is the whole
+// point of the package: a mismatch is a compile error here rather than a share
+// that refuses every pipe at run time.
+var (
+	_ server.PipeHandler = (*Handler)(nil)
+	_ server.PipeSession = (*Session)(nil)
+)
 
 // Handler answers RPC calls on the pipes of an IPC$ share.
 //
@@ -77,12 +89,10 @@ var _ server.PipeHandler = (*Handler)(nil)
 // every connection the server accepts.
 type Handler struct {
 	// endpoints maps a normalised pipe name to the dispatcher answering it. It is
-	// written once by New and only read afterwards.
+	// written once by New and only read afterwards, which is what makes a Handler
+	// safe to share: everything a client establishes lives on the Session its
+	// open returns.
 	endpoints map[string]*rpcserver.Dispatcher
-
-	// mutex guards opened, the count of opens outstanding per pipe.
-	mutex  sync.Mutex
-	opened map[string]int
 }
 
 // New builds a Handler serving srvsvc and wkssvc.
@@ -103,18 +113,28 @@ func New(options Options) *Handler {
 		versionMajor, versionMinor = defaultVersionMajor, defaultVersionMinor
 	}
 
-	return &Handler{
-		endpoints: map[string]*rpcserver.Dispatcher{
-			"srvsvc": rpcserver.New(&srvsvcService{shares: shares}),
-			"wkssvc": rpcserver.New(&wkssvcService{
-				serverName:   options.ServerName,
-				domainName:   options.DomainName,
-				versionMajor: versionMajor,
-				versionMinor: versionMinor,
-			}),
-		},
-		opened: map[string]int{},
+	served := map[string][]rpcserver.Service{
+		"srvsvc": {&srvsvcService{shares: shares}},
+		"wkssvc": {&wkssvcService{
+			serverName:   options.ServerName,
+			domainName:   options.DomainName,
+			versionMajor: versionMajor,
+			versionMinor: versionMinor,
+		}},
 	}
+	for name, services := range options.Services {
+		endpoint := normalisePipeName(name)
+		if endpoint == "" || len(services) == 0 {
+			continue
+		}
+		served[endpoint] = append(served[endpoint], services...)
+	}
+
+	endpoints := make(map[string]*rpcserver.Dispatcher, len(served))
+	for endpoint, services := range served {
+		endpoints[endpoint] = rpcserver.New(services...)
+	}
+	return &Handler{endpoints: endpoints}
 }
 
 // ForServer builds a Handler whose share enumeration reports a server's own
@@ -154,41 +174,70 @@ func sharesOf(srv *server.Server) []ShareEntry {
 	return entries
 }
 
-// OpenPipe reports whether a pipe exists under this handler.
-func (h *Handler) OpenPipe(name string) error {
-	endpoint := normalisePipeName(name)
-	if _, served := h.endpoints[endpoint]; !served {
-		return fmt.Errorf("pipe %q is not served", name)
-	}
-
-	h.mutex.Lock()
-	h.opened[endpoint]++
-	h.mutex.Unlock()
-
-	logger.Debugf("rpcpipe: opened %q", endpoint)
-	return nil
-}
-
-// Transact answers one RPC exchange on a pipe.
+// OpenPipe opens one instance of a pipe.
+//
+// The session it returns owns this client's RPC association: what its bind
+// negotiates is remembered for the requests that follow, and two opens of the
+// same pipe negotiate independently.
 //
 // Parameters:
-//   - name: the pipe, without its leading separator or "PIPE" element
+//   - name: the pipe, in any of the forms a client names one
+//
+// Returns:
+//   - The session, or an error naming the pipe when this handler does not serve
+//     it
+func (h *Handler) OpenPipe(name string) (server.PipeSession, error) {
+	endpoint := normalisePipeName(name)
+	dispatcher, served := h.endpoints[endpoint]
+	if !served {
+		// "not found" is the wording the server maps to
+		// STATUS_OBJECT_NAME_NOT_FOUND, which is what a client asking for a pipe
+		// that does not exist should be told.
+		return nil, fmt.Errorf("pipe %q not found", name)
+	}
+
+	logger.Debugf("rpcpipe: opened %q", endpoint)
+	return &Session{name: endpoint, association: dispatcher.Open()}, nil
+}
+
+// Session is one open of a pipe served by a Handler.
+//
+// It holds the RPC association for that open, which is the whole reason a session
+// exists: a bind establishes the presentation contexts and the fragment size the
+// requests after it are read against, and those belong to one client's open rather
+// than to the pipe.
+type Session struct {
+	// name is the pipe this session is an open of, for the log lines and errors
+	// that name it.
+	name string
+
+	// association is this open's RPC conversation with the endpoint.
+	association *rpcserver.Association
+
+	// mutex guards closed. A session belongs to one open on one connection, so
+	// the server does not use one from two goroutines; the guard is here so a
+	// caller that does still gets an error rather than a race.
+	mutex  sync.Mutex
+	closed bool
+}
+
+// Transact answers one RPC exchange on this open.
+//
+// Parameters:
 //   - input: the request PDU the client wrote
 //   - maxOutput: the largest answer the caller will take in one exchange
 //
 // Returns:
 //   - The reply PDUs, whether more of the answer remains, and an error only when
-//     the pipe is not served or the request is not a PDU at all
-func (h *Handler) Transact(name string, input []byte, maxOutput int) ([]byte, bool, error) {
-	endpoint := normalisePipeName(name)
-	dispatcher, served := h.endpoints[endpoint]
-	if !served {
-		return nil, false, fmt.Errorf("pipe %q is not served", name)
+//     the session is closed or the request is not a PDU at all
+func (s *Session) Transact(input []byte, maxOutput int) ([]byte, bool, error) {
+	if s.isClosed() {
+		return nil, false, fmt.Errorf("pipe %q: the session is closed", s.name)
 	}
 
-	reply, err := dispatcher.Handle(input)
+	reply, err := s.association.Handle(input)
 	if err != nil {
-		return nil, false, fmt.Errorf("pipe %q: %w", endpoint, err)
+		return nil, false, fmt.Errorf("pipe %q: %w", s.name, err)
 	}
 
 	// An answer past the caller's ceiling is cut and reported as incomplete,
@@ -196,24 +245,33 @@ func (h *Handler) Transact(name string, input []byte, maxOutput int) ([]byte, bo
 	// client reads the rest off the handle.
 	if maxOutput > 0 && len(reply) > maxOutput {
 		logger.Debugf("rpcpipe: %q answered with %d bytes, cut to the %d the caller allows",
-			endpoint, len(reply), maxOutput)
+			s.name, len(reply), maxOutput)
 		return reply[:maxOutput], true, nil
 	}
 
-	logger.Debugf("rpcpipe: %q answered %d request bytes with %d", endpoint, len(input), len(reply))
+	logger.Debugf("rpcpipe: %q answered %d request bytes with %d", s.name, len(input), len(reply))
 	return reply, false, nil
 }
 
-// ClosePipe releases what OpenPipe recorded.
-func (h *Handler) ClosePipe(name string) error {
-	endpoint := normalisePipeName(name)
-
-	h.mutex.Lock()
-	if h.opened[endpoint] > 0 {
-		h.opened[endpoint]--
-	}
-	h.mutex.Unlock()
+// Close releases the session. It is safe to call more than once.
+func (s *Session) Close() error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	s.closed = true
 	return nil
+}
+
+// Bound reports how many presentation contexts this open has negotiated, which is
+// zero until its client binds.
+func (s *Session) Bound() int {
+	return s.association.Bound()
+}
+
+// isClosed reports whether Close has been called.
+func (s *Session) isClosed() bool {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	return s.closed
 }
 
 // Pipes returns the pipe names this handler serves, sorted for a stable listing.
@@ -244,7 +302,14 @@ func sortStrings(values []string) {
 // case-insensitive because pipe names are.
 func normalisePipeName(name string) string {
 	trimmed := strings.Trim(strings.ReplaceAll(name, `\`, "/"), "/")
-	if upper := strings.ToUpper(trimmed); strings.HasPrefix(upper, "PIPE/") {
+
+	upper := strings.ToUpper(trimmed)
+	switch {
+	case upper == "PIPE":
+		// The pipe directory itself, which names no pipe. Without this it would
+		// normalise to "pipe" and a caller could register an endpoint under it.
+		return ""
+	case strings.HasPrefix(upper, "PIPE/"):
 		trimmed = trimmed[len("PIPE/"):]
 	}
 	return strings.ToLower(strings.Trim(trimmed, "/"))

--- a/network/smb/smb_v10/server/rpcpipe/rpcpipe_test.go
+++ b/network/smb/smb_v10/server/rpcpipe/rpcpipe_test.go
@@ -12,7 +12,9 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/pdu"
+	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/rpcserver"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/server"
+	"github.com/TheManticoreProject/Manticore/windows/guid"
 	mssrvs "github.com/TheManticoreProject/Manticore/windows/protocols/ms-srvs"
 )
 
@@ -31,9 +33,28 @@ const maxPipeAnswer = 64 * 1024
 // would fail here rather than only against a real client.
 type pipeInvoker struct {
 	t       *testing.T
-	handler *Handler
 	pipe    string
+	session server.PipeSession
 	callID  uint32
+}
+
+// openInvoker opens a pipe on a handler and returns a client for that open.
+//
+// The session is what the invoker drives, because that is what a client holds: an
+// open of the pipe, not the pipe.
+func openInvoker(t *testing.T, handler *Handler, pipe string) *pipeInvoker {
+	t.Helper()
+
+	session, err := handler.OpenPipe(pipe)
+	if err != nil {
+		t.Fatalf("OpenPipe(%q) failed: %v", pipe, err)
+	}
+	t.Cleanup(func() {
+		if err := session.Close(); err != nil {
+			t.Errorf("closing the session on %q failed: %v", pipe, err)
+		}
+	})
+	return &pipeInvoker{t: t, pipe: pipe, session: session}
 }
 
 // bind performs the association's bind and returns the bind_ack.
@@ -56,7 +77,7 @@ func (p *pipeInvoker) bind(abstract syntax.SyntaxID) *pdu.BindAck {
 		p.t.Fatalf("failed to marshal the bind: %v", err)
 	}
 
-	reply, more, err := p.handler.Transact(p.pipe, request, maxPipeAnswer)
+	reply, more, err := p.session.Transact(request, maxPipeAnswer)
 	if err != nil {
 		p.t.Fatalf("Transact refused the bind on %q: %v", p.pipe, err)
 	}
@@ -97,7 +118,7 @@ func (p *pipeInvoker) Invoke(in ndr.Call, out any) error {
 		return fmt.Errorf("marshal the request PDU: %w", err)
 	}
 
-	reply, more, err := p.handler.Transact(p.pipe, framed, maxPipeAnswer)
+	reply, more, err := p.session.Transact(framed, maxPipeAnswer)
 	if err != nil {
 		return fmt.Errorf("transact on %q: %w", p.pipe, err)
 	}
@@ -113,6 +134,69 @@ func (p *pipeInvoker) Invoke(in ndr.Call, out any) error {
 		return fmt.Errorf("unmarshal the response stub: %w", err)
 	}
 	return nil
+}
+
+// callRaw sends one request with a stub of its own choosing and reports what came
+// back, so a test can drive an opnum or a stub no client stub would produce.
+//
+// Parameters:
+//   - opnum: the method to call
+//   - stub: the request stub, byte for byte
+//
+// Returns:
+//   - nil when a response came back, or the fault or transport error
+func (p *pipeInvoker) callRaw(opnum uint16, stub []byte) error {
+	p.t.Helper()
+
+	p.callID++
+	request := &pdu.Request{
+		Header: pdu.NewHeader(pdu.PacketTypeRequest, pdu.PFCFirstFrag|pdu.PFCLastFrag, p.callID),
+		Opnum:  opnum,
+		Stub:   stub,
+	}
+	framed, err := request.Marshal()
+	if err != nil {
+		p.t.Fatalf("failed to marshal the request: %v", err)
+	}
+
+	reply, _, err := p.session.Transact(framed, maxPipeAnswer)
+	if err != nil {
+		return fmt.Errorf("transact on %q: %w", p.pipe, err)
+	}
+	_, err = reassemble(reply)
+	return err
+}
+
+// callOnContext sends one request under a chosen presentation context and returns
+// the reassembled response stub.
+//
+// Parameters:
+//   - contextID: the presentation context to send under
+//   - opnum: the method to call
+//   - stub: the request stub
+//
+// Returns:
+//   - The response stub, or the fault the call produced
+func (p *pipeInvoker) callOnContext(contextID uint16, opnum uint16, stub []byte) ([]byte, error) {
+	p.t.Helper()
+
+	p.callID++
+	request := &pdu.Request{
+		Header:    pdu.NewHeader(pdu.PacketTypeRequest, pdu.PFCFirstFrag|pdu.PFCLastFrag, p.callID),
+		ContextID: contextID,
+		Opnum:     opnum,
+		Stub:      stub,
+	}
+	framed, err := request.Marshal()
+	if err != nil {
+		p.t.Fatalf("failed to marshal the request: %v", err)
+	}
+
+	reply, _, err := p.session.Transact(framed, maxPipeAnswer)
+	if err != nil {
+		return nil, fmt.Errorf("transact on %q: %w", p.pipe, err)
+	}
+	return reassemble(reply)
 }
 
 // reassemble joins the response fragments of a reply, and reports a fault as an
@@ -184,18 +268,81 @@ func TestHandlerSatisfiesThePipeContract(t *testing.T) {
 	handler := testHandler()
 
 	for _, name := range []string{"srvsvc", "wkssvc", `\PIPE\srvsvc`, "PIPE/wkssvc", "SrvSvc"} {
-		if err := handler.OpenPipe(name); err != nil {
+		session, err := handler.OpenPipe(name)
+		if err != nil {
 			t.Errorf("OpenPipe(%q) failed: %v", name, err)
 			continue
 		}
-		if err := handler.ClosePipe(name); err != nil {
-			t.Errorf("ClosePipe(%q) failed: %v", name, err)
+		if session == nil {
+			t.Errorf("OpenPipe(%q) returned no session and no error", name)
+			continue
+		}
+		if err := session.Close(); err != nil {
+			t.Errorf("closing the session on %q failed: %v", name, err)
+		}
+		// Closing twice is what happens when a handle is released along two
+		// paths, so it has to be harmless rather than an error the server logs.
+		if err := session.Close(); err != nil {
+			t.Errorf("closing the session on %q a second time failed: %v", name, err)
 		}
 	}
 
 	for _, name := range []string{"lsarpc", "samr", "", "srvsvc2"} {
-		if err := handler.OpenPipe(name); err == nil {
+		session, err := handler.OpenPipe(name)
+		if err == nil {
 			t.Errorf("OpenPipe(%q) succeeded for a pipe this handler does not serve", name)
+			continue
+		}
+		if session != nil {
+			t.Errorf("OpenPipe(%q) returned a session alongside its error", name)
+		}
+		// The server turns an error whose message says "not found" into
+		// STATUS_OBJECT_NAME_NOT_FOUND, which is what a client asking for a pipe
+		// that does not exist has to be told.
+		if !strings.Contains(err.Error(), "not found") {
+			t.Errorf("OpenPipe(%q) failed with %v, which the server cannot map to STATUS_OBJECT_NAME_NOT_FOUND", name, err)
+		}
+	}
+}
+
+func TestTransactAfterCloseIsRefused(t *testing.T) {
+	session, err := testHandler().OpenPipe("srvsvc")
+	if err != nil {
+		t.Fatalf("OpenPipe failed: %v", err)
+	}
+	if err := session.Close(); err != nil {
+		t.Fatalf("closing the session failed: %v", err)
+	}
+
+	if _, _, err := session.Transact([]byte{0}, maxPipeAnswer); err == nil {
+		t.Error("a closed session answered a transaction")
+	}
+}
+
+func TestNormalisePipeName(t *testing.T) {
+	// The server strips the leading separator and the PIPE element before it
+	// calls a handler, but Options.Services and a caller handing over a raw path
+	// both come through here, so every form a client names a pipe in has to
+	// reduce to the endpoint name.
+	cases := map[string]string{
+		"srvsvc":        "srvsvc",
+		"SrvSvc":        "srvsvc",
+		`\srvsvc`:       "srvsvc",
+		`\PIPE\srvsvc`:  "srvsvc",
+		`\pipe\srvsvc`:  "srvsvc",
+		"PIPE/srvsvc":   "srvsvc",
+		"/pipe/srvsvc/": "srvsvc",
+		// The pipe directory itself names no pipe, and neither does nothing.
+		`\PIPE\`: "",
+		"PIPE":   "",
+		"pipe":   "",
+		`\`:      "",
+		"":       "",
+	}
+
+	for given, want := range cases {
+		if got := normalisePipeName(given); got != want {
+			t.Errorf("normalisePipeName(%q) is %q, want %q", given, got, want)
 		}
 	}
 }
@@ -209,11 +356,11 @@ func TestPipesServed(t *testing.T) {
 	}
 }
 
-func TestTransactOnAnUnservedPipeFails(t *testing.T) {
-	handler := testHandler()
+func TestSomethingThatIsNotAPDUIsRefused(t *testing.T) {
+	rpc := openInvoker(t, testHandler(), "srvsvc")
 
-	if _, _, err := handler.Transact("lsarpc", []byte{0}, maxPipeAnswer); err == nil {
-		t.Error("Transact answered on a pipe the handler does not serve")
+	if _, _, err := rpc.session.Transact([]byte("not a PDU"), maxPipeAnswer); err == nil {
+		t.Error("the session accepted nine bytes that are not a PDU")
 	}
 }
 
@@ -221,8 +368,8 @@ func TestBindOnEachPipeNamesItsOwnInterface(t *testing.T) {
 	handler := testHandler(sampleShares()...)
 
 	// The srvsvc pipe accepts srvsvc and refuses wkssvc, and the other way
-	// round. That is the whole of what one-interface-per-pipe means, and it is
-	// what a client relies on to discover it opened the wrong pipe.
+	// round. Each pipe carries the interface it is named for, which is what a
+	// client relies on to discover it opened the wrong pipe.
 	cases := []struct {
 		pipe     string
 		abstract syntax.SyntaxID
@@ -251,7 +398,8 @@ func TestBindOnEachPipeNamesItsOwnInterface(t *testing.T) {
 				t.Fatalf("failed to marshal the bind: %v", err)
 			}
 
-			reply, _, err := handler.Transact(test.pipe, request, maxPipeAnswer)
+			rpc := openInvoker(t, handler, test.pipe)
+			reply, _, err := rpc.session.Transact(request, maxPipeAnswer)
 			if err != nil {
 				t.Fatalf("Transact failed: %v", err)
 			}
@@ -281,7 +429,7 @@ func TestNetrShareEnumLevel1ReportsEveryShare(t *testing.T) {
 	shares := sampleShares()
 	handler := testHandler(shares...)
 
-	rpc := &pipeInvoker{t: t, handler: handler, pipe: "srvsvc"}
+	rpc := openInvoker(t, handler, "srvsvc")
 	rpc.bind(srvsvcSyntax())
 
 	info, total, resume, err := srvsvcfunctions.NetrShareEnum(rpc, "",
@@ -326,7 +474,7 @@ func TestNetrShareEnumLevel1ReportsEveryShare(t *testing.T) {
 
 func TestNetrShareEnumLevel0ReportsNamesOnly(t *testing.T) {
 	shares := sampleShares()
-	rpc := &pipeInvoker{t: t, handler: testHandler(shares...), pipe: "srvsvc"}
+	rpc := openInvoker(t, testHandler(shares...), "srvsvc")
 	rpc.bind(srvsvcSyntax())
 
 	info, total, _, err := srvsvcfunctions.NetrShareEnum(rpc, "",
@@ -359,7 +507,7 @@ func TestNetrShareEnumLevel0ReportsNamesOnly(t *testing.T) {
 func TestNetrShareEnumOnAnEmptyServer(t *testing.T) {
 	// A server with no shares answers an empty list, not a failure: that is how
 	// a client learns there is nothing to browse.
-	rpc := &pipeInvoker{t: t, handler: testHandler(), pipe: "srvsvc"}
+	rpc := openInvoker(t, testHandler(), "srvsvc")
 	rpc.bind(srvsvcSyntax())
 
 	info, total, _, err := srvsvcfunctions.NetrShareEnum(rpc, "",
@@ -383,7 +531,7 @@ func TestNetrShareEnumWithNoShareSourceReportsNone(t *testing.T) {
 	// Options.Shares left nil. Reporting nothing is the honest answer for an
 	// endpoint with no share source, and a nil call would panic on the
 	// connection's goroutine.
-	rpc := &pipeInvoker{t: t, handler: New(Options{}), pipe: "srvsvc"}
+	rpc := openInvoker(t, New(Options{}), "srvsvc")
 	rpc.bind(srvsvcSyntax())
 
 	_, total, _, err := srvsvcfunctions.NetrShareEnum(rpc, "",
@@ -398,7 +546,7 @@ func TestNetrShareEnumWithNoShareSourceReportsNone(t *testing.T) {
 }
 
 func TestNetrShareEnumRefusesAnUnservedLevel(t *testing.T) {
-	rpc := &pipeInvoker{t: t, handler: testHandler(sampleShares()...), pipe: "srvsvc"}
+	rpc := openInvoker(t, testHandler(sampleShares()...), "srvsvc")
 	rpc.bind(srvsvcSyntax())
 
 	// Level 2 has a union arm this does not fill, and level 99 has none at all.
@@ -420,32 +568,68 @@ func TestNetrShareEnumRefusesAnUnservedLevel(t *testing.T) {
 }
 
 func TestNetrShareEnumUnknownOpnumFaults(t *testing.T) {
-	handler := testHandler(sampleShares()...)
+	rpc := openInvoker(t, testHandler(sampleShares()...), "srvsvc")
+	rpc.bind(srvsvcSyntax())
 
 	// NetrShareAdd, opnum 14, which this does not implement.
-	request := &pdu.Request{
-		Header: pdu.NewHeader(pdu.PacketTypeRequest, pdu.PFCFirstFrag|pdu.PFCLastFrag, 1),
-		Opnum:  srvsvc.OpnumNetrShareAdd,
-		Stub:   make([]byte, 16),
-	}
-	framed, err := request.Marshal()
-	if err != nil {
-		t.Fatalf("failed to marshal the request: %v", err)
-	}
-
-	reply, _, err := handler.Transact("srvsvc", framed, maxPipeAnswer)
-	if err != nil {
-		t.Fatalf("Transact failed: %v", err)
-	}
-	if _, err := reassemble(reply); err == nil {
+	if err := rpc.callRaw(srvsvc.OpnumNetrShareAdd, make([]byte, 16)); err == nil {
 		t.Fatal("an opnum the interface does not implement was answered with a response")
 	} else if !strings.Contains(err.Error(), "nca_s_op_rng_error") {
 		t.Errorf("the call failed with %v, want a fault of nca_s_op_rng_error", err)
 	}
 }
 
-func TestNetrShareEnumUndecodableStubFaults(t *testing.T) {
+func TestRequestBeforeABindFaults(t *testing.T) {
+	// A request names its interface by the presentation context its bind
+	// negotiated, so one that arrives before any bind names nothing.
+	rpc := openInvoker(t, testHandler(sampleShares()...), "srvsvc")
+
+	if err := rpc.callRaw(srvsvc.OpnumNetrShareEnum, make([]byte, 32)); err == nil {
+		t.Fatal("a request before a bind was answered with a response")
+	} else if !strings.Contains(err.Error(), "nca_s_fault_context_mismatch") {
+		t.Errorf("the call failed with %v, want a fault of nca_s_fault_context_mismatch", err)
+	}
+}
+
+func TestTwoOpensOfOnePipeBindSeparately(t *testing.T) {
+	// The point of a session. Two clients open \srvsvc; one binds and the other
+	// does not, and only the one that bound can call. A handler keyed by pipe
+	// name would have let the second client ride on the first one's bind.
 	handler := testHandler(sampleShares()...)
+
+	bound := openInvoker(t, handler, "srvsvc")
+	bound.bind(srvsvcSyntax())
+	unbound := openInvoker(t, handler, "srvsvc")
+
+	if _, _, _, err := srvsvcfunctions.NetrShareEnum(bound, "",
+		mssrvs.SHARE_ENUM_STRUCT{Level: 1, ShareInfo: mssrvs.SHARE_ENUM_UNION{Tag: 1}},
+		maxPreferredLength, nil); err != nil {
+		t.Fatalf("the bound client's enumeration failed: %v", err)
+	}
+
+	if err := unbound.callRaw(srvsvc.OpnumNetrShareEnum, make([]byte, 32)); err == nil {
+		t.Fatal("the client that never bound was answered with a response")
+	} else if !strings.Contains(err.Error(), "nca_s_fault_context_mismatch") {
+		t.Errorf("the unbound client's call failed with %v, want nca_s_fault_context_mismatch", err)
+	}
+
+	// Bound counts what each open negotiated, which is the state a session
+	// exists to hold.
+	if session, ok := bound.session.(*Session); ok {
+		if got := session.Bound(); got != 1 {
+			t.Errorf("the bound open reports %d presentation contexts, want 1", got)
+		}
+	}
+	if session, ok := unbound.session.(*Session); ok {
+		if got := session.Bound(); got != 0 {
+			t.Errorf("the open that never bound reports %d presentation contexts, want 0", got)
+		}
+	}
+}
+
+func TestNetrShareEnumUndecodableStubFaults(t *testing.T) {
+	rpc := openInvoker(t, testHandler(sampleShares()...), "srvsvc")
+	rpc.bind(srvsvcSyntax())
 
 	// Three bytes where a SHARE_ENUM_STRUCT and three more parameters belong.
 	request := &pdu.Request{
@@ -458,7 +642,7 @@ func TestNetrShareEnumUndecodableStubFaults(t *testing.T) {
 		t.Fatalf("failed to marshal the request: %v", err)
 	}
 
-	reply, _, err := handler.Transact("srvsvc", framed, maxPipeAnswer)
+	reply, _, err := rpc.session.Transact(framed, maxPipeAnswer)
 	if err != nil {
 		t.Fatalf("Transact failed: %v", err)
 	}
@@ -474,7 +658,7 @@ func TestNetrShareEnumResumesWhereItStopped(t *testing.T) {
 	// it with ERROR_MORE_DATA and a resume handle, which the client sends back to
 	// continue. Walking it to the end has to yield every share exactly once.
 	shares := sampleShares()
-	rpc := &pipeInvoker{t: t, handler: testHandler(shares...), pipe: "srvsvc"}
+	rpc := openInvoker(t, testHandler(shares...), "srvsvc")
 	rpc.bind(srvsvcSyntax())
 
 	handle := ndr.DWORD(0)
@@ -521,7 +705,7 @@ func TestNetrShareEnumResumesWhereItStopped(t *testing.T) {
 func TestNetrShareEnumResumeHandlePastTheEndFinishes(t *testing.T) {
 	// A share removed between two calls can leave a handle past the end. The
 	// enumeration is over, and saying so is what lets the client stop.
-	rpc := &pipeInvoker{t: t, handler: testHandler(sampleShares()...), pipe: "srvsvc"}
+	rpc := openInvoker(t, testHandler(sampleShares()...), "srvsvc")
 	rpc.bind(srvsvcSyntax())
 
 	handle := ndr.DWORD(9999)
@@ -557,7 +741,7 @@ func TestNetrShareEnumFragmentsALongList(t *testing.T) {
 	}
 
 	handler := testHandler(shares...)
-	rpc := &pipeInvoker{t: t, handler: handler, pipe: "srvsvc"}
+	rpc := openInvoker(t, handler, "srvsvc")
 	rpc.bind(srvsvcSyntax())
 
 	info, total, _, err := srvsvcfunctions.NetrShareEnum(rpc, "",
@@ -586,7 +770,7 @@ func TestNetrShareEnumFragmentsALongList(t *testing.T) {
 }
 
 func TestNetrWkstaGetInfoLevel100(t *testing.T) {
-	rpc := &pipeInvoker{t: t, handler: testHandler(), pipe: "wkssvc"}
+	rpc := openInvoker(t, testHandler(), "wkssvc")
 	rpc.bind(wkssvcSyntax())
 
 	info, err := wkssvcfunctions.NetrWkstaGetInfo(rpc, nil, 100)
@@ -618,7 +802,7 @@ func TestNetrWkstaGetInfoLevel100(t *testing.T) {
 
 func TestNetrWkstaGetInfoLevel101(t *testing.T) {
 	handler := New(Options{ServerName: "HOST", DomainName: "LAB", VersionMajor: 10, VersionMinor: 0})
-	rpc := &pipeInvoker{t: t, handler: handler, pipe: "wkssvc"}
+	rpc := openInvoker(t, handler, "wkssvc")
 	rpc.bind(wkssvcSyntax())
 
 	info, err := wkssvcfunctions.NetrWkstaGetInfo(rpc, nil, 101)
@@ -648,7 +832,7 @@ func TestNetrWkstaGetInfoLevel101(t *testing.T) {
 }
 
 func TestNetrWkstaGetInfoWithNoNamesConfigured(t *testing.T) {
-	rpc := &pipeInvoker{t: t, handler: New(Options{}), pipe: "wkssvc"}
+	rpc := openInvoker(t, New(Options{}), "wkssvc")
 	rpc.bind(wkssvcSyntax())
 
 	info, err := wkssvcfunctions.NetrWkstaGetInfo(rpc, nil, 100)
@@ -665,7 +849,7 @@ func TestNetrWkstaGetInfoWithNoNamesConfigured(t *testing.T) {
 }
 
 func TestNetrWkstaGetInfoRefusesAnUnservedLevel(t *testing.T) {
-	rpc := &pipeInvoker{t: t, handler: testHandler(), pipe: "wkssvc"}
+	rpc := openInvoker(t, testHandler(), "wkssvc")
 	rpc.bind(wkssvcSyntax())
 
 	for _, level := range []ndr.DWORD{102, 502, 1013, 0} {
@@ -704,7 +888,7 @@ func TestForServerReportsTheServersOwnShares(t *testing.T) {
 		t.Fatalf("failed to add PUBLIC: %v", err)
 	}
 
-	rpc := &pipeInvoker{t: t, handler: pipes, pipe: "srvsvc"}
+	rpc := openInvoker(t, pipes, "srvsvc")
 	rpc.bind(srvsvcSyntax())
 
 	info, _, _, err := srvsvcfunctions.NetrShareEnum(rpc, "",
@@ -765,7 +949,7 @@ func TestForServerReportsTheServersOwnShares(t *testing.T) {
 }
 
 func TestForServerWithoutAServerReportsNoShares(t *testing.T) {
-	rpc := &pipeInvoker{t: t, handler: ForServer(nil, Options{}), pipe: "srvsvc"}
+	rpc := openInvoker(t, ForServer(nil, Options{}), "srvsvc")
 	rpc.bind(srvsvcSyntax())
 
 	_, total, _, err := srvsvcfunctions.NetrShareEnum(rpc, "",
@@ -807,38 +991,34 @@ func TestShareTypeOf(t *testing.T) {
 func TestConcurrentClientsOfOnePipe(t *testing.T) {
 	// The SMB server calls a pipe handler on the goroutine of whichever
 	// connection is asking, and one handler serves every connection. Under -race
-	// this is what proves the handler can be shared.
+	// this is what proves the handler and its endpoints can be shared while each
+	// client keeps its own association.
 	handler := testHandler(sampleShares()...)
 
-	var waiting sync.WaitGroup
+	// The opens and binds happen on the test's own goroutine, because the
+	// helpers report failure with t.Fatalf and only that goroutine may. What runs
+	// concurrently below is the calls.
+	clients := make([]*pipeInvoker, 0, 8)
 	for client := 0; client < 8; client++ {
+		pipe := "srvsvc"
+		abstract := srvsvcSyntax()
+		if client%2 == 1 {
+			pipe, abstract = "wkssvc", wkssvcSyntax()
+		}
+
+		rpc := openInvoker(t, handler, pipe)
+		rpc.callID = uint32(client) * 1000
+		rpc.bind(abstract)
+		clients = append(clients, rpc)
+	}
+
+	var waiting sync.WaitGroup
+	for client, rpc := range clients {
 		waiting.Add(1)
-		go func(client int) {
+		go func(client int, rpc *pipeInvoker) {
 			defer waiting.Done()
-
-			pipe := "srvsvc"
-			if client%2 == 1 {
-				pipe = "wkssvc"
-			}
-			if err := handler.OpenPipe(pipe); err != nil {
-				t.Errorf("client %d: OpenPipe failed: %v", client, err)
-				return
-			}
-			defer func() {
-				if err := handler.ClosePipe(pipe); err != nil {
-					t.Errorf("client %d: ClosePipe failed: %v", client, err)
-				}
-			}()
-
-			rpc := &pipeInvoker{t: t, handler: handler, pipe: pipe, callID: uint32(client) * 1000}
-			if pipe == "srvsvc" {
-				rpc.bind(srvsvcSyntax())
-			} else {
-				rpc.bind(wkssvcSyntax())
-			}
-
 			for round := 0; round < 10; round++ {
-				if pipe == "srvsvc" {
+				if rpc.pipe == "srvsvc" {
 					if _, _, _, err := srvsvcfunctions.NetrShareEnum(rpc, "",
 						mssrvs.SHARE_ENUM_STRUCT{Level: 1, ShareInfo: mssrvs.SHARE_ENUM_UNION{Tag: 1}},
 						maxPreferredLength, nil); err != nil {
@@ -852,7 +1032,181 @@ func TestConcurrentClientsOfOnePipe(t *testing.T) {
 					return
 				}
 			}
-		}(client)
+		}(client, rpc)
 	}
 	waiting.Wait()
+}
+
+func TestConcurrentOpensOfOnePipe(t *testing.T) {
+	// A handler is reachable from every connection the server accepts, so opens
+	// of one pipe overlap. Each has to come back with a session of its own.
+	handler := testHandler(sampleShares()...)
+
+	sessions := make([]server.PipeSession, 16)
+	var waiting sync.WaitGroup
+	for index := range sessions {
+		waiting.Add(1)
+		go func(index int) {
+			defer waiting.Done()
+			session, err := handler.OpenPipe("srvsvc")
+			if err != nil {
+				t.Errorf("open %d failed: %v", index, err)
+				return
+			}
+			sessions[index] = session
+		}(index)
+	}
+	waiting.Wait()
+
+	distinct := map[server.PipeSession]bool{}
+	for index, session := range sessions {
+		if session == nil {
+			t.Fatalf("open %d produced no session", index)
+		}
+		if distinct[session] {
+			t.Errorf("open %d was handed a session another open already holds", index)
+		}
+		distinct[session] = true
+	}
+
+	for index, session := range sessions {
+		if err := session.Close(); err != nil {
+			t.Errorf("closing session %d failed: %v", index, err)
+		}
+	}
+}
+
+func TestServicesOptionAddsAnInterfaceToAPipe(t *testing.T) {
+	// A pipe may carry more than one interface. Here srvsvc and a caller's own
+	// interface share \srvsvc: a bind offering both is accepted under two
+	// presentation contexts, and each request is answered by the interface its
+	// context names.
+	extra := &countingService{answer: []byte("from the caller's interface")}
+	handler := New(Options{
+		Shares:   func() []ShareEntry { return sampleShares() },
+		Services: map[string][]rpcserver.Service{`\PIPE\srvsvc`: {extra}},
+	})
+
+	rpc := openInvoker(t, handler, "srvsvc")
+	bind := &pdu.Bind{
+		Header:      pdu.NewHeader(pdu.PacketTypeBind, pdu.PFCFirstFrag|pdu.PFCLastFrag, 1),
+		MaxXmitFrag: 4280,
+		MaxRecvFrag: 4280,
+		ContextList: []pdu.ContextElement{
+			{
+				ContextID:        0,
+				AbstractSyntax:   srvsvcSyntax(),
+				TransferSyntaxes: []syntax.SyntaxID{syntax.NDRTransferSyntax()},
+			},
+			{
+				ContextID:        1,
+				AbstractSyntax:   extra.AbstractSyntax(),
+				TransferSyntaxes: []syntax.SyntaxID{syntax.NDRTransferSyntax()},
+			},
+		},
+	}
+	request, err := bind.Marshal()
+	if err != nil {
+		t.Fatalf("failed to marshal the bind: %v", err)
+	}
+
+	reply, _, err := rpc.session.Transact(request, maxPipeAnswer)
+	if err != nil {
+		t.Fatalf("Transact failed: %v", err)
+	}
+	ack := &pdu.BindAck{}
+	if _, err := ack.Unmarshal(reply); err != nil {
+		t.Fatalf("the bind was not accepted: %v", err)
+	}
+	for index, result := range ack.Results {
+		if result.Result != pdu.ResultAcceptance {
+			t.Fatalf("context %d was answered with result %d, want acceptance", index, result.Result)
+		}
+	}
+
+	// The share enumeration still works, on context 0.
+	if _, _, _, err := srvsvcfunctions.NetrShareEnum(rpc, "",
+		mssrvs.SHARE_ENUM_STRUCT{Level: 1, ShareInfo: mssrvs.SHARE_ENUM_UNION{Tag: 1}},
+		maxPreferredLength, nil); err != nil {
+		t.Fatalf("NetrShareEnum on the shared pipe failed: %v", err)
+	}
+
+	// And the caller's interface answers on context 1.
+	answer, err := rpc.callOnContext(1, 0, nil)
+	if err != nil {
+		t.Fatalf("the caller's interface failed: %v", err)
+	}
+	if string(answer) != string(extra.answer) {
+		t.Errorf("the caller's interface returned %q, want %q", answer, extra.answer)
+	}
+	if extra.callCount() != 1 {
+		t.Errorf("the caller's interface was called %d times, want 1", extra.callCount())
+	}
+}
+
+func TestServicesOptionAddsAPipe(t *testing.T) {
+	extra := &countingService{answer: []byte("answered")}
+	handler := New(Options{Services: map[string][]rpcserver.Service{"lsarpc": {extra}}})
+
+	if got := handler.Pipes(); strings.Join(got, ",") != "lsarpc,srvsvc,wkssvc" {
+		t.Errorf("Pipes reports %v, want the built-in two plus lsarpc", got)
+	}
+
+	rpc := openInvoker(t, handler, `\PIPE\lsarpc`)
+	rpc.bind(extra.AbstractSyntax())
+
+	answer, err := rpc.callOnContext(0, 0, nil)
+	if err != nil {
+		t.Fatalf("the call on the added pipe failed: %v", err)
+	}
+	if string(answer) != string(extra.answer) {
+		t.Errorf("the added pipe returned %q, want %q", answer, extra.answer)
+	}
+}
+
+func TestServicesOptionIgnoresEmptyEntries(t *testing.T) {
+	// A nil or empty service list, and a name that normalises to nothing, add no
+	// pipe rather than an endpoint that serves nothing.
+	handler := New(Options{Services: map[string][]rpcserver.Service{
+		"lsarpc": nil,
+		"":       {&countingService{}},
+		`\PIPE\`: {&countingService{}},
+	}})
+
+	if got := handler.Pipes(); strings.Join(got, ",") != "srvsvc,wkssvc" {
+		t.Errorf("Pipes reports %v, want only the built-in two", got)
+	}
+}
+
+// countingService is a caller-supplied RPC interface, used to check that a pipe
+// can carry more than the built-in one.
+type countingService struct {
+	answer []byte
+
+	mutex sync.Mutex
+	calls int
+}
+
+func (s *countingService) AbstractSyntax() syntax.SyntaxID {
+	return syntax.SyntaxID{
+		UUID:         guid.GUID{A: 0x0a0b0c0d, B: 0x1112, C: 0x2122, D: 0x3132, E: 0x414243444546},
+		MajorVersion: 1,
+		MinorVersion: 0,
+	}
+}
+
+func (s *countingService) Call(opnum uint16, stub []byte) ([]byte, error) {
+	if opnum != 0 {
+		return nil, rpcserver.ErrUnknownOpnum
+	}
+	s.mutex.Lock()
+	s.calls++
+	s.mutex.Unlock()
+	return s.answer, nil
+}
+
+func (s *countingService) callCount() int {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	return s.calls
 }

--- a/network/smb/smb_v10/server/tree.go
+++ b/network/smb/smb_v10/server/tree.go
@@ -46,6 +46,15 @@ type Open struct {
 	// pipe by the FID in the request's setup words, not by the name it carries.
 	IsPipe bool
 
+	// Pipe is the handler's session for this open, and is what a transaction on
+	// the handle runs against. It is the pipe counterpart of File.
+	//
+	// The session rather than the pipe's name is what the handle carries, because
+	// state a client builds up on a pipe belongs to its open of it: an RPC bind
+	// establishes the presentation contexts and fragment size the requests after
+	// it are read against, and two clients of one pipe bind separately.
+	Pipe PipeSession
+
 	// Readable and Writable are the access the open was granted, enforced on
 	// every use so a handle opened for reading cannot later be written through.
 	Readable bool
@@ -97,6 +106,15 @@ func (c *Connection) Open(fid uint16) *Open {
 }
 
 // addTree records a connected tree.
+// pipeSession returns the handler session this handle transacts on, which is nil
+// for a handle that does not name a pipe.
+func (o *Open) pipeSession() PipeSession {
+	if o == nil {
+		return nil
+	}
+	return o.Pipe
+}
+
 // drainPipeOutput removes up to limit bytes of the answer buffered on a pipe
 // handle and reports whether any is left after it.
 //
@@ -212,10 +230,10 @@ func (c *Connection) closeOpen(fid uint16) error {
 		}
 	}
 
-	// A pipe handle has no backend file; what it holds is whatever the handler
-	// prepared when the pipe was opened, so closing it is the handler's business.
-	if open.IsPipe && open.Tree != nil && open.Tree.Share.Pipes != nil {
-		if err := open.Tree.Share.Pipes.ClosePipe(open.Path); err != nil && firstErr == nil {
+	// A pipe handle has no backend file; what it holds is the handler's session,
+	// so closing it is the handler's business.
+	if open.Pipe != nil {
+		if err := open.Pipe.Close(); err != nil && firstErr == nil {
 			firstErr = err
 		}
 	}


### PR DESCRIPTION
### Linked Issue
`Closes #1178`

### Root Cause
All three `PipeHandler` methods took only the pipe's name, never the open. The FID the server holds was not passed, so two opens of `\srvsvc` — on one connection or on two — were indistinguishable to a handler, and a handler had nowhere to keep state that belongs to one client's open rather than to the pipe.

That is the one thing an RPC endpoint over a pipe needs. A bind establishes which interface each presentation context names and the largest fragment the client can receive, and every request after it is interpreted against those. Two clients of one pipe bind separately. With state keyed only by pipe name, `rpcserver` could not hold a context table at all, and the consequences ran through the whole design: `Dispatcher.handleRequest` dispatched to the single interface the endpoint served instead of by the context the request named, faulting outright when an endpoint served more than one; and `Dispatcher.maxFragment` was endpoint-wide, so it had to be the smallest size any client had asked for, since a fragment larger than a client's `max_recv_frag` is not acceptable to it.

### Fix Description
`OpenPipe(name string) (PipeSession, error)`, where `PipeSession` carries `Transact(input []byte, maxOutput int)` and `Close()`. This mirrors `FileSystem.Open` returning a `File`, which is the same problem already solved the same way one field over: the `Open` holds the session beside its `File`, every transaction on that handle runs against it, and `closeOpen` closes it. `TRANS_WAIT_NMPIPE` opens and immediately closes a session, since the wait asks whether an instance can be had rather than for one to keep.

`rpcserver` splits along the line the transport dictates:

- A `Dispatcher` is the endpoint's interface table and holds nothing belonging to a client, so it stays shareable across every open.
- `Dispatcher.Open()` returns an `Association` — one client's conversation — holding the context table and the negotiated fragment size. `Association.Handle` is what answers a PDU. A caller knows what one client is (one open of a pipe, one TCP connection) and the dispatcher does not, so the caller opens an association per client.

What that buys, each of which the issue asked for:

- **Dispatch by presentation context.** A bind records `context id → Service`, and a request is answered by the interface its own context names. A pipe can therefore carry several interfaces, and a request naming a context that was never negotiated — a request before any bind, or one on a context the bind rejected — faults with `nca_s_fault_context_mismatch` rather than being attributed by guess.
- **A fragment size per client.** Each association negotiates its own, so the endpoint-wide minimum is gone and a client with a 1 KiB buffer no longer shrinks another client's replies.
- **`alter_context` semantics.** It adds to what is bound; a bind replaces it. [C706] 12.6.3.3 has alter_context negotiate a new presentation context *on an existing association*, which only means anything once there is an association to add to.

`rpcpipe` follows: `OpenPipe` returns a `Session` wrapping an `Association`, the instance counter it kept is gone (sessions are the real thing it was approximating), and `Options.Services` adds interfaces to a built-in pipe or adds a pipe outright — so the lifted limit is usable rather than theoretical, and a caller can serve its own interface over IPC$ without writing a `PipeHandler`. `\srvsvc` still carries only srvsvc and `\wkssvc` only wkssvc, which is how Windows serves them.

`Association` is guarded by a mutex. The server uses a session from one goroutine, so it is not needed for this caller; it is what makes a transport that pipelines calls on one association a supported thing to do rather than a corrupted context table, and `TestOneAssociationUsedFromSeveralGoroutines` covers it under `-race`.

### How Verified
**Tests:** `go test -race ./network/dcerpc/v5/rpcserver/ ./network/smb/smb_v10/server/rpcpipe/ ./network/smb/smb_v10/server/` — all passing; 53 tests in the two RPC packages (67 with subtests). `go test ./...` across the repository is clean, as is `go vet ./network/...` and `go vet -tags integration ./network/smb/smb_v10/server/` for the interop file behind the build tag.

The `rpcpipe` tests still drive everything through `ndr.Invoker`, so the interfaces' own client stubs run against the server unchanged; they now hold a session rather than calling the handler, which is what a client does.

Two defects were found while writing the tests:

- `rpcpipe.normalisePipeName` did not handle the bare pipe directory: `\PIPE\` reduced to `"pipe"` rather than to nothing, so a caller could register an endpoint under it. The server's own `pipeNameOf` has that case and this had lost it. `TestServicesOptionIgnoresEmptyEntries` caught it, and `TestNormalisePipeName` now covers every form a client names a pipe in.
- `rpcpipe.OpenPipe` refused an unknown pipe with `pipe %q is not served`. The server maps a pipe error to `STATUS_OBJECT_NAME_NOT_FOUND` only when the message contains "not found", so a client asking for a pipe that does not exist was told `STATUS_UNSUCCESSFUL`. The message now says "not found", the convention is written down in the `PipeHandler` doc comment, and `TestHandlerSatisfiesThePipeContract` asserts it.

### Test Coverage
**Added.**

`network/smb/smb_v10/server/nttransact_test.go` — `TestNamedPipeEachHandleGetsItsOwnSession` is the end-to-end one: a real SMB1 client opens `\PIPE\srvsvc` twice, transacts twice on the first handle and once on the second, and the per-session transaction counts show the two are separate conversations; closing the first handle closes its session and leaves the second's alone, and the surviving handle still transacts. `echoPipe` and `oversizedAnswerPipe` grew sessions, and the existing named-pipe suite (name forms, unknown pipe, truncated answer, oversized answer drained by `READ_ANDX`, `TRANS_READ_NMPIPE` and `TRANS_PEEK_NMPIPE`, pipe state, file commands on a pipe handle) exercises the new path unchanged.

`network/dcerpc/v5/rpcserver/rpcserver_test.go`:
- `TestMultiInterfaceEndpointDispatchesByPresentationContext` — two interfaces bound in one bind under two context ids, each request answered by the right one, replacing the test that asserted such an endpoint had to refuse.
- `TestRequestBeforeABindIsFaulted` and `TestRequestOnAContextTheBindRejectedIsFaulted` — both `nca_s_fault_context_mismatch`, and the interface is never called.
- `TestAlterContextAddsToWhatIsBoundAndABindReplacesIt`.
- `TestTwoAssociationsOfOneEndpointBindIndependently` — one client's bind does not make another's requests answerable, and the bound one still works.
- `TestEachAssociationNegotiatesItsOwnFragmentSize` — a 1 KiB client and a 4280-byte client answered at their own sizes, replacing the endpoint-minimum test.
- `TestServicesReportsTheEndpointsInterfaces` (including that the slice is a copy), `TestOneAssociationUsedFromSeveralGoroutines`, and `TestConcurrentClientsOfOneEndpoint` reworked to give each client its own association.

`network/smb/smb_v10/server/rpcpipe/rpcpipe_test.go`:
- `TestTwoOpensOfOnePipeBindSeparately` — the point of the change at the pipe level: one open binds and enumerates, the other never binds and is faulted, and `Session.Bound` reports 1 and 0.
- `TestRequestBeforeABindFaults`, `TestTransactAfterCloseIsRefused`, `TestSomethingThatIsNotAPDUIsRefused`.
- `TestServicesOptionAddsAnInterfaceToAPipe` — srvsvc and a caller's own interface sharing `\srvsvc`, both accepted in one bind and each answering on its own context — `TestServicesOptionAddsAPipe`, `TestServicesOptionIgnoresEmptyEntries`.
- `TestNormalisePipeName`, `TestConcurrentOpensOfOnePipe` (16 overlapping opens, all distinct sessions), and `TestHandlerSatisfiesThePipeContract` extended to cover a double `Close`, that no session comes back with an error, and the "not found" wording.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/server/{handler_pipe.go,tree.go,doc.go}`, `network/smb/smb_v10/server/{nttransact_test.go,live_interop_integration_test.go}`, `network/dcerpc/v5/rpcserver/{doc.go,rpcserver.go,rpcserver_test.go}`, `network/smb/smb_v10/server/rpcpipe/{doc.go,rpcpipe.go,rpcpipe_test.go}`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none. Every change is the contract change or a direct consequence of it — the two defects above are in the code paths it moves, and the doc updates describe the new contract.

### Risk and Rollout
`PipeHandler` is a breaking interface change, which #1178 anticipated. `network/smb/smb_v10/server/rpcpipe` is the only implementation in the tree and the test fixtures are the only others; an out-of-tree implementation needs `OpenPipe` to return a session and its `Transact`/`ClosePipe` to move onto it, which is mechanical. Behaviour on the wire is unchanged except where it was wrong: a request before a bind now faults rather than being answered, and an unknown pipe now reports `STATUS_OBJECT_NAME_NOT_FOUND`.

### Notes
One behaviour is worth a reviewer's eye. A `TRANS_TRANSACT_NMPIPE` that carries no FID — not what [MS-CIFS] 3.3.5.57.7 specifies, but accommodated since the pipe handling was written — now gets a session for that one exchange and closes it afterwards. A bind and a request sent that way land on different associations, so an interface needing a bind refuses the request. That is the honest outcome: there is no handle to have bound on, and the alternative is a request dispatched by guess.

Separately, `network/smb/smb_v10/server/doc.go` has a sentence duplicated at L120–L121 ("PipeHandler is all an RPC service needs to be reachable over SMB1."), which predates this branch. Left alone to keep the diff to the contract change.
