### PR TITLE
Fix SMB2 client under-declaring CreditCharge on multi-credit requests (Fixes #1187)

### DIFF
--- a/network/smb/smb_v20/client/changenotify.go
+++ b/network/smb/smb_v20/client/changenotify.go
@@ -37,7 +37,7 @@ func (c *Client) ChangeNotify(fileId types.SMB2_FILEID, completionFilter uint32,
 	req := commands.NewChangeNotifyRequest()
 	req.FileId = fileId
 	req.CompletionFilter = types.ULONG(completionFilter)
-	req.OutputBufferLength = types.ULONG(c.Connection.Server.MaxTransactSize)
+	req.OutputBufferLength = types.ULONG(c.maxPayloadForRequest(c.Connection.Server.MaxTransactSize))
 	if watchTree {
 		req.Flags = commands.SMB2_WATCH_TREE
 	}

--- a/network/smb/smb_v20/client/compound.go
+++ b/network/smb/smb_v20/client/compound.go
@@ -144,7 +144,7 @@ func (c *Client) sendReceiveCompound(msgs []*message.Message, label string) ([]*
 			}
 		}
 		if resp.Header.Credit > 0 {
-			c.Connection.Credits = resp.Header.Credit
+			c.grantCredits(resp.Header.Credit)
 		}
 
 		if uint64(resp.Header.MessageId) != unsolicitedMessageId && !requestIds[uint64(resp.Header.MessageId)] {

--- a/network/smb/smb_v20/client/credits.go
+++ b/network/smb/smb_v20/client/credits.go
@@ -1,0 +1,143 @@
+package client
+
+import (
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/dialects"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/message/commands/command_interface"
+)
+
+// creditGranularity is the payload size, in bytes, that a single credit covers.
+// [MS-SMB2] 3.1.5.2 counts a request against the credits it holds in 64 KiB
+// units, so a one-credit request may carry at most this many bytes of payload.
+const creditGranularity = 65536
+
+// targetCredits is the credit window the client tries to hold. The server grants
+// only one credit alongside the NEGOTIATE response, so without asking for more
+// the client could never issue a request larger than one credit's worth. 128
+// credits corresponds to the 8 MiB maximum a Windows server advertises, which is
+// the largest single request the negotiated limits allow.
+const targetCredits = 128
+
+// creditsFor returns the number of credits a payload of n bytes consumes:
+// (n - 1) / 65536 + 1, per [MS-SMB2] 3.1.5.2. An empty payload still charges one
+// credit, because every request costs at least one.
+func creditsFor(n uint32) uint16 {
+	if n <= creditGranularity {
+		return 1
+	}
+	charge := (n-1)/creditGranularity + 1
+	// A charge cannot exceed the 16-bit field; the payload clamp in
+	// maxPayloadForRequest keeps callers well below this in practice.
+	if charge > 0xFFFF {
+		return 0xFFFF
+	}
+	return uint16(charge)
+}
+
+// requestCreditCharge returns the CreditCharge a request must carry. The charge
+// covers the larger of the payload sent and the payload expected back
+// ([MS-SMB2] 3.1.5.2), so a read charges for the data it asks for even though
+// the request itself is small.
+//
+// Commands whose payload is bounded by the fixed part of the structure — every
+// command not listed here — charge a single credit.
+func requestCreditCharge(command command_interface.CommandInterface) uint16 {
+	var payload uint32
+
+	switch cmd := command.(type) {
+	case *commands.ReadRequest:
+		// The response carries Length bytes back.
+		payload = uint32(cmd.Length)
+	case *commands.WriteRequest:
+		payload = uint32(len(cmd.Data))
+	case *commands.QueryDirectoryRequest:
+		payload = uint32(cmd.OutputBufferLength)
+	case *commands.QueryInfoRequest:
+		payload = maxU32(uint32(cmd.OutputBufferLength), uint32(len(cmd.Input)))
+	case *commands.SetInfoRequest:
+		payload = uint32(len(cmd.Buffer))
+	case *commands.IoctlRequest:
+		payload = maxU32(uint32(cmd.MaxOutputResponse), uint32(len(cmd.Input)))
+	case *commands.ChangeNotifyRequest:
+		payload = uint32(cmd.OutputBufferLength)
+	}
+
+	return creditsFor(payload)
+}
+
+// maxPayloadForRequest returns the largest payload the client may currently ask
+// for in a single request: the smaller of the server's advertised ceiling and
+// what the credits on hand can pay for.
+//
+// Sizing a request from the server's ceiling alone is what makes an 8 MiB
+// request go out against a one-credit grant, which the server rejects with
+// STATUS_INVALID_PARAMETER ([MS-SMB2] 3.3.5.2.5).
+func (c *Client) maxPayloadForRequest(serverMax uint32) uint32 {
+	// Before the first response arrives the client holds the single credit the
+	// server grants with NEGOTIATE.
+	held := c.Connection.Credits
+	if held == 0 {
+		held = 1
+	}
+
+	// The SMB 2.0.2 dialect has no credit model: CreditCharge MUST be 0 and a
+	// request may not exceed one credit's worth of payload.
+	if c.Connection.Dialect < dialects.SMB2_DIALECT_2_1_0 {
+		held = 1
+	}
+
+	budget := uint32(held) * creditGranularity
+	if serverMax > 0 && serverMax < budget {
+		return serverMax
+	}
+	return budget
+}
+
+// creditRequest returns the CreditRequest to place on an outgoing request: enough
+// to replace the credits this request spends, plus enough to grow the window
+// toward targetCredits. The server grants what it chooses; asking is what lets
+// the window grow past the single credit NEGOTIATE leaves the client with.
+//
+// Before a dialect that supports multi-credit is negotiated there is no window to
+// grow — the SMB 2.0.2 dialect has no credit model at all — so the request asks
+// only for what it spends.
+func (c *Client) creditRequest(charge uint16) uint16 {
+	want := charge
+	if c.Connection.Dialect >= dialects.SMB2_DIALECT_2_1_0 {
+		if held := c.Connection.Credits; held < targetCredits {
+			if shortfall := targetCredits - held; shortfall > want {
+				want = shortfall
+			}
+		}
+	}
+	if want == 0 {
+		want = 1
+	}
+	return want
+}
+
+// spendCredits deducts what a request charges from the credits on hand. The
+// server replenishes them through the Credit field of each response.
+func (c *Client) spendCredits(charge uint16) {
+	if c.Connection.Credits >= charge {
+		c.Connection.Credits -= charge
+		return
+	}
+	c.Connection.Credits = 0
+}
+
+// grantCredits adds the credits a response carries to the credits on hand.
+func (c *Client) grantCredits(granted uint16) {
+	total := uint32(c.Connection.Credits) + uint32(granted)
+	if total > 0xFFFF {
+		total = 0xFFFF
+	}
+	c.Connection.Credits = uint16(total)
+}
+
+func maxU32(a, b uint32) uint32 {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/network/smb/smb_v20/client/credits_test.go
+++ b/network/smb/smb_v20/client/credits_test.go
@@ -1,0 +1,192 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/dialects"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/message/commands"
+)
+
+// TestCreditsFor pins the charge formula from MS-SMB2 3.1.5.2:
+// (payload - 1) / 65536 + 1, with an empty payload still costing one credit.
+func TestCreditsFor(t *testing.T) {
+	tests := []struct {
+		payload uint32
+		want    uint16
+	}{
+		{0, 1},
+		{1, 1},
+		{65535, 1},
+		{65536, 1},
+		{65537, 2},
+		{131072, 2},
+		{131073, 3},
+		{1 << 20, 16},          // 1 MiB
+		{8 * 1024 * 1024, 128}, // the 8 MiB a Windows server advertises
+	}
+	for _, tt := range tests {
+		if got := creditsFor(tt.payload); got != tt.want {
+			t.Errorf("creditsFor(%d) = %d, want %d", tt.payload, got, tt.want)
+		}
+	}
+}
+
+// TestRequestCreditCharge covers each command whose charge depends on its payload
+// — the charge must reflect the larger of what is sent and what is expected back.
+func TestRequestCreditCharge(t *testing.T) {
+	read := commands.NewReadRequest()
+	read.Length = 1 << 20 // expects 1 MiB back
+	if got := requestCreditCharge(read); got != 16 {
+		t.Errorf("READ of 1 MiB charges %d, want 16", got)
+	}
+
+	write := commands.NewWriteRequest()
+	write.Data = make([]byte, 200000)
+	if got := requestCreditCharge(write); got != 4 {
+		t.Errorf("WRITE of 200000 bytes charges %d, want 4", got)
+	}
+
+	qd := commands.NewQueryDirectoryRequest()
+	qd.OutputBufferLength = 8 * 1024 * 1024
+	if got := requestCreditCharge(qd); got != 128 {
+		t.Errorf("QUERY_DIRECTORY expecting 8 MiB charges %d, want 128", got)
+	}
+
+	qi := commands.NewQueryInfoRequest()
+	qi.OutputBufferLength = 65536
+	if got := requestCreditCharge(qi); got != 1 {
+		t.Errorf("QUERY_INFO expecting 64 KiB charges %d, want 1", got)
+	}
+
+	ioctl := commands.NewIoctlRequest()
+	ioctl.MaxOutputResponse = 131072
+	if got := requestCreditCharge(ioctl); got != 2 {
+		t.Errorf("IOCTL expecting 128 KiB charges %d, want 2", got)
+	}
+
+	// A command with no variable payload costs a single credit.
+	if got := requestCreditCharge(commands.NewCloseRequest()); got != 1 {
+		t.Errorf("CLOSE charges %d, want 1", got)
+	}
+}
+
+// TestNewRequestChargesAndConsumesSequenceNumbers is the regression guard for the
+// defect: a multi-credit request must declare its charge and must consume one
+// sequence number per credit charged (MS-SMB2 3.2.4.1.3). Advancing MessageId by
+// one reuses identifiers the server has retired, and it drops the connection.
+func TestNewRequestChargesAndConsumesSequenceNumbers(t *testing.T) {
+	c := newTestClient(&fakeTransport{})
+	c.Connection.Dialect = dialects.SMB2_DIALECT_3_1_1
+	c.Connection.MessageId = 4
+	c.Connection.Credits = 200
+
+	read := commands.NewReadRequest()
+	read.Length = 1 << 20 // 16 credits
+
+	m := c.newRequest(read)
+	if m.Header.CreditCharge != 16 {
+		t.Errorf("CreditCharge = %d, want 16", m.Header.CreditCharge)
+	}
+	if m.Header.MessageId != 4 {
+		t.Errorf("MessageId = %d, want 4", m.Header.MessageId)
+	}
+	if c.Connection.MessageId != 20 {
+		t.Errorf("next MessageId = %d, want 20 (4 + the 16 charged)", c.Connection.MessageId)
+	}
+	if c.Connection.Credits != 184 {
+		t.Errorf("credits after spending = %d, want 184", c.Connection.Credits)
+	}
+}
+
+// TestNewRequestSMB202HasNoCreditModel checks the SMB 2.0.2 exception: CreditCharge
+// MUST be 0, one sequence number is consumed, and no credit window is requested.
+func TestNewRequestSMB202HasNoCreditModel(t *testing.T) {
+	c := newTestClient(&fakeTransport{})
+	c.Connection.Dialect = dialects.SMB2_DIALECT_2_0_2
+
+	read := commands.NewReadRequest()
+	read.Length = 1 << 20
+
+	m := c.newRequest(read)
+	if m.Header.CreditCharge != 0 {
+		t.Errorf("CreditCharge = %d, want 0 for SMB 2.0.2", m.Header.CreditCharge)
+	}
+	if m.Header.Credit != 1 {
+		t.Errorf("CreditRequest = %d, want 1 for SMB 2.0.2", m.Header.Credit)
+	}
+	if c.Connection.MessageId != 1 {
+		t.Errorf("next MessageId = %d, want 1", c.Connection.MessageId)
+	}
+}
+
+// TestCreditRequestGrowsTheWindow checks that the client asks for credits while its
+// window is below target — without asking, the single credit granted alongside
+// NEGOTIATE is all it would ever hold.
+func TestCreditRequestGrowsTheWindow(t *testing.T) {
+	c := newTestClient(&fakeTransport{})
+	c.Connection.Dialect = dialects.SMB2_DIALECT_3_1_1
+
+	c.Connection.Credits = 1
+	if got := c.creditRequest(1); got != targetCredits-1 {
+		t.Errorf("creditRequest with 1 credit held = %d, want %d", got, targetCredits-1)
+	}
+
+	// At target, ask only to replace what is spent.
+	c.Connection.Credits = targetCredits
+	if got := c.creditRequest(4); got != 4 {
+		t.Errorf("creditRequest at target = %d, want 4", got)
+	}
+}
+
+// TestMaxPayloadForRequest checks that a request is sized by the credits actually
+// held, not by the server's advertised ceiling.
+func TestMaxPayloadForRequest(t *testing.T) {
+	c := newTestClient(&fakeTransport{})
+	c.Connection.Dialect = dialects.SMB2_DIALECT_3_1_1
+
+	// One credit held against an 8 MiB ceiling: the credit window wins.
+	c.Connection.Credits = 1
+	if got := c.maxPayloadForRequest(8 * 1024 * 1024); got != creditGranularity {
+		t.Errorf("with 1 credit = %d, want %d", got, creditGranularity)
+	}
+
+	// Plenty of credits: the server's ceiling wins.
+	c.Connection.Credits = 512
+	if got := c.maxPayloadForRequest(1 << 20); got != 1<<20 {
+		t.Errorf("with 512 credits = %d, want %d", got, 1<<20)
+	}
+
+	// SMB 2.0.2 has no credit model: one credit's worth regardless.
+	c.Connection.Dialect = dialects.SMB2_DIALECT_2_0_2
+	c.Connection.Credits = 512
+	if got := c.maxPayloadForRequest(8 * 1024 * 1024); got != creditGranularity {
+		t.Errorf("SMB 2.0.2 = %d, want %d", got, creditGranularity)
+	}
+}
+
+// TestGrantCreditsAccumulates checks that a response's Credit field adds to the
+// window rather than replacing it: the field is what that response grants, not the
+// size of the window.
+func TestGrantCreditsAccumulates(t *testing.T) {
+	c := newTestClient(&fakeTransport{})
+
+	c.Connection.Credits = 0
+	c.grantCredits(31)
+	c.grantCredits(31)
+	if c.Connection.Credits != 62 {
+		t.Errorf("credits = %d, want 62", c.Connection.Credits)
+	}
+
+	// Spending more than is held floors at zero rather than wrapping.
+	c.spendCredits(100)
+	if c.Connection.Credits != 0 {
+		t.Errorf("credits after overspend = %d, want 0", c.Connection.Credits)
+	}
+
+	// Granting cannot overflow the 16-bit field.
+	c.Connection.Credits = 0xFFF0
+	c.grantCredits(0xFF)
+	if c.Connection.Credits != 0xFFFF {
+		t.Errorf("credits = %#x, want 0xFFFF", c.Connection.Credits)
+	}
+}

--- a/network/smb/smb_v20/client/directory.go
+++ b/network/smb/smb_v20/client/directory.go
@@ -28,7 +28,7 @@ func (c *Client) QueryDirectory(fileId types.SMB2_FILEID, fileInformationClass u
 	req.FileInformationClass = fileInformationClass
 	req.Flags = flags
 	req.FileName = searchPattern
-	req.OutputBufferLength = c.Connection.Server.MaxTransactSize
+	req.OutputBufferLength = types.ULONG(c.maxPayloadForRequest(c.Connection.Server.MaxTransactSize))
 
 	response, err := c.sendReceive(c.newRequest(req), "QueryDirectory")
 	if err != nil {

--- a/network/smb/smb_v20/client/engine.go
+++ b/network/smb/smb_v20/client/engine.go
@@ -9,26 +9,36 @@ import (
 )
 
 // newRequest builds an SMB2 request message with the header fields common to
-// every command: the next 64-bit MessageId on the connection, a one-credit
-// request (CreditCharge is 0 in the SMB 2.0.2 dialect), and — when a session is
-// established — the current SessionId and TreeId. The command code is taken from
-// the command when it is attached via SetCommand.
+// every command: the credit charge the payload incurs, a credit request sized to
+// sustain the window, the next 64-bit MessageId on the connection, and — when a
+// session is established — the current SessionId and TreeId. The command code is
+// taken from the command when it is attached via SetCommand.
 func (c *Client) newRequest(command command_interface.CommandInterface) *message.Message {
 	msg := message.NewMessage()
 
-	// Allocate the next MessageId for this connection.
-	msg.Header.MessageId = c.Connection.MessageId
-	c.Connection.MessageId++
-
 	// The SMB 2.0.2 dialect requires CreditCharge to be 0. From SMB 2.1 onward the
-	// large-MTU credit model applies and a small (single-block) request charges 1
-	// credit; the client requests a single credit back per message.
+	// large-MTU credit model applies and the charge is a function of the payload,
+	// not a constant: a request carrying (or expecting back) more than 64 KiB costs
+	// more than one credit, and a server rejects one that under-declares its charge
+	// (MS-SMB2 3.1.5.2, 3.3.5.2.5).
+	charge := requestCreditCharge(command)
 	if c.Connection.Dialect >= dialects.SMB2_DIALECT_2_1_0 {
-		msg.Header.CreditCharge = 1
+		msg.Header.CreditCharge = charge
 	} else {
 		msg.Header.CreditCharge = 0
+		charge = 1
 	}
-	msg.Header.Credit = 1
+	// Ask for enough credits to cover what this request spends and to grow the
+	// window; the server grants only one credit with NEGOTIATE.
+	msg.Header.Credit = c.creditRequest(charge)
+	c.spendCredits(charge)
+
+	// Allocate the next MessageId for this connection. A multi-credit request
+	// consumes one sequence number per credit charged (MS-SMB2 3.2.4.1.3), so
+	// advancing by one would reuse identifiers the server has already retired and
+	// it drops the connection.
+	msg.Header.MessageId = c.Connection.MessageId
+	c.Connection.MessageId += uint64(charge)
 
 	if c.Session != nil {
 		msg.Header.SessionId = c.Session.SessionId
@@ -131,9 +141,11 @@ func (c *Client) sendReceive(msg *message.Message, label string) (*message.Messa
 				return nil, fmt.Errorf("%s response failed SMB2 signature verification", label)
 			}
 		}
-		// The server replenishes credits via the response Credit field.
+		// The server replenishes credits via the response Credit field. They add to
+		// the credits on hand rather than replacing them: the count is what this
+		// response grants, not the size of the window.
 		if response.Header.Credit > 0 {
-			c.Connection.Credits = response.Header.Credit
+			c.grantCredits(response.Header.Credit)
 		}
 
 		// A response must carry the MessageId of the request it answers; an

--- a/network/smb/smb_v20/client/file.go
+++ b/network/smb/smb_v20/client/file.go
@@ -105,8 +105,10 @@ func (c *Client) ReadFile(fileId types.SMB2_FILEID, offset uint64, length uint32
 	pos := offset
 	for remaining > 0 {
 		chunk := remaining
-		if chunk > maxRead {
-			chunk = maxRead
+		// Recomputed per chunk: the credit window grows as responses arrive, and a
+		// chunk may not exceed what the credits on hand can pay for.
+		if budget := c.maxPayloadForRequest(maxRead); chunk > budget {
+			chunk = budget
 		}
 		data, eof, err := c.readChunk(fileId, pos, chunk)
 		if err != nil {
@@ -170,8 +172,8 @@ func (c *Client) WriteFile(fileId types.SMB2_FILEID, offset uint64, data []byte)
 	pos := offset
 	for len(data) > 0 {
 		n := uint32(len(data))
-		if n > maxWrite {
-			n = maxWrite
+		if budget := c.maxPayloadForRequest(maxWrite); n > budget {
+			n = budget
 		}
 		written, err := c.writeChunk(fileId, pos, data[:n])
 		if err != nil {

--- a/network/smb/smb_v20/client/info.go
+++ b/network/smb/smb_v20/client/info.go
@@ -23,7 +23,7 @@ func (c *Client) QueryInfo(fileId types.SMB2_FILEID, infoType, fileInfoClass uin
 	req.InfoType = types.UCHAR(infoType)
 	req.FileInfoClass = types.UCHAR(fileInfoClass)
 	req.AdditionalInformation = types.ULONG(additionalInformation)
-	req.OutputBufferLength = types.ULONG(c.Connection.Server.MaxTransactSize)
+	req.OutputBufferLength = types.ULONG(c.maxPayloadForRequest(c.Connection.Server.MaxTransactSize))
 	req.FileId = fileId
 
 	response, err := c.sendReceive(c.newRequest(req), "QueryInfo")


### PR DESCRIPTION
### Linked Issue
`Closes #1187`

### Root Cause
The large-MTU credit model was never implemented on the SMB2 client. `CreditCharge` was treated as a per-dialect constant rather than a function of payload size, and request sizes were taken from the server's advertised ceiling rather than from the credits the client actually holds.

Those two assumptions are individually harmless and jointly fatal. A Windows server advertises `MaxTransactSize = MaxReadSize = MaxWriteSize = 8388608`, so `QueryDirectory` asked for 8 MiB of output while declaring `CreditCharge = 1`. [MS-SMB2] 3.1.5.2 charges one credit per 64 KiB of the larger of a request's send and expected-receive payload — 128 credits here — and 3.3.5.2.5 has the server reject a request that under-declares its charge.

### Fix Description
Three coupled corrections, in a new `credits.go`:

1. **Charge from the payload.** `requestCreditCharge` computes the charge per command, from the larger of what is sent and what is expected back: `Length` for READ, `len(Data)` for WRITE, `OutputBufferLength` for QUERY_DIRECTORY / QUERY_INFO / CHANGE_NOTIFY, `max(MaxOutputResponse, len(Input))` for IOCTL. Commands with no variable payload charge one credit.

2. **Sustain a credit window.** `CreditRequest` now asks for enough to replace what a request spends plus enough to grow toward `targetCredits`. Credits from a response *accumulate* rather than replacing the count — the `Credit` field is what that response grants, not the size of the window.

3. **Consume a sequence-number span.** `MessageId` advances by the charge, per [MS-SMB2] 3.2.4.1.3.

Requests are additionally clamped by `maxPayloadForRequest` to what the credits on hand can pay for, so the client cannot size a request from a ceiling it cannot afford.

All three were necessary: charging correctly without growing the window means an 8 MiB request is refused for want of credits, and charging 128 credits while advancing `MessageId` by 1 makes the server drop the connection. Each intermediate state was observed live during development.

The SMB 2.0.2 exception is preserved throughout — `CreditCharge` stays 0, one sequence number is consumed, no window is requested — which is what the pre-existing `TestNewRequestSequencing` asserts, and it still passes unchanged.

### How Verified
**Runtime, against a live Windows Server 2025 domain controller.**

Before — negotiate and tree connect succeed, enumeration does not:

```
negotiated dialect: SMB v3.1.1
tree connect C$ OK
list Windows: query directory failed: INVALID_PARAMETER (0xc000000d)
```

After:

```
=== RUN   TestLiveCreditPaths/QueryDirectory
    106 entries
=== RUN   TestLiveCreditPaths/QuerySecurityDescriptor
    security descriptor: 168 bytes
=== RUN   TestLiveCreditPaths/Read
    read 92 bytes
=== RUN   TestLiveCreditPaths/Write
    wrote 200000 bytes across a multi-credit request
    scratch file removed
```

The 200000-byte write charges 4 credits, so it exercises the multi-credit send path and the matching `MessageId` span end to end. The scratch file was written under `C$\Windows\Temp` and deleted again; no other server state was touched.

**Tests.** With the fix reverted, the regression guard reports both halves of the defect:

```
--- FAIL: TestNewRequestChargesAndConsumesSequenceNumbers
    credits_test.go:88: CreditCharge = 1, want 16
    credits_test.go:94: next MessageId = 5, want 20 (4 + the 16 charged)
```

`go build ./...`, `go vet ./network/smb/...` and `go test ./network/smb/...` are all clean.

### Test Coverage
**Added** — `network/smb/smb_v20/client/credits_test.go`, 7 tests:
- `TestCreditsFor` — pins the [MS-SMB2] 3.1.5.2 formula across the 64 KiB boundaries, including the 8 MiB → 128 case.
- `TestRequestCreditCharge` — the charge for READ, WRITE, QUERY_DIRECTORY, QUERY_INFO, IOCTL, and a payload-free command.
- `TestNewRequestChargesAndConsumesSequenceNumbers` — the regression guard: charge declared *and* `MessageId` span consumed.
- `TestNewRequestSMB202HasNoCreditModel` — the SMB 2.0.2 exception.
- `TestCreditRequestGrowsTheWindow`, `TestMaxPayloadForRequest`, `TestGrantCreditsAccumulates`.

### Scope of Change
- **Files changed:** `network/smb/smb_v20/client/credits.go` (new), `credits_test.go` (new), `engine.go`, `directory.go`, `info.go`, `changenotify.go`, `compound.go`, `file.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
The blast radius is every SMB2 request, since `newRequest` builds them all — but the change is a strict correction of three header fields plus a clamp on requested sizes, and the direction of change is from "rejected by the server" to "accepted". Requests that previously fit in one credit are unaffected: they still charge 1 and advance `MessageId` by 1. The unit suite and the live matrix above both cover the unchanged single-credit path.

### Notes
One case remains blocked by a **separate** defect, found while validating this one: a read at or above 1 MiB fails in the transport, not in the credit layer —

```
1 MiB read: failed to receive Read response:
  Direct TCP payload length 1048656 exceeds maximum 1048576
```

`MaxDirectTCPPayloadSize` (`network/tcp/tcp.go`) caps receive at 1 MiB, below both the 16 MiB the Direct TCP length field allows and the 8 MiB `MaxReadSize` a Windows server advertises. The multi-credit *send* path is proven by the 200000-byte write above; the multi-credit *receive* path needs that cap raised. It is being filed separately rather than folded in here, since it is a distinct defect in a different package.