### PR TITLE
Fix NewGUID producing a non-RFC4122 GUID from a non-cryptographic PRNG (Fixes #1184)

### DIFF
--- a/windows/guid/Guid.go
+++ b/windows/guid/Guid.go
@@ -1,8 +1,9 @@
 package guid
 
 import (
+	"crypto/rand"
+	"encoding/binary"
 	"fmt"
-	"math/rand/v2"
 	"regexp"
 	"strconv"
 	"strings"
@@ -33,28 +34,34 @@ type GUID struct {
 	E uint64
 }
 
-// NewGUID generates a new random GUID.
+// NewGUID generates a new random RFC 4122 version-4 GUID.
 //
-// The function creates a new GUID by generating random values for each of its five fields:
-// - A: A 32-bit unsigned integer.
-// - B: A 16-bit unsigned integer.
-// - C: A 16-bit unsigned integer.
-// - D: A 16-bit unsigned integer.
-// - E: A 64-bit unsigned integer.
+// The 122 free bits come from crypto/rand. The remaining six carry the version
+// and variant RFC 4122 4.4 requires: the high nibble of C (time_hi_and_version)
+// is set to 0100, and the two high bits of D (clock_seq_hi_and_reserved) to 10.
+// A consumer that parses those fields — an SMB peer reading a ServerGUID, for
+// instance — sees a well-formed v4 GUID rather than an arbitrary one.
 //
 // Returns:
 // - A pointer to a newly generated GUID.
 func NewGUID() *GUID {
-	a := uint32(rand.Uint32())
+	// crypto/rand.Read is documented never to return an error as of Go 1.24: it
+	// panics if the operating system's source of randomness fails. There is
+	// therefore no failure for this constructor to report, and its signature is
+	// left unchanged.
+	var buf [16]byte
+	_, _ = rand.Read(buf[:])
 
-	b := uint16(rand.Uint32() & 0xFFFF)
+	a := binary.BigEndian.Uint32(buf[0:4])
+	b := binary.BigEndian.Uint16(buf[4:6])
+	c := binary.BigEndian.Uint16(buf[6:8])
+	d := binary.BigEndian.Uint16(buf[8:10])
+	e := uint64(binary.BigEndian.Uint16(buf[10:12]))<<32 | uint64(binary.BigEndian.Uint32(buf[12:16]))
 
-	c := uint16(rand.Uint32() & 0xFFFF)
-
-	d := uint16(rand.Uint32() & 0xFFFF)
-
-	e := uint64(rand.Uint32())<<32 | uint64(rand.Uint32())
-	e = e & 0xFFFFFFFFFFFF
+	// RFC 4122 4.4: version 4 in the high nibble of time_hi_and_version, and the
+	// variant 10 in the two high bits of clock_seq_hi_and_reserved.
+	c = (c & 0x0FFF) | 0x4000
+	d = (d & 0x3FFF) | 0x8000
 
 	return &GUID{A: a, B: b, C: c, D: d, E: e}
 }

--- a/windows/guid/guid_test.go
+++ b/windows/guid/guid_test.go
@@ -1,6 +1,7 @@
 package guid
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -143,5 +144,67 @@ func TestFromStringToStringFormatX(t *testing.T) {
 		if result != guid.ToFormatX() {
 			t.Errorf("Expected %s, but got %s", data, result)
 		}
+	}
+}
+
+// TestNewGUIDIsRFC4122Version4 guards the defect: NewGUID previously left the
+// version and variant bits as whatever the generator produced, so the value was
+// not a valid version-4 GUID. RFC 4122 4.4 fixes six bits — the high nibble of
+// time_hi_and_version and the two high bits of clock_seq_hi_and_reserved — and a
+// peer that parses them (an SMB client reading a ServerGUID) can check both.
+func TestNewGUIDIsRFC4122Version4(t *testing.T) {
+	// Enough samples that a generator leaving these bits to chance fails
+	// essentially always: one unfixed nibble alone passes only 1 time in 16.
+	const samples = 256
+
+	for i := 0; i < samples; i++ {
+		g := NewGUID()
+		if g == nil {
+			t.Fatal("NewGUID() returned nil")
+		}
+		if version := (g.C >> 12) & 0xF; version != 4 {
+			t.Fatalf("sample %d: version nibble = %d, want 4 (C = %#04x)", i, version, g.C)
+		}
+		if variant := (g.D >> 14) & 0x3; variant != 0x2 {
+			t.Fatalf("sample %d: variant bits = %#b, want 0b10 (D = %#04x)", i, variant, g.D)
+		}
+		if g.E > 0xFFFFFFFFFFFF {
+			t.Fatalf("sample %d: node field %#x exceeds 48 bits", i, g.E)
+		}
+	}
+}
+
+// TestNewGUIDIsDistinct checks that successive GUIDs differ. It does not prove the
+// source is cryptographically secure — that cannot be asserted from output — but it
+// does catch a generator that is unseeded or constant.
+func TestNewGUIDIsDistinct(t *testing.T) {
+	const samples = 1024
+
+	seen := make(map[GUID]struct{}, samples)
+	for i := 0; i < samples; i++ {
+		g := *NewGUID()
+		if _, dup := seen[g]; dup {
+			t.Fatalf("NewGUID() returned a duplicate after %d samples: %s", i, g.ToFormatD())
+		}
+		seen[g] = struct{}{}
+	}
+}
+
+// TestNewGUIDFormatsAsV4 checks that the generated value survives the string form,
+// where the version digit is directly visible as the first character of the third
+// group.
+func TestNewGUIDFormatsAsV4(t *testing.T) {
+	g := NewGUID()
+	formatted := g.ToFormatD()
+
+	groups := strings.Split(formatted, "-")
+	if len(groups) != 5 {
+		t.Fatalf("ToFormatD() = %q, want five hyphen-separated groups", formatted)
+	}
+	if groups[2][0] != '4' {
+		t.Errorf("third group of %q starts with %q, want '4'", formatted, groups[2][0])
+	}
+	if c := groups[3][0]; c != '8' && c != '9' && c != 'a' && c != 'b' {
+		t.Errorf("fourth group of %q starts with %q, want one of 8/9/a/b", formatted, c)
 	}
 }


### PR DESCRIPTION
### Linked Issue
`Closes #1184`

### Root Cause
`NewGUID` treated a GUID as five independent random integers and filled each with raw generator output. That skips the step RFC 4122 4.4 requires: six of the 128 bits are not free, and must carry the version and variant. Nothing masked them, so the version nibble came out as 0–15 and the variant as 0–3.

The choice of generator followed from the same framing. Treated as opaque identifiers, `math/rand/v2` looks adequate; but the value is emitted as the SMB `ServerGUID` in every NEGOTIATE response, which makes it both wire-visible and security-relevant.

### Fix Description
Draw 16 bytes from `crypto/rand`, split them across the five fields, then set the version to 4 (`c = (c & 0x0FFF) | 0x4000`) and the variant to `10` (`d = (d & 0x3FFF) | 0x8000`). The node field keeps its 48-bit width.

This matches how the SMB server already produces its other wire-visible random values — the NEGOTIATE `SessionKey` generated a few lines away in `handler_negotiate.go` comes from `crypto/rand`.

The constructor keeps its `*GUID` signature. `crypto/rand.Read` is documented never to return an error as of Go 1.24 (it panics if the operating system's source fails), so there is no failure for this constructor to report. Adding an error return was tried and rejected: it does not describe a reachable state, and it would ripple a signature change through `network/dcerpc/v4/client.New` and from there into `epm`, `mgmt` and `interfaces` — well outside a GUID fix.

### How Verified
**Tests.** With the two bit-fixing lines removed, both new invariant tests fail immediately and name the defect:

```
--- FAIL: TestNewGUIDIsRFC4122Version4
    guid_test.go:166: sample 0: version nibble = 5, want 4 (C = 0x5dca)
--- FAIL: TestNewGUIDFormatsAsV4
    guid_test.go:205: third group of "9a81cba3-8b0b-1069-2e41-1951edbcdc9c"
                      starts with '1', want '4'
    guid_test.go:208: fourth group of "9a81cba3-8b0b-1069-2e41-1951edbcdc9c"
                      starts with '2', want one of 8/9/a/b
```

That string is a good illustration of the bug: it announces itself as a version-1 (time-based) GUID with a reserved NCS variant, which is what an SMB peer would have parsed out of a `ServerGUID`.

With the fix, `go test ./windows/guid/` passes, and the SMB1 server suite — the consumer that emits this value — is green:

```
ok  github.com/TheManticoreProject/Manticore/windows/guid
ok  github.com/TheManticoreProject/Manticore/network/smb/smb_v10/server  2.164s
```

`go build ./...` and `go vet ./windows/guid/` are clean.

### Test Coverage
**Added** — `windows/guid/guid_test.go`:
- `TestNewGUIDIsRFC4122Version4` — 256 samples, asserting the version nibble is 4, the variant bits are `10`, and the node field stays within 48 bits. The sample count matters: a single unfixed nibble would still pass 1 time in 16, so one sample would be a flaky test rather than a guard.
- `TestNewGUIDIsDistinct` — 1024 samples with no duplicate. This does not prove the source is cryptographically secure, which cannot be asserted from output, but it does catch an unseeded or constant generator.
- `TestNewGUIDFormatsAsV4` — checks the invariants through `ToFormatD()`, where the version digit is the first character of the third group and the variant the first of the fourth.

### Scope of Change
- **Files changed:** `windows/guid/Guid.go`, `windows/guid/guid_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Two call sites consume this: the SMB1 server's `ServerGUID` and the DCE/RPC v4 client's activity UUID. Both want a unique opaque identifier and neither depends on the previously-malformed bits, so the change is safe to merge directly. GUIDs generated before and after remain mutually distinct; nothing persists them across versions.

### Notes
`math/rand/v2` is no longer imported by this package.