### PR TITLE
Route TsProxyRpcInterface and FileServerVssAgent status reporting through hresult (Refs #1219)

### DIFF
--- a/network/dcerpc/interfaces/44e265dd-7daf-42cd-8560-3cdb6e7a2729/1.3/interface.go
+++ b/network/dcerpc/interfaces/44e265dd-7daf-42cd-8560-3cdb6e7a2729/1.3/interface.go
@@ -23,9 +23,9 @@ package rpcinterface_44e265dd7daf42cd85603cdb6e7a2729_1_3
 // A fetched copy is kept at ms-tsgu.idl in the interface directory.
 
 import (
-	"fmt"
-
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
 	"github.com/TheManticoreProject/Manticore/windows/guid"
 )
 
@@ -49,13 +49,40 @@ const (
 	OpnumTsProxySendToServer     uint16 = 9
 )
 
-// Return codes ([MS-TSGU] 2.2.6 "Common Return Codes"). The HRESULT forms are returned
-// by the TsProxy* methods that return HRESULT; StatusSuccess (ERROR_SUCCESS) is 0.
+// Return codes ([MS-TSGU] 2.2.6 "Common Return Codes"). The values that reach a caller
+// through the DWORD return of these methods come from three different namespaces, and
+// only a few of them are values the shared tables can name.
+//
+// The E_PROXY_* HRESULTs are in FACILITY_WIN32 (7), so each wraps a Win32 code in the
+// 0x59D8..0x59F9 range that Terminal Services Gateway assigns for itself. [MS-ERREF]
+// 2.1.1 names five FACILITY_WIN32 values and none of these, and [MS-ERREF] 2.2 names no
+// code in that range either, so neither the HRESULT table nor the HRESULT_FROM_WIN32
+// derivation resolves them: hresult.HRESULT(0x800759D8).String() renders hex. They stay
+// declared here and StatusString decodes them.
+//
+// The E_PROXY_*_CODE values are not HRESULTs at all but HRESULT_CODE, the low 16 bits on
+// their own, returned over the RPC/HTTP transports. Their severity bit is clear, so
+// reading one as an HRESULT would report success; they stay declared here too.
+// E_PROXY_CONNECTIONABORTED_CODE is the one value of that block [MS-ERREF] 2.2 does
+// name — as ERROR_CONNECTION_ABORTED, the generic socket error rather than the gateway's
+// own meaning — so it keeps its [MS-TSGU] name here as well.
+//
+// Four values this block used to declare are gone. SEC_E_LOGON_DENIED (0x8009030C) is
+// named by [MS-ERREF] 2.1.1 and resolves as hresult.SEC_E_LOGON_DENIED. ERROR_ACCESS_DENIED
+// (0x00000005), ERROR_BAD_ARGUMENTS (0x000000A0) and ERROR_GRACEFUL_DISCONNECT
+// (0x000004CA) are Win32 codes rather than HRESULTs — an HRESULT reading of any of them
+// is a meaningless success-severity value — and [MS-ERREF] 2.2 names all three under
+// exactly those names in
+// github.com/TheManticoreProject/Manticore/windows/errors/win32.
 const (
-	// StatusSuccess is ERROR_SUCCESS: the requested operation succeeded.
+	// StatusSuccess is zero, which is ERROR_SUCCESS as a Win32 code and S_OK as an
+	// HRESULT. The method stubs compare the returned status against it rather than
+	// against hresult.HRESULT.IsSuccess, which is a range and would accept every
+	// success-severity value, the HRESULT_CODE block below included.
 	StatusSuccess uint32 = 0x00000000
 
-	// HRESULT values defined by [MS-TSGU].
+	// HRESULTs defined by [MS-TSGU] itself, in FACILITY_WIN32 over a Win32 code range
+	// [MS-ERREF] does not name.
 	E_PROXY_INTERNALERROR                       uint32 = 0x800759D8
 	E_PROXY_RAP_ACCESSDENIED                    uint32 = 0x800759DA
 	E_PROXY_NAP_ACCESSDENIED                    uint32 = 0x800759DB
@@ -66,12 +93,6 @@ const (
 	E_PROXY_COOKIE_BADPACKET                    uint32 = 0x800759F7
 	E_PROXY_COOKIE_AUTHENTICATION_ACCESS_DENIED uint32 = 0x800759F8
 	E_PROXY_UNSUPPORTED_AUTHENTICATION_METHOD   uint32 = 0x800759F9
-	SEC_E_LOGON_DENIED                          uint32 = 0x8009030C
-
-	// Win32 error codes also returned by the HRESULT-returning methods.
-	ERROR_ACCESS_DENIED       uint32 = 0x00000005
-	ERROR_BAD_ARGUMENTS       uint32 = 0x000000A0
-	ERROR_GRACEFUL_DISCONNECT uint32 = 0x000004CA
 
 	// DWORD (HRESULT_CODE) values returned only over the RPC/HTTP transports, chiefly by
 	// TsProxySetupReceivePipe and TsProxySendToServer ([MS-TSGU] 2.2.6).
@@ -98,8 +119,12 @@ func SyntaxID() syntax.SyntaxID {
 	}
 }
 
-// StatusString returns a mnemonic for the documented status codes, otherwise the
-// hex value.
+// StatusString names the status values [MS-TSGU] defines for itself — the E_PROXY_*
+// HRESULTs, whose FACILITY_WIN32 code [MS-ERREF] leaves unnamed, and the HRESULT_CODE
+// values the receive-pipe and send-to-server methods return — and defers every other
+// value to the shared tables: the Win32 codes of [MS-TSGU] 2.2.6 to [MS-ERREF] 2.2, and
+// anything else to the [MS-ERREF] 2.1.1 HRESULT table, which names each value the
+// specification defines and renders hex for the rest.
 func StatusString(status uint32) string {
 	switch status {
 	case StatusSuccess:
@@ -124,14 +149,6 @@ func StatusString(status uint32) string {
 		return "E_PROXY_COOKIE_AUTHENTICATION_ACCESS_DENIED"
 	case E_PROXY_UNSUPPORTED_AUTHENTICATION_METHOD:
 		return "E_PROXY_UNSUPPORTED_AUTHENTICATION_METHOD"
-	case SEC_E_LOGON_DENIED:
-		return "SEC_E_LOGON_DENIED"
-	case ERROR_ACCESS_DENIED:
-		return "ERROR_ACCESS_DENIED"
-	case ERROR_BAD_ARGUMENTS:
-		return "ERROR_BAD_ARGUMENTS"
-	case ERROR_GRACEFUL_DISCONNECT:
-		return "ERROR_GRACEFUL_DISCONNECT"
 	case E_PROXY_CONNECTIONABORTED_CODE:
 		return "E_PROXY_CONNECTIONABORTED"
 	case E_PROXY_INTERNALERROR_CODE:
@@ -154,8 +171,10 @@ func StatusString(status uint32) string {
 		return "E_PROXY_SDR_NOT_SUPPORTED_BY_TS"
 	case E_PROXY_REAUTH_NAP_FAILED_CODE:
 		return "E_PROXY_REAUTH_NAP_FAILED"
+	case uint32(win32.ERROR_ACCESS_DENIED), uint32(win32.ERROR_BAD_ARGUMENTS), uint32(win32.ERROR_GRACEFUL_DISCONNECT):
+		return win32.WIN32_ERROR(status).String()
 	default:
-		return fmt.Sprintf("0x%08x", status)
+		return hresult.HRESULT(status).String()
 	}
 }
 

--- a/network/dcerpc/interfaces/44e265dd-7daf-42cd-8560-3cdb6e7a2729/1.3/interface_test.go
+++ b/network/dcerpc/interfaces/44e265dd-7daf-42cd-8560-3cdb6e7a2729/1.3/interface_test.go
@@ -1,6 +1,12 @@
 package rpcinterface_44e265dd7daf42cd85603cdb6e7a2729_1_3
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
+	"github.com/TheManticoreProject/Manticore/windows/errors/win32"
+)
 
 // TestSyntaxID pins the abstract syntax identifier for the TsProxyRpcInterface
 // (44e265dd-7daf-42cd-8560-3cdb6e7a2729 v1.3, [MS-TSGU]).
@@ -39,18 +45,135 @@ func TestOpnumNameRoundTrip(t *testing.T) {
 	}
 }
 
-// TestStatusString checks a couple of mnemonics and the hex fallback.
-func TestStatusString(t *testing.T) {
+// TestMigratedStatusCodesResolveThroughSharedTables pins the four values this
+// descriptor no longer declares: SEC_E_LOGON_DENIED, which [MS-ERREF] 2.1.1 names, and
+// the three Win32 codes of [MS-TSGU] 2.2.6, which [MS-ERREF] 2.2 names. It also pins
+// that a value outside the old subset now renders by name, and that an undefined value
+// still renders as hex.
+func TestMigratedStatusCodesResolveThroughSharedTables(t *testing.T) {
+	if got := uint32(hresult.SEC_E_LOGON_DENIED); got != 0x8009030C {
+		t.Errorf("hresult.SEC_E_LOGON_DENIED = 0x%08x, want 0x8009030c", got)
+	}
+	if got := StatusString(uint32(hresult.SEC_E_LOGON_DENIED)); got != "SEC_E_LOGON_DENIED" {
+		t.Errorf("StatusString(0x8009030c) = %q, want SEC_E_LOGON_DENIED", got)
+	}
+
+	win32Codes := map[win32.WIN32_ERROR]string{
+		win32.ERROR_ACCESS_DENIED:       "ERROR_ACCESS_DENIED",
+		win32.ERROR_BAD_ARGUMENTS:       "ERROR_BAD_ARGUMENTS",
+		win32.ERROR_GRACEFUL_DISCONNECT: "ERROR_GRACEFUL_DISCONNECT",
+	}
+	for code, name := range win32Codes {
+		if got := win32.WIN32_ERROR(code).String(); got != name {
+			t.Errorf("win32.WIN32_ERROR(0x%08x).String() = %q, want %q", uint32(code), got, name)
+		}
+		if got := StatusString(uint32(code)); got != name {
+			t.Errorf("StatusString(0x%08x) = %q, want %q", uint32(code), got, name)
+		}
+		// Each is a Win32 code, not an HRESULT: read as one it is a
+		// success-severity value the HRESULT table cannot name, which is why
+		// StatusString routes these three through the Win32 table.
+		if _, defined := hresult.Lookup(hresult.HRESULT(code)); defined {
+			t.Errorf("hresult.Lookup(0x%08x) resolves; %s is a Win32 code, not an HRESULT", uint32(code), name)
+		}
+		if !hresult.HRESULT(code).IsSuccess() {
+			t.Errorf("HRESULT(0x%08x).IsSuccess() = false, want true for a bare Win32 code", uint32(code))
+		}
+	}
+
+	// E_FAIL was outside the subset this descriptor used to declare, so it rendered as
+	// hex; it resolves by name now, through StatusString as well.
+	if got := StatusString(0x80004005); got != "E_FAIL" {
+		t.Errorf("StatusString(0x80004005) = %q, want E_FAIL", got)
+	}
+	// A value neither table defines still renders as hex.
+	if got := StatusString(0xDEADBEEF); got != "0xdeadbeef" {
+		t.Errorf("StatusString(unknown) = %q, want 0xdeadbeef", got)
+	}
 	if got := StatusString(StatusSuccess); got != "ERROR_SUCCESS" {
 		t.Errorf("StatusString(0) = %q, want ERROR_SUCCESS", got)
 	}
-	if got := StatusString(E_PROXY_INTERNALERROR); got != "E_PROXY_INTERNALERROR" {
-		t.Errorf("StatusString(0x800759D8) = %q, want E_PROXY_INTERNALERROR", got)
+}
+
+// TestStatusStringDecodesGatewayPrivateCodes pins the reason StatusString still exists.
+// The E_PROXY_* HRESULTs sit in FACILITY_WIN32 over the Win32 code range Terminal
+// Services Gateway assigns for itself, which [MS-ERREF] names in neither table, and the
+// E_PROXY_*_CODE values are HRESULT_CODE rather than HRESULT — success-severity if read
+// as one. Both blocks must therefore keep decoding locally.
+func TestStatusStringDecodesGatewayPrivateCodes(t *testing.T) {
+	proxyHRESULTs := map[uint32]string{
+		E_PROXY_INTERNALERROR:                       "E_PROXY_INTERNALERROR",
+		E_PROXY_RAP_ACCESSDENIED:                    "E_PROXY_RAP_ACCESSDENIED",
+		E_PROXY_NAP_ACCESSDENIED:                    "E_PROXY_NAP_ACCESSDENIED",
+		E_PROXY_ALREADYDISCONNECTED:                 "E_PROXY_ALREADYDISCONNECTED",
+		E_PROXY_CAPABILITYMISMATCH:                  "E_PROXY_CAPABILITYMISMATCH",
+		E_PROXY_QUARANTINE_ACCESSDENIED:             "E_PROXY_QUARANTINE_ACCESSDENIED",
+		E_PROXY_NOCERTAVAILABLE:                     "E_PROXY_NOCERTAVAILABLE",
+		E_PROXY_COOKIE_BADPACKET:                    "E_PROXY_COOKIE_BADPACKET",
+		E_PROXY_COOKIE_AUTHENTICATION_ACCESS_DENIED: "E_PROXY_COOKIE_AUTHENTICATION_ACCESS_DENIED",
+		E_PROXY_UNSUPPORTED_AUTHENTICATION_METHOD:   "E_PROXY_UNSUPPORTED_AUTHENTICATION_METHOD",
 	}
-	if got := StatusString(E_PROXY_TS_CONNECTFAILED_CODE); got != "E_PROXY_TS_CONNECTFAILED" {
-		t.Errorf("StatusString(0x59DD) = %q, want E_PROXY_TS_CONNECTFAILED", got)
+	if len(proxyHRESULTs) != 10 {
+		t.Fatalf("gateway HRESULT table has %d entries, want 10", len(proxyHRESULTs))
 	}
-	if got := StatusString(0xDEADBEEF); got != "0xdeadbeef" {
-		t.Errorf("StatusString(unknown) = %q, want 0xdeadbeef", got)
+	for code, name := range proxyHRESULTs {
+		if got := StatusString(code); got != name {
+			t.Errorf("StatusString(0x%08x) = %q, want %q", code, got, name)
+		}
+		if _, defined := hresult.Lookup(hresult.HRESULT(code)); defined {
+			t.Errorf("hresult.Lookup(0x%08x) resolves; %s belongs in the shared table instead", code, name)
+		}
+		if want := fmt.Sprintf("0x%08x", code); hresult.HRESULT(code).String() != want {
+			t.Errorf("hresult.HRESULT(0x%08x).String() = %q, want the hex rendering %q", code, hresult.HRESULT(code).String(), want)
+		}
+		// The retention reason, derived from the value: FACILITY_WIN32, over a code
+		// [MS-ERREF] 2.2 does not name either, so the HRESULT_FROM_WIN32 derivation
+		// cannot resolve it.
+		wrapped, wraps := hresult.HRESULT(code).ToWin32()
+		if !wraps {
+			t.Errorf("HRESULT(0x%08x).ToWin32() reports no Win32 code, want FACILITY_WIN32", code)
+		}
+		if wrapped < 0x59D8 || wrapped > 0x59F9 {
+			t.Errorf("%s wraps 0x%04x, outside the gateway range 0x59D8..0x59F9", name, uint32(wrapped))
+		}
+		if _, defined := win32.Lookup(wrapped); defined {
+			t.Errorf("win32.Lookup(0x%04x) resolves; %s could be built with hresult.FromWin32 instead", uint32(wrapped), name)
+		}
+	}
+
+	proxyCodes := map[uint32]string{
+		E_PROXY_CONNECTIONABORTED_CODE:       "E_PROXY_CONNECTIONABORTED",
+		E_PROXY_INTERNALERROR_CODE:           "E_PROXY_INTERNALERROR (HRESULT_CODE)",
+		E_PROXY_TS_CONNECTFAILED_CODE:        "E_PROXY_TS_CONNECTFAILED",
+		E_PROXY_MAXCONNECTIONSREACHED_CODE:   "E_PROXY_MAXCONNECTIONSREACHED",
+		E_PROXY_NOTSUPPORTED_CODE:            "E_PROXY_NOTSUPPORTED",
+		E_PROXY_SESSIONTIMEOUT_CODE:          "E_PROXY_SESSIONTIMEOUT",
+		E_PROXY_REAUTH_AUTHN_FAILED_CODE:     "E_PROXY_REAUTH_AUTHN_FAILED",
+		E_PROXY_REAUTH_CAP_FAILED_CODE:       "E_PROXY_REAUTH_CAP_FAILED",
+		E_PROXY_REAUTH_RAP_FAILED_CODE:       "E_PROXY_REAUTH_RAP_FAILED",
+		E_PROXY_SDR_NOT_SUPPORTED_BY_TS_CODE: "E_PROXY_SDR_NOT_SUPPORTED_BY_TS",
+		E_PROXY_REAUTH_NAP_FAILED_CODE:       "E_PROXY_REAUTH_NAP_FAILED",
+	}
+	if len(proxyCodes) != 11 {
+		t.Fatalf("gateway HRESULT_CODE table has %d entries, want 11", len(proxyCodes))
+	}
+	for code, name := range proxyCodes {
+		if got := StatusString(code); got != name {
+			t.Errorf("StatusString(0x%08x) = %q, want %q", code, got, name)
+		}
+		if _, defined := hresult.Lookup(hresult.HRESULT(code)); defined {
+			t.Errorf("hresult.Lookup(0x%08x) resolves; %s belongs in the shared table instead", code, name)
+		}
+		// Read as an HRESULT each of these is a success, which is exactly why the
+		// stubs test the status against StatusSuccess and not against IsSuccess.
+		if !hresult.HRESULT(code).IsSuccess() {
+			t.Errorf("HRESULT(0x%08x).IsSuccess() = false, want true for an HRESULT_CODE value", code)
+		}
+	}
+
+	// The one collision in that block: [MS-ERREF] 2.2 names 0x000004D4 for the generic
+	// socket error, not for the gateway, so it cannot be read out of the shared table.
+	if got := win32.WIN32_ERROR(E_PROXY_CONNECTIONABORTED_CODE).String(); got != "ERROR_CONNECTION_ABORTED" {
+		t.Errorf("win32.WIN32_ERROR(0x000004d4).String() = %q, want ERROR_CONNECTION_ABORTED", got)
 	}
 }

--- a/network/dcerpc/interfaces/a8e0653c-2744-4389-a61d-7373df8b2292/1.0/interface.go
+++ b/network/dcerpc/interfaces/a8e0653c-2744-4389-a61d-7373df8b2292/1.0/interface.go
@@ -15,9 +15,8 @@ package rpcinterface_a8e0653c27444389a61d7373df8b2292_1_0
 // A fetched copy is kept at ms-fsrvp.idl in the interface directory.
 
 import (
-	"fmt"
-
 	"github.com/TheManticoreProject/Manticore/network/dcerpc/syntax"
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	"github.com/TheManticoreProject/Manticore/windows/guid"
 )
 
@@ -42,18 +41,33 @@ const (
 	OpnumPrepareShadowCopySet          uint16 = 12
 )
 
-// Status codes. FSRVP methods return an HRESULT/error code: ZERO (0x00000000) on
-// success, common [MS-ERREF] HRESULTs, or the FSRVP-specific codes below
-// ([MS-FSRVP] section 2.2.4 Error Codes).
+// Status codes ([MS-FSRVP] section 2.2.4 Error Codes). FSRVP methods return an HRESULT:
+// ZERO (0x00000000) on success, a few common [MS-ERREF] HRESULTs, or one of the codes
+// the protocol defines for itself.
+//
+// The three common ones are gone from this block. E_INVALIDARG (0x80070057),
+// E_ACCESSDENIED (0x80070005) and E_OUTOFMEMORY (0x8007000E) each have a row in
+// [MS-ERREF] 2.1.1 under exactly that name, so they resolve through
+// github.com/TheManticoreProject/Manticore/windows/errors/hresult and StatusString
+// defers to it for them.
+//
+// The FSRVP_E_* codes below cannot follow. Six of them sit at 0x8004 23xx, which is
+// FACILITY_ITF (4), the facility COM reserves for interface-specific meanings: an
+// interface may define whatever it likes there, [MS-FSRVP] does exactly that, and
+// [MS-ERREF] 2.1.1 has no row for any of 0x80042301, 0x80042308, 0x8004230C, 0x8004230D,
+// 0x80042316 or 0x8004231B — nor for 0x80042501. FSRVP_E_WAIT_TIMEOUT and
+// FSRVP_E_WAIT_FAILED are not HRESULTs at all but the Win32 wait results carried
+// verbatim, and 0x00000102 has its severity bit clear, so an HRESULT reading of it
+// reports success. All nine therefore stay declared here and StatusString decodes them
+// before deferring to the shared table for everything else.
 const (
+	// StatusSuccess is zero, the value [MS-FSRVP] 2.2.4 calls ZERO and the shared table
+	// calls S_OK. The method stubs compare the returned status against it rather than
+	// against hresult.HRESULT.IsSuccess, which is a range: IsSuccess accepts every
+	// success-severity value, FSRVP_E_WAIT_TIMEOUT among them.
 	StatusSuccess uint32 = 0x00000000
 
-	// Common [MS-ERREF] HRESULTs referenced by FSRVP method processing rules.
-	ErrorInvalidArg   uint32 = 0x80070057 // E_INVALIDARG
-	ErrorAccessDenied uint32 = 0x80070005 // E_ACCESSDENIED
-	ErrorOutOfMemory  uint32 = 0x8007000E // E_OUTOFMEMORY
-
-	// FSRVP-specific error codes ([MS-FSRVP] 2.2.4).
+	// Error codes [MS-FSRVP] defines for itself, which [MS-ERREF] 2.1.1 does not name.
 	FsrvpEBadState                uint32 = 0x80042301 // FSRVP_E_BAD_STATE
 	FsrvpENotSupported            uint32 = 0x8004230C // FSRVP_E_NOT_SUPPORTED
 	FsrvpEObjectAlreadyExists     uint32 = 0x8004230D // FSRVP_E_OBJECT_ALREADY_EXISTS
@@ -61,7 +75,7 @@ const (
 	FsrvpEShadowCopySetInProgress uint32 = 0x80042316 // FSRVP_E_SHADOW_COPY_SET_IN_PROGRESS
 	FsrvpEUnsupportedContext      uint32 = 0x8004231B // FSRVP_E_UNSUPPORTED_CONTEXT
 	FsrvpEShadowcopysetIdMismatch uint32 = 0x80042501 // FSRVP_E_SHADOWCOPYSET_ID_MISMATCH
-	FsrvpEWaitTimeout             uint32 = 0x00000102 // FSRVP_E_WAIT_TIMEOUT
+	FsrvpEWaitTimeout             uint32 = 0x00000102 // FSRVP_E_WAIT_TIMEOUT, success severity
 	FsrvpEWaitFailed              uint32 = 0xFFFFFFFF // FSRVP_E_WAIT_FAILED
 )
 
@@ -75,18 +89,15 @@ func SyntaxID() syntax.SyntaxID {
 	}
 }
 
-// StatusString returns a mnemonic for the documented status codes, otherwise the
-// hex value.
+// StatusString names the codes [MS-FSRVP] 2.2.4 defines for itself, which [MS-ERREF]
+// 2.1.1 does not name — the FACILITY_ITF block the protocol fills with its own meanings,
+// and the two Win32 wait results it carries verbatim — and defers every other status to
+// the shared [MS-ERREF] 2.1.1 table, which names each HRESULT the specification defines
+// and renders hex only for a value it does not.
 func StatusString(status uint32) string {
 	switch status {
 	case StatusSuccess:
 		return "ZERO"
-	case ErrorInvalidArg:
-		return "E_INVALIDARG"
-	case ErrorAccessDenied:
-		return "E_ACCESSDENIED"
-	case ErrorOutOfMemory:
-		return "E_OUTOFMEMORY"
 	case FsrvpEBadState:
 		return "FSRVP_E_BAD_STATE"
 	case FsrvpENotSupported:
@@ -106,7 +117,7 @@ func StatusString(status uint32) string {
 	case FsrvpEWaitFailed:
 		return "FSRVP_E_WAIT_FAILED"
 	default:
-		return fmt.Sprintf("0x%08x", status)
+		return hresult.HRESULT(status).String()
 	}
 }
 

--- a/network/dcerpc/interfaces/a8e0653c-2744-4389-a61d-7373df8b2292/1.0/interface_test.go
+++ b/network/dcerpc/interfaces/a8e0653c-2744-4389-a61d-7373df8b2292/1.0/interface_test.go
@@ -1,8 +1,10 @@
 package rpcinterface_a8e0653c27444389a61d7373df8b2292_1_0
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/TheManticoreProject/Manticore/windows/errors/hresult"
 	"github.com/TheManticoreProject/Manticore/windows/guid"
 )
 
@@ -38,18 +40,112 @@ func TestOpnumNameRoundTrip(t *testing.T) {
 	}
 }
 
-// TestStatusString spot-checks the known-code mnemonics and the hex fallback.
-func TestStatusString(t *testing.T) {
-	cases := map[uint32]string{
-		StatusSuccess:                 "ZERO",
-		FsrvpEBadState:                "FSRVP_E_BAD_STATE",
-		FsrvpEShadowcopysetIdMismatch: "FSRVP_E_SHADOWCOPYSET_ID_MISMATCH",
-		FsrvpEWaitFailed:              "FSRVP_E_WAIT_FAILED",
-		0xdeadbeef:                    "0xdeadbeef",
+// TestMigratedStatusCodesResolveThroughHRESULT pins the three values this descriptor no
+// longer declares. Each has a row in [MS-ERREF] 2.1.1 under the name FSRVP uses for it,
+// so it resolves through the shared table in both directions and through StatusString's
+// fallthrough. It also pins that a common HRESULT outside the old subset now renders by
+// name, and that an undefined value still renders as hex.
+func TestMigratedStatusCodesResolveThroughHRESULT(t *testing.T) {
+	migrated := map[hresult.HRESULT]string{
+		hresult.E_INVALIDARG:   "E_INVALIDARG",
+		hresult.E_ACCESSDENIED: "E_ACCESSDENIED",
+		hresult.E_OUTOFMEMORY:  "E_OUTOFMEMORY",
 	}
-	for code, want := range cases {
-		if got := StatusString(code); got != want {
-			t.Errorf("StatusString(0x%08x) = %q, want %q", code, got, want)
+	values := map[string]uint32{
+		"E_INVALIDARG":   0x80070057,
+		"E_ACCESSDENIED": 0x80070005,
+		"E_OUTOFMEMORY":  0x8007000E,
+	}
+	for code, name := range migrated {
+		if got := uint32(code); got != values[name] {
+			t.Errorf("hresult.%s = 0x%08x, want 0x%08x", name, got, values[name])
 		}
+		if got := code.String(); got != name {
+			t.Errorf("hresult.HRESULT(0x%08x).String() = %q, want %q", uint32(code), got, name)
+		}
+		if resolved, defined := hresult.FromName(name); !defined || resolved != code {
+			t.Errorf("hresult.FromName(%q) = 0x%08x, %v; want 0x%08x, true", name, uint32(resolved), defined, uint32(code))
+		}
+		if got := StatusString(uint32(code)); got != name {
+			t.Errorf("StatusString(0x%08x) = %q, want %q", uint32(code), got, name)
+		}
+	}
+
+	// E_UNEXPECTED was outside the subset this descriptor used to declare, so it
+	// rendered as hex; it resolves by name now, through StatusString as well.
+	if got := StatusString(0x8000FFFF); got != "E_UNEXPECTED" {
+		t.Errorf("StatusString(0x8000ffff) = %q, want E_UNEXPECTED", got)
+	}
+	// A value [MS-ERREF] 2.1.1 does not define still renders as hex.
+	if got := StatusString(0xdeadbeef); got != "0xdeadbeef" {
+		t.Errorf("StatusString(unknown) = %q, want 0xdeadbeef", got)
+	}
+	// Zero keeps the specification's own name for it, not the shared table's S_OK.
+	if got := StatusString(StatusSuccess); got != "ZERO" {
+		t.Errorf("StatusString(0) = %q, want ZERO", got)
+	}
+	if got := hresult.HRESULT(StatusSuccess).String(); got != "S_OK" {
+		t.Errorf("hresult.HRESULT(0).String() = %q, want S_OK", got)
+	}
+}
+
+// TestStatusStringDecodesFsrvpSpecificErrors pins the reason StatusString still exists.
+// Six of these codes sit in FACILITY_ITF, the interface-specific facility, where
+// [MS-FSRVP] defines its own meanings and [MS-ERREF] 2.1.1 has no row at all; a seventh
+// sits at 0x80042501 in the same facility; and the two wait results are Win32 values
+// carried verbatim, one of them success-severity. None can be read out of the shared
+// table, so all nine must keep decoding here.
+func TestStatusStringDecodesFsrvpSpecificErrors(t *testing.T) {
+	fsrvpSpecific := map[uint32]string{
+		FsrvpEBadState:                "FSRVP_E_BAD_STATE",
+		FsrvpENotSupported:            "FSRVP_E_NOT_SUPPORTED",
+		FsrvpEObjectAlreadyExists:     "FSRVP_E_OBJECT_ALREADY_EXISTS",
+		FsrvpEObjectNotFound:          "FSRVP_E_OBJECT_NOT_FOUND",
+		FsrvpEShadowCopySetInProgress: "FSRVP_E_SHADOW_COPY_SET_IN_PROGRESS",
+		FsrvpEUnsupportedContext:      "FSRVP_E_UNSUPPORTED_CONTEXT",
+		FsrvpEShadowcopysetIdMismatch: "FSRVP_E_SHADOWCOPYSET_ID_MISMATCH",
+		FsrvpEWaitTimeout:             "FSRVP_E_WAIT_TIMEOUT",
+		FsrvpEWaitFailed:              "FSRVP_E_WAIT_FAILED",
+	}
+	if len(fsrvpSpecific) != 9 {
+		t.Fatalf("FSRVP-specific table has %d entries, want 9", len(fsrvpSpecific))
+	}
+	for code, name := range fsrvpSpecific {
+		if got := StatusString(code); got != name {
+			t.Errorf("StatusString(0x%08x) = %q, want %q", code, got, name)
+		}
+		if _, defined := hresult.Lookup(hresult.HRESULT(code)); defined {
+			t.Errorf("hresult.Lookup(0x%08x) resolves; %s belongs in the shared table instead", code, name)
+		}
+		if _, defined := hresult.FromName(name); defined {
+			t.Errorf("hresult.FromName(%q) resolves; the code belongs in the shared table instead", name)
+		}
+		if want := fmt.Sprintf("0x%08x", code); hresult.HRESULT(code).String() != want {
+			t.Errorf("hresult.HRESULT(0x%08x).String() = %q, want the hex rendering %q", code, hresult.HRESULT(code).String(), want)
+		}
+	}
+
+	// The seven HRESULT-shaped codes are all in FACILITY_ITF (4), the facility whose
+	// meanings are the interface's own to define; that is why the table cannot name them.
+	for _, code := range []uint32{
+		FsrvpEBadState, FsrvpENotSupported, FsrvpEObjectAlreadyExists, FsrvpEObjectNotFound,
+		FsrvpEShadowCopySetInProgress, FsrvpEUnsupportedContext, FsrvpEShadowcopysetIdMismatch,
+	} {
+		if facility := (code >> 16) & 0x07FF; facility != 0x004 {
+			t.Errorf("0x%08x is in facility %d, want FACILITY_ITF (4)", code, facility)
+		}
+		if hresult.HRESULT(code).IsSuccess() {
+			t.Errorf("HRESULT(0x%08x).IsSuccess() = true, want false", code)
+		}
+	}
+
+	// FSRVP_E_WAIT_TIMEOUT is the value that makes the stubs' comparison against
+	// StatusSuccess load-bearing: its severity bit is clear, so the shared table's
+	// IsSuccess calls a timed-out wait a success.
+	if !hresult.HRESULT(FsrvpEWaitTimeout).IsSuccess() {
+		t.Errorf("HRESULT(0x%08x).IsSuccess() = false, want true", FsrvpEWaitTimeout)
+	}
+	if err := hresult.HRESULT(FsrvpEWaitTimeout).Error(); err != nil {
+		t.Errorf("HRESULT(0x%08x).Error() = %v, want nil for a success-severity value", FsrvpEWaitTimeout, err)
 	}
 }


### PR DESCRIPTION
### Linked Issue

Refs #1219. This is the HRESULT-returning tail of that issue, resting on the table added in #1221: the two interfaces here are TsProxyRpcInterface ([MS-TSGU], 44e265dd-7daf-42cd-8560-3cdb6e7a2729 v1.3) and FileServerVssAgent ([MS-FSRVP], a8e0653c-2744-4389-a61d-7373df8b2292 v1.0). Both come out as partial retirements, the shape the fax interface already has for Win32.

### Root Cause

**TsProxyRpcInterface.** The descriptor declared twenty-six status constants and a StatusString switch over all twenty-six, transcribed from [MS-TSGU] section 2.2.6. Four of those values are rows in the shared tables and were duplicated here; the other twenty-two are the protocol's own, and the old default arm rendered everything outside the twenty-six as bare hex, so every HRESULT the gateway can pass through from a lower layer reached a caller undecoded.

**FileServerVssAgent.** The descriptor declared thirteen status constants and a StatusString switch over them, transcribed from [MS-FSRVP] section 2.2.4. Three are rows in the shared HRESULT table and were duplicated; nine are the protocol's own, sitting in the facility COM reserves for interface-specific meanings; and, as above, the default arm rendered every other HRESULT as hex.

### Fix Description

Every constant in both descriptors was checked against `windows/errors/errgen/ms-erref-2.1.1-hresult.tsv` **by value, not by name**, and where the value is FACILITY_WIN32 the wrapped Win32 code was checked against `ms-erref-2.2-win32.tsv` as well, since that is the derivation `hresult.lookup` falls back on.

**TsProxyRpcInterface — four values migrate, twenty-two stay.**

`SEC_E_LOGON_DENIED` (0x8009030C) has a row under exactly that name and is deleted; StatusString's fallthrough resolves it. `ERROR_ACCESS_DENIED` (0x00000005), `ERROR_BAD_ARGUMENTS` (0x000000A0) and `ERROR_GRACEFUL_DISCONNECT` (0x000004CA) are not HRESULTs but the Win32 codes [MS-TSGU] 2.2.6 lists alongside the HRESULT forms — read as HRESULTs they are meaningless success-severity values no HRESULT row names — while [MS-ERREF] 2.2 names all three under precisely those names, so they are deleted too and one switch arm renders them through `windows/errors/win32`.

The ten `E_PROXY_*` HRESULTs stay. They are FACILITY_WIN32, so each wraps a Win32 code, and the wrapped codes are 0x59D8..0x59F9 — the range Terminal Services Gateway assigns for its own use. [MS-ERREF] 2.1.1 names five FACILITY_WIN32 values and none of these ten, and [MS-ERREF] 2.2 names no code in that range either, so the HRESULT_FROM_WIN32 derivation has nothing to resolve them against: `hresult.HRESULT(0x800759D8).String()` renders hex. The eleven `E_PROXY_*_CODE` values stay as well. They are not HRESULTs but HRESULT_CODE, the low sixteen bits alone, returned over the RPC/HTTP transports; their severity bit is clear, so an HRESULT reading of any of them reports success. One of them collides outright: [MS-ERREF] 2.2 names 0x000004D4 `ERROR_CONNECTION_ABORTED`, the generic socket error, where [MS-TSGU] means `E_PROXY_CONNECTIONABORTED`.

**FileServerVssAgent — three values migrate, ten stay.**

`E_INVALIDARG` (0x80070057), `E_ACCESSDENIED` (0x80070005) and `E_OUTOFMEMORY` (0x8007000E) each have a row under the name FSRVP uses, so the three declarations are deleted and the fallthrough resolves them. The nine `FSRVP_E_*` codes stay: six sit at 0x8004 23xx, which is FACILITY_ITF, and [MS-ERREF] 2.1.1 has no row for 0x80042301, 0x80042308, 0x8004230C, 0x8004230D, 0x80042316 or 0x8004231B, nor for `FSRVP_E_SHADOWCOPYSET_ID_MISMATCH` at 0x80042501 in the same facility; `FSRVP_E_WAIT_TIMEOUT` (0x00000102) and `FSRVP_E_WAIT_FAILED` (0xFFFFFFFF) are the Win32 wait results carried verbatim and have no row either. That the table crowds FACILITY_ITF with 238 OLE and drag-drop rows is exactly why the check had to be by value: a code migrated on the strength of its name would have decoded a share-mapping failure as a window-handle error and still passed every test.

`StatusSuccess` stays in both descriptors, and StatusString still renders zero as `ERROR_SUCCESS` for the gateway and as `ZERO` for FSRVP, the names the two specifications give the value rather than the shared table's `S_OK`. Both comments record why the stubs compare against that constant rather than against `hresult.HRESULT.IsSuccess`: IsSuccess is a range, and eleven gateway HRESULT_CODE values plus `FSRVP_E_WAIT_TIMEOUT` have bit 31 clear, so a stub rewritten to ask IsSuccess would report a timed-out shadow-copy wait, or an aborted tunnel, as a successful call.

### How Verified

```
$ go build ./...                     # exit 0
$ go vet ./...                       # exit 0
$ go test -count=1 ./...             # 315 ok, 0 FAIL  (main is 315 ok)
$ CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build ./...   # exit 0
$ CGO_ENABLED=0 GOOS=windows GOARCH=386   go build ./...   # exit 0
$ CGO_ENABLED=0 GOOS=linux   GOARCH=arm64 go build ./...   # exit 0
$ CGO_ENABLED=0 GOOS=linux   GOARCH=386   go build ./...   # exit 0
$ gofmt -l <the four touched files>  # no output; all four were clean on main first
```

The tree was grepped for both import paths and for every constant name before anything was deleted: neither interface has a consumer outside its own directory. Nothing in `network/dcerpc/ms-protocols/`, `network/smb/smb_v10/server/rpcpipe/`, `windows/protocols/ms-tsgu` or `windows/protocols/ms-fsrvp` references a status constant, and no test anywhere asserts the hex string the old subsets rendered.

Every status guard was rewritten — or, as it turned out, left alone — one comparison term at a time rather than one condition at a time. All eight gateway stubs and all thirteen FSRVP stubs hold single-term comparisons against `StatusSuccess`; not one tolerates a second status, so no stub needed changing and nothing under `functions/` is touched in either interface. A script counted the comparison and boolean operators in every `if` in every tracked Go file of both directories and compared the per-file census against the parent revision: identical in all twenty-one stubs and in both descriptors, the two test files being the only files whose census changes.

### Test Coverage

`TestStatusString` is replaced in both descriptors by a migrated-values test and a retained-values test.

For the gateway, `TestMigratedStatusCodesResolveThroughSharedTables` pins `SEC_E_LOGON_DENIED` through the HRESULT table, the three Win32 codes through the Win32 table and through StatusString, that no HRESULT row names any of the three and that each is success-severity read as one, that `E_FAIL` — never in the old subset — now renders by name where it used to render as hex, and that an undefined value still renders as hex. `TestStatusStringDecodesGatewayPrivateCodes` is the regression test against a future pass routing the private block through the shared table: each of the twenty-one retained codes still renders under its own name, `hresult.Lookup` reports nothing for any of them, each `E_PROXY_*` HRESULT is confirmed FACILITY_WIN32 over a wrapped code in 0x59D8..0x59F9 that the Win32 table also leaves unnamed, every HRESULT_CODE value is confirmed to read as a success, and 0x000004D4 is pinned to `ERROR_CONNECTION_ABORTED` in the shared table so the collision is recorded rather than remembered.

For FSRVP, `TestMigratedStatusCodesResolveThroughHRESULT` pins the three migrated values through the table in both directions and through StatusString, pins `E_UNEXPECTED` as the code that now decodes where it used to render as hex, pins the hex fallback, and pins that zero renders as `ZERO` here while the shared table calls it `S_OK`. `TestStatusStringDecodesFsrvpSpecificErrors` pins that each of the nine retained codes renders under its own name while both `hresult.Lookup` and `hresult.FromName` report nothing for it, that the seven HRESULT-shaped ones are in FACILITY_ITF, and that `FSRVP_E_WAIT_TIMEOUT` satisfies `IsSuccess` and reports a nil `Error` — the trap the retained comparison against `StatusSuccess` avoids.

### Scope of Change

Two commits, one per interface, four files:

- `network/dcerpc/interfaces/44e265dd-7daf-42cd-8560-3cdb6e7a2729/1.3/interface.go` and `interface_test.go`
- `network/dcerpc/interfaces/a8e0653c-2744-4389-a61d-7373df8b2292/1.0/interface.go` and `interface_test.go`

No file under either `functions/` directory is touched, no shared package is modified, and no file outside these two interface directories changes. `PipeName`, `SyntaxID`, the opnum constants and the `OpnumToName`/`NameToOpnum` maps survive intact in both descriptors.

### Risk and Rollout

Behaviour changes only in the rendering of status text. Seven constants disappear from two package APIs — `SEC_E_LOGON_DENIED`, `ERROR_ACCESS_DENIED`, `ERROR_BAD_ARGUMENTS` and `ERROR_GRACEFUL_DISCONNECT` from the gateway descriptor, `ErrorInvalidArg`, `ErrorAccessDenied` and `ErrorOutOfMemory` from FSRVP — and nothing in the repository referenced any of them. Each of the seven renders exactly as before, now out of the shared table; every other value gains a name where it previously rendered as hex; and the values held back render exactly as before out of the reduced switch. No control flow changed in any stub, so no call that used to succeed can now fail or the reverse.

### Notes

The honest summary is that little migrates here. Four of the gateway's twenty-six values and three of FSRVP's thirteen are rows in a shared table; the remaining thirty-two are protocol-private, and for a tunnelling interface whose status namespace mixes HRESULT, HRESULT_CODE and bare Win32 codes in one DWORD return, that is the correct outcome rather than a shortfall. What the change buys is the 2928-value fallthrough, the seven duplicated rows gone, and — the durable part — a comment at each retained block recording which facility it is in and that [MS-ERREF] 2.1.1 does not name it, so the next pass over these files does not have to rediscover it by breaking something.

One candidate worth flagging rather than acting on: `FSRVP_E_WAIT_TIMEOUT` at 0x00000102 has bit 31 clear. Any future change that reads FSRVP status through `hresult.HRESULT.IsSuccess` or `Error` instead of comparing against `StatusSuccess` will silently classify a timed-out shadow-copy wait as success. The same holds for all eleven of the gateway's HRESULT_CODE values, which is why both descriptors now say so in the comment on `StatusSuccess` and both test files assert it.

Also noticed while grepping, and out of scope here: `network/dcerpc/interfaces/b9785960-524f-11df-8b6d-83dcded72085/1.0/interface_test.go` asserts that `StatusString(0x80070005)` renders the literal `"0x80070005"`. That interface has not been migrated yet, and whoever migrates it will have to replace that assertion — it pins the pre-migration hex for a value the shared table names `E_ACCESSDENIED`.
