### PR TITLE
Route samr status reporting through nt_status (Refs #1219)

### DIFF
--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/00_SamrConnect.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/00_SamrConnect.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -34,8 +35,8 @@ func SamrConnect(rpc ndr.Invoker, serverName string, desiredAccess uint32) (mssa
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return mssamr.SAMPR_HANDLE{}, fmt.Errorf("SamrConnect: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.Handle, fmt.Errorf("SamrConnect failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Handle, fmt.Errorf("SamrConnect failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Handle, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/01_SamrCloseHandle.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/01_SamrCloseHandle.go
@@ -10,6 +10,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -29,8 +30,8 @@ func SamrCloseHandle(rpc ndr.Invoker, handle mssamr.SAMPR_HANDLE) (mssamr.SAMPR_
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return handle, fmt.Errorf("SamrCloseHandle: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.Handle, fmt.Errorf("SamrCloseHandle failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Handle, fmt.Errorf("SamrCloseHandle failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Handle, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/02_SamrSetSecurityObject.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/02_SamrSetSecurityObject.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -36,8 +37,8 @@ func SamrSetSecurityObject(rpc ndr.Invoker, handle mssamr.SAMPR_HANDLE, security
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("SamrSetSecurityObject: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return fmt.Errorf("SamrSetSecurityObject failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return fmt.Errorf("SamrSetSecurityObject failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/03_SamrQuerySecurityObject.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/03_SamrQuerySecurityObject.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -41,8 +42,8 @@ func SamrQuerySecurityObject(rpc ndr.Invoker, handle mssamr.SAMPR_HANDLE, securi
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return nil, fmt.Errorf("SamrQuerySecurityObject: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.SecurityDescriptor, fmt.Errorf("SamrQuerySecurityObject failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.SecurityDescriptor, fmt.Errorf("SamrQuerySecurityObject failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.SecurityDescriptor, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/05_SamrLookupDomainInSamServer.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/05_SamrLookupDomainInSamServer.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
@@ -44,8 +45,8 @@ func SamrLookupDomainInSamServer(rpc ndr.Invoker, handle mssamr.SAMPR_HANDLE, na
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return nil, fmt.Errorf("SamrLookupDomainInSamServer: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.DomainId, fmt.Errorf("SamrLookupDomainInSamServer failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.DomainId, fmt.Errorf("SamrLookupDomainInSamServer failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.DomainId, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/06_SamrEnumerateDomainsInSamServer.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/06_SamrEnumerateDomainsInSamServer.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -50,9 +51,8 @@ func SamrEnumerateDomainsInSamServer(rpc ndr.Invoker, handle mssamr.SAMPR_HANDLE
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return 0, nil, 0, fmt.Errorf("SamrEnumerateDomainsInSamServer: %w", err)
 	}
-	status := uint32(resp.Status)
-	if status != samr.StatusSuccess && status != samr.StatusMoreEntries {
-		return uint32(resp.EnumerationContext), resp.Buffer, uint32(resp.CountReturned), fmt.Errorf("SamrEnumerateDomainsInSamServer failed: %s", samr.StatusString(status))
+	if status := nt_status.NT_STATUS(resp.Status); status != nt_status.NT_STATUS_SUCCESS && status != nt_status.NT_STATUS_MORE_ENTRIES {
+		return uint32(resp.EnumerationContext), resp.Buffer, uint32(resp.CountReturned), fmt.Errorf("SamrEnumerateDomainsInSamServer failed: %s", status)
 	}
 	return uint32(resp.EnumerationContext), resp.Buffer, uint32(resp.CountReturned), nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/07_SamrOpenDomain.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/07_SamrOpenDomain.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
@@ -36,8 +37,8 @@ func SamrOpenDomain(rpc ndr.Invoker, serverHandle mssamr.SAMPR_HANDLE, desiredAc
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return mssamr.SAMPR_HANDLE{}, fmt.Errorf("SamrOpenDomain: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.Handle, fmt.Errorf("SamrOpenDomain failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Handle, fmt.Errorf("SamrOpenDomain failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Handle, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/08_SamrQueryInformationDomain.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/08_SamrQueryInformationDomain.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -42,8 +43,8 @@ func SamrQueryInformationDomain(rpc ndr.Invoker, domainHandle mssamr.SAMPR_HANDL
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return nil, fmt.Errorf("SamrQueryInformationDomain: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.Buffer, fmt.Errorf("SamrQueryInformationDomain failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Buffer, fmt.Errorf("SamrQueryInformationDomain failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Buffer, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/09_SamrSetInformationDomain.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/09_SamrSetInformationDomain.go
@@ -10,6 +10,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -40,8 +41,8 @@ func SamrSetInformationDomain(rpc ndr.Invoker, domainHandle mssamr.SAMPR_HANDLE,
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("SamrSetInformationDomain: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return fmt.Errorf("SamrSetInformationDomain failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return fmt.Errorf("SamrSetInformationDomain failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/10_SamrCreateGroupInDomain.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/10_SamrCreateGroupInDomain.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
@@ -45,8 +46,8 @@ func SamrCreateGroupInDomain(rpc ndr.Invoker, domainHandle mssamr.SAMPR_HANDLE, 
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return mssamr.SAMPR_HANDLE{}, 0, fmt.Errorf("SamrCreateGroupInDomain: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.GroupHandle, uint32(resp.RelativeId), fmt.Errorf("SamrCreateGroupInDomain failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.GroupHandle, uint32(resp.RelativeId), fmt.Errorf("SamrCreateGroupInDomain failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.GroupHandle, uint32(resp.RelativeId), nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/11_SamrEnumerateGroupsInDomain.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/11_SamrEnumerateGroupsInDomain.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -47,9 +48,8 @@ func SamrEnumerateGroupsInDomain(rpc ndr.Invoker, domainHandle mssamr.SAMPR_HAND
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return 0, nil, 0, fmt.Errorf("SamrEnumerateGroupsInDomain: %w", err)
 	}
-	status := uint32(resp.Status)
-	if status != samr.StatusSuccess && status != samr.StatusMoreEntries {
-		return uint32(resp.EnumerationContext), resp.Buffer, uint32(resp.CountReturned), fmt.Errorf("SamrEnumerateGroupsInDomain failed: %s", samr.StatusString(status))
+	if status := nt_status.NT_STATUS(resp.Status); status != nt_status.NT_STATUS_SUCCESS && status != nt_status.NT_STATUS_MORE_ENTRIES {
+		return uint32(resp.EnumerationContext), resp.Buffer, uint32(resp.CountReturned), fmt.Errorf("SamrEnumerateGroupsInDomain failed: %s", status)
 	}
 	return uint32(resp.EnumerationContext), resp.Buffer, uint32(resp.CountReturned), nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/12_SamrCreateUserInDomain.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/12_SamrCreateUserInDomain.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
@@ -45,8 +46,8 @@ func SamrCreateUserInDomain(rpc ndr.Invoker, domainHandle mssamr.SAMPR_HANDLE, n
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return mssamr.SAMPR_HANDLE{}, 0, fmt.Errorf("SamrCreateUserInDomain: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.UserHandle, uint32(resp.RelativeId), fmt.Errorf("SamrCreateUserInDomain failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.UserHandle, uint32(resp.RelativeId), fmt.Errorf("SamrCreateUserInDomain failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.UserHandle, uint32(resp.RelativeId), nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/13_SamrEnumerateUsersInDomain.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/13_SamrEnumerateUsersInDomain.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -50,9 +51,8 @@ func SamrEnumerateUsersInDomain(rpc ndr.Invoker, domainHandle mssamr.SAMPR_HANDL
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return 0, nil, 0, fmt.Errorf("SamrEnumerateUsersInDomain: %w", err)
 	}
-	status := uint32(resp.Status)
-	if status != samr.StatusSuccess && status != samr.StatusMoreEntries {
-		return uint32(resp.EnumerationContext), resp.Buffer, uint32(resp.CountReturned), fmt.Errorf("SamrEnumerateUsersInDomain failed: %s", samr.StatusString(status))
+	if status := nt_status.NT_STATUS(resp.Status); status != nt_status.NT_STATUS_SUCCESS && status != nt_status.NT_STATUS_MORE_ENTRIES {
+		return uint32(resp.EnumerationContext), resp.Buffer, uint32(resp.CountReturned), fmt.Errorf("SamrEnumerateUsersInDomain failed: %s", status)
 	}
 	return uint32(resp.EnumerationContext), resp.Buffer, uint32(resp.CountReturned), nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/14_SamrCreateAliasInDomain.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/14_SamrCreateAliasInDomain.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
@@ -45,8 +46,8 @@ func SamrCreateAliasInDomain(rpc ndr.Invoker, domainHandle mssamr.SAMPR_HANDLE, 
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return mssamr.SAMPR_HANDLE{}, 0, fmt.Errorf("SamrCreateAliasInDomain: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.AliasHandle, uint32(resp.RelativeId), fmt.Errorf("SamrCreateAliasInDomain failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.AliasHandle, uint32(resp.RelativeId), fmt.Errorf("SamrCreateAliasInDomain failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.AliasHandle, uint32(resp.RelativeId), nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/15_SamrEnumerateAliasesInDomain.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/15_SamrEnumerateAliasesInDomain.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -47,9 +48,8 @@ func SamrEnumerateAliasesInDomain(rpc ndr.Invoker, domainHandle mssamr.SAMPR_HAN
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return 0, nil, 0, fmt.Errorf("SamrEnumerateAliasesInDomain: %w", err)
 	}
-	status := uint32(resp.Status)
-	if status != samr.StatusSuccess && status != samr.StatusMoreEntries {
-		return uint32(resp.EnumerationContext), resp.Buffer, uint32(resp.CountReturned), fmt.Errorf("SamrEnumerateAliasesInDomain failed: %s", samr.StatusString(status))
+	if status := nt_status.NT_STATUS(resp.Status); status != nt_status.NT_STATUS_SUCCESS && status != nt_status.NT_STATUS_MORE_ENTRIES {
+		return uint32(resp.EnumerationContext), resp.Buffer, uint32(resp.CountReturned), fmt.Errorf("SamrEnumerateAliasesInDomain failed: %s", status)
 	}
 	return uint32(resp.EnumerationContext), resp.Buffer, uint32(resp.CountReturned), nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/16_SamrGetAliasMembership.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/16_SamrGetAliasMembership.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -40,8 +41,8 @@ func SamrGetAliasMembership(rpc ndr.Invoker, domainHandle mssamr.SAMPR_HANDLE, s
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return mssamr.SAMPR_ULONG_ARRAY{}, fmt.Errorf("SamrGetAliasMembership: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.Membership, fmt.Errorf("SamrGetAliasMembership failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Membership, fmt.Errorf("SamrGetAliasMembership failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Membership, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/17_SamrLookupNamesInDomain.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/17_SamrLookupNamesInDomain.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
@@ -55,9 +56,8 @@ func SamrLookupNamesInDomain(rpc ndr.Invoker, domainHandle mssamr.SAMPR_HANDLE, 
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return mssamr.SAMPR_ULONG_ARRAY{}, mssamr.SAMPR_ULONG_ARRAY{}, fmt.Errorf("SamrLookupNamesInDomain: %w", err)
 	}
-	status := uint32(resp.Status)
-	if status != samr.StatusSuccess && status != samr.StatusSomeNotMapped && status != samr.StatusNoneMapped {
-		return resp.RelativeIds, resp.Use, fmt.Errorf("SamrLookupNamesInDomain failed: %s", samr.StatusString(status))
+	if status := nt_status.NT_STATUS(resp.Status); status != nt_status.NT_STATUS_SUCCESS && status != nt_status.NT_STATUS_SOME_NOT_MAPPED && status != nt_status.NT_STATUS_NONE_MAPPED {
+		return resp.RelativeIds, resp.Use, fmt.Errorf("SamrLookupNamesInDomain failed: %s", status)
 	}
 	return resp.RelativeIds, resp.Use, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/18_SamrLookupIdsInDomain.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/18_SamrLookupIdsInDomain.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -53,9 +54,8 @@ func SamrLookupIdsInDomain(rpc ndr.Invoker, domainHandle mssamr.SAMPR_HANDLE, re
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return mssamr.SAMPR_RETURNED_USTRING_ARRAY{}, mssamr.SAMPR_ULONG_ARRAY{}, fmt.Errorf("SamrLookupIdsInDomain: %w", err)
 	}
-	status := uint32(resp.Status)
-	if status != samr.StatusSuccess && status != samr.StatusSomeNotMapped && status != samr.StatusNoneMapped {
-		return resp.Names, resp.Use, fmt.Errorf("SamrLookupIdsInDomain failed: %s", samr.StatusString(status))
+	if status := nt_status.NT_STATUS(resp.Status); status != nt_status.NT_STATUS_SUCCESS && status != nt_status.NT_STATUS_SOME_NOT_MAPPED && status != nt_status.NT_STATUS_NONE_MAPPED {
+		return resp.Names, resp.Use, fmt.Errorf("SamrLookupIdsInDomain failed: %s", status)
 	}
 	return resp.Names, resp.Use, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/19_SamrOpenGroup.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/19_SamrOpenGroup.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -35,8 +36,8 @@ func SamrOpenGroup(rpc ndr.Invoker, domainHandle mssamr.SAMPR_HANDLE, desiredAcc
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return mssamr.SAMPR_HANDLE{}, fmt.Errorf("SamrOpenGroup: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.Handle, fmt.Errorf("SamrOpenGroup failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Handle, fmt.Errorf("SamrOpenGroup failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Handle, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/20_SamrQueryInformationGroup.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/20_SamrQueryInformationGroup.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -42,8 +43,8 @@ func SamrQueryInformationGroup(rpc ndr.Invoker, groupHandle mssamr.SAMPR_HANDLE,
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return nil, fmt.Errorf("SamrQueryInformationGroup: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.Buffer, fmt.Errorf("SamrQueryInformationGroup failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Buffer, fmt.Errorf("SamrQueryInformationGroup failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Buffer, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/21_SamrSetInformationGroup.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/21_SamrSetInformationGroup.go
@@ -10,6 +10,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -35,8 +36,8 @@ func SamrSetInformationGroup(rpc ndr.Invoker, groupHandle mssamr.SAMPR_HANDLE, g
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("SamrSetInformationGroup: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return fmt.Errorf("SamrSetInformationGroup failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return fmt.Errorf("SamrSetInformationGroup failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/22_SamrAddMemberToGroup.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/22_SamrAddMemberToGroup.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -35,8 +36,8 @@ func SamrAddMemberToGroup(rpc ndr.Invoker, groupHandle mssamr.SAMPR_HANDLE, memb
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("SamrAddMemberToGroup: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return fmt.Errorf("SamrAddMemberToGroup failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return fmt.Errorf("SamrAddMemberToGroup failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/23_SamrDeleteGroup.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/23_SamrDeleteGroup.go
@@ -10,6 +10,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -29,8 +30,8 @@ func SamrDeleteGroup(rpc ndr.Invoker, groupHandle mssamr.SAMPR_HANDLE) (mssamr.S
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return groupHandle, fmt.Errorf("SamrDeleteGroup: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.Handle, fmt.Errorf("SamrDeleteGroup failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Handle, fmt.Errorf("SamrDeleteGroup failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Handle, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/24_SamrRemoveMemberFromGroup.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/24_SamrRemoveMemberFromGroup.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -35,8 +36,8 @@ func SamrRemoveMemberFromGroup(rpc ndr.Invoker, groupHandle mssamr.SAMPR_HANDLE,
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("SamrRemoveMemberFromGroup: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return fmt.Errorf("SamrRemoveMemberFromGroup failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return fmt.Errorf("SamrRemoveMemberFromGroup failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/25_SamrGetMembersInGroup.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/25_SamrGetMembersInGroup.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -35,8 +36,8 @@ func SamrGetMembersInGroup(rpc ndr.Invoker, groupHandle mssamr.SAMPR_HANDLE) (*m
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return nil, fmt.Errorf("SamrGetMembersInGroup: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.Members, fmt.Errorf("SamrGetMembersInGroup failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Members, fmt.Errorf("SamrGetMembersInGroup failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Members, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/26_SamrSetMemberAttributesOfGroup.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/26_SamrSetMemberAttributesOfGroup.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -37,8 +38,8 @@ func SamrSetMemberAttributesOfGroup(rpc ndr.Invoker, groupHandle mssamr.SAMPR_HA
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("SamrSetMemberAttributesOfGroup: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return fmt.Errorf("SamrSetMemberAttributesOfGroup failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return fmt.Errorf("SamrSetMemberAttributesOfGroup failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/27_SamrOpenAlias.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/27_SamrOpenAlias.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -35,8 +36,8 @@ func SamrOpenAlias(rpc ndr.Invoker, domainHandle mssamr.SAMPR_HANDLE, desiredAcc
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return mssamr.SAMPR_HANDLE{}, fmt.Errorf("SamrOpenAlias: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.Handle, fmt.Errorf("SamrOpenAlias failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Handle, fmt.Errorf("SamrOpenAlias failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Handle, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/28_SamrQueryInformationAlias.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/28_SamrQueryInformationAlias.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -42,8 +43,8 @@ func SamrQueryInformationAlias(rpc ndr.Invoker, aliasHandle mssamr.SAMPR_HANDLE,
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return nil, fmt.Errorf("SamrQueryInformationAlias: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.Buffer, fmt.Errorf("SamrQueryInformationAlias failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Buffer, fmt.Errorf("SamrQueryInformationAlias failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Buffer, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/29_SamrSetInformationAlias.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/29_SamrSetInformationAlias.go
@@ -10,6 +10,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -35,8 +36,8 @@ func SamrSetInformationAlias(rpc ndr.Invoker, aliasHandle mssamr.SAMPR_HANDLE, a
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("SamrSetInformationAlias: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return fmt.Errorf("SamrSetInformationAlias failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return fmt.Errorf("SamrSetInformationAlias failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/30_SamrDeleteAlias.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/30_SamrDeleteAlias.go
@@ -10,6 +10,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -29,8 +30,8 @@ func SamrDeleteAlias(rpc ndr.Invoker, aliasHandle mssamr.SAMPR_HANDLE) (mssamr.S
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return aliasHandle, fmt.Errorf("SamrDeleteAlias: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.Handle, fmt.Errorf("SamrDeleteAlias failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Handle, fmt.Errorf("SamrDeleteAlias failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Handle, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/31_SamrAddMemberToAlias.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/31_SamrAddMemberToAlias.go
@@ -10,6 +10,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
@@ -34,8 +35,8 @@ func SamrAddMemberToAlias(rpc ndr.Invoker, aliasHandle mssamr.SAMPR_HANDLE, memb
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("SamrAddMemberToAlias: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return fmt.Errorf("SamrAddMemberToAlias failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return fmt.Errorf("SamrAddMemberToAlias failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/32_SamrRemoveMemberFromAlias.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/32_SamrRemoveMemberFromAlias.go
@@ -10,6 +10,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
@@ -36,8 +37,8 @@ func SamrRemoveMemberFromAlias(rpc ndr.Invoker, aliasHandle mssamr.SAMPR_HANDLE,
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("SamrRemoveMemberFromAlias: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return fmt.Errorf("SamrRemoveMemberFromAlias failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return fmt.Errorf("SamrRemoveMemberFromAlias failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/33_SamrGetMembersInAlias.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/33_SamrGetMembersInAlias.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -35,8 +36,8 @@ func SamrGetMembersInAlias(rpc ndr.Invoker, aliasHandle mssamr.SAMPR_HANDLE) (ms
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return mssamr.SAMPR_PSID_ARRAY_OUT{}, fmt.Errorf("SamrGetMembersInAlias: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.Members, fmt.Errorf("SamrGetMembersInAlias failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Members, fmt.Errorf("SamrGetMembersInAlias failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Members, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/34_SamrOpenUser.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/34_SamrOpenUser.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -35,8 +36,8 @@ func SamrOpenUser(rpc ndr.Invoker, domainHandle mssamr.SAMPR_HANDLE, desiredAcce
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return mssamr.SAMPR_HANDLE{}, fmt.Errorf("SamrOpenUser: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.Handle, fmt.Errorf("SamrOpenUser failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Handle, fmt.Errorf("SamrOpenUser failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Handle, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/35_SamrDeleteUser.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/35_SamrDeleteUser.go
@@ -10,6 +10,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -29,8 +30,8 @@ func SamrDeleteUser(rpc ndr.Invoker, userHandle mssamr.SAMPR_HANDLE) (mssamr.SAM
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return userHandle, fmt.Errorf("SamrDeleteUser: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.Handle, fmt.Errorf("SamrDeleteUser failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Handle, fmt.Errorf("SamrDeleteUser failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Handle, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/36_SamrQueryInformationUser.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/36_SamrQueryInformationUser.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -42,8 +43,8 @@ func SamrQueryInformationUser(rpc ndr.Invoker, userHandle mssamr.SAMPR_HANDLE, u
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return nil, fmt.Errorf("SamrQueryInformationUser: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.Buffer, fmt.Errorf("SamrQueryInformationUser failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Buffer, fmt.Errorf("SamrQueryInformationUser failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Buffer, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/37_SamrSetInformationUser.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/37_SamrSetInformationUser.go
@@ -10,6 +10,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -36,8 +37,8 @@ func SamrSetInformationUser(rpc ndr.Invoker, userHandle mssamr.SAMPR_HANDLE, use
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("SamrSetInformationUser: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return fmt.Errorf("SamrSetInformationUser failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return fmt.Errorf("SamrSetInformationUser failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/38_SamrChangePasswordUser.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/38_SamrChangePasswordUser.go
@@ -10,6 +10,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -53,8 +54,8 @@ func SamrChangePasswordUser(rpc ndr.Invoker, userHandle mssamr.SAMPR_HANDLE, lmP
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("SamrChangePasswordUser: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return fmt.Errorf("SamrChangePasswordUser failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return fmt.Errorf("SamrChangePasswordUser failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/39_SamrGetGroupsForUser.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/39_SamrGetGroupsForUser.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -36,8 +37,8 @@ func SamrGetGroupsForUser(rpc ndr.Invoker, userHandle mssamr.SAMPR_HANDLE) (*mss
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return nil, fmt.Errorf("SamrGetGroupsForUser: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.Groups, fmt.Errorf("SamrGetGroupsForUser failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Groups, fmt.Errorf("SamrGetGroupsForUser failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Groups, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/40_SamrQueryDisplayInformation.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/40_SamrQueryDisplayInformation.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -53,9 +54,8 @@ func SamrQueryDisplayInformation(rpc ndr.Invoker, domainHandle mssamr.SAMPR_HAND
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return 0, 0, mssamr.SAMPR_DISPLAY_INFO_BUFFER{}, fmt.Errorf("SamrQueryDisplayInformation: %w", err)
 	}
-	status := uint32(resp.Status)
-	if status != samr.StatusSuccess && status != samr.StatusMoreEntries {
-		return uint32(resp.TotalAvailable), uint32(resp.TotalReturned), resp.Buffer, fmt.Errorf("SamrQueryDisplayInformation failed: %s", samr.StatusString(status))
+	if status := nt_status.NT_STATUS(resp.Status); status != nt_status.NT_STATUS_SUCCESS && status != nt_status.NT_STATUS_MORE_ENTRIES {
+		return uint32(resp.TotalAvailable), uint32(resp.TotalReturned), resp.Buffer, fmt.Errorf("SamrQueryDisplayInformation failed: %s", status)
 	}
 	return uint32(resp.TotalAvailable), uint32(resp.TotalReturned), resp.Buffer, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/41_SamrGetDisplayEnumerationIndex.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/41_SamrGetDisplayEnumerationIndex.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
@@ -46,9 +47,8 @@ func SamrGetDisplayEnumerationIndex(rpc ndr.Invoker, domainHandle mssamr.SAMPR_H
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return 0, fmt.Errorf("SamrGetDisplayEnumerationIndex: %w", err)
 	}
-	status := uint32(resp.Status)
-	if status != samr.StatusSuccess && status != samr.StatusMoreEntries && status != samr.StatusNoMoreEntries {
-		return uint32(resp.Index), fmt.Errorf("SamrGetDisplayEnumerationIndex failed: %s", samr.StatusString(status))
+	if status := nt_status.NT_STATUS(resp.Status); status != nt_status.NT_STATUS_SUCCESS && status != nt_status.NT_STATUS_MORE_ENTRIES && status != nt_status.NT_STATUS_NO_MORE_ENTRIES {
+		return uint32(resp.Index), fmt.Errorf("SamrGetDisplayEnumerationIndex failed: %s", status)
 	}
 	return uint32(resp.Index), nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/44_SamrGetUserDomainPasswordInformation.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/44_SamrGetUserDomainPasswordInformation.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -38,8 +39,8 @@ func SamrGetUserDomainPasswordInformation(rpc ndr.Invoker, userHandle mssamr.SAM
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return mssamr.USER_DOMAIN_PASSWORD_INFORMATION{}, fmt.Errorf("SamrGetUserDomainPasswordInformation: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.PasswordInformation, fmt.Errorf("SamrGetUserDomainPasswordInformation failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.PasswordInformation, fmt.Errorf("SamrGetUserDomainPasswordInformation failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.PasswordInformation, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/45_SamrRemoveMemberFromForeignDomain.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/45_SamrRemoveMemberFromForeignDomain.go
@@ -10,6 +10,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
@@ -38,8 +39,8 @@ func SamrRemoveMemberFromForeignDomain(rpc ndr.Invoker, domainHandle mssamr.SAMP
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("SamrRemoveMemberFromForeignDomain: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return fmt.Errorf("SamrRemoveMemberFromForeignDomain failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return fmt.Errorf("SamrRemoveMemberFromForeignDomain failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/46_SamrQueryInformationDomain2.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/46_SamrQueryInformationDomain2.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -43,8 +44,8 @@ func SamrQueryInformationDomain2(rpc ndr.Invoker, domainHandle mssamr.SAMPR_HAND
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return nil, fmt.Errorf("SamrQueryInformationDomain2: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.Buffer, fmt.Errorf("SamrQueryInformationDomain2 failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Buffer, fmt.Errorf("SamrQueryInformationDomain2 failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Buffer, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/47_SamrQueryInformationUser2.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/47_SamrQueryInformationUser2.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -42,8 +43,8 @@ func SamrQueryInformationUser2(rpc ndr.Invoker, userHandle mssamr.SAMPR_HANDLE, 
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return nil, fmt.Errorf("SamrQueryInformationUser2: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.Buffer, fmt.Errorf("SamrQueryInformationUser2 failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Buffer, fmt.Errorf("SamrQueryInformationUser2 failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Buffer, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/48_SamrQueryDisplayInformation2.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/48_SamrQueryDisplayInformation2.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -54,9 +55,8 @@ func SamrQueryDisplayInformation2(rpc ndr.Invoker, domainHandle mssamr.SAMPR_HAN
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return 0, 0, mssamr.SAMPR_DISPLAY_INFO_BUFFER{}, fmt.Errorf("SamrQueryDisplayInformation2: %w", err)
 	}
-	status := uint32(resp.Status)
-	if status != samr.StatusSuccess && status != samr.StatusMoreEntries {
-		return uint32(resp.TotalAvailable), uint32(resp.TotalReturned), resp.Buffer, fmt.Errorf("SamrQueryDisplayInformation2 failed: %s", samr.StatusString(status))
+	if status := nt_status.NT_STATUS(resp.Status); status != nt_status.NT_STATUS_SUCCESS && status != nt_status.NT_STATUS_MORE_ENTRIES {
+		return uint32(resp.TotalAvailable), uint32(resp.TotalReturned), resp.Buffer, fmt.Errorf("SamrQueryDisplayInformation2 failed: %s", status)
 	}
 	return uint32(resp.TotalAvailable), uint32(resp.TotalReturned), resp.Buffer, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/49_SamrGetDisplayEnumerationIndex2.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/49_SamrGetDisplayEnumerationIndex2.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
@@ -46,9 +47,8 @@ func SamrGetDisplayEnumerationIndex2(rpc ndr.Invoker, domainHandle mssamr.SAMPR_
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return 0, fmt.Errorf("SamrGetDisplayEnumerationIndex2: %w", err)
 	}
-	status := uint32(resp.Status)
-	if status != samr.StatusSuccess && status != samr.StatusMoreEntries && status != samr.StatusNoMoreEntries {
-		return uint32(resp.Index), fmt.Errorf("SamrGetDisplayEnumerationIndex2 failed: %s", samr.StatusString(status))
+	if status := nt_status.NT_STATUS(resp.Status); status != nt_status.NT_STATUS_SUCCESS && status != nt_status.NT_STATUS_MORE_ENTRIES && status != nt_status.NT_STATUS_NO_MORE_ENTRIES {
+		return uint32(resp.Index), fmt.Errorf("SamrGetDisplayEnumerationIndex2 failed: %s", status)
 	}
 	return uint32(resp.Index), nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/50_SamrCreateUser2InDomain.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/50_SamrCreateUser2InDomain.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
@@ -48,8 +49,8 @@ func SamrCreateUser2InDomain(rpc ndr.Invoker, domainHandle mssamr.SAMPR_HANDLE, 
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return mssamr.SAMPR_HANDLE{}, 0, 0, fmt.Errorf("SamrCreateUser2InDomain: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.UserHandle, uint32(resp.GrantedAccess), uint32(resp.RelativeId), fmt.Errorf("SamrCreateUser2InDomain failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.UserHandle, uint32(resp.GrantedAccess), uint32(resp.RelativeId), fmt.Errorf("SamrCreateUser2InDomain failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.UserHandle, uint32(resp.GrantedAccess), uint32(resp.RelativeId), nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/51_SamrQueryDisplayInformation3.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/51_SamrQueryDisplayInformation3.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -54,9 +55,8 @@ func SamrQueryDisplayInformation3(rpc ndr.Invoker, domainHandle mssamr.SAMPR_HAN
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return 0, 0, mssamr.SAMPR_DISPLAY_INFO_BUFFER{}, fmt.Errorf("SamrQueryDisplayInformation3: %w", err)
 	}
-	status := uint32(resp.Status)
-	if status != samr.StatusSuccess && status != samr.StatusMoreEntries {
-		return uint32(resp.TotalAvailable), uint32(resp.TotalReturned), resp.Buffer, fmt.Errorf("SamrQueryDisplayInformation3 failed: %s", samr.StatusString(status))
+	if status := nt_status.NT_STATUS(resp.Status); status != nt_status.NT_STATUS_SUCCESS && status != nt_status.NT_STATUS_MORE_ENTRIES {
+		return uint32(resp.TotalAvailable), uint32(resp.TotalReturned), resp.Buffer, fmt.Errorf("SamrQueryDisplayInformation3 failed: %s", status)
 	}
 	return uint32(resp.TotalAvailable), uint32(resp.TotalReturned), resp.Buffer, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/52_SamrAddMultipleMembersToAlias.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/52_SamrAddMultipleMembersToAlias.go
@@ -10,6 +10,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -35,8 +36,8 @@ func SamrAddMultipleMembersToAlias(rpc ndr.Invoker, aliasHandle mssamr.SAMPR_HAN
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("SamrAddMultipleMembersToAlias: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return fmt.Errorf("SamrAddMultipleMembersToAlias failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return fmt.Errorf("SamrAddMultipleMembersToAlias failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/53_SamrRemoveMultipleMembersFromAlias.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/53_SamrRemoveMultipleMembersFromAlias.go
@@ -10,6 +10,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -35,8 +36,8 @@ func SamrRemoveMultipleMembersFromAlias(rpc ndr.Invoker, aliasHandle mssamr.SAMP
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("SamrRemoveMultipleMembersFromAlias: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return fmt.Errorf("SamrRemoveMultipleMembersFromAlias failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return fmt.Errorf("SamrRemoveMultipleMembersFromAlias failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/54_SamrOemChangePasswordUser2.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/54_SamrOemChangePasswordUser2.go
@@ -10,6 +10,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -41,8 +42,8 @@ func SamrOemChangePasswordUser2(rpc ndr.Invoker, serverName *mssamr.RPC_STRING, 
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("SamrOemChangePasswordUser2: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return fmt.Errorf("SamrOemChangePasswordUser2 failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return fmt.Errorf("SamrOemChangePasswordUser2 failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/55_SamrUnicodeChangePasswordUser2.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/55_SamrUnicodeChangePasswordUser2.go
@@ -10,6 +10,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
@@ -50,8 +51,8 @@ func SamrUnicodeChangePasswordUser2(rpc ndr.Invoker, serverName *msdtyp.RPC_UNIC
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("SamrUnicodeChangePasswordUser2: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return fmt.Errorf("SamrUnicodeChangePasswordUser2 failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return fmt.Errorf("SamrUnicodeChangePasswordUser2 failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/56_SamrGetDomainPasswordInformation.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/56_SamrGetDomainPasswordInformation.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
@@ -41,8 +42,8 @@ func SamrGetDomainPasswordInformation(rpc ndr.Invoker) (mssamr.USER_DOMAIN_PASSW
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return mssamr.USER_DOMAIN_PASSWORD_INFORMATION{}, fmt.Errorf("SamrGetDomainPasswordInformation: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.PasswordInformation, fmt.Errorf("SamrGetDomainPasswordInformation failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.PasswordInformation, fmt.Errorf("SamrGetDomainPasswordInformation failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.PasswordInformation, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/57_SamrConnect2.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/57_SamrConnect2.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -33,8 +34,8 @@ func SamrConnect2(rpc ndr.Invoker, serverName string, desiredAccess uint32) (mss
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return mssamr.SAMPR_HANDLE{}, fmt.Errorf("SamrConnect2: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.Handle, fmt.Errorf("SamrConnect2 failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Handle, fmt.Errorf("SamrConnect2 failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Handle, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/58_SamrSetInformationUser2.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/58_SamrSetInformationUser2.go
@@ -10,6 +10,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -36,8 +37,8 @@ func SamrSetInformationUser2(rpc ndr.Invoker, userHandle mssamr.SAMPR_HANDLE, us
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("SamrSetInformationUser2: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return fmt.Errorf("SamrSetInformationUser2 failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return fmt.Errorf("SamrSetInformationUser2 failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/62_SamrConnect4.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/62_SamrConnect4.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -36,8 +37,8 @@ func SamrConnect4(rpc ndr.Invoker, serverName string, clientRevision uint32, des
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return mssamr.SAMPR_HANDLE{}, fmt.Errorf("SamrConnect4: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.Handle, fmt.Errorf("SamrConnect4 failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Handle, fmt.Errorf("SamrConnect4 failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Handle, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/64_SamrConnect5.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/64_SamrConnect5.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -59,8 +60,8 @@ func SamrConnect5(rpc ndr.Invoker, serverName string, desiredAccess uint32) (mss
 		return mssamr.SAMPR_HANDLE{}, 0, nil, fmt.Errorf("SamrConnect5: %w", err)
 	}
 	outInfo := resp.OutRevisionInfo
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.ServerHandle, uint32(resp.OutVersion), &outInfo, fmt.Errorf("SamrConnect5 failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.ServerHandle, uint32(resp.OutVersion), &outInfo, fmt.Errorf("SamrConnect5 failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.ServerHandle, uint32(resp.OutVersion), &outInfo, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/65_SamrRidToSid.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/65_SamrRidToSid.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
@@ -41,8 +42,8 @@ func SamrRidToSid(rpc ndr.Invoker, handle mssamr.SAMPR_HANDLE, rid uint32) (*msd
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return nil, fmt.Errorf("SamrRidToSid: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.Sid, fmt.Errorf("SamrRidToSid failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Sid, fmt.Errorf("SamrRidToSid failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Sid, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/66_SamrSetDSRMPassword.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/66_SamrSetDSRMPassword.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
@@ -37,8 +38,8 @@ func SamrSetDSRMPassword(rpc ndr.Invoker, userId uint32, encryptedNtOwfPassword 
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("SamrSetDSRMPassword: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return fmt.Errorf("SamrSetDSRMPassword failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return fmt.Errorf("SamrSetDSRMPassword failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/67_SamrValidatePassword.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/67_SamrValidatePassword.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -43,8 +44,8 @@ func SamrValidatePassword(rpc ndr.Invoker, validationType mssamr.PASSWORD_POLICY
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return nil, fmt.Errorf("SamrValidatePassword: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.OutputArg, fmt.Errorf("SamrValidatePassword failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.OutputArg, fmt.Errorf("SamrValidatePassword failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.OutputArg, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/73_SamrUnicodeChangePasswordUser4.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/73_SamrUnicodeChangePasswordUser4.go
@@ -10,6 +10,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
@@ -40,8 +41,8 @@ func SamrUnicodeChangePasswordUser4(rpc ndr.Invoker, serverName *msdtyp.RPC_UNIC
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("SamrUnicodeChangePasswordUser4: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return fmt.Errorf("SamrUnicodeChangePasswordUser4 failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return fmt.Errorf("SamrUnicodeChangePasswordUser4 failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/74_SamrValidateComputerAccountReuseAttempt.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/74_SamrValidateComputerAccountReuseAttempt.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
@@ -44,8 +45,8 @@ func SamrValidateComputerAccountReuseAttempt(rpc ndr.Invoker, serverHandle mssam
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return 0, fmt.Errorf("SamrValidateComputerAccountReuseAttempt: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.Result, fmt.Errorf("SamrValidateComputerAccountReuseAttempt failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Result, fmt.Errorf("SamrValidateComputerAccountReuseAttempt failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Result, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/77_SamrAccountIsDelegatedManagedServiceAccount.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/77_SamrAccountIsDelegatedManagedServiceAccount.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
@@ -47,8 +48,8 @@ func SamrAccountIsDelegatedManagedServiceAccount(rpc ndr.Invoker, serverHandle m
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return false, false, fmt.Errorf("SamrAccountIsDelegatedManagedServiceAccount: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.Result, resp.Authorized, fmt.Errorf("SamrAccountIsDelegatedManagedServiceAccount failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Result, resp.Authorized, fmt.Errorf("SamrAccountIsDelegatedManagedServiceAccount failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Result, resp.Authorized, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/interface.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/interface.go
@@ -8,8 +8,8 @@
 // interface UUID with the version in the nested 1.0/ directory.
 //
 // This package holds only the interface-level descriptor: the abstract syntax
-// identifier, the transport endpoint (PipeName), the opnum constants and opnum<->name
-// maps, and the NTSTATUS return codes. NDR types live in the structures subpackage and
+// identifier, the transport endpoint (PipeName), and the opnum constants and
+// opnum<->name maps. NDR types live in the structures subpackage and
 // the method stubs in functions; both depend on this package, never the reverse.
 //
 // References:
@@ -23,8 +23,6 @@ package rpcinterface_123457781234abcdef000123456789ac_1_0
 // A fetched copy is kept at ms-samr.idl in the interface directory.
 
 import (
-	"fmt"
-
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
 	"github.com/TheManticoreProject/Manticore/windows/guid"
 )
@@ -101,28 +99,12 @@ const (
 	OpnumSamrAccountIsDelegatedManagedServiceAccount uint16 = 77
 )
 
-// Common NTSTATUS codes returned by samr methods ([MS-ERREF] 2.3.1). samr methods return
-// an NTSTATUS (the IDL "long" return value).
-const (
-	StatusSuccess            uint32 = 0x00000000
-	StatusMoreEntries        uint32 = 0x00000105
-	StatusSomeNotMapped      uint32 = 0x00000107
-	StatusNoMoreEntries      uint32 = 0x8000001A
-	StatusInvalidHandle      uint32 = 0xC0000008
-	StatusInvalidParameter   uint32 = 0xC000000D
-	StatusAccessDenied       uint32 = 0xC0000022
-	StatusObjectNameNotFound uint32 = 0xC0000034
-	StatusNoSuchUser         uint32 = 0xC0000064
-	StatusNoneMapped         uint32 = 0xC0000073
-	StatusNoSuchDomain       uint32 = 0xC00000DF
-	StatusNoSuchAlias        uint32 = 0xC0000151
-	StatusNoSuchGroup        uint32 = 0xC0000066
-	StatusUserExists         uint32 = 0xC0000063
-	StatusGroupExists        uint32 = 0xC0000065
-	StatusAliasExists        uint32 = 0xC0000154
-	StatusWrongPassword      uint32 = 0xC000006A
-	StatusNotSupported       uint32 = 0xC00000BB
-)
+// samr methods return an NTSTATUS as the IDL "long" return value. The codes are not
+// declared here: the whole of [MS-ERREF] 2.3.1 lives in
+// github.com/TheManticoreProject/Manticore/windows/errors/nt_status, and the method
+// stubs in functions convert their return value to nt_status.NT_STATUS to compare and
+// render it. A subset transcribed here would cover a fraction of the table and drift
+// from it.
 
 // SyntaxID returns the samr abstract syntax identifier:
 // 12345778-1234-abcd-ef00-0123456789ac, version 1.0.
@@ -131,51 +113,6 @@ func SyntaxID() syntax.SyntaxID {
 		UUID:         guid.GUID{A: 0x12345778, B: 0x1234, C: 0xabcd, D: 0xef00, E: 0x0123456789ac},
 		MajorVersion: 1,
 		MinorVersion: 0,
-	}
-}
-
-// StatusString returns a mnemonic for the documented status codes, otherwise the hex
-// value.
-func StatusString(status uint32) string {
-	switch status {
-	case StatusSuccess:
-		return "STATUS_SUCCESS"
-	case StatusMoreEntries:
-		return "STATUS_MORE_ENTRIES"
-	case StatusSomeNotMapped:
-		return "STATUS_SOME_NOT_MAPPED"
-	case StatusNoMoreEntries:
-		return "STATUS_NO_MORE_ENTRIES"
-	case StatusInvalidHandle:
-		return "STATUS_INVALID_HANDLE"
-	case StatusInvalidParameter:
-		return "STATUS_INVALID_PARAMETER"
-	case StatusAccessDenied:
-		return "STATUS_ACCESS_DENIED"
-	case StatusObjectNameNotFound:
-		return "STATUS_OBJECT_NAME_NOT_FOUND"
-	case StatusNoSuchUser:
-		return "STATUS_NO_SUCH_USER"
-	case StatusNoneMapped:
-		return "STATUS_NONE_MAPPED"
-	case StatusNoSuchDomain:
-		return "STATUS_NO_SUCH_DOMAIN"
-	case StatusNoSuchAlias:
-		return "STATUS_NO_SUCH_ALIAS"
-	case StatusNoSuchGroup:
-		return "STATUS_NO_SUCH_GROUP"
-	case StatusUserExists:
-		return "STATUS_USER_EXISTS"
-	case StatusGroupExists:
-		return "STATUS_GROUP_EXISTS"
-	case StatusAliasExists:
-		return "STATUS_ALIAS_EXISTS"
-	case StatusWrongPassword:
-		return "STATUS_WRONG_PASSWORD"
-	case StatusNotSupported:
-		return "STATUS_NOT_SUPPORTED"
-	default:
-		return fmt.Sprintf("0x%08x", status)
 	}
 }
 

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/interface_test.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/interface_test.go
@@ -1,16 +1,51 @@
 package rpcinterface_123457781234abcdef000123456789ac_1_0
 
-import "testing"
+import (
+	"testing"
 
-func TestStatusString(t *testing.T) {
-	if got := StatusString(StatusMoreEntries); got != "STATUS_MORE_ENTRIES" {
-		t.Errorf("StatusString(0x105) = %q", got)
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
+)
+
+// TestReturnCodesResolveThroughNTStatus pins that the status codes [MS-SAMR]
+// documents for these methods resolve through the shared [MS-ERREF] table, which
+// is what the method stubs in functions render with now that this package carries
+// no subset of its own.
+func TestReturnCodesResolveThroughNTStatus(t *testing.T) {
+	cases := map[nt_status.NT_STATUS]string{
+		nt_status.NT_STATUS_SUCCESS:               "NT_STATUS_SUCCESS",
+		nt_status.NT_STATUS_MORE_ENTRIES:          "NT_STATUS_MORE_ENTRIES",
+		nt_status.NT_STATUS_SOME_NOT_MAPPED:       "NT_STATUS_SOME_NOT_MAPPED",
+		nt_status.NT_STATUS_NO_MORE_ENTRIES:       "NT_STATUS_NO_MORE_ENTRIES",
+		nt_status.NT_STATUS_INVALID_HANDLE:        "NT_STATUS_INVALID_HANDLE",
+		nt_status.NT_STATUS_INVALID_PARAMETER:     "NT_STATUS_INVALID_PARAMETER",
+		nt_status.NT_STATUS_ACCESS_DENIED:         "NT_STATUS_ACCESS_DENIED",
+		nt_status.NT_STATUS_OBJECT_NAME_NOT_FOUND: "NT_STATUS_OBJECT_NAME_NOT_FOUND",
+		nt_status.NT_STATUS_NO_SUCH_USER:          "NT_STATUS_NO_SUCH_USER",
+		nt_status.NT_STATUS_NONE_MAPPED:           "NT_STATUS_NONE_MAPPED",
+		nt_status.NT_STATUS_NO_SUCH_DOMAIN:        "NT_STATUS_NO_SUCH_DOMAIN",
+		nt_status.NT_STATUS_NO_SUCH_ALIAS:         "NT_STATUS_NO_SUCH_ALIAS",
+		nt_status.NT_STATUS_NO_SUCH_GROUP:         "NT_STATUS_NO_SUCH_GROUP",
+		nt_status.NT_STATUS_USER_EXISTS:           "NT_STATUS_USER_EXISTS",
+		nt_status.NT_STATUS_GROUP_EXISTS:          "NT_STATUS_GROUP_EXISTS",
+		nt_status.NT_STATUS_ALIAS_EXISTS:          "NT_STATUS_ALIAS_EXISTS",
+		nt_status.NT_STATUS_WRONG_PASSWORD:        "NT_STATUS_WRONG_PASSWORD",
+		nt_status.NT_STATUS_NOT_SUPPORTED:         "NT_STATUS_NOT_SUPPORTED",
 	}
-	if got := StatusString(StatusSuccess); got != "STATUS_SUCCESS" {
-		t.Errorf("StatusString(0) = %q", got)
+
+	for status, want := range cases {
+		if got := status.String(); got != want {
+			t.Errorf("0x%08X renders as %q, want %q", uint32(status), got, want)
+		}
 	}
-	if got := StatusString(0x12345678); got != "0x12345678" {
-		t.Errorf("StatusString(unknown) = %q, want hex", got)
+
+	// A status this interface has never returned still renders, where the
+	// package's own subset reported an undecoded hex value for anything outside
+	// the 18 codes above.
+	if got := nt_status.NT_STATUS_LOGON_FAILURE.String(); got != "NT_STATUS_LOGON_FAILURE" {
+		t.Errorf("a status outside the old subset renders as %q", got)
+	}
+	if got := nt_status.NT_STATUS(0x12345678).String(); got != "0x12345678" {
+		t.Errorf("an undefined status renders as %q, want the hex form", got)
 	}
 }
 


### PR DESCRIPTION
### Linked Issue
`Refs #1219`

First interface of phase 4. **#1219 stays open** — it covers 74 interface packages and this is one of them, so there is deliberately no closing keyword here.

### Root Cause
`samr` declared 18 NTSTATUS values in its interface descriptor (`interface.go:106–124`) and a `StatusString` switch over exactly those (`:139–179`), falling back to `fmt.Sprintf("0x%08x", status)` for anything else. Since `windows/errors/nt_status` holds all 1817 values, the subset was both a duplicate of an in-repo table and a ceiling on what the interface could report: a `SamrConnect5` failing with `STATUS_LOGON_FAILURE` came back as `0xc000006d`.

The subset existed because there was nowhere else for it to live when the interface was written. Phases 1 to 3 of #1208 changed that.

### Fix Description
The constant block and `StatusString` are deleted. Each of the 64 method stubs that compared or rendered a status converts its return value to `nt_status.NT_STATUS` and uses the shared table:

```go
if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
    return resp.Handle, fmt.Errorf("SamrConnect2 failed: %s", nt_status.NT_STATUS(resp.Status).String())
}
```

That is a typed comparison, where before it compared two `uint32` values that happened to agree.

Three decisions worth review:

- **The constant mapping was derived from values, not names.** Rather than assume `StatusNoSuchAlias` means `NT_STATUS_NO_SUCH_ALIAS`, each of the 18 values was looked up in the [MS-ERREF] table and the generated canonical name used. All 18 resolved, so a mistranscribed name in the old subset could not have carried through — and if one had not resolved, the script would have stopped rather than guessed.
- **The rewrite is per comparison term, not per condition.** Eleven methods accept more than one status — `SamrEnumerateDomainsInSamServer` also accepts `STATUS_MORE_ENTRIES`, `SamrGetDisplayEnumerationIndex2` also accepts `STATUS_NO_MORE_ENTRIES` — and a per-condition rewrite could have dropped a term while still compiling. Working term-by-term makes that impossible.
- **Those eleven hoist the conversion into the `if` initializer**, because repeating `nt_status.NT_STATUS(status) != …` three times in one condition reads badly:
  ```go
  if status := nt_status.NT_STATUS(resp.Status); status != nt_status.NT_STATUS_SUCCESS && status != nt_status.NT_STATUS_MORE_ENTRIES {
  ```
  The other 53 compare inline, where a local would add nothing.

`samr` keeps its opnum constants, `NameToOpnum`/`OpnumToName`, `PipeName`, `SyntaxID()` and its access masks — 66 of the 67 files touched change two or three lines each. Only the error table it had no business owning is removed.

### How Verified
- **Runtime:** `go test -count=1 ./...` clean — **311 packages ok, 0 failures**, matching the baseline. `go vet ./...` clean.
- **Runtime:** cross-compiled for the CI matrix — `windows/amd64`, `windows/386`, `linux/arm64`, `linux/386`.
- **Static:** `grep` confirms no `Status*` constant or `StatusString` remains in `interface.go`, and no `samr.Status*` reference remains anywhere. The 66 files that still import `samr` do so for opnums and access masks, which is correct.
- **Static:** every one of the 64 `if` conditions was checked to have the same number of comparison terms before and after. The three condition shapes in the package (53 single-term, 7 two-term, 4 three-term) are all accounted for.
- **Static:** `gofmt` verified per file against `HEAD`. The new import sorts before `network/dcerpc/ndr`, so 46 files needed reordering; all were clean on `main` beforehand, so the drift was mine and is fixed.

### Test Coverage
**Modified** — `interface_test.go`: `TestStatusString` tested a function that no longer exists. It is replaced by `TestReturnCodesResolveThroughNTStatus`, which asserts all 18 codes [MS-SAMR] documents for these methods resolve through the shared table under their expected names, and adds the case the old subset could not handle — `NT_STATUS_LOGON_FAILURE` now renders by name where it previously came back as hex — plus the hex fallback for a genuinely undefined value.

`TestSyntaxID` and `TestOpnumNameMapsRoundTrip` are untouched and still pass.

### Scope of Change
- **Files changed:** `network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/interface.go`, `interface_test.go`, and 64 files under `functions/`. 66 files, 243 insertions, 218 deletions.
- **Submodule pointer updated:** no — the repository has no submodules.
- **Behavioral changes outside the bug fix:** none. Error text for the 18 previously-known codes changes from `STATUS_ACCESS_DENIED` to `NT_STATUS_ACCESS_DENIED`, following the `Name()` convention settled in #1218; codes outside the subset change from hex to their name, which is the point of the change.

### Risk and Rollout
Wide but shallow, and compiler-checked throughout: a missed reference is a build failure, not a runtime fault. The only runtime-visible difference is the text of an error message. Safe to merge as is.

### Notes
This PR also measures the cost of the two end states offered in the [corrected survey on #1219](https://github.com/TheManticoreProject/Manticore/issues/1219#issuecomment-5603698012), which is why it was done first:

- **Direct references, as here:** 66 files for one interface, ~2000 across all 74. Honest end state, no indirection, fully compiler-verified — but the great majority of that diff is two mechanical lines per method stub.
- **Typed delegation:** keep each interface's `Status*` names as aliases of the shared constants and reduce `StatusString` to a one-line delegate. One file per interface, no duplicated values, no possible drift, and full table coverage immediately — at the cost of leaving a thin naming layer in place.

Worth choosing before the remaining interfaces are done, since the difference over the whole phase is roughly 2000 file edits against roughly 70.

Remaining `nt_status` interfaces, in the order I would take them: `12345778-…-89ab/0.0` lsarpc (13 constants, 69 files), `12345678-…-cffb/1.0` netlogon (9 constants, 48 files), `afc07e2e-…/1.0` lsacap (4 constants, 1 file). The 36 `win32` interfaces follow. The 23 HRESULT interfaces are blocked on #1221.
