### PR TITLE
Route frsrpc and NtFrsApi status reporting through win32 (Refs #1219)

### DIFF
--- a/network/dcerpc/interfaces/d049b186-814f-11d1-9a3c-00c04fc9b232/1.1/functions/04_NtFrsApi_Rpc_Set_DsPollingIntervalW.go
+++ b/network/dcerpc/interfaces/d049b186-814f-11d1-9a3c-00c04fc9b232/1.1/functions/04_NtFrsApi_Rpc_Set_DsPollingIntervalW.go
@@ -10,6 +10,7 @@ import (
 
 	frsapi "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/d049b186-814f-11d1-9a3c-00c04fc9b232/1.1"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 )
 
 // ntFrsApi_Rpc_Set_DsPollingIntervalWRequest carries the [in] parameters of NtFrsApi_Rpc_Set_DsPollingIntervalW.
@@ -35,8 +36,8 @@ func NtFrsApi_Rpc_Set_DsPollingIntervalW(rpc ndr.Invoker, useShortInterval ndr.D
 		err = fmt.Errorf("NtFrsApi_Rpc_Set_DsPollingIntervalW: %w", err)
 		return
 	}
-	if uint32(resp.Status) != frsapi.StatusSuccess {
-		err = fmt.Errorf("NtFrsApi_Rpc_Set_DsPollingIntervalW failed: %s", frsapi.StatusString(uint32(resp.Status)))
+	if win32.WIN32_ERROR(resp.Status) != win32.ERROR_SUCCESS {
+		err = fmt.Errorf("NtFrsApi_Rpc_Set_DsPollingIntervalW failed: %s", win32.WIN32_ERROR(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/d049b186-814f-11d1-9a3c-00c04fc9b232/1.1/functions/05_NtFrsApi_Rpc_Get_DsPollingIntervalW.go
+++ b/network/dcerpc/interfaces/d049b186-814f-11d1-9a3c-00c04fc9b232/1.1/functions/05_NtFrsApi_Rpc_Get_DsPollingIntervalW.go
@@ -10,6 +10,7 @@ import (
 
 	frsapi "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/d049b186-814f-11d1-9a3c-00c04fc9b232/1.1"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 )
 
 // ntFrsApi_Rpc_Get_DsPollingIntervalWRequest carries the [in] parameters of NtFrsApi_Rpc_Get_DsPollingIntervalW.
@@ -39,8 +40,8 @@ func NtFrsApi_Rpc_Get_DsPollingIntervalW(rpc ndr.Invoker) (Interval ndr.DWORD, L
 	Interval = resp.Interval
 	LongInterval = resp.LongInterval
 	ShortInterval = resp.ShortInterval
-	if uint32(resp.Status) != frsapi.StatusSuccess {
-		err = fmt.Errorf("NtFrsApi_Rpc_Get_DsPollingIntervalW failed: %s", frsapi.StatusString(uint32(resp.Status)))
+	if win32.WIN32_ERROR(resp.Status) != win32.ERROR_SUCCESS {
+		err = fmt.Errorf("NtFrsApi_Rpc_Get_DsPollingIntervalW failed: %s", win32.WIN32_ERROR(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/d049b186-814f-11d1-9a3c-00c04fc9b232/1.1/functions/07_NtFrsApi_Rpc_InfoW.go
+++ b/network/dcerpc/interfaces/d049b186-814f-11d1-9a3c-00c04fc9b232/1.1/functions/07_NtFrsApi_Rpc_InfoW.go
@@ -10,6 +10,7 @@ import (
 
 	frsapi "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/d049b186-814f-11d1-9a3c-00c04fc9b232/1.1"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 )
 
 // ntFrsApi_Rpc_InfoWRequest carries the [in] parameters of NtFrsApi_Rpc_InfoW.
@@ -40,8 +41,8 @@ func NtFrsApi_Rpc_InfoW(rpc ndr.Invoker, blobSize ndr.DWORD, blob []uint8) (Blob
 		return
 	}
 	Blob = resp.Blob
-	if uint32(resp.Status) != frsapi.StatusSuccess {
-		err = fmt.Errorf("NtFrsApi_Rpc_InfoW failed: %s", frsapi.StatusString(uint32(resp.Status)))
+	if win32.WIN32_ERROR(resp.Status) != win32.ERROR_SUCCESS {
+		err = fmt.Errorf("NtFrsApi_Rpc_InfoW failed: %s", win32.WIN32_ERROR(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/d049b186-814f-11d1-9a3c-00c04fc9b232/1.1/functions/08_NtFrsApi_Rpc_IsPathReplicated.go
+++ b/network/dcerpc/interfaces/d049b186-814f-11d1-9a3c-00c04fc9b232/1.1/functions/08_NtFrsApi_Rpc_IsPathReplicated.go
@@ -10,6 +10,7 @@ import (
 
 	frsapi "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/d049b186-814f-11d1-9a3c-00c04fc9b232/1.1"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 )
 
@@ -47,8 +48,8 @@ func NtFrsApi_Rpc_IsPathReplicated(rpc ndr.Invoker, path *ndr.WSTR, replicaSetTy
 	Primary = resp.Primary
 	Root = resp.Root
 	ReplicaSetGuid = resp.ReplicaSetGuid
-	if uint32(resp.Status) != frsapi.StatusSuccess {
-		err = fmt.Errorf("NtFrsApi_Rpc_IsPathReplicated failed: %s", frsapi.StatusString(uint32(resp.Status)))
+	if win32.WIN32_ERROR(resp.Status) != win32.ERROR_SUCCESS {
+		err = fmt.Errorf("NtFrsApi_Rpc_IsPathReplicated failed: %s", win32.WIN32_ERROR(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/d049b186-814f-11d1-9a3c-00c04fc9b232/1.1/functions/09_NtFrsApi_Rpc_WriterCommand.go
+++ b/network/dcerpc/interfaces/d049b186-814f-11d1-9a3c-00c04fc9b232/1.1/functions/09_NtFrsApi_Rpc_WriterCommand.go
@@ -10,6 +10,7 @@ import (
 
 	frsapi "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/d049b186-814f-11d1-9a3c-00c04fc9b232/1.1"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 )
 
 // ntFrsApi_Rpc_WriterCommandRequest carries the [in] parameters of NtFrsApi_Rpc_WriterCommand.
@@ -31,8 +32,8 @@ func NtFrsApi_Rpc_WriterCommand(rpc ndr.Invoker, command ndr.DWORD) (err error) 
 		err = fmt.Errorf("NtFrsApi_Rpc_WriterCommand: %w", err)
 		return
 	}
-	if uint32(resp.Status) != frsapi.StatusSuccess {
-		err = fmt.Errorf("NtFrsApi_Rpc_WriterCommand failed: %s", frsapi.StatusString(uint32(resp.Status)))
+	if win32.WIN32_ERROR(resp.Status) != win32.ERROR_SUCCESS {
+		err = fmt.Errorf("NtFrsApi_Rpc_WriterCommand failed: %s", win32.WIN32_ERROR(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/d049b186-814f-11d1-9a3c-00c04fc9b232/1.1/functions/10_NtFrsApi_Rpc_ForceReplication.go
+++ b/network/dcerpc/interfaces/d049b186-814f-11d1-9a3c-00c04fc9b232/1.1/functions/10_NtFrsApi_Rpc_ForceReplication.go
@@ -10,6 +10,7 @@ import (
 
 	frsapi "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/d049b186-814f-11d1-9a3c-00c04fc9b232/1.1"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 )
 
@@ -38,8 +39,8 @@ func NtFrsApi_Rpc_ForceReplication(rpc ndr.Invoker, replicaSetGuid *msdtyp.GUID,
 		err = fmt.Errorf("NtFrsApi_Rpc_ForceReplication: %w", err)
 		return
 	}
-	if uint32(resp.Status) != frsapi.StatusSuccess {
-		err = fmt.Errorf("NtFrsApi_Rpc_ForceReplication failed: %s", frsapi.StatusString(uint32(resp.Status)))
+	if win32.WIN32_ERROR(resp.Status) != win32.ERROR_SUCCESS {
+		err = fmt.Errorf("NtFrsApi_Rpc_ForceReplication failed: %s", win32.WIN32_ERROR(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/d049b186-814f-11d1-9a3c-00c04fc9b232/1.1/interface.go
+++ b/network/dcerpc/interfaces/d049b186-814f-11d1-9a3c-00c04fc9b232/1.1/interface.go
@@ -2,9 +2,9 @@
 // syntax d049b186-814f-11d1-9a3c-00c04fc9b232 version 1.1 ([MS-FRS1]).
 //
 // This package holds only the interface-level descriptor (abstract syntax,
-// transport endpoint, opnums, opnum<->name maps, and status constants). The NDR
-// wire types live in windows/protocols/ms-frs1 and the method stubs in functions;
-// both depend on this package, never the reverse.
+// transport endpoint, opnums, and opnum<->name maps). The NDR wire types live in
+// windows/protocols/ms-frs1 and the method stubs in functions; both depend on this
+// package, never the reverse.
 package rpcinterface_d049b186814f11d19a3c00c04fc9b232_1_1
 
 // IDL source: [MS-FRS1] — this interface is translated from and verified
@@ -13,8 +13,6 @@ package rpcinterface_d049b186814f11d19a3c00c04fc9b232_1_1
 // A fetched copy is kept at ms-frs1.idl in the interface directory.
 
 import (
-	"fmt"
-
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
 	"github.com/TheManticoreProject/Manticore/windows/guid"
 )
@@ -35,13 +33,23 @@ const (
 	OpnumNtFrsApi_Rpc_ForceReplication       uint16 = 10
 )
 
-// Status codes returned by this interface. FRSAPI methods return a Win32 error code
-// ([MS-ERREF] 2.2): 0 on success, and all nonzero values are equivalent failures unless
-// otherwise specified ([MS-FRS1] 3.2.4). Failed access checks yield ERROR_ACCESS_DENIED.
-const (
-	StatusSuccess     uint32 = 0x00000000 // ERROR_SUCCESS
-	ErrorAccessDenied uint32 = 0x00000005 // ERROR_ACCESS_DENIED
-)
+// The status codes this interface returns are not declared here. FRSAPI methods return a
+// Win32 error code ([MS-ERREF] 2.2): 0 on success, and all nonzero values are equivalent
+// failures unless otherwise specified ([MS-FRS1] 3.2.4); a failed access check yields
+// ERROR_ACCESS_DENIED. The whole of [MS-ERREF] 2.2 lives in
+// github.com/TheManticoreProject/Manticore/windows/errors/win32 as the WIN32_ERROR type,
+// and a subset repeated here would cover a fraction of that 2703-code table while
+// drifting from it. Convert a returned status with win32.WIN32_ERROR(status) and compare
+// against win32.ERROR_SUCCESS and the rest.
+//
+// Both codes this descriptor used to declare have an [MS-ERREF] 2.2 row under the name
+// the specification uses, so neither stays local: StatusSuccess is win32.ERROR_SUCCESS
+// (0x00000000) and ErrorAccessDenied is win32.ERROR_ACCESS_DENIED (0x00000005).
+// StatusString went with them.
+//
+// The NtFrs service errors an FRSAPI method reports are the FRS_ERR_* family, which the
+// shared table carries at 0x00001F41..0x00001F51. They are unrelated to the FRS_ERROR_*
+// family [MS-FRS2] defines at 0x23xx, which [MS-ERREF] 2.2 has no rows for at all.
 
 // SyntaxID returns the NtFrsApi abstract syntax identifier:
 // d049b186-814f-11d1-9a3c-00c04fc9b232, version 1.1.
@@ -50,19 +58,6 @@ func SyntaxID() syntax.SyntaxID {
 		UUID:         guid.GUID{A: 0xd049b186, B: 0x814f, C: 0x11d1, D: 0x9a3c, E: 0x00c04fc9b232},
 		MajorVersion: 1,
 		MinorVersion: 1,
-	}
-}
-
-// StatusString returns a mnemonic for the documented status codes, otherwise the
-// hex value.
-func StatusString(status uint32) string {
-	switch status {
-	case StatusSuccess:
-		return "ERROR_SUCCESS"
-	case ErrorAccessDenied:
-		return "ERROR_ACCESS_DENIED"
-	default:
-		return fmt.Sprintf("0x%08x", status)
 	}
 }
 

--- a/network/dcerpc/interfaces/d049b186-814f-11d1-9a3c-00c04fc9b232/1.1/interface_test.go
+++ b/network/dcerpc/interfaces/d049b186-814f-11d1-9a3c-00c04fc9b232/1.1/interface_test.go
@@ -1,6 +1,10 @@
 package rpcinterface_d049b186814f11d19a3c00c04fc9b232_1_1
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
+)
 
 // TestSyntaxID pins the abstract syntax: d049b186-814f-11d1-9a3c-00c04fc9b232 v1.1.
 func TestSyntaxID(t *testing.T) {
@@ -46,16 +50,56 @@ func TestOpnumNameRoundTrip(t *testing.T) {
 	}
 }
 
-// TestStatusString spot-checks the mnemonics and the hex fallback.
-func TestStatusString(t *testing.T) {
-	cases := map[uint32]string{
-		StatusSuccess:     "ERROR_SUCCESS",
-		ErrorAccessDenied: "ERROR_ACCESS_DENIED",
-		0xdeadbeef:        "0xdeadbeef",
+// TestStatusCodesResolveThroughWin32 pins that the two status codes this descriptor
+// used to declare resolve through the shared [MS-ERREF] 2.2 table under the names the
+// specification gives them, that the NtFrs service errors the descriptor never
+// enumerated now render by name rather than as undecoded hex, and that a value the
+// specification does not define still renders as hex.
+func TestStatusCodesResolveThroughWin32(t *testing.T) {
+	// The retired subset: StatusSuccess and ErrorAccessDenied.
+	retired := map[uint32]string{
+		0x00000000: "ERROR_SUCCESS",
+		0x00000005: "ERROR_ACCESS_DENIED",
 	}
-	for code, want := range cases {
-		if got := StatusString(code); got != want {
-			t.Errorf("StatusString(0x%08x) = %q, want %q", code, got, want)
+	for code, name := range retired {
+		if got := win32.WIN32_ERROR(code).String(); got != name {
+			t.Errorf("win32.WIN32_ERROR(0x%08x).String() = %q, want %q", code, got, name)
 		}
+		if resolved, defined := win32.FromName(name); !defined || uint32(resolved) != code {
+			t.Errorf("win32.FromName(%q) = 0x%08x, %v; want 0x%08x, true", name, uint32(resolved), defined, code)
+		}
+	}
+
+	// The NtFrs service errors [MS-ERREF] 2.2 carries at 0x00001F41..0x00001F51 sat
+	// outside the subset this interface declared, so they rendered as bare hex; they
+	// resolve by name now. These are the failures an FRSAPI call reports.
+	serviceErrors := map[uint32]string{
+		0x00001F41: "FRS_ERR_INVALID_API_SEQUENCE",
+		0x00001F44: "FRS_ERR_INTERNAL_API",
+		0x00001F46: "FRS_ERR_SERVICE_COMM",
+		0x00001F47: "FRS_ERR_INSUFFICIENT_PRIV",
+		0x00001F51: "FRS_ERR_INVALID_SERVICE_PARAMETER",
+	}
+	for code, name := range serviceErrors {
+		if got := win32.WIN32_ERROR(code).String(); got != name {
+			t.Errorf("win32.WIN32_ERROR(0x%08x).String() = %q, want %q", code, got, name)
+		}
+		if resolved, defined := win32.FromName(name); !defined || uint32(resolved) != code {
+			t.Errorf("win32.FromName(%q) = 0x%08x, %v; want 0x%08x, true", name, uint32(resolved), defined, code)
+		}
+	}
+
+	// The FRS_ERROR_* family [MS-FRS2] defines at 0x23xx is a different set of values
+	// the shared table has no rows for, so nothing in this interface may be resolved
+	// against it by name similarity.
+	for _, code := range []uint32{0x00002342, 0x0000235A, 0x00002375} {
+		if entry, defined := win32.Lookup(win32.WIN32_ERROR(code)); defined {
+			t.Errorf("win32.Lookup(0x%08x) resolves to %q; [MS-ERREF] 2.2 has no row for it", code, entry.Name)
+		}
+	}
+
+	// A value [MS-ERREF] 2.2 does not define still renders as hex.
+	if got := win32.WIN32_ERROR(0xdeadbeef).String(); got != "0xdeadbeef" {
+		t.Errorf("win32.WIN32_ERROR(0xdeadbeef).String() = %q, want 0xdeadbeef", got)
 	}
 }

--- a/network/dcerpc/interfaces/f5cc59b4-4264-101a-8c59-08002b2f8426/1.1/functions/00_FrsRpcSendCommPkt.go
+++ b/network/dcerpc/interfaces/f5cc59b4-4264-101a-8c59-08002b2f8426/1.1/functions/00_FrsRpcSendCommPkt.go
@@ -10,6 +10,7 @@ import (
 
 	frsrpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/f5cc59b4-4264-101a-8c59-08002b2f8426/1.1"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	msfrs1 "github.com/TheManticoreProject/Manticore/windows/protocols/ms-frs1"
 )
 
@@ -30,8 +31,8 @@ func FrsRpcSendCommPkt(rpc ndr.Invoker, commPkt msfrs1.COMM_PACKET) (err error) 
 		err = fmt.Errorf("FrsRpcSendCommPkt: %w", err)
 		return
 	}
-	if uint32(resp.Status) != frsrpc.StatusSuccess {
-		err = fmt.Errorf("FrsRpcSendCommPkt failed: %s", frsrpc.StatusString(uint32(resp.Status)))
+	if win32.WIN32_ERROR(resp.Status) != win32.ERROR_SUCCESS {
+		err = fmt.Errorf("FrsRpcSendCommPkt failed: %s", win32.WIN32_ERROR(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/f5cc59b4-4264-101a-8c59-08002b2f8426/1.1/functions/01_FrsRpcVerifyPromotionParent.go
+++ b/network/dcerpc/interfaces/f5cc59b4-4264-101a-8c59-08002b2f8426/1.1/functions/01_FrsRpcVerifyPromotionParent.go
@@ -10,6 +10,7 @@ import (
 
 	frsrpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/f5cc59b4-4264-101a-8c59-08002b2f8426/1.1"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 )
 
 // frsRpcVerifyPromotionParentRequest carries the [in] parameters of FrsRpcVerifyPromotionParent.
@@ -41,8 +42,8 @@ func FrsRpcVerifyPromotionParent(rpc ndr.Invoker, parentAccount *ndr.WSTR, paren
 		err = fmt.Errorf("FrsRpcVerifyPromotionParent: %w", err)
 		return
 	}
-	if uint32(resp.Status) != frsrpc.StatusSuccess {
-		err = fmt.Errorf("FrsRpcVerifyPromotionParent failed: %s", frsrpc.StatusString(uint32(resp.Status)))
+	if win32.WIN32_ERROR(resp.Status) != win32.ERROR_SUCCESS {
+		err = fmt.Errorf("FrsRpcVerifyPromotionParent failed: %s", win32.WIN32_ERROR(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/f5cc59b4-4264-101a-8c59-08002b2f8426/1.1/functions/02_FrsRpcStartPromotionParent.go
+++ b/network/dcerpc/interfaces/f5cc59b4-4264-101a-8c59-08002b2f8426/1.1/functions/02_FrsRpcStartPromotionParent.go
@@ -10,6 +10,7 @@ import (
 
 	frsrpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/f5cc59b4-4264-101a-8c59-08002b2f8426/1.1"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 )
 
 // frsRpcStartPromotionParentRequest carries the [in] parameters of FrsRpcStartPromotionParent.
@@ -62,8 +63,8 @@ func FrsRpcStartPromotionParent(rpc ndr.Invoker, parentAccount *ndr.WSTR, parent
 		return
 	}
 	ParentGuid = resp.ParentGuid
-	if uint32(resp.Status) != frsrpc.StatusSuccess {
-		err = fmt.Errorf("FrsRpcStartPromotionParent failed: %s", frsrpc.StatusString(uint32(resp.Status)))
+	if win32.WIN32_ERROR(resp.Status) != win32.ERROR_SUCCESS {
+		err = fmt.Errorf("FrsRpcStartPromotionParent failed: %s", win32.WIN32_ERROR(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/f5cc59b4-4264-101a-8c59-08002b2f8426/1.1/functions/03_FrsNOP.go
+++ b/network/dcerpc/interfaces/f5cc59b4-4264-101a-8c59-08002b2f8426/1.1/functions/03_FrsNOP.go
@@ -10,6 +10,7 @@ import (
 
 	frsrpc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/f5cc59b4-4264-101a-8c59-08002b2f8426/1.1"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 )
 
 // frsNOPRequest carries the [in] parameters of FrsNOP.
@@ -26,8 +27,8 @@ func FrsNOP(rpc ndr.Invoker) (err error) {
 		err = fmt.Errorf("FrsNOP: %w", err)
 		return
 	}
-	if uint32(resp.Status) != frsrpc.StatusSuccess {
-		err = fmt.Errorf("FrsNOP failed: %s", frsrpc.StatusString(uint32(resp.Status)))
+	if win32.WIN32_ERROR(resp.Status) != win32.ERROR_SUCCESS {
+		err = fmt.Errorf("FrsNOP failed: %s", win32.WIN32_ERROR(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/f5cc59b4-4264-101a-8c59-08002b2f8426/1.1/interface.go
+++ b/network/dcerpc/interfaces/f5cc59b4-4264-101a-8c59-08002b2f8426/1.1/interface.go
@@ -2,9 +2,9 @@
 // syntax f5cc59b4-4264-101a-8c59-08002b2f8426 version 1.1 ([MS-FRS1]).
 //
 // This package holds only the interface-level descriptor (abstract syntax,
-// transport endpoint, opnums, opnum<->name maps, and status constants). The NDR
-// wire types live in windows/protocols/ms-frs1 and the method stubs in functions;
-// both depend on this package, never the reverse.
+// transport endpoint, opnums, and opnum<->name maps). The NDR wire types live in
+// windows/protocols/ms-frs1 and the method stubs in functions; both depend on this
+// package, never the reverse.
 package rpcinterface_f5cc59b44264101a8c5908002b2f8426_1_1
 
 // IDL source: [MS-FRS1] — this interface is translated from and verified
@@ -13,8 +13,6 @@ package rpcinterface_f5cc59b44264101a8c5908002b2f8426_1_1
 // A fetched copy is kept at ms-frs1.idl in the interface directory.
 
 import (
-	"fmt"
-
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
 	"github.com/TheManticoreProject/Manticore/windows/guid"
 )
@@ -33,15 +31,25 @@ const (
 	OpnumFrsNOP                      uint16 = 3
 )
 
-// Status codes returned by this interface. FRS methods return a Win32 error code
-// ([MS-ERREF] 2.2): 0 on success, and all nonzero values are equivalent failures unless
-// otherwise specified ([MS-FRS1] 3.3.4). FrsRpcVerifyPromotionParent always returns
-// ERROR_CALL_NOT_IMPLEMENTED ([MS-FRS1] 3.3.4.2).
-const (
-	StatusSuccess           uint32 = 0x00000000 // ERROR_SUCCESS
-	ErrorAccessDenied       uint32 = 0x00000005 // ERROR_ACCESS_DENIED
-	ErrorCallNotImplemented uint32 = 0x00000078 // ERROR_CALL_NOT_IMPLEMENTED
-)
+// The status codes this interface returns are not declared here. FRS methods return a
+// Win32 error code ([MS-ERREF] 2.2): 0 on success, and all nonzero values are equivalent
+// failures unless otherwise specified ([MS-FRS1] 3.3.4); FrsRpcVerifyPromotionParent
+// always returns ERROR_CALL_NOT_IMPLEMENTED ([MS-FRS1] 3.3.4.2). The whole of
+// [MS-ERREF] 2.2 lives in
+// github.com/TheManticoreProject/Manticore/windows/errors/win32 as the WIN32_ERROR type,
+// and a subset repeated here would cover a fraction of that 2703-code table while
+// drifting from it. Convert a returned status with win32.WIN32_ERROR(status) and compare
+// against win32.ERROR_SUCCESS and the rest.
+//
+// Each of the three codes this descriptor used to declare has an [MS-ERREF] 2.2 row
+// under the name the specification uses, so none of them stays local: StatusSuccess is
+// win32.ERROR_SUCCESS (0x00000000), ErrorAccessDenied is win32.ERROR_ACCESS_DENIED
+// (0x00000005) and ErrorCallNotImplemented is win32.ERROR_CALL_NOT_IMPLEMENTED
+// (0x00000078). StatusString went with them.
+//
+// The FRS_ERROR_* family [MS-FRS2] defines at 0x23xx is a different set of values that
+// [MS-ERREF] 2.2 has no rows for at all, and it is unrelated to the FRS_ERR_* NtFrs
+// service errors the shared table does carry at 0x00001F41..0x00001F51.
 
 // SyntaxID returns the frsrpc abstract syntax identifier:
 // f5cc59b4-4264-101a-8c59-08002b2f8426, version 1.1.
@@ -50,21 +58,6 @@ func SyntaxID() syntax.SyntaxID {
 		UUID:         guid.GUID{A: 0xf5cc59b4, B: 0x4264, C: 0x101a, D: 0x8c59, E: 0x08002b2f8426},
 		MajorVersion: 1,
 		MinorVersion: 1,
-	}
-}
-
-// StatusString returns a mnemonic for the documented status codes, otherwise the
-// hex value.
-func StatusString(status uint32) string {
-	switch status {
-	case StatusSuccess:
-		return "ERROR_SUCCESS"
-	case ErrorAccessDenied:
-		return "ERROR_ACCESS_DENIED"
-	case ErrorCallNotImplemented:
-		return "ERROR_CALL_NOT_IMPLEMENTED"
-	default:
-		return fmt.Sprintf("0x%08x", status)
 	}
 }
 

--- a/network/dcerpc/interfaces/f5cc59b4-4264-101a-8c59-08002b2f8426/1.1/interface_test.go
+++ b/network/dcerpc/interfaces/f5cc59b4-4264-101a-8c59-08002b2f8426/1.1/interface_test.go
@@ -1,6 +1,10 @@
 package rpcinterface_f5cc59b44264101a8c5908002b2f8426_1_1
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
+)
 
 // TestSyntaxID pins the abstract syntax: f5cc59b4-4264-101a-8c59-08002b2f8426 v1.1.
 func TestSyntaxID(t *testing.T) {
@@ -46,17 +50,45 @@ func TestOpnumNameRoundTrip(t *testing.T) {
 	}
 }
 
-// TestStatusString spot-checks the mnemonics and the hex fallback.
-func TestStatusString(t *testing.T) {
-	cases := map[uint32]string{
-		StatusSuccess:           "ERROR_SUCCESS",
-		ErrorAccessDenied:       "ERROR_ACCESS_DENIED",
-		ErrorCallNotImplemented: "ERROR_CALL_NOT_IMPLEMENTED",
-		0xdeadbeef:              "0xdeadbeef",
+// TestStatusCodesResolveThroughWin32 pins that the three status codes this descriptor
+// used to declare resolve through the shared [MS-ERREF] 2.2 table under the names the
+// specification gives them, that FRS codes the descriptor never enumerated now render by
+// name rather than as undecoded hex, and that a value the specification does not define
+// still renders as hex.
+func TestStatusCodesResolveThroughWin32(t *testing.T) {
+	// The retired subset: StatusSuccess, ErrorAccessDenied, ErrorCallNotImplemented.
+	retired := map[uint32]string{
+		0x00000000: "ERROR_SUCCESS",
+		0x00000005: "ERROR_ACCESS_DENIED",
+		0x00000078: "ERROR_CALL_NOT_IMPLEMENTED",
 	}
-	for code, want := range cases {
-		if got := StatusString(code); got != want {
-			t.Errorf("StatusString(0x%08x) = %q, want %q", code, got, want)
+	for code, name := range retired {
+		if got := win32.WIN32_ERROR(code).String(); got != name {
+			t.Errorf("win32.WIN32_ERROR(0x%08x).String() = %q, want %q", code, got, name)
 		}
+		if resolved, defined := win32.FromName(name); !defined || uint32(resolved) != code {
+			t.Errorf("win32.FromName(%q) = 0x%08x, %v; want 0x%08x, true", name, uint32(resolved), defined, code)
+		}
+	}
+
+	// The NtFrs service errors [MS-ERREF] 2.2 carries at 0x00001F41..0x00001F51 sat
+	// outside the subset this interface declared, so they rendered as bare hex; they
+	// resolve by name now. These two are the promotion-path failures FrsRpc reports.
+	beyondSubset := map[uint32]string{
+		0x00001F49: "FRS_ERR_PARENT_INSUFFICIENT_PRIV",
+		0x00001F4A: "FRS_ERR_PARENT_AUTHENTICATION",
+	}
+	for code, name := range beyondSubset {
+		if got := win32.WIN32_ERROR(code).String(); got != name {
+			t.Errorf("win32.WIN32_ERROR(0x%08x).String() = %q, want %q", code, got, name)
+		}
+		if resolved, defined := win32.FromName(name); !defined || uint32(resolved) != code {
+			t.Errorf("win32.FromName(%q) = 0x%08x, %v; want 0x%08x, true", name, uint32(resolved), defined, code)
+		}
+	}
+
+	// A value [MS-ERREF] 2.2 does not define still renders as hex.
+	if got := win32.WIN32_ERROR(0xdeadbeef).String(); got != "0xdeadbeef" {
+		t.Errorf("win32.WIN32_ERROR(0xdeadbeef).String() = %q, want 0xdeadbeef", got)
 	}
 }


### PR DESCRIPTION
### Linked Issue

Refs #1219 — phase 4 of the sweep that replaces each RPC interface's private
error-code subset with direct references to `windows/errors/win32`. Two
interfaces, one commit each, both from [MS-FRS1]:

- **frsrpc** — `network/dcerpc/interfaces/f5cc59b4-4264-101a-8c59-08002b2f8426/1.1/`, 3 constants retired
- **NtFrsApi** — `network/dcerpc/interfaces/d049b186-814f-11d1-9a3c-00c04fc9b232/1.1/`, 2 constants retired

Both are full retirements: nothing stays local, so `StatusString` is deleted
outright in each rather than reduced.

### Root Cause

**frsrpc** declared `StatusSuccess` (0x00000000), `ErrorAccessDenied`
(0x00000005) and `ErrorCallNotImplemented` (0x00000078), with a `StatusString`
switch over the three whose default arm rendered every other status as bare hex.

**NtFrsApi** declared `StatusSuccess` (0x00000000) and `ErrorAccessDenied`
(0x00000005), with the same shape of `StatusString`.

All five values are rows of [MS-ERREF] 2.2, the whole of which already lives in
`windows/errors/win32` as 2703 codes under the `WIN32_ERROR` type. So each
descriptor duplicated a handful of those rows while the codes that actually
describe an FRS failure went out undecoded — most visibly the seventeen
`FRS_ERR_*` NtFrs service errors the shared table carries at 0x00001F41 through
0x00001F51, from `FRS_ERR_INVALID_API_SEQUENCE` to
`FRS_ERR_INVALID_SERVICE_PARAMETER`, which are exactly what an FRSAPI call
reports. [MS-FRS1] 3.3.4 and 3.2.4 both say a method returns 0 or a Win32 error
code, so nothing about either return space was private to its interface.

### Fix Description

**frsrpc.** The four method stubs under `functions/` now convert the returned
status with `win32.WIN32_ERROR(resp.Status)`, compare it against
`win32.ERROR_SUCCESS` and render a failure with
`win32.WIN32_ERROR(resp.Status).String()`. The three constants and
`StatusString` are gone from `interface.go`, along with its `"fmt"` import;
the block comment is replaced by a note pointing at
`github.com/TheManticoreProject/Manticore/windows/errors/win32`.

**NtFrsApi.** The same rewrite across its six method stubs; the two constants,
`StatusString` and `"fmt"` are gone from `interface.go`, with the same
replacement note.

Both descriptors' package doc comments drop the now-inaccurate "and status
constants" from the list of what the package holds, matching the phrasing
already used by the migrated W32Time descriptor.

Every name was derived **from the value, not from the private identifier**: each
constant was looked up in the committed [MS-ERREF] 2.2 extract at
`windows/errors/errgen/ms-erref-2.2-win32.tsv`.

| Interface | Constant | Value | [MS-ERREF] 2.2 row | Outcome |
| --- | --- | --- | --- | --- |
| frsrpc | `StatusSuccess` | `0x00000000` | `ERROR_SUCCESS` | migrated to `win32.ERROR_SUCCESS` |
| frsrpc | `ErrorAccessDenied` | `0x00000005` | `ERROR_ACCESS_DENIED` | migrated to `win32.ERROR_ACCESS_DENIED` |
| frsrpc | `ErrorCallNotImplemented` | `0x00000078` | `ERROR_CALL_NOT_IMPLEMENTED` | migrated to `win32.ERROR_CALL_NOT_IMPLEMENTED` |
| NtFrsApi | `StatusSuccess` | `0x00000000` | `ERROR_SUCCESS` | migrated to `win32.ERROR_SUCCESS` |
| NtFrsApi | `ErrorAccessDenied` | `0x00000005` | `ERROR_ACCESS_DENIED` | migrated to `win32.ERROR_ACCESS_DENIED` |

Nothing is kept local in either interface, and no name was expanded from its
private identifier. That value-first check matters in FRS territory because two
similarly named error families exist and neither name shape implies the other's
range: `FRS_ERR_*` is in the shared table at 0x00001F41 through 0x00001F51,
while the `FRS_ERROR_*` family [MS-FRS2] defines at 0x23xx is absent from it
entirely and the part of 0x2300 through 0x26FF the table does populate is the
unrelated `DNS_ERROR_*` range. Neither of these two interfaces declared either
family, but both descriptors now record the distinction so a later reader does
not fold one onto the other, and the NtFrsApi test asserts it.

No alias constants, local re-declarations or delegating wrappers were left
behind. Each stub keeps its interface-descriptor import for the opnum its
request type reports.

The rewrite was applied one comparison term at a time rather than one condition
at a time, so a condition accepting a second code alongside success could not
silently lose a term and still compile. All ten status conditions across the two
interfaces turned out to be single-term, and a per-file count of the comparison
terms in every `if` statement is identical before and after the change on all
ten touched `functions/*.go` files. Behaviour is preserved exactly: in
particular no tolerance was added for `ERROR_CALL_NOT_IMPLEMENTED`, which
[MS-FRS1] 3.3.4.2 says `FrsRpcVerifyPromotionParent` always returns — the stub
reported that as a failure before and still does.

### How Verified

- `go build ./...` — exit 0.
- `go vet ./...` — exit 0, no diagnostics.
- `go test -count=1 ./...` — exit 0, **313 ok, 0 failures**, matching `main`'s 313.
- `CGO_ENABLED=0 go build ./...` for `windows/amd64`, `windows/386`,
  `linux/arm64` and `linux/386` — all exit 0.
- `gofmt -l` over both interface trees lists nothing; both trees were also clean
  on `main` before the change, and no file outside them was reformatted.
- Import blocks were reconstructed rather than patched blind: the
  stdlib/project blank line survives in all ten touched `functions/*.go` files,
  with `windows/errors/win32` inserted in path order between
  `network/dcerpc/ndr` and the `windows/...` protocol imports.
- Greps confirm the survivors are intact in both descriptors — `PipeName`,
  `SyntaxID()`, every opnum constant, `OpnumToName` and `NameToOpnum` — and
  that no reference to `StatusString` or to any of the five retired constants
  remains anywhere in the tree.

### Test Coverage

`TestStatusString` is replaced in each interface by
`TestStatusCodesResolveThroughWin32`. Every value asserted in either test was
looked up in `ms-erref-2.2-win32.tsv` first.

**frsrpc** pins the three retired values to `ERROR_SUCCESS`,
`ERROR_ACCESS_DENIED` and `ERROR_CALL_NOT_IMPLEMENTED` through the shared table
in both directions (`WIN32_ERROR.String()` and `win32.FromName`), checks that
two FRS service errors the descriptor never enumerated —
`FRS_ERR_PARENT_INSUFFICIENT_PRIV` (0x00001F49) and `FRS_ERR_PARENT_AUTHENTICATION`
(0x00001F4A), the promotion-path failures this interface reports — now render by
name where they used to render as hex, and that an undefined value still renders
as hex.

**NtFrsApi** pins both retired values the same way, checks five of the
`FRS_ERR_*` service errors (0x00001F41, 0x00001F44, 0x00001F46, 0x00001F47,
0x00001F51) now render by name, asserts `win32.Lookup` claims none of the three
0x23xx `FRS_ERROR_*` values so nothing can be resolved across the two families
by name similarity, and that an undefined value still renders as hex.

`TestSyntaxID`, `TestPipeName` and `TestOpnumNameRoundTrip` are unchanged in
both interfaces.

### Scope of Change

**frsrpc** — 6 files:

- `interface.go` (3 constants + `StatusString` + `"fmt"` removed, note added)
- `interface_test.go`
- `functions/00_FrsRpcSendCommPkt.go`
- `functions/01_FrsRpcVerifyPromotionParent.go`
- `functions/02_FrsRpcStartPromotionParent.go`
- `functions/03_FrsNOP.go`

**NtFrsApi** — 8 files:

- `interface.go` (2 constants + `StatusString` + `"fmt"` removed, note added)
- `interface_test.go`
- `functions/04_NtFrsApi_Rpc_Set_DsPollingIntervalW.go`
- `functions/05_NtFrsApi_Rpc_Get_DsPollingIntervalW.go`
- `functions/07_NtFrsApi_Rpc_InfoW.go`
- `functions/08_NtFrsApi_Rpc_IsPathReplicated.go`
- `functions/09_NtFrsApi_Rpc_WriterCommand.go`
- `functions/10_NtFrsApi_Rpc_ForceReplication.go`

`functions/functions.go` in each interface holds only the shared
`statusResponse` stub and needed no change. Nothing outside these two
directories is touched — in particular the already-migrated FrsTransport
interface at `897e2e5f-93f3-4376-9c9c-fd2277495c27/1.0/` is byte-identical to
`main`.

### Risk and Rollout

Low. Neither descriptor has a consumer outside its own directory: a tree-wide
grep for both import paths and for every retired constant name finds hits only
inside the two interface directories, so `network/dcerpc/ms-protocols/` and
`network/smb/smb_v10/server/rpcpipe/` are unaffected, and
`windows/protocols/ms-frs1` and `ms-frs2` reference no status constant at all.
No test anywhere classifies a failure by matching a rendered mnemonic against
`"FRS"` or `"STATUS_"`; the only such matches in the tree are two
`ERROR_INVALID_LEVEL` assertions in `rpcpipe_test.go`, which belong to srvsvc.

The one observable change is in error text: a failing FRS call previously
reported `0x00001f47`, and now reports `FRS_ERR_INSUFFICIENT_PRIV`. Codes the
old switch did name render identically, since the shared table uses the same
specification names. Both retired sets are gone in a single commit each, so a
revert of either commit restores that interface exactly.

### Notes

These two interfaces are the clean case of a pattern the FrsTransport migration
had to handle carefully. All five constants resolved by value under the name the
specification uses, so both `StatusString` functions could be deleted rather
than reduced — unlike FrsTransport, which had to keep three `FRS_ERROR_*` codes
local because [MS-ERREF] 2.2 has no row for them.

Nothing here is off-pattern. `ErrorCallNotImplemented` was declared in the
frsrpc descriptor but referenced by no stub, so its retirement removes a
declaration that had no call site; the comment noting that
`FrsRpcVerifyPromotionParent` always returns it is preserved in the replacement
note, without turning it into a tolerance the code never had.
