### PR TITLE
Route eventlog status reporting through win32 (Refs #1219)

### DIFF
--- a/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/00_ElfrClearELFW.go
+++ b/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/00_ElfrClearELFW.go
@@ -10,6 +10,7 @@ import (
 
 	eventlog "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mseven "github.com/TheManticoreProject/Manticore/windows/protocols/ms-even"
 )
@@ -33,7 +34,7 @@ func ElfrClearELFW(rpc ndr.Invoker, logHandle mseven.IELF_HANDLE, backupFileName
 		err = fmt.Errorf("ElfrClearELFW: %w", err)
 		return
 	}
-	if uint32(resp.Status) != eventlog.StatusSuccess {
+	if win32.WIN32_ERROR(resp.Status) != win32.ERROR_SUCCESS {
 		err = fmt.Errorf("ElfrClearELFW failed: %s", eventlog.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/01_ElfrBackupELFW.go
+++ b/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/01_ElfrBackupELFW.go
@@ -10,6 +10,7 @@ import (
 
 	eventlog "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mseven "github.com/TheManticoreProject/Manticore/windows/protocols/ms-even"
 )
@@ -33,7 +34,7 @@ func ElfrBackupELFW(rpc ndr.Invoker, logHandle mseven.IELF_HANDLE, backupFileNam
 		err = fmt.Errorf("ElfrBackupELFW: %w", err)
 		return
 	}
-	if uint32(resp.Status) != eventlog.StatusSuccess {
+	if win32.WIN32_ERROR(resp.Status) != win32.ERROR_SUCCESS {
 		err = fmt.Errorf("ElfrBackupELFW failed: %s", eventlog.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/02_ElfrCloseEL.go
+++ b/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/02_ElfrCloseEL.go
@@ -10,6 +10,7 @@ import (
 
 	eventlog "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	mseven "github.com/TheManticoreProject/Manticore/windows/protocols/ms-even"
 )
 
@@ -31,7 +32,7 @@ func ElfrCloseEL(rpc ndr.Invoker, logHandle mseven.IELF_HANDLE) (LogHandle mseve
 		return
 	}
 	LogHandle = resp.LogHandle
-	if uint32(resp.Status) != eventlog.StatusSuccess {
+	if win32.WIN32_ERROR(resp.Status) != win32.ERROR_SUCCESS {
 		err = fmt.Errorf("ElfrCloseEL failed: %s", eventlog.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/03_ElfrDeregisterEventSource.go
+++ b/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/03_ElfrDeregisterEventSource.go
@@ -10,6 +10,7 @@ import (
 
 	eventlog "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	mseven "github.com/TheManticoreProject/Manticore/windows/protocols/ms-even"
 )
 
@@ -33,7 +34,7 @@ func ElfrDeregisterEventSource(rpc ndr.Invoker, logHandle mseven.IELF_HANDLE) (L
 		return
 	}
 	LogHandle = resp.LogHandle
-	if uint32(resp.Status) != eventlog.StatusSuccess {
+	if win32.WIN32_ERROR(resp.Status) != win32.ERROR_SUCCESS {
 		err = fmt.Errorf("ElfrDeregisterEventSource failed: %s", eventlog.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/04_ElfrNumberOfRecords.go
+++ b/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/04_ElfrNumberOfRecords.go
@@ -10,6 +10,7 @@ import (
 
 	eventlog "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	mseven "github.com/TheManticoreProject/Manticore/windows/protocols/ms-even"
 )
 
@@ -37,7 +38,7 @@ func ElfrNumberOfRecords(rpc ndr.Invoker, logHandle mseven.IELF_HANDLE) (NumberO
 		return
 	}
 	NumberOfRecords = resp.NumberOfRecords
-	if uint32(resp.Status) != eventlog.StatusSuccess {
+	if win32.WIN32_ERROR(resp.Status) != win32.ERROR_SUCCESS {
 		err = fmt.Errorf("ElfrNumberOfRecords failed: %s", eventlog.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/05_ElfrOldestRecord.go
+++ b/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/05_ElfrOldestRecord.go
@@ -10,6 +10,7 @@ import (
 
 	eventlog "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	mseven "github.com/TheManticoreProject/Manticore/windows/protocols/ms-even"
 )
 
@@ -37,7 +38,7 @@ func ElfrOldestRecord(rpc ndr.Invoker, logHandle mseven.IELF_HANDLE) (OldestReco
 		return
 	}
 	OldestRecordNumber = resp.OldestRecordNumber
-	if uint32(resp.Status) != eventlog.StatusSuccess {
+	if win32.WIN32_ERROR(resp.Status) != win32.ERROR_SUCCESS {
 		err = fmt.Errorf("ElfrOldestRecord failed: %s", eventlog.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/06_ElfrChangeNotify.go
+++ b/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/06_ElfrChangeNotify.go
@@ -10,6 +10,7 @@ import (
 
 	eventlog "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	mseven "github.com/TheManticoreProject/Manticore/windows/protocols/ms-even"
 )
 
@@ -34,7 +35,7 @@ func ElfrChangeNotify(rpc ndr.Invoker, logHandle mseven.IELF_HANDLE, clientId ms
 		err = fmt.Errorf("ElfrChangeNotify: %w", err)
 		return
 	}
-	if uint32(resp.Status) != eventlog.StatusSuccess {
+	if win32.WIN32_ERROR(resp.Status) != win32.ERROR_SUCCESS {
 		err = fmt.Errorf("ElfrChangeNotify failed: %s", eventlog.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/07_ElfrOpenELW.go
+++ b/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/07_ElfrOpenELW.go
@@ -10,6 +10,7 @@ import (
 
 	eventlog "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mseven "github.com/TheManticoreProject/Manticore/windows/protocols/ms-even"
 )
@@ -40,7 +41,7 @@ func ElfrOpenELW(rpc ndr.Invoker, uNCServerName ndr.WSTR, moduleName msdtyp.RPC_
 		return
 	}
 	LogHandle = resp.LogHandle
-	if uint32(resp.Status) != eventlog.StatusSuccess {
+	if win32.WIN32_ERROR(resp.Status) != win32.ERROR_SUCCESS {
 		err = fmt.Errorf("ElfrOpenELW failed: %s", eventlog.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/08_ElfrRegisterEventSourceW.go
+++ b/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/08_ElfrRegisterEventSourceW.go
@@ -10,6 +10,7 @@ import (
 
 	eventlog "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mseven "github.com/TheManticoreProject/Manticore/windows/protocols/ms-even"
 )
@@ -40,7 +41,7 @@ func ElfrRegisterEventSourceW(rpc ndr.Invoker, uNCServerName ndr.WSTR, moduleNam
 		return
 	}
 	LogHandle = resp.LogHandle
-	if uint32(resp.Status) != eventlog.StatusSuccess {
+	if win32.WIN32_ERROR(resp.Status) != win32.ERROR_SUCCESS {
 		err = fmt.Errorf("ElfrRegisterEventSourceW failed: %s", eventlog.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/09_ElfrOpenBELW.go
+++ b/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/09_ElfrOpenBELW.go
@@ -10,6 +10,7 @@ import (
 
 	eventlog "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mseven "github.com/TheManticoreProject/Manticore/windows/protocols/ms-even"
 )
@@ -38,7 +39,7 @@ func ElfrOpenBELW(rpc ndr.Invoker, uNCServerName ndr.WSTR, backupFileName msdtyp
 		return
 	}
 	LogHandle = resp.LogHandle
-	if uint32(resp.Status) != eventlog.StatusSuccess {
+	if win32.WIN32_ERROR(resp.Status) != win32.ERROR_SUCCESS {
 		err = fmt.Errorf("ElfrOpenBELW failed: %s", eventlog.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/10_ElfrReadELW.go
+++ b/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/10_ElfrReadELW.go
@@ -10,6 +10,7 @@ import (
 
 	eventlog "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	mseven "github.com/TheManticoreProject/Manticore/windows/protocols/ms-even"
 )
 
@@ -47,7 +48,7 @@ func ElfrReadELW(rpc ndr.Invoker, logHandle mseven.IELF_HANDLE, readFlags ndr.DW
 	Buffer = resp.Buffer
 	NumberOfBytesRead = resp.NumberOfBytesRead
 	MinNumberOfBytesNeeded = resp.MinNumberOfBytesNeeded
-	if uint32(resp.Status) != eventlog.StatusSuccess {
+	if win32.WIN32_ERROR(resp.Status) != win32.ERROR_SUCCESS {
 		err = fmt.Errorf("ElfrReadELW failed: %s", eventlog.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/11_ElfrReportEventW.go
+++ b/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/11_ElfrReportEventW.go
@@ -10,6 +10,7 @@ import (
 
 	eventlog "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mseven "github.com/TheManticoreProject/Manticore/windows/protocols/ms-even"
 )
@@ -66,7 +67,7 @@ func ElfrReportEventW(rpc ndr.Invoker, logHandle mseven.IELF_HANDLE, time ndr.DW
 	}
 	RecordNumber = resp.RecordNumber
 	TimeWritten = resp.TimeWritten
-	if uint32(resp.Status) != eventlog.StatusSuccess {
+	if win32.WIN32_ERROR(resp.Status) != win32.ERROR_SUCCESS {
 		err = fmt.Errorf("ElfrReportEventW failed: %s", eventlog.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/12_ElfrClearELFA.go
+++ b/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/12_ElfrClearELFA.go
@@ -10,6 +10,7 @@ import (
 
 	eventlog "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	mseven "github.com/TheManticoreProject/Manticore/windows/protocols/ms-even"
 )
 
@@ -32,7 +33,7 @@ func ElfrClearELFA(rpc ndr.Invoker, logHandle mseven.IELF_HANDLE, backupFileName
 		err = fmt.Errorf("ElfrClearELFA: %w", err)
 		return
 	}
-	if uint32(resp.Status) != eventlog.StatusSuccess {
+	if win32.WIN32_ERROR(resp.Status) != win32.ERROR_SUCCESS {
 		err = fmt.Errorf("ElfrClearELFA failed: %s", eventlog.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/13_ElfrBackupELFA.go
+++ b/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/13_ElfrBackupELFA.go
@@ -10,6 +10,7 @@ import (
 
 	eventlog "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	mseven "github.com/TheManticoreProject/Manticore/windows/protocols/ms-even"
 )
 
@@ -32,7 +33,7 @@ func ElfrBackupELFA(rpc ndr.Invoker, logHandle mseven.IELF_HANDLE, backupFileNam
 		err = fmt.Errorf("ElfrBackupELFA: %w", err)
 		return
 	}
-	if uint32(resp.Status) != eventlog.StatusSuccess {
+	if win32.WIN32_ERROR(resp.Status) != win32.ERROR_SUCCESS {
 		err = fmt.Errorf("ElfrBackupELFA failed: %s", eventlog.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/14_ElfrOpenELA.go
+++ b/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/14_ElfrOpenELA.go
@@ -10,6 +10,7 @@ import (
 
 	eventlog "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	mseven "github.com/TheManticoreProject/Manticore/windows/protocols/ms-even"
 )
 
@@ -39,7 +40,7 @@ func ElfrOpenELA(rpc ndr.Invoker, uNCServerName ndr.STR, moduleName mseven.RPC_S
 		return
 	}
 	LogHandle = resp.LogHandle
-	if uint32(resp.Status) != eventlog.StatusSuccess {
+	if win32.WIN32_ERROR(resp.Status) != win32.ERROR_SUCCESS {
 		err = fmt.Errorf("ElfrOpenELA failed: %s", eventlog.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/15_ElfrRegisterEventSourceA.go
+++ b/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/15_ElfrRegisterEventSourceA.go
@@ -10,6 +10,7 @@ import (
 
 	eventlog "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	mseven "github.com/TheManticoreProject/Manticore/windows/protocols/ms-even"
 )
 
@@ -39,7 +40,7 @@ func ElfrRegisterEventSourceA(rpc ndr.Invoker, uNCServerName ndr.STR, moduleName
 		return
 	}
 	LogHandle = resp.LogHandle
-	if uint32(resp.Status) != eventlog.StatusSuccess {
+	if win32.WIN32_ERROR(resp.Status) != win32.ERROR_SUCCESS {
 		err = fmt.Errorf("ElfrRegisterEventSourceA failed: %s", eventlog.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/16_ElfrOpenBELA.go
+++ b/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/16_ElfrOpenBELA.go
@@ -10,6 +10,7 @@ import (
 
 	eventlog "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	mseven "github.com/TheManticoreProject/Manticore/windows/protocols/ms-even"
 )
 
@@ -37,7 +38,7 @@ func ElfrOpenBELA(rpc ndr.Invoker, uNCServerName ndr.STR, backupFileName mseven.
 		return
 	}
 	LogHandle = resp.LogHandle
-	if uint32(resp.Status) != eventlog.StatusSuccess {
+	if win32.WIN32_ERROR(resp.Status) != win32.ERROR_SUCCESS {
 		err = fmt.Errorf("ElfrOpenBELA failed: %s", eventlog.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/17_ElfrReadELA.go
+++ b/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/17_ElfrReadELA.go
@@ -10,6 +10,7 @@ import (
 
 	eventlog "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	mseven "github.com/TheManticoreProject/Manticore/windows/protocols/ms-even"
 )
 
@@ -47,7 +48,7 @@ func ElfrReadELA(rpc ndr.Invoker, logHandle mseven.IELF_HANDLE, readFlags ndr.DW
 	Buffer = resp.Buffer
 	NumberOfBytesRead = resp.NumberOfBytesRead
 	MinNumberOfBytesNeeded = resp.MinNumberOfBytesNeeded
-	if uint32(resp.Status) != eventlog.StatusSuccess {
+	if win32.WIN32_ERROR(resp.Status) != win32.ERROR_SUCCESS {
 		err = fmt.Errorf("ElfrReadELA failed: %s", eventlog.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/18_ElfrReportEventA.go
+++ b/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/18_ElfrReportEventA.go
@@ -10,6 +10,7 @@ import (
 
 	eventlog "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mseven "github.com/TheManticoreProject/Manticore/windows/protocols/ms-even"
 )
@@ -66,7 +67,7 @@ func ElfrReportEventA(rpc ndr.Invoker, logHandle mseven.IELF_HANDLE, time ndr.DW
 	}
 	RecordNumber = resp.RecordNumber
 	TimeWritten = resp.TimeWritten
-	if uint32(resp.Status) != eventlog.StatusSuccess {
+	if win32.WIN32_ERROR(resp.Status) != win32.ERROR_SUCCESS {
 		err = fmt.Errorf("ElfrReportEventA failed: %s", eventlog.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/22_ElfrGetLogInformation.go
+++ b/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/22_ElfrGetLogInformation.go
@@ -10,6 +10,7 @@ import (
 
 	eventlog "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	mseven "github.com/TheManticoreProject/Manticore/windows/protocols/ms-even"
 )
 
@@ -43,7 +44,7 @@ func ElfrGetLogInformation(rpc ndr.Invoker, logHandle mseven.IELF_HANDLE, infoLe
 	}
 	LpBuffer = resp.LpBuffer
 	PcbBytesNeeded = resp.PcbBytesNeeded
-	if uint32(resp.Status) != eventlog.StatusSuccess {
+	if win32.WIN32_ERROR(resp.Status) != win32.ERROR_SUCCESS {
 		err = fmt.Errorf("ElfrGetLogInformation failed: %s", eventlog.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/24_ElfrReportEventAndSourceW.go
+++ b/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/24_ElfrReportEventAndSourceW.go
@@ -10,6 +10,7 @@ import (
 
 	eventlog "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mseven "github.com/TheManticoreProject/Manticore/windows/protocols/ms-even"
 )
@@ -70,7 +71,7 @@ func ElfrReportEventAndSourceW(rpc ndr.Invoker, logHandle mseven.IELF_HANDLE, ti
 	}
 	RecordNumber = resp.RecordNumber
 	TimeWritten = resp.TimeWritten
-	if uint32(resp.Status) != eventlog.StatusSuccess {
+	if win32.WIN32_ERROR(resp.Status) != win32.ERROR_SUCCESS {
 		err = fmt.Errorf("ElfrReportEventAndSourceW failed: %s", eventlog.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/25_ElfrReportEventExW.go
+++ b/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/25_ElfrReportEventExW.go
@@ -10,6 +10,7 @@ import (
 
 	eventlog "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mseven "github.com/TheManticoreProject/Manticore/windows/protocols/ms-even"
 )
@@ -62,7 +63,7 @@ func ElfrReportEventExW(rpc ndr.Invoker, logHandle mseven.IELF_HANDLE, timeGener
 		return
 	}
 	RecordNumber = resp.RecordNumber
-	if uint32(resp.Status) != eventlog.StatusSuccess {
+	if win32.WIN32_ERROR(resp.Status) != win32.ERROR_SUCCESS {
 		err = fmt.Errorf("ElfrReportEventExW failed: %s", eventlog.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/26_ElfrReportEventExA.go
+++ b/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/functions/26_ElfrReportEventExA.go
@@ -10,6 +10,7 @@ import (
 
 	eventlog "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	mseven "github.com/TheManticoreProject/Manticore/windows/protocols/ms-even"
 )
@@ -62,7 +63,7 @@ func ElfrReportEventExA(rpc ndr.Invoker, logHandle mseven.IELF_HANDLE, timeGener
 		return
 	}
 	RecordNumber = resp.RecordNumber
-	if uint32(resp.Status) != eventlog.StatusSuccess {
+	if win32.WIN32_ERROR(resp.Status) != win32.ERROR_SUCCESS {
 		err = fmt.Errorf("ElfrReportEventExA failed: %s", eventlog.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/interface.go
+++ b/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/interface.go
@@ -2,9 +2,9 @@
 // syntax 82273fdc-e32a-18c3-3f78-827929dc23ea version 0.0 ([MS-EVEN]).
 //
 // This package holds only the interface-level descriptor (abstract syntax,
-// transport endpoint, opnums, opnum<->name maps, and status constants). The NDR
-// wire types live in windows/protocols/ms-even and the method stubs in functions;
-// both depend on this package, never the reverse.
+// transport endpoint, opnums, and opnum<->name maps). The NDR wire types live in
+// windows/protocols/ms-even and the method stubs in functions; both depend on this
+// package, never the reverse.
 package rpcinterface_82273fdce32a18c33f78827929dc23ea_0_0
 
 // IDL source: [MS-EVEN] — this interface is translated from and verified
@@ -13,9 +13,8 @@ package rpcinterface_82273fdce32a18c33f78827929dc23ea_0_0
 // A fetched copy is kept at ms-even.idl in the interface directory.
 
 import (
-	"fmt"
-
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	"github.com/TheManticoreProject/Manticore/windows/guid"
 )
 
@@ -51,28 +50,22 @@ const (
 	OpnumElfrReportEventExA        uint16 = 26
 )
 
-// Status codes returned by this interface. The methods are declared to return
-// NTSTATUS, but the EventLog Remoting Protocol reports failures as Win32 error
-// codes ([MS-EVEN] 3.1.4; [MS-ERREF] 2.2/2.3). Both families are listed here.
+// The methods are declared to return NTSTATUS, but the EventLog Remoting Protocol
+// reports failures as Win32 error codes ([MS-EVEN] 3.1.4, [MS-ERREF] 2.2). Those
+// Win32 codes are not declared here: the whole of [MS-ERREF] 2.2 lives in
+// github.com/TheManticoreProject/Manticore/windows/errors/win32 as the WIN32_ERROR
+// type, and a subset repeated here would cover a fraction of that 2703-code table
+// while drifting from it. Convert a returned status with win32.WIN32_ERROR(status)
+// and compare against win32.ERROR_SUCCESS and the rest.
+//
+// The two NTSTATUS values below are the exception. A server may fail a read with
+// them directly, and they belong to [MS-ERREF] 2.3, which the Win32 table does not
+// cover: it has no row for 0xC0000023 or 0xC000000D, so it renders both as hex.
+// These stay declared here and StatusString decodes them before deferring to the
+// shared table for everything else.
 const (
-	StatusSuccess uint32 = 0x00000000 // ERROR_SUCCESS
-
-	// Win32 error codes ([MS-ERREF] 2.2).
-	ErrorFileNotFound        uint32 = 0x00000002 // ERROR_FILE_NOT_FOUND
-	ErrorAccessDenied        uint32 = 0x00000005 // ERROR_ACCESS_DENIED
-	ErrorInvalidHandle       uint32 = 0x00000006 // ERROR_INVALID_HANDLE
-	ErrorNotEnoughMemory     uint32 = 0x00000008 // ERROR_NOT_ENOUGH_MEMORY
-	ErrorHandleEOF           uint32 = 0x00000026 // ERROR_HANDLE_EOF (read past the last record)
-	ErrorInvalidParameter    uint32 = 0x00000057 // ERROR_INVALID_PARAMETER
-	ErrorInsufficientBuffer  uint32 = 0x0000007A // ERROR_INSUFFICIENT_BUFFER
-	ErrorEventlogFileCorrupt uint32 = 0x000005DC // ERROR_EVENTLOG_FILE_CORRUPT
-	ErrorEventlogCantStart   uint32 = 0x000005DD // ERROR_EVENTLOG_CANT_START
-	ErrorLogFileFull         uint32 = 0x000005DE // ERROR_LOG_FILE_FULL
-	ErrorEventlogFileChanged uint32 = 0x000005DF // ERROR_EVENTLOG_FILE_CHANGED
-
-	// NTSTATUS codes ([MS-ERREF] 2.3) that the server may return directly.
-	StatusBufferTooSmall   uint32 = 0xC0000023 // STATUS_BUFFER_TOO_SMALL
-	StatusInvalidParameter uint32 = 0xC000000D // STATUS_INVALID_PARAMETER
+	StatusBufferTooSmall   uint32 = 0xC0000023 // STATUS_BUFFER_TOO_SMALL, an [MS-ERREF] 2.3 NTSTATUS with no [MS-ERREF] 2.2 row
+	StatusInvalidParameter uint32 = 0xC000000D // STATUS_INVALID_PARAMETER, an [MS-ERREF] 2.3 NTSTATUS with no [MS-ERREF] 2.2 row
 )
 
 // SyntaxID returns the eventlog abstract syntax identifier:
@@ -85,40 +78,18 @@ func SyntaxID() syntax.SyntaxID {
 	}
 }
 
-// StatusString returns a mnemonic for the documented status codes, otherwise the
-// hex value.
+// StatusString names the two NTSTATUS values this interface declares locally, which
+// [MS-ERREF] 2.2 has no row for, and defers every other status to the shared
+// [MS-ERREF] 2.2 table, which names each code the specification defines and renders
+// hex only for values it does not.
 func StatusString(status uint32) string {
 	switch status {
-	case StatusSuccess:
-		return "ERROR_SUCCESS"
-	case ErrorFileNotFound:
-		return "ERROR_FILE_NOT_FOUND"
-	case ErrorAccessDenied:
-		return "ERROR_ACCESS_DENIED"
-	case ErrorInvalidHandle:
-		return "ERROR_INVALID_HANDLE"
-	case ErrorNotEnoughMemory:
-		return "ERROR_NOT_ENOUGH_MEMORY"
-	case ErrorHandleEOF:
-		return "ERROR_HANDLE_EOF"
-	case ErrorInvalidParameter:
-		return "ERROR_INVALID_PARAMETER"
-	case ErrorInsufficientBuffer:
-		return "ERROR_INSUFFICIENT_BUFFER"
-	case ErrorEventlogFileCorrupt:
-		return "ERROR_EVENTLOG_FILE_CORRUPT"
-	case ErrorEventlogCantStart:
-		return "ERROR_EVENTLOG_CANT_START"
-	case ErrorLogFileFull:
-		return "ERROR_LOG_FILE_FULL"
-	case ErrorEventlogFileChanged:
-		return "ERROR_EVENTLOG_FILE_CHANGED"
 	case StatusBufferTooSmall:
 		return "STATUS_BUFFER_TOO_SMALL"
 	case StatusInvalidParameter:
 		return "STATUS_INVALID_PARAMETER"
 	default:
-		return fmt.Sprintf("0x%08x", status)
+		return win32.WIN32_ERROR(status).String()
 	}
 }
 

--- a/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/interface_test.go
+++ b/network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/interface_test.go
@@ -1,6 +1,10 @@
 package rpcinterface_82273fdce32a18c33f78827929dc23ea_0_0
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
+)
 
 // TestSyntaxID pins the abstract syntax: 82273fdc-e32a-18c3-3f78-827929dc23ea v0.0.
 func TestSyntaxID(t *testing.T) {
@@ -46,19 +50,81 @@ func TestOpnumNameRoundTrip(t *testing.T) {
 	}
 }
 
-// TestStatusString spot-checks a few mnemonics and the hex fallback.
-func TestStatusString(t *testing.T) {
-	cases := map[uint32]string{
-		StatusSuccess:            "ERROR_SUCCESS",
-		ErrorAccessDenied:        "ERROR_ACCESS_DENIED",
-		ErrorHandleEOF:           "ERROR_HANDLE_EOF",
-		ErrorEventlogFileChanged: "ERROR_EVENTLOG_FILE_CHANGED",
-		StatusBufferTooSmall:     "STATUS_BUFFER_TOO_SMALL",
-		0xdeadbeef:               "0xdeadbeef",
+// TestStatusCodesResolveThroughWin32 pins that the Win32 codes [MS-EVEN] 3.1.4
+// documents for the EventLog Remoting Protocol resolve through the shared [MS-ERREF]
+// 2.2 table under their specification names, that a code this interface never
+// enumerated now renders by name rather than as undecoded hex, and that a value the
+// specification does not define still renders as hex.
+func TestStatusCodesResolveThroughWin32(t *testing.T) {
+	documented := map[uint32]string{
+		0x00000000: "ERROR_SUCCESS",
+		0x00000002: "ERROR_FILE_NOT_FOUND",
+		0x00000005: "ERROR_ACCESS_DENIED",
+		0x00000006: "ERROR_INVALID_HANDLE",
+		0x00000008: "ERROR_NOT_ENOUGH_MEMORY",
+		0x00000026: "ERROR_HANDLE_EOF",
+		0x00000057: "ERROR_INVALID_PARAMETER",
+		0x0000007A: "ERROR_INSUFFICIENT_BUFFER",
+		0x000005DC: "ERROR_EVENTLOG_FILE_CORRUPT",
+		0x000005DD: "ERROR_EVENTLOG_CANT_START",
+		0x000005DE: "ERROR_LOG_FILE_FULL",
+		0x000005DF: "ERROR_EVENTLOG_FILE_CHANGED",
 	}
-	for code, want := range cases {
-		if got := StatusString(code); got != want {
-			t.Errorf("StatusString(0x%08x) = %q, want %q", code, got, want)
+	for code, name := range documented {
+		if got := win32.WIN32_ERROR(code).String(); got != name {
+			t.Errorf("win32.WIN32_ERROR(0x%08x).String() = %q, want %q", code, got, name)
 		}
+		if resolved, defined := win32.FromName(name); !defined || uint32(resolved) != code {
+			t.Errorf("win32.FromName(%q) = 0x%08x, %v; want 0x%08x, true", name, uint32(resolved), defined, code)
+		}
+	}
+
+	// ERROR_MORE_DATA was outside the subset this interface used to declare, so it
+	// rendered as hex; it resolves by name now.
+	if got := win32.WIN32_ERROR(0x000000EA).String(); got != "ERROR_MORE_DATA" {
+		t.Errorf("win32.WIN32_ERROR(0x000000ea).String() = %q, want ERROR_MORE_DATA", got)
+	}
+
+	// A value [MS-ERREF] 2.2 does not define still renders as hex.
+	if got := win32.WIN32_ERROR(0xdeadbeef).String(); got != "0xdeadbeef" {
+		t.Errorf("win32.WIN32_ERROR(0xdeadbeef).String() = %q, want hex", got)
+	}
+}
+
+// TestStatusStringKeepsTheNTStatusCodes pins the two values this interface still
+// decodes itself. Both are [MS-ERREF] 2.3 NTSTATUS codes with no row in the
+// [MS-ERREF] 2.2 Win32 table, so the shared table renders them as hex and
+// StatusString names them; everything else defers to the shared table.
+func TestStatusStringKeepsTheNTStatusCodes(t *testing.T) {
+	if StatusBufferTooSmall != 0xC0000023 {
+		t.Errorf("StatusBufferTooSmall = 0x%08x, want 0xc0000023", StatusBufferTooSmall)
+	}
+	if StatusInvalidParameter != 0xC000000D {
+		t.Errorf("StatusInvalidParameter = 0x%08x, want 0xc000000d", StatusInvalidParameter)
+	}
+	if got := StatusString(StatusBufferTooSmall); got != "STATUS_BUFFER_TOO_SMALL" {
+		t.Errorf("StatusString(0xc0000023) = %q, want STATUS_BUFFER_TOO_SMALL", got)
+	}
+	if got := StatusString(StatusInvalidParameter); got != "STATUS_INVALID_PARAMETER" {
+		t.Errorf("StatusString(0xc000000d) = %q, want STATUS_INVALID_PARAMETER", got)
+	}
+	if got := win32.WIN32_ERROR(StatusBufferTooSmall).String(); got != "0xc0000023" {
+		t.Errorf("win32.WIN32_ERROR(0xc0000023).String() = %q, want hex", got)
+	}
+	if got := win32.WIN32_ERROR(StatusInvalidParameter).String(); got != "0xc000000d" {
+		t.Errorf("win32.WIN32_ERROR(0xc000000d).String() = %q, want hex", got)
+	}
+	// Every other code defers to the shared table.
+	if got := StatusString(0x00000000); got != "ERROR_SUCCESS" {
+		t.Errorf("StatusString(0x00000000) = %q, want ERROR_SUCCESS", got)
+	}
+	if got := StatusString(0x000005DF); got != "ERROR_EVENTLOG_FILE_CHANGED" {
+		t.Errorf("StatusString(0x000005df) = %q, want ERROR_EVENTLOG_FILE_CHANGED", got)
+	}
+	if got := StatusString(0x0000000D); got != "ERROR_INVALID_DATA" {
+		t.Errorf("StatusString(0x0000000d) = %q, want ERROR_INVALID_DATA", got)
+	}
+	if got := StatusString(0xdeadbeef); got != "0xdeadbeef" {
+		t.Errorf("StatusString(0xdeadbeef) = %q, want hex fallback", got)
 	}
 }


### PR DESCRIPTION
### Linked Issue

Refs #1219 — phase 4, eventlog (EventLog Remoting Protocol, [MS-EVEN], abstract syntax 82273fdc-e32a-18c3-3f78-827929dc23ea version 0.0).

### Root Cause

The eventlog descriptor declared its own block of fourteen status constants and a `StatusString` switch over them. Twelve of those values are rows of [MS-ERREF] 2.2, which `windows/errors/win32` already holds in full as 2703 codes under the `WIN32_ERROR` type, so the block was a hand-maintained duplicate of twelve rows out of 2703 with nothing keeping it in step with the generated table. It was also a ceiling: `StatusString` named the codes it listed and rendered every other value as bare hex, so a status the protocol can legitimately return but the subset omitted — `ERROR_INVALID_DATA`, `ERROR_MORE_DATA`, `ERROR_NOT_SUPPORTED`, `RPC_S_SERVER_UNAVAILABLE` — came out of a failure message undecoded even though the shared table names it.

### Fix Description

The twelve Win32 values are gone from the descriptor and the twenty-three method stubs compare the returned status through the shared type: `win32.WIN32_ERROR(resp.Status) != win32.ERROR_SUCCESS`. No alias constants, local re-declarations or delegating wrappers for codes the shared table holds remain. Each stub keeps its `eventlog` import for the opnum its request type reports.

Every replacement was derived from the value, not from the private identifier. Each numeric constant was looked up in the committed extract at `windows/errors/errgen/ms-erref-2.2-win32.tsv` and the symbolic name that row records is the constant now referenced. Twelve values resolved and the private camel-cased name agreed with the specification in all twelve; nothing was folded onto a near-miss name.

Two values have no row in [MS-ERREF] 2.2 and stay local. `StatusBufferTooSmall` (0xC0000023) and `StatusInvalidParameter` (0xC000000D) are NTSTATUS codes from [MS-ERREF] 2.3, which the Win32 extract does not cover, so the shared table renders both as hex. `StatusString` is reduced to those two cases and defers everything else to `win32.WIN32_ERROR(status).String()`, which is what the stubs' failure messages call, so a server that fails a read with either code still gets its mnemonic while every Win32 code now resolves through the shared table. This is the same shape as the fax interface (ea0a3165-4834-11d2-a6f8-00c04fa346cc/4.0), which retained its `FAX_ERR_*` values for the same reason.

The rewrite was done one comparison term at a time, not one condition at a time, so a condition accepting `ERROR_HANDLE_EOF` or `ERROR_MORE_DATA` alongside success could not lose a term and still compile. All twenty-three conditions turned out to be single-term, and a scripted per-`if` term count over every touched file is identical to the parent revision. No tolerance the code did not already have was introduced.

### How Verified

- `go build ./...` — exit 0.
- `go vet ./...` — exit 0, no diagnostics.
- `go test -count=1 ./...` — 313 packages `ok`, 0 failures, matching `main`; `network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0` ok 0.004s.
- `CGO_ENABLED=0 go build ./...` for `windows/amd64`, `windows/386`, `linux/arm64`, `linux/386` — all exit 0.
- Scripted per-`if` comparison-term count against `HEAD` for all 25 touched files: identical for the 23 stubs and `interface.go`; the only difference is `interface_test.go`, where the replacement test adds assertions.
- `grep -rn` over the interface for the twelve migrated identifiers (`StatusSuccess`, `ErrorFileNotFound`, `ErrorAccessDenied`, `ErrorInvalidHandle`, `ErrorNotEnoughMemory`, `ErrorHandleEOF`, `ErrorInvalidParameter`, `ErrorInsufficientBuffer`, `ErrorEventlogFileCorrupt`, `ErrorEventlogCantStart`, `ErrorLogFileFull`, `ErrorEventlogFileChanged`) — no hits anywhere in the repository.
- `grep -rn` over the whole tree for the interface's import path: the only references outside the interface directory are the UUID string in `network/dcerpc/interfaces/catalog/data.go`, which does not touch the status codes. No consumer in `network/dcerpc/ms-protocols/` or `network/smb/smb_v10/server/rpcpipe/`.
- `grep -rn` for `Contains`/`HasPrefix` against rendered mnemonics inside the interface — none, so no test classifies failures by matching `"ERROR_"`/`"NERR_"`/`"STATUS_"` text.
- `gofmt -l` over each touched file — no file listed; nothing was reformatted.

### Test Coverage

`TestStatusString` is replaced by two tests in `interface_test.go`. `TestStatusCodesResolveThroughWin32` pins all twelve migrated values to their specification names through the shared table in both directions (`WIN32_ERROR.String` and `win32.FromName`), asserts that `ERROR_MORE_DATA` (0x000000EA), a code outside the old subset, now renders by name, and that 0xdeadbeef still renders as hex. `TestStatusStringKeepsTheNTStatusCodes` pins the two retained values to 0xC0000023 and 0xC000000D, asserts `StatusString` names both, asserts the shared table renders both as hex, and checks that `ERROR_SUCCESS`, `ERROR_EVENTLOG_FILE_CHANGED`, `ERROR_INVALID_DATA` and the hex fallback all come back through the deferred path. Every value used in the tests was looked up in the extract rather than recalled. `TestSyntaxID`, `TestPipeName` and `TestOpnumNameRoundTrip` are unchanged.

### Scope of Change

Files, all under `network/dcerpc/interfaces/82273fdc-e32a-18c3-3f78-827929dc23ea/0.0/`:

- `interface.go` — the Win32 constant block and its comment replaced by the note pointing at `windows/errors/win32`, the two NTSTATUS constants retained with their rationale, `StatusString` reduced to those two cases with a `win32` fallthrough, `"fmt"` dropped (nothing else used it) and the `win32` import added in sorted position. `PipeName`, `SyntaxID()`, the twenty-three opnum constants, `OpnumToName` and `NameToOpnum` are untouched; the package doc no longer advertises status constants.
- `interface_test.go` — `TestStatusString` replaced as described.
- 23 stubs, `functions/00_ElfrClearELFW.go` through `functions/26_ElfrReportEventExA.go` — one comparison term each rewritten through `win32`, plus the `win32` import. `functions/functions.go` is untouched.

Submodule pointer updated: no — the repository has no submodules.

Behavioural changes: a failure message now names any [MS-ERREF] 2.2 code the old fourteen-value subset omitted instead of printing hex. The twelve migrated codes and the two retained NTSTATUS codes render exactly the same text as before. The success test is byte-for-byte the same comparison against 0x00000000. No control flow, no wire format and no exported signature changed.

### Risk and Rollout

Low. The change is confined to one interface directory, is a straight substitution of an identical numeric comparison, and alters only the text of already-failing error messages. `StatusString` keeps its signature and its behaviour for the two codes it still names, so any caller of it continues to compile and to get the same string. The twelve deleted identifiers were referenced nowhere outside the interface, so no consumer can break. Rollback is a revert of the single commit.

### Notes

The two retained values are the only ones in this interface without an [MS-ERREF] 2.2 row, and both are genuine NTSTATUS codes rather than a collision: 0xC0000023 and 0xC000000D fall outside the Win32 table's range entirely, so unlike the fax range there is no unrelated Win32 name to be folded onto. `windows/errors/nt_status` exists and is the eventual home for them, but moving them is out of scope for a phase-4 change whose target is `windows/errors/win32`.

The stubs render failures with `eventlog.StatusString(uint32(resp.Status))` rather than `win32.WIN32_ERROR(resp.Status).String()` directly. That is deliberate and follows the fax interface: rendering through `win32` alone would have degraded a server-returned `STATUS_BUFFER_TOO_SMALL` or `STATUS_INVALID_PARAMETER` from a mnemonic to hex, a behavioural regression on a read path. The success comparison itself goes through `win32` in every stub.

`f6beaff7-1e19-4fbb-9f8f-b89e2018337c/1.0` (IEventService, [MS-EVEN6]) was not touched.
