### PR TITLE
Fix NTLMv2 blob omitting MsvAvChannelBindings (Fixes #1202)

### DIFF
--- a/crypto/spnego/ntlm/targetinfo/channel_bindings_test.go
+++ b/crypto/spnego/ntlm/targetinfo/channel_bindings_test.go
@@ -1,0 +1,98 @@
+package targetinfo_test
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/avpair"
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/targetinfo"
+)
+
+// avPairOffsets walks a TargetInfo and records the byte offset of each AvId, so a
+// test can assert ordering as well as presence.
+func avPairOffsets(t *testing.T, info []byte) (map[avpair.AvId]int, map[avpair.AvId][]byte) {
+	t.Helper()
+
+	offsets := make(map[avpair.AvId]int)
+	values := make(map[avpair.AvId][]byte)
+	for i := 0; i+4 <= len(info); {
+		id := avpair.AvId(binary.LittleEndian.Uint16(info[i : i+2]))
+		avLen := int(binary.LittleEndian.Uint16(info[i+2 : i+4]))
+		if i+4+avLen > len(info) {
+			t.Fatalf("AV_PAIR %s at offset %d declares %d bytes, past the end of the buffer", id, i, avLen)
+		}
+		offsets[id] = i
+		values[id] = info[i+4 : i+4+avLen]
+		if id == avpair.MsvAvEOL {
+			break
+		}
+		i += 4 + avLen
+	}
+	return offsets, values
+}
+
+// TestBlobCarriesChannelBindings guards the defect: MsvAvChannelBindings was defined
+// but had no writer, and a server enforcing channel binding returns
+// GSS_S_BAD_BINDINGS when the pair is absent (MS-NLMP 3.2.5.1.2).
+func TestBlobCarriesChannelBindings(t *testing.T) {
+	serverInfo, err := targetinfo.BuildServerTargetInfo("DC01", "TMP", "dc01.tmp.local", "tmp.local", nil)
+	if err != nil {
+		t.Fatalf("BuildServerTargetInfo: %v", err)
+	}
+
+	blob := targetinfo.BuildBlobTargetInfo(serverInfo)
+	offsets, values := avPairOffsets(t, blob)
+
+	cb, ok := values[avpair.MsvAvChannelBindings]
+	if !ok {
+		t.Fatal("blob TargetInfo carries no MsvAvChannelBindings AV_PAIR")
+	}
+	if len(cb) != 16 {
+		t.Errorf("MsvAvChannelBindings value is %d bytes, want 16", len(cb))
+	}
+	if !bytes.Equal(cb, make([]byte, 16)) {
+		t.Errorf("MsvAvChannelBindings = % x, want 16 zero bytes when no bindings were supplied", cb)
+	}
+
+	// The EOL marker must still terminate the list, after the inserted pairs.
+	eol, ok := offsets[avpair.MsvAvEOL]
+	if !ok {
+		t.Fatal("blob TargetInfo has no MsvAvEOL terminator")
+	}
+	if offsets[avpair.MsvAvChannelBindings] >= eol {
+		t.Error("MsvAvChannelBindings appears at or after the EOL marker")
+	}
+
+	// The server's own pairs must survive unchanged alongside the insertions.
+	for _, id := range []avpair.AvId{
+		avpair.MsvAvNbDomainName,
+		avpair.MsvAvNbComputerName,
+		avpair.MsvAvDnsDomainName,
+		avpair.MsvAvDnsComputerName,
+	} {
+		if _, ok := values[id]; !ok {
+			t.Errorf("server AV_PAIR %s was dropped from the blob", id)
+		}
+	}
+}
+
+// TestBlobChannelBindingsPrecedeTargetName pins the ordering a Windows client uses:
+// the channel-bindings pair comes before the SPN pair.
+func TestBlobChannelBindingsPrecedeTargetName(t *testing.T) {
+	serverInfo, err := targetinfo.BuildServerTargetInfo("DC01", "TMP", "dc01.tmp.local", "tmp.local", nil)
+	if err != nil {
+		t.Fatalf("BuildServerTargetInfo: %v", err)
+	}
+
+	offsets, _ := avPairOffsets(t, targetinfo.BuildBlobTargetInfo(serverInfo))
+
+	spn, ok := offsets[avpair.MsvAvTargetName]
+	if !ok {
+		t.Skip("no MsvAvTargetName inserted, so there is no ordering to check")
+	}
+	if offsets[avpair.MsvAvChannelBindings] >= spn {
+		t.Errorf("MsvAvChannelBindings at %d, want before MsvAvTargetName at %d",
+			offsets[avpair.MsvAvChannelBindings], spn)
+	}
+}

--- a/crypto/spnego/ntlm/targetinfo/targetinfo.go
+++ b/crypto/spnego/ntlm/targetinfo/targetinfo.go
@@ -69,6 +69,11 @@ func GetTimestamp(targetInfo []byte) []byte {
 	return ts
 }
 
+// channelBindingsLength is the size of an MsvAvChannelBindings value: the MD5 hash
+// of a gss_channel_bindings_struct, or all zeroes when the application supplied no
+// bindings ([MS-NLMP] 2.2.2.1).
+const channelBindingsLength = 16
+
 // BuildBlobTargetInfo constructs the modified TargetInfo to embed in the NTLMv2 blob.
 //
 // It copies all AVPairs from the challenge TargetInfo and, when a DNS computer name
@@ -94,6 +99,17 @@ func BuildBlobTargetInfo(targetInfo []byte) []byte {
 		avLen := binary.LittleEndian.Uint16(targetInfo[i+2 : i+4])
 
 		if currentID == avpair.MsvAvEOL {
+			// Insert MsvAvChannelBindings before EOL. A client with no application-
+			// supplied channel bindings sends the pair with an all-zero 16-byte
+			// value, which is what a Windows client emits; omitting the pair
+			// entirely is what a server enforcing channel binding (EPA) rejects
+			// (MS-NLMP 3.2.5.1.2).
+			hdr := make([]byte, 4)
+			binary.LittleEndian.PutUint16(hdr[0:2], uint16(avpair.MsvAvChannelBindings))
+			binary.LittleEndian.PutUint16(hdr[2:4], channelBindingsLength)
+			result = append(result, hdr...)
+			result = append(result, make([]byte, channelBindingsLength)...)
+
 			// Insert MsvAvTargetName (SPN) before EOL, then append EOL.
 			if len(targetName) > 0 {
 				hdr := make([]byte, 4)


### PR DESCRIPTION
### Linked Issue
`Closes #1202`

### Root Cause
`BuildBlobTargetInfo` was written to solve one specific interop problem — a Windows Server that rejected the authentication without an `MsvAvTargetName` (SPN) AV_PAIR — and it inserts exactly that one pair before the `MsvAvEOL` marker. The other pairs a Windows client contributes to the blob were never added. `MsvAvChannelBindings` had a defined AvId (`avpair/avid.go` L57) and a `String()` case, and no writer anywhere in the repository.

The consequence is not cosmetic. [MS-NLMP] 3.2.5.1.2: *"Else If ApplicationRequiresCBT == TRUE: If the AUTHENTICATE_MESSAGE does not contain a nonzero MsvAvChannelBindings AV_PAIR, the server MUST return GSS_S_BAD_BINDINGS."* A server with Extended Protection for Authentication enabled refuses the client outright, whatever the credentials.

### Fix Description
Emit the pair with an all-zero 16-byte value — what a Windows client sends when the application supplies no channel bindings — inserted before the SPN pair and ahead of the `MsvAvEOL` terminator, matching the order a Windows client uses.

Sixteen zero bytes is the correct value here rather than a placeholder: the field carries the MD5 hash of a `gss_channel_bindings_struct`, and the all-zero value is the defined encoding for "no bindings supplied". Plumbing real bindings through from the application is a separate, larger change (there is no API surface for them today) and is deliberately not attempted here; this fix makes the EPA-required pair present, which is what unblocks those servers.

The `channelBindingsLength` constant names the 16 so the header length and the value length cannot drift apart.

### How Verified
**Runtime, against a live Windows Server 2025 domain controller** with signing required. The pair changes the NTLMv2 blob, which is covered by the `NTProofStr`, so a malformed insertion breaks authentication immediately:

```
server SecurityMode   = SIGNING_ENABLED|SIGNING_REQUIRED
session SigningActive = true
session key length    = 16
tree connect IPC$ OK (signed round trip)
tree disconnect + logoff OK
```

The full SMB2 matrix (`QueryDirectory`, `QuerySecurityDescriptor`, `Read`, multi-credit `Write`, 1 MiB `Read`) also passes. An EPA-enforcing server was not available to test the positive case; what is verified is that the pair is emitted with the correct encoding and that a non-EPA server is unaffected.

**Tests.** With the insertion removed, the guard fails:

```
--- FAIL: TestBlobCarriesChannelBindings
    blob TargetInfo carries no MsvAvChannelBindings AV_PAIR
```

`go build ./...`, `go vet ./crypto/...`, `go test ./crypto/... ./network/smb/...` all clean.

### Test Coverage
**Added** — `crypto/spnego/ntlm/targetinfo/channel_bindings_test.go`:
- `TestBlobCarriesChannelBindings` — asserts the pair is present, is exactly 16 bytes, is all-zero, sits before the EOL marker, and — importantly — that the four server-supplied pairs still survive the insertion, since this function rebuilds the list rather than appending to it.
- `TestBlobChannelBindingsPrecedeTargetName` — pins the Windows ordering relative to the SPN pair.
- An `avPairOffsets` helper walks the list recording offsets, so ordering is assertable rather than just presence; it also fails loudly on an AV_PAIR whose declared length runs past the buffer.

### Scope of Change
- **Files changed:** `crypto/spnego/ntlm/targetinfo/targetinfo.go`, `crypto/spnego/ntlm/targetinfo/channel_bindings_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
The blob is an input to the `NTProofStr`, so this changes the bytes of every NTLMv2 authentication. The server recomputes over the AV pairs as received, so a correctly-formed addition is transparent to it — confirmed live against a signing-required DC. Servers that do not require channel binding ignore the pair.

### Notes
This is the last independently shippable item of the NTLM emission cluster. Of the five identified, four are now fixed (#1194, #1196, #1199, #1202); the fifth, the MIC (#1198), is blocked on SPNEGO `mechListMIC` support (#1201) — emitting an NTLM MIC makes a Windows DC answer `accept-incomplete` with its own `mechListMIC` and hold the context open, which needs a third session-setup leg that neither SMB state machine can represent.