### PR TITLE
Remove a duplicated sentence from the SMB1 server package documentation

### DIFF
--- a/network/smb/smb_v10/server/doc.go
+++ b/network/smb/smb_v10/server/doc.go
@@ -118,7 +118,6 @@
 //   - Named pipes, over TRANSACTION: a pipe is opened on a pipe share like a
 //     file, and TRANS_TRANSACT_NMPIPE writes a message to the handle and returns
 //     the answer. That write-then-read is the operation MS-RPC travels over, so a
-//     PipeHandler is all an RPC service needs to be reachable over SMB1.
 //     PipeHandler is all an RPC service needs to be reachable over SMB1. An answer
 //     too large for one response is collected with TRANS_READ_NMPIPE,
 //     TRANS_PEEK_NMPIPE or SMB_COM_READ_ANDX on the same handle.


### PR DESCRIPTION
### Summary
The named-pipes bullet of `network/smb/smb_v10/server/doc.go` stated "PipeHandler is all an RPC service needs to be reachable over SMB1" twice, the second occurrence running into the sentence that follows it:

```
//     the answer. That write-then-read is the operation MS-RPC travels over, so a
//     PipeHandler is all an RPC service needs to be reachable over SMB1.
//     PipeHandler is all an RPC service needs to be reachable over SMB1. An answer
//     too large for one response is collected with TRANS_READ_NMPIPE,
```

The duplicate line is dropped and the continuation kept, so the bullet reads as one sentence followed by the next.

### Scope of Change
- **Files changed:** `network/smb/smb_v10/server/doc.go` — one line deleted
- **Submodule pointer updated:** no
- **Behavioral changes:** none. It is a package comment.

### How Verified
`go build ./...`, `go vet ./network/smb/smb_v10/server/` and `gofmt -l` are clean.

### Notes
No issue filed: a duplicated sentence in a comment is not a defect in the sense the bug workflow covers, and filing one to point at a one-line documentation fix would be noise. It arrived with a merge conflict resolution.