### PR TITLE
Route msgsvc and msgsvcsend status reporting through win32 (Refs #1219)

### DIFF
--- a/network/dcerpc/interfaces/17fdd703-1827-4e34-79d4-24a55c53bb37/1.0/functions/00_NetrMessageNameAdd.go
+++ b/network/dcerpc/interfaces/17fdd703-1827-4e34-79d4-24a55c53bb37/1.0/functions/00_NetrMessageNameAdd.go
@@ -10,6 +10,7 @@ import (
 
 	msgsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/17fdd703-1827-4e34-79d4-24a55c53bb37/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 )
 
 // netrMessageNameAddRequest carries the [in] parameters of NetrMessageNameAdd.
@@ -37,8 +38,8 @@ func NetrMessageNameAdd(rpc ndr.Invoker, serverName *ndr.WSTR, msgName ndr.WSTR)
 		err = fmt.Errorf("NetrMessageNameAdd: %w", err)
 		return
 	}
-	if uint32(resp.Status) != msgsvc.StatusSuccess {
-		err = fmt.Errorf("NetrMessageNameAdd failed: %s", msgsvc.StatusString(uint32(resp.Status)))
+	if win32.WIN32_ERROR(resp.Status) != win32.NERR_Success {
+		err = fmt.Errorf("NetrMessageNameAdd failed: %s", win32.WIN32_ERROR(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/17fdd703-1827-4e34-79d4-24a55c53bb37/1.0/functions/01_NetrMessageNameEnum.go
+++ b/network/dcerpc/interfaces/17fdd703-1827-4e34-79d4-24a55c53bb37/1.0/functions/01_NetrMessageNameEnum.go
@@ -10,6 +10,7 @@ import (
 
 	msgsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/17fdd703-1827-4e34-79d4-24a55c53bb37/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	msmsrp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-msrp"
 )
 
@@ -48,8 +49,8 @@ func NetrMessageNameEnum(rpc ndr.Invoker, serverName *ndr.WSTR, infoStruct msmsr
 	InfoStruct = resp.InfoStruct
 	TotalEntries = resp.TotalEntries
 	ResumeHandle = resp.ResumeHandle
-	if uint32(resp.Status) != msgsvc.StatusSuccess {
-		err = fmt.Errorf("NetrMessageNameEnum failed: %s", msgsvc.StatusString(uint32(resp.Status)))
+	if win32.WIN32_ERROR(resp.Status) != win32.NERR_Success {
+		err = fmt.Errorf("NetrMessageNameEnum failed: %s", win32.WIN32_ERROR(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/17fdd703-1827-4e34-79d4-24a55c53bb37/1.0/functions/02_NetrMessageNameGetInfo.go
+++ b/network/dcerpc/interfaces/17fdd703-1827-4e34-79d4-24a55c53bb37/1.0/functions/02_NetrMessageNameGetInfo.go
@@ -10,6 +10,7 @@ import (
 
 	msgsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/17fdd703-1827-4e34-79d4-24a55c53bb37/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	msmsrp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-msrp"
 )
 
@@ -42,8 +43,8 @@ func NetrMessageNameGetInfo(rpc ndr.Invoker, serverName *ndr.WSTR, msgName ndr.W
 		return
 	}
 	InfoStruct = resp.InfoStruct
-	if uint32(resp.Status) != msgsvc.StatusSuccess {
-		err = fmt.Errorf("NetrMessageNameGetInfo failed: %s", msgsvc.StatusString(uint32(resp.Status)))
+	if win32.WIN32_ERROR(resp.Status) != win32.NERR_Success {
+		err = fmt.Errorf("NetrMessageNameGetInfo failed: %s", win32.WIN32_ERROR(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/17fdd703-1827-4e34-79d4-24a55c53bb37/1.0/functions/03_NetrMessageNameDel.go
+++ b/network/dcerpc/interfaces/17fdd703-1827-4e34-79d4-24a55c53bb37/1.0/functions/03_NetrMessageNameDel.go
@@ -10,6 +10,7 @@ import (
 
 	msgsvc "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/17fdd703-1827-4e34-79d4-24a55c53bb37/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 )
 
 // netrMessageNameDelRequest carries the [in] parameters of NetrMessageNameDel.
@@ -37,8 +38,8 @@ func NetrMessageNameDel(rpc ndr.Invoker, serverName *ndr.WSTR, msgName ndr.WSTR)
 		err = fmt.Errorf("NetrMessageNameDel: %w", err)
 		return
 	}
-	if uint32(resp.Status) != msgsvc.StatusSuccess {
-		err = fmt.Errorf("NetrMessageNameDel failed: %s", msgsvc.StatusString(uint32(resp.Status)))
+	if win32.WIN32_ERROR(resp.Status) != win32.NERR_Success {
+		err = fmt.Errorf("NetrMessageNameDel failed: %s", win32.WIN32_ERROR(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/17fdd703-1827-4e34-79d4-24a55c53bb37/1.0/interface.go
+++ b/network/dcerpc/interfaces/17fdd703-1827-4e34-79d4-24a55c53bb37/1.0/interface.go
@@ -1,8 +1,8 @@
 // Package rpcinterface_17fdd70318274e3479d424a55c53bb37_1_0 is the descriptor for the msgsvc RPC interface, abstract
 // syntax 17fdd703-1827-4e34-79d4-24a55c53bb37 version 1.0 ([MS-MSRP]).
 //
-// The PipeName, the NET_API_STATUS code table, and doc comments are not derivable
-// from the IDL and were filled in by hand from [MS-MSRP] and [MS-ERREF].
+// The PipeName and the doc comments are not derivable from the IDL and were
+// filled in by hand from [MS-MSRP].
 package rpcinterface_17fdd70318274e3479d424a55c53bb37_1_0
 
 // IDL source: [MS-MSRP] — this interface is translated from and verified
@@ -11,8 +11,6 @@ package rpcinterface_17fdd70318274e3479d424a55c53bb37_1_0
 // A fetched copy is kept at ms-msrp.idl in the interface directory.
 
 import (
-	"fmt"
-
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
 	"github.com/TheManticoreProject/Manticore/windows/guid"
 )
@@ -30,26 +28,13 @@ const (
 	OpnumNetrMessageNameDel     uint16 = 3
 )
 
-// NET_API_STATUS codes returned by this interface ([MS-MSRP] 3.1.4, [MS-ERREF],
-// lmerr.h). NERR_* values are relative to NERR_BASE (2100 / 0x834).
-const (
-	StatusSuccess         uint32 = 0x00000000 // NERR_Success / ERROR_SUCCESS
-	ErrorAccessDenied     uint32 = 0x00000005 // ERROR_ACCESS_DENIED
-	ErrorNotEnoughMemory  uint32 = 0x00000008 // ERROR_NOT_ENOUGH_MEMORY
-	ErrorInvalidParameter uint32 = 0x00000057 // ERROR_INVALID_PARAMETER
-	ErrorInvalidName      uint32 = 0x0000007B // ERROR_INVALID_NAME
-	ErrorInvalidLevel     uint32 = 0x0000007C // ERROR_INVALID_LEVEL
-	NerrBufTooSmall       uint32 = 0x0000084B // NERR_BufTooSmall
-	NerrNetworkError      uint32 = 0x00000858 // NERR_NetworkError
-	NerrInternalError     uint32 = 0x0000085C // NERR_InternalError
-	NerrAlreadyExists     uint32 = 0x000008E4 // NERR_AlreadyExists
-	NerrTooManyNames      uint32 = 0x000008E5 // NERR_TooManyNames
-	NerrDelComputerName   uint32 = 0x000008E6 // NERR_DelComputerName
-	NerrNameInUse         uint32 = 0x000008EB // NERR_NameInUse
-	NerrNotLocalName      uint32 = 0x000008ED // NERR_NotLocalName
-	NerrDuplicateName     uint32 = 0x000008F9 // NERR_DuplicateName
-	NerrIncompleteDel     uint32 = 0x000008FB // NERR_IncompleteDel
-)
+// The NET_API_STATUS codes msgsvc methods return ([MS-MSRP] 3.1.4, [MS-ERREF] 2.2,
+// lmerr.h) are not declared here. The whole of [MS-ERREF] 2.2, the NERR_* range
+// included, lives in
+// github.com/TheManticoreProject/Manticore/windows/errors/win32 as the WIN32_ERROR type,
+// and a subset repeated here would cover a fraction of that 2703-code table while drifting
+// from it. Convert a returned status with win32.WIN32_ERROR(status) and compare against
+// win32.NERR_Success and the rest.
 
 // SyntaxID returns the msgsvc abstract syntax identifier:
 // 17fdd703-1827-4e34-79d4-24a55c53bb37, version 1.0.
@@ -58,47 +43,6 @@ func SyntaxID() syntax.SyntaxID {
 		UUID:         guid.GUID{A: 0x17fdd703, B: 0x1827, C: 0x4e34, D: 0x79d4, E: 0x24a55c53bb37},
 		MajorVersion: 1,
 		MinorVersion: 0,
-	}
-}
-
-// StatusString returns a mnemonic for the documented status codes, otherwise the
-// hex value.
-func StatusString(status uint32) string {
-	switch status {
-	case StatusSuccess:
-		return "NERR_Success"
-	case ErrorAccessDenied:
-		return "ERROR_ACCESS_DENIED"
-	case ErrorNotEnoughMemory:
-		return "ERROR_NOT_ENOUGH_MEMORY"
-	case ErrorInvalidParameter:
-		return "ERROR_INVALID_PARAMETER"
-	case ErrorInvalidName:
-		return "ERROR_INVALID_NAME"
-	case ErrorInvalidLevel:
-		return "ERROR_INVALID_LEVEL"
-	case NerrBufTooSmall:
-		return "NERR_BufTooSmall"
-	case NerrNetworkError:
-		return "NERR_NetworkError"
-	case NerrInternalError:
-		return "NERR_InternalError"
-	case NerrAlreadyExists:
-		return "NERR_AlreadyExists"
-	case NerrTooManyNames:
-		return "NERR_TooManyNames"
-	case NerrDelComputerName:
-		return "NERR_DelComputerName"
-	case NerrNameInUse:
-		return "NERR_NameInUse"
-	case NerrNotLocalName:
-		return "NERR_NotLocalName"
-	case NerrDuplicateName:
-		return "NERR_DuplicateName"
-	case NerrIncompleteDel:
-		return "NERR_IncompleteDel"
-	default:
-		return fmt.Sprintf("0x%08x", status)
 	}
 }
 

--- a/network/dcerpc/interfaces/17fdd703-1827-4e34-79d4-24a55c53bb37/1.0/interface_test.go
+++ b/network/dcerpc/interfaces/17fdd703-1827-4e34-79d4-24a55c53bb37/1.0/interface_test.go
@@ -1,6 +1,10 @@
 package rpcinterface_17fdd70318274e3479d424a55c53bb37_1_0
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
+)
 
 // TestSyntaxID verifies the abstract syntax identity (UUID + version).
 func TestSyntaxID(t *testing.T) {
@@ -31,19 +35,59 @@ func TestOpnums(t *testing.T) {
 	}
 }
 
-// TestStatusString verifies mnemonic rendering of documented codes and the hex fallback.
-func TestStatusString(t *testing.T) {
-	cases := map[uint32]string{
-		StatusSuccess:     "NERR_Success",
-		ErrorAccessDenied: "ERROR_ACCESS_DENIED",
-		ErrorInvalidLevel: "ERROR_INVALID_LEVEL",
-		NerrBufTooSmall:   "NERR_BufTooSmall",
-		NerrIncompleteDel: "NERR_IncompleteDel",
-		0xdeadbeef:        "0xdeadbeef",
+// TestStatusCodesResolveThroughWin32 pins that the NET_API_STATUS codes [MS-MSRP]
+// 3.1.4 documents for msgsvc resolve through the shared [MS-ERREF] 2.2 table under
+// their specification names, that a code the interface never enumerated now renders
+// by name rather than as undecoded hex, and that a value the specification does not
+// define still renders as hex.
+func TestStatusCodesResolveThroughWin32(t *testing.T) {
+	documented := map[uint32]string{
+		0x00000000: "ERROR_SUCCESS",
+		0x00000005: "ERROR_ACCESS_DENIED",
+		0x00000008: "ERROR_NOT_ENOUGH_MEMORY",
+		0x00000057: "ERROR_INVALID_PARAMETER",
+		0x0000007B: "ERROR_INVALID_NAME",
+		0x0000007C: "ERROR_INVALID_LEVEL",
+		0x0000084B: "NERR_BufTooSmall",
+		0x00000858: "NERR_NetworkError",
+		0x0000085C: "NERR_InternalError",
+		0x000008E4: "NERR_AlreadyExists",
+		0x000008E5: "NERR_TooManyNames",
+		0x000008E6: "NERR_DelComputerName",
+		0x000008EB: "NERR_NameInUse",
+		0x000008ED: "NERR_NotLocalName",
+		0x000008F9: "NERR_DuplicateName",
+		0x000008FB: "NERR_IncompleteDel",
 	}
-	for code, want := range cases {
-		if got := StatusString(code); got != want {
-			t.Errorf("StatusString(0x%08x) = %q, want %q", code, got, want)
+	for code, name := range documented {
+		if got := win32.WIN32_ERROR(code).String(); got != name {
+			t.Errorf("win32.WIN32_ERROR(0x%08x).String() = %q, want %q", code, got, name)
 		}
+		if resolved, defined := win32.FromName(name); !defined || uint32(resolved) != code {
+			t.Errorf("win32.FromName(%q) = 0x%08x, %v; want 0x%08x, true", name, uint32(resolved), defined, code)
+		}
+	}
+
+	// Success carries two names in [MS-ERREF] 2.2, ERROR_SUCCESS and NERR_Success, and
+	// the method stubs compare against win32.NERR_Success because [MS-MSRP] 3.1.4
+	// documents NET_API_STATUS returns. Both names resolve to the same value, which
+	// renders under the canonical ERROR_SUCCESS.
+	if resolved, defined := win32.FromName("NERR_Success"); !defined || uint32(resolved) != 0x00000000 {
+		t.Errorf("win32.FromName(%q) = 0x%08x, %v; want 0x00000000, true", "NERR_Success", uint32(resolved), defined)
+	}
+	if win32.NERR_Success != win32.ERROR_SUCCESS {
+		t.Errorf("win32.NERR_Success = 0x%08x, want the same value as win32.ERROR_SUCCESS", uint32(win32.NERR_Success))
+	}
+
+	// NERR_MsgNotStarted, the Messenger service not being started, was outside the
+	// subset this interface used to declare, so it rendered as hex; it resolves by name
+	// now.
+	if got := win32.WIN32_ERROR(0x000008EC).String(); got != "NERR_MsgNotStarted" {
+		t.Errorf("win32.WIN32_ERROR(0x000008ec).String() = %q, want NERR_MsgNotStarted", got)
+	}
+
+	// A value [MS-ERREF] 2.2 does not define still renders as hex.
+	if got := win32.WIN32_ERROR(0x12345678).String(); got != "0x12345678" {
+		t.Errorf("win32.WIN32_ERROR(0x12345678).String() = %q, want hex", got)
 	}
 }

--- a/network/dcerpc/interfaces/5a7b91f8-ff00-11d0-a9b2-00c04fb6e6fc/1.0/functions/00_NetrSendMessage.go
+++ b/network/dcerpc/interfaces/5a7b91f8-ff00-11d0-a9b2-00c04fb6e6fc/1.0/functions/00_NetrSendMessage.go
@@ -10,6 +10,7 @@ import (
 
 	msgsvcsend "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/5a7b91f8-ff00-11d0-a9b2-00c04fb6e6fc/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 )
 
 // netrSendMessageRequest carries the [in] parameters of NetrSendMessage.
@@ -46,8 +47,8 @@ func NetrSendMessage(rpc ndr.Invoker, from ndr.STR, to ndr.STR, text ndr.STR) (e
 		err = fmt.Errorf("NetrSendMessage: %w", err)
 		return
 	}
-	if uint32(resp.Status) != msgsvcsend.StatusSuccess {
-		err = fmt.Errorf("NetrSendMessage failed: %s", msgsvcsend.StatusString(uint32(resp.Status)))
+	if win32.WIN32_ERROR(resp.Status) != win32.NERR_Success {
+		err = fmt.Errorf("NetrSendMessage failed: %s", win32.WIN32_ERROR(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/5a7b91f8-ff00-11d0-a9b2-00c04fb6e6fc/1.0/interface.go
+++ b/network/dcerpc/interfaces/5a7b91f8-ff00-11d0-a9b2-00c04fb6e6fc/1.0/interface.go
@@ -1,8 +1,8 @@
 // Package rpcinterface_5a7b91f8ff0011d0a9b200c04fb6e6fc_1_0 is the descriptor for the msgsvcsend RPC interface, abstract
 // syntax 5a7b91f8-ff00-11d0-a9b2-00c04fb6e6fc version 1.0 ([MS-MSRP]).
 //
-// The PipeName, the NET_API_STATUS code table, and doc comments are not derivable
-// from the IDL and were filled in by hand from [MS-MSRP] and [MS-ERREF].
+// The PipeName and the doc comments are not derivable from the IDL and were
+// filled in by hand from [MS-MSRP].
 package rpcinterface_5a7b91f8ff0011d0a9b200c04fb6e6fc_1_0
 
 // IDL source: [MS-MSRP] — this interface is translated from and verified
@@ -11,8 +11,6 @@ package rpcinterface_5a7b91f8ff0011d0a9b200c04fb6e6fc_1_0
 // A fetched copy is kept at ms-msrp.idl in the interface directory.
 
 import (
-	"fmt"
-
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
 	"github.com/TheManticoreProject/Manticore/windows/guid"
 )
@@ -27,23 +25,13 @@ const (
 	OpnumNetrSendMessage uint16 = 0
 )
 
-// NET_API_STATUS / error_status_t codes returned by this interface ([MS-MSRP] 3.2.4.1,
-// [MS-ERREF], lmerr.h). NERR_* values are relative to NERR_BASE (2100 / 0x834).
-const (
-	StatusSuccess          uint32 = 0x00000000 // ERROR_SUCCESS
-	ErrorAccessDenied      uint32 = 0x00000005 // ERROR_ACCESS_DENIED
-	ErrorNotSupported      uint32 = 0x00000032 // ERROR_NOT_SUPPORTED
-	ErrorInvalidParameter  uint32 = 0x00000057 // ERROR_INVALID_PARAMETER
-	NerrNetworkError       uint32 = 0x00000858 // NERR_NetworkError
-	NerrNameNotFound       uint32 = 0x000008E1 // NERR_NameNotFound
-	NerrGrpMsgProcessor    uint32 = 0x000008E8 // NERR_GrpMsgProcessor
-	NerrPausedRemote       uint32 = 0x000008E9 // NERR_PausedRemote
-	NerrBadReceive         uint32 = 0x000008EA // NERR_BadReceive
-	NerrNameInUse          uint32 = 0x000008EB // NERR_NameInUse
-	NerrNotLocalName       uint32 = 0x000008ED // NERR_NotLocalName
-	NerrTruncatedBroadcast uint32 = 0x000008F1 // NERR_TruncatedBroadcast
-	NerrDuplicateName      uint32 = 0x000008F9 // NERR_DuplicateName
-)
+// The NET_API_STATUS / error_status_t codes NetrSendMessage returns ([MS-MSRP] 3.2.4.1,
+// [MS-ERREF] 2.2, lmerr.h) are not declared here. The whole of [MS-ERREF] 2.2, the
+// NERR_* range included, lives in
+// github.com/TheManticoreProject/Manticore/windows/errors/win32 as the WIN32_ERROR type,
+// and a subset repeated here would cover a fraction of that 2703-code table while drifting
+// from it. Convert a returned status with win32.WIN32_ERROR(status) and compare against
+// win32.NERR_Success and the rest.
 
 // SyntaxID returns the msgsvcsend abstract syntax identifier:
 // 5a7b91f8-ff00-11d0-a9b2-00c04fb6e6fc, version 1.0.
@@ -52,41 +40,6 @@ func SyntaxID() syntax.SyntaxID {
 		UUID:         guid.GUID{A: 0x5a7b91f8, B: 0xff00, C: 0x11d0, D: 0xa9b2, E: 0x00c04fb6e6fc},
 		MajorVersion: 1,
 		MinorVersion: 0,
-	}
-}
-
-// StatusString returns a mnemonic for the documented status codes, otherwise the
-// hex value.
-func StatusString(status uint32) string {
-	switch status {
-	case StatusSuccess:
-		return "ERROR_SUCCESS"
-	case ErrorAccessDenied:
-		return "ERROR_ACCESS_DENIED"
-	case ErrorNotSupported:
-		return "ERROR_NOT_SUPPORTED"
-	case ErrorInvalidParameter:
-		return "ERROR_INVALID_PARAMETER"
-	case NerrNetworkError:
-		return "NERR_NetworkError"
-	case NerrNameNotFound:
-		return "NERR_NameNotFound"
-	case NerrGrpMsgProcessor:
-		return "NERR_GrpMsgProcessor"
-	case NerrPausedRemote:
-		return "NERR_PausedRemote"
-	case NerrBadReceive:
-		return "NERR_BadReceive"
-	case NerrNameInUse:
-		return "NERR_NameInUse"
-	case NerrNotLocalName:
-		return "NERR_NotLocalName"
-	case NerrTruncatedBroadcast:
-		return "NERR_TruncatedBroadcast"
-	case NerrDuplicateName:
-		return "NERR_DuplicateName"
-	default:
-		return fmt.Sprintf("0x%08x", status)
 	}
 }
 

--- a/network/dcerpc/interfaces/5a7b91f8-ff00-11d0-a9b2-00c04fb6e6fc/1.0/interface_test.go
+++ b/network/dcerpc/interfaces/5a7b91f8-ff00-11d0-a9b2-00c04fb6e6fc/1.0/interface_test.go
@@ -1,6 +1,10 @@
 package rpcinterface_5a7b91f8ff0011d0a9b200c04fb6e6fc_1_0
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
+)
 
 // TestSyntaxID verifies the abstract syntax identity (UUID + version).
 func TestSyntaxID(t *testing.T) {
@@ -26,18 +30,56 @@ func TestOpnums(t *testing.T) {
 	}
 }
 
-// TestStatusString verifies mnemonic rendering of documented codes and the hex fallback.
-func TestStatusString(t *testing.T) {
-	cases := map[uint32]string{
-		StatusSuccess:     "ERROR_SUCCESS",
-		ErrorAccessDenied: "ERROR_ACCESS_DENIED",
-		NerrNetworkError:  "NERR_NetworkError",
-		NerrDuplicateName: "NERR_DuplicateName",
-		0xdeadbeef:        "0xdeadbeef",
+// TestStatusCodesResolveThroughWin32 pins that the status codes [MS-MSRP] 3.2.4.1
+// documents for NetrSendMessage resolve through the shared [MS-ERREF] 2.2 table under
+// their specification names, that a code the interface never enumerated now renders by
+// name rather than as undecoded hex, and that a value the specification does not define
+// still renders as hex.
+func TestStatusCodesResolveThroughWin32(t *testing.T) {
+	documented := map[uint32]string{
+		0x00000000: "ERROR_SUCCESS",
+		0x00000005: "ERROR_ACCESS_DENIED",
+		0x00000032: "ERROR_NOT_SUPPORTED",
+		0x00000057: "ERROR_INVALID_PARAMETER",
+		0x00000858: "NERR_NetworkError",
+		0x000008E1: "NERR_NameNotFound",
+		0x000008E8: "NERR_GrpMsgProcessor",
+		0x000008E9: "NERR_PausedRemote",
+		0x000008EA: "NERR_BadReceive",
+		0x000008EB: "NERR_NameInUse",
+		0x000008ED: "NERR_NotLocalName",
+		0x000008F1: "NERR_TruncatedBroadcast",
+		0x000008F9: "NERR_DuplicateName",
 	}
-	for code, want := range cases {
-		if got := StatusString(code); got != want {
-			t.Errorf("StatusString(0x%08x) = %q, want %q", code, got, want)
+	for code, name := range documented {
+		if got := win32.WIN32_ERROR(code).String(); got != name {
+			t.Errorf("win32.WIN32_ERROR(0x%08x).String() = %q, want %q", code, got, name)
 		}
+		if resolved, defined := win32.FromName(name); !defined || uint32(resolved) != code {
+			t.Errorf("win32.FromName(%q) = 0x%08x, %v; want 0x%08x, true", name, uint32(resolved), defined, code)
+		}
+	}
+
+	// Success carries two names in [MS-ERREF] 2.2, ERROR_SUCCESS and NERR_Success, and
+	// the method stub compares against win32.NERR_Success because [MS-MSRP] 3.2.4.1
+	// documents NetrSendMessage's return values as NERR_* codes. Both names resolve to
+	// the same value, which renders under the canonical ERROR_SUCCESS.
+	if resolved, defined := win32.FromName("NERR_Success"); !defined || uint32(resolved) != 0x00000000 {
+		t.Errorf("win32.FromName(%q) = 0x%08x, %v; want 0x00000000, true", "NERR_Success", uint32(resolved), defined)
+	}
+	if win32.NERR_Success != win32.ERROR_SUCCESS {
+		t.Errorf("win32.NERR_Success = 0x%08x, want the same value as win32.ERROR_SUCCESS", uint32(win32.NERR_Success))
+	}
+
+	// NERR_RemoteFull, the message alias table on the remote station being full, was
+	// outside the subset this interface used to declare, so it rendered as hex; it
+	// resolves by name now.
+	if got := win32.WIN32_ERROR(0x000008EF).String(); got != "NERR_RemoteFull" {
+		t.Errorf("win32.WIN32_ERROR(0x000008ef).String() = %q, want NERR_RemoteFull", got)
+	}
+
+	// A value [MS-ERREF] 2.2 does not define still renders as hex.
+	if got := win32.WIN32_ERROR(0x12345678).String(); got != "0x12345678" {
+		t.Errorf("win32.WIN32_ERROR(0x12345678).String() = %q, want hex", got)
 	}
 }


### PR DESCRIPTION
### Linked Issue

Refs #1219

### Root Cause

Both `[MS-MSRP]` interfaces carried their own private slice of the Win32 error table plus a `StatusString` switch over it, and both had the highest constant-to-method ratio left in the phase: 16 constants over 4 methods in msgsvc, 13 constants over a single method in msgsvcsend.

msgsvc (`network/dcerpc/interfaces/17fdd703-1827-4e34-79d4-24a55c53bb37/1.0/interface.go`) declared 16 `NET_API_STATUS` constants — six system codes plus ten `NERR_*` codes from the lmerr.h message-alias range — and a `StatusString` switch over all 16. msgsvcsend (`network/dcerpc/interfaces/5a7b91f8-ff00-11d0-a9b2-00c04fb6e6fc/1.0/interface.go`) declared 13 — four system codes plus nine `NERR_*` codes — and the same switch shape for its one method. Every one of those 29 values already exists in `windows/errors/win32`, generated from the committed `[MS-ERREF]` 2.2 extract, whose 2703 rows include the whole `NERR_*` range. Both blocks were hand-maintained duplicates of a generated table and could only drift from it.

They were also ceilings rather than conveniences. `StatusString` rendered `fmt.Sprintf("0x%08x", status)` for anything outside its own switch, so the rest of the message-alias range came back to the caller undecoded. For msgsvc that included `NERR_MsgNotStarted` (0x000008EC, "The Messenger service has not been started"), the plainest answer a message-name call can get from a host that is not running the service, along with `NERR_MsgInitFailed`, `NERR_AlreadyForwarded`, `NERR_LocalForward`, `NERR_NoForwardName` and `NERR_NameNotForwarded`. For msgsvcsend it included `NERR_RemoteFull` (0x000008EF, "The message alias table on the remote station is full") and the same `NERR_MsgNotStarted`, both ordinary outcomes of a send to a live host.

The dead-code finding is the other half of the root cause, and it is evidence about how these subsets were written: of msgsvc's 16 constants, 15 had no reader anywhere in the tree beyond `StatusString`'s own switch, and of msgsvcsend's 13, 12 did. In each interface the only constant any code compared against was success, once per method stub. Both subsets were documentation written in the shape of code, with no callers to preserve.

### Fix Description

All 29 constants and both `StatusString` functions are removed outright — neither interface keeps a reduced switch, because neither has a code the shared table cannot name. The const block's doc comment in each descriptor is replaced by a note saying why the codes are not declared there and pointing at `github.com/TheManticoreProject/Manticore/windows/errors/win32`, and each package doc no longer advertises a status-code table. The `fmt` import is dropped from both descriptors, which had no other use for it.

The five method stubs (four in msgsvc, one in msgsvcsend) convert the retval with `win32.WIN32_ERROR(resp.Status)`, compare against `win32.NERR_Success` and render failures with the shared type's `String`, which names every code the specification defines and falls back to hex only for a value it does not. No alias constants, no local re-declaration, no delegating wrapper; each stub keeps its descriptor import for the opnum its request type reports.

Success is spelled `win32.NERR_Success` rather than `win32.ERROR_SUCCESS` in both interfaces. 0x00000000 carries both names in `[MS-ERREF]` 2.2 and `String()` renders it under the canonical `ERROR_SUCCESS` either way, so the choice is documentation rather than behaviour, but `NERR_Success` is the name the protocol uses: msgsvc's four methods are declared `NET_API_STATUS` in the IDL and `[MS-MSRP]` 3.1.4 documents their returns as `NERR_*` codes. msgsvcsend's `NetrSendMessage` is declared `error_status_t` in the IDL, yet the codes `[MS-MSRP]` 3.2.4.1 documents for it are the same `NET_API_STATUS` `NERR_*` values, and its own private block was already a mix of both, so it uses `win32.NERR_Success` too rather than splitting the protocol across two spellings of zero.

The mapping was derived from values, not names. Each numeric constant was looked up in `windows/errors/errgen/ms-erref-2.2-win32.tsv` and the symbolic name recorded for that row is the Go constant now referenced. This mattered here: `[MS-MSRP]` uses `NERR_*` codes whose names all exist in the table and are easy to mis-pair by name, since eight of them sit within a few values of each other in the message-alias block.

msgsvc, 16 constants:

| value | private name | `[MS-ERREF]` 2.2 row | outcome |
| --- | --- | --- | --- |
| 0x00000000 | `StatusSuccess` | `ERROR_SUCCESS` / `NERR_Success` | migrated to `win32.NERR_Success` |
| 0x00000005 | `ErrorAccessDenied` | `ERROR_ACCESS_DENIED` | migrated |
| 0x00000008 | `ErrorNotEnoughMemory` | `ERROR_NOT_ENOUGH_MEMORY` | migrated |
| 0x00000057 | `ErrorInvalidParameter` | `ERROR_INVALID_PARAMETER` | migrated |
| 0x0000007B | `ErrorInvalidName` | `ERROR_INVALID_NAME` | migrated |
| 0x0000007C | `ErrorInvalidLevel` | `ERROR_INVALID_LEVEL` | migrated |
| 0x0000084B | `NerrBufTooSmall` | `NERR_BufTooSmall` | migrated |
| 0x00000858 | `NerrNetworkError` | `NERR_NetworkError` | migrated |
| 0x0000085C | `NerrInternalError` | `NERR_InternalError` | migrated |
| 0x000008E4 | `NerrAlreadyExists` | `NERR_AlreadyExists` | migrated |
| 0x000008E5 | `NerrTooManyNames` | `NERR_TooManyNames` | migrated |
| 0x000008E6 | `NerrDelComputerName` | `NERR_DelComputerName` | migrated |
| 0x000008EB | `NerrNameInUse` | `NERR_NameInUse` | migrated |
| 0x000008ED | `NerrNotLocalName` | `NERR_NotLocalName` | migrated |
| 0x000008F9 | `NerrDuplicateName` | `NERR_DuplicateName` | migrated |
| 0x000008FB | `NerrIncompleteDel` | `NERR_IncompleteDel` | migrated |

msgsvcsend, 13 constants:

| value | private name | `[MS-ERREF]` 2.2 row | outcome |
| --- | --- | --- | --- |
| 0x00000000 | `StatusSuccess` | `ERROR_SUCCESS` / `NERR_Success` | migrated to `win32.NERR_Success` |
| 0x00000005 | `ErrorAccessDenied` | `ERROR_ACCESS_DENIED` | migrated |
| 0x00000032 | `ErrorNotSupported` | `ERROR_NOT_SUPPORTED` | migrated |
| 0x00000057 | `ErrorInvalidParameter` | `ERROR_INVALID_PARAMETER` | migrated |
| 0x00000858 | `NerrNetworkError` | `NERR_NetworkError` | migrated |
| 0x000008E1 | `NerrNameNotFound` | `NERR_NameNotFound` | migrated |
| 0x000008E8 | `NerrGrpMsgProcessor` | `NERR_GrpMsgProcessor` | migrated |
| 0x000008E9 | `NerrPausedRemote` | `NERR_PausedRemote` | migrated |
| 0x000008EA | `NerrBadReceive` | `NERR_BadReceive` | migrated |
| 0x000008EB | `NerrNameInUse` | `NERR_NameInUse` | migrated |
| 0x000008ED | `NerrNotLocalName` | `NERR_NotLocalName` | migrated |
| 0x000008F1 | `NerrTruncatedBroadcast` | `NERR_TruncatedBroadcast` | migrated |
| 0x000008F9 | `NerrDuplicateName` | `NERR_DuplicateName` | migrated |

All 29 resolved, and in all 29 cases the name the table records for that value agrees with the private identifier, so nothing is kept local and nothing is folded onto a near miss. Neighbouring rows were checked as well as the rows themselves: the gaps in the two subsets (0x000008E0, 0x000008E2, 0x000008E3, 0x000008E7, 0x000008EC, 0x000008EE, 0x000008EF, 0x000008F0) are all populated in the table, and all of them by further `NERR_*` message-alias codes rather than by an unrelated range, so there is no collision of the `FAX_ERR_*`-over-`ERROR_CTX_*` kind where a private name expands to the right identifier while the value belongs to someone else.

The rewrite was applied per comparison term, not per condition. All five status checks in the two interfaces turned out to be single-term (`uint32(resp.Status) != <descriptor>.StatusSuccess`), so no if-initializer hoist was needed. The per-`if` count of comparison terms was captured per file before the change and compared against the same tally afterwards by script; both tallies are `[1, 1]` for each of the five method files — the `Invoke` error check and the status check — and identical file by file. That is what rules out a condition accepting `NERR_BufTooSmall` or `NERR_IncompleteDel` alongside success in msgsvc, or `NERR_TruncatedBroadcast` or `NERR_PausedRemote` in msgsvcsend, which are the shapes an enumeration sizing probe, a partial name deletion or a partially delivered broadcast would use for normal termination, silently losing a term while still compiling. No tolerance was added that the code did not already have.

### How Verified

- `go build ./...` — clean, exit 0.
- `go vet ./...` — clean, exit 0, no output.
- `go test -count=1 ./...` — 313 packages ok, 0 failures, exit 0. `main` is at 313 ok.
- Cross-compile with `CGO_ENABLED=0 go build ./...`: `windows/amd64` exit 0, `windows/386` exit 0, `linux/arm64` exit 0, `linux/386` exit 0.
- Grep: none of the 29 migrated constant names remains anywhere in either interface directory, and `StatusString` no longer appears in either — neither declared nor called. The only `msgsvc.`- and `msgsvcsend.`-qualified references left under `functions/` are the `Opnum*` constants each request type reports.
- Grep for survivors: `PipeName`, `SyntaxID`, the opnum constants (four in msgsvc, one in msgsvcsend), `OpnumToName` and `NameToOpnum` are present and unchanged in both descriptors. This was checked explicitly because an earlier attempt in this phase removed `SyntaxID()` by slicing a file.
- Term-count check, scripted over all five method files: each has two `if`s with one comparison term each, identical to the same tally taken from the pristine files before the change.
- `gofmt -l` over each of the nine touched files lists nothing, and the same check over the pre-change copies of all nine lists nothing either, so every file was already `gofmt`-clean and no `gofmt -w` was run. No file outside the diff was reformatted.
- Import blocks were reconstructed rather than patched blindly: the stdlib/project blank line survives in all five method files, and `win32` is inserted in path order after `network/dcerpc/ndr` and before `windows/protocols/ms-msrp` where that import is present.
- Out-of-directory search: a tree-wide grep for both import paths, for the `msgsvc` and `msgsvcsend` aliases, for both UUIDs and for all 29 constant names finds no consumer outside the two interface directories. `windows/protocols/ms-msrp`, which holds this protocol's structures (`MSG_INFO`, `MSG_ENUM_STRUCT` and the containers), has no reference to either descriptor package and no reference to `win32`. `network/dcerpc/ms-protocols/` has no MSRP client, `network/smb/smb_v10/server/rpcpipe/` serves only srvsvc and wkssvc, and `network/dcerpc/interfaces/catalog/` has no row for either UUID. Neither interface has any test file other than `interface_test.go`.
- No test in the tree classifies an MSRP failure by matching a rendered mnemonic. The only `strings.Contains` matches against a rendered error name are in `network/smb/smb_v10/server/rpcpipe/rpcpipe_test.go`, which asserts `ERROR_INVALID_LEVEL` on srvsvc's `NetrShareEnum` and wkssvc's `NetrWkstaGetInfo`; both interfaces are untouched here, and those tests pass in the full run above.

### Test Coverage

`TestStatusString` in each `interface_test.go` is replaced by `TestStatusCodesResolveThroughWin32`.

msgsvc's version asserts that each of the 16 migrated codes renders through `win32.WIN32_ERROR.String()` under its specification name and resolves back through `win32.FromName` to the same value; that `win32.FromName("NERR_Success")` resolves to 0x00000000 and that `win32.NERR_Success` equals `win32.ERROR_SUCCESS`, which pins the alias the stubs compare against; that 0x000008EC, outside the old subset and previously hex, now renders as `NERR_MsgNotStarted`; and that 0x12345678, which the specification does not define, still renders as `0x12345678`.

msgsvcsend's version does the same for its 13 codes and the success alias, with 0x000008EF rendering as `NERR_RemoteFull` for the outside-the-subset case and the same undefined value for the hex fallback.

Every value in both tests was read out of the committed TSV rather than recalled, including the descriptions quoted in the comments; 0x000008EC and 0x000008EF were confirmed as the `NERR_MsgNotStarted` and `NERR_RemoteFull` rows, and 0x12345678 confirmed absent from the table. `TestSyntaxID` and `TestOpnums` are unchanged in both files and still pass.

### Scope of Change

Two commits, nine files, all under the two interface directories.

msgsvc — 6 files changed, 79 insertions, 87 deletions:

- `network/dcerpc/interfaces/17fdd703-1827-4e34-79d4-24a55c53bb37/1.0/interface.go` — 16 constants and `StatusString` removed, doc comments updated, `fmt` dropped, no other declaration touched.
- `.../1.0/interface_test.go` — `TestStatusString` replaced by `TestStatusCodesResolveThroughWin32`, `win32` import added.
- `.../1.0/functions/00_NetrMessageNameAdd.go`, `01_NetrMessageNameEnum.go`, `02_NetrMessageNameGetInfo.go`, `03_NetrMessageNameDel.go` — compare and render through `win32`.

msgsvcsend — 3 files changed, 67 insertions, 71 deletions:

- `network/dcerpc/interfaces/5a7b91f8-ff00-11d0-a9b2-00c04fb6e6fc/1.0/interface.go` — 13 constants and `StatusString` removed, doc comments updated, `fmt` dropped, no other declaration touched.
- `.../1.0/interface_test.go` — `TestStatusString` replaced by `TestStatusCodesResolveThroughWin32`, `win32` import added.
- `.../1.0/functions/00_NetrSendMessage.go` — compares and renders through `win32`.

Submodule pointer updated: no — the repository has no submodules.

Behavioral changes outside the migration: none. The only visible change is the text of a failure message, and for all 29 codes the subsets covered the messages are byte-identical, since `StatusString` returned the same specification names the shared table holds — including msgsvc's success case, which the old switch rendered as `NERR_Success` and which is unreachable in a failure message anyway. Codes the subsets omitted now name themselves instead of printing hex. The hex fallback format is unchanged: `win32.WIN32_ERROR.String()` renders an undefined value as lowercase `0x%08x`, exactly as the deleted `fmt.Sprintf` did.

### Risk and Rollout

Low. The change is confined to two interface packages with five method stubs between them, the numeric comparison against zero is unchanged, and the wire behaviour is identical — only the string in the returned error differs. `win32.WIN32_ERROR` is a `uint32` underneath and `ndr.DWORD` converts to it directly, so the conversions are free and the intermediate `uint32(...)` cast is gone. A tree-wide grep found no consumer of the removed identifiers outside the two directories, so nothing else can break, and the 15-of-16 and 12-of-13 dead-constant counts mean there was almost nothing for a consumer to have used in the first place.

### Notes

`windows/errors/win32` documents that Win32 codes and NTSTATUS values collide by value and are deliberately separate types. `[MS-MSRP]` has every method of both interfaces return a `NET_API_STATUS`/`error_status_t` result rather than an NTSTATUS, so `win32.WIN32_ERROR` is the correct table here; the type system now enforces that rather than leaving it to a comment.

The two subsets overlapped by five values (0x00000000, 0x00000005, 0x00000057, 0x000008EB, 0x000008ED) and disagreed on the name for success — msgsvc's `StatusString` rendered 0x00000000 as `NERR_Success` while msgsvcsend's rendered it as `ERROR_SUCCESS`. That is the sort of divergence a per-interface copy of a shared table produces on its own, and it is gone now that both defer to the generated one.

`NERR_*` codes are documented in `[MS-MSRP]` as offsets from `NERR_BASE` (2100 / 0x834), and the removed comments recorded that. The shared table stores absolute values, which is what the wire carries and what the stubs compare, so no base arithmetic survives anywhere in the two interfaces.
