### PR TITLE
Record LocToLoc's status codes as NSI rather than Win32 (Refs #1219)

### DIFF
--- a/network/dcerpc/interfaces/e33c0cc4-0482-101a-bc0c-02608c6ba218/1.0/interface.go
+++ b/network/dcerpc/interfaces/e33c0cc4-0482-101a-bc0c-02608c6ba218/1.0/interface.go
@@ -40,6 +40,20 @@ const (
 // NSI_S_OK (0); most methods treat every nonzero value as an undifferentiated failure.
 // The one documented exception is I_nsi_lookup_next ([MS-RPCL] 3.1.4.3), which also
 // returns NSI_S_NO_MORE_BINDINGS to mark the (successful) end of the enumeration.
+//
+// These are Name Service Interface status codes, not [MS-ERREF] 2.2 Win32 error codes, so
+// they are declared here rather than referenced from
+// github.com/TheManticoreProject/Manticore/windows/errors/win32 the way an interface that
+// reports a WIN32_ERROR does. The two spaces collide by value and disagree on meaning:
+// [MS-ERREF] 2.2 assigns 0x00000001 to ERROR_INVALID_FUNCTION ("Incorrect function."),
+// and its own code for the condition NSI_S_NO_MORE_BINDINGS reports is a different value
+// entirely, RPC_S_NO_MORE_BINDINGS = 0x0000070E ("There are no more bindings."). Naming
+// this interface's 0x00000001 out of that table would turn a locator's normal
+// end-of-enumeration into an invalid-function failure. The shared table names neither NSI
+// code, and the specification documents no others: every method's status is defined in
+// terms of NSI_S_OK, I_nsi_ping_locator's 32-bit error_status_t included ([MS-RPCL]
+// 3.1.4.5), so the whole interface reports one NSI status space and windows/errors/win32
+// does not apply to any of it.
 const (
 	// StatusSuccess (NSI_S_OK) indicates the method completed successfully.
 	StatusSuccess uint32 = 0x00000000
@@ -63,7 +77,9 @@ func SyntaxID() syntax.SyntaxID {
 }
 
 // StatusString returns a mnemonic for the documented status codes, otherwise the
-// hex value.
+// hex value. An unrecognized status stays hexadecimal rather than being resolved through
+// windows/errors/win32, which would name an NSI code out of the Win32 table: 0x00000002
+// would read as ERROR_FILE_NOT_FOUND, a meaning the locator never assigns it.
 func StatusString(status uint32) string {
 	switch status {
 	case NSI_S_OK:

--- a/network/dcerpc/interfaces/e33c0cc4-0482-101a-bc0c-02608c6ba218/1.0/interface_test.go
+++ b/network/dcerpc/interfaces/e33c0cc4-0482-101a-bc0c-02608c6ba218/1.0/interface_test.go
@@ -1,6 +1,10 @@
 package rpcinterface_e33c0cc40482101abc0c02608c6ba218_1_0
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
+)
 
 // TestSyntaxID verifies the abstract syntax identity (UUID + version) of the LocToLoc interface.
 func TestSyntaxID(t *testing.T) {
@@ -58,5 +62,53 @@ func TestStatusString(t *testing.T) {
 	}
 	if got := StatusString(0xDEADBEEF); got != "0xdeadbeef" {
 		t.Fatalf("StatusString(unknown) = %s, want 0xdeadbeef", got)
+	}
+}
+
+// TestStatusCodesAreNSINotWin32 pins this interface's status codes to the Name Service
+// Interface space they come from, so that a later pass does not route them through
+// windows/errors/win32. [MS-RPCL] 3.1.4.3 documents NSI_S_OK as 0x00000000 and
+// NSI_S_NO_MORE_BINDINGS as 0x00000001; [MS-ERREF] 2.2 gives that second value an
+// unrelated name, and names the condition NSI_S_NO_MORE_BINDINGS reports under a
+// different value altogether.
+func TestStatusCodesAreNSINotWin32(t *testing.T) {
+	if NSI_S_OK != 0x00000000 {
+		t.Errorf("NSI_S_OK = 0x%08x, want 0x00000000 ([MS-RPCL] 3.1.4.3)", NSI_S_OK)
+	}
+	if NSI_S_NO_MORE_BINDINGS != 0x00000001 {
+		t.Errorf("NSI_S_NO_MORE_BINDINGS = 0x%08x, want 0x00000001 ([MS-RPCL] 3.1.4.3)", NSI_S_NO_MORE_BINDINGS)
+	}
+	if StatusSuccess != NSI_S_OK {
+		t.Errorf("StatusSuccess = 0x%08x, want NSI_S_OK 0x%08x", StatusSuccess, NSI_S_OK)
+	}
+
+	// The [MS-ERREF] 2.2 table names neither NSI code, so it cannot render either of
+	// them; a migration to win32 would have nothing to migrate them to.
+	for _, name := range []string{"NSI_S_OK", "NSI_S_NO_MORE_BINDINGS"} {
+		if code, defined := win32.FromName(name); defined {
+			t.Errorf("win32.FromName(%q) resolved to 0x%08x; %s is an NSI code and the Win32 table must not claim it", name, uint32(code), name)
+		}
+	}
+
+	// What the Win32 table does say about 0x00000001, and why reporting the locator's
+	// status through it would be wrong.
+	if entry, defined := win32.Lookup(win32.WIN32_ERROR(NSI_S_NO_MORE_BINDINGS)); !defined {
+		t.Errorf("win32 defines no name for 0x%08x; [MS-ERREF] 2.2 gives it ERROR_INVALID_FUNCTION", NSI_S_NO_MORE_BINDINGS)
+	} else if entry.Name != "ERROR_INVALID_FUNCTION" {
+		t.Errorf("win32 names 0x%08x %q, want ERROR_INVALID_FUNCTION: the collision this interface must keep out of its status reporting", NSI_S_NO_MORE_BINDINGS, entry.Name)
+	}
+
+	// The Win32 code for "there are no more bindings" is a different value entirely, so
+	// the two spaces do not even agree where they name the same condition.
+	if code, defined := win32.FromName("RPC_S_NO_MORE_BINDINGS"); !defined {
+		t.Error(`win32.FromName("RPC_S_NO_MORE_BINDINGS") is undefined, want 0x0000070e ([MS-ERREF] 2.2)`)
+	} else if uint32(code) != 0x0000070E || uint32(code) == NSI_S_NO_MORE_BINDINGS {
+		t.Errorf("RPC_S_NO_MORE_BINDINGS = 0x%08x, want 0x0000070e and not NSI_S_NO_MORE_BINDINGS 0x%08x", uint32(code), NSI_S_NO_MORE_BINDINGS)
+	}
+
+	// StatusString renders only the NSI names and never falls through to the Win32
+	// table: 0x00000002 is ERROR_FILE_NOT_FOUND there and has no NSI meaning here.
+	if got := StatusString(0x00000002); got != "0x00000002" {
+		t.Errorf("StatusString(0x00000002) = %s, want 0x00000002: the NSI status field must not be named out of the Win32 table", got)
 	}
 }


### PR DESCRIPTION
### Linked Issue

Refs #1219 — phase 4, LocToLoc (`e33c0cc4-0482-101a-bc0c-02608c6ba218/1.0`, [MS-RPCL]). This interface is out of scope for the migration, and this PR records that in the code.

### Root Cause

The phase 4 sweep replaces each interface's private error-code subset with references to `windows/errors/win32`, on the premise that the private subset is a fragment of the [MS-ERREF] 2.2 Win32 table. That premise does not hold for LocToLoc: its two status constants are Name Service Interface codes from [MS-RPCL] 3.1.4, a different status space, and the shared table names neither of them.

Looked up by value rather than by name:

| Interface constant | Value | [MS-ERREF] 2.2 row for that value | Verdict |
| --- | --- | --- | --- |
| `NSI_S_OK` | `0x00000000` | `ERROR_SUCCESS` (alias `NERR_Success`), "The operation completed successfully." | Agrees in meaning, but is an NSI name the table does not carry |
| `NSI_S_NO_MORE_BINDINGS` | `0x00000001` | `ERROR_INVALID_FUNCTION`, "Incorrect function." | Unrelated name — must not migrate |

The Win32 table's own code for the condition `NSI_S_NO_MORE_BINDINGS` reports is a different value entirely: `RPC_S_NO_MORE_BINDINGS` at `0x0000070E`, "There are no more bindings." A mechanical migration would therefore have compiled and passed while renaming the locator's normal end-of-enumeration into an invalid-function failure — and `I_nsi_lookup_next`, the one method that reads that status as success, is precisely where it would have shown up.

Nor is any part of the interface in the Win32 space, so migrating only `NSI_S_OK` was not an option either. [MS-RPCL] documents every method's status in terms of `NSI_S_OK`, `I_nsi_ping_locator` included: its parameter is a 32-bit `error_status_t`, but 3.1.4.5 still defines it as "In case of success, the value will contain NSI_S_OK, or a nonzero value on failure."

### Fix Description

The constants stay local. The block comment above them now states that they are NSI codes from [MS-RPCL] 3.1.4 rather than [MS-ERREF] 2.2 Win32 codes, gives the value collision and the `0x0000070E` counterpart that make the two spaces non-interchangeable, and records that `windows/errors/win32` does not apply to any of this interface — the 32-bit `error_status_t` of `I_nsi_ping_locator` included.

`StatusString` keeps its hexadecimal fallback for an unrecognized status, and its doc comment now says why: resolving it through the shared table would name an NSI code out of the wrong space, rendering `0x00000002` as `ERROR_FILE_NOT_FOUND`.

No constant is added, removed or renamed, no import changes, and nothing under `functions/` is touched — that directory is byte-identical to `main`. Which statuses each method tolerates is unchanged; `I_nsi_lookup_next` already treats `NSI_S_NO_MORE_BINDINGS` as success as [MS-RPCL] 3.1.4.3 requires, and no other method documents a second tolerated value, so there is no behavioural gap to defer.

### How Verified

- `go build ./...` — exit 0
- `go vet ./...` — exit 0
- `go test -count=1 ./...` — 313 ok, 0 failures (matches the `main` baseline)
- `CGO_ENABLED=0 go build ./...` for `windows/amd64`, `windows/386`, `linux/arm64`, `linux/386` — all exit 0
- `gofmt -l` on both touched files — no output
- Every value in the code and the tests was looked up in `windows/errors/errgen/ms-erref-2.2-win32.tsv`: `0x00000000` `ERROR_SUCCESS`, `0x00000001` `ERROR_INVALID_FUNCTION`, `0x00000002` `ERROR_FILE_NOT_FOUND`, `0x0000070E` `RPC_S_NO_MORE_BINDINGS`. The [MS-RPCL] values were confirmed against 3.1.4.1, 3.1.4.3, 3.1.4.4 and 3.1.4.5, whose status tables give `NSI_S_OK` `0x00000000` and `NSI_S_NO_MORE_BINDINGS` `0x00000001`.
- The interface path, both constant names, and `Contains`/`HasPrefix` against `"ERROR_"`, `"NSI_"` and `"STATUS_"` were grepped repo-wide. There are no consumers outside the interface directory. The two `strings.Contains(err.Error(), "ERROR_INVALID_LEVEL")` sites in `network/smb/smb_v10/server/rpcpipe/rpcpipe_test.go` are srvsvc and wkssvc, unrelated to LocToLoc.

### Test Coverage

`TestStatusCodesAreNSINotWin32` in `interface_test.go` pins the conclusion so a later pass cannot quietly route these codes through the shared table. It asserts the two values [MS-RPCL] 3.1.4.3 documents, asserts `win32.FromName` resolves neither `NSI_S_OK` nor `NSI_S_NO_MORE_BINDINGS`, records that the Win32 table names `0x00000001` `ERROR_INVALID_FUNCTION`, checks that `RPC_S_NO_MORE_BINDINGS` is `0x0000070E` and so does not share a value with the NSI code, and checks that `StatusString(0x00000002)` renders hexadecimal rather than `ERROR_FILE_NOT_FOUND`.

The pin was verified by mutation: rewriting `StatusString` to `return win32.WIN32_ERROR(status).String()` — the migration this PR argues against — fails both `TestStatusCodesAreNSINotWin32` ("StatusString(0x00000002) = ERROR_FILE_NOT_FOUND") and the pre-existing `TestStatusString` ("StatusString(NSI_S_OK) = ERROR_SUCCESS"). The mutation was reverted.

### Scope of Change

Two files, comments and tests only:

- `network/dcerpc/interfaces/e33c0cc4-0482-101a-bc0c-02608c6ba218/1.0/interface.go` — comments only
- `network/dcerpc/interfaces/e33c0cc4-0482-101a-bc0c-02608c6ba218/1.0/interface_test.go` — one new test plus the `win32` import it needs

`SyntaxID()`, `PipeName`, the seven opnum constants, `OpnumToName`, `NameToOpnum`, `StatusString`'s body and the `fmt` import all survive unchanged.

### Risk and Rollout

None. No executable line changes outside the new test, so no wire format, no status interpretation and no public identifier is affected. Reverting the commit restores the previous comments.

### Notes

Phase 4 should mark LocToLoc as deliberately skipped rather than pending. The general rule this case establishes is that an interface whose status parameter is 16 bits wide is a signal worth checking before migrating: six of the seven LocToLoc methods declare `[out] unsigned short *status`, which the [MS-ERREF] 2.2 table, a 32-bit `DWORD` space, cannot be the source of.
