### PR TITLE
Route RemoteRead, qm2qm and dscomm2 status reporting through hresult

### DIFF
--- a/network/dcerpc/interfaces/1088a980-eae5-11d0-8d9b-00a02453c337/1.0/functions/00_RemoteQMStartReceive.go
+++ b/network/dcerpc/interfaces/1088a980-eae5-11d0-8d9b-00a02453c337/1.0/functions/00_RemoteQMStartReceive.go
@@ -10,6 +10,7 @@ import (
 
 	qm2qm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/1088a980-eae5-11d0-8d9b-00a02453c337/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msmqqp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqqp"
 )
 
@@ -39,7 +40,7 @@ func RemoteQMStartReceive(rpc ndr.Invoker, lpRemoteReadDesc msmqqp.REMOTEREADDES
 	}
 	PphContext = resp.PphContext
 	LpRemoteReadDesc = resp.LpRemoteReadDesc
-	if uint32(resp.Status) != qm2qm.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("RemoteQMStartReceive failed: %s", qm2qm.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/1088a980-eae5-11d0-8d9b-00a02453c337/1.0/functions/01_RemoteQMEndReceive.go
+++ b/network/dcerpc/interfaces/1088a980-eae5-11d0-8d9b-00a02453c337/1.0/functions/01_RemoteQMEndReceive.go
@@ -10,6 +10,7 @@ import (
 
 	qm2qm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/1088a980-eae5-11d0-8d9b-00a02453c337/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msmqqp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqqp"
 )
 
@@ -39,7 +40,7 @@ func RemoteQMEndReceive(rpc ndr.Invoker, pphContext msmqqp.PCTX_REMOTEREAD_HANDL
 		return
 	}
 	PphContext = resp.PphContext
-	if uint32(resp.Status) != qm2qm.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("RemoteQMEndReceive failed: %s", qm2qm.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/1088a980-eae5-11d0-8d9b-00a02453c337/1.0/functions/02_RemoteQMOpenQueue.go
+++ b/network/dcerpc/interfaces/1088a980-eae5-11d0-8d9b-00a02453c337/1.0/functions/02_RemoteQMOpenQueue.go
@@ -10,6 +10,7 @@ import (
 
 	qm2qm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/1088a980-eae5-11d0-8d9b-00a02453c337/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	"github.com/TheManticoreProject/Manticore/windows/guid"
 	msmqqp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqqp"
 )
@@ -46,7 +47,7 @@ func RemoteQMOpenQueue(rpc ndr.Invoker, pLicGuid guid.GUID, dwMQS ndr.DWORD, hQu
 		return
 	}
 	PhContext = resp.PhContext
-	if uint32(resp.Status) != qm2qm.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("RemoteQMOpenQueue failed: %s", qm2qm.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/1088a980-eae5-11d0-8d9b-00a02453c337/1.0/functions/03_RemoteQMCloseQueue.go
+++ b/network/dcerpc/interfaces/1088a980-eae5-11d0-8d9b-00a02453c337/1.0/functions/03_RemoteQMCloseQueue.go
@@ -10,6 +10,7 @@ import (
 
 	qm2qm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/1088a980-eae5-11d0-8d9b-00a02453c337/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msmqqp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqqp"
 )
 
@@ -37,7 +38,7 @@ func RemoteQMCloseQueue(rpc ndr.Invoker, pphContext msmqqp.PCTX_RRSESSION_HANDLE
 		return
 	}
 	PphContext = resp.PphContext
-	if uint32(resp.Status) != qm2qm.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("RemoteQMCloseQueue failed: %s", qm2qm.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/1088a980-eae5-11d0-8d9b-00a02453c337/1.0/functions/04_RemoteQMCloseCursor.go
+++ b/network/dcerpc/interfaces/1088a980-eae5-11d0-8d9b-00a02453c337/1.0/functions/04_RemoteQMCloseCursor.go
@@ -10,6 +10,7 @@ import (
 
 	qm2qm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/1088a980-eae5-11d0-8d9b-00a02453c337/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 )
 
 // remoteQMCloseCursorRequest carries the [in] parameters of RemoteQMCloseCursor.
@@ -36,7 +37,7 @@ func RemoteQMCloseCursor(rpc ndr.Invoker, hQueue ndr.DWORD, hCursor ndr.DWORD) (
 		err = fmt.Errorf("RemoteQMCloseCursor: %w", err)
 		return
 	}
-	if uint32(resp.Status) != qm2qm.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("RemoteQMCloseCursor failed: %s", qm2qm.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/1088a980-eae5-11d0-8d9b-00a02453c337/1.0/functions/05_RemoteQMCancelReceive.go
+++ b/network/dcerpc/interfaces/1088a980-eae5-11d0-8d9b-00a02453c337/1.0/functions/05_RemoteQMCancelReceive.go
@@ -10,6 +10,7 @@ import (
 
 	qm2qm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/1088a980-eae5-11d0-8d9b-00a02453c337/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 )
 
 // remoteQMCancelReceiveRequest carries the [in] parameters of RemoteQMCancelReceive.
@@ -38,7 +39,7 @@ func RemoteQMCancelReceive(rpc ndr.Invoker, hQueue ndr.DWORD, pQueue ndr.DWORD, 
 		err = fmt.Errorf("RemoteQMCancelReceive: %w", err)
 		return
 	}
-	if uint32(resp.Status) != qm2qm.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("RemoteQMCancelReceive failed: %s", qm2qm.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/1088a980-eae5-11d0-8d9b-00a02453c337/1.0/functions/06_RemoteQMPurgeQueue.go
+++ b/network/dcerpc/interfaces/1088a980-eae5-11d0-8d9b-00a02453c337/1.0/functions/06_RemoteQMPurgeQueue.go
@@ -10,6 +10,7 @@ import (
 
 	qm2qm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/1088a980-eae5-11d0-8d9b-00a02453c337/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 )
 
 // remoteQMPurgeQueueRequest carries the [in] parameters of RemoteQMPurgeQueue.
@@ -34,7 +35,7 @@ func RemoteQMPurgeQueue(rpc ndr.Invoker, hQueue ndr.DWORD) (err error) {
 		err = fmt.Errorf("RemoteQMPurgeQueue: %w", err)
 		return
 	}
-	if uint32(resp.Status) != qm2qm.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("RemoteQMPurgeQueue failed: %s", qm2qm.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/1088a980-eae5-11d0-8d9b-00a02453c337/1.0/functions/09_RemoteQMStartReceive2.go
+++ b/network/dcerpc/interfaces/1088a980-eae5-11d0-8d9b-00a02453c337/1.0/functions/09_RemoteQMStartReceive2.go
@@ -10,6 +10,7 @@ import (
 
 	qm2qm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/1088a980-eae5-11d0-8d9b-00a02453c337/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msmqqp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqqp"
 )
 
@@ -39,7 +40,7 @@ func RemoteQMStartReceive2(rpc ndr.Invoker, lpRemoteReadDesc2 msmqqp.REMOTEREADD
 	}
 	PphContext = resp.PphContext
 	LpRemoteReadDesc2 = resp.LpRemoteReadDesc2
-	if uint32(resp.Status) != qm2qm.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("RemoteQMStartReceive2 failed: %s", qm2qm.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/1088a980-eae5-11d0-8d9b-00a02453c337/1.0/functions/10_RemoteQMStartReceiveByLookupId.go
+++ b/network/dcerpc/interfaces/1088a980-eae5-11d0-8d9b-00a02453c337/1.0/functions/10_RemoteQMStartReceiveByLookupId.go
@@ -10,6 +10,7 @@ import (
 
 	qm2qm "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/1088a980-eae5-11d0-8d9b-00a02453c337/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msmqqp "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqqp"
 )
 
@@ -43,7 +44,7 @@ func RemoteQMStartReceiveByLookupId(rpc ndr.Invoker, lookupId uint64, lpRemoteRe
 	}
 	PphContext = resp.PphContext
 	LpRemoteReadDesc2 = resp.LpRemoteReadDesc2
-	if uint32(resp.Status) != qm2qm.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("RemoteQMStartReceiveByLookupId failed: %s", qm2qm.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/1088a980-eae5-11d0-8d9b-00a02453c337/1.0/interface.go
+++ b/network/dcerpc/interfaces/1088a980-eae5-11d0-8d9b-00a02453c337/1.0/interface.go
@@ -12,9 +12,8 @@ package rpcinterface_1088a980eae511d08d9b00a02453c337_1_0
 // A fetched copy is kept at ms-mqqp.idl in the interface directory.
 
 import (
-	"fmt"
-
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	"github.com/TheManticoreProject/Manticore/windows/guid"
 )
 
@@ -40,18 +39,35 @@ const (
 	OpnumRemoteQMStartReceiveByLookupId uint16 = 10
 )
 
-// Status codes returned by the HRESULT-returning methods of this interface. The values are
-// the Message Queuing result codes ([MS-MQMQ] 2.4, mqerror.h), plus the one NTSTATUS the
-// spec cites directly. MQ_OK is success; per [MS-MQQP] 3.1.4.x the client MUST treat every
-// failure HRESULT identically. Only the codes the [MS-MQQP] method sections enumerate are
-// listed here; StatusString falls back to the hex value for any other code.
+// Status codes returned by the HRESULT-returning methods of this interface. Most are the
+// Message Queuing result codes ([MS-MQMQ] 2.4, mqerror.h). They are HRESULTs in
+// FACILITY_MSMQ (0x00E), and [MS-ERREF] section 2.1.1 carries no row for that facility at
+// all: the table names nothing in 0xC00E____ or 0x400E____ and no value whose name begins
+// MQ_. So none of them can be read out of
+// github.com/TheManticoreProject/Manticore/windows/errors/hresult, and they stay declared
+// here, decoded by StatusString before it defers to the shared table.
+//
+// MQ_OK is gone from this block: its value is 0x00000000, which the shared package declares
+// as hresult.S_OK, so the stubs compare a returned status against that constant. They
+// compare for equality with it rather than testing IsSuccess, which preserves the behaviour
+// they have always had — [MS-MQQP] 3.1.4.x documents MQ_OK as the success value and requires
+// the client to treat every failure identically, so a success-severity value that is not
+// MQ_OK, such as one of the MQ_INFORMATION_* codes in 0x400E____, is still reported as a
+// failure.
+//
+// STATUS_INVALID_PARAMETER stays for a second, unrelated reason: it is not an HRESULT at all
+// but the NTSTATUS 0xC000000D that [MS-MQQP] cites directly, and [MS-ERREF] section 2.3.1 is
+// the table that names it. Read as an HRESULT the same value is FACILITY_NULL code 0x000D,
+// which [MS-ERREF] 2.1.1 does not define, so deferring it to the shared HRESULT table would
+// render it as bare hex; the local arm keeps naming it.
+//
+// Only the codes the [MS-MQQP] method sections enumerate are listed here; StatusString
+// defers every other value to the shared HRESULT table.
 //
 // Note the two exceptions among the opnums: RemoteQMGetQMQMServerPort (opnum 7) does NOT
 // return an HRESULT — its DWORD result is a TCP/SPX port, with 0x00000000 signalling failure
 // — and RemoteQmGetVersion (opnum 8) has no return value at all.
 const (
-	StatusSuccess uint32 = 0x00000000 // MQ_OK
-
 	MQ_ERROR                   uint32 = 0xC00E0001
 	MQ_ERROR_INVALID_PARAMETER uint32 = 0xC00E0006
 	MQ_ERROR_INVALID_HANDLE    uint32 = 0xC00E0007
@@ -70,12 +86,14 @@ func SyntaxID() syntax.SyntaxID {
 	}
 }
 
-// StatusString returns a mnemonic for the documented status codes, otherwise the
-// hex value.
+// StatusString names the FACILITY_MSMQ result codes above, which [MS-ERREF] section 2.1.1
+// does not carry, along with the one NTSTATUS the specification cites, and defers every other
+// status to the shared HRESULT table. The deferral is correct because an MSMQ result code
+// genuinely is an HRESULT and only its facility is absent from the specification's table:
+// 0x00000000 renders as S_OK, a FACILITY_WIN32 value renders through the Win32 code it wraps,
+// and a value the table does not define renders as hex, exactly as it did before.
 func StatusString(status uint32) string {
 	switch status {
-	case StatusSuccess:
-		return "MQ_OK"
 	case MQ_ERROR:
 		return "MQ_ERROR"
 	case MQ_ERROR_INVALID_PARAMETER:
@@ -87,7 +105,7 @@ func StatusString(status uint32) string {
 	case STATUS_INVALID_PARAMETER:
 		return "STATUS_INVALID_PARAMETER"
 	default:
-		return fmt.Sprintf("0x%08x", status)
+		return hresult.HRESULT(status).String()
 	}
 }
 

--- a/network/dcerpc/interfaces/1088a980-eae5-11d0-8d9b-00a02453c337/1.0/interface_test.go
+++ b/network/dcerpc/interfaces/1088a980-eae5-11d0-8d9b-00a02453c337/1.0/interface_test.go
@@ -1,6 +1,12 @@
 package rpcinterface_1088a980eae511d08d9b00a02453c337_1_0
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
+	"github.com/TheManticoreProject/Manticore/windows/errors/nt_status"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
+)
 
 // TestSyntaxID verifies the abstract syntax identity (UUID + version) of the qm2qm interface.
 func TestSyntaxID(t *testing.T) {
@@ -36,18 +42,99 @@ func TestOpnums(t *testing.T) {
 	}
 }
 
-// TestStatusString verifies mnemonic rendering and the hex fallback.
-func TestStatusString(t *testing.T) {
-	if got := StatusString(StatusSuccess); got != "MQ_OK" {
-		t.Fatalf("StatusString(StatusSuccess) = %s, want MQ_OK", got)
+// TestStatusStringKeepsMSMQFacilityAndDefersTheRest pins both halves of the split. MQ_OK
+// left this package: it is 0x00000000, the value the shared HRESULT package declares as
+// S_OK, so it resolves there and the stubs compare against that constant. The MQ_ERROR_*
+// codes could not leave: they are HRESULTs in FACILITY_MSMQ (0x00E), a facility for which
+// [MS-ERREF] section 2.1.1 carries no row, so hresult.Lookup reports nothing for any of
+// them and StatusString must name them itself.
+func TestStatusStringKeepsMSMQFacilityAndDefersTheRest(t *testing.T) {
+	if hresult.S_OK != 0x00000000 {
+		t.Fatalf("hresult.S_OK = 0x%08x, want 0x00000000 (the value MQ_OK had)", uint32(hresult.S_OK))
 	}
-	if got := StatusString(MQ_ERROR_INVALID_HANDLE); got != "MQ_ERROR_INVALID_HANDLE" {
-		t.Fatalf("StatusString(MQ_ERROR_INVALID_HANDLE) = %s, want MQ_ERROR_INVALID_HANDLE", got)
+	if got := hresult.S_OK.String(); got != "S_OK" {
+		t.Errorf("hresult.S_OK.String() = %q, want S_OK", got)
+	}
+	if err := hresult.S_OK.Error(); err != nil {
+		t.Errorf("hresult.S_OK.Error() = %v, want nil", err)
+	}
+	if got := StatusString(uint32(hresult.S_OK)); got != "S_OK" {
+		t.Errorf("StatusString(0x00000000) = %q, want S_OK", got)
+	}
+
+	retained := map[uint32]string{
+		MQ_ERROR:                   "MQ_ERROR",
+		MQ_ERROR_INVALID_PARAMETER: "MQ_ERROR_INVALID_PARAMETER",
+		MQ_ERROR_INVALID_HANDLE:    "MQ_ERROR_INVALID_HANDLE",
+		MQ_ERROR_IO_TIMEOUT:        "MQ_ERROR_IO_TIMEOUT",
+	}
+	if len(retained) != 4 {
+		t.Fatalf("retained table has %d entries, want 4", len(retained))
+	}
+	for code, name := range retained {
+		if got := StatusString(code); got != name {
+			t.Errorf("StatusString(0x%08x) = %q, want %q", code, got, name)
+		}
+		if facility := (code >> 16) & 0x07FF; facility != 0x00E {
+			t.Errorf("%s = 0x%08x, facility 0x%03x, want FACILITY_MSMQ (0x00E)", name, code, facility)
+		}
+		if entry, defined := hresult.Lookup(hresult.HRESULT(code)); defined {
+			t.Errorf("hresult.Lookup(0x%08x) resolves to %q; the code belongs in the shared table instead", code, entry.Name)
+		}
+		if hresult.HRESULT(code).IsSuccess() {
+			t.Errorf("%s = 0x%08x reports success, want failure severity", name, code)
+		}
+	}
+
+	// The fallthrough is the gain: a generic HRESULT this interface never enumerated used to
+	// render as undecoded hex and now resolves by name.
+	if got := StatusString(0x80004005); got != "E_FAIL" {
+		t.Errorf("StatusString(0x80004005) = %q, want E_FAIL", got)
+	}
+	if got := StatusString(0x80070005); got != "E_ACCESSDENIED" {
+		t.Errorf("StatusString(0x80070005) = %q, want E_ACCESSDENIED", got)
+	}
+
+	// So does a FACILITY_WIN32 value the specification's table does not name, which resolves
+	// through the Win32 code it wraps.
+	wrapped := hresult.FromWin32(win32.ERROR_FILE_NOT_FOUND)
+	if uint32(wrapped) != 0x80070002 {
+		t.Fatalf("hresult.FromWin32(ERROR_FILE_NOT_FOUND) = 0x%08x, want 0x80070002", uint32(wrapped))
+	}
+	if code, wraps := wrapped.ToWin32(); !wraps || code != win32.ERROR_FILE_NOT_FOUND {
+		t.Errorf("ToWin32() = 0x%08x, %v; want 0x%08x, true", uint32(code), wraps, uint32(win32.ERROR_FILE_NOT_FOUND))
+	}
+	if got := StatusString(uint32(wrapped)); got != "HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND)" {
+		t.Errorf("StatusString(0x80070002) = %q, want HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND)", got)
+	}
+
+	// A value neither table defines still renders as hex, as it always did.
+	if got := StatusString(0xDEADBEEF); got != "0xdeadbeef" {
+		t.Errorf("StatusString(0xdeadbeef) = %q, want 0xdeadbeef", got)
+	}
+}
+
+// TestStatusStringKeepsTheCitedNTSTATUS pins the second reason StatusString still has a
+// local table. STATUS_INVALID_PARAMETER is not an HRESULT: it is the NTSTATUS 0xC000000D
+// that [MS-MQQP] cites directly, named by [MS-ERREF] section 2.3.1. Read as an HRESULT the
+// same value is FACILITY_NULL code 0x000D, which [MS-ERREF] 2.1.1 does not define, so the
+// shared HRESULT table cannot name it and the local arm has to.
+func TestStatusStringKeepsTheCitedNTSTATUS(t *testing.T) {
+	if STATUS_INVALID_PARAMETER != 0xC000000D {
+		t.Fatalf("STATUS_INVALID_PARAMETER = 0x%08x, want 0xc000000d", STATUS_INVALID_PARAMETER)
 	}
 	if got := StatusString(STATUS_INVALID_PARAMETER); got != "STATUS_INVALID_PARAMETER" {
-		t.Fatalf("StatusString(STATUS_INVALID_PARAMETER) = %s, want STATUS_INVALID_PARAMETER", got)
+		t.Errorf("StatusString(0xc000000d) = %q, want STATUS_INVALID_PARAMETER", got)
 	}
-	if got := StatusString(0xDEADBEEF); got != "0xdeadbeef" {
-		t.Fatalf("StatusString(unknown) = %s, want 0xdeadbeef", got)
+	if entry, defined := hresult.Lookup(hresult.HRESULT(STATUS_INVALID_PARAMETER)); defined {
+		t.Errorf("hresult.Lookup(0xc000000d) resolves to %q; [MS-ERREF] 2.1.1 carries no such row", entry.Name)
+	}
+	if facility := (STATUS_INVALID_PARAMETER >> 16) & 0x07FF; facility != 0x000 {
+		t.Errorf("as an HRESULT 0xc000000d has facility 0x%03x, want FACILITY_NULL (0x000)", facility)
+	}
+	// The NTSTATUS table is the one that carries the value, under its own NT_-prefixed
+	// spelling of the name, so routing this arm there would change what StatusString renders.
+	if got := nt_status.NT_STATUS(STATUS_INVALID_PARAMETER).String(); got != "NT_STATUS_INVALID_PARAMETER" {
+		t.Errorf("nt_status.NT_STATUS(0xc000000d).String() = %q, want NT_STATUS_INVALID_PARAMETER", got)
 	}
 }

--- a/network/dcerpc/interfaces/1a9134dd-7b39-45ba-ad88-44d01ca47f28/1.0/functions/03_R_CloseQueue.go
+++ b/network/dcerpc/interfaces/1a9134dd-7b39-45ba-ad88-44d01ca47f28/1.0/functions/03_R_CloseQueue.go
@@ -10,6 +10,7 @@ import (
 
 	RemoteRead "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/1a9134dd-7b39-45ba-ad88-44d01ca47f28/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msmqrr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqrr"
 )
 
@@ -38,7 +39,7 @@ func R_CloseQueue(rpc ndr.Invoker, pphContext msmqrr.QUEUE_CONTEXT_HANDLE_SERIAL
 		return
 	}
 	PphContext = resp.PphContext
-	if uint32(resp.Status) != RemoteRead.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("R_CloseQueue failed: %s", RemoteRead.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/1a9134dd-7b39-45ba-ad88-44d01ca47f28/1.0/functions/04_R_CreateCursor.go
+++ b/network/dcerpc/interfaces/1a9134dd-7b39-45ba-ad88-44d01ca47f28/1.0/functions/04_R_CreateCursor.go
@@ -10,6 +10,7 @@ import (
 
 	RemoteRead "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/1a9134dd-7b39-45ba-ad88-44d01ca47f28/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msmqrr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqrr"
 )
 
@@ -38,7 +39,7 @@ func R_CreateCursor(rpc ndr.Invoker, phContext msmqrr.QUEUE_CONTEXT_HANDLE_NOSER
 		return
 	}
 	PhCursor = resp.PhCursor
-	if uint32(resp.Status) != RemoteRead.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("R_CreateCursor failed: %s", RemoteRead.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/1a9134dd-7b39-45ba-ad88-44d01ca47f28/1.0/functions/05_R_CloseCursor.go
+++ b/network/dcerpc/interfaces/1a9134dd-7b39-45ba-ad88-44d01ca47f28/1.0/functions/05_R_CloseCursor.go
@@ -10,6 +10,7 @@ import (
 
 	RemoteRead "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/1a9134dd-7b39-45ba-ad88-44d01ca47f28/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msmqrr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqrr"
 )
 
@@ -38,7 +39,7 @@ func R_CloseCursor(rpc ndr.Invoker, phContext msmqrr.QUEUE_CONTEXT_HANDLE_NOSERI
 		err = fmt.Errorf("R_CloseCursor: %w", err)
 		return
 	}
-	if uint32(resp.Status) != RemoteRead.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("R_CloseCursor failed: %s", RemoteRead.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/1a9134dd-7b39-45ba-ad88-44d01ca47f28/1.0/functions/06_R_PurgeQueue.go
+++ b/network/dcerpc/interfaces/1a9134dd-7b39-45ba-ad88-44d01ca47f28/1.0/functions/06_R_PurgeQueue.go
@@ -10,6 +10,7 @@ import (
 
 	RemoteRead "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/1a9134dd-7b39-45ba-ad88-44d01ca47f28/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msmqrr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqrr"
 )
 
@@ -36,7 +37,7 @@ func R_PurgeQueue(rpc ndr.Invoker, phContext msmqrr.QUEUE_CONTEXT_HANDLE_NOSERIA
 		err = fmt.Errorf("R_PurgeQueue: %w", err)
 		return
 	}
-	if uint32(resp.Status) != RemoteRead.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("R_PurgeQueue failed: %s", RemoteRead.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/1a9134dd-7b39-45ba-ad88-44d01ca47f28/1.0/functions/07_R_StartReceive.go
+++ b/network/dcerpc/interfaces/1a9134dd-7b39-45ba-ad88-44d01ca47f28/1.0/functions/07_R_StartReceive.go
@@ -10,6 +10,7 @@ import (
 
 	RemoteRead "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/1a9134dd-7b39-45ba-ad88-44d01ca47f28/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msmqrr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqrr"
 )
 
@@ -62,7 +63,7 @@ func R_StartReceive(rpc ndr.Invoker, phContext msmqrr.QUEUE_CONTEXT_HANDLE_NOSER
 	PSequenceId = resp.PSequenceId
 	PdwNumberOfSections = resp.PdwNumberOfSections
 	PpPacketSections = resp.PpPacketSections
-	if uint32(resp.Status) != RemoteRead.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("R_StartReceive failed: %s", RemoteRead.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/1a9134dd-7b39-45ba-ad88-44d01ca47f28/1.0/functions/08_R_CancelReceive.go
+++ b/network/dcerpc/interfaces/1a9134dd-7b39-45ba-ad88-44d01ca47f28/1.0/functions/08_R_CancelReceive.go
@@ -10,6 +10,7 @@ import (
 
 	RemoteRead "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/1a9134dd-7b39-45ba-ad88-44d01ca47f28/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msmqrr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqrr"
 )
 
@@ -38,7 +39,7 @@ func R_CancelReceive(rpc ndr.Invoker, phContext msmqrr.QUEUE_CONTEXT_HANDLE_NOSE
 		err = fmt.Errorf("R_CancelReceive: %w", err)
 		return
 	}
-	if uint32(resp.Status) != RemoteRead.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("R_CancelReceive failed: %s", RemoteRead.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/1a9134dd-7b39-45ba-ad88-44d01ca47f28/1.0/functions/09_R_EndReceive.go
+++ b/network/dcerpc/interfaces/1a9134dd-7b39-45ba-ad88-44d01ca47f28/1.0/functions/09_R_EndReceive.go
@@ -10,6 +10,7 @@ import (
 
 	RemoteRead "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/1a9134dd-7b39-45ba-ad88-44d01ca47f28/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msmqrr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqrr"
 )
 
@@ -40,7 +41,7 @@ func R_EndReceive(rpc ndr.Invoker, phContext msmqrr.QUEUE_CONTEXT_HANDLE_NOSERIA
 		err = fmt.Errorf("R_EndReceive: %w", err)
 		return
 	}
-	if uint32(resp.Status) != RemoteRead.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("R_EndReceive failed: %s", RemoteRead.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/1a9134dd-7b39-45ba-ad88-44d01ca47f28/1.0/functions/10_R_MoveMessage.go
+++ b/network/dcerpc/interfaces/1a9134dd-7b39-45ba-ad88-44d01ca47f28/1.0/functions/10_R_MoveMessage.go
@@ -10,6 +10,7 @@ import (
 
 	RemoteRead "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/1a9134dd-7b39-45ba-ad88-44d01ca47f28/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msmqmq "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqmq"
 	msmqrr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqrr"
 )
@@ -43,7 +44,7 @@ func R_MoveMessage(rpc ndr.Invoker, phContextFrom msmqrr.QUEUE_CONTEXT_HANDLE_NO
 		err = fmt.Errorf("R_MoveMessage: %w", err)
 		return
 	}
-	if uint32(resp.Status) != RemoteRead.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("R_MoveMessage failed: %s", RemoteRead.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/1a9134dd-7b39-45ba-ad88-44d01ca47f28/1.0/functions/12_R_QMEnlistRemoteTransaction.go
+++ b/network/dcerpc/interfaces/1a9134dd-7b39-45ba-ad88-44d01ca47f28/1.0/functions/12_R_QMEnlistRemoteTransaction.go
@@ -10,6 +10,7 @@ import (
 
 	RemoteRead "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/1a9134dd-7b39-45ba-ad88-44d01ca47f28/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msmqmq "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqmq"
 )
 
@@ -44,7 +45,7 @@ func R_QMEnlistRemoteTransaction(rpc ndr.Invoker, pTransactionId msmqmq.XACTUOW,
 		err = fmt.Errorf("R_QMEnlistRemoteTransaction: %w", err)
 		return
 	}
-	if uint32(resp.Status) != RemoteRead.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("R_QMEnlistRemoteTransaction failed: %s", RemoteRead.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/1a9134dd-7b39-45ba-ad88-44d01ca47f28/1.0/functions/13_R_StartTransactionalReceive.go
+++ b/network/dcerpc/interfaces/1a9134dd-7b39-45ba-ad88-44d01ca47f28/1.0/functions/13_R_StartTransactionalReceive.go
@@ -10,6 +10,7 @@ import (
 
 	RemoteRead "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/1a9134dd-7b39-45ba-ad88-44d01ca47f28/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msmqmq "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqmq"
 	msmqrr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqrr"
 )
@@ -65,7 +66,7 @@ func R_StartTransactionalReceive(rpc ndr.Invoker, phContext msmqrr.QUEUE_CONTEXT
 	PSequenceId = resp.PSequenceId
 	PdwNumberOfSections = resp.PdwNumberOfSections
 	PpPacketSections = resp.PpPacketSections
-	if uint32(resp.Status) != RemoteRead.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("R_StartTransactionalReceive failed: %s", RemoteRead.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/1a9134dd-7b39-45ba-ad88-44d01ca47f28/1.0/functions/14_R_SetUserAcknowledgementClass.go
+++ b/network/dcerpc/interfaces/1a9134dd-7b39-45ba-ad88-44d01ca47f28/1.0/functions/14_R_SetUserAcknowledgementClass.go
@@ -10,6 +10,7 @@ import (
 
 	RemoteRead "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/1a9134dd-7b39-45ba-ad88-44d01ca47f28/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msmqrr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqrr"
 )
 
@@ -42,7 +43,7 @@ func R_SetUserAcknowledgementClass(rpc ndr.Invoker, phContext msmqrr.QUEUE_CONTE
 		err = fmt.Errorf("R_SetUserAcknowledgementClass: %w", err)
 		return
 	}
-	if uint32(resp.Status) != RemoteRead.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("R_SetUserAcknowledgementClass failed: %s", RemoteRead.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/1a9134dd-7b39-45ba-ad88-44d01ca47f28/1.0/functions/15_R_EndTransactionalReceive.go
+++ b/network/dcerpc/interfaces/1a9134dd-7b39-45ba-ad88-44d01ca47f28/1.0/functions/15_R_EndTransactionalReceive.go
@@ -10,6 +10,7 @@ import (
 
 	RemoteRead "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/1a9134dd-7b39-45ba-ad88-44d01ca47f28/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msmqrr "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqrr"
 )
 
@@ -42,7 +43,7 @@ func R_EndTransactionalReceive(rpc ndr.Invoker, phContext msmqrr.QUEUE_CONTEXT_H
 		err = fmt.Errorf("R_EndTransactionalReceive: %w", err)
 		return
 	}
-	if uint32(resp.Status) != RemoteRead.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("R_EndTransactionalReceive failed: %s", RemoteRead.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/1a9134dd-7b39-45ba-ad88-44d01ca47f28/1.0/interface.go
+++ b/network/dcerpc/interfaces/1a9134dd-7b39-45ba-ad88-44d01ca47f28/1.0/interface.go
@@ -12,9 +12,8 @@ package rpcinterface_1a9134dd7b3945baad8844d01ca47f28_1_0
 // A fetched copy is kept at ms-mqmq.idl in the interface directory.
 
 import (
-	"fmt"
-
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	"github.com/TheManticoreProject/Manticore/windows/guid"
 )
 
@@ -45,16 +44,27 @@ const (
 )
 
 // Status codes returned by the HRESULT-returning methods of this interface. The values are
-// the Message Queuing result codes ([MS-MQMQ] section 2.4, mqerror.h). MQ_OK is success; per
-// [MS-MQRR] the client treats every failure HRESULT identically. Only the codes the
-// [MS-MQRR] method sections enumerate for remote-read/cursor/transaction operations are
-// listed here; StatusString falls back to the hex value for any other code.
+// the Message Queuing result codes ([MS-MQMQ] section 2.4, mqerror.h). They are HRESULTs in
+// FACILITY_MSMQ (0x00E), and [MS-ERREF] section 2.1.1 carries no row for that facility at
+// all: the table names nothing in 0xC00E____ or 0x400E____ and no value whose name begins
+// MQ_. So none of these can be read out of
+// github.com/TheManticoreProject/Manticore/windows/errors/hresult, and they stay declared
+// here, decoded by StatusString before it defers to the shared table.
+//
+// MQ_OK is the one exception, and it is gone from this block: its value is 0x00000000, which
+// the shared package declares as hresult.S_OK, so the stubs compare a returned status against
+// that constant. They compare for equality with it rather than testing IsSuccess, which
+// preserves the behaviour they have always had — [MS-MQRR] documents MQ_OK as the success
+// value of every one of these methods and requires the client to treat every other result
+// identically, so a success-severity value that is not MQ_OK, such as one of the
+// MQ_INFORMATION_* codes in 0x400E____, is still reported as a failure.
+//
+// Only the codes the [MS-MQRR] method sections enumerate for remote-read/cursor/transaction
+// operations are listed here; StatusString defers every other value to the shared table.
 //
 // Note: R_GetServerPort (opnum 0) does NOT return an HRESULT — its DWORD result is the RPC
 // port on which the server receives remote-read requests (0x00000000 signals failure).
 const (
-	StatusSuccess uint32 = 0x00000000 // MQ_OK
-
 	MQ_ERROR                          uint32 = 0xC00E0001
 	MQ_ERROR_QUEUE_NOT_FOUND          uint32 = 0xC00E0003
 	MQ_ERROR_QUEUE_NOT_ACTIVE         uint32 = 0xC00E0004
@@ -88,12 +98,14 @@ func SyntaxID() syntax.SyntaxID {
 	}
 }
 
-// StatusString returns a mnemonic for the documented status codes, otherwise the
-// hex value.
+// StatusString names the FACILITY_MSMQ result codes above, which [MS-ERREF] section 2.1.1
+// does not carry, and defers every other status to the shared HRESULT table. The deferral is
+// correct because an MSMQ result code genuinely is an HRESULT and only its facility is absent
+// from the specification's table: 0x00000000 renders as S_OK, a FACILITY_WIN32 value renders
+// through the Win32 code it wraps, and a value the table does not define renders as hex,
+// exactly as it did before.
 func StatusString(status uint32) string {
 	switch status {
-	case StatusSuccess:
-		return "MQ_OK"
 	case MQ_ERROR:
 		return "MQ_ERROR"
 	case MQ_ERROR_QUEUE_NOT_FOUND:
@@ -137,7 +149,7 @@ func StatusString(status uint32) string {
 	case MQ_ERROR_MESSAGE_NOT_FOUND:
 		return "MQ_ERROR_MESSAGE_NOT_FOUND"
 	default:
-		return fmt.Sprintf("0x%08x", status)
+		return hresult.HRESULT(status).String()
 	}
 }
 

--- a/network/dcerpc/interfaces/1a9134dd-7b39-45ba-ad88-44d01ca47f28/1.0/interface_test.go
+++ b/network/dcerpc/interfaces/1a9134dd-7b39-45ba-ad88-44d01ca47f28/1.0/interface_test.go
@@ -1,6 +1,11 @@
 package rpcinterface_1a9134dd7b3945baad8844d01ca47f28_1_0
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
+)
 
 // TestSyntaxID verifies the abstract syntax identity (UUID + version) of the RemoteRead interface.
 func TestSyntaxID(t *testing.T) {
@@ -40,18 +45,91 @@ func TestOpnums(t *testing.T) {
 	}
 }
 
-// TestStatusString verifies mnemonic rendering and the hex fallback.
-func TestStatusString(t *testing.T) {
-	if got := StatusString(StatusSuccess); got != "MQ_OK" {
-		t.Fatalf("StatusString(StatusSuccess) = %s, want MQ_OK", got)
+// TestStatusStringKeepsMSMQFacilityAndDefersTheRest pins both halves of the split. MQ_OK
+// left this package: it is 0x00000000, the value the shared HRESULT package declares as
+// S_OK, so it resolves there and the stubs compare against that constant. The MQ_ERROR_*
+// codes could not leave: they are HRESULTs in FACILITY_MSMQ (0x00E), a facility for which
+// [MS-ERREF] section 2.1.1 carries no row, so hresult.Lookup reports nothing for any of
+// them and StatusString must name them itself.
+func TestStatusStringKeepsMSMQFacilityAndDefersTheRest(t *testing.T) {
+	if hresult.S_OK != 0x00000000 {
+		t.Fatalf("hresult.S_OK = 0x%08x, want 0x00000000 (the value MQ_OK had)", uint32(hresult.S_OK))
 	}
-	if got := StatusString(MQ_ERROR_INVALID_HANDLE); got != "MQ_ERROR_INVALID_HANDLE" {
-		t.Fatalf("StatusString(MQ_ERROR_INVALID_HANDLE) = %s, want MQ_ERROR_INVALID_HANDLE", got)
+	if got := hresult.S_OK.String(); got != "S_OK" {
+		t.Errorf("hresult.S_OK.String() = %q, want S_OK", got)
 	}
-	if got := StatusString(MQ_ERROR_MESSAGE_ALREADY_RECEIVED); got != "MQ_ERROR_MESSAGE_ALREADY_RECEIVED" {
-		t.Fatalf("StatusString(MQ_ERROR_MESSAGE_ALREADY_RECEIVED) = %s, want MQ_ERROR_MESSAGE_ALREADY_RECEIVED", got)
+	if err := hresult.S_OK.Error(); err != nil {
+		t.Errorf("hresult.S_OK.Error() = %v, want nil", err)
 	}
+	if got := StatusString(uint32(hresult.S_OK)); got != "S_OK" {
+		t.Errorf("StatusString(0x00000000) = %q, want S_OK", got)
+	}
+
+	retained := map[uint32]string{
+		MQ_ERROR:                          "MQ_ERROR",
+		MQ_ERROR_QUEUE_NOT_FOUND:          "MQ_ERROR_QUEUE_NOT_FOUND",
+		MQ_ERROR_QUEUE_NOT_ACTIVE:         "MQ_ERROR_QUEUE_NOT_ACTIVE",
+		MQ_ERROR_INVALID_PARAMETER:        "MQ_ERROR_INVALID_PARAMETER",
+		MQ_ERROR_INVALID_HANDLE:           "MQ_ERROR_INVALID_HANDLE",
+		MQ_ERROR_OPERATION_CANCELLED:      "MQ_ERROR_OPERATION_CANCELLED",
+		MQ_ERROR_SHARING_VIOLATION:        "MQ_ERROR_SHARING_VIOLATION",
+		MQ_ERROR_SERVICE_NOT_AVAILABLE:    "MQ_ERROR_SERVICE_NOT_AVAILABLE",
+		MQ_ERROR_IO_TIMEOUT:               "MQ_ERROR_IO_TIMEOUT",
+		MQ_ERROR_ILLEGAL_CURSOR_ACTION:    "MQ_ERROR_ILLEGAL_CURSOR_ACTION",
+		MQ_ERROR_MESSAGE_ALREADY_RECEIVED: "MQ_ERROR_MESSAGE_ALREADY_RECEIVED",
+		MQ_ERROR_ACCESS_DENIED:            "MQ_ERROR_ACCESS_DENIED",
+		MQ_ERROR_PRIVILEGE_NOT_HELD:       "MQ_ERROR_PRIVILEGE_NOT_HELD",
+		MQ_ERROR_INSUFFICIENT_RESOURCES:   "MQ_ERROR_INSUFFICIENT_RESOURCES",
+		MQ_ERROR_TRANSACTION_USAGE:        "MQ_ERROR_TRANSACTION_USAGE",
+		MQ_ERROR_TRANSACTION_SEQUENCE:     "MQ_ERROR_TRANSACTION_SEQUENCE",
+		MQ_ERROR_TRANSACTION_ENLIST:       "MQ_ERROR_TRANSACTION_ENLIST",
+		MQ_ERROR_STALE_HANDLE:             "MQ_ERROR_STALE_HANDLE",
+		MQ_ERROR_QUEUE_DELETED:            "MQ_ERROR_QUEUE_DELETED",
+		MQ_ERROR_ILLEGAL_CONTEXT:          "MQ_ERROR_ILLEGAL_CONTEXT",
+		MQ_ERROR_MESSAGE_NOT_FOUND:        "MQ_ERROR_MESSAGE_NOT_FOUND",
+	}
+	if len(retained) != 21 {
+		t.Fatalf("retained table has %d entries, want 21", len(retained))
+	}
+	for code, name := range retained {
+		if got := StatusString(code); got != name {
+			t.Errorf("StatusString(0x%08x) = %q, want %q", code, got, name)
+		}
+		if facility := (code >> 16) & 0x07FF; facility != 0x00E {
+			t.Errorf("%s = 0x%08x, facility 0x%03x, want FACILITY_MSMQ (0x00E)", name, code, facility)
+		}
+		if entry, defined := hresult.Lookup(hresult.HRESULT(code)); defined {
+			t.Errorf("hresult.Lookup(0x%08x) resolves to %q; the code belongs in the shared table instead", code, entry.Name)
+		}
+		if hresult.HRESULT(code).IsSuccess() {
+			t.Errorf("%s = 0x%08x reports success, want failure severity", name, code)
+		}
+	}
+
+	// The fallthrough is the gain: a generic HRESULT this interface never enumerated used to
+	// render as undecoded hex and now resolves by name.
+	if got := StatusString(0x80004005); got != "E_FAIL" {
+		t.Errorf("StatusString(0x80004005) = %q, want E_FAIL", got)
+	}
+	if got := StatusString(0x80070005); got != "E_ACCESSDENIED" {
+		t.Errorf("StatusString(0x80070005) = %q, want E_ACCESSDENIED", got)
+	}
+
+	// So does a FACILITY_WIN32 value the specification's table does not name, which resolves
+	// through the Win32 code it wraps.
+	wrapped := hresult.FromWin32(win32.ERROR_FILE_NOT_FOUND)
+	if uint32(wrapped) != 0x80070002 {
+		t.Fatalf("hresult.FromWin32(ERROR_FILE_NOT_FOUND) = 0x%08x, want 0x80070002", uint32(wrapped))
+	}
+	if code, wraps := wrapped.ToWin32(); !wraps || code != win32.ERROR_FILE_NOT_FOUND {
+		t.Errorf("ToWin32() = 0x%08x, %v; want 0x%08x, true", uint32(code), wraps, uint32(win32.ERROR_FILE_NOT_FOUND))
+	}
+	if got := StatusString(uint32(wrapped)); got != "HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND)" {
+		t.Errorf("StatusString(0x80070002) = %q, want HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND)", got)
+	}
+
+	// A value neither table defines still renders as hex, as it always did.
 	if got := StatusString(0xDEADBEEF); got != "0xdeadbeef" {
-		t.Fatalf("StatusString(unknown) = %s, want 0xdeadbeef", got)
+		t.Errorf("StatusString(0xdeadbeef) = %q, want 0xdeadbeef", got)
 	}
 }

--- a/network/dcerpc/interfaces/708cca10-9569-11d1-b2a5-0060977d8118/1.0/functions/00_S_DSGetComputerSites.go
+++ b/network/dcerpc/interfaces/708cca10-9569-11d1-b2a5-0060977d8118/1.0/functions/00_S_DSGetComputerSites.go
@@ -10,6 +10,7 @@ import (
 
 	dscomm2 "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/708cca10-9569-11d1-b2a5-0060977d8118/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	msmqds "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqds"
 )
@@ -49,7 +50,7 @@ func S_DSGetComputerSites(rpc ndr.Invoker, pwcsPathName *ndr.WSTR, phServerAuth 
 	PpguidSites = resp.PpguidSites
 	PbServerSignature = resp.PbServerSignature
 	PdwServerSignatureSize = resp.PdwServerSignatureSize
-	if uint32(resp.Status) != dscomm2.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("S_DSGetComputerSites failed: %s", dscomm2.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/708cca10-9569-11d1-b2a5-0060977d8118/1.0/functions/01_S_DSGetPropsEx.go
+++ b/network/dcerpc/interfaces/708cca10-9569-11d1-b2a5-0060977d8118/1.0/functions/01_S_DSGetPropsEx.go
@@ -10,6 +10,7 @@ import (
 
 	dscomm2 "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/708cca10-9569-11d1-b2a5-0060977d8118/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msmqds "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqds"
 	msmqmq "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqmq"
 )
@@ -55,7 +56,7 @@ func S_DSGetPropsEx(rpc ndr.Invoker, dwObjectType ndr.DWORD, pwcsPathName ndr.WS
 	ApVar = resp.ApVar
 	PbServerSignature = resp.PbServerSignature
 	PdwServerSignatureSize = resp.PdwServerSignatureSize
-	if uint32(resp.Status) != dscomm2.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("S_DSGetPropsEx failed: %s", dscomm2.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/708cca10-9569-11d1-b2a5-0060977d8118/1.0/functions/02_S_DSGetPropsGuidEx.go
+++ b/network/dcerpc/interfaces/708cca10-9569-11d1-b2a5-0060977d8118/1.0/functions/02_S_DSGetPropsGuidEx.go
@@ -10,6 +10,7 @@ import (
 
 	dscomm2 "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/708cca10-9569-11d1-b2a5-0060977d8118/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msdtyp "github.com/TheManticoreProject/Manticore/windows/ms-dtyp"
 	msmqds "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqds"
 	msmqmq "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqmq"
@@ -56,7 +57,7 @@ func S_DSGetPropsGuidEx(rpc ndr.Invoker, dwObjectType ndr.DWORD, pGuid *msdtyp.G
 	ApVar = resp.ApVar
 	PbServerSignature = resp.PbServerSignature
 	PdwServerSignatureSize = resp.PdwServerSignatureSize
-	if uint32(resp.Status) != dscomm2.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("S_DSGetPropsGuidEx failed: %s", dscomm2.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/708cca10-9569-11d1-b2a5-0060977d8118/1.0/functions/03_S_DSBeginDeleteNotification.go
+++ b/network/dcerpc/interfaces/708cca10-9569-11d1-b2a5-0060977d8118/1.0/functions/03_S_DSBeginDeleteNotification.go
@@ -10,6 +10,7 @@ import (
 
 	dscomm2 "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/708cca10-9569-11d1-b2a5-0060977d8118/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msmqds "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqds"
 )
 
@@ -42,7 +43,7 @@ func S_DSBeginDeleteNotification(rpc ndr.Invoker, pwcsPathName ndr.WSTR, phServe
 		return
 	}
 	PHandle = resp.PHandle
-	if uint32(resp.Status) != dscomm2.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("S_DSBeginDeleteNotification failed: %s", dscomm2.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/708cca10-9569-11d1-b2a5-0060977d8118/1.0/functions/04_S_DSNotifyDelete.go
+++ b/network/dcerpc/interfaces/708cca10-9569-11d1-b2a5-0060977d8118/1.0/functions/04_S_DSNotifyDelete.go
@@ -10,6 +10,7 @@ import (
 
 	dscomm2 "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/708cca10-9569-11d1-b2a5-0060977d8118/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msmqds "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqds"
 )
 
@@ -36,7 +37,7 @@ func S_DSNotifyDelete(rpc ndr.Invoker, handle msmqds.PCONTEXT_HANDLE_DELETE_TYPE
 		err = fmt.Errorf("S_DSNotifyDelete: %w", err)
 		return
 	}
-	if uint32(resp.Status) != dscomm2.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("S_DSNotifyDelete failed: %s", dscomm2.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/708cca10-9569-11d1-b2a5-0060977d8118/1.0/functions/08_S_DSGetGCListInDomain.go
+++ b/network/dcerpc/interfaces/708cca10-9569-11d1-b2a5-0060977d8118/1.0/functions/08_S_DSGetGCListInDomain.go
@@ -10,6 +10,7 @@ import (
 
 	dscomm2 "github.com/TheManticoreProject/Manticore/network/dcerpc/interfaces/708cca10-9569-11d1-b2a5-0060977d8118/1.0"
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/ndr"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	msmqds "github.com/TheManticoreProject/Manticore/windows/protocols/ms-mqds"
 )
 
@@ -48,7 +49,7 @@ func S_DSGetGCListInDomain(rpc ndr.Invoker, lpwszComputerName *ndr.WSTR, lpwszDo
 	LplpwszGCList = resp.LplpwszGCList
 	PbServerSignature = resp.PbServerSignature
 	PdwServerSignatureSize = resp.PdwServerSignatureSize
-	if uint32(resp.Status) != dscomm2.StatusSuccess {
+	if hresult.HRESULT(resp.Status) != hresult.S_OK {
 		err = fmt.Errorf("S_DSGetGCListInDomain failed: %s", dscomm2.StatusString(uint32(resp.Status)))
 	}
 	return

--- a/network/dcerpc/interfaces/708cca10-9569-11d1-b2a5-0060977d8118/1.0/interface.go
+++ b/network/dcerpc/interfaces/708cca10-9569-11d1-b2a5-0060977d8118/1.0/interface.go
@@ -12,9 +12,8 @@ package rpcinterface_708cca10956911d1b2a50060977d8118_1_0
 // A fetched copy is kept at ms-mqds.idl in the interface directory.
 
 import (
-	"fmt"
-
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	"github.com/TheManticoreProject/Manticore/windows/guid"
 )
 
@@ -38,13 +37,26 @@ const (
 	OpnumS_DSGetGCListInDomain       uint16 = 8
 )
 
-// Status codes returned by this interface. Most dscomm2 methods return an HRESULT (the
-// Message Queuing result codes, [MS-MQMQ] 2.4, mqerror.h); S_DSIsServerGC returns a
-// Boolean-valued long. Only the codes most relevant to directory operations are
-// enumerated here; StatusString falls back to the hex value for any other HRESULT.
+// Status codes returned by this interface. Most dscomm2 methods return an HRESULT — the
+// Message Queuing result codes of [MS-MQMQ] 2.4, mqerror.h — while S_DSIsServerGC returns a
+// Boolean-valued long and S_DSEndDeleteNotification returns nothing at all. The result codes
+// are HRESULTs in FACILITY_MSMQ (0x00E), and [MS-ERREF] section 2.1.1 carries no row for
+// that facility: the table names nothing in 0xC00E____ or 0x400E____ and no value whose name
+// begins MQ_. So none of them can be read out of
+// github.com/TheManticoreProject/Manticore/windows/errors/hresult, and they stay declared
+// here, decoded by StatusString before it defers to the shared table.
+//
+// MQ_OK is the one exception, and it is gone from this block: its value is 0x00000000, which
+// the shared package declares as hresult.S_OK, so the stubs compare a returned status against
+// that constant. They compare for equality with it rather than testing IsSuccess, which
+// preserves the behaviour they have always had — [MS-MQDS] documents MQ_OK as the success
+// value of these methods and requires the client to treat every other result as a failure, so
+// a success-severity value that is not MQ_OK, such as one of the MQ_INFORMATION_* codes in
+// 0x400E____, is still reported as a failure.
+//
+// Only the codes most relevant to directory operations are enumerated here; StatusString
+// defers every other value to the shared table.
 const (
-	StatusSuccess uint32 = 0x00000000 // MQ_OK
-
 	MQ_ERROR                        uint32 = 0xC00E0001
 	MQ_ERROR_PROPERTY               uint32 = 0xC00E0002
 	MQ_ERROR_QUEUE_NOT_FOUND        uint32 = 0xC00E0003
@@ -68,12 +80,14 @@ func SyntaxID() syntax.SyntaxID {
 	}
 }
 
-// StatusString returns a mnemonic for the documented status codes, otherwise the
-// hex value.
+// StatusString names the FACILITY_MSMQ result codes above, which [MS-ERREF] section 2.1.1
+// does not carry, and defers every other status to the shared HRESULT table. The deferral is
+// correct because an MSMQ result code genuinely is an HRESULT and only its facility is absent
+// from the specification's table: 0x00000000 renders as S_OK, a FACILITY_WIN32 value renders
+// through the Win32 code it wraps, and a value the table does not define renders as hex,
+// exactly as it did before.
 func StatusString(status uint32) string {
 	switch status {
-	case StatusSuccess:
-		return "MQ_OK"
 	case MQ_ERROR:
 		return "MQ_ERROR"
 	case MQ_ERROR_PROPERTY:
@@ -97,7 +111,7 @@ func StatusString(status uint32) string {
 	case MQ_ERROR_DS_ERROR:
 		return "MQ_ERROR_DS_ERROR"
 	default:
-		return fmt.Sprintf("0x%08x", status)
+		return hresult.HRESULT(status).String()
 	}
 }
 

--- a/network/dcerpc/interfaces/708cca10-9569-11d1-b2a5-0060977d8118/1.0/interface_test.go
+++ b/network/dcerpc/interfaces/708cca10-9569-11d1-b2a5-0060977d8118/1.0/interface_test.go
@@ -1,6 +1,11 @@
 package rpcinterface_708cca10956911d1b2a50060977d8118_1_0
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
+)
 
 // TestSyntaxID verifies the abstract syntax identity (UUID + version) of the dscomm2 interface.
 func TestSyntaxID(t *testing.T) {
@@ -33,15 +38,81 @@ func TestOpnums(t *testing.T) {
 	}
 }
 
-// TestStatusString verifies mnemonic rendering and the hex fallback.
-func TestStatusString(t *testing.T) {
-	if got := StatusString(StatusSuccess); got != "MQ_OK" {
-		t.Fatalf("StatusString(StatusSuccess) = %s, want MQ_OK", got)
+// TestStatusStringKeepsMSMQFacilityAndDefersTheRest pins both halves of the split. MQ_OK
+// left this package: it is 0x00000000, the value the shared HRESULT package declares as
+// S_OK, so it resolves there and the stubs compare against that constant. The MQ_ERROR_*
+// codes could not leave: they are HRESULTs in FACILITY_MSMQ (0x00E), a facility for which
+// [MS-ERREF] section 2.1.1 carries no row, so hresult.Lookup reports nothing for any of
+// them and StatusString must name them itself.
+func TestStatusStringKeepsMSMQFacilityAndDefersTheRest(t *testing.T) {
+	if hresult.S_OK != 0x00000000 {
+		t.Fatalf("hresult.S_OK = 0x%08x, want 0x00000000 (the value MQ_OK had)", uint32(hresult.S_OK))
 	}
-	if got := StatusString(MQ_ERROR_NO_DS); got != "MQ_ERROR_NO_DS" {
-		t.Fatalf("StatusString(MQ_ERROR_NO_DS) = %s, want MQ_ERROR_NO_DS", got)
+	if got := hresult.S_OK.String(); got != "S_OK" {
+		t.Errorf("hresult.S_OK.String() = %q, want S_OK", got)
 	}
+	if err := hresult.S_OK.Error(); err != nil {
+		t.Errorf("hresult.S_OK.Error() = %v, want nil", err)
+	}
+	if got := StatusString(uint32(hresult.S_OK)); got != "S_OK" {
+		t.Errorf("StatusString(0x00000000) = %q, want S_OK", got)
+	}
+
+	retained := map[uint32]string{
+		MQ_ERROR:                        "MQ_ERROR",
+		MQ_ERROR_PROPERTY:               "MQ_ERROR_PROPERTY",
+		MQ_ERROR_QUEUE_NOT_FOUND:        "MQ_ERROR_QUEUE_NOT_FOUND",
+		MQ_ERROR_INVALID_PARAMETER:      "MQ_ERROR_INVALID_PARAMETER",
+		MQ_ERROR_INVALID_HANDLE:         "MQ_ERROR_INVALID_HANDLE",
+		MQ_ERROR_NO_DS:                  "MQ_ERROR_NO_DS",
+		MQ_ERROR_ILLEGAL_QUEUE_PATHNAME: "MQ_ERROR_ILLEGAL_QUEUE_PATHNAME",
+		MQ_ERROR_ACCESS_DENIED:          "MQ_ERROR_ACCESS_DENIED",
+		MQ_ERROR_ILLEGAL_PROPID:         "MQ_ERROR_ILLEGAL_PROPID",
+		MQ_ERROR_ILLEGAL_PROPERTY_VALUE: "MQ_ERROR_ILLEGAL_PROPERTY_VALUE",
+		MQ_ERROR_DS_ERROR:               "MQ_ERROR_DS_ERROR",
+	}
+	if len(retained) != 11 {
+		t.Fatalf("retained table has %d entries, want 11", len(retained))
+	}
+	for code, name := range retained {
+		if got := StatusString(code); got != name {
+			t.Errorf("StatusString(0x%08x) = %q, want %q", code, got, name)
+		}
+		if facility := (code >> 16) & 0x07FF; facility != 0x00E {
+			t.Errorf("%s = 0x%08x, facility 0x%03x, want FACILITY_MSMQ (0x00E)", name, code, facility)
+		}
+		if entry, defined := hresult.Lookup(hresult.HRESULT(code)); defined {
+			t.Errorf("hresult.Lookup(0x%08x) resolves to %q; the code belongs in the shared table instead", code, entry.Name)
+		}
+		if hresult.HRESULT(code).IsSuccess() {
+			t.Errorf("%s = 0x%08x reports success, want failure severity", name, code)
+		}
+	}
+
+	// The fallthrough is the gain: a generic HRESULT this interface never enumerated used to
+	// render as undecoded hex and now resolves by name.
+	if got := StatusString(0x80004005); got != "E_FAIL" {
+		t.Errorf("StatusString(0x80004005) = %q, want E_FAIL", got)
+	}
+	if got := StatusString(0x80070005); got != "E_ACCESSDENIED" {
+		t.Errorf("StatusString(0x80070005) = %q, want E_ACCESSDENIED", got)
+	}
+
+	// So does a FACILITY_WIN32 value the specification's table does not name, which resolves
+	// through the Win32 code it wraps.
+	wrapped := hresult.FromWin32(win32.ERROR_FILE_NOT_FOUND)
+	if uint32(wrapped) != 0x80070002 {
+		t.Fatalf("hresult.FromWin32(ERROR_FILE_NOT_FOUND) = 0x%08x, want 0x80070002", uint32(wrapped))
+	}
+	if code, wraps := wrapped.ToWin32(); !wraps || code != win32.ERROR_FILE_NOT_FOUND {
+		t.Errorf("ToWin32() = 0x%08x, %v; want 0x%08x, true", uint32(code), wraps, uint32(win32.ERROR_FILE_NOT_FOUND))
+	}
+	if got := StatusString(uint32(wrapped)); got != "HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND)" {
+		t.Errorf("StatusString(0x80070002) = %q, want HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND)", got)
+	}
+
+	// A value neither table defines still renders as hex, as it always did.
 	if got := StatusString(0xDEADBEEF); got != "0xdeadbeef" {
-		t.Fatalf("StatusString(unknown) = %s, want 0xdeadbeef", got)
+		t.Errorf("StatusString(0xdeadbeef) = %q, want 0xdeadbeef", got)
 	}
 }


### PR DESCRIPTION
### Linked Issue

Refs #1219. This is the HRESULT-returning end of the status-table retirement, for the three MSMQ interfaces RemoteRead ([MS-MQRR]), qm2qm ([MS-MQQP]) and dscomm2 ([MS-MQDS]), against the `windows/errors/hresult` table that landed in #1221.

### Root Cause

Each of the three interfaces carried a hand-typed status table in its `interface.go` and a `StatusString` that switched over it before falling back to `fmt.Sprintf("0x%08x", status)`. Twenty-two constants in RemoteRead, six in qm2qm, twelve in dscomm2. Every one of them duplicates something a shared `windows/errors` table already owns, or else needs a recorded reason why it does not — and the hex fallback meant any status outside the interface's own subset was reported as an undecoded number.

The three tables turn out to be almost entirely irreducible, and the reason is the same in all three. The Message Queuing result codes are HRESULTs in FACILITY_MSMQ (0x00E), and [MS-ERREF] section 2.1.1 carries no row for that facility at all: checked by value against `windows/errors/errgen/ms-erref-2.1.1-hresult.tsv`, the table names nothing in `0xC00E____`, nothing in `0x400E____`, and no value whose name begins `MQ_` or contains `MSMQ`. So every `MQ_ERROR_*` constant has to stay local, and what changes is that the interface now says so instead of leaving the local table looking like an oversight nobody got round to.

### Fix Description

**RemoteRead — `network/dcerpc/interfaces/1a9134dd-7b39-45ba-ad88-44d01ca47f28/1.0/`.** One constant of twenty-two migrates: `MQ_OK` at `0x00000000`, which the shared package declares as `hresult.S_OK`. It is deleted, and the twelve stubs that tested a returned status against it compare against `hresult.S_OK` directly. The twenty-one `MQ_ERROR_*` codes stay, with the FACILITY_MSMQ reason recorded above the block, and `StatusString` keeps naming them while deferring everything else to `hresult.HRESULT(status).String()`.

**qm2qm — `network/dcerpc/interfaces/1088a980-eae5-11d0-8d9b-00a02453c337/1.0/`.** One constant of six migrates, the same `MQ_OK`, and nine stubs move to `hresult.S_OK`. Four `MQ_ERROR_*` codes stay for the FACILITY_MSMQ reason. The fifth retained constant is off-pattern and is documented as such: `STATUS_INVALID_PARAMETER` is not an HRESULT at all but the NTSTATUS `0xC000000D` that [MS-MQQP] cites directly. Read as an HRESULT that value is FACILITY_NULL code `0x000D`, which [MS-ERREF] 2.1.1 leaves undefined, so deferring it would render it as bare hex. `windows/errors/nt_status` does carry the value, but under the `NT_`-prefixed spelling its generated constants use, so routing the arm there would change what `StatusString` renders; the arm keeps naming the value itself and the test pins all three facts.

**dscomm2 — `network/dcerpc/interfaces/708cca10-9569-11d1-b2a5-0060977d8118/1.0/`.** One constant of twelve migrates, the same `MQ_OK`, and six stubs move to `hresult.S_OK`. The eleven `MQ_ERROR_*` codes stay for the FACILITY_MSMQ reason.

In all three, the stubs keep comparing for equality with `S_OK` rather than testing `IsSuccess`. HRESULT success is a range, so the two are not the same test, and the difference is deliberate: the specifications document `MQ_OK` as the success value of these methods and require the client to treat any other result as a failure, so a success-severity value that is not `MQ_OK` — one of the `MQ_INFORMATION_*` codes in `0x400E____`, say — is still reported as a failure, exactly as before. No stub in any of the three tolerated a second status such as a timeout or an end-of-queue value, so there was no such shape to preserve. The methods that never returned an HRESULT are untouched: `R_GetServerPort` and `RemoteQMGetQMQMServerPort` return a port, `S_DSIsServerGC` returns a Boolean-valued long, and `R_OpenQueue`, `R_OpenQueueForMove`, `RemoteQmGetVersion` and `S_DSEndDeleteNotification` return nothing on the wire.

### How Verified

`go build ./...`, `go vet ./...` and `go test -count=1 ./...` all pass, the suite reporting 315 ok and 0 failures, which is the count `main` reports. `CGO_ENABLED=0 go build ./...` passes for windows/amd64, windows/386, linux/arm64 and linux/386.

Every judgement was derived from the value rather than the name, checked against `windows/errors/errgen/ms-erref-2.1.1-hresult.tsv`: all thirty-six `0xC00E____` values across the three interfaces are absent from the table, as is `0xC000000D`, while `0x00000000` is `S_OK` in the shared package's well-known set and `0x80004005` is `E_FAIL` in the table itself.

Because a dropped comparison term compiles cleanly, the rewrite was checked term by term rather than condition by condition: a script compared the per-`if` operator profile of every production file in each interface against its state on `main`, and all thirty-seven files match. The import blocks were checked the same way, by parsing each rewritten block and comparing its group count and membership against the parent revision, since a collapsed blank line between the stdlib and project groups is invisible to `gofmt`. `gofmt -l` lists none of the thirty-three touched files, and all three directories were clean on `main` before any change; no file was reformatted.

Greps confirm the structural declarations survived: `SyntaxID`, `PipeName`, all thirty-four opnum constants and both `OpnumToName` and `NameToOpnum` are present in all three interfaces, and no reference to the deleted `StatusSuccess` or to the `"MQ_OK"` literal remains anywhere in the three trees.

### Test Coverage

Each interface's `TestStatusString` is replaced by `TestStatusStringKeepsMSMQFacilityAndDefersTheRest`, which asserts both halves of the split. For the migrated value it checks that `hresult.S_OK` is `0x00000000`, that it renders as `S_OK`, that `Error()` reports nil for it, and that `StatusString` resolves it through the shared table. For each retained code it checks that `StatusString` still renders the MSMQ name, that the value's facility really is `0x00E`, that `hresult.Lookup` reports nothing for it, and that its severity is failure. It then pins the gain from the new fallthrough — `0x80004005` resolving as `E_FAIL`, `0x80070005` as `E_ACCESSDENIED`, and `hresult.FromWin32(win32.ERROR_FILE_NOT_FOUND)` round-tripping through `ToWin32` and rendering as `HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND)` — and confirms that a value neither table defines still renders as hex.

qm2qm additionally gets `TestStatusStringKeepsTheCitedNTSTATUS`, which pins that `STATUS_INVALID_PARAMETER` is `0xC000000D`, that `StatusString` names it, that `hresult.Lookup` does not, that as an HRESULT it is FACILITY_NULL, and that the NTSTATUS table names it `NT_STATUS_INVALID_PARAMETER` — the difference that keeps the arm local.

### Scope of Change

Thirty-three files across the three interface directories, and nothing outside them. RemoteRead: `interface.go`, `interface_test.go` and twelve stubs under `functions/`. qm2qm: `interface.go`, `interface_test.go` and nine stubs. dscomm2: `interface.go`, `interface_test.go` and six stubs.

A tree-wide grep for the three import paths, the three package names and every constant name found no consumer outside the interface directories themselves — nothing in `network/dcerpc/ms-protocols/`, nothing in `network/smb/smb_v10/server/rpcpipe/`, and nothing in the `windows/protocols/ms-mqrr`, `ms-mqqp`, `ms-mqds` or `ms-mqmq` structure packages, which hold wire structures and never referenced these status tables. No `Contains` or `HasPrefix` test asserts against `"MQ_"` or `"0xC00E"` anywhere. The other four MSMQ interfaces — `fdb3a030-…`, `77df7a80-…`, `76d12b80-…` and `41208ee0-…` — are untouched.

### Risk and Rollout

Low. The behavioural surface is one rendering change and one comparison rewrite. `StatusString(0)` now returns `S_OK` rather than `MQ_OK`, the same value under the name the shared table gives it; every other retained code renders exactly as before, and every previously unrecognised code renders at least as well, since the hex fallback is still what `hresult.HRESULT.String()` produces for a value neither table defines. The comparison `hresult.HRESULT(resp.Status) != hresult.S_OK` is the same test as the `uint32(resp.Status) != StatusSuccess` it replaces, bit for bit. Nothing on the wire changes and no marshalling code is touched.

The removal of the exported `StatusSuccess` constant from the three packages is the only source-compatible break, and no consumer in the tree referenced it.

### Notes

The honest summary is that almost nothing migrates: three constants in total, all of them the same `0x00000000`. FACILITY_MSMQ has no representation in [MS-ERREF] 2.1.1, so the `MQ_*` blocks cannot be retired at all, and the deliverable is that the code now records why, with a test that fails if the shared table ever grows a row that would contradict it. That check is what makes the local tables defensible rather than merely inherited.

The finding generalises to the four MSMQ interfaces being handled in parallel: any constant in `0xC00E____` or `0x400E____` must stay local, and only `0x00000000`, `0x8007XXXX` and the generic HRESULTs can move. `0xC000000D` is worth flagging too — it looks like an MSMQ neighbour but it is an NTSTATUS, and the HRESULT table has no row for it.
