### PR TITLE
Cite the correct [MS-TRP] sections in tapsrv and remotesp (Fixes #1270)

### DIFF
--- a/network/dcerpc/interfaces/2f5f6520-ca46-1067-b319-00dd010662da/1.0/functions/00_ClientAttach.go
+++ b/network/dcerpc/interfaces/2f5f6520-ca46-1067-b319-00dd010662da/1.0/functions/00_ClientAttach.go
@@ -15,7 +15,7 @@ import (
 )
 
 // clientAttachRequest carries the [in] parameters of ClientAttach. pszDomainUser and
-// pszMachine are top-level [ref] [string] wchar_t* parameters ([MS-TRP] 3.2.4.1), so they
+// pszMachine are top-level [ref] [string] wchar_t* parameters ([MS-TRP] 3.1.4.1), so they
 // marshal inline as conformant-varying UTF-16LE strings with no referent id.
 type clientAttachRequest struct {
 	LProcessID    int32
@@ -32,7 +32,7 @@ type clientAttachResponse struct {
 	Return             ndr.DWORD `ndr:"retval"`
 }
 
-// ClientAttach calls ClientAttach (opnum 0) ([MS-TRP] 3.2.4.1). The client uses it to
+// ClientAttach calls ClientAttach (opnum 0) ([MS-TRP] 3.1.4.1). The client uses it to
 // establish a session with the telephony server: lProcessID identifies the client
 // process (0xFFFFFFFF / 0xFFFFFFFD select the reduced-privilege forms described by the
 // spec), pszDomainUser is the caller's domain\user, and pszMachine the client machine

--- a/network/dcerpc/interfaces/2f5f6520-ca46-1067-b319-00dd010662da/1.0/functions/01_ClientRequest.go
+++ b/network/dcerpc/interfaces/2f5f6520-ca46-1067-b319-00dd010662da/1.0/functions/01_ClientRequest.go
@@ -16,7 +16,7 @@ import (
 // clientRequestRequest carries the [in]/[in,out] parameters of ClientRequest.
 //
 // pBuffer is a top-level [ref] pointer to a conformant-varying byte array with
-// independent bounds ([MS-TRP] 3.2.4.2): its maximum_count comes from lNeededSize (the
+// independent bounds ([MS-TRP] 3.1.4.2): its maximum_count comes from lNeededSize (the
 // buffer capacity) and its actual_count from plUsedSize (the number of bytes actually
 // carried). Modeling it [ref] (not [unique]) suppresses both a referent id and the
 // hoisting of maximum_count ahead of the preceding context handle, matching the wire.
@@ -44,7 +44,7 @@ type clientRequestResponse struct {
 	PlUsedSize ndr.DWORD
 }
 
-// ClientRequest calls ClientRequest (opnum 1) ([MS-TRP] 3.2.4.2). The client sends a
+// ClientRequest calls ClientRequest (opnum 1) ([MS-TRP] 3.1.4.2). The client sends a
 // packed TAPI request in pBuffer; the server processes it and returns the (possibly
 // updated) buffer in place. lNeededSize is the total capacity of pBuffer and plUsedSize
 // the number of valid bytes; both are [in,out]. The returned buffer and used size are

--- a/network/dcerpc/interfaces/2f5f6520-ca46-1067-b319-00dd010662da/1.0/functions/02_ClientDetach.go
+++ b/network/dcerpc/interfaces/2f5f6520-ca46-1067-b319-00dd010662da/1.0/functions/02_ClientDetach.go
@@ -28,7 +28,7 @@ type clientDetachResponse struct {
 	PphContext mstrp.PCONTEXT_HANDLE_TYPE
 }
 
-// ClientDetach calls ClientDetach (opnum 2) ([MS-TRP] 3.2.4.3). It closes the tapsrv
+// ClientDetach calls ClientDetach (opnum 2) ([MS-TRP] 3.1.4.3). It closes the tapsrv
 // session identified by the context handle and frees the server-side state. The server
 // returns the handle nulled out (IsZero); transport-level failures surface through err.
 func ClientDetach(rpc ndr.Invoker, pphContext mstrp.PCONTEXT_HANDLE_TYPE) (PphContext mstrp.PCONTEXT_HANDLE_TYPE, err error) {

--- a/network/dcerpc/interfaces/2f5f6520-ca46-1067-b319-00dd010662da/1.0/functions/functions_test.go
+++ b/network/dcerpc/interfaces/2f5f6520-ca46-1067-b319-00dd010662da/1.0/functions/functions_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 // TestClientRequest_BufferWireShape pins the independent-bounds wire layout of
-// ClientRequest's pBuffer ([MS-TRP] 3.2.4.2): a top-level [ref] conformant-varying byte
+// ClientRequest's pBuffer ([MS-TRP] 3.1.4.2): a top-level [ref] conformant-varying byte
 // array whose maximum_count is lNeededSize (capacity) and actual_count is plUsedSize (the
 // valid length), with no referent id. This matches the reference wire encoding used by
 // interop implementations.

--- a/network/dcerpc/interfaces/2f5f6520-ca46-1067-b319-00dd010662da/1.0/interface.go
+++ b/network/dcerpc/interfaces/2f5f6520-ca46-1067-b319-00dd010662da/1.0/interface.go
@@ -35,7 +35,7 @@ const (
 )
 
 // ClientAttach returns 0 on success and otherwise a nonzero error code "as specified in
-// [MS-ERREF]" ([MS-TRP] 3.2.4.1); the void methods (ClientRequest, ClientDetach) carry
+// [MS-ERREF]" ([MS-TRP] 3.1.4.1); the void methods (ClientRequest, ClientDetach) carry
 // their result inside the packed TAPI buffer rather than as an RPC return value. Those
 // codes are not declared here. The whole of [MS-ERREF] 2.2 lives in
 // github.com/TheManticoreProject/Manticore/windows/errors/win32 as the WIN32_ERROR type,

--- a/network/dcerpc/interfaces/2f5f6520-ca46-1067-b319-00dd010662da/1.0/interface_test.go
+++ b/network/dcerpc/interfaces/2f5f6520-ca46-1067-b319-00dd010662da/1.0/interface_test.go
@@ -72,7 +72,7 @@ func TestStatusCodesResolveThroughWin32(t *testing.T) {
 		}
 	}
 
-	// The two values [MS-TRP] 3.2.4.1 names for this return are not Win32 error codes:
+	// The two values [MS-TRP] 3.1.4.1 names for this return are not Win32 error codes:
 	// LINEERR_OPERATIONFAILED is a TAPI code in the 0x8000xxxx block and -19 is a raw
 	// negative. [MS-ERREF] 2.2 covers neither, so both stay hexadecimal exactly as they
 	// did before and neither can be misnamed out of the shared table.

--- a/network/dcerpc/interfaces/2f5f6521-ca47-1068-b319-00dd010662db/1.0/functions/00_RemoteSPAttach.go
+++ b/network/dcerpc/interfaces/2f5f6521-ca47-1068-b319-00dd010662db/1.0/functions/00_RemoteSPAttach.go
@@ -27,7 +27,7 @@ type remoteSPAttachResponse struct {
 	Return     ndr.DWORD `ndr:"retval"`
 }
 
-// RemoteSPAttach calls RemoteSPAttach (opnum 0) ([MS-TRP] 3.1.4.1). In the protocol the
+// RemoteSPAttach calls RemoteSPAttach (opnum 0) ([MS-TRP] 3.3.4.1). In the protocol the
 // telephony server is the RPC client for the remotesp interface: it calls RemoteSPAttach
 // on the client (which hosts the remotesp server) to establish a reverse binding for
 // event delivery. On success the callee returns the remotesp context handle. The method

--- a/network/dcerpc/interfaces/2f5f6521-ca47-1068-b319-00dd010662db/1.0/functions/01_RemoteSPEventProc.go
+++ b/network/dcerpc/interfaces/2f5f6521-ca47-1068-b319-00dd010662db/1.0/functions/01_RemoteSPEventProc.go
@@ -14,7 +14,7 @@ import (
 )
 
 // remoteSPEventProcRequest carries the [in] parameters of RemoteSPEventProc. pBuffer is a
-// top-level conformant-varying byte array ([MS-TRP] 3.1.4.2) whose maximum_count and
+// top-level conformant-varying byte array ([MS-TRP] 3.3.4.2) whose maximum_count and
 // actual_count both come from lSize; it is transmitted inline (no referent id).
 type remoteSPEventProcRequest struct {
 	PhContext mstrp.PCONTEXT_HANDLE_TYPE2
@@ -32,7 +32,7 @@ func (*remoteSPEventProcRequest) Opnum() uint16 { return remotesp.OpnumRemoteSPE
 type remoteSPEventProcResponse struct {
 }
 
-// RemoteSPEventProc calls RemoteSPEventProc (opnum 1) ([MS-TRP] 3.1.4.2). The telephony
+// RemoteSPEventProc calls RemoteSPEventProc (opnum 1) ([MS-TRP] 3.3.4.2). The telephony
 // server invokes it on the client to push an asynchronous TAPI event: pBuffer holds the
 // packed event data of lSize bytes for the session identified by phContext. It returns no
 // value; transport-level failures surface through err.

--- a/network/dcerpc/interfaces/2f5f6521-ca47-1068-b319-00dd010662db/1.0/functions/02_RemoteSPDetach.go
+++ b/network/dcerpc/interfaces/2f5f6521-ca47-1068-b319-00dd010662db/1.0/functions/02_RemoteSPDetach.go
@@ -28,7 +28,7 @@ type remoteSPDetachResponse struct {
 	PphContext mstrp.PCONTEXT_HANDLE_TYPE2
 }
 
-// RemoteSPDetach calls RemoteSPDetach (opnum 2) ([MS-TRP] 3.1.4.3). The telephony server
+// RemoteSPDetach calls RemoteSPDetach (opnum 2) ([MS-TRP] 3.3.4.3). The telephony server
 // invokes it on the client to tear down the reverse binding established by RemoteSPAttach
 // and free the associated state. The callee returns the handle nulled out (IsZero);
 // transport-level failures surface through err.

--- a/network/dcerpc/interfaces/2f5f6521-ca47-1068-b319-00dd010662db/1.0/functions/functions_test.go
+++ b/network/dcerpc/interfaces/2f5f6521-ca47-1068-b319-00dd010662db/1.0/functions/functions_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 // TestRemoteSPEventProc_BufferWireShape pins the wire layout of RemoteSPEventProc's
-// pBuffer ([MS-TRP] 3.1.4.2): a top-level conformant-varying byte array transmitted inline
+// pBuffer ([MS-TRP] 3.3.4.2): a top-level conformant-varying byte array transmitted inline
 // (no referent id) whose maximum_count and actual_count both equal lSize, followed by the
 // lSize field itself. lSize is derived from the slice length so the count and elements
 // cannot disagree.

--- a/network/dcerpc/interfaces/2f5f6521-ca47-1068-b319-00dd010662db/1.0/interface.go
+++ b/network/dcerpc/interfaces/2f5f6521-ca47-1068-b319-00dd010662db/1.0/interface.go
@@ -41,7 +41,7 @@ const (
 )
 
 // RemoteSPAttach returns 0 on success and otherwise a nonzero error code "as specified in
-// [MS-ERREF]" ([MS-TRP] 3.1.4.1); the void methods (RemoteSPEventProc, RemoteSPDetach)
+// [MS-ERREF]" ([MS-TRP] 3.3.4.1); the void methods (RemoteSPEventProc, RemoteSPDetach)
 // carry no RPC return value. Those codes are not declared here. The whole of [MS-ERREF]
 // 2.2 lives in github.com/TheManticoreProject/Manticore/windows/errors/win32 as the
 // WIN32_ERROR type, and a subset repeated here would cover a fraction of that 2703-code


### PR DESCRIPTION
### Linked Issue
`Closes #1270`

### Root Cause
[MS-TRP] documents four roles — 3.1 Tapsrv Server, 3.2 Tapsrv Client, 3.3 Remotesp Server, 3.4 Remotesp Client. These two descriptors are the server halves, so their methods are specified under 3.1.4 and 3.3.4. `tapsrv` cited 3.2.4 throughout and `remotesp` cited 3.1.4.

For `remotesp` that is worse than a wrong role: 3.1.4 is *Tapsrv* Server, so following its citations lands the reader in a different interface. For `tapsrv` the citations name a subsection that does not exist — the specification's table of contents gives 3.2.4 and 3.4.4 no subsections at all, so `3.2.4.1` has no referent.

The two interfaces were scaffolded from each other: adjacent UUIDs in one specification with near-identical method shapes. The section prefix was carried across without being re-derived for the second interface.

### Fix Description
Only the prefix moves. Every trailing index already matched its opnum, confirmed against the specification's own table of contents:

| Method | Opnum | Correct section |
|---|---|---|
| `ClientAttach` | 0 | 3.1.4.1 |
| `ClientRequest` | 1 | 3.1.4.2 |
| `ClientDetach` | 2 | 3.1.4.3 |
| `RemoteSPAttach` | 0 | 3.3.4.1 |
| `RemoteSPEventProc` | 1 | 3.3.4.2 |
| `RemoteSPDetach` | 2 | 3.3.4.3 |

So `tapsrv`'s eight citations become 3.1.4.x and `remotesp`'s six become 3.3.4.x, with the method numbering untouched. Each `sed` was scoped to a single interface directory so the two rewrites could not overlap — `remotesp`'s target prefix is `tapsrv`'s corrected one.

### How Verified
- **Static:** the section list was read from the specification's own `toc.json`, not inferred: `3.1 Tapsrv Server Details`, `3.2 Tapsrv Client Details`, `3.3 Remotesp Server Details`, `3.4 Remotesp Client Details`, with subsections `3.1.4.1`–`3.1.4.3` and `3.3.4.1`–`3.3.4.3` and none under 3.2.4 or 3.4.4.
- **Static:** after the change, `tapsrv` carries only `3.1.4.{1,2,3}` and `remotesp` only `3.3.4.{1,2,3}`; a tree-wide grep for `[MS-TRP] 3.2.4` or `[MS-TRP] 3.4.4` returns **0**.
- **Runtime:** `go build ./...` clean and `go test -count=1 ./...` clean at **317 packages ok, 0 failures**, matching `main`. `gofmt -l` reports nothing for either directory.

### Test Coverage
**None** — the change is confined to comment text. Two of the eleven files are tests, but only their comments move; no assertion changes, and both packages still pass. There is nothing executable to cover: a wrong specification citation is not observable at runtime, which is precisely why it survived.

### Scope of Change
- **Files changed:** 11 across the two interface directories — 14 insertions, 14 deletions, all of them inside comments.
- **Submodule pointer updated:** no — the repository has no submodules.
- **Behavioral changes outside the bug fix:** none.

### Notes
Found while migrating both interfaces onto `windows/errors/win32` for #1219 (PR #1268). That change deliberately preserved the existing numbering rather than half-correcting it, so a status-reporting migration would not smuggle in a documentation change.

The scaffolded-from-a-sibling pattern turned up three times in that work and is worth watching for in future interface pairs: the [MS-RSP] pair (`InitShutdown`/`WindowsShutdown`) carried byte-identical nine-value status subsets, the [MS-MSRP] pair (`msgsvc`/`msgsvcsend`) had drifted into rendering `0x00000000` under two different names, and this pair shares a section prefix.
