### PR TITLE
Validate the negotiate exchange on SMB 3.0/3.0.2 connections (Fixes #1236)

### DIFF
--- a/network/smb/smb_v20/client/client_structures.go
+++ b/network/smb/smb_v20/client/client_structures.go
@@ -85,6 +85,15 @@ type Connection struct {
 	// Dialect is the SMB2 dialect selected during negotiation.
 	Dialect dialects.Dialect
 
+	// OfferedDialects, ClientCapabilities and ClientSecurityMode record what this
+	// client put in its NEGOTIATE request. The secure-negotiate validation after a
+	// tree connect asks the server to restate them, so they have to survive the
+	// exchange: comparing the server's answer against the values it sent back
+	// would confirm nothing.
+	OfferedDialects    []dialects.Dialect
+	ClientCapabilities capabilities.Capabilities
+	ClientSecurityMode securitymode.SecurityMode
+
 	// Cipher is the encryption algorithm the server selected in the SMB 3.1.1
 	// SMB2_ENCRYPTION_CAPABILITIES negotiate context (e.g. AES-128-GCM). It is 0
 	// when encryption was not negotiated. For the 3.0/3.0.2 dialects it is

--- a/network/smb/smb_v20/client/negotiate.go
+++ b/network/smb/smb_v20/client/negotiate.go
@@ -38,6 +38,12 @@ func (c *Client) Negotiate() error {
 	req.SecurityMode = securitymode.SMB2_NEGOTIATE_SIGNING_ENABLED
 	req.Capabilities = capabilities.SMB2_GLOBAL_CAP_LARGE_MTU | capabilities.SMB2_GLOBAL_CAP_ENCRYPTION
 
+	// Retain what was offered: the secure-negotiate validation performed after a
+	// tree connect replays these exact values for the server to confirm.
+	c.Connection.OfferedDialects = append([]dialects.Dialect(nil), req.Dialects...)
+	c.Connection.ClientCapabilities = req.Capabilities
+	c.Connection.ClientSecurityMode = req.SecurityMode
+
 	// SMB 3.1.1 negotiate contexts: pre-auth integrity (SHA-512 + random salt)
 	// and encryption ciphers in preference order (AES-128-GCM, then AES-128-CCM).
 	salt := make([]byte, preauthSaltLength)

--- a/network/smb/smb_v20/client/tree.go
+++ b/network/smb/smb_v20/client/tree.go
@@ -56,6 +56,16 @@ func (c *Client) TreeConnect(shareName string) error {
 		TreeId:     treeId,
 		ShareType:  treeConnectResponse.ShareType,
 	}
+	// A dialect below 3.1.1 has no pre-authentication integrity, so the NEGOTIATE
+	// exchange that produced this connection was unprotected. Have the server
+	// restate it under the session's signature now that one exists; a downgrade
+	// that altered the original cannot be reproduced ([MS-SMB2] 3.2.5.5).
+	if c.requiresSecureNegotiateValidation() {
+		if err := c.validateNegotiateInfo(); err != nil {
+			return err
+		}
+	}
+
 	if c.Connection.TreeConnectTable == nil {
 		c.Connection.TreeConnectTable = make(map[uint32]*TreeConnect)
 	}

--- a/network/smb/smb_v20/client/validatenegotiate.go
+++ b/network/smb/smb_v20/client/validatenegotiate.go
@@ -1,0 +1,109 @@
+package client
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/capabilities"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/dialects"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/securitymode"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/types"
+	"github.com/TheManticoreProject/Manticore/windows/filesystem"
+)
+
+// validateNegotiateInfoResponseSize is the fixed size of a VALIDATE_NEGOTIATE_INFO
+// response: Capabilities(4) ServerGuid(16) SecurityMode(2) Dialect(2)
+// ([MS-SMB2] 2.2.32.6).
+const validateNegotiateInfoResponseSize = 24
+
+// requiresSecureNegotiateValidation reports whether this connection must validate
+// its negotiate exchange after a tree connect.
+//
+// [MS-SMB2] 3.2.5.5 requires it when the negotiated dialect is in the SMB 3.x
+// family but is *not* 3.1.1. The exclusion is not an oversight: 3.1.1 carries
+// pre-authentication integrity, which already covers the NEGOTIATE exchange, and
+// [MS-SMB2] 3.3.5.15.12 has a 3.1.1 server terminate the connection outright on
+// receiving the request. Sending it there would break the session it was meant to
+// protect.
+//
+// The request must be signed to be worth anything — an unprotected response can
+// simply be forged by whoever forged the negotiate — so it is skipped when neither
+// signing nor encryption is in force.
+func (c *Client) requiresSecureNegotiateValidation() bool {
+	if c.Session == nil {
+		return false
+	}
+	if !isSMB3Dialect(c.Connection.Dialect) || c.Connection.Dialect == dialects.SMB2_DIALECT_3_1_1 {
+		return false
+	}
+	return c.Session.SigningActive || c.Session.EncryptData
+}
+
+// validateNegotiateInfo asks the server to restate the negotiate exchange under the
+// protection of the established session, and checks that what comes back matches
+// what this client actually negotiated.
+//
+// A downgrade attacker who tampered with the unprotected NEGOTIATE cannot produce a
+// matching signed answer, so a mismatch means the negotiation was altered and the
+// connection must not be used ([MS-SMB2] 3.2.5.14.12).
+func (c *Client) validateNegotiateInfo() error {
+	input := buildValidateNegotiateInfoRequest(
+		c.Connection.ClientCapabilities,
+		c.ClientGuid,
+		c.Connection.ClientSecurityMode,
+		c.Connection.OfferedDialects,
+	)
+
+	output, err := c.Ioctl(validateNegotiateFileId(), filesystem.FSCTL_VALIDATE_NEGOTIATE_INFO, input, true, validateNegotiateInfoResponseSize)
+	if err != nil {
+		return fmt.Errorf("secure negotiate validation failed: %w", err)
+	}
+	if len(output) < validateNegotiateInfoResponseSize {
+		return fmt.Errorf("secure negotiate validation returned %d bytes, want %d", len(output), validateNegotiateInfoResponseSize)
+	}
+
+	gotCapabilities := capabilities.Capabilities(binary.LittleEndian.Uint32(output[0:4]))
+	var gotServerGuid [16]byte
+	copy(gotServerGuid[:], output[4:20])
+	gotSecurityMode := securitymode.SecurityMode(binary.LittleEndian.Uint16(output[20:22]))
+	gotDialect := dialects.Dialect(binary.LittleEndian.Uint16(output[22:24]))
+
+	server := c.Connection.Server
+	if gotCapabilities != server.Capabilities {
+		return fmt.Errorf("secure negotiate validation: server capabilities %#08x do not match the negotiated %#08x", uint32(gotCapabilities), uint32(server.Capabilities))
+	}
+	if !bytes.Equal(gotServerGuid[:], server.ServerGuid[:]) {
+		return fmt.Errorf("secure negotiate validation: server GUID % x does not match the negotiated % x", gotServerGuid, server.ServerGuid)
+	}
+	if gotSecurityMode != server.SecurityMode {
+		return fmt.Errorf("secure negotiate validation: server security mode %#04x does not match the negotiated %#04x", uint16(gotSecurityMode), uint16(server.SecurityMode))
+	}
+	if gotDialect != c.Connection.Dialect {
+		return fmt.Errorf("secure negotiate validation: server dialect %s does not match the negotiated %s", gotDialect, c.Connection.Dialect)
+	}
+
+	return nil
+}
+
+// buildValidateNegotiateInfo builds the VALIDATE_NEGOTIATE_INFO request body
+// ([MS-SMB2] 2.2.31.4). The values are the ones this client put in its NEGOTIATE
+// request, not the ones the server answered with: the point is to have the server
+// confirm what it saw against what was sent.
+func buildValidateNegotiateInfoRequest(caps capabilities.Capabilities, clientGuid [16]byte, mode securitymode.SecurityMode, offered []dialects.Dialect) []byte {
+	body := make([]byte, 0, 24+2*len(offered))
+	body = binary.LittleEndian.AppendUint32(body, uint32(caps))
+	body = append(body, clientGuid[:]...)
+	body = binary.LittleEndian.AppendUint16(body, uint16(mode))
+	body = binary.LittleEndian.AppendUint16(body, uint16(len(offered)))
+	for _, dialect := range offered {
+		body = binary.LittleEndian.AppendUint16(body, uint16(dialect))
+	}
+	return body
+}
+
+// validateNegotiateFileId is the reserved handle an FSCTL that addresses the
+// connection rather than a file is sent on.
+func validateNegotiateFileId() types.SMB2_FILEID {
+	return types.SMB2_FILEID{Persistent: 0xFFFFFFFFFFFFFFFF, Volatile: 0xFFFFFFFFFFFFFFFF}
+}

--- a/network/smb/smb_v20/client/validatenegotiate_test.go
+++ b/network/smb/smb_v20/client/validatenegotiate_test.go
@@ -1,0 +1,126 @@
+package client
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/capabilities"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/dialects"
+	"github.com/TheManticoreProject/Manticore/network/smb/smb_v20/securitymode"
+)
+
+// TestRequiresSecureNegotiateValidationByDialect pins the MS-SMB2 3.2.5.5
+// condition, whose exclusion of 3.1.1 is the part most easily got wrong: 3.1.1
+// carries pre-authentication integrity, and a 3.1.1 server terminates the
+// connection outright on receiving the request ([MS-SMB2] 3.3.5.15.12), so
+// sending one there breaks the session it was meant to protect.
+func TestRequiresSecureNegotiateValidationByDialect(t *testing.T) {
+	tests := []struct {
+		dialect dialects.Dialect
+		want    bool
+	}{
+		{dialects.SMB2_DIALECT_2_0_2, false},
+		{dialects.SMB2_DIALECT_2_1_0, false},
+		{dialects.SMB2_DIALECT_3_0_0, true},
+		{dialects.SMB2_DIALECT_3_0_2, true},
+		{dialects.SMB2_DIALECT_3_1_1, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.dialect.String(), func(t *testing.T) {
+			c := newTestClient(&fakeTransport{})
+			c.Connection.Dialect = tt.dialect
+			c.Session = &Session{Client: c, SigningActive: true}
+
+			if got := c.requiresSecureNegotiateValidation(); got != tt.want {
+				t.Errorf("requiresSecureNegotiateValidation() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSecureNegotiateValidationNeedsProtection checks the request is skipped when
+// neither signing nor encryption is in force. An unprotected answer proves nothing:
+// whoever could forge the negotiate could forge the confirmation too.
+func TestSecureNegotiateValidationNeedsProtection(t *testing.T) {
+	c := newTestClient(&fakeTransport{})
+	c.Connection.Dialect = dialects.SMB2_DIALECT_3_0_2
+
+	c.Session = &Session{Client: c}
+	if c.requiresSecureNegotiateValidation() {
+		t.Error("validation attempted with neither signing nor encryption active")
+	}
+
+	c.Session = &Session{Client: c, EncryptData: true}
+	if !c.requiresSecureNegotiateValidation() {
+		t.Error("validation skipped although the session is encrypted")
+	}
+
+	c.Session = nil
+	if c.requiresSecureNegotiateValidation() {
+		t.Error("validation attempted with no session")
+	}
+}
+
+// TestBuildValidateNegotiateInfoRequest pins the request body ([MS-SMB2] 2.2.31.4).
+// The values must be the ones the client offered, not those the server answered
+// with — echoing the server's own values back would confirm nothing.
+func TestBuildValidateNegotiateInfoRequest(t *testing.T) {
+	guid := [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+	offered := []dialects.Dialect{
+		dialects.SMB2_DIALECT_2_0_2,
+		dialects.SMB2_DIALECT_2_1_0,
+		dialects.SMB2_DIALECT_3_0_0,
+		dialects.SMB2_DIALECT_3_0_2,
+	}
+
+	body := buildValidateNegotiateInfoRequest(
+		capabilities.SMB2_GLOBAL_CAP_LARGE_MTU,
+		guid,
+		securitymode.SMB2_NEGOTIATE_SIGNING_ENABLED,
+		offered,
+	)
+
+	if want := 24 + 2*len(offered); len(body) != want {
+		t.Fatalf("body is %d bytes, want %d", len(body), want)
+	}
+	if got := binary.LittleEndian.Uint32(body[0:4]); got != uint32(capabilities.SMB2_GLOBAL_CAP_LARGE_MTU) {
+		t.Errorf("Capabilities = %#08x, want %#08x", got, uint32(capabilities.SMB2_GLOBAL_CAP_LARGE_MTU))
+	}
+	if !bytes.Equal(body[4:20], guid[:]) {
+		t.Errorf("ClientGuid = % x, want % x", body[4:20], guid)
+	}
+	if got := binary.LittleEndian.Uint16(body[20:22]); got != uint16(securitymode.SMB2_NEGOTIATE_SIGNING_ENABLED) {
+		t.Errorf("SecurityMode = %#04x, want %#04x", got, uint16(securitymode.SMB2_NEGOTIATE_SIGNING_ENABLED))
+	}
+	if got := binary.LittleEndian.Uint16(body[22:24]); int(got) != len(offered) {
+		t.Errorf("DialectCount = %d, want %d", got, len(offered))
+	}
+	for i, dialect := range offered {
+		off := 24 + 2*i
+		if got := dialects.Dialect(binary.LittleEndian.Uint16(body[off : off+2])); got != dialect {
+			t.Errorf("dialect %d = %s, want %s", i, got, dialect)
+		}
+	}
+}
+
+// TestNegotiateRetainsOfferedValues checks the values the validation replays are
+// recorded during NEGOTIATE. Without them the request would have nothing to assert.
+func TestNegotiateRetainsOfferedValues(t *testing.T) {
+	ft := &fakeTransport{responses: [][]byte{cannedNegotiateResponse(t)}}
+	c := newTestClient(ft)
+
+	if err := c.Negotiate(); err != nil {
+		t.Fatalf("Negotiate: %v", err)
+	}
+	if len(c.Connection.OfferedDialects) == 0 {
+		t.Error("Negotiate did not retain the offered dialects")
+	}
+	if c.Connection.ClientCapabilities == 0 {
+		t.Error("Negotiate did not retain the offered capabilities")
+	}
+	if c.Connection.ClientSecurityMode == 0 {
+		t.Error("Negotiate did not retain the offered security mode")
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #1236`

### Root Cause
The IOCTL surface was built for the named-pipe transport, which needs only `FSCTL_PIPE_TRANSCEIVE`. The connection-level FSCTLs were never wired, and the negotiate state the validation depends on was not retained — `Negotiate` kept what the server *answered* and discarded what the client *offered*.

On SMB 3.0/3.0.2 the NEGOTIATE exchange is unprotected and nothing afterwards confirms it, so a stripped `SMB2_NEGOTIATE_SIGNING_REQUIRED` or a forced weaker dialect went undetected.

### Fix Description
After the first tree connect on a signed or encrypted 3.0/3.0.2 connection, replay what was offered — dialects, capabilities, security mode ([MS-SMB2] 2.2.31.4) — and reject the connection when the server's answer does not match the negotiated result.

Two details are load-bearing:

**The dialect gate runs both ways.** [MS-SMB2] 3.2.5.5 requires the validation only when `Connection.Dialect` is *not* 3.1.1. That exclusion is not a nicety: 3.1.1 carries pre-authentication integrity, which already covers the NEGOTIATE exchange, and [MS-SMB2] 3.3.5.15.12 has a 3.1.1 server **terminate the transport connection** on receiving the request. Sending it there would break the session it is meant to protect. So the gate excludes 3.1.1 as deliberately as it includes 3.0.2 — and since this client negotiates 3.1.1 against any modern Windows server, the new code path is *not* the common one.

**The values must be the client's own.** `Negotiate` now retains the offered dialect list, capabilities and security mode. Echoing back what the server answered with would produce a request that always matches and confirms nothing.

The request is skipped when neither signing nor encryption is in force, since an unprotected answer is forgeable by whoever forged the negotiate.

### How Verified
**Runtime, against both lab hosts, exercising both branches of the condition.** This is the part that makes the change trustworthy — the two hosts happen to sit on opposite sides of the 3.1.1 boundary:

```
Server 2012R2 (10.7.0.15): dialect SMB 3.0.2, signing=true
Server 2025   (10.7.0.13): dialect SMB 3.1.1, signing=true
```

```
=== 3.0.2 validates
    dialect SMB 3.0.2
    tree connect + FSCTL_VALIDATE_NEGOTIATE_INFO OK
=== 3.1.1 does not validate
    dialect SMB 3.1.1
    tree connect OK, connection intact (no validation sent)
```

The second case is a real assertion, not a formality: a 3.1.1 server drops the connection on receiving this request, so the tree connect completing at all is the evidence that nothing was sent.

`go build ./...`, `go vet ./network/smb/...`, `go test ./network/smb/... ./crypto/...` clean, and the full live matrix across both hosts passes.

### Test Coverage
**Added** — `network/smb/smb_v20/client/validatenegotiate_test.go`:
- `TestRequiresSecureNegotiateValidationByDialect` — all five dialects, pinning that 3.0 and 3.0.2 validate while 2.0.2, 2.1 and **3.1.1** do not. The 3.1.1 row is the one that matters; getting it wrong disconnects every modern session.
- `TestSecureNegotiateValidationNeedsProtection` — skipped with no signing and no encryption, performed when encrypted, skipped with no session.
- `TestBuildValidateNegotiateInfoRequest` — the request body field by field against [MS-SMB2] 2.2.31.4.
- `TestNegotiateRetainsOfferedValues` — the offered values survive NEGOTIATE, without which the request would assert nothing.

### Scope of Change
- **Files changed:** `validatenegotiate.go` (new), `validatenegotiate_test.go` (new), `tree.go`, `negotiate.go`, `client_structures.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none. `Connection` gains three fields recording what NEGOTIATE offered.

### Risk and Rollout
The new exchange runs only on signed or encrypted SMB 3.0/3.0.2 connections, so the default path against a modern Windows server (3.1.1) is unchanged and was verified to stay unchanged. Where it does run, a mismatch now fails the tree connect — which is the intended behaviour, since the alternative is proceeding on a connection whose negotiation may have been tampered with. Against a genuine server the values match, as the 2012 R2 run shows.

### Notes
An earlier assessment of this issue in the planning notes claimed the validation was required *because* the client offers 3.1.1 unencrypted. That was backwards, and the spec check above corrects it: 3.1.1 is exactly the case where the request must not be sent. The fix is narrower than that assessment implied, and only reachable against pre-3.1.1 servers.