### PR TITLE
Fix SMB1 session setup truncating MaxBufferSize to 16 bits (Fixes #1185)

### DIFF
--- a/network/smb/smb_v10/client/client_structures.go
+++ b/network/smb/smb_v10/client/client_structures.go
@@ -19,6 +19,16 @@ const (
 	DefaultNativeLanMan = "Samba"
 )
 
+// DefaultMaxBufferSize is the client's own maximum receive buffer, declared in
+// SESSION_SETUP_ANDX when Client.MaxBufferSize is left zero.
+//
+// [MS-CIFS] 2.2.4.53.1 defines this field as the largest message the *client* can
+// receive, so it is a property of the client and not an echo of what the server
+// advertised: the field is 16 bits wide, while the server's MaxBufferSize is 32
+// bits and routinely exceeds it. 16644 is the value Windows sends, and the value
+// this repository's own SMB1 server defaults to.
+const DefaultMaxBufferSize uint16 = 16644
+
 // Client represents an SMB v1.0 client
 type Client struct {
 	// Transport is the transport layer for the client
@@ -38,6 +48,10 @@ type Client struct {
 
 	// Workstation is the workstation name of the client
 	Workstation string
+
+	// MaxBufferSize is the largest message this client can receive, declared in
+	// SESSION_SETUP_ANDX. Zero selects DefaultMaxBufferSize.
+	MaxBufferSize uint16
 }
 
 // Connection represents an established SMB connection between the client and server

--- a/network/smb/smb_v10/client/session.go
+++ b/network/smb/smb_v10/client/session.go
@@ -81,7 +81,15 @@ func (s *Session) SessionSetup() error {
 	requestStep1Msg.Header.TID = 65535
 	requestStep1Msg.Header.UID = 0
 
-	sessionSetupCmd.MaxBufferSize = types.USHORT(s.Client.Connection.Server.MaxBufferSize)
+	// The client declares its own receive buffer here. Narrowing the server's
+	// 32-bit advertised value into this 16-bit field discards its high half, and a
+	// server advertising an exact multiple of 65536 — 65536 itself is common —
+	// would be told the client can receive nothing.
+	maxBufferSize := s.Client.MaxBufferSize
+	if maxBufferSize == 0 {
+		maxBufferSize = DefaultMaxBufferSize
+	}
+	sessionSetupCmd.MaxBufferSize = types.USHORT(maxBufferSize)
 	sessionSetupCmd.MaxMpxCount = s.Client.Connection.MaxMpxCount
 	sessionSetupCmd.Capabilities = s.Client.Connection.Server.Capabilities
 

--- a/network/smb/smb_v10/client/session_maxbuffer_test.go
+++ b/network/smb/smb_v10/client/session_maxbuffer_test.go
@@ -1,0 +1,85 @@
+package client_test
+
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/client"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header/flags"
+	"github.com/TheManticoreProject/Manticore/windows/credentials"
+)
+
+// sentSessionSetup drives SessionSetup against a canned response and returns the
+// SESSION_SETUP_ANDX the client put on the wire.
+func sentSessionSetup(t *testing.T, serverMaxBufferSize uint32, clientMaxBufferSize uint16) *commands.SessionSetupAndxRequest {
+	t.Helper()
+
+	resp := message.NewMessage()
+	resp.Header.SetFlags(flags.FLAGS_REPLY)
+	resp.Header.UID = 0x0901
+	resp.AddCommand(commands.NewSessionSetupAndxResponse())
+	raw, err := resp.Marshal()
+	if err != nil {
+		t.Fatalf("marshal canned response: %v", err)
+	}
+
+	tr := &capturingTransport{response: raw}
+	c := &client.Client{
+		Transport:     tr,
+		Connection:    &client.Connection{Server: &client.Server{MaxBufferSize: serverMaxBufferSize}},
+		MaxBufferSize: clientMaxBufferSize,
+	}
+	if err := c.SessionSetup(&credentials.Credentials{Username: "alice"}); err != nil {
+		t.Fatalf("SessionSetup: %v", err)
+	}
+
+	reqMsg := message.NewMessage()
+	if err := reqMsg.Unmarshal(tr.sent); err != nil {
+		t.Fatalf("unmarshal sent request: %v", err)
+	}
+	req, ok := reqMsg.Command.(*commands.SessionSetupAndxRequest)
+	if !ok {
+		t.Fatalf("sent command is %T, want *SessionSetupAndxRequest", reqMsg.Command)
+	}
+	return req
+}
+
+// TestSessionSetupDeclaresClientMaxBufferSize guards the truncation bug: the
+// SESSION_SETUP_ANDX MaxBufferSize field is 16 bits and describes the *client's*
+// receive buffer ([MS-CIFS] 2.2.4.53.1). Narrowing the server's 32-bit advertised
+// value into it discarded the high half, and a server advertising an exact multiple
+// of 65536 made the client declare that it could receive nothing.
+func TestSessionSetupDeclaresClientMaxBufferSize(t *testing.T) {
+	tests := []struct {
+		name             string
+		serverAdvertised uint32
+	}{
+		{"server advertises 16644", 16644},
+		{"server advertises 64 KiB", 65536},   // truncated to 0 before the fix
+		{"server advertises 128 KiB", 131072}, // truncated to 0 before the fix
+		{"server advertises 66000", 66000},    // truncated to 464 before the fix
+		{"server advertises nothing", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := sentSessionSetup(t, tt.serverAdvertised, 0)
+			if req.MaxBufferSize != uint16(client.DefaultMaxBufferSize) {
+				t.Errorf("MaxBufferSize = %d, want the client default %d (server advertised %d)",
+					req.MaxBufferSize, client.DefaultMaxBufferSize, tt.serverAdvertised)
+			}
+			if req.MaxBufferSize == 0 {
+				t.Error("MaxBufferSize = 0: the client declared that it can receive no message at all")
+			}
+		})
+	}
+}
+
+// TestSessionSetupHonoursConfiguredMaxBufferSize checks that a caller can declare
+// its own buffer size.
+func TestSessionSetupHonoursConfiguredMaxBufferSize(t *testing.T) {
+	req := sentSessionSetup(t, 65536, 4356)
+	if req.MaxBufferSize != 4356 {
+		t.Errorf("MaxBufferSize = %d, want the configured 4356", req.MaxBufferSize)
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #1185`

### Root Cause
Two distinct quantities were conflated. `Connection.Server.MaxBufferSize` is what the *server* advertised in its NEGOTIATE response and is 32 bits wide; the `MaxBufferSize` field of SESSION_SETUP_ANDX is what the *client* can receive and is 16 bits wide ([MS-CIFS] 2.2.4.53.1). Assigning the former to the latter was wrong in kind, and the `types.USHORT` conversion then silently discarded the high half.

The failure mode is worst for the most ordinary values, because the truncation is modulo 65536:

| Server advertises | Client declared |
|---|---|
| 16644 (`0x4104`) | 16644 |
| 65536 (`0x10000`) | **0** |
| 131072 (`0x20000`) | **0** |
| 66000 (`0x101D0`) | 464 |

A client announcing `MaxBufferSize = 0` is asserting it cannot receive any message at all, which strict servers reject.

### Fix Description
Add `Client.MaxBufferSize` and declare that, defaulting to `DefaultMaxBufferSize` (16644) when the caller leaves it zero. 16644 is the value Windows sends and the value this repository's own SMB1 server already defaults to (`network/smb/smb_v10/server/server.go` L102), so client and server now agree on the same constant.

The server's advertised value keeps its existing and correct role — bounding *outgoing* request sizes in `file.go` and `find.go` — and those call sites are untouched. Only the one assignment that mislabelled it as the client's own capability changed.

Clamping the server's value to `0xFFFF` instead was rejected: it would still be describing the server's buffer in a field that means the client's, and it would declare a receive capability the client has no basis for.

### How Verified
**Tests.** With the old assignment restored, the new table-driven test fails on exactly the values the issue predicts:

```
--- FAIL: TestSessionSetupDeclaresClientMaxBufferSize/server_advertises_64_KiB
    MaxBufferSize = 0, want the client default 16644 (server advertised 65536)
    MaxBufferSize = 0: the client declared that it can receive no message at all
--- FAIL: TestSessionSetupDeclaresClientMaxBufferSize/server_advertises_128_KiB
    MaxBufferSize = 0, want the client default 16644 (server advertised 131072)
--- FAIL: TestSessionSetupDeclaresClientMaxBufferSize/server_advertises_66000
```

The tests assert against the bytes actually sent: the request is marshalled through the transport, read back from the captured buffer, and unmarshalled before the field is checked.

With the fix, `go test ./network/smb/...` is green in full, `go build ./...` passes and `go vet ./network/smb/smb_v10/...` is clean.

**Not live-validated.** The Windows Server 2025 host available for this work has SMB1 disabled (`smbclient -L` reports `SMB1 disabled -- no workgroup available`), which is the default on Windows 10 1709 / Server 2019 and later, so there was no live SMB1 server to negotiate 64 KiB against. The defect and the fix are both in the value the client emits, and that value is asserted from the wire bytes in the tests above.

### Test Coverage
**Added** — `network/smb/smb_v10/client/session_maxbuffer_test.go`:
- `TestSessionSetupDeclaresClientMaxBufferSize` — five cases covering the truncation boundaries (16644, 65536, 131072, 66000, and a server that advertises nothing), each asserting the declared value is the client's own and, separately, that it is never 0.
- `TestSessionSetupHonoursConfiguredMaxBufferSize` — a caller-supplied value is used as given.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/client/client_structures.go`, `network/smb/smb_v10/client/session.go`, `network/smb/smb_v10/client/session_maxbuffer_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local to the value SESSION_SETUP_ANDX declares. Against a server advertising 16644 the emitted byte is unchanged, so the common case is bit-identical; against servers advertising 64 KiB or more the client now sends a usable value where it previously sent 0. Both session-setup legs carry the same value, as before — leg 2 copies it from leg 1 at `session.go` L303.

### Notes
`MaxMpxCount` and `Capabilities` are echoed from the server's NEGOTIATE response in the same function, and are the client's own capabilities for the same reason this field is. Those are a separate defect and are not touched here; they will be filed on their own.