### PR TITLE
Locate large read and write data by DataOffset so a transfer can exceed 0xFFFF bytes (Fixes #1161)

### DIFF
--- a/network/smb/smb_v10/client/file.go
+++ b/network/smb/smb_v10/client/file.go
@@ -13,25 +13,11 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
 )
 
-const (
-	// writeAndxWordsSize is the size in bytes of the WriteAndx request Words block
-	// for the 32-bit-offset form (WordCount 0x0C, no OffsetHigh): AndX(4) + FID(2) +
-	// Offset(4) + Timeout(4) + WriteMode(2) + Remaining(2) + Reserved(2) + DataLength(2)
-	// + DataOffset(2).
-	writeAndxWordsSize = 24
-
-	// writeAndxDataOffset is the byte offset, measured from the start of the SMB
-	// header, at which the Data block begins in our single (non-chained) WriteAndx
-	// request when the 32-bit-offset form (WordCount 0x0C, no OffsetHigh) is used:
-	// SMB header + WordCount(1) + Words + ByteCount(2) + Pad(1).
-	writeAndxDataOffset = header.SMB_HEADER_SIZE + 1 + writeAndxWordsSize + 2 + 1
-
-	// writeAndxDataOffset64 is the equivalent Data block offset when the 64-bit-offset
-	// form (WordCount 0x0E) is used. WriteAndxRequest.Marshal appends the 4-byte
-	// OffsetHigh word to the parameter block when OffsetHigh is non-zero, which shifts
-	// the Data block 4 bytes further from the start of the header.
-	writeAndxDataOffset64 = writeAndxDataOffset + 4
-)
+// writeAndxOverhead is the space a WriteAndx request needs beyond its data: the
+// SMB header, the 24-byte parameter words of the 32-bit-offset form with their
+// WordCount, the ByteCount and the pad byte. Reserving it keeps a chunk inside the
+// negotiated buffer.
+const writeAndxOverhead = header.SMB_HEADER_SIZE + 1 + 24 + 2 + 1
 
 // FID is an opaque file handle returned by the server for an open file or directory.
 type FID uint16
@@ -240,7 +226,12 @@ func (c *Client) ReadFile(fid FID, offset uint64, maxLen uint32) ([]byte, error)
 			return result, fmt.Errorf("unexpected response command: 0x%02x", response.Header.Command)
 		}
 
-		dataLen := int(readResponse.DataLength)
+		// The length spans two words. [MS-SMB] section 2.2.4.2.2 has a read of
+		// 0x10000 bytes or more put its low half in DataLength and its high half in
+		// DataLengthHigh, so reading DataLength alone decodes a 64 KiB response as
+		// zero bytes — which the loop below treats as end of file, silently
+		// truncating the read.
+		dataLen := int(readResponse.DataLengthHigh)<<16 | int(readResponse.DataLength)
 		dataOff := int(readResponse.DataOffset)
 		if dataLen == 0 {
 			// End of file reached.
@@ -276,7 +267,7 @@ func (c *Client) WriteFile(fid FID, offset uint64, data []byte) (int, error) {
 	// whole message within the negotiated buffer by reserving the fixed overhead.
 	chunkSize := 0xFF00
 	if c.Connection.Server != nil && c.Connection.Server.MaxBufferSize > 0 {
-		budget := int(c.Connection.Server.MaxBufferSize) - writeAndxDataOffset
+		budget := int(c.Connection.Server.MaxBufferSize) - writeAndxOverhead
 		if budget <= 0 {
 			return 0, fmt.Errorf("negotiated MaxBufferSize (%d) too small to write", c.Connection.Server.MaxBufferSize)
 		}
@@ -306,18 +297,10 @@ func (c *Client) WriteFile(fid FID, offset uint64, data []byte) (int, error) {
 		cmd.Timeout = types.ULONG(0)
 		cmd.WriteMode = types.USHORT(0)
 		cmd.Remaining = types.USHORT(0)
-		cmd.Reserved = types.USHORT(0)
-		cmd.DataLength = types.USHORT(len(chunk))
-		// DataOffset is measured from the start of the SMB header (not from the AndX
-		// command's position). When OffsetHigh is non-zero, WriteAndxRequest.Marshal
-		// appends the 4-byte OffsetHigh word to the parameter block, which moves the
-		// Data block 4 bytes further out; use the matching offset so the server reads
-		// the data from where it is actually placed.
-		if cmd.OffsetHigh != 0 {
-			cmd.DataOffset = types.USHORT(writeAndxDataOffset64)
-		} else {
-			cmd.DataOffset = types.USHORT(writeAndxDataOffset)
-		}
+		// DataLength, DataLengthHigh and DataOffset are derived from the data when
+		// the request is marshalled. Setting them here as well would mean keeping a
+		// copy of the command's own wire layout in the client, which is where the
+		// two would eventually disagree.
 		cmd.Pad = types.UCHAR(0)
 		cmd.Data = []types.UCHAR(chunk)
 

--- a/network/smb/smb_v10/message/commands/ReadAndxResponse.go
+++ b/network/smb/smb_v10/message/commands/ReadAndxResponse.go
@@ -155,7 +155,13 @@ func (c *ReadAndxResponse) Marshal() ([]byte, error) {
 	// Place the file data immediately after the data block's ByteCount (no pad)
 	// and advertise its length and its absolute offset from the start of the SMB
 	// header so the parameter fields below carry the matching values.
-	c.DataLength = types.USHORT(len(c.Data))
+	// The length spans two words: [MS-SMB] section 2.2.4.2.2 requires a read of
+	// 0x10000 bytes or more to put the low half in DataLength and the high half
+	// in DataLengthHigh, and "otherwise, this field MUST be set to zero". Both
+	// are derived from the data rather than taken from the caller, since they are
+	// the only description of it a receiver gets.
+	c.DataLength = types.USHORT(len(c.Data) & 0xFFFF)
+	c.DataLengthHigh = types.USHORT(len(c.Data) >> 16)
 	c.DataOffset = types.USHORT(readAndxResponseDataOffset + c.chainOffset)
 
 	rawDataContent := []byte{}
@@ -314,18 +320,44 @@ func (c *ReadAndxResponse) Unmarshal(rawData []byte) (int, error) {
 		offset += 2
 	}
 
-	// Then unmarshal the data. The file bytes are the trailing DataLength bytes of
-	// the data block; any pad inserted to align the data to DataOffset precedes them.
-	offset = 0
-	if c.DataLength > 0 {
-		if int(c.DataLength) > len(rawDataContent) {
-			return offset, fmt.Errorf("ReadAndx DataLength %d exceeds data block size %d", c.DataLength, len(rawDataContent))
-		}
-		c.Data = append([]types.UCHAR{}, rawDataContent[len(rawDataContent)-int(c.DataLength):]...)
-		offset = int(c.DataLength)
-	} else {
+	// Then locate the data.
+	//
+	// Its length spans two words, and reading DataLength alone would report a
+	// 64 KiB read as having returned nothing ([MS-SMB] section 2.2.4.2.2).
+	declared := int(c.DataLengthHigh)<<16 | int(c.DataLength)
+	if declared == 0 {
 		c.Data = []types.UCHAR{}
+		return 0, nil
 	}
 
-	return offset, nil
+	// The position comes from DataOffset, "the offset in bytes from the header of
+	// the read data" ([MS-CIFS] section 2.2.4.42.2). rawData begins at this
+	// command, so the header and everything batched ahead of it come off first.
+	//
+	// ByteCount is not usable for this: it cannot describe a block of 0x10000
+	// bytes or more, so a large read has to be found by its offset. A sender that
+	// leaves DataOffset unset is still understood — the bytes are then the tail of
+	// the data block, which is where an unrelocated read puts them — because
+	// refusing a reply this decoder could read would be a worse answer than
+	// reading it.
+	commandStart := header.SMB_HEADER_SIZE + c.chainOffset
+	start := int(c.DataOffset) - commandStart
+	minimumDataStart := bytesRead + 2
+
+	if start >= minimumDataStart {
+		if start+declared > len(rawData) {
+			return 0, fmt.Errorf(
+				"ReadAndx declares %d bytes of data at offset %d, which runs past the %d bytes of the message that remain",
+				declared, c.DataOffset, len(rawData))
+		}
+		c.Data = append([]types.UCHAR{}, rawData[start:start+declared]...)
+		return declared, nil
+	}
+
+	if declared > len(rawDataContent) {
+		return 0, fmt.Errorf("ReadAndx declares %d bytes of data but its data block holds %d",
+			declared, len(rawDataContent))
+	}
+	c.Data = append([]types.UCHAR{}, rawDataContent[len(rawDataContent)-declared:]...)
+	return declared, nil
 }

--- a/network/smb/smb_v10/message/commands/WriteAndxRequest.go
+++ b/network/smb/smb_v10/message/commands/WriteAndxRequest.go
@@ -8,8 +8,28 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/codes"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/command_interface"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/data"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/parameters"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+)
+
+// The parameter block sizes of the two forms of the request. WordCount is 0x0C
+// without OffsetHigh and 0x0E with it, and the four extra bytes move the data
+// four bytes further from the header ([MS-CIFS] section 2.2.4.43.1).
+const (
+	writeAndxWordsSize   = 2 * 0x0C
+	writeAndxWordsSize64 = 2 * 0x0E
+)
+
+// writeAndxDataOffset and writeAndxDataOffset64 are where this request's data
+// begins, in bytes from the start of the SMB header, for a request at the front
+// of the message: header + WordCount(1) + words + ByteCount(2) + Pad(1).
+//
+// A request batched later in an AndX chain adds its chain offset, which is what
+// SetChainOffset records.
+const (
+	writeAndxDataOffset   = header.SMB_HEADER_SIZE + 1 + writeAndxWordsSize + 2 + 1
+	writeAndxDataOffset64 = header.SMB_HEADER_SIZE + 1 + writeAndxWordsSize64 + 2 + 1
 )
 
 // WriteAndxRequest
@@ -72,6 +92,34 @@ type WriteAndxRequest struct {
 
 	// Data (variable): The raw bytes to be written to the file.
 	Data []types.UCHAR
+
+	// chainOffset is how far past the SMB header this request begins, which is
+	// non-zero only when it is batched behind another command. DataOffset is
+	// measured from the header rather than from the request, so the two have to
+	// be added.
+	chainOffset int
+}
+
+// SetChainOffset records where this request begins, so DataOffset describes where
+// its data actually is.
+//
+// Parameters:
+//   - offset: bytes from the end of the SMB header to the start of this request
+func (c *WriteAndxRequest) SetChainOffset(offset int) {
+	c.chainOffset = offset
+}
+
+// dataOffset is the offset this request's data sits at, from the start of the SMB
+// header.
+//
+// The 64-bit-offset form carries OffsetHigh in its parameter block, which pushes
+// the data four bytes further out. Marshal emits that word only for a non-zero
+// OffsetHigh, so the same condition decides the offset.
+func (c *WriteAndxRequest) dataOffset() int {
+	if c.OffsetHigh != 0 {
+		return writeAndxDataOffset64 + c.chainOffset
+	}
+	return writeAndxDataOffset + c.chainOffset
 }
 
 // NewWriteAndxRequest creates a new WriteAndxRequest structure
@@ -145,6 +193,20 @@ func (c *WriteAndxRequest) Marshal() ([]byte, error) {
 
 	// Marshalling data Data
 	rawDataContent = append(rawDataContent, c.Data...)
+
+	// The three fields that describe the data are derived from the data, not
+	// taken from the caller: they are the only way a receiver can find and size
+	// it, and a caller computing them by hand has to know this command's own
+	// wire layout to do it.
+	//
+	// The length spans two words. [MS-SMB] section 2.2.4.3.1 allocates the CIFS
+	// Reserved field as DataLengthHigh, and requires a write of 0x10000 bytes or
+	// more to put the low half in DataLength and the high half there. Below that
+	// the high half is zero, which is also what [MS-CIFS] section 2.2.4.43.1
+	// requires of Reserved, so writing it unconditionally is right either way.
+	c.DataLength = types.USHORT(len(c.Data) & 0xFFFF)
+	c.Reserved = types.USHORT(len(c.Data) >> 16)
+	c.DataOffset = types.USHORT(c.dataOffset())
 
 	// Then marshal the parameters
 	rawParametersContent := []byte{}
@@ -247,21 +309,30 @@ func (c *WriteAndxRequest) Unmarshal(rawData []byte) (int, error) {
 	}
 	offset := 0
 
-	// First unmarshal the two structures
+	// First unmarshal the parameters
 	bytesRead, err := c.GetParameters().Unmarshal(rawData)
 	if err != nil {
 		return 0, err
 	}
 	rawParametersContent := c.GetParameters().GetBytes()
-	_, err = c.GetData().Unmarshal(rawData[bytesRead:])
-	if err != nil {
-		return 0, err
-	}
-	rawDataContent := c.GetData().GetBytes()
 
-	// If the parameters and data are empty, this is a response containing an error code in
+	// Then the data block, for the ByteCount the sender put on the wire — but not
+	// for the data itself, and not fatally.
+	//
+	// ByteCount cannot be trusted to bound this command's data. [MS-CIFS] section
+	// 2.2.4.43.1 describes relocating the data to the end of an AndX chain and
+	// keeps ByteCount at "1 + SMB_Parameters.Words.DataLength", counting bytes
+	// that are not in the block at all; and a write of 0x10000 bytes or more
+	// cannot state its length in a USHORT. Windows servers "ignore the ByteCount
+	// field, and calculate the number of bytes to be written as DataLength |
+	// DataLengthHigh <<16" ([MS-SMB] section 3.3.5.8), which is what happens
+	// below. So a ByteCount that overruns the buffer is the sender describing a
+	// relocated block, not a truncated message.
+	_, _ = c.GetData().Unmarshal(rawData[bytesRead:])
+
+	// If the parameters are empty, this is a response containing an error code in
 	// the SMB Header Status field
-	if len(rawParametersContent) == 0 && len(rawDataContent) == 0 {
+	if len(rawParametersContent) == 0 {
 		return 0, nil
 	}
 
@@ -336,17 +407,7 @@ func (c *WriteAndxRequest) Unmarshal(rawData []byte) (int, error) {
 		offset += 4
 	}
 
-	// Then unmarshal the data
-	offset = 0
-
-	// Unmarshalling data Pad
-	if len(rawDataContent) < offset+1 {
-		return offset, fmt.Errorf("rawParametersContent too short for Pad")
-	}
-	c.Pad = types.UCHAR(rawDataContent[offset])
-	offset++
-
-	// Unmarshalling data Data
+	// Then locate the data.
 	//
 	// The length spans two fields. [MS-SMB] section 2.2.4.3.1 allocates the CIFS
 	// Reserved field as DataLengthHigh, which is the only way a write above
@@ -356,12 +417,44 @@ func (c *WriteAndxRequest) Unmarshal(rawData []byte) (int, error) {
 	// every large write to its low word: the server would write 4464 of 70000
 	// bytes and report success.
 	declared := int(c.DataLengthHigh())<<16 | int(c.DataLength)
-	if len(rawDataContent) < offset+declared {
-		return offset, fmt.Errorf("rawDataContent too short for Data: need %d bytes from %d, have %d",
-			declared, offset, len(rawDataContent))
+	if declared == 0 {
+		c.Data = []types.UCHAR{}
+		return 0, nil
 	}
-	c.Data = rawDataContent[offset : offset+declared]
-	offset += declared
 
-	return offset, nil
+	// The position comes from DataOffset, measured from the start of the SMB
+	// header "regardless of the command request's position in an AndX chain"
+	// ([MS-CIFS] section 2.2.4.43.1). rawData begins at this command, so the
+	// header and everything batched ahead of it come off the offset first.
+	//
+	// This is the only way to find data the sender relocated, and the only way to
+	// find data at all once the block is too large for ByteCount to describe.
+	commandStart := header.SMB_HEADER_SIZE + c.chainOffset
+	start := int(c.DataOffset) - commandStart
+
+	// A DataOffset that lands inside this command's own parameter block, or that
+	// would run the data past the end of the message, is not a relocation but a
+	// malformed request: [MS-CIFS] section 3.3.5.37 has the server fail such a
+	// request with STATUS_INVALID_SMB, which is what an error here becomes.
+	minimumDataStart := bytesRead + 2
+	if start < minimumDataStart {
+		return 0, fmt.Errorf(
+			"WriteAndx DataOffset %d places the data %d bytes into a command whose data block starts at %d",
+			c.DataOffset, start, minimumDataStart)
+	}
+	if start+declared > len(rawData) {
+		return 0, fmt.Errorf(
+			"WriteAndx declares %d bytes of data at offset %d, which runs past the %d bytes of the message that remain",
+			declared, c.DataOffset, len(rawData))
+	}
+
+	// The pad, if the sender inserted one, is the byte before the data. Reading it
+	// from the front of the data block instead would pick up a data byte for a
+	// sender that padded with nothing.
+	if start > minimumDataStart {
+		c.Pad = types.UCHAR(rawData[start-1])
+	}
+
+	c.Data = rawData[start : start+declared]
+	return declared, nil
 }

--- a/network/smb/smb_v10/message/commands/command_interface/command_interface.go
+++ b/network/smb/smb_v10/message/commands/command_interface/command_interface.go
@@ -70,9 +70,18 @@ type CommandInterface interface {
 // measured from the start of the SMB header rather than from the command itself.
 //
 // Such a command is only correct at the front of a message: batched second or
-// later, its own offsets have to account for everything ahead of it.
-// Message.Marshal tells each command where it begins before marshalling it, so a
-// command that needs the number has it, and one that does not is unaffected.
+// later, its own offsets have to account for everything ahead of it. Both
+// Message.Marshal and Message.Unmarshal tell each command where it begins before
+// handing it its bytes, so a command that needs the number has it and one that
+// does not is unaffected.
+//
+// The number serves both directions. Marshalling, it is what an offset field is
+// measured against when it is written; unmarshalling, it is what turns an offset
+// field back into a position in the slice the command was given. That matters for
+// a field a command cannot find any other way: a read response's data and a large
+// write's data are located by DataOffset, because SMB_Data.ByteCount is a USHORT
+// that cannot describe a block of 0x10000 bytes or more and is not a dependable
+// bound below that either.
 type ChainPositioned interface {
 	// SetChainOffset records how far past the end of the SMB header this command
 	// begins. Zero means it is the first command in the message.

--- a/network/smb/smb_v10/message/commands/large_transfer_wire_test.go
+++ b/network/smb/smb_v10/message/commands/large_transfer_wire_test.go
@@ -1,0 +1,342 @@
+package commands
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+)
+
+// countingPayload is a block whose every byte identifies its own position, so a
+// transfer that is right in length but wrong in content, or reassembled out of
+// order, still fails.
+func countingPayload(length int) []byte {
+	block := make([]byte, length)
+	for index := range block {
+		block[index] = byte(index % 251)
+	}
+	return block
+}
+
+// The positions of the fields this file patches, in bytes from the start of a
+// WriteAndx request's own block: WordCount(1), then the AndX block(4), FID(2),
+// Offset(4), Timeout(4), WriteMode(2), Remaining(2), and then the three fields
+// that describe the data.
+const (
+	writeAndxDataLengthHighAt = 1 + 4 + 2 + 4 + 4 + 2 + 2
+	writeAndxDataLengthAt     = writeAndxDataLengthHighAt + 2
+	writeAndxDataOffsetAt     = writeAndxDataLengthAt + 2
+	writeAndxByteCountAt      = writeAndxDataOffsetAt + 2
+)
+
+func TestWriteAndxRequestDerivesTheFieldsThatDescribeItsData(t *testing.T) {
+	// A caller sets Data and nothing else: the length and the offset are the
+	// command's own wire layout, which the command is the only thing that knows.
+	payload := countingPayload(300)
+
+	request := NewWriteAndxRequest()
+	request.FID = types.USHORT(0x4001)
+	request.Data = []types.UCHAR(payload)
+
+	if _, err := request.Marshal(); err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	if int(request.DataLength) != len(payload) {
+		t.Errorf("DataLength is %d, want %d", request.DataLength, len(payload))
+	}
+	if request.DataLengthHigh() != 0 {
+		t.Errorf("DataLengthHigh is %d for a %d-byte write, want 0", request.DataLengthHigh(), len(payload))
+	}
+	if request.DataOffset != writeAndxDataOffset {
+		t.Errorf("DataOffset is %d, want %d", request.DataOffset, writeAndxDataOffset)
+	}
+}
+
+func TestWriteAndxRequestAbove64KiBRoundTrips(t *testing.T) {
+	// The case the length fields exist for: a write no single USHORT can describe.
+	payload := countingPayload(0x10000 + 1234)
+
+	request := NewWriteAndxRequest()
+	request.FID = types.USHORT(0x1234)
+	request.Offset = types.ULONG(4096)
+	request.Data = []types.UCHAR(payload)
+
+	raw, err := request.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	// The length is split across the two words, and neither alone describes it.
+	if want := types.USHORT(len(payload) & 0xFFFF); request.DataLength != want {
+		t.Errorf("DataLength is 0x%04X, want 0x%04X", request.DataLength, want)
+	}
+	if want := types.USHORT(len(payload) >> 16); request.DataLengthHigh() != want {
+		t.Errorf("DataLengthHigh is 0x%04X, want 0x%04X", request.DataLengthHigh(), want)
+	}
+
+	// ByteCount carries the low 16 bits of the block, which is all a USHORT can
+	// hold. Asserting it rather than ignoring it records that the value is
+	// deliberate: a receiver of a write this size reads the length fields, which
+	// is what [MS-SMB] section 3.3.5.8 has Windows servers do.
+	block := 1 + len(payload)
+	if got := binary.LittleEndian.Uint16(raw[writeAndxByteCountAt : writeAndxByteCountAt+2]); got != uint16(block&0xFFFF) {
+		t.Errorf("ByteCount is 0x%04X, want the low word of the %d-byte block (0x%04X)",
+			got, block, uint16(block&0xFFFF))
+	}
+
+	decoded := NewWriteAndxRequest()
+	if _, err := decoded.Unmarshal(raw); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if len(decoded.Data) != len(payload) {
+		t.Fatalf("decoded %d bytes, want %d", len(decoded.Data), len(payload))
+	}
+	if !bytes.Equal([]byte(decoded.Data), payload) {
+		t.Error("the decoded bytes are not the ones written")
+	}
+}
+
+func TestWriteAndxRequestSixtyFourBitFormMovesItsData(t *testing.T) {
+	// The 64-bit-offset form carries OffsetHigh in its parameter block, which
+	// pushes the data four bytes further from the header. A DataOffset that did
+	// not follow would point four bytes short and the server would write the
+	// wrong bytes.
+	payload := countingPayload(0x10000)
+
+	request := NewWriteAndxRequest()
+	request.FID = types.USHORT(7)
+	request.Offset = types.ULONG(0x80000000)
+	request.OffsetHigh = types.ULONG(1)
+	request.Data = []types.UCHAR(payload)
+
+	raw, err := request.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+	if request.DataOffset != writeAndxDataOffset64 {
+		t.Errorf("DataOffset is %d, want the 64-bit form's %d", request.DataOffset, writeAndxDataOffset64)
+	}
+
+	decoded := NewWriteAndxRequest()
+	if _, err := decoded.Unmarshal(raw); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if decoded.OffsetHigh != 1 {
+		t.Errorf("decoded OffsetHigh is %d, want 1", decoded.OffsetHigh)
+	}
+	if !bytes.Equal([]byte(decoded.Data), payload) {
+		t.Error("the decoded bytes are not the ones written")
+	}
+}
+
+func TestWriteAndxRequestBatchedResolvesItsDataOffset(t *testing.T) {
+	// Batched behind another command, DataOffset has to account for everything
+	// ahead of it: it is measured from the SMB header "regardless of the command
+	// request's position in an AndX chain" ([MS-CIFS] section 2.2.4.43.1).
+	const chainOffset = 41
+	payload := countingPayload(0x10000 + 8)
+
+	request := NewWriteAndxRequest()
+	request.FID = types.USHORT(9)
+	request.Data = []types.UCHAR(payload)
+	request.SetChainOffset(chainOffset)
+
+	raw, err := request.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+	if want := types.USHORT(writeAndxDataOffset + chainOffset); request.DataOffset != want {
+		t.Errorf("DataOffset is %d, want %d", request.DataOffset, want)
+	}
+
+	// Decoded without being told where it sits, the offset resolves 41 bytes past
+	// the data and the request is refused rather than silently reading the wrong
+	// window.
+	unpositioned := NewWriteAndxRequest()
+	if _, err := unpositioned.Unmarshal(raw); err == nil {
+		t.Error("a batched request decoded as if it were first in the message")
+	}
+
+	decoded := NewWriteAndxRequest()
+	decoded.SetChainOffset(chainOffset)
+	if _, err := decoded.Unmarshal(raw); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if !bytes.Equal([]byte(decoded.Data), payload) {
+		t.Error("the decoded bytes are not the ones written")
+	}
+}
+
+func TestWriteAndxRequestRejectsADataOffsetItsOwnParametersCover(t *testing.T) {
+	// A DataOffset inside the command's own parameter block is not a relocation:
+	// [MS-CIFS] section 3.3.5.37 has the server fail such a request, and an error
+	// here becomes STATUS_INVALID_SMB.
+	request := NewWriteAndxRequest()
+	request.FID = types.USHORT(1)
+	request.Data = []types.UCHAR(countingPayload(64))
+
+	raw, err := request.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	// Point it at the FID, which is inside the parameter words.
+	binary.LittleEndian.PutUint16(raw[writeAndxDataOffsetAt:writeAndxDataOffsetAt+2],
+		uint16(header.SMB_HEADER_SIZE+1+4))
+
+	decoded := NewWriteAndxRequest()
+	if _, err := decoded.Unmarshal(raw); err == nil {
+		t.Error("a DataOffset pointing into the parameter words was accepted")
+	}
+}
+
+func TestWriteAndxRequestRejectsDataPastTheEndOfTheMessage(t *testing.T) {
+	// A declared length that runs off the end of what arrived is a malformed
+	// request, not licence to read past the buffer.
+	request := NewWriteAndxRequest()
+	request.FID = types.USHORT(1)
+	request.Data = []types.UCHAR(countingPayload(64))
+
+	raw, err := request.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	// Claim a megabyte, across both words, of a message that carries 64 bytes.
+	binary.LittleEndian.PutUint16(raw[writeAndxDataLengthAt:writeAndxDataLengthAt+2], 0x0000)
+	binary.LittleEndian.PutUint16(raw[writeAndxDataLengthHighAt:writeAndxDataLengthHighAt+2], 0x0010)
+
+	decoded := NewWriteAndxRequest()
+	if _, err := decoded.Unmarshal(raw); err == nil {
+		t.Error("a request declaring a megabyte of data in a 64-byte message was accepted")
+	}
+}
+
+func TestWriteAndxRequestFindsRelocatedData(t *testing.T) {
+	// The relocation [MS-CIFS] section 2.2.4.43.1 describes: the data sits past
+	// the end of the command's own block, with a pad between. Nothing but
+	// DataOffset can find it.
+	payload := countingPayload(0x10000 + 3)
+
+	request := NewWriteAndxRequest()
+	request.FID = types.USHORT(1)
+
+	raw, err := request.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	// Seven bytes of filler stand in for whatever the sender put between its
+	// command block and the relocated data — another command in the chain, or
+	// alignment padding.
+	relocated := append(append([]byte{}, raw...), make([]byte, 7)...)
+	dataAt := len(relocated)
+	relocated = append(relocated, payload...)
+
+	binary.LittleEndian.PutUint16(relocated[writeAndxDataLengthAt:writeAndxDataLengthAt+2],
+		uint16(len(payload)&0xFFFF))
+	binary.LittleEndian.PutUint16(relocated[writeAndxDataLengthHighAt:writeAndxDataLengthHighAt+2],
+		uint16(len(payload)>>16))
+	binary.LittleEndian.PutUint16(relocated[writeAndxDataOffsetAt:writeAndxDataOffsetAt+2],
+		uint16(header.SMB_HEADER_SIZE+dataAt))
+	// ByteCount stays at "1 + SMB_Parameters.Words.DataLength", as the
+	// specification's own example has it — counting bytes that are not in the
+	// block. A decoder that trusted it would refuse this message.
+	binary.LittleEndian.PutUint16(relocated[writeAndxByteCountAt:writeAndxByteCountAt+2],
+		uint16((1+len(payload))&0xFFFF))
+
+	decoded := NewWriteAndxRequest()
+	if _, err := decoded.Unmarshal(relocated); err != nil {
+		t.Fatalf("Unmarshal failed on a relocated data block: %v", err)
+	}
+	if !bytes.Equal([]byte(decoded.Data), payload) {
+		t.Errorf("the decoded bytes are not the relocated ones (%d of %d bytes)",
+			len(decoded.Data), len(payload))
+	}
+}
+
+func TestReadAndxResponseAbove64KiBRoundTrips(t *testing.T) {
+	payload := countingPayload(0x10000 + 55)
+
+	response := NewReadAndxResponse()
+	response.Data = []types.UCHAR(payload)
+
+	raw, err := response.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	if want := types.USHORT(len(payload) & 0xFFFF); response.DataLength != want {
+		t.Errorf("DataLength is 0x%04X, want 0x%04X", response.DataLength, want)
+	}
+	if want := types.USHORT(len(payload) >> 16); response.DataLengthHigh != want {
+		t.Errorf("DataLengthHigh is 0x%04X, want 0x%04X", response.DataLengthHigh, want)
+	}
+
+	decoded := NewReadAndxResponse()
+	if _, err := decoded.Unmarshal(raw); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if !bytes.Equal([]byte(decoded.Data), payload) {
+		t.Errorf("the decoded bytes are not the ones read (%d of %d bytes)",
+			len(decoded.Data), len(payload))
+	}
+}
+
+func TestReadAndxResponseBatchedResolvesItsDataOffset(t *testing.T) {
+	const chainOffset = 39
+	payload := countingPayload(0x10000)
+
+	response := NewReadAndxResponse()
+	response.Data = []types.UCHAR(payload)
+	response.SetChainOffset(chainOffset)
+
+	raw, err := response.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+	if want := types.USHORT(readAndxResponseDataOffset + chainOffset); response.DataOffset != want {
+		t.Errorf("DataOffset is %d, want %d", response.DataOffset, want)
+	}
+
+	decoded := NewReadAndxResponse()
+	decoded.SetChainOffset(chainOffset)
+	if _, err := decoded.Unmarshal(raw); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if !bytes.Equal([]byte(decoded.Data), payload) {
+		t.Error("the decoded bytes are not the ones read")
+	}
+}
+
+func TestReadAndxResponseWithoutADataOffsetReadsTheBlockTail(t *testing.T) {
+	// A sender that leaves DataOffset unset is still understood: the bytes are
+	// then the tail of the data block, which is where an unrelocated read puts
+	// them. Refusing a reply this decoder can read would be the worse answer.
+	payload := countingPayload(4096)
+
+	response := NewReadAndxResponse()
+	response.Data = []types.UCHAR(payload)
+
+	raw, err := response.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+	binary.LittleEndian.PutUint16(raw[readAndxResponseDataOffsetAt:readAndxResponseDataOffsetAt+2], 0)
+
+	decoded := NewReadAndxResponse()
+	if _, err := decoded.Unmarshal(raw); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if !bytes.Equal([]byte(decoded.Data), payload) {
+		t.Error("the decoded bytes are not the ones read")
+	}
+}
+
+// readAndxResponseDataOffsetAt is where the DataOffset field sits in a read
+// response's own block: WordCount(1), the AndX block(4), Available(2),
+// DataCompactionMode(2), Reserved1(2), DataLength(2).
+const readAndxResponseDataOffsetAt = 1 + 4 + 2 + 2 + 2 + 2

--- a/network/smb/smb_v10/message/data/data.go
+++ b/network/smb/smb_v10/message/data/data.go
@@ -7,6 +7,21 @@ import (
 
 // Data represents the data field in an SMB message
 // Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/48b4bd5d-7206-4002-bde1-c34cf614b138
+//
+// ByteCount is a USHORT and no extension widens it, so it cannot describe a block
+// of 0x10000 bytes or more. Two commands legitimately carry one — a large read
+// response and a large write request, under CAP_LARGE_READX and CAP_LARGE_WRITEX
+// — and they locate and size their own payload from DataOffset and
+// DataLength/DataLengthHigh instead. [MS-SMB] section 3.3.5.8 says a server
+// SHOULD reject a write whose data is not (DataLength | DataLengthHigh <<16)
+// bytes, and Windows servers "ignore the ByteCount field" outright when working
+// it out.
+//
+// ByteCount is not a reliable bound even below that. [MS-CIFS] section 2.2.4.43.1
+// describes relocating a write's data to the end of an AndX chain and has
+// ByteCount stay at "1 + SMB_Parameters.Words.DataLength" — counting bytes that
+// are not in the block at all. So Length, not ByteCount, is what a caller should
+// ask for the size of what is actually held.
 type Data struct {
 	ByteCount uint16
 	Bytes     []byte
@@ -25,17 +40,37 @@ func NewData() *Data {
 // Size returns the size of the Data structure
 //
 // This function returns the size of the Data structure. It returns the ByteCount field.
+//
+// It is the field as it goes on the wire, which for a block of 0x10000 bytes or
+// more is the low 16 bits of the true length. Use Length for how many bytes are
+// actually held.
 func (d *Data) Size() uint16 {
 	return d.ByteCount
+}
+
+// Length returns the number of bytes the Data structure holds.
+//
+// It differs from Size for a block that ByteCount cannot describe, which is the
+// case a large read or write produces.
+//
+// Returns:
+//   - The number of bytes held
+func (d *Data) Length() int {
+	return len(d.Bytes)
 }
 
 // Add appends bytes to the Data structure and updates the ByteCount
 //
 // This function appends the given bytes to the existing bytes in the Data structure and updates the ByteCount
 // to reflect the new length of the Bytes field.
+//
+// Past 0xFFFF bytes ByteCount holds the low 16 bits of the length, because that
+// is all a USHORT can carry. That is deliberate rather than an overflow: the two
+// commands that produce such a block describe their payload with their own length
+// and offset fields, and a receiver of one reads those.
 func (d *Data) Add(bytes []byte) {
 	d.Bytes = append(d.Bytes, bytes...)
-	d.ByteCount = uint16(len(d.Bytes))
+	d.ByteCount = uint16(len(d.Bytes) & 0xFFFF)
 }
 
 // SetData sets the data for the message
@@ -44,7 +79,8 @@ func (d *Data) Add(bytes []byte) {
 // to reflect the length of the given data.
 func (d *Data) SetData(data []byte) {
 	d.Bytes = data
-	d.ByteCount = uint16(len(data))
+	// The low 16 bits, for the same reason as Add.
+	d.ByteCount = uint16(len(data) & 0xFFFF)
 }
 
 // GetBytes returns the data for the message

--- a/network/smb/smb_v10/message/data/data_test.go
+++ b/network/smb/smb_v10/message/data/data_test.go
@@ -127,3 +127,41 @@ func Test_DataUnmarshalOneByteDoesNotPanic(t *testing.T) {
 		t.Fatal("Expected error when unmarshalling 1-byte data, got nil")
 	}
 }
+
+// Test_DataLengthReportsWhatIsHeldPastWhatByteCountCanSay verifies that a block
+// larger than a USHORT can describe reports its true size through Length while
+// ByteCount holds the low 16 bits.
+//
+// A large read or write produces such a block, and the two commands that carry
+// one describe their payload with their own length and offset fields. ByteCount
+// truncating is therefore the intended representation rather than an overflow,
+// which is what this pins down.
+func Test_DataLengthReportsWhatIsHeldPastWhatByteCountCanSay(t *testing.T) {
+	const size = 0x10000 + 37
+
+	d := data.NewData()
+	d.Add(make([]byte, size))
+
+	if got := d.Length(); got != size {
+		t.Errorf("Length() = %d, want %d", got, size)
+	}
+	if want := uint16(size & 0xFFFF); d.Size() != want {
+		t.Errorf("Size() = 0x%04X, want the low word 0x%04X", d.Size(), want)
+	}
+
+	// SetData reports the same way, and the marshalled block carries every byte
+	// however ByteCount describes it.
+	d = data.NewData()
+	d.SetData(make([]byte, size))
+	if got := d.Length(); got != size {
+		t.Errorf("Length() after SetData = %d, want %d", got, size)
+	}
+
+	marshalled, err := d.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	if got := len(marshalled); got != 2+size {
+		t.Errorf("the marshalled block is %d bytes, want the ByteCount plus %d", got, size)
+	}
+}

--- a/network/smb/smb_v10/message/large_transfer_chain_test.go
+++ b/network/smb/smb_v10/message/large_transfer_chain_test.go
@@ -1,0 +1,165 @@
+package message_test
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+)
+
+// The fields of a WriteAndx request that describe its data, in bytes from the
+// start of the whole message: the SMB header, WordCount(1), the AndX block(4),
+// FID(2), Offset(4), Timeout(4), WriteMode(2), Remaining(2), and then the three
+// fields themselves. The commands package keeps these positions privately, so
+// they are recomputed here from the field widths [MS-CIFS] section 2.2.4.43.1
+// gives.
+const (
+	writeDataLengthHighAt = header.SMB_HEADER_SIZE + 1 + 4 + 2 + 4 + 4 + 2 + 2
+	writeDataLengthAt     = writeDataLengthHighAt + 2
+	writeDataOffsetAt     = writeDataLengthAt + 2
+	writeByteCountAt      = writeDataOffsetAt + 2
+)
+
+// countingPayload is a block whose every byte identifies its own position.
+func countingPayload(length int) []byte {
+	block := make([]byte, length)
+	for index := range block {
+		block[index] = byte(index % 251)
+	}
+	return block
+}
+
+// TestUnmarshalFindsALargeWriteRelocatedPastAnAndXChain assembles the message
+// [MS-CIFS] section 2.2.4.43.1 describes: an SMB_COM_WRITE_ANDX +
+// SMB_COM_CLOSE chain whose write data has been relocated past the close, with
+// ByteCount left at "1 + SMB_Parameters.Words.DataLength" — counting bytes that
+// are not in the write's own block at all.
+//
+// It is the case that needs every part of this to work at once: the payload is
+// too large for ByteCount to describe, it is nowhere near the write's data block,
+// and the close that follows has to be decoded as well.
+func TestUnmarshalFindsALargeWriteRelocatedPastAnAndXChain(t *testing.T) {
+	payload := countingPayload(0x10000 + 21)
+
+	// Build the chain with no data on the write, so its block ends at its pad
+	// byte and the close follows immediately.
+	msg := message.NewMessage()
+	write := commands.NewWriteAndxRequest()
+	write.FID = types.USHORT(0x00AB)
+	write.Offset = types.ULONG(8192)
+	msg.AddCommand(write)
+
+	closeCommand := commands.NewCloseRequest()
+	closeCommand.FID = types.USHORT(0x00AB)
+	msg.AddCommand(closeCommand)
+
+	raw, err := msg.Marshal()
+	if err != nil {
+		t.Fatalf("failed to marshal the chain: %v", err)
+	}
+
+	// Two bytes of alignment padding, then the relocated data, exactly as the
+	// specification's example lays it out.
+	relocated := append(append([]byte{}, raw...), 0x00, 0x00)
+	dataAt := len(relocated)
+	relocated = append(relocated, payload...)
+
+	binary.LittleEndian.PutUint16(relocated[writeDataLengthAt:writeDataLengthAt+2],
+		uint16(len(payload)&0xFFFF))
+	binary.LittleEndian.PutUint16(relocated[writeDataLengthHighAt:writeDataLengthHighAt+2],
+		uint16(len(payload)>>16))
+	binary.LittleEndian.PutUint16(relocated[writeDataOffsetAt:writeDataOffsetAt+2], uint16(dataAt))
+	binary.LittleEndian.PutUint16(relocated[writeByteCountAt:writeByteCountAt+2],
+		uint16((1+len(payload))&0xFFFF))
+
+	decoded := message.NewMessage()
+	if err := decoded.Unmarshal(relocated); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+
+	decodedWrite, ok := decoded.Command.(*commands.WriteAndxRequest)
+	if !ok {
+		t.Fatalf("the first command decoded as %T, want a WriteAndxRequest", decoded.Command)
+	}
+	if decodedWrite.FID != 0x00AB {
+		t.Errorf("the write's FID is 0x%04X, want 0x00AB", decodedWrite.FID)
+	}
+	if len(decodedWrite.Data) != len(payload) {
+		t.Fatalf("the write carries %d bytes, want the %d relocated", len(decodedWrite.Data), len(payload))
+	}
+	if !bytes.Equal([]byte(decodedWrite.Data), payload) {
+		t.Error("the write's bytes are not the relocated ones")
+	}
+
+	// And the command batched behind it is still found, since the chain is
+	// followed by AndXOffset and not by where the data happens to be.
+	next := decodedWrite.GetNextCommand()
+	if next == nil {
+		t.Fatal("the close batched behind the write was not decoded")
+	}
+	decodedClose, ok := next.(*commands.CloseRequest)
+	if !ok {
+		t.Fatalf("the second command decoded as %T, want a CloseRequest", next)
+	}
+	if decodedClose.FID != 0x00AB {
+		t.Errorf("the close's FID is 0x%04X, want 0x00AB", decodedClose.FID)
+	}
+}
+
+// TestMarshalPositionsALargeWriteBatchedSecond asserts a write batched behind
+// another command describes its data by where the data actually is.
+//
+// DataOffset is measured from the SMB header "regardless of the command
+// request's position in an AndX chain", so a write that assumed it was first
+// would point its server at the bytes of whatever preceded it.
+func TestMarshalPositionsALargeWriteBatchedSecond(t *testing.T) {
+	payload := countingPayload(0x10000 + 5)
+
+	msg := message.NewMessage()
+
+	// A lock taken and then written through is a real chain, and the lock request
+	// carries no strings, so what this test asserts stays about the positioning.
+	lead := commands.NewLockingAndxRequest()
+	lead.FID = types.USHORT(0x0101)
+	msg.AddCommand(lead)
+
+	write := commands.NewWriteAndxRequest()
+	write.FID = types.USHORT(0x0101)
+	write.Data = []types.UCHAR(payload)
+	msg.AddCommand(write)
+
+	raw, err := msg.Marshal()
+	if err != nil {
+		t.Fatalf("failed to marshal the chain: %v", err)
+	}
+
+	decoded := message.NewMessage()
+	if err := decoded.Unmarshal(raw); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+
+	next := decoded.Command.GetNextCommand()
+	if next == nil {
+		t.Fatal("the write batched behind the open was not decoded")
+	}
+	decodedWrite, ok := next.(*commands.WriteAndxRequest)
+	if !ok {
+		t.Fatalf("the second command decoded as %T, want a WriteAndxRequest", next)
+	}
+
+	// The offset it wrote has to name the bytes it meant, in the whole message.
+	at := int(decodedWrite.DataOffset)
+	if at+len(payload) > len(raw) {
+		t.Fatalf("DataOffset %d plus %d bytes runs past the %d-byte message", at, len(payload), len(raw))
+	}
+	if !bytes.Equal(raw[at:at+len(payload)], payload) {
+		t.Error("DataOffset does not point at the bytes the write carried")
+	}
+	if !bytes.Equal([]byte(decodedWrite.Data), payload) {
+		t.Errorf("the decoded write carries %d bytes that are not the ones written", len(decodedWrite.Data))
+	}
+}

--- a/network/smb/smb_v10/message/message.go
+++ b/network/smb/smb_v10/message/message.go
@@ -205,6 +205,12 @@ func (m *Message) Unmarshal(marshalledData []byte) error {
 	// Propagate the message's Unicode setting (SMB_FLAGS2_UNICODE) so the command
 	// decodes string fields with the correct character encoding.
 	c.SetUnicode(m.Header.Flags2.IsUnicode())
+	// A command that locates one of its own fields by an offset from the SMB
+	// header needs to know where it begins, the same way Marshal tells it. First
+	// in the message, that is zero.
+	if positioned, ok := c.(command_interface.ChainPositioned); ok {
+		positioned.SetChainOffset(0)
+	}
 	if _, err = c.Unmarshal(fullData[headerSize:]); err != nil {
 		return err
 	}
@@ -248,6 +254,11 @@ func (m *Message) Unmarshal(marshalledData []byte) error {
 		}
 		next.Init()
 		next.SetUnicode(m.Header.Flags2.IsUnicode())
+		// Batched behind another command, so its offset fields are measured
+		// against a position further into the message than its own slice begins.
+		if positioned, ok := next.(command_interface.ChainPositioned); ok {
+			positioned.SetChainOffset(andxOffset - headerSize)
+		}
 		if _, err = next.Unmarshal(fullData[andxOffset:]); err != nil {
 			return err
 		}

--- a/network/smb/smb_v10/server/doc.go
+++ b/network/smb/smb_v10/server/doc.go
@@ -136,8 +136,13 @@
 // signature rather than merely truncate, and [MS-SMB] has clients hold to
 // MaxBufferSize whenever signing is active.
 //
-// The ceiling stays under 0x10000 because SMB_Data.ByteCount is a USHORT that no
-// extension widens, so a larger data block could not describe its own length.
+// The ceiling is 64 KiB, which the capabilities exist to reach. A transfer that
+// large cannot be described by SMB_Data.ByteCount, a USHORT no extension widens,
+// and does not need to be: it carries its length across DataLength and
+// DataLengthHigh and its position in DataOffset, which is what both directions
+// read and write. Reading at that size is a choice [MS-SMB] section 3.3.5.7
+// leaves to the server and Windows declines; it is safe here because only a
+// client that set MaxCountHigh, a field the capability defines, can ask for one.
 //
 //   - The pass-through information classes for files, in both directions: the
 //     basic, standard, internal, EA, access, position, name, alternate-name,

--- a/network/smb/smb_v10/server/handler_file.go
+++ b/network/smb/smb_v10/server/handler_file.go
@@ -385,12 +385,11 @@ func handleReadAndx(conn *Connection, w ResponseWriter, req *message.Message) nt
 	}
 
 	response := commands.NewReadAndxResponse()
+	// The length and offset fields are derived from the data when the response is
+	// marshalled, across DataLength and DataLengthHigh for a read of 0x10000
+	// bytes or more ([MS-SMB] section 2.2.4.2.2). Setting them here as well would
+	// be a second place for them to be wrong.
 	response.Data = buffer[:read]
-	// DataLength is 16 bits, so a read of 0x10000 bytes or more describes its
-	// length across DataLength and DataLengthHigh ([MS-SMB] section 2.2.4.2.2).
-	// Reporting only the low word would tell the client it received nothing.
-	response.DataLength = types.USHORT(read & 0xFFFF)
-	response.DataLengthHigh = types.USHORT(read >> 16)
 
 	if err := w.WriteResponse(response); err != nil {
 		logger.Debugf("SMB1 server: failed to answer the read for %s: %v", conn.Remote, err)
@@ -498,7 +497,6 @@ func (c *Connection) readPipeHandle(w ResponseWriter, open *Open, length int) nt
 
 	response := commands.NewReadAndxResponse()
 	response.Data = chunk
-	response.DataLength = types.USHORT(len(chunk))
 
 	if err := w.WriteResponse(response); err != nil {
 		logger.Debugf("SMB1 server: failed to answer the pipe read for %s: %v", c.Remote, err)

--- a/network/smb/smb_v10/server/large_transfer_test.go
+++ b/network/smb/smb_v10/server/large_transfer_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
 	"github.com/TheManticoreProject/Manticore/windows/credentials"
 	"github.com/TheManticoreProject/Manticore/windows/fileflags"
+	"github.com/TheManticoreProject/Manticore/windows/nt_status"
 )
 
 // countingBytes is a block whose every byte identifies its own position, so a
@@ -293,10 +294,9 @@ func TestLargeReadOnAPipeReadsTheFieldAsATimeout(t *testing.T) {
 // TestLargeWriteExceedsTheNegotiatedBuffer asserts one write may carry more than
 // MaxBufferSize, which is what CAP_LARGE_WRITEX is for.
 //
-// The size is above the negotiated 16644 bytes and below 0x10000, which is the
-// range the capability actually buys: at 0x10000 and above the data block cannot
-// describe itself, because SMB_Data.ByteCount is a USHORT that [MS-SMB] does not
-// widen. DefaultMaxLargeTransfer stays under that for the same reason.
+// The size is above the negotiated 16644 bytes and below 0x10000, so the whole
+// write is described by DataLength alone. The range at and above that is covered
+// by TestWriteAtSixtyFourKiBLandsInFull.
 func TestLargeWriteExceedsTheNegotiatedBuffer(t *testing.T) {
 	const size = 40000
 
@@ -316,11 +316,9 @@ func TestLargeWriteExceedsTheNegotiatedBuffer(t *testing.T) {
 	cmd := commands.NewWriteAndxRequest()
 	cmd.FID = types.USHORT(fid)
 	cmd.Offset = types.ULONG(0)
-	cmd.DataLength = types.USHORT(size & 0xFFFF)
-	// Reserved is DataLengthHigh under CAP_LARGE_WRITEX; zero at this size.
-	cmd.Reserved = types.USHORT(size >> 16)
-	cmd.DataOffset = types.USHORT(header.SMB_HEADER_SIZE + 1 + 24 + 2 + 1)
 	cmd.Pad = types.UCHAR(0)
+	// DataLength, DataLengthHigh and DataOffset are derived from the data when the
+	// request is marshalled, so the test does not restate this command's layout.
 	cmd.Data = []types.UCHAR(payload)
 	request.AddCommand(cmd)
 
@@ -361,19 +359,198 @@ func TestLargeWriteExceedsTheNegotiatedBuffer(t *testing.T) {
 	}
 }
 
-// TestLargeTransferCeilingKeepsByteCountTruthful asserts the ceiling stays inside
-// what SMB_Data.ByteCount can describe.
+// TestLargeTransferCeilingFitsOneTransportFrame asserts the ceiling stays inside
+// what a transport will carry.
 //
-// ByteCount is a USHORT and [MS-SMB] does not widen it for a large transfer, so a
-// data block of 0x10000 bytes or more cannot state its own length. Raising the
-// ceiling past that would emit messages whose ByteCount is wrong, readable only by
-// a client that ignores the field — so the invariant is asserted rather than left
-// to a comment.
-func TestLargeTransferCeilingKeepsByteCountTruthful(t *testing.T) {
-	// One byte of pad precedes a write's data, so the block is the transfer plus
-	// one and must still fit.
-	if DefaultMaxLargeTransfer+1 > 0xFFFF {
-		t.Fatalf("DefaultMaxLargeTransfer is %d, which with its pad byte exceeds what ByteCount can describe",
+// This is the constraint that actually bounds the ceiling. SMB_Data.ByteCount no
+// longer does: a transfer of 0x10000 bytes or more carries its length in
+// DataLength and DataLengthHigh and its position in DataOffset. But a message
+// larger than one frame cannot be sent at all, and NetBIOS over TCP is the
+// tighter of the two transports — RFC 1002 4.3.1 gives its session message a
+// 17-bit length, so 0x1FFFF bytes including the SMB header and framing.
+func TestLargeTransferCeilingFitsOneTransportFrame(t *testing.T) {
+	// A read response is the larger of the two framings, at the SMB header plus
+	// the parameter words and the byte count.
+	const framing = header.SMB_HEADER_SIZE + 1 + 2*12 + 2
+
+	if DefaultMaxLargeTransfer+framing > 0x1FFFF {
+		t.Fatalf("DefaultMaxLargeTransfer is %d, which with %d bytes of framing exceeds the %d a NetBIOS session message carries",
+			DefaultMaxLargeTransfer, framing, 0x1FFFF)
+	}
+
+	// And it is at least the 64 KiB the capability exists to reach, since a
+	// ceiling below that leaves the extension buying nothing a plain
+	// MaxBufferSize increase would not.
+	if DefaultMaxLargeTransfer < 0x10000 {
+		t.Errorf("DefaultMaxLargeTransfer is %d, below the 64 KiB CAP_LARGE_READX and CAP_LARGE_WRITEX are for",
 			DefaultMaxLargeTransfer)
+	}
+}
+
+// TestReadAtSixtyFourKiBIsFramedAcrossBothLengthWords asserts a read of exactly
+// 0x10000 bytes is described and delivered.
+//
+// This is the size that cannot be stated in one USHORT: DataLength wraps to zero
+// and the whole length lives in DataLengthHigh, so a client reading DataLength
+// alone sees an empty reply. It is also where ByteCount stops being usable, which
+// is why the data is located by DataOffset.
+func TestReadAtSixtyFourKiBIsFramedAcrossBothLengthWords(t *testing.T) {
+	const size = 0x10000
+
+	config := conformanceConfig(SigningDisabled)
+	client, fid := openLargeFile(t, config, 200*1024)
+
+	// MaxCountHigh 0x0001 with a zero low word asks for exactly 0x10000 bytes.
+	raw := sendReadAndx(t, client, fid, 0x0000, 0x0001)
+	response := readReplyOf(t, raw)
+
+	if response.DataLength != 0 {
+		t.Errorf("DataLength is 0x%04X, want 0 — a 64 KiB length has nothing in its low word",
+			response.DataLength)
+	}
+	if response.DataLengthHigh != 1 {
+		t.Errorf("DataLengthHigh is 0x%04X, want 1", response.DataLengthHigh)
+	}
+	if length := readReplyLength(t, raw); length != size {
+		t.Fatalf("the read described %d bytes, want %d", length, size)
+	}
+
+	// The bytes are where DataOffset says, and they are the file's.
+	at := int(response.DataOffset)
+	if at+size > len(raw) {
+		t.Fatalf("DataOffset %d plus %d bytes runs past the %d-byte reply", at, size, len(raw))
+	}
+	if !bytes.Equal(raw[at:at+size], countingBytes(200 * 1024)[:size]) {
+		t.Error("the bytes returned are not the file's")
+	}
+
+	// ByteCount holds the low word of the block, which at this size is zero. The
+	// reply is still readable because nothing needs it: asserting the value keeps
+	// it from looking like a defect to the next reader.
+	byteCount := binary.LittleEndian.Uint16(raw[at-2 : at])
+	if byteCount != uint16(size&0xFFFF) {
+		t.Errorf("ByteCount is 0x%04X, want the low word of %d (0x%04X)",
+			byteCount, size, uint16(size&0xFFFF))
+	}
+
+	// And the decoder recovers it, which is what a client does with the reply.
+	if len(response.Data) != size {
+		t.Errorf("the decoded reply carries %d bytes, want %d", len(response.Data), size)
+	}
+}
+
+// TestWriteAtSixtyFourKiBLandsInFull asserts a write of exactly 0x10000 bytes is
+// accepted and every byte reaches the file.
+//
+// Before the data was located by DataOffset this was the request that could not
+// be represented: ByteCount wrapped, the data block was truncated to the wrapped
+// value before the command saw it, and the server answered STATUS_INVALID_SMB.
+func TestWriteAtSixtyFourKiBLandsInFull(t *testing.T) {
+	const size = 0x10000
+
+	config := conformanceConfig(SigningDisabled)
+	client, fid := openLargeFile(t, config, size)
+
+	payload := countingBytes(size)
+	for index := range payload {
+		// Distinguish what is written from what the file already held.
+		payload[index] ^= 0xFF
+	}
+
+	request := newRequest(codes.SMB_COM_WRITE_ANDX)
+	request.Header.UID = client.Session.SessionUID
+	request.Header.TID = client.Session.TreeID
+
+	cmd := commands.NewWriteAndxRequest()
+	cmd.FID = types.USHORT(fid)
+	cmd.Offset = types.ULONG(0)
+	cmd.Data = []types.UCHAR(payload)
+	request.AddCommand(cmd)
+
+	marshalled, err := request.Marshal()
+	if err != nil {
+		t.Fatalf("failed to marshal the write: %v", err)
+	}
+	// The length has to be described across both words for the request to say
+	// what it carries at all.
+	if cmd.DataLength != 0 || cmd.DataLengthHigh() != 1 {
+		t.Fatalf("the request describes its %d bytes as DataLength 0x%04X and DataLengthHigh 0x%04X, want 0x0000 and 0x0001",
+			size, cmd.DataLength, cmd.DataLengthHigh())
+	}
+
+	if _, err := client.Transport.Send(marshalled); err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+	raw, err := client.Transport.Receive()
+	if err != nil {
+		t.Fatalf("Receive() error = %v", err)
+	}
+	if status := binary.LittleEndian.Uint32(raw[5:9]); status != 0 {
+		t.Fatalf("the write reported 0x%08X, want success", status)
+	}
+
+	response := commands.NewWriteAndxResponse()
+	if _, err := response.Unmarshal(raw[header.SMB_HEADER_SIZE:]); err != nil {
+		t.Fatalf("the reply did not decode: %v", err)
+	}
+	if written := int(response.CountHigh)<<16 | int(response.Count); written != size {
+		t.Fatalf("the reply reports %d bytes written, want %d", written, size)
+	}
+
+	// And every byte is in the file, read back in chunks the client can describe.
+	readBack, err := client.ReadFile(fid, 0, size)
+	if err != nil {
+		t.Fatalf("reading the file back failed: %v", err)
+	}
+	if !bytes.Equal(readBack, payload) {
+		t.Fatalf("the file holds %d bytes that do not match the %d written", len(readBack), len(payload))
+	}
+}
+
+// TestWriteWithADataOffsetInsideItsParametersIsRefused asserts a request whose
+// DataOffset does not describe where its data is gets STATUS_INVALID_SMB.
+//
+// [MS-CIFS] section 3.3.5.37: a DataOffset below the start of
+// SMB_Data.Bytes.Data, or past the end of the data it claims, fails the request.
+// Locating data by an offset the client supplies is only safe if the offset is
+// checked.
+func TestWriteWithADataOffsetInsideItsParametersIsRefused(t *testing.T) {
+	config := conformanceConfig(SigningDisabled)
+	client, fid := openLargeFile(t, config, 4096)
+
+	request := newRequest(codes.SMB_COM_WRITE_ANDX)
+	request.Header.UID = client.Session.SessionUID
+	request.Header.TID = client.Session.TreeID
+
+	cmd := commands.NewWriteAndxRequest()
+	cmd.FID = types.USHORT(fid)
+	cmd.Data = []types.UCHAR(countingBytes(512))
+	request.AddCommand(cmd)
+
+	marshalled, err := request.Marshal()
+	if err != nil {
+		t.Fatalf("failed to marshal the write: %v", err)
+	}
+
+	// Point DataOffset at the FID, inside the parameter words. The offset of the
+	// field itself: the header, WordCount(1), the AndX block(4), FID(2),
+	// Offset(4), Timeout(4), WriteMode(2), Remaining(2), DataLengthHigh(2) and
+	// DataLength(2).
+	const dataOffsetField = header.SMB_HEADER_SIZE + 1 + 4 + 2 + 4 + 4 + 2 + 2 + 2 + 2
+	binary.LittleEndian.PutUint16(marshalled[dataOffsetField:dataOffsetField+2],
+		uint16(header.SMB_HEADER_SIZE+1+4))
+
+	if _, err := client.Transport.Send(marshalled); err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+	raw, err := client.Transport.Receive()
+	if err != nil {
+		t.Fatalf("Receive() error = %v", err)
+	}
+
+	status := binary.LittleEndian.Uint32(raw[5:9])
+	if status != uint32(nt_status.NT_STATUS_INVALID_SMB) {
+		t.Errorf("the write reported 0x%08X, want STATUS_INVALID_SMB (0x%08X)",
+			status, uint32(nt_status.NT_STATUS_INVALID_SMB))
 	}
 }

--- a/network/smb/smb_v10/server/server.go
+++ b/network/smb/smb_v10/server/server.go
@@ -133,21 +133,30 @@ const (
 	DefaultMaxOpensPerConnection    = 1024
 	DefaultMaxSearchesPerConnection = 128
 
-	// DefaultMaxLargeTransfer is the ceiling on one large read or write.
+	// DefaultMaxLargeTransfer is the ceiling on one large read or write: 64 KiB,
+	// which is what CAP_LARGE_READX and CAP_LARGE_WRITEX exist to reach and what
+	// Windows uses.
 	//
-	// It is 0xFF00 rather than the 64 KiB Windows uses, and the difference is not
-	// arbitrary. SMB_Data.ByteCount is a USHORT, and neither [MS-SMB] section
-	// 2.2.4.2.2 nor 2.2.4.3.1 widens it for a large transfer, so a data block of
-	// 0x10000 bytes or more cannot describe itself — its length has to be taken
-	// from DataLength and DataLengthHigh instead, and a data block here is parsed
-	// by its ByteCount. Staying under 0x10000 keeps ByteCount truthful, which
-	// keeps the message readable by any client rather than only by one that
-	// ignores it.
+	// A transfer of 0x10000 bytes or more cannot be described by
+	// SMB_Data.ByteCount, which is a USHORT that neither [MS-SMB] section
+	// 2.2.4.2.2 nor 2.2.4.3.1 widens. It does not have to be: such a transfer
+	// carries its length in DataLength and DataLengthHigh and its position in
+	// DataOffset, and both directions of this server read and write it that way.
 	//
-	// The point of the capability survives intact: a transfer goes from the
-	// negotiated 16644 bytes to 65280, and escaping MaxBufferSize is what matters
-	// rather than the last kilobyte.
-	DefaultMaxLargeTransfer = 0xFF00
+	// Reading at this size is a choice the specification leaves open. [MS-SMB]
+	// section 3.3.5.7 says a server "MAY" return a read of 0x10000 bytes or more,
+	// and Windows declines — it answers STATUS_SUCCESS with both length words
+	// zero and no data at all. Returning the bytes is safe here because the size
+	// is the client's own: a client only reaches this range by setting
+	// MaxCountHigh, a field CAP_LARGE_READX defines, so a client that does not
+	// implement the extension never asks for a reply it could not read. A
+	// deployment that would rather match Windows sets Config.MaxLargeTransfer to
+	// 0xFF00.
+	//
+	// The ceiling also has to fit one transport frame, since a message larger
+	// than a frame cannot be sent: NetBIOS over TCP carries at most 0x1FFFF bytes
+	// (RFC 1002 4.3.1's 17-bit length), which this leaves ample room inside.
+	DefaultMaxLargeTransfer = 0x10000
 	// DefaultMaxLockWait is how long a blocked lock request waits before it is
 	// refused. It is long enough for a lock held across a short read or write to
 	// be released, and short enough that a client that asked to wait forever gets


### PR DESCRIPTION
### Linked Issue
`Closes #1161`

### Root Cause
A command's data block was located and sized by `SMB_Data.ByteCount`. That is a `USHORT`, and neither [MS-SMB] 2.2.4.2.2 nor 2.2.4.3.1 widens it for a large transfer, so a block of 0x10000 bytes or more could not state its own length. A 70000-byte `SMB_COM_WRITE_ANDX` arrived with `ByteCount` wrapped to 4465, `Data.Unmarshal` truncated the block to that before `WriteAndxRequest.Unmarshal` ever saw it, the declared length no longer matched what had arrived, and the server answered `STATUS_INVALID_SMB`. `DefaultMaxLargeTransfer` sat at 0xFF00 as a direct consequence.

Underneath that was a plumbing gap. Such a transfer is meant to describe itself with its own fields — its length across `DataLength` and `DataLengthHigh`, its position in `DataOffset` — but `DataOffset` is measured from the start of the SMB header, and `Message.Unmarshal` handed a command only its own slice. There was nothing to measure the offset against, so the field could not be used even where it was the only thing that would work.

Reading the specs closely while fixing this turned up that `ByteCount` is not a dependable bound *below* 0x10000 either. [MS-CIFS] 2.2.4.43.1's own worked example relocates a write's data past an `SMB_COM_CLOSE` in the same chain and keeps `ByteCount` at "1 + SMB_Parameters.Words.DataLength" — counting bytes that are not in the block at all. A decoder that trusts `ByteCount` refuses that message outright, and [MS-SMB] 3.3.5.8 footnote 127 says plainly that Windows servers "ignore the ByteCount field, and calculate the number of bytes to be written as `DataLength | DataLengthHigh <<16`".

### Fix Description
**The plumbing.** `Message.Unmarshal` now calls `SetChainOffset` on each command before handing it its bytes, the way `Message.Marshal` already did. The same number serves both directions: marshalling, it is what an offset field is measured against when written; unmarshalling, it is what turns an offset field back into a position in the slice the command was given. That is the option #1161's own Notes preferred — "the offset of its own block within it" — and it needs no second buffer, since a command's slice already runs to the end of the message and so covers relocated data.

**`WriteAndxRequest`.** `Marshal` derives `DataLength`, `DataLengthHigh` and `DataOffset` from the data rather than taking them from the caller: they are the only description a receiver gets, and a caller computing them by hand needs a copy of this command's wire layout to do it. `Unmarshal` sizes the data as `DataLength | DataLengthHigh <<16` and locates it at `DataOffset`, ignoring `ByteCount` as Windows does. The data block is still parsed, but only for the `ByteCount` the sender put on the wire, and no longer fatally — a `ByteCount` that overruns the buffer is the sender describing a relocated block, not a truncated message. `Pad` is read from the byte before the data, so a sender that padded with nothing does not have a data byte reported as its pad.

`DataOffset` is client-supplied, so it is checked: an offset that lands inside the command's own parameter block, or a length that would run past the end of what arrived, is an error — which the server turns into `STATUS_INVALID_SMB`, per [MS-CIFS] 3.3.5.37.

**`ReadAndxResponse`.** `Marshal` now derives `DataLengthHigh` alongside `DataLength`, and `Unmarshal` locates the data by `DataOffset` and sizes it across both words. A sender that leaves `DataOffset` unset is still understood — the bytes are then the tail of the data block, where an unrelocated read puts them — because refusing a reply this decoder can read would be the worse answer.

**`data.Data`.** `Add` and `SetData` mask `ByteCount` to 16 bits explicitly, and a new `Length` reports what is actually held. The truncation was already happening implicitly; making it explicit and documented is what turns it from an overflow into the intended representation, and gives callers a size they can trust.

**The ceiling.** `DefaultMaxLargeTransfer` becomes 0x10000 — 64 KiB, what the capabilities exist to reach and what Windows uses. Two things make that safe, both recorded at the constant:

- *Writes* are sized by the client, and the size arrives in fields only `CAP_LARGE_WRITEX` defines.
- *Reads* at this size are a `MAY` in [MS-SMB] 3.3.5.7, and Windows declines them (footnote 126: both length words zero, no data, `STATUS_SUCCESS`). Returning the bytes is safe here because a client reaches this range only by setting `MaxCountHigh`, a field `CAP_LARGE_READX` defines — so a client that does not implement the extension never asks for a reply it could not read. A deployment that would rather match Windows sets `Config.MaxLargeTransfer` to 0xFF00.

The frame is what actually bounds the ceiling now, and `TestLargeTransferCeilingFitsOneTransportFrame` asserts it: NetBIOS over TCP is the tighter transport at 0x1FFFF bytes (RFC 1002 4.3.1's 17-bit length), which 64 KiB plus framing sits well inside.

**Client.** `ReadFile` read only `DataLength`, so a 0x10000-byte response decoded as zero bytes — which its loop treats as end of file, silently truncating the read. Now reachable, since this server returns such responses, so it reads both words. `WriteFile` drops its hand-computed `DataLength`/`DataOffset` and the two local layout constants now that `Marshal` derives them; keeping a second copy of the command's layout in the client is where the two would eventually disagree.

### How Verified
**Tests:** `go test -race ./network/...` is clean, as is `go test ./...` across the repository, `go vet ./network/...`, and `go vet -tags integration ./network/smb/smb_v10/server/` for the interop file behind the build tag. 960 tests pass in the message and server packages.

**Runtime:** the end-to-end tests drive a real SMB1 client against the server over a piped transport. `TestWriteAtSixtyFourKiBLandsInFull` sends the exact request that used to be answered `STATUS_INVALID_SMB`, asserts the reply reports 65536 bytes written across `Count` and `CountHigh`, and reads the file back byte for byte. `TestReadAtSixtyFourKiBIsFramedAcrossBothLengthWords` asks for 0x10000 via `MaxCountHigh` and checks `DataLength` is 0, `DataLengthHigh` is 1, and the `DataOffset` window holds the file's bytes.

**Specs:** the behaviour is taken from the local copies of [MS-SMB] and [MS-CIFS] under `network/smb/smb_v10/docs/`, with sections cited at each decision — 2.2.4.2.2 and 2.2.4.3.1 for the length fields, 2.2.4.43.1 for `DataOffset` and the relocation example, 3.3.5.7 and its footnote 126 for the read `MAY`, 3.3.5.8 and its footnote 127 for the write rule and `ByteCount` being ignored, 3.3.5.37 for the offset validation.

### Test Coverage
**Added.**

`network/smb/smb_v10/message/commands/large_transfer_wire_test.go` (new):
- `TestWriteAndxRequestDerivesTheFieldsThatDescribeItsData`
- `TestWriteAndxRequestAbove64KiBRoundTrips` — 0x104D2 bytes; asserts the length split *and* that `ByteCount` is the low word of the block, so the deliberate truncation is pinned down rather than left to look like a defect
- `TestWriteAndxRequestSixtyFourBitFormMovesItsData` — `OffsetHigh` pushes the data four bytes out and `DataOffset` follows
- `TestWriteAndxRequestBatchedResolvesItsDataOffset` — and that the same bytes decoded *without* being told the position are refused, rather than reading a window 41 bytes off
- `TestWriteAndxRequestRejectsADataOffsetItsOwnParametersCover`, `TestWriteAndxRequestRejectsDataPastTheEndOfTheMessage`
- `TestWriteAndxRequestFindsRelocatedData` — data past the command's block with `ByteCount` left at the spec's `1 + DataLength`
- `TestReadAndxResponseAbove64KiBRoundTrips`, `TestReadAndxResponseBatchedResolvesItsDataOffset`, `TestReadAndxResponseWithoutADataOffsetReadsTheBlockTail`

`network/smb/smb_v10/message/large_transfer_chain_test.go` (new):
- `TestUnmarshalFindsALargeWriteRelocatedPastAnAndXChain` — assembles the message [MS-CIFS] 2.2.4.43.1 describes: `WRITE_ANDX` + `CLOSE` with a 0x10015-byte payload relocated past the close and `ByteCount` counting bytes that are not in the block. Needs every part working at once, and asserts the close is still decoded, since the chain is followed by `AndXOffset` and not by where the data happens to be.
- `TestMarshalPositionsALargeWriteBatchedSecond` — a `LOCKING_ANDX` + `WRITE_ANDX` chain round-tripped through `Message.Marshal`/`Unmarshal`, checking the offset written names the bytes meant *in the whole message*.

`network/smb/smb_v10/message/data/data_test.go`: `Test_DataLengthReportsWhatIsHeldPastWhatByteCountCanSay`.

`network/smb/smb_v10/server/large_transfer_test.go`: `TestReadAtSixtyFourKiBIsFramedAcrossBothLengthWords`, `TestWriteAtSixtyFourKiBLandsInFull`, `TestWriteWithADataOffsetInsideItsParametersIsRefused`, and `TestLargeTransferCeilingKeepsByteCountTruthful` replaced by `TestLargeTransferCeilingFitsOneTransportFrame` — the old test asserted the very invariant this removes, so it could not simply be kept. The new one bounds the ceiling by the transport frame and also asserts it is at least 64 KiB, so a later change cannot quietly give the capability back nothing.

### Scope of Change
- **Files changed:** `message/message.go`, `message/commands/{WriteAndxRequest.go,ReadAndxResponse.go}`, `message/commands/command_interface/command_interface.go`, `message/data/data.go`, `server/{server.go,handler_file.go,doc.go}`, `client/file.go`, plus the four test files above
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none. The server's read handler and pipe-read handler stop setting the length words by hand, since `Marshal` derives them from the data — the same information, from one place instead of two.

### Risk and Rollout
Two behaviour changes reach existing traffic. Reads now return up to 64 KiB where they previously stopped at 0xFF00, which only a client that set `MaxCountHigh` can trigger; `Config.MaxLargeTransfer` restores the old ceiling for a deployment that wants it. A write whose `DataOffset` does not describe where its data is now gets `STATUS_INVALID_SMB` rather than having the data read from the data block anyway — that is the [MS-CIFS] 3.3.5.37 behaviour, and it is the check that makes locating data by a client-supplied offset safe. Everything else is decode paths that previously could not represent the input at all.

### Notes
The client still chunks its own reads and writes inside the negotiated `MaxBufferSize`, so `client.WriteFile` does not itself send a 64 KiB write even though it agrees `CAP_LARGE_WRITEX`. Raising that is a separate question — it needs a view on what ceiling to assume for a server that does not advertise one — and the large-transfer tests hand-build their requests for the same reason the existing ones did.

`network/smb/smb_v10/server/doc.go` still has a sentence duplicated at L120–L121, noted on #1180 and left alone again here.
