### PR TITLE
Report FILE_ATTRIBUTE_ARCHIVE for regular files (Fixes #1210)

### DIFF
--- a/network/smb/smb_v10/server/archive_attribute_test.go
+++ b/network/smb/smb_v10/server/archive_attribute_test.go
@@ -1,0 +1,83 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/windows/fileflags"
+)
+
+// TestAttributesForSetsArchiveOnFiles guards the change: every regular file now
+// carries FILE_ATTRIBUTE_ARCHIVE, as Windows reports, and no entry is described as
+// FILE_ATTRIBUTE_NORMAL — which is valid only when it stands alone ([MS-FSCC] 2.6)
+// and now has no entry left to describe.
+func TestAttributesForSetsArchiveOnFiles(t *testing.T) {
+	tests := []struct {
+		name string
+		attr FileAttr
+		want uint32
+	}{
+		{
+			name: "regular file",
+			attr: FileAttr{Name: "plain.txt"},
+			want: fileflags.FILE_ATTRIBUTE_ARCHIVE,
+		},
+		{
+			name: "read-only file",
+			attr: FileAttr{Name: "ro.txt", ReadOnly: true},
+			want: fileflags.FILE_ATTRIBUTE_ARCHIVE | fileflags.FILE_ATTRIBUTE_READONLY,
+		},
+		{
+			name: "directory carries no archive bit",
+			attr: FileAttr{Name: "subdir", IsDir: true},
+			want: fileflags.FILE_ATTRIBUTE_DIRECTORY,
+		},
+		{
+			name: "read-only directory",
+			attr: FileAttr{Name: "rodir", IsDir: true, ReadOnly: true},
+			want: fileflags.FILE_ATTRIBUTE_DIRECTORY | fileflags.FILE_ATTRIBUTE_READONLY,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := attributesFor(tt.attr)
+			if got != tt.want {
+				t.Errorf("attributesFor = %#08x, want %#08x", got, tt.want)
+			}
+			if got&fileflags.FILE_ATTRIBUTE_NORMAL != 0 {
+				t.Errorf("attributesFor = %#08x, which sets FILE_ATTRIBUTE_NORMAL alongside other bits", got)
+			}
+		})
+	}
+}
+
+// TestLegacyAttributesAgreeWithExtended checks the 16-bit and 32-bit views of the
+// same entry describe it the same way. They are computed by separate functions, so
+// they can drift apart; the archive bit is the case where they just did.
+func TestLegacyAttributesAgreeWithExtended(t *testing.T) {
+	for _, attr := range []FileAttr{
+		{Name: "plain.txt"},
+		{Name: "ro.txt", ReadOnly: true},
+		{Name: "subdir", IsDir: true},
+		{Name: "rodir", IsDir: true, ReadOnly: true},
+	} {
+		extended := attributesFor(attr)
+		legacy := legacyAttributesFor(attr)
+
+		if (extended&fileflags.FILE_ATTRIBUTE_ARCHIVE != 0) != (legacy&smbFileAttributeArchive != 0) {
+			t.Errorf("%q: archive bit differs (extended %#08x, legacy %#04x)", attr.Name, extended, legacy)
+		}
+		if (extended&fileflags.FILE_ATTRIBUTE_DIRECTORY != 0) != (legacy&smbFileAttributeDirectory != 0) {
+			t.Errorf("%q: directory bit differs (extended %#08x, legacy %#04x)", attr.Name, extended, legacy)
+		}
+		if (extended&fileflags.FILE_ATTRIBUTE_READONLY != 0) != (legacy&smbFileAttributeReadOnly != 0) {
+			t.Errorf("%q: read-only bit differs (extended %#08x, legacy %#04x)", attr.Name, extended, legacy)
+		}
+
+		// The legacy field reserves 0x0080; the extended NORMAL value must never
+		// leak into it.
+		if legacy&0x0080 != 0 {
+			t.Errorf("%q: legacy attributes %#04x set the reserved 0x0080 bit", attr.Name, legacy)
+		}
+	}
+}

--- a/network/smb/smb_v10/server/handler_file.go
+++ b/network/smb/smb_v10/server/handler_file.go
@@ -272,18 +272,26 @@ func createActionFor(existed bool, flags OpenFlags) uint32 {
 }
 
 // attributesFor renders a backend's view of an entry as the attribute bits a
-// client expects. FILE_ATTRIBUTE_NORMAL is only meaningful alone, so it is used
-// when nothing else applies.
+// client expects.
+//
+// A regular file carries FILE_ATTRIBUTE_ARCHIVE, as Windows reports for
+// essentially every file. The bit means "modified since the last backup"; no
+// backend here records a backup and none can clear the bit, so set is the
+// accurate value rather than a guess. Windows does not set it on directories and
+// neither does this.
+//
+// FILE_ATTRIBUTE_NORMAL is not used: it is valid only when it stands alone
+// ([MS-FSCC] 2.6), and with the archive bit on every file and the directory bit
+// on every directory there is no entry left for it to describe.
 func attributesFor(attr FileAttr) uint32 {
 	attributes := uint32(0)
 	if attr.IsDir {
 		attributes |= fileflags.FILE_ATTRIBUTE_DIRECTORY
+	} else {
+		attributes |= fileflags.FILE_ATTRIBUTE_ARCHIVE
 	}
 	if attr.ReadOnly {
 		attributes |= fileflags.FILE_ATTRIBUTE_READONLY
-	}
-	if attributes == 0 {
-		attributes = fileflags.FILE_ATTRIBUTE_NORMAL
 	}
 	return attributes
 }

--- a/network/smb/smb_v10/server/handler_legacy_info.go
+++ b/network/smb/smb_v10/server/handler_legacy_info.go
@@ -27,10 +27,16 @@ const (
 )
 
 // legacyAttributesFor renders what the backend reported as SMB_FILE_ATTRIBUTES.
+//
+// A regular file carries the archive bit here too, so the 16-bit and 32-bit views
+// of the same entry agree. SMB_FILE_ATTRIBUTE_NORMAL is 0x0000, the absence of
+// every bit, so it remains the starting value rather than a bit to set.
 func legacyAttributesFor(attr FileAttr) uint16 {
 	attributes := uint16(smbFileAttributeNormal)
 	if attr.IsDir {
 		attributes |= smbFileAttributeDirectory
+	} else {
+		attributes |= smbFileAttributeArchive
 	}
 	if attr.ReadOnly {
 		attributes |= smbFileAttributeReadOnly


### PR DESCRIPTION
### Linked Issue
`Closes #1210`

### Root Cause
`attributesFor` was written from the two states the backend interface models — `IsDir` and `ReadOnly` — with `FILE_ATTRIBUTE_NORMAL` as the fallback when neither applied. The archive bit is not a backend state, so it had nowhere to come from in that design and was simply absent.

`FileAttr` carries `Name`, `IsDir`, `Size`, `AllocationSize` and `ReadOnly`, so no backend can express an archive bit and none can clear one. That is what makes setting it unconditionally correct rather than a guess: the bit means "modified since the last backup", and nothing in this server performs or records a backup, so the bit's true value is always set.

### Fix Description
A regular file now carries `FILE_ATTRIBUTE_ARCHIVE`. Directories do not, matching Windows.

`FILE_ATTRIBUTE_NORMAL` is dropped rather than kept as a fallback. It is valid only when it stands alone ([MS-FSCC] 2.6), and with the archive bit on every file and the directory bit on every directory there is no entry left for it to describe — keeping it would have left dead code guarded by a condition that can no longer hold.

The 16-bit `SMB_FILE_ATTRIBUTES` view is updated in step. That is the part worth reviewing: `legacyAttributesFor` is a *separate* function computing a *different* encoding of the same entry, and `smbFileAttributeArchive` was already defined there and unused — so the two views had the same gap and could have been fixed apart. In the legacy encoding `SMB_FILE_ATTRIBUTE_NORMAL` is `0x0000`, the absence of every bit, so it correctly remains the starting value rather than a bit to set, and the extended form's `0x0080` must never leak into that field.

`attributesFor` feeds six emission sites — find entries, two native information classes, the NT_CREATE response and the legacy subcommands — so the change is made once and applies consistently. The named-pipe open path (`handler_pipe.go`) is untouched: a pipe is not a file on a volume and Windows reports `NORMAL` for it.

### How Verified
**Runtime, third-party client against this server.** Driving the server from `smbclient` forced to NT1, before and after.

Before:

```
plain.txt                           N        6  Wed Sep  9 11:41:56 2026
unicode_éàü                         D        0  Wed Sep  9 11:41:56 2026
```

After:

```
plain.txt                           A        6  Wed Sep  9 11:46:39 2026
unicode_éàü                         D        0  Wed Sep  9 11:46:39 2026
```

`A` is what a Windows server produces for the same file, and the directory still reports `D` alone.

**Reference.** A live Windows Server 2012 R2 Standard 9600 reports `0x20` for `C:\Windows\win.ini`, queried through `TRANS2_QUERY_PATH_INFORMATION`.

**Tests.** With the archive bit removed, the guards fail and show the exact values:

```
--- FAIL: TestAttributesForSetsArchiveOnFiles/regular_file
    attributesFor = 0x00000000, want 0x00000020
--- FAIL: TestAttributesForSetsArchiveOnFiles/read-only_file
    attributesFor = 0x00000001, want 0x00000021
--- FAIL: TestLegacyAttributesAgreeWithExtended
```

`go build ./...`, `go vet ./network/smb/smb_v10/server/` and `go test ./network/smb/...` are clean.

### Test Coverage
**Added** — `network/smb/smb_v10/server/archive_attribute_test.go`:
- `TestAttributesForSetsArchiveOnFiles` — four cases (file, read-only file, directory, read-only directory) asserting the exact word, plus that `FILE_ATTRIBUTE_NORMAL` never appears alongside another bit.
- `TestLegacyAttributesAgreeWithExtended` — the more useful of the two: it cross-checks the 16-bit and 32-bit encodings agree on archive, directory and read-only for the same entry, and that the legacy field never sets the reserved `0x0080`. Since the two are computed by separate functions, this is what stops them drifting apart again.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/server/handler_file.go`, `network/smb/smb_v10/server/handler_legacy_info.go`, `network/smb/smb_v10/server/archive_attribute_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Every file this server describes gains one attribute bit, across all six emission sites. Nothing in the server branches on the archive bit, and a client that ignores it is unaffected; a client that reads it now gets the Windows-consistent answer. Safe to merge.