### PR TITLE
Route qmcomm and dscomm status reporting through hresult (Refs #1219)

### DIFF
--- a/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0/functions/00_S_DSCreateObject.go
+++ b/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0/functions/00_S_DSCreateObject.go
@@ -10,6 +10,7 @@ import (
 
 	dscomm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	msmqmq "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqmq"
 )
@@ -53,7 +54,7 @@ func S_DSCreateObject(rpc ndr.Invoker, dwObjectType ndr.DWORD, pwcsPathName *ndr
 		return
 	}
 	PObjGuid = resp.PObjGuid
-	if uint32(resp.Status) != dscomm.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("S_DSCreateObject failed: %s", dscomm.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0/functions/01_S_DSDeleteObject.go
+++ b/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0/functions/01_S_DSDeleteObject.go
@@ -10,6 +10,7 @@ import (
 
 	dscomm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 )
 
 // s_DSDeleteObjectRequest carries the [in] parameters of S_DSDeleteObject.
@@ -37,7 +38,7 @@ func S_DSDeleteObject(rpc ndr.Invoker, dwObjectType ndr.DWORD, pwcsPathName ndr.
 		err = fmt.Errorf("S_DSDeleteObject: %w", err)
 		return
 	}
-	if uint32(resp.Status) != dscomm.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("S_DSDeleteObject failed: %s", dscomm.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0/functions/02_S_DSGetProps.go
+++ b/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0/functions/02_S_DSGetProps.go
@@ -10,6 +10,7 @@ import (
 
 	dscomm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msmqds "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqds"
 	msmqmq "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqmq"
 )
@@ -55,7 +56,7 @@ func S_DSGetProps(rpc ndr.Invoker, dwObjectType ndr.DWORD, pwcsPathName ndr.WSTR
 	ApVar = resp.ApVar
 	PbServerSignature = resp.PbServerSignature
 	PdwServerSignatureSize = resp.PdwServerSignatureSize
-	if uint32(resp.Status) != dscomm.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("S_DSGetProps failed: %s", dscomm.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0/functions/03_S_DSSetProps.go
+++ b/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0/functions/03_S_DSSetProps.go
@@ -10,6 +10,7 @@ import (
 
 	dscomm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msmqmq "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqmq"
 )
 
@@ -44,7 +45,7 @@ func S_DSSetProps(rpc ndr.Invoker, dwObjectType ndr.DWORD, pwcsPathName ndr.WSTR
 		err = fmt.Errorf("S_DSSetProps: %w", err)
 		return
 	}
-	if uint32(resp.Status) != dscomm.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("S_DSSetProps failed: %s", dscomm.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0/functions/04_S_DSGetObjectSecurity.go
+++ b/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0/functions/04_S_DSGetObjectSecurity.go
@@ -10,6 +10,7 @@ import (
 
 	dscomm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msmqds "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqds"
 )
 
@@ -54,7 +55,7 @@ func S_DSGetObjectSecurity(rpc ndr.Invoker, dwObjectType ndr.DWORD, pwcsPathName
 	LpnLengthNeeded = resp.LpnLengthNeeded
 	PbServerSignature = resp.PbServerSignature
 	PdwServerSignatureSize = resp.PdwServerSignatureSize
-	if uint32(resp.Status) != dscomm.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("S_DSGetObjectSecurity failed: %s", dscomm.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0/functions/05_S_DSSetObjectSecurity.go
+++ b/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0/functions/05_S_DSSetObjectSecurity.go
@@ -10,6 +10,7 @@ import (
 
 	dscomm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 )
 
 // s_DSSetObjectSecurityRequest carries the [in] parameters of S_DSSetObjectSecurity.
@@ -43,7 +44,7 @@ func S_DSSetObjectSecurity(rpc ndr.Invoker, dwObjectType ndr.DWORD, pwcsPathName
 		err = fmt.Errorf("S_DSSetObjectSecurity: %w", err)
 		return
 	}
-	if uint32(resp.Status) != dscomm.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("S_DSSetObjectSecurity failed: %s", dscomm.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0/functions/06_S_DSLookupBegin.go
+++ b/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0/functions/06_S_DSLookupBegin.go
@@ -10,6 +10,7 @@ import (
 
 	dscomm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msmqds "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqds"
 )
 
@@ -46,7 +47,7 @@ func S_DSLookupBegin(rpc ndr.Invoker, pwcsContext *ndr.WSTR, pRestriction *msmqd
 		return
 	}
 	PHandle = resp.PHandle
-	if uint32(resp.Status) != dscomm.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("S_DSLookupBegin failed: %s", dscomm.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0/functions/07_S_DSLookupNext.go
+++ b/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0/functions/07_S_DSLookupNext.go
@@ -10,6 +10,7 @@ import (
 
 	dscomm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msmqds "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqds"
 	msmqmq "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqmq"
 )
@@ -51,7 +52,7 @@ func S_DSLookupNext(rpc ndr.Invoker, handle msmqds.PCONTEXT_HANDLE_TYPE, dwSize 
 	PbBuffer = resp.PbBuffer
 	PbServerSignature = resp.PbServerSignature
 	PdwServerSignatureSize = resp.PdwServerSignatureSize
-	if uint32(resp.Status) != dscomm.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("S_DSLookupNext failed: %s", dscomm.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0/functions/08_S_DSLookupEnd.go
+++ b/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0/functions/08_S_DSLookupEnd.go
@@ -10,6 +10,7 @@ import (
 
 	dscomm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msmqds "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqds"
 )
 
@@ -38,7 +39,7 @@ func S_DSLookupEnd(rpc ndr.Invoker, phContext msmqds.PPCONTEXT_HANDLE_TYPE) (PhC
 		return
 	}
 	PhContext = resp.PhContext
-	if uint32(resp.Status) != dscomm.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("S_DSLookupEnd failed: %s", dscomm.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0/functions/10_S_DSDeleteObjectGuid.go
+++ b/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0/functions/10_S_DSDeleteObjectGuid.go
@@ -10,6 +10,7 @@ import (
 
 	dscomm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 )
 
@@ -38,7 +39,7 @@ func S_DSDeleteObjectGuid(rpc ndr.Invoker, dwObjectType ndr.DWORD, pGuid msdtyp.
 		err = fmt.Errorf("S_DSDeleteObjectGuid: %w", err)
 		return
 	}
-	if uint32(resp.Status) != dscomm.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("S_DSDeleteObjectGuid failed: %s", dscomm.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0/functions/11_S_DSGetPropsGuid.go
+++ b/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0/functions/11_S_DSGetPropsGuid.go
@@ -10,6 +10,7 @@ import (
 
 	dscomm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	msmqds "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqds"
 	msmqmq "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqmq"
@@ -56,7 +57,7 @@ func S_DSGetPropsGuid(rpc ndr.Invoker, dwObjectType ndr.DWORD, pGuid *msdtyp.GUI
 	ApVar = resp.ApVar
 	PbServerSignature = resp.PbServerSignature
 	PdwServerSignatureSize = resp.PdwServerSignatureSize
-	if uint32(resp.Status) != dscomm.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("S_DSGetPropsGuid failed: %s", dscomm.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0/functions/12_S_DSSetPropsGuid.go
+++ b/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0/functions/12_S_DSSetPropsGuid.go
@@ -10,6 +10,7 @@ import (
 
 	dscomm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	msmqmq "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqmq"
 )
@@ -45,7 +46,7 @@ func S_DSSetPropsGuid(rpc ndr.Invoker, dwObjectType ndr.DWORD, pGuid msdtyp.GUID
 		err = fmt.Errorf("S_DSSetPropsGuid: %w", err)
 		return
 	}
-	if uint32(resp.Status) != dscomm.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("S_DSSetPropsGuid failed: %s", dscomm.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0/functions/13_S_DSGetObjectSecurityGuid.go
+++ b/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0/functions/13_S_DSGetObjectSecurityGuid.go
@@ -10,6 +10,7 @@ import (
 
 	dscomm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	msmqds "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqds"
 )
@@ -55,7 +56,7 @@ func S_DSGetObjectSecurityGuid(rpc ndr.Invoker, dwObjectType ndr.DWORD, pGuid ms
 	LpnLengthNeeded = resp.LpnLengthNeeded
 	PbServerSignature = resp.PbServerSignature
 	PdwServerSignatureSize = resp.PdwServerSignatureSize
-	if uint32(resp.Status) != dscomm.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("S_DSGetObjectSecurityGuid failed: %s", dscomm.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0/functions/14_S_DSSetObjectSecurityGuid.go
+++ b/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0/functions/14_S_DSSetObjectSecurityGuid.go
@@ -10,6 +10,7 @@ import (
 
 	dscomm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 )
 
@@ -44,7 +45,7 @@ func S_DSSetObjectSecurityGuid(rpc ndr.Invoker, dwObjectType ndr.DWORD, pGuid ms
 		err = fmt.Errorf("S_DSSetObjectSecurityGuid: %w", err)
 		return
 	}
-	if uint32(resp.Status) != dscomm.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("S_DSSetObjectSecurityGuid failed: %s", dscomm.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0/functions/19_S_DSQMSetMachineProperties.go
+++ b/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0/functions/19_S_DSQMSetMachineProperties.go
@@ -10,6 +10,7 @@ import (
 
 	dscomm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msmqmq "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqmq"
 )
 
@@ -46,7 +47,7 @@ func S_DSQMSetMachineProperties(rpc ndr.Invoker, pwcsPathName ndr.WSTR, cp ndr.D
 		err = fmt.Errorf("S_DSQMSetMachineProperties: %w", err)
 		return
 	}
-	if uint32(resp.Status) != dscomm.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("S_DSQMSetMachineProperties failed: %s", dscomm.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0/functions/20_S_DSCreateServersCache.go
+++ b/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0/functions/20_S_DSCreateServersCache.go
@@ -10,6 +10,7 @@ import (
 
 	dscomm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msmqds "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqds"
 )
 
@@ -50,7 +51,7 @@ func S_DSCreateServersCache(rpc ndr.Invoker, pdwIndex ndr.DWORD, lplpSiteServers
 	LplpSiteServers = resp.LplpSiteServers
 	PbServerSignature = resp.PbServerSignature
 	PdwServerSignatureSize = resp.PdwServerSignatureSize
-	if uint32(resp.Status) != dscomm.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("S_DSCreateServersCache failed: %s", dscomm.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0/functions/21_S_DSQMGetObjectSecurity.go
+++ b/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0/functions/21_S_DSQMGetObjectSecurity.go
@@ -10,6 +10,7 @@ import (
 
 	dscomm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	msmqds "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqds"
 )
@@ -57,7 +58,7 @@ func S_DSQMGetObjectSecurity(rpc ndr.Invoker, dwObjectType ndr.DWORD, pGuid msdt
 	LpnLengthNeeded = resp.LpnLengthNeeded
 	PbServerSignature = resp.PbServerSignature
 	PdwServerSignatureSize = resp.PdwServerSignatureSize
-	if uint32(resp.Status) != dscomm.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("S_DSQMGetObjectSecurity failed: %s", dscomm.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0/functions/22_S_DSValidateServer.go
+++ b/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0/functions/22_S_DSValidateServer.go
@@ -10,6 +10,7 @@ import (
 
 	dscomm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	msmqds "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqds"
 )
@@ -49,7 +50,7 @@ func S_DSValidateServer(rpc ndr.Invoker, pguidEnterpriseId msdtyp.GUID, fSetupMo
 		return
 	}
 	PphServerAuth = resp.PphServerAuth
-	if uint32(resp.Status) != dscomm.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("S_DSValidateServer failed: %s", dscomm.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0/functions/23_S_DSCloseServerHandle.go
+++ b/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0/functions/23_S_DSCloseServerHandle.go
@@ -10,6 +10,7 @@ import (
 
 	dscomm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msmqds "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqds"
 )
 
@@ -38,7 +39,7 @@ func S_DSCloseServerHandle(rpc ndr.Invoker, pphServerAuth msmqds.PPCONTEXT_HANDL
 		return
 	}
 	PphServerAuth = resp.PphServerAuth
-	if uint32(resp.Status) != dscomm.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("S_DSCloseServerHandle failed: %s", dscomm.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0/interface.go
+++ b/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0/interface.go
@@ -12,9 +12,8 @@ package rpcinterface_77df7a80f29811d0835800a024c480a8_1_0
 // A fetched copy is kept at ms-mqds.idl in the interface directory.
 
 import (
-	"fmt"
-
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	"github.com/TheManticoreProject/Manticore/windows/guid"
 )
 
@@ -52,11 +51,18 @@ const (
 
 // Status codes returned by this interface. Every dscomm method returns an HRESULT; the
 // values are the Message Queuing result codes ([MS-MQMQ] 2.4, mqerror.h). Only the codes
-// most relevant to directory operations are enumerated here; StatusString falls back to
-// the hex value for any other HRESULT.
+// most relevant to directory operations are enumerated here.
+//
+// These are MQ_* values in FACILITY_MSMQ (0x00E), and that is why they stay declared here
+// instead of moving to github.com/TheManticoreProject/Manticore/windows/errors/hresult:
+// [MS-ERREF] section 2.1.1 does not carry that facility at all. Its 2928 values span 22
+// facilities and none of them is 0x00E; no name in the table begins with MQ_ and none
+// contains MSMQ. Routing MQ_ERROR_ILLEGAL_PROPID (0xC00E0039) through the shared table
+// would therefore render it as bare hex rather than name it.
+//
+// MQ_OK is the one value that does move. It is 0x00000000, which is S_OK, so the methods
+// compare against hresult.S_OK and no local success constant is declared here.
 const (
-	StatusSuccess uint32 = 0x00000000 // MQ_OK
-
 	MQ_ERROR                            uint32 = 0xC00E0001
 	MQ_ERROR_PROPERTY                   uint32 = 0xC00E0002
 	MQ_ERROR_QUEUE_NOT_FOUND            uint32 = 0xC00E0003
@@ -85,12 +91,16 @@ func SyntaxID() syntax.SyntaxID {
 	}
 }
 
-// StatusString returns a mnemonic for the documented status codes, otherwise the
-// hex value.
+// StatusString names the Message Queuing result codes of [MS-MQMQ] 2.4 that this interface
+// returns, whose FACILITY_MSMQ values [MS-ERREF] 2.1.1 does not carry, and defers every
+// other status to the shared [MS-ERREF] 2.1.1 table.
+//
+// That fall-through is correct despite the missing facility: an MSMQ status genuinely is an
+// HRESULT, with bit 31 as its severity and 0x00E in its facility field, so a value outside
+// the list below is decoded as the HRESULT it is and rendered as hex only where the
+// specification names nothing.
 func StatusString(status uint32) string {
 	switch status {
-	case StatusSuccess:
-		return "MQ_OK"
 	case MQ_ERROR:
 		return "MQ_ERROR"
 	case MQ_ERROR_PROPERTY:
@@ -124,7 +134,7 @@ func StatusString(status uint32) string {
 	case MQ_ERROR_ILLEGAL_SORT_PROPID:
 		return "MQ_ERROR_ILLEGAL_SORT_PROPID"
 	default:
-		return fmt.Sprintf("0x%08x", status)
+		return hresult.HRESULT(status).String()
 	}
 }
 

--- a/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0/interface_test.go
+++ b/network/dcerpc/interfaces/77df7a80-f298-11d0-8358-00a024c480a8/1.0/interface_test.go
@@ -1,6 +1,11 @@
 package rpcinterface_77df7a80f29811d0835800a024c480a8_1_0
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
+)
 
 // TestSyntaxID verifies the abstract syntax identity (UUID + version) of the dscomm interface.
 func TestSyntaxID(t *testing.T) {
@@ -33,15 +38,107 @@ func TestOpnums(t *testing.T) {
 	}
 }
 
-// TestStatusString verifies mnemonic rendering and the hex fallback.
-func TestStatusString(t *testing.T) {
-	if got := StatusString(StatusSuccess); got != "MQ_OK" {
-		t.Fatalf("StatusString(StatusSuccess) = %s, want MQ_OK", got)
+// TestSuccessResolvesThroughHRESULT pins the one status value this package no longer
+// declares. MQ_OK is 0x00000000, which is S_OK, so the methods compare the retval against
+// hresult.S_OK and StatusString renders it out of the shared table.
+func TestSuccessResolvesThroughHRESULT(t *testing.T) {
+	if uint32(hresult.S_OK) != 0x00000000 {
+		t.Fatalf("hresult.S_OK = 0x%08x, want 0x00000000", uint32(hresult.S_OK))
 	}
-	if got := StatusString(MQ_ERROR_QUEUE_NOT_FOUND); got != "MQ_ERROR_QUEUE_NOT_FOUND" {
-		t.Fatalf("StatusString(MQ_ERROR_QUEUE_NOT_FOUND) = %s, want MQ_ERROR_QUEUE_NOT_FOUND", got)
+	if got := hresult.S_OK.String(); got != "S_OK" {
+		t.Errorf("hresult.S_OK.String() = %q, want S_OK", got)
+	}
+	if resolved, defined := hresult.FromName("S_OK"); !defined || resolved != hresult.S_OK {
+		t.Errorf("hresult.FromName(\"S_OK\") = 0x%08x, %v; want 0x00000000, true", uint32(resolved), defined)
+	}
+	if !hresult.S_OK.IsSuccess() || hresult.S_OK.Error() != nil {
+		t.Errorf("hresult.S_OK reports failure; MQ_OK is a success status")
+	}
+	if got := StatusString(uint32(hresult.S_OK)); got != "S_OK" {
+		t.Errorf("StatusString(0x00000000) = %q, want S_OK", got)
+	}
+}
+
+// TestStatusStringDecodesMSMQFacility pins the reason the MQ_* block stays declared in this
+// package: every one of these values sits in FACILITY_MSMQ (0x00E), a facility [MS-ERREF]
+// 2.1.1 does not carry at all, so the shared table resolves none of them. StatusString
+// names them and hresult.Lookup reports nothing for them; should a later pass route them
+// through the shared table, this fails instead of silently renaming a directory error.
+func TestStatusStringDecodesMSMQFacility(t *testing.T) {
+	msmq := map[uint32]string{
+		MQ_ERROR:                            "MQ_ERROR",
+		MQ_ERROR_PROPERTY:                   "MQ_ERROR_PROPERTY",
+		MQ_ERROR_QUEUE_NOT_FOUND:            "MQ_ERROR_QUEUE_NOT_FOUND",
+		MQ_ERROR_QUEUE_EXISTS:               "MQ_ERROR_QUEUE_EXISTS",
+		MQ_ERROR_INVALID_PARAMETER:          "MQ_ERROR_INVALID_PARAMETER",
+		MQ_ERROR_INVALID_HANDLE:             "MQ_ERROR_INVALID_HANDLE",
+		MQ_ERROR_NO_DS:                      "MQ_ERROR_NO_DS",
+		MQ_ERROR_ILLEGAL_QUEUE_PATHNAME:     "MQ_ERROR_ILLEGAL_QUEUE_PATHNAME",
+		MQ_ERROR_ACCESS_DENIED:              "MQ_ERROR_ACCESS_DENIED",
+		MQ_ERROR_ILLEGAL_MQCOLUMNS:          "MQ_ERROR_ILLEGAL_MQCOLUMNS",
+		MQ_ERROR_ILLEGAL_PROPID:             "MQ_ERROR_ILLEGAL_PROPID",
+		MQ_ERROR_ILLEGAL_RELATION:           "MQ_ERROR_ILLEGAL_RELATION",
+		MQ_ERROR_ILLEGAL_PROPERTY_VALUE:     "MQ_ERROR_ILLEGAL_PROPERTY_VALUE",
+		MQ_ERROR_ILLEGAL_RESTRICTION_PROPID: "MQ_ERROR_ILLEGAL_RESTRICTION_PROPID",
+		MQ_ERROR_DS_ERROR:                   "MQ_ERROR_DS_ERROR",
+		MQ_ERROR_ILLEGAL_SORT_PROPID:        "MQ_ERROR_ILLEGAL_SORT_PROPID",
+	}
+	if len(msmq) != 16 {
+		t.Fatalf("MSMQ status table has %d entries, want 16", len(msmq))
+	}
+	for code, name := range msmq {
+		if got := StatusString(code); got != name {
+			t.Errorf("StatusString(0x%08x) = %q, want %q", code, got, name)
+		}
+		if facility := (code >> 16) & 0x07FF; facility != 0x00E {
+			t.Errorf("%s = 0x%08x, facility 0x%03x, want FACILITY_MSMQ 0x00E", name, code, facility)
+		}
+		if entry, defined := hresult.Lookup(hresult.HRESULT(code)); defined {
+			t.Errorf("hresult.Lookup(0x%08x) resolves to %q; [MS-ERREF] 2.1.1 carries no FACILITY_MSMQ row", code, entry.Name)
+		}
+		if _, defined := hresult.FromName(name); defined {
+			t.Errorf("hresult.FromName(%q) resolves; the code is declared in this package instead", name)
+		}
+		if hresult.HRESULT(code).IsSuccess() {
+			t.Errorf("%s = 0x%08x reports success; the MQ_ERROR_* values are failures", name, code)
+		}
+	}
+}
+
+// TestStatusStringFallsThroughToHRESULT shows what the fall-through buys. A generic HRESULT
+// the old switch never enumerated reached the caller as bare hex and now resolves by name,
+// including one the shared table derives through HRESULT_FROM_WIN32, while a value the
+// specification defines nowhere still renders as hex.
+func TestStatusStringFallsThroughToHRESULT(t *testing.T) {
+	generic := map[uint32]string{
+		0x80004005: "E_FAIL",
+		0x80070005: "E_ACCESSDENIED",
+		0x8007000E: "E_OUTOFMEMORY",
+	}
+	for code, name := range generic {
+		if got := StatusString(code); got != name {
+			t.Errorf("StatusString(0x%08x) = %q, want %q", code, got, name)
+		}
+	}
+
+	// A FACILITY_WIN32 code the table does not name is derived from the Win32 table.
+	wrapped := hresult.FromWin32(win32.ERROR_INVALID_NAME)
+	if uint32(wrapped) != 0x8007007B {
+		t.Fatalf("hresult.FromWin32(ERROR_INVALID_NAME) = 0x%08x, want 0x8007007b", uint32(wrapped))
+	}
+	if got := StatusString(uint32(wrapped)); got != "HRESULT_FROM_WIN32(ERROR_INVALID_NAME)" {
+		t.Errorf("StatusString(0x8007007b) = %q, want HRESULT_FROM_WIN32(ERROR_INVALID_NAME)", got)
+	}
+	if code, wraps := wrapped.ToWin32(); !wraps || code != win32.ERROR_INVALID_NAME {
+		t.Errorf("ToWin32() = 0x%08x, %v; want 0x0000007b, true", uint32(code), wraps)
+	}
+
+	// A FACILITY_MSMQ value outside the list this package declares still renders as hex:
+	// the shared table has no row for the facility to fall back on.
+	if got := StatusString(0xC00E7FFF); got != "0xc00e7fff" {
+		t.Errorf("StatusString(0xc00e7fff) = %q, want 0xc00e7fff", got)
 	}
 	if got := StatusString(0xDEADBEEF); got != "0xdeadbeef" {
-		t.Fatalf("StatusString(unknown) = %s, want 0xdeadbeef", got)
+		t.Errorf("StatusString(0xdeadbeef) = %q, want 0xdeadbeef", got)
 	}
 }

--- a/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0/functions/01_R_QMGetRemoteQueueName.go
+++ b/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0/functions/01_R_QMGetRemoteQueueName.go
@@ -10,6 +10,7 @@ import (
 
 	qmcomm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 )
 
 // r_QMGetRemoteQueueNameRequest carries the [in] parameters of R_QMGetRemoteQueueName.
@@ -39,7 +40,7 @@ func R_QMGetRemoteQueueName(rpc ndr.Invoker, pQueue ndr.DWORD, lplpRemoteQueueNa
 		return
 	}
 	LplpRemoteQueueName = resp.LplpRemoteQueueName
-	if uint32(resp.Status) != qmcomm.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("R_QMGetRemoteQueueName failed: %s", qmcomm.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0/functions/02_R_QMOpenRemoteQueue.go
+++ b/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0/functions/02_R_QMOpenRemoteQueue.go
@@ -10,6 +10,7 @@ import (
 
 	qmcomm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	msmqmp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqmp"
 	msmqmq "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqmq"
@@ -56,7 +57,7 @@ func R_QMOpenRemoteQueue(rpc ndr.Invoker, pQueueFormat *msmqmq.QUEUE_FORMAT, dwC
 	PdwContext = resp.PdwContext
 	DwpQueue = resp.DwpQueue
 	PhQueue = resp.PhQueue
-	if uint32(resp.Status) != qmcomm.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("R_QMOpenRemoteQueue failed: %s", qmcomm.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0/functions/06_R_QMCreateObjectInternal.go
+++ b/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0/functions/06_R_QMCreateObjectInternal.go
@@ -10,6 +10,7 @@ import (
 
 	qmcomm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msmqmq "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqmq"
 )
 
@@ -48,7 +49,7 @@ func R_QMCreateObjectInternal(rpc ndr.Invoker, dwObjectType ndr.DWORD, lpwcsPath
 		err = fmt.Errorf("R_QMCreateObjectInternal: %w", err)
 		return
 	}
-	if uint32(resp.Status) != qmcomm.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("R_QMCreateObjectInternal failed: %s", qmcomm.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0/functions/07_R_QMSetObjectSecurityInternal.go
+++ b/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0/functions/07_R_QMSetObjectSecurityInternal.go
@@ -10,6 +10,7 @@ import (
 
 	qmcomm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msmqmp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqmp"
 )
 
@@ -44,7 +45,7 @@ func R_QMSetObjectSecurityInternal(rpc ndr.Invoker, pObjectFormat msmqmp.OBJECT_
 		err = fmt.Errorf("R_QMSetObjectSecurityInternal: %w", err)
 		return
 	}
-	if uint32(resp.Status) != qmcomm.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("R_QMSetObjectSecurityInternal failed: %s", qmcomm.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0/functions/08_R_QMGetObjectSecurityInternal.go
+++ b/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0/functions/08_R_QMGetObjectSecurityInternal.go
@@ -10,6 +10,7 @@ import (
 
 	qmcomm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msmqmp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqmp"
 )
 
@@ -46,7 +47,7 @@ func R_QMGetObjectSecurityInternal(rpc ndr.Invoker, pObjectFormat msmqmp.OBJECT_
 	}
 	PSecurityDescriptor = resp.PSecurityDescriptor
 	LpnLengthNeeded = resp.LpnLengthNeeded
-	if uint32(resp.Status) != qmcomm.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("R_QMGetObjectSecurityInternal failed: %s", qmcomm.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0/functions/09_R_QMDeleteObject.go
+++ b/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0/functions/09_R_QMDeleteObject.go
@@ -10,6 +10,7 @@ import (
 
 	qmcomm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msmqmp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqmp"
 )
 
@@ -36,7 +37,7 @@ func R_QMDeleteObject(rpc ndr.Invoker, pObjectFormat msmqmp.OBJECT_FORMAT) (err 
 		err = fmt.Errorf("R_QMDeleteObject: %w", err)
 		return
 	}
-	if uint32(resp.Status) != qmcomm.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("R_QMDeleteObject failed: %s", qmcomm.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0/functions/10_R_QMGetObjectProperties.go
+++ b/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0/functions/10_R_QMGetObjectProperties.go
@@ -10,6 +10,7 @@ import (
 
 	qmcomm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msmqmp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqmp"
 	msmqmq "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqmq"
 )
@@ -45,7 +46,7 @@ func R_QMGetObjectProperties(rpc ndr.Invoker, pObjectFormat msmqmp.OBJECT_FORMAT
 		return
 	}
 	ApVar = resp.ApVar
-	if uint32(resp.Status) != qmcomm.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("R_QMGetObjectProperties failed: %s", qmcomm.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0/functions/11_R_QMSetObjectProperties.go
+++ b/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0/functions/11_R_QMSetObjectProperties.go
@@ -10,6 +10,7 @@ import (
 
 	qmcomm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msmqmp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqmp"
 	msmqmq "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqmq"
 )
@@ -43,7 +44,7 @@ func R_QMSetObjectProperties(rpc ndr.Invoker, pObjectFormat msmqmp.OBJECT_FORMAT
 		err = fmt.Errorf("R_QMSetObjectProperties: %w", err)
 		return
 	}
-	if uint32(resp.Status) != qmcomm.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("R_QMSetObjectProperties failed: %s", qmcomm.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0/functions/12_R_QMObjectPathToObjectFormat.go
+++ b/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0/functions/12_R_QMObjectPathToObjectFormat.go
@@ -10,6 +10,7 @@ import (
 
 	qmcomm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msmqmp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqmp"
 )
 
@@ -42,7 +43,7 @@ func R_QMObjectPathToObjectFormat(rpc ndr.Invoker, lpwcsPathName ndr.WSTR, pObje
 		return
 	}
 	PObjectFormat = resp.PObjectFormat
-	if uint32(resp.Status) != qmcomm.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("R_QMObjectPathToObjectFormat failed: %s", qmcomm.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0/functions/14_R_QMGetTmWhereabouts.go
+++ b/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0/functions/14_R_QMGetTmWhereabouts.go
@@ -10,6 +10,7 @@ import (
 
 	qmcomm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 )
 
 // r_QMGetTmWhereaboutsRequest carries the [in] parameters of R_QMGetTmWhereabouts.
@@ -39,7 +40,7 @@ func R_QMGetTmWhereabouts(rpc ndr.Invoker, cbBufSize ndr.DWORD) (PbWhereabouts [
 	}
 	PbWhereabouts = resp.PbWhereabouts
 	PcbWhereabouts = resp.PcbWhereabouts
-	if uint32(resp.Status) != qmcomm.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("R_QMGetTmWhereabouts failed: %s", qmcomm.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0/functions/15_R_QMEnlistTransaction.go
+++ b/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0/functions/15_R_QMEnlistTransaction.go
@@ -10,6 +10,7 @@ import (
 
 	qmcomm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msmqmq "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqmq"
 )
 
@@ -40,7 +41,7 @@ func R_QMEnlistTransaction(rpc ndr.Invoker, pUow msmqmq.XACTUOW, cbCookie ndr.DW
 		err = fmt.Errorf("R_QMEnlistTransaction: %w", err)
 		return
 	}
-	if uint32(resp.Status) != qmcomm.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("R_QMEnlistTransaction failed: %s", qmcomm.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0/functions/16_R_QMEnlistInternalTransaction.go
+++ b/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0/functions/16_R_QMEnlistInternalTransaction.go
@@ -10,6 +10,7 @@ import (
 
 	qmcomm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msmqmp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqmp"
 	msmqmq "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqmq"
 )
@@ -41,7 +42,7 @@ func R_QMEnlistInternalTransaction(rpc ndr.Invoker, pUow msmqmq.XACTUOW) (PhIntX
 		return
 	}
 	PhIntXact = resp.PhIntXact
-	if uint32(resp.Status) != qmcomm.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("R_QMEnlistInternalTransaction failed: %s", qmcomm.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0/functions/17_R_QMCommitTransaction.go
+++ b/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0/functions/17_R_QMCommitTransaction.go
@@ -10,6 +10,7 @@ import (
 
 	qmcomm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msmqmp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqmp"
 )
 
@@ -38,7 +39,7 @@ func R_QMCommitTransaction(rpc ndr.Invoker, phIntXact msmqmp.RPC_INT_XACT_HANDLE
 		return
 	}
 	PhIntXact = resp.PhIntXact
-	if uint32(resp.Status) != qmcomm.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("R_QMCommitTransaction failed: %s", qmcomm.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0/functions/18_R_QMAbortTransaction.go
+++ b/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0/functions/18_R_QMAbortTransaction.go
@@ -10,6 +10,7 @@ import (
 
 	qmcomm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msmqmp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqmp"
 )
 
@@ -38,7 +39,7 @@ func R_QMAbortTransaction(rpc ndr.Invoker, phIntXact msmqmp.RPC_INT_XACT_HANDLE)
 		return
 	}
 	PhIntXact = resp.PhIntXact
-	if uint32(resp.Status) != qmcomm.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("R_QMAbortTransaction failed: %s", qmcomm.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0/functions/19_rpc_QMOpenQueueInternal.go
+++ b/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0/functions/19_rpc_QMOpenQueueInternal.go
@@ -10,6 +10,7 @@ import (
 
 	qmcomm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	msmqmp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqmp"
 	msmqmq "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqmq"
@@ -62,7 +63,7 @@ func Rpc_QMOpenQueueInternal(rpc ndr.Invoker, pQueueFormat msmqmq.QUEUE_FORMAT, 
 	LplpRemoteQueueName = resp.LplpRemoteQueueName
 	PdwQMContext = resp.PdwQMContext
 	PhQueue = resp.PhQueue
-	if uint32(resp.Status) != qmcomm.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("rpc_QMOpenQueueInternal failed: %s", qmcomm.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0/functions/20_rpc_ACCloseHandle.go
+++ b/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0/functions/20_rpc_ACCloseHandle.go
@@ -10,6 +10,7 @@ import (
 
 	qmcomm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msmqmp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqmp"
 )
 
@@ -38,7 +39,7 @@ func Rpc_ACCloseHandle(rpc ndr.Invoker, phQueue msmqmp.RPC_QUEUE_HANDLE) (PhQueu
 		return
 	}
 	PhQueue = resp.PhQueue
-	if uint32(resp.Status) != qmcomm.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("rpc_ACCloseHandle failed: %s", qmcomm.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0/functions/22_rpc_ACCloseCursor.go
+++ b/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0/functions/22_rpc_ACCloseCursor.go
@@ -10,6 +10,7 @@ import (
 
 	qmcomm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msmqmp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqmp"
 )
 
@@ -38,7 +39,7 @@ func Rpc_ACCloseCursor(rpc ndr.Invoker, hQueue msmqmp.RPC_QUEUE_HANDLE, hCursor 
 		err = fmt.Errorf("rpc_ACCloseCursor: %w", err)
 		return
 	}
-	if uint32(resp.Status) != qmcomm.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("rpc_ACCloseCursor failed: %s", qmcomm.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0/functions/23_rpc_ACSetCursorProperties.go
+++ b/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0/functions/23_rpc_ACSetCursorProperties.go
@@ -10,6 +10,7 @@ import (
 
 	qmcomm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msmqmp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqmp"
 )
 
@@ -40,7 +41,7 @@ func Rpc_ACSetCursorProperties(rpc ndr.Invoker, hProxy msmqmp.RPC_QUEUE_HANDLE, 
 		err = fmt.Errorf("rpc_ACSetCursorProperties: %w", err)
 		return
 	}
-	if uint32(resp.Status) != qmcomm.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("rpc_ACSetCursorProperties failed: %s", qmcomm.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0/functions/26_rpc_ACHandleToFormatName.go
+++ b/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0/functions/26_rpc_ACHandleToFormatName.go
@@ -10,6 +10,7 @@ import (
 
 	qmcomm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msmqmp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqmp"
 )
 
@@ -46,7 +47,7 @@ func Rpc_ACHandleToFormatName(rpc ndr.Invoker, hQueue msmqmp.RPC_QUEUE_HANDLE, d
 	}
 	LpwcsFormatName = resp.LpwcsFormatName
 	PdwLength = resp.PdwLength
-	if uint32(resp.Status) != qmcomm.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("rpc_ACHandleToFormatName failed: %s", qmcomm.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0/functions/27_rpc_ACPurgeQueue.go
+++ b/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0/functions/27_rpc_ACPurgeQueue.go
@@ -10,6 +10,7 @@ import (
 
 	qmcomm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msmqmp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqmp"
 )
 
@@ -36,7 +37,7 @@ func Rpc_ACPurgeQueue(rpc ndr.Invoker, hQueue msmqmp.RPC_QUEUE_HANDLE) (err erro
 		err = fmt.Errorf("rpc_ACPurgeQueue: %w", err)
 		return
 	}
-	if uint32(resp.Status) != qmcomm.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("rpc_ACPurgeQueue failed: %s", qmcomm.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0/functions/28_R_QMQueryQMRegistryInternal.go
+++ b/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0/functions/28_R_QMQueryQMRegistryInternal.go
@@ -10,6 +10,7 @@ import (
 
 	qmcomm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 )
 
 // r_QMQueryQMRegistryInternalRequest carries the [in] parameters of R_QMQueryQMRegistryInternal.
@@ -42,7 +43,7 @@ func R_QMQueryQMRegistryInternal(rpc ndr.Invoker, dwQueryType ndr.DWORD) (LplpMQ
 		return
 	}
 	LplpMQISServer = resp.LplpMQISServer
-	if uint32(resp.Status) != qmcomm.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("R_QMQueryQMRegistryInternal failed: %s", qmcomm.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0/interface.go
+++ b/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0/interface.go
@@ -12,9 +12,8 @@ package rpcinterface_fdb3a030065f11d1bb9b00a024ea5525_1_0
 // A fetched copy is kept at ms-mqmp.idl in the interface directory.
 
 import (
-	"fmt"
-
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	"github.com/TheManticoreProject/Manticore/windows/guid"
 )
 
@@ -57,11 +56,18 @@ const (
 // Status codes returned by this interface. Every qmcomm method returns an HRESULT (except
 // R_QMGetRTQMServerPort, which returns a port number); the values are the Message Queuing
 // result codes ([MS-MQMQ] 2.4, mqerror.h). Only the codes most relevant to queue-manager
-// operations are enumerated here; StatusString falls back to the hex value for any other
-// HRESULT.
+// operations are enumerated here.
+//
+// These are MQ_* values in FACILITY_MSMQ (0x00E), and that is why they stay declared here
+// instead of moving to github.com/TheManticoreProject/Manticore/windows/errors/hresult:
+// [MS-ERREF] section 2.1.1 does not carry that facility at all. Its 2928 values span 22
+// facilities and none of them is 0x00E; no name in the table begins with MQ_ and none
+// contains MSMQ. Routing MQ_ERROR_QUEUE_NOT_FOUND (0xC00E0003) through the shared table
+// would therefore render it as bare hex rather than name it.
+//
+// MQ_OK is the one value that does move. It is 0x00000000, which is S_OK, so the methods
+// compare against hresult.S_OK and no local success constant is declared here.
 const (
-	StatusSuccess uint32 = 0x00000000 // MQ_OK
-
 	MQ_ERROR                             uint32 = 0xC00E0001
 	MQ_ERROR_PROPERTY                    uint32 = 0xC00E0002
 	MQ_ERROR_QUEUE_NOT_FOUND             uint32 = 0xC00E0003
@@ -94,12 +100,16 @@ func SyntaxID() syntax.SyntaxID {
 	}
 }
 
-// StatusString returns a mnemonic for the documented status codes, otherwise the
-// hex value.
+// StatusString names the Message Queuing result codes of [MS-MQMQ] 2.4 that this interface
+// returns, whose FACILITY_MSMQ values [MS-ERREF] 2.1.1 does not carry, and defers every
+// other status to the shared [MS-ERREF] 2.1.1 table.
+//
+// That fall-through is correct despite the missing facility: an MSMQ status genuinely is an
+// HRESULT, with bit 31 as its severity and 0x00E in its facility field, so a value outside
+// the list below is decoded as the HRESULT it is and rendered as hex only where the
+// specification names nothing.
 func StatusString(status uint32) string {
 	switch status {
-	case StatusSuccess:
-		return "MQ_OK"
 	case MQ_ERROR:
 		return "MQ_ERROR"
 	case MQ_ERROR_PROPERTY:
@@ -141,7 +151,7 @@ func StatusString(status uint32) string {
 	case MQ_ERROR_TRANSACTION_ENLIST:
 		return "MQ_ERROR_TRANSACTION_ENLIST"
 	default:
-		return fmt.Sprintf("0x%08x", status)
+		return hresult.HRESULT(status).String()
 	}
 }
 

--- a/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0/interface_test.go
+++ b/network/dcerpc/interfaces/fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0/interface_test.go
@@ -1,6 +1,11 @@
 package rpcinterface_fdb3a030065f11d1bb9b00a024ea5525_1_0
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
+)
 
 // TestSyntaxID verifies the abstract syntax identity (UUID + version) of the qmcomm interface.
 func TestSyntaxID(t *testing.T) {
@@ -33,15 +38,111 @@ func TestOpnums(t *testing.T) {
 	}
 }
 
-// TestStatusString verifies mnemonic rendering and the hex fallback.
-func TestStatusString(t *testing.T) {
-	if got := StatusString(StatusSuccess); got != "MQ_OK" {
-		t.Fatalf("StatusString(StatusSuccess) = %s, want MQ_OK", got)
+// TestSuccessResolvesThroughHRESULT pins the one status value this package no longer
+// declares. MQ_OK is 0x00000000, which is S_OK, so the methods compare the retval against
+// hresult.S_OK and StatusString renders it out of the shared table.
+func TestSuccessResolvesThroughHRESULT(t *testing.T) {
+	if uint32(hresult.S_OK) != 0x00000000 {
+		t.Fatalf("hresult.S_OK = 0x%08x, want 0x00000000", uint32(hresult.S_OK))
 	}
-	if got := StatusString(MQ_ERROR_QUEUE_NOT_FOUND); got != "MQ_ERROR_QUEUE_NOT_FOUND" {
-		t.Fatalf("StatusString(MQ_ERROR_QUEUE_NOT_FOUND) = %s, want MQ_ERROR_QUEUE_NOT_FOUND", got)
+	if got := hresult.S_OK.String(); got != "S_OK" {
+		t.Errorf("hresult.S_OK.String() = %q, want S_OK", got)
+	}
+	if resolved, defined := hresult.FromName("S_OK"); !defined || resolved != hresult.S_OK {
+		t.Errorf("hresult.FromName(\"S_OK\") = 0x%08x, %v; want 0x00000000, true", uint32(resolved), defined)
+	}
+	if !hresult.S_OK.IsSuccess() || hresult.S_OK.Error() != nil {
+		t.Errorf("hresult.S_OK reports failure; MQ_OK is a success status")
+	}
+	if got := StatusString(uint32(hresult.S_OK)); got != "S_OK" {
+		t.Errorf("StatusString(0x00000000) = %q, want S_OK", got)
+	}
+}
+
+// TestStatusStringDecodesMSMQFacility pins the reason the MQ_* block stays declared in this
+// package: every one of these values sits in FACILITY_MSMQ (0x00E), a facility [MS-ERREF]
+// 2.1.1 does not carry at all, so the shared table resolves none of them. StatusString
+// names them and hresult.Lookup reports nothing for them; should a later pass route them
+// through the shared table, this fails instead of silently renaming a queue error.
+func TestStatusStringDecodesMSMQFacility(t *testing.T) {
+	msmq := map[uint32]string{
+		MQ_ERROR:                             "MQ_ERROR",
+		MQ_ERROR_PROPERTY:                    "MQ_ERROR_PROPERTY",
+		MQ_ERROR_QUEUE_NOT_FOUND:             "MQ_ERROR_QUEUE_NOT_FOUND",
+		MQ_ERROR_QUEUE_NOT_ACTIVE:            "MQ_ERROR_QUEUE_NOT_ACTIVE",
+		MQ_ERROR_QUEUE_EXISTS:                "MQ_ERROR_QUEUE_EXISTS",
+		MQ_ERROR_INVALID_PARAMETER:           "MQ_ERROR_INVALID_PARAMETER",
+		MQ_ERROR_INVALID_HANDLE:              "MQ_ERROR_INVALID_HANDLE",
+		MQ_ERROR_OPERATION_CANCELLED:         "MQ_ERROR_OPERATION_CANCELLED",
+		MQ_ERROR_SHARING_VIOLATION:           "MQ_ERROR_SHARING_VIOLATION",
+		MQ_ERROR_SERVICE_NOT_AVAILABLE:       "MQ_ERROR_SERVICE_NOT_AVAILABLE",
+		MQ_ERROR_NO_DS:                       "MQ_ERROR_NO_DS",
+		MQ_ERROR_ILLEGAL_QUEUE_PATHNAME:      "MQ_ERROR_ILLEGAL_QUEUE_PATHNAME",
+		MQ_ERROR_ILLEGAL_FORMATNAME:          "MQ_ERROR_ILLEGAL_FORMATNAME",
+		MQ_ERROR_FORMATNAME_BUFFER_TOO_SMALL: "MQ_ERROR_FORMATNAME_BUFFER_TOO_SMALL",
+		MQ_ERROR_ACCESS_DENIED:               "MQ_ERROR_ACCESS_DENIED",
+		MQ_ERROR_PRIVILEGE_NOT_HELD:          "MQ_ERROR_PRIVILEGE_NOT_HELD",
+		MQ_ERROR_INSUFFICIENT_RESOURCES:      "MQ_ERROR_INSUFFICIENT_RESOURCES",
+		MQ_ERROR_QUEUE_DELETED:               "MQ_ERROR_QUEUE_DELETED",
+		MQ_ERROR_TRANSACTION_USAGE:           "MQ_ERROR_TRANSACTION_USAGE",
+		MQ_ERROR_TRANSACTION_ENLIST:          "MQ_ERROR_TRANSACTION_ENLIST",
+	}
+	if len(msmq) != 20 {
+		t.Fatalf("MSMQ status table has %d entries, want 20", len(msmq))
+	}
+	for code, name := range msmq {
+		if got := StatusString(code); got != name {
+			t.Errorf("StatusString(0x%08x) = %q, want %q", code, got, name)
+		}
+		if facility := (code >> 16) & 0x07FF; facility != 0x00E {
+			t.Errorf("%s = 0x%08x, facility 0x%03x, want FACILITY_MSMQ 0x00E", name, code, facility)
+		}
+		if entry, defined := hresult.Lookup(hresult.HRESULT(code)); defined {
+			t.Errorf("hresult.Lookup(0x%08x) resolves to %q; [MS-ERREF] 2.1.1 carries no FACILITY_MSMQ row", code, entry.Name)
+		}
+		if _, defined := hresult.FromName(name); defined {
+			t.Errorf("hresult.FromName(%q) resolves; the code is declared in this package instead", name)
+		}
+		if hresult.HRESULT(code).IsSuccess() {
+			t.Errorf("%s = 0x%08x reports success; the MQ_ERROR_* values are failures", name, code)
+		}
+	}
+}
+
+// TestStatusStringFallsThroughToHRESULT shows what the fall-through buys. A generic HRESULT
+// the old switch never enumerated reached the caller as bare hex and now resolves by name,
+// including one the shared table derives through HRESULT_FROM_WIN32, while a value the
+// specification defines nowhere still renders as hex.
+func TestStatusStringFallsThroughToHRESULT(t *testing.T) {
+	generic := map[uint32]string{
+		0x80004005: "E_FAIL",
+		0x80070005: "E_ACCESSDENIED",
+		0x8007000E: "E_OUTOFMEMORY",
+	}
+	for code, name := range generic {
+		if got := StatusString(code); got != name {
+			t.Errorf("StatusString(0x%08x) = %q, want %q", code, got, name)
+		}
+	}
+
+	// A FACILITY_WIN32 code the table does not name is derived from the Win32 table.
+	wrapped := hresult.FromWin32(win32.ERROR_INVALID_NAME)
+	if uint32(wrapped) != 0x8007007B {
+		t.Fatalf("hresult.FromWin32(ERROR_INVALID_NAME) = 0x%08x, want 0x8007007b", uint32(wrapped))
+	}
+	if got := StatusString(uint32(wrapped)); got != "HRESULT_FROM_WIN32(ERROR_INVALID_NAME)" {
+		t.Errorf("StatusString(0x8007007b) = %q, want HRESULT_FROM_WIN32(ERROR_INVALID_NAME)", got)
+	}
+	if code, wraps := wrapped.ToWin32(); !wraps || code != win32.ERROR_INVALID_NAME {
+		t.Errorf("ToWin32() = 0x%08x, %v; want 0x0000007b, true", uint32(code), wraps)
+	}
+
+	// A FACILITY_MSMQ value outside the list this package declares still renders as hex:
+	// the shared table has no row for the facility to fall back on.
+	if got := StatusString(0xC00E7FFF); got != "0xc00e7fff" {
+		t.Errorf("StatusString(0xc00e7fff) = %q, want 0xc00e7fff", got)
 	}
 	if got := StatusString(0xDEADBEEF); got != "0xdeadbeef" {
-		t.Fatalf("StatusString(unknown) = %s, want 0xdeadbeef", got)
+		t.Errorf("StatusString(0xdeadbeef) = %q, want 0xdeadbeef", got)
 	}
 }


### PR DESCRIPTION
### Linked Issue
`Refs #1219`

The HRESULT phase, continued: `qmcomm` ([MS-MQMP]) and `dscomm` ([MS-MQDS]), both **partial** retirements on the model of the fax interface in 73256f1.

### Root Cause
Both descriptors carried a private table of Message Queuing result codes and a `StatusString` switch over it — 21 constants in `qmcomm`, 17 in `dscomm` — with the switch falling through to `fmt.Sprintf("0x%08x", status)`. The fall-through is the defect: the enumerated subset was a ceiling rather than a convenience, so any HRESULT the list happened to omit reached the caller undecoded. A method failing with `E_FAIL` or with anything the shared table derives through `HRESULT_FROM_WIN32` produced bare hex where the table names it.

**The interesting half of the root cause is what the shared table cannot do.** `FACILITY_MSMQ` (`0x00E`) has **zero rows in the whole of [MS-ERREF] 2.1.1**. All 2928 rows of `windows/errors/errgen/ms-erref-2.1.1-hresult.tsv` were checked by value: the facility field `0x00E` appears in none of them, no name begins with `MQ_`, and none contains `MSMQ`. The 22 facilities the table does carry are `0x000`–`0x004`, `0x007`–`0x009`, `0x00B`, `0x00D`, `0x00F`–`0x011`, `0x01F`, `0x026`, `0x028`, `0x029`, `0x030`–`0x032`, `0x034` and a stray `0x5EA`; Message Queuing is simply not among them. So the `0xC00E____` constants in these two interfaces are not merely unmigrated — they are unmigratable, and routing them through the shared table would replace `MQ_ERROR_QUEUE_NOT_FOUND` with `0xc00e0003` in every log line that carries it.

### Fix Description
Each interface keeps its `MQ_ERROR_*` block, with a comment in `interface.go` recording that these are `MQ_*` values in `FACILITY_MSMQ` and that [MS-ERREF] 2.1.1 does not carry that facility at all, so the next pass over these interfaces does not repeat the lookup. `StatusString` survives in reduced form over exactly those retained codes and defers everything else to `hresult.HRESULT(status).String()`.

That fall-through is correct despite the missing facility, and the comment says why: an MSMQ status genuinely *is* an HRESULT — bit 31 is its severity and `0x00E` sits in its facility field — so a status outside the retained list is decoded as the HRESULT it is, and only the facility is what the table omits. A generic value now names itself; a `FACILITY_MSMQ` value outside the list still renders as hex, because there is no row to fall back on.

Every judgement was derived **from the value, not the name**, against `ms-erref-2.1.1-hresult.tsv`. The full mapping, per interface:

**A) `qmcomm` — `fdb3a030-065f-11d1-bb9b-00a024ea5525/1.0` ([MS-MQMP])**

| value | private name | shared-table name | outcome |
|---|---|---|---|
| `0x00000000` | `StatusSuccess` (`MQ_OK`) | `S_OK` (`wellknown.go`) | **migrated** → `hresult.S_OK` |
| `0xC00E0001` | `MQ_ERROR` | *no row* | retained |
| `0xC00E0002` | `MQ_ERROR_PROPERTY` | *no row* | retained |
| `0xC00E0003` | `MQ_ERROR_QUEUE_NOT_FOUND` | *no row* | retained |
| `0xC00E0004` | `MQ_ERROR_QUEUE_NOT_ACTIVE` | *no row* | retained |
| `0xC00E0005` | `MQ_ERROR_QUEUE_EXISTS` | *no row* | retained |
| `0xC00E0006` | `MQ_ERROR_INVALID_PARAMETER` | *no row* | retained |
| `0xC00E0007` | `MQ_ERROR_INVALID_HANDLE` | *no row* | retained |
| `0xC00E0008` | `MQ_ERROR_OPERATION_CANCELLED` | *no row* | retained |
| `0xC00E0009` | `MQ_ERROR_SHARING_VIOLATION` | *no row* | retained |
| `0xC00E000B` | `MQ_ERROR_SERVICE_NOT_AVAILABLE` | *no row* | retained |
| `0xC00E0013` | `MQ_ERROR_NO_DS` | *no row* | retained |
| `0xC00E0014` | `MQ_ERROR_ILLEGAL_QUEUE_PATHNAME` | *no row* | retained |
| `0xC00E001E` | `MQ_ERROR_ILLEGAL_FORMATNAME` | *no row* | retained |
| `0xC00E001F` | `MQ_ERROR_FORMATNAME_BUFFER_TOO_SMALL` | *no row* | retained |
| `0xC00E0025` | `MQ_ERROR_ACCESS_DENIED` | *no row* | retained |
| `0xC00E0026` | `MQ_ERROR_PRIVILEGE_NOT_HELD` | *no row* | retained |
| `0xC00E0027` | `MQ_ERROR_INSUFFICIENT_RESOURCES` | *no row* | retained |
| `0xC00E002E` | `MQ_ERROR_QUEUE_DELETED` | *no row* | retained |
| `0xC00E0050` | `MQ_ERROR_TRANSACTION_USAGE` | *no row* | retained |
| `0xC00E0058` | `MQ_ERROR_TRANSACTION_ENLIST` | *no row* | retained |

One of 21 migrates. The 21 methods that check a retval now compare `hresult.HRESULT(resp.Status)` against `hresult.S_OK`; three of the 24 files in `functions/` check no status (`03_R_QMCloseRemoteQueueContext`, `04_R_QMCreateRemoteCursor`, and `31_R_QMGetRTQMServerPort`, which returns a port number rather than an HRESULT) and are untouched.

**B) `dscomm` — `77df7a80-f298-11d0-8358-00a024c480a8/1.0` ([MS-MQDS])**

| value | private name | shared-table name | outcome |
|---|---|---|---|
| `0x00000000` | `StatusSuccess` (`MQ_OK`) | `S_OK` (`wellknown.go`) | **migrated** → `hresult.S_OK` |
| `0xC00E0001` | `MQ_ERROR` | *no row* | retained |
| `0xC00E0002` | `MQ_ERROR_PROPERTY` | *no row* | retained |
| `0xC00E0003` | `MQ_ERROR_QUEUE_NOT_FOUND` | *no row* | retained |
| `0xC00E0005` | `MQ_ERROR_QUEUE_EXISTS` | *no row* | retained |
| `0xC00E0006` | `MQ_ERROR_INVALID_PARAMETER` | *no row* | retained |
| `0xC00E0007` | `MQ_ERROR_INVALID_HANDLE` | *no row* | retained |
| `0xC00E0013` | `MQ_ERROR_NO_DS` | *no row* | retained |
| `0xC00E0014` | `MQ_ERROR_ILLEGAL_QUEUE_PATHNAME` | *no row* | retained |
| `0xC00E0025` | `MQ_ERROR_ACCESS_DENIED` | *no row* | retained |
| `0xC00E0038` | `MQ_ERROR_ILLEGAL_MQCOLUMNS` | *no row* | retained |
| `0xC00E0039` | `MQ_ERROR_ILLEGAL_PROPID` | *no row* | retained |
| `0xC00E003A` | `MQ_ERROR_ILLEGAL_RELATION` | *no row* | retained |
| `0xC00E003C` | `MQ_ERROR_ILLEGAL_PROPERTY_VALUE` | *no row* | retained |
| `0xC00E003E` | `MQ_ERROR_ILLEGAL_RESTRICTION_PROPID` | *no row* | retained |
| `0xC00E0043` | `MQ_ERROR_DS_ERROR` | *no row* | retained |
| `0xC00E0055` | `MQ_ERROR_ILLEGAL_SORT_PROPID` | *no row* | retained |

One of 17 migrates. The 19 methods that check a retval now compare against `hresult.S_OK`; `27_S_DSGetServerPort` returns a port number and is untouched.

**Behaviour is preserved exactly where it could have been "fixed".** The old comparison treated anything other than `0x00000000` as a failure, which for an HRESULT is stricter than the specification's rule that bit 31 clear means success — so a success-severity `MQ_INFORMATION_*` value in `0x400E____` would be reported as an error. The comparison shape is kept as `!= hresult.S_OK` rather than widened to `IsSuccess()`. This is a status-reporting change; which statuses a method tolerates is a separate question and does not belong here. Neither interface declared an `MQ_INFORMATION_*` value, so nothing is affected in practice, and this is recorded in both commit messages.

### How Verified
- **Runtime:** `go build ./...` clean, `go vet ./...` clean, `go test -count=1 ./...` — **315 packages ok, 0 failures**, matching `main`'s 315.
- **Runtime:** cross-compiled `CGO_ENABLED=0` for the CI matrix — `windows/amd64`, `windows/386`, `linux/arm64`, `linux/386`, all exit 0.
- **Static — the absent facility, established rather than assumed:** a script parsed all 2928 TSV rows and reported `facility 0x00E rows: 0`, `names starting MQ_: []`, `names containing MSMQ: []`, and then looked up each of the 38 constants by value — every `0xC00E____` came back `NOT IN TABLE`, and `0x00000000` came back absent from the generated table (it lives in `wellknown.go`, which is why `hresult.S_OK` resolves).
- **Static — per-comparison-term parity:** the rewrite substituted the left operand `uint32(resp.Status)` and the right operand `<alias>.StatusSuccess` independently, never the condition as a unit — 42 operand substitutions across 21 `qmcomm` files, 38 across 19 `dscomm` files. A script then compared the ordered per-`if` comparison-term count of **every** file in each `functions/` directory against the parent revision: 24 of 24 identical for `qmcomm`, 20 of 20 for `dscomm`, 0 mismatches. A dropped term compiles cleanly, so the count is the check.
- **Static — structural survivors:** grepped after the edit. `PipeName`, `SyntaxID()`, `StatusString`, `OpnumToName` and `NameToOpnum` are present in both `interface.go` files; the opnum constants and map entries count 24+24 for `qmcomm` and 20+20 for `dscomm`; the retained `MQ_` constants count 20 and 16; `StatusSuccess` appears nowhere in either interface tree.
- **Static — out-of-directory consumers:** grepped the tree for both import paths and for every constant name. Neither interface has a consumer outside its own directory — nothing in `network/dcerpc/ms-protocols/`, nothing in `network/smb/smb_v10/server/rpcpipe/`, and `windows/protocols/ms-mqmp`, `ms-mqds` and `ms-mqmq` reference neither `StatusString` nor `StatusSuccess` (they hold the wire structures and the shared `PROPVARIANT` types, not status handling). `Contains`/`HasPrefix` against `"MQ_"` or `"0xC00E"` occurs nowhere in the repository. The remaining `MQ_*` hits belong to the sibling MSMQ interfaces, which are out of scope for this PR and untouched.
- **Static — imports:** each `functions/` import block was reconstructed rather than appended to, and the stdlib/project blank line was audited afterwards by counting group separators: 24 of 24 blocks in `qmcomm` and 20 of 20 in `dscomm` still carry it. `gofmt` does not restore that line once collapsed, so `gofmt -l` alone would not have caught its loss.
- **Static — formatting:** `gofmt -l` over both interface directories was empty **before** any edit, so every file was clean on `main`; it is empty again after. No file outside the 44 changed was reformatted.

### Test Coverage
`TestStatusString` is replaced in each interface by three tests. `TestOpnums` and `TestSyntaxID` are unchanged.

**Added** — `TestSuccessResolvesThroughHRESULT`: pins the one migrated value. `hresult.S_OK` is `0x00000000`, renders as `S_OK`, resolves in both directions through `FromName`, reports `IsSuccess()` true and `Error()` nil, and `StatusString(0)` renders it out of the shared table.

**Added** — `TestStatusStringDecodesMSMQFacility`: the regression test against a future pass routing these codes through the shared table. For each of the 20 (`qmcomm`) / 16 (`dscomm`) retained codes it asserts that `StatusString` still renders the MSMQ name, that the facility field really is `0x00E`, that **`hresult.Lookup` reports nothing** for it, that `hresult.FromName` does not resolve its name, and that it is failure-severity. Should someone fold the block into the shared table, this fails loudly instead of silently renaming a queue error.

**Added** — `TestStatusStringFallsThroughToHRESULT`: exercises what the fall-through buys. `E_FAIL`, `E_ACCESSDENIED` and `E_OUTOFMEMORY` resolve by name through `StatusString` where they previously rendered as hex; `hresult.FromWin32(win32.ERROR_INVALID_NAME)` is checked to be `0x8007007B`, to render as `HRESULT_FROM_WIN32(ERROR_INVALID_NAME)`, and to unwrap through `ToWin32()`; and a `FACILITY_MSMQ` value outside the retained list (`0xC00E7FFF`) plus an undefined value (`0xDEADBEEF`) still render as hex.

### Scope of Change
- **Files changed:** 44, all inside the two interface directories, in two commits.
  - `qmcomm` (23): `interface.go`, `interface_test.go`, and 21 of the 24 files in `functions/`.
  - `dscomm` (21): `interface.go`, `interface_test.go`, and 19 of the 20 files in `functions/`.
- **Constants removed:** exactly one per interface — `StatusSuccess`. Nothing structural was touched; the `MQ_ERROR_*` blocks, opnums, opnum maps, `PipeName` and `SyntaxID()` all survive, verified by grep.
- **Submodule pointer updated:** no.
- **Behavioral changes outside the status reporting:** none. The one rendering change is deliberate: `StatusString(0)` now returns `"S_OK"` rather than `"MQ_OK"`, which is the shared table's name for that value.

### Risk and Rollout
Low. The only semantic edit is a comparison against a constant of identical value — `hresult.S_OK` is `0x00000000`, exactly what `StatusSuccess` was — so no method's success/failure decision changes for any status. Everything else is naming: statuses outside the retained lists render better, and statuses inside them render as they did. No caller outside the two directories exists, so the surface is closed. Reverting either commit is independent of the other.

### Notes
**For the sibling MSMQ interfaces** — `76d12b80-…`, `1088a980-…` (`MS-MQQP`), `708cca10-…`, `41208ee0-…` (`MS-MQMR`) and `1a9134dd-…` — the finding generalises and can be reused without re-deriving it: the entire `MQ_*` space is `FACILITY_MSMQ` and **`FACILITY_MSMQ` has zero rows in [MS-ERREF] 2.1.1**, so every `0xC00E____` constant in those descriptors stays local, and by the same argument every `0x400E____` (`MQ_INFORMATION_*`) would too. Each of those interfaces is a partial retirement of exactly the same shape: `StatusSuccess`/`MQ_OK` is `0x00000000` and migrates to `hresult.S_OK`; the `MQ_ERROR_*` block stays with a comment; `StatusString` reduces and falls through to `hresult.HRESULT(status).String()`. All five additionally have a `TestStatusString` asserting `StatusString(StatusSuccess) == "MQ_OK"`, which stops compiling once `StatusSuccess` is deleted — that test needs replacing, not adapting.

No interface under `network/dcerpc/interfaces/` currently declares an `MQ_INFORMATION_*` value or any `0x400E____` constant — grepped. Should one turn up, note that a `!= StatusSuccess` comparison treats it as a failure even though bit 31 is clear: worth reporting, not silently correcting inside a status-reporting change.

Not done here and not proposed: an `msmq` package under `windows/errors/` for the `MQ_*` space. It would be a real table rather than a per-interface subset, but its source is `mqerror.h` and [MS-MQMQ] 2.4 rather than [MS-ERREF], so it is a different exercise from #1219 and should be argued on its own.
