### PR TITLE
Route lsarpc status reporting through nt_status (Refs #1219)

### DIFF
--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/00_LsarClose.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/00_LsarClose.go
@@ -10,6 +10,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
 
@@ -28,8 +29,8 @@ func LsarClose(rpc ndr.Invoker, handle mslsad.LSAPR_HANDLE) (mslsad.LSAPR_HANDLE
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return mslsad.LSAPR_HANDLE{}, fmt.Errorf("LsarClose: %w", err)
 	}
-	if uint32(resp.Status) != lsarpc.StatusSuccess {
-		return resp.Handle, fmt.Errorf("LsarClose failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Handle, fmt.Errorf("LsarClose failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Handle, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/02_LsarEnumeratePrivileges.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/02_LsarEnumeratePrivileges.go
@@ -10,6 +10,7 @@ import (
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
 
@@ -49,8 +50,8 @@ func LsarEnumeratePrivileges(rpc ndr.Invoker, policyHandle mslsad.LSAPR_HANDLE, 
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return 0, mslsad.LSAPR_PRIVILEGE_ENUM_BUFFER{}, fmt.Errorf("LsarEnumeratePrivileges: %w", err)
 	}
-	if uint32(resp.Status) != lsarpc.StatusSuccess {
-		return uint32(resp.EnumerationContext), resp.EnumerationBuffer, fmt.Errorf("LsarEnumeratePrivileges failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return uint32(resp.EnumerationContext), resp.EnumerationBuffer, fmt.Errorf("LsarEnumeratePrivileges failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return uint32(resp.EnumerationContext), resp.EnumerationBuffer, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/03_LsarQuerySecurityObject.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/03_LsarQuerySecurityObject.go
@@ -10,6 +10,7 @@ import (
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
 
@@ -42,8 +43,8 @@ func LsarQuerySecurityObject(rpc ndr.Invoker, objectHandle mslsad.LSAPR_HANDLE, 
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return nil, fmt.Errorf("LsarQuerySecurityObject: %w", err)
 	}
-	if uint32(resp.Status) != lsarpc.StatusSuccess {
-		return resp.SecurityDescriptor, fmt.Errorf("LsarQuerySecurityObject failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.SecurityDescriptor, fmt.Errorf("LsarQuerySecurityObject failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.SecurityDescriptor, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/04_LsarSetSecurityObject.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/04_LsarSetSecurityObject.go
@@ -10,6 +10,7 @@ import (
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
 
@@ -37,8 +38,8 @@ func LsarSetSecurityObject(rpc ndr.Invoker, objectHandle mslsad.LSAPR_HANDLE, se
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("LsarSetSecurityObject: %w", err)
 	}
-	if uint32(resp.Status) != lsarpc.StatusSuccess {
-		return fmt.Errorf("LsarSetSecurityObject failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return fmt.Errorf("LsarSetSecurityObject failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/06_LsarOpenPolicy.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/06_LsarOpenPolicy.go
@@ -10,6 +10,7 @@ import (
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
 
@@ -34,8 +35,8 @@ func LsarOpenPolicy(rpc ndr.Invoker, desiredAccess uint32) (mslsad.LSAPR_HANDLE,
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return mslsad.LSAPR_HANDLE{}, fmt.Errorf("LsarOpenPolicy: %w", err)
 	}
-	if uint32(resp.Status) != lsarpc.StatusSuccess {
-		return resp.Handle, fmt.Errorf("LsarOpenPolicy failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Handle, fmt.Errorf("LsarOpenPolicy failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Handle, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/07_LsarQueryInformationPolicy.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/07_LsarQueryInformationPolicy.go
@@ -10,6 +10,7 @@ import (
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
 
@@ -42,8 +43,8 @@ func LsarQueryInformationPolicy(rpc ndr.Invoker, policyHandle mslsad.LSAPR_HANDL
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return nil, fmt.Errorf("LsarQueryInformationPolicy: %w", err)
 	}
-	if uint32(resp.Status) != lsarpc.StatusSuccess {
-		return resp.PolicyInformation, fmt.Errorf("LsarQueryInformationPolicy failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.PolicyInformation, fmt.Errorf("LsarQueryInformationPolicy failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.PolicyInformation, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/08_LsarSetInformationPolicy.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/08_LsarSetInformationPolicy.go
@@ -10,6 +10,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
 
@@ -40,8 +41,8 @@ func LsarSetInformationPolicy(rpc ndr.Invoker, policyHandle mslsad.LSAPR_HANDLE,
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("LsarSetInformationPolicy: %w", err)
 	}
-	if uint32(resp.Status) != lsarpc.StatusSuccess {
-		return fmt.Errorf("LsarSetInformationPolicy failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return fmt.Errorf("LsarSetInformationPolicy failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/10_LsarCreateAccount.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/10_LsarCreateAccount.go
@@ -10,6 +10,7 @@ import (
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
@@ -36,8 +37,8 @@ func LsarCreateAccount(rpc ndr.Invoker, policyHandle mslsad.LSAPR_HANDLE, accoun
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return mslsad.LSAPR_HANDLE{}, fmt.Errorf("LsarCreateAccount: %w", err)
 	}
-	if uint32(resp.Status) != lsarpc.StatusSuccess {
-		return resp.Handle, fmt.Errorf("LsarCreateAccount failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Handle, fmt.Errorf("LsarCreateAccount failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Handle, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/11_LsarEnumerateAccounts.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/11_LsarEnumerateAccounts.go
@@ -10,6 +10,7 @@ import (
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
 
@@ -48,9 +49,9 @@ func LsarEnumerateAccounts(rpc ndr.Invoker, policyHandle mslsad.LSAPR_HANDLE, en
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return mslsad.LSAPR_ACCOUNT_ENUM_BUFFER{}, enumerationContext, fmt.Errorf("LsarEnumerateAccounts: %w", err)
 	}
-	status := uint32(resp.Status)
-	if status != lsarpc.StatusSuccess && status != lsarpc.StatusMoreEntries {
-		return resp.EnumerationBuffer, uint32(resp.EnumerationContext), fmt.Errorf("LsarEnumerateAccounts failed: %s", lsarpc.StatusString(status))
+	status := nt_status.NT_STATUS(resp.Status)
+	if status != nt_status.NT_STATUS_SUCCESS && status != nt_status.NT_STATUS_MORE_ENTRIES {
+		return resp.EnumerationBuffer, uint32(resp.EnumerationContext), fmt.Errorf("LsarEnumerateAccounts failed: %s", status)
 	}
 	return resp.EnumerationBuffer, uint32(resp.EnumerationContext), nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/129_LsarCreateTrustedDomainEx3.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/129_LsarCreateTrustedDomainEx3.go
@@ -10,6 +10,7 @@ import (
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
 
@@ -46,8 +47,8 @@ func LsarCreateTrustedDomainEx3(rpc ndr.Invoker, policyHandle mslsad.LSAPR_HANDL
 		return
 	}
 	TrustedDomainHandle = resp.TrustedDomainHandle
-	if uint32(resp.Status) != lsarpc.StatusSuccess {
-		err = fmt.Errorf("LsarCreateTrustedDomainEx3 failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		err = fmt.Errorf("LsarCreateTrustedDomainEx3 failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/12_LsarCreateTrustedDomain.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/12_LsarCreateTrustedDomain.go
@@ -10,6 +10,7 @@ import (
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
 
@@ -38,8 +39,8 @@ func LsarCreateTrustedDomain(rpc ndr.Invoker, policyHandle mslsad.LSAPR_HANDLE, 
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return mslsad.LSAPR_HANDLE{}, fmt.Errorf("LsarCreateTrustedDomain: %w", err)
 	}
-	if uint32(resp.Status) != lsarpc.StatusSuccess {
-		return resp.Handle, fmt.Errorf("LsarCreateTrustedDomain failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Handle, fmt.Errorf("LsarCreateTrustedDomain failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Handle, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/130_LsarOpenPolicy3.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/130_LsarOpenPolicy3.go
@@ -10,6 +10,7 @@ import (
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
 
@@ -53,8 +54,8 @@ func LsarOpenPolicy3(rpc ndr.Invoker, systemName *ndr.WSTR, objectAttributes msl
 	OutVersion = resp.OutVersion
 	OutRevisionInfo = resp.OutRevisionInfo
 	PolicyHandle = resp.PolicyHandle
-	if uint32(resp.Status) != lsarpc.StatusSuccess {
-		err = fmt.Errorf("LsarOpenPolicy3 failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		err = fmt.Errorf("LsarOpenPolicy3 failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/132_LsarQueryForestTrustInformation2.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/132_LsarQueryForestTrustInformation2.go
@@ -10,6 +10,7 @@ import (
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
 
@@ -44,8 +45,8 @@ func LsarQueryForestTrustInformation2(rpc ndr.Invoker, policyHandle mslsad.LSAPR
 		return
 	}
 	ForestTrustInfo2 = resp.ForestTrustInfo2
-	if uint32(resp.Status) != lsarpc.StatusSuccess {
-		err = fmt.Errorf("LsarQueryForestTrustInformation2 failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		err = fmt.Errorf("LsarQueryForestTrustInformation2 failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/133_LsarSetForestTrustInformation2.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/133_LsarSetForestTrustInformation2.go
@@ -10,6 +10,7 @@ import (
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
 
@@ -48,8 +49,8 @@ func LsarSetForestTrustInformation2(rpc ndr.Invoker, policyHandle mslsad.LSAPR_H
 		return
 	}
 	CollisionInfo = resp.CollisionInfo
-	if uint32(resp.Status) != lsarpc.StatusSuccess {
-		err = fmt.Errorf("LsarSetForestTrustInformation2 failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		err = fmt.Errorf("LsarSetForestTrustInformation2 failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/135_LsarOpenPolicyWithCreds.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/135_LsarOpenPolicyWithCreds.go
@@ -10,6 +10,7 @@ import (
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
 
@@ -51,8 +52,8 @@ func LsarOpenPolicyWithCreds(rpc ndr.Invoker, objectAttributes mslsad.LSAPR_OBJE
 	OutVersion = resp.OutVersion
 	OutRevisionInfo = resp.OutRevisionInfo
 	PolicyHandle = resp.PolicyHandle
-	if uint32(resp.Status) != lsarpc.StatusSuccess {
-		err = fmt.Errorf("LsarOpenPolicyWithCreds failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		err = fmt.Errorf("LsarOpenPolicyWithCreds failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/136_LsarOpenSecret2.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/136_LsarOpenSecret2.go
@@ -10,6 +10,7 @@ import (
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
 
@@ -42,8 +43,8 @@ func LsarOpenSecret2(rpc ndr.Invoker, policyHandle mslsad.LSAPR_HANDLE, encrypte
 		return
 	}
 	SecretHandle = resp.SecretHandle
-	if uint32(resp.Status) != lsarpc.StatusSuccess {
-		err = fmt.Errorf("LsarOpenSecret2 failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		err = fmt.Errorf("LsarOpenSecret2 failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/137_LsarCreateSecret2.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/137_LsarCreateSecret2.go
@@ -10,6 +10,7 @@ import (
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
 
@@ -42,8 +43,8 @@ func LsarCreateSecret2(rpc ndr.Invoker, policyHandle mslsad.LSAPR_HANDLE, encryp
 		return
 	}
 	SecretHandle = resp.SecretHandle
-	if uint32(resp.Status) != lsarpc.StatusSuccess {
-		err = fmt.Errorf("LsarCreateSecret2 failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		err = fmt.Errorf("LsarCreateSecret2 failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/138_LsarSetSecret2.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/138_LsarSetSecret2.go
@@ -10,6 +10,7 @@ import (
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
 
@@ -40,8 +41,8 @@ func LsarSetSecret2(rpc ndr.Invoker, secretHandle mslsad.LSAPR_HANDLE, encrypted
 		err = fmt.Errorf("LsarSetSecret2: %w", err)
 		return
 	}
-	if uint32(resp.Status) != lsarpc.StatusSuccess {
-		err = fmt.Errorf("LsarSetSecret2 failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		err = fmt.Errorf("LsarSetSecret2 failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/139_LsarQuerySecret2.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/139_LsarQuerySecret2.go
@@ -10,6 +10,7 @@ import (
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
@@ -53,8 +54,8 @@ func LsarQuerySecret2(rpc ndr.Invoker, secretHandle mslsad.LSAPR_HANDLE, encrypt
 	CurrentValueSetTime = resp.CurrentValueSetTime
 	EncryptedOldValue = resp.EncryptedOldValue
 	OldValueSetTime = resp.OldValueSetTime
-	if uint32(resp.Status) != lsarpc.StatusSuccess {
-		err = fmt.Errorf("LsarQuerySecret2 failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		err = fmt.Errorf("LsarQuerySecret2 failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/13_LsarEnumerateTrustedDomains.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/13_LsarEnumerateTrustedDomains.go
@@ -10,6 +10,7 @@ import (
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
 
@@ -50,10 +51,10 @@ func LsarEnumerateTrustedDomains(rpc ndr.Invoker, policyHandle mslsad.LSAPR_HAND
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return enumerationContext, mslsad.LSAPR_TRUSTED_ENUM_BUFFER{}, fmt.Errorf("LsarEnumerateTrustedDomains: %w", err)
 	}
-	switch uint32(resp.Status) {
-	case lsarpc.StatusSuccess, lsarpc.StatusMoreEntries, lsarpc.StatusNoMoreEntries:
+	switch status := nt_status.NT_STATUS(resp.Status); status {
+	case nt_status.NT_STATUS_SUCCESS, nt_status.NT_STATUS_MORE_ENTRIES, nt_status.NT_STATUS_NO_MORE_ENTRIES:
 		return uint32(resp.EnumerationContext), resp.EnumerationBuffer, nil
 	default:
-		return uint32(resp.EnumerationContext), resp.EnumerationBuffer, fmt.Errorf("LsarEnumerateTrustedDomains failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+		return uint32(resp.EnumerationContext), resp.EnumerationBuffer, fmt.Errorf("LsarEnumerateTrustedDomains failed: %s", status)
 	}
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/140_LsarStorePrivateData2.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/140_LsarStorePrivateData2.go
@@ -10,6 +10,7 @@ import (
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
 
@@ -40,8 +41,8 @@ func LsarStorePrivateData2(rpc ndr.Invoker, policyHandle mslsad.LSAPR_HANDLE, en
 		err = fmt.Errorf("LsarStorePrivateData2: %w", err)
 		return
 	}
-	if uint32(resp.Status) != lsarpc.StatusSuccess {
-		err = fmt.Errorf("LsarStorePrivateData2 failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		err = fmt.Errorf("LsarStorePrivateData2 failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/141_LsarRetrievePrivateData2.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/141_LsarRetrievePrivateData2.go
@@ -10,6 +10,7 @@ import (
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
 
@@ -42,8 +43,8 @@ func LsarRetrievePrivateData2(rpc ndr.Invoker, policyHandle mslsad.LSAPR_HANDLE,
 		return
 	}
 	EncryptedData = resp.EncryptedData
-	if uint32(resp.Status) != lsarpc.StatusSuccess {
-		err = fmt.Errorf("LsarRetrievePrivateData2 failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		err = fmt.Errorf("LsarRetrievePrivateData2 failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/14_LsarLookupNames.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/14_LsarLookupNames.go
@@ -10,6 +10,7 @@ import (
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 	mslsat "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsat"
@@ -58,11 +59,11 @@ func LsarLookupNames(rpc ndr.Invoker, policyHandle mslsad.LSAPR_HANDLE, names []
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return nil, mslsat.LSAPR_TRANSLATED_SIDS{}, 0, fmt.Errorf("LsarLookupNames: %w", err)
 	}
-	status := uint32(resp.Status)
+	status := nt_status.NT_STATUS(resp.Status)
 	switch status {
-	case lsarpc.StatusSuccess, lsarpc.StatusSomeNotMapped, lsarpc.StatusNoneMapped:
+	case nt_status.NT_STATUS_SUCCESS, nt_status.NT_STATUS_SOME_NOT_MAPPED, nt_status.NT_STATUS_NONE_MAPPED:
 		return resp.ReferencedDomains, resp.TranslatedSids, uint32(resp.MappedCount), nil
 	default:
-		return resp.ReferencedDomains, resp.TranslatedSids, uint32(resp.MappedCount), fmt.Errorf("LsarLookupNames failed: %s", lsarpc.StatusString(status))
+		return resp.ReferencedDomains, resp.TranslatedSids, uint32(resp.MappedCount), fmt.Errorf("LsarLookupNames failed: %s", status)
 	}
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/15_LsarLookupSids.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/15_LsarLookupSids.go
@@ -10,6 +10,7 @@ import (
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 	mslsat "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsat"
 )
@@ -51,11 +52,11 @@ func LsarLookupSids(rpc ndr.Invoker, policyHandle mslsad.LSAPR_HANDLE, sidEnumBu
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return nil, mslsat.LSAPR_TRANSLATED_NAMES{}, 0, fmt.Errorf("LsarLookupSids: %w", err)
 	}
-	status := uint32(resp.Status)
+	status := nt_status.NT_STATUS(resp.Status)
 	switch status {
-	case lsarpc.StatusSuccess, lsarpc.StatusSomeNotMapped, lsarpc.StatusNoneMapped:
+	case nt_status.NT_STATUS_SUCCESS, nt_status.NT_STATUS_SOME_NOT_MAPPED, nt_status.NT_STATUS_NONE_MAPPED:
 		return resp.ReferencedDomains, resp.TranslatedNames, uint32(resp.MappedCount), nil
 	default:
-		return resp.ReferencedDomains, resp.TranslatedNames, uint32(resp.MappedCount), fmt.Errorf("LsarLookupSids failed: %s", lsarpc.StatusString(status))
+		return resp.ReferencedDomains, resp.TranslatedNames, uint32(resp.MappedCount), fmt.Errorf("LsarLookupSids failed: %s", status)
 	}
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/16_LsarCreateSecret.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/16_LsarCreateSecret.go
@@ -10,6 +10,7 @@ import (
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
@@ -37,8 +38,8 @@ func LsarCreateSecret(rpc ndr.Invoker, policyHandle mslsad.LSAPR_HANDLE, secretN
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return mslsad.LSAPR_HANDLE{}, fmt.Errorf("LsarCreateSecret: %w", err)
 	}
-	if uint32(resp.Status) != lsarpc.StatusSuccess {
-		return resp.Handle, fmt.Errorf("LsarCreateSecret failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Handle, fmt.Errorf("LsarCreateSecret failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Handle, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/17_LsarOpenAccount.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/17_LsarOpenAccount.go
@@ -10,6 +10,7 @@ import (
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
@@ -36,8 +37,8 @@ func LsarOpenAccount(rpc ndr.Invoker, policyHandle mslsad.LSAPR_HANDLE, accountS
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return mslsad.LSAPR_HANDLE{}, fmt.Errorf("LsarOpenAccount: %w", err)
 	}
-	if uint32(resp.Status) != lsarpc.StatusSuccess {
-		return resp.Handle, fmt.Errorf("LsarOpenAccount failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Handle, fmt.Errorf("LsarOpenAccount failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Handle, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/18_LsarEnumeratePrivilegesAccount.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/18_LsarEnumeratePrivilegesAccount.go
@@ -10,6 +10,7 @@ import (
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
 
@@ -38,8 +39,8 @@ func LsarEnumeratePrivilegesAccount(rpc ndr.Invoker, accountHandle mslsad.LSAPR_
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return nil, fmt.Errorf("LsarEnumeratePrivilegesAccount: %w", err)
 	}
-	if uint32(resp.Status) != lsarpc.StatusSuccess {
-		return resp.Privileges, fmt.Errorf("LsarEnumeratePrivilegesAccount failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Privileges, fmt.Errorf("LsarEnumeratePrivilegesAccount failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Privileges, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/19_LsarAddPrivilegesToAccount.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/19_LsarAddPrivilegesToAccount.go
@@ -10,6 +10,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
 
@@ -33,8 +34,8 @@ func LsarAddPrivilegesToAccount(rpc ndr.Invoker, accountHandle mslsad.LSAPR_HAND
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("LsarAddPrivilegesToAccount: %w", err)
 	}
-	if uint32(resp.Status) != lsarpc.StatusSuccess {
-		return fmt.Errorf("LsarAddPrivilegesToAccount failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return fmt.Errorf("LsarAddPrivilegesToAccount failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/20_LsarRemovePrivilegesFromAccount.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/20_LsarRemovePrivilegesFromAccount.go
@@ -10,6 +10,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
 
@@ -40,8 +41,8 @@ func LsarRemovePrivilegesFromAccount(rpc ndr.Invoker, accountHandle mslsad.LSAPR
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("LsarRemovePrivilegesFromAccount: %w", err)
 	}
-	if uint32(resp.Status) != lsarpc.StatusSuccess {
-		return fmt.Errorf("LsarRemovePrivilegesFromAccount failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return fmt.Errorf("LsarRemovePrivilegesFromAccount failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/23_LsarGetSystemAccessAccount.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/23_LsarGetSystemAccessAccount.go
@@ -10,6 +10,7 @@ import (
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
 
@@ -38,8 +39,8 @@ func LsarGetSystemAccessAccount(rpc ndr.Invoker, accountHandle mslsad.LSAPR_HAND
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return 0, fmt.Errorf("LsarGetSystemAccessAccount: %w", err)
 	}
-	if uint32(resp.Status) != lsarpc.StatusSuccess {
-		return 0, fmt.Errorf("LsarGetSystemAccessAccount failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return 0, fmt.Errorf("LsarGetSystemAccessAccount failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return uint32(resp.SystemAccess), nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/24_LsarSetSystemAccessAccount.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/24_LsarSetSystemAccessAccount.go
@@ -10,6 +10,7 @@ import (
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
 
@@ -32,8 +33,8 @@ func LsarSetSystemAccessAccount(rpc ndr.Invoker, accountHandle mslsad.LSAPR_HAND
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("LsarSetSystemAccessAccount: %w", err)
 	}
-	if uint32(resp.Status) != lsarpc.StatusSuccess {
-		return fmt.Errorf("LsarSetSystemAccessAccount failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return fmt.Errorf("LsarSetSystemAccessAccount failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/25_LsarOpenTrustedDomain.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/25_LsarOpenTrustedDomain.go
@@ -10,6 +10,7 @@ import (
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
@@ -39,8 +40,8 @@ func LsarOpenTrustedDomain(rpc ndr.Invoker, policyHandle mslsad.LSAPR_HANDLE, tr
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return mslsad.LSAPR_HANDLE{}, fmt.Errorf("LsarOpenTrustedDomain: %w", err)
 	}
-	if uint32(resp.Status) != lsarpc.StatusSuccess {
-		return resp.Handle, fmt.Errorf("LsarOpenTrustedDomain failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Handle, fmt.Errorf("LsarOpenTrustedDomain failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Handle, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/26_LsarQueryInfoTrustedDomain.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/26_LsarQueryInfoTrustedDomain.go
@@ -10,6 +10,7 @@ import (
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
 
@@ -43,8 +44,8 @@ func LsarQueryInfoTrustedDomain(rpc ndr.Invoker, trustedDomainHandle mslsad.LSAP
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return nil, fmt.Errorf("LsarQueryInfoTrustedDomain: %w", err)
 	}
-	if uint32(resp.Status) != lsarpc.StatusSuccess {
-		return resp.TrustedDomainInformation, fmt.Errorf("LsarQueryInfoTrustedDomain failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.TrustedDomainInformation, fmt.Errorf("LsarQueryInfoTrustedDomain failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.TrustedDomainInformation, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/27_LsarSetInformationTrustedDomain.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/27_LsarSetInformationTrustedDomain.go
@@ -10,6 +10,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
 
@@ -40,8 +41,8 @@ func LsarSetInformationTrustedDomain(rpc ndr.Invoker, trustedDomainHandle mslsad
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("LsarSetInformationTrustedDomain: %w", err)
 	}
-	if uint32(resp.Status) != lsarpc.StatusSuccess {
-		return fmt.Errorf("LsarSetInformationTrustedDomain failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return fmt.Errorf("LsarSetInformationTrustedDomain failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/28_LsarOpenSecret.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/28_LsarOpenSecret.go
@@ -10,6 +10,7 @@ import (
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
@@ -37,8 +38,8 @@ func LsarOpenSecret(rpc ndr.Invoker, policyHandle mslsad.LSAPR_HANDLE, secretNam
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return mslsad.LSAPR_HANDLE{}, fmt.Errorf("LsarOpenSecret: %w", err)
 	}
-	if uint32(resp.Status) != lsarpc.StatusSuccess {
-		return resp.Handle, fmt.Errorf("LsarOpenSecret failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Handle, fmt.Errorf("LsarOpenSecret failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Handle, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/29_LsarSetSecret.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/29_LsarSetSecret.go
@@ -10,6 +10,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
 
@@ -36,8 +37,8 @@ func LsarSetSecret(rpc ndr.Invoker, secretHandle mslsad.LSAPR_HANDLE, encryptedC
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("LsarSetSecret: %w", err)
 	}
-	if uint32(resp.Status) != lsarpc.StatusSuccess {
-		return fmt.Errorf("LsarSetSecret failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return fmt.Errorf("LsarSetSecret failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/30_LsarQuerySecret.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/30_LsarQuerySecret.go
@@ -10,6 +10,7 @@ import (
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
@@ -48,8 +49,8 @@ func LsarQuerySecret(rpc ndr.Invoker, secretHandle mslsad.LSAPR_HANDLE) (encrypt
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return nil, nil, nil, nil, fmt.Errorf("LsarQuerySecret: %w", err)
 	}
-	if uint32(resp.Status) != lsarpc.StatusSuccess {
-		return resp.EncryptedCurrentValue, resp.CurrentValueSetTime, resp.EncryptedOldValue, resp.OldValueSetTime, fmt.Errorf("LsarQuerySecret failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.EncryptedCurrentValue, resp.CurrentValueSetTime, resp.EncryptedOldValue, resp.OldValueSetTime, fmt.Errorf("LsarQuerySecret failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.EncryptedCurrentValue, resp.CurrentValueSetTime, resp.EncryptedOldValue, resp.OldValueSetTime, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/31_LsarLookupPrivilegeValue.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/31_LsarLookupPrivilegeValue.go
@@ -10,6 +10,7 @@ import (
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
@@ -46,8 +47,8 @@ func LsarLookupPrivilegeValue(rpc ndr.Invoker, policyHandle mslsad.LSAPR_HANDLE,
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return msdtyp.LUID{}, fmt.Errorf("LsarLookupPrivilegeValue: %w", err)
 	}
-	if uint32(resp.Status) != lsarpc.StatusSuccess {
-		return resp.Value, fmt.Errorf("LsarLookupPrivilegeValue failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Value, fmt.Errorf("LsarLookupPrivilegeValue failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Value, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/32_LsarLookupPrivilegeName.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/32_LsarLookupPrivilegeName.go
@@ -10,6 +10,7 @@ import (
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
@@ -45,8 +46,8 @@ func LsarLookupPrivilegeName(rpc ndr.Invoker, policyHandle mslsad.LSAPR_HANDLE, 
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return nil, fmt.Errorf("LsarLookupPrivilegeName: %w", err)
 	}
-	if uint32(resp.Status) != lsarpc.StatusSuccess {
-		return resp.Name, fmt.Errorf("LsarLookupPrivilegeName failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Name, fmt.Errorf("LsarLookupPrivilegeName failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Name, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/33_LsarLookupPrivilegeDisplayName.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/33_LsarLookupPrivilegeDisplayName.go
@@ -10,6 +10,7 @@ import (
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
@@ -53,8 +54,8 @@ func LsarLookupPrivilegeDisplayName(rpc ndr.Invoker, policyHandle mslsad.LSAPR_H
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return nil, 0, fmt.Errorf("LsarLookupPrivilegeDisplayName: %w", err)
 	}
-	if uint32(resp.Status) != lsarpc.StatusSuccess {
-		return resp.DisplayName, resp.LanguageReturned, fmt.Errorf("LsarLookupPrivilegeDisplayName failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.DisplayName, resp.LanguageReturned, fmt.Errorf("LsarLookupPrivilegeDisplayName failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.DisplayName, resp.LanguageReturned, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/34_LsarDeleteObject.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/34_LsarDeleteObject.go
@@ -10,6 +10,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
 
@@ -30,8 +31,8 @@ func LsarDeleteObject(rpc ndr.Invoker, handle mslsad.LSAPR_HANDLE) (mslsad.LSAPR
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return mslsad.LSAPR_HANDLE{}, fmt.Errorf("LsarDeleteObject: %w", err)
 	}
-	if uint32(resp.Status) != lsarpc.StatusSuccess {
-		return resp.Handle, fmt.Errorf("LsarDeleteObject failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Handle, fmt.Errorf("LsarDeleteObject failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Handle, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/35_LsarEnumerateAccountsWithUserRight.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/35_LsarEnumerateAccountsWithUserRight.go
@@ -10,6 +10,7 @@ import (
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
@@ -42,8 +43,8 @@ func LsarEnumerateAccountsWithUserRight(rpc ndr.Invoker, policyHandle mslsad.LSA
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return mslsad.LSAPR_ACCOUNT_ENUM_BUFFER{}, fmt.Errorf("LsarEnumerateAccountsWithUserRight: %w", err)
 	}
-	if uint32(resp.Status) != lsarpc.StatusSuccess {
-		return resp.EnumerationBuffer, fmt.Errorf("LsarEnumerateAccountsWithUserRight failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.EnumerationBuffer, fmt.Errorf("LsarEnumerateAccountsWithUserRight failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.EnumerationBuffer, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/36_LsarEnumerateAccountRights.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/36_LsarEnumerateAccountRights.go
@@ -10,6 +10,7 @@ import (
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
@@ -40,8 +41,8 @@ func LsarEnumerateAccountRights(rpc ndr.Invoker, policyHandle mslsad.LSAPR_HANDL
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return mslsad.LSAPR_USER_RIGHT_SET{}, fmt.Errorf("LsarEnumerateAccountRights: %w", err)
 	}
-	if uint32(resp.Status) != lsarpc.StatusSuccess {
-		return resp.UserRights, fmt.Errorf("LsarEnumerateAccountRights failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.UserRights, fmt.Errorf("LsarEnumerateAccountRights failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.UserRights, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/37_LsarAddAccountRights.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/37_LsarAddAccountRights.go
@@ -10,6 +10,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
@@ -38,8 +39,8 @@ func LsarAddAccountRights(rpc ndr.Invoker, policyHandle mslsad.LSAPR_HANDLE, acc
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("LsarAddAccountRights: %w", err)
 	}
-	if uint32(resp.Status) != lsarpc.StatusSuccess {
-		return fmt.Errorf("LsarAddAccountRights failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return fmt.Errorf("LsarAddAccountRights failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/38_LsarRemoveAccountRights.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/38_LsarRemoveAccountRights.go
@@ -10,6 +10,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
@@ -43,8 +44,8 @@ func LsarRemoveAccountRights(rpc ndr.Invoker, policyHandle mslsad.LSAPR_HANDLE, 
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("LsarRemoveAccountRights: %w", err)
 	}
-	if uint32(resp.Status) != lsarpc.StatusSuccess {
-		return fmt.Errorf("LsarRemoveAccountRights failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return fmt.Errorf("LsarRemoveAccountRights failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/39_LsarQueryTrustedDomainInfo.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/39_LsarQueryTrustedDomainInfo.go
@@ -10,6 +10,7 @@ import (
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
@@ -47,8 +48,8 @@ func LsarQueryTrustedDomainInfo(rpc ndr.Invoker, policyHandle mslsad.LSAPR_HANDL
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return nil, fmt.Errorf("LsarQueryTrustedDomainInfo: %w", err)
 	}
-	if uint32(resp.Status) != lsarpc.StatusSuccess {
-		return resp.TrustedDomainInformation, fmt.Errorf("LsarQueryTrustedDomainInfo failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.TrustedDomainInformation, fmt.Errorf("LsarQueryTrustedDomainInfo failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.TrustedDomainInformation, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/40_LsarSetTrustedDomainInfo.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/40_LsarSetTrustedDomainInfo.go
@@ -10,6 +10,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
@@ -43,8 +44,8 @@ func LsarSetTrustedDomainInfo(rpc ndr.Invoker, policyHandle mslsad.LSAPR_HANDLE,
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("LsarSetTrustedDomainInfo: %w", err)
 	}
-	if uint32(resp.Status) != lsarpc.StatusSuccess {
-		return fmt.Errorf("LsarSetTrustedDomainInfo failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return fmt.Errorf("LsarSetTrustedDomainInfo failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/41_LsarDeleteTrustedDomain.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/41_LsarDeleteTrustedDomain.go
@@ -10,6 +10,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
@@ -36,8 +37,8 @@ func LsarDeleteTrustedDomain(rpc ndr.Invoker, policyHandle mslsad.LSAPR_HANDLE, 
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("LsarDeleteTrustedDomain: %w", err)
 	}
-	if uint32(resp.Status) != lsarpc.StatusSuccess {
-		return fmt.Errorf("LsarDeleteTrustedDomain failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return fmt.Errorf("LsarDeleteTrustedDomain failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/42_LsarStorePrivateData.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/42_LsarStorePrivateData.go
@@ -10,6 +10,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
@@ -38,8 +39,8 @@ func LsarStorePrivateData(rpc ndr.Invoker, policyHandle mslsad.LSAPR_HANDLE, key
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("LsarStorePrivateData: %w", err)
 	}
-	if uint32(resp.Status) != lsarpc.StatusSuccess {
-		return fmt.Errorf("LsarStorePrivateData failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return fmt.Errorf("LsarStorePrivateData failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/43_LsarRetrievePrivateData.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/43_LsarRetrievePrivateData.go
@@ -10,6 +10,7 @@ import (
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
@@ -46,8 +47,8 @@ func LsarRetrievePrivateData(rpc ndr.Invoker, policyHandle mslsad.LSAPR_HANDLE, 
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return nil, fmt.Errorf("LsarRetrievePrivateData: %w", err)
 	}
-	if uint32(resp.Status) != lsarpc.StatusSuccess {
-		return resp.EncryptedData, fmt.Errorf("LsarRetrievePrivateData failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.EncryptedData, fmt.Errorf("LsarRetrievePrivateData failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.EncryptedData, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/44_LsarOpenPolicy2.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/44_LsarOpenPolicy2.go
@@ -10,6 +10,7 @@ import (
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
 
@@ -31,8 +32,8 @@ func LsarOpenPolicy2(rpc ndr.Invoker, desiredAccess uint32) (mslsad.LSAPR_HANDLE
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return mslsad.LSAPR_HANDLE{}, fmt.Errorf("LsarOpenPolicy2: %w", err)
 	}
-	if uint32(resp.Status) != lsarpc.StatusSuccess {
-		return resp.Handle, fmt.Errorf("LsarOpenPolicy2 failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Handle, fmt.Errorf("LsarOpenPolicy2 failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Handle, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/45_LsarGetUserName.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/45_LsarGetUserName.go
@@ -10,6 +10,7 @@ import (
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 )
 
@@ -42,8 +43,8 @@ func LsarGetUserName(rpc ndr.Invoker) (*msdtyp.RPC_UNICODE_STRING, *msdtyp.RPC_U
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return nil, nil, fmt.Errorf("LsarGetUserName: %w", err)
 	}
-	if uint32(resp.Status) != lsarpc.StatusSuccess {
-		return resp.UserName, resp.DomainName, fmt.Errorf("LsarGetUserName failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.UserName, resp.DomainName, fmt.Errorf("LsarGetUserName failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.UserName, resp.DomainName, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/46_LsarQueryInformationPolicy2.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/46_LsarQueryInformationPolicy2.go
@@ -10,6 +10,7 @@ import (
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
 
@@ -43,8 +44,8 @@ func LsarQueryInformationPolicy2(rpc ndr.Invoker, policyHandle mslsad.LSAPR_HAND
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return nil, fmt.Errorf("LsarQueryInformationPolicy2: %w", err)
 	}
-	if uint32(resp.Status) != lsarpc.StatusSuccess {
-		return resp.PolicyInformation, fmt.Errorf("LsarQueryInformationPolicy2 failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.PolicyInformation, fmt.Errorf("LsarQueryInformationPolicy2 failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.PolicyInformation, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/47_LsarSetInformationPolicy2.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/47_LsarSetInformationPolicy2.go
@@ -10,6 +10,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
 
@@ -40,8 +41,8 @@ func LsarSetInformationPolicy2(rpc ndr.Invoker, policyHandle mslsad.LSAPR_HANDLE
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("LsarSetInformationPolicy2: %w", err)
 	}
-	if uint32(resp.Status) != lsarpc.StatusSuccess {
-		return fmt.Errorf("LsarSetInformationPolicy2 failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return fmt.Errorf("LsarSetInformationPolicy2 failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/48_LsarQueryTrustedDomainInfoByName.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/48_LsarQueryTrustedDomainInfoByName.go
@@ -10,6 +10,7 @@ import (
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
@@ -48,8 +49,8 @@ func LsarQueryTrustedDomainInfoByName(rpc ndr.Invoker, policyHandle mslsad.LSAPR
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return nil, fmt.Errorf("LsarQueryTrustedDomainInfoByName: %w", err)
 	}
-	if uint32(resp.Status) != lsarpc.StatusSuccess {
-		return resp.TrustedDomainInformation, fmt.Errorf("LsarQueryTrustedDomainInfoByName failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.TrustedDomainInformation, fmt.Errorf("LsarQueryTrustedDomainInfoByName failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.TrustedDomainInformation, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/49_LsarSetTrustedDomainInfoByName.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/49_LsarSetTrustedDomainInfoByName.go
@@ -10,6 +10,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
@@ -45,8 +46,8 @@ func LsarSetTrustedDomainInfoByName(rpc ndr.Invoker, policyHandle mslsad.LSAPR_H
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("LsarSetTrustedDomainInfoByName: %w", err)
 	}
-	if uint32(resp.Status) != lsarpc.StatusSuccess {
-		return fmt.Errorf("LsarSetTrustedDomainInfoByName failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return fmt.Errorf("LsarSetTrustedDomainInfoByName failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/50_LsarEnumerateTrustedDomainsEx.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/50_LsarEnumerateTrustedDomainsEx.go
@@ -10,6 +10,7 @@ import (
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
 
@@ -50,10 +51,10 @@ func LsarEnumerateTrustedDomainsEx(rpc ndr.Invoker, policyHandle mslsad.LSAPR_HA
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return enumerationContext, mslsad.LSAPR_TRUSTED_ENUM_BUFFER_EX{}, fmt.Errorf("LsarEnumerateTrustedDomainsEx: %w", err)
 	}
-	switch uint32(resp.Status) {
-	case lsarpc.StatusSuccess, lsarpc.StatusMoreEntries, lsarpc.StatusNoMoreEntries:
+	switch status := nt_status.NT_STATUS(resp.Status); status {
+	case nt_status.NT_STATUS_SUCCESS, nt_status.NT_STATUS_MORE_ENTRIES, nt_status.NT_STATUS_NO_MORE_ENTRIES:
 		return uint32(resp.EnumerationContext), resp.EnumerationBuffer, nil
 	default:
-		return uint32(resp.EnumerationContext), resp.EnumerationBuffer, fmt.Errorf("LsarEnumerateTrustedDomainsEx failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+		return uint32(resp.EnumerationContext), resp.EnumerationBuffer, fmt.Errorf("LsarEnumerateTrustedDomainsEx failed: %s", status)
 	}
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/51_LsarCreateTrustedDomainEx.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/51_LsarCreateTrustedDomainEx.go
@@ -10,6 +10,7 @@ import (
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
 
@@ -42,8 +43,8 @@ func LsarCreateTrustedDomainEx(rpc ndr.Invoker, policyHandle mslsad.LSAPR_HANDLE
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return mslsad.LSAPR_HANDLE{}, fmt.Errorf("LsarCreateTrustedDomainEx: %w", err)
 	}
-	if uint32(resp.Status) != lsarpc.StatusSuccess {
-		return resp.Handle, fmt.Errorf("LsarCreateTrustedDomainEx failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Handle, fmt.Errorf("LsarCreateTrustedDomainEx failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Handle, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/53_LsarQueryDomainInformationPolicy.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/53_LsarQueryDomainInformationPolicy.go
@@ -10,6 +10,7 @@ import (
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
 
@@ -43,8 +44,8 @@ func LsarQueryDomainInformationPolicy(rpc ndr.Invoker, policyHandle mslsad.LSAPR
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return nil, fmt.Errorf("LsarQueryDomainInformationPolicy: %w", err)
 	}
-	if uint32(resp.Status) != lsarpc.StatusSuccess {
-		return resp.PolicyDomainInformation, fmt.Errorf("LsarQueryDomainInformationPolicy failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.PolicyDomainInformation, fmt.Errorf("LsarQueryDomainInformationPolicy failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.PolicyDomainInformation, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/54_LsarSetDomainInformationPolicy.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/54_LsarSetDomainInformationPolicy.go
@@ -10,6 +10,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
 
@@ -42,8 +43,8 @@ func LsarSetDomainInformationPolicy(rpc ndr.Invoker, policyHandle mslsad.LSAPR_H
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("LsarSetDomainInformationPolicy: %w", err)
 	}
-	if uint32(resp.Status) != lsarpc.StatusSuccess {
-		return fmt.Errorf("LsarSetDomainInformationPolicy failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return fmt.Errorf("LsarSetDomainInformationPolicy failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/55_LsarOpenTrustedDomainByName.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/55_LsarOpenTrustedDomainByName.go
@@ -10,6 +10,7 @@ import (
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
@@ -40,8 +41,8 @@ func LsarOpenTrustedDomainByName(rpc ndr.Invoker, policyHandle mslsad.LSAPR_HAND
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return mslsad.LSAPR_HANDLE{}, fmt.Errorf("LsarOpenTrustedDomainByName: %w", err)
 	}
-	if uint32(resp.Status) != lsarpc.StatusSuccess {
-		return resp.Handle, fmt.Errorf("LsarOpenTrustedDomainByName failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Handle, fmt.Errorf("LsarOpenTrustedDomainByName failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Handle, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/57_LsarLookupSids2.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/57_LsarLookupSids2.go
@@ -10,6 +10,7 @@ import (
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 	mslsat "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsat"
 )
@@ -55,11 +56,11 @@ func LsarLookupSids2(rpc ndr.Invoker, policyHandle mslsad.LSAPR_HANDLE, sidEnumB
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return nil, mslsat.LSAPR_TRANSLATED_NAMES_EX{}, 0, fmt.Errorf("LsarLookupSids2: %w", err)
 	}
-	status := uint32(resp.Status)
+	status := nt_status.NT_STATUS(resp.Status)
 	switch status {
-	case lsarpc.StatusSuccess, lsarpc.StatusSomeNotMapped, lsarpc.StatusNoneMapped:
+	case nt_status.NT_STATUS_SUCCESS, nt_status.NT_STATUS_SOME_NOT_MAPPED, nt_status.NT_STATUS_NONE_MAPPED:
 		return resp.ReferencedDomains, resp.TranslatedNames, uint32(resp.MappedCount), nil
 	default:
-		return resp.ReferencedDomains, resp.TranslatedNames, uint32(resp.MappedCount), fmt.Errorf("LsarLookupSids2 failed: %s", lsarpc.StatusString(status))
+		return resp.ReferencedDomains, resp.TranslatedNames, uint32(resp.MappedCount), fmt.Errorf("LsarLookupSids2 failed: %s", status)
 	}
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/58_LsarLookupNames2.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/58_LsarLookupNames2.go
@@ -10,6 +10,7 @@ import (
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 	mslsat "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsat"
@@ -58,11 +59,11 @@ func LsarLookupNames2(rpc ndr.Invoker, policyHandle mslsad.LSAPR_HANDLE, names [
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return nil, mslsat.LSAPR_TRANSLATED_SIDS_EX{}, 0, fmt.Errorf("LsarLookupNames2: %w", err)
 	}
-	status := uint32(resp.Status)
+	status := nt_status.NT_STATUS(resp.Status)
 	switch status {
-	case lsarpc.StatusSuccess, lsarpc.StatusSomeNotMapped, lsarpc.StatusNoneMapped:
+	case nt_status.NT_STATUS_SUCCESS, nt_status.NT_STATUS_SOME_NOT_MAPPED, nt_status.NT_STATUS_NONE_MAPPED:
 		return resp.ReferencedDomains, resp.TranslatedSids, uint32(resp.MappedCount), nil
 	default:
-		return resp.ReferencedDomains, resp.TranslatedSids, uint32(resp.MappedCount), fmt.Errorf("LsarLookupNames2 failed: %s", lsarpc.StatusString(status))
+		return resp.ReferencedDomains, resp.TranslatedSids, uint32(resp.MappedCount), fmt.Errorf("LsarLookupNames2 failed: %s", status)
 	}
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/59_LsarCreateTrustedDomainEx2.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/59_LsarCreateTrustedDomainEx2.go
@@ -10,6 +10,7 @@ import (
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
 
@@ -42,8 +43,8 @@ func LsarCreateTrustedDomainEx2(rpc ndr.Invoker, policyHandle mslsad.LSAPR_HANDL
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return mslsad.LSAPR_HANDLE{}, fmt.Errorf("LsarCreateTrustedDomainEx2: %w", err)
 	}
-	if uint32(resp.Status) != lsarpc.StatusSuccess {
-		return resp.Handle, fmt.Errorf("LsarCreateTrustedDomainEx2 failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Handle, fmt.Errorf("LsarCreateTrustedDomainEx2 failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Handle, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/68_LsarLookupNames3.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/68_LsarLookupNames3.go
@@ -10,6 +10,7 @@ import (
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 	mslsat "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsat"
@@ -57,11 +58,11 @@ func LsarLookupNames3(rpc ndr.Invoker, policyHandle mslsad.LSAPR_HANDLE, names [
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return nil, mslsat.LSAPR_TRANSLATED_SIDS_EX2{}, 0, fmt.Errorf("LsarLookupNames3: %w", err)
 	}
-	status := uint32(resp.Status)
+	status := nt_status.NT_STATUS(resp.Status)
 	switch status {
-	case lsarpc.StatusSuccess, lsarpc.StatusSomeNotMapped, lsarpc.StatusNoneMapped:
+	case nt_status.NT_STATUS_SUCCESS, nt_status.NT_STATUS_SOME_NOT_MAPPED, nt_status.NT_STATUS_NONE_MAPPED:
 		return resp.ReferencedDomains, resp.TranslatedSids, uint32(resp.MappedCount), nil
 	default:
-		return resp.ReferencedDomains, resp.TranslatedSids, uint32(resp.MappedCount), fmt.Errorf("LsarLookupNames3 failed: %s", lsarpc.StatusString(status))
+		return resp.ReferencedDomains, resp.TranslatedSids, uint32(resp.MappedCount), fmt.Errorf("LsarLookupNames3 failed: %s", status)
 	}
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/73_LsarQueryForestTrustInformation.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/73_LsarQueryForestTrustInformation.go
@@ -10,6 +10,7 @@ import (
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
@@ -47,8 +48,8 @@ func LsarQueryForestTrustInformation(rpc ndr.Invoker, policyHandle mslsad.LSAPR_
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return nil, fmt.Errorf("LsarQueryForestTrustInformation: %w", err)
 	}
-	if uint32(resp.Status) != lsarpc.StatusSuccess {
-		return resp.ForestTrustInfo, fmt.Errorf("LsarQueryForestTrustInformation failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.ForestTrustInfo, fmt.Errorf("LsarQueryForestTrustInformation failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.ForestTrustInfo, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/74_LsarSetForestTrustInformation.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/74_LsarSetForestTrustInformation.go
@@ -10,6 +10,7 @@ import (
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mslsad "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsad"
 )
@@ -54,8 +55,8 @@ func LsarSetForestTrustInformation(rpc ndr.Invoker, policyHandle mslsad.LSAPR_HA
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return nil, fmt.Errorf("LsarSetForestTrustInformation: %w", err)
 	}
-	if uint32(resp.Status) != lsarpc.StatusSuccess {
-		return resp.CollisionInfo, fmt.Errorf("LsarSetForestTrustInformation failed: %s", lsarpc.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.CollisionInfo, fmt.Errorf("LsarSetForestTrustInformation failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.CollisionInfo, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/76_LsarLookupSids3.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/76_LsarLookupSids3.go
@@ -10,6 +10,7 @@ import (
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mslsat "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsat"
 )
 
@@ -54,11 +55,11 @@ func LsarLookupSids3(rpc ndr.Invoker, sidEnumBuffer mslsat.LSAPR_SID_ENUM_BUFFER
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return nil, mslsat.LSAPR_TRANSLATED_NAMES_EX{}, 0, fmt.Errorf("LsarLookupSids3: %w", err)
 	}
-	status := uint32(resp.Status)
+	status := nt_status.NT_STATUS(resp.Status)
 	switch status {
-	case lsarpc.StatusSuccess, lsarpc.StatusSomeNotMapped, lsarpc.StatusNoneMapped:
+	case nt_status.NT_STATUS_SUCCESS, nt_status.NT_STATUS_SOME_NOT_MAPPED, nt_status.NT_STATUS_NONE_MAPPED:
 		return resp.ReferencedDomains, resp.TranslatedNames, uint32(resp.MappedCount), nil
 	default:
-		return resp.ReferencedDomains, resp.TranslatedNames, uint32(resp.MappedCount), fmt.Errorf("LsarLookupSids3 failed: %s", lsarpc.StatusString(status))
+		return resp.ReferencedDomains, resp.TranslatedNames, uint32(resp.MappedCount), fmt.Errorf("LsarLookupSids3 failed: %s", status)
 	}
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/77_LsarLookupNames4.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/77_LsarLookupNames4.go
@@ -10,6 +10,7 @@ import (
 
 	lsarpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mslsat "github.com/TheManticoreProject/Manticore/windows/protocols/ms-lsat"
 )
@@ -57,11 +58,11 @@ func LsarLookupNames4(rpc ndr.Invoker, names []msdtyp.RPC_UNICODE_STRING, lookup
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return nil, mslsat.LSAPR_TRANSLATED_SIDS_EX2{}, 0, fmt.Errorf("LsarLookupNames4: %w", err)
 	}
-	status := uint32(resp.Status)
+	status := nt_status.NT_STATUS(resp.Status)
 	switch status {
-	case lsarpc.StatusSuccess, lsarpc.StatusSomeNotMapped, lsarpc.StatusNoneMapped:
+	case nt_status.NT_STATUS_SUCCESS, nt_status.NT_STATUS_SOME_NOT_MAPPED, nt_status.NT_STATUS_NONE_MAPPED:
 		return resp.ReferencedDomains, resp.TranslatedSids, uint32(resp.MappedCount), nil
 	default:
-		return resp.ReferencedDomains, resp.TranslatedSids, uint32(resp.MappedCount), fmt.Errorf("LsarLookupNames4 failed: %s", lsarpc.StatusString(status))
+		return resp.ReferencedDomains, resp.TranslatedSids, uint32(resp.MappedCount), fmt.Errorf("LsarLookupNames4 failed: %s", status)
 	}
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/live_validation_test.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/live_validation_test.go
@@ -55,7 +55,7 @@ func classify(t *testing.T, method string, err error) (bool, bool) {
 		strings.Contains(msg, "dcerpc call") || strings.Contains(msg, "fault") ||
 		strings.Contains(msg, "unmarshal") || strings.Contains(msg, "decode")
 	// Our method wrappers report a decoded NTSTATUS as "<Method> failed: <status>".
-	appStatus := strings.Contains(msg, "failed: STATUS_") || strings.Contains(msg, "failed: 0x")
+	appStatus := strings.Contains(msg, "failed: NT_STATUS_") || strings.Contains(msg, "failed: 0x")
 	if appStatus && !transport {
 		t.Logf("[server status] %s -> %v", method, err)
 		return true, false

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/interface.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/interface.go
@@ -8,8 +8,8 @@
 // the nested 0.0/ directory) rather than after the pipe.
 //
 // This package holds only the interface-level descriptor: the abstract syntax
-// identifier, the transport endpoint (PipeName), the opnum constants, and the status
-// and access-mask values shared across methods. The NDR types live in the structures
+// identifier, the transport endpoint (PipeName), the opnum constants and the
+// access-mask values shared across methods. The NDR types live in the structures
 // subpackage and the method stubs in the functions subpackage; both depend on this
 // package, never the reverse.
 //
@@ -28,8 +28,6 @@ package rpcinterface_123457781234abcdef000123456789ab_0_0
 // A fetched copy is kept at ms-lsad.idl in the interface directory.
 
 import (
-	"fmt"
-
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
 	"github.com/TheManticoreProject/Manticore/windows/guid"
 )
@@ -163,23 +161,10 @@ const (
 	TrustedQueryAuth          uint32 = 0x00000040
 )
 
-// Common NTSTATUS codes returned by these methods ([MS-LSAD] return values and
-// [MS-ERREF] 2.3.1).
-const (
-	StatusSuccess            uint32 = 0x00000000
-	StatusMoreEntries        uint32 = 0x00000105
-	StatusNoMoreEntries      uint32 = 0x8000001A
-	StatusObjectNameNotFound uint32 = 0xC0000034
-	StatusAccessDenied       uint32 = 0xC0000022
-	StatusInvalidParameter   uint32 = 0xC000000D
-	StatusInvalidHandle      uint32 = 0xC0000008
-	StatusNoSuchPrivilege    uint32 = 0xC0000060
-	StatusNoSuchDomain       uint32 = 0xC00000DF
-	StatusNoneMapped         uint32 = 0xC0000073
-	StatusSomeNotMapped      uint32 = 0x00000107
-	StatusInvalidSid         uint32 = 0xC0000078
-	StatusNotSupported       uint32 = 0xC00000BB
-)
+// The NTSTATUS codes these methods return are not declared here. The whole of
+// [MS-ERREF] 2.3.1 lives in
+// github.com/TheManticoreProject/Manticore/windows/errors/nt_status, and a subset
+// repeated here would cover a fraction of that table and drift from it.
 
 // SyntaxID returns the lsarpc abstract syntax identifier:
 // 12345778-1234-abcd-ef00-0123456789ab, version 0.0.
@@ -188,41 +173,6 @@ func SyntaxID() syntax.SyntaxID {
 		UUID:         guid.GUID{A: 0x12345778, B: 0x1234, C: 0xabcd, D: 0xef00, E: 0x0123456789ab},
 		MajorVersion: 0,
 		MinorVersion: 0,
-	}
-}
-
-// StatusString returns a mnemonic for the documented status codes, otherwise the hex
-// value.
-func StatusString(status uint32) string {
-	switch status {
-	case StatusSuccess:
-		return "STATUS_SUCCESS"
-	case StatusMoreEntries:
-		return "STATUS_MORE_ENTRIES"
-	case StatusNoMoreEntries:
-		return "STATUS_NO_MORE_ENTRIES"
-	case StatusSomeNotMapped:
-		return "STATUS_SOME_NOT_MAPPED"
-	case StatusObjectNameNotFound:
-		return "STATUS_OBJECT_NAME_NOT_FOUND"
-	case StatusAccessDenied:
-		return "STATUS_ACCESS_DENIED"
-	case StatusInvalidParameter:
-		return "STATUS_INVALID_PARAMETER"
-	case StatusInvalidHandle:
-		return "STATUS_INVALID_HANDLE"
-	case StatusNoSuchPrivilege:
-		return "STATUS_NO_SUCH_PRIVILEGE"
-	case StatusNoSuchDomain:
-		return "STATUS_NO_SUCH_DOMAIN"
-	case StatusNoneMapped:
-		return "STATUS_NONE_MAPPED"
-	case StatusInvalidSid:
-		return "STATUS_INVALID_SID"
-	case StatusNotSupported:
-		return "STATUS_NOT_SUPPORTED"
-	default:
-		return fmt.Sprintf("0x%08x", status)
 	}
 }
 

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/interface_test.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/interface_test.go
@@ -1,13 +1,50 @@
 package rpcinterface_123457781234abcdef000123456789ab_0_0
 
-import "testing"
+import (
+	"testing"
 
-func TestStatusString(t *testing.T) {
-	if got := StatusString(StatusAccessDenied); got != "STATUS_ACCESS_DENIED" {
-		t.Errorf("StatusString(0xC0000022) = %q", got)
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
+)
+
+// TestDocumentedStatusesResolve pins that the NTSTATUS codes [MS-LSAD] and
+// [MS-LSAT] list as return values of these methods resolve through the shared
+// [MS-ERREF] 2.3.1 table under their NT_STATUS_* names, which is why this
+// interface declares no subset of its own.
+func TestDocumentedStatusesResolve(t *testing.T) {
+	documented := map[nt_status.NT_STATUS]string{
+		0x00000000: "NT_STATUS_SUCCESS",
+		0x00000105: "NT_STATUS_MORE_ENTRIES",
+		0x00000107: "NT_STATUS_SOME_NOT_MAPPED",
+		0x8000001A: "NT_STATUS_NO_MORE_ENTRIES",
+		0xC0000008: "NT_STATUS_INVALID_HANDLE",
+		0xC000000D: "NT_STATUS_INVALID_PARAMETER",
+		0xC0000022: "NT_STATUS_ACCESS_DENIED",
+		0xC0000034: "NT_STATUS_OBJECT_NAME_NOT_FOUND",
+		0xC0000060: "NT_STATUS_NO_SUCH_PRIVILEGE",
+		0xC0000073: "NT_STATUS_NONE_MAPPED",
+		0xC0000078: "NT_STATUS_INVALID_SID",
+		0xC00000BB: "NT_STATUS_NOT_SUPPORTED",
+		0xC00000DF: "NT_STATUS_NO_SUCH_DOMAIN",
 	}
-	if got := StatusString(0x12345678); got != "0x12345678" {
-		t.Errorf("StatusString(unknown) = %q", got)
+	for status, name := range documented {
+		if got := status.String(); got != name {
+			t.Errorf("NT_STATUS(0x%08x).String() = %q, want %q", uint32(status), got, name)
+		}
+	}
+}
+
+// TestStatusOutsideDocumentedSetResolves pins what the subset cost. A status
+// these methods return but the subset never listed — LsarCreateAccount reports
+// NT_STATUS_OBJECT_NAME_COLLISION when the account already exists — now renders
+// by name where it used to render as undecoded hexadecimal. A value no
+// specification defines still renders as hexadecimal, which is all that can be
+// said about it.
+func TestStatusOutsideDocumentedSetResolves(t *testing.T) {
+	if got := nt_status.NT_STATUS(0xC0000035).String(); got != "NT_STATUS_OBJECT_NAME_COLLISION" {
+		t.Errorf("NT_STATUS(0xc0000035).String() = %q, want %q", got, "NT_STATUS_OBJECT_NAME_COLLISION")
+	}
+	if got := nt_status.NT_STATUS(0x12345678).String(); got != "0x12345678" {
+		t.Errorf("NT_STATUS(0x12345678).String() = %q, want the hexadecimal value", got)
 	}
 }
 


### PR DESCRIPTION
### Linked Issue

Refs #1219

### Root Cause

`interface.go` for the lsarpc interface (12345778-1234-abcd-ef00-0123456789ab v0.0) declared thirteen NTSTATUS constants and a `StatusString` that switched over them. Every one of those values is already in `windows/errors/nt_status`, which holds the whole of [MS-ERREF] 2.3.1, so the block was a second transcription of the same numbers with nothing keeping the two in agreement.

The subset was also a ceiling. `StatusString` returned a mnemonic for the thirteen values it knew and `0x%08x` for everything else, so any status outside the subset reached the caller as undecoded hexadecimal. That covers most of what these methods return in practice: `LsarCreateAccount` reports `0xC0000035` for an account that already exists, and the [MS-LSAD] and [MS-LSAT] method sections list far more statuses than thirteen.

### Fix Description

The private constant block and `StatusString` are deleted from `interface.go`, which keeps its opnum constants, access masks, `SyntaxID`, `PipeName` and the opnum name maps, and gains a comment recording why the status codes are not declared there. The `fmt` import is dropped because `StatusString` was its only user.

The mapping from the private constants to the shared ones was derived from values, not from names. Each constant's numeric value was looked up in `windows/errors/errgen/ms-erref-2.3.1-ntstatus.tsv` and the Go name taken from the specification name in that row, so a mistranscribed mnemonic in the old block could not carry through:

| value | old name | [MS-ERREF] name | new name |
| --- | --- | --- | --- |
| `0x00000000` | `StatusSuccess` | `STATUS_SUCCESS` | `NT_STATUS_SUCCESS` |
| `0x00000105` | `StatusMoreEntries` | `STATUS_MORE_ENTRIES` | `NT_STATUS_MORE_ENTRIES` |
| `0x00000107` | `StatusSomeNotMapped` | `STATUS_SOME_NOT_MAPPED` | `NT_STATUS_SOME_NOT_MAPPED` |
| `0x8000001A` | `StatusNoMoreEntries` | `STATUS_NO_MORE_ENTRIES` | `NT_STATUS_NO_MORE_ENTRIES` |
| `0xC0000008` | `StatusInvalidHandle` | `STATUS_INVALID_HANDLE` | `NT_STATUS_INVALID_HANDLE` |
| `0xC000000D` | `StatusInvalidParameter` | `STATUS_INVALID_PARAMETER` | `NT_STATUS_INVALID_PARAMETER` |
| `0xC0000022` | `StatusAccessDenied` | `STATUS_ACCESS_DENIED` | `NT_STATUS_ACCESS_DENIED` |
| `0xC0000034` | `StatusObjectNameNotFound` | `STATUS_OBJECT_NAME_NOT_FOUND` | `NT_STATUS_OBJECT_NAME_NOT_FOUND` |
| `0xC0000060` | `StatusNoSuchPrivilege` | `STATUS_NO_SUCH_PRIVILEGE` | `NT_STATUS_NO_SUCH_PRIVILEGE` |
| `0xC0000073` | `StatusNoneMapped` | `STATUS_NONE_MAPPED` | `NT_STATUS_NONE_MAPPED` |
| `0xC0000078` | `StatusInvalidSid` | `STATUS_INVALID_SID` | `NT_STATUS_INVALID_SID` |
| `0xC00000BB` | `StatusNotSupported` | `STATUS_NOT_SUPPORTED` | `NT_STATUS_NOT_SUPPORTED` |
| `0xC00000DF` | `StatusNoSuchDomain` | `STATUS_NO_SUCH_DOMAIN` | `NT_STATUS_NO_SUCH_DOMAIN` |

All thirteen resolved in the table, so none of them is interface-specific and none had to stay behind.

The 69 method files under `functions/` now compare and report through the shared type directly, with no alias constants and no delegating wrapper. A single-status check converts inline:

```go
if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
        return resp.Handle, fmt.Errorf("LsarOpenPolicy failed: %s", nt_status.NT_STATUS(resp.Status).String())
}
```

A condition or switch that accepts more than one status hoists the conversion into the initializer, so the conversion is written once:

```go
status := nt_status.NT_STATUS(resp.Status)
if status != nt_status.NT_STATUS_SUCCESS && status != nt_status.NT_STATUS_MORE_ENTRIES {
        return resp.EnumerationBuffer, uint32(resp.EnumerationContext), fmt.Errorf("LsarEnumerateAccounts failed: %s", status)
}
```

The rewrite was applied one comparison term at a time rather than one condition at a time. Ten call sites accept more than one status — `LsarEnumerateAccounts` takes `NT_STATUS_MORE_ENTRIES` alongside success, `LsarEnumerateTrustedDomains` and `LsarEnumerateTrustedDomainsEx` additionally take `NT_STATUS_NO_MORE_ENTRIES`, and the seven `LsarLookupNames`/`LsarLookupSids` variants take `NT_STATUS_SOME_NOT_MAPPED` and `NT_STATUS_NONE_MAPPED` — and a per-condition rewrite can drop a term and still compile, turning a partial lookup into a reported failure. Every `if` was checked afterwards for the same number of `!=`/`==` terms it carried before, and every `case` list for the same number of values.

`functions/live_validation_test.go` classifies a decoded server status by the text of the error. It matched `"failed: STATUS_"`, which no longer occurs because the shared table's names carry the `NT_STATUS_` prefix, so the classifier would have reported every application status as a wire failure. It now matches `"failed: NT_STATUS_"`.

### How Verified

- `go build ./...` — clean.
- `go vet ./...` — clean.
- `go test -count=1 ./...` — 311 packages ok, 0 failures.
- Cross-compiled with `CGO_ENABLED=0 go build ./...` for `windows/amd64`, `windows/386`, `linux/arm64` and `linux/386` — all clean.
- `gofmt -l` over every file touched reports no drift.
- `grep -rn 'lsarpc\.Status' --include=*.go .` returns nothing, and no `Status*` constant or `StatusString` remains in `interface.go`. `SyntaxID`, `PipeName`, `OpnumToName` and `NameToOpnum` are all still present.
- Mechanical check that each rewritten file has the same per-`if` count of `!=` and `==` terms as its parent revision: no mismatches.

### Test Coverage

`TestStatusString` in `interface_test.go` is replaced by two tests. `TestDocumentedStatusesResolve` asserts that all thirteen codes this interface documents resolve through the shared table under their `NT_STATUS_*` names, keyed by value, so the interface's documented set stays pinned to [MS-ERREF] without redeclaring it. `TestStatusOutsideDocumentedSetResolves` asserts that `0xC0000035`, a status these methods return but the old subset never listed, now renders as `NT_STATUS_OBJECT_NAME_COLLISION` where it previously rendered as hexadecimal, and that a value no specification defines still renders as hexadecimal.

`TestOpnumNameMapsRoundTrip` and `TestSyntaxID` are unchanged and still pass, which pins that nothing beyond the status block left `interface.go`.

### Scope of Change

Files changed: 72.

- `network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/interface.go` — status constants and `StatusString` removed, `fmt` import dropped, package and block comments updated.
- `network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/interface_test.go` — `TestStatusString` replaced by the two tests above.
- 69 files under `network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/` — status comparison and reporting routed through `nt_status`, import added.
- `network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ab/0.0/functions/live_validation_test.go` — classifier prefix updated.

Submodule pointer updated: no — the repository has no submodules.

Behavioral changes outside the bug fix: the text of a reported status changes. `STATUS_ACCESS_DENIED` becomes `NT_STATUS_ACCESS_DENIED`, and a status outside the old subset becomes its name rather than `0x%08x`. Every status comparison keeps the values it accepted before.

### Risk and Rollout

The change is confined to one interface directory. The wire format is untouched: no request or response structure, opnum, access mask or NDR tag changes, and the set of statuses each method treats as success is identical to the values the private constants held. The exposed surface shrinks — thirteen exported constants and one exported function are removed — and nothing outside this interface referenced them, which the tree-wide build confirms. The visible difference is the text of an error string, consumed by `classify` in the live-validation test, which is updated in the same commit.

### Notes

This is one of the 74 interfaces #1219 covers, so the commit uses `Refs #1219` rather than a closing keyword.

Nothing in the subset fell outside [MS-ERREF] 2.3.1, and the old mnemonics all matched the specification names for their values, so the value-derived mapping confirmed the old table rather than correcting it. Two switch statements, in `LsarEnumerateTrustedDomains` and `LsarEnumerateTrustedDomainsEx`, converted `resp.Status` twice — once in the switch expression and once in the default branch's error; both now share one conversion in the switch initializer.
