### PR TITLE
Fix NTLM AUTHENTICATE dropping its Version field (Fixes #1199)

### DIFF
--- a/crypto/spnego/ntlm/message/authenticate/authenticate.go
+++ b/crypto/spnego/ntlm/message/authenticate/authenticate.go
@@ -153,7 +153,12 @@ func newAuthenticateMessage(challenge *challenge.ChallengeMessage, username, pas
 		flags.NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY |
 		flags.NTLMSSP_NEGOTIATE_TARGET_INFO |
 		flags.NTLMSSP_NEGOTIATE_128 |
-		flags.NTLMSSP_NEGOTIATE_56
+		flags.NTLMSSP_NEGOTIATE_56 |
+		// The Version field is physically present in the AUTHENTICATE structure
+		// whether or not this flag is set ([MS-NLMP] 2.2.1.3), and the payload
+		// offsets — and the position of the MIC when one is carried — follow from
+		// that. Emitting it keeps the layout the one a server expects.
+		flags.NTLMSSP_NEGOTIATE_VERSION
 
 	// Key exchange is only asserted when the server offered it, since a server that
 	// sees the flag MUST then find a valid EncryptedRandomSessionKey or fail the
@@ -272,11 +277,9 @@ func newAuthenticateMessage(challenge *challenge.ChallengeMessage, username, pas
 		msg.EncryptedRandomSessionKey = []byte{}
 	}
 
-	// Set version if needed
-	if (challenge.NegotiateFlags & flags.NTLMSSP_NEGOTIATE_VERSION) != 0 {
-		v := version.DefaultVersion()
-		msg.Version = &v
-	}
+	// Populate the Version the flag above advertises.
+	v := version.DefaultVersion()
+	msg.Version = &v
 
 	return &msg, nil
 }

--- a/crypto/spnego/ntlm/message/authenticate/version_field_test.go
+++ b/crypto/spnego/ntlm/message/authenticate/version_field_test.go
@@ -1,0 +1,77 @@
+package authenticate_test
+
+import (
+	"encoding/binary"
+	"testing"
+	"time"
+
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/message/authenticate"
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/message/challenge"
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/message/negotiate/flags"
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/targetinfo"
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/version"
+)
+
+// verChallenge builds a CHALLENGE with a server TargetInfo carrying an
+// MsvAvTimestamp, as a Windows domain controller sends.
+func verChallenge(t *testing.T) *challenge.ChallengeMessage {
+	t.Helper()
+
+	ts := make([]byte, 8)
+	binary.LittleEndian.PutUint64(ts, (uint64(time.Now().Unix())+116444736000)*10000000)
+
+	info, err := targetinfo.BuildServerTargetInfo("DC01", "TMP", "dc01.tmp.local", "tmp.local", ts)
+	if err != nil {
+		t.Fatalf("BuildServerTargetInfo: %v", err)
+	}
+
+	msg := &challenge.ChallengeMessage{
+		NegotiateFlags: flags.NTLMSSP_NEGOTIATE_UNICODE |
+			flags.NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY |
+			flags.NTLMSSP_NEGOTIATE_TARGET_INFO,
+		TargetInfo: info,
+	}
+	copy(msg.ServerChallenge[:], []byte{1, 2, 3, 4, 5, 6, 7, 8})
+	return msg
+}
+
+// TestAuthenticateCarriesVersion guards the defect: the Version was computed and
+// then discarded, because the assignment was gated on the server's advertised flags
+// while Marshal gates on the client's own. [MS-NLMP] 2.2.1.3 makes Version a fixed
+// field, so dropping it shifts every payload offset 8 bytes down from what a server
+// computes.
+func TestAuthenticateCarriesVersion(t *testing.T) {
+	msg, err := authenticate.CreateAuthenticateMessage(
+		verChallenge(t), "Administrator", "pass", "TMP", "WORKSTATION")
+	if err != nil {
+		t.Fatalf("CreateAuthenticateMessage: %v", err)
+	}
+
+	if !msg.NegotiateFlags.HasFlag(flags.NTLMSSP_NEGOTIATE_VERSION) {
+		t.Error("AUTHENTICATE does not assert NTLMSSP_NEGOTIATE_VERSION")
+	}
+	if msg.Version == nil {
+		t.Fatal("AUTHENTICATE carries no Version")
+	}
+	if want := version.DefaultVersion(); *msg.Version != want {
+		t.Errorf("Version = %+v, want %+v", *msg.Version, want)
+	}
+	if msg.Version.ProductBuild == 0 {
+		t.Error("Version.ProductBuild is 0, which is not a real Windows build")
+	}
+
+	// The payload must begin after the 64-byte fixed part plus the 8-byte Version,
+	// which is where a server reads it from.
+	raw, err := msg.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if len(raw) < 64 {
+		t.Fatalf("marshalled AUTHENTICATE is %d bytes", len(raw))
+	}
+	// DomainNameFields.BufferOffset sits at offset 32 of the fixed part and is the
+	// first payload field in the canonical layout this marshaller emits.
+	if got := binary.LittleEndian.Uint32(raw[32:36]); got != 72 {
+		t.Errorf("first payload field begins at offset %d, want 72 (64-byte fixed part plus the 8-byte Version)", got)
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #1199`

### Root Cause
The presence of the Version field was gated on the wrong party's flags. The assignment read the **server's** advertised flags:

```go
if (challenge.NegotiateFlags & flags.NTLMSSP_NEGOTIATE_VERSION) != 0 {
	v := version.DefaultVersion()
	msg.Version = &v
}
```

while `Marshal` emits the field based on the **message's own** flags, and `NTLMSSP_NEGOTIATE_VERSION` was absent from the hardcoded flag set. Those two conditions could never both hold, so `msg.Version` was assigned and then discarded in every case — the work was done and thrown away.

[MS-NLMP] 2.2.1.3 makes Version a fixed 8-byte field following `NegotiateFlags`, itself followed by the 16-byte MIC. A conforming payload therefore begins at offset 72, not 64.

### Fix Description
Assert `NTLMSSP_NEGOTIATE_VERSION` in the AUTHENTICATE flags and populate the Version unconditionally, as Windows does. `version.DefaultVersion()` already returns a plausible triple (10.0.18362 with `NTLMSSP_REVISION_W2K3`); nothing new is introduced, it simply stops being dropped.

Gating the flag on the server's CHALLENGE instead was rejected: the Version field is structurally present regardless of the flag, so its emission is a property of the layout this client produces, not something to negotiate. Making the two guards merely *agree* on the challenge would still have left the payload at 64 against a Windows server that reads it at 72.

### How Verified
**Runtime, against a live Windows Server 2025 domain controller** with signing required. This changes the offset of every payload field in the message, so a mismatch fails immediately:

```
server SecurityMode   = SIGNING_ENABLED|SIGNING_REQUIRED
session SigningActive = true
session key length    = 16
tree connect IPC$ OK (signed round trip)
tree disconnect + logoff OK
```

The full SMB2 matrix (`QueryDirectory`, `QuerySecurityDescriptor`, `Read`, multi-credit `Write`, 1 MiB `Read`) also passes.

**Tests.** With the flag removed, the guard reports both symptoms:

```
--- FAIL: TestAuthenticateCarriesVersion
    AUTHENTICATE does not assert NTLMSSP_NEGOTIATE_VERSION
    first payload field begins at offset 64, want 72
      (64-byte fixed part plus the 8-byte Version)
```

`go build ./...`, `go vet ./crypto/spnego/...`, and `go test ./crypto/... ./network/smb/...` are clean.

### Test Coverage
**Added** — `crypto/spnego/ntlm/message/authenticate/version_field_test.go`:
- `TestAuthenticateCarriesVersion` — asserts the flag is set, the Version is populated and equals `DefaultVersion()`, and that `ProductBuild` is non-zero (a build of 0 is not a real Windows build). Crucially it also marshals the message and checks `DomainNameFields.BufferOffset` is 72, which is the property a server actually depends on — a flag assertion alone would not catch a `Marshal` regression.

### Scope of Change
- **Files changed:** `crypto/spnego/ntlm/message/authenticate/authenticate.go`, `crypto/spnego/ntlm/message/authenticate/version_field_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Every payload offset in every AUTHENTICATE moves by 8 bytes, so the blast radius is all NTLM authentication. Offsets are self-describing and the receiving side reads them from the fields, so this is the layout servers expect; live-validated against a signing-required Windows Server 2025 DC, where a wrong offset produces `STATUS_INVALID_PARAMETER` rather than a silent failure.

The SMB1 path shares this code but could not be live-validated — the DC reports `SMB1 disabled`, the default since Server 2019.

### Notes
This unblocks the MIC. A MIC sits immediately after Version, so with the field absent the MIC landed at offset 64 and the payload at 80, and a Windows Server 2025 DC rejects that layout with `STATUS_INVALID_PARAMETER` — observed directly while attempting the MIC fix first. `#1198` (no MIC emitted) will be implemented on top of this change.