### PR TITLE
Route rasrpc status reporting through win32 (Refs #1219)

### DIFF
--- a/network/dcerpc/interfaces/20610036-fa22-11cf-9823-00a0c911e5df/1.0/functions/05_RasRpcDeleteEntry.go
+++ b/network/dcerpc/interfaces/20610036-fa22-11cf-9823-00a0c911e5df/1.0/functions/05_RasRpcDeleteEntry.go
@@ -10,6 +10,7 @@ import (
 
 	rasrpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/20610036-fa22-11cf-9823-00a0c911e5df/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 )
 
 // rasRpcDeleteEntryRequest carries the [in] parameters of RasRpcDeleteEntry.
@@ -37,7 +38,7 @@ func RasRpcDeleteEntry(rpc ndr.Invoker, lpszPhonebook ndr.WSTR, lpszEntry ndr.WS
 		err = fmt.Errorf("RasRpcDeleteEntry: %w", err)
 		return
 	}
-	if uint32(resp.Status) != rasrpc.StatusSuccess {
+	if win32.WIN32_ERROR(resp.Status) != win32.ERROR_SUCCESS {
 		err = fmt.Errorf("RasRpcDeleteEntry failed: %s", rasrpc.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/20610036-fa22-11cf-9823-00a0c911e5df/1.0/functions/09_RasRpcGetUserPreferences.go
+++ b/network/dcerpc/interfaces/20610036-fa22-11cf-9823-00a0c911e5df/1.0/functions/09_RasRpcGetUserPreferences.go
@@ -10,6 +10,7 @@ import (
 
 	rasrpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/20610036-fa22-11cf-9823-00a0c911e5df/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	msrrasm "github.com/TheManticoreProject/Manticore/windows/protocols/ms-rrasm"
 )
 
@@ -40,7 +41,7 @@ func RasRpcGetUserPreferences(rpc ndr.Invoker, pUser msrrasm.RASRPC_PBUSER, dwMo
 		return
 	}
 	PUser = resp.PUser
-	if uint32(resp.Status) != rasrpc.StatusSuccess {
+	if win32.WIN32_ERROR(resp.Status) != win32.ERROR_SUCCESS {
 		err = fmt.Errorf("RasRpcGetUserPreferences failed: %s", rasrpc.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/20610036-fa22-11cf-9823-00a0c911e5df/1.0/functions/10_RasRpcSetUserPreferences.go
+++ b/network/dcerpc/interfaces/20610036-fa22-11cf-9823-00a0c911e5df/1.0/functions/10_RasRpcSetUserPreferences.go
@@ -10,6 +10,7 @@ import (
 
 	rasrpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/20610036-fa22-11cf-9823-00a0c911e5df/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	msrrasm "github.com/TheManticoreProject/Manticore/windows/protocols/ms-rrasm"
 )
 
@@ -38,7 +39,7 @@ func RasRpcSetUserPreferences(rpc ndr.Invoker, pUser msrrasm.RASRPC_PBUSER, dwMo
 		err = fmt.Errorf("RasRpcSetUserPreferences: %w", err)
 		return
 	}
-	if uint32(resp.Status) != rasrpc.StatusSuccess {
+	if win32.WIN32_ERROR(resp.Status) != win32.ERROR_SUCCESS {
 		err = fmt.Errorf("RasRpcSetUserPreferences failed: %s", rasrpc.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/20610036-fa22-11cf-9823-00a0c911e5df/1.0/functions/11_RasRpcGetSystemDirectory.go
+++ b/network/dcerpc/interfaces/20610036-fa22-11cf-9823-00a0c911e5df/1.0/functions/11_RasRpcGetSystemDirectory.go
@@ -10,6 +10,7 @@ import (
 
 	rasrpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/20610036-fa22-11cf-9823-00a0c911e5df/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 )
 
 // rasRpcGetSystemDirectoryRequest carries the [in] parameters of RasRpcGetSystemDirectory.
@@ -39,7 +40,7 @@ func RasRpcGetSystemDirectory(rpc ndr.Invoker, lpBuffer ndr.WSTR, uSize uint32) 
 		return
 	}
 	LpBuffer = resp.LpBuffer
-	if uint32(resp.Status) != rasrpc.StatusSuccess {
+	if win32.WIN32_ERROR(resp.Status) != win32.ERROR_SUCCESS {
 		err = fmt.Errorf("RasRpcGetSystemDirectory failed: %s", rasrpc.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/20610036-fa22-11cf-9823-00a0c911e5df/1.0/functions/12_RasRpcSubmitRequest.go
+++ b/network/dcerpc/interfaces/20610036-fa22-11cf-9823-00a0c911e5df/1.0/functions/12_RasRpcSubmitRequest.go
@@ -10,6 +10,7 @@ import (
 
 	rasrpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/20610036-fa22-11cf-9823-00a0c911e5df/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 )
 
 // rasRpcSubmitRequestRequest carries the [in] parameters of RasRpcSubmitRequest.
@@ -39,7 +40,7 @@ func RasRpcSubmitRequest(rpc ndr.Invoker, pReqBuffer []uint8, dwcbBufSize ndr.DW
 		return
 	}
 	PReqBuffer = resp.PReqBuffer
-	if uint32(resp.Status) != rasrpc.StatusSuccess {
+	if win32.WIN32_ERROR(resp.Status) != win32.ERROR_SUCCESS {
 		err = fmt.Errorf("RasRpcSubmitRequest failed: %s", rasrpc.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/20610036-fa22-11cf-9823-00a0c911e5df/1.0/functions/14_RasRpcGetInstalledProtocolsEx.go
+++ b/network/dcerpc/interfaces/20610036-fa22-11cf-9823-00a0c911e5df/1.0/functions/14_RasRpcGetInstalledProtocolsEx.go
@@ -10,6 +10,7 @@ import (
 
 	rasrpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/20610036-fa22-11cf-9823-00a0c911e5df/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 )
 
 // rasRpcGetInstalledProtocolsExRequest carries the [in] parameters of RasRpcGetInstalledProtocolsEx.
@@ -41,7 +42,7 @@ func RasRpcGetInstalledProtocolsEx(rpc ndr.Invoker, fRouter ndr.BOOL, fRasCli nd
 		err = fmt.Errorf("RasRpcGetInstalledProtocolsEx: %w", err)
 		return
 	}
-	if uint32(resp.Status) != rasrpc.StatusSuccess {
+	if win32.WIN32_ERROR(resp.Status) != win32.ERROR_SUCCESS {
 		err = fmt.Errorf("RasRpcGetInstalledProtocolsEx failed: %s", rasrpc.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/20610036-fa22-11cf-9823-00a0c911e5df/1.0/functions/15_RasRpcGetVersion.go
+++ b/network/dcerpc/interfaces/20610036-fa22-11cf-9823-00a0c911e5df/1.0/functions/15_RasRpcGetVersion.go
@@ -10,6 +10,7 @@ import (
 
 	rasrpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/20610036-fa22-11cf-9823-00a0c911e5df/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 )
 
 // rasRpcGetVersionRequest carries the [in] parameters of RasRpcGetVersion.
@@ -37,7 +38,7 @@ func RasRpcGetVersion(rpc ndr.Invoker, pdwVersion ndr.DWORD) (PdwVersion ndr.DWO
 		return
 	}
 	PdwVersion = resp.PdwVersion
-	if uint32(resp.Status) != rasrpc.StatusSuccess {
+	if win32.WIN32_ERROR(resp.Status) != win32.ERROR_SUCCESS {
 		err = fmt.Errorf("RasRpcGetVersion failed: %s", rasrpc.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/20610036-fa22-11cf-9823-00a0c911e5df/1.0/interface.go
+++ b/network/dcerpc/interfaces/20610036-fa22-11cf-9823-00a0c911e5df/1.0/interface.go
@@ -12,9 +12,8 @@ package rpcinterface_20610036fa2211cf982300a0c911e5df_1_0
 // A fetched copy is kept at ms-rrasm.idl in the interface directory.
 
 import (
-	"fmt"
-
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	"github.com/TheManticoreProject/Manticore/windows/guid"
 )
 
@@ -34,19 +33,24 @@ const (
 	OpnumRasRpcGetVersion              uint16 = 15
 )
 
-// Status codes. rasrpc methods return a Win32 error code (32-bit) as their return
-// value ([MS-RRASM] 3.3.4; [MS-ERREF] 2.2). The values below are the ones commonly
-// returned; any other code is rendered as hex by StatusString.
+// rasrpc methods return a Win32 error code (32-bit) as their return value
+// ([MS-RRASM] 3.3.4; [MS-ERREF] 2.2). Those codes are not declared here. The whole
+// of [MS-ERREF] 2.2 lives in
+// github.com/TheManticoreProject/Manticore/windows/errors/win32 as the WIN32_ERROR
+// type, and a subset repeated here would cover a fraction of that 2703-code table
+// while drifting from it. Convert a returned status with win32.WIN32_ERROR(status)
+// and compare against win32.ERROR_SUCCESS and the rest.
+//
+// The RAS-specific code below is the exception. Remote Access errors live in the
+// 600..999 range that raserror.h owns (RASBASE is 600) and [MS-ERREF] 2.2 does not
+// cover that block at all: it assigns those values to unrelated errors of its own,
+// so the shared table decodes 0x0000025B as ERROR_MARSHALL_OVERFLOW, a
+// user/kernel marshaling buffer overflow, rather than as the RAS
+// ERROR_BUFFER_TOO_SMALL (603) this interface means by it. It stays declared here
+// and StatusString decodes it before deferring to the shared table for everything
+// else.
 const (
-	StatusSuccess            uint32 = 0x00000000 // ERROR_SUCCESS
-	StatusFileNotFound       uint32 = 0x00000002 // ERROR_FILE_NOT_FOUND
-	StatusAccessDenied       uint32 = 0x00000005 // ERROR_ACCESS_DENIED
-	StatusInvalidHandle      uint32 = 0x00000006 // ERROR_INVALID_HANDLE
-	StatusNotEnoughMemory    uint32 = 0x00000008 // ERROR_NOT_ENOUGH_MEMORY
-	StatusNotSupported       uint32 = 0x00000032 // ERROR_NOT_SUPPORTED
-	StatusInvalidParameter   uint32 = 0x00000057 // ERROR_INVALID_PARAMETER
-	StatusInsufficientBuffer uint32 = 0x0000007A // ERROR_INSUFFICIENT_BUFFER
-	StatusBufferTooSmall     uint32 = 0x0000025B // ERROR_BUFFER_TOO_SMALL
+	StatusBufferTooSmall uint32 = 0x0000025B // ERROR_BUFFER_TOO_SMALL (603), RASBASE+3 in raserror.h
 )
 
 // SyntaxID returns the rasrpc abstract syntax identifier:
@@ -59,30 +63,16 @@ func SyntaxID() syntax.SyntaxID {
 	}
 }
 
-// StatusString returns a mnemonic for the documented status codes, otherwise the
-// hex value.
+// StatusString names the RAS-specific status code, whose value [MS-ERREF] 2.2
+// assigns to an unrelated error, and defers every other status to the shared
+// [MS-ERREF] 2.2 table, which names each code the specification defines and renders
+// hex only for values it does not.
 func StatusString(status uint32) string {
 	switch status {
-	case StatusSuccess:
-		return "ERROR_SUCCESS"
-	case StatusFileNotFound:
-		return "ERROR_FILE_NOT_FOUND"
-	case StatusAccessDenied:
-		return "ERROR_ACCESS_DENIED"
-	case StatusInvalidHandle:
-		return "ERROR_INVALID_HANDLE"
-	case StatusNotEnoughMemory:
-		return "ERROR_NOT_ENOUGH_MEMORY"
-	case StatusNotSupported:
-		return "ERROR_NOT_SUPPORTED"
-	case StatusInvalidParameter:
-		return "ERROR_INVALID_PARAMETER"
-	case StatusInsufficientBuffer:
-		return "ERROR_INSUFFICIENT_BUFFER"
 	case StatusBufferTooSmall:
 		return "ERROR_BUFFER_TOO_SMALL"
 	default:
-		return fmt.Sprintf("0x%08x", status)
+		return win32.WIN32_ERROR(status).String()
 	}
 }
 

--- a/network/dcerpc/interfaces/20610036-fa22-11cf-9823-00a0c911e5df/1.0/interface_test.go
+++ b/network/dcerpc/interfaces/20610036-fa22-11cf-9823-00a0c911e5df/1.0/interface_test.go
@@ -1,6 +1,10 @@
 package rpcinterface_20610036fa2211cf982300a0c911e5df_1_0
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
+)
 
 // TestSyntaxID pins the abstract syntax identifier for the rasrpc interface
 // (20610036-fa22-11cf-9823-00a0c911e5df v1.0, [MS-RRASM]).
@@ -39,13 +43,76 @@ func TestOpnumNameRoundTrip(t *testing.T) {
 	}
 }
 
-// TestStatusString checks a known mnemonic and the hex fallback.
-func TestStatusString(t *testing.T) {
-	if got := StatusString(StatusSuccess); got != "ERROR_SUCCESS" {
-		t.Errorf("StatusString(0) = %q, want ERROR_SUCCESS", got)
+// TestStatusCodesResolveThroughWin32 pins that the eight Win32 codes this interface
+// used to declare itself resolve through the shared [MS-ERREF] 2.2 table under their
+// specification names, that a code the interface never enumerated now renders by
+// name rather than as undecoded hex, and that a value the specification does not
+// define still renders as hex.
+func TestStatusCodesResolveThroughWin32(t *testing.T) {
+	documented := map[uint32]string{
+		0x00000000: "ERROR_SUCCESS",
+		0x00000002: "ERROR_FILE_NOT_FOUND",
+		0x00000005: "ERROR_ACCESS_DENIED",
+		0x00000006: "ERROR_INVALID_HANDLE",
+		0x00000008: "ERROR_NOT_ENOUGH_MEMORY",
+		0x00000032: "ERROR_NOT_SUPPORTED",
+		0x00000057: "ERROR_INVALID_PARAMETER",
+		0x0000007A: "ERROR_INSUFFICIENT_BUFFER",
+	}
+	for code, name := range documented {
+		if got := win32.WIN32_ERROR(code).String(); got != name {
+			t.Errorf("win32.WIN32_ERROR(0x%08x).String() = %q, want %q", code, got, name)
+		}
+		if resolved, defined := win32.FromName(name); !defined || uint32(resolved) != code {
+			t.Errorf("win32.FromName(%q) = 0x%08x, %v; want 0x%08x, true", name, uint32(resolved), defined, code)
+		}
+		if got := StatusString(code); got != name {
+			t.Errorf("StatusString(0x%08x) = %q, want %q", code, got, name)
+		}
+	}
+
+	// ERROR_INVALID_LEVEL was outside the subset this interface used to declare, so
+	// it rendered as hex; it resolves by name now, through StatusString as well.
+	if got := win32.WIN32_ERROR(0x0000007C).String(); got != "ERROR_INVALID_LEVEL" {
+		t.Errorf("win32.WIN32_ERROR(0x0000007c).String() = %q, want ERROR_INVALID_LEVEL", got)
+	}
+	if got := StatusString(0x0000007C); got != "ERROR_INVALID_LEVEL" {
+		t.Errorf("StatusString(0x0000007c) = %q, want ERROR_INVALID_LEVEL", got)
+	}
+
+	// A value [MS-ERREF] 2.2 does not define still renders as hex.
+	if got := win32.WIN32_ERROR(0xDEADBEEF).String(); got != "0xdeadbeef" {
+		t.Errorf("win32.WIN32_ERROR(0xdeadbeef).String() = %q, want hex", got)
 	}
 	if got := StatusString(0xDEADBEEF); got != "0xdeadbeef" {
-		t.Errorf("StatusString(unknown) = %q, want 0xdeadbeef", got)
+		t.Errorf("StatusString(0xdeadbeef) = %q, want hex", got)
+	}
+}
+
+// TestStatusStringDecodesRASSpecificError pins the one reason StatusString still
+// exists: Remote Access errors live in the 600..999 range raserror.h owns, which
+// [MS-ERREF] 2.2 does not cover, so routing StatusBufferTooSmall through the shared
+// table would rename a RAS buffer-size complaint into an unrelated marshaling
+// overflow.
+func TestStatusStringDecodesRASSpecificError(t *testing.T) {
+	if StatusBufferTooSmall != 0x0000025B {
+		t.Fatalf("StatusBufferTooSmall = 0x%08x, want 0x0000025b (603, RASBASE+3)", StatusBufferTooSmall)
+	}
+	if StatusBufferTooSmall < 600 || StatusBufferTooSmall > 999 {
+		t.Errorf("StatusBufferTooSmall = %d, outside the RAS error range 600..999", StatusBufferTooSmall)
+	}
+	if got := StatusString(StatusBufferTooSmall); got != "ERROR_BUFFER_TOO_SMALL" {
+		t.Errorf("StatusString(0x0000025b) = %q, want ERROR_BUFFER_TOO_SMALL", got)
+	}
+
+	// The collision that makes the local constant necessary: the shared table names
+	// 0x0000025B for the user/kernel marshaling buffer, not for RAS, and it knows no
+	// code by the RAS name at all.
+	if got := win32.WIN32_ERROR(StatusBufferTooSmall).String(); got != "ERROR_MARSHALL_OVERFLOW" {
+		t.Errorf("win32.WIN32_ERROR(0x0000025b).String() = %q, want ERROR_MARSHALL_OVERFLOW", got)
+	}
+	if resolved, defined := win32.FromName("ERROR_BUFFER_TOO_SMALL"); defined {
+		t.Errorf("win32.FromName(\"ERROR_BUFFER_TOO_SMALL\") = 0x%08x, true; want undefined", uint32(resolved))
 	}
 }
 


### PR DESCRIPTION
### Linked Issue

Refs #1219 — phase 4, the rasrpc interface (`20610036-fa22-11cf-9823-00a0c911e5df/1.0`, Routing and Remote Access Service, [MS-RRASM]).

### Root Cause

The rasrpc descriptor declared its own table of nine Win32 error codes and a `StatusString` switch over them. Eight of the nine were plain duplicates of rows in `windows/errors/win32`, which holds the whole of [MS-ERREF] 2.2 as 2703 codes under the `WIN32_ERROR` type, so the block was a hand-maintained copy of eight rows out of 2703 that could only drift from the generated table. It was also a ceiling rather than a convenience: `StatusString` decoded the nine codes it knew and rendered everything else as bare hex, and the protocol returns far more codes than that. `ERROR_INVALID_LEVEL` at `0x0000007C` sits two values from a code the subset did list and came out as undecoded hex.

The ninth is a range collision, not a duplicate. `StatusBufferTooSmall` was declared as `0x0000025B` and commented `ERROR_BUFFER_TOO_SMALL`, which is the Remote Access error 603, `RASBASE+3` in `raserror.h`. [MS-ERREF] 2.2 does not cover the RAS 600..999 block at all: it assigns `0x0000025B` to `ERROR_MARSHALL_OVERFLOW`, a user/kernel marshaling buffer overflow, and the neighbouring `0x0000025A` and `0x0000025C` to `ERROR_ALLOCATE_BUCKET` and `ERROR_INVALID_VARIANT`. The name `ERROR_BUFFER_TOO_SMALL` appears nowhere in the 2.2 table. Migrating that value would have renamed a RAS buffer-size complaint into an unrelated marshaling failure while compiling and passing every test.

### Fix Description

The eight resolving codes are deleted from the descriptor. `StatusString` is reduced to the single RAS case and defers everything else to `win32.WIN32_ERROR(status).String()`, which names every code the specification defines and falls back to hex only for a value it does not. `StatusBufferTooSmall` stays declared locally, and the block comment now records that RAS errors live in the 600..999 range `raserror.h` owns, that [MS-ERREF] 2.2 does not cover that block, and what the shared table would call the value instead. This is the same arrangement the fax interface uses for the `FAX_ERR_*` codes that collide with the Terminal Services `ERROR_CTX_*` range.

The seven method stubs under `functions/` now compare the returned status against the shared package directly:

```go
if win32.WIN32_ERROR(resp.Status) != win32.ERROR_SUCCESS {
    err = fmt.Errorf("RasRpcSubmitRequest failed: %s", rasrpc.StatusString(uint32(resp.Status)))
}
```

No alias constants, local re-declarations or delegating wrappers were left behind. Failures render through the reduced `StatusString` — the sanctioned escape hatch for an interface that keeps local constants — so a RAS 603 still reports under its RAS name while every other code is named by the shared table. Each stub keeps its `rasrpc` import for the opnum its request type reports.

Every replacement name was derived from the value rather than from the private identifier: each numeric constant was looked up in the committed [MS-ERREF] 2.2 extract at `windows/errors/errgen/ms-erref-2.2-win32.tsv` and the symbolic name the specification records for that row is the constant now referenced. Eight resolved with the private camel-cased name agreeing with the specification; the ninth resolved under an unrelated name and is retained.

| Value | Private name | [MS-ERREF] 2.2 name for that value | Outcome |
| --- | --- | --- | --- |
| `0x00000000` | `StatusSuccess` | `ERROR_SUCCESS` | migrated |
| `0x00000002` | `StatusFileNotFound` | `ERROR_FILE_NOT_FOUND` | migrated |
| `0x00000005` | `StatusAccessDenied` | `ERROR_ACCESS_DENIED` | migrated |
| `0x00000006` | `StatusInvalidHandle` | `ERROR_INVALID_HANDLE` | migrated |
| `0x00000008` | `StatusNotEnoughMemory` | `ERROR_NOT_ENOUGH_MEMORY` | migrated |
| `0x00000032` | `StatusNotSupported` | `ERROR_NOT_SUPPORTED` | migrated |
| `0x00000057` | `StatusInvalidParameter` | `ERROR_INVALID_PARAMETER` | migrated |
| `0x0000007A` | `StatusInsufficientBuffer` | `ERROR_INSUFFICIENT_BUFFER` | migrated |
| `0x0000025B` | `StatusBufferTooSmall` (RAS 603) | `ERROR_MARSHALL_OVERFLOW` | kept local — unrelated name |

### How Verified

`go build ./...`, `go vet ./...` and `go test -count=1 ./...` are clean: 313 packages ok, 0 failures, the same ok count as `main`. `CGO_ENABLED=0 go build ./...` passes for `windows/amd64`, `windows/386`, `linux/arm64` and `linux/386`.

The rewrite was applied one comparison term at a time rather than one condition at a time, and a script compared the per-`if` comparison-term count of each touched file against its parent revision. All nine files match: seven stubs at two `if` statements and one term each, `interface.go` at zero. Every status condition in this interface turned out to be single-term, and no tolerance the code did not already have was introduced.

`grep` confirms the survivors around the deleted block are intact — `PipeName`, `SyntaxID()`, the seven `OpnumRasRpc*` constants, `OpnumToName` and `NameToOpnum` — and that none of the eight retired constant names remains anywhere in the repository. `"fmt"` is dropped from `interface.go`, which no longer uses it, and kept in every stub, which still does. Each import block was reconstructed from `git show HEAD:<path>` and inspected with whitespace visible, so the stdlib/project blank line is preserved in all seven stubs and in the test file. All nine touched files were `gofmt -l`-clean on `main` before the change and are `gofmt -l`-clean after it; no `gofmt -w` was run and no untouched file was reformatted.

### Test Coverage

`TestStatusString` is replaced by two tests. `TestStatusCodesResolveThroughWin32` pins each of the eight migrated codes to its specification name in both directions, through `win32.WIN32_ERROR(...).String()` and `win32.FromName(...)` and through `StatusString`; pins that `ERROR_INVALID_LEVEL` at `0x0000007C`, outside the old subset, now renders by name where it used to come out as hex; and pins that `0xDEADBEEF`, which the specification does not define, still renders as hex.

`TestStatusStringDecodesRASSpecificError` is the regression guard. It pins that `StatusBufferTooSmall` is `0x0000025B` and inside the RAS 600..999 range, that `StatusString` renders it as `ERROR_BUFFER_TOO_SMALL`, that the shared table names the same value `ERROR_MARSHALL_OVERFLOW`, and that `win32.FromName("ERROR_BUFFER_TOO_SMALL")` is undefined. Together those four assertions fail if a later change routes the RAS constant through the shared table. Every value asserted in either test was looked up in the committed [MS-ERREF] 2.2 extract.

### Scope of Change

Nine files, all inside `network/dcerpc/interfaces/20610036-fa22-11cf-9823-00a0c911e5df/1.0/`: `interface.go`, `interface_test.go` and the seven stubs under `functions/`. 110 insertions, 46 deletions.

Nothing outside the interface directory changed, and nothing outside it needed to. `grep` for the package import path and for all nine constant names found no consumer in `network/dcerpc/ms-protocols/`, `network/smb/smb_v10/server/rpcpipe/` or any test; the package has no importers at all outside its own `functions/` subpackage. The two `strings.Contains` matches against `"ERROR_"` in the repository are in `network/smb/smb_v10/server/rpcpipe/rpcpipe_test.go` and both test for `ERROR_INVALID_LEVEL`, which is not one of these nine constants and is unrelated to rasrpc. The sibling dimsvc interface `8f09f000-b7ed-11ce-bbd2-00001a181cad/0.0`, which shares [MS-RRASM] and the `\PIPE\ROUTER` endpoint and is already migrated, is untouched.

### Risk and Rollout

Behaviour-preserving for callers. The success comparison is the same test on the same value, expressed on the typed constant instead of a local `uint32`. Rendered strings are unchanged for the nine values previously enumerated, including the RAS 603, and improve from hex to a symbolic name for the other 2694 codes [MS-ERREF] 2.2 defines. Values the specification does not define still render as hex in the same `0x%08x` form. The eight deleted constants were unexported-in-effect by having no consumer outside the interface, so their removal breaks nothing in the repository; an out-of-tree caller comparing against one would substitute the `win32` constant of the same name and the same value. The only judgement call is the retained RAS constant, and it is the conservative one: it leaves the pre-existing local name in place rather than renaming an error.

### Notes

Nothing off-pattern beyond the collision itself. The one deviation from the fully-migrated interfaces is that `StatusString` survives here rather than being retired, which is required by the RAS range and matches the fax precedent exactly, including the deferral to `win32.WIN32_ERROR(status).String()` in the `default` arm.

The `raserror.h` provenance is worth recording for whoever handles the remaining [MS-RRASM] surface: `RASBASE` is 600 and the RAS codes run to 999, so any future rasrpc or dimsvc constant landing in that range is a collision by construction and must not be routed through the shared table. dimsvc happens to declare nothing in the range, which is why it could retire its subset outright.
