### PR TITLE
Route IObjectExporter and browser status reporting through win32, and record epmapper's codes as DCE (Refs #1219)

### DIFF
--- a/network/dcerpc/interfaces/6bffd098-a112-3610-9833-012892020162/0.0/functions/02_I_BrowserrQueryOtherDomains.go
+++ b/network/dcerpc/interfaces/6bffd098-a112-3610-9833-012892020162/0.0/functions/02_I_BrowserrQueryOtherDomains.go
@@ -10,6 +10,7 @@ import (
 
 	browser "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/6bffd098-a112-3610-9833-012892020162/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	msbrwsa "github.com/TheManticoreProject/Manticore/windows/protocols/ms-brwsa"
 )
 
@@ -48,9 +49,8 @@ func I_BrowserrQueryOtherDomains(rpc ndr.Invoker, serverName string, info msbrws
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return msbrwsa.SERVER_ENUM_STRUCT{}, 0, fmt.Errorf("I_BrowserrQueryOtherDomains: %w", err)
 	}
-	status := uint32(resp.Status)
-	if status != browser.NERR_Success && status != browser.ERROR_MORE_DATA {
-		return resp.InfoStruct, uint32(resp.TotalEntries), fmt.Errorf("I_BrowserrQueryOtherDomains failed: %s", browser.StatusString(status))
+	if status := win32.WIN32_ERROR(resp.Status); status != win32.NERR_Success && status != win32.ERROR_MORE_DATA {
+		return resp.InfoStruct, uint32(resp.TotalEntries), fmt.Errorf("I_BrowserrQueryOtherDomains failed: %s", status.String())
 	}
 	return resp.InfoStruct, uint32(resp.TotalEntries), nil
 }

--- a/network/dcerpc/interfaces/6bffd098-a112-3610-9833-012892020162/0.0/interface.go
+++ b/network/dcerpc/interfaces/6bffd098-a112-3610-9833-012892020162/0.0/interface.go
@@ -15,8 +15,6 @@ package rpcinterface_6bffd098a11236109833012892020162_0_0
 // A fetched copy is kept at ms-brwsa.idl in the interface directory.
 
 import (
-	"fmt"
-
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
 	"github.com/TheManticoreProject/Manticore/windows/guid"
 )
@@ -31,16 +29,14 @@ const (
 	OpnumI_BrowserrQueryOtherDomains uint16 = 2
 )
 
-// NET_API_STATUS codes returned by I_BrowserrQueryOtherDomains ([MS-BRWSA] 3.1.4.1;
-// values from [MS-ERREF] Win32 error codes).
-const (
-	NERR_Success            uint32 = 0x00000000 // The operation completed successfully.
-	ERROR_ACCESS_DENIED     uint32 = 0x00000005 // Access is denied.
-	ERROR_NOT_ENOUGH_MEMORY uint32 = 0x00000008 // The server could not allocate enough memory.
-	ERROR_INVALID_PARAMETER uint32 = 0x00000057 // A parameter is incorrect (e.g. InfoStruct or Level100 is NULL).
-	ERROR_INVALID_LEVEL     uint32 = 0x0000007C // The Level member is not 100.
-	ERROR_MORE_DATA         uint32 = 0x000000EA // Not all available entries were returned.
-)
+// The NET_API_STATUS codes I_BrowserrQueryOtherDomains returns ([MS-BRWSA] 3.1.4.1) are
+// not declared here. A NET_API_STATUS is a Win32 error code, and the whole of
+// [MS-ERREF] 2.2 lives in
+// github.com/TheManticoreProject/Manticore/windows/errors/win32 as the WIN32_ERROR type,
+// so a subset repeated here would cover a fraction of that 2703-code table while drifting
+// from it. Convert a returned status with win32.WIN32_ERROR(status) and compare against
+// win32.NERR_Success, which is the zero success the specification calls NERR_Success, and
+// against win32.ERROR_MORE_DATA and the rest.
 
 // SyntaxID returns the browser abstract syntax identifier:
 // 6bffd098-a112-3610-9833-012892020162, version 0.0.
@@ -49,27 +45,6 @@ func SyntaxID() syntax.SyntaxID {
 		UUID:         guid.GUID{A: 0x6bffd098, B: 0xa112, C: 0x3610, D: 0x9833, E: 0x012892020162},
 		MajorVersion: 0,
 		MinorVersion: 0,
-	}
-}
-
-// StatusString returns a mnemonic for the documented status codes, otherwise the
-// hex value.
-func StatusString(status uint32) string {
-	switch status {
-	case NERR_Success:
-		return "NERR_Success"
-	case ERROR_ACCESS_DENIED:
-		return "ERROR_ACCESS_DENIED"
-	case ERROR_NOT_ENOUGH_MEMORY:
-		return "ERROR_NOT_ENOUGH_MEMORY"
-	case ERROR_INVALID_PARAMETER:
-		return "ERROR_INVALID_PARAMETER"
-	case ERROR_INVALID_LEVEL:
-		return "ERROR_INVALID_LEVEL"
-	case ERROR_MORE_DATA:
-		return "ERROR_MORE_DATA"
-	default:
-		return fmt.Sprintf("0x%08x", status)
 	}
 }
 

--- a/network/dcerpc/interfaces/6bffd098-a112-3610-9833-012892020162/0.0/interface_test.go
+++ b/network/dcerpc/interfaces/6bffd098-a112-3610-9833-012892020162/0.0/interface_test.go
@@ -1,6 +1,10 @@
 package rpcinterface_6bffd098a11236109833012892020162_0_0
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
+)
 
 // TestSyntaxID verifies the abstract syntax identity (UUID + version) of the interface.
 func TestSyntaxID(t *testing.T) {
@@ -26,16 +30,48 @@ func TestOpnums(t *testing.T) {
 	}
 }
 
-// TestStatusString verifies mnemonic rendering and the hex fallback.
-func TestStatusString(t *testing.T) {
-	if got := StatusString(ERROR_INVALID_LEVEL); got != "ERROR_INVALID_LEVEL" {
-		t.Fatalf("StatusString(ERROR_INVALID_LEVEL) = %s", got)
+// TestStatusCodesResolveThroughWin32 pins that the six NET_API_STATUS codes this
+// interface used to declare itself resolve through the shared [MS-ERREF] 2.2 table under
+// their specification names, that a code the interface never enumerated now renders by
+// name rather than as undecoded hex, and that a value the specification does not define
+// still renders as hex.
+func TestStatusCodesResolveThroughWin32(t *testing.T) {
+	documented := map[uint32]string{
+		0x00000000: "ERROR_SUCCESS",
+		0x00000005: "ERROR_ACCESS_DENIED",
+		0x00000008: "ERROR_NOT_ENOUGH_MEMORY",
+		0x00000057: "ERROR_INVALID_PARAMETER",
+		0x0000007C: "ERROR_INVALID_LEVEL",
+		0x000000EA: "ERROR_MORE_DATA",
 	}
-	if got := StatusString(NERR_Success); got != "NERR_Success" {
-		t.Fatalf("StatusString(NERR_Success) = %s", got)
+	for code, name := range documented {
+		if got := win32.WIN32_ERROR(code).String(); got != name {
+			t.Errorf("win32.WIN32_ERROR(0x%08x).String() = %q, want %q", code, got, name)
+		}
+		if resolved, defined := win32.FromName(name); !defined || uint32(resolved) != code {
+			t.Errorf("win32.FromName(%q) = 0x%08x, %v; want 0x%08x, true", name, uint32(resolved), defined, code)
+		}
 	}
-	if got := StatusString(0xDEADBEEF); got != "0xdeadbeef" {
-		t.Fatalf("StatusString(unknown) = %s, want 0xdeadbeef", got)
+
+	// NERR_Success is the NET_API_STATUS name [MS-ERREF] 2.2 gives the same zero it also
+	// names ERROR_SUCCESS, so the success comparison the stub makes against
+	// win32.NERR_Success is the one the specification documents.
+	if uint32(win32.NERR_Success) != 0x00000000 {
+		t.Errorf("win32.NERR_Success = 0x%08x, want 0x00000000", uint32(win32.NERR_Success))
+	}
+	if resolved, defined := win32.FromName("NERR_Success"); !defined || uint32(resolved) != 0x00000000 {
+		t.Errorf("win32.FromName(\"NERR_Success\") = 0x%08x, %v; want 0x00000000, true", uint32(resolved), defined)
+	}
+
+	// ERROR_INVALID_HANDLE sits one value away from a code the subset did list and was
+	// outside it, so it rendered as hex; it resolves by name now.
+	if got := win32.WIN32_ERROR(0x00000006).String(); got != "ERROR_INVALID_HANDLE" {
+		t.Errorf("win32.WIN32_ERROR(0x00000006).String() = %q, want ERROR_INVALID_HANDLE", got)
+	}
+
+	// A value [MS-ERREF] 2.2 does not define still renders as hex.
+	if got := win32.WIN32_ERROR(0xDEADBEEF).String(); got != "0xdeadbeef" {
+		t.Errorf("win32.WIN32_ERROR(0xdeadbeef).String() = %q, want hex", got)
 	}
 }
 

--- a/network/dcerpc/interfaces/99fcfec4-5260-101b-bbcb-00aa0021347a/0.0/functions/00_ResolveOxid.go
+++ b/network/dcerpc/interfaces/99fcfec4-5260-101b-bbcb-00aa0021347a/0.0/functions/00_ResolveOxid.go
@@ -10,6 +10,7 @@ import (
 
 	IObjectExporter "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/99fcfec4-5260-101b-bbcb-00aa0021347a/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	msdcom "github.com/TheManticoreProject/Manticore/windows/protocols/ms-dcom"
 )
 
@@ -54,8 +55,8 @@ func ResolveOxid(rpc ndr.Invoker, pOxid msdcom.OXID, cRequestedProtseqs uint16, 
 	PpdsaOxidBindings = resp.PpdsaOxidBindings
 	PipidRemUnknown = resp.PipidRemUnknown
 	PAuthnHint = resp.PAuthnHint
-	if uint32(resp.Status) != IObjectExporter.StatusSuccess {
-		err = fmt.Errorf("ResolveOxid failed: %s", IObjectExporter.StatusString(uint32(resp.Status)))
+	if win32.WIN32_ERROR(resp.Status) != win32.ERROR_SUCCESS {
+		err = fmt.Errorf("ResolveOxid failed: %s", win32.WIN32_ERROR(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/99fcfec4-5260-101b-bbcb-00aa0021347a/0.0/functions/01_SimplePing.go
+++ b/network/dcerpc/interfaces/99fcfec4-5260-101b-bbcb-00aa0021347a/0.0/functions/01_SimplePing.go
@@ -10,6 +10,7 @@ import (
 
 	IObjectExporter "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/99fcfec4-5260-101b-bbcb-00aa0021347a/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	msdcom "github.com/TheManticoreProject/Manticore/windows/protocols/ms-dcom"
 )
 
@@ -38,8 +39,8 @@ func SimplePing(rpc ndr.Invoker, pSetId msdcom.SETID) (err error) {
 		err = fmt.Errorf("SimplePing: %w", err)
 		return
 	}
-	if uint32(resp.Status) != IObjectExporter.StatusSuccess {
-		err = fmt.Errorf("SimplePing failed: %s", IObjectExporter.StatusString(uint32(resp.Status)))
+	if win32.WIN32_ERROR(resp.Status) != win32.ERROR_SUCCESS {
+		err = fmt.Errorf("SimplePing failed: %s", win32.WIN32_ERROR(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/99fcfec4-5260-101b-bbcb-00aa0021347a/0.0/functions/02_ComplexPing.go
+++ b/network/dcerpc/interfaces/99fcfec4-5260-101b-bbcb-00aa0021347a/0.0/functions/02_ComplexPing.go
@@ -10,6 +10,7 @@ import (
 
 	IObjectExporter "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/99fcfec4-5260-101b-bbcb-00aa0021347a/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	msdcom "github.com/TheManticoreProject/Manticore/windows/protocols/ms-dcom"
 )
 
@@ -57,8 +58,8 @@ func ComplexPing(rpc ndr.Invoker, pSetId msdcom.SETID, sequenceNum uint16, cAddT
 	}
 	PSetId = resp.PSetId
 	PPingBackoffFactor = resp.PPingBackoffFactor
-	if uint32(resp.Status) != IObjectExporter.StatusSuccess {
-		err = fmt.Errorf("ComplexPing failed: %s", IObjectExporter.StatusString(uint32(resp.Status)))
+	if win32.WIN32_ERROR(resp.Status) != win32.ERROR_SUCCESS {
+		err = fmt.Errorf("ComplexPing failed: %s", win32.WIN32_ERROR(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/99fcfec4-5260-101b-bbcb-00aa0021347a/0.0/functions/03_ServerAlive.go
+++ b/network/dcerpc/interfaces/99fcfec4-5260-101b-bbcb-00aa0021347a/0.0/functions/03_ServerAlive.go
@@ -10,6 +10,7 @@ import (
 
 	IObjectExporter "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/99fcfec4-5260-101b-bbcb-00aa0021347a/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 )
 
 // serverAliveRequest carries the [in] parameters of ServerAlive.
@@ -33,8 +34,8 @@ func ServerAlive(rpc ndr.Invoker) (err error) {
 		err = fmt.Errorf("ServerAlive: %w", err)
 		return
 	}
-	if uint32(resp.Status) != IObjectExporter.StatusSuccess {
-		err = fmt.Errorf("ServerAlive failed: %s", IObjectExporter.StatusString(uint32(resp.Status)))
+	if win32.WIN32_ERROR(resp.Status) != win32.ERROR_SUCCESS {
+		err = fmt.Errorf("ServerAlive failed: %s", win32.WIN32_ERROR(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/99fcfec4-5260-101b-bbcb-00aa0021347a/0.0/functions/04_ResolveOxid2.go
+++ b/network/dcerpc/interfaces/99fcfec4-5260-101b-bbcb-00aa0021347a/0.0/functions/04_ResolveOxid2.go
@@ -10,6 +10,7 @@ import (
 
 	IObjectExporter "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/99fcfec4-5260-101b-bbcb-00aa0021347a/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	msdcom "github.com/TheManticoreProject/Manticore/windows/protocols/ms-dcom"
 )
 
@@ -51,8 +52,8 @@ func ResolveOxid2(rpc ndr.Invoker, pOxid msdcom.OXID, cRequestedProtseqs uint16,
 	PipidRemUnknown = resp.PipidRemUnknown
 	PAuthnHint = resp.PAuthnHint
 	PComVersion = resp.PComVersion
-	if uint32(resp.Status) != IObjectExporter.StatusSuccess {
-		err = fmt.Errorf("ResolveOxid2 failed: %s", IObjectExporter.StatusString(uint32(resp.Status)))
+	if win32.WIN32_ERROR(resp.Status) != win32.ERROR_SUCCESS {
+		err = fmt.Errorf("ResolveOxid2 failed: %s", win32.WIN32_ERROR(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/99fcfec4-5260-101b-bbcb-00aa0021347a/0.0/functions/05_ServerAlive2.go
+++ b/network/dcerpc/interfaces/99fcfec4-5260-101b-bbcb-00aa0021347a/0.0/functions/05_ServerAlive2.go
@@ -10,6 +10,7 @@ import (
 
 	IObjectExporter "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/99fcfec4-5260-101b-bbcb-00aa0021347a/0.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	msdcom "github.com/TheManticoreProject/Manticore/windows/protocols/ms-dcom"
 )
 
@@ -43,8 +44,8 @@ func ServerAlive2(rpc ndr.Invoker) (PComVersion msdcom.COMVERSION, PpdsaOrBindin
 	PComVersion = resp.PComVersion
 	PpdsaOrBindings = resp.PpdsaOrBindings
 	PReserved = resp.PReserved
-	if uint32(resp.Status) != IObjectExporter.StatusSuccess {
-		err = fmt.Errorf("ServerAlive2 failed: %s", IObjectExporter.StatusString(uint32(resp.Status)))
+	if win32.WIN32_ERROR(resp.Status) != win32.ERROR_SUCCESS {
+		err = fmt.Errorf("ServerAlive2 failed: %s", win32.WIN32_ERROR(resp.Status).String())
 	}
 	return
 }

--- a/network/dcerpc/interfaces/99fcfec4-5260-101b-bbcb-00aa0021347a/0.0/interface.go
+++ b/network/dcerpc/interfaces/99fcfec4-5260-101b-bbcb-00aa0021347a/0.0/interface.go
@@ -20,8 +20,6 @@ package rpcinterface_99fcfec45260101bbbcb00aa0021347a_0_0
 // A fetched copy is kept at ms-dcom.idl in the interface directory.
 
 import (
-	"fmt"
-
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
 	"github.com/TheManticoreProject/Manticore/windows/guid"
 )
@@ -47,15 +45,15 @@ const (
 	OpnumServerAlive2 uint16 = 5
 )
 
-// Status codes returned by this interface. IObjectExporter methods return error_status_t,
-// an RPC/Win32 status ([C706]; [MS-ERREF] 2.2). RPC_S_OK indicates success; the OR_* codes
-// are the object resolver specific failures. Any other Win32/RPC status can also surface.
-const (
-	StatusSuccess uint32 = 0x00000000 // RPC_S_OK
-	OrInvalidOxid uint32 = 0x00000776 // OR_INVALID_OXID: the object exporter identifier is not known
-	OrInvalidOid  uint32 = 0x00000777 // OR_INVALID_OID: the object identifier is not known
-	OrInvalidSet  uint32 = 0x00000778 // OR_INVALID_SET: the ping set identifier is not known
-)
+// The status codes IObjectExporter methods return in their error_status_t ([C706];
+// [MS-ERREF] 2.2, [MS-DCOM] 3.1.2.5) are not declared here. The whole of [MS-ERREF] 2.2
+// lives in github.com/TheManticoreProject/Manticore/windows/errors/win32 as the
+// WIN32_ERROR type, and a subset repeated here would cover a fraction of that 2703-code
+// table while drifting from it. The object resolver specific failures are part of that
+// table: OR_INVALID_OXID is 0x00000776, OR_INVALID_OID is 0x00000777 and OR_INVALID_SET
+// is 0x00000778, and RPC_S_OK is the zero the table names ERROR_SUCCESS. Convert a
+// returned status with win32.WIN32_ERROR(status) and compare against win32.ERROR_SUCCESS,
+// win32.OR_INVALID_OXID and the rest.
 
 // SyntaxID returns the IObjectExporter abstract syntax identifier:
 // 99fcfec4-5260-101b-bbcb-00aa0021347a, version 0.0.
@@ -64,23 +62,6 @@ func SyntaxID() syntax.SyntaxID {
 		UUID:         guid.GUID{A: 0x99fcfec4, B: 0x5260, C: 0x101b, D: 0xbbcb, E: 0x00aa0021347a},
 		MajorVersion: 0,
 		MinorVersion: 0,
-	}
-}
-
-// StatusString returns a mnemonic for the documented status codes, otherwise the
-// hex value.
-func StatusString(status uint32) string {
-	switch status {
-	case StatusSuccess:
-		return "RPC_S_OK"
-	case OrInvalidOxid:
-		return "OR_INVALID_OXID"
-	case OrInvalidOid:
-		return "OR_INVALID_OID"
-	case OrInvalidSet:
-		return "OR_INVALID_SET"
-	default:
-		return fmt.Sprintf("0x%08x", status)
 	}
 }
 

--- a/network/dcerpc/interfaces/99fcfec4-5260-101b-bbcb-00aa0021347a/0.0/interface_test.go
+++ b/network/dcerpc/interfaces/99fcfec4-5260-101b-bbcb-00aa0021347a/0.0/interface_test.go
@@ -1,6 +1,10 @@
 package rpcinterface_99fcfec45260101bbbcb00aa0021347a_0_0
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
+)
 
 // TestSyntaxID verifies the abstract syntax identity (UUID + version) of IObjectExporter.
 func TestSyntaxID(t *testing.T) {
@@ -39,18 +43,44 @@ func TestOpnums(t *testing.T) {
 	}
 }
 
-// TestStatusString verifies mnemonic rendering of the documented codes and the hex fallback.
-func TestStatusString(t *testing.T) {
-	cases := map[uint32]string{
-		StatusSuccess: "RPC_S_OK",
-		OrInvalidOxid: "OR_INVALID_OXID",
-		OrInvalidOid:  "OR_INVALID_OID",
-		OrInvalidSet:  "OR_INVALID_SET",
-		0xdeadbeef:    "0xdeadbeef",
+// TestStatusCodesResolveThroughWin32 pins that the four status codes this interface used
+// to declare itself resolve through the shared [MS-ERREF] 2.2 table under their
+// specification names, that a code the interface never enumerated now renders by name
+// rather than as undecoded hex, and that a value the specification does not define still
+// renders as hex. The object resolver failures [MS-DCOM] 3.1.2.5 documents are rows of
+// that table, so the private subset was a copy of four of its 2703 codes.
+func TestStatusCodesResolveThroughWin32(t *testing.T) {
+	documented := map[uint32]string{
+		0x00000000: "ERROR_SUCCESS",
+		0x00000776: "OR_INVALID_OXID",
+		0x00000777: "OR_INVALID_OID",
+		0x00000778: "OR_INVALID_SET",
 	}
-	for code, want := range cases {
-		if got := StatusString(code); got != want {
-			t.Fatalf("StatusString(0x%08x) = %s, want %s", code, got, want)
+	for code, name := range documented {
+		if got := win32.WIN32_ERROR(code).String(); got != name {
+			t.Errorf("win32.WIN32_ERROR(0x%08x).String() = %q, want %q", code, got, name)
 		}
+		if resolved, defined := win32.FromName(name); !defined || uint32(resolved) != code {
+			t.Errorf("win32.FromName(%q) = 0x%08x, %v; want 0x%08x, true", name, uint32(resolved), defined, code)
+		}
+	}
+
+	// RPC_S_OK is the name [C706] gives the zero the table names ERROR_SUCCESS, and both
+	// resolve to the same code, so reporting success through win32.ERROR_SUCCESS says what
+	// the interface used to say with its own constant.
+	if uint32(win32.ERROR_SUCCESS) != 0x00000000 {
+		t.Errorf("win32.ERROR_SUCCESS = 0x%08x, want 0x00000000 (RPC_S_OK)", uint32(win32.ERROR_SUCCESS))
+	}
+
+	// RPC_S_SERVER_UNAVAILABLE, which a resolver that is not listening produces, was
+	// outside the subset this interface used to declare, so it rendered as hex; it
+	// resolves by name now.
+	if got := win32.WIN32_ERROR(0x000006BA).String(); got != "RPC_S_SERVER_UNAVAILABLE" {
+		t.Errorf("win32.WIN32_ERROR(0x000006ba).String() = %q, want RPC_S_SERVER_UNAVAILABLE", got)
+	}
+
+	// A value [MS-ERREF] 2.2 does not define still renders as hex.
+	if got := win32.WIN32_ERROR(0xDEADBEEF).String(); got != "0xdeadbeef" {
+		t.Errorf("win32.WIN32_ERROR(0xdeadbeef).String() = %q, want hex", got)
 	}
 }

--- a/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/interface.go
+++ b/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/interface.go
@@ -48,6 +48,25 @@ const (
 // the ept specific codes are DCE error-status values ([C706] Appendix O / Appendix E).
 // ept_lookup additionally returns ept_s_not_registered (EptStatusNotRegistered) once no
 // further elements match, which the paging loop treats as a normal end of enumeration.
+//
+// These are DCE RPC status codes, not [MS-ERREF] 2.2 Win32 error codes, so they are
+// declared here rather than referenced from
+// github.com/TheManticoreProject/Manticore/windows/errors/win32 the way an interface
+// reporting a WIN32_ERROR does. The ept_s_* values belong to the DCE status facility
+// 0x16c9a0xx, and the [MS-ERREF] 2.2 table windows/errors/win32 carries has no row for
+// any of them: looked up by value, 0x16c9a0d6, 0x16c9a0d7 and 0x16c9a0d8 are absent from
+// it, and it names no code rpc_s_ok either. There is nothing in the shared table to
+// migrate these to.
+//
+// The Win32 space does name the same three conditions, at values of its own:
+// EPT_S_INVALID_ENTRY is 0x000006D7, EPT_S_CANT_PERFORM_OP is 0x000006D8 and
+// EPT_S_NOT_REGISTERED is 0x000006D9, which is what the RPC runtime hands a local caller
+// after mapping the DCE status the wire carried. Two of the three DCE values share their
+// low byte with the Win32 code for the same condition and the third does not, so a
+// migration trusting that resemblance would land ept_s_not_registered on 0x000006D6,
+// RPC_S_UNKNOWN_AUTHZ_SERVICE, an unrelated authorization failure, while compiling and
+// passing every test. The two spaces run parallel rather than coinciding, and this
+// interface reports the one the wire carries.
 const (
 	EptStatusSuccess       uint32 = 0x00000000 // rpc_s_ok
 	EptStatusCantPerform   uint32 = 0x16c9a0d8 // ept_s_cant_perform_op
@@ -86,7 +105,11 @@ func SyntaxID() syntax.SyntaxID {
 }
 
 // StatusString returns a mnemonic for the documented status codes, otherwise the hex
-// value.
+// value. An unrecognized status stays hexadecimal rather than being resolved through
+// windows/errors/win32, which would name a DCE facility status out of the Win32 table:
+// 0x000006D9 would read as EPT_S_NOT_REGISTERED and 0x00000002 as ERROR_FILE_NOT_FOUND,
+// meanings the endpoint mapper's error_status_t never carries. Hex is the honest
+// rendering of a value this interface does not document.
 func StatusString(status uint32) string {
 	switch status {
 	case EptStatusSuccess:

--- a/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/interface_test.go
+++ b/network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/interface_test.go
@@ -1,6 +1,10 @@
 package rpcinterface_e1af83085d1f11c991a408002b14a0fa_3_0
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
+)
 
 func TestSyntaxID(t *testing.T) {
 	s := SyntaxID()
@@ -37,5 +41,85 @@ func TestOpnumNameRoundTrip(t *testing.T) {
 	}
 	if OpnumEptMap != 3 {
 		t.Errorf("OpnumEptMap = %d, want 3", OpnumEptMap)
+	}
+}
+
+// TestStatusCodesAreDCENotWin32 pins this interface's status codes to the DCE RPC space
+// they come from, so a later pass does not route them through windows/errors/win32. The
+// endpoint mapper's error_status_t carries values from the DCE status facility
+// 0x16c9a0xx; [MS-ERREF] 2.2 has no row for any of them, and it names the same three
+// conditions under Win32 values of its own.
+func TestStatusCodesAreDCENotWin32(t *testing.T) {
+	dce := map[string]uint32{
+		"rpc_s_ok":              EptStatusSuccess,
+		"ept_s_not_registered":  EptStatusNotRegistered,
+		"ept_s_invalid_entry":   EptStatusInvalidEntry,
+		"ept_s_cant_perform_op": EptStatusCantPerform,
+	}
+	want := map[string]uint32{
+		"rpc_s_ok":              0x00000000,
+		"ept_s_not_registered":  0x16c9a0d6,
+		"ept_s_invalid_entry":   0x16c9a0d7,
+		"ept_s_cant_perform_op": 0x16c9a0d8,
+	}
+	for name, code := range dce {
+		if code != want[name] {
+			t.Errorf("%s = 0x%08x, want 0x%08x", name, code, want[name])
+		}
+		// The shared table knows none of the DCE mnemonics, so a name-driven migration
+		// would have nothing to resolve.
+		if resolved, defined := win32.FromName(name); defined {
+			t.Errorf("win32.FromName(%q) = 0x%08x, true; %s is a DCE code and the Win32 table must not claim it",
+				name, uint32(resolved), name)
+		}
+	}
+
+	// Nor does it have a row for any of the three ept_s_* values, so a value-driven
+	// migration has nothing to resolve either.
+	for _, code := range []uint32{EptStatusNotRegistered, EptStatusInvalidEntry, EptStatusCantPerform} {
+		if entry, defined := win32.Lookup(win32.WIN32_ERROR(code)); defined {
+			t.Errorf("win32 names 0x%08x %q; [MS-ERREF] 2.2 defines no code in the DCE 0x16c9a0xx facility",
+				code, entry.Name)
+		}
+	}
+
+	// The Win32 codes for the same three conditions, and how far they sit from the DCE
+	// values this interface reads off the wire.
+	parallel := map[string]uint32{
+		"EPT_S_INVALID_ENTRY":   0x000006D7,
+		"EPT_S_CANT_PERFORM_OP": 0x000006D8,
+		"EPT_S_NOT_REGISTERED":  0x000006D9,
+	}
+	for name, code := range parallel {
+		resolved, defined := win32.FromName(name)
+		if !defined {
+			t.Errorf("win32.FromName(%q) is undefined, want 0x%08x ([MS-ERREF] 2.2)", name, code)
+			continue
+		}
+		if uint32(resolved) != code {
+			t.Errorf("win32.FromName(%q) = 0x%08x, want 0x%08x", name, uint32(resolved), code)
+		}
+		for _, dceCode := range []uint32{EptStatusNotRegistered, EptStatusInvalidEntry, EptStatusCantPerform} {
+			if uint32(resolved) == dceCode {
+				t.Errorf("win32 %s = 0x%08x collides with a DCE value this interface declares", name, dceCode)
+			}
+		}
+	}
+
+	// The trap the parallel spaces set: two of the three DCE values share their low byte
+	// with the Win32 code for the same condition, and ept_s_not_registered does not, so
+	// transposing 0x16c9a0d6 into the Win32 block lands on an authorization error.
+	if entry, defined := win32.Lookup(0x000006D6); !defined || entry.Name != "RPC_S_UNKNOWN_AUTHZ_SERVICE" {
+		t.Errorf("win32.Lookup(0x000006d6) = %q, %v; want RPC_S_UNKNOWN_AUTHZ_SERVICE, the code a low-byte transposition of ept_s_not_registered would hit",
+			entry.Name, defined)
+	}
+
+	// StatusString renders only the four DCE names and never falls through to the Win32
+	// table, so neither a Win32 EPT_S_* value nor a small Win32 code is named out of it.
+	for code, want := range map[uint32]string{0x000006D9: "0x000006d9", 0x00000002: "0x00000002"} {
+		if got := StatusString(code); got != want {
+			t.Errorf("StatusString(0x%08x) = %s, want %s: the DCE status field must not be named out of the Win32 table",
+				code, got, want)
+		}
 	}
 }


### PR DESCRIPTION
### Linked Issue

Refs #1219.

Phase 4 of the sweep that replaces each RPC interface's private error-code subset with direct references to `windows/errors/win32`. Three interfaces, one commit each, and they do not all end the same way: IObjectExporter and browser migrate in full, and the endpoint mapper turns out to be out of scope, for the same reason the LocToLoc locator was.

### Root Cause

**epmapper (`e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0`, `[C706]` Appendix O / `[MS-RPCE]`)** — its four status constants are not Win32 error codes. They are DCE RPC status values from the `0x16c9a0xx` facility, and the `[MS-ERREF]` 2.2 table `windows/errors/win32` carries has no row for three of the four. What makes the distinction worth recording is that the Win32 space names the very same three conditions at values of its own, which is what the RPC runtime hands a local caller after mapping the DCE status the wire carried. The two spaces run parallel and describe the same failures under two numbering schemes.

**IObjectExporter (`99fcfec4-5260-101b-bbcb-00aa0021347a/0.0`, `[MS-DCOM]`)** — its four status constants were plain duplicates of rows in the shared table. The block was a hand-maintained copy of four of 2703 rows that could only drift from the generated table, and it was a ceiling rather than a convenience: `StatusString` decoded the four codes it knew and rendered everything else as bare hex, while an object resolver returns far more than four.

**browser (`6bffd098-a112-3610-9833-012892020162/0.0`, `[MS-BRWSA]`)** — same shape, six codes, and the descriptor's own block comment already conceded the source: "values from `[MS-ERREF]` Win32 error codes". A NET_API_STATUS is a Win32 error code. The block also declared the plain identifiers `ERROR_ACCESS_DENIED`, `ERROR_NOT_ENOUGH_MEMORY`, `ERROR_INVALID_PARAMETER`, `ERROR_INVALID_LEVEL` and `ERROR_MORE_DATA` at package scope, so an interface descriptor was exporting names that belong to the shared table.

### Fix Description

Every replacement was derived from the value, not the private identifier: each numeric constant was looked up in the committed `[MS-ERREF]` 2.2 extract at `windows/errors/errgen/ms-erref-2.2-win32.tsv`, and the symbolic name the specification records for that row is the constant now referenced.

**epmapper — kept local, recorded as DCE.** Looked up by value, `0x16c9a0d6`, `0x16c9a0d7` and `0x16c9a0d8` have no row in the table at all, so there is nothing to migrate them to; `EptStatusSuccess` is zero, which the table does name `ERROR_SUCCESS`, but the interface reports it as `rpc_s_ok`, a name the table does not carry. The table does carry an `EPT_S_*` family, and that is the trap rather than the answer: `EPT_S_INVALID_ENTRY` is `0x000006D7`, `EPT_S_CANT_PERFORM_OP` is `0x000006D8` and `EPT_S_NOT_REGISTERED` is `0x000006D9`. Two of the three DCE values share their low byte with the Win32 code for the same condition and the third does not, so a migration that trusted the resemblance would land `ept_s_not_registered` on `0x000006D6`, which the table names `RPC_S_UNKNOWN_AUTHZ_SERVICE`, an unrelated authorization failure, and nothing in the build would object. The four constants stay, and `StatusString` keeps its hexadecimal fallback rather than deferring to the shared table: a fallthrough would render `0x000006D9` as `EPT_S_NOT_REGISTERED` and `0x00000002` as `ERROR_FILE_NOT_FOUND`, meanings the endpoint mapper's `error_status_t` never carries. Only comments and a test change; nothing changes on the wire or in behaviour.

**IObjectExporter — full retirement.** All four values resolved and all four agreed with what the descriptor claimed: `0x00000776` `OR_INVALID_OXID`, `0x00000777` `OR_INVALID_OID`, `0x00000778` `OR_INVALID_SET`, and zero, which the table names `ERROR_SUCCESS` and `[C706]` calls `RPC_S_OK` — the same code under two names for the same condition, not a collision. The constants and `StatusString` are deleted, `"fmt"` leaves the descriptor, and the six stubs compare `win32.WIN32_ERROR(resp.Status)` against `win32.ERROR_SUCCESS` and render failures with `win32.WIN32_ERROR(resp.Status).String()`.

**browser — full retirement.** All six values resolved and agreed: `0x00000005` `ERROR_ACCESS_DENIED`, `0x00000008` `ERROR_NOT_ENOUGH_MEMORY`, `0x00000057` `ERROR_INVALID_PARAMETER`, `0x0000007C` `ERROR_INVALID_LEVEL`, `0x000000EA` `ERROR_MORE_DATA`, and zero, which the table names twice — once `ERROR_SUCCESS` and once `NERR_Success`, the NET_API_STATUS spelling this protocol uses, so the shared table carries the interface's own name for it and the stub compares against `win32.NERR_Success`. The constants and `StatusString` are deleted and `"fmt"` leaves the descriptor.

The rewrite was applied one comparison term at a time rather than one condition at a time, because dropping a term still compiles and can turn normal termination into an error. browser is the case where that matters: `I_BrowserrQueryOtherDomains` tolerates two statuses, and `ERROR_MORE_DATA` means the server returned some but not all of the domains it knows (`[MS-BRWSA]` 3.1.4.1), a successful partial enumeration a caller must be able to read. Both terms were rewritten and hoisted into the `if` initializer, and the condition still accepts `NERR_Success` and `ERROR_MORE_DATA` and nothing else. epmapper's paging tolerance in `ept_lookup`, which treats `ept_s_not_registered` alongside `rpc_s_ok` as a normal end of enumeration, is untouched. No tolerance was added anywhere that the code did not already have.

### How Verified

Real output from this branch:

- `go build ./...` — exit 0, no output.
- `go vet ./...` — exit 0, no output.
- `go test -count=1 ./...` — exit 0, **313 ok, 0 FAIL**, matching `main`.
- `CGO_ENABLED=0 go build ./...` for `windows/amd64`, `windows/386`, `linux/arm64`, `linux/386` — all four succeed.
- `gofmt -l` over each of the 13 touched files — lists nothing; all were clean on `main` and none was reformatted wholesale.
- Per-`if` comparison-term count compared against the parent revision across all `.go` files of the three interfaces: 117 `if` statements in the parent, every non-test one identical; the only differences are the `if` statements added inside the three `interface_test.go` files.
- Import blocks checked programmatically for the stdlib/project blank line, which `gofmt -l` cannot see: all 13 files keep exactly one separator where both groups exist, and the two descriptors that lost `"fmt"` correctly have none.
- Grepped the tree for all three import paths and for every constant name before starting and after finishing. `StatusSuccess`, `OrInvalidOxid`, `OrInvalidOid`, `OrInvalidSet` and the browser identifiers had no consumer outside their own interface directory, and no reference to any retired symbol remains.

### Test Coverage

epmapper's `TestStatusString` is kept and joined by `TestStatusCodesAreDCENotWin32`, the regression guard against a later pass routing these codes through the shared table. It asserts the four documented values, asserts that the Win32 table knows none of the DCE mnemonics and has no row for any of the three `ept_s_*` values, records the Win32 codes for the same three conditions and that none collides with a value declared here, names `0x000006D6` as the authorization error a low-byte transposition would hit, and checks that `StatusString` never falls through to that table.

IObjectExporter's and browser's `TestStatusString` are each replaced by a `TestStatusCodesResolveThroughWin32` that pins every migrated code to its specification name through the shared table in both directions (`String()` and `FromName`), pins the success identity the stub now relies on (`win32.ERROR_SUCCESS` for `RPC_S_OK`, `win32.NERR_Success` for `NERR_Success`), pins a code from outside the old subset that now renders by name rather than as hex (`RPC_S_SERVER_UNAVAILABLE` `0x000006BA` for the resolver, `ERROR_INVALID_HANDLE` `0x00000006` for the browser), and pins that a value the specification does not define still renders as hex. Every value used in a test was looked up in the extract.

### Scope of Change

Thirteen files, three commits.

epmapper (2 files): `network/dcerpc/interfaces/e1af8308-5d1f-11c9-91a4-08002b14a0fa/3.0/interface.go`, `.../interface_test.go`.

IObjectExporter (8 files): `network/dcerpc/interfaces/99fcfec4-5260-101b-bbcb-00aa0021347a/0.0/interface.go`, `.../interface_test.go`, and the six stubs `functions/00_ResolveOxid.go`, `01_SimplePing.go`, `02_ComplexPing.go`, `03_ServerAlive.go`, `04_ResolveOxid2.go`, `05_ServerAlive2.go`.

browser (3 files): `network/dcerpc/interfaces/6bffd098-a112-3610-9833-012892020162/0.0/interface.go`, `.../interface_test.go`, `functions/02_I_BrowserrQueryOtherDomains.go`.

Each interface's other declarations are untouched in all three cases: `PipeName`, `SyntaxID()`, the opnum constants and the `OpnumToName`/`NameToOpnum` maps, and, for epmapper, the `EptInquiry*` and `EptVers*` blocks that sit alongside the status codes.

### Risk and Rollout

Low. Nothing on the wire changes: the same status values are read from the same fields and compared against the same numbers, only spelled from the shared table. The behavioural surface that could have moved is the text of an error string, and for the two migrated interfaces it moves in one direction only, from hex to a name, for the codes the old subsets did not cover. `RPC_S_OK` now prints as `ERROR_SUCCESS` and `NERR_Success` as `ERROR_SUCCESS` in the one place a success could be rendered, which is unreachable because both are the value the condition tests for.

epmapper carries the most external weight of the three — `network/dcerpc/ms-protocols/msproto/binder.go` maps interfaces through it, and the `catalog`, `v5/client` and `v5/transport/tcp` integration tests bind to it — and it is precisely the interface whose declarations do not change. Those consumers use `SyntaxID()` and `functions.Map` only; no consumer of any of the three interfaces referenced a status constant or `StatusString`.

No test anywhere classifies a failure from any of these three interfaces by matching a rendered mnemonic. The two `strings.Contains(err.Error(), "ERROR_INVALID_LEVEL")` checks in `network/smb/smb_v10/server/rpcpipe/rpcpipe_test.go` belong to srvsvc and wkssvc, which were migrated in earlier phases and still render that name through the shared table; both pass.

### Notes

The honest answer for the endpoint mapper is that it is out of scope for #1219, and the first commit records that in the code rather than forcing a migration. It is the second interface in this sweep to land there, after the LocToLoc locator's NSI codes, and the two are worth reading together: in both, the private subset belongs to a non-Win32 status space, in both a mechanical expansion would have compiled and passed every test, and in both the fallback stays hexadecimal because resolving an unknown status through the shared table would name a code out of the wrong table. epmapper's version of the trap is sharper than the locator's, because the `[MS-ERREF]` 2.2 table does carry an `EPT_S_*` family — the names agree, the values do not, and two of the three low bytes coincide by accident.

That leaves `StatusString` alive in the epmapper descriptor by design, decoding only the four DCE names it documents. A future pass over this interface should treat the new test as the statement of intent rather than an obstacle.

Nothing off-pattern otherwise. The browser stub is the only place a multi-term condition needed hoisting, and it now reads the way the migrated srvsvc stubs do, with the status bound in the `if` initializer.
