### PR TITLE
Emit the NTLM AUTHENTICATE MIC (Fixes #1198)

### DIFF
--- a/crypto/spnego/ntlm/avpair/avid.go
+++ b/crypto/spnego/ntlm/avpair/avid.go
@@ -63,6 +63,21 @@ func (id AvId) Compare(other AvId) bool {
 }
 
 // String returns a human-readable name for a given AV ID.
+// Values carried by an MsvAvFlags AV_PAIR ([MS-NLMP] 2.2.2.1).
+const (
+	// MsvAvFlagConstrainedAuth indicates the account authentication is constrained.
+	MsvAvFlagConstrainedAuth uint32 = 0x00000001
+
+	// MsvAvFlagMICPresent indicates the client is providing message integrity in
+	// the MIC field of the AUTHENTICATE_MESSAGE. A server detects a MIC by this
+	// bit ([MS-NLMP] 3.2.5.1.2).
+	MsvAvFlagMICPresent uint32 = 0x00000002
+
+	// MsvAvFlagUntrustedSPN indicates the target SPN was generated from an
+	// untrusted source.
+	MsvAvFlagUntrustedSPN uint32 = 0x00000004
+)
+
 func (id AvId) String() string {
 	switch id {
 	case MsvAvEOL:

--- a/crypto/spnego/ntlm/message/authenticate/authenticate.go
+++ b/crypto/spnego/ntlm/message/authenticate/authenticate.go
@@ -196,12 +196,6 @@ func newAuthenticateMessage(challenge *challenge.ChallengeMessage, username, pas
 	if v2 != nil {
 		// Use NTLMv2 (MS-NLMP 3.3.2)
 
-		// Prepare TargetInfo for the blob: add the MsvAvTargetName (SPN) AVPair, as
-		// the Windows client does. This server (Server 2016, signing required)
-		// requires the SPN rather than an MsvAvFlags MIC, so no MIC is emitted.
-		blobTargetInfo := targetinfo.BuildBlobTargetInfo(challenge.TargetInfo)
-		msg.NeedsMIC = false
-
 		// Use server's MsvAvTimestamp when present; otherwise derive current Windows FILETIME
 		timestamp := targetinfo.GetTimestamp(challenge.TargetInfo)
 		serverSuppliedTimestamp := len(timestamp) == 8
@@ -210,6 +204,19 @@ func newAuthenticateMessage(challenge *challenge.ChallengeMessage, username, pas
 			timestamp = make([]byte, 8)
 			binary.LittleEndian.PutUint64(timestamp, windowsFiletime)
 		}
+
+		// A MIC binds the NEGOTIATE and CHALLENGE to this AUTHENTICATE. It is emitted
+		// whenever the server supplied an MsvAvTimestamp — the same condition under
+		// which MS-NLMP 3.1.5.1.2 zeroes the LM response, and the signal that the
+		// server is recent enough to verify one.
+		msg.NeedsMIC = serverSuppliedTimestamp
+
+		// Prepare TargetInfo for the blob: the MsvAvTargetName (SPN) AVPair and the
+		// channel-bindings pair as the Windows client sends, plus the MsvAvFlags
+		// MIC-present bit when a MIC will follow. All are added before the NT
+		// response is computed, so they are covered by the NTProofStr as well as by
+		// the MIC.
+		blobTargetInfo := targetinfo.BuildBlobTargetInfo(challenge.TargetInfo, msg.NeedsMIC)
 
 		var ntProofStr []byte
 		msg.NtChallengeResponse, ntProofStr, err = v2.ComputeNTChallengeResponse(timestamp, blobTargetInfo)

--- a/crypto/spnego/ntlm/message/authenticate/mic_test.go
+++ b/crypto/spnego/ntlm/message/authenticate/mic_test.go
@@ -1,0 +1,155 @@
+package authenticate_test
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+	"time"
+
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/avpair"
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/message/authenticate"
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/message/challenge"
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/message/negotiate/flags"
+	"github.com/TheManticoreProject/Manticore/crypto/spnego/ntlm/targetinfo"
+)
+
+// micChallenge builds a CHALLENGE with a server TargetInfo, carrying an
+// MsvAvTimestamp when withTimestamp is set — the condition under which a Windows
+// client emits a MIC.
+func micChallenge(t *testing.T, withTimestamp bool) *challenge.ChallengeMessage {
+	t.Helper()
+
+	var ts []byte
+	if withTimestamp {
+		ts = make([]byte, 8)
+		binary.LittleEndian.PutUint64(ts, (uint64(time.Now().Unix())+116444736000)*10000000)
+	}
+	info, err := targetinfo.BuildServerTargetInfo("DC01", "TMP", "dc01.tmp.local", "tmp.local", ts)
+	if err != nil {
+		t.Fatalf("BuildServerTargetInfo: %v", err)
+	}
+
+	msg := &challenge.ChallengeMessage{
+		NegotiateFlags: flags.NTLMSSP_NEGOTIATE_UNICODE |
+			flags.NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY |
+			flags.NTLMSSP_NEGOTIATE_TARGET_INFO,
+		TargetInfo: info,
+	}
+	copy(msg.ServerChallenge[:], []byte{1, 2, 3, 4, 5, 6, 7, 8})
+	return msg
+}
+
+// avPairValue walks a TargetInfo and returns the value of the first pair with id.
+func avPairValue(t *testing.T, info []byte, id avpair.AvId) ([]byte, bool) {
+	t.Helper()
+
+	for i := 0; i+4 <= len(info); {
+		current := avpair.AvId(binary.LittleEndian.Uint16(info[i : i+2]))
+		avLen := int(binary.LittleEndian.Uint16(info[i+2 : i+4]))
+		if i+4+avLen > len(info) {
+			return nil, false
+		}
+		if current == id {
+			return info[i+4 : i+4+avLen], true
+		}
+		if current == avpair.MsvAvEOL {
+			return nil, false
+		}
+		i += 4 + avLen
+	}
+	return nil, false
+}
+
+// TestAuthenticateSignalsAndCarriesAMIC guards the defect: NeedsMIC was hardcoded
+// false, so the MsvAvFlags pair was never added and the MIC never computed. A
+// server detects a MIC solely by MsvAvFlags bit 0x2 ([MS-NLMP] 3.2.5.1.2), so the
+// flag and the field have to agree or the MIC is ignored.
+func TestAuthenticateSignalsAndCarriesAMIC(t *testing.T) {
+	msg, err := authenticate.CreateAuthenticateMessage(
+		micChallenge(t, true), "Administrator", "pass", "TMP", "WORKSTATION")
+	if err != nil {
+		t.Fatalf("CreateAuthenticateMessage: %v", err)
+	}
+
+	if !msg.NeedsMIC {
+		t.Fatal("a CHALLENGE carrying MsvAvTimestamp produced no MIC")
+	}
+
+	// The NTLMv2 response is NTProofStr(16) followed by the blob, whose TargetInfo
+	// must now carry MsvAvFlags with the MIC-present bit.
+	if len(msg.NtChallengeResponse) <= 16 {
+		t.Fatalf("NtChallengeResponse is %d bytes, too short to hold a blob", len(msg.NtChallengeResponse))
+	}
+	blob := msg.NtChallengeResponse[16:]
+	// The blob header is 28 bytes before its TargetInfo (MS-NLMP 2.2.2.7).
+	if len(blob) <= 28 {
+		t.Fatalf("NTLMv2 blob is %d bytes, too short to hold a TargetInfo", len(blob))
+	}
+	value, ok := avPairValue(t, blob[28:], avpair.MsvAvFlags)
+	if !ok {
+		t.Fatal("the NTLMv2 blob carries no MsvAvFlags pair, so a server will not look for a MIC")
+	}
+	if len(value) != 4 {
+		t.Fatalf("MsvAvFlags value is %d bytes, want 4", len(value))
+	}
+	if got := binary.LittleEndian.Uint32(value); got&avpair.MsvAvFlagMICPresent == 0 {
+		t.Errorf("MsvAvFlags = %#08x, missing the MIC-present bit %#08x", got, avpair.MsvAvFlagMICPresent)
+	}
+
+	// The MIC itself is computed by the caller that holds the NEGOTIATE bytes, so
+	// here it is still zero; what must be true now is that Marshal reserves it.
+	raw, err := msg.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if got := binary.LittleEndian.Uint32(raw[32:36]); got != 88 {
+		t.Errorf("first payload field begins at offset %d, want 88 (64 fixed + 8 Version + 16 MIC)", got)
+	}
+}
+
+// TestAuthenticateWithoutTimestampCarriesNoMIC pins the other branch: a server
+// that supplies no MsvAvTimestamp gets no MsvAvFlags pair and no reserved MIC.
+func TestAuthenticateWithoutTimestampCarriesNoMIC(t *testing.T) {
+	msg, err := authenticate.CreateAuthenticateMessage(
+		micChallenge(t, false), "Administrator", "pass", "TMP", "WORKSTATION")
+	if err != nil {
+		t.Fatalf("CreateAuthenticateMessage: %v", err)
+	}
+
+	if msg.NeedsMIC {
+		t.Error("a CHALLENGE without MsvAvTimestamp produced a MIC")
+	}
+	blob := msg.NtChallengeResponse[16:]
+	if _, ok := avPairValue(t, blob[28:], avpair.MsvAvFlags); ok {
+		t.Error("MsvAvFlags was added although no MIC will be carried")
+	}
+}
+
+// TestComputeMICChangesTheMessage checks the MIC is actually written and depends
+// on the handshake messages it covers.
+func TestComputeMICChangesTheMessage(t *testing.T) {
+	msg, err := authenticate.CreateAuthenticateMessage(
+		micChallenge(t, true), "Administrator", "pass", "TMP", "WORKSTATION")
+	if err != nil {
+		t.Fatalf("CreateAuthenticateMessage: %v", err)
+	}
+
+	negotiate := []byte("NTLMSSP\x00\x01\x00\x00\x00pretend-negotiate")
+	challengeBytes := []byte("NTLMSSP\x00\x02\x00\x00\x00pretend-challenge")
+
+	if err := msg.ComputeMIC(negotiate, challengeBytes); err != nil {
+		t.Fatalf("ComputeMIC: %v", err)
+	}
+	first := msg.MIC
+	if first == ([16]byte{}) {
+		t.Fatal("ComputeMIC left the MIC zeroed")
+	}
+
+	// A different NEGOTIATE must produce a different MIC, or it binds nothing.
+	if err := msg.ComputeMIC([]byte("NTLMSSP\x00\x01\x00\x00\x00different"), challengeBytes); err != nil {
+		t.Fatalf("ComputeMIC (second): %v", err)
+	}
+	if bytes.Equal(first[:], msg.MIC[:]) {
+		t.Error("the MIC is unchanged by a different NEGOTIATE message, so it binds nothing")
+	}
+}

--- a/crypto/spnego/ntlm/message/authenticate/version_field_test.go
+++ b/crypto/spnego/ntlm/message/authenticate/version_field_test.go
@@ -60,8 +60,38 @@ func TestAuthenticateCarriesVersion(t *testing.T) {
 		t.Error("Version.ProductBuild is 0, which is not a real Windows build")
 	}
 
-	// The payload must begin after the 64-byte fixed part plus the 8-byte Version,
-	// which is where a server reads it from.
+	// The payload begins after the 64-byte fixed part, the 8-byte Version and,
+	// when one is carried, the 16-byte MIC ([MS-NLMP] 2.2.1.3). This challenge
+	// supplies an MsvAvTimestamp, so a MIC is emitted and the payload starts at 88.
+	assertFirstPayloadOffset(t, msg, 88)
+}
+
+// TestAuthenticateVersionOffsetWithoutMIC covers the other layout: a server that
+// supplies no MsvAvTimestamp gets no MIC, and the payload then starts at 72.
+func TestAuthenticateVersionOffsetWithoutMIC(t *testing.T) {
+	ch := verChallenge(t)
+	// Rebuild the TargetInfo without a timestamp, which is what suppresses the MIC.
+	info, err := targetinfo.BuildServerTargetInfo("DC01", "TMP", "dc01.tmp.local", "tmp.local", nil)
+	if err != nil {
+		t.Fatalf("BuildServerTargetInfo: %v", err)
+	}
+	ch.TargetInfo = info
+
+	msg, err := authenticate.CreateAuthenticateMessage(ch, "Administrator", "pass", "TMP", "WORKSTATION")
+	if err != nil {
+		t.Fatalf("CreateAuthenticateMessage: %v", err)
+	}
+	if msg.NeedsMIC {
+		t.Fatal("a challenge without MsvAvTimestamp produced a MIC")
+	}
+	assertFirstPayloadOffset(t, msg, 72)
+}
+
+// assertFirstPayloadOffset marshals the message and checks where the payload
+// begins, which is where a server reads it from.
+func assertFirstPayloadOffset(t *testing.T, msg *authenticate.AuthenticateMessage, want uint32) {
+	t.Helper()
+
 	raw, err := msg.Marshal()
 	if err != nil {
 		t.Fatalf("Marshal: %v", err)
@@ -71,7 +101,7 @@ func TestAuthenticateCarriesVersion(t *testing.T) {
 	}
 	// DomainNameFields.BufferOffset sits at offset 32 of the fixed part and is the
 	// first payload field in the canonical layout this marshaller emits.
-	if got := binary.LittleEndian.Uint32(raw[32:36]); got != 72 {
-		t.Errorf("first payload field begins at offset %d, want 72 (64-byte fixed part plus the 8-byte Version)", got)
+	if got := binary.LittleEndian.Uint32(raw[32:36]); got != want {
+		t.Errorf("first payload field begins at offset %d, want %d", got, want)
 	}
 }

--- a/crypto/spnego/ntlm/targetinfo/channel_bindings_test.go
+++ b/crypto/spnego/ntlm/targetinfo/channel_bindings_test.go
@@ -41,7 +41,7 @@ func TestBlobCarriesChannelBindings(t *testing.T) {
 		t.Fatalf("BuildServerTargetInfo: %v", err)
 	}
 
-	blob := targetinfo.BuildBlobTargetInfo(serverInfo)
+	blob := targetinfo.BuildBlobTargetInfo(serverInfo, false)
 	offsets, values := avPairOffsets(t, blob)
 
 	cb, ok := values[avpair.MsvAvChannelBindings]
@@ -85,7 +85,7 @@ func TestBlobChannelBindingsPrecedeTargetName(t *testing.T) {
 		t.Fatalf("BuildServerTargetInfo: %v", err)
 	}
 
-	offsets, _ := avPairOffsets(t, targetinfo.BuildBlobTargetInfo(serverInfo))
+	offsets, _ := avPairOffsets(t, targetinfo.BuildBlobTargetInfo(serverInfo, false))
 
 	spn, ok := offsets[avpair.MsvAvTargetName]
 	if !ok {

--- a/crypto/spnego/ntlm/targetinfo/targetinfo.go
+++ b/crypto/spnego/ntlm/targetinfo/targetinfo.go
@@ -82,7 +82,7 @@ const channelBindingsLength = 16
 // what the Windows client sends; modern Windows servers require the SPN in the
 // AUTHENTICATE's NTLMv2 AVPairs and reject the authentication (STATUS_INVALID_PARAMETER)
 // when it is absent.
-func BuildBlobTargetInfo(targetInfo []byte) []byte {
+func BuildBlobTargetInfo(targetInfo []byte, micPresent bool) []byte {
 	// Build the SMB SPN "cifs/<DnsComputerName>" from the DNS computer name AVPair,
 	// in UTF-16LE (DnsComputerName is already UTF-16LE on the wire).
 	var targetName []byte
@@ -99,6 +99,20 @@ func BuildBlobTargetInfo(targetInfo []byte) []byte {
 		avLen := binary.LittleEndian.Uint16(targetInfo[i+2 : i+4])
 
 		if currentID == avpair.MsvAvEOL {
+			// Insert MsvAvFlags before EOL when the AUTHENTICATE will carry a MIC:
+			// that bit is how a server detects one (MS-NLMP 3.2.5.1.2). It is added
+			// before the NT response is computed, so it is covered by the NTProofStr
+			// as well as by the MIC itself.
+			if micPresent {
+				hdr := make([]byte, 4)
+				binary.LittleEndian.PutUint16(hdr[0:2], uint16(avpair.MsvAvFlags))
+				binary.LittleEndian.PutUint16(hdr[2:4], 4)
+				value := make([]byte, 4)
+				binary.LittleEndian.PutUint32(value, avpair.MsvAvFlagMICPresent)
+				result = append(result, hdr...)
+				result = append(result, value...)
+			}
+
 			// Insert MsvAvChannelBindings before EOL. A client with no application-
 			// supplied channel bindings sends the pair with an all-zero 16-byte
 			// value, which is what a Windows client emits; omitting the pair

--- a/crypto/spnego/ntlm/targetinfo/targetinfo_test.go
+++ b/crypto/spnego/ntlm/targetinfo/targetinfo_test.go
@@ -19,5 +19,5 @@ func TestBuildBlobTargetInfoRejectsOversizedAVPairLength(t *testing.T) {
 		}
 	}()
 
-	_ = targetinfo.BuildBlobTargetInfo(malformed)
+	_ = targetinfo.BuildBlobTargetInfo(malformed, true)
 }

--- a/network/smb/smb_v10/client/session.go
+++ b/network/smb/smb_v10/client/session.go
@@ -112,6 +112,13 @@ func (s *Session) SessionSetup() error {
 	// the share-level and plaintext paths complete in a single round trip.
 	useExtendedSecurity := false
 
+	// The authentication context spans both steps. State the exchange accumulates
+	// in step 1 — the NEGOTIATE message the AUTHENTICATE MIC is computed over, and
+	// the mech list its mechListMIC covers — is only available to step 2 if the
+	// same context is carried across, so it is declared here rather than in either
+	// branch.
+	var authCtx *spnego.AuthContext
+
 	// Check if we're using share level access control
 	if s.Client.Connection.Server.SecurityMode.SupportsShareLevelAccessControl() {
 		// Share level access control is required by the server
@@ -144,7 +151,7 @@ func (s *Session) SessionSetup() error {
 
 			useUnicode := s.Client.Connection.Server.Capabilities&capabilities.CAP_UNICODE == capabilities.CAP_UNICODE
 
-			authCtx := spnego.NewAuthContext(
+			authCtx = spnego.NewAuthContext(
 				spnego.AuthTypeNTLM,
 				s.Credentials.Domain,
 				s.Credentials.Username,
@@ -274,18 +281,12 @@ func (s *Session) SessionSetup() error {
 	// Server supports challenge/response authentication
 	// Determine authentication type based on policies
 
-	useUnicode := s.Client.Connection.Server.Capabilities&capabilities.CAP_UNICODE == capabilities.CAP_UNICODE
-
-	authCtx := spnego.NewAuthContext(
-		spnego.AuthTypeNTLM,
-		s.Credentials.Domain,
-		s.Credentials.Username,
-		s.Credentials.Password,
-		s.Client.Workstation,
-		useUnicode,
-	)
-	// Pass-the-hash: when an NT hash is supplied, authenticate from it instead of the password.
-	authCtx.NTHash = s.Credentials.GetNTHash()
+	// Step 2 continues the context step 1 started. Building a second one here would
+	// discard the retained NEGOTIATE message and mech list, leaving the AUTHENTICATE
+	// unable to compute either MIC.
+	if authCtx == nil {
+		return fmt.Errorf("session setup reached the authenticate step without an authentication context")
+	}
 
 	requestStep2Msg := message.NewMessage()
 	requestStep2Msg.Header.Command = codes.SMB_COM_SESSION_SETUP_ANDX


### PR DESCRIPTION
### Linked Issue
`Closes #1198`

### Root Cause
Two independent causes, and the second only became visible once the first was fixed.

**1. The MIC was switched off.** `NeedsMIC` was assigned a hardcoded `false` on every path, so `BuildBlobTargetInfo` never added an `MsvAvFlags` pair, `Marshal` never reserved the 16 MIC bytes, and `ComputeMIC` — already written, already called from `crypto/spnego/challenge.go` — was unreachable. A server detects a MIC solely by `MsvAvFlags` bit `0x2` ([MS-NLMP] 3.2.5.1.2), so the flag and the field have to be emitted together or the MIC is ignored.

**2. The SMB 1.0 client threw away its authentication context between steps.** Step 2 of `SessionSetup` built a *second* `AuthContext`, so everything step 1 accumulated was discarded. With the MIC enabled this surfaced immediately as a hard failure:

```
session setup: failed to process challenge token:
  cannot compute NTLM MIC: NEGOTIATE message not retained
```

That same loss had a quieter consequence worth stating plainly: **the mechListMIC added in #1201 was never emitted over SMB1.** `MechListDER` was recorded on the discarded context, so `computeMechListMIC` saw an empty list and returned nil. The SMB1 run in that PR therefore demonstrated only that nothing regressed, not that a MIC went out — the claim of SMB1 validation there was too strong. One context now spans both steps, which is what makes either MIC reachable over SMB1 at all.

### Fix Description
Emit the `MsvAvFlags` MIC-present bit and the MIC whenever the server supplied an `MsvAvTimestamp` — the same condition under which [MS-NLMP] 3.1.5.1.2 zeroes the LM response, and the signal that the server is recent enough to verify one. The pair is added to the blob *before* the NT response is computed, so it is covered by the `NTProofStr` as well as by the MIC itself.

On the SMB1 side, `authCtx` is declared once alongside `useExtendedSecurity` and assigned in step 1, and step 2 continues it rather than constructing a replacement.

### How Verified
**Runtime, against two live Windows hosts**, both with signing required.

Windows Server 2025, SMB 3.1.1 — full operation matrix:

```
QueryDirectory            107 entries
QuerySecurityDescriptor   168 bytes
Read / Write              200000 bytes across a multi-credit request
MultiCreditRead           1048576 bytes
session SigningActive = true
```

Windows Server 2012 R2, SMB1:

```
session established, signing active = true
listed 86 entries
win.ini attributes = 0x20
FileSystemName = "NTFS", attributes = 0x00c700ff
tree disconnect + logoff OK
```

`signing active = true` on both is what makes these real checks: the SMB signing key is derived from the same session key the MIC is keyed on, so a wrong MIC or a broken context fails every subsequent request rather than passing quietly.

**On the dependency.** This was blocked until #1201. With a MIC but no mechListMIC, the DC answered `MORE_PROCESSING_REQUIRED`, returning `accept-incomplete` with its own `mechListMIC` and holding the context open. It also depended on #1199: without the Version field the MIC lands at offset 64 instead of 72 and the DC rejects the layout outright.

**Tests.** `go build ./...`, `go vet ./crypto/... ./network/smb/...`, `go test ./crypto/... ./network/smb/...` all clean.

### Test Coverage
**Added** — `crypto/spnego/ntlm/message/authenticate/mic_test.go`:
- `TestAuthenticateSignalsAndCarriesAMIC` — walks into the NTLMv2 blob's TargetInfo and asserts the `MsvAvFlags` pair is present with bit `0x2`, then that `Marshal` places the payload at 88. Checking the flag alone would pass while a server still ignored the MIC.
- `TestAuthenticateWithoutTimestampCarriesNoMIC` — no timestamp, no flag, no reserved MIC.
- `TestComputeMICChangesTheMessage` — the MIC is written and *changes* when the NEGOTIATE it covers changes, which is the property that makes it bind the handshake rather than merely occupy 16 bytes.

**Modified** — `version_field_test.go`. Its offset assertion said 72, correct only without a MIC. It now covers both layouts via a shared helper: 72 with Version alone, 88 with Version and MIC. This is a strengthening, not a relaxation — the previous test could not have distinguished a missing MIC from a correct one.

### Scope of Change
- **Files changed:** `crypto/spnego/ntlm/message/authenticate/authenticate.go`, `mic_test.go` (new), `version_field_test.go`, `crypto/spnego/ntlm/targetinfo/targetinfo.go`, `targetinfo_test.go`, `channel_bindings_test.go`, `crypto/spnego/ntlm/avpair/avid.go`, `network/smb/smb_v10/client/session.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none. The `BuildBlobTargetInfo` signature gains a parameter, which is why its two test call sites change; the SMB1 session-setup edit is required for the fix to work at all on that path.

### Risk and Rollout
Every NTLM authentication against a timestamp-supplying server — in practice every Windows server — now carries an extra AV pair and 16 extra bytes, and the payload offsets shift by 16. That is the largest blast radius of this series, which is why it is validated on both an SMB1 and an SMB 3.1.1 Windows host with signing required rather than by unit test alone. A server that does not supply a timestamp takes the previous path byte for byte.

### Notes
`avpair` gains named constants for the three `MsvAvFlags` values; only the MIC-present bit is used. The two parts of #1201 left unimplemented — acting on `request-mic`, and a third session-setup leg — remain unnecessary: both hosts complete in two legs once the MIC accompanies the AUTHENTICATE.