### PR TITLE
Route nspi status reporting through hresult (Refs #1219)

### DIFF
--- a/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0/functions/00_NspiBind.go
+++ b/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0/functions/00_NspiBind.go
@@ -10,6 +10,7 @@ import (
 
 	nspi "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msnspi "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nspi"
 )
 
@@ -44,7 +45,7 @@ func NspiBind(rpc ndr.Invoker, dwFlags ndr.DWORD, pStat msnspi.STAT, pServerGuid
 	}
 	PServerGuid = resp.PServerGuid
 	ContextHandle = resp.ContextHandle
-	if uint32(resp.Status) != nspi.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("NspiBind failed: %s", nspi.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0/functions/01_NspiUnbind.go
+++ b/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0/functions/01_NspiUnbind.go
@@ -10,6 +10,7 @@ import (
 
 	nspi "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msnspi "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nspi"
 )
 
@@ -40,7 +41,7 @@ func NspiUnbind(rpc ndr.Invoker, contextHandle msnspi.NSPI_HANDLE, reserved ndr.
 		return
 	}
 	ContextHandle = resp.ContextHandle
-	if uint32(resp.Status) != nspi.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("NspiUnbind failed: %s", nspi.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0/functions/02_NspiUpdateStat.go
+++ b/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0/functions/02_NspiUpdateStat.go
@@ -10,6 +10,7 @@ import (
 
 	nspi "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msnspi "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nspi"
 )
 
@@ -46,7 +47,7 @@ func NspiUpdateStat(rpc ndr.Invoker, hRpc msnspi.NSPI_HANDLE, reserved ndr.DWORD
 	}
 	PStat = resp.PStat
 	PlDelta = resp.PlDelta
-	if uint32(resp.Status) != nspi.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("NspiUpdateStat failed: %s", nspi.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0/functions/03_NspiQueryRows.go
+++ b/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0/functions/03_NspiQueryRows.go
@@ -10,6 +10,7 @@ import (
 
 	nspi "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msnspi "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nspi"
 )
 
@@ -54,7 +55,7 @@ func NspiQueryRows(rpc ndr.Invoker, hRpc msnspi.NSPI_HANDLE, dwFlags ndr.DWORD, 
 	PpRows = resp.PpRows
 	// ErrorsReturned is a success-severity warning: the call succeeded overall but one or
 	// more returned properties are PtypErrorCode ([MS-NSPI] 3.1.4.1.10 / [MS-OXCDATA] 2.5).
-	if s := uint32(resp.Status); s != nspi.StatusSuccess && s != nspi.StatusErrorsReturned {
+	if s := uint32(resp.Status); hresult.HRESULT(s) != hresult.S_OK && s != nspi.StatusErrorsReturned {
 		err = fmt.Errorf("NspiQueryRows failed: %s", nspi.StatusString(s))
 	}
 	return

--- a/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0/functions/04_NspiSeekEntries.go
+++ b/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0/functions/04_NspiSeekEntries.go
@@ -10,6 +10,7 @@ import (
 
 	nspi "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msnspi "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nspi"
 )
 
@@ -55,7 +56,7 @@ func NspiSeekEntries(rpc ndr.Invoker, hRpc msnspi.NSPI_HANDLE, reserved ndr.DWOR
 	PpRows = resp.PpRows
 	// ErrorsReturned is a success-severity warning: the call succeeded overall but one or
 	// more returned properties are PtypErrorCode ([MS-NSPI] 3.1.4.1.9 / [MS-OXCDATA] 2.5).
-	if s := uint32(resp.Status); s != nspi.StatusSuccess && s != nspi.StatusErrorsReturned {
+	if s := uint32(resp.Status); hresult.HRESULT(s) != hresult.S_OK && s != nspi.StatusErrorsReturned {
 		err = fmt.Errorf("NspiSeekEntries failed: %s", nspi.StatusString(s))
 	}
 	return

--- a/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0/functions/05_NspiGetMatches.go
+++ b/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0/functions/05_NspiGetMatches.go
@@ -10,6 +10,7 @@ import (
 
 	nspi "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msnspi "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nspi"
 )
 
@@ -65,7 +66,7 @@ func NspiGetMatches(rpc ndr.Invoker, hRpc msnspi.NSPI_HANDLE, reserved1 ndr.DWOR
 	PpRows = resp.PpRows
 	// ErrorsReturned is a success-severity warning: the call succeeded overall but one or
 	// more returned properties are PtypErrorCode ([MS-NSPI] 3.1.4.1.11 / [MS-OXCDATA] 2.5).
-	if s := uint32(resp.Status); s != nspi.StatusSuccess && s != nspi.StatusErrorsReturned {
+	if s := uint32(resp.Status); hresult.HRESULT(s) != hresult.S_OK && s != nspi.StatusErrorsReturned {
 		err = fmt.Errorf("NspiGetMatches failed: %s", nspi.StatusString(s))
 	}
 	return

--- a/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0/functions/06_NspiResortRestriction.go
+++ b/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0/functions/06_NspiResortRestriction.go
@@ -10,6 +10,7 @@ import (
 
 	nspi "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msnspi "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nspi"
 )
 
@@ -48,7 +49,7 @@ func NspiResortRestriction(rpc ndr.Invoker, hRpc msnspi.NSPI_HANDLE, reserved nd
 	}
 	PStat = resp.PStat
 	PpOutMIds = resp.PpOutMIds
-	if uint32(resp.Status) != nspi.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("NspiResortRestriction failed: %s", nspi.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0/functions/07_NspiDNToMId.go
+++ b/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0/functions/07_NspiDNToMId.go
@@ -10,6 +10,7 @@ import (
 
 	nspi "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msnspi "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nspi"
 )
 
@@ -42,7 +43,7 @@ func NspiDNToMId(rpc ndr.Invoker, hRpc msnspi.NSPI_HANDLE, reserved ndr.DWORD, p
 		return
 	}
 	PpOutMIds = resp.PpOutMIds
-	if uint32(resp.Status) != nspi.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("NspiDNToMId failed: %s", nspi.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0/functions/08_NspiGetPropList.go
+++ b/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0/functions/08_NspiGetPropList.go
@@ -10,6 +10,7 @@ import (
 
 	nspi "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msnspi "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nspi"
 )
 
@@ -44,7 +45,7 @@ func NspiGetPropList(rpc ndr.Invoker, hRpc msnspi.NSPI_HANDLE, dwFlags ndr.DWORD
 		return
 	}
 	PpPropTags = resp.PpPropTags
-	if uint32(resp.Status) != nspi.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("NspiGetPropList failed: %s", nspi.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0/functions/09_NspiGetProps.go
+++ b/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0/functions/09_NspiGetProps.go
@@ -10,6 +10,7 @@ import (
 
 	nspi "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msnspi "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nspi"
 )
 
@@ -46,7 +47,7 @@ func NspiGetProps(rpc ndr.Invoker, hRpc msnspi.NSPI_HANDLE, dwFlags ndr.DWORD, p
 	PpRows = resp.PpRows
 	// ErrorsReturned is a success-severity warning: the call succeeded overall but one or
 	// more returned properties are PtypErrorCode ([MS-NSPI] 3.1.4.1.7 / [MS-OXCDATA] 2.5).
-	if s := uint32(resp.Status); s != nspi.StatusSuccess && s != nspi.StatusErrorsReturned {
+	if s := uint32(resp.Status); hresult.HRESULT(s) != hresult.S_OK && s != nspi.StatusErrorsReturned {
 		err = fmt.Errorf("NspiGetProps failed: %s", nspi.StatusString(s))
 	}
 	return

--- a/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0/functions/10_NspiCompareMIds.go
+++ b/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0/functions/10_NspiCompareMIds.go
@@ -10,6 +10,7 @@ import (
 
 	nspi "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msnspi "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nspi"
 )
 
@@ -46,7 +47,7 @@ func NspiCompareMIds(rpc ndr.Invoker, hRpc msnspi.NSPI_HANDLE, reserved ndr.DWOR
 		return
 	}
 	PlResult = resp.PlResult
-	if uint32(resp.Status) != nspi.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("NspiCompareMIds failed: %s", nspi.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0/functions/11_NspiModProps.go
+++ b/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0/functions/11_NspiModProps.go
@@ -10,6 +10,7 @@ import (
 
 	nspi "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msnspi "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nspi"
 )
 
@@ -47,7 +48,7 @@ func NspiModProps(rpc ndr.Invoker, hRpc msnspi.NSPI_HANDLE, reserved ndr.DWORD, 
 		err = fmt.Errorf("NspiModProps: %w", err)
 		return
 	}
-	if uint32(resp.Status) != nspi.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("NspiModProps failed: %s", nspi.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0/functions/12_NspiGetSpecialTable.go
+++ b/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0/functions/12_NspiGetSpecialTable.go
@@ -10,6 +10,7 @@ import (
 
 	nspi "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msnspi "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nspi"
 )
 
@@ -46,7 +47,7 @@ func NspiGetSpecialTable(rpc ndr.Invoker, hRpc msnspi.NSPI_HANDLE, dwFlags ndr.D
 	}
 	LpVersion = resp.LpVersion
 	PpRows = resp.PpRows
-	if uint32(resp.Status) != nspi.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("NspiGetSpecialTable failed: %s", nspi.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0/functions/13_NspiGetTemplateInfo.go
+++ b/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0/functions/13_NspiGetTemplateInfo.go
@@ -10,6 +10,7 @@ import (
 
 	nspi "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msnspi "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nspi"
 )
 
@@ -50,7 +51,7 @@ func NspiGetTemplateInfo(rpc ndr.Invoker, hRpc msnspi.NSPI_HANDLE, dwFlags ndr.D
 	PpData = resp.PpData
 	// ErrorsReturned is a success-severity warning: the call succeeded overall but one or
 	// more returned properties are PtypErrorCode ([MS-NSPI] 3.1.4.1.14 / [MS-OXCDATA] 2.5).
-	if s := uint32(resp.Status); s != nspi.StatusSuccess && s != nspi.StatusErrorsReturned {
+	if s := uint32(resp.Status); hresult.HRESULT(s) != hresult.S_OK && s != nspi.StatusErrorsReturned {
 		err = fmt.Errorf("NspiGetTemplateInfo failed: %s", nspi.StatusString(s))
 	}
 	return

--- a/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0/functions/14_NspiModLinkAtt.go
+++ b/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0/functions/14_NspiModLinkAtt.go
@@ -10,6 +10,7 @@ import (
 
 	nspi "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msnspi "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nspi"
 )
 
@@ -44,7 +45,7 @@ func NspiModLinkAtt(rpc ndr.Invoker, hRpc msnspi.NSPI_HANDLE, dwFlags ndr.DWORD,
 		err = fmt.Errorf("NspiModLinkAtt: %w", err)
 		return
 	}
-	if uint32(resp.Status) != nspi.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("NspiModLinkAtt failed: %s", nspi.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0/functions/16_NspiQueryColumns.go
+++ b/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0/functions/16_NspiQueryColumns.go
@@ -10,6 +10,7 @@ import (
 
 	nspi "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msnspi "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nspi"
 )
 
@@ -42,7 +43,7 @@ func NspiQueryColumns(rpc ndr.Invoker, hRpc msnspi.NSPI_HANDLE, reserved ndr.DWO
 		return
 	}
 	PpColumns = resp.PpColumns
-	if uint32(resp.Status) != nspi.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("NspiQueryColumns failed: %s", nspi.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0/functions/17_NspiGetNamesFromIDs.go
+++ b/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0/functions/17_NspiGetNamesFromIDs.go
@@ -10,6 +10,7 @@ import (
 
 	nspi "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msnspi "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nspi"
 )
 
@@ -46,7 +47,7 @@ func NspiGetNamesFromIDs(rpc ndr.Invoker, hRpc msnspi.NSPI_HANDLE, reserved ndr.
 	}
 	PpReturnedPropTags = resp.PpReturnedPropTags
 	PpNames = resp.PpNames
-	if uint32(resp.Status) != nspi.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("NspiGetNamesFromIDs failed: %s", nspi.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0/functions/18_NspiGetIDsFromNames.go
+++ b/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0/functions/18_NspiGetIDsFromNames.go
@@ -10,6 +10,7 @@ import (
 
 	nspi "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msnspi "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nspi"
 )
 
@@ -46,7 +47,7 @@ func NspiGetIDsFromNames(rpc ndr.Invoker, hRpc msnspi.NSPI_HANDLE, reserved ndr.
 		return
 	}
 	PpPropTags = resp.PpPropTags
-	if uint32(resp.Status) != nspi.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("NspiGetIDsFromNames failed: %s", nspi.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0/functions/19_NspiResolveNames.go
+++ b/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0/functions/19_NspiResolveNames.go
@@ -10,6 +10,7 @@ import (
 
 	nspi "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msnspi "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nspi"
 )
 
@@ -50,7 +51,7 @@ func NspiResolveNames(rpc ndr.Invoker, hRpc msnspi.NSPI_HANDLE, reserved ndr.DWO
 	PpRows = resp.PpRows
 	// ErrorsReturned is a success-severity warning: the call succeeded overall but one or
 	// more returned properties are PtypErrorCode ([MS-NSPI] 3.1.4.1.19 / [MS-OXCDATA] 2.5).
-	if s := uint32(resp.Status); s != nspi.StatusSuccess && s != nspi.StatusErrorsReturned {
+	if s := uint32(resp.Status); hresult.HRESULT(s) != hresult.S_OK && s != nspi.StatusErrorsReturned {
 		err = fmt.Errorf("NspiResolveNames failed: %s", nspi.StatusString(s))
 	}
 	return

--- a/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0/functions/20_NspiResolveNamesW.go
+++ b/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0/functions/20_NspiResolveNamesW.go
@@ -10,6 +10,7 @@ import (
 
 	nspi "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msnspi "github.com/TheManticoreProject/Manticore/windows/protocols/ms-nspi"
 )
 
@@ -50,7 +51,7 @@ func NspiResolveNamesW(rpc ndr.Invoker, hRpc msnspi.NSPI_HANDLE, reserved ndr.DW
 	PpRows = resp.PpRows
 	// ErrorsReturned is a success-severity warning: the call succeeded overall but one or
 	// more returned properties are PtypErrorCode ([MS-NSPI] 3.1.4.1.20 / [MS-OXCDATA] 2.5).
-	if s := uint32(resp.Status); s != nspi.StatusSuccess && s != nspi.StatusErrorsReturned {
+	if s := uint32(resp.Status); hresult.HRESULT(s) != hresult.S_OK && s != nspi.StatusErrorsReturned {
 		err = fmt.Errorf("NspiResolveNamesW failed: %s", nspi.StatusString(s))
 	}
 	return

--- a/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0/interface.go
+++ b/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0/interface.go
@@ -12,9 +12,8 @@ package rpcinterface_f5cc5a184264101a8c5908002b2f8426_56_0
 // A fetched copy is kept at ms-nspi.idl in the interface directory.
 
 import (
-	"fmt"
-
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	"github.com/TheManticoreProject/Manticore/windows/guid"
 )
 
@@ -52,28 +51,50 @@ const (
 
 // Status codes an NSPI method may return. NSPI methods return a LONG whose permitted
 // values are the [MS-NSPI] section 2.2.2 "Permitted Error Code Values", defined in
-// [MS-OXCDATA] section 2.4 (Error Codes) and 2.5 (Warning Codes). The two success-severity
-// codes (high bit clear) are Success and the ErrorsReturned warning; the remainder are
-// failures ([MS-OXCDATA] values). [MS-NSPI] also permits "TooBig", whose numeric value is
-// defined in [MS-OXCDATA]; it is intentionally not hardcoded here.
+// [MS-OXCDATA] section 2.4 (Error Codes) and 2.5 (Warning Codes). Those values are
+// HRESULTs ([MS-ERREF] section 2.1), so severity is a range rather than a single value:
+// Success and the ErrorsReturned warning both have the severity bit clear and are
+// successes, and every other permitted value has it set. [MS-NSPI] also permits
+// "TooBig", whose numeric value is defined in [MS-OXCDATA]; it is intentionally not
+// hardcoded here.
+//
+// Five of the seventeen permitted values are generic HRESULTs that the whole of
+// [MS-ERREF] 2.1.1 already carries in
+// github.com/TheManticoreProject/Manticore/windows/errors/hresult under the HRESULT
+// type, so they are not re-declared here. 0x00000000 is S_OK and 0x80004005 is E_FAIL,
+// and the three FACILITY_WIN32 values 0x80070005, 0x8007000E and 0x80070057 are the
+// HRESULT_FROM_WIN32 wrappings of ERROR_ACCESS_DENIED, ERROR_OUTOFMEMORY and
+// ERROR_INVALID_PARAMETER ([MS-ERREF] 2.1.2), which the shared table names outright as
+// E_ACCESSDENIED, E_OUTOFMEMORY and E_INVALIDARG and hresult.HRESULT.ToWin32 unwraps.
+// Reference those from the shared package, converting a returned status with
+// hresult.HRESULT(status) first. The wrapped code for 0x8007000E is ERROR_OUTOFMEMORY
+// (0x0000000E), not the ERROR_NOT_ENOUGH_MEMORY (0x00000008) the value's former private
+// name suggested; that code wraps to the different HRESULT 0x80070008.
+//
+// The twelve values below are the exception, and they cannot move. They are MAPI status
+// values in FACILITY_ITF (0x004), the facility [MS-ERREF] 2.1 sets aside for meanings
+// specific to the interface returning them, so the same number legitimately means
+// different things in different interfaces. The shared table fills facility 4 with the
+// OLE, drag-drop and class-registration names, and for two of these values it holds an
+// unrelated row: it decodes 0x80040102 as DRAGDROP_E_INVALIDHWND where NSPI means
+// MAPI_E_NO_SUPPORT, and 0x80040111 as CLASS_E_CLASSNOTAVAILABLE where NSPI means
+// MAPI_E_LOGON_FAILED, so reading those out of it would report a failed address-book
+// logon as a missing class factory. The other ten have no [MS-ERREF] 2.1.1 row at all.
+// They stay declared here, and StatusString decodes them before deferring to the shared
+// table for everything else.
 const (
-	StatusSuccess            uint32 = 0x00000000 // Success (S_OK)
-	StatusErrorsReturned     uint32 = 0x00040380 // ErrorsReturned (MAPI_W_ERRORS_RETURNED) — warning
-	StatusGeneralFailure     uint32 = 0x80004005 // GeneralFailure (MAPI_E_CALL_FAILED)
-	StatusNotSupported       uint32 = 0x80040102 // NotSupported (MAPI_E_NO_SUPPORT)
-	StatusInvalidObject      uint32 = 0x80040108 // InvalidObject (MAPI_E_INVALID_OBJECT)
-	StatusOutOfResources     uint32 = 0x8004010E // OutOfResources (MAPI_E_NOT_ENOUGH_RESOURCES)
-	StatusNotFound           uint32 = 0x8004010F // NotFound (MAPI_E_NOT_FOUND)
-	StatusLogonFailed        uint32 = 0x80040111 // LogonFailed (MAPI_E_LOGON_FAILED)
-	StatusTooComplex         uint32 = 0x80040117 // TooComplex (MAPI_E_TOO_COMPLEX)
-	StatusInvalidCodepage    uint32 = 0x8004011E // InvalidCodepage (MAPI_E_UNKNOWN_CPID)
-	StatusInvalidLocale      uint32 = 0x8004011F // InvalidLocale (MAPI_E_UNKNOWN_LCID)
-	StatusTableTooBig        uint32 = 0x80040403 // TableTooBig (MAPI_E_TABLE_TOO_BIG)
-	StatusInvalidBookmark    uint32 = 0x80040405 // InvalidBookmark (MAPI_E_INVALID_BOOKMARK)
-	StatusAmbiguousRecipient uint32 = 0x80040700 // AmbiguousRecipient (MAPI_E_AMBIGUOUS_RECIP)
-	StatusAccessDenied       uint32 = 0x80070005 // AccessDenied (MAPI_E_NO_ACCESS)
-	StatusNotEnoughMemory    uint32 = 0x8007000E // NotEnoughMemory (MAPI_E_NOT_ENOUGH_MEMORY)
-	StatusInvalidParameter   uint32 = 0x80070057 // InvalidParameter (MAPI_E_INVALID_PARAMETER)
+	StatusErrorsReturned     uint32 = 0x00040380 // ErrorsReturned (MAPI_W_ERRORS_RETURNED) — warning, no [MS-ERREF] 2.1.1 row
+	StatusNotSupported       uint32 = 0x80040102 // NotSupported (MAPI_E_NO_SUPPORT); [MS-ERREF] 2.1.1 names this value DRAGDROP_E_INVALIDHWND
+	StatusInvalidObject      uint32 = 0x80040108 // InvalidObject (MAPI_E_INVALID_OBJECT), no [MS-ERREF] 2.1.1 row
+	StatusOutOfResources     uint32 = 0x8004010E // OutOfResources (MAPI_E_NOT_ENOUGH_RESOURCES), no [MS-ERREF] 2.1.1 row
+	StatusNotFound           uint32 = 0x8004010F // NotFound (MAPI_E_NOT_FOUND), no [MS-ERREF] 2.1.1 row
+	StatusLogonFailed        uint32 = 0x80040111 // LogonFailed (MAPI_E_LOGON_FAILED); [MS-ERREF] 2.1.1 names this value CLASS_E_CLASSNOTAVAILABLE
+	StatusTooComplex         uint32 = 0x80040117 // TooComplex (MAPI_E_TOO_COMPLEX), no [MS-ERREF] 2.1.1 row
+	StatusInvalidCodepage    uint32 = 0x8004011E // InvalidCodepage (MAPI_E_UNKNOWN_CPID), no [MS-ERREF] 2.1.1 row
+	StatusInvalidLocale      uint32 = 0x8004011F // InvalidLocale (MAPI_E_UNKNOWN_LCID), no [MS-ERREF] 2.1.1 row
+	StatusTableTooBig        uint32 = 0x80040403 // TableTooBig (MAPI_E_TABLE_TOO_BIG), no [MS-ERREF] 2.1.1 row
+	StatusInvalidBookmark    uint32 = 0x80040405 // InvalidBookmark (MAPI_E_INVALID_BOOKMARK), no [MS-ERREF] 2.1.1 row
+	StatusAmbiguousRecipient uint32 = 0x80040700 // AmbiguousRecipient (MAPI_E_AMBIGUOUS_RECIP), no [MS-ERREF] 2.1.1 row
 )
 
 // SyntaxID returns the nspi abstract syntax identifier:
@@ -86,46 +107,41 @@ func SyntaxID() syntax.SyntaxID {
 	}
 }
 
-// StatusString returns a mnemonic for the documented status codes, otherwise the
-// hex value.
+// StatusString names the MAPI status values of [MS-NSPI] section 2.2.2 that sit in
+// FACILITY_ITF, where [MS-ERREF] 2.1.1 either says nothing or names the same value for
+// an unrelated OLE error, and defers every other status to the shared [MS-ERREF] 2.1
+// table, which names each value the specification defines, derives a name for a
+// FACILITY_WIN32 value from the Win32 code it wraps, and renders hex only for a value it
+// cannot name. Deferring is right here because an NSPI return is itself an HRESULT; only
+// the facility-4 block is interface-private.
 func StatusString(status uint32) string {
 	switch status {
-	case StatusSuccess:
-		return "Success"
 	case StatusErrorsReturned:
-		return "ErrorsReturned"
-	case StatusGeneralFailure:
-		return "GeneralFailure"
+		return "MAPI_W_ERRORS_RETURNED"
 	case StatusNotSupported:
-		return "NotSupported"
+		return "MAPI_E_NO_SUPPORT"
 	case StatusInvalidObject:
-		return "InvalidObject"
+		return "MAPI_E_INVALID_OBJECT"
 	case StatusOutOfResources:
-		return "OutOfResources"
+		return "MAPI_E_NOT_ENOUGH_RESOURCES"
 	case StatusNotFound:
-		return "NotFound"
+		return "MAPI_E_NOT_FOUND"
 	case StatusLogonFailed:
-		return "LogonFailed"
+		return "MAPI_E_LOGON_FAILED"
 	case StatusTooComplex:
-		return "TooComplex"
+		return "MAPI_E_TOO_COMPLEX"
 	case StatusInvalidCodepage:
-		return "InvalidCodepage"
+		return "MAPI_E_UNKNOWN_CPID"
 	case StatusInvalidLocale:
-		return "InvalidLocale"
+		return "MAPI_E_UNKNOWN_LCID"
 	case StatusTableTooBig:
-		return "TableTooBig"
+		return "MAPI_E_TABLE_TOO_BIG"
 	case StatusInvalidBookmark:
-		return "InvalidBookmark"
+		return "MAPI_E_INVALID_BOOKMARK"
 	case StatusAmbiguousRecipient:
-		return "AmbiguousRecipient"
-	case StatusAccessDenied:
-		return "AccessDenied"
-	case StatusNotEnoughMemory:
-		return "NotEnoughMemory"
-	case StatusInvalidParameter:
-		return "InvalidParameter"
+		return "MAPI_E_AMBIGUOUS_RECIP"
 	default:
-		return fmt.Sprintf("0x%08x", status)
+		return hresult.HRESULT(status).String()
 	}
 }
 

--- a/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0/interface_test.go
+++ b/network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0/interface_test.go
@@ -1,6 +1,11 @@
 package rpcinterface_f5cc5a184264101a8c5908002b2f8426_56_0
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
+)
 
 // TestSyntaxID pins the abstract syntax identifier for the nspi interface
 // (f5cc5a18-4264-101a-8c59-08002b2f8426 v56.0, [MS-NSPI]).
@@ -40,18 +45,141 @@ func TestOpnumNameRoundTrip(t *testing.T) {
 	}
 }
 
-// TestStatusString checks a known success mnemonic, the ErrorsReturned warning, a failure
-// code, and the hex fallback.
-func TestStatusString(t *testing.T) {
-	cases := map[uint32]string{
-		StatusSuccess:        "Success",
-		StatusErrorsReturned: "ErrorsReturned",
-		StatusLogonFailed:    "LogonFailed",
-		0xDEADBEEF:           "0xdeadbeef",
+// TestGenericStatusCodesResolveThroughHRESULT pins the five permitted values of [MS-NSPI]
+// section 2.2.2 that are generic HRESULTs to their [MS-ERREF] 2.1 names through the shared
+// table in both directions, and shows StatusString reaching them by falling through rather
+// than by a local case. The three FACILITY_WIN32 values are also checked against the
+// HRESULT_FROM_WIN32 macro of [MS-ERREF] 2.1.2 they are built from.
+func TestGenericStatusCodesResolveThroughHRESULT(t *testing.T) {
+	generic := map[uint32]string{
+		0x00000000: "S_OK",           // Success
+		0x80004005: "E_FAIL",         // GeneralFailure (MAPI_E_CALL_FAILED)
+		0x80070005: "E_ACCESSDENIED", // AccessDenied (MAPI_E_NO_ACCESS)
+		0x8007000E: "E_OUTOFMEMORY",  // NotEnoughMemory (MAPI_E_NOT_ENOUGH_MEMORY)
+		0x80070057: "E_INVALIDARG",   // InvalidParameter (MAPI_E_INVALID_PARAMETER)
 	}
-	for status, want := range cases {
-		if got := StatusString(status); got != want {
-			t.Errorf("StatusString(0x%08x) = %q, want %q", status, got, want)
+	for code, name := range generic {
+		if got := hresult.HRESULT(code).String(); got != name {
+			t.Errorf("hresult.HRESULT(0x%08x).String() = %q, want %q", code, got, name)
+		}
+		if resolved, defined := hresult.FromName(name); !defined || uint32(resolved) != code {
+			t.Errorf("hresult.FromName(%q) = 0x%08x, %v; want 0x%08x, true", name, uint32(resolved), defined, code)
+		}
+		if got := StatusString(code); got != name {
+			t.Errorf("StatusString(0x%08x) = %q, want %q", code, got, name)
+		}
+	}
+
+	// The three 0x8007xxxx values are HRESULT_FROM_WIN32 wrappings ([MS-ERREF] 2.1.2), so
+	// they build from and unwrap to their Win32 codes. The wrapped code for 0x8007000E is
+	// ERROR_OUTOFMEMORY (0x0000000E) and not the ERROR_NOT_ENOUGH_MEMORY (0x00000008) the
+	// value's former private name suggested: 0x00000008 wraps to 0x80070008, a different
+	// HRESULT altogether.
+	wrapped := map[uint32]win32.WIN32_ERROR{
+		0x80070005: win32.ERROR_ACCESS_DENIED,
+		0x8007000E: win32.ERROR_OUTOFMEMORY,
+		0x80070057: win32.ERROR_INVALID_PARAMETER,
+	}
+	for code, want := range wrapped {
+		if got := hresult.FromWin32(want); uint32(got) != code {
+			t.Errorf("hresult.FromWin32(0x%08x) = 0x%08x, want 0x%08x", uint32(want), uint32(got), code)
+		}
+		if got, wraps := hresult.HRESULT(code).ToWin32(); !wraps || got != want {
+			t.Errorf("hresult.HRESULT(0x%08x).ToWin32() = 0x%08x, %v; want 0x%08x, true", code, uint32(got), wraps, uint32(want))
+		}
+	}
+
+	// A value neither [MS-NSPI] nor [MS-ERREF] 2.1 defines still renders as hex.
+	if got := StatusString(0xDEADBEEF); got != "0xdeadbeef" {
+		t.Errorf("StatusString(0xdeadbeef) = %q, want 0xdeadbeef", got)
+	}
+}
+
+// TestStatusStringDecodesMAPIFacilityITFCodes pins the one reason StatusString still
+// exists: the twelve MAPI values this interface declares live in FACILITY_ITF (0x004),
+// the facility [MS-ERREF] 2.1 reserves for interface-specific meanings, and the shared
+// table either has no row for them or names the same value for an unrelated OLE error.
+// Each must keep rendering under its MAPI name here, and the two colliding values must
+// keep reporting the table's different name through hresult.Lookup, so that a later pass
+// folding them into the shared table fails loudly instead of silently renaming a failed
+// address-book logon.
+func TestStatusStringDecodesMAPIFacilityITFCodes(t *testing.T) {
+	mapiOnly := map[uint32]string{
+		StatusErrorsReturned:     "MAPI_W_ERRORS_RETURNED",
+		StatusNotSupported:       "MAPI_E_NO_SUPPORT",
+		StatusInvalidObject:      "MAPI_E_INVALID_OBJECT",
+		StatusOutOfResources:     "MAPI_E_NOT_ENOUGH_RESOURCES",
+		StatusNotFound:           "MAPI_E_NOT_FOUND",
+		StatusLogonFailed:        "MAPI_E_LOGON_FAILED",
+		StatusTooComplex:         "MAPI_E_TOO_COMPLEX",
+		StatusInvalidCodepage:    "MAPI_E_UNKNOWN_CPID",
+		StatusInvalidLocale:      "MAPI_E_UNKNOWN_LCID",
+		StatusTableTooBig:        "MAPI_E_TABLE_TOO_BIG",
+		StatusInvalidBookmark:    "MAPI_E_INVALID_BOOKMARK",
+		StatusAmbiguousRecipient: "MAPI_E_AMBIGUOUS_RECIP",
+	}
+	if len(mapiOnly) != 12 {
+		t.Fatalf("MAPI-only table has %d entries, want 12", len(mapiOnly))
+	}
+	for code, name := range mapiOnly {
+		if got := StatusString(code); got != name {
+			t.Errorf("StatusString(0x%08x) = %q, want %q", code, got, name)
+		}
+		if (code>>16)&0x07FF != 0x004 {
+			t.Errorf("%s = 0x%08x, facility %#x, want FACILITY_ITF (0x004)", name, code, (code>>16)&0x07FF)
+		}
+		if _, defined := hresult.FromName(name); defined {
+			t.Errorf("hresult.FromName(%q) resolves; the code belongs in the shared table instead", name)
+		}
+	}
+
+	// The collision that makes the local block necessary: for these two values the shared
+	// table holds a row, and it names something unrelated.
+	colliding := map[uint32]string{
+		StatusNotSupported: "DRAGDROP_E_INVALIDHWND",
+		StatusLogonFailed:  "CLASS_E_CLASSNOTAVAILABLE",
+	}
+	for code, tableName := range colliding {
+		entry, defined := hresult.Lookup(hresult.HRESULT(code))
+		if !defined || entry.Name != tableName {
+			t.Errorf("hresult.Lookup(0x%08x) = %q, %v; want %q, true", code, entry.Name, defined, tableName)
+		}
+		if entry.Name == StatusString(code) {
+			t.Errorf("0x%08x: shared table and StatusString agree on %q; the collision this test pins is gone", code, entry.Name)
+		}
+	}
+
+	// The other ten have no [MS-ERREF] 2.1.1 row at all, so the shared table would render
+	// them as bare hex where StatusString names them.
+	for code := range mapiOnly {
+		if _, colliding := colliding[code]; colliding {
+			continue
+		}
+		if entry, defined := hresult.Lookup(hresult.HRESULT(code)); defined {
+			t.Errorf("hresult.Lookup(0x%08x) = %q, true; want no entry", code, entry.Name)
+		}
+	}
+}
+
+// TestErrorsReturnedIsSuccessSeverity records that the ErrorsReturned warning of
+// [MS-OXCDATA] section 2.5 has the severity bit clear and is therefore a success by the
+// HRESULT rule of [MS-ERREF] 2.1, while the seven methods that tolerate it name it
+// explicitly alongside S_OK and the other thirteen do not. Which statuses a method
+// tolerates is [MS-NSPI]'s to decide, so the stubs keep the shape they had; this pins the
+// severity fact so the discrepancy stays visible.
+func TestErrorsReturnedIsSuccessSeverity(t *testing.T) {
+	if !hresult.HRESULT(StatusErrorsReturned).IsSuccess() {
+		t.Errorf("hresult.HRESULT(0x%08x).IsSuccess() = false, want true", StatusErrorsReturned)
+	}
+	if err := hresult.HRESULT(StatusErrorsReturned).Error(); err != nil {
+		t.Errorf("hresult.HRESULT(0x%08x).Error() = %v, want nil", StatusErrorsReturned, err)
+	}
+	if !hresult.S_OK.IsSuccess() {
+		t.Error("hresult.S_OK.IsSuccess() = false, want true")
+	}
+	for _, code := range []uint32{StatusNotSupported, StatusLogonFailed, 0x80004005} {
+		if hresult.HRESULT(code).IsSuccess() {
+			t.Errorf("hresult.HRESULT(0x%08x).IsSuccess() = true, want false", code)
 		}
 	}
 }


### PR DESCRIPTION
### Linked Issue

Refs #1219. Depends on the HRESULT table added by #1221 (merged as `windows/errors/hresult`).

### Root Cause

The nspi descriptor at `network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0/` declared its own block of seventeen status codes with a `StatusString` switch over all of them, and the switch fell through to a bare hex string, so any HRESULT the subset happened to omit reached the caller undecoded.

Twelve of those seventeen cannot be moved to the shared table, and two of them are actively dangerous. NSPI methods return a LONG whose permitted values are the [MS-NSPI] section 2.2.2 Permitted Error Code Values, defined in [MS-OXCDATA] sections 2.4 and 2.5, and those are MAPI status values in FACILITY_ITF — facility `0x004`, which [MS-ERREF] 2.1 sets aside for meanings specific to the interface returning them. The shared [MS-ERREF] 2.1.1 table fills facility 4 with 283 OLE, drag-drop and class-registration names, and for two of nspi's values it holds a row that means something else entirely:

| nspi constant | value | nspi means | [MS-ERREF] 2.1.1 says |
|---|---|---|---|
| `StatusNotSupported` | `0x80040102` | `MAPI_E_NO_SUPPORT` | `DRAGDROP_E_INVALIDHWND` |
| `StatusLogonFailed` | `0x80040111` | `MAPI_E_LOGON_FAILED` | `CLASS_E_CLASSNOTAVAILABLE` |

Migrating those would have compiled, passed every test, and reported a failed address-book logon as a missing class factory. The other ten facility-4 values — `0x00040380`, `0x80040108`, `0x8004010E`, `0x8004010F`, `0x80040117`, `0x8004011E`, `0x8004011F`, `0x80040403`, `0x80040405`, `0x80040700` — have no row in [MS-ERREF] 2.1.1 at all, so there is nothing to migrate them to either.

### Fix Description

Five of the seventeen do move, and they are the genuinely generic HRESULTs: `0x00000000` as `S_OK`, `0x80004005` as `E_FAIL`, and the three FACILITY_WIN32 values `0x80070005`, `0x8007000E` and `0x80070057` as `E_ACCESSDENIED`, `E_OUTOFMEMORY` and `E_INVALIDARG`. Those five are deleted from the descriptor and referenced from `windows/errors/hresult` directly — no alias constants, no local re-declaration of a code the shared table already carries, no delegating wrappers.

Every value was looked up by number in the committed extract at `windows/errors/errgen/ms-erref-2.1.1-hresult.tsv` rather than read off its private identifier, which is what turned up both collisions and one other discrepancy. `0x8007000E` carried the private name `StatusNotEnoughMemory` and a comment naming `MAPI_E_NOT_ENOUGH_MEMORY`, but by value it is the `HRESULT_FROM_WIN32` wrapping of `ERROR_OUTOFMEMORY` (`0x0000000E`) and the table names it `E_OUTOFMEMORY`. `ERROR_NOT_ENOUGH_MEMORY` is `0x00000008` and wraps to the different HRESULT `0x80070008`, so a name-driven mapping would have referenced the wrong Win32 constant.

The twelve MAPI values stay declared in `interface.go`, with a comment recording that they are [MS-NSPI]/MAPI values in FACILITY_ITF and that the shared table names two of them differently and knows nothing of the other ten. `StatusString` survives in reduced form over only those twelve, rendering each under its MAPI name and deferring everything else to `hresult.HRESULT(status).String()`. That fallthrough is correct here because an NSPI return is itself an HRESULT; only the facility-4 block is interface-private.

The twenty method stubs convert the retval with `hresult.HRESULT` and compare against `hresult.S_OK`, keeping the reduced `StatusString` for rendering. They keep their nspi import for the opnum their request types report and for the retained warning.

Success is a range for an HRESULT rather than the single value zero, and that changes nothing about which statuses these methods tolerate. Seven of the twenty — `NspiQueryRows`, `NspiSeekEntries`, `NspiGetMatches`, `NspiGetProps`, `NspiGetTemplateInfo`, `NspiResolveNames`, `NspiResolveNamesW` — accept the `ErrorsReturned` warning alongside success; the other thirteen compare against success alone and therefore treat `0x00040380` as a failure even though its severity bit is clear. Which statuses a method tolerates is [MS-NSPI]'s to decide and not this change's, so every condition keeps the shape it had rather than being widened to a severity test. A test records the severity fact so the discrepancy stays visible.

The rewrite was applied one comparison term at a time rather than one condition at a time, so a condition accepting the warning alongside success could not silently lose a term and still compile.

### How Verified

- `go build ./...` — exit 0.
- `go vet ./...` — no output.
- `go test -count=1 ./...` — 315 ok, 0 failures, matching `main`.
- `CGO_ENABLED=0 go build ./...` for `windows/amd64`, `windows/386`, `linux/arm64`, `linux/386` — all exit 0.
- Per-`if` comparison-term count over all twenty `functions/*.go` files, compared against the parent revision: identical, thirteen single-term conditions and seven two-term ones.
- `gofmt -l` over the interface directory: clean on `main` before the change and clean after it, with no `gofmt -w` needed. Each import block was reconstructed from `git show HEAD:<path>` so the stdlib/project blank line survives; all twenty files were confirmed to hold exactly one blank line inside their import block.
- Tree-wide greps for the interface's import path and for every one of the seventeen constant names found no consumer outside the interface directory — no `network/dcerpc/ms-protocols/` client, no `rpcpipe` server dispatch, no package test asserting the literal hex the old subset rendered. Greps for `Contains`/`HasPrefix` against `"MAPI"`, `"E_"` and `"0x8004"` found nothing anywhere in the tree. `windows/protocols/ms-nspi`, which holds this protocol's wire structures, carries no status handling at all.
- Each of the five migrated values and the seventeen originals were resolved by number against `windows/errors/errgen/ms-erref-2.1.1-hresult.tsv`; six of the seventeen have a row, eleven do not.

### Test Coverage

`TestStatusString` is replaced by three tests in `interface_test.go`.

`TestGenericStatusCodesResolveThroughHRESULT` pins each of the five migrated values to its specification name through the shared table in both directions, shows `StatusString` reaching them by falling through rather than by a local case, checks the three FACILITY_WIN32 values against the `HRESULT_FROM_WIN32` macro in both directions including the `0x8007000E`/`ERROR_OUTOFMEMORY` correction, and shows an undefined value still rendering as hex.

`TestStatusStringDecodesMAPIFacilityITFCodes` is the regression test that stops a future pass from routing the retained block through the shared table. It pins all twelve to their MAPI names, asserts each sits in FACILITY_ITF, asserts the shared table resolves none of those MAPI names, pins the two collisions by requiring `hresult.Lookup` to report `DRAGDROP_E_INVALIDHWND` and `CLASS_E_CLASSNOTAVAILABLE` for values `StatusString` names differently, and requires the other ten to have no entry at all.

`TestErrorsReturnedIsSuccessSeverity` pins that `0x00040380` has the severity bit clear and that `hresult.Error` reports nil for it.

`TestSyntaxID`, `TestOpnumNameRoundTrip` and `TestPipeName` are unchanged and still pass.

### Scope of Change

22 files, all under `network/dcerpc/interfaces/f5cc5a18-4264-101a-8c59-08002b2f8426/56.0/`: `interface.go`, `interface_test.go` and the twenty `functions/*.go` stubs. Nothing outside the interface directory is touched, and `windows/errors/hresult` itself is unmodified.

The interface's other declarations are untouched: the deliberately empty `PipeName`, `SyntaxID()`, the twenty opnum constants and the `OpnumToName` and `NameToOpnum` maps.

### Risk and Rollout

No wire behaviour changes. Nothing about request or response encoding is touched, and each of the twenty status conditions accepts and rejects exactly the set of values it accepted and rejected before.

What changes is rendered text. `StatusString(0)` now returns `S_OK` rather than `Success`, and the four other migrated values render under their [MS-ERREF] names — `E_FAIL`, `E_ACCESSDENIED`, `E_OUTOFMEMORY`, `E_INVALIDARG` — rather than the descriptor's private mnemonics. The twelve retained values render under their MAPI names rather than the private ones, so `StatusString(0x80040111)` returns `MAPI_E_LOGON_FAILED` rather than `LogonFailed`. Any HRESULT outside the old subset, which used to reach the caller as bare hex, now resolves through the shared table. These strings appear only in error messages, and no test outside this interface asserted any of them.

The five deleted constants are exported identifiers, so a caller outside the repository referencing them would break; the greps above confirm there is no such caller inside it.

### Notes

The `TooBig` status [MS-NSPI] 2.2.2 also permits stays unhardcoded, as before: its numeric value is defined in [MS-OXCDATA] and was never transcribed here, so there was no value to check against the table.

The two collisions are the second instance in this issue of a facility whose values a shared table names for one protocol while an interface means another, after the [MS-FAX] `0x1B59..0x1B65` overlap with the Terminal Services `ERROR_CTX_*` errors handled in #1245. The FACILITY_ITF case is broader than that one: the collision there was accidental range reuse, whereas facility 4 is interface-specific by definition, so any interface returning MAPI or other `[object]`-style status values should be expected to disagree with the shared table over facility 4 rather than checked for it as an exception.
