### PR TITLE
Fix Direct TCP Receive rejecting frames above 1 MiB (Fixes #1189)

### DIFF
--- a/network/tcp/tcp.go
+++ b/network/tcp/tcp.go
@@ -7,17 +7,46 @@ import (
 	"time"
 )
 
-// MaxDirectTCPPayloadSize caps the payload size accepted from a single Direct TCP frame.
-// The Direct TCP session service length field is 24 bits wide (up to ~16 MiB), but SMB1
-// negotiates a MaxBufferSize of at most a few tens of kilobytes in practice. 1 MiB is a
-// generous upper bound that rejects DoS-scale frames without blocking legitimate traffic.
-const MaxDirectTCPPayloadSize = 1 * 1024 * 1024
+// MaxDirectTCPPayloadSize is the default cap on the payload accepted from a single
+// Direct TCP frame, and is the largest the session service can describe: the length
+// field is 24 bits wide ([MS-SMB2] 2.1).
+//
+// The transport carries SMB1, SMB2 and SMB3, whose negotiated limits differ by more
+// than an order of magnitude — a Windows server advertises an 8 MiB MaxReadSize —
+// so a smaller default here would refuse frames the peer was entitled to send after
+// a successful negotiation. Bounding what a peer can induce this side to allocate is
+// a policy the accepting side sets with SetMaxPayloadSize, not something a constant
+// shared with the client can express.
+const MaxDirectTCPPayloadSize = 0xFFFFFF
 
 // TCPTransport implements the Transport interface for Direct TCP transport
 // Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb/f906c680-330c-43ae-9a71-f854e24aeee6
 type TCPTransport struct {
 	conn    net.Conn
 	timeout time.Duration
+
+	// maxPayload caps the payload accepted from a single frame. Zero means
+	// MaxDirectTCPPayloadSize.
+	maxPayload uint32
+}
+
+// SetMaxPayloadSize caps the payload this transport will accept from a single
+// Direct TCP frame, so a listener can bound the allocation an unauthenticated peer
+// can induce. A value of 0, or one above what the 24-bit length field can describe,
+// restores the MaxDirectTCPPayloadSize default.
+func (t *TCPTransport) SetMaxPayloadSize(n uint32) {
+	if n == 0 || n > MaxDirectTCPPayloadSize {
+		n = MaxDirectTCPPayloadSize
+	}
+	t.maxPayload = n
+}
+
+// maxPayloadSize returns the cap in effect for this transport.
+func (t *TCPTransport) maxPayloadSize() uint32 {
+	if t.maxPayload == 0 {
+		return MaxDirectTCPPayloadSize
+	}
+	return t.maxPayload
 }
 
 // NewTCPTransport creates a new Direct TCP transport
@@ -127,8 +156,8 @@ func (t *TCPTransport) Receive() ([]byte, error) {
 	// Parse length from 3 bytes
 	length := (int(header[1]) << 16) | (int(header[2]) << 8) | int(header[3])
 
-	if length > MaxDirectTCPPayloadSize {
-		return nil, fmt.Errorf("Direct TCP payload length %d exceeds maximum %d", length, MaxDirectTCPPayloadSize)
+	if cap := t.maxPayloadSize(); uint32(length) > cap {
+		return nil, fmt.Errorf("Direct TCP payload length %d exceeds maximum %d", length, cap)
 	}
 
 	buffer := make([]byte, length)

--- a/network/tcp/tcp_test.go
+++ b/network/tcp/tcp_test.go
@@ -113,10 +113,10 @@ func TestTCPTransport_ReceiveRejectsOversizedLength(t *testing.T) {
 			return
 		}
 		defer c.Close()
-		// Send a Direct TCP header claiming a 0xFFFFFF (≈16 MiB) payload,
-		// well above MaxDirectTCPPayloadSize; Receive should reject before
-		// allocating or reading.
-		_, _ = c.Write([]byte{0x00, 0xFF, 0xFF, 0xFF})
+		// Send a Direct TCP header claiming a 0x100000 (1 MiB) payload, above the
+		// cap the test installs below; Receive should reject before allocating or
+		// reading.
+		_, _ = c.Write([]byte{0x00, 0x10, 0x00, 0x00})
 	}()
 
 	host, portStr, err := net.SplitHostPort(ln.Addr().String())
@@ -133,10 +133,118 @@ func TestTCPTransport_ReceiveRejectsOversizedLength(t *testing.T) {
 		t.Fatalf("TCPTransport.Connect() error = %v", err)
 	}
 	defer tr.Close()
+	// A frame of 1 MiB is legal by default now, so bound this transport explicitly.
+	tr.SetMaxPayloadSize(64 * 1024)
 
 	_, err = tr.Receive()
 	if err == nil {
 		t.Fatal("TCPTransport.Receive() should return error for oversized length, got nil")
+	}
+}
+
+// TestTCPTransport_ReceiveAcceptsLargeNegotiatedFrame guards the defect: a frame
+// larger than the old 1 MiB cap but within what the 24-bit length field describes
+// must be accepted, because a Windows server advertises an 8 MiB MaxReadSize and is
+// entitled to answer a read in one frame of that size.
+func TestTCPTransport_ReceiveAcceptsLargeNegotiatedFrame(t *testing.T) {
+	const payloadLen = 2 * 1024 * 1024 // above the old cap, within the field
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start test server: %v", err)
+	}
+	defer ln.Close()
+
+	go func() {
+		c, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer c.Close()
+		header := []byte{0x00, byte((payloadLen >> 16) & 0xFF), byte((payloadLen >> 8) & 0xFF), byte(payloadLen & 0xFF)}
+		if _, err := c.Write(header); err != nil {
+			return
+		}
+		_, _ = c.Write(make([]byte, payloadLen))
+	}()
+
+	host, portStr, err := net.SplitHostPort(ln.Addr().String())
+	if err != nil {
+		t.Fatalf("failed to parse listener address: %v", err)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("failed to parse port: %v", err)
+	}
+
+	tr := tcp.NewTCPTransport()
+	tr.SetTimeout(10 * time.Second)
+	if err := tr.Connect(net.ParseIP(host), port); err != nil {
+		t.Fatalf("TCPTransport.Connect() error = %v", err)
+	}
+	defer tr.Close()
+
+	got, err := tr.Receive()
+	if err != nil {
+		t.Fatalf("TCPTransport.Receive() rejected a %d-byte frame: %v", payloadLen, err)
+	}
+	if len(got) != payloadLen {
+		t.Errorf("Receive() returned %d bytes, want %d", len(got), payloadLen)
+	}
+}
+
+// TestTCPTransport_SetMaxPayloadSizeBounds checks the listener-side lever: an
+// explicit cap is honoured, and 0 or an unrepresentable value restores the default.
+func TestTCPTransport_SetMaxPayloadSizeBounds(t *testing.T) {
+	// Drive each case through Receive against a peer that announces a frame of a
+	// known size, since the cap is only observable there.
+	for _, tc := range []struct {
+		name      string
+		cap       uint32
+		announce  int
+		wantError bool
+	}{
+		{"within explicit cap", 64 * 1024, 1024, false},
+		{"above explicit cap", 1024, 64 * 1024, true},
+		{"zero restores default", 0, 2 * 1024 * 1024, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ln, err := net.Listen("tcp", "127.0.0.1:0")
+			if err != nil {
+				t.Fatalf("listen: %v", err)
+			}
+			defer ln.Close()
+
+			go func() {
+				c, err := ln.Accept()
+				if err != nil {
+					return
+				}
+				defer c.Close()
+				n := tc.announce
+				_, _ = c.Write([]byte{0x00, byte(n >> 16), byte(n >> 8), byte(n)})
+				_, _ = c.Write(make([]byte, n))
+			}()
+
+			host, portStr, _ := net.SplitHostPort(ln.Addr().String())
+			port, _ := strconv.Atoi(portStr)
+
+			conn := tcp.NewTCPTransport()
+			conn.SetTimeout(10 * time.Second)
+			if err := conn.Connect(net.ParseIP(host), port); err != nil {
+				t.Fatalf("connect: %v", err)
+			}
+			defer conn.Close()
+			conn.SetMaxPayloadSize(tc.cap)
+
+			_, err = conn.Receive()
+			if tc.wantError && err == nil {
+				t.Errorf("Receive() accepted %d bytes under a %d cap", tc.announce, tc.cap)
+			}
+			if !tc.wantError && err != nil {
+				t.Errorf("Receive() rejected %d bytes under a %d cap: %v", tc.announce, tc.cap, err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
### Linked Issue
`Closes #1189`

### Root Cause
`MaxDirectTCPPayloadSize` was a single package-level cap of 1 MiB, and the comment above it justified the value from SMB1 alone — *"SMB1 negotiates a MaxBufferSize of at most a few tens of kilobytes in practice"*. That reasoning does not extend to the SMB2/SMB3 client that shares the transport: a Windows server advertises an 8 MiB `MaxReadSize` and is entitled to answer a read in one frame of that size. The limit was therefore applied one layer below the one that knows what was negotiated.

The follow-on damage came from where the check sits. `Receive` rejects after reading the 4-byte header but before consuming the payload, so the frame stays in the socket and the next operation parses file data as a header.

### Fix Description
Raise the default to `0xFFFFFF`, the largest payload the Direct TCP session service can describe ([MS-SMB2] 2.1), so the transport no longer refuses a frame the peer was entitled to send after a successful negotiation. Per-dialect limits stay with the layer that negotiated them — the SMB2 client already clamps its own requests to `MaxReadSize`/`MaxWriteSize` and, after #1187, to its credit window.

Bounding the allocation an unauthenticated peer can induce is still worth doing, but it is a property of the accepting side, not of a constant shared with the client. It becomes a per-transport setting, `SetMaxPayloadSize`, which a listener can apply to an accepted connection. Simply lowering the shared constant was rejected: any value that protects the accept path also refuses legal traffic on the client path, which is the defect being fixed.

### How Verified
**Runtime, against a live Windows Server 2025 domain controller**, reading 1 MiB from `C$\Windows\System32\ntoskrnl.exe`.

Before:

```
1 MiB read: failed to receive Read response:
  Direct TCP payload length 1048656 exceeds maximum 1048576
tree disconnect: failed to receive TreeDisconnect response:
  invalid Direct TCP header: first byte must be 0x00, got 0x40
```

After (validated on a scratch branch combining this with #1188, since a 1 MiB read needs the credit fix too):

```
=== RUN   TestLiveCreditPaths/QueryDirectory
    106 entries
=== RUN   TestLiveCreditPaths/QuerySecurityDescriptor
    security descriptor: 168 bytes
=== RUN   TestLiveCreditPaths/Read
    read 92 bytes
=== RUN   TestLiveCreditPaths/Write
    wrote 200000 bytes across a multi-credit request
    scratch file removed
=== RUN   TestLiveCreditPaths/MultiCreditRead
    read 1048576 bytes in one multi-credit request span
--- PASS: TestLiveCreditPaths (0.05s)
```

The desynchronization in the "before" output is gone because the frame is now consumed rather than refused.

**Tests.** `go test ./network/tcp/` and `go vet ./network/tcp/` are clean; `go build ./...` passes.

### Test Coverage
**Added** — `network/tcp/tcp_test.go`:
- `TestTCPTransport_ReceiveAcceptsLargeNegotiatedFrame` — the regression guard: a 2 MiB frame (above the old cap, within the field) is received in full and returns all 2 MiB.
- `TestTCPTransport_SetMaxPayloadSizeBounds` — three cases: within an explicit cap, above an explicit cap, and 0 restoring the default.

**Modified** — `TestTCPTransport_ReceiveRejectsOversizedLength` now installs a 64 KiB cap and announces 1 MiB. Without that change it would still pass, but for the wrong reason: its 0xFFFFFF announcement is legal under the new default, so `Receive` would have failed on the truncated body rather than on the cap, and the test would no longer test the cap.

### Scope of Change
- **Files changed:** `network/tcp/tcp.go`, `network/tcp/tcp_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
The accept path (`network/smb/common/transport/listener.go` L109) no longer carries a default 1 MiB bound on what a peer can ask this side to allocate, and nothing calls `SetMaxPayloadSize` yet — so a hostile client can announce up to 16 MiB and hold that allocation until the read deadline. That is a deliberate trade: the previous default was an arbitrary value that broke legal client traffic, and the lever to restore a bound now exists where it belongs. Wiring the SMB1 server listener to set a bound from its negotiated `MaxBufferSize` is the natural follow-up and is noted below rather than folded in here.

### Notes
Two follow-ups, neither in scope for this fix:
- The SMB1 server listener should call `SetMaxPayloadSize` with a bound derived from its configured `MaxBufferSize`, restoring a tight limit on the accept path.
- `Receive` leaves an over-cap frame unconsumed, so a rejected frame desynchronizes the connection for every later operation. Consuming or closing on that error is a separate robustness fix.