### PR TITLE
Claim FILE_UNICODE_ON_DISK in the SMB1 server's FileSystemAttributes (Fixes #1206)

### DIFF
--- a/network/smb/smb_v10/server/fsattributes_test.go
+++ b/network/smb/smb_v10/server/fsattributes_test.go
@@ -1,0 +1,91 @@
+package server
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+// TestFsAttributeInfoClaimsUnicodeOnDisk guards the defect: the server reported
+// only FILE_CASE_PRESERVED_NAMES, so a client was told the volume could not store
+// Unicode names. It can — a UTF-16LE name from a third-party client round-trips
+// through the server intact — so withholding the bit made clients avoid names the
+// server would have stored correctly.
+func TestFsAttributeInfoClaimsUnicodeOnDisk(t *testing.T) {
+	volume := VolumeInfo{
+		Label:                    "FILES",
+		FileSystemName:           "NTFS",
+		SerialNumber:             0x11223344,
+		BytesPerSector:           512,
+		SectorsPerAllocationUnit: 8,
+	}
+
+	for _, unicode := range []bool{false, true} {
+		info, served := encodeVolumeInformation(smbQueryFsAttributeInfo, volume, unicode)
+		if !served {
+			t.Fatalf("unicode=%v: SMB_QUERY_FS_ATTRIBUTE_INFO not served", unicode)
+		}
+		if len(info) < 12 {
+			t.Fatalf("unicode=%v: response is %d bytes, want at least 12", unicode, len(info))
+		}
+
+		attrs := binary.LittleEndian.Uint32(info[0:4])
+		if attrs&fileUnicodeOnDisk == 0 {
+			t.Errorf("unicode=%v: FileSystemAttributes = %#08x, missing FILE_UNICODE_ON_DISK", unicode, attrs)
+		}
+		if attrs&fileCasePreservedNames == 0 {
+			t.Errorf("unicode=%v: FileSystemAttributes = %#08x, missing FILE_CASE_PRESERVED_NAMES", unicode, attrs)
+		}
+		if attrs != serverFileSystemAttributes {
+			t.Errorf("unicode=%v: FileSystemAttributes = %#08x, want %#08x", unicode, attrs, serverFileSystemAttributes)
+		}
+
+		// MaxFileNameLengthInBytes, then the name length and the name itself.
+		if got := binary.LittleEndian.Uint32(info[4:8]); got != MaxPathComponentLength {
+			t.Errorf("unicode=%v: MaxFileNameLengthInBytes = %d, want %d", unicode, got, MaxPathComponentLength)
+		}
+		nameLen := int(binary.LittleEndian.Uint32(info[8:12]))
+		if 12+nameLen != len(info) {
+			t.Errorf("unicode=%v: declared name length %d does not match the %d trailing bytes", unicode, nameLen, len(info)-12)
+		}
+	}
+}
+
+// TestServerFileSystemAttributesClaimsNothingUnimplemented is the counterweight: it
+// fails if a bit is ever added for a feature the server does not implement. Claiming
+// one is worse than claiming none, because a client then uses it and the follow-up
+// request is refused.
+func TestServerFileSystemAttributesClaimsNothingUnimplemented(t *testing.T) {
+	const (
+		fileCaseSensitiveSearch   uint32 = 0x00000001
+		filePersistentACLs        uint32 = 0x00000008
+		fileFileCompression       uint32 = 0x00000010
+		fileVolumeQuotas          uint32 = 0x00000020
+		fileSupportsSparseFiles   uint32 = 0x00000040
+		fileSupportsReparsePoints uint32 = 0x00000080
+		fileSupportsObjectIDs     uint32 = 0x00010000
+		fileSupportsEncryption    uint32 = 0x00020000
+		fileNamedStreams          uint32 = 0x00040000
+		fileSupportsHardLinks     uint32 = 0x00400000
+		fileSupportsExtendedAttrs uint32 = 0x00800000
+	)
+
+	unimplemented := map[string]uint32{
+		"FILE_CASE_SENSITIVE_SEARCH":        fileCaseSensitiveSearch,
+		"FILE_PERSISTENT_ACLS":              filePersistentACLs,
+		"FILE_FILE_COMPRESSION":             fileFileCompression,
+		"FILE_VOLUME_QUOTAS":                fileVolumeQuotas,
+		"FILE_SUPPORTS_SPARSE_FILES":        fileSupportsSparseFiles,
+		"FILE_SUPPORTS_REPARSE_POINTS":      fileSupportsReparsePoints,
+		"FILE_SUPPORTS_OBJECT_IDS":          fileSupportsObjectIDs,
+		"FILE_SUPPORTS_ENCRYPTION":          fileSupportsEncryption,
+		"FILE_NAMED_STREAMS":                fileNamedStreams,
+		"FILE_SUPPORTS_HARD_LINKS":          fileSupportsHardLinks,
+		"FILE_SUPPORTS_EXTENDED_ATTRIBUTES": fileSupportsExtendedAttrs,
+	}
+
+	for name, bit := range unimplemented {
+		if serverFileSystemAttributes&bit != 0 {
+			t.Errorf("serverFileSystemAttributes claims %s, which this server does not implement", name)
+		}
+	}
+}

--- a/network/smb/smb_v10/server/infolevels.go
+++ b/network/smb/smb_v10/server/infolevels.go
@@ -42,6 +42,33 @@ const (
 	smbQueryFsAttributeInfo = 0x0105
 )
 
+// FileSystemAttributes bits reported by SMB_QUERY_FS_ATTRIBUTE_INFO ([MS-FSCC]
+// 2.5.1). Only the bits this server honours are named; the rest are deliberately
+// absent rather than defined-and-unused.
+const (
+	// fileCasePreservedNames: the volume stores the case of a name as given.
+	fileCasePreservedNames uint32 = 0x00000002
+
+	// fileUnicodeOnDisk: the volume stores names in Unicode. The server decodes a
+	// request name and re-encodes it per message, so a UTF-16LE name is carried
+	// and returned intact whatever the backend stores it as.
+	fileUnicodeOnDisk uint32 = 0x00000004
+)
+
+// serverFileSystemAttributes is the set this server claims.
+//
+// It is deliberately far short of what a real NTFS volume reports — a Windows
+// Server 2012 R2 volume reports 0x00C700FF — because the remaining bits stand for
+// features this server does not implement: compression, quotas, sparse files,
+// reparse points, encryption, object IDs and named streams. Claiming a capability
+// the server lacks is worse than claiming none, since a client then uses it and
+// the follow-up request is refused. Each bit becomes claimable when the feature
+// behind it exists.
+//
+// FILE_CASE_SENSITIVE_SEARCH is likewise withheld: path resolution here is
+// case-insensitive.
+const serverFileSystemAttributes = fileCasePreservedNames | fileUnicodeOnDisk
+
 // bothDirectoryInfoFixedSize is the fixed part of an
 // SMB_FIND_FILE_BOTH_DIRECTORY_INFO entry, before its variable-length name.
 const bothDirectoryInfoFixedSize = 94
@@ -366,12 +393,9 @@ func encodeVolumeInformation(level uint16, volume VolumeInfo, unicode bool) ([]b
 		// FileSystemAttributes(4) MaxFileNameLengthInBytes(4)
 		// LengthOfFileSystemName(4) FileSystemName(variable).
 		//
-		// Only case-preserving names are claimed. Claiming a capability the
-		// storage does not have — unicode-on-disk, compression, quotas — is worse
-		// than claiming none, because a client then uses it.
 		name := encodeWireString(volume.FileSystemName, unicode)
 		info := make([]byte, 12)
-		binary.LittleEndian.PutUint32(info[0:4], 0x00000002) // FILE_CASE_PRESERVED_NAMES
+		binary.LittleEndian.PutUint32(info[0:4], serverFileSystemAttributes)
 		binary.LittleEndian.PutUint32(info[4:8], MaxPathComponentLength)
 		binary.LittleEndian.PutUint32(info[8:12], uint32(len(name)))
 		return append(info, name...), true


### PR DESCRIPTION
### Linked Issue
`Closes #1206`

### Root Cause
The attribute set was chosen conservatively, on a stated principle:

```go
// Only case-preserving names are claimed. Claiming a capability the
// storage does not have — unicode-on-disk, compression, quotas — is worse
// than claiming none, because a client then uses it.
```

The principle is right and this PR keeps it. The *premise* was wrong for one of the three examples. Unicode-on-disk is not a property of the storage backend here: the server decodes a request name and re-encodes it per message, so a UTF-16LE name is carried and returned intact whatever the backend stores it as. The bit was withheld on the assumption that it depended on the backend, and it does not.

### Fix Description
Add `FILE_UNICODE_ON_DISK`, so the reported set becomes `0x00000006`. Nothing else changes.

`FILE_CASE_SENSITIVE_SEARCH` stays withheld because path resolution here is case-insensitive, and compression, quotas, sparse files, reparse points, encryption, object IDs, named streams, hard links and extended attributes stay withheld because none is implemented.

Adopting the real NTFS value wholesale was explicitly rejected. A live Windows Server 2012 R2 volume reports `0x00C700FF`, and that number is now recorded in a comment for whenever those features exist — but setting it today would claim nine capabilities the server does not have, and Explorer does query stream and reparse information. That would trade a passive mismatch for active request failures.

The bits also gain names. The word was a bare `0x00000002` literal and no `FILE_*` FileSystemAttributes constants existed anywhere in the tree, which is what made the set hard to review against [MS-FSCC] 2.5.1 in the first place.

### How Verified
**Runtime, third-party client against this server.** This repository's SMB 1.0 server was run on loopback with an in-memory share and driven from `smbclient` forced to NT1, which negotiates Unicode:

```
smbclient -c 'mkdir "unicode_éàü"; ls'
  plain.txt                           N        6  Wed Sep  9 11:41:56 2026
  unicode_éàü                         D        0  Wed Sep  9 11:41:56 2026
```

The name travelled as UTF-16LE, was decoded, stored, and re-encoded on the way back unchanged — which is the capability the bit describes, established by a client that shares none of this implementation's assumptions.

**Tests.** With the bit removed the guard fails on both encodings:

```
--- FAIL: TestFsAttributeInfoClaimsUnicodeOnDisk
    unicode=false: FileSystemAttributes = 0x00000002, missing FILE_UNICODE_ON_DISK
    unicode=true:  FileSystemAttributes = 0x00000002, missing FILE_UNICODE_ON_DISK
```

`go build ./...`, `go vet ./network/smb/smb_v10/server/` and `go test ./network/smb/...` are clean.

### Test Coverage
**Added** — `network/smb/smb_v10/server/fsattributes_test.go`:
- `TestFsAttributeInfoClaimsUnicodeOnDisk` — checks the emitted word under both OEM and Unicode encodings, and that the declared name length matches the trailing bytes.
- `TestServerFileSystemAttributesClaimsNothingUnimplemented` — the counterweight, and the more valuable of the two: it enumerates the eleven bits standing for unimplemented features and fails if any is ever added to the set. This encodes the principle from the original comment as something a future change has to argue with, rather than a comment it can quietly contradict.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/server/infolevels.go`, `network/smb/smb_v10/server/fsattributes_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
One bit in one information level. The direction is from under-claiming to accurate, so a client that previously avoided Unicode names may now use them — which the run above shows the server handles. Safe to merge.

### Notes
The measured Windows value (`0x00C700FF`, `MaxFileNameLength` 255, `FileSystemName` "NTFS") came from a live Windows Server 2012 R2 Standard 9600 and is the reference for the remaining bits. Full parity on this field is gated on implementing the features behind them, which is protocol-completeness work rather than a fix to this response.