### PR TITLE
Remove the duplicated Direct TCP length limit and its stale comment

### DIFF
--- a/network/tcp/tcp.go
+++ b/network/tcp/tcp.go
@@ -7,24 +7,22 @@ import (
 	"time"
 )
 
-// MaxDirectTCPPayloadSize is the default cap on the payload accepted from a single
-// Direct TCP frame, and is the largest the session service can describe: the length
-// field is 24 bits wide ([MS-SMB2] 2.1).
-//
-// The transport carries SMB1, SMB2 and SMB3, whose negotiated limits differ by more
-// than an order of magnitude — a Windows server advertises an 8 MiB MaxReadSize —
-// so a smaller default here would refuse frames the peer was entitled to send after
-// a successful negotiation. Bounding what a peer can induce this side to allocate is
-// a policy the accepting side sets with SetMaxPayloadSize, not something a constant
-// shared with the client can express.
-const MaxDirectTCPPayloadSize = 0xFFFFFF
-
 // MaxDirectTCPFrameLength is the largest payload the Direct TCP session service can
 // describe: [MS-SMB2] 2.1 gives the header as a zero byte followed by a 3-byte
 // big-endian length, so a longer payload has no representable length and MUST NOT be
-// sent. This bounds what Send will encode; MaxDirectTCPPayloadSize is the separate,
-// stricter policy applied to what Receive will accept.
+// sent. It bounds what Send will encode.
 const MaxDirectTCPFrameLength = 0xFFFFFF
+
+// MaxDirectTCPPayloadSize is the default cap on the payload Receive will accept from
+// a single frame. It is the wire limit above, because the transport carries SMB1,
+// SMB2 and SMB3, whose negotiated limits differ by more than an order of magnitude —
+// a Windows server advertises an 8 MiB MaxReadSize — so any smaller default would
+// refuse frames the peer was entitled to send after a successful negotiation.
+//
+// Bounding what a peer can induce this side to allocate is a policy the accepting
+// side sets per connection with SetMaxPayloadSize, not something a constant shared
+// with the client can express.
+const MaxDirectTCPPayloadSize = MaxDirectTCPFrameLength
 
 // TCPTransport implements the Transport interface for Direct TCP transport
 // Source: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb/f906c680-330c-43ae-9a71-f854e24aeee6


### PR DESCRIPTION
### Linked Issue
None — this is not a functional defect, so no issue was filed. It is the residue of #1186 and #1190 landing together, and it is being corrected rather than left for a reader to trip over.

### Root Cause
The two fixes were deliberately kept as separate PRs, since they addressed separate defects in separate directions of the transport. Each was self-consistent on its own branch:

- #1186 bounded `Send` against the width of the length field and introduced `MaxDirectTCPFrameLength` for it, describing `MaxDirectTCPPayloadSize` as "the separate, stricter policy applied to what `Receive` will accept" — true at the time, when it was 1 MiB.
- #1190 raised `MaxDirectTCPPayloadSize` to the wire maximum, because any smaller default refuses frames a Windows server is entitled to send.

Git merged them without conflict because they touch adjacent but distinct lines. The result compiles and behaves correctly, but holds the same literal in two exported constants and carries a comment that asserts an ordering between them which no longer exists.

### Fix Description
Define the wire limit once, in `MaxDirectTCPFrameLength`, and derive `MaxDirectTCPPayloadSize` from it. Both constants keep their names and values, so no caller changes. The comments now describe the real relationship: the default receive cap *is* the wire limit, and tightening the accept path is the job of the per-connection `SetMaxPayloadSize`.

Deleting one of the two constants was rejected: `MaxDirectTCPPayloadSize` is pre-existing and referenced by tests, and `MaxDirectTCPFrameLength` names a genuinely different thing (a protocol invariant, versus a configurable default that currently equals it).

### How Verified
**Static.** The change is a constant definition and two comments; `MaxDirectTCPPayloadSize == MaxDirectTCPFrameLength == 0xFFFFFF` before and after, so `Send`'s guard and `Receive`'s default cap are unchanged.

**Tests.** `go build ./...`, `go vet ./network/tcp/` and `go test ./network/tcp/` are clean:

```
ok  github.com/TheManticoreProject/Manticore/network/tcp  0.138s
```

That suite includes the guards from both prior PRs — `TestTCPTransport_SendRejectsOversizedPayload`, `TestTCPTransport_ReceiveAcceptsLargeNegotiatedFrame` and `TestTCPTransport_SetMaxPayloadSizeBounds` — so both behaviours are still pinned.

### Test Coverage
**Existing** — no new tests. The behaviour is unchanged by construction, and it is already covered by the three tests named above.

### Scope of Change
- **Files changed:** `network/tcp/tcp.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none