### PR TITLE
Grant and break level II oplocks so a client can cache reads (Fixes #1152)

### DIFF
--- a/network/smb/smb_v10/server/async.go
+++ b/network/smb/smb_v10/server/async.go
@@ -70,17 +70,6 @@ type AsyncResponder interface {
 // no request accounts for.
 var ErrResponderDone = errors.New("the asynchronous responder has already been released")
 
-// ErrUnsolicitedWhileSigning reports an attempt to send a server-initiated message
-// on a signing connection.
-//
-// A signed message consumes a sequence number from the pair the two sides keep in
-// step, and a message the client never asked for has no request whose number it
-// can use. Getting that wrong desynchronises signing for the rest of the
-// connection, and every subsequent request fails verification — so it is refused
-// here rather than guessed at, until the numbering can be checked against a
-// reference capture.
-var ErrUnsolicitedWhileSigning = errors.New("cannot send a server-initiated message on a signing connection")
-
 // asyncResponder is the AsyncResponder bound to one deferred request.
 type asyncResponder struct {
 	conn *Connection
@@ -335,28 +324,27 @@ func (c *Connection) OutstandingResponses() int {
 // SMB_COM_LOCKING_ANDX with SMB_FLAGS_REPLY clear to break an oplock. The message
 // carries a fresh MID, because there is no request to correlate it with.
 //
-// It is refused on a signing connection. A signed message consumes a sequence
-// number from the pair the two sides keep in step, and a message with no request
-// behind it has no number reserved for it; a wrong guess desynchronises signing
-// for the rest of the connection and every later request fails verification.
-// Refusing is better than a guess that cannot be checked here against a real
-// client.
+// It goes unsigned even on a signing connection, which is what [MS-CIFS] section
+// 3.3.4.1 requires: after saying that a message the server sends MUST be signed
+// with the sequence number in ServerSendSequenceNumber[PID,MID], it adds that
+// "OpLock Break Notification messages are exempt from signing". The exemption is
+// what makes the message possible at all — that table is keyed by the PID and MID
+// of a request, and a message with no request behind it has no entry in it, so
+// there is no number to sign with. Sending it unsigned consumes none, which
+// leaves the two sides' numbering in step.
 //
 // Parameters:
 //   - cmd: the command to send
 //   - uid, tid, mid: the identifiers to carry
 //
 // Returns:
-//   - ErrUnsolicitedWhileSigning on a signing connection, or the send error
+//   - The send error, if any
 func (c *Connection) SendUnsolicited(
 	cmd command_interface.CommandInterface,
 	uid, tid, mid uint16,
 ) error {
 	if cmd == nil {
 		return fmt.Errorf("cannot send no command")
-	}
-	if c.SigningActive {
-		return ErrUnsolicitedWhileSigning
 	}
 
 	request := message.NewMessage()
@@ -375,6 +363,8 @@ func (c *Connection) SendUnsolicited(
 
 	logger.Debugf("SMB1 server: sending unsolicited command 0x%02X to %s",
 		uint8(cmd.GetCommandCode()), c.Remote)
+	// No key and no sequence number: see above, the message is exempt from
+	// signing whatever the connection has agreed.
 	return c.frame(request, nil, 0)
 }
 

--- a/network/smb/smb_v10/server/async_test.go
+++ b/network/smb/smb_v10/server/async_test.go
@@ -2,15 +2,18 @@ package server
 
 import (
 	"bytes"
-	"errors"
+	"net"
 	"testing"
 	"time"
+
+	"github.com/TheManticoreProject/Manticore/network/tcp"
 
 	smb1client "github.com/TheManticoreProject/Manticore/network/smb/smb_v10/client"
 
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/codes"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
 	"github.com/TheManticoreProject/Manticore/windows/nt_status"
 )
@@ -237,21 +240,68 @@ func TestClosingTheConnectionCancelsWhatItOwes(t *testing.T) {
 	}
 }
 
-// TestUnsolicitedSendIsRefusedWhileSigning asserts a server-initiated message is
-// refused on a signing connection rather than sent with a guessed sequence number.
+// TestUnsolicitedSendGoesUnsignedOnASigningConnection asserts an oplock break is
+// sent, and sent without a signature, on a connection that is signing.
 //
-// A signed message consumes a number from the pair the two sides keep in step, and
-// one with no request behind it has none reserved. A wrong guess desynchronises
-// signing for the rest of the connection and every later request fails
-// verification — a failure mode far worse than a refused oplock break.
-func TestUnsolicitedSendIsRefusedWhileSigning(t *testing.T) {
-	conn := &Connection{SigningActive: true}
+// [MS-CIFS] section 3.3.4.1 requires exactly that: a message the server sends is
+// signed with the number in ServerSendSequenceNumber[PID,MID], and then "OpLock
+// Break Notification messages are exempt from signing". The exemption is what
+// makes the message possible — that table is keyed by a request's PID and MID,
+// and a message with no request behind it has no entry — and sending it unsigned
+// consumes no number, so the two sides' numbering stays in step.
+func TestUnsolicitedSendGoesUnsignedOnASigningConnection(t *testing.T) {
+	serverSide, clientSide := net.Pipe()
+	t.Cleanup(func() {
+		serverSide.Close()
+		clientSide.Close()
+	})
 
-	err := conn.SendUnsolicited(commands.NewLockingAndxRequest(), 1, 1, 1)
-	if err == nil {
-		t.Fatal("an unsolicited send succeeded on a signing connection")
+	conn := &Connection{
+		Transport: tcp.NewTCPTransportFromConn(serverSide),
+		Remote:    &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 1},
+		// Signing active, with a key that would produce a visible signature if
+		// one were applied.
+		SigningActive: true,
+		SigningKey:    bytes.Repeat([]byte{0xAB}, 16),
 	}
-	if !errors.Is(err, ErrUnsolicitedWhileSigning) {
-		t.Errorf("the refusal is %v, want ErrUnsolicitedWhileSigning", err)
+
+	clientTransport := tcp.NewTCPTransportFromConn(clientSide)
+	clientTransport.SetTimeout(5 * time.Second)
+
+	received := make(chan []byte, 1)
+	go func() {
+		frame, err := clientTransport.Receive()
+		if err != nil {
+			received <- nil
+			return
+		}
+		received <- frame
+	}()
+
+	notification := commands.NewLockingAndxRequest()
+	notification.FID = types.USHORT(0x1234)
+	notification.TypeOfLock = types.UCHAR(commands.LockingAndxOplockRelease)
+	if err := conn.SendUnsolicited(notification, 1, 1, conn.nextUnsolicitedMID()); err != nil {
+		t.Fatalf("the break was refused on a signing connection: %v", err)
+	}
+
+	var frame []byte
+	select {
+	case frame = <-received:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the break was never sent")
+	}
+	if frame == nil {
+		t.Fatal("reading the break failed")
+	}
+
+	// The SecuritySignature field is bytes 14 to 22 of the SMB header. An exempt
+	// message leaves it zero.
+	if len(frame) < header.SMB_HEADER_SIZE {
+		t.Fatalf("the frame is %d bytes, shorter than an SMB header", len(frame))
+	}
+	signature := frame[14:22]
+	if !bytes.Equal(signature, make([]byte, 8)) {
+		t.Errorf("the break carries the signature % x, want it left zero as an exempt message", signature)
 	}
 }

--- a/network/smb/smb_v10/server/connection.go
+++ b/network/smb/smb_v10/server/connection.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"sync"
+	"sync/atomic"
 
 	"github.com/TheManticoreProject/Manticore/crypto/spnego"
 	"github.com/TheManticoreProject/Manticore/logger"
@@ -53,6 +54,12 @@ type Connection struct {
 	// in its session setup, bounding what the server may send back.
 	ClientMaxBufferSize uint32
 	ClientCapabilities  capabilities.Capabilities
+
+	// ClientMaxMpxCount is how many commands the client said it can have
+	// outstanding. It decides whether an oplock may be granted: [MS-CIFS] section
+	// 3.3.5.53 forbids one below two, because a client with a single command slot
+	// could not answer a break while it was waiting for anything else.
+	ClientMaxMpxCount uint16
 
 	// UseUnicode and UseNTStatus record what the client negotiated, so a handler
 	// does not have to re-derive them from each request header.
@@ -116,6 +123,13 @@ type Connection struct {
 	responderMutex sync.Mutex
 	responders     map[*asyncResponder]struct{}
 
+	// unsolicitedMID numbers the messages the server originates.
+	//
+	// A break notification has no request to correlate it with, so it carries a
+	// MID of its own ([MS-CIFS] section 3.3.4.2). It is atomic because a break is
+	// sent from whichever goroutine caused it, which is not this connection's.
+	unsolicitedMID atomic.Uint32
+
 	// pendingAuth holds the authentication exchanges part-way through, keyed by
 	// the UID assigned when the challenge was issued.
 	//
@@ -142,6 +156,22 @@ func newConnection(srv *Server, t transport.Transport, remote net.Addr) *Connect
 		sids:        newIdentifierAllocator(srv.config.MaxSearchesPerConnection),
 		pendingAuth: make(map[uint16]*spnego.AcceptContext),
 	}
+}
+
+// nextUnsolicitedMID returns a MID for a message the server originates.
+//
+// The numbers only have to be distinct from each other: a client matches a
+// response to a request by MID, and an unsolicited request is not a response to
+// anything. Zero is skipped because a client may read it as "no MID".
+//
+// Returns:
+//   - The next MID
+func (c *Connection) nextUnsolicitedMID() uint16 {
+	next := uint16(c.unsolicitedMID.Add(1))
+	if next == 0 {
+		next = uint16(c.unsolicitedMID.Add(1))
+	}
+	return next
 }
 
 // PendingAuth returns the authentication exchange a UID names while it is still

--- a/network/smb/smb_v10/server/doc.go
+++ b/network/smb/smb_v10/server/doc.go
@@ -195,9 +195,47 @@
 // rather than something the interval can fix, and it is why the poll is documented
 // where a caller will see it.
 //
-// Oplocks are still never granted. Breaking one means sending a message the client
-// did not ask for, and Connection.SendUnsolicited refuses to do that on a signing
-// connection for the reason given below.
+// # Oplocks
+//
+// A level II oplock is granted on an open that asks for one, and broken with an
+// unsolicited SMB_COM_LOCKING_ANDX before anything makes it untrue. Level II is
+// the only level granted: it lets a client cache reads and nothing else, so
+// withdrawing it needs no acknowledgement and the break can go out without
+// holding up the operation that caused it. A request for an exclusive or batch
+// oplock is answered with level II, which [MS-SMB] 3.3.5.1.2 sanctions — an
+// exclusive oplock lets a client cache writes, and breaking one means suspending
+// the operation that broke it until the client has flushed and acknowledged,
+// which needs a request this server can park and resume and it has none.
+//
+// Nothing is granted to a client whose MaxMpxCount is below two: [MS-CIFS]
+// 3.3.5.53 forbids it, because a client with a single command slot could not
+// answer a break while it was waiting for anything else. Nothing is granted on a
+// directory either, per 3.3.5.2.7.
+//
+// The oplock is withdrawn before the change that caused it: the table stops
+// counting the holder first, so nothing after that point can grant or keep one on
+// the strength of it. What breaks an oplock is an open that can write, a write, a
+// set-information level that resizes, a delete, and a rename — the last three
+// because they are reached by path rather than by handle, so no open of theirs
+// has broken anything. A timestamp-only change does not break one: a level II
+// oplock caches data, and a timestamp is not data.
+//
+// The notification itself goes out on a goroutine of its own. Writing to another
+// connection blocks until that client reads, so sending it inline would let a
+// client idling with a full receive buffer stall the unrelated client whose write
+// broke the oplock. Nothing waits on the break, which is what makes that safe.
+//
+// [MS-CIFS] 3.3.5.2.7 would also refuse an oplock on a file another handle holds
+// open for writing. This grants it and withdraws it when that handle actually
+// changes the file, which keeps the same promise — the client is told before any
+// change to its cached data can be seen — without reading every connection's open
+// table, which belongs to those connections' own goroutines.
+//
+// The guarantee is the one level II carries and no more. The break is in flight
+// while the change is applied, so a client that reads from its cache in that
+// window sees data that is about to be replaced. That is inherent to a level
+// nobody acknowledges, and it is why the levels that promise more require an
+// acknowledgement — which is also why they are not granted here.
 //
 // # Deferred answers
 //
@@ -221,13 +259,14 @@
 // to discover it on a failed write.
 //
 // A server-initiated message — the oplock break of [MS-CIFS] 2.2.4.32.1, the one
-// place the server sends a request — goes out through Connection.SendUnsolicited.
-// It is refused on a signing connection: a signed message consumes a number from
-// the sequence the two sides keep in step, and a message with no request behind it
-// has none reserved for it. A wrong guess desynchronises signing for the rest of
-// the connection and every later request fails verification, so it is refused
-// rather than guessed at until the numbering can be checked against a reference
-// capture.
+// place the server sends a request — goes out through Connection.SendUnsolicited,
+// unsigned even on a connection that is signing. That is what [MS-CIFS] 3.3.4.1
+// requires: having said that a message the server sends MUST be signed with the
+// number in ServerSendSequenceNumber[PID,MID], it adds that "OpLock Break
+// Notification messages are exempt from signing". The exemption is what makes the
+// message possible at all, since that table is keyed by a request's PID and MID
+// and a message with no request behind it has no entry in it; sending it unsigned
+// consumes no number, so the two sides' numbering stays in step.
 //
 // NT_TRANSACT_CREATE and TRANS2_OPEN2 are served, as are TRANS2_CREATE_DIRECTORY
 // and the extended attributes those two can carry — except that the attributes

--- a/network/smb/smb_v10/server/handler_core_file.go
+++ b/network/smb/smb_v10/server/handler_core_file.go
@@ -527,6 +527,11 @@ func (c *Connection) coreWrite(open *Open, offset int64, data []byte, declared i
 		return 0, status
 	}
 
+	// The break goes out before the file changes, for both of the changes this
+	// path makes: a client caching reads on the promise that nothing is writing
+	// has to be told before the data under its cache moves.
+	c.breakOplocksOn(open.Tree.Share, open.Path, open)
+
 	// A count of zero sets the length rather than writing nothing.
 	if declared == 0 {
 		if err := file.Truncate(offset); err != nil {

--- a/network/smb/smb_v10/server/handler_file.go
+++ b/network/smb/smb_v10/server/handler_file.go
@@ -231,8 +231,15 @@ func handleNtCreateAndx(conn *Connection, w ResponseWriter, req *message.Message
 
 	logger.Debugf("SMB1 server: %s opened %q on %q as FID 0x%04X", conn.Remote, path, tree.Share.Name, fid)
 
+	// An open that can change the file withdraws everyone else's promise that
+	// nothing will. This handle keeps whatever it is granted below.
+	if open.Writable || flags.Truncate {
+		conn.breakOplocksOn(tree.Share, path, open)
+	}
+
 	response := commands.NewNtCreateAndxResponse()
 	response.FID = types.USHORT(fid)
+	response.OpLockLevel = types.UCHAR(conn.grantOplock(open, uint16(req.Header.UID), uint32(request.Flags)))
 	response.CreateDisposition = types.ULONG(createActionFor(existed, flags))
 	response.CreateTime = *msdtyp.NewFILETIMEFromTime(attr.Created)
 	response.LastAccessTime = *msdtyp.NewFILETIMEFromTime(attr.Accessed)
@@ -570,6 +577,12 @@ func handleWriteAndx(conn *Connection, w ResponseWriter, req *message.Message) n
 	if status != nt_status.NT_STATUS_SUCCESS {
 		return status
 	}
+
+	// The break goes out before the bytes land. A client holding a level II
+	// oplock is caching reads on the promise that nothing is writing, and telling
+	// it afterwards would leave a window in which it could serve data this write
+	// has already replaced.
+	conn.breakOplocksOn(open.Tree.Share, open.Path, open)
 
 	written, err := file.WriteAt(data, offset)
 	if err != nil {

--- a/network/smb/smb_v10/server/handler_filemgmt.go
+++ b/network/smb/smb_v10/server/handler_filemgmt.go
@@ -49,6 +49,10 @@ func handleDelete(conn *Connection, w ResponseWriter, req *message.Message) nt_s
 
 	// No wildcard: one named file.
 	if pattern == "" {
+		// A delete is reached by path rather than by handle, so nothing has
+		// broken the oplocks on it yet. A holder has to be told before the file
+		// it is caching stops existing.
+		conn.breakOplocksOn(tree.Share, directory, nil)
 		if err := tree.Share.FS.Remove(directory); err != nil {
 			logger.Debugf("SMB1 server: deleting %q for %s failed: %v", directory, conn.Remote, err)
 			return statusForFSError(err)
@@ -66,6 +70,7 @@ func handleDelete(conn *Connection, w ResponseWriter, req *message.Message) nt_s
 		if entry.Attr.IsDir {
 			continue
 		}
+		conn.breakOplocksOn(tree.Share, joinPath(directory, entry.Attr.Name), nil)
 		if err := tree.Share.FS.Remove(joinPath(directory, entry.Attr.Name)); err != nil {
 			logger.Debugf("SMB1 server: deleting %q for %s failed: %v",
 				joinPath(directory, entry.Attr.Name), conn.Remote, err)
@@ -108,6 +113,10 @@ func handleRename(conn *Connection, w ResponseWriter, req *message.Message) nt_s
 		// Renaming the share root is not a thing.
 		return nt_status.NT_STATUS_ACCESS_DENIED
 	}
+
+	// A rename is reached by path too, and it moves the file out from under
+	// whatever was caching it.
+	conn.breakOplocksOn(tree.Share, oldPath, nil)
 
 	// SMB_COM_RENAME does not replace: a destination that exists is a collision.
 	// The NT_RENAME variant is what a client uses when it means to overwrite.

--- a/network/smb/smb_v10/server/handler_info.go
+++ b/network/smb/smb_v10/server/handler_info.go
@@ -131,6 +131,10 @@ func handleSetPathInformation(conn *Connection, req *message.Message, reassembly
 		return nil, nil, nt_status.NT_STATUS_ACCESS_DENIED
 	}
 
+	// A set level can change the file's length, and this one is reached by path,
+	// so nothing has broken the oplocks on it yet.
+	conn.breakOplocksOn(tree.Share, path, nil)
+
 	// A path-based set has no handle, so the levels that are properties of a
 	// handle rather than of a file cannot be applied through it.
 	served, err := applyFileInformation(tree.Share.FS, path, level, reassembly.data, nil)
@@ -166,6 +170,8 @@ func handleSetFileInformation(conn *Connection, req *message.Message, reassembly
 	if !open.Writable {
 		return nil, nil, nt_status.NT_STATUS_ACCESS_DENIED
 	}
+
+	conn.breakOplocksOn(open.Tree.Share, open.Path, open)
 
 	served, err := applyFileInformation(open.Tree.Share.FS, open.Path, level, reassembly.data, open)
 	if !served {

--- a/network/smb/smb_v10/server/handler_lock.go
+++ b/network/smb/smb_v10/server/handler_lock.go
@@ -75,12 +75,21 @@ func handleLockingAndx(conn *Connection, w ResponseWriter, req *message.Message)
 	// An OpLock Break Request carries no ranges, and [MS-CIFS] section 3.3.5.30
 	// is explicit that it is answered with silence: "If NumberOfRequestedUnlocks
 	// and NumberOfRequestedLocks are both zero (0x0000) [...] the server MUST NOT
-	// send an SMB_COM_LOCKING_ANDX Response". No OpLock is ever granted here, so
-	// there is none to release, and the same section says that is not an error.
+	// send an SMB_COM_LOCKING_ANDX Response".
 	if len(unlocks) == 0 && len(locks) == 0 {
+		if typeOfLock&commands.LockingAndxOplockRelease != 0 {
+			conn.releaseOplock(open)
+		}
 		logger.Debugf("SMB1 server: %s sent a lock request with no ranges on FID 0x%04X, which is answered with silence",
 			conn.Remote, uint16(request.FID))
 		return nt_status.NT_STATUS_SUCCESS
+	}
+
+	// The release bit can also arrive alongside ranges, since [MS-CIFS] section
+	// 3.3.5.30 has all three parts of the request executed. It is applied first,
+	// because it is what the client is acknowledging rather than asking for.
+	if typeOfLock&commands.LockingAndxOplockRelease != 0 {
+		conn.releaseOplock(open)
 	}
 
 	locksTable := open.Tree.Share.locks

--- a/network/smb/smb_v10/server/handler_negotiate.go
+++ b/network/smb/smb_v10/server/handler_negotiate.go
@@ -24,10 +24,16 @@ const noDialectSelected = 0xFFFF
 // serverCapabilities are the capabilities advertised in the NEGOTIATE response.
 //
 // Each one is a promise, so the set is deliberately limited to what the server
-// actually honours. CAP_RAW_MODE, CAP_LOCK_AND_READ and CAP_LEVEL_II_OPLOCKS are
-// absent because raw transfers, the combined lock-and-read command and oplocks are
-// not implemented; advertising them would have clients issue commands that are
-// then refused.
+// actually honours. CAP_RAW_MODE and CAP_LOCK_AND_READ are absent because raw
+// transfers and the combined lock-and-read command are not implemented;
+// advertising them would have clients issue commands that are then refused.
+//
+// CAP_LEVEL_II_OPLOCKS says a client may be granted a level II oplock and told
+// when it is broken. Level II is the only level granted: it permits a client to
+// cache reads and nothing else, so withdrawing it needs no acknowledgement, and
+// the break can be sent without holding up the operation that caused it. A
+// request for an exclusive or batch oplock is answered with level II, which
+// [MS-SMB] section 3.3.5.1.2 sanctions.
 //
 // CAP_LARGE_READX and CAP_LARGE_WRITEX let one read or write exceed the
 // negotiated MaxBufferSize, bounded by Config.MaxLargeTransfer. Both are a
@@ -46,6 +52,7 @@ const serverCapabilities = capabilities.CAP_UNICODE |
 	capabilities.CAP_NT_FIND |
 	capabilities.CAP_LARGE_READX |
 	capabilities.CAP_LARGE_WRITEX |
+	capabilities.CAP_LEVEL_II_OPLOCKS |
 	capabilities.CAP_INFOLEVEL_PASSTHROUGH |
 	capabilities.CAP_EXTENDED_SECURITY
 

--- a/network/smb/smb_v10/server/handler_nt_rename.go
+++ b/network/smb/smb_v10/server/handler_nt_rename.go
@@ -87,6 +87,7 @@ func handleNtRename(conn *Connection, w ResponseWriter, req *message.Message) nt
 	case smbNtRenameRenameFile:
 		// Treated as SMB_COM_RENAME: the target must not already exist, which is
 		// what a rename with replace=false gives.
+		conn.breakOplocksOn(tree.Share, source, nil)
 		if err := tree.Share.FS.Rename(source, target, false); err != nil {
 			logger.Debugf("SMB1 server: %s renamed %q to %q, which failed: %v",
 				conn.Remote, source, target, err)

--- a/network/smb/smb_v10/server/handler_remaining_subcommands.go
+++ b/network/smb/smb_v10/server/handler_remaining_subcommands.go
@@ -183,6 +183,9 @@ func handleNtTransactCreate(
 		return nil, nil, nt_status.NT_STATUS_INVALID_PARAMETER
 	}
 
+	// Flags is the first field of the parameter block ([MS-CIFS] section
+	// 2.2.7.1.1), and carries the oplock request bits.
+	flagsField := binary.LittleEndian.Uint32(reassembly.parameters[0:4])
 	rootDirectoryFID := binary.LittleEndian.Uint32(reassembly.parameters[4:8])
 	desiredAccess := binary.LittleEndian.Uint32(reassembly.parameters[8:12])
 	createDisposition := binary.LittleEndian.Uint32(reassembly.parameters[28:32])
@@ -220,10 +223,15 @@ func handleNtTransactCreate(
 		return nil, nil, statusForFSError(err)
 	}
 
+	// An open that can change the file withdraws everyone else's promise that
+	// nothing will, before this one is granted anything.
+	if open.Writable || flags.Truncate {
+		conn.breakOplocksOn(open.Tree.Share, open.Path, open)
+	}
+
 	// Response parameters are 69 bytes, per [MS-CIFS] section 2.2.7.1.2.
 	parameters := make([]byte, 69)
-	// OpLockLevel stays zero: no oplock is granted, and claiming one the server
-	// cannot break would have the client cache on a promise nothing keeps.
+	parameters[0] = conn.grantOplock(open, uint16(req.Header.UID), flagsField)
 	binary.LittleEndian.PutUint16(parameters[2:4], open.FID)
 	binary.LittleEndian.PutUint32(parameters[4:8], createActionFor(existed, flags))
 	binary.LittleEndian.PutUint64(parameters[12:20], filetimeOf(attr.Created))

--- a/network/smb/smb_v10/server/handler_session.go
+++ b/network/smb/smb_v10/server/handler_session.go
@@ -52,9 +52,11 @@ func handleSessionSetupAndx(conn *Connection, w ResponseWriter, req *message.Mes
 		return nt_status.NT_STATUS_NOT_IMPLEMENTED
 	}
 
-	// Record what the client says it can handle: it bounds what may be sent back.
+	// Record what the client says it can handle: it bounds what may be sent back,
+	// and MaxMpxCount decides whether an oplock may be granted at all.
 	conn.ClientMaxBufferSize = uint32(request.MaxBufferSize)
 	conn.ClientCapabilities = request.Capabilities
+	conn.ClientMaxMpxCount = uint16(request.MaxMpxCount)
 
 	uid := uint16(req.Header.UID)
 	switch {

--- a/network/smb/smb_v10/server/oplocks.go
+++ b/network/smb/smb_v10/server/oplocks.go
@@ -1,0 +1,375 @@
+package server
+
+import (
+	"strings"
+	"sync"
+
+	"github.com/TheManticoreProject/Manticore/logger"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/capabilities"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+)
+
+// The OpLock levels an SMB_COM_NT_CREATE_ANDX response reports ([MS-CIFS]
+// section 2.2.4.64.2).
+const (
+	// OplockLevelNone is granted when the server grants nothing.
+	OplockLevelNone = 0x00
+
+	// OplockLevelExclusive and OplockLevelBatch are the two exclusive levels. A
+	// client asks for one of them; this server never grants either, because both
+	// let a client cache writes and so require a break the client must
+	// acknowledge before the write behind it can proceed.
+	OplockLevelExclusive = 0x01
+	OplockLevelBatch     = 0x02
+
+	// OplockLevelLevelII is a level II oplock: "multiple readers of a file and no
+	// writers" ([MS-SMB] section 1.1). It permits a client to cache reads and
+	// nothing else, which is why it is the level this server grants.
+	OplockLevelLevelII = 0x03
+)
+
+// The NewOpLockLevel values a break notification carries ([MS-CIFS] section
+// 2.2.4.32.1): "If NewOpLockLevel is 0x00, the client possesses no OpLocks on the
+// file at all. If NewOpLockLevel is 0x01, then the client possesses a Level II
+// OpLock."
+//
+// Only the first is ever sent here, since level II is the only level granted and
+// there is nothing below it to break to.
+const (
+	breakToNone    = 0x00
+	breakToLevelII = 0x01
+)
+
+// The NT_CREATE_ANDX request flags that ask for an oplock ([MS-CIFS] section
+// 2.2.4.64.1).
+const (
+	ntCreateRequestOplock  = 0x00000002
+	ntCreateRequestOpBatch = 0x00000004
+)
+
+// oplockHolder is one level II oplock granted on a file.
+//
+// It carries the identifiers a break notification needs rather than a pointer to
+// the connection's tables, because the break is sent from whichever goroutine
+// caused it: the tables belong to the receive loop of the connection that owns
+// them and have no locking of their own.
+type oplockHolder struct {
+	// conn is the connection to notify, and fid, uid and tid name the handle in
+	// the terms that connection assigned.
+	conn *Connection
+	fid  uint16
+	uid  uint16
+	tid  uint16
+
+	// owner is the handle the oplock was granted on, which is what identifies it
+	// when the handle closes or the client acknowledges a break.
+	owner *Open
+}
+
+// oplockTable holds the level II oplocks granted on the files of one share.
+//
+// It belongs to the share rather than to a connection for the same reason the
+// lock table does: an oplock is a statement about a file, and the handles it has
+// to notify are on other connections as much as this one. Every path through it
+// takes the mutex.
+type oplockTable struct {
+	mutex sync.Mutex
+
+	// granted maps an upper-cased share-relative path to the oplocks held on that
+	// file. A file with none carries no entry, so a file nobody caches costs
+	// nothing.
+	//
+	// The key is upper-cased because the file commands match names
+	// case-insensitively, and two spellings of one path have to reach one entry
+	// or a break would miss a holder.
+	granted map[string][]*oplockHolder
+}
+
+// newOplockTable builds an empty table.
+func newOplockTable() *oplockTable {
+	return &oplockTable{granted: make(map[string][]*oplockHolder)}
+}
+
+// oplockKey is the table key for a share-relative path.
+func oplockKey(path string) string {
+	return strings.ToUpper(path)
+}
+
+// Grant records a level II oplock on a handle.
+//
+// Parameters:
+//   - open: the handle asking, already registered on its connection
+//   - conn: the connection the handle belongs to
+//   - uid: the session the handle was opened under
+//
+// Returns:
+//   - Whether the oplock was recorded
+func (t *oplockTable) Grant(open *Open, conn *Connection, uid uint16) bool {
+	if open == nil || conn == nil || open.Tree == nil {
+		return false
+	}
+
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+
+	key := oplockKey(open.Path)
+	t.granted[key] = append(t.granted[key], &oplockHolder{
+		conn:  conn,
+		fid:   open.FID,
+		uid:   uid,
+		tid:   open.Tree.TID,
+		owner: open,
+	})
+	return true
+}
+
+// Break removes every oplock held on a path by a handle other than except, and
+// returns the holders it removed so the caller can notify them.
+//
+// The notification is deliberately not sent here. Sending it takes the target
+// connection's write lock, and doing that while holding this table's mutex would
+// have a slow client on one connection stall every other connection's opens.
+//
+// Parameters:
+//   - path: the share-relative path whose holders are losing their oplock
+//   - except: a handle to leave alone, or nil to break every holder
+//
+// Returns:
+//   - The holders that lost their oplock
+func (t *oplockTable) Break(path string, except *Open) []*oplockHolder {
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+
+	key := oplockKey(path)
+	held := t.granted[key]
+	if len(held) == 0 {
+		return nil
+	}
+
+	broken := make([]*oplockHolder, 0, len(held))
+	kept := held[:0]
+	for _, holder := range held {
+		if except != nil && holder.owner == except {
+			kept = append(kept, holder)
+			continue
+		}
+		broken = append(broken, holder)
+	}
+
+	if len(kept) == 0 {
+		delete(t.granted, key)
+	} else {
+		t.granted[key] = kept
+	}
+	return broken
+}
+
+// Release drops the oplock a handle holds, and reports whether it held one.
+//
+// It is what both a close and a client's break acknowledgement come to: [MS-CIFS]
+// section 3.3.5.30 has the acknowledgement "set Server.Open.Oplock to NONE", and
+// a handle that no longer exists cannot hold one either.
+func (t *oplockTable) Release(open *Open) bool {
+	if open == nil {
+		return false
+	}
+
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+
+	key := oplockKey(open.Path)
+	held := t.granted[key]
+	kept := held[:0]
+	released := false
+	for _, holder := range held {
+		if holder.owner == open {
+			released = true
+			continue
+		}
+		kept = append(kept, holder)
+	}
+
+	if len(kept) == 0 {
+		delete(t.granted, key)
+	} else {
+		t.granted[key] = kept
+	}
+	return released
+}
+
+// HeldOn reports how many oplocks are held on a path.
+func (t *oplockTable) HeldOn(path string) int {
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+	return len(t.granted[oplockKey(path)])
+}
+
+// Holds reports whether a handle holds an oplock.
+func (t *oplockTable) Holds(open *Open) bool {
+	if open == nil {
+		return false
+	}
+
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+	for _, holder := range t.granted[oplockKey(open.Path)] {
+		if holder.owner == open {
+			return true
+		}
+	}
+	return false
+}
+
+// grantOplock decides what oplock an open gets and records it.
+//
+// A request for an exclusive or batch oplock is downgraded and answered with
+// level II, which [MS-SMB] section 3.3.5.1.2 sanctions: it is what a share with
+// SHI1005_FLAGS_FORCE_LEVELII_OPLOCK does. It is also the only honest answer
+// here, because an exclusive oplock lets a client cache writes, and breaking one
+// means holding the operation that caused the break until the client has flushed
+// and acknowledged — which needs a request this server can suspend and resume,
+// and it has none.
+//
+// [MS-CIFS] section 3.3.5.2.7 would additionally refuse an oplock on a file
+// another handle has open for writing. This grants it and withdraws it at the
+// point the writer actually changes the file instead, which keeps the same
+// promise to the client — it is told before any change of its cached data can be
+// seen — without a snapshot of every connection's open table, which belongs to
+// those connections' own goroutines and could not be read here without a race.
+//
+// Parameters:
+//   - conn: the connection the open belongs to
+//   - open: the handle just registered
+//   - uid: the session the handle was opened under
+//   - createFlags: the request's Flags field
+//
+// Returns:
+//   - The level to report in the response
+func (c *Connection) grantOplock(open *Open, uid uint16, createFlags uint32) uint8 {
+	if createFlags&(ntCreateRequestOplock|ntCreateRequestOpBatch) == 0 {
+		// Nothing was asked for. [MS-SMB] section 3.3.5.1.2 notes that Windows
+		// grants level II anyway; this does not, because a client that did not
+		// ask has not agreed to answer a break.
+		return OplockLevelNone
+	}
+	if !c.oplocksSupported() {
+		return OplockLevelNone
+	}
+	if open.IsDirectory {
+		// "If the open or create is on a directory file, then an Oplock MUST NOT
+		// be granted" ([MS-CIFS] section 3.3.5.2.7).
+		return OplockLevelNone
+	}
+	if open.Tree == nil || open.Tree.Share == nil || open.Tree.Share.oplocks == nil {
+		return OplockLevelNone
+	}
+
+	if !open.Tree.Share.oplocks.Grant(open, c, uid) {
+		return OplockLevelNone
+	}
+
+	logger.Debugf("SMB1 server: %s granted a level II oplock on %q (FID 0x%04X)",
+		c.Remote, open.Path, open.FID)
+	return OplockLevelLevelII
+}
+
+// oplocksSupported reports whether this connection may be granted an oplock.
+//
+// [MS-CIFS] section 3.3.5.53 requires it to be false when the client's
+// MaxMpxCount is below two, and gives the reason: "a client attempting to break
+// its own OpLock would always time out because there would not be enough
+// outstanding command slots to properly revoke the OpLock". A client that can
+// have only one command in flight cannot answer a break while it is waiting for
+// anything else.
+func (c *Connection) oplocksSupported() bool {
+	if !c.Negotiated || c.ClientMaxMpxCount < 2 {
+		return false
+	}
+	return serverCapabilities&capabilities.CAP_LEVEL_II_OPLOCKS != 0
+}
+
+// breakOplocksOn breaks every level II oplock on a path except one handle's,
+// because the file is about to change or has just been opened for writing.
+//
+// A level II oplock is a promise that there are no writers, so it has to be
+// withdrawn before anything makes that false. The withdrawal is immediate: the
+// table stops counting the holder before this returns, so nothing that follows
+// can grant or keep an oplock on the strength of it.
+//
+// The notification is handed to a goroutine of its own rather than sent here.
+// Writing to another connection blocks until that client reads, and a client
+// idling with a full receive buffer would otherwise stall the unrelated client
+// whose write broke the oplock — one client's slowness becoming another's. That
+// is safe precisely because a level II break needs no acknowledgement: nothing
+// waits on it, and the holder has no cached writes to flush before the change
+// goes ahead. It does mean the break is in flight while the change is applied
+// rather than provably ahead of it, which is the guarantee level II carries in
+// any implementation.
+//
+// Parameters:
+//   - share: the share the path belongs to
+//   - path: the share-relative path about to change
+//   - except: the handle causing the change, which keeps whatever it holds
+func (c *Connection) breakOplocksOn(share *Share, path string, except *Open) {
+	if share == nil || share.oplocks == nil {
+		return
+	}
+
+	for _, holder := range share.oplocks.Break(path, except) {
+		go func(holder *oplockHolder) {
+			if err := holder.notifyBreak(); err != nil {
+				// A break that cannot be delivered has still been withdrawn:
+				// the holder is out of the table. Its client keeps a cache it
+				// should have dropped, so this is worth a line.
+				logger.Debugf("SMB1 server: could not tell %s its oplock on %q was broken: %v",
+					holder.conn.Remote, path, err)
+			}
+		}(holder)
+	}
+}
+
+// notifyBreak sends the oplock break notification for one holder.
+//
+// It is an SMB_COM_LOCKING_ANDX request rather than a response — the one message
+// the server originates — carrying OPLOCK_RELEASE and a NewOpLockLevel of zero.
+// [MS-CIFS] section 3.3.4.2 has the other fields zero with it: "the server
+// SHOULD set the Timeout, NumberOfUnlocks, NumberofLocks, and ByteCount fields to
+// zero".
+func (h *oplockHolder) notifyBreak() error {
+	notification := commands.NewLockingAndxRequest()
+	notification.FID = types.USHORT(h.fid)
+	notification.TypeOfLock = types.UCHAR(commands.LockingAndxOplockRelease)
+	notification.NewOpLockLevel = types.UCHAR(breakToNone)
+	notification.Timeout = types.ULONG(0)
+
+	return h.conn.SendUnsolicited(notification, h.uid, h.tid, h.conn.nextUnsolicitedMID())
+}
+
+// releaseOplock applies a client's OpLock Break Request: the acknowledgement it
+// sends after being told its oplock was broken.
+//
+// [MS-CIFS] section 3.3.5.30 requires the server to "release the OpLock on the
+// Open" and to set its state to NONE, and is equally clear that a release naming
+// a handle that holds none is not an error: "If there are no outstanding OpLock
+// breaks, or if the FID in the request does not match the FID of an outstanding
+// OpLock Break Notification, then no OpLock is released. This does not generate
+// an error."
+//
+// Nothing is waiting on the acknowledgement here. A level II oplock is withdrawn
+// the moment the break is sent, because the client has no cached writes to flush
+// first, so by the time this arrives the server has already stopped counting the
+// handle as a holder — and the operation that broke it has already gone ahead.
+//
+// Parameters:
+//   - open: the handle the client is releasing
+func (c *Connection) releaseOplock(open *Open) {
+	if open == nil || open.Tree == nil || open.Tree.Share == nil || open.Tree.Share.oplocks == nil {
+		return
+	}
+
+	released := open.Tree.Share.oplocks.Release(open)
+
+	logger.Debugf("SMB1 server: %s released the oplock on FID 0x%04X (%q), which it held=%t",
+		c.Remote, open.FID, open.Path, released)
+}

--- a/network/smb/smb_v10/server/oplocks_test.go
+++ b/network/smb/smb_v10/server/oplocks_test.go
@@ -1,0 +1,598 @@
+package server
+
+import (
+	"encoding/binary"
+	"net"
+	"testing"
+	"time"
+
+	smb1client "github.com/TheManticoreProject/Manticore/network/smb/smb_v10/client"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/codes"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+	"github.com/TheManticoreProject/Manticore/network/tcp"
+	"github.com/TheManticoreProject/Manticore/windows/credentials"
+	"github.com/TheManticoreProject/Manticore/windows/fileflags"
+)
+
+// oplockServer stands up a server with one memory share holding a file, and
+// returns the server and a client connected to it.
+func oplockServer(t *testing.T) (*Server, *smb1client.Client) {
+	t.Helper()
+
+	fs := NewMemoryFileSystem("FILES")
+	if err := fs.AddFile("cached.bin", []byte("the bytes a client would cache")); err != nil {
+		t.Fatalf("AddFile() error = %v", err)
+	}
+	if err := fs.Mkdir("folder"); err != nil {
+		t.Fatalf("Mkdir() error = %v", err)
+	}
+	return fileServer(t, fs, false)
+}
+
+// attachClient connects a second client to a server already running, so a break
+// crossing from one connection to another can be observed.
+func attachClient(t *testing.T, srv *Server) *smb1client.Client {
+	t.Helper()
+
+	serverSide, clientSide := net.Pipe()
+	remote := &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 2}
+
+	served := make(chan struct{})
+	go func() {
+		defer close(served)
+		_ = srv.ServeConn(tcp.NewTCPTransportFromConn(serverSide), remote)
+	}()
+
+	transportEnd := tcp.NewTCPTransportFromConn(clientSide)
+	transportEnd.SetTimeout(5 * time.Second)
+	t.Cleanup(func() {
+		clientSide.Close()
+		serverSide.Close()
+		<-served
+	})
+
+	client := smb1client.NewFromTransport(transportEnd, net.IPv4(127, 0, 0, 1), 445)
+	if err := client.Negotiate(); err != nil {
+		t.Fatalf("Negotiate() error = %v", err)
+	}
+	creds, err := credentials.NewCredentials(captureDomain, captureUsername, capturePassword, "")
+	if err != nil {
+		t.Fatalf("NewCredentials() error = %v", err)
+	}
+	if err := client.SessionSetup(creds); err != nil {
+		t.Fatalf("SessionSetup() error = %v", err)
+	}
+	if err := client.TreeConnect(fileShareName); err != nil {
+		t.Fatalf("TreeConnect() error = %v", err)
+	}
+	return client
+}
+
+// openAsking opens a file with a chosen NT_CREATE_ANDX Flags field and returns
+// the handle and the oplock level granted.
+//
+// The client API does not carry the Flags field, and the oplock request lives
+// there, so the request is built here.
+func openAsking(
+	t *testing.T,
+	client *smb1client.Client,
+	name string,
+	createFlags uint32,
+	access uint32,
+	options uint32,
+) (smb1client.FID, uint8) {
+	t.Helper()
+
+	request := newRequest(codes.SMB_COM_NT_CREATE_ANDX)
+	request.Header.UID = client.Session.SessionUID
+	request.Header.TID = client.Session.TreeID
+	request.Header.Flags2 &^= 0x8000
+
+	cmd := commands.NewNtCreateAndxRequest()
+	cmd.FileName = *types.NewSMB_STRING([]byte("\\" + name))
+	cmd.Flags = types.ULONG(createFlags)
+	cmd.DesiredAccess = types.ULONG(access)
+	cmd.ShareAccess = types.ULONG(fileflags.FILE_SHARE_READ | fileflags.FILE_SHARE_WRITE | fileflags.FILE_SHARE_DELETE)
+	cmd.CreateDisposition = types.ULONG(fileflags.FILE_OPEN)
+	cmd.CreateOptions = types.ULONG(options)
+	request.AddCommand(cmd)
+
+	marshalled, err := request.Marshal()
+	if err != nil {
+		t.Fatalf("failed to marshal the open: %v", err)
+	}
+	if _, err := client.Transport.Send(marshalled); err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+	raw, err := client.Transport.Receive()
+	if err != nil {
+		t.Fatalf("Receive() error = %v", err)
+	}
+	if status := binary.LittleEndian.Uint32(raw[5:9]); status != 0 {
+		t.Fatalf("opening %q reported 0x%08X, want success", name, status)
+	}
+
+	response := commands.NewNtCreateAndxResponse()
+	if _, err := response.Unmarshal(raw[header.SMB_HEADER_SIZE:]); err != nil {
+		t.Fatalf("the open reply did not decode: %v", err)
+	}
+	return smb1client.FID(response.FID), uint8(response.OpLockLevel)
+}
+
+// awaitBreak reads the next frame on a client's transport and decodes it as an
+// oplock break notification.
+//
+// A break is a request rather than a response, so a client that is not waiting
+// for anything still has one arrive on its transport. That is what this reads.
+func awaitBreak(t *testing.T, client *smb1client.Client) *commands.LockingAndxRequest {
+	t.Helper()
+
+	raw, err := client.Transport.Receive()
+	if err != nil {
+		t.Fatalf("no oplock break arrived: %v", err)
+	}
+
+	decoded := message.NewMessage()
+	if err := decoded.Unmarshal(raw); err != nil {
+		t.Fatalf("the break did not decode: %v", err)
+	}
+	if decoded.Header.Command != codes.SMB_COM_LOCKING_ANDX {
+		t.Fatalf("the server sent command 0x%02X, want SMB_COM_LOCKING_ANDX",
+			uint8(decoded.Header.Command))
+	}
+	// A break is a request: [MS-CIFS] section 3.3.4.1 has SMB_FLAGS_REPLY set on
+	// every message the server sends "unless the message is an OpLock Break
+	// Notification request initiated by the server".
+	if decoded.Header.Flags.IsReply() {
+		t.Error("the break has SMB_FLAGS_REPLY set, so a client would decode it as a response")
+	}
+
+	notification, ok := decoded.Command.(*commands.LockingAndxRequest)
+	if !ok {
+		t.Fatalf("the break decoded as %T, want a LockingAndxRequest", decoded.Command)
+	}
+	if uint8(notification.TypeOfLock)&commands.LockingAndxOplockRelease == 0 {
+		t.Errorf("the break's TypeOfLock is 0x%02X, want the OPLOCK_RELEASE bit (0x%02X)",
+			notification.TypeOfLock, commands.LockingAndxOplockRelease)
+	}
+	if notification.NewOpLockLevel != breakToNone {
+		t.Errorf("the break reports NewOpLockLevel %d, want 0 — level II breaks to nothing",
+			notification.NewOpLockLevel)
+	}
+	return notification
+}
+
+// expectNoBreak asserts nothing arrives on a client's transport.
+func expectNoBreak(t *testing.T, client *smb1client.Client) {
+	t.Helper()
+
+	client.Transport.SetTimeout(250 * time.Millisecond)
+	defer client.Transport.SetTimeout(5 * time.Second)
+
+	if raw, err := client.Transport.Receive(); err == nil {
+		t.Errorf("an unexpected %d-byte message arrived, first bytes % x", len(raw), raw[:min(16, len(raw))])
+	}
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func TestOplockGrantedOnAnOpenThatAsksForOne(t *testing.T) {
+	_, client := oplockServer(t)
+
+	_, level := openAsking(t, client, "cached.bin", ntCreateRequestOplock,
+		fileflags.GENERIC_READ, fileflags.FILE_NON_DIRECTORY_FILE)
+
+	if level != OplockLevelLevelII {
+		t.Errorf("the open was granted oplock level %d, want level II (%d)", level, OplockLevelLevelII)
+	}
+}
+
+func TestBatchOplockRequestIsDowngradedToLevelII(t *testing.T) {
+	// [MS-SMB] section 3.3.5.1.2 sanctions answering a request for an exclusive or
+	// batch oplock with level II. Refusing outright would leave a client that asks
+	// for a batch oplock with no caching at all, which the capability exists to
+	// avoid.
+	_, client := oplockServer(t)
+
+	for _, asked := range []uint32{ntCreateRequestOplock, ntCreateRequestOpBatch, ntCreateRequestOplock | ntCreateRequestOpBatch} {
+		_, level := openAsking(t, client, "cached.bin", asked,
+			fileflags.GENERIC_READ, fileflags.FILE_NON_DIRECTORY_FILE)
+		if level != OplockLevelLevelII {
+			t.Errorf("an open asking with flags 0x%08X was granted level %d, want level II (%d)",
+				asked, level, OplockLevelLevelII)
+		}
+	}
+}
+
+func TestOplockNotGrantedWhenNoneIsAskedFor(t *testing.T) {
+	// A client that did not ask has not agreed to answer a break, so granting one
+	// would have the server expect an acknowledgement it will never get and the
+	// client cache on a promise it does not know it holds.
+	_, client := oplockServer(t)
+
+	_, level := openAsking(t, client, "cached.bin", 0,
+		fileflags.GENERIC_READ, fileflags.FILE_NON_DIRECTORY_FILE)
+
+	if level != OplockLevelNone {
+		t.Errorf("an open that asked for nothing was granted level %d, want none", level)
+	}
+}
+
+func TestOplockNotGrantedOnADirectory(t *testing.T) {
+	// "If the open or create is on a directory file, then an Oplock MUST NOT be
+	// granted" ([MS-CIFS] section 3.3.5.2.7).
+	_, client := oplockServer(t)
+
+	_, level := openAsking(t, client, "folder", ntCreateRequestOplock,
+		fileflags.GENERIC_READ, fileflags.FILE_DIRECTORY_FILE)
+
+	if level != OplockLevelNone {
+		t.Errorf("an open of a directory was granted level %d, want none", level)
+	}
+}
+
+func TestOplockNotGrantedWithASingleCommandSlot(t *testing.T) {
+	// [MS-CIFS] section 3.3.5.53: a MaxMpxCount below two turns oplock support off
+	// for the connection, "because there would not be enough outstanding command
+	// slots to properly revoke the OpLock". Asserted against the decision rather
+	// than over the wire, because the client fixes its own MaxMpxCount from what
+	// the server advertised.
+	conn := &Connection{
+		Server:            &Server{config: Config{}},
+		Negotiated:        true,
+		ClientMaxMpxCount: 1,
+	}
+	open := &Open{Path: "cached.bin"}
+
+	if got := conn.grantOplock(open, 1, ntCreateRequestOplock); got != OplockLevelNone {
+		t.Errorf("a client with one command slot was granted level %d, want none", got)
+	}
+
+	// And two slots is enough, given a share to record it on.
+	conn.ClientMaxMpxCount = 2
+	share := &Share{Name: "files", oplocks: newOplockTable()}
+	open.Tree = &Tree{TID: 1, Share: share}
+	if got := conn.grantOplock(open, 1, ntCreateRequestOplock); got != OplockLevelLevelII {
+		t.Errorf("a client with two command slots was granted level %d, want level II", got)
+	}
+}
+
+func TestOplockBrokenByAWriteFromAnotherConnection(t *testing.T) {
+	// The exchange the capability exists for: one client caches on a level II
+	// oplock, another writes, and the first is told before the bytes land.
+	srv, holder := oplockServer(t)
+	writer := attachClient(t, srv)
+
+	_, level := openAsking(t, holder, "cached.bin", ntCreateRequestOplock,
+		fileflags.GENERIC_READ, fileflags.FILE_NON_DIRECTORY_FILE)
+	if level != OplockLevelLevelII {
+		t.Fatalf("the holder was granted level %d, want level II", level)
+	}
+
+	// The writer's own open breaks nothing yet — it has to be able to write for
+	// that — so open it read-write and then write through it.
+	fid, err := writer.OpenFile("cached.bin",
+		fileflags.GENERIC_READ|fileflags.GENERIC_WRITE,
+		fileflags.FILE_SHARE_READ|fileflags.FILE_SHARE_WRITE,
+		fileflags.FILE_OPEN,
+		fileflags.FILE_NON_DIRECTORY_FILE)
+	if err != nil {
+		t.Fatalf("the writer could not open the file: %v", err)
+	}
+
+	// The writable open is itself a break, so the notification is already on its
+	// way before the write.
+	awaitBreak(t, holder)
+
+	if _, err := writer.WriteFile(fid, 0, []byte("replaced")); err != nil {
+		t.Fatalf("the write failed: %v", err)
+	}
+
+	// And the oplock is gone rather than broken twice: a second break would have
+	// the client acknowledge something it no longer holds.
+	expectNoBreak(t, holder)
+
+	share := srv.Share(fileShareName)
+	if held := share.oplocks.HeldOn("cached.bin"); held != 0 {
+		t.Errorf("%d oplocks are still recorded on the file, want none", held)
+	}
+}
+
+func TestOplockBrokenByAWriteThroughAHandleOpenedBeforeIt(t *testing.T) {
+	// A writer that was already there when the oplock was granted. [MS-CIFS]
+	// section 3.3.5.2.7 would have refused the oplock; this grants it and
+	// withdraws it when the writer actually writes, which keeps the same promise.
+	srv, writer := oplockServer(t)
+	holder := attachClient(t, srv)
+
+	fid, err := writer.OpenFile("cached.bin",
+		fileflags.GENERIC_READ|fileflags.GENERIC_WRITE,
+		fileflags.FILE_SHARE_READ|fileflags.FILE_SHARE_WRITE,
+		fileflags.FILE_OPEN,
+		fileflags.FILE_NON_DIRECTORY_FILE)
+	if err != nil {
+		t.Fatalf("the writer could not open the file: %v", err)
+	}
+
+	_, level := openAsking(t, holder, "cached.bin", ntCreateRequestOplock,
+		fileflags.GENERIC_READ, fileflags.FILE_NON_DIRECTORY_FILE)
+	if level != OplockLevelLevelII {
+		t.Fatalf("the holder was granted level %d, want level II", level)
+	}
+
+	if _, err := writer.WriteFile(fid, 0, []byte("replaced")); err != nil {
+		t.Fatalf("the write failed: %v", err)
+	}
+
+	awaitBreak(t, holder)
+}
+
+func TestOplockBrokenByADelete(t *testing.T) {
+	// A delete is reached by path, so no open of the deleting client has broken
+	// anything. Without an explicit break the holder would go on caching a file
+	// that no longer exists.
+	srv, holder := oplockServer(t)
+	deleter := attachClient(t, srv)
+
+	if _, level := openAsking(t, holder, "cached.bin", ntCreateRequestOplock,
+		fileflags.GENERIC_READ, fileflags.FILE_NON_DIRECTORY_FILE); level != OplockLevelLevelII {
+		t.Fatalf("the holder was granted level %d, want level II", level)
+	}
+
+	if err := deleter.DeleteFile("cached.bin"); err != nil {
+		t.Fatalf("the delete failed: %v", err)
+	}
+
+	awaitBreak(t, holder)
+}
+
+func TestOplockBrokenByARename(t *testing.T) {
+	srv, holder := oplockServer(t)
+	renamer := attachClient(t, srv)
+
+	if _, level := openAsking(t, holder, "cached.bin", ntCreateRequestOplock,
+		fileflags.GENERIC_READ, fileflags.FILE_NON_DIRECTORY_FILE); level != OplockLevelLevelII {
+		t.Fatalf("the holder was granted level %d, want level II", level)
+	}
+
+	if err := renamer.RenameFile("cached.bin", "moved.bin"); err != nil {
+		t.Fatalf("the rename failed: %v", err)
+	}
+
+	awaitBreak(t, holder)
+}
+
+func TestOplockNotBrokenByAnotherReader(t *testing.T) {
+	// Level II is "multiple readers of a file and no writers", so a second reader
+	// is exactly what it is for. Breaking on one would make the oplock useless.
+	srv, holder := oplockServer(t)
+	reader := attachClient(t, srv)
+
+	if _, level := openAsking(t, holder, "cached.bin", ntCreateRequestOplock,
+		fileflags.GENERIC_READ, fileflags.FILE_NON_DIRECTORY_FILE); level != OplockLevelLevelII {
+		t.Fatalf("the holder was granted level %d, want level II", level)
+	}
+
+	fid, err := reader.OpenFile("cached.bin",
+		fileflags.GENERIC_READ,
+		fileflags.FILE_SHARE_READ|fileflags.FILE_SHARE_WRITE,
+		fileflags.FILE_OPEN,
+		fileflags.FILE_NON_DIRECTORY_FILE)
+	if err != nil {
+		t.Fatalf("the second reader could not open the file: %v", err)
+	}
+	if _, err := reader.ReadFile(fid, 0, 8); err != nil {
+		t.Fatalf("the second reader could not read: %v", err)
+	}
+
+	expectNoBreak(t, holder)
+
+	share := srv.Share(fileShareName)
+	if held := share.oplocks.HeldOn("cached.bin"); held != 1 {
+		t.Errorf("%d oplocks are recorded on the file, want the holder's one", held)
+	}
+}
+
+func TestOplockReleasedByTheClientsAcknowledgement(t *testing.T) {
+	// [MS-CIFS] section 3.3.5.30: the release sets the handle's oplock to NONE and
+	// is answered with silence, since both range counts are zero.
+	srv, client := oplockServer(t)
+
+	fid, level := openAsking(t, client, "cached.bin", ntCreateRequestOplock,
+		fileflags.GENERIC_READ, fileflags.FILE_NON_DIRECTORY_FILE)
+	if level != OplockLevelLevelII {
+		t.Fatalf("the open was granted level %d, want level II", level)
+	}
+
+	share := srv.Share(fileShareName)
+	if held := share.oplocks.HeldOn("cached.bin"); held != 1 {
+		t.Fatalf("%d oplocks are recorded, want one", held)
+	}
+
+	request := newRequest(codes.SMB_COM_LOCKING_ANDX)
+	request.Header.UID = client.Session.SessionUID
+	request.Header.TID = client.Session.TreeID
+
+	release := commands.NewLockingAndxRequest()
+	release.FID = types.USHORT(fid)
+	release.TypeOfLock = types.UCHAR(commands.LockingAndxOplockRelease)
+	request.AddCommand(release)
+
+	marshalled, err := request.Marshal()
+	if err != nil {
+		t.Fatalf("failed to marshal the release: %v", err)
+	}
+	if _, err := client.Transport.Send(marshalled); err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+
+	// Answered with silence, so the only way to see it landed is the table. An
+	// echo afterwards proves the connection is still in step rather than holding
+	// an unsent response.
+	waitFor(t, func() bool { return share.oplocks.HeldOn("cached.bin") == 0 },
+		"the release did not drop the oplock")
+	if _, err := client.Echo([]byte("still here")); err != nil {
+		t.Errorf("the connection did not survive the release: %v", err)
+	}
+}
+
+func TestOplockReleasedWhenTheHandleCloses(t *testing.T) {
+	srv, client := oplockServer(t)
+
+	fid, level := openAsking(t, client, "cached.bin", ntCreateRequestOplock,
+		fileflags.GENERIC_READ, fileflags.FILE_NON_DIRECTORY_FILE)
+	if level != OplockLevelLevelII {
+		t.Fatalf("the open was granted level %d, want level II", level)
+	}
+
+	share := srv.Share(fileShareName)
+	if held := share.oplocks.HeldOn("cached.bin"); held != 1 {
+		t.Fatalf("%d oplocks are recorded, want one", held)
+	}
+
+	if err := client.CloseFile(fid); err != nil {
+		t.Fatalf("closing the handle failed: %v", err)
+	}
+	if held := share.oplocks.HeldOn("cached.bin"); held != 0 {
+		t.Errorf("%d oplocks are recorded after the close, want none", held)
+	}
+}
+
+func TestOpenReportsTheOplockItHolds(t *testing.T) {
+	// Open.OplockLevel asks the table rather than keeping a copy, so it cannot
+	// disagree with what a break has already withdrawn — and cannot be written
+	// from two goroutines at once, which a field on the handle would be.
+	table := newOplockTable()
+	share := &Share{Name: "files", oplocks: table}
+	tree := &Tree{TID: 1, Share: share}
+	open := &Open{FID: 1, Path: "cached.bin", Tree: tree}
+
+	if got := open.OplockLevel(); got != OplockLevelNone {
+		t.Errorf("a handle with no oplock reports level %d, want none", got)
+	}
+
+	if !table.Grant(open, &Connection{}, 1) {
+		t.Fatal("granting failed")
+	}
+	if got := open.OplockLevel(); got != OplockLevelLevelII {
+		t.Errorf("a handle holding an oplock reports level %d, want level II", got)
+	}
+
+	table.Break("cached.bin", nil)
+	if got := open.OplockLevel(); got != OplockLevelNone {
+		t.Errorf("a handle whose oplock was broken reports level %d, want none", got)
+	}
+
+	// A handle on a share with no table, and a nil handle, report none rather
+	// than panicking: every mutation path asks.
+	if got := (&Open{Path: "x", Tree: &Tree{Share: &Share{}}}).OplockLevel(); got != OplockLevelNone {
+		t.Errorf("a handle on a share with no table reports level %d, want none", got)
+	}
+	var missing *Open
+	if got := missing.OplockLevel(); got != OplockLevelNone {
+		t.Errorf("a nil handle reports level %d, want none", got)
+	}
+}
+
+func TestCapabilityIsAdvertised(t *testing.T) {
+	// The capability is a promise that a break can be sent, so it belongs in the
+	// negotiate response only now that one can.
+	if serverCapabilities&0x00000080 == 0 {
+		t.Error("CAP_LEVEL_II_OPLOCKS is not advertised, so no client will ask for an oplock")
+	}
+}
+
+func TestOplockTableBreaksEveryHolderButOne(t *testing.T) {
+	// The table itself, since the wire tests can only reach it two handles at a
+	// time.
+	table := newOplockTable()
+	share := &Share{Name: "files", oplocks: table}
+	tree := &Tree{TID: 1, Share: share}
+
+	first := &Open{FID: 1, Path: "a/b.txt", Tree: tree}
+	second := &Open{FID: 2, Path: "A/B.TXT", Tree: tree}
+	third := &Open{FID: 3, Path: "a/b.txt", Tree: tree}
+	other := &Open{FID: 4, Path: "a/c.txt", Tree: tree}
+
+	conn := &Connection{}
+	for _, open := range []*Open{first, second, third, other} {
+		if !table.Grant(open, conn, 1) {
+			t.Fatalf("granting on FID %d failed", open.FID)
+		}
+	}
+
+	// The three spellings of one path share an entry, because the file commands
+	// match names case-insensitively and a break must not miss a holder over
+	// capitalisation.
+	if held := table.HeldOn("a/b.txt"); held != 3 {
+		t.Errorf("%d oplocks are recorded on the file, want 3 across its spellings", held)
+	}
+
+	broken := table.Break("A/b.TXT", second)
+	if len(broken) != 2 {
+		t.Fatalf("breaking left %d holders broken, want 2", len(broken))
+	}
+	for _, holder := range broken {
+		if holder.owner == second {
+			t.Error("the excepted handle was broken")
+		}
+	}
+	if held := table.HeldOn("a/b.txt"); held != 1 {
+		t.Errorf("%d oplocks remain, want the excepted one", held)
+	}
+	if held := table.HeldOn("a/c.txt"); held != 1 {
+		t.Errorf("breaking one file dropped %d oplocks on another", 1-held)
+	}
+
+	// Releasing the last one empties the entry, and releasing again reports that
+	// nothing was held rather than failing.
+	if !table.Release(second) {
+		t.Error("releasing the remaining holder reported it held nothing")
+	}
+	if table.Release(second) {
+		t.Error("releasing twice reported an oplock the second time")
+	}
+	if held := table.HeldOn("a/b.txt"); held != 0 {
+		t.Errorf("%d oplocks remain after the release, want none", held)
+	}
+}
+
+func TestBreakingWithNoHoldersIsHarmless(t *testing.T) {
+	// Every mutation path calls the break, and almost none of them will find a
+	// holder, so the empty case has to cost nothing and touch nothing.
+	table := newOplockTable()
+	if broken := table.Break("nothing/here.txt", nil); len(broken) != 0 {
+		t.Errorf("breaking an unheld file reported %d holders", len(broken))
+	}
+
+	conn := &Connection{Server: &Server{config: Config{}}}
+	conn.breakOplocksOn(nil, "nothing/here.txt", nil)
+	conn.breakOplocksOn(&Share{Name: "files"}, "nothing/here.txt", nil)
+}
+
+func TestUnsolicitedMIDsAreDistinctAndNonZero(t *testing.T) {
+	// A client matches a response to a request by MID, so two breaks in flight
+	// must not share one. Zero is skipped because a client may read it as "no
+	// MID".
+	conn := &Connection{}
+
+	seen := map[uint16]bool{}
+	for round := 0; round < 4; round++ {
+		mid := conn.nextUnsolicitedMID()
+		if mid == 0 {
+			t.Fatal("an unsolicited MID of zero was handed out")
+		}
+		if seen[mid] {
+			t.Fatalf("MID 0x%04X was handed out twice", mid)
+		}
+		seen[mid] = true
+	}
+}

--- a/network/smb/smb_v10/server/share.go
+++ b/network/smb/smb_v10/server/share.go
@@ -57,6 +57,11 @@ type Share struct {
 	// handles it excludes may be on other connections. AddShare creates it, so a
 	// share reached through the server always has one.
 	locks *lockTable
+
+	// oplocks holds the level II oplocks granted on this share's files, for the
+	// same reason: the handles a break has to notify are on other connections as
+	// much as this one. AddShare creates it too.
+	oplocks *oplockTable
 }
 
 // OpenFlags describe what an open is for. They are the subset of the client's
@@ -321,10 +326,13 @@ func (s *Server) AddShare(share *Share) error {
 		return fmt.Errorf("disk share %q has no file system", share.Name)
 	}
 
-	// Every share gets a lock table, so a handler never has to ask whether the
-	// share it was given can hold a lock.
+	// Every share gets a lock table and an oplock table, so a handler never has
+	// to ask whether the share it was given can hold either.
 	if share.locks == nil {
 		share.locks = newLockTable()
+	}
+	if share.oplocks == nil {
+		share.oplocks = newOplockTable()
 	}
 
 	key := strings.ToUpper(share.Name)

--- a/network/smb/smb_v10/server/tree.go
+++ b/network/smb/smb_v10/server/tree.go
@@ -106,6 +106,25 @@ func (c *Connection) Open(fid uint16) *Open {
 }
 
 // addTree records a connected tree.
+// OplockLevel reports the oplock this handle holds, as an OplockLevel* constant.
+//
+// It asks the share's table rather than caching the answer on the handle. An
+// oplock is broken by whichever goroutine changes the file, which is not this
+// handle's connection, so a copy kept here would be written from two goroutines
+// at once — and the table is guarded and is the thing that decides who holds one.
+//
+// Returns:
+//   - The level held, or OplockLevelNone
+func (o *Open) OplockLevel() uint8 {
+	if o == nil || o.Tree == nil || o.Tree.Share == nil || o.Tree.Share.oplocks == nil {
+		return OplockLevelNone
+	}
+	if o.Tree.Share.oplocks.Holds(o) {
+		return OplockLevelLevelII
+	}
+	return OplockLevelNone
+}
+
 // pipeSession returns the handler session this handle transacts on, which is nil
 // for a handle that does not name a pipe.
 func (o *Open) pipeSession() PipeSession {
@@ -221,6 +240,13 @@ func (c *Connection) closeOpen(fid uint16) error {
 	// of the share.
 	if open.Tree != nil && open.Tree.Share != nil && open.Tree.Share.locks != nil {
 		open.Tree.Share.locks.ReleaseAll(open)
+	}
+
+	// An oplock goes the same way, and for the same reason: it is a promise made
+	// to a handle, and a handle that no longer exists cannot be told the promise
+	// has been withdrawn.
+	if open.Tree != nil && open.Tree.Share != nil && open.Tree.Share.oplocks != nil {
+		open.Tree.Share.oplocks.Release(open)
 	}
 
 	var firstErr error


### PR DESCRIPTION
### Linked Issue
`Closes #1152`

The `NT_TRANSACT_NOTIFY_CHANGE` half of this issue shipped with the asynchronous response path (`handler_notify.go`, the `Watcher` backends, `AsyncResponder`). This is the oplock half, which is all that was left.

### Root Cause
`CAP_LEVEL_II_OPLOCKS` was not advertised and no oplock was ever granted, so the `OpLockLevel` field of every `NT_CREATE_ANDX` and `NT_TRANSACT_CREATE` response was left at zero however the client asked. There was no oplock table, and nothing broke anything.

I had recorded the remaining blocker as the signing sequence number for a server-initiated message — `SendUnsolicited` refused outright on a signing connection, with a comment saying the numbering could not be settled without a reference capture from a real client. **That was wrong, and reading the spec rather than reasoning about it settles it.** [MS-CIFS] 3.3.4.1, having said that a message the server sends MUST be signed with the number in `ServerSendSequenceNumber[PID,MID]`, adds:

> OpLock Break Notification messages are exempt from signing.

The exemption is not a convenience, it is what makes the message possible at all: that table is keyed by a request's PID and MID, and a break has no request behind it, so there is no entry to sign with. Sending it unsigned consumes no number, which is precisely why the two sides' numbering stays in step. The same section covers the other half of the message's oddity — `SMB_FLAGS_REPLY` is set on everything the server sends "unless the message is an OpLock Break Notification request initiated by the server", which the code already did.

So no capture was needed and nothing was blocked.

### Fix Description
**What is granted.** Level II and only level II. It permits a client to cache reads and nothing else, so withdrawing it needs no acknowledgement and cannot leave the operation that broke it suspended. A request for an exclusive or batch oplock is answered with level II rather than refused — [MS-SMB] 3.3.5.1.2 sanctions exactly that for a share with `SHI1005_FLAGS_FORCE_LEVELII_OPLOCK`, and refusing would leave a client that asks for a batch oplock with no caching at all, which the capability exists to avoid. Granting exclusive would mean suspending the operation that broke it until the client had flushed and acknowledged, which needs a request this server can park and resume, and it has none.

Nothing is granted when the client asked for nothing (it has not agreed to answer a break), on a directory ([MS-CIFS] 3.3.5.2.7), or to a client whose `MaxMpxCount` is below two — [MS-CIFS] 3.3.5.53 forbids that, with the reason spelled out: "a client attempting to break its own OpLock would always time out because there would not be enough outstanding command slots to properly revoke the OpLock". The client's `MaxMpxCount` was not recorded before; it is now.

**Where the state lives.** `oplockTable` on the `Share`, next to `lockTable` and for the same reason: an oplock is a statement about a file, and the handles a break must notify are on other connections as much as this one. It is keyed by upper-cased path, because the file commands match names case-insensitively and a break must not miss a holder over capitalisation.

**What breaks one.** An open that can write, a write, a set-information level that resizes, a delete, and a rename. The last three are reached by path rather than by handle, so no open of theirs has broken anything — a holder would otherwise go on caching a file that no longer exists. A timestamp-only change does not break one: a level II oplock caches data, and a timestamp is not data.

**Two deliberate deviations, both documented at the code:**

- [MS-CIFS] 3.3.5.2.7 would additionally refuse an oplock on a file another handle holds open for writing. This grants it and withdraws it when that handle actually changes the file. It keeps the same promise to the client — told before any change to its cached data can be seen — without taking a snapshot of every connection's open table, which belongs to those connections' own goroutines and could not be read from the granting path without a race. `TestOplockBrokenByAWriteThroughAHandleOpenedBeforeIt` covers the case this substitution creates.
- The notification is sent on a goroutine of its own. This one was found by a test, not by design: `TestOplockBrokenByAWriteFromAnotherConnection` deadlocked, because writing to another connection blocks until that client reads, and the holder was idle. Sending inline lets a client idling with a full receive buffer stall the *unrelated* client whose write broke the oplock. The withdrawal is still immediate — the table stops counting the holder before the mutation proceeds — so nothing after that point can grant or keep an oplock on the strength of it; only the notification is in flight. That is safe precisely because a level II break needs no acknowledgement.

**The acknowledgement.** A client's `SMB_COM_LOCKING_ANDX` with `OPLOCK_RELEASE` releases the handle's oplock and is answered with silence, both of which [MS-CIFS] 3.3.5.30 requires. A release naming a handle that holds none is not an error — "This does not generate an error" — and the release bit is honoured alongside ranges as well as alone, since that section has all three parts of the request executed.

`Open.OplockLevel` is a method rather than a field. A field would be written by whichever goroutine breaks the oplock as well as by the handle's own connection, which is a data race for a value nothing reads for a decision; asking the guarded table instead cannot disagree with what a break has already withdrawn.

### How Verified
**Tests:** `go test -race ./network/smb/...` is clean, as is `go test ./...` across the repository, `go vet ./network/...`, and `go vet -tags integration ./network/smb/smb_v10/server/`. 596 tests pass in the server package, 17 of them new.

**Runtime, over the wire:** the break tests stand up one server with two clients on separate piped connections, so the notification genuinely crosses from the goroutine serving one connection to the transport of another. `TestOplockBrokenByAWriteFromAnotherConnection` grants the oplock to one client, has the other open the file for writing and write to it, and reads the break off the holder's transport — asserting `SMB_FLAGS_REPLY` is clear (so a client decodes it as the request it is), that `TypeOfLock` carries `OPLOCK_RELEASE`, and that `NewOpLockLevel` is zero. `TestUnsolicitedSendGoesUnsignedOnASigningConnection` sends a break on a connection with signing active and a non-zero MAC key, then inspects bytes 14–22 of the header to confirm the signature was left zero.

**Specs:** taken from the local copies of [MS-CIFS] and [MS-SMB] under `network/smb/smb_v10/docs/`, cited at each decision — 3.3.4.1 for the signing exemption and the reply bit, 3.3.4.2 for the notification's fields, 3.3.5.2.7 for the granting rules, 3.3.5.30 for the acknowledgement, 3.3.5.53 for the `MaxMpxCount` rule, 2.2.4.64.2 for the level values, 2.2.4.32.1 for `NewOpLockLevel`, and [MS-SMB] 3.3.5.1.2 for the downgrade.

### Test Coverage
**Added.** `network/smb/smb_v10/server/oplocks_test.go`:

- Granting: `TestOplockGrantedOnAnOpenThatAsksForOne`, `TestBatchOplockRequestIsDowngradedToLevelII` (all three flag combinations), `TestOplockNotGrantedWhenNoneIsAskedFor`, `TestOplockNotGrantedOnADirectory`, `TestOplockNotGrantedWithASingleCommandSlot`
- Breaking, each end-to-end across two connections: `TestOplockBrokenByAWriteFromAnotherConnection`, `TestOplockBrokenByAWriteThroughAHandleOpenedBeforeIt`, `TestOplockBrokenByADelete`, `TestOplockBrokenByARename`, and `TestOplockNotBrokenByAnotherReader` — the last is what keeps the oplock worth granting, since level II *is* multiple readers, and it asserts no break arrives
- Release: `TestOplockReleasedByTheClientsAcknowledgement` (including that the connection is still in step afterwards, since the request is answered with silence), `TestOplockReleasedWhenTheHandleCloses`
- The table and its edges: `TestOplockTableBreaksEveryHolderButOne` (three spellings of one path sharing an entry, the excepted holder surviving, another file untouched, a double release), `TestBreakingWithNoHoldersIsHarmless` (every mutation path calls the break and almost none find a holder), `TestOpenReportsTheOplockItHolds`, `TestUnsolicitedMIDsAreDistinctAndNonZero`, `TestCapabilityIsAdvertised`

`async_test.go`: `TestUnsolicitedSendIsRefusedWhileSigning` is replaced by `TestUnsolicitedSendGoesUnsignedOnASigningConnection`. The old test asserted the behaviour this PR corrects, so it could not be kept.

### Scope of Change
- **Files changed:** `oplocks.go` and `oplocks_test.go` (new); `share.go` and `tree.go` (the table and the accessor); `connection.go` and `handler_session.go` (`ClientMaxMpxCount`, the unsolicited MID); `async.go` and `async_test.go` (the signing exemption); `handler_negotiate.go` (the capability); `handler_file.go`, `handler_remaining_subcommands.go` (grant on create), `handler_core_file.go`, `handler_filemgmt.go`, `handler_info.go`, `handler_nt_rename.go` (the break call sites); `handler_lock.go` (the acknowledgement); `doc.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none. Every edit is the oplock feature, the signing correction it depends on, or a break call site.

### Risk and Rollout
`CAP_LEVEL_II_OPLOCKS` now appears in the negotiate response, so a client may start asking for oplocks where it previously could not. The capability is a promise that a break can be sent, and it is advertised only now that one can. A client that does not ask is unaffected: nothing is granted unasked, unlike Windows, which [MS-SMB] 3.3.5.1.2 footnote 108 notes grants level II "even if the client does not request an oplock".

The break call sites add one map lookup under a mutex to each write, delete, rename and resize, which finds nothing when no oplock is held.

### Notes
One client-side gap is worth a reviewer's eye, and it is not addressed here. `client.sendReceive` reads one frame and treats it as the response to what it just sent, so a break arriving while the client is waiting would be decoded as that response. It is unreachable from this repository's client today — `client.OpenFile` never sets the `NT_CREATE_ANDX` Flags field, so it never asks for an oplock and never receives a break — but a client that did ask would need to recognise an unsolicited `SMB_COM_LOCKING_ANDX` in its receive path. That is client work rather than server work, and #1152 is a server issue, so I have left it alone rather than widen this PR.

Also unchanged: the oplock timeout machinery of [MS-CIFS] 3.3.2.1 and the `Breaking` open state. Both exist to bound how long a server waits for an acknowledgement, and a level II break is never waited on, so there is nothing here for a timer to fire on. They would be needed by exclusive and batch oplocks, which this does not grant.

`network/smb/smb_v10/server/doc.go` still has a sentence duplicated at L120–L121, noted on #1180 and #1181 and left alone again.
