### PR TITLE
Fix NTLM client never negotiating key exchange (Fixes #1196)

### DIFF
--- a/crypto/spnego/ntlm/message/authenticate/authenticate.go
+++ b/crypto/spnego/ntlm/message/authenticate/authenticate.go
@@ -4,6 +4,7 @@ import (
 	"crypto/hmac"
 	"crypto/md5"
 	"crypto/rand"
+	"crypto/rc4"
 	"encoding/binary"
 	"fmt"
 	"strings"
@@ -154,6 +155,14 @@ func newAuthenticateMessage(challenge *challenge.ChallengeMessage, username, pas
 		flags.NTLMSSP_NEGOTIATE_128 |
 		flags.NTLMSSP_NEGOTIATE_56
 
+	// Key exchange is only asserted when the server offered it, since a server that
+	// sees the flag MUST then find a valid EncryptedRandomSessionKey or fail the
+	// authentication outright (MS-NLMP 3.2.5.1.2).
+	keyExchange := (challenge.NegotiateFlags & flags.NTLMSSP_NEGOTIATE_KEY_EXCH) != 0
+	if keyExchange {
+		msg.NegotiateFlags |= flags.NTLMSSP_NEGOTIATE_KEY_EXCH
+	}
+
 	// Determine if we should use Unicode
 	useUnicode := (challenge.NegotiateFlags & flags.NTLMSSP_NEGOTIATE_UNICODE) != 0
 
@@ -204,9 +213,26 @@ func newAuthenticateMessage(challenge *challenge.ChallengeMessage, username, pas
 		// Send a real LMv2 response (the Windows client does, even with a timestamp).
 		msg.LmChallengeResponse = v2.ComputeLMChallengeResponse(false)
 
-		// EXPERIMENT: no key exchange. The exported session key (the SMB signing MAC
-		// key) equals the SessionBaseKey.
-		msg.SessionKey = v2.ComputeSessionBaseKey(ntProofStr)
+		// KXKEY for NTLMv2 is the SessionBaseKey itself (MS-NLMP 3.4.5.1).
+		keyExchangeKey := v2.ComputeSessionBaseKey(ntProofStr)
+
+		// With key exchange, the key that protects signing and sealing is generated
+		// here and travels RC4-wrapped under the KeyExchangeKey; without it, the
+		// KeyExchangeKey is used directly (MS-NLMP 3.1.5.1.2).
+		if keyExchange {
+			exportedSessionKey := make([]byte, 16)
+			if _, err := rand.Read(exportedSessionKey); err != nil {
+				return nil, fmt.Errorf("failed to generate an exported session key: %w", err)
+			}
+			wrapped, err := rc4k(keyExchangeKey, exportedSessionKey)
+			if err != nil {
+				return nil, err
+			}
+			msg.EncryptedRandomSessionKey = wrapped
+			msg.SessionKey = exportedSessionKey
+		} else {
+			msg.SessionKey = keyExchangeKey
+		}
 	} else {
 		// Use NTLMv1
 		ntlmv1Ctx, err := ntlmv1.NewNTLMv1CtxWithPassword(domain, username, password, challenge.ServerChallenge)
@@ -249,6 +275,19 @@ func newAuthenticateMessage(challenge *challenge.ChallengeMessage, username, pas
 	}
 
 	return &msg, nil
+}
+
+// rc4k applies RC4 keyed with key to data and returns the result, the RC4K
+// primitive of [MS-NLMP] 6. RC4 is a stream cipher, so the output is the same
+// length as the input and the operation is its own inverse.
+func rc4k(key, data []byte) ([]byte, error) {
+	cipher, err := rc4.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialise RC4 for key exchange: %w", err)
+	}
+	out := make([]byte, len(data))
+	cipher.XORKeyStream(out, data)
+	return out, nil
 }
 
 // ComputeMIC computes the AUTHENTICATE_MESSAGE message integrity code and stores

--- a/crypto/spnego/ntlm/message/authenticate/key_exchange_test.go
+++ b/crypto/spnego/ntlm/message/authenticate/key_exchange_test.go
@@ -1,0 +1,128 @@
+package authenticate_test
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/md5"
+	"crypto/rc4"
+	"encoding/binary"
+	"testing"
+	"time"
+
+	"github.com/TheManticoreProject/Manticore/crypto/ntlmv2"
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/message/authenticate"
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/message/challenge"
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/message/negotiate/flags"
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/targetinfo"
+)
+
+const (
+	kxUser     = "Administrator"
+	kxPassword = "pass"
+	kxDomain   = "TMP"
+)
+
+// kxChallenge builds a CHALLENGE with a server TargetInfo carrying an
+// MsvAvTimestamp, as a Windows domain controller sends.
+func kxChallenge(t *testing.T) *challenge.ChallengeMessage {
+	t.Helper()
+
+	ts := make([]byte, 8)
+	binary.LittleEndian.PutUint64(ts, (uint64(time.Now().Unix())+116444736000)*10000000)
+
+	info, err := targetinfo.BuildServerTargetInfo("DC01", kxDomain, "dc01.tmp.local", "tmp.local", ts)
+	if err != nil {
+		t.Fatalf("BuildServerTargetInfo: %v", err)
+	}
+
+	msg := &challenge.ChallengeMessage{
+		NegotiateFlags: flags.NTLMSSP_NEGOTIATE_UNICODE |
+			flags.NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY |
+			flags.NTLMSSP_NEGOTIATE_TARGET_INFO,
+		TargetInfo: info,
+	}
+	copy(msg.ServerChallenge[:], []byte{1, 2, 3, 4, 5, 6, 7, 8})
+	return msg
+}
+
+// sessionBaseKeyOf recomputes the SessionBaseKey the server would derive:
+// HMAC-MD5(NTOWFv2, NTProofStr), where NTProofStr is the leading 16 bytes of the
+// NTLMv2 response ([MS-NLMP] 2.2.2.8).
+func sessionBaseKeyOf(t *testing.T, ntChallengeResponse []byte) []byte {
+	t.Helper()
+	if len(ntChallengeResponse) < 16 {
+		t.Fatalf("NtChallengeResponse is %d bytes, too short to contain an NTProofStr", len(ntChallengeResponse))
+	}
+	mac := hmac.New(md5.New, ntlmv2.NTOWFv2(kxPassword, kxUser, kxDomain))
+	mac.Write(ntChallengeResponse[:16])
+	return mac.Sum(nil)
+}
+
+// TestKeyExchangeWrapsARandomSessionKey guards the defect: key exchange was stubbed
+// out, so the exported session key was the SessionBaseKey and
+// EncryptedRandomSessionKey was always empty.
+//
+// It verifies the exchange cryptographically rather than structurally: the wrapped
+// key must decrypt, under the KeyExchangeKey the server independently derives, to
+// exactly the key the client kept for signing ([MS-NLMP] 3.1.5.1.2).
+func TestKeyExchangeWrapsARandomSessionKey(t *testing.T) {
+	ch := kxChallenge(t)
+	ch.NegotiateFlags |= flags.NTLMSSP_NEGOTIATE_KEY_EXCH
+
+	msg, err := authenticate.CreateAuthenticateMessage(ch, kxUser, kxPassword, kxDomain, "WORKSTATION")
+	if err != nil {
+		t.Fatalf("CreateAuthenticateMessage: %v", err)
+	}
+
+	if msg.NegotiateFlags&flags.NTLMSSP_NEGOTIATE_KEY_EXCH == 0 {
+		t.Error("AUTHENTICATE does not assert NTLMSSP_NEGOTIATE_KEY_EXCH")
+	}
+	if len(msg.EncryptedRandomSessionKey) != 16 {
+		t.Fatalf("EncryptedRandomSessionKey is %d bytes, want 16", len(msg.EncryptedRandomSessionKey))
+	}
+	if len(msg.SessionKey) != 16 {
+		t.Fatalf("SessionKey is %d bytes, want 16", len(msg.SessionKey))
+	}
+
+	// For NTLMv2 the KeyExchangeKey is the SessionBaseKey (MS-NLMP 3.4.5.1).
+	keyExchangeKey := sessionBaseKeyOf(t, msg.NtChallengeResponse)
+
+	if bytes.Equal(msg.SessionKey, keyExchangeKey) {
+		t.Error("SessionKey equals the SessionBaseKey: no independent key was generated")
+	}
+
+	cipher, err := rc4.NewCipher(keyExchangeKey)
+	if err != nil {
+		t.Fatalf("rc4.NewCipher: %v", err)
+	}
+	unwrapped := make([]byte, 16)
+	cipher.XORKeyStream(unwrapped, msg.EncryptedRandomSessionKey)
+
+	if !bytes.Equal(unwrapped, msg.SessionKey) {
+		t.Errorf("unwrapping EncryptedRandomSessionKey under the KeyExchangeKey gave % x, want the retained SessionKey % x",
+			unwrapped, msg.SessionKey)
+	}
+}
+
+// TestWithoutKeyExchangeSessionKeyIsTheBaseKey pins the other branch: a server that
+// does not offer key exchange must not be sent a wrapped key, and the exported key
+// is then the KeyExchangeKey itself.
+func TestWithoutKeyExchangeSessionKeyIsTheBaseKey(t *testing.T) {
+	ch := kxChallenge(t)
+	ch.NegotiateFlags &^= flags.NTLMSSP_NEGOTIATE_KEY_EXCH
+
+	msg, err := authenticate.CreateAuthenticateMessage(ch, kxUser, kxPassword, kxDomain, "WORKSTATION")
+	if err != nil {
+		t.Fatalf("CreateAuthenticateMessage: %v", err)
+	}
+
+	if msg.NegotiateFlags&flags.NTLMSSP_NEGOTIATE_KEY_EXCH != 0 {
+		t.Error("AUTHENTICATE asserts NTLMSSP_NEGOTIATE_KEY_EXCH although the CHALLENGE did not offer it")
+	}
+	if len(msg.EncryptedRandomSessionKey) != 0 {
+		t.Errorf("EncryptedRandomSessionKey is %d bytes, want empty when key exchange was not negotiated", len(msg.EncryptedRandomSessionKey))
+	}
+	if want := sessionBaseKeyOf(t, msg.NtChallengeResponse); !bytes.Equal(msg.SessionKey, want) {
+		t.Errorf("SessionKey = % x, want the SessionBaseKey % x", msg.SessionKey, want)
+	}
+}

--- a/network/smb/smb_v10/client/session.go
+++ b/network/smb/smb_v10/client/session.go
@@ -162,10 +162,13 @@ func (s *Session) SessionSetup() error {
 					// takes the NTLMv2 path and computes the SessionBaseKey ([MS-NLMP] 3.3.2).
 					// Without it the NTLMv1 path runs and no key is derived, so SMB message
 					// signing (required by hardened servers, e.g. Windows Server 2003+) cannot
-					// be activated. We deliberately do NOT request NTLMSSP_NEGOTIATE_KEY_EXCH,
-					// so ExportedSessionKey == KeyExchangeKey == SessionBaseKey ([MS-NLMP]
-					// KXKEY) and EncryptedRandomSessionKey stays empty.
+					// be activated.
 					spnego_ntlm_negotiate_flags.NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY |
+					// Key exchange, so the signing key is a random key of the client's
+					// choosing rather than the SessionBaseKey derived from the
+					// credentials. The server only offers it back in its CHALLENGE if it
+					// is requested here.
+					spnego_ntlm_negotiate_flags.NTLMSSP_NEGOTIATE_KEY_EXCH |
 					spnego_ntlm_negotiate_flags.NTLMSSP_NEGOTIATE_SIGN |
 					spnego_ntlm_negotiate_flags.NTLMSSP_NEGOTIATE_ALWAYS_SIGN |
 					spnego_ntlm_negotiate_flags.NTLMSSP_NEGOTIATE_128 |

--- a/network/smb/smb_v20/client/session.go
+++ b/network/smb/smb_v20/client/session.go
@@ -78,6 +78,12 @@ func (c *Client) SessionSetup(creds *credentials.Credentials) error {
 			spnego_ntlm_negotiate_flags.NTLMSSP_NEGOTIATE_56 |
 			spnego_ntlm_negotiate_flags.NTLMSSP_REQUEST_TARGET |
 			spnego_ntlm_negotiate_flags.NTLMSSP_NEGOTIATE_TARGET_INFO |
+			// Key exchange, so the signing key is a random key of the client's
+			// choosing rather than the SessionBaseKey derived from the credentials.
+			// The server only offers it back in its CHALLENGE if it is requested
+			// here, and the AUTHENTICATE performs the exchange only when the
+			// CHALLENGE confirms it.
+			spnego_ntlm_negotiate_flags.NTLMSSP_NEGOTIATE_KEY_EXCH |
 			spnego_ntlm_negotiate_flags.NTLMSSP_NEGOTIATE_VERSION,
 	)
 	v := &version.Version{


### PR DESCRIPTION
### Linked Issue
`Closes #1196`

### Root Cause
Key exchange was stubbed out during bring-up and the stub outlived its purpose. The `// EXPERIMENT: no key exchange` marker at the derivation site was the only such marker anywhere in the emission path, and the SMB1 caller documented the shortcut as deliberate: *"We deliberately do NOT request NTLMSSP_NEGOTIATE_KEY_EXCH, so ExportedSessionKey == KeyExchangeKey == SessionBaseKey."*

The consequence is that the key protecting SMB message signing and sealing was `HMAC-MD5(ResponseKeyNT, NTProofStr)` — a deterministic function of the user's NT hash and the two challenges, with no entropy contributed by the client.

### Fix Description
The fix necessarily spans both NTLM messages, and finding that out was the substance of the work. An AUTHENTICATE-side change alone is **inert**: the server mirrors the client's request, so a Windows DC that was never asked for `KEY_EXCH` does not set it in its CHALLENGE, and a correctly-gated AUTHENTICATE then takes the no-exchange branch. I confirmed this on the live DC before widening the change — see below.

So:
- Both SMB clients now request `NTLMSSP_NEGOTIATE_KEY_EXCH` in the NEGOTIATE.
- The AUTHENTICATE performs the exchange **only when the CHALLENGE confirms it**: a random 16-byte `ExportedSessionKey` is generated with `crypto/rand`, `EncryptedRandomSessionKey` is `RC4K(KeyExchangeKey, ExportedSessionKey)`, and the random key is retained for signing. Otherwise the `KeyExchangeKey` is used directly, exactly as before.

The gating direction matters and is not merely defensive: a server that sees the flag MUST find a valid `EncryptedRandomSessionKey` or fail the authentication outright ([MS-NLMP] 3.2.5.1.2), so asserting it unilaterally would be worse than not asking. For NTLMv2 the `KeyExchangeKey` is the `SessionBaseKey` ([MS-NLMP] 3.4.5.1), which is what the new code wraps under.

A small `rc4k` helper implements the [MS-NLMP] 6 primitive; the NTLMv1 branch is untouched.

### How Verified
**Runtime, against a live Windows Server 2025 domain controller** with signing required.

First, the finding that shaped the fix. With only the AUTHENTICATE side changed, instrumentation showed the branch was never taken:

```
LIVEDBG challengeFlags= 2726920725 keyExchange= false     (0xA2898215 — no KEY_EXCH bit)
```

After adding the flag to the NEGOTIATE, the DC offers it back and the exchange runs:

```
LIVEDBG challengeFlags= 3800662549 keyExchange= true      (0xE2898215 — KEY_EXCH set)
session SigningActive = true
session key length    = 16
tree connect IPC$ OK (signed round trip)
tree disconnect + logoff OK
```

`SigningActive = true` is the proof that matters. The SMB signing key is derived from the exported session key, so a signed round trip only succeeds if the DC RC4-unwrapped our random key under the `KeyExchangeKey` it derived independently and arrived at the same signing key. Wrong flag, wrong wrap, or wrong retained key all fail here. The full SMB2 matrix (`QueryDirectory`, `QuerySecurityDescriptor`, `Read`, multi-credit `Write`, 1 MiB `Read`) also passes.

The instrumentation was temporary and is not in the diff.

**Tests.** With the exchange stubbed back out the guard fails:

```
--- FAIL: TestKeyExchangeWrapsARandomSessionKey
    key_exchange_test.go:81: EncryptedRandomSessionKey is 0 bytes, want 16
```

`go build ./...`, `go vet ./crypto/spnego/... ./network/smb/...`, `go test ./crypto/... ./network/smb/...` all clean.

### Test Coverage
**Added** — `crypto/spnego/ntlm/message/authenticate/key_exchange_test.go`:
- `TestKeyExchangeWrapsARandomSessionKey` — verifies the exchange *cryptographically*, not structurally. It recomputes the `KeyExchangeKey` the way a server would (`HMAC-MD5(NTOWFv2, NTProofStr)`, with `NTProofStr` read from the leading 16 bytes of the NTLMv2 response), RC4-decrypts `EncryptedRandomSessionKey` under it, and asserts the result equals the key the client retained. It also asserts the retained key is *not* the `SessionBaseKey`, which is what distinguishes a real exchange from the old behaviour.
- `TestWithoutKeyExchangeSessionKeyIsTheBaseKey` — pins the other branch: no flag asserted, no wrapped key sent, and the exported key is the `KeyExchangeKey`.

### Scope of Change
- **Files changed:** `crypto/spnego/ntlm/message/authenticate/authenticate.go`, `crypto/spnego/ntlm/message/authenticate/key_exchange_test.go`, `network/smb/smb_v20/client/session.go`, `network/smb/smb_v10/client/session.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none — the two SMB files change only the NTLM NEGOTIATE flag set, which is what the defect requires.

### Risk and Rollout
This changes the key used for SMB signing on every NTLM session, so the blast radius is every authenticated connection. It is gated on the server offering the flag, so a server that does not is unaffected and takes the previous code path byte for byte. Live-validated against a signing-required Windows Server 2025 DC, and the cryptographic round trip is pinned by unit test.

The SMB1 path could not be live-validated: the DC reports `SMB1 disabled`, the default since Server 2019. Its NEGOTIATE flag change is the same one-line addition as SMB2's, and the shared AUTHENTICATE code it drives is covered by the tests above.

### Notes
The MIC is keyed on `ExportedSessionKey` ([MS-NLMP] 3.2.5.1.2), so the remaining `NeedsMIC` defect depends on this change and is filed separately to land after it.