### PR TITLE
Carry SMB1 client paths as Unicode when the server negotiated it (Fixes #1234)

### DIFF
--- a/network/smb/smb_v10/client/file.go
+++ b/network/smb/smb_v10/client/file.go
@@ -3,6 +3,7 @@ package client
 import (
 	"encoding/hex"
 	"fmt"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/capabilities"
 
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
@@ -35,6 +36,15 @@ func fileIODump(label string, data []byte) {
 	}
 }
 
+// useUnicode reports whether names must be carried as UTF-16LE, which is so
+// whenever the server advertised CAP_UNICODE in its NEGOTIATE response.
+func (c *Client) useUnicode() bool {
+	if c.Connection == nil || c.Connection.Server == nil {
+		return false
+	}
+	return c.Connection.Server.Capabilities&capabilities.CAP_UNICODE == capabilities.CAP_UNICODE
+}
+
 // newFileIOMessage builds a message pre-populated with the header fields common to
 // every file-I/O command issued on the currently selected tree/session.
 func (c *Client) newFileIOMessage(command codes.CommandCode) *message.Message {
@@ -42,6 +52,14 @@ func (c *Client) newFileIOMessage(command codes.CommandCode) *message.Message {
 	msg.Header.Command = command
 	msg.Header.Flags = flags.Flags(flags.FLAGS_CANONICALIZED_PATHS | flags.FLAGS_CASE_INSENSITIVE)
 	msg.Header.Flags2 = flags2.Flags2(flags2.FLAGS2_NT_STATUS_ERROR_CODES | flags2.FLAGS2_LONG_NAMES_ALLOWED)
+	// Carry names as Unicode whenever the server negotiated it. Dropping the flag
+	// after authentication puts every path on the wire as OEM, which cannot
+	// represent a non-ASCII name: the bytes round-trip through SMB1 because both
+	// directions treat them as opaque, while the name the server actually stores
+	// is not the one that was asked for.
+	if c.useUnicode() {
+		msg.Header.Flags2 |= flags2.FLAGS2_UNICODE
+	}
 	msg.Header.SetPID(msg.Header.GetPID())
 	msg.Header.MID = c.Connection.MaxMpxCount
 	msg.Header.TID = c.Session.TreeID
@@ -111,10 +129,12 @@ func (c *Client) OpenFile(path string, desiredAccess, shareAccess, createDisp, c
 	cmd.ImpersonationLevel = types.ULONG(0x00000002)
 	// FILE_ATTRIBUTE_NORMAL
 	cmd.ExtFileAttributes = types.SMB_EXT_FILE_ATTR(0x00000080)
-	if err := cmd.FileName.SetString(smbPath); err != nil {
+	if err := cmd.FileName.SetStringWithEncoding(smbPath, c.useUnicode()); err != nil {
 		return 0, fmt.Errorf("failed to set file name: %v", err)
 	}
-	cmd.NameLength = types.USHORT(len(smbPath))
+	// NameLength counts the bytes the name occupies on the wire, which is twice
+	// the character count once the name is UTF-16LE.
+	cmd.NameLength = types.USHORT(len(cmd.FileName.Buffer))
 
 	msg.AddCommand(cmd)
 

--- a/network/smb/smb_v10/client/fileops.go
+++ b/network/smb/smb_v10/client/fileops.go
@@ -22,7 +22,7 @@ func (c *Client) DeleteFile(pattern string) error {
 
 	cmd := commands.NewDeleteRequest()
 	cmd.SearchAttributes = types.SMB_FILE_ATTRIBUTES{}
-	if err := cmd.FileName.SetString(pattern); err != nil {
+	if err := cmd.FileName.SetStringWithEncoding(pattern, c.useUnicode()); err != nil {
 		return fmt.Errorf("failed to set file name: %v", err)
 	}
 
@@ -53,10 +53,10 @@ func (c *Client) RenameFile(oldPath, newPath string) error {
 
 	cmd := commands.NewRenameRequest()
 	cmd.SearchAttributes = types.SMB_FILE_ATTRIBUTES{}
-	if err := cmd.OldFileName.SetString(oldPath); err != nil {
+	if err := cmd.OldFileName.SetStringWithEncoding(oldPath, c.useUnicode()); err != nil {
 		return fmt.Errorf("failed to set old file name: %v", err)
 	}
-	if err := cmd.NewFileName.SetString(newPath); err != nil {
+	if err := cmd.NewFileName.SetStringWithEncoding(newPath, c.useUnicode()); err != nil {
 		return fmt.Errorf("failed to set new file name: %v", err)
 	}
 
@@ -86,7 +86,7 @@ func (c *Client) CreateDirectory(path string) error {
 	msg := c.newFileIOMessage(codes.SMB_COM_CREATE_DIRECTORY)
 
 	cmd := commands.NewCreateDirectoryRequest()
-	if err := cmd.DirectoryName.SetString(path); err != nil {
+	if err := cmd.DirectoryName.SetStringWithEncoding(path, c.useUnicode()); err != nil {
 		return fmt.Errorf("failed to set directory name: %v", err)
 	}
 
@@ -116,7 +116,7 @@ func (c *Client) DeleteDirectory(path string) error {
 	msg := c.newFileIOMessage(codes.SMB_COM_DELETE_DIRECTORY)
 
 	cmd := commands.NewDeleteDirectoryRequest()
-	if err := cmd.DirectoryName.SetString(path); err != nil {
+	if err := cmd.DirectoryName.SetStringWithEncoding(path, c.useUnicode()); err != nil {
 		return fmt.Errorf("failed to set directory name: %v", err)
 	}
 
@@ -147,7 +147,7 @@ func (c *Client) CheckDirectory(path string) error {
 	msg := c.newFileIOMessage(codes.SMB_COM_CHECK_DIRECTORY)
 
 	cmd := commands.NewCheckDirectoryRequest()
-	if err := cmd.DirectoryName.SetString(path); err != nil {
+	if err := cmd.DirectoryName.SetStringWithEncoding(path, c.useUnicode()); err != nil {
 		return fmt.Errorf("failed to set directory name: %v", err)
 	}
 

--- a/network/smb/smb_v10/client/find.go
+++ b/network/smb/smb_v10/client/find.go
@@ -3,6 +3,7 @@ package client
 import (
 	"encoding/binary"
 	"fmt"
+	mutf16 "github.com/TheManticoreProject/Manticore/encoding/utf16"
 	"strings"
 	"time"
 	"unicode/utf16"
@@ -138,7 +139,7 @@ func (c *Client) ListEntries(pattern string) ([]Entry, error) {
 	}
 
 	// TRANS2_FIND_FIRST2.
-	respParams, respData, err := c.trans2(uint16(subcommands.TRANS2_FIND_FIRST2), buildFindFirst2Params(pattern), nil)
+	respParams, respData, err := c.trans2(uint16(subcommands.TRANS2_FIND_FIRST2), buildFindFirst2Params(pattern, c.useUnicode()), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -150,11 +151,11 @@ func (c *Client) ListEntries(pattern string) ([]Entry, error) {
 	searchCount := binary.LittleEndian.Uint16(respParams[2:4])
 	endOfSearch := binary.LittleEndian.Uint16(respParams[4:6])
 
-	entries := parseBothDirInfo(respData)
+	entries := parseBothDirInfo(respData, c.useUnicode())
 
 	// TRANS2_FIND_NEXT2 until the server reports end-of-search or returns nothing.
 	for endOfSearch == 0 && searchCount > 0 {
-		respParams, respData, err = c.trans2(uint16(subcommands.TRANS2_FIND_NEXT2), buildFindNext2Params(sid), nil)
+		respParams, respData, err = c.trans2(uint16(subcommands.TRANS2_FIND_NEXT2), buildFindNext2Params(sid, c.useUnicode()), nil)
 		if err != nil {
 			break
 		}
@@ -164,7 +165,7 @@ func (c *Client) ListEntries(pattern string) ([]Entry, error) {
 		searchCount = binary.LittleEndian.Uint16(respParams[0:2])
 		endOfSearch = binary.LittleEndian.Uint16(respParams[2:4])
 
-		next := parseBothDirInfo(respData)
+		next := parseBothDirInfo(respData, c.useUnicode())
 		if len(next) == 0 {
 			break
 		}
@@ -493,7 +494,7 @@ func placeTrans2Fragment(dst, run []byte, displacement int, label string) (int, 
 // Each entry may represent a file or a directory.
 // FileName is decoded as OEM/ASCII because the client issues non-Unicode requests,
 // and its SMB_STRING terminator is stripped.
-func parseBothDirInfo(data []byte) []Entry {
+func parseBothDirInfo(data []byte, unicode bool) []Entry {
 	entries := []Entry{}
 
 	for pos := 0; pos+bothDirInfoFixedSize <= len(data); {
@@ -521,10 +522,14 @@ func parseBothDirInfo(data []byte) []Entry {
 			// decoded string so a UTF-16LE name's two-byte terminator is also
 			// removed if the request ever negotiates Unicode.
 			raw := data[pos+bothDirInfoFixedSize : pos+bothDirInfoFixedSize+nameLen]
-			for len(raw) > 0 && raw[len(raw)-1] == 0x00 {
-				raw = raw[:len(raw)-1]
+			if unicode {
+				longName = decodeUTF16LE(raw)
+			} else {
+				for len(raw) > 0 && raw[len(raw)-1] == 0x00 {
+					raw = raw[:len(raw)-1]
+				}
+				longName = string(raw)
 			}
-			longName = string(raw)
 		}
 
 		entries = append(entries, Entry{
@@ -569,29 +574,44 @@ func (c *Client) findClose2(sid uint16) error {
 	return nil
 }
 
+// encodeTrans2Name renders a name for a TRANS2 parameter block in the encoding the
+// message declares, with the terminator that encoding needs.
+//
+// The names in these blocks sit at an even header-relative offset — the fixed
+// parameters ahead of them are 12 bytes for FIND_FIRST2/FIND_NEXT2 and 6 for the
+// path-information levels, on top of a parameter block the transaction aligns to
+// four — so a Unicode name needs no extra alignment byte here.
+func encodeTrans2Name(name string, unicode bool) []byte {
+	if unicode {
+		return append(mutf16.EncodeUTF16LE(name), 0x00, 0x00)
+	}
+	return append([]byte(name), 0x00)
+}
+
 // buildFindFirst2Params builds the TRANS2_FIND_FIRST2 transaction parameters.
-func buildFindFirst2Params(pattern string) []byte {
+func buildFindFirst2Params(pattern string, unicode bool) []byte {
 	b := []byte{}
 	b = binary.LittleEndian.AppendUint16(b, 0x0016) // SearchAttributes: include hidden/system/directory
 	b = binary.LittleEndian.AppendUint16(b, 512)    // SearchCount: max entries per response
 	b = binary.LittleEndian.AppendUint16(b, 0x0000) // Flags: none (the search is closed explicitly)
 	b = binary.LittleEndian.AppendUint16(b, smbFindFileBothDirectoryInfo)
 	b = binary.LittleEndian.AppendUint32(b, 0) // SearchStorageType
-	b = append(b, []byte(pattern)...)
-	b = append(b, 0x00) // null-terminated OEM pattern
+	b = append(b, encodeTrans2Name(pattern, unicode)...)
 	return b
 }
 
 // buildFindNext2Params builds the TRANS2_FIND_NEXT2 transaction parameters that
 // continue a search from the server's cursor.
-func buildFindNext2Params(sid uint16) []byte {
+func buildFindNext2Params(sid uint16, unicode bool) []byte {
 	b := []byte{}
 	b = binary.LittleEndian.AppendUint16(b, sid) // SID (search handle)
 	b = binary.LittleEndian.AppendUint16(b, 512) // SearchCount
 	b = binary.LittleEndian.AppendUint16(b, smbFindFileBothDirectoryInfo)
 	b = binary.LittleEndian.AppendUint32(b, 0)      // ResumeKey (unused; we did not request resume keys)
 	b = binary.LittleEndian.AppendUint16(b, 0x0008) // Flags: SMB_FIND_CONTINUE_FROM_LAST
-	b = append(b, 0x00)                             // FileName: empty (resume from server cursor)
+	// FileName: empty (resume from the server cursor), terminated as the
+	// declared encoding requires.
+	b = append(b, encodeTrans2Name("", unicode)...)
 	return b
 }
 

--- a/network/smb/smb_v10/client/find_internal_test.go
+++ b/network/smb/smb_v10/client/find_internal_test.go
@@ -33,7 +33,7 @@ func TestParseBothDirInfo(t *testing.T) {
 	dir := makeBothDirInfoEntry("subdir", "SUBDIR", 0, fileAttributeDirectory, tick, tick, tick, tick, uint32(bothDirInfoFixedSize+len("subdir")))
 	file := makeBothDirInfoEntry("report.txt", "REPORT~1.TXT", 4096, 0x20, tick+10_000_000, tick, tick, tick, 0)
 
-	entries := parseBothDirInfo(append(dir, file...))
+	entries := parseBothDirInfo(append(dir, file...), false)
 
 	if len(entries) != 2 {
 		t.Fatalf("got %d entries, want 2", len(entries))
@@ -64,12 +64,12 @@ func TestParseBothDirInfo(t *testing.T) {
 }
 
 func TestParseBothDirInfoEmpty(t *testing.T) {
-	if got := parseBothDirInfo(nil); len(got) != 0 {
-		t.Errorf("parseBothDirInfo(nil) = %d entries, want 0", len(got))
+	if got := parseBothDirInfo(nil, false); len(got) != 0 {
+		t.Errorf("parseBothDirInfo(nil, false) = %d entries, want 0", len(got))
 	}
 	// A truncated buffer (shorter than the fixed portion) yields no entries and no panic.
-	if got := parseBothDirInfo(make([]byte, bothDirInfoFixedSize-1)); len(got) != 0 {
-		t.Errorf("parseBothDirInfo(truncated) = %d entries, want 0", len(got))
+	if got := parseBothDirInfo(make([]byte, bothDirInfoFixedSize-1), false); len(got) != 0 {
+		t.Errorf("parseBothDirInfo(truncated, false) = %d entries, want 0", len(got))
 	}
 }
 
@@ -156,7 +156,7 @@ func TestDecodeUTF16LE(t *testing.T) {
 }
 
 func TestBuildFindFirst2Params(t *testing.T) {
-	b := buildFindFirst2Params("\\*")
+	b := buildFindFirst2Params("\\*", false)
 	// SearchAttributes, SearchCount, Flags, InformationLevel, SearchStorageType(4), pattern, NUL
 	if len(b) != 2+2+2+2+4+len("\\*")+1 {
 		t.Fatalf("unexpected length %d", len(b))
@@ -173,7 +173,7 @@ func TestBuildFindFirst2Params(t *testing.T) {
 }
 
 func TestBuildFindNext2Params(t *testing.T) {
-	b := buildFindNext2Params(0x1234)
+	b := buildFindNext2Params(0x1234, false)
 	if binary.LittleEndian.Uint16(b[0:2]) != 0x1234 {
 		t.Errorf("SID = 0x%04x, want 0x1234", binary.LittleEndian.Uint16(b[0:2]))
 	}

--- a/network/smb/smb_v10/client/find_name_test.go
+++ b/network/smb/smb_v10/client/find_name_test.go
@@ -38,7 +38,7 @@ func bothDirInfoEntry(name string, last bool, attrs uint32) []byte {
 func TestParseBothDirInfoStripsNameTerminator(t *testing.T) {
 	data := append(bothDirInfoEntry("ADFS", false, fileAttributeDirectory), bothDirInfoEntry("AppCompat", true, 0)...)
 
-	entries := parseBothDirInfo(data)
+	entries := parseBothDirInfo(data, false)
 	if len(entries) != 2 {
 		t.Fatalf("parsed %d entries, want 2", len(entries))
 	}
@@ -64,7 +64,7 @@ func TestParseBothDirInfoStripsUTF16Terminator(t *testing.T) {
 	binary.LittleEndian.PutUint32(buf[60:64], uint32(len(nameBytes)))
 	copy(buf[bothDirInfoFixedSize:], nameBytes)
 
-	entries := parseBothDirInfo(buf)
+	entries := parseBothDirInfo(buf, false)
 	if len(entries) != 1 {
 		t.Fatalf("parsed %d entries, want 1", len(entries))
 	}

--- a/network/smb/smb_v10/client/queryinfo.go
+++ b/network/smb/smb_v10/client/queryinfo.go
@@ -52,12 +52,12 @@ func (c *Client) QueryPathInformation(path string, infoLevel uint16) ([]byte, er
 		return nil, fmt.Errorf("no session established")
 	}
 
-	// Parameters: InformationLevel(2) + Reserved(4) + FileName (OEM, null-terminated).
+	// Parameters: InformationLevel(2) + Reserved(4) + FileName, in the encoding the
+	// message declares.
 	params := []byte{}
 	params = binary.LittleEndian.AppendUint16(params, infoLevel)
 	params = binary.LittleEndian.AppendUint32(params, 0) // Reserved
-	params = append(params, []byte(normalizeSMBPath(path))...)
-	params = append(params, 0x00)
+	params = append(params, encodeTrans2Name(normalizeSMBPath(path), c.useUnicode())...)
 
 	_, data, err := c.trans2(uint16(subcommands.TRANS2_QUERY_PATH_INFORMATION), params, nil)
 	if err != nil {
@@ -126,12 +126,12 @@ func (c *Client) SetPathInformation(path string, infoLevel uint16, data []byte) 
 		return fmt.Errorf("no session established")
 	}
 
-	// Parameters: InformationLevel(2) + Reserved(4) + FileName (OEM, null-terminated).
+	// Parameters: InformationLevel(2) + Reserved(4) + FileName, in the encoding the
+	// message declares.
 	params := []byte{}
 	params = binary.LittleEndian.AppendUint16(params, infoLevel)
 	params = binary.LittleEndian.AppendUint32(params, 0) // Reserved
-	params = append(params, []byte(normalizeSMBPath(path))...)
-	params = append(params, 0x00)
+	params = append(params, encodeTrans2Name(normalizeSMBPath(path), c.useUnicode())...)
 
 	_, _, err := c.trans2(uint16(subcommands.TRANS2_SET_PATH_INFORMATION), params, data)
 	return err

--- a/network/smb/smb_v10/client/tree.go
+++ b/network/smb/smb_v10/client/tree.go
@@ -3,9 +3,12 @@ package client
 import (
 	"fmt"
 
+	"github.com/TheManticoreProject/Manticore/encoding/utf16"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/commands/codes"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header/flags"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/message/header/flags2"
 	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
 )
 
@@ -25,8 +28,11 @@ func (c *Client) TreeConnect(shareName string) error {
 
 	requestMsg := message.NewMessage()
 	requestMsg.Header.Command = codes.SMB_COM_TREE_CONNECT_ANDX
-	requestMsg.Header.Flags = 0x0000
-	requestMsg.Header.Flags2 = 0x0000
+	requestMsg.Header.Flags = flags.Flags(flags.FLAGS_CANONICALIZED_PATHS | flags.FLAGS_CASE_INSENSITIVE)
+	requestMsg.Header.Flags2 = flags2.Flags2(flags2.FLAGS2_NT_STATUS_ERROR_CODES | flags2.FLAGS2_LONG_NAMES_ALLOWED)
+	if c.useUnicode() {
+		requestMsg.Header.Flags2 |= flags2.FLAGS2_UNICODE
+	}
 	requestMsg.Header.SetPID(requestMsg.Header.GetPID())
 	requestMsg.Header.MID = c.Connection.MaxMpxCount
 	requestMsg.Header.TID = 65535
@@ -37,8 +43,16 @@ func (c *Client) TreeConnect(shareName string) error {
 	treeConnectCmd.Password = []types.UCHAR{}
 	treeConnectCmd.PasswordLength = types.USHORT(0x0000)
 
-	uncPath := "\\\\" + c.Connection.Server.Host.String() + "\\" + shareName + "\x00"
-	treeConnectCmd.Path = []types.UCHAR(uncPath)
+	// The share path is a name like any other: it must be carried in the encoding
+	// the header declares. With a one-byte null password ahead of it the path
+	// begins at header offset 44, which is already even, so a Unicode path needs
+	// no alignment byte here.
+	uncPath := "\\\\" + c.Connection.Server.Host.String() + "\\" + shareName
+	if c.useUnicode() {
+		treeConnectCmd.Path = []types.UCHAR(append(utf16.EncodeUTF16LE(uncPath), 0x00, 0x00))
+	} else {
+		treeConnectCmd.Path = []types.UCHAR(uncPath + "\x00")
+	}
 
 	treeConnectCmd.Service = []types.UCHAR("?????" + "\x00")
 

--- a/network/smb/smb_v10/message/commands/NtCreateAndxRequest.go
+++ b/network/smb/smb_v10/message/commands/NtCreateAndxRequest.go
@@ -164,8 +164,23 @@ func (c *NtCreateAndxRequest) Marshal() ([]byte, error) {
 	// NOT be prefixed with an SMB_STRING buffer-format byte. Marshalling it through
 	// SMB_STRING (ASCII) would prepend a spurious 0x04 byte, which servers reject with
 	// STATUS_OBJECT_NAME_INVALID.
+	//
+	// A Unicode FileName is 16-bit aligned relative to the start of the SMB header
+	// ([MS-CIFS] section 2.2.4.64.1). The data block begins at an odd offset —
+	// SMB_HEADER_SIZE(32) + WordCount(1) + 24 words(48) + ByteCount(2) = 83 — so a
+	// pad byte precedes the name, and its terminator is two bytes wide. Unmarshal
+	// already expects both; emitting neither made this the one direction that could
+	// parse a Unicode name but not produce one, and a server reading the name a byte
+	// out of phase sees every character byte-swapped.
+	if c.IsUnicode() && (ntCreateAndxDataOffset+len(rawDataContent))%2 != 0 {
+		rawDataContent = append(rawDataContent, 0x00)
+	}
 	rawDataContent = append(rawDataContent, []byte(c.FileName.Buffer)...)
-	rawDataContent = append(rawDataContent, 0x00)
+	if c.IsUnicode() {
+		rawDataContent = append(rawDataContent, 0x00, 0x00)
+	} else {
+		rawDataContent = append(rawDataContent, 0x00)
+	}
 
 	// Then marshal the parameters
 	rawParametersContent := []byte{}

--- a/network/smb/smb_v10/message/commands/ntcreateandx_unicode_test.go
+++ b/network/smb/smb_v10/message/commands/ntcreateandx_unicode_test.go
@@ -1,0 +1,76 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/encoding/utf16"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v10/types"
+)
+
+// TestNtCreateAndxUnicodeNameRoundTrips guards the alignment defect: a Unicode
+// FileName is 16-bit aligned relative to the SMB header ([MS-CIFS] 2.2.4.64.1),
+// and this command's data block starts at the odd offset 83, so the name needs a
+// preceding pad byte and a two-byte terminator.
+//
+// Unmarshal already expected both. Marshal emitted neither, so the command could
+// parse a Unicode name but not produce one, and a peer read every character one
+// byte out of phase — "batched.txt" arrived as "戀愀琀挀栀攀搀⸀琀砀琀".
+func TestNtCreateAndxUnicodeNameRoundTrips(t *testing.T) {
+	for _, name := range []string{
+		`\plain.txt`,
+		`\unicode_éàü`,
+		`\dir\nested_ß.txt`,
+		`\`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			req := NewNtCreateAndxRequest()
+			req.SetUnicode(true)
+			if err := req.FileName.SetStringWithEncoding(name, true); err != nil {
+				t.Fatalf("SetStringWithEncoding: %v", err)
+			}
+			req.NameLength = types.USHORT(len(req.FileName.Buffer))
+
+			raw, err := req.Marshal()
+			if err != nil {
+				t.Fatalf("Marshal: %v", err)
+			}
+
+			parsed := NewNtCreateAndxRequest()
+			parsed.SetUnicode(true)
+			if _, err := parsed.Unmarshal(raw); err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+
+			if got := utf16.DecodeUTF16LE([]byte(parsed.FileName.Buffer)); got != name {
+				t.Errorf("FileName round-tripped as %q, want %q", got, name)
+			}
+		})
+	}
+}
+
+// TestNtCreateAndxOEMNameUnchanged pins the non-Unicode path, so the alignment
+// work cannot leak a stray pad byte into an OEM message.
+func TestNtCreateAndxOEMNameUnchanged(t *testing.T) {
+	const name = `\plain.txt`
+
+	req := NewNtCreateAndxRequest()
+	req.SetUnicode(false)
+	if err := req.FileName.SetStringWithEncoding(name, false); err != nil {
+		t.Fatalf("SetStringWithEncoding: %v", err)
+	}
+	req.NameLength = types.USHORT(len(req.FileName.Buffer))
+
+	raw, err := req.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	parsed := NewNtCreateAndxRequest()
+	parsed.SetUnicode(false)
+	if _, err := parsed.Unmarshal(raw); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got := string(parsed.FileName.Buffer); got != name {
+		t.Errorf("FileName round-tripped as %q, want %q", got, name)
+	}
+}

--- a/network/smb/smb_v10/message/message.go
+++ b/network/smb/smb_v10/message/message.go
@@ -77,6 +77,11 @@ func (m *Message) Marshal() ([]byte, error) {
 	blocks := [][]byte{}
 	written := 0
 	for command := m.Command; command != nil; command = command.GetNextCommand() {
+		// Propagate the message's Unicode setting (SMB_FLAGS2_UNICODE) so the
+		// command encodes its string fields to the width the header declares.
+		// Unmarshal already does this for the receive side; without it here a
+		// command built for a Unicode message is still serialized as OEM.
+		command.SetUnicode(m.Header.Flags2.IsUnicode())
 		if command.GetNextCommand() != nil && !command.IsAndX() {
 			return nil, fmt.Errorf(
 				"command 0x%02X is followed in an AndX chain but is not an AndX command",

--- a/network/smb/smb_v10/types/SMB_STRING.go
+++ b/network/smb/smb_v10/types/SMB_STRING.go
@@ -3,7 +3,9 @@ package types
 import (
 	"encoding/binary"
 	"fmt"
+	"github.com/TheManticoreProject/Manticore/encoding/utf16"
 	"math"
+	"strings"
 )
 
 const (
@@ -58,6 +60,51 @@ func (s *SMB_STRING) SetString(str string) error {
 	s.Length = USHORT(len(str))
 
 	return nil
+}
+
+// SetStringWithEncoding stores str in the character encoding the enclosing message
+// declared, so Buffer always holds the bytes that will go on the wire.
+//
+// SetString stores the UTF-8 bytes of a Go string, which is correct only for the
+// OEM encoding. When SMB_FLAGS2_UNICODE is set the wire wants UTF-16LE, and a
+// caller that stores UTF-8 there sends mojibake for any character outside ASCII:
+// the bytes round-trip through an SMB1 peer that treats them as opaque, while a
+// Unicode-capable reader sees a different name.
+//
+// Parameters:
+//   - str: the string to store
+//   - unicode: whether the enclosing message set SMB_FLAGS2_UNICODE
+//
+// Returns:
+//   - An error if the encoded string does not fit the length field
+func (s *SMB_STRING) SetStringWithEncoding(str string, unicode bool) error {
+	if !unicode {
+		return s.SetString(str)
+	}
+
+	encoded := utf16.EncodeUTF16LE(str)
+	if len(encoded) > math.MaxUint16 {
+		return fmt.Errorf("string too long")
+	}
+	s.Buffer = []UCHAR(encoded)
+	s.Length = USHORT(len(encoded))
+	return nil
+}
+
+// StringWithEncoding returns the string Buffer holds, decoded from the character
+// encoding the enclosing message declared. It is the counterpart of
+// SetStringWithEncoding, and of the raw bytes UnmarshalWithEncoding leaves behind.
+//
+// Parameters:
+//   - unicode: whether the enclosing message set SMB_FLAGS2_UNICODE
+//
+// Returns:
+//   - The decoded string, without any trailing terminator
+func (s *SMB_STRING) StringWithEncoding(unicode bool) string {
+	if !unicode {
+		return strings.TrimRight(string(s.Buffer), "\x00")
+	}
+	return strings.TrimRight(utf16.DecodeUTF16LE([]byte(s.Buffer)), "\x00")
 }
 
 // Marshal serializes the SMB_STRING structure into a byte slice.

--- a/network/smb/smb_v10/types/SMB_STRING_encoding_test.go
+++ b/network/smb/smb_v10/types/SMB_STRING_encoding_test.go
@@ -1,0 +1,53 @@
+package types
+
+import (
+	"testing"
+)
+
+// TestSetStringWithEncodingRoundTrip checks that a string stored in either
+// encoding reads back unchanged. SetString stores the UTF-8 bytes of a Go string,
+// which is right for OEM and wrong for Unicode: the wire wants UTF-16LE there, and
+// a caller that stores UTF-8 sends a different name than it asked for.
+func TestSetStringWithEncodingRoundTrip(t *testing.T) {
+	for _, name := range []string{"plain.txt", "unicode_éàü", `\dir\nested_ß.txt`, ""} {
+		for _, unicode := range []bool{false, true} {
+			s := &SMB_STRING{}
+			if err := s.SetStringWithEncoding(name, unicode); err != nil {
+				t.Fatalf("SetStringWithEncoding(%q, %v): %v", name, unicode, err)
+			}
+			if got := s.StringWithEncoding(unicode); got != name {
+				t.Errorf("unicode=%v: round-tripped %q as %q", unicode, name, got)
+			}
+			if int(s.Length) != len(s.Buffer) {
+				t.Errorf("unicode=%v: Length %d does not match the %d buffer bytes", unicode, s.Length, len(s.Buffer))
+			}
+		}
+	}
+}
+
+// TestSetStringWithEncodingWidth checks the Unicode form really is two bytes per
+// ASCII character — a length check is what distinguishes UTF-16LE from the UTF-8
+// bytes SetString would have stored.
+func TestSetStringWithEncodingWidth(t *testing.T) {
+	const ascii = "abc"
+
+	oem := &SMB_STRING{}
+	if err := oem.SetStringWithEncoding(ascii, false); err != nil {
+		t.Fatalf("SetStringWithEncoding: %v", err)
+	}
+	if len(oem.Buffer) != 3 {
+		t.Errorf("OEM buffer is %d bytes, want 3", len(oem.Buffer))
+	}
+
+	uni := &SMB_STRING{}
+	if err := uni.SetStringWithEncoding(ascii, true); err != nil {
+		t.Fatalf("SetStringWithEncoding: %v", err)
+	}
+	if len(uni.Buffer) != 6 {
+		t.Errorf("Unicode buffer is %d bytes, want 6", len(uni.Buffer))
+	}
+	// Little-endian: each ASCII character is its byte followed by a zero.
+	if uni.Buffer[0] != 'a' || uni.Buffer[1] != 0x00 {
+		t.Errorf("Unicode buffer starts % x, want 61 00", uni.Buffer[:2])
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #1234`

### Root Cause
`SMB_FLAGS2_UNICODE` is set on NEGOTIATE and SESSION_SETUP, where the SPNEGO blob and native strings need it, and the post-authentication request builders were written without it. Nothing downstream re-derives the encoding from the negotiated capability, so every path, pattern and file name went out as OEM — a field that cannot represent a non-ASCII name.

What made this survive so long is that **SMB1 cannot show it**. The client writes the UTF-8 bytes of the name, the server stores those bytes, and the FIND response returns them unchanged. Client and server agree byte-for-byte while both differ from what a Windows client produces. It took reading the same directory with a Unicode-capable client to see the damage.

### Fix Description
Setting the flag alone accomplishes nothing — three layers had to change together, and each was independently incomplete:

1. **`message.Marshal` now propagates the header's Unicode setting to each command.** `Unmarshal` already did this for the receive side; without the matching send side, a command built for a Unicode message still serialized as OEM.

2. **`SMB_STRING` gains `SetStringWithEncoding` / `StringWithEncoding`.** `SetString` stores the UTF-8 bytes of a Go string, which is correct for OEM and wrong for Unicode. `Buffer` holds *wire* bytes by design — `UnmarshalWithEncoding` copies raw UTF-16LE into it without decoding — so the encode step belongs at the setter.

3. **`NtCreateAndxRequest.Marshal` emits the alignment pad and two-byte terminator.** This is the subtle one. A Unicode name is 16-bit aligned relative to the SMB header ([MS-CIFS] 2.2.4.64.1) and this command's data block begins at the odd offset 83. `Unmarshal` already expected both, so the command could *parse* a Unicode name but not *produce* one.

The client then sets the flag when the server advertised `CAP_UNICODE`, encodes outbound names through the new setter, encodes the hand-built TRANS2 parameter names, and decodes FIND entry names. `TreeConnect` also stops sending `Flags`/`Flags2` of zero, which additionally restores NT status codes on that command.

The TRANS2 names need no alignment byte and the PR does not add one: their fixed parameters are 12 bytes for FIND_FIRST2/FIND_NEXT2 and 6 for the path-information levels, on top of a parameter block the transaction already aligns to four, so each name starts at an even offset. The same is true of the tree-connect path, which follows a one-byte null password at offset 44.

### How Verified
**Runtime, against Windows Server 2012 R2 Standard 9600.** The decisive check is a cross-check, because SMB1 alone cannot distinguish the two cases.

Before — created through the SMB1 client, then read with a Unicode-capable client over SMB3:

```
bytes sent:  ... 5f c3 a9 c3 a0 c3 bc      (UTF-8 for éàü, in an OEM field)
stored name: manticore_oem_probe_├⌐├á├╝
```

After:

```
created via SMB1:              manticore_xcheck_éàü
smbclient over SMB3 sees:      manticore_xcheck_éàü
deleted again via SMB1:        OK
```

The delete matters as a second signal: previously the client could not remove a name it had itself created (`0x00050002`), because it could not address the name the server had recorded.

The full SMB1 suite against that host also passes — session setup with signing required, 86-entry listing, `QueryPathInformation`, `QueryFsAttributeInfo`, open/read/close — as does the SMB2/3 suite against Server 2025 and the `smbclient` interop against this repository's own SMB1 server.

**Tests.** With the NT_CREATE alignment pad removed, the round-trip guard reproduces the exact corruption:

```
--- FAIL: TestNtCreateAndxUnicodeNameRoundTrips/\plain.txt
    FileName round-tripped as "瀀氀愀椀渀⸀琀砀琀", want "\plain.txt"
```

That is the name read one byte out of phase, which is what a server saw.

`go build ./...`, `go vet ./network/smb/...`, `go test ./network/smb/... ./crypto/...` all clean.

### Test Coverage
**Added**
- `network/smb/smb_v10/message/commands/ntcreateandx_unicode_test.go` — `TestNtCreateAndxUnicodeNameRoundTrips` marshals and re-parses four names (ASCII, accented, a nested path with `ß`, and a bare `\`) and is the guard for the alignment defect; `TestNtCreateAndxOEMNameUnchanged` pins the OEM path so the alignment work cannot leak a stray pad byte into a non-Unicode message.
- `network/smb/smb_v10/types/SMB_STRING_encoding_test.go` — round-trips both encodings and checks the Unicode form really is two bytes per ASCII character, which is what distinguishes UTF-16LE from the UTF-8 bytes `SetString` would have stored.

**Modified** — `find_internal_test.go`, `find_name_test.go`: call sites for the two functions that gained an encoding parameter.

### Scope of Change
- **Files changed:** `client/file.go`, `client/fileops.go`, `client/find.go`, `client/queryinfo.go`, `client/tree.go`, `message/message.go`, `message/commands/NtCreateAndxRequest.go`, `types/SMB_STRING.go`, plus two new test files and two updated ones
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** `TreeConnect` now sends `Flags = 0x18` and `NT_STATUS`, where it previously sent zero for both. That is required — the Unicode bit lives in the same field — and it means tree-connect failures now arrive as NT statuses rather than DOS codes, which is what every other command on this client already negotiates.

### Risk and Rollout
This is the widest change in the series: every name the SMB1 client sends changes encoding when the server advertises `CAP_UNICODE`, which Windows always does. It is validated against a real Windows SMB1 server rather than only against this repository's own, precisely because the in-repo pair is structurally unable to detect an encoding mismatch.

A server that does not advertise `CAP_UNICODE` takes the OEM path unchanged, and `TestNtCreateAndxOEMNameUnchanged` pins that.

### Notes
The `network/smb/client` facade already decoded SMB1 names defensively, so callers using it see no change beyond names now being correct. Remaining SMB1 fingerprint items — PID always 0, MID pinned to `MaxMpxCount`, the big-endian `AndXOffset` — are unaffected and tracked separately.