### PR TITLE
Route srvsvc status reporting through win32 (Refs #1219)

### DIFF
--- a/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/08_NetrConnectionEnum.go
+++ b/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/08_NetrConnectionEnum.go
@@ -10,6 +10,7 @@ import (
 
 	srvsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	mssrvs "github.com/TheManticoreProject/Manticore/windows/protocols/ms-srvs"
 )
 
@@ -59,9 +60,9 @@ func NetrConnectionEnum(rpc ndr.Invoker, serverName, qualifier string, info mssr
 	if resp.ResumeHandle != nil {
 		outResume = uint32(*resp.ResumeHandle)
 	}
-	status := uint32(resp.Status)
-	if status != srvsvc.NERR_Success && status != srvsvc.ERROR_MORE_DATA {
-		return resp.InfoStruct, uint32(resp.TotalEntries), outResume, fmt.Errorf("NetrConnectionEnum failed: %s", srvsvc.StatusString(status))
+	status := win32.WIN32_ERROR(resp.Status)
+	if status != win32.NERR_Success && status != win32.ERROR_MORE_DATA {
+		return resp.InfoStruct, uint32(resp.TotalEntries), outResume, fmt.Errorf("NetrConnectionEnum failed: %s", status)
 	}
 	return resp.InfoStruct, uint32(resp.TotalEntries), outResume, nil
 }

--- a/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/09_NetrFileEnum.go
+++ b/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/09_NetrFileEnum.go
@@ -10,6 +10,7 @@ import (
 
 	srvsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	mssrvs "github.com/TheManticoreProject/Manticore/windows/protocols/ms-srvs"
 )
 
@@ -61,9 +62,9 @@ func NetrFileEnum(rpc ndr.Invoker, serverName, basePath, userName string, info m
 	if resp.ResumeHandle != nil {
 		outResume = uint32(*resp.ResumeHandle)
 	}
-	status := uint32(resp.Status)
-	if status != srvsvc.NERR_Success && status != srvsvc.ERROR_MORE_DATA {
-		return resp.InfoStruct, uint32(resp.TotalEntries), outResume, fmt.Errorf("NetrFileEnum failed: %s", srvsvc.StatusString(status))
+	status := win32.WIN32_ERROR(resp.Status)
+	if status != win32.NERR_Success && status != win32.ERROR_MORE_DATA {
+		return resp.InfoStruct, uint32(resp.TotalEntries), outResume, fmt.Errorf("NetrFileEnum failed: %s", status)
 	}
 	return resp.InfoStruct, uint32(resp.TotalEntries), outResume, nil
 }

--- a/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/10_NetrFileGetInfo.go
+++ b/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/10_NetrFileGetInfo.go
@@ -10,6 +10,7 @@ import (
 
 	srvsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	mssrvs "github.com/TheManticoreProject/Manticore/windows/protocols/ms-srvs"
 )
 
@@ -43,9 +44,9 @@ func NetrFileGetInfo(rpc ndr.Invoker, serverName string, fileId, level uint32) (
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return mssrvs.FILE_INFO{}, fmt.Errorf("NetrFileGetInfo: %w", err)
 	}
-	status := uint32(resp.Status)
-	if status != srvsvc.NERR_Success && status != srvsvc.ERROR_MORE_DATA {
-		return resp.InfoStruct, fmt.Errorf("NetrFileGetInfo failed: %s", srvsvc.StatusString(status))
+	status := win32.WIN32_ERROR(resp.Status)
+	if status != win32.NERR_Success && status != win32.ERROR_MORE_DATA {
+		return resp.InfoStruct, fmt.Errorf("NetrFileGetInfo failed: %s", status)
 	}
 	return resp.InfoStruct, nil
 }

--- a/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/11_NetrFileClose.go
+++ b/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/11_NetrFileClose.go
@@ -10,6 +10,7 @@ import (
 
 	srvsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 )
 
 // netrFileCloseRequest is the [in] parameter set of NetrFileClose: the [unique] server
@@ -32,9 +33,9 @@ func NetrFileClose(rpc ndr.Invoker, serverName string, fileId uint32) error {
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("NetrFileClose: %w", err)
 	}
-	status := uint32(resp.Status)
-	if status != srvsvc.NERR_Success && status != srvsvc.ERROR_MORE_DATA {
-		return fmt.Errorf("NetrFileClose failed: %s", srvsvc.StatusString(status))
+	status := win32.WIN32_ERROR(resp.Status)
+	if status != win32.NERR_Success && status != win32.ERROR_MORE_DATA {
+		return fmt.Errorf("NetrFileClose failed: %s", status)
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/12_NetrSessionEnum.go
+++ b/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/12_NetrSessionEnum.go
@@ -10,6 +10,7 @@ import (
 
 	srvsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	mssrvs "github.com/TheManticoreProject/Manticore/windows/protocols/ms-srvs"
 )
 
@@ -61,9 +62,9 @@ func NetrSessionEnum(rpc ndr.Invoker, serverName, clientName, userName string, i
 	if resp.ResumeHandle != nil {
 		outResume = uint32(*resp.ResumeHandle)
 	}
-	status := uint32(resp.Status)
-	if status != srvsvc.NERR_Success && status != srvsvc.ERROR_MORE_DATA {
-		return resp.InfoStruct, uint32(resp.TotalEntries), outResume, fmt.Errorf("NetrSessionEnum failed: %s", srvsvc.StatusString(status))
+	status := win32.WIN32_ERROR(resp.Status)
+	if status != win32.NERR_Success && status != win32.ERROR_MORE_DATA {
+		return resp.InfoStruct, uint32(resp.TotalEntries), outResume, fmt.Errorf("NetrSessionEnum failed: %s", status)
 	}
 	return resp.InfoStruct, uint32(resp.TotalEntries), outResume, nil
 }

--- a/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/13_NetrSessionDel.go
+++ b/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/13_NetrSessionDel.go
@@ -10,6 +10,7 @@ import (
 
 	srvsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 )
 
 // netrSessionDelRequest is the [in] parameter set of NetrSessionDel: the [unique] server
@@ -34,9 +35,9 @@ func NetrSessionDel(rpc ndr.Invoker, serverName, clientName, userName string) er
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("NetrSessionDel: %w", err)
 	}
-	status := uint32(resp.Status)
-	if status != srvsvc.NERR_Success && status != srvsvc.ERROR_MORE_DATA {
-		return fmt.Errorf("NetrSessionDel failed: %s", srvsvc.StatusString(status))
+	status := win32.WIN32_ERROR(resp.Status)
+	if status != win32.NERR_Success && status != win32.ERROR_MORE_DATA {
+		return fmt.Errorf("NetrSessionDel failed: %s", status)
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/14_NetrShareAdd.go
+++ b/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/14_NetrShareAdd.go
@@ -10,6 +10,7 @@ import (
 
 	srvsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	mssrvs "github.com/TheManticoreProject/Manticore/windows/protocols/ms-srvs"
 )
 
@@ -48,8 +49,8 @@ func NetrShareAdd(rpc ndr.Invoker, serverName string, level ndr.DWORD, infoStruc
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return nil, fmt.Errorf("NetrShareAdd: %w", err)
 	}
-	if uint32(resp.Status) != srvsvc.NERR_Success && uint32(resp.Status) != srvsvc.ERROR_MORE_DATA {
-		return resp.ParmErr, fmt.Errorf("NetrShareAdd failed: %s", srvsvc.StatusString(uint32(resp.Status)))
+	if status := win32.WIN32_ERROR(resp.Status); status != win32.NERR_Success && status != win32.ERROR_MORE_DATA {
+		return resp.ParmErr, fmt.Errorf("NetrShareAdd failed: %s", status)
 	}
 	return resp.ParmErr, nil
 }

--- a/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/15_NetrShareEnum.go
+++ b/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/15_NetrShareEnum.go
@@ -10,6 +10,7 @@ import (
 
 	srvsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	mssrvs "github.com/TheManticoreProject/Manticore/windows/protocols/ms-srvs"
 )
 
@@ -49,8 +50,8 @@ func NetrShareEnum(rpc ndr.Invoker, serverName string, infoStruct mssrvs.SHARE_E
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return mssrvs.SHARE_ENUM_STRUCT{}, 0, nil, fmt.Errorf("NetrShareEnum: %w", err)
 	}
-	if uint32(resp.Status) != srvsvc.NERR_Success && uint32(resp.Status) != srvsvc.ERROR_MORE_DATA {
-		return resp.InfoStruct, resp.TotalEntries, resp.ResumeHandle, fmt.Errorf("NetrShareEnum failed: %s", srvsvc.StatusString(uint32(resp.Status)))
+	if status := win32.WIN32_ERROR(resp.Status); status != win32.NERR_Success && status != win32.ERROR_MORE_DATA {
+		return resp.InfoStruct, resp.TotalEntries, resp.ResumeHandle, fmt.Errorf("NetrShareEnum failed: %s", status)
 	}
 	return resp.InfoStruct, resp.TotalEntries, resp.ResumeHandle, nil
 }

--- a/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/16_NetrShareGetInfo.go
+++ b/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/16_NetrShareGetInfo.go
@@ -10,6 +10,7 @@ import (
 
 	srvsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	mssrvs "github.com/TheManticoreProject/Manticore/windows/protocols/ms-srvs"
 )
 
@@ -45,8 +46,8 @@ func NetrShareGetInfo(rpc ndr.Invoker, serverName string, netName string, level 
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return mssrvs.SHARE_INFO{}, fmt.Errorf("NetrShareGetInfo: %w", err)
 	}
-	if uint32(resp.Status) != srvsvc.NERR_Success && uint32(resp.Status) != srvsvc.ERROR_MORE_DATA {
-		return resp.InfoStruct, fmt.Errorf("NetrShareGetInfo failed: %s", srvsvc.StatusString(uint32(resp.Status)))
+	if status := win32.WIN32_ERROR(resp.Status); status != win32.NERR_Success && status != win32.ERROR_MORE_DATA {
+		return resp.InfoStruct, fmt.Errorf("NetrShareGetInfo failed: %s", status)
 	}
 	return resp.InfoStruct, nil
 }

--- a/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/17_NetrShareSetInfo.go
+++ b/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/17_NetrShareSetInfo.go
@@ -10,6 +10,7 @@ import (
 
 	srvsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	mssrvs "github.com/TheManticoreProject/Manticore/windows/protocols/ms-srvs"
 )
 
@@ -51,8 +52,8 @@ func NetrShareSetInfo(rpc ndr.Invoker, serverName string, netName string, level 
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return nil, fmt.Errorf("NetrShareSetInfo: %w", err)
 	}
-	if uint32(resp.Status) != srvsvc.NERR_Success && uint32(resp.Status) != srvsvc.ERROR_MORE_DATA {
-		return resp.ParmErr, fmt.Errorf("NetrShareSetInfo failed: %s", srvsvc.StatusString(uint32(resp.Status)))
+	if status := win32.WIN32_ERROR(resp.Status); status != win32.NERR_Success && status != win32.ERROR_MORE_DATA {
+		return resp.ParmErr, fmt.Errorf("NetrShareSetInfo failed: %s", status)
 	}
 	return resp.ParmErr, nil
 }

--- a/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/18_NetrShareDel.go
+++ b/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/18_NetrShareDel.go
@@ -10,6 +10,7 @@ import (
 
 	srvsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 )
 
 // netrShareDelRequest is the [in] parameter set of NetrShareDel: the optional server name,
@@ -36,8 +37,8 @@ func NetrShareDel(rpc ndr.Invoker, serverName string, netName string, reserved n
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("NetrShareDel: %w", err)
 	}
-	if uint32(resp.Status) != srvsvc.NERR_Success && uint32(resp.Status) != srvsvc.ERROR_MORE_DATA {
-		return fmt.Errorf("NetrShareDel failed: %s", srvsvc.StatusString(uint32(resp.Status)))
+	if status := win32.WIN32_ERROR(resp.Status); status != win32.NERR_Success && status != win32.ERROR_MORE_DATA {
+		return fmt.Errorf("NetrShareDel failed: %s", status)
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/19_NetrShareDelSticky.go
+++ b/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/19_NetrShareDelSticky.go
@@ -10,6 +10,7 @@ import (
 
 	srvsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 )
 
 // netrShareDelStickyRequest is the [in] parameter set of NetrShareDelSticky: the optional
@@ -36,8 +37,8 @@ func NetrShareDelSticky(rpc ndr.Invoker, serverName string, netName string, rese
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("NetrShareDelSticky: %w", err)
 	}
-	if uint32(resp.Status) != srvsvc.NERR_Success && uint32(resp.Status) != srvsvc.ERROR_MORE_DATA {
-		return fmt.Errorf("NetrShareDelSticky failed: %s", srvsvc.StatusString(uint32(resp.Status)))
+	if status := win32.WIN32_ERROR(resp.Status); status != win32.NERR_Success && status != win32.ERROR_MORE_DATA {
+		return fmt.Errorf("NetrShareDelSticky failed: %s", status)
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/20_NetrShareCheck.go
+++ b/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/20_NetrShareCheck.go
@@ -10,6 +10,7 @@ import (
 
 	srvsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 )
 
 // netrShareCheckRequest is the [in] parameter set of NetrShareCheck: the optional server
@@ -41,8 +42,8 @@ func NetrShareCheck(rpc ndr.Invoker, serverName string, device string) (ndr.DWOR
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return 0, fmt.Errorf("NetrShareCheck: %w", err)
 	}
-	if uint32(resp.Status) != srvsvc.NERR_Success && uint32(resp.Status) != srvsvc.ERROR_MORE_DATA {
-		return resp.Type, fmt.Errorf("NetrShareCheck failed: %s", srvsvc.StatusString(uint32(resp.Status)))
+	if status := win32.WIN32_ERROR(resp.Status); status != win32.NERR_Success && status != win32.ERROR_MORE_DATA {
+		return resp.Type, fmt.Errorf("NetrShareCheck failed: %s", status)
 	}
 	return resp.Type, nil
 }

--- a/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/21_NetrServerGetInfo.go
+++ b/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/21_NetrServerGetInfo.go
@@ -10,6 +10,7 @@ import (
 
 	srvsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	mssrvs "github.com/TheManticoreProject/Manticore/windows/protocols/ms-srvs"
 )
 
@@ -40,9 +41,9 @@ func NetrServerGetInfo(rpc ndr.Invoker, serverName string, level uint32) (mssrvs
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return mssrvs.SERVER_INFO{}, fmt.Errorf("NetrServerGetInfo: %w", err)
 	}
-	status := uint32(resp.Status)
-	if status != srvsvc.NERR_Success && status != srvsvc.ERROR_MORE_DATA {
-		return resp.InfoStruct, fmt.Errorf("NetrServerGetInfo failed: %s", srvsvc.StatusString(status))
+	status := win32.WIN32_ERROR(resp.Status)
+	if status != win32.NERR_Success && status != win32.ERROR_MORE_DATA {
+		return resp.InfoStruct, fmt.Errorf("NetrServerGetInfo failed: %s", status)
 	}
 	return resp.InfoStruct, nil
 }

--- a/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/22_NetrServerSetInfo.go
+++ b/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/22_NetrServerSetInfo.go
@@ -10,6 +10,7 @@ import (
 
 	srvsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	mssrvs "github.com/TheManticoreProject/Manticore/windows/protocols/ms-srvs"
 )
 
@@ -53,9 +54,8 @@ func NetrServerSetInfo(rpc ndr.Invoker, serverName string, level uint32, serverI
 	if resp.ParmErr != nil {
 		outParmErr = uint32(*resp.ParmErr)
 	}
-	status := uint32(resp.Status)
-	if status != srvsvc.NERR_Success {
-		return outParmErr, fmt.Errorf("NetrServerSetInfo failed: %s", srvsvc.StatusString(status))
+	if win32.WIN32_ERROR(resp.Status) != win32.NERR_Success {
+		return outParmErr, fmt.Errorf("NetrServerSetInfo failed: %s", win32.WIN32_ERROR(resp.Status).String())
 	}
 	return outParmErr, nil
 }

--- a/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/23_NetrServerDiskEnum.go
+++ b/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/23_NetrServerDiskEnum.go
@@ -10,6 +10,7 @@ import (
 
 	srvsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	mssrvs "github.com/TheManticoreProject/Manticore/windows/protocols/ms-srvs"
 )
 
@@ -56,9 +57,9 @@ func NetrServerDiskEnum(rpc ndr.Invoker, serverName string, level uint32, diskIn
 	if resp.ResumeHandle != nil {
 		outResume = uint32(*resp.ResumeHandle)
 	}
-	status := uint32(resp.Status)
-	if status != srvsvc.NERR_Success && status != srvsvc.ERROR_MORE_DATA {
-		return resp.DiskInfoStruct, uint32(resp.TotalEntries), outResume, fmt.Errorf("NetrServerDiskEnum failed: %s", srvsvc.StatusString(status))
+	status := win32.WIN32_ERROR(resp.Status)
+	if status != win32.NERR_Success && status != win32.ERROR_MORE_DATA {
+		return resp.DiskInfoStruct, uint32(resp.TotalEntries), outResume, fmt.Errorf("NetrServerDiskEnum failed: %s", status)
 	}
 	return resp.DiskInfoStruct, uint32(resp.TotalEntries), outResume, nil
 }

--- a/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/24_NetrServerStatisticsGet.go
+++ b/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/24_NetrServerStatisticsGet.go
@@ -10,6 +10,7 @@ import (
 
 	srvsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	mssrvs "github.com/TheManticoreProject/Manticore/windows/protocols/ms-srvs"
 )
 
@@ -45,9 +46,8 @@ func NetrServerStatisticsGet(rpc ndr.Invoker, serverName, service string, level,
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return nil, fmt.Errorf("NetrServerStatisticsGet: %w", err)
 	}
-	status := uint32(resp.Status)
-	if status != srvsvc.NERR_Success {
-		return resp.InfoStruct, fmt.Errorf("NetrServerStatisticsGet failed: %s", srvsvc.StatusString(status))
+	if win32.WIN32_ERROR(resp.Status) != win32.NERR_Success {
+		return resp.InfoStruct, fmt.Errorf("NetrServerStatisticsGet failed: %s", win32.WIN32_ERROR(resp.Status).String())
 	}
 	return resp.InfoStruct, nil
 }

--- a/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/25_NetrServerTransportAdd.go
+++ b/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/25_NetrServerTransportAdd.go
@@ -10,6 +10,7 @@ import (
 
 	srvsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	mssrvs "github.com/TheManticoreProject/Manticore/windows/protocols/ms-srvs"
 )
 
@@ -36,8 +37,8 @@ func NetrServerTransportAdd(rpc ndr.Invoker, serverName string, level uint32, bu
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("NetrServerTransportAdd: %w", err)
 	}
-	if status := uint32(resp.Status); status != srvsvc.NERR_Success {
-		return fmt.Errorf("NetrServerTransportAdd failed: %s", srvsvc.StatusString(status))
+	if win32.WIN32_ERROR(resp.Status) != win32.NERR_Success {
+		return fmt.Errorf("NetrServerTransportAdd failed: %s", win32.WIN32_ERROR(resp.Status).String())
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/26_NetrServerTransportEnum.go
+++ b/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/26_NetrServerTransportEnum.go
@@ -10,6 +10,7 @@ import (
 
 	srvsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	mssrvs "github.com/TheManticoreProject/Manticore/windows/protocols/ms-srvs"
 )
 
@@ -56,9 +57,9 @@ func NetrServerTransportEnum(rpc ndr.Invoker, serverName string, info mssrvs.SER
 	if resp.ResumeHandle != nil {
 		outResume = uint32(*resp.ResumeHandle)
 	}
-	status := uint32(resp.Status)
-	if status != srvsvc.NERR_Success && status != srvsvc.ERROR_MORE_DATA {
-		return resp.InfoStruct, uint32(resp.TotalEntries), outResume, fmt.Errorf("NetrServerTransportEnum failed: %s", srvsvc.StatusString(status))
+	status := win32.WIN32_ERROR(resp.Status)
+	if status != win32.NERR_Success && status != win32.ERROR_MORE_DATA {
+		return resp.InfoStruct, uint32(resp.TotalEntries), outResume, fmt.Errorf("NetrServerTransportEnum failed: %s", status)
 	}
 	return resp.InfoStruct, uint32(resp.TotalEntries), outResume, nil
 }

--- a/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/27_NetrServerTransportDel.go
+++ b/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/27_NetrServerTransportDel.go
@@ -10,6 +10,7 @@ import (
 
 	srvsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	mssrvs "github.com/TheManticoreProject/Manticore/windows/protocols/ms-srvs"
 )
 
@@ -36,8 +37,8 @@ func NetrServerTransportDel(rpc ndr.Invoker, serverName string, level uint32, bu
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("NetrServerTransportDel: %w", err)
 	}
-	if status := uint32(resp.Status); status != srvsvc.NERR_Success {
-		return fmt.Errorf("NetrServerTransportDel failed: %s", srvsvc.StatusString(status))
+	if win32.WIN32_ERROR(resp.Status) != win32.NERR_Success {
+		return fmt.Errorf("NetrServerTransportDel failed: %s", win32.WIN32_ERROR(resp.Status).String())
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/28_NetrRemoteTOD.go
+++ b/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/28_NetrRemoteTOD.go
@@ -10,6 +10,7 @@ import (
 
 	srvsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	mssrvs "github.com/TheManticoreProject/Manticore/windows/protocols/ms-srvs"
 )
 
@@ -38,9 +39,8 @@ func NetrRemoteTOD(rpc ndr.Invoker, serverName string) (*mssrvs.TIME_OF_DAY_INFO
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return nil, fmt.Errorf("NetrRemoteTOD: %w", err)
 	}
-	status := uint32(resp.Status)
-	if status != srvsvc.NERR_Success {
-		return resp.BufferPtr, fmt.Errorf("NetrRemoteTOD failed: %s", srvsvc.StatusString(status))
+	if win32.WIN32_ERROR(resp.Status) != win32.NERR_Success {
+		return resp.BufferPtr, fmt.Errorf("NetrRemoteTOD failed: %s", win32.WIN32_ERROR(resp.Status).String())
 	}
 	return resp.BufferPtr, nil
 }

--- a/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/30_NetprPathType.go
+++ b/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/30_NetprPathType.go
@@ -10,6 +10,7 @@ import (
 
 	srvsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 )
 
 // netprPathTypeRequest is the [in] parameter set of NetprPathType: the [unique] server
@@ -41,9 +42,9 @@ func NetprPathType(rpc ndr.Invoker, serverName, pathName string, flags uint32) (
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return 0, fmt.Errorf("NetprPathType: %w", err)
 	}
-	status := uint32(resp.Status)
-	if status != srvsvc.NERR_Success && status != srvsvc.ERROR_MORE_DATA {
-		return uint32(resp.PathType), fmt.Errorf("NetprPathType failed: %s", srvsvc.StatusString(status))
+	status := win32.WIN32_ERROR(resp.Status)
+	if status != win32.NERR_Success && status != win32.ERROR_MORE_DATA {
+		return uint32(resp.PathType), fmt.Errorf("NetprPathType failed: %s", status)
 	}
 	return uint32(resp.PathType), nil
 }

--- a/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/31_NetprPathCanonicalize.go
+++ b/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/31_NetprPathCanonicalize.go
@@ -10,6 +10,7 @@ import (
 
 	srvsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 )
 
 // netprPathCanonicalizeRequest is the [in] parameter set of NetprPathCanonicalize: the
@@ -49,9 +50,9 @@ func NetprPathCanonicalize(rpc ndr.Invoker, serverName, pathName string, outbufL
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return nil, 0, fmt.Errorf("NetprPathCanonicalize: %w", err)
 	}
-	status := uint32(resp.Status)
-	if status != srvsvc.NERR_Success && status != srvsvc.ERROR_MORE_DATA {
-		return resp.Outbuf, uint32(resp.PathType), fmt.Errorf("NetprPathCanonicalize failed: %s", srvsvc.StatusString(status))
+	status := win32.WIN32_ERROR(resp.Status)
+	if status != win32.NERR_Success && status != win32.ERROR_MORE_DATA {
+		return resp.Outbuf, uint32(resp.PathType), fmt.Errorf("NetprPathCanonicalize failed: %s", status)
 	}
 	return resp.Outbuf, uint32(resp.PathType), nil
 }

--- a/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/33_NetprNameValidate.go
+++ b/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/33_NetprNameValidate.go
@@ -10,6 +10,7 @@ import (
 
 	srvsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 )
 
 // netprNameValidateRequest is the [in] parameter set of NetprNameValidate: the [unique]
@@ -36,9 +37,9 @@ func NetprNameValidate(rpc ndr.Invoker, serverName, name string, nameType, flags
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("NetprNameValidate: %w", err)
 	}
-	status := uint32(resp.Status)
-	if status != srvsvc.NERR_Success && status != srvsvc.ERROR_MORE_DATA {
-		return fmt.Errorf("NetprNameValidate failed: %s", srvsvc.StatusString(status))
+	status := win32.WIN32_ERROR(resp.Status)
+	if status != win32.NERR_Success && status != win32.ERROR_MORE_DATA {
+		return fmt.Errorf("NetprNameValidate failed: %s", status)
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/34_NetprNameCanonicalize.go
+++ b/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/34_NetprNameCanonicalize.go
@@ -10,6 +10,7 @@ import (
 
 	srvsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 )
 
 // netprNameCanonicalizeRequest is the [in] parameter set of NetprNameCanonicalize: the
@@ -46,9 +47,9 @@ func NetprNameCanonicalize(rpc ndr.Invoker, serverName, name string, outbufLen, 
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return nil, fmt.Errorf("NetprNameCanonicalize: %w", err)
 	}
-	status := uint32(resp.Status)
-	if status != srvsvc.NERR_Success && status != srvsvc.ERROR_MORE_DATA {
-		return resp.Outbuf, fmt.Errorf("NetprNameCanonicalize failed: %s", srvsvc.StatusString(status))
+	status := win32.WIN32_ERROR(resp.Status)
+	if status != win32.NERR_Success && status != win32.ERROR_MORE_DATA {
+		return resp.Outbuf, fmt.Errorf("NetprNameCanonicalize failed: %s", status)
 	}
 	return resp.Outbuf, nil
 }

--- a/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/36_NetrShareEnumSticky.go
+++ b/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/36_NetrShareEnumSticky.go
@@ -10,6 +10,7 @@ import (
 
 	srvsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	mssrvs "github.com/TheManticoreProject/Manticore/windows/protocols/ms-srvs"
 )
 
@@ -50,8 +51,8 @@ func NetrShareEnumSticky(rpc ndr.Invoker, serverName string, infoStruct mssrvs.S
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return mssrvs.SHARE_ENUM_STRUCT{}, 0, nil, fmt.Errorf("NetrShareEnumSticky: %w", err)
 	}
-	if uint32(resp.Status) != srvsvc.NERR_Success && uint32(resp.Status) != srvsvc.ERROR_MORE_DATA {
-		return resp.InfoStruct, resp.TotalEntries, resp.ResumeHandle, fmt.Errorf("NetrShareEnumSticky failed: %s", srvsvc.StatusString(uint32(resp.Status)))
+	if status := win32.WIN32_ERROR(resp.Status); status != win32.NERR_Success && status != win32.ERROR_MORE_DATA {
+		return resp.InfoStruct, resp.TotalEntries, resp.ResumeHandle, fmt.Errorf("NetrShareEnumSticky failed: %s", status)
 	}
 	return resp.InfoStruct, resp.TotalEntries, resp.ResumeHandle, nil
 }

--- a/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/37_NetrShareDelStart.go
+++ b/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/37_NetrShareDelStart.go
@@ -10,6 +10,7 @@ import (
 
 	srvsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	mssrvs "github.com/TheManticoreProject/Manticore/windows/protocols/ms-srvs"
 )
 
@@ -44,8 +45,8 @@ func NetrShareDelStart(rpc ndr.Invoker, serverName string, netName string, reser
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return mssrvs.SHARE_DEL_HANDLE{}, fmt.Errorf("NetrShareDelStart: %w", err)
 	}
-	if uint32(resp.Status) != srvsvc.NERR_Success && uint32(resp.Status) != srvsvc.ERROR_MORE_DATA {
-		return resp.ContextHandle, fmt.Errorf("NetrShareDelStart failed: %s", srvsvc.StatusString(uint32(resp.Status)))
+	if status := win32.WIN32_ERROR(resp.Status); status != win32.NERR_Success && status != win32.ERROR_MORE_DATA {
+		return resp.ContextHandle, fmt.Errorf("NetrShareDelStart failed: %s", status)
 	}
 	return resp.ContextHandle, nil
 }

--- a/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/38_NetrShareDelCommit.go
+++ b/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/38_NetrShareDelCommit.go
@@ -10,6 +10,7 @@ import (
 
 	srvsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	mssrvs "github.com/TheManticoreProject/Manticore/windows/protocols/ms-srvs"
 )
 
@@ -40,8 +41,8 @@ func NetrShareDelCommit(rpc ndr.Invoker, contextHandle mssrvs.SHARE_DEL_HANDLE) 
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return mssrvs.SHARE_DEL_HANDLE{}, fmt.Errorf("NetrShareDelCommit: %w", err)
 	}
-	if uint32(resp.Status) != srvsvc.NERR_Success && uint32(resp.Status) != srvsvc.ERROR_MORE_DATA {
-		return resp.ContextHandle, fmt.Errorf("NetrShareDelCommit failed: %s", srvsvc.StatusString(uint32(resp.Status)))
+	if status := win32.WIN32_ERROR(resp.Status); status != win32.NERR_Success && status != win32.ERROR_MORE_DATA {
+		return resp.ContextHandle, fmt.Errorf("NetrShareDelCommit failed: %s", status)
 	}
 	return resp.ContextHandle, nil
 }

--- a/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/39_NetrpGetFileSecurity.go
+++ b/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/39_NetrpGetFileSecurity.go
@@ -10,6 +10,7 @@ import (
 
 	srvsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	mssrvs "github.com/TheManticoreProject/Manticore/windows/protocols/ms-srvs"
 )
 
@@ -45,9 +46,9 @@ func NetrpGetFileSecurity(rpc ndr.Invoker, serverName, shareName, lpFileName str
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return nil, fmt.Errorf("NetrpGetFileSecurity: %w", err)
 	}
-	status := uint32(resp.Status)
-	if status != srvsvc.NERR_Success && status != srvsvc.ERROR_MORE_DATA {
-		return resp.SecurityDescriptor, fmt.Errorf("NetrpGetFileSecurity failed: %s", srvsvc.StatusString(status))
+	status := win32.WIN32_ERROR(resp.Status)
+	if status != win32.NERR_Success && status != win32.ERROR_MORE_DATA {
+		return resp.SecurityDescriptor, fmt.Errorf("NetrpGetFileSecurity failed: %s", status)
 	}
 	return resp.SecurityDescriptor, nil
 }

--- a/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/40_NetrpSetFileSecurity.go
+++ b/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/40_NetrpSetFileSecurity.go
@@ -10,6 +10,7 @@ import (
 
 	srvsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	mssrvs "github.com/TheManticoreProject/Manticore/windows/protocols/ms-srvs"
 )
 
@@ -41,9 +42,9 @@ func NetrpSetFileSecurity(rpc ndr.Invoker, serverName, shareName, lpFileName str
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("NetrpSetFileSecurity: %w", err)
 	}
-	status := uint32(resp.Status)
-	if status != srvsvc.NERR_Success && status != srvsvc.ERROR_MORE_DATA {
-		return fmt.Errorf("NetrpSetFileSecurity failed: %s", srvsvc.StatusString(status))
+	status := win32.WIN32_ERROR(resp.Status)
+	if status != win32.NERR_Success && status != win32.ERROR_MORE_DATA {
+		return fmt.Errorf("NetrpSetFileSecurity failed: %s", status)
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/41_NetrServerTransportAddEx.go
+++ b/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/41_NetrServerTransportAddEx.go
@@ -10,6 +10,7 @@ import (
 
 	srvsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	mssrvs "github.com/TheManticoreProject/Manticore/windows/protocols/ms-srvs"
 )
 
@@ -40,8 +41,8 @@ func NetrServerTransportAddEx(rpc ndr.Invoker, serverName string, level uint32, 
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("NetrServerTransportAddEx: %w", err)
 	}
-	if status := uint32(resp.Status); status != srvsvc.NERR_Success {
-		return fmt.Errorf("NetrServerTransportAddEx failed: %s", srvsvc.StatusString(status))
+	if win32.WIN32_ERROR(resp.Status) != win32.NERR_Success {
+		return fmt.Errorf("NetrServerTransportAddEx failed: %s", win32.WIN32_ERROR(resp.Status).String())
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/43_NetrDfsGetVersion.go
+++ b/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/43_NetrDfsGetVersion.go
@@ -10,6 +10,7 @@ import (
 
 	srvsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 )
 
 // netrDfsGetVersionRequest is the [in] parameter set of NetrDfsGetVersion: the [unique]
@@ -37,9 +38,9 @@ func NetrDfsGetVersion(rpc ndr.Invoker, serverName string) (uint32, error) {
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return 0, fmt.Errorf("NetrDfsGetVersion: %w", err)
 	}
-	status := uint32(resp.Status)
-	if status != srvsvc.NERR_Success && status != srvsvc.ERROR_MORE_DATA {
-		return uint32(resp.Version), fmt.Errorf("NetrDfsGetVersion failed: %s", srvsvc.StatusString(status))
+	status := win32.WIN32_ERROR(resp.Status)
+	if status != win32.NERR_Success && status != win32.ERROR_MORE_DATA {
+		return uint32(resp.Version), fmt.Errorf("NetrDfsGetVersion failed: %s", status)
 	}
 	return uint32(resp.Version), nil
 }

--- a/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/44_NetrDfsCreateLocalPartition.go
+++ b/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/44_NetrDfsCreateLocalPartition.go
@@ -10,6 +10,7 @@ import (
 
 	srvsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	"github.com/TheManticoreProject/Manticore/windows/guid"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mssrvs "github.com/TheManticoreProject/Manticore/windows/protocols/ms-srvs"
@@ -50,9 +51,9 @@ func NetrDfsCreateLocalPartition(rpc ndr.Invoker, serverName, shareName string, 
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("NetrDfsCreateLocalPartition: %w", err)
 	}
-	status := uint32(resp.Status)
-	if status != srvsvc.NERR_Success && status != srvsvc.ERROR_MORE_DATA {
-		return fmt.Errorf("NetrDfsCreateLocalPartition failed: %s", srvsvc.StatusString(status))
+	status := win32.WIN32_ERROR(resp.Status)
+	if status != win32.NERR_Success && status != win32.ERROR_MORE_DATA {
+		return fmt.Errorf("NetrDfsCreateLocalPartition failed: %s", status)
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/45_NetrDfsDeleteLocalPartition.go
+++ b/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/45_NetrDfsDeleteLocalPartition.go
@@ -10,6 +10,7 @@ import (
 
 	srvsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	"github.com/TheManticoreProject/Manticore/windows/guid"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 )
@@ -39,9 +40,9 @@ func NetrDfsDeleteLocalPartition(rpc ndr.Invoker, serverName string, uid guid.GU
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("NetrDfsDeleteLocalPartition: %w", err)
 	}
-	status := uint32(resp.Status)
-	if status != srvsvc.NERR_Success && status != srvsvc.ERROR_MORE_DATA {
-		return fmt.Errorf("NetrDfsDeleteLocalPartition failed: %s", srvsvc.StatusString(status))
+	status := win32.WIN32_ERROR(resp.Status)
+	if status != win32.NERR_Success && status != win32.ERROR_MORE_DATA {
+		return fmt.Errorf("NetrDfsDeleteLocalPartition failed: %s", status)
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/46_NetrDfsSetLocalVolumeState.go
+++ b/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/46_NetrDfsSetLocalVolumeState.go
@@ -10,6 +10,7 @@ import (
 
 	srvsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	"github.com/TheManticoreProject/Manticore/windows/guid"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 )
@@ -41,9 +42,9 @@ func NetrDfsSetLocalVolumeState(rpc ndr.Invoker, serverName string, uid guid.GUI
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("NetrDfsSetLocalVolumeState: %w", err)
 	}
-	status := uint32(resp.Status)
-	if status != srvsvc.NERR_Success && status != srvsvc.ERROR_MORE_DATA {
-		return fmt.Errorf("NetrDfsSetLocalVolumeState failed: %s", srvsvc.StatusString(status))
+	status := win32.WIN32_ERROR(resp.Status)
+	if status != win32.NERR_Success && status != win32.ERROR_MORE_DATA {
+		return fmt.Errorf("NetrDfsSetLocalVolumeState failed: %s", status)
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/48_NetrDfsCreateExitPoint.go
+++ b/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/48_NetrDfsCreateExitPoint.go
@@ -10,6 +10,7 @@ import (
 
 	srvsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	"github.com/TheManticoreProject/Manticore/windows/guid"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 )
@@ -48,9 +49,9 @@ func NetrDfsCreateExitPoint(rpc ndr.Invoker, serverName string, uid guid.GUID, p
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return nil, fmt.Errorf("NetrDfsCreateExitPoint: %w", err)
 	}
-	status := uint32(resp.Status)
-	if status != srvsvc.NERR_Success && status != srvsvc.ERROR_MORE_DATA {
-		return resp.ShortPrefix, fmt.Errorf("NetrDfsCreateExitPoint failed: %s", srvsvc.StatusString(status))
+	status := win32.WIN32_ERROR(resp.Status)
+	if status != win32.NERR_Success && status != win32.ERROR_MORE_DATA {
+		return resp.ShortPrefix, fmt.Errorf("NetrDfsCreateExitPoint failed: %s", status)
 	}
 	return resp.ShortPrefix, nil
 }

--- a/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/49_NetrDfsDeleteExitPoint.go
+++ b/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/49_NetrDfsDeleteExitPoint.go
@@ -10,6 +10,7 @@ import (
 
 	srvsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	"github.com/TheManticoreProject/Manticore/windows/guid"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 )
@@ -39,9 +40,9 @@ func NetrDfsDeleteExitPoint(rpc ndr.Invoker, serverName string, uid guid.GUID, p
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("NetrDfsDeleteExitPoint: %w", err)
 	}
-	status := uint32(resp.Status)
-	if status != srvsvc.NERR_Success && status != srvsvc.ERROR_MORE_DATA {
-		return fmt.Errorf("NetrDfsDeleteExitPoint failed: %s", srvsvc.StatusString(status))
+	status := win32.WIN32_ERROR(resp.Status)
+	if status != win32.NERR_Success && status != win32.ERROR_MORE_DATA {
+		return fmt.Errorf("NetrDfsDeleteExitPoint failed: %s", status)
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/50_NetrDfsModifyPrefix.go
+++ b/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/50_NetrDfsModifyPrefix.go
@@ -10,6 +10,7 @@ import (
 
 	srvsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	"github.com/TheManticoreProject/Manticore/windows/guid"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 )
@@ -37,9 +38,9 @@ func NetrDfsModifyPrefix(rpc ndr.Invoker, serverName string, uid guid.GUID, pref
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("NetrDfsModifyPrefix: %w", err)
 	}
-	status := uint32(resp.Status)
-	if status != srvsvc.NERR_Success && status != srvsvc.ERROR_MORE_DATA {
-		return fmt.Errorf("NetrDfsModifyPrefix failed: %s", srvsvc.StatusString(status))
+	status := win32.WIN32_ERROR(resp.Status)
+	if status != win32.NERR_Success && status != win32.ERROR_MORE_DATA {
+		return fmt.Errorf("NetrDfsModifyPrefix failed: %s", status)
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/51_NetrDfsFixLocalVolume.go
+++ b/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/51_NetrDfsFixLocalVolume.go
@@ -10,6 +10,7 @@ import (
 
 	srvsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	"github.com/TheManticoreProject/Manticore/windows/guid"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mssrvs "github.com/TheManticoreProject/Manticore/windows/protocols/ms-srvs"
@@ -52,9 +53,9 @@ func NetrDfsFixLocalVolume(rpc ndr.Invoker, serverName, volumeName string, entry
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("NetrDfsFixLocalVolume: %w", err)
 	}
-	status := uint32(resp.Status)
-	if status != srvsvc.NERR_Success && status != srvsvc.ERROR_MORE_DATA {
-		return fmt.Errorf("NetrDfsFixLocalVolume failed: %s", srvsvc.StatusString(status))
+	status := win32.WIN32_ERROR(resp.Status)
+	if status != win32.NERR_Success && status != win32.ERROR_MORE_DATA {
+		return fmt.Errorf("NetrDfsFixLocalVolume failed: %s", status)
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/52_NetrDfsManagerReportSiteInfo.go
+++ b/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/52_NetrDfsManagerReportSiteInfo.go
@@ -10,6 +10,7 @@ import (
 
 	srvsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	mssrvs "github.com/TheManticoreProject/Manticore/windows/protocols/ms-srvs"
 )
 
@@ -44,9 +45,9 @@ func NetrDfsManagerReportSiteInfo(rpc ndr.Invoker, serverName string, ppSiteInfo
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return nil, fmt.Errorf("NetrDfsManagerReportSiteInfo: %w", err)
 	}
-	status := uint32(resp.Status)
-	if status != srvsvc.NERR_Success && status != srvsvc.ERROR_MORE_DATA {
-		return resp.PpSiteInfo, fmt.Errorf("NetrDfsManagerReportSiteInfo failed: %s", srvsvc.StatusString(status))
+	status := win32.WIN32_ERROR(resp.Status)
+	if status != win32.NERR_Success && status != win32.ERROR_MORE_DATA {
+		return resp.PpSiteInfo, fmt.Errorf("NetrDfsManagerReportSiteInfo failed: %s", status)
 	}
 	return resp.PpSiteInfo, nil
 }

--- a/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/53_NetrServerTransportDelEx.go
+++ b/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/53_NetrServerTransportDelEx.go
@@ -10,6 +10,7 @@ import (
 
 	srvsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	mssrvs "github.com/TheManticoreProject/Manticore/windows/protocols/ms-srvs"
 )
 
@@ -40,8 +41,8 @@ func NetrServerTransportDelEx(rpc ndr.Invoker, serverName string, level uint32, 
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("NetrServerTransportDelEx: %w", err)
 	}
-	if status := uint32(resp.Status); status != srvsvc.NERR_Success {
-		return fmt.Errorf("NetrServerTransportDelEx failed: %s", srvsvc.StatusString(status))
+	if win32.WIN32_ERROR(resp.Status) != win32.NERR_Success {
+		return fmt.Errorf("NetrServerTransportDelEx failed: %s", win32.WIN32_ERROR(resp.Status).String())
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/54_NetrServerAliasAdd.go
+++ b/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/54_NetrServerAliasAdd.go
@@ -10,6 +10,7 @@ import (
 
 	srvsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	mssrvs "github.com/TheManticoreProject/Manticore/windows/protocols/ms-srvs"
 )
 
@@ -37,8 +38,8 @@ func NetrServerAliasAdd(rpc ndr.Invoker, serverName string, level uint32, info m
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("NetrServerAliasAdd: %w", err)
 	}
-	if status := uint32(resp.Status); status != srvsvc.NERR_Success {
-		return fmt.Errorf("NetrServerAliasAdd failed: %s", srvsvc.StatusString(status))
+	if win32.WIN32_ERROR(resp.Status) != win32.NERR_Success {
+		return fmt.Errorf("NetrServerAliasAdd failed: %s", win32.WIN32_ERROR(resp.Status).String())
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/55_NetrServerAliasEnum.go
+++ b/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/55_NetrServerAliasEnum.go
@@ -10,6 +10,7 @@ import (
 
 	srvsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	mssrvs "github.com/TheManticoreProject/Manticore/windows/protocols/ms-srvs"
 )
 
@@ -56,9 +57,9 @@ func NetrServerAliasEnum(rpc ndr.Invoker, serverName string, info mssrvs.SERVER_
 	if resp.ResumeHandle != nil {
 		outResume = uint32(*resp.ResumeHandle)
 	}
-	status := uint32(resp.Status)
-	if status != srvsvc.NERR_Success && status != srvsvc.ERROR_MORE_DATA {
-		return resp.InfoStruct, uint32(resp.TotalEntries), outResume, fmt.Errorf("NetrServerAliasEnum failed: %s", srvsvc.StatusString(status))
+	status := win32.WIN32_ERROR(resp.Status)
+	if status != win32.NERR_Success && status != win32.ERROR_MORE_DATA {
+		return resp.InfoStruct, uint32(resp.TotalEntries), outResume, fmt.Errorf("NetrServerAliasEnum failed: %s", status)
 	}
 	return resp.InfoStruct, uint32(resp.TotalEntries), outResume, nil
 }

--- a/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/56_NetrServerAliasDel.go
+++ b/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/56_NetrServerAliasDel.go
@@ -10,6 +10,7 @@ import (
 
 	srvsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	mssrvs "github.com/TheManticoreProject/Manticore/windows/protocols/ms-srvs"
 )
 
@@ -37,8 +38,8 @@ func NetrServerAliasDel(rpc ndr.Invoker, serverName string, level uint32, info m
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("NetrServerAliasDel: %w", err)
 	}
-	if status := uint32(resp.Status); status != srvsvc.NERR_Success {
-		return fmt.Errorf("NetrServerAliasDel failed: %s", srvsvc.StatusString(status))
+	if win32.WIN32_ERROR(resp.Status) != win32.NERR_Success {
+		return fmt.Errorf("NetrServerAliasDel failed: %s", win32.WIN32_ERROR(resp.Status).String())
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/57_NetrShareDelEx.go
+++ b/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/57_NetrShareDelEx.go
@@ -10,6 +10,7 @@ import (
 
 	srvsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	mssrvs "github.com/TheManticoreProject/Manticore/windows/protocols/ms-srvs"
 )
 
@@ -40,8 +41,8 @@ func NetrShareDelEx(rpc ndr.Invoker, serverName string, level ndr.DWORD, shareIn
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("NetrShareDelEx: %w", err)
 	}
-	if uint32(resp.Status) != srvsvc.NERR_Success && uint32(resp.Status) != srvsvc.ERROR_MORE_DATA {
-		return fmt.Errorf("NetrShareDelEx failed: %s", srvsvc.StatusString(uint32(resp.Status)))
+	if status := win32.WIN32_ERROR(resp.Status); status != win32.NERR_Success && status != win32.ERROR_MORE_DATA {
+		return fmt.Errorf("NetrShareDelEx failed: %s", status)
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/interface.go
+++ b/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/interface.go
@@ -7,10 +7,11 @@
 // after the interface UUID (with the version in the nested 3.0/ directory).
 //
 // This package holds only the interface-level descriptor: the abstract syntax
-// identifier, the transport endpoint (PipeName), the opnum constants and opnum<->name
-// maps, and the NET_API_STATUS return codes. The NDR types live in the protocol
-// structures package windows/protocols/ms-srvs (package mssrvs) and the method stubs in
-// functions; both depend on this package, never the reverse.
+// identifier, the transport endpoint (PipeName), and the opnum constants and
+// opnum<->name maps. The NET_API_STATUS values the methods return are Win32 error
+// codes decoded through windows/errors/win32, not redeclared here. The NDR types live
+// in the protocol structures package windows/protocols/ms-srvs (package mssrvs) and the
+// method stubs in functions; both depend on this package, never the reverse.
 //
 // References:
 //   - [MS-SRVS] Server Service Remote Protocol:
@@ -23,8 +24,6 @@ package rpcinterface_4b324fc8167001d312785a47bf6ee188_3_0
 // A fetched copy is kept at ms-srvs.idl in the interface directory.
 
 import (
-	"fmt"
-
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
 	"github.com/TheManticoreProject/Manticore/windows/guid"
 )
@@ -84,25 +83,19 @@ const (
 	OpnumNetrShareDelEx               uint16 = 57
 )
 
-// NET_API_STATUS return codes ([MS-ERREF] 2.2 Win32 error codes / lmerr.h). srvsvc
-// methods return a NET_API_STATUS (a 32-bit Win32 error) rather than an NTSTATUS.
-const (
-	NERR_Success            uint32 = 0
-	ERROR_FILE_NOT_FOUND    uint32 = 2
-	ERROR_ACCESS_DENIED     uint32 = 5
-	ERROR_NOT_SUPPORTED     uint32 = 50
-	ERROR_INVALID_PARAMETER uint32 = 87
-	ERROR_INVALID_NAME      uint32 = 123
-	ERROR_INVALID_LEVEL     uint32 = 124
-	ERROR_MORE_DATA         uint32 = 234
-	NERR_BASE               uint32 = 2100
-	NERR_BufTooSmall        uint32 = 2123
-	NERR_NetNameNotFound    uint32 = 2310
-	NERR_DeviceNotShared    uint32 = 2311
-	NERR_ClientNameNotFound uint32 = 2312
-	NERR_UserNotFound       uint32 = 2221
-	NERR_DuplicateShare     uint32 = 2118
-)
+// The NET_API_STATUS codes srvsvc methods return are not declared here. A
+// NET_API_STATUS is a 32-bit Win32 error rather than an NTSTATUS, and the whole of
+// [MS-ERREF] 2.2 lives in
+// [github.com/TheManticoreProject/Manticore/windows/errors/win32] as the
+// win32.WIN32_ERROR type: a subset repeated here would cover a fraction of that
+// 2703-code table, would render everything outside itself as an undecoded number, and
+// would drift from the specification as the table is regenerated. Compare a returned
+// status against win32.NERR_Success, win32.ERROR_MORE_DATA and the rest, and render it
+// with win32.WIN32_ERROR.String.
+//
+// NERR_BASE is the exception: it is the base of the lmerr.h network-error range rather
+// than a code, so [MS-ERREF] 2.2 has no row for it and it stays here.
+const NERR_BASE uint32 = 2100
 
 // SyntaxID returns the srvsvc abstract syntax identifier:
 // 4b324fc8-1670-01d3-1278-5a47bf6ee188, version 3.0.
@@ -111,43 +104,6 @@ func SyntaxID() syntax.SyntaxID {
 		UUID:         guid.GUID{A: 0x4b324fc8, B: 0x1670, C: 0x01d3, D: 0x1278, E: 0x5a47bf6ee188},
 		MajorVersion: 3,
 		MinorVersion: 0,
-	}
-}
-
-// StatusString returns a mnemonic for the documented NET_API_STATUS codes, otherwise the
-// decimal value (Win32 error codes are conventionally decimal).
-func StatusString(status uint32) string {
-	switch status {
-	case NERR_Success:
-		return "NERR_Success"
-	case ERROR_FILE_NOT_FOUND:
-		return "ERROR_FILE_NOT_FOUND"
-	case ERROR_ACCESS_DENIED:
-		return "ERROR_ACCESS_DENIED"
-	case ERROR_NOT_SUPPORTED:
-		return "ERROR_NOT_SUPPORTED"
-	case ERROR_INVALID_PARAMETER:
-		return "ERROR_INVALID_PARAMETER"
-	case ERROR_INVALID_NAME:
-		return "ERROR_INVALID_NAME"
-	case ERROR_INVALID_LEVEL:
-		return "ERROR_INVALID_LEVEL"
-	case ERROR_MORE_DATA:
-		return "ERROR_MORE_DATA"
-	case NERR_BufTooSmall:
-		return "NERR_BufTooSmall"
-	case NERR_NetNameNotFound:
-		return "NERR_NetNameNotFound"
-	case NERR_DeviceNotShared:
-		return "NERR_DeviceNotShared"
-	case NERR_ClientNameNotFound:
-		return "NERR_ClientNameNotFound"
-	case NERR_UserNotFound:
-		return "NERR_UserNotFound"
-	case NERR_DuplicateShare:
-		return "NERR_DuplicateShare"
-	default:
-		return fmt.Sprintf("%d", status)
 	}
 }
 

--- a/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/interface_test.go
+++ b/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/interface_test.go
@@ -1,16 +1,74 @@
 package rpcinterface_4b324fc8167001d312785a47bf6ee188_3_0
 
-import "testing"
+import (
+	"testing"
 
-func TestStatusString(t *testing.T) {
-	if got := StatusString(ERROR_MORE_DATA); got != "ERROR_MORE_DATA" {
-		t.Errorf("StatusString(234) = %q", got)
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
+)
+
+// TestDocumentedStatusCodesResolveThroughWin32 pins the NET_API_STATUS codes [MS-SRVS]
+// documents to the shared [MS-ERREF] 2.2 table: each resolves under the symbolic name
+// the specification gives it, and each renders under a name rather than a number.
+func TestDocumentedStatusCodesResolveThroughWin32(t *testing.T) {
+	documented := map[string]win32.WIN32_ERROR{
+		"NERR_Success":            0,
+		"ERROR_SUCCESS":           0,
+		"ERROR_FILE_NOT_FOUND":    2,
+		"ERROR_ACCESS_DENIED":     5,
+		"ERROR_NOT_SUPPORTED":     50,
+		"ERROR_INVALID_PARAMETER": 87,
+		"ERROR_INVALID_NAME":      123,
+		"ERROR_INVALID_LEVEL":     124,
+		"ERROR_MORE_DATA":         234,
+		"NERR_BufTooSmall":        2123,
+		"NERR_DuplicateShare":     2118,
+		"NERR_UserNotFound":       2221,
+		"NERR_NetNameNotFound":    2310,
+		"NERR_DeviceNotShared":    2311,
+		"NERR_ClientNameNotFound": 2312,
 	}
-	if got := StatusString(NERR_Success); got != "NERR_Success" {
-		t.Errorf("StatusString(0) = %q", got)
+	for name, code := range documented {
+		got, defined := win32.FromName(name)
+		if !defined {
+			t.Errorf("win32.FromName(%q) is undefined", name)
+			continue
+		}
+		if got != code {
+			t.Errorf("win32.FromName(%q) = %d, want %d", name, got, code)
+		}
+		if rendered := code.String(); rendered == "" || rendered[0] == '0' {
+			t.Errorf("win32.WIN32_ERROR(%d).String() = %q, want a symbolic name", code, rendered)
+		}
 	}
-	if got := StatusString(0x12345678); got != "305419896" {
-		t.Errorf("StatusString(unknown) = %q, want decimal", got)
+}
+
+// TestStatusCodeOutsideOldSubsetRendersByName covers what the interface's private
+// subset could not: a Win32 error srvsvc can return that the subset never listed now
+// decodes to its name instead of an undecoded number, while a value [MS-ERREF] 2.2
+// leaves undefined still renders as hexadecimal.
+func TestStatusCodeOutsideOldSubsetRendersByName(t *testing.T) {
+	// ERROR_NETNAME_DELETED (64) and NERR_ServerNotStarted (2114) were outside the
+	// interface's old subset and used to print as "64" and "2114".
+	if got := win32.WIN32_ERROR(64).String(); got != "ERROR_NETNAME_DELETED" {
+		t.Errorf("win32.WIN32_ERROR(64).String() = %q, want ERROR_NETNAME_DELETED", got)
+	}
+	if got := win32.WIN32_ERROR(2114).String(); got != "NERR_ServerNotStarted" {
+		t.Errorf("win32.WIN32_ERROR(2114).String() = %q, want NERR_ServerNotStarted", got)
+	}
+	if got := win32.WIN32_ERROR(0x12345678).String(); got != "0x12345678" {
+		t.Errorf("win32.WIN32_ERROR(0x12345678).String() = %q, want hexadecimal", got)
+	}
+}
+
+// TestNerrBaseStaysLocal guards the one constant that could not migrate: NERR_BASE is
+// the base of the lmerr.h network-error range, not a code, so [MS-ERREF] 2.2 has no row
+// for it.
+func TestNerrBaseStaysLocal(t *testing.T) {
+	if NERR_BASE != 2100 {
+		t.Errorf("NERR_BASE = %d, want 2100", NERR_BASE)
+	}
+	if _, defined := win32.Lookup(win32.WIN32_ERROR(NERR_BASE)); defined {
+		t.Error("win32 defines a code for NERR_BASE; it no longer needs a local declaration")
 	}
 }
 

--- a/network/dcerpc/ms-protocols/ms-srvs/client_dialer_test.go
+++ b/network/dcerpc/ms-protocols/ms-srvs/client_dialer_test.go
@@ -6,6 +6,7 @@ import (
 	srvsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 	dcerpctransport "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/transport"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	srvstypes "github.com/TheManticoreProject/Manticore/windows/protocols/ms-srvs"
 )
 
@@ -43,7 +44,7 @@ func TestNewUsesDialerToBindSrvsvc(t *testing.T) {
 			},
 		},
 		TotalEntries: 1,
-		Status:       ndr.DWORD(srvsvc.NERR_Success),
+		Status:       ndr.DWORD(win32.NERR_Success),
 	}
 	ft.queue(responsePDU(t, 2, stub(t, resp)))
 

--- a/network/dcerpc/ms-protocols/ms-srvs/server_info_test.go
+++ b/network/dcerpc/ms-protocols/ms-srvs/server_info_test.go
@@ -6,6 +6,7 @@ import (
 	srvsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/pdu"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	srvstypes "github.com/TheManticoreProject/Manticore/windows/protocols/ms-srvs"
 )
 
@@ -30,7 +31,7 @@ func TestGetServerInfo(t *testing.T) {
 				Sv101Comment:      "main file server",
 			},
 		},
-		Status: ndr.DWORD(srvsvc.NERR_Success),
+		Status: ndr.DWORD(win32.NERR_Success),
 	}
 	ft.queue(responsePDU(t, 2, stub(t, resp)))
 
@@ -61,7 +62,7 @@ func TestGetServerInfo_MissingArm(t *testing.T) {
 	// Success status but a nil level-101 arm must be reported, not nil-dereferenced.
 	resp := &serverGetInfoResp{
 		InfoStruct: srvstypes.SERVER_INFO{Tag: 101},
-		Status:     ndr.DWORD(srvsvc.NERR_Success),
+		Status:     ndr.DWORD(win32.NERR_Success),
 	}
 	ft.queue(responsePDU(t, 2, stub(t, resp)))
 	if _, err := getServerInfo(c); err == nil {

--- a/network/dcerpc/ms-protocols/ms-srvs/sessions_test.go
+++ b/network/dcerpc/ms-protocols/ms-srvs/sessions_test.go
@@ -6,6 +6,7 @@ import (
 	srvsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/pdu"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	srvstypes "github.com/TheManticoreProject/Manticore/windows/protocols/ms-srvs"
 )
 
@@ -34,7 +35,7 @@ func TestListSessions(t *testing.T) {
 			},
 		},
 		TotalEntries: 1,
-		Status:       ndr.DWORD(srvsvc.NERR_Success),
+		Status:       ndr.DWORD(win32.NERR_Success),
 	}
 	ft.queue(responsePDU(t, 2, stub(t, resp)))
 

--- a/network/dcerpc/ms-protocols/ms-srvs/shares_test.go
+++ b/network/dcerpc/ms-protocols/ms-srvs/shares_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
 	dcerpcclient "github.com/TheManticoreProject/Manticore/network/dcerpc/v5/client"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/pdu"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	srvstypes "github.com/TheManticoreProject/Manticore/windows/protocols/ms-srvs"
 )
 
@@ -109,7 +110,7 @@ func TestListShares(t *testing.T) {
 			},
 		},
 		TotalEntries: 2,
-		Status:       ndr.DWORD(srvsvc.NERR_Success),
+		Status:       ndr.DWORD(win32.NERR_Success),
 	}
 	ft.queue(responsePDU(t, 2, stub(t, resp)))
 
@@ -142,7 +143,7 @@ func TestListShares_AccessDenied(t *testing.T) {
 	c := boundClient(t, ft)
 	resp := &shareEnumResp{
 		InfoStruct: srvstypes.SHARE_ENUM_STRUCT{Level: 1, ShareInfo: srvstypes.SHARE_ENUM_UNION{Tag: 1}},
-		Status:     ndr.DWORD(srvsvc.ERROR_ACCESS_DENIED),
+		Status:     ndr.DWORD(win32.ERROR_ACCESS_DENIED),
 	}
 	ft.queue(responsePDU(t, 2, stub(t, resp)))
 	if _, err := listShares(c); err == nil {

--- a/network/smb/smb_v10/server/rpcpipe/srvsvc.go
+++ b/network/smb/smb_v10/server/rpcpipe/srvsvc.go
@@ -6,6 +6,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/v5/rpcserver"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	mssrvs "github.com/TheManticoreProject/Manticore/windows/protocols/ms-srvs"
 )
 
@@ -83,7 +84,7 @@ func (s *srvsvcService) netrShareEnum(stub []byte) ([]byte, error) {
 				ShareInfo: mssrvs.SHARE_ENUM_UNION{Tag: ndr.DWORD(level)},
 			},
 			ResumeHandle: echoResumeHandle(request.ResumeHandle, 0),
-			Status:       ndr.DWORD(srvsvc.ERROR_INVALID_LEVEL),
+			Status:       ndr.DWORD(win32.ERROR_INVALID_LEVEL),
 		})
 	}
 
@@ -111,7 +112,7 @@ func (s *srvsvcService) netrShareEnum(stub []byte) ([]byte, error) {
 	response := &netrShareEnumResponse{
 		InfoStruct:   shareEnumStruct(level, sent),
 		TotalEntries: ndr.DWORD(len(remaining)),
-		Status:       ndr.DWORD(srvsvc.NERR_Success),
+		Status:       ndr.DWORD(win32.NERR_Success),
 	}
 	if truncated {
 		// ERROR_MORE_DATA with a resume handle is how the enumeration continues.
@@ -119,7 +120,7 @@ func (s *srvsvcService) netrShareEnum(stub []byte) ([]byte, error) {
 		// between two calls shifts what a resumed enumeration sees; SMB offers no
 		// way to hold an enumeration open across calls, so an index is the whole
 		// of what a resume handle can be.
-		response.Status = ndr.DWORD(srvsvc.ERROR_MORE_DATA)
+		response.Status = ndr.DWORD(win32.ERROR_MORE_DATA)
 		response.ResumeHandle = echoResumeHandle(request.ResumeHandle, uint32(from+len(sent)))
 	} else {
 		response.ResumeHandle = echoResumeHandle(request.ResumeHandle, 0)


### PR DESCRIPTION
### Linked Issue

Refs #1219

### Root Cause

The srvsvc interface package declared fifteen NET_API_STATUS constants and a
`StatusString` that switched on fourteen of them. Fourteen of the fifteen values are
rows of [MS-ERREF] 2.2, which `windows/errors/win32` has held in full since #1208, so
the block duplicated data that already exists in generated form and gave a value a
second place to be mistyped.

The subset was also a ceiling. `StatusString`'s default arm printed the bare decimal,
so any of the other 2689 codes in the table came back as an undecoded number:
`NetrShareEnum failed: 2114` rather than `NERR_ServerNotStarted`. The codes the subset
covered were the ones the methods were expected to return, which is the set that needs
the least help; the codes worth decoding are the unanticipated ones, and those were
exactly the ones it could not name.

Nine of the fifteen constants were written as plain decimals (`ERROR_MORE_DATA uint32 =
234`), which hid the values behind identifiers and made the duplication hard to audit
against the specification.

### Fix Description

The constant block and `StatusString` are removed from `interface.go` and replaced by a
comment stating why the codes are not declared there. Call sites compare against
`win32.WIN32_ERROR` and render through its `String`, which names any of the 2703 codes
and falls back to hexadecimal only for a value the specification leaves undefined.

The mapping was derived from the numeric values, not the names: each constant's value
was converted to hexadecimal and looked up in `windows/errors/errgen/ms-erref-2.2-win32.tsv`.

| value | hex | resolved name |
| --- | --- | --- |
| 0 | `00000000` | `ERROR_SUCCESS` / `NERR_Success` |
| 2 | `00000002` | `ERROR_FILE_NOT_FOUND` |
| 5 | `00000005` | `ERROR_ACCESS_DENIED` |
| 50 | `00000032` | `ERROR_NOT_SUPPORTED` |
| 87 | `00000057` | `ERROR_INVALID_PARAMETER` |
| 123 | `0000007B` | `ERROR_INVALID_NAME` |
| 124 | `0000007C` | `ERROR_INVALID_LEVEL` |
| 234 | `000000EA` | `ERROR_MORE_DATA` |
| 2118 | `00000846` | `NERR_DuplicateShare` |
| 2123 | `0000084B` | `NERR_BufTooSmall` |
| 2221 | `000008AD` | `NERR_UserNotFound` |
| 2310 | `00000906` | `NERR_NetNameNotFound` |
| 2311 | `00000907` | `NERR_DeviceNotShared` |
| 2312 | `00000908` | `NERR_ClientNameNotFound` |
| 2100 | `00000834` | no row — kept locally |

All fourteen resolved to the identifier the block already used. Zero carries two names
in the specification; srvsvc documents its returns as NET_API_STATUS, so the call sites
keep `win32.NERR_Success`, which the shared package defines as the same value.

`NERR_BASE` (2100) stays in `interface.go`. It is the base of the lmerr.h network-error
range rather than an error code, [MS-ERREF] 2.2 has no row for `0x00000834`, and it was
never in the `StatusString` switch. It keeps a comment saying why, and a test asserts
the shared table still defines nothing for it.

The rewrite was done a comparison term at a time. Thirty-six of the checks read
`status != NERR_Success && status != ERROR_MORE_DATA`, because a paged enumeration
reports `ERROR_MORE_DATA` to say another page remains — `NetrFileEnum`,
`NetrSessionEnum`, `NetrShareEnum`, `NetrConnectionEnum`, `NetrServerAliasEnum`,
`NetrServerTransportEnum`, `NetrServerDiskEnum` and `NetrShareEnumSticky` all treat it
as success. Rewriting such a condition as a unit invites dropping the second term,
which compiles and passes the round-trip tests while turning every multi-page
enumeration into a failure. Conditions with two terms hoist the conversion into the
`if` initialiser and interpolate that value; conditions with one term compare inline.

No alias constants and no delegating wrapper were introduced, so the four `ms-srvs`
tests and the SMB1 `rpcpipe` srvsvc service that referenced the private names now name
the shared constants directly.

### How Verified

- `go build ./...` — clean.
- `go vet ./...` — clean.
- `go test -count=1 ./...` — 311 packages `ok`, 81 with no test files, 0 failures.
- Cross-compile with `CGO_ENABLED=0`: `windows/amd64`, `windows/386`, `linux/arm64`,
  `linux/386` all build.
- Term-count audit over the diff: 45 `NERR_Success` comparisons and 36
  `ERROR_MORE_DATA` comparisons on the removed side, 45 and 36 on the added side, so no
  paged-enumeration condition lost its `ERROR_MORE_DATA` term.
- `grep` confirms no migrated constant and no `StatusString` remain in `interface.go`,
  and no `srvsvc.ERROR_*` / `srvsvc.NERR_*` / `srvsvc.StatusString` reference remains
  anywhere in the tree.
- `gofmt -l` reports no drift on any touched file; the import-order churn from adding
  the win32 import was formatted, and files not touched here were left alone.

### Test Coverage

`TestStatusString` is replaced by three tests in `interface_test.go`:

- `TestDocumentedStatusCodesResolveThroughWin32` pins each of the fifteen documented
  names to its value through `win32.FromName` and asserts each renders under a symbolic
  name rather than a number.
- `TestStatusCodeOutsideOldSubsetRendersByName` covers the ceiling the subset imposed:
  `ERROR_NETNAME_DELETED` (64) and `NERR_ServerNotStarted` (2114) used to print as `64`
  and `2114` and now render by name, while `0x12345678` renders as hexadecimal.
- `TestNerrBaseStaysLocal` pins `NERR_BASE` at 2100 and asserts the shared table defines
  no entry for it, so the local declaration can be dropped if that changes.

The existing `ms-srvs` and `rpcpipe` tests exercise the rewritten paths, including
`rpcpipe`'s truncated `NetrShareEnum` answering `ERROR_MORE_DATA` with a resume handle
and its `ERROR_INVALID_LEVEL` refusal, and both suites pass unchanged in behaviour.

### Scope of Change

52 files:

- `network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/interface.go` —
  constant block and `StatusString` removed, `NERR_BASE` kept, package doc updated,
  `fmt` import dropped.
- `network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/interface_test.go`
  — `TestStatusString` replaced by the three tests above.
- 45 files under
  `network/dcerpc/interfaces/4b324fc8-1670-01d3-1278-5a47bf6ee188/3.0/functions/` —
  status comparisons and error rendering repointed at `win32`.
- `network/dcerpc/ms-protocols/ms-srvs/{client_dialer,server_info,sessions,shares}_test.go`
  — the private names they set on fixture responses replaced by the shared ones.
- `network/smb/smb_v10/server/rpcpipe/srvsvc.go` — the three status values it writes
  replaced by the shared ones.

Submodule pointer updated: no — the repository has no submodules.

Behavioral changes outside the bug fix: an srvsvc status outside the old fourteen-code
subset now renders under its [MS-ERREF] name instead of a decimal, and an undefined
value renders as hexadecimal instead of decimal. Error message text is the only thing
that changes; no comparison, no return value and nothing on the wire is affected.

### Risk and Rollout

The change is confined to how a status is compared and rendered. The values themselves
are unchanged — each was checked against the specification's table by value — and the
term-count audit shows every condition kept the terms it had, so the paged enumerations
still accept `ERROR_MORE_DATA`. `win32.WIN32_ERROR` is a `uint32` with a `String`
method, so `%s` formatting and `ndr.DWORD` conversion behave as before. Reverting the
commit restores the previous subset with no data migration.

### Notes

This is one of the 74 interfaces #1219 covers, so the commit uses `Refs #1219` rather
than a closing keyword.

`NERR_BASE` is the only constant that could not migrate, and the reason is that it is
not a code. If [MS-ERREF] ever lists it, `TestNerrBaseStaysLocal` fails and the local
declaration goes.

`win32.WIN32_ERROR(0).String()` answers `ERROR_SUCCESS`, since that is the first name
the specification lists for zero and the generated table holds it as canonical. The
call sites compare against `win32.NERR_Success` to match how srvsvc documents its
returns, and the two are the same value, so this only affects the text of a message
that is never produced — a zero status is the success path and is not rendered.
