### PR TITLE
Fix NTLM AUTHENTICATE sending an LMv2 response where MS-NLMP requires Z(24) (Fixes #1194)

### DIFF
--- a/crypto/spnego/ntlm/message/authenticate/authenticate.go
+++ b/crypto/spnego/ntlm/message/authenticate/authenticate.go
@@ -190,7 +190,8 @@ func newAuthenticateMessage(challenge *challenge.ChallengeMessage, username, pas
 
 		// Use server's MsvAvTimestamp when present; otherwise derive current Windows FILETIME
 		timestamp := targetinfo.GetTimestamp(challenge.TargetInfo)
-		if len(timestamp) != 8 {
+		serverSuppliedTimestamp := len(timestamp) == 8
+		if !serverSuppliedTimestamp {
 			windowsFiletime := (uint64(time.Now().Unix()) + 116444736000) * 10000000
 			timestamp = make([]byte, 8)
 			binary.LittleEndian.PutUint64(timestamp, windowsFiletime)
@@ -201,8 +202,11 @@ func newAuthenticateMessage(challenge *challenge.ChallengeMessage, username, pas
 		if err != nil {
 			return nil, err
 		}
-		// Send a real LMv2 response (the Windows client does, even with a timestamp).
-		msg.LmChallengeResponse = v2.ComputeLMChallengeResponse(false)
+		// When the server supplied an MsvAvTimestamp, MS-NLMP 3.1.5.1.2 requires
+		// Z(24) here rather than a computed response. KXKEY for NTLMv2 derives
+		// KeyExchangeKey from SessionBaseKey alone and does not consume this field
+		// (MS-NLMP 3.4.5.1), so zeroing it changes no derived key.
+		msg.LmChallengeResponse = v2.ComputeLMChallengeResponse(serverSuppliedTimestamp)
 
 		// EXPERIMENT: no key exchange. The exported session key (the SMB signing MAC
 		// key) equals the SessionBaseKey.

--- a/crypto/spnego/ntlm/message/authenticate/lm_response_test.go
+++ b/crypto/spnego/ntlm/message/authenticate/lm_response_test.go
@@ -1,0 +1,80 @@
+package authenticate_test
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+	"time"
+
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/message/authenticate"
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/message/challenge"
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/message/negotiate/flags"
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/targetinfo"
+)
+
+// challengeWithTargetInfo builds a CHALLENGE carrying a server TargetInfo, with an
+// MsvAvTimestamp when withTimestamp is set — which is what a Windows domain
+// controller always sends.
+func challengeWithTargetInfo(t *testing.T, withTimestamp bool) *challenge.ChallengeMessage {
+	t.Helper()
+
+	var ts []byte
+	if withTimestamp {
+		ts = make([]byte, 8)
+		binary.LittleEndian.PutUint64(ts, (uint64(time.Now().Unix())+116444736000)*10000000)
+	}
+
+	info, err := targetinfo.BuildServerTargetInfo("DC01", "TMP", "dc01.tmp.local", "tmp.local", ts)
+	if err != nil {
+		t.Fatalf("BuildServerTargetInfo: %v", err)
+	}
+
+	msg := &challenge.ChallengeMessage{
+		NegotiateFlags: flags.NTLMSSP_NEGOTIATE_UNICODE |
+			flags.NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY |
+			flags.NTLMSSP_NEGOTIATE_TARGET_INFO,
+		TargetInfo: info,
+	}
+	copy(msg.ServerChallenge[:], []byte{1, 2, 3, 4, 5, 6, 7, 8})
+	return msg
+}
+
+// TestLmChallengeResponseIsZeroedWhenServerSuppliesTimestamp guards the defect: the
+// caller passed a hardcoded false, so the conforming branch of
+// ComputeLMChallengeResponse was dead. MS-NLMP 3.1.5.1.2 requires Z(24) when the
+// CHALLENGE TargetInfo carries MsvAvTimestamp, which a Windows DC always does.
+func TestLmChallengeResponseIsZeroedWhenServerSuppliesTimestamp(t *testing.T) {
+	authMsg, err := authenticate.CreateAuthenticateMessage(
+		challengeWithTargetInfo(t, true), "Administrator", "pass", "TMP", "WORKSTATION")
+	if err != nil {
+		t.Fatalf("CreateAuthenticateMessage: %v", err)
+	}
+
+	if len(authMsg.LmChallengeResponse) != 24 {
+		t.Fatalf("LmChallengeResponse is %d bytes, want 24", len(authMsg.LmChallengeResponse))
+	}
+	if !bytes.Equal(authMsg.LmChallengeResponse, make([]byte, 24)) {
+		t.Errorf("LmChallengeResponse = % x, want 24 zero bytes", authMsg.LmChallengeResponse)
+	}
+}
+
+// TestLmChallengeResponseIsComputedWithoutTimestamp checks the other branch is intact:
+// with no MsvAvTimestamp the field carries the computed LMv2 response.
+func TestLmChallengeResponseIsComputedWithoutTimestamp(t *testing.T) {
+	authMsg, err := authenticate.CreateAuthenticateMessage(
+		challengeWithTargetInfo(t, false), "Administrator", "pass", "TMP", "WORKSTATION")
+	if err != nil {
+		t.Fatalf("CreateAuthenticateMessage: %v", err)
+	}
+
+	if len(authMsg.LmChallengeResponse) != 24 {
+		t.Fatalf("LmChallengeResponse is %d bytes, want 24", len(authMsg.LmChallengeResponse))
+	}
+	if bytes.Equal(authMsg.LmChallengeResponse, make([]byte, 24)) {
+		t.Error("LmChallengeResponse is zeroed, want the computed LMv2 response when no MsvAvTimestamp was supplied")
+	}
+	// The trailing 8 bytes are the client challenge, so they must not be zero either.
+	if bytes.Equal(authMsg.LmChallengeResponse[16:], make([]byte, 8)) {
+		t.Error("LmChallengeResponse client-challenge tail is zeroed")
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #1194`

### Root Cause
The rule was implemented but never reached. `ComputeLMChallengeResponse(hasTimestamp bool)` correctly returns 24 zero bytes when told the server supplied an `MsvAvTimestamp`, and its only non-test caller passed the literal `false` — so the conforming branch was dead code and the computed LMv2 response was sent unconditionally.

What makes this a defect rather than an oversight is that the governing condition was already in hand. Ten lines above the call, the same function inspects the server's TargetInfo for a timestamp in order to decide whether to synthesise one; that result was used for the synthesis decision and then discarded. The in-code comment — *"Send a real LMv2 response (the Windows client does, even with a timestamp)"* — asserts the opposite of [MS-NLMP] 3.1.5.1.2.

### Fix Description
Keep the outcome of the existing timestamp check in `serverSuppliedTimestamp` and pass it to the helper. Two lines changed in the emission path; the helper is untouched.

[MS-NLMP] 3.1.5.1.2 states: *"If NTLM v2 authentication is used and the CHALLENGE_MESSAGE TargetInfo field has an MsvAvTimestamp present, the client SHOULD NOT send the LmChallengeResponse and SHOULD send Z(24) instead."*

Zeroing the field is key-neutral, which is what makes this safe to change in isolation: `KXKEY` for NTLMv2 derives `KeyExchangeKey` from `SessionBaseKey` alone and does not consume `LmChallengeResponse` ([MS-NLMP] 3.4.5.1). Note this is *not* true for NTLMv1 with extended session security, where `KXKEY` reads the first 8 bytes of the LM response — the NTLMv1 branch of this function is untouched.

### How Verified
**Runtime, against a live Windows Server 2025 domain controller** (signing required). Windows always sends `MsvAvTimestamp`, so this change alters the bytes of every authentication against it, and authentication continues to succeed:

```
server SecurityMode   = SIGNING_ENABLED|SIGNING_REQUIRED
session SigningActive = true
session key length    = 16
tree connect IPC$ OK (signed round trip)
tree disconnect + logoff OK
```

`SigningActive = true` is what makes this a real check rather than a smoke test: the SMB signing key is derived from the NTLM exchange, so every signed round trip above would fail if the change had perturbed key derivation. The full SMB2 operation matrix also still passes (`QueryDirectory`, `QuerySecurityDescriptor`, `Read`, multi-credit `Write`, 1 MiB `Read`).

**Tests.** With the hardcoded `false` restored, the guard fails and prints the response that should have been zeroed:

```
--- FAIL: TestLmChallengeResponseIsZeroedWhenServerSuppliesTimestamp
    LmChallengeResponse = 6b bc 8d 28 6b 05 ff 26 e1 1a 4c 95 4b c1 bc 94
                          49 c6 8c 0d c5 35 a5 55, want 24 zero bytes
```

`go build ./...`, `go vet ./crypto/spnego/...` and `go test ./crypto/spnego/...` are clean.

### Test Coverage
**Added** — `crypto/spnego/ntlm/message/authenticate/lm_response_test.go`:
- `TestLmChallengeResponseIsZeroedWhenServerSuppliesTimestamp` — the regression guard, driving a CHALLENGE built with `BuildServerTargetInfo` carrying an `MsvAvTimestamp`, as a Windows DC sends.
- `TestLmChallengeResponseIsComputedWithoutTimestamp` — pins the other branch, so the fix cannot degenerate into always zeroing the field. It also asserts the trailing 8 bytes (the client challenge) are non-zero, which distinguishes a real response from a zeroed one more sharply than a length check.

### Scope of Change
- **Files changed:** `crypto/spnego/ntlm/message/authenticate/authenticate.go`, `crypto/spnego/ntlm/message/authenticate/lm_response_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Affects every NTLMv2 authentication where the server supplies a timestamp, which in practice is every authentication against Windows. The field is key-neutral for NTLMv2 (above) and the server recomputes `ExpectedLmChallengeResponse` only to compare it when the NT response has already failed to match ([MS-NLMP] 3.2.5.1.2), so a conforming `Z(24)` does not affect the success path. Live-validated end to end against a signing-required DC. Safe to merge.

### Notes
This is one of five NTLM emission defects identified together; the others (no VERSION in AUTHENTICATE, `NeedsMIC` hardcoded false, `KEY_EXCH` declined, `MsvAvChannelBindings` never emitted) are filed and fixed separately, since the MIC is keyed on `ExportedSessionKey` and so depends on the KEY_EXCH change landing first.