### PR TITLE
Route netlogon status reporting through nt_status (Refs #1219)

### DIFF
--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/00_NetrLogonUasLogon.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/00_NetrLogonUasLogon.go
@@ -10,6 +10,7 @@ import (
 
 	logon "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msnrpc "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nrpc"
 )
 
@@ -42,8 +43,8 @@ func NetrLogonUasLogon(rpc ndr.Invoker, serverName *ndr.WSTR, userName ndr.WSTR,
 		return
 	}
 	ValidationInformation = resp.ValidationInformation
-	if uint32(resp.Status) != logon.StatusSuccess {
-		err = fmt.Errorf("NetrLogonUasLogon failed: %s", logon.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		err = fmt.Errorf("NetrLogonUasLogon failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/01_NetrLogonUasLogoff.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/01_NetrLogonUasLogoff.go
@@ -10,6 +10,7 @@ import (
 
 	logon "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msnrpc "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nrpc"
 )
 
@@ -42,8 +43,8 @@ func NetrLogonUasLogoff(rpc ndr.Invoker, serverName *ndr.WSTR, userName ndr.WSTR
 		return
 	}
 	LogoffInformation = resp.LogoffInformation
-	if uint32(resp.Status) != logon.StatusSuccess {
-		err = fmt.Errorf("NetrLogonUasLogoff failed: %s", logon.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		err = fmt.Errorf("NetrLogonUasLogoff failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/02_NetrLogonSamLogon.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/02_NetrLogonSamLogon.go
@@ -10,6 +10,7 @@ import (
 
 	logon "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msnrpc "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nrpc"
 )
 
@@ -54,8 +55,8 @@ func NetrLogonSamLogon(rpc ndr.Invoker, logonServer *ndr.WSTR, computerName *ndr
 	ReturnAuthenticator = resp.ReturnAuthenticator
 	ValidationInformation = resp.ValidationInformation
 	Authoritative = resp.Authoritative
-	if uint32(resp.Status) != logon.StatusSuccess {
-		err = fmt.Errorf("NetrLogonSamLogon failed: %s", logon.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		err = fmt.Errorf("NetrLogonSamLogon failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/03_NetrLogonSamLogoff.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/03_NetrLogonSamLogoff.go
@@ -10,6 +10,7 @@ import (
 
 	logon "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msnrpc "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nrpc"
 )
 
@@ -48,8 +49,8 @@ func NetrLogonSamLogoff(rpc ndr.Invoker, logonServer *ndr.WSTR, computerName *nd
 		return
 	}
 	ReturnAuthenticator = resp.ReturnAuthenticator
-	if uint32(resp.Status) != logon.StatusSuccess {
-		err = fmt.Errorf("NetrLogonSamLogoff failed: %s", logon.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		err = fmt.Errorf("NetrLogonSamLogoff failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/05_NetrServerAuthenticate.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/05_NetrServerAuthenticate.go
@@ -10,6 +10,7 @@ import (
 
 	logon "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msnrpc "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nrpc"
 )
 
@@ -46,8 +47,8 @@ func NetrServerAuthenticate(rpc ndr.Invoker, primaryName *ndr.WSTR, accountName 
 		return
 	}
 	ServerCredential = resp.ServerCredential
-	if uint32(resp.Status) != logon.StatusSuccess {
-		err = fmt.Errorf("NetrServerAuthenticate failed: %s", logon.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		err = fmt.Errorf("NetrServerAuthenticate failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/06_NetrServerPasswordSet.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/06_NetrServerPasswordSet.go
@@ -10,6 +10,7 @@ import (
 
 	logon "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msnrpc "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nrpc"
 )
 
@@ -48,8 +49,8 @@ func NetrServerPasswordSet(rpc ndr.Invoker, primaryName *ndr.WSTR, accountName n
 		return
 	}
 	ReturnAuthenticator = resp.ReturnAuthenticator
-	if uint32(resp.Status) != logon.StatusSuccess {
-		err = fmt.Errorf("NetrServerPasswordSet failed: %s", logon.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		err = fmt.Errorf("NetrServerPasswordSet failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/07_NetrDatabaseDeltas.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/07_NetrDatabaseDeltas.go
@@ -10,6 +10,7 @@ import (
 
 	logon "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msnrpc "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nrpc"
 )
 
@@ -54,8 +55,8 @@ func NetrDatabaseDeltas(rpc ndr.Invoker, primaryName ndr.WSTR, computerName ndr.
 	ReturnAuthenticator = resp.ReturnAuthenticator
 	DomainModifiedCount = resp.DomainModifiedCount
 	DeltaArray = resp.DeltaArray
-	if uint32(resp.Status) != logon.StatusSuccess {
-		err = fmt.Errorf("NetrDatabaseDeltas failed: %s", logon.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		err = fmt.Errorf("NetrDatabaseDeltas failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/08_NetrDatabaseSync.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/08_NetrDatabaseSync.go
@@ -10,6 +10,7 @@ import (
 
 	logon "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msnrpc "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nrpc"
 )
 
@@ -54,8 +55,8 @@ func NetrDatabaseSync(rpc ndr.Invoker, primaryName ndr.WSTR, computerName ndr.WS
 	ReturnAuthenticator = resp.ReturnAuthenticator
 	SyncContext = resp.SyncContext
 	DeltaArray = resp.DeltaArray
-	if uint32(resp.Status) != logon.StatusSuccess {
-		err = fmt.Errorf("NetrDatabaseSync failed: %s", logon.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		err = fmt.Errorf("NetrDatabaseSync failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/09_NetrAccountDeltas.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/09_NetrAccountDeltas.go
@@ -10,6 +10,7 @@ import (
 
 	logon "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msnrpc "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nrpc"
 )
 
@@ -60,8 +61,8 @@ func NetrAccountDeltas(rpc ndr.Invoker, primaryName *ndr.WSTR, computerName ndr.
 	CountReturned = resp.CountReturned
 	TotalEntries = resp.TotalEntries
 	NextRecordId = resp.NextRecordId
-	if uint32(resp.Status) != logon.StatusSuccess {
-		err = fmt.Errorf("NetrAccountDeltas failed: %s", logon.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		err = fmt.Errorf("NetrAccountDeltas failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/10_NetrAccountSync.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/10_NetrAccountSync.go
@@ -10,6 +10,7 @@ import (
 
 	logon "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msnrpc "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nrpc"
 )
 
@@ -60,8 +61,8 @@ func NetrAccountSync(rpc ndr.Invoker, primaryName *ndr.WSTR, computerName ndr.WS
 	TotalEntries = resp.TotalEntries
 	NextReference = resp.NextReference
 	LastRecordId = resp.LastRecordId
-	if uint32(resp.Status) != logon.StatusSuccess {
-		err = fmt.Errorf("NetrAccountSync failed: %s", logon.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		err = fmt.Errorf("NetrAccountSync failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/11_NetrGetDCName.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/11_NetrGetDCName.go
@@ -10,6 +10,7 @@ import (
 
 	logon "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 )
 
 // netrGetDCNameRequest carries the [in] parameters of NetrGetDCName.
@@ -39,8 +40,8 @@ func NetrGetDCName(rpc ndr.Invoker, serverName ndr.WSTR, domainName *ndr.WSTR) (
 		return
 	}
 	Buffer = resp.Buffer
-	if uint32(resp.Status) != logon.StatusSuccess {
-		err = fmt.Errorf("NetrGetDCName failed: %s", logon.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		err = fmt.Errorf("NetrGetDCName failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/12_NetrLogonControl.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/12_NetrLogonControl.go
@@ -10,6 +10,7 @@ import (
 
 	logon "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msnrpc "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nrpc"
 )
 
@@ -42,8 +43,8 @@ func NetrLogonControl(rpc ndr.Invoker, serverName *ndr.WSTR, functionCode ndr.DW
 		return
 	}
 	Buffer = resp.Buffer
-	if uint32(resp.Status) != logon.StatusSuccess {
-		err = fmt.Errorf("NetrLogonControl failed: %s", logon.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		err = fmt.Errorf("NetrLogonControl failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/13_NetrGetAnyDCName.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/13_NetrGetAnyDCName.go
@@ -10,6 +10,7 @@ import (
 
 	logon "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 )
 
 // netrGetAnyDCNameRequest carries the [in] parameters of NetrGetAnyDCName.
@@ -39,8 +40,8 @@ func NetrGetAnyDCName(rpc ndr.Invoker, serverName *ndr.WSTR, domainName *ndr.WST
 		return
 	}
 	Buffer = resp.Buffer
-	if uint32(resp.Status) != logon.StatusSuccess {
-		err = fmt.Errorf("NetrGetAnyDCName failed: %s", logon.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		err = fmt.Errorf("NetrGetAnyDCName failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/14_NetrLogonControl2.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/14_NetrLogonControl2.go
@@ -10,6 +10,7 @@ import (
 
 	logon "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msnrpc "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nrpc"
 )
 
@@ -44,8 +45,8 @@ func NetrLogonControl2(rpc ndr.Invoker, serverName *ndr.WSTR, functionCode ndr.D
 		return
 	}
 	Buffer = resp.Buffer
-	if uint32(resp.Status) != logon.StatusSuccess {
-		err = fmt.Errorf("NetrLogonControl2 failed: %s", logon.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		err = fmt.Errorf("NetrLogonControl2 failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/16_NetrDatabaseSync2.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/16_NetrDatabaseSync2.go
@@ -10,6 +10,7 @@ import (
 
 	logon "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msnrpc "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nrpc"
 )
 
@@ -56,8 +57,8 @@ func NetrDatabaseSync2(rpc ndr.Invoker, primaryName ndr.WSTR, computerName ndr.W
 	ReturnAuthenticator = resp.ReturnAuthenticator
 	SyncContext = resp.SyncContext
 	DeltaArray = resp.DeltaArray
-	if uint32(resp.Status) != logon.StatusSuccess {
-		err = fmt.Errorf("NetrDatabaseSync2 failed: %s", logon.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		err = fmt.Errorf("NetrDatabaseSync2 failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/17_NetrDatabaseRedo.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/17_NetrDatabaseRedo.go
@@ -10,6 +10,7 @@ import (
 
 	logon "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msnrpc "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nrpc"
 )
 
@@ -50,8 +51,8 @@ func NetrDatabaseRedo(rpc ndr.Invoker, primaryName ndr.WSTR, computerName ndr.WS
 	}
 	ReturnAuthenticator = resp.ReturnAuthenticator
 	DeltaArray = resp.DeltaArray
-	if uint32(resp.Status) != logon.StatusSuccess {
-		err = fmt.Errorf("NetrDatabaseRedo failed: %s", logon.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		err = fmt.Errorf("NetrDatabaseRedo failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/18_NetrLogonControl2Ex.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/18_NetrLogonControl2Ex.go
@@ -10,6 +10,7 @@ import (
 
 	logon "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msnrpc "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nrpc"
 )
 
@@ -44,8 +45,8 @@ func NetrLogonControl2Ex(rpc ndr.Invoker, serverName *ndr.WSTR, functionCode ndr
 		return
 	}
 	Buffer = resp.Buffer
-	if uint32(resp.Status) != logon.StatusSuccess {
-		err = fmt.Errorf("NetrLogonControl2Ex failed: %s", logon.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		err = fmt.Errorf("NetrLogonControl2Ex failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/19_NetrEnumerateTrustedDomains.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/19_NetrEnumerateTrustedDomains.go
@@ -10,6 +10,7 @@ import (
 
 	logon "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msnrpc "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nrpc"
 )
 
@@ -40,8 +41,8 @@ func NetrEnumerateTrustedDomains(rpc ndr.Invoker, serverName *ndr.WSTR) (DomainN
 		return
 	}
 	DomainNameBuffer = resp.DomainNameBuffer
-	if uint32(resp.Status) != logon.StatusSuccess {
-		err = fmt.Errorf("NetrEnumerateTrustedDomains failed: %s", logon.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		err = fmt.Errorf("NetrEnumerateTrustedDomains failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/20_DsrGetDcName.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/20_DsrGetDcName.go
@@ -10,6 +10,7 @@ import (
 
 	logon "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	"github.com/TheManticoreProject/Manticore/windows/guid"
 	msnrpc "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nrpc"
 )
@@ -47,8 +48,8 @@ func DsrGetDcName(rpc ndr.Invoker, computerName *ndr.WSTR, domainName *ndr.WSTR,
 		return
 	}
 	DomainControllerInfo = resp.DomainControllerInfo
-	if uint32(resp.Status) != logon.StatusSuccess {
-		err = fmt.Errorf("DsrGetDcName failed: %s", logon.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		err = fmt.Errorf("DsrGetDcName failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/21_NetrLogonGetCapabilities.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/21_NetrLogonGetCapabilities.go
@@ -10,6 +10,7 @@ import (
 
 	logon "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msnrpc "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nrpc"
 )
 
@@ -48,8 +49,8 @@ func NetrLogonGetCapabilities(rpc ndr.Invoker, serverName ndr.WSTR, computerName
 	}
 	ReturnAuthenticator = resp.ReturnAuthenticator
 	Capabilities = resp.Capabilities
-	if uint32(resp.Status) != logon.StatusSuccess {
-		err = fmt.Errorf("NetrLogonGetCapabilities failed: %s", logon.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		err = fmt.Errorf("NetrLogonGetCapabilities failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/22_NetrLogonSetServiceBits.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/22_NetrLogonSetServiceBits.go
@@ -10,6 +10,7 @@ import (
 
 	logon "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 )
 
 // netrLogonSetServiceBitsRequest carries the [in] parameters of NetrLogonSetServiceBits.
@@ -39,8 +40,8 @@ func NetrLogonSetServiceBits(rpc ndr.Invoker, serverName *ndr.WSTR, serviceBitsO
 		err = fmt.Errorf("NetrLogonSetServiceBits: %w", err)
 		return
 	}
-	if uint32(resp.Status) != logon.StatusSuccess {
-		err = fmt.Errorf("NetrLogonSetServiceBits failed: %s", logon.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		err = fmt.Errorf("NetrLogonSetServiceBits failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/23_NetrLogonGetTrustRid.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/23_NetrLogonGetTrustRid.go
@@ -10,6 +10,7 @@ import (
 
 	logon "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 )
 
 // netrLogonGetTrustRidRequest carries the [in] parameters of NetrLogonGetTrustRid.
@@ -39,8 +40,8 @@ func NetrLogonGetTrustRid(rpc ndr.Invoker, serverName *ndr.WSTR, domainName *ndr
 		return
 	}
 	Rid = resp.Rid
-	if uint32(resp.Status) != logon.StatusSuccess {
-		err = fmt.Errorf("NetrLogonGetTrustRid failed: %s", logon.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		err = fmt.Errorf("NetrLogonGetTrustRid failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/24_NetrLogonComputeServerDigest.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/24_NetrLogonComputeServerDigest.go
@@ -10,6 +10,7 @@ import (
 
 	logon "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 )
 
 // netrLogonComputeServerDigestRequest carries the [in] parameters of NetrLogonComputeServerDigest.
@@ -47,8 +48,8 @@ func NetrLogonComputeServerDigest(rpc ndr.Invoker, serverName *ndr.WSTR, rid ndr
 	}
 	NewMessageDigest = resp.NewMessageDigest
 	OldMessageDigest = resp.OldMessageDigest
-	if uint32(resp.Status) != logon.StatusSuccess {
-		err = fmt.Errorf("NetrLogonComputeServerDigest failed: %s", logon.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		err = fmt.Errorf("NetrLogonComputeServerDigest failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/25_NetrLogonComputeClientDigest.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/25_NetrLogonComputeClientDigest.go
@@ -10,6 +10,7 @@ import (
 
 	logon "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 )
 
 // netrLogonComputeClientDigestRequest carries the [in] parameters of NetrLogonComputeClientDigest.
@@ -47,8 +48,8 @@ func NetrLogonComputeClientDigest(rpc ndr.Invoker, serverName *ndr.WSTR, domainN
 	}
 	NewMessageDigest = resp.NewMessageDigest
 	OldMessageDigest = resp.OldMessageDigest
-	if uint32(resp.Status) != logon.StatusSuccess {
-		err = fmt.Errorf("NetrLogonComputeClientDigest failed: %s", logon.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		err = fmt.Errorf("NetrLogonComputeClientDigest failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/26_NetrServerAuthenticate3.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/26_NetrServerAuthenticate3.go
@@ -10,6 +10,7 @@ import (
 
 	logon "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msnrpc "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nrpc"
 )
 
@@ -52,8 +53,8 @@ func NetrServerAuthenticate3(rpc ndr.Invoker, primaryName *ndr.WSTR, accountName
 	ServerCredential = resp.ServerCredential
 	NegotiateFlags = resp.NegotiateFlags
 	AccountRid = resp.AccountRid
-	if uint32(resp.Status) != logon.StatusSuccess {
-		err = fmt.Errorf("NetrServerAuthenticate3 failed: %s", logon.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		err = fmt.Errorf("NetrServerAuthenticate3 failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/27_DsrGetDcNameEx.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/27_DsrGetDcNameEx.go
@@ -10,6 +10,7 @@ import (
 
 	logon "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	"github.com/TheManticoreProject/Manticore/windows/guid"
 	msnrpc "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nrpc"
 )
@@ -47,8 +48,8 @@ func DsrGetDcNameEx(rpc ndr.Invoker, computerName *ndr.WSTR, domainName *ndr.WST
 		return
 	}
 	DomainControllerInfo = resp.DomainControllerInfo
-	if uint32(resp.Status) != logon.StatusSuccess {
-		err = fmt.Errorf("DsrGetDcNameEx failed: %s", logon.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		err = fmt.Errorf("DsrGetDcNameEx failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/28_DsrGetSiteName.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/28_DsrGetSiteName.go
@@ -10,6 +10,7 @@ import (
 
 	logon "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 )
 
 // dsrGetSiteNameRequest carries the [in] parameters of DsrGetSiteName.
@@ -37,8 +38,8 @@ func DsrGetSiteName(rpc ndr.Invoker, computerName *ndr.WSTR) (SiteName ndr.WSTR,
 		return
 	}
 	SiteName = resp.SiteName
-	if uint32(resp.Status) != logon.StatusSuccess {
-		err = fmt.Errorf("DsrGetSiteName failed: %s", logon.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		err = fmt.Errorf("DsrGetSiteName failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/29_NetrLogonGetDomainInfo.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/29_NetrLogonGetDomainInfo.go
@@ -10,6 +10,7 @@ import (
 
 	logon "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msnrpc "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nrpc"
 )
 
@@ -50,8 +51,8 @@ func NetrLogonGetDomainInfo(rpc ndr.Invoker, serverName ndr.WSTR, computerName *
 	}
 	ReturnAuthenticator = resp.ReturnAuthenticator
 	DomBuffer = resp.DomBuffer
-	if uint32(resp.Status) != logon.StatusSuccess {
-		err = fmt.Errorf("NetrLogonGetDomainInfo failed: %s", logon.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		err = fmt.Errorf("NetrLogonGetDomainInfo failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/31_NetrServerPasswordGet.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/31_NetrServerPasswordGet.go
@@ -10,6 +10,7 @@ import (
 
 	logon "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msnrpc "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nrpc"
 )
 
@@ -48,8 +49,8 @@ func NetrServerPasswordGet(rpc ndr.Invoker, primaryName *ndr.WSTR, accountName n
 	}
 	ReturnAuthenticator = resp.ReturnAuthenticator
 	EncryptedNtOwfPassword = resp.EncryptedNtOwfPassword
-	if uint32(resp.Status) != logon.StatusSuccess {
-		err = fmt.Errorf("NetrServerPasswordGet failed: %s", logon.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		err = fmt.Errorf("NetrServerPasswordGet failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/32_NetrLogonSendToSam.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/32_NetrLogonSendToSam.go
@@ -10,6 +10,7 @@ import (
 
 	logon "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msnrpc "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nrpc"
 )
 
@@ -46,8 +47,8 @@ func NetrLogonSendToSam(rpc ndr.Invoker, primaryName *ndr.WSTR, computerName ndr
 		return
 	}
 	ReturnAuthenticator = resp.ReturnAuthenticator
-	if uint32(resp.Status) != logon.StatusSuccess {
-		err = fmt.Errorf("NetrLogonSendToSam failed: %s", logon.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		err = fmt.Errorf("NetrLogonSendToSam failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/33_DsrAddressToSiteNamesW.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/33_DsrAddressToSiteNamesW.go
@@ -10,6 +10,7 @@ import (
 
 	logon "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msnrpc "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nrpc"
 )
 
@@ -42,8 +43,8 @@ func DsrAddressToSiteNamesW(rpc ndr.Invoker, computerName *ndr.WSTR, entryCount 
 		return
 	}
 	SiteNames = resp.SiteNames
-	if uint32(resp.Status) != logon.StatusSuccess {
-		err = fmt.Errorf("DsrAddressToSiteNamesW failed: %s", logon.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		err = fmt.Errorf("DsrAddressToSiteNamesW failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/34_DsrGetDcNameEx2.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/34_DsrGetDcNameEx2.go
@@ -10,6 +10,7 @@ import (
 
 	logon "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	"github.com/TheManticoreProject/Manticore/windows/guid"
 	msnrpc "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nrpc"
 )
@@ -51,8 +52,8 @@ func DsrGetDcNameEx2(rpc ndr.Invoker, computerName *ndr.WSTR, accountName *ndr.W
 		return
 	}
 	DomainControllerInfo = resp.DomainControllerInfo
-	if uint32(resp.Status) != logon.StatusSuccess {
-		err = fmt.Errorf("DsrGetDcNameEx2 failed: %s", logon.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		err = fmt.Errorf("DsrGetDcNameEx2 failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/35_NetrLogonGetTimeServiceParentDomain.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/35_NetrLogonGetTimeServiceParentDomain.go
@@ -10,6 +10,7 @@ import (
 
 	logon "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 )
 
 // netrLogonGetTimeServiceParentDomainRequest carries the [in] parameters of NetrLogonGetTimeServiceParentDomain.
@@ -41,8 +42,8 @@ func NetrLogonGetTimeServiceParentDomain(rpc ndr.Invoker, serverName *ndr.WSTR) 
 	}
 	DomainName = resp.DomainName
 	PdcSameSite = resp.PdcSameSite
-	if uint32(resp.Status) != logon.StatusSuccess {
-		err = fmt.Errorf("NetrLogonGetTimeServiceParentDomain failed: %s", logon.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		err = fmt.Errorf("NetrLogonGetTimeServiceParentDomain failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/36_NetrEnumerateTrustedDomainsEx.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/36_NetrEnumerateTrustedDomainsEx.go
@@ -10,6 +10,7 @@ import (
 
 	logon "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msnrpc "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nrpc"
 )
 
@@ -40,8 +41,8 @@ func NetrEnumerateTrustedDomainsEx(rpc ndr.Invoker, serverName *ndr.WSTR) (Domai
 		return
 	}
 	Domains = resp.Domains
-	if uint32(resp.Status) != logon.StatusSuccess {
-		err = fmt.Errorf("NetrEnumerateTrustedDomainsEx failed: %s", logon.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		err = fmt.Errorf("NetrEnumerateTrustedDomainsEx failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/37_DsrAddressToSiteNamesExW.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/37_DsrAddressToSiteNamesExW.go
@@ -10,6 +10,7 @@ import (
 
 	logon "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msnrpc "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nrpc"
 )
 
@@ -42,8 +43,8 @@ func DsrAddressToSiteNamesExW(rpc ndr.Invoker, computerName *ndr.WSTR, entryCoun
 		return
 	}
 	SiteNames = resp.SiteNames
-	if uint32(resp.Status) != logon.StatusSuccess {
-		err = fmt.Errorf("DsrAddressToSiteNamesExW failed: %s", logon.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		err = fmt.Errorf("DsrAddressToSiteNamesExW failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/38_DsrGetDcSiteCoverageW.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/38_DsrGetDcSiteCoverageW.go
@@ -10,6 +10,7 @@ import (
 
 	logon "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msnrpc "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nrpc"
 )
 
@@ -38,8 +39,8 @@ func DsrGetDcSiteCoverageW(rpc ndr.Invoker, serverName *ndr.WSTR) (SiteNames *ms
 		return
 	}
 	SiteNames = resp.SiteNames
-	if uint32(resp.Status) != logon.StatusSuccess {
-		err = fmt.Errorf("DsrGetDcSiteCoverageW failed: %s", logon.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		err = fmt.Errorf("DsrGetDcSiteCoverageW failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/39_NetrLogonSamLogonEx.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/39_NetrLogonSamLogonEx.go
@@ -10,6 +10,7 @@ import (
 
 	logon "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msnrpc "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nrpc"
 )
 
@@ -52,8 +53,8 @@ func NetrLogonSamLogonEx(rpc ndr.Invoker, logonServer *ndr.WSTR, computerName *n
 	ValidationInformation = resp.ValidationInformation
 	Authoritative = resp.Authoritative
 	ExtraFlags = resp.ExtraFlags
-	if uint32(resp.Status) != logon.StatusSuccess {
-		err = fmt.Errorf("NetrLogonSamLogonEx failed: %s", logon.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		err = fmt.Errorf("NetrLogonSamLogonEx failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/40_DsrEnumerateDomainTrusts.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/40_DsrEnumerateDomainTrusts.go
@@ -10,6 +10,7 @@ import (
 
 	logon "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msnrpc "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nrpc"
 )
 
@@ -40,8 +41,8 @@ func DsrEnumerateDomainTrusts(rpc ndr.Invoker, serverName *ndr.WSTR, flags ndr.D
 		return
 	}
 	Domains = resp.Domains
-	if uint32(resp.Status) != logon.StatusSuccess {
-		err = fmt.Errorf("DsrEnumerateDomainTrusts failed: %s", logon.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		err = fmt.Errorf("DsrEnumerateDomainTrusts failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/41_DsrDeregisterDnsHostRecords.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/41_DsrDeregisterDnsHostRecords.go
@@ -10,6 +10,7 @@ import (
 
 	logon "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	"github.com/TheManticoreProject/Manticore/windows/guid"
 )
 
@@ -46,8 +47,8 @@ func DsrDeregisterDnsHostRecords(rpc ndr.Invoker, serverName *ndr.WSTR, dnsDomai
 		err = fmt.Errorf("DsrDeregisterDnsHostRecords: %w", err)
 		return
 	}
-	if uint32(resp.Status) != logon.StatusSuccess {
-		err = fmt.Errorf("DsrDeregisterDnsHostRecords failed: %s", logon.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		err = fmt.Errorf("DsrDeregisterDnsHostRecords failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/42_NetrServerTrustPasswordsGet.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/42_NetrServerTrustPasswordsGet.go
@@ -10,6 +10,7 @@ import (
 
 	logon "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msnrpc "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nrpc"
 )
 
@@ -52,8 +53,8 @@ func NetrServerTrustPasswordsGet(rpc ndr.Invoker, trustedDcName *ndr.WSTR, accou
 	ReturnAuthenticator = resp.ReturnAuthenticator
 	EncryptedNewOwfPassword = resp.EncryptedNewOwfPassword
 	EncryptedOldOwfPassword = resp.EncryptedOldOwfPassword
-	if uint32(resp.Status) != logon.StatusSuccess {
-		err = fmt.Errorf("NetrServerTrustPasswordsGet failed: %s", logon.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		err = fmt.Errorf("NetrServerTrustPasswordsGet failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/43_DsrGetForestTrustInformation.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/43_DsrGetForestTrustInformation.go
@@ -10,6 +10,7 @@ import (
 
 	logon "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msnrpc "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nrpc"
 )
 
@@ -44,8 +45,8 @@ func DsrGetForestTrustInformation(rpc ndr.Invoker, serverName *ndr.WSTR, trusted
 		return
 	}
 	ForestTrustInfo = resp.ForestTrustInfo
-	if uint32(resp.Status) != logon.StatusSuccess {
-		err = fmt.Errorf("DsrGetForestTrustInformation failed: %s", logon.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		err = fmt.Errorf("DsrGetForestTrustInformation failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/44_NetrGetForestTrustInformation.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/44_NetrGetForestTrustInformation.go
@@ -10,6 +10,7 @@ import (
 
 	logon "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msnrpc "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nrpc"
 )
 
@@ -48,8 +49,8 @@ func NetrGetForestTrustInformation(rpc ndr.Invoker, serverName *ndr.WSTR, comput
 	}
 	ReturnAuthenticator = resp.ReturnAuthenticator
 	ForestTrustInfo = resp.ForestTrustInfo
-	if uint32(resp.Status) != logon.StatusSuccess {
-		err = fmt.Errorf("NetrGetForestTrustInformation failed: %s", logon.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		err = fmt.Errorf("NetrGetForestTrustInformation failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/45_NetrLogonSamLogonWithFlags.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/45_NetrLogonSamLogonWithFlags.go
@@ -10,6 +10,7 @@ import (
 
 	logon "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msnrpc "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nrpc"
 )
 
@@ -60,8 +61,8 @@ func NetrLogonSamLogonWithFlags(rpc ndr.Invoker, logonServer *ndr.WSTR, computer
 	ValidationInformation = resp.ValidationInformation
 	Authoritative = resp.Authoritative
 	ExtraFlags = resp.ExtraFlags
-	if uint32(resp.Status) != logon.StatusSuccess {
-		err = fmt.Errorf("NetrLogonSamLogonWithFlags failed: %s", logon.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		err = fmt.Errorf("NetrLogonSamLogonWithFlags failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/46_NetrServerGetTrustInfo.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/46_NetrServerGetTrustInfo.go
@@ -10,6 +10,7 @@ import (
 
 	logon "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msnrpc "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nrpc"
 )
 
@@ -52,8 +53,8 @@ func NetrServerGetTrustInfo(rpc ndr.Invoker, trustedDcName *ndr.WSTR, accountNam
 	EncryptedNewOwfPassword = resp.EncryptedNewOwfPassword
 	EncryptedOldOwfPassword = resp.EncryptedOldOwfPassword
 	TrustInfo = resp.TrustInfo
-	if uint32(resp.Status) != logon.StatusSuccess {
-		err = fmt.Errorf("NetrServerGetTrustInfo failed: %s", logon.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		err = fmt.Errorf("NetrServerGetTrustInfo failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/47_OpnumUnused47.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/47_OpnumUnused47.go
@@ -10,6 +10,7 @@ import (
 
 	logon "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 )
 
 // opnumUnused47Request carries the [in] parameters of OpnumUnused47.
@@ -32,8 +33,8 @@ func OpnumUnused47(rpc ndr.Invoker) (err error) {
 		err = fmt.Errorf("OpnumUnused47: %w", err)
 		return
 	}
-	if uint32(resp.Status) != logon.StatusSuccess {
-		err = fmt.Errorf("OpnumUnused47 failed: %s", logon.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		err = fmt.Errorf("OpnumUnused47 failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/48_DsrUpdateReadOnlyServerDnsRecords.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/48_DsrUpdateReadOnlyServerDnsRecords.go
@@ -10,6 +10,7 @@ import (
 
 	logon "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msnrpc "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nrpc"
 )
 
@@ -52,8 +53,8 @@ func DsrUpdateReadOnlyServerDnsRecords(rpc ndr.Invoker, serverName *ndr.WSTR, co
 	}
 	ReturnAuthenticator = resp.ReturnAuthenticator
 	DnsNames = resp.DnsNames
-	if uint32(resp.Status) != logon.StatusSuccess {
-		err = fmt.Errorf("DsrUpdateReadOnlyServerDnsRecords failed: %s", logon.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		err = fmt.Errorf("DsrUpdateReadOnlyServerDnsRecords failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/49_NetrChainSetClientAttributes.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/49_NetrChainSetClientAttributes.go
@@ -10,6 +10,7 @@ import (
 
 	logon "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msnrpc "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nrpc"
 )
 
@@ -60,8 +61,8 @@ func NetrChainSetClientAttributes(rpc ndr.Invoker, primaryName ndr.WSTR, chained
 	ReturnAuthenticator = resp.ReturnAuthenticator
 	PdwOutVersion = resp.PdwOutVersion
 	PmsgOut = resp.PmsgOut
-	if uint32(resp.Status) != logon.StatusSuccess {
-		err = fmt.Errorf("NetrChainSetClientAttributes failed: %s", logon.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		err = fmt.Errorf("NetrChainSetClientAttributes failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/59_NetrServerAuthenticateKerberos.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/59_NetrServerAuthenticateKerberos.go
@@ -10,6 +10,7 @@ import (
 
 	logon "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msnrpc "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nrpc"
 )
 
@@ -50,8 +51,8 @@ func NetrServerAuthenticateKerberos(rpc ndr.Invoker, primaryName *ndr.WSTR, acco
 	}
 	NegotiateFlags = resp.NegotiateFlags
 	AccountRid = resp.AccountRid
-	if uint32(resp.Status) != logon.StatusSuccess {
-		err = fmt.Errorf("NetrServerAuthenticateKerberos failed: %s", logon.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		err = fmt.Errorf("NetrServerAuthenticateKerberos failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/interface.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/interface.go
@@ -4,9 +4,9 @@
 //
 // An RPC interface is identified by its UUID and version, never by the named pipe it is
 // reached over. This package holds only the interface-level descriptor (abstract syntax,
-// transport endpoint, opnums, opnum<->name maps, status and negotiate-flag constants). NDR
-// types live in windows/protocols/ms-nrpc and method stubs in functions; both depend on
-// this package, never the reverse.
+// transport endpoint, opnums, opnum<->name maps and negotiate-flag constants). NDR types
+// live in windows/protocols/ms-nrpc and method stubs in functions; both depend on this
+// package, never the reverse.
 package rpcinterface_123456781234abcdef0001234567cffb_1_0
 
 // IDL source: [MS-NRPC] — this interface is translated from and verified
@@ -15,8 +15,6 @@ package rpcinterface_123456781234abcdef0001234567cffb_1_0
 // A fetched copy is kept at ms-nrpc.idl in the interface directory.
 
 import (
-	"fmt"
-
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
 	"github.com/TheManticoreProject/Manticore/windows/guid"
 )
@@ -82,21 +80,10 @@ const (
 	OpnumNetrServerAuthenticateKerberos      uint16 = 59
 )
 
-// NTSTATUS values returned by Netlogon methods ([MS-ERREF] 2.3). Netlogon returns NTSTATUS
-// (not the Win32 error_status_t that MS-RRP uses). StatusSuccess is the canonical success
-// value; StatusAccessDenied is what the server returns for a rejected secure-channel
-// credential.
-const (
-	StatusSuccess           uint32 = 0x00000000 // STATUS_SUCCESS
-	StatusInvalidParameter  uint32 = 0xC000000D // STATUS_INVALID_PARAMETER
-	StatusAccessDenied      uint32 = 0xC0000022 // STATUS_ACCESS_DENIED
-	StatusNoSuchUser        uint32 = 0xC0000064 // STATUS_NO_SUCH_USER
-	StatusNoTrustSAMAccount uint32 = 0xC000018B // STATUS_NO_TRUST_SAM_ACCOUNT
-	StatusNotSupported      uint32 = 0xC00000BB // STATUS_NOT_SUPPORTED
-	StatusMoreEntries       uint32 = 0x00000105 // STATUS_MORE_ENTRIES
-	StatusNoMoreEntries     uint32 = 0x8000001A // STATUS_NO_MORE_ENTRIES
-	StatusDowngradeDetected uint32 = 0xC0000388 // STATUS_DOWNGRADE_DETECTED
-)
+// Netlogon methods return NTSTATUS ([MS-ERREF] 2.3.1), not the Win32 error_status_t that
+// MS-RRP uses. The codes are not declared here: the whole of [MS-ERREF] 2.3.1 lives in
+// github.com/TheManticoreProject/Manticore/windows/errors/nt_status, and a subset here
+// would cover a fraction of that table and drift from it.
 
 // SyntaxID returns the logon abstract syntax identifier:
 // 12345678-1234-abcd-ef00-01234567cffb, version 1.0.
@@ -105,33 +92,6 @@ func SyntaxID() syntax.SyntaxID {
 		UUID:         guid.GUID{A: 0x12345678, B: 0x1234, C: 0xabcd, D: 0xef00, E: 0x01234567cffb},
 		MajorVersion: 1,
 		MinorVersion: 0,
-	}
-}
-
-// StatusString returns a mnemonic for the documented status codes, otherwise the
-// hex value.
-func StatusString(status uint32) string {
-	switch status {
-	case StatusSuccess:
-		return "STATUS_SUCCESS"
-	case StatusInvalidParameter:
-		return "STATUS_INVALID_PARAMETER"
-	case StatusAccessDenied:
-		return "STATUS_ACCESS_DENIED"
-	case StatusNoSuchUser:
-		return "STATUS_NO_SUCH_USER"
-	case StatusNoTrustSAMAccount:
-		return "STATUS_NO_TRUST_SAM_ACCOUNT"
-	case StatusNotSupported:
-		return "STATUS_NOT_SUPPORTED"
-	case StatusMoreEntries:
-		return "STATUS_MORE_ENTRIES"
-	case StatusNoMoreEntries:
-		return "STATUS_NO_MORE_ENTRIES"
-	case StatusDowngradeDetected:
-		return "STATUS_DOWNGRADE_DETECTED"
-	default:
-		return fmt.Sprintf("0x%08x", status)
 	}
 }
 

--- a/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/interface_test.go
+++ b/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/interface_test.go
@@ -1,6 +1,10 @@
 package rpcinterface_123456781234abcdef0001234567cffb_1_0
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
+)
 
 // TestSyntaxID verifies the abstract syntax identity (UUID + version) of the interface.
 func TestSyntaxID(t *testing.T) {
@@ -23,12 +27,33 @@ func TestOpnums(t *testing.T) {
 	}
 }
 
-// TestStatusString verifies mnemonic rendering and the hex fallback.
-func TestStatusString(t *testing.T) {
-	if got := StatusString(StatusAccessDenied); got != "STATUS_ACCESS_DENIED" {
-		t.Fatalf("StatusString(AccessDenied) = %s", got)
+// TestStatusCodesResolveThroughNTStatus verifies that the NTSTATUS values Netlogon
+// documents resolve through the shared [MS-ERREF] 2.3.1 table under their NT_STATUS_*
+// names, that a status the interface never enumerated now renders by name instead of as
+// undecoded hex, and that a value no specification defines still renders as hex.
+func TestStatusCodesResolveThroughNTStatus(t *testing.T) {
+	documented := map[nt_status.NT_STATUS]string{
+		0x00000000: "NT_STATUS_SUCCESS",
+		0xC000000D: "NT_STATUS_INVALID_PARAMETER",
+		0xC0000022: "NT_STATUS_ACCESS_DENIED",
+		0xC0000064: "NT_STATUS_NO_SUCH_USER",
+		0xC00000BB: "NT_STATUS_NOT_SUPPORTED",
+		0xC000018B: "NT_STATUS_NO_TRUST_SAM_ACCOUNT",
+		0x00000105: "NT_STATUS_MORE_ENTRIES",
+		0x8000001A: "NT_STATUS_NO_MORE_ENTRIES",
+		0xC0000388: "NT_STATUS_DOWNGRADE_DETECTED",
 	}
-	if got := StatusString(0xDEADBEEF); got != "0xdeadbeef" {
-		t.Fatalf("StatusString(unknown) = %s, want 0xdeadbeef", got)
+	for status, want := range documented {
+		if got := status.String(); got != want {
+			t.Fatalf("NT_STATUS(0x%08x).String() = %s, want %s", uint32(status), got, want)
+		}
+	}
+	// STATUS_NOLOGON_WORKSTATION_TRUST_ACCOUNT is a routine Netlogon rejection that the
+	// interface's own subset never listed, so it used to print as bare hex.
+	if got := nt_status.NT_STATUS(0xC0000199).String(); got != "NT_STATUS_NOLOGON_WORKSTATION_TRUST_ACCOUNT" {
+		t.Fatalf("NT_STATUS(0xc0000199).String() = %s, want NT_STATUS_NOLOGON_WORKSTATION_TRUST_ACCOUNT", got)
+	}
+	if got := nt_status.NT_STATUS(0xDEADBEEF).String(); got != "0xdeadbeef" {
+		t.Fatalf("NT_STATUS(0xdeadbeef).String() = %s, want 0xdeadbeef", got)
 	}
 }

--- a/windows/protocols/ms-nrpc/securechannel/securechannel.go
+++ b/windows/protocols/ms-nrpc/securechannel/securechannel.go
@@ -13,6 +13,7 @@ import (
 	logon "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msnrpc "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nrpc"
 	nrpccrypto "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nrpc/crypto"
 )
@@ -107,8 +108,8 @@ func Establish(rpc ndr.Invoker, cfg SecureChannelConfig) (*SecureChannel, error)
 	if err != nil {
 		return nil, fmt.Errorf("netlogon secure channel: NetrServerReqChallenge: %w", err)
 	}
-	if status != logon.StatusSuccess {
-		return nil, fmt.Errorf("netlogon secure channel: NetrServerReqChallenge: %s", logon.StatusString(status))
+	if nt_status.NT_STATUS(status) != nt_status.NT_STATUS_SUCCESS {
+		return nil, fmt.Errorf("netlogon secure channel: NetrServerReqChallenge: %s", nt_status.NT_STATUS(status).String())
 	}
 
 	flags := cfg.NegotiateFlags

--- a/windows/protocols/ms-nrpc/securechannel/securechannel_test.go
+++ b/windows/protocols/ms-nrpc/securechannel/securechannel_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/crypto/nt"
 	netlogon "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msnrpc "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nrpc"
 	nrpccrypto "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nrpc/crypto"
 )
@@ -93,7 +94,7 @@ type scriptInvoker struct {
 	sessionKey      [16]byte
 	aes             bool
 	echoFlags       uint32
-	reqStatus       uint32
+	reqStatus       nt_status.NT_STATUS
 	forgeServer     bool
 	opnums          []uint16
 	auth3Stub       []byte
@@ -125,7 +126,7 @@ func (s *scriptInvoker) Invoke(in ndr.Call, out any) error {
 		if s.forgeServer {
 			cred[0] ^= 0xff
 		}
-		b, err := ndr.Marshal(&authenticate3Resp{ServerCredential: cred, NegotiateFlags: ndr.DWORD(s.echoFlags), Status: ndr.DWORD(netlogon.StatusSuccess)})
+		b, err := ndr.Marshal(&authenticate3Resp{ServerCredential: cred, NegotiateFlags: ndr.DWORD(s.echoFlags), Status: ndr.DWORD(nt_status.NT_STATUS_SUCCESS)})
 		if err != nil {
 			return err
 		}
@@ -136,7 +137,7 @@ func (s *scriptInvoker) Invoke(in ndr.Call, out any) error {
 
 // establishFixture builds a scripted invoker and config for a fixed client/server challenge
 // and password, for the AES suite (aes=true) or the legacy strong-key suite (aes=false).
-func establishFixture(aes, forge bool, reqStatus uint32) (*scriptInvoker, SecureChannelConfig, msnrpc.NETLOGON_CREDENTIAL, [16]byte) {
+func establishFixture(aes, forge bool, reqStatus nt_status.NT_STATUS) (*scriptInvoker, SecureChannelConfig, msnrpc.NETLOGON_CREDENTIAL, [16]byte) {
 	clientChallenge := msnrpc.NETLOGON_CREDENTIAL{1, 2, 3, 4, 5, 6, 7, 8}
 	serverChallenge := msnrpc.NETLOGON_CREDENTIAL{8, 7, 6, 5, 4, 3, 2, 1}
 	const password = "Machine$Pass1"
@@ -164,7 +165,7 @@ func establishFixture(aes, forge bool, reqStatus uint32) (*scriptInvoker, Secure
 // TestEstablishHappyPathAES verifies the handshake sequence, the derived session key, the
 // seeded stored credential, and the credential the client sent in NetrServerAuthenticate3.
 func TestEstablishHappyPathAES(t *testing.T) {
-	inv, cfg, clientChallenge, sk := establishFixture(true, false, netlogon.StatusSuccess)
+	inv, cfg, clientChallenge, sk := establishFixture(true, false, nt_status.NT_STATUS_SUCCESS)
 
 	sc, err := Establish(inv, cfg)
 	if err != nil {
@@ -195,7 +196,7 @@ func TestEstablishHappyPathAES(t *testing.T) {
 // TestEstablishHappyPathRC4 exercises the legacy strong-key suite selection end to end
 // (offline): the session key is strong-key-derived and the credential is DES-based.
 func TestEstablishHappyPathRC4(t *testing.T) {
-	inv, cfg, _, sk := establishFixture(false, false, netlogon.StatusSuccess)
+	inv, cfg, _, sk := establishFixture(false, false, nt_status.NT_STATUS_SUCCESS)
 	sc, err := Establish(inv, cfg)
 	if err != nil {
 		t.Fatalf("Establish (RC4 suite): %v", err)
@@ -211,7 +212,7 @@ func TestEstablishHappyPathRC4(t *testing.T) {
 // TestEstablishRejectsForgedServerCredential confirms Establish fails when the server does
 // not prove knowledge of the shared secret.
 func TestEstablishRejectsForgedServerCredential(t *testing.T) {
-	inv, cfg, _, _ := establishFixture(true, true, netlogon.StatusSuccess)
+	inv, cfg, _, _ := establishFixture(true, true, nt_status.NT_STATUS_SUCCESS)
 	if _, err := Establish(inv, cfg); err == nil {
 		t.Fatal("Establish accepted a forged server credential")
 	}
@@ -220,7 +221,7 @@ func TestEstablishRejectsForgedServerCredential(t *testing.T) {
 // TestEstablishRejectsBadSecret confirms Establish validates the machine secret before
 // issuing any RPC: a wrong-length NTHash and a missing secret both fail fast.
 func TestEstablishRejectsBadSecret(t *testing.T) {
-	inv, cfg, _, _ := establishFixture(true, false, netlogon.StatusSuccess)
+	inv, cfg, _, _ := establishFixture(true, false, nt_status.NT_STATUS_SUCCESS)
 
 	bad := cfg
 	bad.NTHash = make([]byte, 10)
@@ -241,7 +242,7 @@ func TestEstablishRejectsBadSecret(t *testing.T) {
 // TestEstablishPassTheHash confirms a raw 16-byte NTHash (no password) drives the same
 // session key as the equivalent password, i.e. the pass-the-hash path works.
 func TestEstablishPassTheHash(t *testing.T) {
-	inv, cfg, _, sk := establishFixture(true, false, netlogon.StatusSuccess)
+	inv, cfg, _, sk := establishFixture(true, false, nt_status.NT_STATUS_SUCCESS)
 	h := nt.NTHash(cfg.Password)
 	cfg.Password = ""
 	cfg.NTHash = h[:]
@@ -259,7 +260,7 @@ func TestEstablishPassTheHash(t *testing.T) {
 // TestEstablishReqChallengeStatusError confirms a non-success ReqChallenge status aborts the
 // handshake before NetrServerAuthenticate3 is called.
 func TestEstablishReqChallengeStatusError(t *testing.T) {
-	inv, cfg, _, _ := establishFixture(true, false, netlogon.StatusAccessDenied)
+	inv, cfg, _, _ := establishFixture(true, false, nt_status.NT_STATUS_ACCESS_DENIED)
 	if _, err := Establish(inv, cfg); err == nil {
 		t.Fatal("Establish ignored a failed NetrServerReqChallenge status")
 	}


### PR DESCRIPTION
### Linked Issue

Refs #1219

### Root Cause

The netlogon interface (`12345678-1234-abcd-ef00-01234567cffb/1.0`) declared its own nine-value NTSTATUS block and a `StatusString` switch over it. Both duplicated `windows/errors/nt_status`, which since #1218 carries the whole of [MS-ERREF] 2.3.1 generated from a committed extract of the specification.

The subset was also a ceiling, not just a duplicate. `StatusString` decoded the nine values it happened to list and returned `fmt.Sprintf("0x%08x", status)` for everything else, so the many other statuses Netlogon returns reached callers as undecoded hex: a machine account rejected with `STATUS_NOLOGON_WORKSTATION_TRUST_ACCOUNT` printed `0xc0000199`, and a broken trust with `STATUS_TRUSTED_DOMAIN_FAILURE` printed `0xc000018c`. Nothing tied the subset to the specification, so a correction to the shared table would have stopped at the interface boundary.

### Fix Description

`interface.go` loses the status constant block and `StatusString`. The block's doc comment is replaced with a note saying the codes are not declared here because the whole of [MS-ERREF] 2.3.1 lives in `github.com/TheManticoreProject/Manticore/windows/errors/nt_status`, and that a subset would cover a fraction of that table and drift from it. The package doc no longer advertises status constants, and the now-unused `fmt` import is dropped. `SyntaxID`, `PipeName`, the opnum constants, `OpnumToName`/`NameToOpnum` and the negotiate flags are untouched.

The forty-eight method stubs under `functions/` compare `nt_status.NT_STATUS(resp.Status)` against `nt_status.NT_STATUS_SUCCESS` and render a failure with the value's own `String`, which resolves every status the shared table defines and falls back to hex only for a value no specification defines. No alias constants, no local re-declaration and no delegating wrapper were left behind.

The mapping was derived from values, not names. Each of the nine codes was looked up by hex in `windows/errors/errgen/ms-erref-2.3.1-ntstatus.tsv` and its shared name taken from the specification name that row records:

| value | specification name | shared constant |
| --- | --- | --- |
| `0x00000000` | `STATUS_SUCCESS` | `NT_STATUS_SUCCESS` |
| `0x00000105` | `STATUS_MORE_ENTRIES` | `NT_STATUS_MORE_ENTRIES` |
| `0x8000001A` | `STATUS_NO_MORE_ENTRIES` | `NT_STATUS_NO_MORE_ENTRIES` |
| `0xC000000D` | `STATUS_INVALID_PARAMETER` | `NT_STATUS_INVALID_PARAMETER` |
| `0xC0000022` | `STATUS_ACCESS_DENIED` | `NT_STATUS_ACCESS_DENIED` |
| `0xC0000064` | `STATUS_NO_SUCH_USER` | `NT_STATUS_NO_SUCH_USER` |
| `0xC00000BB` | `STATUS_NOT_SUPPORTED` | `NT_STATUS_NOT_SUPPORTED` |
| `0xC000018B` | `STATUS_NO_TRUST_SAM_ACCOUNT` | `NT_STATUS_NO_TRUST_SAM_ACCOUNT` |
| `0xC0000388` | `STATUS_DOWNGRADE_DETECTED` | `NT_STATUS_DOWNGRADE_DETECTED` |

All nine resolved in the specification extract, so none of them was interface-specific and the whole block could be deleted rather than partly retained.

The rewrite was applied per comparison term, not per condition, because a whole-expression substitution on `a != X && a != Y` can drop a term and still compile. Every status comparison was replaced individually and the inequality counts were diffed before and after: 48 removed, 48 added. All forty-eight conditions here carry a single term, so no hoisting into an `if` initializer was needed.

### How Verified

- `go build ./...` — clean, no output.
- `go vet ./...` — clean, no output.
- `go test -count=1 ./...` — exit 0, 311 packages `ok`, 81 with no test files, 0 `FAIL` lines.
- Cross-compiles with `CGO_ENABLED=0 go build ./...`: `windows/amd64`, `windows/386`, `linux/arm64`, `linux/386` — all clean.
- `grep -rn 'StatusString\|logon\.Status\|netlogon\.Status'` over the repository — no matches; the private names have no remaining references anywhere.
- `gofmt -l` over all 52 changed files — no drift reported; the inserted import already sorted into position.

### Test Coverage

`TestStatusString` in `interface_test.go` is replaced by `TestStatusCodesResolveThroughNTStatus`, which asserts that the nine codes this interface documents resolve through the shared table under their `NT_STATUS_*` names, that `0xC0000199` — outside the old subset, and therefore previously printed as hex — now renders as `NT_STATUS_NOLOGON_WORKSTATION_TRUST_ACCOUNT`, and that `0xDEADBEEF`, which no specification defines, still renders as `0xdeadbeef`. `TestSyntaxID` and `TestOpnums` are unchanged and continue to pass, which is what pins that the deletion took only the two intended declarations.

The `windows/protocols/ms-nrpc/securechannel` suite covers the `Establish` call site and passes with its fixture's `reqStatus` field retyped to `nt_status.NT_STATUS`; `TestEstablishReqChallengeStatusError` exercises the rewritten non-success branch.

### Scope of Change

52 files:

- `network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/interface.go` — status constants and `StatusString` removed, doc comments updated, `fmt` import dropped.
- `network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/interface_test.go` — `StatusString` test replaced.
- 48 files under `network/dcerpc/interfaces/12345678-1234-abcd-ef00-01234567cffb/1.0/functions/` — status comparison and error rendering routed through `nt_status`, import added. The three stubs that return the raw NTSTATUS to the caller (opnums 4, 15, 30) never referenced the constants and are unchanged.
- `windows/protocols/ms-nrpc/securechannel/securechannel.go` and `securechannel_test.go` — the only consumers outside the interface directory; their references to the deleted names are moved to `nt_status`, and the test fixture's `reqStatus` field is retyped from `uint32` to `nt_status.NT_STATUS`. The secure-channel implementation is otherwise untouched.

Submodule pointer updated: no — the repository has no submodules.

Behavioral changes outside the bug fix: none beyond the rendering change this change is for. A failed Netlogon method now names any status the shared table defines instead of only the nine the subset listed, and a name it does report is the Go constant name (`NT_STATUS_ACCESS_DENIED`) rather than the specification mnemonic (`STATUS_ACCESS_DENIED`), matching the convention the rest of the tree adopted in #1218. Error text is the only thing that changes; no wire behaviour, no control flow and no exported API outside the deleted symbols.

### Risk and Rollout

The deleted symbols were exported, so their removal is a compile-time break for anything referencing them. The two consumers in the tree are updated in this commit and the repository builds and vets clean on four target platforms. Anything outside the tree that used `StatusSuccess` or `StatusString` fails to compile rather than misbehaving, and the replacement is a direct one.

The rendering change is visible in log and error strings only. Nothing in the tree parses those strings; the comparison in every rewritten stub is against a constant, not against text.

### Notes

This is one of the 74 interfaces #1219 covers, hence `Refs` rather than a closing keyword.

`nt_status.String` consults the [MS-CIFS] extension table before [MS-ERREF], which matters for exactly one value, `0x00010002`. Netlogon does not return it and no code in this change compares against it.
