### PR TITLE
Compute and emit the SPNEGO mechListMIC (Fixes #1201)

### DIFF
--- a/crypto/spnego/authcontext.go
+++ b/crypto/spnego/authcontext.go
@@ -2,6 +2,7 @@ package spnego
 
 import (
 	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/message/challenge"
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/message/negotiate/flags"
 	"github.com/TheManticoreProject/Manticore/encoding/utf16"
 )
 
@@ -33,6 +34,17 @@ type AuthContext struct {
 	// NegotiateMessageBytes retains the raw NTLM NEGOTIATE_MESSAGE that was sent,
 	// so the AUTHENTICATE MIC can be computed over NEGOTIATE||CHALLENGE||AUTHENTICATE.
 	NegotiateMessageBytes []byte
+
+	// MechListDER retains the DER-encoded MechTypeList advertised in the
+	// NegTokenInit. The SPNEGO mechListMIC is computed over exactly these bytes
+	// (RFC 4178 section 5), so they must be the ones that went on the wire rather
+	// than a re-encoding of the same list.
+	MechListDER []byte
+
+	// authenticateFlags are the flags carried by the AUTHENTICATE message, which
+	// key the per-message security context a mechListMIC is taken under. They are
+	// the negotiated flags, not those the client asked for.
+	authenticateFlags flags.NegotiateFlags
 
 	// SessionKey is the session key derived during the most recent successful
 	// CreateAuthenticateTokenFromChallengeToken call. It is not transmitted on the

--- a/crypto/spnego/challenge.go
+++ b/crypto/spnego/challenge.go
@@ -95,8 +95,10 @@ func (ctx *AuthContext) processChallengeInnerTokenNTLM(innerToken []byte) ([]byt
 		return nil, fmt.Errorf("failed to create NTLM AUTHENTICATE message: %v", err)
 	}
 
-	// Retain the derived session key so callers can use it as the SMB signing MAC key.
+	// Retain the derived session key so callers can use it as the SMB signing MAC key,
+	// and the flags it was negotiated under, which key the mechListMIC below.
 	ctx.SessionKey = ntlmAuth.SessionKey
+	ctx.authenticateFlags = ntlmAuth.NegotiateFlags
 
 	// When the server's CHALLENGE carried an MsvAvTimestamp, CreateAuthenticateMessage
 	// sets the MsvAvFlags MIC-present bit in the NtChallengeResponse, so the
@@ -120,6 +122,19 @@ func (ctx *AuthContext) processChallengeInnerTokenNTLM(innerToken []byte) ([]byt
 	// — no negState and no supportedMech — matching the Windows client.
 	negTokenResp := NegTokenResp{SuppressNegState: true}
 	negTokenResp.SetMechToken(ntlmAuthBytes)
+
+	// Protect the negotiation itself. The mechListMIC is a GSS_GetMIC over the
+	// DER-encoded MechTypeList this client advertised, keyed on the session the
+	// AUTHENTICATE just established (RFC 4178 section 5), so a peer that altered
+	// the offered mech list cannot go undetected. A server that requires it
+	// answers accept-incomplete and holds the context open until it arrives.
+	mic, err := ctx.computeMechListMIC(ctx.authenticateFlags)
+	if err != nil {
+		return nil, err
+	}
+	if len(mic) > 0 {
+		negTokenResp.MechListMIC = mic
+	}
 
 	marshalledNegTokenResp, err := negTokenResp.Marshal()
 	if err != nil {

--- a/crypto/spnego/mechlistmic.go
+++ b/crypto/spnego/mechlistmic.go
@@ -1,0 +1,92 @@
+package spnego
+
+import (
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/message/negotiate/flags"
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/security"
+)
+
+// computeMechListMIC returns the SPNEGO mechListMIC for the negotiation this
+// context is completing: GSS_GetMIC over the DER-encoded MechTypeList that was
+// advertised in the NegTokenInit (RFC 4178 section 5), taken under the security
+// context the mechanism just established.
+//
+// For NTLM the MIC is an NTLMSSP_MESSAGE_SIGNATURE ([MS-NLMP] 3.4.4) produced with
+// the client signing key and sequence number 0 — it is the first message protected
+// on the session. When key exchange is negotiated the checksum is additionally
+// encrypted with the client sealing handle, which the security context handles.
+//
+// It returns nil, and no error, when there is nothing to compute a MIC under: no
+// session key was derived, or the mech list was never recorded. Emitting no MIC is
+// what the exchange did before, and is valid whenever the peer does not require one.
+func (ctx *AuthContext) computeMechListMIC(negFlg flags.NegotiateFlags) ([]byte, error) {
+	if len(ctx.SessionKey) == 0 || len(ctx.MechListDER) == 0 {
+		return nil, nil
+	}
+
+	sec, err := security.NewContext(ctx.SessionKey, negFlg)
+	if err != nil {
+		return nil, fmt.Errorf("spnego: cannot key the mechListMIC: %w", err)
+	}
+
+	sig := sec.Sign(ctx.MechListDER)
+	return sig[:], nil
+}
+
+// VerifyServerMechListMIC checks the mechListMIC a server returned in its final
+// NegTokenResp against the mech list this client advertised.
+//
+// The server's MIC is taken with the server signing key over the same DER-encoded
+// MechTypeList, at sequence number 0. A token carrying no mechListMIC verifies
+// trivially: RFC 4178 leaves the field optional, and a server that does not require
+// negotiation protection omits it.
+func (ctx *AuthContext) VerifyServerMechListMIC(finalToken []byte) error {
+	if len(finalToken) == 0 || len(ctx.SessionKey) == 0 || len(ctx.MechListDER) == 0 {
+		return nil
+	}
+
+	resp, err := parseFinalNegTokenResp(finalToken)
+	if err != nil {
+		// A final token this client cannot parse is not evidence of tampering;
+		// the exchange has already completed at the SMB layer.
+		return nil
+	}
+	if len(resp.MechListMIC) == 0 {
+		return nil
+	}
+	if len(resp.MechListMIC) != security.SignatureSize {
+		return fmt.Errorf("spnego: server mechListMIC is %d bytes, want %d", len(resp.MechListMIC), security.SignatureSize)
+	}
+
+	sec, err := security.NewContext(ctx.SessionKey, ctx.authenticateFlags)
+	if err != nil {
+		return fmt.Errorf("spnego: cannot key the mechListMIC check: %w", err)
+	}
+
+	var sig [security.SignatureSize]byte
+	copy(sig[:], resp.MechListMIC)
+	if err := sec.VerifySignature(ctx.MechListDER, sig); err != nil {
+		return fmt.Errorf("spnego: server mechListMIC does not verify over the advertised mech list: %w", err)
+	}
+	return nil
+}
+
+// parseFinalNegTokenResp unwraps a server's final SPNEGO token. The token may or
+// may not be wrapped in a GSS-API SecurityBlob depending on the leg it arrived on.
+func parseFinalNegTokenResp(token []byte) (*NegTokenResp, error) {
+	resp := &NegTokenResp{}
+	if _, err := resp.Unmarshal(token); err == nil {
+		return resp, nil
+	}
+
+	blob := &SecurityBlob{}
+	if _, err := blob.Unmarshal(token); err != nil {
+		return nil, err
+	}
+	resp = &NegTokenResp{}
+	if _, err := resp.Unmarshal(blob.Data); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}

--- a/crypto/spnego/mechlistmic_test.go
+++ b/crypto/spnego/mechlistmic_test.go
@@ -1,0 +1,165 @@
+package spnego
+
+import (
+	"bytes"
+	"encoding/asn1"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/message/negotiate/flags"
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/security"
+)
+
+// TestMarshalMechTypeListOmitsTheContextTag pins the input a mechListMIC is taken
+// over. RFC 4178 section 5 is explicit that the message is the DER encoding of
+// MechTypeList and NOT of "[0] MechTypeList", so a leading 0xA0 context tag here
+// would make every MIC disagree with the peer's.
+func TestMarshalMechTypeListOmitsTheContextTag(t *testing.T) {
+	der, err := MarshalMechTypeList([]asn1.ObjectIdentifier{NtlmOID})
+	if err != nil {
+		t.Fatalf("MarshalMechTypeList: %v", err)
+	}
+	if len(der) == 0 {
+		t.Fatal("MarshalMechTypeList returned no bytes")
+	}
+	if der[0] == 0xA0 {
+		t.Errorf("MechTypeList DER starts with the [0] context tag: % x", der)
+	}
+	if der[0] != 0x30 {
+		t.Errorf("MechTypeList DER starts with %#02x, want 0x30 (SEQUENCE)", der[0])
+	}
+
+	// The NTLMSSP OID must appear in the encoding.
+	want, err := asn1.Marshal(NtlmOID)
+	if err != nil {
+		t.Fatalf("marshal OID: %v", err)
+	}
+	if !bytes.Contains(der, want) {
+		t.Errorf("MechTypeList DER % x does not contain the NTLMSSP OID % x", der, want)
+	}
+}
+
+// authContextForMIC builds a context in the state it reaches after a successful
+// AUTHENTICATE: a session key derived and the advertised mech list retained.
+func authContextForMIC(t *testing.T) *AuthContext {
+	t.Helper()
+
+	der, err := MarshalMechTypeList([]asn1.ObjectIdentifier{NtlmOID})
+	if err != nil {
+		t.Fatalf("MarshalMechTypeList: %v", err)
+	}
+	return &AuthContext{
+		SessionKey:  []byte("0123456789abcdef"),
+		MechListDER: der,
+		authenticateFlags: flags.NTLMSSP_NEGOTIATE_UNICODE |
+			flags.NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY |
+			flags.NTLMSSP_NEGOTIATE_SIGN |
+			flags.NTLMSSP_NEGOTIATE_KEY_EXCH,
+	}
+}
+
+// TestComputeMechListMICIsAnNTLMSignature checks the MIC is a well-formed
+// NTLMSSP_MESSAGE_SIGNATURE over the advertised mech list, at sequence number 0 —
+// it is the first message protected on the new session.
+func TestComputeMechListMICIsAnNTLMSignature(t *testing.T) {
+	ctx := authContextForMIC(t)
+
+	mic, err := ctx.computeMechListMIC(ctx.authenticateFlags)
+	if err != nil {
+		t.Fatalf("computeMechListMIC: %v", err)
+	}
+	if len(mic) != security.SignatureSize {
+		t.Fatalf("mechListMIC is %d bytes, want %d", len(mic), security.SignatureSize)
+	}
+
+	// Version 1, little-endian, then an 8-byte checksum, then the sequence number.
+	if got := uint32(mic[0]) | uint32(mic[1])<<8 | uint32(mic[2])<<16 | uint32(mic[3])<<24; got != 1 {
+		t.Errorf("signature version = %d, want 1", got)
+	}
+	if got := uint32(mic[12]) | uint32(mic[13])<<8 | uint32(mic[14])<<16 | uint32(mic[15])<<24; got != 0 {
+		t.Errorf("sequence number = %d, want 0", got)
+	}
+
+	// Computing it again from an equivalent context must give the same bytes: the
+	// MIC is a function of the key and the mech list, not of call order.
+	again, err := authContextForMIC(t).computeMechListMIC(ctx.authenticateFlags)
+	if err != nil {
+		t.Fatalf("computeMechListMIC (second context): %v", err)
+	}
+	if !bytes.Equal(mic, again) {
+		t.Errorf("mechListMIC is not deterministic:\n first % x\nsecond % x", mic, again)
+	}
+}
+
+// TestComputeMechListMICCoversTheMechList checks the MIC actually depends on the
+// mech list — a MIC that ignored its input would be worthless as negotiation
+// protection.
+func TestComputeMechListMICCoversTheMechList(t *testing.T) {
+	ctx := authContextForMIC(t)
+	base, err := ctx.computeMechListMIC(ctx.authenticateFlags)
+	if err != nil {
+		t.Fatalf("computeMechListMIC: %v", err)
+	}
+
+	altered := authContextForMIC(t)
+	der, err := MarshalMechTypeList([]asn1.ObjectIdentifier{NtlmOID, KerberosOID})
+	if err != nil {
+		t.Fatalf("MarshalMechTypeList: %v", err)
+	}
+	altered.MechListDER = der
+
+	other, err := altered.computeMechListMIC(altered.authenticateFlags)
+	if err != nil {
+		t.Fatalf("computeMechListMIC (altered list): %v", err)
+	}
+	if bytes.Equal(base, other) {
+		t.Error("the mechListMIC is unchanged by a different mech list, so it protects nothing")
+	}
+}
+
+// TestComputeMechListMICWithoutASessionIsSkipped checks the exchange still works
+// where no MIC can be produced: a mechanism that derives no key, or a context with
+// no recorded mech list. Emitting none is valid whenever the peer does not require
+// one, and is what the exchange did before.
+func TestComputeMechListMICWithoutASessionIsSkipped(t *testing.T) {
+	noKey := authContextForMIC(t)
+	noKey.SessionKey = nil
+	if mic, err := noKey.computeMechListMIC(noKey.authenticateFlags); err != nil || mic != nil {
+		t.Errorf("with no session key: got (% x, %v), want (nil, nil)", mic, err)
+	}
+
+	noList := authContextForMIC(t)
+	noList.MechListDER = nil
+	if mic, err := noList.computeMechListMIC(noList.authenticateFlags); err != nil || mic != nil {
+		t.Errorf("with no mech list: got (% x, %v), want (nil, nil)", mic, err)
+	}
+}
+
+// TestVerifyServerMechListMICAcceptsAbsentAndRejectsWrong covers the receiving
+// side: an omitted MIC is valid, and one that does not verify is an error.
+func TestVerifyServerMechListMICAcceptsAbsentAndRejectsWrong(t *testing.T) {
+	ctx := authContextForMIC(t)
+
+	// No token at all, and a token with no mechListMIC, both verify trivially.
+	if err := ctx.VerifyServerMechListMIC(nil); err != nil {
+		t.Errorf("empty token: %v", err)
+	}
+
+	withoutMIC := NegTokenResp{NegState: NegStateAcceptCompleted}
+	tokenNoMIC, err := withoutMIC.Marshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := ctx.VerifyServerMechListMIC(tokenNoMIC); err != nil {
+		t.Errorf("token without a mechListMIC: %v", err)
+	}
+
+	// A MIC of the right length but the wrong bytes must be rejected.
+	bad := NegTokenResp{NegState: NegStateAcceptCompleted, MechListMIC: make([]byte, security.SignatureSize)}
+	tokenBad, err := bad.Marshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := ctx.VerifyServerMechListMIC(tokenBad); err == nil {
+		t.Error("a zeroed mechListMIC was accepted, want a verification failure")
+	}
+}

--- a/crypto/spnego/negotiate.go
+++ b/crypto/spnego/negotiate.go
@@ -1,6 +1,7 @@
 package spnego
 
 import (
+	"encoding/asn1"
 	"errors"
 	"fmt"
 
@@ -41,6 +42,14 @@ func (ctx *AuthContext) processNegotiateInnerTokenNTLM(negotiateFlags flags.Nego
 
 	// Retain the raw NEGOTIATE message for the AUTHENTICATE MIC computation.
 	ctx.NegotiateMessageBytes = ntlmNegotiateBytes
+
+	// Retain the mech list for the mechListMIC computed over it later.
+	mechTypes := []asn1.ObjectIdentifier{NtlmOID}
+	mechListDER, err := MarshalMechTypeList(mechTypes)
+	if err != nil {
+		return nil, err
+	}
+	ctx.MechListDER = mechListDER
 
 	// Wrap in SPNEGO
 	return CreateNegTokenInit(ntlmNegotiateBytes)

--- a/crypto/spnego/negtokeninit.go
+++ b/crypto/spnego/negtokeninit.go
@@ -14,6 +14,23 @@ type NegTokenInit struct {
 	MechTokenMIC []byte                  `asn1:"explicit,optional,tag:3"`
 }
 
+// MarshalMechTypeList returns the DER encoding of a MechTypeList: the bare
+// SEQUENCE OF MechType, without the [0] context tag that wraps it inside a
+// NegTokenInit.
+//
+// This is the exact input a mechListMIC is computed over. RFC 4178 section 5 is
+// explicit that the message is "the DER encoding of the value of type
+// MechTypeList, which is contained in the mechTypes field of the NegTokenInit",
+// and NOT the DER encoding of the type "[0] MechTypeList" — so the context tag
+// must be absent or the MIC will not verify against a peer's.
+func MarshalMechTypeList(mechTypes []asn1.ObjectIdentifier) ([]byte, error) {
+	der, err := asn1.Marshal(mechTypes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal MechTypeList: %v", err)
+	}
+	return der, nil
+}
+
 // CreateNegTokenInit creates a SPNEGO NegTokenInit with the given NTLM token and marshals it.
 // Parameters:
 //   - ntlmToken: The NTLM token bytes to include in the SPNEGO token

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/00_SamrConnect.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/00_SamrConnect.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -34,8 +35,8 @@ func SamrConnect(rpc ndr.Invoker, serverName string, desiredAccess uint32) (mssa
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return mssamr.SAMPR_HANDLE{}, fmt.Errorf("SamrConnect: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.Handle, fmt.Errorf("SamrConnect failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Handle, fmt.Errorf("SamrConnect failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Handle, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/01_SamrCloseHandle.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/01_SamrCloseHandle.go
@@ -10,6 +10,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -29,8 +30,8 @@ func SamrCloseHandle(rpc ndr.Invoker, handle mssamr.SAMPR_HANDLE) (mssamr.SAMPR_
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return handle, fmt.Errorf("SamrCloseHandle: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.Handle, fmt.Errorf("SamrCloseHandle failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Handle, fmt.Errorf("SamrCloseHandle failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Handle, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/02_SamrSetSecurityObject.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/02_SamrSetSecurityObject.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -36,8 +37,8 @@ func SamrSetSecurityObject(rpc ndr.Invoker, handle mssamr.SAMPR_HANDLE, security
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("SamrSetSecurityObject: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return fmt.Errorf("SamrSetSecurityObject failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return fmt.Errorf("SamrSetSecurityObject failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/03_SamrQuerySecurityObject.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/03_SamrQuerySecurityObject.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -41,8 +42,8 @@ func SamrQuerySecurityObject(rpc ndr.Invoker, handle mssamr.SAMPR_HANDLE, securi
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return nil, fmt.Errorf("SamrQuerySecurityObject: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.SecurityDescriptor, fmt.Errorf("SamrQuerySecurityObject failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.SecurityDescriptor, fmt.Errorf("SamrQuerySecurityObject failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.SecurityDescriptor, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/05_SamrLookupDomainInSamServer.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/05_SamrLookupDomainInSamServer.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
@@ -44,8 +45,8 @@ func SamrLookupDomainInSamServer(rpc ndr.Invoker, handle mssamr.SAMPR_HANDLE, na
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return nil, fmt.Errorf("SamrLookupDomainInSamServer: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.DomainId, fmt.Errorf("SamrLookupDomainInSamServer failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.DomainId, fmt.Errorf("SamrLookupDomainInSamServer failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.DomainId, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/06_SamrEnumerateDomainsInSamServer.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/06_SamrEnumerateDomainsInSamServer.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -50,9 +51,8 @@ func SamrEnumerateDomainsInSamServer(rpc ndr.Invoker, handle mssamr.SAMPR_HANDLE
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return 0, nil, 0, fmt.Errorf("SamrEnumerateDomainsInSamServer: %w", err)
 	}
-	status := uint32(resp.Status)
-	if status != samr.StatusSuccess && status != samr.StatusMoreEntries {
-		return uint32(resp.EnumerationContext), resp.Buffer, uint32(resp.CountReturned), fmt.Errorf("SamrEnumerateDomainsInSamServer failed: %s", samr.StatusString(status))
+	if status := nt_status.NT_STATUS(resp.Status); status != nt_status.NT_STATUS_SUCCESS && status != nt_status.NT_STATUS_MORE_ENTRIES {
+		return uint32(resp.EnumerationContext), resp.Buffer, uint32(resp.CountReturned), fmt.Errorf("SamrEnumerateDomainsInSamServer failed: %s", status)
 	}
 	return uint32(resp.EnumerationContext), resp.Buffer, uint32(resp.CountReturned), nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/07_SamrOpenDomain.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/07_SamrOpenDomain.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
@@ -36,8 +37,8 @@ func SamrOpenDomain(rpc ndr.Invoker, serverHandle mssamr.SAMPR_HANDLE, desiredAc
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return mssamr.SAMPR_HANDLE{}, fmt.Errorf("SamrOpenDomain: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.Handle, fmt.Errorf("SamrOpenDomain failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Handle, fmt.Errorf("SamrOpenDomain failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Handle, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/08_SamrQueryInformationDomain.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/08_SamrQueryInformationDomain.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -42,8 +43,8 @@ func SamrQueryInformationDomain(rpc ndr.Invoker, domainHandle mssamr.SAMPR_HANDL
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return nil, fmt.Errorf("SamrQueryInformationDomain: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.Buffer, fmt.Errorf("SamrQueryInformationDomain failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Buffer, fmt.Errorf("SamrQueryInformationDomain failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Buffer, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/09_SamrSetInformationDomain.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/09_SamrSetInformationDomain.go
@@ -10,6 +10,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -40,8 +41,8 @@ func SamrSetInformationDomain(rpc ndr.Invoker, domainHandle mssamr.SAMPR_HANDLE,
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("SamrSetInformationDomain: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return fmt.Errorf("SamrSetInformationDomain failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return fmt.Errorf("SamrSetInformationDomain failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/10_SamrCreateGroupInDomain.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/10_SamrCreateGroupInDomain.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
@@ -45,8 +46,8 @@ func SamrCreateGroupInDomain(rpc ndr.Invoker, domainHandle mssamr.SAMPR_HANDLE, 
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return mssamr.SAMPR_HANDLE{}, 0, fmt.Errorf("SamrCreateGroupInDomain: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.GroupHandle, uint32(resp.RelativeId), fmt.Errorf("SamrCreateGroupInDomain failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.GroupHandle, uint32(resp.RelativeId), fmt.Errorf("SamrCreateGroupInDomain failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.GroupHandle, uint32(resp.RelativeId), nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/11_SamrEnumerateGroupsInDomain.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/11_SamrEnumerateGroupsInDomain.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -47,9 +48,8 @@ func SamrEnumerateGroupsInDomain(rpc ndr.Invoker, domainHandle mssamr.SAMPR_HAND
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return 0, nil, 0, fmt.Errorf("SamrEnumerateGroupsInDomain: %w", err)
 	}
-	status := uint32(resp.Status)
-	if status != samr.StatusSuccess && status != samr.StatusMoreEntries {
-		return uint32(resp.EnumerationContext), resp.Buffer, uint32(resp.CountReturned), fmt.Errorf("SamrEnumerateGroupsInDomain failed: %s", samr.StatusString(status))
+	if status := nt_status.NT_STATUS(resp.Status); status != nt_status.NT_STATUS_SUCCESS && status != nt_status.NT_STATUS_MORE_ENTRIES {
+		return uint32(resp.EnumerationContext), resp.Buffer, uint32(resp.CountReturned), fmt.Errorf("SamrEnumerateGroupsInDomain failed: %s", status)
 	}
 	return uint32(resp.EnumerationContext), resp.Buffer, uint32(resp.CountReturned), nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/12_SamrCreateUserInDomain.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/12_SamrCreateUserInDomain.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
@@ -45,8 +46,8 @@ func SamrCreateUserInDomain(rpc ndr.Invoker, domainHandle mssamr.SAMPR_HANDLE, n
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return mssamr.SAMPR_HANDLE{}, 0, fmt.Errorf("SamrCreateUserInDomain: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.UserHandle, uint32(resp.RelativeId), fmt.Errorf("SamrCreateUserInDomain failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.UserHandle, uint32(resp.RelativeId), fmt.Errorf("SamrCreateUserInDomain failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.UserHandle, uint32(resp.RelativeId), nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/13_SamrEnumerateUsersInDomain.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/13_SamrEnumerateUsersInDomain.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -50,9 +51,8 @@ func SamrEnumerateUsersInDomain(rpc ndr.Invoker, domainHandle mssamr.SAMPR_HANDL
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return 0, nil, 0, fmt.Errorf("SamrEnumerateUsersInDomain: %w", err)
 	}
-	status := uint32(resp.Status)
-	if status != samr.StatusSuccess && status != samr.StatusMoreEntries {
-		return uint32(resp.EnumerationContext), resp.Buffer, uint32(resp.CountReturned), fmt.Errorf("SamrEnumerateUsersInDomain failed: %s", samr.StatusString(status))
+	if status := nt_status.NT_STATUS(resp.Status); status != nt_status.NT_STATUS_SUCCESS && status != nt_status.NT_STATUS_MORE_ENTRIES {
+		return uint32(resp.EnumerationContext), resp.Buffer, uint32(resp.CountReturned), fmt.Errorf("SamrEnumerateUsersInDomain failed: %s", status)
 	}
 	return uint32(resp.EnumerationContext), resp.Buffer, uint32(resp.CountReturned), nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/14_SamrCreateAliasInDomain.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/14_SamrCreateAliasInDomain.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
@@ -45,8 +46,8 @@ func SamrCreateAliasInDomain(rpc ndr.Invoker, domainHandle mssamr.SAMPR_HANDLE, 
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return mssamr.SAMPR_HANDLE{}, 0, fmt.Errorf("SamrCreateAliasInDomain: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.AliasHandle, uint32(resp.RelativeId), fmt.Errorf("SamrCreateAliasInDomain failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.AliasHandle, uint32(resp.RelativeId), fmt.Errorf("SamrCreateAliasInDomain failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.AliasHandle, uint32(resp.RelativeId), nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/15_SamrEnumerateAliasesInDomain.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/15_SamrEnumerateAliasesInDomain.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -47,9 +48,8 @@ func SamrEnumerateAliasesInDomain(rpc ndr.Invoker, domainHandle mssamr.SAMPR_HAN
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return 0, nil, 0, fmt.Errorf("SamrEnumerateAliasesInDomain: %w", err)
 	}
-	status := uint32(resp.Status)
-	if status != samr.StatusSuccess && status != samr.StatusMoreEntries {
-		return uint32(resp.EnumerationContext), resp.Buffer, uint32(resp.CountReturned), fmt.Errorf("SamrEnumerateAliasesInDomain failed: %s", samr.StatusString(status))
+	if status := nt_status.NT_STATUS(resp.Status); status != nt_status.NT_STATUS_SUCCESS && status != nt_status.NT_STATUS_MORE_ENTRIES {
+		return uint32(resp.EnumerationContext), resp.Buffer, uint32(resp.CountReturned), fmt.Errorf("SamrEnumerateAliasesInDomain failed: %s", status)
 	}
 	return uint32(resp.EnumerationContext), resp.Buffer, uint32(resp.CountReturned), nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/16_SamrGetAliasMembership.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/16_SamrGetAliasMembership.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -40,8 +41,8 @@ func SamrGetAliasMembership(rpc ndr.Invoker, domainHandle mssamr.SAMPR_HANDLE, s
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return mssamr.SAMPR_ULONG_ARRAY{}, fmt.Errorf("SamrGetAliasMembership: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.Membership, fmt.Errorf("SamrGetAliasMembership failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Membership, fmt.Errorf("SamrGetAliasMembership failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Membership, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/17_SamrLookupNamesInDomain.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/17_SamrLookupNamesInDomain.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
@@ -55,9 +56,8 @@ func SamrLookupNamesInDomain(rpc ndr.Invoker, domainHandle mssamr.SAMPR_HANDLE, 
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return mssamr.SAMPR_ULONG_ARRAY{}, mssamr.SAMPR_ULONG_ARRAY{}, fmt.Errorf("SamrLookupNamesInDomain: %w", err)
 	}
-	status := uint32(resp.Status)
-	if status != samr.StatusSuccess && status != samr.StatusSomeNotMapped && status != samr.StatusNoneMapped {
-		return resp.RelativeIds, resp.Use, fmt.Errorf("SamrLookupNamesInDomain failed: %s", samr.StatusString(status))
+	if status := nt_status.NT_STATUS(resp.Status); status != nt_status.NT_STATUS_SUCCESS && status != nt_status.NT_STATUS_SOME_NOT_MAPPED && status != nt_status.NT_STATUS_NONE_MAPPED {
+		return resp.RelativeIds, resp.Use, fmt.Errorf("SamrLookupNamesInDomain failed: %s", status)
 	}
 	return resp.RelativeIds, resp.Use, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/18_SamrLookupIdsInDomain.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/18_SamrLookupIdsInDomain.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -53,9 +54,8 @@ func SamrLookupIdsInDomain(rpc ndr.Invoker, domainHandle mssamr.SAMPR_HANDLE, re
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return mssamr.SAMPR_RETURNED_USTRING_ARRAY{}, mssamr.SAMPR_ULONG_ARRAY{}, fmt.Errorf("SamrLookupIdsInDomain: %w", err)
 	}
-	status := uint32(resp.Status)
-	if status != samr.StatusSuccess && status != samr.StatusSomeNotMapped && status != samr.StatusNoneMapped {
-		return resp.Names, resp.Use, fmt.Errorf("SamrLookupIdsInDomain failed: %s", samr.StatusString(status))
+	if status := nt_status.NT_STATUS(resp.Status); status != nt_status.NT_STATUS_SUCCESS && status != nt_status.NT_STATUS_SOME_NOT_MAPPED && status != nt_status.NT_STATUS_NONE_MAPPED {
+		return resp.Names, resp.Use, fmt.Errorf("SamrLookupIdsInDomain failed: %s", status)
 	}
 	return resp.Names, resp.Use, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/19_SamrOpenGroup.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/19_SamrOpenGroup.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -35,8 +36,8 @@ func SamrOpenGroup(rpc ndr.Invoker, domainHandle mssamr.SAMPR_HANDLE, desiredAcc
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return mssamr.SAMPR_HANDLE{}, fmt.Errorf("SamrOpenGroup: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.Handle, fmt.Errorf("SamrOpenGroup failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Handle, fmt.Errorf("SamrOpenGroup failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Handle, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/20_SamrQueryInformationGroup.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/20_SamrQueryInformationGroup.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -42,8 +43,8 @@ func SamrQueryInformationGroup(rpc ndr.Invoker, groupHandle mssamr.SAMPR_HANDLE,
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return nil, fmt.Errorf("SamrQueryInformationGroup: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.Buffer, fmt.Errorf("SamrQueryInformationGroup failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Buffer, fmt.Errorf("SamrQueryInformationGroup failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Buffer, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/21_SamrSetInformationGroup.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/21_SamrSetInformationGroup.go
@@ -10,6 +10,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -35,8 +36,8 @@ func SamrSetInformationGroup(rpc ndr.Invoker, groupHandle mssamr.SAMPR_HANDLE, g
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("SamrSetInformationGroup: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return fmt.Errorf("SamrSetInformationGroup failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return fmt.Errorf("SamrSetInformationGroup failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/22_SamrAddMemberToGroup.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/22_SamrAddMemberToGroup.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -35,8 +36,8 @@ func SamrAddMemberToGroup(rpc ndr.Invoker, groupHandle mssamr.SAMPR_HANDLE, memb
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("SamrAddMemberToGroup: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return fmt.Errorf("SamrAddMemberToGroup failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return fmt.Errorf("SamrAddMemberToGroup failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/23_SamrDeleteGroup.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/23_SamrDeleteGroup.go
@@ -10,6 +10,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -29,8 +30,8 @@ func SamrDeleteGroup(rpc ndr.Invoker, groupHandle mssamr.SAMPR_HANDLE) (mssamr.S
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return groupHandle, fmt.Errorf("SamrDeleteGroup: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.Handle, fmt.Errorf("SamrDeleteGroup failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Handle, fmt.Errorf("SamrDeleteGroup failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Handle, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/24_SamrRemoveMemberFromGroup.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/24_SamrRemoveMemberFromGroup.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -35,8 +36,8 @@ func SamrRemoveMemberFromGroup(rpc ndr.Invoker, groupHandle mssamr.SAMPR_HANDLE,
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("SamrRemoveMemberFromGroup: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return fmt.Errorf("SamrRemoveMemberFromGroup failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return fmt.Errorf("SamrRemoveMemberFromGroup failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/25_SamrGetMembersInGroup.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/25_SamrGetMembersInGroup.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -35,8 +36,8 @@ func SamrGetMembersInGroup(rpc ndr.Invoker, groupHandle mssamr.SAMPR_HANDLE) (*m
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return nil, fmt.Errorf("SamrGetMembersInGroup: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.Members, fmt.Errorf("SamrGetMembersInGroup failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Members, fmt.Errorf("SamrGetMembersInGroup failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Members, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/26_SamrSetMemberAttributesOfGroup.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/26_SamrSetMemberAttributesOfGroup.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -37,8 +38,8 @@ func SamrSetMemberAttributesOfGroup(rpc ndr.Invoker, groupHandle mssamr.SAMPR_HA
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("SamrSetMemberAttributesOfGroup: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return fmt.Errorf("SamrSetMemberAttributesOfGroup failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return fmt.Errorf("SamrSetMemberAttributesOfGroup failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/27_SamrOpenAlias.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/27_SamrOpenAlias.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -35,8 +36,8 @@ func SamrOpenAlias(rpc ndr.Invoker, domainHandle mssamr.SAMPR_HANDLE, desiredAcc
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return mssamr.SAMPR_HANDLE{}, fmt.Errorf("SamrOpenAlias: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.Handle, fmt.Errorf("SamrOpenAlias failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Handle, fmt.Errorf("SamrOpenAlias failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Handle, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/28_SamrQueryInformationAlias.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/28_SamrQueryInformationAlias.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -42,8 +43,8 @@ func SamrQueryInformationAlias(rpc ndr.Invoker, aliasHandle mssamr.SAMPR_HANDLE,
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return nil, fmt.Errorf("SamrQueryInformationAlias: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.Buffer, fmt.Errorf("SamrQueryInformationAlias failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Buffer, fmt.Errorf("SamrQueryInformationAlias failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Buffer, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/29_SamrSetInformationAlias.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/29_SamrSetInformationAlias.go
@@ -10,6 +10,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -35,8 +36,8 @@ func SamrSetInformationAlias(rpc ndr.Invoker, aliasHandle mssamr.SAMPR_HANDLE, a
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("SamrSetInformationAlias: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return fmt.Errorf("SamrSetInformationAlias failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return fmt.Errorf("SamrSetInformationAlias failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/30_SamrDeleteAlias.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/30_SamrDeleteAlias.go
@@ -10,6 +10,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -29,8 +30,8 @@ func SamrDeleteAlias(rpc ndr.Invoker, aliasHandle mssamr.SAMPR_HANDLE) (mssamr.S
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return aliasHandle, fmt.Errorf("SamrDeleteAlias: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.Handle, fmt.Errorf("SamrDeleteAlias failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Handle, fmt.Errorf("SamrDeleteAlias failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Handle, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/31_SamrAddMemberToAlias.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/31_SamrAddMemberToAlias.go
@@ -10,6 +10,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
@@ -34,8 +35,8 @@ func SamrAddMemberToAlias(rpc ndr.Invoker, aliasHandle mssamr.SAMPR_HANDLE, memb
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("SamrAddMemberToAlias: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return fmt.Errorf("SamrAddMemberToAlias failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return fmt.Errorf("SamrAddMemberToAlias failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/32_SamrRemoveMemberFromAlias.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/32_SamrRemoveMemberFromAlias.go
@@ -10,6 +10,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
@@ -36,8 +37,8 @@ func SamrRemoveMemberFromAlias(rpc ndr.Invoker, aliasHandle mssamr.SAMPR_HANDLE,
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("SamrRemoveMemberFromAlias: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return fmt.Errorf("SamrRemoveMemberFromAlias failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return fmt.Errorf("SamrRemoveMemberFromAlias failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/33_SamrGetMembersInAlias.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/33_SamrGetMembersInAlias.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -35,8 +36,8 @@ func SamrGetMembersInAlias(rpc ndr.Invoker, aliasHandle mssamr.SAMPR_HANDLE) (ms
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return mssamr.SAMPR_PSID_ARRAY_OUT{}, fmt.Errorf("SamrGetMembersInAlias: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.Members, fmt.Errorf("SamrGetMembersInAlias failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Members, fmt.Errorf("SamrGetMembersInAlias failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Members, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/34_SamrOpenUser.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/34_SamrOpenUser.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -35,8 +36,8 @@ func SamrOpenUser(rpc ndr.Invoker, domainHandle mssamr.SAMPR_HANDLE, desiredAcce
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return mssamr.SAMPR_HANDLE{}, fmt.Errorf("SamrOpenUser: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.Handle, fmt.Errorf("SamrOpenUser failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Handle, fmt.Errorf("SamrOpenUser failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Handle, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/35_SamrDeleteUser.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/35_SamrDeleteUser.go
@@ -10,6 +10,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -29,8 +30,8 @@ func SamrDeleteUser(rpc ndr.Invoker, userHandle mssamr.SAMPR_HANDLE) (mssamr.SAM
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return userHandle, fmt.Errorf("SamrDeleteUser: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.Handle, fmt.Errorf("SamrDeleteUser failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Handle, fmt.Errorf("SamrDeleteUser failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Handle, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/36_SamrQueryInformationUser.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/36_SamrQueryInformationUser.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -42,8 +43,8 @@ func SamrQueryInformationUser(rpc ndr.Invoker, userHandle mssamr.SAMPR_HANDLE, u
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return nil, fmt.Errorf("SamrQueryInformationUser: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.Buffer, fmt.Errorf("SamrQueryInformationUser failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Buffer, fmt.Errorf("SamrQueryInformationUser failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Buffer, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/37_SamrSetInformationUser.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/37_SamrSetInformationUser.go
@@ -10,6 +10,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -36,8 +37,8 @@ func SamrSetInformationUser(rpc ndr.Invoker, userHandle mssamr.SAMPR_HANDLE, use
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("SamrSetInformationUser: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return fmt.Errorf("SamrSetInformationUser failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return fmt.Errorf("SamrSetInformationUser failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/38_SamrChangePasswordUser.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/38_SamrChangePasswordUser.go
@@ -10,6 +10,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -53,8 +54,8 @@ func SamrChangePasswordUser(rpc ndr.Invoker, userHandle mssamr.SAMPR_HANDLE, lmP
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("SamrChangePasswordUser: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return fmt.Errorf("SamrChangePasswordUser failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return fmt.Errorf("SamrChangePasswordUser failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/39_SamrGetGroupsForUser.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/39_SamrGetGroupsForUser.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -36,8 +37,8 @@ func SamrGetGroupsForUser(rpc ndr.Invoker, userHandle mssamr.SAMPR_HANDLE) (*mss
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return nil, fmt.Errorf("SamrGetGroupsForUser: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.Groups, fmt.Errorf("SamrGetGroupsForUser failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Groups, fmt.Errorf("SamrGetGroupsForUser failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Groups, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/40_SamrQueryDisplayInformation.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/40_SamrQueryDisplayInformation.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -53,9 +54,8 @@ func SamrQueryDisplayInformation(rpc ndr.Invoker, domainHandle mssamr.SAMPR_HAND
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return 0, 0, mssamr.SAMPR_DISPLAY_INFO_BUFFER{}, fmt.Errorf("SamrQueryDisplayInformation: %w", err)
 	}
-	status := uint32(resp.Status)
-	if status != samr.StatusSuccess && status != samr.StatusMoreEntries {
-		return uint32(resp.TotalAvailable), uint32(resp.TotalReturned), resp.Buffer, fmt.Errorf("SamrQueryDisplayInformation failed: %s", samr.StatusString(status))
+	if status := nt_status.NT_STATUS(resp.Status); status != nt_status.NT_STATUS_SUCCESS && status != nt_status.NT_STATUS_MORE_ENTRIES {
+		return uint32(resp.TotalAvailable), uint32(resp.TotalReturned), resp.Buffer, fmt.Errorf("SamrQueryDisplayInformation failed: %s", status)
 	}
 	return uint32(resp.TotalAvailable), uint32(resp.TotalReturned), resp.Buffer, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/41_SamrGetDisplayEnumerationIndex.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/41_SamrGetDisplayEnumerationIndex.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
@@ -46,9 +47,8 @@ func SamrGetDisplayEnumerationIndex(rpc ndr.Invoker, domainHandle mssamr.SAMPR_H
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return 0, fmt.Errorf("SamrGetDisplayEnumerationIndex: %w", err)
 	}
-	status := uint32(resp.Status)
-	if status != samr.StatusSuccess && status != samr.StatusMoreEntries && status != samr.StatusNoMoreEntries {
-		return uint32(resp.Index), fmt.Errorf("SamrGetDisplayEnumerationIndex failed: %s", samr.StatusString(status))
+	if status := nt_status.NT_STATUS(resp.Status); status != nt_status.NT_STATUS_SUCCESS && status != nt_status.NT_STATUS_MORE_ENTRIES && status != nt_status.NT_STATUS_NO_MORE_ENTRIES {
+		return uint32(resp.Index), fmt.Errorf("SamrGetDisplayEnumerationIndex failed: %s", status)
 	}
 	return uint32(resp.Index), nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/44_SamrGetUserDomainPasswordInformation.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/44_SamrGetUserDomainPasswordInformation.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -38,8 +39,8 @@ func SamrGetUserDomainPasswordInformation(rpc ndr.Invoker, userHandle mssamr.SAM
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return mssamr.USER_DOMAIN_PASSWORD_INFORMATION{}, fmt.Errorf("SamrGetUserDomainPasswordInformation: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.PasswordInformation, fmt.Errorf("SamrGetUserDomainPasswordInformation failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.PasswordInformation, fmt.Errorf("SamrGetUserDomainPasswordInformation failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.PasswordInformation, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/45_SamrRemoveMemberFromForeignDomain.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/45_SamrRemoveMemberFromForeignDomain.go
@@ -10,6 +10,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
@@ -38,8 +39,8 @@ func SamrRemoveMemberFromForeignDomain(rpc ndr.Invoker, domainHandle mssamr.SAMP
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("SamrRemoveMemberFromForeignDomain: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return fmt.Errorf("SamrRemoveMemberFromForeignDomain failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return fmt.Errorf("SamrRemoveMemberFromForeignDomain failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/46_SamrQueryInformationDomain2.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/46_SamrQueryInformationDomain2.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -43,8 +44,8 @@ func SamrQueryInformationDomain2(rpc ndr.Invoker, domainHandle mssamr.SAMPR_HAND
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return nil, fmt.Errorf("SamrQueryInformationDomain2: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.Buffer, fmt.Errorf("SamrQueryInformationDomain2 failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Buffer, fmt.Errorf("SamrQueryInformationDomain2 failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Buffer, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/47_SamrQueryInformationUser2.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/47_SamrQueryInformationUser2.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -42,8 +43,8 @@ func SamrQueryInformationUser2(rpc ndr.Invoker, userHandle mssamr.SAMPR_HANDLE, 
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return nil, fmt.Errorf("SamrQueryInformationUser2: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.Buffer, fmt.Errorf("SamrQueryInformationUser2 failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Buffer, fmt.Errorf("SamrQueryInformationUser2 failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Buffer, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/48_SamrQueryDisplayInformation2.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/48_SamrQueryDisplayInformation2.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -54,9 +55,8 @@ func SamrQueryDisplayInformation2(rpc ndr.Invoker, domainHandle mssamr.SAMPR_HAN
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return 0, 0, mssamr.SAMPR_DISPLAY_INFO_BUFFER{}, fmt.Errorf("SamrQueryDisplayInformation2: %w", err)
 	}
-	status := uint32(resp.Status)
-	if status != samr.StatusSuccess && status != samr.StatusMoreEntries {
-		return uint32(resp.TotalAvailable), uint32(resp.TotalReturned), resp.Buffer, fmt.Errorf("SamrQueryDisplayInformation2 failed: %s", samr.StatusString(status))
+	if status := nt_status.NT_STATUS(resp.Status); status != nt_status.NT_STATUS_SUCCESS && status != nt_status.NT_STATUS_MORE_ENTRIES {
+		return uint32(resp.TotalAvailable), uint32(resp.TotalReturned), resp.Buffer, fmt.Errorf("SamrQueryDisplayInformation2 failed: %s", status)
 	}
 	return uint32(resp.TotalAvailable), uint32(resp.TotalReturned), resp.Buffer, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/49_SamrGetDisplayEnumerationIndex2.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/49_SamrGetDisplayEnumerationIndex2.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
@@ -46,9 +47,8 @@ func SamrGetDisplayEnumerationIndex2(rpc ndr.Invoker, domainHandle mssamr.SAMPR_
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return 0, fmt.Errorf("SamrGetDisplayEnumerationIndex2: %w", err)
 	}
-	status := uint32(resp.Status)
-	if status != samr.StatusSuccess && status != samr.StatusMoreEntries && status != samr.StatusNoMoreEntries {
-		return uint32(resp.Index), fmt.Errorf("SamrGetDisplayEnumerationIndex2 failed: %s", samr.StatusString(status))
+	if status := nt_status.NT_STATUS(resp.Status); status != nt_status.NT_STATUS_SUCCESS && status != nt_status.NT_STATUS_MORE_ENTRIES && status != nt_status.NT_STATUS_NO_MORE_ENTRIES {
+		return uint32(resp.Index), fmt.Errorf("SamrGetDisplayEnumerationIndex2 failed: %s", status)
 	}
 	return uint32(resp.Index), nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/50_SamrCreateUser2InDomain.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/50_SamrCreateUser2InDomain.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
@@ -48,8 +49,8 @@ func SamrCreateUser2InDomain(rpc ndr.Invoker, domainHandle mssamr.SAMPR_HANDLE, 
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return mssamr.SAMPR_HANDLE{}, 0, 0, fmt.Errorf("SamrCreateUser2InDomain: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.UserHandle, uint32(resp.GrantedAccess), uint32(resp.RelativeId), fmt.Errorf("SamrCreateUser2InDomain failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.UserHandle, uint32(resp.GrantedAccess), uint32(resp.RelativeId), fmt.Errorf("SamrCreateUser2InDomain failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.UserHandle, uint32(resp.GrantedAccess), uint32(resp.RelativeId), nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/51_SamrQueryDisplayInformation3.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/51_SamrQueryDisplayInformation3.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -54,9 +55,8 @@ func SamrQueryDisplayInformation3(rpc ndr.Invoker, domainHandle mssamr.SAMPR_HAN
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return 0, 0, mssamr.SAMPR_DISPLAY_INFO_BUFFER{}, fmt.Errorf("SamrQueryDisplayInformation3: %w", err)
 	}
-	status := uint32(resp.Status)
-	if status != samr.StatusSuccess && status != samr.StatusMoreEntries {
-		return uint32(resp.TotalAvailable), uint32(resp.TotalReturned), resp.Buffer, fmt.Errorf("SamrQueryDisplayInformation3 failed: %s", samr.StatusString(status))
+	if status := nt_status.NT_STATUS(resp.Status); status != nt_status.NT_STATUS_SUCCESS && status != nt_status.NT_STATUS_MORE_ENTRIES {
+		return uint32(resp.TotalAvailable), uint32(resp.TotalReturned), resp.Buffer, fmt.Errorf("SamrQueryDisplayInformation3 failed: %s", status)
 	}
 	return uint32(resp.TotalAvailable), uint32(resp.TotalReturned), resp.Buffer, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/52_SamrAddMultipleMembersToAlias.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/52_SamrAddMultipleMembersToAlias.go
@@ -10,6 +10,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -35,8 +36,8 @@ func SamrAddMultipleMembersToAlias(rpc ndr.Invoker, aliasHandle mssamr.SAMPR_HAN
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("SamrAddMultipleMembersToAlias: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return fmt.Errorf("SamrAddMultipleMembersToAlias failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return fmt.Errorf("SamrAddMultipleMembersToAlias failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/53_SamrRemoveMultipleMembersFromAlias.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/53_SamrRemoveMultipleMembersFromAlias.go
@@ -10,6 +10,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -35,8 +36,8 @@ func SamrRemoveMultipleMembersFromAlias(rpc ndr.Invoker, aliasHandle mssamr.SAMP
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("SamrRemoveMultipleMembersFromAlias: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return fmt.Errorf("SamrRemoveMultipleMembersFromAlias failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return fmt.Errorf("SamrRemoveMultipleMembersFromAlias failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/54_SamrOemChangePasswordUser2.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/54_SamrOemChangePasswordUser2.go
@@ -10,6 +10,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -41,8 +42,8 @@ func SamrOemChangePasswordUser2(rpc ndr.Invoker, serverName *mssamr.RPC_STRING, 
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("SamrOemChangePasswordUser2: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return fmt.Errorf("SamrOemChangePasswordUser2 failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return fmt.Errorf("SamrOemChangePasswordUser2 failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/55_SamrUnicodeChangePasswordUser2.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/55_SamrUnicodeChangePasswordUser2.go
@@ -10,6 +10,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
@@ -50,8 +51,8 @@ func SamrUnicodeChangePasswordUser2(rpc ndr.Invoker, serverName *msdtyp.RPC_UNIC
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("SamrUnicodeChangePasswordUser2: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return fmt.Errorf("SamrUnicodeChangePasswordUser2 failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return fmt.Errorf("SamrUnicodeChangePasswordUser2 failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/56_SamrGetDomainPasswordInformation.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/56_SamrGetDomainPasswordInformation.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
@@ -41,8 +42,8 @@ func SamrGetDomainPasswordInformation(rpc ndr.Invoker) (mssamr.USER_DOMAIN_PASSW
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return mssamr.USER_DOMAIN_PASSWORD_INFORMATION{}, fmt.Errorf("SamrGetDomainPasswordInformation: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.PasswordInformation, fmt.Errorf("SamrGetDomainPasswordInformation failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.PasswordInformation, fmt.Errorf("SamrGetDomainPasswordInformation failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.PasswordInformation, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/57_SamrConnect2.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/57_SamrConnect2.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -33,8 +34,8 @@ func SamrConnect2(rpc ndr.Invoker, serverName string, desiredAccess uint32) (mss
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return mssamr.SAMPR_HANDLE{}, fmt.Errorf("SamrConnect2: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.Handle, fmt.Errorf("SamrConnect2 failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Handle, fmt.Errorf("SamrConnect2 failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Handle, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/58_SamrSetInformationUser2.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/58_SamrSetInformationUser2.go
@@ -10,6 +10,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -36,8 +37,8 @@ func SamrSetInformationUser2(rpc ndr.Invoker, userHandle mssamr.SAMPR_HANDLE, us
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("SamrSetInformationUser2: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return fmt.Errorf("SamrSetInformationUser2 failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return fmt.Errorf("SamrSetInformationUser2 failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/62_SamrConnect4.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/62_SamrConnect4.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -36,8 +37,8 @@ func SamrConnect4(rpc ndr.Invoker, serverName string, clientRevision uint32, des
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return mssamr.SAMPR_HANDLE{}, fmt.Errorf("SamrConnect4: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.Handle, fmt.Errorf("SamrConnect4 failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Handle, fmt.Errorf("SamrConnect4 failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Handle, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/64_SamrConnect5.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/64_SamrConnect5.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -59,8 +60,8 @@ func SamrConnect5(rpc ndr.Invoker, serverName string, desiredAccess uint32) (mss
 		return mssamr.SAMPR_HANDLE{}, 0, nil, fmt.Errorf("SamrConnect5: %w", err)
 	}
 	outInfo := resp.OutRevisionInfo
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.ServerHandle, uint32(resp.OutVersion), &outInfo, fmt.Errorf("SamrConnect5 failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.ServerHandle, uint32(resp.OutVersion), &outInfo, fmt.Errorf("SamrConnect5 failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.ServerHandle, uint32(resp.OutVersion), &outInfo, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/65_SamrRidToSid.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/65_SamrRidToSid.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
@@ -41,8 +42,8 @@ func SamrRidToSid(rpc ndr.Invoker, handle mssamr.SAMPR_HANDLE, rid uint32) (*msd
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return nil, fmt.Errorf("SamrRidToSid: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.Sid, fmt.Errorf("SamrRidToSid failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Sid, fmt.Errorf("SamrRidToSid failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Sid, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/66_SamrSetDSRMPassword.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/66_SamrSetDSRMPassword.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
@@ -37,8 +38,8 @@ func SamrSetDSRMPassword(rpc ndr.Invoker, userId uint32, encryptedNtOwfPassword 
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("SamrSetDSRMPassword: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return fmt.Errorf("SamrSetDSRMPassword failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return fmt.Errorf("SamrSetDSRMPassword failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/67_SamrValidatePassword.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/67_SamrValidatePassword.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
 
@@ -43,8 +44,8 @@ func SamrValidatePassword(rpc ndr.Invoker, validationType mssamr.PASSWORD_POLICY
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return nil, fmt.Errorf("SamrValidatePassword: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.OutputArg, fmt.Errorf("SamrValidatePassword failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.OutputArg, fmt.Errorf("SamrValidatePassword failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.OutputArg, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/73_SamrUnicodeChangePasswordUser4.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/73_SamrUnicodeChangePasswordUser4.go
@@ -10,6 +10,7 @@ import (
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
@@ -40,8 +41,8 @@ func SamrUnicodeChangePasswordUser4(rpc ndr.Invoker, serverName *msdtyp.RPC_UNIC
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("SamrUnicodeChangePasswordUser4: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return fmt.Errorf("SamrUnicodeChangePasswordUser4 failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return fmt.Errorf("SamrUnicodeChangePasswordUser4 failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/74_SamrValidateComputerAccountReuseAttempt.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/74_SamrValidateComputerAccountReuseAttempt.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
@@ -44,8 +45,8 @@ func SamrValidateComputerAccountReuseAttempt(rpc ndr.Invoker, serverHandle mssam
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return 0, fmt.Errorf("SamrValidateComputerAccountReuseAttempt: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.Result, fmt.Errorf("SamrValidateComputerAccountReuseAttempt failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Result, fmt.Errorf("SamrValidateComputerAccountReuseAttempt failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Result, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/77_SamrAccountIsDelegatedManagedServiceAccount.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/functions/77_SamrAccountIsDelegatedManagedServiceAccount.go
@@ -10,6 +10,7 @@ import (
 
 	samr "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mssamr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-samr"
 )
@@ -47,8 +48,8 @@ func SamrAccountIsDelegatedManagedServiceAccount(rpc ndr.Invoker, serverHandle m
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return false, false, fmt.Errorf("SamrAccountIsDelegatedManagedServiceAccount: %w", err)
 	}
-	if uint32(resp.Status) != samr.StatusSuccess {
-		return resp.Result, resp.Authorized, fmt.Errorf("SamrAccountIsDelegatedManagedServiceAccount failed: %s", samr.StatusString(uint32(resp.Status)))
+	if nt_status.NT_STATUS(resp.Status) != nt_status.NT_STATUS_SUCCESS {
+		return resp.Result, resp.Authorized, fmt.Errorf("SamrAccountIsDelegatedManagedServiceAccount failed: %s", nt_status.NT_STATUS(resp.Status).String())
 	}
 	return resp.Result, resp.Authorized, nil
 }

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/interface.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/interface.go
@@ -8,8 +8,8 @@
 // interface UUID with the version in the nested 1.0/ directory.
 //
 // This package holds only the interface-level descriptor: the abstract syntax
-// identifier, the transport endpoint (PipeName), the opnum constants and opnum<->name
-// maps, and the NTSTATUS return codes. NDR types live in the structures subpackage and
+// identifier, the transport endpoint (PipeName), and the opnum constants and
+// opnum<->name maps. NDR types live in the structures subpackage and
 // the method stubs in functions; both depend on this package, never the reverse.
 //
 // References:
@@ -23,8 +23,6 @@ package rpcinterface_123457781234abcdef000123456789ac_1_0
 // A fetched copy is kept at ms-samr.idl in the interface directory.
 
 import (
-	"fmt"
-
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
 	"github.com/TheManticoreProject/Manticore/windows/guid"
 )
@@ -101,28 +99,12 @@ const (
 	OpnumSamrAccountIsDelegatedManagedServiceAccount uint16 = 77
 )
 
-// Common NTSTATUS codes returned by samr methods ([MS-ERREF] 2.3.1). samr methods return
-// an NTSTATUS (the IDL "long" return value).
-const (
-	StatusSuccess            uint32 = 0x00000000
-	StatusMoreEntries        uint32 = 0x00000105
-	StatusSomeNotMapped      uint32 = 0x00000107
-	StatusNoMoreEntries      uint32 = 0x8000001A
-	StatusInvalidHandle      uint32 = 0xC0000008
-	StatusInvalidParameter   uint32 = 0xC000000D
-	StatusAccessDenied       uint32 = 0xC0000022
-	StatusObjectNameNotFound uint32 = 0xC0000034
-	StatusNoSuchUser         uint32 = 0xC0000064
-	StatusNoneMapped         uint32 = 0xC0000073
-	StatusNoSuchDomain       uint32 = 0xC00000DF
-	StatusNoSuchAlias        uint32 = 0xC0000151
-	StatusNoSuchGroup        uint32 = 0xC0000066
-	StatusUserExists         uint32 = 0xC0000063
-	StatusGroupExists        uint32 = 0xC0000065
-	StatusAliasExists        uint32 = 0xC0000154
-	StatusWrongPassword      uint32 = 0xC000006A
-	StatusNotSupported       uint32 = 0xC00000BB
-)
+// samr methods return an NTSTATUS as the IDL "long" return value. The codes are not
+// declared here: the whole of [MS-ERREF] 2.3.1 lives in
+// github.com/TheManticoreProject/Manticore/windows/errors/nt_status, and the method
+// stubs in functions convert their return value to nt_status.NT_STATUS to compare and
+// render it. A subset transcribed here would cover a fraction of the table and drift
+// from it.
 
 // SyntaxID returns the samr abstract syntax identifier:
 // 12345778-1234-abcd-ef00-0123456789ac, version 1.0.
@@ -131,51 +113,6 @@ func SyntaxID() syntax.SyntaxID {
 		UUID:         guid.GUID{A: 0x12345778, B: 0x1234, C: 0xabcd, D: 0xef00, E: 0x0123456789ac},
 		MajorVersion: 1,
 		MinorVersion: 0,
-	}
-}
-
-// StatusString returns a mnemonic for the documented status codes, otherwise the hex
-// value.
-func StatusString(status uint32) string {
-	switch status {
-	case StatusSuccess:
-		return "STATUS_SUCCESS"
-	case StatusMoreEntries:
-		return "STATUS_MORE_ENTRIES"
-	case StatusSomeNotMapped:
-		return "STATUS_SOME_NOT_MAPPED"
-	case StatusNoMoreEntries:
-		return "STATUS_NO_MORE_ENTRIES"
-	case StatusInvalidHandle:
-		return "STATUS_INVALID_HANDLE"
-	case StatusInvalidParameter:
-		return "STATUS_INVALID_PARAMETER"
-	case StatusAccessDenied:
-		return "STATUS_ACCESS_DENIED"
-	case StatusObjectNameNotFound:
-		return "STATUS_OBJECT_NAME_NOT_FOUND"
-	case StatusNoSuchUser:
-		return "STATUS_NO_SUCH_USER"
-	case StatusNoneMapped:
-		return "STATUS_NONE_MAPPED"
-	case StatusNoSuchDomain:
-		return "STATUS_NO_SUCH_DOMAIN"
-	case StatusNoSuchAlias:
-		return "STATUS_NO_SUCH_ALIAS"
-	case StatusNoSuchGroup:
-		return "STATUS_NO_SUCH_GROUP"
-	case StatusUserExists:
-		return "STATUS_USER_EXISTS"
-	case StatusGroupExists:
-		return "STATUS_GROUP_EXISTS"
-	case StatusAliasExists:
-		return "STATUS_ALIAS_EXISTS"
-	case StatusWrongPassword:
-		return "STATUS_WRONG_PASSWORD"
-	case StatusNotSupported:
-		return "STATUS_NOT_SUPPORTED"
-	default:
-		return fmt.Sprintf("0x%08x", status)
 	}
 }
 

--- a/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/interface_test.go
+++ b/network/dcerpc/interfaces/12345778-1234-abcd-ef00-0123456789ac/1.0/interface_test.go
@@ -1,16 +1,51 @@
 package rpcinterface_123457781234abcdef000123456789ac_1_0
 
-import "testing"
+import (
+	"testing"
 
-func TestStatusString(t *testing.T) {
-	if got := StatusString(StatusMoreEntries); got != "STATUS_MORE_ENTRIES" {
-		t.Errorf("StatusString(0x105) = %q", got)
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
+)
+
+// TestReturnCodesResolveThroughNTStatus pins that the status codes [MS-SAMR]
+// documents for these methods resolve through the shared [MS-ERREF] table, which
+// is what the method stubs in functions render with now that this package carries
+// no subset of its own.
+func TestReturnCodesResolveThroughNTStatus(t *testing.T) {
+	cases := map[nt_status.NT_STATUS]string{
+		nt_status.NT_STATUS_SUCCESS:               "NT_STATUS_SUCCESS",
+		nt_status.NT_STATUS_MORE_ENTRIES:          "NT_STATUS_MORE_ENTRIES",
+		nt_status.NT_STATUS_SOME_NOT_MAPPED:       "NT_STATUS_SOME_NOT_MAPPED",
+		nt_status.NT_STATUS_NO_MORE_ENTRIES:       "NT_STATUS_NO_MORE_ENTRIES",
+		nt_status.NT_STATUS_INVALID_HANDLE:        "NT_STATUS_INVALID_HANDLE",
+		nt_status.NT_STATUS_INVALID_PARAMETER:     "NT_STATUS_INVALID_PARAMETER",
+		nt_status.NT_STATUS_ACCESS_DENIED:         "NT_STATUS_ACCESS_DENIED",
+		nt_status.NT_STATUS_OBJECT_NAME_NOT_FOUND: "NT_STATUS_OBJECT_NAME_NOT_FOUND",
+		nt_status.NT_STATUS_NO_SUCH_USER:          "NT_STATUS_NO_SUCH_USER",
+		nt_status.NT_STATUS_NONE_MAPPED:           "NT_STATUS_NONE_MAPPED",
+		nt_status.NT_STATUS_NO_SUCH_DOMAIN:        "NT_STATUS_NO_SUCH_DOMAIN",
+		nt_status.NT_STATUS_NO_SUCH_ALIAS:         "NT_STATUS_NO_SUCH_ALIAS",
+		nt_status.NT_STATUS_NO_SUCH_GROUP:         "NT_STATUS_NO_SUCH_GROUP",
+		nt_status.NT_STATUS_USER_EXISTS:           "NT_STATUS_USER_EXISTS",
+		nt_status.NT_STATUS_GROUP_EXISTS:          "NT_STATUS_GROUP_EXISTS",
+		nt_status.NT_STATUS_ALIAS_EXISTS:          "NT_STATUS_ALIAS_EXISTS",
+		nt_status.NT_STATUS_WRONG_PASSWORD:        "NT_STATUS_WRONG_PASSWORD",
+		nt_status.NT_STATUS_NOT_SUPPORTED:         "NT_STATUS_NOT_SUPPORTED",
 	}
-	if got := StatusString(StatusSuccess); got != "STATUS_SUCCESS" {
-		t.Errorf("StatusString(0) = %q", got)
+
+	for status, want := range cases {
+		if got := status.String(); got != want {
+			t.Errorf("0x%08X renders as %q, want %q", uint32(status), got, want)
+		}
 	}
-	if got := StatusString(0x12345678); got != "0x12345678" {
-		t.Errorf("StatusString(unknown) = %q, want hex", got)
+
+	// A status this interface has never returned still renders, where the
+	// package's own subset reported an undecoded hex value for anything outside
+	// the 18 codes above.
+	if got := nt_status.NT_STATUS_LOGON_FAILURE.String(); got != "NT_STATUS_LOGON_FAILURE" {
+		t.Errorf("a status outside the old subset renders as %q", got)
+	}
+	if got := nt_status.NT_STATUS(0x12345678).String(); got != "0x12345678" {
+		t.Errorf("an undefined status renders as %q, want the hex form", got)
 	}
 }
 


### PR DESCRIPTION
### Linked Issue
`Closes #1201`

### Root Cause
SPNEGO was implemented for the two-leg NTLM case, which completes without any integrity at the negotiation layer. The `mechListMIC` field was declared on both `NegTokenInit` and `NegTokenResp`, marshalled when non-empty and parsed on receipt — everything except the computation existed — so the field was structurally supported and never populated. The mech list a client advertised therefore travelled unauthenticated.

### Fix Description
Compute the MIC as RFC 4178 section 5 specifies: `GSS_GetMIC` over the DER encoding of the `MechTypeList` from the `NegTokenInit`, taken under the security context the mechanism just established.

Three details carry the correctness of this:

1. **The signed input excludes the context tag.** RFC 4178 states the message is the DER encoding of the value of type `MechTypeList`, and *not* the DER encoding of the type `[0] MechTypeList`. Including the `0xA0` wrapper that surrounds the field inside a `NegTokenInit` would make every MIC disagree with the peer's. `MarshalMechTypeList` produces the bare `SEQUENCE OF MechType`, and a test asserts the first byte is `0x30` and not `0xA0`.

2. **The bytes advertised are retained, not re-encoded.** `AuthContext.MechListDER` holds what actually went out, so the MIC cannot end up covering a different encoding of the same list.

3. **The MIC is an NTLM per-message signature.** For NTLM it is an `NTLMSSP_MESSAGE_SIGNATURE` ([MS-NLMP] 3.4.4) with the client signing key at sequence number 0 — the first message protected on the new session — and with the checksum additionally encrypted by the sealing handle, since key exchange is now negotiated. `crypto/spnego/ntlm/security` already implements exactly this against the published GSS_WrapEx vectors, so no new cryptography is introduced here; this reuses it.

`VerifyServerMechListMIC` provides the receiving half, checking the server's MIC over the same list under the server signing key.

Emitting no MIC remains valid and is the behaviour whenever there is nothing to key one under — no session key derived, or no mech list recorded. Likewise an absent MIC from the server verifies trivially: RFC 4178 leaves the field optional, and both lab hosts omit it today.

### How Verified
**Runtime, against two live Windows hosts**, both with SMB signing required — which matters, because the same session key that keys the MIC also keys SMB signing, so a wrong key fails every subsequent request rather than passing quietly.

Windows Server 2025, SMB 3.1.1:

```
session SigningActive = true
session key length    = 16
tree connect IPC$ OK (signed round trip)
tree disconnect + logoff OK
```

Windows Server 2012 R2, SMB1:

```
session established, signing active = true
tree connect IPC$ OK
tree disconnect + logoff OK
```

**The dependent case.** This change is what unblocks #1198. With the NTLM MIC enabled experimentally *on top of* this branch, Windows Server 2025 now completes the exchange:

```
session SigningActive = true
tree connect IPC$ OK (signed round trip)
```

Previously that same NTLM MIC produced `MORE_PROCESSING_REQUIRED`, with the DC answering `accept-incomplete` and its own `mechListMIC` — it was waiting for this. That experiment is *not* part of this diff; #1198 will be a separate change on top, now that its blocker is resolved.

`go build ./...`, `go vet ./crypto/... ./network/smb/...` and `go test ./crypto/... ./network/smb/...` are clean.

### Test Coverage
**Added** — `crypto/spnego/mechlistmic_test.go`:
- `TestMarshalMechTypeListOmitsTheContextTag` — guards the single detail most likely to be got wrong, asserting the encoding starts with `0x30` and not `0xA0`.
- `TestComputeMechListMICIsAnNTLMSignature` — the MIC is 16 bytes, version 1, sequence number 0, and deterministic for a given key and list.
- `TestComputeMechListMICCoversTheMechList` — a different mech list yields a different MIC. Without this, a MIC that ignored its input would pass every other test here while protecting nothing.
- `TestComputeMechListMICWithoutASessionIsSkipped` — no key or no list yields no MIC and no error, so mechanisms that derive no key still complete.
- `TestVerifyServerMechListMICAcceptsAbsentAndRejectsWrong` — absent is fine, wrong is an error.

### Scope of Change
- **Files changed:** `crypto/spnego/mechlistmic.go` (new), `crypto/spnego/mechlistmic_test.go` (new), `crypto/spnego/authcontext.go`, `crypto/spnego/challenge.go`, `crypto/spnego/negotiate.go`, `crypto/spnego/negtokeninit.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Every NTLM-over-SPNEGO authentication now carries an extra optional field in its final token. A server that ignores `mechListMIC` is unaffected; a server that checks it now gets a MIC that verifies. Both lab hosts accept it over SMB1 and SMB 3.1.1. The failure mode of a wrong MIC would be an authentication refusal, which is loud rather than silent.

### Notes
Two parts of #1201 are deliberately not implemented here, because nothing observed requires them and neither can be exercised against the available hosts: acting on `negState` `request-mic`, and running a third session-setup leg. Both lab servers complete in two legs once the MIC accompanies the AUTHENTICATE. The issue notes them as gaps; if a server is later found that demands `request-mic`, that is a further change with a reproducible case behind it rather than speculative state-machine work now.