### PR TITLE
Fix Direct TCP Send truncating an oversized payload length (Fixes #1183)

### DIFF
--- a/network/tcp/tcp.go
+++ b/network/tcp/tcp.go
@@ -13,6 +13,13 @@ import (
 // generous upper bound that rejects DoS-scale frames without blocking legitimate traffic.
 const MaxDirectTCPPayloadSize = 1 * 1024 * 1024
 
+// MaxDirectTCPFrameLength is the largest payload the Direct TCP session service can
+// describe: [MS-SMB2] 2.1 gives the header as a zero byte followed by a 3-byte
+// big-endian length, so a longer payload has no representable length and MUST NOT be
+// sent. This bounds what Send will encode; MaxDirectTCPPayloadSize is the separate,
+// stricter policy applied to what Receive will accept.
+const MaxDirectTCPFrameLength = 0xFFFFFF
+
 // TCPTransport implements the Transport interface for Direct TCP transport
 // Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb/f906c680-330c-43ae-9a71-f854e24aeee6
 type TCPTransport struct {
@@ -83,10 +90,17 @@ func (t *TCPTransport) Send(data []byte) (int, error) {
 		return 0, fmt.Errorf("not connected")
 	}
 
+	// The length field is 3 bytes wide, so a longer payload cannot be described.
+	// Truncating it would leave the peer framing the rest of the stream at the wrong
+	// offset, with nothing at the sender to indicate it happened.
+	length := len(data)
+	if length > MaxDirectTCPFrameLength {
+		return 0, fmt.Errorf("Direct TCP message too large: %d bytes (max %d)", length, MaxDirectTCPFrameLength)
+	}
+
 	// Create Direct TCP header
 	header := []byte{0x00} // First byte must be 0
 	// Set length in big-endian format (3 bytes)
-	length := len(data)
 	header = append(header, byte((length>>16)&0xFF))
 	header = append(header, byte((length>>8)&0xFF))
 	header = append(header, byte(length&0xFF))

--- a/network/tcp/tcp_test.go
+++ b/network/tcp/tcp_test.go
@@ -1,6 +1,8 @@
 package tcp_test
 
 import (
+	"bytes"
+	"io"
 	"net"
 	"strconv"
 	"testing"
@@ -181,5 +183,95 @@ func TestTCPTransport_ReceiveTimesOutOnSilentServer(t *testing.T) {
 	}
 	if elapsed > 5*time.Second {
 		t.Fatalf("TCPTransport.Receive() took %v to fail, want a bounded timeout", elapsed)
+	}
+}
+
+// dialLoopback starts a listener, hands the accepted connection back on a channel,
+// and returns a transport already connected to it.
+func dialLoopback(t *testing.T) (*tcp.TCPTransport, <-chan net.Conn) {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start test server: %v", err)
+	}
+	t.Cleanup(func() { ln.Close() })
+
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		c, err := ln.Accept()
+		if err != nil {
+			close(accepted)
+			return
+		}
+		accepted <- c
+	}()
+
+	host, portStr, err := net.SplitHostPort(ln.Addr().String())
+	if err != nil {
+		t.Fatalf("failed to parse listener address: %v", err)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("failed to parse port: %v", err)
+	}
+
+	tr := tcp.NewTCPTransport()
+	tr.SetTimeout(2 * time.Second)
+	if err := tr.Connect(net.ParseIP(host), port); err != nil {
+		t.Fatalf("TCPTransport.Connect() error = %v", err)
+	}
+	t.Cleanup(func() { tr.Close() })
+
+	return tr, accepted
+}
+
+// TestTCPTransport_SendWritesDirectTCPHeader pins the framing Send emits: a zero
+// byte followed by the 3-byte big-endian payload length ([MS-SMB2] 2.1).
+func TestTCPTransport_SendWritesDirectTCPHeader(t *testing.T) {
+	tr, accepted := dialLoopback(t)
+
+	payload := []byte{0xFE, 'S', 'M', 'B'}
+	if _, err := tr.Send(payload); err != nil {
+		t.Fatalf("TCPTransport.Send() error = %v", err)
+	}
+
+	conn := <-accepted
+	defer conn.Close()
+
+	got := make([]byte, 4+len(payload))
+	if err := conn.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		t.Fatalf("failed to set read deadline: %v", err)
+	}
+	if _, err := io.ReadFull(conn, got); err != nil {
+		t.Fatalf("failed to read frame: %v", err)
+	}
+
+	want := []byte{0x00, 0x00, 0x00, 0x04, 0xFE, 'S', 'M', 'B'}
+	if !bytes.Equal(got, want) {
+		t.Errorf("Send() wrote % x, want % x", got, want)
+	}
+}
+
+// TestTCPTransport_SendRejectsOversizedPayload guards the length-truncation bug: a
+// payload above the 24-bit field must be refused, not encoded modulo 2^24. At
+// exactly MaxDirectTCPFrameLength+1 the truncated length would be 0, so the peer
+// would frame the remainder of the stream at the wrong offset.
+func TestTCPTransport_SendRejectsOversizedPayload(t *testing.T) {
+	tr, accepted := dialLoopback(t)
+
+	// Drain the peer for the duration of the test. Without this the unguarded code
+	// path blocks forever on TCP backpressure partway through the 16 MiB write, so a
+	// regression would hang the suite instead of failing it.
+	conn := <-accepted
+	defer conn.Close()
+	go io.Copy(io.Discard, conn)
+
+	n, err := tr.Send(make([]byte, tcp.MaxDirectTCPFrameLength+1))
+	if err == nil {
+		t.Fatalf("TCPTransport.Send() accepted a payload larger than the 24-bit length field, wrote %d bytes", n)
+	}
+	if n != 0 {
+		t.Errorf("TCPTransport.Send() wrote %d byte(s) for a rejected message, want 0", n)
 	}
 }


### PR DESCRIPTION
### Linked Issue
`Closes #1183`

### Root Cause
The Direct TCP session service header is a zero byte followed by a 3-byte big-endian payload length ([MS-SMB2] 2.1). `Send` applied that width when composing the three header bytes but never applied it as a precondition on its input, so `length := len(data)` could hold a value the field cannot represent. Shifting and masking an `int` discards bits 24 and above without any error, so the width of the field was enforced on the output bytes and not on the value they were derived from.

### Fix Description
Bound the payload against the width of the field before encoding, and return an error rather than emitting an unrepresentable length. This mirrors what the NetBIOS transport already does for its own (17-bit) length field in `network/netbios/nbt/nbt.go` L444–L447, so both transports now refuse a message they cannot describe instead of misdescribing it.

The limit is named `MaxDirectTCPFrameLength` (0xFFFFFF) to keep it distinct from the pre-existing `MaxDirectTCPPayloadSize` (1 MiB), which is a stricter *policy* applied to what `Receive` will accept. Reusing the receive constant here was rejected: it would make `Send` refuse frames that are perfectly representable on the wire, which is a behavioural change beyond the defect.

### How Verified
**Tests.** With the guard removed, `TestTCPTransport_SendRejectsOversizedPayload` fails and reports the truncation directly:

```
--- FAIL: TestTCPTransport_SendRejectsOversizedPayload (0.01s)
    tcp_test.go:272: TCPTransport.Send() accepted a payload larger than the
                     24-bit length field, wrote 16777220 bytes
```

16777220 bytes is the 16 MiB payload plus its 4-byte header — i.e. the frame that would have gone out carrying a length of 0. With the guard in place both new tests pass and the full package is green:

```
ok  github.com/TheManticoreProject/Manticore/network/tcp  0.108s
```

`go vet ./network/tcp/` is clean.

### Test Coverage
**Added** — `network/tcp/tcp_test.go`:
- `TestTCPTransport_SendRejectsOversizedPayload` — asserts a payload of `MaxDirectTCPFrameLength+1` is refused and that nothing is written. The peer is drained in a goroutine for the duration of the test: without that, the unguarded path blocks indefinitely on TCP backpressure partway through the write, so a regression would hang the suite rather than fail it.
- `TestTCPTransport_SendWritesDirectTCPHeader` — pins the emitted framing for a normal payload (`00 00 00 04 FE 53 4D 42`), which had no byte-level coverage before.
- `dialLoopback` helper, factored from the existing loopback-listener pattern in this file.

### Scope of Change
- **Files changed:** `network/tcp/tcp.go`, `network/tcp/tcp_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local to `Send`. The new error is reachable only for payloads at or above 16 MiB, which no current caller produces — SMB1 negotiates a `MaxBufferSize` of tens of kilobytes, and the SMB2 client clamps to the negotiated `MaxReadSize`/`MaxWriteSize`. Safe to merge directly.

### Notes
`Receive` still caps at `MaxDirectTCPPayloadSize` (1 MiB), which is below both the 16 MiB the wire field allows and the 8 MiB `MaxReadSize` a Windows server can advertise for SMB3. That asymmetry is a separate concern and is deliberately left untouched here; it will be filed on its own.