### PR TITLE
Route qmcomm2 and qmmgmt status reporting through hresult (Refs #1219)

### DIFF
--- a/network/dcerpc/interfaces/41208ee0-e970-11d1-9b9e-00e02c064c39/1.0/functions/00_R_QMMgmtGetInfo.go
+++ b/network/dcerpc/interfaces/41208ee0-e970-11d1-9b9e-00e02c064c39/1.0/functions/00_R_QMMgmtGetInfo.go
@@ -10,6 +10,7 @@ import (
 
 	qmmgmt "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/41208ee0-e970-11d1-9b9e-00e02c064c39/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msmqmq "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqmq"
 	msmqmr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqmr"
 )
@@ -51,8 +52,8 @@ func R_QMMgmtGetInfo(rpc ndr.Invoker, pObjectFormat msmqmr.MGMT_OBJECT, cp ndr.D
 		return
 	}
 	ApVar = resp.ApVar
-	if uint32(resp.Status) != qmmgmt.StatusSuccess {
-		err = fmt.Errorf("R_QMMgmtGetInfo failed: %s", qmmgmt.StatusString(uint32(resp.Status)))
+	if status := hresult.HRESULT(resp.Status); status != hresult.S_OK {
+		err = fmt.Errorf("R_QMMgmtGetInfo failed: %s", qmmgmt.StatusString(uint32(status)))
 	}
 	return
 }

--- a/network/dcerpc/interfaces/41208ee0-e970-11d1-9b9e-00e02c064c39/1.0/functions/01_R_QMMgmtAction.go
+++ b/network/dcerpc/interfaces/41208ee0-e970-11d1-9b9e-00e02c064c39/1.0/functions/01_R_QMMgmtAction.go
@@ -10,6 +10,7 @@ import (
 
 	qmmgmt "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/41208ee0-e970-11d1-9b9e-00e02c064c39/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msmqmr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqmr"
 )
 
@@ -42,8 +43,8 @@ func R_QMMgmtAction(rpc ndr.Invoker, pObjectFormat msmqmr.MGMT_OBJECT, action st
 	if err := rpc.Invoke(req, &resp); err != nil {
 		return fmt.Errorf("R_QMMgmtAction: %w", err)
 	}
-	if uint32(resp.Status) != qmmgmt.StatusSuccess {
-		return fmt.Errorf("R_QMMgmtAction failed: %s", qmmgmt.StatusString(uint32(resp.Status)))
+	if status := hresult.HRESULT(resp.Status); status != hresult.S_OK {
+		return fmt.Errorf("R_QMMgmtAction failed: %s", qmmgmt.StatusString(uint32(status)))
 	}
 	return nil
 }

--- a/network/dcerpc/interfaces/41208ee0-e970-11d1-9b9e-00e02c064c39/1.0/interface.go
+++ b/network/dcerpc/interfaces/41208ee0-e970-11d1-9b9e-00e02c064c39/1.0/interface.go
@@ -12,9 +12,8 @@ package rpcinterface_41208ee0e97011d19b9e00e02c064c39_1_0
 // A fetched copy is kept at ms-mqmq.idl in the interface directory.
 
 import (
-	"fmt"
-
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	"github.com/TheManticoreProject/Manticore/windows/guid"
 )
 
@@ -29,13 +28,25 @@ const (
 	OpnumR_QMMgmtAction  uint16 = 1
 )
 
-// Status codes returned by this interface. Both qmmgmt methods return an HRESULT; the
-// values are Message Queuing result codes ([MS-MQMQ] 2.4, mqerror.h). [MS-MQMR] 3.1.4.1
-// and 3.1.4.2 name only the codes below; StatusString falls back to the hex value for
-// any other failure HRESULT.
+// Status codes returned by this interface. Both qmmgmt methods return an HRESULT, and
+// the whole of [MS-ERREF] section 2.1.1 lives in
+// github.com/TheManticoreProject/Manticore/windows/errors/hresult as the HRESULT type,
+// so no code that table names is repeated here. MQ_OK, the success value, is the
+// HRESULT S_OK and is spelled hresult.S_OK.
+//
+// The three Message Queuing result codes [MS-MQMR] 3.1.4.1 and 3.1.4.2 name are the
+// exception. They are MQ_* values of [MS-MQMQ] 2.4 (mqerror.h) living in FACILITY_MSMQ
+// (0x00E): each is of the form 0xC00E____, and [MS-ERREF] 2.1.1 carries no row in that
+// facility at all — not one of its 2928 values has a code whose facility field is
+// 0x00E. The shared table names none of these, so they stay declared here and
+// StatusString decodes them before deferring to the shared table for everything else.
+//
+// MQ_ERROR_INVALID_PARAMETER is the one with server behaviour attached, and that
+// knowledge is why it stays spelled out: the server returns it when pObjectFormat names
+// the MGMT_SESSION object type rather than MGMT_MACHINE or MGMT_QUEUE, and, for
+// R_QMMgmtAction, when lpwszAction is not one of the documented verbs (see the Action*
+// constants below).
 const (
-	StatusSuccess uint32 = 0x00000000 // MQ_OK
-
 	MQ_ERROR                   uint32 = 0xC00E0001 // generic error
 	MQ_ERROR_INVALID_PARAMETER uint32 = 0xC00E0006 // e.g. MGMT_SESSION type or bad lpwszAction
 	MQ_ERROR_ILLEGAL_PROPID    uint32 = 0xC00E0039 // a property id in aProp is not valid for the object
@@ -62,12 +73,14 @@ func SyntaxID() syntax.SyntaxID {
 	}
 }
 
-// StatusString returns a mnemonic for the documented status codes, otherwise the
-// hex value.
+// StatusString names the Message Queuing result codes of [MS-MQMQ] 2.4, which live in
+// the FACILITY_MSMQ facility that [MS-ERREF] 2.1.1 does not cover, and defers every
+// other status to the shared [MS-ERREF] 2.1.1 table, which names each value the
+// specification defines, derives the FACILITY_WIN32 values it wraps, and renders hex
+// only for values it does not know. A zero status renders as S_OK, the name the shared
+// table gives the value MSMQ also spells MQ_OK.
 func StatusString(status uint32) string {
 	switch status {
-	case StatusSuccess:
-		return "MQ_OK"
 	case MQ_ERROR:
 		return "MQ_ERROR"
 	case MQ_ERROR_INVALID_PARAMETER:
@@ -75,7 +88,7 @@ func StatusString(status uint32) string {
 	case MQ_ERROR_ILLEGAL_PROPID:
 		return "MQ_ERROR_ILLEGAL_PROPID"
 	default:
-		return fmt.Sprintf("0x%08x", status)
+		return hresult.HRESULT(status).String()
 	}
 }
 

--- a/network/dcerpc/interfaces/41208ee0-e970-11d1-9b9e-00e02c064c39/1.0/interface_test.go
+++ b/network/dcerpc/interfaces/41208ee0-e970-11d1-9b9e-00e02c064c39/1.0/interface_test.go
@@ -1,6 +1,10 @@
 package rpcinterface_41208ee0e97011d19b9e00e02c064c39_1_0
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
+)
 
 // TestSyntaxID verifies the abstract syntax identity (UUID + version) of the qmmgmt interface.
 func TestSyntaxID(t *testing.T) {
@@ -36,15 +40,44 @@ func TestOpnums(t *testing.T) {
 	}
 }
 
-// TestStatusString verifies mnemonic rendering and the hex fallback.
-func TestStatusString(t *testing.T) {
-	if got := StatusString(StatusSuccess); got != "MQ_OK" {
-		t.Fatalf("StatusString(StatusSuccess) = %s, want MQ_OK", got)
+// TestStatusStringSharedTable verifies that the statuses this interface no longer
+// declares resolve through the shared [MS-ERREF] 2.1.1 table: MQ_OK is the HRESULT S_OK,
+// and a generic HRESULT the interface never enumerated is named rather than rendered as
+// hex.
+func TestStatusStringSharedTable(t *testing.T) {
+	if got := StatusString(uint32(hresult.S_OK)); got != "S_OK" {
+		t.Errorf("StatusString(S_OK) = %s, want S_OK", got)
 	}
-	if got := StatusString(MQ_ERROR_INVALID_PARAMETER); got != "MQ_ERROR_INVALID_PARAMETER" {
-		t.Fatalf("StatusString(MQ_ERROR_INVALID_PARAMETER) = %s, want MQ_ERROR_INVALID_PARAMETER", got)
+	const eFail = 0x80004005
+	if got := StatusString(eFail); got != "E_FAIL" {
+		t.Errorf("StatusString(0x%08x) = %s, want E_FAIL", uint32(eFail), got)
 	}
 	if got := StatusString(0xDEADBEEF); got != "0xdeadbeef" {
-		t.Fatalf("StatusString(unknown) = %s, want 0xdeadbeef", got)
+		t.Errorf("StatusString(unknown) = %s, want 0xdeadbeef", got)
+	}
+}
+
+// TestStatusStringMSMQFacility verifies that every retained code still renders under its
+// Message Queuing name, and that the shared table genuinely does not know it — [MS-ERREF]
+// 2.1.1 carries no row in FACILITY_MSMQ, which is why these stay declared locally.
+func TestStatusStringMSMQFacility(t *testing.T) {
+	retained := map[uint32]string{
+		MQ_ERROR:                   "MQ_ERROR",
+		MQ_ERROR_INVALID_PARAMETER: "MQ_ERROR_INVALID_PARAMETER",
+		MQ_ERROR_ILLEGAL_PROPID:    "MQ_ERROR_ILLEGAL_PROPID",
+	}
+	if len(retained) != 3 {
+		t.Fatalf("retained code count = %d, want 3", len(retained))
+	}
+	for value, name := range retained {
+		if got := StatusString(value); got != name {
+			t.Errorf("StatusString(0x%08x) = %s, want %s", value, got, name)
+		}
+		if value>>16&0x07FF != 0x00E {
+			t.Errorf("%s (0x%08x) is not in FACILITY_MSMQ", name, value)
+		}
+		if entry, defined := hresult.Lookup(hresult.HRESULT(value)); defined {
+			t.Errorf("hresult.Lookup(0x%08x) = %s, want undefined", value, entry.Name)
+		}
 	}
 }

--- a/network/dcerpc/interfaces/76d12b80-3467-11d3-91ff-0090272f9ea3/1.0/functions/03_rpc_ACCreateCursorEx.go
+++ b/network/dcerpc/interfaces/76d12b80-3467-11d3-91ff-0090272f9ea3/1.0/functions/03_rpc_ACCreateCursorEx.go
@@ -10,6 +10,7 @@ import (
 
 	qmcomm2 "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/76d12b80-3467-11d3-91ff-0090272f9ea3/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msmqmp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqmp"
 )
 
@@ -41,8 +42,8 @@ func Rpc_ACCreateCursorEx(rpc ndr.Invoker, hQueue msmqmp.RPC_QUEUE_HANDLE, pcc m
 		return
 	}
 	Pcc = resp.Pcc
-	if uint32(resp.Status) != qmcomm2.StatusSuccess {
-		err = fmt.Errorf("rpc_ACCreateCursorEx failed: %s", qmcomm2.StatusString(uint32(resp.Status)))
+	if status := hresult.HRESULT(resp.Status); status != hresult.S_OK {
+		err = fmt.Errorf("rpc_ACCreateCursorEx failed: %s", qmcomm2.StatusString(uint32(status)))
 	}
 	return
 }

--- a/network/dcerpc/interfaces/76d12b80-3467-11d3-91ff-0090272f9ea3/1.0/interface.go
+++ b/network/dcerpc/interfaces/76d12b80-3467-11d3-91ff-0090272f9ea3/1.0/interface.go
@@ -12,9 +12,8 @@ package rpcinterface_76d12b80346711d391ff0090272f9ea3_1_0
 // A fetched copy is kept at ms-mqmp.idl in the interface directory.
 
 import (
-	"fmt"
-
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	"github.com/TheManticoreProject/Manticore/windows/guid"
 )
 
@@ -33,13 +32,20 @@ const (
 	Opnumrpc_ACCreateCursorEx    uint16 = 3
 )
 
-// Status codes returned by this interface. Every qmcomm2 method returns an HRESULT; the
-// values are the Message Queuing result codes ([MS-MQMQ] 2.4, mqerror.h). Only the codes
-// most relevant to the send/receive operations are enumerated here; StatusString falls
-// back to the hex value for any other HRESULT.
+// Status codes returned by this interface. Every qmcomm2 method returns an HRESULT, and
+// the whole of [MS-ERREF] section 2.1.1 lives in
+// github.com/TheManticoreProject/Manticore/windows/errors/hresult as the HRESULT type,
+// so no code that table names is repeated here. MQ_OK, the success value, is the
+// HRESULT S_OK and is spelled hresult.S_OK.
+//
+// The Message Queuing result codes below are the exception. They are the MQ_* values of
+// [MS-MQMQ] 2.4 (mqerror.h), which live in FACILITY_MSMQ (0x00E): every one of them is
+// of the form 0xC00E____, and [MS-ERREF] 2.1.1 carries no row in that facility at all —
+// not one of its 2928 values has a code whose facility field is 0x00E. The shared table
+// therefore names none of these, and cannot be made to without the specification
+// listing them. They stay declared here, and StatusString decodes them before deferring
+// to the shared table for everything else.
 const (
-	StatusSuccess uint32 = 0x00000000 // MQ_OK
-
 	MQ_ERROR                          uint32 = 0xC00E0001
 	MQ_ERROR_QUEUE_NOT_FOUND          uint32 = 0xC00E0003
 	MQ_ERROR_QUEUE_NOT_ACTIVE         uint32 = 0xC00E0004
@@ -65,12 +71,14 @@ func SyntaxID() syntax.SyntaxID {
 	}
 }
 
-// StatusString returns a mnemonic for the documented status codes, otherwise the
-// hex value.
+// StatusString names the Message Queuing result codes of [MS-MQMQ] 2.4, which live in
+// the FACILITY_MSMQ facility that [MS-ERREF] 2.1.1 does not cover, and defers every
+// other status to the shared [MS-ERREF] 2.1.1 table, which names each value the
+// specification defines, derives the FACILITY_WIN32 values it wraps, and renders hex
+// only for values it does not know. A zero status renders as S_OK, the name the shared
+// table gives the value MSMQ also spells MQ_OK.
 func StatusString(status uint32) string {
 	switch status {
-	case StatusSuccess:
-		return "MQ_OK"
 	case MQ_ERROR:
 		return "MQ_ERROR"
 	case MQ_ERROR_QUEUE_NOT_FOUND:
@@ -98,7 +106,7 @@ func StatusString(status uint32) string {
 	case MQ_ERROR_TRANSACTION_USAGE:
 		return "MQ_ERROR_TRANSACTION_USAGE"
 	default:
-		return fmt.Sprintf("0x%08x", status)
+		return hresult.HRESULT(status).String()
 	}
 }
 

--- a/network/dcerpc/interfaces/76d12b80-3467-11d3-91ff-0090272f9ea3/1.0/interface_test.go
+++ b/network/dcerpc/interfaces/76d12b80-3467-11d3-91ff-0090272f9ea3/1.0/interface_test.go
@@ -1,6 +1,10 @@
 package rpcinterface_76d12b80346711d391ff0090272f9ea3_1_0
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
+)
 
 // TestSyntaxID verifies the abstract syntax identity (UUID + version) of the qmcomm2 interface.
 func TestSyntaxID(t *testing.T) {
@@ -29,15 +33,54 @@ func TestOpnums(t *testing.T) {
 	}
 }
 
-// TestStatusString verifies mnemonic rendering and the hex fallback.
-func TestStatusString(t *testing.T) {
-	if got := StatusString(StatusSuccess); got != "MQ_OK" {
-		t.Fatalf("StatusString(StatusSuccess) = %s, want MQ_OK", got)
+// TestStatusStringSharedTable verifies that the statuses this interface no longer
+// declares resolve through the shared [MS-ERREF] 2.1.1 table: MQ_OK is the HRESULT S_OK,
+// and a generic HRESULT the interface never enumerated is named rather than rendered as
+// hex.
+func TestStatusStringSharedTable(t *testing.T) {
+	if got := StatusString(uint32(hresult.S_OK)); got != "S_OK" {
+		t.Errorf("StatusString(S_OK) = %s, want S_OK", got)
 	}
-	if got := StatusString(MQ_ERROR_INVALID_HANDLE); got != "MQ_ERROR_INVALID_HANDLE" {
-		t.Fatalf("StatusString(MQ_ERROR_INVALID_HANDLE) = %s, want MQ_ERROR_INVALID_HANDLE", got)
+	const eFail = 0x80004005
+	if got := StatusString(eFail); got != "E_FAIL" {
+		t.Errorf("StatusString(0x%08x) = %s, want E_FAIL", uint32(eFail), got)
 	}
 	if got := StatusString(0xDEADBEEF); got != "0xdeadbeef" {
-		t.Fatalf("StatusString(unknown) = %s, want 0xdeadbeef", got)
+		t.Errorf("StatusString(unknown) = %s, want 0xdeadbeef", got)
+	}
+}
+
+// TestStatusStringMSMQFacility verifies that every retained code still renders under its
+// Message Queuing name, and that the shared table genuinely does not know it — [MS-ERREF]
+// 2.1.1 carries no row in FACILITY_MSMQ, which is why these stay declared locally.
+func TestStatusStringMSMQFacility(t *testing.T) {
+	retained := map[uint32]string{
+		MQ_ERROR:                          "MQ_ERROR",
+		MQ_ERROR_QUEUE_NOT_FOUND:          "MQ_ERROR_QUEUE_NOT_FOUND",
+		MQ_ERROR_QUEUE_NOT_ACTIVE:         "MQ_ERROR_QUEUE_NOT_ACTIVE",
+		MQ_ERROR_INVALID_PARAMETER:        "MQ_ERROR_INVALID_PARAMETER",
+		MQ_ERROR_INVALID_HANDLE:           "MQ_ERROR_INVALID_HANDLE",
+		MQ_ERROR_OPERATION_CANCELLED:      "MQ_ERROR_OPERATION_CANCELLED",
+		MQ_ERROR_SHARING_VIOLATION:        "MQ_ERROR_SHARING_VIOLATION",
+		MQ_ERROR_SERVICE_NOT_AVAILABLE:    "MQ_ERROR_SERVICE_NOT_AVAILABLE",
+		MQ_ERROR_MESSAGE_ALREADY_RECEIVED: "MQ_ERROR_MESSAGE_ALREADY_RECEIVED",
+		MQ_ERROR_ACCESS_DENIED:            "MQ_ERROR_ACCESS_DENIED",
+		MQ_ERROR_INSUFFICIENT_RESOURCES:   "MQ_ERROR_INSUFFICIENT_RESOURCES",
+		MQ_ERROR_IO_TIMEOUT:               "MQ_ERROR_IO_TIMEOUT",
+		MQ_ERROR_TRANSACTION_USAGE:        "MQ_ERROR_TRANSACTION_USAGE",
+	}
+	if len(retained) != 13 {
+		t.Fatalf("retained code count = %d, want 13", len(retained))
+	}
+	for value, name := range retained {
+		if got := StatusString(value); got != name {
+			t.Errorf("StatusString(0x%08x) = %s, want %s", value, got, name)
+		}
+		if value>>16&0x07FF != 0x00E {
+			t.Errorf("%s (0x%08x) is not in FACILITY_MSMQ", name, value)
+		}
+		if entry, defined := hresult.Lookup(hresult.HRESULT(value)); defined {
+			t.Errorf("hresult.Lookup(0x%08x) = %s, want undefined", value, entry.Name)
+		}
 	}
 }


### PR DESCRIPTION
### Linked Issue

Refs #1219 — the HRESULT-returning RPC interfaces, now that the [MS-ERREF] section 2.1.1 table has landed in `windows/errors/hresult` (Refs #1221). Two interfaces, one commit each.

### Root Cause

**qmcomm2 ([MS-MQMP], `76d12b80-3467-11d3-91ff-0090272f9ea3/1.0`).** Every method of this interface returns an HRESULT, and the descriptor carried a hand-picked fourteen-value status table with `fmt.Sprintf("0x%08x", status)` as its fallback. Any status the interface had not happened to enumerate therefore reached the caller as a bare hexadecimal number, and the table was a subset that could only drift from the specification it was copied out of.

**qmmgmt ([MS-MQMR], `41208ee0-e970-11d1-9b9e-00e02c064c39/1.0`).** The same shape at a smaller size: four constants and the same hex fallback, so `E_ACCESSDENIED` or an `HRESULT_FROM_WIN32` value from a failed bind rendered as a number rather than a name.

### Fix Description

Both are **partial** retirements, following the pattern set by the fax interface, and the honest summary is that almost nothing migrates. `FACILITY_MSMQ` (0x00E) has **zero rows in [MS-ERREF] 2.1.1** — not one of the table's 2928 values has a code whose facility field is 0x00E, no name begins `MQ_`, and no name contains `MSMQ`. Every `MQ_ERROR_*` constant in both interfaces is of the form `0xC00E____`, so the shared table cannot name any of them and could not be made to without the specification listing them. They all stay local.

What migrates is the success value alone. `MQ_OK` is `0x00000000`, which is the HRESULT `S_OK`, so in each interface the local `StatusSuccess` constant is deleted and callers compare against `hresult.S_OK`. Neither interface declared a `0x8007XXXX` value, so `hresult.FromWin32` and `HRESULT.ToWin32` have no use here; neither declared a generic HRESULT such as `E_FAIL` either.

**qmcomm2.** `StatusSuccess` is gone; the thirteen `MQ_ERROR_*` values are retained with a comment recording that they are `MQ_*` values in `FACILITY_MSMQ` and that [MS-ERREF] 2.1.1 carries no row in that facility. `StatusString` keeps those thirteen cases and its default arm becomes `hresult.HRESULT(status).String()`, so any other status now resolves by name — through the specification's table, through the well-known values it omits, or by deriving the `FACILITY_WIN32` code it wraps — and renders hex only when none of those knows it. `functions/03_rpc_ACCreateCursorEx.go` hoists the status into the `if` initializer and compares it against `hresult.S_OK`. The other three files under `functions/` are the deferred `CACTransferBufferV2` stubs (issue #801) and reference no status at all, so they are untouched.

**qmmgmt.** The same reduction over three retained values, both `functions/` files rewritten the same way. The comment on the retained block keeps and expands the domain knowledge that was attached to `MQ_ERROR_INVALID_PARAMETER`: the server returns it when `pObjectFormat` names the `MGMT_SESSION` object type rather than `MGMT_MACHINE` or `MGMT_QUEUE`, and, for `R_QMMgmtAction`, when `lpwszAction` is not one of the documented verbs carried by the `Action*` constants alongside it. `SyntaxID`, `PipeName`, the `Action*` constants, the opnum constants and `OpnumToName`/`NameToOpnum` are all intact in both interfaces.

Two consequences are worth naming rather than leaving to be discovered. A zero status now renders as `S_OK`, the name the shared table gives the value MSMQ also spells `MQ_OK`. And an HRESULT's success is a range rather than a single value: the three success comparisons still treat exactly zero as success and every other value as a failure, so a success-severity `MQ_INFORMATION_*` return of the form `0x400E____` would be reported as a failure by that shape. No such value is declared by either interface, and the existing behaviour is preserved exactly as it stood rather than widened in a status-reporting change.

### How Verified

`go build ./...`, `go vet ./...` and `go test -count=1 ./...` all clean: **315 ok, 0 failures**, the same package count as `main`. `CGO_ENABLED=0 go build ./...` succeeds for `windows/amd64`, `windows/386`, `linux/arm64` and `linux/386`.

Every judgement was derived from the value rather than the name, by looking each constant up in `windows/errors/errgen/ms-erref-2.1.1-hresult.tsv`: `0x00000000`, `0xC00E0001`, `0xC00E0003`, `0xC00E0004`, `0xC00E0006`, `0xC00E0007`, `0xC00E0008`, `0xC00E0009`, `0xC00E000B`, `0xC00E001B`, `0xC00E001D`, `0xC00E0025`, `0xC00E0027`, `0xC00E0039` and `0xC00E0050` return no row. A facility sweep over the whole table confirms zero rows in `0x00E`, which is what makes these retentions correct rather than convenient.

A script compared the per-`if` comparison-term count of every rewritten non-test file against its parent revision: `interface.go` 0/0 in both interfaces, `03_rpc_ACCreateCursorEx.go` 2/2, `00_R_QMMgmtGetInfo.go` 2/2, `01_R_QMMgmtAction.go` 2/2 — no term dropped in the rewrite. Each import block was reconstructed from the parent revision rather than patched blind, and the stdlib/project blank line is present in every file that still has both groups; the two `interface.go` files no longer import `fmt` and so carry a single project group. `gofmt -l` names none of the seven touched files, and each was confirmed clean on `main` first, so nothing was reformatted that this change did not already edit.

The tree was grepped for both interface import paths, for `StatusSuccess` and `StatusString`, for every `MQ_*` constant name, and for `Contains`/`HasPrefix` against `"MQ_"` and `"0xC00E"`. There are no consumers outside the two directories: nothing in `network/dcerpc/ms-protocols/`, nothing in `network/smb/smb_v10/server/rpcpipe/`, and `windows/protocols/ms-mqmp`, `ms-mqmr` and `ms-mqmq` hold structures only and reference no status constant. The other MSMQ interfaces that also declare `MQ_*` values — `fdb3a030-…`, `77df7a80-…`, `1a9134dd-…`, `1088a980-…` and `708cca10-…` — are untouched here.

### Test Coverage

The `TestStatusString` in each interface pinned the old rendering, including the literal `0xdeadbeef` the hex fallback produced, and is replaced by two tests. `TestStatusStringSharedTable` asserts that the retired values resolve through the shared table — `StatusString(uint32(hresult.S_OK))` is `S_OK`, and `0x80004005`, a generic HRESULT neither interface ever enumerated, is now named `E_FAIL` rather than rendered as a number — and that a value nothing defines still falls through to hex. `TestStatusStringMSMQFacility` asserts, for every retained code, that `StatusString` still renders it under its Message Queuing name, that its facility field really is `0x00E`, and that `hresult.Lookup` reports nothing for it; that last assertion is what will fail loudly if a future revision of [MS-ERREF] 2.1.1 starts carrying `FACILITY_MSMQ`, at which point these constants should be retired too.

### Scope of Change

Seven files across two interface directories, three in qmcomm2 and four in qmmgmt. No structure, codec, opnum, transport or wire behaviour is touched, and no file outside the two directories changes.

qmcomm2: `interface.go`, `interface_test.go`, `functions/03_rpc_ACCreateCursorEx.go`.

qmmgmt: `interface.go`, `interface_test.go`, `functions/00_R_QMMgmtGetInfo.go`, `functions/01_R_QMMgmtAction.go`.

### Risk and Rollout

Low. The only behavioural change is the text of a status rendered in an error string: statuses the interfaces did not enumerate gain names, and a zero status reads `S_OK` instead of `MQ_OK`. The success/failure decision is byte-for-byte the same comparison it was, and both interfaces have no callers elsewhere in the tree, so nothing downstream can observe the change. Each commit is independently revertible.

### Notes

The size of this change is the finding. Of eighteen constants across the two interfaces, one migrates and seventeen stay, because the specification's HRESULT table simply does not cover MSMQ's facility. What the interfaces gain is not a shorter constant list but a `StatusString` that no longer prints a bare number for the far larger set of HRESULTs an MSMQ server can return that have nothing to do with `FACILITY_MSMQ` — the access denials, the `HRESULT_FROM_WIN32` wrappings, the generic COM failures.

These are also the first two RPC interfaces in the tree to import `windows/errors/hresult`.
