### PR TITLE
Replace the SMB1 server's NativeOS/NativeLanMan defaults (Fixes #1209)

### DIFF
--- a/network/smb/smb_v10/server/identity_test.go
+++ b/network/smb/smb_v10/server/identity_test.go
@@ -1,0 +1,65 @@
+package server
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestDefaultIdentityIsWindowsPlausible guards the change away from "Unix" and
+// "Manticore". These two strings are returned in every SESSION_SETUP_ANDX response,
+// so a default-configured server described itself by naming this project — the most
+// direct identification available to anyone observing a session.
+func TestDefaultIdentityIsWindowsPlausible(t *testing.T) {
+	// Non-empty is the original constraint: a strict client rejects a session setup
+	// whose native strings are empty.
+	if DefaultNativeOS == "" {
+		t.Error("DefaultNativeOS is empty; strict clients reject the session setup")
+	}
+	if DefaultNativeLanMan == "" {
+		t.Error("DefaultNativeLanMan is empty; strict clients reject the session setup")
+	}
+
+	// No default may name this project or another implementation.
+	for _, banned := range []string{"Manticore", "manticore", "Samba", "Unix", "Go", "golang"} {
+		for field, value := range map[string]string{
+			"DefaultNativeOS":     DefaultNativeOS,
+			"DefaultNativeLanMan": DefaultNativeLanMan,
+		} {
+			if strings.Contains(value, banned) {
+				t.Errorf("%s = %q contains %q", field, value, banned)
+			}
+		}
+	}
+
+	// The pair must describe the same product, the way Windows does: one field
+	// carries the build number and the other the major.minor version.
+	if !strings.HasPrefix(DefaultNativeOS, "Windows ") {
+		t.Errorf("DefaultNativeOS = %q, want a Windows product string", DefaultNativeOS)
+	}
+	if !strings.HasPrefix(DefaultNativeLanMan, "Windows ") {
+		t.Errorf("DefaultNativeLanMan = %q, want a Windows product string", DefaultNativeLanMan)
+	}
+}
+
+// TestNewServerAppliesIdentityDefaults checks the defaults actually reach the
+// configuration, and that an operator-supplied value is preserved.
+func TestNewServerAppliesIdentityDefaults(t *testing.T) {
+	srv, err := NewServer(Config{})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	if got := srv.config.NativeOS; got != DefaultNativeOS {
+		t.Errorf("NativeOS = %q, want the default %q", got, DefaultNativeOS)
+	}
+	if got := srv.config.NativeLanMan; got != DefaultNativeLanMan {
+		t.Errorf("NativeLanMan = %q, want the default %q", got, DefaultNativeLanMan)
+	}
+
+	custom, err := NewServer(Config{NativeOS: "Windows Server 2019 Standard 17763", NativeLanMan: "Windows Server 2019 Standard 10.0"})
+	if err != nil {
+		t.Fatalf("NewServer with overrides: %v", err)
+	}
+	if got := custom.config.NativeOS; got != "Windows Server 2019 Standard 17763" {
+		t.Errorf("operator NativeOS was overwritten: got %q", got)
+	}
+}

--- a/network/smb/smb_v10/server/server.go
+++ b/network/smb/smb_v10/server/server.go
@@ -110,10 +110,18 @@ type Config struct {
 
 // Configuration defaults applied by NewServer when a field is left zero.
 const (
-	// DefaultNativeOS and DefaultNativeLanMan are informational only, but must
-	// be non-empty for strict clients to accept the session setup.
-	DefaultNativeOS     = "Unix"
-	DefaultNativeLanMan = "Manticore"
+	// DefaultNativeOS and DefaultNativeLanMan are informational only ([MS-CIFS]
+	// 2.2.4.53.2), but must be non-empty for strict clients to accept the session
+	// setup, and they are returned in every SESSION_SETUP_ANDX response — which
+	// makes them the most direct description of this server available to anyone
+	// observing a session.
+	//
+	// The pair below is what a Windows Server 2012 R2 Standard 9600 returns, and
+	// is self-consistent in the way Windows makes it: the same product name, with
+	// the build number in one field and the major.minor version in the other.
+	// Override both through Config for a different identity.
+	DefaultNativeOS     = "Windows Server 2012 R2 Standard 9600"
+	DefaultNativeLanMan = "Windows Server 2012 R2 Standard 6.3"
 
 	// DefaultMaxBufferSize is what Windows offers. [MS-CIFS] 2.2.4.52.2 requires
 	// a multiple of 4 and suggests at least 4356.


### PR DESCRIPTION
### Linked Issue
`Closes #1209`

### Root Cause
The defaults had to be non-empty — a strict client rejects a session setup whose native strings are blank — and satisfying that constraint was the only requirement applied when they were chosen. Their *content* was never revisited, so `"Unix"` and `"Manticore"` persisted into every SESSION_SETUP_ANDX response a default-configured server sends.

Two separate problems in one pair: `"Manticore"` names this project outright, and `"Unix"` is the string Samba sends, so the server also identified itself as a different implementation than it is.

### Fix Description
Use the pair a live Windows Server 2012 R2 Standard 9600 returns:

| Field | Value |
|---|---|
| `NativeOS` | `Windows Server 2012 R2 Standard 9600` |
| `NativeLanMan` | `Windows Server 2012 R2 Standard 6.3` |

These were read from a real host rather than composed, which matters because the pair has internal structure that is easy to get wrong when inventing it: the same product name appears in both, with the build number in one field and the major.minor version in the other. Two independently plausible strings that disagree about the product would be its own tell.

Both fields are informational ([MS-CIFS] 2.2.4.53.2), so no client behaviour depends on the content, and both remain overridable through `Config.NativeOS` / `Config.NativeLanMan` — only the defaults change.

### How Verified
**Tests.** `TestDefaultIdentityIsWindowsPlausible` asserts the defaults are non-empty (the original constraint, previously unguarded), name neither this project nor another implementation, and both describe a Windows product. `TestNewServerAppliesIdentityDefaults` confirms the defaults reach the configuration and that an operator-supplied value is not overwritten.

**Interop.** This server was run on loopback and driven from `smbclient` forced to NT1; session setup is accepted and the share is usable, so the new strings do not disturb the exchange.

`go build ./...` and `go test ./network/smb/...` are clean.

**Not verified:** I did not read the strings back out of the wire with a third-party tool. `nmap`'s `smb-os-discovery` — which is how the reference values were obtained from the real 2012 R2 host — has a portrule bound to 445/139 and does not fire on the unprivileged port the test server uses, and `smbclient -d 5` does not print the server's native strings. The values are asserted by unit test and the session-setup path is covered by the interop run above.

### Test Coverage
**Added** — `network/smb/smb_v10/server/identity_test.go`:
- `TestDefaultIdentityIsWindowsPlausible` — the substantive guard. It checks the non-empty constraint *and* screens both defaults against `Manticore`, `Samba`, `Unix`, `Go` and `golang`, so reintroducing a tool name fails rather than passing quietly.
- `TestNewServerAppliesIdentityDefaults` — defaults applied, overrides preserved.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/server/server.go`, `network/smb/smb_v10/server/identity_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Two informational string constants. Nothing branches on them, and any deployment that cares already sets them through `Config`. Safe to merge.

### Notes
The client side is unchanged and still carries the equivalent problem: `network/smb/smb_v10/client/client_structures.go` defaults to `"Unix"`/`"Samba"`, and the generic client at `network/smb/client/client.go` and `negotiate.go` overrides both to `"Manticore"`. That is a separate change against the client, filed separately, and it is the more visible of the two since it is what an outbound connection announces.